### PR TITLE
feat(showcase): ADR-0047 — lookup quick-filter example (project)

### DIFF
--- a/examples/app-showcase/src/views/task.view.ts
+++ b/examples/app-showcase/src/views/task.view.ts
@@ -75,6 +75,9 @@ export const TaskViews = defineView({
           { field: 'status' },
           { field: 'priority', showCount: true },
           { field: 'done', type: 'boolean' },
+          // Lookup field — renders as a record-picker dropdown (the
+          // CRM-parity case: filter by a referenced record, e.g. owner).
+          { field: 'project' },
         ],
       },
     },


### PR DESCRIPTION
Adds `{ field: 'project' }` (a master-detail lookup) to the showcase Task List view's quick filters — the record-picker dropdown (search box + multi-select record list) that CRM consumers depend on ([hotcrm#383](https://github.com/objectstack-ai/hotcrm/pull/383) filters accounts by `owner`, a user lookup).

Browser-verified against the live stack and locked by [objectui#1682](https://github.com/objectstack-ai/objectui/pull/1682) (`e2e/live/user-filters.spec.ts`: picker opens, record selection narrows the grid, persists as `uf_project`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)