### PR TITLE
chore(spec): cut orphaned object.recordTypes and object.cdc stubs

### DIFF
--- a/.changeset/cut-recordtypes-cdc.md
+++ b/.changeset/cut-recordtypes-cdc.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(spec): remove the orphaned `object.recordTypes` and `object.cdc` properties from `ObjectSchema`. Both were spec-only stubs with elaborate docstrings and zero consumers in either repo (framework runtime + objectui authoring/rendering): `recordTypes` (Salesforce-specific concept — the platform models record variants via a discriminator field + conditional layouts / form variants) and `cdc` / `CDCConfigSchema` (aspirational enterprise change-data-capture — low-code change propagation is served by webhooks + triggers). Removes false surface from the metadata contract; both were classified `dead` in the liveness ledger. No package version impact.

--- a/packages/spec/liveness/object.json
+++ b/packages/spec/liveness/object.json
@@ -181,10 +181,6 @@
       "status": "dead",
       "evidence": "aspirational; no runtime"
     },
-    "cdc": {
-      "status": "dead",
-      "evidence": "aspirational; no runtime"
-    },
     "softDelete": {
       "status": "dead",
       "evidence": "no runtime; duplicates the (also dead) enable.trash"
@@ -192,10 +188,6 @@
     "search": {
       "status": "dead",
       "evidence": "SearchConfigSchema — no runtime; duplicates enable.searchable"
-    },
-    "recordTypes": {
-      "status": "dead",
-      "evidence": "elaborate docstring, unimplemented"
     },
     "defaultDetailForm": {
       "status": "dead",

--- a/packages/spec/src/data/object.zod.ts
+++ b/packages/spec/src/data/object.zod.ts
@@ -199,23 +199,6 @@ export const PartitioningConfigSchema = lazySchema(() => z.object({
 }));
 
 /**
- * Change Data Capture (CDC) Configuration Schema
- * Enables real-time data streaming to external systems
- * 
- * @example Stream all changes to Kafka
- * {
- *   enabled: true,
- *   events: ['insert', 'update', 'delete'],
- *   destination: 'kafka://events.objectstack'
- * }
- */
-export const CDCConfigSchema = lazySchema(() => z.object({
-  enabled: z.boolean().describe('Enable Change Data Capture'),
-  events: z.array(z.enum(['insert', 'update', 'delete'])).describe('Event types to capture'),
-  destination: z.string().describe('Destination endpoint (e.g., "kafka://topic", "webhook://url")'),
-}));
-
-/**
  * Object Field Group Schema — MVP (data-layer protocol)
  * 
  * Declares the set of logical field groups for an object. A group bundles
@@ -514,9 +497,6 @@ const ObjectSchemaBase = z.object({
   // Partitioning strategy
   partitioning: PartitioningConfigSchema.optional().describe('Table partitioning configuration for performance'),
   
-  // Change Data Capture
-  cdc: CDCConfigSchema.optional().describe('Change Data Capture (CDC) configuration for real-time data streaming'),
-  
   /**
    * Logic & Validation (Co-located)
    * Best Practice: Define rules close to data.
@@ -606,9 +586,6 @@ const ObjectSchemaBase = z.object({
    * System Capabilities 
    */
   enable: ObjectCapabilities.optional().describe('Enabled system features modules'),
-
-  /** Record Types */
-  recordTypes: z.array(z.string()).optional().describe('Record type names for this object'),
 
   /** Sharing Model */
   sharingModel: z.enum(['private', 'read', 'read_write', 'full']).optional().describe('Default sharing model'),
@@ -882,7 +859,6 @@ export type TenancyConfig = z.infer<typeof TenancyConfigSchema>;
 export type SoftDeleteConfig = z.infer<typeof SoftDeleteConfigSchema>;
 export type VersioningConfig = z.infer<typeof VersioningConfigSchema>;
 export type PartitioningConfig = z.infer<typeof PartitioningConfigSchema>;
-export type CDCConfig = z.infer<typeof CDCConfigSchema>;
 
 /**
  * Resolved CRUD affordance matrix for an object — what generic


### PR DESCRIPTION
## What

Removes two spec-only properties from `ObjectSchema` that had elaborate docstrings but **zero consumers in either repo** (framework runtime + objectui authoring/rendering). Both were classified `dead` in the spec-liveness ledger.

| Prop | Why it's gone | What to use instead |
|---|---|---|
| `object.recordTypes` | Salesforce-specific concept; never wired | Discriminator field + conditional layouts (`visibleWhen` / form variants) |
| `object.cdc` (+ `CDCConfigSchema`, `CDCConfig` type) | Aspirational enterprise change-data-capture; no streaming runtime | Webhooks + triggers for change propagation |

This is part of the spec-liveness "narrow-and-true" hygiene: shedding false surface from the metadata contract. Verified orphaned in **both** `framework` and `../objectui` before removal (cross-repo grep + read).

## Verification

- `check:liveness` green — `object 56 classified`, all governed properties classified.
- `gen:schema` regenerates clean (1686 schemas).
- `@objectstack/spec` tests: **6562 passed (242 files)**.
- No `recordTypes` / `CDCConfig` references remain anywhere under `packages/` (excluding `dist`/`node_modules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)