### PR TITLE
docs(skill): verified anti-pattern deltas for formula + data authoring skills

### DIFF
--- a/.changeset/formula-data-skill-antipatterns.md
+++ b/.changeset/formula-data-skill-antipatterns.md
@@ -1,0 +1,12 @@
+---
+---
+
+docs(skill): add verified anti-pattern deltas to the formula and data authoring skills
+
+Documentation-only. Both skills were already mature, so this adds only the
+*verified* gaps from this season (no padding):
+- objectstack-formula: only the stdlib + CEL built-ins are callable — an UNKNOWN
+  function now FAILS `objectstack build` (#1877), not a silent runtime no-op.
+- objectstack-data: a `multiple: true` lookup is an ARRAY column (not a junction
+  object) — reference positionally (#1872); and on insert an omitted optional
+  field reads as `null` in validation predicates (#1871).

--- a/skills/objectstack-data/SKILL.md
+++ b/skills/objectstack-data/SKILL.md
@@ -295,14 +295,26 @@ See [rules/field-types.md](./rules/field-types.md) for full reference.
 |:--------|:---------------|
 | One-to-Many (independent) | `lookup` field on child |
 | One-to-Many (owned) | `master_detail` field on child |
-| Many-to-Many | Junction object with two `lookup` fields |
+| Many-to-Many (simple) | multi-value `lookup` (`multiple: true`) — an **array column** of ids |
+| Many-to-Many (with attributes) | Junction object with two `lookup` fields |
 | Hierarchical | `tree` field (self-reference) |
 
 See [rules/relationships.md](./rules/relationships.md) for detailed examples.
 
+> **`multiple: true` lookup ≠ junction object.** A multi-value lookup
+> (`{ type: 'lookup', reference: 'x', multiple: true }`) is stored and read as an
+> **array of ids** on the record — reference elements positionally
+> (`{record.tags.0}` in flow values). It is NOT a junction table. Reach for a
+> **junction object** (two lookups) only when the relationship itself carries
+> attributes (role, added_at, …). (#1872)
+
 ### Validation Patterns
 
 **⚠️ Script validation is inverted:** Validation **fails** when expression is `true`.
+
+> On **insert**, an optional field omitted from the payload reads as `null` in a
+> validation predicate — so `record.due_date == null` matches an omitted field the
+> same as an explicit `null` (#1871). (On update, the prior record supplies it.)
 
 Common validation types:
 - `script` — Formula expression (inverted logic)

--- a/skills/objectstack-formula/SKILL.md
+++ b/skills/objectstack-formula/SKILL.md
@@ -138,6 +138,13 @@ Registered automatically. Source:
 If you need a helper that doesn't exist, prefer adding it to the stdlib
 (small, pure, dependency-free) over inlining a complex CEL expression.
 
+> **Only the stdlib above + CEL built-ins (`has`, `size`, `contains`,
+> `startsWith`, `endsWith`, `matches`, `min`, `max`, …) are callable.** An
+> UNKNOWN function — `PRIOR()`, a legacy `ISBLANK()`, a typo'd `isBlnk()` — now
+> **fails `objectstack build`** with a "no matching overload" type error (#1877),
+> rather than silently no-op'ing the predicate at run time. Use `previous.x`
+> (not `PRIOR()`), `isBlank()` (not `ISBLANK()`).
+
 ---
 
 ## Mandatory patterns for AI emission


### PR DESCRIPTION
Continues the upstream "teach the AI the right pattern at the source" work (after #1921 for the automation skill) to the other two authoring skills.

## Discipline: verified deltas only, no padding
Both skills are **already mature** — formula already documents the #1491 brace-in-CEL mistake + the dialect split + `isBlank`/null handling; data already warns that script validation is inverted. So this adds **only the verified gaps from this session**, not fabricated anti-patterns:

**objectstack-formula** — only the stdlib + CEL built-ins are callable; an UNKNOWN function (`PRIOR()`, legacy `ISBLANK()`, a typo'd `isBlnk()`) now **fails `objectstack build`** with a "no matching overload" type error, not a silent runtime no-op. Use `previous.x` / `isBlank()`. (#1877)

**objectstack-data**
- A `multiple: true` lookup is an **array column**, not a junction object — reference positionally (`{record.tags.0}`); use a junction object only when the relationship carries attributes. (This is the exact confusion in #1872.)
- On insert, an optional field omitted from the payload reads as `null` in a validation predicate, so `record.due_date == null` matches an omitted field the same as explicit `null`. (#1871)

## Verification
Docs-only. `pnpm check:skill-docs` passes (generated docs derive from SKILL.md *frontmatter*, unchanged). Empty changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)