### PR TITLE
fix(identity): sys_verification.value must not be UNIQUE — breaks OIDC authorize (503)

### DIFF
--- a/packages/platform-objects/src/identity/sys-verification.object.ts
+++ b/packages/platform-objects/src/identity/sys-verification.object.ts
@@ -67,7 +67,13 @@ export const SysVerification = ObjectSchema.create({
   },
   
   indexes: [
-    { fields: ['value'], unique: true },
+    // `value` must NOT be unique. better-auth's oauth-provider stores OIDC
+    // authorization codes in this table with `value` = a JSON blob keyed by
+    // user+client+state, which can legitimately repeat. A UNIQUE constraint
+    // makes `/api/v1/auth/oauth2/authorize` fail (`UNIQUE constraint failed:
+    // sys_verification.value`) → 503, breaking cloud-as-IdP SSO entirely.
+    // better-auth keys verification lookups on `identifier`, not `value`.
+    { fields: ['value'], unique: false },
     { fields: ['identifier'], unique: false },
     { fields: ['expires_at'], unique: false },
   ],


### PR DESCRIPTION
## Bug
`/api/v1/auth/oauth2/authorize` (the cloud-as-IdP OP) returns **HTTP 503** with:
```
UNIQUE constraint failed: sys_verification.value
```
better-auth's `oauth-provider` stores OIDC **authorization codes** in the verification table with `value` = a JSON blob (`{type:"authorization_code", query:{…,state}, userId, sessionId, …}`). That blob can legitimately repeat (same user+client+state on retry), but `sys-verification.object.ts` declared `{ fields: ['value'], unique: true }` → the insert violates the constraint → 503.

**Impact:** the env→cloud OIDC SSO ("Continue with ObjectStack", ADR-0024 D3) **loops forever** — the cloud login SPA re-issues the signed authorize request every ~20s and never completes.

## Fix
`value` → `unique: false` (keep the index for lookups; better-auth keys on `identifier`, not `value`).

## Found via
Local browser E2E of the env-side SSO against a real cloud OP (anonymous env login → "Continue with ObjectStack"). Confirmed in the server log (`SqliteError … SQLITE_CONSTRAINT_UNIQUE`); dropping `uniq_sys_verification_value` in the live DB stopped the UNIQUE errors.

## Follow-ups (separate)
- **Migration:** existing control-plane DBs already have `uniq_sys_verification_value`; schema-sync is additive, so they need a one-off `DROP INDEX`.
- **Frontend:** even with this fixed, the cloud login SPA does not navigate to the authorize success redirect (200-with-body) — the OIDC SSO still needs a frontend fix to complete. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
