### PR TITLE
ci(release): pre-publish backward-compat smoke against live hotcrm (#2035)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,18 @@ jobs:
         # prepublishOnly guard in @objectstack/console passes.
         run: bash scripts/build-console.sh
 
+      - name: Downstream backward-compat smoke (live hotcrm)
+        # Pre-publish gate (#2035): the about-to-publish @objectstack/spec must
+        # not break a real third-party consumer pinned to a published release.
+        # Clones objectstack-ai/hotcrm@${HOTCRM_REF}, installs it (published
+        # deps), overlays the freshly-built spec dist, and runs hotcrm's own
+        # typecheck + `objectstack validate`. A red here blocks the publish.
+        # The deterministic in-repo floor is @objectstack/downstream-contract;
+        # this is the live ceiling.
+        env:
+          HOTCRM_REF: v1.2.0
+        run: bash scripts/downstream-smoke.sh
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1

--- a/scripts/downstream-smoke.sh
+++ b/scripts/downstream-smoke.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# downstream-smoke.sh — pre-publish backward-compatibility gate (#2035).
+#
+# The spec package IS the third-party API. In-repo consumers (examples,
+# @objectstack/dogfood, downstream-contract) co-evolve with the spec, so they
+# cannot prove the *about-to-publish* spec still works for a real, independently
+# authored consumer pinned to a PUBLISHED release.
+#
+# This clones objectstack-ai/hotcrm at a pinned tag, installs it (pulling the
+# published @objectstack/* packages), overlays the freshly-built — i.e.
+# unreleased — @objectstack/spec dist, and runs hotcrm's own typecheck +
+# `objectstack validate`. A failure means the release would break a real third
+# party: block the publish.
+#
+# Requires `pnpm run build` (or at least the spec build) to have run first.
+# Override the pinned ref with HOTCRM_REF.
+set -euo pipefail
+
+HOTCRM_REF="${HOTCRM_REF:-v1.2.0}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SPEC_DIST="$REPO_ROOT/packages/spec/dist"
+
+if [ ! -d "$SPEC_DIST" ]; then
+  echo "::error::spec dist not found at $SPEC_DIST — build it first (pnpm --filter @objectstack/spec build)."
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+echo "→ Cloning objectstack-ai/hotcrm@${HOTCRM_REF} ..."
+git clone --quiet --depth 1 --branch "$HOTCRM_REF" https://github.com/objectstack-ai/hotcrm.git "$WORK/hotcrm"
+cd "$WORK/hotcrm"
+
+echo "→ Installing hotcrm (published @objectstack/* deps) ..."
+pnpm install --frozen-lockfile 2>/dev/null || pnpm install --no-frozen-lockfile
+
+DEST="node_modules/@objectstack/spec/dist"
+if [ ! -d "$DEST" ]; then
+  echo "::error::hotcrm did not install @objectstack/spec — cannot run the gate."
+  exit 1
+fi
+
+echo "→ Overlaying the unreleased @objectstack/spec dist into hotcrm ..."
+rm -rf "$DEST"
+cp -R "$SPEC_DIST" "$DEST"
+
+echo "→ hotcrm typecheck (against unreleased spec) ..."
+pnpm run typecheck
+
+echo "→ hotcrm validate (loader parses all metadata against unreleased spec) ..."
+pnpm run validate
+
+echo "✅ Downstream smoke passed — unreleased @objectstack/spec is backward compatible with hotcrm@${HOTCRM_REF}."


### PR DESCRIPTION
Follow-up to #2035 / #2088 / #2089 / #2092 — the final layer of the third-party validation strategy. You chose to run the live-hotcrm gate in the **pre-publish / release workflow**; this implements exactly that.

## What

`scripts/downstream-smoke.sh`:
1. clones `objectstack-ai/hotcrm` at a pinned tag (`v1.2.0`),
2. installs it against the **published** `@objectstack/*` packages,
3. overlays the freshly-built — i.e. **unreleased** — `@objectstack/spec` dist,
4. runs hotcrm's own `typecheck` + `objectstack validate`.

If the about-to-publish spec breaks a real, independently-authored consumer, the release is blocked.

Wired into `release.yml` between the build and the changesets publish step — so it runs **only in the release pipeline**, never on a feature PR. It mirrors the existing console-SPA step that already clones an external repo (objectui) at a pinned ref, so the pattern is established.

## Where it sits

| Layer | Gate | Runs | PR |
|---|---|---|---|
| floor (deterministic) | `downstream-contract` fixture | every PR | #2089 |
| floor (deterministic) | api-surface snapshot | every PR | #2092 |
| **ceiling (live)** | **hotcrm smoke** | **pre-publish only** | **this** |

The fixture and snapshot are fast and run on every PR; this heavy, live check is the pre-publish backstop for anything they miss — at the cost of coupling to one external repo, which is why it's release-only and pinned to a tag (override via `HOTCRM_REF`).

## Verified end-to-end (locally, real clone)

Ran the actual script: cloned `hotcrm@v1.2.0` → `pnpm install` → overlaid the current spec build → `typecheck` (0 errors) + `objectstack validate` (✓ — 15 objects / 297 fields / 15 pages / 10 reports / 11 actions / 17 flows / 10 roles). Exit 0. (The only output warnings are hotcrm's own pre-existing dashboard-widget notices, unrelated to the spec.)

## Notes

- hotcrm is public, so no token needed; `pnpm install` falls back to `--no-frozen-lockfile` if hotcrm's lockfile drifts from current published versions.
- CI/release-infra only — no consumer-facing change, no changeset.
- Possible follow-up: retry-wrap the clone for transient network resilience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)