### PR TITLE
chore(todo): fix owner lookup ref + completed-task seed validation

### DIFF
--- a/.changeset/todo-seed-fixes.md
+++ b/.changeset/todo-seed-fixes.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(todo): fix two app-todo defects found driving it end-to-end — (1) `todo_task.owner` was a lookup to `user`, which isn't a registered object, so seed/owner resolution hit "no such table: user" (the platform user object is `sys_user`); (2) the two `completed` seed tasks omitted `completed_date`, violating the object's own `completed_date_required` validation, so they silently failed to seed (6 of 8 rows loaded). Repointed the lookup to `sys_user`, dropped the unresolvable `owner: 'admin'` seed value, and gave completed seeds a `completed_date`. Now all 8 rows seed; validation still rejects a completed task with no date. Example-app only.

--- a/examples/app-todo/src/data/index.ts
+++ b/examples/app-todo/src/data/index.ts
@@ -7,15 +7,20 @@ import { Task } from '../objects/task.object';
 const tasks = defineSeed(Task, {
   mode: 'upsert',
   externalId: 'subject',
+  // NOTE: `owner` is a lookup to `sys_user`; there's no stable seed key for the
+  // bootstrap admin (created by auth), so it's left unset rather than pointing
+  // at a non-existent 'admin'. Completed tasks MUST carry `completed_date` — the
+  // object's `completed_date_required` validation rejects the row otherwise
+  // (this is why the two completed seeds previously failed to load).
   records: [
-    { subject: 'Learn ObjectStack',           status: 'completed',   priority: 'high',   category: 'work',     owner: 'admin' },
-    { subject: 'Build a cool app',            status: 'in_progress', priority: 'normal', category: 'work',     owner: 'admin', due_date: cel`daysFromNow(3)` },
-    { subject: 'Review PR #102',              status: 'completed',   priority: 'high',   category: 'work',     owner: 'admin' },
-    { subject: 'Write Documentation',         status: 'not_started', priority: 'normal', category: 'work',     owner: 'admin', due_date: cel`daysFromNow(1)` },
-    { subject: 'Fix Server bug',              status: 'waiting',     priority: 'urgent', category: 'work',     owner: 'admin' },
-    { subject: 'Buy groceries',               status: 'not_started', priority: 'low',    category: 'shopping', owner: 'admin', due_date: cel`today()` },
-    { subject: 'Schedule dentist appointment',status: 'not_started', priority: 'normal', category: 'health',   owner: 'admin', due_date: cel`daysFromNow(7)` },
-    { subject: 'Pay utility bills',           status: 'not_started', priority: 'high',   category: 'finance',  owner: 'admin', due_date: cel`daysFromNow(2)` },
+    { subject: 'Learn ObjectStack',           status: 'completed',   priority: 'high',   category: 'work',     completed_date: cel`daysAgo(2)` },
+    { subject: 'Build a cool app',            status: 'in_progress', priority: 'normal', category: 'work',     due_date: cel`daysFromNow(3)` },
+    { subject: 'Review PR #102',              status: 'completed',   priority: 'high',   category: 'work',     completed_date: cel`daysAgo(1)` },
+    { subject: 'Write Documentation',         status: 'not_started', priority: 'normal', category: 'work',     due_date: cel`daysFromNow(1)` },
+    { subject: 'Fix Server bug',              status: 'waiting',     priority: 'urgent', category: 'work' },
+    { subject: 'Buy groceries',               status: 'not_started', priority: 'low',    category: 'shopping', due_date: cel`today()` },
+    { subject: 'Schedule dentist appointment',status: 'not_started', priority: 'normal', category: 'health',   due_date: cel`daysFromNow(7)` },
+    { subject: 'Pay utility bills',           status: 'not_started', priority: 'high',   category: 'finance',  due_date: cel`daysFromNow(2)` },
   ],
 });
 

--- a/examples/app-todo/src/objects/task.object.ts
+++ b/examples/app-todo/src/objects/task.object.ts
@@ -73,8 +73,10 @@ export const Task = ObjectSchema.create({
       readonly: true,
     }),
     
-    // Assignment
-    owner: Field.lookup('user', {
+    // Assignment — the platform user object is `sys_user` (better-auth managed);
+    // `user` is not a registered object/table, so the old reference resolved to
+    // a non-existent `user` table at seed/lookup time ("no such table: user").
+    owner: Field.lookup('sys_user', {
       label: 'Assigned To',
     }),
     


### PR DESCRIPTION
Two app-todo defects found driving it end-to-end (boot + seed + CRUD over HTTP).

## 1. `owner` lookup pointed at a non-existent object

`todo_task.owner` was `Field.lookup('user', …)`. `user` is **not a registered object** — the platform user object is `sys_user` (better-auth managed). So at seed/owner-resolution time the driver queried a `user` table that doesn't exist, flooding the boot log with:
```
select `id` from `user` where `name` = 'admin' — no such table: user
```
Fix: repoint to `Field.lookup('sys_user')`, and drop the seed `owner: 'admin'` (there's no stable seed key for the auth-created bootstrap admin; leaving it unset is correct).

## 2. Completed seed tasks failed their own validation

Two seed tasks are `status: 'completed'` but had **no `completed_date`** — which the object's own `completed_date_required` validation rejects. They silently failed to insert, so only **6 of 8** rows seeded:
```
Insert failed: todo_task — Validation failed for 1 field(s): _record (rule_violation)
```
Fix: gave the completed seeds a `completed_date`.

## Verification (live boot)

- **0** `no such table: user` errors, **0** `rule_violation`s.
- `todo_task` now seeds **all 8 rows** (both completed tasks load).
- Validation still enforced: `POST` a completed task with no `completed_date` → **400**.
- Aggregation/reports group-by-status returns correct counts (200).

Example-app only; no package impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)