### PR TITLE
fix(platform-objects): drop unenforceable sys_user email_unique validation (#1485 regression)

### DIFF
--- a/.changeset/fix-sys-user-unique-validation.md
+++ b/.changeset/fix-sys-user-unique-validation.md
@@ -1,0 +1,17 @@
+---
+'@objectstack/platform-objects': patch
+---
+
+Fix `sys_user` load failure after the validation-rule type trim (#1485)
+
+#1485 trimmed the unenforceable validation-rule types (`unique`, `async`,
+`custom`) from the `ValidationRuleSchema` discriminated union, but `sys_user`
+still declared an `email_unique` rule with `type: 'unique'`. Loading the object
+then threw a `ZodError` ("Invalid discriminator value … at validations[0].type"),
+failing `platform-objects.test.ts` and turning `main` red.
+
+The rule was redundant: `sys_user` already declares a unique index on `email`
+(`indexes: [{ fields: ['email'], unique: true }]`), and the user table is
+managed by better-auth which enforces email uniqueness at the source. Removed
+the unenforceable validation rule; uniqueness remains enforced by the index.
+No other object uses a trimmed validation type.

--- a/packages/platform-objects/src/identity/sys-user.object.ts
+++ b/packages/platform-objects/src/identity/sys-user.object.ts
@@ -439,14 +439,8 @@ export const SysUser = ObjectSchema.create({
     mru: true,
   },
 
-  validations: [
-    {
-      name: 'email_unique',
-      type: 'unique',
-      severity: 'error',
-      message: 'Email must be unique',
-      fields: ['email'],
-      caseSensitive: false,
-    },
-  ],
+  // Email uniqueness is enforced by the unique index above (and better-auth's
+  // managed user table). A declarative `unique` validation rule is intentionally
+  // not used — uniqueness needs a DB lookup, not a synchronous validation, so it
+  // is not one of the declarable validation-rule types.
 });


### PR DESCRIPTION
## What & why

`main` has been **red since [#1485](https://github.com/objectstack-ai/framework/pull/1485)** ("enforce all declared validation-rule types; trim the unenforceable three"). That PR removed `unique` / `async` / `custom` from the `ValidationRuleSchema` discriminated union, but `sys_user` still declared:

```ts
validations: [{ name: 'email_unique', type: 'unique', ... }]
```

So `ObjectSchema.create(SysUser)` throws at module load:

```
ZodError: Invalid discriminator value at validations[0].type.
Expected 'script' | 'state_machine' | 'format' | 'cross_field' | 'json_schema' | 'conditional'
```

…which fails `packages/platform-objects/src/platform-objects.test.ts` (CI "Test Core"). CI history: `11905faf8` (#1484) green → `764824299` (#1485) red → still red through `f950b43d9` (#1487).

## Fix

The validation rule was **redundant**: `sys_user` already declares a unique index on `email` (`indexes: [{ fields: ['email'], unique: true }]`), and the table is `managedBy: 'better-auth'` which enforces email uniqueness at the source. `unique` was trimmed precisely because it's unenforceable as a synchronous validation rule. So the rule is removed (not migrated). Swept the repo — **no other object** uses a trimmed validation type.

## Verification

`platform-objects.test.ts` → **52/52 pass** locally with the fix (was a failing suite before).

Unblocks #1488 (notification dispatcher test) which is red only due to this pre-existing failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)