### PR TITLE
fix(deps): override undici >=7.28.0 to close GHSA-vmh5-mc38-953g

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   minimatch@<10.2.3: 10.2.3
   tar@>=2.0.0 <7.5.11: ^7.5.11
   form-data@<4.0.6: '>=4.0.6'
+  undici@>=7.23.0 <7.28.0: ^7.28.0
 
 importers:
 
@@ -8321,8 +8322,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.27.2:
-    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
@@ -11640,7 +11641,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.27.2
+      undici: 7.28.0
       whatwg-mimetype: 4.0.0
 
   chokidar@4.0.3:
@@ -15392,7 +15393,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.27.2: {}
+  undici@7.28.0: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,8 +24,13 @@ onlyBuiltDependencies:
 #   - form-data: GHSA-hmw2-7cc7-3qxx (high) — CRLF injection via unescaped
 #     multipart field names. Pulled 4.0.5 transitively through @vscode/vsce;
 #     force the patched >=4.0.6 line. Fails `pnpm audit --audit-level=high` (CI).
+#   - undici: GHSA-vmh5-mc38-953g (high) — TLS cert validation bypass via
+#     dropped requestTls in SOCKS5 ProxyAgent. Pulled 7.27.2 through
+#     @vscode/vsce > cheerio (declares undici ^7.19.0); force the patched
+#     7.28.0 line (stays in the 7.x major cheerio supports). CI audit gate.
 overrides:
   esbuild: '>=0.28.1'
   'minimatch@<10.2.3': '10.2.3'
   'tar@>=2.0.0 <7.5.11': '^7.5.11'
   'form-data@<4.0.6': '>=4.0.6'
+  'undici@>=7.23.0 <7.28.0': '^7.28.0'


### PR DESCRIPTION
## What

Close HIGH-severity advisory **GHSA-vmh5-mc38-953g** (undici TLS certificate validation bypass via dropped `requestTls` in the SOCKS5 `ProxyAgent`) that is failing the **Validate Package Dependencies** CI gate (`pnpm audit --audit-level=high`).

The vulnerable `undici@7.27.2` is pulled in transitively through the VS Code extension's publish tooling only:

```
packages/vscode-objectstack > @vscode/vsce > cheerio > undici
```

This is repo-wide and pre-existing (it red-flags the dependency-validation gate for everyone, not just one PR).

## How

Add a single transitive pin to **`pnpm-workspace.yaml`** `overrides` — the repo's canonical location (pnpm v10 silently ignores `pnpm.overrides` in `package.json`, as documented in that file alongside the existing `esbuild` / `form-data` / `tar` / `minimatch` pins):

```yaml
'undici@>=7.23.0 <7.28.0': '^7.28.0'
```

- Advisory range is `>=7.23.0 <7.28.0`, patched `>=7.28.0`.
- `cheerio@1.2.0` declares `undici: ^7.19.0`, so the override targets **only the vulnerable range** and forces `^7.28.0`, which resolves to **7.28.0** — the patched line within the **7.x major cheerio supports**. A bare `>=7.28.0` would resolve to undici **8.5.0**, an out-of-range major bump for cheerio; this stays minimal and in-range.

`package.json` is intentionally untouched. Change is just the override + lockfile.

## Verification

- `pnpm audit --audit-level=high` → **0 high** (exit `0`), gate passes. (Before: `1 high` = undici.)
- All pre-existing security pins preserved in the lockfile (`esbuild`, `minimatch`, `tar`, `form-data`).
- `turbo run build --filter=objectstack-vscode` → succeeds.
- Lockfile diff: only `undici 7.27.2 → 7.28.0` + the override line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
