### PR TITLE
feat(cloud-connection): Installed Apps page ships as plugin metadata (ADR-0009 P2a)

### DIFF
--- a/.changeset/installed-page-metadata.md
+++ b/.changeset/installed-page-metadata.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/cloud-connection": minor
+---
+
+The Installed Apps page ships as metadata with `MarketplaceInstallLocalPlugin` (cloud ADR-0009 P2a): `marketplace_installed` page (page:header + `marketplace:installed-list` widget) and the Setup nav entry switches to `type:'page'`.

--- a/packages/cloud-connection/src/marketplace-ui.ts
+++ b/packages/cloud-connection/src/marketplace-ui.ts
@@ -38,22 +38,57 @@ export const MARKETPLACE_BROWSE_UI_BUNDLE = {
     ],
 };
 
-/** "Installed Apps" — owned by the local-install capability. */
+/** "Installed Apps" — owned by the local-install capability (ADR-0009 P2a:
+ *  the page itself is now metadata; the console provides only the
+ *  `marketplace:installed-list` widget). */
+export const MarketplaceInstalledPage = {
+    name: 'marketplace_installed',
+    label: 'Installed Apps',
+    type: 'app' as const,
+    template: 'default',
+    kind: 'full' as const,
+    isDefault: false,
+    regions: [
+        {
+            name: 'header',
+            width: 'full' as const,
+            components: [
+                {
+                    type: 'page:header',
+                    properties: {
+                        title: 'Installed Apps',
+                        subtitle: 'Marketplace packages currently installed into this runtime\'s kernel.',
+                        icon: 'package-check',
+                    },
+                },
+            ],
+        },
+        {
+            name: 'main',
+            width: 'large' as const,
+            components: [
+                { type: 'marketplace:installed-list', properties: {} },
+            ],
+        },
+    ],
+};
+
 export const MARKETPLACE_INSTALLED_UI_BUNDLE = {
     id: 'com.objectstack.cloud-connection.marketplace-installed-ui',
     namespace: 'sys',
-    version: '0.1.0',
+    version: '0.2.0',
     type: 'plugin',
     scope: 'system',
     name: 'Marketplace Installed UI',
-    description: 'Setup navigation for locally-installed marketplace packages.',
+    description: 'Installed Apps page + Setup navigation for locally-installed marketplace packages.',
+    pages: [MarketplaceInstalledPage],
     navigationContributions: [
         {
             app: 'setup',
             group: 'group_apps',
             priority: 110,
             items: [
-                { id: 'nav_marketplace_installed', type: 'url', label: 'Installed Apps', url: '/apps/setup/system/marketplace/installed', icon: 'package-check' },
+                { id: 'nav_marketplace_installed', type: 'page', pageName: 'marketplace_installed', label: 'Installed Apps', icon: 'package-check' },
             ],
         },
     ],


### PR DESCRIPTION
install-local 插件的 UI bundle 升级:携带 `marketplace_installed` 元数据页(page:header + `marketplace:installed-list` widget,objectui 配套 PR)+ nav 切 `type:'page'`。36/36。

🤖 Generated with [Claude Code](https://claude.com/claude-code)