### PR TITLE
feat(spec):detail 块补 typed stageField 键

### DIFF
--- a/.changeset/detail-stagefield-typed.md
+++ b/.changeset/detail-stagefield-typed.md
@@ -1,0 +1,13 @@
+---
+'@objectstack/spec': patch
+---
+
+feat(spec): add a typed `stageField` key to the object `detail` block
+
+The detail-page synth (`@object-ui/plugin-detail`) already reads
+`def.detail?.stageField` to drive — or disable — the auto status-path stepper
+(`record:path`). It only survived via the `detail` block's `.passthrough()`, so
+authors got no type or autocomplete and no way to discover the switch. Declare
+it explicitly: `string` forces a status field, `false`/`null` disables the
+stepper (use it when `status` is a non-linear picklist). `.passthrough()` is
+kept for back-compat.

--- a/packages/spec/src/data/object.zod.ts
+++ b/packages/spec/src/data/object.zod.ts
@@ -707,11 +707,18 @@ const ObjectSchemaBase = z.object({
    * - `hideRelatedTab=true` suppresses the "Related" tab. By default the
    *   synth removes the Related tab automatically when the rail is shown to
    *   avoid duplication; set this flag to force hide/show regardless.
+   * - `stageField` controls the auto status-path stepper (`record:path`).
+   *   A field name forces that field; `false`/`null` disables the stepper —
+   *   use it when `status` is a non-linear picklist (active/paused/voided)
+   *   that shouldn't render as an ordered Path. Omit it to let the synth
+   *   auto-detect (status/stage/state/phase, or a status/stage-typed field).
    */
   detail: z.object({
     renderViaSchema: z.boolean().optional().describe('Opt this object out of the schema-driven detail renderer'),
     hideReferenceRail: z.boolean().optional().describe('Suppress the right-hand reference-rail on the detail page'),
     hideRelatedTab: z.boolean().optional().describe('Suppress the Related tab on the detail page'),
+    stageField: z.union([z.string(), z.literal(false), z.null()]).optional()
+      .describe('record:path status field name; false/null disables the auto status-path stepper'),
   }).passthrough().optional().describe('Detail-page UI hints consumed by @object-ui/plugin-detail synth'),
 
   /**


### PR DESCRIPTION
## 问题

objectui 详情页 synth(`@object-ui/plugin-detail` 的 `buildDefaultPageSchema` / `detectStatusField`)在**没有手写 record page** 时会自动合成详情页,自动探测状态字段在记录顶部渲染有序状态进度条(Lightning Path 风格的 `record:path`)。非线性 `status`(正常/暂停/作废)被画成进度条不合适;objectui objectstack-ai/objectui#2066 已支持 `detail: { stageField: false }` 关闭(synth 读 `def.detail?.stageField`)。

但 `detail.stageField` 此前只靠 `detail` 块的 `.passthrough()` 放行,**没有 typed 键** → 作者(及 AI)写它时没有任何类型 / 自动补全,也无从发现这个开关。

## 改动

`packages/spec/src/data/object.zod.ts` 的 `detail` 块里,与 `renderViaSchema` / `hideReferenceRail` / `hideRelatedTab` 并列,补一个 typed `stageField` 键(带 `.describe()`),并在块上方的 doc-comment 补一条说明。保留 `.passthrough()`。

```ts
stageField: z.union([z.string(), z.literal(false), z.null()]).optional()
  .describe('record:path status field name; false/null disables the auto status-path stepper'),
```

类型与 synth 读取的 `string | false | null` 一致:字段名 → 强制用该字段;`false`/`null` → 关闭进度条;省略 → synth 自动探测。

## 自测

- `pnpm gen:schema` ✅(1681 schemas,eager 求值新 union 无误)
- `tsc --noEmit` ✅
- changeset:`@objectstack/spec` patch

纯类型 / 发现性改动,运行时行为不变(passthrough 早已放行)。原 skill 文档方案(#2453)一次加太多,已放弃。

Closes #2452