### PR TITLE
feat(showcase): computed (expression) amount on invoice line

### DIFF
--- a/examples/app-showcase/src/objects/invoice.object.ts
+++ b/examples/app-showcase/src/objects/invoice.object.ts
@@ -61,6 +61,18 @@ export const InvoiceLine = ObjectSchema.create({
     product: Field.text({ label: 'Product', required: true, maxLength: 200 }),
     quantity: Field.number({ label: 'Qty', required: true, min: 0, defaultValue: 1 }),
     unit_price: Field.currency({ label: 'Unit Price', scale: 2, min: 0 }),
-    amount: Field.currency({ label: 'Amount', scale: 2, min: 0 }),
+    // Amount = Qty × Unit Price. Kept as a *stored* currency column (so the
+    // parent Invoice.total summary can roll it up — summary aggregation reads
+    // stored columns, not on-read formula fields), but the `expression` makes
+    // the line-item grid render it READ-ONLY and recompute it live client-side
+    // as quantity/unit_price change, then persist the computed value. The
+    // server does not treat a non-`formula` field's expression as computed, so
+    // the client-sent value is stored as-is.
+    amount: Field.currency({
+      label: 'Amount',
+      scale: 2,
+      min: 0,
+      expression: 'record.quantity * record.unit_price',
+    }),
   },
 });


### PR DESCRIPTION
## Why

Backs the spreadsheet-style line-item grid (objectui): the invoice line's **Amount** should be computed (`quantity × unit_price`), read-only, and recomputed live as you type — not hand-typed.

## What

`showcase_invoice_line.amount` gains `expression: 'record.quantity * record.unit_price'`. It stays a **stored `currency`** column on purpose:

- The server only treats `type: 'formula'` fields as computed/virtual. A `currency` field with an `expression` keeps a real DB column, is accepted/persisted from the client, and is **not** overwritten on read — so the parent `Invoice.total` summary (which aggregates stored columns) keeps rolling it up unchanged.
- The objectui line-item grid reads the `expression` from metadata to render Amount **read-only** and recompute it client-side, then persists the computed value in the atomic batch.

## Verification

- Backend serves `amount.expression = { dialect: 'cel', source: 'record.quantity * record.unit_price' }` and `amount.type = currency` (writable).
- Live e2e (objectui): New Invoice computes amount live (2 × 50 → 100), persists it, and the server total rolls it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)