### PR TITLE
fix(showcase): register Mark Done action handler via inline body

### DIFF
--- a/examples/app-showcase/src/actions/index.ts
+++ b/examples/app-showcase/src/actions/index.ts
@@ -10,13 +10,37 @@ const task = 'showcase_task';
  * record header/more, related list, global nav).
  */
 
-/** script — inline handler, shown on each row and the record header. */
+/**
+ * script — inline sandboxed handler, shown on each row and the record header.
+ *
+ * The `body` (L2 sandboxed JS) is what makes this action *executable*: AppPlugin
+ * walks the bundle's actions on bind and only registers an engine handler for
+ * those carrying a `body` (or `target` -> bundle function). Without it the
+ * runtime has nothing to invoke and `POST /actions/showcase_task/showcase_mark_done`
+ * fails with "Action ... not found".
+ *
+ * It flips the dedicated `done` flag and `progress` rather than the `status`
+ * select on purpose: `status` is governed by the `task_status_flow`
+ * state-machine (only `in_review -> done` is a legal direct jump), so writing
+ * `status: 'done'` from a Backlog/To Do/In Progress row would be rejected. The
+ * `done` boolean is the completion flag that works from any state.
+ */
 export const MarkDoneAction = defineAction({
   name: 'showcase_mark_done',
   label: 'Mark Done',
   icon: 'check',
   objectName: task,
   type: 'script',
+  body: {
+    language: 'js',
+    source:
+      "var id = ctx.recordId || (ctx.record && ctx.record.id) || input.recordId;" +
+      "if (!id) throw new Error('No record to mark done');" +
+      "await ctx.api.object('showcase_task').update({ id: id, done: true, progress: 100 });" +
+      "return { ok: true, id: id };",
+    capabilities: ['api.write'],
+  },
+  successMessage: 'Task marked done.',
   // `record_section` so the Task Detail page's `record:quick_actions` bar
   // (which names this action) resolves it — the engine location-filters even
   // explicitly-named actions, mirroring the platform's own sys-user pages.


### PR DESCRIPTION
## Problem

Clicking **Mark Done** on a `showcase_task` record errored. The request
`POST /api/v1/actions/showcase_task/showcase_mark_done` returned HTTP 200 with
an error payload:

```json
{"success":true,"data":{"success":false,"error":"Action 'showcase_mark_done' on object '*' not found"}}
```

The `showcase_mark_done` action was declared `type: 'script'` but carried
**neither a `body` nor a `target` handler**. `AppPlugin` only registers an
engine handler for actions that have an inline `body` (or a `target` → bundle
function), so nothing was wired up. The dispatcher tried `showcase_task`, fell
back to the `'*'` wildcard, and surfaced the engine's "not found" — shown in the
UI as an error.

## Fix

Add an L2 sandboxed `body` to `MarkDoneAction` that flips the dedicated `done`
flag and sets `progress` to 100.

It deliberately **does not** write `status: 'done'`: the `task_status_flow`
state-machine only permits `in_review → done`, so a direct status write would be
rejected from Backlog / To Do / In Progress rows. Using the `done` boolean lets
the action succeed from any state. Also added `successMessage: 'Task marked done.'`.

## Verification

- **Browser (localhost:3000):** rebuilt bundle + restarted the showcase dev
  server (metadata hot-reload does not re-register action handlers — that only
  happens at bundle bind), clicked **Mark Done** → green **"Task marked done."**
  toast, no errors, clean console.
- **API regression:** ran the action on an *In Progress* task → `progress 45→100`,
  `done false→true`, `status` unchanged (no state-machine violation); test record
  restored afterward.
- `pnpm verify` green: `tsc --noEmit` clean + **22 tests passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)