### PR TITLE
fix: AI-built apps usable immediately — table sync on publish + valid kanban config

### DIFF
--- a/.changeset/publish-object-table-sync-and-kanban-groupby.md
+++ b/.changeset/publish-object-table-sync-and-kanban-groupby.md
@@ -1,0 +1,13 @@
+---
+'@objectstack/objectql': minor
+'@objectstack/spec': minor
+'@objectstack/service-ai': minor
+---
+
+fix: AI-built apps are usable immediately — sync new object tables on publish + emit valid kanban config
+
+Two gaps found by end-to-end testing of an AI-built app:
+
+1. **A freshly-published object couldn't accept records until a server restart.** Publishing a drafted object registered it in the in-memory registry but never created its physical table (table sync only ran at boot), so inserts failed with `object_not_found` ("no such table"). Added `ObjectQL.syncObjectSchema(name)` (a targeted, idempotent single-object schema sync) and call it from the publish paths (`protocol.publishMetaItem` and `saveMetaItem` mode:'publish', via `ensureObjectStorage`). Best-effort + non-fatal. New objects are now CRUD-able the moment they're published.
+
+2. **AI-generated kanban views rendered as plain lists** (and sometimes failed validation). The blueprint `viewBody` emitted `list.type:'kanban'` with no `kanban` config; `KanbanConfigSchema` requires `groupByField` **and** `columns`. Added an optional `groupBy` to the blueprint view schema (lenient + strict) and have `apply_blueprint` set `list.kanban = { groupByField, columns }` — using the view's explicit `groupBy` when given, else inferring the object's first `select` field. AI-built kanban views now validate, publish, and carry a real group-by field.

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -2344,6 +2344,24 @@ export class ObjectQL implements IDataEngine {
   }
 
   /**
+   * Sync a SINGLE object's physical storage (create/alter its table) on
+   * demand. Boot-time {@link syncSchemas} runs once at startup, so an object
+   * that becomes live at runtime (e.g. publishing a drafted object) has a
+   * registry entry but no table — data CRUD then fails with "no such table"
+   * until the next restart. Calling this right after the object is registered
+   * makes it immediately usable. Idempotent: the SQL driver only creates the
+   * table when absent (and alters to add new columns).
+   */
+  async syncObjectSchema(objectName: string): Promise<void> {
+    const obj = this._registry.getObject(objectName) as any;
+    if (!obj) return;
+    const driver = this.getDriverForObject(objectName);
+    if (!driver || typeof (driver as any).syncSchema !== 'function') return;
+    const tableName = StorageNameMapping.resolveTableName(obj);
+    await (driver as any).syncSchema(tableName, obj);
+  }
+
+  /**
    * Get a registered driver by datasource name.
    * Alias matching @objectql/core datasource() API.
    *

--- a/packages/objectql/src/protocol.ts
+++ b/packages/objectql/src/protocol.ts
@@ -3189,6 +3189,25 @@ export class ObjectStackProtocolImplementation implements ObjectStackProtocol {
         }
     }
 
+    /**
+     * Ensure a just-PUBLISHED object's physical table exists so it is usable
+     * for data CRUD immediately — without a server restart. Registering the
+     * object (above) only updates the in-memory registry; the table is created
+     * by the driver's schema sync, which otherwise only runs at boot. Without
+     * this, inserting into a freshly-published object fails with "no such
+     * table" (surfaced as `object_not_found`) until the next restart.
+     * Best-effort + non-fatal: drivers without DDL (or read-only datasources)
+     * simply no-op, and a sync failure must not abort the publish.
+     */
+    private async ensureObjectStorage(type: string, name: string): Promise<void> {
+        if (type !== 'object' && type !== 'objects') return;
+        try {
+            await this.engine.syncObjectSchema(name);
+        } catch (err: any) {
+            console.warn(`[Protocol] table sync failed for object '${name}': ${err?.message ?? err}`);
+        }
+    }
+
     async saveMetaItem(request: { type: string, name: string, item?: any, organizationId?: string, parentVersion?: string | null, actor?: string, force?: boolean, mode?: 'draft' | 'publish', packageId?: string | null }) {
         if (!request.item) {
             throw new Error('Item data is required');
@@ -3437,6 +3456,7 @@ export class ObjectStackProtocolImplementation implements ObjectStackProtocol {
                 // object registry (would defeat the staging buffer).
                 if (mode === 'publish') {
                     this.applyObjectRegistryMutation(request);
+                    await this.ensureObjectStorage(request.type, request.name);
                 }
                 // ADR-0010 — success audit (best-effort).
                 await this.recordMetadataAudit({
@@ -3665,6 +3685,8 @@ export class ObjectStackProtocolImplementation implements ObjectStackProtocol {
                 name: request.name,
                 item: result.item.body,
             });
+            // Create the object's table now so it's CRUD-able without a restart.
+            await this.ensureObjectStorage(request.type, request.name);
             return {
                 success: true,
                 version: result.version,

--- a/packages/services/service-ai/src/__tests__/blueprint-tools.test.ts
+++ b/packages/services/service-ai/src/__tests__/blueprint-tools.test.ts
@@ -189,6 +189,33 @@ describe('apply_blueprint handler', () => {
     expect(view.list.columns).toEqual(['title']);
   });
 
+  it('emits kanban config (groupByField + columns) — explicit groupBy wins, else infers the select field', async () => {
+    const blueprint = {
+      summary: 'recruiting',
+      objects: [{
+        name: 'lead',
+        label: 'Lead',
+        fields: [
+          { name: 'name', label: 'Name', type: 'text' },
+          { name: 'stage', label: 'Stage', type: 'select', options: [{ label: 'New', value: 'new' }] },
+        ],
+      }],
+      views: [
+        { object: 'lead', name: 'lead_board', label: 'Board', type: 'kanban', columns: ['name', 'stage'] },
+        { object: 'lead', name: 'lead_board2', label: 'Board2', type: 'kanban', columns: ['name'], groupBy: 'stage' },
+      ],
+    };
+    await registry.execute(call('apply_blueprint', { blueprint }));
+
+    // Inferred from the object's first select field.
+    const inferred = drafts.get('view:lead_board') as any;
+    expect(inferred.list.type).toBe('kanban');
+    expect(inferred.list.kanban).toEqual({ groupByField: 'stage', columns: ['name', 'stage'] });
+    // Explicit groupBy on the view wins.
+    const explicit = drafts.get('view:lead_board2') as any;
+    expect(explicit.list.kanban.groupByField).toBe('stage');
+  });
+
   it('reports seed data as proposed-but-not-applied', async () => {
     const parsed = parse(await registry.execute(call('apply_blueprint', { blueprint: SAMPLE_BLUEPRINT })));
     expect(parsed.seedDataProposed).toEqual([{ object: 'project', rows: 2 }]);

--- a/packages/services/service-ai/src/tools/blueprint-tools.ts
+++ b/packages/services/service-ai/src/tools/blueprint-tools.ts
@@ -214,6 +214,7 @@ const LIST_TYPE: Record<string, string> = { list: 'grid', kanban: 'kanban', cale
 function viewBody(
   v: NonNullable<SolutionBlueprint['views']>[number],
   columnsByObject: Map<string, string[]>,
+  groupFieldByObject?: Map<string, string>,
 ): Record<string, unknown> {
   const cols = v.columns?.length ? v.columns : columnsByObject.get(v.object) ?? ['name'];
   const data = { provider: 'object', object: v.object };
@@ -227,14 +228,21 @@ function viewBody(
       ...(v.label ? { label: v.label } : {}),
     };
   }
-  return {
-    list: {
-      type: LIST_TYPE[v.type] ?? 'grid',
-      data,
-      columns: cols,
-      ...(v.label ? { label: v.label } : {}),
-    },
+  const list: Record<string, unknown> = {
+    type: LIST_TYPE[v.type] ?? 'grid',
+    data,
+    columns: cols,
+    ...(v.label ? { label: v.label } : {}),
   };
+  // A kanban board needs a group-by field to form its columns; without it the
+  // renderer falls back to a flat grid. Prefer the blueprint's explicit
+  // `groupBy`, else infer the object's first select/status field.
+  if (v.type === 'kanban') {
+    const groupByField = v.groupBy || groupFieldByObject?.get(v.object);
+    // KanbanConfig requires both the group-by field and the card columns.
+    if (groupByField) list.kanban = { groupByField, columns: cols };
+  }
+  return { list };
 }
 
 /** Convert a blueprint dashboard into a `dashboard` metadata body. */
@@ -384,12 +392,16 @@ function createApplyBlueprintHandler(ctx: BlueprintToolContext): ToolHandler {
 
     // Objects first (views/dashboards reference them).
     const columnsByObject = new Map<string, string[]>();
+    const groupFieldByObject = new Map<string, string>();
     for (const o of blueprint.objects ?? []) {
       columnsByObject.set(o.name, (o.fields ?? []).map((f) => f.name));
+      // Remember the first select field — the natural kanban group-by column.
+      const sel = (o.fields ?? []).find((f) => f.type === 'select');
+      if (sel) groupFieldByObject.set(o.name, sel.name);
       await record('object', o.name, objectBody(o));
     }
     for (const v of blueprint.views ?? []) {
-      await record('view', v.name, viewBody(v, columnsByObject));
+      await record('view', v.name, viewBody(v, columnsByObject, groupFieldByObject));
     }
     for (const d of blueprint.dashboards ?? []) {
       await record('dashboard', d.name, dashboardBody(d));

--- a/packages/spec/src/ai/solution-blueprint.zod.ts
+++ b/packages/spec/src/ai/solution-blueprint.zod.ts
@@ -58,6 +58,8 @@ export const BlueprintViewSchema = lazySchema(() => z.object({
   type: z.enum(['list', 'form', 'kanban', 'calendar']).default('list').describe('View kind'),
   columns: z.array(z.string().regex(SNAKE_CASE)).optional()
     .describe('Field names shown as columns (in order)'),
+  groupBy: z.string().regex(SNAKE_CASE).optional()
+    .describe('REQUIRED for kanban views: the select/status field whose options become the board columns (e.g. "stage", "status"). Without it a kanban renders as a plain list.'),
 }));
 export type BlueprintView = z.infer<typeof BlueprintViewSchema>;
 
@@ -184,6 +186,7 @@ const StrictView = z.object({
   label: z.string().nullable().describe('Human-readable view label, or null'),
   type: z.enum(['list', 'form', 'kanban', 'calendar']).nullable().describe('View kind, or null for list'),
   columns: z.array(z.string()).nullable().describe('Field names shown as columns, or null'),
+  groupBy: z.string().nullable().describe('REQUIRED for kanban: the select/status field whose options become the board columns (e.g. "stage"). Null for non-kanban views.'),
 });
 
 const StrictDashboard = z.object({


### PR DESCRIPTION
## Context

Found by testing a *complex* AI-built app (招聘管理 / ATS: 3 objects, lookups, a kanban) end-to-end as a real user. Two genuine gaps surfaced — the kind that make an AI-built app feel broken even though the metadata pipeline "succeeded".

## Fixes

### 1. A freshly-published object couldn't accept records until a server restart
Publishing a drafted object registered it in the in-memory registry but **never created its physical table** — table sync (`driver.syncSchema`) only ran at boot. So inserting into a just-published object failed with `object_not_found` ("no such table") until the next restart.

- Added `ObjectQL.syncObjectSchema(objectName)` — a targeted, idempotent single-object schema sync.
- New `protocol.ensureObjectStorage(type, name)` calls it after the registry mutation in **both** publish paths (`publishMetaItem` and `saveMetaItem` mode:`'publish'`). Best-effort + non-fatal.

**Verified live:** built an app via the AI, published it, created a record **with no restart** — previously this threw `object_not_found`.

### 2. AI-generated kanban views rendered as lists (and could fail validation)
`viewBody` emitted `list.type:'kanban'` with no `kanban` config. `KanbanConfigSchema` requires **both** `groupByField` and `columns`.

- Added an optional `groupBy` to the blueprint view schema (lenient + strict mirror).
- `apply_blueprint` now sets `list.kanban = { groupByField, columns }` — explicit `groupBy` when provided, else **inferred from the object's first `select` field**.

**Verified live:** an AI-built kanban app publishes the kanban view (4/4 artifacts) with `kanban: { groupByField: 'bug_state', columns: [...] }`.

## Tests
New blueprint-tools kanban test; full suites green: service-ai + objectql + spec/ai = **1108 passing**.

## Known follow-up (objectui, out of scope)
The console still renders the kanban as a list / doesn't surface AI views as tabs — a frontend renderer gap, now unblocked because the metadata is valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)