### PR TITLE
chore(changeset): bump bare-ref validation to minor + downstream note

### DIFF
--- a/.changeset/validate-formula-bare-refs.md
+++ b/.changeset/validate-formula-bare-refs.md
@@ -1,9 +1,17 @@
 ---
-"@objectstack/formula": patch
-"@objectstack/cli": patch
+"@objectstack/formula": minor
+"@objectstack/cli": minor
 ---
 
 feat(validate): flag bare field references in record-scoped CEL sites at build time
+
+> **Heads-up for downstream:** this adds a NEW build-time error. A `Field.formula`
+> or validation predicate that references a field bare (`amount` instead of
+> `record.amount`) now fails `objectstack compile`. These expressions were already
+> silently broken at runtime (they evaluated to `null` / never fired), so this is a
+> fix that surfaces a latent bug — but a stack carrying one will go from
+> "builds, silently wrong" to "fails the build" on upgrade. The error message
+> states the exact correction (`write record.<field>`).
 
 A `Field.formula` and an object validation predicate evaluate against the
 `record` namespace only — there is no field flattening — so a bare top-level


### PR DESCRIPTION
The build-time bare-ref error from #1931 can fail a previously-passing build for any stack carrying a latent bare-reference bug (the expression was already silently broken at runtime). That is a behavior change for downstream consumers, so it warrants a **minor** bump and an explicit release note rather than a silent patch.

No code change — only the #1931 changeset (`@objectstack/formula` + `@objectstack/cli` patch -> minor) plus a heads-up note that lands in the changelog.

Refs #1928, #1931.

🤖 Generated with [Claude Code](https://claude.com/claude-code)