### PR TITLE
fix(dev): print seeded dev-admin credentials in the serve startup banner

### DIFF
--- a/.changeset/print-seeded-admin-banner.md
+++ b/.changeset/print-seeded-admin-banner.md
@@ -1,0 +1,21 @@
+---
+"@objectstack/plugin-auth": patch
+"@objectstack/cli": patch
+---
+
+fix(dev): surface the seeded dev-admin credentials in the `serve` startup banner.
+
+When the runtime seeds the dev admin on an empty DB, the confirmation was
+emitted via `ctx.logger` during `runtime.start()` — inside serve's boot-quiet
+window — so it was swallowed and never reached the console. plugin-auth now
+records the seed result on the `auth` service and `serve` prints it in the
+ready banner (after stdout is restored), e.g.:
+
+```
+  🔑  Dev admin: admin@objectos.ai / admin123
+      seeded on empty DB · dev only — do not use in production
+```
+
+Shown only when an admin was actually seeded this boot (empty DB) — never on a
+DB that already had a user, so stale credentials are never displayed. Visible
+in both `serve --dev` and `os dev` (the child's stdout is inherited).

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1754,6 +1754,17 @@ export default class Serve extends Command {
         }
       }
 
+      // Surface the dev admin seeded this boot (if any) in the banner. The
+      // seed runs in-process during runtime.start() under serve's boot-quiet
+      // window, so plugin-auth records the result on the `auth` service and
+      // we print it here, after stdout is restored. Visible in both
+      // `serve --dev` and `os dev` (the child's stdout is inherited).
+      let seededAdmin: { email: string; password: string } | undefined;
+      try {
+        const authSvc: any = kernel.getService?.('auth');
+        if (authSvc?.devSeedResult?.email) seededAdmin = authSvc.devSeedResult;
+      } catch { /* auth service not present — nothing to show */ }
+
       // ── Clean startup summary ──────────────────────────────────────
       printServerReady({
         port,
@@ -1766,6 +1777,7 @@ export default class Serve extends Command {
         driverLabel: resolvedDriverLabel,
         databaseUrl: redactDbUrl(resolvedDatabaseUrl),
         multiTenant: String(readEnvWithDeprecation('OS_MULTI_ORG_ENABLED', 'OS_MULTI_TENANT') ?? 'false').toLowerCase() !== 'false',
+        seededAdmin,
       });
 
       // ── Publish the actually-bound port ────────────────────────────

--- a/packages/cli/src/utils/format.ts
+++ b/packages/cli/src/utils/format.ts
@@ -189,6 +189,12 @@ export interface ServerReadyOptions {
   databaseUrl?: string;
   /** Whether the SecurityPlugin was wired in multi-tenant mode (default true). */
   multiTenant?: boolean;
+  /**
+   * Credentials of the dev admin seeded on an empty DB this boot (dev only).
+   * When present, the banner surfaces them so backend debugging never has to
+   * guess the login. Absent when nothing was seeded.
+   */
+  seededAdmin?: { email: string; password: string };
 }
 
 export function printServerReady(opts: ServerReadyOptions) {
@@ -199,6 +205,14 @@ export function printServerReady(opts: ServerReadyOptions) {
   console.log(chalk.cyan('  ➜') + chalk.bold('  API:       ') + chalk.cyan(base + '/'));
   if (opts.uiEnabled && opts.consolePath) {
     console.log(chalk.cyan('  ➜') + chalk.bold('  Console:   ') + chalk.cyan(base + opts.consolePath + '/'));
+  }
+  if (opts.seededAdmin) {
+    console.log('');
+    console.log(
+      chalk.green('  🔑') + chalk.bold('  Dev admin: ') +
+      chalk.bold.green(`${opts.seededAdmin.email} / ${opts.seededAdmin.password}`),
+    );
+    console.log(chalk.dim('      seeded on empty DB · dev only — do not use in production'));
   }
   console.log('');
   console.log(chalk.dim(`  Config:  ${opts.configFile}`));

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -235,6 +235,15 @@ export class AuthManager {
   private auth: Auth<any> | null = null;
   private config: AuthManagerOptions;
 
+  /**
+   * Result of the dev-only admin seed (set by `AuthPlugin.maybeSeedDevAdmin`
+   * when it provisions the well-known admin on an empty DB). The `serve`
+   * command reads this after boot to surface the credentials in the startup
+   * banner. Undefined when no seed ran (production, opt-out, or a DB that
+   * already had a user).
+   */
+  public devSeedResult?: { email: string; password: string };
+
   constructor(config: AuthManagerOptions) {
     this.config = config;
 

--- a/packages/plugins/plugin-auth/src/auth-plugin.ts
+++ b/packages/plugins/plugin-auth/src/auth-plugin.ts
@@ -389,6 +389,12 @@ export class AuthPlugin implements Plugin {
       // is otherwise disabled.
       await api.signUpEmail({ body: { email, password, name } });
       ctx.logger.info(`🔑 Dev admin seeded: ${email} / ${password}`);
+      // Surface the credentials in the `serve` startup banner. The
+      // ctx.logger line above is swallowed by serve's boot-quiet window
+      // (the seed runs during runtime.start(), before stdout is restored),
+      // so the CLI reads this off the `auth` service and prints it after
+      // the banner instead.
+      this.authManager.devSeedResult = { email, password };
     } catch (err: any) {
       // Best-effort. The common benign case is a race where a real sign-up
       // landed first (unique-email violation) — treat as "already seeded".


### PR DESCRIPTION
## Problem

After [#1503](https://github.com/objectstack-ai/framework/pull/1503) moved dev-admin seeding in-process, the confirmation line went **silent**. The seed runs inside `runtime.start()`, which is within `serve`'s boot-quiet window (stdout is suppressed to produce a clean banner, restored only afterward). So the `ctx.logger.info('🔑 Dev admin seeded …')` line was swallowed — a DX regression vs the old HTTP seed, which printed the credentials.

## Fix

`plugin-auth` records the seed result on the `auth` service (`AuthManager.devSeedResult`). `serve` reads it after `restoreOutput()` and renders it inside the ready banner:

```
  ✓ Server is ready

  ➜  API:       http://localhost:3999/
  ➜  Console:   http://localhost:3999/_console/

  🔑  Dev admin: admin@objectos.ai / admin123
      seeded on empty DB · dev only — do not use in production
```

- **Single print point.** Because `os dev` spawns `serve` with inherited stdout, printing from the serve child covers both `serve --dev` standalone and the `os dev` console — no IPC needed for this.
- **Never stale.** The line shows only when an admin was actually seeded this boot (empty DB). On a populated DB the seed skips, `devSeedResult` stays undefined, and nothing prints.
- **Dev-only** by construction (the seed itself is hard-gated to `NODE_ENV=development`).

## Verification (showcase)

| Case | Result |
|---|---|
| Fresh DB → seeds | banner shows `🔑 Dev admin: …` ✓ |
| Second run, same DB → skip | banner has **no** Dev-admin line ✓ |

Tests: cli **144**, plugin-auth **88** — all green. Typecheck/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)