### PR TITLE
fix(ai): AI-authored views bind to their object + render (kanban as a board, not a list)

### DIFF
--- a/.changeset/ai-view-shape-binds-and-renders.md
+++ b/.changeset/ai-view-shape-binds-and-renders.md
@@ -1,0 +1,13 @@
+---
+'@objectstack/service-ai': patch
+---
+
+fix(ai): AI-authored views now bind to their object and render (kanban as a board, not a list)
+
+An AI-built app's views (including kanban) appeared only as the default list and never as selectable tabs. Diagnosis (vs the working showcase kanban) showed it was a **metadata-shape** bug in the blueprint's `viewBody`, not the renderer or skill: it emitted a bare `{ list: {…} }` fragment instead of the canonical view record. Three things were missing/wrong:
+
+- no top-level **`name`** → `getMetaItems` only surfaces overlay rows whose body has `name`, so every AI view was silently dropped from the object's view list;
+- no top-level **`object`** / **`viewKind`** → the console couldn't bind the view to its object;
+- the view name wasn't **`<object>.<key>`**-prefixed (the convention the console keys view tabs off).
+
+`viewBody` now emits `{ name: '<object>.<key>', object, viewKind: 'list'|'form', config: <ListView|FormView> }`, matching the shape the showcase's own views use (verified against the real `ViewSchema`). End-to-end verified: an AI-built kanban app surfaces 看板 + 列表 as tabs and renders the kanban as a board grouped by status.

--- a/packages/services/service-ai/src/__tests__/blueprint-tools.test.ts
+++ b/packages/services/service-ai/src/__tests__/blueprint-tools.test.ts
@@ -172,7 +172,8 @@ describe('apply_blueprint handler', () => {
     expect(parsed.drafted).toEqual([
       { type: 'object', name: 'project' },
       { type: 'object', name: 'task' },
-      { type: 'view', name: 'open_tasks' },
+      // View is named `<object>.<key>` so the console binds it to the object.
+      { type: 'view', name: 'task.open_tasks' },
     ]);
     expect(parsed.failed).toEqual([]);
 
@@ -183,10 +184,16 @@ describe('apply_blueprint handler', () => {
     // Object body expanded fields into a record keyed by name.
     const task = drafts.get('object:task') as any;
     expect(task.fields.project_id).toMatchObject({ type: 'lookup', reference: 'project' });
-    // View body became a list sub-view bound to the object.
-    const view = drafts.get('view:open_tasks') as any;
-    expect(view.list.data).toEqual({ provider: 'object', object: 'task' });
-    expect(view.list.columns).toEqual(['title']);
+    // View is the canonical record shape: top-level object + viewKind + config
+    // (NOT a bare `{ list }`), so the console can bind + render it.
+    const view = drafts.get('view:task.open_tasks') as any;
+    // Top-level name is REQUIRED — getMetaItems only surfaces overlay rows
+    // whose body carries `name`, so a nameless view never lists as a tab.
+    expect(view.name).toBe('task.open_tasks');
+    expect(view.object).toBe('task');
+    expect(view.viewKind).toBe('list');
+    expect(view.config.data).toEqual({ provider: 'object', object: 'task' });
+    expect(view.config.columns).toEqual(['title']);
   });
 
   it('emits kanban config (groupByField + columns) — explicit groupBy wins, else infers the select field', async () => {
@@ -208,12 +215,14 @@ describe('apply_blueprint handler', () => {
     await registry.execute(call('apply_blueprint', { blueprint }));
 
     // Inferred from the object's first select field.
-    const inferred = drafts.get('view:lead_board') as any;
-    expect(inferred.list.type).toBe('kanban');
-    expect(inferred.list.kanban).toEqual({ groupByField: 'stage', columns: ['name', 'stage'] });
+    const inferred = drafts.get('view:lead.lead_board') as any;
+    expect(inferred.object).toBe('lead');
+    expect(inferred.viewKind).toBe('list');
+    expect(inferred.config.type).toBe('kanban');
+    expect(inferred.config.kanban).toEqual({ groupByField: 'stage', columns: ['name', 'stage'] });
     // Explicit groupBy on the view wins.
-    const explicit = drafts.get('view:lead_board2') as any;
-    expect(explicit.list.kanban.groupByField).toBe('stage');
+    const explicit = drafts.get('view:lead.lead_board2') as any;
+    expect(explicit.config.kanban.groupByField).toBe('stage');
   });
 
   it('reports seed data as proposed-but-not-applied', async () => {
@@ -236,7 +245,7 @@ describe('apply_blueprint handler', () => {
     const parsed = parse(await registry.execute(call('apply_blueprint', { blueprint: SAMPLE_BLUEPRINT })));
     expect(parsed.drafted.map((d: any) => d.name)).toEqual(['project', 'task']);
     expect(parsed.failed).toHaveLength(1);
-    expect(parsed.failed[0]).toMatchObject({ type: 'view', name: 'open_tasks', code: 'invalid_metadata' });
+    expect(parsed.failed[0]).toMatchObject({ type: 'view', name: 'task.open_tasks', code: 'invalid_metadata' });
     // Partial success is still 'drafted' (some items landed).
     expect(parsed.status).toBe('drafted');
   });
@@ -263,8 +272,8 @@ describe('apply_blueprint handler', () => {
       views: [{ object: 'lead', name: 'all_leads', type: 'list' }],
     };
     await registry.execute(call('apply_blueprint', { blueprint: bp }));
-    const view = drafts.get('view:all_leads') as any;
-    expect(view.list.columns).toEqual(['name', 'email']);
+    const view = drafts.get('view:lead.all_leads') as any;
+    expect(view.config.columns).toEqual(['name', 'email']);
   });
 
   it('drafts the app (navigation shell) with explicit nav referencing the objects', async () => {

--- a/packages/services/service-ai/src/tools/blueprint-tools.ts
+++ b/packages/services/service-ai/src/tools/blueprint-tools.ts
@@ -210,7 +210,16 @@ function objectBody(o: SolutionBlueprint['objects'][number]): Record<string, unk
 /** Map a blueprint view's kind to a ListView `type`. */
 const LIST_TYPE: Record<string, string> = { list: 'grid', kanban: 'kanban', calendar: 'calendar' };
 
-/** Convert a blueprint view into a `view` metadata body (list- or form-family). */
+/**
+ * Convert a blueprint view into a `view` metadata RECORD (ADR-0005 view item).
+ *
+ * Emits the canonical single-view shape the console binds + renders:
+ *   `{ object, viewKind: 'list'|'form', config: <ListView|FormView> }`
+ * NOT the bare `{ list: … }` container fragment — without the top-level
+ * `object` (and the `<object>.<key>` record name set by {@link viewName}) the
+ * console can't associate the view with its object, so it never surfaces as a
+ * tab and a kanban silently falls back to the default grid.
+ */
 function viewBody(
   v: NonNullable<SolutionBlueprint['views']>[number],
   columnsByObject: Map<string, string[]>,
@@ -218,17 +227,25 @@ function viewBody(
 ): Record<string, unknown> {
   const cols = v.columns?.length ? v.columns : columnsByObject.get(v.object) ?? ['name'];
   const data = { provider: 'object', object: v.object };
+  // The body MUST carry a top-level `name` (the `<object>.<key>` record name):
+  // getMetaItems only surfaces overlay rows whose body has `name`, so a view
+  // without it is silently dropped from the object's view list (never a tab).
+  const name = viewName(v);
   if (v.type === 'form') {
     return {
-      form: {
+      name,
+      object: v.object,
+      viewKind: 'form',
+      config: {
         type: 'simple',
         data,
         sections: [{ fields: cols.map((field) => ({ field })) }],
+        ...(v.label ? { label: v.label } : {}),
       },
       ...(v.label ? { label: v.label } : {}),
     };
   }
-  const list: Record<string, unknown> = {
+  const config: Record<string, unknown> = {
     type: LIST_TYPE[v.type] ?? 'grid',
     data,
     columns: cols,
@@ -240,9 +257,24 @@ function viewBody(
   if (v.type === 'kanban') {
     const groupByField = v.groupBy || groupFieldByObject?.get(v.object);
     // KanbanConfig requires both the group-by field and the card columns.
-    if (groupByField) list.kanban = { groupByField, columns: cols };
+    if (groupByField) config.kanban = { groupByField, columns: cols };
   }
-  return { list };
+  return {
+    name,
+    object: v.object,
+    viewKind: 'list',
+    config,
+    ...(v.label ? { label: v.label } : {}),
+  };
+}
+
+/**
+ * Canonical view record name: `<object>.<key>` (e.g. `delivery_task.task_kanban`).
+ * The console keys an object's view tabs off this `<object>.` prefix, so a bare
+ * view name never appears as a selectable view on the object page.
+ */
+function viewName(v: NonNullable<SolutionBlueprint['views']>[number]): string {
+  return v.name.startsWith(`${v.object}.`) ? v.name : `${v.object}.${v.name}`;
 }
 
 /** Convert a blueprint dashboard into a `dashboard` metadata body. */
@@ -401,7 +433,7 @@ function createApplyBlueprintHandler(ctx: BlueprintToolContext): ToolHandler {
       await record('object', o.name, objectBody(o));
     }
     for (const v of blueprint.views ?? []) {
-      await record('view', v.name, viewBody(v, columnsByObject, groupFieldByObject));
+      await record('view', viewName(v), viewBody(v, columnsByObject, groupFieldByObject));
     }
     for (const d of blueprint.dashboards ?? []) {
       await record('dashboard', d.name, dashboardBody(d));


### PR DESCRIPTION
## Problem

An AI-built app's views — including a "kanban by status" — never appeared as selectable view tabs and always rendered as the default list. The user pointed out the **showcase's own kanban renders fine**, which ruled out the renderer.

## Diagnosis: metadata-shape bug in the blueprint's `viewBody` (not renderer, not skill)

Comparing the AI view to the working showcase view (`showcase_project.by_status`):

| | showcase (works) | AI (broken) |
|---|---|---|
| `name` | `showcase_project.by_status` | _missing_ |
| top-level `object` | `showcase_project` | _missing_ |
| top-level `viewKind` | `list` | _missing_ |
| config | under `config` | under `list` |

`viewBody` emitted a bare `{ list: {…} }` fragment. Three concrete failures:
1. **No top-level `name`** → `protocol.getMetaItems` only merges sys_metadata overlay rows whose body has `name` (protocol.ts ~L1188 `'name' in data`). Every AI view (always an overlay) was silently dropped from `getMetaItems({type:'view'})` → the object page's view list was empty → no tabs.
2. **No top-level `object` / `viewKind`** → the console can't bind the view to its object.
3. **Name not `<object>.<key>`-prefixed** → the convention the console keys an object's view tabs off.

## Fix

`viewBody` now emits the canonical view record (matching the showcase's own views):
```
{ name: '<object>.<key>', object, viewKind: 'list'|'form', config: <ListView|FormView> }
```
Validated against the real `ViewSchema` (`getMetadataTypeSchema('view')`).

## Verification (end-to-end, browser)

Built a fresh AI app with a "kanban by stage" view → published → opened the object page:
- `getMetaItems({type:'view'})` now lists `feature_req.feature_req_kanban` + `feature_req.feature_req_list` (was empty).
- The object page shows **view tabs** (需求看板 | 需求列表), and the kanban **renders as a board** grouped by stage (待评估/已排期/开发中/已上线/…) with cards — identical behaviour to the showcase kanban.

service-ai blueprint suite green (25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)