### PR TITLE
fix(runtime): serve /discovery with Cache-Control: no-store (cloud#152)

### DIFF
--- a/packages/runtime/src/dispatcher-plugin.routes.test.ts
+++ b/packages/runtime/src/dispatcher-plugin.routes.test.ts
@@ -14,11 +14,14 @@ import { createDispatcherPlugin } from './dispatcher-plugin.js';
 
 function makeFakeServer() {
   const routes: string[] = [];
-  const rec = (verb: string) => (path: string, _handler: unknown) => {
+  const handlers: Record<string, (req: any, res: any) => any> = {};
+  const rec = (verb: string) => (path: string, handler: any) => {
     routes.push(`${verb} ${path}`);
+    handlers[`${verb} ${path}`] = handler;
   };
   return {
     routes,
+    handlers,
     server: {
       get: rec('GET'),
       post: rec('POST'),
@@ -71,5 +74,26 @@ describe('createDispatcherPlugin — HTTP route registration', () => {
 
     expect(routes).toContain('POST /v2/mcp');
     expect(routes).toContain('POST /v2/keys');
+  });
+
+  // cloud#152: discovery reflects mutable runtime config (e.g. routes.mcp toggles
+  // with OS_MCP_SERVER_ENABLED). It must be served Cache-Control: no-store so an
+  // edge/CDN never serves a stale payload after the config changes.
+  it('serves both discovery routes with Cache-Control: no-store', async () => {
+    const { server, handlers } = makeFakeServer();
+    const plugin = createDispatcherPlugin({ prefix: '/api/v1', securityHeaders: false });
+    await plugin.start?.(makeCtx(server));
+
+    for (const route of ['GET /.well-known/objectstack', 'GET /api/v1/discovery']) {
+      const handler = handlers[route];
+      expect(handler, `${route} should be registered`).toBeTypeOf('function');
+      const headers: Record<string, string> = {};
+      const res: any = {
+        header: (k: string, v: string) => { headers[k] = v; },
+        json: () => {},
+      };
+      await handler({}, res);
+      expect(headers['Cache-Control'], `${route} Cache-Control`).toBe('no-store');
+    }
   });
 });

--- a/packages/runtime/src/dispatcher-plugin.ts
+++ b/packages/runtime/src/dispatcher-plugin.ts
@@ -452,6 +452,14 @@ export function createDispatcherPlugin(config: DispatcherPluginConfig = {}): Plu
                         res.header(k, v);
                     }
                 }
+                // Discovery reflects MUTABLE runtime config (which routes/services
+                // are live — e.g. `mcp` only when OS_MCP_SERVER_ENABLED=true). It
+                // must never be cached by an edge/CDN, or a config change (enable
+                // MCP) leaves clients reading a stale payload that still says the
+                // route is absent — the Integrations UI then shows "MCP not
+                // enabled" against a live server (cloud#152). The body is computed
+                // fresh per request; the only staleness is the HTTP cache layer.
+                res.header('Cache-Control', 'no-store');
                 res.json({ data: await dispatcher.getDiscoveryInfo(prefix) });
             });
 
@@ -462,6 +470,9 @@ export function createDispatcherPlugin(config: DispatcherPluginConfig = {}): Plu
                         res.header(k, v);
                     }
                 }
+                // See the .well-known handler above: discovery must not be cached
+                // (mutable runtime config; cloud#152 stale `routes.mcp`).
+                res.header('Cache-Control', 'no-store');
                 res.json({ data: await dispatcher.getDiscoveryInfo(prefix) });
             });
 


### PR DESCRIPTION
## Bug (cloud#152)
Discovery reflects **mutable** runtime config — `routes.mcp` is only advertised when `OS_MCP_SERVER_ENABLED=true`. But the discovery routes set **no `Cache-Control`**, so an edge/CDN can cache the response. On a staging env, after enabling MCP, `GET /api/v1/discovery` kept returning `routes.mcp: undefined` (stale, even with cache-busting query params) while `POST /api/v1/mcp` correctly served — so the objectui Integrations page showed **"MCP not enabled"** against a live server.

## Root cause
`getDiscoveryInfo()` (http-dispatcher.ts) and `isMcpEnabled()` (reads `process.env` fresh) recompute the payload correctly per request — the in-app value is never stale. `buildSecurityHeaders()` sets no `Cache-Control` (its `max-age` is HSTS). So the only staleness is the HTTP cache layer.

## Fix
Mark both discovery routes (`/.well-known/objectstack` + `${prefix}/discovery`) **`Cache-Control: no-store`**. `res.header()` is the same emit method the adjacent no-cache routes use. +regression test asserting the header on both routes.

## Test
`@objectstack/runtime` builds clean; `dispatcher-plugin.routes.test.ts` green (4/4, incl. the new no-store assertion).

Note: the actual CF-edge cache only clears once cloud bumps `.framework-sha` to this and deploys to staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)