### PR TITLE
fix(rest): resolve public forms from flattened view metadata

### DIFF
--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -3448,6 +3448,7 @@ export class RestServer {
             for (const view of views ?? []) {
                 if (!view || typeof view !== 'object') continue;
                 const candidates: Array<{ form: any; key?: string }> = [];
+                // Authoring/nested shape (defineView): { form, formViews: { key: {...} } }.
                 if (view.form && view.form.sharing) candidates.push({ form: view.form });
                 const formViews = view.formViews;
                 if (formViews && typeof formViews === 'object') {
@@ -3456,6 +3457,14 @@ export class RestServer {
                             candidates.push({ form: fv as any, key });
                         }
                     }
+                }
+                // Flattened registered shape (getMetaItems → one item per view:
+                // { name, object, viewKind:'form', config:{ data, sections, sharing } }).
+                // A form view carries its sharing under `config`; without this branch
+                // public-form resolution silently fails for the standard view metadata.
+                if (view.viewKind === 'form' && view.config && typeof view.config === 'object'
+                    && (view.config as any).sharing) {
+                    candidates.push({ form: view.config, key: view.name });
                 }
                 for (const c of candidates) {
                     const sharing = c.form?.sharing;


### PR DESCRIPTION
## What

Fix `findPublicFormView` so the public-form endpoints (`/forms/:slug`, `/forms/:slug/submit`) actually resolve standard form views.

## Bug

The resolver only matched the **authoring** view shape (`view.form.sharing`, `view.formViews.{key}.sharing`). But `getMetaItems({type:'view'})` returns the **registered/flattened** shape — one item per view: `{ name: 'crm_lead.web_to_lead', object: 'crm_lead', viewKind: 'form', config: { data, sections, sharing } }`. The `sharing` (allowAnonymous + publicLink) sits under `config`, which the resolver never inspected.

Result: **every** standard Web-to-Lead / Web-to-Case form returned `FORM_NOT_FOUND` — the capability was fully declared (profile + view + spec + UI component) but non-functional at runtime. An unenforced/untested surface.

## Fix

Add a third candidate: a `viewKind === 'form'` item whose `config` carries `sharing`. Object name resolves via `config.data.object` (or the item's `object`).

## Verification (HotCRM, end-to-end)

- `GET /api/v1/forms/contact-us` (no auth) → **200** form spec
- `POST /api/v1/forms/contact-us/submit` (no auth) → creates a `crm_lead`
- `POST /api/v1/forms/support/submit` (no auth) → creates a `crm_case`
- `GET /api/v1/data/crm_lead` (no auth) → **401** (guests still can't read — INSERT-only enforced)

`@objectstack/rest` 121/121 tests pass.

> Found by browser-verifying web-to-lead. Note: a *separate* app-side bug also blocked it — guest profiles must key the **full** object name (`crm_lead`, not `lead`) for the anonymous permission path; the short-name path that works for authenticated profiles does not resolve here (possible follow-up: normalize short→full names consistently in the explicit-permission-set path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
