### PR TITLE
fix(cli): add @ai-sdk/openai, anthropic, google as direct dependencies

### DIFF
--- a/.changeset/cli-ai-sdk-deps.md
+++ b/.changeset/cli-ai-sdk-deps.md
@@ -1,0 +1,12 @@
+---
+"@objectstack/cli": patch
+---
+
+Bundle the `@ai-sdk/openai`, `@ai-sdk/anthropic`, and `@ai-sdk/google` provider
+SDKs as direct CLI dependencies. These were previously only declared as optional
+peer dependencies on `@objectstack/service-ai`, so a globally-installed CLI could
+not resolve them at runtime. Configuring an OpenAI-compatible provider (DeepSeek,
+DashScope, SiliconFlow, OpenRouter, Cloudflare) — all of which normalise to
+`provider=openai` and dynamically import `@ai-sdk/openai` — failed with
+"Could not build adapter for provider=…". The CLI now ships these providers so
+they work out of the box.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,10 @@
     "topicSeparator": " "
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.0",
     "@ai-sdk/gateway": "^3.0.121",
+    "@ai-sdk/google": "^3.0.0",
+    "@ai-sdk/openai": "^3.0.0",
     "@objectstack/account": "workspace:*",
     "@objectstack/client": "workspace:*",
     "@objectstack/console": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,9 +449,18 @@ importers:
 
   packages/cli:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.0
+        version: 3.0.79(zod@4.4.3)
       '@ai-sdk/gateway':
         specifier: ^3.0.121
         version: 3.0.121(zod@4.4.3)
+      '@ai-sdk/google':
+        specifier: ^3.0.0
+        version: 3.0.79(zod@4.4.3)
+      '@ai-sdk/openai':
+        specifier: ^3.0.0
+        version: 3.0.65(zod@4.4.3)
       '@objectstack/account':
         specifier: workspace:*
         version: link:../../apps/account


### PR DESCRIPTION
## 问题

全局安装的 CLI（`npm install -g @objectstack/cli`）不会自动安装 `peerDependencies`，导致用户配置 DeepSeek 等 provider 后报错：

```
Could not build adapter for provider=deepseek. Check API key (or the corresponding env var) and that the provider SDK package is installed.
```

```
Failed to load @ai-sdk/openai for provider=openai
{"error":"Cannot find package '@ai-sdk/openai' imported from ...@objectstack/cli/node_modules/index.js"}
```

## 根本原因

`service-ai` 将 `@ai-sdk/openai` 等声明为 optional peerDependencies，设计意图是让消费方按需安装。但 CLI 作为消费方一直缺少这三个包的显式声明，而 `normalisePresetProvider()` 会将 deepseek / siliconflow / dashscope / openrouter / cloudflare 等 5 个预设 provider 全部重写为 `provider=openai`，再去动态 `import('@ai-sdk/openai')`，包不存在就报错。

## 修复

在 `packages/cli/package.json` 里将三个 provider SDK 加为直接依赖，与 `@ai-sdk/gateway` 保持一致。

## Test plan

- [ ] 全局安装 CLI 后配置 DeepSeek provider，验证不再报 `Cannot find package '@ai-sdk/openai'`
- [ ] 配置 Anthropic / Google provider 同样正常工作