### PR TITLE
fix(cli): fail loudly on port conflict in production instead of silently drifting

### DIFF
--- a/.changeset/cli-production-port-conflict.md
+++ b/.changeset/cli-production-port-conflict.md
@@ -1,0 +1,20 @@
+---
+'@objectstack/cli': patch
+---
+
+**`os start` no longer silently shifts ports on a conflict.**
+
+Port resolution is unchanged (`--port` › `$OS_PORT` › `$PORT` › `3000`), but the
+conflict behaviour is now mode-dependent:
+
+- **Dev** (`os dev`, or `NODE_ENV=development`): still auto-hops to the next free
+  port (up to +100) so multiple example apps can run side-by-side. The startup
+  banner shows the actual bound port.
+- **Production** (`os start`): if the resolved port is busy, the CLI now fails
+  loudly and exits `1` instead of binding a different port. A silently drifted
+  port breaks reverse-proxy upstreams, better-auth callback URLs (`OS_AUTH_URL`),
+  and CORS trusted-origins (`OS_TRUSTED_ORIGINS`) as opaque 403/502s.
+
+Also fixed: the `os start` startup banner now prints the real Console URL when
+the port comes from `$PORT`/`$OS_PORT` (previously it always showed the
+`--port`/`3000` value, which could be wrong).

--- a/content/docs/getting-started/cli.mdx
+++ b/content/docs/getting-started/cli.mdx
@@ -127,7 +127,7 @@ os dev --database file:./data/test.db --auth-secret $(openssl rand -hex 32)
 | `--database-auth-token <t>` | `OS_DATABASE_AUTH_TOKEN` | libsql/Turso token |
 | `--auth-secret <s>` | `AUTH_SECRET` | Override the dev-fallback secret |
 | `--project-id <id>` | `OS_PROJECT_ID` | Project identifier (default `proj_local`) |
-| `-p, --port <n>` | `PORT` | Listen port |
+| `-p, --port <n>` | `PORT` / `OS_PORT` | Listen port (default `3000`). In dev a busy port auto-hops to the next free one; the banner shows the actual port. |
 | `--ui` | — | Force Studio UI on (already on by default in dev) |
 | `--no-compile` | — | Skip the auto-compile step (errors if no artifact present) |
 | `-v, --verbose` | — | Verbose output |
@@ -269,8 +269,15 @@ os start
 | `--database-auth-token <token>` | `OS_DATABASE_AUTH_TOKEN` | Auth token for libsql/Turso |
 | `--auth-secret <secret>` | `AUTH_SECRET` | Secret for `@objectstack/plugin-auth`; without it `/api/v1/auth/*` is skipped (server still runs) |
 | `--project-id <id>` | `OS_PROJECT_ID` | Project identifier (default `proj_local`) |
-| `-p, --port <port>` | `PORT` | Listen port (default `3000`) |
+| `-p, --port <port>` | `PORT` / `OS_PORT` | Listen port (default `3000`). **Production fails loudly if the port is busy** — see note below. |
 | `--ui` | — | **Opt-in.** Mount Studio / Account / Console portals at `/_studio/`, `/_account/`, `/_console/`. Off by default in `os start` (Studio is a dev/admin surface). `os dev` mounts them by default. |
+
+> **Port conflicts: production never auto-shifts.** Unlike `os dev` (which
+> hops to the next free port for local convenience), `os start` exits with an
+> error if its resolved port is in use. A silently drifted port would break
+> your reverse-proxy upstream, `OS_AUTH_URL` callbacks, and `OS_TRUSTED_ORIGINS`
+> (CORS). **Pin the port explicitly** (`PORT=8080 os start`) and keep
+> `OS_AUTH_URL` / `OS_TRUSTED_ORIGINS` in sync when you change it.
 | `-v, --verbose` | — | Verbose output |
 
 **Resolution priority (artifact):** `--artifact` > `OS_ARTIFACT_PATH` > `<cwd>/dist/objectstack.json`.

--- a/content/docs/guides/cloud-deployment.mdx
+++ b/content/docs/guides/cloud-deployment.mdx
@@ -212,7 +212,7 @@ point a wildcard DNS (`*.example.com`) at it. The container does the rest.
 | `OS_ENV_CACHE_TTL_MS`    | cloud                     | TTL for the envRegistry's hostname/id cache (default 300000).                    |
 | `OS_COOKIE_DOMAIN`       | cloud                     | Shared cookie domain for cross-subdomain sessions (e.g. `.objectstack.app`).     |
 | `AUTH_SECRET`                     | all                       | Better-Auth session secret (≥ 32 chars).                                         |
-| `PORT` / `HOST`                   | all (node-entry)          | HTTP bind. Defaults to `3000` / `0.0.0.0`.                                       |
+| `PORT` / `HOST`                   | all (node-entry)          | HTTP bind. Defaults to `3000` / `0.0.0.0`. In production a busy port is a hard error (no auto-shift) — pin it and match `OS_AUTH_URL` / `OS_TRUSTED_ORIGINS`. |
 
 ---
 

--- a/content/docs/guides/environment-variables.mdx
+++ b/content/docs/guides/environment-variables.mdx
@@ -23,11 +23,20 @@ read at startup unless noted otherwise. Boolean variables accept `true` / `false
 
 | Variable | Type | Default | Description |
 |:---|:---|:---|:---|
-| `OS_PORT` | number | `3000` | HTTP listener port for `os serve` / `os dev` / `os start`. |
+| `OS_PORT` | number | `3000` | HTTP listener port for `os serve` / `os dev` / `os start`. Resolution: `--port` › `OS_PORT` › `PORT` › `3000`. |
 | `OS_HOME` | path | `$HOME/.objectstack` | ObjectStack config / state directory. |
 | `OS_MODE` | enum | `standalone` | Runtime mode. `standalone` \| `cloud`. |
 | `OS_BOOT_EMPTY` | flag | `0` | When `1`, boot the kernel with no metadata artifact (CLI internal). |
 | `OS_MIGRATE_AND_EXIT` | flag | `0` | When `1`, run pending migrations and exit (suitable for one-shot jobs). |
+
+> **Port conflicts behave differently by mode.** In **dev** (`os dev`, or
+> `NODE_ENV=development`) a busy port auto-hops to the next free one (up to
+> +100) and the banner prints the actual bound port. In **production**
+> (`os start`) a busy port is a hard error (exit 1) — it never silently
+> drifts, because a shifted port breaks reverse-proxy upstreams, `OS_AUTH_URL`
+> callbacks, and `OS_TRUSTED_ORIGINS` (CORS). Pin the port explicitly in
+> production (`PORT=8080 os start`) and keep `OS_AUTH_URL` / `OS_TRUSTED_ORIGINS`
+> in sync with it.
 | `OS_DISABLE_CONSOLE` | flag | `0` | When `1`, do not mount the Studio Console UI under `/_console`. |
 | `OS_EAGER_SCHEMAS` | flag | `0` | When `1`, eagerly materialise all object schemas at boot (slower start, faster first request). |
 | `OS_SKIP_SCHEMA_SYNC` | flag | `0` | When `1`, skip the implicit `db:sync` on boot. Use after running migrations manually. |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -153,7 +153,7 @@ Common variables: `OS_DATABASE_URL`, `OS_DATABASE_DRIVER`,
 
 ### `os serve`
 
-- `-p, --port <port>` — Server port (default: `3000`)
+- `-p, --port <port>` — Server port. Resolution: `--port` › `$OS_PORT` › `$PORT` › `3000`. With `--dev` a busy port auto-hops to the next free one; in production mode it's a hard error (never silently drifts).
 - `--dev` — Run in development mode (load devPlugins, pretty logging)
 - `--ui` — Enable Studio UI
 - `--no-server` — Skip starting HTTP server plugin

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -109,21 +109,22 @@ async function buildServeObservability(): Promise<{ metrics: any; errorReporter:
   }
 }
 
-// Helper to find available port
-const getAvailablePort = async (startPort: number): Promise<number> => {
-  const isPortAvailable = (port: number): Promise<boolean> => {
-    return new Promise((resolve) => {
-      const server = net.createServer();
-      server.once('error', (err: any) => {
-        resolve(false);
-      });
-      server.once('listening', () => {
-        server.close(() => resolve(true));
-      });
-      server.listen(port);
+// Probe whether a TCP port can be bound right now.
+const isPortAvailable = (port: number): Promise<boolean> => {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once('error', () => {
+      resolve(false);
     });
-  };
+    server.once('listening', () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port);
+  });
+};
 
+// Helper to find available port (dev convenience — see the gated caller).
+const getAvailablePort = async (startPort: number): Promise<number> => {
   let port = startPort;
   while (!(await isPortAvailable(port))) {
     port++;
@@ -197,14 +198,32 @@ export default class Serve extends Command {
       process.env.NODE_ENV = 'development';
     }
 
-    let port = parseInt(flags.port);
-    try {
-      const availablePort = await getAvailablePort(port);
-      if (availablePort !== port) {
-        port = availablePort;
+    const requestedPort = parseInt(flags.port);
+    let port = requestedPort;
+    // Port-conflict policy differs by mode:
+    //
+    //  • Dev (`os dev`, or NODE_ENV=development): hop to the next free port
+    //    so several example apps can run side-by-side without manual config.
+    //
+    //  • Production (`os start`): NEVER silently drift off the configured
+    //    port. A drifted port breaks reverse-proxy upstreams, better-auth
+    //    callback URLs, and CORS trusted-origins in ways that surface as
+    //    opaque 403/502s with no obvious cause. Fail loudly so the operator
+    //    frees the port (or sets PORT / --port) before anything boots.
+    const portAutoShiftAllowed = flags.dev || process.env.NODE_ENV === 'development';
+    if (portAutoShiftAllowed) {
+      try {
+        port = await getAvailablePort(requestedPort);
+      } catch {
+        // Ignore — fall through and try the requested port.
       }
-    } catch (e) {
-      // Ignore error and try with original port
+    } else if (!(await isPortAvailable(requestedPort))) {
+      console.log('');
+      printError(`Port ${requestedPort} is already in use.`);
+      console.log(chalk.dim('  ObjectStack does not auto-select a different port in production mode:'));
+      console.log(chalk.dim('  a drifted port silently breaks reverse-proxy, OAuth callback, and CORS config.'));
+      console.log(chalk.dim('  Free the port, or pick another via PORT=<port> (or --port <port>).'));
+      this.exit(1);
     }
 
     // Load .env files following Vite/Next.js convention
@@ -298,8 +317,6 @@ export default class Serve extends Command {
       console.log = originalConsoleLog;
       console.debug = originalConsoleDebug;
     };
-
-    const portShifted = parseInt(flags.port) !== port;
 
     try {
       // ── Suppress ALL runtime noise during boot ────────────────────

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -207,7 +207,11 @@ export default class Start extends Command {
     }
     printKV('Database', redactDbUrl(databaseUrl), '🗄️');
     printKV('Environment', environmentId, '🎯');
-    if (flags.ui) printKV('Console', `http://localhost:${flags.port ?? 3000}/_console/`, '🖥️');
+    // Resolve the port the child `serve` will actually bind, matching its
+    // flag default (`--port` > $OS_PORT/$PORT > 3000). Using `flags.port`
+    // alone printed the wrong URL whenever the port came from the env.
+    const bannerPort = flags.port ?? readEnvWithDeprecation('OS_PORT', 'PORT') ?? 3000;
+    if (flags.ui) printKV('Console', `http://localhost:${bannerPort}/_console/`, '🖥️');
 
     printStep('Starting server...');
 

--- a/skills/objectstack-platform/SKILL.md
+++ b/skills/objectstack-platform/SKILL.md
@@ -426,8 +426,13 @@ CLI: `os serve` / `os dev`
      ├── AIServicePlugin (if available)
      └── StudioPlugin (if --ui flag)
   5. Runtime.start() → init + start all plugins
-  6. Server listens on configured port
+  6. Server listens on the resolved port (see "Ports & networking" in Part 3)
 ```
+
+**Port resolution** (both `os dev` and `os start` → `os serve`):
+`--port` flag › `$OS_PORT` › `$PORT` › `3000`. On a conflict the behaviour is
+mode-dependent — dev hops to the next free port, production fails loudly. See
+[Ports & networking](#ports--networking).
 
 ### Plugin Loading Order Matters
 
@@ -551,10 +556,10 @@ sheet for the bootstrap loop:
 ```bash
 npx create-objectstack my-app --template full-stack
 cd my-app && pnpm install
-os dev --ui          # dev server + Studio
+os dev --ui          # dev server + Studio (auto-hops port if taken)
 os validate          # metadata cross-reference checks
 os compile           # produce dist/ artifact
-os serve --port 3000 # production
+PORT=8080 os start   # production — pin the port explicitly (see Ports & networking)
 ```
 
 ---
@@ -1072,6 +1077,34 @@ be re-run when commands are added.
 | `os start` | Production-grade boot (validates env, applies migrations, starts adapter) |
 | `os generate <kind>` | Scaffold an object / view / flow / agent from a template |
 
+## Ports & networking
+
+Port resolution is the same for `os dev` and `os start` (both spawn `os serve`):
+
+```
+--port <n>  ›  $OS_PORT  ›  $PORT  ›  3000   (default)
+```
+
+**Conflict behaviour is mode-dependent — this is deliberate:**
+
+| Mode | If the resolved port is busy |
+|:-----|:-----------------------------|
+| **Dev** (`os dev`, or `NODE_ENV=development`) | Auto-hops to the next free port (up to +100) so several example apps run side-by-side. The startup banner shows the *actual* bound port. |
+| **Production** (`os start`) | **Fails loudly and exits 1.** It never silently drifts — a shifted port breaks reverse-proxy upstreams, better-auth callback URLs, and CORS trusted-origins as opaque 403/502s. |
+
+**Production guidance:**
+
+- **Pin the port explicitly** — `PORT=8080 os start` (or `--port 8080`). Don't
+  rely on the `3000` default; it collides easily on shared hosts.
+- **Keep these in sync when you change the port** (mismatch ⇒ better-auth
+  `Invalid origin` 403 / CORS failures):
+  - reverse-proxy upstream (`nginx`/`caddy`)
+  - `OS_AUTH_URL` / better-auth `baseURL` + `callbackURL`
+  - `OS_TRUSTED_ORIGINS` (CORS allow-list)
+  - the app's `hostname`
+- **Recommended topology:** terminate TLS on a reverse proxy (`:443`) and let
+  the app listen on an internal high port (e.g. `8080`) fixed via `PORT`.
+
 ## Data & migrations
 
 | Command | What it does |
@@ -1127,7 +1160,7 @@ describe('account hooks', () => {
 | Edge (Cloudflare Workers, Vercel Edge) | `driver-turso` / `driver-d1` | `adapter-hono` | Cold-start friendly; LiteKernel only |
 | Serverless (Lambda, Vercel functions) | `driver-postgres` (with pooler) | `adapter-nextjs` / `adapter-express` | Mind cold-start: prefer LiteKernel |
 | Browser / WebContainer | `driver-sqlite-wasm` | none (in-process) | Studio playground, demos |
-| Docker / Kubernetes | any | any | Use `os start` as the entrypoint |
+| Docker / Kubernetes | any | any | Use `os start` as the entrypoint; pin `PORT` and `EXPOSE` it (see [Ports & networking](#ports--networking)) |
 
 ## Health & observability
 
@@ -1144,6 +1177,8 @@ describe('account hooks', () => {
 | Symptom | Likely cause |
 |:--------|:-------------|
 | `os dev` hangs at "Loading metadata…" | Circular import in `objectstack.config.ts` — run `os validate` |
+| `os start` exits with "Port N is already in use" | Intended: production never auto-shifts ports. Free the port or set `PORT=<n>` — see [Ports & networking](#ports--networking) |
+| better-auth `Invalid origin` 403 after a port/host change | Port or hostname out of sync with `OS_AUTH_URL` / `OS_TRUSTED_ORIGINS` — see [Ports & networking](#ports--networking) |
 | Migrations apply locally but not in cloud | `env` scoping on the dataset excludes the target environment |
 | Adapter 404s on auto-generated routes | `enable.apiEnabled: false` on the object, or missing `os build` |
 | LiteKernel test passes, ObjectKernel boot fails | Test missed a plugin dependency — list with `os info` |


### PR DESCRIPTION
## What

Make `os start` (production) **fail loudly** when its resolved port is busy, instead of silently hopping to the next free port. Dev (`os dev`) keeps the auto-hop convenience.

Port resolution is unchanged for all three entry points (`os dev` / `os start` both spawn `os serve`):

```
--port  ›  $OS_PORT  ›  $PORT  ›  3000
```

| Mode | Busy port behaviour |
|:-----|:--------------------|
| **Dev** (`os dev`, or `NODE_ENV=development`) | Auto-hops to next free port (up to +100); banner shows the real bound port. |
| **Production** (`os start`) | **Errors and exits `1`** — never drifts. |

## Why

The auto-shift in `serve.ts` was **not gated by mode**, so `os start` would also silently bind a different port on conflict. In production a drifted port quietly breaks:

- reverse-proxy upstreams (502),
- better-auth callback URLs (`OS_AUTH_URL` → `Invalid origin` 403),
- CORS trusted-origins (`OS_TRUSTED_ORIGINS`),

with no obvious cause. Failing fast forces the operator to free the port or pin one explicitly (`PORT=8080 os start`).

Also fixed a related papercut: the `os start` startup banner computed the Console URL from `flags.port ?? 3000`, so it printed the **wrong** URL whenever the port came from `$PORT`/`$OS_PORT`. It now mirrors `serve`'s resolution.

## Changes

- **`packages/cli/src/commands/serve.ts`** — gate the auto-shift to dev (`flags.dev || NODE_ENV==='development'`); production probes the port and exits `1` with a clear message if taken. Hoisted `isPortAvailable` to module scope so both paths share it; removed a dead `portShifted` local.
- **`packages/cli/src/commands/start.ts`** — banner resolves the real port (`--port › $OS_PORT/$PORT › 3000`).
- **Docs** — `getting-started/cli.mdx`, `guides/environment-variables.mdx`, `guides/cloud-deployment.mdx`, `packages/cli/README.md`.
- **Skill** — `objectstack-platform`: new "Ports & networking" section, updated cheat sheet/boot sequence, ops-pitfalls rows.
- **Changeset** — `@objectstack/cli` patch.

## Verification

Built the CLI and ran both paths against a deliberately-occupied port:

- **Production** (`NODE_ENV=production serve --port 4321`, 4321 busy) → prints `✗ Port 4321 is already in use.` + exit code **1**. ✅
- **Dev** (`serve --dev --port 4321`, 4321 busy) → auto-shifted to **4322**, server ready, banner shows `http://localhost:4322/`. ✅
- `tsc --noEmit` on `@objectstack/cli` is clean.

## Reviewer notes

- No change to the default port (`3000`) — production correctness comes from *pinning explicitly*, not from changing the default.
- The dev auto-hop logic itself is unchanged; it's only now conditional on mode.