### PR TITLE
chore(spec): close react-block frontend-only divergence — overlay data/fields/options (ADR-0081)

### DIFF
--- a/packages/spec/react-conformance.baseline.json
+++ b/packages/spec/react-conformance.baseline.json
@@ -6,16 +6,11 @@
       "missing": false
     },
     "ListView": {
-      "frontendOnly": [
-        "fields",
-        "options"
-      ],
+      "frontendOnly": [],
       "missing": false
     },
     "ObjectChart": {
-      "frontendOnly": [
-        "data"
-      ],
+      "frontendOnly": [],
       "missing": false
     },
     "RecordDetails": {

--- a/packages/spec/src/ui/react-blocks.ts
+++ b/packages/spec/src/ui/react-blocks.ts
@@ -96,6 +96,8 @@ export const REACT_BLOCKS: ReactBlockDef[] = [
       { name: 'navigation', type: "{ mode: 'page' | 'drawer' | 'modal' | 'split' | 'none' }", kind: 'binding', description: 'What a row click does. Use { mode: \"none\" } when you handle clicks via onRowClick.' },
       { name: 'onRowClick', type: '(record) => void', kind: 'callback', description: "Called with the clicked row's record — the hook for master/detail." },
       { name: 'onNavigate', type: "(recordId, action: 'view' | 'edit') => void", kind: 'callback', description: 'Called for page-level navigation.' },
+      { name: 'fields', type: 'string[]', kind: 'binding', description: 'Limit/order the columns shown (defaults to the object list fields).' },
+      { name: 'options', type: 'Record<string, any>', kind: 'binding', description: 'View-type-specific options bag (kanban/calendar/gantt extras); prefer the typed spec props where they exist.' },
     ],
   },
   {
@@ -108,6 +110,7 @@ export const REACT_BLOCKS: ReactBlockDef[] = [
       OBJECT_NAME,
       { name: 'filter', type: 'FilterArray', kind: 'controlled', description: 'ObjectQL filter scoping the data; drive from React state.' },
       { name: 'aggregate', type: '{ field, function, groupBy }', kind: 'binding', description: 'Aggregation: function (sum/avg/count) over field, grouped by groupBy.' },
+      { name: 'data', type: 'any[]', kind: 'binding', description: 'Static/precomputed data to chart directly instead of binding via objectName + aggregate.' },
     ],
   },
   {

--- a/skills/objectstack-ui/contracts/react-blocks.contract.json
+++ b/skills/objectstack-ui/contracts/react-blocks.contract.json
@@ -180,6 +180,20 @@
           "description": "What a row click does. Use { mode: \"none\" } when you handle clicks via onRowClick."
         },
         {
+          "name": "fields",
+          "type": "string[]",
+          "kind": "binding",
+          "required": false,
+          "description": "Limit/order the columns shown (defaults to the object list fields)."
+        },
+        {
+          "name": "options",
+          "type": "Record<string, any>",
+          "kind": "binding",
+          "required": false,
+          "description": "View-type-specific options bag (kanban/calendar/gantt extras); prefer the typed spec props where they exist."
+        },
+        {
           "name": "filters",
           "type": "FilterArray e.g. ['status','=','active']",
           "kind": "controlled",
@@ -291,6 +305,13 @@
           "kind": "binding",
           "required": false,
           "description": "Aggregation: function (sum/avg/count) over field, grouped by groupBy."
+        },
+        {
+          "name": "data",
+          "type": "any[]",
+          "kind": "binding",
+          "required": false,
+          "description": "Static/precomputed data to chart directly instead of binding via objectName + aggregate."
         },
         {
           "name": "filter",

--- a/skills/objectstack-ui/references/react-blocks.md
+++ b/skills/objectstack-ui/references/react-blocks.md
@@ -47,6 +47,8 @@ Server-connected object table with toolbar and switchable visualizations (grid/k
 | `objectName` | `string` | binding | ✓ | The object this block binds to (server-connected). |
 | `viewType` | `'grid' \| 'kanban' \| 'gallery' \| 'calendar' \| 'timeline' \| 'gantt' \| 'map'` | binding |  | Which visualization to render (default grid). How you get a kanban/calendar/gantt of the object. |
 | `navigation` | `{ mode: 'page' \| 'drawer' \| 'modal' \| 'split' \| 'none' }` | binding |  | What a row click does. Use { mode: "none" } when you handle clicks via onRowClick. |
+| `fields` | `string[]` | binding |  | Limit/order the columns shown (defaults to the object list fields). |
+| `options` | `Record<string, any>` | binding |  | View-type-specific options bag (kanban/calendar/gantt extras); prefer the typed spec props where they exist. |
 | `filters` | `FilterArray e.g. ['status','=','active']` | controlled |  | ObjectQL base filter; drive from React state for tabbed/searched lists. ([field, op, value]; ops =, !=, >, <, contains, in; compound: ["and", […], […]]). |
 | `onRowClick` | `(record) => void` | callback |  | Called with the clicked row's record — the hook for master/detail. |
 | `onNavigate` | `(recordId, action: 'view' \| 'edit') => void` | callback |  | Called for page-level navigation. |
@@ -69,6 +71,7 @@ Chart over an object’s aggregated data. Config props come from the spec Chart 
 |------|------|------|:--------:|-------------|
 | `objectName` | `string` | binding | ✓ | The object this block binds to (server-connected). |
 | `aggregate` | `{ field, function, groupBy }` | binding |  | Aggregation: function (sum/avg/count) over field, grouped by groupBy. |
+| `data` | `any[]` | binding |  | Static/precomputed data to chart directly instead of binding via objectName + aggregate. |
 | `filter` | `FilterArray` | controlled |  | ObjectQL filter scoping the data; drive from React state. |
 | `showLegend` | `boolean` | data | ✓ | Display legend |
 | `title` | `string` | data |  | Chart title |


### PR DESCRIPTION
## What

Follow-up to the conformance ratchet (#2485). That PR's baseline *accepted* three frontend-only props — `ObjectChart.data`, `ListView.fields`, `ListView.options`. This closes them so the baseline is **0 frontend-only across every block**, making the ratchet noise-free.

## Why these aren't real divergence

All three are legitimate **binding escape-hatches** the component genuinely accepts, that the spec schema just doesn't model:
- `ObjectChart.data` — pass static/precomputed data directly instead of binding via `objectName` + `aggregate`.
- `ListView.fields` — a simplified column list (directly analogous to `ObjectForm.fields`, already in the overlay).
- `ListView.options` — a per-viewType options bag (kanban/calendar/gantt extras).

The divergence was "component accepts a prop the contract doesn't document." The fix is to **document it** (in the react-blocks overlay → the AI-facing contract), not to leave it sitting as accepted baseline noise.

## How

- Add the three props to the `react-blocks.ts` overlay as `binding` kind with honest descriptions.
- Regenerate `react-blocks.contract.json` + `references/react-blocks.md` (AI now sees these props) and `react-conformance.baseline.json` (all `frontendOnly: []`).

## Result

- Every block: **0 frontend-only**. The ratchet now treats *any* future frontend-only prop as a real, actionable signal.
- `@objectstack/spec` build green; **api-surface unchanged** (overlay entries, not new exports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)