### PR TITLE
fix(service-ai): stamp agent_id on auto-created chat conversations

### DIFF
--- a/packages/services/service-ai/src/__tests__/ai-service.test.ts
+++ b/packages/services/service-ai/src/__tests__/ai-service.test.ts
@@ -394,6 +394,27 @@ describe('AIService', () => {
     expect(after?.messages[1].content).toBe('hello back');
   });
 
+  it('auto-creates the conversation with the agentId from the execution context', async () => {
+    const conversationService = new InMemoryConversationService();
+    const adapter: LLMAdapter = {
+      name: 'agentid-test',
+      chat: async () => ({ content: 'ok', model: 'test' }),
+      complete: async () => ({ content: '' }),
+    };
+    const service = new AIService({ adapter, conversationService, logger: silentLogger });
+
+    // No conversationId → autoCreateConversation fires (needs an actor); it must
+    // stamp agent_id so downstream per-agent attribution/metering isn't null.
+    await service.chatWithTools(
+      [{ role: 'user', content: 'hi' }],
+      { toolExecutionContext: { actor: { id: 'u1' }, agentId: 'ask' } },
+    );
+
+    const mine = await conversationService.list({ agentId: 'ask' });
+    expect(mine.length).toBe(1);
+    expect(mine[0].agentId).toBe('ask');
+  });
+
   it('chatWithTools persists assistant + tool turns across iterations', async () => {
     const conversationService = new InMemoryConversationService();
     const toolRegistry = new ToolRegistry();

--- a/packages/services/service-ai/src/ai-service.ts
+++ b/packages/services/service-ai/src/ai-service.ts
@@ -322,13 +322,16 @@ export class AIService implements IAIService {
    * which case we silently fall back to non-persisted chat).
    */
   private async autoCreateConversation(
-    ctx: { actor?: { id?: string }; environmentId?: string } | undefined,
+    ctx: { actor?: { id?: string }; environmentId?: string; agentId?: string } | undefined,
   ): Promise<string | undefined> {
     const actorId = ctx?.actor?.id;
     if (!actorId) return undefined;
     try {
       const conv = await this.conversationService.create({
         userId: actorId,
+        // Stamp the agent so the conversation (and its messages' usage) is
+        // attributable per-agent instead of null (e.g. cloud per-agent metering).
+        agentId: ctx?.agentId,
         metadata: ctx?.environmentId ? { environmentId: ctx.environmentId } : undefined,
       });
       this.logger.debug('[AI] auto-created conversation', { conversationId: conv.id, actorId });

--- a/packages/services/service-ai/src/routes/agent-routes.ts
+++ b/packages/services/service-ai/src/routes/agent-routes.ts
@@ -256,6 +256,9 @@ export function buildAgentRoutes(
                     typeof chatContext?.environmentId === 'string'
                       ? chatContext.environmentId
                       : undefined,
+                  // The agent this chat runs as → stamped onto an auto-created
+                  // conversation's agent_id (per-agent attribution / metering).
+                  agentId: agentName,
                   // The object/view the user has open — lets built-in data
                   // tools fall back to "this object" when the request doesn't
                   // name one (ADR-aligned with the schema injection above).

--- a/packages/spec/src/contracts/ai-service.ts
+++ b/packages/spec/src/contracts/ai-service.ts
@@ -411,6 +411,13 @@ export interface ToolExecutionContext {
     /** Active environment (multi-tenant project) id, if known. */
     environmentId?: string;
     /**
+     * The agent this chat runs as (e.g. the `:agentName` from
+     * `/api/v1/ai/agents/:agentName/chat`). Stamped onto an auto-created
+     * conversation's `agent_id` so downstream analytics / per-agent metering can
+     * attribute usage to the right agent instead of leaving it null.
+     */
+    agentId?: string;
+    /**
      * Object the user is currently viewing in the UI (e.g. the list/detail
      * page they have open). Built-in data tools use this as a fallback target
      * when the user refers to "this object" / "the current object" and the


### PR DESCRIPTION
## What
`/api/v1/ai/agents/:agentName/chat` auto-creates its conversation (when the client sends no `conversationId`) via `autoCreateConversation()`, which only set `userId` + `metadata` — leaving **`ai_conversations.agent_id` NULL**. Every chat conversation looked agent-less, so per-agent attribution (analytics + cloud's per-agent AI metering) was impossible.

## Change
Thread the agent end-to-end (additive, backward-compatible):
- **spec**: add optional `ToolExecutionContext.agentId`.
- **agent-routes**: set `agentId: agentName` in the request's `toolExecutionContext`.
- **ai-service**: forward `ctx.agentId` into `conversationService.create({ agentId })` in `autoCreateConversation`.

`undefined → null`, so the general `/api/v1/ai/chat` route and system invocations are unchanged.

## Why (downstream)
cloud's AI token guardrail meters **build vs data-Q&A separately** by joining `ai_messages → ai_conversations.agent_id`. With agent_id null, everything classified as `build` (fail-safe but the data-Q&A meter stayed inert). This populates the field so the split actually works for new conversations.

## Test
`ai-service` › *auto-creates the conversation with the agentId from the execution context*. Full `service-ai` suite green (104 + 130).

🤖 Generated with [Claude Code](https://claude.com/claude-code)