### PR TITLE
chore(crm): surface Reassign Lead on the record header

### DIFF
--- a/.changeset/crm-reassign-record-header.md
+++ b/.changeset/crm-reassign-record-header.md
@@ -1,0 +1,8 @@
+---
+---
+
+chore(example): CRM "Reassign Lead" action now also surfaces on the record
+header (`locations: ['list_item', 'record_header']`) and uses the
+`record.status == "converted"` predicate convention so its CEL `disabled` greys
+out consistently on both surfaces. Param collection, `dataSource.update`, and
+the Undo toast now all drive from the header too. Example-only.

--- a/examples/app-crm/src/actions/park-lead.action.ts
+++ b/examples/app-crm/src/actions/park-lead.action.ts
@@ -21,14 +21,13 @@ export const ParkLeadAction: UI.Action = {
   // `dataSource.update` path (the row id comes from the list_item row record).
   type: 'api',
   target: 'crm_lead',
-  // List-row only: the apiHandler needs the row record (to capture prior values
-  // for Undo), and the list runtime drives param collection + the Undo toast.
-  locations: ['list_item'],
-  // Conditional disable (CEL): a converted lead is locked — the row-menu item
-  // shows but greys out, rather than disappearing. Demonstrates `disabled`
-  // (greys) vs `visible` (hides). Row-menu predicates resolve against the row's
-  // fields directly (bare `status`, not `record.status`).
-  disabled: 'status == "converted"',
+  // From the list row AND the record header — both runtimes drive param
+  // collection, the dataSource.update, and the Undo toast.
+  locations: ['list_item', 'record_header'],
+  // Conditional disable (CEL): a converted lead is locked — the action shows but
+  // greys out, rather than disappearing. Demonstrates `disabled` (greys) vs
+  // `visible` (hides). Evaluated against the record on every surface.
+  disabled: 'record.status == "converted"',
   params: [
     { field: 'assigned_to', label: 'Reassign to', defaultValue: 'Triage Queue', required: true },
   ],


### PR DESCRIPTION
## What

Extends the CRM "Reassign Lead" demo action so it appears on the **record
header** in addition to the list row:

- `locations: ['list_item', 'record_header']`
- adopts the `record.status == "converted"` predicate convention so the CEL
  `disabled` greys out consistently on both surfaces (the row menu now exposes
  both `record.*` and bare-field scopes).

Param collection, `dataSource.update`, and the Undo toast now all drive from the
header too.

## Why

Pairs with [objectui#1788](https://github.com/objectstack-ai/objectui/pull/1788),
which fixes `evaluateCondition` so a bare-CEL `disabled` actually evaluates
(instead of being silently always-truthy). Before that fix, a param-collecting
`api` action on the record header was treated as permanently disabled and never
opened its param dialog.

## Verification

Browser E2E on the lead record page: header **Reassign Lead** → param dialog →
custom **"Lead reassigned."** toast → **Undo** → **"Change undone."**

Example-only; no shipped-package changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)