### PR TITLE
feat(spec): interface-editor polish — composite disclosure popover + buttons=object-actions

### DIFF
--- a/examples/app-showcase/src/pages/task-workbench.page.ts
+++ b/examples/app-showcase/src/pages/task-workbench.page.ts
@@ -61,6 +61,10 @@ export const TaskWorkbenchPage: Page = {
       addRecordForm: false,
     },
 
+    // Toolbar buttons ARE object actions (ADR-0047) — referenced by name from
+    // the showcase_task object's ActionSchema, not free text.
+    buttons: ['showcase_bulk_reassign', 'showcase_mark_done'],
+
     showRecordCount: true,
   },
 };

--- a/packages/spec/src/ui/page.form.ts
+++ b/packages/spec/src/ui/page.form.ts
@@ -105,6 +105,8 @@ export const pageForm = defineForm({
             // ── User actions ──
             { field: 'userActions', type: 'composite', disclosure: 'popover', helpText: 'Toolbar toggles (search, sort, filter, row height)' },
             { field: 'addRecord', type: 'composite', disclosure: 'popover', helpText: 'Add-record entry point' },
+            // Buttons ARE object actions — pick from the source object's actions.
+            { field: 'buttons', widget: 'action-multi', dependsOn: 'source', helpText: "Toolbar buttons — pick from this object's actions" },
             { field: 'showRecordCount', helpText: 'Show the record count bar' },
             { field: 'allowPrinting', helpText: 'Allow users to print this page' },
           ],

--- a/packages/spec/src/ui/page.form.ts
+++ b/packages/spec/src/ui/page.form.ts
@@ -95,7 +95,7 @@ export const pageForm = defineForm({
             { field: 'filterBy', type: 'repeater', helpText: 'Always-on base filter for the page' },
             { field: 'levels', helpText: 'Hierarchy levels to display (tree-like sources)' },
             // ── Appearance ──
-            { field: 'appearance', type: 'composite', helpText: 'Allowed visualizations (Grid / Kanban / Calendar / …) and description visibility' },
+            { field: 'appearance', type: 'composite', disclosure: 'popover', helpText: 'Allowed visualizations (Grid / Kanban / Calendar / …) and description visibility' },
             // ── User filters ──
             {
               field: 'userFilters',
@@ -103,8 +103,8 @@ export const pageForm = defineForm({
               helpText: 'End-user filter bar: None (no bar) / Tabs (named presets) / Dropdown (per-field). None removes the config.',
             },
             // ── User actions ──
-            { field: 'userActions', type: 'composite', helpText: 'Toolbar toggles (search, sort, filter, row height)' },
-            { field: 'addRecord', type: 'composite', helpText: 'Add-record entry point' },
+            { field: 'userActions', type: 'composite', disclosure: 'popover', helpText: 'Toolbar toggles (search, sort, filter, row height)' },
+            { field: 'addRecord', type: 'composite', disclosure: 'popover', helpText: 'Add-record entry point' },
             { field: 'showRecordCount', helpText: 'Show the record count bar' },
             { field: 'allowPrinting', helpText: 'Allow users to print this page' },
           ],

--- a/packages/spec/src/ui/page.zod.ts
+++ b/packages/spec/src/ui/page.zod.ts
@@ -257,6 +257,10 @@ export const InterfacePageConfigSchema = lazySchema(() => z.object({
   /** Add record */
   addRecord: AddRecordConfigSchema.optional().describe('Add record entry point configuration'),
 
+  /** Toolbar buttons — references to the source object's actions (ActionSchema).
+   * Buttons ARE object actions (not free text): correct-by-construction. */
+  buttons: z.array(z.string()).optional().describe("Toolbar buttons — names of the source object's actions to surface in the page toolbar"),
+
   /** Record count */
   showRecordCount: z.boolean().optional().describe('Show record count at page bottom'),
 

--- a/packages/spec/src/ui/view.zod.ts
+++ b/packages/spec/src/ui/view.zod.ts
@@ -715,6 +715,7 @@ export const FormFieldSchema: z.ZodType<any> = lazySchema(() => z.object({
 
   dependsOn: z.string().optional().describe('Parent field name for cascading'),
   visibleOn: ExpressionInputSchema.optional().describe('Visibility predicate (CEL).'),
+  disclosure: z.enum(['inline', 'popover']).optional().describe('Composite rendering: inline bordered box (default) or a summary line + gear popover (progressive disclosure).'),
 }));
 
 /**


### PR DESCRIPTION
## Summary

Spec side of the interface-page editor polish (pairs with the objectui runtime PR).

### Progressive-disclosure popover
- `FormFieldSchema` gains `disclosure?: 'inline' | 'popover'`. A composite marked `disclosure: 'popover'` renders as a summary line + gear popover instead of an inline box.
- The page form marks `appearance` / `userActions` / `addRecord` with `disclosure: 'popover'`.

### Buttons = object actions
- `InterfacePageConfigSchema` gains `buttons: z.array(z.string())` — names of the source object's actions surfaced as page toolbar buttons.
- The page form renders Buttons with the new **`action-multi`** widget (`dependsOn: source`) so the author picks from the object's real actions (correct-by-construction).
- Showcase `task-workbench` demonstrates it: `buttons: ['showcase_bulk_reassign', 'showcase_mark_done']` → **Reassign… / Mark Done** in the page header.

## Verification
Browser-tested against the live showcase (see objectui PR): the Buttons picker lists the task object's actions, the workbench header renders them, and the composite popovers collapse/expand correctly. Spec `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)