### PR TITLE
fix(spec): raise DTS build heap 4096→12288 (fix flaky DTS OOM)

### DIFF
--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -178,7 +178,7 @@
     "src/**/*.zod.ts"
   ],
   "scripts": {
-    "build": "pnpm gen:schema && pnpm gen:openapi && tsup && if [ -z \"$OS_SKIP_DTS\" ]; then NODE_OPTIONS=\"--max-old-space-size=4096\" BUILD_DTS=true tsup; fi",
+    "build": "pnpm gen:schema && pnpm gen:openapi && tsup && if [ -z \"$OS_SKIP_DTS\" ]; then NODE_OPTIONS=\"--max-old-space-size=12288\" BUILD_DTS=true tsup; fi",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "gen:schema": "OS_EAGER_SCHEMAS=1 tsx scripts/build-schemas.ts",


### PR DESCRIPTION
spec build 的 DTS 单独步骤硬编码 `NODE_OPTIONS=--max-old-space-size=4096`,**覆盖了 Docker/CI 外层的 12288**——所以类型声明构建被限在 4GB,schema/类型面变大后偶发 `ERR_WORKER_OUT_OF_MEMORY`,导致 objectos 镜像构建失败(本会话 #143 部署即因此挂)。调到 12288 与外层一致;`--max-old-space-size` 是上限非预留,小机器也安全。