### PR TITLE
fix(spec): declare extended Gantt config fields the renderer reads

### DIFF
--- a/.changeset/gantt-config-extended-fields.md
+++ b/.changeset/gantt-config-extended-fields.md
@@ -1,0 +1,17 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): declare the extended Gantt config fields the renderer actually reads
+
+`GanttConfigSchema` only declared the 5 core timeline fields as a plain
+`z.object` (no passthrough), so every other field the Gantt renderer consumes —
+`parentField`/`typeField` (two-level summary→step hierarchy), `colorField`,
+`groupByField`, `tooltipFields`, `baselineStartField`/`baselineEndField`,
+`resourceView`/`assigneeField`/`effortField`/`capacity`, `quickFilters`,
+`autoZoomToFilter` — was silently stripped by `.parse()` on both the compile-time
+protocol check and the runtime `GET /api/v1/meta/view/:object` re-validation. With
+the keys gone before render, the Gantt degraded to a flat list (no parent/child
+rows, no summary bars, no expand/collapse). These fields are now declared
+explicitly (with descriptions), so the renderer contract round-trips through the
+spec instead of requiring downstream patches.

--- a/packages/spec/src/ui/view.test.ts
+++ b/packages/spec/src/ui/view.test.ts
@@ -210,6 +210,33 @@ describe('GanttConfigSchema', () => {
 
     expect(() => GanttConfigSchema.parse(config)).not.toThrow();
   });
+
+  it('should accept extended renderer fields (hierarchy, baseline, grouping, resource, tooltip, quick filters)', () => {
+    const config = {
+      startDateField: 'start_date',
+      endDateField: 'end_date',
+      titleField: 'name',
+      colorField: 'status',
+      parentField: 'parent_id',
+      typeField: 'row_type',
+      baselineStartField: 'planned_start',
+      baselineEndField: 'planned_end',
+      groupByField: 'workshop',
+      resourceView: true,
+      assigneeField: 'owner',
+      effortField: 'effort',
+      capacity: 8,
+      tooltipFields: ['owner', { field: 'effort', label: '工时' }],
+      quickFilters: [
+        { field: 'status' },
+        { field: 'category', label: '类别', options: ['A', { value: 1, label: 'B' }] },
+      ],
+      autoZoomToFilter: false,
+    };
+
+    expect(() => GanttConfigSchema.parse(config)).not.toThrow();
+    expect(GanttConfigSchema.parse(config)).toMatchObject({ parentField: 'parent_id', typeField: 'row_type' });
+  });
 });
 
 describe('ListViewSchema', () => {

--- a/packages/spec/src/ui/view.zod.ts
+++ b/packages/spec/src/ui/view.zod.ts
@@ -379,7 +379,26 @@ export const CalendarConfigSchema = lazySchema(() => z.object({
 }));
 
 /**
+ * Quick filter dimension for the Gantt toolbar.
+ */
+export const GanttQuickFilterSchema = lazySchema(() => z.object({
+  field: z.string().describe('Record field / dot-path the dimension filters on'),
+  label: z.string().optional().describe('Trigger label (falls back to the field label)'),
+  options: z.array(z.union([
+    z.string(),
+    z.object({
+      value: z.union([z.string(), z.number()]),
+      label: z.string().optional(),
+    }),
+  ])).optional().describe('Explicit option override for fixed enums'),
+}));
+
+/**
  * Gantt Settings
+ *
+ * Beyond the core timeline fields, the renderer supports a two-level
+ * parent/child hierarchy (parentField/typeField), planned-vs-actual baselines,
+ * dynamic grouping, a resource/workload view, hover tooltips and quick filters.
  */
 export const GanttConfigSchema = lazySchema(() => z.object({
   startDateField: z.string(),
@@ -387,6 +406,27 @@ export const GanttConfigSchema = lazySchema(() => z.object({
   titleField: z.string(),
   progressField: z.string().optional(),
   dependenciesField: z.string().optional(),
+  colorField: z.string().optional().describe('Field that drives the bar color'),
+  // Two-level hierarchy: a parent task id (summary bar) and a row type.
+  parentField: z.string().optional().describe('Field holding the parent task id (builds the summary → step tree)'),
+  typeField: z.string().optional().describe('Field whose value maps to task/summary/milestone'),
+  // Planned-vs-actual reference bars.
+  baselineStartField: z.string().optional().describe('Baseline (planned) start field'),
+  baselineEndField: z.string().optional().describe('Baseline (planned) end field'),
+  // Dynamic grouping: bucket leaf tasks under one synthesized summary per value.
+  groupByField: z.string().optional().describe('Field to group leaf tasks by (synthesized summary rows)'),
+  // Resource / workload view.
+  resourceView: z.boolean().optional().describe('Render a per-resource workload histogram instead of the timeline'),
+  assigneeField: z.string().optional().describe('Resource field to bucket load by (resource view)'),
+  effortField: z.string().optional().describe('Per-task load units (resource view; default 1)'),
+  capacity: z.number().optional().describe('Per-resource capacity ceiling; loads above this flag overload'),
+  // Hover tooltip + quick filters.
+  tooltipFields: z.array(z.union([
+    z.string(),
+    z.object({ field: z.string(), label: z.string().optional() }),
+  ])).optional().describe('Fields to surface in the hover tooltip, in display order'),
+  quickFilters: z.array(GanttQuickFilterSchema).optional().describe('Multi-select filter dropdowns rendered above the chart'),
+  autoZoomToFilter: z.boolean().optional().describe('When true (default), filtering zooms the range to the filtered tasks'),
 }));
 
 /**


### PR DESCRIPTION
## Problem

`GanttConfigSchema` (`packages/spec/src/ui/view.zod.ts`) declared only the 5 core timeline fields as a plain `z.object` with **no `.passthrough()`**:

```ts
z.object({ startDateField, endDateField, titleField, progressField, dependenciesField })
```

The Gantt renderer (`@object-ui/plugin-gantt`), however, reads many more fields — `parentField`/`typeField` (the two-level summary→step hierarchy), `colorField`, `groupByField`, `tooltipFields`, `baselineStartField`/`baselineEndField`, `resourceView`/`assigneeField`/`effortField`/`capacity`, `quickFilters`, `autoZoomToFilter`.

Because zod strips undeclared keys on `.parse()`, those fields were dropped on **both** seams this schema guards:

1. `objectstack compile` protocol validation before writing the dist artifact, and
2. the runtime metadata service re-validating the view on `GET /api/v1/meta/view/:object`.

Net effect: the API data and view config were correct, but the renderer received `parentField`/`typeField === undefined` and the Gantt degraded to a flat list (no parent/child rows, no summary bars, no expand/collapse). Downstream apps had to patch the bundled spec copy to work around it.

## Fix

Declare the fields the renderer actually consumes, explicitly and with `.describe()` annotations (matching the surrounding `*ConfigSchema` idiom — none of them use `passthrough`). Also adds a small `GanttQuickFilterSchema` for the `quickFilters` entries. Core-field validation is unchanged.

## Test

`packages/spec/src/ui/view.test.ts` — added a case asserting a full extended config (hierarchy, baseline, grouping, resource view, tooltip fields, quick filters) parses and round-trips `parentField`/`typeField`. Full spec suite: **179 passed**.

A changeset is included (`@objectstack/spec` patch).