### PR TITLE
docs(objectstack-ui): document detail.relatedLayout 'stack' | 'tabs'

### DIFF
--- a/skills/objectstack-ui/SKILL.md
+++ b/skills/objectstack-ui/SKILL.md
@@ -150,6 +150,24 @@ columns (see objectstack-data → Relationships → Detail-page related lists).
 Authored record pages can still place an explicit `record:related_list` (or
 inline-editable `record:line_items`) when they need bespoke placement.
 
+**Related-list layout — `detail.relatedLayout` (`'stack'` | `'tabs'`).** By
+default every related list stacks under a single **Related** tab on the record
+detail page (`relatedLayout: 'stack'`). To promote each related table to its own
+**peer tab** — sitting alongside *Details* / *Activity* instead of nested under
+*Related* — set `relatedLayout: 'tabs'` in the object's `detail` block:
+
+```typescript
+detail: { relatedLayout: 'tabs' }   // Details · Tasks · Risks · Milestones …
+```
+
+Pure config — no custom record page needed; the synthesized detail page emits
+one peer tab per related entry (label falls back to the object name, the
+relationship's icon carries through), with Activity/History ordered after them.
+Omit it (or `'stack'`) for the default single-Related-tab behavior — zero
+regression. Use `tabs` when a record has several substantial child tables that
+each deserve first-class navigation; keep `stack` when related lists are
+secondary to the main record body.
+
 ### Field Conditional Rules in Forms
 
 For conditions that belong to a field's lifecycle, declare the rule on the


### PR DESCRIPTION
## What

Documents the **`detail.relatedLayout`** switch in the `objectstack-ui` skill, under *Read side — detail-page related lists*.

```typescript
detail: { relatedLayout: 'tabs' }   // Details · Tasks · Risks · Milestones …
```

- `'stack'` (default) — every related list stacks under a single **Related** tab.
- `'tabs'` — each related table becomes its own **peer tab** alongside *Details* / *Activity*, via pure config (no custom record page).

## Why

The renderer feature shipped in [objectui#2051](https://github.com/objectstack-ai/objectui/pull/2051) (`@object-ui/plugin-detail` + `app-shell`), but the skill — what authors and AI design sessions read — didn't mention it, so the capability was undiscoverable. Default `'stack'` keeps the single Related tab → zero regression.

## Scope

Docs only — one block added to `skills/objectstack-ui/SKILL.md` (+18 lines).