### PR TITLE
docs(adr): renumber package-first ADR 0069 → 0070 (number collision)

### DIFF
--- a/docs/adr/0070-package-first-authoring.md
+++ b/docs/adr/0070-package-first-authoring.md
@@ -1,4 +1,4 @@
-# ADR-0069: Package-first authoring — every runtime-authored item lives in a writable package (base); no orphans
+# ADR-0070: Package-first authoring — every runtime-authored item lives in a writable package (base); no orphans
 
 **Status**: Proposed (2026-06-24)
 **Deciders**: ObjectStack Protocol Architects


### PR DESCRIPTION
ADR-0069 was concurrently merged twice (enterprise-auth + package-first, #2277). This renames the **package-first** ADR to the next free number **0070** (content unchanged) to resolve the collision. The enterprise-auth ADR keeps 0069.

🤖 Generated with [Claude Code](https://claude.com/claude-code)