### PR TITLE
test(service-cluster-redis): de-flake Redis wiring test (hoist cold imports)

### DIFF
--- a/.changeset/redis-wiring-test-stabilize.md
+++ b/.changeset/redis-wiring-test-stabilize.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: stabilize the Redis driver wiring contract test (hoist imports out of the timed test body to fix a flaky 5s timeout on slow CI).

--- a/packages/services/service-cluster-redis/src/redis.contract.test.ts
+++ b/packages/services/service-cluster-redis/src/redis.contract.test.ts
@@ -17,6 +17,14 @@ import {
     runKVContract,
     runCounterContract,
 } from '@objectstack/service-cluster/testing';
+// Load the driver entrypoint at module eval — importing it registers the
+// 'redis' cluster driver as a side-effect, which `defineCluster({ driver:
+// 'redis' })` then resolves. Doing this here (not via `await import()` inside
+// the timed test bodies) keeps the one-time cold module-load cost out of the
+// per-test 5s timeout — the wiring tests below were flaky on slow CI for
+// exactly that reason (the first test paid the full import cost and timed out).
+import './index.js';
+import { defineCluster } from '@objectstack/service-cluster';
 
 import { RedisPubSub } from './pubsub.js';
 import { RedisLock } from './lock.js';
@@ -118,8 +126,6 @@ describe('IPubSub contract — redis(mock)', () => {
 
 describe('Redis driver — wiring', () => {
     it('exports a registerable driver and defineCluster picks it up', async () => {
-        await import('./index.js');
-        const { defineCluster } = await import('@objectstack/service-cluster');
         const client = makeClient();
         const cluster = defineCluster({
             driver: 'redis',
@@ -145,8 +151,6 @@ describe('Redis driver — wiring', () => {
     });
 
     it('does NOT quit caller-owned client on close', async () => {
-        await import('./index.js');
-        const { defineCluster } = await import('@objectstack/service-cluster');
         const client = makeClient();
         const cluster = defineCluster({
             driver: 'redis',


### PR DESCRIPTION
## Problem

`Test Core` intermittently fails on `packages/services/service-cluster-redis/src/redis.contract.test.ts`:

```
FAIL  Redis driver — wiring > exports a registerable driver and defineCluster picks it up
Error: Test timed out in 5000ms.
  ❯ redis.contract.test.ts:120  →  await import('./index.js') / await import('@objectstack/service-cluster')
```

Both wiring tests did two `await import(...)` **inside the test body**, under the default 5000ms timeout. On a cold/slow CI runner the one-time module load alone exceeds 5s, so the first test times out (the second only passed because the first had warmed the module cache). It's a flake, unrelated to any product code — it red-flagged #1488's Test Core, for instance.

## Fix

Hoist both to top-level static imports:

```ts
import './index.js';                              // side-effect: registers the 'redis' driver
import { defineCluster } from '@objectstack/service-cluster';
```

`import './index.js'` still registers the driver as a side-effect at module eval, and `defineCluster` is a normal named export (`service-cluster/src/index.ts`). The cold import cost now lands once at file load, outside any per-test timeout. The two test bodies drop their local `await import(...)` lines; all assertions are unchanged.

Verified by inspection (pure import hoist; `defineCluster` is a confirmed named export, `./testing` is a separate subpath import that's untouched). CI exercises the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)