### PR TITLE
docs(ui): drill 'Open in list' escape hatch + unified report drill

### DIFF
--- a/content/docs/guides/metadata/dashboard.mdx
+++ b/content/docs/guides/metadata/dashboard.mdx
@@ -201,6 +201,13 @@ drawer to open that single record's detail. This completes the
 **group → records → record** chain (e.g. *Revenue by Region* → the orders in
 the *West* bucket → one order).
 
+The drawer also offers an **"Open in list →"** escape hatch — escalate the peek
+to the object's full list page (sort / bulk-select / export / shareable URL),
+scoped by the same drill filter. In-place drawer is the default (keep context);
+the escape hatch is there when you need the full surface. **Reports drill
+identically**: a `summary` / `matrix` report opens the same in-place drawer on
+row/cell click, so dashboard and report drill behave the same.
+
 ```typescript
 // A drill-through table widget. No drill configuration is required — it is
 // automatic whenever the dataset exposes the base object and the widget groups
@@ -222,10 +229,12 @@ click-drillable; expose the detail through a `table`/`pivot` widget instead.
 
 > **Renderer note.** Object/record-backed list and table surfaces (and the
 > ObjectUI renderer's `options.drillDown` block) support a richer drill model —
-> a `mode: 'filter' | 'record'` discriminator, drawer-vs-dialog target, a column
+> a `mode: 'filter' | 'record'` discriminator, a `target` of `'drawer'` /
+> `'dialog'` / `'navigate'` (the last opens the list page directly), a column
 > whitelist, and chart-segment drill for the `scatter` / `treemap` / `sankey`
 > families. Those knobs live in the renderer; dataset-bound dashboards drill
-> through the semantic layer as described above.
+> through the semantic layer as described above (and get the "Open in list →"
+> escape hatch from the host app, e.g. the console).
 
 ### Aggregation Functions
 

--- a/skills/objectstack-ui/SKILL.md
+++ b/skills/objectstack-ui/SKILL.md
@@ -963,20 +963,32 @@ behind it; **drill-to-record** opens one record.
   *exact* records (no label→id guessing). Automatic — no per-widget config.
 * **The drilled record list drills to record.** Any row in that drawer opens the
   single record's detail, completing the **group → records → record** chain.
+* **Escape hatch — "Open in list →".** The drawer header offers a link to the
+  object's *full* list page (sort / bulk-select / export / shareable URL),
+  scoped by the same drill filter. The in-place drawer is the default (peek
+  without losing the dashboard); the escape hatch escalates when the user wants
+  the full surface — the Looker / Power BI "see records → open page" model.
 * **`metric` / `chart` widgets are not click-drillable** in the dataset form
   (they render the aggregate only; `compareTo` still applies). Surface the detail
   through a `table` / `pivot` widget instead.
 
+**Reports drill the same way.** A `summary` / `matrix` report (`drilldown`
+defaults `true`) opens the identical in-place drawer on row/cell click — peek the
+records, click a row to open one, or "Open in list →" for the full list page.
+Dashboard and report drill are unified.
+
 > **Renderer note (object/record-backed surfaces).** The ObjectUI renderer
 > exposes a richer `options.drillDown` block for non-dataset list/table widgets
 > and the drill drawers — `enabled`, `mode` (`'filter'` = aggregate → filtered
-> list; `'record'` = row → that record), `target` (`'drawer'` | `'dialog'`),
-> `columns` (whitelist), and `title` (`${event.*}` interpolation). At the
-> renderer level drill-through covers the `bar` / `line` / `area` / `pie` /
+> list; `'record'` = row → that record), `target` (`'drawer'` | `'dialog'` |
+> `'navigate'`, where `'navigate'` skips the drawer and opens the list page
+> directly), `columns` (whitelist), and `title` (`${event.*}` interpolation). At
+> the renderer level drill-through covers the `bar` / `line` / `area` / `pie` /
 > `donut` / `funnel` / `scatter` / `treemap` / `sankey` families and pivot
 > cell/row/column/total clicks (`radar` is excluded — no single clickable
-> category point). **Dataset-bound dashboards use the semantic-layer drill above
-> and ignore this block.**
+> category point). The "Open in list →" escape hatch appears whenever the host
+> app wired drill navigation (the console does). **Dataset-bound dashboards use
+> the semantic-layer drill above and ignore the rest of this block.**
 
 | `dateGranularity` | Rendered bucket label |
 |:--|:--|


### PR DESCRIPTION
Documents the drill UX work in objectstack-ai/objectui#1866: drill-through opens an in-place drawer with an **"Open in list →"** escape hatch to the full object list page, and **reports now drill via the same in-place drawer** (unified with dashboards) instead of navigating away.

- `skills/objectstack-ui/SKILL.md` — Drilldown subsection: escape hatch bullet, "Reports drill the same way" note, and `target: 'navigate'` in the renderer note.
- `content/docs/guides/metadata/dashboard.mdx` — same, in the guide's Drill-down section.

Docs/skills only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)