### PR TITLE
feat(showcase): invoice header tax_rate for the live totals stack

### DIFF
--- a/examples/app-showcase/src/objects/invoice.object.ts
+++ b/examples/app-showcase/src/objects/invoice.object.ts
@@ -55,10 +55,14 @@ export const Invoice = ObjectSchema.create({
       ],
     }),
     issued_on: Field.date({ label: 'Issued On' }),
+    // Header tax rate (percent). The line-item entry form reads it live to show
+    // a Subtotal / Tax / Total stack under the grid as lines are entered.
+    tax_rate: Field.number({ label: 'Tax Rate (%)', min: 0, max: 100, defaultValue: 0 }),
     // Roll-up: recomputed server-side as line items are inserted/updated/deleted
-    // (child FK auto-detected: showcase_invoice_line.invoice).
+    // (child FK auto-detected: showcase_invoice_line.invoice). This is the line
+    // subtotal; the tax-inclusive grand total is shown live during entry.
     total: Field.summary({
-      label: 'Total',
+      label: 'Subtotal',
       summaryOperations: { object: 'showcase_invoice_line', field: 'amount', function: 'sum' },
     }),
   },


### PR DESCRIPTION
## Why

Backs the live Subtotal / Tax / Total stack in the invoice line-item entry form (objectui).

## What

- Add `tax_rate` (percent number, default 0) to `showcase_invoice`.
- Relabel the line subtotal summary "Subtotal".

The objectui line-item form reads `tax_rate` live and renders **Subtotal → Tax (rate%) → Total** under the grid as lines are entered.

## Verification

- Backend serves `showcase_invoice.tax_rate` (number).
- Live e2e (objectui): New Invoice → pick Widget A, Qty 2 → Subtotal ¥59.98, Tax (10%) ¥6.00, Total ¥65.98.

> Pairs with objectui (master-detail totals stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)