### PR TITLE
docs(dogfood-skill): pre-check vendored console build before declaring UI bugs

### DIFF
--- a/.claude/skills/dogfood-verification/SKILL.md
+++ b/.claude/skills/dogfood-verification/SKILL.md
@@ -54,6 +54,18 @@ unsaved drafts that block navigation, and dirty the working tree. Isolate up fro
 - [ ] So: make **all** source edits first → `pnpm --filter <pkg...> build` →
       `preview_stop` + `preview_start`. Don't edit→build→restart per fix.
 - [ ] `dist/` is gitignored — safe; never commit build output.
+- [ ] **The `/_console` UI is a *vendored objectui build*, separate from framework `dist`.**
+      It's pinned by `.objectui-sha` and served as a pre-built bundle. A merged objectui
+      fix — *or even a bumped `.objectui-sha`* — is **not live at :3000 until the vendored
+      console is rebuilt**: the running server keeps serving the old build artifact (stale
+      BUILD ≠ stale PIN). So **before declaring a console/Studio UI bug found at
+      :3000/_console, check it against current objectui source or a fresh build** — the
+      vendored bundle may be stale and the bug already fixed upstream. Fastest authoritative
+      check = objectui's HMR console against your server:
+      `VITE_SERVER_URL=http://localhost:<port> DEV_PROXY_TARGET=http://localhost:<port> pnpm --filter @object-ui/console dev`
+      (separate origin → needs its own `admin@objectos.ai/admin123` login). Skipping this
+      cost a full spawn-a-fix cycle on an action-create dead-end that was already fixed in
+      objectui main.
 
 ## 3. Verify — visual / API first, DOM last (the anti-false-positive rule)
 


### PR DESCRIPTION
## What
Adds a §2 pre-check to the internal **dogfood-verification** skill: the `/_console` UI at :3000 is a *vendored objectui build* pinned by `.objectui-sha`, distinct from framework `dist`. A merged objectui fix — or even a bumped pin — is **not live until the vendored console is rebuilt** (the server keeps serving the old bundle). So a "console/Studio UI bug" found on the vendored console may already be fixed upstream.

The new bullet says: before declaring a console/Studio UI bug at :3000/_console, check it against current objectui source or a fresh/HMR console.

## Why
Real cost this session: an action-create dead-end found on the stale vendored :3000 console was **already fixed in objectui main** (`anchors.ts` createDefaults seeds a valid no-op body) — but the running build predated it. Verified after rebuild that action create now works. This pre-check would have skipped a full spawn-a-fix investigation.

Internal `.claude/` tooling only — no published-package change, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)