### PR TITLE
feat(spec): create seeds for agent / tool / skill / email_template / permission

### DIFF
--- a/.changeset/ai-type-create-seeds.md
+++ b/.changeset/ai-type-create-seeds.md
@@ -1,0 +1,7 @@
+---
+'@objectstack/spec': minor
+---
+
+Add authoritative create seeds for agent / tool / skill / email_template / permission
+
+Extends the spec-derived create-shape contract to the AI and integration metadata types. Each now has an authoritative minimal create seed (validated against its schema), so the Studio designer / CLI / API derive their create defaults from the spec via `/meta/types` — closing the "designer emits a minimal shape the spec rejects → create→save 422" gap for these types too (agent needs `role`+`instructions`, tool needs `description`+`parameters`, skill needs `tools`, email_template needs `subject`+`bodyHtml`, permission needs `objects`). `trigger` has no spec schema and is intentionally not seeded.

--- a/packages/spec/src/kernel/metadata-create-seeds.ts
+++ b/packages/spec/src/kernel/metadata-create-seeds.ts
@@ -104,6 +104,38 @@ const BUILTIN_METADATA_CREATE_SEEDS: Partial<Record<MetadataType, unknown>> = {
     pluralLabel: 'New Objects',
     fields: {},
   },
+  agent: {
+    name: 'new_agent',
+    label: 'New Agent',
+    // role + instructions are required — the agent's persona and behavior.
+    role: 'A helpful assistant.',
+    instructions: 'Describe what this agent should do.',
+  },
+  tool: {
+    name: 'new_tool',
+    label: 'New Tool',
+    // description + a (possibly empty) parameters record are required.
+    description: 'Describe what this tool does.',
+    parameters: {},
+  },
+  skill: {
+    name: 'new_skill',
+    label: 'New Skill',
+    // a skill bundles tools; an empty list is a valid starting point.
+    tools: [],
+  },
+  email_template: {
+    name: 'new_email_template',
+    label: 'New Email Template',
+    subject: 'Subject line',
+    bodyHtml: '<p>Email body</p>',
+  },
+  permission: {
+    name: 'new_permission',
+    label: 'New Permission',
+    // a permission set's per-object grant map; empty = no grants yet.
+    objects: {},
+  },
 };
 
 /**


### PR DESCRIPTION
## Why

Extends the **spec-derived create-shape contract** (#2270 seeds → #2276 `/meta/types` → objectui#1967 designer consumes) to the **AI + integration metadata types** my earlier create-roundtrip probe never covered. Without a seed, "New agent/tool/skill → Save" would hit the same `create→save 422` family (e.g. an agent needs `role`+`instructions`, which the name-first create form doesn't supply).

## What

Authoritative minimal create seeds, empirically derived from each schema's required fields and validated by `metadata-create-seeds.test.ts`:

| type | required fields seeded |
|---|---|
| `agent` | `role`, `instructions` |
| `tool` | `description`, `parameters` |
| `skill` | `tools` |
| `email_template` | `subject`, `bodyHtml` |
| `permission` | `objects` |

`trigger` has no spec schema (`getMetadataTypeSchema('trigger')` is undefined) and is intentionally left unseeded. No new exports → **api-surface unchanged**.

These flow to the designer / CLI / API automatically via `/meta/types` (#2276) and `buildCreateModeBody` (objectui#1967) — no further wiring.

## Verification

`metadata-create-seeds.test.ts` — **17 pass** (the 5 new seeds each validate against their registered schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)