### PR TITLE
fix(auth): make the SSO Providers list visible to admins (ADR-0024 / cloud#551)

### DIFF
--- a/.changeset/adr-0024-sso-list-visibility.md
+++ b/.changeset/adr-0024-sso-list-visibility.md
@@ -1,0 +1,13 @@
+---
+'@objectstack/platform-objects': patch
+---
+
+Auth: make the SSO Providers list visible to admins (ADR-0024 / cloud#551)
+
+The `sys_sso_provider` Setup list rendered empty even after an admin registered a provider: `member_default`'s wildcard `tenant_isolation` RLS (`organization_id == current_user.organization_id`) denied every row, because better-auth writes these via its adapter with no tenantId context so `organization_id` is never stamped, and the platform-admin `viewAllRecords` superuser bypass is gated to private/non-tenant objects.
+
+`sys_sso_provider` is env-global, admin-only identity config, so it now declares:
+- `tenancy: { enabled: false }` — opts out of multi-tenancy (the env IS the tenant; providers are env-wide), letting a platform admin's `viewAllRecords` bypass see every provider.
+- `requiredPermissions: ['manage_platform_settings']` — object-level capability gate so ordinary members are denied (without it, tenancy-disabled + `member_default`'s `'*': allowRead` would expose providers to every authenticated user).
+
+Verified E2E: an admin sees all env providers in the Setup → Access Control → SSO Providers list; a non-admin gets 403. (Env-only object — no control-plane cross-tenant impact. The sibling `sys_oauth_application` / `sys_account` nav entries share the same empty-list symptom but span the control plane and need separate per-object analysis.)

--- a/packages/platform-objects/src/identity/sys-sso-provider.object.ts
+++ b/packages/platform-objects/src/identity/sys-sso-provider.object.ts
@@ -31,6 +31,22 @@ export const SysSsoProvider = ObjectSchema.create({
   icon: 'shield-check',
   isSystem: true,
   managedBy: 'better-auth',
+  // ADR-0024 — env-global, ADMIN-ONLY identity config. Two orthogonal controls:
+  //   • `tenancy.enabled: false` — the env IS the tenant; providers are env-wide,
+  //     not org-partitioned. Opting out of multi-tenancy lets a platform admin's
+  //     `viewAllRecords` superuser bypass see every provider (without it, the
+  //     `member_default` wildcard `tenant_isolation` RLS denies every row, since
+  //     better-auth writes via its adapter with no tenantId → `organization_id`
+  //     is never stamped).
+  //   • `requiredPermissions: ['manage_platform_settings']` — object-level
+  //     capability gate (ADR-0066 D3) so ordinary members are denied entirely
+  //     (without it, tenancy-disabled + `member_default`'s `'*': allowRead` would
+  //     leak providers to every authenticated user).
+  // Together: admins see all env providers; non-admins get 403. better-auth's
+  // own endpoints already read via a system context. (Env-only object — no
+  // control-plane cross-tenant risk.)
+  tenancy: { enabled: false, strategy: 'shared' },
+  requiredPermissions: ['manage_platform_settings'],
   // ADR-0010 §3.7 — managed by better-auth; tenants may not edit schema.
   protection: {
     lock: 'full',


### PR DESCRIPTION
## Why
After an admin registers an external IdP, the **Setup → Access Control → SSO Providers** list rendered **empty**. `member_default`'s wildcard `tenant_isolation` RLS (`organization_id == current_user.organization_id`) denied every row — better-auth writes `sys_sso_provider` via its adapter with no tenantId context, so `organization_id` is never stamped, and the platform-admin `viewAllRecords` superuser bypass is gated to private/non-tenant objects.

## What
`sys_sso_provider` is **env-global, admin-only** identity config, so it now declares:
- `tenancy: { enabled: false }` — opts out of multi-tenancy (the env IS the tenant; providers are env-wide), so a platform admin's `viewAllRecords` bypass sees every provider.
- `requiredPermissions: ['manage_platform_settings']` — object-level capability gate so ordinary members are **denied** (without it, tenancy-disabled + `member_default`'s `'*': allowRead` would leak providers to every authenticated user — I verified that leak before adding this).

## Verification (browser E2E)
- **Admin** → Setup list shows all env providers (`total=1`, the registered `gl` row renders); register form still works.
- **Non-admin** → `403 'requires capability [manage_platform_settings]'`.

Env-only object (no control-plane cross-tenant impact). The sibling `sys_oauth_application` / `sys_account` nav entries share the same empty-list symptom but span the control plane — separate per-object follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)