### PR TITLE
fix: lockfile entry for showcase's @objectstack/cloud-connection dep

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,9 @@ importers:
 
   examples/app-showcase:
     dependencies:
+      '@objectstack/cloud-connection':
+        specifier: workspace:*
+        version: link:../../packages/cloud-connection
       '@objectstack/connector-rest':
         specifier: workspace:*
         version: link:../../packages/connectors/connector-rest


### PR DESCRIPTION
#1755 added `@objectstack/cloud-connection` to the showcase's package.json without the lockfile update — main CI fails with `ERR_PNPM_OUTDATED_LOCKFILE`. `pnpm install --frozen-lockfile` passes locally with this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)