### PR TITLE
feat(service-ai): consistent agent narration when builds auto-publish

### DIFF
--- a/packages/services/service-ai/src/__tests__/chatbot-features.test.ts
+++ b/packages/services/service-ai/src/__tests__/chatbot-features.test.ts
@@ -606,6 +606,19 @@ describe('AgentRuntime', () => {
       const messages = runtime.buildSystemMessages(DATA_CHAT_AGENT, {});
       expect(messages[0].content).not.toContain('Current Context');
     });
+
+    it('tells the agent builds are live when the environment auto-publishes', () => {
+      const messages = runtime.buildSystemMessages(DATA_CHAT_AGENT, { autoPublishAiBuilds: true });
+      expect(messages[0].content).toContain('publish AUTOMATICALLY');
+      expect(messages[0].content).toContain('is live');
+    });
+
+    it('stays silent on publishing when auto-publish is off/absent', () => {
+      for (const ctx of [{}, { autoPublishAiBuilds: false }]) {
+        const messages = runtime.buildSystemMessages(DATA_CHAT_AGENT, ctx);
+        expect(messages[0].content).not.toContain('publish AUTOMATICALLY');
+      }
+    });
   });
 
   describe('buildRequestOptions', () => {

--- a/packages/services/service-ai/src/agent-runtime.ts
+++ b/packages/services/service-ai/src/agent-runtime.ts
@@ -28,6 +28,13 @@ export interface AgentChatContext extends SkillContext {
   recordId?: string;
   /** Current view name */
   viewName?: string;
+  /**
+   * Whether this environment auto-publishes whole-app builds. When the client
+   * passes `true`, the agent is told a finished build is live immediately, so
+   * its narration matches reality ("your app is live") instead of defaulting to
+   * "publish it to make it live". Absent/false keeps the conservative framing.
+   */
+  autoPublishAiBuilds?: boolean;
 }
 
 /**
@@ -129,6 +136,21 @@ export class AgentRuntime {
       if (context.viewName) ctx.push(`Current view: ${context.viewName}`);
       if (ctx.length > 0) {
         parts.push('\n--- Current Context ---\n' + ctx.join('\n'));
+      }
+      // Environment publishing posture. When auto-publish is on, a finished
+      // whole-app build is already live, so the agent should say so rather than
+      // ask the user to publish. Authoring skills stay neutral by default (they
+      // can't see this runtime setting); this is what makes the narration match
+      // the UI's published state instead of hedging.
+      if (context.autoPublishAiBuilds === true) {
+        parts.push(
+          '\n--- Publishing in this environment ---\n' +
+            'Whole-app builds publish AUTOMATICALLY here: the moment you finish building an app, ' +
+            'it is live and ready to use — there is no manual publish step for the build. Tell the ' +
+            'user their app is built and live (e.g. "your app is ready — open it from the launcher"). ' +
+            'Do NOT tell them to "publish it to make it live" for a whole-app build. Smaller ' +
+            'incremental edits are still staged for review — the chat panel shows each change\'s status.',
+        );
       }
     }
 


### PR DESCRIPTION
## What
The metadata agent couldn't see whether an environment auto-publishes AI builds, so it hedged ("staged for review / publish to make it live") even after a build went live — contradicting the UI's **Published** state.

`buildSystemMessages` now reads `context.autoPublishAiBuilds`: when on, the agent is told a finished whole-app build is **live immediately** and to say so. Absent/false keeps the conservative framing. The chat ([objectui](https://github.com/objectstack-ai/objectui)) passes the runtime flag in the chat context.

This is the optional polish on top of the auto-publish "magic moment" — the UI panel was already the source of truth; this makes the model's prose agree with it.

## Changes
- `AgentChatContext`: add `autoPublishAiBuilds?: boolean`
- `buildSystemMessages`: append a "Publishing in this environment" note when on
- tests: instruction present when on; silent when off/absent (service-ai suite 333 green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)