### PR TITLE
feat(spec): add `element:metadata_viewer` component (ADR-0051 P1)

### DIFF
--- a/packages/spec/src/ui/component.zod.ts
+++ b/packages/spec/src/ui/component.zod.ts
@@ -217,6 +217,33 @@ export const ElementImagePropsSchema = lazySchema(() => z.object({
 }));
 
 /**
+ * Read-only, synthesized view of a metadata item, embedded inline in content
+ * (ADR-0051). This is the *inline form* of ADR-0046 §3.5 ("derived content is
+ * rendered, never written") and the component a ` ```metadata ` doc fence
+ * compiles to. Because it renders the platform's *own* metadata via the
+ * platform's *own* viewer, it carries no expressions or actions — it stays on
+ * the data side of the §3.4 trust boundary and is safe to embed in inert docs
+ * (`embeddableInDoc`). The view is resolved live at read time, then projected
+ * to the reader's permissions automatically (see `detail` for the distinct,
+ * author-controlled altitude projection). `object` embeds are deferred
+ * (ADR-0051 §5).
+ */
+export const ElementMetadataViewerPropsSchema = lazySchema(() => z.object({
+  type: z.enum(['state_machine', 'flow', 'permission'])
+    .describe('Metadata view kind (ADR-0051): state_machine | flow | permission'),
+  name: z.string()
+    .describe('Target metadata item name; resolved package-scoped (ADR-0048), then dependencies (ADR-0046 §3.3)'),
+  object: z.string().optional()
+    .describe('Owning object — required for object-scoped kinds: state_machine is a rule ON an object (ADR-0020), permission renders a matrix FOR one; omit for top-level flow'),
+  mode: z.enum(['diagram', 'matrix', 'summary']).optional()
+    .describe('Render form; defaults per type (diagram for flow/state_machine, matrix for permission)'),
+  detail: z.enum(['business', 'technical']).optional().default('business')
+    .describe('Authoring altitude (ADR-0051 §3.4): business collapses technical flow nodes to business steps + approvals. NOT access (cf. book.audience); permission projection is automatic and render-time, never set here'),
+  /** ARIA accessibility */
+  aria: AriaPropsSchema.optional().describe('ARIA accessibility attributes'),
+}));
+
+/**
  * ----------------------------------------------------------------------
  * 4. Interactive Element Components (Phase B — Element Library)
  * ----------------------------------------------------------------------
@@ -311,6 +338,7 @@ export const ComponentPropsMap = {
   'element:text': ElementTextPropsSchema,
   'element:number': ElementNumberPropsSchema,
   'element:image': ElementImagePropsSchema,
+  'element:metadata_viewer': ElementMetadataViewerPropsSchema, // ADR-0051: inline read-only metadata view (embeddableInDoc)
   'element:divider': EmptyProps,
 
   // Interactive Elements


### PR DESCRIPTION
Implements the **P1 spec slice** of [ADR-0051](https://github.com/objectstack-ai/framework/pull/1940) — the read-only SDUI component that a ` ```metadata ` doc fence compiles to.

## Change

- New `ElementMetadataViewerPropsSchema` in `component.zod.ts`, placed in **Content Elements** (read-only), *not* Interactive — reinforcing the content-embeddable vs interactive-not boundary.
- Registered as `'element:metadata_viewer'` in `ComponentPropsMap`.

```ts
{ type: 'state_machine' | 'flow' | 'permission',
  name: string,            // package-scoped resolution (ADR-0048)
  object?: string,         // required for object-scoped kinds (state_machine, permission)
  mode?: 'diagram' | 'matrix' | 'summary',
  detail?: 'business' | 'technical' }  // authored altitude — NOT access, NOT permission projection
```

## Why this is the safe shape

The props are a **declarative reference** — no expressions, no action bindings. The view is drawn by the platform's *own* viewer over the package's *own* already-governed metadata, so the embed stays on the **data side of the ADR-0046 §3.4 / ADR-0025 trust boundary** that banned MDX. (A general component embed could carry CEL/actions = code; that's deferred to a future `objectui` fence — see ADR-0051 §4.)

`detail` is the *authored* altitude (`business` collapses technical flow nodes to business steps + approvals). Permission projection — stripping what a reader may not see — is **automatic and render-time**, never authored here, and deliberately not named `audience` to avoid colliding with `book.audience` (access tier).

## Scope

Spec-only. `object` embeds are deferred (ADR-0051 §5). The fence parser, the live-transclusion resolver, publish lint (parse + validate + reference-liveness), and the console render all land in follow-ups.

## Verification

- `vitest run src/ui/component.test.ts` → 91/91 pass
- `tsc --noEmit` → clean
- `dist/` is gitignored; no committed generated artifacts to regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)