### PR TITLE
feat(spec): ActionSchema — opensInNewTab + newTabUrl zero-roundtrip new-tab contract

### DIFF
--- a/packages/spec/src/ui/action.zod.ts
+++ b/packages/spec/src/ui/action.zod.ts
@@ -421,6 +421,25 @@ export const ActionSchema = lazySchema(() => z.object({
    */
   mode: z.enum(['create', 'edit', 'delete', 'custom']).optional().describe('Semantic mode of the action.'),
 
+  /**
+   * Open the action's result in a NEW TAB. The renderer pre-opens the tab
+   * synchronously on click (preserving the user gesture so popup blockers
+   * don't fire), paints a progress page, then drives the tab to the
+   * handler's returned `redirectUrl` — or, when `newTabUrl` is set, straight
+   * to that URL with no server round trip.
+   */
+  opensInNewTab: z.boolean().optional().describe('Open the action result in a new tab. The renderer pre-opens the tab synchronously on click (popup-blocker-safe) and navigates it to the handler\'s redirectUrl.'),
+
+  /**
+   * Zero-roundtrip new-tab target. A path template the renderer navigates
+   * the pre-opened tab to IMMEDIATELY on click, skipping the action POST
+   * entirely. Only valid together with `opensInNewTab`. The target endpoint
+   * MUST perform all auth/authz itself (e.g. the cloud `/sso-open` endpoint,
+   * which re-runs every check the POST half would have done). Supports the
+   * `{recordId}` placeholder, URL-encoded on substitution.
+   */
+  newTabUrl: z.string().optional().describe('Direct new-tab URL template ({recordId} placeholder). When set with opensInNewTab, the renderer navigates the pre-opened tab here immediately — no action POST. The endpoint must enforce auth itself.'),
+
   /** Execution */
   timeout: z.number().optional().describe('Maximum execution time in milliseconds for the action'),
 


### PR DESCRIPTION
## Summary
- Add `opensInNewTab` (documents the existing renderer convention: pre-open the tab synchronously on click, popup-blocker-safe, then drive it to the handler's `redirectUrl`) to `ActionSchema`
- Add `newTabUrl`: a direct new-tab URL template (`{recordId}` placeholder). When set together with `opensInNewTab`, the renderer navigates the pre-opened tab to it **immediately on click — no action POST**. The target endpoint must perform all auth/authz itself.

## Motivation
The cloud console's environment **Open** button felt laggy: the click paid a full POST round trip before the popup started navigating, even though `GET /sso-open` re-runs every check server-side (defense in depth). This contract lets metadata declare the zero-roundtrip path. Renderer support: objectui PR (app-shell fast path); first consumer: cloud `sys_environment.sso_as_owner`.

## Test plan
- `pnpm --filter @objectstack/spec build` ✓
- `pnpm --filter @objectstack/spec test` — 240 files / 6529 tests ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)