### PR TITLE
docs(skill,showcase): SDUI styling (ADR-0065) — skill section + renderable showcase page

### DIFF
--- a/examples/app-showcase/objectstack.config.ts
+++ b/examples/app-showcase/objectstack.config.ts
@@ -22,7 +22,7 @@ import { ChartGalleryDashboard, OpsDashboard } from './src/dashboards/index.js';
 import { ShowcaseTaskDataset, ShowcaseProjectDataset } from './src/datasets/index.js';
 import { allReports } from './src/reports/index.js';
 import { allActions } from './src/actions/index.js';
-import { ComponentGalleryPage, ProjectWorkspacePage, ProjectDetailPage, TaskWorkbenchPage, TaskTriagePage, TaskBoardPage, TaskCalendarPage, TaskGalleryPage, TaskSchedulePage, TaskTimelinePage, TaskMapPage, TaskAllViewsPage, ActiveProjectsPage, TaskDetailPage, AccountDetailPage, ReviewQueuePage, NewProjectWizardPage, MyWorkPage, SettingsPage } from './src/pages/index.js';
+import { ComponentGalleryPage, ProjectWorkspacePage, ProjectDetailPage, TaskWorkbenchPage, TaskTriagePage, TaskBoardPage, TaskCalendarPage, TaskGalleryPage, TaskSchedulePage, TaskTimelinePage, TaskMapPage, TaskAllViewsPage, ActiveProjectsPage, TaskDetailPage, AccountDetailPage, ReviewQueuePage, NewProjectWizardPage, MyWorkPage, SettingsPage, StylingGalleryPage } from './src/pages/index.js';
 import { allFlows } from './src/flows/index.js';
 import { allWebhooks } from './src/webhooks/index.js';
 import { allHooks } from './src/hooks/index.js';
@@ -156,7 +156,7 @@ export default defineStack({
   apps: [ShowcaseApp],
   portals: allPortals,
   views: [TaskViews, ProjectViews, InquiryViews, BusinessUnitViews],
-  pages: [ComponentGalleryPage, ProjectWorkspacePage, ProjectDetailPage, TaskWorkbenchPage, TaskTriagePage, TaskBoardPage, TaskCalendarPage, TaskGalleryPage, TaskSchedulePage, TaskTimelinePage, TaskMapPage, TaskAllViewsPage, ActiveProjectsPage, TaskDetailPage, AccountDetailPage, ReviewQueuePage, NewProjectWizardPage, MyWorkPage, SettingsPage],
+  pages: [ComponentGalleryPage, ProjectWorkspacePage, ProjectDetailPage, TaskWorkbenchPage, TaskTriagePage, TaskBoardPage, TaskCalendarPage, TaskGalleryPage, TaskSchedulePage, TaskTimelinePage, TaskMapPage, TaskAllViewsPage, ActiveProjectsPage, TaskDetailPage, AccountDetailPage, ReviewQueuePage, NewProjectWizardPage, MyWorkPage, SettingsPage, StylingGalleryPage],
   dashboards: [ChartGalleryDashboard, OpsDashboard],
   books: allBooks,
   datasets: [ShowcaseTaskDataset, ShowcaseProjectDataset],

--- a/examples/app-showcase/src/apps/index.ts
+++ b/examples/app-showcase/src/apps/index.ts
@@ -64,6 +64,7 @@ export const ShowcaseApp = App.create({
       icon: 'layout',
       children: [
         { id: 'nav_gallery', type: 'page', pageName: 'showcase_component_gallery', label: 'Component Gallery', icon: 'layout-template' },
+        { id: 'nav_styling_gallery', type: 'page', pageName: 'showcase_styling_gallery', label: 'Styling (ADR-0065)', icon: 'palette' },
         { id: 'nav_project_workspace', type: 'page', pageName: 'showcase_project_workspace', label: 'New Project + Tasks', icon: 'folder-plus' },
         // ADR-0047 interface mode: same object as nav_tasks, curated surface.
         { id: 'nav_task_workbench', type: 'page', pageName: 'showcase_task_workbench', label: 'Task Workbench', icon: 'sliders-horizontal' },

--- a/examples/app-showcase/src/pages/index.ts
+++ b/examples/app-showcase/src/pages/index.ts
@@ -13,6 +13,7 @@ export { ReviewQueuePage } from './review-queue.page.js';
 export { NewProjectWizardPage } from './new-project-wizard.page.js';
 export { MyWorkPage } from './my-work.page.js';
 export { SettingsPage } from './settings.page.js';
+export { StylingGalleryPage } from './styling-gallery.page.js';
 export {
   TaskBoardPage,
   TaskCalendarPage,

--- a/examples/app-showcase/src/pages/styling-gallery.page.ts
+++ b/examples/app-showcase/src/pages/styling-gallery.page.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { definePage } from '@objectstack/spec/ui';
+
+/**
+ * Styling Gallery (ADR-0065) — the canonical example of the SDUI scoped-styling
+ * model. A pricing page composed from generic blocks (`flex` / `element:text` /
+ * `element:button`) that each carry a `responsiveStyles` object (per-breakpoint
+ * CSS-property maps) with **design-token values** (`var(--space-*)`,
+ * `var(--surface)`, `var(--brand)`, `hsl(var(--primary))`, …) — NO `className`.
+ *
+ * objectui's `SchemaRenderer` compiles each node's `responsiveStyles` to
+ * **id-scoped CSS** injected as an unlayered `<style>` at render: build-independent
+ * (arbitrary values + tokens pass through verbatim), collision-free (per-node
+ * scope beats base utilities without `@layer` games), responsive-correct
+ * (breakpoint maps → generated `@media`, never `md:` classes). This is the
+ * preferred way to style a metadata-authored page; see the objectstack-ui skill
+ * "Styling (ADR-0065)" section.
+ *
+ * Note: child nodes go in `properties.children` (the renderer hoists `properties`
+ * to schema level at render); `responsiveStyles`/`id` are top-level envelope fields.
+ */
+
+/** One checklist line: an accent-coloured check + the label. */
+function feature(label: string): any {
+  return {
+    id: `feat_${label}`,
+    type: 'flex',
+    responsiveStyles: { large: { display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' } },
+    properties: {
+      children: [
+        { id: `feat_${label}_chk`, type: 'element:text', responsiveStyles: { large: { color: 'hsl(var(--primary))', fontWeight: '700', lineHeight: '1.5' } }, properties: { content: '✓' } },
+        { id: `feat_${label}_lbl`, type: 'element:text', responsiveStyles: { large: { fontSize: '14px', color: 'var(--text-strong)', lineHeight: '1.5' } }, properties: { content: label } },
+      ],
+    },
+  };
+}
+
+/** A plan column — a styled `flex` box (no opinionated page:card). */
+function planCard(o: { name: string; price: string; period: string; tagline: string; features: string[]; cta: string; popular?: boolean }): any {
+  return {
+    id: `plan_${o.name}`,
+    type: 'flex',
+    responsiveStyles: {
+      large: {
+        display: 'flex', flexDirection: 'column', gap: 'var(--space-4)',
+        padding: 'var(--space-6)', borderRadius: 'var(--radius-xl)',
+        backgroundColor: 'var(--surface)',
+        border: o.popular ? '1px solid hsl(var(--primary))' : '1px solid var(--hairline)',
+        boxShadow: o.popular ? '0 0 0 3px hsl(var(--primary) / 0.25), var(--shadow-lg)' : 'var(--shadow-sm)',
+      },
+      small: { padding: 'var(--space-4)', gap: 'var(--space-3)' },
+    },
+    properties: {
+      children: [
+        ...(o.popular
+          ? [{ id: `plan_${o.name}_badge`, type: 'element:text', responsiveStyles: { large: { alignSelf: 'flex-start', fontSize: '12px', fontWeight: '600', color: 'var(--brand-foreground)', backgroundColor: 'var(--brand)', padding: '2px 10px', borderRadius: '999px' } }, properties: { content: 'Most popular' } }]
+          : []),
+        { id: `plan_${o.name}_name`, type: 'element:text', responsiveStyles: { large: { fontSize: '13px', fontWeight: '600', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.06em' } }, properties: { content: o.name } },
+        {
+          id: `plan_${o.name}_price_row`, type: 'flex',
+          responsiveStyles: { large: { display: 'flex', alignItems: 'baseline', gap: 'var(--space-2)' } },
+          properties: {
+            children: [
+              { id: `plan_${o.name}_price`, type: 'element:text', responsiveStyles: { large: { fontSize: '40px', fontWeight: '700', color: 'var(--text-strong)', fontVariantNumeric: 'tabular-nums' }, small: { fontSize: '32px' } }, properties: { content: o.price } },
+              { id: `plan_${o.name}_period`, type: 'element:text', responsiveStyles: { large: { fontSize: '13px', color: 'var(--text-muted)' } }, properties: { content: o.period } },
+            ],
+          },
+        },
+        { id: `plan_${o.name}_tagline`, type: 'element:text', responsiveStyles: { large: { fontSize: '13px', color: 'var(--text-muted)', minHeight: '34px' } }, properties: { content: o.tagline } },
+        { id: `plan_${o.name}_divider`, type: 'flex', responsiveStyles: { large: { height: '1px', backgroundColor: 'var(--hairline)', margin: 'var(--space-1) 0' } }, properties: { children: [] } },
+        ...o.features.map(feature),
+        { id: `cta_${o.name}`, type: 'element:button', responsiveStyles: { large: { marginTop: 'auto', width: '100%' } }, properties: { label: o.cta, variant: o.popular ? 'primary' : 'secondary', size: 'large' } },
+      ],
+    },
+  };
+}
+
+export const StylingGalleryPage = definePage({
+  name: 'showcase_styling_gallery',
+  label: 'Styling (ADR-0065)',
+  type: 'app',
+  template: 'default',
+  kind: 'full',
+  isDefault: false,
+  regions: [
+    {
+      name: 'main',
+      width: 'full',
+      components: [
+        {
+          id: 'styling_root',
+          type: 'flex',
+          responsiveStyles: {
+            large: { minHeight: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 'var(--space-8)', padding: 'var(--space-12) var(--space-6)' },
+            small: { padding: 'var(--space-8) var(--space-4)' },
+          },
+          properties: {
+            children: [
+              {
+                id: 'styling_header', type: 'flex',
+                responsiveStyles: { large: { display: 'flex', flexDirection: 'column', gap: 'var(--space-3)', textAlign: 'center', maxWidth: '42rem' } },
+                properties: {
+                  children: [
+                    { id: 'styling_title', type: 'element:text', responsiveStyles: { large: { fontSize: '40px', fontWeight: '700', letterSpacing: '-0.02em', color: 'var(--text-strong)' }, small: { fontSize: '30px' } }, properties: { content: 'Plans & Pricing' } },
+                    { id: 'styling_subtitle', type: 'element:text', responsiveStyles: { large: { fontSize: '16px', color: 'var(--text-muted)' } }, properties: { content: 'Styled entirely with responsiveStyles + design tokens — zero Tailwind class strings (ADR-0065).' } },
+                  ],
+                },
+              },
+              {
+                id: 'plan_grid', type: 'flex',
+                responsiveStyles: {
+                  large: { display: 'grid', gridTemplateColumns: 'repeat(4, minmax(0,1fr))', gap: 'var(--space-6)', width: '100%', maxWidth: '80rem', alignItems: 'stretch', marginTop: 'var(--space-4)' },
+                  medium: { gridTemplateColumns: 'repeat(2, minmax(0,1fr))' },
+                  small: { gridTemplateColumns: '1fr' },
+                },
+                properties: {
+                  children: [
+                    planCard({ name: 'Free', price: '$0', period: 'forever', tagline: 'For evaluating and small personal projects.', features: ['1 environment', '3 users', 'AI online development', '7-day audit retention'], cta: 'Get started' }),
+                    planCard({ name: 'Solo', price: '$29', period: 'per month', tagline: 'For solo builders and indie makers.', features: ['2 environments', '10 users', 'Custom domains', 'Stronger AI model', '30-day audit retention'], cta: 'Upgrade to Solo', popular: true }),
+                    planCard({ name: 'Team', price: '$99', period: 'per month', tagline: 'For teams shipping real apps.', features: ['2 environments', '100 users', 'Custom domains', '30-day audit retention'], cta: 'Upgrade to Team' }),
+                    planCard({ name: 'Business', price: '$299', period: 'per month', tagline: 'For organizations that need SSO and scale.', features: ['4 environments', '500 users', 'SSO / SAML', '1-year audit retention'], cta: 'Upgrade to Business' }),
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+});

--- a/skills/objectstack-ui/SKILL.md
+++ b/skills/objectstack-ui/SKILL.md
@@ -562,6 +562,9 @@ which contain components.
 |:---------------------|:----|
 | `page:header`        | Title + subtitle + breadcrumb + inline `actions: Action[]` |
 | `page:card`          | Bordered/un-bordered card with `body: Component[]` |
+| `flex`               | Generic styleable box (`properties.children`) — the workhorse for custom layout; style via `responsiveStyles` (see Styling below) |
+| `element:text`       | Text node — `properties.content`; style via `responsiveStyles` |
+| `element:button`     | Button — `properties.label` + `variant`/`size` + optional `action` |
 | `record:highlights`  | Salesforce highlights panel — strip of key fields |
 | `record:path`        | Stage progress bar driven by a status field |
 | `record:related`     | Related-list (child records via lookup) |
@@ -629,6 +632,67 @@ export const LeadDetailPage = definePage({
 > **Actions in header** — pass full `Action` objects into
 > `page:header.properties.actions`; do **not** create a sibling action node.
 > The header renders them inline in the action slot.
+
+### Styling a page (ADR-0065) — `responsiveStyles`, NOT `className`
+
+To style a metadata-authored block, give it a **`responsiveStyles`** object — a
+per-breakpoint map of CSS properties. The renderer compiles each styled node to
+**id-scoped CSS** at render time. **Do NOT put Tailwind classes in `className`**
+expecting them to render: Tailwind is compiled at the *renderer's* build over the
+*renderer's* source, never over your metadata, so a class only happens to work if
+objectui already uses it — arbitrary classes (`text-[27px]`, `bg-[#1a2b3c]`,
+`grid-cols-7`) silently do nothing. `responsiveStyles` has no such trap (values
+are compiled from your data at render).
+
+Rules:
+- **`responsiveStyles` and `id` are top-level** envelope fields; **child nodes go
+  in `properties.children`** (the renderer hoists `properties` to schema level).
+- Every styled node **needs a stable `id`** (the CSS is scoped to it).
+- **Values should be design tokens** for consistency: spacing `var(--space-1..12)`,
+  radius `var(--radius)` / `var(--radius-xl)`, shadow `var(--shadow-sm|md|lg)`,
+  colors `var(--surface)` / `var(--surface-sunken)` / `var(--text-strong)` /
+  `var(--text-muted)` / `var(--brand)` / `var(--brand-foreground)` /
+  `var(--hairline)`, or `hsl(var(--primary))` etc. (theme tokens track light/dark).
+- **Responsive lives in the breakpoint maps** — `large` (base, desktop-first),
+  then `medium` / `small` / `xsmall` as `max-width` overrides. **Never** author
+  `md:`-style variant classes.
+- **Compose from generic styleable blocks** — `flex`, `element:text`,
+  `element:button` — and style each block's root. (`page:card` etc. are fine for
+  structure but style what you control.)
+
+```typescript
+// A styled pricing card — every block carries responsiveStyles + tokens.
+{
+  id: 'plan_solo', type: 'flex',
+  responsiveStyles: {
+    large: {
+      display: 'flex', flexDirection: 'column', gap: 'var(--space-4)',
+      padding: 'var(--space-6)', borderRadius: 'var(--radius-xl)',
+      backgroundColor: 'var(--surface)', border: '1px solid hsl(var(--primary))',
+      boxShadow: '0 0 0 3px hsl(var(--primary) / 0.25), var(--shadow-lg)',
+    },
+    small: { padding: 'var(--space-4)', gap: 'var(--space-3)' },  // responsive via the model
+  },
+  properties: {
+    children: [
+      { id: 'plan_solo_price', type: 'element:text',
+        responsiveStyles: { large: { fontSize: '40px', fontWeight: '700', color: 'var(--text-strong)' }, small: { fontSize: '32px' } },
+        properties: { content: '$29' } },
+      { id: 'cta_solo', type: 'element:button',
+        responsiveStyles: { large: { marginTop: 'auto', width: '100%' } },  // pin CTA to card bottom
+        properties: { label: 'Upgrade', variant: 'primary', size: 'large' } },
+    ],
+  },
+}
+```
+
+Why this model: it's **build-independent** (no Tailwind compile dependency),
+**collision-free** (per-node scoped, beats base utilities without `@layer`
+games), and **responsive-correct** (breakpoint maps → generated `@media`). The
+spec field is `PageComponentSchema.responsiveStyles` (`@objectstack/spec`,
+`ResponsiveStylesSchema`). Full worked example:
+`examples/app-showcase/src/pages/styling-gallery.page.ts` (the "Styling
+(ADR-0065)" nav entry). See [ADR-0065](../../docs/adr/0065-sdui-styling-model.md).
 
 ---
 


### PR DESCRIPTION
Closes the authoring + demonstration gap for **ADR-0065** (SDUI scoped styling). The mechanism (objectstack-ai/objectui#1912) and spec field (#2214) merged; this makes it **usable** (skill) and **demonstrated** (showcase).

## 1. `objectstack-ui` skill — the AI-author contract

The skill had **zero styling guidance** — so an AI authoring a page either left it unstyled or invented `className` (the exact footgun ADR-0065 exists to kill). Adds a **"Styling (ADR-0065)"** section under Pages:
- style via `responsiveStyles` (per-breakpoint CSS maps), **NOT** `className` — with the explicit "arbitrary Tailwind classes silently do nothing" warning;
- `responsiveStyles`/`id` top-level, children in `properties.children`;
- design-token values (`var(--space-*)`, `var(--surface)`, `var(--brand)`, …);
- responsive via breakpoint maps (`large→medium→small`), never `md:`;
- compose from generic styleable blocks; + a worked card example.

Also adds `flex` / `element:text` / `element:button` to the Component Catalogue.

## 2. Renderable showcase page

`examples/app-showcase/src/pages/styling-gallery.page.ts` — a real `definePage` (`type: 'app'`) pricing page styled **entirely** via `responsiveStyles` + tokens (zero `className`), wired into nav ("Styling (ADR-0065)") + `objectstack.config`.

## Verification

- **Typechecks clean** against the merged spec (`definePage` accepts `responsiveStyles`; `properties.children` is the spec shape).
- **Browser-verified end-to-end** through the real merged `SchemaRenderer`: the exact page schema renders to **89 per-node scoped `<style>` tags**; the `$29` price computes `font-size: 40px` (unlayered scoped beats layered `text-sm`); "Most popular" ring, bottom-aligned CTAs, responsive 4→2→1 grid. Screenshot in the linked thread.

(The showcase's local Console is pinned to an older objectui, so verification used a runner at the merged source — faithful to the real renderer.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)