### PR TITLE
fix(spec): correct 9 field props mis-classified dead — they are objectui-live

### DIFF
--- a/.changeset/fix-ledger-objectui-live.md
+++ b/.changeset/fix-ledger-objectui-live.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(spec): correct 9 field liveness classifications that were wrongly marked `dead`. They are LIVE via objectui renderers (verified against ../objectui): `externalId`, `currencyConfig`, `searchable`, and the master-detail/related-list overrides `inlineTitle`/`inlineColumns`/`inlineAmountField`/`relatedList`/`relatedListTitle`/`relatedListColumns`. The 2026-06 liveness audit's renderer-side verdicts were unreliable (objectui not re-checked); pruning these would have broken detail-page rendering. Ledger/process now include objectui. No prune.

--- a/packages/spec/liveness/field.json
+++ b/packages/spec/liveness/field.json
@@ -161,20 +161,23 @@
       "note": "DANGEROUS — advertises custom physical columns the driver never honors."
     },
     "searchable": {
-      "status": "dead",
-      "evidence": "field-level — no DDL/query consumer; search is object-level / view searchableFields"
+      "status": "live",
+      "evidence": "objectui: packages/plugin-dashboard/src/WidgetConfigPanel.tsx:458",
+      "note": "LIVE via objectui renderer — the 2026-06 audit mis-classified as dead (renderer side not re-verified). Corrected after checking ../objectui."
     },
     "index": {
       "status": "dead",
       "evidence": "field-level — driver reads object indexes[] (sql-driver.ts:1252); field bool unused"
     },
     "externalId": {
-      "status": "dead",
-      "evidence": "field-level — upsert keys off dataset-level externalId (seed-loader.ts:175)"
+      "status": "live",
+      "evidence": "objectui: apps/console/src/utils/metadataConverters.ts:125 reads field.externalId",
+      "note": "LIVE via objectui renderer — the 2026-06 audit mis-classified as dead (renderer side not re-verified). Corrected after checking ../objectui."
     },
     "currencyConfig": {
-      "status": "dead",
-      "evidence": "nested config — renderers read flat currency/precision (CurrencyField.tsx:40); no currencyConfig consumer"
+      "status": "live",
+      "evidence": "objectui: packages/fields/src/index.tsx:469 reads currencyConfig.defaultCurrency",
+      "note": "LIVE via objectui renderer — the 2026-06 audit mis-classified as dead (renderer side not re-verified). Corrected after checking ../objectui."
     },
     "vectorConfig": {
       "status": "dead",
@@ -193,28 +196,34 @@
       "evidence": "no consumer"
     },
     "inlineTitle": {
-      "status": "dead",
-      "evidence": "master-detail explicit override — auto-derivation works (deriveMasterDetail.ts); overrides unread"
+      "status": "live",
+      "evidence": "objectui: packages/app-shell/src/providers/MetadataProvider.tsx + plugin-form/deriveMasterDetail.ts",
+      "note": "LIVE via objectui renderer — the 2026-06 audit mis-classified as dead (renderer side not re-verified). Corrected after checking ../objectui."
     },
     "inlineColumns": {
-      "status": "dead",
-      "evidence": "master-detail explicit override — unread"
+      "status": "live",
+      "evidence": "objectui: packages/plugin-form/src/deriveMasterDetail.ts + app-shell/MetadataProvider.tsx",
+      "note": "LIVE via objectui renderer — the 2026-06 audit mis-classified as dead (renderer side not re-verified). Corrected after checking ../objectui."
     },
     "inlineAmountField": {
-      "status": "dead",
-      "evidence": "master-detail explicit override — unread"
+      "status": "live",
+      "evidence": "objectui: packages/app-shell/src/providers/MetadataProvider.tsx",
+      "note": "LIVE via objectui renderer — the 2026-06 audit mis-classified as dead (renderer side not re-verified). Corrected after checking ../objectui."
     },
     "relatedList": {
-      "status": "dead",
-      "evidence": "detail-page related lists come from view metadata, not FieldSchema"
+      "status": "live",
+      "evidence": "objectui: packages/app-shell/src/views/RecordDetailView.tsx + utils/deriveRelatedLists.ts",
+      "note": "LIVE via objectui renderer — the 2026-06 audit mis-classified as dead (renderer side not re-verified). Corrected after checking ../objectui."
     },
     "relatedListTitle": {
-      "status": "dead",
-      "evidence": "master-detail explicit override — unread"
+      "status": "live",
+      "evidence": "objectui: packages/app-shell/src/views/RecordDetailView.tsx + utils/deriveRelatedLists.ts",
+      "note": "LIVE via objectui renderer — the 2026-06 audit mis-classified as dead (renderer side not re-verified). Corrected after checking ../objectui."
     },
     "relatedListColumns": {
-      "status": "dead",
-      "evidence": "master-detail explicit override — unread"
+      "status": "live",
+      "evidence": "objectui: packages/app-shell/src/utils/deriveRelatedLists.ts + views/RecordDetailView.tsx",
+      "note": "LIVE via objectui renderer — the 2026-06 audit mis-classified as dead (renderer side not re-verified). Corrected after checking ../objectui."
     }
   }
 }


### PR DESCRIPTION
The liveness ledgers' renderer-side verdicts are unreliable — seeded from the 2026-06 audits, which did NOT re-check the frontend repo ../objectui. Verifying against objectui shows 9 field props marked dead are actually LIVE in the renderer: externalId (metadataConverters.ts:125 reads field.externalId), currencyConfig (fields/src/index.tsx:469), searchable (plugin-dashboard WidgetConfigPanel), and the master-detail/related-list overrides inlineTitle/inlineColumns/inlineAmountField/relatedList/relatedListTitle/relatedListColumns (app-shell RecordDetailView + deriveRelatedLists/deriveMasterDetail).

Pruning these (as the dead-surface plan proposed) would have broken detail-page/master-detail rendering. Reclassified dead→live with objectui evidence; gate green (field 43 live / 8 dead).

Already-merged prune batches #1945 (display configs) + #1946 (governance) were re-verified against objectui and confirmed renderer-dead — safe, no breakage shipped. Further pruning paused until the remaining ledgers + disposition plan are re-verified against objectui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)