### PR TITLE
chore(changeset): @objectstack/spec major for ADR-0021 single-form cutover

### DIFF
--- a/.changeset/adr-0021-single-form-cutover.md
+++ b/.changeset/adr-0021-single-form-cutover.md
@@ -1,0 +1,25 @@
+---
+"@objectstack/spec": major
+---
+
+ADR-0021 single-form cutover (BREAKING): the inline analytics author surface is
+removed — every dashboard widget, report, and list-chart must now bind a
+semantic `dataset` and select dimensions/measures **by name**.
+
+Removed from the spec:
+
+- **DashboardWidget** — `object`, `categoryField`, `categoryGranularity`,
+  `valueField`, `aggregate`, `measures` (and the `WidgetMeasure` schema/type).
+  `dataset` + `values` are now required; `filter` is the presentation-scope
+  runtimeFilter; `dimensions` / `compareTo` are retained.
+- **Report** — top-level (and joined-block) `objectName`, `columns`,
+  `groupingsDown`, `groupingsAcross`, `filter`. A non-joined report now requires
+  `dataset` + `values`; `rows` are the dimensions.
+- **ListChart** — `xAxisField`, `yAxisFields`, `aggregation`, `groupByField`.
+  `dataset` + `values` are now required.
+
+Migration: replace the inline query with a `defineDataset(...)` and reference it
+by name. A flat record listing (the former `tabular` report / inline list) is an
+object-bound ListView (ADR-0017), not an analytics dataset. See
+`docs/adr/0021-analytics-dataset-semantic-layer.md` and the
+`content/docs/guides/analytics-datasets.mdx` guide.


### PR DESCRIPTION
## Why

The ADR-0021 single-form cutover ([#1676](https://github.com/objectstack-ai/framework/pull/1676), merged) removed the inline analytics author surface — a **breaking** spec change — but landed **without a changeset declaring the major bump**.

The repo's changeset `fixed` group version-locks the entire published platform to `@objectstack/spec`. Without a `major` changeset, the next release would ship this breaking change as a **non-major** version, silently breaking `^8.x` consumers under their caret range (e.g. hotcrm pins `@objectstack/spec: ^8.0.1`).

## What

Adds `.changeset/adr-0021-single-form-cutover.md` declaring `@objectstack/spec: major`, which cascades the whole fixed group to the next major (8.0.1 → 9.0.0). The changeset body documents the removed fields and the migration path.

No code changes — release hygiene only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)