### PR TITLE
feat(metadata): declarative type-level actions for metadata-admin

### DIFF
--- a/packages/metadata/src/metadata-manager.ts
+++ b/packages/metadata/src/metadata-manager.ts
@@ -42,6 +42,7 @@ import type {
   MetadataTypeRegistryEntry,
 } from '@objectstack/spec/kernel';
 import type { MetadataOverlay } from '@objectstack/spec/kernel';
+import { getMetadataTypeActions } from '@objectstack/spec/kernel';
 import { createLogger, type Logger } from '@objectstack/core';
 import { JSONSerializer } from './serializers/json-serializer.js';
 import { YAMLSerializer } from './serializers/yaml-serializer.js';
@@ -1255,6 +1256,17 @@ export class MetadataManager implements IMetadataService {
     const entry = this.typeRegistry.find(e => e.type === type);
     if (!entry) return undefined;
 
+    // Merge declarative (live registry entry — covers built-ins AND
+    // plugin-contributed `additionalTypes`) + plugin-registered type-level
+    // actions. Deduped by name; imperatively-registered actions win on
+    // collision. Emitted so the metadata-admin engine can render per-type
+    // buttons (e.g. datasource "Test connection"). Omit the key entirely
+    // when the type has none, to keep the response lean.
+    const byName = new Map<string, any>();
+    for (const a of (entry.actions ?? [])) byName.set(a.name, a);
+    for (const a of getMetadataTypeActions(type)) byName.set(a.name, a);
+    const actions = Array.from(byName.values());
+
     return {
       type: entry.type,
       label: entry.label,
@@ -1262,6 +1274,7 @@ export class MetadataManager implements IMetadataService {
       filePatterns: entry.filePatterns,
       supportsOverlay: entry.supportsOverlay,
       domain: entry.domain,
+      ...(actions.length > 0 ? { actions } : {}),
     };
   }
 

--- a/packages/metadata/src/metadata-service.test.ts
+++ b/packages/metadata/src/metadata-service.test.ts
@@ -628,6 +628,19 @@ describe('MetadataManager — IMetadataService Contract', () => {
       const info = await manager.getTypeInfo('unknown_type');
       expect(info).toBeUndefined();
     });
+
+    it('should emit declarative type-level actions (datasource Test connection)', async () => {
+      const info = await manager.getTypeInfo('datasource');
+      expect(info).toBeDefined();
+      const test = info!.actions?.find((a: any) => a.name === 'test_connection');
+      expect(test).toMatchObject({ type: 'api', method: 'POST' });
+    });
+
+    it('should omit the actions key for types with no actions', async () => {
+      const info = await manager.getTypeInfo('object');
+      expect(info).toBeDefined();
+      expect('actions' in info!).toBe(false);
+    });
   });
 
   // ==========================================

--- a/packages/spec/src/api/metadata.zod.ts
+++ b/packages/spec/src/api/metadata.zod.ts
@@ -5,6 +5,7 @@ import { BaseResponseSchema } from './contract.zod';
 import { ObjectSchema } from '../data/object.zod';
 import { AppSchema } from '../ui/app.zod';
 import { MetadataTypeSchema, MetadataQuerySchema, MetadataQueryResultSchema, MetadataValidationResultSchema, MetadataBulkResultSchema, MetadataDependencySchema } from '../kernel/metadata-plugin.zod';
+import { ActionSchema } from '../ui/action.zod';
 import { MetadataOverlaySchema } from '../kernel/metadata-customization.zod';
 
 /**
@@ -314,6 +315,7 @@ export const MetadataTypeInfoResponseSchema = lazySchema(() => BaseResponseSchem
     filePatterns: z.array(z.string()).describe('File glob patterns'),
     supportsOverlay: z.boolean().describe('Overlay support'),
     domain: z.string().describe('Protocol domain'),
+    actions: z.array(ActionSchema).optional().describe('Declarative type-level actions (buttons) the metadata-admin UI renders for this type'),
   }).optional().describe('Type info'),
 }));
 

--- a/packages/spec/src/contracts/metadata-service.ts
+++ b/packages/spec/src/contracts/metadata-service.ts
@@ -36,6 +36,7 @@
  */
 
 import type { MetadataQuery, MetadataQueryResult, MetadataValidationResult, MetadataBulkResult, MetadataDependency } from '../kernel/metadata-plugin.zod';
+import type { Action } from '../ui/action.zod';
 import type { MetadataOverlay } from '../kernel/metadata-customization.zod';
 import type { PackagePublishResult, MetadataHistoryQueryOptions, MetadataHistoryQueryResult, MetadataDiffResult } from '../system/metadata-persistence.zod';
 
@@ -113,6 +114,14 @@ export interface MetadataTypeInfo {
     supportsOverlay: boolean;
     /** Protocol domain */
     domain: string;
+    /**
+     * Declarative type-level actions (buttons) for this metadata type — the
+     * merged result of the registry entry's declarative `actions` and any
+     * plugin-registered actions (`registerMetadataTypeActions`). The Studio
+     * metadata-admin engine renders these the same way `ObjectView` renders
+     * an object's actions. Omitted/empty when the type declares none.
+     */
+    actions?: Action[];
 }
 
 export interface IMetadataService {

--- a/packages/spec/src/kernel/metadata-plugin.zod.ts
+++ b/packages/spec/src/kernel/metadata-plugin.zod.ts
@@ -3,6 +3,7 @@
 import { z } from 'zod';
 import { MetadataManagerConfigSchema } from './metadata-loader.zod';
 import { MergeStrategyConfigSchema, CustomizationPolicySchema } from './metadata-customization.zod';
+import { ActionSchema } from '../ui/action.zod';
 
 /**
  * # Metadata Plugin Protocol
@@ -213,6 +214,29 @@ const MetadataTypeRegistryEntryBaseSchema = z.object({
   /** The domain this type belongs to */
   domain: z.enum(['data', 'ui', 'automation', 'system', 'security', 'ai'])
     .describe('Protocol domain'),
+
+  /**
+   * Declarative **type-level** actions for this metadata type.
+   *
+   * These are buttons the Studio metadata-admin engine renders for the type
+   * as a whole (or for a single item of the type) — the same `ActionSchema`
+   * business objects already use for row/header actions, reused verbatim so
+   * there is no third button mechanism to learn.
+   *
+   * The canonical example is the `datasource` **Test connection** button: an
+   * `ActionType: 'api'` action whose `url` calls the connection-probe
+   * endpoint. Built-in types declare actions here; plugins layer additional
+   * actions onto any type at runtime via `registerMetadataTypeActions()`
+   * (the engine merges declarative + registered when emitting
+   * `/api/v1/meta/types/:type`).
+   *
+   * Note: this is distinct from the per-record `actions` a business *object*
+   * carries (`ObjectSchema.actions`) — those act on rows of a user object,
+   * these act on definitions of a metadata type.
+   */
+  actions: z.array(ActionSchema).optional().describe(
+    'Declarative type-level actions (e.g. datasource "Test connection"), reusing ActionSchema; merged with plugin-registered actions when emitted'
+  ),
 });
 
 export const MetadataTypeRegistryEntrySchema = lazySchema(() =>
@@ -592,7 +616,37 @@ export const DEFAULT_METADATA_TYPE_REGISTRY: MetadataTypeRegistryEntry[] = [
   // Code-defined (`origin: 'code'`) datasources remain read-only and win on
   // name collision; record-level read-only gating is enforced by origin, not
   // by this flag. No per-org overlay (a datasource = one physical connection).
-  { type: 'datasource', label: 'Datasource', filePatterns: ['**/*.datasource.ts', '**/*.datasource.yml'], supportsOverlay: false, allowOrgOverride: false, allowRuntimeCreate: true, supportsVersioning: false, executionPinned: false, loadOrder: 5, domain: 'system' },
+  {
+    type: 'datasource',
+    label: 'Datasource',
+    filePatterns: ['**/*.datasource.ts', '**/*.datasource.yml'],
+    supportsOverlay: false,
+    allowOrgOverride: false,
+    allowRuntimeCreate: true,
+    supportsVersioning: false,
+    executionPinned: false,
+    loadOrder: 5,
+    domain: 'system',
+    // First metadata-admin type-level action (GAP 1): probe the live
+    // connection for an existing datasource. The matching route
+    // (`POST /api/v1/datasources/:name/test`) is registered by the host's
+    // datasource-admin backend; when that backend is absent the button is
+    // still emitted but the call returns "unavailable" rather than 404-ing
+    // the page. `${ctx.recordId}` resolves to the datasource's name.
+    actions: [
+      {
+        name: 'test_connection',
+        label: 'Test connection',
+        icon: 'plug-zap',
+        type: 'api',
+        target: '/api/v1/datasources/${ctx.recordId}/test',
+        method: 'POST',
+        variant: 'secondary',
+        refreshAfter: false,
+        locations: ['record_header', 'list_item'],
+      },
+    ],
+  },
   { type: 'external_catalog', label: 'External Catalog', filePatterns: ['**/*.external-catalog.ts', '**/*.external-catalog.yml', '**/*.external-catalog.json'], supportsOverlay: false, allowOrgOverride: false, allowRuntimeCreate: true, supportsVersioning: false, executionPinned: false, loadOrder: 6, domain: 'system' },
   { type: 'translation', label: 'Translation', filePatterns: ['**/*.translation.ts', '**/*.translation.yml', '**/*.translation.json'], supportsOverlay: true, allowOrgOverride: true, allowRuntimeCreate: true, supportsVersioning: false, executionPinned: false, loadOrder: 90, domain: 'system' },
   { type: 'router', label: 'Router', filePatterns: ['**/*.router.ts'], supportsOverlay: false, allowOrgOverride: false, allowRuntimeCreate: false, supportsVersioning: false, executionPinned: false, loadOrder: 40, domain: 'system' },

--- a/packages/spec/src/kernel/metadata-type-actions.test.ts
+++ b/packages/spec/src/kernel/metadata-type-actions.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import {
+  registerMetadataTypeActions,
+  getMetadataTypeActions,
+} from './metadata-type-schemas';
+import { DEFAULT_METADATA_TYPE_REGISTRY } from './metadata-plugin.zod';
+import type { Action } from '../ui/action.zod';
+
+const action = (name: string, overrides: Partial<Action> = {}): Action =>
+  ({
+    name,
+    label: name,
+    type: 'api',
+    refreshAfter: false,
+    ...overrides,
+  }) as Action;
+
+describe('Metadata type-level actions', () => {
+  describe('declarative actions on the registry entry', () => {
+    it('ships a Test-connection action on the datasource entry', () => {
+      const ds = DEFAULT_METADATA_TYPE_REGISTRY.find((e) => e.type === 'datasource');
+      expect(ds?.actions).toBeDefined();
+      const test = ds!.actions!.find((a) => a.name === 'test_connection');
+      expect(test).toMatchObject({
+        type: 'api',
+        method: 'POST',
+        target: '/api/v1/datasources/${ctx.recordId}/test',
+      });
+    });
+
+    it('surfaces declarative actions through getMetadataTypeActions', () => {
+      const actions = getMetadataTypeActions('datasource');
+      expect(actions.map((a) => a.name)).toContain('test_connection');
+    });
+
+    it('returns [] for a type with no actions', () => {
+      expect(getMetadataTypeActions('object')).toEqual([]);
+    });
+  });
+
+  describe('registerMetadataTypeActions (runtime registry)', () => {
+    it('registers actions for a custom type', () => {
+      registerMetadataTypeActions('my_custom_type', [action('do_thing')]);
+      expect(getMetadataTypeActions('my_custom_type').map((a) => a.name)).toEqual(['do_thing']);
+    });
+
+    it('merges plugin actions on top of declarative ones, declarative first', () => {
+      registerMetadataTypeActions('datasource', [action('rotate_secret')]);
+      const names = getMetadataTypeActions('datasource').map((a) => a.name);
+      expect(names).toContain('test_connection');
+      expect(names).toContain('rotate_secret');
+      expect(names.indexOf('test_connection')).toBeLessThan(names.indexOf('rotate_secret'));
+    });
+
+    it('dedupes by name — a later registration overrides the earlier', () => {
+      registerMetadataTypeActions('dedupe_type', [action('a', { label: 'first' })]);
+      registerMetadataTypeActions('dedupe_type', [action('a', { label: 'second' })]);
+      const actions = getMetadataTypeActions('dedupe_type');
+      expect(actions).toHaveLength(1);
+      expect(actions[0].label).toBe('second');
+    });
+  });
+});

--- a/packages/spec/src/kernel/metadata-type-schemas.ts
+++ b/packages/spec/src/kernel/metadata-type-schemas.ts
@@ -38,6 +38,7 @@ import { PageSchema } from '../ui/page.zod';
 import { DashboardSchema } from '../ui/dashboard.zod';
 import { AppSchema } from '../ui/app.zod';
 import { ActionSchema } from '../ui/action.zod';
+import type { Action } from '../ui/action.zod';
 import { ReportSchema } from '../ui/report.zod';
 
 import { FlowSchema } from '../automation/flow.zod';
@@ -56,6 +57,7 @@ import { ToolSchema } from '../ai/tool.zod';
 import { SkillSchema } from '../ai/skill.zod';
 
 import type { MetadataType } from './metadata-plugin.zod';
+import { DEFAULT_METADATA_TYPE_REGISTRY } from './metadata-plugin.zod';
 
 /**
  * Built-in mapping from metadata type identifier → its canonical Zod
@@ -133,4 +135,57 @@ export function listMetadataTypeSchemaTypes(): string[] {
   const types = new Set<string>(Object.keys(BUILTIN_METADATA_TYPE_SCHEMAS));
   for (const t of EXTRA_METADATA_TYPE_SCHEMAS.keys()) types.add(t);
   return Array.from(types).sort();
+}
+
+// ==========================================
+// Metadata Type Actions (type-level buttons)
+// ==========================================
+
+/**
+ * Runtime-extensible overlay of plugin-contributed **type-level** actions,
+ * keyed by metadata type. Mirrors `EXTRA_METADATA_TYPE_SCHEMAS` above.
+ *
+ * The merged view (built-in declarative actions from
+ * `DEFAULT_METADATA_TYPE_REGISTRY` + these registered ones) is what the
+ * `/api/v1/meta/types/:type` endpoint emits, so the Studio metadata-admin
+ * engine renders one button mechanism — the same `ActionSchema` business
+ * objects already use — for every metadata type.
+ */
+const EXTRA_METADATA_TYPE_ACTIONS = new Map<string, Action[]>();
+
+/**
+ * Register (or extend) the type-level actions for a metadata type.
+ *
+ * Plugins call this from `onInstall` to layer actions onto any type —
+ * built-in or custom — without forking the registry. Actions merge by
+ * `name`: a later registration with the same `name` replaces the earlier
+ * one; new names append. Idempotent for identical input.
+ *
+ * Declarative actions baked into `DEFAULT_METADATA_TYPE_REGISTRY` are the
+ * base layer; registered actions are merged on top by `getMetadataTypeActions`.
+ */
+export function registerMetadataTypeActions(type: string, actions: Action[]): void {
+  const byName = new Map<string, Action>();
+  for (const a of EXTRA_METADATA_TYPE_ACTIONS.get(type) ?? []) byName.set(a.name, a);
+  for (const a of actions) byName.set(a.name, a);
+  EXTRA_METADATA_TYPE_ACTIONS.set(type, Array.from(byName.values()));
+}
+
+/**
+ * Resolve the full, merged list of type-level actions for a metadata type.
+ *
+ * Order: declarative actions from the registry entry first, then
+ * plugin-registered actions (which override by `name`). Returns `[]` for a
+ * type with no actions. This is the single accessor the metadata API layer
+ * should call when emitting `MetadataTypeInfo.actions`.
+ */
+export function getMetadataTypeActions(type: string): Action[] {
+  const declarative =
+    (DEFAULT_METADATA_TYPE_REGISTRY.find((e) => e.type === type)?.actions as Action[] | undefined) ?? [];
+  const registered = EXTRA_METADATA_TYPE_ACTIONS.get(type) ?? [];
+  if (declarative.length === 0 && registered.length === 0) return [];
+  const byName = new Map<string, Action>();
+  for (const a of declarative) byName.set(a.name, a);
+  for (const a of registered) byName.set(a.name, a);
+  return Array.from(byName.values());
 }


### PR DESCRIPTION
## What

Give metadata **types** the same action mechanism business objects already have, so the Studio metadata-admin engine can render per-type buttons — the canonical example being a `datasource` **Test connection** button. Reuses the existing `ActionSchema` verbatim; no third button concept is introduced.

## Design (声明式 + 运行注册表)

| Layer | Where | What |
|---|---|---|
| **Declarative (per type)** | `MetadataTypeRegistryEntryBaseSchema` | `actions?: ActionSchema[]` on the registry entry; built-in types declare directly in `DEFAULT_METADATA_TYPE_REGISTRY`. |
| **First action** | `datasource` entry | `test_connection` (`type:'api'`, `POST /api/v1/datasources/${ctx.recordId}/test`). |
| **Runtime registry (plugins)** | `metadata-type-schemas.ts` | `registerMetadataTypeActions()` / `getMetadataTypeActions()`, mirroring `registerMetadataTypeSchema()`. Merges declarative + registered, deduped by `name` (registered wins). |
| **Emission** | `MetadataManager.getTypeInfo()` | merges the live registry entry's `actions` + the runtime overlay onto `MetadataTypeInfo.actions`, so `/api/v1/meta/types/:type` carries the buttons. |

The `test_connection` route lives in the host's datasource-admin backend (private package). When that backend is absent the button is still emitted; the call degrades to "unavailable" rather than 404-ing.

## Files (7)

- `packages/spec/src/kernel/metadata-plugin.zod.ts` — `actions` field + datasource action
- `packages/spec/src/kernel/metadata-type-schemas.ts` — runtime registry
- `packages/spec/src/contracts/metadata-service.ts` — `MetadataTypeInfo.actions`
- `packages/spec/src/api/metadata.zod.ts` — response schema
- `packages/metadata/src/metadata-manager.ts` — `getTypeInfo()` merge + emit
- `packages/spec/src/kernel/metadata-type-actions.test.ts` (new, 6 tests)
- `packages/metadata/src/metadata-service.test.ts` — getTypeInfo emission (2 tests)

## Tests

- spec: **6604 passed**; metadata: **240 passed**
- spec / metadata / objectql / rest build clean (incl. dts)

## Not in this PR

Frontend rendering of `MetadataTypeInfo.actions` in the metadata-admin engine lives in the separate `objectui` repo (follow-up).