### PR TITLE
feat(cli)!: os package publish defaults visibility to org (ADR-0007 ②)

### DIFF
--- a/packages/cli/src/commands/package/publish.ts
+++ b/packages/cli/src/commands/package/publish.ts
@@ -165,9 +165,13 @@ export default class PackagePublish extends Command {
       description: 'Marketplace category slug (e.g. crm, hr, devtools)',
     }),
     visibility: Flags.string({
-      description: 'Who can see / install this package',
+      description:
+        "Who can see / install this package. " +
+        "'org' (default): auto-visible/installable across your organization's environments. " +
+        "'private': only explicitly-granted orgs/envs. " +
+        "'marketplace': public after review.",
       options: ['private', 'org', 'marketplace'],
-      default: 'private',
+      default: 'org',
     }),
     org: Flags.string({
       description: 'owner_org_id (required when using a bearer key in service mode; ignored in user mode)',


### PR DESCRIPTION
Per ADR-0007 decision ②: a published package should be auto-visible/installable across the owner org's environments by default. `os package publish --visibility` default **private → org**. Publishers opt into `private` (grant/ACL) or `marketplace` (public) explicitly. Pairs with cloud #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)