### PR TITLE
perf(build): OS_SKIP_DTS gating + fix optional AI plugin "Cannot find package" skip

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
     "os": "./bin/run.js"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "if [ -n \"$OS_SKIP_DTS\" ]; then tsc -p tsconfig.build.json --noCheck --declaration false --declarationMap false; else tsc -p tsconfig.build.json; fi",
     "dev": "tsc -p tsconfig.build.json --watch",
     "test": "vitest run",
     "lint": "eslint src"

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1377,7 +1377,11 @@ export default class Serve extends Command {
           trackPlugin('AIService');
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : String(err);
-          if (!msg.includes('Cannot find module') && !msg.includes('ERR_MODULE_NOT_FOUND')) {
+          const code = (err as { code?: string })?.code;
+          const missing = code === 'ERR_MODULE_NOT_FOUND'
+            || msg.includes('Cannot find module')
+            || msg.includes('Cannot find package');
+          if (!missing) {
             console.error('[AI] AIServicePlugin failed to start:', msg);
           }
           // @objectstack/service-ai not installed — AI features unavailable
@@ -1401,7 +1405,11 @@ export default class Serve extends Command {
             trackPlugin('AIStudio');
           } catch (err: unknown) {
             const msg = err instanceof Error ? err.message : String(err);
-            if (!msg.includes('Cannot find module') && !msg.includes('ERR_MODULE_NOT_FOUND')) {
+            const code = (err as { code?: string })?.code;
+            const missing = code === 'ERR_MODULE_NOT_FOUND'
+              || msg.includes('Cannot find module')
+              || msg.includes('Cannot find package');
+            if (!missing) {
               console.error('[AI Studio] AIStudioPlugin failed to start:', msg);
             }
             // @objectstack/service-ai-studio not installed — AI authoring unavailable

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -17,7 +17,7 @@ export default defineConfig([
   {
     entry: ['src/index.ts'],
     format: ['esm'],
-    dts: true,
+    dts: !process.env.OS_SKIP_DTS,
     shims: true,
   },
 ]);

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   splitting: false,
   sourcemap: true,
   clean: true,
-  dts: true,
+  dts: !process.env.OS_SKIP_DTS,
   format: ['esm', 'cjs'],
   target: 'es2020',
 });

--- a/packages/metadata-core/tsup.config.ts
+++ b/packages/metadata-core/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   splitting: true,
   sourcemap: true,
   clean: true,
-  dts: true,
+  dts: !process.env.OS_SKIP_DTS,
   format: ['esm', 'cjs'],
   target: 'es2020',
   external: ['vitest'],

--- a/packages/metadata-fs/tsup.config.ts
+++ b/packages/metadata-fs/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   splitting: false,
   sourcemap: true,
   clean: true,
-  dts: true,
+  dts: !process.env.OS_SKIP_DTS,
   format: ['esm', 'cjs'],
   target: 'es2020',
   external: ['chokidar', '@objectstack/metadata-core'],

--- a/packages/metadata/tsup.config.ts
+++ b/packages/metadata/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   splitting: false,
   sourcemap: true,
   clean: true,
-  dts: true,
+  dts: !process.env.OS_SKIP_DTS,
   format: ['esm', 'cjs'],
   target: 'es2020',
 });

--- a/packages/platform-objects/tsup.config.ts
+++ b/packages/platform-objects/tsup.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     plugin: 'src/plugin.ts',
   },
   format: ['cjs', 'esm'],
-  dts: true,
+  dts: !process.env.OS_SKIP_DTS,
   clean: true,
   sourcemap: true,
   splitting: false,

--- a/packages/plugins/plugin-webhooks/tsup.config.ts
+++ b/packages/plugins/plugin-webhooks/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     splitting: true,
     sourcemap: true,
     clean: true,
-    dts: true,
+    dts: !process.env.OS_SKIP_DTS,
     format: ['esm', 'cjs'],
     target: 'es2020',
     external: ['vitest'],

--- a/packages/runtime/tsup.config.ts
+++ b/packages/runtime/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   splitting: false,
   sourcemap: true,
   clean: true,
-  dts: true,
+  dts: !process.env.OS_SKIP_DTS,
   format: ['esm', 'cjs'],
   target: 'es2020',
   // Mark driver packages as external so they are resolved at runtime, not bundled

--- a/packages/services/service-cluster-redis/tsup.config.ts
+++ b/packages/services/service-cluster-redis/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     splitting: true,
     sourcemap: true,
     clean: true,
-    dts: true,
+    dts: !process.env.OS_SKIP_DTS,
     format: ['esm', 'cjs'],
     target: 'es2020',
     external: ['vitest', 'ioredis'],

--- a/packages/services/service-cluster/tsup.config.ts
+++ b/packages/services/service-cluster/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   splitting: true,
   sourcemap: true,
   clean: true,
-  dts: true,
+  dts: !process.env.OS_SKIP_DTS,
   format: ['esm', 'cjs'],
   target: 'es2020',
   external: ['vitest'],

--- a/packages/services/service-datasource/tsup.config.ts
+++ b/packages/services/service-datasource/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     splitting: true,
     sourcemap: true,
     clean: true,
-    dts: true,
+    dts: !process.env.OS_SKIP_DTS,
     format: ['esm', 'cjs'],
     target: 'es2020',
     // Driver packages are loaded via optional, lazy `await import('@objectstack/driver-*')`

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -178,7 +178,7 @@
     "src/**/*.zod.ts"
   ],
   "scripts": {
-    "build": "pnpm gen:schema && pnpm gen:openapi && tsup && NODE_OPTIONS=\"--max-old-space-size=4096\" BUILD_DTS=true tsup",
+    "build": "pnpm gen:schema && pnpm gen:openapi && tsup && if [ -z \"$OS_SKIP_DTS\" ]; then NODE_OPTIONS=\"--max-old-space-size=4096\" BUILD_DTS=true tsup; fi",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "gen:schema": "OS_EAGER_SCHEMAS=1 tsx scripts/build-schemas.ts",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   splitting: false,
   sourcemap: true,
   clean: true,
-  dts: true,
+  dts: !process.env.OS_SKIP_DTS,
   format: ['esm', 'cjs'],
   target: 'es2020',
 });

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["tsconfig.json", "tsup.config.ts"],
+  "globalEnv": ["OS_SKIP_DTS"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Implements the framework-side changes tracked in [objectstack-ai/cloud#107](https://github.com/objectstack-ai/cloud/issues/107). The companion cloud PR sets `ENV OS_SKIP_DTS=1` in the image build; the big build-time win lives here (framework's build dominates image time).

## Part 1 — `OS_SKIP_DTS` gating (build-time only; default behavior unchanged)

Skip `.d.ts` emission **only when `OS_SKIP_DTS` is set**. Default `pnpm build` / `turbo typecheck` / npm publish keep generating full types.

- 12 tsup configs: `dts: true` → `dts: !process.env.OS_SKIP_DTS`
- `packages/spec/package.json`: skip the separate `BUILD_DTS=true tsup` pass (~80–90s) when `OS_SKIP_DTS` is set
- `packages/cli/package.json`: cli builds via `tsc`; when `OS_SKIP_DTS` is set, deps have no `.d.ts`, so build with `--noCheck --declaration false` to still emit runnable JS (full typecheck preserved by default)
- `turbo.json`: declare `OS_SKIP_DTS` in `globalEnv` (Turbo 2.x strict env mode otherwise filters it out; also part of the cache key)

Measured: framework `turbo run build` **~5m03s → ~1m12s** (the `@objectstack/spec` DTS pass alone is ~80–90s).

## Part 2 — fix optional AI plugin "failed to start" false alarm

`serve.ts` loads `@objectstack/service-ai` and optional `@objectstack/service-ai-studio` via `importFromHost()`, meant to silently skip when absent. The old guard only matched `Cannot find module` / `ERR_MODULE_NOT_FOUND`, but ESM throws **`Cannot find package '...'`** (the code is on `err.code`, not in the message). Control-plane hosts (e.g. `apps/cloud`) logged a scary `[AI Studio] AIStudioPlugin failed to start: Cannot find package ...` on every boot.

Fix: detect missing module via `err.code === 'ERR_MODULE_NOT_FOUND'` and also match `Cannot find package`. Applied to both the AIService and AIStudio guards.

## Verification
- `tsc -p tsconfig.build.json --noEmit` on the cli package: **exit 0** (serve.ts change typechecks).
- tsup config gating spot-check: default → `dts = true`; `OS_SKIP_DTS=1` → `dts = false`.
- JSON validity confirmed for `turbo.json`, `packages/cli/package.json`, `packages/spec/package.json`.

After merge, bump `cloud/.framework-sha` to this PR's merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)