### PR TITLE
fix(spec): escape unmatched `<`/`{` in generated MDX docs (unblock apps/docs build)

### DIFF
--- a/.changeset/fix-docs-mdx-escape.md
+++ b/.changeset/fix-docs-mdx-escape.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/spec": patch
+---
+
+Fix the docs generator (`build-docs.ts`) leaking an unmatched `<` / `{` into generated MDX, which broke the `apps/docs` Turbopack build (e.g. a SemVer range `">=4.0 <5"` in a `.describe()` string was read as the start of a JSX tag). Unmatched openers are now emitted as HTML entities (`&lt;` / `&#123;`); union-variant descriptions also go through the escaper.

--- a/packages/spec/scripts/build-docs.ts
+++ b/packages/spec/scripts/build-docs.ts
@@ -167,6 +167,12 @@ function generateMarkdown(schemaName: string, schema: any, category: string, zod
   // span are left untouched. A naive two-pass replace double-wraps nested cases
   // like `{<id>}` into `` `{`<id>`}` `` — the inner backticks close the span
   // early and leak `<id>` as raw JSX (MDX: "Expected a closing tag for `<id>`").
+  //
+  // A matched `{…}` / `<…>` pair is wrapped in an inline-code span so it renders
+  // literally. A *lone* `<` or `{` with no closing partner (e.g. a SemVer range
+  // `">=4.0 <5"`, or prose like `count < 5`) can't be wrapped, so it is replaced
+  // with its HTML entity — otherwise MDX reads the `<` as the start of a JSX tag
+  // and the build dies ("Unexpected character `5` before name").
   const escapeMdxDescription = (raw: string): string => {
     let out = '';
     let inCode = false;
@@ -185,6 +191,9 @@ function generateMarkdown(schemaName: string, schema: any, category: string, zod
           i = end;
           continue;
         }
+        // Unmatched: escape so MDX doesn't treat it as a JSX/expression opener.
+        out += ch === '<' ? '&lt;' : '&#123;';
+        continue;
       }
       out += ch;
     }
@@ -223,7 +232,7 @@ function generateMarkdown(schemaName: string, schema: any, category: string, zod
      variants.forEach((variant: any, index: number) => {
          const variantTitle = variant.title || `Option ${index + 1}`;
          md += `#### ${variantTitle}\n\n`;
-         if (variant.description) md += `${variant.description}\n\n`;
+         if (variant.description) md += `${escapeMdxDescription(variant.description)}\n\n`;
          
          if (variant.type === 'object' && variant.properties) {
               if (variant.properties.type && variant.properties.type.const) {


### PR DESCRIPTION
## Summary

Unblocks `main` — the `apps/docs` Next.js (Turbopack + fumadocs-mdx) production build currently fails:

```
./content/docs/references/kernel/manifest.mdx
82:97: Unexpected character `5` (U+0035) before name, expected a character that can start a name
```

(This is a docs-build regression unrelated to the validation-rules work; it surfaced once the #1485 → #1490 platform-objects regression was cleared and the pipeline reached the docs build.)

## Root cause

`packages/spec/scripts/build-docs.ts` generates the reference MDX from the Zod schemas. Its `escapeMdxDescription` only backtick-wrapped **matched** `<…>` / `{…}` pairs. A **lone** `<` with no closing partner — e.g. the SemVer range in `manifest`'s `platform` field, `.describe('... ">=4.0 <5"')` — was emitted raw, and MDX read the `<5` as the start of a JSX tag.

## Fix

- An unmatched `<` / `{` is now emitted as its HTML entity (`&lt;` / `&#123;`) so it renders literally and never opens a JSX/expression node. Matched pairs keep their existing backtick-wrapping; fragments already inside inline-code spans are still left untouched.
- Union-variant descriptions (previously emitted raw) now also go through the escaper.

Only the generator changes — the committed generated `.mdx` is regenerated by the build (`gen:schema && gen:docs && next build`), so no generated content is included here.

## Verification

`pnpm --filter @objectstack/docs build` (full gen + `next build`) **completes successfully**. A sweep of all generated `content/docs/references/**` confirms no remaining unmatched `<` outside code spans (`>=2.0.0 <3.0.0` style ranges are inside backticks and unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)