### PR TITLE
fix(cli): make scaffolded projects start cleanly under pnpm

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -61,6 +61,36 @@ export function sanitizeNamespace(name: string): string {
   return s;
 }
 
+/**
+ * Native dependencies the scaffold pulls in (transitively) that need their
+ * build scripts to run at install time. pnpm 10+ blocks dependency build
+ * scripts by default; without this allowlist `better-sqlite3` (used by the
+ * default standalone SQLite store, via knex) ships uncompiled and `serve`
+ * fails with "Could not locate the bindings file".
+ *
+ * Current pnpm reads this from `pnpm-workspace.yaml`, NOT the `pnpm` field in
+ * package.json (that field is now ignored and emits a deprecation warning).
+ * npm/yarn/bun build native modules by default and ignore this file.
+ */
+export const SCAFFOLD_BUILT_DEPENDENCIES = ['better-sqlite3', 'esbuild'];
+
+/**
+ * Render the `pnpm-workspace.yaml` that allowlists native build scripts.
+ * Kept minimal (no `packages:` key) so it acts purely as a settings file for
+ * the single-package scaffold rather than declaring a workspace.
+ */
+export function renderPnpmWorkspaceYaml(builtDeps: string[] = SCAFFOLD_BUILT_DEPENDENCIES): string {
+  return [
+    '# Allowlist native dependency build scripts so `pnpm install` compiles',
+    '# them (pnpm 10+ blocks build scripts by default). Without this,',
+    '# better-sqlite3 ships uncompiled and `objectstack serve` fails with',
+    '# "Could not locate the bindings file".',
+    'onlyBuiltDependencies:',
+    ...builtDeps.map((d) => `  - ${d}`),
+    '',
+  ].join('\n');
+}
+
 export const TEMPLATES: Record<string, {
   description: string;
   dependencies: Record<string, string>;
@@ -88,7 +118,10 @@ export const TEMPLATES: Record<string, {
     },
     scripts: {
       dev: 'objectstack dev',
-      start: 'objectstack serve',
+      // `serve` is production mode and boots from the compiled artifact
+      // (dist/objectstack.json). Compile first so `pnpm start` works straight
+      // after `pnpm install` without a separate build step.
+      start: 'objectstack compile && objectstack serve',
       build: 'objectstack compile',
       validate: 'objectstack validate',
       typecheck: 'tsc --noEmit',
@@ -402,6 +435,15 @@ export default class Init extends Command {
         createdFiles.push('package.json');
       } else {
         printInfo('package.json already exists, skipping');
+      }
+
+      // 1b. Create pnpm-workspace.yaml so pnpm compiles the native deps the
+      // standalone store needs (see SCAFFOLD_BUILT_DEPENDENCIES). Harmless for
+      // npm/yarn/bun, which ignore this file and build native modules anyway.
+      const pnpmWorkspacePath = path.join(targetDir, 'pnpm-workspace.yaml');
+      if (!fs.existsSync(pnpmWorkspacePath)) {
+        fs.writeFileSync(pnpmWorkspacePath, renderPnpmWorkspaceYaml());
+        createdFiles.push('pnpm-workspace.yaml');
       }
 
       // 2. Create objectstack.config.ts

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -440,10 +440,14 @@ export default class Init extends Command {
       // 1b. Create pnpm-workspace.yaml so pnpm compiles the native deps the
       // standalone store needs (see SCAFFOLD_BUILT_DEPENDENCIES). Harmless for
       // npm/yarn/bun, which ignore this file and build native modules anyway.
+      // Use an exclusive write ('wx') rather than exists()-then-write so the
+      // "don't clobber an existing file" check is atomic (no TOCTOU race).
       const pnpmWorkspacePath = path.join(targetDir, 'pnpm-workspace.yaml');
-      if (!fs.existsSync(pnpmWorkspacePath)) {
-        fs.writeFileSync(pnpmWorkspacePath, renderPnpmWorkspaceYaml());
+      try {
+        fs.writeFileSync(pnpmWorkspacePath, renderPnpmWorkspaceYaml(), { flag: 'wx' });
         createdFiles.push('pnpm-workspace.yaml');
+      } catch (err: any) {
+        if (err?.code !== 'EEXIST') throw err;
       }
 
       // 2. Create objectstack.config.ts

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { TEMPLATES, getCliVersion, detectPackageManager, sanitizeNamespace } from '../src/commands/init';
+import { TEMPLATES, getCliVersion, detectPackageManager, sanitizeNamespace, SCAFFOLD_BUILT_DEPENDENCIES, renderPnpmWorkspaceYaml } from '../src/commands/init';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(
@@ -48,6 +48,40 @@ describe('init command — published scaffold', () => {
         expect(allDeps['@objectstack/cli']).toBeDefined();
       }
     });
+  });
+});
+
+describe('native build allowlist (pnpm-workspace.yaml)', () => {
+  // pnpm 10+ blocks dependency build scripts by default. Without an allowlist,
+  // the scaffold installs but `serve` crashes with "Could not locate the
+  // bindings file" because `better-sqlite3` shipped uncompiled. Current pnpm
+  // reads the allowlist from pnpm-workspace.yaml, not the package.json `pnpm`
+  // field (which it now ignores).
+  it('includes the native deps the standalone store needs', () => {
+    expect(SCAFFOLD_BUILT_DEPENDENCIES).toContain('better-sqlite3');
+  });
+
+  it('does NOT put the allowlist in package.json (current pnpm ignores it)', () => {
+    const t = TEMPLATES.app;
+    // Mirror init.ts's package.json construction.
+    const pkgJson: Record<string, unknown> = {
+      name: 'my-app',
+      version: '0.1.0',
+      private: true,
+      type: 'module',
+      scripts: t.scripts,
+      dependencies: t.dependencies,
+      devDependencies: t.devDependencies,
+    };
+    expect(pkgJson.pnpm).toBeUndefined();
+  });
+
+  it('renders a pnpm-workspace.yaml that allowlists better-sqlite3', () => {
+    const yaml = renderPnpmWorkspaceYaml();
+    expect(yaml).toMatch(/^onlyBuiltDependencies:/m);
+    expect(yaml).toMatch(/^ {2}- better-sqlite3$/m);
+    // No `packages:` key — this is a settings file, not a workspace declaration.
+    expect(yaml).not.toMatch(/^packages:/m);
   });
 });
 


### PR DESCRIPTION
## Problem

`npx @objectstack/cli init` → `pnpm install` → `pnpm start` failed for a freshly scaffolded `app` project, in two independent ways:

1. **`better-sqlite3` native binding missing.** It's pulled in transitively by the default standalone SQLite store (via knex). pnpm 10+ blocks dependency build scripts by default, so the native module shipped uncompiled and `objectstack serve` crashed at runtime with:
   ```
   Could not locate the bindings file ... better_sqlite3.node
   ```

2. **`pnpm start` failed before any build.** The scaffold's `start` script was `objectstack serve` (production mode), which boots from the compiled `dist/objectstack.json`. That artifact doesn't exist right after `pnpm install`, so `serve` errored out (surfacing as a cryptic `Service 'manifest' is async`).

## Fix

Both changes are in the `init` `app` template only.

1. **Generate `pnpm-workspace.yaml`** allowlisting the native build deps:
   ```yaml
   onlyBuiltDependencies:
     - better-sqlite3
     - esbuild
   ```
   The allowlist must live in `pnpm-workspace.yaml` — current pnpm (10.33) **ignores the `pnpm` field in `package.json`** and emits a deprecation warning. This mirrors how this repo configures itself. npm/yarn/bun ignore the file and build native modules by default, so it's harmless for them.

2. **`start` now runs `objectstack compile && objectstack serve`**, so it works straight after `pnpm install` without a separate build step.

## Verification (pnpm v10.33.0)

- A/B: without `pnpm-workspace.yaml` → binding missing (bug reproduced); with it → binding compiled automatically.
- Real `init --package-manager pnpm`: generates `pnpm-workspace.yaml`, no `pnpm` field in `package.json`, `better_sqlite3.node` built.
- `init → install → pnpm start` (no manual build): auto-compiles, reaches `✓ Server is ready` (HTTP 302).
- `pnpm dev` works out of the box (`SqlDriver(better-sqlite3)`).
- `init.test.ts`: 28/28 passing (added coverage for the rendered `pnpm-workspace.yaml` and that the allowlist is *not* in `package.json`).

## Note (out of scope)

Discovered a separate, deeper bug: `objectstack serve` booting directly from config (no prebuilt artifact) throws `Service 'manifest' is async` (`packages/core/src/kernel.ts:106`). This PR sidesteps it via compile-before-serve rather than changing the kernel/serve boot ordering. Worth a follow-up.