### PR TITLE
feat(runtime): MarketplaceProxyPlugin browse-only — drop the install 405 dead-end (ADR §5.2)

### DIFF
--- a/packages/runtime/src/cloud/marketplace-proxy-browse-only.test.ts
+++ b/packages/runtime/src/cloud/marketplace-proxy-browse-only.test.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * MarketplaceProxyPlugin is a BROWSE-ONLY mechanism (ADR §5.2): it forwards
+ * GET/HEAD marketplace reads and must NOT own install *policy*. Non-GET
+ * requests pass through (`next()`) so a host-supplied install route (mounted
+ * via the createObjectOSStack `extraPlugins` seam) can claim them — instead of
+ * the old 405 "install via cloud" dead-end (framework#1548).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { MarketplaceProxyPlugin } from './marketplace-proxy-plugin.js';
+
+/** Drive the plugin's kernel:ready wiring and capture the registered handler. */
+async function captureHandler(plugin: MarketplaceProxyPlugin) {
+    let handler: any;
+    let readyFn: any;
+    const rawApp = {
+        all: (_path: string, h: any) => { handler = h; },
+        get: () => {}, post: () => {}, head: () => {},
+    };
+    const ctx: any = {
+        hook: (ev: string, fn: any) => { if (ev === 'kernel:ready') readyFn = fn; },
+        getService: (name: string) => (name === 'http-server' ? { getRawApp: () => rawApp } : undefined),
+        logger: { info() {}, warn() {}, error() {} },
+    };
+    await plugin.start(ctx);
+    await readyFn();
+    return handler;
+}
+
+function fakeCtx(method: string, path: string) {
+    return {
+        req: {
+            url: `http://env.test${path}`,
+            method,
+            header: () => undefined,
+            raw: {},
+        },
+        json: (body: any, status: number) => ({ __status: status, __body: body }),
+    };
+}
+
+describe('MarketplaceProxyPlugin — browse-only (no install dead-end)', () => {
+    it('passes through a non-GET marketplace request (next()) instead of 405', async () => {
+        const plugin = new MarketplaceProxyPlugin({ controlPlaneUrl: 'http://cloud.test', cacheDisabled: true });
+        const handler = await captureHandler(plugin);
+        expect(typeof handler).toBe('function');
+
+        let nextCalled = false;
+        const result = await handler(
+            fakeCtx('POST', '/api/v1/marketplace/packages/pkg_1/install'),
+            async () => { nextCalled = true; return 'PASSED_THROUGH'; },
+        );
+
+        // The handler delegates to the next route rather than emitting a 405.
+        expect(nextCalled).toBe(true);
+        expect(result).toBe('PASSED_THROUGH');
+    });
+
+    it('still passes install-local through (owned by the local install plugin)', async () => {
+        const plugin = new MarketplaceProxyPlugin({ controlPlaneUrl: 'http://cloud.test', cacheDisabled: true });
+        const handler = await captureHandler(plugin);
+
+        let nextCalled = false;
+        await handler(
+            fakeCtx('POST', '/api/v1/marketplace/install-local'),
+            async () => { nextCalled = true; return 'LOCAL'; },
+        );
+        expect(nextCalled).toBe(true);
+    });
+
+    it('503s when no control plane is configured (unchanged behaviour)', async () => {
+        const plugin = new MarketplaceProxyPlugin({ controlPlaneUrl: 'off', cacheDisabled: true });
+        const handler = await captureHandler(plugin);
+        const result: any = await handler(fakeCtx('GET', '/api/v1/marketplace/packages'), async () => 'NEXT');
+        expect(result.__status).toBe(503);
+        expect(result.__body?.error?.code).toBe('marketplace_unavailable');
+    });
+});

--- a/packages/runtime/src/cloud/marketplace-proxy-plugin.ts
+++ b/packages/runtime/src/cloud/marketplace-proxy-plugin.ts
@@ -232,18 +232,20 @@ export class MarketplaceProxyPlugin implements Plugin {
                     // Preserve the full /api/v1/marketplace/... path on cloud.
                     const target = `${cloudUrl}${incomingUrl.pathname}${incomingUrl.search}`;
 
-                    // Forward only safe, idempotent methods. We intentionally
-                    // do NOT proxy POST / PUT / DELETE here — those would
-                    // need credentialled cloud auth which the tenant runtime
-                    // does not carry.
+                    // Browse-only mechanism: this plugin forwards only safe,
+                    // idempotent GET/HEAD (it carries no credentialled cloud
+                    // auth). It does NOT own install *policy* — that is a host
+                    // concern (ObjectStack Cloud supplies a credentialled
+                    // install route via the `extraPlugins` seam; see ADR
+                    // docs/design/cloud-account-binding-marketplace-install.md
+                    // §5.2). So instead of dead-ending non-GET with a 405
+                    // "install via cloud", we PASS THROUGH: a host-supplied
+                    // handler mounted after this plugin can claim the request;
+                    // if none does, the app returns its normal 404. This
+                    // removes the browse-only install dead-end (framework#1548)
+                    // without this plugin pretending to know install policy.
                     if (method !== 'GET' && method !== 'HEAD') {
-                        return c.json({
-                            success: false,
-                            error: {
-                                code: 'marketplace_method_not_allowed',
-                                message: `Marketplace proxy only forwards GET/HEAD; install via cloud.`,
-                            },
-                        }, 405);
+                        return next();
                     }
 
                     // Cache lookup. Key includes accept-language because


### PR DESCRIPTION
## What

Removes the framework's hardcoded marketplace **install-policy dead-end**. `MarketplaceProxyPlugin` is a **browse** mechanism — it forwards GET/HEAD reads and carries no credentialled cloud auth. It should not pretend to own install policy.

**Before:** a non-GET marketplace request returned `405 marketplace_method_not_allowed` — "install via cloud" — a dead-end the in-env Install button hit (framework#1548).

**After:** non-GET requests **pass through** (`next()`), so a host-supplied install route — mounted after this plugin via the `createObjectOSStack` **`extraPlugins`** seam (framework #1566) — can claim them. If none does, the app returns its normal 404 instead of a misleading policy 405.

## Why now

This is the **"remove framework's hardcoded policy"** half of [ADR §5.2](../blob/main/docs/design/cloud-account-binding-marketplace-install.md), deliberately deferred until **the cloud side landed + deployed**. It has:

- ObjectStack Cloud now owns install — the `/cloud-connection/install` route + `sys_package.install_package` action + the **tiered cloud-connection gate** (cloud PR #53, **merged + deployed to staging** ✅).
- The `extraPlugins` seam (framework #1566, merged) is how cloud supplies that install route to the runtime.

So the framework can now drop its browse-only install policy and keep only the neutral browse forwarder.

## Test
```
pnpm --filter @objectstack/runtime exec vitest run src/cloud/marketplace-proxy-browse-only.test.ts
# 3 passed: non-GET passes through (not 405); install-local still passes through; no-control-plane still 503s
```
Full `src/cloud` suite (40 tests) stays green.

## Sequencing note
Pairs with cloud PR #53 (binding + install gate, deployed) and framework #1566 (extraPlugins seam, merged). The remaining cloud-side follow-ups (bump `.framework-sha`; migrate `apps/objectos/objectstack.config.ts` from `config.plugins.push` to the `extraPlugins` seam) are tracked separately and don't block this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)