### PR TITLE
feat(ai/settings): surface, reject, and recover AI provider misconfiguration

### DIFF
--- a/.changeset/ai-settings-diagnostics.md
+++ b/.changeset/ai-settings-diagnostics.md
@@ -1,0 +1,11 @@
+---
+"@objectstack/service-ai": minor
+"@objectstack/service-settings": minor
+---
+
+AI provider misconfiguration is now visible, rejected at save time, and recoverable from the UI. Background: a half-saved `ai` settings row (provider=cloudflare, empty key) silently overrode env auto-detection and the only symptom was a bare "Bad Request" in chat.
+
+- `GET /api/v1/ai/status` — active adapter provenance: `source` (explicit/env/settings/fallback), provider, model, plus `settingsError` explaining why saved settings were NOT applied. `AIServicePlugin` tracks this through boot detection, settings rebuilds, and resets.
+- Save-time validation in `SettingsService.setMany` (fulfilling the spec promise that `required` is enforced server-side): visible+required fields and `pattern` mismatches reject the whole batch with field-level errors (`400 SETTINGS_VALIDATION`). Visibility expressions (`${data.provider === '…'}`) are evaluated server-side by a restricted-grammar parser; unparseable expressions and all-null patches (resets) stay lenient. `gateway_model` / `cloudflare_model` gain `provider/model` patterns.
+- Built-in `reset` settings action for every namespace (`SettingsService.resetNamespace`), overridden for `ai` to also re-run env adapter detection immediately; the AI manifest ships a "Reset to environment defaults" button — no more hand-editing `sys_setting`.
+- Chat/agent/assistant stream errors are enriched with the active adapter description and actionable hints (400 → model-id format, 401/403 → credential, 404 → unknown model, 429 → rate limit) instead of a bare HTTP status.

--- a/packages/services/service-ai/src/__tests__/adapter-status.test.ts
+++ b/packages/services/service-ai/src/__tests__/adapter-status.test.ts
@@ -1,0 +1,260 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// Adapter provenance — `GET /api/v1/ai/status` and the settings-apply
+// status tracking on AIServicePlugin. Persisted settings silently override
+// env auto-detection, so the plugin must expose WHICH config is live and
+// WHY a saved config was not applied (broken settings used to be
+// indistinguishable from working ones).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AIServicePlugin } from '../plugin.js';
+import { AIService } from '../ai-service.js';
+import { buildAIRoutes } from '../routes/ai-routes.js';
+import { InMemoryConversationService } from '../conversation/in-memory-conversation-service.js';
+import { MemoryLLMAdapter } from '../adapters/memory-adapter.js';
+import type { Logger } from '@objectstack/spec/contracts';
+
+const silentLogger: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+};
+
+function createMockContext() {
+  const services = new Map<string, unknown>();
+  const hooks = new Map<string, Function[]>();
+  services.set('manifest', { register: vi.fn() });
+
+  return {
+    services,
+    hooks,
+    registerService: vi.fn((name: string, service: unknown) => services.set(name, service)),
+    replaceService: vi.fn((name: string, service: unknown) => services.set(name, service)),
+    getService: vi.fn(<T,>(name: string): T => {
+      if (!services.has(name)) throw new Error(`Service "${name}" not found`);
+      return services.get(name) as T;
+    }),
+    getServices: vi.fn(() => services),
+    hook: vi.fn((name: string, handler: Function) => {
+      if (!hooks.has(name)) hooks.set(name, []);
+      hooks.get(name)!.push(handler);
+    }),
+    trigger: vi.fn(async () => {}),
+    logger: silentLogger,
+    getKernel: vi.fn(),
+  } as any;
+}
+
+async function fireHook(ctx: any, name: string): Promise<void> {
+  for (const handler of ctx.hooks.get(name) ?? []) await handler();
+}
+
+/** Settings-service stub returning the given `ai` namespace values. */
+function settingsStub(values: Record<string, { value: unknown; source?: string }>) {
+  const actions = new Map<string, Function>();
+  return {
+    actions,
+    getNamespace: vi.fn(async () => ({ values })),
+    subscribe: vi.fn(),
+    registerAction: vi.fn((ns: string, id: string, fn: Function) => actions.set(`${ns}/${id}`, fn)),
+    resetNamespace: vi.fn(async () => 3),
+  };
+}
+
+const AI_ENV_KEYS = [
+  'AI_GATEWAY_MODEL',
+  'AI_GATEWAY_API_KEY',
+  'OPENAI_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'GOOGLE_GENERATIVE_AI_API_KEY',
+];
+
+describe('GET /api/v1/ai/status route', () => {
+  it('returns adapter name plus the provenance from getAdapterStatus', async () => {
+    const service = new AIService({
+      adapter: new MemoryLLMAdapter(),
+      conversationService: new InMemoryConversationService(),
+    });
+    const routes = buildAIRoutes(service, service.conversationService, silentLogger, {
+      getAdapterStatus: () => ({
+        description: 'Vercel AI Gateway (model: anthropic/claude-sonnet-4.6)',
+        source: 'env',
+        provider: 'gateway',
+        model: 'anthropic/claude-sonnet-4.6',
+        settingsError: null,
+      }),
+    });
+    const statusRoute = routes.find(r => r.method === 'GET' && r.path === '/api/v1/ai/status');
+    expect(statusRoute).toBeDefined();
+    expect(statusRoute!.permissions).toEqual(['ai:read']);
+
+    const response = await statusRoute!.handler({});
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      adapter: 'memory',
+      source: 'env',
+      provider: 'gateway',
+      model: 'anthropic/claude-sonnet-4.6',
+      settingsError: null,
+    });
+  });
+
+  it('still serves adapter name when no status getter is wired', async () => {
+    const service = new AIService({
+      adapter: new MemoryLLMAdapter(),
+      conversationService: new InMemoryConversationService(),
+    });
+    const routes = buildAIRoutes(service, service.conversationService, silentLogger);
+    const statusRoute = routes.find(r => r.path === '/api/v1/ai/status')!;
+    const response = await statusRoute.handler({});
+    expect(response.status).toBe(200);
+    expect((response.body as any).adapter).toBe('memory');
+  });
+});
+
+describe('AIServicePlugin adapter provenance', () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of AI_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of AI_ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+  });
+
+  async function statusOf(ctx: any): Promise<Record<string, unknown>> {
+    // The plugin caches routes on trigger('ai:routes', routes).
+    const call = ctx.trigger.mock.calls.find((c: unknown[]) => c[0] === 'ai:routes');
+    const routes = call![1] as Array<{ path: string; handler: (req: object) => Promise<{ body?: unknown }> }>;
+    const route = routes.find(r => r.path === '/api/v1/ai/status')!;
+    return (await route.handler({})).body as Record<string, unknown>;
+  }
+
+  it('reports source=fallback when nothing is configured', async () => {
+    const plugin = new AIServicePlugin();
+    const ctx = createMockContext();
+    await plugin.init(ctx);
+    await plugin.start!(ctx);
+
+    const body = await statusOf(ctx);
+    expect(body.adapter).toBe('memory');
+    expect(body.source).toBe('fallback');
+    expect(body.provider).toBe('memory');
+  });
+
+  it('reports source=explicit for a constructor-supplied adapter', async () => {
+    const plugin = new AIServicePlugin({
+      adapter: {
+        name: 'custom-test',
+        chat: async () => ({ content: 'ok' }),
+        complete: async () => ({ content: '' }),
+      },
+    });
+    const ctx = createMockContext();
+    await plugin.init(ctx);
+    await plugin.start!(ctx);
+
+    const body = await statusOf(ctx);
+    expect(body.adapter).toBe('custom-test');
+    expect(body.source).toBe('explicit');
+  });
+
+  it('flags settingsError when saved settings cannot build an adapter (broken cloudflare)', async () => {
+    const plugin = new AIServicePlugin();
+    const ctx = createMockContext();
+    // provider=cloudflare with an empty key — exactly the broken leftover
+    // a half-filled Setup form produces.
+    ctx.services.set('settings', settingsStub({
+      provider: { value: 'cloudflare', source: 'database' },
+      cloudflare_account_id: { value: '2846eb40a60f4738e292b90dcd8cce10', source: 'database' },
+      cloudflare_api_key: { value: '', source: 'database' },
+      cloudflare_model: { value: 'claude/sonnet-4.6', source: 'database' },
+    }));
+
+    await plugin.init(ctx);
+    await plugin.start!(ctx);
+    await fireHook(ctx, 'kernel:ready');
+
+    const body = await statusOf(ctx);
+    // The broken settings must NOT have replaced the fallback adapter…
+    expect(body.adapter).toBe('memory');
+    expect(body.source).toBe('fallback');
+    // …and the failure must be visible, naming the saved provider.
+    expect(body.settingsProvider).toBe('cloudflare');
+    expect(String(body.settingsError)).toContain('cloudflare');
+  });
+
+  it('reports source=settings when saved settings apply cleanly', async () => {
+    const plugin = new AIServicePlugin();
+    const ctx = createMockContext();
+    // `memory` stored explicitly (source=database) is a valid, buildable choice.
+    ctx.services.set('settings', settingsStub({
+      provider: { value: 'memory', source: 'database' },
+    }));
+
+    await plugin.init(ctx);
+    await plugin.start!(ctx);
+    await fireHook(ctx, 'kernel:ready');
+
+    const body = await statusOf(ctx);
+    expect(body.source).toBe('settings');
+    expect(body.settingsProvider).toBe('memory');
+    expect(body.settingsError).toBeNull();
+  });
+
+  it('ai/reset clears saved values and re-runs env adapter detection', async () => {
+    const plugin = new AIServicePlugin();
+    const ctx = createMockContext();
+    const settings = settingsStub({
+      provider: { value: 'memory', source: 'database' },
+    });
+    ctx.services.set('settings', settings);
+
+    await plugin.init(ctx);
+    await plugin.start!(ctx);
+    await fireHook(ctx, 'kernel:ready');
+
+    // Saved settings are in effect…
+    expect((await statusOf(ctx)).source).toBe('settings');
+
+    // …then the operator hits "Reset to environment defaults".
+    const reset = settings.actions.get('ai/reset');
+    expect(reset).toBeDefined();
+    const result = await reset!({ ctx: {} });
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain('Cleared 3');
+    expect(settings.resetNamespace).toHaveBeenCalledWith('ai', {});
+
+    const body = await statusOf(ctx);
+    // No AI env vars in this test → detection falls back to echo mode.
+    expect(body.source).toBe('fallback');
+    expect(body.settingsProvider).toBeUndefined();
+    expect(body.settingsError).toBeNull();
+  });
+
+  it('keeps env provenance and clears settingsError when no settings are saved', async () => {
+    const plugin = new AIServicePlugin();
+    const ctx = createMockContext();
+    ctx.services.set('settings', settingsStub({
+      provider: { value: 'memory', source: 'default' },
+    }));
+
+    await plugin.init(ctx);
+    await plugin.start!(ctx);
+    await fireHook(ctx, 'kernel:ready');
+
+    const body = await statusOf(ctx);
+    expect(body.source).toBe('fallback');
+    expect(body.settingsProvider).toBeUndefined();
+    expect(body.settingsError).toBeNull();
+  });
+});

--- a/packages/services/service-ai/src/__tests__/ai-service.test.ts
+++ b/packages/services/service-ai/src/__tests__/ai-service.test.ts
@@ -533,9 +533,10 @@ describe('AI Routes', () => {
 
   it('should build all expected routes', () => {
     const routes = buildAIRoutes(service, service.conversationService, silentLogger);
-    expect(routes.length).toBe(10);
+    expect(routes.length).toBe(11);
 
     const paths = routes.map(r => `${r.method} ${r.path}`);
+    expect(paths).toContain('GET /api/v1/ai/status');
     expect(paths).toContain('POST /api/v1/ai/chat');
     expect(paths).toContain('POST /api/v1/ai/chat/stream');
     expect(paths).toContain('POST /api/v1/ai/complete');

--- a/packages/services/service-ai/src/__tests__/error-hints.test.ts
+++ b/packages/services/service-ai/src/__tests__/error-hints.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, expect, it } from 'vitest';
+import { describeProviderError } from '../stream/error-hints.js';
+import { encodeVercelDataStream } from '../stream/vercel-stream-encoder.js';
+
+const GATEWAY = 'Vercel AI Gateway (model: claude/sonnet-4.6)';
+
+describe('describeProviderError', () => {
+  it('names the adapter and maps HTTP 400 to a model-id hint', () => {
+    const msg = describeProviderError(
+      { message: 'Bad Request', statusCode: 400 },
+      GATEWAY,
+    );
+    expect(msg).toContain('Bad Request (HTTP 400)');
+    expect(msg).toContain(GATEWAY);
+    expect(msg).toContain('provider/model');
+  });
+
+  it('maps auth failures to a credential hint', () => {
+    const msg = describeProviderError(
+      { name: 'GatewayAuthenticationError', message: 'Unauthorized', statusCode: 401 },
+      GATEWAY,
+    );
+    expect(msg).toContain('API key');
+    expect(msg).toContain('Test connection');
+  });
+
+  it('appends the provider response body excerpt', () => {
+    const msg = describeProviderError({
+      message: 'Bad Request',
+      statusCode: 400,
+      responseBody: '{"error":"model claude/sonnet-4.6 not found"}',
+    });
+    expect(msg).toContain('provider says:');
+    expect(msg).toContain('not found');
+  });
+
+  it('reads nested cause status and survives non-object errors', () => {
+    expect(describeProviderError({ message: 'fail', cause: { statusCode: 429 } })).toContain('HTTP 429');
+    expect(describeProviderError('plain text error')).toContain('plain text error');
+    expect(describeProviderError(undefined)).toContain('Unknown provider error');
+  });
+});
+
+describe('encodeVercelDataStream error enrichment', () => {
+  async function* failingStream(): AsyncIterable<any> {
+    yield { type: 'error', error: { message: 'Bad Request', statusCode: 400 } };
+  }
+
+  it('emits the enriched error text on provider error parts', async () => {
+    const frames: string[] = [];
+    for await (const f of encodeVercelDataStream(failingStream() as any, { adapterDescription: GATEWAY })) {
+      frames.push(f);
+    }
+    const errFrame = frames.find((f) => f.includes('"type":"error"'))!;
+    expect(errFrame).toContain('HTTP 400');
+    expect(errFrame).toContain('claude/sonnet-4.6');
+    const finish = frames.find((f) => f.includes('"type":"finish"'))!;
+    expect(finish).toContain('"finishReason":"error"');
+  });
+
+  it('enriches thrown errors too', async () => {
+    async function* throwingStream(): AsyncIterable<any> {
+      throw Object.assign(new Error('Unauthorized'), { statusCode: 401 });
+      yield undefined; // unreachable — makes this a generator
+    }
+    const frames: string[] = [];
+    for await (const f of encodeVercelDataStream(throwingStream() as any, { adapterDescription: GATEWAY })) {
+      frames.push(f);
+    }
+    const errFrame = frames.find((f) => f.includes('"type":"error"'))!;
+    expect(errFrame).toContain('HTTP 401');
+    expect(errFrame).toContain('API key');
+  });
+});

--- a/packages/services/service-ai/src/index.ts
+++ b/packages/services/service-ai/src/index.ts
@@ -6,7 +6,7 @@ export type { AIServiceConfig } from './ai-service.js';
 
 // Kernel plugin
 export { AIServicePlugin } from './plugin.js';
-export type { AIServicePluginOptions } from './plugin.js';
+export type { AIServicePluginOptions, AIAdapterStatus } from './plugin.js';
 
 // Adapters
 export { MemoryLLMAdapter } from './adapters/memory-adapter.js';

--- a/packages/services/service-ai/src/plugin.ts
+++ b/packages/services/service-ai/src/plugin.ts
@@ -116,6 +116,35 @@ export interface AIServicePluginOptions {
 }
 
 /**
+ * Provenance of the active LLM adapter, exposed via `GET /api/v1/ai/status`
+ * so operators can see at a glance which provider/model is live and WHERE
+ * it came from — persisted settings silently override env auto-detection,
+ * and without this surface a broken saved config (e.g. provider=cloudflare
+ * with an empty key) is indistinguishable from a working one in the UI.
+ */
+export interface AIAdapterStatus {
+  /** Human-readable description, e.g. `Vercel AI Gateway (model: anthropic/claude-sonnet-4.6)`. */
+  description: string;
+  /** Where the active adapter came from. */
+  source: 'explicit' | 'env' | 'settings' | 'fallback';
+  /** Provider key when known (gateway / openai / anthropic / google / cloudflare / …). */
+  provider?: string;
+  /** Model id when known. */
+  model?: string;
+  /**
+   * Provider stored in the `ai` settings namespace, even when it could not
+   * be applied. `undefined` when no settings are saved (env-only mode).
+   */
+  settingsProvider?: string;
+  /**
+   * Why the last settings apply failed (missing credentials, SDK not
+   * installed, …). `null` when settings applied cleanly or none are saved.
+   * Non-null means the saved settings are NOT in effect.
+   */
+  settingsError?: string | null;
+}
+
+/**
  * AIServicePlugin — Kernel plugin for the unified AI capability service.
  *
  * Lifecycle:
@@ -146,6 +175,11 @@ export class AIServicePlugin implements Plugin {
 
   private service?: AIService;
   private readonly options: AIServicePluginOptions;
+  /** Provenance of the active adapter — served by `GET /api/v1/ai/status`. */
+  private adapterStatus: AIAdapterStatus = {
+    description: 'not initialised',
+    source: 'fallback',
+  };
 
   constructor(options: AIServicePluginOptions = {}) {
     this.options = options;
@@ -210,12 +244,15 @@ export class AIServicePlugin implements Plugin {
   private async buildAdapterFromValues(
     ctx: PluginContext,
     rawValues: Record<string, unknown>,
-  ): Promise<{ adapter: LLMAdapter; description: string } | null> {
+  ): Promise<{ adapter: LLMAdapter; description: string; provider: string; model?: string } | null> {
+    // Report the provider the operator picked (e.g. `cloudflare`), not the
+    // openai shape it normalises to — status/diagnostics must match the form.
+    const rawProvider = String(rawValues.provider ?? 'memory');
     const values = this.normalisePresetProvider(rawValues);
     const provider = String(values.provider ?? 'memory');
 
     if (provider === 'memory') {
-      return { adapter: new MemoryLLMAdapter(), description: 'MemoryLLMAdapter (echo mode)' };
+      return { adapter: new MemoryLLMAdapter(), description: 'MemoryLLMAdapter (echo mode)', provider: 'memory' };
     }
 
     if (provider === 'gateway') {
@@ -241,6 +278,8 @@ export class AIServicePlugin implements Plugin {
         return {
           adapter: new VercelLLMAdapter({ model: gw(gatewayModel) }),
           description: `Vercel AI Gateway (model: ${gatewayModel})`,
+          provider: 'gateway',
+          model: gatewayModel,
         };
       } catch (err) {
         ctx.logger.warn(
@@ -311,6 +350,8 @@ export class AIServicePlugin implements Plugin {
       return {
         adapter: new VercelLLMAdapter({ model }),
         description: `${spec.displayName} (model: ${modelId})${apiSuffix}${baseSuffix}`,
+        provider: rawProvider,
+        model: modelId,
       };
     } catch (err) {
       ctx.logger.warn(
@@ -406,7 +447,7 @@ export class AIServicePlugin implements Plugin {
    *
    * Returns the adapter and a description for logging.
    */
-  private async detectAdapter(ctx: PluginContext): Promise<{ adapter: LLMAdapter; description: string }> {
+  private async detectAdapter(ctx: PluginContext): Promise<{ adapter: LLMAdapter; description: string; status: AIAdapterStatus }> {
     // 1. Vercel AI Gateway — works with any provider via gateway('provider/model').
     //    A per-instance `gatewayModel` option wins over the process-wide env var
     //    so a multi-tenant host can route the model per kernel (e.g. by plan).
@@ -416,7 +457,8 @@ export class AIServicePlugin implements Plugin {
         const gatewayPkg = '@ai-sdk/gateway';
         const { gateway } = await import(/* webpackIgnore: true */ gatewayPkg);
         const adapter = new VercelLLMAdapter({ model: gateway(gatewayModel) });
-        return { adapter, description: `Vercel AI Gateway (model: ${gatewayModel})` };
+        const description = `Vercel AI Gateway (model: ${gatewayModel})`;
+        return { adapter, description, status: { description, source: 'env', provider: 'gateway', model: gatewayModel } };
       } catch (err) {
         ctx.logger.warn(
           `[AI] Failed to load @ai-sdk/gateway for model=${gatewayModel}, trying next provider`,
@@ -477,7 +519,8 @@ export class AIServicePlugin implements Plugin {
               : provider(modelId);
             const adapter = new VercelLLMAdapter({ model });
             const apiSuffix = useChatApi ? ' [chat-completions]' : '';
-            return { adapter, description: `${displayName} (model: ${modelId})${apiSuffix}` };
+            const description = `${displayName} (model: ${modelId})${apiSuffix}`;
+            return { adapter, description, status: { description, source: 'env', provider: factory, model: modelId } };
           }
         } catch (err) {
           ctx.logger.warn(
@@ -490,7 +533,8 @@ export class AIServicePlugin implements Plugin {
 
     // 3. Fallback to MemoryLLMAdapter
     ctx.logger.warn('[AI] No LLM provider configured via environment variables. Falling back to MemoryLLMAdapter (echo mode). Set AI_GATEWAY_MODEL, OPENAI_API_KEY, ANTHROPIC_API_KEY, or GOOGLE_GENERATIVE_AI_API_KEY to use a real LLM.');
-    return { adapter: new MemoryLLMAdapter(), description: 'MemoryLLMAdapter (echo mode - for testing only)' };
+    const description = 'MemoryLLMAdapter (echo mode - for testing only)';
+    return { adapter: new MemoryLLMAdapter(), description, status: { description, source: 'fallback', provider: 'memory' } };
   }
 
   async init(ctx: PluginContext): Promise<void> {
@@ -528,11 +572,13 @@ export class AIServicePlugin implements Plugin {
       // User provided an explicit adapter
       adapter = this.options.adapter;
       adapterDescription = `${adapter.name} (explicitly configured)`;
+      this.adapterStatus = { description: adapterDescription, source: 'explicit' };
     } else {
       // Auto-detect from environment variables
       const detected = await this.detectAdapter(ctx);
       adapter = detected.adapter;
       adapterDescription = detected.description;
+      this.adapterStatus = detected.status;
     }
 
     // Log the selected adapter
@@ -842,7 +888,9 @@ export class AIServicePlugin implements Plugin {
     }
 
     // Build and expose route definitions
-    const routes = buildAIRoutes(this.service, this.service.conversationService, ctx.logger);
+    const routes = buildAIRoutes(this.service, this.service.conversationService, ctx.logger, {
+      getAdapterStatus: () => ({ ...this.adapterStatus }),
+    });
 
     // Build tool routes
     const toolRoutes = buildToolRoutes(this.service, ctx.logger);
@@ -877,11 +925,16 @@ export class AIServicePlugin implements Plugin {
         }
       }
 
-      const agentRoutes = buildAgentRoutes(this.service, agentRuntime, ctx.logger, { quota: chatQuota });
+      const agentRoutes = buildAgentRoutes(this.service, agentRuntime, ctx.logger, {
+        quota: chatQuota,
+        adapterDescription: () => this.adapterStatus.description,
+      });
       routes.push(...agentRoutes);
       ctx.logger.info(`[AI] Agent routes registered (${agentRoutes.length} routes)`);
 
-      const assistantRoutes = buildAssistantRoutes(this.service, agentRuntime, skillRegistry, ctx.logger);
+      const assistantRoutes = buildAssistantRoutes(this.service, agentRuntime, skillRegistry, ctx.logger, {
+        adapterDescription: () => this.adapterStatus.description,
+      });
       routes.push(...assistantRoutes);
       ctx.logger.info(`[AI] Assistant (ambient) routes registered (${assistantRoutes.length} routes)`);
 
@@ -987,19 +1040,34 @@ export class AIServicePlugin implements Plugin {
         // The manifest default is `memory`; default values should not mask
         // boot-time env auto-detection. A stored or env-locked `memory` value
         // is explicit, though, and should switch the service back to memory.
-        if (provider === 'memory' && (sources.provider ?? 'default') === 'default') return;
+        if (provider === 'memory' && (sources.provider ?? 'default') === 'default') {
+          // No settings saved — the boot-time adapter (env/explicit) stays.
+          this.adapterStatus = { ...this.adapterStatus, settingsProvider: undefined, settingsError: null };
+          return;
+        }
         const built = await this.buildAdapterFromValues(ctx, values);
         if (!built) {
-          ctx.logger.warn(
-            `[AI] Settings provider=${provider} could not be applied (missing credentials or package). ` +
-              `Adapter unchanged (current="${this.service.adapterName}").`,
-          );
+          const reason =
+            `Saved settings (provider=${provider}) could not be applied: missing credentials ` +
+            `or provider SDK not installed. The active adapter is unchanged ("${this.service.adapterName}").`;
+          this.adapterStatus = { ...this.adapterStatus, settingsProvider: provider, settingsError: reason };
+          ctx.logger.warn(`[AI] ${reason}`);
           return;
         }
         this.service.setAdapter(built.adapter);
+        this.adapterStatus = {
+          description: built.description,
+          source: 'settings',
+          provider: built.provider,
+          model: built.model,
+          settingsProvider: provider,
+          settingsError: null,
+        };
         ctx.logger.info(`[AI] Adapter rebuilt from settings: ${built.description}`);
       } catch (err: any) {
-        ctx.logger.warn('[AI] Failed to apply ai settings: ' + (err?.message ?? err));
+        const reason = `Failed to apply ai settings: ${err?.message ?? err}`;
+        this.adapterStatus = { ...this.adapterStatus, settingsError: reason };
+        ctx.logger.warn(`[AI] ${reason}`);
       }
     };
 
@@ -1193,6 +1261,29 @@ export class AIServicePlugin implements Plugin {
         }
       });
       ctx.logger.info('[AI] Registered live settings action ai/test');
+
+      // Live `ai/reset` — overrides the settings service's built-in
+      // namespace reset so the LLM adapter is ALSO rebuilt from env
+      // auto-detection right away (the built-in only clears rows and
+      // would leave a previously-applied adapter running until restart).
+      settings.registerAction('ai', 'reset', async ({ ctx: actionCtx }: any) => {
+        let cleared = 0;
+        if (typeof settings.resetNamespace === 'function') {
+          cleared = await settings.resetNamespace('ai', actionCtx ?? {});
+        }
+        const detected = await this.detectAdapter(ctx);
+        this.service!.setAdapter(detected.adapter);
+        this.adapterStatus = { ...detected.status, settingsProvider: undefined, settingsError: null };
+        ctx.logger.info(`[AI] Settings reset — adapter now: ${detected.description}`);
+        return {
+          ok: true,
+          severity: 'info',
+          message:
+            (cleared > 0 ? `Cleared ${cleared} saved value(s). ` : 'No saved values to clear. ') +
+            `Active adapter: ${detected.description}.`,
+        };
+      });
+      ctx.logger.info('[AI] Registered live settings action ai/reset');
     }
   }
 

--- a/packages/services/service-ai/src/routes/agent-routes.ts
+++ b/packages/services/service-ai/src/routes/agent-routes.ts
@@ -43,6 +43,11 @@ export interface AgentRouteOptions {
    * behavior). Policy lives in the implementation; the route only enforces.
    */
   quota?: AgentChatQuota;
+  /**
+   * Active adapter description, attached to provider errors in the
+   * stream so failures name the provider/model that was hit.
+   */
+  adapterDescription?: () => string | undefined;
 }
 
 /**
@@ -253,7 +258,7 @@ export function buildAgentRoutes(
                 'Connection': 'keep-alive',
                 'x-vercel-ai-ui-message-stream': 'v1',
               },
-              events: encodeVercelDataStream(events),
+              events: encodeVercelDataStream(events, { adapterDescription: options?.adapterDescription?.() }),
             };
           }
 

--- a/packages/services/service-ai/src/routes/ai-routes.ts
+++ b/packages/services/service-ai/src/routes/ai-routes.ts
@@ -124,7 +124,19 @@ export function buildAIRoutes(
   aiService: IAIService,
   conversationService: IAIConversationService,
   logger: Logger,
+  opts: {
+    /**
+     * Provenance of the active LLM adapter (description / source / provider /
+     * model / settingsError). Served by `GET /api/v1/ai/status` so the UI can
+     * show which configuration is actually live.
+     */
+    getAdapterStatus?: () => Record<string, unknown>;
+  } = {},
 ): RouteDefinition[] {
+  const adapterDescription = (): string | undefined => {
+    const d = (opts.getAdapterStatus?.() ?? {}).description;
+    return typeof d === 'string' && d ? d : undefined;
+  };
   return [
     // ── Chat ────────────────────────────────────────────────────
     //
@@ -203,7 +215,7 @@ export function buildAIRoutes(
                 'Connection': 'keep-alive',
                 'x-vercel-ai-ui-message-stream': 'v1',
               },
-              events: encodeVercelDataStream(events),
+              events: encodeVercelDataStream(events, { adapterDescription: adapterDescription() }),
             };
           } catch (err) {
             logger.error('[AI Route] /chat stream error', err instanceof Error ? err : undefined);
@@ -297,6 +309,29 @@ export function buildAIRoutes(
           return { status: 200, body: { models } };
         } catch (err) {
           logger.error('[AI Route] /models error', err instanceof Error ? err : undefined);
+          return { status: 500, body: { error: 'Internal AI service error' } };
+        }
+      },
+    },
+
+    // ── Status ──────────────────────────────────────────────────
+    // Which adapter is live and where it came from. Persisted settings
+    // silently override env auto-detection; this is the surface that makes
+    // that resolution visible (Setup banner / diagnostics).
+    {
+      method: 'GET',
+      path: '/api/v1/ai/status',
+      description: 'Active LLM adapter provenance (source, provider, model, settings errors)',
+      auth: true,
+      permissions: ['ai:read'],
+      handler: async () => {
+        try {
+          const status = opts.getAdapterStatus?.() ?? {};
+          // `adapterName` lives on the concrete AIService, not the contract.
+          const adapter = (aiService as { adapterName?: string }).adapterName ?? 'unknown';
+          return { status: 200, body: { adapter, ...status } };
+        } catch (err) {
+          logger.error('[AI Route] /status error', err instanceof Error ? err : undefined);
           return { status: 500, body: { error: 'Internal AI service error' } };
         }
       },

--- a/packages/services/service-ai/src/routes/assistant-routes.ts
+++ b/packages/services/service-ai/src/routes/assistant-routes.ts
@@ -55,6 +55,10 @@ export function buildAssistantRoutes(
   agentRuntime: AgentRuntime,
   skillRegistry: SkillRegistry,
   logger: Logger,
+  opts: {
+    /** Active adapter description, attached to provider errors in the stream. */
+    adapterDescription?: () => string | undefined;
+  } = {},
 ): RouteDefinition[] {
   return [
     // ── Resolve current assistant + skill set ──────────────────
@@ -257,7 +261,7 @@ export function buildAssistantRoutes(
                 'x-objectstack-agent': agent.name,
                 'x-objectstack-skills': activeSkills.map((s) => s.name).join(','),
               },
-              events: encodeVercelDataStream(events),
+              events: encodeVercelDataStream(events, { adapterDescription: opts.adapterDescription?.() }),
             };
           }
 

--- a/packages/services/service-ai/src/stream/error-hints.ts
+++ b/packages/services/service-ai/src/stream/error-hints.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Turn raw LLM provider errors into actionable messages.
+ *
+ * Providers surface failures as terse HTTP statuses ("Bad Request") that
+ * give an operator nothing to act on — and the chat UI is often the first
+ * place a broken provider config becomes visible. This helper attaches
+ * the active adapter description (so the reader knows WHICH provider/model
+ * was hit) and maps the common failure classes to concrete next steps.
+ */
+
+interface ProviderErrorShape {
+  message?: unknown;
+  name?: unknown;
+  statusCode?: unknown;
+  status?: unknown;
+  responseBody?: unknown;
+  cause?: unknown;
+}
+
+function httpStatusOf(err: ProviderErrorShape): number | undefined {
+  for (const candidate of [err.statusCode, err.status]) {
+    const n = Number(candidate);
+    if (Number.isInteger(n) && n >= 100 && n <= 599) return n;
+  }
+  // Some SDK errors nest the transport error (e.g. APICallError as cause).
+  if (err.cause && typeof err.cause === 'object') {
+    return httpStatusOf(err.cause as ProviderErrorShape);
+  }
+  return undefined;
+}
+
+function hintFor(status: number | undefined, name: string, message: string): string | undefined {
+  if (name === 'GatewayAuthenticationError' || status === 401 || status === 403) {
+    return 'The API key is missing, invalid, or lacks access to this model. Verify the credential in Setup → AI (or the corresponding env var) and use "Test connection".';
+  }
+  if (status === 400) {
+    return 'The provider rejected the request — most often an invalid model id. The model must be in provider/model form (e.g. anthropic/claude-sonnet-4.6 for a gateway). Check Setup → AI and use "Test connection".';
+  }
+  if (status === 404) {
+    return 'The model id does not exist for this provider. Check the model name in Setup → AI.';
+  }
+  if (status === 429) {
+    return 'The provider rate-limited the request. Retry shortly or check the plan/quota for this API key.';
+  }
+  if (/ENOTFOUND|ECONNREFUSED|fetch failed|network/i.test(message)) {
+    return 'Could not reach the provider endpoint. Check the base URL / network egress from this server.';
+  }
+  return undefined;
+}
+
+/**
+ * Build the operator-facing error text for a failed chat/stream call.
+ *
+ * @param raw - The error part payload or thrown error from the provider stream.
+ * @param adapterDescription - Active adapter description (e.g. `Vercel AI Gateway (model: …)`).
+ */
+export function describeProviderError(raw: unknown, adapterDescription?: string): string {
+  const err: ProviderErrorShape =
+    raw && typeof raw === 'object' ? (raw as ProviderErrorShape) : { message: raw };
+  const message =
+    typeof err.message === 'string' && err.message.trim()
+      ? err.message.trim()
+      : typeof raw === 'string' && raw.trim()
+        ? raw.trim()
+        : 'Unknown provider error';
+  const status = httpStatusOf(err);
+  const name = typeof err.name === 'string' ? err.name : '';
+
+  const parts: string[] = [];
+  parts.push(status ? `${message} (HTTP ${status})` : message);
+  if (adapterDescription) parts.push(`— adapter: ${adapterDescription}`);
+  const hint = hintFor(status, name, message);
+  if (hint) parts.push(`· ${hint}`);
+
+  // Provider response bodies often carry the real reason ("model not
+  // found", "invalid_request_error"...) — append a trimmed excerpt.
+  if (typeof err.responseBody === 'string') {
+    const body = err.responseBody.trim().replace(/\s+/g, ' ');
+    if (body && body !== message) parts.push(`· provider says: ${body.slice(0, 300)}`);
+  }
+
+  return parts.join(' ');
+}

--- a/packages/services/service-ai/src/stream/vercel-stream-encoder.ts
+++ b/packages/services/service-ai/src/stream/vercel-stream-encoder.ts
@@ -16,6 +16,7 @@
  */
 
 import type { TextStreamPart, ToolSet } from 'ai';
+import { describeProviderError } from './error-hints.js';
 
 // ── SSE helpers ──────────────────────────────────────────────────────
 
@@ -117,6 +118,14 @@ export function encodeStreamPart(part: TextStreamPart<ToolSet>): string {
  */
 export async function* encodeVercelDataStream(
   events: AsyncIterable<TextStreamPart<ToolSet>>,
+  opts: {
+    /**
+     * Active adapter description (e.g. `Vercel AI Gateway (model: …)`),
+     * attached to provider errors so the chat surface names the
+     * provider/model that failed instead of a bare HTTP status.
+     */
+    adapterDescription?: string;
+  } = {},
 ): AsyncIterable<string> {
   // Preamble
   yield sse({ type: 'start' });
@@ -132,13 +141,7 @@ export async function* encodeVercelDataStream(
       // Surface error parts emitted by the underlying provider stream.
       if ((part as { type: string }).type === 'error') {
         const errPart = part as unknown as { error?: unknown };
-        const raw = errPart.error;
-        errorMessage =
-          (raw && typeof raw === 'object' && 'message' in raw
-            ? String((raw as { message: unknown }).message)
-            : typeof raw === 'string'
-              ? raw
-              : 'Unknown provider error');
+        errorMessage = describeProviderError(errPart.error, opts.adapterDescription);
         finishReason = 'error';
         break;
       }
@@ -167,7 +170,7 @@ export async function* encodeVercelDataStream(
     // Upstream provider threw (auth failure, network error, etc.). Without
     // this catch the SSE response would hang half-open and the client would
     // never leave its "streaming" state.
-    errorMessage = err instanceof Error ? err.message : String(err);
+    errorMessage = describeProviderError(err, opts.adapterDescription);
     finishReason = 'error';
   }
 

--- a/packages/services/service-settings/src/index.ts
+++ b/packages/services/service-settings/src/index.ts
@@ -32,9 +32,15 @@ export {
   type SettingsServiceOptions,
   envKeyOf,
   SettingsLockedError,
+  SettingsValidationError,
   UnknownKeyError,
   UnknownNamespaceError,
 } from './settings-service.types.js';
+export {
+  evaluateVisibility,
+  referencedKeys,
+  VisibilityParseError,
+} from './visibility-eval.js';
 export {
   SettingsServicePlugin,
   type SettingsServicePluginOptions,

--- a/packages/services/service-settings/src/manifests/ai.manifest.ts
+++ b/packages/services/service-settings/src/manifests/ai.manifest.ts
@@ -58,7 +58,8 @@ const manifest = {
       visible: "${data.provider === 'gateway'}",
       description: 'Multi-provider router. The model spec follows `provider/model`, e.g. `openai/gpt-4o`.' },
     { type: 'text', key: 'gateway_model', label: 'Gateway model', required: true,
-      description: 'Forwarded as AI_GATEWAY_MODEL. Example: openai/gpt-4o',
+      description: 'Forwarded as AI_GATEWAY_MODEL. Format: provider/model, e.g. openai/gpt-4o or anthropic/claude-sonnet-4.6.',
+      pattern: '^[A-Za-z0-9_-]+\\/[A-Za-z0-9._:-]+$',
       visible: "${data.provider === 'gateway'}" },
     { type: 'password', key: 'gateway_api_key', label: 'Gateway API key',
       required: false, encrypted: true,
@@ -151,6 +152,7 @@ const manifest = {
       visible: "${data.provider === 'cloudflare'}" },
     { type: 'text', key: 'cloudflare_model', label: 'Model', required: false,
       default: 'openai/gpt-4o-mini',
+      pattern: '^[A-Za-z0-9_-]+\\/[A-Za-z0-9._:@-]+$',
       description:
         'Format: provider/model. Allowed providers (per Cloudflare /compat): anthropic, openai, groq, ' +
         'mistral, cohere, perplexity, workers-ai, google-ai-studio, vertex, grok, deepseek, cerebras, baseten, parallel.',
@@ -228,6 +230,13 @@ const manifest = {
     { type: 'action_button', id: 'test', label: 'Test connection',
       required: false, icon: 'Plug',
       handler: { kind: 'http', method: 'POST', url: '/api/settings/ai/test' } },
+    // Escape hatch: clears every saved row in this namespace so the
+    // runtime falls back to env auto-detection (AI_GATEWAY_MODEL /
+    // OPENAI_API_KEY / …). Without it, a broken saved config can only
+    // be removed by editing sys_setting by hand.
+    { type: 'action_button', id: 'reset', label: 'Reset to environment defaults',
+      required: false, icon: 'RotateCcw',
+      handler: { kind: 'http', method: 'POST', url: '/api/settings/ai/reset' } },
 
     // ════════════════════════════════════════════════════════════════
     // Embedder — text → vector provider used by knowledge / RAG.

--- a/packages/services/service-settings/src/settings-routes.ts
+++ b/packages/services/service-settings/src/settings-routes.ts
@@ -17,6 +17,7 @@ import type { IHttpServer, IHttpRequest, IHttpResponse, RouteHandler } from '@ob
 import { SettingsService } from './settings-service.js';
 import {
   SettingsLockedError,
+  SettingsValidationError,
   UnknownKeyError,
   UnknownNamespaceError,
   type SettingsContext,
@@ -103,6 +104,11 @@ export function registerSettingsRoutes(
         sendError(res, 404, 'UNKNOWN_NAMESPACE', err.message);
       } else if (err instanceof UnknownKeyError) {
         sendError(res, 400, 'UNKNOWN_KEY', err.message, { namespace: err.namespace, key: err.key });
+      } else if (err instanceof SettingsValidationError) {
+        sendError(res, 400, 'SETTINGS_VALIDATION', err.message, {
+          namespace: err.namespace,
+          fields: err.fields,
+        });
       } else {
         sendError(res, 500, 'INTERNAL', err?.message ?? 'Failed to write namespace');
       }

--- a/packages/services/service-settings/src/settings-service.test.ts
+++ b/packages/services/service-settings/src/settings-service.test.ts
@@ -5,6 +5,7 @@ import { SettingsService } from './settings-service';
 import { SettingsLockedError, UnknownKeyError, UnknownNamespaceError, envKeyOf } from './settings-service.types';
 import { NoopCryptoAdapter } from './crypto-adapter';
 import { mailSettingsManifest, mailTestActionHandler } from './manifests/mail.manifest';
+import { aiSettingsManifest } from './manifests/ai.manifest';
 import { brandingSettingsManifest } from './manifests/branding.manifest';
 import { featureFlagsSettingsManifest } from './manifests/feature-flags.manifest';
 import { SettingsManifestSchema } from '@objectstack/spec/system';
@@ -102,7 +103,7 @@ describe('SettingsService — global scope', () => {
   it('returns source="global" for platform-wide values', async () => {
     const svc = new SettingsService({ env: {} });
     svc.registerManifest(mailSettingsManifest);
-    await svc.setMany('mail', { provider: 'smtp', from_email: 'ops@example.com' });
+    await svc.setMany('mail', { provider: 'smtp', smtp_host: 'smtp.example.com', from_email: 'ops@example.com' });
     const r = await svc.get('mail', 'from_email');
     expect(r.source).toBe('global');
     expect(r.value).toBe('ops@example.com');
@@ -112,7 +113,7 @@ describe('SettingsService — global scope', () => {
   it('global value is visible from any user context (no per-user isolation)', async () => {
     const svc = new SettingsService({ env: {} });
     svc.registerManifest(mailSettingsManifest);
-    await svc.setMany('mail', { provider: 'smtp', from_email: 'ops@example.com' }, { userId: 'u1' });
+    await svc.setMany('mail', { provider: 'smtp', smtp_host: 'smtp.example.com', from_email: 'ops@example.com' }, { userId: 'u1' });
     const fromU2 = await svc.get('mail', 'from_email', { userId: 'u2' });
     expect(fromU2.source).toBe('global');
     expect(fromU2.value).toBe('ops@example.com');
@@ -199,6 +200,132 @@ describe('SettingsService — runAction', () => {
     const r = await svc.runAction('branding', 'boom', null);
     expect(r.ok).toBe(false);
     expect(r.message).toContain('kaboom');
+  });
+});
+
+describe('SettingsService — resetNamespace / built-in reset action', () => {
+  it('clears persisted rows so values fall back to defaults', async () => {
+    const svc = new SettingsService({ env: {} });
+    svc.registerManifest(brandingSettingsManifest);
+    await svc.set('branding', 'workspace_name', 'Acme');
+    expect((await svc.get('branding', 'workspace_name')).source).toBe('tenant');
+
+    const cleared = await svc.resetNamespace('branding');
+    expect(cleared).toBe(1);
+    const r = await svc.get('branding', 'workspace_name');
+    expect(r.source).toBe('default');
+    expect(r.value).toBe('ObjectStack');
+  });
+
+  it('leaves env-locked keys untouched', async () => {
+    const svc = new SettingsService({ env: { OS_BRANDING_WORKSPACE_NAME: 'EnvCorp' } });
+    svc.registerManifest(brandingSettingsManifest);
+    await expect(svc.resetNamespace('branding')).resolves.toBe(0);
+    const r = await svc.get('branding', 'workspace_name');
+    expect(r.source).toBe('env');
+    expect(r.value).toBe('EnvCorp');
+  });
+
+  it('runAction falls back to the built-in reset when no handler is registered', async () => {
+    const svc = new SettingsService({ env: {} });
+    svc.registerManifest(brandingSettingsManifest);
+    await svc.set('branding', 'workspace_name', 'Acme');
+
+    const r = await svc.runAction('branding', 'reset', null);
+    expect(r.ok).toBe(true);
+    expect(r.message).toContain('Cleared 1');
+    expect((await svc.get('branding', 'workspace_name')).source).toBe('default');
+  });
+
+  it('a registered reset handler overrides the built-in', async () => {
+    const svc = new SettingsService({ env: {} });
+    svc.registerManifest(brandingSettingsManifest);
+    svc.registerAction('branding', 'reset', async () => ({ ok: true, severity: 'info', message: 'custom' }));
+    const r = await svc.runAction('branding', 'reset', null);
+    expect(r.message).toBe('custom');
+  });
+});
+
+describe('SettingsService — save-time validation (required/visible/pattern)', () => {
+  function aiService(): SettingsService {
+    const svc = new SettingsService({ env: {} });
+    svc.registerManifest(aiSettingsManifest);
+    return svc;
+  }
+
+  it('rejects a provider switch whose required visible fields are empty', async () => {
+    const svc = aiService();
+    // The exact incident: provider=cloudflare saved with an empty API key.
+    await expect(
+      svc.setMany('ai', {
+        provider: 'cloudflare',
+        cloudflare_account_id: '2846eb40a60f4738e292b90dcd8cce10',
+        cloudflare_api_key: '',
+      }),
+    ).rejects.toMatchObject({
+      code: 'SETTINGS_VALIDATION',
+      fields: { cloudflare_api_key: expect.stringContaining('required') },
+    });
+    // Nothing was persisted — the batch is atomic.
+    expect((await svc.get('ai', 'provider')).source).toBe('default');
+  });
+
+  it('rejects switching provider without supplying its required fields at all', async () => {
+    const svc = aiService();
+    await expect(svc.setMany('ai', { provider: 'cloudflare' })).rejects.toMatchObject({
+      code: 'SETTINGS_VALIDATION',
+      fields: {
+        cloudflare_account_id: expect.any(String),
+        cloudflare_api_key: expect.any(String),
+      },
+    });
+  });
+
+  it('accepts a complete provider config', async () => {
+    const svc = aiService();
+    await expect(
+      svc.setMany('ai', {
+        provider: 'cloudflare',
+        cloudflare_account_id: '2846eb40a60f4738e292b90dcd8cce10',
+        cloudflare_api_key: 'cfut_secret',
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it('does not validate fields hidden for the selected provider', async () => {
+    const svc = aiService();
+    // openai_api_key is required:true but invisible when provider=memory.
+    await expect(svc.setMany('ai', { provider: 'memory' })).resolves.toBeDefined();
+  });
+
+  it('leaves unrelated single-key writes untouched', async () => {
+    const svc = aiService();
+    // trace_enabled has no required/visible coupling to provider fields.
+    await expect(svc.setMany('ai', { trace_enabled: true })).resolves.toBeDefined();
+  });
+
+  it('enforces the gateway model id pattern (provider/model)', async () => {
+    const svc = aiService();
+    await expect(
+      svc.setMany('ai', { provider: 'gateway', gateway_model: 'gpt-4o' }),
+    ).rejects.toMatchObject({
+      code: 'SETTINGS_VALIDATION',
+      fields: { gateway_model: expect.stringContaining('format') },
+    });
+    await expect(
+      svc.setMany('ai', { provider: 'gateway', gateway_model: 'anthropic/claude-sonnet-4.6' }),
+    ).resolves.toBeDefined();
+  });
+
+  it('still allows resets (all-null patches) of incomplete namespaces', async () => {
+    const svc = aiService();
+    await svc.setMany('ai', {
+      provider: 'cloudflare',
+      cloudflare_account_id: 'acc',
+      cloudflare_api_key: 'key',
+    });
+    await expect(svc.resetNamespace('ai')).resolves.toBeGreaterThan(0);
+    expect((await svc.get('ai', 'provider')).source).toBe('default');
   });
 });
 

--- a/packages/services/service-settings/src/settings-service.ts
+++ b/packages/services/service-settings/src/settings-service.ts
@@ -23,9 +23,11 @@ import {
   type SettingsServiceOptions,
   envKeyOf,
   SettingsLockedError,
+  SettingsValidationError,
   UnknownKeyError,
   UnknownNamespaceError,
 } from './settings-service.types.js';
+import { evaluateVisibility, referencedKeys } from './visibility-eval.js';
 
 const DEFAULT_OBJECT = 'sys_setting';
 
@@ -446,6 +448,11 @@ export class SettingsService {
       }
     }
 
+    // Reject writes that would leave the namespace in a known-broken
+    // state (visible required field empty / pattern mismatch). See
+    // validatePatch for the exact semantics.
+    await this.validatePatch(namespace, patch, ctx);
+
     for (const [key, rawValue] of Object.entries(patch)) {
       const scope = reg.scopes.get(key)!;
       // global rows are platform-wide (tenant_id=null, user_id=null);
@@ -554,6 +561,116 @@ export class SettingsService {
     return out;
   }
 
+  /**
+   * Save-time validation for `setMany`, fulfilling the spec promise that
+   * `required` is enforced server-side and hidden specifiers are not
+   * validated. Semantics, tuned to reject broken configs without
+   * breaking unrelated single-key writes:
+   *
+   * - The post-write value map is computed (current values overlaid
+   *   with the patch; `null` patch entries fall back to the default).
+   * - A specifier is checked only when the patch TOUCHES it — its own
+   *   key is in the patch, or a key its `visible` expression references
+   *   is (switching provider must validate that provider's fields).
+   * - `required` + visible + empty → rejected.
+   * - `pattern` (text fields) + non-empty value that mismatches → rejected.
+   * - All-null patches (namespace reset) and unparseable visibility
+   *   expressions skip validation rather than block the write.
+   */
+  private async validatePatch(
+    namespace: string,
+    patch: Record<string, unknown>,
+    ctx: SettingsContext,
+  ): Promise<void> {
+    const reg = this.registry.get(namespace);
+    if (!reg) return;
+    const entries = Object.entries(patch);
+    if (entries.length === 0) return;
+    // An all-null patch is a reset — clearing values is never blocked.
+    if (entries.every(([, v]) => v === null || typeof v === 'undefined')) return;
+
+    // Post-write value map: resolved values overlaid with the patch.
+    const data: Record<string, unknown> = {};
+    for (const [key] of reg.scopes) {
+      data[key] = (await this.get(namespace, key, ctx)).value;
+    }
+    for (const [key, value] of entries) {
+      data[key] = value === null || typeof value === 'undefined'
+        ? reg.defaults.get(key) ?? null
+        : value;
+    }
+
+    const patchKeys = new Set(Object.keys(patch));
+    const errors: Record<string, string> = {};
+
+    for (const spec of (reg.manifest.specifiers ?? []) as Array<Record<string, unknown>>) {
+      const key = spec.key as string | undefined;
+      const type = String(spec.type ?? '');
+      if (!key || LAYOUT_ONLY_TYPES.has(type)) continue;
+
+      let visible = true;
+      let deps: string[] = [];
+      if (typeof spec.visible !== 'undefined') {
+        try {
+          visible = evaluateVisibility(spec.visible, data);
+          deps = referencedKeys(spec.visible);
+        } catch {
+          continue; // can't determine visibility — stay lenient
+        }
+      }
+      if (!visible) continue;
+      if (!patchKeys.has(key) && !deps.some((d) => patchKeys.has(d))) continue;
+
+      const value = data[key];
+      const label = typeof spec.label === 'string' ? spec.label : key;
+      const empty =
+        value === null || typeof value === 'undefined' ||
+        (typeof value === 'string' && value.trim() === '');
+
+      if (spec.required === true && empty) {
+        errors[key] = `${label} is required for this configuration.`;
+        continue;
+      }
+      if (!empty && typeof spec.pattern === 'string' && typeof value === 'string') {
+        let re: RegExp | undefined;
+        try {
+          re = new RegExp(spec.pattern);
+        } catch {
+          re = undefined; // invalid manifest pattern — don't block writes
+        }
+        if (re && !re.test(value)) {
+          const hint = typeof spec.description === 'string' ? ` ${spec.description}` : '';
+          errors[key] = `${label} does not match the expected format.${hint}`;
+        }
+      }
+    }
+
+    if (Object.keys(errors).length > 0) {
+      throw new SettingsValidationError(namespace, errors);
+    }
+  }
+
+  /**
+   * Clear every persisted row in a namespace so values fall back to
+   * env/defaults. Env-locked keys are untouched (env wins over rows
+   * anyway and refuses writes). Persisted rows are nulled rather than
+   * deleted so the audit trail records the reset per key.
+   *
+   * Returns the number of cleared keys.
+   */
+  async resetNamespace(namespace: string, ctx: SettingsContext = {}): Promise<number> {
+    const payload = await this.getNamespace(namespace, ctx);
+    const patch: Record<string, null> = {};
+    for (const [key, v] of Object.entries(payload.values)) {
+      if (v.source === 'global' || v.source === 'tenant' || v.source === 'user') {
+        patch[key] = null;
+      }
+    }
+    const keys = Object.keys(patch);
+    if (keys.length > 0) await this.setMany(namespace, patch, ctx);
+    return keys.length;
+  }
+
   /** Invoke a declared action (test connection, rotate, …). */
   async runAction(
     namespace: string,
@@ -565,6 +682,20 @@ export class SettingsService {
     if (!reg) throw new UnknownNamespaceError(namespace);
     const handler = reg.actions.get(actionId);
     if (!handler) {
+      // Built-in fallback: every namespace gets a `reset` action that
+      // clears persisted rows (back to env/defaults). Plugins may
+      // override it via registerAction for richer behaviour (e.g. the
+      // AI plugin re-runs env adapter detection after the clear).
+      if (actionId === 'reset') {
+        const cleared = await this.resetNamespace(namespace, ctx);
+        return {
+          ok: true,
+          severity: 'info',
+          message: cleared > 0
+            ? `Cleared ${cleared} saved value(s); environment/default configuration is back in effect.`
+            : 'No saved values to clear — already using environment/default configuration.',
+        };
+      }
       return {
         ok: false,
         severity: 'error',

--- a/packages/services/service-settings/src/settings-service.types.ts
+++ b/packages/services/service-settings/src/settings-service.types.ts
@@ -233,3 +233,23 @@ export class UnknownKeyError extends Error {
     super(`Key '${key}' is not declared in manifest '${namespace}'.`);
   }
 }
+
+/**
+ * Thrown when a write would leave the namespace in an invalid state —
+ * a `required` field that is visible under the post-write values is
+ * empty (e.g. provider=cloudflare saved without an API key). The whole
+ * batch is rejected; `fields` maps each offending key to a message the
+ * UI can render inline.
+ */
+export class SettingsValidationError extends Error {
+  readonly code = 'SETTINGS_VALIDATION' as const;
+  constructor(
+    readonly namespace: string,
+    readonly fields: Record<string, string>,
+  ) {
+    super(
+      `Settings for '${namespace}' are incomplete: ` +
+        Object.entries(fields).map(([k, msg]) => `${k} — ${msg}`).join('; '),
+    );
+  }
+}

--- a/packages/services/service-settings/src/visibility-eval.test.ts
+++ b/packages/services/service-settings/src/visibility-eval.test.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, expect, it } from 'vitest';
+import { evaluateVisibility, referencedKeys, VisibilityParseError } from './visibility-eval';
+
+describe('evaluateVisibility', () => {
+  it('handles every expression shape used by the bundled manifests', () => {
+    expect(evaluateVisibility("${data.provider === 'cloudflare'}", { provider: 'cloudflare' })).toBe(true);
+    expect(evaluateVisibility("${data.provider === 'cloudflare'}", { provider: 'openai' })).toBe(false);
+    expect(evaluateVisibility("${data.provider !== 'memory'}", { provider: 'memory' })).toBe(false);
+    expect(evaluateVisibility("${data.embedder_provider && data.embedder_provider !== 'none'}", { embedder_provider: 'openai' })).toBe(true);
+    expect(evaluateVisibility("${data.embedder_provider && data.embedder_provider !== 'none'}", { embedder_provider: 'none' })).toBe(false);
+    expect(evaluateVisibility("${data.embedder_provider && data.embedder_provider !== 'none'}", {})).toBe(false);
+    expect(evaluateVisibility("${data.embedder_provider === 'custom' || data.embedder_provider === 'azure'}", { embedder_provider: 'azure' })).toBe(true);
+    expect(evaluateVisibility("${data.provider !== 'memory' && data.title_generation_enabled !== false}", { provider: 'openai' })).toBe(true);
+    expect(evaluateVisibility("${data.google_enabled !== false}", { google_enabled: false })).toBe(false);
+  });
+
+  it('supports negation, parentheses, and envelope form', () => {
+    expect(evaluateVisibility('${!data.flag}', { flag: false })).toBe(true);
+    expect(evaluateVisibility("${(data.a === '1' || data.b === '2') && data.c !== '3'}", { a: '1', c: 'x' })).toBe(true);
+    expect(evaluateVisibility({ dialect: 'template', source: "${data.provider === 'smtp'}" }, { provider: 'smtp' })).toBe(true);
+  });
+
+  it('treats missing expressions as visible', () => {
+    expect(evaluateVisibility(undefined, {})).toBe(true);
+  });
+
+  it('throws VisibilityParseError outside the grammar', () => {
+    expect(() => evaluateVisibility('${data.x.map(y => y)}', {})).toThrow(VisibilityParseError);
+    expect(() => evaluateVisibility('${window.location}', {})).toThrow(VisibilityParseError);
+    expect(() => evaluateVisibility("${data.a === 'unterminated}", {})).toThrow(VisibilityParseError);
+  });
+});
+
+describe('referencedKeys', () => {
+  it('lists the data.* keys an expression depends on', () => {
+    expect(referencedKeys("${data.provider === 'cloudflare'}")).toEqual(['provider']);
+    expect(referencedKeys("${data.a === '1' || data.b === '2'}")).toEqual(['a', 'b']);
+    expect(referencedKeys(undefined)).toEqual([]);
+  });
+});

--- a/packages/services/service-settings/src/visibility-eval.ts
+++ b/packages/services/service-settings/src/visibility-eval.ts
@@ -1,0 +1,189 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Evaluator for the restricted visibility expressions used by settings
+ * manifests, e.g. `"${data.provider === 'cloudflare'}"` or
+ * `"${data.embedder_provider && data.embedder_provider !== 'none'}"`.
+ *
+ * The server needs these at save time so `setMany` can enforce `required`
+ * only on fields that are actually visible for the current provider —
+ * a half-filled Cloudflare form must be rejected, while OpenAI fields
+ * stay irrelevant. The console UI evaluates the same strings client-side;
+ * this is deliberately NOT a general JS evaluator, just the tiny grammar
+ * the manifests use:
+ *
+ *   orExpr   := andExpr ('||' andExpr)*
+ *   andExpr  := unary ('&&' unary)*
+ *   unary    := '!' unary | comparison
+ *   compare  := primary (('===' | '!==' | '==' | '!=') primary)?
+ *   primary  := '(' orExpr ')' | string | number | true | false | null | data.<ident>
+ *
+ * Anything outside the grammar throws `VisibilityParseError`; callers
+ * should treat that as "cannot determine visibility" and skip validation
+ * for the field (lenient) rather than block the save.
+ */
+
+export class VisibilityParseError extends Error {
+  constructor(expr: string, detail: string) {
+    super(`Cannot parse visibility expression "${expr}": ${detail}`);
+    this.name = 'VisibilityParseError';
+  }
+}
+
+type Token =
+  | { kind: 'punct'; value: '(' | ')' | '!' | '&&' | '||' | '===' | '!==' | '==' | '!=' }
+  | { kind: 'string'; value: string }
+  | { kind: 'number'; value: number }
+  | { kind: 'keyword'; value: boolean | null }
+  | { kind: 'ref'; value: string };
+
+/**
+ * Unwrap the manifest forms a `visible` field can take: a bare string,
+ * a `${…}` template string, or a `{ dialect, source }` envelope.
+ */
+export function visibilitySource(visible: unknown): string | undefined {
+  let src: string | undefined;
+  if (typeof visible === 'string') src = visible;
+  else if (visible && typeof visible === 'object' && typeof (visible as { source?: unknown }).source === 'string') {
+    src = (visible as { source: string }).source;
+  }
+  if (src === undefined) return undefined;
+  const trimmed = src.trim();
+  if (trimmed.startsWith('${') && trimmed.endsWith('}')) return trimmed.slice(2, -1).trim();
+  return trimmed;
+}
+
+/** `data.*` keys referenced by a visibility expression (regex-level scan). */
+export function referencedKeys(visible: unknown): string[] {
+  const src = visibilitySource(visible);
+  if (!src) return [];
+  return [...src.matchAll(/data\.([A-Za-z_][A-Za-z0-9_]*)/g)].map((m) => m[1]);
+}
+
+function tokenize(expr: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  while (i < expr.length) {
+    const ch = expr[i];
+    if (/\s/.test(ch)) { i++; continue; }
+    if (ch === '(' || ch === ')') { tokens.push({ kind: 'punct', value: ch }); i++; continue; }
+    let matchedOp = false;
+    for (const op of ['===', '!==', '==', '!=', '&&', '||'] as const) {
+      if (expr.startsWith(op, i)) {
+        tokens.push({ kind: 'punct', value: op });
+        i += op.length;
+        matchedOp = true;
+        break;
+      }
+    }
+    if (matchedOp) continue;
+    if (ch === '!') { tokens.push({ kind: 'punct', value: '!' }); i++; continue; }
+    if (ch === "'" || ch === '"') {
+      const quote = ch;
+      let j = i + 1;
+      let out = '';
+      while (j < expr.length && expr[j] !== quote) {
+        if (expr[j] === '\\' && j + 1 < expr.length) { out += expr[j + 1]; j += 2; }
+        else { out += expr[j]; j++; }
+      }
+      if (j >= expr.length) throw new VisibilityParseError(expr, 'unterminated string');
+      tokens.push({ kind: 'string', value: out });
+      i = j + 1;
+      continue;
+    }
+    if (/[0-9]/.test(ch)) {
+      const m = /^[0-9]+(\.[0-9]+)?/.exec(expr.slice(i))!;
+      tokens.push({ kind: 'number', value: Number(m[0]) });
+      i += m[0].length;
+      continue;
+    }
+    if (/[A-Za-z_]/.test(ch)) {
+      const m = /^[A-Za-z_][A-Za-z0-9_.]*/.exec(expr.slice(i))!;
+      const word = m[0];
+      if (word === 'true') tokens.push({ kind: 'keyword', value: true });
+      else if (word === 'false') tokens.push({ kind: 'keyword', value: false });
+      else if (word === 'null') tokens.push({ kind: 'keyword', value: null });
+      else if (word.startsWith('data.')) {
+        const key = word.slice('data.'.length);
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) throw new VisibilityParseError(expr, `unsupported reference "${word}"`);
+        tokens.push({ kind: 'ref', value: key });
+      } else throw new VisibilityParseError(expr, `unsupported identifier "${word}"`);
+      i += word.length;
+      continue;
+    }
+    throw new VisibilityParseError(expr, `unexpected character "${ch}"`);
+  }
+  return tokens;
+}
+
+/**
+ * Evaluate a visibility expression against the merged form data.
+ * Throws {@link VisibilityParseError} for anything outside the grammar.
+ */
+export function evaluateVisibility(visible: unknown, data: Record<string, unknown>): boolean {
+  const src = visibilitySource(visible);
+  if (!src) return true;
+  const tokens = tokenize(src);
+  let pos = 0;
+
+  const peek = (): Token | undefined => tokens[pos];
+  const eat = (value: string): boolean => {
+    const t = tokens[pos];
+    if (t?.kind === 'punct' && t.value === value) { pos++; return true; }
+    return false;
+  };
+
+  function primary(): unknown {
+    const t = peek();
+    if (!t) throw new VisibilityParseError(src!, 'unexpected end of expression');
+    if (t.kind === 'punct' && t.value === '(') {
+      pos++;
+      const v = orExpr();
+      if (!eat(')')) throw new VisibilityParseError(src!, 'missing closing parenthesis');
+      return v;
+    }
+    if (t.kind === 'string' || t.kind === 'number' || t.kind === 'keyword') { pos++; return t.value; }
+    if (t.kind === 'ref') { pos++; return data[t.value]; }
+    throw new VisibilityParseError(src!, `unexpected token`);
+  }
+
+  function comparison(): unknown {
+    const left = primary();
+    const t = peek();
+    if (t?.kind === 'punct' && ['===', '!==', '==', '!='].includes(t.value)) {
+      pos++;
+      const right = primary();
+      // Loose == / != are treated as strict — manifest values are
+      // primitives written by hand; the distinction never matters here.
+      return t.value === '===' || t.value === '==' ? left === right : left !== right;
+    }
+    return left;
+  }
+
+  function unary(): unknown {
+    if (eat('!')) return !unary();
+    return comparison();
+  }
+
+  function andExpr(): unknown {
+    let v = unary();
+    while (eat('&&')) {
+      const r = unary();
+      v = v && r;
+    }
+    return v;
+  }
+
+  function orExpr(): unknown {
+    let v = andExpr();
+    while (eat('||')) {
+      const r = andExpr();
+      v = v || r;
+    }
+    return v;
+  }
+
+  const result = orExpr();
+  if (pos !== tokens.length) throw new VisibilityParseError(src, 'trailing tokens');
+  return Boolean(result);
+}


### PR DESCRIPTION
## 背景

本地 showcase 曾出现:Setup UI 半填的 AI 设置(provider=cloudflare、API key 为空)被存进 `sys_setting`,静默覆盖了 env 自动检测出的 adapter;唯一症状是聊天流里一句裸的 `Bad Request`。排查只能靠 sqlite 手术。本 PR 把这条链路上的四个缺口全部补上(服务端部分;前端按钮/错误展示由 manifest 与现有 toast 机制驱动,objectui 零改动)。

## 改动

### 1. 生效配置可见 — `GET /api/v1/ai/status`
`AIServicePlugin` 全程追踪 adapter 来源(boot 检测 / settings 重建 / reset),新接口返回:
```json
{ "adapter": "vercel", "description": "Vercel AI Gateway (model: …)",
  "source": "env | settings | explicit | fallback",
  "provider": "gateway", "model": "…",
  "settingsProvider": "…", "settingsError": null }
```
`settingsError` 非空 = 已保存的 settings 没有生效及其原因(此前只有一行服务端 warn)。

### 2. 保存时服务端校验(spec 早已承诺,首次实现)
`SettingsService.setMany` 现在按 manifest 校验:对"当前可见(`visible` 表达式服务端求值)+ required + 被本次写入触及"的字段拒绝空值;`pattern` 不匹配同样拒绝。整批原子拒绝,`400 SETTINGS_VALIDATION` 携带字段级错误,UI toast 直接可读。受限文法求值器见 `visibility-eval.ts`(`data.x === 'y'`、`&&`/`||`/`!`、括号、字面量);不可解析表达式与全空 patch(重置)保持宽松。`gateway_model`/`cloudflare_model` 增加 `provider/model` 格式 pattern。

### 3. 一键恢复 — 内置 `reset` action + manifest 按钮
每个 settings 命名空间获得内置 `reset`(清持久化行,回落 env/默认,留审计);`ai` 命名空间的覆盖版还会立即重跑 env adapter 检测。AI manifest 增加 "Reset to environment defaults" 按钮,前端自动渲染。

### 4. chat 流错误可诊断
chat/agents/assistant 三条流式路由的 provider 错误经 `error-hints.ts` 增强:带 adapter 描述 + 按状态码映射的下一步提示(400→model id 格式、401/403→凭据、404→模型不存在、429→限流、网络错误)。`Bad Request` 变成:
> Model 'claude/sonnet-4.6' not found (HTTP 404) — adapter: Vercel AI Gateway (model: claude/sonnet-4.6) · The model id does not exist for this provider. Check the model name in Setup → AI.

## 测试

- 新增 `adapter-status.test.ts`(8)、`error-hints.test.ts`(6)、`visibility-eval.test.ts`(6)+ settings reset/校验用例;service-ai 359、service-settings 113 全绿。
- 两个旧测试因新校验按预期拦截"只存 provider 不带必填字段"而补全为完整配置。
- 浏览器实测(showcase :3000 → Setup → AI 与 Embedder):坏 cloudflare 配置保存被拒(字段级 toast,DB 零写入);`gpt-4o` 无斜杠被 pattern 拒;存入合规但错误的 model 后 status 立即显示 `source: settings` + 该 model;chat 错误带完整诊断;点 Reset 按钮 toast 报告 "Cleared 2 saved value(s). Active adapter: …" 且 chat 即刻恢复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)