### PR TITLE
docs(references): regenerate flow reference for the map node type

### DIFF
--- a/content/docs/references/automation/flow.mdx
+++ b/content/docs/references/automation/flow.mdx
@@ -80,6 +80,7 @@ const result = FlowNode.parse(data);
 * `screen`
 * `wait`
 * `subflow`
+* `map`
 * `connector_action`
 * `parallel_gateway`
 * `join_gateway`


### PR DESCRIPTION
Follow-up to #1709 — `map` was added to the `FlowNodeAction` enum; this regenerates `content/docs/references/automation/flow.mdx` (generated from the Zod descriptions) so the published node-type list includes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)