### PR TITLE
fix(rest): ADR-0046 — /meta/doc list omits content by default

### DIFF
--- a/.changeset/adr-0046-rest-doc-list-slim.md
+++ b/.changeset/adr-0046-rest-doc-list-slim.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/rest": patch
+---
+
+ADR-0046: `GET /meta/doc` list responses omit `content` by default (`?include=content` opts back in; `GET /meta/doc/:name` always returns the full body). The runtime dispatcher's `/metadata/doc` route already slims docs (#1789) — this applies the same rule on the REST `/meta/:type` route the console actually reads, keeping unbounded manuals off the list surface.

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -1832,6 +1832,29 @@ export class RestServer {
                             }
                         }
 
+                        // ADR-0046: `doc` list responses omit `content` by
+                        // default — manuals are the one metadata payload that
+                        // grows unbounded, and the list surface only needs
+                        // name + label. `?include=content` opts back in; the
+                        // single-item GET /meta/doc/:name always returns the
+                        // full body.
+                        if (req.params.type === 'doc' && req.query?.include !== 'content') {
+                            const raw = visible as unknown;
+                            const list: any[] | null = Array.isArray(raw)
+                                ? (raw as any[])
+                                : (raw && typeof raw === 'object' && Array.isArray((raw as any).items))
+                                    ? ((raw as any).items as any[])
+                                    : null;
+                            if (list) {
+                                const slim = list.map((it: any) => {
+                                    if (!it || typeof it !== 'object') return it;
+                                    const { content: _content, ...rest } = it;
+                                    return rest;
+                                });
+                                visible = Array.isArray(raw) ? slim : { ...(raw as any), items: slim };
+                            }
+                        }
+
                         const translated = await this.translateMetaItems(req, req.params.type, environmentId, visible);
                         res.header('Vary', 'Accept-Language');
                         res.json(translated);


### PR DESCRIPTION
## Summary

Follow-up to [#1789](https://github.com/objectstack-ai/framework/pull/1789). The ADR-0046 hard requirement — doc **list** responses carry `name` + `label` without `content` — was implemented on the runtime dispatcher's `/metadata/:type` route, but the console actually reads the REST server's `GET /meta/:type` route, which still returned full bodies. This applies the same slimming there: default list omits `content`, `?include=content` opts back in, and the single-item `GET /meta/doc/:name` always returns the full body.

Found during live E2E verification of the console `/docs/:name` route (objectui [#1677](https://github.com/objectstack-ai/objectui/pull/1677)).

## Test plan
- [x] `@objectstack/rest` build + tests green (107 passed)
- [x] Live verification on the app-todo example: `GET /api/v1/meta/doc` items carry no `content`; `?include=content` restores it; `GET /api/v1/meta/doc/todo_index` returns the full body; console doc page renders end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)