### PR TITLE
feat(runtime): add GET /ready readiness probe for graceful rolling restarts

### DIFF
--- a/packages/runtime/src/http-dispatcher.ready.test.ts
+++ b/packages/runtime/src/http-dispatcher.ready.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { HttpDispatcher } from './http-dispatcher.js';
+
+function kernel(state: string): any {
+  return {
+    getState: () => state,
+    getService: () => undefined,
+    getServiceAsync: async () => undefined,
+  };
+}
+const ctx: any = {};
+
+describe('HttpDispatcher — GET /ready readiness probe', () => {
+  it('returns 200 when the kernel is running', async () => {
+    const res = await new HttpDispatcher(kernel('running')).dispatch('GET', '/ready', undefined, undefined, ctx);
+    expect(res.handled).toBe(true);
+    expect(res.response.status).toBe(200);
+    expect(res.response.body.data.state).toBe('running');
+  });
+
+  it('returns 503 while booting or shutting down', async () => {
+    for (const state of ['idle', 'initializing', 'stopping', 'stopped']) {
+      const res = await new HttpDispatcher(kernel(state)).dispatch('GET', '/ready', undefined, undefined, ctx);
+      expect(res.response.status).toBe(503);
+    }
+  });
+});

--- a/packages/runtime/src/http-dispatcher.ts
+++ b/packages/runtime/src/http-dispatcher.ts
@@ -699,7 +699,7 @@ export class HttpDispatcher {
         if (!this.enforceMembership) return null;
 
         // Control-plane paths — never gated by project membership.
-        const skipPaths = ['/auth', '/cloud', '/health', '/discovery'];
+        const skipPaths = ['/auth', '/cloud', '/health', '/ready', '/discovery'];
         if (skipPaths.some(p => path.startsWith(p))) return null;
 
         // Public share-link resolve/messages — the token IS the authorisation,
@@ -3074,6 +3074,20 @@ export class HttpDispatcher {
                     uptime: typeof process !== 'undefined' ? process.uptime() : undefined,
                 }),
             };
+        }
+
+        // 0b2. Readiness Endpoint (GET /ready) — k8s / load-balancer readiness probe.
+        // 200 only when the kernel is fully running; 503 while booting
+        // (idle/initializing) or shutting down (stopping/stopped) so a load
+        // balancer stops routing to this replica BEFORE in-flight requests are
+        // drained and the server closes (graceful rolling restart).
+        if (cleanPath === '/ready' && method === 'GET') {
+            const state: string = typeof (this.kernel as any)?.getState === 'function'
+                ? (this.kernel as any).getState()
+                : 'running';
+            return state === 'running'
+                ? { handled: true, response: this.success({ status: 'ready', state }) }
+                : { handled: true, response: this.error('Service not ready', 503, { state }) };
         }
 
         // 0c. Plan-A diagnostics removed; the seed-replay and oauth2/callback


### PR DESCRIPTION
## Why
The dispatcher exposed only `/health` (always 200). Multi-replica deployments need a **readiness** signal distinct from liveness: a load balancer must stop routing to a replica **before** its in-flight requests are force-closed on shutdown, and must not route to a replica that is still booting.

## What
- `GET /ready` → **200** only when `kernel.getState() === 'running'`; **503** while booting (`idle`/`initializing`) or shutting down (`stopping`/`stopped`).
- Added `/ready` to the membership-skip paths (like `/health`) so it's reachable without auth/environment scoping.
- Pairs with the **existing** in-flight drain in `HonoHttpServer.close()` (P1-3): `/ready` 503 → LB drains → in-flight finish → close.
- Unit test added (200 running / 503 booting+stopping). Verified locally: strict DTS build of `@objectstack/runtime` + tests green.

## Scope
Generic open-core production-hygiene mechanism (benefits any deployment, single- or multi-node). No cluster dependency. Part of the multi-node readiness groundwork (cloud ADR-0018).

🤖 Generated with [Claude Code](https://claude.com/claude-code)