### PR TITLE
fix(objectql): listDrafts surfaces env-wide drafts under a non-null org (orphaned-draft fix)

### DIFF
--- a/packages/objectql/src/sys-metadata-repository-list-drafts.test.ts
+++ b/packages/objectql/src/sys-metadata-repository-list-drafts.test.ts
@@ -17,14 +17,21 @@ const ROWS = [
   { type: 'object', name: 'live', state: 'active', package_id: 'app.edu', organization_id: null, updated_at: 't4' },
 ];
 
-function makeRepo(rows = ROWS) {
-  // Minimal engine whose find() does equality-only WHERE matching.
+const matchesWhere = (r: any, clause: any): boolean =>
+  Object.entries(clause).every(([k, v]) =>
+    k === '$or'
+      ? (v as any[]).some((c) => matchesWhere(r, c))
+      : (r as any)[k] === v,
+  );
+
+function makeRepo(rows = ROWS, organizationId: string | null = null) {
+  // Minimal engine whose find() does equality WHERE matching, plus `$or`.
   const find = vi.fn(async (_table: string, q: any) => {
     const where = q?.where ?? {};
-    return rows.filter((r) => Object.entries(where).every(([k, v]) => (r as any)[k] === v));
+    return rows.filter((r) => matchesWhere(r, where));
   });
   const engine = { find } as any;
-  const repo = new SysMetadataRepository({ engine, organizationId: null, orgLabel: 'env' });
+  const repo = new SysMetadataRepository({ engine, organizationId, orgLabel: 'env' });
   return { repo, find };
 }
 
@@ -48,6 +55,28 @@ describe('SysMetadataRepository.listDrafts (ADR-0033)', () => {
     const { repo } = makeRepo();
     const out = await repo.listDrafts({ packageId: 'app.edu' });
     expect(out.map((d) => d.name).sort()).toEqual(['course', 'course_list', 'student']);
+  });
+
+  it('surfaces env-wide (org IS NULL) drafts even when the repo has a non-null active org', async () => {
+    // Regression (orphaned-draft bug): AI-authored metadata is written env-wide
+    // (organization_id NULL). A non-null active org used a strict equality that
+    // dropped those drafts → they showed in preview but the Publish CTA never
+    // appeared, so the user could not publish them.
+    const { repo } = makeRepo(ROWS, 'org_acme');
+    const names = (await repo.listDrafts()).map((d) => d.name).sort();
+    expect(names).toEqual(['course', 'course_list', 'legacy', 'student']);
+    expect(names).not.toContain('live');
+  });
+
+  it('returns both org-scoped and env-wide drafts for a non-null org, excluding other orgs', async () => {
+    const rows = [
+      { type: 'object', name: 'env_wide', state: 'draft', package_id: 'p', organization_id: null, updated_at: 't1' },
+      { type: 'object', name: 'org_scoped', state: 'draft', package_id: 'p', organization_id: 'org_acme', updated_at: 't2' },
+      { type: 'object', name: 'other_org', state: 'draft', package_id: 'p', organization_id: 'org_other', updated_at: 't3' },
+    ];
+    const { repo } = makeRepo(rows, 'org_acme');
+    const names = (await repo.listDrafts()).map((d) => d.name).sort();
+    expect(names).toEqual(['env_wide', 'org_scoped']);
   });
 
   it('filters by type', async () => {

--- a/packages/objectql/src/sys-metadata-repository.ts
+++ b/packages/objectql/src/sys-metadata-repository.ts
@@ -730,10 +730,23 @@ export class SysMetadataRepository implements MetadataRepository {
     }>
   > {
     this.assertOpen();
-    const where: Record<string, unknown> = {
-      organization_id: this.organizationId,
-      state: 'draft',
-    };
+    const where: Record<string, unknown> = { state: 'draft' };
+    // Surface BOTH org-scoped drafts and env-wide (`organization_id IS NULL`)
+    // drafts. Env-wide drafts are real pending changes — `getMetaItems`/preview
+    // overlays them and `publish-drafts` promotes them — but a strict
+    // `organization_id = this.organizationId` equality silently dropped them
+    // whenever the active org was non-null. AI-authored metadata is written
+    // env-wide, so its drafts vanished from the pending-changes list and the
+    // Publish CTA never appeared: the change showed in preview yet could not be
+    // published from the UI (the "orphaned draft" bug).
+    if (this.organizationId != null) {
+      where.$or = [
+        { organization_id: this.organizationId },
+        { organization_id: null },
+      ];
+    } else {
+      where.organization_id = null;
+    }
     if (filter?.type) where.type = filter.type;
     if (filter?.packageId) where.package_id = filter.packageId;
     const rows = await this.engine.find('sys_metadata', { where });


### PR DESCRIPTION
## Problem

`GET /meta/_drafts` — the pending-changes list that drives the **Publish CTA** — calls `SysMetadataRepository.listDrafts`, which queried:

```ts
{ organization_id: this.organizationId, state: 'draft' }
```

AI-authored metadata is written **env-wide** (`organization_id IS NULL`). Under a **non-null active org** (every multi-tenant / cloud request) the strict equality dropped those drafts. So an AI-added field/view:

- ✅ showed in `?preview=draft` (getMetaItems overlays env-wide rows)
- ✅ would be promoted by `publish-drafts`
- ❌ but never appeared in the pending-changes list → **the Publish CTA never showed → the user couldn't publish their AI-made change** ("orphaned draft").

(In single-env `org=null` the old query already matched env-wide rows, so this only bit the multi-tenant/cloud path.)

## Fix

Surface **both** org-scoped and env-wide drafts — when the active org is non-null, match `organization_id = org OR organization_id IS NULL`; when null, keep the env-wide query. Mirrors how `getMetaItems`/preview already overlays env-wide drafts.

## Verification

- 2 regression tests: a non-null-org repo surfaces env-wide drafts; mixed org-scoped + env-wide returned while *other* orgs' drafts stay excluded. `listDrafts` suite green (6); mock engine extended to evaluate `$or`.
- On the objectos-ee rig (single-env, org=null — the no-op path) the full loop is clean: draft → `_drafts` lists it → `publish-drafts` materializes the field immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)