### PR TITLE
feat(authz): ADR-0066 D1 — capability registry (sys_capability records)

### DIFF
--- a/packages/plugins/plugin-security/src/bootstrap-system-capabilities.test.ts
+++ b/packages/plugins/plugin-security/src/bootstrap-system-capabilities.test.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { bootstrapSystemCapabilities, KNOWN_CAPABILITIES } from './bootstrap-system-capabilities.js';
+
+/** Minimal in-memory ql for sys_capability seeding. */
+function makeQl() {
+  const rows: any[] = [];
+  return {
+    rows,
+    async find(object: string, q: any) {
+      if (object !== 'sys_capability') return [];
+      const where = q?.where ?? {};
+      return rows.filter((r) => Object.entries(where).every(([k, v]) => r[k] === v));
+    },
+    async insert(object: string, data: any) {
+      if (object !== 'sys_capability') return null;
+      rows.push({ ...data });
+      return { id: data.id };
+    },
+    async update(object: string, data: any) {
+      if (object !== 'sys_capability') return;
+      const r = rows.find((x) => x.id === data.id);
+      if (r) Object.assign(r, data);
+    },
+  };
+}
+
+describe('bootstrapSystemCapabilities (ADR-0066 D1 back-compat seed)', () => {
+  it('seeds the curated platform capabilities as records (idempotent)', async () => {
+    const ql = makeQl();
+    const r1 = await bootstrapSystemCapabilities(ql, []);
+    expect(r1.seeded).toBe(KNOWN_CAPABILITIES.length);
+    // every known capability is now a row with managed_by=platform + active
+    for (const cap of KNOWN_CAPABILITIES) {
+      const row = ql.rows.find((x) => x.name === cap.name);
+      expect(row).toBeDefined();
+      expect(row.managed_by).toBe('platform');
+      expect(row.active).toBe(true);
+      expect(row.scope).toBe(cap.scope);
+    }
+    // re-run → no new inserts (idempotent)
+    const r2 = await bootstrapSystemCapabilities(ql, []);
+    expect(r2.seeded).toBe(0);
+    expect(ql.rows.length).toBe(KNOWN_CAPABILITIES.length);
+  });
+
+  it('derives extra capabilities referenced by permission sets', async () => {
+    const ql = makeQl();
+    await bootstrapSystemCapabilities(ql, [{ systemPermissions: ['manage_users', 'export_data', 'approve_invoice'] }]);
+    expect(ql.rows.find((x) => x.name === 'export_data')).toBeDefined();
+    expect(ql.rows.find((x) => x.name === 'approve_invoice')).toBeDefined();
+    // org-scoped known capability keeps its scope
+    expect(ql.rows.find((x) => x.name === 'manage_org_users')?.scope).toBe('org');
+  });
+
+  it('marks manage_org_users as org-scoped and the rest platform', () => {
+    const org = KNOWN_CAPABILITIES.find((c) => c.name === 'manage_org_users');
+    expect(org?.scope).toBe('org');
+    expect(KNOWN_CAPABILITIES.filter((c) => c.scope === 'platform').length).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/packages/plugins/plugin-security/src/bootstrap-system-capabilities.ts
+++ b/packages/plugins/plugin-security/src/bootstrap-system-capabilities.ts
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * bootstrapSystemCapabilities — back-compat seed the capability registry
+ * (ADR-0066 D1).
+ *
+ * Promotes the platform's authorization capabilities from bare strings to
+ * first-class `sys_capability` records. Idempotently upserts (by `name`):
+ *   1. a CURATED set of well-known platform capabilities (label/description/
+ *      scope), and
+ *   2. any capability referenced by the seeded permission sets'
+ *      `systemPermissions[]` that isn't in the curated set (derived defaults),
+ * so every string a default grant references resolves to a definition record
+ * while existing string references keep working unchanged (no migration).
+ *
+ * Pre-launch posture: upsert only — never prune (admins may add their own
+ * capabilities in Setup; package-declared capabilities arrive via their own
+ * seeding). Platform-seeded rows are `managed_by: 'platform'` so they are not
+ * presented as admin-deletable. Runs on `kernel:ready` alongside the other
+ * security bootstraps.
+ */
+
+const SYSTEM_CTX = { isSystem: true };
+
+function genId(prefix: string): string {
+  const rand = Math.random().toString(36).slice(2, 10);
+  const ts = Date.now().toString(36);
+  return `${prefix}_${ts}${rand}`;
+}
+
+async function tryFind(ql: any, object: string, where: any, limit = 1): Promise<any[]> {
+  try {
+    const rows = await ql.find(object, { where, limit }, { context: SYSTEM_CTX });
+    return Array.isArray(rows) ? rows : [];
+  } catch { return []; }
+}
+async function tryInsert(ql: any, object: string, data: any): Promise<any | null> {
+  try { return await ql.insert(object, data, { context: SYSTEM_CTX }); } catch { return null; }
+}
+async function tryUpdate(ql: any, object: string, data: any): Promise<boolean> {
+  try { await ql.update(object, data, { context: SYSTEM_CTX }); return true; } catch { return false; }
+}
+
+interface CapabilityDef {
+  name: string;
+  label: string;
+  description: string;
+  scope: 'platform' | 'org';
+}
+
+/**
+ * Well-known platform capabilities. Exported so tests + tooling can assert the
+ * back-compat set. `managed_by` is always `'platform'` for these.
+ */
+export const KNOWN_CAPABILITIES: readonly CapabilityDef[] = [
+  { name: 'manage_users', label: 'Manage Users', description: 'Create, edit, and deactivate users across the platform.', scope: 'platform' },
+  { name: 'manage_org_users', label: 'Manage Organization Users', description: 'Manage members within the caller’s organization.', scope: 'org' },
+  { name: 'manage_metadata', label: 'Manage Metadata', description: 'Author and publish object/view/flow and other metadata.', scope: 'platform' },
+  { name: 'manage_platform_settings', label: 'Manage Platform Settings', description: 'Configure global platform settings (mail, storage, AI, licensing, …) and platform-only Setup pages.', scope: 'platform' },
+  { name: 'setup.access', label: 'Setup Access', description: 'Enter the Setup app shell.', scope: 'platform' },
+  { name: 'studio.access', label: 'Studio Access', description: 'Enter the Studio metadata-design surfaces.', scope: 'platform' },
+];
+
+function humanize(name: string): string {
+  return name
+    .replace(/[._]/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+interface SeedOptions {
+  logger?: { info?: (m: string, meta?: Record<string, any>) => void; warn?: (m: string, meta?: Record<string, any>) => void };
+}
+
+export async function bootstrapSystemCapabilities(
+  ql: any,
+  permissionSets: Array<{ systemPermissions?: string[] }> = [],
+  options: SeedOptions = {},
+): Promise<{ seeded: number; updated: number; total: number }> {
+  if (!ql || typeof ql.find !== 'function' || typeof ql.insert !== 'function') {
+    return { seeded: 0, updated: 0, total: 0 };
+  }
+
+  // Build the full definition set: curated first, then any extra capability
+  // string referenced by the seeded permission sets (derived defaults).
+  const byName = new Map<string, CapabilityDef>();
+  for (const c of KNOWN_CAPABILITIES) byName.set(c.name, c);
+  for (const ps of permissionSets) {
+    for (const cap of ps?.systemPermissions ?? []) {
+      if (typeof cap === 'string' && cap && !byName.has(cap)) {
+        byName.set(cap, { name: cap, label: humanize(cap), description: `Capability ${cap}.`, scope: 'platform' });
+      }
+    }
+  }
+
+  let seeded = 0;
+  let updated = 0;
+  for (const def of byName.values()) {
+    const existing = await tryFind(ql, 'sys_capability', { name: def.name }, 1);
+    if (existing[0]?.id) {
+      // Keep label/description/scope fresh, but do NOT clobber admin edits to
+      // managed_by/active — only platform-owned fields are reconciled.
+      if (await tryUpdate(ql, 'sys_capability', { id: existing[0].id, label: def.label, description: def.description, scope: def.scope })) {
+        updated += 1;
+      }
+    } else {
+      const created = await tryInsert(ql, 'sys_capability', {
+        id: genId('cap'),
+        name: def.name,
+        label: def.label,
+        description: def.description,
+        scope: def.scope,
+        managed_by: 'platform',
+        active: true,
+      });
+      if (created) seeded += 1;
+    }
+  }
+  options.logger?.info?.('[security] system capabilities seeded into sys_capability (ADR-0066 D1)', { seeded, updated, total: byName.size });
+  return { seeded, updated, total: byName.size };
+}

--- a/packages/plugins/plugin-security/src/manifest.ts
+++ b/packages/plugins/plugin-security/src/manifest.ts
@@ -11,6 +11,7 @@
 import {
   SysPermissionSet,
   SysRole,
+  SysCapability,
   SysUserPermissionSet,
   SysRolePermissionSet,
   SysUserRole,
@@ -23,6 +24,7 @@ export const SECURITY_PLUGIN_VERSION = '1.0.0';
 /** Security objects owned by plugin-security. */
 export const securityObjects = [
   SysRole,
+  SysCapability,
   SysPermissionSet,
   SysUserPermissionSet,
   SysRolePermissionSet,

--- a/packages/plugins/plugin-security/src/objects/index.ts
+++ b/packages/plugins/plugin-security/src/objects/index.ts
@@ -10,6 +10,7 @@
  */
 
 export { SysRole } from './sys-role.object.js';
+export { SysCapability } from './sys-capability.object.js';
 export { SysPermissionSet } from './sys-permission-set.object.js';
 export { SysUserPermissionSet } from './sys-user-permission-set.object.js';
 export { SysRolePermissionSet } from './sys-role-permission-set.object.js';

--- a/packages/plugins/plugin-security/src/objects/rbac-objects.test.ts
+++ b/packages/plugins/plugin-security/src/objects/rbac-objects.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
-import { SysRole, SysPermissionSet, defaultPermissionSets } from './index.js';
+import { SysRole, SysPermissionSet, SysCapability, defaultPermissionSets } from './index.js';
 
 /**
  * RBAC object + default-permission-set assertions. Moved here with the objects
@@ -117,5 +117,32 @@ describe('RBAC object canonical names + row actions', () => {
   it('SysPermissionSet exposes activate/deactivate/clone row actions', () => {
     const names = (SysPermissionSet.actions ?? []).map((a) => a.name).sort();
     expect(names).toEqual(['activate_permission_set', 'clone_permission_set', 'deactivate_permission_set']);
+  });
+});
+
+
+describe('sys_capability — ADR-0066 D1 capability registry', () => {
+  it('is a system config object with the canonical name', () => {
+    expect(SysCapability.name).toBe('sys_capability');
+    expect(SysCapability.isSystem).toBe(true);
+    expect(SysCapability.managedBy).toBe('config');
+  });
+
+  it('declares name/label/scope/managed_by fields', () => {
+    const f: any = SysCapability.fields;
+    expect(f.name).toBeDefined();
+    expect(f.label).toBeDefined();
+    expect(f.scope).toBeDefined();
+    expect(f.managed_by).toBeDefined();
+    // scope + managed_by are constrained selects
+    const scopeOpts = (f.scope.options ?? []).map((o: any) => o.value).sort();
+    expect(scopeOpts).toEqual(['org', 'platform']);
+    const mbOpts = (f.managed_by.options ?? []).map((o: any) => o.value).sort();
+    expect(mbOpts).toEqual(['admin', 'package', 'platform']);
+  });
+
+  it('enforces a unique index on name', () => {
+    const nameIdx = (SysCapability.indexes ?? []).find((i: any) => Array.isArray(i.fields) && i.fields.includes('name'));
+    expect(nameIdx?.unique).toBe(true);
   });
 });

--- a/packages/plugins/plugin-security/src/objects/sys-capability.object.ts
+++ b/packages/plugins/plugin-security/src/objects/sys-capability.object.ts
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { ObjectSchema, Field } from '@objectstack/spec/data';
+
+/**
+ * sys_capability — Capability definition registry (ADR-0066 D1).
+ *
+ * Promotes authorization *capabilities* from bare strings to first-class
+ * records. A capability is layer 1 of the ADR-0066 three-way separation
+ * (capability / assignment / requirement): "what can be done"
+ * (`manage_users`, `manage_platform_settings`, `export_data`, …). The
+ * platform/packages DEFINE capabilities; admins EXTEND them in Setup.
+ *
+ * `PermissionSet.systemPermissions[]` (assignment) and a resource's
+ * `requiredPermissions[]` (requirement) reference a capability **by name** —
+ * so this table is the catalog/definition, NOT the grant. Existing string
+ * capabilities are back-compat seeded as rows with the same `name`, so all
+ * current references keep resolving (no migration).
+ *
+ * Named `sys_capability` (not `sys_permission` as the ADR loosely floats) to
+ * avoid collision with `sys_permission_set` and to match the "capability"
+ * vocabulary used throughout ADR-0066.
+ *
+ * @namespace sys
+ */
+export const SysCapability = ObjectSchema.create({
+  name: 'sys_capability',
+  label: 'Capability',
+  pluralLabel: 'Capabilities',
+  icon: 'badge-check',
+  isSystem: true,
+  managedBy: 'config',
+  // ADR-0010 §3.7 — RBAC primitive; tenants/admins may add custom rows
+  // (created via UI / API) but the schema itself is locked.
+  protection: {
+    lock: 'no-overlay',
+    reason: 'Capability registry schema is platform-defined — see ADR-0066 / ADR-0010.',
+    docsUrl: 'https://docs.objectstack.ai/adr/0010-metadata-protection',
+  },
+  description: 'Authorization capability definitions (ADR-0066 D1). Referenced by name from permission-set systemPermissions and resource requiredPermissions.',
+  displayNameField: 'label',
+  titleFormat: '{label}',
+  compactLayout: ['label', 'name', 'scope', 'managed_by', 'active'],
+
+  actions: [
+    {
+      name: 'activate_capability',
+      label: 'Activate',
+      icon: 'circle-check',
+      variant: 'secondary',
+      mode: 'custom',
+      locations: ['list_item', 'record_header'],
+      type: 'api',
+      method: 'PATCH',
+      target: '/api/v1/data/sys_capability/{id}',
+      bodyExtra: { active: true },
+      successMessage: 'Capability activated',
+      refreshAfter: true,
+    },
+    {
+      name: 'deactivate_capability',
+      label: 'Deactivate',
+      icon: 'circle-off',
+      variant: 'danger',
+      mode: 'custom',
+      locations: ['list_item', 'record_header'],
+      type: 'api',
+      method: 'PATCH',
+      target: '/api/v1/data/sys_capability/{id}',
+      bodyExtra: { active: false },
+      confirmText: 'Deactivate this capability? Grants and resource requirements that reference it stop resolving until re-activated.',
+      successMessage: 'Capability deactivated',
+      refreshAfter: true,
+    },
+  ],
+
+  listViews: {
+    platform: {
+      type: 'grid',
+      name: 'platform',
+      label: 'Platform',
+      data: { provider: 'object', object: 'sys_capability' },
+      columns: ['label', 'name', 'managed_by', 'active'],
+      filter: [{ field: 'scope', operator: 'equals', value: 'platform' }],
+      sort: [{ field: 'name', order: 'asc' }],
+      pagination: { pageSize: 50 },
+    },
+    org: {
+      type: 'grid',
+      name: 'org',
+      label: 'Organization',
+      data: { provider: 'object', object: 'sys_capability' },
+      columns: ['label', 'name', 'managed_by', 'active'],
+      filter: [{ field: 'scope', operator: 'equals', value: 'org' }],
+      sort: [{ field: 'name', order: 'asc' }],
+      pagination: { pageSize: 50 },
+    },
+    all_capabilities: {
+      type: 'grid',
+      name: 'all_capabilities',
+      label: 'All',
+      data: { provider: 'object', object: 'sys_capability' },
+      columns: ['label', 'name', 'scope', 'managed_by', 'active'],
+      sort: [{ field: 'name', order: 'asc' }],
+      pagination: { pageSize: 50 },
+    },
+  },
+
+  fields: {
+    // ── Identity ─────────────────────────────────────────────────
+    label: Field.text({
+      label: 'Display Name',
+      required: true,
+      searchable: true,
+      maxLength: 255,
+      group: 'Identity',
+    }),
+
+    name: Field.text({
+      label: 'API Name',
+      required: true,
+      searchable: true,
+      maxLength: 100,
+      description: 'Unique capability key referenced by systemPermissions / requiredPermissions (e.g. manage_users, setup.access).',
+      group: 'Identity',
+    }),
+
+    description: Field.textarea({
+      label: 'Description',
+      required: false,
+      group: 'Identity',
+    }),
+
+    // ── Classification ───────────────────────────────────────────
+    scope: Field.select({
+      label: 'Scope',
+      required: true,
+      defaultValue: 'platform',
+      description: 'platform = a platform-wide power; org = scoped to an organization.',
+      options: [
+        { value: 'platform', label: 'Platform' },
+        { value: 'org', label: 'Organization' },
+      ],
+      group: 'Classification',
+    }),
+
+    managed_by: Field.select({
+      label: 'Managed By',
+      required: true,
+      defaultValue: 'admin',
+      description: 'platform/package-owned capabilities are shipped and not user-deletable; admin-owned are created in Setup.',
+      options: [
+        { value: 'platform', label: 'Platform' },
+        { value: 'package', label: 'Package' },
+        { value: 'admin', label: 'Admin' },
+      ],
+      group: 'Classification',
+    }),
+
+    // ── Status ───────────────────────────────────────────────────
+    active: Field.boolean({
+      label: 'Active',
+      defaultValue: true,
+      group: 'Status',
+    }),
+
+    // ── System ───────────────────────────────────────────────────
+    id: Field.text({
+      label: 'Capability ID',
+      required: true,
+      readonly: true,
+      group: 'System',
+    }),
+
+    created_at: Field.datetime({
+      label: 'Created At',
+      defaultValue: 'NOW()',
+      readonly: true,
+      group: 'System',
+    }),
+
+    updated_at: Field.datetime({
+      label: 'Updated At',
+      defaultValue: 'NOW()',
+      readonly: true,
+      group: 'System',
+    }),
+  },
+
+  indexes: [
+    { fields: ['name'], unique: true },
+    { fields: ['scope'] },
+    { fields: ['active'] },
+  ],
+
+  enable: {
+    trackHistory: true,
+    searchable: true,
+    apiEnabled: true,
+    apiMethods: ['get', 'list', 'create', 'update', 'delete'],
+    trash: true,
+    mru: false,
+  },
+});

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -4,6 +4,7 @@ import { Plugin, PluginContext } from '@objectstack/core';
 import type { PermissionSet, RowLevelSecurityPolicy } from '@objectstack/spec/security';
 import { PermissionEvaluator } from './permission-evaluator.js';
 import { bootstrapDeclaredRoles } from './bootstrap-declared-roles.js';
+import { bootstrapSystemCapabilities } from './bootstrap-system-capabilities.js';
 import { RLSCompiler, RLS_DENY_FILTER } from './rls-compiler.js';
 import { matchesFilterCondition } from '@objectstack/formula';
 import { FieldMasker } from './field-masker.js';
@@ -167,6 +168,7 @@ export class SecurityPlugin implements Plugin {
           priority: 100,
           items: [
             { id: 'nav_roles', type: 'object', label: 'Roles', objectName: 'sys_role', icon: 'shield-check' },
+            { id: 'nav_capabilities', type: 'object', label: 'Capabilities', objectName: 'sys_capability', icon: 'badge-check' },
             { id: 'nav_permission_sets', type: 'object', label: 'Permission Sets', objectName: 'sys_permission_set', icon: 'lock' },
           ],
         },
@@ -712,6 +714,13 @@ export class SecurityPlugin implements Plugin {
           await bootstrapDeclaredRoles(ql, this.metadata, { logger: ctx.logger });
         } catch (e) {
           ctx.logger.warn('[security] declared-role seeding failed', { error: (e as Error).message });
+        }
+        // [ADR-0066 D1] Back-compat seed the capability registry (sys_capability)
+        // from the curated platform set + the default grants' systemPermissions.
+        try {
+          await bootstrapSystemCapabilities(ql, this.bootstrapPermissionSets, { logger: ctx.logger });
+        } catch (e) {
+          ctx.logger.warn('[security] capability seeding failed', { error: (e as Error).message });
         }
         bootstrapRanOnce = true;
         ctx.logger.info('[security] platform bootstrap complete', report);


### PR DESCRIPTION
Implements **ADR-0066 D1**: promotes authorization **capabilities** from bare strings to **first-class records** (layer 1 of the three-way separation: capability / assignment / requirement).

### Changes (plugin-security)
- **`sys_capability`** system object — `name`, `label`, `description`, `scope` (platform | org), `managed_by` (platform | package | admin), `active`. Registered in the manifest + given a **Setup → Access Control** nav entry (Roles → Capabilities → Permission Sets).
- **`bootstrapSystemCapabilities`** — back-compat seed (idempotent, on `kernel:ready`): the curated platform set (`manage_users`, `manage_org_users`, `manage_metadata`, `manage_platform_settings`, `setup.access`, `studio.access`) **plus** any capability referenced by the default grants' `systemPermissions[]`. Platform-seeded rows are `managed_by: 'platform'`; never pruned (admins add their own in Setup).

### Design notes
- `systemPermissions[]` (assignment) and `requiredPermissions[]` (requirement) keep referencing capabilities **by name** — the strings *are* the references, so **nothing migrates**; `sys_capability` is the catalog/definition. The string-based gates (D2/D3/D4) keep working unchanged; this is purely additive.
- Named **`sys_capability`** (not the ADR's loosely-floated `sys_permission`) to avoid collision with `sys_permission_set` and match ADR-0066's "capability" vocabulary.

### Tests
+6 (object shape: name/fields/scope+managed_by options/unique index; seeding: curated set, idempotency, derivation from systemPermissions, org-scope). plugin-security full-DTS build + 139 tests green.

Follow-up (later phase): D1's optional admin/Studio authoring polish; capabilities in the CEL surface (`$Permission`) is a roadmap item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)