### PR TITLE
feat(auth): source email brand name from branding.workspace_name setting

### DIFF
--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -1100,9 +1100,25 @@ export class AuthManager {
     return this.config.emailService;
   }
 
+  /**
+   * Override the brand name surfaced in built-in auth emails (`{{appName}}`),
+   * sourced from the live `branding.workspace_name` setting.
+   *
+   * AuthPlugin calls this on `kernel:ready` (and again whenever the setting
+   * changes) once the `settings` service resolves. Passing `undefined` clears
+   * the override so resolution falls back to the configured `appName`. The
+   * value only reflects an *explicitly set* setting — when the operator has
+   * not customised it, AuthPlugin passes `undefined` so a deployment's
+   * configured `appName` (e.g. `OS_APP_NAME`) keeps precedence.
+   */
+  setAppName(name: string | undefined): void {
+    this.appNameOverride = name?.trim() || undefined;
+  }
+  private appNameOverride?: string;
+
   /** @internal `{{appName}}` placeholder value for built-in templates. */
   private getAppName(): string {
-    return this.config.appName ?? 'ObjectStack';
+    return this.appNameOverride ?? this.config.appName ?? 'ObjectStack';
   }
 
   /**

--- a/packages/plugins/plugin-auth/src/auth-plugin.test.ts
+++ b/packages/plugins/plugin-auth/src/auth-plugin.test.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AuthPlugin } from './auth-plugin';
+import { AuthManager } from './auth-manager';
 import type { PluginContext } from '@objectstack/core';
 
 describe('AuthPlugin', () => {
@@ -381,6 +382,69 @@ describe('AuthPlugin', () => {
 
       await expect(uninitializedPlugin.start(mockContext)).rejects.toThrow(
         'Auth manager not initialized'
+      );
+    });
+  });
+
+  describe('Brand name binding (branding.workspace_name)', () => {
+    let hookCapture: ReturnType<typeof createHookCapture>;
+    let setAppNameSpy: ReturnType<typeof vi.spyOn>;
+
+    const makeSettings = (resolved: { value: unknown; source: string } | Error) => ({
+      get: vi.fn(async () => {
+        if (resolved instanceof Error) throw resolved;
+        return resolved;
+      }),
+      subscribe: vi.fn(),
+    });
+
+    const bootWithSettings = async (settings: unknown) => {
+      hookCapture = createHookCapture();
+      mockContext.hook = hookCapture.hookFn;
+      mockContext.getService = vi.fn((name: string) => {
+        if (name === 'manifest') return { register: vi.fn() };
+        if (name === 'settings') return settings;
+        // 'data', 'email', 'http-server' → absent in this harness
+        return undefined;
+      });
+      setAppNameSpy = vi.spyOn(AuthManager.prototype, 'setAppName');
+      authPlugin = new AuthPlugin({
+        secret: 'test-secret-at-least-32-chars-long',
+        baseUrl: 'http://localhost:3000',
+        appName: 'Configured Default',
+      });
+      await authPlugin.init(mockContext);
+      await authPlugin.start(mockContext);
+      await hookCapture.trigger('kernel:ready');
+    };
+
+    afterEach(() => {
+      setAppNameSpy?.mockRestore();
+    });
+
+    it('overrides appName when the setting is explicitly set', async () => {
+      const settings = makeSettings({ value: 'Acme Corp', source: 'global' });
+      await bootWithSettings(settings);
+
+      expect(settings.get).toHaveBeenCalledWith('branding', 'workspace_name', {});
+      expect(setAppNameSpy).toHaveBeenCalledWith('Acme Corp');
+      expect(settings.subscribe).toHaveBeenCalledWith('branding', expect.any(Function));
+    });
+
+    it('clears the override when the setting falls through to its manifest default', async () => {
+      const settings = makeSettings({ value: 'ObjectStack', source: 'default' });
+      await bootWithSettings(settings);
+
+      // source === 'default' means the operator never customised it, so the
+      // configured appName (e.g. OS_APP_NAME) must keep precedence.
+      expect(setAppNameSpy).toHaveBeenCalledWith(undefined);
+    });
+
+    it('does not throw when reading the setting fails', async () => {
+      const settings = makeSettings(new Error('boom'));
+      await expect(bootWithSettings(settings)).resolves.toBeUndefined();
+      expect(mockContext.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('failed to apply branding.workspace_name'),
       );
     });
   });

--- a/packages/plugins/plugin-auth/src/auth-plugin.ts
+++ b/packages/plugins/plugin-auth/src/auth-plugin.ts
@@ -201,6 +201,43 @@ export class AuthPlugin implements Plugin {
           } catch {
             ctx.logger.info('Auth: no email service registered — auth callbacks will log instead of sending');
           }
+
+          // Bind the email brand name (`{{appName}}`) to the live
+          // `branding.workspace_name` setting so the admin UI can rename the
+          // product without a redeploy. Only an *explicitly set* value
+          // overrides the configured `appName` — when the operator hasn't
+          // customised it (resolver returns the manifest default), we clear
+          // the override so the deployment's `appName` (e.g. `OS_APP_NAME`)
+          // keeps precedence. Mirrors EmailServicePlugin's settings binding.
+          try {
+            const settings = ctx.getService<any>('settings');
+            if (settings && typeof settings.get === 'function') {
+              const applyBrand = async () => {
+                try {
+                  const resolved = await settings.get('branding', 'workspace_name', {});
+                  const explicit = resolved && resolved.source !== 'default'
+                    ? resolved.value
+                    : undefined;
+                  this.authManager?.setAppName(
+                    typeof explicit === 'string' ? explicit : undefined,
+                  );
+                } catch (err: any) {
+                  ctx.logger.warn(
+                    'Auth: failed to apply branding.workspace_name: ' + (err?.message ?? err),
+                  );
+                }
+              };
+              await applyBrand();
+              if (typeof settings.subscribe === 'function') {
+                settings.subscribe('branding', () => {
+                  void applyBrand();
+                });
+                ctx.logger.info('Auth: bound appName to settings namespace=branding');
+              }
+            }
+          } catch {
+            // settings service is optional — keep the configured appName.
+          }
         }
 
         let httpServer: IHttpServer | null = null;


### PR DESCRIPTION
Refs #1447 — wires the existing (but unconsumed) `branding.workspace_name` setting into the auth email brand name.

## Problem

The Branding settings page already exposes a **Workspace name** field (`branding.workspace_name`), editable in the UI and persisted via the settings service — but **nothing consumes it**. Auth emails (`{{appName}}`) instead use a static `config.appName`, so renaming the product in the UI does nothing.

## Change

`AuthPlugin` now binds the email brand name to the live setting, mirroring `EmailServicePlugin`'s settings binding:

- On `kernel:ready` (right after the email service is wired), read `branding.workspace_name` and push it into `AuthManager.setAppName()`.
- Subscribe to the `branding` namespace so edits apply **without a redeploy**.
- **Backward-compatible precedence:** only an *explicitly set* value overrides. When the resolver returns the manifest **default** (`source === 'default'`), the override is cleared so the configured `appName` (e.g. a deployment's `OS_APP_NAME`) keeps precedence.

**Resolution order:** `branding.workspace_name` (when set) → `config.appName` → `'ObjectStack'`.

The settings service is treated as optional — if it's absent, behaviour is unchanged.

## Files

- `auth-manager.ts` — add `setAppName(name?)` + `appNameOverride`; `getAppName()` now resolves override → config → default.
- `auth-plugin.ts` — `kernel:ready` binding + `subscribe('branding', …)`, guarded by try/catch.
- `auth-plugin.test.ts` — 3 new tests: explicit value overrides; `default` source clears the override; read failure degrades gracefully. (21/21 pass.)

## Out of scope (remaining #1447 checklist)

These are separate layers and not touched here:
- [ ] `apps/account/index.html` `<title>` — Vite SPA; needs a client-side `document.title` update on boot.
- [ ] `packages/rest/src/rest-server.ts` `/docs` `<title>` — needs the settings service threaded into `RestServer`.
- [ ] Align conflicting defaults (`ObjectStack` vs `ObjectOS Account`).

## Note on tenant scope

`branding` is `scope: 'tenant'`, but the brand name is read globally here (no tenant ctx in email callbacks). For the single-brand control plane this is correct; per-tenant email branding would be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)