### PR TITLE
fix: single-tenant audit follow-ups — member/invitation org optional + headOf org-scope (ADR-0057)

### DIFF
--- a/.changeset/fix-single-tenant-followup.md
+++ b/.changeset/fix-single-tenant-followup.md
@@ -1,0 +1,16 @@
+---
+"@objectstack/platform-objects": patch
+"@objectstack/plugin-sharing": patch
+---
+
+Single-tenant audit follow-ups (ADR-0057):
+
+- **`sys_member` / `sys_invitation`**: make `organization_id` optional (same class as the
+  sys_business_unit/sys_team fix #2178). Single-tenant has no org row and no auto-stamp;
+  multi-tenant still auto-stamps via OrgScopingPlugin with null-org rows hidden by
+  tenant-isolation RLS (fail-closed). Completes the org-scoped identity graph's
+  single-tenant consistency.
+- **`BusinessUnitGraphService.headOf()`**: add the missing `orgScope()` org filter (it
+  queries under SYSTEM_CTX, bypassing RLS, so the scope is the only isolation). Previously
+  `headOf(buId)` read a business unit's `manager_user_id` by id alone — a cross-organization
+  leak in multi-tenant. Now consistent with `descendants()`. +regression test.

--- a/packages/platform-objects/src/identity/sys-invitation.object.ts
+++ b/packages/platform-objects/src/identity/sys-invitation.object.ts
@@ -172,7 +172,10 @@ export const SysInvitation = ObjectSchema.create({
     
     organization_id: Field.lookup('sys_organization', {
       label: 'Organization',
-      required: true,
+      // Optional: single-tenant has no sys_organization row and no auto-stamp
+      // (org-scoping is multi-tenant-only). Multi-tenant: OrgScopingPlugin stamps it
+      // and tenant-isolation RLS hides null-org rows (fail-closed). ADR-0057 addendum.
+      required: false,
     }),
     
     email: Field.email({

--- a/packages/platform-objects/src/identity/sys-member.object.ts
+++ b/packages/platform-objects/src/identity/sys-member.object.ts
@@ -141,7 +141,10 @@ export const SysMember = ObjectSchema.create({
     
     organization_id: Field.lookup('sys_organization', {
       label: 'Organization',
-      required: true,
+      // Optional: single-tenant has no sys_organization row and no auto-stamp
+      // (org-scoping is multi-tenant-only). Multi-tenant: OrgScopingPlugin stamps it
+      // and tenant-isolation RLS hides null-org rows (fail-closed). ADR-0057 addendum.
+      required: false,
     }),
     
     user_id: Field.lookup('sys_user', {

--- a/packages/plugins/plugin-sharing/src/business-unit-graph.ts
+++ b/packages/plugins/plugin-sharing/src/business-unit-graph.ts
@@ -139,7 +139,7 @@ export class BusinessUnitGraphService implements IBusinessUnitGraphService {
     let row: any = null;
     try {
       const rows = await this.engine.find('sys_business_unit', {
-        where: { id: businessUnitId },
+        where: this.orgScope({ id: businessUnitId }),
         fields: ['id', 'manager_user_id'],
         limit: 1,
         context: SYSTEM_CTX,

--- a/packages/plugins/plugin-sharing/src/sharing-rule.test.ts
+++ b/packages/plugins/plugin-sharing/src/sharing-rule.test.ts
@@ -170,6 +170,14 @@ describe('BusinessUnitGraphService (recursive sys_business_unit)', () => {
     expect(await d.headOf('emea_sales')).toEqual('alice');
     expect(await d.headOf('emea_marketing')).toBeNull();
   });
+
+  it('headOf is org-scoped — does not leak a manager across organizations', async () => {
+    // 'foreign' is in org2; an org1-scoped service must not read its head.
+    const foreign = engine._tables.sys_business_unit.find((r: any) => r.id === 'foreign');
+    foreign.manager_user_id = 'mallory';
+    const d = new BusinessUnitGraphService({ engine: engine as any, organizationId: 'org1' });
+    expect(await d.headOf('foreign')).toBeNull();
+  });
 });
 
 describe('SharingRuleService', () => {


### PR DESCRIPTION
Follow-ups from the single-tenant audit you requested (after #2178).

## 1. `sys_member` / `sys_invitation` — `organization_id` optional

Same class as #2178 (BU/team): `required` org-id with no org row + no auto-stamp in single-tenant. These are better-auth org-flow objects so they're not *directly* reachable in single-tenant Setup, but this completes the org-scoped identity graph's single-tenant consistency. Multi-tenant still auto-stamps via OrgScopingPlugin; tenant-isolation RLS hides any null-org row (fail-closed).

## 2. `BusinessUnitGraphService.headOf()` — missing org isolation (real bug)

`headOf(buId)` queried `sys_business_unit` by **id alone** under `SYSTEM_CTX` (which bypasses RLS), while its sibling `descendants()` correctly uses `orgScope()`. So in **multi-tenant** a caller could read another organization's BU `manager_user_id` (cross-tenant leak). Fixed to use `orgScope()` + added a regression test (an org1-scoped service must not read an org2 BU's head).

## Audit result (the rest is clean)

The runtime is otherwise correct-by-design in single-tenant — verified: the wildcard `organization_id` RLS policies are **stripped** when org-scoping is absent (saw it live), and the `organization_id == tenantId` lookups are all guarded by `if (tenantId)` (fall back to self). No other actionable single-tenant breakage found.

Verified: `headOf` tests 2/2 pass locally; changed packages build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
