### PR TITLE
ci(framework): assert capability packages ship a runtime entry (no dts-only / half-built)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,32 @@ jobs:
           fi
           echo "Build outputs verified successfully"
 
+      # Capability packages (services / triggers / plugins) are loaded by the
+      # multi-tenant runtime via a DYNAMIC import of their published entry. If a
+      # package ships a dts-only / half-built / 0-byte `dist` (an interrupted
+      # build, or a package retired in source but still referenced), that import
+      # resolves to nothing and the capability SILENTLY fails to load — e.g.
+      # record-change automation never fires, with no user-visible signal. The
+      # build config always emits JS, so this can only happen by accident; assert
+      # every buildable capability package actually produced its declared runtime
+      # entry. Self-maintaining: reads each package's own `main`, skips dirs with
+      # no package.json (e.g. a retired service-feed/service-ai leftover).
+      - name: Verify capability packages ship a runtime entry (no dts-only / half-built)
+        run: |
+          fail=0
+          for d in packages/triggers/* packages/services/* packages/plugins/*; do
+            [ -f "$d/package.json" ] || continue
+            has_build=$(node -p "Boolean((require('./$d/package.json').scripts||{}).build)" 2>/dev/null || echo false)
+            [ "$has_build" = "true" ] || continue
+            main=$(node -p "require('./$d/package.json').main || 'dist/index.js'" 2>/dev/null || echo dist/index.js)
+            if [ ! -s "$d/$main" ]; then
+              echo "✗ $d: missing/empty runtime entry '$main' — dts-only or unbuilt? dynamic import would silently fail"
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then exit 1; fi
+          echo "✓ all buildable capability packages ship a runtime JS entry"
+
       - name: Analyze bundle size
         run: pnpm --filter @objectstack/spec analyze
 


### PR DESCRIPTION
## Why

Capability packages under `packages/{services,triggers,plugins}` are loaded by the cloud multi-tenant runtime via a **dynamic import** of their published entry. If one ships a **dts-only / half-built / 0-byte `dist`** (an interrupted build, or a package retired in source but still referenced), the import resolves to nothing and that capability **silently fails to load** — e.g. AI-built record-change automation registers but never fires, with no user-visible signal.

The shared `tsup` config always emits JS (the only toggle, `OS_SKIP_DTS`, drops *declarations*, not JS), so a dts-only `dist` can only happen by accident — and nothing in CI caught it. (This came up while debugging a cloud-side `triggers` capability that wasn't loading; the framework package itself was fine, but there was no guard proving it.)

## What

Extend the existing **Verify build outputs** step (runs right after `pnpm build`, so no build-ordering ambiguity) with a filesystem assertion that every *buildable* capability package produced its declared `main` runtime entry.

Self-maintaining and false-positive-safe:
- reads each package's own `main` (defaults to `dist/index.js`);
- skips dirs with no `package.json` (a retired `service-feed` / `service-ai` leftover);
- skips packages with no `scripts.build`;
- `-s` catches 0-byte half-writes.

## Validation
- Passes against a freshly-built tree (all capability packages have runtime entries).
- **Negative test**: removing `trigger-record-change/dist/index.js` is caught and fails the step.
- `ci.yml` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)