### PR TITLE
feat(showcase): complete the state_machine validation demonstration

### DIFF
--- a/examples/app-showcase/src/objects/account.object.ts
+++ b/examples/app-showcase/src/objects/account.object.ts
@@ -48,6 +48,8 @@ export const Account = ObjectSchema.create({
       label: 'Account Lifecycle',
       description: 'Accounts move prospect → active → churned, and can be reactivated.',
       field: 'status',
+      // Transitions are validated on update; insert sets the initial state.
+      events: ['update'] as const,
       message: 'Invalid account lifecycle transition.',
       transitions: {
         prospect: ['active', 'churned'],

--- a/examples/app-showcase/src/objects/project.object.ts
+++ b/examples/app-showcase/src/objects/project.object.ts
@@ -74,6 +74,9 @@ export const Project = ObjectSchema.create({
       label: 'Project Status Flow',
       description: 'Projects progress through valid status transitions.',
       field: 'status',
+      // State machines validate *transitions*, so they run on update only —
+      // an insert sets the initial state (constrained by the select options).
+      events: ['update'] as const,
       message: 'Invalid project status transition.',
       transitions: {
         planned: ['active', 'cancelled'],
@@ -81,6 +84,25 @@ export const Project = ObjectSchema.create({
         on_hold: ['active', 'cancelled'],
         completed: [],
         cancelled: ['planned'],
+      },
+    },
+    {
+      // Advisory (severity: 'warning') state machine — demonstrates a soft
+      // transition guard: health should escalate/de-escalate one step at a
+      // time (green↔yellow↔red). A jump (e.g. green→red) is *flagged* (logged
+      // server-side) but NOT blocked, unlike the error-severity status flow.
+      type: 'state_machine' as const,
+      name: 'project_health_progression',
+      label: 'Project Health Progression (advisory)',
+      description: 'Health should change one step at a time; skips are warned, not blocked.',
+      field: 'health',
+      events: ['update'] as const,
+      severity: 'warning' as const,
+      message: 'Health changed by more than one step — confirm this is intentional.',
+      transitions: {
+        green: ['yellow'],
+        yellow: ['green', 'red'],
+        red: ['yellow'],
       },
     },
   ],

--- a/examples/app-showcase/src/objects/task.object.ts
+++ b/examples/app-showcase/src/objects/task.object.ts
@@ -66,6 +66,8 @@ export const Task = ObjectSchema.create({
       label: 'Task Status Flow',
       description: 'Tasks move forward through the board (reopen allowed from Done).',
       field: 'status',
+      // Transitions are validated on update; insert sets the initial state.
+      events: ['update'] as const,
       message: 'Invalid task status transition.',
       transitions: {
         backlog: ['todo'],


### PR DESCRIPTION
## Summary
The showcase had 3 `state_machine` validations (task/project/account) covering transition **topologies** (linear+reopen, branching+terminal, re-entrant) but not the rule's other knobs. Rounds out the demonstration so the showcase exercises — and verifies — the full state_machine surface:

- **`events: ['update']`** on all three: state machines validate *transitions*, so they run on update only (an insert sets the initial state). Makes intent explicit.
- **New advisory `project_health_progression`** with **`severity: 'warning'`**: health should change one step at a time (green↔yellow↔red); a skip is *flagged* (logged) but **not blocked** — demonstrating soft guards alongside the error-severity (blocking) status flows.

## Verification (runtime enforcement is live)
- error-severity invalid transition (`task done→backlog`) → **HTTP 400 `invalid_transition`**
- warning-severity skip (`project health green→red`) → **HTTP 200** (flagged, not blocked)

## Note (separate finding)
`objectql/validation/rule-validator.ts` enforces only 3 of the spec's 9 rule types — `state_machine`, `script`, `cross_field` — exactly what the showcase covers. The other 6 (`unique`-rule, `format`, `json_schema`, `async`, `custom`, `conditional`) are declared but **not enforced** on the write path — same "advertise only what you can deliver" issue as the ChartType taxonomy; worth a follow-up (trim vs implement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)