### PR TITLE
fix(cli): link dev banner to interactive API docs instead of root

### DIFF
--- a/.changeset/banner-api-docs-link.md
+++ b/.changeset/banner-api-docs-link.md
@@ -1,0 +1,10 @@
+---
+"@objectstack/cli": patch
+---
+
+fix(cli): point the dev startup banner at the interactive API docs.
+
+The ready banner's `API:` line pointed at `/` (the server root, not the API).
+Replace it with an `API Docs:` link to `<apiBase>/docs` — the interactive
+Scalar/OpenAPI explorer — which is the useful human entry point into the
+running server's API. Adds an optional `apiBasePath` (default `/api/v1`).

--- a/packages/cli/src/utils/format.ts
+++ b/packages/cli/src/utils/format.ts
@@ -183,6 +183,8 @@ export interface ServerReadyOptions {
   pluginNames?: string[];
   uiEnabled?: boolean;
   consolePath?: string;
+  /** REST API base path (default '/api/v1'). Drives the API Docs link. */
+  apiBasePath?: string;
   /** Resolved storage driver display name (e.g. "MongoDBDriver", "SqlDriver(pg)"). */
   driverLabel?: string;
   /** Resolved DB URL with credentials redacted. */
@@ -202,7 +204,8 @@ export function printServerReady(opts: ServerReadyOptions) {
   console.log('');
   console.log(chalk.bold.green('  ✓ Server is ready'));
   console.log('');
-  console.log(chalk.cyan('  ➜') + chalk.bold('  API:       ') + chalk.cyan(base + '/'));
+  const apiBase = opts.apiBasePath ?? '/api/v1';
+  console.log(chalk.cyan('  ➜') + chalk.bold('  API Docs:  ') + chalk.cyan(base + apiBase + '/docs'));
   if (opts.uiEnabled && opts.consolePath) {
     console.log(chalk.cyan('  ➜') + chalk.bold('  Console:   ') + chalk.cyan(base + opts.consolePath + '/'));
   }


### PR DESCRIPTION
## What

The dev startup banner's `API:` line pointed at `/` — the server **root**, not the API. This replaces it with an **API Docs** link to the interactive Scalar/OpenAPI explorer:

```
  ➜  API Docs:  http://localhost:3999/api/v1/docs
  ➜  Console:   http://localhost:3999/_console/
```

## Why

Probing the running showcase:

| Path | Result |
|---|---|
| `/api/v1/docs` | **200** HTML — interactive Scalar API explorer |
| `/api/v1` | 200 JSON — machine-facing route index |
| `/api/v1/` | **404** (trailing slash) |
| `/` (old `API:` target) | 302 redirect — not the API |

The interactive docs is the useful human entry point; the bare `/api/v1` index is machine-facing and not worth a banner line, and the old `/` target was misleading. Adds an optional `apiBasePath` (default `/api/v1`).

Verified: banner renders the two lines; `GET /api/v1/docs` → 200 HTML, `GET /api/v1/openapi.json` → 200. cli tests 144 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)