### PR TITLE
docs: post-cloud-split README + CHANGELOG cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed — Cloud control plane moved to private `objectstack-ai/cloud` repo
+
+The framework repository (`objectstack-ai/framework`) is now open-core only.
+The hosted Cloud control plane — `apps/cloud` and
+`@objectstack/service-cloud` — has been extracted to a separate, private
+repository (`objectstack-ai/cloud`). Production traffic on
+`cloud.objectos.app` is now served from that repo as a Cloudflare Container
+Worker.
+
+What this means for framework consumers:
+
+- **`packages/services/service-cloud`** — deleted from this repo. ~10k LOC,
+  56 files. Lives in `objectstack-ai/cloud` going forward.
+- **`apps/cloud`** — deleted from this repo. The reference cloud host now
+  lives in `objectstack-ai/cloud/apps/cloud`.
+- **`@objectstack/cli`** — no longer hard-depends on
+  `@objectstack/service-cloud`. The `serve --mode=cloud` boot path keeps
+  the existing optional dynamic `import('@objectstack/service-cloud')`
+  with a try/catch that surfaces a clear "install / use cloud-aware
+  distribution" hint when the package is absent. The ambient TypeScript
+  stub (`packages/cli/src/types/service-cloud.d.ts`) is retained so the
+  optional path still typechecks.
+- **`apps/objectos`** — unchanged. The reference *tenant* runtime stays
+  in this repo and reaches the control plane over HTTP via
+  `OS_CLOUD_URL`. Defaults: `OS_CLOUD_URL=https://cloud.objectos.app`
+  in production, or `local` to disable cloud routing.
+- **Structural couplings remain `any`-typed.** `packages/runtime/`,
+  `packages/rest/`, and `packages/adapters/hono/` previously documented
+  service-cloud as the source of `KernelManager` / `EnvironmentDriverRegistry`
+  but never imported it. Doc comments are retained; behaviour is unchanged.
+- **Tag `pre-cloud-split`** marks the last commit before this extraction
+  and can be used as a rollback anchor.
+
 ### Added — Cloud identity split: `os cloud login` separates from `os login`
 
 Introduced a second credential store at `~/.objectstack/cloud.json` to model

--- a/README.md
+++ b/README.md
@@ -206,7 +206,6 @@ Cloud, package registry, and project management subcommands (`os projects`, `os 
 | [`@objectstack/service-analytics`](packages/services/service-analytics) | Analytics — aggregations, time series, funnels, dashboards |
 | [`@objectstack/service-automation`](packages/services/service-automation) | Automation engine — flows, triggers, DAG-based workflows |
 | [`@objectstack/service-cache`](packages/services/service-cache) | Cache — in-memory, Redis, multi-tier |
-| [`@objectstack/service-cloud`](packages/services/service-cloud) | Cloud orchestration — multi-project, control-plane, deployment |
 | [`@objectstack/service-feed`](packages/services/service-feed) | Activity feed / chatter |
 | [`@objectstack/service-i18n`](packages/services/service-i18n) | Internationalization service |
 | [`@objectstack/service-job`](packages/services/service-job) | Cron & interval job scheduler |
@@ -237,7 +236,6 @@ Cloud, package registry, and project management subcommands (`os projects`, `os 
 | [`create-objectstack`](packages/create-objectstack) | Project scaffolder (`npx create-objectstack`) |
 | [`objectstack-vscode`](packages/vscode-objectstack) | VS Code extension — autocomplete, validation, diagnostics |
 | [`@objectstack/objectos`](apps/objectos) | Reference host — local and self-contained ObjectOS runtime |
-| [`@objectstack/cloud`](apps/cloud) | Cloud host — multi-project, control-plane connected, deployable to Vercel / Workers |
 | [`@objectstack/studio`](apps/studio) | Studio IDE — metadata explorer, schema inspector, AI assistant |
 | [`@objectstack/console`](apps/console) | Cloud console — org / project / branch management UI |
 | [`@objectstack/account`](apps/account) | Account & identity portal — sign in, organizations, connected apps |


### PR DESCRIPTION
Follow-up to #1257. Removes the two stale rows in the README's package tables and adds an Unreleased CHANGELOG entry documenting the extraction.

No code changes.

- Tag `pre-cloud-split` (already pushed) marks the pre-split anchor.
- `apps/objectos` stays in framework; only `apps/cloud` + `@objectstack/service-cloud` moved to objectstack-ai/cloud.