### PR TITLE
fix(app-showcase): surface Task Detail quick actions in the record_section bar

### DIFF
--- a/examples/app-showcase/src/actions/index.ts
+++ b/examples/app-showcase/src/actions/index.ts
@@ -17,7 +17,10 @@ export const MarkDoneAction: Action = {
   icon: 'check',
   objectName: task,
   type: 'script',
-  locations: ['list_item', 'record_header'],
+  // `record_section` so the Task Detail page's `record:quick_actions` bar
+  // (which names this action) resolves it — the engine location-filters even
+  // explicitly-named actions, mirroring the platform's own sys-user pages.
+  locations: ['list_item', 'record_header', 'record_section'],
   refreshAfter: true,
 };
 
@@ -82,7 +85,8 @@ export const LogTimeAction: Action = {
   objectName: task,
   type: 'form',
   target: 'showcase_task.default',
-  locations: ['record_header', 'record_related'],
+  // `record_section` so it surfaces in the Task Detail quick-actions bar too.
+  locations: ['record_header', 'record_related', 'record_section'],
   refreshAfter: true,
 };
 


### PR DESCRIPTION
While QA-ing the showcase workspace, the Task Detail drawer leaked a dev placeholder into the business UI:

> `record:quick_actions — no actions configured`

### Root cause
The Task Detail page's `record:quick_actions` bar is configured with `location: 'record_section'` and `actionNames: ['showcase_mark_done', 'showcase_log_time']`. The renderer resolves those named actions, then location-filters them via `getActionsForLocation('record_section')` — but neither action declared `record_section` in its `locations` (mark_done was `list_item`/`record_header`; log_time was `record_header`/`record_related`), so both were filtered out.

This is the platform's intended contract: the platform's own `sys-user.page.ts` uses the identical pattern, and every action it names in a `record_section` bar (`change_my_password`, `delete_my_account`, …) declares `record_section` in its object definition.

### Fix
Add `record_section` to the `locations` of `showcase_mark_done` and `showcase_log_time` (metadata only), matching the platform convention.

### Testing
Verified in the browser (showcase backend rebuilt from this branch): the Task Detail drawer now renders the **Mark Done** and **Log Time** buttons instead of the placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)