### PR TITLE
chore(spec): govern identity in the spec-liveness gate

### DIFF
--- a/.changeset/identity-liveness.md
+++ b/.changeset/identity-liveness.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(spec): extend the spec-liveness gate to the `identity` category. Governs `Role` (the one authorable RBAC type: `name`/`label`/`description` live, `parent` dead — org hierarchy uses `sys_department`, not `sys_role.parent`); the SCIM-protocol DTOs and better-auth runtime tables (User/Session/Account/…) are classified `internal`. Same audit as security; repo-internal tooling, no package version impact.

--- a/packages/spec/liveness/identity.json
+++ b/packages/spec/liveness/identity.json
@@ -1,0 +1,40 @@
+{
+  "category": "identity",
+  "_note": "Liveness for authorable identity metadata. Same audit as security (docs/audits/2026-06-security-identity-property-liveness.md), which scoped identity to RoleSchema. The only author-written metadata type here is Role (RBAC). The rest are NOT authorable metadata: SCIM 2.0 provisioning protocol DTOs, better-auth runtime tables (User/Session/Account/VerificationToken/ApiKey), and org/membership primitives (Member/Organization/Invitation) managed by plugin-auth / better-auth / the org plugins — classified `internal`.",
+  "schemas": {
+    "Role": {
+      "props": {
+        "name": { "status": "live", "evidence": "packages/plugins/plugin-security/src/permission-evaluator.ts:113", "note": "sys_role.name reused as a permission-set name for RBAC resolution." },
+        "label": { "status": "live", "note": "display metadata (admin nav/forms, security-plugin.ts:153)." },
+        "description": { "status": "live", "note": "display metadata." },
+        "parent": { "status": "dead", "evidence": "no consumer (grep); org hierarchy walks sys_department.parent_department_id via department-graph.ts, not sys_role.parent", "note": "Role 'Reports To' rollup unimplemented — removal candidate (ADR-0049). label/description display-only." }
+      }
+    },
+    "User": { "_schema": "internal", "_note": "better-auth runtime user table — not authorable metadata." },
+    "Session": { "_schema": "internal", "_note": "better-auth runtime session table." },
+    "Account": { "_schema": "internal", "_note": "better-auth runtime account/credential table." },
+    "VerificationToken": { "_schema": "internal", "_note": "better-auth runtime verification token." },
+    "ApiKey": { "_schema": "internal", "_note": "better-auth API key table." },
+    "Member": { "_schema": "internal", "_note": "org membership primitive (org plugin), not author-written metadata." },
+    "Organization": { "_schema": "internal", "_note": "org/tenant primitive (org plugin)." },
+    "Invitation": { "_schema": "internal", "_note": "org invitation primitive (org plugin)." },
+    "SCIMUser": { "_schema": "internal", "_note": "SCIM 2.0 provisioning protocol DTO." },
+    "SCIMGroup": { "_schema": "internal", "_note": "SCIM 2.0 protocol DTO." },
+    "SCIMEnterpriseUser": { "_schema": "internal", "_note": "SCIM 2.0 protocol DTO." },
+    "SCIMName": { "_schema": "internal", "_note": "SCIM 2.0 protocol DTO." },
+    "SCIMEmail": { "_schema": "internal", "_note": "SCIM 2.0 protocol DTO." },
+    "SCIMPhoneNumber": { "_schema": "internal", "_note": "SCIM 2.0 protocol DTO." },
+    "SCIMAddress": { "_schema": "internal", "_note": "SCIM 2.0 protocol DTO." },
+    "SCIMMeta": { "_schema": "internal", "_note": "SCIM 2.0 protocol DTO." },
+    "SCIMGroupReference": { "_schema": "internal", "_note": "SCIM 2.0 protocol DTO." },
+    "SCIMMemberReference": { "_schema": "internal", "_note": "SCIM 2.0 protocol DTO." },
+    "SCIMListResponse": { "_schema": "internal", "_note": "SCIM 2.0 protocol response DTO." },
+    "SCIMError": { "_schema": "internal", "_note": "SCIM 2.0 protocol error DTO." },
+    "SCIMPatchOperation": { "_schema": "internal", "_note": "SCIM 2.0 protocol DTO." },
+    "SCIMPatchRequest": { "_schema": "internal", "_note": "SCIM 2.0 protocol DTO." },
+    "SCIMBulkOperation": { "_schema": "internal", "_note": "SCIM 2.0 protocol DTO." },
+    "SCIMBulkRequest": { "_schema": "internal", "_note": "SCIM 2.0 protocol DTO." },
+    "SCIMBulkResponse": { "_schema": "internal", "_note": "SCIM 2.0 protocol DTO." },
+    "SCIMBulkResponseOperation": { "_schema": "internal", "_note": "SCIM 2.0 protocol DTO." }
+  }
+}

--- a/packages/spec/scripts/liveness/check-liveness.mjs
+++ b/packages/spec/scripts/liveness/check-liveness.mjs
@@ -38,7 +38,7 @@ const ledgerRoot = join(specRoot, 'liveness');
 
 // Categories whose authorable schemas must be fully classified. Extend
 // highest-risk-first as each category's ledger is seeded from its audit.
-const GOVERNED = ['security'];
+const GOVERNED = ['security', 'identity'];
 
 const args = process.argv.slice(2);
 const asJson = args.includes('--json');


### PR DESCRIPTION
Second category for the spec-liveness gate (#1919), completing the security/identity audit cluster.

## What it governs
- **`Role`** — the one author-written RBAC metadata type:
  - `name` → **live** (`sys_role.name` is reused as a permission-set name; `permission-evaluator.ts:113`)
  - `label` / `description` → **live** (display metadata)
  - `parent` → **dead** — the "Reports To" rollup is unimplemented; the org hierarchy walks `sys_department.parent_department_id` via `department-graph.ts`, nothing reads `sys_role.parent`. Removal candidate (ADR-0049).
- Everything else in `identity` is **not authorable metadata** → `internal`: SCIM 2.0 provisioning DTOs (16), better-auth runtime tables (`User`/`Session`/`Account`/`VerificationToken`/`ApiKey`), and org primitives (`Member`/`Organization`/`Invitation`).

## Gate result
```
security: 93 classified, 0 unclassified
identity:  4 classified (live 3, dead 1), 0 unclassified
```

## Note on rollout (for reviewers)
The json-schema **categories don't map cleanly to "authorable metadata types"** — most categories (`data`, `automation`, `ui`, `kernel`, …) are dominated by ObjectQL/engine/protocol DTOs, not author-written metadata. `security`/`identity` were the clean, fully-authorable cluster. Future categories will need either an explicit per-category authorable allowlist or per-type seeding from each type's liveness audit, rather than blanket per-category classification. Flagged so the next rollout step is scoped deliberately.

Independent of #1923 (depends only on the merged #1919).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
