### PR TITLE
fix(cli): drop stale `ownership` key from init scaffold object template

### DIFF
--- a/.changeset/init-scaffold-drop-ownership.md
+++ b/.changeset/init-scaffold-drop-ownership.md
@@ -1,0 +1,7 @@
+---
+"@objectstack/cli": patch
+---
+
+fix(cli): drop stale `ownership` key from the `os init` scaffold object template
+
+The `app` and `plugin` scaffold templates emitted `ownership: 'own'` on the starter object. `ownership` is no longer a valid `ObjectSchema` field (it's not in `ObjectSchemaBase`, and `ObjectSchema.create()` rejects unknown top-level keys per ADR-0032 / #1535), so a user migrating the scaffolded object into `ObjectSchema.create({...})` would hit a validation error. Removed the key from both templates; the rest of the scaffold output is unchanged.

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -150,7 +150,6 @@ export default defineStack({
 const ${toCamelCase(namespace)}Item: Data.Object = {
   name: '${namespace}_item',
   label: '${toTitleCase(namespace)} Item',
-  ownership: 'own',
   fields: {
     name: {
       type: 'text',
@@ -223,7 +222,6 @@ export default defineStack({
 const ${toCamelCase(namespace)}Item: Data.Object = {
   name: '${namespace}_item',
   label: '${toTitleCase(namespace)} Item',
-  ownership: 'own',
   fields: {
     name: {
       type: 'text',


### PR DESCRIPTION
## What

The `os init` scaffold emitted `ownership: 'own'` on the starter object in **both** the `app` and `plugin` templates (`packages/cli/src/commands/init.ts`). This PR removes it.

## Why

`ownership` is no longer a valid `ObjectSchema` field — it's not in `ObjectSchemaBase`, and `ObjectSchema.create()` rejects unknown top-level keys (ADR-0032 / #1535). The `'own'`/`'extend'` values belong to `ObjectOwnershipEnum`, which models a *package↔object* relationship (`objectExtensions`/manifests), not a top-level object-schema field.

The scaffold emitted the starter object as a plain object literal, so it didn't throw at scaffold time — but it taught a dead field, and a user migrating the object into `ObjectSchema.create({...})` would hit a validation error.

Surfaced during the docs audit in #1866 (`getting-started/quick-start.mdx`), where the example was aligned to the scaffold output while the scaffold itself still carried the stale key.

## Verification

- `pnpm vitest run test/init.test.ts` → 28/28 pass.
- End-to-end render of both `app` and `plugin` object templates → neither contains `ownership`; rest of scaffold output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)