### PR TITLE
fix(runtime,cli): resolve optional capability packages from host app context

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1348,10 +1348,27 @@ export default class Serve extends Command {
         (p: any) => p.name === 'com.objectstack.service-ai'
             || p.constructor?.name === 'AIServicePlugin'
       );
+      // Resolve optional plugin packages from the HOST APP's context (the app
+      // being served declares them as deps — including private packages like
+      // @objectstack/service-ai-studio that the framework CLI itself does not
+      // depend on). A bare import would resolve relative to the CLI's location
+      // and miss a package linked into the app's node_modules. Falls back to a
+      // bare import for framework-owned packages.
+      const { createRequire: _createRequire } = await import('node:module');
+      const { pathToFileURL: _pathToFileURL } = await import('node:url');
+      const _nodePath = await import('node:path');
+      const _hostRequire = _createRequire(_nodePath.join(process.cwd(), 'package.json'));
+      const importFromHost = async (pkg: string): Promise<any> => {
+        try {
+          return await import(_pathToFileURL(_hostRequire.resolve(pkg)).href);
+        } catch {
+          return import(/* webpackIgnore: true */ pkg);
+        }
+      };
       if (!hasAIPlugin && tierEnabled('ai')) {
         try {
           const aiPkg = '@objectstack/service-ai';
-          const { AIServicePlugin } = await import(/* webpackIgnore: true */ aiPkg);
+          const { AIServicePlugin } = await importFromHost(aiPkg);
 
           // AIServicePlugin will auto-detect LLM provider from environment variables
           // (AI_GATEWAY_MODEL, OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY)
@@ -1379,7 +1396,7 @@ export default class Serve extends Command {
         if (!hasAIStudio) {
           try {
             const studioPkg = '@objectstack/service-ai-studio';
-            const { AIStudioPlugin } = await import(/* webpackIgnore: true */ studioPkg);
+            const { AIStudioPlugin } = await importFromHost(studioPkg);
             await kernel.use(new AIStudioPlugin());
             trackPlugin('AIStudio');
           } catch (err: unknown) {

--- a/packages/runtime/src/cloud/capability-loader.ts
+++ b/packages/runtime/src/cloud/capability-loader.ts
@@ -19,6 +19,33 @@
  */
 
 import type { ObjectKernel } from '@objectstack/core';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import { join } from 'node:path';
+
+/**
+ * Import an optional capability package, resolving it from the HOST APP's
+ * context first.
+ *
+ * The host app (a tenant runtime like apps/objectos, or an enterprise
+ * objectos-ee install) is what declares optional plugin packages — including
+ * private ones such as `@objectstack/service-ai-studio` that are NOT part of
+ * the framework's own dependency graph. A bare `import(pkg)` from this file
+ * resolves relative to the framework package's location, which cannot see a
+ * package linked into the *app's* node_modules (the failure surfaces as
+ * "Cannot find package … imported from …/framework/…"). Anchoring a
+ * `createRequire` at the app's cwd resolves it from the app's node_modules.
+ * Falls back to a bare import for framework-owned packages.
+ */
+async function importFromHost(pkg: string): Promise<any> {
+    try {
+        const req = createRequire(join(process.cwd(), 'package.json'));
+        const resolved = req.resolve(pkg);
+        return await import(pathToFileURL(resolved).href);
+    } catch {
+        return import(/* webpackIgnore: true */ pkg);
+    }
+}
 
 export interface CapabilitySpec {
     /** npm package name to import. */
@@ -161,7 +188,7 @@ export async function loadCapabilities(opts: LoadCapabilitiesOptions): Promise<s
         }
 
         try {
-            const mod: any = await import(/* webpackIgnore: true */ spec.pkg);
+            const mod: any = await importFromHost(spec.pkg);
             const Ctor = mod[spec.export];
             if (!Ctor) {
                 logger.warn?.(
@@ -187,7 +214,7 @@ export async function loadCapabilities(opts: LoadCapabilitiesOptions): Promise<s
             if (spec.extras) {
                 for (const ex of spec.extras) {
                     try {
-                        const exMod: any = await import(/* webpackIgnore: true */ ex.pkg);
+                        const exMod: any = await importFromHost(ex.pkg);
                         const ExCtor = exMod[ex.export];
                         if (ExCtor) {
                             await kernel.use(new ExCtor());


### PR DESCRIPTION
`loadCapabilities()` (per-environment kernels, apps/objectos) and the CLI `serve` auto-register both did a **bare** dynamic `import(pkg)` of optional capability packages. A bare specifier resolves relative to the **framework** package's own location, so a private/optional package linked into the **app's** `node_modules` — e.g. `@objectstack/service-ai-studio`, which the framework itself does not depend on — is invisible. It failed with `Cannot find package … imported from …/framework/…`, so **cloud tenants never actually loaded AI Studio** despite `apps/objectos` declaring the dependency (and the same for enterprise objectos-ee).

## Fix
Resolve via `createRequire` anchored at `process.cwd()` (the host app), import the resolved path, and fall back to a bare import for framework-owned packages.

- `packages/runtime/src/cloud/capability-loader.ts` — `importFromHost()` helper used for the main provider + extras.
- `packages/cli/src/commands/serve.ts` — same host-context resolution for the AI + AI Studio auto-register.

## Verified
- `createRequire(<app>/package.json).resolve('@objectstack/service-ai-studio')` → resolves to its `dist`; the old framework-relative resolution returns `MODULE_NOT_FOUND`.
- `runtime` + `cli` build clean.

Unblocks the cloud multi-tenant path for `@objectstack/service-ai-studio` (and any private capability package). Enterprise objectos-ee already works via explicit `plugins:[...]` registration; this makes the auto-discovery path correct too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)