### PR TITLE
fix(app-showcase): complete field translations so list columns don't mix locales

### DIFF
--- a/examples/app-showcase/src/translations/index.ts
+++ b/examples/app-showcase/src/translations/index.ts
@@ -1,6 +1,13 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
-/** English + Simplified Chinese labels for the core showcase objects. */
+/**
+ * English + Simplified Chinese labels for the core showcase objects.
+ *
+ * Covers EVERY field surfaced as a column on the showcase pages so a list never
+ * mixes locales (the prior bundle translated only a handful, leaving columns
+ * like Project / Assignee / Progress falling back to their English field label
+ * next to translated 状态 / 优先级 — an obvious inconsistency on a zh-CN session).
+ */
 export const ShowcaseTranslationBundle = {
   en: {
     objects: {
@@ -10,8 +17,13 @@ export const ShowcaseTranslationBundle = {
         fields: {
           name: { label: 'Project Name' },
           account: { label: 'Account' },
+          owner: { label: 'Owner' },
           status: { label: 'Status' },
+          health: { label: 'Health' },
           budget: { label: 'Budget' },
+          spent: { label: 'Spent' },
+          start_date: { label: 'Start Date' },
+          end_date: { label: 'End Date' },
         },
       },
       showcase_task: {
@@ -19,9 +31,18 @@ export const ShowcaseTranslationBundle = {
         pluralLabel: 'Tasks',
         fields: {
           title: { label: 'Title' },
+          project: { label: 'Project' },
+          assignee: { label: 'Assignee' },
           status: { label: 'Status' },
           priority: { label: 'Priority' },
           due_date: { label: 'Due Date' },
+          progress: { label: 'Progress' },
+          estimate_hours: { label: 'Estimate (h)' },
+          start_date: { label: 'Start Date' },
+          end_date: { label: 'End Date' },
+          created_at: { label: 'Created' },
+          location: { label: 'Work Location' },
+          cover: { label: 'Cover' },
         },
       },
     },
@@ -34,8 +55,13 @@ export const ShowcaseTranslationBundle = {
         fields: {
           name: { label: '项目名称' },
           account: { label: '客户' },
+          owner: { label: '负责人' },
           status: { label: '状态' },
+          health: { label: '健康度' },
           budget: { label: '预算' },
+          spent: { label: '已花费' },
+          start_date: { label: '开始日期' },
+          end_date: { label: '结束日期' },
         },
       },
       showcase_task: {
@@ -43,9 +69,18 @@ export const ShowcaseTranslationBundle = {
         pluralLabel: '任务',
         fields: {
           title: { label: '标题' },
+          project: { label: '项目' },
+          assignee: { label: '负责人' },
           status: { label: '状态' },
           priority: { label: '优先级' },
           due_date: { label: '截止日期' },
+          progress: { label: '进度' },
+          estimate_hours: { label: '预计工时' },
+          start_date: { label: '开始日期' },
+          end_date: { label: '结束日期' },
+          created_at: { label: '创建时间' },
+          location: { label: '工作地点' },
+          cover: { label: '封面' },
         },
       },
     },


### PR DESCRIPTION
## Summary

The showcase translation bundle only translated a handful of fields, so list columns like **Project / Assignee / Progress / Estimate** fell back to their English field label and sat next to the translated **状态 / 优先级 / 截止日期** on a zh-CN session — a visible locale-mixing inconsistency.

Extends both `en` and `zh-CN` to **every field surfaced as a column** on the showcase pages (task + project).

## Verification
Task Triage header now reads `标题 / 项目 / 负责人 / 状态 / 优先级 / 截止日期 / 进度` — fully consistent, no Latin fallback.

### Context (enterprise-UI review)
This is the one genuine visual gap from an Apple-craft-but-enterprise-calibrated review of the new pages. The objectui design system already handles the rest at the component layer — soft-pill badges (not candy-saturated) with a `appearance: 'dot'` density option, right-aligned `tabular-nums` numeric columns, and a polished data-table — so those were deliberately **not** churned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)