### PR TITLE
fix(auth): restore admin gate on OAuth toggle-disabled after ADR-0068

### DIFF
--- a/.changeset/oauth-toggle-admin-gate.md
+++ b/.changeset/oauth-toggle-admin-gate.md
@@ -1,0 +1,16 @@
+---
+'@objectstack/plugin-auth': patch
+---
+
+fix(auth): restore the admin gate on POST /admin/oauth-application/toggle-disabled after ADR-0068
+
+ADR-0068 stopped `customSession` from synthesizing `user.role = 'admin'`;
+canonical roles now arrive in `user.roles[]` with `user.isPlatformAdmin` as a
+derived alias. The OAuth-client enable/disable route was missed in that
+migration and still gated on `session.user.role !== 'admin'`, which now rejects
+even platform admins (the scalar is no longer synthesized). It now mirrors the
+sibling /admin/unlock-user gate: `isPlatformAdmin` / `platform_admin` in
+`roles[]`, with the legacy `role` scalar as a fallback.
+
+Also corrects the now-stale `customSession()` doc comment in auth-manager that
+still described the removed `user.role = 'admin'` overwrite.

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -1539,18 +1539,19 @@ export class AuthManager {
       }));
     }
 
-    // customSession() — augments the session payload with a derived `role`
-    // field so frontend gating (e.g. AppShell's `isAdmin = user.role === 'admin'`)
-    // works without each consumer having to re-query permission sets.
+    // customSession() — augments the session payload with the canonical
+    // `roles: string[]` array (ADR-0068 D1/D2): the stored `user.role` scalar
+    // split on commas, PLUS the active membership mapped to canonical
+    // `org_owner`/`org_admin`/`org_member`, PLUS `platform_admin` when the user
+    // holds the admin_full_access permission set. `user.isPlatformAdmin` is a
+    // derived alias of `'platform_admin' in roles`.
     //
-    // It also returns a `roles: string[]` array: the stored `user.role`
-    // string split on commas (the admin plugin stores multi-role users as
-    // e.g. `"admin,manager"`), with `'admin'` appended (deduplicated) when
-    // the user is promoted below. Consumers that match on individual role
-    // names (e.g. the Console approvals inbox resolving `role:<name>`
-    // approvers) must read `roles` — `user.role` is *replaced* by the
-    // literal `'admin'` on promotion, so business roles such as `manager`
-    // only survive in the array.
+    // IMPORTANT: `user.role` is NOT overwritten anymore — consumers must gate
+    // on `roles[]` / `isPlatformAdmin` (e.g. via objectui's useIsWorkspaceAdmin),
+    // never on `user.role === 'admin'`. Consumers that match individual role
+    // names (e.g. the Console approvals inbox resolving `role:<name>` approvers)
+    // also read `roles` — business roles such as `manager` survive only there.
+    // The raw membership role stays on the organization plugin's `member` payload.
     //
     // Better-auth's `sys_user` table doesn't carry a `role` column. We derive
     // it from two sources:

--- a/packages/plugins/plugin-auth/src/auth-plugin.ts
+++ b/packages/plugins/plugin-auth/src/auth-plugin.ts
@@ -940,10 +940,18 @@ export class AuthPlugin implements Plugin {
         if (!session?.user?.id) {
           return c.json({ success: false, error: { code: 'unauthorized', message: 'Sign in first' } }, 401);
         }
-        // The customSession plugin synthesizes `user.role = 'admin'` for
-        // platform admins (admin_full_access permission set) and active-org
-        // owners/admins; anyone else is denied.
-        if ((session.user as any).role !== 'admin') {
+        // Platform-admin gate. ADR-0068 removed the `user.role = 'admin'`
+        // synthesis, so a stale `role === 'admin'` check now rejects even
+        // platform admins. Accept the canonical signals customSession carries
+        // (the derived `isPlatformAdmin` alias / `platform_admin` in roles[]),
+        // with the legacy admin-plugin `role` scalar as a fallback. Mirrors the
+        // /admin/unlock-user gate below.
+        const u: any = session.user;
+        const isAdmin =
+          u?.isPlatformAdmin === true ||
+          (Array.isArray(u?.roles) && u.roles.includes('platform_admin')) ||
+          u?.role === 'admin';
+        if (!isAdmin) {
           return c.json({ success: false, error: { code: 'forbidden', message: 'Admin role required' } }, 403);
         }
 


### PR DESCRIPTION
## What

ADR-0068 (`a3a5abff8`) stopped the server `customSession` from synthesizing `user.role = 'admin'`. Canonical roles now arrive in `user.roles[]` (`platform_admin` / `org_*`) with `user.isPlatformAdmin` as a derived alias.

The OAuth-client enable/disable route — `POST {basePath}/admin/oauth-application/toggle-disabled` in `auth-plugin.ts` — was **missed in that migration** and still gated on:

```ts
if ((session.user as any).role !== 'admin') { /* 403 */ }
```

Since `user.role` is no longer synthesized, this now **rejects even platform admins** (unless the admin-plugin literally stored the `'admin'` scalar on their row). The sibling `/admin/unlock-user` route in the same file was migrated correctly; this one was not.

## Fix

Gate on the same three canonical signals as `/admin/unlock-user`:

```ts
const u: any = session.user;
const isAdmin =
  u?.isPlatformAdmin === true ||
  (Array.isArray(u?.roles) && u.roles.includes('platform_admin')) ||
  u?.role === 'admin';
```

Also corrects the stale `customSession()` doc comment in `auth-manager.ts` that still described the removed `user.role = 'admin'` overwrite (the very pattern downstream consumers copied).

## ⚠️ Behavior / posture note for reviewers

The pre-ADR-0068 `role === 'admin'` check implicitly allowed **active-org owners/admins** too (they were synthesized to `role='admin'`), as the old comment stated. This fix makes the gate **platform-admin-only**, matching the sibling `unlock-user` route and treating OAuth-client management as an instance-level concern. If org owners/admins are intended to manage OAuth clients, add `org_owner`/`org_admin` to the `roles[]` check — flagging explicitly so this is a conscious decision rather than a silent change.

## Verification

- `@objectstack/plugin-auth` build + DTS type-check clean.
- Changeset included (`patch`).

## Companion

objectui [#2063](https://github.com/objectstack-ai/objectui/pull/2063) fixes the same missed migration on the client (4 views gating on `user?.role === 'admin'`).