### PR TITLE
feat(spec): interfaceConfig.recordAction — configure how a list opens a record

### DIFF
--- a/packages/spec/src/ui/page.form.ts
+++ b/packages/spec/src/ui/page.form.ts
@@ -107,6 +107,16 @@ export const pageForm = defineForm({
             { field: 'addRecord', type: 'composite', disclosure: 'popover', helpText: 'Add-record entry point' },
             // Buttons ARE object actions — pick from the source object's actions.
             { field: 'buttons', widget: 'action-multi', dependsOn: 'source', helpText: "Toolbar buttons — pick from this object's actions" },
+            {
+              field: 'recordAction',
+              options: [
+                { label: 'Drawer (right-side peek)', value: 'drawer' },
+                { label: 'Full page', value: 'page' },
+                { label: 'Modal', value: 'modal' },
+                { label: 'Not clickable', value: 'none' },
+              ],
+              helpText: 'How clicking a record opens its detail',
+            },
             { field: 'showRecordCount', helpText: 'Show the record count bar' },
             { field: 'allowPrinting', helpText: 'Allow users to print this page' },
           ],

--- a/packages/spec/src/ui/page.zod.ts
+++ b/packages/spec/src/ui/page.zod.ts
@@ -261,6 +261,12 @@ export const InterfacePageConfigSchema = lazySchema(() => z.object({
    * Buttons ARE object actions (not free text): correct-by-construction. */
   buttons: z.array(z.string()).optional().describe("Toolbar buttons — names of the source object's actions to surface in the page toolbar"),
 
+  /** How clicking a record opens its detail: 'drawer' (right-side peek panel,
+   * default), 'page' (full-page navigate to the record route), 'modal', or
+   * 'none' (rows not clickable). */
+  recordAction: z.enum(['drawer', 'page', 'modal', 'none']).optional()
+    .describe("How clicking a record opens its detail (drawer | page | modal | none). Default: drawer"),
+
   /** Record count */
   showRecordCount: z.boolean().optional().describe('Show record count at page bottom'),
 


### PR DESCRIPTION
## Summary
Adds `recordAction: 'drawer' | 'page' | 'modal' | 'none'` to `InterfacePageConfig` plus a select in the page form (under User actions). Lets the author choose how clicking a record opens its detail — right-side **drawer** (default), full-page **navigate**, **modal**, or **not clickable**.

Pairs with objectstack-ai/objectui#1812 (the runtime wires the click accordingly; without an explicit value it defaults to drawer, restoring record-opening on interface pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)