### PR TITLE
feat(messaging): digest batching for notifications (ADR-0030 P3b-2)

### DIFF
--- a/.changeset/notification-digest.md
+++ b/.changeset/notification-digest.md
@@ -1,0 +1,22 @@
+---
+'@objectstack/service-messaging': minor
+---
+
+feat(messaging): digest batching for notifications (ADR-0030 P3b-2)
+
+Recipients can now batch a topic into a `daily` / `weekly` **digest** instead of
+receiving every notification immediately. Builds on P3b-1's deferral seam:
+
+- `PreferenceResolver` consumes the `digest` preference field and `digestDeferral()`
+  defers a batched recipient to the next window (local midnight / Monday 00:00),
+  tagging the target with a stable `window`. Digest takes precedence over
+  quiet-hours; `critical` and mandatory topics bypass it.
+- `sys_notification_delivery` gains a `digest_key` (`recipient|channel|window`).
+  Batched rows partition by that key so a window's rows co-locate, and the normal
+  outbox `claim()` skips them while the new `claimDigest()` drains a window whole.
+- The dispatcher's digest pass collapses each `(recipient, channel, window)` group
+  into one `renderDigest()` message under the existing per-partition cluster lock,
+  then acks every row in the group with that single outcome.
+
+Additive: non-digest notifications are unchanged. Timezone-from-`sys_user`,
+configurable send-hour, and MJML digest emails are deferred follow-ups.

--- a/docs/adr/0030-notification-platform-convergence.md
+++ b/docs/adr/0030-notification-platform-convergence.md
@@ -1,6 +1,6 @@
 # ADR-0030 — Notification Platform Convergence (single ingress, layered pipeline)
 
-**Status**: Accepted (2026-06-01) — **P0–P3b1 shipped**; P3b-2 (digest) + cross-repo objectui cut-over remain. See [§ Implementation status & remaining work](#implementation-status--remaining-work).
+**Status**: Accepted (2026-06-01) — **P0–P3b2 shipped** (P3b-2 digest collapse landed); cross-repo objectui cut-over remains. See [§ Implementation status & remaining work](#implementation-status--remaining-work).
 **Supersedes / refines**: [ADR-0012 — Notification Platform](./0012-notification-platform.md) (Draft)
 **Related**: [ADR-0019 — Approval as a Flow Node](./0019-approval-as-flow-node.md), [ADR-0022 — Connectors vs Messaging Channels](./0022-connectors-vs-messaging-channels.md)
 **Build spec**: [docs/design/notification-platform-convergence.md](../design/notification-platform-convergence.md)
@@ -82,16 +82,17 @@ The detailed cut-over runbook and per-item notes live in
 | **P2 — Subscription + preference** | `sys_notification_preference` (user×topic×channel, admin-global `*` defaults + per-user override, wildcards) + `sys_notification_subscription`; `PreferenceResolver` wired into `emit()` (most-specific-wins, mandatory bypass, fail-open). | #1444 |
 | **P3a — email channel + templates** | `createEmailChannel` (delegates transport to the `email` service per ADR-0022); `sys_notification_template` (topic×channel×locale) + declarative `{{ payload.x }}` renderer with `payload.title`/`body` fallback. | #1449 |
 | **P3b-1 — quiet-hours** | Deferred dispatch on the outbox (`EnqueueDeliveryInput.notBefore` → `nextAttemptAt`); `quietHoursDeferral()` (tz/HH:MM, overnight-aware); `critical` bypass. | #1453 |
+| **P3b-2 — digest** | `PreferenceResolver` consumes the `digest` field (`daily`/`weekly`) → `digestDeferral()` defers to the next window and tags the target; `digest_key` on `sys_notification_delivery` (partition-keyed so a window's rows co-locate); `INotificationOutbox.claimDigest()` drains batched rows whole while normal `claim()` skips them; the dispatcher's digest pass collapses each `(recipient, channel, window)` group into one `renderDigest()` message under the partition lock. `critical`/mandatory bypass. | this PR |
 | Startup | `messaging` is foundational: in `ALWAYS_ON_CAPABILITIES` (CLI) and auto-loaded when `audit` is required (cloud capability-loader). | (in #1434) |
 
 ### Remaining work (handed off to a follow-up agent)
 
-**1. P3b-2 — Digest (completes the build spec).** Build on P3b-1's deferral:
-enqueue digest items deferred to the next window, then a **collapse** step merges
-same-`(user, channel, window)` deliveries into one materialization at window time.
-Needs: a `digest_key` on `sys_notification_delivery`; a digest assembler (in/beside
-the dispatcher); a digest render template. Consumes P2's `digest` field;
-`critical`/mandatory bypass.
+**1. ~~P3b-2 — Digest~~ — done (this PR).** `PreferenceResolver` batches digest
+recipients to the next window; deliveries carry `digest_key`; the dispatcher
+collapses same-`(recipient, channel, window)` rows into one rendered message.
+Deferred sub-items not in this cut: timezone fallback to a `sys_user` field
+(digest windows currently use `quiet_hours.tz` → UTC), MJML digest emails, and a
+configurable daily send-hour (windows flush at local midnight / Monday 00:00).
 
 **2. Cross-repo objectui cut-over (the user-facing delivery — separate `objectui` repo).**
 - Repoint the Console bell (`AppHeader`/`InboxPopover`/record views) from

--- a/packages/services/service-messaging/src/digest-render.ts
+++ b/packages/services/service-messaging/src/digest-render.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { NotificationDeliveryRecord } from './outbox.js';
+
+/**
+ * One collapsed digest message assembled from a window's batched deliveries
+ * (ADR-0030 P3b-2). `items` preserves the individual notifications so a
+ * structured channel (inbox) can render a list, while `title`/`body` give a
+ * flat rendering for plain channels (email text).
+ */
+export interface DigestRenderResult {
+    title: string;
+    body: string;
+    severity: 'info';
+    count: number;
+    items: Array<{
+        notificationId: string;
+        title: string;
+        body?: string;
+        topic?: string;
+        actionUrl?: string;
+    }>;
+}
+
+/**
+ * Collapse same-`(recipient, channel, window)` deliveries into a single message.
+ * The caller guarantees `rows` is non-empty and shares a recipient + channel
+ * (the digest group). Only non-`critical` notifications are ever batched, so the
+ * digest severity is always `info`.
+ */
+export function renderDigest(rows: NotificationDeliveryRecord[]): DigestRenderResult {
+    const items = rows.map((r) => {
+        const p = r.payload ?? {};
+        return {
+            notificationId: r.notificationId,
+            title: typeof p.title === 'string' && p.title ? p.title : (r.topic ?? 'Notification'),
+            body: typeof p.body === 'string' && p.body ? p.body : undefined,
+            topic: r.topic,
+            actionUrl: typeof p.actionUrl === 'string' && p.actionUrl ? p.actionUrl : undefined,
+        };
+    });
+    const count = items.length;
+    const title = count === 1 ? items[0].title : `You have ${count} notifications`;
+    const body = items.map((it) => `• ${it.title}`).join('\n');
+    return { title, body, severity: 'info', count, items };
+}

--- a/packages/services/service-messaging/src/digest.test.ts
+++ b/packages/services/service-messaging/src/digest.test.ts
@@ -1,0 +1,139 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { MemoryNotificationOutbox } from './memory-outbox.js';
+import { NotificationDispatcher } from './dispatcher.js';
+import { renderDigest } from './digest-render.js';
+import type { NotificationDeliveryRecord } from './outbox.js';
+import type { MessagingChannel, Notification } from './channel.js';
+
+function row(over: Partial<NotificationDeliveryRecord>): NotificationDeliveryRecord {
+    return {
+        id: 'd', notificationId: 'n', recipientId: 'u1', channel: 'inbox',
+        payload: {}, partitionKey: 0, status: 'pending', attempts: 0,
+        createdAt: 0, updatedAt: 0, ...over,
+    };
+}
+
+describe('renderDigest (P3b-2)', () => {
+    it('collapses a group into one message with a per-item list', () => {
+        const out = renderDigest([
+            row({ notificationId: 'a', payload: { title: 'Task A assigned', body: 'do A' }, topic: 'task.assigned' }),
+            row({ notificationId: 'b', payload: { title: 'Task B assigned' }, topic: 'task.assigned' }),
+            row({ notificationId: 'c', payload: { title: 'Mentioned in C' }, topic: 'mention' }),
+        ]);
+        expect(out.count).toBe(3);
+        expect(out.title).toBe('You have 3 notifications');
+        expect(out.body).toBe('• Task A assigned\n• Task B assigned\n• Mentioned in C');
+        expect(out.items.map((i) => i.notificationId)).toEqual(['a', 'b', 'c']);
+        expect(out.severity).toBe('info');
+    });
+
+    it('uses the single item’s title when the window holds one notification', () => {
+        const out = renderDigest([row({ payload: { title: 'Just one' } })]);
+        expect(out.count).toBe(1);
+        expect(out.title).toBe('Just one');
+    });
+
+    it('falls back to the topic when an item has no title', () => {
+        const out = renderDigest([row({ payload: {}, topic: 'system.alert' })]);
+        expect(out.items[0].title).toBe('system.alert');
+    });
+});
+
+describe('MemoryNotificationOutbox — digest claim separation', () => {
+    it('claim() skips batched rows; claimDigest() returns only them', async () => {
+        const outbox = new MemoryNotificationOutbox(1, () => 1000);
+        await outbox.enqueue({ notificationId: 'imm', recipientId: 'u1', channel: 'inbox', payload: {} });
+        await outbox.enqueue({ notificationId: 'g1', recipientId: 'u1', channel: 'inbox', payload: {}, digestKey: 'u1|inbox|w', notBefore: 500 });
+
+        const normal = await outbox.claim({ nodeId: 'n', limit: 10, claimTtlMs: 1000 });
+        expect(normal.map((r) => r.notificationId)).toEqual(['imm']);
+
+        const digest = await outbox.claimDigest({ nodeId: 'n', limit: 10, claimTtlMs: 1000 });
+        expect(digest.map((r) => r.notificationId)).toEqual(['g1']);
+    });
+
+    it('claimDigest() defers a batched row until its window opens', async () => {
+        let now = 100;
+        const outbox = new MemoryNotificationOutbox(1, () => now);
+        await outbox.enqueue({ notificationId: 'g', recipientId: 'u1', channel: 'inbox', payload: {}, digestKey: 'u1|inbox|w', notBefore: 1000 });
+        expect(await outbox.claimDigest({ nodeId: 'n', limit: 10, claimTtlMs: 1000 })).toHaveLength(0);
+        now = 1000;
+        expect(await outbox.claimDigest({ nodeId: 'n', limit: 10, claimTtlMs: 1000 })).toHaveLength(1);
+    });
+});
+
+/** A channel that records every notification it is asked to send. */
+function recordingChannel(id: string): { channel: MessagingChannel; sent: Notification[] } {
+    const sent: Notification[] = [];
+    const channel: MessagingChannel = {
+        id,
+        async send(_ctx, req) { sent.push(req.notification); return { ok: true }; },
+        classifyError: () => 'retryable',
+    };
+    return { channel, sent };
+}
+
+function dispatcher(outbox: MemoryNotificationOutbox, channels: MessagingChannel[], now: () => number) {
+    return new NotificationDispatcher({
+        nodeId: 'node-test',
+        outbox,
+        channels: { getChannel: (cid: string) => channels.find((c) => c.id === cid) },
+        channelContext: { logger: { info() {}, warn() {}, error() {} } },
+        rng: () => 0.5,
+        now,
+        partitionCount: 1,
+        intervalMs: 10_000,
+    });
+}
+
+describe('NotificationDispatcher — digest collapse (P3b-2)', () => {
+    it('collapses a window into one message at window time and sends normal rows immediately', async () => {
+        let now = Date.UTC(2026, 0, 1, 9, 0);
+        const windowAt = Date.UTC(2026, 0, 2, 0, 0);
+        const outbox = new MemoryNotificationOutbox(1, () => now);
+        const key = 'u1|inbox|2026-01-01';
+        for (let i = 0; i < 3; i++) {
+            await outbox.enqueue({ notificationId: `n${i}`, recipientId: 'u1', channel: 'inbox', payload: { title: `Item ${i}` }, digestKey: key, notBefore: windowAt });
+        }
+        await outbox.enqueue({ notificationId: 'imm', recipientId: 'u1', channel: 'inbox', payload: { title: 'Immediate' } });
+
+        const rec = recordingChannel('inbox');
+        const d = dispatcher(outbox, [rec.channel], () => now);
+
+        // Before the window: only the immediate row sends; the batch waits.
+        await d.tick();
+        expect(rec.sent.map((n) => n.title)).toEqual(['Immediate']);
+
+        // At the window: the 3 batched rows collapse into one message.
+        now = windowAt;
+        await d.tick();
+        expect(rec.sent).toHaveLength(2);
+        const digest = rec.sent[1];
+        expect(digest.title).toBe('You have 3 notifications');
+        expect(digest.payload?.digest).toBe(true);
+        expect(digest.payload?.count).toBe(3);
+
+        // All three batched rows are acked success by the single send.
+        const success = await outbox.list({ status: 'success' });
+        expect(success.filter((r) => r.digestKey === key)).toHaveLength(3);
+    });
+
+    it('re-defers the whole group when the digest send fails', async () => {
+        let now = 1000;
+        const outbox = new MemoryNotificationOutbox(1, () => now);
+        const key = 'u1|inbox|w';
+        for (let i = 0; i < 2; i++) {
+            await outbox.enqueue({ notificationId: `n${i}`, recipientId: 'u1', channel: 'inbox', payload: { title: `Item ${i}` }, digestKey: key, notBefore: 1000 });
+        }
+        const failing: MessagingChannel = { id: 'inbox', async send() { return { ok: false, error: 'boom' }; }, classifyError: () => 'retryable' };
+        const d = dispatcher(outbox, [failing], () => now);
+
+        await d.tick();
+        // Both rows go back to pending with a future next_attempt_at (retry), not success.
+        const pending = await outbox.list({ status: 'pending' });
+        expect(pending.filter((r) => r.digestKey === key)).toHaveLength(2);
+        expect(pending.every((r) => (r.nextAttemptAt ?? 0) > now)).toBe(true);
+    });
+});

--- a/packages/services/service-messaging/src/dispatcher.ts
+++ b/packages/services/service-messaging/src/dispatcher.ts
@@ -3,6 +3,7 @@
 import type { MessagingChannel, MessagingChannelContext, Notification, SendResult } from './channel.js';
 import type { INotificationOutbox, NotificationDeliveryRecord } from './outbox.js';
 import { classifyDeliveryAttempt } from './backoff.js';
+import { renderDigest } from './digest-render.js';
 
 /** Minimal channel-registry surface the dispatcher needs (MessagingService satisfies it). */
 export interface ChannelRegistry {
@@ -166,14 +167,78 @@ export class NotificationDispatcher {
                 partition: { index, count: this.opts.partitionCount },
                 claimTtlMs: this.opts.claimTtlMs,
             });
-            if (claimed.length === 0) return;
-            await handle.renew?.(this.opts.lockTtlMs);
-            for (const row of claimed) {
-                if (handle.isHeld && !handle.isHeld()) break;
-                await this.processRow(row);
+            if (claimed.length > 0) {
+                await handle.renew?.(this.opts.lockTtlMs);
+                for (const row of claimed) {
+                    if (handle.isHeld && !handle.isHeld()) break;
+                    await this.processRow(row);
+                }
+            }
+
+            // P3b-2 digest pass: collapse due batched rows by group. Runs under
+            // the same partition lock — a window's rows share a partition (keyed
+            // on digest_key), so exactly one node assembles each digest.
+            const digestRows = await this.opts.outbox.claimDigest({
+                nodeId: this.opts.nodeId,
+                limit: this.opts.batchSize,
+                partition: { index, count: this.opts.partitionCount },
+                claimTtlMs: this.opts.claimTtlMs,
+            });
+            if (digestRows.length > 0) {
+                await handle.renew?.(this.opts.lockTtlMs);
+                for (const group of groupByDigestKey(digestRows)) {
+                    if (handle.isHeld && !handle.isHeld()) break;
+                    await this.processDigestGroup(group);
+                }
             }
         } finally {
             await handle.release();
+        }
+    }
+
+    /**
+     * Send one collapsed message for a `(recipient, channel, window)` group and
+     * ack every row in it with that one outcome. On failure the whole group
+     * re-defers together (each row keeps its own backoff via its `attempts`).
+     */
+    private async processDigestGroup(rows: NotificationDeliveryRecord[]): Promise<void> {
+        const channelName = rows[0].channel;
+        const recipient = rows[0].recipientId;
+        const channel = this.opts.channels.getChannel(channelName);
+        if (!channel) {
+            for (const row of rows) {
+                await this.opts.outbox.ack(row.id, { success: false, error: `channel '${channelName}' not registered`, dead: true });
+                this.opts.onAttempt?.(row, false);
+            }
+            return;
+        }
+
+        const digest = renderDigest(rows);
+        const notification: Notification = {
+            notificationId: rows[0].notificationId, // representative event id
+            organizationId: rows[0].organizationId,
+            topic: rows[0].topic,
+            title: digest.title,
+            body: digest.body,
+            severity: 'info',
+            recipients: [recipient],
+            channels: [channelName],
+            payload: { digest: true, count: digest.count, items: digest.items },
+        };
+
+        let result: SendResult;
+        try {
+            result = await channel.send(this.opts.channelContext, { notification, channel: channelName, recipient });
+        } catch (err) {
+            result = { ok: false, error: (err as Error)?.message ?? String(err) };
+        }
+
+        const errorClass = !result.ok && channel.classifyError ? channel.classifyError(result.error) : undefined;
+        const now = this.opts.now?.() ?? Date.now();
+        for (const row of rows) {
+            const ack = classifyDeliveryAttempt(result, errorClass, row.attempts, now, this.opts.rng);
+            await this.opts.outbox.ack(row.id, ack);
+            this.opts.onAttempt?.(row, result.ok);
         }
     }
 
@@ -221,6 +286,18 @@ export class NotificationDispatcher {
         await this.opts.outbox.ack(row.id, ack);
         this.opts.onAttempt?.(row, result.ok);
     }
+}
+
+/** Group claimed digest rows by their `digestKey` (insertion order preserved). */
+function groupByDigestKey(rows: NotificationDeliveryRecord[]): NotificationDeliveryRecord[][] {
+    const groups = new Map<string, NotificationDeliveryRecord[]>();
+    for (const r of rows) {
+        const key = r.digestKey ?? r.id; // defensive — claimDigest only returns keyed rows
+        let g = groups.get(key);
+        if (!g) { g = []; groups.set(key, g); }
+        g.push(r);
+    }
+    return [...groups.values()];
 }
 
 /** Spread the starting partition per node so contention rotates fairly. */

--- a/packages/services/service-messaging/src/memory-outbox.ts
+++ b/packages/services/service-messaging/src/memory-outbox.ts
@@ -45,12 +45,15 @@ export class MemoryNotificationOutbox implements INotificationOutbox {
             topic: input.topic,
             payload: input.payload ?? {},
             organizationId: input.organizationId,
-            partitionKey: hashPartition(input.notificationId, this.partitionCount),
+            // Digest rows partition by their group key so a window's rows land in
+            // one partition and a single node collapses them under its lock.
+            partitionKey: hashPartition(input.digestKey ?? input.notificationId, this.partitionCount),
             status: 'pending',
             attempts: 0,
-            // Deferred dispatch (quiet-hours, P3): claim() skips pending rows
-            // whose nextAttemptAt is still in the future.
+            // Deferred dispatch (quiet-hours / digest, P3): claim() skips pending
+            // rows whose nextAttemptAt is still in the future.
             nextAttemptAt: input.notBefore,
+            digestKey: input.digestKey,
             createdAt: now,
             updatedAt: now,
         });
@@ -72,6 +75,35 @@ export class MemoryNotificationOutbox implements INotificationOutbox {
         for (const r of this.rows.values()) {
             if (out.length >= opts.limit) break;
             if (r.status !== 'pending') continue;
+            if (r.digestKey != null) continue; // batched rows drain via claimDigest
+            if (opts.partition && r.partitionKey !== opts.partition.index) continue;
+            if (r.nextAttemptAt != null && r.nextAttemptAt > now) continue;
+            r.status = 'in_flight';
+            r.claimedBy = opts.nodeId;
+            r.claimedAt = now;
+            r.updatedAt = now;
+            out.push({ ...r });
+        }
+        return out;
+    }
+
+    async claimDigest(opts: ClaimOptions): Promise<NotificationDeliveryRecord[]> {
+        const now = opts.now ?? this.clock();
+        // Reap stale in_flight (same as claim).
+        for (const r of this.rows.values()) {
+            if (r.status === 'in_flight' && (r.claimedAt ?? 0) < now - opts.claimTtlMs) {
+                r.status = 'pending';
+                r.claimedBy = undefined;
+                r.claimedAt = undefined;
+                r.updatedAt = now;
+            }
+        }
+        // Claim every DUE batched row in the partition — a window must be taken
+        // whole, so `limit` does not truncate a group here.
+        const out: NotificationDeliveryRecord[] = [];
+        for (const r of this.rows.values()) {
+            if (r.status !== 'pending') continue;
+            if (r.digestKey == null) continue;
             if (opts.partition && r.partitionKey !== opts.partition.index) continue;
             if (r.nextAttemptAt != null && r.nextAttemptAt > now) continue;
             r.status = 'in_flight';

--- a/packages/services/service-messaging/src/messaging-service.ts
+++ b/packages/services/service-messaging/src/messaging-service.ts
@@ -496,7 +496,7 @@ export class MessagingService {
             actionUrl: actionUrlFor(input, payload),
         };
         const deliveries: DeliveryOutcome[] = [];
-        for (const { recipient, channels, notBefore } of targets) {
+        for (const { recipient, channels, notBefore, digest } of targets) {
             for (const channel of channels) {
                 try {
                     const id = await outbox.enqueue({
@@ -506,9 +506,12 @@ export class MessagingService {
                         topic: input.topic,
                         payload: deliveryPayload,
                         organizationId: input.organizationId,
-                        // Quiet-hours deferral (P3b): the dispatcher won't claim
-                        // this row until `notBefore`. Absent ⇒ immediate.
+                        // Quiet-hours / digest deferral (P3b): the dispatcher won't
+                        // claim this row until `notBefore`. Absent ⇒ immediate.
                         notBefore,
+                        // P3b-2: tag batched deliveries so the dispatcher collapses
+                        // a `(recipient, channel, window)` group into one message.
+                        digestKey: digest ? `${recipient}|${channel}|${digest.window}` : undefined,
                     });
                     deliveries.push({ channel, recipient, ok: true, externalId: id });
                 } catch (err) {

--- a/packages/services/service-messaging/src/objects/notification-delivery.object.ts
+++ b/packages/services/service-messaging/src/objects/notification-delivery.object.ts
@@ -39,6 +39,14 @@ export const NotificationDelivery = ObjectSchema.create({
         channel: Field.text({ label: 'Channel', required: true }),
         topic: Field.text({ label: 'Topic', searchable: true }),
 
+        // P3b-2 digest: when the recipient's preference batches this channel
+        // (`digest: daily|weekly`), the row enqueues deferred to the next window
+        // and carries `${recipient}|${channel}|${window}` here. The dispatcher's
+        // digest pass collapses all same-key rows into ONE rendered message at
+        // window time. Null ⇒ an ordinary (immediate / quiet-hours) delivery.
+        digest_key: Field.text({ label: 'Digest Key', searchable: true,
+            description: 'recipient|channel|window grouping key for batched (digest) deliveries; null for normal sends.' }),
+
         payload: Field.json({
             label: 'Payload',
             description: 'Snapshot of the rendered notification content for dispatch.',
@@ -71,5 +79,7 @@ export const NotificationDelivery = ObjectSchema.create({
         // Stale-in_flight reaper.
         { fields: ['status', 'claimed_at'] },
         { fields: ['notification_id'] },
+        // P3b-2: the digest collapse pass — claim due batched rows by group.
+        { fields: ['digest_key', 'status', 'next_attempt_at'] },
     ],
 });

--- a/packages/services/service-messaging/src/outbox.ts
+++ b/packages/services/service-messaging/src/outbox.ts
@@ -45,6 +45,13 @@ export interface NotificationDeliveryRecord {
     error?: string;
     createdAt: number;
     updatedAt: number;
+    /**
+     * P3b-2 digest grouping key (`${recipient}|${channel}|${window}`). When set,
+     * the row is batched: the normal {@link INotificationOutbox.claim} path skips
+     * it, and {@link INotificationOutbox.claimDigest} collapses all same-key rows
+     * into one rendered message at window time.
+     */
+    digestKey?: string;
 }
 
 export interface EnqueueDeliveryInput {
@@ -61,6 +68,12 @@ export interface EnqueueDeliveryInput {
      * by the ADR-0030 P3 quiet-hours scheduler; absent ⇒ immediate.
      */
     notBefore?: number;
+    /**
+     * P3b-2 digest grouping key. When set, the row partitions by this key (so a
+     * window's rows share a partition and one node collapses them) and is drained
+     * via {@link INotificationOutbox.claimDigest} rather than the normal claim.
+     */
+    digestKey?: string;
 }
 
 export interface ClaimOptions {
@@ -104,4 +117,13 @@ export interface INotificationOutbox {
     claim(opts: ClaimOptions): Promise<NotificationDeliveryRecord[]>;
     ack(id: string, result: AckResult): Promise<void>;
     list(filter?: { status?: DeliveryStatus; notificationId?: string }): Promise<NotificationDeliveryRecord[]>;
+    /**
+     * P3b-2: atomically claim **all** due batched rows (those with a `digestKey`)
+     * in scope, so the dispatcher can collapse same-key rows into one message.
+     * Like {@link claim} it flips rows to `in_flight` and respects `partition` /
+     * `nextAttemptAt`; unlike it, it returns *only* digest rows and is not
+     * `limit`-bounded per group (a window must be claimed whole). Normal `claim`
+     * MUST exclude digest rows so they are never sent individually.
+     */
+    claimDigest(opts: ClaimOptions): Promise<NotificationDeliveryRecord[]>;
 }

--- a/packages/services/service-messaging/src/preference-resolver.test.ts
+++ b/packages/services/service-messaging/src/preference-resolver.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
-import { PreferenceResolver, quietHoursDeferral } from './preference-resolver.js';
+import { PreferenceResolver, quietHoursDeferral, digestDeferral } from './preference-resolver.js';
 
 function silentLogger() {
     return { info: () => {}, warn: () => {}, error: () => {} };
@@ -197,5 +197,63 @@ describe('PreferenceResolver — quiet hours', () => {
         const r = resolver(() => data.engine);
         const out = await r.filter(['u1'], ['inbox'], { topic: 'task.assigned', now });
         expect(out[0].notBefore).toBe(Date.UTC(2026, 0, 2, 8, 0));
+    });
+});
+
+describe('digestDeferral (P3b-2)', () => {
+    // 2026-01-01 09:00 UTC is a Thursday (ISO weekday 4).
+    const now = Date.UTC(2026, 0, 1, 9, 0);
+
+    it('daily → next local midnight, window keyed by the current date', () => {
+        const out = digestDeferral('daily', now, 'UTC');
+        expect(out.notBefore).toBe(Date.UTC(2026, 0, 2, 0, 0));
+        expect(out.window).toBe('2026-01-01');
+    });
+
+    it('weekly → next Monday 00:00, window keyed by this week’s Monday', () => {
+        const out = digestDeferral('weekly', now, 'UTC');
+        expect(out.notBefore).toBe(Date.UTC(2026, 0, 5, 0, 0)); // Mon 2026-01-05
+        expect(out.window).toBe('2025-12-29'); // Mon of the current week
+    });
+
+    it('defaults to UTC when no tz is given', () => {
+        expect(digestDeferral('daily', now).window).toBe('2026-01-01');
+    });
+});
+
+describe('PreferenceResolver — digest', () => {
+    it('stamps notBefore + the digest window on the target', async () => {
+        const now = Date.UTC(2026, 0, 1, 9, 0);
+        const rows = [pref({ user_id: 'u1', topic: '*', channel: '*', enabled: true })];
+        (rows[0] as any).digest = 'daily';
+        const data = fakeData(rows);
+        const r = resolver(() => data.engine);
+        const out = await r.filter(['u1'], ['inbox', 'email'], { topic: 'task.assigned', now });
+        expect(out).toEqual([{
+            recipient: 'u1',
+            channels: ['inbox', 'email'],
+            notBefore: Date.UTC(2026, 0, 2, 0, 0),
+            digest: { window: '2026-01-01' },
+        }]);
+    });
+
+    it('takes precedence over quiet-hours when both are set', async () => {
+        const now = Date.UTC(2026, 0, 1, 9, 0);
+        const rows = [pref({ user_id: 'u1', topic: '*', channel: '*', enabled: true })];
+        (rows[0] as any).digest = 'daily';
+        (rows[0] as any).quiet_hours = { tz: 'UTC', start: '09:00', end: '17:00' };
+        const r = resolver(() => fakeData(rows).engine);
+        const out = await r.filter(['u1'], ['inbox'], { topic: 'task.assigned', now });
+        expect(out[0].digest).toEqual({ window: '2026-01-01' });
+        expect(out[0].notBefore).toBe(Date.UTC(2026, 0, 2, 0, 0)); // digest window, not the 17:00 quiet-hours end
+    });
+
+    it('a critical event bypasses digest batching', async () => {
+        const now = Date.UTC(2026, 0, 1, 9, 0);
+        const rows = [pref({ user_id: 'u1', topic: '*', channel: '*', enabled: true })];
+        (rows[0] as any).digest = 'daily';
+        const r = resolver(() => fakeData(rows).engine);
+        const out = await r.filter(['u1'], ['inbox'], { topic: 'task.assigned', now, severity: 'critical' });
+        expect(out).toEqual([{ recipient: 'u1', channels: ['inbox'] }]); // no notBefore, no digest
     });
 });

--- a/packages/services/service-messaging/src/preference-resolver.ts
+++ b/packages/services/service-messaging/src/preference-resolver.ts
@@ -39,12 +39,20 @@ export interface PreferenceTarget {
     recipient: string;
     channels: string[];
     /**
-     * Earliest dispatch time (epoch ms) when the recipient is inside their
-     * quiet-hours window; absent ⇒ send now. Applies to all of this recipient's
-     * channels (quiet hours are a per-person setting). Honored only on the
-     * durable outbox path; inline best-effort fan-out ignores it.
+     * Earliest dispatch time (epoch ms) when the recipient is deferred — by
+     * quiet-hours *or* a digest window (P3b). Absent ⇒ send now. Applies to all
+     * of this recipient's channels. Honored only on the durable outbox path;
+     * inline best-effort fan-out ignores it.
      */
     notBefore?: number;
+    /**
+     * P3b-2 digest: present when the recipient batches this topic. `window` is a
+     * stable label for the accumulation window (e.g. the local date for `daily`,
+     * the week-start date for `weekly`); the dispatcher collapses all
+     * `${recipient}|${channel}|${window}` deliveries into one message. Pairs with
+     * `notBefore` = the window's dispatch time.
+     */
+    digest?: { window: string };
 }
 
 /** Quiet-hours window declared on a preference row. */
@@ -53,6 +61,9 @@ export interface QuietHours {
     start?: string; // 'HH:MM'
     end?: string; // 'HH:MM'
 }
+
+/** Digest cadence declared on a preference row (P3b-2). `none` ⇒ no batching. */
+export type DigestCadence = 'daily' | 'weekly';
 
 const WILDCARD = '*';
 
@@ -123,6 +134,7 @@ export class PreferenceResolver {
             index.set(`${user}|${topic}|${channel}`, {
                 enabled: asBool(r.enabled),
                 quietHours: parseQuietHours(r.quiet_hours),
+                digest: parseDigest(r.digest),
             });
         }
 
@@ -134,14 +146,28 @@ export class PreferenceResolver {
                 (channel) => this.resolveRow(index, recipient, ctx.topic, channel)?.enabled ?? true,
             );
             if (accepted.length === 0) continue;
-            // Quiet-hours deferral (per person; declared on a channel-wildcard
-            // row). Critical events bypass it.
+            // Deferral (per person; declared on a channel-wildcard row). Critical
+            // events bypass both. A digest cadence takes precedence over
+            // quiet-hours: batching already defers to a window boundary, and it
+            // additionally tags the target so the dispatcher can collapse the
+            // window's deliveries into one message.
             let notBefore: number | undefined;
+            let digest: { window: string } | undefined;
             if (!critical) {
-                const qh = this.resolveQuietHours(index, recipient, ctx.topic);
-                notBefore = qh ? quietHoursDeferral(qh, nowMs) : undefined;
+                const cadence = this.resolveDigest(index, recipient, ctx.topic);
+                if (cadence) {
+                    const d = digestDeferral(cadence, nowMs, this.resolveQuietHours(index, recipient, ctx.topic)?.tz);
+                    notBefore = d.notBefore;
+                    digest = { window: d.window };
+                } else {
+                    const qh = this.resolveQuietHours(index, recipient, ctx.topic);
+                    notBefore = qh ? quietHoursDeferral(qh, nowMs) : undefined;
+                }
             }
-            targets.push(notBefore != null ? { recipient, channels: accepted, notBefore } : { recipient, channels: accepted });
+            const target: PreferenceTarget = { recipient, channels: accepted };
+            if (notBefore != null) target.notBefore = notBefore;
+            if (digest) target.digest = digest;
+            targets.push(target);
         }
         return targets;
     }
@@ -189,11 +215,27 @@ export class PreferenceResolver {
         }
         return undefined;
     }
+
+    /**
+     * Resolve a recipient's digest cadence. Like quiet-hours, declared on a
+     * channel-wildcard row (`(user, *, *)` or `(user, topic, *)`) — batching is a
+     * per-person, channel-agnostic setting. Most-specific user/topic wins.
+     */
+    private resolveDigest(index: Map<string, PrefRowLite>, user: string, topic: string): DigestCadence | undefined {
+        for (const u of [user, WILDCARD]) {
+            for (const t of [topic, WILDCARD]) {
+                const hit = index.get(`${u}|${t}|${WILDCARD}`);
+                if (hit?.digest) return hit.digest;
+            }
+        }
+        return undefined;
+    }
 }
 
 interface PrefRowLite {
     enabled: boolean;
     quietHours?: QuietHours;
+    digest?: DigestCadence;
 }
 
 function asBool(v: unknown): boolean {
@@ -208,6 +250,42 @@ function parseQuietHours(v: unknown): QuietHours | undefined {
     if (!o || typeof o !== 'object') return undefined;
     if (o.start == null || o.end == null) return undefined;
     return { tz: o.tz, start: String(o.start), end: String(o.end) };
+}
+
+/** Parse the `digest` preference column; only `daily`/`weekly` enable batching. */
+function parseDigest(v: unknown): DigestCadence | undefined {
+    return v === 'daily' || v === 'weekly' ? v : undefined;
+}
+
+/**
+ * Compute the digest dispatch target for `cadence` relative to `now`:
+ *  - `notBefore` (epoch ms) — when the accumulating window is flushed:
+ *      `daily` → next local midnight; `weekly` → next local Monday 00:00.
+ *  - `window` — a stable label for the *current* accumulating window so all
+ *    deliveries emitted within it collapse together: the local date for `daily`,
+ *    the week-start (Monday) date for `weekly`.
+ *
+ * Wall-clock is read in `tz` (default UTC). Day length is treated as 1440 min;
+ * a DST transition can shift the boundary by an hour — acceptable for a batch
+ * window, and the dispatcher reconciles against the real `next_attempt_at`. The
+ * `tz`→`sys_user` fallback is a separate follow-up (ADR-0030 §remaining).
+ */
+export function digestDeferral(
+    cadence: DigestCadence,
+    nowMs: number,
+    tz?: string,
+): { notBefore: number; window: string } {
+    const zone = tz ?? 'UTC';
+    const { minutesOfDay, isoWeekday, date } = wallClockInTz(nowMs, zone);
+    if (cadence === 'daily') {
+        const minsToMidnight = 1440 - minutesOfDay;
+        return { notBefore: nowMs + minsToMidnight * 60_000, window: date };
+    }
+    // weekly: flush at the next Monday 00:00; window keyed by this week's Monday.
+    const daysToNextMonday = ((8 - isoWeekday) % 7) || 7;
+    const minsToTarget = daysToNextMonday * 1440 - minutesOfDay;
+    const mondayMs = nowMs - (isoWeekday - 1) * 86_400_000;
+    return { notBefore: nowMs + minsToTarget * 60_000, window: wallClockInTz(mondayMs, zone).date };
 }
 
 /**
@@ -259,6 +337,40 @@ function minutesOfDayInTz(nowMs: number, tz: string): number {
         const d = new Date(nowMs);
         return d.getUTCHours() * 60 + d.getUTCMinutes();
     }
+}
+
+/**
+ * Wall-clock view of `nowMs` in `tz`: minutes since local midnight, ISO weekday
+ * (1=Mon … 7=Sun), and the local calendar date as `YYYY-MM-DD`. Falls back to
+ * UTC for an unknown tz.
+ */
+function wallClockInTz(nowMs: number, tz: string): { minutesOfDay: number; isoWeekday: number; date: string } {
+    try {
+        const parts = new Intl.DateTimeFormat('en-US', {
+            hour12: false, year: 'numeric', month: '2-digit', day: '2-digit',
+            hour: '2-digit', minute: '2-digit', timeZone: tz,
+        }).formatToParts(new Date(nowMs));
+        const get = (t: string) => parts.find((p) => p.type === t)?.value ?? '0';
+        const y = Number(get('year'));
+        const mo = Number(get('month'));
+        const d = Number(get('day'));
+        const hour = Number(get('hour')) % 24; // '24' → 0
+        const minute = Number(get('minute'));
+        const dow = new Date(Date.UTC(y, mo - 1, d)).getUTCDay(); // 0=Sun
+        return { minutesOfDay: hour * 60 + minute, isoWeekday: dow === 0 ? 7 : dow, date: `${y}-${pad(mo)}-${pad(d)}` };
+    } catch {
+        const dt = new Date(nowMs);
+        const dow = dt.getUTCDay();
+        return {
+            minutesOfDay: dt.getUTCHours() * 60 + dt.getUTCMinutes(),
+            isoWeekday: dow === 0 ? 7 : dow,
+            date: dt.toISOString().slice(0, 10),
+        };
+    }
+}
+
+function pad(n: number): string {
+    return String(n).padStart(2, '0');
 }
 
 function msg(err: unknown): string {

--- a/packages/services/service-messaging/src/sql-outbox.ts
+++ b/packages/services/service-messaging/src/sql-outbox.ts
@@ -37,6 +37,7 @@ interface DeliveryRow {
     next_attempt_at?: number | null;
     last_attempted_at?: number | null;
     error?: string | null;
+    digest_key?: string | null;
     created_at: number;
     updated_at: number;
 }
@@ -78,12 +79,15 @@ export class SqlNotificationOutbox implements INotificationOutbox {
             topic: input.topic ?? null,
             payload: input.payload ?? {},
             organization_id: input.organizationId ?? null,
-            partition_key: hashPartition(input.notificationId, this.partitionCount),
+            // Digest rows partition by their group key so a window's rows land in
+            // one partition and a single node collapses them under its lock.
+            partition_key: hashPartition(input.digestKey ?? input.notificationId, this.partitionCount),
             status: 'pending',
             attempts: 0,
-            // Deferred dispatch (quiet-hours, P3): claim() skips pending rows
-            // whose next_attempt_at is in the future.
+            // Deferred dispatch (quiet-hours / digest, P3): claim() skips pending
+            // rows whose next_attempt_at is in the future.
             next_attempt_at: input.notBefore ?? null,
+            digest_key: input.digestKey ?? null,
             created_at: now,
             updated_at: now,
         };
@@ -108,11 +112,13 @@ export class SqlNotificationOutbox implements INotificationOutbox {
             { where: { status: 'in_flight', claimed_at: { $lt: now - opts.claimTtlMs } }, multi: true } as any,
         );
 
-        // 2. Candidate ids: ready pending rows in our partition.
+        // 2. Candidate ids: ready pending rows in our partition. Batched (digest)
+        //    rows are excluded — they drain via claimDigest so they collapse.
         const partitionFilter = opts.partition ? { partition_key: opts.partition.index } : {};
         const candidates = await this.engine.find(this.objectName, {
             where: {
                 status: 'pending',
+                digest_key: null,
                 ...partitionFilter,
                 $or: [{ next_attempt_at: null }, { next_attempt_at: { $lte: now } }],
             },
@@ -130,6 +136,46 @@ export class SqlNotificationOutbox implements INotificationOutbox {
         );
 
         // 4. Read back only the rows we own.
+        const claimed = (await this.engine.find(this.objectName, {
+            where: { id: { $in: ids }, claimed_by: opts.nodeId, claimed_at: now, status: 'in_flight' },
+        })) as DeliveryRow[];
+        return claimed.map((r) => this.toRecord(r));
+    }
+
+    async claimDigest(opts: ClaimOptions): Promise<NotificationDeliveryRecord[]> {
+        const now = opts.now ?? Date.now();
+
+        // 1. Reap stale in_flight (same as claim).
+        await this.engine.update(
+            this.objectName,
+            { status: 'pending', claimed_by: null, claimed_at: null, updated_at: now },
+            { where: { status: 'in_flight', claimed_at: { $lt: now - opts.claimTtlMs } }, multi: true } as any,
+        );
+
+        // 2. All DUE batched rows in our partition — a window is claimed whole, so
+        //    we don't apply `limit` (a generous cap guards a pathological backlog).
+        const partitionFilter = opts.partition ? { partition_key: opts.partition.index } : {};
+        const candidates = await this.engine.find(this.objectName, {
+            where: {
+                status: 'pending',
+                digest_key: { $ne: null },
+                ...partitionFilter,
+                $or: [{ next_attempt_at: null }, { next_attempt_at: { $lte: now } }],
+            },
+            fields: ['id'],
+            limit: 10000,
+        });
+        if (!candidates.length) return [];
+        const ids = (candidates as Array<{ id: string }>).map((c) => c.id);
+
+        // 3. Atomic claim.
+        await this.engine.update(
+            this.objectName,
+            { status: 'in_flight', claimed_by: opts.nodeId, claimed_at: now, updated_at: now },
+            { where: { id: { $in: ids }, status: 'pending' }, multi: true } as any,
+        );
+
+        // 4. Read back the rows we own.
         const claimed = (await this.engine.find(this.objectName, {
             where: { id: { $in: ids }, claimed_by: opts.nodeId, claimed_at: now, status: 'in_flight' },
         })) as DeliveryRow[];
@@ -207,6 +253,7 @@ export class SqlNotificationOutbox implements INotificationOutbox {
             nextAttemptAt: r.next_attempt_at ?? undefined,
             lastAttemptedAt: r.last_attempted_at ?? undefined,
             error: r.error ?? undefined,
+            digestKey: r.digest_key ?? undefined,
             createdAt: r.created_at,
             updatedAt: r.updated_at,
         };


### PR DESCRIPTION
Completes **ADR-0030 P3b-2** — the digest middleware the platform declared in P2 (`sys_notification_preference.digest`) but never consumed.

## What

Recipients can batch a topic into a `daily` / `weekly` **digest** instead of getting every notification immediately. Builds directly on P3b-1's deferral seam.

- **PreferenceResolver** now reads the `digest` field. `digestDeferral()` defers a batched recipient to the next window (local midnight for daily, Monday 00:00 for weekly) and tags the target with a stable `window` label. Digest takes precedence over quiet-hours; `critical` and mandatory topics bypass it entirely.
- **`sys_notification_delivery`** gains `digest_key` (`recipient|channel|window`) + a grouping index. Batched rows **partition by that key** so a window's rows co-locate in one partition; the normal outbox `claim()` **skips** them and a new **`claimDigest()`** drains a window whole (implemented in both memory + sql outbox).
- **Dispatcher digest pass**: under the existing per-partition cluster lock, it claims due batched rows, groups by `digest_key`, and collapses each `(recipient, channel, window)` group into **one** `renderDigest()` message, then acks every row in the group with that single outcome (failure re-defers the whole group).

Partition-by-`digest_key` + the existing lock means exactly one node assembles each digest — no double-send across a cluster.

## Scope

Additive: non-digest notifications are completely unchanged. Deferred follow-ups (noted in the ADR): timezone fallback to a `sys_user` field (windows currently use `quiet_hours.tz` → UTC), a configurable daily send-hour, and MJML digest emails.

## Tests

+13 (`127` total in service-messaging): `digestDeferral` daily/weekly + tz; resolver stamps window + precedence + critical bypass; `renderDigest` collapse; outbox `claim`/`claimDigest` separation + window deferral; end-to-end dispatcher collapse (3 rows → 1 message, all acked) + group re-defer on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)