### PR TITLE
docs(readme): bridge hero to open-source / AI-native app positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 ![Version](https://img.shields.io/badge/version-v4.0.1-green.svg)
 ![Tests](https://img.shields.io/badge/tests-6%2C507%20passing-brightgreen.svg)
 
-> The AI-native business backend: define business objects, permissions, workflows, APIs, UI metadata, and agent tools once as structured Zod metadata.
+> **Open-source, AI-native backend for real business apps.** Describe a business app and AI builds the whole thing — objects, APIs, UI, workflows, and permissions — as version-controlled Zod metadata on a database you own. Self-host it; AI agents then operate it within RBAC / RLS and audit.
+
+**Try it in ~30s** — boot the [HotCRM](https://github.com/objectstack-ai/hotcrm) reference app on [StackBlitz](https://stackblitz.com/github/objectstack-ai/hotcrm) (no install). · Hosted platform: **[ObjectOS](https://cloud.objectos.app)**.
 
 ## What is ObjectStack?
 
-ObjectStack is a metadata-driven backend for building business applications that AI agents can understand, operate, and audit safely.
+ObjectStack is an **open-source**, metadata-driven backend for building business applications that AI agents can understand, operate, and audit safely — self-hostable, with your data on your own database.
 
 Instead of hiding business logic inside ad-hoc SQL queries, UI state, or JavaScript strings, ObjectStack makes the business system explicit:
 


### PR DESCRIPTION
## What
Bridges the README hero to the marketing positioning (objectos.ai) while keeping every bit of technical depth and the ObjectStack name.

- **Tagline** now leads with **open-source**, "AI builds the whole app", "a database you own", and **self-host** — so a visitor arriving from the site sees the same promise. Keeps the "backend / Zod metadata" substance.
- Adds a **"Try it in ~30s"** line: HotCRM on StackBlitz (no install) + a link to the hosted platform.
- **Intro** now states open-source + self-hostable up front.

Nothing technical removed — "not another low-code UI builder", the architecture, features, the Retool/Appsmith comparison table, and quick-start are all untouched.

## ⚠️ Founder decision needed: brand architecture
I added "Hosted platform: **ObjectOS**", which implies **ObjectStack = the open-source framework** and **ObjectOS = the hosted platform**. But "ObjectOS" is *also* the name of the **Control Layer** in this repo (ObjectQL / ObjectOS / ObjectUI), and the marketing site brands the whole product "ObjectOS". That's a name collision worth resolving deliberately — confirm the intended hierarchy and I'll align both the README and the marketing site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
