### PR TITLE
feat(showcase): ADR-0046 — package docs coverage (flat src/docs/*.md)

### DIFF
--- a/examples/app-showcase/src/coverage.ts
+++ b/examples/app-showcase/src/coverage.ts
@@ -73,6 +73,10 @@ export const COVERAGE = {
   i18nThemingPortals: {
     coveredBy: 'translations/index.ts (en + zh-CN), themes/index.ts (light + dark), portals/index.ts',
   },
+  docs: {
+    source: 'ADR-0046 (doc metadata)',
+    coveredBy: 'src/docs/*.md — flat Markdown compiled to `doc` items: frontmatter title + first-heading title, cross-references with anchors, namespace-prefixed names',
+  },
 } as const;
 
 /** Collect every field `type` used across a set of object definitions. */

--- a/examples/app-showcase/src/docs/showcase_docs_guide.md
+++ b/examples/app-showcase/src/docs/showcase_docs_guide.md
@@ -1,0 +1,31 @@
+---
+title: Documentation Guide
+---
+
+# Writing package docs
+
+Rules this very file follows (each one is enforced by `os build`):
+
+- **Flat directory** — every doc lives directly in `src/docs/`;
+  subdirectories fail the build. Flatness is what keeps references
+  stable: a link is resolved by basename, never by path.
+- **Namespace-prefixed filename** — the stem becomes the doc name
+  (`showcase_docs_guide.md` → `showcase_docs_guide`), globally unique
+  inside a running instance, so the console URL needs no package
+  coordinate.
+- **Title** — frontmatter `title:` wins (this file uses it); otherwise
+  the first `#` heading; otherwise the name.
+- **Pure Markdown** — CommonMark + GFM only. MDX and image references
+  are rejected at build time (trust boundary + version immutability).
+
+## Cross-references
+
+Link to a sibling doc with a plain relative link:
+
+```md
+See the [overview](./showcase_index.md).
+```
+
+The console rewrites it to `/docs/showcase_index`; in an editor or on
+GitHub the same link just works. Broken same-package links fail the
+build. Back to the [overview](./showcase_index.md).

--- a/examples/app-showcase/src/docs/showcase_index.md
+++ b/examples/app-showcase/src/docs/showcase_index.md
@@ -1,0 +1,16 @@
+# Showcase
+
+The living conformance fixture for the ObjectStack protocol: every field
+type, view type, chart type, report type, and action location appears at
+least once, and the coverage test fails when the platform gains a
+feature this package does not yet demonstrate.
+
+This manual itself demonstrates one of those features — **package docs
+as metadata** (ADR-0046). Every Markdown file in the flat `src/docs/`
+directory compiles into a `doc` metadata item at build time, ships
+inside the package artifact, and renders in the console at
+`/docs/<name>`.
+
+For the authoring rules this page must itself obey, see the
+[documentation guide](./showcase_docs_guide.md) — or jump straight to
+its [cross-reference section](./showcase_docs_guide.md#cross-references).


### PR DESCRIPTION
## Summary

Adds the ADR-0046 dimension to the showcase: two cross-referencing docs under flat `examples/app-showcase/src/docs/` that demonstrate (and are gated by) every authoring rule `os build` enforces — flat directory, namespace-prefixed filename stems (`showcase_*`), frontmatter `title:` vs first-`#`-heading title derivation, relative cross-references with anchors (`./showcase_docs_guide.md#cross-references`), and code blocks keeping link syntax literal. A `COVERAGE.docs` entry tracks the dimension alongside field types, chart types, etc.

Follow-up to framework [#1789](https://github.com/objectstack-ai/framework/pull/1789)/[#1790](https://github.com/objectstack-ai/framework/pull/1790) and objectui [#1677](https://github.com/objectstack-ai/objectui/pull/1677).

## Test plan
- [x] `pnpm build` in app-showcase: both docs compile into `dist/objectstack.json` (`showcase_index` with first-heading label, `showcase_docs_guide` with frontmatter label); ADR lint (flatness/prefix/links/MDX/image) passes
- Note: `pnpm verify` (typecheck) is currently broken on main by pre-existing issues unrelated to this change (reports `drilldown`, pages `template`/`isDefault`, invoice formula — fields that gained `.default()` in recent spec PRs are required on the output types the example annotates with); tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)