### PR TITLE
docs: tabbed sidebar nav + de-emphasize objectql/ui/os protocol branding

### DIFF
--- a/.changeset/docs-nav-restructure.md
+++ b/.changeset/docs-nav-restructure.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: restructure the docs site left navigation — split the single long sidebar into six icon-labelled tabs (Getting Started, Concepts, Guides, Reference, Protocol, Releases), de-emphasise the ObjectQL/ObjectUI/ObjectOS protocol branding (Protocol moved to the last tab), isolate the 238 generated reference pages into their own tab, group the Guides section (Foundations/Building/Integration/Operations/Cheatsheets), and fix the top-nav GitHub link (objectstack-ai/spec → framework). Nav-only; no doc URLs change.

--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 
 export const gitConfig = {
   user: 'objectstack-ai',
-  repo: 'spec',
+  repo: 'framework',
   branch: 'main',
 };
 

--- a/content/docs/concepts/meta.json
+++ b/content/docs/concepts/meta.json
@@ -1,4 +1,6 @@
 {
   "title": "Concepts",
+  "icon": "Lightbulb",
+  "root": true,
   "pages": ["index", "north-star", "metadata-driven", "metadata-lifecycle", "design-principles", "architecture", "cluster-semantics", "webhook-delivery", "skills", "core", "packages", "setup-app", "cloud-artifact-api", "terminology", "implementation-status"]
 }

--- a/content/docs/getting-started/meta.json
+++ b/content/docs/getting-started/meta.json
@@ -1,4 +1,6 @@
 {
   "title": "Getting Started",
+  "icon": "Rocket",
+  "root": true,
   "pages": ["index", "quick-start", "core-concepts", "architecture", "examples", "cli", "glossary"]
 }

--- a/content/docs/guides/contracts/meta.json
+++ b/content/docs/guides/contracts/meta.json
@@ -1,4 +1,4 @@
 {
-  "title": "Contracts Protocol",
+  "title": "Service Contracts",
   "pages": ["index", "metadata-service", "auth-service", "storage-service", "data-engine", "cache-service"]
 }

--- a/content/docs/guides/meta.json
+++ b/content/docs/guides/meta.json
@@ -1,7 +1,10 @@
 {
   "title": "Guides",
+  "icon": "BookOpen",
+  "root": true,
   "pages": [
     "index",
+    "---Foundations---",
     "packages",
     "metadata",
     "adding-a-metadata-type",
@@ -26,6 +29,7 @@
     "---Integration---",
     "api-reference",
     "client-sdk",
+    "contracts",
     "project-scoping",
     "driver-configuration",
     "kernel-services",
@@ -43,8 +47,7 @@
     "error-handling-server",
     "standards",
     "troubleshooting",
-    "---",
-    "contracts",
+    "---Cheatsheets---",
     "cheatsheets"
   ]
 }

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -4,11 +4,8 @@
     "getting-started",
     "concepts",
     "guides",
-    "---",
-    "protocol",
-    "---",
     "references",
-    "---",
+    "protocol",
     "releases"
   ]
 }

--- a/content/docs/protocol/meta.json
+++ b/content/docs/protocol/meta.json
@@ -1,4 +1,6 @@
 {
-  "title": "Protocol Overview",
+  "title": "Protocol",
+  "icon": "Network",
+  "root": true,
   "pages": ["index", "objectql", "objectui", "objectos", "knowledge"]
 }

--- a/content/docs/references/meta.json
+++ b/content/docs/references/meta.json
@@ -1,5 +1,7 @@
 {
-  "title": "Protocol Reference",
+  "title": "Reference",
+  "icon": "FileCode",
+  "root": true,
   "pages": [
     "ai",
     "api",

--- a/content/docs/releases/meta.json
+++ b/content/docs/releases/meta.json
@@ -1,4 +1,6 @@
 {
   "title": "Releases",
+  "icon": "Tag",
+  "root": true,
   "pages": ["index", "v9"]
 }

--- a/packages/spec/scripts/build-docs.ts
+++ b/packages/spec/scripts/build-docs.ts
@@ -442,7 +442,11 @@ const pages = [
 ];
 
 const meta = {
-  title: "Protocol Reference",
+  title: "Reference",
+  icon: "FileCode",
+  // Render the (large, generated) reference as its own sidebar tab so it does not
+  // crowd the hand-written docs. Keep in sync with the other root sections' meta.json.
+  root: true,
   pages: pages
 };
 fs.writeFileSync(path.join(DOCS_ROOT, 'meta.json'), JSON.stringify(meta, null, 2));


### PR DESCRIPTION
Reworks the docs site **left navigation** for reader experience. The whole sidebar was one long rail mixing all 9 top-level groups + the 238 generated reference pages; this splits it into **six icon-labelled tabs** (fumadocs folder roots) so a reader sees one section at a time.

### Changes (nav-only — no files moved, no doc URLs changed)
- **Tabs + icons** — `root: true` + lucide `icon` on each top-level section's `meta.json`.
- **De-emphasize ObjectQL/ObjectUI/ObjectOS** — per maintainer call, the protocol layer was early-emphasis branding; root nav reordered so **Protocol is the last tab**, and the **generated Reference gets its own tab** instead of crowding hand-written docs.
- **Reference tab config is generated** — `references/meta.json` is emitted by `packages/spec/scripts/build-docs.ts`, so the title/icon/root were set there (title `Protocol Reference` → `Reference`), not by hand-editing the generated file.
- **Guides regrouped** — added a `Foundations` label, moved Service Contracts into `Integration`, surfaced `Cheatsheets` under their own label (was buried after a bare divider).
- **Fixed "Protocol" label collisions** — `Protocol Overview` → `Protocol`, `Contracts Protocol` → `Service Contracts`.
- **Bug fix** — top-nav GitHub link pointed at the renamed `objectstack-ai/spec`; now `framework`.

### Verification
- `pnpm --filter @objectstack/docs build` → compiles **all 1113 pages clean**, no lucide "unknown icon" warnings.
- Diff scoped to 8 `meta.json` + `layout.shared.tsx` + the generator. No reference content drift.

> Tabs are a visible UX change — worth a quick `pnpm --filter @objectstack/docs dev` eyeball before merge. Fully reversible (config-only).

Deferred (needs content decisions, not in this PR): three duplicate "Architecture" pages, glossary vs terminology overlap, and semantic renames of the 14 Reference categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
