### PR TITLE
fix(example-crm): author SalesByAccountReport via defineReport (lint #2035)

### DIFF
--- a/examples/app-crm/src/reports/sales-by-account.report.ts
+++ b/examples/app-crm/src/reports/sales-by-account.report.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
-import type * as UI from '@objectstack/spec/ui';
+import { defineReport } from '@objectstack/spec/ui';
 
 /**
  * Example report — total opportunity amount grouped by ACCOUNT.
@@ -13,7 +13,7 @@ import type * as UI from '@objectstack/spec/ui';
  * `total_amount` measure (USD), this exercises both render paths — Intl
  * currency formatting AND raw-value lookup drill — end to end.
  */
-export const SalesByAccountReport: UI.ReportInput = {
+export const SalesByAccountReport = defineReport({
   name: 'crm_sales_by_account',
   label: 'Sales by Account',
   description: 'Total opportunity amount grouped by account (lookup-dimension drill).',
@@ -21,4 +21,4 @@ export const SalesByAccountReport: UI.ReportInput = {
   dataset: 'opportunity_metrics',
   rows: ['account'],
   values: ['total_amount'],
-};
+});


### PR DESCRIPTION
## What

Follow-up to [#2107](https://github.com/objectstack-ai/framework/pull/2107). The new `SalesByAccountReport` fixture was authored as a bare `: UI.ReportInput` typed literal, which the `no-restricted-syntax` rule (#2035) disallows — metadata must go through its `defineX` factory so it validates at parse time (a broken value import fails loudly instead of degrading to `any`).

I copied the pattern from `sales-by-stage.report.ts`, but that file had **already migrated** to `defineReport` — my reference was stale. Since CI ESLint only lints **changed** files, #2107 merged with the violation; this corrects it on `main`.

## Change
`export const SalesByAccountReport: UI.ReportInput = {…}` → `export const SalesByAccountReport = defineReport({…})`. Same export, same fields — no behavior change.

## Verified
- `eslint` on the file → **clean**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)