### PR TITLE
feat(objectql): secret field type with encrypt-on-write to sys_secret

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1615,6 +1615,45 @@ export default class Serve extends Command {
       await new Promise(r => setTimeout(r, 100));
       restoreOutput();
 
+      // ── Secret-field CryptoProvider wiring (host composition root) ──
+      // objectql's `secret` field type encrypts on write to `sys_secret`
+      // and fails closed when no ICryptoProvider is registered. objectql
+      // must NOT depend on a crypto implementation (layering), so the
+      // host injects one here. Dev/self-host gets an independent
+      // InMemoryCryptoProvider; production hosts swap this for a
+      // KMS/Vault-backed provider (e.g. via an env-gated branch or a
+      // dedicated plugin) before secrets are written. We resolve the
+      // data engine by its registered service name and feature-detect
+      // `setCryptoProvider` so older engines / alternate data services
+      // degrade gracefully (writing a secret then fails closed, as
+      // designed, rather than silently storing cleartext).
+      try {
+        const dataEngine: any =
+          kernel.getService?.('data') ?? kernel.getService?.('objectql');
+        if (dataEngine && typeof dataEngine.setCryptoProvider === 'function') {
+          const { InMemoryCryptoProvider } = await import(
+            /* webpackIgnore: true */ '@objectstack/service-settings'
+          );
+          dataEngine.setCryptoProvider(new InMemoryCryptoProvider());
+          if (isDev) {
+            console.log(
+              chalk.dim(
+                '  ↪ secret fields: InMemoryCryptoProvider wired (dev) — swap for KMS/Vault in production',
+              ),
+            );
+          }
+        }
+      } catch (err: any) {
+        // Non-fatal: without a provider, secret writes fail closed by
+        // design. Surface a hint so operators know why a `secret` field
+        // write might reject.
+        console.warn(
+          chalk.yellow(
+            `  ⚠ secret fields: no CryptoProvider wired (${err?.message ?? err}); writing a secret field will fail closed`,
+          ),
+        );
+      }
+
       // ── Migrate-and-exit short-circuit ─────────────────────────────
       // Out-of-band migration mode: the caller (e.g.
       // `apps/cloud/scripts/migrate.ts`) just wants the kernel

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -13,6 +13,14 @@ import { ExecutionContext, ExecutionContextSchema } from '@objectstack/spec/kern
 import { DriverInterface, IDataEngine, Logger, createLogger } from '@objectstack/core';
 import { CoreServiceName, StorageNameMapping } from '@objectstack/spec/system';
 import { IRealtimeService, RealtimeEventPayload } from '@objectstack/spec/contracts';
+import type { ICryptoProvider, CryptoHandle } from '@objectstack/spec/contracts';
+import {
+  collectSecretFields,
+  makeSecretRef,
+  parseSecretRef,
+  isSecretRef,
+  SECRET_MASK,
+} from './secret-fields.js';
 import { pluralToSingular, ExternalWriteForbiddenError } from '@objectstack/spec/shared';
 import { SchemaRegistry, computeFQN } from './registry.js';
 import { ExpressionEngine } from '@objectstack/formula';
@@ -234,6 +242,11 @@ export class ObjectQL implements IDataEngine {
 
   // Realtime service for event publishing
   private realtimeService?: IRealtimeService;
+
+  // Crypto provider backing `secret`-typed fields. Optional: when absent,
+  // writing an object that declares a secret field fails closed (never
+  // persists cleartext). Injected by the host via setCryptoProvider().
+  private cryptoProvider?: ICryptoProvider;
 
   // Per-engine SchemaRegistry instance.
   //
@@ -1040,6 +1053,162 @@ export class ObjectQL implements IDataEngine {
   }
 
   /**
+   * Register the crypto provider that backs `secret`-typed fields.
+   *
+   * When set, the engine encrypts secret fields on write (storing ciphertext in
+   * `sys_secret` and only an opaque ref on the business row) and masks them on
+   * read. When NOT set, writing to an object that declares a secret field is
+   * **fail-closed** — the write throws rather than persist cleartext.
+   *
+   * Mirrors the Settings subsystem's ICryptoProvider wiring; the host (e.g.
+   * `serve`) injects `InMemoryCryptoProvider` in dev and a KMS/Vault-backed
+   * provider in production.
+   */
+  setCryptoProvider(provider: ICryptoProvider): void {
+    this.cryptoProvider = provider;
+    this.logger.info('CryptoProvider configured for secret fields');
+  }
+
+  /**
+   * Encrypt any `secret`-typed fields on `row` in place before it reaches the
+   * driver. Each plaintext is wrapped by the ICryptoProvider, persisted as a
+   * `sys_secret` row, and replaced on `row` by an opaque ref. Cleartext never
+   * reaches the business table.
+   *
+   * Rules:
+   *  - No secret fields on the object ⇒ no-op (fast path, no crypto cost).
+   *  - `null`/`undefined` value ⇒ left as-is (clears the secret).
+   *  - Value already a ref (re-save of an unchanged ref) ⇒ left as-is.
+   *  - Value equal to the read mask ⇒ dropped, so a form round-trip that
+   *    echoes the mask does not overwrite the stored secret.
+   *  - **Fail-closed:** any other value with no CryptoProvider registered, or
+   *    no reachable `sys_secret` store, THROWS — never persists cleartext.
+   */
+  private async encryptSecretFields(
+    object: string,
+    row: Record<string, unknown>,
+    context: ExecutionContext | undefined,
+    driverOptions: unknown,
+  ): Promise<void> {
+    if (!row || typeof row !== 'object') return;
+    const schema = this._registry.getObject(object);
+    const secretFields = collectSecretFields(schema);
+    if (secretFields.length === 0) return;
+
+    for (const field of secretFields) {
+      if (!(field in row)) continue;
+      const value = row[field];
+
+      if (value === null || typeof value === 'undefined') continue; // clear
+      if (isSecretRef(value)) continue; // already encrypted ref
+      if (value === SECRET_MASK) {
+        // The read path masks secrets to SECRET_MASK; a form that echoes it
+        // back means "unchanged". Drop the key so the stored secret survives.
+        delete row[field];
+        continue;
+      }
+
+      if (!this.cryptoProvider) {
+        throw new Error(
+          `Cannot persist secret field "${object}.${field}": no CryptoProvider is registered. `
+            + 'Wire one via engine.setCryptoProvider(...) (e.g. InMemoryCryptoProvider in dev, '
+            + 'a KMS/Vault provider in production). Refusing to store cleartext (fail-closed).',
+        );
+      }
+
+      const plain = typeof value === 'string' ? value : JSON.stringify(value);
+      const handle: CryptoHandle = await this.cryptoProvider.encrypt(plain, {
+        namespace: object,
+        key: field,
+        tenantId: context?.tenantId,
+      });
+
+      let secretDriver;
+      try {
+        secretDriver = this.getDriver('sys_secret');
+      } catch {
+        throw new Error(
+          `Cannot persist secret field "${object}.${field}": the sys_secret store is not available. `
+            + 'Ensure the platform-objects (sys_secret) are registered before writing secret fields (fail-closed).',
+        );
+      }
+
+      await secretDriver.create(
+        'sys_secret',
+        {
+          id: handle.id,
+          namespace: object,
+          key: field,
+          kms_key_id: handle.kmsKeyId,
+          alg: handle.alg,
+          version: handle.version,
+          ciphertext: handle.ciphertext,
+          created_at: new Date().toISOString(),
+        },
+        driverOptions as any,
+      );
+
+      row[field] = makeSecretRef(handle.id);
+    }
+  }
+
+  /**
+   * Mask `secret`-typed fields on read so plaintext never leaves the engine
+   * through the normal query path. A set secret becomes {@link SECRET_MASK};
+   * an unset one stays `null`. Privileged callers that genuinely need the
+   * plaintext use {@link resolveSecret} against the stored ref.
+   */
+  private maskSecretFields(object: string, rows: any): void {
+    if (!rows) return;
+    const schema = this._registry.getObject(object);
+    const secretFields = collectSecretFields(schema);
+    if (secretFields.length === 0) return;
+    const list = Array.isArray(rows) ? rows : [rows];
+    for (const row of list) {
+      if (!row || typeof row !== 'object') continue;
+      for (const field of secretFields) {
+        if (!(field in row)) continue;
+        row[field] = row[field] == null ? null : SECRET_MASK;
+      }
+    }
+  }
+
+  /**
+   * Dereference a stored secret ref back to its plaintext. Intended for
+   * privileged, server-side consumers (e.g. a datasource connection-pool
+   * binder) — NOT exposed through the generic read path, which only ever
+   * returns the mask.
+   *
+   * Fail-closed: throws when no CryptoProvider is registered or the
+   * `sys_secret` row is missing. Returns `null` when `ref` is not a secret ref.
+   */
+  async resolveSecret(ref: unknown, opts?: { tenantId?: string }): Promise<string | null> {
+    const id = parseSecretRef(ref);
+    if (!id) return null;
+    if (!this.cryptoProvider) {
+      throw new Error('Cannot resolve secret: no CryptoProvider is registered (fail-closed).');
+    }
+    const secretDriver = this.getDriver('sys_secret');
+    const found = await secretDriver.find('sys_secret', { object: 'sys_secret', where: { id } } as QueryAST);
+    const secret: any = Array.isArray(found) ? found[0] : found;
+    if (!secret) {
+      throw new Error(`Cannot resolve secret: sys_secret row "${id}" not found (fail-closed).`);
+    }
+    const handle: CryptoHandle = {
+      id: secret.id,
+      kmsKeyId: secret.kms_key_id,
+      alg: secret.alg,
+      version: secret.version,
+      ciphertext: secret.ciphertext,
+    };
+    return this.cryptoProvider.decrypt(handle, {
+      namespace: secret.namespace,
+      key: secret.key,
+      tenantId: opts?.tenantId,
+    });
+  }
+
+  /**
    * Helper to get object definition
    */
   getSchema(objectName: string): ServiceObject | undefined {
@@ -1455,7 +1624,12 @@ export class ObjectQL implements IDataEngine {
           hookContext.event = 'afterFind';
           hookContext.result = result;
           await this.triggerHooks('afterFind', hookContext);
-          
+
+          // Never let secret-field plaintext (or its ref) leave through the
+          // generic read path — mask after hooks run. Privileged consumers use
+          // resolveSecret() against the stored ref instead.
+          this.maskSecretFields(object, hookContext.result);
+
           return hookContext.result;
       } catch (e) {
           this.logger.error('Find operation failed', e as Error, { object });
@@ -1514,6 +1688,9 @@ export class ObjectQL implements IDataEngine {
         result = expanded[0];
       }
 
+      // Mask secret fields — plaintext never leaves through the read path.
+      this.maskSecretFields(objectName, result);
+
       return result;
     });
 
@@ -1561,6 +1738,9 @@ export class ObjectQL implements IDataEngine {
           const rows = (hookContext.input.data as any[]).map((row) =>
             this.applyFieldDefaults(object, row as Record<string, unknown>, opCtx.context, nowSnap),
           );
+          for (const r of rows) {
+            await this.encryptSecretFields(object, r, opCtx.context, hookContext.input.options);
+          }
           for (const r of rows) validateRecord(schemaForValidation, r, 'insert');
           if (driver.bulkCreate) {
                result = await driver.bulkCreate(object, rows, hookContext.input.options as any);
@@ -1575,6 +1755,7 @@ export class ObjectQL implements IDataEngine {
             opCtx.context,
             nowSnap,
           );
+          await this.encryptSecretFields(object, row, opCtx.context, hookContext.input.options);
           validateRecord(schemaForValidation, row, 'insert');
           result = await driver.create(object, row, hookContext.input.options as any);
         }
@@ -1665,9 +1846,11 @@ export class ObjectQL implements IDataEngine {
        try {
            let result;
            if (hookContext.input.id) {
+               await this.encryptSecretFields(object, hookContext.input.data as Record<string, unknown>, opCtx.context, hookContext.input.options);
                validateRecord(this._registry.getObject(object), hookContext.input.data as Record<string, unknown>, 'update');
                result = await driver.update(object, hookContext.input.id as string, hookContext.input.data as Record<string, unknown>, hookContext.input.options as any);
            } else if (options?.multi && driver.updateMany) {
+               await this.encryptSecretFields(object, hookContext.input.data as Record<string, unknown>, opCtx.context, hookContext.input.options);
                validateRecord(this._registry.getObject(object), hookContext.input.data as Record<string, unknown>, 'update');
                const ast: QueryAST = { object, where: options.where };
                result = await driver.updateMany(object, ast, hookContext.input.data as Record<string, unknown>, hookContext.input.options as any);

--- a/packages/objectql/src/index.ts
+++ b/packages/objectql/src/index.ts
@@ -57,6 +57,16 @@ export { ObjectQLPlugin } from './plugin.js';
 export { createObjectQLKernel } from './kernel-factory.js';
 export type { ObjectQLKernelOptions } from './kernel-factory.js';
 
+// Export secret-field channel helpers (for hosts / privileged consumers)
+export {
+  SECRET_REF_PREFIX,
+  SECRET_MASK,
+  makeSecretRef,
+  isSecretRef,
+  parseSecretRef,
+  collectSecretFields,
+} from './secret-fields.js';
+
 // Export Utilities
 export {
   toTitleCase,

--- a/packages/objectql/src/secret-fields.test.ts
+++ b/packages/objectql/src/secret-fields.test.ts
@@ -1,0 +1,234 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Secret-field channel — end-to-end against a REAL {@link ObjectQL} engine + a
+ * minimal in-memory driver. Verifies the core encryption chain:
+ *  - encrypt-on-write: plaintext → sys_secret ciphertext + opaque ref on the row
+ *  - mask-on-read: the generic read path never returns plaintext or the ref
+ *  - resolveSecret: privileged dereference round-trips back to plaintext
+ *  - fail-closed: no CryptoProvider ⇒ writing a secret field throws
+ *  - update semantics: change re-encrypts; echoed mask is a no-op; null clears
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ObjectQL } from './engine.js';
+import { SECRET_MASK, isSecretRef } from './secret-fields.js';
+import type { ICryptoProvider, CryptoHandle, CryptoContext } from '@objectstack/spec/contracts';
+
+// ---- minimal in-memory driver (equality-only WHERE) -----------------------
+function makeMemoryDriver() {
+  const stores = new Map<string, Map<string, Record<string, unknown>>>();
+  const storeFor = (obj: string) => {
+    let s = stores.get(obj);
+    if (!s) { s = new Map(); stores.set(obj, s); }
+    return s;
+  };
+  let nextId = 0;
+  const matches = (row: any, where: any): boolean => {
+    if (!where || typeof where !== 'object') return true;
+    for (const [k, v] of Object.entries(where)) {
+      if (k.startsWith('$')) continue;
+      const expected = (v && typeof v === 'object' && '$eq' in (v as any)) ? (v as any).$eq : v;
+      if ((row[k] ?? null) !== (expected ?? null)) return false;
+    }
+    return true;
+  };
+  const driver: any = {
+    name: 'memory', version: '0.0.0', supports: {},
+    async connect() {}, async disconnect() {}, async checkHealth() { return true; },
+    async execute() { return null; },
+    async find(object: string, ast: any) {
+      return Array.from(storeFor(object).values()).filter((r) => matches(r, ast?.where));
+    },
+    findStream() { throw new Error('not implemented'); },
+    async findOne(object: string, ast: any) {
+      for (const r of storeFor(object).values()) if (matches(r, ast?.where)) return r;
+      return null;
+    },
+    async create(object: string, data: Record<string, unknown>) {
+      nextId += 1;
+      const id = (data.id as string) ?? `r_${nextId}`;
+      const row = { ...data, id };
+      storeFor(object).set(id, row);
+      return row;
+    },
+    async update(object: string, id: string, data: Record<string, unknown>) {
+      const s = storeFor(object);
+      const cur = s.get(id);
+      if (!cur) throw new Error(`not found: ${object}/${id}`);
+      const updated = { ...cur, ...data, id };
+      s.set(id, updated);
+      return updated;
+    },
+    async upsert(object: string, data: Record<string, unknown>) {
+      const id = data.id as string | undefined;
+      if (id && storeFor(object).has(id)) return this.update(object, id, data);
+      return this.create(object, data);
+    },
+    async delete(object: string, id: string) { return storeFor(object).delete(id); },
+    async count(object: string, ast: any) { return (await this.find(object, ast)).length; },
+    async bulkCreate(object: string, rows: Record<string, unknown>[]) {
+      return Promise.all(rows.map((r) => this.create(object, r)));
+    },
+    async bulkUpdate() { return []; },
+    async bulkDelete() {},
+    async beginTransaction() { return { commit: async () => {}, rollback: async () => {} }; },
+    async commit() {}, async rollback() {},
+  };
+  return { driver, stores };
+}
+
+// ---- fake reversible crypto provider (base64 wrap) ------------------------
+function makeFakeCrypto() {
+  let n = 0;
+  const calls: { encrypt: number; decrypt: number } = { encrypt: 0, decrypt: 0 };
+  const provider: ICryptoProvider = {
+    async encrypt(plain: string, _ctx: CryptoContext): Promise<CryptoHandle> {
+      calls.encrypt += 1;
+      n += 1;
+      return {
+        id: `sec_${n}`,
+        kmsKeyId: 'local',
+        alg: 'test-b64',
+        version: 1,
+        ciphertext: Buffer.from(plain, 'utf8').toString('base64'),
+      };
+    },
+    async decrypt(handle: CryptoHandle, _ctx: CryptoContext): Promise<string> {
+      calls.decrypt += 1;
+      return Buffer.from(handle.ciphertext, 'base64').toString('utf8');
+    },
+    async rotateKey(handle: CryptoHandle): Promise<CryptoHandle> {
+      return { ...handle, version: handle.version + 1 };
+    },
+    digest(plain: string): string { return `d:${plain.length}`; },
+  };
+  return { provider, calls };
+}
+
+const sysSecretObject = {
+  name: 'sys_secret', label: 'Secret',
+  fields: {
+    id: { name: 'id', label: 'ID', type: 'text' as const },
+    namespace: { name: 'namespace', label: 'Namespace', type: 'text' as const },
+    key: { name: 'key', label: 'Key', type: 'text' as const },
+    kms_key_id: { name: 'kms_key_id', label: 'KMS', type: 'text' as const },
+    alg: { name: 'alg', label: 'Alg', type: 'text' as const },
+    version: { name: 'version', label: 'Version', type: 'number' as const },
+    ciphertext: { name: 'ciphertext', label: 'Ciphertext', type: 'text' as const },
+    created_at: { name: 'created_at', label: 'Created', type: 'datetime' as const },
+  },
+};
+
+const dsObject = {
+  name: 'ext_datasource', label: 'Datasource',
+  fields: {
+    id: { name: 'id', label: 'ID', type: 'text' as const },
+    name: { name: 'name', label: 'Name', type: 'text' as const },
+    db_password: { name: 'db_password', label: 'DB Password', type: 'secret' as const },
+  },
+};
+
+async function buildEngine(withCrypto: boolean) {
+  const engine = new ObjectQL();
+  const { driver, stores } = makeMemoryDriver();
+  engine.registerDriver(driver, true);
+  await engine.init();
+  engine.registry.registerObject(sysSecretObject as any);
+  engine.registry.registerObject(dsObject as any);
+  const crypto = makeFakeCrypto();
+  if (withCrypto) engine.setCryptoProvider(crypto.provider);
+  return { engine, stores, crypto };
+}
+
+describe('objectql secret-field channel', () => {
+  let ctx: Awaited<ReturnType<typeof buildEngine>>;
+  beforeEach(async () => { ctx = await buildEngine(true); });
+
+  it('encrypts on write: row stores a ref, sys_secret holds ciphertext, no cleartext on the row', async () => {
+    const created = await ctx.engine.insert('ext_datasource', { name: 'pg', db_password: 's3cr3t' });
+
+    // Returned/persisted business row holds a ref, never the plaintext.
+    const stored = ctx.stores.get('ext_datasource')!.get(created.id) as any;
+    expect(isSecretRef(stored.db_password)).toBe(true);
+    expect(stored.db_password).not.toContain('s3cr3t');
+
+    // sys_secret got exactly one ciphertext row, keyed by object/field.
+    const secrets = Array.from(ctx.stores.get('sys_secret')!.values()) as any[];
+    expect(secrets).toHaveLength(1);
+    expect(secrets[0].namespace).toBe('ext_datasource');
+    expect(secrets[0].key).toBe('db_password');
+    expect(secrets[0].ciphertext).not.toContain('s3cr3t');
+    expect(ctx.crypto.calls.encrypt).toBe(1);
+  });
+
+  it('masks on read: find / findOne never return plaintext or the ref', async () => {
+    const created = await ctx.engine.insert('ext_datasource', { name: 'pg', db_password: 's3cr3t' });
+
+    const viaFind = (await ctx.engine.find('ext_datasource', { where: { id: created.id } }))[0] as any;
+    expect(viaFind.db_password).toBe(SECRET_MASK);
+
+    const viaOne = await ctx.engine.findOne('ext_datasource', { where: { id: created.id } }) as any;
+    expect(viaOne.db_password).toBe(SECRET_MASK);
+  });
+
+  it('resolveSecret round-trips a stored ref back to plaintext', async () => {
+    const created = await ctx.engine.insert('ext_datasource', { name: 'pg', db_password: 's3cr3t' });
+    const stored = ctx.stores.get('ext_datasource')!.get(created.id) as any;
+
+    const plain = await ctx.engine.resolveSecret(stored.db_password);
+    expect(plain).toBe('s3cr3t');
+    expect(ctx.crypto.calls.decrypt).toBe(1);
+  });
+
+  it('fail-closed: writing a secret field with no CryptoProvider throws', async () => {
+    const bare = await buildEngine(false);
+    await expect(
+      bare.engine.insert('ext_datasource', { name: 'pg', db_password: 'nope' }),
+    ).rejects.toThrow(/no CryptoProvider/i);
+    // Nothing leaked into either store.
+    expect(bare.stores.get('ext_datasource')?.size ?? 0).toBe(0);
+    expect(bare.stores.get('sys_secret')?.size ?? 0).toBe(0);
+  });
+
+  it('update: changing the secret re-encrypts into a new sys_secret row', async () => {
+    const created = await ctx.engine.insert('ext_datasource', { name: 'pg', db_password: 'old' });
+    await ctx.engine.update('ext_datasource', { id: created.id, db_password: 'new' });
+
+    expect(ctx.crypto.calls.encrypt).toBe(2);
+    const stored = ctx.stores.get('ext_datasource')!.get(created.id) as any;
+    const plain = await ctx.engine.resolveSecret(stored.db_password);
+    expect(plain).toBe('new');
+  });
+
+  it('update: echoing the read mask back does NOT overwrite the stored secret', async () => {
+    const created = await ctx.engine.insert('ext_datasource', { name: 'pg', db_password: 'keep' });
+    const refBefore = (ctx.stores.get('ext_datasource')!.get(created.id) as any).db_password;
+
+    // Simulate a form round-trip: user changes name, secret field still shows the mask.
+    await ctx.engine.update('ext_datasource', { id: created.id, name: 'renamed', db_password: SECRET_MASK });
+
+    const after = ctx.stores.get('ext_datasource')!.get(created.id) as any;
+    expect(after.name).toBe('renamed');
+    expect(after.db_password).toBe(refBefore); // unchanged
+    expect(ctx.crypto.calls.encrypt).toBe(1);   // no re-encrypt
+  });
+
+  it('non-secret objects are untouched (no crypto cost)', async () => {
+    engineWithoutSecretField: {
+      const engine = new ObjectQL();
+      const { driver, stores } = makeMemoryDriver();
+      engine.registerDriver(driver, true);
+      await engine.init();
+      engine.registry.registerObject({
+        name: 'plain', label: 'Plain',
+        fields: { id: { name: 'id', type: 'text' as const }, title: { name: 'title', type: 'text' as const } },
+      } as any);
+      // No crypto provider, but no secret field ⇒ must not throw.
+      const row = await engine.insert('plain', { title: 'hello' });
+      const back = await engine.findOne('plain', { where: { id: row.id } }) as any;
+      expect(back.title).toBe('hello');
+      void stores;
+    }
+  });
+});

--- a/packages/objectql/src/secret-fields.ts
+++ b/packages/objectql/src/secret-fields.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Secret-field channel — helpers for the `secret` FieldType.
+ *
+ * A `secret` field (DB password, API key, token) is **reversible**: the engine
+ * encrypts it on write via the registered `ICryptoProvider`, persists the
+ * ciphertext as a `sys_secret` row, and stores only an opaque *ref* on the
+ * business row. On read the ref is masked, never the plaintext. This mirrors
+ * the Settings subsystem (`sys_setting.value_enc → sys_secret.id`), generalized
+ * to object fields.
+ *
+ * Contrast with `password` — a one-way hash owned by the auth subsystem, never
+ * decrypted. The two never share a code path.
+ */
+
+import type { ServiceObject } from '@objectstack/spec/data';
+
+/**
+ * Prefix marking a persisted field value as a `sys_secret` handle ref rather
+ * than cleartext. Chosen to be unambiguous and human-greppable in a DB dump,
+ * while making it obvious that the column holds no plaintext.
+ */
+export const SECRET_REF_PREFIX = 'secret:';
+
+/**
+ * Value returned in place of a secret field on a normal read. Indicates
+ * "a secret is set" without leaking the handle id or the plaintext. A field
+ * with no stored secret resolves to `null` instead.
+ */
+export const SECRET_MASK = '••••••••';
+
+/** Wrap a `sys_secret` handle id as the opaque ref persisted on the row. */
+export function makeSecretRef(handleId: string): string {
+  return `${SECRET_REF_PREFIX}${handleId}`;
+}
+
+/** True when `value` is a secret ref previously produced by {@link makeSecretRef}. */
+export function isSecretRef(value: unknown): value is string {
+  return typeof value === 'string' && value.startsWith(SECRET_REF_PREFIX);
+}
+
+/** Extract the `sys_secret` handle id from a ref, or `null` when not a ref. */
+export function parseSecretRef(value: unknown): string | null {
+  return isSecretRef(value) ? (value as string).slice(SECRET_REF_PREFIX.length) : null;
+}
+
+/**
+ * Collect the names of `secret`-typed fields declared on an object schema.
+ * Returns an empty array when the schema has no fields or no secret fields —
+ * callers can fast-path on `length === 0` to skip all crypto work.
+ */
+export function collectSecretFields(schema: ServiceObject | undefined | null): string[] {
+  const fields = (schema as any)?.fields as Record<string, { type?: string }> | undefined;
+  if (!fields) return [];
+  const out: string[] = [];
+  for (const [name, def] of Object.entries(fields)) {
+    if (def && def.type === 'secret') out.push(name);
+  }
+  return out;
+}

--- a/packages/plugins/driver-memory/src/memory-driver.test.ts
+++ b/packages/plugins/driver-memory/src/memory-driver.test.ts
@@ -719,4 +719,34 @@ describe('InMemoryDriver', () => {
       expect(results.map((r: any) => r.name)).toContain('Frank');
     });
   });
+
+  describe('Read isolation (no live references into the backing table)', () => {
+    // Callers (notably the ObjectQL engine's read-time mutations — secret-field
+    // masking, expand, afterFind hooks) mutate returned rows in place. find /
+    // findOne must therefore hand back COPIES, never live references into the
+    // stored table — otherwise a read would corrupt the persisted record (e.g.
+    // overwrite a `secret:` ref with the read mask, permanently losing the
+    // secret). `create()` already honors this; these guard find / findOne.
+    beforeEach(async () => {
+      await driver.create(testTable, { id: '1', name: 'original', secret_ref: 'secret:abc123' });
+    });
+
+    it('find() returns copies — mutating a result does not change the store', async () => {
+      const first = await driver.find(testTable, { object: testTable, where: { id: '1' } });
+      (first[0] as any).secret_ref = '••••••••'; // simulate engine masking the row in place
+
+      const second = await driver.find(testTable, { object: testTable, where: { id: '1' } });
+      expect((second[0] as any).secret_ref).toBe('secret:abc123'); // store intact
+      expect(second[0]).not.toBe(first[0]); // distinct object identity
+    });
+
+    it('findOne() returns a copy — mutating it does not change the store', async () => {
+      const first = await driver.findOne(testTable, { object: testTable, where: { id: '1' } });
+      (first as any).secret_ref = '••••••••';
+
+      const second = await driver.findOne(testTable, { object: testTable, where: { id: '1' } });
+      expect((second as any).secret_ref).toBe('secret:abc123');
+      expect(second).not.toBe(first);
+    });
+  });
 });

--- a/packages/plugins/driver-memory/src/memory-driver.ts
+++ b/packages/plugins/driver-memory/src/memory-driver.ts
@@ -295,6 +295,15 @@ export class InMemoryDriver implements IDataDriver {
     // 5. Field Projection
     if (query.fields && Array.isArray(query.fields) && query.fields.length > 0) {
       results = results.map(record => this.projectFields(record, query.fields as string[]));
+    } else {
+      // Return shallow copies, never live references into the backing table.
+      // `create()` already honors this contract (`return { ...newRecord }`),
+      // and callers (notably the engine's read-time mutations — secret-field
+      // masking, expand, afterFind hooks) mutate returned rows in place. Handing
+      // back live references would corrupt the stored record on read — e.g. a
+      // masked `secret:` ref overwritten with the mask, permanently losing the
+      // secret. The projection branch above already produces fresh objects.
+      results = results.map(record => ({ ...record }));
     }
 
     this.logger.debug('Find completed', { object, resultCount: results.length });

--- a/packages/spec/src/data/field.zod.ts
+++ b/packages/spec/src/data/field.zod.ts
@@ -13,6 +13,13 @@ import { lazySchema } from '../shared/lazy-schema';
 export const FieldType = z.enum([
   // Core Text
   'text', 'textarea', 'email', 'url', 'phone', 'password',
+  // Secret — reversible, encrypted-at-rest value (DB password, API key, token).
+  // UNLIKE 'password' (a one-way hash owned by the auth subsystem), a 'secret'
+  // is round-tripped: the engine encrypts it on write via the registered
+  // ICryptoProvider, stores the ciphertext handle in `sys_secret`, persists only
+  // an opaque ref on the row, and masks it on read. Fail-closed: no provider ⇒
+  // writes throw rather than persist cleartext. See ADR (secret field channel).
+  'secret',
   // Rich Content
   'markdown', 'html', 'richtext',
   // Numbers
@@ -532,6 +539,13 @@ export const Field = {
   markdown: (config: FieldInput = {}) => ({ type: 'markdown', ...config } as const),
   html: (config: FieldInput = {}) => ({ type: 'html', ...config } as const),
   password: (config: FieldInput = {}) => ({ type: 'password', ...config } as const),
+  /**
+   * Secret field — reversible encrypted-at-rest value (DB password, API key,
+   * token). Encrypted on write to `sys_secret` via the registered
+   * ICryptoProvider; only an opaque ref is persisted on the row; masked on
+   * read. Distinct from `password` (one-way hash, owned by the auth subsystem).
+   */
+  secret: (config: FieldInput = {}) => ({ type: 'secret', ...config } as const),
   
   /**
    * Select field helper with backward-compatible API


### PR DESCRIPTION
## What

Adds a reversible **`secret`** field type whose values are encrypted on write and never returned in plaintext through the normal read path — for DB passwords, API keys, tokens.

Distinct from `password` (a one-way scrypt hash owned by the auth/better-auth subsystem; the two **never share a code path**): `secret` is reversible (`encrypt`/`decrypt`), `password` is verify-only.

## Core encryption chain

- **spec** — add `secret` to `FieldType` + a `Field.secret()` helper, documented as reversible / encrypted / fail-closed.
- **objectql** — encrypt-on-write in insert/update (ciphertext → `sys_secret`, the business row keeps only an opaque `secret:<id>` ref); mask-on-read in find/findOne (returns a mask, never plaintext or the ref); `engine.resolveSecret(ref)` for privileged server-side dereference; `engine.setCryptoProvider(p)` injection point. **Fail-closed**: writing a secret with no registered `ICryptoProvider` throws — never persists cleartext.
- **host wiring** — the `serve` composition root resolves the data engine after `runtime.start()` and injects an independent `InMemoryCryptoProvider` (dev); production hosts swap for KMS/Vault. objectql keeps **zero dependency** on the provider implementation — the host injects.

## Driver contract fix

mask-on-read mutates returned rows in place, so a driver **must return fresh row copies on read**. `InMemoryDriver.find` previously returned live references (it cloned the array, not the rows), which would corrupt a stored `secret:` ref into the mask on first read — permanently losing the secret. It now copies rows on the non-projected path, matching its own `create()` contract. This guards **all** read-time mutation (expand, afterFind hooks), not just secrets.

## Tests

- 7 end-to-end secret-field tests (encrypt-on-write, mask-on-read, `resolveSecret` round-trip, fail-closed, update re-encrypt / mask-echo no-op, non-secret zero-cost).
- 2 driver read-isolation regression tests.
- Verified end-to-end against the **real** `InMemoryCryptoProvider` + **real** `InMemoryDriver` (secret survives repeated masked reads; `resolveSecret` round-trips).

## Notes

- objectql build clean; secret-field tests green. There is **one pre-existing failure unrelated to this PR** in `metadata-validation-sweep.test.ts` (the `workflow` state-machine sweep fixture) inherited from `main`'s intermediate state — this PR touches no workflow/state-machine/field-validation code.
- Follow-up (separate PR): objectui renders `secret` as a write-only input; driver `configSchema`-driven config widget; datasource "Test connection" action.