### PR TITLE
feat(analytics): carry measure label + format on dataset result fields

### DIFF
--- a/.changeset/analytics-measure-label-format.md
+++ b/.changeset/analytics-measure-label-format.md
@@ -1,0 +1,15 @@
+---
+"@objectstack/spec": minor
+"@objectstack/service-analytics": minor
+---
+
+`queryDataset` now carries each measure's display `label` and `format` on the
+result `fields`, so presentations can show "Tasks" / "$616,000" instead of the
+raw measure name "task_count" / "616000".
+
+- `AnalyticsResult.fields[]` gains optional `label?` and `format?`.
+- The dataset executor enriches measure columns from the dataset's measure
+  definitions (matching `<name>` and `<name>__compare`).
+
+The format can't be baked into the numeric row value (charts need the raw
+number), so the renderer applies it at display time.

--- a/packages/services/service-analytics/src/__tests__/dimension-labels.test.ts
+++ b/packages/services/service-analytics/src/__tests__/dimension-labels.test.ts
@@ -220,4 +220,21 @@ describe('AnalyticsService.queryDataset — label resolution (integration)', () 
       { account: 'Globex', task_count: 2 },
     ]);
   });
+
+  it('enriches measure fields with their display label + format', async () => {
+    const labelledDataset = DatasetSchema.parse({
+      name: 'sales_metrics',
+      label: 'Sales',
+      object: 'task',
+      dimensions: [{ name: 'status', field: 'status', type: 'string' }],
+      measures: [{ name: 'spent_sum', aggregate: 'sum', field: 'spent', label: 'Total Spent', format: '$0,0' }],
+    });
+    const svc = new AnalyticsService({
+      queryCapabilities: () => ({ nativeSql: false, objectqlAggregate: true, inMemory: false }),
+      executeAggregate: async () => [{ status: 'backlog', spent_sum: 616000 }],
+    });
+    const res = await svc.queryDataset(labelledDataset, { dimensions: ['status'], measures: ['spent_sum'] });
+    const field = res.fields.find((f) => f.name === 'spent_sum');
+    expect(field).toMatchObject({ name: 'spent_sum', label: 'Total Spent', format: '$0,0' });
+  });
 });

--- a/packages/services/service-analytics/src/analytics-service.ts
+++ b/packages/services/service-analytics/src/analytics-service.ts
@@ -342,6 +342,20 @@ export class AnalyticsService implements IAnalyticsService {
         }
       }
     }
+
+    // ADR-0021 — enrich measure columns with their display `label` + `format`
+    // so presentations show "Tasks" / "$616,000" instead of the raw measure
+    // name "task_count" / "616000". Carried on the result fields; the renderer
+    // applies the format (it can't be baked into the numeric row value).
+    if (result.fields?.length && dataset.measures?.length) {
+      const measureByName = new Map(dataset.measures.map((m) => [m.name, m]));
+      for (const f of result.fields) {
+        const m = measureByName.get(f.name) ?? measureByName.get(f.name.replace(/__compare$/, ''));
+        if (!m) continue;
+        if (f.label == null && typeof m.label === 'string') f.label = m.label;
+        if (f.format == null && m.format) f.format = m.format;
+      }
+    }
     return result;
   }
 

--- a/packages/spec/src/contracts/analytics-service.ts
+++ b/packages/spec/src/contracts/analytics-service.ts
@@ -68,6 +68,10 @@ export interface AnalyticsResult {
     fields: Array<{
         name: string;
         type: string;
+        /** Human display label (e.g. measure `label`) — for legends/KPIs. */
+        label?: string;
+        /** Display format hint (e.g. measure `format` like "$0,0", "0.0%"). */
+        format?: string;
     }>;
     /** Generated SQL (if available) */
     sql?: string;


### PR DESCRIPTION
## Why

Dashboard KPIs and chart legends showed the **raw measure name** (`task_count`, `spent_sum`) and **unformatted numbers** (`616000`) — the analytics result exposed only `{name, type}`, never the dataset measure's `label` / `format`. (From the Chart Gallery dashboard review.)

## What

- **spec**: `AnalyticsResult.fields[]` gains optional `label?` + `format?`.
- **service-analytics**: `queryDataset` enriches each measure field with the dataset measure's `label` and `format` (matching `<name>` and `<name>__compare`).

The renderer applies the format at display time — it can't be baked into the numeric row value because charts need the raw number.

Pairs with the objectui `DatasetWidget` change (separate PR) that consumes these fields to render `Tasks` / `$616,000` and gives dataset-bound metric widgets a proper card.

## Verification

`turbo build` 72/72, `turbo test` 123/123. New test asserts `result.fields` carries `label` + `format`. Browser-verified on the showcase Chart Gallery (with the paired console build): KPIs show `Tasks` / `Total Spent` / `$616,000`; chart legends show `Tasks` / `Estimated Hours`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)