### PR TITLE
fix(build): externalize lazily-imported optional drivers (unbreak main from #1524)

### DIFF
--- a/.changeset/fix-build-optional-driver-bundling.md
+++ b/.changeset/fix-build-optional-driver-bundling.md
@@ -1,0 +1,14 @@
+---
+"@objectstack/plugin-dev": patch
+"@objectstack/service-datasource": patch
+---
+
+fix(build): don't bundle lazily-imported optional drivers (fixes build break from #1524).
+
+After moving optional internal `@objectstack/*` peerDependencies off `peer` (to
+stop the changesets fixed-group major cascade), tsup no longer auto-externalized
+them and began bundling the lazily `await import()`-ed driver packages — pulling
+in their optional native clients (`mysql` / `oracledb` via knex) and failing the
+build. Fix: `service-datasource` externalizes `@objectstack/driver-*` in tsup
+(kept as devDeps for tests); `plugin-dev` moves its framework packages to
+`dependencies` (auto-externalized; it's a dev-only plugin). Full build green.

--- a/packages/plugins/plugin-dev/package.json
+++ b/packages/plugins/plugin-dev/package.json
@@ -19,9 +19,7 @@
   "dependencies": {
     "@objectstack/core": "workspace:*",
     "@objectstack/spec": "workspace:*",
-    "@objectstack/types": "workspace:*"
-  },
-  "devDependencies": {
+    "@objectstack/types": "workspace:*",
     "@objectstack/driver-memory": "workspace:^",
     "@objectstack/objectql": "workspace:^",
     "@objectstack/plugin-auth": "workspace:^",
@@ -30,7 +28,9 @@
     "@objectstack/plugin-security": "workspace:^",
     "@objectstack/rest": "workspace:^",
     "@objectstack/runtime": "workspace:^",
-    "@objectstack/service-i18n": "workspace:^",
+    "@objectstack/service-i18n": "workspace:^"
+  },
+  "devDependencies": {
     "@types/node": "^25.9.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"

--- a/packages/services/service-datasource/tsup.config.ts
+++ b/packages/services/service-datasource/tsup.config.ts
@@ -10,5 +10,10 @@ export default defineConfig({
     dts: true,
     format: ['esm', 'cjs'],
     target: 'es2020',
-    external: ['vitest'],
+    // Driver packages are loaded via optional, lazy `await import('@objectstack/driver-*')`
+    // (default-datasource-driver-factory) — and pull in optional native clients
+    // (mysql / pg / better-sqlite3 / mongodb). They must stay EXTERNAL so esbuild
+    // never tries to bundle/resolve those optional natives. (They are devDeps for
+    // tests; previously they were optional peerDeps, which tsup auto-externalized.)
+    external: ['vitest', /^@objectstack\/driver-/],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1279,13 +1279,6 @@ importers:
       '@objectstack/core':
         specifier: workspace:*
         version: link:../../core
-      '@objectstack/spec':
-        specifier: workspace:*
-        version: link:../../spec
-      '@objectstack/types':
-        specifier: workspace:*
-        version: link:../../types
-    devDependencies:
       '@objectstack/driver-memory':
         specifier: workspace:^
         version: link:../driver-memory
@@ -1313,6 +1306,13 @@ importers:
       '@objectstack/service-i18n':
         specifier: workspace:^
         version: link:../../services/service-i18n
+      '@objectstack/spec':
+        specifier: workspace:*
+        version: link:../../spec
+      '@objectstack/types':
+        specifier: workspace:*
+        version: link:../../types
+    devDependencies:
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1


### PR DESCRIPTION
## What

Unbreaks `main`: #1524 (the fixed-group major-cascade fix) moved optional internal `@objectstack/*` peerDependencies off `peer`, after which tsup stopped auto-externalizing them and began **bundling** the lazily `await import()`-ed driver packages — pulling in their optional native clients (`mysql` / `oracledb` via `knex`) and failing the build for `service-datasource` and `plugin-dev`.

## Fix

- **service-datasource**: externalize `@objectstack/driver-*` in tsup (drivers stay devDeps for tests, never bundled — preserves their optionality).
- **plugin-dev**: move framework packages from devDeps to `dependencies` (tsup auto-externalizes deps; dev-only plugin, so hard deps are fine).

Neither re-introduces the major cascade (regular deps/devDeps don't cascade; only peerDeps did).

## Verification

Full `pnpm build` **71/71 green**; `changeset status` still **0 major** (next release 7.6.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
