### PR TITLE
fix(platform-objects): drop invalid `unique` validation on sys_user

### DIFF
--- a/.changeset/fix-sys-user-unique-validation.md
+++ b/.changeset/fix-sys-user-unique-validation.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/platform-objects": patch
+---
+
+fix(platform-objects): remove invalid `unique` validation rule on sys_user
+
+`sys_user` declared a `validations: [{ type: 'unique', ... }]` rule, but #1485
+removed `'unique'` from the enforceable validation-rule types (uniqueness is an
+index concern, not a validation rule). The stray rule slipped onto `main` as a
+semantic merge conflict and failed schema parse at registration (ZodError:
+invalid discriminator value), breaking Test Core. Email uniqueness is already
+enforced by the unique index (`indexes: [{ fields: ['email'], unique: true }]`),
+so the redundant validation block is removed.

--- a/packages/platform-objects/src/identity/sys-user.object.ts
+++ b/packages/platform-objects/src/identity/sys-user.object.ts
@@ -439,14 +439,8 @@ export const SysUser = ObjectSchema.create({
     mru: true,
   },
 
-  validations: [
-    {
-      name: 'email_unique',
-      type: 'unique',
-      severity: 'error',
-      message: 'Email must be unique',
-      fields: ['email'],
-      caseSensitive: false,
-    },
-  ],
+  // Email uniqueness is enforced by the unique index declared above
+  // (`indexes: [{ fields: ['email'], unique: true }]`). The standalone `unique`
+  // validation rule was removed in #1485 — uniqueness is an index concern, not
+  // an enforceable validation-rule type — so no `validations` block is needed.
 });


### PR DESCRIPTION
## Problem

`main` is currently red on **Test Core** for every PR. `packages/platform-objects/src/identity/sys-user.object.ts` declares:

```ts
validations: [
  { name: 'email_unique', type: 'unique', severity: 'error', message: 'Email must be unique', fields: ['email'], caseSensitive: false },
],
```

But **#1485** ("enforce all declared validation-rule types; trim the unenforceable three") removed `'unique'` from the allowed validation-rule discriminator (`script | state_machine | format | cross_field | json_schema | conditional`). The two changes were a **semantic merge conflict** — each passed independently, but together `sys_user` fails schema parse at registration:

```
ZodError: invalid discriminator value. Expected 'script' | 'state_machine' | 'format' | 'cross_field' | 'json_schema' | 'conditional'
  at packages/platform-objects/src/identity/sys-user.object.ts:16
```

## Fix

Remove the redundant `validations` block. Email uniqueness is **already** enforced by the unique index declared on the same object:

```ts
indexes: [ { fields: ['email'], unique: true }, ... ]
```

Uniqueness is an index concern, not an enforceable validation rule — which is exactly why #1485 dropped the type. No behavior change; just removes a now-invalid declaration.

## Verification
- `@objectstack/platform-objects` tests: **52 passed**.
- Scanned the repo — `sys_user` was the only object carrying a trimmed validation-rule type.

This unblocks `Test Core` on `main` and on the in-flight ADR-0031 PRs (#1489).

https://claude.ai/code/session_012ti8cx3TkdiQdjCnZXZg2Q

---
_Generated by [Claude Code](https://claude.ai/code/session_012ti8cx3TkdiQdjCnZXZg2Q)_