### PR TITLE
feat(cloud-connection): runtime-identity bind v2 — environment-less self-hosted binding

### DIFF
--- a/.changeset/runtime-identity-claim.md
+++ b/.changeset/runtime-identity-claim.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/cloud-connection": minor
+---
+
+Runtime-identity bind v2 (cloud ADR runtime-identity-binding): a self-hosted runtime binds like a device — no environment id required. `bind/start`/`bind/poll` work environment-less in `singleEnvironment` mode; the bind call carries a registration claim (`hostname`, `runtime_version`, and the stored `runtime_id` on re-bind) and the store persists the cloud-minted `runtime_id` (durable identity, stable across token rotations). `status` reports `runtimeId` and treats "no env id" as unbound rather than 404; `unbind` revokes bearer-first with no environment requirement; `org-packages` forwards bearer-only when no environment is configured (the connection carries the org); `installation`/`installed` degrade gracefully for registration-only runtimes. `StoredConnectionCredential.environmentId` is now optional (`runtimeId` added).

--- a/packages/cloud-connection/src/cloud-connection-plugin.test.ts
+++ b/packages/cloud-connection/src/cloud-connection-plugin.test.ts
@@ -118,7 +118,7 @@ describe('multi-tenant mode (env-registry + per-env kernel auth)', () => {
         await new CloudConnectionPlugin({ controlPlaneUrl: 'http://cloud.test', controlPlaneApiKey: 'svc-key' }).start(ctx as any);
         await fireKernelReady();
         const res = await rawApp.routes.get('GET /api/v1/cloud-connection/status')!(makeC('https://t1.example.com/api/v1/cloud-connection/status'));
-        expect(res.payload).toEqual({ success: true, data: { environmentId: ENV, bound: true, provider: 'objectstack-cloud', connection: null } });
+        expect(res.payload).toEqual({ success: true, data: { environmentId: ENV, runtimeId: null, bound: true, provider: 'objectstack-cloud', connection: null } });
     });
 
     it('status 404s for an unknown hostname', async () => {
@@ -200,7 +200,7 @@ describe('single-environment mode (host auth, fixed env id)', () => {
         await fireKernelReady();
         const res = await rawApp.routes.get('GET /api/v1/cloud-connection/status')!(makeC('http://localhost:3000/x'));
         expect(res.status).toBe(200);
-        expect(res.payload.data).toEqual({ environmentId: null, bound: false, provider: 'objectstack-cloud', connection: null });
+        expect(res.payload.data).toEqual({ environmentId: null, runtimeId: null, bound: false, provider: 'objectstack-cloud', connection: null });
     });
 
     it('uses the configured environment id + the host kernel auth session', async () => {

--- a/packages/cloud-connection/src/cloud-connection-plugin.ts
+++ b/packages/cloud-connection/src/cloud-connection-plugin.ts
@@ -67,6 +67,7 @@ interface Plugin {
     start(ctx: PluginContext): Promise<void>;
 }
 
+import { hostname } from 'node:os';
 import { ConnectionCredentialStore } from './connection-credential-store.js';
 import { CLOUD_CONNECTION_UI_BUNDLE } from './cloud-connection-ui.js';
 
@@ -101,7 +102,7 @@ export interface CloudConnectionPluginConfig {
 
 export class CloudConnectionPlugin implements Plugin {
     readonly name = 'com.objectstack.cloud.connection';
-    readonly version = '0.2.0';
+    readonly version = '0.3.0';
 
     private readonly cfg: CloudConnectionPluginConfig;
     private readonly store: ConnectionCredentialStore;
@@ -199,35 +200,46 @@ export class CloudConnectionPlugin implements Plugin {
                 }
             };
 
-            // GET /status — is this env bound to a cloud account?
+            // GET /status — is this runtime bound to a cloud account?
             rawApp.get(`${CLOUD_CONNECTION_PREFIX}/status`, async (c: any) => {
                 const environmentId = await resolveEnvironmentId(c);
-                if (!environmentId) {
-                    // Single-env runtimes are valid before they are bound —
-                    // report unbound instead of failing the Setup page.
-                    if (this.cfg.singleEnvironment) {
-                        return c.json({ success: true, data: { environmentId: null, bound: false, provider: 'objectstack-cloud', connection: null } });
-                    }
+                const stored = this.store.read();
+                const runtimeId = stored?.runtimeId;
+                if (!environmentId && !this.cfg.singleEnvironment) {
                     return c.json({ success: false, error: { code: 'environment_not_found' } }, 404);
                 }
-                // Prefer the real, device-bound sys_cloud_connection from the
-                // control plane. Fall back to the implicit local binding
-                // (service key or stored runtime bearer) when unreachable.
+                // A single-env runtime with no env id and no credential is
+                // simply not bound yet — valid state, not an error.
+                if (!environmentId && !credential()) {
+                    return c.json({ success: true, data: { environmentId: null, runtimeId: runtimeId ?? null, bound: false, provider: 'objectstack-cloud', connection: null } });
+                }
+                // Prefer the real sys_cloud_connection from the control plane.
+                // The oscc_ bearer self-identifies; service-key callers query
+                // by environment_id (cloud-hosted) or runtime_id (claim).
                 if (cloudUrl) {
                     try {
-                        const resp = await fetch(`${cloudUrl}/api/v1/cloud-connection/status?environment_id=${encodeURIComponent(environmentId)}`, {
+                        const qs = environmentId
+                            ? `?environment_id=${encodeURIComponent(environmentId)}`
+                            : runtimeId ? `?runtime_id=${encodeURIComponent(runtimeId)}` : '';
+                        const resp = await fetch(`${cloudUrl}/api/v1/cloud-connection/status${qs}`, {
                             headers: authHeaders(),
                         });
                         if (resp.ok) {
                             const json: any = await resp.json().catch(() => null);
                             const data = json?.data ?? {};
                             const bound = Boolean(data.bound) || Boolean(credential());
-                            return c.json({ success: true, data: { environmentId, bound, provider: 'objectstack-cloud', connection: data.connection ?? null } });
+                            return c.json({ success: true, data: {
+                                environmentId: environmentId ?? null,
+                                runtimeId: data.runtime_id ?? runtimeId ?? null,
+                                bound,
+                                provider: 'objectstack-cloud',
+                                connection: data.connection ?? null,
+                            } });
                         }
                     } catch { /* fall through to implicit */ }
                 }
                 const bound = Boolean(credential());
-                return c.json({ success: true, data: { environmentId, bound, provider: 'objectstack-cloud', connection: null } });
+                return c.json({ success: true, data: { environmentId: environmentId ?? null, runtimeId: runtimeId ?? null, bound, provider: 'objectstack-cloud', connection: null } });
             });
 
             // POST /bind/start — begin a device-code bind. The runtime is the
@@ -237,15 +249,18 @@ export class CloudConnectionPlugin implements Plugin {
             rawApp.post(`${CLOUD_CONNECTION_PREFIX}/bind/start`, async (c: any) => {
                 let body: any = {};
                 try { body = await c.req.json(); } catch { body = {}; }
-                // Single-env runtimes that have never bound have no env id yet:
-                // the Setup UI passes the target environment id explicitly (the
-                // operator copies it from the cloud console).
+                // Self-hosted (single-env) runtimes need NO environment id —
+                // registration happens cloud-side at approval (ADR
+                // runtime-identity-binding). An explicit environment_id in the
+                // body is still honored for cloud-hosted-style binds.
                 let environmentId = await resolveEnvironmentId(c);
                 if (!environmentId && this.cfg.singleEnvironment) {
                     environmentId = String(body?.environment_id ?? body?.environmentId ?? '').trim() || undefined;
                 }
-                if (!environmentId) return c.json({ success: false, error: { code: 'environment_not_found', message: 'Provide environment_id (create an environment in the cloud console and paste its id).' } }, 404);
-                const session = await resolveSession(environmentId, c.req.raw);
+                if (!environmentId && !this.cfg.singleEnvironment) {
+                    return c.json({ success: false, error: { code: 'environment_not_found' } }, 404);
+                }
+                const session = await resolveSession(environmentId ?? '', c.req.raw);
                 if (!session?.userId) return c.json({ success: false, error: { code: 'unauthenticated', message: 'Sign in to this environment to connect a cloud account.' } }, 401);
                 if (!cloudUrl) return c.json({ success: false, error: { code: 'cloud_unconfigured', message: 'No cloud control plane configured.' } }, 503);
                 try {
@@ -281,8 +296,10 @@ export class CloudConnectionPlugin implements Plugin {
                 if (!environmentId && this.cfg.singleEnvironment) {
                     environmentId = String(body?.environment_id ?? body?.environmentId ?? '').trim() || undefined;
                 }
-                if (!environmentId) return c.json({ success: false, error: { code: 'environment_not_found' } }, 404);
-                const session = await resolveSession(environmentId, c.req.raw);
+                if (!environmentId && !this.cfg.singleEnvironment) {
+                    return c.json({ success: false, error: { code: 'environment_not_found' } }, 404);
+                }
+                const session = await resolveSession(environmentId ?? '', c.req.raw);
                 if (!session?.userId) return c.json({ success: false, error: { code: 'unauthenticated' } }, 401);
                 if (!cloudUrl) return c.json({ success: false, error: { code: 'cloud_unconfigured' } }, 503);
 
@@ -304,12 +321,23 @@ export class CloudConnectionPlugin implements Plugin {
                         const pending = errCode === 'authorization_pending' || errCode === 'slow_down';
                         return c.json({ success: pending, data: { pending }, error: pending ? undefined : { code: errCode } }, pending ? 200 : 400);
                     }
-                    // Persist the binding through the control plane (it validates
-                    // the token + authorizes the operator for the env's org).
+                    // Persist the binding through the control plane. The
+                    // registration claim rides along (ADR
+                    // runtime-identity-binding §2.3): hostname + version name
+                    // the device; a stored runtime_id keeps the identity
+                    // stable across re-binds (claim verified cloud-side).
+                    const stored = this.store.read();
                     const bindResp = await fetch(`${cloudUrl}/api/v1/cloud-connection/bind`, {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json', ...(cloudApiKey ? { Authorization: `Bearer ${cloudApiKey}` } : {}) },
-                        body: JSON.stringify({ environment_id: environmentId, token: accessToken, scope: deviceScope }),
+                        body: JSON.stringify({
+                            ...(environmentId ? { environment_id: environmentId } : {}),
+                            ...(stored?.runtimeId ? { runtime_id: stored.runtimeId } : {}),
+                            name: (() => { try { return hostname(); } catch { return undefined; } })(),
+                            runtime_version: (process.env.OS_RUNTIME_VERSION ?? this.version) || undefined,
+                            token: accessToken,
+                            scope: deviceScope,
+                        }),
                     });
                     const bindJson: any = await bindResp.json().catch(() => ({ success: false, error: 'bind failed (no body)' }));
                     // The bind response carries the one-time runtime bearer.
@@ -321,7 +349,8 @@ export class CloudConnectionPlugin implements Plugin {
                         try {
                             this.store.write({
                                 runtimeToken,
-                                environmentId,
+                                runtimeId: bindJson?.data?.runtime_id ?? bindJson?.data?.connection?.runtime_id ?? undefined,
+                                environmentId: environmentId || undefined,
                                 controlPlaneUrl: cloudUrl,
                                 organizationId: bindJson?.data?.connection?.organization_id ?? undefined,
                                 accountEmail: bindJson?.data?.connection?.account_email ?? undefined,
@@ -345,23 +374,29 @@ export class CloudConnectionPlugin implements Plugin {
             // bind/start.
             rawApp.post(`${CLOUD_CONNECTION_PREFIX}/unbind`, async (c: any) => {
                 const environmentId = await resolveEnvironmentId(c);
-                if (!environmentId) return c.json({ success: false, error: { code: 'environment_not_found' } }, 404);
-                const session = await resolveSession(environmentId, c.req.raw);
+                if (!environmentId && !this.cfg.singleEnvironment) {
+                    return c.json({ success: false, error: { code: 'environment_not_found' } }, 404);
+                }
+                const session = await resolveSession(environmentId ?? '', c.req.raw);
                 if (!session?.userId) return c.json({ success: false, error: { code: 'unauthenticated' } }, 401);
 
+                // Revoke cloud-side FIRST (the oscc_ bearer self-identifies;
+                // env-keyed bindings name the environment), then clear the
+                // local credential regardless — a device signing out must not
+                // leave a live token behind when the control plane is up.
                 let revoked = false;
                 if (cloudUrl && credential()) {
                     try {
                         const resp = await fetch(`${cloudUrl}/api/v1/cloud-connection/revoke`, {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json', ...authHeaders() },
-                            body: JSON.stringify({ environment_id: environmentId }),
+                            body: JSON.stringify(environmentId ? { environment_id: environmentId } : {}),
                         });
                         revoked = resp.ok;
                     } catch { /* control plane unreachable — local clear still proceeds */ }
                 }
                 const cleared = (() => { try { return this.store.clear(); } catch { return false; } })();
-                return c.json({ success: true, data: { environmentId, revoked, cleared } });
+                return c.json({ success: true, data: { environmentId: environmentId ?? null, revoked, cleared } });
             });
 
             // POST /install { package_id, seed_sample_data? } — in-environment
@@ -418,7 +453,13 @@ export class CloudConnectionPlugin implements Plugin {
             // case it offers an install the control plane upserts idempotently).
             rawApp.get(`${CLOUD_CONNECTION_PREFIX}/installation`, async (c: any) => {
                 const environmentId = await resolveEnvironmentId(c);
-                if (!environmentId) return c.json({ success: false, error: { code: 'environment_not_found' } }, 404);
+                if (!environmentId) {
+                    // Self-hosted v2: cloud-side installation records are
+                    // env-scoped; a registration-only runtime tracks installs
+                    // locally (LocalManifestSource). Report not-installed.
+                    if (this.cfg.singleEnvironment) return c.json({ success: true, data: { installed: false } });
+                    return c.json({ success: false, error: { code: 'environment_not_found' } }, 404);
+                }
 
                 const session = await resolveSession(environmentId, c.req.raw);
                 if (!session?.userId) {
@@ -473,7 +514,14 @@ export class CloudConnectionPlugin implements Plugin {
             // unreachable (never hard-fails the page).
             rawApp.get(`${CLOUD_CONNECTION_PREFIX}/installed`, async (c: any) => {
                 const environmentId = await resolveEnvironmentId(c);
-                if (!environmentId) return c.json({ success: false, error: { code: 'environment_not_found' } }, 404);
+                if (!environmentId) {
+                    // Self-hosted v2: no env-scoped cloud install ledger —
+                    // the Installed view is fed by the local manifest ledger.
+                    if (this.cfg.singleEnvironment) {
+                        return c.json({ success: true, data: { packages: [], total: 0, connected: Boolean(credential()) } });
+                    }
+                    return c.json({ success: false, error: { code: 'environment_not_found' } }, 404);
+                }
 
                 const session = await resolveSession(environmentId, c.req.raw);
                 if (!session?.userId) {
@@ -508,9 +556,11 @@ export class CloudConnectionPlugin implements Plugin {
             // which derives the org from environment_id.
             rawApp.get(`${CLOUD_CONNECTION_PREFIX}/org-packages`, async (c: any) => {
                 const environmentId = await resolveEnvironmentId(c);
-                if (!environmentId) return c.json({ success: false, error: { code: 'environment_not_found' } }, 404);
+                if (!environmentId && !this.cfg.singleEnvironment) {
+                    return c.json({ success: false, error: { code: 'environment_not_found' } }, 404);
+                }
 
-                const session = await resolveSession(environmentId, c.req.raw);
+                const session = await resolveSession(environmentId ?? '', c.req.raw);
                 if (!session?.userId) {
                     return c.json({ success: false, error: { code: 'unauthenticated', message: 'Sign in to this environment.' } }, 401);
                 }
@@ -520,8 +570,11 @@ export class CloudConnectionPlugin implements Plugin {
                 }
 
                 try {
+                    // env-keyed callers pass environment_id; a registration-only
+                    // runtime's oscc_ bearer carries the org by itself.
+                    const qs = environmentId ? `?environment_id=${encodeURIComponent(environmentId)}` : '';
                     const resp = await fetch(
-                        `${cloudUrl}/api/v1/cloud/org-packages?environment_id=${encodeURIComponent(environmentId)}`,
+                        `${cloudUrl}/api/v1/cloud/org-packages${qs}`,
                         { headers: { Accept: 'application/json', ...authHeaders() } },
                     );
                     if (!resp.ok) return c.json({ success: true, data: { items: [], total: 0, connected: true } });

--- a/packages/cloud-connection/src/connection-credential-store.test.ts
+++ b/packages/cloud-connection/src/connection-credential-store.test.ts
@@ -150,6 +150,106 @@ describe('CloudConnectionPlugin credential behavior', () => {
         expect(store.read()).toBeNull();
     });
 
+    it('bind/poll sends the registration claim (hostname/version/stored runtime_id), omits environment_id, persists runtime_id', async () => {
+        const credPath = join(dir, 'cc.json');
+        // Simulate a prior v2 bind: identity exists, bearer will rotate.
+        new ConnectionCredentialStore(credPath).write({ runtimeToken: 'oscc_old', runtimeId: 'rt-1' });
+        const rawApp = makeRawApp();
+        const { ctx, fire } = makeCtx(rawApp, { auth: sessionAuth('admin'), manifest: { register: vi.fn() } });
+        let bindBody: any = null;
+        vi.stubGlobal('fetch', vi.fn(async (url: any, init: any) => {
+            const u = String(url);
+            if (u.includes('/auth/device/token')) {
+                return new Response(JSON.stringify({ access_token: 'op-token' }), { status: 200 });
+            }
+            if (u.includes('/cloud-connection/bind')) {
+                bindBody = JSON.parse(init.body);
+                return new Response(JSON.stringify({ success: true, data: { bound: true, runtime_id: 'rt-1', connection: { organization_id: 'org_x', runtime_id: 'rt-1' }, runtime_token: 'oscc_new' } }), { status: 200 });
+            }
+            throw new Error(`unexpected fetch ${u}`);
+        }));
+        await new CloudConnectionPlugin({
+            singleEnvironment: true, controlPlaneUrl: 'http://cloud.test', credentialPath: credPath,
+        }).start(ctx as any);
+        await fire();
+
+        const res = await rawApp.routes.get('POST /api/v1/cloud-connection/bind/poll')!(
+            makeC('http://localhost:3000/x', { device_code: 'dc' }),
+        );
+        expect(res.payload.success).toBe(true);
+        // The claim: identity + device context, NO environment.
+        expect(bindBody.environment_id).toBeUndefined();
+        expect(bindBody.runtime_id).toBe('rt-1');
+        expect(typeof bindBody.name).toBe('string');
+        expect(bindBody.name.length).toBeGreaterThan(0);
+        expect(typeof bindBody.runtime_version).toBe('string');
+        expect(bindBody.token).toBe('op-token');
+        // Identity survives, bearer rotated, no phantom env persisted.
+        const stored = new ConnectionCredentialStore(credPath).read();
+        expect(stored?.runtimeId).toBe('rt-1');
+        expect(stored?.runtimeToken).toBe('oscc_new');
+        expect(stored?.environmentId).toBeUndefined();
+    });
+
+    it('bind/start works without an environment id in single-environment mode', async () => {
+        const rawApp = makeRawApp();
+        const { ctx, fire } = makeCtx(rawApp, { auth: sessionAuth('admin'), manifest: { register: vi.fn() } });
+        vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+            device_code: 'dc', user_code: 'ABCD-EFGH', verification_uri: 'http://cloud.test/_console/auth/device',
+            verification_uri_complete: 'http://cloud.test/_console/auth/device?user_code=ABCD-EFGH', interval: 5, expires_in: 600,
+        }), { status: 200 })));
+        await new CloudConnectionPlugin({
+            singleEnvironment: true, controlPlaneUrl: 'http://cloud.test', credentialPath: join(dir, 'cc.json'),
+        }).start(ctx as any);
+        await fire();
+
+        const res = await rawApp.routes.get('POST /api/v1/cloud-connection/bind/start')!(
+            makeC('http://localhost:3000/x', {}),
+        );
+        expect(res.status).toBe(200);
+        expect(res.payload.data.user_code).toBe('ABCD-EFGH');
+    });
+
+    it('unbind without an environment id revokes via the bearer (empty body) and clears the store', async () => {
+        const credPath = join(dir, 'cc.json');
+        const store = new ConnectionCredentialStore(credPath);
+        store.write({ runtimeToken: 'oscc_stored', runtimeId: 'rt-1' });
+        const rawApp = makeRawApp();
+        const { ctx, fire } = makeCtx(rawApp, { auth: sessionAuth('admin'), manifest: { register: vi.fn() } });
+        const fetchSpy = vi.fn(async () => new Response(JSON.stringify({ success: true }), { status: 200 }));
+        vi.stubGlobal('fetch', fetchSpy);
+        await new CloudConnectionPlugin({
+            singleEnvironment: true, controlPlaneUrl: 'http://cloud.test', controlPlaneApiKey: '', credentialPath: credPath,
+        }).start(ctx as any);
+        await fire();
+
+        const res = await rawApp.routes.get('POST /api/v1/cloud-connection/unbind')!(makeC('http://localhost:3000/x'));
+        expect(res.payload.data).toEqual({ environmentId: null, revoked: true, cleared: true });
+        expect((fetchSpy.mock.calls[0]![1] as any).body).toBe('{}');
+        expect((fetchSpy.mock.calls[0]![1] as any).headers.Authorization).toBe('Bearer oscc_stored');
+        expect(store.read()).toBeNull();
+    });
+
+    it('org-packages without an environment id forwards bearer-only (org from the connection)', async () => {
+        const credPath = join(dir, 'cc.json');
+        new ConnectionCredentialStore(credPath).write({ runtimeToken: 'oscc_stored', runtimeId: 'rt-1' });
+        const rawApp = makeRawApp();
+        const { ctx, fire } = makeCtx(rawApp, { auth: sessionAuth('admin'), manifest: { register: vi.fn() } });
+        const fetchSpy = vi.fn(async () => new Response(JSON.stringify({ success: true, data: { items: [{ id: 'p1' }] } }), { status: 200 }));
+        vi.stubGlobal('fetch', fetchSpy);
+        await new CloudConnectionPlugin({
+            singleEnvironment: true, controlPlaneUrl: 'http://cloud.test', controlPlaneApiKey: '', credentialPath: credPath,
+        }).start(ctx as any);
+        await fire();
+
+        const res = await rawApp.routes.get('GET /api/v1/cloud-connection/org-packages')!(
+            makeC('http://localhost:3000/api/v1/cloud-connection/org-packages'),
+        );
+        expect(res.payload.data.total).toBe(1);
+        expect(String(fetchSpy.mock.calls[0]![0])).toBe('http://cloud.test/api/v1/cloud/org-packages');
+        expect((fetchSpy.mock.calls[0]![1] as any).headers.Authorization).toBe('Bearer oscc_stored');
+    });
+
     it('registers the SDUI bundle (page + nav) with the manifest service', async () => {
         const register = vi.fn();
         const rawApp = makeRawApp();

--- a/packages/cloud-connection/src/connection-credential-store.ts
+++ b/packages/cloud-connection/src/connection-credential-store.ts
@@ -29,8 +29,17 @@ import { dirname, resolve } from 'node:path';
 export interface StoredConnectionCredential {
     /** The `oscc_…` runtime bearer returned ONCE by the bind route. */
     runtimeToken: string;
-    /** Control-plane environment id this runtime is bound as. */
-    environmentId: string;
+    /**
+     * Cloud-minted durable runtime identity (ADR runtime-identity-binding).
+     * Presented as a claim on re-bind so the registration survives token
+     * rotation. Absent on stores written before v2.
+     */
+    runtimeId?: string;
+    /**
+     * Control-plane environment id — set only when the binding targeted a
+     * cloud-hosted environment. Self-hosted v2 registrations have none.
+     */
+    environmentId?: string;
     /** Control-plane base URL the binding was made against. */
     controlPlaneUrl?: string;
     organizationId?: string;
@@ -57,7 +66,6 @@ export class ConnectionCredentialStore {
         try {
             const parsed = JSON.parse(readFileSync(this.path, 'utf8'));
             if (!parsed || typeof parsed.runtimeToken !== 'string' || !parsed.runtimeToken) return null;
-            if (typeof parsed.environmentId !== 'string' || !parsed.environmentId) return null;
             return parsed as StoredConnectionCredential;
         } catch {
             return null;


### PR DESCRIPTION
## Summary

Framework counterpart of [cloud ADR runtime-identity-binding](https://github.com/objectstack-ai/cloud/blob/main/docs/design/runtime-identity-binding.md) + [cloud#264](https://github.com/objectstack-ai/cloud/pull/264): a self-hosted runtime binds to the control plane like a device binding to an account.

- **No environment id anywhere in the self-hosted flow**: `bind/start`/`bind/poll` work environment-less in `singleEnvironment` mode (the registration row is created cloud-side at approval). The Setup-page "create an environment in the cloud console and paste its id" dead-end is gone.
- **Registration claim**: the bind call carries `hostname` + `runtime_version` (names the device on the approval surface / runtimes list) and the stored `runtime_id` on re-bind — identity survives token rotation; the claim is verified cloud-side (org match) against squatting.
- **Store**: persists the cloud-minted `runtime_id`; `environmentId` optional (cloud-hosted binds only).
- **status**: reports `runtimeId`; an env-less single-env runtime reads as unbound (200) instead of 404.
- **unbind**: env-optional; revokes via the `oscc_` bearer (it self-identifies) before clearing the local credential.
- **org-packages**: bearer-only forward when no env — the cloud derives the org from the connection (existing behavior). `installation`/`installed` degrade gracefully for registration-only runtimes (local installs are tracked by LocalManifestSource).

## Tests
- +4 cases (claim contents + runtime_id persistence; env-less bind/start; bearer-only unbind; bearer-only org-packages); 2 status-shape assertions updated
- @objectstack/cloud-connection 40/40, build + dts clean

Consumed by the cloud repo via SHA pin bump after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)