### PR TITLE
Fix Studio metadata form i18n coverage

### DIFF
--- a/packages/cli/src/utils/i18n-coverage.ts
+++ b/packages/cli/src/utils/i18n-coverage.ts
@@ -259,9 +259,7 @@ function walkMetadataFormField(field: any, type: string, parentPath: string, out
   const name = typeof field.field === 'string' ? field.field : undefined;
   const path = name ? (parentPath ? `${parentPath}.${name}` : name) : parentPath;
   if (path) {
-    if (typeof field.label === 'string' && field.label.length > 0) {
-      pushKey(out, ['metadataForms', type, 'fields', path, 'label'], 'metadataForm', `Metadata form ${type}.fields.${path} label`);
-    }
+    pushKey(out, ['metadataForms', type, 'fields', path, 'label'], 'metadataForm', `Metadata form ${type}.fields.${path} label`);
     if (typeof field.helpText === 'string' && field.helpText.length > 0) {
       pushKey(out, ['metadataForms', type, 'fields', path, 'helpText'], 'metadataForm', `Metadata form ${type}.fields.${path} helpText`);
     }

--- a/packages/cli/src/utils/i18n-extract.ts
+++ b/packages/cli/src/utils/i18n-extract.ts
@@ -356,9 +356,10 @@ function walkFormField(field: any, type: string, parentPath: string, out: Expect
   const name = typeof field.field === 'string' ? field.field : undefined;
   const path = name ? (parentPath ? `${parentPath}.${name}` : name) : parentPath;
   if (path) {
-    if (typeof field.label === 'string' && field.label.length > 0) {
-      pushEntry(out, ['metadataForms', type, 'fields', path, 'label'], field.label, 'metadataFormField', { metadataType: type });
-    }
+    const label = typeof field.label === 'string' && field.label.length > 0
+      ? field.label
+      : humanizeFieldPath(path);
+    pushEntry(out, ['metadataForms', type, 'fields', path, 'label'], label, 'metadataFormField', { metadataType: type });
     if (typeof field.helpText === 'string' && field.helpText.length > 0) {
       pushEntry(out, ['metadataForms', type, 'fields', path, 'helpText'], field.helpText, 'metadataFormField', { metadataType: type });
     }
@@ -369,6 +370,15 @@ function walkFormField(field: any, type: string, parentPath: string, out: Expect
   if (Array.isArray(field.fields)) {
     for (const child of field.fields) walkFormField(child, type, path, out);
   }
+}
+
+/** Match the metadata form renderer's fallback label for fields without an explicit label. */
+function humanizeFieldPath(path: string): string {
+  const leaf = path.split('.').pop() ?? path;
+  return leaf
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 /**

--- a/packages/cli/test/i18n-coverage.test.ts
+++ b/packages/cli/test/i18n-coverage.test.ts
@@ -159,6 +159,7 @@ describe('computeI18nCoverage', () => {
     const objectSources = new Set(['object', 'field', 'option', 'view', 'action', 'globalAction']);
     expect(report.issues.filter((i) => objectSources.has(i.source))).toEqual([]);
     expect(report.totals.expectedKeys).toBeGreaterThan(0); // metadataForms baseline
+    expect(report.issues.some((i) => i.key === 'metadataForms.flow.fields.name.label')).toBe(true);
   });
 
   it('treats data.object as fallback for view objectName', () => {

--- a/packages/cli/test/i18n-extract.test.ts
+++ b/packages/cli/test/i18n-extract.test.ts
@@ -80,6 +80,7 @@ describe('collectExpectedEntries', () => {
     expect(paths).toContain('objects.sys_role._actions.merge.successMessage');
     expect(paths).toContain('globalActions.export_csv.label');
     expect(paths).toContain('globalActions.export_csv.successMessage');
+    expect(paths).toContain('metadataForms.flow.fields.name.label');
   });
 
   it('carries source values from the schema', () => {
@@ -89,6 +90,7 @@ describe('collectExpectedEntries', () => {
     expect(byPath['objects.sys_role.fields.status.options.on']).toBe('On');
     expect(byPath['objects.sys_role.fields.kind.options.internal']).toBe('Internal');
     expect(byPath['objects.sys_role._actions.merge.label']).toBe('Merge');
+    expect(byPath['metadataForms.flow.fields.name.label']).toBe('Name');
   });
 });
 

--- a/packages/platform-objects/src/apps/translations/en.metadata-forms.generated.ts
+++ b/packages/platform-objects/src/apps/translations/en.metadata-forms.generated.ts
@@ -31,156 +31,246 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
     },
     fields: {
       name: {
+        label: "Name",
         helpText: "snake_case unique identifier (immutable after creation)"
       },
       label: {
+        label: "Label",
         helpText: "Singular display name (e.g. \"Account\")"
       },
       pluralLabel: {
+        label: "Plural Label",
         helpText: "Plural display name (e.g. \"Accounts\")"
       },
       icon: {
+        label: "Icon",
         helpText: "Lucide icon name (e.g. \"building\", \"users\")"
       },
       description: {
+        label: "Description",
         helpText: "Developer documentation"
       },
       tags: {
+        label: "Tags",
         helpText: "Categorization tags (e.g. \"sales\", \"system\")"
       },
       active: {
+        label: "Active",
         helpText: "Is the object active and usable"
       },
       isSystem: {
+        label: "Is System",
         helpText: "System object (protected from deletion)"
       },
       abstract: {
+        label: "Abstract",
         helpText: "Abstract base (cannot be instantiated)"
       },
       fields: {
+        label: "Fields",
         helpText: "Add the columns this object will store"
       },
       "fields.label": {
+        label: "Label",
         helpText: "Display label"
       },
       "fields.type": {
+        label: "Type",
         helpText: "Field type"
       },
       "fields.description": {
+        label: "Description",
         helpText: "Developer documentation for this column"
       },
       "fields.required": {
+        label: "Required",
         helpText: "Must be set on every record"
       },
       "fields.unique": {
+        label: "Unique",
         helpText: "Disallow duplicate values"
       },
       "fields.indexed": {
+        label: "Indexed",
         helpText: "Create a database index for faster querying"
       },
       "fields.readonly": {
+        label: "Readonly",
         helpText: "Visible but never user-editable"
       },
       "fields.immutable": {
+        label: "Immutable",
         helpText: "Editable on create, locked thereafter"
       },
       "fields.hidden": {
+        label: "Hidden",
         helpText: "Hidden from default UI"
       },
       "fields.searchable": {
+        label: "Searchable",
         helpText: "Include in full-text search"
       },
       "fields.sortable": {
+        label: "Sortable",
         helpText: "Allow sorting on this column"
       },
       "fields.filterable": {
+        label: "Filterable",
         helpText: "Allow filtering on this column"
       },
       "fields.defaultValue": {
+        label: "Default Value",
         helpText: "Default value for new records (JSON literal)"
       },
       "fields.placeholder": {
+        label: "Placeholder",
         helpText: "Placeholder hint"
       },
       "fields.maxLength": {
+        label: "Max Length",
         helpText: "Max characters"
       },
       "fields.minLength": {
+        label: "Min Length",
         helpText: "Min characters"
       },
       "fields.min": {
+        label: "Min",
         helpText: "Minimum value"
       },
       "fields.max": {
+        label: "Max",
         helpText: "Maximum value"
       },
       "fields.precision": {
+        label: "Precision",
         helpText: "Total digits"
       },
       "fields.scale": {
+        label: "Scale",
         helpText: "Decimal places"
       },
       "fields.options": {
+        label: "Options",
         helpText: "Available choices"
       },
+      "fields.options.label": {
+        label: "Label"
+      },
+      "fields.options.value": {
+        label: "Value"
+      },
+      "fields.options.color": {
+        label: "Color"
+      },
       "fields.options.icon": {
+        label: "Icon",
         helpText: "Lucide icon name"
       },
+      "fields.options.description": {
+        label: "Description"
+      },
       "fields.reference": {
+        label: "Reference",
         helpText: "Target object (for lookup/master_detail)"
       },
       "fields.referenceFilter": {
+        label: "Reference Filter",
         helpText: "CEL filter applied to the picker"
       },
       "fields.cascadeDelete": {
+        label: "Cascade Delete",
         helpText: "Delete children when parent is deleted"
       },
       "fields.multiple": {
+        label: "Multiple",
         helpText: "Allow selecting multiple records"
       },
       "fields.formula": {
+        label: "Formula",
         helpText: "CEL formula expression"
       },
       "fields.returnType": {
+        label: "Return Type",
         helpText: "Result type for formulas"
       },
       "fields.summaryType": {
+        label: "Summary Type",
         helpText: "Aggregation"
       },
       "fields.summaryField": {
+        label: "Summary Field",
         helpText: "Field on child object to aggregate"
       },
       "fields.displayFormat": {
+        label: "Display Format",
         helpText: "e.g. \"INV-{0000}\""
       },
       "fields.startingNumber": {
+        label: "Starting Number",
         helpText: "Starting sequence value"
       },
       "fields.language": {
+        label: "Language",
         helpText: "Editor language (e.g. sql, javascript)"
       },
       "fields.validation": {
+        label: "Validation",
         helpText: "CEL predicate — must evaluate true"
       },
       "fields.errorMessage": {
+        label: "Error Message",
         helpText: "Shown when validation fails"
       },
       "fields.audit": {
+        label: "Audit",
         helpText: "Audit changes to this field"
       },
       "fields.trackHistory": {
+        label: "Track History",
         helpText: "Keep change history"
       },
       "fields.pii": {
+        label: "Pii",
         helpText: "Personally identifiable information"
       },
       "fields.encrypted": {
+        label: "Encrypted",
         helpText: "Encrypt at rest"
       },
       capabilities: {
+        label: "Capabilities",
         helpText: "Enable/disable system features"
       },
+      "capabilities.trackHistory": {
+        label: "Track History"
+      },
+      "capabilities.searchable": {
+        label: "Searchable"
+      },
+      "capabilities.apiEnabled": {
+        label: "Api Enabled"
+      },
+      "capabilities.files": {
+        label: "Files"
+      },
+      "capabilities.feeds": {
+        label: "Feeds"
+      },
+      "capabilities.activities": {
+        label: "Activities"
+      },
+      "capabilities.trash": {
+        label: "Trash"
+      },
+      "capabilities.mru": {
+        label: "Mru"
+      },
+      "capabilities.clone": {
+        label: "Clone"
+      },
       datasource: {
+        label: "Datasource",
         helpText: "Target datasource ID (default: \"default\")"
       }
     }
@@ -207,102 +297,135 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
     },
     fields: {
       name: {
+        label: "Name",
         helpText: "Unique identifier (snake_case, immutable after creation)"
       },
       label: {
+        label: "Label",
         helpText: "Display name for users"
       },
       type: {
+        label: "Type",
         helpText: "Data type of this field"
       },
       group: {
+        label: "Group",
         helpText: "Group name for form layout"
       },
       description: {
+        label: "Description",
         helpText: "Help text shown to users"
       },
       required: {
+        label: "Required",
         helpText: "User must provide a value"
       },
       unique: {
+        label: "Unique",
         helpText: "No two records can have the same value"
       },
       multiple: {
+        label: "Multiple",
         helpText: "Allow multiple values (for select/lookup)"
       },
       defaultValue: {
+        label: "Default Value",
         helpText: "Default value for new records"
       },
       minLength: {
+        label: "Min Length",
         helpText: "Minimum character length"
       },
       maxLength: {
+        label: "Max Length",
         helpText: "Maximum character length"
       },
       min: {
+        label: "Min",
         helpText: "Minimum value"
       },
       max: {
+        label: "Max",
         helpText: "Maximum value"
       },
       precision: {
+        label: "Precision",
         helpText: "Decimal places (e.g., 2 for $10.50)"
       },
       scale: {
+        label: "Scale",
         helpText: "Number of decimal digits"
       },
       options: {
+        label: "Options",
         helpText: "Available options (label/value pairs)"
       },
       reference: {
+        label: "Reference",
         helpText: "Referenced object name"
       },
       referenceFilters: {
+        label: "Reference Filters",
         helpText: "Filter expressions (e.g., \"active = true\")"
       },
       deleteBehavior: {
+        label: "Delete Behavior",
         helpText: "What happens when referenced record is deleted"
       },
       expression: {
+        label: "Expression",
         helpText: "CEL expression to calculate this field (makes it read-only)"
       },
       summaryOperations: {
+        label: "Summary Operations",
         helpText: "Roll-up summary configuration (for parent-child relationships)"
       },
       cached: {
+        label: "Cached",
         helpText: "Caching configuration for computed fields"
       },
       columnName: {
+        label: "Column Name",
         helpText: "Physical column name in database (defaults to field name)"
       },
       index: {
+        label: "Index",
         helpText: "Create database index for faster queries"
       },
       externalId: {
+        label: "External Id",
         helpText: "Mark as external ID for upsert operations"
       },
       readonly: {
+        label: "Readonly",
         helpText: "Field is read-only in forms"
       },
       hidden: {
+        label: "Hidden",
         helpText: "Hide field from default UI views"
       },
       searchable: {
+        label: "Searchable",
         helpText: "Include in global search results"
       },
       sortable: {
+        label: "Sortable",
         helpText: "Allow sorting lists by this field"
       },
       auditTrail: {
+        label: "Audit Trail",
         helpText: "Track detailed changes with user and timestamp"
       },
       trackFeedHistory: {
+        label: "Track Feed History",
         helpText: "Show changes in activity feed"
       },
       encryptionConfig: {
+        label: "Encryption Config",
         helpText: "Field-level encryption (GDPR/HIPAA/PCI-DSS)"
       },
       maskingRule: {
+        label: "Masking Rule",
         helpText: "Data masking rules for PII protection"
       }
     }
@@ -334,39 +457,60 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
     },
     fields: {
       name: {
+        label: "Name",
         helpText: "snake_case identifier (immutable after creation)"
       },
+      label: {
+        label: "Label"
+      },
+      description: {
+        label: "Description"
+      },
       object: {
+        label: "Object",
         helpText: "Target object name (or \"*\" for global)"
       },
       events: {
+        label: "Events",
         helpText: "Lifecycle events (e.g. beforeInsert, afterUpdate)"
       },
       priority: {
+        label: "Priority",
         helpText: "Lower numbers run first"
       },
       body: {
+        label: "Body",
         helpText: "Either an L1 expression or an L2 sandboxed JS body"
       },
       "body.language": {
+        label: "Language",
         helpText: "expression = pure formula; js = sandboxed JavaScript"
       },
       "body.source": {
+        label: "Source",
         helpText: "Function body source — no top-level imports"
       },
       "body.capabilities": {
+        label: "Capabilities",
         helpText: "Allowed ctx APIs (api.read, api.write, crypto.uuid, log, …)"
       },
       "body.timeoutMs": {
+        label: "Timeout Ms",
         helpText: "Per-invocation timeout (ms)"
       },
       handler: {
+        label: "Handler",
         helpText: "Handler function name (deprecated — prefer `body`)"
       },
       async: {
+        label: "Async",
         helpText: "Run in background, do not block the transaction"
       },
+      onError: {
+        label: "On Error"
+      },
       condition: {
+        label: "Condition",
         helpText: "Optional formula — skip the hook when this evaluates to false"
       }
     }
@@ -417,28 +561,87 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
     },
     fields: {
       name: {
+        label: "Name",
         helpText: "snake_case, unique per environment"
       },
+      label: {
+        label: "Label"
+      },
+      description: {
+        label: "Description"
+      },
       type: {
+        label: "Type",
         helpText: "Primary view surface"
       },
       data: {
+        label: "Data",
         helpText: "Data source — e.g. {\"provider\":\"object\",\"object\":\"task\"}"
       },
       columns: {
+        label: "Columns",
         helpText: "Columns to display (field names from selected object)"
       },
       filter: {
+        label: "Filter",
         helpText: "Filter conditions"
       },
       sort: {
+        label: "Sort",
         helpText: "Default sort order"
       },
       searchableFields: {
+        label: "Searchable Fields",
         helpText: "Field names available for quick search"
       },
       filterableFields: {
+        label: "Filterable Fields",
         helpText: "Field names available for filtering"
+      },
+      resizable: {
+        label: "Resizable"
+      },
+      striped: {
+        label: "Striped"
+      },
+      bordered: {
+        label: "Bordered"
+      },
+      compactToolbar: {
+        label: "Compact Toolbar"
+      },
+      rowHeight: {
+        label: "Row Height"
+      },
+      selection: {
+        label: "Selection"
+      },
+      pagination: {
+        label: "Pagination"
+      },
+      kanban: {
+        label: "Kanban"
+      },
+      calendar: {
+        label: "Calendar"
+      },
+      gantt: {
+        label: "Gantt"
+      },
+      gallery: {
+        label: "Gallery"
+      },
+      timeline: {
+        label: "Timeline"
+      },
+      chart: {
+        label: "Chart"
+      },
+      navigation: {
+        label: "Navigation"
+      },
+      sharing: {
+        label: "Sharing"
       }
     }
   },
@@ -464,42 +667,55 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
     },
     fields: {
       name: {
+        label: "Name",
         helpText: "Unique identifier (snake_case)"
       },
       label: {
+        label: "Label",
         helpText: "Page title shown to users"
       },
       icon: {
+        label: "Icon",
         helpText: "Icon for navigation menu"
       },
       type: {
+        label: "Type",
         helpText: "Page type (record, home, app, dashboard, etc.)"
       },
       template: {
+        label: "Template",
         helpText: "Layout template (e.g., \"header-sidebar-main\")"
       },
       description: {
+        label: "Description",
         helpText: "Page description for navigation"
       },
       object: {
+        label: "Object",
         helpText: "Bound object (for Record pages)"
       },
       variables: {
+        label: "Variables",
         helpText: "Local page state variables"
       },
       regions: {
+        label: "Regions",
         helpText: "Layout regions (header, main, sidebar, footer) with components"
       },
       isDefault: {
+        label: "Is Default",
         helpText: "Set as default page for this page type"
       },
       kind: {
+        label: "Kind",
         helpText: "Page override mode: full or slotted (for record pages)"
       },
       assignedProfiles: {
+        label: "Assigned Profiles",
         helpText: "Profiles that can access this page"
       },
       aria: {
+        label: "Aria",
         helpText: "Accessibility attributes (ARIA labels, roles)"
       }
     }
@@ -530,36 +746,50 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
     },
     fields: {
       name: {
+        label: "Name",
         helpText: "snake_case unique identifier"
       },
       label: {
+        label: "Label",
         helpText: "Display name"
       },
+      description: {
+        label: "Description"
+      },
       columns: {
+        label: "Columns",
         helpText: "Grid columns (default 12)"
       },
       gap: {
+        label: "Gap",
         helpText: "Grid gap (Tailwind units)"
       },
       refreshInterval: {
+        label: "Refresh Interval",
         helpText: "Auto-refresh (seconds)"
       },
       header: {
+        label: "Header",
         helpText: "Dashboard header config (title, subtitle, actions)"
       },
       widgets: {
+        label: "Widgets",
         helpText: "Dashboard widgets with position and sizing"
       },
       dateRange: {
+        label: "Date Range",
         helpText: "Default date range selector"
       },
       globalFilters: {
+        label: "Global Filters",
         helpText: "Filters applied to all widgets"
       },
       aria: {
+        label: "Aria",
         helpText: "Accessibility labels"
       },
       performance: {
+        label: "Performance",
         helpText: "Caching and optimization config"
       }
     }
@@ -590,48 +820,75 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
     },
     fields: {
       name: {
+        label: "Name",
         helpText: "snake_case, unique"
       },
+      label: {
+        label: "Label"
+      },
+      description: {
+        label: "Description"
+      },
+      version: {
+        label: "Version"
+      },
       icon: {
+        label: "Icon",
         helpText: "Lucide icon name (e.g. \"users\", \"briefcase\")"
       },
+      active: {
+        label: "Active"
+      },
       isDefault: {
+        label: "Is Default",
         helpText: "Make this the default app for new users"
       },
       navigation: {
+        label: "Navigation",
         helpText: "Nav tree — recursive structure"
       },
       areas: {
+        label: "Areas",
         helpText: "Group items into collapsible areas"
       },
       homePageId: {
+        label: "Home Page Id",
         helpText: "Landing page when app opens"
       },
       mobileNavigation: {
+        label: "Mobile Navigation",
         helpText: "Bottom tab bar config for mobile"
       },
       objects: {
+        label: "Objects",
         helpText: "Object names this app exposes"
       },
       apis: {
+        label: "Apis",
         helpText: "API endpoint definitions"
       },
       defaultAgent: {
+        label: "Default Agent",
         helpText: "AI agent for the ambient assistant button"
       },
       branding: {
+        label: "Branding",
         helpText: "Primary/secondary colors, logo, theme"
       },
       requiredPermissions: {
+        label: "Required Permissions",
         helpText: "Permissions needed to access this app"
       },
       sharing: {
+        label: "Sharing",
         helpText: "Public/internal/restricted access control"
       },
       embed: {
+        label: "Embed",
         helpText: "iFrame embed configuration"
       },
       aria: {
+        label: "Aria",
         helpText: "Accessibility labels"
       }
     }
@@ -658,72 +915,95 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
     },
     fields: {
       name: {
+        label: "Name",
         helpText: "Unique identifier (snake_case)"
       },
       label: {
+        label: "Label",
         helpText: "Button text shown to users"
       },
       objectName: {
+        label: "Object Name",
         helpText: "Object this action belongs to (optional)"
       },
       icon: {
+        label: "Icon",
         helpText: "Lucide icon name (e.g., \"check\", \"x-circle\")"
       },
       type: {
+        label: "Type",
         helpText: "What happens when clicked"
       },
       variant: {
+        label: "Variant",
         helpText: "Button style (primary=blue, danger=red, ghost=transparent)"
       },
       target: {
+        label: "Target",
         helpText: "URL, flow name, or API endpoint to call"
       },
       method: {
+        label: "Method",
         helpText: "HTTP method (GET, POST, PUT, DELETE)"
       },
       body: {
+        label: "Body",
         helpText: "JavaScript code to execute"
       },
       params: {
+        label: "Params",
         helpText: "User input parameters (show form before executing)"
       },
       confirmText: {
+        label: "Confirm Text",
         helpText: "Confirmation message (e.g., \"Are you sure?\")"
       },
       successMessage: {
+        label: "Success Message",
         helpText: "Success message after completion"
       },
       refreshAfter: {
+        label: "Refresh After",
         helpText: "Refresh the list/page after action completes"
       },
       locations: {
+        label: "Locations",
         helpText: "Where to show this action (toolbar, row menu, etc.)"
       },
       component: {
+        label: "Component",
         helpText: "How to render (button, icon, menu item)"
       },
       visible: {
+        label: "Visible",
         helpText: "CEL expression: show only when condition is true"
       },
       disabled: {
+        label: "Disabled",
         helpText: "CEL expression: disable when condition is true"
       },
       shortcut: {
+        label: "Shortcut",
         helpText: "Keyboard shortcut (e.g., \"Ctrl+S\", \"Cmd+Enter\")"
       },
       bulkEnabled: {
+        label: "Bulk Enabled",
         helpText: "Allow applying to multiple selected records"
       },
       aiExposed: {
+        label: "Ai Exposed",
         helpText: "Allow AI agents to call this action"
       },
       recordIdParam: {
+        label: "Record Id Param",
         helpText: "Body parameter name for record ID"
       },
       recordIdField: {
+        label: "Record Id Field",
         helpText: "Field to use as record ID (default: \"id\")"
       },
       bodyShape: {
+        label: "Body Shape",
         helpText: "Request body structure (flat or nested)"
       }
     }
@@ -758,36 +1038,53 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
     },
     fields: {
       name: {
+        label: "Name",
         helpText: "snake_case unique identifier"
       },
+      label: {
+        label: "Label"
+      },
+      description: {
+        label: "Description"
+      },
       objectName: {
+        label: "Object Name",
         helpText: "Data source object"
       },
       type: {
+        label: "Type",
         helpText: "Report type: tabular/summary/matrix/joined"
       },
       columns: {
+        label: "Columns",
         helpText: "Columns to display in the report"
       },
       groupingsDown: {
+        label: "Groupings Down",
         helpText: "Row grouping levels"
       },
       groupingsAcross: {
+        label: "Groupings Across",
         helpText: "Column grouping levels (matrix only)"
       },
       blocks: {
+        label: "Blocks",
         helpText: "Join multiple objects (joined report only)"
       },
       filter: {
+        label: "Filter",
         helpText: "Report-level filters"
       },
       chart: {
+        label: "Chart",
         helpText: "Chart config (type, legend, colors)"
       },
       aria: {
+        label: "Aria",
         helpText: "Accessibility labels"
       },
       performance: {
+        label: "Performance",
         helpText: "Caching and optimization"
       }
     }
@@ -810,39 +1107,51 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
     },
     fields: {
       name: {
+        label: "Name",
         helpText: "Unique identifier (snake_case)"
       },
       label: {
+        label: "Label",
         helpText: "Display name for users"
       },
       type: {
+        label: "Type",
         helpText: "How the flow starts (autolaunched, record_change, schedule, screen, api)"
       },
       template: {
+        label: "Template",
         helpText: "Is this a reusable subflow (can be called from other flows)"
       },
       description: {
+        label: "Description",
         helpText: "What this flow does"
       },
       nodes: {
+        label: "Nodes",
         helpText: "⚠️ Consider using Flow Designer visual editor instead of JSON"
       },
       edges: {
+        label: "Edges",
         helpText: "Connections between nodes — use Flow Designer for easier editing"
       },
       variables: {
+        label: "Variables",
         helpText: "Flow variables (inputs/outputs)"
       },
       status: {
+        label: "Status",
         helpText: "Deployment status: draft → active → obsolete"
       },
       version: {
+        label: "Version",
         helpText: "Version number (auto-incremented)"
       },
       runAs: {
+        label: "Run As",
         helpText: "Execute as system (admin) or user (current user permissions)"
       },
       errorHandling: {
+        label: "Error Handling",
         helpText: "What to do when a node fails (fail, retry, continue)"
       }
     }
@@ -901,24 +1210,49 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
     },
     fields: {
       name: {
+        label: "Name",
         helpText: "Dotted snake_case (e.g. auth.password_reset, crm.welcome)"
       },
+      label: {
+        label: "Label"
+      },
+      category: {
+        label: "Category"
+      },
       locale: {
+        label: "Locale",
         helpText: "BCP-47 tag — e.g. en-US, zh-CN"
       },
+      description: {
+        label: "Description"
+      },
+      subject: {
+        label: "Subject"
+      },
+      bodyHtml: {
+        label: "Body Html"
+      },
+      bodyText: {
+        label: "Body Text"
+      },
       variables: {
+        label: "Variables",
         helpText: "List of variable names referenced in subject/body"
       },
       fromOverride: {
+        label: "From Override",
         helpText: "{ \"name\": \"Acme Sales\", \"address\": \"sales@acme.com\" }"
       },
       replyTo: {
+        label: "Reply To",
         helpText: "Reply-To email address"
       },
       active: {
+        label: "Active",
         helpText: "When unchecked, sendTemplate() returns TEMPLATE_INACTIVE."
       },
       isSystem: {
+        label: "Is System",
         helpText: "Built-in template; tenants may override but should not delete."
       }
     }
@@ -945,30 +1279,39 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
     },
     fields: {
       name: {
+        label: "Name",
         helpText: "Machine name (snake_case)"
       },
       label: {
+        label: "Label",
         helpText: "Display label for admins"
       },
       isProfile: {
+        label: "Is Profile",
         helpText: "Profile = base set assigned to users. Permission Set = additive grant."
       },
       systemPermissions: {
+        label: "System Permissions",
         helpText: "List of system capability keys"
       },
       objects: {
+        label: "Objects",
         helpText: "{ \"account\": { allowRead: true, allowEdit: true, ... } }"
       },
       fields: {
+        label: "Fields",
         helpText: "{ \"account.amount\": { readable: true, editable: false } }"
       },
       tabPermissions: {
+        label: "Tab Permissions",
         helpText: "{ \"app_crm\": \"visible\", \"app_admin\": \"hidden\" }"
       },
       rowLevelSecurity: {
+        label: "Row Level Security",
         helpText: "Array of RLS policies (see rls.zod.ts)"
       },
       contextVariables: {
+        label: "Context Variables",
         helpText: "Custom variables referenced in RLS predicates"
       }
     }
@@ -995,30 +1338,39 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
     },
     fields: {
       name: {
+        label: "Name",
         helpText: "Machine name (snake_case)"
       },
       label: {
+        label: "Label",
         helpText: "Display label for admins"
       },
       isProfile: {
+        label: "Is Profile",
         helpText: "Profile = base set assigned to users. Permission Set = additive grant."
       },
       systemPermissions: {
+        label: "System Permissions",
         helpText: "List of system capability keys"
       },
       objects: {
+        label: "Objects",
         helpText: "{ \"account\": { allowRead: true, allowEdit: true, ... } }"
       },
       fields: {
+        label: "Fields",
         helpText: "{ \"account.amount\": { readable: true, editable: false } }"
       },
       tabPermissions: {
+        label: "Tab Permissions",
         helpText: "{ \"app_crm\": \"visible\", \"app_admin\": \"hidden\" }"
       },
       rowLevelSecurity: {
+        label: "Row Level Security",
         helpText: "Array of RLS policies (see rls.zod.ts)"
       },
       contextVariables: {
+        label: "Context Variables",
         helpText: "Custom variables referenced in RLS predicates"
       }
     }
@@ -1033,10 +1385,18 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
     },
     fields: {
       name: {
+        label: "Name",
         helpText: "snake_case"
       },
+      label: {
+        label: "Label"
+      },
       parent: {
+        label: "Parent",
         helpText: "Parent role machine name (Reports To)"
+      },
+      description: {
+        label: "Description"
       }
     }
   },
@@ -1062,57 +1422,75 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
     },
     fields: {
       name: {
+        label: "Name",
         helpText: "Unique identifier (snake_case)"
       },
       label: {
+        label: "Label",
         helpText: "Display name (e.g., \"Sales Assistant\")"
       },
       role: {
+        label: "Role",
         helpText: "Agent persona (e.g., \"Customer Support Specialist\")"
       },
       avatar: {
+        label: "Avatar",
         helpText: "Avatar image URL"
       },
       active: {
+        label: "Active",
         helpText: "Enable/disable this agent"
       },
       instructions: {
+        label: "Instructions",
         helpText: "System prompt — tell the agent how to behave and what it can do"
       },
       model: {
+        label: "Model",
         helpText: "AI model configuration (provider, model name, temperature, etc.)"
       },
       planning: {
+        label: "Planning",
         helpText: "Autonomous reasoning configuration (strategy, max iterations, replan)"
       },
       memory: {
+        label: "Memory",
         helpText: "Memory management (short-term, long-term, reflection)"
       },
       lifecycle: {
+        label: "Lifecycle",
         helpText: "State machine defining conversation flow"
       },
       skills: {
+        label: "Skills",
         helpText: "Skill names (Agent→Skill→Tool architecture)"
       },
       tools: {
+        label: "Tools",
         helpText: "Direct tool references (legacy mode)"
       },
       knowledge: {
+        label: "Knowledge",
         helpText: "RAG knowledge access configuration"
       },
       visibility: {
+        label: "Visibility",
         helpText: "Scope: global, organization, or private"
       },
       access: {
+        label: "Access",
         helpText: "User IDs or role names who can chat with this agent"
       },
       permissions: {
+        label: "Permissions",
         helpText: "Required permissions to use this agent"
       },
       tenantId: {
+        label: "Tenant Id",
         helpText: "Restrict to specific organization ID"
       },
       guardrails: {
+        label: "Guardrails",
         helpText: "Safety rules and content policies"
       }
     }
@@ -1135,36 +1513,47 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
     },
     fields: {
       name: {
+        label: "Name",
         helpText: "Unique identifier (snake_case)"
       },
       label: {
+        label: "Label",
         helpText: "Display name for Studio UI"
       },
       description: {
+        label: "Description",
         helpText: "Tell AI when to use this tool — be specific!"
       },
       category: {
+        label: "Category",
         helpText: "Tool category (data, action, flow, integration, etc.)"
       },
       objectName: {
+        label: "Object Name",
         helpText: "Related object (if this tool operates on a specific object)"
       },
       active: {
+        label: "Active",
         helpText: "Enable/disable this tool"
       },
       builtIn: {
+        label: "Built In",
         helpText: "Platform built-in tool (vs user-defined)"
       },
       parameters: {
+        label: "Parameters",
         helpText: "Input parameters — define properties like: {name: {type: \"string\", description: \"...\"}}"
       },
       outputSchema: {
+        label: "Output Schema",
         helpText: "Output schema for validation (optional)"
       },
       requiresConfirmation: {
+        label: "Requires Confirmation",
         helpText: "Ask user to approve before executing (for destructive actions)"
       },
       permissions: {
+        label: "Permissions",
         helpText: "Required permissions to use this tool"
       }
     }
@@ -1191,30 +1580,39 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
     },
     fields: {
       name: {
+        label: "Name",
         helpText: "Unique identifier (snake_case)"
       },
       label: {
+        label: "Label",
         helpText: "Display name (e.g., \"Case Management\")"
       },
       description: {
+        label: "Description",
         helpText: "What this skill does"
       },
       active: {
+        label: "Active",
         helpText: "Enable/disable this skill"
       },
       instructions: {
+        label: "Instructions",
         helpText: "Instructions for AI — tell it how to use these tools together"
       },
       tools: {
+        label: "Tools",
         helpText: "Tool names (supports wildcard: action_*)"
       },
       triggerPhrases: {
+        label: "Trigger Phrases",
         helpText: "Natural language phrases that activate this skill"
       },
       triggerConditions: {
+        label: "Trigger Conditions",
         helpText: "Programmatic conditions (e.g., objectName == \"case\")"
       },
       permissions: {
+        label: "Permissions",
         helpText: "Required permissions to use this skill"
       }
     }

--- a/packages/platform-objects/src/apps/translations/en.ts
+++ b/packages/platform-objects/src/apps/translations/en.ts
@@ -108,6 +108,7 @@ export const en: TranslationData = {
       navigation: {
         group_overview: { label: 'Overview' },
         nav_metadata_directory: { label: 'All Metadata Types' },
+        nav_packages: { label: 'Packages' },
         group_data_model: { label: 'Data Model' },
         nav_objects: { label: 'Objects' },
         nav_validations: { label: 'Validations' },

--- a/packages/platform-objects/src/apps/translations/es-ES.metadata-forms.generated.ts
+++ b/packages/platform-objects/src/apps/translations/es-ES.metadata-forms.generated.ts
@@ -31,156 +31,246 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "Nombre",
         helpText: "Identificador único snake_case (inmutable tras la creación)"
       },
       label: {
+        label: "Etiqueta",
         helpText: "Nombre mostrado en singular (p. ej. \"Account\")"
       },
       pluralLabel: {
+        label: "Etiqueta plural",
         helpText: "Nombre mostrado en plural (p. ej. \"Accounts\")"
       },
       icon: {
+        label: "Icono",
         helpText: "Nombre de icono Lucide (p. ej. \"building\", \"users\")"
       },
       description: {
+        label: "Descripción",
         helpText: "Documentación para desarrolladores"
       },
       tags: {
+        label: "Etiquetas",
         helpText: "Etiquetas de categorización (p. ej. \"sales\", \"system\")"
       },
       active: {
+        label: "Activo",
         helpText: "Indica si el objeto está activo y usable"
       },
       isSystem: {
+        label: "Integrado del sistema",
         helpText: "Objeto de sistema (protegido contra eliminación)"
       },
       abstract: {
+        label: "Abstracto",
         helpText: "Base abstracta (no se puede instanciar)"
       },
       fields: {
+        label: "Campos",
         helpText: "Añade las columnas que almacenará este objeto"
       },
       "fields.label": {
+        label: "Etiqueta",
         helpText: "Etiqueta mostrada"
       },
       "fields.type": {
+        label: "Tipo",
         helpText: "Tipo de campo"
       },
       "fields.description": {
-        helpText: "Developer documentation for this column"
+        label: "Descripción",
+        helpText: "Documentación para desarrolladores de esta columna"
       },
       "fields.required": {
-        helpText: "Must be set on every record"
+        label: "Obligatorio",
+        helpText: "Debe estar definido en cada registro"
       },
       "fields.unique": {
-        helpText: "Disallow duplicate values"
+        label: "Único",
+        helpText: "No permite valores duplicados"
       },
       "fields.indexed": {
-        helpText: "Create a database index for faster querying"
+        label: "Indexado",
+        helpText: "Crea un índice de base de datos para consultas más rápidas"
       },
       "fields.readonly": {
-        helpText: "Visible but never user-editable"
+        label: "Solo lectura",
+        helpText: "Visible, pero nunca editable por usuarios"
       },
       "fields.immutable": {
-        helpText: "Editable on create, locked thereafter"
+        label: "Inmutable",
+        helpText: "Editable al crear; bloqueado después"
       },
       "fields.hidden": {
-        helpText: "Hidden from default UI"
+        label: "Oculto",
+        helpText: "Oculto en la UI predeterminada"
       },
       "fields.searchable": {
-        helpText: "Include in full-text search"
+        label: "Buscable",
+        helpText: "Incluir en búsqueda de texto completo"
       },
       "fields.sortable": {
-        helpText: "Allow sorting on this column"
+        label: "Ordenable",
+        helpText: "Permitir ordenar por esta columna"
       },
       "fields.filterable": {
-        helpText: "Allow filtering on this column"
+        label: "Filtrable",
+        helpText: "Permitir filtrar por esta columna"
       },
       "fields.defaultValue": {
-        helpText: "Default value for new records (JSON literal)"
+        label: "Valor predeterminado",
+        helpText: "Valor predeterminado para registros nuevos (literal JSON)"
       },
       "fields.placeholder": {
-        helpText: "Placeholder hint"
+        label: "Marcador",
+        helpText: "Texto de marcador"
       },
       "fields.maxLength": {
-        helpText: "Max characters"
+        label: "Longitud máxima",
+        helpText: "Máximo de caracteres"
       },
       "fields.minLength": {
-        helpText: "Min characters"
+        label: "Longitud mínima",
+        helpText: "Mínimo de caracteres"
       },
       "fields.min": {
-        helpText: "Minimum value"
+        label: "Mínimo",
+        helpText: "Valor mínimo"
       },
       "fields.max": {
-        helpText: "Maximum value"
+        label: "Máximo",
+        helpText: "Valor máximo"
       },
       "fields.precision": {
-        helpText: "Total digits"
+        label: "Precisión",
+        helpText: "Total de dígitos"
       },
       "fields.scale": {
-        helpText: "Decimal places"
+        label: "Decimales",
+        helpText: "Decimales"
       },
       "fields.options": {
-        helpText: "Available choices"
+        label: "Opciones",
+        helpText: "Opciones disponibles"
+      },
+      "fields.options.label": {
+        label: "Etiqueta"
+      },
+      "fields.options.value": {
+        label: "Valor"
+      },
+      "fields.options.color": {
+        label: "Color de opción"
       },
       "fields.options.icon": {
-        helpText: "Lucide icon name"
+        label: "Icono",
+        helpText: "Nombre de icono Lucide"
+      },
+      "fields.options.description": {
+        label: "Descripción"
       },
       "fields.reference": {
+        label: "Referencia",
         helpText: "Objeto de destino (para lookup/master_detail)"
       },
       "fields.referenceFilter": {
-        helpText: "CEL filter applied to the picker"
+        label: "Filtro de referencia",
+        helpText: "Filtro CEL aplicado al selector"
       },
       "fields.cascadeDelete": {
-        helpText: "Delete children when parent is deleted"
+        label: "Eliminación en cascada",
+        helpText: "Eliminar registros hijos cuando se elimine el padre"
       },
       "fields.multiple": {
-        helpText: "Allow selecting multiple records"
+        label: "Selección múltiple",
+        helpText: "Permitir seleccionar varios registros"
       },
       "fields.formula": {
-        helpText: "CEL formula expression"
+        label: "Fórmula",
+        helpText: "Expresión de fórmula CEL"
       },
       "fields.returnType": {
-        helpText: "Result type for formulas"
+        label: "Tipo de retorno",
+        helpText: "Tipo de resultado para fórmulas"
       },
       "fields.summaryType": {
-        helpText: "Aggregation"
+        label: "Tipo de resumen",
+        helpText: "Agregación"
       },
       "fields.summaryField": {
-        helpText: "Field on child object to aggregate"
+        label: "Campo de resumen",
+        helpText: "Campo del objeto hijo que se agregará"
       },
       "fields.displayFormat": {
-        helpText: "e.g. \"INV-{0000}\""
+        label: "Formato de visualización",
+        helpText: "p. ej. \"INV-{0000}\""
       },
       "fields.startingNumber": {
-        helpText: "Starting sequence value"
+        label: "Número inicial",
+        helpText: "Valor inicial de la secuencia"
       },
       "fields.language": {
-        helpText: "Editor language (e.g. sql, javascript)"
+        label: "Idioma",
+        helpText: "Lenguaje del editor (p. ej. sql, javascript)"
       },
       "fields.validation": {
-        helpText: "CEL predicate — must evaluate true"
+        label: "Validación",
+        helpText: "Predicado CEL; debe evaluar a true"
       },
       "fields.errorMessage": {
-        helpText: "Shown when validation fails"
+        label: "Mensaje de error",
+        helpText: "Se muestra cuando falla la validación"
       },
       "fields.audit": {
-        helpText: "Audit changes to this field"
+        label: "Auditoría",
+        helpText: "Auditar cambios en este campo"
       },
       "fields.trackHistory": {
-        helpText: "Keep change history"
+        label: "Seguimiento de historial",
+        helpText: "Conservar historial de cambios"
       },
       "fields.pii": {
-        helpText: "Personally identifiable information"
+        label: "Información personal",
+        helpText: "Información de identificación personal"
       },
       "fields.encrypted": {
-        helpText: "Encrypt at rest"
+        label: "Cifrado",
+        helpText: "Cifrar en reposo"
       },
       capabilities: {
+        label: "Capacidades",
         helpText: "Activa/desactiva funciones del sistema"
       },
+      "capabilities.trackHistory": {
+        label: "Seguimiento de historial"
+      },
+      "capabilities.searchable": {
+        label: "Buscable"
+      },
+      "capabilities.apiEnabled": {
+        label: "API activada"
+      },
+      "capabilities.files": {
+        label: "Archivos"
+      },
+      "capabilities.feeds": {
+        label: "Feed de actividad"
+      },
+      "capabilities.activities": {
+        label: "Actividades"
+      },
+      "capabilities.trash": {
+        label: "Papelera"
+      },
+      "capabilities.mru": {
+        label: "Uso reciente"
+      },
+      "capabilities.clone": {
+        label: "Clonar"
+      },
       datasource: {
+        label: "Fuente de datos",
         helpText: "ID de fuente de datos de destino (valor predeterminado: \"default\")"
       }
     }
@@ -207,102 +297,135 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "Nombre",
         helpText: "Identificador único (snake_case, inmutable tras la creación)"
       },
       label: {
+        label: "Etiqueta",
         helpText: "Nombre mostrado a los usuarios"
       },
       type: {
+        label: "Tipo",
         helpText: "Tipo de datos de este campo"
       },
       group: {
+        label: "Grupo",
         helpText: "Nombre de grupo para el diseño del formulario"
       },
       description: {
+        label: "Descripción",
         helpText: "Texto de ayuda mostrado a los usuarios"
       },
       required: {
+        label: "Obligatorio",
         helpText: "El usuario debe proporcionar un valor"
       },
       unique: {
+        label: "Único",
         helpText: "No puede haber dos registros con el mismo valor"
       },
       multiple: {
+        label: "Selección múltiple",
         helpText: "Permite varios valores (para select/lookup)"
       },
       defaultValue: {
+        label: "Valor predeterminado",
         helpText: "Valor predeterminado para registros nuevos"
       },
       minLength: {
+        label: "Longitud mínima",
         helpText: "Longitud mínima de caracteres"
       },
       maxLength: {
+        label: "Longitud máxima",
         helpText: "Longitud máxima de caracteres"
       },
       min: {
+        label: "Mínimo",
         helpText: "Valor mínimo"
       },
       max: {
+        label: "Máximo",
         helpText: "Valor máximo"
       },
       precision: {
+        label: "Precisión",
         helpText: "Decimales (p. ej., 2 para $10.50)"
       },
       scale: {
+        label: "Decimales",
         helpText: "Número de dígitos decimales"
       },
       options: {
+        label: "Opciones",
         helpText: "Opciones disponibles (pares label/value)"
       },
       reference: {
+        label: "Referencia",
         helpText: "Nombre del objeto referenciado"
       },
       referenceFilters: {
+        label: "Filtros de referencia",
         helpText: "Expresiones de filtro (p. ej., \"active = true\")"
       },
       deleteBehavior: {
+        label: "Comportamiento al eliminar",
         helpText: "Qué ocurre cuando se elimina el registro referenciado"
       },
       expression: {
+        label: "Expresión",
         helpText: "Expresión CEL para calcular este campo (lo hace de solo lectura)"
       },
       summaryOperations: {
+        label: "Operaciones de resumen",
         helpText: "Configuración de resumen roll-up (para relaciones padre-hijo)"
       },
       cached: {
+        label: "En caché",
         helpText: "Configuración de caché para campos calculados"
       },
       columnName: {
+        label: "Nombre de columna",
         helpText: "Nombre de columna física en la base de datos (por defecto, el nombre del campo)"
       },
       index: {
+        label: "Índice",
         helpText: "Crea un índice de base de datos para consultas más rápidas"
       },
       externalId: {
+        label: "ID externo",
         helpText: "Marca como ID externo para operaciones upsert"
       },
       readonly: {
+        label: "Solo lectura",
         helpText: "El campo es de solo lectura en formularios"
       },
       hidden: {
+        label: "Oculto",
         helpText: "Oculta el campo en las vistas UI predeterminadas"
       },
       searchable: {
+        label: "Buscable",
         helpText: "Incluye en los resultados de búsqueda global"
       },
       sortable: {
+        label: "Ordenable",
         helpText: "Permite ordenar listas por este campo"
       },
       auditTrail: {
+        label: "Rastro de auditoría",
         helpText: "Registra cambios detallados con usuario y marca temporal"
       },
       trackFeedHistory: {
+        label: "Historial de feed",
         helpText: "Muestra cambios en el feed de actividad"
       },
       encryptionConfig: {
+        label: "Configuración de cifrado",
         helpText: "Cifrado a nivel de campo (GDPR/HIPAA/PCI-DSS)"
       },
       maskingRule: {
+        label: "Regla de enmascaramiento",
         helpText: "Reglas de enmascaramiento de datos para protección de PII"
       }
     }
@@ -314,7 +437,7 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     label: "Regla de validación"
   },
   hook: {
-    label: "Hook",
+    label: "Gancho",
     sections: {
       identity: {
         label: "Identidad",
@@ -334,39 +457,60 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "Nombre",
         helpText: "Identificador snake_case (inmutable tras la creación)"
       },
+      label: {
+        label: "Etiqueta"
+      },
+      description: {
+        label: "Descripción"
+      },
       object: {
+        label: "Objeto",
         helpText: "Nombre del objeto de destino (o \"*\" para global)"
       },
       events: {
+        label: "Eventos",
         helpText: "Eventos de ciclo de vida (p. ej. beforeInsert, afterUpdate)"
       },
       priority: {
+        label: "Prioridad",
         helpText: "Los números menores se ejecutan primero"
       },
       body: {
+        label: "Cuerpo",
         helpText: "Una expresión L1 o un body JS L2 en sandbox"
       },
       "body.language": {
+        label: "Idioma",
         helpText: "expression = fórmula pura; js = JavaScript en sandbox"
       },
       "body.source": {
+        label: "Código fuente",
         helpText: "Código fuente del body de la función — sin imports de nivel superior"
       },
       "body.capabilities": {
+        label: "Capacidades",
         helpText: "API ctx permitidas (api.read, api.write, crypto.uuid, log, …)"
       },
       "body.timeoutMs": {
+        label: "Tiempo de espera (ms)",
         helpText: "Tiempo de espera por invocación (ms)"
       },
       handler: {
+        label: "Manejador",
         helpText: "Nombre de función manejadora (obsoleto — preferir `body`)"
       },
       async: {
+        label: "Asíncrono",
         helpText: "Ejecutar en segundo plano, sin bloquear la transacción"
       },
+      onError: {
+        label: "Al error"
+      },
       condition: {
+        label: "Condición",
         helpText: "Fórmula opcional — omite el hook cuando evalúa a false"
       }
     }
@@ -387,7 +531,7 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
         description: "Opciones de visualización solo de cuadrícula."
       },
       kanban: {
-        label: "Kanban",
+        label: "Tablero Kanban",
         description: "Configuración de tablero específica de Kanban."
       },
       calendar: {
@@ -395,7 +539,7 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
         description: "Configuración específica de calendario."
       },
       gantt: {
-        label: "Gantt",
+        label: "Diagrama de Gantt",
         description: "Configuración específica de Gantt."
       },
       gallery: {
@@ -417,28 +561,87 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "Nombre",
         helpText: "snake_case, único por environment"
       },
+      label: {
+        label: "Etiqueta"
+      },
+      description: {
+        label: "Descripción"
+      },
       type: {
+        label: "Tipo",
         helpText: "Superficie principal de la vista"
       },
       data: {
+        label: "Datos",
         helpText: "Fuente de datos — p. ej. {\"provider\":\"object\",\"object\":\"task\"}"
       },
       columns: {
+        label: "Columnas",
         helpText: "Columnas que mostrar (nombres de campo del objeto seleccionado)"
       },
       filter: {
+        label: "Filtro",
         helpText: "Condiciones de filtro"
       },
       sort: {
+        label: "Orden",
         helpText: "Orden predeterminado"
       },
       searchableFields: {
+        label: "Campos buscables",
         helpText: "Nombres de campo disponibles para búsqueda rápida"
       },
       filterableFields: {
+        label: "Campos filtrables",
         helpText: "Nombres de campo disponibles para filtrado"
+      },
+      resizable: {
+        label: "Redimensionable"
+      },
+      striped: {
+        label: "Con franjas"
+      },
+      bordered: {
+        label: "Con borde"
+      },
+      compactToolbar: {
+        label: "Barra compacta"
+      },
+      rowHeight: {
+        label: "Altura de fila"
+      },
+      selection: {
+        label: "Selección"
+      },
+      pagination: {
+        label: "Paginación"
+      },
+      kanban: {
+        label: "Configuración Kanban"
+      },
+      calendar: {
+        label: "Calendario"
+      },
+      gantt: {
+        label: "Configuración Gantt"
+      },
+      gallery: {
+        label: "Galería"
+      },
+      timeline: {
+        label: "Cronología"
+      },
+      chart: {
+        label: "Gráfico"
+      },
+      navigation: {
+        label: "Navegación"
+      },
+      sharing: {
+        label: "Compartición"
       }
     }
   },
@@ -464,42 +667,55 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "Nombre",
         helpText: "Identificador único (snake_case)"
       },
       label: {
+        label: "Etiqueta",
         helpText: "Título de página mostrado a los usuarios"
       },
       icon: {
+        label: "Icono",
         helpText: "Icono para el menú de navegación"
       },
       type: {
+        label: "Tipo",
         helpText: "Tipo de página (record, home, app, dashboard, etc.)"
       },
       template: {
+        label: "Plantilla",
         helpText: "Plantilla de diseño (p. ej., \"header-sidebar-main\")"
       },
       description: {
+        label: "Descripción",
         helpText: "Descripción de página para navegación"
       },
       object: {
+        label: "Objeto",
         helpText: "Objeto vinculado (para páginas Record)"
       },
       variables: {
+        label: "Variables de página",
         helpText: "Variables de estado local de página"
       },
       regions: {
+        label: "Regiones",
         helpText: "Regiones de diseño (header, main, sidebar, footer) con componentes"
       },
       isDefault: {
+        label: "Predeterminado",
         helpText: "Establece como página predeterminada para este tipo de página"
       },
       kind: {
+        label: "Modo",
         helpText: "Modo de anulación de página: full o slotted (para páginas record)"
       },
       assignedProfiles: {
+        label: "Perfiles asignados",
         helpText: "Perfiles que pueden acceder a esta página"
       },
       aria: {
+        label: "Accesibilidad",
         helpText: "Atributos de accesibilidad (etiquetas ARIA, roles)"
       }
     }
@@ -516,7 +732,7 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
         description: "Tamaño de cuadrícula y cadencia de actualización."
       },
       widgets: {
-        label: "Widgets",
+        label: "Widgets del panel",
         description: "Tarjetas y gráficos colocados en la cuadrícula."
       },
       filters: {
@@ -530,36 +746,50 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "Nombre",
         helpText: "Identificador único snake_case"
       },
       label: {
+        label: "Etiqueta",
         helpText: "Nombre mostrado"
       },
+      description: {
+        label: "Descripción"
+      },
       columns: {
+        label: "Columnas",
         helpText: "Columnas de cuadrícula (predeterminado 12)"
       },
       gap: {
+        label: "Separación",
         helpText: "Separación de cuadrícula (unidades Tailwind)"
       },
       refreshInterval: {
+        label: "Intervalo de actualización",
         helpText: "Actualización automática (segundos)"
       },
       header: {
+        label: "Encabezado",
         helpText: "Configuración de cabecera del panel (title, subtitle, actions)"
       },
       widgets: {
+        label: "Widgets del panel",
         helpText: "Widgets del panel con posición y tamaño"
       },
       dateRange: {
+        label: "Rango de fechas",
         helpText: "Selector predeterminado de intervalo de fechas"
       },
       globalFilters: {
+        label: "Filtros globales",
         helpText: "Filtros aplicados a todos los widgets"
       },
       aria: {
+        label: "Accesibilidad",
         helpText: "Etiquetas de accesibilidad"
       },
       performance: {
+        label: "Rendimiento",
         helpText: "Configuración de caché y optimización"
       }
     }
@@ -590,48 +820,75 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "Nombre",
         helpText: "snake_case, único"
       },
+      label: {
+        label: "Etiqueta"
+      },
+      description: {
+        label: "Descripción"
+      },
+      version: {
+        label: "Versión"
+      },
       icon: {
+        label: "Icono",
         helpText: "Nombre de icono Lucide (p. ej. \"users\", \"briefcase\")"
       },
+      active: {
+        label: "Activo"
+      },
       isDefault: {
+        label: "Predeterminado",
         helpText: "Convierte esta app en la predeterminada para usuarios nuevos"
       },
       navigation: {
+        label: "Navegación",
         helpText: "Árbol de navegación — estructura recursiva"
       },
       areas: {
+        label: "Áreas",
         helpText: "Agrupa elementos en áreas plegables"
       },
       homePageId: {
+        label: "ID de página inicial",
         helpText: "Página de inicio al abrir la app"
       },
       mobileNavigation: {
+        label: "Navegación móvil",
         helpText: "Configuración de barra de pestañas inferior para móvil"
       },
       objects: {
+        label: "Permisos de objeto",
         helpText: "Nombres de objeto que expone esta app"
       },
       apis: {
+        label: "API",
         helpText: "Definiciones de endpoints API"
       },
       defaultAgent: {
+        label: "Agente predeterminado",
         helpText: "Agente de IA para el botón de asistente ambiental"
       },
       branding: {
+        label: "Marca",
         helpText: "Colores primario/secundario, logotipo, tema"
       },
       requiredPermissions: {
+        label: "Permisos requeridos",
         helpText: "Permisos necesarios para acceder a esta app"
       },
       sharing: {
+        label: "Compartición",
         helpText: "Control de acceso público/interno/restringido"
       },
       embed: {
+        label: "Incrustación",
         helpText: "Configuración de incrustación iFrame"
       },
       aria: {
+        label: "Accesibilidad",
         helpText: "Etiquetas de accesibilidad"
       }
     }
@@ -658,72 +915,95 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "Nombre",
         helpText: "Identificador único (snake_case)"
       },
       label: {
+        label: "Etiqueta",
         helpText: "Texto de botón mostrado a los usuarios"
       },
       objectName: {
+        label: "Nombre de objeto",
         helpText: "Objeto al que pertenece esta acción (opcional)"
       },
       icon: {
+        label: "Icono",
         helpText: "Nombre de icono Lucide (p. ej., \"check\", \"x-circle\")"
       },
       type: {
+        label: "Tipo",
         helpText: "Qué ocurre al hacer clic"
       },
       variant: {
+        label: "Variante visual",
         helpText: "Estilo de botón (primary=blue, danger=red, ghost=transparent)"
       },
       target: {
+        label: "Destino",
         helpText: "URL, nombre de flujo o endpoint API que llamar"
       },
       method: {
+        label: "Método",
         helpText: "Método HTTP (GET, POST, PUT, DELETE)"
       },
       body: {
+        label: "Cuerpo",
         helpText: "Código JavaScript que ejecutar"
       },
       params: {
+        label: "Parámetros",
         helpText: "Parámetros de entrada de usuario (muestra el formulario antes de ejecutar)"
       },
       confirmText: {
+        label: "Texto de confirmación",
         helpText: "Mensaje de confirmación (p. ej., \"Are you sure?\")"
       },
       successMessage: {
+        label: "Mensaje de éxito",
         helpText: "Mensaje de éxito tras completar"
       },
       refreshAfter: {
+        label: "Actualizar después",
         helpText: "Actualiza la lista/página tras completar la acción"
       },
       locations: {
+        label: "Ubicaciones",
         helpText: "Dónde mostrar esta acción (toolbar, row menu, etc.)"
       },
       component: {
+        label: "Componente",
         helpText: "Cómo renderizar (button, icon, menu item)"
       },
       visible: {
+        label: "Condición de visibilidad",
         helpText: "Expresión CEL: mostrar solo cuando la condición sea true"
       },
       disabled: {
+        label: "Deshabilitado",
         helpText: "Expresión CEL: desactivar cuando la condición sea true"
       },
       shortcut: {
+        label: "Atajo",
         helpText: "Atajo de teclado (p. ej., \"Ctrl+S\", \"Cmd+Enter\")"
       },
       bulkEnabled: {
+        label: "Acción masiva",
         helpText: "Permite aplicar a varios registros seleccionados"
       },
       aiExposed: {
+        label: "Expuesto a IA",
         helpText: "Permite que agentes de IA llamen a esta acción"
       },
       recordIdParam: {
+        label: "Parámetro de ID de registro",
         helpText: "Nombre del parámetro body para ID de registro"
       },
       recordIdField: {
+        label: "Campo de ID de registro",
         helpText: "Campo que usar como ID de registro (valor predeterminado: \"id\")"
       },
       bodyShape: {
+        label: "Forma del cuerpo",
         helpText: "Estructura del cuerpo de solicitud (flat o nested)"
       }
     }
@@ -758,36 +1038,53 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "Nombre",
         helpText: "Identificador único snake_case"
       },
+      label: {
+        label: "Etiqueta"
+      },
+      description: {
+        label: "Descripción"
+      },
       objectName: {
+        label: "Nombre de objeto",
         helpText: "Objeto de fuente de datos"
       },
       type: {
+        label: "Tipo",
         helpText: "Tipo de informe: tabular/summary/matrix/joined"
       },
       columns: {
+        label: "Columnas",
         helpText: "Columnas que mostrar en el informe"
       },
       groupingsDown: {
+        label: "Agrupaciones verticales",
         helpText: "Niveles de agrupación de filas"
       },
       groupingsAcross: {
+        label: "Agrupaciones horizontales",
         helpText: "Niveles de agrupación de columnas (solo matrix)"
       },
       blocks: {
+        label: "Bloques",
         helpText: "Une varios objetos (solo informe joined)"
       },
       filter: {
+        label: "Filtro",
         helpText: "Filtros a nivel de informe"
       },
       chart: {
+        label: "Gráfico",
         helpText: "Configuración de gráfico (type, legend, colors)"
       },
       aria: {
+        label: "Accesibilidad",
         helpText: "Etiquetas de accesibilidad"
       },
       performance: {
+        label: "Rendimiento",
         helpText: "Caché y optimización"
       }
     }
@@ -810,39 +1107,51 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "Nombre",
         helpText: "Identificador único (snake_case)"
       },
       label: {
+        label: "Etiqueta",
         helpText: "Nombre mostrado a los usuarios"
       },
       type: {
+        label: "Tipo",
         helpText: "Cómo se inicia el flujo (autolaunched, record_change, schedule, screen, api)"
       },
       template: {
+        label: "Plantilla",
         helpText: "Indica si es un subflujo reutilizable (puede llamarse desde otros flujos)"
       },
       description: {
+        label: "Descripción",
         helpText: "Qué hace este flujo"
       },
       nodes: {
+        label: "Nodos",
         helpText: "⚠️ Considera usar el editor visual Flow Designer en lugar de JSON"
       },
       edges: {
+        label: "Conexiones",
         helpText: "Conexiones entre nodos — usa Flow Designer para editar más fácilmente"
       },
       variables: {
+        label: "Variables de flujo",
         helpText: "Variables de flujo (inputs/outputs)"
       },
       status: {
+        label: "Estado",
         helpText: "Estado de despliegue: draft → active → obsolete"
       },
       version: {
+        label: "Versión",
         helpText: "Número de versión (autoincrementado)"
       },
       runAs: {
+        label: "Ejecutar como",
         helpText: "Ejecutar como system (admin) o user (permisos del usuario actual)"
       },
       errorHandling: {
+        label: "Manejo de errores",
         helpText: "Qué hacer cuando falla un nodo (fail, retry, continue)"
       }
     }
@@ -854,7 +1163,7 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     label: "Fuente de datos"
   },
   external_catalog: {
-    label: "External Catalog"
+    label: "Catálogo externo"
   },
   translation: {
     label: "Traducción"
@@ -880,46 +1189,71 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
         description: "Línea de asunto. Admite interpolación {{var.path}}."
       },
       html_body: {
-        label: "HTML body",
-        description: "Rich HTML body. Most clients strip <head>, so use inline styles."
+        label: "Cuerpo HTML",
+        description: "Cuerpo HTML enriquecido. La mayoría de clientes elimina <head>, así que usa estilos en línea."
       },
       plain_text_body: {
-        label: "Plain-text body",
-        description: "Optional plain-text alternative. When omitted, the service strips tags from the HTML body to derive one. Providing one improves spam scoring."
+        label: "Cuerpo en texto plano",
+        description: "Alternativa opcional en texto plano. Si se omite, el servicio elimina etiquetas del HTML para derivarla; proporcionarla mejora la puntuación antispam."
       },
       variables: {
-        label: "Variables",
-        description: "Declared variables. Rendered as hints in Studio and validated by sendTemplate() when required."
+        label: "Variables declaradas",
+        description: "Variables declaradas. Studio las muestra como ayudas y sendTemplate() las valida cuando son obligatorias."
       },
       delivery_overrides: {
-        label: "Delivery overrides",
-        description: "Optional per-template overrides for From / Reply-To."
+        label: "Sobrescrituras de entrega",
+        description: "Sobrescrituras opcionales por plantilla para From / Reply-To."
       },
       status: {
-        label: "Status"
+        label: "Estado"
       }
     },
     fields: {
       name: {
-        helpText: "Dotted snake_case (e.g. auth.password_reset, crm.welcome)"
+        label: "Nombre",
+        helpText: "snake_case con puntos (p. ej. auth.password_reset, crm.welcome)"
+      },
+      label: {
+        label: "Etiqueta"
+      },
+      category: {
+        label: "Categoría"
       },
       locale: {
-        helpText: "BCP-47 tag — e.g. en-US, zh-CN"
+        label: "Configuración regional",
+        helpText: "Etiqueta BCP-47, p. ej. en-US, zh-CN"
+      },
+      description: {
+        label: "Descripción"
+      },
+      subject: {
+        label: "Asunto"
+      },
+      bodyHtml: {
+        label: "Cuerpo HTML"
+      },
+      bodyText: {
+        label: "Cuerpo de texto"
       },
       variables: {
+        label: "Variables de plantilla",
         helpText: "Lista de nombres de variable referenciados en subject/body"
       },
       fromOverride: {
-        helpText: "{ \"name\": \"Acme Sales\", \"address\": \"sales@acme.com\" }"
+        label: "Sobrescritura de remitente",
+        helpText: "Ejemplo: { \"name\": \"Acme Sales\", \"address\": \"sales@acme.com\" }"
       },
       replyTo: {
-        helpText: "Reply-To email address"
+        label: "Responder a",
+        helpText: "Dirección de email Reply-To"
       },
       active: {
-        helpText: "When unchecked, sendTemplate() returns TEMPLATE_INACTIVE."
+        label: "Activo",
+        helpText: "Si no está marcado, sendTemplate() devuelve TEMPLATE_INACTIVE."
       },
       isSystem: {
-        helpText: "Built-in template; tenants may override but should not delete."
+        label: "Integrado del sistema",
+        helpText: "Plantilla integrada; los tenants pueden sobrescribirla, pero no deberían eliminarla."
       }
     }
   },
@@ -945,30 +1279,39 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "Nombre",
         helpText: "Nombre de máquina (snake_case)"
       },
       label: {
+        label: "Etiqueta",
         helpText: "Etiqueta mostrada para administradores"
       },
       isProfile: {
+        label: "Es perfil",
         helpText: "Profile = conjunto base asignado a usuarios. Permission Set = concesión adicional."
       },
       systemPermissions: {
+        label: "Permisos del sistema",
         helpText: "Lista de claves de capacidades del sistema"
       },
       objects: {
-        helpText: "{ \"account\": { allowRead: true, allowEdit: true, ... } }"
+        label: "Permisos de objeto",
+        helpText: "Ejemplo: { \"account\": { allowRead: true, allowEdit: true, ... } }"
       },
       fields: {
-        helpText: "{ \"account.amount\": { readable: true, editable: false } }"
+        label: "Campos",
+        helpText: "Ejemplo: { \"account.amount\": { readable: true, editable: false } }"
       },
       tabPermissions: {
-        helpText: "{ \"app_crm\": \"visible\", \"app_admin\": \"hidden\" }"
+        label: "Permisos de pestaña",
+        helpText: "Ejemplo: { \"app_crm\": \"visible\", \"app_admin\": \"hidden\" }"
       },
       rowLevelSecurity: {
+        label: "Seguridad a nivel de fila",
         helpText: "Array de políticas RLS (ver rls.zod.ts)"
       },
       contextVariables: {
+        label: "Variables de contexto",
         helpText: "Variables personalizadas referenciadas en predicados RLS"
       }
     }
@@ -995,30 +1338,39 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "Nombre",
         helpText: "Nombre de máquina (snake_case)"
       },
       label: {
+        label: "Etiqueta",
         helpText: "Etiqueta mostrada para administradores"
       },
       isProfile: {
+        label: "Es perfil",
         helpText: "Profile = conjunto base asignado a usuarios. Permission Set = concesión adicional."
       },
       systemPermissions: {
+        label: "Permisos del sistema",
         helpText: "Lista de claves de capacidades del sistema"
       },
       objects: {
-        helpText: "{ \"account\": { allowRead: true, allowEdit: true, ... } }"
+        label: "Permisos de objeto",
+        helpText: "Ejemplo: { \"account\": { allowRead: true, allowEdit: true, ... } }"
       },
       fields: {
-        helpText: "{ \"account.amount\": { readable: true, editable: false } }"
+        label: "Campos",
+        helpText: "Ejemplo: { \"account.amount\": { readable: true, editable: false } }"
       },
       tabPermissions: {
-        helpText: "{ \"app_crm\": \"visible\", \"app_admin\": \"hidden\" }"
+        label: "Permisos de pestaña",
+        helpText: "Ejemplo: { \"app_crm\": \"visible\", \"app_admin\": \"hidden\" }"
       },
       rowLevelSecurity: {
+        label: "Seguridad a nivel de fila",
         helpText: "Array de políticas RLS (ver rls.zod.ts)"
       },
       contextVariables: {
+        label: "Variables de contexto",
         helpText: "Variables personalizadas referenciadas en predicados RLS"
       }
     }
@@ -1033,10 +1385,18 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
-        helpText: "snake_case"
+        label: "Nombre",
+        helpText: "Formato snake_case"
+      },
+      label: {
+        label: "Etiqueta"
       },
       parent: {
+        label: "Padre",
         helpText: "Nombre de máquina del rol padre (Reports To)"
+      },
+      description: {
+        label: "Descripción"
       }
     }
   },
@@ -1062,57 +1422,75 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "Nombre",
         helpText: "Identificador único (snake_case)"
       },
       label: {
+        label: "Etiqueta",
         helpText: "Nombre mostrado (p. ej., \"Sales Assistant\")"
       },
       role: {
+        label: "Rol del agente",
         helpText: "Persona del agente (p. ej., \"Customer Support Specialist\")"
       },
       avatar: {
+        label: "Avatar del agente",
         helpText: "URL de imagen de avatar"
       },
       active: {
+        label: "Activo",
         helpText: "Activa/desactiva este agente"
       },
       instructions: {
+        label: "Instrucciones",
         helpText: "Prompt del sistema — indica al agente cómo comportarse y qué puede hacer"
       },
       model: {
+        label: "Modelo",
         helpText: "Configuración del modelo de IA (provider, model name, temperature, etc.)"
       },
       planning: {
+        label: "Planificación",
         helpText: "Configuración de razonamiento autónomo (strategy, max iterations, replan)"
       },
       memory: {
+        label: "Memoria",
         helpText: "Gestión de memoria (short-term, long-term, reflection)"
       },
       lifecycle: {
+        label: "Ciclo de vida",
         helpText: "Máquina de estado que define el flujo de conversación"
       },
       skills: {
+        label: "Habilidades",
         helpText: "Nombres de skill (arquitectura Agent→Skill→Tool)"
       },
       tools: {
+        label: "Herramientas",
         helpText: "Referencias directas a herramientas (modo heredado)"
       },
       knowledge: {
+        label: "Conocimiento",
         helpText: "Configuración de acceso a conocimiento RAG"
       },
       visibility: {
+        label: "Visibilidad",
         helpText: "Ámbito: global, organization o private"
       },
       access: {
+        label: "Acceso",
         helpText: "IDs de usuario o nombres de rol que pueden chatear con este agente"
       },
       permissions: {
+        label: "Permisos",
         helpText: "Permisos necesarios para usar este agente"
       },
       tenantId: {
+        label: "ID de tenant",
         helpText: "Restringe a un ID de organization específico"
       },
       guardrails: {
+        label: "Reglas de protección",
         helpText: "Reglas de seguridad y políticas de contenido"
       }
     }
@@ -1135,36 +1513,47 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "Nombre",
         helpText: "Identificador único (snake_case)"
       },
       label: {
+        label: "Etiqueta",
         helpText: "Nombre mostrado para Studio UI"
       },
       description: {
+        label: "Descripción",
         helpText: "Indica a IA cuándo usar esta herramienta — sé específico."
       },
       category: {
+        label: "Categoría",
         helpText: "Categoría de herramienta (data, action, flow, integration, etc.)"
       },
       objectName: {
+        label: "Nombre de objeto",
         helpText: "Objeto relacionado (si esta herramienta opera sobre un objeto específico)"
       },
       active: {
+        label: "Activo",
         helpText: "Activa/desactiva esta herramienta"
       },
       builtIn: {
+        label: "Integrado",
         helpText: "Herramienta integrada de la plataforma (frente a definida por usuario)"
       },
       parameters: {
+        label: "Parámetros",
         helpText: "Parámetros de entrada — define propiedades como: {name: {type: \"string\", description: \"...\"}}"
       },
       outputSchema: {
+        label: "Esquema de salida",
         helpText: "Esquema de salida para validación (opcional)"
       },
       requiresConfirmation: {
+        label: "Requiere confirmación",
         helpText: "Pide aprobación al usuario antes de ejecutar (para acciones destructivas)"
       },
       permissions: {
+        label: "Permisos",
         helpText: "Permisos necesarios para usar esta herramienta"
       }
     }
@@ -1191,30 +1580,39 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "Nombre",
         helpText: "Identificador único (snake_case)"
       },
       label: {
+        label: "Etiqueta",
         helpText: "Nombre mostrado (p. ej., \"Case Management\")"
       },
       description: {
+        label: "Descripción",
         helpText: "Qué hace esta skill"
       },
       active: {
+        label: "Activo",
         helpText: "Activa/desactiva esta skill"
       },
       instructions: {
+        label: "Instrucciones",
         helpText: "Instrucciones para IA — indica cómo usar estas herramientas juntas"
       },
       tools: {
+        label: "Herramientas",
         helpText: "Nombres de herramienta (admite comodín: action_*)"
       },
       triggerPhrases: {
+        label: "Frases disparadoras",
         helpText: "Frases de lenguaje natural que activan esta skill"
       },
       triggerConditions: {
+        label: "Condiciones disparadoras",
         helpText: "Condiciones programáticas (p. ej., objectName == \"case\")"
       },
       permissions: {
+        label: "Permisos",
         helpText: "Permisos necesarios para usar esta skill"
       }
     }

--- a/packages/platform-objects/src/apps/translations/es-ES.ts
+++ b/packages/platform-objects/src/apps/translations/es-ES.ts
@@ -85,6 +85,7 @@ export const esES: TranslationData = {
       navigation: {
         group_overview: { label: 'Resumen' },
         nav_metadata_directory: { label: 'Todos los tipos de metadatos' },
+        nav_packages: { label: 'Paquetes' },
         group_data_model: { label: 'Modelo de datos' },
         nav_objects: { label: 'Objetos' },
         nav_validations: { label: 'Validaciones' },

--- a/packages/platform-objects/src/apps/translations/ja-JP.metadata-forms.generated.ts
+++ b/packages/platform-objects/src/apps/translations/ja-JP.metadata-forms.generated.ts
@@ -31,156 +31,246 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名前",
         helpText: "snake_case の一意識別子（作成後は変更不可）"
       },
       label: {
+        label: "表示名",
         helpText: "単数表示名（例: \"Account\"）"
       },
       pluralLabel: {
+        label: "複数表示名",
         helpText: "複数表示名（例: \"Accounts\"）"
       },
       icon: {
+        label: "アイコン",
         helpText: "Lucide アイコン名（例: \"building\", \"users\"）"
       },
       description: {
+        label: "説明",
         helpText: "開発者向けドキュメント"
       },
       tags: {
+        label: "タグ",
         helpText: "分類タグ（例: \"sales\", \"system\"）"
       },
       active: {
+        label: "有効",
         helpText: "オブジェクトが有効で使用可能か"
       },
       isSystem: {
+        label: "システム組み込み",
         helpText: "システムオブジェクト（削除から保護）"
       },
       abstract: {
+        label: "抽象",
         helpText: "抽象ベース（インスタンス化不可）"
       },
       fields: {
+        label: "フィールド",
         helpText: "このオブジェクトが保存する列を追加"
       },
       "fields.label": {
+        label: "表示名",
         helpText: "表示ラベル"
       },
       "fields.type": {
+        label: "型",
         helpText: "フィールド型"
       },
       "fields.description": {
-        helpText: "Developer documentation for this column"
+        label: "説明",
+        helpText: "この列の開発者向けドキュメント"
       },
       "fields.required": {
-        helpText: "Must be set on every record"
+        label: "必須",
+        helpText: "すべてのレコードで必須"
       },
       "fields.unique": {
-        helpText: "Disallow duplicate values"
+        label: "一意",
+        helpText: "重複値を許可しない"
       },
       "fields.indexed": {
-        helpText: "Create a database index for faster querying"
+        label: "インデックス済み",
+        helpText: "高速検索のためにデータベースインデックスを作成"
       },
       "fields.readonly": {
-        helpText: "Visible but never user-editable"
+        label: "読み取り専用",
+        helpText: "表示されるがユーザーは編集不可"
       },
       "fields.immutable": {
-        helpText: "Editable on create, locked thereafter"
+        label: "変更不可",
+        helpText: "作成時のみ編集可能、その後はロック"
       },
       "fields.hidden": {
-        helpText: "Hidden from default UI"
+        label: "非表示",
+        helpText: "既定 UI では非表示"
       },
       "fields.searchable": {
-        helpText: "Include in full-text search"
+        label: "検索可能",
+        helpText: "全文検索に含める"
       },
       "fields.sortable": {
-        helpText: "Allow sorting on this column"
+        label: "並び替え可能",
+        helpText: "この列での並び替えを許可"
       },
       "fields.filterable": {
-        helpText: "Allow filtering on this column"
+        label: "フィルター可能",
+        helpText: "この列でのフィルターを許可"
       },
       "fields.defaultValue": {
-        helpText: "Default value for new records (JSON literal)"
+        label: "既定値",
+        helpText: "新規レコードの既定値（JSON リテラル）"
       },
       "fields.placeholder": {
-        helpText: "Placeholder hint"
+        label: "プレースホルダー",
+        helpText: "プレースホルダーのヒント"
       },
       "fields.maxLength": {
-        helpText: "Max characters"
+        label: "最大長",
+        helpText: "最大文字数"
       },
       "fields.minLength": {
-        helpText: "Min characters"
+        label: "最小長",
+        helpText: "最小文字数"
       },
       "fields.min": {
-        helpText: "Minimum value"
+        label: "最小値",
+        helpText: "最小値"
       },
       "fields.max": {
-        helpText: "Maximum value"
+        label: "最大値",
+        helpText: "最大値"
       },
       "fields.precision": {
-        helpText: "Total digits"
+        label: "精度",
+        helpText: "総桁数"
       },
       "fields.scale": {
-        helpText: "Decimal places"
+        label: "小数桁",
+        helpText: "小数桁数"
       },
       "fields.options": {
-        helpText: "Available choices"
+        label: "選択肢",
+        helpText: "選択肢"
+      },
+      "fields.options.label": {
+        label: "表示名"
+      },
+      "fields.options.value": {
+        label: "値"
+      },
+      "fields.options.color": {
+        label: "色"
       },
       "fields.options.icon": {
-        helpText: "Lucide icon name"
+        label: "アイコン",
+        helpText: "Lucide アイコン名"
+      },
+      "fields.options.description": {
+        label: "説明"
       },
       "fields.reference": {
+        label: "参照",
         helpText: "対象オブジェクト（lookup/master_detail 用）"
       },
       "fields.referenceFilter": {
-        helpText: "CEL filter applied to the picker"
+        label: "参照フィルター",
+        helpText: "ピッカーに適用する CEL フィルター"
       },
       "fields.cascadeDelete": {
-        helpText: "Delete children when parent is deleted"
+        label: "カスケード削除",
+        helpText: "親の削除時に子も削除"
       },
       "fields.multiple": {
-        helpText: "Allow selecting multiple records"
+        label: "複数選択",
+        helpText: "複数レコードの選択を許可"
       },
       "fields.formula": {
-        helpText: "CEL formula expression"
+        label: "数式",
+        helpText: "CEL 公式式"
       },
       "fields.returnType": {
-        helpText: "Result type for formulas"
+        label: "戻り値の型",
+        helpText: "公式の結果型"
       },
       "fields.summaryType": {
-        helpText: "Aggregation"
+        label: "集計タイプ",
+        helpText: "集計方法"
       },
       "fields.summaryField": {
-        helpText: "Field on child object to aggregate"
+        label: "集計フィールド",
+        helpText: "集計対象の子オブジェクトのフィールド"
       },
       "fields.displayFormat": {
-        helpText: "e.g. \"INV-{0000}\""
+        label: "表示形式",
+        helpText: "例: \"INV-{0000}\""
       },
       "fields.startingNumber": {
-        helpText: "Starting sequence value"
+        label: "開始番号",
+        helpText: "連番の開始値"
       },
       "fields.language": {
-        helpText: "Editor language (e.g. sql, javascript)"
+        label: "言語",
+        helpText: "エディター言語（例: sql, javascript）"
       },
       "fields.validation": {
-        helpText: "CEL predicate — must evaluate true"
+        label: "検証",
+        helpText: "CEL 述語。true と評価される必要があります"
       },
       "fields.errorMessage": {
-        helpText: "Shown when validation fails"
+        label: "エラーメッセージ",
+        helpText: "検証失敗時に表示"
       },
       "fields.audit": {
-        helpText: "Audit changes to this field"
+        label: "監査",
+        helpText: "このフィールドの変更を監査"
       },
       "fields.trackHistory": {
-        helpText: "Keep change history"
+        label: "履歴追跡",
+        helpText: "変更履歴を保持"
       },
       "fields.pii": {
-        helpText: "Personally identifiable information"
+        label: "個人情報",
+        helpText: "個人識別情報"
       },
       "fields.encrypted": {
-        helpText: "Encrypt at rest"
+        label: "暗号化",
+        helpText: "保存時に暗号化"
       },
       capabilities: {
+        label: "機能",
         helpText: "システム機能の有効/無効"
       },
+      "capabilities.trackHistory": {
+        label: "履歴追跡"
+      },
+      "capabilities.searchable": {
+        label: "検索可能"
+      },
+      "capabilities.apiEnabled": {
+        label: "API 有効"
+      },
+      "capabilities.files": {
+        label: "ファイル"
+      },
+      "capabilities.feeds": {
+        label: "フィード"
+      },
+      "capabilities.activities": {
+        label: "活動"
+      },
+      "capabilities.trash": {
+        label: "ごみ箱"
+      },
+      "capabilities.mru": {
+        label: "最近使用"
+      },
+      "capabilities.clone": {
+        label: "複製"
+      },
       datasource: {
+        label: "データソース",
         helpText: "対象データソース ID（既定: \"default\"）"
       }
     }
@@ -207,102 +297,135 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名前",
         helpText: "一意識別子（snake_case、作成後は変更不可）"
       },
       label: {
+        label: "表示名",
         helpText: "ユーザー向け表示名"
       },
       type: {
+        label: "型",
         helpText: "このフィールドのデータ型"
       },
       group: {
+        label: "グループ",
         helpText: "フォームレイアウトのグループ名"
       },
       description: {
+        label: "説明",
         helpText: "ユーザーに表示するヘルプテキスト"
       },
       required: {
+        label: "必須",
         helpText: "ユーザーによる値入力が必須"
       },
       unique: {
+        label: "一意",
         helpText: "複数レコードで同じ値を不可"
       },
       multiple: {
+        label: "複数選択",
         helpText: "複数値を許可（select/lookup 用）"
       },
       defaultValue: {
+        label: "既定値",
         helpText: "新規レコードの既定値"
       },
       minLength: {
+        label: "最小長",
         helpText: "最小文字数"
       },
       maxLength: {
+        label: "最大長",
         helpText: "最大文字数"
       },
       min: {
+        label: "最小値",
         helpText: "最小値"
       },
       max: {
+        label: "最大値",
         helpText: "最大値"
       },
       precision: {
+        label: "精度",
         helpText: "小数桁数（例: $10.50 なら 2）"
       },
       scale: {
+        label: "小数桁",
         helpText: "小数部の桁数"
       },
       options: {
+        label: "選択肢",
         helpText: "使用可能な選択肢（label/value ペア）"
       },
       reference: {
+        label: "参照",
         helpText: "参照先オブジェクト名"
       },
       referenceFilters: {
+        label: "参照フィルター",
         helpText: "フィルター式（例: \"active = true\"）"
       },
       deleteBehavior: {
+        label: "削除動作",
         helpText: "参照先レコード削除時の動作"
       },
       expression: {
+        label: "式",
         helpText: "このフィールドを計算する CEL 式（読み取り専用化）"
       },
       summaryOperations: {
+        label: "集計操作",
         helpText: "ロールアップ集計設定（親子関係用）"
       },
       cached: {
+        label: "キャッシュ",
         helpText: "計算フィールドのキャッシュ設定"
       },
       columnName: {
+        label: "列名",
         helpText: "データベース上の物理列名（既定はフィールド名）"
       },
       index: {
+        label: "インデックス",
         helpText: "高速クエリ用のデータベースインデックスを作成"
       },
       externalId: {
+        label: "外部 ID",
         helpText: "upsert 操作用の外部 ID としてマーク"
       },
       readonly: {
+        label: "読み取り専用",
         helpText: "フォームでフィールドを読み取り専用にする"
       },
       hidden: {
+        label: "非表示",
         helpText: "既定 UI ビューからフィールドを非表示"
       },
       searchable: {
+        label: "検索可能",
         helpText: "グローバル検索結果に含める"
       },
       sortable: {
+        label: "並び替え可能",
         helpText: "このフィールドでリストの並べ替えを許可"
       },
       auditTrail: {
+        label: "監査証跡",
         helpText: "ユーザーとタイムスタンプ付きで詳細変更を追跡"
       },
       trackFeedHistory: {
+        label: "フィード履歴追跡",
         helpText: "アクティビティフィードに変更を表示"
       },
       encryptionConfig: {
+        label: "暗号化設定",
         helpText: "フィールドレベル暗号化（GDPR/HIPAA/PCI-DSS）"
       },
       maskingRule: {
+        label: "マスキングルール",
         helpText: "PII 保護用データマスキングルール"
       }
     }
@@ -334,39 +457,60 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名前",
         helpText: "snake_case 識別子（作成後は変更不可）"
       },
+      label: {
+        label: "表示名"
+      },
+      description: {
+        label: "説明"
+      },
       object: {
+        label: "オブジェクト",
         helpText: "対象オブジェクト名（グローバルは \"*\"）"
       },
       events: {
+        label: "イベント",
         helpText: "ライフサイクルイベント（例: beforeInsert, afterUpdate）"
       },
       priority: {
+        label: "優先度",
         helpText: "小さい数値ほど先に実行"
       },
       body: {
+        label: "本文",
         helpText: "L1 式または L2 サンドボックス JS body"
       },
       "body.language": {
+        label: "言語",
         helpText: "expression = 純粋な数式; js = サンドボックス化 JavaScript"
       },
       "body.source": {
+        label: "ソース",
         helpText: "関数 body ソース — トップレベル import 不可"
       },
       "body.capabilities": {
+        label: "機能",
         helpText: "許可する ctx API（api.read, api.write, crypto.uuid, log, …）"
       },
       "body.timeoutMs": {
+        label: "タイムアウト（ms）",
         helpText: "呼び出しごとのタイムアウト（ms）"
       },
       handler: {
+        label: "ハンドラー",
         helpText: "ハンドラー関数名（非推奨 — `body` を推奨）"
       },
       async: {
+        label: "非同期",
         helpText: "バックグラウンドで実行し、トランザクションをブロックしない"
       },
+      onError: {
+        label: "エラー時"
+      },
       condition: {
+        label: "条件",
         helpText: "任意の数式 — false 評価時はフックをスキップ"
       }
     }
@@ -417,28 +561,87 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名前",
         helpText: "snake_case、environment ごとに一意"
       },
+      label: {
+        label: "表示名"
+      },
+      description: {
+        label: "説明"
+      },
       type: {
+        label: "型",
         helpText: "主要ビューサーフェス"
       },
       data: {
+        label: "データ",
         helpText: "データソース — 例: {\"provider\":\"object\",\"object\":\"task\"}"
       },
       columns: {
+        label: "列",
         helpText: "表示する列（選択オブジェクトのフィールド名）"
       },
       filter: {
+        label: "フィルター",
         helpText: "フィルター条件"
       },
       sort: {
+        label: "並び替え",
         helpText: "既定の並び順"
       },
       searchableFields: {
+        label: "検索対象フィールド",
         helpText: "クイック検索で使用可能なフィールド名"
       },
       filterableFields: {
+        label: "フィルター対象フィールド",
         helpText: "フィルターで使用可能なフィールド名"
+      },
+      resizable: {
+        label: "サイズ変更可"
+      },
+      striped: {
+        label: "縞表示"
+      },
+      bordered: {
+        label: "枠線"
+      },
+      compactToolbar: {
+        label: "コンパクトツールバー"
+      },
+      rowHeight: {
+        label: "行の高さ"
+      },
+      selection: {
+        label: "選択"
+      },
+      pagination: {
+        label: "ページネーション"
+      },
+      kanban: {
+        label: "カンバン"
+      },
+      calendar: {
+        label: "カレンダー"
+      },
+      gantt: {
+        label: "ガント"
+      },
+      gallery: {
+        label: "ギャラリー"
+      },
+      timeline: {
+        label: "タイムライン"
+      },
+      chart: {
+        label: "チャート"
+      },
+      navigation: {
+        label: "ナビゲーション"
+      },
+      sharing: {
+        label: "共有"
       }
     }
   },
@@ -464,42 +667,55 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名前",
         helpText: "一意識別子（snake_case）"
       },
       label: {
+        label: "表示名",
         helpText: "ユーザーに表示するページタイトル"
       },
       icon: {
+        label: "アイコン",
         helpText: "ナビゲーションメニューのアイコン"
       },
       type: {
+        label: "型",
         helpText: "ページ種別（record, home, app, dashboard など）"
       },
       template: {
+        label: "テンプレート",
         helpText: "レイアウトテンプレート（例: \"header-sidebar-main\"）"
       },
       description: {
+        label: "説明",
         helpText: "ナビゲーション用ページ説明"
       },
       object: {
+        label: "オブジェクト",
         helpText: "バインド先オブジェクト（Record ページ用）"
       },
       variables: {
+        label: "変数",
         helpText: "ページローカル状態変数"
       },
       regions: {
+        label: "リージョン",
         helpText: "コンポーネントを含むレイアウト領域（header, main, sidebar, footer）"
       },
       isDefault: {
+        label: "既定",
         helpText: "このページ種別の既定ページに設定"
       },
       kind: {
+        label: "モード",
         helpText: "ページ上書きモード: full または slotted（record ページ用）"
       },
       assignedProfiles: {
+        label: "割り当てプロファイル",
         helpText: "このページにアクセス可能なプロファイル"
       },
       aria: {
+        label: "アクセシビリティ",
         helpText: "アクセシビリティ属性（ARIA ラベル、ロール）"
       }
     }
@@ -530,36 +746,50 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名前",
         helpText: "snake_case の一意識別子"
       },
       label: {
+        label: "表示名",
         helpText: "表示名"
       },
+      description: {
+        label: "説明"
+      },
       columns: {
+        label: "列",
         helpText: "グリッド列（既定 12）"
       },
       gap: {
+        label: "間隔",
         helpText: "グリッド間隔（Tailwind 単位）"
       },
       refreshInterval: {
+        label: "更新間隔",
         helpText: "自動更新（秒）"
       },
       header: {
+        label: "ヘッダー",
         helpText: "ダッシュボードヘッダー設定（title, subtitle, actions）"
       },
       widgets: {
+        label: "ウィジェット",
         helpText: "位置とサイズを持つダッシュボードウィジェット"
       },
       dateRange: {
+        label: "日付範囲",
         helpText: "既定の日付範囲セレクター"
       },
       globalFilters: {
+        label: "グローバルフィルター",
         helpText: "全ウィジェットに適用するフィルター"
       },
       aria: {
+        label: "アクセシビリティ",
         helpText: "アクセシビリティラベル"
       },
       performance: {
+        label: "パフォーマンス",
         helpText: "キャッシュと最適化設定"
       }
     }
@@ -590,48 +820,75 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名前",
         helpText: "snake_case、一意"
       },
+      label: {
+        label: "表示名"
+      },
+      description: {
+        label: "説明"
+      },
+      version: {
+        label: "バージョン"
+      },
       icon: {
+        label: "アイコン",
         helpText: "Lucide アイコン名（例: \"users\", \"briefcase\"）"
       },
+      active: {
+        label: "有効"
+      },
       isDefault: {
+        label: "既定",
         helpText: "新規ユーザーの既定アプリにする"
       },
       navigation: {
+        label: "ナビゲーション",
         helpText: "ナビツリー — 再帰構造"
       },
       areas: {
+        label: "領域",
         helpText: "項目を折りたたみ可能なエリアにグループ化"
       },
       homePageId: {
+        label: "ホームページ ID",
         helpText: "アプリ起動時のランディングページ"
       },
       mobileNavigation: {
+        label: "モバイルナビゲーション",
         helpText: "モバイル用ボトムタブバー設定"
       },
       objects: {
+        label: "オブジェクト権限",
         helpText: "このアプリが公開するオブジェクト名"
       },
       apis: {
+        label: "API",
         helpText: "API エンドポイント定義"
       },
       defaultAgent: {
+        label: "既定エージェント",
         helpText: "常駐アシスタントボタン用 AI エージェント"
       },
       branding: {
+        label: "ブランド",
         helpText: "プライマリ/セカンダリカラー、ロゴ、テーマ"
       },
       requiredPermissions: {
+        label: "必要な権限",
         helpText: "このアプリへのアクセスに必要な権限"
       },
       sharing: {
+        label: "共有",
         helpText: "公開/内部/制限付きアクセス制御"
       },
       embed: {
+        label: "埋め込み",
         helpText: "iFrame 埋め込み設定"
       },
       aria: {
+        label: "アクセシビリティ",
         helpText: "アクセシビリティラベル"
       }
     }
@@ -658,72 +915,95 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名前",
         helpText: "一意識別子（snake_case）"
       },
       label: {
+        label: "表示名",
         helpText: "ユーザーに表示するボタンテキスト"
       },
       objectName: {
+        label: "オブジェクト名",
         helpText: "このアクションが属するオブジェクト（任意）"
       },
       icon: {
+        label: "アイコン",
         helpText: "Lucide アイコン名（例: \"check\", \"x-circle\"）"
       },
       type: {
+        label: "型",
         helpText: "クリック時の動作"
       },
       variant: {
+        label: "ボタン種別",
         helpText: "ボタンスタイル（primary=blue, danger=red, ghost=transparent）"
       },
       target: {
+        label: "ターゲット",
         helpText: "呼び出す URL、フロー名、または API エンドポイント"
       },
       method: {
+        label: "メソッド",
         helpText: "HTTP メソッド（GET, POST, PUT, DELETE）"
       },
       body: {
+        label: "本文",
         helpText: "実行する JavaScript コード"
       },
       params: {
+        label: "パラメーター",
         helpText: "ユーザー入力パラメーター（実行前にフォームを表示）"
       },
       confirmText: {
+        label: "確認文",
         helpText: "確認メッセージ（例: \"Are you sure?\"）"
       },
       successMessage: {
+        label: "成功メッセージ",
         helpText: "完了後の成功メッセージ"
       },
       refreshAfter: {
+        label: "完了後に更新",
         helpText: "アクション完了後にリスト/ページを更新"
       },
       locations: {
+        label: "表示位置",
         helpText: "このアクションの表示場所（toolbar, row menu など）"
       },
       component: {
+        label: "コンポーネント",
         helpText: "レンダリング方法（button, icon, menu item）"
       },
       visible: {
+        label: "表示",
         helpText: "CEL 式: 条件が true の場合のみ表示"
       },
       disabled: {
+        label: "無効",
         helpText: "CEL 式: 条件が true の場合に無効化"
       },
       shortcut: {
+        label: "ショートカット",
         helpText: "キーボードショートカット（例: \"Ctrl+S\", \"Cmd+Enter\"）"
       },
       bulkEnabled: {
+        label: "一括操作有効",
         helpText: "選択した複数レコードへの適用を許可"
       },
       aiExposed: {
+        label: "AI に公開",
         helpText: "AI エージェントによるこのアクションの呼び出しを許可"
       },
       recordIdParam: {
+        label: "レコード ID パラメーター",
         helpText: "レコード ID 用 body パラメーター名"
       },
       recordIdField: {
+        label: "レコード ID フィールド",
         helpText: "レコード ID として使用するフィールド（既定: \"id\"）"
       },
       bodyShape: {
+        label: "本文構造",
         helpText: "リクエスト body 構造（flat または nested）"
       }
     }
@@ -758,36 +1038,53 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名前",
         helpText: "snake_case の一意識別子"
       },
+      label: {
+        label: "表示名"
+      },
+      description: {
+        label: "説明"
+      },
       objectName: {
+        label: "オブジェクト名",
         helpText: "データソースオブジェクト"
       },
       type: {
+        label: "型",
         helpText: "レポート種別: tabular/summary/matrix/joined"
       },
       columns: {
+        label: "列",
         helpText: "レポートに表示する列"
       },
       groupingsDown: {
+        label: "縦グループ",
         helpText: "行グループ化レベル"
       },
       groupingsAcross: {
+        label: "横グループ",
         helpText: "列グループ化レベル（matrix のみ）"
       },
       blocks: {
+        label: "ブロック",
         helpText: "複数オブジェクトを結合（joined レポートのみ）"
       },
       filter: {
+        label: "フィルター",
         helpText: "レポートレベルのフィルター"
       },
       chart: {
+        label: "チャート",
         helpText: "チャート設定（type, legend, colors）"
       },
       aria: {
+        label: "アクセシビリティ",
         helpText: "アクセシビリティラベル"
       },
       performance: {
+        label: "パフォーマンス",
         helpText: "キャッシュと最適化"
       }
     }
@@ -810,39 +1107,51 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名前",
         helpText: "一意識別子（snake_case）"
       },
       label: {
+        label: "表示名",
         helpText: "ユーザー向け表示名"
       },
       type: {
+        label: "型",
         helpText: "フローの開始方法（autolaunched, record_change, schedule, screen, api）"
       },
       template: {
+        label: "テンプレート",
         helpText: "再利用可能なサブフローか（他のフローから呼び出し可）"
       },
       description: {
+        label: "説明",
         helpText: "このフローの処理内容"
       },
       nodes: {
+        label: "ノード",
         helpText: "⚠️ JSON ではなく Flow Designer ビジュアルエディターの利用を検討"
       },
       edges: {
+        label: "エッジ",
         helpText: "ノード間の接続 — 編集しやすい Flow Designer を使用"
       },
       variables: {
+        label: "変数",
         helpText: "フロー変数（inputs/outputs）"
       },
       status: {
+        label: "状態",
         helpText: "デプロイ状態: draft → active → obsolete"
       },
       version: {
+        label: "バージョン",
         helpText: "バージョン番号（自動インクリメント）"
       },
       runAs: {
+        label: "実行主体",
         helpText: "system（admin）または user（現在のユーザー権限）として実行"
       },
       errorHandling: {
+        label: "エラー処理",
         helpText: "ノード失敗時の処理（fail, retry, continue）"
       }
     }
@@ -854,7 +1163,7 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     label: "データソース"
   },
   external_catalog: {
-    label: "External Catalog"
+    label: "外部カタログ"
   },
   translation: {
     label: "翻訳"
@@ -880,46 +1189,71 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
         description: "件名行。{{var.path}} 補間をサポート。"
       },
       html_body: {
-        label: "HTML body",
-        description: "Rich HTML body. Most clients strip <head>, so use inline styles."
+        label: "HTML 本文",
+        description: "リッチ HTML 本文。多くのクライアントは <head> を削除するため、インラインスタイルを使用してください。"
       },
       plain_text_body: {
-        label: "Plain-text body",
-        description: "Optional plain-text alternative. When omitted, the service strips tags from the HTML body to derive one. Providing one improves spam scoring."
+        label: "プレーンテキスト本文",
+        description: "任意のプレーンテキスト代替本文。省略時は HTML 本文からタグを除去して生成します。明示するとスパム判定の改善に役立ちます。"
       },
       variables: {
-        label: "Variables",
-        description: "Declared variables. Rendered as hints in Studio and validated by sendTemplate() when required."
+        label: "変数",
+        description: "宣言済み変数。Studio ではヒントとして表示され、必須時は sendTemplate() で検証されます。"
       },
       delivery_overrides: {
-        label: "Delivery overrides",
-        description: "Optional per-template overrides for From / Reply-To."
+        label: "配信オーバーライド",
+        description: "テンプレートごとの任意の From / Reply-To オーバーライド。"
       },
       status: {
-        label: "Status"
+        label: "状態"
       }
     },
     fields: {
       name: {
-        helpText: "Dotted snake_case (e.g. auth.password_reset, crm.welcome)"
+        label: "名前",
+        helpText: "ドット区切りの snake_case（例: auth.password_reset, crm.welcome）"
+      },
+      label: {
+        label: "表示名"
+      },
+      category: {
+        label: "カテゴリ"
       },
       locale: {
-        helpText: "BCP-47 tag — e.g. en-US, zh-CN"
+        label: "ロケール",
+        helpText: "BCP-47 タグ（例: en-US, zh-CN）"
+      },
+      description: {
+        label: "説明"
+      },
+      subject: {
+        label: "件名"
+      },
+      bodyHtml: {
+        label: "HTML 本文"
+      },
+      bodyText: {
+        label: "テキスト本文"
       },
       variables: {
+        label: "変数",
         helpText: "subject/body で参照する変数名リスト"
       },
       fromOverride: {
-        helpText: "{ \"name\": \"Acme Sales\", \"address\": \"sales@acme.com\" }"
+        label: "送信者オーバーライド",
+        helpText: "例: { \"name\": \"Acme Sales\", \"address\": \"sales@acme.com\" }"
       },
       replyTo: {
-        helpText: "Reply-To email address"
+        label: "返信先",
+        helpText: "Reply-To メールアドレス"
       },
       active: {
-        helpText: "When unchecked, sendTemplate() returns TEMPLATE_INACTIVE."
+        label: "有効",
+        helpText: "未チェックの場合、sendTemplate() は TEMPLATE_INACTIVE を返します。"
       },
       isSystem: {
-        helpText: "Built-in template; tenants may override but should not delete."
+        label: "システム組み込み",
+        helpText: "組み込みテンプレート。テナントは上書きできますが、削除すべきではありません。"
       }
     }
   },
@@ -945,30 +1279,39 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名前",
         helpText: "マシン名（snake_case）"
       },
       label: {
+        label: "表示名",
         helpText: "管理者向け表示ラベル"
       },
       isProfile: {
+        label: "プロファイルか",
         helpText: "Profile = ユーザーに割り当てる基本セット。Permission Set = 追加権限。"
       },
       systemPermissions: {
+        label: "システム権限",
         helpText: "システム機能キーのリスト"
       },
       objects: {
-        helpText: "{ \"account\": { allowRead: true, allowEdit: true, ... } }"
+        label: "オブジェクト権限",
+        helpText: "例: { \"account\": { allowRead: true, allowEdit: true, ... } }"
       },
       fields: {
-        helpText: "{ \"account.amount\": { readable: true, editable: false } }"
+        label: "フィールド",
+        helpText: "例: { \"account.amount\": { readable: true, editable: false } }"
       },
       tabPermissions: {
-        helpText: "{ \"app_crm\": \"visible\", \"app_admin\": \"hidden\" }"
+        label: "タブ権限",
+        helpText: "例: { \"app_crm\": \"visible\", \"app_admin\": \"hidden\" }"
       },
       rowLevelSecurity: {
+        label: "行レベルセキュリティ",
         helpText: "RLS ポリシーの配列（rls.zod.ts 参照）"
       },
       contextVariables: {
+        label: "コンテキスト変数",
         helpText: "RLS 述語で参照するカスタム変数"
       }
     }
@@ -995,30 +1338,39 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名前",
         helpText: "マシン名（snake_case）"
       },
       label: {
+        label: "表示名",
         helpText: "管理者向け表示ラベル"
       },
       isProfile: {
+        label: "プロファイルか",
         helpText: "Profile = ユーザーに割り当てる基本セット。Permission Set = 追加権限。"
       },
       systemPermissions: {
+        label: "システム権限",
         helpText: "システム機能キーのリスト"
       },
       objects: {
-        helpText: "{ \"account\": { allowRead: true, allowEdit: true, ... } }"
+        label: "オブジェクト権限",
+        helpText: "例: { \"account\": { allowRead: true, allowEdit: true, ... } }"
       },
       fields: {
-        helpText: "{ \"account.amount\": { readable: true, editable: false } }"
+        label: "フィールド",
+        helpText: "例: { \"account.amount\": { readable: true, editable: false } }"
       },
       tabPermissions: {
-        helpText: "{ \"app_crm\": \"visible\", \"app_admin\": \"hidden\" }"
+        label: "タブ権限",
+        helpText: "例: { \"app_crm\": \"visible\", \"app_admin\": \"hidden\" }"
       },
       rowLevelSecurity: {
+        label: "行レベルセキュリティ",
         helpText: "RLS ポリシーの配列（rls.zod.ts 参照）"
       },
       contextVariables: {
+        label: "コンテキスト変数",
         helpText: "RLS 述語で参照するカスタム変数"
       }
     }
@@ -1033,10 +1385,18 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
-        helpText: "snake_case"
+        label: "名前",
+        helpText: "snake_case 形式"
+      },
+      label: {
+        label: "表示名"
       },
       parent: {
+        label: "親",
         helpText: "親ロールのマシン名（Reports To）"
+      },
+      description: {
+        label: "説明"
       }
     }
   },
@@ -1062,57 +1422,75 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名前",
         helpText: "一意識別子（snake_case）"
       },
       label: {
+        label: "表示名",
         helpText: "表示名（例: \"Sales Assistant\"）"
       },
       role: {
+        label: "ペルソナロール",
         helpText: "エージェントペルソナ（例: \"Customer Support Specialist\"）"
       },
       avatar: {
+        label: "アバター",
         helpText: "アバター画像 URL"
       },
       active: {
+        label: "有効",
         helpText: "このエージェントの有効/無効"
       },
       instructions: {
+        label: "指示",
         helpText: "システムプロンプト — エージェントの振る舞いと可能な操作を指定"
       },
       model: {
+        label: "モデル",
         helpText: "AI モデル設定（provider, model name, temperature など）"
       },
       planning: {
+        label: "計画",
         helpText: "自律推論設定（strategy, max iterations, replan）"
       },
       memory: {
+        label: "メモリ",
         helpText: "メモリ管理（short-term, long-term, reflection）"
       },
       lifecycle: {
+        label: "ライフサイクル",
         helpText: "会話フローを定義するステートマシン"
       },
       skills: {
+        label: "スキル",
         helpText: "スキル名（Agent→Skill→Tool アーキテクチャ）"
       },
       tools: {
+        label: "ツール",
         helpText: "直接ツール参照（レガシーモード）"
       },
       knowledge: {
+        label: "ナレッジ",
         helpText: "RAG ナレッジアクセス設定"
       },
       visibility: {
+        label: "可視範囲",
         helpText: "スコープ: global, organization, または private"
       },
       access: {
+        label: "アクセス",
         helpText: "このエージェントとチャット可能なユーザー ID またはロール名"
       },
       permissions: {
+        label: "権限",
         helpText: "このエージェントの使用に必要な権限"
       },
       tenantId: {
+        label: "テナント ID",
         helpText: "特定 organization ID に制限"
       },
       guardrails: {
+        label: "ガードレール",
         helpText: "安全ルールとコンテンツポリシー"
       }
     }
@@ -1135,36 +1513,47 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名前",
         helpText: "一意識別子（snake_case）"
       },
       label: {
+        label: "表示名",
         helpText: "Studio UI 向け表示名"
       },
       description: {
+        label: "説明",
         helpText: "AI にこのツールの使用タイミングを指示 — 具体的に！"
       },
       category: {
+        label: "カテゴリ",
         helpText: "ツールカテゴリ（data, action, flow, integration など）"
       },
       objectName: {
+        label: "オブジェクト名",
         helpText: "関連オブジェクト（このツールが特定オブジェクトを扱う場合）"
       },
       active: {
+        label: "有効",
         helpText: "このツールの有効/無効"
       },
       builtIn: {
+        label: "組み込み",
         helpText: "プラットフォーム組み込みツール（ユーザー定義との対比）"
       },
       parameters: {
+        label: "パラメーター",
         helpText: "入力パラメーター — 次のようなプロパティを定義: {name: {type: \"string\", description: \"...\"}}"
       },
       outputSchema: {
+        label: "出力スキーマ",
         helpText: "検証用出力スキーマ（任意）"
       },
       requiresConfirmation: {
+        label: "確認が必要",
         helpText: "実行前にユーザー承認を求める（破壊的アクション用）"
       },
       permissions: {
+        label: "権限",
         helpText: "このツールの使用に必要な権限"
       }
     }
@@ -1191,30 +1580,39 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名前",
         helpText: "一意識別子（snake_case）"
       },
       label: {
+        label: "表示名",
         helpText: "表示名（例: \"Case Management\"）"
       },
       description: {
+        label: "説明",
         helpText: "このスキルの処理内容"
       },
       active: {
+        label: "有効",
         helpText: "このスキルの有効/無効"
       },
       instructions: {
+        label: "指示",
         helpText: "AI への指示 — これらのツールを併用する方法を指定"
       },
       tools: {
+        label: "ツール",
         helpText: "ツール名（ワイルドカード対応: action_*）"
       },
       triggerPhrases: {
+        label: "トリガーフレーズ",
         helpText: "このスキルを起動する自然言語フレーズ"
       },
       triggerConditions: {
+        label: "トリガー条件",
         helpText: "プログラム条件（例: objectName == \"case\"）"
       },
       permissions: {
+        label: "権限",
         helpText: "このスキルの使用に必要な権限"
       }
     }

--- a/packages/platform-objects/src/apps/translations/ja-JP.ts
+++ b/packages/platform-objects/src/apps/translations/ja-JP.ts
@@ -85,6 +85,7 @@ export const jaJP: TranslationData = {
       navigation: {
         group_overview: { label: '概要' },
         nav_metadata_directory: { label: 'すべてのメタデータタイプ' },
+        nav_packages: { label: 'パッケージ' },
         group_data_model: { label: 'データモデル' },
         nav_objects: { label: 'オブジェクト' },
         nav_validations: { label: 'バリデーション' },

--- a/packages/platform-objects/src/apps/translations/zh-CN.metadata-forms.generated.ts
+++ b/packages/platform-objects/src/apps/translations/zh-CN.metadata-forms.generated.ts
@@ -31,156 +31,246 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名称",
         helpText: "snake_case 唯一标识符（创建后不可修改）"
       },
       label: {
+        label: "显示名称",
         helpText: "单数显示名（如：\"客户\"）"
       },
       pluralLabel: {
+        label: "复数显示名称",
         helpText: "复数显示名（如：\"客户列表\"）"
       },
       icon: {
+        label: "图标",
         helpText: "Lucide 图标名称（如：\"building\"、\"users\"）"
       },
       description: {
+        label: "描述",
         helpText: "开发文档说明"
       },
       tags: {
+        label: "标签",
         helpText: "分类标签（如：\"sales\"、\"system\"）"
       },
       active: {
+        label: "启用",
         helpText: "对象是否启用并可用"
       },
       isSystem: {
+        label: "系统内置",
         helpText: "系统对象（受保护，不可删除）"
       },
       abstract: {
+        label: "抽象",
         helpText: "抽象基类（不能直接实例化）"
       },
       fields: {
+        label: "字段",
         helpText: "添加该对象将存储的列"
       },
       "fields.label": {
+        label: "显示名称",
         helpText: "展示用标签"
       },
       "fields.type": {
+        label: "类型",
         helpText: "字段类型"
       },
       "fields.description": {
-        helpText: "Developer documentation for this column"
+        label: "描述",
+        helpText: "此列的开发者文档"
       },
       "fields.required": {
-        helpText: "Must be set on every record"
+        label: "必填",
+        helpText: "每条记录都必须填写"
       },
       "fields.unique": {
-        helpText: "Disallow duplicate values"
+        label: "唯一",
+        helpText: "不允许重复值"
       },
       "fields.indexed": {
-        helpText: "Create a database index for faster querying"
+        label: "已索引",
+        helpText: "创建数据库索引以加快查询"
       },
       "fields.readonly": {
-        helpText: "Visible but never user-editable"
+        label: "只读",
+        helpText: "可见，但用户不可编辑"
       },
       "fields.immutable": {
-        helpText: "Editable on create, locked thereafter"
+        label: "不可变",
+        helpText: "创建时可编辑，之后锁定"
       },
       "fields.hidden": {
-        helpText: "Hidden from default UI"
+        label: "隐藏",
+        helpText: "在默认界面中隐藏"
       },
       "fields.searchable": {
-        helpText: "Include in full-text search"
+        label: "可搜索",
+        helpText: "纳入全文搜索"
       },
       "fields.sortable": {
-        helpText: "Allow sorting on this column"
+        label: "可排序",
+        helpText: "允许按此列排序"
       },
       "fields.filterable": {
-        helpText: "Allow filtering on this column"
+        label: "可筛选",
+        helpText: "允许按此列筛选"
       },
       "fields.defaultValue": {
-        helpText: "Default value for new records (JSON literal)"
+        label: "默认值",
+        helpText: "新记录的默认值（JSON 字面量）"
       },
       "fields.placeholder": {
-        helpText: "Placeholder hint"
+        label: "占位符",
+        helpText: "占位提示"
       },
       "fields.maxLength": {
-        helpText: "Max characters"
+        label: "最大长度",
+        helpText: "最大字符数"
       },
       "fields.minLength": {
-        helpText: "Min characters"
+        label: "最小长度",
+        helpText: "最小字符数"
       },
       "fields.min": {
-        helpText: "Minimum value"
+        label: "最小值",
+        helpText: "最小值"
       },
       "fields.max": {
-        helpText: "Maximum value"
+        label: "最大值",
+        helpText: "最大值"
       },
       "fields.precision": {
-        helpText: "Total digits"
+        label: "精度",
+        helpText: "总位数"
       },
       "fields.scale": {
-        helpText: "Decimal places"
+        label: "小数位",
+        helpText: "小数位数"
       },
       "fields.options": {
-        helpText: "Available choices"
+        label: "选项",
+        helpText: "可选项"
+      },
+      "fields.options.label": {
+        label: "显示名称"
+      },
+      "fields.options.value": {
+        label: "值"
+      },
+      "fields.options.color": {
+        label: "颜色"
       },
       "fields.options.icon": {
-        helpText: "Lucide icon name"
+        label: "图标",
+        helpText: "Lucide 图标名称"
+      },
+      "fields.options.description": {
+        label: "描述"
       },
       "fields.reference": {
+        label: "引用对象",
         helpText: "目标对象（用于 lookup / master_detail）"
       },
       "fields.referenceFilter": {
-        helpText: "CEL filter applied to the picker"
+        label: "引用过滤",
+        helpText: "应用于选择器的 CEL 过滤条件"
       },
       "fields.cascadeDelete": {
-        helpText: "Delete children when parent is deleted"
+        label: "级联删除",
+        helpText: "删除父记录时一并删除子记录"
       },
       "fields.multiple": {
-        helpText: "Allow selecting multiple records"
+        label: "多选",
+        helpText: "允许选择多条记录"
       },
       "fields.formula": {
-        helpText: "CEL formula expression"
+        label: "公式",
+        helpText: "CEL 公式表达式"
       },
       "fields.returnType": {
-        helpText: "Result type for formulas"
+        label: "返回类型",
+        helpText: "公式结果类型"
       },
       "fields.summaryType": {
-        helpText: "Aggregation"
+        label: "汇总类型",
+        helpText: "聚合方式"
       },
       "fields.summaryField": {
-        helpText: "Field on child object to aggregate"
+        label: "汇总字段",
+        helpText: "要聚合的子对象字段"
       },
       "fields.displayFormat": {
-        helpText: "e.g. \"INV-{0000}\""
+        label: "显示格式",
+        helpText: "例如 \"INV-{0000}\""
       },
       "fields.startingNumber": {
-        helpText: "Starting sequence value"
+        label: "起始编号",
+        helpText: "序列起始值"
       },
       "fields.language": {
-        helpText: "Editor language (e.g. sql, javascript)"
+        label: "语言",
+        helpText: "编辑器语言（如 sql、javascript）"
       },
       "fields.validation": {
-        helpText: "CEL predicate — must evaluate true"
+        label: "校验",
+        helpText: "CEL 谓词，必须求值为 true"
       },
       "fields.errorMessage": {
-        helpText: "Shown when validation fails"
+        label: "错误消息",
+        helpText: "校验失败时显示"
       },
       "fields.audit": {
-        helpText: "Audit changes to this field"
+        label: "审计",
+        helpText: "审计此字段的变更"
       },
       "fields.trackHistory": {
-        helpText: "Keep change history"
+        label: "历史跟踪",
+        helpText: "保留变更历史"
       },
       "fields.pii": {
-        helpText: "Personally identifiable information"
+        label: "个人信息",
+        helpText: "个人身份信息"
       },
       "fields.encrypted": {
-        helpText: "Encrypt at rest"
+        label: "加密",
+        helpText: "静态加密存储"
       },
       capabilities: {
+        label: "功能",
         helpText: "启用或禁用系统功能"
       },
+      "capabilities.trackHistory": {
+        label: "历史跟踪"
+      },
+      "capabilities.searchable": {
+        label: "可搜索"
+      },
+      "capabilities.apiEnabled": {
+        label: "启用 API"
+      },
+      "capabilities.files": {
+        label: "文件"
+      },
+      "capabilities.feeds": {
+        label: "动态"
+      },
+      "capabilities.activities": {
+        label: "活动"
+      },
+      "capabilities.trash": {
+        label: "回收站"
+      },
+      "capabilities.mru": {
+        label: "最近使用"
+      },
+      "capabilities.clone": {
+        label: "克隆"
+      },
       datasource: {
+        label: "数据源",
         helpText: "目标数据源 ID（默认：\"default\"）"
       }
     }
@@ -207,102 +297,135 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名称",
         helpText: "唯一标识符（snake_case，创建后不可修改）"
       },
       label: {
+        label: "显示名称",
         helpText: "用户看到的显示名称"
       },
       type: {
+        label: "类型",
         helpText: "该字段的数据类型"
       },
       group: {
+        label: "分组",
         helpText: "表单布局中的分组名称"
       },
       description: {
+        label: "描述",
         helpText: "展示给用户的帮助文本"
       },
       required: {
+        label: "必填",
         helpText: "用户必须填写"
       },
       unique: {
+        label: "唯一",
         helpText: "任意两条记录的值不能相同"
       },
       multiple: {
+        label: "多选",
         helpText: "允许多个值（用于 select / lookup）"
       },
       defaultValue: {
+        label: "默认值",
         helpText: "新建记录时的默认值"
       },
       minLength: {
+        label: "最小长度",
         helpText: "最少字符数"
       },
       maxLength: {
+        label: "最大长度",
         helpText: "最多字符数"
       },
       min: {
+        label: "最小值",
         helpText: "允许的最小数值"
       },
       max: {
+        label: "最大值",
         helpText: "允许的最大数值"
       },
       precision: {
+        label: "精度",
         helpText: "小数位数（如：货币用 2 表示保留两位）"
       },
       scale: {
+        label: "小数位",
         helpText: "小数部分位数"
       },
       options: {
+        label: "选项",
         helpText: "可选项（label/value 对）"
       },
       reference: {
+        label: "引用对象",
         helpText: "被引用的对象名称"
       },
       referenceFilters: {
+        label: "引用过滤",
         helpText: "筛选表达式（如：active = true）"
       },
       deleteBehavior: {
+        label: "删除行为",
         helpText: "被引用记录删除时的处理方式"
       },
       expression: {
+        label: "表达式",
         helpText: "用 CEL 表达式计算此字段的值（自动设为只读）"
       },
       summaryOperations: {
+        label: "汇总操作",
         helpText: "父子关系下的汇总聚合配置"
       },
       cached: {
+        label: "缓存",
         helpText: "计算字段的缓存配置"
       },
       columnName: {
+        label: "列名",
         helpText: "数据库中的物理列名（默认与字段名相同）"
       },
       index: {
+        label: "索引",
         helpText: "建立数据库索引以加速查询"
       },
       externalId: {
+        label: "外部 ID",
         helpText: "标记为外部 ID 用于 upsert 操作"
       },
       readonly: {
+        label: "只读",
         helpText: "在表单中只读"
       },
       hidden: {
+        label: "隐藏",
         helpText: "在默认界面视图中隐藏"
       },
       searchable: {
+        label: "可搜索",
         helpText: "纳入全局搜索结果"
       },
       sortable: {
+        label: "可排序",
         helpText: "允许按此字段排序"
       },
       auditTrail: {
+        label: "审计跟踪",
         helpText: "记录详细变更与操作人、时间戳"
       },
       trackFeedHistory: {
+        label: "动态历史跟踪",
         helpText: "在活动动态中展示变更"
       },
       encryptionConfig: {
+        label: "加密配置",
         helpText: "字段级加密（GDPR / HIPAA / PCI-DSS）"
       },
       maskingRule: {
+        label: "掩码规则",
         helpText: "PII 数据脱敏规则"
       }
     }
@@ -334,39 +457,60 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名称",
         helpText: "snake_case 标识符（创建后不可修改）"
       },
+      label: {
+        label: "显示名称"
+      },
+      description: {
+        label: "描述"
+      },
       object: {
+        label: "对象",
         helpText: "目标对象名（或 \"*\" 表示全局）"
       },
       events: {
+        label: "事件",
         helpText: "生命周期事件（如 beforeInsert、afterUpdate）"
       },
       priority: {
+        label: "优先级",
         helpText: "数字越小越先执行"
       },
       body: {
+        label: "正文",
         helpText: "L1 表达式或 L2 沙箱 JS 体"
       },
       "body.language": {
+        label: "语言",
         helpText: "expression = 纯公式；js = 沙箱 JavaScript"
       },
       "body.source": {
+        label: "源码",
         helpText: "函数体源码——禁止顶层 import"
       },
       "body.capabilities": {
+        label: "功能",
         helpText: "可用的 ctx API（api.read、api.write、crypto.uuid、log 等）"
       },
       "body.timeoutMs": {
+        label: "超时（毫秒）",
         helpText: "单次调用超时时间（毫秒）"
       },
       handler: {
+        label: "处理器",
         helpText: "处理器函数名（已废弃——建议使用 body）"
       },
       async: {
+        label: "异步",
         helpText: "后台运行，不阻塞当前事务"
       },
+      onError: {
+        label: "错误处理"
+      },
       condition: {
+        label: "条件",
         helpText: "可选公式——求值为 false 时跳过该钩子"
       }
     }
@@ -417,28 +561,87 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名称",
         helpText: "snake_case，环境内唯一"
       },
+      label: {
+        label: "显示名称"
+      },
+      description: {
+        label: "描述"
+      },
       type: {
+        label: "类型",
         helpText: "主要的视图形态"
       },
       data: {
+        label: "数据",
         helpText: "数据源——如：{\"provider\":\"object\",\"object\":\"task\"}"
       },
       columns: {
+        label: "列",
         helpText: "要展示的列（来自所选对象的字段名）"
       },
       filter: {
+        label: "筛选",
         helpText: "筛选规则"
       },
       sort: {
+        label: "排序",
         helpText: "默认排序方式"
       },
       searchableFields: {
+        label: "可搜索字段",
         helpText: "可用于快速搜索的字段名"
       },
       filterableFields: {
+        label: "可筛选字段",
         helpText: "可用于筛选的字段名"
+      },
+      resizable: {
+        label: "可调整大小"
+      },
+      striped: {
+        label: "斑马纹"
+      },
+      bordered: {
+        label: "边框"
+      },
+      compactToolbar: {
+        label: "紧凑工具栏"
+      },
+      rowHeight: {
+        label: "行高"
+      },
+      selection: {
+        label: "选择"
+      },
+      pagination: {
+        label: "分页"
+      },
+      kanban: {
+        label: "看板"
+      },
+      calendar: {
+        label: "日历"
+      },
+      gantt: {
+        label: "甘特图"
+      },
+      gallery: {
+        label: "画廊"
+      },
+      timeline: {
+        label: "时间线"
+      },
+      chart: {
+        label: "图表"
+      },
+      navigation: {
+        label: "导航"
+      },
+      sharing: {
+        label: "共享"
       }
     }
   },
@@ -464,42 +667,55 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名称",
         helpText: "snake_case 唯一标识符"
       },
       label: {
+        label: "显示名称",
         helpText: "展示给用户的页面标题"
       },
       icon: {
+        label: "图标",
         helpText: "导航菜单中显示的图标"
       },
       type: {
+        label: "类型",
         helpText: "页面类型（record、home、app、dashboard 等）"
       },
       template: {
+        label: "模板",
         helpText: "布局模板（如 \"header-sidebar-main\"）"
       },
       description: {
+        label: "描述",
         helpText: "用于导航的页面描述"
       },
       object: {
+        label: "对象",
         helpText: "绑定的对象（用于记录页）"
       },
       variables: {
+        label: "变量",
         helpText: "页面本地状态变量"
       },
       regions: {
+        label: "区域",
         helpText: "布局区域（header、main、sidebar、footer）及其组件"
       },
       isDefault: {
+        label: "默认",
         helpText: "设为该页面类型的默认页"
       },
       kind: {
+        label: "模式",
         helpText: "页面种类分组（如 record / list / detail）"
       },
       assignedProfiles: {
+        label: "指定配置文件",
         helpText: "此页面对哪些 Profile 可用"
       },
       aria: {
+        label: "无障碍",
         helpText: "无障碍标签与角色"
       }
     }
@@ -530,36 +746,50 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名称",
         helpText: "snake_case 唯一标识符"
       },
       label: {
+        label: "显示名称",
         helpText: "显示名"
       },
+      description: {
+        label: "描述"
+      },
       columns: {
+        label: "列",
         helpText: "栅格列数（默认 12）"
       },
       gap: {
+        label: "间距",
         helpText: "栅格间距（Tailwind 单位）"
       },
       refreshInterval: {
+        label: "刷新间隔",
         helpText: "自动刷新间隔（秒）"
       },
       header: {
+        label: "页眉",
         helpText: "标题、操作按钮与筛选"
       },
       widgets: {
+        label: "组件",
         helpText: "包含位置和尺寸的仪表板组件"
       },
       dateRange: {
+        label: "日期范围",
         helpText: "默认日期范围选择器"
       },
       globalFilters: {
+        label: "全局筛选",
         helpText: "应用到所有组件的筛选条件"
       },
       aria: {
+        label: "无障碍",
         helpText: "无障碍标签"
       },
       performance: {
+        label: "性能",
         helpText: "懒加载、虚拟滚动、缓存等"
       }
     }
@@ -590,48 +820,75 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名称",
         helpText: "snake_case 唯一标识符"
       },
+      label: {
+        label: "显示名称"
+      },
+      description: {
+        label: "描述"
+      },
+      version: {
+        label: "版本"
+      },
       icon: {
+        label: "图标",
         helpText: "Lucide 图标名（如 users、briefcase）"
       },
+      active: {
+        label: "启用"
+      },
       isDefault: {
+        label: "默认",
         helpText: "设为新用户的默认应用"
       },
       navigation: {
+        label: "导航",
         helpText: "递归的导航结构"
       },
       areas: {
+        label: "区域",
         helpText: "将菜单项组织为可折叠分组"
       },
       homePageId: {
+        label: "首页 ID",
         helpText: "应用打开时跳转的页面"
       },
       mobileNavigation: {
+        label: "移动端导航",
         helpText: "移动端底部 Tab 栏配置"
       },
       objects: {
+        label: "对象权限",
         helpText: "此应用暴露的对象名"
       },
       apis: {
+        label: "API",
         helpText: "API 端点定义"
       },
       defaultAgent: {
+        label: "默认智能体",
         helpText: "右下角浮动助手按钮调用的 AI 智能体"
       },
       branding: {
+        label: "品牌",
         helpText: "主色、辅色、Logo 与主题"
       },
       requiredPermissions: {
+        label: "所需权限",
         helpText: "访问该应用需要的权限"
       },
       sharing: {
+        label: "共享",
         helpText: "公开 / 内部 / 受限的访问控制"
       },
       embed: {
+        label: "嵌入",
         helpText: "iFrame 嵌入配置"
       },
       aria: {
+        label: "无障碍",
         helpText: "无障碍标签与角色"
       }
     }
@@ -658,72 +915,95 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名称",
         helpText: "唯一标识符（snake_case）"
       },
       label: {
+        label: "显示名称",
         helpText: "展示给用户的按钮文字"
       },
       objectName: {
+        label: "对象名称",
         helpText: "所属对象（可选）"
       },
       icon: {
+        label: "图标",
         helpText: "Lucide 图标名（如 \"check\"、\"x-circle\"）"
       },
       type: {
+        label: "类型",
         helpText: "点击后发生什么"
       },
       variant: {
+        label: "按钮样式",
         helpText: "按钮样式（primary=蓝色，danger=红色，ghost=透明）"
       },
       target: {
+        label: "目标",
         helpText: "调用的 URL、流程名或 API 端点"
       },
       method: {
+        label: "方法",
         helpText: "GET / POST / PUT / DELETE"
       },
       body: {
+        label: "正文",
         helpText: "要执行的 JavaScript 代码"
       },
       params: {
+        label: "参数",
         helpText: "执行前向用户收集的输入参数"
       },
       confirmText: {
+        label: "确认文本",
         helpText: "执行前的确认提示（如 \"确定要执行吗？\"）"
       },
       successMessage: {
+        label: "成功消息",
         helpText: "执行成功后的提示信息"
       },
       refreshAfter: {
+        label: "完成后刷新",
         helpText: "执行完成后刷新当前列表/页面"
       },
       locations: {
+        label: "位置",
         helpText: "出现在工具栏、行菜单等位置"
       },
       component: {
+        label: "组件",
         helpText: "以按钮、图标或菜单项的形式呈现"
       },
       visible: {
+        label: "可见",
         helpText: "CEL 表达式：满足条件时显示"
       },
       disabled: {
+        label: "禁用",
         helpText: "CEL 表达式：满足条件时禁用"
       },
       shortcut: {
+        label: "快捷键",
         helpText: "键盘快捷键（如 \"Ctrl+S\"、\"Cmd+Enter\"）"
       },
       bulkEnabled: {
+        label: "批量启用",
         helpText: "允许对多条选中记录执行"
       },
       aiExposed: {
+        label: "暴露给 AI",
         helpText: "允许 AI 智能体调用此操作"
       },
       recordIdParam: {
+        label: "记录 ID 参数",
         helpText: "API 请求体中记录 ID 的参数名"
       },
       recordIdField: {
+        label: "记录 ID 字段",
         helpText: "作为记录 ID 的字段（默认 \"id\"）"
       },
       bodyShape: {
+        label: "请求体结构",
         helpText: "请求体的组织形式（扁平或嵌套）"
       }
     }
@@ -758,36 +1038,53 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名称",
         helpText: "snake_case 唯一标识符"
       },
+      label: {
+        label: "显示名称"
+      },
+      description: {
+        label: "描述"
+      },
       objectName: {
+        label: "对象名称",
         helpText: "报表数据源对象"
       },
       type: {
+        label: "类型",
         helpText: "报表类型：tabular / summary / matrix / joined"
       },
       columns: {
+        label: "列",
         helpText: "报表中显示的列"
       },
       groupingsDown: {
+        label: "行分组",
         helpText: "行方向分组层级"
       },
       groupingsAcross: {
+        label: "列分组",
         helpText: "列方向分组层级（matrix 报表）"
       },
       blocks: {
+        label: "分块",
         helpText: "joined 报表的联合查询块"
       },
       filter: {
+        label: "筛选",
         helpText: "报表级别的筛选规则"
       },
       chart: {
+        label: "图表",
         helpText: "图表类型与配置"
       },
       aria: {
+        label: "无障碍",
         helpText: "无障碍标签与角色"
       },
       performance: {
+        label: "性能",
         helpText: "性能与缓存策略"
       }
     }
@@ -810,39 +1107,51 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名称",
         helpText: "唯一标识符（snake_case）"
       },
       label: {
+        label: "显示名称",
         helpText: "用户看到的显示名称"
       },
       type: {
+        label: "类型",
         helpText: "流程如何启动（autolaunched / record_change / schedule / screen / api）"
       },
       template: {
+        label: "模板",
         helpText: "是否为可复用子流程（可被其他流程调用）"
       },
       description: {
+        label: "描述",
         helpText: "此流程做什么"
       },
       nodes: {
+        label: "节点",
         helpText: "⚠️ 建议使用流程设计器，而非手写 JSON"
       },
       edges: {
+        label: "连线",
         helpText: "节点间的连接——建议用流程设计器编辑"
       },
       variables: {
+        label: "变量",
         helpText: "流程变量（输入/输出）"
       },
       status: {
+        label: "状态",
         helpText: "部署状态：draft → active → obsolete"
       },
       version: {
+        label: "版本",
         helpText: "版本号（自动递增）"
       },
       runAs: {
+        label: "运行身份",
         helpText: "以系统（管理员）或当前用户权限执行"
       },
       errorHandling: {
+        label: "错误处理",
         helpText: "节点失败时的处理方式（fail / retry / continue）"
       }
     }
@@ -854,7 +1163,7 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     label: "数据源"
   },
   external_catalog: {
-    label: "External Catalog"
+    label: "外部目录"
   },
   translation: {
     label: "翻译"
@@ -880,46 +1189,71 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
         description: "邮件主题模板"
       },
       html_body: {
-        label: "HTML body",
-        description: "Rich HTML body. Most clients strip <head>, so use inline styles."
+        label: "HTML 正文",
+        description: "富 HTML 正文。大多数客户端会移除 <head>，因此请使用内联样式。"
       },
       plain_text_body: {
-        label: "Plain-text body",
-        description: "Optional plain-text alternative. When omitted, the service strips tags from the HTML body to derive one. Providing one improves spam scoring."
+        label: "纯文本正文",
+        description: "可选的纯文本替代正文。省略时，服务会从 HTML 正文去除标签生成；显式提供可改善垃圾邮件评分。"
       },
       variables: {
-        label: "Variables",
-        description: "Declared variables. Rendered as hints in Studio and validated by sendTemplate() when required."
+        label: "变量",
+        description: "声明的变量。Studio 会将其渲染为提示，并在必填时由 sendTemplate() 校验。"
       },
       delivery_overrides: {
-        label: "Delivery overrides",
-        description: "Optional per-template overrides for From / Reply-To."
+        label: "发送覆盖项",
+        description: "可选的模板级 From / Reply-To 覆盖配置。"
       },
       status: {
-        label: "Status"
+        label: "状态"
       }
     },
     fields: {
       name: {
-        helpText: "Dotted snake_case (e.g. auth.password_reset, crm.welcome)"
+        label: "名称",
+        helpText: "点分隔的 snake_case（如 auth.password_reset、crm.welcome）"
+      },
+      label: {
+        label: "显示名称"
+      },
+      category: {
+        label: "分类"
       },
       locale: {
-        helpText: "BCP-47 tag — e.g. en-US, zh-CN"
+        label: "语言区域",
+        helpText: "BCP-47 标签，例如 en-US、zh-CN"
+      },
+      description: {
+        label: "描述"
+      },
+      subject: {
+        label: "主题"
+      },
+      bodyHtml: {
+        label: "HTML 正文"
+      },
+      bodyText: {
+        label: "纯文本正文"
       },
       variables: {
+        label: "变量",
         helpText: "模板内可引用的变量与默认值"
       },
       fromOverride: {
-        helpText: "{ \"name\": \"Acme Sales\", \"address\": \"sales@acme.com\" }"
+        label: "发件人覆盖",
+        helpText: "示例：{ \"name\": \"Acme Sales\", \"address\": \"sales@acme.com\" }"
       },
       replyTo: {
-        helpText: "Reply-To email address"
+        label: "回复地址",
+        helpText: "Reply-To 邮箱地址"
       },
       active: {
-        helpText: "When unchecked, sendTemplate() returns TEMPLATE_INACTIVE."
+        label: "启用",
+        helpText: "未勾选时，sendTemplate() 返回 TEMPLATE_INACTIVE。"
       },
       isSystem: {
-        helpText: "Built-in template; tenants may override but should not delete."
+        label: "系统内置",
+        helpText: "内置模板；租户可以覆盖，但不应删除。"
       }
     }
   },
@@ -945,30 +1279,39 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名称",
         helpText: "唯一标识符（snake_case）"
       },
       label: {
+        label: "显示名称",
         helpText: "面向管理员的显示标签"
       },
       isProfile: {
+        label: "是否配置文件",
         helpText: "勾选后作为完整配置文件（而非附加权限集）"
       },
       systemPermissions: {
+        label: "系统权限",
         helpText: "应用访问、API、管理操作"
       },
       objects: {
+        label: "对象权限",
         helpText: "按对象配置增删改查"
       },
       fields: {
+        label: "字段",
         helpText: "按字段配置可读 / 可写"
       },
       tabPermissions: {
+        label: "标签页权限",
         helpText: "导航中标签页的可见性"
       },
       rowLevelSecurity: {
+        label: "行级安全",
         helpText: "基于记录条件的访问规则"
       },
       contextVariables: {
+        label: "上下文变量",
         helpText: "可在规则中引用的变量"
       }
     }
@@ -995,30 +1338,39 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名称",
         helpText: "机器名（snake_case）"
       },
       label: {
+        label: "显示名称",
         helpText: "面向管理员显示的标签"
       },
       isProfile: {
+        label: "是否配置文件",
         helpText: "配置文件 = 分配给用户的基础集合。权限集 = 附加授予。"
       },
       systemPermissions: {
+        label: "系统权限",
         helpText: "系统能力键列表"
       },
       objects: {
-        helpText: "{ \"account\": { allowRead: true, allowEdit: true, ... } }"
+        label: "对象权限",
+        helpText: "示例：{ \"account\": { allowRead: true, allowEdit: true, ... } }"
       },
       fields: {
-        helpText: "{ \"account.amount\": { readable: true, editable: false } }"
+        label: "字段",
+        helpText: "示例：{ \"account.amount\": { readable: true, editable: false } }"
       },
       tabPermissions: {
-        helpText: "{ \"app_crm\": \"visible\", \"app_admin\": \"hidden\" }"
+        label: "标签页权限",
+        helpText: "示例：{ \"app_crm\": \"visible\", \"app_admin\": \"hidden\" }"
       },
       rowLevelSecurity: {
+        label: "行级安全",
         helpText: "RLS 策略数组（参见 rls.zod.ts）"
       },
       contextVariables: {
+        label: "上下文变量",
         helpText: "RLS 谓词中引用的自定义变量"
       }
     }
@@ -1033,10 +1385,18 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名称",
         helpText: "snake_case 唯一标识符"
       },
+      label: {
+        label: "显示名称"
+      },
       parent: {
+        label: "父级",
         helpText: "继承父角色的权限"
+      },
+      description: {
+        label: "描述"
       }
     }
   },
@@ -1062,57 +1422,75 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名称",
         helpText: "唯一标识符（snake_case）"
       },
       label: {
+        label: "显示名称",
         helpText: "显示名称（如：\"销售助手\"）"
       },
       role: {
+        label: "人设角色",
         helpText: "代理人设（如：\"客户支持专家\"）"
       },
       avatar: {
+        label: "头像",
         helpText: "头像图片 URL"
       },
       active: {
+        label: "启用",
         helpText: "启用或禁用此代理"
       },
       instructions: {
+        label: "指令",
         helpText: "系统提示词——告诉代理如何行动与可以做什么"
       },
       model: {
+        label: "模型",
         helpText: "AI 模型配置（提供方、模型名、温度等）"
       },
       planning: {
+        label: "规划",
         helpText: "自主推理配置（策略、最大迭代、是否重规划）"
       },
       memory: {
+        label: "记忆",
         helpText: "记忆管理（短期、长期、反思）"
       },
       lifecycle: {
+        label: "生命周期",
         helpText: "定义会话流程的状态机"
       },
       skills: {
+        label: "技能",
         helpText: "技能名称（Agent→Skill→Tool 架构）"
       },
       tools: {
+        label: "工具",
         helpText: "直接引用的工具（旧版模式）"
       },
       knowledge: {
+        label: "知识",
         helpText: "RAG 知识访问配置"
       },
       visibility: {
+        label: "可见范围",
         helpText: "范围：全局、组织或私有"
       },
       access: {
+        label: "访问",
         helpText: "可以与此代理对话的用户 ID 或角色名"
       },
       permissions: {
+        label: "权限",
         helpText: "使用此代理所需的权限"
       },
       tenantId: {
+        label: "租户 ID",
         helpText: "限定到特定组织"
       },
       guardrails: {
+        label: "护栏",
         helpText: "安全规则与内容策略"
       }
     }
@@ -1135,36 +1513,47 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名称",
         helpText: "唯一标识符（snake_case）"
       },
       label: {
+        label: "显示名称",
         helpText: "Studio 中展示的名称"
       },
       description: {
+        label: "描述",
         helpText: "告诉 AI 何时使用此工具——请尽量具体！"
       },
       category: {
+        label: "分类",
         helpText: "工具类别（data、action、flow、integration 等）"
       },
       objectName: {
+        label: "对象名称",
         helpText: "相关对象（若工具针对特定对象）"
       },
       active: {
+        label: "启用",
         helpText: "启用或禁用此工具"
       },
       builtIn: {
+        label: "内置",
         helpText: "平台内置工具（区别于用户自定义）"
       },
       parameters: {
+        label: "参数",
         helpText: "输入参数——定义形如：{name: {type: \"string\", description: \"...\"}}"
       },
       outputSchema: {
+        label: "输出 Schema",
         helpText: "用于校验的输出结构（可选）"
       },
       requiresConfirmation: {
+        label: "需要确认",
         helpText: "在执行前请求用户确认（用于破坏性操作）"
       },
       permissions: {
+        label: "权限",
         helpText: "使用此工具所需的权限"
       }
     }
@@ -1191,30 +1580,39 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
     },
     fields: {
       name: {
+        label: "名称",
         helpText: "唯一标识符（snake_case）"
       },
       label: {
+        label: "显示名称",
         helpText: "显示名（如：\"案件管理\"）"
       },
       description: {
+        label: "描述",
         helpText: "AI 用来判断是否调用的简短说明"
       },
       active: {
+        label: "启用",
         helpText: "启用或禁用此技能"
       },
       instructions: {
+        label: "指令",
         helpText: "AI 调用此技能时遵循的详细指令"
       },
       tools: {
+        label: "工具",
         helpText: "工具名（支持通配符：action_*）"
       },
       triggerPhrases: {
+        label: "触发短语",
         helpText: "激活此技能的自然语言短语"
       },
       triggerConditions: {
+        label: "触发条件",
         helpText: "程序化条件（如 objectName == \"case\"）"
       },
       permissions: {
+        label: "权限",
         helpText: "使用此技能所需的权限"
       }
     }

--- a/packages/platform-objects/src/apps/translations/zh-CN.ts
+++ b/packages/platform-objects/src/apps/translations/zh-CN.ts
@@ -85,6 +85,7 @@ export const zhCN: TranslationData = {
       navigation: {
         group_overview: { label: '总览' },
         nav_metadata_directory: { label: '全部元数据类型' },
+        nav_packages: { label: '软件包' },
         group_data_model: { label: '数据模型' },
         nav_objects: { label: '对象' },
         nav_validations: { label: '校验规则' },


### PR DESCRIPTION
## Summary\n- Generate metadata form field labels for every schema path so Studio forms have complete i18n keys\n- Update i18n coverage expectations and extraction tests\n- Regenerate metadata form bundles and add Studio Packages nav labels\n\n## Verification\n- pnpm --filter @objectstack/cli test -- i18n-coverage.test.ts i18n-extract.test.ts\n- Previously verified platform-objects build/test and Studio browser flow during implementation