### PR TITLE
fix(ADR-0046): serve package docs at runtime, not just in the compiled artifact

### DIFF
--- a/.changeset/adr-0046-docs-runtime-serving.md
+++ b/.changeset/adr-0046-docs-runtime-serving.md
@@ -1,0 +1,22 @@
+---
+"@objectstack/cli": patch
+"@objectstack/metadata": patch
+---
+
+fix(ADR-0046): serve package docs at runtime, not just in the compiled artifact
+
+Package docs (`src/docs/*.md`) compiled into a bundle were never reaching the
+runtime, so `GET /meta/doc` returned an empty list and the docs were invisible
+even though `os build` produced them.
+
+Two gaps:
+
+- **`os dev` / `os serve` (config-load path)** re-derives metadata from
+  `defineStack(...)`, which never carries the markdown docs — those are
+  collected only at compile time. `serve.ts` now collects `src/docs/*.md` into
+  the stack on the config-load path too (collection only — additive, never
+  blocks boot), so docs serve in dev exactly as from a built artifact.
+- **The MetadataPlugin artifact loader** (`ARTIFACT_FIELD_TO_TYPE`) omitted the
+  `docs` → `doc` mapping, so the bundle's `docs` array was skipped when loading
+  through that path. Added the mapping (with a regression test) for parity with
+  the ObjectQL engine's `metadataArrayKeys`.

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -383,6 +383,31 @@ export default class Serve extends Command {
         config = merged;
       }
 
+      // Package docs (ADR-0046): flat `src/docs/*.md` are collected into the
+      // stack at COMPILE time (compile.ts step 3d). The config-load path here
+      // re-derives metadata from `defineStack(...)`, which never carries the
+      // markdown docs — so without this, `os dev`/`os serve` against a config
+      // serves ZERO docs (GET /meta/doc empty) even though `os build` produces
+      // them and an artifact boot serves them. Mirror compile's collection so
+      // docs render under /docs/<name> in dev exactly as from a built artifact.
+      // Collection only (no lint-fail): docs are additive; never block boot.
+      if (!useArtifactFallback) {
+        try {
+          const { collectDocsFromSrc } = await import('../utils/collect-docs.js');
+          const collected = collectDocsFromSrc(absolutePath);
+          if (collected.docs.length > 0) {
+            const byName = new Map<string, any>();
+            for (const d of (Array.isArray((config as any).docs) ? (config as any).docs : [])) {
+              if (d?.name) byName.set(d.name, d);
+            }
+            for (const d of collected.docs) byName.set(d.name, d);
+            config = { ...config, docs: Array.from(byName.values()) };
+          }
+        } catch {
+          /* docs are additive — never block boot on collection */
+        }
+      }
+
       // Boot-mode dispatch: this open-core CLI only supports `standalone`
       // (and the artifact-fallback shortcut). Cloud / multi-environment
       // boot modes live in a separate distribution and are no longer

--- a/packages/metadata/src/plugin.test.ts
+++ b/packages/metadata/src/plugin.test.ts
@@ -112,6 +112,50 @@ describe('MetadataPlugin._parseAndRegisterArtifact — view name resolution (PR-
 });
 
 // ─────────────────────────────────────────────────────────────────────────
+// ADR-0046 regression: a compiled artifact carries package docs in a
+// top-level `docs: DocSchema[]` array. The artifact loader registers only
+// the metadata fields enumerated in ARTIFACT_FIELD_TO_TYPE; `docs` was
+// omitted, so the bundle's docs were silently dropped and GET /meta/doc
+// returned an empty list even though the package shipped docs. The field
+// must map to the `doc` type so docs register like any other item.
+// ─────────────────────────────────────────────────────────────────────────
+describe('MetadataPlugin._parseAndRegisterArtifact — package docs (ADR-0046)', () => {
+    it('registers `doc` items from the artifact `docs` array', async () => {
+        const plugin = new MetadataPlugin({
+            watch: false,
+            config: { bootstrap: 'eager' },
+            environmentId: 'proj_test',
+        });
+        const mgr = (plugin as any).manager as NodeMetadataManager;
+        const fakeCtx = {
+            logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+        } as any;
+
+        const artifact = {
+            id: 'com.example.docs',
+            name: 'test',
+            version: '0.0.0',
+            type: 'app',
+            scope: 'app',
+            namespace: 'test',
+            defaultDatasource: 'memory',
+            docs: [
+                { name: 'test_index', label: 'Overview', content: '# Overview\n' },
+                { name: 'test_guide', content: '# Guide\n' },
+            ],
+        };
+
+        await (plugin as any)._parseAndRegisterArtifact(fakeCtx, artifact, 'test-artifact');
+
+        const index = await mgr.get('doc', 'test_index');
+        expect(index).toBeDefined();
+        expect((index as any)?.content).toContain('# Overview');
+        const guide = await mgr.get('doc', 'test_guide');
+        expect(guide).toBeDefined();
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
 // Filesystem-scanner provenance: when the host declares its package id
 // (options.packageId — the project's `defineStack` manifest id), scanned
 // source-file metadata must be stamped `_packageId`/`_provenance` exactly

--- a/packages/metadata/src/plugin.ts
+++ b/packages/metadata/src/plugin.ts
@@ -71,6 +71,7 @@ const ARTIFACT_FIELD_TO_TYPE: Record<string, string> = {
     analyticsCubes: 'analytics_cube',
     connectors: 'connector',
     emailTemplates: 'email_template',
+    docs: 'doc',
     data: 'dataset',
 };
 


### PR DESCRIPTION
## Problem

Package docs (`src/docs/*.md`, ADR-0046) compiled into a bundle **never reached the runtime**. `GET /meta/doc` returned `{"type":"doc","items":[]}` and docs were invisible in the console — even though `os build` produced them and a pure-artifact boot served them fine. This is the actual reason "the showcase has no docs": the data was never there to render.

## Root cause — two gaps, one per load path

1. **`os dev` / `os serve` (config-load path).** With an `objectstack.config.ts` present, serve re-derives metadata from `defineStack(...)`. The markdown docs are **not** part of `defineStack` — they're a compile-time augmentation (`compile.ts` step 3d, `collectAndLintDocs`). So the dev/serve path loaded zero docs. `serve.ts` now collects `src/docs/*.md` into the stack on the config-load path too — collection only (additive; never blocks boot).

2. **MetadataPlugin artifact loader.** `ARTIFACT_FIELD_TO_TYPE` (`packages/metadata/src/plugin.ts`) omitted `docs → doc`, so the bundle's `docs` array was skipped on that load path. Added the mapping for parity with the ObjectQL engine's `metadataArrayKeys`, plus a `_parseAndRegisterArtifact` regression test.

## Verification (live)

| Boot | `/meta/doc` before | after |
|---|---|---|
| `os dev` / `serve` (config) | `items:[]` | ✅ `showcase_index`, `showcase_docs_guide` |
| pure artifact | already worked | ✅ still works |

`servicePayload` now carries `docs` into `registerApp`; list + single-item (`/meta/doc/showcase_index` with content) both resolve. `@objectstack/metadata` 9/9 tests pass (incl. new regression); CLI typecheck clean.

## Scope

Backend/runtime only. The console-side docs **portal + nav entry** is a separate objectui PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)