### PR TITLE
feat(auth): env-side AI-seat marker via sys_user.ai_access + resolveCtx synthesis

### DIFF
--- a/packages/platform-objects/src/identity/sys-user.object.ts
+++ b/packages/platform-objects/src/identity/sys-user.object.ts
@@ -395,6 +395,19 @@ export const SysUser = ObjectSchema.create({
       description: 'When set, the ban auto-clears at this time.',
     }),
 
+    ai_access: Field.boolean({
+      label: 'AI Access',
+      defaultValue: false,
+      group: 'Admin',
+      description:
+        'Whether this user holds an AI seat — grants access to the in-UI AI ' +
+        'agents (build / ask). The framework synthesizes the `ai_seat` ' +
+        'capability from this flag (plugin-hono-server resolveCtx). Assignment ' +
+        'is capped by the licensed / purchased seat count (enforced by ' +
+        '@objectstack/security-enterprise AiSeatPlugin). Owned by objectql ' +
+        '(better-auth is oblivious to this column).',
+    }),
+
     // ── Profile ──────────────────────────────────────────────────
     image: Field.url({
       label: 'Profile Image',

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -324,6 +324,15 @@ export class AuthManager {
       // createAdapterFactory.
       user: {
         ...AUTH_USER_CONFIG,
+        // System-managed per-user capability flag(s). `ai_access` is the
+        // env-side AI-seat marker (single-org env DB has only sys_user, so the
+        // seat lives here as a boolean, not a permission set). better-auth
+        // includes additionalFields in the session user, so resolveCtx reads
+        // it with no extra query and synthesizes the `ai_seat` capability.
+        // `input:false` → not self-settable; set by the entitlement layer/admin.
+        additionalFields: {
+          ai_access: { type: 'boolean', required: false, defaultValue: false, input: false },
+        },
       },
       account: {
         ...AUTH_ACCOUNT_CONFIG,

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -324,15 +324,14 @@ export class AuthManager {
       // createAdapterFactory.
       user: {
         ...AUTH_USER_CONFIG,
-        // System-managed per-user capability flag(s). `ai_access` is the
-        // env-side AI-seat marker (single-org env DB has only sys_user, so the
-        // seat lives here as a boolean, not a permission set). better-auth
-        // includes additionalFields in the session user, so resolveCtx reads
-        // it with no extra query and synthesizes the `ai_seat` capability.
-        // `input:false` → not self-settable; set by the entitlement layer/admin.
-        additionalFields: {
-          ai_access: { type: 'boolean', required: false, defaultValue: false, input: false },
-        },
+        // NOTE: the env-side AI-seat marker `sys_user.ai_access` is deliberately
+        // NOT declared as a better-auth additionalField. sys_user is a
+        // better-auth-MANAGED table and better-auth SELECTs explicit columns, so
+        // declaring it here would make getSession query a column that may not
+        // exist on every env yet → broken auth. Instead the column is owned by
+        // the objectql `SysUser` object def (provisioned by boot schema-sync)
+        // and read by a GUARDED system query in resolveCtx (can only no-op,
+        // never break auth). better-auth stays oblivious to the extra column.
       },
       account: {
         ...AUTH_ACCOUNT_CONFIG,

--- a/packages/plugins/plugin-hono-server/src/hono-plugin.ts
+++ b/packages/plugins/plugin-hono-server/src/hono-plugin.ts
@@ -490,6 +490,16 @@ export class HonoServerPlugin implements Plugin {
                         /* fall back to self-only */
                     }
                 }
+                // Env-side AI-seat marker (ADR: simple model). The single-org
+                // env DB has no permission-set/org dimension for this — the seat
+                // is a boolean on sys_user (a better-auth additionalField, so it
+                // rides on the session user). When set, synthesize the `ai_seat`
+                // capability so the existing per-agent gate (evaluateAgentAccess
+                // → requires `ai_seat`) admits the user with no permission-set
+                // grant. Absent/false → no synthesis (gate denies as before).
+                if ((session.user as any)?.ai_access === true && !permissions.includes('ai_seat')) {
+                    permissions.push('ai_seat');
+                }
                 return {
                     userId,
                     tenantId,

--- a/packages/plugins/plugin-hono-server/src/hono-plugin.ts
+++ b/packages/plugins/plugin-hono-server/src/hono-plugin.ts
@@ -490,15 +490,29 @@ export class HonoServerPlugin implements Plugin {
                         /* fall back to self-only */
                     }
                 }
-                // Env-side AI-seat marker (ADR: simple model). The single-org
-                // env DB has no permission-set/org dimension for this — the seat
-                // is a boolean on sys_user (a better-auth additionalField, so it
-                // rides on the session user). When set, synthesize the `ai_seat`
-                // capability so the existing per-agent gate (evaluateAgentAccess
-                // → requires `ai_seat`) admits the user with no permission-set
-                // grant. Absent/false → no synthesis (gate denies as before).
-                if ((session.user as any)?.ai_access === true && !permissions.includes('ai_seat')) {
-                    permissions.push('ai_seat');
+                // Env-side AI-seat marker (simple model). The single-org env
+                // DB has no permission-set/org dimension for this — the seat is
+                // the boolean `sys_user.ai_access`. Read it with a GUARDED system
+                // query (NOT a better-auth additionalField: sys_user is
+                // better-auth-managed and better-auth SELECTs explicit columns,
+                // so an additionalField would make getSession query a possibly-
+                // missing column → broken auth; a guarded read can only no-op).
+                // When true, synthesize the `ai_seat` capability so the per-agent
+                // gate (evaluateAgentAccess → requires `ai_seat`) admits the user
+                // with no permission-set grant. Absent/false/missing-column →
+                // no synthesis (deny, as before).
+                if (!permissions.includes('ai_seat')) {
+                    try {
+                        const ql = getObjectQL();
+                        const sysCtx = { context: { isSystem: true } };
+                        const uRows = await ql?.find?.(
+                            'sys_user',
+                            { where: { id: userId }, limit: 1, ...sysCtx } as any,
+                        ).catch(() => []);
+                        if ((uRows?.[0] as any)?.ai_access === true) permissions.push('ai_seat');
+                    } catch {
+                        /* no ai_access column / query failed → no seat (safe) */
+                    }
                 }
                 return {
                     userId,


### PR DESCRIPTION
Part 1 of the simplified per-user AI-seat gate (pairs with cloud `feat/ai-seat-simple-model`; both must land together + cloud bumps `.framework-sha`).

**What**: the env DB (Turso) is single-org with only `sys_user`, so the AI seat is a boolean on the user — not a permission set. `resolveCtx` synthesizes the `ai_seat` capability from `sys_user.ai_access`, so the existing per-agent gate (`evaluateAgentAccess` → requires `ai_seat`), catalog filter, and frontend are UNCHANGED — only the seat's source moves to a user field.

**Safe-by-construction** (the important bit): `ai_access` is NOT a better-auth additionalField. `sys_user` is better-auth-managed and better-auth SELECTs explicit columns, so an additionalField would make `getSession` query a column that may not exist on every env yet → broken auth on deploy. Instead:
- the column is owned by the objectql `SysUser` object def (provisioned by boot schema-sync; also makes it an editable field — the management UI is just a checkbox);
- `resolveCtx` reads it via a GUARDED system query (`.catch → []`), so a missing column / failed read can only NO-OP — never break auth;
- better-auth stays oblivious to the column.

**Dormant by default**: nothing sets `ai_access` until the cloud `OS_CLOUD_AI_SEAT_MODE` (default `off`) flips to provision/enforce, or a licensed objectos-ee mounts the AiSeatPlugin.

Built clean (platform-objects + plugin-auth + plugin-hono-server). Cap logic unit-verified in the cloud half (24 tests). Browser-level E2E deferred (env blocker) — merging per explicit owner decision given the safe-by-construction design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)