### PR TITLE
chore(crm): demo CEL disabled on the Reassign Lead action

### DIFF
--- a/.changeset/crm-reassign-disabled-demo.md
+++ b/.changeset/crm-reassign-disabled-demo.md
@@ -1,0 +1,6 @@
+---
+---
+
+chore(example): CRM "Reassign Lead" action gains a CEL `disabled` predicate
+(`status == "converted"`) — greys the row-menu item on converted leads,
+demonstrating `disabled` (greys) vs `visible` (hides). Example-only.

--- a/examples/app-crm/src/actions/park-lead.action.ts
+++ b/examples/app-crm/src/actions/park-lead.action.ts
@@ -21,8 +21,14 @@ export const ParkLeadAction: UI.Action = {
   // `dataSource.update` path (the row id comes from the list_item row record).
   type: 'api',
   target: 'crm_lead',
-  // List-row only: the apiHandler needs the row record to capture prior values.
+  // List-row only: the apiHandler needs the row record (to capture prior values
+  // for Undo), and the list runtime drives param collection + the Undo toast.
   locations: ['list_item'],
+  // Conditional disable (CEL): a converted lead is locked — the row-menu item
+  // shows but greys out, rather than disappearing. Demonstrates `disabled`
+  // (greys) vs `visible` (hides). Row-menu predicates resolve against the row's
+  // fields directly (bare `status`, not `record.status`).
+  disabled: 'status == "converted"',
   params: [
     { field: 'assigned_to', label: 'Reassign to', defaultValue: 'Triage Queue', required: true },
   ],


### PR DESCRIPTION
## What

Example-only: the CRM **Reassign Lead** list action gains a CEL `disabled` predicate (`status == "converted"`), so the row-menu item **greys out** on converted leads — demonstrating `disabled` (greys) vs `visible` (hides).

Pairs with the objectui PR that makes the action renderers evaluate a CEL `disabled` (previously boolean-only). No spec change (`disabled` already accepts a CEL predicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
