### PR TITLE
fix(objectql): artifact lock envelope survives overlay hydration and reset (ADR-0010 §3.3)

### DIFF
--- a/.changeset/registry-shadow-lock-envelope.md
+++ b/.changeset/registry-shadow-lock-envelope.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/objectql": patch
+---
+
+Fix metadata registry pollution: a packaged artifact's protection envelope (`_lock`/`_packageId`/`_provenance`) survives overlay hydration and reset (ADR-0010 §3.3). GET-list hydration used to register the sys_metadata overlay body under the registry's plain key, shadowing the artifact — a `_lock: full` app read back as unlocked after PUT+GET, and DELETE (reset) left the stale shadow in place until restart. Envelope readers now resolve through the shadow-immune `SchemaRegistry.getArtifactItem()`, hydration grafts the artifact envelope onto the overlay body (overlay content wins, artifact protection wins), and reset heals the registry via `removeRuntimeShadow()` — including self-healing on a no-op DELETE.

--- a/packages/objectql/src/protocol-registry-shadow.test.ts
+++ b/packages/objectql/src/protocol-registry-shadow.test.ts
@@ -1,0 +1,316 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ADR-0010 §3.3 — artifact protection envelope vs. registry shadows.
+ *
+ * Regression suite for the "registry pollution" bug: on a control-plane
+ * kernel (`environmentId === undefined`), PUT /meta/app/<name> on a
+ * `_lock: full` artifact-backed app succeeded (the L3 gate is
+ * intentionally bypassed there), and the next GET list hydrated the
+ * overlay body into the SchemaRegistry under the PLAIN key — shadowing
+ * the packaged artifact registered under `<packageId>:<name>`. Every
+ * envelope reader (`lookupArtifactItem` / `getEffectiveLock` /
+ * `isArtifactBacked`) resolved the shadow instead of the artifact, so
+ * `_lock`/`_packageId`/`_provenance` read back as undefined. A
+ * subsequent DELETE (reset) removed the sys_metadata row but left the
+ * shadow in place — the lock stayed lost until restart.
+ *
+ * Pinned here:
+ *  1. The hydrated shadow carries the artifact's protection envelope.
+ *  2. The list/get surfaces keep `_lock` through PUT → GET → DELETE.
+ *  3. Reset heals the registry: the artifact value is visible again.
+ *  4. Lock enforcement on scoped kernels is shadow-immune.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ObjectStackProtocolImplementation } from './protocol.js';
+import { ObjectQL } from './engine.js';
+import { SchemaRegistry } from './registry.js';
+
+const PKG = 'com.objectstack.test-pkg';
+
+const sysMetadataObject = {
+    name: 'sys_metadata',
+    label: 'System Metadata',
+    fields: {
+        id: { name: 'id', label: 'ID', type: 'text' as const, primaryKey: true },
+        type: { name: 'type', label: 'Type', type: 'text' as const, required: true },
+        name: { name: 'name', label: 'Name', type: 'text' as const, required: true },
+        organization_id: { name: 'organization_id', label: 'Org', type: 'text' as const },
+        metadata: { name: 'metadata', label: 'Body', type: 'longtext' as const },
+        checksum: { name: 'checksum', label: 'Checksum', type: 'text' as const, maxLength: 71 },
+        state: { name: 'state', label: 'State', type: 'text' as const },
+        version: { name: 'version', label: 'Version', type: 'number' as const },
+        created_at: { name: 'created_at', label: 'Created', type: 'datetime' as const },
+        updated_at: { name: 'updated_at', label: 'Updated', type: 'datetime' as const },
+    },
+};
+
+const sysMetadataHistoryObject = {
+    name: 'sys_metadata_history',
+    label: 'Metadata History',
+    fields: {
+        id: { name: 'id', label: 'ID', type: 'text' as const, primaryKey: true },
+        event_seq: { name: 'event_seq', label: 'Seq', type: 'number' as const, required: true },
+        type: { name: 'type', label: 'Type', type: 'text' as const, required: true },
+        name: { name: 'name', label: 'Name', type: 'text' as const, required: true },
+        version: { name: 'version', label: 'Version', type: 'number' as const, required: true },
+        operation_type: { name: 'operation_type', label: 'Op', type: 'text' as const, required: true },
+        metadata: { name: 'metadata', label: 'Body', type: 'longtext' as const },
+        checksum: { name: 'checksum', label: 'Checksum', type: 'text' as const, maxLength: 71 },
+        previous_checksum: { name: 'previous_checksum', label: 'Prev', type: 'text' as const, maxLength: 71 },
+        change_note: { name: 'change_note', label: 'Note', type: 'longtext' as const },
+        source: { name: 'source', label: 'Source', type: 'text' as const },
+        organization_id: { name: 'organization_id', label: 'Org', type: 'text' as const },
+        recorded_by: { name: 'recorded_by', label: 'By', type: 'text' as const },
+        recorded_at: { name: 'recorded_at', label: 'At', type: 'datetime' as const, required: true },
+    },
+};
+
+/** Equality-only in-memory driver — same shape as the PR-10d.4 suite. */
+function makeMemoryDriver() {
+    const stores = new Map<string, Map<string, Record<string, unknown>>>();
+    const storeFor = (obj: string) => {
+        let s = stores.get(obj);
+        if (!s) { s = new Map(); stores.set(obj, s); }
+        return s;
+    };
+    let nextId = 0;
+
+    const matchesWhere = (row: Record<string, unknown>, where: any): boolean => {
+        if (!where || typeof where !== 'object') return true;
+        if (Array.isArray(where.$and)) return where.$and.every((w: any) => matchesWhere(row, w));
+        if (Array.isArray(where.$or)) return where.$or.some((w: any) => matchesWhere(row, w));
+        for (const [k, v] of Object.entries(where)) {
+            if (k.startsWith('$')) continue;
+            const expected = (v && typeof v === 'object' && '$eq' in (v as any)) ? (v as any).$eq : v;
+            const a = row[k] === undefined ? null : row[k];
+            const b = expected === undefined ? null : expected;
+            if (a !== b) return false;
+        }
+        return true;
+    };
+
+    const driver: any = {
+        name: 'memory',
+        version: '0.0.0',
+        supports: {} as any,
+        async connect() {},
+        async disconnect() {},
+        async checkHealth() { return true; },
+        async execute() { return null; },
+        async find(object: string, ast: any) {
+            return Array.from(storeFor(object).values()).filter((r) => matchesWhere(r, ast?.where));
+        },
+        findStream() { throw new Error('not implemented'); },
+        async findOne(object: string, ast: any) {
+            for (const r of storeFor(object).values()) if (matchesWhere(r, ast?.where)) return r;
+            return null;
+        },
+        async create(object: string, data: Record<string, unknown>) {
+            nextId += 1;
+            const id = (data.id as string) ?? `r_${nextId}`;
+            const row = { ...data, id };
+            storeFor(object).set(id, row);
+            return row;
+        },
+        async update(object: string, id: string, data: Record<string, unknown>) {
+            const s = storeFor(object);
+            const cur = s.get(id);
+            if (!cur) throw new Error(`not found: ${object}/${id}`);
+            const updated = { ...cur, ...data, id };
+            s.set(id, updated);
+            return updated;
+        },
+        async upsert(object: string, data: Record<string, unknown>) {
+            const id = data.id as string | undefined;
+            if (id && storeFor(object).has(id)) return this.update(object, id, data);
+            return this.create(object, data);
+        },
+        async delete(object: string, id: string) {
+            return storeFor(object).delete(id);
+        },
+        async count(object: string, ast: any) {
+            return (await this.find(object, ast)).length;
+        },
+        async bulkCreate(object: string, rows: Record<string, unknown>[]) {
+            return Promise.all(rows.map((r) => this.create(object, r)));
+        },
+        async bulkUpdate() { return []; },
+        async bulkDelete() {},
+        async beginTransaction() { return { commit: async () => {}, rollback: async () => {} }; },
+        async commit() {},
+        async rollback() {},
+    };
+    return { driver, stores };
+}
+
+/** Artifact app shipped by a code package with a hard lock. */
+function artifactApp() {
+    return {
+        name: 'setup',
+        label: 'Setup',
+        navigation: [],
+        _packageId: PKG,
+        _packageVersion: '1.0.0',
+        _provenance: 'package',
+        _lock: 'full',
+        _lockReason: 'Core admin UI shipped by the platform package.',
+    };
+}
+
+const overlayBody = { name: 'setup', label: 'Setup HACKED', navigation: [] };
+
+function findByName(items: any[], name: string): any {
+    return (items as any[]).find((it) => it?.name === name);
+}
+
+describe('registry shadow — control-plane PUT → GET → DELETE keeps the artifact envelope', () => {
+    let engine: ObjectQL;
+    let protocol: ObjectStackProtocolImplementation;
+
+    beforeEach(async () => {
+        engine = new ObjectQL();
+        const { driver } = makeMemoryDriver();
+        engine.registerDriver(driver, true);
+        await engine.init();
+        engine.registry.registerObject(sysMetadataObject as any);
+        engine.registry.registerObject(sysMetadataHistoryObject as any);
+        engine.registry.registerItem('app', artifactApp(), 'name', PKG);
+        // No environmentId — single-kernel / control-plane mode, where the
+        // L3 lock gate is bypassed and the GET list hydrates overlay rows
+        // into the process-wide registry.
+        protocol = new ObjectStackProtocolImplementation(engine);
+    });
+
+    it('GET list while the overlay row exists: overlay content wins, artifact envelope wins', async () => {
+        await protocol.saveMetaItem({ type: 'app', name: 'setup', item: { ...overlayBody } });
+
+        const res = await protocol.getMetaItems({ type: 'app' });
+        const setup = findByName((res as any).items, 'setup');
+        expect(setup).toBeDefined();
+        expect(setup.label).toBe('Setup HACKED');     // overlay content
+        expect(setup._lock).toBe('full');             // artifact envelope (ADR-0010 §3.3)
+        expect(setup._packageId).toBe(PKG);
+        expect(setup._provenance).toBe('package');
+    });
+
+    it('the hydrated plain-key shadow itself carries the artifact envelope', async () => {
+        await protocol.saveMetaItem({ type: 'app', name: 'setup', item: { ...overlayBody } });
+        await protocol.getMetaItems({ type: 'app' }); // triggers hydration
+
+        // Registry-direct read (what nav/UI code does) must not see a
+        // stripped envelope even though the overlay body shadows the
+        // artifact on the plain key.
+        const direct: any = engine.registry.getItem('app', 'setup');
+        expect(direct.label).toBe('Setup HACKED');
+        expect(direct._lock).toBe('full');
+        expect(direct._packageId).toBe(PKG);
+    });
+
+    it('DELETE (reset) heals the registry: artifact value and lock are back without a restart', async () => {
+        await protocol.saveMetaItem({ type: 'app', name: 'setup', item: { ...overlayBody } });
+        await protocol.getMetaItems({ type: 'app' }); // pollute via hydration
+
+        const del = await protocol.deleteMetaItem({ type: 'app', name: 'setup' });
+        expect(del.success).toBe(true);
+        expect(del.reset).toBe(true);
+
+        // Registry-direct read resolves the packaged artifact again.
+        const direct: any = engine.registry.getItem('app', 'setup');
+        expect(direct.label).toBe('Setup');
+        expect(direct._lock).toBe('full');
+        expect(direct._packageId).toBe(PKG);
+
+        // And the protocol list surface agrees.
+        const res = await protocol.getMetaItems({ type: 'app' });
+        const setup = findByName((res as any).items, 'setup');
+        expect(setup.label).toBe('Setup');
+        expect(setup._lock).toBe('full');
+        expect(setup._packageId).toBe(PKG);
+    });
+
+    it('a second DELETE self-heals pre-existing pollution even with no overlay row', async () => {
+        // Simulate the pre-fix world: overlay body sits on the plain key
+        // with a stripped envelope, and the sys_metadata row is gone.
+        engine.registry.registerItem('app', { ...overlayBody }, 'name');
+
+        const del = await protocol.deleteMetaItem({ type: 'app', name: 'setup' });
+        expect(del.success).toBe(true);
+        expect(del.reset).toBe(false); // no row to delete…
+
+        // …but the registry shadow is healed anyway.
+        const direct: any = engine.registry.getItem('app', 'setup');
+        expect(direct.label).toBe('Setup');
+        expect(direct._lock).toBe('full');
+    });
+});
+
+describe('registry shadow — scoped-kernel lock enforcement is shadow-immune', () => {
+    it('saveMetaItem still 403s on a full-locked artifact when a stripped shadow exists', async () => {
+        const registry = new SchemaRegistry({ multiTenant: false });
+        registry.registerItem('app', artifactApp(), 'name', PKG);
+        // Pre-fix pollution: plain-key shadow without the lock envelope.
+        registry.registerItem('app', { ...overlayBody }, 'name');
+
+        const mockEngine: any = {
+            registry,
+            find: async () => [],
+            findOne: async () => null,
+            insert: async () => ({ id: 'x' }),
+            update: async () => ({ id: 'x' }),
+            delete: async () => ({ deleted: 1 }),
+        };
+        const protocol = new ObjectStackProtocolImplementation(
+            mockEngine, undefined, undefined, 'env_prod',
+        );
+
+        await expect(protocol.saveMetaItem({
+            type: 'app', name: 'setup', organizationId: 'org_a',
+            item: { ...overlayBody },
+        })).rejects.toMatchObject({ code: 'item_locked', status: 403 });
+
+        await expect(protocol.deleteMetaItem({
+            type: 'app', name: 'setup', organizationId: 'org_a',
+        })).rejects.toMatchObject({ code: 'item_locked', status: 403 });
+    });
+});
+
+describe('SchemaRegistry.getArtifactItem / removeRuntimeShadow', () => {
+    it('getArtifactItem prefers the composite-key artifact over a plain-key shadow', () => {
+        const registry = new SchemaRegistry({ multiTenant: false });
+        registry.registerItem('app', artifactApp(), 'name', PKG);
+        registry.registerItem('app', { ...overlayBody }, 'name');
+
+        expect((registry.getItem('app', 'setup') as any).label).toBe('Setup HACKED');
+        const artifact: any = registry.getArtifactItem('app', 'setup');
+        expect(artifact.label).toBe('Setup');
+        expect(artifact._lock).toBe('full');
+    });
+
+    it('getArtifactItem returns undefined for runtime-only and sys_metadata-sentinel items', () => {
+        const registry = new SchemaRegistry({ multiTenant: false });
+        registry.registerItem('app', { name: 'mine', label: 'Mine' }, 'name');
+        registry.registerItem(
+            'app',
+            { name: 'hydrated', label: 'Hydrated', _packageId: 'sys_metadata' },
+            'name',
+        );
+        expect(registry.getArtifactItem('app', 'mine')).toBeUndefined();
+        expect(registry.getArtifactItem('app', 'hydrated')).toBeUndefined();
+    });
+
+    it('removeRuntimeShadow deletes the plain key only when a packaged artifact remains', () => {
+        const registry = new SchemaRegistry({ multiTenant: false });
+        registry.registerItem('app', artifactApp(), 'name', PKG);
+        registry.registerItem('app', { ...overlayBody }, 'name');
+
+        expect(registry.removeRuntimeShadow('app', 'setup')).toBe(true);
+        expect((registry.getItem('app', 'setup') as any).label).toBe('Setup');
+
+        // Runtime-only item: never removed.
+        registry.registerItem('app', { name: 'mine', label: 'Mine' }, 'name');
+        expect(registry.removeRuntimeShadow('app', 'mine')).toBe(false);
+        expect((registry.getItem('app', 'mine') as any)?.label).toBe('Mine');
+    });
+});

--- a/packages/objectql/src/protocol.ts
+++ b/packages/objectql/src/protocol.ts
@@ -1223,8 +1223,20 @@ export class ObjectStackProtocolImplementation implements ObjectStackProtocol {
                     }
                     // Only hydrate the global registry for unscoped calls —
                     // scoped project entries must not leak process-wide.
-                    if (this.environmentId === undefined) {
-                        this.engine.registry.registerItem(request.type, data, 'name' as any);
+                    // Graft the artifact's protection envelope onto the
+                    // overlay body BEFORE registering: the plain-key entry
+                    // written here shadows the packaged artifact on
+                    // `registry.getItem`, and a bare overlay body would
+                    // strip `_lock`/`_packageId`/`_provenance` from every
+                    // registry-direct reader (ADR-0010 §3.3 — an overlay
+                    // must never loosen a packaged lock).
+                    if (this.environmentId === undefined && data && typeof data === 'object') {
+                        const artifact = this.lookupArtifactItem(request.type, (data as any).name);
+                        this.engine.registry.registerItem(
+                            request.type,
+                            mergeArtifactProtection(data, artifact),
+                            'name' as any,
+                        );
                     }
                 }
                 items = Array.from(byName.values());
@@ -1647,7 +1659,11 @@ export class ObjectStackProtocolImplementation implements ObjectStackProtocol {
             // ignore
         }
         if (code === null) {
-            let regItem = this.engine.registry.getItem(request.type, request.name);
+            // Prefer the artifact-only lookup so an overlay row hydrated
+            // into the registry's plain key can't masquerade as the "code
+            // default" layer; fall back to getItem for runtime-only items.
+            let regItem = this.lookupArtifactItem(request.type, request.name)
+                ?? this.engine.registry.getItem(request.type, request.name);
             if (regItem === undefined) {
                 const alt = PLURAL_TO_SINGULAR[request.type] ?? SINGULAR_TO_PLURAL[request.type];
                 if (alt) regItem = this.engine.registry.getItem(alt, request.name);
@@ -3061,22 +3077,11 @@ export class ObjectStackProtocolImplementation implements ObjectStackProtocol {
      * "authoring a DB-only item" (requires only `allowRuntimeCreate`).
      */
     private isArtifactBacked(type: string, name: string): boolean {
-        const registry = (this.engine as any)?.registry;
-        if (!registry || typeof registry.getItem !== 'function') {
-            // No registry available (test fixtures with partial engine
-            // mocks). Treat as no artifact backing — safer for create paths
-            // and the type-level gates still apply.
-            return false;
-        }
-        const singular = PLURAL_TO_SINGULAR[type] ?? type;
-        const item = registry.getItem(singular, name) ?? registry.getItem(type, name);
-        if (!item || !item._packageId) return false;
-        // `loadMetaFromDb` (line ~3092) registers DB-only objects with
-        // a synthetic `'sys_metadata'` packageId so the registry can
-        // distinguish them from purely transient entries. That sentinel
-        // is NOT an artifact origin — exclude it here so DB-only objects
-        // continue to behave as runtime-authored items.
-        return item._packageId !== 'sys_metadata';
+        // `lookupArtifactItem` only returns items whose `_packageId` marks a
+        // genuine code package (the `'sys_metadata'` rehydration sentinel is
+        // excluded), and — via `SchemaRegistry.getArtifactItem` — is immune
+        // to plain-key shadows hydrated from overlay rows.
+        return this.lookupArtifactItem(type, name) !== undefined;
     }
 
     // ───────────────────────────────────────────────────────────────────
@@ -3090,9 +3095,26 @@ export class ObjectStackProtocolImplementation implements ObjectStackProtocol {
      */
     private lookupArtifactItem(type: string, name: string): unknown {
         const registry = (this.engine as any)?.registry;
-        if (!registry || typeof registry.getItem !== 'function') return undefined;
+        if (!registry) return undefined;
         const singular = PLURAL_TO_SINGULAR[type] ?? type;
-        return registry.getItem(singular, name) ?? registry.getItem(type, name);
+        // Prefer the artifact-only lookup: it scans composite
+        // (`<packageId>:<name>`) entries first, so an overlay row hydrated
+        // into the plain key (getMetaItems / loadMetaFromDb) can never
+        // shadow the packaged artifact's protection envelope (ADR-0010
+        // §3.3 — pre-fix, that shadow made a `_lock: full` app read back
+        // as unlocked after PUT+GET until restart).
+        if (typeof registry.getArtifactItem === 'function') {
+            return registry.getArtifactItem(singular, name)
+                ?? registry.getArtifactItem(type, name);
+        }
+        // Partial registry mocks in tests — fall back to getItem and apply
+        // the same package-provenance filter inline.
+        if (typeof registry.getItem !== 'function') return undefined;
+        const item = registry.getItem(singular, name) ?? registry.getItem(type, name);
+        if (!item || !(item as any)._packageId || (item as any)._packageId === 'sys_metadata') {
+            return undefined;
+        }
+        return item;
     }
 
     /**
@@ -3115,14 +3137,11 @@ export class ObjectStackProtocolImplementation implements ObjectStackProtocol {
         lockReason: string | undefined;
         lockSource: 'artifact' | 'overlay' | undefined;
     }> {
-        // 1. Artifact wins.
-        const registry = (this.engine as any)?.registry;
-        const singular = PLURAL_TO_SINGULAR[type] ?? type;
-        let artifactItem: any;
-        if (registry && typeof registry.getItem === 'function') {
-            artifactItem = registry.getItem(singular, name) ?? registry.getItem(type, name);
-        }
-        if (artifactItem && artifactItem._packageId && artifactItem._packageId !== 'sys_metadata') {
+        // 1. Artifact wins. `lookupArtifactItem` is shadow-immune: a
+        //    sys_metadata overlay row hydrated into the registry's plain
+        //    key cannot mask the packaged artifact's `_lock` envelope.
+        const artifactItem = this.lookupArtifactItem(type, name) as any;
+        if (artifactItem) {
             const p = extractProtection(artifactItem);
             if (p.lock !== 'none') {
                 return { lock: p.lock, lockReason: p.lockReason, lockSource: 'artifact' };
@@ -3299,6 +3318,54 @@ export class ObjectStackProtocolImplementation implements ObjectStackProtocol {
             console.warn(
                 `[Protocol] registerObject failed for ${request.name}: ${err?.message ?? err}`,
             );
+        }
+    }
+
+    /**
+     * Heal the in-memory registry after a metadata reset (overlay-row
+     * delete) on control-plane kernels. Two layers:
+     *
+     *  1. Drop the plain-key runtime shadow so the packaged artifact
+     *     (registered under `<packageId>:<name>`) becomes the visible
+     *     value again. The shadow is written by the overlay-hydration
+     *     paths (`getMetaItems` / `loadMetaFromDb`) and — pre-fix —
+     *     survived the reset until restart, leaving stale overlay
+     *     content (and a stripped `_lock` envelope) in every
+     *     registry-direct read (ADR-0010 §3.3).
+     *  2. When no composite-key artifact exists, fall back to the
+     *     MetadataService baseline (FilesystemLoader-sourced types) and
+     *     re-register it, preserving the historical refresh behaviour
+     *     for items the SchemaRegistry never held as artifacts.
+     *
+     * Best-effort: a failure must never block the delete that already
+     * succeeded; the next full reload fixes the registry anyway.
+     */
+    private async restoreArtifactRegistryView(type: string, name: string): Promise<void> {
+        try {
+            const registry: any = this.engine.registry;
+            let healed = false;
+            if (typeof registry.removeRuntimeShadow === 'function') {
+                const singular = PLURAL_TO_SINGULAR[type] ?? type;
+                healed = registry.removeRuntimeShadow(singular, name);
+                if (type !== singular) {
+                    healed = registry.removeRuntimeShadow(type, name) || healed;
+                }
+            }
+            if (healed) return;
+            // MetadataService re-registration is control-plane-only — it
+            // preserves the historical refresh semantics gated on
+            // `environmentId === undefined` at the original call sites.
+            if (this.environmentId !== undefined) return;
+            const services = this.getServicesRegistry?.();
+            const metadataService = services?.get('metadata');
+            if (metadataService && typeof metadataService.get === 'function') {
+                const artifactItem = await metadataService.get(type, name);
+                if (artifactItem !== undefined) {
+                    this.engine.registry.registerItem(type, artifactItem, 'name');
+                }
+            }
+        } catch {
+            // Best-effort registry refresh; next read fixes it anyway
         }
     }
 
@@ -4519,6 +4586,13 @@ export class ObjectStackProtocolImplementation implements ObjectStackProtocol {
                 // a conflict. The repo would otherwise throw ConflictError.
                 const current = await repo.get(ref, { state: targetState });
                 if (!current) {
+                    // Self-heal: even with no overlay row, a stale runtime
+                    // shadow may linger in the registry (e.g. pollution from
+                    // before this fix shipped) — drop it so the artifact
+                    // view really IS the default we claim below.
+                    if (targetState === 'active') {
+                        await this.restoreArtifactRegistryView(request.type, request.name);
+                    }
                     return {
                         success: true,
                         reset: false,
@@ -4545,22 +4619,14 @@ export class ObjectStackProtocolImplementation implements ObjectStackProtocol {
                     state: targetState,
                 });
 
-                // Refresh the in-memory artifact-side state on control-plane
-                // kernels (same logic as the legacy branch — see comments
-                // there for why this only runs when environmentId === undefined).
-                if (this.environmentId === undefined) {
-                    try {
-                        const services = this.getServicesRegistry?.();
-                        const metadataService = services?.get('metadata');
-                        if (metadataService && typeof metadataService.get === 'function') {
-                            const artifactItem = await metadataService.get(request.type, request.name);
-                            if (artifactItem !== undefined) {
-                                this.engine.registry.registerItem(request.type, artifactItem, 'name');
-                            }
-                        }
-                    } catch {
-                        // Best-effort registry refresh; next read fixes it anyway
-                    }
+                // Heal the registry: drop the overlay's runtime shadow so the
+                // packaged artifact is visible again (all kernels), and on
+                // control-plane kernels also refresh from MetadataService —
+                // see {@link restoreArtifactRegistryView}. Draft discards
+                // skip this: drafts never hydrate into the registry, and the
+                // still-active overlay (if any) must keep its shadow.
+                if (targetState === 'active') {
+                    await this.restoreArtifactRegistryView(request.type, request.name);
                 }
 
                 // Storage teardown (opt-in): drop the now-orphaned physical table
@@ -4637,19 +4703,8 @@ export class ObjectStackProtocolImplementation implements ObjectStackProtocol {
                 }
             }
 
-            if (this.environmentId === undefined) {
-                try {
-                    const services = this.getServicesRegistry?.();
-                    const metadataService = services?.get('metadata');
-                    if (metadataService && typeof metadataService.get === 'function') {
-                        const artifactItem = await metadataService.get(request.type, request.name);
-                        if (artifactItem !== undefined) {
-                            this.engine.registry.registerItem(request.type, artifactItem, 'name');
-                        }
-                    }
-                } catch {
-                    // Best-effort registry refresh; next read fixes it anyway
-                }
+            if (request.state !== 'draft') {
+                await this.restoreArtifactRegistryView(request.type, request.name);
             }
 
             return {
@@ -4696,7 +4751,18 @@ export class ObjectStackProtocolImplementation implements ObjectStackProtocol {
                     if (normalizedType === 'object') {
                         this.engine.registry.registerObject(data as any, record.packageId || 'sys_metadata');
                     } else {
-                        this.engine.registry.registerItem(normalizedType, data, 'name' as any);
+                        // Same envelope graft as the getMetaItems hydration:
+                        // the plain-key entry shadows any packaged artifact,
+                        // so carry the artifact's `_lock`/`_packageId`/
+                        // `_provenance` along (ADR-0010 §3.3). When artifacts
+                        // load after this hydration the merge finds nothing
+                        // and the row registers unchanged — same as before.
+                        const artifact = this.lookupArtifactItem(normalizedType, (data as any)?.name);
+                        this.engine.registry.registerItem(
+                            normalizedType,
+                            mergeArtifactProtection(data, artifact) as any,
+                            'name' as any,
+                        );
                     }
                     loaded++;
                 } catch (e) {

--- a/packages/objectql/src/registry.ts
+++ b/packages/objectql/src/registry.ts
@@ -830,6 +830,74 @@ export class SchemaRegistry {
   }
 
   /**
+   * Artifact-only lookup (ADR-0010 §3.3). Unlike {@link getItem} — which
+   * returns the plain-key entry first, so a runtime/DB-rehydrated row
+   * registered under the bare name SHADOWS the packaged artifact — this
+   * scans the composite (`<packageId>:<name>`) entries first and only
+   * returns an item whose `_packageId` marks a genuine code package
+   * (truthy and not the `'sys_metadata'` rehydration sentinel).
+   *
+   * This is what the protocol's lock/provenance resolution must use:
+   * the artifact's `_lock` envelope always wins over an overlay, and an
+   * overlay row hydrated into the plain key must never be able to mask
+   * it (that masking is exactly the "registry pollution" bug where a
+   * locked app's `_lock` read back as undefined after a PUT+GET).
+   */
+  getArtifactItem<T>(type: string, name: string): T | undefined {
+    if (type === 'object' || type === 'objects') {
+      const obj = this.getObject(name) as any;
+      return obj && obj._packageId && obj._packageId !== 'sys_metadata'
+        ? (obj as T)
+        : undefined;
+    }
+    const collection = this.metadata.get(type);
+    if (!collection) return undefined;
+    for (const [key, item] of collection) {
+      if (key !== name && key.endsWith(`:${name}`)) {
+        const it = item as any;
+        if (it && it._packageId && it._packageId !== 'sys_metadata') return item as T;
+      }
+    }
+    const direct = collection.get(name) as any;
+    if (direct && direct._packageId && direct._packageId !== 'sys_metadata') {
+      return direct as T;
+    }
+    return undefined;
+  }
+
+  /**
+   * Remove a plain-key runtime shadow so the packaged artifact registered
+   * under a composite key becomes the visible value again. Used by the
+   * metadata reset path (`deleteMetaItem`): deleting the `sys_metadata`
+   * overlay row must also heal the in-memory registry, otherwise the
+   * stale overlay copy keeps shadowing the artifact until restart.
+   *
+   * Deliberately conservative: the plain-key entry is only deleted when a
+   * packaged artifact still exists under a composite key, so the name
+   * stays resolvable afterwards. A runtime-only item (no artifact
+   * backing) is left untouched. Note the plain entry's own `_packageId`
+   * is NOT consulted — the hydration path grafts the artifact envelope
+   * onto the shadow (ADR-0010 §3.3), so a stamped `_packageId` does not
+   * mean the plain entry IS the artifact registration; artifact loaders
+   * always register under a composite key.
+   */
+  removeRuntimeShadow(type: string, name: string): boolean {
+    const collection = this.metadata.get(type);
+    if (!collection || !collection.has(name)) return false;
+    for (const [key, item] of collection) {
+      if (key !== name && key.endsWith(`:${name}`)) {
+        const it = item as any;
+        if (it && it._packageId && it._packageId !== 'sys_metadata') {
+          collection.delete(name);
+          this.log(`[Registry] Removed runtime shadow ${type}: ${name} (artifact ${it._packageId} restored)`);
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
    * Universal List Method
    */
   listItems<T>(type: string, packageId?: string): T[] {


### PR DESCRIPTION
## Problem

在无 `environmentId` 的本地栈（control-plane kernel）复现的元数据状态污染：

1. 对带 `_lock: full` 的 artifact-backed app 执行 `PUT /api/v1/meta/app/setup`（锁门禁在 control-plane 被设计性跳过，写入成功）；
2. overlay 行存在期间的任意 `GET /api/v1/meta/app` 会把 overlay body 以**无 packageId** 的 `registerItem` 水合进 SchemaRegistry 的 plain key，shadow 掉 composite key（`<packageId>:<name>`）下的 artifact；
3. `lookupArtifactItem` / `getEffectiveLock` / `isArtifactBacked` 都经 `registry.getItem`（plain key 优先命中）拿到被剥光 envelope 的 overlay body → GET 返回 `_lock: undefined`，违反 ADR-0010 §3.3（overlay 不得放松 packaged lock）；
4. `DELETE`（reset）只删 DB 行，恢复块查 `metadataService.get` 落空 → 污染的 shadow 残留到服务重启。

## Fix（三层）

- **`SchemaRegistry.getArtifactItem()`** — 穿透 shadow 的 artifact 专用查找：优先扫 composite key、要求真实 `_packageId`（排除 `'sys_metadata'` 哨兵）。protocol 的全部 envelope 读取点（`lookupArtifactItem` / `getEffectiveLock` / `isArtifactBacked` / `getMetaItemLayered` code 层）改用，锁解析从此对 shadow 免疫。
- **水合保留 envelope** — `getMetaItems` / `loadMetaFromDb` 注册 shadow 前先 `mergeArtifactProtection` 把 artifact 的 `_lock`/`_packageId`/`_provenance` 嫁接到 overlay body：内容字段 overlay win，保护信封 artifact win。
- **`SchemaRegistry.removeRuntimeShadow()` + `restoreArtifactRegistryView()`** — reset 删除 plain-key shadow，artifact 视图立即恢复（无需重启）；no-op 二次 DELETE 可自愈历史污染；draft 丢弃不清 shadow（active overlay 可能仍在）。

## Verification

- 新增 `protocol-registry-shadow.test.ts`（8 用例）：PUT→GET→DELETE 全链路 envelope 保持、reset 自愈、scoped kernel 在 registry 已被污染时 `403 item_locked` 仍生效、两个新 registry 方法的单元行为。
- objectql 全套 569 测试通过，`tsc --noEmit` 干净。
- showcase 实机端到端（OS_PORT=3700）：PUT → GET（overlay 存在）→ DELETE → GET，`_lock: full` / `_packageId` / `_provenance` 全程保持；单条 GET 信封 `editable/deletable: false` 正确。

🤖 Generated with [Claude Code](https://claude.com/claude-code)