### PR TITLE
feat(service-ai): stream tool progress mid-execution (data-* parts)

### DIFF
--- a/packages/services/service-ai/src/__tests__/ai-service.test.ts
+++ b/packages/services/service-ai/src/__tests__/ai-service.test.ts
@@ -418,6 +418,50 @@ describe('AIService', () => {
     expect(after?.messages.map(m => m.role)).toEqual(['user', 'assistant', 'tool', 'assistant']);
   });
 
+  it('streamChatWithTools drains a tool\'s onProgress events into the stream, before its result', async () => {
+    const registry = new ToolRegistry();
+    registry.register(
+      { name: 'build', description: 'B', parameters: {} },
+      async (_args, ctx) => {
+        // A long-running tool reporting progress mid-execution.
+        ctx?.onProgress?.({ type: 'data-build-progress', id: 'b', data: { phase: 'objects', done: 1 } });
+        ctx?.onProgress?.({ type: 'data-build-progress', id: 'b', data: { phase: 'seed', done: 2 } });
+        return 'built';
+      },
+    );
+    let calls = 0;
+    const adapter: LLMAdapter = {
+      name: 'progress-test',
+      chat: async () => {
+        calls += 1;
+        if (calls === 1) {
+          return {
+            content: '',
+            model: 'test',
+            toolCalls: [{ type: 'tool-call' as const, toolCallId: 'tc1', toolName: 'build', input: {} }],
+          };
+        }
+        return { content: 'done', model: 'test' };
+      },
+      complete: async () => ({ content: '' }),
+    };
+    const service = new AIService({ adapter, toolRegistry: registry, logger: silentLogger });
+
+    const events: TextStreamPart<ToolSet>[] = [];
+    for await (const ev of service.streamChatWithTools([{ role: 'user', content: 'build' }])) {
+      events.push(ev);
+    }
+
+    const progress = events.filter((e) => (e as { type: string }).type === 'data-build-progress');
+    expect(progress).toHaveLength(2);
+    expect((progress[0] as any).data).toMatchObject({ phase: 'objects' });
+    expect((progress[1] as any).data).toMatchObject({ phase: 'seed' });
+    // Progress surfaces BEFORE the tool-result (the whole point — mid-execution).
+    const firstProgress = events.findIndex((e) => (e as { type: string }).type === 'data-build-progress');
+    const toolResult = events.findIndex((e) => (e as { type: string }).type === 'tool-result');
+    expect(firstProgress).toBeLessThan(toolResult);
+  });
+
   it('streamChatWithTools auto-persists user + assistant turns when conversationId is provided', async () => {
     const conversationService = new InMemoryConversationService();
     const adapter: LLMAdapter = {

--- a/packages/services/service-ai/src/__tests__/vercel-stream-encoder.test.ts
+++ b/packages/services/service-ai/src/__tests__/vercel-stream-encoder.test.ts
@@ -103,6 +103,20 @@ describe('encodeStreamPart', () => {
     });
   });
 
+  it('encodes a custom data-* part (e.g. build progress) verbatim, with id for reconciliation', () => {
+    const part = {
+      type: 'data-build-progress',
+      id: 'build',
+      data: { phase: 'objects', items: [{ type: 'object', name: 'deal', status: 'done' }] },
+    } as unknown as TextStreamPart<ToolSet>;
+    const payload = parseSSE(encodeStreamPart(part));
+    expect(payload).toEqual({
+      type: 'data-build-progress',
+      id: 'build',
+      data: { phase: 'objects', items: [{ type: 'object', name: 'deal', status: 'done' }] },
+    });
+  });
+
   it('should return empty string for finish (handled by generator)', () => {
     const part = {
       type: 'finish',

--- a/packages/services/service-ai/src/ai-service.ts
+++ b/packages/services/service-ai/src/ai-service.ts
@@ -24,7 +24,7 @@ import type { z } from 'zod';
 import { createLogger } from '@objectstack/core';
 import { MemoryLLMAdapter } from './adapters/memory-adapter.js';
 import { ToolRegistry } from './tools/tool-registry.js';
-import type { ToolExecutionResult } from './tools/tool-registry.js';
+import type { ToolExecutionResult, ToolExecutionContext } from './tools/tool-registry.js';
 import { InMemoryConversationService } from './conversation/in-memory-conversation-service.js';
 import { ModelRegistry } from './model-registry.js';
 import {
@@ -808,10 +808,45 @@ export class AIService implements IAIService {
         await this.persistMessage(conversationId, assistantTurn, turnObservability);
       }
 
-      const toolResults: ToolExecutionResult[] = await this.toolRegistry.executeAll(
-        result.toolCalls,
-        toolExecutionContext,
-      );
+      // Drain tool PROGRESS events (emitted via `ctx.onProgress` during a
+      // long-running tool, e.g. apply_blueprint's build tree) into the stream
+      // WHILE the tools run, then yield their final results. Backward-compatible:
+      // a tool that never emits leaves `progress` empty, so this awaits execution
+      // exactly once — identical to the previous single `await executeAll`.
+      const progress: TextStreamPart<ToolSet>[] = [];
+      let resolveTick: (() => void) | null = null;
+      const tick = (): void => {
+        const r = resolveTick;
+        resolveTick = null;
+        r?.();
+      };
+      const execCtx: ToolExecutionContext = {
+        ...(toolExecutionContext ?? {}),
+        onProgress: (part) => {
+          progress.push(part as unknown as TextStreamPart<ToolSet>);
+          tick();
+        },
+      };
+      const execPromise = this.toolRegistry.executeAll(result.toolCalls, execCtx);
+      let execSettled = false;
+      // Swallow rejection on the tracking chain (the real throw is re-surfaced by
+      // `await execPromise` below) so it never becomes an unhandled rejection.
+      void execPromise.then(
+        () => {},
+        () => {},
+      ).finally(() => {
+        execSettled = true;
+        tick();
+      });
+      // Yield any buffered progress, then park until the next emit or completion.
+      while (true) {
+        while (progress.length > 0) yield progress.shift()!;
+        if (execSettled) break;
+        await new Promise<void>((resolve) => {
+          resolveTick = resolve;
+        });
+      }
+      const toolResults: ToolExecutionResult[] = await execPromise;
 
       for (const tr of toolResults) {
         if (tr.isError && onToolError) {

--- a/packages/services/service-ai/src/stream/vercel-stream-encoder.ts
+++ b/packages/services/service-ai/src/stream/vercel-stream-encoder.ts
@@ -92,6 +92,13 @@ export function encodeStreamPart(part: TextStreamPart<ToolSet>): string {
 
     // finish-step and finish are handled by the generator, not here
     default:
+      // Custom data parts (Vercel UI-message-stream `data-*`) — e.g. a tool's
+      // mid-execution progress (`data-build-progress`). Emit verbatim with the
+      // optional `id` (present ⇒ the client RECONCILES/replaces the part).
+      if (typeof (part as any).type === 'string' && (part as any).type.startsWith('data-')) {
+        const p = part as { type: string; id?: string; data?: unknown };
+        return sse({ type: p.type, ...(p.id ? { id: p.id } : {}), data: p.data });
+      }
       // Pass through any unknown event types that might be custom
       // (e.g., step-start, step-finish from custom providers)
       if ((part as any).type?.startsWith('step-')) {

--- a/packages/spec/src/contracts/ai-service.ts
+++ b/packages/spec/src/contracts/ai-service.ts
@@ -404,6 +404,21 @@ export interface ToolExecutionContext {
     environmentId?: string;
     /** Distributed-trace id for cross-service correlation. */
     traceId?: string;
+    /**
+     * Emit a progress event WHILE a long-running tool executes, surfaced to the
+     * client mid-stream (before the tool returns). Set only on the streaming
+     * path (`streamChatWithTools`); `undefined` for non-streaming/system calls,
+     * so handlers must call it optionally (`ctx.onProgress?.(…)`).
+     *
+     * `type` is a Vercel UI-message-stream custom data-part name (must start
+     * with `data-`, e.g. `data-build-progress`). Pass a stable `id` to RECONCILE
+     * (replace) the part across emits — ideal for a single progress object that
+     * updates in place; omit `id` for append-only events. `data` is the payload.
+     *
+     * Example (apply_blueprint streaming its build tree):
+     *   ctx.onProgress?.({ type: 'data-build-progress', id: 'build', data: { phase, items } });
+     */
+    onProgress?: (part: { type: string; id?: string; data?: unknown }) => void;
 }
 
 /**


### PR DESCRIPTION
Long-running tools can report progress WHILE they run, surfaced before the tool returns — the mechanism behind apply_blueprint's live build tree. Adds ToolExecutionContext.onProgress (emits Vercel data-* parts), drains them in streamChatWithTools (backward-compatible), and passes data-* through the encoder. service-ai 335 tests; verified live.

Generated with Claude Code