### PR TITLE
feat(serve): thread api.enforceProjectMembership to the dispatcher (ADR-0024 D9)

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1354,6 +1354,11 @@ export default class Serve extends Command {
         const apiConfig = (config as any).api ?? {};
         const enableProjectScoping = apiConfig.enableProjectScoping ?? false;
         const projectResolution = apiConfig.projectResolution ?? 'auto';
+        // Per-project membership (sys_environment_member 403 gate) is, by
+        // default, ON whenever project-scoping is on. A host can opt OUT
+        // (env-native auth IS the membership — ADR-0024 D9) by setting
+        // `api.enforceProjectMembership: false`. Undefined → dispatcher default.
+        const enforceProjectMembership = apiConfig.enforceProjectMembership;
         // `requireAuth: true` rejects anonymous requests on `/api/v1/data/*`
         // with HTTP 401 before they reach ObjectQL. Default-on when the
         // stack opts in OR when the resolved tier set includes `auth`
@@ -1383,6 +1388,7 @@ export default class Serve extends Command {
           await kernel.use(
             createDispatcherPlugin({
               scoping: { enableProjectScoping, projectResolution },
+              enforceProjectMembership,
               observability,
             }),
           );


### PR DESCRIPTION
Threads `api.enforceProjectMembership` from the served app's config through to `createDispatcherPlugin` (it was sourcing `enableProjectScoping`/`projectResolution` but silently dropping membership).

**Why:** `enforceProjectMembership` defaults to `scoping.enableProjectScoping` — so the `sys_environment_member` 403 gate was forced ON for any project-scoped host with no way to opt out. ADR-0024 D9 makes **env-native auth the membership** (a valid env session = a member; cross-env is already protected by per-env sessions), so a host needs to disable the redundant cloud-mirror gate. This adds that seam.

**Backward-compatible:** `apiConfig.enforceProjectMembership` is `undefined` for every app that doesn't set it → the dispatcher keeps its existing default (`= enableProjectScoping`). Only an app that explicitly sets `api.enforceProjectMembership: false` changes behavior.

Consumed by cloud `objectos-stack` (forthcoming PR) to retire the `sys_environment_member` access gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
