### PR TITLE
docs(skill): teach the automation skill the ADR-0044 send-back-for-revision shape

### DIFF
--- a/skills/objectstack-automation/SKILL.md
+++ b/skills/objectstack-automation/SKILL.md
@@ -297,6 +297,56 @@ is one diagram a reviewer (or AI) can read end-to-end.
 }
 ```
 
+### Send-back for revision (ADR-0044)
+
+Approval centers also model **send back for revision** (退回修改) — distinct from
+`reject` (terminate) and from a comment thread (which keeps the request pending).
+Send-back is a **flow movement**: the request finalizes as `returned`, the run
+walks a **`revise`** out-edge to a `wait` node where the record unlocks and the
+submitter reworks it, and an explicit *resubmit* re-enters the approval node over
+a **declared back-edge**, opening round N+1 with a fresh approver slate.
+
+```
+approval ──approve──▶ …
+         ──reject───▶ …
+         ──revise───▶ wait (signal; record unlocked, submitter edits)
+                        └──resubmit──[type:'back']──▶ approval   (round N+1)
+```
+
+Three pieces author it:
+
+1. **`revise` out-edge** — a third branch label alongside `approve` / `reject`,
+   targeting an ordinary `wait` node (signal flavour).
+2. **`type: 'back'` resubmit edge** — the edge from the wait node back into the
+   approval node MUST be typed `'back'`. This is the *only* thing that legalizes
+   the cycle: `registerFlow` validates the graph **minus `back` edges** as a DAG,
+   so an **unmarked** cycle is rejected — you opt in, edge by edge. At run time a
+   back-edge traverses normally (it just re-enters the node).
+3. **`maxRevisions`** on the approval `config` (default `3`) — the budget of
+   send-backs per run; exceeding it **auto-rejects** (resumes down the `reject`
+   edge). `maxRevisions: 0` disables send-back, so never pair `0` with a `revise`
+   edge.
+
+```typescript
+{
+  id: 'manager_review', type: 'approval',
+  config: { approvers: [{ type: 'role', value: 'manager' }], lockRecord: true, maxRevisions: 2 },
+},
+{ id: 'wait_revision', type: 'wait', label: 'Awaiting Revision',
+  config: { eventType: 'signal', signalName: 'budget_revision' } },
+// …among the approval's edges…
+{ id: 'rev',  source: 'manager_review', target: 'wait_revision',  label: 'revise' },
+{ id: 'back', source: 'wait_revision',  target: 'manager_review', label: 'resubmit', type: 'back' },
+```
+
+> Two mistakes the compile-time flow lint flags: a `revise` edge whose wait node
+> never loops back (a dead end `registerFlow` accepts but that leaves the
+> submitter nowhere to resubmit), and a resubmit edge left **without**
+> `type: 'back'` (an unmarked cycle `registerFlow` rejects). Resubmit is an
+> explicit verb (`POST /api/v1/approvals/requests/:id/resubmit`), never a
+> record-save. See `examples/app-showcase` → `showcase_budget_approval` for the
+> canonical shape.
+
 ### Re-homing the old process model
 
 If you've seen the pre-ADR-0019 `ApprovalProcess.create({...})` shape, every


### PR DESCRIPTION
Completes the **agent-teaching** slice of #2274 (ADR-0044). The `objectstack-automation` skill — how the AI agent learns to author flows in this repo — documented approve/reject approvals (ADR-0019) but **not the revise loop**, so AI-authored approval flows omit send-back (and a revise loop built without the back-edge gets rejected by `registerFlow`).

Adds a **Send-back for revision (ADR-0044)** section to the Approvals area:
- the `revise` out-edge → a signal `wait` node,
- the resubmit edge typed **`type: 'back'`** (the only thing that legalizes the cycle — graph-minus-`back`-edges must be a DAG; authors opt in edge by edge, per the ADR),
- the **`maxRevisions`** budget (default 3; `0` disables),
- the two footguns the compile-time lint flags (dead-end revise; unmarked back-edge), and a pointer to the canonical `showcase_budget_approval`.

ADR-aligned (teaches correct opt-in — **no** auto-mutation, which would contradict ADR-0044 D5). Markdown-only; `check:doc-authoring` ✓ and `check:skill-docs` in-sync ✓ (frontmatter unchanged, so no generated-doc regen).

This closes the practical scope of #2274: lint #2279 + spec #2291 + this skill, with the engine's cycle-rejection error already carrying the specific hint. Remaining (optional): a dedicated agent **eval**. Refs #2274, #1770. 🤖 Generated with [Claude Code](https://claude.com/claude-code)