### PR TITLE
chore: default `pnpm dev` to the showcase app + add dev:showcase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,13 +20,12 @@ pnpm docs:dev         # docs site
 
 | Scenario | Command | Notes |
 |:---|:---|:---|
-| **Frontend debug** (UI in `../objectui` calls backend) | `PORT=3000 pnpm dev:crm` | Port **must** be 3000 (UI hard-wired); persistent state; leave running |
-| **Frontend debug (showcase)** | `PORT=3000 pnpm dev` | `pnpm dev` = the **showcase** example; same port-3000 rule. Use this (not `dev:crm`) when debugging showcase UI/automation |
-| **Backend-only debug** | `pnpm dev:crm -- --fresh -p <random>` | Random high port; ephemeral tempdir; **you must kill it** when done |
+| **Frontend debug** (UI in `../objectui` calls backend) | `PORT=3000 pnpm dev` | `pnpm dev` = the **showcase** kitchen-sink app (default; best for exercising the platform). Port **must** be 3000 (UI hard-wired); persistent state; leave running. For the minimal CRM app instead: `PORT=3000 pnpm dev:crm`. |
+| **Backend-only debug** | `pnpm dev -- --fresh -p <random>` | Random high port; ephemeral tempdir; **you must kill it** when done |
 
 `--fresh`: ephemeral tempdir (auto-deleted on exit) + `--seed-admin` (POSTs sign-up, prints creds — default `admin@objectos.ai` / `admin123`, override via `--admin-email`/`--admin-password`). The seeded admin is auto-promoted to **platform admin** (the system seed identity `usr_system` is skipped), so Setup/Studio are reachable on first login.
 
-Rules: never run two backends on port 3000; for backend tasks pick a random port and tear it down; always use `pnpm dev:crm` (flags after `--` are forwarded), not raw `pnpm --filter`.
+Rules: never run two backends on port 3000; for backend tasks pick a random port and tear it down; always use a `pnpm dev`/`dev:crm`/`dev:showcase` script (flags after `--` are forwarded), not raw `pnpm --filter`.
 
 ```bash
 pnpm dev:crm -- --fresh -p 38421   # start; debug via curl

--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ pnpm docs:dev
 | Script | Description |
 | :--- | :--- |
 | `pnpm build` | Build all packages (excludes docs) |
-| `pnpm dev` | Run the minimal CRM example (`@objectstack/example-crm`) — REST + Studio |
+| `pnpm dev` | Run the showcase kitchen-sink example (`@objectstack/example-showcase`) — REST + Studio; exercises every metadata type, view, automation, AI & security chain |
+| `pnpm dev:showcase` | Same as `pnpm dev` (explicit alias) |
+| `pnpm dev:crm` | Run the minimal CRM example (`@objectstack/example-crm`) |
 | `pnpm dev:todo` | Run the Todo example (`@example/app-todo`) |
 | `pnpm studio:start` | Start the prebuilt Studio IDE |
 | `pnpm test` | Run all tests (Turborepo) |

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "ObjectStack Protocol & Specification - Monorepo for TypeScript Interfaces, JSON Schemas, and Convention Configurations",
   "scripts": {
     "build": "turbo run build --filter=!@objectstack/docs",
-    "dev": "pnpm --filter @objectstack/example-crm dev",
+    "dev": "pnpm --filter @objectstack/example-showcase dev",
+    "dev:showcase": "pnpm --filter @objectstack/example-showcase dev",
     "dev:crm": "pnpm --filter @objectstack/example-crm dev",
     "dev:todo": "pnpm --filter @example/app-todo dev",
     "test": "turbo run test",


### PR DESCRIPTION
Makes the **showcase** kitchen-sink example the default `pnpm dev` (it exercises every metadata type, view, chart, and the automation/AI/security chains — the best app to spin up to see/test the platform). CRM stays available explicitly.

- **package.json**: `dev` → showcase filter; add explicit `dev:showcase` (parallel to `dev:crm`/`dev:todo`); `dev:crm` retained.
- **README.md**: scripts table reflects the new default + adds `dev:showcase`/`dev:crm` rows.
- **AGENTS.md**: frontend-debug recipe leads with `PORT=3000 pnpm dev` (showcase), CRM as the alternative.

No CI depends on the bare `pnpm dev` default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)