### PR TITLE
chore: changeset for approvals thread interactions (#1740)

### DIFF
--- a/.changeset/approvals-thread-interactions.md
+++ b/.changeset/approvals-thread-interactions.md
@@ -1,0 +1,7 @@
+---
+"@objectstack/spec": minor
+"@objectstack/plugin-approvals": minor
+"@objectstack/rest": minor
+---
+
+Approvals thread interactions — the collaboration layer between submit and decide. `reassign()` hands a pending-approver slot to someone else (audit-first ordering, new approver notified via the optional `messaging` service), `remind()` nudges every pending approver with a 4h per-request throttle (`THROTTLED` → HTTP 429), `requestInfo()` sends a request back to the submitter for more material while it stays pending, and `comment()` adds free-form thread replies. Rows expose `sla_due_at` (`created_at + escalation.timeoutHours`, display-only) and single reads attach `flow_steps` (the owning flow's approval trunk with done/current/upcoming states). REST grows the four matching POST routes; the `sys_approval_action.action` enum gains the new kinds.


### PR DESCRIPTION
Adds the missing changeset for #1740 (spec / plugin-approvals / rest, all minor) — its Check Changeset failed post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)