### PR TITLE
fix(app-todo): re-model count-only dashboard tables as ListViews (#1719)

### DIFF
--- a/examples/app-todo/src/apps/todo.app.ts
+++ b/examples/app-todo/src/apps/todo.app.ts
@@ -21,8 +21,8 @@ export const TodoApp = App.create({
       children: [
         { id: 'nav_all_tasks', type: 'object', objectName: 'todo_task', label: 'All Tasks', icon: 'list' },
         { id: 'nav_my_tasks', type: 'object', objectName: 'todo_task', label: 'My Tasks', icon: 'user-check' },
-        { id: 'nav_overdue', type: 'object', objectName: 'todo_task', label: 'Overdue', icon: 'alert-circle' },
-        { id: 'nav_today', type: 'object', objectName: 'todo_task', label: 'Due Today', icon: 'calendar' },
+        { id: 'nav_overdue', type: 'object', objectName: 'todo_task', viewName: 'overdue', label: 'Overdue', icon: 'alert-circle' },
+        { id: 'nav_today', type: 'object', objectName: 'todo_task', viewName: 'due_today', label: 'Due Today', icon: 'calendar' },
         { id: 'nav_upcoming', type: 'object', objectName: 'todo_task', label: 'Upcoming', icon: 'calendar-plus' },
       ]
     },

--- a/examples/app-todo/src/dashboards/task.dashboard.ts
+++ b/examples/app-todo/src/dashboards/task.dashboard.ts
@@ -115,24 +115,11 @@ export const TaskDashboard: Dashboard = {
       options: { showLegend: true }
     },
 
-    // Row 4: Tables
-    {
-      id: 'overdue_tasks_table',
-      title: 'Overdue Tasks',
-      type: 'table',
-      filter: { is_overdue: true, is_completed: false },
-      dataset: 'task_metrics',
-      values: ['task_count'],
-      layout: { x: 0, y: 10, w: 6, h: 4 },
-    },
-    {
-      id: 'due_today',
-      title: 'Due Today',
-      type: 'table',
-      filter: { due_date: '{today}', is_completed: false },
-      dataset: 'task_metrics',
-      values: ['task_count'],
-      layout: { x: 6, y: 10, w: 6, h: 4 },
-    },
+    // The former Row 4 count-only `table` widgets (`overdue_tasks_table`,
+    // `due_today`) rendered a single summary row, not the record listing
+    // they intended (#1719). Those listings live as ListViews on
+    // `todo_task` (`overdue`, `due_today` — ADR-0017), reachable from the
+    // app navigation; the `overdue_tasks` / `completed_today` metric
+    // widgets above keep the counts.
   ],
 };

--- a/examples/app-todo/src/views/task.view.ts
+++ b/examples/app-todo/src/views/task.view.ts
@@ -11,6 +11,12 @@ const data = { provider: 'object' as const, object: 'todo_task' };
  * (no grouping / aggregation), which is a ListView concern, not analytics. It
  * is converted here to an `overdue` grid view filtered to incomplete, overdue
  * tasks — replacing the report entirely.
+ *
+ * Issue #1719: the dashboard's `overdue_tasks_table` / `due_today` widgets
+ * were count-only `table` widgets on the `task_metrics` dataset — a single
+ * summary row, not the record listing they intended. They are re-modelled
+ * here as the `overdue` / `due_today` views, surfaced via app navigation;
+ * the dashboard keeps the counts on its `metric` widgets.
  */
 export const TaskViews = defineView({
   list: {
@@ -45,6 +51,25 @@ export const TaskViews = defineView({
         { field: 'is_completed', operator: 'equals', value: false },
       ],
       sort: [{ field: 'due_date', order: 'asc' }],
+    },
+
+    // Replaces the dashboard's count-only `due_today` table widget (#1719).
+    due_today: {
+      label: 'Due Today',
+      type: 'grid',
+      data,
+      columns: [
+        { field: 'subject' },
+        { field: 'priority' },
+        { field: 'status' },
+        { field: 'owner' },
+        { field: 'category' },
+      ],
+      filter: [
+        { field: 'due_date', operator: 'equals', value: '{today}' },
+        { field: 'is_completed', operator: 'equals', value: false },
+      ],
+      sort: [{ field: 'priority', order: 'desc' }],
     },
   },
 });


### PR DESCRIPTION
## Summary

The `overdue_tasks_table` and `due_today` widgets in `examples/app-todo/src/dashboards/task.dashboard.ts` were `type: 'table'` widgets bound to the `task_metrics` dataset selecting only the `task_count` count measure with no dimensions — rendering a single summary row instead of the task listings they intended. `objectstack validate`/`build` emitted the `table-count-only` warning for both (#1719).

Per ADR-0017 (object has-many view), record listings belong in object-bound ListViews surfaced through app navigation — the same fix class as objectstack-ai/templates#27 downstream:

- **views/task.view.ts** — add a `due_today` grid ListView on `todo_task`, filtered to `due_date = {today}` (date macro) and `is_completed = false`, sorted by priority. The `overdue` ListView already existed from the ADR-0021 Phase 2 report conversion.
- **apps/todo.app.ts** — the existing "Overdue" / "Due Today" nav items now carry `viewName: 'overdue'` / `viewName: 'due_today'` so they land directly on the filtered listings.
- **dashboards/task.dashboard.ts** — remove the two count-only table widgets; counts remain covered by the existing `overdue_tasks` / `completed_today` metric widgets.

## Verification

`node packages/cli/bin/run.js validate` and `build` inside `examples/app-todo` pass with the `table-count-only` warnings gone (CLI rebuilt locally first — the stale local `dist` predated the widget-binding check). Remaining `tsc --noEmit` errors in the example are pre-existing on `main` (confirmed via stash) and untouched by this change.

Closes #1719.

🤖 Generated with [Claude Code](https://claude.com/claude-code)