### PR TITLE
feat(app-showcase): demonstrate the two list-view navigation modes (ADR-0053)

### DIFF
--- a/examples/app-showcase/objectstack.config.ts
+++ b/examples/app-showcase/objectstack.config.ts
@@ -18,7 +18,7 @@ import { ChartGalleryDashboard } from './src/dashboards/index.js';
 import { ShowcaseTaskDataset, ShowcaseProjectDataset } from './src/datasets/index.js';
 import { allReports } from './src/reports/index.js';
 import { allActions } from './src/actions/index.js';
-import { ComponentGalleryPage, ProjectWorkspacePage, ProjectDetailPage, TaskWorkbenchPage } from './src/pages/index.js';
+import { ComponentGalleryPage, ProjectWorkspacePage, ProjectDetailPage, TaskWorkbenchPage, TaskTriagePage } from './src/pages/index.js';
 import { allFlows } from './src/flows/index.js';
 import { allWebhooks } from './src/webhooks/index.js';
 import { allHooks } from './src/hooks/index.js';
@@ -143,7 +143,7 @@ export default defineStack({
   apps: [ShowcaseApp],
   portals: allPortals,
   views: [TaskViews, ProjectViews],
-  pages: [ComponentGalleryPage, ProjectWorkspacePage, ProjectDetailPage, TaskWorkbenchPage],
+  pages: [ComponentGalleryPage, ProjectWorkspacePage, ProjectDetailPage, TaskWorkbenchPage, TaskTriagePage],
   dashboards: [ChartGalleryDashboard],
   books: allBooks,
   datasets: [ShowcaseTaskDataset, ShowcaseProjectDataset],

--- a/examples/app-showcase/src/apps/index.ts
+++ b/examples/app-showcase/src/apps/index.ts
@@ -53,6 +53,7 @@ export const ShowcaseApp = App.create({
         { id: 'nav_project_workspace', type: 'page', pageName: 'showcase_project_workspace', label: 'New Project + Tasks', icon: 'folder-plus' },
         // ADR-0047 interface mode: same object as nav_tasks, curated surface.
         { id: 'nav_task_workbench', type: 'page', pageName: 'showcase_task_workbench', label: 'Task Workbench', icon: 'sliders-horizontal' },
+        { id: 'nav_task_triage', type: 'page', pageName: 'showcase_task_triage', label: 'Task Triage (Tabs)', icon: 'layout-list' },
       ],
     },
   ],

--- a/examples/app-showcase/src/pages/index.ts
+++ b/examples/app-showcase/src/pages/index.ts
@@ -5,6 +5,7 @@ import type { Page } from '@objectstack/spec/ui';
 export { ProjectWorkspacePage } from './project-workspace.page.js';
 export { ProjectDetailPage } from './project-detail.page.js';
 export { TaskWorkbenchPage } from './task-workbench.page.js';
+export { TaskTriagePage } from './task-triage.page.js';
 
 /**
  * Component Gallery — a custom page that places a spread of standard page

--- a/examples/app-showcase/src/pages/task-triage.page.ts
+++ b/examples/app-showcase/src/pages/task-triage.page.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { Page } from '@objectstack/spec/ui';
+
+/**
+ * Task Triage — interface page demonstrating the **tabs** user-filter element
+ * (Airtable "User filters" → Elements: Tabs). Counterpart to Task Workbench,
+ * which demonstrates **dropdowns**: same source view, but end users switch a
+ * single preset tab instead of combining per-field dropdowns.
+ *
+ * Tabs and dropdowns are the two mutually-exclusive Elements of one
+ * `userFilters` config (ADR-0053). A tab is a pure filter preset
+ * (`{ name, label, filter }`) — it never switches the view form; that is the
+ * separate "Visualizations" axis (locked to grid here).
+ */
+export const TaskTriagePage: Page = {
+  name: 'showcase_task_triage',
+  label: 'Task Triage',
+  type: 'list',
+  object: 'showcase_task',
+  kind: 'full',
+  template: 'default',
+  isDefault: false,
+  regions: [],
+  interfaceConfig: {
+    source: 'showcase_task',
+    // Inherit columns/filter/sort from the object's default view (ADR-0047).
+    sourceView: 'default',
+
+    // End-user filter element: a row of preset tabs. `showAllRecords` adds the
+    // leading unfiltered "All" tab automatically.
+    userFilters: {
+      element: 'tabs',
+      showAllRecords: true,
+      tabs: [
+        { name: 'in_progress', label: 'In Progress', filter: [{ field: 'status', operator: 'equals', value: 'in_progress' }] },
+        { name: 'urgent', label: 'Urgent', icon: 'flame', filter: [{ field: 'priority', operator: 'equals', value: 'urgent' }] },
+        { name: 'in_review', label: 'In Review', filter: [{ field: 'status', operator: 'equals', value: 'in_review' }] },
+        { name: 'done', label: 'Done', filter: [{ field: 'status', operator: 'equals', value: 'done' }] },
+      ],
+    },
+
+    // Locked visualization (single-entry whitelist renders no form switcher).
+    appearance: {
+      showDescription: true,
+      allowedVisualizations: ['grid'],
+    },
+
+    userActions: {
+      sort: true,
+      search: true,
+      filter: false,
+      rowHeight: false,
+      addRecordForm: false,
+    },
+
+    showRecordCount: true,
+  },
+};

--- a/examples/app-showcase/src/views/task.view.ts
+++ b/examples/app-showcase/src/views/task.view.ts
@@ -26,18 +26,11 @@ export const TaskViews = defineView({
       { field: 'progress' },
     ],
 
-    // ADR-0047 — in-view filter tabs (ViewTab presets). Each tab applies
-    // its own filter rules on top of the view's base criteria; the first
-    // tab is the unfiltered default. Filter tabs and dropdown filters are
-    // MUTUALLY EXCLUSIVE on the toolbar (Airtable's Elements choice):
-    // this view demonstrates tabs; the `tabular` view below demonstrates
-    // dropdowns. Configuring both renders tabs only.
-    tabs: [
-      { name: 'all_tasks', label: 'All', isDefault: true },
-      { name: 'in_progress', label: 'In Progress', filter: [{ field: 'status', operator: 'equals', value: 'in_progress' }] },
-      { name: 'urgent', label: 'Urgent', icon: 'flame', filter: [{ field: 'priority', operator: 'equals', value: 'urgent' }] },
-      { name: 'done', label: 'Done', filter: [{ field: 'status', operator: 'equals', value: 'done' }] },
-    ],
+    // ADR-0053 — on the object's DEFAULT list (views mode) status presets are
+    // *named views* in the switcher (Salesforce/Airtable "saved views"), not an
+    // in-view tab row. See the `in_progress` / `urgent` / `done` listViews below.
+    // The end-user filter ELEMENTS (Airtable "User filters": tabs / dropdowns)
+    // belong to interface pages (filters mode) — see the *.page.ts examples.
 
     // ADR-0047 — runtime visualization whitelist (Airtable "Appearance →
     // Visualizations"). Rendered as a compact dropdown in the toolbar's
@@ -49,6 +42,30 @@ export const TaskViews = defineView({
   },
 
   listViews: {
+    // ── Status presets (ADR-0053) — saved views with a base ListView.filter,
+    // shown as switcher entries on the object's default list (views mode). ──
+    in_progress: {
+      label: 'In Progress',
+      type: 'grid',
+      data,
+      columns: [{ field: 'title' }, { field: 'project' }, { field: 'assignee' }, { field: 'status' }, { field: 'priority' }, { field: 'due_date' }],
+      filter: [{ field: 'status', operator: 'equals', value: 'in_progress' }],
+    },
+    urgent: {
+      label: 'Urgent',
+      type: 'grid',
+      data,
+      columns: [{ field: 'title' }, { field: 'project' }, { field: 'assignee' }, { field: 'status' }, { field: 'priority' }, { field: 'due_date' }],
+      filter: [{ field: 'priority', operator: 'equals', value: 'urgent' }],
+    },
+    done: {
+      label: 'Done',
+      type: 'grid',
+      data,
+      columns: [{ field: 'title' }, { field: 'project' }, { field: 'assignee' }, { field: 'status' }, { field: 'due_date' }],
+      filter: [{ field: 'status', operator: 'equals', value: 'done' }],
+    },
+
     // 0 ── Tabular ───────────────────────────────────────────────────────
     // ADR-0021 Phase 2: replaces the former `showcase_task_list` report
     // (a flat record list — a ListView concern, not analytics).


### PR DESCRIPTION
## Summary

Brings the showcase in line with the post-refactor list-view navigation model (ADR-0053), giving each of the two **orthogonal** list-nav modes a clean, AI-authorable example and removing the now-deprecated in-view `tabs` mechanism.

| Mode | Surface | Mechanism | Example |
|------|---------|-----------|---------|
| **Views** (Salesforce-style saved views) | object default list → view switcher | `listViews.*` with a base `ListView.filter` | `task.view.ts`: All Tasks / In Progress / Urgent / Done |
| **Filters** (Airtable "User filters") | interface page | `userFilters.element: 'dropdown' \| 'tabs'` | Task Workbench (dropdown) ↔ **Task Triage (tabs, new)** |

### Changes
- **`src/views/task.view.ts`** — status presets moved from a default-view `list.tabs` row to **named views** (`listViews.in_progress / urgent / done`) each carrying a base `filter`. The object list now surfaces them in its view switcher with no redundant second tab row.
- **`src/pages/task-triage.page.ts`** (new) — interface page demonstrating `userFilters.element: 'tabs'`: a row of pure filter presets (`{ name, label, filter }`) over a **locked grid** visualization. Direct counterpart to Task Workbench's `dropdown` element.
- Registered the new page in `src/pages/index.ts`, the explicit `pages: [...]` array in `objectstack.config.ts`, and as a `Task Triage (Tabs)` nav entry in `src/apps/index.ts`.

### Verification
Browser-verified against the live showcase backend:
- **Task Triage tabs** filter correctly: All `10` → In Progress `2` (all status=in_progress) → Done `2` → All `10`; selected tab persists to the URL (`?uf__tab=...`).
- **Object task list** view switcher shows the named views; In Progress filters `10 → 2`.
- Neither surface renders a redundant second tab/filter row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)