### PR TITLE
fix(i18n): correct stale page-type help text in metadata-form bundles

### DIFF
--- a/.changeset/i18n-page-type-helptext.md
+++ b/.changeset/i18n-page-type-helptext.md
@@ -1,0 +1,7 @@
+---
+"@objectstack/platform-objects": patch
+---
+
+i18n(metadata-forms): correct stale page-`type` help text across locales
+
+The page `type` field help text still described page types as "record, home, app, dashboard …" — listing `dashboard` (and implying grid/kanban/calendar) as page types, which is wrong after the ADR-0047 page-type cleanup: those are visualizations configured under Interface, not page kinds. Updated en / zh-CN / ja-JP / es-ES to "page kind — list / record / home / app / utility; visualizations live under Interface". Also fixed the stale zh-CN `kind` help text (it described "record / list / detail" instead of the record-page override mode).

--- a/packages/platform-objects/src/apps/translations/en.metadata-forms.generated.ts
+++ b/packages/platform-objects/src/apps/translations/en.metadata-forms.generated.ts
@@ -680,7 +680,7 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
       },
       type: {
         label: "Type",
-        helpText: "Page type (record, home, app, dashboard, etc.)"
+        helpText: "Page kind — list / record / home / app / utility. How a list page looks (grid / kanban / calendar) is a visualization set under Interface, not a page type."
       },
       template: {
         label: "Template",

--- a/packages/platform-objects/src/apps/translations/es-ES.metadata-forms.generated.ts
+++ b/packages/platform-objects/src/apps/translations/es-ES.metadata-forms.generated.ts
@@ -680,7 +680,7 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
       },
       type: {
         label: "Tipo",
-        helpText: "Tipo de página (record, home, app, dashboard, etc.)"
+        helpText: "Tipo de página: list / record / home / app / utility. Cómo se ve una página de lista (grid / kanban / calendar) es una visualización configurada en Interface, no un tipo de página."
       },
       template: {
         label: "Plantilla",

--- a/packages/platform-objects/src/apps/translations/ja-JP.metadata-forms.generated.ts
+++ b/packages/platform-objects/src/apps/translations/ja-JP.metadata-forms.generated.ts
@@ -680,7 +680,7 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
       },
       type: {
         label: "型",
-        helpText: "ページ種別（record, home, app, dashboard など）"
+        helpText: "ページの種類 — list / record / home / app / utility。リストページの見せ方（grid / kanban / calendar）はページタイプではなく、Interface で設定するビジュアライゼーションです。"
       },
       template: {
         label: "テンプレート",

--- a/packages/platform-objects/src/apps/translations/zh-CN.metadata-forms.generated.ts
+++ b/packages/platform-objects/src/apps/translations/zh-CN.metadata-forms.generated.ts
@@ -680,7 +680,7 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
       },
       type: {
         label: "类型",
-        helpText: "页面类型（record、home、app、dashboard 等）"
+        helpText: "页面种类 — list / record / home / app / utility。列表页的展现形式（grid / kanban / calendar）是在 Interface 中设置的可视化，不是页面类型。"
       },
       template: {
         label: "模板",
@@ -708,7 +708,7 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
       },
       kind: {
         label: "模式",
-        helpText: "页面种类分组（如 record / list / detail）"
+        helpText: "页面覆盖模式：完整（full）或插槽式（slotted），仅用于记录页。"
       },
       assignedProfiles: {
         label: "指定配置文件",


### PR DESCRIPTION
The last of the panel-audit follow-ups. The page `type` field's help text in the metadata-form translation bundles still read **"page type (record, home, app, dashboard, etc.)"** — listing `dashboard` (and implying grid/kanban/calendar) as page types. That's wrong after the ADR-0047 page-type cleanup: those are **visualizations** configured under Interface, not page kinds.

## Changes
`packages/platform-objects/src/apps/translations/*.metadata-forms.generated.ts` (hand-edited; the generator's `--merge` preserves these):
- `page.type.helpText` in **en / zh-CN / ja-JP / es-ES** → "page kind — list / record / home / app / utility; how a list page looks (grid / kanban / calendar) is a visualization set under Interface, not a page type".
- Stale **zh-CN `page.kind.helpText`** ("页面种类分组（如 record / list / detail）") → matches the English ("record-page override mode: full or slotted").

These bundles **override** the spec's inline `helpText` at runtime, so editing `page.form.ts` alone would not have fixed the displayed Chinese/Japanese/Spanish text.

## Verification
- `pnpm --filter @objectstack/spec build` (with dts) then `tsc --noEmit` on `@objectstack/platform-objects` → **0 errors from these files** (only an unrelated cached-dep dts artifact).
- Edited strings contain no embedded quotes/escapes; verified single-match replacement per locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)