### PR TITLE
fix(cloud-connection): never present env_local/proj_local as cloud environment ids

### DIFF
--- a/.changeset/local-env-sentinel.md
+++ b/.changeset/local-env-sentinel.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/cloud-connection": patch
+---
+
+`resolveEnvironmentId` no longer presents the CLI's local-dev sentinel ids (`env_local` / `proj_local`) to the control plane as cloud environment ids — they identify the local kernel only. A single-environment runtime started via `objectstack dev` now reads as cleanly unbound and binds environment-less (ADR runtime-identity-binding), instead of 404-ing the bind against a non-existent cloud environment.

--- a/packages/cloud-connection/src/cloud-connection-plugin.test.ts
+++ b/packages/cloud-connection/src/cloud-connection-plugin.test.ts
@@ -220,6 +220,19 @@ describe('single-environment mode (host auth, fixed env id)', () => {
         expect(res.payload.data.total).toBe(1);
     });
 
+    it("ignores the CLI's local sentinel env ids (env_local / proj_local)", async () => {
+        process.env.OS_ENVIRONMENT_ID = 'env_local';
+        const rawApp = makeRawApp();
+        const { ctx, fireKernelReady } = makeCtx({ rawApp });
+        await new CloudConnectionPlugin({ singleEnvironment: true, controlPlaneUrl: 'http://cloud.test' }).start(ctx as any);
+        await fireKernelReady();
+        const res = await rawApp.routes.get('GET /api/v1/cloud-connection/status')!(makeC('http://localhost:3000/x'));
+        expect(res.status).toBe(200);
+        // Treated as "no cloud environment", not presented to the control plane.
+        expect(res.payload.data.environmentId).toBeNull();
+        expect(res.payload.data.bound).toBe(false);
+    });
+
     it('falls back to OS_ENVIRONMENT_ID when no config id is given', async () => {
         process.env.OS_ENVIRONMENT_ID = 'env-from-env-var';
         const rawApp = makeRawApp();

--- a/packages/cloud-connection/src/cloud-connection-plugin.ts
+++ b/packages/cloud-connection/src/cloud-connection-plugin.ts
@@ -147,7 +147,12 @@ export class CloudConnectionPlugin implements Plugin {
 
             const resolveEnvironmentId = async (c: any): Promise<string | undefined> => {
                 const fixed = (this.cfg.environmentId ?? process.env.OS_ENVIRONMENT_ID ?? '').trim();
-                if (fixed) return fixed;
+                // The CLI's local-dev defaults ('env_local' / 'proj_local')
+                // identify the LOCAL kernel, not a cloud environment — never
+                // present them to the control plane as one (they would 404
+                // the bind and resurrect the phantom-environment confusion
+                // ADR runtime-identity-binding removes).
+                if (fixed && fixed !== 'env_local' && fixed !== 'proj_local') return fixed;
                 if (this.cfg.singleEnvironment) {
                     // A completed bind persisted the environment id — a
                     // self-hosted runtime needs no OS_ENVIRONMENT_ID after it.


### PR DESCRIPTION
Found during the runtime-identity-binding E2E: `objectstack dev` exports `OS_ENVIRONMENT_ID=env_local` (a local-kernel identifier), which the cloud-connection plugin treated as a cloud environment id — the bind then 404s against a non-existent env, resurrecting exactly the phantom-environment confusion the ADR removes. Filter the two CLI sentinels in `resolveEnvironmentId`; such runtimes read as cleanly unbound and bind environment-less.

+1 test; 41/41 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)