### PR TITLE
chore(ai)!: drop @ai-sdk provider SDKs from framework, align spec with ai v7

### DIFF
--- a/.changeset/ai-sdk-v7-framework.md
+++ b/.changeset/ai-sdk-v7-framework.md
@@ -1,0 +1,25 @@
+---
+'@objectstack/spec': minor
+---
+
+chore(ai): align framework with Vercel AI SDK v7 and stop bundling provider SDKs
+
+AI runtime capabilities now live in the cloud package (service-ai removed from the
+open edition, ADR-0025 S2). The framework therefore no longer ships any `@ai-sdk/*`
+provider SDK:
+
+- `@objectstack/cli` drops the dead `@ai-sdk/anthropic|gateway|google|openai`
+  dependencies (zero usages in `cli/src` — they were only bundled so the old
+  in-tree `service-ai` could `require()` them at runtime). Apps that boot the
+  closed AI now declare the providers themselves (cloud side).
+- `examples/app-todo` drops the unused `ai` / `@ai-sdk/gateway` devDeps and the
+  dead `test:ai*` / `test:agent` / `test:llm` scripts (their test files were
+  migrated to cloud).
+- `@objectstack/spec` bumps its `ai` peer/dev dependency from `^6` to `^7`. The
+  protocol still re-exports the canonical message/stream types (`ModelMessage`,
+  `TextStreamPart`, `ToolSet`, `FinishReason`, …) — all verified present in
+  `ai@7`; `ai` stays an OPTIONAL peer so installs are not forced.
+
+First step of the AI SDK v6→v7 / providers v3→v4 upgrade. Cloud (service-ai
+adapter migration + apps declaring v4 providers) and objectui (chatbot useChat
+v7) follow in their own PRs.

--- a/examples/app-todo/package.json
+++ b/examples/app-todo/package.json
@@ -17,13 +17,6 @@
     "validate": "objectstack validate",
     "typecheck": "tsc --noEmit",
     "test": "objectstack test",
-    "test:ai": "tsx test/ai.test.ts",
-    "test:agent": "tsx test/ai-agent.test.ts",
-    "test:action": "tsx test/ai-action.test.ts",
-    "test:hitl": "tsx test/ai-hitl.test.ts",
-    "test:hitl:llm": "tsx test/ai-hitl-llm.test.ts",
-    "test:llm": "tsx test/ai-llm.test.ts",
-    "test:knowledge:llm": "tsx test/ai-knowledge-llm.test.ts",
     "test:mcp": "tsx test/mcp-actions.test.ts"
   },
   "dependencies": {
@@ -38,9 +31,7 @@
     "@objectstack/spec": "workspace:*"
   },
   "devDependencies": {
-    "@ai-sdk/gateway": "^3.0.139",
     "@objectstack/cli": "workspace:*",
-    "ai": "^6.0.214",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,10 +39,6 @@
     "topicSeparator": " "
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.89",
-    "@ai-sdk/gateway": "^3.0.139",
-    "@ai-sdk/google": "^3.0.86",
-    "@ai-sdk/openai": "^3.0.77",
     "@objectstack/account": "workspace:*",
     "@objectstack/client": "workspace:*",
     "@objectstack/cloud-connection": "workspace:*",

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -208,7 +208,7 @@
   "devDependencies": {
     "@types/node": "^26.0.1",
     "@vitest/coverage-v8": "^4.1.9",
-    "ai": "^6.0.214",
+    "ai": "^7.0.4",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
@@ -217,7 +217,7 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "ai": "^6.0.0"
+    "ai": "^7.0.0"
   },
   "peerDependenciesMeta": {
     "ai": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,15 +190,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/spec
     devDependencies:
-      '@ai-sdk/gateway':
-        specifier: ^3.0.139
-        version: 3.0.139(zod@4.4.3)
       '@objectstack/cli':
         specifier: workspace:*
         version: link:../../packages/cli
-      ai:
-        specifier: ^6.0.214
-        version: 6.0.214(zod@4.4.3)
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
@@ -321,18 +315,6 @@ importers:
 
   packages/cli:
     dependencies:
-      '@ai-sdk/anthropic':
-        specifier: ^3.0.89
-        version: 3.0.89(zod@4.4.3)
-      '@ai-sdk/gateway':
-        specifier: ^3.0.139
-        version: 3.0.139(zod@4.4.3)
-      '@ai-sdk/google':
-        specifier: ^3.0.86
-        version: 3.0.86(zod@4.4.3)
-      '@ai-sdk/openai':
-        specifier: ^3.0.77
-        version: 3.0.77(zod@4.4.3)
       '@objectstack/account':
         specifier: workspace:*
         version: link:../apps/account
@@ -487,7 +469,7 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       esbuild:
-        specifier: ^0.28.1
+        specifier: '>=0.28.1'
         version: 0.28.1
       ts-morph:
         specifier: ^28.0.0
@@ -2034,8 +2016,8 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
       ai:
-        specifier: ^6.0.214
-        version: 6.0.214(zod@4.4.3)
+        specifier: ^7.0.4
+        version: 7.0.4(zod@4.4.3)
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
@@ -2194,39 +2176,21 @@ importers:
 
 packages:
 
-  '@ai-sdk/anthropic@3.0.89':
-    resolution: {integrity: sha512-Vbnyq8YO36XUKwcrZRS9T9GAJ0obPGTCX0AYFHfToD/4YdkYXxIYxb4BNjNwW0QPuPEs/1leBM4fnHpTOn5wKA==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.4':
+    resolution: {integrity: sha512-xO0e9duft/uZlnDaIeBZmzTMjfdEz1kkDzWnhQNkJZZljsKWVi6IREZW9nAa+Dx6jYJssyxSUggaFYBAV1WZpw==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.139':
-    resolution: {integrity: sha512-RFpxyh5j9g7ZMfKxhiwCcF7bGU872o3JvoiIqZbHOM4qkR4RCzeKJF+k+zHomcJYGeUabEbeMXTKNASzz4Toxw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider-utils@5.0.1':
+    resolution: {integrity: sha512-p9Ra+dN4jjHrssXvklNf4nFvWbj1KePMfUOs7nue0NuoIMbYFBULhX4Vu0+6DWLnw3+UsLL9+RCKLtzzU43Qpg==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/google@3.0.86':
-    resolution: {integrity: sha512-NZoFXTdK2/C7VuuGhAatoQ/wSiIvxVzw4Xr0AvcD3cotS5+iP/y0eN1J12pvFSZv+nAHa2Xl7xvFHDadzeU90g==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/openai@3.0.77':
-    resolution: {integrity: sha512-DK0sGy/9j6KhgSrdhSKplTo3qf5frzGjLNYo9DVloH37L6DT42AxR/26UVCCoTEjR+WdsA9svm+5cT3Aye9NTg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@4.0.33':
-    resolution: {integrity: sha512-nJ0bAfegMAIJtrzMJtbzer1cS3nb7c7DsyU1S4nrPm7ZU0Mn6SBBZv5IGZZGTbpWTJwqKTSPeZJTXalbAxt1BA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider@3.0.12':
-    resolution: {integrity: sha512-sj9DWTJ2Ze0WR9qsiOPqoqzNx3OxL6iMxHImbhvoe9qOspekbzxNDMiJ4TIGfYHYh9w4OmBjz3prvqhzTi96+Q==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider@4.0.0':
+    resolution: {integrity: sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg==}
+    engines: {node: '>=22'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -4447,6 +4411,9 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   '@xmldom/is-dom-node@1.0.1':
     resolution: {integrity: sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q==}
     engines: {node: '>= 16'}
@@ -4492,9 +4459,9 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
-  ai@6.0.214:
-    resolution: {integrity: sha512-9MlePEXT5pXtQv4fXqmiR0RG3DZU4Dbv+kU9ktEJC2COi2RH2WvI2GiyG9MuCqgPII6f1w+5kB5fNIiArqPzaQ==}
-    engines: {node: '>=18'}
+  ai@7.0.4:
+    resolution: {integrity: sha512-mZub080RWRxpWg8OY56KVnI3AoMVniccSWG+dwVb3nH81+GiNMDYBIdP41RLUivLpmU49pB7ssD7tvfIUaSaCA==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -8378,39 +8345,22 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/anthropic@3.0.89(zod@4.4.3)':
+  '@ai-sdk/gateway@4.0.4(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.12
-      '@ai-sdk/provider-utils': 4.0.33(zod@4.4.3)
-      zod: 4.4.3
-
-  '@ai-sdk/gateway@3.0.139(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.12
-      '@ai-sdk/provider-utils': 4.0.33(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.1(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/google@3.0.86(zod@4.4.3)':
+  '@ai-sdk/provider-utils@5.0.1(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.12
-      '@ai-sdk/provider-utils': 4.0.33(zod@4.4.3)
-      zod: 4.4.3
-
-  '@ai-sdk/openai@3.0.77(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.12
-      '@ai-sdk/provider-utils': 4.0.33(zod@4.4.3)
-      zod: 4.4.3
-
-  '@ai-sdk/provider-utils@4.0.33(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.12
+      '@ai-sdk/provider': 4.0.0
       '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
-  '@ai-sdk/provider@3.0.12':
+  '@ai-sdk/provider@4.0.0':
     dependencies:
       json-schema: 0.4.0
 
@@ -9628,7 +9578,8 @@ snapshots:
   '@open-draft/until@2.1.0':
     optional: true
 
-  '@opentelemetry/api@1.9.1': {}
+  '@opentelemetry/api@1.9.1':
+    optional: true
 
   '@opentelemetry/semantic-conventions@1.41.1': {}
 
@@ -10789,6 +10740,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@workflow/serde@4.1.0': {}
+
   '@xmldom/is-dom-node@1.0.1': {}
 
   '@xmldom/xmldom@0.8.13': {}
@@ -10831,12 +10784,11 @@ snapshots:
       indent-string: 4.0.0
     optional: true
 
-  ai@6.0.214(zod@4.4.3):
+  ai@7.0.4(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.139(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.12
-      '@ai-sdk/provider-utils': 4.0.33(zod@4.4.3)
-      '@opentelemetry/api': 1.9.1
+      '@ai-sdk/gateway': 4.0.4(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.1(zod@4.4.3)
       zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.20.0):


### PR DESCRIPTION
## 背景
AI 运行时能力已迁到 cloud 包(`service-ai` 从开源版移除,ADR-0025 S2)。因此 framework **不应再携带任何 `@ai-sdk/*` provider SDK**——本 PR 是 Vercel AI SDK `v6→v7` / providers `v3→v4` 大版本迁移的**第一步(framework 侧)**。

## 改动
- **`@objectstack/cli`**:删除死依赖 `@ai-sdk/anthropic|gateway|google|openai`(`cli/src` **零引用**——它们当初只是为让 in-tree 的 `service-ai` 运行时 `require()` 而打包)。
- **`examples/app-todo`**:删除未使用的 `ai` / `@ai-sdk/gateway` devDeps,以及指向已迁移文件的死脚本 `test:ai*` / `test:agent` / `test:llm` 等。
- **`@objectstack/spec`**:`ai` peer/dev 依赖 `^6 → ^7`。协议仍 re-export 正准的消息/流类型(`ModelMessage`/`TextStreamPart`/`ToolSet`/`FinishReason`…),已逐一确认在 `ai@7` 存在;`ai` 保持 **optional peer**,不强制安装。

## 验证
- `@objectstack/spec` build ✅ + **6650 测试全绿**(ai@7 下契约测试通过)
- `ai@7` 类型 re-export **10/10 存在** ✅
- `turbo build --filter=@objectstack/cli`(含上游)**54/54 成功** ✅

## ⚠️ 合并时序提醒
合并本 PR 后,cloud 的 `apps/objectos` / `apps/cloud`(通过 `link:` 引用 framework cli)会**暂时失去 provider 来源**。**配套的 cloud PR**(`service-ai` 适配器迁移 v7 + apps 声明 v4 provider)需随后跟进。objectui chatbot(`useChat` v7)再单独一个 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)