### PR TITLE
docs(adr-0006): Phase 1 — mark framework cloud-plugin duplicates @deprecated

### DIFF
--- a/packages/runtime/src/cloud/cloud-url.ts
+++ b/packages/runtime/src/cloud/cloud-url.ts
@@ -8,6 +8,13 @@
  * Until we have a competing public hosted cloud, this points at the
  * ObjectStack-operated control plane so a vanilla `objectstack dev` can
  * browse the marketplace out of the box.
+ *
+ * @deprecated ADR-0006 — framework's DUPLICATE copy. Canonical implementation
+ * lives in cloud `@objectstack/objectos-runtime`
+ * (`packages/objectos-runtime/src/cloud-url.ts`), which `apps/objectos` already
+ * uses. **Still load-bearing**: the framework CLI `serve.ts` dynamically
+ * imports `resolveCloudUrl` for cloud-dev serve mode — DO NOT DELETE until
+ * ADR-0006 Phase 4 decouples the CLI (= ADR-0007 ⑤). Phase 1 declaration only.
  */
 export const DEFAULT_CLOUD_URL = 'https://cloud.objectos.ai';
 

--- a/packages/runtime/src/cloud/marketplace-install-local-plugin.ts
+++ b/packages/runtime/src/cloud/marketplace-install-local-plugin.ts
@@ -80,6 +80,16 @@ function safeFilename(manifestId: string): string {
     return manifestId.replace(/[^a-zA-Z0-9._-]/g, '_') + '.json';
 }
 
+/**
+ * @deprecated ADR-0006 / ADR-0007 ⑤ — framework's DUPLICATE copy. Canonical
+ * implementation lives in cloud `@objectstack/objectos-runtime`
+ * (`packages/objectos-runtime/src/marketplace-install-local-plugin.ts`), which
+ * `apps/objectos` already uses and which is AHEAD of this copy (e.g. the
+ * ADR-0036 `seeds:` rename). **Still load-bearing**: the framework CLI
+ * `serve.ts` dynamically imports this for cloud-dev serve mode — DO NOT DELETE
+ * until ADR-0006 Phase 4 decouples the CLI. Phase 1 is a declaration only:
+ * no behavior change.
+ */
 export class MarketplaceInstallLocalPlugin implements Plugin {
     readonly name = 'com.objectstack.runtime.marketplace-install-local';
     readonly version = '1.0.0';

--- a/packages/runtime/src/cloud/marketplace-proxy-plugin.ts
+++ b/packages/runtime/src/cloud/marketplace-proxy-plugin.ts
@@ -145,6 +145,15 @@ export interface MarketplaceProxyPluginConfig {
     publicMarketplaceBaseUrl?: string;
 }
 
+/**
+ * @deprecated ADR-0006 — framework's DUPLICATE copy. Canonical implementation
+ * lives in cloud `@objectstack/objectos-runtime`
+ * (`packages/objectos-runtime/src/marketplace-proxy-plugin.ts`), which
+ * `apps/objectos` already uses. **Still load-bearing**: the framework CLI
+ * `serve.ts` dynamically imports this for cloud-dev serve mode — DO NOT DELETE
+ * until ADR-0006 Phase 4 decouples the CLI (= ADR-0007 ⑤). Phase 1 is a
+ * declaration only: no behavior change.
+ */
 export class MarketplaceProxyPlugin implements Plugin {
     readonly name = 'com.objectstack.runtime.marketplace-proxy';
     readonly version = '1.1.0';

--- a/packages/runtime/src/cloud/runtime-config-plugin.ts
+++ b/packages/runtime/src/cloud/runtime-config-plugin.ts
@@ -65,6 +65,15 @@ export interface RuntimeConfigPluginConfig {
     productShortName?: string;
 }
 
+/**
+ * @deprecated ADR-0006 — framework's DUPLICATE copy. Canonical implementation
+ * lives in cloud `@objectstack/objectos-runtime`
+ * (`packages/objectos-runtime/src/runtime-config-plugin.ts`), which
+ * `apps/objectos` already uses. **Still load-bearing**: the framework CLI
+ * `serve.ts` dynamically imports this for cloud-dev serve mode — DO NOT DELETE
+ * until ADR-0006 Phase 4 decouples the CLI (= ADR-0007 ⑤). Phase 1 is a
+ * declaration only: no behavior change.
+ */
 export class RuntimeConfigPlugin implements Plugin {
     readonly name = 'com.objectstack.runtime.runtime-config';
     readonly version = '1.0.0';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -100,12 +100,25 @@ export type { LoadArtifactBundleOptions } from './load-artifact-bundle.js';
 // (`@objectstack/objectos-runtime`). The framework keeps only the interface
 // contracts a host runtime needs to accept an externally-supplied
 // multi-tenant kernel router (see http-dispatcher's optional `kernelManager`).
+//
+// ADR-0006 Phase 1: the three plugins + cloud-url below are DUPLICATES of the
+// canonical copies in cloud `@objectstack/objectos-runtime`. They stay exported
+// and load-bearing (framework CLI cloud-dev serve) until ADR-0006 Phase 4
+// removes them (= ADR-0007 ⑤). `EnvironmentDriverRegistry` / `KernelManager`
+// are RETAINED contracts (D3) — not deprecated.
+/** @deprecated ADR-0006 — use cloud `@objectstack/objectos-runtime`. Removed in Phase 4. */
 export { MarketplaceProxyPlugin } from './cloud/marketplace-proxy-plugin.js';
+/** @deprecated ADR-0006 — use cloud `@objectstack/objectos-runtime`. Removed in Phase 4. */
 export type { MarketplaceProxyPluginConfig } from './cloud/marketplace-proxy-plugin.js';
+/** @deprecated ADR-0006 / ADR-0007 ⑤ — use cloud `@objectstack/objectos-runtime`. Removed in Phase 4. */
 export { MarketplaceInstallLocalPlugin } from './cloud/marketplace-install-local-plugin.js';
+/** @deprecated ADR-0006 / ADR-0007 ⑤ — use cloud `@objectstack/objectos-runtime`. Removed in Phase 4. */
 export type { MarketplaceInstallLocalPluginConfig } from './cloud/marketplace-install-local-plugin.js';
+/** @deprecated ADR-0006 — use cloud `@objectstack/objectos-runtime`. Removed in Phase 4. */
 export { RuntimeConfigPlugin } from './cloud/runtime-config-plugin.js';
+/** @deprecated ADR-0006 — use cloud `@objectstack/objectos-runtime`. Removed in Phase 4. */
 export type { RuntimeConfigPluginConfig } from './cloud/runtime-config-plugin.js';
+/** @deprecated ADR-0006 — use cloud `@objectstack/objectos-runtime`. Removed in Phase 4. */
 export { DEFAULT_CLOUD_URL, resolveCloudUrl } from './cloud/cloud-url.js';
 export type { EnvironmentDriverRegistry, KernelManager } from './cloud/environment-registry.js';
 


### PR DESCRIPTION
## ADR-0006 Phase 1 — 去重声明 (also ADR-0007 ⑤ "宣告 canonical")

Low-risk, declaration-only step of the multi-tenant runtime boundary refactor (cloud ADR-0006). The cloud repo's `@objectstack/objectos-runtime` is the **canonical** source for these plugins — `apps/objectos` already uses it, and its `marketplace-install-local` copy is **ahead** of this one (ADR-0036 `seeds:` rename). This marks the framework's **duplicate** copies `@deprecated` and points consumers at the canonical cloud copies.

### Scope (ADR D5 delete-set only)
`@deprecated` on: `MarketplaceProxyPlugin`, `MarketplaceInstallLocalPlugin`, `RuntimeConfigPlugin`, `cloud-url` (`DEFAULT_CLOUD_URL` / `resolveCloudUrl`) — file-level (above each export) **and** on the `packages/runtime/src/index.ts` re-exports.

**Deliberately NOT deprecated:** `EnvironmentDriverRegistry` / `KernelManager` — those are *retained* generic contracts (ADR D3), converged later in Phase 3/5.

### These copies are STILL load-bearing — do not delete yet
The framework CLI `serve.ts` dynamically imports these for cloud-dev serve mode, and the cloud app itself boots via the framework CLI. Each banner says explicitly: **DO NOT DELETE until ADR-0006 Phase 4** decouples the CLI. Phase 1 is a declaration only; deletion is Phase 4.

### Safety
JSDoc tags only — **no behavior change, no API removed**. `pnpm --filter @objectstack/runtime build` (incl. DTS) succeeds; `@objectstack/runtime` tests **381 passed**.

> Pairs with cloud-repo ADR-0006 **Phase 0** safety-net PR (objectstack-ai/cloud#206). Merge order is not constrained — this PR removes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)