### PR TITLE
ui(page.form): icon field uses the searchable icon-picker widget

### DIFF
--- a/.changeset/page-form-icon-picker.md
+++ b/.changeset/page-form-icon-picker.md
@@ -1,0 +1,11 @@
+---
+"@objectstack/spec": patch
+---
+
+ui(page.form): icon field uses the searchable icon-picker widget
+
+The Basics → `icon` field now carries `widget: 'icon'`, so the metadata-admin
+form renders a searchable Lucide icon picker (preview + name) instead of a raw
+text input where authors had to type an exact icon name. Mirrors the existing
+`view-ref` / `filter-mode` widget hints; the picker ships in
+`@object-ui/app-shell` and is reusable for app/object icon fields.

--- a/packages/spec/src/ui/page.form.ts
+++ b/packages/spec/src/ui/page.form.ts
@@ -18,7 +18,7 @@ export const pageForm = defineForm({
       fields: [
         { field: 'name', required: true, colSpan: 1, helpText: 'Unique identifier (snake_case)' },
         { field: 'label', required: true, colSpan: 1, helpText: 'Page title shown to users' },
-        { field: 'icon', colSpan: 1, helpText: 'Icon for navigation menu' },
+        { field: 'icon', widget: 'icon', colSpan: 1, helpText: 'Icon for navigation menu' },
         {
           field: 'type',
           colSpan: 1,


### PR DESCRIPTION
## What

Sets `widget: 'icon'` on the page `Basics → icon` field so the metadata-admin form renders a **searchable Lucide icon picker** (preview + name) instead of a raw text input where the author had to type an exact icon name.

```diff
- { field: 'icon', colSpan: 1, helpText: 'Icon for navigation menu' },
+ { field: 'icon', widget: 'icon', colSpan: 1, helpText: 'Icon for navigation menu' },
```

Mirrors the existing `view-ref` / `filter-mode` widget hints (the `widget` field is free-form `z.string()`, so no schema change is needed). The same hint is reusable for app/object icon fields.

## Paired with

The `icon` widget itself ships in `@object-ui/app-shell`: objectstack-ai/objectui#1725. Merge that first (or together) so the hint resolves to a real renderer; until then an unknown widget falls back to the default text input, so this is safe to land independently.

Changeset: `@objectstack/spec` patch. `pnpm --filter @objectstack/spec build` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)