### PR TITLE
feat(studio): add Datasets nav entry (ADR-0021)

### DIFF
--- a/packages/platform-objects/src/apps/studio.app.ts
+++ b/packages/platform-objects/src/apps/studio.app.ts
@@ -165,6 +165,15 @@ export const STUDIO_APP: App = {
           params: { type: 'report', package: '{active_package}' },
           icon: 'bar-chart-3',
         },
+        {
+          // ADR-0021 — the analytics semantic layer reports/dashboards bind to.
+          id: 'nav_datasets',
+          type: 'component',
+          label: 'Datasets',
+          componentRef: 'metadata:resource',
+          params: { type: 'dataset', package: '{active_package}' },
+          icon: 'database',
+        },
       ],
     },
     {

--- a/packages/platform-objects/src/apps/translations/en.ts
+++ b/packages/platform-objects/src/apps/translations/en.ts
@@ -118,6 +118,7 @@ export const en: TranslationData = {
         nav_pages: { label: 'Pages' },
         nav_dashboards: { label: 'Dashboards' },
         nav_reports: { label: 'Reports' },
+        nav_datasets: { label: 'Datasets' },
         group_logic: { label: 'Logic' },
         nav_actions: { label: 'Actions' },
         nav_hooks: { label: 'Hooks' },

--- a/packages/platform-objects/src/apps/translations/es-ES.ts
+++ b/packages/platform-objects/src/apps/translations/es-ES.ts
@@ -95,6 +95,7 @@ export const esES: TranslationData = {
         nav_pages: { label: 'Páginas' },
         nav_dashboards: { label: 'Paneles' },
         nav_reports: { label: 'Informes' },
+        nav_datasets: { label: 'Conjuntos de datos' },
         group_logic: { label: 'Lógica' },
         nav_actions: { label: 'Acciones' },
         nav_hooks: { label: 'Hooks' },

--- a/packages/platform-objects/src/apps/translations/ja-JP.ts
+++ b/packages/platform-objects/src/apps/translations/ja-JP.ts
@@ -95,6 +95,7 @@ export const jaJP: TranslationData = {
         nav_pages: { label: 'ページ' },
         nav_dashboards: { label: 'ダッシュボード' },
         nav_reports: { label: 'レポート' },
+        nav_datasets: { label: 'データセット' },
         group_logic: { label: 'ロジック' },
         nav_actions: { label: 'アクション' },
         nav_hooks: { label: 'フック' },

--- a/packages/platform-objects/src/apps/translations/zh-CN.ts
+++ b/packages/platform-objects/src/apps/translations/zh-CN.ts
@@ -95,6 +95,7 @@ export const zhCN: TranslationData = {
         nav_pages: { label: '页面' },
         nav_dashboards: { label: '仪表盘' },
         nav_reports: { label: '报表' },
+        nav_datasets: { label: '数据集' },
         group_logic: { label: '逻辑' },
         nav_actions: { label: '动作' },
         nav_hooks: { label: '钩子' },


### PR DESCRIPTION
Surfaces the analytics `dataset` type in the Studio sidebar (under User Experience, after Reports) so authors can discover/manage datasets without a direct URL. Mirrors the reports/dashboards nav entries; i18n for en/zh-CN/es-ES/ja-JP.

Found during browser e2e of the dataset designer + live preview (the type was functional but only reachable by URL). Follow-up to #1643 / objectui #1570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)