### PR TITLE
ci(showcase): build dependency closure before the smoke

### DIFF
--- a/.github/workflows/showcase-smoke.yml
+++ b/.github/workflows/showcase-smoke.yml
@@ -16,7 +16,7 @@ jobs:
   smoke:
     name: Showcase nav-surface smoke
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -25,8 +25,11 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      # The smoke's webServer runs the CLI (`os serve --dev`); build it first.
-      - run: pnpm turbo run build --filter=@objectstack/cli
+      # The smoke's webServer runs `os serve --dev`, which loads the showcase
+      # config + its workspace runtime deps (CLI, connector-rest, …) from their
+      # built `dist/`. Build the whole dependency closure (excluding the
+      # showcase's own app build, which serve --dev doesn't need).
+      - run: pnpm turbo run build --filter=@objectstack/example-showcase^...
       - name: Install Playwright Chromium
         working-directory: examples/app-showcase
         run: pnpm exec playwright install --with-deps chromium

--- a/.github/workflows/showcase-smoke.yml
+++ b/.github/workflows/showcase-smoke.yml
@@ -16,7 +16,7 @@ jobs:
   smoke:
     name: Showcase nav-surface smoke
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -30,6 +30,12 @@ jobs:
       # built `dist/`. Build the whole dependency closure (excluding the
       # showcase's own app build, which serve --dev doesn't need).
       - run: pnpm turbo run build --filter=@objectstack/example-showcase^...
+      # The console SPA served at /_console is vendored by build-console.sh
+      # (shallow-clones objectui@.objectui-sha, builds @object-ui/console, copies
+      # dist → packages/console/dist). Without it serve --dev warns "Console dist
+      # not found" and the app shell never renders.
+      - name: Vendor the pinned Console SPA
+        run: bash scripts/build-console.sh
       - name: Install Playwright Chromium
         working-directory: examples/app-showcase
         run: pnpm exec playwright install --with-deps chromium


### PR DESCRIPTION
Fixes the showcase-smoke workflow (added in #2109): its first `workflow_dispatch` shakedown failed because `os serve --dev` couldn't load `@objectstack/connector-rest/dist/index.mjs` — only the CLI was built, not the showcase's workspace runtime deps.

Now builds the full dependency closure (`pnpm turbo run build --filter=@objectstack/example-showcase^...`, excluding the showcase's own app build which `serve --dev` doesn't need) and bumps the job timeout to 30m.

Verifying via a `workflow_dispatch` run on this branch before merge. Still non-blocking (manual + nightly only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)