### PR TITLE
fix(security): invalidate metadata-derived caches on runtime metadata change

### DIFF
--- a/packages/plugins/plugin-security/src/security-plugin.test.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.test.ts
@@ -1365,3 +1365,41 @@ describe('RLSCompiler — SQL→CEL deprecation bridge (ADR-0058 D1)', () => {
     expect(warned.length).toBe(0);
   });
 });
+
+describe('SecurityPlugin – metadata-change cache invalidation', () => {
+  it('clears metadata-derived caches when metadata changes at runtime', async () => {
+    const plugin = new SecurityPlugin();
+    let watchCb: (() => void) | undefined;
+    const metadata = {
+      watch: (_type: string, cb: () => void) => {
+        watchCb = cb;
+        return { unsubscribe: vi.fn() };
+      },
+    };
+    const ctx: any = {
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      registerService: vi.fn(),
+      hook: vi.fn(),
+      getService: vi.fn().mockImplementation((name: string) => {
+        if (name === 'manifest') return { register: vi.fn() };
+        if (name === 'metadata') return metadata;
+        if (name === 'objectql') return { registerMiddleware: vi.fn() };
+        return undefined;
+      }),
+    };
+    await plugin.init(ctx);
+    await plugin.start(ctx);
+
+    expect(typeof watchCb).toBe('function');
+
+    (plugin as any).fieldNamesCache.set('crm_account', new Set(['name']));
+    (plugin as any).tenancyDisabledCache.set('crm_account', true);
+    (plugin as any).cbpRelCache.set('crm_account', null);
+
+    watchCb!();
+
+    expect((plugin as any).fieldNamesCache.size).toBe(0);
+    expect((plugin as any).tenancyDisabledCache.size).toBe(0);
+    expect((plugin as any).cbpRelCache.size).toBe(0);
+  });
+});

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -108,6 +108,8 @@ export class SecurityPlugin implements Plugin {
    */
   private metadata: any = null;
   private ql: any = null;
+  /** Unsubscribe handle for metadata-change cache invalidation (runtime metadata edits). */
+  private metadataWatch: { unsubscribe: () => void } | null = null;
   /** ADR-0055: cache the resolved master-detail relation per controlled_by_parent object. */
   private cbpRelCache = new Map<string, { fk: string; master: string } | null>();
   private dbLoader?: (names: string[]) => Promise<PermissionSet[]>;
@@ -211,6 +213,19 @@ export class SecurityPlugin implements Plugin {
     this.ql = ql;
     this.logger = ctx.logger;
     this.rlsCompiler.setLogger?.(ctx.logger);
+
+    // Invalidate metadata-derived caches when object/field metadata changes
+    // at runtime (Studio / AI authoring). Without this they go stale until
+    // restart — even single-node. With a cluster pub/sub driver the
+    // metadata.changed event propagates cross-node, so peers invalidate too.
+    const md: any = this.metadata;
+    if (typeof md?.watch === 'function') {
+      this.metadataWatch = md.watch('*', () => {
+        this.fieldNamesCache.clear();
+        this.tenancyDisabledCache.clear();
+        this.cbpRelCache.clear();
+      });
+    }
 
     // Probe for OrgScopingPlugin presence. When registered, its
     // `init()` exposes itself as the `org-scoping` service. We capture
@@ -764,7 +779,8 @@ export class SecurityPlugin implements Plugin {
   }
 
   async destroy(): Promise<void> {
-    // No cleanup needed
+    this.metadataWatch?.unsubscribe();
+    this.metadataWatch = null;
   }
 
   /**


### PR DESCRIPTION
## Why
`SecurityPlugin` 的 `fieldNamesCache` / `tenancyDisabledCache` / `cbpRelCache` 从元数据惰性填充,但**从不失效**。"元数据在 kernel 生命周期内不变"的假设在**运行时改元数据**(Studio / AI Studio 在线建模)时被打破——schema/RLS 会读到旧值直到重启,**单节点也如此**。

## What
- 在 `start()` 订阅 `metadata.watch('*')`,元数据变更时清这三个缓存。
- 通用开源机制(对可选的 `watch` API 做了 guard)。配合 cluster pub/sub 驱动时,`metadata.changed` 会跨节点传播 → 这也是 EE 多节点跨节点缓存失效的铺底(见 cloud ADR-0018)。
- 新增针对性单测;本地验证全绿(plugin-security 123 passing)。

## 影响
- 单节点:修了一个 latent 正确性 bug(运行时改元数据后缓存陈旧)。
- 多节点:为 EE 的跨节点失效提供本地钩子(跨节点激活由 EE 的 cluster 驱动完成,不在本 PR)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)