### PR TITLE
feat(spec): add userActions.editInline toggle for inline record editing

### DIFF
--- a/.changeset/useractions-edit-inline.md
+++ b/.changeset/useractions-edit-inline.md
@@ -1,0 +1,14 @@
+---
+'@objectstack/spec': patch
+---
+
+feat(spec): add `userActions.editInline` toggle for inline record editing
+
+`UserActionsConfigSchema` — the shared toggle set behind both a view's toolbar
+and a page's `interfaceConfig.userActions` — gains `editInline: boolean`
+(default `false`, alongside `addRecordForm`). The runtime already honors it
+(objectui `InterfaceListPage` reads `userActions.editInline` → `inlineEdit`),
+and the metadata-admin "Interface (list pages)" panel — which auto-renders
+these booleans as checkboxes — now exposes an "Edit Inline" toggle. When on,
+cells edit with the field's type-aware widget (the same control the form uses).
+A list stays read-only unless the author opts in.

--- a/packages/spec/src/ui/view.test.ts
+++ b/packages/spec/src/ui/view.test.ts
@@ -2051,6 +2051,7 @@ describe('UserActionsConfigSchema', () => {
     expect(config.filter).toBe(true);
     expect(config.rowHeight).toBe(true);
     expect(config.addRecordForm).toBe(false);
+    expect(config.editInline).toBe(false);
     expect(config.buttons).toBeUndefined();
   });
 
@@ -2061,11 +2062,13 @@ describe('UserActionsConfigSchema', () => {
       filter: false,
       rowHeight: true,
       addRecordForm: true,
+      editInline: true,
       buttons: ['btn_export', 'btn_archive'],
     });
     expect(config.sort).toBe(false);
     expect(config.filter).toBe(false);
     expect(config.addRecordForm).toBe(true);
+    expect(config.editInline).toBe(true);
     expect(config.buttons).toEqual(['btn_export', 'btn_archive']);
   });
 

--- a/packages/spec/src/ui/view.zod.ts
+++ b/packages/spec/src/ui/view.zod.ts
@@ -241,6 +241,7 @@ export const UserActionsConfigSchema = lazySchema(() => z.object({
   filter: z.boolean().default(true).describe('Allow users to filter records'),
   rowHeight: z.boolean().default(true).describe('Allow users to toggle row height/density'),
   addRecordForm: z.boolean().default(false).describe('Add records through a form instead of inline'),
+  editInline: z.boolean().default(false).describe('Allow users to edit records inline — click a cell to edit it with the field\'s type-aware widget (the same control the form uses). Off by default: the list is read-only unless the author opts in.'),
   buttons: z.array(z.string()).optional().describe('Custom action button IDs to show in the toolbar'),
 }).describe('User action toggles for the view toolbar'));
 


### PR DESCRIPTION
## What

Add `editInline: boolean` (default `false`) to **`UserActionsConfigSchema`** — the shared toggle set behind both a view's toolbar and a page's `interfaceConfig.userActions`.

## Why

Inline cell editing is meant to be a first-class, author-controlled list property, and the objectui runtime already honors it (`InterfaceListPage` reads `userActions.editInline === true` → `inlineEdit`). But the schema had no field for it, so the metadata-admin **"Interface (list pages)"** panel — which auto-renders these booleans as checkboxes (sort/search/filter/rowHeight/addRecordForm) — had no toggle to expose. This adds the missing schema field so the panel renders an **"Edit Inline"** checkbox, sitting right alongside `addRecordForm`.

Default `false`: a list stays read-only unless the author opts in. When on, cells edit with the field's **type-aware widget** (the same control the form uses — select→dropdown, boolean→checkbox, date→picker, …).

## Tests

`view.test.ts` → `UserActionsConfigSchema` asserts the new default (`false`) and the accepted (`true`) value. `pnpm vitest run src/ui/view.test.ts -t UserActionsConfigSchema` → 3 passed.

## Downstream

objectui mirrors this in `ListViewSchema.userActions` (objectstack-ai/objectui#feat/inline-edit-view-toggle). The metadata-panel checkbox appears once a runtime serves this spec via `/meta/types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)