### PR TITLE
fix(rest): register static data-action routes before greedy :object/:id

### DIFF
--- a/.changeset/rest-export-route-before-getbyid.md
+++ b/.changeset/rest-export-route-before-getbyid.md
@@ -1,0 +1,16 @@
+---
+"@objectstack/rest": patch
+---
+
+fix(rest): register static data-action routes before the greedy `:object/:id` matcher
+
+The REST router matches first-registered-wins with no specificity sorting, but
+`registerDataActionEndpoints` (which holds `GET /data/:object/export`) ran AFTER
+`registerCrudEndpoints` (which holds the greedy `GET /data/:object/:id`). A
+request to `GET /data/<object>/export` was therefore captured by `:object/:id` —
+`"export"` treated as a record id — returning `404 RECORD_NOT_FOUND` instead of
+streaming the export. The data-action registration now runs first, mirroring the
+existing `/meta/:type/:name/references`-before-`/meta/:type/:name` convention.
+Reordering is safe both ways: `registerDataActionEndpoints` contains no greedy
+2-segment `:object/:id` routes, so it cannot shadow any CRUD literal. A
+regression test asserts the export route registers ahead of the get-by-id route.

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -1552,10 +1552,22 @@ export class RestServer {
             this.registerReportsEndpoints(bp);
             this.registerApprovalsEndpoints(bp);
             this.registerAnalyticsEndpoints(bp);
+            // Data-action routes (e.g. GET /data/:object/export, POST
+            // /data/:object/import) use static-literal action segments that
+            // MUST be registered BEFORE the greedy GET /data/:object/:id
+            // matcher in registerCrudEndpoints — the router is first-match-wins
+            // with no specificity sorting (see route-manager.ts), so otherwise
+            // a request to `.../export` is captured by `:id` and "export" is
+            // treated as a record id (404 RECORD_NOT_FOUND). This mirrors the
+            // /meta/:type/:name/references-before-/meta/:type/:name convention.
+            // Safe in the other direction too: registerDataActionEndpoints has
+            // no greedy 2-segment `:object/:id` routes (only literal actions and
+            // deeper `:id/clone`, `:id/shares` paths), so it cannot shadow any
+            // CRUD literal.
+            this.registerDataActionEndpoints(bp);
             if (this.config.api.enableCrud) {
                 this.registerCrudEndpoints(bp);
             }
-            this.registerDataActionEndpoints(bp);
             if (this.config.api.enableBatch) {
                 this.registerBatchEndpoints(bp);
             }

--- a/packages/rest/src/rest.test.ts
+++ b/packages/rest/src/rest.test.ts
@@ -904,6 +904,29 @@ describe('RestServer', () => {
       // 1 header + 50 000 rows.
       expect(lines.length).toBe(50_001);
     });
+
+    // Regression: the router is first-match-wins with no specificity sorting,
+    // so the static-literal `GET /data/:object/export` route MUST be registered
+    // BEFORE the greedy `GET /data/:object/:id` matcher. Otherwise a request to
+    // `/data/<object>/export` is captured by `:id` ("export" treated as a record
+    // id) and 404s with RECORD_NOT_FOUND instead of streaming the export.
+    it('registers GET /export ahead of the greedy GET /:object/:id matcher', () => {
+      const rest = new RestServer(server as any, protocol as any);
+      rest.registerRoutes();
+      const routes = rest.getRoutes();
+
+      const exportIdx = routes.findIndex(
+        (r: any) => r.method === 'GET' && r.path === '/api/v1/data/:object/export',
+      );
+      const getByIdIdx = routes.findIndex(
+        (r: any) => r.method === 'GET' && r.path === '/api/v1/data/:object/:id',
+      );
+
+      expect(exportIdx).toBeGreaterThanOrEqual(0);
+      expect(getByIdIdx).toBeGreaterThanOrEqual(0);
+      // First match wins → the more-specific export route must come first.
+      expect(exportIdx).toBeLessThan(getByIdIdx);
+    });
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## 问题

REST 路由器(`RouteManager` → `IHttpServer`/Express 适配器)按**先注册先匹配**(first-match-wins)工作,没有任何按具体性排序的逻辑(见 `packages/rest/src/route-manager.ts:88,196`)。

`registerDataActionEndpoints`(含 `GET /data/:object/export`)在 `registerCrudEndpoints`(含贪婪的 `GET /data/:object/:id`)**之后**注册,于是请求 `GET /api/v1/data/<object>/export?format=csv` 会先撞上 `:object/:id`,`"export"` 被当成一条记录的 id → 返回 `404 RECORD_NOT_FOUND`,根本到不了导出处理器。已对 `rest@10.0.0` 实证复现。

## 修复

把 `registerDataActionEndpoints(bp)` 调到 `registerCrudEndpoints(bp)` **之前**注册,让静态字面量动作路由(`/export`、`/import`、`/:id/clone` 等)排在贪婪的 `:object/:id` 之前。沿用代码库已有惯例(`/meta/:type/:name/references` 先于 `/meta/:type/:name`,见 `rest-server.ts:2140`)。

### 为什么安全(两个方向都核对过)

按 HTTP 方法 + 段数穷举,first-match 下只有"同方法 + 同段数 + 字面量 vs `:param`"才会互相遮蔽:

| 方法 | 数据命名空间里的贪婪 `:param` | 调换影响 |
|---|---|---|
| GET | `:object/:id` | ✅ `export` 抢到 `:id` 前 = 修复目标;`export` 只精确匹配 `/export` 段,不会反向遮蔽真实 id |
| POST | **无**(克隆是更深的 `:object/:id/clone`) | ✅ `import`/`query`/`batch` 等全是字面量,任何顺序都精确命中 |
| PATCH / DELETE | `:object/:id` | ✅ DataAction 里没有同方法路由,不受影响 |

- `registerDataActionEndpoints` 里**没有**任何贪婪 2 段 `:object/:id` 路由(只有字面量动作和更深的 `:id/clone`、`:id/shares`),所以它先注册也吃不掉任何 CRUD 字面量路由。
- `enableCrud=false` 时行为不变:export 的注册条件没动。

## 测试

- 新增回归测试:断言 `GET /export` 的注册下标必须**小于** `GET /:object/:id`。在修复前的顺序下该测试失败(`export idx 61` 不小于 `:id idx 54`),修复后通过。
- `packages/rest` 全量 **136 个测试通过**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)