### PR TITLE
docs(datasource): external-datasource federation guide + objectstack-data skill rule (ADR-0062)

### DIFF
--- a/content/docs/guides/external-datasources.mdx
+++ b/content/docs/guides/external-datasources.mdx
@@ -1,0 +1,173 @@
+---
+title: External Datasources (Federation)
+description: Declare an external database as a datasource and query its tables as ObjectStack objects — visible, auto-connected, and queryable with zero app code.
+---
+
+# External Datasources (Federation)
+
+ObjectStack can treat a **mature external database** — one it does not own — as a
+read-only (or, with explicit opt-in, writable) datasource, and expose its tables
+as normal objects. This is *federation*: the data stays in the remote database;
+ObjectStack queries it live through the same ObjectQL / REST surface as native
+objects.
+
+The headline guarantee: **declare an external datasource and it is visible,
+auto-connected, validated at boot, and queryable — with no application code.**
+
+<Callout type="info">
+This guide is about reading/writing the *live* remote tables (federation). To
+*copy* rows into ObjectStack-owned tables instead, see seed data / data sync. For
+the plain multi-datasource routing of **managed** databases ObjectStack owns, see
+[Database Drivers](/docs/guides/driver-configuration).
+</Callout>
+
+## 1. Declare the datasource
+
+Use `defineDatasource` with `schemaMode: 'external'`. The `external` block carries
+the federation policy (write gate, boot validation, credentials).
+
+```typescript
+import { defineDatasource } from '@objectstack/spec/data';
+
+export const Warehouse = defineDatasource({
+  name: 'warehouse',
+  label: 'Analytics Warehouse (Postgres)',
+  driver: 'postgres',
+  schemaMode: 'external',          // ObjectStack never runs DDL here
+  config: { host: 'db.internal', port: 5432, database: 'analytics', user: 'readonly' },
+  external: {
+    allowWrites: false,            // read-only (the default)
+    credentialsRef: 'secret:warehouse/password', // resolved from the secret store
+    validation: { onMismatch: 'fail', checkOnBoot: true },
+  },
+  active: true,
+});
+```
+
+Register it on the stack (array or name-keyed map both work):
+
+```typescript
+export default defineStack({
+  datasources: [Warehouse],
+  // ...
+});
+```
+
+`schemaMode`:
+
+| Mode | Meaning |
+| --- | --- |
+| `managed` (default) | ObjectStack owns the schema — DDL + migrations allowed. |
+| `external` | A mature external DB — **DDL forbidden**; a schema mismatch **fails** boot. |
+| `validate-only` | Like `external`, but a mismatch **warns** instead of failing. |
+
+## 2. Bind objects to the remote tables
+
+A federated object sets `datasource` to the external datasource and declares its
+remote binding in `external`. When the remote table or column names differ from
+your object/field names, map them with `external.remoteName` / `external.remoteSchema`
+and `external.columnMap`.
+
+```typescript
+export const Customer = ObjectSchema.create({
+  name: 'ext_customer',
+  datasource: 'warehouse',
+  external: {
+    remoteName: 'customers',       // remote TABLE name (object name may differ)
+    // remoteSchema: 'public',     // optional schema/namespace (pg/mysql)
+    // columnMap: { cust_region: 'region' }, // remoteColumn → localField
+  },
+  fields: {
+    id: { type: 'text' },
+    name: { type: 'text' },
+    region: { type: 'text' },
+  },
+});
+```
+
+That's it. `GET /api/v1/data/ext_customer` now returns live rows from the remote
+`customers` table; filters (`?region=EU`) push down to the remote query.
+
+<Callout type="warn">
+**Do not set `field.columnName` on an external object.** For federated objects the
+driver's query pipeline ignores `field.columnName`; `external.columnMap`
+(`remoteColumn → localField`) is the single, authoritative column mapping.
+`os build` / `os validate` rejects `field.columnName` on an external object with a
+clear error (ADR-0062 D7). Managed objects are unaffected.
+</Callout>
+
+## 3. Auto-connect — no `onEnable` needed
+
+At boot the runtime builds a live driver for the datasource, connects it, and
+registers its federated objects' read metadata — automatically. You do **not**
+need an `onEnable` hook or `ctx.drivers.register(...)`.
+
+A declared datasource auto-connects when it is **meaningfully addressed**:
+
+1. it is **external** (`schemaMode !== 'managed'`), **or**
+2. an object **explicitly** binds to it via `object.datasource === <name>`, **or**
+3. it sets **`autoConnect: true`**.
+
+A `managed` datasource that nothing explicitly binds to (for example one that is
+only referenced by a `datasourceMapping` rule) stays *metadata-only* — visible in
+Setup, but not connected — so existing apps are unchanged. Use `autoConnect: true`
+to opt such a datasource into a live connection at boot.
+
+<Callout type="info">
+**Escape hatch.** An `onEnable` hook calling `ctx.drivers.register(driver)` is
+still supported for advanced cases — e.g. a driver built dynamically at runtime
+from external configuration. Auto-connect is idempotent with it (whichever
+registers the datasource name first wins), so the two never conflict.
+</Callout>
+
+A connected external datasource is also visible in **Setup → Datasources** (stamped
+`origin: code`, read-only in the UI) and via `GET /api/v1/datasources` and
+`GET /api/v1/meta/datasource`, where an admin can run the "Sync objects" wizard.
+
+## 4. Credentials
+
+Never inline a password. Put a reference in `external.credentialsRef` and store the
+secret in the secret store (the same `SecretBinder` / `ICryptoProvider` the
+runtime-admin "Add Datasource" wizard uses). The credential is resolved to
+cleartext **at connect, before the driver is built**.
+
+Resolution is **fail-closed**: if a `credentialsRef` is declared but no secret store
+is configured, or the secret cannot be resolved/decrypted, the datasource is left
+**unconnected with a clear error** — never connected without the credential. For a
+code-defined external datasource with `validation.onMismatch: 'fail'` this fails
+the boot; otherwise it degrades with a warning. (Credential-less drivers such as
+SQLite simply have no `credentialsRef`.)
+
+## 5. Writes (double opt-in)
+
+Federation is read-only by default. To allow writes, **both** the datasource and the
+object must opt in:
+
+```typescript
+defineDatasource({ /* ... */ external: { allowWrites: true } });   // datasource gate
+ObjectSchema.create({ /* ... */ external: { remoteName: 'orders', writable: true } }); // object gate
+```
+
+With either gate off, insert/update/delete on the federated object is rejected.
+
+## 6. Analytics over external objects
+
+Dashboards and reports over a federated object aggregate against the **correct**
+remote table/columns: the analytics layer routes such queries through the driver's
+physical-table resolution (honoring `remoteName` / `remoteSchema`) rather than the
+object name, so they never hit the wrong table.
+
+## Multi-tenant hosts
+
+A self-hosted single-environment runtime connects external datasources out of the
+box. A multi-tenant host can bind a stricter **connect policy** (egress allow-list /
+per-tenant quota) that is consulted before any connection is opened — the same
+single connect path, no fork. This is a host-composition concern; the open-core
+default allows all connects (subject to the gating above).
+
+## See also
+
+- [Database Drivers](/docs/guides/driver-configuration) — managed multi-datasource routing.
+- [Datasource reference](/docs/references/data/datasource) — every `defineDatasource` field.
+- The `examples/app-showcase` `showcase_external` datasource — a runnable end-to-end demo.
+- ADR-0015 (federation spec) and ADR-0062 (external-datasource runtime).

--- a/content/docs/guides/meta.json
+++ b/content/docs/guides/meta.json
@@ -33,6 +33,7 @@
     "contracts",
     "project-scoping",
     "driver-configuration",
+    "external-datasources",
     "kernel-services",
     "runtime-services",
     "data-flow",

--- a/skills/objectstack-data/SKILL.md
+++ b/skills/objectstack-data/SKILL.md
@@ -198,6 +198,7 @@ For comprehensive documentation with incorrect/correct examples:
 - **[Validation Rules](./rules/validation.md)** — All validation types, script inversion, severity levels
 - **[Index Strategy](./rules/indexing.md)** — btree/gin/gist/fulltext, composite indexes, partial indexes
 - **[Lifecycle Hooks](./rules/hooks.md)** — Hook quick reference (→ see [references/data-hooks.md](./references/data-hooks.md) for the full 14-event guide)
+- **[Datasources & Federation](./rules/datasources.md)** — `defineDatasource`, external/federated objects (`remoteName`/`columnMap`), auto-connect gating, credentials; ❌ no `field.columnName` on external objects
 
 ---
 

--- a/skills/objectstack-data/rules/datasources.md
+++ b/skills/objectstack-data/rules/datasources.md
@@ -1,0 +1,76 @@
+# Datasources & Federation
+
+A **datasource** (`defineDatasource`, a `*.datasource.ts` metadata file) is a
+connection to a data store. Objects route to one via their `datasource` field
+(default: `'default'`). Most apps need only the `default` datasource; declare more
+to read/write a **separate** or **external** database.
+
+Full field reference: `node_modules/@objectstack/spec/src/data/datasource.zod.ts`.
+Narrative guide: `content/docs/guides/external-datasources.mdx`.
+
+## `schemaMode` — who owns the schema
+
+| Mode | Meaning |
+|:--|:--|
+| `managed` (default) | ObjectStack owns the schema; DDL + migrations allowed. |
+| `external` | A mature external DB ObjectStack does **not** own; DDL forbidden; boot mismatch **fails**. |
+| `validate-only` | Like `external`, but a mismatch **warns** instead of failing boot. |
+
+`external` settings are required iff `schemaMode !== 'managed'` (and forbidden otherwise).
+
+## Federated (external) objects
+
+An object on an external datasource binds to its remote table via `external`:
+
+```typescript
+ObjectSchema.create({
+  name: 'ext_customer',
+  datasource: 'warehouse',
+  external: {
+    remoteName: 'customers',        // remote TABLE (object name may differ)
+    // remoteSchema: 'public',      // optional schema/namespace (pg/mysql)
+    // columnMap: { cust_region: 'region' }, // remoteColumn → localField
+    // writable: true,              // per-object write opt-in (see below)
+  },
+  fields: { id: { type: 'text' }, name: { type: 'text' }, region: { type: 'text' } },
+});
+```
+
+### ✅ / ❌ Column mapping (ADR-0062 D7)
+
+- ✅ Map remote columns with **`external.columnMap`** (`remoteColumn → localField`).
+- ❌ **Never set `field.columnName` on an external object.** The driver's query
+  pipeline ignores it for federated objects, so it is a silent dual-source trap.
+  `os build` / `os validate` **rejects** it with a clear error. (`field.columnName`
+  on **managed** objects is unaffected.)
+
+## Auto-connect (no `onEnable`)
+
+A declared datasource is built into a live driver, connected, and its federated
+objects' read metadata registered **automatically at boot** — no `onEnable` /
+`ctx.drivers.register`. It auto-connects when **meaningfully addressed**:
+
+1. it is **external** (`schemaMode !== 'managed'`), **or**
+2. an object **explicitly** binds via `object.datasource === <name>`, **or**
+3. it sets **`autoConnect: true`**.
+
+A `managed` datasource that nothing explicitly binds (e.g. only referenced by a
+`datasourceMapping` rule) stays **metadata-only** — visible but not connected — so
+existing apps are unchanged. Set `autoConnect: true` to force a live connection.
+
+> `onEnable` + `ctx.drivers.register(driver)` remains supported only as an escape
+> hatch for drivers built dynamically at runtime; it is idempotent with auto-connect.
+
+## Credentials — fail-closed
+
+Never inline a password. Use `external.credentialsRef` and store the secret in the
+secret store; it is resolved **at connect, before the driver is built**. A declared
+`credentialsRef` that cannot be resolved/decrypted (or no secret store configured)
+leaves the datasource **unconnected with a clear error** — never connected without
+the credential.
+
+## Writes — double opt-in
+
+Federation is read-only by default. To write, **both** gates must be on:
+`datasource.external.allowWrites: true` **and** the object's `external.writable: true`.
+With either off, insert/update/delete on the federated object is rejected.


### PR DESCRIPTION
## Docs + skill for the ADR-0062 federation runtime

Follow-up to the merged ADR-0062 epic (#2163). The headline capability — **declare an external datasource → it's visible, auto-connected, validated, and queryable with zero app code** — had **no narrative documentation**. This adds it.

> Nothing was *stale* (no doc told users to use the now-removed `onEnable` bridge), and the new `datasource.autoConnect` field already auto-appears in the **generated** `references/data/datasource.mdx` (from the spec `.describe()`) — not hand-edited. This PR is purely the missing *narrative*.

### Added
- **`content/docs/guides/external-datasources.mdx`** — a how-to guide:
  - `defineDatasource({ schemaMode: 'external', external: {...} })`
  - object binding via `datasource` + `external.remoteName`/`remoteSchema`/`columnMap`
  - **auto-connect** (D2 gate: external / explicit `object.datasource` / `autoConnect:true`; a mapping-only managed datasource stays metadata-only) — **no `onEnable` needed**
  - `onEnable` + `ctx.drivers.register` as the dynamic-driver **escape hatch** only
  - **`credentialsRef` fail-closed** (D3)
  - **❌ no `field.columnName` on external objects → use `external.columnMap`** (D7, build-rejected)
  - writes double opt-in; analytics over external; multi-tenant connect policy
  - Listed in the **Integration** nav after *Database Drivers*. **Browser-verified rendering** (TOC + Callouts + code blocks).
- **`skills/objectstack-data/rules/datasources.md`** (+ linked from `SKILL.md`) — the same rules in the authoring skill, leading with the `columnMap`-not-`columnName` guardrail.

### Not changed
- The generated datasource reference (auto-includes `autoConnect`).
- No code change → docs/skills only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)