### PR TITLE
fix(release): push version tags in one atomic push (avoid commit_refs race)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,11 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+          # publish (pnpm run release) ends in scripts/release-publish.sh,
+          # which pushes all new version tags in ONE atomic git push. This
+          # pre-empts changesets/action's own concurrent per-tag pushes, which
+          # otherwise race GitHub's ref backend (remote: fatal error in
+          # commit_refs) and reject ~half the tags on a large fixed-group bump (#2191).
           publish: pnpm run release
           version: pnpm run version
           commit: 'chore: version packages'

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean": "turbo run clean && rm -rf dist",
     "setup": "pnpm install && pnpm --filter @objectstack/spec build",
     "version": "changeset version",
-    "release": "pnpm run build && bash scripts/build-console.sh && changeset publish",
+    "release": "pnpm run build && bash scripts/build-console.sh && bash scripts/release-publish.sh",
     "docs:dev": "pnpm --filter @objectstack/docs dev",
     "docs:build": "pnpm --filter @objectstack/docs build",
     "docs:start": "pnpm --filter @objectstack/docs start",

--- a/scripts/release-publish.sh
+++ b/scripts/release-publish.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# release-publish.sh — npm publish + atomic git-tag push for the Release workflow.
+#
+# Why this exists (the bug it fixes):
+#   `changeset publish` publishes every package to npm and creates a local
+#   annotated git tag (`<pkg>@<version>`) for each one. changesets/action
+#   then pushes those tags — but it fires one `git push origin <tag>` per tag
+#   *concurrently* (Promise.all). With this monorepo's large Changesets "fixed"
+#   group (~70+ packages all bumping in lockstep), that burst of simultaneous
+#   ref-creation pushes races on GitHub's ref backend, which responds with
+#   `remote: fatal error in commit_refs` and rejects a chunk of the tags. npm
+#   publishing has already fully succeeded by then, yet the job fails and the
+#   rejected version tags never make it to the remote (#2191).
+#
+# The fix:
+#   Push ALL new tags ourselves in a SINGLE atomic `git push origin --tags`
+#   immediately after `changeset publish`. One push = one ref transaction, so
+#   there is no concurrency to race. By the time changesets/action runs its own
+#   per-tag pushes, every tag already exists on the remote at the same SHA, so
+#   each of those pushes is a harmless no-op ("Everything up-to-date").
+#
+#   git push auth comes from the persisted actions/checkout credentials. The
+#   tags themselves are already created by `changeset publish` (which configures
+#   the CI git identity); this script only pushes them. Run as the `publish:`
+#   command of changesets/action (see
+#   .github/workflows/release.yml) so the atomic push happens before the action
+#   pushes tags itself.
+set -euo pipefail
+
+# Publish to npm and create the local version tags.
+changeset publish
+
+# Push every new tag in one atomic transaction (see header). --tags pushes ALL
+# local tags regardless of reachability; --follow-tags would push nothing here
+# since this is a bare push with no branch ref attached.
+git push origin --tags


### PR DESCRIPTION
## Problem

The Release job failed on #2191 with `remote: fatal error in commit_refs` and ~half the version tags `[remote rejected] ... (failure)`.

**Root cause:** `changeset publish` publishes every package to npm and creates one git tag per package. `changesets/action` then pushes those tags by firing **one `git push origin <tag>` per tag concurrently** (every `[command]/usr/bin/git push` in the log shares the same millisecond timestamp). With our large Changesets `fixed` group (~73 packages bumping in lockstep), that burst of simultaneous ref-creation pushes races GitHub's ref backend → `fatal error in commit_refs` → ~half the tags rejected. **npm publishing had already fully succeeded** by then, so the job fails *after* the artifacts are live.

Concrete fallout on `10.0.0`: all 73 packages published to npm, but only 54/73 git tags reached the remote — 19 are missing and no future release run will recreate them (changeset only tags what it publishes).

> Note: the follow-up run (#2193) went green only because everything was already on npm, so it published nothing and pushed no tags. The bug is masked, not fixed, and recurs on the next multi-package bump.

## Fix

Route the publish command through `scripts/release-publish.sh`:

```sh
changeset publish
git push origin --tags
```

All new tags go up in a **single atomic `git push`** = one ref transaction, so there's no concurrency to race. The action's subsequent per-tag pushes become harmless no-ops (every tag already exists on the remote at the same SHA).

## Files
- `scripts/release-publish.sh` — new, documented wrapper (publish + atomic tag push)
- `package.json` — `release` script now ends in the wrapper instead of bare `changeset publish`
- `.github/workflows/release.yml` — comment explaining why

## Not covered here
Backfilling the 19 `10.0.0` tags already missing from the remote is a separate one-time op (these packages are published, so changeset won't re-tag them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)