### PR TITLE
fix(cli): type approvalFlow test helper — unbreak workspace build (follow-up #2279)

### DIFF
--- a/packages/cli/src/utils/lint-flow-patterns.test.ts
+++ b/packages/cli/src/utils/lint-flow-patterns.test.ts
@@ -187,7 +187,7 @@ describe('lintFlowPatterns — wrong interpolation syntax (#1315)', () => {
 
 
 describe('lintFlowPatterns — approval revise loop (ADR-0044)', () => {
-  const approvalFlow = (edges, approvalConfig = {}) => ({
+  const approvalFlow = (edges: Record<string, unknown>[], approvalConfig: Record<string, unknown> = {}) => ({
     flows: [{
       name: 'budget_approval',
       nodes: [


### PR DESCRIPTION
One-line follow-up to #2279: the `approvalFlow` test helper's `edges` param was implicitly `any`, which the strict cli `tsc` build (`tsconfig.build.json`) rejects — vitest/esbuild transpiled it without a full type-check, so it passed locally but broke the workspace **Build / TypeScript Type Check** jobs after merge. Typed it explicitly; `pnpm --filter @objectstack/cli build` is green again. No behavior change. Refs #2274, #1770.