### PR TITLE
feat(cli): wire SDUI manifest generation+consumption (ADR-0080)

### DIFF
--- a/.changeset/sdui-manifest-wiring.md
+++ b/.changeset/sdui-manifest-wiring.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/cli": minor
+---
+
+ADR-0080: wire the SDUI manifest end-to-end. `build-console.sh` now (best-effort, guarded) generates `sdui.manifest.json` from the just-built console's public-tier registry into `@objectstack/console/dist/`; the `os build` / `os validate` JSX gate resolves the manifest from `@objectstack/console` (in addition to the project root) and does full component/prop validation when present. Activating full validation requires bumping `.objectui-sha` to an objectui commit that ships the dump tooling (>=96b1293); until then the gate falls back to parse-level and the build step skips.

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -2,6 +2,7 @@
 
 import { Args, Command, Flags } from '@oclif/core';
 import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { join } from 'node:path';
 import chalk from 'chalk';
 import { ZodError } from 'zod';
@@ -179,6 +180,12 @@ export default class Validate extends Command {
       try {
         const mp = join(process.cwd(), 'sdui.manifest.json');
         if (existsSync(mp)) sduiManifest = JSON.parse(readFileSync(mp, 'utf8'));
+        if (!sduiManifest) {
+          // Fall back to the manifest shipped inside @objectstack/console
+          // (built from objectui's public-tier registry; cli already deps it).
+          const cp = createRequire(import.meta.url).resolve('@objectstack/console/dist/sdui.manifest.json');
+          if (existsSync(cp)) sduiManifest = JSON.parse(readFileSync(cp, 'utf8'));
+        }
       } catch { /* fall back to parse-level */ }
       const jsxFindings = validateJsxPages(
         result.data as Record<string, unknown>,

--- a/scripts/build-console.sh
+++ b/scripts/build-console.sh
@@ -128,3 +128,26 @@ cp -R "$CONSOLE_DIST" "$TARGET"
 
 BYTES="$(du -sk "$TARGET" 2>/dev/null | awk '{print $1}')"
 echo "✓ @objectstack/console dist ready (${BYTES} KB) from objectui@${PINNED_SHA:0:12}"
+
+# ADR-0080: generate the public-tier SDUI manifest from the just-built console's
+# registry so the framework os-build JSX gate can do full component/prop
+# validation. Best-effort and GUARDED: skips on a sha without the dump tooling,
+# and never fails the console build (the gate falls back to parse-level).
+DUMP_PAGE="${BUILD_ROOT}/apps/console/dev/manifest-dump.html"
+DUMP_SCRIPT="${BUILD_ROOT}/scripts/dump-public-manifest.mjs"
+if [[ -f "$DUMP_PAGE" && -f "$DUMP_SCRIPT" ]]; then
+  echo "→ Generating SDUI public-tier manifest (ADR-0080)..."
+  pushd "$BUILD_ROOT" > /dev/null
+  pnpm --filter @object-ui/console exec vite dev --port 5180 > /tmp/sdui-dump-dev.log 2>&1 &
+  DUMP_DEV_PID=$!
+  for _ in $(seq 1 90); do curl -sf "http://localhost:5180/" > /dev/null 2>&1 && break; sleep 1; done
+  if BASE_URL="http://localhost:5180" OUT="${TARGET}/sdui.manifest.json" node scripts/dump-public-manifest.mjs; then
+    echo "✓ wrote ${TARGET}/sdui.manifest.json"
+  else
+    echo "⚠ manifest generation failed — os-build JSX gate falls back to parse-level (non-fatal)"
+  fi
+  kill "$DUMP_DEV_PID" 2>/dev/null || true
+  popd > /dev/null
+else
+  echo "ℹ manifest dump tooling not present at objectui@${PINNED_SHA:0:12} — skipping (bump .objectui-sha to >=96b1293 to enable full JSX validation)"
+fi


### PR DESCRIPTION
ADR-0080 — wires the manifest end-to-end (the generation mechanism merged as objectstack-ai/objectui #2068).

- **`build-console.sh`**: a **guarded, best-effort** step that boots the just-built console's registry and dumps the public-tier manifest (`getPublicConfigs()` → `manifestFromConfigs`) into `@objectstack/console/dist/sdui.manifest.json`. Skips cleanly on an objectui sha without the dump tooling; **never fails the console build** (the gate just falls back to parse-level).
- **`validate.ts`**: the `os build` / `os validate` JSX gate now resolves the manifest from `@objectstack/console` too (cli already deps it), in addition to the project root → full component/prop validation when present.

**Verified end-to-end already** (manually, the real path the script automates): live registry → 35-block manifest with full contracts → `compile()` catches missing-required / bad-enum / unknown-component.

**Activation (deliberate release step, not in this PR):** bump `.objectui-sha` to `>=96b1293` (the objectui commit that ships the dump tooling). `build-console.sh` runs at publish time, not on PR CI, and a pin bump ships a new console across unrelated objectui changes — so it's surfaced here rather than buried in a feature PR. Until then everything is non-breaking (gate = parse-level; build step = skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)