### PR TITLE
chore: drop @objectstack/service-cloud from changeset fixed list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -45,7 +45,6 @@
       "@objectstack/service-realtime",
       "@objectstack/service-ai",
       "@objectstack/service-storage",
-      "@objectstack/service-cloud",
       "@objectstack/service-package",
       "@objectstack/service-tenant",
       "@objectstack/docs",


### PR DESCRIPTION
## Why
The package was removed from this repo in #1257 (cloud split) but its entry in `.changeset/config.json`'s `fixed` list was left behind. Every Release workflow run since then has failed with:

```
ValidationError: The package or glob expression "@objectstack/service-cloud" specified in the `fixed` option does not match any package in the project.
```

## What this unblocks
- `changesets/action` will refresh PR #1256 (`chore: version packages`)
- 11 pending changesets will be consumed, bumping published packages **4.0.5 → 4.1.0** (minor, driven by the `@objectstack/cli` changeset added in #1260)
- Merging PR #1256 triggers npm publish

## Verified locally
Ran `pnpm run version` with this fix: ✅ produces clean diff, all fixed packages bump to 4.1.0, CHANGELOGs generated.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>