### PR TITLE
feat(approvals+automation): flow-level send-back-for-revision — revise branch + typed back-edge re-entry (ADR-0044)

### DIFF
--- a/.changeset/approvals-send-back-revision.md
+++ b/.changeset/approvals-send-back-revision.md
@@ -1,0 +1,8 @@
+---
+"@objectstack/spec": minor
+"@objectstack/service-automation": minor
+"@objectstack/plugin-approvals": minor
+"@objectstack/rest": minor
+---
+
+ADR-0044 flow-level send-back-for-revision (#1744). The approval node gains a third flow movement beyond approve/reject: `sendBack()` finalizes the pending request as `returned` (new `ApprovalStatus`), resumes the run down its `revise` edge to a wait point where the record lock releases, and the submitter's `resubmit()` re-enters the approval node over a declared back-edge, opening the next round's request (fresh approver slate, re-locked, `round` stamped via the config snapshot). Engine: `FlowEdgeSchema.type` gains `'back'` — cycle validation now requires the graph *minus* back-edges to be a DAG (unmarked cycles still rejected), node re-entry overwrites outputs/appends steps, a 100-re-entry runaway guard backstops misauthored loops, and `cancelRun(runId, reason)` lands as the first run-cancel primitive (recall crossing a revise window cancels the parked run). `maxRevisions` (default 3) on the approval node config auto-rejects send-backs past the budget. REST: `POST /approvals/requests/:id/revise` and `/resubmit`. Audit kinds `revise`/`resubmit` join `ApprovalActionKind` and the `sys_approval_action` enum.

--- a/docs/adr/0044-approval-send-back-for-revision.md
+++ b/docs/adr/0044-approval-send-back-for-revision.md
@@ -1,0 +1,214 @@
+# ADR-0044: Flow-level send-back-for-revision — `revise` branch + typed back-edge re-entry
+
+**Status**: Proposed (2026-06-12)
+**Deciders**: ObjectStack Protocol Architects
+**Builds on**: [ADR-0019](./0019-approval-as-flow-node.md) (approval as a durable-pause flow node), [ADR-0039](./0039-token-scope-tree-execution.md) (single-program-counter suspend model), thread interactions (#1740), [ADR-0042](./0042-approval-sla-escalation.md) (audit-first discipline)
+**Closes**: [#1744](https://github.com/objectstack-ai/framework/issues/1744)
+**Consumers**: `@objectstack/spec` (flow edge type, branch labels, contracts), `@objectstack/service-automation` (back-edge traversal), `@objectstack/plugin-approvals` (send-back / resubmit runtime), REST, Console approvals inbox
+
+---
+
+## TL;DR
+
+`requestInfo()` (#1740) is a conversation: the request stays pending, the
+record stays locked, the approver keeps the slot. Mainstream approval
+centers also model 退回修改 / *send back for revision* — a **flow
+movement**: the current approval request terminates, the flow walks a
+`revise` out-edge to a wait point where the record unlocks and the
+submitter edits it, and a *resubmit* walks a **back-edge** into the
+approval node, opening a fresh request (round 2) with a clean approver
+slate. A `maxRevisions` guard auto-rejects instances that would orbit
+forever.
+
+```
+approval (suspended, round N)
+  ├─ approve ──▶ …
+  ├─ reject ───▶ …
+  └─ revise ──▶ wait (suspended; record unlocked; submitter edits)
+                  └─ resubmit ──[back-edge]──▶ approval (round N+1)
+```
+
+## Decisions
+
+### D1 — the sent-back request's terminal state is a new `ApprovalStatus: 'returned'`
+
+A third terminal state alongside `approved` / `rejected` / `recalled`
+(do **not** reuse `recalled`: recall is submitter-initiated withdrawal,
+returned is approver-initiated rework — inbox filters, SLA reporting and
+the status mirror must distinguish them). Because the record lock and the
+`openNodeRequest` per-(object, record) pending-dedupe are both keyed on
+`status: 'pending'`, finalizing round N as `returned` *automatically*
+unlocks the record and clears the way for round N+1 — no lock-machinery
+change at all.
+
+Sync points (dual-source enums, all updated together):
+`ApprovalStatus` (spec contracts), `sys_approval_request.object.ts`
+status select, and the Console status filters/badges.
+
+### D2 — `revise` joins `APPROVAL_BRANCH_LABELS`; `maxRevisions` joins the node config
+
+- `APPROVAL_BRANCH_LABELS = { approve, reject, revise }`. The decision
+  surface stays `approve | reject` (`ApprovalDecision` unchanged);
+  send-back is a **separate service verb** (`sendBack`), mirroring how
+  `recall` is not a "decision".
+- `ApprovalNodeConfigSchema` gains
+  `maxRevisions: int ≥ 0, default 3` — the maximum number of send-backs
+  per (run, node). A send-back that would *exceed* the budget instead
+  **auto-rejects**: the request finalizes `rejected` (audit carries the
+  revise intent + an auto-reject marker comment), and the run resumes
+  down the `reject` edge with `output.decision = 'reject'`,
+  `output.autoRejected = true`. `maxRevisions: 0` ⇒ send-back always
+  auto-rejects (effectively disabled, loudly).
+- A flow whose approval node has **no `revise` out-edge** rejects
+  `sendBack` with `VALIDATION_FAILED` (checked against
+  `automation.getFlow()` before any mutation). This guards the engine's
+  label-fallback behavior — resuming with an unmatched `branchLabel`
+  falls back to *all* out-edges, which must never happen by a user
+  clicking a button.
+
+### D3 — wait-node + REST resubmit (not record-change triggers)
+
+The revise edge targets an ordinary **`wait` node** (signal flavor) — the
+durable pause already shipped for timers/signals. The revise window is
+therefore *visible flow state* (designer canvas, run logs, suspended-run
+stores all already understand it), not an invisible service limbo.
+
+Resubmit is an explicit REST verb by the submitter:
+
+```
+POST /api/v1/approvals/requests/:id/revise    (approver; audited 'revise')
+POST /api/v1/approvals/requests/:id/resubmit  (submitter; audited 'resubmit')
+```
+
+`resubmit` validates: actor is the submitter, the request is `returned`,
+and it is the **latest** request for its (run, node) — then resumes the
+run (branch label `resubmit`, informational). Traversal walks the
+back-edge into the approval node, whose executor re-runs `openNodeRequest`
+→ round N+1 pending request → re-lock → suspend. A record-change trigger
+was rejected: saving a draft mid-edit must not resubmit; an explicit
+"I'm done" verb matches every mainstream approval center and gives the
+UI an unambiguous button.
+
+New audit kinds `'revise'` / `'resubmit'` join `ApprovalActionKind` AND
+the `sys_approval_action` select enum (dual-source, missed sync = insert
+500). Both rows land on the *round-N* request: round N's trail ends
+`… revise → resubmit`, round N+1 opens with its own `submit`.
+
+### D4 — round numbering rides the config snapshot (`__round`), no migration
+
+`openNodeRequest` counts existing requests for (`flow_run_id`,
+`flow_node_id`) and stamps `__round: N+1` into `node_config_json`
+(precedent: `__flowLabel` / `__nodeLabel`). Surfaced as `round?: number`
+on `ApprovalRequestRow` (absent/1 ⇒ first round). `current_step_index`
+keeps its existing meaning; no schema change, old rows read as round 1.
+
+### D5 — engine: typed back-edges, re-entry semantics, runaway guard
+
+The flow spec docs already promise back-edges (*"back-to-previous
+rejection → a back-edge to an earlier node"*); the executor now honours
+them, under explicit constraints:
+
+- **Authoring**: `FlowEdgeSchema.type` gains `'back'`. A back-edge is an
+  ordinary traversal edge at run time; its *only* special property is
+  that **cycle validation ignores it**. `registerFlow` validation becomes:
+  the graph **minus `back`-typed edges must be a DAG** (the existing
+  `detectCycles` runs on the reduced graph). An unmarked cycle is still
+  rejected — authors must opt in, edge by edge.
+- **Re-entry semantics** (same node, second visit): node outputs are
+  written under `${nodeId}.${key}` — a re-entry **overwrites** (latest
+  round wins), which is exactly what `decision`-style outputs want;
+  the step log appends (every visit is a separate step entry, so run
+  observability shows round 1 and round 2); a re-suspend at the same
+  node persists a fresh continuation under the same `runId` (the resume
+  path already rebuilds `SuspendedRun` from live state — no keyed-by-node
+  assumption exists).
+- **ADR-0039 compatibility**: the single-program-counter invariant is
+  untouched — a back-edge moves the *one* position backwards; it never
+  creates a second concurrent position. Back-edges remain **banned inside
+  structured regions** (regions stay acyclic per ADR-0031 validation, and
+  durable pause inside a region is already rejected). ADR-0039's D7
+  "no back-edges" applied to *Track B's runtime tokens*; this ADR amends
+  the authoring surface deliberately and narrowly.
+- **Runaway guard**: `executeNode` counts top-level visits per node
+  (step-log entries without a `parentNodeId`, so loop-region iterations
+  don't count); exceeding `MAX_NODE_REENTRIES = 100` fails the run with
+  a loud error. This is the engine's backstop; the *product* guard is
+  `maxRevisions` (D2), which terminates well before.
+
+### D6 — lock lifecycle and the interaction matrix
+
+| moment | request status | lock |
+|---|---|---|
+| round N pending | `pending` | locked |
+| revise window (run at wait node) | `returned` | **unlocked** (hook keys on pending) |
+| after resubmit (round N+1) | new row `pending` | re-locked |
+
+- **unanimous × revise**: one approver's send-back finalizes the request
+  immediately (like reject under unanimous). Round N+1 reopens with the
+  **full approver set**; prior approvals do not carry over — the data
+  changed, so every sign-off is stale by definition.
+- **recall × revise window**: the submitter may abandon a revision —
+  `recall` on the *latest `returned`* request (the one normal recall
+  precondition `pending` doesn't cover) flips it `returned → recalled`
+  (the one sanctioned terminal→terminal transition) and audits `recall`.
+  The run is paused at the *wait node*, which has no `reject` out-edge to
+  resume down — so this lands the engine's first **run-cancel primitive**:
+  `cancelRun(runId, reason)` consumes the continuation and records a
+  terminal `cancelled` log (`ExecutionStatus` already reserves the value).
+  Recall of a *pending* request keeps its existing reject-edge resume.
+  SLA escalation, reminders and action links all key on `pending` and are
+  naturally inert during the window.
+- **escalation × revise**: `returned` requests are invisible to the
+  escalation sweep (it scans `pending`); round N+1 starts a fresh SLA
+  clock from its own `created_at`. Deliberate: the clock measures *this
+  approver's* latency, not the submitter's rework time.
+
+## Why not the alternatives
+
+- **Reuse `recalled` for sent-back** — collapses two different actors and
+  intents into one state; the inbox can no longer say "waiting on you to
+  fix and resubmit" vs "you withdrew this".
+- **Approval node re-suspends itself in a "revise mode"** (no wait node,
+  no back-edge) — hides a whole state machine inside one node, invisible
+  to the canvas/run log, and still needs re-entry semantics the moment a
+  second round opens a new request.
+- **Record-change-triggered resubmit** — every draft save becomes a
+  resubmission; no explicit user intent; collides with the lock hook's
+  system-write exemptions.
+- **Generic engine `goto`/jump API** — strictly more power than needed;
+  typed back-edges keep the authored graph the single source of truth
+  and keep validation decidable.
+
+## Consequences
+
+- **Revise window × record-change triggers**: an edit made inside the
+  window can re-fire the very record-change trigger that opened the flow
+  (the showcase budget flow gates on `budget != previous.budget`), opening
+  a *parallel* run's pending request on the same record. `resubmit`
+  refuses with `DUPLICATE_REQUEST` while any pending request collides on
+  the record — refusing *before* the suspension is consumed, so the
+  parked run stays resumable once the collision is recalled. Flow authors
+  should gate such start conditions (e.g. on the mirrored approval-status
+  field) when the trigger field is one the submitter is expected to edit
+  during revision.
+
+- The DAG invariant softens to "DAG modulo declared back-edges" — cycle
+  detection, designer validation and AI flow authoring all need the same
+  reduced-graph rule (Studio designer support for *drawing* revise edges
+  is a follow-up issue; the model/engine land first).
+- Two enum dual-sources gain values (`returned`; `revise`/`resubmit`) —
+  the known 500-on-insert trap if either side is missed.
+- `IApprovalService` grows `sendBack()` / `resubmit()`; REST grows the
+  two verbs; Console inbox grows the approver button, the submitter
+  resubmit entry, timeline rendering and ten-locale strings.
+- Round-aware inbox: `round` on the row enables "Round 2" chips with no
+  migration.
+
+## Test matrix (the real cost, ADR-0039 style)
+
+multi-round (1→2→3) × `unanimous` (send-back mid-round clears partial
+approvals) × lock states (locked → unlocked → re-locked) × recall crossing
+the revise window × `maxRevisions` overflow auto-reject × flows with no
+revise edge (sendBack rejected) × engine: back-edge registration passes /
+unmarked cycle still rejected / re-entry overwrites outputs / runaway
+guard trips.

--- a/examples/app-showcase/src/flows/index.ts
+++ b/examples/app-showcase/src/flows/index.ts
@@ -147,6 +147,13 @@ export const TaskAssignedNotifyFlow = defineFlow({
  * approval and resumes down the matching `approve` / `reject` edge. The
  * executive step only runs for budgets above $500k — that gate is a decision
  * node on the manager step's approve edge.
+ *
+ * The manager step also demos ADR-0044 **send back for revision**: its
+ * `revise` edge walks to a signal `wait` node where the record unlocks for
+ * rework, and the submitter's resubmit re-enters the approval node over the
+ * declared back-edge (round 2, fresh approver slate). `maxRevisions: 2` keeps
+ * the loop guarded — a third send-back auto-rejects. The executive step has
+ * NO revise edge on purpose: send-back there is rejected with a clear error.
  */
 export const BudgetApprovalFlow = defineFlow({
   name: 'showcase_budget_approval',
@@ -176,7 +183,17 @@ export const BudgetApprovalFlow = defineFlow({
         approvers: [{ type: 'role', value: 'manager' }],
         behavior: 'first_response',
         lockRecord: true,
+        // ADR-0044: at most two send-backs; the third auto-rejects.
+        maxRevisions: 2,
       },
+    },
+    {
+      // ADR-0044 revise window: the run parks here while the submitter reworks
+      // the (now unlocked) record; their resubmit resumes it over the back-edge.
+      id: 'wait_revision',
+      type: 'wait',
+      label: 'Awaiting Revision',
+      config: { eventType: 'signal', signalName: 'budget_revision' },
     },
     {
       id: 'needs_exec',
@@ -209,6 +226,12 @@ export const BudgetApprovalFlow = defineFlow({
     { id: 'e5', source: 'needs_exec', target: 'approved', label: 'false', condition: 'budget <= 500000' },
     { id: 'e6', source: 'exec_review', target: 'approved', label: 'approve' },
     { id: 'e7', source: 'exec_review', target: 'rejected', label: 'reject' },
+    // ADR-0044 send-back-for-revision loop on the manager step: revise walks
+    // to the wait node; the resubmit edge is the declared back-edge closing
+    // the cycle (type 'back' — excluded from DAG validation, traversed
+    // normally), re-entering the approval node as round 2.
+    { id: 'e8', source: 'manager_review', target: 'wait_revision', label: 'revise' },
+    { id: 'e9', source: 'wait_revision', target: 'manager_review', label: 'resubmit', type: 'back' },
   ],
 });
 

--- a/packages/plugins/plugin-approvals/src/approval-revise.test.ts
+++ b/packages/plugins/plugin-approvals/src/approval-revise.test.ts
@@ -1,0 +1,411 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ADR-0044 send-back-for-revision matrix:
+ *
+ *   multi-round (1→2→3) × unanimous (send-back clears partial approvals) ×
+ *   lock states (locked → unlocked → re-locked) × recall crossing the revise
+ *   window × maxRevisions overflow auto-reject × flows with no revise edge.
+ *
+ * Drives the REAL automation engine (back-edge re-entry) against the approval
+ * service with an in-memory ObjectQL stand-in — the same harness as
+ * approval-node.test.ts, extended with orderBy support (assertLatestForRun
+ * sorts by created_at) and a ticking clock (rounds must not share timestamps).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AutomationEngine } from '@objectstack/service-automation';
+import { ApprovalService } from './approval-service.js';
+import { registerApprovalNode } from './approval-node.js';
+import { bindApprovalLockHook, APPROVALS_HOOK_PACKAGE } from './lifecycle-hooks.js';
+
+const SYSTEM_CTX = { isSystem: true, roles: [], permissions: [] } as any;
+const USER_CTX = { isSystem: false, roles: [], permissions: [] } as any;
+
+const noopLogger = { info() {}, warn() {}, error() {}, debug() {} };
+
+/** In-memory ObjectQL stand-in: equality/$in where, orderBy, limit. */
+function makeFakeEngine() {
+  const tables = new Map<string, any[]>();
+  const rows = (o: string) => (tables.get(o) ?? (tables.set(o, []), tables.get(o)!));
+  const matches = (row: any, where: any) => Object.entries(where ?? {}).every(([k, v]) => {
+    if (v && typeof v === 'object' && '$in' in (v as any)) return (v as any).$in.includes(row[k]);
+    if (v && typeof v === 'object' && '$ne' in (v as any)) return row[k] !== (v as any).$ne;
+    return row[k] === v;
+  });
+  return {
+    tables,
+    async find(object: string, opts: any = {}) {
+      const where = opts.where ?? opts.filter ?? {};
+      let out = rows(object).filter(r => matches(r, where));
+      for (const ord of [...(opts.orderBy ?? [])].reverse()) {
+        // Canonical SortNode key only (spec/data/query.zod.ts): the real
+        // engine strips an unknown `direction:` key and defaults to asc, so
+        // the mock must too — honoring both keys masks wrong-key sorts.
+        const dir = ord.order === 'desc' ? -1 : 1;
+        out = [...out].sort((a, b) => (a[ord.field] < b[ord.field] ? -dir : a[ord.field] > b[ord.field] ? dir : 0));
+      }
+      if (opts.limit) out = out.slice(0, opts.limit);
+      return out.map(r => ({ ...r }));
+    },
+    async insert(object: string, data: any) {
+      rows(object).push({ ...data });
+      return { ...data };
+    },
+    async update(object: string, idOrData: any) {
+      const row = rows(object).find(r => r.id === idOrData.id);
+      if (row) Object.assign(row, idOrData);
+      return row ? { ...row } : null;
+    },
+    async delete(object: string, opts: any = {}) {
+      const where = opts.where ?? {};
+      const list = rows(object);
+      for (let i = list.length - 1; i >= 0; i--) if (matches(list[i], where)) list.splice(i, 1);
+      return { affected: 1 };
+    },
+  };
+}
+
+describe('Send back for revision (ADR-0044)', () => {
+  let automation: AutomationEngine;
+  let service: ApprovalService;
+  let fake: ReturnType<typeof makeFakeEngine>;
+  const marks: string[] = [];
+
+  beforeEach(() => {
+    marks.length = 0;
+    automation = new AutomationEngine(noopLogger as any);
+    fake = makeFakeEngine();
+    // Ticking clock: every read advances 1s, so rounds never share created_at
+    // (assertLatestForRun orders by it).
+    let t = Date.parse('2026-06-12T00:00:00Z');
+    service = new ApprovalService({
+      engine: fake as any,
+      logger: noopLogger,
+      clock: { now: () => new Date((t += 1000)) },
+    });
+    service.attachAutomation(automation);
+    registerApprovalNode(automation, service, noopLogger);
+    automation.registerNodeExecutor({
+      type: 'mark',
+      async execute(node: any) { marks.push(node.id); return { success: true }; },
+    });
+    // Signal-flavor wait stand-in: suspends until an external resume — the
+    // same contract as the built-in wait node's non-timer path.
+    automation.registerNodeExecutor({
+      type: 'wait',
+      async execute(node: any) { return { success: true, suspend: true, correlation: `wait:${node.id}` }; },
+    });
+  });
+
+  function registerReviseFlow(opts?: {
+    maxRevisions?: number;
+    behavior?: 'first_response' | 'unanimous';
+    approvers?: Array<{ type: string; value?: string }>;
+  }) {
+    automation.registerFlow('expense_approval', {
+      name: 'expense_approval',
+      label: 'Expense Approval',
+      type: 'autolaunched',
+      nodes: [
+        { id: 'start', type: 'start', label: 'Start' },
+        {
+          id: 'review', type: 'approval', label: 'Manager Review',
+          config: {
+            approvers: opts?.approvers ?? [{ type: 'user', value: 'u1' }],
+            behavior: opts?.behavior,
+            ...(opts?.maxRevisions !== undefined ? { maxRevisions: opts.maxRevisions } : {}),
+          },
+        },
+        { id: 'wait_revision', type: 'wait', label: 'Awaiting Revision' },
+        { id: 'on_approved', type: 'mark', label: 'Approved' },
+        { id: 'on_rejected', type: 'mark', label: 'Rejected' },
+        { id: 'end', type: 'end', label: 'End' },
+      ],
+      edges: [
+        { id: 'e1', source: 'start', target: 'review' },
+        { id: 'e2', source: 'review', target: 'on_approved', label: 'approve' },
+        { id: 'e3', source: 'review', target: 'on_rejected', label: 'reject' },
+        { id: 'e4', source: 'review', target: 'wait_revision', label: 'revise' },
+        // The cycle-closing back-edge (ADR-0044): resubmit re-enters the approval node.
+        { id: 'e5', source: 'wait_revision', target: 'review', label: 'resubmit', type: 'back' },
+        { id: 'e6', source: 'on_approved', target: 'end' },
+        { id: 'e7', source: 'on_rejected', target: 'end' },
+      ],
+    });
+  }
+
+  async function startFlow() {
+    const paused = await automation.execute('expense_approval', {
+      object: 'fin_expense', record: { id: 'x1', amount: 900 }, userId: 'submitter',
+    });
+    expect(paused.status).toBe('paused');
+    const [req] = await fake.find('sys_approval_request', { where: { status: 'pending' } });
+    return { runId: paused.runId!, req };
+  }
+
+  const pendingReq = async () => (await fake.find('sys_approval_request', { where: { status: 'pending' } }))[0];
+  const actionsOf = async (requestId: string) =>
+    (await fake.find('sys_approval_action', { where: { request_id: requestId } })).map((a: any) => a.action);
+
+  it('registers a revise flow with a declared back-edge (cycle allowed)', () => {
+    expect(() => registerReviseFlow()).not.toThrow();
+  });
+
+  it('full round trip: send back → returned + wait → resubmit → round 2 → approve', async () => {
+    registerReviseFlow();
+    const { runId, req } = await startFlow();
+
+    const sent = await service.sendBack(req.id, { actorId: 'u1', comment: 'fix the totals' }, USER_CTX);
+    expect(sent.resumed).toBe(true);
+    expect(sent.autoRejected).toBeUndefined();
+    expect(sent.request.status).toBe('returned');
+    expect(marks).toHaveLength(0);
+
+    // The run is paused at the wait point, not terminal.
+    expect(automation.listSuspendedRuns()).toMatchObject([{ runId, nodeId: 'wait_revision' }]);
+    expect(await actionsOf(req.id)).toEqual(['submit', 'revise']);
+
+    const re = await service.resubmit(req.id, { actorId: 'submitter', comment: 'totals fixed' }, USER_CTX);
+    expect(re.resumed).toBe(true);
+    expect(await actionsOf(req.id)).toEqual(['submit', 'revise', 'resubmit']);
+
+    // Round 2: a NEW pending request on the same (run, node), round stamped.
+    const round2 = await pendingReq();
+    expect(round2.id).not.toBe(req.id);
+    expect(round2).toMatchObject({ flow_run_id: runId, flow_node_id: 'review' });
+    expect((await service.getRequest(round2.id, SYSTEM_CTX))?.round).toBe(2);
+    expect(automation.listSuspendedRuns()).toMatchObject([{ runId, nodeId: 'review' }]);
+
+    // Round 2 approval completes the flow down the approve branch.
+    const out = await service.decide(round2.id, { decision: 'approve', actorId: 'u1' }, SYSTEM_CTX);
+    expect(out).toMatchObject({ finalized: true, resumed: true });
+    expect(marks).toEqual(['on_approved']);
+    expect(automation.listSuspendedRuns()).toHaveLength(0);
+  });
+
+  it('multi-round: two send-backs stamp rounds 2 and 3', async () => {
+    registerReviseFlow();
+    const { req } = await startFlow();
+    expect((await service.getRequest(req.id, SYSTEM_CTX))?.round).toBeUndefined(); // round 1
+
+    await service.sendBack(req.id, { actorId: 'u1' }, USER_CTX);
+    await service.resubmit(req.id, { actorId: 'submitter' }, USER_CTX);
+    const round2 = await pendingReq();
+    expect((await service.getRequest(round2.id, SYSTEM_CTX))?.round).toBe(2);
+
+    await service.sendBack(round2.id, { actorId: 'u1' }, USER_CTX);
+    await service.resubmit(round2.id, { actorId: 'submitter' }, USER_CTX);
+    const round3 = await pendingReq();
+    expect((await service.getRequest(round3.id, SYSTEM_CTX))?.round).toBe(3);
+  });
+
+  it('maxRevisions overflow auto-rejects instead of returning', async () => {
+    registerReviseFlow({ maxRevisions: 1 });
+    const { req } = await startFlow();
+
+    // Send-back #1 fits the budget.
+    await service.sendBack(req.id, { actorId: 'u1' }, USER_CTX);
+    await service.resubmit(req.id, { actorId: 'submitter' }, USER_CTX);
+    const round2 = await pendingReq();
+
+    // Send-back #2 exceeds it → auto-reject, flow takes the reject branch.
+    const out = await service.sendBack(round2.id, { actorId: 'u1', comment: 'still wrong' }, USER_CTX);
+    expect(out.autoRejected).toBe(true);
+    expect(out.resumed).toBe(true);
+    expect(out.request.status).toBe('rejected');
+    expect(marks).toEqual(['on_rejected']);
+    // The trail preserves the approver's actual intent before the auto-reject.
+    expect(await actionsOf(round2.id)).toEqual(['submit', 'revise', 'reject']);
+    const acts = await fake.find('sys_approval_action', { where: { request_id: round2.id, action: 'reject' } });
+    expect(acts[0].comment).toMatch(/revision limit \(1\) exceeded/i);
+  });
+
+  it('maxRevisions 0 disables send-back (immediate auto-reject)', async () => {
+    registerReviseFlow({ maxRevisions: 0 });
+    const { req } = await startFlow();
+    const out = await service.sendBack(req.id, { actorId: 'u1' }, USER_CTX);
+    expect(out.autoRejected).toBe(true);
+    expect(marks).toEqual(['on_rejected']);
+  });
+
+  it('rejects send-back when the flow has no revise out-edge', async () => {
+    automation.registerFlow('no_revise', {
+      name: 'no_revise', label: 'No Revise', type: 'autolaunched',
+      nodes: [
+        { id: 'start', type: 'start', label: 'Start' },
+        { id: 'review', type: 'approval', label: 'Review', config: { approvers: [{ type: 'user', value: 'u1' }] } },
+        { id: 'end', type: 'end', label: 'End' },
+      ],
+      edges: [
+        { id: 'e1', source: 'start', target: 'review' },
+        { id: 'e2', source: 'review', target: 'end', label: 'approve' },
+        { id: 'e3', source: 'review', target: 'end', label: 'reject' },
+      ],
+    });
+    await automation.execute('no_revise', { object: 'fin_expense', record: { id: 'x2' }, userId: 'submitter' });
+    const req = await pendingReq();
+
+    await expect(service.sendBack(req.id, { actorId: 'u1' }, USER_CTX)).rejects.toThrow(/no 'revise' out-edge/);
+    // Nothing moved: still pending, no revise audit row.
+    expect((await fake.find('sys_approval_request', { where: { id: req.id } }))[0].status).toBe('pending');
+    expect(await actionsOf(req.id)).toEqual(['submit']);
+  });
+
+  it('unanimous: one send-back finalizes immediately and round 2 reopens the full slate', async () => {
+    registerReviseFlow({
+      behavior: 'unanimous',
+      approvers: [{ type: 'user', value: 'u1' }, { type: 'user', value: 'u2' }],
+    });
+    const { req } = await startFlow();
+
+    // u1 approves — request holds for u2.
+    const first = await service.decide(req.id, { decision: 'approve', actorId: 'u1' }, SYSTEM_CTX);
+    expect(first.finalized).toBe(false);
+
+    // u2 sends back instead: finalizes despite u1's earlier approval.
+    const sent = await service.sendBack(req.id, { actorId: 'u2', comment: 'rework' }, USER_CTX);
+    expect(sent.request.status).toBe('returned');
+
+    await service.resubmit(req.id, { actorId: 'submitter' }, USER_CTX);
+    const round2 = await pendingReq();
+    // Fresh slate: BOTH approvers pending again — prior approvals are stale.
+    expect((round2.pending_approvers as string).split(',').sort()).toEqual(['u1', 'u2']);
+  });
+
+  it('lock lifecycle: locked while pending, unlocked in the revise window, re-locked on resubmit', async () => {
+    registerReviseFlow();
+    const { req } = await startFlow();
+
+    // Bind the real lock hook against a hook-capturing engine facade.
+    let hook: ((ctx: any) => Promise<void>) | undefined;
+    bindApprovalLockHook({
+      registerHook: (_e: string, h: any) => { hook = h; },
+      unregisterHooksByPackage: () => 0,
+      find: fake.find.bind(fake),
+    } as any, noopLogger);
+    expect(hook).toBeDefined();
+    const editAttempt = () => hook!({
+      object: 'fin_expense',
+      input: { id: 'x1', data: { amount: 1200 } },
+      session: { isSystem: false, roles: [] },
+    });
+
+    await expect(editAttempt()).rejects.toThrow(/RECORD_LOCKED/);          // pending → locked
+    await service.sendBack(req.id, { actorId: 'u1' }, USER_CTX);
+    await expect(editAttempt()).resolves.toBeUndefined();                  // returned → unlocked
+    await service.resubmit(req.id, { actorId: 'submitter' }, USER_CTX);
+    await expect(editAttempt()).rejects.toThrow(/RECORD_LOCKED/);          // round 2 pending → re-locked
+  });
+
+  it('recall crossing the revise window cancels the run (returned → recalled)', async () => {
+    registerReviseFlow();
+    const { runId, req } = await startFlow();
+    await service.sendBack(req.id, { actorId: 'u1' }, USER_CTX);
+
+    // Only the submitter may abandon the revision.
+    await expect(service.recall(req.id, { actorId: 'u1' }, USER_CTX)).rejects.toThrow(/FORBIDDEN/);
+
+    const out = await service.recall(req.id, { actorId: 'submitter' }, USER_CTX);
+    expect(out.request.status).toBe('recalled');
+    expect(out.resumed).toBe(false);
+    // The run was terminally cancelled, not resumed down any branch.
+    expect(automation.listSuspendedRuns()).toHaveLength(0);
+    expect(marks).toHaveLength(0);
+    const log = (await automation.listRuns('expense_approval'))[0];
+    expect(log.status).toBe('cancelled');
+    expect(log.id).toBe(runId);
+
+    // The window is closed: resubmit is no longer possible.
+    await expect(service.resubmit(req.id, { actorId: 'submitter' }, USER_CTX)).rejects.toThrow(/INVALID_STATE/);
+  });
+
+  it('refuses resubmit while another pending request collides on the record (run stays resumable)', async () => {
+    registerReviseFlow();
+    const { runId, req } = await startFlow();
+    await service.sendBack(req.id, { actorId: 'u1' }, USER_CTX);
+
+    // Simulate a record-change trigger re-firing off an edit made inside the
+    // revise window: a second, unrelated run opened its own pending request.
+    await fake.insert('sys_approval_request', {
+      id: 'areq_collider', object_name: 'fin_expense', record_id: 'x1',
+      status: 'pending', flow_run_id: 'run_other', flow_node_id: 'review',
+      submitter_id: 'submitter', process_name: 'flow:expense_approval',
+      created_at: new Date().toISOString(),
+    });
+
+    await expect(service.resubmit(req.id, { actorId: 'submitter' }, USER_CTX)).rejects.toThrow(/DUPLICATE_REQUEST/);
+    // The refusal happened BEFORE the suspension was consumed — clearing the
+    // collision makes the same resubmit succeed.
+    expect(automation.listSuspendedRuns().some(r => r.runId === runId)).toBe(true);
+    await fake.delete('sys_approval_request', { where: { id: 'areq_collider' } });
+    const re = await service.resubmit(req.id, { actorId: 'submitter' }, USER_CTX);
+    expect(re.resumed).toBe(true);
+  });
+
+  it('a superseded returned request can neither resubmit again nor be recalled', async () => {
+    registerReviseFlow();
+    const { req } = await startFlow();
+    await service.sendBack(req.id, { actorId: 'u1' }, USER_CTX);
+    await service.resubmit(req.id, { actorId: 'submitter' }, USER_CTX);
+
+    // Round 2 is the live frontier; the round-1 row is history.
+    await expect(service.resubmit(req.id, { actorId: 'submitter' }, USER_CTX)).rejects.toThrow(/supersedes/);
+    await expect(service.recall(req.id, { actorId: 'submitter' }, USER_CTX)).rejects.toThrow(/supersedes/);
+  });
+
+  it('enforces the actor matrix: only pending approvers send back, only the submitter resubmits', async () => {
+    registerReviseFlow();
+    const { req } = await startFlow();
+
+    await expect(service.sendBack(req.id, { actorId: 'intruder' }, USER_CTX)).rejects.toThrow(/FORBIDDEN/);
+    await expect(service.sendBack(req.id, { actorId: 'submitter' }, USER_CTX)).rejects.toThrow(/FORBIDDEN/);
+
+    await service.sendBack(req.id, { actorId: 'u1' }, USER_CTX);
+    await expect(service.resubmit(req.id, { actorId: 'u1' }, USER_CTX)).rejects.toThrow(/FORBIDDEN/);
+    // Resubmit only applies to returned requests — a pending one rejects.
+    const fresh = await startFlowSecondRecord();
+    await expect(service.resubmit(fresh.id, { actorId: 'submitter' }, USER_CTX)).rejects.toThrow(/INVALID_STATE/);
+  });
+
+  /** A second record's pending request, to probe resubmit-on-pending. */
+  async function startFlowSecondRecord() {
+    await automation.execute('expense_approval', {
+      object: 'fin_expense', record: { id: 'x9', amount: 50 }, userId: 'submitter',
+    });
+    const rows = await fake.find('sys_approval_request', { where: { status: 'pending', record_id: 'x9' } });
+    return rows[0];
+  }
+
+  it('status mirror follows the rounds when approvalStatusField is configured', async () => {
+    automation.registerFlow('mirrored_flow', {
+      name: 'mirrored_flow', label: 'Mirrored Flow', type: 'autolaunched',
+      nodes: [
+        { id: 'start', type: 'start', label: 'Start' },
+        {
+          id: 'review', type: 'approval', label: 'Review',
+          config: { approvers: [{ type: 'user', value: 'u1' }], approvalStatusField: 'approval_status' },
+        },
+        { id: 'wait_revision', type: 'wait', label: 'Awaiting Revision' },
+        { id: 'end', type: 'end', label: 'End' },
+      ],
+      edges: [
+        { id: 'e1', source: 'start', target: 'review' },
+        { id: 'e2', source: 'review', target: 'end', label: 'approve' },
+        { id: 'e3', source: 'review', target: 'end', label: 'reject' },
+        { id: 'e4', source: 'review', target: 'wait_revision', label: 'revise' },
+        { id: 'e5', source: 'wait_revision', target: 'review', label: 'resubmit', type: 'back' },
+      ],
+    });
+    await fake.insert('fin_expense', { id: 'm1', approval_status: null });
+    await automation.execute('mirrored_flow', { object: 'fin_expense', record: { id: 'm1' }, userId: 'submitter' });
+    const req = await pendingReq();
+    const mirror = async () => (await fake.find('fin_expense', { where: { id: 'm1' } }))[0].approval_status;
+
+    expect(await mirror()).toBe('pending');
+    await service.sendBack(req.id, { actorId: 'u1' }, USER_CTX);
+    expect(await mirror()).toBe('returned');
+    await service.resubmit(req.id, { actorId: 'submitter' }, USER_CTX);
+    expect(await mirror()).toBe('pending'); // round 2 re-mirrors
+  });
+});

--- a/packages/plugins/plugin-approvals/src/approval-service.test.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { ApprovalService } from './approval-service.js';
+import { ApprovalService, REMIND_COOLDOWN_MS } from './approval-service.js';
 import { bindApprovalLockHook, unbindAllHooks } from './lifecycle-hooks.js';
 
 interface FakeRow { [k: string]: any }
@@ -51,12 +51,16 @@ function makeFakeEngine() {
     async find(object: string, options?: any) {
       const rows = ensure(object).filter(r => matches(r, options?.filter ?? options?.where));
       if (options?.orderBy?.[0]) {
-        const { field, direction } = options.orderBy[0];
+        // Canonical SortNode key only (spec/data/query.zod.ts): a sloppy
+        // `direction:` key must fall through to the schema default (asc),
+        // exactly like the real engine — that's how the remind() cool-down
+        // regression stayed invisible when this mock honored both keys.
+        const { field, order } = options.orderBy[0];
         rows.sort((a, b) => {
           const av = a[field]; const bv = b[field];
           if (av === bv) return 0;
           const cmp = av > bv ? 1 : -1;
-          return direction === 'desc' ? -cmp : cmp;
+          return order === 'desc' ? -cmp : cmp;
         });
       }
       const start = options?.offset ?? 0;
@@ -454,6 +458,27 @@ describe('ApprovalService (node era)', () => {
     expect(actions.at(-1)?.action).toBe('remind');
     // The fake clock steps 1s per call — well inside the 4h cool-down.
     await expect(svc.remind(req.id, { actorId: 'u1' }, CTX)).rejects.toThrow(/THROTTLED/);
+  });
+
+  it('remind: cool-down measures from the NEWEST reminder, not the first', async () => {
+    // Regression: the throttle query sorted with the non-canonical
+    // `direction: 'desc'` key, which SortNode strips — so it sorted asc and
+    // compared against the FIRST reminder ever sent. Once 4h passed after
+    // reminder #1, every later remind() sailed through unthrottled.
+    let nowMs = baseTime;
+    const localSvc = new ApprovalService({
+      engine: engine as any,
+      clock: { now: () => new Date(nowMs += 1000) },
+    });
+    const req = await localSvc.openNodeRequest(openInput(['u9']), CTX);
+    await localSvc.remind(req.id, { actorId: 'u1' }, CTX);
+    // Jump past the cool-down: a second reminder is legitimately allowed.
+    nowMs += REMIND_COOLDOWN_MS;
+    await localSvc.remind(req.id, { actorId: 'u1' }, CTX);
+    // Immediately after reminder #2 the throttle must bite again — with the
+    // wrong sort key it compared against reminder #1 (now >4h old) and let
+    // unlimited reminders through.
+    await expect(localSvc.remind(req.id, { actorId: 'u1' }, CTX)).rejects.toThrow(/THROTTLED/);
   });
 
   it('remind: only the submitter may nudge', async () => {

--- a/packages/plugins/plugin-approvals/src/approval-service.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.ts
@@ -13,6 +13,10 @@ import type {
   ApprovalDecisionResult,
   ApprovalRecallInput,
   ApprovalRecallResult,
+  ApprovalSendBackInput,
+  ApprovalSendBackResult,
+  ApprovalResubmitInput,
+  ApprovalResubmitResult,
   ApprovalStatus,
   SharingExecutionContext,
 } from '@objectstack/spec/contracts';
@@ -50,6 +54,12 @@ export interface ApprovalResumeSurface {
   resume?(runId: string, signal?: { output?: Record<string, unknown>; branchLabel?: string }): Promise<unknown>;
   /** Flow definition lookup, used to derive step-progress display data. */
   getFlow?(name: string): Promise<any | null>;
+  /**
+   * Terminally cancel a suspended run (ADR-0044). Used when a recall lands
+   * during a revision window — the run is paused at the revise wait node,
+   * which has no reject edge to resume down.
+   */
+  cancelRun?(runId: string, reason?: string): Promise<unknown>;
 }
 
 /**
@@ -153,6 +163,8 @@ function rowFromRequest(row: any): ApprovalRequestRow {
     process_label: cfg?.__flowLabel ?? prettifyMachineName(row.process_name),
     step_label: cfg?.__nodeLabel ?? prettifyMachineName(row.current_step),
     sla_due_at: slaDueAt(row.created_at, cfg),
+    // ADR-0044 revision round (rides the config snapshot; absent ⇒ round 1).
+    round: typeof cfg?.__round === 'number' ? cfg.__round : undefined,
   } as any;
 }
 
@@ -450,6 +462,16 @@ export class ApprovalService implements IApprovalService {
     const configSnapshot: any = { ...input.config };
     if (input.flowLabel) configSnapshot.__flowLabel = input.flowLabel;
     if (input.nodeLabel) configSnapshot.__nodeLabel = input.nodeLabel;
+    // ADR-0044 round numbering: rounds of a revise loop share the run — count
+    // this (run, node)'s prior requests; the new one is round N+1. Stamped on
+    // the snapshot (precedent: __flowLabel), so no schema migration.
+    try {
+      const prior = await this.engine.find('sys_approval_request', {
+        where: { flow_run_id: input.runId, flow_node_id: input.nodeId }, limit: 500, context: SYSTEM_CTX,
+      });
+      const n = Array.isArray(prior) ? prior.length : 0;
+      if (n > 0) configSnapshot.__round = n + 1;
+    } catch { /* round display is best-effort */ }
     const row: any = {
       id,
       process_name: processName,
@@ -601,8 +623,14 @@ export class ApprovalService implements IApprovalService {
    * Withdraw a pending request (submitter only). Finalises the row as
    * `recalled`, releases the record lock (keyed on pending status), mirrors
    * the status field when configured, and resumes the owning flow run down
-   * the `reject` branch with `output.decision = 'recall'` — the engine has no
-   * run-cancel primitive, and leaving the run suspended forever would leak it.
+   * the `reject` branch with `output.decision = 'recall'` — leaving the run
+   * suspended forever would leak it.
+   *
+   * ADR-0044: also valid on the LATEST `returned` request of its run — the
+   * submitter abandons the revision window instead of resubmitting. The run
+   * is then paused at the revise wait node (no reject edge), so it is
+   * terminally cancelled via {@link ApprovalResumeSurface.cancelRun} rather
+   * than resumed.
    */
   async recall(
     requestId: string,
@@ -617,10 +645,16 @@ export class ApprovalService implements IApprovalService {
     });
     const raw: any = Array.isArray(rawRows) ? rawRows[0] : null;
     if (!raw) throw new Error(`REQUEST_NOT_FOUND: ${requestId}`);
-    if (raw.status !== 'pending') throw new Error(`INVALID_STATE: request is ${raw.status}`);
+    const inReviseWindow = raw.status === 'returned';
+    if (raw.status !== 'pending' && !inReviseWindow) {
+      throw new Error(`INVALID_STATE: request is ${raw.status}`);
+    }
     if (!context.isSystem && raw.submitter_id && String(raw.submitter_id) !== String(input.actorId)) {
       throw new Error(`FORBIDDEN: only the submitter may recall this request`);
     }
+    // A returned request is only recallable while it is still the run's live
+    // frontier — a resubmitted (or later-node) request supersedes it.
+    if (inReviseWindow) await this.assertLatestForRun(raw);
 
     const config = parseJson<ApprovalNodeConfig>(raw.node_config_json, { approvers: [], behavior: 'first_response' } as any);
     const org = raw.organization_id ?? null;
@@ -642,7 +676,19 @@ export class ApprovalService implements IApprovalService {
     }
 
     let resumed = false;
-    if (runId && typeof this.automation?.resume === 'function') {
+    if (inReviseWindow) {
+      // ADR-0044: the run is paused at the revise wait node, which has no
+      // reject out-edge to resume down — terminally cancel it instead.
+      if (runId && typeof this.automation?.cancelRun === 'function') {
+        try {
+          await this.automation.cancelRun(runId, `approval request ${requestId} recalled during revision`);
+        } catch (err: any) {
+          this.logger?.warn?.('[approvals] cancelRun after revise-window recall failed', {
+            request: requestId, run: runId, error: err?.message ?? String(err),
+          });
+        }
+      }
+    } else if (runId && typeof this.automation?.resume === 'function') {
       try {
         await this.automation.resume(runId, {
           branchLabel: APPROVAL_BRANCH_LABELS.reject,
@@ -658,6 +704,260 @@ export class ApprovalService implements IApprovalService {
 
     const fresh = await this.getRequest(requestId, context);
     return { request: fresh!, runId, resumed };
+  }
+
+  // ── Send back for revision / resubmit (ADR-0044) ─────────────
+
+  /**
+   * ADR-0044 send back for revision. Finalises the pending request as
+   * `returned` (a third terminal state — approver-initiated rework, distinct
+   * from submitter-initiated `recalled`) and resumes the owning flow run down
+   * its `revise` edge to a wait point: the record lock (keyed on `pending`)
+   * releases, the submitter reworks the data, then {@link resubmit}s.
+   *
+   * Requires the approval node to declare a `revise` out-edge — validated
+   * BEFORE any mutation, because resuming with an unmatched `branchLabel`
+   * falls back to *all* out-edges. Past the node's `maxRevisions` budget the
+   * request auto-rejects instead (resumes down `reject` with
+   * `output.autoRejected = true`) so instances cannot orbit forever.
+   */
+  async sendBack(
+    requestId: string,
+    input: ApprovalSendBackInput,
+    context: SharingExecutionContext,
+  ): Promise<ApprovalSendBackResult> {
+    if (!input?.actorId) throw new Error('VALIDATION_FAILED: actorId is required');
+    const raw = await this.loadPendingRow(requestId);
+    const pending = csvSplit(raw.pending_approvers);
+    if (!context.isSystem && !pending.includes(input.actorId)) {
+      throw new Error(`FORBIDDEN: actor '${input.actorId}' is not a pending approver`);
+    }
+
+    const config = parseJson<ApprovalNodeConfig>(raw.node_config_json, { approvers: [], behavior: 'first_response' } as any);
+    const org = raw.organization_id ?? null;
+    const nodeId: string | null = raw.flow_node_id ?? raw.current_step ?? null;
+    const runId: string | null = raw.flow_run_id ?? null;
+
+    await this.assertReviseEdge(raw, nodeId);
+
+    const now = this.clock.now().toISOString();
+    const maxRevisions = typeof (config as any).maxRevisions === 'number' ? (config as any).maxRevisions : 3;
+    let priorSendBacks = 0;
+    if (runId && nodeId) {
+      const siblings = await this.engine.find('sys_approval_request', {
+        where: { flow_run_id: runId, flow_node_id: nodeId, status: 'returned' }, limit: 500, context: SYSTEM_CTX,
+      });
+      priorSendBacks = Array.isArray(siblings) ? siblings.length : 0;
+    }
+
+    // Audit the revise intent first (audit-first, like decideNode) — on the
+    // auto-reject path the trail then reads `revise → reject`, preserving
+    // what the approver actually asked for.
+    await this.engine.insert('sys_approval_action', {
+      id: uid('aact'), request_id: requestId, organization_id: org,
+      step_name: nodeId, step_index: 0, action: 'revise',
+      actor_id: input.actorId, comment: input.comment ?? null, created_at: now,
+    }, { context: SYSTEM_CTX });
+
+    if (priorSendBacks >= maxRevisions) {
+      // Revision budget exhausted — auto-reject (ADR-0044 loop guard).
+      await this.engine.insert('sys_approval_action', {
+        id: uid('aact'), request_id: requestId, organization_id: org,
+        step_name: nodeId, step_index: 0, action: 'reject',
+        actor_id: input.actorId,
+        comment: `Auto-rejected: revision limit (${maxRevisions}) exceeded`, created_at: now,
+      }, { context: SYSTEM_CTX });
+      await this.engine.update('sys_approval_request', {
+        id: requestId, status: 'rejected', pending_approvers: null, completed_at: now, updated_at: now,
+      }, { context: SYSTEM_CTX });
+      if (config.approvalStatusField) {
+        await this.mirrorStatusField(raw.object_name, raw.record_id, config.approvalStatusField, 'rejected');
+      }
+      let resumed = false;
+      if (runId && typeof this.automation?.resume === 'function') {
+        try {
+          await this.automation.resume(runId, {
+            branchLabel: APPROVAL_BRANCH_LABELS.reject,
+            output: { decision: 'reject', autoRejected: true, requestId },
+          });
+          resumed = true;
+        } catch (err: any) {
+          this.logger?.warn?.('[approvals] resume after auto-reject failed', {
+            request: requestId, run: runId, error: err?.message ?? String(err),
+          });
+        }
+      }
+      if (raw.submitter_id) {
+        await this.notify({
+          topic: 'approval.returned',
+          audience: [String(raw.submitter_id)],
+          actorId: input.actorId,
+          source: { object: 'sys_approval_request', id: requestId },
+          payload: {
+            title: 'Approval auto-rejected',
+            message: `Your ${raw.object_name}/${raw.record_id} exceeded the revision limit (${maxRevisions}) and was rejected.`,
+            actionUrl: '/system/approvals',
+          },
+        });
+      }
+      const fresh = await this.getRequest(requestId, context);
+      return { request: fresh!, runId, resumed, autoRejected: true };
+    }
+
+    await this.engine.update('sys_approval_request', {
+      id: requestId, status: 'returned', pending_approvers: null, completed_at: now, updated_at: now,
+    }, { context: SYSTEM_CTX });
+    if (config.approvalStatusField) {
+      await this.mirrorStatusField(raw.object_name, raw.record_id, config.approvalStatusField, 'returned');
+    }
+
+    let resumed = false;
+    if (runId && typeof this.automation?.resume === 'function') {
+      try {
+        await this.automation.resume(runId, {
+          branchLabel: APPROVAL_BRANCH_LABELS.revise,
+          output: { decision: 'revise', requestId },
+        });
+        resumed = true;
+      } catch (err: any) {
+        this.logger?.warn?.('[approvals] resume after send-back failed', {
+          request: requestId, run: runId, error: err?.message ?? String(err),
+        });
+      }
+    }
+
+    if (raw.submitter_id) {
+      await this.notify({
+        topic: 'approval.returned',
+        audience: [String(raw.submitter_id)],
+        actorId: input.actorId,
+        source: { object: 'sys_approval_request', id: requestId },
+        payload: {
+          title: 'Sent back for revision',
+          message: input.comment?.trim() || `Your ${raw.object_name}/${raw.record_id} needs rework before it can be approved.`,
+          actionUrl: '/system/approvals',
+        },
+      });
+    }
+
+    const fresh = await this.getRequest(requestId, context);
+    return { request: fresh!, runId, resumed };
+  }
+
+  /**
+   * ADR-0044 resubmit after rework. Valid on the LATEST `returned` request of
+   * its run, submitter-only. Audits `resubmit` on the returned (round-N)
+   * request and resumes the run from the revise wait node; traversal walks
+   * the declared back-edge into the approval node, whose executor opens the
+   * round-N+1 request — fresh approver slate, record re-locks.
+   */
+  async resubmit(
+    requestId: string,
+    input: ApprovalResubmitInput,
+    context: SharingExecutionContext,
+  ): Promise<ApprovalResubmitResult> {
+    if (!input?.actorId) throw new Error('VALIDATION_FAILED: actorId is required');
+    const rawRows = await this.engine.find('sys_approval_request', {
+      where: { id: requestId }, limit: 1, context: SYSTEM_CTX,
+    });
+    const raw: any = Array.isArray(rawRows) ? rawRows[0] : null;
+    if (!raw) throw new Error(`REQUEST_NOT_FOUND: ${requestId}`);
+    if (raw.status !== 'returned') {
+      throw new Error(`INVALID_STATE: request is ${raw.status} (resubmit applies to returned requests)`);
+    }
+    if (!context.isSystem && raw.submitter_id && String(raw.submitter_id) !== String(input.actorId)) {
+      throw new Error('FORBIDDEN: only the submitter may resubmit');
+    }
+    await this.assertLatestForRun(raw);
+
+    // A colliding pending request on the same record (e.g. a record-change
+    // trigger re-fired off an edit made inside the revise window) would make
+    // the approval node's re-entry fail AFTER the engine consumed the
+    // suspension — permanently killing the run. Refuse up front instead; the
+    // submitter resolves the collision (recall the other request) first.
+    const colliding = await this.engine.find('sys_approval_request', {
+      where: { object_name: raw.object_name, record_id: raw.record_id, status: 'pending' },
+      limit: 1, context: SYSTEM_CTX,
+    });
+    if (Array.isArray(colliding) && colliding[0]) {
+      throw new Error(
+        `DUPLICATE_REQUEST: another approval request is already pending on ${raw.object_name}/${raw.record_id} — resolve it before resubmitting`,
+      );
+    }
+
+    const org = raw.organization_id ?? null;
+    const nodeId: string | null = raw.flow_node_id ?? raw.current_step ?? null;
+    const runId: string | null = raw.flow_run_id ?? null;
+    const now = this.clock.now().toISOString();
+
+    await this.engine.insert('sys_approval_action', {
+      id: uid('aact'), request_id: requestId, organization_id: org,
+      step_name: nodeId, step_index: 0, action: 'resubmit',
+      actor_id: input.actorId, comment: input.comment ?? null, created_at: now,
+    }, { context: SYSTEM_CTX });
+
+    // The next round only exists if this resume lands — surface `resumed`
+    // honestly so a stuck run is visible instead of silently swallowed.
+    let resumed = false;
+    if (runId && typeof this.automation?.resume === 'function') {
+      try {
+        await this.automation.resume(runId, {
+          branchLabel: APPROVAL_BRANCH_LABELS.resubmit,
+          output: { resubmitted: true, requestId },
+        });
+        resumed = true;
+      } catch (err: any) {
+        this.logger?.warn?.('[approvals] resume after resubmit failed', {
+          request: requestId, run: runId, error: err?.message ?? String(err),
+        });
+      }
+    }
+
+    const fresh = await this.getRequest(requestId, context);
+    return { request: fresh!, runId, resumed };
+  }
+
+  /**
+   * ADR-0044 guard: the flow's approval node must declare a `revise`
+   * out-edge before send-back is allowed — the engine's branch-label fallback
+   * (no matching label ⇒ ALL out-edges) must never be reachable from a user
+   * action.
+   */
+  private async assertReviseEdge(raw: any, nodeId: string | null): Promise<void> {
+    const processName = String(raw.process_name ?? '');
+    const flowName = processName.startsWith('flow:') ? processName.slice('flow:'.length) : undefined;
+    if (!flowName || !nodeId || typeof this.automation?.getFlow !== 'function') {
+      throw new Error('VALIDATION_FAILED: send-back requires the owning flow definition (automation engine unavailable)');
+    }
+    const flow: any = await this.automation.getFlow(flowName);
+    const hasRevise = Array.isArray(flow?.edges)
+      && flow.edges.some((e: any) => e?.source === nodeId && e?.label === APPROVAL_BRANCH_LABELS.revise);
+    if (!hasRevise) {
+      throw new Error(
+        `VALIDATION_FAILED: approval node '${nodeId}' has no '${APPROVAL_BRANCH_LABELS.revise}' out-edge — ` +
+        'the flow does not support send-back for revision',
+      );
+    }
+  }
+
+  /**
+   * ADR-0044 guard: a `returned` request is only actionable (resubmit /
+   * recall) while it is still the newest request on its run — a later round
+   * or a later node's request supersedes it.
+   */
+  private async assertLatestForRun(raw: any): Promise<void> {
+    const runId = raw.flow_run_id;
+    if (!runId) return;
+    // SortNode's key is `order` (spec/data/query.zod.ts) — `direction` would
+    // silently default to ascending and return the OLDEST row.
+    const rows = await this.engine.find('sys_approval_request', {
+      where: { flow_run_id: runId },
+      orderBy: [{ field: 'created_at', order: 'desc' }], limit: 1, context: SYSTEM_CTX,
+    });
+    const latest: any = Array.isArray(rows) ? rows[0] : null;
+    if (latest && String(latest.id) !== String(raw.id)) {
+      throw new Error('INVALID_STATE: a newer approval request supersedes this one');
+    }
   }
 
   // ── Thread interactions (no flow movement) ───────────────────
@@ -736,7 +1036,7 @@ export class ApprovalService implements IApprovalService {
 
     const acts = await this.engine.find('sys_approval_action', {
       where: { request_id: requestId, action: 'remind' },
-      orderBy: [{ field: 'created_at', direction: 'desc' }], limit: 1, context: SYSTEM_CTX,
+      orderBy: [{ field: 'created_at', order: 'desc' }], limit: 1, context: SYSTEM_CTX,
     });
     const last: any = Array.isArray(acts) ? acts[0] : null;
     const now = this.clock.now();
@@ -1366,7 +1666,7 @@ export class ApprovalService implements IApprovalService {
       && (filter?.limit != null || filter?.offset != null);
     const findOpts: any = {
       where,
-      orderBy: [{ field: 'created_at', direction: 'desc' }],
+      orderBy: [{ field: 'created_at', order: 'desc' }],
       context: SYSTEM_CTX,
     };
     if (pushWindow) {
@@ -1493,7 +1793,7 @@ export class ApprovalService implements IApprovalService {
     const rows = await this.engine.find('sys_approval_action', {
       where: { request_id: requestId },
       limit: 500,
-      orderBy: [{ field: 'created_at', direction: 'asc' }],
+      orderBy: [{ field: 'created_at', order: 'asc' }],
       context: SYSTEM_CTX,
     });
     const actions = Array.isArray(rows) ? rows.map(rowFromAction) : [];

--- a/packages/plugins/plugin-approvals/src/sys-approval-action.object.ts
+++ b/packages/plugins/plugin-approvals/src/sys-approval-action.object.ts
@@ -88,9 +88,11 @@ export const SysApprovalAction = ObjectSchema.create({
     }),
 
     action: Field.select(
-      // Keep in sync with `ApprovalActionKind` (spec/contracts). The last four
-      // are thread interactions — they never move the flow.
-      ['submit', 'approve', 'reject', 'recall', 'escalate', 'reassign', 'remind', 'request_info', 'comment'],
+      // Keep in sync with `ApprovalActionKind` (spec/contracts). reassign /
+      // remind / request_info / comment are thread interactions — they never
+      // move the flow. revise / resubmit (ADR-0044) DO move it: send back for
+      // revision and the later resubmission.
+      ['submit', 'approve', 'reject', 'recall', 'escalate', 'reassign', 'remind', 'request_info', 'comment', 'revise', 'resubmit'],
       {
         label: 'Action',
         required: true,

--- a/packages/plugins/plugin-approvals/src/sys-approval-request.object.ts
+++ b/packages/plugins/plugin-approvals/src/sys-approval-request.object.ts
@@ -127,7 +127,9 @@ export const SysApprovalRequest = ObjectSchema.create({
     }),
 
     status: Field.select(
-      ['pending', 'approved', 'rejected', 'recalled'],
+      // Keep in sync with `ApprovalStatus` (spec/contracts). `returned` =
+      // sent back for revision (ADR-0044) — terminal for this round.
+      ['pending', 'approved', 'rejected', 'recalled', 'returned'],
       {
         label: 'Status',
         required: true,

--- a/packages/services/service-automation/src/engine.test.ts
+++ b/packages/services/service-automation/src/engine.test.ts
@@ -1518,6 +1518,132 @@ describe('AutomationEngine - DAG Cycle Detection', () => {
     });
 });
 
+// ─── Back-edge Re-entry Tests (ADR-0044) ─────────────────────────────
+
+describe('AutomationEngine - Back-edge re-entry (ADR-0044)', () => {
+    let engine: AutomationEngine;
+
+    beforeEach(() => {
+        engine = new AutomationEngine(createTestLogger());
+    });
+
+    /** A self-looping counter flow: `inc` re-enters itself over a declared back-edge until the cap. */
+    const counterFlow = (cap: number) => ({
+        name: 'counter_flow',
+        label: 'Counter Flow',
+        type: 'autolaunched',
+        nodes: [
+            { id: 'start', type: 'start', label: 'Start' },
+            { id: 'inc', type: 'inc', label: 'Increment' },
+            { id: 'end', type: 'end', label: 'End' },
+        ],
+        edges: [
+            { id: 'e1', source: 'start', target: 'inc' },
+            { id: 'e_back', source: 'inc', target: 'inc', type: 'back', condition: `inc.count < ${cap}` },
+            { id: 'e_done', source: 'inc', target: 'end', condition: `inc.count >= ${cap}` },
+        ],
+    });
+
+    const registerIncExecutor = () => {
+        let count = 0;
+        engine.registerNodeExecutor({
+            type: 'inc',
+            async execute() {
+                count += 1;
+                return { success: true, output: { count } };
+            },
+        });
+        return () => count;
+    };
+
+    it('accepts a cycle whose closing edge is typed back', () => {
+        registerIncExecutor();
+        expect(() => engine.registerFlow('counter_flow', counterFlow(3))).not.toThrow();
+    });
+
+    it('still rejects an unmarked cycle alongside a declared back-edge', () => {
+        expect(() => engine.registerFlow('mixed_cycles', {
+            name: 'mixed_cycles',
+            label: 'Mixed Cycles',
+            type: 'autolaunched',
+            nodes: [
+                { id: 'start', type: 'start', label: 'Start' },
+                { id: 'a', type: 'assignment', label: 'A' },
+                { id: 'b', type: 'assignment', label: 'B' },
+            ],
+            edges: [
+                { id: 'e1', source: 'start', target: 'a' },
+                { id: 'e2', source: 'a', target: 'b' },
+                // declared rework loop — fine on its own…
+                { id: 'e3', source: 'b', target: 'a', type: 'back' },
+                // …but this second, unmarked cycle must still be rejected
+                { id: 'e4', source: 'b', target: 'b' },
+            ],
+        })).toThrow(/cycle/i);
+    });
+
+    it('re-enters a node over the back-edge, overwriting its outputs (latest round wins)', async () => {
+        const getCount = registerIncExecutor();
+        engine.registerFlow('counter_flow', counterFlow(3));
+
+        const result = await engine.execute('counter_flow', {});
+
+        expect(result.success).toBe(true);
+        expect(getCount()).toBe(3);
+        // Every visit is its own step entry — observability shows each round.
+        const run = (await engine.listRuns('counter_flow'))[0];
+        expect(run.steps.filter(s => s.nodeId === 'inc')).toHaveLength(3);
+    });
+
+    it('aborts a runaway back-edge loop at the re-entry cap', async () => {
+        registerIncExecutor();
+        engine.registerFlow('counter_flow', counterFlow(1_000_000));
+
+        const result = await engine.execute('counter_flow', {});
+
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/runaway/i);
+        expect(result.error).toContain(String(AutomationEngine.MAX_NODE_REENTRIES));
+    });
+
+    it('cancelRun consumes a suspended run and records a terminal cancelled log', async () => {
+        engine.registerNodeExecutor({
+            type: 'pause',
+            async execute() { return { success: true, suspend: true, correlation: 'test-pause' }; },
+        });
+        engine.registerFlow('pausing_flow', {
+            name: 'pausing_flow',
+            label: 'Pausing Flow',
+            type: 'autolaunched',
+            nodes: [
+                { id: 'start', type: 'start', label: 'Start' },
+                { id: 'hold', type: 'pause', label: 'Hold' },
+                { id: 'end', type: 'end', label: 'End' },
+            ],
+            edges: [
+                { id: 'e1', source: 'start', target: 'hold' },
+                { id: 'e2', source: 'hold', target: 'end' },
+            ],
+        });
+
+        const paused = await engine.execute('pausing_flow', {});
+        expect(paused.status).toBe('paused');
+        const runId = paused.runId!;
+
+        expect(await engine.cancelRun(runId, 'abandoned by submitter')).toBe(true);
+        expect(engine.listSuspendedRuns()).toHaveLength(0);
+        // listRuns returns newest-first; the paused entry precedes the cancelled one.
+        const log = (await engine.listRuns('pausing_flow'))[0];
+        expect(log?.status).toBe('cancelled');
+        expect(log?.error).toBe('abandoned by submitter');
+
+        // The continuation is consumed: resume now fails, and cancel is idempotent.
+        const resumed = await engine.resume(runId);
+        expect(resumed.success).toBe(false);
+        expect(await engine.cancelRun(runId)).toBe(false);
+    });
+});
+
 // ─── Node Timeout Tests ──────────────────────────────────────────────
 
 describe('AutomationEngine - Node Timeout', () => {

--- a/packages/services/service-automation/src/engine.ts
+++ b/packages/services/service-automation/src/engine.ts
@@ -311,6 +311,14 @@ export interface SuspendedRunStore {
 }
 
 export class AutomationEngine implements IAutomationService {
+    /**
+     * ADR-0044: maximum times a single node may be (re-)entered at the top
+     * level of one run before the engine aborts it as a runaway back-edge
+     * loop. Generous on purpose — the product guard (`maxRevisions`) sits
+     * orders of magnitude lower.
+     */
+    static readonly MAX_NODE_REENTRIES = 100;
+
     private flows = new Map<string, FlowParsed>();
     private flowEnabled = new Map<string, boolean>();
     private flowVersionHistory = new Map<string, Array<{ version: number; definition: FlowParsed; createdAt: string }>>();
@@ -1339,6 +1347,47 @@ export class AutomationEngine implements IAutomationService {
     }
 
     /**
+     * Cancel a suspended run (ADR-0044): consume its continuation and record a
+     * terminal `cancelled` log so it stops surfacing as resumable. The
+     * engine-level primitive behind "the submitter abandoned the revision
+     * window" — recalling there leaves the run paused at a wait node with no
+     * reject edge to resume down, so the run must end, not continue. Returns
+     * `false` when no suspended run exists under the id (already terminal /
+     * unknown), which callers treat as idempotent success.
+     */
+    async cancelRun(runId: string, reason?: string): Promise<boolean> {
+        let run = this.suspendedRuns.get(runId) ?? null;
+        if (!run && this.store) {
+            try {
+                run = await this.store.load(runId);
+            } catch (err) {
+                this.logger.warn(
+                    `[automation] cancelRun: failed to load suspended run '${runId}' from durable store: ${(err as Error).message}`,
+                );
+            }
+        }
+        if (!run) return false;
+        await this.forgetSuspendedRun(runId);
+        this.recordLog({
+            id: run.runId,
+            flowName: run.flowName,
+            flowVersion: run.flowVersion,
+            status: 'cancelled',
+            startedAt: run.startedAt,
+            completedAt: new Date().toISOString(),
+            durationMs: Date.now() - run.startTime,
+            trigger: {
+                type: run.context?.event ?? 'manual',
+                userId: run.context?.userId,
+                object: run.context?.object,
+            },
+            steps: run.steps,
+            error: reason,
+        });
+        return true;
+    }
+
+    /**
      * Walk a failed run's `$parentRunId` chain and fail each suspended
      * ancestor (see {@link failSuspendedRun}). Bounded so a corrupt context
      * can't loop forever.
@@ -1489,6 +1538,13 @@ export class AutomationEngine implements IAutomationService {
      * Detect cycles in the flow graph (DAG validation).
      * Uses DFS with coloring (white/gray/black) to detect back edges.
      * Throws an error with cycle details if a cycle is found.
+     *
+     * ADR-0044: edges explicitly typed `back` (declared back-edges — e.g. a
+     * revise/rework loop re-entering an approval node) are excluded from the
+     * analysis: the graph **minus `back` edges** must be a DAG. An unmarked
+     * cycle is still rejected — authors opt in edge by edge. At run time a
+     * `back` edge traverses like any default edge; the re-entry runaway guard
+     * lives in {@link executeNode}.
      */
     private detectCycles(flow: FlowParsed): void {
         const WHITE = 0, GRAY = 1, BLACK = 2;
@@ -1502,6 +1558,7 @@ export class AutomationEngine implements IAutomationService {
             adj.set(node.id, []);
         }
         for (const edge of flow.edges) {
+            if (edge.type === 'back') continue; // ADR-0044 declared back-edge
             const targets = adj.get(edge.source);
             if (targets) targets.push(edge.target);
         }
@@ -1534,7 +1591,10 @@ export class AutomationEngine implements IAutomationService {
             if (color.get(node.id) === WHITE) {
                 const cycle = dfs(node.id);
                 if (cycle) {
-                    throw new Error(`Flow contains a cycle: ${cycle.join(' → ')}. Only DAG flows are allowed.`);
+                    throw new Error(
+                        `Flow contains a cycle: ${cycle.join(' → ')}. Only DAG flows are allowed — ` +
+                        `to author an intentional rework loop, mark the cycle-closing edge with type: 'back' (ADR-0044).`,
+                    );
                 }
             }
         }
@@ -1587,6 +1647,23 @@ export class AutomationEngine implements IAutomationService {
         steps: StepLogEntry[],
     ): Promise<void> {
         if (node.type === 'end') return;
+
+        // ADR-0044 runaway guard: declared back-edges make re-entering a node
+        // legal, so a misauthored unconditional loop could otherwise spin
+        // forever. Count this node's prior *top-level* visits in the run's step
+        // log (region body steps carry `parentNodeId` and are excluded — a
+        // 200-iteration `loop` region is legitimate) and fail the run loudly
+        // past the cap. Product-level guards (e.g. an approval node's
+        // `maxRevisions`) terminate far earlier; this is the engine backstop.
+        const priorVisits = steps.reduce(
+            (n, s) => (s.nodeId === node.id && s.parentNodeId === undefined ? n + 1 : n), 0,
+        );
+        if (priorVisits >= AutomationEngine.MAX_NODE_REENTRIES) {
+            throw new Error(
+                `Node '${node.id}' was entered ${priorVisits} times in one run — aborting as a runaway loop ` +
+                `(back-edge cycles must terminate; see ADR-0044)`,
+            );
+        }
 
         const stepStart = Date.now();
         const stepStartedAt = new Date().toISOString();

--- a/packages/spec/src/automation/approval.test.ts
+++ b/packages/spec/src/automation/approval.test.ts
@@ -24,8 +24,15 @@ describe('ApproverType', () => {
 describe('Approval node constants (ADR-0019)', () => {
   it('exposes the canonical node type and decision branch labels', () => {
     expect(APPROVAL_NODE_TYPE).toBe('approval');
+    // The decision surface stays approve|reject — send-back (ADR-0044) is a
+    // separate service verb, not a third decision.
     expect(ApprovalDecision.options).toEqual(['approve', 'reject']);
-    expect(APPROVAL_BRANCH_LABELS).toEqual({ approve: 'approve', reject: 'reject' });
+    expect(APPROVAL_BRANCH_LABELS).toEqual({
+      approve: 'approve',
+      reject: 'reject',
+      revise: 'revise',
+      resubmit: 'resubmit',
+    });
   });
 });
 
@@ -49,6 +56,15 @@ describe('ApprovalNodeConfigSchema', () => {
     expect(result.behavior).toBe('first_response');
     expect(result.lockRecord).toBe(true);
     expect(result.escalation).toBeUndefined();
+    // ADR-0044: revision budget defaults to 3 send-backs.
+    expect(result.maxRevisions).toBe(3);
+  });
+
+  it('accepts an explicit maxRevisions and rejects negatives (ADR-0044)', () => {
+    expect(ApprovalNodeConfigSchema.parse({ ...minimal, maxRevisions: 0 }).maxRevisions).toBe(0);
+    expect(ApprovalNodeConfigSchema.parse({ ...minimal, maxRevisions: 5 }).maxRevisions).toBe(5);
+    expect(() => ApprovalNodeConfigSchema.parse({ ...minimal, maxRevisions: -1 })).toThrow();
+    expect(() => ApprovalNodeConfigSchema.parse({ ...minimal, maxRevisions: 1.5 })).toThrow();
   });
 
   it('accepts a full node config with escalation', () => {

--- a/packages/spec/src/automation/approval.zod.ts
+++ b/packages/spec/src/automation/approval.zod.ts
@@ -56,6 +56,18 @@ export type ApprovalDecision = z.infer<typeof ApprovalDecision>;
 export const APPROVAL_BRANCH_LABELS = {
   approve: 'approve',
   reject: 'reject',
+  /**
+   * ADR-0044 send-back-for-revision: the request finalizes `returned` and the
+   * flow walks this edge to a wait point where the submitter reworks the
+   * record; a later resubmit re-enters the approval node via a declared
+   * back-edge (round N+1).
+   */
+  revise: 'revise',
+  /**
+   * ADR-0044: informational label a resubmit resume passes so the wait node's
+   * out-edge selection is explicit when authors label the back-edge.
+   */
+  resubmit: 'resubmit',
 } as const;
 
 /** A single approver assignment on an Approval node. */
@@ -156,6 +168,16 @@ export const ApprovalNodeConfigSchema = lazySchema(() => z.object({
 
   /** Optional per-node SLA escalation. */
   escalation: ApprovalEscalationSchema.optional().describe('Per-node SLA escalation'),
+
+  /**
+   * ADR-0044: maximum send-backs-for-revision per (run, node). A send-back
+   * that would exceed the budget auto-rejects instead (the run resumes down
+   * the `reject` edge with `output.autoRejected = true`), so instances cannot
+   * orbit the revise loop forever. `0` disables send-back (always
+   * auto-rejects). Only meaningful when the node has a `revise` out-edge.
+   */
+  maxRevisions: z.number().int().min(0).default(3)
+    .describe('Max send-backs for revision before auto-reject (0 = send-back disabled)'),
 }));
 export type ApprovalNodeConfig = z.infer<typeof ApprovalNodeConfigSchema>;
 

--- a/packages/spec/src/automation/flow.zod.ts
+++ b/packages/spec/src/automation/flow.zod.ts
@@ -180,8 +180,13 @@ export const FlowEdgeSchema = lazySchema(() => z.object({
   /** Condition for this path (only for decision/branch nodes) */
   condition: ExpressionInputSchema.optional().describe('Predicate (CEL) returning boolean used for branching.'),
   
-  type: z.enum(['default', 'fault', 'conditional']).default('default')
-    .describe('Connection type: default (normal flow), fault (error path), or conditional (expression-guarded)'),
+  type: z.enum(['default', 'fault', 'conditional', 'back'])
+    .default('default')
+    .describe(
+      'Connection type: default (normal flow), fault (error path), conditional (expression-guarded), '
+      + 'or back (ADR-0044 declared back-edge — traversed normally at run time, but excluded from DAG '
+      + 'cycle validation so a revise/rework loop can re-enter an earlier node)',
+    ),
   label: z.string().optional().describe('Label on the connector'),
 
   /**

--- a/packages/spec/src/contracts/approval-service.ts
+++ b/packages/spec/src/contracts/approval-service.ts
@@ -18,8 +18,17 @@
 
 import type { SharingExecutionContext } from './sharing-service.js';
 
-/** Lifecycle state of an approval request. */
-export type ApprovalStatus = 'pending' | 'approved' | 'rejected' | 'recalled';
+/**
+ * Lifecycle state of an approval request.
+ *
+ * `returned` (ADR-0044): the approver sent the request back for revision —
+ * terminal for THIS request/round; the flow walks the `revise` edge to a wait
+ * point, and a later resubmit opens a fresh `pending` request (next round).
+ * Distinct from `recalled` (submitter-initiated withdrawal).
+ *
+ * Dual-source: keep in sync with the `sys_approval_request` status select.
+ */
+export type ApprovalStatus = 'pending' | 'approved' | 'rejected' | 'recalled' | 'returned';
 
 /** Live request row. */
 export interface ApprovalRequestRow {
@@ -82,6 +91,12 @@ export interface ApprovalRequestRow {
    * attached). `state` is relative to this request's node.
    */
   flow_steps?: Array<{ id: string; label: string; state: 'done' | 'current' | 'upcoming' }>;
+  /**
+   * ADR-0044 revision round of this request on its (run, node): 1 (or absent)
+   * for the first round, 2 after one send-back-and-resubmit, … Carried in the
+   * `node_config_json` snapshot (`__round`), so no schema migration.
+   */
+  round?: number;
 }
 
 /** Kinds of entries on a request's audit trail. */
@@ -98,7 +113,11 @@ export type ApprovalActionKind =
   /** An approver asked the submitter for more information (request stays pending). */
   | 'request_info'
   /** A free-form reply on the thread (submitter or approver). */
-  | 'comment';
+  | 'comment'
+  /** ADR-0044: an approver sent the request back for revision (request finalizes `returned`). */
+  | 'revise'
+  /** ADR-0044: the submitter resubmitted after rework (the next round's request opens with its own `submit`). */
+  | 'resubmit';
 
 /** Audit row. */
 export interface ApprovalActionRow {
@@ -139,6 +158,45 @@ export interface ApprovalRecallResult {
    * engine has no run-cancel primitive yet; the reject edge is the closest
    * "did not pass" semantics.
    */
+  resumed?: boolean;
+}
+
+/** Input for sending a pending request back for revision (ADR-0044). */
+export interface ApprovalSendBackInput {
+  /** Must be a pending approver on the request (or a system context). */
+  actorId: string;
+  /** Why the material needs rework — shown to the submitter. */
+  comment?: string;
+}
+
+/** Result of a send-back (ADR-0044). */
+export interface ApprovalSendBackResult {
+  request: ApprovalRequestRow;
+  /** The suspended flow run this request gated, if any. */
+  runId?: string | null;
+  /** True when the owning flow run was resumed (down `revise`, or `reject` on auto-reject). */
+  resumed?: boolean;
+  /**
+   * True when the send-back exceeded the node's `maxRevisions` budget and the
+   * request was auto-rejected instead (resumed down `reject` with
+   * `output.autoRejected = true`).
+   */
+  autoRejected?: boolean;
+}
+
+/** Input for resubmitting a returned request after rework (ADR-0044). */
+export interface ApprovalResubmitInput {
+  /** Must be the request's submitter (or a system context). */
+  actorId: string;
+  comment?: string;
+}
+
+/** Result of a resubmit (ADR-0044). */
+export interface ApprovalResubmitResult {
+  /** The round-N request the resubmit was recorded on (stays `returned`). */
+  request: ApprovalRequestRow;
+  runId?: string | null;
+  /** True when the owning flow run was resumed (it re-enters the approval node and opens round N+1). */
   resumed?: boolean;
 }
 
@@ -216,8 +274,40 @@ export interface IApprovalService {
    * Withdraw a pending request. Only the submitter (or a system context) may
    * recall. Finalises the request as `recalled` and resumes the owning flow
    * run down the `reject` branch with `output.decision = 'recall'`.
+   *
+   * ADR-0044: also valid on the LATEST `returned` request of its (run, node)
+   * — the submitter abandons the revision window instead of resubmitting; the
+   * request flips `returned → recalled` and the run resumes down `reject` the
+   * same way.
    */
   recall(requestId: string, input: ApprovalRecallInput, context: SharingExecutionContext): Promise<ApprovalRecallResult>;
+
+  /**
+   * ADR-0044 send back for revision. Finalises the pending request as
+   * `returned` and resumes the owning flow run down its `revise` edge to a
+   * wait point (record unlocks; the submitter reworks the data and
+   * {@link resubmit}s). Requires the approval node to declare a `revise`
+   * out-edge; past the node's `maxRevisions` budget the request auto-rejects
+   * instead. Audited as `revise`.
+   */
+  sendBack(
+    requestId: string,
+    input: ApprovalSendBackInput,
+    context: SharingExecutionContext,
+  ): Promise<ApprovalSendBackResult>;
+
+  /**
+   * ADR-0044 resubmit after rework. Valid on the LATEST `returned` request of
+   * its (run, node), submitter-only. Resumes the suspended run from the wait
+   * point; traversal re-enters the approval node via the declared back-edge
+   * and opens the next round's request (fresh approver slate, record
+   * re-locks). Audited as `resubmit` on the returned request.
+   */
+  resubmit(
+    requestId: string,
+    input: ApprovalResubmitInput,
+    context: SharingExecutionContext,
+  ): Promise<ApprovalResubmitResult>;
 
   /**
    * Hand a pending-approver slot to someone else. The actor must currently


### PR DESCRIPTION
Closes #1744. Implements ADR-0044 (docs/adr/0044-approval-send-back-for-revision.md).

## What

`requestInfo()` (#1740) is a thread conversation; this lands the real flow movement mainstream approval centers call 退回修改 / *send back for revision*:

```
approval (round N) ──revise──▶ wait (record unlocked, submitter edits)
        ▲                            │
        └────────[back-edge]── resubmit (round N+1, fresh slate, re-lock)
```

## Decisions (ADR-0044)

- **`returned`** — third terminal `ApprovalStatus` (approver-initiated rework ≠ submitter-initiated `recalled`); lock + pending-dedupe key on `pending`, so unlock/round-N+1 need no lock-machinery change
- **`revise` branch + `maxRevisions`** (default 3) on the node config — overflow **auto-rejects** (resumes down `reject`, `output.autoRejected: true`); send-back validated against the flow graph before any mutation (no revise edge ⇒ `VALIDATION_FAILED`)
- **wait node + REST resubmit** — `POST …/revise`, `POST …/resubmit`; revise window is visible flow state
- **`__round` config-snapshot numbering** — `row.round`, no migration (precedent: `__flowLabel`)
- **Engine: typed back-edges** — `FlowEdgeSchema.type: 'back'`; cycle validation = DAG on the graph *minus* back-edges (unmarked cycles still rejected); re-entry overwrites node outputs / appends steps; 100-re-entry runaway guard; **`cancelRun()`** lands as the first run-cancel primitive (recall crossing a revise window cancels the parked run — the wait node has no reject edge)
- **Collision guard** — resubmit refuses `DUPLICATE_REQUEST` while another pending request holds the record (refuses *before* the suspension is consumed, so the run stays resumable)

Also fixes a latent orderBy bug (`direction:` is not a SortNode key — silently sorted asc) in `remind()`'s cool-down and the new latest-row guard, with regression tests.

## Tests

- Engine suite: back-edge registration, unmarked-cycle rejection, re-entry output overwrite + step append, runaway guard, cancelRun (185 ✓)
- ADR-0039-style matrix (`approval-revise.test.ts`): multi-round 1→3 · unanimous slate reset · lock locked→unlocked→re-locked · recall crossing the window · superseded rows · overflow auto-reject · no-revise-edge rejection · resubmit collision guard (83 ✓)
- spec 6529 ✓ · rest 103 ✓

## Browser-verified (showcase stack, 3700/5790)

Send back from the inbox (violet `returned` badge, timeline `revise` entry) → record unlocks (PATCH 200 while returned, 409 while pending) → resubmit from the submitter view → **round 2** opens (Round-2 chip, fresh trail, re-lock, survives server restart via the durable store) → round-2 approve completes the flow. Third send-back on `maxRevisions: 2` auto-rejects with the audit trail `revise → reject ("Auto-rejected: revision limit (2) exceeded")`.

Console UI counterpart: objectui PR (send-back button/dialog, resubmit entry, timeline, ten-locale i18n). Studio designer authoring for the revise edge is a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)