### PR TITLE
feat(cli): build-time warning for count-only table/pivot dashboard widgets (table-count-only)

### DIFF
--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -9,6 +9,7 @@ import { ObjectStackDefinitionSchema, normalizeStackInput } from '@objectstack/s
 import { loadConfig } from '../utils/config.js';
 import { lowerCallables } from '../utils/lower-callables.js';
 import { validateStackExpressions } from '../utils/validate-expressions.js';
+import { validateWidgetBindings } from '../utils/validate-widget-bindings.js';
 import { buildRuntimeBundle, cleanupOldRuntimeBundles } from '../utils/build-runtime.js';
 import {
   printHeader,
@@ -16,6 +17,7 @@ import {
   printSuccess,
   printError,
   printStep,
+  printWarning,
   createTimer,
   formatZodErrors,
   collectMetadataStats,
@@ -145,6 +147,22 @@ export default class Compile extends Command {
         this.exit(1);
       }
 
+      // 3c. Widget-binding diagnostics (issue #1719) — semantic checks that
+      //     need the widget's `dataset` reference resolved to its dataset and
+      //     `values` resolved to measures with known aggregates. Advisory
+      //     only: warnings are printed (and included in --json output) but
+      //     never fail the build. Suppress per widget via
+      //     `suppressWarnings: ['<rule-id>']`.
+      const widgetWarnings = validateWidgetBindings(result.data as Record<string, unknown>);
+      if (widgetWarnings.length > 0 && !flags.json) {
+        console.log('');
+        for (const w of widgetWarnings) {
+          printWarning(`${w.where}: ${w.message}`);
+          console.log(chalk.dim(`    ${w.hint}`));
+          console.log(chalk.dim(`    rule: ${w.rule}  at ${w.path}`));
+        }
+      }
+
       // 4. Generate Artifact
       if (!flags.json) printStep('Writing artifact...');
       const output = flags.output!;
@@ -227,6 +245,7 @@ export default class Compile extends Command {
           handlersBundled: lowering.count,
           runtimeModule: runtimeBundle?.outputFileName ?? null,
           runtimeModuleSize: runtimeBundle?.size ?? 0,
+          warnings: widgetWarnings,
           stats,
           duration: timer.elapsed(),
         }));
@@ -236,6 +255,9 @@ export default class Compile extends Command {
       // 5. Summary
       console.log('');
       printSuccess(`Build complete ${chalk.dim(`(${timer.display()})`)}`);
+      if (widgetWarnings.length > 0) {
+        printWarning(`${widgetWarnings.length} widget-binding warning(s) — see above`);
+      }
       console.log('');
       printMetadataStats(stats);
       console.log('');

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -7,6 +7,7 @@ import { normalizeStackInput } from '@objectstack/spec';
 import { loadConfig, BUNDLE_REQUIRE_EXTERNALS } from '../utils/config.js';
 import { computeI18nCoverage } from '../utils/i18n-coverage.js';
 import { lintDataModel } from '../lint/data-model-rules.js';
+import { validateWidgetBindings } from '../utils/validate-widget-bindings.js';
 import { scoreMetadata } from '../lint/score.js';
 import { runMetadataEval } from '../lint/metadata-eval.js';
 import { DEFAULT_METADATA_EVAL_CORPUS } from '../lint/corpus.js';
@@ -218,6 +219,20 @@ export function lintConfig(config: any): LintIssue[] {
   // Cross-object rules that encode the conventions in ADR-0035 and the
   // objectstack-data/-ui skills. These double as the eval rubric (see score.ts).
   issues.push(...lintDataModel(objects));
+
+  // ── Dashboard widget bindings (ADR-0021, issue #1719) ──
+  // e.g. a table/pivot widget whose binding resolves to count-only measures
+  // with no dimensions — almost always a record listing that belongs in an
+  // object-bound ListView (ADR-0017), not an analytics dataset.
+  for (const w of validateWidgetBindings(config)) {
+    issues.push({
+      severity: 'warning',
+      rule: w.rule,
+      message: `${w.where}: ${w.message}`,
+      path: w.path,
+      fix: w.hint,
+    });
+  }
 
   return issues;
 }

--- a/packages/cli/src/utils/validate-widget-bindings.test.ts
+++ b/packages/cli/src/utils/validate-widget-bindings.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { validateWidgetBindings, TABLE_COUNT_ONLY } from './validate-widget-bindings.js';
+
+/** The downstream repro from issue #1719 — dataset with a count AND a sum
+ *  measure plus a dimension; the widget selects only the count, no dims. */
+function reproStack(widgetOverrides: Record<string, unknown> = {}) {
+  return {
+    datasets: [{
+      name: 'expense_report_metrics',
+      label: 'Expense report metrics',
+      object: 'expense_report',
+      measures: [
+        { name: 'report_count', label: 'report_count', aggregate: 'count' },
+        { name: 'total_amount', label: 'total_amount', aggregate: 'sum', field: 'total_amount' },
+      ],
+      dimensions: [{ name: 'cost_center', field: 'cost_center' }],
+    }],
+    dashboards: [{
+      name: 'expenses_overview_dashboard',
+      label: 'Expenses Overview',
+      widgets: [{
+        id: 'pending_reports_table',
+        type: 'table',
+        dataset: 'expense_report_metrics',
+        values: ['report_count'],
+        filter: { status: 'submitted' },
+        layout: { x: 0, y: 0, w: 6, h: 4 },
+        ...widgetOverrides,
+      }],
+    }],
+  };
+}
+
+describe('validateWidgetBindings (table-count-only, issue #1719)', () => {
+  it('warns on the issue repro: count-only table widget without dimensions', () => {
+    const warnings = validateWidgetBindings(reproStack());
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].rule).toBe(TABLE_COUNT_ONLY);
+    expect(warnings[0].where).toContain('expenses_overview_dashboard');
+    expect(warnings[0].where).toContain('pending_reports_table');
+    expect(warnings[0].path).toBe('dashboards[0].widgets[0]');
+    expect(warnings[0].message).toContain('report_count');
+    expect(warnings[0].message).toContain('single summary row');
+    expect(warnings[0].hint).toContain('ListView (ADR-0017)');
+    expect(warnings[0].hint).toContain(`suppressWarnings: ['${TABLE_COUNT_ONLY}']`);
+  });
+
+  it('warns for pivot widgets too', () => {
+    const warnings = validateWidgetBindings(reproStack({ type: 'pivot' }));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain("'pivot' widget");
+  });
+
+  it('is keyed on the WIDGET binding — selecting the sum measure is clean', () => {
+    expect(validateWidgetBindings(reproStack({ values: ['total_amount'] }))).toHaveLength(0);
+  });
+
+  it('mixed count + non-count selection is clean', () => {
+    expect(validateWidgetBindings(reproStack({ values: ['report_count', 'total_amount'] }))).toHaveLength(0);
+  });
+
+  it('declaring a dimension on the widget is clean', () => {
+    expect(validateWidgetBindings(reproStack({ dimensions: ['cost_center'] }))).toHaveLength(0);
+  });
+
+  it('metric widgets are exactly what a count-only binding wants — clean', () => {
+    expect(validateWidgetBindings(reproStack({ type: 'metric' }))).toHaveLength(0);
+  });
+
+  it('suppressWarnings opts a deliberate single-row table out', () => {
+    expect(validateWidgetBindings(reproStack({ suppressWarnings: [TABLE_COUNT_ONLY] }))).toHaveLength(0);
+  });
+
+  it('unrelated suppressWarnings entries do not suppress', () => {
+    expect(validateWidgetBindings(reproStack({ suppressWarnings: ['some-other-rule'] }))).toHaveLength(1);
+  });
+
+  it('skips dangling dataset references (cross-reference finding, not this rule)', () => {
+    expect(validateWidgetBindings(reproStack({ dataset: 'no_such_dataset' }))).toHaveLength(0);
+  });
+
+  it('skips unresolvable measure names (a different diagnostic)', () => {
+    expect(validateWidgetBindings(reproStack({ values: ['no_such_measure'] }))).toHaveLength(0);
+  });
+
+  it('treats derived measures as non-count even when aggregate says count', () => {
+    const stack = reproStack({ values: ['count_ratio'] });
+    (stack.datasets[0].measures as Record<string, unknown>[]).push({
+      name: 'count_ratio',
+      aggregate: 'count',
+      derived: { op: 'ratio', of: ['report_count', 'report_count'] },
+    });
+    expect(validateWidgetBindings(stack)).toHaveLength(0);
+  });
+
+  it('count_distinct is a deliberate analytic — clean', () => {
+    const stack = reproStack({ values: ['unique_requesters'] });
+    (stack.datasets[0].measures as Record<string, unknown>[]).push({
+      name: 'unique_requesters',
+      aggregate: 'count_distinct',
+      field: 'requester',
+    });
+    expect(validateWidgetBindings(stack)).toHaveLength(0);
+  });
+
+  it('handles map-keyed datasets/dashboards collections', () => {
+    const arrayForm = reproStack();
+    const { name: _dsName, ...dsRest } = arrayForm.datasets[0];
+    const { name: _dashName, ...dashRest } = arrayForm.dashboards[0];
+    const stack = {
+      datasets: { expense_report_metrics: dsRest },
+      dashboards: { expenses_overview_dashboard: dashRest },
+    };
+    const warnings = validateWidgetBindings(stack);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].where).toContain('expenses_overview_dashboard');
+  });
+
+  it('is silent on stacks without dashboards or datasets', () => {
+    expect(validateWidgetBindings({})).toHaveLength(0);
+    expect(validateWidgetBindings({ dashboards: [], datasets: [] })).toHaveLength(0);
+  });
+});

--- a/packages/cli/src/utils/validate-widget-bindings.ts
+++ b/packages/cli/src/utils/validate-widget-bindings.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Build-time dashboard widget binding diagnostics (issue #1719).
+ *
+ * Runs at `objectstack compile`/`build` AFTER the stack has been schema-parsed,
+ * so every widget's `dataset` reference can be linked to its `defineDataset`
+ * and each entry in `values` resolved to a concrete measure with a known
+ * `aggregate`. This is the semantic/cross-reference phase — the rules here
+ * cannot run during plain Zod parsing of the raw widget literal.
+ *
+ * Rule `table-count-only`: a `table` / `pivot` widget whose selected measures
+ * are ALL `aggregate: 'count'` and which declares no `dimensions` asks the
+ * analytics service for a single summary row. That is the shape a `metric`
+ * widget wants — for a table it almost always means the author wanted a
+ * per-record listing, which is not an analytics dataset at all (model it as an
+ * object-bound ListView, ADR-0017). The signal is evaluated on the WIDGET's
+ * binding, not the dataset: a dataset may well carry other measures and
+ * dimensions the widget simply doesn't select.
+ *
+ * Warnings are non-fatal by design — `objectstack build` stays green — and a
+ * deliberate single-row table can opt out per widget via
+ * `suppressWarnings: ['table-count-only']`.
+ */
+
+export const TABLE_COUNT_ONLY = 'table-count-only';
+
+export interface WidgetBindingWarning {
+  /** Diagnostic rule id (registry entry), e.g. `table-count-only`. */
+  rule: string;
+  /** Human-readable location, e.g. `dashboard "x" › widget "y"`. */
+  where: string;
+  /** Config path, e.g. `dashboards[0].widgets[3]`. */
+  path: string;
+  /** What is wrong. */
+  message: string;
+  /** How to fix (or deliberately suppress) it. */
+  hint: string;
+}
+
+type AnyRec = Record<string, unknown>;
+
+/** Coerce a collection (array or name-keyed map) to an array. */
+function asArray(v: unknown): AnyRec[] {
+  if (Array.isArray(v)) return v as AnyRec[];
+  if (v && typeof v === 'object') {
+    return Object.entries(v as AnyRec).map(([name, def]) => ({ name, ...(def as AnyRec) }));
+  }
+  return [];
+}
+
+/**
+ * Validate every dashboard widget's dataset binding. Returns the list of
+ * warnings (empty = clean). Caller decides how to surface them — these are
+ * advisory and must never fail the build on their own.
+ */
+export function validateWidgetBindings(stack: AnyRec): WidgetBindingWarning[] {
+  const warnings: WidgetBindingWarning[] = [];
+
+  const datasets = new Map<string, AnyRec>();
+  for (const ds of asArray(stack.datasets)) {
+    if (typeof ds.name === 'string') datasets.set(ds.name, ds);
+  }
+
+  const dashboards = asArray(stack.dashboards);
+  for (let i = 0; i < dashboards.length; i++) {
+    const dash = dashboards[i];
+    const dashName = typeof dash.name === 'string' ? dash.name : `(dashboard ${i})`;
+    const widgets = Array.isArray(dash.widgets) ? (dash.widgets as AnyRec[]) : [];
+
+    for (let j = 0; j < widgets.length; j++) {
+      const w = widgets[j];
+      if (w.type !== 'table' && w.type !== 'pivot') continue;
+      // Grouped by at least one dimension → genuinely aggregated rows.
+      if (Array.isArray(w.dimensions) && w.dimensions.length > 0) continue;
+      // Author opted out — a single-row summary table is intentional here.
+      if (Array.isArray(w.suppressWarnings) && w.suppressWarnings.includes(TABLE_COUNT_ONLY)) continue;
+
+      const dsName = typeof w.dataset === 'string' ? w.dataset : undefined;
+      const dataset = dsName ? datasets.get(dsName) : undefined;
+      // A dangling dataset reference is a cross-reference finding, not this rule.
+      if (!dataset) continue;
+
+      const measures = new Map<string, AnyRec>();
+      for (const m of asArray(dataset.measures)) {
+        if (typeof m.name === 'string') measures.set(m.name, m);
+      }
+
+      const values = Array.isArray(w.values)
+        ? (w.values as unknown[]).filter((v): v is string => typeof v === 'string')
+        : [];
+      if (values.length === 0) continue;
+      const resolved = values.map((v) => measures.get(v));
+      // An unresolvable measure name is a different diagnostic — don't guess.
+      if (resolved.some((m) => !m)) continue;
+
+      // Derived measures combine other measures; treat them as non-count even
+      // when their (ignored) `aggregate` says otherwise.
+      const countOnly = resolved.every((m) => m!.aggregate === 'count' && !m!.derived);
+      if (!countOnly) continue;
+
+      const widgetId = typeof w.id === 'string' ? w.id : `(widget ${j})`;
+      warnings.push({
+        rule: TABLE_COUNT_ONLY,
+        where: `dashboard "${dashName}" › widget "${widgetId}"`,
+        path: `dashboards[${i}].widgets[${j}]`,
+        message:
+          `a '${w.type}' widget bound to dataset "${dsName}" selects only count ` +
+          `measure(s) (${values.join(', ')}) and no dimensions, so it renders a ` +
+          `single summary row — not a per-record list.`,
+        hint:
+          `A flat record listing is not an analytics dataset. Model it as an ` +
+          `object-bound ListView (ADR-0017) surfaced through app navigation, and ` +
+          `use a 'metric' widget here if you only need the count. If a single-row ` +
+          `table is intentional, add an explicit dimension or suppress with: ` +
+          `suppressWarnings: ['${TABLE_COUNT_ONLY}']`,
+      });
+    }
+  }
+
+  return warnings;
+}

--- a/packages/spec/src/ui/dashboard.zod.ts
+++ b/packages/spec/src/ui/dashboard.zod.ts
@@ -176,6 +176,13 @@ export const DashboardWidgetSchema = lazySchema(() => z.object({
   /** Widget specific options (colors, legend, etc.) */
   options: z.unknown().optional().describe('Widget specific configuration'),
 
+  /**
+   * Rule ids of build diagnostics intentionally suppressed on this widget
+   * (e.g. `'table-count-only'` when a single-row summary table is deliberate).
+   * Consumed by `objectstack build` / `objectstack lint`; no runtime effect.
+   */
+  suppressWarnings: z.array(z.string()).optional().describe('Build diagnostic rule ids suppressed on this widget'),
+
   /** Responsive layout overrides per breakpoint */
   responsive: ResponsiveConfigSchema.optional().describe('Responsive layout configuration'),
 


### PR DESCRIPTION
Closes #1719.

## What

After the ADR-0021 single-form cutover, a `table`/`pivot` `DashboardWidget` whose selected `values` resolve to **only `count` measures** and which declares **no `dimensions`** asks the analytics service for a single summary row. That's exactly what a `metric` widget wants — but for a table it almost always means the author wanted a per-record listing, which is not an analytics dataset at all (ADR-0017 ListView territory). `objectstack build` was silently green on this shape; downstream it collapsed **19 record-listing tables across 11 dashboards** ([templates#27](https://github.com/objectstack-ai/templates/pull/27)).

`objectstack build` now emits a **non-fatal** `table-count-only` warning per offending widget:

```
⚠ dashboard "expenses_overview_dashboard" › widget "pending_reports_table": a 'table' widget
  bound to dataset "expense_report_metrics" selects only count measure(s) (report_count) and
  no dimensions, so it renders a single summary row — not a per-record list.
    A flat record listing is not an analytics dataset. Model it as an object-bound ListView
    (ADR-0017) surfaced through app navigation, and use a 'metric' widget here if you only
    need the count. If a single-row table is intentional, add an explicit dimension or
    suppress with: suppressWarnings: ['table-count-only']
    rule: table-count-only  at dashboards[0].widgets[0]
```

## How

- **`packages/cli/src/utils/validate-widget-bindings.ts`** — new semantic-phase check mirroring the ADR-0032 `validateStackExpressions` pattern. It runs after Zod parse, when each widget's `dataset` name is linked to its `defineDataset` and every `values` entry resolves to a measure with a known `aggregate`. Per the issue, the heuristic is keyed on the **widget's binding**, not the dataset — the repro dataset also carries a `sum` measure and a dimension, and still warns because the widget selects neither.
- **`compile.ts` (= `build`)** — prints warnings in human output; `--json` gains a `warnings[]` array. The build never fails on these.
- **`lint.ts`** — the same rule surfaces through `objectstack lint` with rule id `table-count-only`, consistent with the existing rule registry.
- **`spec/ui/dashboard.zod.ts`** — new optional widget field `suppressWarnings: string[]` as the opt-out for deliberate single-row tables.

## Deviations from the issue

The proposed `// objectstack-disable-next-line table-count-only` comment can't work here: the config is evaluated through bundle-require, so source comments never reach the metadata the check runs on. The suppression is metadata-level instead (`suppressWarnings: ['table-count-only']` on the widget), schema-validated and mentioned verbatim in the warning text.

Deliberately **not** warned (each is a different diagnostic or a legitimate shape): dangling dataset references, unresolvable measure names, mixed count+non-count selections, `count_distinct`, derived measures, any widget with ≥1 dimension, and `metric` widgets.

## Testing

- 14 new unit tests covering the issue's repro, the widget-binding-vs-dataset distinction, pivot, suppression, and all the skip cases (`validate-widget-bindings.test.ts`)
- Full `@objectstack/cli` suite: 28 files / 240 tests green; `@objectstack/spec` dashboard+stack tests green; both packages compile
- End-to-end: ran `objectstack build` on the issue's minimal repro — warning fires, build stays green, `--json` carries the warning, `suppressWarnings` silences it; `objectstack lint` reports the same rule
- The platform's own `system_overview` table widget declares `dimensions: ['action']` and does not trip the rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)