### PR TITLE
feat(cli): validate action visible/disabled predicates at build time

### DIFF
--- a/.changeset/validate-action-predicates.md
+++ b/.changeset/validate-action-predicates.md
@@ -1,0 +1,22 @@
+---
+"@objectstack/cli": minor
+"@objectstack/formula": patch
+---
+
+build: validate UI action `visible` / `disabled` predicates at compile time
+
+Extends the ADR-0032 build-time expression check to cover action `visible` and
+`disabled` predicates (stack-level and object-attached), evaluated record-scoped
+like validation rules. A record-header / row action's `visible` is evaluated by
+`ActionEngine` against `{ record, recordId, objectName, user, … }` with
+fail-closed semantics, so a **bare** field reference (`!done` instead of
+`!record.done`) throws at runtime and the action is **silently hidden on every
+record** — the trap behind the #2183 "Mark Done never hides" debugging hunt.
+`os build` now reports it as an error with the corrective `record.<field>`
+message instead of letting it ship.
+
+`@objectstack/formula`: `ctx` and `features` are added to the record-scope
+namespace roots (alongside the existing `user`, `data`, `context`, …) so the
+ambient globals real action predicates use (`record.id == ctx.user.id`,
+`features.multiOrgEnabled`) are not false-positives. Verified against the full
+monorepo build (every example + platform bundle still compiles clean).

--- a/packages/cli/src/utils/validate-expressions.test.ts
+++ b/packages/cli/src/utils/validate-expressions.test.ts
@@ -233,4 +233,58 @@ describe('validateStackExpressions (ADR-0032 build-time)', () => {
       expect(issues[0].severity).toBe('error');
     });
   });
+
+  describe('action visible/disabled predicates (record-scoped) — #2183 class', () => {
+    it('flags a bare-field `visible` on a stack action (the trap that hid Mark Done)', () => {
+      const issues = validateStackExpressions({
+        objects: [{ name: 'showcase_task', fields: { done: { type: 'boolean' }, status: { type: 'select' } } }],
+        actions: [{ name: 'mark_done', objectName: 'showcase_task', type: 'script', locations: ['record_header'], visible: '!done' }],
+      });
+      const v = issues.filter(i => i.where.includes("action 'mark_done' visible"));
+      expect(v).toHaveLength(1);
+      expect(v[0].severity).toBe('error');
+      expect(v[0].message).toMatch(/bare reference `done`/);
+    });
+
+    it('accepts the record-qualified form', () => {
+      const issues = validateStackExpressions({
+        objects: [{ name: 'showcase_task', fields: { done: { type: 'boolean' } } }],
+        actions: [{ name: 'mark_done', objectName: 'showcase_task', type: 'script', visible: '!record.done' }],
+      });
+      expect(issues).toHaveLength(0);
+    });
+
+    it('accepts ambient globals (ctx / features / user) used by platform actions', () => {
+      const issues = validateStackExpressions({
+        objects: [{ name: 'sys_user', fields: { id: { type: 'text' }, email_verified: { type: 'boolean' } } }],
+        actions: [{ name: 'verify_email', objectName: 'sys_user', visible: 'record.id == ctx.user.id && record.email_verified == false && features.x != true' }],
+      });
+      expect(issues).toHaveLength(0);
+    });
+
+    it('flags a bare-field `disabled` predicate but ignores a boolean `disabled`', () => {
+      const bad = validateStackExpressions({
+        objects: [{ name: 'crm_lead', fields: { status: { type: 'select' } } }],
+        actions: [{ name: 'park', objectName: 'crm_lead', disabled: 'status == "converted"' }],
+      });
+      expect(bad.filter(i => i.where.includes("action 'park' disabled"))).toHaveLength(1);
+
+      const ok = validateStackExpressions({
+        objects: [{ name: 'crm_lead', fields: { status: { type: 'select' } } }],
+        actions: [{ name: 'park', objectName: 'crm_lead', disabled: true }],
+      });
+      expect(ok).toHaveLength(0);
+    });
+
+    it('validates an action attached to an object (record scope = parent object)', () => {
+      const issues = validateStackExpressions({
+        objects: [{
+          name: 'showcase_task',
+          fields: { done: { type: 'boolean' } },
+          actions: [{ name: 'mark_done', type: 'script', visible: '!done' }],
+        }],
+      });
+      expect(issues.filter(i => i.where.includes("action 'mark_done' visible"))).toHaveLength(1);
+    });
+  });
 });

--- a/packages/cli/src/utils/validate-expressions.ts
+++ b/packages/cli/src/utils/validate-expressions.ts
@@ -10,8 +10,9 @@
  * agent `validate_expression` tool exactly.
  *
  * Scope (v1): flow predicates (start/decision `config.condition` + edge
- * `condition`) and object validation-rule / formula predicates. Each error is
- * located (flow/object + node/edge/field) with a corrective message.
+ * `condition`), object validation-rule / formula predicates, and UI action
+ * `visible` / `disabled` predicates. Each error is located (flow/object/action
+ * + node/edge/field) with a corrective message.
  */
 
 import { validateExpression } from '@objectstack/formula';
@@ -157,6 +158,38 @@ export function validateStackExpressions(stack: AnyRec): ExprIssue[] {
         for (const e of res.errors) issues.push({ where: fieldWhere, message: e.message, source: e.source, severity: 'error' });
         for (const w of res.warnings) issues.push({ where: fieldWhere, message: w.message, source: w.source, severity: 'warning' });
       }
+    }
+  }
+
+  // ── Action `visible` / `disabled` predicates ───────────────────────
+  // Record-scoped, same as validation rules: a record-header / row action's
+  // `visible` is evaluated by ActionEngine against `{ record, recordId,
+  // objectName, user, … }` with fail-closed semantics, so a BARE field ref
+  // (`done` instead of `record.done`) throws and the action is silently hidden
+  // on every record (the trap behind the #2183 "Mark Done never hides" hunt).
+  // Flagging it here turns that into a build error with a corrective message.
+  // `disabled` may be a boolean (skip) or a predicate (check).
+  const seenActions = new Set<string>();
+  const checkAction = (where: string, action: AnyRec, objectName?: string): void => {
+    const obj = objectName
+      ?? (typeof action.objectName === 'string' ? action.objectName : undefined)
+      ?? (typeof action.object === 'string' ? action.object : undefined);
+    const name = typeof action.name === 'string' ? action.name : '?';
+    const key = `${obj ?? ''}:${name}`;
+    if (seenActions.has(key)) return; // de-dup (actions are merged onto objects AND kept top-level)
+    seenActions.add(key);
+    check(`${where} · action '${name}' visible`, action.visible, obj, 'record');
+    if (typeof action.disabled !== 'boolean') {
+      check(`${where} · action '${name}' disabled`, action.disabled, obj, 'record');
+    }
+  };
+  for (const action of asArray(stack.actions)) {
+    checkAction('stack', action);
+  }
+  for (const obj of objects) {
+    const objectName = typeof obj.name === 'string' ? obj.name : undefined;
+    for (const action of asArray(obj.actions)) {
+      checkAction(`object '${objectName}'`, action, objectName);
     }
   }
 

--- a/packages/formula/src/cel-engine.ts
+++ b/packages/formula/src/cel-engine.ts
@@ -53,6 +53,9 @@ const SCOPE_ROOTS = [
   'record', 'previous', 'input', 'output', 'os', 'vars', 'variables',
   'automation', 'context', 'args', 'item', 'env', 'user', 'step', 'result',
   'trigger', 'event', 'payload', 'data', 'params', 'config', 'settings',
+  // UI action / predicate context (ActionEngine, renderers): the current
+  // record plus ambient globals exposed to `visible`/`disabled` predicates.
+  'ctx', 'features',
 ] as const;
 
 /**


### PR DESCRIPTION
The build-time guard that would have caught the #2183 bug at `os build` instead of at click-time. Closes the post-mortem follow-up from the Mark Done / action-UX work.

## Why

A record-header / row action's `visible` is evaluated by `ActionEngine.getActionsForLocation` against `{ record, recordId, objectName, user, … }` with **fail-closed** semantics (`evaluateCondition(expr, { throwOnError: true })` → `catch` → hide). So a **bare** field reference — `!done` instead of `!record.done` — is an undefined top-level identifier, throws, and the action is **silently hidden on every record**. That's exactly the trap that sent the #2183 debugging down a long path: the predicate *looked* fine and the failure was invisible (no error, just a missing button).

The ADR-0032 build validator already detects "bare reference in a record-scoped formula" — but its v1 scope was flows + validation-rule / field-formula predicates only. **Action predicates weren't covered**, so a bare-field `visible` shipped clean.

## What

- `@objectstack/cli` — `validateStackExpressions` now also checks action `visible` / `disabled` predicates (stack-level and object-attached), record-scoped, with the same corrective `record.<field>` message. `disabled: <boolean>` is skipped; `disabled: <predicate>` is checked. Actions merged onto objects *and* kept top-level are de-duped.
- `@objectstack/formula` — adds `ctx` and `features` to the record-scope namespace roots, so the ambient globals real action predicates legitimately use (`record.id == ctx.user.id`, `features.multiOrgEnabled`) are not false-positives. (Consistent with the file's stated "declare more roots — a missing root is a build-breaking false positive" philosophy.)

## Effect

```ts
// Before: builds clean, button silently hidden on every record at runtime.
// After:  os build → error: bare reference `done` — did you mean `record.done`?
defineAction({ name: 'mark_done', objectName: 'showcase_task', visible: '!done' })
```

## Verification

- **Full monorepo build (`turbo build`, 76 tasks)**: every example + platform bundle still compiles clean — no false positives (incl. platform-objects' `ctx.user` / `features` predicates and the showcase's `!record.done`).
- **Tests**: `@objectstack/formula` 201 pass; `@objectstack/cli` 496 pass, incl. 5 new cases (bare-field action `visible` flagged; `record.`-qualified accepted; `ctx`/`features`/`user` accepted; bare `disabled` flagged but boolean `disabled` ignored; object-attached action validated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)