### PR TITLE
docs: sync recent architecture updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,19 @@ Instead of hiding business logic inside ad-hoc SQL queries, UI state, or JavaScr
 - **Business objects** are Zod schemas with typed fields, relations, validation, and permissions.
 - **Business actions** are generated from metadata as REST APIs, SDK calls, and MCP tools.
 - **Business logic** is represented as analyzable metadata: flows, conditions, policies, and artifacts.
-- **Business runtime** is a microkernel that loads plugins, drivers, services, and compiled project artifacts.
+- **Business runtime** is a microkernel that loads plugins, drivers, services, and compiled environment artifacts.
 
 The goal is not to be another low-code UI builder. ObjectStack is the structured execution layer for AI-native business software: agent-ready, permission-aware, versioned, and auditable.
 
 ObjectStack is built around three protocol layers:
 
 - **ObjectQL** (Data Layer) — Objects, fields, queries, relations, validation, and data access.
-- **ObjectOS** (Control Layer) — Runtime, permissions, automation, plugins, tenants, and artifact loading.
+- **ObjectOS** (Control Layer) — Runtime, permissions, automation, plugins, environments, and artifact loading.
 - **ObjectUI** (View Layer) — Apps, views, dashboards, actions, and presentation metadata.
 
 All core definitions start with **Zod schemas** (1,600+ exported schemas across 200 schema files). TypeScript types, JSON Schemas, REST routes, UI metadata, and agent tools are derived from the same source of truth.
 
-See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full microkernel and layer architecture documentation, and [content/docs/concepts/north-star.mdx](./content/docs/concepts/north-star.mdx) for the product north star (Studio · Org/Project/Branch · per-project ObjectOS · compiled app artifacts).
+See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full microkernel and layer architecture documentation, and [content/docs/concepts/north-star.mdx](./content/docs/concepts/north-star.mdx) for the product north star (metadata protocols · environment-aware runtime · compiled app artifacts).
 
 ## Key Features
 
@@ -45,8 +45,8 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full microkernel and layer arch
 - **RBAC / RLS / FLS security** — Role-based, row-level, and field-level access control.
 - **Automation engine** — DAG-based flows, triggers, and workflow management.
 - **AI service** — Agent, Tool, and Skill protocol built on the Vercel AI SDK.
-- **Studio IDE** — Web-based metadata explorer, schema inspector, API console, and AI assistant.
-- **CLI toolchain** — `os init`, `os dev`, `os studio`, `os serve`, `os validate`, and more.
+- **Console UI** — Published ObjectUI console bundle for metadata exploration, schema inspection, API testing, and administration.
+- **CLI toolchain** — `os init`, `os dev`, `os start`, `os serve`, `os validate`, and more.
 
 ## Why AI-native?
 
@@ -63,7 +63,7 @@ The point isn't lines of code. The point is **fit in an agent's context window.*
 | Business model | Implicit in pages, queries, and scripts | Explicit Zod `ObjectSchema` metadata |
 | Code footprint | Thousands of lines of queries, JS, and UI state per app | **~100× less** — declarative metadata replaces CRUD, forms, validation, and API glue |
 | Business logic | JavaScript snippets and query glue | Flows, policies, conditions, and typed metadata |
-| External contract | App-specific UI state | Self-describing JSON Project Artifact |
+| External contract | App-specific UI state | Self-describing JSON Environment Artifact |
 | Agent tools | Manually defined one by one | Generated from metadata and permissions |
 | Agent reasoning | Calls predefined queries | Reads the full schema, composes safe actions, respects boundaries |
 | AI maintainability | Agents must crawl sprawling app code | Whole app fits in an agent's context window |
@@ -80,10 +80,10 @@ This makes ObjectStack a backend substrate for AI-native business applications: 
 npx create-objectstack my-app
 cd my-app
 
-# Start dev server (REST API + Studio IDE)
+# Start dev server (REST API + console UI)
 pnpm dev
 # → API:    http://localhost:3000/api/v1/
-# → Studio: http://localhost:3000/_studio/
+# → Console: http://localhost:3000/_console/
 ```
 
 Alternatively, with the CLI installed: `os init my-app && cd my-app && os dev`.
@@ -116,7 +116,7 @@ pnpm docs:dev
 | `pnpm dev:showcase` | Same as `pnpm dev` (explicit alias) |
 | `pnpm dev:crm` | Run the minimal CRM example (`@objectstack/example-crm`) |
 | `pnpm dev:todo` | Run the Todo example (`@example/app-todo`) |
-| `pnpm studio:start` | Start the prebuilt Studio IDE |
+| `pnpm objectui:refresh` | Pull the sibling `../objectui` build into `packages/console/` |
 | `pnpm test` | Run all tests (Turborepo) |
 | `pnpm setup` | Install dependencies and build the spec package |
 | `pnpm docs:dev` | Start the documentation site locally |
@@ -129,11 +129,10 @@ The CLI binary ships as both `os` and `objectstack`.
 ```bash
 os init [name]    # Scaffold a new project
 os create         # Interactive project / object scaffolder
-os dev            # Start dev server with hot-reload (REST + Studio)
-os studio         # Open the Studio IDE
+os dev            # Start dev server with hot-reload (REST + console)
 os start          # Start the production server
 os serve          # Serve a compiled artifact
-os compile        # Build a deployable JSON Project Artifact
+os compile        # Build a deployable JSON Environment Artifact
 os validate       # Validate metadata against the protocol
 os lint           # Lint metadata for best-practice violations
 os info           # Display project metadata summary
@@ -142,7 +141,7 @@ os doctor         # Check environment health
 os explain        # Explain protocol concepts on the command line
 ```
 
-Cloud, package registry, and project management subcommands (`os projects`, `os publish`, `os login`, `os whoami`, `os cloud …`) are available when targeting an ObjectStack Cloud control plane.
+Cloud, package registry, and environment management subcommands (`os publish`, `os rollback`, `os package`, `os login`, `os whoami`, `os cloud …`) are available when targeting an ObjectStack Cloud control plane.
 
 ## Package Directory
 
@@ -154,7 +153,7 @@ Cloud, package registry, and project management subcommands (`os projects`, `os 
 | [`@objectstack/core`](packages/core) | Microkernel runtime — Plugin system, DI container, EventBus, Logger |
 | [`@objectstack/types`](packages/types) | Shared TypeScript type utilities |
 | [`@objectstack/formula`](packages/formula) | Canonical expression engine — CEL (cel-js) + ObjectStack stdlib for formula fields, predicates, conditions, dynamic defaults |
-| [`@objectstack/platform-objects`](packages/platform-objects) | Built-in platform object schemas — identity, security, audit, tenant |
+| [`@objectstack/platform-objects`](packages/platform-objects) | Built-in platform object schemas — identity, security, audit, notification, package, and environment |
 
 ### Engine
 
@@ -205,7 +204,7 @@ Cloud, package registry, and project management subcommands (`os projects`, `os 
 | :--- | :--- |
 | [`@objectstack/service-ai`](packages/services/service-ai) | AI service — Agent, Tool, Skill, Vercel AI SDK integration |
 | [`@objectstack/service-analytics`](packages/services/service-analytics) | Analytics — aggregations, time series, funnels, dashboards |
-| [`@objectstack/service-automation`](packages/services/service-automation) | Automation engine — flows, triggers, DAG-based workflows |
+| [`@objectstack/service-automation`](packages/services/service-automation) | Automation engine — flows, triggers, and workflow state machines |
 | [`@objectstack/service-cache`](packages/services/service-cache) | Cache — in-memory, Redis, multi-tier |
 | [`@objectstack/service-feed`](packages/services/service-feed) | Activity feed / chatter |
 | [`@objectstack/service-i18n`](packages/services/service-i18n) | Internationalization service |
@@ -215,7 +214,6 @@ Cloud, package registry, and project management subcommands (`os projects`, `os 
 | [`@objectstack/service-realtime`](packages/services/service-realtime) | Real-time events and subscriptions |
 | [`@objectstack/service-settings`](packages/services/service-settings) | Settings — manifest registry + K/V resolver (Env > Tenant > User) |
 | [`@objectstack/service-storage`](packages/services/service-storage) | File storage (local, S3, R2, GCS) |
-| [`@objectstack/service-tenant`](packages/services/service-tenant) | Multi-tenant context and routing |
 
 ### Framework Adapters
 
@@ -233,10 +231,9 @@ Cloud, package registry, and project management subcommands (`os projects`, `os 
 
 | Package / App | Description |
 | :--- | :--- |
-| [`@objectstack/cli`](packages/cli) | CLI binary (`os` / `objectstack`) — `init`, `dev`, `serve`, `studio`, `compile`, `validate`, `generate`, `lint`, `doctor` |
+| [`@objectstack/cli`](packages/cli) | CLI binary (`os` / `objectstack`) — `init`, `dev`, `start`, `serve`, `compile`, `publish`, `validate`, `generate`, `lint`, `doctor` |
 | [`create-objectstack`](packages/create-objectstack) | Project scaffolder (`npx create-objectstack`) |
 | [`objectstack-vscode`](packages/vscode-objectstack) | VS Code extension — autocomplete, validation, diagnostics |
-| [`@objectstack/studio`](apps/studio) | Studio IDE — metadata explorer, schema inspector, AI assistant |
 | [`@object-ui/console`](https://github.com/objectstack-ai/objectui/tree/main/apps/console) | Fork-ready runtime console SPA (lives in objectstack-ai/objectui, served via `@object-ui/console` on npm) |
 | [`@objectstack/account`](apps/account) | Account & identity portal — sign in, organizations, connected apps |
 | [`@objectstack/docs`](apps/docs) | Documentation site (Fumadocs + Next.js) |
@@ -254,9 +251,9 @@ Cloud, package registry, and project management subcommands (`os projects`, `os 
 | Metric | Value |
 | :--- | :--- |
 | Source packages | 51 |
-| Apps | 6 (objectos, cloud, studio, console, account, docs) |
+| Apps | 2 (account, docs) |
 | Framework adapters | 7 (Express, Fastify, Hono, NestJS, Next.js, Nuxt, SvelteKit) |
-| Database drivers | 4 (Memory, SQL, SQLite-WASM, MongoDB) |
+| Database drivers | 3 (Memory, SQL, MongoDB) |
 | Zod schema files | 200 |
 | Exported schemas | 1,600+ |
 | `.describe()` annotations | 8,750+ |
@@ -300,9 +297,7 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) for the complete design documentation i
 
 ## Roadmap
 
-See [ROADMAP.md](./ROADMAP.md) for the planned phases covering runtime hardening, framework adapter completion, developer experience improvements, performance optimization, and security hardening.
-
-Studio-specific roadmap: [apps/studio/ROADMAP.md](./apps/studio/ROADMAP.md)
+See [ROADMAP.md](./ROADMAP.md) for the current documentation and architecture cleanup priorities.
 
 ## Contributing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,598 +1,72 @@
-# ObjectStack - Road Map
+# ObjectStack Roadmap
 
-> **Last Updated:** 2026-05-08 (M9 Expression Unification + D9/D10/D11 added — CEL/AST-first migration plan)
-> **Authoritative Spec:** [content/docs/concepts/north-star.mdx](content/docs/concepts/north-star.mdx) - §7 Alignment Check is the single source of truth for Built / Drift / Missing.
-> This file is the **actionable checklist** derived from that ledger. When north-star §7 changes, update this file too.
+> **Last updated:** 2026-06-06
+> **Source of truth:** [content/docs/concepts/north-star.mdx](content/docs/concepts/north-star.mdx) for product direction, ADRs for architectural decisions, and code for shipped behavior.
 
----
-
-## How to Read This File
-
-| Symbol | Meaning |
-|:---:|:---|
-| ✅ | Shipped - code exists and is integrated |
-| 🟡 | Partial / Drift - exists but wrong shape, needs evolution |
-| 🔴 | Not started |
-| ⛔ | Explicit non-goal - do not implement in Phase 1 |
-
-Phase 1 is **code-first ObjectStack**:
-
-- The local TypeScript workspace is the only user-metadata authoring surface.
-- `objectstack compile` produces JSON.
-- `objectstack publish` uploads that JSON to the control plane.
-- Studio is a control-plane dashboard, metadata viewer, artifact inspector, and observability surface.
-- ObjectOS pulls artifacts through HTTP and never reads control-plane DB tables directly.
-
-The implementation path is therefore:
-
-```
-Artifact format -> control-plane metadata -> Artifact API -> ObjectOS loader -> publish endpoint -> Studio viewer
-```
+This roadmap tracks the current framework repository. Historical Cloud/ObjectOS
+milestone plans that referred to `apps/cloud`, `apps/objectos`,
+`@objectstack/service-tenant`, `sys_project`, or `/api/v1/cloud/projects/*`
+have been retired. Cloud control-plane distribution work now lives outside this
+repo; this repo owns the framework runtime, protocol schemas, CLI, examples,
+docs, adapters, services, plugins, and the bundled console integration.
 
 ---
 
-## ✅ Built (Aligned)
+## Current Architecture
 
-Code that exists and matches the intended architecture. Do not regress these.
-
-| What | Code anchor |
-|:---|:---|
-| Organization CRUD + member/invitation system | [apps/studio/src/hooks/useSession.ts](apps/studio/src/hooks/useSession.ts) |
-| Project CRUD + per-project Turso/memory DB provisioning | [packages/services/service-tenant/](packages/services/service-tenant/) |
-| Per-project ObjectKernel with LRU cache | [packages/runtime/src/cloud/kernel-manager.ts](packages/runtime/src/cloud/kernel-manager.ts) |
-| Hostname-based routing: `sys_project.hostname` -> kernel resolution | [packages/runtime/src/cloud/artifact-environment-registry.ts](packages/runtime/src/cloud/artifact-environment-registry.ts) |
-| `ControlPlaneProxyDriver` - org-scoped data isolation | [apps/cloud/src/control-plane-proxy-driver.ts](apps/cloud/src/control-plane-proxy-driver.ts) |
-| `AppCatalogService` - per-project app events -> org-scoped `sys_app` catalog | [packages/services/service-tenant/src/services/app-catalog.service.ts](packages/services/service-tenant/src/services/app-catalog.service.ts) |
-| TS -> JSON compile pipeline (`objectstack compile`) | [packages/cli/src/commands/compile.ts](packages/cli/src/commands/compile.ts) |
-| Zod -> JSON Schema publishing (`z.toJSONSchema`) - TS/JSON bridge | [packages/spec/scripts/build-schemas.ts](packages/spec/scripts/build-schemas.ts) |
-| Scaffolded TS file tree (`create-objectstack` -> `defineStack()` + split `src/objects/*.ts`) | [packages/create-objectstack/src/index.ts](packages/create-objectstack/src/index.ts) |
-| JSON-payload metadata column (`sys_metadata.metadata` textarea) | [packages/metadata/src/objects/sys-metadata.object.ts](packages/metadata/src/objects/sys-metadata.object.ts) |
-| CLI `publish` - local JSON -> remote server wire (endpoint shape still wrong, see D2) | [packages/cli/src/commands/publish.ts](packages/cli/src/commands/publish.ts) |
-| **M1** Project Artifact envelope schema (`schemaVersion / projectId / commitId / checksum / metadata / functions / manifest`) | [packages/spec/src/system/project-artifact.zod.ts](packages/spec/src/system/project-artifact.zod.ts) |
-| **M3 / M4** Cloud Artifact API + runtime loader (`/cloud/resolve-hostname`, `/cloud/projects/:id/artifact`, `/cloud/projects/:id/metadata` + `ArtifactKernelFactory`) | [packages/services/service-cloud/src/cloud-artifact-api-plugin.ts](packages/services/service-cloud/src/cloud-artifact-api-plugin.ts) |
-| Single-project boot mode (`OS_MODE=standalone`) — `createSingleProjectPlugin` seeds local org/project + serves `studio/runtime-config` | [packages/services/service-cloud/src/single-project-plugin.ts](packages/services/service-cloud/src/single-project-plugin.ts) |
-| Static Setup App (no runtime `SetupPlugin`) — fixed `App` artifact registered by `plugin-auth` | [packages/platform-objects/src/apps/setup.app.ts](packages/platform-objects/src/apps/setup.app.ts) |
-| ~~Formula expression evaluator (text / math / date / logical)~~ — see D9 (replaced by CEL via M9) | [packages/objectql/src/formula.ts](packages/objectql/src/formula.ts) |
-| Studio Flow Viewer + Flow Test Runner + Flow Runs panel | [apps/studio/src/components/FlowViewer.tsx](apps/studio/src/components/FlowViewer.tsx) |
-| Automation: flow auto-discovery from ObjectQL registry | [packages/services/service-automation/src/plugin.ts](packages/services/service-automation/src/plugin.ts) |
-| **D1** ObjectOS metadata DB bridge removed - `MetadataPlugin` no longer registers `sys_metadata` / `sys_metadata_history` or auto-bridges ObjectQL to `DatabaseLoader` | [packages/metadata/src/plugin.ts](packages/metadata/src/plugin.ts) |
-| **S1** REST `requireAuth` gate + `resolveExecCtx` hostname routing (resolved 2026-05-18) — anonymous `/api/v1/data/*` returns 401 on multi-tenant ObjectOS hosts (CRUD + batch routes both gated). Auto-enabled when `tierEnabled('auth')`; force-enabled on `createObjectOSStack`. `resolveExecCtx` now mirrors `resolveProtocol`'s hostname→projectId mapping so authenticated users on hostname-routed projects can read their own org's data. **Verified live on crm.objectos.app**: anonymous=401, user A=200 (own org records), user B=200 (different org, isolated). Original CF "two accounts see same data" complaint closed. | [packages/rest/src/rest-server.ts](packages/rest/src/rest-server.ts), [packages/runtime/src/cloud/objectos-stack.ts](packages/runtime/src/cloud/objectos-stack.ts), [packages/cli/src/commands/serve.ts](packages/cli/src/commands/serve.ts) |
+- **Runtime:** `@objectstack/runtime` boots standalone/local hosts and exposes
+  Cloud-aware seams such as environment registry, runtime config, marketplace
+  proxy, and environment artifact loading.
+- **Environment identity:** current docs and runtime paths use
+  `environment`, not `project`: `OS_ENVIRONMENT_ID`,
+  `X-Environment-Id`, `/api/v1/environments/:environmentId`, and
+  `environment_id`.
+- **Console UI:** framework serves the published ObjectUI console bundle from
+  `packages/console`; active UI source development happens in sibling repo
+  `../objectui`.
+- **Cloud publishing:** CLI publish/rollback target
+  `/api/v1/cloud/environments/:environment/...` endpoints when pointed at an
+  ObjectStack Cloud control plane.
+- **Generated references:** `content/docs/references/` is generated from Zod
+  descriptions. Update `packages/spec/src/**/*.zod.ts`, then regenerate.
 
 ---
 
-## 🟡 Drift (Needs Cleanup)
+## Near-Term Priorities
 
-Existing code that contradicts the intended Phase 1 architecture. Fix these before building new surface area that depends on them.
-
-### D2 - `objectstack publish` uses legacy `/api/v1/packages` endpoint
-
-[packages/cli/src/commands/publish.ts](packages/cli/src/commands/publish.ts) POSTs a "package" payload that is not the Phase 1 project metadata endpoint.
-
-**Required evolution:**
-- Endpoint: `POST /api/v1/cloud/projects/:projectId/metadata`
-- Payload: compiled `dist/objectstack.json` (output of `objectstack compile`)
-- Server behavior: validate with Zod, write current project metadata state, create `commitId`, compute checksum
-- Response: `{ projectId, commitId, checksum }`
-
-### D3 - Remove `env_id` from metadata storage
-
-**Decision (2026-04-25): delete, don't repurpose.** Phase 1 metadata is scoped by `organization_id` + `project_id`. Deployment target differences are runtime/deployment configuration, not metadata row partitioning. Branch-like variants are explicitly deferred.
-
-**Fix path:**
-1. Add/control-plane metadata ownership columns: `organization_id` + `project_id`.
-2. Backfill existing rows to the owning organization/project.
-3. Delete `env_id` column and all references.
-4. Update unique indexes from environment-scoped keys to project-scoped keys.
-
-Known anchors to scrub:
-- [packages/metadata/src/objects/sys-metadata.object.ts](packages/metadata/src/objects/sys-metadata.object.ts)
-- [packages/metadata/src/objects/sys-metadata-history.object.ts](packages/metadata/src/objects/sys-metadata-history.object.ts)
-- [packages/metadata/src/loaders/database-loader.ts](packages/metadata/src/loaders/database-loader.ts)
-- [packages/metadata/src/projection/metadata-projector.ts](packages/metadata/src/projection/metadata-projector.ts)
-- [packages/metadata/src/utils/history-cleanup.ts](packages/metadata/src/utils/history-cleanup.ts)
-- [packages/objectql/src/plugin.ts](packages/objectql/src/plugin.ts)
-- [packages/objectql/src/protocol.ts](packages/objectql/src/protocol.ts)
-- [packages/client/src/index.ts](packages/client/src/index.ts)
-
-### D4 - ✅ `namespace` residue (resolved 2026-04-26)
-
-Object identity is now single-sourced on `name`. The deprecated `namespace`
-field has been removed from `ObjectSchemaBase` ([packages/spec/src/data/object.zod.ts](packages/spec/src/data/object.zod.ts))
-and the schema strips the key from any legacy input. Package-level namespace
-(used by the registry for FQN computation, marketplace publishing, and
-DatasourceRoutingRule) is intentionally retained — it is a separate mechanic.
-
-### D5 - ✅ Plugin `scope` enum trimmed (resolved 2026-04-26)
-
-`ManifestSchema.scope` is now a clean three-value enum (`'cloud' | 'system' | 'project'`).
-The deprecated `'platform'` and `'environment'` aliases have been removed
-([packages/spec/src/kernel/manifest.zod.ts](packages/spec/src/kernel/manifest.zod.ts)).
-
-### D6 - Half-wired abstractions
-
-`ScopedServiceManager` and `SharedProjectPlugin` were added but their integration into the request path is incomplete. Either finish them or remove them.
-
-### D6b - `packages/services/service-cloud` mixes runtime + control-plane (resolved 2026-05-17 — Phase R)
-
-The package historically housed three unrelated concerns under one name:
-
-1. **ObjectOS runtime** (artifact-fetching, per-project kernel manager, auth proxy) — used by `apps/objectos`
-2. **Cloud control plane** (multi-project orchestration, templates, local-identity seeding) — used by `apps/cloud`
-3. **Legacy single-project shells** (`single-project-plugin`, `shared-project-plugin`, `multi-project-plugin`) — pre-artifact-API code
-
-This forced `apps/objectos` to depend on `@objectstack/service-cloud` — a "cloud service" package — even though objectos only needs a runtime that pulls compiled artifacts over HTTP. The dispatcher (`boot-stack.ts`) that bridged the two was an `if/else` over `OS_MODE`.
-
-**Phase R — completed:**
-
-- Runtime-side files (`artifact-api-client`, `artifact-environment-registry`, `artifact-kernel-factory`, `auth-proxy-plugin`, `kernel-manager`, `objectos-stack`, plus new `file-artifact-api-client`) live in [`packages/runtime/src/cloud/`](packages/runtime/src/cloud/) and are exported from `@objectstack/runtime`.
-- `apps/objectos/objectstack.config.ts` now imports `createObjectOSStack` from `@objectstack/runtime` directly. No `@objectstack/service-cloud` dependency.
-- `apps/cloud/objectstack.config.ts` calls `createCloudStack` from `@objectstack/service-cloud` directly. The `createBootStack` dispatcher is removed.
-- Dead duplicates (`packages/runtime/src/{kernel-manager,multi-project-plugin,project-kernel-factory,environment-registry,control-plane-proxy-driver}.ts`) and legacy plugins in `service-cloud` (`single-project-plugin`, `shared-project-plugin`, `multi-project-plugin`, …) are deleted.
-- Result: `service-cloud` shrinks from 5 294 LOC / 27 files to the cloud-only control-plane core; the runtime no longer has a "cloud" dependency.
-
-### D7 - ✅ Plugin-config churn converged (resolved 2026-04-26)
-
-Each plugin's manifest header + objects list now lives in a single canonical
-`src/manifest.ts` per plugin. Both `objectstack.config.ts` (compile-time) and
-the plugin's runtime `manifest.register()` import from that file, eliminating
-the empty-`./src/objects/` divergence that previously caused `plugin-auth` and
-`plugin-security` to ship empty object lists from compile while their runtimes
-registered the real schemas.
-
-Anchors:
-- [packages/plugins/plugin-auth/src/manifest.ts](packages/plugins/plugin-auth/src/manifest.ts)
-- [packages/plugins/plugin-security/src/manifest.ts](packages/plugins/plugin-security/src/manifest.ts)
-- [packages/services/service-tenant/src/manifest.ts](packages/services/service-tenant/src/manifest.ts)
-
-### D9 - Custom Salesforce-flavor formula engine (replace with CEL)
-
-[packages/objectql/src/formula.ts](packages/objectql/src/formula.ts) is a hand-written 433 LoC recursive-descent parser exposing 22 functions (UPPER / NOW / TODAY / IF / AND …). It is the only "real" expression engine in the repo, but:
-
-- **No public training corpus.** AI agents have to learn our private DSL from scratch every prompt.
-- **Silent failure mode.** `evaluateFormula` wraps the whole evaluator in `try { … } catch { return undefined }`. Business rules fail open with no signal.
-- **No execution bounds.** No recursion depth limit, no step counter, no timeout. Untrusted input is a DoS vector.
-- **Salesforce-incomplete.** 22 functions vs 100+ in the language we'd be cloning.
-- **Single-engine bet.** All formula / predicate / condition fields share the same evaluator regardless of security posture.
-
-**Decision (2026-05-08):** delete and replace with CEL. Salesforce compatibility is **not** a goal — see `content/docs/concepts/north-star.mdx` §8. See M9 Expression Unification below.
-
-### D10 - Untyped `z.string()` expression fields scattered across spec
-
-~25 fields named `formula / condition / expression / criteria / visible / visibleOn` are declared as bare `z.string()` with `.describe('Formula expression')`. These are not all the same language — they include Salesforce-style formulas, predicate conditions, JS expressions (mapping), cron expressions (job), SQL fragments (analytics joins, partial indexes), and OpenAPI runtime expressions (rest-server callbacks). None are typed, none declare a dialect.
-
-Anchors (non-exhaustive):
-- [packages/spec/src/data/field.zod.ts](packages/spec/src/data/field.zod.ts) — `formula.expression`, `conditionalRequired`
-- [packages/spec/src/data/validation.zod.ts](packages/spec/src/data/validation.zod.ts) — `condition`, `scope`
-- [packages/spec/src/data/hook.zod.ts](packages/spec/src/data/hook.zod.ts) — `condition`
-- [packages/spec/src/ui/{app,page,view,action}.zod.ts](packages/spec/src/ui) — `visible / visibility / visibleOn / disabled`
-- [packages/spec/src/security/sharing.zod.ts](packages/spec/src/security/sharing.zod.ts) — `condition`
-- [packages/spec/src/automation/{workflow,approval}.zod.ts](packages/spec/src/automation) — `criteria`, `entryCriteria`
-- [packages/spec/src/ai/{orchestration,predictive}.zod.ts](packages/spec/src/ai) — `condition`, `entryCriteria`, `dataFilter`
-- [packages/spec/src/kernel/feature.zod.ts](packages/spec/src/kernel/feature.zod.ts) — `expression`
-
-**Resolved by:** M9 — replace with `ExpressionSchema { dialect, ast }` (string shorthand accepted as input, AST emitted in artifact).
-
-### D11 - Compile-time-frozen seed timestamps in `Dataset.records`
-
-[examples/app-crm/src/data/index.ts](examples/app-crm/src/data/index.ts) uses `new Date(Date.now() + 86400000 * 30)` and similar patterns inside seed records. These are evaluated at TS compile time, baking the developer's wall-clock into `dist/objectstack.json`:
-
-- Two consecutive `objectstack build` runs produce **non-byte-identical** artifacts (timestamps drift seconds-to-minutes apart). This violates the implicit "deterministic build" contract for cacheable artifacts.
-- Customers installing the package later receive seed dates anchored to **the developer's** "today + 30 days", forever. The dynamic semantics intended by the developer are lost.
-
-**Resolved by:** M9 — `Dataset.records` accepts `SeedValue = primitive | Expression`; SeedLoader evaluates expressions at install time using the customer's clock and identity context.
-
-### D8 - `apps/objectos` is a hybrid (Control Plane + ObjectOS in one process)
-
-[apps/objectos/objectstack.config.ts](apps/objectos/objectstack.config.ts) currently registers control-plane and ObjectOS concerns on the same `ObjectKernel`. North-star §5 names these as two separate vertices; implementation should follow.
-
-**Decision:** split into **`apps/cloud`** (Control Plane Server) and **`apps/objectos`** (ObjectOS Runtime). Both are ObjectStack-framework apps booted from their own `objectstack.config.ts`. They share the same `ObjectKernel`, spec, and adapter stack. They differ only in their plugin manifest.
-
-**Plugin partition:**
-
-| Plugin | `apps/cloud` (Control Plane) | `apps/objectos` (ObjectOS) |
-|:---|:---:|:---:|
-| `createControlPlanePlugins(...)` (ObjectQL on control DB + driver + system-project + sys_* metadata) | Yes | - |
-| `MultiProjectPlugin` (`env-registry`, `kernel-manager`, `template-seeder`) | Yes | - |
-| `AuthPlugin` | Yes | Yes |
-| `createTenantPlugin(...)` | Yes | Yes |
-| `SecurityPlugin` | Yes | Yes |
-| `AuditPlugin` | Yes | Yes |
-| `SetupPlugin` (Studio bootstrap) | Yes (optional) | - |
-| `ObjectQLPlugin` (project-scoped) | - | Yes |
-| `MetadataPlugin` (artifact-loader mode - see M4) | - | Yes |
-| User-app `AppPlugin` (compiled app) | - | Yes |
-
-**Fix path:**
-1. Create `apps/cloud/` with its own `objectstack.config.ts` carrying the Control Plane manifest above.
-2. Strip control-plane plugins out of [apps/objectos/objectstack.config.ts](apps/objectos/objectstack.config.ts); reduce it to the ObjectOS manifest.
-3. Decide deployment topology (separate Vercel projects vs. one repo / two entrypoints).
-
-**Depends on:** M3, M4. Until ObjectOS can boot from Artifact API, `apps/objectos` cannot run standalone.
-
----
-
-## 🔴 Missing (Not Started)
-
-Ordered by dependency. Items higher in the list unblock those below them.
-
-### M1 - ✅ Artifact format v0 (resolved 2026-04-26)
-
-- [x] Add a Zod schema for the artifact envelope.
-- [x] Minimum envelope: `schemaVersion`, `projectId`, `commitId`, `checksum`, `metadata`, `functions`, `manifest`.
-- [x] Specify function-code packaging (`ProjectArtifactFunctionSchema`: name + language + inlined `code` + optional source/hash) and plugin/driver requirement declaration (`ProjectArtifactManifestSchema`: plugins, drivers, engine).
-- [x] Required: schemaVersion / projectId / commitId / checksum / metadata / manifest. Optional: builtAt / builtWith / payloadRef.
-- [x] Reserved `payloadRef` for future S3 indirection (`{ url, expiresAt, checksum }`).
-
-Code anchor: [packages/spec/src/system/project-artifact.zod.ts](packages/spec/src/system/project-artifact.zod.ts).
-Tests: [packages/spec/src/system/project-artifact.test.ts](packages/spec/src/system/project-artifact.test.ts).
-
-**Prerequisite for:** M3, M4.
-
-### M1.x - Runtime Inputs 边界化
-
-明确 ObjectOS 启动输入 = **Artifact**（不可变、可缓存的元数据信封）+ **Deployment Config**（业务 DB 坐标、凭据、项目身份、密钥；不进 artifact）。详见 [north-star.mdx §6.3](content/docs/concepts/north-star.mdx)。
-
-- [x] north-star.mdx §6.3 增补 Runtime Inputs 节（含本地单 project env 表 + 反模式说明）
-- [x] 实现本地 standalone / cloud env 路径：`OS_MODE` (旧 `OS_MULTI_PROJECT`) / `OS_PROJECT_ID` / `OS_DATABASE_URL` / `OS_DATABASE_DRIVER` / `OS_ARTIFACT_PATH`（默认 `./dist/objectstack.json`）/ `AUTH_SECRET`
-- [x] 修复 Drift：`ProjectKernelFactory` 不再直连控制面 DB 读 `sys_project` / `sys_project_credential`，改走 Artifact API + Deployment Config 注入（`localProject` 分支）
-- [x] [apps/objectos/objectstack.config.ts](apps/objectos/objectstack.config.ts) 的 env 命名收敛到 `OS_*` 前缀，`isLocalMode` 分流本地/云端路径
-
-**Resolves:** Open Question §9.2（已解决）+ 新增 Drift（`ProjectKernelFactory` 绕过 Artifact API）。
-
-### M2 - Metadata migration to control plane
-
-- [ ] Move user metadata out of project DBs into the control-plane DB.
-- [ ] Scope metadata rows by `organization_id` + `project_id`.
-- [ ] Add or update unique keys for `project_id` + metadata `type` + metadata `name`.
-- [ ] Data migration script for existing installations.
-- [ ] Keep project DBs for business rows only.
-
-**Prerequisite for:** M3, D3.
-
-### M3 - ✅ Project Artifact API endpoint (resolved 2026-04-30)
-
-- [x] `GET /api/v1/cloud/projects/:projectId/artifact` - assembles the current project's metadata + inlined function code into a single consumable blob.
-- [x] Validate the outgoing artifact with the M1 Zod schema.
-- [x] Content hash / ETag for cache validation. (Synthetic `sha256`-prefixed `commitId` + `checksum` minted when the source bundle does not provide them.)
-- [x] Response includes `commitId` and `checksum`.
-- [x] Reserve response shape for future `{ url, expiresAt, checksum }` indirection, but do not build S3 yet.
-
-Code anchor: [packages/services/service-cloud/src/cloud-artifact-api-plugin.ts](packages/services/service-cloud/src/cloud-artifact-api-plugin.ts).
-Docs: [content/docs/concepts/cloud-artifact-api.mdx](content/docs/concepts/cloud-artifact-api.mdx).
-
-**Prerequisite for:** M4.
-
-### M4 - ✅ ObjectOS artifact loader (resolved 2026-04-30)
-
-- [x] `MetadataPlugin` production source: HTTP fetch against Artifact API. (`ArtifactApiClient` + `ArtifactKernelFactory`.)
-- [x] Validate artifact with Zod before hydrating kernel.
-- [x] Local artifact cache with durability across control-plane outages. (TTL cache in `ArtifactApiClient`.)
-- [x] Cache key by `projectId` + `commitId`/`checksum`.
-
-Code anchor: [packages/services/service-cloud/src/artifact-kernel-factory.ts](packages/services/service-cloud/src/artifact-kernel-factory.ts).
-
-**Completes:** production ObjectOS artifact source.
-
-### M5 - Project publish endpoint
-
-- [x] `POST /api/v1/cloud/projects/:projectId/metadata` - receives compiled JSON. *(server side shipped 2026-04-30 alongside M3; see `cloud-artifact-api-plugin.ts`.)*
-- [ ] Validates payload with `ObjectStackDefinitionSchema` or the canonical compiled stack schema.
-- [ ] Writes current project metadata state to control-plane storage.
-- [ ] Creates `commitId`, computes checksum, and returns `{ projectId, commitId, checksum }`.
-- [ ] Evolves [packages/cli/src/commands/publish.ts](packages/cli/src/commands/publish.ts) to call this endpoint.
-
-**Resolves:** D2.
-
-### M6 - Studio metadata/artifact viewer
-
-- [ ] Project metadata browser for Objects / Fields / Functions / Views / Flows / Agents.
-- [ ] Artifact inspector: schema version, commit id, checksum, publish time, payload preview.
-- [ ] Publish history list.
-- [ ] Runtime health/logs panels.
-- [ ] Explicitly read-only for user metadata.
-
-### M7 - `objectstack dev` offline boot path
-
-- [ ] `from-local-file` kernel boot mode: ObjectOS reads `dist/objectstack.json` (or in-memory TS definition) and runs without a control-plane connection.
-- [ ] Wire as a distinct boot mode; does not pollute the production `from-artifact-api` path.
-- [ ] `objectstack dev` CLI command triggers this mode.
-
-**Open question:** should `dev` consume TS directly (hot reload friendly) or compile-first (production-path parity)?
-
-### M8 - UI auto-generation
-
-- [ ] Artifact schemas -> Amis/React components without hand-wiring.
-
-### M9 - Expression Unification (CEL + AST-first)
-
-Single canonical expression language across all metadata domains. Replace the
-custom formula engine (D9), the scattered `z.string()` expression fields (D10),
-and the compile-time-frozen seed timestamps (D11) with one tagged
-`ExpressionSchema { dialect, ast }` whose persisted form is always an AST.
-
-**Strategic rationale.** Future authors of metadata and formulas are AI agents,
-not human admins. The wire format must therefore have (a) abundant public
-training corpus, (b) formal grammar, (c) AST-first persistence (no parsing
-ambiguity, structured-output friendly), (d) sandboxed bounded execution.
-**CEL** (Google Common Expression Language, Apache-2.0) satisfies all four;
-the existing custom DSL satisfies none. **Salesforce flavor is explicitly not
-a goal** — see north-star §8.
-
-**Dialect map:**
-
-| dialect | engine | use cases |
+| Priority | Work | Why |
 |:---|:---|:---|
-| `cel` | `cel-js` + ObjectStack stdlib | formula fields, predicates (condition / criteria / visible), seed dynamic values |
-| `js` | isolated-vm / quickjs (existing) | L2 hook bodies (`packages/spec/src/data/hook-body.zod.ts` ScriptBody) |
-| `cron` | `cron-parser` | `system/job.zod.ts` schedule |
-
-SQL fragments (analytics joins, partial indexes) stay driver-native and are
-**not** unified into the expression registry — they have a different security
-and portability posture.
-
-#### M9.1 - `packages/formula` package + ExpressionSchema ✅
-
-- [x] New `packages/formula/` with `cel-js` integration.
-- [x] ObjectStack CEL stdlib: `now()`, `today()`, `daysFromNow(n)`, `daysAgo(n)`, `isBlank(v)`, `coalesce(v, fallback)`, plus `record.*` / `previous.*` / `input.*` / `os.user.*` / `os.org.*` / `os.env` variable scope.
-- [x] `packages/spec/src/shared/expression.zod.ts` exports `ExpressionDialect`, `ExpressionSchema`, `ExpressionInputSchema`, `PredicateSchema`.
-- [x] `ExpressionEngine` registry with `evaluate(expr, ctx)` single entrypoint.
-
-#### M9.2 - DX shorthand (build-time only) ✅ (partial)
-
-- [x] `cel\`...\``, `F\`...\`` (formula), `P\`...\`` (predicate) tagged-template helpers exported from `@objectstack/spec`.
-- [ ] `objectstack compile` normalizes any `source` string in input metadata into `ast`. **Deferred to M9.7** — current artifact carries `{ dialect, source }`; AST emission lands with the AI structured-output milestone.
-
-#### M9.3 - Replace scattered `z.string()` expression fields ✅
-
-- [x] Migrated all ~25 fields listed in D10 to `ExpressionInputSchema`. Input accepts `string | Expression` for back-compat; output is the canonical `Expression` envelope.
-- [x] Surfaces migrated: `Field.formula` (formula type), `Field.conditionalRequired`, `Field.visibleOn`, `ConditionalValidation.when`, `ObjectFieldGroup.visibleOn`, `View.visibleOn`, `View.criteria`, `Action.disabled`, `Hook.condition`, `SharingRule.condition`, `Flow.decision.expression`, `Mapping.transform` (js dialect), `Job.schedule.expression` (cron dialect).
-- [x] Spec test suite updated (6840 passing).
-
-**Resolves:** D10.
-
-#### M9.4 - Seed dynamic values ✅
-
-- [x] `Dataset.records` accepts `SeedValue = primitive | Expression | nested`.
-- [x] `SeedLoader.load()` walks records, calls `ExpressionEngine.evaluate` with a per-load pinned `now` before write. `seedCtx` exposes `os.user / os.org / os.env` from the install environment.
-- [x] CRM example: 48 dynamic dates migrated from `new Date()` (compile-time) to `cel\`daysFromNow(N)\`` / `cel\`daysAgo(N)\`` (install-time).
-
-**Resolves:** D11.
-
-#### M9.5 - Delete custom formula engine ✅
-
-- [x] `packages/objectql/src/engine.ts` (computed fields, `planFormulaProjection` / `applyFormulaPlan`) and `packages/objectql/src/hook-wrappers.ts` (hook conditions) call `ExpressionEngine.evaluate`.
-- [x] **Deleted** the legacy `packages/objectql/src/formula.ts` recursive-descent parser and `packages/spec/docs/formula-functions.md`.
-
-**Resolves:** D9.
-
-#### M9.6 - Migrate `examples/app-crm` ✅
-
-- [x] All 4 CRM formula fields (`lead.full_name`, `contact.full_name`, `campaign.response_rate`, `campaign.roi`) re-written in CEL using `coalesce(...)` / ternary patterns.
-- [x] CI determinism gate: two consecutive `objectstack build` runs produce byte-identical `dist/objectstack.json` (SHA-1 `91efccc…`).
-- [x] `planFormulaProjection` fix: formulas are now evaluated even when REST returns the default projection (no explicit `?fields=`).
-- [x] Browser-verified end-to-end via `pnpm dev:crm`: `Lead.full_name` renders "Lisa Thompson", `Campaign.roi` renders `1907.04`.
-- [ ] _Follow-up:_ ~22 inert validation/sharing `condition:` strings on other CRM objects still use Salesforce flavor (not yet evaluated by runtime — no validation engine wired). Migrate when validation engine lands.
-
-#### M9.7 - AI structured-output integration
-
-- [ ] Publish `CelExprSchema` as JSON Schema for AI constrained decoding.
-- [x] New [`skills/objectstack-formula/SKILL.md`](skills/objectstack-formula/SKILL.md) — mandates CEL-only emission, lists stdlib, gives mandatory patterns and the legacy → CEL translation table.
-- [ ] Wire structured-output prompts into Studio AI assistant + CLI scaffolding.
-
-#### M9.8 - Studio visual expression editor
-
-- [ ] Node-graph editor backed directly by `CelExprSchema`. No string parser needed in Studio. Deferred — depends on M6.
-
-#### M9.9 - Spec-wide Expression coverage sweep (NEW — 2026-05-08) ✅ COMPLETE
-
-A full audit across all 15 protocol domains identified surfaces that still
-escape the canonical envelope. M9.3 fixed the 25 obvious formula/predicate
-fields; this milestone closes the gaps in adjacent semantic categories.
-
-**Status:** All 5 sub-milestones (a–e) shipped 2026-05-08. Engines: real
-`cron-engine` + `template-engine` registered alongside `cel`. CRM example
-fully migrated (codemod) and remains byte-identical across builds
-(`e2af9e57…`). Flow runtime now routes `dialect:'cel'` conditions through
-`@objectstack/formula` with a `vars.*` scope; legacy `{var}` template syntax
-preserved for back-compat.
-
-##### M9.9a - Bare `z.string()` predicates / formulas to migrate
-
-- [x] `automation/workflow.zod.ts` `Task.dueDate` (documented "ISO string or formula") → `z.union([z.string(), ExpressionInputSchema])` so authors can write `cel\`daysFromNow(3)\``.
-- [x] `api/graphql.zod.ts` `ComputedField.expression` ("Computation expression") → `ExpressionInputSchema`.
-- [x] `ai/runtime-ops.zod.ts` `customCondition` → `ExpressionInputSchema` (predicate semantics identical to `Hook.condition`).
-- [x] `kernel/metadata-loader.zod.ts` `filter: 'Filter predicate as string'` → `ExpressionInputSchema`.
-- [x] `ui/component.zod.ts` `Form.onSubmit: 'Action expression on form submit'` → disambiguate: action reference vs CEL predicate; pick one shape.
-
-##### M9.9b - `defaultValue` accepts Expression for derived defaults
-
-- [x] `data/field.zod.ts` `Field.defaultValue: z.unknown()` → `z.union([z.unknown(), ExpressionSchema])` so authors can write `defaultValue: cel\`today()\`` or `cel\`os.user.id\`` instead of writing a hook.
-- [x] Same change for `data/external-lookup.zod.ts`, `ui/page.zod.ts`, `ui/dashboard.zod.ts`, `api/export.zod.ts`.
-- [x] DataEngine on insert: when `defaultValue.dialect` is set, evaluate via `ExpressionEngine` with the request-time identity context.
-
-##### M9.9c - Cron strings normalize to `{ dialect: 'cron', source }`
-
-10 sites still ship bare `z.string().describe('Cron expression…')` instead of using the canonical envelope (`Job.schedule.expression` already does it):
-
-- [x] `integration/connector.zod.ts` `schedule`
-- [x] `automation/etl.zod.ts` `schedule`
-- [x] `automation/execution.zod.ts` `cronExpression`
-- [x] `api/export.zod.ts` `cronExpression` (×2)
-- [x] `system/disaster-recovery.zod.ts` `schedule` (×2)
-- [x] `system/cache.zod.ts` `schedule`
-- [x] `ai/predictive.zod.ts` `retrainSchedule`
-- [x] `ai/orchestration.zod.ts` `cron`
-- [x] `ai/devops-agent.zod.ts` `iterationFrequency`
-
-Persist as `ExpressionInputSchema` so AI authors emit one envelope shape regardless of domain. Engine wraps `cron-parser`.
-
-##### M9.9d - Add `template` dialect for string interpolation
-
-Today every domain reinvents `{{var}}` interpolation:
-
-- `system/notification.zod.ts` — Email `subject`/`body`, SMS `message`, Push `body`
-- `data/object.zod.ts` — `titleFormat: '{name} - {code}'`
-- `integration/connector/github.zod.ts` — `messageTemplate`, `titleTemplate`, `bodyTemplate`, `releaseNameTemplate`
-- `ai/model-registry.zod.ts` / `ai/orchestration.zod.ts` / `ai/mcp.zod.ts` — prompt templates
-- `api/graphql.zod.ts` — cache key / query templates
-
-- [x] Add `'template'` to `ExpressionDialect` enum.
-- [x] `@objectstack/formula` engine for `dialect: 'template'` — strict Mustache subset (`{{path.to.value}}` only, no logic), same variable scope as CEL (`record`, `os.user`, …).
-- [x] Migrate the surfaces above to `ExpressionInputSchema`. AI authors then know: **anything templated or computed goes through `Expression`**.
-
-##### M9.9e - Structured rule objects gain Expression escape hatch
-
-These are typed structured objects today, but power users sometimes need a raw CEL fallback. Make each `z.union([structured, ExpressionInputSchema])`:
-
-- [x] `system/audit.zod.ts` `condition`
-- [x] `system/metrics.zod.ts` `successCriteria`, `condition`
-- [x] `system/tracing.zod.ts` `condition`
-- [x] `cloud/marketplace-admin.zod.ts` `criteria`
-
-##### M9.9 — Intentional non-targets (documented for clarity)
-
-These remain non-CEL by design and should NOT be unified:
-
-- **SQL fragments** — `data/analytics.zod.ts` (`sql`), `data/object.zod.ts` (`partial` SQL WHERE). Driver-native; portability story differs.
-- **NoSQL filters** — `data/driver-nosql.zod.ts` `partialFilterExpression` (MongoDB JSON).
-- **OData / OpenAPI runtime expressions** — `api/odata.zod.ts`, `api/rest-server.zod.ts` `expression` (`{$request.body#/callbackUrl}`). Externally-specified DSLs.
-- **Wire query params** — `api/protocol.zod.ts` `filter`/`filters`/`sort`. JSON-encoded ObjectQL on the wire.
-- **Structured `FilterCondition`** — `data/data-engine.zod.ts` `where`. Typed object DSL preferred for query planner; CEL escape hatch already exists via `View.criteria` / `Workflow.criteria`.
+| P0 | Keep public docs aligned with the environment rename. | Prevent users from copying stale `project` route/header/env examples. |
+| P0 | Keep CLI/docs/examples aligned with actual scripts: `pnpm dev`, `pnpm dev:crm`, `os dev`, `os start`, `os serve`, `os publish`. | Avoid broken onboarding. |
+| P0 | Remove references to deleted app/service packages from current docs. | `apps/cloud`, `apps/objectos`, `apps/studio`, and `service-tenant` no longer exist in this repo. |
+| P1 | Document Flow-first automation and workflow state-machine semantics. | Old Workflow Rule docs imply a retired Salesforce-style rule engine. |
+| P1 | Document explicit AI action opt-in via action metadata. | AI tool exposure is no longer automatic for every action. |
+| P1 | Document implemented formula, summary, autonumber, notifications, and master-detail behavior. | Recent runtime work is under-documented and older status pages still mark it missing. |
+| P2 | Regenerate reference docs after Zod description updates. | Keeps generated schema pages consistent without hand-editing them. |
 
 ---
 
-## ⛔ Explicit Non-Goals (Phase 1)
+## Documentation Rules
 
-| Item | Reason |
-|:---|:---|
-| Branch / `sys_branch` / `branch_id` | Deferred. Phase 1 has one current metadata state per project. |
-| Branch hostnames, branch diff, branch merge | Deferred with the branch model. |
-| Studio metadata editing | Deferred. Studio is read-only for user metadata in Phase 1. |
-| Bidirectional CLI ↔ Studio write model | Deferred. Local TS workspace is the only metadata authoring surface in Phase 1. |
-| `objectstack pull` JSON -> TS emitter | Deferred until there is a control-plane writer that can change metadata outside local TS. |
-| Merge/conflict UX | Deferred. `commitId` identifies revisions and artifacts, not collaborative merge state. |
-| Versioning / Release / Tag entity | Deferred. Freezing current metadata into immutable releases comes later. |
-| Salesforce-flavor formula compatibility | Deferred / not pursued. The legacy 22-function custom DSL (D9) is replaced by CEL (M9), not extended. Authors targeting Salesforce semantics rewrite in CEL — see north-star §8 anti-pattern "No private DSL". |
-| S3 artifact backend | Deferred. Artifact API response shape should allow it later, but backend is control-plane DB now. |
+- Do not hand-edit `content/docs/references/`.
+- When adding guide pages, update the nearest `meta.json`.
+- Use `environment` for runtime/deployment identity.
+- Use `project` only for npm/monorepo/project-folder meaning, or when quoting
+  historical ADR text.
+- Link to sibling UI work as `../objectui` or the ObjectUI repo, not
+  `apps/studio`.
 
 ---
 
-## Future Phases
+## Verification
 
-These are intentionally outside Phase 1 but should remain compatible with the Phase 1 model.
+For doc-only updates, prefer targeted checks:
 
-### Phase 2 - Studio authoring
-
-- Add visual metadata editors in Studio.
-- Route every Studio save through a control-plane metadata write API.
-- Introduce optimistic concurrency for CLI ↔ Studio writes.
-- Decide whether `objectstack pull` generates canonical TS or attempts source-preserving round trips.
-
-### Phase 3 - Branching and collaboration
-
-- Add `sys_branch` and `branch_id`.
-- Migrate the Phase 1 current project metadata state to default branch `main`.
-- Evolve partition key from `(organization_id, project_id)` to `(organization_id, project_id, branch_id)`.
-- Add branch hostnames, branch diff, branch merge, and conflict UX.
-
-### Phase 4 - Releases and artifact storage
-
-- Add Release / Tag entity.
-- Freeze project or branch states into immutable artifacts.
-- Add rollback UI.
-- Swap Artifact API backend to S3/signed URL where useful.
-
----
-
-## Dependency Graph (Reading Order for Implementation)
-
-```
-M1 Artifact format v0
-├── M1.x Runtime Inputs 边界化 (Artifact + Deployment Config 分离)
-└── M2 Metadata migration to control plane
-    ├── M3 Project Artifact API
-    │   └── M4 ObjectOS artifact loader
-    └── M5 Project publish endpoint -> resolves D2
-        └── M6 Studio metadata/artifact viewer
-
-M7 objectstack dev offline boot  (parallel after M1)
-M8 UI auto-generation            (long tail after artifact schema stabilizes)
-M9 Expression unification        (parallel; spec-only changes, no Phase-1 prereq)
-   ├── M9.1 packages/formula + ExpressionSchema
-   ├── M9.2 DX shorthand (cel`…`, F`…`, P`…`) + compile normalization
-   ├── M9.3 Replace ~25 z.string() expression fields → resolves D10
-   ├── M9.4 Dataset SeedValue + SeedLoader expression eval → resolves D11
-   ├── M9.5 Delete packages/objectql/src/formula.ts → resolves D9
-   ├── M9.6 Migrate examples/app-crm + byte-identical-build CI gate
-   ├── M9.7 AI structured-output (publish JSON Schema + skill doc)
-   └── M9.8 Studio visual editor   (after M6)
-D3 remove env_id                 (after M2 ownership columns exist)
-D8 split apps/cloud + apps/objectos(after M3/M4 make ObjectOS standalone)
-D9 / D10 / D11                   (resolved through M9 sub-tasks above)
+```bash
+pnpm --filter @objectstack/docs build
+pnpm --filter @objectstack/spec gen:docs
+rg "X-Project-Id|OS_PROJECT_ID|/api/v1/projects|sys_project|apps/studio|service-tenant" README.md content/docs docs/design docs/handoff packages/spec/src
 ```
 
----
-
-## M10 — CRM Production-Readiness (App-Layer + Platform Gaps)
-
-> Derived from the 2026-05-18 real-customer audit of `examples/app-crm`.
-> Full report: `~/.copilot/session-state/.../files/production-readiness-assessment.md`.
-> Goal: take the CRM example from "single-user demo" to "5-20 person sales team pilot".
-
-### M10 P0 — Blockers (must-have for any paying customer)
-
-- [x] **M10.1 — Audit / Activity auto-writers.** `plugin-audit` registers `sys_audit_log` but never writes; `sys_activity` and `sys_comment` likewise empty after CRUD. Subscribe to ObjectQL `data:*` events from `EventBus` and emit immutable audit rows + human-readable activity entries with field-level diffs. Anchor: [packages/plugins/plugin-audit/src/audit-plugin.ts](packages/plugins/plugin-audit/src/audit-plugin.ts).
-- [x] **M10.2 — User invite + default roles.** No `/api/v1/admin/users/invite` endpoint exists. Wrap better-auth `organization.inviteMember` as a first-class REST route. Seed three default roles into `sys_role` (`admin`, `sales_manager`, `sales_rep`). Anchor: [packages/plugins/plugin-auth/](packages/plugins/plugin-auth/).
-- [x] **M10.3 — Attachments.** No `sys_attachment` object, no upload component. Register the schema in `packages/spec/src/system/`, wire it to `service-storage`, add an `AttachmentList` view widget. P0 because every CRM contract/quote/PDF is currently un-storable.
-- [x] **M10.4 — Validation envelope + Zod-at-rest.** Currently a malformed POST returns raw SQL text. Wrap REST handlers with a structured error envelope (`{code,message,fields[]}`) and run the canonical Zod schema inside ObjectQL `insert/update` before touching the driver. Anchors: [packages/rest/src/rest-server.ts](packages/rest/src/rest-server.ts), [packages/objectql/](packages/objectql/).
-- [x] **M10.5 — Global search.** Header already shows `⌘K` but it is inert. Add `GET /api/v1/search?q=` (driver-side `LIKE` across registered searchable fields; FTS later) and wire the Studio command palette to it.
-
-### M10 P1 — Critical (80%+ of customers need these)
-
-- [x] M10.6 — `POST /api/v1/data/lead/:id/convert` → Lead → Account + Contact + Opportunity (compensating rollback; true tx is M11 follow-up).
-- [ ] M10.7 — `service-email` + `sys_email` (IMAP/SMTP, OAuth Gmail/Outlook), thread linking to records. **Deferred to M11** — requires external infra outside the first-wave pilot scope.
-- [x] M10.8 — `sys_notification` inbox + assignment / @mention writers + header bell (polling). WebSocket push deferred to M11.
-- [x] M10.9 — `POST /api/v1/data/:obj/import` CSV/JSON parser with dry-run + field mapping.
-- [x] M10.10 — Comments / @mentions UI on detail pages (sys_comment snake_case fix + reactions writeback).
-- [x] M10.11 — Activity-timeline component (consumes M10.1 data via sys_activity → FeedItem mapping).
-- [x] M10.12 — `full_name` CEL formula bug (leading space when `salutation` is null).
-- [x] M10.13 — Date / datetime column formatters in grid plugin.
-- [x] M10.14 — Stop SQL error leakage in REST error responses (centralized sendError → mapDataError).
-
-### M10 P2 — Important (50%+ of customers need these)
-
-- [x] M10.15 — Workflow / approval engine — delivered as M11.C15 (`@objectstack/plugin-approvals` + `sys_approval_process` / `sys_approval_request` / `sys_approval_action`, tenant-scoped REST surface, autopilot lifecycle hooks).
-- [x] M10.16 — Saved reports + scheduled email — delivered as M11.C16 (`@objectstack/plugin-reports` + matrix `groupBy` with `dateGranularity`).
-- [x] M10.17 — Record-level sharing rules (`sys_sharing_rule`) + team hierarchy (`sys_team.parent_team_id`). Declarative criteria-based sharing materialised into `sys_record_share` with `source='rule'` and reconciled by `SharingRuleService`; team graph used by both rule evaluator and `ApprovalService.expandApprovers()` for `team:` / `role:` / `manager:` approver expansion. REST surface at `/api/v1/sharing/rules` (promoted from `/api/v1/data/sharing/rules`); auto-loaded by the CLI capability resolver when `requires: ['…, 'sharing']`.
-- [x] M10.17.1 — Split enterprise org skeleton (`sys_department` + `sys_department_member`) from better-auth's flat `sys_team`. Dropped `sys_team.parent_team_id` (better-auth contract restored); new `DepartmentGraphService` BFS over `parent_department_id` with active-only subtree, effective dates, `kind` enum (`company|division|department|team|office|cost_center`) for HRIS-grade modelling. `ApprovalService` `department:`/`dept:` approver prefix + `SharingRuleService` `recipient_type='department'` now resolve through the dept graph; `team:` is flat. Contracts split (`ITeamGraphService` flat, `IDepartmentGraphService` hierarchical).
-- [x] M10.28 — Setup app sidebar reorganized into 7 semantic groups (Overview / People & Organization / Access Control / Approvals / Platform / Diagnostics / Advanced). 10 better-auth internals (OAuth tokens/consents, JWKS, verifications, two-factor, device codes, linked accounts) moved into a collapsed "Advanced" group; sharing rules + record shares promoted into "Access Control". Companion **objectui** change adds a `ManagedByBanner` to ObjectView / RecordDetailView / RecordFormPage that warns when `managedBy !== 'platform'` and disables form inputs by default.
-- [x] M10.30a — Built-in `listViews` block on `ObjectSchemaBase` + curated segmented views for `sys_approval_{request,process,action}`, `sys_audit_log`, `sys_notification`. Console substitutes `{current_user_id}` in filter values so "My Pending" / "I Submitted" / "Unread" tabs scope to the current user. Replaces the previous "All records in insertion order" fallback for the most-visited system tables.
-- [ ] M10.29 — `IIdentityService` contract + `plugin-identity` adapter so approvals/sharing stop reading better-auth tables directly (insulates against upstream schema changes; supports future Auth0/Okta integrations behind the same façade).
-- [ ] M10.30 — `identity_health` dashboard (active sessions / failed-login spikes / pending approvals / orphaned OAuth grants).
-- [ ] M10.31 — Mark sensitive better-auth fields (`password_hash`, `email_verified`, two-factor secrets) as `readOnly: true` on the schema so even the "Advanced" group can't accidentally corrupt them.
-- [ ] M10.18 — Tags (`sys_tag`).
-- [ ] M10.19 — Re-enable GraphQL (currently 501) and OpenAPI spec endpoint (currently 404).
-- [ ] M10.20 — Realtime channels (collaborative editing on the same opportunity).
-- [ ] M10.21 — Outbound webhooks + CSV export.
-- [ ] M10.22 — Mobile-optimized layouts (kanban + grid).
-- [ ] M10.23 — i18n review for CRM business terms (pipeline / forecast / SLA).
-
-### M10 P3 — Polish
-
-- [ ] M10.24 — Soft delete + recycle bin.
-- [ ] M10.25 — Dark-mode visual parity audit.
-- [ ] M10.26 — WCAG 2.1 AA accessibility audit.
-- [ ] M10.27 — 10K+ record performance (virtual scrolling, indices).
-
----
-
-## Related Documents
-
-| Document | Role |
-|:---|:---|
-| [content/docs/concepts/north-star.mdx](content/docs/concepts/north-star.mdx) | Authoritative spec - §1 tenets, §3 surfaces, §5 architecture, §7 ledger, §9 open questions |
-| [CLAUDE.md](CLAUDE.md) | Dev conventions - Zod-first, naming, kernel standards |
-| [.github/copilot-instructions.md](.github/copilot-instructions.md) | Mirror of CLAUDE.md for Copilot |
-| [packages/cli/src/commands/compile.ts](packages/cli/src/commands/compile.ts) | TS -> JSON compile (Built anchor) |
-| [packages/cli/src/commands/publish.ts](packages/cli/src/commands/publish.ts) | Publish command (Drift D2 target) |
-| [packages/metadata/src/plugin.ts](packages/metadata/src/plugin.ts) | MetadataPlugin (artifact/local-file metadata loader; D1 resolved anchor) |
+Run the full `pnpm test` suite when documentation changes accompany runtime or
+schema behavior changes.

--- a/content/docs/concepts/cloud-artifact-api.mdx
+++ b/content/docs/concepts/cloud-artifact-api.mdx
@@ -1,185 +1,104 @@
 ---
-title: Cloud Artifact API
-description: HTTP contract between the cloud control plane and runtime ObjectOS nodes
+title: Cloud Environment Artifact API
+description: HTTP contract for publishing and resolving ObjectStack environment artifacts.
 ---
 
-# Cloud Artifact API
+# Cloud Environment Artifact API
 
-The **Cloud Artifact API** is the HTTP contract between an ObjectStack
-**control plane** (a deployment of `apps/cloud` running
-`@objectstack/service-cloud`) and a **runtime node** (any ObjectOS process
-running in `OS_MODE=runtime`). Runtime nodes contain no project metadata
-of their own — every request is resolved through this API.
+The Cloud Environment Artifact API is the control-plane contract used to publish
+compiled metadata and activate immutable environment revisions. The framework
+runtime consumes the resulting artifact plus deployment config to boot the
+target environment.
 
-The API is served by `createCloudArtifactApiPlugin` and is wired into
-`createCloudStack()` automatically. It is also re-served by
-`apps/cloud/objectstack.config.ts` as part of the cloud preset.
-
-> **Spec anchor.** The artifact envelope itself is defined by
-> `ProjectArtifactSchema` in `packages/spec/src/system/project-artifact.zod.ts`
-> (M1 in the [ROADMAP](https://github.com/objectstack-ai/framework/blob/main/ROADMAP.md)).
-> This page documents the *transport*; the envelope shape is normative.
+The artifact envelope is defined by `EnvironmentArtifactSchema` in
+`packages/spec/src/system/environment-artifact.zod.ts`.
 
 ---
 
-## Authentication
+## Publish endpoint
 
-If `OS_CLOUD_API_KEY` is set on the cloud side, every endpoint requires
-the same value as a bearer token:
-
-```
-Authorization: Bearer <OS_CLOUD_API_KEY>
+```text
+POST /api/v1/cloud/environments/:environment/metadata
 ```
 
-When unset, endpoints are open to any caller (intended for
-loopback / docker-internal calls only — **do not** expose an unauthenticated
-control plane on the public internet).
-
-Runtime nodes pass the matching token via `OS_CLOUD_API_KEY`
-(consumed by `ArtifactApiClient`).
-
----
-
-## Endpoints
-
-All endpoints live under the configured prefix — default `/api/v1`.
-
-### `GET /api/v1/cloud/resolve-hostname`
-
-Resolve a public hostname to its owning project. Used by
-`ArtifactEnvironmentRegistry` to map the inbound `Host:` header before
-fetching the artifact.
-
-**Query parameters**
-
-| Name       | Required | Notes |
-|:-----------|:--------:|:------|
-| `host`     | ✅ | The hostname to resolve. `hostname` is accepted as an alias. |
-
-**Response** — `200 OK`
+The body is the compiled JSON produced by `os compile` or `objectstack
+compile`. The control plane validates the object payload, stores it as a new
+revision, computes a checksum, and returns the commit metadata used by runtime
+caches.
 
 ```jsonc
 {
   "success": true,
   "data": {
-    "projectId": "proj_01h…",
-    "organizationId": "org_01h…",
-    "runtime": {
-      "datasource": {
-        "driver": "turso",
-        "url":    "libsql://example.turso.io",
-        "authToken": "…"
-      }
-    }
+    "environmentId": "env_prod",
+    "commitId": "9ce1bd48dd7022b8",
+    "checksum": { "algorithm": "sha256", "value": "..." }
   }
 }
 ```
 
-**Lookup rules**
+The CLI command is:
 
-1. Exact match against `sys_project.hostname`.
-2. The wildcard marker `*` matches any host (used by the system project
-   when one project is intentionally global).
-3. `404` if neither matches.
-
-The `runtime` block is assembled from `sys_project_credential` (preferred)
-or from `sys_project.database_*` columns (fallback). It is the same
-structure consumed by `DriverPlugin` on the runtime node.
-
----
-
-### `GET /api/v1/cloud/projects/:id/artifact`
-
-Returns the **v0 ProjectArtifact envelope** for a project, ready to hand
-off to `ArtifactKernelFactory`.
-
-**Path parameters**
-
-| Name | Required | Notes |
-|:-----|:--------:|:------|
-| `id` | ✅ | The `sys_project.id` value. |
-
-**Response** — `200 OK`
-
-```jsonc
-{
-  "success": true,
-  "data": {
-    "schemaVersion": "0.1",
-    "projectId":     "proj_01h…",
-    "commitId":      "a1b2c3d4e5f6g7h8",
-    "checksum":      { "algorithm": "sha256", "value": "…" },
-    "metadata":      { "objects": [...], "apps": [...], "flows": [...], … },
-    "functions":     [{ "name": "calc_total", "language": "ts", "code": "…" }],
-    "manifest":      { "plugins": [...], "drivers": [...], "engines": {} },
-    "builtAt":       "2026-04-12T08:00:00.000Z",
-    "builtWith":     "objectstack-cli@2.x",
-    "runtime":       { "datasource": { "driver": "turso", "url": "…" } }
-  }
-}
+```bash
+OS_CLOUD_URL=https://cloud.example.com \
+OS_ENVIRONMENT_ID=env_prod \
+os publish
 ```
 
-**Assembly rules**
+---
 
-1. Read `sys_project.metadata.artifact_path` (or `artifact_paths[]` for
-   multi-bundle projects). Relative paths are resolved against
-   `artifactRoot` (defaults to `process.cwd()`; override via plugin
-   options).
-2. For each path, load the JSON file. Both shapes are accepted:
-   - **v0 nested** — `{ metadata: { objects: [...] }, functions, manifest, … }`
-   - **`objectstack compile` flat** — top-level `objects`, `apps`,
-     `dashboards`, …
-3. Merge each bundle's `metadata.*` arrays into one envelope; `functions`
-   from every bundle are concatenated.
-4. `commitId` / `checksum` / `builtAt` / `builtWith` / `manifest` are
-   carried forward from the **first** bundle. If the first bundle does
-   not provide them, a deterministic synthetic `commitId` (16-char
-   `sha256` prefix of the merged content) and `checksum` are minted so
-   downstream caches still rev correctly.
-5. The `runtime` block is appended exactly as in `resolve-hostname`.
+## Activate revision endpoint
 
-`404` if the project does not exist; `503` if the control-plane DB is
-unavailable.
+```text
+POST /api/v1/cloud/environments/:environment/revisions/:commit/activate
+```
+
+Activating a revision changes the environment's current artifact pointer.
+Runtime nodes can then reload or refresh their environment kernel based on the
+new commit/checksum.
+
+```bash
+OS_CLOUD_URL=https://cloud.example.com \
+OS_ENVIRONMENT_ID=env_prod \
+os rollback --commit 9ce1bd48dd7022b8
+```
 
 ---
 
-### `POST /api/v1/cloud/projects/:id/metadata`
+## Artifact envelope
 
-Receives a compiled artifact (the JSON output of `os compile` /
-`objectstack compile`) and persists it so subsequent
-`GET .../artifact` calls return it.
+`EnvironmentArtifactSchema` contains the immutable, cacheable portion of a
+deployment:
 
-**Body** — the raw artifact JSON (a JSON object — arrays are rejected).
+- `schemaVersion`
+- `environmentId`
+- `commitId`
+- `checksum`
+- `metadata`
+- `functions`
+- `manifest`
+- optional `builtAt`, `builtWith`, and `payloadRef`
 
-**Behaviour**
-
-1. Validates that the body is a plain JSON object.
-2. Writes the artifact to `<artifactRoot>/<projectId>/artifact.json`.
-3. Updates `sys_project.metadata.artifact_path` to that file so the GET
-   endpoint can serve it on the next request.
-4. Returns `{ success: true, data: { projectId, commitId, checksum, ... } }`
-   echoing the same fields the GET endpoint would assemble.
-
-This is the endpoint that **M5 — Project publish endpoint**
-(see `ROADMAP.md`) will eventually graduate `os publish` onto. Until then
-it accepts any compiled JSON.
+Deployment config does not belong in the artifact. Database coordinates,
+secrets, runtime credentials, and hostname bindings are mutable operational
+inputs provided by the host or Cloud control plane.
 
 ---
 
-## Caching contract
+## Runtime resolution
 
-`ArtifactApiClient` (the runtime client used by `ArtifactKernelFactory`)
-caches responses with a TTL keyed by the response content. Servers
-should:
+Environment-aware runtime hosts resolve the target environment before serving a
+data-plane request:
 
-- Keep `commitId` stable across rebuilds when the underlying metadata is
-  unchanged. If you rebuild without metadata changes, reuse the previous
-  `commitId` so kernels can short-circuit.
-- Use the synthetic `sha256` derivation if you do not have a real CI
-  commit id — it is deterministic over the merged metadata content.
-- Treat the `runtime` block as **mutable** independently of `commitId` —
-  the client is allowed to invalidate the runtime block separately when
-  `resolve-hostname` returns a different `runtime`.
+1. `/api/v1/environments/:environmentId/...`
+2. Hostname through the environment registry
+3. `X-Environment-Id`
+4. `session.activeEnvironmentId`
+5. Configured default environment
+6. Single unambiguous environment
+
+Control-plane routes under `/api/v1/cloud/environments/...` are management
+calls, not data-plane calls.
 
 ---
 
@@ -187,14 +106,16 @@ should:
 
 | File | Purpose |
 |:---|:---|
-| `packages/services/service-cloud/src/cloud-artifact-api-plugin.ts` | Server: registers all three endpoints, performs DB reads, assembles envelopes |
-| `packages/services/service-cloud/src/artifact-api-client.ts` | Client: TTL-cached HTTP wrapper used by runtime nodes |
-| `packages/services/service-cloud/src/artifact-environment-registry.ts` | Maps `Host:` header → `projectId` via `resolve-hostname` |
-| `packages/services/service-cloud/src/artifact-kernel-factory.ts` | Boots a kernel from a returned artifact (no `ControlPlaneProxyDriver`) |
-| `packages/spec/src/system/project-artifact.zod.ts` | Normative envelope schema |
+| `packages/cli/src/commands/publish.ts` | CLI publish command and endpoint construction. |
+| `packages/cli/src/commands/rollback.ts` | CLI revision activation command. |
+| `packages/runtime/src/cloud/environment-registry.ts` | Runtime seam for id/hostname environment resolution. |
+| `packages/runtime/src/cloud/runtime-config-plugin.ts` | Console runtime-config for active/default environment state. |
+| `packages/spec/src/system/environment-artifact.zod.ts` | Normative artifact envelope schema. |
+
+---
 
 ## Related
 
-- [North Star — §6.3 Runtime Inputs](./north-star)
-- [Cloud Deployment](../guides/cloud-deployment) — `OS_MODE=runtime` setup
-- [Single-Project Mode](../guides/single-project-mode) — alternative for local / one-tenant workloads
+- [Deployment Modes](../guides/cloud-deployment)
+- [Environment-Scoped Routing](../guides/project-scoping)
+- [North Star](./north-star)

--- a/content/docs/concepts/design-principles.mdx
+++ b/content/docs/concepts/design-principles.mdx
@@ -132,7 +132,7 @@ Each translation layer can lose validation, authorization, or business meaning.
 ObjectStack derives agent capabilities from the protocol itself:
 
 ```
-Zod metadata -> Project Artifact -> ObjectOS runtime -> API / UI / MCP tools
+Zod metadata -> Environment Artifact -> ObjectStack runtime -> API / UI / MCP tools
 ```
 
 **Benefits:**

--- a/content/docs/concepts/implementation-status.mdx
+++ b/content/docs/concepts/implementation-status.mdx
@@ -89,7 +89,7 @@ This matrix is generated from actual codebase analysis and represents the curren
 | **Encryption** | ❌ | 📋 | Planned |
 | **Compliance** | ❌ | 📋 | Planned |
 | **Masking** | ❌ | 📋 | Planned |
-| **Notification** | ❌ | 📋 | Planned |
+| **Notification** | ✅ | 🟡 | Framework pipeline shipped; objectui bell cut-over remains |
 | **Change Management** | ❌ | 📋 | Planned |
 | **Collaboration** | ❌ | 📋 | Planned |
 
@@ -120,8 +120,8 @@ This matrix is generated from actual codebase analysis and represents the curren
 | date, datetime, time | ✅ | Full support |
 | select, multiselect | ✅ | Full support |
 | lookup, master_detail | ✅ | Full support in spec, partial in memory driver |
-| formula | 📋 | Protocol defined, not implemented |
-| rollup_summary | 📋 | Protocol defined, not implemented |
+| formula | ✅ | CEL-backed formula fields are implemented |
+| summary | ✅ | Server-side rollups for count/sum/min/max/avg on child records |
 | json, array | ✅ | Full support |
 | file, image | 📋 | Protocol defined, not implemented |
 
@@ -380,10 +380,9 @@ The `auth` service in `CoreServiceName` covers both **authentication** (identity
 - [ ] Dashboard Renderer
 - [ ] Theme Engine
 
-### Phase 8: Automation (Plugin) 📋 **PLANNED**
-- [ ] Workflow Engine Plugin
-- [ ] Flow Builder Plugin
-- [ ] Approval Process Plugin
+### Phase 8: Automation (Plugin) 🟡 **IN PROGRESS**
+- [x] Flow Engine Plugin
+- [x] Approval Node Plugin
 - [ ] ETL Pipeline Plugin
 - [ ] Trigger Registry Plugin
 

--- a/content/docs/concepts/north-star.mdx
+++ b/content/docs/concepts/north-star.mdx
@@ -1,658 +1,134 @@
 ---
 title: North Star
-description: The product shape of ObjectStack - AI-native business backend, code-first metadata authoring, control-plane artifacts, Studio observability, and stateless ObjectOS runtimes.
+description: ObjectStack's current product and architecture direction.
 ---
-
-import { AlertTriangle, Cloud, Cpu, Globe, Layers, Terminal } from 'lucide-react';
 
 # North Star
 
-> This document is the **product-shape blueprint** for ObjectStack. The sibling documents
-> (`architecture.mdx`, `metadata-driven.mdx`) describe the **microkernel internals**.
-> This one describes **what users actually do** and **what the platform looks like from
-> the outside**. When an architecture decision is unclear, read this first.
+ObjectStack is the metadata-native backend for business software that humans and
+AI agents can both operate safely. The platform makes the business system
+explicit: data models, views, flows, permissions, actions, AI tools, and runtime
+requirements are typed metadata instead of scattered ad-hoc code.
 
-## 1. Mission
+The goal is a small, inspectable, governed application surface:
 
-ObjectStack is an **AI-native business backend**. Users author data shape,
-business logic, permissions, UI metadata, and agent-facing tools as
-**declarative metadata** in a local TypeScript workspace. The platform compiles
-that metadata into JSON artifacts, publishes each artifact as an immutable
-Project Version in the control plane, and serves running applications from the
-Project's current Version - no glue code, no hand-written CRUD, no separate
-frontend/backend codebases, and no manually duplicated agent tool definitions.
-
-Phase 1 is deliberately **code-first**:
-
-- The local TypeScript workspace is the only metadata authoring surface.
-- The CLI compiles metadata and publishes a new Project Version to the control plane.
-- Studio is a hosted control-plane dashboard for project configuration, version
-  history, artifact inspection, logs, and health. It does **not** modify user
-  metadata in Phase 1.
-- ObjectOS runtimes are stateless consumers of the Project's current Version artifact.
-
-Six non-negotiable tenets:
-
-- **Agent-Ready Business Metadata** - objects, fields, functions, views, flows, permissions, and tools are all explicit metadata artifacts
-- **Compact by Construction** - because the whole business system is declarative metadata, a typical enterprise app needs **roughly two orders of magnitude less code** (~100× fewer lines to write and maintain) than a hand-written equivalent. Small enough for an AI agent to load end-to-end, reason about every dependency, and safely refactor across data, API, UI, and permissions in a single change - this is the real moat, not "low-code UI"
-- **Versioned Artifacts, Stateless Runtime** - every publish creates an immutable Project Version; ObjectOS runtimes pull the current Version artifact and serve it
-- **TS-Authored, JSON-Stored** - TypeScript is the authoring form (type safety, IDE intelligence, AI-assisted editing); JSON is the wire and storage form (Project Version artifact payload, Artifact API response body, local artifact cache). Zod schemas are the only bridge between the two.
-- **Local-First (development)** - every project can run against local drivers (memory, SQLite, embedded Turso replica); cloud is an enhancement, not a dependency. This refers to the *developer/runtime* mode, not to data sovereignty on end-user devices.
-- **Open Core** - this repository is Apache-2.0 licensed as the open-source framework foundation; enterprise editions, official cloud services, and marketplace commercial terms live outside this repository
-
-## 2. Product Shape
-
-ObjectStack's first production shape is **code-first AI-native metadata deployment**:
-developers author a TypeScript metadata tree locally, compile it to JSON, publish
-it as an immutable Project Version in the control plane, inspect the version and
-artifact in Studio, and run the Project's current Version through ObjectOS. The
-same artifact is the source for APIs, UI metadata, permission checks, workflows,
-and agent tool surfaces.
-
-Branching, visual metadata editing, and pull/merge workflows are future phases.
-The Phase 1 goal is smaller and more important: make the artifact boundary real
-and make every publish a durable, rollback-capable Version.
-
-<Cards>
-  <Card icon={<Terminal />} title="Local Workspace + CLI" description="TS-authored project tree. `compile` turns it into JSON; `publish` creates an immutable Project Version." />
-  <Card icon={<Cloud />} title="Studio Dashboard" description="Create orgs and projects. Inspect versions, artifacts, publish history, logs, and health. Phase 1 is read-only for user metadata." />
-  <Card icon={<Globe />} title="Artifact API" description="Control-plane endpoint that returns a project's current Version artifact. HTTP today, S3-backed tomorrow." />
-  <Card icon={<Cpu />} title="ObjectOS Runtime" description="Stateless artifact consumer. Pulls once, caches, serves API + UI, and survives control-plane outages." />
-</Cards>
-
-| Developer / Cloud Concept | ObjectStack Phase 1 |
-| :------------------------ | :------------------ |
-| Organization              | Organization        |
-| Hosted project            | Project             |
-| Working tree              | Local TS file tree (`objectstack.config.ts` + `src/objects/*.ts` + ... ) |
-| Build                     | `objectstack compile` - validates TS, writes `dist/objectstack.json` |
-| Deploy                    | `objectstack publish` - creates a new immutable Project Version for one project |
-| Dashboard                 | Studio - project management, version history, artifact inspection, logs, health |
-| Runtime boot              | ObjectOS pulls current Version artifact -> hydrates kernel -> serves app |
-| Artifact storage          | Project Version artifact JSON or payload reference, validated by Zod |
-| Metadata projection       | Optional derived indexes / summaries; full metadata browsing is not required for Phase 1 |
-| Business rows             | Per-project business DB, never the control-plane DB |
-| Project URL               | Project hostname    |
-
-The deliberate simplification is that Phase 1 has **one writer** for user
-metadata: the CLI publishing from the local TypeScript workspace. Studio can show
-version history, artifact payloads, generated tool surfaces, permission
-boundaries, and runtime state, but it cannot edit metadata. This keeps the core
-loop tight:
-
+```text
+Zod metadata -> compiled environment artifact -> ObjectStack runtime -> REST / UI / MCP / AI tools
 ```
-TS authoring -> compile -> publish Project Version -> current artifact -> ObjectOS runtime
-```
-
-## 3. Primary Surfaces
-
-Four user-facing surfaces. Everything else is infrastructure.
-
-### <Terminal className="inline" /> Local Workspace + CLI
-
-Authoring surface. A scaffolded TypeScript file tree driven by the `objectstack`
-CLI. Exists because AI coding assistants, IDE intellisense, and Zod type
-inference work best when metadata is authored in TS. JSON is a storage and wire
-format, not the human authoring format.
-
-**Shape:**
-- `objectstack.config.ts` calling `defineStack({...})`
-- Object / view / flow / agent files under `src/*/` using `ObjectSchema.create()`, `Field.*`, `defineView()`, `defineAgent()` etc.
-- Scaffolded via `npx create-objectstack`. See [packages/create-objectstack/src/index.ts](packages/create-objectstack/src/index.ts).
-
-**Core commands:**
-- `objectstack dev` - boots a local ObjectOS against the local TS tree, fully offline (no control-plane call)
-- `objectstack compile` - validates TS against `ObjectStackDefinitionSchema` and emits `dist/objectstack.json`. See [packages/cli/src/commands/compile.ts](packages/cli/src/commands/compile.ts).
-- `objectstack publish` - POSTs the compiled JSON to the control plane for the current project, creating a new immutable Project Version. Today routes to `/api/v1/packages` (legacy) - see [packages/cli/src/commands/publish.ts](packages/cli/src/commands/publish.ts); it must evolve to a project publish endpoint that returns `versionId`, `versionNumber`, `commitId`, and `checksum` (Drift in §7).
-
-**Relationship to Studio:** the CLI is the Phase 1 metadata writer. Studio is a
-reader for project configuration, Project Versions, artifacts, publish history,
-runtime health, logs, and usage signals. Bidirectional CLI/Studio editing is
-intentionally deferred.
-
-**Version model:** every successful publish creates an immutable Project Version
-with `versionId`, `versionNumber`, `commitId`, and a content checksum. A Project
-has a current Version pointer that controls what ObjectOS serves. Rollback is a
-pointer change, not artifact mutation. These identifiers are not yet a
-collaborative merge or bidirectional write protocol.
-
-### <Cloud className="inline" /> Studio Dashboard
-
-Cloud-hosted web UI. In Phase 1 Studio is the **control-plane console**, not a
-metadata authoring surface.
-
-**Responsibilities:**
-- Org / member / billing management
-- Project lifecycle (create, configure, delete)
-- Project version history (current version, latest version, rollback/promote state)
-- Artifact inspector (schema version, version id, checksum, commit id, publish time, payload preview)
-- API console, logs, usage metrics, runtime health
-- Publish history and diagnostics
-
-**Explicit Phase 1 boundary:** Studio does not edit user metadata. Visual
-metadata editors, metadata browsing as a primary product surface, Studio writes,
-and collaborative conflict handling belong to a future phase after the
-versioned-artifact runtime path is stable.
-
-**Status:** ~70% built for org/project/member UI. Version history, artifact
-viewer, and runtime observability need to be added. See [apps/studio/src/routes/](apps/studio/src/routes/).
-
-### <Globe className="inline" /> Control Plane Artifact API
-
-The **protocol boundary** between the control plane and ObjectOS runtimes. A
-single well-known HTTP endpoint returns everything ObjectOS needs to boot a
-project.
-
-```
-GET /api/v1/cloud/projects/:projectId/artifact
--> { schemaVersion, projectId, versionId, commitId, checksum, metadata, functions, manifest }
-```
-
-**Today (M3 built):** `GET /api/v1/cloud/projects/:projectId/artifact` is live — assembles the artifact from `sys_project.metadata.artifact_path` / `artifact_paths[]`, merges metadata bundles, and returns the `ProjectArtifact` envelope with `commitId` and `checksum`. `GET /api/v1/cloud/resolve-hostname` resolves a hostname to a project id. See [packages/services/service-cloud/src/cloud-artifact-api-plugin.ts](packages/services/service-cloud/src/cloud-artifact-api-plugin.ts).
-**Phase 1 next step:** wire proper Project Versions so the endpoint returns `versionId` / `versionNumber` and ObjectOS can use them for ETag cache invalidation.
-**Future:** the same endpoint can return a redirect or signed URL pointing at an
-S3 object. The interface is stable; the backend swaps.
-
-**Phase 1 target:** the control plane returns the Project's current Version
-artifact. A pinned endpoint can later return a specific immutable version:
-`GET /api/v1/cloud/projects/:projectId/versions/:versionId/artifact`.
-**Future:** the same endpoint can return a redirect or signed URL pointing at an
-S3 object. The interface is stable; the backend swaps.
-
-**Responsibilities:**
-- Serve the current Version's metadata + inlined function code as a single consumable blob
-- Expose `versionId`, `commitId`, content hash, and ETag so runtimes can detect drift and decide when to refetch
-- Leave room in the response shape for future `{ url, expiresAt, checksum }` indirection
-- Be cacheable at the CDN edge (future; read-heavy by design)
-
-**Status:** M3 + D2 built. Core endpoint live; Project Versions (immutable `versionId` / `versionNumber`) are the next step (M5).
-
-### <Cpu className="inline" /> ObjectOS Runtime
-
-The per-project runtime kernel. **Stateless** with respect to metadata -
-everything it knows comes from an artifact pulled over HTTP from the control
-plane. Connects to an **independent business database** for the project's actual
-data rows.
-
-**Responsibilities:**
-- Resolve incoming request -> project kernel via hostname
-- On first request for a project: pull artifact from Artifact API -> deserialize into kernel
-- Cache artifact locally; continue serving even if the control plane is unreachable
-- Auto-generate REST API from the artifact's object schemas
-- Auto-generate UI schemas (Amis/React-renderable)
-- Execute object functions in sandboxed runtime
-- Query/mutate the project's **business DB** (not the control-plane DB) through ObjectQL
-- Enforce permissions, emit audit events back to the control plane (best-effort)
-
-**Status:** Multi-project kernel + hostname routing built. `local-file` artifact
-boot (M1.x) implemented — ObjectOS can boot from `dist/objectstack.json` without
-any DB read. D1 is resolved: `MetadataPlugin` no longer registers
-`sys_metadata` / `sys_metadata_history` into the ObjectOS manifest and no longer
-auto-bridges ObjectQL to `DatabaseLoader` after startup. See
-[packages/runtime/src/project-kernel-factory.ts](packages/runtime/src/project-kernel-factory.ts)
-and [packages/metadata/src/plugin.ts](packages/metadata/src/plugin.ts).
-
-## 4. Core Entity Hierarchy
-
-Everything in the control plane; business data lives alongside but isolated per
-project.
-
-```
-Organization                            <- control plane
-  ├── Members (with roles)
-  ├── Billing
-  └── Project                           <- control plane; binds primary hostname
-      ├── Current Version Pointer       <- current_version_id
-      ├── Project Versions              <- immutable publish history
-      │   ├── version_id / version_number
-      │   ├── commit_id / checksum
-      │   └── Artifact JSON or payloadRef
-      ├── Artifact API                  <- control-plane response shape
-      │   └── Current Version compiled JSON document
-      └── Business DB                   <- per-project, independent
-          └── Rows of user objects (customer, order, ...)
-          !! Does NOT store metadata.
-```
-
-| Entity | Location / Table | Status |
-| :----- | :--------------- | :----- |
-| Organization | Control plane `sys_organization` | Built |
-| Project | Control plane `sys_project` (hostname binding) | Built |
-| Project Version | Control-plane immutable artifact release (`version_id`, `version_number`, `commit_id`, checksum, artifact JSON or payload reference) | To build |
-| Current Version Pointer | `sys_project.current_version_id` (target shape) controls the version ObjectOS serves | To build |
-| Artifact | `GET /api/v1/cloud/projects/:projectId/artifact` response for the current Version | To build |
-| Business DB | Per-project dedicated DB (Turso / SQL / memory) | Built (driver provisioning), but currently shares space with metadata |
-| Branch | Future control-plane entity that points to a version and owns runnable branch config | Deferred |
-
-See [packages/services/service-tenant/src/objects/sys-project.object.ts](packages/services/service-tenant/src/objects/sys-project.object.ts)
-for the current Project schema.
-
-### Authoring vs Storage
-
-Metadata has two physical forms in ObjectStack, and the boundary between them is
-strict:
-
-- **Authoring form - TypeScript.** Developers edit `objectstack.config.ts` and
-  `src/*` files locally. The thing humans and AI agents interact with is typed
-  TypeScript backed by Zod schemas.
-- **Storage / wire form - JSON.** Everything that hits a disk or a network -
-  the Project Version artifact payload, the Artifact API response body, the
-  local artifact cache, and any future object-storage payload reference - is
-  JSON. It is small, portable, and has no dependency on the TypeScript compiler.
-
-The bridge between the two is **Zod**, nothing else:
-
-- CLI `compile` validates the local TS tree against `ObjectStackDefinitionSchema.safeParse` and emits JSON.
-- The control plane validates incoming JSON with the same Zod schemas before creating a Project Version.
-- ObjectOS validates the artifact with Zod on load.
-- JSON Schema (published via `z.toJSONSchema()` in [packages/spec/scripts/build-schemas.ts](packages/spec/scripts/build-schemas.ts)) powers IDE validation and CLI error messages.
-
-If Studio later needs rich metadata browsing, diffing, or visual editing, those
-features read **directly from the artifact in memory** (the same source the
-runtime uses). The control plane does **not** materialise artifact contents
-into `sys_metadata` — that table is reserved exclusively for per-organisation
-overlay deltas (ADR-0005, ADR-0008 §0). Artifact change history lives in Git
-and in the deployment log; see the
-[FAQ in Metadata Lifecycle](/concepts/metadata-lifecycle#faq--when-does-code-defined-metadata-enter-the-database)
-for the full rationale.
-
-Any serializer that bypasses Zod is an anti-pattern - see §8. The Zod schema
-**is** the protocol.
-
-## 5. Operational Architecture - Three Vertices, One Protocol
-
-This is **how the platform runs**, not how the code is organized. The control
-plane sits at the center of a triangle: **Local Workspace** pushes compiled JSON
-in; **Studio** reads and visualizes control-plane state; **ObjectOS runtimes**
-pull the compiled artifact out over HTTP. One HTTP contract (the Artifact API)
-carries everything that leaves the control plane for runtime boot.
-
-```
-┌─ Local Workspace ──────────┐         ┌─ Studio (UI) ─────────┐
-│ objectstack.config.ts (TS) │         │ Project dashboard     │
-│ src/objects/*.ts      (TS) │         │ Version history       │
-│ src/views/*.ts        (TS) │         │ Artifact inspector    │
-│                            │         │ Logs / health         │
-│ objectstack compile        │         │                       │
-│   -> dist/objectstack.json │         │                       │
-└────────────┬───────────────┘         └───────────▲───────────┘
-             │ publish                            │ read-only APIs
-             ▼                                    │
-┌─────────────────────────────────────────────────────────────┐
-│ Control Plane  (singleton, cloud-hosted)                    │
-│ ──────────────────────────────────────                      │
-│ Studio UI (React) + Hono backend                            │
-│                                                             │
-│ Platform metadata:                                          │
-│   sys_organization · sys_project · sys_user · sys_app       │
-│   Auth · Billing · Audit                                    │
-│                                                             │
-│ Project Versions (all projects):                           │
-│   Immutable publish artifacts                               │
-│   - artifact JSON or payloadRef                             │
-│   - version_id / version_number / commit_id / checksum      │
-│   - current_version_id pointer on sys_project               │
-│   - extracted summaries / indexes for Studio views          │
-│                                                             │
-│ Artifact API:                                               │
-│   GET /api/v1/cloud/projects/:projectId/artifact            │
-│   today : returns current Version artifact                  │
-│   future: pinned version endpoint + S3 redirect / signed URL│
-│                                                             │
-│ Hostname routing: host -> project                           │
-└──────────────────────────┬──────────────────────────────────┘
-                           │ Artifact over HTTP   <- the protocol
-                           ▼
-┌─────────────────────────────────────────────────────────────┐
-│ ObjectOS Runtimes  (one ObjectKernel per active project)    │
-│ ──────────────────────────────────────                      │
-│ Two boot paths, one kernel:                                 │
-│   (a) from-artifact-api - production, cloud ObjectOS        │
-│       pull JSON over HTTP -> hydrate kernel -> cache locally│
-│   (b) from-local-file - `objectstack dev`, fully offline    │
-│       read dist/objectstack.json (or in-memory TS) -> run   │
-│                                                             │
-│ Serve: auto-generated REST + UI schema from metadata        │
-│ Data : business driver -> per-project business DB           │
-│        (no metadata queries; business rows only)            │
-└─────────────────────────────────────────────────────────────┘
-```
-
-The **immutability of the artifact** is a Phase 1 product boundary. Each publish
-creates a new Project Version; the Project's current Version pointer decides
-what production ObjectOS serves. `versionId`, `commitId`, and `checksum`
-identify exactly which bytes a runtime loaded. Rollback and promotion mutate
-pointers, never Version payloads.
-
-**Two vertices, two apps, one framework.** The Control Plane vertex and the
-ObjectOS Runtime vertex are both realized as ObjectStack-framework apps booted
-from their own `objectstack.config.ts`. They share the same `ObjectKernel`,
-spec, and adapter stack - they differ **only in the plugin manifest they
-register**. Today [apps/objectos/objectstack.config.ts](apps/objectos/objectstack.config.ts)
-is a hybrid that loads both manifests in one process; the target shape is two apps:
-
-| Plugin | `apps/cloud` (Control Plane) | `apps/objectos` (ObjectOS) |
-|:---|:---:|:---:|
-| `createControlPlanePlugins(...)` (ObjectQL on control DB + driver + system-project + sys_* metadata) | Yes | - |
-| `MultiProjectPlugin` (`env-registry`, `kernel-manager`, `template-seeder`) | Yes | - |
-| `AuthPlugin` | Yes | Yes |
-| `createTenantPlugin(...)` | Yes | Yes |
-| `SecurityPlugin` | Yes | Yes |
-| `AuditPlugin` | Yes | Yes |
-| `SetupPlugin` (Studio bootstrap) | Yes (optional) | - |
-| `ObjectQLPlugin` (project-scoped) | - | Yes |
-| `MetadataPlugin` (artifact-loader mode) | - | Yes |
-| User-app `AppPlugin` (compiled app) | - | Yes |
-
-Identity plugins (Auth/Tenant/Security/Audit) are installed on **both** sides:
-a request to either vertex must resolve the same user/org/role. Splitting
-identity would require federated auth, which is out of scope.
-
-**Key code anchors:**
-- Control-plane app (target): [apps/cloud/objectstack.config.ts](apps/cloud/objectstack.config.ts) (D8 complete)
-- ObjectOS app (target): [apps/objectos/objectstack.config.ts](apps/objectos/objectstack.config.ts) (currently hybrid; will be reduced to ObjectOS manifest)
-- Hostname -> project resolver: [packages/runtime/src/environment-registry.ts](packages/runtime/src/environment-registry.ts)
-- Per-project kernel factory: [packages/runtime/src/project-kernel-factory.ts](packages/runtime/src/project-kernel-factory.ts)
-- HTTP dispatch: [packages/runtime/src/http-dispatcher.ts](packages/runtime/src/http-dispatcher.ts)
-- Org-scoped proxy: [packages/runtime/src/control-plane-proxy-driver.ts](packages/runtime/src/control-plane-proxy-driver.ts)
-- Metadata loading (artifact/local-file backed; no automatic ObjectQL -> `DatabaseLoader` bridge in ObjectOS): [packages/metadata/src/plugin.ts](packages/metadata/src/plugin.ts)
-- App catalog sync: [packages/services/service-tenant/src/services/app-catalog.service.ts](packages/services/service-tenant/src/services/app-catalog.service.ts)
-
-## 6. Key Lifecycles
-
-### 6.0 Local Development and Push
-
-```
-npx create-objectstack my-app          # scaffold TS file tree (objectstack.config.ts + src/*)
-cd my-app
-objectstack dev                         # boot ObjectOS from local TS - no control-plane call
-  ... iterate: edit src/objects/*.ts, Fast Refresh ...
-objectstack compile                     # validate TS -> emit dist/objectstack.json
-objectstack login                       # obtain auth token for the target control plane
-objectstack publish                     # POST JSON, create Project Version
-                                        # returns versionId + commitId + checksum
-```
-
-Two things to notice:
-
-1. **`objectstack dev` is fully offline.** The local ObjectOS reads the TS tree
-   (or the compiled `dist/objectstack.json`) directly. It does not hit the
-   Artifact API, and it does not need login/network.
-2. **`publish` creates an immutable Project Version.** In Phase 1 the local TS
-    workspace is the only metadata writer, so `versionId`, `commitId`, and
-    checksum are primarily release-history, audit, rollback, and
-    cache-validation identifiers.
-
-### 6.1 Onboarding
-
-```
-signup -> create org -> create project
-  -> control plane allocates primary hostname
-  -> control plane provisions per-project business DB (Turso / SQL / memory)
-  -> Studio lands on the project overview
-  -> ObjectOS does NOT boot yet - it boots lazily on first request
-```
-
-### 6.2 Publish and Inspect
-
-```
-developer runs objectstack publish
-  -> control plane validates JSON with Zod
-  -> creates immutable Project Version with artifact JSON or payloadRef
-  -> records versionId, versionNumber, commitId, and checksum
-  -> advances project current_version_id (auto-promote in Phase 1)
-  -> Studio shows current version, artifact envelope, publish history, and validation state
-  -> ObjectOS pulls the current Version artifact on next boot/refetch
-```
-
-Studio is intentionally a viewer and release console here. If a user sees bad
-metadata in an artifact, the fix is to edit the local TS files and publish a new
-Version, or roll back the Project's current Version pointer to a known-good
-Version.
-
-### 6.3 Runtime Inputs
-
-ObjectOS 的运行时输入分两类，**缺一不可**。把两类混在一起就破坏了 §2「Versioned Artifacts, Stateless Runtime」与 §8「ObjectOS 只通过 Artifact API 接触控制面」的边界。
-
-**A. Artifact**（不可变、可缓存、随 metadata 变更而变更）
-
-`ProjectArtifactSchema` envelope，定义在 [packages/spec/src/cloud/project-artifact.zod.ts](packages/spec/src/cloud/project-artifact.zod.ts)：
-
-```
-{ schemaVersion, projectId, versionId?, commitId, checksum, metadata, functions, manifest, builtAt, builtWith, payloadRef? }
-```
-
-`metadata` 字段承载声明性元数据（objects、views、flows、agents 等），`functions` 内联可执行源码，`manifest` 声明插件 / driver / engine 要求。Envelope 在外面包一层 `versionId` / `commitId` / `checksum`，让 ObjectOS 能做完整性校验、ETag 校验和缓存失效。`payloadRef` 为未来 S3 / signed URL 旁路保留，不需要 envelope 破坏性升级。
-
-**B. Deployment Config**（可变、不进 artifact、与元数据正交）
-
-ObjectOS 启动时必须从外部注入：
-
-1. 业务 DB 坐标（URL / driver / 凭据）
-2. 项目身份（`projectId` / `organizationId` / `hostname`）
-3. 控制面 URL（用于拉 artifact、上报 audit）
-4. 进程级密钥（`AUTH_SECRET`、KMS 密钥）
-
-**云端模式**下，B 来自控制面 `sys_project` + `sys_project_credential` + 进程 env。**本地单 project 模式**（一个 ObjectOS 进程对应一个 project，不是多租户网关）下退化为扁平 env：
-
-| Env | 用途 | 备注 |
-|:---|:---|:---|
-| `OS_PROJECT_ID` | 项目身份 | 本地可固定为 `proj_local` |
-| `OS_DATABASE_URL` | 业务 DB URL | 例：`file:./.data/app.db` |
-| `OS_DATABASE_DRIVER` | 业务 DB driver | `turso` / `sqlite` / `memory` |
-| `OS_ARTIFACT_PATH` | 本地 artifact 路径 | 默认 `./dist/objectstack.json`；填了即跳过 Artifact API |
-| `OS_MODE` | 部署模式 | `standalone`（默认）/ `cloud`；`cloud` 时 `OS_DATABASE_URL` 解释为控制面 DB URL |
-| `OS_MULTI_PROJECT` | 多项目开关（已废弃） | 旧别名：`=true` 等价 `OS_MODE=cloud`，将于下个 major 移除 |
-| `AUTH_SECRET` | 进程级密钥 | |
-
-本地模式可以用磁盘 `dist/objectstack.json` 直接喂内核（用 `commitId: 'local-dev'` 之类的占位 envelope），不需要控制面在场。
-
-**结论**：`objectstack.json` 是元数据（A）的充分输入，但**不是**运行时的充分输入。任何把业务 DB 连接、密钥、租户身份塞进 `objectstack.json` 的尝试都是反模式（见 §8）。
-
-### 6.4 Runtime Request
-
-```
-GET https://proj.app/api/v1/data/customer
-  ↓
-ObjectOS gateway receives request -> EnvironmentDriverRegistry resolves
-  hostname -> projectId
-  ↓
-KernelManager looks up ObjectKernel for projectId
-  ↓
-If kernel has no artifact loaded:
-    GET /api/v1/cloud/projects/:projectId/artifact
-  -> returns current Version artifact
-  -> hydrate metadata + function code into kernel
-    -> cache artifact locally (survives control-plane downtime)
-  ↓
-REST plugin auto-generates `customer` handler from artifact schema
-  ↓
-ObjectQL runs query against the project's BUSINESS DB (not control plane)
-  ↓
-Response flows back; audit event emitted to control plane (best-effort)
-```
-
-Subsequent requests reuse the cached artifact. Cache invalidation strategy
-(push / poll / ETag) is an Open Question.
-
-## 7. Alignment Check
-
-Honest state of the platform as of 2026-05-08, **re-classified under the Phase
-1 code-first, version-first model**. Every future architectural decision should
-preserve Built, reduce Drift, and advance Missing.
-
-> **2026-04-13 amendment.** `MetaRef` no longer carries `project` or `branch` —
-> the metadata layer is keyed purely by `(org, type, name)`. Project survives
-> only as an artifact-packaging concept (the `objectstack.json` envelope);
-> branching is left to Git. See
-> [ADR-0008 §0](/adr/0008-metadata-repository-and-change-log#0-2026-04-13-amendment--drop-project-and-branch-from-metaref)
-> and the
-> [Metadata Lifecycle FAQ](/concepts/metadata-lifecycle#faq--when-does-code-defined-metadata-enter-the-database)
-> for the rationale.
-
-### <Layers className="inline" /> Built (Aligned)
-
-- Organization CRUD + member/invitation system - [apps/studio/src/hooks/useSession.ts](apps/studio/src/hooks/useSession.ts)
-- Project CRUD + per-project Turso/memory DB provisioning - [packages/services/service-tenant/](packages/services/service-tenant/)
-- Per-project ObjectKernel with LRU cache - [packages/runtime/src/project-kernel-factory.ts](packages/runtime/src/project-kernel-factory.ts)
-- Hostname-based routing: `sys_project.hostname` -> kernel resolution - [packages/runtime/src/environment-registry.ts](packages/runtime/src/environment-registry.ts)
-- ControlPlaneProxyDriver for org-scoped data isolation - [packages/runtime/src/control-plane-proxy-driver.ts](packages/runtime/src/control-plane-proxy-driver.ts)
-- AppCatalogService (per-project app events -> org-scoped `sys_app` catalog) - [packages/services/service-tenant/src/services/app-catalog.service.ts](packages/services/service-tenant/src/services/app-catalog.service.ts)
-- **TS -> JSON compile pipeline.** `objectstack compile` validates a local TS stack against `ObjectStackDefinitionSchema` and writes `dist/objectstack.json` - [packages/cli/src/commands/compile.ts](packages/cli/src/commands/compile.ts).
-- **Zod -> JSON Schema publishing pipeline.** The bridge that makes TS/JSON interchangeable - [packages/spec/scripts/build-schemas.ts](packages/spec/scripts/build-schemas.ts).
-- **Scaffolded TS file tree.** `create-objectstack` emits a `defineStack()` entry point plus split-out `src/objects/*.ts`, `src/views/*.ts` etc. - [packages/create-objectstack/src/index.ts](packages/create-objectstack/src/index.ts).
-- **ObjectOS metadata DB bridge removed.** `MetadataPlugin` no longer registers `sys_metadata` / `sys_metadata_history` into the ObjectOS manifest and no longer auto-connects ObjectQL to a `DatabaseLoader`; runtime metadata is hydrated from files or artifacts only - [packages/metadata/src/plugin.ts](packages/metadata/src/plugin.ts).
-- **JSON-payload storage primitive.** `sys_metadata.metadata` proves the platform can persist JSON payloads in metadata objects - [packages/metadata/src/objects/sys-metadata.object.ts](packages/metadata/src/objects/sys-metadata.object.ts). In the version-first model, user metadata browsing can be a projection from Project Version artifacts rather than the primary storage path.
-- **Project artifact envelope schema (M1).** `ProjectArtifactSchema` v0 exists with `schemaVersion`, `projectId`, `commitId`, `checksum`, `metadata`, `functions`, `manifest`, and reserved `payloadRef` - [packages/spec/src/cloud/project-artifact.zod.ts](packages/spec/src/cloud/project-artifact.zod.ts).
-- **Project artifact path binding.** Multi-project provisioning accepts `metadata.artifact_path`, and `os projects create --artifact` / `os projects bind --artifact` wire local compiled bundles into existing projects - [packages/cli/src/commands/projects/create.ts](packages/cli/src/commands/projects/create.ts), [packages/cli/src/commands/projects/bind.ts](packages/cli/src/commands/projects/bind.ts).
-- **Live kernel bundle resolver.** Project kernels read `sys_project.metadata.artifact_path` / `artifact_paths[]`, with `OS_PROJECT_ARTIFACTS` and `OS_PROJECT_ARTIFACT_ROOT` overrides for local development - [apps/objectos/server/fs-app-bundle-resolver.ts](apps/objectos/server/fs-app-bundle-resolver.ts).
-- **Object identity is single-sourced on `name`.** `ObjectSchemaBase.namespace` has been removed; package namespace remains internal registry metadata, not an object identity field - [packages/spec/src/data/object.zod.ts](packages/spec/src/data/object.zod.ts).
-- **Manifest scope enum trimmed.** `ManifestSchema.scope` accepts only `cloud`, `system`, and `project` - [packages/spec/src/kernel/manifest.zod.ts](packages/spec/src/kernel/manifest.zod.ts).
-- **Canonical package manifest files.** Plugin/service packages now share a single `src/manifest.ts` between compile-time config and runtime registration, reducing object-list drift.
-- **CLI `publish` link.** The end-to-end "local JSON -> remote server" wire is alive, even though the endpoint shape is wrong - [packages/cli/src/commands/publish.ts](packages/cli/src/commands/publish.ts).
-- **`env_id` → `project_id` migration (M2 — superseded 2026-04).** Metadata storage tables (`sys_metadata`, `sys_metadata_history`) were migrated from `env_id` to `project_id` as the partition key. Idempotent helper at `@objectstack/metadata/migrations` - [packages/metadata/src/migrations/migrate-env-id-to-project-id.ts](packages/metadata/src/migrations/migrate-env-id-to-project-id.ts). **Note**: per the [ADR-0008 §0 amendment (2026-04-13)](/adr/0008-metadata-repository-and-change-log#0-2026-04-13-amendment--drop-project-and-branch-from-metaref), `project` and `branch` are removed from `MetaRef`; `SysMetadataRepository` now keys overlay rows purely by `organization_id` and ignores the legacy `project_id` / `branch` columns at read time. They survive in the schema for backward compatibility and will be dropped in a future major. (Per-type tables `sys_object` / `sys_view` / `sys_flow` / `sys_agent` / `sys_tool` were removed in 2026-05 — all metadata now lives as JSON in `sys_metadata`.)
-- **Artifact API endpoints (M3 + D2).** `GET /api/v1/cloud/projects/:id/artifact` returns the current artifact assembled from `sys_project.metadata.artifact_path`. `POST /api/v1/cloud/projects/:id/metadata` receives compiled JSON, persists it under `<artifactRoot>/<projectId>/artifact.json`, and updates the project metadata pointer — [packages/services/service-cloud/src/cloud-artifact-api-plugin.ts](packages/services/service-cloud/src/cloud-artifact-api-plugin.ts). `GET /api/v1/cloud/resolve-hostname` resolves a hostname to a project id.
-- **CLI `publish` routes to project publish endpoint (D2).** `objectstack publish` now POSTs to `/api/v1/cloud/projects/:id/metadata`, accepts `--project` and `--server` flags, and returns `versionId`, `commitId`, and `checksum` — [packages/cli/src/commands/publish.ts](packages/cli/src/commands/publish.ts).
-- **`apps/objectos` uses ObjectOS runtime mode (M4).** `apps/objectos/objectstack.config.ts` boots via `createBootStack({ runtime: { cloudUrl: ... } })`, separating the ObjectOS runtime from the control plane — [apps/objectos/objectstack.config.ts](apps/objectos/objectstack.config.ts).
-- **`apps/cloud` is an independent control plane (D8).** `apps/cloud/objectstack.config.ts` boots via `createBootStack({ mode: 'cloud', ... })`, running the control plane independently without the ObjectOS runtime manifest — [apps/cloud/objectstack.config.ts](apps/cloud/objectstack.config.ts).
-- **Storage driver matrix expanded to MongoDB.** `@objectstack/driver-mongodb` ships a full `IDataDriver` (filter translator, aggregation builder, schema sync) with 75 unit tests against `mongodb-memory-server`, and is wired into the CLI / `service-cloud` driver factory — [packages/plugins/driver-mongodb/](packages/plugins/driver-mongodb/), [packages/services/service-cloud/src/driver-factory.ts](packages/services/service-cloud/src/driver-factory.ts).
-- **Driver auto-detection from URL scheme.** `OS_DATABASE_URL` / `OS_CONTROL_DATABASE_URL` infer the driver from `mongodb://`, `postgres://`, `mysql://`, `libsql://`, `file:`, `:memory:` so deploys can drop the explicit `OS_DATABASE_DRIVER` flag — [packages/cli/src/commands/serve.ts](packages/cli/src/commands/serve.ts), [apps/objectos/objectstack.config.ts](apps/objectos/objectstack.config.ts).
-- **CLI startup banner shows resolved driver + redacted DB URL.** `objectstack serve` prints a `Driver:` line (e.g. `MongoDBDriver → mongodb://admin:****@host/db`) so operators can verify URL inference at a glance — [packages/cli/src/utils/format.ts](packages/cli/src/utils/format.ts).
-- **Multi-driver e2e harness.** The [HotCRM reference app](https://github.com/objectstack-ai/hotcrm) ships a shared `runDriverAcceptance()` helper plus per-driver Playwright specs (sqlite / mongodb / postgres) and a `scripts/run-driver-acceptance.sh` wrapper that boots `pnpm dev` per-driver.
-- **AI routes are identity-aware end to end.** Cookie sessions and Bearer tokens both resolve to `req.user` on `/api/v1/ai/*`, which is forwarded as `toolExecutionContext.actor` so every `query_records` / `get_record` / `aggregate_data` / `action_*` tool call runs through ObjectQL with the caller's RLS context — agents inherit the user's row visibility for free. LLM-generated conversation titles also fire under that same identity. See [AI Capabilities → Permission-aware execution](/guides/ai-capabilities#permission-aware-execution-rls-for-agents).
-
-### <AlertTriangle className="inline" /> Drift (Needs Cleanup)
-
-- **Half-wired abstractions**: `ScopedServiceManager` and `SharedProjectPlugin`
-  were added but their integration into the request path is incomplete. Either
-  finish them or remove.
-- **`ProjectKernelFactory` 直连控制面 DB 读 `sys_project` / `sys_project_credential`，绕过 Artifact API。**
-  [packages/runtime/src/project-kernel-factory.ts](packages/runtime/src/project-kernel-factory.ts)
-  在 boot 时直接查控制面表拿业务 DB 坐标和凭据，破坏了 §8「ObjectOS 只通过
-  Artifact API 接触控制面」的边界。修复方向：业务 DB 坐标和凭据归 Deployment
-  Config（§6.3 B），通过启动时注入而非控制面 DB 直连。
-- **Custom Salesforce-flavor formula engine.**
-  [packages/objectql/src/formula.ts](packages/objectql/src/formula.ts) 是一个 433
-  LoC、22 函数、手写递归下降的私有 DSL。它没有公开训练语料，AI agent 每次都要从
-  prompt 里学一遍语法；`evaluateFormula` 用 `try { … } catch { return undefined }`
-  吞掉所有错误，业务规则静默失败；无递归深度上限/求值步数上限/超时，是潜在的 DoS
-  通道。修复方向：删除并替换为 CEL（Apache-2.0、Google CEL spec、K8s/GCP IAM/
-  Firestore 训练语料丰富、形式语法、AST-first、有界执行）。详见 ROADMAP M9。
-- **Untyped `z.string()` expression fields scattered across spec.** ~25 个
-  `formula / condition / expression / criteria / visible / visibleOn` 字段散布在
-  Data / UI / Security / Automation / AI / Kernel 各域，全部声明为裸
-  `z.string()` 并附 `.describe('Formula expression')`。这些字段实际涉及多种语言
-  （Salesforce-style formula、CEL-style predicate、JS expression、cron、SQL、
-  OpenAPI runtime expression），但 schema 层既不区分 dialect 也不强制 AST 形式。
-  修复方向：统一替换为 `ExpressionSchema { dialect, ast }`（详见 ROADMAP M9.3）。
-- **Compile-time-frozen seed timestamps.**
-  HotCRM 的种子
-  记录用 `new Date(Date.now() + 86400000 * 30)` 形式生成日期。这些表达式在 TS
-  编译期就被求值，把开发者的 wall-clock 烧进 `dist/objectstack.json`：(1) 两次
-  连续 `objectstack build` 的产物**不字节一致**，破坏 cacheable artifact 的隐式
-  契约；(2) 客户后续安装得到的种子日期是**开发者的**「今天 + 30 天」，dynamic
-  semantics 完全丢失。修复方向：种子记录里使用
-  `{ dialect: 'cel', ast: <os.now() + duration("P30D")> }`，由 SeedLoader 在
-  install 时按客户时钟求值。详见 ROADMAP M9.4。
-
-### <Globe className="inline" /> Missing (Not Started)
-
-- **Project Version storage** - persist every publish as an immutable Project Version with artifact JSON or `payloadRef`, `versionId`, `versionNumber`, `commitId`, checksum, publish metadata, and summary indexes.
-- **Current Version pointer** - add a project-level pointer that decides which Version ObjectOS serves; rollback/promote should update this pointer without mutating Version rows.
-- **Studio version/artifact viewer** - browse current version, publish history, artifact envelope, version id, commit id, checksum, logs, and runtime health. No metadata editing.
-- **UI auto-generation** - artifact schemas -> Amis/React components without hand-wiring.
-- **Unified `ExpressionSchema` + AST-first persistence.** Single
-  `{ dialect, ast }` envelope replacing all scattered `z.string()` formula
-  fields. Persisted artifact contains AST only; source strings are an
-  authoring-time DX shorthand normalized away by `objectstack compile`. See
-  ROADMAP M9.1 / M9.2 / M9.3.
-- **`packages/formula` + ObjectStack CEL stdlib.** New package wrapping
-  `cel-js` with a registry (`cel` / `js` / `cron` dialects) and an ObjectStack
-  standard function namespace (`os.now()`, `os.today()`, `os.user.*`,
-  `os.org.*`, `os.exists()`, `os.lookup()`, etc.). See ROADMAP M9.1.
-- **AI structured-output for expressions.** Publish `CelExprSchema` as JSON
-  Schema, mandate AST-only output in `skills/objectstack-formula/SKILL.md`,
-  wire constrained decoding into Studio AI assistant + CLI scaffolding. See
-  ROADMAP M9.7.
-
-## 8. Non-Goals and Anti-Patterns
-
-Decisions the platform has already rejected for Phase 1. Do not relitigate
-without explicit project-level buy-in.
-
-### Phase 1 non-goals
-
-- <AlertTriangle className="inline" /> **No branches in this round.** `sys_branch`, `branch_id`, branch hostnames, branch diff/merge, branch DB forks, and branch-scoped publish endpoints are deferred. Versioning comes first; branches later become named runnable pointers to versions.
-- <AlertTriangle className="inline" /> **Studio does not edit user metadata in this round.** It is a dashboard, version history, artifact inspector, and observability surface.
-- <AlertTriangle className="inline" /> **No bidirectional CLI/Studio write model.** The local TS workspace is the only Phase 1 metadata authoring source.
-- <AlertTriangle className="inline" /> **No `objectstack pull` in this round.** Reverse-hydrating JSON back into TS is deferred until Studio or other control-plane writers exist.
-- <AlertTriangle className="inline" /> **No merge/conflict UX in this round.** `versionId` and `commitId` identify versions and artifacts; they are not yet a collaborative merge protocol.
-- <AlertTriangle className="inline" /> **No multi-environment release train in this round.** Phase 1 supports one current Version per Project. Staged promotion across dev/staging/prod and branch-specific releases are deferred.
-- <AlertTriangle className="inline" /> **No S3 in this round.** The Artifact API's backend is the control-plane DB today. Design the response shape to accommodate a future `{ url, expiresAt, checksum }` indirection without building the S3 path now.
-
-### Architectural boundaries
-
-- <AlertTriangle className="inline" /> **ObjectOS runtimes don't talk to the control-plane DB.** The only coupling surface is the Artifact API (HTTP). Runtimes never open a connection to the control-plane database, even for "just a quick lookup."
-- <AlertTriangle className="inline" /> **Project business data is not metadata.** Business rows live in the per-project business DB. Metadata lives in the control plane.
-- <AlertTriangle className="inline" /> **Deployment Config 不进 artifact。** 业务 DB 坐标、凭据、进程密钥、租户身份等可变运行配置必须从启动环境（云端模式：控制面 `sys_project` + env；本地模式：扁平 env）注入，**绝不**写入 `objectstack.json`。把可缓存的不可变内容和易变的部署配置混在一起会同时破坏 §2 和 §8。详见 §6.3。
-
-### Representation-form boundaries
-
-- <AlertTriangle className="inline" /> **JSON is not an authoring form.** Phase 1 authors produce metadata via TypeScript and the CLI. If you find yourself editing Project Version JSON directly in the control plane, you are patching around a missing CLI affordance.
-- <AlertTriangle className="inline" /> **TS is not a wire form.** ObjectOS runtimes never consume `.ts` files directly. The only runtime inputs are a compiled `dist/objectstack.json` or the control plane's Artifact API response (also JSON).
-- <AlertTriangle className="inline" /> **No bypassing Zod for TS-to-JSON conversion.** Any hand-rolled serializer will diverge from the schema on the Nth protocol bump and silently corrupt data. `z.toJSONSchema()` + `schema.parse()` **is** the contract.
-
-### Prior anti-patterns (still in force)
-
-- <AlertTriangle className="inline" /> **No escape hatch for non-metadata logic.** All business logic lives in declared Object Functions or Flows. "Just add a raw endpoint" is not a supported pattern.
-- <AlertTriangle className="inline" /> **`packages/spec` stays logic-free.** Schemas, types, constants only. Runtime logic belongs in `core` / `runtime` / `services`. (Prime Directive #2.)
-- <AlertTriangle className="inline" /> **No `namespace` prefix mechanism.** If a module needs a prefix, embed it in the object `name` (`sys_user`, `crm_account`). The field is deprecated. (Prime Directive #7.)
-- <AlertTriangle className="inline" /> **No direct-DB SDK.** Every client access goes through ObjectQL - no bypass, no "just for perf" exception.
-- <AlertTriangle className="inline" /> **No deprecated-alias enums.** When refactoring enums (plugin scope, metadata types, etc.), break cleanly with a migration. Do not ship "old value still accepted" aliases.
-- <AlertTriangle className="inline" /> **No hand-written content in `content/docs/references/`.** That tree is regenerated from Zod schemas.
-- <AlertTriangle className="inline" /> **No private expression DSL.** Any "expression" string in metadata MUST declare a `dialect` and persist as an AST. New private grammars (Salesforce-flavor formula, custom predicate languages, ad-hoc condition syntax) are forbidden — they have no public training corpus, no formal grammar, and no AST round-trip story, all of which are required for the AI-native authoring path. The canonical dialects are `cel` (formulas + predicates), `js` (sandboxed L2 hook bodies), and `cron` (job schedules). SQL fragments stay driver-native and are not part of the expression registry.
-- <AlertTriangle className="inline" /> **Artifacts must be deterministic.** `objectstack compile` of unchanged source MUST produce a byte-identical `objectstack.json`. Anything that drifts between two consecutive builds — wall-clock timestamps, `Date.now()` / `Math.random()` / process IDs / absolute machine paths inside seed values, hostname-dependent data — is a bug. Dynamic semantics (e.g. "30 days from install time") belong in `ExpressionSchema` AST, evaluated at install time by the runtime, not at compile time by the author's clock. CI gate (M9.6): `objectstack build` twice, `sha256` must match.
-
-## 9. Open Questions
-
-Questions this document deliberately leaves unresolved. Answer them in follow-up
-design docs before building.
-
-1. ~~**Artifact content format details.**~~ **Resolved (2026-04-26):**
-   `ProjectArtifactSchema` v0 defines the envelope, manifest requirements,
-   function-code packaging, checksum, and future `payloadRef` indirection.
-2. ~~**Business DB connection config ownership.**~~ **Resolved (2026-04-25):**
-   Business DB coordinates and credentials are **Deployment Config**, never
-   part of the Artifact. See §6.3 Runtime Inputs. Cloud mode sources them from
-   control-plane `sys_project` / `sys_project_credential` + process env;
-   local single-project mode sources them from flat `OS_*` env vars.
-3. **Artifact cache invalidation.** Control-plane push notification?
-   Periodic polling from ObjectOS? HTTP ETag on every request? Each has
-   latency / chattiness / outage-resilience trade-offs.
-4. **Custom domains.** Customers bringing their own domain (`app.acme.com`) -
-   how does it map to project, and where is the TLS cert issued?
-5. **Local `dev` metadata form.** Does `objectstack dev` let ObjectOS consume
-   the in-memory TS definition directly (best DX: hot reload is trivial), or
-   does it always go through a `compile` step to JSON first (best isomorphy
-   with prod: fewer "works on my machine" bugs)?
-6. **Future Studio editing.** When Studio becomes a metadata authoring surface,
-   should it write through a control-plane REST API only? How does it preserve
-   round-trip expectations with TS-authored projects?
-7. **Future branch model.** When branches ship, should each branch be a named
-    runnable pointer to a Project Version with its own hostname, business DB
-    reference, and deployment config? How should branch creation fork or clone
-    data from the source Version?
-8. **Future `objectstack pull` fidelity.** Is a lossless JSON -> TS emitter
-   feasible for everything users might write in `defineStack()`? If authors use
-   TS-only expressions, helper imports, or generics, the pull step either loses
-   information or must constrain the authoring surface.
-9. **Project Version promotion semantics.** Does `publish` always auto-promote
-    the new Version to `current_version_id`, or should the control plane support
-    staged versions where publish and promote are separate operations?
 
 ---
 
-> **When in doubt, re-read this.** Every PR description, every commit, every
-> plan should be testable against this document: does this change preserve
-> Built, reduce Drift, unlock Missing, or answer an Open Question? If none, it
-> probably shouldn't ship.
+## Principles
+
+1. **Zod first.** Zod schemas are the source of truth. Types and JSON Schemas
+   are derived from them.
+2. **Metadata is the app contract.** Objects, fields, views, flows, actions,
+   agents, permissions, datasets, and translations are structured metadata.
+3. **Runtime identity is environment identity.** Use `environment`, not
+   `project`, for deployment/runtime scoping: `OS_ENVIRONMENT_ID`,
+   `X-Environment-Id`, `/api/v1/environments/:environmentId`, and
+   `environment_id`.
+4. **Deployment config is not artifact content.** Database URLs, secrets,
+   runtime credentials, and hostnames are injected by the host or Cloud control
+   plane. They do not belong in `objectstack.json`.
+5. **AI exposure is governed.** Actions become AI tools only through explicit
+   `ai: { exposed: true, description: ... }` metadata.
+6. **Automation is Flow-first.** Event automation, scheduled work, approvals,
+   waits, screens, and notifications are modeled as Flow nodes. State machines
+   model strict lifecycles.
+7. **The console is a consumer, not the source of truth.** The framework serves
+   the published ObjectUI console bundle; source UI work happens in sibling repo
+   `../objectui`.
+
+---
+
+## Runtime Shape
+
+This framework repo owns:
+
+- protocol schemas in `packages/spec`
+- kernel/runtime/bootstrap in `packages/core` and `packages/runtime`
+- REST, ObjectQL, metadata, services, plugins, adapters, CLI, examples, docs
+- bundled console integration in `packages/console`
+- docs site in `apps/docs` and account app in `apps/account`
+
+Cloud control-plane distribution, public SaaS operations, and ObjectUI source
+development live outside this repo.
+
+---
+
+## Environment Artifact
+
+`os compile` produces a deployable environment artifact. The envelope is defined
+by `EnvironmentArtifactSchema` in
+`packages/spec/src/system/environment-artifact.zod.ts`.
+
+The artifact contains:
+
+- `schemaVersion`
+- `environmentId`
+- `commitId`
+- `checksum`
+- `metadata`
+- `functions`
+- `manifest`
+- optional provenance and payload-reference fields
+
+The artifact is enough to describe what the runtime should load. It is not
+enough to deploy by itself; the host still supplies deployment config.
+
+---
+
+## Request Resolution
+
+Environment-aware hosts resolve data-plane requests in this order:
+
+1. `/api/v1/environments/:environmentId/...`
+2. hostname through the environment registry
+3. `X-Environment-Id`
+4. `session.activeEnvironmentId`
+5. configured default environment
+6. one unambiguous environment
+
+Cloud control-plane endpoints such as `/api/v1/cloud/environments/:id` manage
+environments and are not themselves scoped data-plane requests.
+
+---
+
+## Built
+
+- TS-to-JSON compile pipeline (`os compile`)
+- standalone runtime boot from source config or compiled artifact
+- environment-scoped REST routes
+- ObjectQL data engine and memory/SQL/MongoDB drivers
+- Flow engine with durable pause support
+- approval-as-flow-node runtime
+- notification pipeline through single ingress, outbox, preferences, templates,
+  quiet-hours, and digest collapse
+- explicit Action-to-AI tool opt-in
+- formula fields, server-side summary rollups, and autonumber fields
+- config-driven master-detail inline editing via relationship `inlineEdit`
+- bundled console serving from `packages/console`
+
+---
+
+## Drift To Keep Shrinking
+
+- Some docs and source comments still use historical `project` wording where
+  current runtime identity is `environment`.
+- The SDK method name `client.project(id)` remains as a compatibility surface,
+  but it accepts an environment id and generates environment-scoped URLs.
+- The notification framework pipeline is ahead of the objectui bell cut-over;
+  read-state should move through `sys_notification_receipt`.
+- Some generated references need regeneration after Zod description updates.
+
+---
+
+## Non-Goals
+
+- Do not reintroduce `namespace` or `tableName` as object identity fields.
+- Do not put business logic in `packages/spec`.
+- Do not hand-edit `content/docs/references/`.
+- Do not expose every UI action to AI by default.
+- Do not treat Cloud control-plane deployment as part of this framework repo's
+  local dev server.

--- a/content/docs/concepts/packages.mdx
+++ b/content/docs/concepts/packages.mdx
@@ -5,7 +5,7 @@ description: Complete reference of all ObjectStack packages in the monorepo
 
 # Package Reference
 
-ObjectStack is distributed as a monorepo containing **51 publishable packages** organized into core runtime, client SDKs, framework adapters, drivers, plugins, and platform services. Counts are kept in sync with the `packages/` directory in the [framework repository](https://github.com/objectstack-ai/framework/tree/main/packages).
+ObjectStack is distributed as a monorepo containing **70 package manifests** organized into core runtime, client SDKs, framework adapters, drivers, plugins, and platform services.
 
 > **Note for AI Agents**: Each package's `README.md` contains a specific architectural role and usage rules section.
 
@@ -16,11 +16,11 @@ ObjectStack is distributed as a monorepo containing **51 publishable packages** 
 | Core runtime | 9 | `spec`, `core`, `runtime`, `types`, `metadata`, `objectql`, `rest`, `formula`, `platform-objects` |
 | Client / DX | 5 | `client`, `client-react`, `cli`, `create-objectstack`, `vscode-objectstack` |
 | Framework adapters | 7 | Express, Fastify, Hono, NestJS, Next.js, Nuxt, SvelteKit |
-| Drivers | 4 | `driver-memory`, `driver-sql`, `driver-turso`, `driver-mongodb` |
-| Plugins | 12 | `plugin-auth`, `plugin-security`, `plugin-audit`, `plugin-approvals`, `plugin-sharing`, `plugin-email`, `plugin-webhooks`, `plugin-reports`, `plugin-hono-server`, `plugin-mcp-server`, `plugin-msw`, `plugin-dev` |
-| Platform services | 14 | AI, Analytics, Automation, Cache, Cloud, Feed, I18n, Job, Package, Queue, Realtime, Settings, Storage, Tenant |
+| Drivers | 4 | `driver-memory`, `driver-sql`, `driver-sqlite-wasm`, `driver-mongodb` |
+| Plugins | 22 | Auth, security, audit, approvals, sharing, email, webhooks, reports, Hono/MCP servers, MSW/dev, triggers, knowledge, and embedders |
+| Platform services | 17 | AI, Analytics, Automation, Cache, Cluster, Datasource, Feed, I18n, Job, Knowledge, Messaging, Package, Queue, Realtime, Settings, Storage |
 
-**Total: 51 packages**
+**Total: 70 package manifests**
 
 ---
 
@@ -643,15 +643,15 @@ Framework adapters that bridge ObjectStack's unified `HttpDispatcher` to specifi
 
 ---
 
-### @objectstack/service-cloud
+### @objectstack/service-messaging
 
-**Description:** Cloud control-plane bridge service.
+**Description:** Notification and messaging pipeline service.
 
-**Purpose:** Connects an ObjectOS runtime to the hosted (or self-hosted) ObjectStack control plane: artifact fetching, project version selection, telemetry hooks.
+**Purpose:** Provides the single notification ingress, delivery outbox, in-app materialization, preferences, templates, quiet-hours, and digest collapse.
 
-**Use Cases:** Cloud deployments, multi-environment artifact promotion.
+**Use Cases:** Flow `notify` nodes, collaboration mentions, assignment notifications, inbox messages, email delivery, and future channel plugins.
 
-**Implementation Status:** ⚠️ **EVOLVING**
+**Implementation Status:** ✅ **IMPLEMENTED**
 
 ---
 

--- a/content/docs/getting-started/cli.mdx
+++ b/content/docs/getting-started/cli.mdx
@@ -36,13 +36,13 @@ os generate action approve     # Add an action
 os generate flow onboarding    # Add an automation flow
 ```
 
-### Launch the Studio
+### Launch the dev server
 
 ```bash
-os studio
+os dev --ui
 ```
 
-Open [http://localhost:3000/_studio/](http://localhost:3000/_studio/) — you'll see the Console UI with a data browser, metadata explorer, and API documentation.
+Open [http://localhost:3000/_console/](http://localhost:3000/_console/) — you'll see the Console UI with a data browser, metadata explorer, and API documentation.
 
 ### Validate & Build
 
@@ -54,7 +54,7 @@ os compile           # Build production artifact → dist/objectstack.json
 </Steps>
 
 <Callout type="tip">
-`os studio` = `os serve --dev --ui`. It starts a dev server with the Console UI, auto-loads ObjectQL, InMemory driver, and Hono HTTP server — zero config needed.
+`os dev --ui` starts a dev server with the bundled Console UI, auto-loads ObjectQL, an in-memory driver when appropriate, and the Hono HTTP server.
 </Callout>
 
 ## Commands
@@ -66,7 +66,6 @@ os compile           # Build production artifact → dist/objectstack.json
 | `os init [name]` | | Initialize a new ObjectStack project in the current directory |
 | `os dev [package]` | | Start development mode with hot reload |
 | `os serve [config]` | | Start the ObjectStack server with plugin auto-detection |
-| `os studio [config]` | | Launch dev server with Console UI at `/_studio/` |
 
 ### Production
 
@@ -108,7 +107,7 @@ Starts development mode. Three usage shapes:
 ```bash
 os dev                     # Auto-compile cwd config, then start
 os dev my-package          # Workspace package (monorepo orchestration mode)
-os dev --ui -v             # Dev server with Studio UI + verbose
+os dev --ui -v             # Dev server with Console UI + verbose
 
 # Boot a remote artifact in dev mode (no local config needed)
 os dev --artifact https://raw.githubusercontent.com/<org>/<repo>/main/dist/objectstack.json
@@ -126,7 +125,7 @@ os dev --database file:./data/test.db --auth-secret $(openssl rand -hex 32)
 | `--database-driver <kind>` | `OS_DATABASE_DRIVER` | Force `sqlite` \| `turso` \| `postgres` \| `mongodb` \| `memory` |
 | `--database-auth-token <t>` | `OS_DATABASE_AUTH_TOKEN` | libsql/Turso token |
 | `--auth-secret <s>` | `AUTH_SECRET` | Override the dev-fallback secret |
-| `--project-id <id>` | `OS_PROJECT_ID` | Project identifier (default `proj_local`) |
+| `--environment-id <id>` | `OS_ENVIRONMENT_ID` | Environment identifier (default `env_local`) |
 | `-p, --port <n>` | `PORT` / `OS_PORT` | Listen port (default `3000`). In dev a busy port auto-hops to the next free one; the banner shows the actual port. |
 | `--ui` | — | Force Studio UI on (already on by default in dev) |
 | `--no-compile` | — | Skip the auto-compile step (errors if no artifact present) |
@@ -157,7 +156,7 @@ os serve --preset minimal  # Skip auto-loaded auth/i18n/ui plugins
 **Options:**
 - `-p, --port <port>` — Server port (default: env `PORT` or `3000`)
 - `--dev` — Development mode (loads devPlugins, pretty logging)
-- `--ui / --no-ui` — Toggle Console UI at `/_studio/` (default `on`)
+- `--ui / --no-ui` — Toggle Console UI at `/_console/` (default `on`)
 - `--server / --no-server` — Toggle HTTP server plugin
 - `--prebuilt` — Skip esbuild / `bundle-require` and load the config as
   native ESM (use this in production builds where the config is already
@@ -193,36 +192,34 @@ export default defineStack({
 });
 ```
 
-#### `os studio`
+#### Console UI
 
-Launches the development server with the Console UI in one command. Equivalent to `os serve --dev --ui`.
-
-The Console UI is a metadata-driven admin interface that provides:
-- **Object Explorer** — Browse objects, view/edit data, inspect schemas
-- **Package Manager** — View installed plugins and applications
-- **Developer Overview** — Dashboard with runtime metadata summary
+Launch the development server with the Console UI:
 
 ```bash
-os studio                  # Default: port 3000
-os studio -p 4000          # Custom port
+os dev --ui                # Default: port 3000
+os serve --dev --ui -p 4000
 ```
+
+The Console UI is a metadata-driven admin interface that provides object
+exploration, package management, and runtime metadata diagnostics.
 
 **Architecture:**
 
 ```
 ┌─────────────────────────────────────────┐
-│           os studio (:3000)             │
+│          os dev --ui (:3000)            │
 ├─────────────────────────────────────────┤
 │  Hono Server                            │
 │  ├─ /api/v1/*     → ObjectStack API     │
-│  ├─ /_studio/*    → Console SPA         │
+│  ├─ /_console/*   → Console SPA         │
 │  └─ /*            → custom routes       │
 └─────────────────────────────────────────┘
 ```
 
-In development mode, `/_studio/*` requests are proxied to a Vite dev server
-(spawned automatically on an internal port) with full HMR support. In
-production, pre-built static files are served directly.
+In this framework repo the prebuilt console bundle is served at `/_console/`.
+For source-level Console UI work, run the sibling `../objectui` Vite server and
+point it at a backend on port 3000.
 
 ### Production
 
@@ -268,9 +265,9 @@ os start
 | `--database-driver <kind>` | `OS_DATABASE_DRIVER` | Force `sqlite` \| `turso` \| `postgres` \| `mongodb` \| `memory` when the URL is ambiguous |
 | `--database-auth-token <token>` | `OS_DATABASE_AUTH_TOKEN` | Auth token for libsql/Turso |
 | `--auth-secret <secret>` | `AUTH_SECRET` | Secret for `@objectstack/plugin-auth`; without it `/api/v1/auth/*` is skipped (server still runs) |
-| `--project-id <id>` | `OS_PROJECT_ID` | Project identifier (default `proj_local`) |
+| `--environment-id <id>` | `OS_ENVIRONMENT_ID` | Environment identifier (default `env_local`) |
 | `-p, --port <port>` | `PORT` / `OS_PORT` | Listen port (default `3000`). **Production fails loudly if the port is busy** — see note below. |
-| `--ui` | — | **Opt-in.** Mount Studio / Account / Console portals at `/_studio/`, `/_account/`, `/_console/`. Off by default in `os start` (Studio is a dev/admin surface). `os dev` mounts them by default. |
+| `--ui` | — | Mount the Console portal at `/_console/`. `os dev` mounts it by default; `os start` can mount it for production administration when explicitly enabled. |
 
 > **Port conflicts: production never auto-shifts.** Unlike `os dev` (which
 > hops to the next free port for local convenience), `os start` exits with an
@@ -287,7 +284,7 @@ os start
 - Reads the artifact's `manifest`, `objects`, `views`, `flows`, …
 - Auto-registers the platform services declared in `requires: [...]` (e.g. `ai`, `automation`, `analytics`, `auth`, `ui`)
 - Auto-detects the driver from the database URL scheme (`memory://` → in-memory, `libsql://`/`https://` → Turso, `postgres[ql]://`/`pg://` → pg, `mongodb[+srv]://` → MongoDB, otherwise sqlite)
-- Runs `standalone` boot mode (no control plane). For single-/multi-project mode use a host config (`apps/objectos`-style).
+- Runs standalone boot mode with one active environment.
 
 **Authentication:**
 The `auth` capability is auto-loaded only when both (1) the artifact declares `requires: [..., 'auth']` **and** (2) a secret is provided via `--auth-secret` or `AUTH_SECRET`. Without a secret, `AuthPlugin` is **silently skipped with a warning** — the server still boots and serves data/REST routes, only `/api/v1/auth/*` (login/register) is omitted. This is intentional: `os start` is happy to run an unauthenticated, internal-network deployment.
@@ -537,35 +534,35 @@ the server-side session is revoked as well.
 os auth logout
 ```
 
-### Cloud Projects
+### Cloud Environments
 
 | Command | Description |
 |---------|-------------|
-| `os projects list` | List projects visible to the current session |
-| `os projects show <id>` | Show one project |
-| `os projects create` | Provision a new project |
-| `os projects switch <id>` | Set the active project for later CLI calls |
-| `os projects bind <id>` | Bind a compiled local artifact to an existing project |
+| `os environments list` | List environments visible to the current session |
+| `os environments show <id>` | Show one environment |
+| `os environments create` | Provision a new environment |
+| `os environments switch <id>` | Set the active environment for later CLI calls |
+| `os environments bind <id>` | Bind a compiled local artifact to an existing environment |
 
-#### Create a project from a local artifact
+#### Create an environment from a local artifact
 
-Compile first, then create a project and bind the generated
+Compile first, then create an environment and bind the generated
 `dist/objectstack.json` in one call:
 
 ```bash
 os compile
-os projects create --org <org-id> --name CRM --artifact ./dist/objectstack.json
+os environments create --org <org-id> --name CRM --artifact ./dist/objectstack.json
 ```
 
-The server stores the absolute path in `sys_project.metadata.artifact_path`.
-On project-kernel boot, ObjectOS loads the JSON bundle, registers schemas, and
+The server stores the absolute artifact path in environment metadata.
+On environment-kernel boot, ObjectStack loads the JSON bundle, registers schemas, and
 seeds records from the bundle's `data` arrays.
 
-#### Bind an existing project
+#### Bind an existing environment
 
 ```bash
-os projects bind <project-id> --artifact ./dist/objectstack.json
-os projects bind <project-id> --artifact ./dist/objectstack.json --build
+os environments bind <environment-id> --artifact ./dist/objectstack.json
+os environments bind <environment-id> --artifact ./dist/objectstack.json --build
 ```
 
 `--build` runs `objectstack compile` before updating the project. `--reseed`
@@ -628,7 +625,7 @@ os g agent sales-assistant
 os validate
 
 # 5. Start development with Console UI
-os studio
+os dev --ui
 
 # 6. Build for production
 os compile

--- a/content/docs/getting-started/core-concepts.mdx
+++ b/content/docs/getting-started/core-concepts.mdx
@@ -153,7 +153,7 @@ AI agents should not bypass the application model by calling raw SQL, scraping U
 
 ```
 Traditional AI app: Database schema -> App code -> Custom query -> Hand-written MCP tool
-ObjectStack: Zod metadata -> Project Artifact -> ObjectOS runtime -> API / UI / MCP tools
+ObjectStack: Zod metadata -> Environment Artifact -> ObjectStack runtime -> API / UI / MCP tools
 ```
 
 ---

--- a/content/docs/getting-started/examples.mdx
+++ b/content/docs/getting-started/examples.mdx
@@ -29,7 +29,9 @@ The monorepo includes 2 ready-to-run examples that progressively demonstrate Obj
 </Cards>
 
 <Callout type="info">
-  **Looking for the production server example?** It has been moved to [`apps/objectos/`](../../apps/objectos/) — see the [Server documentation](../../apps/objectos/README.md) for multi-app orchestration and deployment.
+  **Looking for a production server shape?** Build an artifact with `os compile`,
+  then run it with `os start` or `os serve --artifact`. The framework repo no
+  longer contains a separate `apps/objectos` production host.
 </Callout>
 
 ---
@@ -276,16 +278,13 @@ new AppPlugin(BiPlugin)  // Load into host
 
 ---
 
-## Multi-App Composition Pattern
+## Composition Pattern
 
-The production server at [`apps/objectos/`](../../apps/objectos/) demonstrates the **Platform Server** pattern: one host loading multiple apps and plugins. This is how you'd run ObjectStack in production with multiple teams' apps.
+Compose apps and plugins in `objectstack.config.ts`, compile them into one
+artifact, then boot that artifact with the CLI.
 
 ```typescript
-// apps/objectos/objectstack.config.ts
 import { defineStack } from '@objectstack/spec';
-import { AppPlugin, DriverPlugin } from '@objectstack/runtime';
-import { ObjectQLPlugin } from '@objectstack/objectql';
-import { InMemoryDriver } from '@objectstack/driver-memory';
 import CrmApp from 'hotcrm/objectstack.config';  // from https://github.com/objectstack-ai/hotcrm
 import TodoApp from '../examples/app-todo/objectstack.config';
 import BiPlugin from '../examples/plugin-bi/objectstack.config';
@@ -296,12 +295,10 @@ export default defineStack({
     version: '1.0.0',
     type: 'app',
   },
-  plugins: [
-    new ObjectQLPlugin(),
-    new DriverPlugin(new InMemoryDriver()),
-    new AppPlugin(CrmApp),      // CRM app contributes objects under namespace 'crm'
-    new AppPlugin(TodoApp),     // Todo app contributes objects under namespace 'todo'
-    new AppPlugin(BiPlugin),    // BI plugin contributes objects under namespace 'bi'
+  imports: [
+    CrmApp,
+    TodoApp,
+    BiPlugin,
   ],
 });
 ```
@@ -321,8 +318,8 @@ If two packages contribute objects with the same short name, the registry logs a
 ### Run It
 
 ```bash
-cd apps/objectos
-pnpm dev        # Loads all 3 apps on one server
+os compile
+OS_ARTIFACT_PATH=./dist/objectstack.json os start
 ```
 
 ---

--- a/content/docs/guides/ai-capabilities.mdx
+++ b/content/docs/guides/ai-capabilities.mdx
@@ -11,7 +11,7 @@ Complete guide to leveraging AI agents, RAG pipelines, and intelligent automatio
 
 1. [AI Architecture](#ai-architecture)
 2. [AI Agents](#ai-agents)
-3. [Actions as Tools (auto-exposed)](#actions-as-tools-auto-exposed)
+3. [Actions as Tools (explicit opt-in)](#actions-as-tools-explicit-opt-in)
    - [Human-In-The-Loop approval](#human-in-the-loop-approval)
 4. [RAG Pipelines](#rag-pipelines)
 5. [Natural Language Queries](#natural-language-queries)
@@ -358,13 +358,38 @@ Use statistical analysis and ML.`,
 
 ---
 
-## Actions as Tools (auto-exposed)
+## Actions as Tools (explicit opt-in)
 
-Every declarative `Action` you attach to an object is **automatically exposed as an AI tool**, named `action_<actionName>`. When the LLM picks one, the AI runtime dispatches to the same handler Studio's row toolbar would invoke — your business logic stays in one place.
+Declarative `Action` metadata can be exposed as AI-callable tools, named
+`action_<actionName>`, but exposure is **explicit opt-in**. Add an `ai:` block
+with `exposed: true` and an LLM-facing `description`; otherwise the action stays
+human/UI-only.
+
+```typescript
+export const triageCaseAction = {
+  name: 'triage_case',
+  label: 'Triage Case',
+  objectName: 'case',
+  type: 'flow',
+  target: 'case_triage',
+  ai: {
+    exposed: true,
+    description: 'Triage a support case, suggest priority, and assign the next support queue.',
+    category: 'action',
+    requiresConfirmation: false,
+  },
+};
+```
+
+When the LLM picks an exposed action, the AI runtime dispatches to the same
+handler the Console row toolbar would invoke, so your business logic stays in
+one place.
 
 ### What gets exposed
 
-The AI runtime walks every registered object's `actions[]` and exposes the ones that pass safety + wiring checks. Three action types are supported:
+The AI runtime walks every registered object's `actions[]` and registers only
+actions with `ai.exposed === true` that also pass safety and wiring checks.
+Three action types are supported:
 
 | `action.type` | Dispatch path | Wiring needed |
 |:---|:---|:---|
@@ -372,7 +397,12 @@ The AI runtime walks every registered object's `actions[]` and exposes the ones 
 | `api` | HTTP call to `action.target` via `ApiActionClient` (default: `fetch`) | `apiBaseUrl` (or a custom `apiClient`) |
 | `flow` | `IAutomationService.execute(target, { triggerData })` | `automation` service registered |
 
-Studio-only types (`url`, `modal`, `form`) are always skipped. Dangerous actions — those with `confirmText`, `mode: 'delete'`, or `variant: 'danger'` — are skipped **by default**, but can be opted into the [HITL approval queue](#human-in-the-loop-approval) so an operator authorises every call. Owners can also opt out per action with `aiExposed: false`.
+Console-only types (`url`, `modal`, `form`) are always skipped. Dangerous
+actions — those with `confirmText`, `mode: 'delete'`, `variant: 'danger'`, or
+`ai.requiresConfirmation: true` — are skipped unless the
+[HITL approval queue](#human-in-the-loop-approval) is wired. To assert that a
+destructive-looking action is safe for autonomous execution, set
+`ai.requiresConfirmation: false`.
 
 ### Wiring it up
 
@@ -404,7 +434,11 @@ For api actions, the request body is built from three sources (last wins):
 
 ### Diagnostics
 
-`registerActionsAsTools()` returns `{ registered, skipped }`. Studio surfaces the skipped list with reasons (e.g. `"no apiClient or apiBaseUrl configured"`, `"mode='delete' — destructive"`) so action authors can see at a glance whether their action will be LLM-callable.
+`registerActionsAsTools()` returns `{ registered, skipped, warnings }`. The
+diagnostics include reasons such as `"not AI-exposed"`,
+`"no apiClient or apiBaseUrl configured"`, or
+`"requires confirmation ... wire HITL approval"` so action authors can see
+whether their action will be LLM-callable.
 
 ### Human-In-The-Loop approval
 

--- a/content/docs/guides/authentication.mdx
+++ b/content/docs/guides/authentication.mdx
@@ -671,14 +671,16 @@ When no auth service handler is registered and the legacy broker login is unavai
 
 This ensures that registration and sign-in flows do not return 404 errors in MSW/browser-only environments.
 
-> **Note:** In server mode with AuthPlugin loaded, the auth service handler takes priority and the mock fallback is never reached. The mock fallback only activates when AuthPlugin is not loaded (e.g. browser-only Studio builds where `better-auth` is unavailable).
+> **Note:** In server mode with AuthPlugin loaded, the auth service handler takes priority and the mock fallback is never reached. The mock fallback only activates when AuthPlugin is not loaded (e.g. browser-only Console/MSW builds where `better-auth` is unavailable).
 
-### Studio Kernel Factory
+### Browser Kernel Factory
 
-The Studio app runs in the browser, where the Node-only `better-auth` library cannot be bundled. Instead of loading `AuthPlugin` directly, Studio relies on `HttpDispatcher`'s built-in mock fallback to handle auth endpoints in MSW mode:
+Browser-only Console builds cannot bundle the Node-only `better-auth` library.
+Instead of loading `AuthPlugin` directly, MSW mode can rely on
+`HttpDispatcher`'s built-in mock fallback to handle auth endpoints:
 
 ```typescript
-// apps/studio/src/mocks/createKernel.ts
+// browser test/mock kernel
 // No AuthPlugin needed — HttpDispatcher provides mock auth endpoints automatically
 const kernel = new ObjectKernel();
 await kernel.use(new ObjectQLPlugin());

--- a/content/docs/guides/business-logic.mdx
+++ b/content/docs/guides/business-logic.mdx
@@ -10,9 +10,9 @@ Complete guide to implementing business rules, validations, and automated proces
 ## Table of Contents
 
 1. [Validation Rules](#validation-rules)
-2. [Workflow Rules](#workflow-rules)
+2. [Flows](#flows)
 3. [Triggers](#triggers)
-4. [Approval Processes](#approval-processes)
+4. [Approval Nodes](#approval-nodes)
 5. [Formula Logic](#formula-logic)
 6. [Best Practices](#best-practices)
 
@@ -106,119 +106,101 @@ Field.text({
 
 ---
 
-## Workflow Rules
+## Flows
 
-Workflow rules automate standard internal procedures and processes to save time.
+Flows automate business processes as explicit node graphs. Use them for field
+updates, notifications, record creation, HTTP calls, decisions, waits, screens,
+subflows, and approval pauses. The old standalone Workflow Rule authoring model
+is retired; model the same logic as a Flow.
 
-### Field Update Workflow
-
-Automatically update fields when conditions are met:
-
-```typescript
-workflows: [
-  {
-    name: 'update_last_activity',
-    objectName: 'account',
-    triggerType: 'on_update',
-    criteria: 'ISCHANGED(owner) OR ISCHANGED(type)',
-    actions: [
-      {
-        name: 'set_activity_date',
-        type: 'field_update',
-        field: 'last_activity_date',
-        value: 'TODAY()',
-      }
-    ],
-    active: true,
-  }
-]
-```
-
-### Email Alert Workflow
-
-Send emails when conditions are met:
+### Record-change flow
 
 ```typescript
-{
-  name: 'notify_high_value_opportunity',
-  objectName: 'opportunity',
-  triggerType: 'on_create',
-  criteria: 'amount > 100000',
-  actions: [
+import type { Flow } from '@objectstack/spec/automation';
+
+export const hotLeadFollowUp: Flow = {
+  name: 'hot_lead_follow_up',
+  label: 'Hot Lead Follow Up',
+  type: 'record_change',
+  status: 'active',
+  trigger: {
+    objectName: 'lead',
+    operations: ['create'],
+    condition: "record.rating == 'hot'",
+  },
+  nodes: [
+    { id: 'start', type: 'start', label: 'Start' },
     {
-      name: 'notify_manager',
-      type: 'email_alert',
-      template: 'high_value_opportunity',
-      recipients: ['{owner.manager}'],
-    }
-  ],
-  active: true,
-}
-```
-
-### Task Creation Workflow
-
-Automatically create tasks:
-
-```typescript
-{
-  name: 'create_follow_up_task',
-  objectName: 'lead',
-  triggerType: 'on_create',
-  criteria: 'rating = "hot"',
-  actions: [
-    {
-      name: 'create_task',
-      type: 'task_create',
-      subject: 'Follow up on hot lead: {name}',
-      relatedTo: '{id}',
-      assignedTo: '{owner}',
-      dueDate: '{TODAY() + 1}',
-      priority: 'high',
-    }
-  ],
-  active: true,
-}
-```
-
-### Scheduled Workflow
-
-Run workflows on a schedule:
-
-```typescript
-{
-  name: 'contract_expiration_check',
-  objectName: 'contract',
-  triggerType: 'scheduled',
-  schedule: '0 0 * * *', // Daily at midnight
-  criteria: 'end_date <= TODAY() AND status = "activated"',
-  actions: [
-    {
-      name: 'mark_expired',
-      type: 'field_update',
-      field: 'status',
-      value: '"expired"',
+      id: 'create_task',
+      type: 'create_record',
+      label: 'Create Follow-up Task',
+      config: {
+        object: 'task',
+        data: {
+          subject: 'Follow up on hot lead',
+          related_to: '${record.id}',
+          priority: 'high',
+        },
+      },
     },
     {
-      name: 'notify_owner',
-      type: 'email_alert',
-      template: 'contract_expired',
-      recipients: ['{owner}'],
-    }
+      id: 'notify_owner',
+      type: 'notify',
+      label: 'Notify Owner',
+      config: {
+        channel: 'in_app',
+        template: 'hot_lead_created',
+      },
+    },
+    { id: 'end', type: 'end', label: 'End' },
   ],
-  active: true,
-}
+  edges: [
+    { id: 'e1', source: 'start', target: 'create_task' },
+    { id: 'e2', source: 'create_task', target: 'notify_owner' },
+    { id: 'e3', source: 'notify_owner', target: 'end' },
+  ],
+};
 ```
 
-### Trigger Types
+### Scheduled flow
 
-| Type | When It Fires | Use Case |
-|------|---------------|----------|
-| `on_create` | Record created | Welcome emails, initial tasks |
-| `on_update` | Record updated | Status changes, notifications |
-| `on_delete` | Record deleted | Cleanup, archival |
-| `on_read` | Record viewed | Lazy updates, calculations |
-| `scheduled` | Cron schedule | Batch processing, cleanup |
+```typescript
+export const contractExpirationCheck: Flow = {
+  name: 'contract_expiration_check',
+  label: 'Contract Expiration Check',
+  type: 'scheduled',
+  status: 'active',
+  schedule: {
+    type: 'cron',
+    expression: '0 0 * * *',
+    timezone: 'UTC',
+  },
+  nodes: [
+    { id: 'start', type: 'start', label: 'Start' },
+    { id: 'find_expiring', type: 'get_record', label: 'Find Expiring Contracts' },
+    { id: 'notify_owners', type: 'notify', label: 'Notify Owners' },
+    { id: 'end', type: 'end', label: 'End' },
+  ],
+  edges: [
+    { id: 'e1', source: 'start', target: 'find_expiring' },
+    { id: 'e2', source: 'find_expiring', target: 'notify_owners' },
+    { id: 'e3', source: 'notify_owners', target: 'end' },
+  ],
+};
+```
+
+### Built-in node types
+
+| Node | Use case |
+|------|----------|
+| `decision` | Branch based on CEL predicates |
+| `assignment` | Set variables |
+| `create_record`, `update_record`, `delete_record`, `get_record` | CRUD |
+| `http` | Outbound HTTP call |
+| `notify` | In-app/email-style notification dispatch |
+| `wait`, `screen`, `approval` | Durable pauses |
+| `subflow` | Invoke another flow |
+| `parallel_gateway`, `join_gateway`, `boundary_event` | BPMN-style orchestration |
 
 ---
 
@@ -319,130 +301,54 @@ context = {
 
 ---
 
-## Approval Processes
+## Approval Nodes
 
-Multi-step approval workflows for business processes.
-
-### Simple Approval
-
-Single-step approval:
+Approvals are authored as Flow nodes with `type: 'approval'`. The
+`@objectstack/plugin-approvals` package owns the durable approval state
+(`sys_approval_request` and `sys_approval_action`), record locking, approver
+resolution, and resume-on-decision behavior.
 
 ```typescript
-{
+export const opportunityApproval: Flow = {
   name: 'opportunity_approval',
-  objectName: 'opportunity',
-  triggerType: 'manual',
-  entryConditions: 'amount > 50000',
-  
-  steps: [
+  label: 'Opportunity Approval',
+  type: 'record_change',
+  status: 'active',
+  trigger: {
+    objectName: 'opportunity',
+    operations: ['update'],
+    condition: "record.amount >= 50000 && record.stage == 'proposal'",
+  },
+  nodes: [
+    { id: 'start', type: 'start', label: 'Start' },
     {
-      name: 'manager_approval',
-      approver: '{owner.manager}',
-      approverType: 'user',
-      emailTemplate: 'approval_request',
-      requiresComments: true,
-      
-      approvalActions: [
-        {
-          type: 'field_update',
-          field: 'approval_status',
-          value: '"approved"',
-        }
-      ],
-      
-      rejectionActions: [
-        {
-          type: 'field_update',
-          field: 'approval_status',
-          value: '"rejected"',
-        },
-        {
-          type: 'email_alert',
-          template: 'approval_rejected',
-          recipients: ['{owner}'],
-        }
-      ],
-    }
+      id: 'manager_approval',
+      type: 'approval',
+      label: 'Manager Approval',
+      config: {
+        approvers: [{ type: 'user', value: '${record.owner_manager_id}' }],
+        behavior: 'all',
+        approvalStatusField: 'approval_status',
+        lockRecord: true,
+      },
+    },
+    { id: 'mark_approved', type: 'update_record', label: 'Mark Approved' },
+    { id: 'mark_rejected', type: 'update_record', label: 'Mark Rejected' },
+    { id: 'end', type: 'end', label: 'End' },
   ],
-  
-  finalApprovalActions: [
-    {
-      type: 'field_update',
-      field: 'stage',
-      value: '"proposal"',
-    }
+  edges: [
+    { id: 'e1', source: 'start', target: 'manager_approval' },
+    { id: 'approved', source: 'manager_approval', target: 'mark_approved', condition: "approval.status == 'approved'" },
+    { id: 'rejected', source: 'manager_approval', target: 'mark_rejected', condition: "approval.status == 'rejected'" },
+    { id: 'e4', source: 'mark_approved', target: 'end' },
+    { id: 'e5', source: 'mark_rejected', target: 'end' },
   ],
-  
-  finalRejectionActions: [
-    {
-      type: 'field_update',
-      field: 'stage',
-      value: '"qualification"',
-    }
-  ],
-}
+};
 ```
 
-### Multi-Step Approval
-
-Sequential approval with multiple approvers:
-
-```typescript
-{
-  name: 'contract_approval',
-  objectName: 'contract',
-  triggerType: 'manual',
-  
-  steps: [
-    // Step 1: Sales Manager
-    {
-      name: 'sales_manager',
-      approver: '{owner.manager}',
-      emailTemplate: 'contract_approval_manager',
-    },
-    
-    // Step 2: Legal Review
-    {
-      name: 'legal_review',
-      approver: '{legal_team}',
-      approverType: 'queue',
-      emailTemplate: 'contract_approval_legal',
-      requiresComments: true,
-    },
-    
-    // Step 3: Finance Approval
-    {
-      name: 'finance_approval',
-      approver: '{finance_director}',
-      condition: 'contract_value > 100000',
-      emailTemplate: 'contract_approval_finance',
-    },
-  ],
-}
-```
-
-### Parallel Approval
-
-Multiple approvers must approve:
-
-```typescript
-{
-  name: 'discount_approval',
-  objectName: 'quote',
-  
-  steps: [
-    {
-      name: 'dual_approval',
-      approverType: 'all',
-      approvers: [
-        '{sales_manager}',
-        '{pricing_manager}',
-      ],
-      emailTemplate: 'discount_approval_request',
-    }
-  ],
-}
-```
+For multi-step approvals, chain multiple `approval` nodes. For parallel
+approvals, combine `parallel_gateway`, multiple `approval` nodes, and
+`join_gateway`.
 
 ---
 
@@ -574,19 +480,19 @@ Field.formula({
 - Block legitimate edge cases
 - Use triggers for simple validations
 
-### 2. Workflow Rules
+### 2. Flows
 
 ✅ **DO:**
-- Keep workflows simple and focused
+- Keep flows simple and focused
 - Document the business logic
-- Test workflow recursion
-- Use scheduled workflows for batch updates
+- Test recursion and retry behavior
+- Use scheduled flows for batch updates
 
 ❌ **DON'T:**
-- Create workflow loops
-- Update too many fields in one workflow
-- Use workflows for complex logic (use triggers)
-- Mix concerns in one workflow
+- Create uncontrolled loops
+- Update too many fields in one node
+- Use triggers when a declarative flow is enough
+- Mix unrelated concerns in one flow
 
 ### 3. Triggers
 
@@ -603,7 +509,7 @@ Field.formula({
 - Perform complex calculations in triggers
 - Ignore governor limits
 
-### 4. Approval Processes
+### 4. Approval Nodes
 
 ✅ **DO:**
 - Define clear entry criteria
@@ -650,23 +556,28 @@ validations: [
   },
 ],
 
-// Workflow: Auto-assign hot leads
-workflows: [
+// Flow: Auto-assign hot leads
+flows: [
   {
     name: 'assign_hot_leads',
-    triggerType: 'on_create',
-    criteria: 'rating = "hot" AND lead_source = "web"',
-    actions: [
-      {
-        type: 'field_update',
-        field: 'owner',
-        value: 'GET_ROUND_ROBIN_USER("sales_team")',
-      },
-      {
-        type: 'task_create',
-        subject: 'Contact hot lead: {name}',
-        dueDate: '{NOW() + 2 hours}',
-      },
+    label: 'Assign Hot Leads',
+    type: 'record_change',
+    status: 'active',
+    trigger: {
+      objectName: 'lead',
+      operations: ['create'],
+      condition: "record.rating == 'hot' && record.lead_source == 'web'",
+    },
+    nodes: [
+      { id: 'start', type: 'start', label: 'Start' },
+      { id: 'assign_owner', type: 'assignment', label: 'Assign Owner' },
+      { id: 'create_task', type: 'create_record', label: 'Create Follow-up Task' },
+      { id: 'end', type: 'end', label: 'End' },
+    ],
+    edges: [
+      { id: 'e1', source: 'start', target: 'assign_owner' },
+      { id: 'e2', source: 'assign_owner', target: 'create_task' },
+      { id: 'e3', source: 'create_task', target: 'end' },
     ],
   },
 ],
@@ -704,24 +615,32 @@ validations: [
   },
 ],
 
-// Workflow: Update probability
-workflows: [
+// Flow: Update probability
+flows: [
   {
     name: 'update_probability',
-    triggerType: 'on_update',
-    criteria: 'ISCHANGED(stage)',
-    actions: [
-      {
-        type: 'field_update',
-        field: 'probability',
-        value: 'GET_STAGE_PROBABILITY(stage)',
-      },
+    label: 'Update Probability',
+    type: 'record_change',
+    status: 'active',
+    trigger: {
+      objectName: 'opportunity',
+      operations: ['update'],
+      condition: 'record.stage != previous.stage',
+    },
+    nodes: [
+      { id: 'start', type: 'start', label: 'Start' },
+      { id: 'update_probability', type: 'update_record', label: 'Update Probability' },
+      { id: 'end', type: 'end', label: 'End' },
+    ],
+    edges: [
+      { id: 'e1', source: 'start', target: 'update_probability' },
+      { id: 'e2', source: 'update_probability', target: 'end' },
     ],
   },
 ],
 
 // Approval: Large deals
-// (See Approval Processes section above)
+// (See Approval Nodes section above)
 ```
 
 ---

--- a/content/docs/guides/cheatsheets/field-type-gallery.mdx
+++ b/content/docs/guides/cheatsheets/field-type-gallery.mdx
@@ -311,9 +311,19 @@ Parent-child relationship (cascading delete by default).
 | `referenceFilters` | `object` | — | Filters to restrict available options |
 | `writeRequiresMasterRead` | `boolean` | — | Require read access on master to write detail |
 | `deleteBehavior` | `'restrict' \| 'cascade' \| 'set_null'` | `'cascade'` | Behavior when parent is deleted |
+| `inlineEdit` | `boolean` | `false` | Render child records inline on the parent create/edit form |
+| `inlineColumns` | `array` | — | Optional explicit inline grid columns |
+| `inlineAmountField` | `string` | — | Numeric child field used for the inline running total |
 
 ```typescript
-{ name: 'project', label: 'Project', type: 'master_detail', reference: 'project' }
+{
+  name: 'order',
+  label: 'Order',
+  type: 'master_detail',
+  reference: 'order',
+  inlineEdit: true,
+  inlineAmountField: 'line_total',
+}
 ```
 
 ### `tree`
@@ -418,11 +428,23 @@ Roll-up summary from child records.
 
 | Property | Type | Default | Description |
 |:---|:---|:---|:---|
-| `summaryOperations` | `string[]` | — | Aggregation operations (count, sum, avg, min, max) |
-| `expression` | `string` | — | Summary expression |
+| `summaryOperations.object` | `string` | **required** | Child object to aggregate |
+| `summaryOperations.field` | `string` | **required** | Child field to aggregate; ignored for `count` |
+| `summaryOperations.function` | `enum` | **required** | `count`, `sum`, `avg`, `min`, or `max` |
+| `summaryOperations.relationshipField` | `string` | auto | Child FK back to the parent when it cannot be inferred |
 
 ```typescript
-{ name: 'task_count', label: 'Task Count', type: 'summary', summaryOperations: ['count'] }
+{
+  name: 'task_count',
+  label: 'Task Count',
+  type: 'summary',
+  summaryOperations: {
+    object: 'task',
+    field: 'id',
+    function: 'count',
+    relationshipField: 'project',
+  },
+}
 ```
 
 ### `autonumber`

--- a/content/docs/guides/cheatsheets/quick-reference.mdx
+++ b/content/docs/guides/cheatsheets/quick-reference.mdx
@@ -156,13 +156,13 @@ REST/GraphQL endpoints, real-time subscriptions, and discovery.
 
 ## Automation Protocol (8 schemas)
 
-Workflows, flows, and integrations.
+Flows, state machines, approvals, and integrations.
 
 | Protocol | Source File | Key Schemas | Purpose |
 |:---------|:-----------|:------------|:--------|
 | **[Flow](./automation/flow)** | `flow.zod.ts` | Flow, FlowNode | Visual workflow builder |
-| **[Workflow](./automation/workflow)** | `workflow.zod.ts` | WorkflowRule | Record-triggered automation |
-| **[Approval](./automation/approval)** | `approval.zod.ts` | ApprovalProcess | Multi-step approval flows |
+| **[Workflow](./automation/workflow)** | `state-machine.zod.ts` | StateMachine | Historical route; current workflow semantics are state machines plus Flow |
+| **[Approval](./automation/approval)** | `approval.zod.ts` | ApprovalNodeConfig | Flow approval-node config |
 | **[State Machine](./automation/state-machine)** | `state-machine.zod.ts` | StateMachine | State machine definitions |
 | **[Webhook](./automation/webhook)** | `webhook.zod.ts` | Webhook, WebhookEvent | Outbound webhooks |
 | **[ETL](./automation/etl)** | `etl.zod.ts` | ETLPipeline | Data transformation pipelines |

--- a/content/docs/guides/client-sdk.mdx
+++ b/content/docs/guides/client-sdk.mdx
@@ -121,7 +121,7 @@ The `@objectstack/client` SDK aims to implement the ObjectStack API protocol spe
 | **automation** | ✅ | 1 | Automation triggers |
 | **storage** | ✅ | 2 | File upload & download |
 | **i18n** | ✅ | 3 | Internationalization |
-| **notifications** | ✅ | 7 | Push notifications |
+| **notifications** | 🟡 | 7 | Legacy notification helpers; receipt/inbox cut-over pending |
 | **realtime** | ✅ | 6 | WebSocket subscriptions |
 | **ai** | ✅ | 4 | AI services (NLQ, chat, insights) |
 
@@ -273,7 +273,7 @@ await client.realtime.setPresence('account', { status: 'online' });
 await client.realtime.getPresence('account');
 await client.realtime.disconnect();
 
-// Notifications — Push notification management
+// Notifications — legacy helper surface
 await client.notifications.registerDevice({ token: 'device-token', platform: 'ios' });
 await client.notifications.unregisterDevice('device-id');
 await client.notifications.getPreferences();
@@ -282,9 +282,13 @@ await client.notifications.list({ read: false });
 await client.notifications.markRead(['notif-1', 'notif-2']);
 await client.notifications.markAllRead();
 
+// ADR-0030 note: the framework pipeline now materializes in-app messages
+// through sys_inbox_message and tracks read-state in sys_notification_receipt.
+// These helpers will be repointed during the objectui bell cut-over.
+
 // AI — AI-powered features
 await client.ai.nlq({ query: 'Show me all active accounts' });
-await client.ai.chat({ message: 'Summarize this project', context: projectId });
+await client.ai.chat({ message: 'Summarize this environment', context: environmentId });
 await client.ai.suggest({ object: 'account', field: 'industry' });
 await client.ai.insights({ object: 'sales', recordId: dealId });
 

--- a/content/docs/guides/cloud-deployment.mdx
+++ b/content/docs/guides/cloud-deployment.mdx
@@ -1,253 +1,135 @@
 ---
-title: Deployment Modes (Standalone & Cloud)
-description: Run a single ObjectStack Server process in standalone (single-project) or cloud (multi-project) mode. Covers control-plane DB URLs, hostname routing, and Fly.io / Docker deployment.
+title: Deployment Modes
+description: Choose between local standalone runtime and Cloud-managed environment deployment.
 ---
 
-# Deployment Modes (Standalone & Cloud)
+# Deployment Modes
 
-The same `apps/objectos` binary boots into one of two modes. Which one you get
-depends only on the `OS_MODE` environment variable — the code and
-Docker image are identical.
+This repository ships the framework runtime, examples, adapters, CLI, docs, and
+the published console bundle. Local development is a single-environment runtime.
+Cloud deployment uses a separate ObjectStack Cloud control plane plus the
+environment-aware runtime seams exported from `@objectstack/runtime`.
 
-| Mode               | `OS_MODE` | Control plane              | Projects | Hostname routing | Typical use                                     |
-| ------------------ | ------------------ | -------------------------- | -------- | ---------------- | ----------------------------------------------- |
-| **standalone**     | unset / `standalone` | — (single kernel)        | 1        | ❌               | OSS single-app install, laptop dev              |
-| **cloud**          | `cloud`            | `OS_DATABASE_URL` | 1 – N    | ✅               | Studio dev, self-hosted multi-project, SaaS    |
-
-> **Legacy alias:** `OS_MULTI_PROJECT=true` is still honoured as a
-> deprecated alias for `OS_MODE=cloud`. The server prints a
-> deprecation warning at boot and the variable will be removed in the next
-> major release.
-
-Both modes reuse:
-
-- `KernelManager` + `DefaultProjectKernelFactory` for per-project kernels
-- `DefaultEnvironmentDriverRegistry` for hostname → project resolution
-- `createControlPlanePlugins()` (cloud only) to install
-  tenant / auth / security / audit / package plugins onto the control DB.
+| Mode | Runs from this repo | Environment selection | Typical use |
+|:---|:---:|:---|:---|
+| Local example | Yes | One active `OS_ENVIRONMENT_ID` | Framework development and smoke tests |
+| Standalone app | Yes | One compiled artifact or stack config | Self-hosted app backend |
+| Cloud-managed environment | Runtime seams only | Cloud control plane, hostname, scoped URL, header, or session | SaaS and multi-environment deployments |
 
 ---
 
-## Mode 1 — standalone
+## Local runtime
+
+Use the repo scripts for framework development:
 
 ```bash
-pnpm --filter @objectstack/objectos dev
-# → http://localhost:3000
+PORT=3000 pnpm dev
+pnpm dev:crm -- --fresh -p 38421
+pnpm docs:dev
 ```
 
-One `ObjectKernel`, every plugin from `apps/objectos/objectstack.config.ts`, no
-per-project isolation. This is what you want on a laptop or for an OSS
-single-app install.
+`pnpm dev` starts the showcase kitchen-sink example. It is the best local
+exercise path for objects, views, flows, AI metadata, security, and the console
+bundle.
 
-Leave `OS_MODE` unset (or set it to `standalone`) to use this mode.
-
-### Mode 1b — standalone from a pre-built artifact (no host config)
-
-Since `@objectstack/runtime@4.x` the standalone path is built into the
-framework: any directory containing a compiled `dist/objectstack.json` (or
-reachable via `OS_ARTIFACT_PATH`, including an `https://` URL) can be booted
-with the **stock CLI** — no `objectstack.config.ts` required.
+For a generated app:
 
 ```bash
-# Local artifact in cwd
-cd hotcrm                                  # https://github.com/objectstack-ai/hotcrm
-objectstack start                          # auto-detects ./dist/objectstack.json
-
-# Explicit artifact path
-OS_ARTIFACT_PATH=/srv/apps/crm/objectstack.json objectstack start
-
-# Remote artifact over HTTPS
-OS_ARTIFACT_PATH=https://example.com/crm/objectstack.json objectstack start
+os dev
+os start
+os serve --artifact ./dist/objectstack.json
 ```
 
-Internally the CLI calls `createDefaultHostConfig()` from
-`@objectstack/runtime`, which wraps `createStandaloneStack()` and exposes the
-artifact's `requires` / `objects` / `manifest`. This path is **standalone-only**
-— it has no dependency on `@objectstack/service-cloud` and is the recommended
-shape for shipping an app as a single JSON deployable.
-
-For the multi-project / control-plane variant, keep using `apps/objectos`'s
-`objectstack.config.ts` (Mode 2 below) which composes cloud plugins on top.
+The active environment is selected with `OS_ENVIRONMENT_ID`.
 
 ---
 
-## Mode 2 — cloud
+## Standalone artifact runtime
+
+Any directory with a compiled `dist/objectstack.json` can boot through the CLI
+or `@objectstack/runtime` helpers:
 
 ```bash
-OS_MODE=cloud \
-OS_DATABASE_URL=file:./.objectstack/data/control.db \
-AUTH_SECRET=$(openssl rand -hex 32) \
-pnpm --filter @objectstack/objectos dev
+os compile
+OS_ENVIRONMENT_ID=env_prod os serve --artifact ./dist/objectstack.json
 ```
 
-- Control-plane tables (`sys_project`, `sys_project_credential`, …) live in
-  the database configured by `OS_DATABASE_URL`. Use `file:...` for a
-  local SQLite control plane, or `libsql://...` / `https://...` for a remote
-  Turso/libSQL control plane.
-- Projects are created through Studio / `POST /api/v1/cloud/projects`. Each
-  project binds its own driver (sqlite / libsql / turso / postgres).
-- Incoming requests are routed to per-project kernels by the `Host` header
-  (matched against `sys_project.hostname`), or by `X-Project-Id`, or by the
-  authenticated session's `activeProjectId`.
+Deployment config stays outside the artifact. Database URLs, auth secrets,
+runtime credentials, and environment identity are injected through process env
+or the host's deployment config.
 
-### Configuring a project driver
+---
 
-When calling `POST /api/v1/cloud/projects`, pass `driver` as one of the
-registered drivers: `memory`, `sqlite`, `turso` / `libsql`, or `postgres`.
-The factory switch lives in
-`packages/runtime/src/project-kernel-factory.ts::createDriver`.
+## Cloud-managed deployment
 
-For a remote shared control plane, only the URL changes:
+When targeting Cloud, publish metadata to an environment:
 
 ```bash
-OS_MODE=cloud \
-OS_DATABASE_URL=libsql://control.turso.io \
-OS_DATABASE_AUTH_TOKEN=... \
-AUTH_SECRET=$(openssl rand -hex 32) \
-pnpm --filter @objectstack/objectos dev
+OS_CLOUD_URL=https://cloud.example.com \
+OS_ENVIRONMENT_ID=env_prod \
+os publish
 ```
 
-Multiple Server replicas can share the same remote `sys_*` schema;
-`DefaultEnvironmentDriverRegistry`'s per-replica cache is coherent within its
-TTL (5 min default), and credential rotation fires
-`envRegistry.invalidate(projectId)` so stale entries drop out within one TTL.
+The CLI posts compiled metadata to:
 
----
+```text
+POST /api/v1/cloud/environments/:environment/metadata
+```
 
-## Hostname routing precedence
+Rollback activates an earlier revision:
 
-`HttpDispatcher.resolveEnvironmentContext` tries these signals in order and
-stops at the first match:
+```text
+POST /api/v1/cloud/environments/:environment/revisions/:commit/activate
+```
 
-1. `/projects/:projectId/...` URL segment.
-2. `Host` header → `sys_project.hostname` (via `envRegistry.resolveByHostname`).
-3. `X-Project-Id` header.
-4. Session `activeProjectId`.
-5. Session `activeOrganizationId` → that org's default project.
-
-Control-plane routes (`/auth`, `/cloud`, `/discovery`, `/health`) skip
-resolution and always hit the control-plane kernel.
-
----
-
-## Cross-subdomain session cookies
-
-Host-based routing means Studio (say `studio.example.com`) and a project
-subdomain (`acme.example.com`) are separate origins. Set
-`OS_COOKIE_DOMAIN=.example.com` to opt in to better-auth's
-cross-subdomain cookie mode. In production the session cookie is also scoped
-`secure` automatically.
-
----
-
-## Deploying to Fly.io
-
-ObjectStack ships a single Dockerfile (`apps/objectos/Dockerfile`) that works
-for both Fly.io and bare Docker. The repo also ships a ready-to-use
-`apps/objectos/fly.toml`.
+Package publishing uses the package registry endpoints:
 
 ```bash
-# From the repo root
-fly launch --copy-config --name objectstack-server \
-           --dockerfile apps/objectos/Dockerfile \
-           --no-deploy
-
-# Persistent volume for the local-SQLite control DB
-fly volumes create objectstack_data --size 3 --region iad
-
-# Secrets (never commit!)
-fly secrets set \
-  AUTH_SECRET=$(openssl rand -hex 32) \
-  OS_COOKIE_DOMAIN=.objectstack.app \
-  TURSO_ORG_NAME=... \
-  TURSO_API_TOKEN=...
-
-fly deploy
-
-# Wildcard cert for per-project subdomains
-fly certs add "*.objectstack.app"
-# Follow the DNS instructions Fly prints (_acme-challenge TXT + A/AAAA)
+os package publish --env env_prod
 ```
 
-### Fly tuning
-
-`OS_KERNEL_CACHE_SIZE` and `OS_KERNEL_TTL_MS` control the
-per-project kernel LRU. The defaults in `fly.toml` (50 kernels, 30 min TTL)
-fit a `shared-cpu-2x / 1GB` machine comfortably. Bump both proportionally if
-you upgrade the VM.
+Cloud control-plane hosts, database provisioning, billing, and public SaaS
+deployment are outside this framework repository. The framework runtime exposes
+the environment registry, marketplace proxy, and runtime-config seams consumed
+by that distribution.
 
 ---
 
-## Deploying with Docker (self-hosted)
+## Routing precedence
 
-```bash
-docker build -f apps/objectos/Dockerfile -t objectstack/server:local .
+Environment-aware hosts resolve requests in this order:
 
-docker run --rm -p 3000:3000 \
-  -v $(pwd)/data:/data \
-  -e OS_MODE=cloud \
-  -e OS_DATABASE_URL=file:/data/control.db \
-  -e AUTH_SECRET=$(openssl rand -hex 32) \
-  objectstack/server:local
+1. `/api/v1/environments/:environmentId/...`
+2. Hostname through the environment registry
+3. `X-Environment-Id`
+4. `session.activeEnvironmentId`
+5. Configured default environment
+6. Single unambiguous environment
 
-curl http://localhost:3000/api/v1/health
-```
-
-Put a reverse proxy (Caddy / Traefik / Nginx) in front for wildcard TLS and
-point a wildcard DNS (`*.example.com`) at it. The container does the rest.
+Control-plane paths under `/api/v1/cloud/environments/...` are not data-plane
+requests and do not run through a target environment kernel.
 
 ---
 
-## Environment variable reference
+## Environment variables
 
-| Variable                          | Mode(s)                   | Purpose                                                                          |
-| --------------------------------- | ------------------------- | -------------------------------------------------------------------------------- |
-| `OS_MODE`                | all                       | `standalone` (default) or `cloud`. Selects whether a control plane is mounted. |
-| `OS_MULTI_PROJECT`       | all (deprecated)          | Legacy alias: `=true` is treated as `OS_MODE=cloud`. Removed in next major. |
-| `OS_DATABASE_URL`        | all                       | In `standalone`, the project business DB URL. In `cloud`, the control-plane DB URL (`file:`, `libsql://`, or `https://`). |
-| `OS_DATABASE_AUTH_TOKEN` | all                       | Auth token for `OS_DATABASE_URL` when using libSQL/Turso.               |
-| `TURSO_ORG_NAME` + `TURSO_API_TOKEN` | cloud                  | Used by `TursoProjectDatabaseAdapter` to provision per-project databases.        |
-| `OS_KERNEL_CACHE_SIZE`   | cloud                     | LRU size for per-project kernels (default 32, fly.toml defaults to 50).          |
-| `OS_KERNEL_TTL_MS`       | cloud                     | Idle eviction TTL in ms (default 900000, fly.toml defaults to 1800000).          |
-| `OS_ENV_CACHE_TTL_MS`    | cloud                     | TTL for the envRegistry's hostname/id cache (default 300000).                    |
-| `OS_COOKIE_DOMAIN`       | cloud                     | Shared cookie domain for cross-subdomain sessions (e.g. `.objectstack.app`).     |
-| `AUTH_SECRET`                     | all                       | Better-Auth session secret (≥ 32 chars).                                         |
-| `PORT` / `HOST`                   | all (node-entry)          | HTTP bind. Defaults to `3000` / `0.0.0.0`. In production a busy port is a hard error (no auto-shift) — pin it and match `OS_AUTH_URL` / `OS_TRUSTED_ORIGINS`. |
+| Variable | Purpose |
+|:---|:---|
+| `OS_ENVIRONMENT_ID` | Active local or publish target environment. |
+| `OS_CLOUD_URL` | Cloud control-plane base URL used by publish/package commands. |
+| `OS_ARTIFACT_PATH` | Artifact path for `os serve` and standalone hosts. |
+| `OS_DATABASE_URL` | Local runtime business database URL. |
+| `OS_DATABASE_DRIVER` | Local runtime driver id. |
+| `AUTH_SECRET` | Better Auth session secret for hosted runtimes. |
+| `PORT` / `HOST` | HTTP bind settings. |
 
----
-
-## Smoke test (cloud mode)
-
-```bash
-# 1. Create a project
-curl -X POST http://localhost:3000/api/v1/cloud/projects \
-  -H 'Content-Type: application/json' \
-  -d '{ "organization_id": "<org-id>", "display_name": "Demo", "driver": "sqlite" }'
-# → { id: "<pid>", status: "provisioning", hostname: "<org-slug>-<short>.objectstack.app", ... }
-
-# 2. Wait for status=active (Studio also polls this)
-curl http://localhost:3000/api/v1/cloud/projects/<pid>
-
-# 3. Call the project-scoped API via Host header
-curl -H "Host: <hostname>" http://localhost:3000/api/v1/meta/objects
-# → returns objects registered in the project's own sys_metadata, not the control plane
-```
-
-If step 3 returns control-plane objects instead of the project's own, the
-host-based routing did not kick in — check that `envRegistry` is wired (see
-`apps/objectos/server/bootstrap.ts`) and that `sys_project.hostname` was
-populated.
+Third-party provider variables such as `OPENAI_API_KEY`, `TURSO_*`,
+`SMTP_*`, `RESEND_API_KEY`, and OAuth client secrets keep their provider names.
 
 ---
 
-## Artifact publishing & versioning
+## Related
 
-Once a project exists, deploy metadata changes by **compiling and publishing**
-artifacts rather than mutating tables directly. Each `objectstack publish`
-creates an immutable revision in object storage; runtime nodes pull the
-current (or pinned) commit via the `artifact-api` source.
-
-See [Publish, Versioning & Preview](./publish-and-preview) for the full loop —
-storage backends (`StorageServicePlugin` local / S3), the
-`/api/v1/cloud/projects/:id/{revisions,artifact,activate}` endpoints, and the
-`MetadataPlugin` `artifactSource: { mode: 'artifact-api' }` runtime config.
+- [Single-Environment Mode](./single-project-mode)
+- [Environment-Scoped Routing](./project-scoping)
+- [Publish, Versioning & Preview](./publish-and-preview)

--- a/content/docs/guides/common-patterns.mdx
+++ b/content/docs/guides/common-patterns.mdx
@@ -88,7 +88,16 @@ Create a parent-child relationship where child records are cascaded on delete.
       fields: {
         order_number: { label: 'Order #', type: 'autonumber', autonumberFormat: 'ORD-{0000}' },
         customer: { label: 'Customer', type: 'lookup', reference: 'contact' },
-        total: { label: 'Total', type: 'summary', summaryOperations: ['sum'] },
+        total: {
+          label: 'Total',
+          type: 'summary',
+          summaryOperations: {
+            object: 'order_line',
+            field: 'line_total',
+            function: 'sum',
+            relationshipField: 'order',
+          },
+        },
         status: { label: 'Status', type: 'select', options: [
           { label: 'Draft', value: 'draft', default: true },
           { label: 'Submitted', value: 'submitted' },
@@ -100,7 +109,13 @@ Create a parent-child relationship where child records are cascaded on delete.
       name: 'order_line',
       label: 'Order Line',
       fields: {
-        order: { label: 'Order', type: 'master_detail', reference: 'order' },
+        order: {
+          label: 'Order',
+          type: 'master_detail',
+          reference: 'order',
+          inlineEdit: true,
+          inlineAmountField: 'line_total',
+        },
         product: { label: 'Product', type: 'lookup', reference: 'product' },
         quantity: { label: 'Qty', type: 'number', min: 1, required: true },
         unit_price: { label: 'Unit Price', type: 'currency' },
@@ -248,9 +263,9 @@ export const assignmentNotification = defineFlow({
 
 ---
 
-## 7. Approval Workflow
+## 7. Approval Flow
 
-Define a multi-step approval process for records.
+Define a multi-step approval flow for records.
 
 ```typescript
 {

--- a/content/docs/guides/deployment-vercel.mdx
+++ b/content/docs/guides/deployment-vercel.mdx
@@ -356,15 +356,16 @@ Configure these in Vercel Project Settings → Environment Variables:
 | `VITE_RUNTIME_MODE` | `msw` (in-browser) or `server` (real backend) |
 | `VITE_SERVER_URL` | Backend API URL (empty for same-origin) |
 
-### ObjectStack Cloud control plane (when deploying `apps/cloud`)
+### Cloud control plane
 
-Vercel functions have an **ephemeral, read-only filesystem** — local SQLite
-and local-FS storage will not persist between invocations. Use Turso/libSQL
-for the control DB and S3-compatible object storage for artifacts.
+The Cloud control-plane distribution lives outside this framework repo. If you
+deploy a Cloud host on Vercel, remember that Vercel functions have an
+**ephemeral, read-only filesystem** — local SQLite and local-FS storage will not
+persist between invocations. Use a durable database and S3-compatible object
+storage for artifacts.
 
 | Variable | Required | Description |
 | :--- | :--- | :--- |
-| `OS_MODE` | yes | `cloud` |
 | `AUTH_SECRET` | yes | ≥ 32 chars |
 | `OS_CONTROL_DATABASE_URL` | yes | `libsql://…` (Turso) — control plane DB |
 | `OS_CONTROL_DATABASE_AUTH_TOKEN` | yes | Turso token (or `TURSO_AUTH_TOKEN`) |

--- a/content/docs/guides/driver-configuration.mdx
+++ b/content/docs/guides/driver-configuration.mdx
@@ -184,32 +184,29 @@ new InMemoryDriver();
 Use the memory driver for unit tests. It requires no setup and runs instantly.
 </Callout>
 
-## `apps/objectos` and Single-Project Local Mode
+## Local Environment Runtime
 
-When running `apps/objectos` (or any boot stack with `runtime: { cloudUrl: 'local' }`),
-two databases are involved:
-
-| DB           | Purpose                                                   | Env var                         |
-|--------------|-----------------------------------------------------------|---------------------------------|
-| Project DB   | Your business data (the records served at `/api/v1/data/*`) | `OS_DATABASE_URL` / `OS_DATABASE_DRIVER` |
-| Control DB   | Framework bookkeeping (`sys_organization`, `sys_project`, …) | `OS_CONTROL_DATABASE_URL`       |
-
-Both honor the same URL-scheme inference described above. If
-`OS_CONTROL_DATABASE_URL` is unset, the control DB defaults to a local
-SQLite file (`<dataDir>/control.db`); for backward compatibility
-`OS_DATABASE_URL` is also accepted as a fallback for the control DB
-when no explicit `OS_CONTROL_DATABASE_URL` is provided **and** no project DB
-URL has consumed it.
+Local framework commands run one active environment. The business records served
+at `/api/v1/data/*` use the driver selected by `OS_DATABASE_URL` and
+`OS_DATABASE_DRIVER`.
 
 ```bash
-# Run apps/objectos with MongoDB as the project DB (control DB stays sqlite):
-OS_DATABASE_URL=mongodb://localhost:27017/objectos pnpm dev
+# Run the showcase with MongoDB as the local environment DB:
+OS_ENVIRONMENT_ID=env_local \
+OS_DATABASE_URL=mongodb://localhost:27017/objectstack \
+pnpm dev
 
-# Pin both DBs explicitly:
-OS_DATABASE_URL=mongodb://localhost:27017/objectos \
-OS_CONTROL_DATABASE_URL=postgres://user:pass@host/control \
+# Pin the driver explicitly when the URL is ambiguous:
+OS_DATABASE_URL=file:./.objectstack/data/app.db \
+OS_DATABASE_DRIVER=sqlite \
 pnpm dev
 ```
+
+Cloud control-plane databases and environment provisioning live in the Cloud
+distribution outside this framework repo. When this runtime is pointed at Cloud,
+the environment id still flows through `OS_ENVIRONMENT_ID`, scoped URLs, or
+`X-Environment-Id`; mutable deployment config does not live in the compiled
+artifact.
 
 ## Multi-Datasource
 

--- a/content/docs/guides/kernel-services.mdx
+++ b/content/docs/guides/kernel-services.mdx
@@ -224,7 +224,7 @@ View CRUD, layout engine, action registry, permission filtering.
 
 ### 6. workflow Service — 5 methods
 `getWorkflowConfig`, `getWorkflowState`, `workflowTransition`, `workflowApprove`, `workflowReject`  
-State machine engine, approval processes, audit trail.
+State machine transitions and approval-node decision helpers.
 
 ### 7. automation Service — 1 method
 `triggerAutomation`  
@@ -343,7 +343,7 @@ AppPlugin will:
 
 | Plugin | Description |
 |:-------|:------------|
-| **plugin-workflow** | State machine + approval process |
+| **service-automation** | Flow orchestration, state-machine adjacent execution, approval-node pauses |
 | **plugin-automation** | Triggers + flow orchestration |
 | **plugin-i18n** | Internationalization |
 | **plugin-storage** | File storage (local + S3) |

--- a/content/docs/guides/metadata/field.mdx
+++ b/content/docs/guides/metadata/field.mdx
@@ -156,6 +156,15 @@ project: Field.masterDetail('project', {
   label: 'Project',
   required: true,
 }),
+
+// Inline line items on the parent form
+order: Field.masterDetail('order', {
+  label: 'Order',
+  required: true,
+  inlineEdit: true,
+  inlineTitle: 'Lines',
+  inlineAmountField: 'line_total',
+}),
 ```
 
 | Property | Type | Description |
@@ -163,6 +172,9 @@ project: Field.masterDetail('project', {
 | `reference` (1st arg) | `string` | Target object name |
 | `referenceFilters` | `string[]` | Filter conditions for the lookup |
 | `deleteBehavior` | `enum` | `'set_null'`, `'cascade'`, `'restrict'` |
+| `inlineEdit` | `boolean` | Render child records inline on the parent create/edit form |
+| `inlineColumns` | `array` | Optional explicit columns for the inline grid |
+| `inlineAmountField` | `string` | Optional numeric child field for the inline running total |
 
 ### File & Media Types
 
@@ -202,6 +214,7 @@ total_amount: Field.summary({
     object: 'order_item',
     field: 'amount',
     function: 'sum',
+    relationshipField: 'order',
   },
 }),
 
@@ -211,6 +224,11 @@ case_number: Field.autonumber({
   autonumberFormat: 'CASE-{0000}',
 }),
 ```
+
+Summary fields are server-owned. The engine recomputes them when child records
+are inserted, updated, or deleted. `relationshipField` is optional when the child
+has only one `lookup`/`master_detail` field pointing back to the parent; set it
+when multiple relationships target the same parent object.
 
 ### Specialized Types
 

--- a/content/docs/guides/metadata/flow.mdx
+++ b/content/docs/guides/metadata/flow.mdx
@@ -393,13 +393,11 @@ The plugin is a **soft dependency** on `metadata` — it tolerates running
 without `MetadataPlugin` and it logs (not throws) on per-flow registration
 failures so one broken flow does not abort startup.
 
-## Studio Flow Viewer & Test Runner
+## Console Flow Viewer & Test Runner
 
-Every flow surfaces in Studio's metadata browser
-(`/_studio/apps/setup/_metadata/flow/<flow-name>`). The
-`flow-viewer-plugin` (registered in
-`apps/studio/src/plugins/built-in/index.ts`) replaces the default JSON
-inspector with three rich tabs:
+Every flow can surface in the Console metadata browser under `/_console/`.
+ObjectUI's flow viewer replaces the default JSON inspector with rich tabs when
+the flow viewer plugin is installed:
 
 | Tab | Component | Purpose |
 |:---|:---|:---|

--- a/content/docs/guides/metadata/workflow.mdx
+++ b/content/docs/guides/metadata/workflow.mdx
@@ -1,329 +1,135 @@
 ---
 title: Workflow Metadata
-description: Define event-triggered automation rules — field updates, email alerts, HTTP calls, and scheduled actions
+description: Use Flow for automation and state machines for strict lifecycle transitions.
 ---
 
 # Workflow Metadata
 
-A **Workflow Rule** is a declarative automation triggered by data events. When a record is created, updated, or deleted, workflow rules evaluate conditions and execute actions like field updates, email alerts, HTTP calls, and task creation.
+ObjectStack no longer has a standalone Salesforce-style Workflow Rule authoring
+type. Use:
 
-## Basic Structure
+- **Flow** for event-triggered or scheduled automation.
+- **State machine metadata** for strict lifecycle transitions.
+- **Approval nodes** inside Flow for human approval pauses.
+
+This page keeps the historical route but documents the current split.
+
+---
+
+## Flow for automation
+
+Use Flow when something should happen after a record event, schedule, button, or
+subflow call:
 
 ```typescript
-const dealClosedWorkflow = {
+import type { Flow } from '@objectstack/spec/automation';
+
+export const dealClosedWon: Flow = {
   name: 'deal_closed_won',
-  objectName: 'opportunity',
-  triggerType: 'on_update',
-  criteria: "status = 'closed_won' AND ISCHANGED(status)",
-  active: true,
-  executionOrder: 10,
-
-  actions: [
-    {
-      type: 'field_update',
-      field: 'closed_date',
-      value: 'TODAY()',
-    },
-    {
-      type: 'email_alert',
-      template: 'deal_won_notification',
-      recipients: ['{record.owner.email}', 'sales-team@company.com'],
-    },
-    {
-      type: 'task_creation',
-      taskObject: 'task',
-      subject: 'Onboard new customer: {record.name}',
-      assignedTo: '{record.owner}',
-      dueDate: 'TODAY() + 3',
-    },
+  label: 'Deal Closed Won',
+  type: 'record_change',
+  status: 'active',
+  trigger: {
+    objectName: 'opportunity',
+    operations: ['update'],
+    condition: "record.stage == 'closed_won' && previous.stage != 'closed_won'",
+  },
+  nodes: [
+    { id: 'start', type: 'start', label: 'Start' },
+    { id: 'set_closed_date', type: 'update_record', label: 'Set Closed Date' },
+    { id: 'notify_sales', type: 'notify', label: 'Notify Sales' },
+    { id: 'end', type: 'end', label: 'End' },
+  ],
+  edges: [
+    { id: 'e1', source: 'start', target: 'set_closed_date' },
+    { id: 'e2', source: 'set_closed_date', target: 'notify_sales' },
+    { id: 'e3', source: 'notify_sales', target: 'end' },
   ],
 };
 ```
 
-## Workflow Properties
+Flow node types are open-ended: the schema accepts built-in node ids and
+plugin-registered node ids. The live automation engine validates executors at
+registration/runtime.
 
-| Property | Type | Required | Description |
-| :--- | :--- | :--- | :--- |
-| `name` | `string` | ✅ | Machine name (`snake_case`) |
-| `objectName` | `string` | ✅ | Target object name |
-| `triggerType` | `TriggerType` | ✅ | When to evaluate (see below) |
-| `criteria` | `string` | optional | Formula condition — workflow fires only when `TRUE` |
-| `actions` | `Action[]` | optional | Immediate actions to execute |
-| `timeTriggers` | `TimeTrigger[]` | optional | Scheduled/delayed actions |
-| `active` | `boolean` | ✅ | Is workflow active |
-| `executionOrder` | `number` | optional | Execution priority (lower = first) |
-| `reevaluateOnChange` | `boolean` | optional | Re-evaluate if field updates change criteria |
+---
 
-### Trigger Types
+## State machines for lifecycle constraints
 
-| Type | Description |
-| :--- | :--- |
-| `on_create` | Fires when a record is created |
-| `on_update` | Fires when a record is updated |
-| `on_create_or_update` | Fires on both create and update |
-| `on_delete` | Fires when a record is deleted |
-| `schedule` | Fires on a time-based schedule |
-
-## Action Types
-
-### Field Update
-
-Update a field value on the triggering record:
+Use `StateMachineSchema` when the core requirement is "this object can only move
+through these states by these events."
 
 ```typescript
-{
-  type: 'field_update',
-  field: 'status',
-  value: 'approved',
-}
-```
+import type { StateMachineConfig } from '@objectstack/spec/automation';
 
-| Property | Type | Description |
-| :--- | :--- | :--- |
-| `field` | `string` | Field to update |
-| `value` | `string` | New value (supports formulas and field references) |
-
-### Email Alert
-
-Send an email notification:
-
-```typescript
-{
-  type: 'email_alert',
-  template: 'order_confirmation',
-  recipients: ['{record.customer_email}', 'support@company.com'],
-}
-```
-
-| Property | Type | Description |
-| :--- | :--- | :--- |
-| `template` | `string` | Email template name |
-| `recipients` | `string[]` | Email addresses (supports field references) |
-
-### HTTP Call
-
-Call an external API:
-
-```typescript
-{
-  type: 'http_call',
-  url: 'https://api.example.com/webhooks',
-  method: 'POST',
-  headers: { 'Authorization': 'Bearer {$credential.api_key}' },
-  body: {
-    event: 'record_updated',
-    record_id: '{record.id}',
-    data: '{record}',
-  },
-}
-```
-
-| Property | Type | Description |
-| :--- | :--- | :--- |
-| `url` | `string` | Target URL |
-| `method` | `string` | HTTP method (`GET`, `POST`, `PUT`, `DELETE`) |
-| `headers` | `object` | Request headers |
-| `body` | `object` | Request body |
-
-### Task Creation
-
-Create a follow-up task:
-
-```typescript
-{
-  type: 'task_creation',
-  taskObject: 'task',
-  subject: 'Review account: {record.name}',
-  assignedTo: '{record.owner}',
-  dueDate: 'TODAY() + 7',
-}
-```
-
-| Property | Type | Description |
-| :--- | :--- | :--- |
-| `taskObject` | `string` | Task object name |
-| `subject` | `string` | Task subject (supports field references) |
-| `assignedTo` | `string` | Assigned user (field reference) |
-| `dueDate` | `string` | Due date expression |
-
-### Connector Action
-
-Execute a pre-configured connector action:
-
-```typescript
-{
-  type: 'connector_action',
-  connectorId: 'slack',
-  actionId: 'send_message',
-  input: {
-    channel: '#sales',
-    text: 'Deal closed: {record.name} - {record.amount}',
-  },
-}
-```
-
-### Push Notification
-
-Send a mobile/web push notification:
-
-```typescript
-{
-  type: 'push_notification',
-  title: 'New Assignment',
-  body: 'You have been assigned to {record.name}',
-  recipients: ['{record.assignee}'],
-}
-```
-
-### Custom Script
-
-Execute custom business logic:
-
-```typescript
-{
-  type: 'custom_script',
-  language: 'javascript',
-  code: `
-    const discount = record.amount > 10000 ? 0.15 : 0.05;
-    await updateRecord('opportunity', record.id, {
-      discount_rate: discount,
-    });
-  `,
-  timeout: 30000,
-}
-```
-
-## Time Triggers
-
-Schedule actions to run at a specified time relative to a trigger event or date field:
-
-```typescript
-timeTriggers: [
-  {
-    timeLength: 3,
-    timeUnit: 'days',
-    offsetDirection: 'before',
-    offsetFrom: 'date_field',
-    dateField: 'due_date',
-    actions: [
-      {
-        type: 'email_alert',
-        template: 'reminder_due_soon',
-        recipients: ['{record.owner.email}'],
+export const caseLifecycle: StateMachineConfig = {
+  id: 'case_lifecycle',
+  initial: 'new',
+  states: {
+    new: {
+      on: {
+        ASSIGN: { target: 'assigned' },
       },
-    ],
-  },
-  {
-    timeLength: 1,
-    timeUnit: 'hours',
-    offsetDirection: 'after',
-    offsetFrom: 'trigger_date',
-    actions: [
-      {
-        type: 'field_update',
-        field: 'follow_up_sent',
-        value: 'true',
+    },
+    assigned: {
+      on: {
+        RESOLVE: { target: 'resolved', cond: 'has_resolution' },
+        ESCALATE: { target: 'escalated' },
       },
-    ],
+    },
+    escalated: {
+      on: {
+        RESOLVE: { target: 'resolved', cond: 'has_resolution' },
+      },
+    },
+    resolved: {
+      type: 'final',
+    },
   },
-]
-```
-
-### Time Trigger Properties
-
-| Property | Type | Description |
-| :--- | :--- | :--- |
-| `timeLength` | `number` | Duration value |
-| `timeUnit` | `enum` | `'minutes'`, `'hours'`, `'days'` |
-| `offsetDirection` | `enum` | `'before'` or `'after'` the reference time |
-| `offsetFrom` | `enum` | `'trigger_date'` (when workflow fires) or `'date_field'` |
-| `dateField` | `string` | Date field name (required when `offsetFrom` is `'date_field'`) |
-| `actions` | `Action[]` | Actions to execute at the scheduled time |
-
-## Execution Order
-
-When multiple workflows match the same event, `executionOrder` determines the sequence:
-
-```typescript
-// Runs first (lower number = higher priority)
-{ name: 'validate_amount', executionOrder: 10, ... }
-
-// Runs second
-{ name: 'update_status', executionOrder: 20, ... }
-
-// Runs third
-{ name: 'send_notification', executionOrder: 30, ... }
-```
-
-## Complete Example
-
-```typescript
-const leadConversion = {
-  name: 'lead_qualified',
-  objectName: 'lead',
-  triggerType: 'on_update',
-  criteria: "status = 'qualified' AND ISCHANGED(status)",
-  active: true,
-  executionOrder: 10,
-
-  actions: [
-    {
-      type: 'field_update',
-      field: 'qualified_date',
-      value: 'TODAY()',
-    },
-    {
-      type: 'email_alert',
-      template: 'lead_qualified_alert',
-      recipients: ['{record.owner.email}'],
-    },
-    {
-      type: 'http_call',
-      url: 'https://api.company.com/crm/convert',
-      method: 'POST',
-      body: { lead_id: '{record.id}' },
-    },
-    {
-      type: 'task_creation',
-      taskObject: 'task',
-      subject: 'Schedule demo for {record.company}',
-      assignedTo: '{record.owner}',
-      dueDate: 'TODAY() + 2',
-    },
-  ],
-
-  timeTriggers: [
-    {
-      timeLength: 7,
-      timeUnit: 'days',
-      offsetDirection: 'after',
-      offsetFrom: 'trigger_date',
-      actions: [
-        {
-          type: 'email_alert',
-          template: 'follow_up_reminder',
-          recipients: ['{record.owner.email}'],
-        },
-      ],
-    },
-  ],
 };
 ```
 
-## Flow vs. Workflow
+State machines describe valid transitions and guards. Use Flow nodes for side
+effects around those transitions when you need notifications, record updates, or
+external calls.
 
-| Aspect | Workflow Rule | Flow |
-| :--- | :--- | :--- |
-| **Trigger** | Data events (create/update/delete) | Manual, API, schedule, or data events |
-| **Logic** | Linear actions | Visual branching with decision trees |
-| **User Interaction** | No | Supports screen nodes |
-| **Complexity** | Simple rules | Complex orchestration |
-| **Use Case** | Field updates, notifications | Approval processes, multi-step logic |
+---
 
-**Rule of thumb:** Use **Workflow Rules** for simple "when X happens, do Y" automation. Use **Flows** for complex multi-step logic with branching.
+## Approvals
 
-## Related
+Approvals are Flow nodes:
 
-- [Flow Metadata](./flow) — Visual automation with branching logic
-- [Object Metadata](./object) — Objects that trigger workflows
-- [Validation Metadata](./validation) — Data validation rules
+```typescript
+{
+  id: 'manager_approval',
+  type: 'approval',
+  label: 'Manager Approval',
+  config: {
+    approvers: [{ type: 'user', value: '${record.owner_manager_id}' }],
+    behavior: 'all',
+    approvalStatusField: 'approval_status',
+    lockRecord: true,
+  },
+}
+```
+
+The approvals plugin persists `sys_approval_request` and
+`sys_approval_action`, enforces record locks, mirrors the optional status field,
+and resumes the paused Flow after approve/reject.
+
+---
+
+## Migration
+
+| Old concept | Current equivalent |
+|:---|:---|
+| Workflow Rule | Flow |
+| Time trigger | Scheduled Flow |
+| Field update action | `update_record` node |
+| Email alert | `notify` node |
+| HTTP call | `http` node |
+| Approval Process | Flow with one or more `approval` nodes |
+
+If the old rule was "when X happens, do Y", model it as a small Flow. If the old
+rule was "this record must move through controlled states", model the lifecycle
+as a state machine and use Flow for side effects.

--- a/content/docs/guides/packages.mdx
+++ b/content/docs/guides/packages.mdx
@@ -5,7 +5,7 @@ description: Complete guide to all ObjectStack packages, services, drivers, plug
 
 # Package Overview
 
-ObjectStack is organized into **51 publishable packages** across multiple categories. This guide provides a complete overview of each package, its purpose, and when to use it. Counts are kept in sync with the `packages/` directory in the [framework repository](https://github.com/objectstack-ai/framework/tree/main/packages).
+ObjectStack is organized into **70 package manifests** across multiple categories. This guide provides an overview of the framework packages, services, drivers, plugins, and adapters in the [framework repository](https://github.com/objectstack-ai/framework/tree/main/packages).
 
 ### Package categories at a glance
 
@@ -14,9 +14,9 @@ ObjectStack is organized into **51 publishable packages** across multiple catego
 | **Core runtime** | 9 | `spec`, `core`, `runtime`, `types`, `metadata`, `objectql`, `rest`, `formula`, `platform-objects` |
 | **Client / DX** | 5 | `client`, `client-react`, `cli`, `create-objectstack`, `vscode-objectstack` |
 | **Framework adapters** | 7 | `express`, `fastify`, `hono`, `nestjs`, `nextjs`, `nuxt`, `sveltekit` |
-| **Drivers** | 4 | `driver-memory`, `driver-sql`, `driver-turso`, `driver-mongodb` |
-| **Plugins** | 13 | `plugin-auth`, `plugin-security`, `plugin-org-scoping`, `plugin-audit`, `plugin-approvals`, `plugin-sharing`, `plugin-email`, `plugin-webhooks`, `plugin-reports`, `plugin-hono-server`, `plugin-mcp-server`, `plugin-msw`, `plugin-dev` |
-| **Platform services** | 14 | `service-ai`, `service-analytics`, `service-automation`, `service-cache`, `service-cloud`, `service-feed`, `service-i18n`, `service-job`, `service-package`, `service-queue`, `service-realtime`, `service-settings`, `service-storage`, `service-tenant` |
+| **Drivers** | 4 | `driver-memory`, `driver-sql`, `driver-sqlite-wasm`, `driver-mongodb` |
+| **Plugins** | 22 | `plugin-auth`, `plugin-security`, `plugin-org-scoping`, `plugin-audit`, `plugin-approvals`, `plugin-sharing`, `plugin-email`, `plugin-webhooks`, `plugin-reports`, `plugin-hono-server`, `plugin-mcp-server`, `plugin-msw`, `plugin-dev`, trigger plugins, and knowledge/embedder plugins |
+| **Platform services** | 17 | `service-ai`, `service-analytics`, `service-automation`, `service-cache`, `service-cluster`, `service-cluster-redis`, `service-datasource`, `service-feed`, `service-i18n`, `service-job`, `service-knowledge`, `service-messaging`, `service-package`, `service-queue`, `service-realtime`, `service-settings`, `service-storage` |
 
 
 ## Core Packages
@@ -286,22 +286,6 @@ All services implement contracts from `@objectstack/spec/contracts` and are kern
 - **When to use**: Marketplace backends, internal tenant-facing registries, CI-driven metadata distribution
 - **README**: [View README](/packages/services/service-package/README.md)
 
-### @objectstack/service-tenant
-
-**Multi-Tenant Service** — Tenant context, routing, and isolation for SaaS deployments.
-
-- **Features**: Tenant resolution from host/header/cookie, per-tenant metadata and data isolation
-- **When to use**: Any multi-tenant SaaS on ObjectStack
-- **README**: [View README](/packages/services/service-tenant/README.md)
-
-### @objectstack/service-cloud
-
-**Cloud Control-Plane Service** — Bridge between ObjectOS runtimes and the hosted control plane (artifact API, project versions).
-
-- **Features**: Artifact fetch/cache, project version selection, telemetry hooks
-- **When to use**: When deploying through the ObjectStack hosted cloud or a self-hosted control plane
-- **README**: [View README](/packages/services/service-cloud/README.md)
-
 ### @objectstack/service-settings
 
 **Settings Service** — Hierarchical, validated application settings backed by metadata.
@@ -528,7 +512,7 @@ npx create-objectstack my-app
 ObjectStack composes packages at two layers:
 
 1. **Metadata** is declared inside `defineStack({...})` (objects, views, flows, agents, …) and lives in `objectstack.config.ts`.
-2. **Runtime** plugins/services/drivers are wired into the host kernel (e.g. `apps/objectos/src/server.ts` or any custom adapter) via `kernel.use(...)` and a host-side `HostConfig`.
+2. **Runtime** plugins/services/drivers are wired into the host kernel through `kernel.use(...)`, `@objectstack/runtime`, or a custom adapter host.
 
 The snippets below illustrate which **runtime** packages you typically reach for in each scenario. See the [Quick Start](/docs/getting-started/quick-start) and [CLI guide](/docs/getting-started/cli) for the full bootstrap pattern.
 

--- a/content/docs/guides/project-scoping.mdx
+++ b/content/docs/guides/project-scoping.mdx
@@ -1,156 +1,115 @@
 ---
-title: Project-Scoped Routing
-description: Enable multi-project isolation at the URL level — /api/v1/projects/:projectId/... — with REST, Client SDK, and dispatcher support.
+title: Environment-Scoped Routing
+description: Route REST, metadata, automation, AI, and package calls through /api/v1/environments/:environmentId/....
 ---
 
-# Project-Scoped Routing
+# Environment-Scoped Routing
 
-ObjectStack's project-scoping feature puts each project (the "workspace" or "base" in Airtable / "environment" in traditional stacks) into its own URL segment. When enabled, every data, metadata, automation, and AI request runs through `/api/v1/projects/:projectId/...` instead of relying on hostname / header / session resolution alone.
+Environment-scoped routing makes the target runtime explicit in the URL:
 
-This gives you:
+```text
+/api/v1/environments/:environmentId/data/:object
+/api/v1/environments/:environmentId/meta
+/api/v1/environments/:environmentId/automation/...
+/api/v1/environments/:environmentId/ai/...
+```
 
-- **Explicit tenancy in URLs** — no more guessing what project a request targets.
-- **Safer client code** — `client.project(id).data.find(...)` cannot be confused with the default project.
-- **Future foundation for RBAC** — the project is in the URL, so middleware can enforce access before any handler runs.
-- **Incremental rollout** — the `'auto'` resolution strategy mounts both scoped and unscoped routes, so you can migrate clients on your own schedule.
+The scoped URL wins over hostname, header, session, and default-environment
+resolution. Use it when a caller must address a specific environment without
+depending on request context.
+
+---
 
 ## Server configuration
 
-Enable scoping in your `objectstack.config.ts`:
+Enable scoped route registration in `objectstack.config.ts`:
 
 ```typescript
 import { defineStack } from '@objectstack/spec';
 
 export default defineStack({
-  // ... rest of your stack
   api: {
     enableProjectScoping: true,
-    projectResolution: 'auto', // 'required' | 'optional' | 'auto'
+    projectResolution: 'auto',
   },
 });
 ```
 
-### Resolution strategies
+The option names are historical for compatibility with existing config files;
+the route, header, env var, and request context all use `environment`.
 
-| Strategy     | Behavior                                                                                   | When to use                                                                 |
-| ------------ | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
-| `'auto'`     | Registers **both** `/api/v1/data/:object` and `/api/v1/projects/:projectId/data/:object`.  | Default. Zero risk during migration — old and new clients both work.        |
-| `'optional'` | Same as `auto` today; reserved so a future release can require one of URL / header / session to be present. | Same as `auto`.                                                             |
-| `'required'` | Only scoped routes are registered. Unscoped requests return 404.                           | Production hardening after all clients have migrated.                       |
+| Strategy | Behavior | When to use |
+|:---|:---|:---|
+| `auto` | Registers both unscoped `/api/v1/...` and scoped `/api/v1/environments/:environmentId/...` routes. | Default migration mode. |
+| `optional` | Same route surface as `auto`; resolution may come from URL, hostname, header, session, or default. | Multi-environment hosts that still accept unscoped callers. |
+| `required` | Registers only environment-scoped routes for data/meta/AI/automation/package handlers. | Hardened clients that always pass an environment id. |
 
-The setting also propagates to:
-
-- **Dispatcher plugin** — AI (`/ai/*`) and automation (`/automation/*`) routes gain scoped variants.
-- **Package management** — `/api/v1/projects/:projectId/packages` mirrors `/api/v1/packages`.
-- **Discovery** — the `/api/v1/discovery` response includes a `scoping` block so clients can detect the mode.
+---
 
 ## Client SDK
 
-The client exposes a `project(id)` factory that returns a sub-client wired to the scoped URL prefix:
+The client keeps the legacy factory name `project(id)`, but the value is an
+environment id and the generated URLs are environment-scoped:
 
 ```typescript
 import { ObjectStackClient } from '@objectstack/client';
 
-const client = new ObjectStackClient({ baseUrl: 'https://api.example.com' });
+const client = new ObjectStackClient({
+  baseUrl: 'https://api.example.com',
+});
 
-const scoped = client.project('00000000-0000-0000-0000-000000000001');
+const env = client.project('env_prod');
 
-// All calls hit /api/v1/projects/:projectId/...
-const tasks = await scoped.data.find('task', { top: 20 });
-const objects = await scoped.meta.getItems('object');
-const pkg = await scoped.packages.get('my-package');
+await env.data.find('customer', { top: 20 });
+await env.meta.getItems('object');
+await env.packages.list();
 ```
 
-The top-level `client.data.*`, `client.meta.*`, `client.packages.*` namespaces continue to work unchanged — they hit the unscoped routes, falling back to hostname / `X-Project-Id` header / session resolution exactly as before.
-
-You can switch between projects without rebuilding the client:
+The top-level client can also set a default environment header:
 
 ```typescript
-const projectA = client.project('proj-a');
-const projectB = client.project('proj-b');
-
-await Promise.all([
-  projectA.data.find('task'),
-  projectB.data.find('task'),
-]);
+const client = new ObjectStackClient({
+  baseUrl: 'https://api.example.com',
+  environmentId: 'env_prod',
+});
 ```
 
-## Request resolution order
+That sends `X-Environment-Id: env_prod` on unscoped requests.
 
-When `enableProjectScoping: true`, `HttpDispatcher.resolveEnvironmentContext` resolves the project in this order:
+---
 
-1. **URL path parameter** — `/api/v1/projects/:projectId/...`. Highest priority.
-2. **Hostname** — `acme-dev.objectstack.app`.
-3. **`X-Project-Id` header** — the client SDK sets this automatically if you pass `projectId` in `ClientConfig`.
-4. **Session** — `session.activeProjectId` (or legacy `activeEnvironmentId`).
-5. **Default project for active organization** — falls back to the org's default.
+## Resolution order
 
-Under `'required'` mode, the URL path is the only supported source; the other fallbacks are bypassed for data/meta/AI/automation routes.
+`HttpDispatcher.resolveEnvironmentContext` resolves the environment in this
+order:
 
-## System project
+1. `:environmentId` from `/api/v1/environments/:environmentId/...`
+2. Hostname through the configured environment registry
+3. `X-Environment-Id`
+4. `session.activeEnvironmentId`
+5. A configured default environment
+6. A single available environment, when the registry can prove the choice is unambiguous
 
-Every deployment has a built-in system project at the well-known UUID `00000000-0000-0000-0000-000000000001`. It's used for platform infrastructure (system packages, platform-level flows, etc.) and is created automatically on first startup if you register the plugin:
+Control-plane endpoints remain unscoped. Requests such as
+`/api/v1/cloud/environments/:id` manage environments rather than running inside
+one, so they are intentionally excluded from data-plane resolution.
 
-```typescript
-import { createSystemProjectPlugin } from '@objectstack/runtime';
-
-kernel.use(tenantPlugin);
-kernel.use(createSystemProjectPlugin());
-```
-
-The plugin is idempotent — it's safe to call `provisionSystemProject()` on every boot. Subsequent calls return the existing row.
-
-## Control-plane routes remain unscoped
-
-Control-plane endpoints always live under their unscoped paths:
-
-- `/api/v1/auth/*`
-- `/api/v1/cloud/projects` (CRUD on the project list itself)
-- `/api/v1/cloud/organizations`
-- `/api/v1/health`
-- `/api/v1/discovery`
-- `/.well-known/objectstack`
-
-These are not affected by `enableProjectScoping` because they operate on the control plane, not a specific project's data plane.
-
-## Binding compiled artifacts to projects
-
-Third-party apps can now bind a locally compiled bundle to a multi-project
-server without raw `curl`.
-
-```bash
-os compile
-os projects create --org <org-id> --name CRM --artifact ./dist/objectstack.json
-os projects bind <project-id> --artifact ./dist/objectstack.json --build
-```
-
-Both commands validate that the artifact file exists and resolve relative paths
-to absolute paths before calling the control plane. The path is stored in
-`sys_project.metadata.artifact_path`; if a project already exists, `bind` updates
-that metadata with `PATCH /api/v1/cloud/projects/:id`.
-
-When a per-project kernel boots, `AppBundleResolver` reads
-`metadata.artifact_path` (or `metadata.artifact_paths[]`) and hydrates the
-project from the bundle: schemas are registered, views and apps are available,
-and seed data in `data` arrays is loaded through the same pipeline used by
-built-in templates.
-
-For local development and demos, `OS_PROJECT_ARTIFACTS` can override
-project bindings with a comma-separated `projectId:path` list, and
-`OS_PROJECT_ARTIFACT_ROOT` resolves relative artifact paths.
+---
 
 ## Migration checklist
 
-1. ✅ Upgrade to `@objectstack/core@≥4.x` with the Phase 2 runtime.
-2. ✅ Add `enableProjectScoping: true, projectResolution: 'auto'` to your stack config.
-3. ✅ Register `createSystemProjectPlugin()` in your kernel wiring.
-4. ⏳ Update callers that hard-code `/api/v1/data/...` to use `client.project(id)` or keep them as-is under `auto` mode.
-5. ⏳ Once all callers have migrated, flip `projectResolution` to `'required'` and remove the unscoped code paths.
+1. Replace `/api/v1/projects/:projectId/...` with
+   `/api/v1/environments/:environmentId/...`.
+2. Replace `X-Project-Id` with `X-Environment-Id`.
+3. Replace `OS_PROJECT_ID` with `OS_ENVIRONMENT_ID`.
+4. Store runtime rows under `environment_id`.
+5. Keep the SDK `client.project(id)` call only as a compatibility method name;
+   pass an environment id to it.
 
-Steps 4 and 5 are intentionally separate — you can ship Step 3 today and migrate clients over weeks or months.
+---
 
-## Related reading
+## Related
 
-- [ADR-0002 — Project-per-database isolation](/docs/adr/0002-environment-database-isolation)
-- [Client SDK](/docs/guides/client-sdk)
-- [Authentication](/docs/guides/authentication)
+- [Single-Environment Mode](./single-project-mode)
+- [Deployment Modes](./cloud-deployment)
+- [Client SDK](./client-sdk)

--- a/content/docs/guides/public-forms.mdx
+++ b/content/docs/guides/public-forms.mdx
@@ -145,9 +145,9 @@ export default leadGuestDefaults;
 
 ## 4. The REST contract
 
-Both routes are mounted under the active project's API base. For the
-default standalone project that is `/api/v1`; for multi-project deployments
-it is `/api/v1/p/:projectId`.
+Both routes are mounted under the active environment's API base. For a
+standalone environment that is `/api/v1`; for scoped deployments it is
+`/api/v1/environments/:environmentId`.
 
 ### `GET /api/v1/forms/:slug`
 

--- a/content/docs/guides/publish-and-preview.mdx
+++ b/content/docs/guides/publish-and-preview.mdx
@@ -1,332 +1,112 @@
 ---
 title: Publish, Versioning & Preview
-description: End-to-end pipeline — `objectstack compile` → `objectstack publish` → cloud control plane stores immutable revisions in object storage → ObjectOS runtime pulls via artifact-api. Includes rollback and pinned-commit preview.
+description: Compile metadata, publish it to a Cloud environment, and activate or roll back revisions.
 ---
 
 # Publish, Versioning & Preview
 
-The cloud control plane keeps **every** publish as an immutable revision in
-object storage and lets runtime nodes boot off any historical commit.
-This page walks through the full loop:
+ObjectStack treats compiled metadata as an immutable environment artifact. The
+local loop is:
 
+```text
+objectstack.config.ts -> os compile -> dist/objectstack.json -> os publish -> Cloud environment revision
 ```
-┌───────────┐   compile    ┌──────────────────┐   publish   ┌────────────────────┐   pull (artifact-api)   ┌──────────────┐
-│ source    │ ───────────▶ │ dist/object-     │ ──────────▶ │ Cloud control      │ ──────────────────────▶ │ ObjectOS     │
-│ tree      │              │ stack.json       │             │ plane (revisions)  │                         │ runtime node │
-└───────────┘              └──────────────────┘             └────────────────────┘                         └──────────────┘
-                                                                      │
-                                                                      ├── object storage
-                                                                      │   (file-storage / S3)
-                                                                      └── sys_project_revision
-                                                                          (commitId, checksum,
-                                                                           is_current, …)
-```
+
+The framework CLI owns compile/publish/rollback commands. The Cloud control
+plane that stores revisions and serves them to runtime nodes lives outside this
+framework repo.
 
 ---
 
 ## 1. Compile
 
 ```bash
-objectstack compile
-# → dist/objectstack.json   (envelope: { schemaVersion, commitId, metadata, … })
+os compile
+# -> dist/objectstack.json
 ```
 
-The artifact is **content-addressable**: `commitId` is a sha256 prefix of the
-canonicalised metadata. Identical content always produces the same `commitId`,
-so re-publishing is a no-op upload.
+The artifact contains metadata, manifest requirements, and packaged function
+code. Deployment config stays outside the artifact: database URLs, secrets,
+runtime credentials, and environment identity are host inputs.
 
 ---
 
 ## 2. Publish
 
 ```bash
-objectstack publish dist/objectstack.json \
-  --project proj_crm \
-  --server  http://localhost:4000
+OS_CLOUD_URL=https://cloud.example.com \
+OS_ENVIRONMENT_ID=env_prod \
+os publish
 ```
 
-Common flags:
+Common inputs:
 
-| Flag                | Env var               | Default                  | Notes |
-|---------------------|-----------------------|--------------------------|-------|
-| `--server`, `-s`    | `OS_CLOUD_URL`        | `http://localhost:4000`  | Control-plane URL |
-| `--project`, `-p`   | `OS_PROJECT_ID`       | — (required)             | Target project id |
-| `--token`,   `-t`   | `OS_CLOUD_API_KEY`    | —                        | Bearer token (when auth is enabled) |
-| `--note`,    `-n`   | —                     | —                        | Optional human-readable note attached to the revision (shown in Studio) |
-| `--timeout`         | `OS_CLOUD_TIMEOUT_MS` | `60000` (60 s)           | Set higher for slow networks; `0` disables |
+| Input | Env var | Purpose |
+|:---|:---|:---|
+| `--server`, `-s` | `OS_CLOUD_URL` | Cloud control-plane URL |
+| `--environment`, `-e` | `OS_ENVIRONMENT_ID` | Target environment id |
+| `--token`, `-t` | `OS_CLOUD_API_KEY` | Bearer token when required |
+| `--timeout` | `OS_CLOUD_TIMEOUT_MS` | Request timeout |
 
-`publish` POSTs to `/api/v1/cloud/projects/:id/metadata`. The control plane:
+The CLI posts the compiled JSON to:
 
-1. Computes / verifies `commitId`.
-2. **Uploads** to object storage at
-   `artifacts/orgs/${organizationId}/projects/${projectId}/${commitId}.json`
-   (no-op if the key already exists — content-addressable). Org-first prefixing
-   makes per-tenant IAM policies, billing attribution, exports and GC trivial.
-   Projects without an `organization_id` (rare, single-tenant installs) fall
-   back to the legacy `artifacts/${projectId}/${commitId}.json` shape.
-   Existing rows keep their original key in `sys_project_revision.storage_key`,
-   so historical artifacts always remain readable regardless of layout changes.
-3. **Inserts** a `sys_project_revision` row, flips the previous current row to
-   `is_current = false`, and marks the new one `is_current = true`.
-4. Updates `sys_project.metadata.current_commit_id`.
+```text
+POST /api/v1/cloud/environments/:environment/metadata
+```
+
+The response includes the environment id, commit id, and checksum for the newly
+published revision.
 
 ---
 
-## 3. Storage backend
+## 3. Activate or roll back
 
-The plugin resolves storage in this order:
-
-1. Explicit `options.storage.service` (passed by host code)
-2. Kernel-registered `file-storage` service (`@objectstack/service-storage`)
-3. Local filesystem fallback (warns at boot)
-
-`createCloudStack()` in `@objectstack/service-cloud` automatically wires
-`StorageServicePlugin` based on **environment variables** — no code changes
-needed when switching backends.
-
-### Env-driven configuration
-
-| Env var                  | Required when           | Description |
-|--------------------------|-------------------------|-------------|
-| `OS_STORAGE_ADAPTER`     | always (default `local`)| `local` \| `s3` \| `none` (`none` skips registering, falls back to plugin's local-FS write — useful for tests) |
-| `OS_STORAGE_LOCAL_DIR`   | `local` adapter         | Root dir for local files (default `./storage`) |
-| `OS_S3_BUCKET`           | `s3` adapter (required) | Bucket name |
-| `OS_S3_REGION`           | `s3` adapter (required) | AWS region (e.g. `us-east-1`, `auto` for R2) |
-| `OS_S3_ENDPOINT`         | S3-compatible only      | Custom endpoint (Cloudflare R2, MinIO, B2, etc.) |
-| `OS_S3_ACCESS_KEY_ID`    | when not using SDK chain | Access key |
-| `OS_S3_SECRET_ACCESS_KEY`| when not using SDK chain | Secret key |
-| `OS_S3_FORCE_PATH_STYLE` | MinIO / self-hosted     | `1` / `true` to force path-style URLs |
-
-### Example: native AWS S3
+To activate a previous commit:
 
 ```bash
-OS_STORAGE_ADAPTER=s3
-OS_S3_BUCKET=objectstack-artifacts
-OS_S3_REGION=us-east-1
-OS_S3_ACCESS_KEY_ID=AKIA…
-OS_S3_SECRET_ACCESS_KEY=…
+OS_CLOUD_URL=https://cloud.example.com \
+OS_ENVIRONMENT_ID=env_prod \
+os rollback --commit 9ce1bd48dd7022b8
 ```
 
-### Example: Cloudflare R2
+The CLI calls:
 
-```bash
-OS_STORAGE_ADAPTER=s3
-OS_S3_BUCKET=objectstack-artifacts
-OS_S3_REGION=auto
-OS_S3_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
-OS_S3_ACCESS_KEY_ID=…
-OS_S3_SECRET_ACCESS_KEY=…
+```text
+POST /api/v1/cloud/environments/:environment/revisions/:commit/activate
 ```
 
-### Example: MinIO (local development against S3 protocol)
-
-```bash
-OS_STORAGE_ADAPTER=s3
-OS_S3_BUCKET=artifacts
-OS_S3_REGION=us-east-1
-OS_S3_ENDPOINT=http://localhost:9000
-OS_S3_ACCESS_KEY_ID=minioadmin
-OS_S3_SECRET_ACCESS_KEY=minioadmin
-OS_S3_FORCE_PATH_STYLE=1
-```
-
-> **Vercel (and other serverless hosts):** the local-FS fallback **does not
-> work** — Vercel functions get a read-only filesystem (only `/tmp` is
-> writable, and it is not shared across invocations). You **must** set
-> `OS_STORAGE_ADAPTER=s3` plus `OS_S3_*` in your project settings.
-> Pair it with `OS_CONTROL_DATABASE_URL` pointing at Turso / libSQL for the
-> control DB.
+Runtime hosts can then refresh the environment kernel using the active
+commit/checksum.
 
 ---
 
-## 4. Cloud HTTP API
+## 4. Package publish
 
-All endpoints live under `/api/v1/cloud/projects/:id/`.
+Packages are separate from environment revisions:
 
-| Method & Path                                | Purpose |
-|----------------------------------------------|---------|
-| `POST /metadata`                             | Publish a new revision (called by CLI) |
-| `GET  /artifact`                             | Get the **current** artifact (envelope) |
-| `GET  /artifact?commit=<sha>`                | Get a **pinned** revision |
-| `GET  /revisions?limit=&cursor=`             | List revisions (most-recent first) |
-| `POST /revisions/:commit/activate`           | Roll back / forward — flip `is_current` |
-| `GET  /resolve-hostname?host=<host>`         | Tenant routing helper used by ObjectOS |
+```bash
+os package publish --env env_prod
+```
 
-Errors follow the standard `{ success: false, error: '…' }` shape. Unknown
-commits return **404** with a descriptive message.
+Package publish targets the Cloud package registry endpoints, while
+`os publish` targets an environment revision.
 
 ---
 
-## 5. Runtime — `artifact-api` source
+## 5. Preview patterns
 
-ObjectOS runtime nodes can boot off any cloud revision without ever touching
-the source tree:
+Use one of these shapes:
 
-```ts
-import { MetadataPlugin } from '@objectstack/metadata';
-
-new MetadataPlugin({
-  bootstrap: 'artifact-only',           // skip filesystem watcher
-  artifactSource: {
-    mode: 'artifact-api',
-    url:  'https://cloud.example.com',
-    projectId: 'proj_crm',
-    commitId: '9707264f0450e8ba',        // optional — omit for latest
-    token: process.env.OS_CLOUD_API_KEY, // optional
-    fetchTimeoutMs: 60_000,              // optional, default 60 s
-  },
-});
-```
-
-The plugin merges the cloud envelope’s `metadata` block, dynamically imports
-`@objectstack/spec/cloud` for Zod validation, and registers every metadata
-item before the kernel marks itself ready.
-
-> **Tip — slow networks:** override the timeout per-plugin
-> (`fetchTimeoutMs`) or globally via `OS_ARTIFACT_FETCH_TIMEOUT_MS`.
+| Pattern | Command |
+|:---|:---|
+| Local artifact preview | `os serve --artifact ./dist/objectstack.json --dev --ui` |
+| Production artifact host | `OS_ARTIFACT_PATH=./dist/objectstack.json os start` |
+| Cloud environment preview | Publish to a preview environment id, then route clients to that environment via `/api/v1/environments/:environmentId/...` or `X-Environment-Id`. |
 
 ---
 
-## 6. Rollback
+## Related
 
-Every publish is preserved. The fastest way to roll back is the CLI:
-
-```bash
-# Accepts either the full 16-char commitId or any unambiguous prefix (≥ 8 chars).
-OS_CLOUD_URL=http://localhost:4000 OS_PROJECT_ID=proj_crm \
-  objectstack rollback --commit 9ce1bd48
-```
-
-Equivalent raw HTTP:
-
-```bash
-curl -X POST http://localhost:4000/api/v1/cloud/projects/proj_crm/revisions/9ce1bd48dd7022b8/activate
-```
-
-The next `GET /artifact` (no `?commit`) — and any runtime node restarted
-without a pinned `commitId` — will pick up the older revision. Roll forward
-the same way.
-
-### Pruning old revisions
-
-History grows with every publish. Use the prune endpoint to enforce a
-retention policy. The current revision is **always** preserved.
-
-```bash
-curl -X POST http://localhost:4000/api/v1/cloud/projects/proj_crm/revisions/prune \
-  -H 'Content-Type: application/json' \
-  -d '{"keepN": 50, "keepDays": 30}'
-```
-
-Defaults are `keepN = 50` and `keepDays = 30`. Any row outside both windows
-is deleted from the table **and** the underlying object-storage key is
-removed (best-effort — orphaned keys won't block the row deletion).
-
----
-
-## 7. Local end-to-end smoke test
-
-```bash
-# Terminal 1 — cloud control plane
-cd apps/cloud
-OS_MODE=cloud PORT=4000 \
-  AUTH_SECRET=local-dev-secret-must-be-at-least-32-chars-long \
-  pnpm dev
-
-# Terminal 2 — compile + publish twice
-cd hotcrm                                  # https://github.com/objectstack-ai/hotcrm
-objectstack compile
-OS_PROJECT_ID=proj_crm objectstack publish
-
-# tweak any object label, recompile, publish again
-
-# Terminal 3 — list revisions
-curl http://localhost:4000/api/v1/cloud/projects/proj_crm/revisions | jq
-```
-
-You should see two `sys_project_revision` rows — the second one
-`isCurrent: true` — and the artifact body for either one accessible via
-`GET /artifact?commit=<id>`.
-
----
-
-## 7. Public artifact API (visibility)
-
-By default every project is **private** — only the authenticated `/cloud/*`
-routes can read it. To support marketplace listings, OSS templates, share
-links, or live documentation demos, switch a project to **public** or
-**unlisted**.
-
-```ts
-// sys_project.visibility — defined in packages/platform-objects/src/tenant/sys-project.object.ts
-visibility: 'private' | 'unlisted' | 'public'   // default: 'private'
-```
-
-| Mode       | `/pub/v1/.../artifact` (no commit) | `/pub/v1/.../artifact?commit=<id>` | `/pub/v1/.../revisions` | `/pub/v1/.../manifest.json` |
-|------------|:-----------------------------------:|:------------------------------------:|:------------------------:|:----------------------------:|
-| `private`  | 404                                 | 404                                  | 404                      | 404                          |
-| `unlisted` | 404                                 | ✅ 200                               | 404                      | 404                          |
-| `public`   | ✅ 200 (current)                    | ✅ 200                               | ✅ 200                   | ✅ 200                       |
-
-`unlisted` requires the caller to know the exact `commit` — it is meant for
-share-preview links you mail to colleagues, not for crawling.
-
-### Public endpoints
-
-- `GET /api/v1/pub/v1/projects/:id/artifact[?commit=<id>][&redirect=1]`
-  Returns the same envelope as the private route. **No auth header required.**
-  Sets `Cache-Control: public, max-age=31536000, immutable` and
-  `ETag: "<commitId>"` so a CDN (Cloudflare, CloudFront, …) in front of the
-  control plane serves it from the edge for free.
-  When the storage adapter is S3 / R2 (or anything that implements
-  `getSignedUrl`), passing `?redirect=1` makes the control plane respond
-  with a `302` to a short-lived (5 min) signed URL — bandwidth then comes
-  straight from the bucket and the control plane is no longer the chokepoint.
-- `GET /api/v1/pub/v1/projects/:id/revisions?limit=N` — public history.
-- `GET /api/v1/pub/v1/projects/:id/manifest.json` — lightweight project info
-  (`projectId`, `displayName`, `currentCommitId`, `currentChecksum`, `builtAt`).
-
-### Flipping visibility
-
-```bash
-# Via the platform REST (control plane)
-curl -X PATCH https://cloud.example.com/api/v1/data/sys_project/proj_crm \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"visibility":"public"}'
-```
-
-Or via SQL on the control DB:
-
-```sql
-UPDATE sys_project SET visibility='public' WHERE id='proj_crm';
-```
-
-> ⚠️ **Before going public, audit the artifact** — it includes every field
-> name, view config, AI prompt, and formula. Treat it like committing to a
-> public Git repo: never embed credentials or PII in metadata.
-
-### Pulling a public artifact from another runtime
-
-```ts
-import { MetadataPlugin } from '@objectstack/metadata';
-
-new MetadataPlugin({
-    artifactSource: {
-        mode: 'artifact-api',
-        url: 'https://cloud.objectstack.dev',
-        // No token needed for /pub routes
-        // Use the public path explicitly:
-        // url: 'https://cloud.objectstack.dev/api/v1/pub/v1/projects/proj_crm'
-    },
-    bootstrap: 'artifact-only',
-});
-```
-
----
-
-## See also
-
-- [`packages/services/service-cloud`](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-cloud) — control-plane plugin source
-- [`packages/metadata`](https://github.com/objectstack-ai/framework/tree/main/packages/metadata) — `MetadataPlugin` and the `artifact-api` loader
-- [Cloud Deployment](./cloud-deployment) — running cloud / standalone modes
+- [Deployment Modes](./cloud-deployment)
+- [Environment-Scoped Routing](./project-scoping)
+- [Cloud Environment Artifact API](../concepts/cloud-artifact-api)

--- a/content/docs/guides/single-project-mode.mdx
+++ b/content/docs/guides/single-project-mode.mdx
@@ -1,178 +1,111 @@
 ---
-title: Single-Project Mode
-description: Run ObjectStack as a one-project local stack (no control plane, no project switcher)
+title: Single-Environment Mode
+description: Run ObjectStack as a one-environment local stack without a Cloud control plane.
 ---
 
-# Single-Project Mode
+# Single-Environment Mode
 
-Single-project mode is the **zero-config** boot shape of `apps/objectos`
-(and any host using `@objectstack/service-cloud`'s standalone preset). It
-runs the entire stack — kernel + driver + REST + Studio — against a single
-named project, with no organization picker and no control-plane HTTP hops.
+Single-environment mode is the default boot shape for this repository's
+framework runtime and examples. One process owns one active environment, loads
+the configured metadata, and serves REST plus the published console bundle.
+There is no organization picker, hostname router, or Cloud control-plane hop.
 
-It is the default mode for:
+This is the mode used by:
 
-- `os dev` / `os serve` against a fresh project
-- `apps/objectos` deployed to Vercel / Fly with `OS_MODE` unset or `=standalone`
-- the docker example image in `apps/objectos/Dockerfile`
+- `pnpm dev`, `pnpm dev:showcase`, `pnpm dev:crm`, and `pnpm dev:todo`
+- `os dev`, `os start`, and `os serve` in a local app
+- `createStandaloneStack()` / `createDefaultHostConfig()` in
+  `@objectstack/runtime`
 
-For multi-tenant deployments use [Cloud Mode](./cloud-deployment) instead.
+Use [Deployment Modes](./cloud-deployment) when you need to publish to an
+ObjectStack Cloud control plane or test environment-scoped routing.
 
 ---
 
-## How it differs from cloud mode
+## How it differs from Cloud mode
 
-| Concern | Single-project | Cloud (multi-project) |
+| Concern | Single environment | Cloud-aware host |
 |:---|:---|:---|
-| Control plane | Same DB as the project, seeded with one `sys_organization` + one `sys_project` row | Separate `control.db` (or Turso) holding many projects |
-| Project resolution | Constant `proj_local` (or your override) | Per-request hostname → `sys_project.hostname` lookup |
-| Studio top-bar | No project / org switcher, no slash divider | Org switcher + project switcher visible |
-| `/api/v1/studio/runtime-config` | `{ singleProject: true, defaultOrgId, defaultProjectId }` | `{ singleProject: false }` |
-| Routes | Use the literal `PLATFORM_PROJECT_ID` constant | `/$projectId/...` patterns |
-| Per-project DB provisioning | n/a — one DB | Optional Turso provisioning via `TURSO_*` env vars |
-
----
-
-## Boot mode selection
-
-`OS_MODE` is the single source of truth:
-
-```bash
-# Default — same as unset
-OS_MODE=standalone
-
-# Multi-tenant control plane
-OS_MODE=cloud
-```
-
-Aliases: `local` and `single-project` map to `standalone`; `multi-project`
-maps to `cloud`. The legacy `OS_MULTI_PROJECT=true` flag still works as a
-deprecated alias and warns once at boot.
-
-> **Migrating from `OBJECTSTACK_*`.** All `OBJECTSTACK_*` env vars were
-> renamed to `OS_*` (see CHANGELOG). Old names are still accepted for one
-> release with a one-shot warning.
+| Active id | `OS_ENVIRONMENT_ID` or the runtime default | Resolved per request |
+| Routing | Direct `/api/v1/...` routes | Optional `/api/v1/environments/:environmentId/...`, hostname, header, or session |
+| Console | Served from `packages/console` / bundled ObjectUI | Same console can target a resolved environment |
+| Metadata source | Local stack config or compiled artifact | Published package/environment artifact and deployment config |
+| Control plane | Not part of this repo's default dev server | Lives in the Cloud distribution |
 
 ---
 
 ## Environment variables
 
 ```bash
-# Boot mode
-OS_MODE=standalone
+# Active environment identity
+OS_ENVIRONMENT_ID=env_local
 
-# Project identity (defaults shown)
-OS_PROJECT_ID=proj_local
-
-# Project DB
+# Business database
 OS_DATABASE_URL=file:./.objectstack/data/app.db
-OS_DATABASE_DRIVER=sqlite          # sqlite | turso | postgres
+OS_DATABASE_DRIVER=sqlite
 
-# Compiled artifact (optional — defaults to ./dist/objectstack.json)
+# Compiled artifact for `os serve` / standalone hosts
 OS_ARTIFACT_PATH=./dist/objectstack.json
 
-# Auth (required outside dev)
+# Auth, required outside dev
 AUTH_SECRET=<random 32-byte secret>
 ```
 
-The literal **`PLATFORM_PROJECT_ID`** is exported from
-`@objectstack/runtime` and equals `OS_PROJECT_ID` (or `proj_local`). Studio
-routes use it instead of a per-request param so links stay stable across
-boots.
+ObjectStack-owned variables use the `OS_` prefix. The old project-scoped names
+are not aliases in current docs or examples.
 
 ---
 
-## What `createSingleProjectPlugin()` does
+## Local commands
 
-`@objectstack/service-cloud` exports `createSingleProjectPlugin(options?)`
-which is registered last in the standalone plugin chain. It performs two
-jobs and nothing else:
+From the framework repo:
 
-1. **Idempotent identity seed.** On every boot it calls `ensureLocalIdentity()`
-   to upsert one `sys_organization` row (`org_local`) and one `sys_project`
-   row (`proj_local` by default) into the control-plane DB. After that,
-   `KernelManager` resolves the local project through the same code path
-   the cloud uses — single-project mode is *not* a separate kernel
-   factory.
-2. **Studio runtime-config.** Registers `GET /api/v1/studio/runtime-config`
-   returning `{ singleProject: true, defaultOrgId, defaultProjectId }`.
-   The Studio shell reads this once on load and conditionally hides the
-   project / org switchers and the slash divider.
+```bash
+PORT=3000 pnpm dev
+# showcase example, persistent state, console at /_console
 
-```typescript
-import { createSingleProjectPlugin } from '@objectstack/service-cloud';
-
-kernel.use(createSingleProjectPlugin({
-  orgId: 'org_local',
-  projectId: 'proj_local',
-  orgName: 'Local',
-  projectDatabaseUrl: 'file:./.objectstack/data/app.db',
-  projectDatabaseDriver: 'sqlite',
-}));
+pnpm dev:crm -- --fresh -p 38421
+# minimal CRM example with an ephemeral tempdir
 ```
 
-There is no synthetic `/cloud/projects` mock route — both modes serve
-real DB-backed records.
+From a generated app:
 
----
-
-## Project templates
-
-`apps/objectos/server/templates/` ships four ready-to-use templates that
-the provisioning seeder can fan out into a freshly-created project:
-
-| Id      | Source                | Notes |
-|:--------|:----------------------|:------|
-| `blank` | `blank.ts`            | Empty project — only platform objects |
-| `crm`   | `crm.ts`              | Loads the [HotCRM](https://github.com/objectstack-ai/hotcrm) bundle |
-| `todo`  | `todo.ts`             | Loads `examples/app-todo` bundle |
-| `extract` | `extract.ts`        | Reads from a local `dist/objectstack.json` (used by `os projects bind --artifact`) |
-
-Templates are lazy: each template's `load()` is only invoked when selected,
-so a Zod drift in one example bundle cannot crash control-plane bootstrap.
-List the registry:
-
-```typescript
-import { listTemplates, templateRegistry } from 'apps/objectos/server/templates/registry';
-listTemplates();           // -> [{ id, label, description, category }]
-templateRegistry['crm'];   // -> ProjectTemplate
+```bash
+os dev
+os start
+os serve --artifact ./dist/objectstack.json
 ```
 
-In **single-project mode** templates are not directly user-selectable
-(there is only one project). They are mostly relevant in cloud mode and
-for `os projects create --template crm`.
+The CLI forwards the active environment through `OS_ENVIRONMENT_ID` and, when
+needed, the `X-Environment-Id` request header.
 
 ---
 
-## Studio behaviour in single-project mode
+## Standalone runtime APIs
 
-`apps/studio/src/components/top-bar.tsx`:
+`@objectstack/runtime` exposes the standalone helpers used by the CLI:
 
-- The **project switcher** and **slash divider** are rendered only when
-  `runtime-config.singleProject === false`.
-- The **package switcher** is always visible and now supports clearing the
-  filter (the `×` button emits an "All packages" reset).
+```typescript
+import { createDefaultHostConfig, createStandaloneStack } from '@objectstack/runtime';
 
-`apps/studio/src/lib/config.ts` exposes `useRuntimeConfig()` so any
-component can branch on `singleProject` without re-fetching.
+const stack = createStandaloneStack({
+  environmentId: 'env_local',
+  artifactPath: './dist/objectstack.json',
+});
 
----
+const host = createDefaultHostConfig({
+  environmentId: 'env_local',
+  artifactPath: './dist/objectstack.json',
+});
+```
 
-## Limitations
-
-- No project-level isolation — every signed-in user sees the same data.
-- No org / member management UI (the `Setup → Organizations` page still
-  lists the seeded `Local` org but invitation flows are no-ops without a
-  real control plane).
-- Per-project DB provisioning (`Turso`) is disabled — `OS_DATABASE_URL`
-  hard-pins the one project DB.
-- Tenant boundaries are advisory; **do not** put production tenant data
-  behind single-project mode.
+These helpers are for one active environment. They do not create Cloud
+environments, provision databases, or mount a control plane.
 
 ---
 
 ## Related
 
-- [Cloud Deployment](./cloud-deployment) — multi-project + control plane
-- [Project Scoping](./project-scoping) — how `projectId` is propagated through requests
-- [`os` CLI reference](../getting-started/cli) — `os run` / `os serve` / `os studio` flags
+- [Environment-Scoped Routing](./project-scoping)
+- [Deployment Modes](./cloud-deployment)
+- [CLI reference](../getting-started/cli)

--- a/content/docs/guides/standards.mdx
+++ b/content/docs/guides/standards.mdx
@@ -316,24 +316,29 @@ export const MyFlow: Flow = {
 };
 ```
 
-### Workflow Rule Pattern
+### Flow Pattern
 
 ```typescript
-workflows: [
+flows: [
   {
-    name: 'workflow_name',
-    objectName: 'object_name',
-    triggerType: 'on_update',
-    criteria: 'ISCHANGED(field)',
-    actions: [
-      {
-        name: 'action_name',
-        type: 'field_update',
-        field: 'field_name',
-        value: 'value',
-      }
+    name: 'flow_name',
+    label: 'Flow Name',
+    type: 'record_change',
+    status: 'active',
+    trigger: {
+      objectName: 'object_name',
+      operations: ['update'],
+      condition: 'record.field != previous.field',
+    },
+    nodes: [
+      { id: 'start', type: 'start', label: 'Start' },
+      { id: 'update_record', type: 'update_record', label: 'Update Record' },
+      { id: 'end', type: 'end', label: 'End' },
     ],
-    active: true,
+    edges: [
+      { id: 'e1', source: 'start', target: 'update_record' },
+      { id: 'e2', source: 'update_record', target: 'end' },
+    ],
   }
 ]
 ```

--- a/content/docs/references/ai/solution-blueprint.mdx
+++ b/content/docs/references/ai/solution-blueprint.mdx
@@ -34,8 +34,8 @@ batch-draft. This is the safety valve for low-specificity input.
 ## TypeScript Usage
 
 ```typescript
-import { BlueprintApp, BlueprintDashboard, BlueprintField, BlueprintNavItem, BlueprintObject, BlueprintSeed, BlueprintView, SolutionBlueprint } from '@objectstack/spec/ai';
-import type { BlueprintApp, BlueprintDashboard, BlueprintField, BlueprintNavItem, BlueprintObject, BlueprintSeed, BlueprintView, SolutionBlueprint } from '@objectstack/spec/ai';
+import { BlueprintApp, BlueprintDashboard, BlueprintField, BlueprintNavItem, BlueprintObject, BlueprintSeed, BlueprintView, SolutionBlueprint, SolutionBlueprintStrict } from '@objectstack/spec/ai';
+import type { BlueprintApp, BlueprintDashboard, BlueprintField, BlueprintNavItem, BlueprintObject, BlueprintSeed, BlueprintView, SolutionBlueprint, SolutionBlueprintStrict } from '@objectstack/spec/ai';
 
 // Validate data
 const result = BlueprintApp.parse(data);
@@ -137,6 +137,7 @@ const result = BlueprintApp.parse(data);
 | **label** | `string` | optional | Human-readable view label |
 | **type** | `Enum<'list' \| 'form' \| 'kanban' \| 'calendar'>` | ✅ | View kind |
 | **columns** | `string[]` | optional | Field names shown as columns (in order) |
+| **groupBy** | `string` | optional | REQUIRED for kanban views: the select/status field whose options become the board columns (e.g. "stage", "status"). Without it a kanban renders as a plain list. |
 
 
 ---
@@ -155,6 +156,23 @@ const result = BlueprintApp.parse(data);
 | **dashboards** | `Object[]` | optional | Dashboards to create |
 | **app** | `Object` | optional | The navigation shell (app) that surfaces the created objects/dashboards to end users |
 | **seedData** | `Object[]` | optional | Suggested seed data (reported, not auto-applied in Phase C) |
+
+
+---
+
+## SolutionBlueprintStrict
+
+### Properties
+
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| **summary** | `string` | ✅ | One-line description of the proposed solution |
+| **assumptions** | `string[]` | ✅ | Design assumptions made from the underspecified goal |
+| **questions** | `string[] \| null` | ✅ | At most 1-2 structure-deciding questions to confirm before building, or null |
+| **objects** | `Object[]` | ✅ | Objects (tables) to create |
+| **views** | `Object[] \| null` | ✅ | Views to create, or null |
+| **dashboards** | `Object[] \| null` | ✅ | Dashboards to create, or null |
+| **app** | `Object \| null` | ✅ | The navigation shell (app) that surfaces the created objects/dashboards, or null |
 
 
 ---

--- a/content/docs/references/api/metadata.mdx
+++ b/content/docs/references/api/metadata.mdx
@@ -314,7 +314,7 @@ Metadata query with filtering, sorting, and pagination
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **types** | `Enum<'object' \| 'field' \| 'trigger' \| 'validation' \| 'hook' \| 'view' \| 'page' \| 'dashboard' \| 'app' \| 'action' \| 'report' \| 'flow' \| 'job' \| 'datasource' \| 'external_catalog' \| 'translation' \| 'router' \| 'function' \| 'service' \| 'email_template' \| 'permission' \| 'profile' \| 'role' \| 'agent' \| 'tool' \| 'skill'>[]` | optional | Filter by metadata types |
+| **types** | `Enum<'object' \| 'field' \| 'trigger' \| 'validation' \| 'hook' \| 'seed' \| 'view' \| 'page' \| 'dashboard' \| 'app' \| 'action' \| 'report' \| 'flow' \| 'job' \| 'datasource' \| 'external_catalog' \| 'translation' \| 'router' \| 'function' \| 'service' \| 'email_template' \| 'permission' \| 'profile' \| 'role' \| 'agent' \| 'tool' \| 'skill'>[]` | optional | Filter by metadata types |
 | **namespaces** | `string[]` | optional | Filter by namespaces |
 | **packageId** | `string` | optional | Filter by owning package |
 | **search** | `string` | optional | Full-text search query |
@@ -349,7 +349,7 @@ Metadata query with filtering, sorting, and pagination
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **type** | `Enum<'object' \| 'field' \| 'trigger' \| 'validation' \| 'hook' \| 'view' \| 'page' \| 'dashboard' \| 'app' \| 'action' \| 'report' \| 'flow' \| 'job' \| 'datasource' \| 'external_catalog' \| 'translation' \| 'router' \| 'function' \| 'service' \| 'email_template' \| 'permission' \| 'profile' \| 'role' \| 'agent' \| 'tool' \| 'skill'>` | ✅ | Metadata type |
+| **type** | `Enum<'object' \| 'field' \| 'trigger' \| 'validation' \| 'hook' \| 'seed' \| 'view' \| 'page' \| 'dashboard' \| 'app' \| 'action' \| 'report' \| 'flow' \| 'job' \| 'datasource' \| 'external_catalog' \| 'translation' \| 'router' \| 'function' \| 'service' \| 'email_template' \| 'permission' \| 'profile' \| 'role' \| 'agent' \| 'tool' \| 'skill'>` | ✅ | Metadata type |
 | **name** | `string` | ✅ | Item name (snake_case) |
 | **data** | `Record<string, any>` | ✅ | Metadata payload |
 | **namespace** | `string` | optional | Optional namespace |

--- a/content/docs/references/automation/execution.mdx
+++ b/content/docs/references/automation/execution.mdx
@@ -151,6 +151,9 @@ const result = Checkpoint.parse(data);
 | **output** | `Record<string, any>` | optional | Output data produced by the node |
 | **error** | `Object` | optional | Error details if step failed |
 | **retryAttempt** | `integer` | optional | Retry attempt number (0 = first try) |
+| **parentNodeId** | `string` | optional | Enclosing structured-region container node ID (loop/parallel/try_catch) |
+| **iteration** | `integer` | optional | Zero-based loop iteration or parallel branch index of the enclosing region |
+| **regionKind** | `string` | optional | Region kind the step ran in: loop-body | parallel-branch | try | catch |
 
 
 ---

--- a/content/docs/references/automation/node-executor.mdx
+++ b/content/docs/references/automation/node-executor.mdx
@@ -69,7 +69,7 @@ Canonical cross-paradigm action/node descriptor (ADR-0018)
 | **description** | `string` | optional | Action description |
 | **icon** | `string` | optional | Icon id resolved by the designer |
 | **category** | `Enum<'logic' \| 'data' \| 'io' \| 'human' \| 'control' \| 'custom'>` | ✅ | Palette category |
-| **paradigms** | `Enum<'flow' \| 'workflow_rule' \| 'approval'>[]` | ✅ | Authoring surfaces that may offer this action |
+| **paradigms** | `Enum<'flow' \| 'approval'>[]` | ✅ | Authoring surfaces that may offer this action |
 | **configSchema** | `any` | optional | JSON Schema for the node config (drives form + parse validation) |
 | **supportsPause** | `boolean` | ✅ | Supports async pause/resume |
 | **supportsCancellation** | `boolean` | ✅ | Supports cancellation |
@@ -90,7 +90,6 @@ Authoring paradigm that may offer this action
 ### Allowed Values
 
 * `flow`
-* `workflow_rule`
 * `approval`
 
 

--- a/content/docs/references/cloud/environment-artifact.mdx
+++ b/content/docs/references/cloud/environment-artifact.mdx
@@ -5,7 +5,7 @@ description: Environment Artifact protocol schemas
 
 {/* ⚠️  AUTO-GENERATED — DO NOT EDIT. Run build-docs.ts to regenerate. Hand-written docs go in content/docs/guides/. */}
 
-# Project Artifact Envelope (M1)
+# Environment Artifact Envelope (M1)
 
 Describes the response shape of `GET /api/v1/cloud/environments/:environmentId/artifact`
 

--- a/content/docs/references/data/dataset.mdx
+++ b/content/docs/references/data/dataset.mdx
@@ -16,8 +16,8 @@ Defines how the engine handles existing records.
 ## TypeScript Usage
 
 ```typescript
-import { Dataset, DatasetMode } from '@objectstack/spec/data';
-import type { Dataset, DatasetMode } from '@objectstack/spec/data';
+import { Dataset, DatasetMode, Seed } from '@objectstack/spec/data';
+import type { Dataset, DatasetMode, Seed } from '@objectstack/spec/data';
 
 // Validate data
 const result = Dataset.parse(data);
@@ -49,6 +49,21 @@ const result = Dataset.parse(data);
 * `upsert`
 * `replace`
 * `ignore`
+
+
+---
+
+## Seed
+
+### Properties
+
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| **object** | `string` | ✅ | Target Object Name |
+| **externalId** | `string` | ✅ | Field match for uniqueness check |
+| **mode** | `Enum<'insert' \| 'update' \| 'upsert' \| 'replace' \| 'ignore'>` | ✅ | Conflict resolution strategy |
+| **env** | `Enum<'prod' \| 'dev' \| 'test'>[]` | ✅ | Applicable environments |
+| **records** | `Record<string, any>[]` | ✅ | Data records |
 
 
 ---

--- a/content/docs/references/data/driver.mdx
+++ b/content/docs/references/data/driver.mdx
@@ -57,6 +57,7 @@ const result = DriverCapabilities.parse(data);
 | **jsonFields** | `boolean` | ✅ | Supports JSON field types |
 | **arrayFields** | `boolean` | ✅ | Supports array field types |
 | **vectorSearch** | `boolean` | ✅ | Supports vector embeddings and similarity search |
+| **autonumber** | `boolean` | optional | Driver natively generates persistent autonumber/sequence values |
 | **schemaSync** | `boolean` | ✅ | Supports automatic schema synchronization |
 | **batchSchemaSync** | `boolean` | ✅ | Supports batched schema sync to reduce schema DDL round-trips |
 | **migrations** | `boolean` | ✅ | Supports database migrations |

--- a/content/docs/references/kernel/metadata-plugin.mdx
+++ b/content/docs/references/kernel/metadata-plugin.mdx
@@ -130,7 +130,7 @@ const result = MetadataBulkRegisterRequest.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **event** | `Enum<'metadata.registered' \| 'metadata.updated' \| 'metadata.unregistered' \| 'metadata.validated' \| 'metadata.deployed' \| 'metadata.overlay.applied' \| 'metadata.overlay.removed' \| 'metadata.imported' \| 'metadata.exported'>` | ✅ | Event type |
-| **metadataType** | `Enum<'object' \| 'field' \| 'trigger' \| 'validation' \| 'hook' \| 'view' \| 'page' \| 'dashboard' \| 'app' \| 'action' \| 'report' \| 'flow' \| 'job' \| 'datasource' \| 'external_catalog' \| 'translation' \| 'router' \| 'function' \| 'service' \| 'email_template' \| 'permission' \| 'profile' \| 'role' \| 'agent' \| 'tool' \| 'skill'>` | ✅ | Metadata type |
+| **metadataType** | `Enum<'object' \| 'field' \| 'trigger' \| 'validation' \| 'hook' \| 'seed' \| 'view' \| 'page' \| 'dashboard' \| 'app' \| 'action' \| 'report' \| 'flow' \| 'job' \| 'datasource' \| 'external_catalog' \| 'translation' \| 'router' \| 'function' \| 'service' \| 'email_template' \| 'permission' \| 'profile' \| 'role' \| 'agent' \| 'tool' \| 'skill'>` | ✅ | Metadata type |
 | **name** | `string` | ✅ | Metadata item name |
 | **namespace** | `string` | optional | Namespace |
 | **packageId** | `string` | optional | Owning package ID |
@@ -147,7 +147,7 @@ const result = MetadataBulkRegisterRequest.parse(data);
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **types** | `Enum<'object' \| 'field' \| 'trigger' \| 'validation' \| 'hook' \| 'view' \| 'page' \| 'dashboard' \| 'app' \| 'action' \| 'report' \| 'flow' \| 'job' \| 'datasource' \| 'external_catalog' \| 'translation' \| 'router' \| 'function' \| 'service' \| 'email_template' \| 'permission' \| 'profile' \| 'role' \| 'agent' \| 'tool' \| 'skill'>[]` | optional | Filter by metadata types |
+| **types** | `Enum<'object' \| 'field' \| 'trigger' \| 'validation' \| 'hook' \| 'seed' \| 'view' \| 'page' \| 'dashboard' \| 'app' \| 'action' \| 'report' \| 'flow' \| 'job' \| 'datasource' \| 'external_catalog' \| 'translation' \| 'router' \| 'function' \| 'service' \| 'email_template' \| 'permission' \| 'profile' \| 'role' \| 'agent' \| 'tool' \| 'skill'>[]` | optional | Filter by metadata types |
 | **namespaces** | `string[]` | optional | Filter by namespaces |
 | **packageId** | `string` | optional | Filter by owning package |
 | **search** | `string` | optional | Full-text search query |
@@ -185,6 +185,7 @@ const result = MetadataBulkRegisterRequest.parse(data);
 * `trigger`
 * `validation`
 * `hook`
+* `seed`
 * `view`
 * `page`
 * `dashboard`

--- a/content/docs/references/system/environment-artifact.mdx
+++ b/content/docs/references/system/environment-artifact.mdx
@@ -5,19 +5,19 @@ description: Environment Artifact protocol schemas
 
 {/* ⚠️  AUTO-GENERATED — DO NOT EDIT. Run build-docs.ts to regenerate. Hand-written docs go in content/docs/guides/. */}
 
-# Project Artifact Format Protocol (v0)
+# Environment Artifact Format Protocol (v0)
 
 Defines the immutable envelope produced by `objectstack compile` and consumed
 
 by ObjectOS at boot. The artifact carries everything an ObjectOS instance
 
-needs to hydrate a project kernel without reading control-plane DB rows
+needs to hydrate an environment kernel without reading control-plane DB rows
 
 directly.
 
 ## Boundary
 
-- **Artifact (this schema):** project metadata + inlined function code +
+- **Artifact (this schema):** environment metadata + inlined function code +
 
 plugin/driver requirements. Immutable, content-addressable via `commitId`
 
@@ -25,7 +25,7 @@ and `checksum`.
 
 - **Deployment Config (NOT in this schema):** business DB coordinates,
 
-credentials, project identity, secrets. Injected at runtime.
+credentials, environment identity, secrets. Injected at runtime.
 
 See [content/docs/concepts/north-star.mdx](content/docs/concepts/north-star.mdx) §6.3 for the runtime-inputs
 
@@ -59,19 +59,19 @@ const result = EnvironmentArtifact.parse(data);
 
 ## EnvironmentArtifact
 
-ObjectStack Project Artifact envelope (v0)
+ObjectStack Environment Artifact envelope (v0)
 
 ### Properties
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **schemaVersion** | `string` | ✅ | Project artifact envelope schema version |
-| **environmentId** | `string` | ✅ | Project identifier (control-plane scoped) |
+| **schemaVersion** | `string` | ✅ | Environment artifact envelope schema version |
+| **environmentId** | `string` | ✅ | Environment identifier (control-plane scoped) |
 | **commitId** | `string` | ✅ | Content-addressable revision id |
 | **checksum** | `Object` | ✅ | Artifact integrity checksum |
 | **builtAt** | `string` | optional | ISO-8601 timestamp of when the artifact was built |
 | **builtWith** | `string` | optional | Build tool identifier |
-| **metadata** | `Record<string, any>` | ✅ | Compiled project metadata grouped by category |
+| **metadata** | `Record<string, any>` | ✅ | Compiled environment metadata grouped by category |
 | **functions** | `Object[]` | ✅ | Inlined function code packaged with the artifact |
 | **manifest** | `Object` | ✅ | Plugin/driver requirements baked into the artifact |
 | **payloadRef** | `Object` | optional | Out-of-band payload reference (reserved for future use) |
@@ -152,7 +152,7 @@ Plugin/driver requirements baked into the artifact
 
 ## EnvironmentArtifactMetadata
 
-Compiled project metadata grouped by category
+Compiled environment metadata grouped by category
 
 ### Properties
 
@@ -208,7 +208,7 @@ A plugin or driver dependency declaration
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **id** | `string` | ✅ | Plugin/driver package id |
-| **version** | `string` | optional | SemVer range required by the project |
+| **version** | `string` | optional | SemVer range required by the environment |
 
 
 ---

--- a/content/docs/references/ui/action.mdx
+++ b/content/docs/references/ui/action.mdx
@@ -48,12 +48,28 @@ to the field name and is used as the request-body key).
 ## TypeScript Usage
 
 ```typescript
-import { ActionLocation, ActionParam, ActionType } from '@objectstack/spec/ui';
-import type { ActionLocation, ActionParam, ActionType } from '@objectstack/spec/ui';
+import { ActionAi, ActionLocation, ActionParam, ActionType } from '@objectstack/spec/ui';
+import type { ActionAi, ActionLocation, ActionParam, ActionType } from '@objectstack/spec/ui';
 
 // Validate data
-const result = ActionLocation.parse(data);
+const result = ActionAi.parse(data);
 ```
+
+---
+
+## ActionAi
+
+### Properties
+
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| **exposed** | `boolean` | ✅ | Expose this action to AI agents. Requires `description` when true. |
+| **description** | `string` | optional | LLM-facing description (≥40 chars). Required when exposed. |
+| **category** | `Enum<'data' \| 'action' \| 'flow' \| 'integration' \| 'vector_search' \| 'analytics' \| 'utility'>` | optional | Tool category override (defaults to "action"). |
+| **paramHints** | `Record<string, Object>` | optional | Per-parameter AI hints keyed by param name. |
+| **outputSchema** | `Record<string, any>` | optional | JSON Schema for the action return value. |
+| **requiresConfirmation** | `boolean` | optional | Override HITL confirmation for AI invocations. |
+
 
 ---
 

--- a/docs/design/notification-platform-convergence.md
+++ b/docs/design/notification-platform-convergence.md
@@ -4,13 +4,14 @@
 **Refines/realizes**: [ADR-0012](../adr/0012-notification-platform.md) · **Channels on connectors**: [ADR-0022](../adr/0022-connectors-vs-messaging-channels.md)
 **Audience**: the implementing agent. This is the executable spec; ADR-0030 holds the *why*.
 
-> **Status (2026-06-01):** P0, P1, P2, P3a, and **P3b-1 (quiet-hours) are shipped**
-> (PRs #1434/#1441/#1444/#1449/#1453). The §4 checklists below are the original
+> **Status (2026-06-01):** P0, P1, P2, P3a, **P3b-1 (quiet-hours)**, and
+> **P3b-2 (digest collapse)** are shipped (PRs #1434/#1441/#1444/#1449/#1453 plus
+> the digest follow-up). The §4 checklists below are the original
 > plan — for the current done/remaining breakdown see
 > [ADR-0030 § Implementation status & remaining work](../adr/0030-notification-platform-convergence.md#implementation-status--remaining-work)
 > and [docs/handoff/adr-0030-notification-convergence.md](../handoff/adr-0030-notification-convergence.md).
-> **Remaining:** P3b-2 (digest), the cross-repo objectui bell cut-over +
-> mark-read write path, and the incremental channels / hardening items.
+> **Remaining:** the cross-repo objectui bell cut-over + mark-read write path,
+> incremental channels, topic catalog, and hardening items.
 
 ---
 

--- a/docs/handoff/adr-0030-notification-convergence.md
+++ b/docs/handoff/adr-0030-notification-convergence.md
@@ -2,7 +2,9 @@
 
 **ADR**: [0030 — Notification Platform Convergence](../adr/0030-notification-platform-convergence.md)
 **Build spec**: [notification-platform-convergence.md](../design/notification-platform-convergence.md)
-**Status of this handoff**: P0 **framework side** shipped. The **objectui** (Console bell) cut-over and phases P1–P3 remain. Date: 2026-06-01.
+**Status of this handoff**: Framework P0–P3b2 shipped. The **objectui**
+(Console bell) cut-over, mark-read write path, incremental channels, topic
+catalog, and hardening remain. Date: 2026-06-01.
 
 ---
 
@@ -172,12 +174,11 @@ flipped — the inbox is being populated the whole time.)
     (`quietHoursDeferral`, HH:MM in tz, overnight-aware). critical bypasses.
     (tz currently from `quiet_hours.tz` → UTC; `sys_user` tz fallback is a
     follow-up.)
-  - **P3b-2 — digest**: pending. Builds on the same deferral: enqueue digest
-    items to the next window, then a **collapse** step merges same-`(user,
-    channel, window)` rows into one materialization at window time (needs a
-    `digest_key` on the delivery row + a digest assembler in/beside the
-    dispatcher + a digest render template). critical/mandatory bypass. Consumes
-    P2's `digest` field.
+  - **P3b-2 — digest**: ✅ shipped. `PreferenceResolver` defers digest items to
+    the next window, deliveries carry `digest_key`, normal claims skip digest
+    rows, and the dispatcher collapses same-`(recipient, channel, window)` rows
+    into one rendered message under the partition lock. critical/mandatory
+    bypass.
   - **Deferred (same seam, incremental)**: **Slack** stays a *connector*
     (`connector-slack` ships the raw API path today); a Slack notification
     *channel* needs identity mapping (`sys_channel_user_link`) + OAuth and is

--- a/packages/spec/PROTOCOL_MAP.md
+++ b/packages/spec/PROTOCOL_MAP.md
@@ -58,9 +58,9 @@ This document serves as the **Grand Map** of the ObjectStack specification. It l
 
 | File | Status | Description |
 | :--- | :--- | :--- |
-| [`workflow.zod.ts`](src/automation/workflow.zod.ts) | ⭐ | **Workflow Rules**. Event-driven automation (if this then that). |
+| [`state-machine.zod.ts`](src/automation/state-machine.zod.ts) | ⭐ | **State Machines**. Strict lifecycle transitions and guards. |
 | [`flow.zod.ts`](src/automation/flow.zod.ts) | ⭐ | **Visual Flow**. Complex orchestration logic (decisions, loops, CRUD). |
-| [`approval.zod.ts`](src/automation/approval.zod.ts) | ⭐ | **Approval Process**. Multi-step approval workflows. |
+| [`approval.zod.ts`](src/automation/approval.zod.ts) | ⭐ | **Approval Node**. Flow node config for human approval pauses. |
 | [`webhook.zod.ts`](src/automation/webhook.zod.ts) | ⭐ | **Webhooks**. Outbound HTTP notification configuration. |
 | [`trigger-registry.zod.ts`](src/automation/trigger-registry.zod.ts) | | **Trigger Registry**. Central registry for all automation triggers. |
 | [`etl.zod.ts`](src/automation/etl.zod.ts) | | **ETL Jobs**. Extract-Transform-Load definitions. |

--- a/packages/spec/src/api/plugin-rest-api.zod.ts
+++ b/packages/spec/src/api/plugin-rest-api.zod.ts
@@ -1129,7 +1129,7 @@ export const DEFAULT_WORKFLOW_ROUTES: RestApiRouteRegistration = {
       category: 'workflow',
       public: false,
       summary: 'Get workflow configuration',
-      description: 'Returns workflow rules and state machine configuration for an object',
+      description: 'Returns flow, approval-node, and state machine configuration for an object',
       tags: ['Workflow'],
       responseSchema: 'GetWorkflowConfigResponseSchema',
       cacheable: true,

--- a/packages/spec/src/automation/node-executor.zod.ts
+++ b/packages/spec/src/automation/node-executor.zod.ts
@@ -189,8 +189,8 @@ export type ActionCategory = z.infer<typeof ActionCategorySchema>;
  */
 export const ActionParadigmSchema = lazySchema(() => z.enum([
   'flow',           // visual Flow canvas
-  'approval',       // Approval Process steps
-  // 'workflow_rule' retired (ADR-0018 M5 dropped; see ADR-0019): Workflow Rules
+  'approval',       // Approval flow-node steps
+  // 'workflow_rule' retired (ADR-0018 M5 dropped; see ADR-0019): workflow rules
   // were removed in #1398 and `workflow` was reclaimed for state machines, so
   // there is no declarative rule authoring view to compile to Flow.
 ]).describe('Authoring paradigm that may offer this action'));
@@ -204,7 +204,7 @@ export type ActionParadigm = z.infer<typeof ActionParadigmSchema>;
  * shape a plugin publishes when it registers an executor. It supersedes the
  * closed enums (`FlowNodeAction`, `WorkflowAction`), which become *seed*
  * descriptor sets registered at boot. (ADR-0019 removed the third such enum,
- * `ApprovalActionType`, along with the standalone approval process type.)
+ * `ApprovalActionType`, along with the standalone approval authoring type.)
  *
  * The runtime registry (`AutomationEngine.getActionDescriptors()`) aggregates
  * these and backs both:

--- a/packages/spec/src/cloud/environment-artifact.zod.ts
+++ b/packages/spec/src/cloud/environment-artifact.zod.ts
@@ -5,7 +5,7 @@ import { lazySchema } from '../shared/lazy-schema';
 import { ObjectStackDefinitionSchema } from '../stack.zod';
 
 /**
- * # Project Artifact Envelope (M1)
+ * # Environment Artifact Envelope (M1)
  *
  * Describes the response shape of `GET /api/v1/cloud/environments/:environmentId/artifact`
  * — the assembled artifact ObjectOS pulls from the control plane.
@@ -29,7 +29,7 @@ export const EnvironmentArtifactSchema = lazySchema(() => z.object({
   /** Envelope format version. Increment on breaking changes. */
   schemaVersion: z.literal('0.1').default('0.1'),
 
-  /** Control-plane project ID this artifact belongs to. */
+  /** Control-plane environment ID this artifact belongs to. */
   environmentId: z.string(),
 
   /** Metadata revision assigned by the control plane on publish. */

--- a/packages/spec/src/system/environment-artifact.zod.ts
+++ b/packages/spec/src/system/environment-artifact.zod.ts
@@ -3,20 +3,20 @@
 import { z } from 'zod';
 
 /**
- * # Project Artifact Format Protocol (v0)
+ * # Environment Artifact Format Protocol (v0)
  *
  * Defines the immutable envelope produced by `objectstack compile` and consumed
  * by ObjectOS at boot. The artifact carries everything an ObjectOS instance
- * needs to hydrate a project kernel without reading control-plane DB rows
+ * needs to hydrate an environment kernel without reading control-plane DB rows
  * directly.
  *
  * ## Boundary
  *
- * - **Artifact (this schema):** project metadata + inlined function code +
+ * - **Artifact (this schema):** environment metadata + inlined function code +
  *   plugin/driver requirements. Immutable, content-addressable via `commitId`
  *   and `checksum`.
  * - **Deployment Config (NOT in this schema):** business DB coordinates,
- *   credentials, project identity, secrets. Injected at runtime.
+ *   credentials, environment identity, secrets. Injected at runtime.
  *
  * See {@link content/docs/concepts/north-star.mdx} §6.3 for the runtime-inputs
  * boundary, and {@link ROADMAP.md} M1 for the milestone definition.
@@ -127,7 +127,7 @@ export type EnvironmentArtifactFunction = z.infer<typeof EnvironmentArtifactFunc
 
 /**
  * Plugin/driver requirement entry. ObjectOS uses these to verify that the
- * runtime has every plugin the project depends on before hydrating the kernel.
+ * runtime has every plugin the environment depends on before hydrating the kernel.
  * Configuration values live in **Deployment Config**, not in the artifact.
  */
 export const EnvironmentArtifactRequirementSchema = z
@@ -135,24 +135,24 @@ export const EnvironmentArtifactRequirementSchema = z
     /** Package id (reverse-domain or short id). */
     id: z.string().describe('Plugin/driver package id'),
 
-    /** SemVer range required by the project. */
-    version: z.string().optional().describe('SemVer range required by the project'),
+    /** SemVer range required by the environment. */
+    version: z.string().optional().describe('SemVer range required by the environment'),
   })
   .describe('A plugin or driver dependency declaration');
 
 export type EnvironmentArtifactRequirement = z.infer<typeof EnvironmentArtifactRequirementSchema>;
 
 /**
- * Project-level manifest captured inside the artifact. Mirrors the parts of
+ * Environment-level manifest captured inside the artifact. Mirrors the parts of
  * the package manifest the runtime needs to bootstrap; user-facing manifest
  * fields (description, icon, marketplace metadata) are excluded.
  */
 export const EnvironmentArtifactManifestSchema = z
   .object({
-    /** Plugins required to run this project's metadata. */
+    /** Plugins required to run this environment's metadata. */
     plugins: z.array(EnvironmentArtifactRequirementSchema).optional(),
 
-    /** Drivers required to run this project's metadata. */
+    /** Drivers required to run this environment's metadata. */
     drivers: z.array(EnvironmentArtifactRequirementSchema).optional(),
 
     /** Minimum platform version (mirrors `Manifest.engine`). */
@@ -209,7 +209,7 @@ export const EnvironmentArtifactMetadataSchema = z
     apis: z.array(z.unknown()).optional(),
   })
   .passthrough()
-  .describe('Compiled project metadata grouped by category');
+  .describe('Compiled environment metadata grouped by category');
 
 export type EnvironmentArtifactMetadata = z.infer<typeof EnvironmentArtifactMetadataSchema>;
 
@@ -240,15 +240,15 @@ export type EnvironmentArtifactPayloadRef = z.infer<typeof EnvironmentArtifactPa
 // ==========================================
 
 /**
- * Project Artifact envelope.
+ * Environment Artifact envelope.
  *
- * Produced by `objectstack compile`, served by the Project Artifact API
+ * Produced by `objectstack compile`, served by the Environment Artifact API
  * (`GET /api/v1/cloud/environments/:environmentId/artifact`), and consumed by the
- * ObjectOS metadata loader to hydrate a project kernel.
+ * ObjectOS metadata loader to hydrate an environment kernel.
  *
  * Required fields (v0):
  * - `schemaVersion`: tracks the envelope itself.
- * - `environmentId`: which project this artifact belongs to.
+ * - `environmentId`: which environment this artifact belongs to.
  * - `commitId`: monotonic, content-addressable identifier; cache key.
  * - `checksum`: integrity check over the artifact body.
  * - `metadata`: compiled metadata grouped by category.
@@ -264,10 +264,10 @@ export const EnvironmentArtifactSchema = z
     /** Envelope schema version. Currently always `'0.1'`. */
     schemaVersion: z
       .literal(ENVIRONMENT_ARTIFACT_SCHEMA_VERSION)
-      .describe('Project artifact envelope schema version'),
+      .describe('Environment artifact envelope schema version'),
 
-    /** Stable project identifier from the control plane. */
-    environmentId: z.string().min(1).describe('Project identifier (control-plane scoped)'),
+    /** Stable environment identifier from the control plane. */
+    environmentId: z.string().min(1).describe('Environment identifier (control-plane scoped)'),
 
     /**
      * Monotonic, content-addressable revision id assigned by the control plane
@@ -289,10 +289,10 @@ export const EnvironmentArtifactSchema = z
     /** Build tool identifier (e.g. `"objectstack-cli@3.4.0"`). */
     builtWith: z.string().optional().describe('Build tool identifier'),
 
-    /** Compiled project metadata grouped by category. */
+    /** Compiled environment metadata grouped by category. */
     metadata: EnvironmentArtifactMetadataSchema,
 
-    /** Inlined function code. Empty array if the project has no functions. */
+    /** Inlined function code. Empty array if the environment has no functions. */
     functions: z
       .array(EnvironmentArtifactFunctionSchema)
       .default([])
@@ -304,7 +304,7 @@ export const EnvironmentArtifactSchema = z
     /** Out-of-band payload reference (reserved). */
     payloadRef: EnvironmentArtifactPayloadRefSchema.optional(),
   })
-  .describe('ObjectStack Project Artifact envelope (v0)');
+  .describe('ObjectStack Environment Artifact envelope (v0)');
 
 export type EnvironmentArtifact = z.infer<typeof EnvironmentArtifactSchema>;
 export type EnvironmentArtifactInput = z.input<typeof EnvironmentArtifactSchema>;


### PR DESCRIPTION
## Summary
- align docs with environment-scoped runtime terminology and current repo layout
- update automation, AI action exposure, master-detail, summary rollup, and notification status docs
- regenerate reference docs from updated spec descriptions

## Verification
- pnpm --filter @objectstack/spec gen:docs
- pnpm docs:build