### PR TITLE
fix(release): stop fixed-group major cascade from internal peerDependencies

### DIFF
--- a/.changeset/fix-fixed-group-peer-major.md
+++ b/.changeset/fix-fixed-group-peer-major.md
@@ -1,0 +1,24 @@
+---
+"@objectstack/cli": patch
+"@objectstack/express": patch
+"@objectstack/sveltekit": patch
+"@objectstack/hono": patch
+"@objectstack/nuxt": patch
+"@objectstack/nextjs": patch
+"@objectstack/nestjs": patch
+"@objectstack/fastify": patch
+"@objectstack/plugin-msw": patch
+"@objectstack/plugin-dev": patch
+"@objectstack/service-datasource": patch
+"@objectstack/service-ai": patch
+---
+
+fix(release): stop the fixed-group major cascade caused by internal `@objectstack/*` peerDependencies.
+
+These packages declared workspace peerDependencies on other framework packages
+in the changesets `fixed` group. Inside a fixed group, changesets rewrites those
+peer ranges on every release and treats a peer-range change as breaking → major,
+which cascaded to **all 69 packages → 8.0.0** on *any* minor changeset. Required
+internal peers are now regular `dependencies`; optional ones move to
+`devDependencies` (kept for in-workspace tests, no longer a published peer edge).
+Releases now bump correctly (patch/minor) instead of a spurious major.

--- a/packages/adapters/express/package.json
+++ b/packages/adapters/express/package.json
@@ -17,7 +17,6 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@objectstack/runtime": "workspace:^",
     "express": "^5.1.0"
   },
   "devDependencies": {
@@ -52,5 +51,8 @@
   ],
   "engines": {
     "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@objectstack/runtime": "workspace:^"
   }
 }

--- a/packages/adapters/fastify/package.json
+++ b/packages/adapters/fastify/package.json
@@ -17,7 +17,6 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@objectstack/runtime": "workspace:^",
     "fastify": "^5.8.5"
   },
   "devDependencies": {
@@ -51,5 +50,8 @@
   ],
   "engines": {
     "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@objectstack/runtime": "workspace:^"
   }
 }

--- a/packages/adapters/hono/package.json
+++ b/packages/adapters/hono/package.json
@@ -18,10 +18,10 @@
   },
   "dependencies": {
     "@objectstack/plugin-hono-server": "workspace:*",
-    "@objectstack/types": "workspace:*"
+    "@objectstack/types": "workspace:*",
+    "@objectstack/runtime": "workspace:^"
   },
   "peerDependencies": {
-    "@objectstack/runtime": "workspace:^",
     "hono": "^4.12.8"
   },
   "devDependencies": {

--- a/packages/adapters/nestjs/package.json
+++ b/packages/adapters/nestjs/package.json
@@ -11,8 +11,7 @@
   },
   "peerDependencies": {
     "@nestjs/common": "^11.1.19",
-    "@nestjs/core": "^11.1.19",
-    "@objectstack/runtime": "workspace:^"
+    "@nestjs/core": "^11.1.19"
   },
   "devDependencies": {
     "@nestjs/common": "^11.1.24",
@@ -45,5 +44,8 @@
   ],
   "engines": {
     "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@objectstack/runtime": "workspace:^"
   }
 }

--- a/packages/adapters/nextjs/package.json
+++ b/packages/adapters/nextjs/package.json
@@ -10,7 +10,6 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@objectstack/runtime": "workspace:^",
     "next": "^16.2.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
@@ -48,5 +47,8 @@
   ],
   "engines": {
     "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@objectstack/runtime": "workspace:^"
   }
 }

--- a/packages/adapters/nuxt/package.json
+++ b/packages/adapters/nuxt/package.json
@@ -17,7 +17,6 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@objectstack/runtime": "workspace:^",
     "h3": "^1.15.11"
   },
   "devDependencies": {
@@ -51,5 +50,8 @@
   ],
   "engines": {
     "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@objectstack/runtime": "workspace:^"
   }
 }

--- a/packages/adapters/sveltekit/package.json
+++ b/packages/adapters/sveltekit/package.json
@@ -17,7 +17,6 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@objectstack/runtime": "workspace:^",
     "@sveltejs/kit": "^2.58.0"
   },
   "devDependencies": {
@@ -50,5 +49,8 @@
   ],
   "engines": {
     "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@objectstack/runtime": "workspace:^"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,7 @@
     "@objectstack/account": "workspace:*",
     "@objectstack/client": "workspace:*",
     "@objectstack/console": "workspace:*",
-    "@objectstack/core": "workspace:*",
+    "@objectstack/core": "workspace:^",
     "@objectstack/driver-memory": "workspace:^",
     "@objectstack/driver-mongodb": "workspace:^",
     "@objectstack/driver-sql": "workspace:^",
@@ -92,9 +92,6 @@
     "tsx": "^4.22.4",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"
-  },
-  "peerDependencies": {
-    "@objectstack/core": "workspace:^"
   },
   "devDependencies": {
     "@oclif/plugin-help": "^6.2.50",

--- a/packages/plugins/plugin-dev/package.json
+++ b/packages/plugins/plugin-dev/package.json
@@ -21,7 +21,7 @@
     "@objectstack/spec": "workspace:*",
     "@objectstack/types": "workspace:*"
   },
-  "peerDependencies": {
+  "devDependencies": {
     "@objectstack/driver-memory": "workspace:^",
     "@objectstack/objectql": "workspace:^",
     "@objectstack/plugin-auth": "workspace:^",
@@ -30,47 +30,7 @@
     "@objectstack/plugin-security": "workspace:^",
     "@objectstack/rest": "workspace:^",
     "@objectstack/runtime": "workspace:^",
-    "@objectstack/service-i18n": "workspace:^"
-  },
-  "peerDependenciesMeta": {
-    "@objectstack/driver-memory": {
-      "optional": true
-    },
-    "@objectstack/objectql": {
-      "optional": true
-    },
-    "@objectstack/runtime": {
-      "optional": true
-    },
-    "@objectstack/plugin-auth": {
-      "optional": true
-    },
-    "@objectstack/plugin-hono-server": {
-      "optional": true
-    },
-    "@objectstack/plugin-org-scoping": {
-      "optional": true
-    },
-    "@objectstack/plugin-security": {
-      "optional": true
-    },
-    "@objectstack/rest": {
-      "optional": true
-    },
-    "@objectstack/service-i18n": {
-      "optional": true
-    }
-  },
-  "devDependencies": {
-    "@objectstack/driver-memory": "workspace:*",
-    "@objectstack/objectql": "workspace:*",
-    "@objectstack/plugin-auth": "workspace:*",
-    "@objectstack/plugin-hono-server": "workspace:*",
-    "@objectstack/plugin-org-scoping": "workspace:*",
-    "@objectstack/plugin-security": "workspace:*",
-    "@objectstack/rest": "workspace:*",
-    "@objectstack/runtime": "workspace:*",
-    "@objectstack/service-i18n": "workspace:*",
+    "@objectstack/service-i18n": "workspace:^",
     "@types/node": "^25.9.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"

--- a/packages/plugins/plugin-msw/package.json
+++ b/packages/plugins/plugin-msw/package.json
@@ -16,15 +16,13 @@
     "build": "tsup --config ../../../tsup.config.ts",
     "test": "vitest run"
   },
-  "peerDependencies": {
-    "@objectstack/runtime": "workspace:^"
-  },
   "dependencies": {
     "@objectstack/core": "workspace:*",
     "@objectstack/objectql": "workspace:*",
     "@objectstack/spec": "workspace:*",
     "@objectstack/types": "workspace:*",
-    "msw": "^2.14.6"
+    "msw": "^2.14.6",
+    "@objectstack/runtime": "workspace:^"
   },
   "devDependencies": {
     "@objectstack/runtime": "workspace:*",

--- a/packages/services/service-ai/package.json
+++ b/packages/services/service-ai/package.json
@@ -30,8 +30,7 @@
     "@ai-sdk/anthropic": "^3.0.0",
     "@ai-sdk/gateway": "^3.0.0",
     "@ai-sdk/google": "^3.0.0",
-    "@ai-sdk/openai": "^3.0.0",
-    "@objectstack/embedder-openai": "workspace:^"
+    "@ai-sdk/openai": "^3.0.0"
   },
   "peerDependenciesMeta": {
     "@ai-sdk/anthropic": {
@@ -45,13 +44,10 @@
     },
     "@ai-sdk/openai": {
       "optional": true
-    },
-    "@objectstack/embedder-openai": {
-      "optional": true
     }
   },
   "devDependencies": {
-    "@objectstack/embedder-openai": "workspace:*",
+    "@objectstack/embedder-openai": "workspace:^",
     "@objectstack/platform-objects": "workspace:*",
     "@types/node": "^25.9.1",
     "typescript": "^6.0.3",

--- a/packages/services/service-datasource/package.json
+++ b/packages/services/service-datasource/package.json
@@ -29,16 +29,6 @@
     "@objectstack/core": "workspace:*",
     "@objectstack/spec": "workspace:*"
   },
-  "peerDependencies": {
-    "@objectstack/driver-memory": "workspace:*",
-    "@objectstack/driver-mongodb": "workspace:*",
-    "@objectstack/driver-sql": "workspace:*"
-  },
-  "peerDependenciesMeta": {
-    "@objectstack/driver-sql": { "optional": true },
-    "@objectstack/driver-mongodb": { "optional": true },
-    "@objectstack/driver-memory": { "optional": true }
-  },
   "devDependencies": {
     "@objectstack/driver-memory": "workspace:*",
     "@objectstack/driver-sql": "workspace:*",
@@ -46,7 +36,8 @@
     "@types/node": "^25.9.1",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.8",
+    "@objectstack/driver-mongodb": "workspace:*"
   },
   "keywords": [
     "objectstack",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,10 +318,11 @@ importers:
         version: 6.0.3
 
   packages/adapters/express:
-    devDependencies:
+    dependencies:
       '@objectstack/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../runtime
+    devDependencies:
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -336,10 +337,11 @@ importers:
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/adapters/fastify:
-    devDependencies:
+    dependencies:
       '@objectstack/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../runtime
+    devDependencies:
       fastify:
         specifier: ^5.8.5
         version: 5.8.5
@@ -355,13 +357,13 @@ importers:
       '@objectstack/plugin-hono-server':
         specifier: workspace:*
         version: link:../../plugins/plugin-hono-server
+      '@objectstack/runtime':
+        specifier: workspace:^
+        version: link:../../runtime
       '@objectstack/types':
         specifier: workspace:*
         version: link:../../types
     devDependencies:
-      '@objectstack/runtime':
-        specifier: workspace:*
-        version: link:../../runtime
       hono:
         specifier: ^4.12.23
         version: 4.12.23
@@ -373,6 +375,10 @@ importers:
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/adapters/nestjs:
+    dependencies:
+      '@objectstack/runtime':
+        specifier: workspace:^
+        version: link:../../runtime
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.24
@@ -380,9 +386,6 @@ importers:
       '@nestjs/core':
         specifier: ^11.1.24
         version: 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@objectstack/runtime':
-        specifier: workspace:*
-        version: link:../../runtime
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -391,10 +394,11 @@ importers:
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/adapters/nextjs:
-    devDependencies:
+    dependencies:
       '@objectstack/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../runtime
+    devDependencies:
       next:
         specifier: ^16.2.6
         version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -412,10 +416,11 @@ importers:
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/adapters/nuxt:
-    devDependencies:
+    dependencies:
       '@objectstack/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../runtime
+    devDependencies:
       h3:
         specifier: ^1.15.11
         version: 1.15.11
@@ -427,10 +432,11 @@ importers:
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/adapters/sveltekit:
-    devDependencies:
+    dependencies:
       '@objectstack/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../runtime
+    devDependencies:
       '@sveltejs/kit':
         specifier: ^2.61.1
         version: 2.61.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.55.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -456,7 +462,7 @@ importers:
         specifier: workspace:*
         version: link:../console
       '@objectstack/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@objectstack/driver-memory':
         specifier: workspace:^
@@ -1281,31 +1287,31 @@ importers:
         version: link:../../types
     devDependencies:
       '@objectstack/driver-memory':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../driver-memory
       '@objectstack/objectql':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../objectql
       '@objectstack/plugin-auth':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../plugin-auth
       '@objectstack/plugin-hono-server':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../plugin-hono-server
       '@objectstack/plugin-org-scoping':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../plugin-org-scoping
       '@objectstack/plugin-security':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../plugin-security
       '@objectstack/rest':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../rest
       '@objectstack/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../runtime
       '@objectstack/service-i18n':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../services/service-i18n
       '@types/node':
         specifier: ^25.9.1
@@ -1403,6 +1409,9 @@ importers:
       '@objectstack/objectql':
         specifier: workspace:*
         version: link:../../objectql
+      '@objectstack/runtime':
+        specifier: workspace:^
+        version: link:../../runtime
       '@objectstack/spec':
         specifier: workspace:*
         version: link:../../spec
@@ -1413,9 +1422,6 @@ importers:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)
     devDependencies:
-      '@objectstack/runtime':
-        specifier: workspace:*
-        version: link:../../runtime
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
@@ -1704,7 +1710,7 @@ importers:
         version: 4.4.3
     devDependencies:
       '@objectstack/embedder-openai':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../plugins/embedder-openai
       '@objectstack/platform-objects':
         specifier: workspace:*
@@ -1831,9 +1837,6 @@ importers:
       '@objectstack/core':
         specifier: workspace:*
         version: link:../../core
-      '@objectstack/driver-mongodb':
-        specifier: workspace:*
-        version: link:../../plugins/driver-mongodb
       '@objectstack/spec':
         specifier: workspace:*
         version: link:../../spec
@@ -1841,6 +1844,9 @@ importers:
       '@objectstack/driver-memory':
         specifier: workspace:*
         version: link:../../plugins/driver-memory
+      '@objectstack/driver-mongodb':
+        specifier: workspace:*
+        version: link:../../plugins/driver-mongodb
       '@objectstack/driver-sql':
         specifier: workspace:*
         version: link:../../plugins/driver-sql


### PR DESCRIPTION
## What

Fixes the **fixed-group major cascade**: every minor changeset was escalating the whole 69-package suite to **8.0.0** instead of 7.6.0.

## Root cause (verified)

Several packages in the changesets `fixed` group declared **internal `@objectstack/*` peerDependencies** (adapters→`runtime`, `cli`→`core`, `plugin-msw`→`runtime`; optional: `plugin-dev`, `service-datasource`, `service-ai`). Inside a `fixed` group, changesets rewrites those peer ranges on every release and treats a **peer-range change as breaking → major**, which cascades to all 69 packages. `onlyUpdatePeerDependentsWhenOutOfRange` does not prevent this within a fixed group.

Proven by bisection: removing any one changeset still left 69-major; a *lone* minor on a peer-free package (`observability`) still produced 8.0.0; and converting the internal peers dropped it to **0 major**.

## Fix

- Required internal peers → `dependencies` (they're lockstep-versioned anyway).
- Optional internal peers → `devDependencies` (still available for in-workspace tests; no longer a published peer edge that cascades).

## Verification

`changeset status` before: **69 packages → major (8.0.0)**. After: **0 major**, next release bumps correctly (patch/minor → **7.6.0**). `pnpm install` clean (no cycles).

Unrelated to ADR-0032 — pre-existing release-config debt that *any* minor changeset triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
