### PR TITLE
docs(ai-capabilities): in-UI ask & build are cloud/Enterprise, not open-source

### DIFF
--- a/content/docs/guides/ai-capabilities.mdx
+++ b/content/docs/guides/ai-capabilities.mdx
@@ -50,8 +50,13 @@ is in — the user never picks from a roster:
 
 | Agent | Surface | Does | Edition |
 |---|---|---|---|
-| **`ask`** | data console | Read / query / explore records + run the business **actions** the app exposes. RLS-bounded. | open-source · free |
-| **`build`** | Studio | Author *metadata* (objects, fields, views, flows) via plan → draft → verify → publish. | cloud · paid |
+| **`ask`** | data console | Read / query / explore records + run the business **actions** the app exposes. RLS-bounded. | cloud / Enterprise |
+| **`build`** | Studio | Author *metadata* (objects, fields, views, flows) via plan → draft → verify → publish. | cloud / Enterprise |
+
+Both in-UI agents ship in the **cloud / Enterprise** distribution, not the open
+framework. A self-hosted **open-source** runtime has no in-product `ask`/`build`
+assistant; it instead exposes the same objects, queries, and actions to *your own*
+AI through **`@objectstack/mcp`** (bring-your-own-AI) — see the note at the top.
 
 There is no per-turn intent classifier and no agent dropdown: the surface binds
 the agent (data console → `ask`, Studio → `build`). A `build`-shaped request that
@@ -68,8 +73,10 @@ Actions / Flows / queries; it then attaches to `ask`. Every skill declares
 surface-compatible skills' tools** — there is no global fall-through, so a skill
 reaches an agent only when their surfaces match
 ([ADR-0064](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0064-tool-scoping-to-agent.md)).
-`surface:'build'` skills are inert on the open-source framework (the `build` agent
-is cloud-only) — intentional tiering, not a bug.
+The in-UI `ask` and `build` agents are cloud / Enterprise only, so
+`surface:'ask'` / `surface:'build'` skills bind no in-product agent on the
+open-source framework — there you reach the same Actions, Flows, and queries
+through `@objectstack/mcp` instead. Intentional tiering, not a bug.
 
 ### The shape of an agent
 


### PR DESCRIPTION
The **AI Capabilities Guide** contradicted itself on edition gating.

The note at the top of the guide states the in-UI AI runtime (the `ask`/`build` assistants, in-product chat) ships in the **cloud / Enterprise** distribution, and the open framework instead exposes objects, queries, and actions to your own AI through `@objectstack/mcp` (BYO-AI). But:

- the **agent table** marked `ask` as `open-source · free`, and
- the **skills section** called only `build` "cloud-only" (implying `ask` is open-source).

Both reasserted the pre-migration model. This aligns the guide:

- Agent table: both `ask` and `build` → **cloud / Enterprise**.
- Add a one-paragraph pointer under the table: the open-source runtime has no in-product assistant; it reaches the same objects/queries/actions via `@objectstack/mcp`.
- Skills tiering note: both in-UI agents are cloud/Enterprise only, so `surface:'ask'`/`surface:'build'` skills bind no in-product agent on the open framework — use MCP there.

Docs-only change. Surfaced while updating the marketing site ([www.objectos.ai#32](https://github.com/objectstack-ai/www.objectos.ai/pull/32)) to the same edition split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
