### PR TITLE
feat(app-showcase): surface Command Center (JSX) in nav (ADR-0080)

### DIFF
--- a/examples/app-showcase/src/apps/index.ts
+++ b/examples/app-showcase/src/apps/index.ts
@@ -65,6 +65,7 @@ export const ShowcaseApp = App.create({
       icon: 'layout',
       children: [
         { id: 'nav_gallery', type: 'page', pageName: 'showcase_component_gallery', label: 'Component Gallery', icon: 'layout-template' },
+        { id: 'nav_command_center_jsx', type: 'page', pageName: 'showcase_command_center_jsx', label: 'Command Center (JSX)', icon: 'code' },
         { id: 'nav_styling_gallery', type: 'page', pageName: 'showcase_styling_gallery', label: 'Styling (ADR-0065)', icon: 'palette' },
         { id: 'nav_page_variables', type: 'page', pageName: 'showcase_page_variables', label: 'Page Variables', icon: 'mouse-pointer-click' },
         { id: 'nav_contact_form', type: 'page', pageName: 'showcase_contact_form', label: 'Contact Form', icon: 'mail-plus' },


### PR DESCRIPTION
Wires the ADR-0080 kind:'jsx' example page (showcase_command_center_jsx, browser-verified) into the showcase app navigation (Pages → Command Center (JSX)) so it's clickable in the running showcase. It's the only kind:'jsx' page in showcase — a Tailwind-freeform layout authored as a JSX source string, compiled (parse, never execute) to the SDUI tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)