### PR TITLE
fix(examples): declare runAs:'system' on showcase webhook + approval-outcome flows (#1888)

### DIFF
--- a/examples/app-showcase/src/flows/index.ts
+++ b/examples/app-showcase/src/flows/index.ts
@@ -883,6 +883,10 @@ export const InvoiceDualSignoffFlow = defineFlow({
   label: 'Invoice Dual Sign-off (parallel approval)',
   description: 'On send, requires finance AND legal to both approve via one aggregating approval node — demonstrates parallel approvals without a token tree (ADR-0039 Track A).',
   type: 'autolaunched',
+  // The revert-on-reject write is an approval-process outcome, not an act of the
+  // submitter — run it as the system principal so it lands regardless of whether
+  // the submitter still has edit rights on a "sent" invoice (#1888 runAs enforced).
+  runAs: 'system',
   nodes: [
     {
       id: 'start',
@@ -1160,6 +1164,11 @@ export const InboundTaskWebhookFlow = defineFlow({
   label: 'Inbound Task Webhook',
   description: 'Creates a task from an external system via the HMAC-verified inbound hook.',
   type: 'api',
+  // An inbound webhook has no authenticated user, so the create must run as the
+  // system principal (#1888 runAs is now enforced). Without this it relies on the
+  // "no identity → security-skipped" fall-through, which breaks the moment the
+  // target object carries row-level security.
+  runAs: 'system',
   nodes: [
     {
       id: 'start',


### PR DESCRIPTION
Regression-audit follow-up to #2302 (flow `runAs` enforcement, #1888). Now that `runAs` is enforced, I audited every example-app flow for ones that would be silently under-privileged or that teach the wrong pattern as AI-authoring reference templates.

## Audit result
**No example flow regresses** under the enforcement (consistent with the green dogfood gate). They split cleanly:
- **`system` (correct)** — cross-owner / no-user work: CRM `lead_qualification_conversion`, `renewal_reminder_flow`, `stale_opportunity_sweep`; todo escalation + recurring-task flows.
- **`user` (correct)** — acts only on the trigger user's own accessible record: CRM `crm_convert_lead_wizard` (get/update the user's own lead), showcase `showcase_reassign_wizard` (edit a task the user launched the action on), `showcase_resilient_sync` (updates the same task the trigger user just completed).
- **No CRUD nodes (unaffected)** — approval/script/notify-only flows (discount approval, high-value-deal, opportunity-won, etc.).

## Fixes (2 showcase flows)
Two flows relied on **implicit** elevation and would teach the wrong pattern as templates:

- **`showcase_inbound_task_webhook`** — an HMAC webhook (`type: 'api'`, **no authenticated user**) that creates a task. It only worked via the "no identity → security-skipped" fall-through. Now declares **`runAs: 'system'`** — the correct, explicit pattern for external ingest, and robust once the target object carries RLS.
- **`showcase_invoice_signoff`** — the revert-on-reject `update_record` is an approval-**process** outcome, not an act of the submitter. **`runAs: 'system'`** so it lands regardless of whether the submitter still has edit rights on a "sent" invoice (mirrors how Salesforce approval field updates run as the process).

No behavioral change in the showcase itself (broad member perms — the gate was already green); this hardens the reference templates so they stay correct under stricter RLS and as patterns AI copies.

## Verification
- `pnpm --filter @objectstack/example-showcase typecheck` ✓
- Full dogfood regression gate: **173 tests green** (35 files; includes the showcase boots + the #1888 `flow-runas` proof).

Example-only change to a **private** package → no changeset needed.

Refs #1888

🤖 Generated with [Claude Code](https://claude.com/claude-code)