### PR TITLE
feat(cli): dashboard widget reference integrity check (dataset → dimensions/measures + chartConfig fields)

### DIFF
--- a/examples/app-crm/src/dashboards/pipeline.dashboard.ts
+++ b/examples/app-crm/src/dashboards/pipeline.dashboard.ts
@@ -90,6 +90,15 @@ export const PipelineDashboard: Dashboard = {
       dataset: 'opportunity_metrics',
       dimensions: ['close_date'],
       values: ['opp_count'],
+      // Axis fields name the dataset's dimension/measure (NOT base columns) —
+      // post-cutover query rows are keyed by measure name (issue #1721).
+      chartConfig: {
+        type: 'line',
+        xAxis: { field: 'close_date', showGridLines: true, logarithmic: false },
+        yAxis: [{ field: 'opp_count', showGridLines: true, logarithmic: false }],
+        showLegend: true,
+        showDataLabels: false,
+      },
       layout: { x: 0, y: 2, w: 8, h: 4 },
     },
     {
@@ -107,6 +116,13 @@ export const PipelineDashboard: Dashboard = {
       dataset: 'opportunity_metrics',
       dimensions: ['stage'],
       values: ['opp_count'],
+      chartConfig: {
+        type: 'bar',
+        xAxis: { field: 'stage', showGridLines: true, logarithmic: false },
+        yAxis: [{ field: 'opp_count', showGridLines: true, logarithmic: false }],
+        showLegend: true,
+        showDataLabels: false,
+      },
       layout: { x: 8, y: 2, w: 4, h: 4 },
     },
 
@@ -120,6 +136,13 @@ export const PipelineDashboard: Dashboard = {
       dataset: 'opportunity_metrics',
       dimensions: ['stage'],
       values: ['total_amount'],
+      chartConfig: {
+        type: 'pie',
+        xAxis: { field: 'stage', showGridLines: true, logarithmic: false },
+        yAxis: [{ field: 'total_amount', showGridLines: true, logarithmic: false }],
+        showLegend: true,
+        showDataLabels: false,
+      },
       layout: { x: 0, y: 6, w: 6, h: 4 },
     },
   ],

--- a/examples/app-showcase/src/dashboards/chart-gallery.dashboard.ts
+++ b/examples/app-showcase/src/dashboards/chart-gallery.dashboard.ts
@@ -1,9 +1,19 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
-import type { Dashboard } from '@objectstack/spec/ui';
+import type { ChartConfig, ChartType, Dashboard } from '@objectstack/spec/ui';
 
 const taskDs = 'showcase_task_metrics';
 const projectDs = 'showcase_project_metrics';
+
+/** Axis fields name the dataset's dimension/measure — query rows are keyed by
+ *  measure NAME post-cutover, never the base column (issue #1721). */
+const cfg = (type: ChartType, dimension: string, measure: string): ChartConfig => ({
+  type,
+  xAxis: { field: dimension, showGridLines: true, logarithmic: false },
+  yAxis: [{ field: measure, showGridLines: true, logarithmic: false }],
+  showLegend: true,
+  showDataLabels: false,
+});
 
 /**
  * Chart Gallery — one widget per chart family the dashboard renderer can draw
@@ -34,26 +44,26 @@ export const ChartGalleryDashboard: Dashboard = {
     { id: 'kpi_total_spent', type: 'metric', title: 'Total Spent', dataset: projectDs, values: ['spent_sum'], layout: { x: 8, y: 0, w: 4, h: 2 } },
 
     // ── Comparison ─────────────────────────────────────────────────────────
-    { id: 'bar_by_status', type: 'bar', title: 'Tasks by Status', dataset: taskDs, dimensions: ['status'], values: ['task_count'], layout: { x: 0, y: 2, w: 4, h: 4 } },
-    { id: 'column_by_priority', type: 'column', title: 'Tasks by Priority', dataset: taskDs, dimensions: ['priority'], values: ['task_count'], layout: { x: 4, y: 2, w: 4, h: 4 } },
-    { id: 'hbar_hours', type: 'horizontal-bar', title: 'Hours by Status', dataset: taskDs, dimensions: ['status'], values: ['est_hours'], layout: { x: 8, y: 2, w: 4, h: 4 } },
+    { id: 'bar_by_status', type: 'bar', title: 'Tasks by Status', dataset: taskDs, dimensions: ['status'], values: ['task_count'], chartConfig: cfg('bar', 'status', 'task_count'), layout: { x: 0, y: 2, w: 4, h: 4 } },
+    { id: 'column_by_priority', type: 'column', title: 'Tasks by Priority', dataset: taskDs, dimensions: ['priority'], values: ['task_count'], chartConfig: cfg('column', 'priority', 'task_count'), layout: { x: 4, y: 2, w: 4, h: 4 } },
+    { id: 'hbar_hours', type: 'horizontal-bar', title: 'Hours by Status', dataset: taskDs, dimensions: ['status'], values: ['est_hours'], chartConfig: cfg('horizontal-bar', 'status', 'est_hours'), layout: { x: 8, y: 2, w: 4, h: 4 } },
 
     // ── Trend (month-bucketed via the dataset's created_at granularity) ──────
-    { id: 'line_created', type: 'line', title: 'Tasks Created (monthly)', dataset: taskDs, dimensions: ['created_at'], values: ['task_count'], layout: { x: 0, y: 6, w: 6, h: 4 } },
-    { id: 'area_created', type: 'area', title: 'Tasks Created (area)', dataset: taskDs, dimensions: ['created_at'], values: ['task_count'], layout: { x: 6, y: 6, w: 6, h: 4 } },
+    { id: 'line_created', type: 'line', title: 'Tasks Created (monthly)', dataset: taskDs, dimensions: ['created_at'], values: ['task_count'], chartConfig: cfg('line', 'created_at', 'task_count'), layout: { x: 0, y: 6, w: 6, h: 4 } },
+    { id: 'area_created', type: 'area', title: 'Tasks Created (area)', dataset: taskDs, dimensions: ['created_at'], values: ['task_count'], chartConfig: cfg('area', 'created_at', 'task_count'), layout: { x: 6, y: 6, w: 6, h: 4 } },
 
     // ── Distribution ─────────────────────────────────────────────────────────
-    { id: 'pie_status', type: 'pie', title: 'Status Split', dataset: taskDs, dimensions: ['status'], values: ['task_count'], layout: { x: 0, y: 10, w: 4, h: 4 } },
-    { id: 'donut_priority', type: 'donut', title: 'Priority Split', dataset: taskDs, dimensions: ['priority'], values: ['task_count'], layout: { x: 4, y: 10, w: 4, h: 4 } },
-    { id: 'funnel_status', type: 'funnel', title: 'Status Funnel', dataset: taskDs, dimensions: ['status'], values: ['task_count'], layout: { x: 8, y: 10, w: 4, h: 4 } },
+    { id: 'pie_status', type: 'pie', title: 'Status Split', dataset: taskDs, dimensions: ['status'], values: ['task_count'], chartConfig: cfg('pie', 'status', 'task_count'), layout: { x: 0, y: 10, w: 4, h: 4 } },
+    { id: 'donut_priority', type: 'donut', title: 'Priority Split', dataset: taskDs, dimensions: ['priority'], values: ['task_count'], chartConfig: cfg('donut', 'priority', 'task_count'), layout: { x: 4, y: 10, w: 4, h: 4 } },
+    { id: 'funnel_status', type: 'funnel', title: 'Status Funnel', dataset: taskDs, dimensions: ['status'], values: ['task_count'], chartConfig: cfg('funnel', 'status', 'task_count'), layout: { x: 8, y: 10, w: 4, h: 4 } },
 
     // ── Relationship + Advanced ──────────────────────────────────────────────
-    { id: 'scatter_estimate', type: 'scatter', title: 'Estimate vs Progress', dataset: taskDs, dimensions: ['progress'], values: ['avg_estimate'], layout: { x: 0, y: 14, w: 6, h: 4 } },
-    { id: 'radar_priority', type: 'radar', title: 'Priority Radar', dataset: taskDs, dimensions: ['priority'], values: ['task_count'], layout: { x: 6, y: 14, w: 6, h: 4 } },
+    { id: 'scatter_estimate', type: 'scatter', title: 'Estimate vs Progress', dataset: taskDs, dimensions: ['progress'], values: ['avg_estimate'], chartConfig: cfg('scatter', 'progress', 'avg_estimate'), layout: { x: 0, y: 14, w: 6, h: 4 } },
+    { id: 'radar_priority', type: 'radar', title: 'Priority Radar', dataset: taskDs, dimensions: ['priority'], values: ['task_count'], chartConfig: cfg('radar', 'priority', 'task_count'), layout: { x: 6, y: 14, w: 6, h: 4 } },
 
     // ── Composition ──────────────────────────────────────────────────────────
-    { id: 'treemap_hours', type: 'treemap', title: 'Hours Treemap', dataset: taskDs, dimensions: ['status'], values: ['est_hours'], layout: { x: 0, y: 18, w: 6, h: 4 } },
-    { id: 'sankey_flow', type: 'sankey', title: 'Status Flow (Sankey)', dataset: taskDs, dimensions: ['status'], values: ['task_count'], layout: { x: 6, y: 18, w: 6, h: 4 } },
+    { id: 'treemap_hours', type: 'treemap', title: 'Hours Treemap', dataset: taskDs, dimensions: ['status'], values: ['est_hours'], chartConfig: cfg('treemap', 'status', 'est_hours'), layout: { x: 0, y: 18, w: 6, h: 4 } },
+    { id: 'sankey_flow', type: 'sankey', title: 'Status Flow (Sankey)', dataset: taskDs, dimensions: ['status'], values: ['task_count'], chartConfig: cfg('sankey', 'status', 'task_count'), layout: { x: 6, y: 18, w: 6, h: 4 } },
 
     // ── Tabular (real grouped tables, multiple measures) ─────────────────────
     { id: 'table_projects', type: 'table', title: 'Projects by Account', dataset: projectDs, dimensions: ['account'], values: ['project_count', 'budget_sum', 'spent_sum'], layout: { x: 0, y: 22, w: 6, h: 4 } },

--- a/examples/app-todo/src/dashboards/task.dashboard.ts
+++ b/examples/app-todo/src/dashboards/task.dashboard.ts
@@ -62,6 +62,8 @@ export const TaskDashboard: Dashboard = {
     },
 
     // Row 2: Task Distribution
+    // chartConfig axis fields name the dataset's dimension/measure — query
+    // rows are keyed by measure NAME post-cutover (issue #1721).
     {
       id: 'tasks_by_status',
       title: 'Tasks by Status',
@@ -70,6 +72,7 @@ export const TaskDashboard: Dashboard = {
       dataset: 'task_metrics',
       dimensions: ['status'],
       values: ['task_count'],
+      chartConfig: { type: 'pie', xAxis: { field: 'status', showGridLines: true, logarithmic: false }, yAxis: [{ field: 'task_count', showGridLines: true, logarithmic: false }], showLegend: true, showDataLabels: false },
       layout: { x: 0, y: 2, w: 6, h: 4 },
       options: { showLegend: true }
     },
@@ -81,6 +84,7 @@ export const TaskDashboard: Dashboard = {
       dataset: 'task_metrics',
       dimensions: ['priority'],
       values: ['task_count'],
+      chartConfig: { type: 'bar', xAxis: { field: 'priority', showGridLines: true, logarithmic: false }, yAxis: [{ field: 'task_count', showGridLines: true, logarithmic: false }], showLegend: true, showDataLabels: false },
       layout: { x: 6, y: 2, w: 6, h: 4 },
       options: { horizontal: true }
     },
@@ -94,6 +98,7 @@ export const TaskDashboard: Dashboard = {
       dataset: 'task_metrics',
       dimensions: ['completed_date'],
       values: ['task_count'],
+      chartConfig: { type: 'line', xAxis: { field: 'completed_date', showGridLines: true, logarithmic: false }, yAxis: [{ field: 'task_count', showGridLines: true, logarithmic: false }], showLegend: true, showDataLabels: false },
       layout: { x: 0, y: 6, w: 8, h: 4 },
       options: { showDataLabels: true }
     },
@@ -105,6 +110,7 @@ export const TaskDashboard: Dashboard = {
       dataset: 'task_metrics',
       dimensions: ['category'],
       values: ['task_count'],
+      chartConfig: { type: 'donut', xAxis: { field: 'category', showGridLines: true, logarithmic: false }, yAxis: [{ field: 'task_count', showGridLines: true, logarithmic: false }], showLegend: true, showDataLabels: false },
       layout: { x: 8, y: 6, w: 4, h: 4 },
       options: { showLegend: true }
     },

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -147,13 +147,31 @@ export default class Compile extends Command {
         this.exit(1);
       }
 
-      // 3c. Widget-binding diagnostics (issue #1719) — semantic checks that
-      //     need the widget's `dataset` reference resolved to its dataset and
-      //     `values` resolved to measures with known aggregates. Advisory
-      //     only: warnings are printed (and included in --json output) but
-      //     never fail the build. Suppress per widget via
+      // 3c. Widget-binding diagnostics (issues #1719/#1721) — semantic checks
+      //     that need the widget's `dataset` reference resolved to its dataset
+      //     and `dimensions`/`values` resolved to declared names. Errors are
+      //     unresolvable bindings (dangling dataset/dimension/measure or a
+      //     chartConfig field the query result won't contain) and fail the
+      //     build; warnings are advisory and suppressible per widget via
       //     `suppressWarnings: ['<rule-id>']`.
-      const widgetWarnings = validateWidgetBindings(result.data as Record<string, unknown>);
+      if (!flags.json) printStep('Checking dashboard widget bindings (ADR-0021)...');
+      const widgetFindings = validateWidgetBindings(result.data as Record<string, unknown>);
+      const widgetErrors = widgetFindings.filter((f) => f.severity === 'error');
+      const widgetWarnings = widgetFindings.filter((f) => f.severity === 'warning');
+      if (widgetErrors.length > 0) {
+        if (flags.json) {
+          console.log(JSON.stringify({ success: false, error: 'widget binding validation failed', issues: widgetErrors }));
+          this.exit(1);
+        }
+        console.log('');
+        printError(`Dashboard widget integrity failed (${widgetErrors.length} issue${widgetErrors.length > 1 ? 's' : ''})`);
+        for (const f of widgetErrors.slice(0, 50)) {
+          console.log(`  • ${f.where}: ${f.message}`);
+          console.log(chalk.dim(`      ${f.hint}`));
+          console.log(chalk.dim(`      rule: ${f.rule}  at ${f.path}`));
+        }
+        this.exit(1);
+      }
       if (widgetWarnings.length > 0 && !flags.json) {
         console.log('');
         for (const w of widgetWarnings) {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -8,6 +8,7 @@ import path from 'path';
 import { normalizeStackInput } from '@objectstack/spec';
 import { printHeader, printSuccess, printWarning, printError, printStep, printInfo } from '../utils/format.js';
 import { loadConfig, configExists } from '../utils/config.js';
+import { validateWidgetBindings } from '../utils/validate-widget-bindings.js';
 
 interface HealthCheckResult {
   name: string;
@@ -523,6 +524,31 @@ export default class Doctor extends Command {
             }
           } else {
             printSuccess('View integrity        All views reference valid objects');
+          }
+        }
+
+        // Dashboard widget integrity (issue #1721) — the widget-side analogue
+        // of the orphan-view pass: every widget's `dataset`, `dimensions`,
+        // `values`, and chartConfig axis/series fields must resolve against
+        // the declared datasets (ADR-0021).
+        if (Array.isArray(config.dashboards) && config.dashboards.length > 0) {
+          printStep('Checking dashboard widget integrity...');
+          const widgetFindings = validateWidgetBindings(config);
+          if (widgetFindings.length > 0) {
+            for (const f of widgetFindings) {
+              if (f.severity === 'error') {
+                hasErrors = true;
+                printError(`${f.where}: ${f.message}`);
+              } else {
+                hasWarnings = true;
+                printWarning(`${f.where}: ${f.message}`);
+              }
+              if (flags.verbose) {
+                console.log(chalk.dim(`      → ${f.hint}`));
+              }
+            }
+          } else {
+            printSuccess('Dashboard integrity   All widgets resolve datasets, dimensions, and measures');
           }
         }
       } catch {

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -220,13 +220,16 @@ export function lintConfig(config: any): LintIssue[] {
   // objectstack-data/-ui skills. These double as the eval rubric (see score.ts).
   issues.push(...lintDataModel(objects));
 
-  // ── Dashboard widget bindings (ADR-0021, issue #1719) ──
-  // e.g. a table/pivot widget whose binding resolves to count-only measures
-  // with no dimensions — almost always a record listing that belongs in an
-  // object-bound ListView (ADR-0017), not an analytics dataset.
+  // ── Dashboard widget bindings (ADR-0021, issues #1719/#1721) ──
+  // Reference integrity (errors): widget `dataset`/`dimensions`/`values` and
+  // chartConfig axis/series fields must resolve against the declared
+  // datasets. Advisory shapes (warnings): e.g. a table/pivot widget whose
+  // binding resolves to count-only measures with no dimensions — almost
+  // always a record listing that belongs in an object-bound ListView
+  // (ADR-0017), not an analytics dataset.
   for (const w of validateWidgetBindings(config)) {
     issues.push({
-      severity: 'warning',
+      severity: w.severity,
       rule: w.rule,
       message: `${w.where}: ${w.message}`,
       path: w.path,

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -5,6 +5,7 @@ import chalk from 'chalk';
 import { ZodError } from 'zod';
 import { ObjectStackDefinitionSchema, normalizeStackInput } from '@objectstack/spec';
 import { loadConfig } from '../utils/config.js';
+import { validateWidgetBindings } from '../utils/validate-widget-bindings.js';
 import {
   printHeader,
   printKV,
@@ -69,7 +70,37 @@ export default class Validate extends Command {
         this.exit(1);
       }
 
-      // 3. Collect and display stats
+      // 3. Dashboard widget reference integrity (issue #1721) — a semantic
+      //    cross-reference pass the protocol schema cannot express: every
+      //    widget's `dataset`/`dimensions`/`values` and chartConfig
+      //    axis/series fields must resolve against the declared datasets
+      //    (ADR-0021). Errors fail validation; warnings are advisory.
+      if (!flags.json) printStep('Checking dashboard widget bindings (ADR-0021)...');
+      const widgetFindings = validateWidgetBindings(result.data as Record<string, unknown>);
+      const widgetErrors = widgetFindings.filter((f) => f.severity === 'error');
+      const widgetWarnings = widgetFindings.filter((f) => f.severity === 'warning');
+
+      if (widgetErrors.length > 0) {
+        if (flags.json) {
+          console.log(JSON.stringify({
+            valid: false,
+            errors: widgetErrors,
+            warnings: widgetWarnings,
+            duration: timer.elapsed(),
+          }, null, 2));
+          this.exit(1);
+        }
+        console.log('');
+        printError(`Dashboard widget integrity failed (${widgetErrors.length} issue${widgetErrors.length > 1 ? 's' : ''})`);
+        for (const f of widgetErrors.slice(0, 50)) {
+          console.log(`  • ${f.where}: ${f.message}`);
+          console.log(chalk.dim(`      ${f.hint}`));
+          console.log(chalk.dim(`      rule: ${f.rule}  at ${f.path}`));
+        }
+        this.exit(1);
+      }
+
+      // 4. Collect and display stats
       const stats = collectMetadataStats(config);
 
       if (flags.json) {
@@ -77,14 +108,18 @@ export default class Validate extends Command {
           valid: true,
           manifest: config.manifest,
           stats,
+          warnings: widgetWarnings,
           duration: timer.elapsed(),
         }, null, 2));
         return;
       }
 
-      // 4. Warnings (non-blocking)
+      // 5. Warnings (non-blocking)
       const warnings: string[] = [];
-      
+
+      for (const f of widgetWarnings) {
+        warnings.push(`${f.where}: ${f.message}`);
+      }
       if (stats.objects === 0) {
         warnings.push('No objects defined — this stack has no data model');
       }
@@ -98,7 +133,7 @@ export default class Validate extends Command {
         warnings.push('Missing manifest.namespace — required for multi-app hosting');
       }
 
-      // 5. Display results
+      // 6. Display results
       console.log('');
       printSuccess(`Validation passed ${chalk.dim(`(${timer.display()})`)}`);
       console.log('');

--- a/packages/cli/src/utils/validate-widget-bindings.test.ts
+++ b/packages/cli/src/utils/validate-widget-bindings.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { validateWidgetBindings, TABLE_COUNT_ONLY } from './validate-widget-bindings.js';
+import {
+  validateWidgetBindings,
+  TABLE_COUNT_ONLY,
+  WIDGET_DATASET_UNKNOWN,
+  WIDGET_DIMENSION_UNKNOWN,
+  WIDGET_MEASURE_UNKNOWN,
+  CHART_FIELD_UNKNOWN,
+  CHART_CONFIG_MISSING,
+} from './validate-widget-bindings.js';
 
 /** The downstream repro from issue #1719 — dataset with a count AND a sum
  *  measure plus a dimension; the widget selects only the count, no dims. */
@@ -31,10 +39,195 @@ function reproStack(widgetOverrides: Record<string, unknown> = {}) {
   };
 }
 
+/** The minimal repro from issue #1721 — dataset measure is `sum_amount`, but
+ *  the chart's yAxis still names the old base column `amount`. */
+function chartStack(widgetOverrides: Record<string, unknown> = {}) {
+  return {
+    datasets: [{
+      name: 'expense_line_metrics',
+      label: 'Expense line metrics',
+      object: 'expense_line',
+      dimensions: [{ name: 'category', field: 'category' }],
+      measures: [
+        { name: 'sum_amount', label: 'sum_amount', aggregate: 'sum', field: 'amount', certified: true },
+        { name: 'ticket_count', label: 'ticket_count', aggregate: 'count' },
+      ],
+    }],
+    dashboards: [{
+      name: 'spend_dashboard',
+      label: 'Spend',
+      widgets: [{
+        id: 'spend_by_category',
+        type: 'bar',
+        dataset: 'expense_line_metrics',
+        dimensions: ['category'],
+        values: ['sum_amount'],
+        chartConfig: {
+          type: 'bar',
+          xAxis: { field: 'category' },
+          yAxis: [{ field: 'sum_amount' }],
+        },
+        layout: { x: 0, y: 0, w: 6, h: 4 },
+        ...widgetOverrides,
+      }],
+    }],
+  };
+}
+
+describe('validateWidgetBindings (reference integrity, issue #1721)', () => {
+  it('a fully resolved chart widget is clean', () => {
+    expect(validateWidgetBindings(chartStack())).toHaveLength(0);
+  });
+
+  it('(a) errors on a dataset reference that does not resolve', () => {
+    const findings = validateWidgetBindings(chartStack({ dataset: 'expense_line_metric' }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('error');
+    expect(findings[0].rule).toBe(WIDGET_DATASET_UNKNOWN);
+    expect(findings[0].message).toContain('expense_line_metric');
+    expect(findings[0].hint).toContain('Did you mean "expense_line_metrics"?');
+  });
+
+  it('(b) errors on a dimension name the dataset does not declare', () => {
+    const findings = validateWidgetBindings(chartStack({ dimensions: ['categry'] }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('error');
+    expect(findings[0].rule).toBe(WIDGET_DIMENSION_UNKNOWN);
+    expect(findings[0].message).toContain('"categry"');
+    expect(findings[0].message).toContain('declared dimensions: category');
+    expect(findings[0].hint).toContain('Did you mean "category"?');
+  });
+
+  it('(c) errors on a measure name the dataset does not declare', () => {
+    const findings = validateWidgetBindings(chartStack({
+      type: 'metric',
+      values: ['amount'],
+      chartConfig: undefined,
+    }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('error');
+    expect(findings[0].rule).toBe(WIDGET_MEASURE_UNKNOWN);
+    expect(findings[0].message).toContain('declared measures: sum_amount, ticket_count');
+    expect(findings[0].hint).toContain('Did you mean "sum_amount"?');
+  });
+
+  it('(d) errors on the issue repro: yAxis.field naming the stale base column', () => {
+    const findings = validateWidgetBindings(chartStack({
+      chartConfig: {
+        type: 'bar',
+        xAxis: { field: 'category' },
+        yAxis: [{ field: 'amount' }],
+      },
+    }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('error');
+    expect(findings[0].rule).toBe(CHART_FIELD_UNKNOWN);
+    expect(findings[0].where).toContain('spend_by_category');
+    expect(findings[0].message).toContain('chartConfig.yAxis[0].field "amount"');
+    expect(findings[0].message).toContain('declared measures: sum_amount, ticket_count');
+    expect(findings[0].hint).toContain('Did you mean "sum_amount"?');
+  });
+
+  it('(d) errors on xAxis.field that is not a dataset dimension', () => {
+    const findings = validateWidgetBindings(chartStack({
+      chartConfig: {
+        type: 'bar',
+        xAxis: { field: 'categories' },
+        yAxis: [{ field: 'sum_amount' }],
+      },
+    }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe(CHART_FIELD_UNKNOWN);
+    expect(findings[0].message).toContain('chartConfig.xAxis.field "categories"');
+    expect(findings[0].hint).toContain('Did you mean "category"?');
+  });
+
+  it('(d) errors on series[].name that resolves to no selected measure', () => {
+    const findings = validateWidgetBindings(chartStack({
+      chartConfig: {
+        type: 'bar',
+        series: [{ name: 'value' }],
+      },
+    }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe(CHART_FIELD_UNKNOWN);
+    expect(findings[0].message).toContain('chartConfig.series[0].name "value"');
+  });
+
+  it('(d) a declared-but-unselected measure gets the targeted message', () => {
+    const findings = validateWidgetBindings(chartStack({
+      chartConfig: {
+        type: 'bar',
+        xAxis: { field: 'category' },
+        yAxis: [{ field: 'ticket_count' }],
+      },
+    }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe(CHART_FIELD_UNKNOWN);
+    expect(findings[0].message).toContain('not selected in the widget\'s values');
+    expect(findings[0].hint).toContain('Add "ticket_count" to the widget\'s values');
+  });
+
+  it('(d) warns when a chart-type widget has no chartConfig at all', () => {
+    const findings = validateWidgetBindings(chartStack({ chartConfig: undefined }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+    expect(findings[0].rule).toBe(CHART_CONFIG_MISSING);
+    expect(findings[0].message).toContain("'bar'");
+    expect(findings[0].hint).toContain(`suppressWarnings: ['${CHART_CONFIG_MISSING}']`);
+  });
+
+  it('(d) missing chartConfig is suppressible per widget', () => {
+    expect(validateWidgetBindings(chartStack({
+      chartConfig: undefined,
+      suppressWarnings: [CHART_CONFIG_MISSING],
+    }))).toHaveLength(0);
+  });
+
+  it('(d) non-chart types do not warn on missing chartConfig', () => {
+    for (const type of ['metric', 'kpi', 'gauge', 'table']) {
+      expect(validateWidgetBindings(chartStack({ type, chartConfig: undefined }))).toHaveLength(0);
+    }
+  });
+
+  it('errors are NOT suppressible via suppressWarnings', () => {
+    const findings = validateWidgetBindings(chartStack({
+      dataset: 'no_such_dataset',
+      suppressWarnings: [WIDGET_DATASET_UNKNOWN],
+    }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('error');
+  });
+
+  it('does not double-report a chartConfig field that names an already-errored selection entry', () => {
+    const findings = validateWidgetBindings(chartStack({
+      values: ['amount'],
+      chartConfig: {
+        type: 'bar',
+        xAxis: { field: 'category' },
+        yAxis: [{ field: 'amount' }],
+      },
+    }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe(WIDGET_MEASURE_UNKNOWN);
+  });
+
+  it('a dangling dataset reports once and skips the name checks', () => {
+    const findings = validateWidgetBindings(chartStack({
+      dataset: 'nope',
+      dimensions: ['whatever'],
+      values: ['also_whatever'],
+    }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe(WIDGET_DATASET_UNKNOWN);
+  });
+});
+
 describe('validateWidgetBindings (table-count-only, issue #1719)', () => {
   it('warns on the issue repro: count-only table widget without dimensions', () => {
     const warnings = validateWidgetBindings(reproStack());
     expect(warnings).toHaveLength(1);
+    expect(warnings[0].severity).toBe('warning');
     expect(warnings[0].rule).toBe(TABLE_COUNT_ONLY);
     expect(warnings[0].where).toContain('expenses_overview_dashboard');
     expect(warnings[0].where).toContain('pending_reports_table');
@@ -75,12 +268,18 @@ describe('validateWidgetBindings (table-count-only, issue #1719)', () => {
     expect(validateWidgetBindings(reproStack({ suppressWarnings: ['some-other-rule'] }))).toHaveLength(1);
   });
 
-  it('skips dangling dataset references (cross-reference finding, not this rule)', () => {
-    expect(validateWidgetBindings(reproStack({ dataset: 'no_such_dataset' }))).toHaveLength(0);
+  it('a dangling dataset reference is the cross-reference error, not this rule', () => {
+    const findings = validateWidgetBindings(reproStack({ dataset: 'no_such_dataset' }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('error');
+    expect(findings[0].rule).toBe(WIDGET_DATASET_UNKNOWN);
   });
 
-  it('skips unresolvable measure names (a different diagnostic)', () => {
-    expect(validateWidgetBindings(reproStack({ values: ['no_such_measure'] }))).toHaveLength(0);
+  it('an unresolvable measure name is the cross-reference error, not this rule', () => {
+    const findings = validateWidgetBindings(reproStack({ values: ['no_such_measure'] }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('error');
+    expect(findings[0].rule).toBe(WIDGET_MEASURE_UNKNOWN);
   });
 
   it('treats derived measures as non-count even when aggregate says count', () => {

--- a/packages/cli/src/utils/validate-widget-bindings.ts
+++ b/packages/cli/src/utils/validate-widget-bindings.ts
@@ -1,32 +1,61 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * Build-time dashboard widget binding diagnostics (issue #1719).
+ * Build-time dashboard widget binding diagnostics (issues #1719, #1721).
  *
- * Runs at `objectstack compile`/`build` AFTER the stack has been schema-parsed,
- * so every widget's `dataset` reference can be linked to its `defineDataset`
- * and each entry in `values` resolved to a concrete measure with a known
- * `aggregate`. This is the semantic/cross-reference phase — the rules here
- * cannot run during plain Zod parsing of the raw widget literal.
+ * Runs at `objectstack validate`/`compile`/`build` AFTER the stack has been
+ * schema-parsed, so every widget's `dataset` reference can be linked to its
+ * `defineDataset` and each entry in `dimensions`/`values` resolved to a
+ * declared dimension/measure. This is the semantic/cross-reference phase —
+ * the rules here cannot run during plain Zod parsing of the raw widget
+ * literal (the dataset may even live in another package of the stack).
  *
- * Rule `table-count-only`: a `table` / `pivot` widget whose selected measures
- * are ALL `aggregate: 'count'` and which declares no `dimensions` asks the
- * analytics service for a single summary row. That is the shape a `metric`
- * widget wants — for a table it almost always means the author wanted a
- * per-record listing, which is not an analytics dataset at all (model it as an
- * object-bound ListView, ADR-0017). The signal is evaluated on the WIDGET's
- * binding, not the dataset: a dataset may well carry other measures and
- * dimensions the widget simply doesn't select.
+ * Reference-integrity rules (#1721) — severity `error`, the page is broken:
  *
- * Warnings are non-fatal by design — `objectstack build` stays green — and a
- * deliberate single-row table can opt out per widget via
- * `suppressWarnings: ['table-count-only']`.
+ * - `widget-dataset-unknown` — `dataset` does not resolve to a declared
+ *   `Dataset`.
+ * - `widget-dimension-unknown` — a `dimensions[]` entry is not a dimension
+ *   name on the bound dataset.
+ * - `widget-measure-unknown` — a `values[]` entry is not a measure name on
+ *   the bound dataset.
+ * - `chart-field-unknown` — a `chartConfig` binding names a field the query
+ *   result will not contain: `xAxis.field` must be one of the widget's
+ *   dimensions (or a dataset dimension), and each `yAxis[].field` /
+ *   `series[].name` must be one of the widget's selected measures
+ *   (`values`). Post-cutover (ADR-0021) the result rows are keyed by
+ *   measure NAME (e.g. `sum_amount`), not the base column (`amount`) — a
+ *   stale base-column reference renders the axis but an empty series.
+ *
+ * Advisory rules — severity `warning`, build stays green:
+ *
+ * - `chart-config-missing` — a chart-type widget (bar/line/pie/…) has no
+ *   `chartConfig`, so the renderer cannot tell which measure to plot.
+ * - `table-count-only` (#1719) — a `table`/`pivot` widget whose selected
+ *   measures are ALL `aggregate: 'count'` and which declares no
+ *   `dimensions` asks the analytics service for a single summary row. That
+ *   is the shape a `metric` widget wants — for a table it almost always
+ *   means the author wanted a per-record listing, which is not an
+ *   analytics dataset at all (model it as an object-bound ListView,
+ *   ADR-0017). Evaluated on the WIDGET's binding, not the dataset.
+ *
+ * Warnings can be deliberately suppressed per widget via
+ * `suppressWarnings: ['<rule-id>']`; errors cannot — they describe a
+ * binding the analytics service cannot satisfy.
  */
 
+export const WIDGET_DATASET_UNKNOWN = 'widget-dataset-unknown';
+export const WIDGET_DIMENSION_UNKNOWN = 'widget-dimension-unknown';
+export const WIDGET_MEASURE_UNKNOWN = 'widget-measure-unknown';
+export const CHART_FIELD_UNKNOWN = 'chart-field-unknown';
+export const CHART_CONFIG_MISSING = 'chart-config-missing';
 export const TABLE_COUNT_ONLY = 'table-count-only';
 
-export interface WidgetBindingWarning {
-  /** Diagnostic rule id (registry entry), e.g. `table-count-only`. */
+export type WidgetBindingSeverity = 'error' | 'warning';
+
+export interface WidgetBindingFinding {
+  /** `error` = unresolvable binding (broken page); `warning` = advisory. */
+  severity: WidgetBindingSeverity;
+  /** Diagnostic rule id (registry entry), e.g. `widget-measure-unknown`. */
   rule: string;
   /** Human-readable location, e.g. `dashboard "x" › widget "y"`. */
   where: string;
@@ -49,13 +78,81 @@ function asArray(v: unknown): AnyRec[] {
   return [];
 }
 
+function asStrings(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((s): s is string => typeof s === 'string') : [];
+}
+
+/**
+ * Chart families whose renderer needs a `chartConfig` measure mapping.
+ * Single-value types (metric/kpi/gauge/…) plot their lone value and tabular
+ * types (table/pivot) render every column, so they are exempt.
+ */
+const CHART_TYPES = new Set([
+  'bar', 'horizontal-bar', 'column',
+  'line', 'area',
+  'pie', 'donut', 'funnel',
+  'scatter', 'treemap', 'sankey', 'radar',
+]);
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length, n = b.length;
+  let prev = Array.from({ length: n + 1 }, (_, j) => j);
+  for (let i = 1; i <= m; i++) {
+    const cur = [i];
+    for (let j = 1; j <= n; j++) {
+      cur[j] = Math.min(
+        prev[j] + 1,
+        cur[j - 1] + 1,
+        prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1),
+      );
+    }
+    prev = cur;
+  }
+  return prev[n];
+}
+
+/**
+ * Nearest declared name for a typo'd/stale reference, or undefined when
+ * nothing is close. Containment is checked first because the cutover's
+ * canonical drift is base column → prefixed measure name (`amount` →
+ * `sum_amount`), which is far in edit distance but obvious to a human.
+ */
+function didYouMean(input: string, candidates: Iterable<string>): string | undefined {
+  let best: string | undefined;
+  let bestScore = Infinity;
+  for (const c of candidates) {
+    let score: number;
+    if (input.length >= 3 && (c.includes(input) || input.includes(c))) {
+      score = Math.abs(c.length - input.length);
+    } else {
+      const d = levenshtein(input, c);
+      if (d > Math.max(2, Math.floor(input.length / 3))) continue;
+      score = 100 + d;
+    }
+    if (score < bestScore) { bestScore = score; best = c; }
+  }
+  return best;
+}
+
+function suggest(input: string, candidates: Iterable<string>): string {
+  const s = didYouMean(input, candidates);
+  return s ? ` Did you mean "${s}"?` : '';
+}
+
+function list(names: Iterable<string>): string {
+  const arr = [...names];
+  return arr.length > 0 ? arr.join(', ') : '(none)';
+}
+
 /**
  * Validate every dashboard widget's dataset binding. Returns the list of
- * warnings (empty = clean). Caller decides how to surface them — these are
- * advisory and must never fail the build on their own.
+ * findings (empty = clean). Caller decides how to surface them: `error`
+ * findings describe bindings the analytics service cannot satisfy and
+ * should fail validate/build; `warning` findings are advisory and must
+ * never fail the build on their own.
  */
-export function validateWidgetBindings(stack: AnyRec): WidgetBindingWarning[] {
-  const warnings: WidgetBindingWarning[] = [];
+export function validateWidgetBindings(stack: AnyRec): WidgetBindingFinding[] {
+  const findings: WidgetBindingFinding[] = [];
 
   const datasets = new Map<string, AnyRec>();
   for (const ds of asArray(stack.datasets)) {
@@ -70,28 +167,152 @@ export function validateWidgetBindings(stack: AnyRec): WidgetBindingWarning[] {
 
     for (let j = 0; j < widgets.length; j++) {
       const w = widgets[j];
-      if (w.type !== 'table' && w.type !== 'pivot') continue;
-      // Grouped by at least one dimension → genuinely aggregated rows.
-      if (Array.isArray(w.dimensions) && w.dimensions.length > 0) continue;
-      // Author opted out — a single-row summary table is intentional here.
-      if (Array.isArray(w.suppressWarnings) && w.suppressWarnings.includes(TABLE_COUNT_ONLY)) continue;
+      const widgetId = typeof w.id === 'string' ? w.id : `(widget ${j})`;
+      const where = `dashboard "${dashName}" › widget "${widgetId}"`;
+      const path = `dashboards[${i}].widgets[${j}]`;
+      const suppressed = (rule: string): boolean =>
+        Array.isArray(w.suppressWarnings) && w.suppressWarnings.includes(rule);
+      const push = (f: Omit<WidgetBindingFinding, 'where' | 'path'>): void => {
+        if (f.severity === 'warning' && suppressed(f.rule)) return;
+        findings.push({ ...f, where, path });
+      };
 
+      // ── (a) dataset reference resolves ──
       const dsName = typeof w.dataset === 'string' ? w.dataset : undefined;
       const dataset = dsName ? datasets.get(dsName) : undefined;
-      // A dangling dataset reference is a cross-reference finding, not this rule.
+      if (dsName && !dataset) {
+        push({
+          severity: 'error',
+          rule: WIDGET_DATASET_UNKNOWN,
+          message: `dataset "${dsName}" does not resolve to a declared dataset.`,
+          hint:
+            `Declared datasets: ${list(datasets.keys())}.${suggest(dsName, datasets.keys())} ` +
+            `Define the dataset with defineDataset() or fix the reference (ADR-0021).`,
+        });
+      }
+      // Without a resolved dataset there is nothing to check names against.
       if (!dataset) continue;
 
+      const dimensionNames = new Set<string>();
+      for (const d of asArray(dataset.dimensions)) {
+        if (typeof d.name === 'string') dimensionNames.add(d.name);
+      }
       const measures = new Map<string, AnyRec>();
       for (const m of asArray(dataset.measures)) {
         if (typeof m.name === 'string') measures.set(m.name, m);
       }
 
-      const values = Array.isArray(w.values)
-        ? (w.values as unknown[]).filter((v): v is string => typeof v === 'string')
-        : [];
+      // ── (b) every dimensions[] entry is a dataset dimension ──
+      const dims = asStrings(w.dimensions);
+      for (let k = 0; k < dims.length; k++) {
+        if (dimensionNames.has(dims[k])) continue;
+        push({
+          severity: 'error',
+          rule: WIDGET_DIMENSION_UNKNOWN,
+          message:
+            `dimensions[${k}] "${dims[k]}" is not a dimension of dataset ` +
+            `"${dsName}" (declared dimensions: ${list(dimensionNames)}).`,
+          hint:
+            `Widgets select dataset dimensions BY NAME.${suggest(dims[k], dimensionNames)} ` +
+            `Add the dimension to the dataset or fix the reference.`,
+        });
+      }
+
+      // ── (c) every values[] entry is a dataset measure ──
+      const values = asStrings(w.values);
+      for (let k = 0; k < values.length; k++) {
+        if (measures.has(values[k])) continue;
+        push({
+          severity: 'error',
+          rule: WIDGET_MEASURE_UNKNOWN,
+          message:
+            `values[${k}] "${values[k]}" is not a measure of dataset ` +
+            `"${dsName}" (declared measures: ${list(measures.keys())}).`,
+          hint:
+            `Widgets select dataset measures BY NAME, not by base column.` +
+            `${suggest(values[k], measures.keys())} ` +
+            `Add the measure to the dataset or fix the reference.`,
+        });
+      }
+
+      // ── (d) chartConfig bindings resolve against the widget's selection ──
+      const chartConfig = (w.chartConfig && typeof w.chartConfig === 'object')
+        ? (w.chartConfig as AnyRec)
+        : undefined;
+      const isChartType = typeof w.type === 'string' && CHART_TYPES.has(w.type);
+
+      if (chartConfig) {
+        // The query result carries the widget's selected dimensions and
+        // measures; resolve every chartConfig field against that shape.
+        const selectedValues = new Set(values.filter((v) => measures.has(v)));
+
+        const xAxis = (chartConfig.xAxis && typeof chartConfig.xAxis === 'object')
+          ? (chartConfig.xAxis as AnyRec)
+          : undefined;
+        // A field naming an entry of the widget's own (already-validated)
+        // selection is not re-reported here — rules (b)/(c) own that error.
+        if (xAxis && typeof xAxis.field === 'string'
+            && !dimensionNames.has(xAxis.field) && !dims.includes(xAxis.field)) {
+          push({
+            severity: 'error',
+            rule: CHART_FIELD_UNKNOWN,
+            message:
+              `chartConfig.xAxis.field "${xAxis.field}" does not resolve to a ` +
+              `dimension of dataset "${dsName}" (declared dimensions: ${list(dimensionNames)}).`,
+            hint: `Point xAxis.field at a dataset dimension name.${suggest(xAxis.field, dimensionNames)}`,
+          });
+        }
+
+        const measureField = (label: string, field: string): void => {
+          if (values.includes(field)) return; // resolvable, or already errored via rule (c)
+          const declaredButUnselected = measures.has(field);
+          push({
+            severity: 'error',
+            rule: CHART_FIELD_UNKNOWN,
+            message: declaredButUnselected
+              ? `chartConfig.${label} "${field}" is a measure of dataset "${dsName}" ` +
+                `but is not selected in the widget's values (${list(values)}), so the ` +
+                `query result will not contain it.`
+              : `chartConfig.${label} "${field}" does not resolve to a measure of ` +
+                `dataset "${dsName}" (declared measures: ${list(measures.keys())}).`,
+            hint: declaredButUnselected
+              ? `Add "${field}" to the widget's values, or bind the chart to a selected measure.`
+              : `Post-cutover data is keyed by the dataset's measure NAME, not the ` +
+                `base column.${suggest(field, selectedValues.size > 0 ? selectedValues : measures.keys())}`,
+          });
+        };
+
+        const yAxes = Array.isArray(chartConfig.yAxis) ? (chartConfig.yAxis as AnyRec[]) : [];
+        for (let k = 0; k < yAxes.length; k++) {
+          const field = yAxes[k]?.field;
+          if (typeof field === 'string') measureField(`yAxis[${k}].field`, field);
+        }
+        const series = Array.isArray(chartConfig.series) ? (chartConfig.series as AnyRec[]) : [];
+        for (let k = 0; k < series.length; k++) {
+          const name = series[k]?.name;
+          if (typeof name === 'string') measureField(`series[${k}].name`, name);
+        }
+      } else if (isChartType) {
+        push({
+          severity: 'warning',
+          rule: CHART_CONFIG_MISSING,
+          message:
+            `chart-type widget ('${w.type}') has no chartConfig — the renderer ` +
+            `cannot determine which measure to plot, so the series renders empty.`,
+          hint:
+            `Add chartConfig with xAxis.field set to a dimension (${list(dims)}) and ` +
+            `yAxis[].field set to a measure name (${list(values)}). If the default ` +
+            `rendering is intentional, suppress with: suppressWarnings: ['${CHART_CONFIG_MISSING}']`,
+        });
+      }
+
+      // ── (e) table/pivot bound to a count-only, dimensionless selection ──
+      if (w.type !== 'table' && w.type !== 'pivot') continue;
+      // Grouped by at least one dimension → genuinely aggregated rows.
+      if (dims.length > 0) continue;
       if (values.length === 0) continue;
       const resolved = values.map((v) => measures.get(v));
-      // An unresolvable measure name is a different diagnostic — don't guess.
+      // An unresolvable measure name already errored above — don't guess here.
       if (resolved.some((m) => !m)) continue;
 
       // Derived measures combine other measures; treat them as non-count even
@@ -99,11 +320,9 @@ export function validateWidgetBindings(stack: AnyRec): WidgetBindingWarning[] {
       const countOnly = resolved.every((m) => m!.aggregate === 'count' && !m!.derived);
       if (!countOnly) continue;
 
-      const widgetId = typeof w.id === 'string' ? w.id : `(widget ${j})`;
-      warnings.push({
+      push({
+        severity: 'warning',
         rule: TABLE_COUNT_ONLY,
-        where: `dashboard "${dashName}" › widget "${widgetId}"`,
-        path: `dashboards[${i}].widgets[${j}]`,
         message:
           `a '${w.type}' widget bound to dataset "${dsName}" selects only count ` +
           `measure(s) (${values.join(', ')}) and no dimensions, so it renders a ` +
@@ -118,5 +337,5 @@ export function validateWidgetBindings(stack: AnyRec): WidgetBindingWarning[] {
     }
   }
 
-  return warnings;
+  return findings;
 }


### PR DESCRIPTION
Closes #1721.

## What

Extends the #1719 semantic widget-binding pass (`validateWidgetBindings`) into the full **dashboard widget reference integrity** check the issue proposes, and surfaces it in all four build-time tools:

| Rule | Severity | Issue item |
|---|---|---|
| `widget-dataset-unknown` | error | (a) `dataset` resolves to a declared `Dataset` |
| `widget-dimension-unknown` | error | (b) every `dimensions[]` entry is a real dataset dimension |
| `widget-measure-unknown` | error | (c) every `values[]` entry is a real dataset measure |
| `chart-field-unknown` | error | (d) `chartConfig.xAxis.field` resolves to a dataset dimension; `yAxis[].field` / `series[].name` resolve to a measure selected in `values` |
| `chart-config-missing` | warning | (d) chart-type widget with no `chartConfig` at all |
| `table-count-only` | warning | (e) — already landed in #1719, unchanged |

- **`validate`** — semantic pass after `safeParse` succeeds; errors fail with located, corrective messages (and in `--json`); warnings print non-blocking (`--strict` makes them fatal).
- **`build`/`compile`** — same: errors fail the build where the cutover damage actually occurred (CI).
- **`lint`** — findings pass their real severity through (was hardcoded `warning`).
- **`doctor`** — new *"Dashboard integrity — All widgets resolve datasets, dimensions, and measures"* section mirroring the orphan-view pass.

Messages list the declared names and carry a **did-you-mean** suggestion with containment checked before edit distance, so the cutover's canonical drift (`amount` → `sum_amount`) is suggested:

```
✗ Dashboard widget integrity failed (1 issue)
• dashboard "pipeline_dashboard" › widget "pipeline_trend_90d": chartConfig.yAxis[0].field "amount"
  does not resolve to a measure of dataset "opportunity_metrics" (declared measures: opp_count,
  total_amount, avg_amount).
    Post-cutover data is keyed by the dataset's measure NAME, not the base column.
    rule: chart-field-unknown  at dashboards[0].widgets[3]
```

## Design notes

- **Errors are not suppressible** — they describe a binding the analytics service cannot satisfy; `suppressWarnings: ['<rule-id>']` keeps working for the two advisory rules.
- A `chartConfig` field that names an already-invalid `values`/`dimensions` entry is **not double-reported** — rules (b)/(c) own that error.
- A widget whose `dataset` doesn't resolve reports once and skips the name checks (nothing to resolve against).
- Per the issue, the check lives in the CLI (where multi-package config is assembled), not the spec schema — a widget in one package can resolve a dataset in another.
- A measure that is declared on the dataset but **not selected** in the widget's `values` gets a targeted message ("the query result will not contain it") instead of the generic one.

## Example apps

`chart-config-missing` flagged 19 chart widgets across the three example apps — all authored without `chartConfig`. They now carry the explicit mapping (`xAxis.field` = dimension, `yAxis[].field` = measure name), the authoring shape templates#30 standardized on after browser-verifying it fixes the blank charts. Note the tension: **objectui HEAD's `DatasetWidget` (since `92449ef99`) derives series from `values` and ignores `chartConfig`**, so at HEAD the warning is advisory rather than a real breakage — but published renderers consume it, and the explicit form is compatible both ways. If values-derived rendering becomes the contract everywhere, `chart-config-missing` can be dropped without touching the error rules.

app-todo's two count-only record-listing tables (`overdue_tasks_table`, `due_today`) still warn under `table-count-only` — re-modeling them as object-bound ListViews (ADR-0017) is #1719's failure class, left as a follow-up.

## Verification

- 28 unit tests on the validator (incl. both issue repros: the #1721 `sum_amount`/`amount` chart and the #1719 count-only table); full CLI suite 254 passed; `tsc` clean.
- All three example apps: `validate` passes, dashboards typecheck (remaining showcase page-type errors are pre-existing drift in untouched files).
- Negative path exercised end-to-end: a stale `yAxis.field` makes both `validate` and `build` exit 1 with the message above; `doctor` prints the new integrity section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)