### PR TITLE
chore(triggers): remove stray [dbg-bc] debug console.log

### DIFF
--- a/packages/triggers/trigger-record-change/src/record-change-trigger.ts
+++ b/packages/triggers/trigger-record-change/src/record-change-trigger.ts
@@ -179,8 +179,6 @@ export class RecordChangeTrigger implements FlowTrigger {
                   { ...(inputDoc ?? {}), ...after }
                 : inputDoc ?? (previous && typeof previous === 'object' ? previous : {});
 
-        // eslint-disable-next-line no-console
-        console.log('[dbg-bc] ctx.input=', JSON.stringify(ctx.input), 'after=', JSON.stringify(after), 'record=', JSON.stringify(record));
         const session = (ctx.session ?? {}) as { userId?: string };
 
         return {


### PR DESCRIPTION
## What

Removes a leftover debug `console.log('[dbg-bc]', ...)` (and its `// eslint-disable-next-line no-console` comment) from `RecordChangeTrigger.buildContext()` in `packages/triggers/trigger-record-change/src/record-change-trigger.ts`.

## Why

Stray debug logging left in from a prior investigation — it dumped `ctx.input` / `after` / `record` on every record-change automation hook fire, polluting logs in production. Pure noise; no behavior change.

## Test

`pnpm --filter @objectstack/trigger-record-change test` — all 17 tests pass. (Two integration test *files* fail to load in an isolated worktree due to unbuilt `@objectstack/core` deps — pre-existing env noise, unaffected by this one-line deletion.)