### PR TITLE
fix(objectql): validate declared required organization_id/tenant_id (provenance, not name) (#1592)

### DIFF
--- a/.changeset/validate-skip-provenance.md
+++ b/.changeset/validate-skip-provenance.md
@@ -1,0 +1,15 @@
+---
+"@objectstack/objectql": patch
+---
+
+fix(objectql): validate a declared required `organization_id`/`tenant_id` instead of silently skipping it by name (#1592)
+
+`validateRecord` skipped required-checks for any field literally named
+`organization_id` / `tenant_id`. That's correct only for the engine-INJECTED
+tenant column (already marked `system: true`, skipped via provenance). A
+genuinely DECLARED required business field with that name — e.g. `sys_team`'s
+`organization_id` lookup, on a `managedBy: 'better-auth'` table where the column
+is NOT injected — was silently bypassed and reached the driver as NULL (a DB
+constraint error instead of a clean `400 required`). Removed the two names from
+the by-name skip set; injected columns remain skipped via `def.system` /
+`def.readonly`.

--- a/packages/objectql/src/validation/record-validator.ts
+++ b/packages/objectql/src/validation/record-validator.ts
@@ -21,7 +21,8 @@
  *  - date / datetime: must be ISO-parsable
  *
  * System-injected fields (`id`, `created_at`, `created_by`,
- * `updated_at`, `updated_by`, `organization_id`) are never validated
+ * `updated_at`, `updated_by`, and provenance-flagged `system`/`readonly`
+ * columns such as an injected `organization_id`) are never validated
  * here — the engine and the audit plugin manage them.
  *
  * On failure, a `ValidationError` is thrown with `.fields[]` holding
@@ -30,9 +31,16 @@
  * the UI can highlight the specific input.
  */
 
+// Lifecycle columns the engine always owns and the client never supplies. These
+// are skipped by NAME because they are not author-declared business fields.
+// NOTE: `organization_id` / `tenant_id` are intentionally NOT here (#1592) — the
+// engine-injected tenant column is marked `system: true` and skipped via
+// provenance below, while a genuinely DECLARED required `organization_id`
+// business field (e.g. `sys_team`, a `managedBy: 'better-auth'` table where the
+// column is not injected) must get a normal required-check instead of silently
+// passing NULL through to the driver.
 const SKIP_FIELDS = new Set<string>([
   'id', 'created_at', 'created_by', 'updated_at', 'updated_by',
-  'organization_id', 'tenant_id',
 ]);
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;

--- a/packages/objectql/src/validation/skip-provenance.test.ts
+++ b/packages/objectql/src/validation/skip-provenance.test.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #1592 — `validateRecord` skipped required-checks for any field literally named
+ * `organization_id` / `tenant_id`. That's correct only for ENGINE-INJECTED tenant
+ * columns (already marked `system: true`); a genuinely declared, required business
+ * field with that name was silently bypassed → reached the DB as NULL. Skip by
+ * provenance (`def.system` / `def.readonly`), never by hardcoded name.
+ */
+import { describe, it, expect } from 'vitest';
+import { validateRecord, ValidationError } from './record-validator';
+
+describe('validateRecord provenance-aware skip (#1592)', () => {
+  it('enforces required on a DECLARED business organization_id (not system)', () => {
+    const schema: any = { name: 'sys_team', fields: {
+      name: { type: 'text', required: true },
+      organization_id: { type: 'lookup', reference: 'sys_organization', required: true },
+    } };
+    let caught: any;
+    try { validateRecord(schema, { name: 'x' }, 'insert'); } catch (e) { caught = e; }
+    expect(caught).toBeInstanceOf(ValidationError);
+    expect(caught.fields.some((f: any) => f.field === 'organization_id' && f.code === 'required')).toBe(true);
+  });
+
+  it('still skips an INJECTED system organization_id (system: true)', () => {
+    const schema: any = { name: 'normal', fields: {
+      name: { type: 'text', required: true },
+      organization_id: { type: 'lookup', reference: 'sys_organization', required: false, system: true, readonly: true },
+    } };
+    expect(() => validateRecord(schema, { name: 'x' }, 'insert')).not.toThrow();
+  });
+
+  it('enforces required on a declared tenant_id too', () => {
+    const schema: any = { name: 't', fields: {
+      name: { type: 'text', required: true },
+      tenant_id: { type: 'text', required: true },
+    } };
+    expect(() => validateRecord(schema, { name: 'x' }, 'insert')).toThrow(ValidationError);
+  });
+});


### PR DESCRIPTION
Closes #1592.

## Problem (confirmed)
`validateRecord` skipped required-checks for any field **literally named** `organization_id` / `tenant_id`. `POST /api/v1/data/sys_team` with `{ "name": "x" }` (omitting the required `organization_id`) reached the driver as NULL → `SQLITE NOT NULL constraint failed` instead of a clean `400 { field: organization_id, code: required }`.

## Root cause
`sys_team.organization_id` is a genuine `required` lookup, and because `sys_team` is `managedBy: 'better-auth'` the registry **does not inject** a tenant column for it. So the required org is neither client-validated (skipped by name) nor engine-injected → silent NULL.

The provenance mechanism to do this correctly **already exists**: the engine-injected tenant column is marked `system: true`, and [record-validator.ts](packages/objectql/src/validation/record-validator.ts) already skips `def.system || def.readonly`. The hardcoded `SKIP_FIELDS` by-name entry for `organization_id`/`tenant_id` was redundant for injected columns and **harmful** for declared ones.

## Fix
Drop `organization_id` / `tenant_id` from the by-name `SKIP_FIELDS` set. Injected system columns remain skipped via `def.system` / `def.readonly`; a declared required `organization_id`/`tenant_id` now gets a normal required-check. (The universal lifecycle columns `id`/`created_at`/`created_by`/`updated_at`/`updated_by` stay in `SKIP_FIELDS` — they are never author-declared business fields.)

## Tests
- New regression: declared required `organization_id` (and `tenant_id`) now throws `ValidationError { required }`; an injected `system: true` `organization_id` is still skipped.
- `@objectstack/objectql` full suite **616 pass** — no test relied on the by-name skip.

> Part of the data-API-honors-metadata set (#1590 unknown-field rejection, #1591 managedBy enforcement). This PR fixes the silent-NULL cause for #1592 specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)