### PR TITLE
feat(app-showcase): Settings page + preference object

### DIFF
--- a/examples/app-showcase/objectstack.config.ts
+++ b/examples/app-showcase/objectstack.config.ts
@@ -18,7 +18,7 @@ import { ChartGalleryDashboard, OpsDashboard } from './src/dashboards/index.js';
 import { ShowcaseTaskDataset, ShowcaseProjectDataset } from './src/datasets/index.js';
 import { allReports } from './src/reports/index.js';
 import { allActions } from './src/actions/index.js';
-import { ComponentGalleryPage, ProjectWorkspacePage, ProjectDetailPage, TaskWorkbenchPage, TaskTriagePage, TaskBoardPage, TaskCalendarPage, TaskGalleryPage, TaskSchedulePage, TaskTimelinePage, TaskMapPage, TaskAllViewsPage, ActiveProjectsPage, TaskDetailPage, AccountDetailPage, ReviewQueuePage, NewProjectWizardPage, MyWorkPage } from './src/pages/index.js';
+import { ComponentGalleryPage, ProjectWorkspacePage, ProjectDetailPage, TaskWorkbenchPage, TaskTriagePage, TaskBoardPage, TaskCalendarPage, TaskGalleryPage, TaskSchedulePage, TaskTimelinePage, TaskMapPage, TaskAllViewsPage, ActiveProjectsPage, TaskDetailPage, AccountDetailPage, ReviewQueuePage, NewProjectWizardPage, MyWorkPage, SettingsPage } from './src/pages/index.js';
 import { allFlows } from './src/flows/index.js';
 import { allWebhooks } from './src/webhooks/index.js';
 import { allHooks } from './src/hooks/index.js';
@@ -143,7 +143,7 @@ export default defineStack({
   apps: [ShowcaseApp],
   portals: allPortals,
   views: [TaskViews, ProjectViews],
-  pages: [ComponentGalleryPage, ProjectWorkspacePage, ProjectDetailPage, TaskWorkbenchPage, TaskTriagePage, TaskBoardPage, TaskCalendarPage, TaskGalleryPage, TaskSchedulePage, TaskTimelinePage, TaskMapPage, TaskAllViewsPage, ActiveProjectsPage, TaskDetailPage, AccountDetailPage, ReviewQueuePage, NewProjectWizardPage, MyWorkPage],
+  pages: [ComponentGalleryPage, ProjectWorkspacePage, ProjectDetailPage, TaskWorkbenchPage, TaskTriagePage, TaskBoardPage, TaskCalendarPage, TaskGalleryPage, TaskSchedulePage, TaskTimelinePage, TaskMapPage, TaskAllViewsPage, ActiveProjectsPage, TaskDetailPage, AccountDetailPage, ReviewQueuePage, NewProjectWizardPage, MyWorkPage, SettingsPage],
   dashboards: [ChartGalleryDashboard, OpsDashboard],
   books: allBooks,
   datasets: [ShowcaseTaskDataset, ShowcaseProjectDataset],

--- a/examples/app-showcase/src/apps/index.ts
+++ b/examples/app-showcase/src/apps/index.ts
@@ -53,6 +53,7 @@ export const ShowcaseApp = App.create({
         { id: 'nav_my_work', type: 'page', pageName: 'showcase_my_work', label: 'My Work', icon: 'home' },
         { id: 'nav_review_queue', type: 'page', pageName: 'showcase_review_queue', label: 'Approvals', icon: 'check-check' },
         { id: 'nav_new_project_wizard', type: 'page', pageName: 'showcase_new_project_wizard', label: 'New Project (Wizard)', icon: 'wand-2' },
+        { id: 'nav_settings', type: 'object', objectName: 'showcase_preference', label: 'Settings', icon: 'settings' },
         { id: 'nav_gallery', type: 'page', pageName: 'showcase_component_gallery', label: 'Component Gallery', icon: 'layout-template' },
         { id: 'nav_project_workspace', type: 'page', pageName: 'showcase_project_workspace', label: 'New Project + Tasks', icon: 'folder-plus' },
         // ADR-0047 interface mode: same object as nav_tasks, curated surface.

--- a/examples/app-showcase/src/data/index.ts
+++ b/examples/app-showcase/src/data/index.ts
@@ -3,6 +3,7 @@
 import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Account } from '../objects/account.object.js';
+import { Preference } from '../objects/preference.object.js';
 import { Project } from '../objects/project.object.js';
 import { Task } from '../objects/task.object.js';
 import { Category } from '../objects/category.object.js';
@@ -174,4 +175,12 @@ const invoiceLines = defineSeed(InvoiceLine, {
   ],
 });
 
-export const ShowcaseSeedData = [accounts, products, projects, tasks, categories, teams, memberships, fieldZoo, invoices, invoiceLines];
+const preferences = defineSeed(Preference, {
+  mode: 'upsert',
+  externalId: 'name',
+  records: [
+    { name: 'My Preferences', theme: 'light', default_landing: 'my_work', email_digest: 'daily', items_per_page: 50, notifications_enabled: true, compact_density: false },
+  ],
+});
+
+export const ShowcaseSeedData = [accounts, products, projects, tasks, categories, teams, memberships, fieldZoo, invoices, invoiceLines, preferences];

--- a/examples/app-showcase/src/objects/index.ts
+++ b/examples/app-showcase/src/objects/index.ts
@@ -7,3 +7,4 @@ export { Category } from './category.object.js';
 export { Team, ProjectMembership } from './team.object.js';
 export { Product, Invoice, InvoiceLine } from './invoice.object.js';
 export { FieldZoo } from './field-zoo.object.js';
+export { Preference } from './preference.object.js';

--- a/examples/app-showcase/src/objects/preference.object.ts
+++ b/examples/app-showcase/src/objects/preference.object.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { ObjectSchema, Field } from '@objectstack/spec/data';
+
+/**
+ * App Preference — backs the Settings page. A small "app config" object so the
+ * showcase has a real settings surface: a record whose detail page is
+ * inline-editable (theme, landing, notifications). One seeded singleton.
+ */
+export const Preference = ObjectSchema.create({
+  name: 'showcase_preference',
+  label: 'Setting',
+  pluralLabel: 'Settings',
+  icon: 'settings',
+  description: 'Workspace preferences edited from the Settings page.',
+  fields: {
+    name: Field.text({ label: 'Name', required: true, searchable: true }),
+    theme: Field.select({
+      label: 'Theme',
+      options: [
+        { label: 'Light', value: 'light', default: true },
+        { label: 'Dark', value: 'dark' },
+        { label: 'Match system', value: 'auto' },
+      ],
+    }),
+    default_landing: Field.select({
+      label: 'Default landing page',
+      options: [
+        { label: 'My Work', value: 'my_work', default: true },
+        { label: 'Delivery Operations', value: 'operations' },
+        { label: 'Task Board', value: 'task_board' },
+      ],
+    }),
+    email_digest: Field.select({
+      label: 'Email digest',
+      options: [
+        { label: 'Daily', value: 'daily', default: true },
+        { label: 'Weekly', value: 'weekly' },
+        { label: 'Off', value: 'off' },
+      ],
+    }),
+    items_per_page: Field.number({ label: 'Rows per page', min: 10, max: 200, defaultValue: 50 }),
+    notifications_enabled: Field.boolean({ label: 'Enable notifications', defaultValue: true }),
+    compact_density: Field.boolean({ label: 'Compact density', defaultValue: false }),
+  },
+});

--- a/examples/app-showcase/src/pages/index.ts
+++ b/examples/app-showcase/src/pages/index.ts
@@ -12,6 +12,7 @@ export { AccountDetailPage } from './account-detail.page.js';
 export { ReviewQueuePage } from './review-queue.page.js';
 export { NewProjectWizardPage } from './new-project-wizard.page.js';
 export { MyWorkPage } from './my-work.page.js';
+export { SettingsPage } from './settings.page.js';
 export {
   TaskBoardPage,
   TaskCalendarPage,

--- a/examples/app-showcase/src/pages/settings.page.ts
+++ b/examples/app-showcase/src/pages/settings.page.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { Page } from '@objectstack/spec/ui';
+
+/**
+ * Settings — every enterprise app needs one. A record page over the singleton
+ * showcase_preference record; record:details is inline-editable (click a value
+ * to change it), so this is a working preferences surface grouped into
+ * Appearance / Notifications sections.
+ */
+export const SettingsPage: Page = {
+  name: 'showcase_settings',
+  label: 'Setting',
+  type: 'record',
+  object: 'showcase_preference',
+  kind: 'full',
+  template: 'default',
+  isDefault: true,
+  regions: [
+    {
+      name: 'main',
+      width: 'full',
+      components: [
+        {
+          type: 'record:details',
+          properties: {
+            sections: [
+              { label: 'Appearance', columns: 2, fields: ['theme', 'compact_density', 'default_landing', 'items_per_page'] },
+              { label: 'Notifications', columns: 2, fields: ['notifications_enabled', 'email_digest'] },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
## Why

The last of the selected enterprise surfaces (after [#2059](https://github.com/objectstack-ai/framework/pull/2059) and [#2060](https://github.com/objectstack-ai/framework/pull/2060)). Every enterprise app needs a settings/preferences page; the showcase had none.

## What

- New `showcase_preference` object — theme / default landing / email digest / rows-per-page / notifications / density — with one seeded singleton ("My Preferences").
- `showcase_settings` record page grouping it into **Appearance / Notifications** sections. `record:details` is inline-editable, so it's a working preferences surface (click a value to change it).
- Reached via **Pages → Settings**.

## Verification

Browser-verified on `:5181`: the seeded preferences render in both sections (Theme = Light, Default landing = My Work, Rows = 50, Digest = Daily, notifications on) and are inline-editable. `typecheck` + **20** showcase tests pass.

This completes the enterprise-surfaces set: Delivery Operations dashboard, Account 360, My Work home, Approvals queue, New Project wizard, and Settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)