### PR TITLE
feat(spec): ADR-0047 — Interface section in the page authoring form

### DIFF
--- a/packages/spec/src/ui/page.form.ts
+++ b/packages/spec/src/ui/page.form.ts
@@ -40,6 +40,21 @@ export const pageForm = defineForm({
       ],
     },
     {
+      label: 'Interface (list pages)',
+      description: 'ADR-0047 interface mode: bind a source view and curate the end-user surface — quick filters, locked visualizations, toolbar actions (Airtable Interfaces parity).',
+      collapsible: true,
+      collapsed: true,
+      visibleOn: "data.type == 'list'",
+      fields: [
+        {
+          field: 'interfaceConfig',
+          type: 'composite',
+          helpText:
+            'source/sourceView bind the object view (columns, base filter and sort are inherited — the iron rule); userFilters picks the element style (dropdown / tabs / toggle) and exposed fields; appearance.allowedVisualizations whitelists renderers (one entry = locked); userActions toggles the toolbar.',
+        },
+      ],
+    },
+    {
       label: 'Advanced',
       description: 'Activation, audience, and accessibility.',
       collapsible: true,


### PR DESCRIPTION
## Summary

Adds an **Interface (list pages)** section to the Studio page authoring form (`page.form.ts`), visible when `type == 'list'`. The `interfaceConfig` composite renders the schema-driven equivalent of Airtable's Interfaces right panel:

- **Source / Source View** with the ADR-0047 iron-rule help text (columns/filter/sort inherited, page adds presentation policy only)
- **Levels**, **Filter By** row editor
- **Appearance**: Show Description toggle + Allowed Visualizations tag input (one entry = locked)
- **User Filters**: Element style select (dropdown / tabs / toggle) + Fields row editor (field/label/type/options/showCount/defaultValues) + Tabs presets
- **User Actions** toggles

Completes the phase-5 authoring surface: views got their End-user controls section in #1792; pages now have parity for interface mode.

## Testing

- `@objectstack/spec` 6542/6542
- Browser-verified in Studio against the showcase Task Workbench page (section renders, visibleOn gates on type, existing metadata round-trips into the editors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)