### PR TITLE
chore(security): pin transitive form-data to >=4.0.6 (GHSA-hmw2-7cc7-3qxx)

### DIFF
--- a/.changeset/form-data-cve.md
+++ b/.changeset/form-data-cve.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(security): pin transitive `form-data` to `>=4.0.6` (GHSA-hmw2-7cc7-3qxx, high — CRLF injection via unescaped multipart field names). `4.0.5` was pulled in through `@vscode/vsce`; added a `pnpm-workspace.yaml` override so `pnpm audit --audit-level=high` (the `Validate Package Dependencies` CI gate) passes. No package version impact.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   esbuild: '>=0.28.1'
   minimatch@<10.2.3: 10.2.3
   tar@>=2.0.0 <7.5.11: ^7.5.11
+  form-data@<4.0.6: '>=4.0.6'
 
 importers:
 
@@ -5467,8 +5468,8 @@ packages:
       debug:
         optional: true
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   forwarded@0.2.0:
@@ -10783,7 +10784,7 @@ snapshots:
       cheerio: 1.2.0
       cockatiel: 3.2.1
       commander: 12.1.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       glob: 13.0.6
       hosted-git-info: 4.1.0
       jsonc-parser: 3.3.1
@@ -11817,7 +11818,7 @@ snapshots:
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,11 @@ onlyBuiltDependencies:
 # pins must live here (previously orphaned in package.json: minimatch, tar).
 #   - esbuild: GHSA-gv7w-rqvm-qjhr (high). tsup/tsx/vite pulled 0.27.7 / 0.28.0
 #     (< 0.28.1); force the patched line everywhere.
+#   - form-data: GHSA-hmw2-7cc7-3qxx (high) — CRLF injection via unescaped
+#     multipart field names. Pulled 4.0.5 transitively through @vscode/vsce;
+#     force the patched >=4.0.6 line. Fails `pnpm audit --audit-level=high` (CI).
 overrides:
   esbuild: '>=0.28.1'
   'minimatch@<10.2.3': '10.2.3'
   'tar@>=2.0.0 <7.5.11': '^7.5.11'
+  'form-data@<4.0.6': '>=4.0.6'


### PR DESCRIPTION
## What

`form-data@4.0.5` — **GHSA-hmw2-7cc7-3qxx** (high: CRLF injection via unescaped multipart field names, vulnerable `>=4.0.0 <4.0.6`) — is pulled in transitively through `@vscode/vsce` (in `packages/vscode-objectstack`). This tripped `pnpm audit --audit-level=high`, the **`Validate Package Dependencies`** CI gate, which was **red on every PR**.

Adds a `pnpm-workspace.yaml` `overrides` pin forcing the patched line, using the same mechanism already in place for the esbuild / minimatch / tar security pins. (pnpm v10 ignores `pnpm.overrides` in `package.json` — overrides must live in `pnpm-workspace.yaml`.)

```yaml
overrides:
  ...
  'form-data@<4.0.6': '>=4.0.6'
```

## Verification

- Lockfile resolves `form-data` 4.0.5 → **4.0.6**; no other resolution changes.
- `pnpm audit --audit-level=high` → **0 high** (was 1 high; 2 low + 6 moderate remain, which don't fail the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)