### PR TITLE
feat(approvals): server-side pagination + search pushdown for listRequests

### DIFF
--- a/.changeset/approvals-server-pagination.md
+++ b/.changeset/approvals-server-pagination.md
@@ -1,0 +1,7 @@
+---
+"@objectstack/spec": minor
+"@objectstack/plugin-approvals": minor
+"@objectstack/rest": minor
+---
+
+Approvals server-side pagination + search pushdown (#1745). `listRequests` accepts `q` / `limit` / `offset` — free-text search pushes into the engine query as an `$or` of `$contains` terms (the `payload_json` snapshot carries record titles, so titles match without a join), and the page window pushes down whenever the filter is fully pushable; approver/status-array filters still post-filter their bounded scan and window in memory (the documented residual until the approver join-table follow-up). New `countRequests` returns the unwindowed total (engine `count` when pushable). REST: `GET /approvals/requests` gains `q`/`limit`/`offset` and returns `{data, total}` when paging.

--- a/packages/plugins/plugin-approvals/src/approval-service.test.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.test.ts
@@ -23,6 +23,10 @@ function makeFakeEngine() {
   function matches(row: FakeRow, filter: any): boolean {
     if (!filter || typeof filter !== 'object') return true;
     for (const [k, v] of Object.entries(filter)) {
+      if (k === '$or') {
+        if (!(v as any[]).some(sub => matches(row, sub))) return false;
+        continue;
+      }
       const rv = row[k];
       if (v != null && typeof v === 'object' && '$in' in (v as any)) {
         if (!(v as any).$in.includes(rv)) return false;
@@ -30,6 +34,10 @@ function makeFakeEngine() {
       }
       if (v != null && typeof v === 'object' && '$ne' in (v as any)) {
         if (rv === (v as any).$ne) return false;
+        continue;
+      }
+      if (v != null && typeof v === 'object' && '$contains' in (v as any)) {
+        if (!String(rv ?? '').includes(String((v as any).$contains))) return false;
         continue;
       }
       if (rv !== v) return false;
@@ -51,7 +59,8 @@ function makeFakeEngine() {
           return direction === 'desc' ? -cmp : cmp;
         });
       }
-      return rows.slice(0, options?.limit ?? 1000);
+      const start = options?.offset ?? 0;
+      return rows.slice(start, start + (options?.limit ?? 1000));
     },
     async insert(object: string, data: any) {
       ensure(object).push({ ...data });
@@ -471,6 +480,49 @@ describe('ApprovalService (node era)', () => {
       .rejects.toThrow(/FORBIDDEN/);
     const actions = await svc.listActions(req.id, SYS);
     expect(actions.filter(a => a.action === 'comment')).toHaveLength(2);
+  });
+
+  // ── pagination + search pushdown (#1745) ────────────────────────
+
+  async function openMany(n: number) {
+    for (let i = 0; i < n; i++) {
+      await svc.openNodeRequest(openInput(['u9'], {
+        recordId: `opp${i}`, record: { id: `opp${i}`, name: `Deal ${i}` },
+      }), CTX);
+    }
+  }
+
+  it('listRequests: windows pushable queries newest-first with limit/offset', async () => {
+    await openMany(5);
+    const page1 = await svc.listRequests({ limit: 2, offset: 0 }, SYS);
+    const page2 = await svc.listRequests({ limit: 2, offset: 2 }, SYS);
+    expect(page1.map(r => r.record_id)).toEqual(['opp4', 'opp3']); // created_at desc
+    expect(page2.map(r => r.record_id)).toEqual(['opp2', 'opp1']);
+  });
+
+  it('listRequests: q matches the payload snapshot (record titles) via pushdown', async () => {
+    await openMany(3);
+    const hit = await svc.listRequests({ q: 'Deal 1', limit: 10 }, SYS);
+    expect(hit.map(r => r.record_id)).toEqual(['opp1']);
+    const miss = await svc.listRequests({ q: 'no-such-thing', limit: 10 }, SYS);
+    expect(miss).toHaveLength(0);
+  });
+
+  it('countRequests: returns the unwindowed total for a filter', async () => {
+    await openMany(4);
+    expect(await svc.countRequests({ status: 'pending' }, SYS)).toBe(4);
+    expect(await svc.countRequests({ q: 'Deal 2' }, SYS)).toBe(1);
+  });
+
+  it('listRequests: approver queries window in memory AFTER exact-match filtering', async () => {
+    await openMany(4); // approver u9 on all
+    await svc.openNodeRequest(openInput(['someone-else'], {
+      recordId: 'oppX', record: { id: 'oppX', name: 'Other' },
+    }), CTX);
+    const page = await svc.listRequests({ approverId: 'u9', limit: 2, offset: 2 }, SYS);
+    expect(page).toHaveLength(2);
+    expect(page.every(r => r.pending_approvers?.includes('u9'))).toBe(true);
+    expect(await svc.countRequests({ approverId: 'u9' }, SYS)).toBe(4);
   });
 
   // ── SLA escalation (ADR-0042) ───────────────────────────────────

--- a/packages/plugins/plugin-approvals/src/approval-service.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.ts
@@ -1149,16 +1149,17 @@ export class ApprovalService implements IApprovalService {
 
   // ── Read API ─────────────────────────────────────────────────
 
-  async listRequests(
+  /** Filter type accepted by {@link listRequests} / {@link countRequests}. */
+  private buildRequestWhere(
     filter: {
       object?: string;
       recordId?: string;
       status?: ApprovalStatus | ApprovalStatus[];
-      approverId?: string | string[];
       submitterId?: string;
+      q?: string;
     } | undefined,
     context: SharingExecutionContext,
-  ): Promise<ApprovalRequestRow[]> {
+  ): { where: any; statusPostFilter?: ApprovalStatus[] } {
     const f: any = {};
     if (filter?.object) f.object_name = filter.object;
     if (filter?.recordId) f.record_id = filter.recordId;
@@ -1171,34 +1172,113 @@ export class ApprovalService implements IApprovalService {
     // on pending_approvers which RLS can't model cleanly).
     const tenantOrg = (context as any)?.organizationId ?? (context as any)?.tenantId;
     if (tenantOrg) f.organization_id = tenantOrg;
+    // Free-text search, pushed down: `payload_json` carries the record
+    // snapshot, so record titles match without any join. `$contains` is the
+    // driver's escaped-LIKE operator.
+    const q = filter?.q?.trim();
+    if (q) {
+      f.$or = [
+        { process_name: { $contains: q } },
+        { object_name: { $contains: q } },
+        { record_id: { $contains: q } },
+        { submitter_id: { $contains: q } },
+        { payload_json: { $contains: q } },
+      ];
+    }
     // Status: when array, post-filter; when single, push into engine filter.
-    let statusFilter: ApprovalStatus[] | undefined;
-    if (Array.isArray(filter?.status)) statusFilter = filter!.status as ApprovalStatus[];
+    let statusPostFilter: ApprovalStatus[] | undefined;
+    if (Array.isArray(filter?.status)) statusPostFilter = filter!.status as ApprovalStatus[];
     else if (filter?.status) f.status = filter.status;
+    return { where: f, statusPostFilter };
+  }
 
-    const rows = await this.engine.find('sys_approval_request', {
-      where: f, limit: 500, orderBy: [{ field: 'updated_at', direction: 'desc' }], context: SYSTEM_CTX,
-    });
+  async listRequests(
+    filter: {
+      object?: string;
+      recordId?: string;
+      status?: ApprovalStatus | ApprovalStatus[];
+      approverId?: string | string[];
+      submitterId?: string;
+      q?: string;
+      limit?: number;
+      offset?: number;
+    } | undefined,
+    context: SharingExecutionContext,
+  ): Promise<ApprovalRequestRow[]> {
+    const { where, statusPostFilter } = this.buildRequestWhere(filter, context);
+    const approverTargets = (Array.isArray(filter?.approverId) ? filter!.approverId : filter?.approverId ? [filter.approverId] : [])
+      .map(t => String(t).trim())
+      .filter(Boolean);
+
+    // The page window pushes into the engine only when nothing post-filters
+    // in memory; an approver/status-array query still scans the (bounded)
+    // candidate set and windows after filtering — correct for personal
+    // queues, and the documented residual limit for org-wide approver
+    // queries (issue #1745's join-table follow-up).
+    const pushWindow = approverTargets.length === 0 && !statusPostFilter
+      && (filter?.limit != null || filter?.offset != null);
+    const findOpts: any = {
+      where,
+      orderBy: [{ field: 'created_at', direction: 'desc' }],
+      context: SYSTEM_CTX,
+    };
+    if (pushWindow) {
+      findOpts.limit = Math.min(Math.max(filter?.limit ?? 50, 1), 200);
+      if (filter?.offset) findOpts.offset = Math.max(filter.offset, 0);
+    } else {
+      findOpts.limit = 500;
+    }
+
+    const rows = await this.engine.find('sys_approval_request', findOpts);
     let list = Array.isArray(rows) ? rows.map(rowFromRequest) : [];
-    if (statusFilter) list = list.filter(r => statusFilter!.includes(r.status));
-    if (filter?.approverId) {
-      // Accept one identity or a list: a request matches when ANY of the
-      // caller's identities (user id / email / role:<r>) is a pending
-      // approver. This lets the Console badge fetch "my pending approvals"
-      // in a single request instead of one-per-identity (previously the
-      // client looped, firing N near-simultaneous calls per poll).
-      const targets = (Array.isArray(filter.approverId) ? filter.approverId : [filter.approverId])
-        .map(t => String(t).trim())
-        .filter(Boolean);
-      if (targets.length) {
-        list = list.filter(r => {
-          const pending = r.pending_approvers ?? [];
-          return targets.some(t => pending.includes(t));
-        });
-      }
+    if (statusPostFilter) list = list.filter(r => statusPostFilter.includes(r.status));
+    if (approverTargets.length) {
+      // A request matches when ANY of the caller's identities (user id /
+      // email / role:<r>) is a pending approver — exact CSV-entry match.
+      list = list.filter(r => {
+        const pending = r.pending_approvers ?? [];
+        return approverTargets.some(t => pending.includes(t));
+      });
+    }
+    if (!pushWindow && (filter?.limit != null || filter?.offset != null)) {
+      const start = Math.max(filter?.offset ?? 0, 0);
+      list = list.slice(start, start + Math.min(Math.max(filter?.limit ?? 50, 1), 200));
     }
     await this.enrichRows(list);
     return list;
+  }
+
+  async countRequests(
+    filter: Parameters<IApprovalService['listRequests']>[0],
+    context: SharingExecutionContext,
+  ): Promise<number> {
+    const { where, statusPostFilter } = this.buildRequestWhere(filter, context);
+    const approverTargets = (Array.isArray(filter?.approverId) ? filter!.approverId : filter?.approverId ? [filter.approverId] : [])
+      .map(t => String(t).trim())
+      .filter(Boolean);
+
+    // Fully pushable → engine count; post-filtered → bounded scan count.
+    if (approverTargets.length === 0 && !statusPostFilter) {
+      const countFn = (this.engine as any).count;
+      if (typeof countFn === 'function') {
+        try {
+          const n = await countFn.call(this.engine, 'sys_approval_request', { where, context: SYSTEM_CTX });
+          if (typeof n === 'number') return n;
+        } catch { /* fall through to scan */ }
+      }
+    }
+    const rows = await this.engine.find('sys_approval_request', {
+      where, fields: ['id', 'status', 'pending_approvers'], limit: 500, context: SYSTEM_CTX,
+    });
+    let list: any[] = Array.isArray(rows) ? rows : [];
+    if (statusPostFilter) list = list.filter(r => statusPostFilter.includes(r.status));
+    if (approverTargets.length) {
+      list = list.filter(r => {
+        const pending = csvSplit(r.pending_approvers);
+        return approverTargets.some(t => pending.includes(t));
+      });
+    }
+    return list.length;
   }
 
   async getRequest(requestId: string, context: SharingExecutionContext): Promise<ApprovalRequestRow | null> {

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -4293,13 +4293,26 @@ export class RestServer {
                         .flatMap((s: any) => String(s).split(','))
                         .map((s: string) => s.trim())
                         .filter(Boolean);
-                    const rows = await svc.listRequests({
+                    const limit = q.limit != null ? Number(q.limit) : undefined;
+                    const offset = q.offset != null ? Number(q.offset) : undefined;
+                    const listFilter = {
                         object: q.object,
                         recordId: q.recordId ?? q.record_id,
                         status: q.status,
                         approverId: approverIds.length ? approverIds : undefined,
                         submitterId: q.submitterId ?? q.submitter_id,
-                    }, context ?? {});
+                        q: typeof q.q === 'string' ? q.q : undefined,
+                        limit: Number.isFinite(limit) ? limit : undefined,
+                        offset: Number.isFinite(offset) ? offset : undefined,
+                    };
+                    const rows = await svc.listRequests(listFilter, context ?? {});
+                    // `total` only when the caller pages — counting costs a
+                    // second query and unpaged callers don't need it.
+                    if (listFilter.limit != null && typeof svc.countRequests === 'function') {
+                        const total = await svc.countRequests(listFilter, context ?? {});
+                        res.json({ data: rows, total });
+                        return;
+                    }
                     res.json({ data: rows });
                 } catch (error: any) {
                     logError('[REST] List approval requests error:', error);

--- a/packages/spec/src/contracts/approval-service.ts
+++ b/packages/spec/src/contracts/approval-service.ts
@@ -176,9 +176,32 @@ export interface IApprovalService {
        */
       approverId?: string | string[];
       submitterId?: string;
+      /**
+       * Free-text search, pushed into the engine query: matches the source
+       * name, object, record id, submitter, and the payload snapshot (which
+       * carries record titles), case behavior per the underlying driver.
+       */
+      q?: string;
+      /**
+       * Page window. Honoured as an engine-level window when the filter is
+       * fully pushable; an `approverId` / status-array filter still
+       * post-filters in memory (bounded personal queues), where the window
+       * is applied after filtering.
+       */
+      limit?: number;
+      offset?: number;
     } | undefined,
     context: SharingExecutionContext,
   ): Promise<ApprovalRequestRow[]>;
+
+  /**
+   * Total rows matching a {@link listRequests} filter (ignoring
+   * `limit`/`offset`) — the pagination companion.
+   */
+  countRequests(
+    filter: Parameters<IApprovalService['listRequests']>[0],
+    context: SharingExecutionContext,
+  ): Promise<number>;
 
   getRequest(requestId: string, context: SharingExecutionContext): Promise<ApprovalRequestRow | null>;
 


### PR DESCRIPTION
## Summary

Closes the dangerous half of #1745 — beyond the 500-row scan cap the inbox silently lost rows. Console companion: objectstack-ai/objectui#1658 (merged).

- **`q` pushdown**: free-text search becomes an `$or` of `$contains` (escaped-LIKE) terms over `process_name` / `object_name` / `record_id` / `submitter_id` / **`payload_json`** — the payload snapshot carries record titles, so business names match with no join.
- **Page window pushdown**: `limit`/`offset` push into the engine (`orderBy created_at desc`) whenever the filter is fully pushable. `approverId` / status-array filters still post-filter their bounded scan and window in memory — correct for personal queues; the org-wide approver case is the documented residual until the approver join-table follow-up (#1745 stays open for that).
- **`countRequests`**: unwindowed total via engine `count()` when pushable, bounded scan otherwise.
- **REST**: `GET /approvals/requests` accepts `q`/`limit`/`offset`, returns `{data, total}` when paging; unpaged callers keep the old shape (no extra count query).

## Test plan

- plugin-approvals: **64 tests** (4 new: window newest-first/no-overlap, q matches payload titles, count totals, approver in-memory windowing after exact-match filter) ✅ — fake engine extended with `$or`/`$contains`/`offset`
- **Live e2e on showcase**: `limit=10&offset=0/10` pages with zero overlap and `total=31`; `q=Compliance` → 5/5 matches; `status=recalled` → 2/2. Console: 56 rows → first page 50 + 「加载更多」 → 56/56 with the button gone; a debounced UI search for a title on an **unloaded** page returned the row (server search, not page filtering) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)