### PR TITLE
fix(showcase): drop dead props f_rating.maxRating / f_vector.vectorConfig

### DIFF
--- a/examples/app-showcase/src/objects/field-zoo.object.ts
+++ b/examples/app-showcase/src/objects/field-zoo.object.ts
@@ -121,13 +121,13 @@ export const FieldZoo = ObjectSchema.create({
     f_code: Field.code('json', { label: 'Code Editor' }),
     f_json: Field.json({ label: 'JSON' }),
     f_color: Field.color({ label: 'Color' }),
-    f_rating: Field.rating(5, { label: 'Rating' }),
+    f_rating: { type: 'rating', label: 'Rating', max: 5 },
     f_slider: Field.slider({ label: 'Slider', min: 0, max: 100, step: 5 }),
     f_signature: Field.signature({ label: 'Signature' }),
     f_qrcode: Field.qrcode({ label: 'QR / Barcode' }),
     f_progress: { type: 'progress', label: 'Progress', min: 0, max: 100 },
 
     // ── AI / ML ──────────────────────────────────────────────────────────
-    f_vector: Field.vector(1536, { label: 'Embedding Vector' }),
+    f_vector: { type: 'vector', label: 'Embedding Vector', dimensions: 1536 },
   },
 });


### PR DESCRIPTION
## What

The spec-liveness author-warning lint (`packages/cli/src/utils/lint-liveness-properties.ts`, run during `objectstack compile`) flagged two genuine **dead-property** usages in `examples/app-showcase` — props that compile fine but do nothing at runtime.

In `examples/app-showcase/src/objects/field-zoo.object.ts`:

| Field | Was | Now | Why |
|---|---|---|---|
| `f_rating` | `Field.rating(5, …)` → emits `maxRating` | `{ type: 'rating', label: 'Rating', max: 5 }` | `RatingField` reads the flat `max` prop, not `maxRating` |
| `f_vector` | `Field.vector(1536, …)` → emits nested `vectorConfig` | `{ type: 'vector', label: 'Embedding Vector', dimensions: 1536 }` | `VectorField` reads the flat `dimensions` sibling; nothing consumes `vectorConfig` (no vector-index DDL) |

Both switched from the builder helpers to raw literals — matching the style of other raw-literal fields already in this file (`f_progress`, `f_time`, etc.) — so the showcase, our exemplary reference app, authors **zero dead props**.

## Verification

`node ../../packages/cli/bin/run.js compile` from `examples/app-showcase`:
- exit 0, `✓ Build complete`
- no `liveness-dead-property` warnings
- no new errors

## Follow-up (out of scope)

The `Field.rating` / `Field.vector` **builders themselves** still emit the dead `maxRating` / `vectorConfig` (`packages/spec/src/data/field.zod.ts:701,727`), so any other app using those helpers trips the same lint. Worth a separate fix to align the builders with what renderers read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)