### PR TITLE
docs(adr): renumber the token/scope-tree ADR 0037 → 0039 (resolve collision)

### DIFF
--- a/content/docs/guides/metadata/flow.mdx
+++ b/content/docs/guides/metadata/flow.mdx
@@ -345,7 +345,7 @@ This is the **aggregating-node** pattern (Camunda multi-instance / Step Function
 `Map`): the run keeps a single program counter and pauses once, so it needs no
 concurrent-token machinery. Durable pause **inside** a hand-drawn `parallel`
 branch or `loop` iteration — where two unrelated positions pause independently —
-is a separate, larger capability ([ADR-0037](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0037-token-scope-tree-execution.md)
+is a separate, larger capability ([ADR-0039](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0039-token-scope-tree-execution.md)
 Track B); the aggregating node covers the common parallel/batch-approval demand
 without it. Worked example: `showcase_invoice_signoff` in the showcase app.
 
@@ -376,7 +376,7 @@ The run holds a **single program counter** the whole time: only one item's
 approval is open at any moment; when it is decided the engine **re-enters** the
 map node to start the next item. v1 is sequential and fail-fast (the first item
 whose subflow fails fails the map). Concurrent fan-out (all items at once) is the
-larger [ADR-0037](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0037-token-scope-tree-execution.md)
+larger [ADR-0039](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0039-token-scope-tree-execution.md)
 Track B work. Worked example: `showcase_release_signoff` → `showcase_one_task_signoff`.
 
 ### Nested pause — pausing inside a subflow

--- a/docs/adr/0019-approval-as-flow-node.md
+++ b/docs/adr/0019-approval-as-flow-node.md
@@ -176,7 +176,7 @@ The open-source / enterprise split is **not** an architectural concern and is **
 A pausing node inside a **subflow** now suspends the whole chain instead of failing the parent.
 Model: **linked runs** (the inter-flow half of the long-term execution-state architecture —
 cf. Step Functions nested executions / Temporal child workflows; the intra-flow half, a
-token/scope tree replacing the single-program-counter continuation, is [ADR-0037](./0037-token-scope-tree-execution.md)).
+token/scope tree replacing the single-program-counter continuation, is [ADR-0039](./0039-token-scope-tree-execution.md)).
 
 - The child's continuation persists under its **own run id** (run identity keeps per-flow version
   pinning, run logs, and `$runId`-based approval/wait correlation intact). The parent suspends at

--- a/docs/adr/0031-advanced-flow-node-executors-and-dag.md
+++ b/docs/adr/0031-advanced-flow-node-executors-and-dag.md
@@ -199,7 +199,7 @@ with best-effort folding of foreign BPMN gateways. BPMN 2.0 **XML**
 - Durable pause *inside* a `parallel` branch or `loop` iteration — the structured
   constructs run their regions synchronously here. Generalizing the engine's
   single-program-counter to a token/scope tree (the runtime dual of these
-  regions) is [ADR-0037](./0037-token-scope-tree-execution.md).
+  regions) is [ADR-0039](./0039-token-scope-tree-execution.md).
 
 ## Already shipped this line of work
 

--- a/docs/adr/0039-token-scope-tree-execution.md
+++ b/docs/adr/0039-token-scope-tree-execution.md
@@ -1,4 +1,4 @@
-# ADR-0037: Concurrent durable pause — multi-instance nodes now, token/scope-tree later
+# ADR-0039: Concurrent durable pause — multi-instance nodes now, token/scope-tree later
 
 **Status**: Proposed (2026-06-11) — revised after a code + industry self-review
 **Deciders**: ObjectStack Protocol Architects

--- a/examples/app-showcase/src/flows/index.ts
+++ b/examples/app-showcase/src/flows/index.ts
@@ -833,7 +833,7 @@ export const ResilientSyncFlow = defineFlow({
 });
 
 /**
- * Invoice Dual Sign-off — the worked **parallel-approval** example (ADR-0037
+ * Invoice Dual Sign-off — the worked **parallel-approval** example (ADR-0039
  * Track A: aggregating approval node, no engine-core change).
  *
  * "Finance AND legal must both sign off before an invoice is sent" is expressed
@@ -853,7 +853,7 @@ export const ResilientSyncFlow = defineFlow({
 export const InvoiceDualSignoffFlow = defineFlow({
   name: 'showcase_invoice_signoff',
   label: 'Invoice Dual Sign-off (parallel approval)',
-  description: 'On send, requires finance AND legal to both approve via one aggregating approval node — demonstrates parallel approvals without a token tree (ADR-0037 Track A).',
+  description: 'On send, requires finance AND legal to both approve via one aggregating approval node — demonstrates parallel approvals without a token tree (ADR-0039 Track A).',
   type: 'autolaunched',
   nodes: [
     {
@@ -957,7 +957,7 @@ export const OneTaskSignoffSubflow = defineFlow({
 });
 
 /**
- * Release Sign-off — the worked **batch-approval** example (ADR-0037 Track A2:
+ * Release Sign-off — the worked **batch-approval** example (ADR-0039 Track A2:
  * the sequential `map` / multi-instance node).
  *
  * "Every task in the release must be signed off, one at a time" is a **single
@@ -975,7 +975,7 @@ export const OneTaskSignoffSubflow = defineFlow({
 export const ReleaseSignoffFlow = defineFlow({
   name: 'showcase_release_signoff',
   label: 'Release Sign-off (batch approval / map)',
-  description: 'Signs off every task in a release one at a time via a map node — demonstrates batch approval (ADR-0037 Track A2).',
+  description: 'Signs off every task in a release one at a time via a map node — demonstrates batch approval (ADR-0039 Track A2).',
   type: 'autolaunched',
   variables: [
     { name: 'items', type: 'list', isInput: true },


### PR DESCRIPTION
Resolves a duplicate ADR-0037 on main: #1694 "Live Canvas" (created 2026-06-10) and #1706 "token tree" (this work, 2026-06-11) both merged as 0037. Live Canvas has precedence; the token-tree ADR yields to the next free number (0038 = Build Verification Loop), so it becomes **0039**. Updates only this work's own references (ADR-0019/0031 forward-refs, flow guide Track A/B links, showcase comments). Live Canvas stays 0037, untouched. Docs build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)