### PR TITLE
chore(security): bump transitive node-tar to >=7.5.11 (clear 6 high advisories)

### DIFF
--- a/.changeset/audit-tar-override.md
+++ b/.changeset/audit-tar-override.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(security): override transitive `node-tar` to `>=7.5.11`, clearing 6 high-severity advisories (GHSA-34x7-hfp2-rc4v, -8qq5-rm4j-mr97, -83g3-92jg-28cx, -qffp-2rhf-9h96, -9ppj-qmqm-q256, -r6q2-hw4h-h46w) that failed the Validate Dependencies gate. Lockfile-only; no published package code change.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "packageManager": "pnpm@10.31.0+sha512.e3927388bfaa8078ceb79b748ffc1e8274e84d75163e67bc22e06c0d3aed43dd153151cbf11d7f8301ff4acb98c68bdc5cadf6989532801ffafe3b3e4a63c268",
   "pnpm": {
     "overrides": {
-      "minimatch@<10.2.3": "10.2.3"
+      "minimatch@<10.2.3": "10.2.3",
+      "tar@>=2.0.0 <7.5.11": "^7.5.11"
     },
     "ignoredBuiltDependencies": [
       "@nestjs/core",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   minimatch@<10.2.3: 10.2.3
+  tar@>=2.0.0 <7.5.11: ^7.5.11
 
 importers:
 
@@ -7048,10 +7049,6 @@ packages:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
     engines: {node: '>=8'}
 
-  minipass@5.0.0:
-    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
-    engines: {node: '>=8'}
-
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -8335,11 +8332,6 @@ packages:
 
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
-
-  tar@6.2.1:
-    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
-    engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.15:
     resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
@@ -12168,7 +12160,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 8.0.1
-      tar: 6.2.1
+      tar: 7.5.15
       unique-filename: 1.1.1
     transitivePeerDependencies:
       - bluebird
@@ -12242,7 +12234,8 @@ snapshots:
 
   chownr@1.1.4: {}
 
-  chownr@2.0.0: {}
+  chownr@2.0.0:
+    optional: true
 
   chownr@3.0.0: {}
 
@@ -12933,6 +12926,7 @@ snapshots:
   fs-minipass@2.1.0:
     dependencies:
       minipass: 3.3.6
+    optional: true
 
   fs.realpath@1.0.0:
     optional: true
@@ -14329,8 +14323,7 @@ snapshots:
   minipass@3.3.6:
     dependencies:
       yallist: 4.0.0
-
-  minipass@5.0.0: {}
+    optional: true
 
   minipass@7.1.3: {}
 
@@ -14338,6 +14331,7 @@ snapshots:
     dependencies:
       minipass: 3.3.6
       yallist: 4.0.0
+    optional: true
 
   minizlib@3.1.0:
     dependencies:
@@ -14345,7 +14339,8 @@ snapshots:
 
   mkdirp-classic@0.5.3: {}
 
-  mkdirp@1.0.4: {}
+  mkdirp@1.0.4:
+    optional: true
 
   mlly@1.8.2:
     dependencies:
@@ -14555,7 +14550,7 @@ snapshots:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.8.1
-      tar: 6.2.1
+      tar: 7.5.15
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -15554,7 +15549,7 @@ snapshots:
       bindings: 1.5.0
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
-      tar: 6.2.1
+      tar: 7.5.15
     optionalDependencies:
       node-gyp: 8.4.1
     transitivePeerDependencies:
@@ -15726,15 +15721,6 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
-
-  tar@6.2.1:
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
 
   tar@7.5.15:
     dependencies:


### PR DESCRIPTION
## Summary

Clears the **Validate Dependencies** gate (`pnpm audit --audit-level=high`), which was red on `main` with 6 high-severity advisories — all the same dependency, **`node-tar@6.2.1`**, pulled transitively by `sqlite3`'s node-gyp toolchain (`driver-sql` → `sqlite3` → … → `tar`).

`sqlite3` is only an **optional peer** of `driver-sql` (the real sqlite driver is `better-sqlite3`) and its build script is pnpm-ignored, so the vulnerable `tar` was never executed — but the audit gate flags it regardless.

## Fix

Scoped `pnpm.override`:

```jsonc
"tar@>=2.0.0 <7.5.11": "^7.5.11"
```

- Bumps every vulnerable `node-tar` (6.2.1) to a patched 7.5.x+ — patched versions (`7.5.15`, `7.9.0`) already resolved elsewhere in the tree.
- The `>=2.0.0` lower bound deliberately leaves the unrelated ancient `tar@1.1.11` (a different package line) untouched.

Advisories cleared: GHSA-34x7-hfp2-rc4v, -8qq5-rm4j-mr97, -83g3-92jg-28cx, -qffp-2rhf-9h96, -9ppj-qmqm-q256, -r6q2-hw4h-h46w.

## Verification

- `pnpm audit --audit-level=high` → **exit 0** (0 high / 0 critical; 2 low + 5 moderate remain, below the gate threshold).
- `pnpm install --frozen-lockfile` → clean; `check-changeset-fixed.mjs` → in sync.
- `tar@6.2.1` no longer in the lockfile; `tar@1.1.11` preserved.
- `@objectstack/driver-sql` build + **132 tests pass**.

Lockfile/override-only; no published package code changes (empty changeset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)