### PR TITLE
feat(messaging): notify baseline node + lean service-messaging vertical slice (ADR-0012)

### DIFF
--- a/examples/app-showcase/src/flows/index.ts
+++ b/examples/app-showcase/src/flows/index.ts
@@ -90,6 +90,56 @@ export const ReassignWizardFlow = defineFlow({
 });
 
 /**
+ * Task Assigned → Notify Assignee — the worked `notify` example (ADR-0012).
+ *
+ * Where {@link TaskCompletedFlow} hand-waves notification through a `script`
+ * node, this flow uses the baseline `notify` node: it hands a topic +
+ * recipient + message to the messaging service, which fans out to the user's
+ * channels (inbox by default). The `notify` node ships in every automation
+ * engine; delivery is backed by `@objectstack/service-messaging`
+ * (`MessagingServicePlugin`). Without that plugin the node degrades to a
+ * logged no-op instead of failing the flow — install it and this flow starts
+ * landing inbox rows with no edit.
+ */
+export const TaskAssignedNotifyFlow = defineFlow({
+  name: 'showcase_task_assigned_notify',
+  label: 'Notify Assignee on Task Assignment',
+  description: 'Notifies the new assignee (inbox channel) when a task is reassigned.',
+  type: 'autolaunched',
+  nodes: [
+    {
+      id: 'start',
+      type: 'start',
+      label: 'On Task Assignee Change',
+      config: {
+        objectName: 'showcase_task',
+        triggerType: 'record-after-update',
+        condition: 'assignee != previous.assignee',
+      },
+    },
+    {
+      id: 'notify_assignee',
+      type: 'notify',
+      label: 'Notify Assignee',
+      config: {
+        topic: 'task.assigned',
+        recipients: ['{record.assignee}'],
+        channels: ['inbox'],
+        severity: 'info',
+        title: 'New task assigned: {record.title}',
+        message: 'You have been assigned "{record.title}".',
+        actionUrl: '/showcase_task/{record.id}',
+      },
+    },
+    { id: 'end', type: 'end', label: 'End' },
+  ],
+  edges: [
+    { id: 'e1', source: 'start', target: 'notify_assignee' },
+    { id: 'e2', source: 'notify_assignee', target: 'end' },
+  ],
+});
+
+/**
  * Project Budget Approval — ADR-0019 approval-as-flow-node.
  *
  * What used to be a standalone two-step approval *process* is now an ordinary
@@ -213,4 +263,5 @@ export const allFlows = [
   ReassignWizardFlow,
   BudgetApprovalFlow,
   TaskCompletedSlackFlow,
+  TaskAssignedNotifyFlow,
 ];

--- a/packages/services/service-automation/src/builtin/index.ts
+++ b/packages/services/service-automation/src/builtin/index.ts
@@ -15,6 +15,7 @@
  *  - human   — screen / script                   (core flow capability)
  *  - io      — http_request                       (foundational outbound I/O)
  *  - io      — connector_action                   (generic integration dispatch)
+ *  - io      — notify                              (outbound notification via messaging service)
  *
  * `connector_action` is the *generic dispatch* counterpart to `http_request`
  * (ADR-0018 §Addendum): the platform ships the node + an (initially empty)
@@ -31,12 +32,14 @@ import { registerCrudNodes } from './crud-nodes.js';
 import { registerScreenNodes } from './screen-nodes.js';
 import { registerHttpNodes } from './http-nodes.js';
 import { registerConnectorNodes } from './connector-nodes.js';
+import { registerNotifyNode } from './notify-node.js';
 
 export { registerLogicNodes } from './logic-nodes.js';
 export { registerCrudNodes } from './crud-nodes.js';
 export { registerScreenNodes } from './screen-nodes.js';
 export { registerHttpNodes } from './http-nodes.js';
 export { registerConnectorNodes } from './connector-nodes.js';
+export { registerNotifyNode } from './notify-node.js';
 
 /**
  * Seed every built-in node executor into the engine. Called by
@@ -49,6 +52,7 @@ export function installBuiltinNodes(engine: AutomationEngine, ctx: PluginContext
     registerScreenNodes(engine, ctx);
     registerHttpNodes(engine, ctx);
     registerConnectorNodes(engine, ctx);
+    registerNotifyNode(engine, ctx);
 
     const types = engine.getRegisteredNodeTypes();
     ctx.logger.info(

--- a/packages/services/service-automation/src/builtin/notify-node.test.ts
+++ b/packages/services/service-automation/src/builtin/notify-node.test.ts
@@ -1,0 +1,156 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AutomationEngine } from '../engine.js';
+import { registerNotifyNode } from './notify-node.js';
+import type { MessagingServiceSurface } from './notify-node.js';
+
+function createTestLogger() {
+    return {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+        child: () => createTestLogger(),
+    } as any;
+}
+
+/**
+ * A PluginContext stub whose `messaging` service can be toggled on/off, so we
+ * exercise both the wired path and the degrade-when-absent path.
+ */
+function createCtx(messaging?: MessagingServiceSurface) {
+    return {
+        logger: createTestLogger(),
+        getService(name: string) {
+            if (name === 'messaging') return messaging;
+            return undefined;
+        },
+    } as any;
+}
+
+/** A fake messaging service capturing emitted notifications. */
+function fakeMessaging() {
+    const emitted: any[] = [];
+    const service: MessagingServiceSurface = {
+        async emit(n) {
+            emitted.push(n);
+            return { delivered: n.recipients.length, failed: 0 };
+        },
+    };
+    return { service, emitted };
+}
+
+function notifyFlow(config: Record<string, unknown>) {
+    return {
+        name: 'notify_flow',
+        label: 'Notify Flow',
+        type: 'autolaunched' as const,
+        variables: [
+            { name: 'dealName', type: 'text' as const, isInput: true },
+            { name: 'dealId', type: 'text' as const, isInput: true },
+            { name: 'notify.delivered', type: 'number' as const, isOutput: true },
+        ],
+        nodes: [
+            { id: 'start', type: 'start' as const, label: 'Start' },
+            { id: 'notify', type: 'notify' as const, label: 'Notify', config },
+            { id: 'end', type: 'end' as const, label: 'End' },
+        ],
+        edges: [
+            { id: 'e1', source: 'start', target: 'notify' },
+            { id: 'e2', source: 'notify', target: 'end' },
+        ],
+    };
+}
+
+describe('notify (baseline node)', () => {
+    it('publishes a builtin io descriptor in the action registry', () => {
+        const engine = new AutomationEngine(createTestLogger());
+        registerNotifyNode(engine, createCtx());
+        expect(engine.getRegisteredNodeTypes()).toContain('notify');
+        const descriptor = engine.getActionDescriptor('notify');
+        expect(descriptor?.source).toBe('builtin');
+        expect(descriptor?.category).toBe('io');
+        expect(descriptor?.paradigms).toEqual(
+            expect.arrayContaining(['flow', 'workflow_rule', 'approval']),
+        );
+    });
+
+    describe('with a messaging service registered', () => {
+        let engine: AutomationEngine;
+        let messaging: ReturnType<typeof fakeMessaging>;
+
+        beforeEach(() => {
+            messaging = fakeMessaging();
+            engine = new AutomationEngine(createTestLogger());
+            registerNotifyNode(engine, createCtx(messaging.service));
+        });
+
+        it('emits a notification, interpolating recipients/title/body, and reports delivered count', async () => {
+            engine.registerFlow('notify_flow', notifyFlow({
+                topic: 'deal.won',
+                recipients: ['user_1', 'user_2'],
+                title: 'Deal {dealName} closed',
+                message: 'Congrats on {dealName}',
+                channels: ['inbox', 'email'],
+                severity: 'info',
+                actionUrl: '/opps/{dealId}',
+            }));
+
+            const result = await engine.execute('notify_flow', {
+                params: { dealName: 'Acme', dealId: '42' },
+            } as any);
+
+            expect(result.success).toBe(true);
+            expect(messaging.emitted).toHaveLength(1);
+            expect(messaging.emitted[0]).toMatchObject({
+                topic: 'deal.won',
+                title: 'Deal Acme closed',
+                body: 'Congrats on Acme',
+                recipients: ['user_1', 'user_2'],
+                channels: ['inbox', 'email'],
+                severity: 'info',
+                actionUrl: '/opps/42',
+            });
+            expect(result.output).toMatchObject({ 'notify.delivered': 2 });
+        });
+
+        it('accepts a single recipient string and the subject/to aliases', async () => {
+            engine.registerFlow('notify_flow', notifyFlow({
+                to: 'user_9',
+                subject: 'Heads up',
+            }));
+            const result = await engine.execute('notify_flow');
+            expect(result.success).toBe(true);
+            expect(messaging.emitted[0]).toMatchObject({ title: 'Heads up', recipients: ['user_9'] });
+        });
+
+        it('fails the step when title is missing', async () => {
+            engine.registerFlow('notify_flow', notifyFlow({ recipients: ['user_1'] }));
+            const result = await engine.execute('notify_flow');
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('title');
+        });
+
+        it('fails the step when no recipient is given', async () => {
+            engine.registerFlow('notify_flow', notifyFlow({ title: 'Hi' }));
+            const result = await engine.execute('notify_flow');
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('recipient');
+        });
+    });
+
+    describe('without a messaging service', () => {
+        it('degrades to a no-op success (skipped) rather than failing the flow', async () => {
+            const engine = new AutomationEngine(createTestLogger());
+            registerNotifyNode(engine, createCtx(undefined));
+            engine.registerFlow('notify_flow', notifyFlow({
+                recipients: ['user_1'],
+                title: 'Hi',
+            }));
+
+            const result = await engine.execute('notify_flow');
+            expect(result.success).toBe(true);
+        });
+    });
+});

--- a/packages/services/service-automation/src/builtin/notify-node.ts
+++ b/packages/services/service-automation/src/builtin/notify-node.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { PluginContext } from '@objectstack/core';
+import { defineActionDescriptor } from '@objectstack/spec/automation';
+import type { AutomationEngine } from '../engine.js';
+import { interpolate } from './template.js';
+
+/**
+ * Structural view of `@objectstack/service-messaging`'s service (ADR-0012),
+ * declared locally so service-automation does not take a runtime dependency on
+ * it — mirrors the `ConnectorRegistrySurface` pattern. The `notify` node
+ * resolves whatever object is registered under the `messaging` service and
+ * dispatches through this shape; if no such service is present the node
+ * degrades to a no-op success.
+ */
+export interface MessagingServiceSurface {
+    emit(notification: {
+        topic?: string;
+        title: string;
+        body: string;
+        severity?: string;
+        recipients: string[];
+        channels?: string[];
+        actionUrl?: string;
+        payload?: Record<string, unknown>;
+    }): Promise<{ delivered: number; failed: number }>;
+}
+
+/** Coerce a config value (string | string[]) into a clean string[]. */
+function toStringList(value: unknown): string[] {
+    if (Array.isArray(value)) return value.map((v) => String(v)).filter(Boolean);
+    if (typeof value === 'string' && value.trim()) return [value.trim()];
+    return [];
+}
+
+/**
+ * `notify` built-in node (ADR-0012) — outbound notification.
+ *
+ * Baseline node and the human-notification counterpart to `http_request`
+ * ("raw call") and `connector_action` ("call a registered integration"):
+ * `notify` hands a topic + recipients + message to the platform's messaging
+ * service, which fans it out across the user's channels (inbox by default).
+ *
+ * Like the CRUD nodes degrade without a data engine, `notify` degrades to a
+ * warning + success when no `messaging` service is registered — the capability
+ * simply isn't installed in that stack. Install `MessagingServicePlugin`
+ * (`@objectstack/service-messaging`) and the same flow starts delivering, with
+ * no flow edit. This is the seam that fixes the "notify drops on the floor"
+ * gap (#1292) once messaging is present.
+ */
+export function registerNotifyNode(engine: AutomationEngine, ctx: PluginContext): void {
+    const getMessaging = (): MessagingServiceSurface | undefined => {
+        try {
+            return ctx.getService<MessagingServiceSurface>('messaging');
+        } catch {
+            return undefined;
+        }
+    };
+
+    engine.registerNodeExecutor({
+        type: 'notify',
+        descriptor: defineActionDescriptor({
+            type: 'notify', version: '1.0.0', name: 'Notify',
+            description: 'Send an outbound notification to users via the messaging service (inbox / email / push / …).',
+            icon: 'bell', category: 'io', source: 'builtin',
+            supportsRetry: true,
+            paradigms: ['flow', 'workflow_rule', 'approval'],
+        }),
+        async execute(node, variables, context) {
+            const cfg = (node.config ?? {}) as Record<string, unknown>;
+
+            const recipients = toStringList(interpolate(cfg.recipients ?? cfg.to ?? [], variables, context));
+            const title = String(interpolate(cfg.title ?? cfg.subject ?? '', variables, context) ?? '');
+            const body = String(interpolate(cfg.message ?? cfg.body ?? '', variables, context) ?? '');
+            const channels = toStringList(cfg.channels);
+            const topic = cfg.topic ? String(cfg.topic) : undefined;
+            const severity = cfg.severity ? String(cfg.severity) : undefined;
+            const actionUrl = cfg.actionUrl
+                ? String(interpolate(cfg.actionUrl, variables, context) ?? '')
+                : undefined;
+            const payload = cfg.payload
+                ? (interpolate(cfg.payload, variables, context) as Record<string, unknown>)
+                : undefined;
+
+            if (!title) return { success: false, error: 'notify: title (or subject) is required' };
+            if (recipients.length === 0) {
+                return { success: false, error: 'notify: at least one recipient is required' };
+            }
+
+            const messaging = getMessaging();
+            if (!messaging) {
+                ctx.logger.warn(
+                    `[notify] no messaging service registered; notification "${title}" not delivered`,
+                );
+                return {
+                    success: true,
+                    output: { delivered: 0, failed: 0, skipped: true },
+                };
+            }
+
+            try {
+                const result = await messaging.emit({
+                    topic,
+                    title,
+                    body,
+                    severity,
+                    recipients,
+                    channels: channels.length ? channels : undefined,
+                    actionUrl,
+                    payload,
+                });
+                return {
+                    success: true,
+                    output: { delivered: result.delivered, failed: result.failed },
+                };
+            } catch (err) {
+                return { success: false, error: `notify failed: ${(err as Error).message}` };
+            }
+        },
+    });
+
+    ctx.logger.info('[Notify] 1 built-in node executor registered (notify)');
+}

--- a/packages/services/service-messaging/package.json
+++ b/packages/services/service-messaging/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@objectstack/service-messaging",
+  "version": "7.3.0",
+  "license": "Apache-2.0",
+  "description": "Messaging Service for ObjectStack — outbound notification dispatch (ADR-0012). Ships the MessagingChannel registry, emit() fan-out, and the always-on inbox channel; other channels (email/webhook/push/IM) plug in.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup --config ../../../tsup.config.ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@objectstack/core": "workspace:*",
+    "@objectstack/spec": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
+  },
+  "keywords": [
+    "objectstack",
+    "service",
+    "messaging",
+    "notification",
+    "inbox"
+  ],
+  "author": "ObjectStack",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/objectstack-ai/framework.git",
+    "directory": "packages/services/service-messaging"
+  },
+  "homepage": "https://objectstack.ai/docs",
+  "bugs": "https://github.com/objectstack-ai/framework/issues",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/services/service-messaging/src/channel.ts
+++ b/packages/services/service-messaging/src/channel.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The `MessagingChannel` seam (ADR-0012).
+ *
+ * A channel does the I/O for one transport — write an inbox row, POST a
+ * webhook, send an email, push to APNs/FCM. Everything *around* the I/O
+ * (recipient resolution, preference checks, fan-out, and — in later
+ * milestones — outbox/retry/cluster-lock) is owned by the messaging service,
+ * not the channel. This is the M1-minimal shape of the full interface in
+ * ADR-0012 §2: the optional `inbound`/`sessions` blocks (ADR-0013) and the
+ * richer `capabilities`/`resolveAddresses` surface are deferred.
+ *
+ * Per ADR-0022, a concrete channel's transport (provider auth, base URL,
+ * rate-limit handling) should sit on top of a `Connector`; the channel adds
+ * only the messaging semantics. The always-on `inbox` channel has no external
+ * transport — it writes a row in our own DB — so it needs no connector.
+ */
+
+/** A platform → user notification, before fan-out to channels. */
+export interface Notification {
+    /** Topic id, e.g. `contract.approval_requested`. Optional in M1-minimal. */
+    readonly topic?: string;
+    /** Short headline shown in the inbox / email subject / push title. */
+    readonly title: string;
+    /** Body text (Markdown for inbox/email; plain for push). */
+    readonly body: string;
+    /** Severity hint for rendering / filtering. */
+    readonly severity?: 'info' | 'warning' | 'critical';
+    /**
+     * Recipients. M1-minimal resolves an explicit list of user ids only;
+     * `role:*` / `owner_of:*` resolver prefixes are reserved for a later
+     * milestone and currently pass through verbatim.
+     */
+    readonly recipients: string[];
+    /** Channels to fan out to. Defaults to `['inbox']` (always on). */
+    readonly channels?: string[];
+    /** Optional deep-link surfaced as the inbox row's call-to-action. */
+    readonly actionUrl?: string;
+    /** Arbitrary structured payload carried to renderers / webhook receivers. */
+    readonly payload?: Record<string, unknown>;
+}
+
+/** One channel × one recipient unit of work handed to a channel's `send()`. */
+export interface Delivery {
+    readonly notification: Notification;
+    /** The channel id this delivery targets (e.g. `inbox`). */
+    readonly channel: string;
+    /** The single recipient (user id / address) this delivery targets. */
+    readonly recipient: string;
+}
+
+/**
+ * Error classification (ADR-0012 §2). The dispatcher uses it to decide retry
+ * vs. dead-letter vs. recipient invalidation. M1-minimal has no outbox, so it
+ * is advisory only, but channels declare it so the seam is stable.
+ */
+export type ErrorClass =
+    | 'retryable'
+    | 'permanent'
+    | 'invalid_recipient'
+    | 'rate_limited'
+    | 'duplicate';
+
+/** Outcome of a single delivery attempt. */
+export interface SendResult {
+    /** Whether the attempt succeeded. */
+    readonly ok: boolean;
+    /** Provider/row id for the delivered artifact, when available. */
+    readonly externalId?: string;
+    /** Failure detail when `ok` is false. */
+    readonly error?: string;
+}
+
+/** Minimal context handed to a channel — just a logger in M1. */
+export interface MessagingChannelContext {
+    readonly logger: {
+        info(...args: unknown[]): void;
+        warn(...args: unknown[]): void;
+        error(...args: unknown[]): void;
+    };
+}
+
+/** The seam a channel implements. See file header for the division of labour. */
+export interface MessagingChannel {
+    /** Stable id: `inbox` | `email` | `webhook` | `push` | `slack` | … */
+    readonly id: string;
+
+    /**
+     * Perform a single delivery attempt. The service has already fanned out per
+     * recipient; the channel only does the I/O and reports the outcome.
+     */
+    send(ctx: MessagingChannelContext, delivery: Delivery): Promise<SendResult>;
+
+    /** Optional: classify a thrown error for the (future) outbox. */
+    classifyError?(err: unknown): ErrorClass;
+}

--- a/packages/services/service-messaging/src/inbox-channel.test.ts
+++ b/packages/services/service-messaging/src/inbox-channel.test.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { createInboxChannel, INBOX_OBJECT } from './inbox-channel.js';
+import type { Delivery } from './channel.js';
+
+function silentCtx() {
+    return { logger: { info: () => {}, warn: () => {}, error: () => {} } };
+}
+
+function delivery(overrides: Partial<Delivery['notification']> = {}, recipient = 'user_1'): Delivery {
+    return {
+        channel: 'inbox',
+        recipient,
+        notification: {
+            topic: 'deal.won',
+            title: 'Deal closed',
+            body: 'Acme signed 🎉',
+            severity: 'info',
+            actionUrl: '/opportunities/42',
+            recipients: [recipient],
+            ...overrides,
+        },
+    };
+}
+
+/** A fake data engine capturing inserts. */
+function fakeData(insertImpl?: (obj: string, row: any) => any) {
+    const inserts: Array<{ object: string; row: any }> = [];
+    return {
+        inserts,
+        engine: {
+            async insert(object: string, row: any) {
+                inserts.push({ object, row });
+                return insertImpl ? insertImpl(object, row) : { id: 'inbox_1', ...row };
+            },
+            async find() { return []; },
+            async findOne() { return null; },
+            async update() { return {}; },
+            async delete() { return {}; },
+        } as any,
+    };
+}
+
+describe('inbox channel', () => {
+    it('has the stable id "inbox"', () => {
+        const ch = createInboxChannel({ getData: () => undefined });
+        expect(ch.id).toBe('inbox');
+    });
+
+    it('writes one sys_inbox_message row keyed by the recipient', async () => {
+        const data = fakeData();
+        const ch = createInboxChannel({ getData: () => data.engine, now: () => '2026-06-01T00:00:00.000Z' });
+
+        const result = await ch.send(silentCtx(), delivery({}, 'user_42'));
+
+        expect(result.ok).toBe(true);
+        expect(result.externalId).toBe('inbox_1');
+        expect(data.inserts).toHaveLength(1);
+        expect(data.inserts[0].object).toBe(INBOX_OBJECT);
+        expect(data.inserts[0].row).toEqual({
+            user_id: 'user_42',
+            topic: 'deal.won',
+            title: 'Deal closed',
+            body_md: 'Acme signed 🎉',
+            severity: 'info',
+            action_url: '/opportunities/42',
+            read: false,
+            created_at: '2026-06-01T00:00:00.000Z',
+        });
+    });
+
+    it('defaults severity to info when the notification omits it', async () => {
+        const data = fakeData();
+        const ch = createInboxChannel({ getData: () => data.engine });
+        await ch.send(silentCtx(), delivery({ severity: undefined }));
+        expect(data.inserts[0].row.severity).toBe('info');
+    });
+
+    it('honours an objectName override', async () => {
+        const data = fakeData();
+        const ch = createInboxChannel({ getData: () => data.engine, objectName: 'custom_inbox' });
+        await ch.send(silentCtx(), delivery());
+        expect(data.inserts[0].object).toBe('custom_inbox');
+    });
+
+    it('reports a no-op success (not a throw) when no data engine is registered', async () => {
+        const ch = createInboxChannel({ getData: () => undefined });
+        const result = await ch.send(silentCtx(), delivery());
+        expect(result.ok).toBe(true);
+        expect(result.externalId).toBeUndefined();
+    });
+
+    it('surfaces an insert failure as ok:false', async () => {
+        const ch = createInboxChannel({
+            getData: () => fakeData(() => { throw new Error('db down'); }).engine,
+        });
+        const result = await ch.send(silentCtx(), delivery());
+        expect(result.ok).toBe(false);
+        expect(result.error).toContain('db down');
+    });
+
+    it('classifies errors as retryable', () => {
+        const ch = createInboxChannel({ getData: () => undefined });
+        expect(ch.classifyError?.(new Error('x'))).toBe('retryable');
+    });
+});

--- a/packages/services/service-messaging/src/inbox-channel.ts
+++ b/packages/services/service-messaging/src/inbox-channel.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { IDataEngine } from '@objectstack/spec/contracts';
+import type {
+    Delivery,
+    ErrorClass,
+    MessagingChannel,
+    MessagingChannelContext,
+    SendResult,
+} from './channel.js';
+
+/** The object the inbox channel writes rows to. */
+export const INBOX_OBJECT = 'sys_inbox_message';
+
+export interface InboxChannelOptions {
+    /**
+     * Resolve the runtime data engine. Returns `undefined` when no data layer
+     * is registered (e.g. a minimal test stack) — the channel then warns and
+     * reports a no-op success rather than throwing, matching the platform's
+     * built-in CRUD-node degradation.
+     */
+    getData(): IDataEngine | undefined;
+    /** Object name override (default {@link INBOX_OBJECT}). */
+    objectName?: string;
+    /** Clock injection for deterministic tests. Defaults to `new Date()`. */
+    now?(): string;
+}
+
+/**
+ * The always-on `inbox` channel (ADR-0012 §4).
+ *
+ * Unlike email/webhook/push, inbox is direction-reversed: there is no outbound
+ * call — we write a `sys_inbox_message` row in our own DB and the user's client
+ * pulls it. So it needs no connector/transport. One delivery → one row keyed by
+ * the recipient user id.
+ */
+export function createInboxChannel(opts: InboxChannelOptions): MessagingChannel {
+    const objectName = opts.objectName ?? INBOX_OBJECT;
+    const now = opts.now ?? (() => new Date().toISOString());
+
+    return {
+        id: 'inbox',
+
+        async send(ctx: MessagingChannelContext, delivery: Delivery): Promise<SendResult> {
+            const data = opts.getData();
+            const n = delivery.notification;
+
+            if (!data) {
+                ctx.logger.warn(
+                    `[inbox] no data engine registered; inbox row for '${delivery.recipient}' not persisted`,
+                );
+                return { ok: true };
+            }
+
+            const row: Record<string, unknown> = {
+                user_id: delivery.recipient,
+                topic: n.topic,
+                title: n.title,
+                body_md: n.body,
+                severity: n.severity ?? 'info',
+                action_url: n.actionUrl,
+                read: false,
+                created_at: now(),
+            };
+
+            try {
+                const created = await data.insert(objectName, row);
+                const id = Array.isArray(created) ? created[0]?.id : created?.id ?? created;
+                return { ok: true, externalId: id != null ? String(id) : undefined };
+            } catch (err) {
+                return { ok: false, error: `inbox insert failed: ${(err as Error).message}` };
+            }
+        },
+
+        classifyError(_err: unknown): ErrorClass {
+            // A failed local insert is almost always transient (lock/timeout).
+            return 'retryable';
+        },
+    };
+}

--- a/packages/services/service-messaging/src/index.ts
+++ b/packages/services/service-messaging/src/index.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * @objectstack/service-messaging
+ *
+ * Outbound notification dispatch (ADR-0012, M1 minimal slice). Ships the
+ * `MessagingChannel` seam, the `MessagingService` registry + `emit()` fan-out,
+ * and the always-on `inbox` channel. The baseline `notify` flow node
+ * (service-automation) dispatches through `kernel.getService('messaging')`.
+ *
+ * Deferred to follow-up milestones: durable outbox / retry / cluster-lock /
+ * dead-letter, the topic catalog + per-user preference matrix, renderers, and
+ * the email / webhook / push / IM channels. The seam is shaped so those land
+ * without breaking callers.
+ */
+
+// Plugin
+export { MessagingServicePlugin } from './messaging-service-plugin.js';
+export type { MessagingServicePluginOptions } from './messaging-service-plugin.js';
+
+// Service + types
+export { MessagingService } from './messaging-service.js';
+export type { DeliveryOutcome, EmitResult } from './messaging-service.js';
+
+// Channel seam
+export { createInboxChannel, INBOX_OBJECT } from './inbox-channel.js';
+export type { InboxChannelOptions } from './inbox-channel.js';
+export type {
+    MessagingChannel,
+    MessagingChannelContext,
+    Notification,
+    Delivery,
+    SendResult,
+    ErrorClass,
+} from './channel.js';
+
+// Objects (metadata definitions)
+export { InboxMessage } from './objects/index.js';

--- a/packages/services/service-messaging/src/messaging-service-plugin.test.ts
+++ b/packages/services/service-messaging/src/messaging-service-plugin.test.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { MessagingServicePlugin } from './messaging-service-plugin.js';
+import type { MessagingService } from './messaging-service.js';
+
+/**
+ * A lightweight fake PluginContext — enough surface for the plugin's init():
+ * a logger, a service registry, and a `manifest` service that records objects.
+ * Avoids a full kernel bootstrap, mirroring the unit-test style used by the
+ * automation builtin-node tests.
+ */
+function fakeCtx() {
+    const services = new Map<string, unknown>();
+    const inserts: Array<{ object: string; row: any }> = [];
+    const registeredObjects: unknown[] = [];
+
+    services.set('manifest', {
+        register(m: { objects?: unknown[] }) {
+            registeredObjects.push(...(m.objects ?? []));
+        },
+    });
+    services.set('data', {
+        async insert(object: string, row: any) {
+            inserts.push({ object, row });
+            return { id: `row_${inserts.length}`, ...row };
+        },
+        async find() { return []; },
+        async findOne() { return null; },
+        async update() { return {}; },
+        async delete() { return {}; },
+    });
+
+    const ctx = {
+        logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {}, child: () => ctx.logger },
+        registerService(name: string, svc: unknown) {
+            services.set(name, svc);
+        },
+        getService<T>(name: string): T {
+            return services.get(name) as T;
+        },
+    } as any;
+
+    return { ctx, services, inserts, registeredObjects };
+}
+
+describe('MessagingServicePlugin', () => {
+    it('registers the messaging service with the always-on inbox channel', async () => {
+        const { ctx, services } = fakeCtx();
+        await new MessagingServicePlugin().init(ctx);
+
+        const messaging = services.get('messaging') as MessagingService;
+        expect(messaging).toBeDefined();
+        expect(messaging.getRegisteredChannels()).toEqual(['inbox']);
+    });
+
+    it('registers the sys_inbox_message object via the manifest service', async () => {
+        const { ctx, registeredObjects } = fakeCtx();
+        await new MessagingServicePlugin().init(ctx);
+
+        const names = registeredObjects.map((o: any) => o?.name);
+        expect(names).toContain('sys_inbox_message');
+    });
+
+    it('end-to-end: emit() through the registered service writes an inbox row', async () => {
+        const { ctx, services, inserts } = fakeCtx();
+        await new MessagingServicePlugin().init(ctx);
+
+        const messaging = services.get('messaging') as MessagingService;
+        const result = await messaging.emit({
+            topic: 'deal.won',
+            title: 'Deal closed',
+            body: 'Acme signed 🎉',
+            recipients: ['user_1'],
+        });
+
+        expect(result.delivered).toBe(1);
+        expect(inserts).toHaveLength(1);
+        expect(inserts[0].object).toBe('sys_inbox_message');
+        expect(inserts[0].row).toMatchObject({ user_id: 'user_1', title: 'Deal closed', read: false });
+    });
+
+    it('can be constructed without the inbox channel for an empty registry', async () => {
+        const { ctx, services } = fakeCtx();
+        await new MessagingServicePlugin({ registerInbox: false }).init(ctx);
+        const messaging = services.get('messaging') as MessagingService;
+        expect(messaging.getRegisteredChannels()).toEqual([]);
+    });
+});

--- a/packages/services/service-messaging/src/messaging-service-plugin.ts
+++ b/packages/services/service-messaging/src/messaging-service-plugin.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { Plugin, PluginContext } from '@objectstack/core';
+import type { IDataEngine } from '@objectstack/spec/contracts';
+import { MessagingService } from './messaging-service.js';
+import { createInboxChannel } from './inbox-channel.js';
+import { InboxMessage } from './objects/index.js';
+
+export interface MessagingServicePluginOptions {
+    /**
+     * Register the always-on `inbox` channel during init (default `true`).
+     * Set `false` only for tests that want an empty registry.
+     */
+    registerInbox?: boolean;
+}
+
+/**
+ * MessagingServicePlugin — registers the `messaging` service (ADR-0012 M1,
+ * minimal slice).
+ *
+ * After bootstrap, `kernel.getService('messaging')` is a {@link MessagingService}
+ * with the always-on `inbox` channel registered. The baseline `notify` flow
+ * node dispatches through it; flows therefore stop being no-ops once this
+ * plugin is installed. Other channels (email/webhook/push/IM) register
+ * themselves on this same service.
+ *
+ * @example
+ * ```ts
+ * const kernel = new ObjectKernel();
+ * kernel.use(new AutomationServicePlugin()); // ships the `notify` node
+ * kernel.use(new MessagingServicePlugin());  // backs it with delivery
+ * await kernel.bootstrap();
+ * ```
+ */
+export class MessagingServicePlugin implements Plugin {
+    name = 'com.objectstack.service.messaging';
+    version = '1.0.0';
+    type = 'standard' as const;
+    dependencies = ['com.objectstack.engine.objectql'];
+
+    private readonly options: MessagingServicePluginOptions;
+
+    constructor(options: MessagingServicePluginOptions = {}) {
+        this.options = { registerInbox: true, ...options };
+    }
+
+    async init(ctx: PluginContext): Promise<void> {
+        const service = new MessagingService({ logger: ctx.logger });
+
+        if (this.options.registerInbox) {
+            const getData = (): IDataEngine | undefined => {
+                try {
+                    return (
+                        ctx.getService<IDataEngine>('data') ??
+                        ctx.getService<IDataEngine>('objectql')
+                    );
+                } catch {
+                    return undefined;
+                }
+            };
+            service.registerChannel(createInboxChannel({ getData }));
+        }
+
+        ctx.registerService('messaging', service);
+
+        // Register the inbox object so `sys_inbox_message` rows can be written.
+        ctx.getService<{ register(m: unknown): void }>('manifest').register({
+            id: 'com.objectstack.service.messaging',
+            name: 'Messaging Service',
+            version: '1.0.0',
+            type: 'plugin',
+            scope: 'system',
+            objects: [InboxMessage],
+        });
+
+        ctx.logger.info(
+            `[messaging] service registered with channels: ${service.getRegisteredChannels().join(', ') || '(none)'}`,
+        );
+    }
+}

--- a/packages/services/service-messaging/src/messaging-service.test.ts
+++ b/packages/services/service-messaging/src/messaging-service.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MessagingService } from './messaging-service.js';
+import type { Delivery, MessagingChannel, SendResult } from './channel.js';
+
+function silentLogger() {
+    return { info: () => {}, warn: () => {}, error: () => {} };
+}
+
+/** A channel that records every delivery it is handed. */
+function recordingChannel(id: string, result: SendResult = { ok: true }): {
+    channel: MessagingChannel;
+    seen: Delivery[];
+} {
+    const seen: Delivery[] = [];
+    return {
+        seen,
+        channel: {
+            id,
+            async send(_ctx, delivery) {
+                seen.push(delivery);
+                return result;
+            },
+        },
+    };
+}
+
+describe('MessagingService', () => {
+    let service: MessagingService;
+
+    beforeEach(() => {
+        service = new MessagingService({ logger: silentLogger() });
+    });
+
+    describe('channel registry', () => {
+        it('registers, lists, and resolves channels', () => {
+            const { channel } = recordingChannel('inbox');
+            service.registerChannel(channel);
+            expect(service.getRegisteredChannels()).toEqual(['inbox']);
+            expect(service.getChannel('inbox')).toBe(channel);
+        });
+
+        it('replaces a channel registered under a duplicate id', () => {
+            const a = recordingChannel('inbox');
+            const b = recordingChannel('inbox');
+            service.registerChannel(a.channel);
+            service.registerChannel(b.channel);
+            expect(service.getRegisteredChannels()).toEqual(['inbox']);
+            expect(service.getChannel('inbox')).toBe(b.channel);
+        });
+
+        it('unregisters a channel', () => {
+            const { channel } = recordingChannel('inbox');
+            service.registerChannel(channel);
+            service.unregisterChannel('inbox');
+            expect(service.getRegisteredChannels()).toEqual([]);
+            expect(service.getChannel('inbox')).toBeUndefined();
+        });
+    });
+
+    describe('emit() fan-out', () => {
+        it('defaults to the inbox channel and one delivery per recipient', async () => {
+            const inbox = recordingChannel('inbox', { ok: true, externalId: 'row_1' });
+            service.registerChannel(inbox.channel);
+
+            const result = await service.emit({
+                title: 'Deal closed',
+                body: 'Acme signed 🎉',
+                recipients: ['user_1', 'user_2'],
+            });
+
+            expect(inbox.seen.map((d) => d.recipient)).toEqual(['user_1', 'user_2']);
+            expect(inbox.seen[0].channel).toBe('inbox');
+            expect(result.delivered).toBe(2);
+            expect(result.failed).toBe(0);
+            expect(result.deliveries[0]).toMatchObject({ channel: 'inbox', recipient: 'user_1', ok: true, externalId: 'row_1' });
+        });
+
+        it('fans out across every requested channel', async () => {
+            const inbox = recordingChannel('inbox');
+            const email = recordingChannel('email');
+            service.registerChannel(inbox.channel);
+            service.registerChannel(email.channel);
+
+            const result = await service.emit({
+                title: 'Hi',
+                body: 'there',
+                recipients: ['user_1'],
+                channels: ['inbox', 'email'],
+            });
+
+            expect(inbox.seen).toHaveLength(1);
+            expect(email.seen).toHaveLength(1);
+            expect(result.delivered).toBe(2);
+        });
+
+        it('reports a failed delivery per recipient when a channel is unregistered, without throwing', async () => {
+            const result = await service.emit({
+                title: 'Hi',
+                body: 'there',
+                recipients: ['user_1', 'user_2'],
+                channels: ['email'],
+            });
+            expect(result.delivered).toBe(0);
+            expect(result.failed).toBe(2);
+            expect(result.deliveries.every((d) => /not registered/.test(d.error ?? ''))).toBe(true);
+        });
+
+        it('isolates a throwing channel as a failed delivery', async () => {
+            service.registerChannel({
+                id: 'inbox',
+                async send() {
+                    throw new Error('boom');
+                },
+            });
+            const result = await service.emit({ title: 'x', body: 'y', recipients: ['user_1'] });
+            expect(result.failed).toBe(1);
+            expect(result.deliveries[0].error).toContain('boom');
+        });
+
+        it('surfaces a channel-reported failure (ok:false)', async () => {
+            service.registerChannel(recordingChannel('inbox', { ok: false, error: 'quota exceeded' }).channel);
+            const result = await service.emit({ title: 'x', body: 'y', recipients: ['user_1'] });
+            expect(result.failed).toBe(1);
+            expect(result.deliveries[0].error).toBe('quota exceeded');
+        });
+    });
+});

--- a/packages/services/service-messaging/src/messaging-service.ts
+++ b/packages/services/service-messaging/src/messaging-service.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type {
+    MessagingChannel,
+    MessagingChannelContext,
+    Notification,
+} from './channel.js';
+
+/** Per-delivery outcome record returned from {@link MessagingService.emit}. */
+export interface DeliveryOutcome {
+    readonly channel: string;
+    readonly recipient: string;
+    readonly ok: boolean;
+    readonly externalId?: string;
+    readonly error?: string;
+}
+
+/** Aggregate result of fanning one notification out to its channels. */
+export interface EmitResult {
+    readonly deliveries: DeliveryOutcome[];
+    readonly delivered: number;
+    readonly failed: number;
+}
+
+/**
+ * MessagingService — the M1-minimal outbound dispatcher (ADR-0012).
+ *
+ * Holds the `MessagingChannel` registry and implements `emit()`: it fans a
+ * notification out to `(channel × recipient)` deliveries and calls each
+ * channel's `send()`. The always-on `inbox` channel is registered by the
+ * plugin; other channels (email/webhook/push/IM) register themselves.
+ *
+ * Deliberately *not* in this milestone (see ADR-0012 §M1 vs the deferred
+ * scope): the durable outbox, retry schedule, cluster-lock, dead-letter, the
+ * topic catalog, the per-user preference matrix, renderers, and middleware.
+ * `emit()` is synchronous best-effort fan-out; failures are reported in the
+ * result rather than persisted for retry. The seam (`MessagingChannel`,
+ * `Notification`) is shaped so those land without breaking callers.
+ */
+export class MessagingService {
+    private readonly channels = new Map<string, MessagingChannel>();
+
+    constructor(private readonly ctx: MessagingChannelContext) {}
+
+    /** Register a channel implementation. A duplicate id warns and replaces. */
+    registerChannel(channel: MessagingChannel): void {
+        if (this.channels.has(channel.id)) {
+            this.ctx.logger.warn(`[messaging] channel '${channel.id}' already registered; replacing`);
+        }
+        this.channels.set(channel.id, channel);
+        this.ctx.logger.info(`[messaging] channel registered: ${channel.id}`);
+    }
+
+    /** Remove a channel. No-op when absent. */
+    unregisterChannel(id: string): void {
+        this.channels.delete(id);
+    }
+
+    /** Look up a channel by id. */
+    getChannel(id: string): MessagingChannel | undefined {
+        return this.channels.get(id);
+    }
+
+    /** All registered channel ids. */
+    getRegisteredChannels(): string[] {
+        return [...this.channels.keys()];
+    }
+
+    /**
+     * Fan a notification out to its channels and recipients. Each
+     * `(channel, recipient)` pair becomes one `send()` call. An unregistered
+     * channel, or a channel that throws, is reported as a failed delivery —
+     * it never aborts the rest of the fan-out.
+     */
+    async emit(notification: Notification): Promise<EmitResult> {
+        const channels = notification.channels?.length ? notification.channels : ['inbox'];
+        const recipients = notification.recipients ?? [];
+        const deliveries: DeliveryOutcome[] = [];
+
+        for (const channelId of channels) {
+            const channel = this.channels.get(channelId);
+            if (!channel) {
+                // Surface the gap per recipient so the caller sees who missed out.
+                for (const recipient of recipients) {
+                    deliveries.push({
+                        channel: channelId,
+                        recipient,
+                        ok: false,
+                        error: `channel '${channelId}' not registered`,
+                    });
+                }
+                this.ctx.logger.warn(`[messaging] emit: channel '${channelId}' not registered`);
+                continue;
+            }
+
+            for (const recipient of recipients) {
+                try {
+                    const result = await channel.send(this.ctx, {
+                        notification,
+                        channel: channelId,
+                        recipient,
+                    });
+                    deliveries.push({
+                        channel: channelId,
+                        recipient,
+                        ok: result.ok,
+                        externalId: result.externalId,
+                        error: result.error,
+                    });
+                } catch (err) {
+                    deliveries.push({
+                        channel: channelId,
+                        recipient,
+                        ok: false,
+                        error: (err as Error)?.message ?? String(err),
+                    });
+                }
+            }
+        }
+
+        const delivered = deliveries.filter((d) => d.ok).length;
+        return { deliveries, delivered, failed: deliveries.length - delivered };
+    }
+}

--- a/packages/services/service-messaging/src/objects/inbox-message.object.ts
+++ b/packages/services/service-messaging/src/objects/inbox-message.object.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { ObjectSchema, Field } from '@objectstack/spec/data';
+
+/**
+ * `sys_inbox_message` — user-facing in-app notification rows (ADR-0012 §4, §11).
+ *
+ * Written by the always-on `inbox` messaging channel, one row per
+ * `(notification, recipient)`. The client pulls these for the in-app inbox;
+ * `service-realtime` decides when to ping an online user. Belongs to
+ * `service-messaging` per the "protocol + service ownership" pattern.
+ */
+export const InboxMessage = ObjectSchema.create({
+    name: 'sys_inbox_message',
+    label: 'Inbox Message',
+    pluralLabel: 'Inbox Messages',
+    icon: 'inbox',
+    description: 'User-facing in-app notification rows written by the inbox messaging channel.',
+    titleFormat: '{title}',
+    compactLayout: ['title', 'user_id', 'severity', 'read', 'created_at'],
+
+    fields: {
+        id: Field.text({
+            label: 'Inbox Message ID',
+            required: true,
+            readonly: true,
+        }),
+
+        user_id: Field.text({
+            label: 'Recipient User',
+            required: true,
+            searchable: true,
+        }),
+
+        topic: Field.text({
+            label: 'Topic',
+            searchable: true,
+        }),
+
+        title: Field.text({
+            label: 'Title',
+            required: true,
+        }),
+
+        body_md: Field.markdown({
+            label: 'Body',
+        }),
+
+        severity: Field.select({
+            label: 'Severity',
+            options: [
+                { label: 'Info', value: 'info' },
+                { label: 'Warning', value: 'warning' },
+                { label: 'Critical', value: 'critical' },
+            ],
+        }),
+
+        action_url: Field.text({
+            label: 'Action URL',
+        }),
+
+        read: Field.boolean({
+            label: 'Read',
+        }),
+
+        created_at: Field.datetime({
+            label: 'Created At',
+            readonly: true,
+        }),
+    },
+});

--- a/packages/services/service-messaging/src/objects/index.ts
+++ b/packages/services/service-messaging/src/objects/index.ts
@@ -1,0 +1,3 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+export { InboxMessage } from './inbox-message.object.js';

--- a/packages/services/service-messaging/tsconfig.json
+++ b/packages/services/service-messaging/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/spec/src/automation/flow.test.ts
+++ b/packages/spec/src/automation/flow.test.ts
@@ -17,7 +17,7 @@ describe('FlowNodeAction', () => {
     const actions = [
       'start', 'end', 'decision', 'assignment', 'loop',
       'create_record', 'update_record', 'delete_record', 'get_record',
-      'http_request', 'script', 'screen', 'wait', 'subflow', 'connector_action',
+      'http_request', 'notify', 'script', 'screen', 'wait', 'subflow', 'connector_action',
       'parallel_gateway', 'join_gateway', 'boundary_event',
     ];
     
@@ -120,7 +120,7 @@ describe('FlowNodeSchema', () => {
     const types = [
       'start', 'end', 'decision', 'assignment', 'loop',
       'create_record', 'update_record', 'delete_record', 'get_record',
-      'http_request', 'script', 'screen', 'wait', 'subflow', 'connector_action',
+      'http_request', 'notify', 'script', 'screen', 'wait', 'subflow', 'connector_action',
       'parallel_gateway', 'join_gateway', 'boundary_event',
     ] as const;
 

--- a/packages/spec/src/automation/flow.zod.ts
+++ b/packages/spec/src/automation/flow.zod.ts
@@ -30,6 +30,7 @@ export const FlowNodeAction = z.enum([
   'delete_record',      // CRUD: Delete
   'get_record',         // CRUD: Get/Query
   'http_request',       // Webhook/API Call
+  'notify',             // Outbound notification (ADR-0012) — dispatched via the messaging service
   'script',             // Custom Script (JS/TS)
   'screen',             // Screen / User-Input Element
   'wait',               // Delay/Sleep

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1820,6 +1820,25 @@ importers:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
+  packages/services/service-messaging:
+    dependencies:
+      '@objectstack/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@objectstack/spec':
+        specifier: workspace:*
+        version: link:../../spec
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
   packages/services/service-package:
     dependencies:
       '@objectstack/core':


### PR DESCRIPTION
## What

Turns the `notify` flow node into a real capability (it was a declared-but-unexecutable node type) backed by a **minimal, ADR-0012-aligned messaging vertical slice** — chosen over the full 13-table platform.

### Spec
- `flow.zod.ts`: add `notify` to the builtin flow-node action enum (+ test).

### `@objectstack/service-messaging` (new)
- **MessagingChannel seam** — `Notification`/`Delivery`/`SendResult` + `MessagingChannel` interface (`id`, `send`, optional `classifyError`).
- **MessagingService** — channel registry + `emit()`: defaults channels to `['inbox']`, fans out per *(channel × recipient)*, isolates a throwing / failing / unregistered channel into a failed delivery — **never throws**.
- **Always-on inbox channel** — writes `sys_inbox_message` rows via the data engine; degrades to a logged no-op when no data engine is present.
- `sys_inbox_message` object + `MessagingServicePlugin` (registers the `messaging` service, the inbox channel, and the object via the manifest).

### `service-automation`
- `notify-node.ts`: baseline `notify` **io** node. Interpolates recipients/title/body/channels/topic/severity/actionUrl/payload; resolves the `messaging` service through a **local structural surface** (no runtime dep on service-messaging, mirroring `ConnectorRegistrySurface`). Degrades to a logged success when messaging isn't installed; emits otherwise. Wired into `installBuiltinNodes`.

### Example
- `app-showcase`: `TaskAssignedNotifyFlow` — worked `notify` example (inbox channel). Install the plugin and the flow starts landing inbox rows with no edit.

## Deferred to follow-ups
Email/push/webhook channels, topic↔preference matrix, outbox/retry extraction.

## Tests
service-messaging **19**, service-automation **95**, spec + runtime green.