### PR TITLE
fix(objectql): findData 返回真实 total/hasMore (#2212)

### DIFF
--- a/.changeset/finddata-pagination-total.md
+++ b/.changeset/finddata-pagination-total.md
@@ -1,0 +1,20 @@
+---
+"@objectstack/objectql": patch
+---
+
+fix(objectql): return the real `total`/`hasMore` from `findData` (#2212)
+
+`ObjectStackProtocolImplementation.findData` previously returned placeholder
+pagination metadata: `total` was always the **page** length and `hasMore` was
+always `false`. Front-end tables therefore believed every result set was a
+single page and never requested records past the first batch (e.g. row 51+ was
+unreachable).
+
+For a normal limited query it now runs `engine.count()` over the same `where` to
+get the true match total and derives `hasMore` from `offset + page length < total`.
+`engine.count()` only honors `where`, so `search`/`distinct` queries skip the
+count and fall back to a page-local estimate (a full page implies there may be
+more) instead of reporting a wrong total. Unlimited queries return the full set,
+whose length already is the total. The aggregate/group branch now reports the
+full group count as `total` with `hasMore` reflecting whether the client-side
+slice dropped any groups.

--- a/packages/objectql/src/protocol-data.test.ts
+++ b/packages/objectql/src/protocol-data.test.ts
@@ -16,6 +16,7 @@ describe('ObjectStackProtocolImplementation - Data Operations', () => {
         mockEngine = {
             find: vi.fn().mockResolvedValue([]),
             findOne: vi.fn().mockResolvedValue(null),
+            count: vi.fn().mockResolvedValue(0),
         };
         protocol = new ObjectStackProtocolImplementation(mockEngine);
     });
@@ -153,6 +154,64 @@ describe('ObjectStackProtocolImplementation - Data Operations', () => {
                     total: 1,
                 }),
             );
+        });
+
+        // ───────────────────────────────────────────────────────────
+        // Pagination metadata (issue #2212): with a `limit`, `total` must be
+        // the match total (via engine.count), not the page size; `hasMore`
+        // must reflect whether more pages remain.
+        // ───────────────────────────────────────────────────────────
+
+        it('returns the real match total (not the page size) when a limit is present', async () => {
+            mockEngine.find.mockResolvedValue(Array.from({ length: 100 }, (_, i) => ({ id: `r${i}` })));
+            mockEngine.count.mockResolvedValue(3125);
+
+            const result = await protocol.findData({ object: 'task', query: { $top: 100, $skip: 0 } });
+
+            expect(mockEngine.count).toHaveBeenCalledWith('task', expect.objectContaining({ where: undefined }));
+            expect(result.total).toBe(3125);
+            expect(result.hasMore).toBe(true);
+        });
+
+        it('forwards the same where filter to engine.count', async () => {
+            mockEngine.find.mockResolvedValue([{ id: 'r1' }]);
+            mockEngine.count.mockResolvedValue(42);
+
+            await protocol.findData({ object: 'task', query: { $top: 10, filter: { status: 'open' } } });
+
+            expect(mockEngine.count).toHaveBeenCalledWith('task', expect.objectContaining({ where: { status: 'open' } }));
+        });
+
+        it('reports hasMore=false on the last page', async () => {
+            // offset 3120, 5 returned, total 3125 → 3120 + 5 === 3125 → no more.
+            mockEngine.find.mockResolvedValue(Array.from({ length: 5 }, (_, i) => ({ id: `r${i}` })));
+            mockEngine.count.mockResolvedValue(3125);
+
+            const result = await protocol.findData({ object: 'task', query: { $top: 100, $skip: 3120 } });
+
+            expect(result.total).toBe(3125);
+            expect(result.hasMore).toBe(false);
+        });
+
+        it('does NOT call engine.count when no limit is given (full result set)', async () => {
+            mockEngine.find.mockResolvedValue([{ id: 't1' }, { id: 't2' }]);
+
+            const result = await protocol.findData({ object: 'task', query: {} });
+
+            expect(mockEngine.count).not.toHaveBeenCalled();
+            expect(result.total).toBe(2);
+            expect(result.hasMore).toBe(false);
+        });
+
+        it('skips count for search queries and estimates hasMore from a full page', async () => {
+            // engine.count() can't reproduce a $search, so we must not call it; a
+            // full page (length === limit) implies there may be more.
+            mockEngine.find.mockResolvedValue(Array.from({ length: 10 }, (_, i) => ({ id: `r${i}` })));
+
+            const result = await protocol.findData({ object: 'task', query: { $top: 10, $search: 'foo' } });
+
+            expect(mockEngine.count).not.toHaveBeenCalled();
+            expect(result.hasMore).toBe(true);
         });
     });
 

--- a/packages/objectql/src/protocol.ts
+++ b/packages/objectql/src/protocol.ts
@@ -2164,26 +2164,59 @@ export class ObjectStackProtocolImplementation implements ObjectStackProtocol {
                 aggregations: options.aggregations,
                 context: options.context,
             } as any);
-            // Apply limit client-side (EngineAggregateOptions doesn't carry limit)
+            // Apply limit client-side (EngineAggregateOptions doesn't carry limit).
+            // `records` is the full grouped set, so its length IS the real total
+            // and `hasMore` follows from whether the slice dropped any groups.
             const limited = typeof options.limit === 'number' && options.limit > 0
                 ? records.slice(0, options.limit)
                 : records;
             return {
                 object: request.object,
                 records: limited,
-                total: limited.length,
-                hasMore: false,
+                total: records.length,
+                hasMore: limited.length < records.length,
             };
         }
 
         const records = await this.engine.find(request.object, options);
-        // Spec: FindDataResponseSchema — only `records` is returned.
-        // OData `value` adaptation (if needed) is handled in the HTTP dispatch layer.
+        // Pagination metadata. When a `limit` is present the response is a single
+        // page, so `records.length` is the page size — NOT the match total. Run a
+        // count over the same `where` so the client can render total pages and know
+        // whether more pages remain (true server-side pagination). Without a limit
+        // the full result set is returned, so its length already IS the total.
+        //
+        // engine.count() only honors `where`; a `search`/`distinct` query can't be
+        // reproduced by it, so for those we skip the count and fall back to a
+        // page-local estimate (a full page implies there may be more) rather than
+        // reporting a wrong total.
+        const pageLimit = typeof options.limit === 'number' && options.limit > 0 ? options.limit : undefined;
+        const pageOffset = typeof options.offset === 'number' && options.offset > 0 ? options.offset : 0;
+        let total = records.length;
+        let hasMore = false;
+        if (pageLimit !== undefined) {
+            const countable = options.search == null && options.distinct == null;
+            if (countable) {
+                try {
+                    total = await this.engine.count(request.object, {
+                        where: options.where,
+                        context: options.context,
+                    } as any);
+                } catch {
+                    // engine.count() has its own find().length fallback; if it still
+                    // throws, degrade to a page-local total rather than failing the list.
+                    total = pageOffset + records.length;
+                }
+                hasMore = pageOffset + records.length < total;
+            } else {
+                hasMore = records.length === pageLimit;
+                total = pageOffset + records.length + (hasMore ? 1 : 0);
+            }
+        }
         return {
             object: request.object,
             records,
-            total: records.length,
-            hasMore: false
+            total,
+            hasMore,
         };
     }
 


### PR DESCRIPTION
Closes #2212

## 问题
`ObjectStackProtocolImplementation.findData` 返回的分页元数据是占位值:
- `total` 永远等于**本页**记录数,而非匹配总数
- `hasMore` 恒为 `false`

因此前端表格认为结果集永远只有一页,永远不会请求第一批之后的记录(例如第 51 条及以后无法翻到)。REST 路由 `/api/v1/data/:object` 直接把该结果原样返回给前端,问题就此暴露。

## 修复
`packages/objectql/src/protocol.ts` `findData`:

- **普通查询**:当带 `limit` 时,响应是单页,`records.length` 是页大小而非总数。对相同的 `where` 跑一次 `engine.count()` 得到真实 `total`,并由 `offset + 本页长度 < total` 推导 `hasMore`,实现真正的服务端分页。`engine.count()` 只认 `where`,无法复现 `search`/`distinct`,这类查询退化为页内估计(满页即可能有更多)而非给出错误总数。不带 `limit` 时返回全量,长度即总数。
- **聚合/分组分支**:原先 slice 到 `limit` 却把 slice 后的长度当 total、`hasMore=false`。改为以完整分组数为 `total`,`hasMore` 取决于 slice 是否丢弃了分组。

## 测试
`packages/objectql/src/protocol-data.test.ts` 新增 5 个分页用例,**39/39 全部通过**。

### 真机验证(天顺 EHR,同一 3125 行对象)
| `$skip` | 修复前 | 修复后 |
|---|---|---|
| 0   | total=50, hasMore=false | 50 行, total=3125, hasMore=true |
| 100 | total=50, hasMore=false | 50 行(#101–150), total=3125, hasMore=true |
| 3100 | — | 25 行, total=3125, hasMore=false |
| 3125 | — | 0 行, total=3125, hasMore=false |

> 前端配套改动见 objectui 仓库 PR(ObjectGrid 服务端分页 + DataTable manual pagination)。