### PR TITLE
chore(release): major changeset — open edition is MCP-only (cut 11.0)

### DIFF
--- a/.changeset/v11-open-edition-mcp-only.md
+++ b/.changeset/v11-open-edition-mcp-only.md
@@ -1,0 +1,12 @@
+---
+"@objectstack/spec": major
+---
+
+Open edition is MCP-only.
+
+The bundled AI authoring service (`@objectstack/service-ai`) is no longer part of
+the open distribution (ADR-0025 S2, #2325); AI now integrates through MCP
+(`@objectstack/mcp`) and the documented opt-in seam — an app that declares
+`@objectstack/service-ai` / `@objectstack/service-ai-studio` still loads the
+service. Removing a published package from the open edition is a breaking change,
+so this cuts the next release as a major.


### PR DESCRIPTION
## What
Adds the missing **major** changeset so the next release cuts **11.0.0**.

## Why
The breaking removal of the bundled AI service — [#2325](https://github.com/objectstack-ai/framework/pull/2325) `feat(framework)!: remove service-ai — open edition is MCP-only (ADR-0025 S2)` — is merged to `main` but **unreleased** (81 commits past the `10.3.0` tag) and **shipped no changeset** (it only edited `.changeset/config.json` to drop service-ai from the fixed group).

The 44 pending changesets are all `minor`/`patch` (**0 major**), so whoever triggers the next release would bump the fixed group to **10.4.0** — leaking the removal of a published package out as a *minor*, violating SemVer. This adds the one major changeset needed to flip it to 11.0.0; the fixed group of 73 packages bumps together, so every pending change folds into 11.0.

## Notes
- Wording is deliberately low-key/factual — "open edition is MCP-only" — not a marketing announcement. The open edition keeps a working AI-integration surface via `@objectstack/mcp` plus the documented opt-in seam (`@objectstack/service-ai` / `-studio`).
- No code change — changeset only. `check-changeset-fixed.mjs` passes; `changeset status` projects a **major** bump.
- Other intentionally-`minor` breaking removals (e.g. `page-hard-remove-dead-schemas`) ride along into 11.0 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)