### PR TITLE
chore: ignore local .codex/ agent tooling directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ studio-crm.png
 examples/app-crm/storage/
 
 .objectstack
+
+# Local agent tooling
+.codex/


### PR DESCRIPTION
Adds `.codex/` to `.gitignore`. The Codex CLI writes a per-developer `.codex/config.toml` into the repo root; it's local tooling, not project source, so it shouldn't be tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)