### PR TITLE
fix(runtime): SSO handoff value must be unique (embed token) — opening same env twice 500s

### DIFF
--- a/packages/runtime/src/cloud/auth-proxy-plugin.ts
+++ b/packages/runtime/src/cloud/auth-proxy-plugin.ts
@@ -257,7 +257,14 @@ export class AuthProxyPlugin implements Plugin {
                             const expiresAt = new Date(Date.now() + ttlSec * 1000);
                             await internal.createVerificationValue({
                                 identifier: `sso-handoff:${handoff}`,
-                                value: JSON.stringify({ email, name, by, envId: envIdInBody ?? environmentId }),
+                                // `sys_verification.value` carries a UNIQUE index (it is the
+                                // OTP/token column for email-verification flows). The handoff
+                                // puts its unique token in `identifier`, so the value payload
+                                // must ALSO embed the token (`t`) — otherwise two handoffs for
+                                // the same owner+env produce identical value JSON and the second
+                                // one fails with `UNIQUE constraint failed: sys_verification.value`
+                                // (i.e. opening the same environment twice 500s).
+                                value: JSON.stringify({ email, name, by, envId: envIdInBody ?? environmentId, t: handoff }),
                                 expiresAt,
                             });
                             return c.json({


### PR DESCRIPTION
## Bug
The cloud-minted SSO handoff (`sso_as_owner` / the "Open" / "打开" button) writes a `sys_verification` row via `AuthProxyPlugin`'s `POST /api/v1/auth/sso-handoff-issue`. The unique handoff token lives in `identifier` (`sso-handoff:<token>`), while `value` held a **static** JSON payload `{email,name,by,envId}`.

But `sys_verification.value` carries a **UNIQUE index** (it's the OTP/token column for email-verification flows — see `platform-objects/.../sys-verification.object.ts`). So issuing a handoff for the **same owner+env twice** produces identical `value` JSON and the second one fails:

```
UNIQUE constraint failed: sys_verification.value
```

→ An operator who opens the same environment a second time gets a **500**.

## Fix
Embed the unique handoff token (`t`) in the value payload so every issuance is distinct. The `sso-exchange` consumer only reads `email`/`name` from the parsed value, so the extra field is inert.

## Verified (local 2-process stack)
`sso_as_owner` minted **3× in a row → all 200** with distinct tokens (previously: 1st 200, 2nd+ 500). Browser handoff then lands the owner authenticated in the env console home.

> The cloud control plane has a mirror of this write (single-process/preview path) — fixed in the cloud repo alongside the harness build fix.
