### PR TITLE
fix(i18n): add view form end_user_controls translations

### DIFF
--- a/.changeset/i18n-view-form-end-user-controls.md
+++ b/.changeset/i18n-view-form-end-user-controls.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/platform-objects": patch
+---
+
+fix(i18n): add view form `end_user_controls` translations for en, es-ES, ja-JP and zh-CN metadata-forms bundles.

--- a/packages/platform-objects/src/apps/translations/en.metadata-forms.generated.ts
+++ b/packages/platform-objects/src/apps/translations/en.metadata-forms.generated.ts
@@ -554,6 +554,10 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
         label: "Chart",
         description: "Chart-specific configuration."
       },
+      end_user_controls: {
+        label: "End-user controls",
+        description: "What end users can do on this view — quick filters, filter tabs, visualization switching (ADR-0047, Airtable Interface parity)."
+      },
       navigation_sharing: {
         label: "Navigation & sharing",
         description: "Where this view appears and who can see it."
@@ -636,6 +640,28 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
       },
       chart: {
         label: "Chart"
+      },
+      userFilters: {
+        label: "User Filters",
+        helpText: "Quick-filter bar: element style (dropdown / tabs / toggle) + exposed fields or tab presets"
+      },
+      tabs: {
+        label: "Tabs",
+        helpText: "In-view filter tabs — each tab applies its own filter rules"
+      },
+      appearance: {
+        label: "Appearance",
+        helpText: "allowedVisualizations: which renderers users may switch between"
+      },
+      userActions: {
+        label: "User Actions",
+        helpText: "Toolbar toggles: sort / search / filter / row height"
+      },
+      addRecord: {
+        label: "Add Record"
+      },
+      showRecordCount: {
+        label: "Show Record Count"
       },
       navigation: {
         label: "Navigation"

--- a/packages/platform-objects/src/apps/translations/es-ES.metadata-forms.generated.ts
+++ b/packages/platform-objects/src/apps/translations/es-ES.metadata-forms.generated.ts
@@ -554,6 +554,10 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
         label: "Gráfico",
         description: "Configuración específica de gráfico."
       },
+      end_user_controls: {
+        label: "Controles de usuario final",
+        description: "Lo que los usuarios finales pueden hacer en esta vista: filtros rápidos, pestañas de filtro, cambio de visualización (ADR-0047, paridad con Airtable Interface)."
+      },
       navigation_sharing: {
         label: "Navegación y uso compartido",
         description: "Dónde aparece esta vista y quién puede verla."
@@ -636,6 +640,28 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
       },
       chart: {
         label: "Gráfico"
+      },
+      userFilters: {
+        label: "Filtros de usuario",
+        helpText: "Barra de filtros rápidos: estilo de elemento (desplegable / pestañas / interruptor) + campos expuestos o preajustes de pestañas"
+      },
+      tabs: {
+        label: "Pestañas",
+        helpText: "Pestañas de filtro en la vista: cada pestaña aplica sus propias reglas de filtro"
+      },
+      appearance: {
+        label: "Apariencia",
+        helpText: "allowedVisualizations: qué renderizadores pueden alternar los usuarios"
+      },
+      userActions: {
+        label: "Acciones de usuario",
+        helpText: "Conmutadores de la barra de herramientas: ordenar / buscar / filtrar / altura de fila"
+      },
+      addRecord: {
+        label: "Agregar registro"
+      },
+      showRecordCount: {
+        label: "Mostrar recuento de registros"
       },
       navigation: {
         label: "Navegación"

--- a/packages/platform-objects/src/apps/translations/ja-JP.metadata-forms.generated.ts
+++ b/packages/platform-objects/src/apps/translations/ja-JP.metadata-forms.generated.ts
@@ -554,6 +554,10 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
         label: "チャート",
         description: "チャート専用設定。"
       },
+      end_user_controls: {
+        label: "エンドユーザー操作",
+        description: "このビューでエンドユーザーが行える操作——クイックフィルター、フィルタータブ、可視化切り替え（ADR-0047、Airtable Interface 互換）。"
+      },
       navigation_sharing: {
         label: "ナビゲーションと共有",
         description: "このビューの表示場所と閲覧可能者。"
@@ -636,6 +640,28 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
       },
       chart: {
         label: "チャート"
+      },
+      userFilters: {
+        label: "ユーザーフィルター",
+        helpText: "クイックフィルターバー：要素スタイル（ドロップダウン / タブ / トグル）+ 公開フィールドまたはタブプリセット"
+      },
+      tabs: {
+        label: "タブ",
+        helpText: "ビュー内フィルタータブ——各タブが独自のフィルタールールを適用"
+      },
+      appearance: {
+        label: "外観",
+        helpText: "allowedVisualizations：ユーザーが切り替え可能なレンダラー"
+      },
+      userActions: {
+        label: "ユーザーアクション",
+        helpText: "ツールバーの切り替え：並べ替え / 検索 / フィルター / 行の高さ"
+      },
+      addRecord: {
+        label: "レコードを追加"
+      },
+      showRecordCount: {
+        label: "レコード数を表示"
       },
       navigation: {
         label: "ナビゲーション"

--- a/packages/platform-objects/src/apps/translations/zh-CN.metadata-forms.generated.ts
+++ b/packages/platform-objects/src/apps/translations/zh-CN.metadata-forms.generated.ts
@@ -554,6 +554,10 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
         label: "图表配置",
         description: "图表专属配置"
       },
+      end_user_controls: {
+        label: "终端用户控制",
+        description: "终端用户在此视图上可执行的操作——快速筛选、筛选标签页、可视化切换（ADR-0047，对标 Airtable Interface）。"
+      },
       navigation_sharing: {
         label: "导航与共享",
         description: "视图出现在哪里以及谁可以查看"
@@ -636,6 +640,28 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
       },
       chart: {
         label: "图表"
+      },
+      userFilters: {
+        label: "用户筛选器",
+        helpText: "快速筛选栏：控件样式（下拉 / 标签页 / 开关）+ 暴露的字段或标签页预设"
+      },
+      tabs: {
+        label: "标签页",
+        helpText: "视图内筛选标签页——每个标签页应用各自的筛选规则"
+      },
+      appearance: {
+        label: "外观",
+        helpText: "allowedVisualizations：允许用户切换的渲染器"
+      },
+      userActions: {
+        label: "用户操作",
+        helpText: "工具栏开关：排序 / 搜索 / 筛选 / 行高"
+      },
+      addRecord: {
+        label: "添加记录"
+      },
+      showRecordCount: {
+        label: "显示记录数"
       },
       navigation: {
         label: "导航"


### PR DESCRIPTION
## Problem

In the view editor (\`编辑视图\`), the **End-user controls** section (ADR-0047, Airtable Interface parity) and its six fields rendered in English even under non-English locales (zh-CN / ja-JP / es-ES).

Root cause: the generated metadata-forms translation bundles were stale relative to [\`packages/spec/src/ui/view.form.ts\`](packages/spec/src/ui/view.form.ts). The \`end_user_controls\` section and its fields (\`userFilters\`, \`tabs\`, \`appearance\`, \`userActions\`, \`addRecord\`, \`showRecordCount\`) had no entries under \`metadataForms.view\`, so the server-side localization (\`rest-server.ts\` → \`translateMetadataDocument\`) had nothing to apply and the form fell back to the raw English spec strings.

## Fix

Add the missing \`end_user_controls\` section (label + description) and its six fields (label + helpText) to all four generated locale bundles:

- \`en.metadata-forms.generated.ts\`
- \`zh-CN.metadata-forms.generated.ts\`
- \`ja-JP.metadata-forms.generated.ts\`
- \`es-ES.metadata-forms.generated.ts\`

The \`view\` form's section/field key set now matches the spec exactly (verified by diffing section/field names in \`view.form.ts\` against the generated keys). These generated files are hand-editable per \`metadata-translations/index.ts\`.

## Verification

- \`pnpm --filter @objectstack/platform-objects build\` — success
- \`pnpm --filter @objectstack/platform-objects test\` — 55 passed
- view-form section/field keys in the en bundle now match \`view.form.ts\` 1:1