### PR TITLE
refactor(audit): move sys_attachment ownership audit → storage (ADR-0052 P0b)

### DIFF
--- a/docs/adr/0052-audit-is-not-the-activity-feed.md
+++ b/docs/adr/0052-audit-is-not-the-activity-feed.md
@@ -281,10 +281,13 @@ rather than written twice.
   human-readable summaries. Smallest change, biggest daily payoff, no migration —
   it only improves the *render* of rows the writer already emits. **This ADR
   ships P0a.**
-- **P0b — ownership, no behavior change.** Move `sys_attachment` → storage,
-  `sys_notification` → messaging (code already concedes these). Make
-  "collaboration/activity is a platform primitive" an explicit capability rather
-  than an audit side-effect; keep it default-available so no UI regresses.
+- **P0b — ownership, no behavior change.** ✅ `sys_attachment` registration moved
+  `plugin-audit` → `service-storage` (both always-on, so it stays available; the
+  definition stays in `platform-objects`). `sys_notification` is **deferred** — it
+  is mid-migration to an event model (`metadata/.../migrate-sys-notification-to-event.ts`,
+  ADR-0030), so moving it now would collide with that in-flight work. Still TODO:
+  make "collaboration/activity is a platform primitive" an explicit capability
+  rather than an audit side-effect; keep it default-available so no UI regresses.
 - **P1 — kill the split-brain + milestone templates (§5b.2).** Choose the
   canonical collaboration backend (§5), migrate/alias `sys_comment`, repoint
   ChatterPanel, surface reactions/threads. Add declarative object-level milestone

--- a/packages/plugins/plugin-audit/src/audit-plugin.ts
+++ b/packages/plugins/plugin-audit/src/audit-plugin.ts
@@ -3,12 +3,12 @@
 import type { Plugin, PluginContext } from '@objectstack/core';
 import type { IDataEngine } from '@objectstack/spec/contracts';
 import { SysAuditLog, SysActivity, SysComment } from './objects/index.js';
-// Registered here but still owned by platform-objects (the plugin contributes
-// them to the kernel without owning the definition yet):
-//   - sys_notification — reworked by ADR-0030 messaging (notification→event).
-//   - sys_attachment    — a file↔record link belonging with service-storage's
-//     sys_file; moves in the storage-domain decomposition, not this audit move.
-import { SysNotification, SysAttachment } from '@objectstack/platform-objects/audit';
+// `sys_notification` is contributed here but owned by platform-objects; it is
+// being reworked by ADR-0030 messaging (notification→event), so it stays put
+// until that migration lands. `sys_attachment` moved to @objectstack/service-
+// storage (ADR-0052 §3 ownership: a file↔record link belongs with storage, not
+// the compliance ledger).
+import { SysNotification } from '@objectstack/platform-objects/audit';
 import { installAuditWriters, type MessagingEmitSurface } from './audit-writers.js';
 
 /**
@@ -37,7 +37,7 @@ export class AuditPlugin implements Plugin {
       scope: 'system',
       defaultDatasource: 'cloud',
       namespace: 'sys',
-      objects: [SysAuditLog, SysActivity, SysComment, SysAttachment, SysNotification],
+      objects: [SysAuditLog, SysActivity, SysComment, SysNotification],
       // ADR-0029 D7 — contribute the Audit Logs entry into the Setup app's
       // `group_diagnostics` slot. The plugin owns sys_audit_log (K2).
       navigationContributions: [

--- a/packages/services/service-storage/package.json
+++ b/packages/services/service-storage/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@objectstack/core": "workspace:*",
     "@objectstack/observability": "workspace:*",
+    "@objectstack/platform-objects": "workspace:*",
     "@objectstack/spec": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/services/service-storage/src/storage-service-plugin.ts
+++ b/packages/services/service-storage/src/storage-service-plugin.ts
@@ -14,6 +14,10 @@ import type { S3StorageAdapterOptions } from './s3-storage-adapter.js';
 import { StorageMetadataStore } from './metadata-store.js';
 import { registerStorageRoutes } from './storage-routes.js';
 import { SystemFile, SystemUploadSession } from './objects/index.js';
+// ADR-0052 §3 ownership: `sys_attachment` (a file↔record link) belongs with the
+// storage domain, not the audit/compliance ledger. Definition stays in
+// platform-objects; storage now contributes (registers) it instead of audit.
+import { SysAttachment } from '@objectstack/platform-objects/audit';
 import { SwappableStorageService } from './swappable-storage-service.js';
 
 /**
@@ -170,7 +174,7 @@ export class StorageServicePlugin implements Plugin {
         version: '1.0.0',
         type: 'plugin',
         scope: 'system',
-        objects: [SystemFile, SystemUploadSession],
+        objects: [SystemFile, SystemUploadSession, SysAttachment],
       });
     } catch {
       // manifest service may not be available in all environments

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2033,6 +2033,9 @@ importers:
       '@objectstack/observability':
         specifier: workspace:*
         version: link:../../observability
+      '@objectstack/platform-objects':
+        specifier: workspace:*
+        version: link:../../platform-objects
       '@objectstack/spec':
         specifier: workspace:*
         version: link:../../spec


### PR DESCRIPTION
## What

ADR-0052 **P0b** (partial) — move `sys_attachment` ownership out of the audit/compliance ledger.

`plugin-audit` was a dumping ground registering 5 objects across 5 domains. This sheds one: a file↔record link (`sys_attachment`) belongs with the **storage** domain. `plugin-audit` stops registering it; `service-storage` now contributes it (the definition stays in `platform-objects`). Both plugins are always-on, so the object stays available — **no behavior change**.

`sys_notification` is **intentionally not moved**: it is mid-migration to an event model (`migrate-sys-notification-to-event.ts`, ADR-0030); moving it now would collide with that in-flight work. Deferred and documented.

## Changes

- `plugin-audit`: drop `SysAttachment` from registered objects + import.
- `service-storage`: depend on `@objectstack/platform-objects`, import + register `SysAttachment` (no dependency cycle — platform-objects doesn't depend on storage).
- ADR-0052 §6 P0b updated.

## Verification (showcase, browser)

- `meta/object/sys_attachment` → 200 (still registered, now via storage); `data/sys_attachment` → 200; **no double-registration / collision** at boot.
- `plugin-audit` 18/18 + `service-storage` 48/48 tests pass; both build clean.

## Builds on

#1948 (trackHistory §5b.1) + #1952 (milestones §5b.2). Remaining: `sys_notification` (after its event migration), P1 split-brain convergence, P2 event bus, objectui feed surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
