### PR TITLE
fix(objectql): seed reference resolution falls back to matching by id

### DIFF
--- a/packages/objectql/src/seed-loader.ts
+++ b/packages/objectql/src/seed-loader.ts
@@ -448,6 +448,25 @@ export class SeedLoaderService implements ISeedLoaderService {
       if (records && records.length > 0) {
         return String(records[0].id || records[0]._id);
       }
+      // Fallback: the value may already be the target's internal id rather than
+      // its natural key — a seed that wires a lookup to a real existing record
+      // (e.g. a people field → the current user, whose id is not a UUID/ObjectId
+      // so `looksLikeInternalId` did not short-circuit). Resolving by id lets a
+      // valid id resolve instead of dangling null, with no risk of a false
+      // natural-key match (an id either exists or it does not).
+      if (targetField !== 'id') {
+        const byId: Record<string, unknown> = { id: value };
+        if (organizationId) byId.organization_id = organizationId;
+        const idMatch = await this.engine.find(targetObject, {
+          where: byId,
+          fields: ['id'],
+          limit: 1,
+          context: { isSystem: true },
+        } as any);
+        if (idMatch && idMatch.length > 0) {
+          return String(idMatch[0].id || idMatch[0]._id);
+        }
+      }
     } catch {
       // Target object may not exist yet
     }


### PR DESCRIPTION
## Problem

`SeedLoaderService.resolveFromDatabase` only matched a reference value against the target's **natural-key** field. A seed that wires a lookup to a **real existing record by its internal id** — e.g. a people field (`approver`/`applicant` → `user`) pointed at the current user — dangled to **null** when:
- the id is not a UUID/ObjectId (so the caller's `looksLikeInternalId` guard didn't short-circuit and write it directly), and
- the id isn't the target's natural key (so the name-based lookup found nothing).

This surfaced while wiring AI-built approval apps' sample rows to a real user (cloud apps#285): the approver field is a proper `user` lookup, the seed carries a valid user id, yet it resolved to null.

## Fix

When the natural-key lookup finds nothing, **try resolving the value as the target's `id`**. Safe: an id either exists or it doesn't, so there's no risk of a false natural-key match; tenant-scoped like the primary lookup.

## Notes

Small, additive change in `resolveFromDatabase`; covers both pass-1 and the deferred pass-2 resolution (both route through this method). Verified by typecheck; cloud-side e2e is pending the next framework bump (the local rig is currently on an unrelated newer framework commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)