### PR TITLE
fix(runtime): accept integer ai_access (Turso) in AI-seat synthesis

### DIFF
--- a/packages/plugins/plugin-hono-server/src/hono-plugin.ts
+++ b/packages/plugins/plugin-hono-server/src/hono-plugin.ts
@@ -509,7 +509,9 @@ export class HonoServerPlugin implements Plugin {
                             'sys_user',
                             { where: { id: userId }, limit: 1, ...sysCtx } as any,
                         ).catch(() => []);
-                        if ((uRows?.[0] as any)?.ai_access === true) permissions.push('ai_seat');
+                        // Turso returns sqlite booleans as 1/0; memory driver as boolean.
+                        const aiAccess = (uRows?.[0] as any)?.ai_access;
+                        if (aiAccess === true || aiAccess === 1 || aiAccess === '1') permissions.push('ai_seat');
                     } catch {
                         /* no ai_access column / query failed → no seat (safe) */
                     }

--- a/packages/runtime/src/security/resolve-execution-context.ts
+++ b/packages/runtime/src/security/resolve-execution-context.ts
@@ -414,7 +414,11 @@ export async function resolveExecutionContext(opts: ResolveOptions): Promise<Exe
   // Guarded (tryFind swallows errors) → can only ever ADD access, never break auth.
   if (userId && !ctx.permissions!.includes('ai_seat')) {
     const seatRows = await tryFind(ql, 'sys_user', { id: userId }, 1);
-    if ((seatRows?.[0] as { ai_access?: unknown } | undefined)?.ai_access === true) {
+    // Turso/libSQL returns sqlite booleans as integer 1/0; the memory driver
+    // returns a JS boolean. Accept both (+ the stringified form) so the seat
+    // resolves regardless of the env's data driver.
+    const aiAccess = (seatRows?.[0] as { ai_access?: unknown } | undefined)?.ai_access;
+    if (aiAccess === true || aiAccess === 1 || aiAccess === '1') {
       ctx.permissions!.push('ai_seat');
     }
   }


### PR DESCRIPTION
Third issue caught by real staging: `sys_user.ai_access` reads back as integer `1` on Turso, but the synthesis checked `=== true` → `1 !== true` → seated users denied. Memory driver returns boolean, masking it locally. Accept `true | 1 | '1'` in resolveExecutionContext (gate) + hono-plugin (data-route). 🤖 Generated with [Claude Code](https://claude.com/claude-code)