### PR TITLE
docs(agents): codify merge/worktree discipline + shared read-only permission allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__Claude_Preview__preview_screenshot",
+      "mcp__Claude_Preview__preview_network",
+      "mcp__Claude_Preview__preview_console_logs",
+      "mcp__Claude_Preview__preview_snapshot",
+      "mcp__Claude_Preview__preview_list",
+      "mcp__Claude_Preview__preview_logs",
+      "mcp__chrome-devtools__take_snapshot",
+      "mcp__chrome-devtools__take_screenshot",
+      "mcp__chrome-devtools__list_pages",
+      "mcp__chrome-devtools__list_console_messages",
+      "mcp__chrome-devtools__list_network_requests",
+      "mcp__Claude_in_Chrome__read_network_requests",
+      "mcp__Claude_in_Chrome__get_page_text",
+      "mcp__Claude_in_Chrome__find",
+      "mcp__Claude_in_Chrome__read_console_messages",
+      "mcp__Claude_in_Chrome__list_connected_browsers",
+      "Bash(agent-browser snapshot *)",
+      "Bash(agent-browser skills *)"
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # ObjectStack — AGENTS.md
 
-Primary AI instruction file for this repo. Mirrored at `.github/copilot-instructions.md` — keep both in sync.
+Primary AI instruction file for this repo. Read natively by Claude Code, GitHub Copilot (coding agent + CLI, since Aug 2025), and other agents — no separate `.github/copilot-instructions.md` mirror needed.
 
 > **v5.0 breaking rename: `project` → `environment`** everywhere (CLI `-e`, `/api/v1/environments/:id`, header `X-Environment-Id`, `OS_ENVIRONMENT_ID`, DB column `environment_id`). No aliases. See ADR-0006. "Project" now only means the npm/monorepo sense.
 
@@ -63,9 +63,12 @@ Other scripts: `objectui:bump` (pull only), `objectui:build`, `objectui:clean`. 
 
 ## Multi-agent working discipline
 
-This repo is worked on by **multiple agents in parallel**. Branches get switched
-and shared files change *under you* mid-task — this is expected, not a bug.
-Operate defensively:
+This repo is worked on by **multiple agents in parallel**. Prefer **one git
+worktree per agent/task** (`git worktree add ../framework-<task> -b <branch>`;
+run `pnpm install` in the new tree) so file systems are physically isolated —
+that avoids most of the contention below. When agents must share one working
+tree, branches get switched and shared files change *under you* mid-task — this
+is expected, not a bug. Operate defensively:
 
 1. **Only touch the files your task needs.** Don't "fix" unrelated diffs,
    reverts, or other agents' in-flight edits, and don't try to manage the whole
@@ -84,6 +87,10 @@ Operate defensively:
    your working-tree change between the edit and the commit. On a real conflict,
    re-apply only *your* lines and let the PR merge integrate the rest.
 6. **Don't rebase or force-update shared branches** to tidy other agents' commits.
+7. **Merge only after remote CI is fully green. Never `gh pr merge --auto`.**
+   Auto-merge can land a still-red PR onto shared `main` and break it for every
+   parallel agent (see #1475). Merge serially; rebase other open branches before
+   merging the next one.
 
 ---
 


### PR DESCRIPTION
## What

Two small, agent-facing housekeeping changes for parallel multi-agent work.

### `AGENTS.md`
- **Drop the stale `.github/copilot-instructions.md` mirror instruction.** That file doesn't exist in the repo, and GitHub Copilot (coding agent + CLI, since Aug 2025) reads `AGENTS.md` natively as primary instructions — no mirror needed. AGENTS.md is now the single source of truth for Claude Code / Copilot / etc.
- **Prefer one git worktree per agent/task** for physical isolation; the existing defensive rules are reframed as the shared-working-tree fallback.
- **New rule #7 — merge only after remote CI is fully green; never `gh pr merge --auto`.** Auto-merge can land a still-red PR onto shared `main` and break it for every parallel agent (see #1475).

### `.claude/settings.json` (new, committed/shared)
Read-only permission allowlist derived from recent transcript usage so parallel agents prompt less. Covers browser/preview **observation** tools (screenshot / snapshot / logs / network / list) plus `agent-browser snapshot|skills`.

Deliberately **excludes**:
- mutating / arbitrary-exec calls — `preview_eval`, `preview_click`/`fill`/`start`/`stop`, `pnpm`, `node`, `npx`
- anything Claude Code already auto-allows — git/gh read-only subcommands, `grep`, `cat`, `ls`, …

`.claude/settings.local.json` (gitignored, per-machine) is untouched.

## Notes
- Docs/config only — no changeset required.
- `examples/app-showcase/objectstack.config.ts` was already modified in the working tree by other in-flight work and is intentionally **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)