### PR TITLE
fix(objectql): normalize OData $search/$searchFields so the search executor runs (ADR-0061)

### DIFF
--- a/packages/objectql/src/protocol-data.test.ts
+++ b/packages/objectql/src/protocol-data.test.ts
@@ -25,6 +25,18 @@ describe('ObjectStackProtocolImplementation - Data Operations', () => {
     // ═══════════════════════════════════════════════════════════════
 
     describe('findData', () => {
+        it('normalizes $search/$searchFields (OData) to bare search/searchFields, not implicit filters', async () => {
+            await protocol.findData({ object: 'showcase_account', query: { $search: 'retail', $searchFields: ['name', 'industry'] } });
+            const opts = mockEngine.find.mock.calls[0][1];
+            expect(opts.search).toBe('retail');
+            expect(opts.searchFields).toEqual(['name', 'industry']);
+            expect(opts.$search).toBeUndefined();
+            expect(opts.$searchFields).toBeUndefined();
+            // critical: must NOT fall through to the implicit-filter pass as where.$search
+            expect(opts.where?.$search).toBeUndefined();
+            expect(opts.where?.searchFields).toBeUndefined();
+        });
+
         it('should normalize $expand (OData) string to expand Record', async () => {
             await protocol.findData({ object: 'order_item', query: { $expand: 'order,product' } });
 

--- a/packages/objectql/src/protocol.ts
+++ b/packages/objectql/src/protocol.ts
@@ -2021,6 +2021,8 @@ export class ObjectStackProtocolImplementation implements ObjectStackProtocol {
             ['$orderby', 'orderBy'],
             ['$select', 'select'],
             ['$count', 'count'],
+            ['$search', 'search'],
+            ['$searchFields', 'searchFields'],
         ] as const) {
             if (options[dollar] != null && options[bare] == null) {
                 options[bare] = options[dollar];
@@ -2133,7 +2135,7 @@ export class ObjectStackProtocolImplementation implements ObjectStackProtocol {
             'expand',
             'distinct', 'count',
             'aggregations', 'groupBy',
-            'search', 'context', 'cursor',
+            'search', 'searchFields', 'context', 'cursor',
         ]);
         if (!options.where) {
             const implicitFilters: Record<string, unknown> = {};


### PR DESCRIPTION
Follow-up to the `$search` executor (#2134). Browser/HTTP end-to-end testing revealed the executor **never ran over the REST/OData path**: `protocol.findData()` normalizes `$`-prefixed OData params (`$top`/`$skip`/`$orderby`/`$select`/`$count`) to bare names, but **not `$search`/`$searchFields`**. So `$search=retail` fell through to the implicit-field-filter pass and became `where.$search = 'retail'` (a non-existent column) → the SQL driver silently returns `[]`. The engine's `expandSearchToFilter` (which reads `ast.search`) therefore never fired — `$search` looked like a no-op over HTTP even though the engine logic was correct and unit-tested.

## Fix
- Add `['$search','search']` and `['$searchFields','searchFields']` to the dollar→bare normalization loop in `findData`.
- Add `'searchFields'` to `knownParams` so the bare form isn't swept into implicit filters.
- Test: `findData` normalizes `$search`/`$searchFields` to bare `search`/`searchFields` and never leaks them into `where`.

## Verification (real HTTP API, dev backend with the executor)
- `?$search=retail` → **3 retail-industry accounts** (Acme Retail / Northwind / Wonka Brands), matched by the industry **label→value**, not by name.
- `?$search=technology` → 4 (by industry label) · `?$search=Contoso` → 1 (by name) · `?$search=zzqq` → 0 · baseline → 13.
- Browser console (pointed at the dev backend) renders the same backend's data.

This is the missing link that makes ADR-0061 P2 actually work end-to-end over REST. Unit tests: protocol-data (34) green; objectql typecheck clean.