### PR TITLE
chore(client): remove dead projects.* env-member SDK methods (ADR-0024 D9)

### DIFF
--- a/.changeset/client-remove-env-member-methods.md
+++ b/.changeset/client-remove-env-member-methods.md
@@ -1,0 +1,15 @@
+---
+"@objectstack/client": patch
+---
+
+chore(client): remove dead `projects.*` env-member SDK methods (cloud#533 / ADR-0024 D9)
+
+Removes `projects.listMembers` / `addMember` / `updateMemberRole` / `removeMember`,
+which called `GET/POST/PATCH/DELETE /api/v1/cloud/environments/:id/members`. Those
+control-plane endpoints were deleted in cloud#533 (retiring `sys_environment_member`),
+so the methods returned 404. Org membership/invites now flow through the better-auth
+`organization` plugin (`organization.inviteMember` / `listMembers` / …); objectui
+already uses `organization.*` and no in-repo callers remained.
+
+The `membership` field on the `projects.get()` response is unchanged — cloud#533 still
+returns it on the single-env GET (re-sourced to the caller's org `sys_member` role).

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -880,64 +880,6 @@ export class ObjectStackClient {
     },
 
     /**
-     * List members of a project (per-project RBAC).
-     */
-    listMembers: async (id: string) => {
-      const res = await this.fetch(`${this.baseUrl}/api/v1/cloud/environments/${encodeURIComponent(id)}/members`);
-      return this.unwrapResponse<{ members: any[] }>(res);
-    },
-
-    /**
-     * Invite a member to a project. Caller must be `owner` or `admin`.
-     * Pass either `email` (resolved against the user table) or `user_id`.
-     * Returns `{ member, alreadyMember }` — `alreadyMember=true` means the
-     * row already existed; the call is idempotent.
-     */
-    addMember: async (
-      id: string,
-      payload: { email?: string; user_id?: string; role?: 'owner' | 'admin' | 'member' | 'viewer' },
-    ) => {
-      const res = await this.fetch(`${this.baseUrl}/api/v1/cloud/environments/${encodeURIComponent(id)}/members`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
-      return this.unwrapResponse<{ member: any; alreadyMember: boolean }>(res);
-    },
-
-    /**
-     * Update a member's role. Caller must be `owner` or `admin`. Demoting
-     * the last `owner` returns 409.
-     */
-    updateMemberRole: async (
-      id: string,
-      memberId: string,
-      role: 'owner' | 'admin' | 'member' | 'viewer',
-    ) => {
-      const res = await this.fetch(
-        `${this.baseUrl}/api/v1/cloud/environments/${encodeURIComponent(id)}/members/${encodeURIComponent(memberId)}`,
-        {
-          method: 'PATCH',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ role }),
-        },
-      );
-      return this.unwrapResponse<{ member: any }>(res);
-    },
-
-    /**
-     * Remove a member. Owners/admins may remove anyone; non-privileged
-     * users may only remove themselves. Removing the last `owner` returns 409.
-     */
-    removeMember: async (id: string, memberId: string) => {
-      const res = await this.fetch(
-        `${this.baseUrl}/api/v1/cloud/environments/${encodeURIComponent(id)}/members/${encodeURIComponent(memberId)}`,
-        { method: 'DELETE' },
-      );
-      return this.unwrapResponse<{ removed: boolean; memberId: string }>(res);
-    },
-
-    /**
      * List ObjectQL drivers registered on the server. Useful for populating a
      * driver selector when provisioning a new project (memory / turso /
      * future sql drivers). Returned `name` is the short alias (e.g. `memory`,


### PR DESCRIPTION
## What
Removes the four dead `projects.*` env-member methods from the `@objectstack/client` SDK:
- `projects.listMembers(id)` → `GET /api/v1/cloud/environments/:id/members`
- `projects.addMember(id, payload)` → `POST …/members`
- `projects.updateMemberRole(id, memberId, role)` → `PATCH …/members/:memberId`
- `projects.removeMember(id, memberId)` → `DELETE …/members/:memberId`

## Why
These control-plane endpoints were **deleted in cloud#533** (retiring `sys_environment_member`, ADR-0024 D9), so the methods now return **404**. Org membership/invites flow through the better-auth `organization` plugin (`organization.inviteMember`/`listMembers`/…). objectui already uses `organization.*`, and there are **no in-repo callers** of the removed methods.

This is the framework-side follow-up explicitly called out in cloud#533's PR description.

## Kept (intentionally)
- The `membership?: any` field on `projects.get()` — cloud#533 still returns it on the single-env GET (re-sourced to the caller's org `sys_member` role), so `packages/cli/src/commands/environments/show.ts` (`res?.membership?.role`) is unchanged.
- `organization.*` and `organization.teams.*` member methods (better-auth) — untouched.

## Verification
- grep (repo-wide): **0 callers** of the removed methods
- `turbo run build --filter=@objectstack/client`: ✅ (DTS clean)
- `tsc --noEmit`: ✅ clean
- `@objectstack/client` tests: ✅ **106 passed (106)**

Changeset: `patch` (removing dead, zero-caller methods; `@objectstack/client` is in the platform `fixed` version group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
