### PR TITLE
docs(showcase): "Live Metadata Views" example doc (ADR-0051 P1)

### DIFF
--- a/examples/app-showcase/src/docs/showcase_metadata_views_guide.md
+++ b/examples/app-showcase/src/docs/showcase_metadata_views_guide.md
@@ -1,0 +1,64 @@
+---
+title: Live Metadata Views in Docs
+description: Embed live, read-only views of state machines, flows, and permissions directly in the prose.
+---
+
+# Live Metadata Views in Docs
+
+Documentation is for the reader who can't — or shouldn't — open Studio: a
+business analyst, a project manager, an auditor. For them a running screen only
+ever shows *their own slice* of the system. It never shows the whole shape of a
+process, the full set of legal state transitions, or who can do what across an
+object.
+
+This page embeds those **live, read-only views** straight into the prose with a
+` ```metadata ` fenced block. Each view is **resolved at read time** from the
+current metadata — change the underlying state machine and the diagram below
+changes with it. Nothing here is a screenshot (ADR-0051).
+
+## A record lifecycle — state machine
+
+A Task moves across a board. Which moves are legal is governed by the
+`task_status_flow` state machine on the `showcase_task` object. Here it is,
+rendered live from that rule:
+
+```metadata
+type: state_machine
+object: showcase_task
+name: task_status_flow
+```
+
+Projects have their own lifecycle, including terminal (dead-end) states:
+
+```metadata
+type: state_machine
+object: showcase_project
+name: project_status_flow
+```
+
+## A process — flow
+
+The reassignment wizard, shown at the **business altitude** — purely technical
+steps (scripts, record I/O) are folded away so the reader sees the process, not
+the plumbing:
+
+```metadata
+type: flow
+name: showcase_reassign_wizard
+detail: business
+```
+
+## Who can do what — permission
+
+The `showcase_contributor` permission set, as an object-access matrix:
+
+```metadata
+type: permission
+name: showcase_contributor
+```
+
+---
+
+> These four views are not authored prose — they are the live metadata,
+> projected read-only into the document. See
+> [the showcase overview](./showcase_index.md) for the rest of the workspace.


### PR DESCRIPTION
Adds a showcase `doc` that demonstrates **ADR-0051** inline metadata views, and serves as the browser-verification fixture for the feature.

`examples/app-showcase/src/docs/showcase_metadata_views_guide.md` embeds four ` ```metadata ` fences against existing showcase metadata:

- `task_status_flow` / `project_status_flow` — state-machine lifecycles
- `showcase_reassign_wizard` — a flow at business altitude (`detail: business`)
- `showcase_contributor` — a permission matrix

## Part of the ADR-0051 set

- [framework#1940](https://github.com/objectstack-ai/framework/pull/1940) — the ADR (merged)
- [framework#1942](https://github.com/objectstack-ai/framework/pull/1942) — spec: `element:metadata_viewer`
- [objectui#1774](https://github.com/objectstack-ai/objectui/pull/1774) — the renderer + ` ```metadata ` fence hook
- **this PR** — the showcase example / fixture

## Independence & verification

The doc compiles through the existing doc collector unchanged (a ` ```metadata ` fence is valid CommonMark, not MDX), so this PR is independently mergeable. It **renders live** once objectui#1774 is deployed.

Verified end-to-end in the browser: ran this showcase backend + the objectui console dev server and confirmed all four embeds resolve live from the showcase metadata with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)