### PR TITLE
feat(app-showcase): task default list switches across every record visualization

### DIFF
--- a/examples/app-showcase/src/views/task.view.ts
+++ b/examples/app-showcase/src/views/task.view.ts
@@ -35,10 +35,26 @@ export const TaskViews = defineView({
     // ADR-0047 — runtime visualization whitelist (Airtable "Appearance →
     // Visualizations"). Rendered as a compact dropdown in the toolbar's
     // right cluster; types whose bindings don't resolve are hidden by the
-    // client regardless.
+    // client regardless. This default list is the showcase's "switch every
+    // view" case: the SAME records re-shaped into each record-based
+    // visualization (chart is excluded — it aggregates a dataset, not records,
+    // and lives as its own named view + dashboard element).
     appearance: {
-      allowedVisualizations: ['grid', 'kanban', 'gallery', 'calendar'],
+      // The six record-based visualizations the spec + runtime switcher support
+      // out of the box: the SAME task records re-shaped on demand. (map needs a
+      // spec MapConfigSchema the ListViewSchema doesn't yet have, and chart
+      // aggregates a dataset rather than records — both live as their own named
+      // views below instead of in this switcher.)
+      allowedVisualizations: ['grid', 'kanban', 'gallery', 'calendar', 'timeline', 'gantt'],
     },
+
+    // Per-visualization bindings so each type in the switcher resolves and
+    // renders the same task records. Field names map to task.object.ts.
+    kanban: { groupByField: 'status', summarizeField: 'estimate_hours', columns: ['title', 'assignee', 'priority'] },
+    gallery: { coverField: 'cover', titleField: 'title', visibleFields: ['assignee', 'status', 'priority'] },
+    calendar: { startDateField: 'due_date', titleField: 'title', colorField: 'status' },
+    timeline: { startDateField: 'created_at', titleField: 'title', colorField: 'priority', scale: 'week' },
+    gantt: { startDateField: 'start_date', endDateField: 'end_date', titleField: 'title', progressField: 'progress' },
   },
 
   listViews: {


### PR DESCRIPTION
## Summary

Makes the showcase task object's default **All Tasks** list the "switch every view" case — Airtable *Visualizations* parity: the **same** task records re-shaped on demand via the toolbar visualization switcher.

Adds the per-visualization binding blocks to the default list and widens `appearance.allowedVisualizations`:

| Visualization | Binding | Verified |
|---|---|---|
| Grid | — | ✅ |
| Kanban | `groupByField: status`, summarize hours | ✅ board columns |
| Gallery | `coverField: cover`, title + fields | ✅ card grid |
| Calendar | `startDateField: due_date` | ✅ month view, tasks on due dates |
| Timeline | `startDateField: created_at` | ✅ time buckets |
| Gantt | `start_date → end_date`, progress | ✅ bars + start/end columns |

Seed data already carries `status / due_date / created_at / start_date / end_date / progress / location`, so each of the six renders with real content.

## Scope note — why not map / chart in this switcher

Comprehensive testing surfaced a real boundary, captured here honestly rather than faked:

- **map** — the spec `ListViewSchema` has **no `MapConfigSchema`** (no `locationField`), and the runtime switcher only offers map when `options.map.locationField` resolves (no field-type inference). So map can't be offered in an object-list switcher today; it stays as its own `listViews.map` named view (which infers the `location` field). Making it switchable needs a spec + runtime addition — proposed as a follow-up.
- **chart** — aggregates a *dataset*, not records, so it's a named view + dashboard element by design, not a record-list visualization.

## Verification

Browser-tested against the live showcase backend (fresh DB): switching the default list to Kanban / Gallery / Calendar / Timeline / Gantt each renders the 10 task records correctly; the switcher offers exactly those six (no phantom map/chart). Screenshots in the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)