### PR TITLE
fix(objectql): honor $searchFields override sent as a comma-string (ADR-0061)

### DIFF
--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -1916,7 +1916,7 @@ export class ObjectQL implements IDataEngine {
         const _searchFilter = expandSearchToFilter(_searchRaw, {
           fields: _findSchema.fields as any,
           searchableFields: (_findSchema as any).searchableFields,
-          requestedFields: Array.isArray(_reqFields) ? _reqFields : undefined,
+          requestedFields: _reqFields,
           displayField: (_findSchema as any).displayNameField,
         });
         if (_searchFilter) {

--- a/packages/objectql/src/search-filter.test.ts
+++ b/packages/objectql/src/search-filter.test.ts
@@ -55,6 +55,15 @@ describe('resolveSearchFields', () => {
     expect(f).toEqual(['industry']);
   });
 
+  it('accepts a comma-separated requestedFields string (URL param form)', () => {
+    const f = resolveSearchFields({
+      fields: accountFields,
+      searchableFields: ['name', 'industry', 'status'],
+      requestedFields: 'industry, status',
+    });
+    expect(f).toEqual(['industry', 'status']);
+  });
+
   it('ignores an override that resolves to nothing allowed (falls back)', () => {
     const f = resolveSearchFields({
       fields: accountFields,

--- a/packages/objectql/src/search-filter.ts
+++ b/packages/objectql/src/search-filter.ts
@@ -31,8 +31,10 @@ export interface ExpandSearchOptions {
   fields: Record<string, SearchFieldMeta>;
   /** Object-declared `searchableFields` (the canonical default set). */
   searchableFields?: string[];
-  /** Validated `$searchFields` override — intersected with the allowed set. */
-  requestedFields?: string[];
+  /** Validated `$searchFields` override — intersected with the allowed set.
+   *  Accepts an array or a comma-separated string (the form a URL query param
+   *  arrives as). */
+  requestedFields?: string | string[];
   /** Preferred display field, placed first in the auto-default. */
   displayField?: string;
 }
@@ -93,9 +95,12 @@ export function resolveSearchFields(opts: ExpandSearchOptions): string[] {
   const all = opts.fields || {};
   const declared = opts.searchableFields?.filter((f) => all[f]);
   const allowed = declared && declared.length > 0 ? declared : autoDefaultFields(all, opts.displayField);
-  if (opts.requestedFields && opts.requestedFields.length > 0) {
+  const requested = typeof opts.requestedFields === 'string'
+    ? opts.requestedFields.split(',').map((f) => f.trim()).filter(Boolean)
+    : opts.requestedFields;
+  if (requested && requested.length > 0) {
     const allowSet = new Set(allowed);
-    const validated = opts.requestedFields.filter((f) => allowSet.has(f));
+    const validated = requested.filter((f) => allowSet.has(f));
     if (validated.length > 0) return validated;
   }
   return allowed;


### PR DESCRIPTION
The $searchFields override (the view-level 'narrow search to these fields' signal list views send) arrives over REST/OData as a comma-separated STRING ('name,industry'), not an array. The engine only applied it when Array.isArray was true, so it was a silent no-op — search=tech&searchFields=name still searched the default fields. Coerce a string requestedFields to an array in resolveSearchFields (single seam); engine.find passes the raw value through. Verified e2e over HTTP: search 'tech' with searchFields=name → only Initech (name); searchFields=industry → the 4 Technology accounts (label→value). Unit test added. Pairs with #2134/#2142 and objectui #1872; closes the override path of ADR-0061 D1.