### PR TITLE
fix(spec): don't require `slots` on slotted pages (unblock slotted page creation in Studio)

### DIFF
--- a/.changeset/slotted-page-no-slots-required.md
+++ b/.changeset/slotted-page-no-slots-required.md
@@ -1,0 +1,12 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): don't require `slots` on slotted pages
+
+`PageSchema`'s superRefine rejected any `kind: 'slotted'` page that didn't
+provide a `slots` map — but a slotted page with no overrides is valid: every
+slot falls through to the synthesized default layout, the natural starting
+point before you add overrides. Requiring `slots` up front made the Studio
+"New Page" form a dead-end the moment you picked "slotted" (the form can't
+author a slot map), the same trap as the old required `regions`.

--- a/packages/spec/src/ui/page.zod.ts
+++ b/packages/spec/src/ui/page.zod.ts
@@ -415,13 +415,12 @@ export const PageSchema = lazySchema(() => z.object({
       message: 'blankLayout is required when type is "blank"',
     });
   }
-  if (data.kind === 'slotted' && !data.slots) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['slots'],
-      message: 'slots is required when kind is "slotted"',
-    });
-  }
+  // NOTE: `kind: 'slotted'` does NOT require `slots`. A slotted page with no
+  // overrides renders the synthesized default layout (every slot falls through
+  // to the default) — the natural starting point: create the slotted shell,
+  // then add slot overrides in the editor. Requiring `slots` up front made the
+  // Studio "New Page" form a dead-end the moment you picked "slotted" (the form
+  // can't author a slot map), the same trap as the old required `regions`.
 }));
 
 export type Page = z.infer<typeof PageSchema>;


### PR DESCRIPTION
Follow-up to #2254, found by continuing to dogfood the Studio page designer.

## Problem
After #2254 unblocked creating record/home/app pages, the **last remaining create-flow dead-end** was the **Kind = "slotted"** option: `PageSchema`'s superRefine rejects any `kind: 'slotted'` page that doesn't provide a `slots` map (`slots: "slots is required when kind is 'slotted'"`). The "New Page" form can't author a slot map (and `createSeed` seeds `regions`, not `slots`), so picking "slotted" instantly blocks save — the same trap as the old required `regions`/`properties`.

## Fix
Removed the superRefine clause. A slotted page with no overrides is valid and useful: every slot falls through to the synthesized default layout — the natural starting point before you add slot overrides in the editor. `slots` stays optional.

## Verification
- ✅ Probed every type/kind combo the create form offers: the slots requirement was the only remaining gate; `slotted`-without-`slots` now parses.
- ✅ 86 page tests pass.
- Confirmed in the Studio editor that a slotted page's slot designer renders each slot ("Inherited from the default page" for un-overridden slots, authored blocks for overrides).

> Companion objectui follow-up (separate): a slotted page renders correctly in the Design tab but blank in Preview — the studio preview needs to synthesize the default layout + apply slot overrides (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)