### PR TITLE
fix(spec): render action body editor as composite (language + source), not [object Object]

### DIFF
--- a/.changeset/studio-action-body-composite.md
+++ b/.changeset/studio-action-body-composite.md
@@ -1,0 +1,7 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): render action `body` as a composite editor (language + source) instead of a flat code field
+
+An action's `body` is a discriminated union (`HookBodySchema`), the same shape hooks use, but `action.form.ts` mapped the whole field to `{ widget: 'code' }`, so the Studio inspector fed the union object to a single JS editor and rendered `[object Object]`. The layout now mirrors the working `hook.form.ts`: a composite with a `language` select, a `source` code editor, and the L2-only capability/timeout knobs.

--- a/packages/spec/src/ui/action.form.ts
+++ b/packages/spec/src/ui/action.form.ts
@@ -30,7 +30,26 @@ export const actionForm = defineForm({
       fields: [
         { field: 'target', visibleOn: "data.type != 'script'", helpText: 'URL, flow name, or API endpoint to call' },
         { field: 'method', visibleOn: "data.type == 'api'", helpText: 'HTTP method (GET, POST, PUT, DELETE)' },
-        { field: 'body', widget: 'code', visibleOn: "data.type == 'script'", helpText: 'JavaScript code to execute' },
+        {
+          field: 'body',
+          type: 'composite',
+          visibleOn: "data.type == 'script'",
+          helpText: 'Either an L1 expression or an L2 sandboxed JS body',
+          // Mirrors hook.form.ts: `body` is a discriminated union
+          // (HookBodySchema) on `language`, not a bare string. A flat
+          // `widget: 'code'` fed the whole object to the editor and rendered
+          // "[object Object]". Render the union as language + source (+ the
+          // L2-only capability/timeout knobs).
+          fields: [
+            { field: 'language', type: 'select', required: true, helpText: 'expression = pure formula; js = sandboxed JavaScript', options: [
+              { label: 'Expression (L1)', value: 'expression' },
+              { label: 'JavaScript (L2 sandboxed)', value: 'js' },
+            ] },
+            { field: 'source', type: 'code', language: 'javascript', required: true, helpText: 'Function body source — no top-level imports' },
+            { field: 'capabilities', type: 'tags', helpText: 'Allowed ctx APIs (api.read, api.write, crypto.uuid, log, …)' },
+            { field: 'timeoutMs', type: 'number', helpText: 'Per-invocation timeout (ms)' },
+          ],
+        },
         { field: 'params', type: 'repeater', helpText: 'User input parameters (show form before executing)' },
         { field: 'confirmText', helpText: 'Confirmation message (e.g., "Are you sure?")' },
         { field: 'successMessage', helpText: 'Success message after completion' },


### PR DESCRIPTION
Found during a browser sweep of the Studio metadata designers.

A script action's inspector showed the **正文 (body)** field as a JavaScript code editor containing literally `[object Object]`. The action `body` is a discriminated union (`HookBodySchema`: `{ language, source, capabilities?, timeoutMs? }`) — the exact shape hooks use — but `action.form.ts` flattened it to `{ field: 'body', widget: 'code' }`, so the inspector fed the union *object* to a single string editor.

This mirrors the **already-shipped, working** `hook.form.ts` layout: a `type: 'composite'` with a `language` select, a `source` code editor (javascript), and the L2-only `capabilities` / `timeoutMs` knobs. `visibleOn: "data.type == 'script'"` is preserved.

### Verification
The action `body` data itself is fine — the design-canvas preview already renders the script correctly; only the inspector widget mapping was wrong. The fix is structurally identical to the hook `body` layout the SchemaForm already renders correctly. Live HotCRM verification was intentionally skipped to avoid rebuilding `@objectstack/spec` and restarting the shared dev backend that other agents depend on; CI type-check + the equivalence to `hook.form.ts` cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)