### PR TITLE
fix(platform-objects): complete ADR-0057 BU rename — Setup menu + i18n (Departments → Business Units / 业务单元)

### DIFF
--- a/.changeset/bu-rename-i18n.md
+++ b/.changeset/bu-rename-i18n.md
@@ -1,0 +1,11 @@
+---
+"@objectstack/platform-objects": patch
+---
+
+Complete the ADR-0057 `sys_department` → `sys_business_unit` rename in the Setup app and across the object's i18n (en / zh / ja / es).
+
+- Setup nav entry "Departments" → "Business Units" (`nav_departments` → `nav_business_units`).
+- `sys_business_unit` / `sys_business_unit_member` field **labels and descriptions** in the object definitions now read "business unit" instead of "department" (the generated `en` labels had been hand-updated ahead of the def; the def was the stale source).
+- All four locales' generated object translations aligned to 业务单元 / ビジネスユニット / Unidad de negocio.
+
+Intentionally preserved: the `kind` enum value `department` (a business unit can be *of kind* department) and the multi-concept node descriptions that list kinds.

--- a/packages/platform-objects/src/apps/setup-nav.contributions.ts
+++ b/packages/platform-objects/src/apps/setup-nav.contributions.ts
@@ -47,7 +47,7 @@ export const SETUP_NAV_CONTRIBUTIONS: NavigationContribution[] = [
     priority: BASE_PRIORITY,
     items: [
       { id: 'nav_users', type: 'object', label: 'Users', objectName: 'sys_user', icon: 'user' },
-      { id: 'nav_departments', type: 'object', label: 'Departments', objectName: 'sys_business_unit', icon: 'building', requiresObject: 'sys_business_unit' },
+      { id: 'nav_business_units', type: 'object', label: 'Business Units', objectName: 'sys_business_unit', icon: 'building', requiresObject: 'sys_business_unit' },
       { id: 'nav_teams', type: 'object', label: 'Teams', objectName: 'sys_team', icon: 'users-round' },
       { id: 'nav_organizations', type: 'object', label: 'Organizations', objectName: 'sys_organization', icon: 'building-2' },
       { id: 'nav_invitations', type: 'object', label: 'Invitations', objectName: 'sys_invitation', icon: 'mail' },

--- a/packages/platform-objects/src/apps/translations/en.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/en.objects.generated.ts
@@ -611,7 +611,7 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
       },
       manager_user_id: {
         label: "Business Unit Head",
-        help: "User responsible for this org unit (department head / lead)."
+        help: "User responsible for this org unit (business unit head / lead)."
       },
       active: {
         label: "Active",
@@ -619,11 +619,11 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
       },
       effective_from: {
         label: "Effective From",
-        help: "When this department came into existence (HRIS sync)."
+        help: "When this business unit came into existence (HRIS sync)."
       },
       effective_to: {
         label: "Effective To",
-        help: "When this department was retired (HRIS sync)."
+        help: "When this business unit was retired (HRIS sync)."
       },
       external_ref: {
         label: "External Reference",
@@ -657,7 +657,7 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
   sys_business_unit_member: {
     label: "Business Unit Member",
     pluralLabel: "Business Unit Members",
-    description: "User assignment to a department (matrix-org friendly, effective-dated).",
+    description: "User assignment to a business unit (matrix-org friendly, effective-dated).",
     fields: {
       id: {
         label: "Member ID"

--- a/packages/platform-objects/src/apps/translations/en.ts
+++ b/packages/platform-objects/src/apps/translations/en.ts
@@ -63,7 +63,7 @@ export const en: TranslationData = {
 
         // People & Organization
         nav_users: { label: 'Users' },
-        nav_departments: { label: 'Departments' },
+        nav_business_units: { label: 'Business Units' },
         nav_teams: { label: 'Teams' },
         nav_organizations: { label: 'Organizations' },
         nav_invitations: { label: 'Invitations' },

--- a/packages/platform-objects/src/apps/translations/es-ES.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/es-ES.objects.generated.ts
@@ -602,7 +602,7 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
         }
       },
       parent_business_unit_id: {
-        label: "Departamento principal",
+        label: "Unidad de negocio principal",
         help: "Autorreferencia para el árbol organizativo. Null = raíz del tenant."
       },
       organization_id: {
@@ -663,7 +663,7 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
         label: "ID de miembro"
       },
       business_unit_id: {
-        label: "Departamento"
+        label: "Unidad de negocio"
       },
       user_id: {
         label: "Usuario"

--- a/packages/platform-objects/src/apps/translations/es-ES.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/es-ES.objects.generated.ts
@@ -578,8 +578,8 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
     }
   },
   sys_business_unit: {
-    label: "Departamento",
-    pluralLabel: "Departamentos",
+    label: "Unidad de negocio",
+    pluralLabel: "Unidades de negocio",
     description: "Nodo jerárquico de la estructura organizativa (departamento / división / unidad de negocio / oficina).",
     fields: {
       name: {
@@ -655,8 +655,8 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
     }
   },
   sys_business_unit_member: {
-    label: "Miembro del departamento",
-    pluralLabel: "Miembros del departamento",
+    label: "Miembro de unidad de negocio",
+    pluralLabel: "Miembros de unidad de negocio",
     description: "Asignación de usuario a un departamento (compatible con organizaciones matriciales y con vigencia temporal).",
     fields: {
       id: {

--- a/packages/platform-objects/src/apps/translations/es-ES.ts
+++ b/packages/platform-objects/src/apps/translations/es-ES.ts
@@ -45,7 +45,7 @@ export const esES: TranslationData = {
         nav_system_overview: { label: 'Resumen del Sistema' },
 
         nav_users: { label: 'Usuarios' },
-        nav_departments: { label: 'Departamentos' },
+        nav_business_units: { label: 'Unidades de negocio' },
         nav_teams: { label: 'Equipos' },
         nav_organizations: { label: 'Organizaciones' },
         nav_invitations: { label: 'Invitaciones' },

--- a/packages/platform-objects/src/apps/translations/ja-JP.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/ja-JP.objects.generated.ts
@@ -578,8 +578,8 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
     }
   },
   sys_business_unit: {
-    label: "部門",
-    pluralLabel: "部門",
+    label: "ビジネスユニット",
+    pluralLabel: "ビジネスユニット",
     description: "階層的な組織ツリーノード（部門 / 事業部 / ビジネスユニット / オフィス）。",
     fields: {
       name: {
@@ -655,8 +655,8 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
     }
   },
   sys_business_unit_member: {
-    label: "部門メンバー",
-    pluralLabel: "部門メンバー",
+    label: "ビジネスユニットメンバー",
+    pluralLabel: "ビジネスユニットメンバー",
     description: "部門へのユーザー割り当て（マトリクス組織対応、有効期限付き）。",
     fields: {
       id: {

--- a/packages/platform-objects/src/apps/translations/ja-JP.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/ja-JP.objects.generated.ts
@@ -602,7 +602,7 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
         }
       },
       parent_business_unit_id: {
-        label: "親部門",
+        label: "親ビジネスユニット",
         help: "組織ツリーの自己参照。null = テナントのルート。"
       },
       organization_id: {
@@ -610,8 +610,8 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
         help: "テナントスコープ。"
       },
       manager_user_id: {
-        label: "部門長",
-        help: "この組織単位の責任者（部門長 / リード）。"
+        label: "ビジネスユニット長",
+        help: "この組織単位の責任者（ビジネスユニット長 / リード）。"
       },
       active: {
         label: "有効",
@@ -619,18 +619,18 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
       },
       effective_from: {
         label: "有効開始日",
-        help: "この部門が設立された日時（HRIS 同期）。"
+        help: "このビジネスユニットが設立された日時（HRIS 同期）。"
       },
       effective_to: {
         label: "有効終了日",
-        help: "この部門が廃止された日時（HRIS 同期）。"
+        help: "このビジネスユニットが廃止された日時（HRIS 同期）。"
       },
       external_ref: {
         label: "外部参照",
         help: "上流 HRIS（Workday / SAP HR / 北森）の ID。"
       },
       id: {
-        label: "部門 ID"
+        label: "ビジネスユニット ID"
       },
       created_at: {
         label: "作成日時"
@@ -657,19 +657,19 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
   sys_business_unit_member: {
     label: "ビジネスユニットメンバー",
     pluralLabel: "ビジネスユニットメンバー",
-    description: "部門へのユーザー割り当て（マトリクス組織対応、有効期限付き）。",
+    description: "ビジネスユニットへのユーザー割り当て（マトリクス組織対応、有効期限付き）。",
     fields: {
       id: {
         label: "メンバー ID"
       },
       business_unit_id: {
-        label: "部門"
+        label: "ビジネスユニット"
       },
       user_id: {
         label: "ユーザー"
       },
       role_in_business_unit: {
-        label: "部門内ロール",
+        label: "ビジネスユニット内ロール",
         help: "`lead` は日常の責任者、`deputy` は承認ルーティングでリードの代理を務める場合があります。",
         options: {
           member: "メンバー",
@@ -679,7 +679,7 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
       },
       is_primary: {
         label: "主要割り当て",
-        help: "ユーザーが複数の部門に所属する場合、レポーティングの正規部門をマークします。"
+        help: "ユーザーが複数のビジネスユニットに所属する場合、レポーティングの正規ビジネスユニットをマークします。"
       },
       effective_from: {
         label: "有効開始日"

--- a/packages/platform-objects/src/apps/translations/ja-JP.ts
+++ b/packages/platform-objects/src/apps/translations/ja-JP.ts
@@ -45,7 +45,7 @@ export const jaJP: TranslationData = {
         nav_system_overview: { label: 'システム概要' },
 
         nav_users: { label: 'ユーザー' },
-        nav_departments: { label: '部署' },
+        nav_business_units: { label: 'ビジネスユニット' },
         nav_teams: { label: 'チーム' },
         nav_organizations: { label: '組織' },
         nav_invitations: { label: '招待' },

--- a/packages/platform-objects/src/apps/translations/zh-CN.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/zh-CN.objects.generated.ts
@@ -578,8 +578,8 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
     }
   },
   sys_business_unit: {
-    label: "部门",
-    pluralLabel: "部门",
+    label: "业务单元",
+    pluralLabel: "业务单元",
     description: "层级化组织骨架节点（部门 / 事业部 / 业务单元 / 办公地点）。",
     fields: {
       name: {
@@ -655,8 +655,8 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
     }
   },
   sys_business_unit_member: {
-    label: "部门成员",
-    pluralLabel: "部门成员",
+    label: "业务单元成员",
+    pluralLabel: "业务单元成员",
     description: "用户到部门的任职关系（适配矩阵组织并支持生效时间）。",
     fields: {
       id: {

--- a/packages/platform-objects/src/apps/translations/zh-CN.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/zh-CN.objects.generated.ts
@@ -602,7 +602,7 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
         }
       },
       parent_business_unit_id: {
-        label: "上级部门",
+        label: "上级业务单元",
         help: "组织树的自关联字段。Null 表示租户根节点。"
       },
       organization_id: {
@@ -610,27 +610,27 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
         help: "租户范围。"
       },
       manager_user_id: {
-        label: "部门负责人",
-        help: "负责该组织单元的用户（部门负责人 / lead）。"
+        label: "业务单元负责人",
+        help: "负责该组织单元的用户（业务单元负责人 / lead）。"
       },
       active: {
         label: "启用",
-        help: "为 false 时，图谱查询不会展开该部门成员。"
+        help: "为 false 时，图谱查询不会展开该业务单元成员。"
       },
       effective_from: {
         label: "生效时间",
-        help: "该部门生效的时间（HRIS 同步）。"
+        help: "该业务单元生效的时间（HRIS 同步）。"
       },
       effective_to: {
         label: "失效时间",
-        help: "该部门停用的时间（HRIS 同步）。"
+        help: "该业务单元停用的时间（HRIS 同步）。"
       },
       external_ref: {
         label: "外部引用",
         help: "上游 HRIS 中的 ID（Workday / SAP HR / 北森）。"
       },
       id: {
-        label: "部门 ID"
+        label: "业务单元 ID"
       },
       created_at: {
         label: "创建时间"
@@ -657,19 +657,19 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
   sys_business_unit_member: {
     label: "业务单元成员",
     pluralLabel: "业务单元成员",
-    description: "用户到部门的任职关系（适配矩阵组织并支持生效时间）。",
+    description: "用户到业务单元的任职关系（适配矩阵组织并支持生效时间）。",
     fields: {
       id: {
         label: "成员 ID"
       },
       business_unit_id: {
-        label: "部门"
+        label: "业务单元"
       },
       user_id: {
         label: "用户"
       },
       role_in_business_unit: {
-        label: "部门内角色",
+        label: "业务单元内角色",
         help: "`lead` 表示日常负责人；`deputy` 可在审批路由中代替负责人。",
         options: {
           member: "成员",
@@ -679,7 +679,7 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
       },
       is_primary: {
         label: "主任职",
-        help: "当用户属于多个部门时，用于标记报表上的主部门。"
+        help: "当用户属于多个业务单元时，用于标记报表上的主业务单元。"
       },
       effective_from: {
         label: "生效时间"

--- a/packages/platform-objects/src/apps/translations/zh-CN.ts
+++ b/packages/platform-objects/src/apps/translations/zh-CN.ts
@@ -45,7 +45,7 @@ export const zhCN: TranslationData = {
         nav_system_overview: { label: '系统概览' },
 
         nav_users: { label: '用户' },
-        nav_departments: { label: '部门' },
+        nav_business_units: { label: '业务单元' },
         nav_teams: { label: '团队' },
         nav_organizations: { label: '组织' },
         nav_invitations: { label: '邀请' },

--- a/packages/platform-objects/src/identity/sys-business-unit-member.object.ts
+++ b/packages/platform-objects/src/identity/sys-business-unit-member.object.ts
@@ -3,10 +3,10 @@
 import { ObjectSchema, Field } from '@objectstack/spec/data';
 
 /**
- * sys_business_unit_member — User ↔ Department Assignment
+ * sys_business_unit_member — User ↔ Business Unit Assignment
  *
  * Many-to-many between `sys_user` and `sys_business_unit`. A user can belong
- * to multiple departments (matrix orgs) but exactly one is marked
+ * to multiple business units (matrix orgs) but exactly one is marked
  * `is_primary` to drive the default reporting view.
  *
  * Effective-dated so that historical reports & audits can reconstruct

--- a/packages/platform-objects/src/identity/sys-business-unit.object.ts
+++ b/packages/platform-objects/src/identity/sys-business-unit.object.ts
@@ -106,7 +106,7 @@ export const SysBusinessUnit = ObjectSchema.create({
 
     // ── Hierarchy ────────────────────────────────────────────────
     parent_business_unit_id: Field.lookup('sys_business_unit', {
-      label: 'Parent Department',
+      label: 'Parent Business Unit',
       required: false,
       description: 'Self-reference for the org tree. Null = root of tenant.',
       group: 'Hierarchy',
@@ -121,9 +121,9 @@ export const SysBusinessUnit = ObjectSchema.create({
 
     // ── Leadership ───────────────────────────────────────────────
     manager_user_id: Field.lookup('sys_user', {
-      label: 'Department Head',
+      label: 'Business Unit Head',
       required: false,
-      description: 'User responsible for this org unit (department head / lead).',
+      description: 'User responsible for this org unit (business unit head / lead).',
       group: 'Leadership',
     }),
 
@@ -139,14 +139,14 @@ export const SysBusinessUnit = ObjectSchema.create({
     effective_from: Field.datetime({
       label: 'Effective From',
       required: false,
-      description: 'When this department came into existence (HRIS sync).',
+      description: 'When this business unit came into existence (HRIS sync).',
       group: 'Lifecycle',
     }),
 
     effective_to: Field.datetime({
       label: 'Effective To',
       required: false,
-      description: 'When this department was retired (HRIS sync).',
+      description: 'When this business unit was retired (HRIS sync).',
       group: 'Lifecycle',
     }),
 
@@ -160,7 +160,7 @@ export const SysBusinessUnit = ObjectSchema.create({
 
     // ── System ───────────────────────────────────────────────────
     id: Field.text({
-      label: 'Department ID',
+      label: 'Business Unit ID',
       required: true,
       readonly: true,
       group: 'System',


### PR DESCRIPTION
## What
Completes the ADR-0057 `sys_department` → `sys_business_unit` rename in the **Setup app and the object's i18n** — the prior rename left the user-facing surface half-renamed.

### Setup menu
- The "People & Organization" nav entry was hidden/stale: `nav_departments` / label "Departments" pointing at `sys_business_unit`. Renamed to `nav_business_units` / "Business Units" and aligned all four locale nav bundles.

### Object labels & descriptions (the real root)
- The **object definition itself** (`sys-business-unit.object.ts`) still said "department" in field labels (`Parent Department`, `Department Head`, `Department ID`) and descriptions — while the generated `en` labels had been hand-updated ahead of it, making the def a silently-stale source. Fixed at the source.
- All four locales' generated object translations (`en`/`zh`/`ja`/`es`) aligned to **业务单元 / ビジネスユニット / Unidad de negocio** across labels, help text, and the `sys_business_unit_member` object.

### Intentionally preserved (not over-renamed)
- The `kind` enum value `department` — a business unit can be *of kind* department.
- The multi-concept node descriptions that list kinds (`company / division / department / …`).
- The unrelated `部署` = "deployment" strings (same characters as Japanese 部署="department" — a blind replace would have corrupted them).

## Verification
- Browser-verified in the console: Setup → 人员与组织 → **业务单元** (→ `sys_business_unit`); the object list/form headers and field labels render the new term.
- Cross-locale scan of both object blocks is clean; old strings remain only in unrelated stale worktrees.

> Note: field *help* text can still render the old term from a prebuilt `@objectstack/console` bundle (a dev-bundle cache, not a source gap) until the console is rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)