### PR TITLE
ci(skills): gate PRs on skill-docs being generated from SKILL.md frontmatter

### DIFF
--- a/.changeset/ci-check-skill-docs.md
+++ b/.changeset/ci-check-skill-docs.md
@@ -1,0 +1,7 @@
+---
+---
+
+ci: add a `Check Skill Docs` job that runs `check:skill-docs` on PRs touching
+`skills/**`, the skills guide, or the generator — failing if the generated
+README/guide listings drift from the `SKILL.md` frontmatter. CI-only, no
+package change.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,11 @@ jobs:
     outputs:
       docs: ${{ steps.changes.outputs.docs }}
       core: ${{ steps.changes.outputs.core }}
+      skilldocs: ${{ steps.changes.outputs.skilldocs }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      
+
       - uses: dorny/paths-filter@v4
         id: changes
         with:
@@ -29,6 +30,11 @@ jobs:
               - 'apps/docs/**'
               - 'content/**'
               - 'pnpm-lock.yaml'
+              - '.github/workflows/ci.yml'
+            skilldocs:
+              - 'skills/**'
+              - 'content/docs/guides/skills.mdx'
+              - 'packages/spec/scripts/build-skill-docs.ts'
               - '.github/workflows/ci.yml'
             core:
               - 'packages/**'
@@ -224,3 +230,42 @@ jobs:
 
       - name: Build Docs
         run: pnpm --filter @objectstack/docs build
+
+  check-skill-docs:
+    name: Check Skill Docs
+    needs: filter
+    if: needs.filter.outputs.skilldocs == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-v3-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-v3-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check skill docs are generated from SKILL.md frontmatter
+        run: pnpm --filter @objectstack/spec check:skill-docs


### PR DESCRIPTION
## Why

Follow-up to [#1842](https://github.com/objectstack-ai/framework/pull/1842), which made the skill catalog (README index + `guides/skills.mdx` tables/cards) **generated** from each `SKILL.md` frontmatter via `build-skill-docs.ts`. Without a CI gate, the generated files can still be hand-edited or left stale when a `SKILL.md` changes — the exact drift that caused the original fabricated-docs problem.

## What

Adds a **`Check Skill Docs`** job to `ci.yml`:
- Gated by `paths-filter` — runs only when `skills/**`, `content/docs/guides/skills.mdx`, or `packages/spec/scripts/build-skill-docs.ts` change.
- Runs `pnpm --filter @objectstack/spec check:skill-docs` (`build-skill-docs.ts --check`), which **fails (exit 1)** if the README/guide listings differ from what the frontmatter would generate, with a hint to run `gen:skill-docs`.
- Lightweight: install + run, no build (the script only reads files via `tsx`).

## Verification

- `ci.yml` validated as YAML.
- Ran the exact CI command against current `main` → **passes** (`Skill docs in sync`).
- Negative test: introduced drift in the guide → check **exits 1** with the fix hint; reverted → passes again.
- This PR edits `ci.yml`, so the new job runs on the PR itself (self-test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)