### PR TITLE
docs(readme): drop the Codebase Metrics table

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,21 +298,6 @@ For the browser, the typed client SDK and React hooks (`useQuery` / `useMutation
 
 </details>
 
-## Codebase Metrics
-
-| Metric | Value |
-| :--- | :--- |
-| Source packages | 72 |
-| Apps | 2 (account, docs) |
-| Framework adapters | 7 (Express, Fastify, Hono, NestJS, Next.js, Nuxt, SvelteKit) |
-| Database drivers | 3 (Memory, SQL, MongoDB) |
-| Zod schema files | 200 |
-| Exported schemas | 1,600+ |
-| `.describe()` annotations | 8,750+ |
-| Service contracts | 27 |
-| Test files | 676 |
-| Tests passing | 6,507 |
-
 ## Architecture
 
 ObjectStack uses a **microkernel architecture** where the kernel provides only the essential infrastructure (DI, EventBus, lifecycle), and all capabilities are delivered as plugins. The three protocol layers sit above the kernel:


### PR DESCRIPTION
## What

Remove the **Codebase Metrics** table from the README. It is hand-maintained, drifts (the source-package and test-file counts were already stale and had to be patched), and several figures (exported schemas, `.describe()` count, service contracts, tests-passing) can't be cheaply verified. Not worth the upkeep. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
