### PR TITLE
fix(metadata): provision sys_metadata_commit for env kernels (ADR-0067)

### DIFF
--- a/packages/metadata/src/plugin.test.ts
+++ b/packages/metadata/src/plugin.test.ts
@@ -221,3 +221,60 @@ describe('MetadataPlugin._loadFromFileSystem — package provenance stamping', (
         expect(item._provenance).toBeUndefined();
     });
 });
+
+// ─────────────────────────────────────────────────────────────────────────
+// ADR-0067 regression: the package-scoped commit log `sys_metadata_commit`
+// must be registered among the queryable system objects so per-project
+// (cloud) env kernels provision the table at boot. Every publish/apply
+// writes a commit row via `publishPackageDrafts`; the object was omitted
+// from `queryableMetadataObjects` (only the standalone ObjectQLPlugin
+// `environmentId === undefined` path had it), so env builds logged
+// `no such table: sys_metadata_commit` and the commit timeline recorded
+// nothing. init() must register it via the manifest — next to its
+// `sys_metadata_history` sibling — whenever registerSystemObjects is on.
+// ─────────────────────────────────────────────────────────────────────────
+describe('MetadataPlugin — system object provisioning (ADR-0067 commit log)', () => {
+    function fakeCtxWithManifest() {
+        const registered: any[] = [];
+        const manifest = { register: vi.fn((m: any) => registered.push(m)) };
+        const ctx = {
+            logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+            registerService: vi.fn(),
+            getService: vi.fn((name: string) => (name === 'manifest' ? manifest : undefined)),
+        } as any;
+        return { ctx, registered };
+    }
+
+    it('registers sys_metadata_commit alongside its history sibling (env kernel)', async () => {
+        const plugin = new MetadataPlugin({
+            watch: false,
+            config: { bootstrap: 'lazy' },
+            environmentId: 'proj_test',
+            // registerSystemObjects defaults to true → env-kernel provisioning path
+        });
+        const { ctx, registered } = fakeCtxWithManifest();
+
+        await plugin.init(ctx);
+
+        const names = registered.flatMap((m) => m.objects ?? []).map((o: any) => o.name);
+        // The bug: history present, commit absent → the table is never provisioned.
+        expect(names).toContain('sys_metadata_history');
+        expect(names).toContain('sys_metadata_commit');
+    });
+
+    it('registers NOTHING when registerSystemObjects=false (control-plane kernel)', async () => {
+        const plugin = new MetadataPlugin({
+            watch: false,
+            config: { bootstrap: 'lazy' },
+            environmentId: 'proj_test',
+            registerSystemObjects: false,
+        });
+        const { ctx, registered } = fakeCtxWithManifest();
+
+        await plugin.init(ctx);
+
+        // Control-plane owns these tables; per-ADR they must NOT leak into a
+        // kernel that opted out of system-object registration.
+        expect(registered).toHaveLength(0);
+    });
+});

--- a/packages/metadata/src/plugin.ts
+++ b/packages/metadata/src/plugin.ts
@@ -11,6 +11,7 @@ import { applyProtection } from '@objectstack/spec/shared';
 import {
     SysMetadataObject,
     SysMetadataHistoryObject,
+    SysMetadataCommitObject,
     SysMetadataAuditObject,
     SysViewDefinitionObject,
 } from '@objectstack/metadata-core';
@@ -28,9 +29,21 @@ import {
 // metadata write decisions — provisioned alongside the storage tables so
 // `_lock` enforcement always has a place to record decisions, even when
 // the deployment skipped @objectstack/plugin-audit.
+//
+// `SysMetadataCommitObject` (ADR-0067) is the package-scoped commit log that
+// GROUPS a turn's `sys_metadata_history` events (the unit `revertCommit`
+// operates on). It MUST be provisioned alongside its history sibling: every
+// publish/apply writes a commit row, so a per-project (cloud) env kernel that
+// omitted it hit `no such table: sys_metadata_commit` on the first AI build —
+// the write is best-effort so the build still landed, but the error spammed
+// logs and the commit timeline silently recorded nothing. Registered here
+// (not only in the ObjectQLPlugin `environmentId === undefined` standalone
+// path) so env kernels — the only place this table is written — get it.
 const queryableMetadataObjects = [
     SysMetadataObject,
     SysMetadataHistoryObject,
+    // ADR-0067 commit log — sibling of sys_metadata_history (see note above).
+    SysMetadataCommitObject,
     SysMetadataAuditObject,
     // Runtime view storage (shared / personal). Must always be provisioned so
     // end-user view creation via the generic data API has a place to write —


### PR DESCRIPTION
## Problem
An AI build into a tenant env logs a hard `SqliteError: no such table: sys_metadata_commit`. The build still lands (objects/views/dashboard register), but the ADR-0067 commit-history write fails, so every AI build/edit spams the error and the commit timeline silently records nothing.

## Root cause
The metadata-storage objects are registered through **two parallel paths that must stay in sync**:
1. `ObjectQLPlugin` registers the full set `[sys_metadata, history, commit, audit, view_definition]` — but only when `environmentId === undefined` (platform / standalone kernels).
2. `MetadataPlugin.queryableMetadataObjects` is what per-project **cloud env kernels** actually provision (`artifact-kernel-factory` boots it with `registerSystemObjects:true` + ObjectQL `skipSchemaSync:false` → boot-sync DDLs every registered object).

ADR-0067 added `SysMetadataCommitObject` to list (1) but **not** (2), so env DBs never got the `sys_metadata_commit` table. Every build's `publishPackageDrafts` writes a commit row (`op='apply'`) → `no such table`. Same class as the already-merged audit/messaging lazy-table provisioning fix.

## Fix
Add `SysMetadataCommitObject` to `queryableMetadataObjects`, next to its `sys_metadata_history` sibling (+ import + unit test). One object, +70 lines.

## Verification
- **Unit test** (`plugin.test.ts`): a new test asserts `init()` registers `sys_metadata_commit` — **fails without the fix** (`expected [4 elements] to include 'sys_metadata_commit'`), passes with it. Full metadata suite: **254 passed**.
- **Real-engine before/after**: a kernel booted with the exact env-kernel triple (`DriverPlugin('cloud')` + `ObjectQLPlugin(skipSchemaSync:false)` + `MetadataPlugin(registerSystemObjects:true)`) over real better-sqlite3 — boot-sync goes **`synced:4 → 5`**, and the writer's `insert('sys_metadata_commit', …)` **reproduces the exact reported error unfixed / succeeds fixed**.

## Deploy
After merge, bump cloud `.framework-sha` to pull this into staging/prod (same flow as the audit/messaging fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)