### PR TITLE
feat(app-showcase): richer project detail (explicit highlights + details)

### DIFF
--- a/examples/app-showcase/src/pages/project-detail.page.ts
+++ b/examples/app-showcase/src/pages/project-detail.page.ts
@@ -23,11 +23,37 @@ export const ProjectDetailPage: Page = {
   isDefault: true,
   regions: [],
   slots: {
+    // Explicit highlights strip — exercises the page editor's field-list picker
+    // (objectFrom:'page' resolves showcase_project's fields).
+    highlights: {
+      type: 'record:highlights',
+      properties: {
+        fields: ['account', 'status', 'health', 'budget', 'end_date'],
+      },
+    },
     tabs: {
       type: 'page:tabs',
       properties: {
         type: 'line',
         items: [
+          {
+            // Explicit details sections — each section's `fields` is a
+            // field-list bound to showcase_project in the page editor.
+            key: 'details',
+            label: 'Details',
+            children: [
+              {
+                type: 'record:details',
+                properties: {
+                  sections: [
+                    { label: 'Overview', columns: 2, fields: ['name', 'account', 'owner', 'status'] },
+                    { label: 'Financials', columns: 2, fields: ['budget', 'spent'] },
+                    { label: 'Timeline', columns: 2, fields: ['start_date', 'end_date'] },
+                  ],
+                },
+              },
+            ],
+          },
           {
             key: 'tasks',
             label: 'Tasks',


### PR DESCRIPTION
Enhances showcase_project_detail with explicit record:highlights (account/status/health/budget/end_date) and a Details tab containing record:details sections (Overview/Financials/Timeline) bound to showcase_project. A richer record-page example that also gives the page editor's new field pickers real content to resolve.

Browser-verified: the rendered project detail shows the highlights strip + Details/Tasks tabs with the details sections (Financials/SPENT) and the master-detail Tasks grid. Example-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)