### PR TITLE
feat(showcase): project Tasks as a form-view subform (Tier 0)

### DIFF
--- a/examples/app-showcase/src/views/project.view.ts
+++ b/examples/app-showcase/src/views/project.view.ts
@@ -44,6 +44,10 @@ export const ProjectViews = defineView({
         { label: 'Project', columns: 2, fields: ['name', 'account', 'status', 'health', 'owner'] },
         { label: 'Budget & Schedule', columns: 2, fields: ['budget', 'spent', 'start_date', 'end_date'] },
       ],
+      // Config-driven master-detail (Tier 0): the standard New/Edit Project form
+      // renders its Tasks inline (FK + columns derived from showcase_task),
+      // saved as one atomic transaction — no bespoke page.
+      subforms: [{ childObject: 'showcase_task', title: 'Tasks', addLabel: 'Add task' }],
     },
   },
 });


### PR DESCRIPTION
`showcase_project`'s default form view declares `subforms: [{ childObject: 'showcase_task' }]`, so the standard New/Edit Project modal renders an inline Tasks subtable (FK + columns derived from `showcase_task`) and saves parent + tasks in one atomic `/api/v1/batch` — no bespoke page. Demonstrates Tier 0 config-driven master-detail.

Pairs with objectui (ModalForm/AppContent subforms) + `@objectstack/spec` `FormViewSchema.subforms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)