### PR TITLE
fix(service-settings): remove legacy buildAuditSink that wrote to sys_audit_log with wrong columns

### DIFF
--- a/packages/services/service-settings/src/settings-service-plugin.ts
+++ b/packages/services/service-settings/src/settings-service-plugin.ts
@@ -5,7 +5,7 @@ import type { IHttpServer, IDataEngine } from '@objectstack/spec/contracts';
 import type { SettingsManifest } from '@objectstack/spec/system';
 import { SettingsService } from './settings-service.js';
 import type { ICryptoProvider } from '@objectstack/spec/contracts';
-import type { SettingsAuditSink, SettingsAuditWriter, SettingsEngine, SettingsSecretStore } from './settings-service.types.js';
+import type { SettingsAuditWriter, SettingsEngine, SettingsSecretStore } from './settings-service.types.js';
 import type { CryptoAdapter } from './crypto-adapter.js';
 import { LocalCryptoProvider } from './local-crypto-provider.js';
 import { registerSettingsRoutes } from './settings-routes.js';
@@ -174,7 +174,7 @@ export class SettingsServicePlugin implements Plugin {
         // its narrow, bundled signature.
         this.service!.bindEngine(
           wrapEngineAsSettingsEngine(engine),
-          this.buildAuditSink(ctx, engine),
+          undefined,
           {
             secretStore: this.buildSecretStore(engine),
             auditWriter: this.buildAuditWriter(ctx, engine),
@@ -203,33 +203,6 @@ export class SettingsServicePlugin implements Plugin {
         'SettingsServicePlugin: REST routes registered at ' + (this.opts.basePath ?? '/api/settings'),
       );
     });
-  }
-
-  /** Glue an `engine.insert('sys_audit_log', …)` audit sink. */
-  private buildAuditSink(ctx: PluginContext, engine: IDataEngine): SettingsAuditSink {
-    return {
-      record: async (entry) => {
-        try {
-          await (engine as any).insert?.('sys_audit_log', {
-            actor_id: entry.userId ?? null,
-            entity_type: 'sys_setting',
-            entity_id: `${entry.namespace}.${entry.key}`,
-            action: entry.action,
-            payload: {
-              namespace: entry.namespace,
-              key: entry.key,
-              scope: entry.scope,
-              encrypted: entry.encrypted,
-              digest: entry.valueDigest,
-            },
-            request_id: entry.requestId ?? null,
-            occurred_at: new Date().toISOString(),
-          });
-        } catch (err: any) {
-          ctx.logger?.warn?.('SettingsServicePlugin: audit record failed: ' + (err?.message ?? err));
-        }
-      },
-    };
   }
 
   /**


### PR DESCRIPTION
## Summary

- `buildAuditSink` in `SettingsServicePlugin` was inserting into `sys_audit_log` with columns that don't exist on that table (`actor_id`, `entity_type`, `entity_id`, `payload`, `occurred_at`). This caused a `SqliteError` on every settings write, caught silently and emitted as a `WARN SettingsServicePlugin: audit record failed` log.
- The Phase 3 `buildAuditWriter` (already wired in the same `bindEngine` call) correctly writes to `sys_setting_audit` with the proper schema.
- Fix: remove `buildAuditSink` entirely and pass `undefined` for the legacy audit sink slot.

## Root cause

The `sys_audit_log` object schema defines `user_id` (not `actor_id`) and has no `entity_type`, `entity_id`, `payload`, or `occurred_at` columns. `buildAuditSink` was written before `sys_setting_audit` existed and was never updated when Phase 3 introduced the dedicated table.

## Test plan

- [ ] Boot `examples/app-crm` and write a setting via the Setup UI — confirm no `WARN SettingsServicePlugin: audit record failed` in the console
- [ ] Confirm `sys_setting_audit` rows are written correctly after a settings save

🤖 Generated with [Claude Code](https://claude.com/claude-code)