### PR TITLE
feat(spec): type ChartConfig `colors` as palette or value→color map

### DIFF
--- a/.changeset/chart-config-colors-map.md
+++ b/.changeset/chart-config-colors-map.md
@@ -1,0 +1,11 @@
+---
+"@objectstack/spec": patch
+---
+
+feat(spec): type ChartConfig `colors` as a palette OR a value→color map
+
+`ChartConfigSchema.colors` now accepts either a positional palette (`string[]`)
+or an explicit value→color map (`Record<value, color>`, kanban-style). A
+value→color map — and a select/lookup dimension's option colors — take
+precedence over the positional palette per category, so semantic charts
+(health, status) paint their own colors instead of the generic palette.

--- a/packages/spec/src/ui/chart.zod.ts
+++ b/packages/spec/src/ui/chart.zod.ts
@@ -185,8 +185,15 @@ export const ChartConfigSchema = lazySchema(() => z.object({
   /** Series Configuration */
   series: z.array(ChartSeriesSchema).optional().describe('Defined series configuration'),
   
-  /** Appearance */
-  colors: z.array(z.string()).optional().describe('Color palette'),
+  /** Appearance. Either a positional palette (string[]) applied per category in
+   *  order, or a value→color map ({ value: color }, kanban-style). A value→color
+   *  map — and a select/lookup dimension's option colors — take precedence over
+   *  the positional palette per category, so semantic charts (health, status)
+   *  paint their own colors instead of the generic palette. */
+  colors: z.union([
+    z.array(z.string()),
+    z.record(z.string(), z.string()),
+  ]).optional().describe('Color palette (string[]) or value→color map ({ value: color })'),
   height: z.number().optional().describe('Fixed height in pixels'),
   
   /** Components */


### PR DESCRIPTION
## What

Types `ChartConfigSchema.colors` as a **union**: either a positional palette (`string[]`) **or** an explicit value→color map (`Record<value, color>`, kanban-style — mirroring `RowColorConfigSchema.colors`).

## Why

Spec-level parity for the `object-chart` semantic-color feature shipped in objectui (objectstack-ai/objectui#1932 renderer + #1936 `ObjectChartSchema` typing). When a chart's category dimension is a select/lookup field, its option colors — and any explicit value→color map — should take precedence over the positional palette per category, so health/status charts paint their own semantic colors instead of the generic `--chart-1..5` palette.

Additive and backward-compatible: the field is optional and the existing `string[]` palette form is unchanged. No framework runtime consumes `ChartConfig.colors` as an array, so the union widens the type with no break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)