### PR TITLE
feat(crm): working Web-to-Lead public form example

### DIFF
--- a/examples/app-crm/objectstack.config.ts
+++ b/examples/app-crm/objectstack.config.ts
@@ -23,6 +23,7 @@ import {
   SalesManagerRole,
   FinanceApproverRole,
   SalesUserPermissionSet,
+  GuestPortalProfile,
   HighValueOpportunitySharingRule,
   RepLeadSharingRule,
   WonDealActivitySharingRule,
@@ -116,7 +117,7 @@ export default defineStack({
 
   // Security
   roles: [SalesRepRole, SalesManagerRole, FinanceApproverRole],
-  permissions: [SalesUserPermissionSet],
+  permissions: [SalesUserPermissionSet, GuestPortalProfile],
   sharingRules: [
     HighValueOpportunitySharingRule,
     RepLeadSharingRule,

--- a/examples/app-crm/src/objects/lead.object.ts
+++ b/examples/app-crm/src/objects/lead.object.ts
@@ -36,6 +36,10 @@ export const Lead = ObjectSchema.create({
     status: Field.select({
       label: 'Status',
       required: true,
+      // Write-path default so minimal creates (e.g. the public Web-to-Lead form,
+      // which doesn't expose status) satisfy `required` — the option `default`
+      // below is only a UI preselect.
+      defaultValue: 'new',
       options: [
         { label: 'New',            value: 'new',            default: true, color: '#94A3B8' },
         { label: 'Contacted',      value: 'contacted',                     color: '#3B82F6' },

--- a/examples/app-crm/src/portals/customer.portal.ts
+++ b/examples/app-crm/src/portals/customer.portal.ts
@@ -51,18 +51,11 @@ export const CustomerPortal: Portal = {
       target: '_blank',
     },
   ],
-  anonymousEntry: {
-    routes: [
-      {
-        path: '/contact',
-        actionRef: 'crm_lead.create',
-        rateLimit: { rule: '5/hour/ip', scope: 'ip' },
-        captcha: true,
-        bindIdentityFromField: 'email',
-      },
-    ],
-    defaultRateLimit: { rule: '100/day/ip', scope: 'ip' },
-  },
+  // NOTE: `anonymousEntry` is a spec property with no runtime consumer yet — the
+  // routes here would never mount (verified: 404). For a WORKING public capture
+  // form, see the `web_to_lead` form view in `views/lead.view.ts`
+  // (`sharing.allowAnonymous` → live `/api/v1/forms/contact-us` endpoint). Re-add
+  // `anonymousEntry` here only once the runtime mounts it.
   defaultRoute: {
     viewRef: 'crm_activity.activity_grid',
   },

--- a/examples/app-crm/src/security/index.ts
+++ b/examples/app-crm/src/security/index.ts
@@ -5,6 +5,7 @@ export {
   SalesManagerRole,
   FinanceApproverRole,
   SalesUserPermissionSet,
+  GuestPortalProfile,
 } from './sales-roles.js';
 
 export {

--- a/examples/app-crm/src/security/sales-roles.ts
+++ b/examples/app-crm/src/security/sales-roles.ts
@@ -43,3 +43,21 @@ export const SalesUserPermissionSet: Security.PermissionSet = {
     crm_activity:    { allowRead: true, allowCreate: true,  allowEdit: true,  allowDelete: false },
   },
 };
+
+/**
+ * Guest profile for the public Web-to-Lead form (lead.view.ts `web_to_lead`).
+ *
+ * Applied to anonymous (unauthenticated) visitors who POST the public form. The
+ * anonymous permission path checks the FULL object name, so this MUST key
+ * `crm_lead` (not a short `lead`). INSERT-only — guests can never read, edit, or
+ * delete any record.
+ */
+export const GuestPortalProfile: Security.PermissionSet = {
+  name: 'guest_portal',
+  label: 'Guest (Public Forms)',
+  description: 'Anonymous Web-to-Lead submitters — INSERT-only on crm_lead.',
+  isProfile: true,
+  objects: {
+    crm_lead: { allowRead: false, allowCreate: true, allowEdit: false, allowDelete: false },
+  },
+};

--- a/examples/app-crm/src/views/lead.view.ts
+++ b/examples/app-crm/src/views/lead.view.ts
@@ -45,6 +45,38 @@ export const LeadViews = defineView({
     },
   },
   formViews: {
+    /**
+     * PUBLIC / ANONYMOUS — Web-to-Lead.
+     *
+     * Hosted at GET/POST `/api/v1/forms/contact-us` (+ `/submit`). An
+     * unauthenticated visitor — or an `EmbeddableForm` iframe on a marketing
+     * site — submits it to create a `crm_lead`. `sharing.allowAnonymous` opens
+     * the public endpoint; the `guest_portal` profile (INSERT-only on crm_lead)
+     * authorizes the write. The lead object's own defaults/hooks stamp internal
+     * fields (status, owner, score).
+     */
+    web_to_lead: {
+      type: 'simple',
+      data: { provider: 'object', object: 'crm_lead' },
+      sections: [
+        {
+          label: 'Contact us',
+          columns: 1,
+          fields: [
+            { field: 'name', required: true },
+            { field: 'company' },
+            { field: 'email', required: true },
+            { field: 'phone' },
+            { field: 'title' },
+          ],
+        },
+      ],
+      sharing: {
+        enabled: true,
+        allowAnonymous: true,
+        publicLink: '/forms/contact-us',
+      },
+    },
     default: {
       type: 'simple',
       sections: [


### PR DESCRIPTION
## What

Add a **working** Web-to-Lead public-form example to `app-crm`.

The example previously demonstrated Web-to-Lead only via `customer.portal` `anonymousEntry` — a spec property with **no runtime consumer** (404, verified). So the canonical CRM example shipped a non-functional public form. This adds the mechanism that actually works and makes the example coherent.

- **lead.view.ts** — `web_to_lead` form view with `sharing.allowAnonymous` → live `GET/POST /api/v1/forms/contact-us` (+ `/submit`).
- **sales-roles.ts** — `GuestPortalProfile` (isProfile, INSERT-only on `crm_lead`, keyed by the **full** object name — the anonymous permission path requires it).
- **lead.object.ts** — `status` gets `defaultValue: 'new'` so a minimal public create satisfies `required` (option-level `default` is only a UI preselect).
- **customer.portal.ts** — drop the dead `anonymousEntry` routes; point to the working form view (re-add when the runtime mounts `anonymousEntry`).
- security barrel + config: export + register the guest profile.

## Why it matters

Builds against the workspace, so it's also a **CI regression test** for the public-form path — the [#1989](https://github.com/objectstack-ai/framework/pull/1989) flattened-metadata resolution bug would have been caught here.

## Verified end-to-end (app-crm, no auth)

- `GET /api/v1/forms/contact-us` → **200** (form spec)
- `POST /api/v1/forms/contact-us/submit` → creates a `crm_lead` (`status=new`)
- `GET /api/v1/data/crm_lead` → **401** (guests can't read — INSERT-only enforced)

validate ✓, app-crm tests 29/29. (Pre-existing example typecheck drift in unrelated files — `UI`/`Cube`/`ApiEndpoint` spec exports — is untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
