### PR TITLE
feat(triggers): trigger-api — inbound webhook trigger with HMAC + queue-backed ingestion (ADR-0041 Tier 1)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -44,6 +44,7 @@
       "@objectstack/plugin-sharing",
       "@objectstack/plugin-webhooks",
       "@objectstack/trigger-record-change",
+      "@objectstack/trigger-api",
       "@objectstack/trigger-schedule",
       "@objectstack/connector-mcp",
       "@objectstack/connector-rest",

--- a/.changeset/trigger-api-inbound-webhook.md
+++ b/.changeset/trigger-api-inbound-webhook.md
@@ -1,0 +1,7 @@
+---
+"@objectstack/trigger-api": minor
+"@objectstack/service-automation": minor
+"@objectstack/cli": patch
+---
+
+ADR-0041 Tier 1 complete: `@objectstack/trigger-api` — inbound webhook/HTTP flow trigger. The engine now derives an `api` trigger binding for `type: 'api'` flows (activating the long-reserved enum value); the trigger mounts `POST /api/v1/automation/hooks/:flowName/:hookId` with GitHub/Stripe-style HMAC verification (`x-objectstack-signature`, constant-time compare, identical 404s for unknown flows and wrong hookIds) and queue-backed ingestion — the handler enqueues and ACKs 202, a queue consumer executes the flow with the JSON payload as the trigger record (`$record` / `record.*` / bare references), and `x-idempotency-key` passes through to the queue's dedup window. The CLI's serve preset auto-loads the trigger alongside record-change and schedule.

--- a/examples/app-showcase/src/flows/index.ts
+++ b/examples/app-showcase/src/flows/index.ts
@@ -1111,6 +1111,62 @@ export const ReleaseSignoffFlow = defineFlow({
   ],
 });
 
+
+/**
+ * Inbound Webhook → Task — the worked `trigger-api` example (ADR-0041 Tier 1).
+ *
+ * A `type: 'api'` flow waits for an external POST instead of a record change
+ * or a schedule. The start node's config arms the hook:
+ *
+ *   POST /api/v1/automation/hooks/showcase_inbound_task_webhook/intake
+ *   x-objectstack-signature: sha256=<hmac-sha256 of the raw body, key below>
+ *   { "title": "...", "assignee": "...", "project": "<showcase_project id>" }
+ *
+ * The trigger validates the HMAC (constant-time), enqueues, and ACKs 202; a
+ * queue consumer runs the flow with the JSON payload as the trigger record —
+ * so `{record.title}` here reads straight from the webhook body, exactly like
+ * a record-change flow reads its record.
+ */
+export const InboundTaskWebhookFlow = defineFlow({
+  name: 'showcase_inbound_task_webhook',
+  label: 'Inbound Task Webhook',
+  description: 'Creates a task from an external system via the HMAC-verified inbound hook.',
+  type: 'api',
+  nodes: [
+    {
+      id: 'start',
+      type: 'start',
+      label: 'On Webhook',
+      config: {
+        triggerType: 'api',
+        hookId: 'intake',
+        // Demo secret — real deployments inject this from configuration.
+        secret: 'showcase-webhook-secret',
+      },
+    },
+    {
+      id: 'create_task',
+      type: 'create_record',
+      label: 'Create Task',
+      config: {
+        objectName: 'showcase_task',
+        fields: {
+          title: '{record.title}',
+          assignee: '{record.assignee}',
+          project: '{record.project}',
+          status: 'todo',
+        },
+        outputVariable: 'taskId',
+      },
+    },
+    { id: 'end', type: 'end', label: 'End' },
+  ],
+  edges: [
+    { id: 'e1', source: 'start', target: 'create_task' },
+    { id: 'e2', source: 'create_task', target: 'end' },
+  ],
+});
+
 export const allFlows = [
   TaskCompletedFlow,
   ReassignWizardFlow,
@@ -1131,4 +1187,5 @@ export const allFlows = [
   FanOutNotifyFlow,
   ResilientSyncFlow,
   ProjectEscalationFlow,
+  InboundTaskWebhookFlow,
 ];

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,6 +66,7 @@
     "@objectstack/plugin-security": "workspace:*",
     "@objectstack/plugin-sharing": "workspace:*",
     "@objectstack/trigger-record-change": "workspace:*",
+    "@objectstack/trigger-api": "workspace:*",
     "@objectstack/trigger-schedule": "workspace:*",
     "@objectstack/plugin-webhooks": "workspace:*",
     "@objectstack/rest": "workspace:*",

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1431,6 +1431,13 @@ export default class Serve extends Command {
               export: 'ScheduleTriggerPlugin',
               nameMatch: ['trigger-schedule', 'ScheduleTriggerPlugin'],
             },
+            {
+              // Inbound webhook/HTTP trigger (ADR-0041 Tier 1) — arms
+              // `type: 'api'` flows with HMAC-verified, queue-backed hooks.
+              pkg: '@objectstack/trigger-api',
+              export: 'ApiTriggerPlugin',
+              nameMatch: ['trigger-api', 'ApiTriggerPlugin'],
+            },
           ],
         },
         realtime: {

--- a/packages/services/service-automation/src/engine.ts
+++ b/packages/services/service-automation/src/engine.ts
@@ -543,7 +543,7 @@ export class AutomationEngine implements IAutomationService {
 
     /**
      * Derive a flow's trigger binding from its `start` node, or `undefined` if
-     * the flow has no auto-trigger (manual / screen / api). The convention —
+     * the flow has no auto-trigger (manual / screen). The convention —
      * established by the showcase flows — is that the start node carries the
      * trigger details in its `config`: `{ objectName, triggerType, condition }`
      * for record-change, or a `schedule` descriptor for time-based flows.
@@ -574,6 +574,17 @@ export class AutomationEngine implements IAutomationService {
             return {
                 triggerType: 'schedule',
                 binding: { flowName, schedule: config.schedule, condition: (config.condition as FlowTriggerBinding['condition']) ?? undefined, config },
+            };
+        }
+
+        // Inbound HTTP (ADR-0041 Tier 1): an `api` flow waits for an external
+        // POST. The concrete trigger (`@objectstack/trigger-api`) mounts the
+        // endpoint and enqueues; the binding's `config` carries the hook
+        // details (`hookId`, `secret`) from the start node.
+        if (flow.type === 'api' || triggerType === 'api') {
+            return {
+                triggerType: 'api',
+                binding: { flowName, condition: (config.condition as FlowTriggerBinding['condition']) ?? undefined, config },
             };
         }
 

--- a/packages/triggers/trigger-api/package.json
+++ b/packages/triggers/trigger-api/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@objectstack/trigger-api",
+  "version": "9.2.0",
+  "license": "Apache-2.0",
+  "description": "Inbound HTTP/webhook flow trigger for ObjectStack — per-flow HMAC-verified endpoints with queue-backed ingestion (ADR-0041)",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup --config ../../../tsup.config.ts",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "@objectstack/core": "workspace:*",
+    "@objectstack/spec": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.2",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  },
+  "keywords": [
+    "objectstack",
+    "trigger",
+    "webhook",
+    "automation"
+  ]
+}

--- a/packages/triggers/trigger-api/src/api-trigger.test.ts
+++ b/packages/triggers/trigger-api/src/api-trigger.test.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { createHmac } from 'node:crypto';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ApiTrigger, verifySignature } from './api-trigger.js';
+import type { QueueServiceSurface } from './api-trigger.js';
+
+/** In-memory queue: publish stores, deliver() drains to subscribers. */
+function makeFakeQueue() {
+    const subs = new Map<string, (m: { data: any }) => Promise<void> | void>();
+    const pending = new Map<string, any[]>();
+    let n = 0;
+    const q: QueueServiceSurface & { deliver(): Promise<number>; published: Array<{ queue: string; data: any; idempotencyKey?: string }> } = {
+        published: [],
+        async publish(queue, data, options) {
+            this.published.push({ queue, data, idempotencyKey: options?.idempotencyKey });
+            (pending.get(queue) ?? pending.set(queue, []).get(queue)!).push(data);
+            return `msg_${++n}`;
+        },
+        async subscribe(queue, handler) { subs.set(queue, handler as any); },
+        async unsubscribe(queue) { subs.delete(queue); },
+        async deliver() {
+            let delivered = 0;
+            for (const [queue, items] of pending) {
+                const handler = subs.get(queue);
+                if (!handler) continue;
+                for (const data of items.splice(0)) { await handler({ data }); delivered++; }
+            }
+            return delivered;
+        },
+    };
+    return q;
+}
+
+const logger = { info: vi.fn(), warn: vi.fn() };
+
+function sig(secret: string, body: string): string {
+    return 'sha256=' + createHmac('sha256', secret).update(body, 'utf8').digest('hex');
+}
+
+describe('ApiTrigger', () => {
+    let queue: ReturnType<typeof makeFakeQueue>;
+    let trigger: ApiTrigger;
+    let runs: any[];
+
+    beforeEach(() => {
+        queue = makeFakeQueue();
+        trigger = new ApiTrigger(() => queue, logger as any);
+        runs = [];
+        vi.clearAllMocks();
+    });
+
+    function arm(config: Record<string, unknown> = {}) {
+        trigger.start({ flowName: 'lead_intake', config }, async (ctx) => { runs.push(ctx); });
+    }
+
+    it('verifySignature accepts a correct GitHub-style signature and rejects others', () => {
+        const body = '{"a":1}';
+        expect(verifySignature('s3cret', body, sig('s3cret', body))).toBe(true);
+        expect(verifySignature('s3cret', body, sig('wrong', body))).toBe(false);
+        expect(verifySignature('s3cret', body, undefined)).toBe(false);
+        expect(verifySignature('s3cret', body, 'sha256=zz')).toBe(false);
+    });
+
+    it('202-enqueues a valid post and the consumer runs the flow with the payload as record', async () => {
+        arm({ hookId: 'hk1', secret: 's3cret' });
+        const body = JSON.stringify({ title: 'New lead', amount: 5000 });
+        const res = await trigger.handleRequest({
+            flowName: 'lead_intake', hookId: 'hk1', rawBody: body, signatureHeader: sig('s3cret', body),
+        });
+        expect(res.status).toBe(202);
+        expect(res.body.accepted).toBe(true);
+        expect(runs).toHaveLength(0); // never executed in-band
+        expect(await queue.deliver()).toBe(1);
+        expect(runs).toHaveLength(1);
+        expect(runs[0].record).toEqual({ title: 'New lead', amount: 5000 });
+        expect(runs[0].params).toEqual({ title: 'New lead', amount: 5000 });
+    });
+
+    it('answers 404 identically for unknown flows and wrong hookIds (no probing oracle)', async () => {
+        arm({ hookId: 'hk1' });
+        const a = await trigger.handleRequest({ flowName: 'nope', hookId: 'hk1', rawBody: '{}' });
+        const b = await trigger.handleRequest({ flowName: 'lead_intake', hookId: 'wrong', rawBody: '{}' });
+        expect(a).toEqual(b);
+        expect(a.status).toBe(404);
+    });
+
+    it('401s a missing or bad signature when the flow declares a secret', async () => {
+        arm({ hookId: 'hk1', secret: 's3cret' });
+        const body = '{"x":1}';
+        expect((await trigger.handleRequest({ flowName: 'lead_intake', hookId: 'hk1', rawBody: body })).status).toBe(401);
+        expect((await trigger.handleRequest({
+            flowName: 'lead_intake', hookId: 'hk1', rawBody: body, signatureHeader: sig('other', body),
+        })).status).toBe(401);
+    });
+
+    it('accepts unsigned posts when no secret is configured (and warned at arm time)', async () => {
+        arm({});
+        const res = await trigger.handleRequest({ flowName: 'lead_intake', hookId: 'default', rawBody: '{"x":1}' });
+        expect(res.status).toBe(202);
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('WITHOUT a secret'));
+    });
+
+    it('400s non-object or invalid JSON bodies', async () => {
+        arm({});
+        expect((await trigger.handleRequest({ flowName: 'lead_intake', hookId: 'default', rawBody: 'not json' })).status).toBe(400);
+        expect((await trigger.handleRequest({ flowName: 'lead_intake', hookId: 'default', rawBody: '[1,2]' })).status).toBe(400);
+    });
+
+    it('passes x-idempotency-key through to the queue dedup window', async () => {
+        arm({});
+        await trigger.handleRequest({
+            flowName: 'lead_intake', hookId: 'default', rawBody: '{}', idempotencyKey: 'evt_42',
+        });
+        expect(queue.published[0].idempotencyKey).toBe('evt_42');
+    });
+
+    it('503s when no queue service is registered', async () => {
+        const t = new ApiTrigger(() => null, logger as any);
+        t.start({ flowName: 'f', config: {} }, async () => {});
+        const res = await t.handleRequest({ flowName: 'f', hookId: 'default', rawBody: '{}' });
+        expect(res.status).toBe(503);
+    });
+
+    it('stop() disarms the hook and unsubscribes the queue', async () => {
+        arm({ hookId: 'hk1' });
+        trigger.stop('lead_intake');
+        const res = await trigger.handleRequest({ flowName: 'lead_intake', hookId: 'hk1', rawBody: '{}' });
+        expect(res.status).toBe(404);
+        expect(trigger.listHooks()).toHaveLength(0);
+    });
+});

--- a/packages/triggers/trigger-api/src/api-trigger.ts
+++ b/packages/triggers/trigger-api/src/api-trigger.ts
@@ -1,0 +1,216 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { AutomationContext } from '@objectstack/spec/contracts';
+
+/**
+ * Structural mirror of the automation engine's `FlowTriggerBinding` — same
+ * decoupling pattern as `trigger-schedule` / `trigger-record-change`: this
+ * package never imports `service-automation`.
+ */
+export interface FlowTriggerBinding {
+    readonly flowName: string;
+    readonly object?: string;
+    readonly event?: string;
+    readonly condition?: string | { dialect?: string; source?: string; ast?: unknown };
+    readonly schedule?: unknown;
+    readonly config?: Record<string, unknown>;
+}
+
+/** Structural mirror of the engine's `FlowTrigger` extension point. */
+export interface FlowTrigger {
+    readonly type: string;
+    start(binding: FlowTriggerBinding, callback: (ctx: AutomationContext) => Promise<void>): void;
+    stop(flowName: string): void;
+}
+
+/**
+ * The slice of `IQueueService` this trigger needs. Boundary triggers MUST
+ * ingest through the queue (ADR-0041 §5): inbound HTTP is the first event
+ * source whose rate we don't control, and a slow flow execution may neither
+ * drop nor block inbound events. At-least-once delivery; flows should be
+ * authored idempotently (an `x-idempotency-key` header passes through to the
+ * queue's dedup window).
+ */
+export interface QueueServiceSurface {
+    publish<T = unknown>(queue: string, data: T, options?: { idempotencyKey?: string }): Promise<string>;
+    subscribe<T = unknown>(queue: string, handler: (message: { data: T }) => Promise<void> | void): Promise<void>;
+    unsubscribe(queue: string): Promise<void>;
+}
+
+/** Minimal logger surface (matches core's `ctx.logger`). */
+export interface TriggerLogger {
+    info(msg: string, ...args: unknown[]): void;
+    warn(msg: string, ...args: unknown[]): void;
+    debug?(msg: string, ...args: unknown[]): void;
+}
+
+const QUEUE_PREFIX = 'flow-api';
+
+/** One armed inbound hook. */
+interface ArmedHook {
+    flowName: string;
+    hookId: string;
+    secret?: string;
+    queue: string;
+    callback: (ctx: AutomationContext) => Promise<void>;
+}
+
+/** Constant-time string compare (length leak only). */
+function safeEqual(a: string, b: string): boolean {
+    const ab = Buffer.from(a, 'utf8');
+    const bb = Buffer.from(b, 'utf8');
+    if (ab.length !== bb.length) return false;
+    return timingSafeEqual(ab, bb);
+}
+
+/**
+ * GitHub/Stripe-style HMAC verification: the sender computes
+ * `sha256=<hex hmac of the raw body>` with the shared per-flow secret and
+ * sends it as `x-objectstack-signature`.
+ */
+export function verifySignature(secret: string, rawBody: string, header: string | undefined): boolean {
+    if (!header) return false;
+    const expected = 'sha256=' + createHmac('sha256', secret).update(rawBody, 'utf8').digest('hex');
+    return safeEqual(expected, header.trim());
+}
+
+/**
+ * `api` flow trigger (ADR-0041 Tier 1) — inbound webhook/HTTP.
+ *
+ * The engine binds every `type: 'api'` flow to this trigger; `start()` arms a
+ * hook (URL path + optional HMAC secret from the start node's `config`) and
+ * subscribes a queue consumer that runs the flow. The HTTP side
+ * ({@link handleRequest}) validates and **enqueues** — it never executes the
+ * flow in-band:
+ *
+ *   POST /api/v1/automation/hooks/:flowName/:hookId
+ *     → 404 unknown flow / wrong hookId
+ *     → 401 missing/bad HMAC signature (when the flow declares a `secret`)
+ *     → 400 non-JSON body
+ *     → 202 { accepted, messageId } — queued; a consumer executes the flow
+ *
+ * The JSON payload is exposed to the flow as the trigger record (`$record` /
+ * `record.*`, fields flattened to bare references) plus `params` — the same
+ * authoring surface record-change flows use.
+ *
+ * Start-node config keys:
+ *   - `hookId`  — URL path token (default `'default'`); rotate it to revoke
+ *                 old URLs without renaming the flow.
+ *   - `secret`  — HMAC-SHA256 shared secret. Strongly recommended; without it
+ *                 the endpoint accepts unsigned posts (the trigger logs a
+ *                 warning at arm time).
+ */
+export class ApiTrigger implements FlowTrigger {
+    readonly type = 'api';
+
+    private hooks = new Map<string, ArmedHook>();
+
+    constructor(
+        private readonly getQueue: () => QueueServiceSurface | null,
+        private readonly logger: TriggerLogger,
+    ) {}
+
+    /** Currently armed hooks (for diagnostics/tests). */
+    listHooks(): Array<{ flowName: string; hookId: string; signed: boolean }> {
+        return [...this.hooks.values()].map(h => ({
+            flowName: h.flowName, hookId: h.hookId, signed: !!h.secret,
+        }));
+    }
+
+    start(binding: FlowTriggerBinding, callback: (ctx: AutomationContext) => Promise<void>): void {
+        const cfg = (binding.config ?? {}) as Record<string, unknown>;
+        const hookId = typeof cfg.hookId === 'string' && cfg.hookId.trim() ? cfg.hookId.trim() : 'default';
+        const secret = typeof cfg.secret === 'string' && cfg.secret.trim() ? cfg.secret.trim() : undefined;
+        const queue = `${QUEUE_PREFIX}:${binding.flowName}`;
+
+        const hook: ArmedHook = { flowName: binding.flowName, hookId, secret, queue, callback };
+        this.hooks.set(binding.flowName, hook);
+
+        const q = this.getQueue();
+        if (!q) {
+            this.logger.warn(
+                `[trigger-api] no queue service — inbound posts for flow '${binding.flowName}' will be rejected until one is registered`,
+            );
+        } else {
+            void q.subscribe<{ payload: Record<string, unknown> }>(queue, async (message) => {
+                const payload = (message?.data as any)?.payload ?? {};
+                await hook.callback({
+                    // The webhook body IS the trigger record: `$record`, `record.*`,
+                    // and bare field references all resolve, matching how
+                    // record-change flows are authored.
+                    record: payload,
+                    params: { ...payload },
+                    event: 'api',
+                } as AutomationContext);
+            }).catch((err: any) => {
+                this.logger.warn(`[trigger-api] subscribe failed for '${queue}': ${err?.message ?? err}`);
+            });
+        }
+
+        if (!secret) {
+            this.logger.warn(
+                `[trigger-api] flow '${binding.flowName}' armed WITHOUT a secret — endpoint accepts unsigned posts`,
+            );
+        }
+        this.logger.info(
+            `[trigger-api] armed: POST .../automation/hooks/${binding.flowName}/${hookId}${secret ? ' (HMAC required)' : ''}`,
+        );
+    }
+
+    stop(flowName: string): void {
+        const hook = this.hooks.get(flowName);
+        if (!hook) return;
+        this.hooks.delete(flowName);
+        const q = this.getQueue();
+        if (q) void q.unsubscribe(hook.queue).catch(() => { /* already gone */ });
+        this.logger.info(`[trigger-api] disarmed: flow '${flowName}'`);
+    }
+
+    /**
+     * Handle one inbound request. Transport-agnostic: the plugin adapts this
+     * to the host HTTP server. Returns the response to send.
+     */
+    async handleRequest(input: {
+        flowName: string;
+        hookId: string;
+        rawBody: string;
+        signatureHeader?: string;
+        idempotencyKey?: string;
+    }): Promise<{ status: number; body: Record<string, unknown> }> {
+        const hook = this.hooks.get(input.flowName);
+        // Unknown flow and wrong hookId answer identically — no oracle for
+        // probing which flows exist.
+        if (!hook || !safeEqual(hook.hookId, input.hookId)) {
+            return { status: 404, body: { error: 'not_found' } };
+        }
+        if (hook.secret && !verifySignature(hook.secret, input.rawBody, input.signatureHeader)) {
+            return { status: 401, body: { error: 'invalid_signature' } };
+        }
+
+        let payload: Record<string, unknown>;
+        try {
+            const parsed: unknown = input.rawBody.trim() ? JSON.parse(input.rawBody) : {};
+            if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+                return { status: 400, body: { error: 'invalid_body', message: 'Body must be a JSON object.' } };
+            }
+            payload = parsed as Record<string, unknown>;
+        } catch {
+            return { status: 400, body: { error: 'invalid_body', message: 'Body must be valid JSON.' } };
+        }
+
+        const q = this.getQueue();
+        if (!q) {
+            return { status: 503, body: { error: 'queue_unavailable', message: 'No queue service is registered.' } };
+        }
+        try {
+            const messageId = await q.publish(hook.queue, { payload }, {
+                idempotencyKey: input.idempotencyKey,
+            });
+            return { status: 202, body: { accepted: true, messageId } };
+        } catch (err: any) {
+            this.logger.warn(`[trigger-api] enqueue failed for '${hook.queue}': ${err?.message ?? err}`);
+            return { status: 503, body: { error: 'enqueue_failed' } };
+        }
+    }
+}

--- a/packages/triggers/trigger-api/src/index.ts
+++ b/packages/triggers/trigger-api/src/index.ts
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+export { ApiTriggerPlugin, HOOKS_PATH } from './plugin.js';
+export { ApiTrigger, verifySignature } from './api-trigger.js';
+export type {
+    FlowTrigger,
+    FlowTriggerBinding,
+    QueueServiceSurface,
+    TriggerLogger,
+} from './api-trigger.js';

--- a/packages/triggers/trigger-api/src/plugin.ts
+++ b/packages/triggers/trigger-api/src/plugin.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { Plugin, PluginContext } from '@objectstack/core';
+import { ApiTrigger } from './api-trigger.js';
+import type { FlowTrigger, QueueServiceSurface } from './api-trigger.js';
+
+/**
+ * The slice of the automation engine this plugin needs. Declared structurally
+ * so the plugin does not take a build dependency on
+ * `@objectstack/service-automation`.
+ */
+interface AutomationTriggerRegistry {
+    registerTrigger(trigger: FlowTrigger): void;
+    unregisterTrigger?(type: string): void;
+}
+
+/** The slice of the Hono host server this plugin needs. */
+interface HttpServerSurface {
+    getRawApp(): {
+        post(path: string, handler: (c: any) => Promise<unknown> | unknown): void;
+    } | null;
+}
+
+/** Mount point for inbound hooks on the host HTTP server. */
+export const HOOKS_PATH = '/api/v1/automation/hooks/:flowName/:hookId';
+
+/**
+ * ApiTriggerPlugin (ADR-0041 Tier 1)
+ *
+ * Makes `type: 'api'` flows actually fire. The automation engine derives an
+ * `api` binding from the flow; this plugin provides the concrete trigger:
+ *
+ *  - mounts `POST /api/v1/automation/hooks/:flowName/:hookId` on the host
+ *    Hono app (resolved via the `http-server` service);
+ *  - validates hookId + HMAC signature (`x-objectstack-signature`,
+ *    GitHub/Stripe style, constant-time) against the flow's start-node
+ *    config;
+ *  - **enqueues** the payload (`queue` service) and ACKs 202 — flow
+ *    execution happens on the queue consumer, never in-band with the
+ *    inbound request (ADR-0041 §5: boundary triggers must not let a slow
+ *    flow drop or block events). `x-idempotency-key` passes through to the
+ *    queue's dedup window.
+ *
+ * Webhook payloads surface to the flow as the trigger record (`$record` /
+ * `record.*` / bare field references) — the same authoring surface
+ * record-change flows use.
+ */
+export class ApiTriggerPlugin implements Plugin {
+    name = 'com.objectstack.trigger.api';
+    type = 'standard';
+    version = '1.0.0';
+    dependencies = ['com.objectstack.service.queue'];
+
+    async init(ctx: PluginContext): Promise<void> {
+        ctx.logger.info('API trigger plugin initialized');
+    }
+
+    async start(ctx: PluginContext): Promise<void> {
+        // Resolve at kernel:ready — the automation engine, queue service, and
+        // HTTP server may all start after this plugin.
+        ctx.hook('kernel:ready', async () => {
+            const automation = this.resolveService<AutomationTriggerRegistry>(ctx, 'automation');
+            if (!automation || typeof automation.registerTrigger !== 'function') {
+                ctx.logger.warn('ApiTriggerPlugin: automation service not available — api trigger NOT installed');
+                return;
+            }
+            if (!this.resolveService<QueueServiceSurface>(ctx, 'queue')) {
+                ctx.logger.warn('ApiTriggerPlugin: queue service not available — inbound posts will 503 until one is registered');
+            }
+
+            const trigger = new ApiTrigger(
+                () => this.resolveService<QueueServiceSurface>(ctx, 'queue'),
+                ctx.logger,
+            );
+            automation.registerTrigger(trigger);
+
+            const http = this.resolveService<HttpServerSurface>(ctx, 'http-server');
+            const rawApp = http && typeof http.getRawApp === 'function' ? http.getRawApp() : null;
+            if (!rawApp) {
+                ctx.logger.warn('ApiTriggerPlugin: HTTP server not available — hooks endpoint not mounted');
+                return;
+            }
+            rawApp.post(HOOKS_PATH, async (c: any) => {
+                const rawBody = await c.req.text();
+                const out = await trigger.handleRequest({
+                    flowName: c.req.param('flowName'),
+                    hookId: c.req.param('hookId'),
+                    rawBody,
+                    signatureHeader: c.req.header('x-objectstack-signature'),
+                    idempotencyKey: c.req.header('x-idempotency-key') || undefined,
+                });
+                return c.json(out.body, out.status);
+            });
+            ctx.logger.info(`ApiTriggerPlugin: api trigger registered, hooks mounted at POST ${HOOKS_PATH}`);
+        });
+    }
+
+    private resolveService<T>(ctx: PluginContext, name: string): T | null {
+        try {
+            return ctx.getService<T>(name) ?? null;
+        } catch {
+            return null;
+        }
+    }
+}

--- a/packages/triggers/trigger-api/tsconfig.json
+++ b/packages/triggers/trigger-api/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "**/*.test.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -581,6 +581,9 @@ importers:
       '@objectstack/spec':
         specifier: workspace:*
         version: link:../spec
+      '@objectstack/trigger-api':
+        specifier: workspace:*
+        version: link:../triggers/trigger-api
       '@objectstack/trigger-record-change':
         specifier: workspace:*
         version: link:../triggers/trigger-record-change
@@ -2109,6 +2112,25 @@ importers:
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.2)(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/triggers/trigger-api:
+    dependencies:
+      '@objectstack/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@objectstack/spec':
+        specifier: workspace:*
+        version: link:../../spec
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.2
+        version: 25.9.2
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary

Completes the ADR-0041 Tier-1 trigger trio (*data changed / time passed / someone called us*). Born in `packages/triggers/` per the new taxonomy.

- **Engine**: `resolveTriggerBinding` now derives an `api` binding for `type: 'api'` flows — activating the enum value that has been schema-reserved (and a Studio trap) until now.
- **`@objectstack/trigger-api`**: mounts `POST /api/v1/automation/hooks/:flowName/:hookId` on the host Hono app (`http-server` service). `hookId` is a rotatable URL token from the start-node config; unknown flows and wrong hookIds answer with **identical 404s** (no probing oracle). HMAC verification is GitHub/Stripe style (`x-objectstack-signature: sha256=<hmac of raw body>`, constant-time compare); secretless flows accept unsigned posts with an arm-time warning.
- **Queue-backed ingestion from day one** (ADR-0041 §5): the handler validates, **enqueues** (`queue` service) and ACKs **202** — flow execution happens on the queue consumer, never in-band. `x-idempotency-key` → queue dedup window; at-least-once delivery. This establishes the ingestion seam every future boundary trigger (queue / connector-event / email) reuses.
- Payload surfaces as the trigger record (`$record` / `record.*` / bare references) — same authoring surface as record-change flows.
- `serve` auto-loads the trigger; showcase gains a worked example (`showcase_inbound_task_webhook`).

## Test plan

- trigger-api: **9 tests** (HMAC accept/reject, identical-404 anti-probing, 401 paths, unsigned-with-warning, non-JSON 400, idempotency passthrough, no-queue 503, stop() disarm) ✅
- service-automation: 180 ✅ · CLI builds ✅ · changesets fixed-group check ✅ (caught the missing new package locally this time)
- **Live e2e on showcase**: `curl` with correct HMAC → `202 {accepted, messageId}`; bad signature → 401; wrong hookId / unknown flow → identical 404; queue consumer executed the flow and created `showcase_task "Webhook 进线：Acme 询价跟进"` (title/assignee/project/status all interpolated from the payload) — verified in the Console record page with the system activity entry. Boot log shows `ApiTriggerPlugin` loaded alongside the other triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)