### PR TITLE
feat(auth): expose isPlatformAdmin on the customSession user

### DIFF
--- a/.changeset/adr-adminvis-platform-admin-session.md
+++ b/.changeset/adr-adminvis-platform-admin-session.md
@@ -1,0 +1,12 @@
+---
+"@objectstack/plugin-auth": patch
+---
+
+auth: expose `isPlatformAdmin` on the customSession user payload
+
+The session already derives a coarse `admin` role for platform admins or
+active-org admins, but never surfaced the underlying platform-admin signal.
+Console action `visible` CEL predicates need it to gate platform-admin-only
+object actions (e.g. `sys_environment.change_plan`) without hiding org-admin
+actions. Both `customSession` return paths now carry the boolean; org-admins
+who are not platform admins correctly get `isPlatformAdmin: false`.

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -1021,15 +1021,16 @@ export class AuthManager {
           }
         };
 
-        const promote = (await isPlatformAdmin()) || (await isActiveOrgAdmin());
+        const platformAdmin = await isPlatformAdmin();
+        const promote = platformAdmin || (await isActiveOrgAdmin());
         const storedRole = typeof (user as any).role === 'string' ? (user as any).role : '';
         const roles = storedRole
           .split(',')
           .map((s: string) => s.trim())
           .filter(Boolean);
         if (promote && !roles.includes('admin')) roles.push('admin');
-        if (!promote) return { user: { ...user, roles }, session };
-        return { user: { ...user, role: 'admin', roles }, session };
+        if (!promote) return { user: { ...user, roles, isPlatformAdmin: platformAdmin }, session };
+        return { user: { ...user, role: 'admin', roles, isPlatformAdmin: platformAdmin }, session };
       }));
     }
 


### PR DESCRIPTION
## What
Attach an `isPlatformAdmin` boolean to the better-auth `customSession` user payload (both return paths).

## Why
The session already derives a coarse `admin` role for platform admins **or** active-org admins, but never surfaces the underlying platform-admin signal. Console action `visible` CEL predicates need to gate **platform-admin-only** actions (e.g. `sys_environment.change_plan`, labeled "Change Plan (admin)") — today a regular user sees the button and clicking it 403s. The `admin` role alone can't distinguish org-admin from platform-admin.

## Change
`packages/plugins/plugin-auth/src/auth-manager.ts`: capture `const platformAdmin = await isPlatformAdmin()` once, reuse it for the existing `promote` logic, and add `isPlatformAdmin: platformAdmin` to both customSession returns. Org-admins who are not platform admins correctly get `false`.

Real authz stays server-side; this only enables a UX visibility gate downstream (objectui + cloud).

## Validation
- `turbo build --filter=@objectstack/plugin-auth` green incl. DTS
- `@objectstack/plugin-auth` tests: 114/114 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)