### PR TITLE
chore(spec): drop the dead agent memory.shortTerm config (ADR-0013 D3, cloud#339)

### DIFF
--- a/packages/services/service-ai/src/agents/data-chat-agent.ts
+++ b/packages/services/service-ai/src/agents/data-chat-agent.ts
@@ -96,12 +96,5 @@ Always answer in the same language the user is using. Detailed tool-usage guidan
     maxIterations: 10,
     allowReplan: true,
   },
-
-  memory: {
-    shortTerm: {
-      maxMessages: 20,
-      maxTokens: 4096,
-    },
-  },
 };
 

--- a/packages/spec/src/ai/agent.test.ts
+++ b/packages/spec/src/ai/agent.test.ts
@@ -589,10 +589,6 @@ Be precise, data-driven, and clear in your explanations.`,
         role: 'Persistent Assistant',
         instructions: 'Remember across sessions.',
         memory: {
-          shortTerm: {
-            maxMessages: 100,
-            maxTokens: 4096,
-          },
           longTerm: {
             enabled: true,
             store: 'vector',
@@ -602,7 +598,6 @@ Be precise, data-driven, and clear in your explanations.`,
         },
       });
 
-      expect(agent.memory?.shortTerm?.maxMessages).toBe(100);
       expect(agent.memory?.longTerm?.enabled).toBe(true);
       expect(agent.memory?.longTerm?.store).toBe('vector');
       expect(agent.memory?.reflectionInterval).toBe(5);

--- a/packages/spec/src/ai/agent.zod.ts
+++ b/packages/spec/src/ai/agent.zod.ts
@@ -173,14 +173,12 @@ export const AgentSchema = lazySchema(() => z.object({
 
   /** Memory Management */
   memory: z.object({
-    /** Short-term (working) memory configuration */
-    shortTerm: z.object({
-      /** Maximum number of recent messages to retain */
-      maxMessages: z.number().int().min(1).default(50).describe('Max recent messages in working memory'),
-
-      /** Maximum token budget for short-term context */
-      maxTokens: z.number().int().min(100).optional().describe('Max tokens for short-term context window'),
-    }).optional().describe('Short-term / working memory'),
+    // NOTE: `shortTerm` ({maxMessages,maxTokens}) was removed (ADR-0013 D3,
+    // cloud#339). It declared a working-memory window that NOTHING in the
+    // runtime consumed — a config that lies. Cross-turn grounding is done by
+    // tools reading live state, and the context budget is governed elsewhere
+    // (the per-request token guardrail), not by this field. `longTerm` /
+    // `reflectionInterval` are kept as forward-looking, off-by-default config.
 
     /** Long-term (persistent) memory configuration */
     longTerm: z.object({


### PR DESCRIPTION
## What
Removes the agent `memory.shortTerm` config (`{maxMessages, maxTokens}`) — a schema field that declared a working-memory window **nothing in the runtime ever consumed**. Per cloud **ADR-0013 D3** ("stop declaring an unwired memory strategy"): cross-turn grounding is done by tools reading live state, and the context budget is governed by the per-request token guardrail — not by this field. It was a config that lies.

## Changes
- `packages/spec/src/ai/agent.zod.ts` — remove `shortTerm` from the agent `memory` schema. **Kept** `longTerm` (off by default) and `reflectionInterval` — those are forward-looking/optional, not actively misleading.
- `packages/services/service-ai/src/agents/data-chat-agent.ts` — remove the dead `memory.shortTerm` declaration (its only set site).
- `packages/spec/src/ai/agent.test.ts` — update the memory-config test to the remaining fields.

## Safety
- **No runtime behavior change** — confirmed nothing reads `memory.shortTerm` (only `agent.model.maxTokens` is consumed). The sole set site (data-chat-agent) is removed.
- **Public API surface unchanged** — `pnpm --filter @objectstack/spec check:api-surface` ✓ (the gate tracks exported names/kinds; a zod object's internal field is not a public export name).
- Spec agent tests **45/45** pass; spec builds clean.

Relates to cloud#339 / cloud ADR-0013 D3. The `sys_audit_log` actor-attribution half (cloud#340) is a separate, larger security/audit-path change and will come in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)