### PR TITLE
feat(cloud-connection): self-hosted credential loop + SDUI binding surface

### DIFF
--- a/.changeset/connection-credential-store.md
+++ b/.changeset/connection-credential-store.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/cloud-connection": minor
+---
+
+Self-hosted binding becomes consumable (cloud ADR-0008 consumption side): `ConnectionCredentialStore` persists the one-time `oscc_` runtime bearer the bind flow returns (0600, env-local); all control-plane forwards fall back to it when no `OS_CLOUD_API_KEY` is set; new `POST /cloud-connection/unbind` revokes + clears; install-local's catalog fetch presents the credential so org/private packages resolve. The binding Setup UI ships WITH the plugin as SDUI metadata (`cloud_connection_settings` page + Setup-nav contribution, ADR-0029 K2) — the console only registers the `cloud-connection:panel` widget.

--- a/packages/cloud-connection/src/cloud-connection-plugin.test.ts
+++ b/packages/cloud-connection/src/cloud-connection-plugin.test.ts
@@ -68,7 +68,7 @@ afterEach(() => {
 });
 
 describe('CloudConnectionPlugin — mounting', () => {
-    it('mounts all 7 routes on kernel:ready', async () => {
+    it('mounts all 8 routes on kernel:ready', async () => {
         const rawApp = makeRawApp();
         const { ctx, fireKernelReady } = makeCtx({ rawApp });
         const plugin = new CloudConnectionPlugin({ controlPlaneUrl: 'http://cloud.test' });
@@ -79,12 +79,13 @@ describe('CloudConnectionPlugin — mounting', () => {
             'GET /api/v1/cloud-connection/status',
             'POST /api/v1/cloud-connection/bind/start',
             'POST /api/v1/cloud-connection/bind/poll',
+            'POST /api/v1/cloud-connection/unbind',
             'POST /api/v1/cloud-connection/install',
             'GET /api/v1/cloud-connection/installation',
             'GET /api/v1/cloud-connection/installed',
             'GET /api/v1/cloud-connection/org-packages',
         ]));
-        expect(keys).toHaveLength(7);
+        expect(keys).toHaveLength(8);
     });
 
     it('warns and mounts nothing without an http-server', async () => {

--- a/packages/cloud-connection/src/cloud-connection-plugin.ts
+++ b/packages/cloud-connection/src/cloud-connection-plugin.ts
@@ -67,6 +67,9 @@ interface Plugin {
     start(ctx: PluginContext): Promise<void>;
 }
 
+import { ConnectionCredentialStore } from './connection-credential-store.js';
+import { CLOUD_CONNECTION_UI_BUNDLE } from './cloud-connection-ui.js';
+
 const CLOUD_CONNECTION_PREFIX = '/api/v1/cloud-connection';
 
 export interface CloudConnectionPluginConfig {
@@ -88,6 +91,12 @@ export interface CloudConnectionPluginConfig {
      * host kernel's own `auth` service.
      */
     singleEnvironment?: boolean;
+    /**
+     * Override the on-disk credential store location. Defaults to
+     * `<cwd>/.objectstack/cloud-connection.json` — where the bind flow
+     * persists the `oscc_…` runtime bearer for self-hosted runtimes.
+     */
+    credentialPath?: string;
 }
 
 export class CloudConnectionPlugin implements Plugin {
@@ -95,9 +104,11 @@ export class CloudConnectionPlugin implements Plugin {
     readonly version = '0.2.0';
 
     private readonly cfg: CloudConnectionPluginConfig;
+    private readonly store: ConnectionCredentialStore;
 
     constructor(config: CloudConnectionPluginConfig = {}) {
         this.cfg = config;
+        this.store = new ConnectionCredentialStore(config.credentialPath);
     }
 
     init = async (_ctx: PluginContext): Promise<void> => { /* HTTP wiring on kernel:ready */ };
@@ -118,6 +129,17 @@ export class CloudConnectionPlugin implements Plugin {
             const deviceClientId = (this.cfg.deviceClientId ?? process.env.OS_CLI_CLIENT_ID ?? 'objectstack-cli').trim();
             const deviceScope = 'openid profile email';
 
+            // Effective control-plane credential, resolved PER REQUEST:
+            // cloud-hosted runtimes carry the env→cloud service key; a
+            // self-hosted runtime presents the `oscc_…` bearer the bind flow
+            // persisted. Lazy so a bind that completes while the runtime is
+            // up takes effect without a restart.
+            const credential = (): string => cloudApiKey || this.store.read()?.runtimeToken || '';
+            const authHeaders = (): Record<string, string> => {
+                const cred = credential();
+                return cred ? { Authorization: `Bearer ${cred}` } : {};
+            };
+
             const hostOf = (c: any): string => {
                 try { return new URL(c.req.url).hostname; } catch { return ''; }
             };
@@ -125,7 +147,11 @@ export class CloudConnectionPlugin implements Plugin {
             const resolveEnvironmentId = async (c: any): Promise<string | undefined> => {
                 const fixed = (this.cfg.environmentId ?? process.env.OS_ENVIRONMENT_ID ?? '').trim();
                 if (fixed) return fixed;
-                if (this.cfg.singleEnvironment) return undefined;
+                if (this.cfg.singleEnvironment) {
+                    // A completed bind persisted the environment id — a
+                    // self-hosted runtime needs no OS_ENVIRONMENT_ID after it.
+                    return this.store.read()?.environmentId || undefined;
+                }
                 try {
                     const envRegistry = ctx.getService<any>('env-registry');
                     const env = await envRegistry?.resolveByHostname?.(hostOf(c));
@@ -134,6 +160,15 @@ export class CloudConnectionPlugin implements Plugin {
                     return undefined;
                 }
             };
+
+            // SDUI surface: the binding page + Setup-nav entry ship with the
+            // plugin as metadata (ADR-0029 K2); the console only provides the
+            // registered `cloud-connection:panel` widget. Best-effort — a
+            // kernel without a manifest service simply has no Setup entry.
+            try {
+                const manifest = ctx.getService<{ register(m: any): void }>('manifest');
+                manifest?.register?.(CLOUD_CONNECTION_UI_BUNDLE);
+            } catch { /* no manifest service — headless kernel */ }
 
             const sessionFromAuthService = async (authSvc: any, rawReq: Request): Promise<{ userId?: string } | null> => {
                 const api = typeof authSvc?.getApi === 'function' ? await authSvc.getApi() : authSvc?.api ?? authSvc;
@@ -176,22 +211,22 @@ export class CloudConnectionPlugin implements Plugin {
                     return c.json({ success: false, error: { code: 'environment_not_found' } }, 404);
                 }
                 // Prefer the real, device-bound sys_cloud_connection from the
-                // control plane. Fall back to the implicit cloud-hosted binding
-                // (OS_CLOUD_API_KEY) when the control plane is unreachable.
+                // control plane. Fall back to the implicit local binding
+                // (service key or stored runtime bearer) when unreachable.
                 if (cloudUrl) {
                     try {
                         const resp = await fetch(`${cloudUrl}/api/v1/cloud-connection/status?environment_id=${encodeURIComponent(environmentId)}`, {
-                            headers: cloudApiKey ? { Authorization: `Bearer ${cloudApiKey}` } : {},
+                            headers: authHeaders(),
                         });
                         if (resp.ok) {
                             const json: any = await resp.json().catch(() => null);
                             const data = json?.data ?? {};
-                            const bound = Boolean(data.bound) || Boolean(cloudApiKey);
+                            const bound = Boolean(data.bound) || Boolean(credential());
                             return c.json({ success: true, data: { environmentId, bound, provider: 'objectstack-cloud', connection: data.connection ?? null } });
                         }
                     } catch { /* fall through to implicit */ }
                 }
-                const bound = Boolean(cloudApiKey);
+                const bound = Boolean(credential());
                 return c.json({ success: true, data: { environmentId, bound, provider: 'objectstack-cloud', connection: null } });
             });
 
@@ -200,8 +235,16 @@ export class CloudConnectionPlugin implements Plugin {
             // code, returns them to the Setup UI, and the operator approves in
             // the cloud console.
             rawApp.post(`${CLOUD_CONNECTION_PREFIX}/bind/start`, async (c: any) => {
-                const environmentId = await resolveEnvironmentId(c);
-                if (!environmentId) return c.json({ success: false, error: { code: 'environment_not_found' } }, 404);
+                let body: any = {};
+                try { body = await c.req.json(); } catch { body = {}; }
+                // Single-env runtimes that have never bound have no env id yet:
+                // the Setup UI passes the target environment id explicitly (the
+                // operator copies it from the cloud console).
+                let environmentId = await resolveEnvironmentId(c);
+                if (!environmentId && this.cfg.singleEnvironment) {
+                    environmentId = String(body?.environment_id ?? body?.environmentId ?? '').trim() || undefined;
+                }
+                if (!environmentId) return c.json({ success: false, error: { code: 'environment_not_found', message: 'Provide environment_id (create an environment in the cloud console and paste its id).' } }, 404);
                 const session = await resolveSession(environmentId, c.req.raw);
                 if (!session?.userId) return c.json({ success: false, error: { code: 'unauthenticated', message: 'Sign in to this environment to connect a cloud account.' } }, 401);
                 if (!cloudUrl) return c.json({ success: false, error: { code: 'cloud_unconfigured', message: 'No cloud control plane configured.' } }, 503);
@@ -232,14 +275,17 @@ export class CloudConnectionPlugin implements Plugin {
             // the operator token for a persisted sys_cloud_connection via the
             // control plane's /bind.
             rawApp.post(`${CLOUD_CONNECTION_PREFIX}/bind/poll`, async (c: any) => {
-                const environmentId = await resolveEnvironmentId(c);
+                let body: any = {};
+                try { body = await c.req.json(); } catch { body = {}; }
+                let environmentId = await resolveEnvironmentId(c);
+                if (!environmentId && this.cfg.singleEnvironment) {
+                    environmentId = String(body?.environment_id ?? body?.environmentId ?? '').trim() || undefined;
+                }
                 if (!environmentId) return c.json({ success: false, error: { code: 'environment_not_found' } }, 404);
                 const session = await resolveSession(environmentId, c.req.raw);
                 if (!session?.userId) return c.json({ success: false, error: { code: 'unauthenticated' } }, 401);
                 if (!cloudUrl) return c.json({ success: false, error: { code: 'cloud_unconfigured' } }, 503);
 
-                let body: any = {};
-                try { body = await c.req.json(); } catch { body = {}; }
                 const deviceCode = String(body?.device_code ?? body?.deviceCode ?? '').trim();
                 if (!deviceCode) return c.json({ success: false, error: { code: 'invalid_request', message: 'device_code is required' } }, 400);
 
@@ -266,11 +312,56 @@ export class CloudConnectionPlugin implements Plugin {
                         body: JSON.stringify({ environment_id: environmentId, token: accessToken, scope: deviceScope }),
                     });
                     const bindJson: any = await bindResp.json().catch(() => ({ success: false, error: 'bind failed (no body)' }));
+                    // The bind response carries the one-time runtime bearer.
+                    // Persist it HERE (server-side, 0600 file) and STRIP it
+                    // from what goes back to the browser — the SPA never
+                    // holds the credential.
+                    const runtimeToken = bindJson?.data?.runtime_token;
+                    if (bindResp.ok && typeof runtimeToken === 'string' && runtimeToken) {
+                        try {
+                            this.store.write({
+                                runtimeToken,
+                                environmentId,
+                                controlPlaneUrl: cloudUrl,
+                                organizationId: bindJson?.data?.connection?.organization_id ?? undefined,
+                                accountEmail: bindJson?.data?.connection?.account_email ?? undefined,
+                                boundAt: bindJson?.data?.connection?.bound_at ?? new Date().toISOString(),
+                            });
+                        } catch (err: any) {
+                            ctx.logger?.error?.('[CloudConnectionPlugin] failed to persist runtime credential', err instanceof Error ? err : new Error(String(err)));
+                        }
+                        delete bindJson.data.runtime_token;
+                    }
                     return c.json(bindJson, bindResp.status as any);
                 } catch (err: any) {
                     ctx.logger?.error?.('[CloudConnectionPlugin] bind/poll failed', err instanceof Error ? err : new Error(String(err)));
                     return c.json({ success: false, error: { code: 'bind_failed', message: String(err?.message ?? err) } }, 502);
                 }
+            });
+
+            // POST /unbind — disconnect this runtime from the control plane.
+            // Revokes the connection server-side (best-effort) and clears the
+            // local credential. Requires an environment session, mirroring
+            // bind/start.
+            rawApp.post(`${CLOUD_CONNECTION_PREFIX}/unbind`, async (c: any) => {
+                const environmentId = await resolveEnvironmentId(c);
+                if (!environmentId) return c.json({ success: false, error: { code: 'environment_not_found' } }, 404);
+                const session = await resolveSession(environmentId, c.req.raw);
+                if (!session?.userId) return c.json({ success: false, error: { code: 'unauthenticated' } }, 401);
+
+                let revoked = false;
+                if (cloudUrl && credential()) {
+                    try {
+                        const resp = await fetch(`${cloudUrl}/api/v1/cloud-connection/revoke`, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json', ...authHeaders() },
+                            body: JSON.stringify({ environment_id: environmentId }),
+                        });
+                        revoked = resp.ok;
+                    } catch { /* control plane unreachable — local clear still proceeds */ }
+                }
+                const cleared = (() => { try { return this.store.clear(); } catch { return false; } })();
+                return c.json({ success: true, data: { environmentId, revoked, cleared } });
             });
 
             // POST /install { package_id, seed_sample_data? } — in-environment
@@ -290,7 +381,7 @@ export class CloudConnectionPlugin implements Plugin {
                     return c.json({ success: false, error: { code: 'unauthenticated', message: 'Sign in to this environment to install apps.' } }, 401);
                 }
 
-                if (!cloudUrl || !cloudApiKey) {
+                if (!cloudUrl || !credential()) {
                     return c.json({ success: false, error: { code: 'cloud_unconfigured', message: 'This runtime is not connected to a cloud account; install is unavailable.' } }, 503);
                 }
 
@@ -308,7 +399,7 @@ export class CloudConnectionPlugin implements Plugin {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',
-                            'Authorization': `Bearer ${cloudApiKey}`,
+                            ...authHeaders(),
                         },
                         body: JSON.stringify({ recordId: packageId, params: { environment_id: environmentId, seed_sample_data: seedSampleData } }),
                     });
@@ -343,7 +434,7 @@ export class CloudConnectionPlugin implements Plugin {
 
                 // Not connected → can't know; report not-installed so the page
                 // still renders (a read should never hard-fail the page).
-                if (!cloudUrl || !cloudApiKey) return c.json({ success: true, data: { installed: false } });
+                if (!cloudUrl || !credential()) return c.json({ success: true, data: { installed: false } });
 
                 try {
                     // Read installed-state from the control plane's
@@ -356,7 +447,7 @@ export class CloudConnectionPlugin implements Plugin {
                     // result back.
                     const resp = await fetch(
                         `${cloudUrl}/api/v1/cloud/environments/${encodeURIComponent(environmentId)}/installations/${encodeURIComponent(packageId)}`,
-                        { headers: { Accept: 'application/json', Authorization: `Bearer ${cloudApiKey}` } },
+                        { headers: { Accept: 'application/json', ...authHeaders() } },
                     );
                     if (!resp.ok) return c.json({ success: true, data: { installed: false } });
                     const json: any = await resp.json().catch(() => ({}));
@@ -389,14 +480,14 @@ export class CloudConnectionPlugin implements Plugin {
                     return c.json({ success: false, error: { code: 'unauthenticated', message: 'Sign in to this environment.' } }, 401);
                 }
 
-                if (!cloudUrl || !cloudApiKey) {
+                if (!cloudUrl || !credential()) {
                     return c.json({ success: true, data: { packages: [], total: 0, connected: false } });
                 }
 
                 try {
                     const resp = await fetch(
                         `${cloudUrl}/api/v1/cloud/environments/${encodeURIComponent(environmentId)}/packages`,
-                        { headers: { Accept: 'application/json', Authorization: `Bearer ${cloudApiKey}` } },
+                        { headers: { Accept: 'application/json', ...authHeaders() } },
                     );
                     if (!resp.ok) return c.json({ success: true, data: { packages: [], total: 0, connected: true } });
                     const json: any = await resp.json().catch(() => ({}));
@@ -424,14 +515,14 @@ export class CloudConnectionPlugin implements Plugin {
                     return c.json({ success: false, error: { code: 'unauthenticated', message: 'Sign in to this environment.' } }, 401);
                 }
 
-                if (!cloudUrl || !cloudApiKey) {
+                if (!cloudUrl || !credential()) {
                     return c.json({ success: true, data: { items: [], total: 0, connected: false } });
                 }
 
                 try {
                     const resp = await fetch(
                         `${cloudUrl}/api/v1/cloud/org-packages?environment_id=${encodeURIComponent(environmentId)}`,
-                        { headers: { Accept: 'application/json', Authorization: `Bearer ${cloudApiKey}` } },
+                        { headers: { Accept: 'application/json', ...authHeaders() } },
                     );
                     if (!resp.ok) return c.json({ success: true, data: { items: [], total: 0, connected: true } });
                     const json: any = await resp.json().catch(() => ({}));

--- a/packages/cloud-connection/src/cloud-connection-ui.ts
+++ b/packages/cloud-connection/src/cloud-connection-ui.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Cloud Connection — SDUI surface (metadata, not React).
+ *
+ * The binding UI ships WITH the plugin as page + navigation metadata
+ * (ADR-0029 K2: capability plugins contribute their own Setup entries;
+ * cloud ADR-0008 / console-SDUI direction: new console surfaces are
+ * metadata-first). The only React involved is the registered
+ * `cloud-connection:panel` widget — the device-code state machine — which
+ * the console registers once as a reusable primitive; everything else
+ * (page shell, nav placement, labels) is server-driven and can evolve
+ * without a console release.
+ */
+
+import type { Page } from '@objectstack/spec/ui';
+
+/** Setup page hosting the binding panel widget. */
+export const CloudConnectionSettingsPage: Page = {
+    name: 'cloud_connection_settings',
+    label: 'Cloud Connection',
+    type: 'app',
+    template: 'default',
+    kind: 'full',
+    isDefault: false,
+    regions: [
+        {
+            name: 'header',
+            width: 'full',
+            components: [
+                {
+                    type: 'page:header',
+                    properties: {
+                        title: 'Cloud Connection',
+                        subtitle:
+                            'Connect this runtime to an ObjectStack control plane to browse your '
+                            + 'organization\'s private packages and install them here.',
+                        icon: 'cloud',
+                    },
+                },
+            ],
+        },
+        {
+            name: 'main',
+            width: 'large',
+            components: [
+                {
+                    // Registered console widget — the RFC 8628 device-code
+                    // state machine (status → start → user-code display →
+                    // poll → bound / disconnect). Talks to the same-origin
+                    // /api/v1/cloud-connection/* routes this plugin mounts.
+                    type: 'cloud-connection:panel',
+                    properties: {},
+                },
+            ],
+        },
+    ],
+};
+
+/** Setup-nav contribution: System group, after the marketplace entries. */
+export const CLOUD_CONNECTION_NAV_CONTRIBUTIONS = [
+    {
+        app: 'setup',
+        group: 'group_apps',
+        priority: 200,
+        items: [
+            {
+                id: 'nav_cloud_connection',
+                type: 'page',
+                pageName: 'cloud_connection_settings',
+                label: 'Cloud Connection',
+                icon: 'cloud',
+            },
+        ],
+    },
+];
+
+/** Manifest bundle the plugin registers so the page + nav reach the kernel. */
+export const CLOUD_CONNECTION_UI_BUNDLE = {
+    id: 'com.objectstack.cloud-connection.ui',
+    namespace: 'sys',
+    version: '0.1.0',
+    type: 'plugin',
+    scope: 'system',
+    name: 'Cloud Connection UI',
+    description: 'Setup page + navigation for binding this runtime to a control plane.',
+    pages: [CloudConnectionSettingsPage],
+    navigationContributions: CLOUD_CONNECTION_NAV_CONTRIBUTIONS,
+};

--- a/packages/cloud-connection/src/connection-credential-store.test.ts
+++ b/packages/cloud-connection/src/connection-credential-store.test.ts
@@ -1,0 +1,165 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ConnectionCredentialStore + the plugin's credential behavior
+ * (cloud ADR-0008 consumption side):
+ *   - store round-trip / clear / corrupt tolerance / 0600 mode
+ *   - bind/poll persists the one-time runtime_token and STRIPS it from
+ *     the browser-facing response
+ *   - forwards fall back to the stored bearer when no service key is set
+ *   - unbind revokes (best-effort) and clears the local credential
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ConnectionCredentialStore } from './connection-credential-store.js';
+import { CloudConnectionPlugin } from './cloud-connection-plugin.js';
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'ccs-')); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); vi.unstubAllGlobals(); });
+
+const CRED = { runtimeToken: 'oscc_abc', environmentId: 'env_1', controlPlaneUrl: 'http://cloud.test' };
+
+describe('ConnectionCredentialStore', () => {
+    it('round-trips, clears, and tolerates corrupt files', () => {
+        const store = new ConnectionCredentialStore(join(dir, 'cc.json'));
+        expect(store.read()).toBeNull();
+        store.write(CRED);
+        expect(store.read()?.runtimeToken).toBe('oscc_abc');
+        expect(store.clear()).toBe(true);
+        expect(store.clear()).toBe(false);
+
+        writeFileSync(store.path, '{nope', 'utf8');
+        expect(store.read()).toBeNull();
+    });
+
+    it('writes the secret 0600', () => {
+        const store = new ConnectionCredentialStore(join(dir, 'cc.json'));
+        store.write(CRED);
+        const mode = statSync(store.path).mode & 0o777;
+        expect(mode).toBe(0o600);
+    });
+});
+
+// ── plugin harness ──────────────────────────────────────────────────────
+type Handler = (c: any) => Promise<any>;
+function makeRawApp() {
+    const routes = new Map<string, Handler>();
+    return {
+        routes,
+        get: (p: string, h: Handler) => routes.set(`GET ${p}`, h),
+        post: (p: string, h: Handler) => routes.set(`POST ${p}`, h),
+    };
+}
+const sessionAuth = (userId?: string) => ({ api: { getSession: async () => (userId ? { user: { id: userId } } : null) } });
+function makeCtx(rawApp: any, services: Record<string, any> = {}) {
+    const hooks = new Map<string, any>();
+    return {
+        ctx: {
+            hook: (e: string, h: any) => hooks.set(e, h),
+            getService: (name: string) => {
+                if (name === 'http-server') return { getRawApp: () => rawApp };
+                const svc = services[name];
+                if (svc === undefined) throw new Error(`no ${name}`);
+                return svc;
+            },
+            logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        },
+        fire: async () => { await hooks.get('kernel:ready')?.(); },
+    };
+}
+function makeC(url: string, body?: any) {
+    const json = vi.fn((payload: any, status?: number) => ({ payload, status: status ?? 200 }));
+    return { req: { url, raw: new Request(url), json: async () => body ?? {} }, json };
+}
+
+describe('CloudConnectionPlugin credential behavior', () => {
+    it('bind/poll persists runtime_token to the store and strips it from the response', async () => {
+        const credPath = join(dir, 'cc.json');
+        const rawApp = makeRawApp();
+        const { ctx, fire } = makeCtx(rawApp, { auth: sessionAuth('admin'), manifest: { register: vi.fn() } });
+        vi.stubGlobal('fetch', vi.fn(async (url: any) => {
+            const u = String(url);
+            if (u.includes('/auth/device/token')) {
+                return new Response(JSON.stringify({ access_token: 'op-token' }), { status: 200 });
+            }
+            if (u.includes('/cloud-connection/bind')) {
+                return new Response(JSON.stringify({ success: true, data: { bound: true, connection: { organization_id: 'org_x' }, runtime_token: 'oscc_minted' } }), { status: 200 });
+            }
+            throw new Error(`unexpected fetch ${u}`);
+        }));
+        await new CloudConnectionPlugin({
+            singleEnvironment: true, environmentId: 'env_1',
+            controlPlaneUrl: 'http://cloud.test', credentialPath: credPath,
+        }).start(ctx as any);
+        await fire();
+
+        const res = await rawApp.routes.get('POST /api/v1/cloud-connection/bind/poll')!(
+            makeC('http://localhost:3000/x', { device_code: 'dc' }),
+        );
+        expect(res.payload.success).toBe(true);
+        expect(JSON.stringify(res.payload)).not.toContain('oscc_minted');
+        const stored = new ConnectionCredentialStore(credPath).read();
+        expect(stored?.runtimeToken).toBe('oscc_minted');
+        expect(stored?.environmentId).toBe('env_1');
+    });
+
+    it('forwards use the stored bearer when no service key is configured', async () => {
+        const credPath = join(dir, 'cc.json');
+        new ConnectionCredentialStore(credPath).write({ runtimeToken: 'oscc_stored', environmentId: 'env_1' });
+        const rawApp = makeRawApp();
+        const { ctx, fire } = makeCtx(rawApp, { auth: sessionAuth('admin'), manifest: { register: vi.fn() } });
+        const fetchSpy = vi.fn(async () => new Response(JSON.stringify({ success: true, data: { items: [] } }), { status: 200 }));
+        vi.stubGlobal('fetch', fetchSpy);
+        await new CloudConnectionPlugin({
+            singleEnvironment: true, controlPlaneUrl: 'http://cloud.test', controlPlaneApiKey: '', credentialPath: credPath,
+        }).start(ctx as any);
+        await fire();
+
+        // env id resolves from the STORE (no OS_ENVIRONMENT_ID, no config id).
+        const res = await rawApp.routes.get('GET /api/v1/cloud-connection/org-packages')!(
+            makeC('http://localhost:3000/api/v1/cloud-connection/org-packages'),
+        );
+        expect(res.payload.success).toBe(true);
+        const [, init] = fetchSpy.mock.calls[0]!;
+        expect((init as any).headers.Authorization).toBe('Bearer oscc_stored');
+    });
+
+    it('unbind revokes against the control plane and clears the local credential', async () => {
+        const credPath = join(dir, 'cc.json');
+        const store = new ConnectionCredentialStore(credPath);
+        store.write({ runtimeToken: 'oscc_stored', environmentId: 'env_1' });
+        const rawApp = makeRawApp();
+        const { ctx, fire } = makeCtx(rawApp, { auth: sessionAuth('admin'), manifest: { register: vi.fn() } });
+        const fetchSpy = vi.fn(async () => new Response(JSON.stringify({ success: true }), { status: 200 }));
+        vi.stubGlobal('fetch', fetchSpy);
+        await new CloudConnectionPlugin({
+            singleEnvironment: true, controlPlaneUrl: 'http://cloud.test', controlPlaneApiKey: '', credentialPath: credPath,
+        }).start(ctx as any);
+        await fire();
+
+        const res = await rawApp.routes.get('POST /api/v1/cloud-connection/unbind')!(
+            makeC('http://localhost:3000/x'),
+        );
+        expect(res.payload.data).toEqual({ environmentId: 'env_1', revoked: true, cleared: true });
+        expect(String(fetchSpy.mock.calls[0]![0])).toContain('/cloud-connection/revoke');
+        expect((fetchSpy.mock.calls[0]![1] as any).headers.Authorization).toBe('Bearer oscc_stored');
+        expect(store.read()).toBeNull();
+    });
+
+    it('registers the SDUI bundle (page + nav) with the manifest service', async () => {
+        const register = vi.fn();
+        const rawApp = makeRawApp();
+        const { ctx, fire } = makeCtx(rawApp, { manifest: { register } });
+        await new CloudConnectionPlugin({ singleEnvironment: true, controlPlaneUrl: 'http://cloud.test', credentialPath: join(dir, 'cc.json') }).start(ctx as any);
+        await fire();
+        expect(register).toHaveBeenCalledWith(expect.objectContaining({
+            id: 'com.objectstack.cloud-connection.ui',
+            pages: [expect.objectContaining({ name: 'cloud_connection_settings' })],
+            navigationContributions: [expect.objectContaining({ app: 'setup' })],
+        }));
+    });
+});

--- a/packages/cloud-connection/src/connection-credential-store.ts
+++ b/packages/cloud-connection/src/connection-credential-store.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ConnectionCredentialStore — where a SELF-HOSTED runtime keeps the
+ * credential it received at bind time (cloud ADR-0008 consumption side).
+ *
+ * Cloud-hosted runtimes authenticate to the control plane with an
+ * env→cloud service key (`OS_CLOUD_API_KEY`, injected by the cloud).
+ * Self-hosted runtimes have no such key: their identity ceremony is the
+ * RFC 8628 device-code bind, whose response carries a one-time
+ * `runtime_token` (`oscc_…`). This store persists that bearer — plus the
+ * environment id the binding established — under the runtime's own
+ * working directory, next to the LocalManifestSource ledger:
+ *
+ *   <cwd>/.objectstack/cloud-connection.json
+ *
+ * Like everything on the runtime's serving path, reads are local file
+ * operations: presenting the credential is how the runtime reaches the
+ * control plane for org-scoped catalog/install calls, but nothing at
+ * boot or serve time DEPENDS on those calls succeeding.
+ *
+ * Treat the file as a secret (it is written 0600).
+ */
+
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+/** Persisted binding credential + context. */
+export interface StoredConnectionCredential {
+    /** The `oscc_…` runtime bearer returned ONCE by the bind route. */
+    runtimeToken: string;
+    /** Control-plane environment id this runtime is bound as. */
+    environmentId: string;
+    /** Control-plane base URL the binding was made against. */
+    controlPlaneUrl?: string;
+    organizationId?: string;
+    accountEmail?: string;
+    boundAt?: string;
+}
+
+/** Default store location, relative to the runtime's working directory. */
+export const DEFAULT_CONNECTION_CREDENTIAL_PATH = '.objectstack/cloud-connection.json';
+
+export class ConnectionCredentialStore {
+    /** Resolved file path. */
+    readonly path: string;
+
+    constructor(path?: string) {
+        this.path = path
+            ? resolve(path)
+            : resolve(process.cwd(), DEFAULT_CONNECTION_CREDENTIAL_PATH);
+    }
+
+    /** Read the stored credential; null when absent or unreadable. */
+    read(): StoredConnectionCredential | null {
+        if (!existsSync(this.path)) return null;
+        try {
+            const parsed = JSON.parse(readFileSync(this.path, 'utf8'));
+            if (!parsed || typeof parsed.runtimeToken !== 'string' || !parsed.runtimeToken) return null;
+            if (typeof parsed.environmentId !== 'string' || !parsed.environmentId) return null;
+            return parsed as StoredConnectionCredential;
+        } catch {
+            return null;
+        }
+    }
+
+    /** Persist (replace) the credential. Written 0600 — it is a secret. */
+    write(credential: StoredConnectionCredential): void {
+        mkdirSync(dirname(this.path), { recursive: true });
+        writeFileSync(this.path, JSON.stringify(credential, null, 2), { encoding: 'utf8', mode: 0o600 });
+    }
+
+    /** Remove the credential (unbind). Returns false when nothing was stored. */
+    clear(): boolean {
+        if (!existsSync(this.path)) return false;
+        unlinkSync(this.path);
+        return true;
+    }
+}

--- a/packages/cloud-connection/src/index.ts
+++ b/packages/cloud-connection/src/index.ts
@@ -44,3 +44,8 @@ export { CloudConnectionPlugin, createCloudConnectionPlugin } from './cloud-conn
 export type { CloudConnectionPluginConfig } from './cloud-connection-plugin.js';
 export { RuntimeConfigPlugin } from './runtime-config-plugin.js';
 export type { RuntimeConfigPluginConfig, RuntimeConfigPlanFeatures } from './runtime-config-plugin.js';
+// ADR-0008 consumption side — the self-hosted credential ledger (bind
+// persists the oscc_ bearer here; forwards present it to the control plane).
+export { ConnectionCredentialStore, DEFAULT_CONNECTION_CREDENTIAL_PATH } from './connection-credential-store.js';
+export type { StoredConnectionCredential } from './connection-credential-store.js';
+export { CloudConnectionSettingsPage, CLOUD_CONNECTION_UI_BUNDLE } from './cloud-connection-ui.js';

--- a/packages/cloud-connection/src/marketplace-install-local-plugin.ts
+++ b/packages/cloud-connection/src/marketplace-install-local-plugin.ts
@@ -46,6 +46,7 @@ import { readEnvWithDeprecation } from '@objectstack/types';
 import { resolveCloudUrl } from './cloud-url.js';
 import { resolveMarketplacePublicBaseUrl } from './marketplace-public-url.js';
 import { LocalManifestSource, type InstalledManifestEntry } from './local-manifest-source.js';
+import { ConnectionCredentialStore } from './connection-credential-store.js';
 
 const ROUTE_BASE = '/api/v1/marketplace/install-local';
 
@@ -72,11 +73,13 @@ export class MarketplaceInstallLocalPlugin implements Plugin {
     private readonly cloudUrl: string;
     private readonly ledger: LocalManifestSource;
     private readonly storageDir: string;
+    private readonly credentials: ConnectionCredentialStore;
 
     constructor(config: MarketplaceInstallLocalPluginConfig = {}) {
         this.cloudUrl = resolveCloudUrl(config.controlPlaneUrl);
         this.ledger = new LocalManifestSource(config.storageDir);
         this.storageDir = this.ledger.dir;
+        this.credentials = new ConnectionCredentialStore();
     }
 
     init = async (_ctx: PluginContext): Promise<void> => {
@@ -215,11 +218,22 @@ export class MarketplaceInstallLocalPlugin implements Plugin {
                 url: `${this.cloudUrl}/api/v1/marketplace/packages/${encodeURIComponent(packageId)}/versions/${encodeURIComponent(versionId)}/manifest`,
             });
 
+            // Credential for the CLOUD attempt: the env→cloud service key
+            // (cloud-hosted) or the bound oscc_ bearer (self-hosted). With it
+            // the catalog also serves the caller's OWN org/private packages —
+            // anonymous fetches keep getting public/listed only. The public
+            // R2 fast-path stays anonymous (it only ever holds public).
+            const cloudCredential = (process.env.OS_CLOUD_API_KEY ?? '').trim()
+                || this.credentials.read()?.runtimeToken
+                || '';
+
             let lastErrStatus = 0;
             let lastErrText = '';
             for (const attempt of fetchAttempts) {
                 try {
-                    const resp = await fetch(attempt.url, { headers: { 'Accept': 'application/json' } });
+                    const headers: Record<string, string> = { Accept: 'application/json' };
+                    if (attempt.label === 'cloud' && cloudCredential) headers.Authorization = `Bearer ${cloudCredential}`;
+                    const resp = await fetch(attempt.url, { headers });
                     if (!resp.ok) {
                         lastErrStatus = resp.status;
                         lastErrText = (await resp.text().catch(() => '')).slice(0, 200);


### PR DESCRIPTION
## 自托管闭环 B + 绑定 UI 的 SDUI 元数据(framework 侧)

配套 cloud#253(bind mint oscc_ + 控制面受理)。

**B — 凭据通道**
- `ConnectionCredentialStore`(`.objectstack/cloud-connection.json`,0600):bind/poll 把一次性 `runtime_token` 存本地并**从浏览器响应剥离**(SPA 永不持凭据);环境 id 一并持久化(首绑后不再需要 OS_ENVIRONMENT_ID)
- 全部控制面转发按请求懒解析凭据:服务键(云托管)→ 存储 bearer(自托管)——绑定完成即生效,无需重启
- 新 `POST /cloud-connection/unbind`(控制面 revoke best-effort + 本地清除)
- install-local 取 manifest 带凭据 → 绑定运行时可解析本组织 org/private 包
- bind/start、bind/poll 支持单环境未绑时 body 传 environment_id(Setup UI 输入)

**SDUI(渐进混合方案——绑定 UI 不硬写 React)**
- 插件 `manifest.register` 自带 `cloud_connection_settings` page + Setup nav contribution(ADR-0029 K2)
- 控制台只注册一个可复用 `cloud-connection:panel` widget(objectui 另 PR)

## 验证
- 包 36/36 测试;E2E 浏览器全链路随 objectui widget 落地后统一跑

🤖 Generated with [Claude Code](https://claude.com/claude-code)