### PR TITLE
feat(docs-metadata): ADR-0046 — package docs as flat Markdown metadata

### DIFF
--- a/.changeset/adr-0046-package-docs-as-metadata.md
+++ b/.changeset/adr-0046-package-docs-as-metadata.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/spec": minor
+"@objectstack/cli": minor
+"@objectstack/objectql": minor
+"@objectstack/runtime": patch
+---
+
+ADR-0046 P1: package documentation as metadata. New `doc` metadata element — flat Markdown files under `src/docs/*.md` compile into `docs: DocSchema[]` on the stack and register like any other metadata.
+
+- spec: `DocSchema` ({ name, label?, content }) in `system/`, `StackDefinition.docs`, `doc` in `MetadataTypeSchema` + type registry (inert data, runtime-creatable) + canonical schema map, `docs → doc` plural mapping.
+- cli: `os build` collects flat `src/docs/*.md` (frontmatter `title:`/first `#` heading → label) and enforces the ADR lint — flat directory, namespace-prefixed snake_case names, namespace required when docs ship, MDX/image ban, same-package relative-link resolution. Same rules surface in `os lint`.
+- objectql: `docs` joins the generic metadata registration loop (manifest + nested plugins).
+- runtime: docs count as app payload; `GET /metadata/doc` list responses omit `content` by default (`?include=content` opts in) so unbounded manuals stay off hot paths.

--- a/docs/adr/0046-package-docs-as-metadata.md
+++ b/docs/adr/0046-package-docs-as-metadata.md
@@ -1,10 +1,10 @@
-# ADR-0046: Package documentation as metadata — `src/docs/` compiled into the manifest, derived content rendered not written
+# ADR-0046: Package documentation as metadata — flat `src/docs/*.md` compiled into the manifest
 
-**Status**: Proposed (2026-06-12)
+**Status**: Proposed (2026-06-12, revised — simplified from the original directory/docSet design)
 **Deciders**: ObjectStack Protocol Architects
-**Builds on**: [ADR-0003](./0003-package-as-first-class-citizen.md) (package + versioned releases), [ADR-0016](./0016-studio-package-authoring-and-publish.md) (publish pipeline, `manifest_json` snapshot), [ADR-0019](./0019-app-as-consumer-unit.md) (App is the only consumer-facing unit), [ADR-0025](./0025-plugin-package-distribution.md) (artifact distribution, trust boundary), [ADR-0033](./0033-ai-assisted-metadata-authoring.md) (AI as primary author)
-**Consumers**: `@objectstack/spec` (manifest `docs` element), `@objectstack/cli` (collection, publish lint, `os docs lint|verify`), `@objectstack/console` (help center, contextual help, metadata views), cloud control plane (registry rendering, grants — implementation design lives in the cloud repo), `@objectstack/core` (kernel skips `docs` at load)
-**Pilot**: `os-tianshun-mtc` (delivery project; repo layout + authoring conventions validated there first)
+**Builds on**: [ADR-0003](./0003-package-as-first-class-citizen.md) (package + versioned releases), [ADR-0016](./0016-studio-package-authoring-and-publish.md) (publish pipeline, `manifest_json` snapshot), [ADR-0025](./0025-plugin-package-distribution.md) (artifact distribution, trust boundary), [ADR-0033](./0033-ai-assisted-metadata-authoring.md) (AI as primary author)
+**Consumers**: `@objectstack/spec` (`DocSchema`, stack `docs` element), `@objectstack/cli` (collection, publish lint), `@objectstack/console` (doc rendering route), cloud control plane (registry rendering, grants), `@objectstack/core` (kernel registers `doc` as inert metadata)
+**Pilot**: `os-tianshun-mtc`
 
 ---
 
@@ -13,234 +13,230 @@
 A package today carries every behavioral fact about itself — objects,
 fields, validations, flows, permissions — but not one sentence of *intent*:
 what it is, how its users operate it, how its admins run it. That prose
-lives in ad-hoc repo trees, wikis, and static sites that rot the moment
-metadata changes, and reaches customers through channels (file shares,
-hosted sites) that duplicate the registry's versioning and access control.
+lives in ad-hoc repo trees and static sites that rot the moment metadata
+changes, and reaches customers through channels that duplicate the
+registry's versioning and access control.
 
-This ADR makes documentation a **metadata element**. Markdown under
-`src/docs/` compiles into the manifest exactly like objects and views do;
-the registry, console, and in-app AI assistant render it from there. Two
-disciplines keep it honest:
+This ADR makes documentation a **metadata element**, with the smallest
+possible shape:
 
-1. **Derived content is rendered, never written.** Field dictionaries,
-   permission matrices, validation lists, state-machine tables are *views
-   of metadata* — the platform renders them live; they must not exist as
-   authored or generated files. The only legitimate generation is a
-   **frozen export** (e.g. a confirmation PDF) bound to a released version.
-2. **Docs bind to what they change with.** Repo layout separates four
-   lifecycles: `src/` (ships with the package), `delivery/` (bound to one
-   customer's contract, never ships), `internal/` (engineering notes,
-   never ships), plus root `CHANGELOG.md` (collected at publish).
+- **One flat directory.** Every `.md` file in `src/docs/` (no
+  subdirectories) compiles into one `doc` metadata item, exactly like a
+  view or a dashboard. There are no docSets, no `meta.json`, no ordering
+  files, no directory taxonomy.
+- **Filename = metadata name = link anchor = URL.** A doc's identity is
+  its filename stem, namespace-prefixed like every other metadata name.
+  Docs reference each other with plain relative Markdown links
+  (`[guide](./crm_lead_guide.md)`); because the tree is flat, link
+  resolution is a basename lookup with zero path arithmetic, and a
+  reference never breaks by "moving a file to another folder" — there is
+  no other folder.
+- **Frontend is one route.** The console renders a doc at
+  `/docs/<name>`, rewriting `*.md` links to that route. No help-center
+  tree, no sidebar taxonomy, no navigation model in v1.
 
 ```
-src/docs/                      compiled into manifest.docs
-├── meta.json                  {"pages": ["index", "user", "admin"]}
-├── index.md                   what this package is        (floor: required)
-├── user/
-│   ├── meta.json              {"title": "...", "pages": ["lead", ...]}
-│   └── lead.md …              how each role operates it
-└── admin/ …                   how to run and configure it
-CHANGELOG.md                   what changed per version    (floor: required)
+src/docs/                      compiled into stack `docs: DocSchema[]`
+├── crm_index.md               what this package is
+├── crm_lead_guide.md          how to work leads        ─┐ reference each
+└── crm_admin_setup.md         how to configure it      ─┘ other by filename
 ```
-
----
 
 ## 1. Context
 
-- The manifest schema (`packages/spec/src/kernel/manifest.zod.ts`) has a
-  `description` string and nothing else documentation-shaped. ADR-0025
-  defines how code and dependencies travel; nothing defines how *intent*
-  travels.
+- The manifest schema has a `description` string and nothing else
+  documentation-shaped. ADR-0025 defines how code and dependencies
+  travel; nothing defines how *intent* travels.
 - Pure-element packages publish as a single self-contained JSON
   (`dist/objectstack.json` → `sys_package_version.manifest_json`,
-  ADR-0016). Anything added to the manifest therefore reaches the registry
-  **with zero registry schema changes** — the cheapest possible v1.
-- Delivery teams hand customers docs via static sites or files, rebuilding
-  versioning (directories), identity (logins), and authorization (per-site
-  auth) that the registry/grant system already provides. The cloud repo's
-  publisher-catalog design (grants, share tokens) makes the duplication
-  explicit: granting a package *should* grant its docs.
-- Field-reference documents generated into git rot by construction: they
-  are caches of a render. The pilot project shipped a 26-page generated
-  dictionary and deleted it within a day once this principle was named.
-- Going forward AI writes most documentation (ADR-0033 extends to prose).
-  The scarce resource is no longer writing effort but a machine-checkable
-  definition of "complete" and "too much".
+  ADR-0016). Anything added to the stack therefore reaches the registry
+  **with zero registry schema changes**, and `sys_package_grant`
+  authorization applies automatically — granting a package grants its
+  docs.
+- The first revision of this ADR designed a directory taxonomy (closed
+  docSet enum, per-directory `meta.json` ordering files, four lifecycle
+  trees). Review verdict: that is a *site* design, not a *metadata*
+  design. Every other metadata element is a flat, namespace-keyed
+  collection; docs gain nothing from being the one tree-shaped element,
+  and the tree actively hurts the property docs need most —
+  **stable cross-references**. A reference into a tree encodes a path;
+  paths change when content is reorganized. A reference into a flat
+  namespace encodes a name; names are forever.
+- Going forward AI writes most documentation (ADR-0033). Flat,
+  name-addressed items are also the shape AI authors best: create/update
+  one item, link by name — identical to how it already authors objects
+  and views (draft-gated via `saveMetaItem`, same review pipeline).
 
 ## 2. Goals & Non-goals
 
 ### Goals
 
-- A spec'd `docs` manifest element: collection rules, structure, syntax
-  boundary, minimal set per package type.
-- Repo layout convention separating the four documentation lifecycles.
-- Platform rendering surfaces (registry page, console help center,
-  contextual help, AI-assistant grounding) and their phasing.
-- Quality gates that make AI authorship safe: coverage floor, bloat
-  ceiling, fact-checking, usefulness evals.
-- i18n model compatible with AI-derived translations.
+- A spec'd `doc` metadata element: schema, naming, collection rule,
+  cross-reference rule, syntax boundary.
+- CLI collection (`os build`) and publish lint (broken links, banned
+  syntax).
+- One console rendering route, plus AI-assistant grounding (agents answer
+  "how do I…" from the package's own docs — same JSON the kernel loads).
 
-### Non-goals
+### Non-goals (unchanged from the original revision)
 
-- **Delivery documents** (requirement traceability, solution confirmation,
-  acceptance records). They bind to one contract, freeze at milestones,
-  and must *not* auto-update with code. Convention: `delivery/`, outside
-  the package. Their confirmation workflow is a cloud/process concern.
-- **Standalone product documentation sites** (e.g. docs.objectstack.ai,
-  docs.objectos.app). Those are websites; `content/docs/` remains their
-  convention. Package docs are package source, not a website.
-- **Internal engineering docs** (`internal/`, formerly `docs/` — renaming
-  removes the perpetual "docs vs content/docs" ambiguity; the word *docs*
-  appears in exactly one shippable path).
-- Rich media. v1 is text-only by design (§5).
+- **Delivery documents** (contract-bound, milestone-frozen) — convention
+  `delivery/`, outside the package.
+- **Standalone product doc sites** (docs.objectstack.ai) — those are
+  websites; `content/docs/` remains their convention.
+- **Internal engineering notes** — `internal/`, never ships.
+- Rich media: v1 is text-only (§3.4).
+
+### Explicitly deferred (was in the original revision, cut from v1)
+
+Directory taxonomy / docSets, `meta.json` ordering, help-center
+navigation tree, `CHANGELOG.md` collection, per-package-type minimal-set
+enforcement, `binds` contextual help, i18n sibling files, quality-gate
+tooling (`os docs lint|verify` beyond publish lint), asset service.
+Each is additive on top of flat name-addressed items; none is expensive
+to retrofit, so none is mandatory now.
 
 ## 3. Design
 
-### 3.1 Collection (one rule)
+### 3.1 Schema
 
-`src/docs/**/*.md` plus per-directory `meta.json` compile into
-`manifest.docs`. Root `CHANGELOG.md` is collected at publish into the
-version record. `src/` already means "everything here ships"; docs simply
-join objects, views, and dashboards under that single boundary. The
-kernel/plugin-loader **skips or lazy-loads** the `docs` section — manuals
-must not occupy runtime memory.
+```ts
+// packages/spec/src/system/doc.zod.ts
+export const DocSchema = z.object({
+  name: z.string().regex(/^[a-z][a-z0-9_]*$/)
+    .describe('Unique doc name; MUST carry the package namespace prefix (enforced by build/publish lint)'),
+  label: z.string().optional()
+    .describe('Display title; defaults to the first `#` heading, then the name'),
+  content: z.string().describe('Raw Markdown (CommonMark + GFM)'),
+});
+```
 
-### 3.2 Structure (closed set + explicit order)
+`StackDefinition` gains `docs: z.array(DocSchema).optional()`, beside
+`views` / `dashboards`. The kernel registers metadata type `doc` as
+**inert data** — no runtime behavior, no load-order participation.
+Two hard requirements keep manuals out of hot paths: the kernel load
+path must not parse or validate `content` beyond schema type-checking,
+and the metadata list endpoint must support returning `name` + `label`
+without `content` — docs are the one element whose payload grows
+unbounded, and manifest-size pressure lands here first.
 
-- **First-level directory = docSet**, a *closed* enum: `index.md`
-  (overview), `user/`, `admin/`. Closed means renderers know canonical
-  order ("what it is → how to use → how to run") and display names without
-  configuration, and AI cannot invent new trees.
-- **`meta.json`** (subset of the Fumadocs convention — exactly two fields,
-  `title` and `pages`) fixes ordering and directory titles. Absent →
-  alphabetical. Page title = first `#` heading; optional frontmatter may
-  override.
-- Ordering deliberately lives in a dedicated, schema-validatable file. The
-  alternatives each failed a long-term test: single-file-per-docSet mixes
-  chapters and destroys diff locality; numeric filename prefixes break
-  links on reorder; deriving order from `index.md` link order welds a
-  machine contract onto human prose, so every copy-edit becomes a
-  structure edit. **Structure and content stay physically separate** for
-  the same reason `delivery/` is a directory and not a flag: separation
-  beats convention, and a 3-line JSON the AI edits to reorder is a smaller
-  blast radius than a prose file it must not accidentally reflow.
+### 3.2 Collection (one rule)
 
-### 3.3 Syntax boundary (the two day-one prohibitions)
+`os build` compiles every `src/docs/*.md` into one `DocSchema` item:
 
-1. **Pure Markdown** (CommonMark + GFM; a small directive whitelist such
-   as admonitions/mermaid may be added later). **MDX is forbidden**: MDX
-   is code, and rendering publisher-supplied code inside the platform
+- `name` = filename stem. The stem MUST match `^[a-z][a-z0-9_]*$` and
+  carry the package namespace prefix (`crm_lead_guide.md` →
+  `crm_lead_guide`). A package that ships docs MUST declare
+  `manifest.namespace` — the natural extension of "defining objects
+  requires a namespace".
+
+  The prefix requirement *looks like* the object rule but sits at a
+  different layer, and the enforcement posture follows from that.
+  Object names are prefix-validated in the kernel because they are
+  physical: object name = table name in a shared database; a collision
+  is a data-layer disaster. Doc names have no physical footprint; their
+  uniqueness need is logical — the metadata registry key is
+  `org/type/name` with **no package coordinate**, so two packages
+  shipping the same bare name silently overwrite each other
+  (last-write-wins), and the console route `/docs/<name>` plus all
+  cross-references key on the name. Hence: enforced as **build/publish
+  lint**, not kernel-level rejection. `doc` is a new type with zero
+  legacy, so day-one lint costs nothing — the same reasoning as the
+  image ban.
+- `label` = frontmatter `title:` if present, else first `#` heading.
+- `content` = the file body (frontmatter stripped).
+- **Subdirectories under `src/docs/` are a build error**, not silently
+  flattened — flatness is the contract that keeps references stable.
+
+TS-first stacks may also pass `docs: [...]` inline in `defineStack()`;
+the md-file convention is sugar over the same array.
+
+### 3.3 Cross-references
+
+Docs link to each other with plain relative Markdown links:
+
+```md
+See the [lead guide](./crm_lead_guide.md#qualification) for details.
+```
+
+- Resolution rule: strip `./` and `.md` → doc name. Because names are
+  globally unique, this resolves the same way everywhere — inside the
+  authoring repo (editors/GitHub preview work natively), in the console,
+  in the registry, even **across packages** (a doc may link to a
+  dependency's doc by its name).
+- Publish lint resolves every relative `.md` link against the package's
+  docs plus its dependencies' docs; unresolvable links block publish.
+  This check is trivial *because* the namespace is flat.
+- Cross-package links are checked at publish against the dependency
+  versions present at publish time; a dependency may later remove a
+  doc. Renderers degrade an unresolvable link to a "doc not found"
+  notice — link integrity must NOT couple into install-time dependency
+  resolution (that would be over-design for prose).
+- Semantic links to metadata (`object://crm_lead`) remain reserved
+  syntax renderers may resolve later; v1 lint only requires they parse.
+
+### 3.4 Syntax boundary (the two day-one prohibitions, unchanged)
+
+1. **Pure Markdown** (CommonMark + GFM). **MDX is forbidden**: MDX is
+   code, and rendering publisher-supplied code inside the platform
    origin crosses the ADR-0025 trust boundary. Markdown is data; a
    sanitizing pipeline renders third-party packages safely.
 2. **No image references in v1** (publish lint rejects `![](…)`).
-   Binaries in the artifact bloat installs; arbitrary external URLs break
-   version immutability (a confirmed v1.3 whose screenshots silently
-   change is not confirmed) and leak customer UI data to unmanaged hosts.
-   v2 introduces a platform **asset service**: content-addressed,
-   immutable, unguessable URLs (`…/blob/sha256-…`); the CLI uploads local
-   images at publish and rewrites references; packages keep containing
-   text only. Enforcing the ban from day one means zero legacy cleanup
-   when assets arrive.
+   Binaries bloat artifacts; external URLs break version immutability
+   and leak customer data to unmanaged hosts. v2 introduces a
+   content-addressed platform asset service; enforcing the ban from day
+   one means zero legacy cleanup.
 
-Everything else — docSet declarations beyond the closed set, audience
-config, binds — is **additive** and deliberately absent from v1. Only
-rules that are expensive to retrofit (syntax, images) are mandatory now.
-
-### 3.4 Derived content is rendered, never written
+### 3.5 Derived content is rendered, never written (unchanged)
 
 Anything reconstructible from the manifest — field dictionaries, option
-lists, validation conditions, state-machine transitions, permission
-matrices — is a **metadata view**: the console renders it live
-(customer-readable schema browser, permission matrix view); the registry
-renders what package pages need. It must not exist as hand-written prose
-*or* as generated markdown committed to the repo (a cache in git, with a
-cache's lifecycle). Handwritten docs reference metadata via semantic links
-(`object://mtc_lead`) that renderers resolve; publish lint heuristically
-flags field-table blocks in prose.
-
-**The frozen-export exception**: at confirmation milestones a tool may
-render metadata + docs into a versioned artifact (PDF) for signature.
-Freezing is the requirement there; the export is produced once and never
+lists, validation conditions, permission matrices — is a **metadata
+view**: the platform renders it live. It must not exist as authored
+prose or generated markdown committed to the repo (a cache in git, with
+a cache's lifecycle). The one exception is a **frozen export** (e.g. a
+confirmation PDF) bound to a released version: produced once, never
 maintained, so it cannot rot.
-
-### 3.5 Minimal set per package type ("intent four-piece")
-
-| Package type | Required | Rationale |
-|:--|:--|:--|
-| App (consumer-facing, ADR-0019) | `index.md`, `user/`, `admin/`, `CHANGELOG.md` | what it is / how to use / how to run / what changed |
-| plugin / driver / connector | `index.md`, `CHANGELOG.md` | the "user" is a developer; `configuration` schema is already metadata and is rendered, not documented |
-
-Enforced by `os package publish` lint once available (warn → block). Until
-then it is the documented floor.
 
 ### 3.6 Distribution & rendering
 
 - **v1 needs no registry change**: docs ride `manifest_json`; package
-  visibility and `sys_package_grant` authorization apply to docs
-  automatically — granting a package grants its documentation.
-- Rendering surfaces, in expected delivery order:
-  1. **Registry package page** renders `index.md` (the npm-README model)
-     and CHANGELOG per version.
-  2. **Console help center**: sidebar tree from directories + `meta.json`,
-     markdown body, search. docSet is *not* a UI concept — users see
-     "Help", one tree; the closed set only fixes order and (later)
-     default visibility (`admin/` → org admins).
-  3. **Contextual help (v2)**: pages may declare `binds:
-     [object/view/flow]`; object pages get a "?" opening the bound
-     chapter. `binds` also powers coverage lint and staleness nudges
-     ("`mtc_lead` changed; its bound page didn't").
-  4. **AI assistant grounding**: in-app agents answer "how do I…" from the
-     package's own manual — same JSON the kernel loads. No UI required;
-     likely the highest-frequency consumer of docs and a direct payoff of
-     docs-in-manifest.
-
-### 3.7 i18n: translations are derived-but-reviewed
-
-- Single canonical source language per package. Translations are sibling
-  files `<page>.<locale>.md`; one tree, one `meta.json`; renderers fall
-  back to the source language.
-- In the AI era translations are *derived content with a review gate*
-  (lockfile model): generated by AI when the source changes, committed via
-  reviewed PR. Each translation records the source content hash;
-  `os docs lint` reports stale translations. Locale-directory mirrors are
-  rejected — two trees and N copies of `meta.json` drift by construction.
-
-### 3.8 Quality gates for AI authorship
-
-The floor and ceiling are computable *because the software is metadata*:
-
-| Gate | Mechanism | Tool |
-|:--|:--|:--|
-| Completeness (floor) | minimal-set check; `binds` coverage (every object/flow bound by ≥1 page); manifest **version-diff → docs impact checklist** the author must address item-by-item | publish lint / `os docs lint` |
-| Bloat (ceiling) | derived-content ban (§3.4); **token budget** per package tracked like bundle size — docs share the agent context window, so size is a functional constraint, not style | `os docs lint` |
-| Correctness | fact-check agent: extract verifiable claims ("approver is the sales director", "status X can only reach Y") and check them against the manifest; contradictions fail CI | `os docs verify` |
-| Usefulness | Q&A eval: an agent that can see *only the docs* answers real user questions; failures are documentation gaps | `os docs verify` |
-
-Humans review one thing only: **intent** — is the business context right.
-Everything mechanical is gated by machines, which is the only arrangement
-that scales when AI is the author (ADR-0033).
+  visibility and `sys_package_grant` apply automatically.
+- Two address spaces, two coordinate systems: *inside an instance*,
+  namespace uniqueness is guaranteed, so routes are single-coordinate
+  (`/docs/<name>`); *in the registry/cloud*, namespace uniqueness does
+  not hold across publishers and versions coexist, so registry surfaces
+  address docs with full coordinates (package id + version + name).
+  Neither weakens the other.
+- The standard metadata read API serves a doc by name
+  (`type='doc', name='crm_lead_guide'`) like any other metadata item.
+- **Console**: one route, `/docs/<name>` — fetch, sanitize, render
+  Markdown, rewrite `*.md` links to `/docs/<target>` (anchors
+  preserved). Any surface that wants to point at documentation (registry
+  package page, app navigation, an agent's answer) does so with that
+  URL. Navigation/sidebar/search are later, additive concerns.
+- **AI assistant grounding**: in-app agents load the package's docs as
+  context to answer "how do I…" — likely the highest-frequency consumer
+  and a direct payoff of docs-in-manifest.
 
 ## 4. Alternatives considered
 
 | Alternative | Verdict |
 |:--|:--|
-| Static doc sites per project (Pages/R2 + auth) | Right answer *without* a platform; duplicates registry versioning, identity, and grants when you have one. Acceptable only as a pre-§3.6 transition channel, retired afterwards. |
-| Docs as separate artifact beside the code artifact | Justified only by size; text-only packages make it moot. Revisit with the asset service if ever needed (ADR-0025 already provides the multi-artifact path). |
-| Generated reference markdown in-repo | A cache in git; rots by construction. Replaced by §3.4. Validated empirically on the pilot. |
-| MDX / React components in docs | Code crosses the trust boundary; interactivity comes from renderer-side directives and metadata views instead. |
-| `content/docs/` as the package-docs home | `content/` is the standalone-website convention (framework/cloud doc sites) and is role-empty for packages; package docs are package source → `src/docs/`. |
-| Ordering via filename prefixes / single file / index-link order | See §3.2 — each fails reorder cost, diff locality, or prose/contract separation. |
+| Directory taxonomy: closed docSet enum + per-directory `meta.json` (the original revision of this ADR) | A site design, not a metadata design. Trees make cross-references path-shaped and fragile; ordering files are structure-beside-content that AI must keep in sync. Flat name-addressed items match every other metadata element and make link lint trivial. Navigation, when needed, becomes *derived* structure (or an explicit later element) — not authored directory shape. |
+| Package-scoped doc names + `/docs/<package>/<name>` URLs | Two coordinates per reference; cross-package links and "one URL per doc" both get harder. Namespace-prefixed names reuse the platform's existing uniqueness rule for free. |
+| Static doc sites per project (Pages/R2 + auth) | Duplicates registry versioning, identity, and grants. Acceptable only as a transition channel. |
+| Generated reference markdown in-repo | A cache in git; rots by construction (§3.5). Validated empirically on the pilot. |
+| MDX / React components in docs | Code crosses the trust boundary; interactivity comes from renderer-side directives and metadata views. |
+| `content/docs/` as the package-docs home | `content/` is the standalone-website convention; package docs are package source → `src/docs/`. |
 
 ## 5. Phasing
 
 | Phase | Scope | Depends on |
 |:--|:--|:--|
-| **P0** (no platform change) | Repo conventions (`src/docs`, `delivery/`, `internal/`, CLAUDE.md authoring checklists) on pilot projects; optional transition static site | this ADR |
-| **P1** (framework) | spec `docs` schema; `os build` collection; publish lint (minimal set, MDX/image ban); kernel skip | P0 |
-| **P2** (cloud/console) | registry page rendering → help center → customer-readable metadata views (dictionary, permission matrix) → contextual help via `binds` | P1 |
-| **P3** (quality) | coverage/budget lint, version-diff checklist, fact-check + Q&A eval (`os docs verify`) | P1, AI service |
-| **P4** (enrichment) | asset service + images, audience filtering, frozen PDF export, i18n staleness tooling | P2 |
+| **P0** (no platform change) | Repo convention (`src/docs/*.md` flat, naming rule, link style) on pilot projects | this ADR |
+| **P1** (framework) | `DocSchema` in spec; `os build` collection; publish lint (naming, flatness, link resolution, MDX/image ban); kernel `doc` type | P0 |
+| **P2** (console/cloud) | `/docs/<name>` rendering route; registry package page renders the package's `*_index` doc; AI-assistant grounding | P1 |
+| **P3** (enrichment, all additive) | navigation/search, `binds` contextual help, i18n, quality gates, asset service + images | P2 |
 
-Project-side conventions (P0) are isomorphic to the P1 schema by
-construction: when the compiler lands, pilot content migrates with zero
-edits.
+P0 conventions are isomorphic to the P1 schema by construction: when the
+compiler lands, pilot content migrates with zero edits.

--- a/examples/app-todo/src/docs/todo_index.md
+++ b/examples/app-todo/src/docs/todo_index.md
@@ -1,0 +1,11 @@
+# Todo App
+
+A minimal task-management app demonstrating the ObjectStack metadata
+protocol end to end: objects, views, flows, agents — and this manual,
+which ships inside the package as `doc` metadata (ADR-0046).
+
+Each Markdown file in the flat `src/docs/` directory compiles into one
+`doc` item at build time; the console renders it at `/docs/<name>`.
+
+To learn how to work with tasks day to day, see the
+[user guide](./todo_user_guide.md).

--- a/examples/app-todo/src/docs/todo_user_guide.md
+++ b/examples/app-todo/src/docs/todo_user_guide.md
@@ -1,0 +1,16 @@
+---
+title: User Guide
+---
+
+# Working with Tasks
+
+Create a task from the **Tasks** list view, set a priority, and assign
+it to a project. Completed tasks are archived automatically by the
+cleanup flow.
+
+Tips:
+
+- Use the kanban view to drag tasks between statuses.
+- Overdue tasks are highlighted in the default list view.
+
+Back to the [overview](./todo_index.md).

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -10,6 +10,7 @@ import { loadConfig } from '../utils/config.js';
 import { lowerCallables } from '../utils/lower-callables.js';
 import { validateStackExpressions } from '../utils/validate-expressions.js';
 import { validateWidgetBindings } from '../utils/validate-widget-bindings.js';
+import { collectAndLintDocs } from '../utils/collect-docs.js';
 import { buildRuntimeBundle, cleanupOldRuntimeBundles } from '../utils/build-runtime.js';
 import {
   printHeader,
@@ -181,6 +182,36 @@ export default class Compile extends Command {
         }
       }
 
+      // 3d. Package docs (ADR-0046): compile flat `src/docs/*.md` into
+      //     `docs: DocSchema[]` and lint the combined set (flatness,
+      //     namespace-prefixed names, MDX/image ban, same-package link
+      //     resolution). Errors fail the build — the artifact is the
+      //     publish unit, so this IS the publish lint for docs.
+      if (!flags.json) printStep('Collecting package docs (ADR-0046)...');
+      const docsResult = collectAndLintDocs(absolutePath, result.data as Record<string, unknown>);
+      const docErrors = docsResult.issues.filter((i) => i.severity === 'error');
+      const docWarnings = docsResult.issues.filter((i) => i.severity === 'warning');
+      if (docErrors.length > 0) {
+        if (flags.json) {
+          console.log(JSON.stringify({ success: false, error: 'docs validation failed', issues: docErrors }));
+          this.exit(1);
+        }
+        console.log('');
+        printError(`Package docs validation failed (${docErrors.length} issue${docErrors.length > 1 ? 's' : ''})`);
+        for (const i of docErrors.slice(0, 50)) {
+          console.log(`  • ${i.path}: ${i.message}`);
+          console.log(chalk.dim(`      rule: ${i.rule}`));
+        }
+        this.exit(1);
+      }
+      if (docWarnings.length > 0 && !flags.json) {
+        console.log('');
+        for (const w of docWarnings) {
+          printWarning(`${w.path}: ${w.message}`);
+          console.log(chalk.dim(`    rule: ${w.rule}`));
+        }
+      }
+
       // 4. Generate Artifact
       if (!flags.json) printStep('Writing artifact...');
       const output = flags.output!;
@@ -192,6 +223,9 @@ export default class Compile extends Command {
       }
 
       const finalBundle: Record<string, unknown> = { ...(result.data as Record<string, unknown>) };
+      if (docsResult.docs.length > 0) {
+        finalBundle.docs = docsResult.docs;
+      }
 
       // 4b. Bundle handler functions into `<artifactDir>/objectstack-runtime.{hash}.mjs`
       //     and stamp the relative path into the JSON so the runtime can

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -8,6 +8,7 @@ import { loadConfig, BUNDLE_REQUIRE_EXTERNALS } from '../utils/config.js';
 import { computeI18nCoverage } from '../utils/i18n-coverage.js';
 import { lintDataModel } from '../lint/data-model-rules.js';
 import { validateWidgetBindings } from '../utils/validate-widget-bindings.js';
+import { collectAndLintDocs } from '../utils/collect-docs.js';
 import { scoreMetadata } from '../lint/score.js';
 import { runMetadataEval } from '../lint/metadata-eval.js';
 import { DEFAULT_METADATA_EVAL_CORPUS } from '../lint/corpus.js';
@@ -302,6 +303,13 @@ export default class Lint extends Command {
 
       const normalized = normalizeStackInput(config as Record<string, unknown>);
       const issues = lintConfig(normalized);
+
+      // ── Package docs (ADR-0046) ── collected src/docs/*.md + inline docs:
+      // flatness, namespace-prefixed names, MDX/image ban, link resolution.
+      const docsResult = collectAndLintDocs(absolutePath, normalized as Record<string, unknown>);
+      for (const d of docsResult.issues) {
+        issues.push({ severity: d.severity, rule: d.rule, message: d.message, path: d.path });
+      }
 
       // ── Translation coverage ──
       if (!flags['skip-i18n']) {

--- a/packages/cli/src/utils/collect-docs.test.ts
+++ b/packages/cli/src/utils/collect-docs.test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { collectDocsFromSrc, lintDocs, collectAndLintDocs, type DocItem } from './collect-docs.js';
+
+let tmp: string;
+let configPath: string;
+let docsDir: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'os-docs-'));
+  configPath = path.join(tmp, 'objectstack.config.ts');
+  fs.writeFileSync(configPath, '// stub');
+  docsDir = path.join(tmp, 'src', 'docs');
+  fs.mkdirSync(docsDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+const write = (name: string, content: string) => fs.writeFileSync(path.join(docsDir, name), content);
+
+describe('collectDocsFromSrc (ADR-0046 §3.2)', () => {
+  it('compiles each flat .md file into a doc item (stem = name)', () => {
+    write('crm_index.md', '# CRM Overview\n\nWhat it is.');
+    write('crm_lead_guide.md', '---\ntitle: Lead Guide\n---\n\nBody here.');
+    const { docs, issues } = collectDocsFromSrc(configPath);
+    expect(issues).toHaveLength(0);
+    expect(docs.map((d) => d.name).sort()).toEqual(['crm_index', 'crm_lead_guide']);
+    const index = docs.find((d) => d.name === 'crm_index')!;
+    expect(index.label).toBe('CRM Overview'); // first # heading
+    const guide = docs.find((d) => d.name === 'crm_lead_guide')!;
+    expect(guide.label).toBe('Lead Guide'); // frontmatter title wins
+    expect(guide.content).not.toContain('title:'); // frontmatter stripped
+  });
+
+  it('errors on subdirectories — flatness is the contract', () => {
+    fs.mkdirSync(path.join(docsDir, 'user'));
+    write('crm_index.md', '# x');
+    const { docs, issues } = collectDocsFromSrc(configPath);
+    expect(issues.some((i) => i.rule === 'docs/flat-directory' && i.severity === 'error')).toBe(true);
+    expect(docs).toHaveLength(1); // the valid file still collects
+  });
+
+  it('errors on non-snake_case filename stems', () => {
+    write('Lead-Guide.md', '# x');
+    const { docs, issues } = collectDocsFromSrc(configPath);
+    expect(issues.some((i) => i.rule === 'docs/filename')).toBe(true);
+    expect(docs).toHaveLength(0);
+  });
+
+  it('ignores non-markdown files and returns empty when src/docs is absent', () => {
+    write('notes.txt', 'not a doc');
+    expect(collectDocsFromSrc(configPath).docs).toHaveLength(0);
+    fs.rmSync(docsDir, { recursive: true });
+    expect(collectDocsFromSrc(configPath).docs).toHaveLength(0);
+  });
+});
+
+describe('lintDocs (ADR-0046 §3.2–§3.4)', () => {
+  const doc = (name: string, content: string): DocItem => ({ name, content });
+
+  it('requires manifest.namespace when docs ship', () => {
+    const issues = lintDocs([doc('crm_index', 'x')], undefined);
+    expect(issues.some((i) => i.rule === 'docs/namespace-required')).toBe(true);
+  });
+
+  it('requires the namespace prefix on every doc name', () => {
+    const issues = lintDocs([doc('lead_guide', 'x')], 'crm');
+    const hit = issues.find((i) => i.rule === 'docs/namespace-prefix');
+    expect(hit?.severity).toBe('error');
+    expect(hit?.message).toContain('crm_lead_guide');
+  });
+
+  it('rejects duplicate names across inline + collected docs', () => {
+    const issues = lintDocs([doc('crm_index', 'a'), doc('crm_index', 'b')], 'crm');
+    expect(issues.some((i) => i.rule === 'docs/duplicate-name')).toBe(true);
+  });
+
+  it('bans image references (v1 text-only)', () => {
+    const issues = lintDocs([doc('crm_index', 'See ![screenshot](https://x/y.png)')], 'crm');
+    expect(issues.some((i) => i.rule === 'docs/no-images')).toBe(true);
+  });
+
+  it('bans MDX/JSX but tolerates code blocks that mention it', () => {
+    expect(
+      lintDocs([doc('crm_a', 'Use <Tabs items={x}> here')], 'crm')
+        .some((i) => i.rule === 'docs/no-mdx'),
+    ).toBe(true);
+    expect(
+      lintDocs([doc('crm_b', 'Example:\n\n```jsx\n<Tabs items={x} />\n```\n\nplain prose')], 'crm')
+        .some((i) => i.rule === 'docs/no-mdx'),
+    ).toBe(false);
+  });
+
+  it('resolves same-package relative links and flags broken ones', () => {
+    const docs = [
+      doc('crm_index', 'See the [guide](./crm_lead_guide.md#start) and [missing](./crm_nope.md).'),
+      doc('crm_lead_guide', 'Back to [index](crm_index.md).'),
+    ];
+    const issues = lintDocs(docs, 'crm');
+    const broken = issues.filter((i) => i.rule === 'docs/broken-link');
+    expect(broken).toHaveLength(1);
+    expect(broken[0].message).toContain('crm_nope');
+  });
+
+  it('leaves cross-package links (foreign prefix) to publish-time checks', () => {
+    const issues = lintDocs([doc('crm_index', 'See [billing](./billing_setup.md).')], 'crm');
+    expect(issues.some((i) => i.rule === 'docs/broken-link')).toBe(false);
+  });
+});
+
+describe('collectAndLintDocs', () => {
+  it('merges inline stack docs with collected files and lints the union', () => {
+    write('crm_admin_setup.md', '# Admin Setup\n\nSee [index](./crm_index.md).');
+    const stack = {
+      manifest: { namespace: 'crm' },
+      docs: [{ name: 'crm_index', content: '# CRM' }],
+    };
+    const { docs, issues } = collectAndLintDocs(configPath, stack);
+    expect(docs.map((d) => d.name).sort()).toEqual(['crm_admin_setup', 'crm_index']);
+    expect(issues).toHaveLength(0);
+  });
+});

--- a/packages/cli/src/utils/collect-docs.ts
+++ b/packages/cli/src/utils/collect-docs.ts
@@ -1,0 +1,228 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Package documentation collection + lint (ADR-0046).
+ *
+ * `os build` compiles every Markdown file in the package's flat
+ * `src/docs/` directory into a `doc` metadata item on the stack
+ * (`docs: DocSchema[]`). This module owns both halves of that contract:
+ *
+ *   - **Collection**: filename stem → `name`, frontmatter `title:` or the
+ *     first `#` heading → `label`, body → `content`. Subdirectories are a
+ *     build error — flatness is the contract that keeps cross-references
+ *     stable (a link is `[text](./<name>.md)`; resolution is a basename
+ *     lookup with zero path arithmetic).
+ *   - **Lint**: namespace-prefix naming (doc uniqueness is logical — the
+ *     metadata registry key carries no package coordinate, so a bare-name
+ *     collision silently overwrites across packages), the v1 syntax bans
+ *     (no MDX, no images), and same-package link resolution.
+ *
+ * Cross-package links (a target whose prefix is not this package's
+ * namespace) are deliberately not checked here: they resolve against
+ * dependency docs at publish time, and render-side they degrade to a
+ * "doc not found" notice rather than coupling into dependency resolution.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+export interface DocItem {
+  name: string;
+  label?: string;
+  content: string;
+}
+
+export interface DocIssue {
+  severity: 'error' | 'warning';
+  rule: string;
+  message: string;
+  path: string;
+}
+
+const DOC_NAME_RE = /^[a-z][a-z0-9_]*$/;
+
+/** Strip a leading `---` frontmatter block; extract a `title:` if present. */
+function parseFrontmatter(raw: string): { title?: string; body: string } {
+  if (!raw.startsWith('---\n') && !raw.startsWith('---\r\n')) return { body: raw };
+  const end = raw.indexOf('\n---', 3);
+  if (end === -1) return { body: raw };
+  const block = raw.slice(raw.indexOf('\n') + 1, end);
+  const bodyStart = raw.indexOf('\n', end + 1);
+  const body = bodyStart === -1 ? '' : raw.slice(bodyStart + 1);
+  const titleLine = block.split(/\r?\n/).find((l) => /^title\s*:/.test(l));
+  const title = titleLine
+    ? titleLine.replace(/^title\s*:\s*/, '').trim().replace(/^['"]|['"]$/g, '')
+    : undefined;
+  return { title: title || undefined, body };
+}
+
+/** Remove fenced code blocks and inline code spans before content scans. */
+function stripCode(markdown: string): string {
+  return markdown
+    .replace(/^(```|~~~)[\s\S]*?^\1\s*$/gm, '')
+    .replace(/`[^`\n]*`/g, '');
+}
+
+function firstHeading(markdown: string): string | undefined {
+  const m = stripCode(markdown).match(/^#\s+(.+)$/m);
+  return m ? m[1].trim() : undefined;
+}
+
+/**
+ * Read `src/docs/*.md` (flat) next to the given config file and compile
+ * each file into a `DocItem`. Structural problems (subdirectories, bad
+ * filename stems) are reported as error issues; offending files are
+ * skipped rather than partially collected.
+ */
+export function collectDocsFromSrc(configPath: string): { docs: DocItem[]; issues: DocIssue[] } {
+  const docsDir = path.join(path.dirname(configPath), 'src', 'docs');
+  const docs: DocItem[] = [];
+  const issues: DocIssue[] = [];
+  if (!fs.existsSync(docsDir)) return { docs, issues };
+
+  for (const entry of fs.readdirSync(docsDir, { withFileTypes: true })) {
+    const rel = `src/docs/${entry.name}`;
+    if (entry.isDirectory()) {
+      issues.push({
+        severity: 'error',
+        rule: 'docs/flat-directory',
+        message: `Subdirectory "${entry.name}" under src/docs/ is not allowed (ADR-0046 §3.2). Flatten all .md files directly into src/docs/.`,
+        path: rel,
+      });
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+
+    const stem = entry.name.slice(0, -3);
+    if (!DOC_NAME_RE.test(stem)) {
+      issues.push({
+        severity: 'error',
+        rule: 'docs/filename',
+        message: `Doc filename "${entry.name}" must be snake_case (e.g. crm_lead_guide.md); the stem becomes the doc name.`,
+        path: rel,
+      });
+      continue;
+    }
+
+    const raw = fs.readFileSync(path.join(docsDir, entry.name), 'utf-8');
+    const { title, body } = parseFrontmatter(raw);
+    docs.push({ name: stem, label: title ?? firstHeading(body), content: body });
+  }
+  return { docs, issues };
+}
+
+/**
+ * Content + naming lint over the package's full doc set (collected files
+ * plus any inline `defineStack({ docs })` items).
+ */
+export function lintDocs(docs: DocItem[], namespace: string | undefined): DocIssue[] {
+  const issues: DocIssue[] = [];
+  if (docs.length === 0) return issues;
+
+  if (!namespace) {
+    issues.push({
+      severity: 'error',
+      rule: 'docs/namespace-required',
+      message: 'A package that ships docs must declare manifest.namespace (ADR-0046 §3.2) — doc names are namespace-prefixed.',
+      path: 'manifest.namespace',
+    });
+  }
+
+  const names = new Set<string>();
+  for (const doc of docs) {
+    const where = `docs/${doc.name}`;
+
+    if (names.has(doc.name)) {
+      issues.push({
+        severity: 'error',
+        rule: 'docs/duplicate-name',
+        message: `Duplicate doc name "${doc.name}" (inline defineStack docs and src/docs/*.md files share one namespace).`,
+        path: where,
+      });
+      continue;
+    }
+    names.add(doc.name);
+
+    if (namespace && !doc.name.startsWith(`${namespace}_`)) {
+      issues.push({
+        severity: 'error',
+        rule: 'docs/namespace-prefix',
+        message: `Doc name "${doc.name}" must carry the package namespace prefix: rename to "${namespace}_${doc.name}" (file ${namespace}_${doc.name}.md).`,
+        path: where,
+      });
+    }
+
+    const scannable = stripCode(doc.content);
+
+    // v1 image ban (ADR-0046 §3.4): binaries bloat artifacts; external
+    // URLs break version immutability.
+    if (/!\[[^\]]*\]\(/.test(scannable) || /<img[\s>]/i.test(scannable)) {
+      issues.push({
+        severity: 'error',
+        rule: 'docs/no-images',
+        message: `Doc "${doc.name}" contains an image reference — not allowed in v1 (ADR-0046 §3.4).`,
+        path: where,
+      });
+    }
+
+    // MDX ban (ADR-0046 §3.4): MDX is code crossing the ADR-0025 trust
+    // boundary. Heuristics are conservative — ESM import/export statement
+    // shapes and capitalized JSX component tags outside code — so prose
+    // like "import the data first" never trips them.
+    if (
+      /^\s*import\s+.+\s+from\s+['"]/m.test(scannable) ||
+      /^\s*export\s+(default|const|function)\s/m.test(scannable) ||
+      /<[A-Z][A-Za-z0-9]*[\s/>]/.test(scannable)
+    ) {
+      issues.push({
+        severity: 'error',
+        rule: 'docs/no-mdx',
+        message: `Doc "${doc.name}" appears to contain MDX/JSX — only CommonMark + GFM Markdown is allowed (ADR-0046 §3.3/§3.4).`,
+        path: where,
+      });
+    }
+  }
+
+  // Same-package link resolution: `[text](./<name>.md#anchor)` where the
+  // target carries OUR namespace prefix must resolve to a doc in this
+  // package. Targets with a different prefix are cross-package links,
+  // verified at publish time against dependency docs.
+  for (const doc of docs) {
+    const linkRe = /\]\((?:\.\/)?([a-zA-Z0-9_.-]+\.md)(#[^)]*)?\)/g;
+    const scannable = stripCode(doc.content);
+    let m: RegExpExecArray | null;
+    while ((m = linkRe.exec(scannable)) !== null) {
+      const target = m[1].slice(0, -3);
+      if (m[1].includes('/')) continue; // path-shaped link; flatness rule already errs on real subdirs
+      if (namespace && !target.startsWith(`${namespace}_`)) continue;
+      if (!names.has(target)) {
+        issues.push({
+          severity: 'error',
+          rule: 'docs/broken-link',
+          message: `Doc "${doc.name}" links to "./${m[1]}" but no doc named "${target}" exists in this package.`,
+          path: `docs/${doc.name}`,
+        });
+      }
+    }
+  }
+
+  return issues;
+}
+
+/**
+ * One-call entry for `os build`: collect `src/docs/*.md`, merge with the
+ * stack's inline `docs`, and lint the combined set. Returns the merged
+ * doc array (inline items first — they were already schema-validated) and
+ * every issue found.
+ */
+export function collectAndLintDocs(
+  configPath: string,
+  stack: Record<string, unknown>,
+): { docs: DocItem[]; issues: DocIssue[] } {
+  const inline = Array.isArray(stack.docs) ? (stack.docs as DocItem[]) : [];
+  const collected = collectDocsFromSrc(configPath);
+  const namespace = (stack.manifest as { namespace?: string } | undefined)?.namespace;
+  const docs = [...inline, ...collected.docs];
+  const issues = [...collected.issues, ...lintDocs(docs, namespace)];
+  return { docs, issues };
+}

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -936,6 +936,8 @@ export class ObjectQL implements IDataEngine {
         'hooks', 'mappings', 'analyticsCubes',
         // Integration Protocol
         'connectors',
+        // System Protocol — package documentation (ADR-0046); inert data
+        'docs',
       ];
       for (const key of metadataArrayKeys) {
           const items = (manifest as any)[key];
@@ -1081,6 +1083,7 @@ export class ObjectQL implements IDataEngine {
           'roles', 'permissions', 'profiles', 'sharingRules', 'policies',
           'agents', 'ragPipelines', 'apis',
           'hooks', 'mappings', 'analyticsCubes', 'connectors',
+          'docs',
       ];
       for (const key of metadataArrayKeys) {
           const items = (plugin as any)[key];

--- a/packages/runtime/src/app-plugin.ts
+++ b/packages/runtime/src/app-plugin.ts
@@ -69,6 +69,7 @@ export class AppPlugin implements Plugin {
                 'flows', 'workflows', 'triggers', 'agents', 'tools', 'skills',
                 'actions', 'permissions', 'roles', 'profiles', 'translations',
                 'sharingRules', 'ragPipelines', 'data', 'emailTemplates',
+                'docs',
             ];
             const hasAppPayload = APP_CATEGORY_KEYS.some((k) => {
                 const v = (bundle && bundle[k]) ?? (sys && sys[k]);

--- a/packages/runtime/src/http-dispatcher.ts
+++ b/packages/runtime/src/http-dispatcher.ts
@@ -207,6 +207,25 @@ export class HttpDispatcher {
     }
 
     /**
+     * ADR-0046: `doc` list responses omit `content` by default — manuals
+     * are the one metadata payload that grows unbounded, and the list
+     * surface only needs `name` + `label`. `?include=content` opts back in
+     * (single-item GET /metadata/doc/:name always returns the full body).
+     */
+    private slimDocList(type: string, data: any, query?: Record<string, string>): any {
+        if (type !== 'doc' || query?.include === 'content') return data;
+        const strip = (items: any[]) =>
+            items.map((i) => {
+                if (!i || typeof i !== 'object') return i;
+                const { content: _content, ...rest } = i as Record<string, unknown>;
+                return rest;
+            });
+        if (Array.isArray(data)) return strip(data);
+        if (data && Array.isArray(data.items)) return { ...data, items: strip(data.items) };
+        return data;
+    }
+
+    /**
      * 404 Route Not Found — no route is registered for this path.
      */
     private routeNotFound(route: string) {
@@ -1207,7 +1226,7 @@ export class HttpDispatcher {
                     const data = await protocol.getMetaItems({ type: typeOrName, packageId, organizationId, previewDrafts });
                     // Return any valid response from protocol (including empty items arrays)
                     if (data && (data.items !== undefined || Array.isArray(data))) {
-                        return { handled: true, response: this.success(data) };
+                        return { handled: true, response: this.success(this.slimDocList(typeOrName, data, query)) };
                     }
                 } catch {
                     // Protocol doesn't know this type, fall through
@@ -1225,7 +1244,7 @@ export class HttpDispatcher {
                         items = items.filter((item: any) => item?._packageId === packageId);
                     }
                     if (items && items.length > 0) {
-                        return { handled: true, response: this.success({ type: typeOrName, items }) };
+                        return { handled: true, response: this.success({ type: typeOrName, items: this.slimDocList(typeOrName, items, query) }) };
                     }
                 } catch (e: any) {
                     // MetadataService doesn't know this type or failed, continue to other fallbacks

--- a/packages/spec/src/kernel/metadata-plugin.zod.ts
+++ b/packages/spec/src/kernel/metadata-plugin.zod.ts
@@ -104,6 +104,7 @@ export const MetadataTypeSchema = lazySchema(() => z.enum([
   'function',    // Serverless functions
   'service',     // Service definitions
   'email_template', // Outbound email templates (EmailTemplateSchema)
+  'doc',         // Package documentation — flat Markdown items (DocSchema, ADR-0046)
 
   // Security Protocol
   'permission',  // Permission sets (PermissionSetSchema)
@@ -659,6 +660,12 @@ export const DEFAULT_METADATA_TYPE_REGISTRY: MetadataTypeRegistryEntry[] = [
   { type: 'function', label: 'Function', filePatterns: ['**/*.function.ts'], supportsOverlay: false, allowOrgOverride: false, allowRuntimeCreate: false, supportsVersioning: false, executionPinned: false, loadOrder: 40, domain: 'system' },
   { type: 'service', label: 'Service', filePatterns: ['**/*.service.ts'], supportsOverlay: false, allowOrgOverride: false, allowRuntimeCreate: false, supportsVersioning: false, executionPinned: false, loadOrder: 40, domain: 'system' },
   { type: 'email_template', label: 'Email Template', filePatterns: ['**/*.email-template.ts', '**/*.email-template.yml', '**/*.email-template.json'], supportsOverlay: true, allowOrgOverride: true, allowRuntimeCreate: true, supportsVersioning: false, executionPinned: false, loadOrder: 85, domain: 'system' },
+  // ADR-0046: package documentation. Inert data — no runtime behavior, no
+  // overlay (a manual is the publisher's voice; tenants don't patch it).
+  // Runtime-creatable so AI/authors can draft docs via saveMetaItem
+  // (ADR-0033). Collected from flat `src/docs/*.md` by the CLI; the kernel
+  // never parses `content`. loadOrder is last: nothing references docs.
+  { type: 'doc', label: 'Documentation', description: 'Package documentation — flat Markdown items (ADR-0046)', filePatterns: ['**/docs/*.md'], supportsOverlay: false, allowOrgOverride: false, allowRuntimeCreate: true, supportsVersioning: false, executionPinned: false, loadOrder: 99, domain: 'system' },
 
   // Security Protocol
   { type: 'permission', label: 'Permission Set', filePatterns: ['**/*.permission.ts', '**/*.permission.yml'], supportsOverlay: true, allowOrgOverride: true, allowRuntimeCreate: true, supportsVersioning: true, executionPinned: false, loadOrder: 15, domain: 'security' },

--- a/packages/spec/src/kernel/metadata-type-schemas.ts
+++ b/packages/spec/src/kernel/metadata-type-schemas.ts
@@ -48,6 +48,7 @@ import { FlowSchema } from '../automation/flow.zod';
 import { JobSchema } from '../system/job.zod';
 import { EmailTemplateDefinitionSchema } from '../system/email-template.zod';
 import { AppTranslationBundleSchema } from '../system/translation.zod';
+import { DocSchema } from '../system/doc.zod';
 
 import { PermissionSetSchema } from '../security/permission.zod';
 import { RoleSchema } from '../identity/role.zod';
@@ -95,6 +96,7 @@ const BUILTIN_METADATA_TYPE_SCHEMAS: Partial<Record<MetadataType, z.ZodType>> = 
   datasource: DatasourceSchema,
   translation: AppTranslationBundleSchema,
   email_template: EmailTemplateDefinitionSchema,
+  doc: DocSchema, // ADR-0046: flat Markdown package documentation
   // `router` / `function` / `service` are code-only (allowRuntimeCreate: false).
 
   // Security Protocol

--- a/packages/spec/src/shared/metadata-collection.zod.ts
+++ b/packages/spec/src/shared/metadata-collection.zod.ts
@@ -135,6 +135,7 @@ export const PLURAL_TO_SINGULAR: Record<string, string> = {
   datasources: 'datasource',
   views: 'view',
   emailTemplates: 'email_template',
+  docs: 'doc',
 };
 
 /** Reverse mapping: singular metadata type → plural manifest field name. */

--- a/packages/spec/src/stack.zod.ts
+++ b/packages/spec/src/stack.zod.ts
@@ -52,6 +52,7 @@ import { WebhookSchema } from './automation/webhook.zod';
 
 // System Protocol (additional)
 import { EmailTemplateDefinitionSchema } from './system/email-template.zod';
+import { DocSchema } from './system/doc.zod';
 
 // Integration Protocol
 import { ConnectorSchema } from './integration/connector.zod';
@@ -224,6 +225,7 @@ export const ObjectStackDefinitionSchema = lazySchema(() => z.object({
   flows: z.array(FlowSchema).optional().describe('Screen Flows'),
   jobs: z.array(JobSchema).optional().describe('Background / Scheduled Jobs (run by IJobService on cron/interval/once schedules)'),
   emailTemplates: z.array(EmailTemplateDefinitionSchema).optional().describe('Email Templates resolved by IEmailService.sendTemplate({ template, locale })'),
+  docs: z.array(DocSchema).optional().describe('Package documentation — flat Markdown items compiled from src/docs/*.md (ADR-0046)'),
 
   /**
    * ObjectGuard: Security Layer

--- a/packages/spec/src/system/doc.test.ts
+++ b/packages/spec/src/system/doc.test.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { DocSchema } from './doc.zod';
+import { ObjectStackDefinitionSchema } from '../stack.zod';
+import { MetadataTypeSchema } from '../kernel/metadata-plugin.zod';
+import { getMetadataTypeSchema } from '../kernel/metadata-type-schemas';
+import { pluralToSingular } from '../shared/metadata-collection.zod';
+
+describe('DocSchema (ADR-0046)', () => {
+  it('accepts a minimal doc (name + content)', () => {
+    const doc = DocSchema.parse({
+      name: 'crm_lead_guide',
+      content: '# Lead Guide\n\nHow to work leads.',
+    });
+    expect(doc.name).toBe('crm_lead_guide');
+    expect(doc.label).toBeUndefined();
+  });
+
+  it('accepts an optional label', () => {
+    const doc = DocSchema.parse({
+      name: 'crm_index',
+      label: 'CRM Overview',
+      content: 'What this package is.',
+    });
+    expect(doc.label).toBe('CRM Overview');
+  });
+
+  it('rejects non-snake_case names', () => {
+    for (const name of ['CrmGuide', 'crm-guide', '1crm', 'crm guide', '']) {
+      expect(() => DocSchema.parse({ name, content: 'x' }), name).toThrow();
+    }
+  });
+
+  it('rejects a doc without content', () => {
+    expect(() => DocSchema.parse({ name: 'crm_index' })).toThrow();
+  });
+});
+
+describe('stack `docs` element wiring', () => {
+  it('parses a stack carrying docs', () => {
+    const stack = ObjectStackDefinitionSchema.parse({
+      manifest: { id: 'com.example.crm', name: 'CRM', version: '1.0.0', type: 'app', namespace: 'crm' },
+      docs: [
+        { name: 'crm_index', content: '# CRM' },
+        { name: 'crm_lead_guide', label: 'Leads', content: 'See [overview](./crm_index.md).' },
+      ],
+    });
+    expect(stack.docs).toHaveLength(2);
+  });
+
+  it('registers `doc` as a metadata type with a canonical schema', () => {
+    expect(MetadataTypeSchema.parse('doc')).toBe('doc');
+    expect(getMetadataTypeSchema('doc')).toBeDefined();
+  });
+
+  it('maps the plural stack key to the singular registry type', () => {
+    expect(pluralToSingular('docs')).toBe('doc');
+  });
+});

--- a/packages/spec/src/system/doc.zod.ts
+++ b/packages/spec/src/system/doc.zod.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { z } from 'zod';
+import { lazySchema } from '../shared/lazy-schema';
+
+/**
+ * Package Documentation Metadata Protocol (ADR-0046)
+ *
+ * One `doc` item per Markdown file under the package's flat `src/docs/`
+ * directory (no subdirectories — flatness is the contract that keeps
+ * cross-references stable). The CLI compiles each file into this shape at
+ * build time; TS-first stacks may also declare items inline via
+ * `defineStack({ docs: [...] })`.
+ *
+ * Identity model: `name` = filename stem and MUST carry the package
+ * namespace prefix (`crm_lead_guide.md` → `crm_lead_guide`). Unlike object
+ * names (validated in the kernel because they map to physical table
+ * names), doc-name prefixing is a *logical* uniqueness requirement — the
+ * metadata registry key carries no package coordinate — so it is enforced
+ * by build/publish lint, not by this schema.
+ *
+ * Docs are inert data: the kernel registers them without parsing
+ * `content`, and they participate in no runtime behavior. Renderers
+ * resolve relative links between docs (`[guide](./crm_lead_guide.md)`)
+ * by stripping `./` and `.md` to obtain the target doc name.
+ */
+export const DocSchema = lazySchema(() => z.object({
+  /**
+   * Unique doc name; equals the source filename stem. Namespace-prefixed
+   * (e.g. `crm_lead_guide`) — see ADR-0046 §3.2 for the enforcement
+   * posture (build/publish lint, not kernel rejection).
+   */
+  name: z.string()
+    .regex(/^[a-z][a-z0-9_]*$/, 'name must be lowercase snake_case')
+    .describe('Unique doc name (= filename stem, namespace-prefixed snake_case)'),
+
+  /**
+   * Display title. The CLI derives it from frontmatter `title:` or the
+   * first `#` heading; renderers fall back to `name` when absent.
+   */
+  label: z.string().optional()
+    .describe('Display title; defaults to the first `#` heading, then the name'),
+
+  /**
+   * Raw Markdown body (CommonMark + GFM), frontmatter stripped.
+   * MDX and image references are banned in v1 (ADR-0046 §3.4) —
+   * enforced by lint, not here: the kernel load path must stay
+   * content-agnostic.
+   */
+  content: z.string().describe('Raw Markdown content (CommonMark + GFM)'),
+}));
+export type Doc = z.infer<typeof DocSchema>;

--- a/packages/spec/src/system/index.ts
+++ b/packages/spec/src/system/index.ts
@@ -28,6 +28,7 @@ export * from './migration.zod';
 
 // Security & Compliance
 export * from './auth-config.zod';
+export * from './doc.zod';
 export * from './email-config.zod';
 export * from './email-template.zod';
 export * from './email-template.form';


### PR DESCRIPTION
## Summary

Revises **ADR-0046** (package documentation as metadata) to the simplified flat design and ships the full **P1 framework implementation**.

### ADR revision
- One flat `src/docs/*.md` directory — no docSets, no `meta.json`, no directory taxonomy; flatness is the contract that keeps cross-references stable
- Filename stem = metadata name = link anchor = URL (`/docs/<name>`); names are namespace-prefixed
- Prefix rationale corrected: object names are kernel-validated because they are *physical* (table names); doc names need only *logical* uniqueness (registry key `org/type/name` has no package coordinate → silent last-write-wins overwrite), hence build/publish-lint enforcement
- Hard requirements: kernel never parses `content`; list endpoint serves `name`+`label` without `content`
- Two address spaces: instance routes are single-coordinate; registry/cloud surfaces use full coordinates (package id + version + name)

### Implementation
- **spec**: `DocSchema { name, label?, content }`, `StackDefinition.docs`, `doc` metadata type + registry entry (inert, runtime-creatable for AI drafting per ADR-0033) + canonical schema map, `docs → doc` plural mapping
- **cli**: `os build` compiles flat `src/docs/*.md` (frontmatter `title:` / first `#` heading → label) and enforces the ADR lint — flat directory, namespace-prefixed snake_case names, namespace required when docs ship, MDX/image ban, same-package link resolution; same rules in `os lint`
- **objectql**: `docs` joins the generic metadata registration loop (manifest + nested plugins)
- **runtime**: docs count as app payload; `GET /metadata/doc` list omits `content` by default (`?include=content` opts in)
- **examples/app-todo**: two cross-referencing docs as a living sample

## Test plan
- [x] New unit tests: `packages/spec/src/system/doc.test.ts`, `packages/cli/src/utils/collect-docs.test.ts` (12 cases)
- [x] Full suites green locally: spec 6536, cli 287, objectql 569, runtime 370; builds (incl. DTS) pass
- [x] E2E: `pnpm build` on app-todo embeds both docs into `dist/objectstack.json` with correct labels; subdirectory + broken-link cases fail the build with corrective messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)