### PR TITLE
feat(spec,showcase): allowCreate flag for inline lookup quick-create

### DIFF
--- a/examples/app-showcase/src/objects/category.object.ts
+++ b/examples/app-showcase/src/objects/category.object.ts
@@ -15,7 +15,7 @@ export const Category = ObjectSchema.create({
 
   fields: {
     name: Field.text({ label: 'Name', required: true, searchable: true, maxLength: 120 }),
-    parent: Field.lookup('showcase_category', { label: 'Parent Category' }),
+    parent: Field.lookup('showcase_category', { label: 'Parent Category', allowCreate: true }),
     color: Field.color({ label: 'Color' }),
     sort_order: Field.number({ label: 'Sort Order', min: 0, defaultValue: 0 }),
   },

--- a/packages/spec/liveness/field.json
+++ b/packages/spec/liveness/field.json
@@ -179,6 +179,10 @@
       "status": "live",
       "note": "objectui LookupField — dependent/cascading lookup; restricts candidates by another field's value (reads dependsOn || depends_on)."
     },
+    "allowCreate": {
+      "status": "live",
+      "note": "objectui LookupField — opt-in inline quick-create (dataSource.create from typed text) (reads allowCreate || allow_create)."
+    },
     "maxRating": {
       "status": "dead",
       "evidence": "RatingField reads `max` (RatingField.tsx:13) — dead + redundant with max",

--- a/packages/spec/src/data/field.test.ts
+++ b/packages/spec/src/data/field.test.ts
@@ -309,6 +309,7 @@ describe('FieldSchema', () => {
         lookupPageSize: 20,
         lookupFilters: [{ field: 'status', operator: 'eq', value: 'active' }],
         dependsOn: ['region', { field: 'country', param: 'country_code' }],
+        allowCreate: true,
       };
 
       const result = FieldSchema.parse(lookupField);
@@ -318,6 +319,7 @@ describe('FieldSchema', () => {
       expect(result.lookupPageSize).toBe(20);
       expect(result.lookupFilters?.[0]).toEqual({ field: 'status', operator: 'eq', value: 'active' });
       expect(result.dependsOn).toHaveLength(2);
+      expect(result.allowCreate).toBe(true);
     });
 
     it('builds a lookup with picker config via Field.lookup', () => {

--- a/packages/spec/src/data/field.zod.ts
+++ b/packages/spec/src/data/field.zod.ts
@@ -473,6 +473,7 @@ export const FieldSchema = lazySchema(() => z.object({
     field: z.string(),
     param: z.string().optional(),
   })])).optional().describe('Dependent lookup: restrict candidates by the value of other field(s) on the same record. String = same local/remote key; {field,param} when the remote filter key differs.'),
+  allowCreate: z.boolean().optional().describe('Allow inline quick-create from the record picker: when no match exists the user can create a record from the typed text (optimistic dataSource.create with the display field). Best for simple objects whose only required field is the display field.'),
 
   /** Calculation — CEL formula. Plain string accepted for back-compat; build emits canonical envelope. */
   expression: ExpressionInputSchema.optional().describe('Formula expression (CEL). e.g. F`record.amount * 0.1`'),


### PR DESCRIPTION
Exposes the opt-in **inline quick-create** that the objectui record picker supports (companion to objectui **#1863**). When no match exists, the user creates a record straight from the typed text via an optimistic `dataSource.create` with the display field — Airtable/Notion-style. Best for simple objects whose only required field is the display field.

## Changes
- **spec** — add `allowCreate` to `FieldSchema` (flows through `Field.lookup` via `FieldInput`); classified `live` in the liveness ledger (objectui consumer, reads `allowCreate || allow_create`).
- **showcase** — enable it on `showcase_category.parent`. Category requires only `name`, so quick-create succeeds end-to-end.
- **test** — assert `allowCreate` survives `FieldSchema.parse`.

## Verification
- `packages/spec` tests: **117 passed**.
- Liveness gate: ✓ all field props classified (field: 60, live 52).
- `app-showcase` typecheck: clean in changed files (only pre-existing connector/objectql module-resolution noise remains).
- Renderer quick-create path is unit-covered in objectui #1863.