### PR TITLE
fix(cli): redirect Console on a bare/reserved platform host to the cloud console

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -859,8 +859,23 @@ export default class Serve extends Command {
                 if (!isPlatformHost) return next();
                 const sub = host === __rootDomain ? '' : host.slice(0, -(__rootDomain.length + 1));
                 const head = sub.split('.').pop() || '';
-                if (RESERVED.has(sub) || RESERVED.has(head)) return next();
                 const p = c.req.path;
+                if (RESERVED.has(sub) || RESERVED.has(head)) {
+                  // A browser loading the Console on a bare/reserved platform host
+                  // (the apex or `www`/`app`/… — none bind a tenant env) gets the
+                  // Console SPA, but its `/api/v1/auth/*` calls 404 (no env → no
+                  // auth) → a dead "Auth request failed with status 404" login.
+                  // When this runtime is cloud-connected (`OS_CLOUD_URL` set), send
+                  // Console requests to the cloud control plane to pick/open an
+                  // environment instead. A self-hosted single-env runtime (no
+                  // `OS_CLOUD_URL`) keeps the prior pass-through. Non-console paths
+                  // (infra, health, /api) fall through below unchanged.
+                  const cloudUrl = (process.env.OS_CLOUD_URL || '').trim();
+                  if (cloudUrl && (p === '/_console' || p.startsWith('/_console/'))) {
+                    return c.redirect(`${cloudUrl.replace(/\/+$/, '')}/_console/`, 302);
+                  }
+                  return next();
+                }
                 if (p.startsWith('/_admin/') || p === '/_admin' || p.startsWith('/.well-known/')) {
                   return next();
                 }


### PR DESCRIPTION
## The "dead login face"

`objectstack serve` / `dev` serves the Console SPA on **any** host, but a bare/reserved platform host (the apex, or `www`/`app`/… — none bind a tenant env) has no env → its `/api/v1/auth/*` calls **404** → the login renders the misleading **"Auth request failed with status 404"** dead form. The unknown-hostname guard already passes reserved hosts through (`RESERVED` includes the empty/apex subdomain), so the SPA loads and breaks.

## Fix
In the guard, when a reserved/apex platform host gets a `/_console*` request **and** the runtime is cloud-connected (`OS_CLOUD_URL` set), **302 it to the cloud control plane** (`OS_CLOUD_URL` + `/_console/`). A self-hosted single-env runtime (no `OS_CLOUD_URL`) keeps the prior pass-through; non-console paths (infra, health, `/api`) are unchanged; a real env host resolves to a tenant and is served normally.

## Verification
Mirrors the same cleanup on the **cloud** `serve-node` path (objectos `server/index.ts`), which was **verified live**: bare `localhost/_console/login` → `302` → cloud console; `/api/v1/auth/*` still `404`; env host `/_console` → `200`. `@objectstack/cli` build green (DTS typecheck clean).

Found while dogfooding the magic moment locally (`run-stack.sh --seed` boots objectos via `objectstack dev` → this guard). The cloud-side mirror is a separate cloud PR; a cloud `.framework-sha` bump consumes this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)