### PR TITLE
chore(examples): rename @example/app-todo to @objectstack/example-todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ pnpm docs:dev
 | `pnpm dev` | Run the showcase kitchen-sink example (`@objectstack/example-showcase`) — REST + Studio; exercises every metadata type, view, automation, AI & security chain |
 | `pnpm dev:showcase` | Same as `pnpm dev` (explicit alias) |
 | `pnpm dev:crm` | Run the minimal CRM example (`@objectstack/example-crm`) |
-| `pnpm dev:todo` | Run the Todo example (`@example/app-todo`) |
+| `pnpm dev:todo` | Run the Todo example (`@objectstack/example-todo`) |
 | `pnpm objectui:refresh` | Pull the sibling `../objectui` build into `packages/console/` |
 | `pnpm test` | Run all tests (Turborepo) |
 | `pnpm setup` | Install dependencies and build the spec package |
@@ -242,7 +242,7 @@ Cloud, package registry, and environment management subcommands (`os publish`, `
 
 | Example | Description | Level |
 | :--- | :--- | :--- |
-| [`@example/app-todo`](examples/app-todo) | Task management app — objects, views, dashboards, flows | Beginner |
+| [`@objectstack/example-todo`](examples/app-todo) | Task management app — objects, views, dashboards, flows | Beginner |
 | [`@objectstack/example-crm`](examples/app-crm) | Minimal CRM smoke-test workspace — validates the metadata loading pipeline | Intermediate |
 | [HotCRM](https://github.com/objectstack-ai/hotcrm) | Full-featured enterprise CRM reference app (separate repo) | Advanced |
 

--- a/examples/app-todo/README.md
+++ b/examples/app-todo/README.md
@@ -101,7 +101,7 @@ pnpm typecheck
 
 ### Build
 ```bash
-pnpm --filter @example/app-todo build
+pnpm --filter @objectstack/example-todo build
 # Expected: Build succeeds, generates dist/ output
 ```
 
@@ -113,7 +113,7 @@ Open `objectstack.config.ts` to see how all pieces connect via `defineStack()`.
 This example also showcases the v1 AI capabilities. Run the end-to-end demo:
 
 ```bash
-pnpm --filter @example/app-todo test:ai
+pnpm --filter @objectstack/example-todo test:ai
 ```
 
 What it does — **no API key required**:
@@ -133,7 +133,7 @@ What it does — **no API key required**:
 A higher-level demo that exercises the **`data_chat` built-in agent** end-to-end:
 
 ```bash
-pnpm --filter @example/app-todo test:agent
+pnpm --filter @objectstack/example-todo test:agent
 ```
 
 1. Sends a natural-language user message to `AIService.chatWithTools()` (the same path the REST endpoint `POST /api/v1/ai/agents/data_chat/chat` uses)

--- a/examples/app-todo/package.json
+++ b/examples/app-todo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@example/app-todo",
+  "name": "@objectstack/example-todo",
   "version": "4.0.52",
   "description": "Example Todo App using ObjectStack Protocol",
   "license": "Apache-2.0",

--- a/examples/app-todo/test/ai-action.test.ts
+++ b/examples/app-todo/test/ai-action.test.ts
@@ -6,7 +6,7 @@
 // `action_<name>` tool, and that the `data_chat` agent can pick the right
 // one in plain English.
 //
-// Run via: `pnpm --filter @example/app-todo test:action`
+// Run via: `pnpm --filter @objectstack/example-todo test:action`
 //
 // No API key required — uses `MemoryLLMAdapter`, which heuristically
 // picks an action tool and resolves the record id from the preceding

--- a/examples/app-todo/test/ai-agent.test.ts
+++ b/examples/app-todo/test/ai-agent.test.ts
@@ -5,7 +5,7 @@
 //   1. the agent invoked the `query_data` tool, and
 //   2. a `chat_with_tools` row landed in `ai_traces`.
 //
-// Run via: `pnpm --filter @example/app-todo test:agent`
+// Run via: `pnpm --filter @objectstack/example-todo test:agent`
 //
 // No API key required — uses `MemoryLLMAdapter`, which knows how to
 // dispatch `query_data` heuristically and summarise the result.

--- a/examples/app-todo/test/ai-hitl-llm.test.ts
+++ b/examples/app-todo/test/ai-hitl-llm.test.ts
@@ -19,7 +19,7 @@
 // the script exits 0 with a notice, so it can be chained in CI without
 // leaking spend.
 //
-// Run via: `AI_GATEWAY_API_KEY=... pnpm --filter @example/app-todo test:hitl:llm`
+// Run via: `AI_GATEWAY_API_KEY=... pnpm --filter @objectstack/example-todo test:hitl:llm`
 
 import { ObjectKernel, DriverPlugin, AppPlugin } from '@objectstack/runtime';
 import { SqliteWasmDriver } from '@objectstack/driver-sqlite-wasm';

--- a/examples/app-todo/test/ai-hitl.test.ts
+++ b/examples/app-todo/test/ai-hitl.test.ts
@@ -20,7 +20,7 @@
 // memory adapter's verb routing. (A parallel real-LLM smoke test lives
 // under `examples/app-todo/test/ai-real-llm.test.ts`.)
 //
-// Run via: `pnpm --filter @example/app-todo test:hitl`
+// Run via: `pnpm --filter @objectstack/example-todo test:hitl`
 
 import { ObjectKernel, DriverPlugin, AppPlugin } from '@objectstack/runtime';
 import { SqliteWasmDriver } from '@objectstack/driver-sqlite-wasm';

--- a/examples/app-todo/test/ai-knowledge-llm.test.ts
+++ b/examples/app-todo/test/ai-knowledge-llm.test.ts
@@ -15,7 +15,7 @@
 // deterministic RLS demo still runs; only the LLM steps are skipped.
 //
 // Run via:
-//   AI_GATEWAY_API_KEY=... pnpm --filter @example/app-todo test:knowledge:llm
+//   AI_GATEWAY_API_KEY=... pnpm --filter @objectstack/example-todo test:knowledge:llm
 
 import { ObjectKernel, DriverPlugin, AppPlugin } from '@objectstack/runtime';
 import { SqliteWasmDriver } from '@objectstack/driver-sqlite-wasm';

--- a/examples/app-todo/test/ai-llm.test.ts
+++ b/examples/app-todo/test/ai-llm.test.ts
@@ -7,7 +7,7 @@
 // a key the script exits 0 with a notice so it can be safely chained in
 // CI without leaking spend.
 //
-// Run via: `AI_GATEWAY_API_KEY=... pnpm --filter @example/app-todo test:llm`
+// Run via: `AI_GATEWAY_API_KEY=... pnpm --filter @objectstack/example-todo test:llm`
 
 import { ObjectKernel, DriverPlugin, AppPlugin } from '@objectstack/runtime';
 import { SqliteWasmDriver } from '@objectstack/driver-sqlite-wasm';

--- a/examples/app-todo/test/ai.test.ts
+++ b/examples/app-todo/test/ai.test.ts
@@ -4,7 +4,7 @@
 // runs the `query_data` tool end-to-end against seeded data, and verifies the
 // call was persisted in the `ai_traces` object.
 //
-// Run via: `pnpm --filter @example/app-todo test:ai`
+// Run via: `pnpm --filter @objectstack/example-todo test:ai`
 //
 // No API key required — the demo uses MemoryLLMAdapter, whose heuristic
 // `generateObject()` builds a QueryPlan from the schema-context snippet.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "pnpm --filter @objectstack/example-showcase dev",
     "dev:showcase": "pnpm --filter @objectstack/example-showcase dev",
     "dev:crm": "pnpm --filter @objectstack/example-crm dev",
-    "dev:todo": "pnpm --filter @example/app-todo dev",
+    "dev:todo": "pnpm --filter @objectstack/example-todo dev",
     "spec:rebuild": "turbo run build --filter=...@objectstack/spec",
     "test": "turbo run test",
     "test:e2e": "turbo run test:e2e",


### PR DESCRIPTION
## What

Rename the Todo example package `@example/app-todo` → `@objectstack/example-todo` for scope consistency with the other two example apps (`@objectstack/example-crm`, `@objectstack/example-showcase`).

This is the follow-up flagged in #2023: the inconsistent scope meant a `--filter @objectstack/example-*` glob **silently skipped** app-todo. (CI itself is safe — #2023 deliberately uses the path filter `./examples/*`, which catches all three regardless of name. This just removes the foot-gun for anyone using the scope glob.)

## Changes

- `examples/app-todo/package.json` — package name.
- Root `package.json` — `dev:todo` filter.
- Current docs — root `README.md` (2×) and `examples/app-todo/README.md` (3×).
- `// Run via:` comments in `examples/app-todo/test/*.test.ts` (7 files).
- **CHANGELOGs left untouched** — historical record of what the commands were at the time.

## Notes

- **No lockfile churn** — pnpm keys importers by path, not name.
- **No changeset** — the package is `private` (never published), so there's no version/changelog to bump. Labeled `skip-changeset` accordingly.

## Verification

```
pnpm --filter @objectstack/example-todo typecheck   # new name resolves
pnpm --filter '@objectstack/example-*' typecheck     # now catches all 3:
  examples/app-todo      typecheck: Done
  examples/app-crm       typecheck: Done
  examples/app-showcase  typecheck: Done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
