### PR TITLE
feat(identity): Org Chart tree view for sys_business_unit

### DIFF
--- a/.changeset/bu-org-chart-tree-view.md
+++ b/.changeset/bu-org-chart-tree-view.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/platform-objects": minor
+---
+
+feat(identity): add an Org Chart tree view to `sys_business_unit`
+
+`sys_business_unit` is already a self-referencing hierarchy
+(`parent_business_unit_id`, ADR-0057 D2) but Setup only exposed flat grids. Adds
+an `org_chart` list view (`type: 'tree'`) that renders the hierarchy as an
+indented, expand/collapse tree-grid, listed first so it's the default tab. No
+schema change — the parent pointer and graph traversal already existed; this only
+surfaces them. The `active` / `inactive` / `by_kind` / `all` grids stay for
+search, filter, and bulk edit.

--- a/packages/platform-objects/src/identity/sys-business-unit.object.ts
+++ b/packages/platform-objects/src/identity/sys-business-unit.object.ts
@@ -33,6 +33,24 @@ export const SysBusinessUnit = ObjectSchema.create({
   compactLayout: ['name', 'kind', 'parent_business_unit_id', 'manager_user_id'],
 
   listViews: {
+    // Org chart — the hierarchy view. Surfaces the self-referencing
+    // `parent_business_unit_id` tree (ADR-0057 D2) as an indented, expand/
+    // collapse tree-grid. Listed first so it's the default tab; the grids
+    // below stay for search / filter / bulk edit.
+    org_chart: {
+      type: 'tree',
+      name: 'org_chart',
+      label: 'Org Chart',
+      data: { provider: 'object', object: 'sys_business_unit' },
+      columns: ['name', 'kind', 'manager_user_id', 'active'],
+      tree: {
+        parentField: 'parent_business_unit_id',
+        labelField: 'name',
+        fields: ['kind', 'manager_user_id', 'active'],
+        defaultExpandedDepth: 1,
+      },
+      sort: [{ field: 'name', order: 'asc' }],
+    },
     active: {
       type: 'grid',
       name: 'active',


### PR DESCRIPTION
## What

Adds an **Org Chart** tree view to the `sys_business_unit` system object so the org hierarchy is visible as an indented, expand/collapse tree-grid in Setup — not just flat grids.

## Why

`sys_business_unit` is **already a self-referencing hierarchy** (`parent_business_unit_id`, ADR-0057 D2) with real BFS graph traversal (`BusinessUnitGraphService.descendants()` / `expandUsers()`), and that tree is load-bearing for authz: `unit` / `unit_and_below` scopes, the `business_unit` sharing recipient, and `unit_subtree_user_ids` rollup all cascade through it. But Setup only surfaced flat grids — the structure users come to this page to see was invisible.

This is a **UI-only, non-breaking** change: no schema change (the parent pointer and graph already exist), it just renders them.

## Changes

- `packages/platform-objects/src/identity/sys-business-unit.object.ts`: new `org_chart` list view (`type: 'tree'`, `tree.parentField: 'parent_business_unit_id'`, `defaultExpandedDepth: 1`), listed **first** so it's the default tab.
- The `active` / `inactive` / `by_kind` / `all` grids are kept — better for search, filter, and bulk edit.

Uses the `tree` view type added in #2184; renderer ships in objectui `@object-ui/plugin-tree`.

## Verification

`platform-objects` typechecks clean. The same tree view pattern was verified end-to-end in the showcase console (#2184) — `parentField` here is the real `parent_business_unit_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
