### PR TITLE
docs(releases): complete v9.0.0 coverage (non-changeset features + Cloud) and make the collector 3-repo aware

### DIFF
--- a/content/docs/releases/index.mdx
+++ b/content/docs/releases/index.mdx
@@ -7,7 +7,10 @@ ObjectStack ships as a single release train: all `@objectstack/*` packages are
 version-locked, so one version number describes the whole platform. The
 Console UI (built from the [objectui](https://github.com/objectstack-ai/objectui)
 repository) is frozen into `@objectstack/console` at release time, so each
-release note here also covers what changed in Studio/Console.
+release note here also covers what changed in Studio/Console. ObjectStack
+Cloud (the hosted control plane) versions independently and deploys
+continuously — developer-facing Cloud changes are summarized in the release
+note for the framework version they accompany.
 
 Each release page is written for **third-party developers** building apps,
 plugins, or clients on ObjectStack. It leads with breaking changes and

--- a/content/docs/releases/v9.mdx
+++ b/content/docs/releases/v9.mdx
@@ -104,6 +104,37 @@ human-readable with no frontend work:
   gains optional `label` and `format`, so a chart can display "Tasks" and
   "$616,000" while keeping raw numbers for plotting.
 
+### Automation: durable pause survives subflows and restarts
+
+Two reliability upgrades to `@objectstack/service-automation`'s durable pause
+(ADR-0019):
+
+- **Nested durable pause.** A pausing node (approval, screen, wait) inside a
+  subflow used to fail the parent run. The whole chain now suspends as linked
+  runs: the child's screen surfaces through the parent, resume signals
+  delegate down to the suspended child, and a completed child auto-resumes its
+  parent.
+- **Wait timers re-arm after a cold boot.** A timer `wait` scheduled its wake-up
+  in process memory, so a restart left the suspended run paused forever. The
+  wake deadline is now persisted with the run; on boot the service resumes
+  overdue runs immediately and re-schedules future ones.
+
+### Publishing: seed data lands on every publish path
+
+Whether a `seed` draft's rows actually materialized used to depend on which
+route you published through — the per-ref publish (used by the Studio home
+banner) never applied them, yielding "Published!" with empty tables. Seed
+application now lives in the protocol itself (`@objectstack/objectql`), so
+every publish path converges on it and reports the outcome under
+`seedApplied`. A seed problem never fails the publish.
+
+### AI service: tools stream progress while they run
+
+`ToolExecutionContext.onProgress(part)` lets a long-running tool report
+progress before it returns, emitted as custom `data-*` parts on the UI message
+stream (this is what powers the live build tree in Console's Build-with-AI).
+Existing tools that never emit behave exactly as before.
+
 ### Auth: Google sign-in and an extension hook
 
 `@objectstack/plugin-auth` binds the `auth` settings namespace to better-auth
@@ -146,10 +177,31 @@ improvements:
 - **Charts**: crowded bar-chart x-axis labels angle and truncate instead of
   overlapping.
 
+## ObjectStack Cloud
+
+ObjectStack Cloud (the hosted control plane) versions independently of this
+release train and deploys continuously; changes that affect how you ship apps
+are summarized here when a framework release lands.
+
+- **Package install via reconciliation (ADR-0007 ①).** Installing a published
+  package into an environment is now a control-plane operation: the
+  environment's **Installed** view in Console reads the control-plane install
+  list when cloud-bound, and publish → install is the documented deployment
+  path (install from the environment Marketplace, not a publish flag).
+- **Authorization hardening across the environment API surface** — environment
+  reads are org-scoped, and destructive environment/organization operations
+  require an owner/admin role.
+
+The second phase of ADR-0007 — org-scoped private package catalogs with
+`os package publish` defaulting to organization visibility — ships in the next
+framework release.
+
 ## Notable fixes
 
 - Publishing pending drafts by ref so package-less drafts can't get stuck in
   the metadata-admin publish queue.
+- New projects scaffolded by `create-objectstack` start cleanly under pnpm.
+- Setup → System Settings menu labels and pages are fully translated.
 - `FlowRunner` closes cleanly when a terminal resume fails instead of leaving
   a dead dialog.
 - The AI service treats a stored or env-locked `provider=memory` as an explicit

--- a/scripts/collect-release-notes.sh
+++ b/scripts/collect-release-notes.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
 # Collect the raw material for a release-notes page in content/docs/releases/.
 #
-# Aggregates, for the release between two framework refs:
-#   1. The changesets consumed by the release (full text, grouped as the
-#      per-package CHANGELOGs were generated from them).
-#   2. The objectui (Console UI) commit range, derived from the .objectui-sha
-#      pin at each ref, with feat/fix commits listed first.
+# The platform spans three repositories; a release page must aggregate all of
+# them. For the release between two framework refs this prints:
+#   1. ALL framework commits in the range (feat/fix first). Changesets are a
+#      curated subset — commits land without one, so the full log is the
+#      source of truth for coverage.
+#   2. The changesets consumed by the release (full text — the best prose for
+#      items that have one).
+#   3. The objectui (Console UI) commit range, derived from the .objectui-sha
+#      pin at each ref.
+#   4. The cloud (control plane) commits inside the release's time window.
+#      Cloud is not pinned by the framework (it tracks it via link: deps and
+#      versions independently), so the window between the two refs' commit
+#      dates is the best available scope — review its edges by hand.
 #
 # Usage:
 #   scripts/collect-release-notes.sh <prev-ref> [<new-ref>]
@@ -15,21 +23,45 @@
 # Output is markdown on stdout — pipe it to a file and write the curated
 # release page from it:
 #   scripts/collect-release-notes.sh "@objectstack/spec@9.0.0" > /tmp/v10-material.md
+#
+# Sibling checkouts are found at ../objectui and ../cloud; override with
+# OBJECTUI_ROOT / CLOUD_ROOT.
 
 set -euo pipefail
 
 FRAMEWORK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OBJECTUI_ROOT="${OBJECTUI_ROOT:-$(cd "${FRAMEWORK_ROOT}/../objectui" 2>/dev/null && pwd || true)}"
+CLOUD_ROOT="${CLOUD_ROOT:-$(cd "${FRAMEWORK_ROOT}/../cloud" 2>/dev/null && pwd || true)}"
 
 PREV_REF="${1:?usage: collect-release-notes.sh <prev-ref> [<new-ref>]}"
 NEW_REF="${2:-HEAD}"
 
 cd "$FRAMEWORK_ROOT"
 
+# Print a commit list with feat/fix first, the rest after — `chore!:` and
+# similar breakage hides in the second bucket, so it stays visible.
+print_log_split() { # <git-dir> <range-or-window...>
+  local dir="$1"; shift
+  local all
+  all=$(git -C "$dir" log --no-merges --pretty='- %h %s' "$@")
+  echo "### feat / fix"
+  echo
+  grep -E '^- [0-9a-f]+ (feat|fix)' <<< "$all" || echo "_none_"
+  echo
+  echo "### everything else (watch for chore!: / refactor!: breakage)"
+  echo
+  grep -Ev '^- [0-9a-f]+ (feat|fix)' <<< "$all" || echo "_none_"
+}
+
 echo "# Release material: ${PREV_REF} → ${NEW_REF}"
 echo
 
-echo "## Framework changesets consumed in this release"
+echo "## 1. Framework — all commits in the range"
+echo
+print_log_split "$FRAMEWORK_ROOT" "${PREV_REF}".."${NEW_REF}"
+echo
+
+echo "## 2. Framework — changesets consumed in this release"
 echo
 
 # Changesets deleted anywhere in the range were consumed by `changeset
@@ -53,7 +85,7 @@ else
   done <<< "$consumed"
 fi
 
-echo "## Console UI (objectui) commit range"
+echo "## 3. Console UI (objectui) — pin range"
 echo
 
 prev_sha=$(git show "${PREV_REF}:.objectui-sha" 2>/dev/null || true)
@@ -70,18 +102,27 @@ elif [[ "$prev_sha" == "$new_sha" ]]; then
 elif [[ -z "$OBJECTUI_ROOT" || ! -d "$OBJECTUI_ROOT/.git" ]]; then
   echo "_objectui checkout not found (set OBJECTUI_ROOT); range is ${prev_sha}..${new_sha}_"
 else
-  echo "### feat / fix"
-  echo
-  git -C "$OBJECTUI_ROOT" log --no-merges --pretty='- %h %s' "${prev_sha}..${new_sha}" \
-    | grep -E '^- [0-9a-f]+ (feat|fix)' || echo "_none_"
-  echo
-  echo "### everything else"
-  echo
-  git -C "$OBJECTUI_ROOT" log --no-merges --pretty='- %h %s' "${prev_sha}..${new_sha}" \
-    | grep -Ev '^- [0-9a-f]+ (feat|fix)' || echo "_none_"
+  print_log_split "$OBJECTUI_ROOT" "${prev_sha}..${new_sha}"
+fi
+echo
+
+echo "## 4. Cloud (control plane) — time window"
+echo
+
+prev_date=$(git log -1 --format=%cI "${PREV_REF}")
+new_date=$(git log -1 --format=%cI "${NEW_REF}")
+echo "- window: ${prev_date} → ${new_date} (cloud is not pinned; window edges are approximate)"
+echo
+
+if [[ -z "$CLOUD_ROOT" || ! -d "$CLOUD_ROOT/.git" ]]; then
+  echo "_cloud checkout not found (set CLOUD_ROOT); scan it by this window manually._"
+else
+  print_log_split "$CLOUD_ROOT" --since="$prev_date" --until="$new_date"
 fi
 
 echo
 echo "---"
 echo "_Write the curated page at content/docs/releases/, register it in"
-echo "content/docs/releases/meta.json, and link it from index.mdx._"
+echo "content/docs/releases/meta.json, and link it from index.mdx. Items with a"
+echo "changeset have the best prose in section 2; section 1 is the completeness"
+echo "check — every developer-visible feat/fix should be accounted for._"


### PR DESCRIPTION
## Why

Follow-up to #1702. The v9.0.0 page was curated from the 8 consumed changesets, but the `@objectstack/spec@8.0.1..9.0.0` range contains **41 commits** — several developer-visible features shipped without a changeset, and the ADR-0007 private package publish/install wave lives in the **cloud** repo, which the page (and the collector script) didn't cover at all.

## Page additions

**New in the framework**
- Automation: nested durable pause — a pausing node inside a subflow suspends the whole chain as linked runs; wait timers re-arm after a cold boot instead of stranding suspended runs
- Publishing: seed rows materialize on **every** publish path, reported under `seedApplied`
- AI service: tools stream progress mid-execution (`data-*` parts) — what powers Console's live build tree

**New section: ObjectStack Cloud**
- In-environment package install via reconciliation (ADR-0007 ①) — Console's Installed view reads the control-plane list when cloud-bound
- Environment API authorization hardening (org-scoped reads, owner/admin for destructive ops)
- Explicitly defers ADR-0007 ② (org-default `os package publish`) to the next release — it landed after the 9.0.0 tag

**Notable fixes**: `create-objectstack` projects start cleanly under pnpm; Setup → System Settings i18n.

## Collector script

`scripts/collect-release-notes.sh` now emits four sections: (1) **all** framework commits in the range — the completeness check, since changeset discipline is partial; (2) consumed changesets (curated prose); (3) objectui pin range; (4) cloud commits in the release time window (cloud tracks the framework via `link:` deps with no pin and versions independently, so the tag-date window is the best available scope).

## Verification

- Rendered locally: all new H2/H3 sections appear, page 200, no console errors
- `scripts/collect-release-notes.sh "@objectstack/spec@8.0.1" "@objectstack/spec@9.0.0"` reproduces all four sections; cloud section matches a manual window scan (19 commits, no branch duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)