### PR TITLE
feat(platform-objects): lock studio & account apps with ADR-0010 full protection

### DIFF
--- a/packages/platform-objects/src/apps/account.app.ts
+++ b/packages/platform-objects/src/apps/account.app.ts
@@ -38,6 +38,16 @@ export const ACCOUNT_APP: App = {
   isDefault: false,
   // Surface via the avatar dropdown, not the App Switcher — see App.hidden.
   hidden: true,
+  // ADR-0010 §3.7 — author-facing protection block. Loader translates
+  // this into the `_lock` envelope at registration time. Every
+  // authenticated user depends on this app to manage their own
+  // sessions / API keys / linked accounts, so a tenant overlay that
+  // breaks it is a security-relevant outage — same class as Setup.
+  protection: {
+    lock: 'full',
+    reason: 'Core self-service security UI shipped by @objectstack/platform-objects — see ADR-0010.',
+    docsUrl: 'https://docs.objectstack.ai/adr/0010-metadata-protection',
+  },
   branding: {
     primaryColor: '#0ea5e9', // sky-500 — distinct from Setup's slate
   },

--- a/packages/platform-objects/src/apps/setup-nav.contributions.ts
+++ b/packages/platform-objects/src/apps/setup-nav.contributions.ts
@@ -38,13 +38,9 @@ export const SETUP_NAV_CONTRIBUTIONS: NavigationContribution[] = [
       { id: 'nav_system_overview', type: 'dashboard', label: 'System Overview', dashboardName: 'system_overview', icon: 'activity' },
     ],
   },
-  {
-    app: 'setup',
-    group: 'group_apps',
-    priority: BASE_PRIORITY,
-    items: [
-    ],
-  },
+  // No group_apps contribution left here — both marketplace entries moved
+  // out (see header note); the group_apps shell anchor in setup.app.ts is
+  // filled entirely by capability plugins now.
   {
     app: 'setup',
     group: 'group_people_org',

--- a/packages/platform-objects/src/apps/studio.app.ts
+++ b/packages/platform-objects/src/apps/studio.app.ts
@@ -34,6 +34,15 @@ export const STUDIO_APP: App = {
   icon: 'hammer',
   active: true,
   isDefault: false,
+  // ADR-0010 §3.7 — author-facing protection block. Loader translates
+  // this into the `_lock` envelope at registration time. Same rationale
+  // as Setup: tenant overlay edits to the metadata workbench can lock
+  // implementers out of the very surface used to repair metadata.
+  protection: {
+    lock: 'full',
+    reason: 'Core developer workbench shipped by @objectstack/platform-objects — see ADR-0010.',
+    docsUrl: 'https://docs.objectstack.ai/adr/0010-metadata-protection',
+  },
   // Studio is the metadata-authoring host, so its ambient copilot is
   // pinned to the schema-architect agent. Resolved by the ambient chat
   // endpoint via `app.defaultAgent` — no UI-side `?agent=` override

--- a/packages/platform-objects/src/platform-objects.test.ts
+++ b/packages/platform-objects/src/platform-objects.test.ts
@@ -28,7 +28,7 @@ import {
   SysMetadataHistoryObject,
 } from './metadata/index.js';
 import { SysSetting } from './system/index.js';
-import { SETUP_APP, SETUP_NAV_CONTRIBUTIONS } from './apps/index.js';
+import { ACCOUNT_APP, SETUP_APP, SETUP_NAV_CONTRIBUTIONS, STUDIO_APP } from './apps/index.js';
 import { AppSchema } from '@objectstack/spec/ui';
 
 const systemObjects = [
@@ -153,6 +153,24 @@ describe('@objectstack/platform-objects', () => {
       // The webhooks entries are no longer static here — plugin-webhooks
       // contributes them into this slot (ADR-0029 D7 / K2.a).
       expect((group as { children?: unknown[] }).children).toEqual([]);
+    });
+  });
+
+  describe('platform app protection (ADR-0010 §3.7)', () => {
+    // All three platform apps are core UI shipped by this package: a
+    // tenant overlay that breaks Setup/Studio locks admins/implementers
+    // out of the repair surface, and Account is every user's only
+    // self-service security surface. The loader translates `protection`
+    // into the `_lock` envelope; clients (e.g. objectui's
+    // isNavigationSyncableApp) rely on `_lock` to skip automatic
+    // navigation writes into these apps.
+    it.each([
+      ['SETUP_APP', SETUP_APP],
+      ['STUDIO_APP', STUDIO_APP],
+      ['ACCOUNT_APP', ACCOUNT_APP],
+    ])('%s declares a full lock', (_name, app) => {
+      expect(app.protection?.lock).toBe('full');
+      expect(() => AppSchema.parse(app)).not.toThrow();
     });
   });
 


### PR DESCRIPTION
## Summary

`setup` already ships `protection: { lock: 'full' }` (ADR-0010 §3.7), but `studio` and `account` had no protection block, so tenant overlay writes via `PUT /api/v1/meta/app/{studio,account}` succeeded. The objectui NavigationSyncEffect bug demonstrated the hazard by writing auto-navigation pages into these writable system apps.

Both are core platform UI in the same class as Setup:
- **studio** — the metadata workbench; a broken tenant overlay locks implementers out of the very surface used to repair metadata
- **account** — every authenticated user's only self-service security surface (sessions / API keys / linked accounts), so a broken overlay is a security-relevant outage

## Changes
- Add `protection: { lock: 'full', reason, docsUrl }` to `studio.app.ts` and `account.app.ts`, mirroring `setup.app.ts`
- Regression test pinning `lock: 'full'` on all three platform apps (and AppSchema parse)

## Notes
- Setup-style navigation contributions are unaffected — they are a registration-time in-memory merge, not overlay writes, and nothing in the repo targets studio/account with contributions
- objectui's `isNavigationSyncableApp` already filters on `_lock ∈ {full, no-overlay}`, so client behavior is automatically correct once the server serves the lock
- Server-side L3 enforcement applies in tenant scope (`environmentId` set); standalone/control-plane stacks skip it by design (`protocol.ts` `assertLockAllowsWrite`)

## Test plan
- [x] `vitest run src/platform-objects.test.ts` — new protection tests pass (the one failing SETUP_NAV_CONTRIBUTIONS test also fails on clean main, pre-existing)
- [x] `tsc --noEmit` clean
- [x] End-to-end: rebuilt package, booted showcase, `GET /api/v1/meta/app` serves `_lock: "full"` + reason for setup/studio/account

🤖 Generated with [Claude Code](https://claude.com/claude-code)