### PR TITLE
feat(hono): re-export the Hono type from @objectstack/hono

### DIFF
--- a/.changeset/hono-type-reexport.md
+++ b/.changeset/hono-type-reexport.md
@@ -1,0 +1,12 @@
+---
+'@objectstack/hono': patch
+---
+
+feat(hono): re-export the `Hono` type from `@objectstack/hono`
+
+Downstream apps that consume `createHonoApp()` only need the `Hono` type to
+annotate the returned app. They can now `import type { Hono } from '@objectstack/hono'`
+instead of adding their own `hono` dependency, which guarantees a single
+`hono` across a `link:`/cross-package boundary (no duplicate-package
+type-identity errors, no version-pin alignment). `hono` remains a normal
+runtime dependency of this package, so standalone usage is unaffected.

--- a/packages/adapters/hono/src/index.ts
+++ b/packages/adapters/hono/src/index.ts
@@ -10,6 +10,18 @@ import {
 import { readEnvWithDeprecation } from '@objectstack/types';
 
 /**
+ * Re-export the `Hono` type from the copy of `hono` this adapter owns.
+ *
+ * Downstream apps (e.g. the cloud control plane) only need the `Hono` TYPE to
+ * annotate the app returned by {@link createHonoApp}. Importing it from here —
+ * rather than adding their own `hono` dependency — guarantees there is exactly
+ * ONE `hono` across the framework boundary, so the app's type matches without
+ * any version-pinning / pnpm.overrides alignment dance. `hono` stays a normal
+ * runtime dependency of THIS package, so standalone `os start` is unaffected.
+ */
+export type { Hono } from 'hono';
+
+/**
  * Minimal structural interface matching KernelManager from @objectstack/service-cloud.
  * Declared locally to avoid a circular build dependency.
  */


### PR DESCRIPTION
Lets downstream apps import the `Hono` type from `@objectstack/hono` instead of declaring their own `hono` dependency, guaranteeing a single hono across a link: boundary (no duplicate-package type-identity errors, no version-pin alignment). hono stays a normal runtime dep so standalone os start is unaffected. Pairs with the cloud change dropping its direct hono dep + pnpm.overrides.hono.

🤖 Generated with [Claude Code](https://claude.com/claude-code)