### PR TITLE
feat(platform-objects): drop unused `team` kind from sys_business_unit (ADR-0057 D11)

### DIFF
--- a/.changeset/adr-0057-d11-drop-bu-kind-team.md
+++ b/.changeset/adr-0057-d11-drop-bu-kind-team.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/platform-objects": minor
+---
+
+Drop the unused `team` value from `sys_business_unit.kind` (ADR-0057 addendum D11).
+
+The `team` kind collided head-on with the first-class `sys_team` object: a
+`kind='team'` business unit walks the hierarchical `BusinessUnitGraphService`,
+while `sys_team` is the flat better-auth collaboration grouping served by
+`TeamGraphService`. `kind` is a display-only categorisation hint (it does not
+change graph semantics) and had **zero** usages anywhere in the repo, so this is a
+safe narrowing with no data migration. New enum:
+`company | division | department | office | cost_center`.

--- a/packages/platform-objects/src/apps/translations/en.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/en.objects.generated.ts
@@ -599,7 +599,6 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
           company: "company",
           division: "division",
           department: "department",
-          team: "team",
           office: "office",
           cost_center: "cost_center"
         }

--- a/packages/platform-objects/src/apps/translations/es-ES.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/es-ES.objects.generated.ts
@@ -599,7 +599,6 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
           company: "Empresa",
           division: "División",
           department: "Departamento",
-          team: "Equipo",
           office: "Oficina",
           cost_center: "Centro de coste"
         }

--- a/packages/platform-objects/src/apps/translations/ja-JP.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/ja-JP.objects.generated.ts
@@ -599,7 +599,6 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
           company: "会社",
           division: "事業部",
           department: "部門",
-          team: "チーム",
           office: "オフィス",
           cost_center: "コストセンター"
         }

--- a/packages/platform-objects/src/apps/translations/zh-CN.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/zh-CN.objects.generated.ts
@@ -599,7 +599,6 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
           company: "公司",
           division: "事业部",
           department: "部门",
-          team: "团队",
           office: "办公地点",
           cost_center: "成本中心"
         }

--- a/packages/platform-objects/src/identity/sys-business-unit.object.ts
+++ b/packages/platform-objects/src/identity/sys-business-unit.object.ts
@@ -9,7 +9,7 @@ import { ObjectSchema, Field } from '@objectstack/spec/data';
  * `sys_team`** (which is the flat better-auth collaboration grouping).
  *
  * A single tenant typically has one `kind='company'` root, then nested
- * `division` / `department` / `team` / `office` nodes underneath. The
+ * `division` / `department` / `office` nodes underneath. The
  * `kind` enum is purely a display/categorisation hint — the recursive
  * structure works identically regardless of value.
  *
@@ -94,7 +94,7 @@ export const SysBusinessUnit = ObjectSchema.create({
     }),
 
     kind: Field.select(
-      ['company', 'division', 'department', 'team', 'office', 'cost_center'],
+      ['company', 'division', 'department', 'office', 'cost_center'],
       {
         label: 'Kind',
         required: true,


### PR DESCRIPTION
First implementation increment of the **ADR-0057 addendum** (#2141) — **PS-1 / D11**.

## What

Drops the unused `team` value from `sys_business_unit.kind`:
`company | division | department | ~~team~~ | office | cost_center`.

## Why

`kind='team'` collided head-on with the first-class **`sys_team`** object — a
`kind='team'` business unit walks the hierarchical `BusinessUnitGraphService`, while
`sys_team` is the flat better-auth collaboration grouping served by `TeamGraphService`.
Two "team" concepts with different semantics and no UI distinction; this was the single
largest source of the "teams vs business units feel redundant" ambiguity the addendum
set out to remove.

## Safety

- `kind` is a **display-only categorisation hint** ("does not change graph semantics").
- **Zero** `kind: 'team'` usages anywhere in the repo (seeds, showcase, tests) → no data migration.
- `bu-rename-consistency.test.ts` is scoped to labels and **explicitly excludes** `kind`, so it is unaffected.
- The `team` picklist labels are removed from the 4 generated locale bundles (en/zh-CN/ja-JP/es-ES), matching what `os i18n extract --merge` produces.

Changeset: `@objectstack/platform-objects` **minor** (schema narrowing, non-breaking in practice).

## Follow-ups (not in this PR)

- **PS-2 / D10** — relocate `nav_business_units` to the hierarchy-security capability + gate `nav_organizations`/`nav_invitations` on `multiOrgEnabled` (needs a `visible`/`requiresFeature` predicate on `NavigationItem` first; the nav-render side may touch the console repo).
- **PS-3 / D12** — `sys_user.primary_business_unit_id` projection for "pick people by BU".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
