### PR TITLE
fix(spec): make GanttConfigSchema forward-compatible via .passthrough()

### DIFF
--- a/.changeset/gantt-config-passthrough.md
+++ b/.changeset/gantt-config-passthrough.md
@@ -1,0 +1,15 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): make `GanttConfigSchema` forward-compatible via `.passthrough()`.
+
+The gantt renderer (objectui plugin-gantt) keeps adding view-config knobs
+(e.g. `lockField`, `defaultCollapsedDepth`) ahead of this schema. Without
+passthrough, the console — which validates the view config against a bundled
+copy of this schema before handing it to the renderer — strips any field not
+declared here, so every new renderer knob needs a spec release + console
+rebuild before it can take effect. Adding `.passthrough()` lets unknown fields
+flow through to the renderer, decoupling renderer releases from spec releases.
+Known fields keep their validation; the renderer still only reads what it
+understands.

--- a/packages/spec/src/ui/view.test.ts
+++ b/packages/spec/src/ui/view.test.ts
@@ -237,6 +237,20 @@ describe('GanttConfigSchema', () => {
     expect(() => GanttConfigSchema.parse(config)).not.toThrow();
     expect(GanttConfigSchema.parse(config)).toMatchObject({ parentField: 'parent_id', typeField: 'row_type' });
   });
+
+  it('should passthrough unknown renderer fields ahead of this schema', () => {
+    const config = {
+      startDateField: 'start_date',
+      endDateField: 'end_date',
+      titleField: 'name',
+      // Newer renderer knobs not yet declared here (e.g. objectui plugin-gantt).
+      lockField: 'is_locked',
+      defaultCollapsedDepth: 2,
+    };
+
+    expect(() => GanttConfigSchema.parse(config)).not.toThrow();
+    expect(GanttConfigSchema.parse(config)).toMatchObject({ lockField: 'is_locked', defaultCollapsedDepth: 2 });
+  });
 });
 
 describe('ListViewSchema', () => {

--- a/packages/spec/src/ui/view.zod.ts
+++ b/packages/spec/src/ui/view.zod.ts
@@ -427,7 +427,11 @@ export const GanttConfigSchema = lazySchema(() => z.object({
   ])).optional().describe('Fields to surface in the hover tooltip, in display order'),
   quickFilters: z.array(GanttQuickFilterSchema).optional().describe('Multi-select filter dropdowns rendered above the chart'),
   autoZoomToFilter: z.boolean().optional().describe('When true (default), filtering zooms the range to the filtered tasks'),
-}));
+// Forward-compatible: the gantt renderer (objectui plugin-gantt) keeps adding
+// config knobs (e.g. lockField / defaultCollapsedDepth) ahead of this schema.
+// Passthrough lets those extra fields reach the renderer instead of being
+// stripped here, so a renderer release no longer has to wait on a spec release.
+}).passthrough());
 
 /**
  * Navigation Mode Enum


### PR DESCRIPTION
## What

`GanttConfigSchema` (`packages/spec/src/ui/view.zod.ts`) is a closed `z.object` — it strips any field it doesn't explicitly declare. This change appends `.passthrough()` so unknown fields survive validation.

## Why

The gantt renderer (objectui `plugin-gantt`) keeps adding view-config knobs ahead of this schema — e.g. `lockField` / `defaultCollapsedDepth` from [objectui#1870](https://github.com/objectstack-ai/objectui/pull/1870), and previously `parentField`/`typeField` (#2030).

The console validates a view's `config.gantt` against a **bundled copy** of this schema before handing it to the renderer. So every field not declared here is silently dropped — meaning each new renderer knob requires a spec release **and** a console rebuild before it can take effect. Downstream this forces local `patch-package`-style patches that re-add `.passthrough()` to the bundled schema.

`.passthrough()` decouples renderer releases from spec releases: unknown fields flow through to the renderer (which still only reads what it understands), while all declared fields keep their validation.

## Tests

- New forward-compat case in `view.test.ts`: unknown fields (`lockField`, `defaultCollapsedDepth`) survive `parse()`.
- Full spec suite: 6602 passing. Typecheck clean.