### PR TITLE
feat(server): GET /auth/me/localization — tenant regional defaults for every user

### DIFF
--- a/.changeset/me-localization-endpoint.md
+++ b/.changeset/me-localization-endpoint.md
@@ -1,0 +1,12 @@
+---
+"@objectstack/plugin-hono-server": minor
+---
+
+Expose resolved regional defaults to every authenticated user.
+
+Adds `GET /api/v1/auth/me/localization` returning the request tenant's resolved
+`{ currency, locale, timezone }` from the ExecutionContext (ADR-0053). The
+`localization` SETTINGS are gated to `setup.access`, but the resolved defaults
+are needed by every renderer to format currency/dates/numbers — so they are
+surfaced here without that gate. Enables a client to format a currency field
+in the tenant's default currency when the field omits its own.

--- a/packages/plugins/plugin-hono-server/src/hono-plugin.ts
+++ b/packages/plugins/plugin-hono-server/src/hono-plugin.ts
@@ -718,6 +718,25 @@ export class HonoServerPlugin implements Plugin {
             }
         });
 
+        // GET /me/localization — the resolved regional defaults (currency /
+        // locale / timezone) for the current request's tenant, exposed to EVERY
+        // authenticated user. The `localization` SETTINGS are gated to
+        // `setup.access`, but the resolved defaults are needed by every renderer
+        // to format currency/dates/numbers — so they ride on the request
+        // ExecutionContext (ADR-0053) and are surfaced here without that gate.
+        rawApp.get(`${prefix}/auth/me/localization`, async (c: any) => {
+            const execCtx = await resolveCtx(c);
+            if (!execCtx?.userId) {
+                return c.json({ authenticated: false });
+            }
+            return c.json({
+                authenticated: true,
+                currency: execCtx.currency ?? null,
+                locale: execCtx.locale ?? null,
+                timezone: execCtx.timezone ?? null,
+            });
+        });
+
         // GET /me/apps — list apps the current user is allowed to enter.
         // Filters `metadata.list('app')` by:
         //   1. AppSchema.requiredPermissions ⊆ ctx.systemPermissions


### PR DESCRIPTION
## Phase 2a — expose regional defaults to the client

The `localization` settings (currency / locale / timezone) are gated to `setup.access`, and the `discovery` endpoint is static / context-free. So a regular user's client has **no way** to learn the tenant's default currency or locale to format values consistently — which is why every objectui currency renderer falls back to a hardcoded `$`/`¥`/`USD` or a bare number (see the cross-repo currency audit).

This adds **`GET /api/v1/auth/me/localization`** → `{ authenticated, currency, locale, timezone }` resolved off the request `ExecutionContext` (the values #2119 wired in), exposed to every **authenticated** user without the `setup.access` gate on the underlying settings.

## Why
It's the prerequisite for Phase 2 (objectui): a `LocalizationProvider` fetches this once and feeds a single currency/number formatter the tenant default + locale, replacing the ~20 ad-hoc per-site currency-resolution paths (2 divergent `formatCurrency`, 3 Intl locales, hardcoded symbols).

## Notes
- Thin passthrough of `resolveCtx(c)`; the ctx resolution (incl. currency) is covered by `resolve-execution-context` tests (#2119). The hono-plugin test harness has no `/me`-route integration fixture, so no bespoke route test is added.
- Additive route — no behavior change until the client consumes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)