### PR TITLE
feat(spec): add `back` edge style to the flow-builder canvas protocol

### DIFF
--- a/.changeset/flow-builder-back-edge-style.md
+++ b/.changeset/flow-builder-back-edge-style.md
@@ -1,0 +1,7 @@
+---
+'@objectstack/spec': patch
+---
+
+feat(spec): add the `back` edge style to the flow-builder canvas protocol
+
+`FlowCanvasEdgeStyleSchema` gains a `back` value alongside `solid`/`dashed`/`dotted`/`bold`, marking an ADR-0044 declared back-edge (a `revise` loop's resubmit edge). Flow-builder-protocol consumers can now render it as a distinct curved/dashed return arc, set apart from forward flow — matching the objectui designer's hand-rolled canvas (objectstack-ai/objectui#1954). Part of #2274.

--- a/packages/spec/src/studio/flow-builder.test.ts
+++ b/packages/spec/src/studio/flow-builder.test.ts
@@ -128,7 +128,7 @@ describe('FlowCanvasEdgeSchema', () => {
   });
 
   it('should accept all edge styles', () => {
-    const styles = ['solid', 'dashed', 'dotted', 'bold'];
+    const styles = ['solid', 'dashed', 'dotted', 'bold', 'back'];
     styles.forEach(s => {
       expect(FlowCanvasEdgeStyleSchema.parse(s)).toBe(s);
     });

--- a/packages/spec/src/studio/flow-builder.zod.ts
+++ b/packages/spec/src/studio/flow-builder.zod.ts
@@ -9,7 +9,7 @@
  * within ObjectStack Studio. Covers:
  * - **Node Shape Registry**: Shape and visual style per FlowNodeAction type
  * - **Canvas Node**: Position, size, and rendering hints for each node on canvas
- * - **Canvas Edge**: Visual properties for sequence flows (normal, default, fault)
+ * - **Canvas Edge**: Visual properties for sequence flows (normal, default, fault, back-edge)
  * - **Flow Builder Config**: Canvas settings, palette, minimap, and toolbar
  *
  * ## Architecture
@@ -132,13 +132,16 @@ export type FlowCanvasNode = z.infer<typeof FlowCanvasNodeSchema>;
 // ─── Canvas Edge ─────────────────────────────────────────────────────
 
 /**
- * Visual style for a sequence flow edge on the canvas.
+ * Visual style for a sequence flow edge on the canvas. The `back` style marks an
+ * ADR-0044 declared back-edge (a `revise` loop's resubmit edge): consumers render
+ * it as a distinct curved/dashed return arc, set apart from forward flow.
  */
 export const FlowCanvasEdgeStyleSchema = lazySchema(() => z.enum([
   'solid',    // Normal sequence flow
   'dashed',   // Default sequence flow (isDefault: true)
   'dotted',   // Conditional edge
   'bold',     // Fault / error edge
+  'back',     // ADR-0044 back-edge (revise loop) — curved dashed return arc
 ]).describe('Edge line style'));
 
 export type FlowCanvasEdgeStyle = z.infer<typeof FlowCanvasEdgeStyleSchema>;


### PR DESCRIPTION
Part of #2274 (#2274 item 3 — spec completeness). `FlowCanvasEdgeStyleSchema` gains a **`back`** value alongside `solid`/`dashed`/`dotted`/`bold`, marking an ADR-0044 declared back-edge (a `revise` loop's resubmit edge) so flow-builder-protocol consumers render it as a distinct curved/dashed return arc — matching the objectui designer's hand-rolled canvas ([objectui#1954](https://github.com/objectstack-ai/objectui/pull/1954)).

**Additive** enum value — `check:api-surface` confirms the public API surface + factory signatures are **unchanged**.

Verification: `@objectstack/spec` flow-builder tests **23 passing** (accepts `back`); `tsc --noEmit` clean; spec build green; api-surface check ✓.

Refs #2274, #1770 (ADR-0044). 🤖 Generated with [Claude Code](https://claude.com/claude-code)