### PR TITLE
fix(driver-memory): accept the engine QueryAST in aggregate() (analytics fallback)

### DIFF
--- a/packages/plugins/driver-memory/src/memory-driver.test.ts
+++ b/packages/plugins/driver-memory/src/memory-driver.test.ts
@@ -749,4 +749,45 @@ describe('InMemoryDriver', () => {
       expect(second).not.toBe(first);
     });
   });
+
+  describe('aggregate() — QueryAST shape (analytics fallback path)', () => {
+    let driver: InMemoryDriver;
+    const tbl = 'expenses';
+
+    beforeEach(async () => {
+      driver = new InMemoryDriver({});
+      await driver.connect();
+      await driver.create(tbl, { id: '1', category: 'travel', amount: 100 });
+      await driver.create(tbl, { id: '2', category: 'travel', amount: 50 });
+      await driver.create(tbl, { id: '3', category: 'meals', amount: 30 });
+    });
+
+    it('accepts the engine AST ({groupBy, aggregations}) and returns grouped sums', async () => {
+      const rows = await driver.aggregate(tbl, {
+        object: tbl,
+        groupBy: ['category'],
+        aggregations: [{ function: 'sum', field: 'amount', alias: 'amount' }],
+      } as any);
+      const byCat = Object.fromEntries(rows.map((r: any) => [r.category, r.amount]));
+      expect(byCat).toEqual({ travel: 150, meals: 30 });
+    });
+
+    it('AST with no groupBy returns a single total row; where filters first', async () => {
+      const rows = await driver.aggregate(tbl, {
+        object: tbl,
+        where: { category: 'travel' },
+        aggregations: [{ function: 'sum', field: 'amount', alias: 'total' }, { function: 'count', field: '*', alias: 'count' }],
+      } as any);
+      expect(rows).toEqual([{ total: 150, count: 2 }]);
+    });
+
+    it('still accepts a real MongoDB pipeline array (Mingo passthrough)', async () => {
+      const rows = await driver.aggregate(tbl, [
+        { $match: { category: 'travel' } },
+        { $group: { _id: null, total: { $sum: '$amount' } } },
+      ]);
+      expect((rows[0] as any).total).toBe(150);
+    });
+  });
+
 });

--- a/packages/plugins/driver-memory/src/memory-driver.ts
+++ b/packages/plugins/driver-memory/src/memory-driver.ts
@@ -625,13 +625,37 @@ export class InMemoryDriver implements IDataDriver {
    *   { $group: { _id: null, avgPrice: { $avg: '$price' } } }
    * ]);
    */
-  async aggregate(object: string, pipeline: Record<string, any>[], options?: DriverOptions): Promise<any[]> {
+  async aggregate(object: string, pipeline: Record<string, any>[] | QueryAST, options?: DriverOptions): Promise<any[]> {
+    // ObjectQL's engine calls driver.aggregate(object, AST) with the SAME
+    // QueryAST shape find() consumes ({ where, groupBy, aggregations }) — not a
+    // MongoDB pipeline. Passing that object into Mingo's Aggregator crashed
+    // with "this[#pipeline].map is not a function" (the analytics fallback path
+    // on in-memory environments). Detect the AST shape and serve it through the
+    // SAME filtering + performAggregation path find() uses; a real pipeline
+    // array keeps the Mingo behavior unchanged.
+    if (!Array.isArray(pipeline)) {
+      const query = pipeline as QueryAST;
+      this.logger.debug('Aggregate operation (QueryAST)', {
+        object,
+        groupBy: (query as any).groupBy,
+        aggregations: (query as any).aggregations?.length ?? 0,
+      });
+      let results = this.getTable(object).map((r) => ({ ...r }));
+      if (query.where) {
+        const mongoQuery = this.convertToMongoQuery(query.where);
+        if (mongoQuery && Object.keys(mongoQuery).length > 0) {
+          results = new Query(mongoQuery).find(results).all() as Record<string, any>[];
+        }
+      }
+      return this.performAggregation(results, query);
+    }
+
     this.logger.debug('Aggregate operation', { object, stageCount: pipeline.length });
-    
+
     const records = this.getTable(object).map(r => ({ ...r }));
     const aggregator = new Aggregator(pipeline);
     const results = aggregator.run(records);
-    
+
     this.logger.debug('Aggregate completed', { object, resultCount: results.length });
     return results;
   }


### PR DESCRIPTION
Completes the staging "No rows" fix chain ([framework#1701](https://github.com/objectstack-ai/framework/pull/1701) was layer 1).

After #1701, dataset queries on in-memory environments correctly fall back from NativeSQL to the aggregate strategy — which then crashed with `this[#pipeline].map is not a function`: `ObjectQL.aggregate` hands drivers the **QueryAST** (`{where, groupBy, aggregations}`), but `InMemoryDriver.aggregate()` only understood **MongoDB pipeline arrays** (Mingo).

`aggregate()` now detects the AST shape and serves it through the same where-filter + `performAggregation` path `find()` already uses (the shapes match exactly — `{function, field, alias}`); real pipeline arrays keep the Mingo passthrough unchanged.

**Test**: driver-memory 68 green — new: grouped sums via AST; `where` + no-groupBy single-row totals; pipeline-array passthrough.

Staging validation: bump cloud `.framework-sha` after merge → the expense Spending Dashboard should finally render real numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)