### PR TITLE
feat(spec): add relatedList field flags (read-side mirror of inlineEdit)

### DIFF
--- a/docs/adr/0035-config-driven-master-detail.md
+++ b/docs/adr/0035-config-driven-master-detail.md
@@ -74,6 +74,34 @@ through the transactional batch.
   `master_detail` (cascade delete) but are associations, not line items, and
   must stay out of the parent's create form (surface as related lists).
 
+### Read-side mirror: detail-page related lists
+
+Inline editing is the **write** side — the child pulled *into* the parent's
+entry form. Its read-side counterpart is the **related list** on the parent's
+record detail page. Both intents live on the same relationship:
+
+| Side | Flag (on the child's FK field) | Effect |
+|---|---|---|
+| Write | `inlineEdit: true` | child rendered as an editable grid inside the parent's create/edit form (atomic save) |
+| Read | `relatedList` (+ `relatedListTitle` / `relatedListColumns`) | child rendered as a related list on the parent's detail page |
+
+Related lists are **shown by default** for every child relationship
+(`master_detail` and `lookup`) — owned (`master_detail`) children are ordered
+first. The flag is opt-*out*: set `relatedList: false` to suppress a noisy
+association/audit link from the detail page. `relatedListTitle` /
+`relatedListColumns` override the derived title / columns. Audit FKs
+(`created_by` / `updated_by` / `owner_id`) are skipped and children deduped to
+one related list each (first eligible FK wins).
+
+The derivation is a pure function — `deriveRelatedLists(objectDef, objects)` in
+`@object-ui/app-shell` (`utils/deriveRelatedLists.ts`) — the read-side analogue
+of `attachInlineSubforms`. `RecordDetailView` feeds its output into the
+synthesized page's `record:related_list` renderers (and the legacy
+`DetailView.related`), so both render paths surface the same relationship-derived
+lists with no page config. Per-object coarse switches
+(`detail.showReferenceRail` / `hideReferenceRail` / `hideRelatedTab`) still
+apply on top.
+
 ### Runtime backbone (relied upon, not re-litigated here)
 
 - **Atomic write**: parent + children in one `POST /api/v1/batch`; intra-batch
@@ -105,8 +133,10 @@ inside their envelope and suppress their own footer (the form owns its Save).
 - **Safe by default**: opt-in per relationship avoids inlining associations.
 - **Escape hatches preserved**: `subforms` (view) overrides; a page block handles
   bespoke layouts; explicit `relationshipField`/`columns` override derivation.
-- **Read/view mode** is unaffected — inline editing applies to create/edit forms;
-  detail pages use related lists.
+- **Read/view mode mirrors the write side** — inline editing applies to
+  create/edit forms; the parent's detail page auto-derives related lists from the
+  same relationships (`relatedList` opt-out + `relatedListTitle`/`relatedListColumns`
+  overrides). No detail-page config for the common case.
 
 ## Status of implementation
 
@@ -117,3 +147,8 @@ RecordFormPage/ObjectView; `attachInlineSubforms`; server-side `summary` rollup;
 atomic `/api/v1/batch` with `$ref`. Covered by unit tests and live browser e2e
 (`e2e/live/master-detail.spec.ts`, `form-view-subforms.spec.ts`,
 `summary-rollup.spec.ts`).
+
+Read-side mirror shipped: spec `field.relatedList` (+ `relatedListTitle`/
+`relatedListColumns`); `deriveRelatedLists` pure helper (unit-tested) wired into
+`RecordDetailView` for both the synthesized and legacy detail paths; showcase
+demonstrates a zero-config Projects related list on the Account detail page.

--- a/examples/app-showcase/src/objects/project.object.ts
+++ b/examples/app-showcase/src/objects/project.object.ts
@@ -17,7 +17,17 @@ export const Project = ObjectSchema.create({
 
   fields: {
     name: Field.text({ label: 'Project Name', required: true, searchable: true, maxLength: 200 }),
-    account: Field.lookup('showcase_account', { label: 'Account', required: true }),
+    // `relatedList*` is the read-side mirror of inline editing: the Account's
+    // record DETAIL page auto-renders a "Projects" related list — derived from
+    // this lookup relationship, with no page config. Title and columns are
+    // declared here on the relationship (where AI authors the model), not in a
+    // hand-built page.
+    account: Field.lookup('showcase_account', {
+      label: 'Account',
+      required: true,
+      relatedListTitle: 'Projects',
+      relatedListColumns: ['name', 'status', 'health', 'budget', 'end_date'],
+    }),
     status: Field.select({
       label: 'Status',
       required: true,

--- a/examples/app-showcase/src/objects/task.object.ts
+++ b/examples/app-showcase/src/objects/task.object.ts
@@ -27,8 +27,17 @@ export const Task = ObjectSchema.create({
     // `inlineEdit` declares (in the data model) that tasks are entered inline
     // within their project's form — so the standard New/Edit Project form
     // auto-renders an atomic Tasks subtable, with no form view config and no
-    // bespoke page.
-    project: Field.masterDetail('showcase_project', { label: 'Project', required: true, inlineEdit: true, inlineTitle: 'Tasks' }),
+    // bespoke page. `relatedList*` is the read-side mirror: the Project's
+    // record DETAIL page auto-renders a Tasks related list, with a focused
+    // column set — again, derived from the relationship, no page config.
+    project: Field.masterDetail('showcase_project', {
+      label: 'Project',
+      required: true,
+      inlineEdit: true,
+      inlineTitle: 'Tasks',
+      relatedListTitle: 'Tasks',
+      relatedListColumns: ['title', 'status', 'priority', 'assignee', 'due_date'],
+    }),
     assignee: Field.text({ label: 'Assignee', maxLength: 200 }),
     status: Field.select({
       label: 'Status',

--- a/packages/spec/src/data/field.zod.ts
+++ b/packages/spec/src/data/field.zod.ts
@@ -421,6 +421,24 @@ export const FieldSchema = lazySchema(() => z.object({
   /** Optional numeric child field summed for the inline grid running total. */
   inlineAmountField: z.string().optional().describe('Numeric child field summed for the inline grid total'),
 
+  /**
+   * Detail-page RELATED LIST — the read-side mirror of `inlineEdit`. On a
+   * child's `master_detail`/`lookup` field (whose `reference` is the parent),
+   * this governs whether/how the child collection appears as a related list on
+   * the parent's record DETAIL page. Owned children (`master_detail`) and
+   * `lookup` children are shown by default (derived from the relationship);
+   * set `relatedList: false` to suppress a child from the detail page (e.g.
+   * noisy audit/association links you don't want surfaced). Where `inlineEdit`
+   * pulls a child INTO the parent's entry form (write side), `relatedList`
+   * controls its appearance on the parent's detail page (read side). The intent
+   * lives here in the data model; the detail page derives the UI.
+   */
+  relatedList: z.boolean().optional().describe('Show this child collection as a related list on the parent\'s detail page (read-side mirror of inlineEdit). Defaults to shown for master_detail/lookup; set false to suppress.'),
+  /** Optional section title for the detail-page related list (defaults to the child object label). */
+  relatedListTitle: z.string().optional().describe('Title for the detail-page related list'),
+  /** Optional explicit columns for the detail-page related list (derived from the child object when omitted). */
+  relatedListColumns: z.array(z.any()).optional().describe('Explicit columns for the detail-page related list (derived from the child object when omitted)'),
+
   /** Calculation — CEL formula. Plain string accepted for back-compat; build emits canonical envelope. */
   expression: ExpressionInputSchema.optional().describe('Formula expression (CEL). e.g. F`record.amount * 0.1`'),
   summaryOperations: z.object({

--- a/skills/objectstack-data/rules/relationships.md
+++ b/skills/objectstack-data/rules/relationships.md
@@ -230,6 +230,38 @@ A form view may still set `subforms` to override the derived columns/order, but
 the relationship `inlineEdit` is the primary, zero-config path. See the
 objectstack-ui skill (Master-Detail Forms) for the rendering side.
 
+### Detail-page related lists (the read-side mirror)
+
+Where `inlineEdit` is the **write** side (child pulled into the parent's entry
+form), the **related list** on the parent's record detail page is the **read**
+side. You usually don't declare it: every child relationship
+(`master_detail` and `lookup`) is shown as a related list on the parent's detail
+page **by default** — owned (`master_detail`) children first. The relationship
+flags exist to *refine* that:
+
+```typescript
+// On the CHILD object's FK field:
+project: {
+  type: 'master_detail',
+  reference: 'project',
+  inlineEdit: true,                 // write side: edit inline in the Project form
+  relatedListTitle: 'Tasks',        // read side: title of the detail-page list
+  relatedListColumns: ['title', 'status', 'priority', 'due_date'],
+},
+
+// Suppress a noisy association from the detail page entirely:
+audit_ref: { type: 'master_detail', reference: 'invoice', relatedList: false },
+```
+
+- `relatedList: false` — suppress this child from the parent's detail page
+  (use for chatty association/log children you don't want surfaced).
+- `relatedListTitle` / `relatedListColumns` — override the derived title /
+  columns (columns are otherwise auto-derived from the child object's fields).
+
+Audit FKs (`created_by`/`updated_by`/`owner_id`) never become related lists, and
+each child object yields at most one related list. See the objectstack-ui skill
+for the rendering side.
+
 ## Incorrect vs Correct
 
 ### ❌ Incorrect — Using lookup When master_detail is Needed

--- a/skills/objectstack-ui/SKILL.md
+++ b/skills/objectstack-ui/SKILL.md
@@ -99,6 +99,15 @@ The relationship FK and grid columns are derived from the child object's
 metadata in every case; select options and lookups carry through. A parent
 `summary` field rolls child values up server-side (see objectstack-data).
 
+**Read side — detail-page related lists.** The mirror of `inlineEdit` is the
+related list on the parent's record DETAIL page. You don't author it: every
+child relationship is shown as a related list by default (owned `master_detail`
+children first). Refine on the relationship — `relatedList: false` to suppress a
+noisy child, `relatedListTitle` / `relatedListColumns` to override title /
+columns (see objectstack-data → Relationships → Detail-page related lists).
+Authored record pages can still place an explicit `record:related_list` (or
+inline-editable `record:line_items`) when they need bespoke placement.
+
 ---
 
 ## Configuring a List View


### PR DESCRIPTION
## Summary

A child's `master_detail`/`lookup` FK can now declare how it appears as a **related list** on the parent's record detail page — the read-side counterpart to `inlineEdit` (which pulls the child into the parent's entry form).

- `relatedList: false` — suppress a child from the detail page (noisy association/audit links); related lists are otherwise shown by default.
- `relatedListTitle` / `relatedListColumns` — override the derived title/columns.

## Changes
- `packages/spec/src/data/field.zod.ts`: add `relatedList`, `relatedListTitle`, `relatedListColumns` (mirroring `inlineEdit`/`inlineTitle`/`inlineColumns`).
- Showcase: `showcase_project.account` declares `relatedListTitle: 'Projects'` + columns → the Account detail page auto-renders a Projects related list with no page config; `showcase_task.project` mirrors its `inlineEdit` with `relatedList*`.
- Docs: ADR-0035 gains a read-side section; `objectstack-data` (Relationships) and `objectstack-ui` (Master-Detail Forms) skills document `relatedList` as the mirror of `inlineEdit`.

## Verification
- `@objectstack/spec` rebuilt; field tests 6647 ✓
- app-showcase typecheck clean (only pre-existing page.ts errors unrelated to this change)
- Rendering verified end-to-end via the objectui live e2e (Account detail → Projects related list).

Pairs with objectui#feat/detail-related-lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)