### PR TITLE
feat(datasource): Setup-app "Datasources" nav entry → metadata-admin engine

### DIFF
--- a/packages/services/service-datasource/src/datasource-admin-plugin.ts
+++ b/packages/services/service-datasource/src/datasource-admin-plugin.ts
@@ -223,6 +223,45 @@ export class DatasourceAdminServicePlugin implements Plugin {
     this.config = config;
     this.service = new DatasourceAdminService(config);
     ctx.registerService('datasource-admin', this.service);
+
+    // Setup-app nav (ADR-0029 D7): datasources are a *capability* this plugin
+    // owns, so it contributes its own entry into the `group_integrations` slot
+    // (core setup-nav must not fill capability-owned slots). datasource is a
+    // metadata type, so the entry opens the generic metadata-admin engine route
+    // rather than a bespoke page or an object view.
+    try {
+      const manifest = ctx.getService<{ register(m: any): void }>('manifest');
+      if (manifest && typeof manifest.register === 'function') {
+        manifest.register({
+          id: 'com.objectstack.service-datasource.nav',
+          namespace: 'sys',
+          version: this.version,
+          type: 'plugin',
+          scope: 'system',
+          name: 'Datasource Navigation',
+          description: 'Contributes the Datasources entry to the Setup app Integrations group.',
+          navigationContributions: [
+            {
+              app: 'setup',
+              group: 'group_integrations',
+              priority: 100,
+              items: [
+                {
+                  id: 'nav_datasources',
+                  type: 'url',
+                  label: 'Datasources',
+                  url: '/apps/setup/component/metadata/resource?type=datasource',
+                  icon: 'database',
+                  requiredPermissions: ['manage_platform_settings'],
+                },
+              ],
+            },
+          ],
+        });
+      }
+    } catch (err) {
+      this.options.logger?.warn?.('datasource nav contribution skipped', err);
+    }
   }
 
   async start(ctx: PluginContext): Promise<void> {


### PR DESCRIPTION
## What
Adds a **Datasources** entry to the Setup app's left menu (Integrations group). It opens the generic **metadata-admin engine** route for the `datasource` type — datasource is a metadata type, so it's administered by the same engine as every other type, not a bespoke page.

The `datasource-admin` plugin registers the navigation contribution itself (into the capability-owned `group_integrations` slot), per ADR-0029 D7 — core `setup-nav.contributions.ts` must not fill capability-plugin slots (enforced by the platform-objects nav invariant test). Entry is `type:'url'` → `/apps/setup/component/metadata/resource?type=datasource` (a datasource is a definition, not business data, so not an object view).

## Pairs with
objectui PR (datasource registered as a metadata-admin engine resource: list/create/edit/test/sync + bespoke page removed).

## Verification
- Live: Setup app left menu shows **Datasources** under Integrations → opens the engine-hosted manager.
- `platform-objects` 55/55 + `service-datasource` 63/63 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)