### PR TITLE
fix(cli): type approvalFlow test helper's edges param (unblock TS on main)

### DIFF
--- a/packages/cli/src/utils/lint-flow-patterns.test.ts
+++ b/packages/cli/src/utils/lint-flow-patterns.test.ts
@@ -187,7 +187,10 @@ describe('lintFlowPatterns — wrong interpolation syntax (#1315)', () => {
 
 
 describe('lintFlowPatterns — approval revise loop (ADR-0044)', () => {
-  const approvalFlow = (edges, approvalConfig = {}) => ({
+  const approvalFlow = (
+    edges: Array<{ source: string; target: string; label?: string; type?: string }>,
+    approvalConfig: Record<string, unknown> = {},
+  ) => ({
     flows: [{
       name: 'budget_approval',
       nodes: [


### PR DESCRIPTION
main's **TypeScript Type Check** is red: `packages/cli/src/utils/lint-flow-patterns.test.ts:190` — `error TS7006: Parameter 'edges' implicitly has an 'any' type` (introduced by #2279). The TS job builds the whole workspace, so this blocks CI for **every open PR** (incl. the ADR renumber #2280).

One-line test-helper type annotation. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)