### PR TITLE
feat(spec): model action-param translations (_actions.params)

### DIFF
--- a/.changeset/action-param-translations.md
+++ b/.changeset/action-param-translations.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/spec": patch
+---
+
+feat(spec): model action-param translations in TranslationData (`_actions.params`) so action param label/helpText/placeholder/options can be localized via the keys+bundles path. Additive and optional — existing bundles unaffected.

--- a/packages/spec/src/system/translation.zod.ts
+++ b/packages/spec/src/system/translation.zod.ts
@@ -79,6 +79,12 @@ export const ObjectTranslationDataSchema = lazySchema(() => z.object({
     label: z.string().optional().describe('Translated action label'),
     confirmText: z.string().optional().describe('Translated confirmation prompt'),
     successMessage: z.string().optional().describe('Translated success toast/message'),
+    params: z.record(z.string(), z.object({
+      label: z.string().optional().describe('Translated action parameter label'),
+      helpText: z.string().optional().describe('Translated action parameter help/hint text'),
+      placeholder: z.string().optional().describe('Translated action parameter placeholder'),
+      options: z.record(z.string(), z.string()).optional().describe('Param select option value to translated label'),
+    })).optional().describe('Action parameter translations keyed by parameter name'),
   })).optional().describe('Action translations keyed by action name'),
 
   /**
@@ -145,6 +151,12 @@ export const TranslationDataSchema = lazySchema(() => z.object({
     label: z.string().optional().describe('Translated action label'),
     confirmText: z.string().optional().describe('Translated confirmation prompt'),
     successMessage: z.string().optional().describe('Translated success toast/message'),
+    params: z.record(z.string(), z.object({
+      label: z.string().optional().describe('Translated action parameter label'),
+      helpText: z.string().optional().describe('Translated action parameter help/hint text'),
+      placeholder: z.string().optional().describe('Translated action parameter placeholder'),
+      options: z.record(z.string(), z.string()).optional().describe('Param select option value to translated label'),
+    })).optional().describe('Action parameter translations keyed by parameter name'),
   })).optional().describe('Global action translations keyed by action name'),
 
   /**
@@ -466,6 +478,12 @@ export const ObjectTranslationNodeSchema = lazySchema(() => z.object({
   _actions: z.record(z.string(), z.object({
     label: z.string().optional().describe('Translated action label'),
     confirmMessage: z.string().optional().describe('Translated confirmation message'),
+    params: z.record(z.string(), z.object({
+      label: z.string().optional().describe('Translated action parameter label'),
+      helpText: z.string().optional().describe('Translated action parameter help/hint text'),
+      placeholder: z.string().optional().describe('Translated action parameter placeholder'),
+      options: z.record(z.string(), z.string()).optional().describe('Param select option value to translated label'),
+    })).optional().describe('Action parameter translations keyed by parameter name'),
   })).optional().describe('Action translations keyed by action name'),
 
   /** Notification message translations keyed by notification name */


### PR DESCRIPTION
Adds an optional `params` record to the action translation schema so action param label/helpText/placeholder/options can be localized via the existing keys+bundles path: `objects.<obj>._actions.<action>.params.<param>.{label,helpText,placeholder,options}`. All optional/additive — existing bundles unaffected. objectui's `useObjectLabel().actionParamText()` already reads this key path; this unblocks the bundle entries (cloud follow-up) + the renderer wiring (objectui follow-up). 1149 spec tests pass; DTS build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)