### PR TITLE
docs(skill): 补充自动状态进度条 & detail.stageField:false 开关

### DIFF
--- a/skills/objectstack-ui/SKILL.md
+++ b/skills/objectstack-ui/SKILL.md
@@ -709,6 +709,35 @@ export const LeadDetailPage = definePage({
 });
 ```
 
+> **Auto-synthesized detail pages & the status path.** When an object has **no
+> authored record page**, ObjectUI synthesizes a default detail page and
+> auto-detects a status field to drive a top `record:path` stepper. The stage
+> hint lives in the object def's `detail` block (`object.zod.ts` — a
+> `.passthrough()` block documented as "Detail-page UI hints consumed by
+> @object-ui/plugin-detail synth"). Detection precedence (`detectStatusField`):
+> (0) `detail.stageField === false | null` → explicit opt-out, no path;
+> (1) `detail.stageField` is a field name → use it; (2) else first field named
+> `status` / `stage` / `state` / `phase`; (3) else first field whose `type` is
+> `status` / `stage`; (4) else no path.
+>
+> **Opt out with `detail: { stageField: false }`.** Many objects carry a
+> `status` *select* that is a **non-linear** picklist (e.g. 正常 / 暂停 / 作废),
+> not an ordered pipeline — rendering it as an ordered stepper is wrong:
+>
+> ```typescript
+> ObjectSchema.create({
+>   name: 'production_plan',
+>   detail: { stageField: false },   // suppress the auto status path
+>   fields: { status: Field.select({ options: [...] }) /* … */ },
+> });
+> ```
+>
+> **Put it under `detail`, not top-level.** `ObjectSchema.create()` rejects
+> unknown *top-level* keys (a bare `stageField:` fails to compile and is rejected
+> at build). The `detail` block is `.passthrough()`, so author-facing synth hints
+> like `stageField` belong there. Use `detail: { stageField: 'my_field' }` to
+> pick which field drives the path.
+
 > **Variable substitution** — `{first_name}`, `{current_user.first_name}`,
 > `{current_quarter_start}` etc. resolve from the page's `variables` block,
 > the bound record, and the runtime context. Declare `variables: [...]` at


### PR DESCRIPTION
## 问题

这是 AI 开发场景:AI 作者装的是 `objectstack-ai/framework` 的 skills。但分发的 `skills/objectstack-ui/SKILL.md` **完全没提**:

- 无手写 record page 时,objectui synth 会**自动合成详情页 + 自动探测状态字段**,在顶部画有序状态进度条 `record:path`;
- objectstack-ai/objectui#2066 新增的 `detail: { stageField: false }` **关闭开关**。

`detail.stageField` 只靠 spec 的 `.passthrough()` 放行、没有 typed 键,所以也无类型/补全提示——对 AI 而言唯一可靠的发现渠道就是 skill。缺这段,别的 AI 会重复踩"非线性 status 被画成进度条且关不掉"的坑。

## 方案

在 `skills/objectstack-ui/SKILL.md` 的 `record:path` 示例之后补一段:

1. 自动详情页 & 状态进度条说明 + `detectStatusField` 探测优先级(含 `detail.stageField === false|null` 显式关闭);
2. `ObjectSchema.create({ detail: { stageField: false }, ... })` 示例,并强调**必须放 `detail` 块、不能放顶层**(顶层未知键被 `ObjectSchema.create()` 拒绝;`detail` 是 `.passthrough()` 的 synth 提示落点)。

仅改文档一处(+29 行),无代码/无包变更。

Closes #2452
配套:objectstack-ai/objectui#2066(行为实现)
