### PR TITLE
fix(examples): ADR-0079 — app-todo uses nameField, not retired titleFormat

### DIFF
--- a/examples/app-todo/src/objects/task.object.ts
+++ b/examples/app-todo/src/objects/task.object.ts
@@ -1,4 +1,4 @@
-import { P, tmpl } from '@objectstack/spec';
+import { P } from '@objectstack/spec';
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { ObjectSchema, Field } from '@objectstack/spec/data';
@@ -180,7 +180,7 @@ export const Task = ObjectSchema.create({
     { fields: ['category'] },
   ],
   
-  titleFormat: tmpl`{{record.subject}}`,
+  nameField: 'subject',
   compactLayout: ['subject', 'status', 'priority', 'due_date', 'owner'],
   
   validations: [


### PR DESCRIPTION
Last titleFormat user in framework examples. Migrates `examples/app-todo` task object from the retired render-only `titleFormat: tmpl\`{{record.subject}}\`` to the canonical `nameField: 'subject'`, and drops the now-unused `tmpl` import.

With autoprov (#2458) designating a derived nameField at registry, a leftover titleFormat is shadowed — so the example would otherwise silently stop demonstrating the intended title. tsc clean. Follows #2434/#2458/#2463.