### PR TITLE
feat(objectql,spec): execute $search via metadata-driven cross-field filter (ADR-0061 P1+P2)

### DIFF
--- a/examples/app-showcase/src/objects/account.object.ts
+++ b/examples/app-showcase/src/objects/account.object.ts
@@ -19,6 +19,11 @@ export const Account = ObjectSchema.create({
   icon: 'building',
   description: 'A company the org delivers projects for.',
 
+  // ADR-0061: which fields `$search` matches. Includes the two selects
+  // (industry/status) so searching a label like "Retail" or "Active" resolves
+  // to the stored value, plus the text identifiers.
+  searchableFields: ['name', 'industry', 'status', 'billing_email', 'tax_id'],
+
   fields: {
     name: Field.text({ label: 'Account Name', required: true, searchable: true, maxLength: 200 }),
     industry: Field.select({

--- a/packages/objectql/src/engine.test.ts
+++ b/packages/objectql/src/engine.test.ts
@@ -225,6 +225,46 @@ describe('ObjectQL Engine', () => {
         });
     });
 
+    describe('$search expansion (ADR-0061)', () => {
+        beforeEach(async () => {
+            engine.registerDriver(mockDriver, true);
+            await engine.init();
+        });
+
+        it('expands $search into a cross-field $or pushed to the driver', async () => {
+            vi.mocked(SchemaRegistry.getObject).mockReturnValue({
+                name: 'account',
+                fields: {
+                    name: { type: 'text' },
+                    industry: { type: 'select', options: [{ label: 'Retail', value: 'retail' }] },
+                },
+            } as any);
+
+            await engine.find('account', { search: 'retail' });
+
+            const ast = (mockDriver.find as any).mock.calls.at(-1)[1];
+            expect(ast.where).toEqual({ $or: [
+                { name: { $contains: 'retail' } },
+                { industry: { $in: ['retail'] } },
+            ] });
+            expect(ast.search).toBeUndefined();
+        });
+
+        it('ANDs $search with an existing filter and honours declared searchableFields', async () => {
+            vi.mocked(SchemaRegistry.getObject).mockReturnValue({
+                name: 'account',
+                fields: { name: { type: 'text' }, code: { type: 'text' } },
+                searchableFields: ['name'],
+            } as any);
+
+            await engine.find('account', { search: 'acme', filter: { status: 'active' } });
+
+            const ast = (mockDriver.find as any).mock.calls.at(-1)[1];
+            expect(ast.where.$and).toContainEqual({ status: 'active' });
+            expect(ast.where.$and).toContainEqual({ $or: [{ name: { $contains: 'acme' } }] });
+        });
+    });
+
     describe('CRUD Operations', () => {
         beforeEach(async () => {
             engine.registerDriver(mockDriver, true);

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -25,6 +25,7 @@ import {
 } from './secret-fields.js';
 import { pluralToSingular, ExternalWriteForbiddenError } from '@objectstack/spec/shared';
 import { SchemaRegistry, computeFQN } from './registry.js';
+import { expandSearchToFilter } from './search-filter.js';
 import { ExpressionEngine } from '@objectstack/formula';
 import type { Expression } from '@objectstack/spec';
 import { isAggregatedViewContainer, expandViewContainer } from '@objectstack/spec';
@@ -1885,6 +1886,32 @@ export class ObjectQL implements IDataEngine {
     // names and inject their dependencies, so the driver returns the raw
     // fields needed to compute the formulas after fetch.
     const _findSchema = this._registry.getObject(object);
+
+    // ADR-0061: expand `$search` into a server-resolved cross-field `$or`
+    // of `$contains`. Field resolution is server-side (declared
+    // `searchableFields` -> auto-default); the optional `$searchFields` override
+    // is intersected with the allowed set. All drivers already execute
+    // `$or`/`$contains`, so this needs no driver changes.
+    {
+      const _searchRaw = (ast as any).search ?? (ast as any).$search;
+      if (_searchRaw != null && _findSchema?.fields) {
+        const _reqFields = (ast as any).searchFields ?? (ast as any).$searchFields
+          ?? (typeof (ast as any).search === 'object' ? (ast as any).search?.fields : undefined);
+        const _searchFilter = expandSearchToFilter(_searchRaw, {
+          fields: _findSchema.fields as any,
+          searchableFields: (_findSchema as any).searchableFields,
+          requestedFields: Array.isArray(_reqFields) ? _reqFields : undefined,
+          displayField: (_findSchema as any).displayNameField,
+        });
+        if (_searchFilter) {
+          ast.where = ast.where ? { $and: [ast.where, _searchFilter] } : _searchFilter;
+        }
+      }
+      delete (ast as any).search;
+      delete (ast as any).$search;
+      delete (ast as any).searchFields;
+      delete (ast as any).$searchFields;
+    }
     const _findFormula = planFormulaProjection(_findSchema, ast.fields as string[] | undefined);
     if (_findFormula.projected) ast.fields = _findFormula.projected;
 

--- a/packages/objectql/src/search-filter.test.ts
+++ b/packages/objectql/src/search-filter.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { expandSearchToFilter, resolveSearchFields, normalizeSearch } from './search-filter';
+
+const accountFields = {
+  name: { type: 'text' },
+  industry: { type: 'select', options: [
+    { label: 'Technology', value: 'technology' },
+    { label: 'Retail', value: 'retail' },
+    { label: 'Healthcare', value: 'healthcare' },
+  ] },
+  annual_revenue: { type: 'currency' },
+  website: { type: 'url' },
+  hq: { type: 'location' },
+  status: { type: 'select', options: [
+    { label: 'Active', value: 'active' },
+    { label: 'Churned', value: 'churned' },
+  ] },
+  support_config: { type: 'json' },
+  owner_id: { type: 'lookup' },
+  created_at: { type: 'datetime' },
+};
+
+describe('normalizeSearch', () => {
+  it('accepts string, {query}, and nullish', () => {
+    expect(normalizeSearch('acme')).toEqual({ query: 'acme' });
+    expect(normalizeSearch({ query: 'acme', fields: ['name'] })).toEqual({ query: 'acme', fields: ['name'] });
+    expect(normalizeSearch(null)).toEqual({ query: '' });
+  });
+});
+
+describe('resolveSearchFields', () => {
+  it('auto-defaults to name + short-text + select, excluding system/heavy types', () => {
+    const f = resolveSearchFields({ fields: accountFields });
+    expect(f[0]).toBe('name');                 // display/name leads
+    expect(f).toContain('industry');           // select included (label search)
+    expect(f).toContain('website');            // url included
+    expect(f).not.toContain('annual_revenue'); // currency excluded
+    expect(f).not.toContain('hq');             // location excluded
+    expect(f).not.toContain('support_config'); // json excluded
+    expect(f).not.toContain('owner_id');       // lookup excluded
+    expect(f).not.toContain('created_at');     // system/date excluded
+  });
+
+  it('honours declared searchableFields over the auto-default', () => {
+    const f = resolveSearchFields({ fields: accountFields, searchableFields: ['name', 'industry'] });
+    expect(f).toEqual(['name', 'industry']);
+  });
+
+  it('intersects a requested ($searchFields) override with the allowed set', () => {
+    const f = resolveSearchFields({
+      fields: accountFields,
+      searchableFields: ['name', 'industry'],
+      requestedFields: ['industry', 'annual_revenue'], // annual_revenue not allowed → dropped
+    });
+    expect(f).toEqual(['industry']);
+  });
+
+  it('ignores an override that resolves to nothing allowed (falls back)', () => {
+    const f = resolveSearchFields({
+      fields: accountFields,
+      searchableFields: ['name'],
+      requestedFields: ['secret_field'],
+    });
+    expect(f).toEqual(['name']);
+  });
+});
+
+describe('expandSearchToFilter', () => {
+  it('returns null for empty query or no fields', () => {
+    expect(expandSearchToFilter('', { fields: accountFields })).toBeNull();
+    expect(expandSearchToFilter('x', { fields: {} })).toBeNull();
+  });
+
+  it('single term → $or of $contains across resolved fields', () => {
+    const f = expandSearchToFilter('acme', { fields: accountFields, searchableFields: ['name', 'website'] });
+    expect(f).toEqual({ $or: [
+      { name: { $contains: 'acme' } },
+      { website: { $contains: 'acme' } },
+    ] });
+  });
+
+  it('maps a select label to stored option values ($in)', () => {
+    const f = expandSearchToFilter('retail', { fields: accountFields, searchableFields: ['name', 'industry'] });
+    expect(f).toEqual({ $or: [
+      { name: { $contains: 'retail' } },
+      { industry: { $in: ['retail'] } },
+    ] });
+  });
+
+  it('multi-term → AND across terms, OR across fields', () => {
+    const f = expandSearchToFilter('acme tech', { fields: accountFields, searchableFields: ['name', 'industry'] });
+    expect(f.$and).toHaveLength(2);
+    // first term "acme": no industry label matches → falls back to $contains
+    expect(f.$and[0]).toEqual({ $or: [
+      { name: { $contains: 'acme' } },
+      { industry: { $contains: 'acme' } },
+    ] });
+    // second term "tech": matches the "Technology" label → $in
+    expect(f.$and[1]).toEqual({ $or: [
+      { name: { $contains: 'tech' } },
+      { industry: { $in: ['technology'] } },
+    ] });
+  });
+
+  it('case-insensitive label match', () => {
+    const f = expandSearchToFilter('ACTIVE', { fields: accountFields, searchableFields: ['status'] });
+    expect(f).toEqual({ $or: [{ status: { $in: ['active'] } }] });
+  });
+});

--- a/packages/objectql/src/search-filter.ts
+++ b/packages/objectql/src/search-filter.ts
@@ -1,0 +1,152 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `$search` → cross-field filter expansion (ADR-0061, Tier 1).
+ *
+ * The picker / list / command-palette surfaces all send a `$search` string;
+ * historically the data layer dropped it (a silent no-op). This module turns
+ * that string into a driver-agnostic `$or` of `$contains` predicates across the
+ * object's *server-resolved* searchable fields — every driver already executes
+ * `$or` + `$contains`, so no driver changes are needed.
+ *
+ * Field resolution (server-side, never client-trusted):
+ *   1. an explicit, validated `requestedFields` subset (`$searchFields` override)
+ *   2. the object's declared `searchableFields`
+ *   3. an auto-default: the name/title field + short-text fields.
+ *
+ * Matching: case-insensitive; multiple whitespace-separated terms are AND-ed
+ * (every term must hit some field); fields are OR-ed. `select`/`status` columns
+ * store a value but users type the label, so the term is mapped to option
+ * values whose label matches (with a raw-value `$contains` fallback).
+ */
+
+export interface SearchFieldMeta {
+  type?: string;
+  hidden?: boolean;
+  options?: Array<{ label?: string; value: unknown } | string> | unknown;
+}
+
+export interface ExpandSearchOptions {
+  /** The referenced object's field map (name → metadata). */
+  fields: Record<string, SearchFieldMeta>;
+  /** Object-declared `searchableFields` (the canonical default set). */
+  searchableFields?: string[];
+  /** Validated `$searchFields` override — intersected with the allowed set. */
+  requestedFields?: string[];
+  /** Preferred display field, placed first in the auto-default. */
+  displayField?: string;
+}
+
+/** Short-text field types that make sense as `$contains` search targets. */
+const TEXTUAL_TYPES = new Set(['text', 'email', 'phone', 'url', 'autonumber', 'textarea', 'markdown']);
+/** Enumerated types searched by mapping the query to option values via labels. */
+const ENUM_TYPES = new Set(['select', 'status']);
+/** System / audit / heavy fields never auto-included. */
+const EXCLUDED_FIELDS = new Set([
+  'id', '_id', 'created', 'modified', 'created_at', 'updated_at',
+  'created_by', 'updated_by', 'owner_id', 'organization_id', 'space', 'company_id',
+]);
+const EXCLUDED_TYPES = new Set([
+  'json', 'object', 'grid', 'image', 'file', 'avatar', 'vector', 'location',
+  'geometry', 'secret', 'password', 'encrypted', 'boolean', 'lookup', 'master_detail',
+]);
+
+export interface NormalizedSearch {
+  query: string;
+  fields?: string[];
+}
+
+/** Accept the term in any shape it may reach the engine under. */
+export function normalizeSearch(raw: unknown): NormalizedSearch {
+  if (raw == null) return { query: '' };
+  if (typeof raw === 'string') return { query: raw };
+  if (typeof raw === 'object') {
+    const o = raw as Record<string, unknown>;
+    const q = typeof o.query === 'string' ? o.query : typeof o.q === 'string' ? o.q : '';
+    const fields = Array.isArray(o.fields) ? (o.fields as string[]) : undefined;
+    return { query: q, fields };
+  }
+  return { query: '' };
+}
+
+function autoDefaultFields(fields: Record<string, SearchFieldMeta>, displayField?: string): string[] {
+  const names = Object.keys(fields).filter((f) => {
+    if (EXCLUDED_FIELDS.has(f)) return false;
+    const meta = fields[f];
+    if (!meta || meta.hidden) return false;
+    const t = meta.type;
+    if (!t) return false;
+    if (EXCLUDED_TYPES.has(t)) return false;
+    return TEXTUAL_TYPES.has(t) || ENUM_TYPES.has(t);
+  });
+  // Lead with the display/name field when present.
+  const lead = displayField && fields[displayField] ? displayField
+    : fields.name ? 'name'
+    : fields.title ? 'title'
+    : undefined;
+  if (!lead) return names;
+  return [lead, ...names.filter((f) => f !== lead)];
+}
+
+/** Resolve the effective searchable field set (server-side, validated). */
+export function resolveSearchFields(opts: ExpandSearchOptions): string[] {
+  const all = opts.fields || {};
+  const declared = opts.searchableFields?.filter((f) => all[f]);
+  const allowed = declared && declared.length > 0 ? declared : autoDefaultFields(all, opts.displayField);
+  if (opts.requestedFields && opts.requestedFields.length > 0) {
+    const allowSet = new Set(allowed);
+    const validated = opts.requestedFields.filter((f) => allowSet.has(f));
+    if (validated.length > 0) return validated;
+  }
+  return allowed;
+}
+
+function optionValuesMatching(meta: SearchFieldMeta, term: string): unknown[] {
+  if (!Array.isArray(meta.options)) return [];
+  const lc = term.toLowerCase();
+  const out: unknown[] = [];
+  for (const opt of meta.options) {
+    if (opt == null) continue;
+    if (typeof opt === 'string') {
+      if (opt.toLowerCase().includes(lc)) out.push(opt);
+      continue;
+    }
+    const label = String((opt as any).label ?? (opt as any).value ?? '');
+    if (label.toLowerCase().includes(lc)) out.push((opt as any).value);
+  }
+  return out;
+}
+
+function fieldClausesForTerm(field: string, term: string, meta: SearchFieldMeta): any[] {
+  if (ENUM_TYPES.has(meta?.type ?? '')) {
+    const values = optionValuesMatching(meta, term);
+    if (values.length > 0) return [{ [field]: { $in: values } }];
+    return [{ [field]: { $contains: term } }];
+  }
+  return [{ [field]: { $contains: term } }];
+}
+
+/**
+ * Expand a `$search` term into a `{ $or: [...] }` (single term) or
+ * `{ $and: [{ $or: [...] }, ...] }` (multi-term) filter. Returns `null` when
+ * there's nothing to search (empty query or no resolvable fields) so the caller
+ * leaves the existing filter untouched.
+ */
+export function expandSearchToFilter(raw: unknown, opts: ExpandSearchOptions): any | null {
+  const { query, fields: requested } = normalizeSearch(raw);
+  if (!query || !query.trim()) return null;
+
+  const searchFields = resolveSearchFields({
+    ...opts,
+    requestedFields: requested ?? opts.requestedFields,
+  });
+  if (searchFields.length === 0) return null;
+
+  const terms = query.trim().split(/\s+/).filter(Boolean);
+  const andClauses = terms.map((term) => ({
+    $or: searchFields.flatMap((f) => fieldClausesForTerm(f, term, opts.fields[f] || {})),
+  }));
+
+  if (andClauses.length === 0) return null;
+  return andClauses.length === 1 ? andClauses[0] : { $and: andClauses };
+}

--- a/packages/spec/liveness/object.json
+++ b/packages/spec/liveness/object.json
@@ -242,6 +242,10 @@
     "active": {
       "status": "dead",
       "evidence": "object-level — no runtime reader"
+    },
+    "searchableFields": {
+      "status": "live",
+      "note": "objectql `$search` executor (ADR-0061: expandSearchToFilter in engine.find) + objectui list/lookup/command-palette; canonical searchable-field source."
     }
   }
 }

--- a/packages/spec/src/data/object.zod.ts
+++ b/packages/spec/src/data/object.zod.ts
@@ -580,6 +580,7 @@ const ObjectSchemaBase = z.object({
   /** 
    * Search Engine Config 
    */
+  searchableFields: z.array(z.string()).optional().describe('Fields the `$search` query matches against (ADR-0061). Canonical default for the record picker, list quick-search and global search; views may narrow it. When unset, search auto-defaults to the name/title field plus short-text fields.'),
   search: SearchConfigSchema.optional().describe('Search engine configuration'),
   
   /** 


### PR DESCRIPTION
Implements **ADR-0061** phases **P1 (contract)** and **P2 (executor)**. `$search` was a textbook declared-but-unenforced no-op (defined in spec, sent by every client, executed by no driver — see `docs/audits/2026-06-record-search-liveness.md`). This wires it end-to-end, server-resolved and driver-agnostic.

## P1 — contract
- `spec`: add **`object.searchableFields`** to `ObjectSchemaBase` — the canonical, server-side source for which fields `$search` matches. Classified **live** in `liveness/object.json`.

## P2 — executor
- `objectql/search-filter.ts` (`expandSearchToFilter`): turns a `$search` term into `{ $or: [{ field: { $contains } }] }` across **server-resolved** fields — declared `searchableFields` → auto-default (name/title + short-text types), excluding system/heavy/enumerated-as-text. Multiple terms **AND**, fields **OR**. `select`/`status` map the query to stored option **values via labels** (`$in`) with a raw-value fallback. An optional `$searchFields` override is **intersected with the allowed set** (never client-trusted).
- Wired into `engine.find()` after schema resolution and before the driver call, merging with any existing filter via `$and`. **No driver changes** — every driver already executes `$or`/`$contains`.

## Showcase
`showcase_account.searchableFields = [name, industry, status, billing_email, tax_id]` — searching **"retail" now matches by industry**, not just name.

## Verification
- `search-filter.test.ts` — 10 cases (field resolution, auto-default exclusions, declared override, `$searchFields` subset-validation, label→value `$in`, multi-term AND/OR, case-insensitive).
- `engine.test.ts` — `$search` expands into the `where` that reaches the driver; ANDs with an existing filter; honours declared `searchableFields`.
- Liveness gate green; objectql typecheck clean; app-showcase typecheck clean (only pre-existing connector/objectql module-resolution noise).

## Scope
Per ADR-0061, **P3** (unify list/lookup/⌘K onto this resolver + objectui `$searchFields` contract) and **P4** (trigram/`tsvector` indexes, relevance/boost/fuzzy, external engines, server `searchAll`) are deferred to follow-ups. The renderer `$or` hack from the "rejected alternatives" is **not** used.