### PR TITLE
docs: fix responsiveStyles keys + dataset include (found dogfooding #2338)

### DIFF
--- a/content/docs/guides/analytics-datasets.mdx
+++ b/content/docs/guides/analytics-datasets.mdx
@@ -135,10 +135,13 @@ capability the inline single-object query could never reach:
 // → revenue by account.region, joined + RLS-enforced per object.
 ```
 
-Joins follow **dotted relationship paths** and may traverse **multiple to-one hops**
-(ADR-0071) — e.g. `account.owner.region` walks the chain order → account → owner →
-region. The path is capped at **3 join hops (4 objects)** and is **to-one only**;
-to-many traversal is rejected (aggregate the many-side as its own measure instead).
+Joins are **derived from the dataset's `include` declarations**: list the relationship
+paths to join (`include: ['account', 'account.owner']`), and dimensions/measures then
+reference fields along them by **dotted path** (`account.owner.region`). Only declared
+paths are joinable. Paths may chain **multiple to-one hops** (ADR-0071 — declaring
+`account.owner` implicitly includes `account`), are capped at **3 join hops (4 objects)**,
+and are **to-one only**; to-many traversal is rejected (aggregate the many-side as its
+own measure instead).
 
 ## How it runs
 

--- a/content/docs/guides/metadata/page.mdx
+++ b/content/docs/guides/metadata/page.mdx
@@ -136,7 +136,7 @@ Components are the building blocks placed inside regions.
 | `events` | `Record<string, string>` | optional | Event handlers (action expressions) |
 | `style` | `object` | optional | CSS styles |
 | `className` | `string` | optional | CSS class names |
-| `responsiveStyles` | `object` | optional | **Preferred** SDUI styling channel (ADR-0065): per-breakpoint scoped CSS-property maps keyed by `xs`/`sm`/`md`/`lg`/`xl`/`2xl`, compiled to id-scoped CSS at render. Prefer design tokens, e.g. `{ base: { padding: 'var(--space-6)' }, md: { padding: 'var(--space-8)' } }`. Use over ad-hoc `style`/`className` for metadata-authored pages. |
+| `responsiveStyles` | `object` | optional | **Preferred** SDUI styling channel (ADR-0065): **desktop-first** per-breakpoint scoped style maps, compiled to id-scoped CSS at render. Keys are `large` (the unconditional base), then `medium` / `small` / `xsmall` as `max-width` overrides. Prefer design tokens, e.g. `{ large: { padding: 'var(--space-8)' }, small: { padding: 'var(--space-4)' } }`. Use over ad-hoc `style` / `className` for metadata-authored pages. |
 | `visibility` | `string` | optional | Visibility predicate (CEL expression) |
 
 The `type` field is a union of the standard `PageComponentType` enum and any custom string. The standard (namespaced) component types include:


### PR DESCRIPTION
## What

Two doc inaccuracies in #2338, **found by dogfooding** (booted `app-showcase`, exercised the newly-documented features at runtime).

## Verified working (no change needed)
- **`$search` / `searchableFields`** (ADR-0061): `$search=technology` on `showcase_account` returned the 4 technology accounts — matching on the `industry` field, proving it searches the declared `searchableFields`, not just name.
- **Multi-hop dataset joins** (ADR-0071): an inline dataset on `showcase_invoice_line` with `include: ['invoice.account']` + dimension `invoice.account.industry` returned correctly grouped rows and the expected chained `LEFT JOIN ... LEFT JOIN ...` SQL.

## Fixed
- **`page.mdx` — `responsiveStyles` breakpoint keys were wrong.** Documented as `xs/sm/md/lg/xl/2xl`, but `ResponsiveStylesSchema` uses **`large` / `medium` / `small` / `xsmall`** (desktop-first: `large` = unconditional base, the rest are `max-width` overrides). The `xs..2xl` axis is `BreakpointName`, used for layout columns/visibility/order — a different axis. Confirmed against the served `showcase_styling_gallery` page metadata (key: `large`).
- **`analytics-datasets.mdx` — multi-hop joins need an `include` declaration.** The prior text implied any dotted path joins; in fact joins are **derived from the dataset's `include`** and only declared paths are joinable. Now shows `include: ['account', 'account.owner']`.

## Not exercised
`access`/`requiredPermissions` (ADR-0066) and `controlled_by_parent` RLS derivation (ADR-0055) are config-verified (showcase ships them; server boots & accepts them; spec/plugin-security confirmed by audit) but their E2E enforcement wasn't exercised — provisioning a scope-limited test principal needs role-assignment plumbing beyond a quick API pass. Those docs are accurate as written.

Docs-only. Build Docs CI validates MDX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
