### PR TITLE
feat(spec): interface base filterBy uses the unified filter-builder widget

### DIFF
--- a/packages/spec/src/ui/page.form.ts
+++ b/packages/spec/src/ui/page.form.ts
@@ -92,7 +92,7 @@ export const pageForm = defineForm({
             // Columns are defined ON the page (no view inheritance). `dependsOn:
             // 'source'` tells the picker which object's fields to offer.
             { field: 'columns', widget: 'field-multi', dependsOn: 'source', helpText: 'Columns to show — defined directly on the page (blank = all object fields)' },
-            { field: 'filterBy', type: 'repeater', helpText: 'Always-on base filter for the page' },
+            { field: 'filterBy', widget: 'filter-builder', dependsOn: 'source', helpText: 'Always-on base filter for the page — same visual builder as the list toolbar.' },
             { field: 'levels', helpText: 'Hierarchy levels to display (tree-like sources)' },
             // ── Appearance ──
             { field: 'appearance', type: 'composite', disclosure: 'popover', helpText: 'Allowed visualizations (Grid / Kanban / Calendar / …) and description visibility' },


### PR DESCRIPTION
## Why

The page form rendered `interfaceConfig.filterBy` (the always-on base filter) as a generic `type:'repeater'` — a different, clunkier editor than the polished FilterBuilder the list toolbar uses.

## What

Switch the base `filterBy` field to `widget:'filter-builder'` with `dependsOn:'source'`, so the Studio renders the **same popout visual builder** for the base filter as for the per-tab presets — one consistent filter UX everywhere.

The widget is implemented in objectui (SchemaForm widget registry, companion PR [objectui#1813](https://github.com/objectstack-ai/objectui/pull/1813)). Stored format is unchanged (`ViewFilterRule[]`).

## Verification

Verified in the studio (`:5181`) against `showcase_task_triage` after `pnpm --filter @objectstack/spec build` + backend restart: the base **Filter By** now shows the "+ Add filter…" popout builder, conditions apply live to the preview, and round-trip to the runtime works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)