### PR TITLE
fix(auth): trust public-routable external-IdP origins at SSO registration (ADR-0024 / cloud#551)

### DIFF
--- a/.changeset/adr-0024-sso-public-idp-trust.md
+++ b/.changeset/adr-0024-sso-public-idp-trust.md
@@ -1,0 +1,11 @@
+---
+'@objectstack/plugin-auth': patch
+---
+
+Auth: trust public-routable external-IdP origins at SSO registration (ADR-0024 / cloud#551)
+
+`@better-auth/sso`'s discovery validation requires every IdP endpoint origin to be in `trustedOrigins` — even for a publicly-routable IdP. That broke ADR-0024's "register your OIDC IdP at runtime, no boot config" promise: registering any external IdP returned `400 discovery_untrusted_origin` unless the operator had pre-listed it.
+
+When the external-SSO RP is enabled, `trustedOrigins` is now exposed as a per-request function that, for a `POST /sso/register` | `/sso/update-provider`, additionally trusts the **public-routable** issuer / `oidcConfig` endpoint origins declared in the request body (via `@better-auth/core`'s own `isPublicRoutableHost`). Private / internal / loopback hosts are never auto-trusted — they still require explicit `trustedOrigins` config (the documented SSRF escape hatch), and better-auth's own DNS-resolution checks still apply.
+
+Verified: a same-origin public IdP (GitLab.com — issuer and all discovered endpoints on one origin, like Okta / Entra / Auth0 / Keycloak) now registers at runtime with no boot config (was a hard 400). The admin gate still fires first (a non-admin is rejected before discovery runs). Note: IdPs that split endpoints across multiple domains (e.g. Google's `accounts.google.com` + `oauth2.googleapis.com`) still need those extra origins in `trustedOrigins`.

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -802,6 +802,32 @@ export class AuthManager {
           origins.push('http://*.localhost:*');
           origins.push('https://*.localhost:*');
         }
+        // ── ADR-0024: runtime self-service external-IdP registration ───────
+        // `@better-auth/sso`'s `validateDiscoveryUrl` requires the IdP's
+        // *discovery* origin to be in `trustedOrigins` — even for a publicly-
+        // routable IdP (stricter than its own sub-endpoint check, which allows
+        // any public host). Without help that breaks ADR-0024's "register your
+        // IdP at runtime, no boot config" promise for every real IdP
+        // (Okta/Entra/Google). When the SSO RP is enabled, expose
+        // `trustedOrigins` as a per-request FUNCTION that, for a
+        // `/sso/register` | `/sso/update-provider` POST, additionally trusts the
+        // PUBLIC-ROUTABLE issuer / discovery origins declared in the request
+        // body. Private / internal hosts are never auto-trusted — they still
+        // require explicit `trustedOrigins` config (the documented SSRF escape
+        // hatch), and better-auth's own DNS-resolution checks still apply.
+        if (this.isSsoWired()) {
+          return {
+            trustedOrigins: async (request?: Request) => {
+              const base = [...origins];
+              try {
+                for (const o of await this.ssoDiscoveryTrustedOrigins(request)) {
+                  if (!base.includes(o)) base.push(o);
+                }
+              } catch { /* never let trust resolution throw */ }
+              return base;
+            },
+          };
+        }
         return origins.length ? { trustedOrigins: origins } : {};
       })(),
 
@@ -1858,6 +1884,50 @@ export class AuthManager {
       return typeof count === 'number' ? count > 0 : true;
     } catch {
       return true; // provider introspection failed — keep the wired behaviour
+    }
+  }
+
+  /**
+   * Extra `trustedOrigins` entries derived from an external-SSO registration
+   * request. For a `POST /sso/register` | `/sso/update-provider`, parse the
+   * (cloned) body and return the PUBLIC-ROUTABLE origins of the declared
+   * `issuer` / `oidcConfig` endpoints so `@better-auth/sso`'s discovery
+   * validation accepts a customer IdP registered at runtime (ADR-0024) without
+   * the operator pre-listing it in boot config. Only public-routable hosts are
+   * returned — private / internal / loopback hosts are never auto-trusted
+   * (better-auth's `isPublicRoutableHost`, the same predicate its own
+   * sub-endpoint check uses). Best-effort: any parse error yields `[]`.
+   */
+  private async ssoDiscoveryTrustedOrigins(request: unknown): Promise<string[]> {
+    try {
+      const req = request as { url?: string; method?: string; clone?: () => Request } | undefined;
+      if (!req || typeof req.clone !== 'function' || !req.url) return [];
+      if ((req.method ?? 'GET').toUpperCase() !== 'POST') return [];
+      const path = new URL(req.url).pathname;
+      if (!/\/sso\/(register|update-provider)$/.test(path)) return [];
+      const body = await req.clone().json().catch(() => null);
+      if (!body || typeof body !== 'object') return [];
+      const oidc = (body as any).oidcConfig ?? {};
+      const candidates = [
+        (body as any).issuer,
+        oidc.discoveryEndpoint,
+        oidc.authorizationEndpoint,
+        oidc.tokenEndpoint,
+        oidc.jwksEndpoint,
+        oidc.userInfoEndpoint,
+      ].filter((v): v is string => typeof v === 'string' && v.length > 0);
+      if (!candidates.length) return [];
+      const { isPublicRoutableHost } = await import('@better-auth/core/utils/host');
+      const out: string[] = [];
+      for (const c of candidates) {
+        try {
+          const u = new URL(c);
+          if (isPublicRoutableHost(u.hostname) && !out.includes(u.origin)) out.push(u.origin);
+        } catch { /* skip malformed URL */ }
+      }
+      return out;
+    } catch {
+      return [];
     }
   }
 


### PR DESCRIPTION
## Why
Follow-up to #2363 (the cloud#551 SSO admin-gate). Local E2E surfaced a second gap: `@better-auth/sso`'s discovery validation (`validateDiscoveryUrl` + `normalizeAndValidateUrl`) requires **every** IdP endpoint origin to be in `trustedOrigins` — even for a publicly-routable IdP. So registering any external OIDC IdP returns `400 discovery_untrusted_origin` unless the operator pre-listed it, which **breaks ADR-0024's "register your IdP at runtime, no boot config" promise**.

## What
When the external-SSO RP is enabled (`isSsoWired()`), `trustedOrigins` is now a per-request function that, for a `POST /sso/register` | `/sso/update-provider`, additionally trusts the **public-routable** issuer / `oidcConfig` endpoint origins declared in the request body — using `@better-auth/core`'s own `isPublicRoutableHost` (the same predicate better-auth's sub-endpoint check uses). All other requests get exactly the previous static origins.

Safety:
- **Private / internal / loopback hosts are never auto-trusted** — they still require explicit `trustedOrigins` config (the documented SSRF escape hatch).
- better-auth's own DNS-resolution checks still apply.
- The function is only consulted for the two SSO admin paths; normal CSRF/origin behavior is unchanged.

## Verification (browser E2E, local prod-like stack, **no** trustedOrigins entry)
- Same-origin public IdP **GitLab.com** (issuer + all discovered endpoints on one origin — like Okta / Entra / Auth0 / Keycloak) → register **200, oidcConfig hydrated** from GitLab's live discovery (was a hard `400`).
- Google's main discovery URL now passes too; Google still needs its split `googleapis.com` endpoint origins trusted (documented caveat — multi-domain IdPs).
- **Regression:** a non-admin registering a valid public IdP is still **403** (the #2363 admin gate fires before discovery); normal auth flows intact.

## Scope
Only `packages/plugins/plugin-auth/src/auth-manager.ts` (+ changeset). SSO mechanism stays framework-open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)