### PR TITLE
ci(lint): extend the authoring-entry guard to packages/apps (#2035)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -78,14 +78,16 @@ export default [
       }],
     },
   },
-  // issue #2035 — authoring-entry guard. Flags exported consts in example
-  // metadata files that are annotated with a spec domain type (simple `Page`
-  // or qualified `UI.Page`) instead of being wrapped in the `defineX` factory.
-  // AST-only (no type info): matches the declaration shape, not local vars or
-  // function params. Scoped to examples — the reference corpus AI learns from.
+  // issue #2035 — authoring-entry guard. Flags exported consts in metadata
+  // files that are annotated with a spec domain type (simple `Page` or qualified
+  // `UI.Page`) instead of being wrapped in the `defineX` factory. AST-only (no
+  // type info): matches the declaration shape, not local vars or function params.
+  // Scoped to the authoring surfaces — the example corpus AI learns from and the
+  // platform's own apps. NOT downstream-contract: its bare literals are a frozen
+  // backward-compat fixture (#2089) and are intentional.
   {
-    files: ['examples/**/*.{ts,tsx,mts,cts}'],
-    ignores: ['**/node_modules/**', '**/dist/**'],
+    files: ['examples/**/*.{ts,tsx,mts,cts}', 'packages/apps/**/*.{ts,tsx,mts,cts}'],
+    ignores: ['**/node_modules/**', '**/dist/**', 'packages/downstream-contract/**'],
     languageOptions: {
       parser: tsParser,
       parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },


### PR DESCRIPTION
Follow-up to #2088. The author-time lint guard (ban bare `: DomainType` exported-const literals; require the `defineX` factory) was scoped to `examples/**`. This broadens it to `packages/apps/**` (the platform's own account/setup/studio apps) so the convention holds across every authoring surface, not just the example corpus AI learns from.

Explicitly **excludes** `packages/downstream-contract/**` — its bare literals are an intentional frozen backward-compat fixture (#2089).

## Notes

- No migrations: the apps author no bare-literal metadata today, so this is future-proofing (a clean scope extension, not a fix).
- Teeth verified: a probe `export const X: Page = {...}` under `packages/apps` is flagged by the guard; removed after the check.
- `pnpm lint` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)