### PR TITLE
feat(spec): add ToolExecutionContext.userMessageText contract field

### DIFF
--- a/packages/spec/src/contracts/ai-service.ts
+++ b/packages/spec/src/contracts/ai-service.ts
@@ -427,6 +427,13 @@ export interface ToolExecutionContext {
     currentObjectName?: string;
     /** View the user is currently viewing, if known. */
     currentViewName?: string;
+    /**
+     * Text of the latest user message (neutral context, like currentObjectName).
+     * Forwarded so a tool can detect intent — e.g. an explicit confirm/approval —
+     * without re-deriving it from the transcript. Consumers own any semantics.
+     * Populated by whichever layer owns the agent route (cloud, post-ADR-0025).
+     */
+    userMessageText?: string;
     /** Distributed-trace id for cross-service correlation. */
     traceId?: string;
     /**


### PR DESCRIPTION
Adds an optional, neutral `userMessageText` to the `ToolExecutionContext` contract — for a tool to detect explicit user intent (e.g. a confirm/approval) without re-deriving it from the transcript. Consumed by cloud's confirm-before-change gate.

**Scope reduced**: my original change also populated this in `service-ai`'s agent route, but #2325 (ADR-0025) removed `service-ai` from framework (open edition = MCP-only). So this PR now adds **only the contract field**; the value is populated by whichever layer owns the agent route (cloud, post-migration). Safe + forward-looking on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)