### PR TITLE
docs(objectstack-ui): document detail.hidePath status-stepper opt-out

### DIFF
--- a/skills/objectstack-ui/SKILL.md
+++ b/skills/objectstack-ui/SKILL.md
@@ -168,6 +168,27 @@ regression. Use `tabs` when a record has several substantial child tables that
 each deserve first-class navigation; keep `stack` when related lists are
 secondary to the main record body.
 
+**Status stepper opt-out — `detail.hidePath`.** The record detail page
+auto-detects a "status/stage" field and renders it as a Salesforce Lightning
+Path-style stepper at the top, marking every option *before* the current value
+as completed. Detection is name/type based (a field named
+`status`/`stage`/`state`/`phase`, or typed `status`/`stage`, or the object's
+explicit `stageField`) — a plain `select` is **not** auto-promoted.
+
+That stepper is right for a genuine linear pipeline, but wrong when the picklist
+isn't one — e.g. a status that folds a **risk gradient** into its options
+(`已完成 / 进行中-正常 / … / 进行中-特高风险 / 已逾期`), where "earlier option =
+done ✓" misrepresents the record. Suppress it per object:
+
+```typescript
+detail: { hidePath: true }   // no top status stepper; status shows as a normal field
+```
+
+Default (unset) keeps the stepper — zero regression. Prefer fixing the data
+model first (split lifecycle vs. risk into two fields, or point `stageField` at
+the real pipeline field); reach for `hidePath` when the picklist genuinely
+isn't a sequence.
+
 ### Field Conditional Rules in Forms
 
 For conditions that belong to a field's lifecycle, declare the rule on the


### PR DESCRIPTION
## What

Documents **`detail.hidePath`** in the `objectstack-ui` skill, next to `detail.relatedLayout` (added in #2418):

```typescript
detail: { hidePath: true }   // no top status stepper; status shows as a normal field
```

## Why

The record detail page auto-detects a status/stage field and renders it as a Lightning Path-style stepper, marking every option *before* the current value as completed. That's wrong when the picklist isn't a linear pipeline — e.g. a status that folds a risk gradient into its options (`已完成 / … / 进行中-特高风险 / 已逾期`). Authors need a config-level off switch; the skill now documents it, including the detection heuristic (a plain `select` is **not** auto-promoted) and the "fix the data model first" guidance.

Pairs with the renderer wiring in [objectui#2062](https://github.com/objectstack-ai/objectui/pull/2062).

## Scope

Docs only — one block added to `skills/objectstack-ui/SKILL.md`.