### PR TITLE
feat(showcase): invoice line position field for persisted drag-reorder

### DIFF
--- a/examples/app-showcase/src/objects/invoice.object.ts
+++ b/examples/app-showcase/src/objects/invoice.object.ts
@@ -87,6 +87,9 @@ export const InvoiceLine = ObjectSchema.create({
     }),
     // Catalog lookup. Picking a product auto-fills `description` + `unit_price`
     // (the grid copies same-named fields from the selected product record).
+    // Line sort position — stamped by the grid on drag-reorder so the order
+    // persists. Excluded from the editable columns (it's not hand-entered).
+    position: Field.number({ label: 'Position', defaultValue: 0 }),
     product: Field.lookup('showcase_product', { label: 'Product', required: true }),
     description: Field.text({ label: 'Description', maxLength: 200 }),
     quantity: Field.number({ label: 'Qty', required: true, min: 0, defaultValue: 1 }),


### PR DESCRIPTION
## Why

So drag-reordering invoice lines persists across reloads.

## What

Add a numeric `position` to `showcase_invoice_line`. The objectui line-item grid excludes it from the editable columns and stamps it on drag-reorder (`row[position] = index`).

## Verification

- Backend serves `showcase_invoice_line.position`.
- Live e2e (objectui): the created line carries `position: 0` from its row order.

> Pairs with objectui (de-frame + compact lookup + sort_field wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)