### PR TITLE
fix(automation): create_record outputVariable exposes the record so {var.id} resolves (#1873)

### DIFF
--- a/.changeset/create-record-output-record.md
+++ b/.changeset/create-record-output-record.md
@@ -1,0 +1,17 @@
+---
+"@objectstack/service-automation": minor
+---
+
+fix(automation): `create_record` outputVariable exposes the created record so `{var.id}` resolves (#1873)
+
+A `create_record` node stored only the created record's **id string** in its
+`outputVariable`, so a later node referencing `{var.id}` (or any `{var.<field>}`)
+traversed into a string and resolved to empty — the created record was
+effectively unreferenceable downstream. `get_record` already stores the record
+object (that's why `{rec.field}` works there); `create_record` now matches.
+
+Behavior change: `outputVariable` holds the created **record** (an object with
+`id` + fields), not the bare id. Reference the id explicitly as `{var.id}`. A
+bare `{var}` that previously yielded the id now yields the record — update such
+references to `{var.id}` (the in-repo `app-todo` create-task flow was updated).
+When the driver returns a bare id, it's wrapped as `{ id }` so `{var.id}` still works.

--- a/examples/app-todo/src/flows/task.flow.ts
+++ b/examples/app-todo/src/flows/task.flow.ts
@@ -194,7 +194,7 @@ export const QuickAddTaskFlow: Flow = {
         message: 'Task "{subject}" created successfully!',
         buttons: [
           { label: 'Create Another', action: 'restart' },
-          { label: 'View Task', action: 'navigate', target: '/task/{newTaskId}' },
+          { label: 'View Task', action: 'navigate', target: '/task/{newTaskId.id}' },
           { label: 'Done', action: 'finish' },
         ],
       },

--- a/packages/services/service-automation/src/builtin/crud-nodes.ts
+++ b/packages/services/service-automation/src/builtin/crud-nodes.ts
@@ -90,15 +90,28 @@ export function registerCrudNodes(engine: AutomationEngine, ctx: PluginContext):
                 const data = getData();
                 if (!data) {
                     ctx.logger.warn(`[create_record] no data engine; skipping ${objectName}`);
-                    if (outputVariable) variables.set(outputVariable, `mock-${objectName}-${Date.now()}`);
-                    return { success: true, output: { id: `mock-${objectName}-${Date.now()}`, object: objectName } };
+                    const mockId = `mock-${objectName}-${Date.now()}`;
+                    if (outputVariable) variables.set(outputVariable, { id: mockId });
+                    return { success: true, output: { id: mockId, object: objectName } };
                 }
 
                 try {
                     const created = await data.insert(objectName, fields);
-                    const insertedId = Array.isArray(created) ? created[0]?.id : created?.id ?? created;
-                    if (outputVariable) variables.set(outputVariable, insertedId);
-                    return { success: true, output: { id: insertedId, record: created, object: objectName } };
+                    const createdRecord = Array.isArray(created) ? created[0] : created;
+                    const insertedId =
+                        createdRecord && typeof createdRecord === 'object'
+                            ? (createdRecord as Record<string, unknown>).id
+                            : createdRecord;
+                    if (outputVariable) {
+                        // #1873 — expose the created RECORD so later nodes can reference
+                        // `{var.id}` (and other fields), not just the bare id string. When the
+                        // driver returns a bare id, wrap it as `{ id }` so `{var.id}` still works.
+                        variables.set(
+                            outputVariable,
+                            createdRecord && typeof createdRecord === 'object' ? createdRecord : { id: insertedId },
+                        );
+                    }
+                    return { success: true, output: { id: insertedId, record: createdRecord, object: objectName } };
                 } catch (err) {
                     return { success: false, error: `create_record(${objectName}) failed: ${(err as Error).message}` };
                 }

--- a/packages/services/service-automation/src/builtin/crud-output-var.test.ts
+++ b/packages/services/service-automation/src/builtin/crud-output-var.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #1873 — a `create_record` node's `outputVariable` must expose the created
+ * record so a later node can reference `{var.id}` (and other fields). Before the
+ * fix the output variable held only the bare id STRING, so `{var.id}` traversed
+ * into a string and resolved to empty.
+ */
+import { describe, it, expect } from 'vitest';
+import { AutomationEngine } from '../engine.js';
+import { registerCrudNodes } from './crud-nodes.js';
+
+function makeLogger(): any {
+  const l: any = { info() {}, warn() {}, error() {}, debug() {} };
+  l.child = () => l;
+  return l;
+}
+
+function fakeData() {
+  const updates: Array<{ obj: string; fields: any; opts: any }> = [];
+  let n = 0;
+  const data: any = {
+    async insert(obj: string, fields: any) { n += 1; return { id: `${obj}_${n}`, ...fields }; },
+    async update(obj: string, fields: any, opts: any) { updates.push({ obj, fields, opts }); return { ok: true }; },
+    async find() { return []; },
+    async findOne() { return null; },
+  };
+  return { data, updates };
+}
+
+const ctxWith = (data: any): any => ({ logger: makeLogger(), getService: (n: string) => (n === 'data' ? data : undefined) });
+
+describe('create_record outputVariable (#1873)', () => {
+  it('exposes the created record so {var.id} resolves in a later node', async () => {
+    const engine = new AutomationEngine(makeLogger());
+    const { data, updates } = fakeData();
+    registerCrudNodes(engine, ctxWith(data));
+
+    engine.registerFlow('promote', {
+      name: 'promote', label: 'P', type: 'autolaunched',
+      nodes: [
+        { id: 'start', type: 'start', label: 'Start' },
+        { id: 'mk', type: 'create_record', label: 'Create', config: { objectName: 'topic', outputVariable: 'topic', fields: { title: 'X' } } },
+        { id: 'upd', type: 'update_record', label: 'Update', config: { objectName: 'signal', filter: { id: 'sig1' }, fields: { promoted_topic: '{topic.id}' } } },
+        { id: 'end', type: 'end', label: 'End' },
+      ],
+      edges: [
+        { id: 'e1', source: 'start', target: 'mk' },
+        { id: 'e2', source: 'mk', target: 'upd' },
+        { id: 'e3', source: 'upd', target: 'end' },
+      ],
+    } as any);
+
+    const res = await engine.execute('promote');
+    expect(res.success).toBe(true);
+    expect(updates).toHaveLength(1);
+    expect(updates[0].fields.promoted_topic).toBe('topic_1');
+  });
+
+  it('exposes non-id fields of the created record too ({var.title})', async () => {
+    const engine = new AutomationEngine(makeLogger());
+    const { data, updates } = fakeData();
+    registerCrudNodes(engine, ctxWith(data));
+    engine.registerFlow('promote2', {
+      name: 'promote2', label: 'P', type: 'autolaunched',
+      nodes: [
+        { id: 'start', type: 'start', label: 'Start' },
+        { id: 'mk', type: 'create_record', label: 'Create', config: { objectName: 'topic', outputVariable: 'topic', fields: { title: 'X' } } },
+        { id: 'upd', type: 'update_record', label: 'Update', config: { objectName: 'signal', filter: { id: 'sig1' }, fields: { ref: '{topic.title}' } } },
+        { id: 'end', type: 'end', label: 'End' },
+      ],
+      edges: [
+        { id: 'e1', source: 'start', target: 'mk' },
+        { id: 'e2', source: 'mk', target: 'upd' },
+        { id: 'e3', source: 'upd', target: 'end' },
+      ],
+    } as any);
+    const res = await engine.execute('promote2');
+    expect(res.success).toBe(true);
+    expect(updates[0].fields.ref).toBe('X');
+  });
+});


### PR DESCRIPTION
Closes #1873.

## Problem (confirmed)
A `create_record` node stored only the inserted **id string** in its `outputVariable`. A later node referencing `{var.id}` — the documented pattern, e.g. content `signal_to_topic_promotion` setting `promoted_topic: '{topic.id}'` — traversed `.id` into a *string* and resolved to empty. The created record was unreferenceable downstream.

Verified by code + an engine-level repro: `resolveToken('topic.id')` → `resolvePath("topic_1", ['id'])` → the value is a string, so `typeof cur !== 'object'` → `undefined` → renders empty.

## Fix
Store the created **record object** as the `outputVariable` — consistent with `get_record`, which already does `variables.set(outputVariable, record)` (that's why `{rec.field}` works there). `create_record` was the inconsistency.

- Array insert → first row; bare-id driver return → wrapped as `{ id }` so `{var.id}` still works.
- The mock/no-data-engine path stores `{ id }` too.

## Behavior change & back-compat
`outputVariable` now holds the record (object), not the bare id. Reference the id as `{var.id}`. A bare `{var}` that previously yielded the id string now yields the record. I swept the repo for that pattern: the only case was the `app-todo` create-task flow's `/task/{newTaskId}`, updated to `/task/{newTaskId.id}`. (The `convert-lead` `lead_record` is a `get_record`, unaffected; it already used `{lead_record.name}` against the record.) Marked **minor**.

## Tests
- New engine-level regression: `create_record` (outputVariable `topic`) → `update_record` resolving `{topic.id}` **and** `{topic.title}` — both fail before the fix, pass after.
- `@objectstack/service-automation` full suite **196 pass**; `app-todo` + `app-crm` builds green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)