### PR TITLE
refactor(service-automation): deprecate non-canonical CRUD node config-key aliases

### DIFF
--- a/packages/services/service-automation/src/builtin/config-aliases.ts
+++ b/packages/services/service-automation/src/builtin/config-aliases.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Deprecation shim for non-canonical flow-node `config` keys.
+ *
+ * `FlowNodeSchema.config` is an unconstrained `z.record(z.string(), z.unknown())`
+ * (packages/spec/src/automation/flow.zod.ts), so the spec blesses *no* particular
+ * key — the executor is the only thing that gives `config` a shape at runtime.
+ * Historically several built-in executors quietly accepted a non-canonical alias
+ * via `cfg.canonical ?? cfg.alias` (e.g. `object` for `objectName`, `filters` for
+ * `filter`). That Postel's-law tolerance fossilizes the wrong shape into a
+ * de-facto second contract and hides metadata-generation bugs: a flow authored
+ * with the wrong key "just works" at runtime, so nothing ever flags it.
+ *
+ * The convergence (mirroring the `fields` / `fieldValues` decision) is to make
+ * the canonical key the *single* contract and reject the wrong shape at
+ * author/publish time:
+ *   • the cloud `graph-lint` gate rejects the alias when a flow is published, and
+ *   • the authoring sources (skills / example flows) only ever emit the canonical.
+ *
+ * graph-lint only runs at publish, so it cannot reach flows already stored in
+ * prod that are never re-published. {@link readAliasedConfig} closes that gap for
+ * the **deprecation window**: it keeps accepting the alias (so live flows keep
+ * running) but emits a one-time `logger.warn` per alias steering the author to
+ * the canonical key. Removal of the alias paths is tracked as a follow-up and
+ * happens once the window has elapsed and graph-lint has been enforcing.
+ *
+ * @see crud-nodes.ts for the first call sites (`objectName`, `filter`).
+ */
+
+/** One-time-warning ledger, keyed by `${nodeType}:${canonical}<-${alias}`. */
+const warnedAliases = new Set<string>();
+
+/** Test-only: clear the one-time-warning ledger so each test starts fresh. */
+export function __resetAliasDeprecationWarnings(): void {
+  warnedAliases.clear();
+}
+
+/**
+ * Read a node-config value by its **canonical** key, tolerating deprecated
+ * aliases for one deprecation window.
+ *
+ * Returns the value under `canonical` when present; otherwise the first present
+ * `alias` (warning once), otherwise `undefined`. "Present" means `!= null`, so
+ * the fall-through matches the `cfg.canonical ?? cfg.alias` semantics it replaces
+ * — callers keep applying their own default (`?? {}` / `?? ''`).
+ *
+ * @deprecated The alias paths exist only to keep already-stored flows running.
+ *   Author flows with the canonical key; the aliases will be removed.
+ */
+export function readAliasedConfig(
+  cfg: Record<string, unknown>,
+  nodeType: string,
+  canonical: string,
+  aliases: readonly string[],
+  logger: { warn(message: string): void },
+): unknown {
+  if (cfg[canonical] != null) return cfg[canonical];
+  for (const alias of aliases) {
+    if (cfg[alias] != null) {
+      const key = `${nodeType}:${canonical}<-${alias}`;
+      if (!warnedAliases.has(key)) {
+        warnedAliases.add(key);
+        logger.warn(
+          `[${nodeType}] config key '${alias}' is a deprecated alias of '${canonical}'. ` +
+            `Rename it to '${canonical}' — the alias still works but is deprecated, rejected at ` +
+            `publish time by graph-lint, and will be removed in a future release.`,
+        );
+      }
+      return cfg[alias];
+    }
+  }
+  return undefined;
+}

--- a/packages/services/service-automation/src/builtin/crud-config-aliases.test.ts
+++ b/packages/services/service-automation/src/builtin/crud-config-aliases.test.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Deprecation window for non-canonical `config` keys on the CRUD nodes
+ * (`object` → `objectName`, `filters` → `filter`). The alias keeps working so
+ * already-stored flows keep running, but emits a one-time `logger.warn` steering
+ * the author to the canonical key. See config-aliases.ts.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AutomationEngine } from '../engine.js';
+import { registerCrudNodes } from './crud-nodes.js';
+import { __resetAliasDeprecationWarnings } from './config-aliases.js';
+
+function silentLogger(): any {
+  const l: any = { info() {}, warn() {}, error() {}, debug() {} };
+  l.child = () => l;
+  return l;
+}
+
+function collectingLogger(warns: string[]): any {
+  const l: any = { info() {}, warn(m: string) { warns.push(m); }, error() {}, debug() {} };
+  l.child = () => l;
+  return l;
+}
+
+function fakeData() {
+  const calls: Array<{ op: string; obj: string; opts?: any }> = [];
+  const data: any = {
+    async find(obj: string, opts: any) { calls.push({ op: 'find', obj, opts }); return [{ id: 'r1' }]; },
+    async findOne(obj: string, opts: any) { calls.push({ op: 'findOne', obj, opts }); return { id: 'r1' }; },
+    async insert(obj: string, fields: any) { calls.push({ op: 'insert', obj, opts: { fields } }); return { id: `${obj}_1`, ...fields }; },
+    async update(obj: string, fields: any, opts: any) { calls.push({ op: 'update', obj, opts: { ...opts, fields } }); return { ok: true }; },
+    async delete(obj: string, opts: any) { calls.push({ op: 'delete', obj, opts }); return { ok: true }; },
+  };
+  return { data, calls };
+}
+
+const ctxWith = (data: any, logger: any): any => ({
+  logger,
+  getService: (n: string) => (n === 'data' ? data : undefined),
+});
+
+function getRecordFlow(config: Record<string, unknown>) {
+  return {
+    name: 'gr', label: 'G', type: 'autolaunched',
+    nodes: [
+      { id: 'start', type: 'start', label: 'Start' },
+      { id: 'g', type: 'get_record', label: 'Get', config },
+      { id: 'end', type: 'end', label: 'End' },
+    ],
+    edges: [
+      { id: 'e1', source: 'start', target: 'g' },
+      { id: 'e2', source: 'g', target: 'end' },
+    ],
+  } as any;
+}
+
+describe('CRUD config-key alias deprecation (object→objectName, filters→filter)', () => {
+  beforeEach(() => __resetAliasDeprecationWarnings());
+
+  it('still resolves the deprecated `object` + `filters` aliases at runtime', async () => {
+    const engine = new AutomationEngine(silentLogger());
+    const { data, calls } = fakeData();
+    const warns: string[] = [];
+    registerCrudNodes(engine, ctxWith(data, collectingLogger(warns)));
+
+    engine.registerFlow('gr', getRecordFlow({ object: 'crm_lead', filters: { id: 'L1' }, outputVariable: 'lead' }));
+    const res = await engine.execute('gr');
+
+    expect(res.success).toBe(true);
+    // The alias values reached the data engine unchanged.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].obj).toBe('crm_lead');
+    expect(calls[0].opts.where).toEqual({ id: 'L1' });
+  });
+
+  it('warns once per alias, naming the canonical key', async () => {
+    const engine = new AutomationEngine(silentLogger());
+    const { data } = fakeData();
+    const warns: string[] = [];
+    registerCrudNodes(engine, ctxWith(data, collectingLogger(warns)));
+
+    engine.registerFlow('gr', getRecordFlow({ object: 'crm_lead', filters: { id: 'L1' } }));
+    await engine.execute('gr');
+
+    const objectWarn = warns.find((w) => w.includes("'object'") && w.includes("'objectName'"));
+    const filterWarn = warns.find((w) => w.includes("'filters'") && w.includes("'filter'"));
+    expect(objectWarn).toBeTruthy();
+    expect(filterWarn).toBeTruthy();
+
+    // Second run in the same process must NOT warn again (one-time per alias).
+    const before = warns.length;
+    await engine.execute('gr');
+    expect(warns.length).toBe(before);
+  });
+
+  it('does NOT warn when the canonical keys are used', async () => {
+    const engine = new AutomationEngine(silentLogger());
+    const { data } = fakeData();
+    const warns: string[] = [];
+    registerCrudNodes(engine, ctxWith(data, collectingLogger(warns)));
+
+    engine.registerFlow('gr', getRecordFlow({ objectName: 'crm_lead', filter: { id: 'L1' }, outputVariable: 'lead' }));
+    const res = await engine.execute('gr');
+
+    expect(res.success).toBe(true);
+    expect(warns).toHaveLength(0);
+  });
+});

--- a/packages/services/service-automation/src/builtin/crud-nodes.ts
+++ b/packages/services/service-automation/src/builtin/crud-nodes.ts
@@ -5,6 +5,7 @@ import { defineActionDescriptor } from '@objectstack/spec/automation';
 import type { IDataEngine } from '@objectstack/spec/contracts';
 import type { AutomationEngine } from '../engine.js';
 import { interpolate } from './template.js';
+import { readAliasedConfig } from './config-aliases.js';
 import { resolveRunDataContext } from '../runtime-identity.js';
 
 /**
@@ -43,10 +44,10 @@ export function registerCrudNodes(engine: AutomationEngine, ctx: PluginContext):
             }),
             async execute(node, variables, context) {
                 const cfg = (node.config ?? {}) as Record<string, unknown>;
-                const objectName = String(cfg.objectName ?? cfg.object ?? '');
+                const objectName = String(readAliasedConfig(cfg, 'get_record', 'objectName', ['object'], ctx.logger) ?? '');
                 if (!objectName) return { success: false, error: 'get_record: objectName required' };
 
-                const filter = interpolate(cfg.filter ?? cfg.filters ?? {}, variables, context) as Record<string, unknown>;
+                const filter = interpolate(readAliasedConfig(cfg, 'get_record', 'filter', ['filters'], ctx.logger) ?? {}, variables, context) as Record<string, unknown>;
                 const fields = cfg.fields as string[] | undefined;
                 const limit = typeof cfg.limit === 'number' ? cfg.limit : undefined;
                 const outputVariable = cfg.outputVariable as string | undefined;
@@ -85,7 +86,7 @@ export function registerCrudNodes(engine: AutomationEngine, ctx: PluginContext):
             }),
             async execute(node, variables, context) {
                 const cfg = (node.config ?? {}) as Record<string, unknown>;
-                const objectName = String(cfg.objectName ?? cfg.object ?? '');
+                const objectName = String(readAliasedConfig(cfg, 'create_record', 'objectName', ['object'], ctx.logger) ?? '');
                 if (!objectName) return { success: false, error: 'create_record: objectName required' };
 
                 const fields = interpolate(cfg.fields ?? {}, variables, context) as Record<string, unknown>;
@@ -134,10 +135,12 @@ export function registerCrudNodes(engine: AutomationEngine, ctx: PluginContext):
             }),
             async execute(node, variables, context) {
                 const cfg = (node.config ?? {}) as Record<string, unknown>;
-                const objectName = String(cfg.objectName ?? cfg.object ?? '');
+                const objectName = String(readAliasedConfig(cfg, 'update_record', 'objectName', ['object'], ctx.logger) ?? '');
                 if (!objectName) return { success: false, error: 'update_record: objectName required' };
 
-                const filter = interpolate(cfg.filter ?? cfg.filters ?? {}, variables, context) as Record<string, unknown>;
+                const filter = interpolate(readAliasedConfig(cfg, 'update_record', 'filter', ['filters'], ctx.logger) ?? {}, variables, context) as Record<string, unknown>;
+                // `fields` is the single canonical write-map key — no alias (the wrong key
+                // `fieldValues` is corrected at the authoring source + rejected by graph-lint).
                 const fields = interpolate(cfg.fields ?? {}, variables, context) as Record<string, unknown>;
 
                 const data = getData();
@@ -167,10 +170,10 @@ export function registerCrudNodes(engine: AutomationEngine, ctx: PluginContext):
             }),
             async execute(node, variables, context) {
                 const cfg = (node.config ?? {}) as Record<string, unknown>;
-                const objectName = String(cfg.objectName ?? cfg.object ?? '');
+                const objectName = String(readAliasedConfig(cfg, 'delete_record', 'objectName', ['object'], ctx.logger) ?? '');
                 if (!objectName) return { success: false, error: 'delete_record: objectName required' };
 
-                const filter = interpolate(cfg.filter ?? cfg.filters ?? {}, variables, context) as Record<string, unknown>;
+                const filter = interpolate(readAliasedConfig(cfg, 'delete_record', 'filter', ['filters'], ctx.logger) ?? {}, variables, context) as Record<string, unknown>;
 
                 const data = getData();
                 if (!data) return { success: true };

--- a/skills/objectstack-automation/SKILL.md
+++ b/skills/objectstack-automation/SKILL.md
@@ -278,7 +278,7 @@ is one diagram a reviewer (or AI) can read end-to-end.
       },
     },
     { id: 'mark_won', type: 'update_record',
-      config: { object: 'opportunity', filter: { id: '{record.id}' }, fields: { stage: 'closed_won' } } },
+      config: { objectName: 'opportunity', filter: { id: '{record.id}' }, fields: { stage: 'closed_won' } } },
     { id: 'approved', type: 'end' },
     { id: 'rejected', type: 'end' },
   ],


### PR DESCRIPTION
## Audit: "lenient input" config-key aliases in automation node executors

`FlowNodeSchema.config` is `z.record(z.string(), z.unknown())` ([flow.zod.ts:102](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/automation/flow.zod.ts#L102)), so **the spec blesses no particular config key** — the executor is the only runtime gate on key names. That makes every `cfg.canonical ?? cfg.alias` in a node executor a Postel's-law tolerance that fossilizes a wrong shape into a de-facto second contract and hides metadata-generation bugs. This PR is **Step 1** of converging them: it follows the `fields`/`fieldValues` precedent (reject the wrong shape at author/publish time; don't absorb it at runtime).

### What this PR changes (clear-cut, zero-risk)
- **`readAliasedConfig()`** helper — returns the canonical value; on the alias path, emits a **one-time `logger.warn`** naming the canonical key, then keeps working. (graph-lint runs only at *publish*, so it can't reach flows already stored in prod that are never re-published — the runtime warn covers that population.)
- Wired into **get/create/update/delete_record** for `objectName` and `filter`.
- **Fixed the one authoring source that taught the alias**: `skills/objectstack-automation/SKILL.md` `update_record` example `object:` → `objectName:` (every example `.flow.ts` already uses `objectName`/`filter`).

**No alias is removed** — all are plausibly present in stored prod flows. Removal is a tracked follow-up gated on (a) the warn window and (b) a cloud `graph-lint` rule.

### Findings table (full audit)

Canonical is established by docs/skill/examples + cloud graph-lint (the spec is `z.record`, vacuously permissive). "Debt" = one canonical key + tolerated alias; "Union" = spec genuinely blesses both.

| # | Alias (file:line) | Spec says | Class | Action |
|---|---|---|---|---|
| 1 | `crud-nodes.ts` `objectName ?? object` (get/create/update/delete) | `z.record` (any key) | **Debt** — `objectName` canonical (all 8 example flows); `object` only in SKILL.md | ✅ this PR: warn + fix skill |
| 2 | `crud-nodes.ts` `filter ?? filters` (get/update/delete) | `z.record` | **Debt** — `filter` canonical; `filters` zero usage | ✅ this PR: warn |
| 3 | `notify-node.ts:75-77` `recipients ?? to`, `title ?? subject`, `message ?? body` | `z.record` | **Debt** — email-flavored aliases; `notify` unused in examples | Follow-up: same warn treatment |
| 4 | `screen-nodes.ts:198` `inputs ?? input` (script) | `z.record` | **Debt** — singular slip; zero usage | Follow-up: warn |
| 5 | `screen-nodes.ts:135` `function ?? functionName` (script) | `z.record` | **Debt — deliberate** (in-code: "AI/templates commonly emit it", #1870) | Fix AI/skill emission first, *then* warn (platform self-emits it today) |
| 6 | `wait-node.ts:61,108` `… ?? loose.duration`, `… ?? loose.signal` | `waitEventConfig.timerDuration`/`signalName` (typed) | **Debt** — off-spec short aliases; zero usage | Follow-up: remove/warn (low traffic) |
| 7 | `wait-node.ts` `waitEventConfig.* ?? config.*` | spec defines `waitEventConfig`; examples author under `config` | **Structural dual-home** (borderline) | Pick one home + document; lower priority |
| 8 | `logic-nodes.ts:71` `variable ?? name ?? key` (assignment) | `z.record` (+ documented 3-surface normalizer) | **Debt slice** in a legit multi-shape normalizer | Keep normalizer; warn on `name`/`key` array-item aliases |
| 9 | `action.zod.ts:529` `p.name ?? p.field` (+ refine :70) | **`.refine(name \|\| field)` blesses both** | **Legitimate union** | ✅ Leave as-is |
| 10 | `http-dispatcher.ts:2836` `ctxBody.objectName ?? ctxBody.object` (API `POST /:name/trigger`) | n/a (HTTP body) | **Debt** — same as #1, on the trigger surface | Converge with #1 (separate PR; runtime pkg) |
| 11 | `http-dispatcher.ts:2892` `inputs ?? variables` (resume body) | n/a | **Debt (lean)** / low traffic | Follow-up |

### Out of scope (separate convergence tracks — flagged, not folded in)
- **Query-DSL multi-spelling** — `metadata-protocol/protocol.ts:2060,2077` (`orderBy ?? sort`, `filter ?? filters ?? $filter ?? where`) and `http-dispatcher.ts:1792` (`where ?? filter ?? filters`): mostly a legit OData/ObjectQL union; `filters` plural is the debt slice. Owner: ObjectQL query options.
- **REST camelCase↔snake_case** — `rest-server.ts` (~40 sites, e.g. `body.object ?? body.object_name`): a deliberate, documented REST body convention. Leave.
- **DB row column reconciliation** — `plugin-approvals/approval-service.ts` (`raw.flow_node_id ?? raw.current_step`), auth/security `*_id ?? *Id`: reading persisted rows, not author config. Separate (legacy column) concern.
- **Spec-ambiguous** — `service-datasource/default-datasource-driver-factory.ts:92` `user ?? username`: `datasource.zod` prose says `user`, the postgres/mongo driver schemas say `username`. **Fix the spec first** (pick one), then converge — not clean runtime debt.

### Why deprecation window, not straight removal
The spec is `z.record`, so the runtime has been the *only* gate; any tolerated alias may sit in a stored prod flow and there's no telemetry to prove otherwise. Several are documented/intuitive (`object` is literally in the skill; `to`/`subject` read as email; `filters`/`input`/`duration` are natural slips). Removal's failure mode is loud-and-safe (`create_record: objectName required`) rather than corruption — but it's still an availability regression for running flows, which is exactly what the window avoids. So: warn now, remove after the window + a graph-lint rule, and stop teaching/emitting the alias at the source.

### Tests
- `@objectstack/service-automation`: **225 pass** (incl. new `crud-config-aliases.test.ts` — alias still resolves, warns once per alias, canonical path silent).
- `@objectstack/spec`: **6600 pass**.
- `tsup` ESM/CJS/DTS build clean.

### Suggested follow-ups
1. Apply the same `readAliasedConfig` warn to notify/screen/wait/logic aliases (#3,4,6,8) and the `http-dispatcher` trigger `object` (#10).
2. Add the cloud **graph-lint** rule rejecting non-canonical CRUD config keys at publish.
3. File the removal-tracking issue; remove alias paths after one release with the warn + graph-lint enforcing.
4. Resolve the datasource `user`/`username` **spec** ambiguity before touching that runtime tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
