### PR TITLE
fix(showcase): hide Mark Done once the task is complete

### DIFF
--- a/examples/app-showcase/src/actions/index.ts
+++ b/examples/app-showcase/src/actions/index.ts
@@ -41,6 +41,14 @@ export const MarkDoneAction = defineAction({
     capabilities: ['api.write'],
   },
   successMessage: 'Task marked done.',
+  // Hide once the task is complete. Gate on `record.done` (the boolean this
+  // action sets) so the button vanishes after a successful click and stays
+  // hidden on finished records (the "why is it still here?" report). NOTE the
+  // `record.`-prefix: the ActionEngine evaluates a record-header action's
+  // `visible` against `{ record, recordId, … }` with fail-closed semantics, so
+  // a bare `done`/`status` throws (field not at top level) and silently hides
+  // the action. Single operand, too — the template path throws on `&&`/`||`.
+  visible: '!record.done',
   // `record_section` so the Task Detail page's `record:quick_actions` bar
   // (which names this action) resolves it — the engine location-filters even
   // explicitly-named actions, mirroring the platform's own sys-user pages.


### PR DESCRIPTION
Closes the last of the action-UX issues from the audit. Mark Done lingered on already-done records, and clicking it again was a silent no-op that still popped a success toast (the "why is it still here?" report).

## Fix

Gate the action: `visible: '!record.done'`. It hides on tasks whose `done` flag is set (which is exactly what this action sets), so the button disappears after a successful click and stays hidden on finished records.

### Why `record.`-prefixed (and a single operand)

This is the subtle part the first attempt got wrong:

- A record-header action's `visible` is filtered by `ActionEngine.getActionsForLocation`, which evaluates against the runner context `{ record, recordId, objectName, user }` with **fail-closed** semantics (`evaluateCondition(expr, { throwOnError: true })` → `catch` → hide). The record fields live under `record.`, so a **bare** `done` / `status` predicate is an undefined top-level variable → throws → the action is hidden on *every* record (active and done alike). `record.done` resolves correctly. (This matches the existing `record:alert` predicate in `task-detail.page.ts`, which uses `record.status`.)
- The renderer wraps `visible` as a `${...}` template whose evaluator throws on compound `&&` / `||`, so the predicate is kept atomic.

## Verification (in-browser, current console)

- Active task (`done=false`) → **Mark Done shows** (alongside Log Time).
- Click Mark Done → `done=true`, `progress=100` (status untouched, per the action's design).
- Reload → **Mark Done hidden** on the now-done record.
- Done seed task → hidden from the start.
- `pnpm verify` (app-showcase): typecheck + **30 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)