### PR TITLE
fix(setup): drop Advanced nav entries for non-listable objects (verifications, device codes)

### DIFF
--- a/.changeset/setup-advanced-nav-unlistable.md
+++ b/.changeset/setup-advanced-nav-unlistable.md
@@ -1,0 +1,14 @@
+---
+"@objectstack/platform-objects": patch
+---
+
+fix(setup): drop Advanced nav entries for non-listable objects (sys_verification, sys_device_code)
+
+Dogfooding every Setup menu surfaced two Advanced entries that always render
+"无法加载记录 / failed to load": **Verifications** (`sys_verification`) and
+**Device Codes** (`sys_device_code`). Both objects deliberately omit `list`
+from `apiMethods` (sensitive, ephemeral secrets — verification tokens and OAuth
+device-grant codes are not meant to be browsed), so the generic object/list-view
+menu can only ever 405. Removed both nav entries (and their orphaned zh labels);
+the objects remain reachable by id. Re-adding a browse menu would require
+enabling `list` on the object — a security decision, not a nav fix.

--- a/packages/platform-objects/src/apps/setup-nav.contributions.ts
+++ b/packages/platform-objects/src/apps/setup-nav.contributions.ts
@@ -113,8 +113,12 @@ export const SETUP_NAV_CONTRIBUTIONS: NavigationContribution[] = [
     items: [
       { id: 'nav_oauth_apps', type: 'object', label: 'OAuth Applications', objectName: 'sys_oauth_application', icon: 'app-window' },
       { id: 'nav_jwks', type: 'object', label: 'Signing Keys (JWKS)', objectName: 'sys_jwks', icon: 'key-round' },
-      { id: 'nav_verifications', type: 'object', label: 'Verifications', objectName: 'sys_verification', icon: 'mail-check' },
-      { id: 'nav_device_codes', type: 'object', label: 'Device Codes', objectName: 'sys_device_code', icon: 'qr-code' },
+      // `sys_verification` (email/phone tokens) and `sys_device_code` (OAuth
+      // device-grant codes) deliberately omit `list` from their `apiMethods`
+      // (sensitive, ephemeral secrets — not browsable), so an object/list-view
+      // nav entry for them can only ever render "failed to load". They're
+      // reachable by id (get) when needed; no browse menu. (Re-adding requires
+      // enabling `list` on the object — a security decision.)
       { id: 'nav_accounts', type: 'object', label: 'Identity Links', objectName: 'sys_account', icon: 'link-2' },
       { id: 'nav_user_preferences', type: 'object', label: 'User Preferences', objectName: 'sys_user_preference', icon: 'sliders' },
     ],

--- a/packages/platform-objects/src/apps/translations/zh-CN.ts
+++ b/packages/platform-objects/src/apps/translations/zh-CN.ts
@@ -84,8 +84,6 @@ export const zhCN: TranslationData = {
 
         nav_oauth_apps: { label: 'OAuth 应用' },
         nav_jwks: { label: '签名密钥 (JWKS)' },
-        nav_verifications: { label: '验证记录' },
-        nav_device_codes: { label: '设备代码' },
         nav_accounts: { label: '身份链接' },
         nav_user_preferences: { label: '用户偏好' },
         nav_metadata: { label: '全部元数据' },


### PR DESCRIPTION
## What

Removes two **Setup → Advanced** menu entries that can never load:
- **Verifications** (`sys_verification`)
- **Device Codes** (`sys_device_code`)

## Why

Found by browser-verifying *every* Setup menu (all 38). Both objects intentionally omit `list` from `apiMethods` (`sys_verification`: `get/create/delete`; `sys_device_code`: `get/create/update/delete`) — they're sensitive, ephemeral secrets that aren't meant to be browsed. But the Advanced group pinned them as generic object/list-view menus, so every visit hit `405 OBJECT_API_METHOD_NOT_ALLOWED` and rendered the "无法加载记录 / failed to load" error boundary.

Removed both nav entries (and their now-orphaned zh labels). The objects stay reachable by id (`get`). Re-introducing a browse menu would require enabling `list` on the object — a security decision, not a nav change.

Sibling objects in the same group (`sys_oauth_application`, `sys_jwks`, `sys_account`, `sys_user_preference`) all allow `list` and render fine.

## Verification

Re-built `platform-objects`, restarted, re-swept: Advanced now shows OAuth 应用 / 签名密钥 / 身份链接 / 用户偏好; the two broken entries are gone; all remaining **36** Setup menus render without error.

Relates to #2246.
