### PR TITLE
ci(release): run Release job on Node 22 for the hotcrm downstream smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          # 22 (not 20 like the other workflows): the downstream hotcrm smoke
+          # below clones hotcrm@v1.2.0, whose manifest pins engines.node >=22.
+          # pnpm install aborts with ERR_PNPM_UNSUPPORTED_ENGINE on Node 20.
+          node-version: '22'
 
       - name: Enable Corepack
         run: corepack enable


### PR DESCRIPTION
## Problem

The `Release` workflow is red on `main`. The **Downstream backward-compat smoke (live hotcrm)** step fails immediately:

```
→ Installing hotcrm (published @objectstack/* deps) ...
 ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)
 Your Node version is incompatible with ".../hotcrm".
 Expected version: >=22
 Got: v20.20.2
```

hotcrm@v1.2.0's manifest pins `engines.node >=22`, but the Release job sets up Node **20**. `pnpm install` aborts before any spec backward-compat is exercised — a false red that blocks every publish.

## Fix

Bump the Release job to Node **22** (matching `showcase-smoke.yml`, which already runs on 22). The framework builds and publishes fine on 22 — root `engines.node` is `>=18`. Only `release.yml` runs `scripts/downstream-smoke.sh`, so no other workflow needs the bump. Added an inline comment so the divergence from the other workflows' Node 20 is self-documenting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)