### PR TITLE
fix(showcase): drop Tailwind from kind:'react' pages — inline styles + pre-styled overlays (ADR-0065)

### DIFF
--- a/examples/app-showcase/src/pages/account-cockpit.page.ts
+++ b/examples/app-showcase/src/pages/account-cockpit.page.ts
@@ -5,11 +5,11 @@ import { definePage } from '@objectstack/spec/ui';
 /**
  * Account Cockpit — a `kind:'react'` business scenario (ADR-0081).
  *
- * A customer-360 cockpit: a live-search account list (React text input drives
- * the real `<ListView>`'s `filters`), a selected account edited in a real
- * `<ObjectForm>`, and a related-data strip that aggregates the account's
- * projects and invoices via cross-object `useAdapter` queries. Demonstrates
- * live search, master-detail edit, and cross-object roll-ups together.
+ * Customer-360 over `showcase_account`: a live search filters a real
+ * `<ListView>`, selecting an account loads it into an `<ObjectForm>` editor and
+ * rolls up related projects & invoices via `useAdapter()` cross-object queries.
+ *
+ * Styling (ADR-0065): no Tailwind — inline `style={{}}` with `hsl(var(--token))`.
  */
 export const AccountCockpitPage = definePage({
   name: 'showcase_account_cockpit',
@@ -38,49 +38,49 @@ function Page() {
   }, [adapter, sel, reload]);
 
   const filters = q.trim() ? ['name', 'contains', q.trim()] : undefined;
+  const card = { background: 'hsl(var(--card))', border: '1px solid hsl(var(--border))', borderRadius: 'var(--radius)' };
   const Stat = ({ label, value, accent }) => (
-    <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
-      <div className="text-xs font-medium uppercase tracking-wide text-slate-400">{label}</div>
-      <div className={'mt-1 text-2xl font-bold ' + (accent || 'text-slate-900')}>{value}</div>
+    <div style={{ background: 'hsl(var(--muted))', border: '1px solid hsl(var(--border))', borderRadius: 'var(--radius)', padding: 12 }}>
+      <div style={{ fontSize: 12, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.04em', color: 'hsl(var(--muted-foreground))' }}>{label}</div>
+      <div style={{ marginTop: 4, fontSize: 24, fontWeight: 700, color: accent || 'hsl(var(--foreground))' }}>{value}</div>
     </div>
   );
 
   return (
-    <div className="mx-auto max-w-6xl space-y-5 p-8">
-      <header className="flex items-end justify-between gap-4">
+    <div style={{ maxWidth: 1152, margin: '0 auto', padding: 32, display: 'flex', flexDirection: 'column', gap: 20 }}>
+      <header style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', gap: 16 }}>
         <div>
-          <h1 className="text-2xl font-bold tracking-tight text-slate-900">Account Cockpit</h1>
-          <p className="mt-1 text-sm text-slate-500">Customer-360 over <code>showcase_account</code> — search, edit, and roll up related projects &amp; invoices.</p>
+          <h1 style={{ margin: 0, fontSize: 24, fontWeight: 700, letterSpacing: '-0.01em', color: 'hsl(var(--foreground))' }}>Account Cockpit</h1>
+          <p style={{ marginTop: 4, fontSize: 14, color: 'hsl(var(--muted-foreground))' }}>Customer-360 over <code>showcase_account</code> — search, edit, and roll up related projects &amp; invoices.</p>
         </div>
-        <input value={q} onChange={(e) => { setQ(e.target.value); setSel(null); }}
-          placeholder="Search accounts…"
-          className="w-64 rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none" />
+        <input value={q} onChange={(e) => { setQ(e.target.value); setSel(null); }} placeholder="Search accounts…"
+          style={{ width: 256, borderRadius: 'var(--radius)', border: '1px solid hsl(var(--border))', background: 'hsl(var(--background))', color: 'hsl(var(--foreground))', padding: '8px 12px', fontSize: 14, outline: 'none' }} />
       </header>
 
-      <div className="grid grid-cols-5 gap-6">
-        <section className="col-span-3 rounded-xl border border-slate-200 bg-white p-2">
+      <div style={{ display: 'grid', gridTemplateColumns: '3fr 2fr', gap: 24, alignItems: 'start' }}>
+        <section style={{ ...card, padding: 8 }}>
           <ListView key={q + ':' + reload} objectName="showcase_account"
             fields={['name', 'industry', 'status', 'annual_revenue']} filters={filters}
             navigation={{ mode: 'none' }} onRowClick={(r) => setSel(r)} />
         </section>
-        <section className="col-span-2 space-y-4">
+        <section style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
           {sel ? (
             <React.Fragment>
-              <div className="grid grid-cols-3 gap-3">
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12 }}>
                 <Stat label="Projects" value={related.projects} />
                 <Stat label="Invoices" value={related.invoices} />
-                <Stat label="Open AR" value={related.openInvoices} accent="text-amber-600" />
+                <Stat label="Open AR" value={related.openInvoices} accent="hsl(38 92% 50%)" />
               </div>
-              <div className="rounded-xl border border-slate-200 bg-white p-5">
+              <div style={{ ...card, padding: 20 }}>
                 <ObjectForm key={sel.id + ':' + reload} objectName="showcase_account" mode="edit"
                   recordId={sel.id} onSuccess={() => { setSel(null); setReload((k) => k + 1); }}
                   onCancel={() => setSel(null)} />
               </div>
             </React.Fragment>
           ) : (
-            <div className="flex h-full min-h-[240px] flex-col items-center justify-center rounded-xl border border-slate-200 bg-white text-center text-slate-400">
-              <div className="text-4xl">🛰️</div>
-              <p className="mt-2 text-sm">Search and select an account.</p>
+            <div style={{ ...card, display: 'flex', minHeight: 240, flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', color: 'hsl(var(--muted-foreground))' }}>
+              <div style={{ fontSize: 32 }}>🛰️</div>
+              <p style={{ marginTop: 8, fontSize: 14 }}>Search and select an account.</p>
             </div>
           )}
         </section>

--- a/examples/app-showcase/src/pages/crm-workbench.page.ts
+++ b/examples/app-showcase/src/pages/crm-workbench.page.ts
@@ -5,27 +5,15 @@ import { definePage } from '@objectstack/spec/ui';
 /**
  * CRM Workbench — a `kind:'react'` page (ADR-0081, the TRUSTED tier).
  *
- * The whole page is REAL React executed at render by `@object-ui/react-runtime`
- * (hooks, event handlers, arbitrary JS) — NOT the constrained parse-never-execute
- * `kind:'html'` tier. It demonstrates exactly what a real customer business UI
- * needs: a master/detail workbench that COMPOSES the platform's real data
- * components — `<ListView>` (the object table) and `<ObjectForm>` — with React
- * state to wire complex interaction the fixed page schema cannot express:
+ * Real React executed at render (hooks, handlers, arbitrary JS) composing the
+ * platform's real data components — `<ListView>` + `<ObjectForm>` — into a
+ * master/detail workbench with a live KPI strip.
  *
- *   - click a project row  → load that record into the editor (controlled `recordId`)
- *   - save the form        → refresh the list (`onSuccess` bumps a remount key)
- *   - "New project"        → the same editor in create mode
- *   - a live KPI strip     → `useAdapter()` queries the object directly
- *
- * The injected scope exposes `React`, `useAdapter`, and the curated public data
- * blocks as PascalCase components (`ListView`, `ObjectForm`, `ObjectMetric`, …),
- * each a real registered renderer. Layout is plain HTML + Tailwind.
- *
- * NOTE: `kind:'react'` executes author code, so it is gated by the host
- * capability `CAP_REACT_PAGES`, which defaults ON (the platform trusts its
- * reviewed, draft-gated authors). A deployment that does not trust its authors
- * turns it off server-side with `OS_PAGE_REACT=off`, in which case
- * this page renders a "disabled on this deployment" notice instead of executing.
+ * Styling (ADR-0065): page source is runtime metadata, so the console's
+ * build-time Tailwind never scans it — utility classes silently no-op. So the
+ * page uses ZERO Tailwind: layout/chrome is inline `style={{}}` with
+ * `hsl(var(--token))` theme colors (real CSS, theme-aware), and the data
+ * components bring their own compiled styling.
  */
 export const CrmWorkbenchPage = definePage({
   name: 'showcase_crm_workbench',
@@ -48,64 +36,50 @@ function Page() {
       setStats({ total: rows.length, active: rows.filter((r) => r.status === 'active').length });
     } catch (e) { /* ignore in demo */ }
   }, [adapter]);
-
   React.useEffect(() => { refreshStats(); }, [refreshStats, reloadKey]);
 
   const openNew = () => { setSelected(null); setMode('create'); };
   const onRowClick = (rec) => { setSelected(rec); setMode('edit'); };
   const afterSave = () => { setSelected(null); setMode('edit'); setReloadKey((k) => k + 1); };
-
   const editing = mode === 'create' || selected;
 
+  const card = { background: 'hsl(var(--card))', border: '1px solid hsl(var(--border))', borderRadius: 'var(--radius)', padding: 16 };
+  const eyebrow = { fontSize: 12, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.04em', color: 'hsl(var(--muted-foreground))' };
+  const big = { marginTop: 4, fontSize: 30, fontWeight: 700, color: 'hsl(var(--foreground))' };
+
   return (
-    <div className="mx-auto max-w-6xl space-y-6 p-8">
-      <header className="flex items-center justify-between">
+    <div style={{ maxWidth: 1152, margin: '0 auto', padding: 32, display: 'flex', flexDirection: 'column', gap: 24 }}>
+      <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 16 }}>
         <div>
-          <h1 className="text-2xl font-bold tracking-tight text-slate-900">CRM Workbench</h1>
-          <p className="mt-1 text-sm text-slate-500">Master/detail over <code>showcase_project</code> — real <code>&lt;ListView&gt;</code> + <code>&lt;ObjectForm&gt;</code> wired with React state.</p>
+          <h1 style={{ margin: 0, fontSize: 24, fontWeight: 700, letterSpacing: '-0.01em', color: 'hsl(var(--foreground))' }}>CRM Workbench</h1>
+          <p style={{ marginTop: 4, fontSize: 14, color: 'hsl(var(--muted-foreground))' }}>Master/detail over <code>showcase_project</code> — real <code>&lt;ListView&gt;</code> + <code>&lt;ObjectForm&gt;</code> wired with React state.</p>
         </div>
-        <button onClick={openNew} className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500">+ New project</button>
+        <button onClick={openNew} style={{ flexShrink: 0, borderRadius: 'var(--radius)', background: 'hsl(var(--primary))', color: 'hsl(var(--primary-foreground))', padding: '8px 16px', fontSize: 14, fontWeight: 600, border: 'none', cursor: 'pointer' }}>+ New project</button>
       </header>
 
-      <div className="grid grid-cols-3 gap-4">
-        <div className="rounded-xl border border-slate-200 bg-white p-4">
-          <div className="text-xs font-medium uppercase tracking-wide text-slate-400">Total projects</div>
-          <div className="mt-1 text-3xl font-bold text-slate-900">{stats.total}</div>
-        </div>
-        <div className="rounded-xl border border-slate-200 bg-white p-4">
-          <div className="text-xs font-medium uppercase tracking-wide text-slate-400">Active</div>
-          <div className="mt-1 text-3xl font-bold text-emerald-600">{stats.active}</div>
-        </div>
-        <div className="rounded-xl border border-slate-200 bg-white p-4">
-          <div className="text-xs font-medium uppercase tracking-wide text-slate-400">Editing</div>
-          <div className="mt-1 truncate text-lg font-semibold text-slate-700">{mode === 'create' ? 'New project' : selected ? (selected.name || selected.id) : '—'}</div>
-        </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16 }}>
+        <div style={card}><div style={eyebrow}>Total projects</div><div style={big}>{stats.total}</div></div>
+        <div style={card}><div style={eyebrow}>Active</div><div style={{ ...big, color: 'hsl(142 70% 45%)' }}>{stats.active}</div></div>
+        <div style={card}><div style={eyebrow}>Editing</div><div style={{ marginTop: 4, fontSize: 18, fontWeight: 600, color: 'hsl(var(--foreground))', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{mode === 'create' ? 'New project' : selected ? (selected.name || selected.id) : '—'}</div></div>
       </div>
 
-      <div className="grid grid-cols-5 gap-6">
-        <section className="col-span-3 rounded-xl border border-slate-200 bg-white p-2">
-          <ListView
-            key={reloadKey}
-            objectName="showcase_project"
+      <div style={{ display: 'grid', gridTemplateColumns: '3fr 2fr', gap: 24, alignItems: 'start' }}>
+        <section style={{ ...card, padding: 8 }}>
+          <ListView key={reloadKey} objectName="showcase_project"
             fields={['name', 'status', 'health', 'budget', 'owner']}
-            navigation={{ mode: 'none' }}
-            onRowClick={onRowClick}
-          />
+            navigation={{ mode: 'none' }} onRowClick={onRowClick} />
         </section>
-        <section className="col-span-2 rounded-xl border border-slate-200 bg-white p-5">
+        <section style={{ ...card, padding: 20 }}>
           {editing ? (
             <ObjectForm
               key={(mode === 'create' ? 'new' : selected && selected.id) + ':' + reloadKey}
-              objectName="showcase_project"
-              mode={mode}
+              objectName="showcase_project" mode={mode}
               recordId={mode === 'edit' && selected ? selected.id : undefined}
-              onSuccess={afterSave}
-              onCancel={() => { setSelected(null); }}
-            />
+              onSuccess={afterSave} onCancel={() => { setSelected(null); }} />
           ) : (
-            <div className="flex h-full min-h-[240px] flex-col items-center justify-center text-center text-slate-400">
-              <div className="text-4xl">🗂️</div>
-              <p className="mt-2 text-sm">Select a project to edit, or create a new one.</p>
+            <div style={{ display: 'flex', minHeight: 240, flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', color: 'hsl(var(--muted-foreground))' }}>
+              <div style={{ fontSize: 32 }}>🗂️</div>
+              <p style={{ marginTop: 8, fontSize: 14 }}>Select a project to edit, or create a new one.</p>
             </div>
           )}
         </section>

--- a/examples/app-showcase/src/pages/inquiry-triage.page.ts
+++ b/examples/app-showcase/src/pages/inquiry-triage.page.ts
@@ -5,12 +5,12 @@ import { definePage } from '@objectstack/spec/ui';
 /**
  * Inquiry Triage Inbox — a `kind:'react'` business scenario (ADR-0081).
  *
- * Models the classic support/lead-triage queue every CRM needs: status TABS
- * with live counts, a real `<ListView>` filtered by the active tab, and a detail
- * panel with one-click status actions ("Mark Contacted" / "Close") that persist
- * via `useAdapter().update` and refresh the list + counts. Demonstrates
- * React-state-driven server filtering, cross-row aggregation, and a status
- * workflow — none of which the fixed page schema can express.
+ * A support/lead-triage queue: status TABS with live counts filter a real
+ * `<ListView>`, and a detail panel with one-click status actions persists via
+ * `useAdapter().update` and refreshes the list + counts.
+ *
+ * Styling (ADR-0065): no Tailwind — page chrome is inline `style={{}}` with
+ * `hsl(var(--token))` theme colors; the data component brings its own styling.
  */
 export const InquiryTriagePage = definePage({
   name: 'showcase_inquiry_triage',
@@ -47,53 +47,60 @@ function Page() {
 
   const TABS = [['all', 'All'], ['new', 'New'], ['contacted', 'Contacted'], ['closed', 'Closed']];
   const filters = tab === 'all' ? undefined : ['status', '=', tab];
-  const STATUS_COLOR = { new: 'bg-blue-100 text-blue-700', contacted: 'bg-amber-100 text-amber-700', closed: 'bg-emerald-100 text-emerald-700' };
+  const STATUS_COLOR = { new: 'hsl(217 91% 60%)', contacted: 'hsl(38 92% 50%)', closed: 'hsl(142 70% 45%)' };
+
+  const card = { background: 'hsl(var(--card))', border: '1px solid hsl(var(--border))', borderRadius: 'var(--radius)' };
+  const tabBtn = (active) => ({
+    display: 'flex', alignItems: 'center', gap: 8, borderRadius: 9999, padding: '6px 16px', fontSize: 14, fontWeight: 600,
+    border: '1px solid ' + (active ? 'transparent' : 'hsl(var(--border))'), cursor: 'pointer',
+    background: active ? 'hsl(var(--primary))' : 'transparent',
+    color: active ? 'hsl(var(--primary-foreground))' : 'hsl(var(--muted-foreground))',
+  });
 
   return (
-    <div className="mx-auto max-w-6xl space-y-5 p-8">
+    <div style={{ maxWidth: 1152, margin: '0 auto', padding: 32, display: 'flex', flexDirection: 'column', gap: 20 }}>
       <header>
-        <h1 className="text-2xl font-bold tracking-tight text-slate-900">Inquiry Triage</h1>
-        <p className="mt-1 text-sm text-slate-500">A support queue over <code>showcase_inquiry</code> — tabs filter a real <code>&lt;ListView&gt;</code>; one click moves an inquiry's status.</p>
+        <h1 style={{ margin: 0, fontSize: 24, fontWeight: 700, letterSpacing: '-0.01em', color: 'hsl(var(--foreground))' }}>Inquiry Triage</h1>
+        <p style={{ marginTop: 4, fontSize: 14, color: 'hsl(var(--muted-foreground))' }}>A support queue over <code>showcase_inquiry</code> — tabs filter a real <code>&lt;ListView&gt;</code>; one click moves an inquiry's status.</p>
       </header>
 
-      <div className="flex flex-wrap gap-2">
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
         {TABS.map(([k, label]) => (
-          <button key={k} onClick={() => { setTab(k); setSel(null); }}
-            className={'flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold ' + (tab === k ? 'bg-slate-900 text-white' : 'bg-slate-100 text-slate-600 hover:bg-slate-200')}>
+          <button key={k} onClick={() => { setTab(k); setSel(null); }} style={tabBtn(tab === k)}>
             {label}
-            <span className={'rounded-full px-2 py-0.5 text-xs ' + (tab === k ? 'bg-white/20' : 'bg-white text-slate-500')}>{counts[k]}</span>
+            <span style={{ borderRadius: 9999, padding: '1px 8px', fontSize: 12, background: tab === k ? 'rgba(255,255,255,0.2)' : 'hsl(var(--muted))', color: tab === k ? 'inherit' : 'hsl(var(--muted-foreground))' }}>{counts[k]}</span>
           </button>
         ))}
       </div>
 
-      <div className="grid grid-cols-5 gap-6">
-        <section className="col-span-3 rounded-xl border border-slate-200 bg-white p-2">
+      <div style={{ display: 'grid', gridTemplateColumns: '3fr 2fr', gap: 24, alignItems: 'start' }}>
+        <section style={{ ...card, padding: 8 }}>
           <ListView key={tab + ':' + reload} objectName="showcase_inquiry"
             fields={['name', 'company', 'email', 'status']} filters={filters}
             navigation={{ mode: 'none' }} onRowClick={(r) => setSel(r)} />
         </section>
-        <section className="col-span-2 rounded-xl border border-slate-200 bg-white p-5">
+        <section style={{ ...card, padding: 20 }}>
           {sel ? (
-            <div className="space-y-4">
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
               <div>
-                <div className="flex items-center justify-between">
-                  <h2 className="text-lg font-semibold text-slate-900">{sel.name}</h2>
-                  <span className={'rounded-full px-2.5 py-0.5 text-xs font-semibold ' + (STATUS_COLOR[sel.status] || 'bg-slate-100 text-slate-600')}>{sel.status}</span>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+                  <h2 style={{ margin: 0, fontSize: 18, fontWeight: 600, color: 'hsl(var(--foreground))' }}>{sel.name}</h2>
+                  <span style={{ borderRadius: 9999, padding: '2px 10px', fontSize: 12, fontWeight: 600, color: '#fff', background: STATUS_COLOR[sel.status] || 'hsl(var(--muted))' }}>{sel.status}</span>
                 </div>
-                <p className="text-sm text-slate-500">{sel.company} · {sel.email}</p>
+                <p style={{ marginTop: 4, fontSize: 14, color: 'hsl(var(--muted-foreground))' }}>{sel.company} · {sel.email}</p>
               </div>
-              <p className="rounded-lg bg-slate-50 p-3 text-sm leading-relaxed text-slate-700">{sel.message || 'No message.'}</p>
-              <div className="flex gap-2">
+              <p style={{ borderRadius: 'var(--radius)', background: 'hsl(var(--muted))', padding: 12, fontSize: 14, lineHeight: 1.6, color: 'hsl(var(--foreground))' }}>{sel.message || 'No message.'}</p>
+              <div style={{ display: 'flex', gap: 8 }}>
                 <button onClick={() => setStatus('contacted')} disabled={sel.status === 'contacted'}
-                  className="rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-600 disabled:opacity-40">Mark Contacted</button>
+                  style={{ borderRadius: 'var(--radius)', background: 'hsl(38 92% 50%)', color: '#fff', padding: '8px 16px', fontSize: 14, fontWeight: 600, border: 'none', cursor: 'pointer', opacity: sel.status === 'contacted' ? 0.4 : 1 }}>Mark Contacted</button>
                 <button onClick={() => setStatus('closed')} disabled={sel.status === 'closed'}
-                  className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:opacity-40">Close</button>
+                  style={{ borderRadius: 'var(--radius)', background: 'hsl(142 70% 40%)', color: '#fff', padding: '8px 16px', fontSize: 14, fontWeight: 600, border: 'none', cursor: 'pointer', opacity: sel.status === 'closed' ? 0.4 : 1 }}>Close</button>
               </div>
             </div>
           ) : (
-            <div className="flex h-full min-h-[240px] flex-col items-center justify-center text-center text-slate-400">
-              <div className="text-4xl">📥</div>
-              <p className="mt-2 text-sm">Select an inquiry to triage.</p>
+            <div style={{ display: 'flex', minHeight: 240, flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', color: 'hsl(var(--muted-foreground))' }}>
+              <div style={{ fontSize: 32 }}>📥</div>
+              <p style={{ marginTop: 8, fontSize: 14 }}>Select an inquiry to triage.</p>
             </div>
           )}
         </section>

--- a/examples/app-showcase/src/pages/invoice-console.page.ts
+++ b/examples/app-showcase/src/pages/invoice-console.page.ts
@@ -5,11 +5,11 @@ import { definePage } from '@objectstack/spec/ui';
 /**
  * Invoice Console — a `kind:'react'` business scenario (ADR-0081).
  *
- * Accounts-receivable management: a KPI strip aggregating invoices by status
- * (useAdapter), a status segmented-filter driving a real `<ListView>`, a real
- * `<ObjectForm>` for create + edit, and a "Mark Paid" quick action on the
- * selected invoice. Demonstrates aggregation KPIs, segmented filtering, full
- * CRUD, and a one-click status transition in one screen.
+ * Accounts-receivable workbench over `showcase_invoice`: aggregate KPIs, a
+ * status segmented control filtering a real `<ListView>`, an `<ObjectForm>`
+ * editor, and a one-click "Mark Paid" collect action.
+ *
+ * Styling (ADR-0065): no Tailwind — inline `style={{}}` with `hsl(var(--token))`.
  */
 export const InvoiceConsolePage = definePage({
   name: 'showcase_invoice_console',
@@ -48,44 +48,52 @@ function Page() {
   const FILTERS = [['all', 'All'], ['draft', 'Draft'], ['sent', 'Sent'], ['paid', 'Paid'], ['void', 'Void']];
   const filters = status === 'all' ? undefined : ['status', '=', status];
   const editing = mode === 'create' || sel;
+
+  const card = { background: 'hsl(var(--card))', border: '1px solid hsl(var(--border))', borderRadius: 'var(--radius)' };
+  const eyebrow = { fontSize: 12, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.04em', color: 'hsl(var(--muted-foreground))' };
   const Kpi = ({ label, value, accent }) => (
-    <div className="rounded-xl border border-slate-200 bg-white p-4">
-      <div className="text-xs font-medium uppercase tracking-wide text-slate-400">{label}</div>
-      <div className={'mt-1 text-3xl font-bold ' + (accent || 'text-slate-900')}>{value}</div>
+    <div style={{ ...card, padding: 16 }}>
+      <div style={eyebrow}>{label}</div>
+      <div style={{ marginTop: 4, fontSize: 30, fontWeight: 700, color: accent || 'hsl(var(--foreground))' }}>{value}</div>
     </div>
   );
+  const pill = (active) => ({
+    borderRadius: 9999, padding: '4px 14px', fontSize: 14, fontWeight: 600, cursor: 'pointer',
+    border: '1px solid ' + (active ? 'transparent' : 'hsl(var(--border))'),
+    background: active ? 'hsl(var(--primary))' : 'transparent',
+    color: active ? 'hsl(var(--primary-foreground))' : 'hsl(var(--muted-foreground))',
+  });
 
   return (
-    <div className="mx-auto max-w-6xl space-y-5 p-8">
-      <header className="flex items-center justify-between">
+    <div style={{ maxWidth: 1152, margin: '0 auto', padding: 32, display: 'flex', flexDirection: 'column', gap: 20 }}>
+      <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 16 }}>
         <div>
-          <h1 className="text-2xl font-bold tracking-tight text-slate-900">Invoice Console</h1>
-          <p className="mt-1 text-sm text-slate-500">Accounts receivable over <code>showcase_invoice</code> — aggregate, filter, edit, and collect.</p>
+          <h1 style={{ margin: 0, fontSize: 24, fontWeight: 700, letterSpacing: '-0.01em', color: 'hsl(var(--foreground))' }}>Invoice Console</h1>
+          <p style={{ marginTop: 4, fontSize: 14, color: 'hsl(var(--muted-foreground))' }}>Accounts receivable over <code>showcase_invoice</code> — aggregate, filter, edit, and collect.</p>
         </div>
-        <button onClick={openNew} className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500">+ New invoice</button>
+        <button onClick={openNew} style={{ flexShrink: 0, borderRadius: 'var(--radius)', background: 'hsl(var(--primary))', color: 'hsl(var(--primary-foreground))', padding: '8px 16px', fontSize: 14, fontWeight: 600, border: 'none', cursor: 'pointer' }}>+ New invoice</button>
       </header>
 
-      <div className="grid grid-cols-4 gap-4">
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 16 }}>
         <Kpi label="Total" value={kpi.count} />
-        <Kpi label="Draft" value={kpi.draft} accent="text-slate-500" />
-        <Kpi label="Sent" value={kpi.sent} accent="text-blue-600" />
-        <Kpi label="Paid" value={kpi.paid} accent="text-emerald-600" />
+        <Kpi label="Draft" value={kpi.draft} accent="hsl(var(--muted-foreground))" />
+        <Kpi label="Sent" value={kpi.sent} accent="hsl(217 91% 60%)" />
+        <Kpi label="Paid" value={kpi.paid} accent="hsl(142 70% 45%)" />
       </div>
 
-      <div className="flex flex-wrap gap-2">
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
         {FILTERS.map(([k, label]) => (
-          <button key={k} onClick={() => setStatus(k)}
-            className={'rounded-full px-3.5 py-1 text-sm font-semibold ' + (status === k ? 'bg-slate-900 text-white' : 'bg-slate-100 text-slate-600 hover:bg-slate-200')}>{label}</button>
+          <button key={k} onClick={() => setStatus(k)} style={pill(status === k)}>{label}</button>
         ))}
       </div>
 
-      <div className="grid grid-cols-5 gap-6">
-        <section className="col-span-3 rounded-xl border border-slate-200 bg-white p-2">
+      <div style={{ display: 'grid', gridTemplateColumns: '3fr 2fr', gap: 24, alignItems: 'start' }}>
+        <section style={{ ...card, padding: 8 }}>
           <ListView key={status + ':' + reload} objectName="showcase_invoice"
             fields={['name', 'account', 'status', 'total']} filters={filters}
             navigation={{ mode: 'none' }} onRowClick={(r) => { setSel(r); setMode('edit'); }} />
         </section>
-        <section className="col-span-2 space-y-3 rounded-xl border border-slate-200 bg-white p-5">
+        <section style={{ ...card, padding: 20, display: 'flex', flexDirection: 'column', gap: 12 }}>
           {editing ? (
             <React.Fragment>
               <ObjectForm key={(mode === 'create' ? 'new' : sel && sel.id) + ':' + reload}
@@ -93,13 +101,13 @@ function Page() {
                 recordId={mode === 'edit' && sel ? sel.id : undefined}
                 onSuccess={afterWrite} onCancel={() => setSel(null)} />
               {mode === 'edit' && sel && sel.status !== 'paid' ? (
-                <button onClick={markPaid} className="w-full rounded-lg border border-emerald-600 px-4 py-2 text-sm font-semibold text-emerald-700 hover:bg-emerald-50">✓ Mark Paid</button>
+                <button onClick={markPaid} style={{ width: '100%', borderRadius: 'var(--radius)', border: '1px solid hsl(142 70% 40%)', background: 'transparent', color: 'hsl(142 70% 45%)', padding: '8px 16px', fontSize: 14, fontWeight: 600, cursor: 'pointer' }}>✓ Mark Paid</button>
               ) : null}
             </React.Fragment>
           ) : (
-            <div className="flex h-full min-h-[240px] flex-col items-center justify-center text-center text-slate-400">
-              <div className="text-4xl">🧾</div>
-              <p className="mt-2 text-sm">Select an invoice, or create one.</p>
+            <div style={{ display: 'flex', minHeight: 240, flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', color: 'hsl(var(--muted-foreground))' }}>
+              <div style={{ fontSize: 32 }}>🧾</div>
+              <p style={{ marginTop: 8, fontSize: 14 }}>Select an invoice, or create one.</p>
             </div>
           )}
         </section>

--- a/examples/app-showcase/src/pages/renewals-pipeline.page.ts
+++ b/examples/app-showcase/src/pages/renewals-pipeline.page.ts
@@ -5,19 +5,14 @@ import { definePage } from '@objectstack/spec/ui';
 /**
  * Renewals Pipeline — a `kind:'react'` business scenario (ADR-0081).
  *
- * Authored as a DOGFOOD of the react-tier component contract
- * (skills/objectstack-ui/references/react-blocks.md): every block prop below is
- * taken straight from the contract — no guessing. A renewals manager works a list
- * of accounts on the left; selecting one drives a 360° panel on the right
- * (highlights + the account's invoices + a value-by-status chart) and a slide-out
- * <ObjectForm drawer> to update the account in place.
+ * A renewals manager works a list of accounts by lifecycle stage; selecting one
+ * drives a 360° panel (highlights + invoices + a value-by-status chart) and a
+ * pre-styled `<ObjectForm formType="drawer">` to update the account in place.
+ * Every block prop is taken straight from the react-tier contract
+ * (skills/objectstack-ui/references/react-blocks.md).
  *
- * Blocks exercised, with the contract props each accepts:
- *   <ListView>          objectName(req) · viewType · filters · columns · searchableFields · navigation · onRowClick
- *   <RecordHighlights>  objectName · recordId · fields · layout
- *   <RecordRelatedList> objectName · recordId · relationshipField · columns · limit · showViewAll · title
- *   <ObjectChart>       objectName(req) · aggregate · title · showLegend
- *   <ObjectForm>        objectName(req) · mode · recordId · formType · drawerSide · drawerWidth · onSuccess · onCancel
+ * Styling (ADR-0065): no Tailwind — inline `style={{}}` with `hsl(var(--token))`;
+ * data blocks and the drawer bring their own compiled styling.
  */
 export const RenewalsPipelinePage = definePage({
   name: 'showcase_renewals_pipeline',
@@ -36,26 +31,23 @@ function Page() {
     { id: 'at_risk', label: 'At risk' },
     { id: 'churned', label: 'Churned' },
   ];
+  const stageBtn = (active) => ({
+    borderRadius: 'var(--radius)', padding: '6px 12px', fontSize: 14, cursor: 'pointer',
+    border: '1px solid ' + (active ? 'hsl(var(--primary))' : 'hsl(var(--border))'),
+    background: active ? 'hsl(var(--primary) / 0.1)' : 'transparent',
+    color: 'hsl(var(--foreground))', fontWeight: active ? 600 : 400,
+  });
 
   return (
-    <div className="flex h-full gap-4 p-4">
-      <div className="flex w-1/2 flex-col gap-3">
+    <div style={{ display: 'flex', height: '100%', gap: 16, padding: 16 }}>
+      <div style={{ display: 'flex', width: '50%', flexDirection: 'column', gap: 12 }}>
         <div>
-          <h1 className="text-lg font-semibold">Renewals Pipeline</h1>
-          <p className="text-sm text-muted-foreground">Work the renewal book by lifecycle stage.</p>
+          <h1 style={{ margin: 0, fontSize: 18, fontWeight: 600, color: 'hsl(var(--foreground))' }}>Renewals Pipeline</h1>
+          <p style={{ marginTop: 2, fontSize: 14, color: 'hsl(var(--muted-foreground))' }}>Work the renewal book by lifecycle stage.</p>
         </div>
-        <div className="flex gap-2">
+        <div style={{ display: 'flex', gap: 8 }}>
           {STAGES.map((s) => (
-            <button
-              key={s.id}
-              onClick={() => { setStage(s.id); setSel(null); }}
-              className={
-                'rounded-md border px-3 py-1.5 text-sm ' +
-                (stage === s.id ? 'border-primary bg-primary/10 font-medium' : 'border-border')
-              }
-            >
-              {s.label}
-            </button>
+            <button key={s.id} onClick={() => { setStage(s.id); setSel(null); }} style={stageBtn(stage === s.id)}>{s.label}</button>
           ))}
         </div>
         <ListView
@@ -69,64 +61,35 @@ function Page() {
         />
       </div>
 
-      <div className="flex w-1/2 flex-col gap-4 overflow-auto">
+      <div style={{ display: 'flex', width: '50%', flexDirection: 'column', gap: 16, overflow: 'auto' }}>
         {!sel ? (
-          <div className="flex h-full items-center justify-center rounded-lg border border-dashed text-sm text-muted-foreground">
+          <div style={{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center', borderRadius: 'var(--radius)', border: '1px dashed hsl(var(--border))', fontSize: 14, color: 'hsl(var(--muted-foreground))' }}>
             Select an account to see its renewal picture.
           </div>
         ) : (
-          <>
-            <div className="flex items-center justify-between">
-              <h2 className="text-base font-semibold">Account 360</h2>
-              <button
-                onClick={() => setEditing(true)}
-                className="rounded-md border border-border px-3 py-1.5 text-sm hover:bg-muted"
-              >
-                Edit account
-              </button>
+          <React.Fragment>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <h2 style={{ margin: 0, fontSize: 16, fontWeight: 600, color: 'hsl(var(--foreground))' }}>Account 360</h2>
+              <button onClick={() => setEditing(true)} style={{ borderRadius: 'var(--radius)', border: '1px solid hsl(var(--border))', background: 'transparent', color: 'hsl(var(--foreground))', padding: '6px 12px', fontSize: 14, cursor: 'pointer' }}>Edit account</button>
             </div>
 
-            <RecordHighlights
-              objectName="showcase_account"
-              recordId={sel}
-              fields={['name', 'status']}
-              layout="horizontal"
-            />
+            <RecordHighlights objectName="showcase_account" recordId={sel} fields={['name', 'status']} layout="horizontal" />
 
-            <ObjectChart
-              objectName="showcase_invoice"
-              aggregate={{ field: 'total', function: 'sum', groupBy: 'status' }}
-              title="Invoice value by status"
-              showLegend={true}
-            />
+            <ObjectChart objectName="showcase_invoice" aggregate={{ field: 'total', function: 'sum', groupBy: 'status' }} title="Invoice value by status" showLegend={true} />
 
-            <RecordRelatedList
-              objectName="showcase_account"
-              recordId={sel}
-              relationshipField="account"
-              columns={['name', 'status', 'total']}
-              limit={5}
-              showViewAll={true}
-              title="Invoices"
-            />
+            <RecordRelatedList objectName="showcase_account" recordId={sel} relationshipField="account" columns={['name', 'status', 'total']} limit={5} showViewAll={true} title="Invoices" />
 
             {editing ? (
-              <ObjectForm
-                objectName="showcase_account"
-                mode="edit"
-                recordId={sel}
-                formType="drawer"
-                drawerSide="right"
-                drawerWidth="480px"
+              <ObjectForm objectName="showcase_account" mode="edit" recordId={sel}
+                formType="drawer" drawerSide="right" drawerWidth="480px" open title="Edit account"
+                onOpenChange={(o) => { if (!o) setEditing(false); }}
                 onSuccess={() => { setEditing(false); setReload((n) => n + 1); }}
-                onCancel={() => setEditing(false)}
-              />
+                onCancel={() => setEditing(false)} />
             ) : null}
-          </>
+          </React.Fragment>
         )}
       </div>
     </div>
   );
-}
-`,
+}`,
 });

--- a/examples/app-showcase/src/pages/task-desk.page.ts
+++ b/examples/app-showcase/src/pages/task-desk.page.ts
@@ -4,11 +4,15 @@ import { definePage } from '@objectstack/spec/ui';
 
 /**
  * Task Desk — a `kind:'react'` business scenario (ADR-0081) showing the
- * popup-edit patterns real apps need: a **slide-out drawer** to edit a row, and
- * a **centered modal** to create. Both are author-built React overlays (fixed
- * positioning + backdrop + Esc/close state) that wrap the platform's real
- * `<ObjectForm>` — demonstrating that the react tier composes drawer/modal
- * interactions the in-page master/detail layout can't.
+ * popup-edit patterns real apps need: a **slide-out drawer** to edit a row and a
+ * **centered modal** to create — both rendered by the platform's own
+ * `<ObjectForm formType="drawer"|"modal">` variant, NOT hand-rolled.
+ *
+ * Styling note (ADR-0065): page source is runtime metadata, so the console's
+ * build-time Tailwind never scans it — arbitrary utility classes silently no-op.
+ * So this page uses ZERO Tailwind: the overlay/backdrop/animation come from the
+ * pre-styled ObjectForm drawer/modal, and the thin page chrome uses inline
+ * `style={{}}` with `hsl(var(--token))` theme colors (real CSS, theme-aware).
  */
 export const TaskDeskPage = definePage({
   name: 'showcase_task_desk',
@@ -17,67 +21,44 @@ export const TaskDeskPage = definePage({
   kind: 'react',
   source: `
 function Page() {
-  const adapter = useAdapter();
-  const [editId, setEditId] = React.useState(null);   // drawer (edit existing)
+  const [editId, setEditId] = React.useState(null);     // drawer (edit existing)
   const [creating, setCreating] = React.useState(false); // modal (create new)
   const [reload, setReload] = React.useState(0);
-
-  const closeAll = () => { setEditId(null); setCreating(false); };
-  const afterWrite = () => { closeAll(); setReload((k) => k + 1); };
-
-  // Close overlays on Escape — the kind of detail a real app needs.
-  React.useEffect(() => {
-    const onKey = (e) => { if (e.key === 'Escape') closeAll(); };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, []);
+  const afterWrite = () => { setEditId(null); setCreating(false); setReload((k) => k + 1); };
 
   return (
-    <div className="mx-auto max-w-5xl space-y-5 p-8">
-      <header className="flex items-center justify-between">
+    <div style={{ maxWidth: 1024, margin: '0 auto', padding: 32, display: 'flex', flexDirection: 'column', gap: 20 }}>
+      <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 16 }}>
         <div>
-          <h1 className="text-2xl font-bold tracking-tight text-slate-900">Task Desk</h1>
-          <p className="mt-1 text-sm text-slate-500">Click a task to edit in a <strong>drawer</strong>; create one in a <strong>modal</strong> — both wrap the real <code>&lt;ObjectForm&gt;</code>.</p>
+          <h1 style={{ fontSize: 24, fontWeight: 700, letterSpacing: '-0.01em', color: 'hsl(var(--foreground))', margin: 0 }}>Task Desk</h1>
+          <p style={{ marginTop: 4, fontSize: 14, color: 'hsl(var(--muted-foreground))' }}>
+            Click a task to edit it in a <strong>drawer</strong>; create one in a <strong>modal</strong> — both render the platform's pre-styled <code>&lt;ObjectForm&gt;</code> overlay.
+          </p>
         </div>
-        <button onClick={() => setCreating(true)} className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500">+ New task</button>
+        <button onClick={() => setCreating(true)}
+          style={{ flexShrink: 0, borderRadius: 'var(--radius)', background: 'hsl(var(--primary))', color: 'hsl(var(--primary-foreground))', padding: '8px 16px', fontSize: 14, fontWeight: 600, border: 'none', cursor: 'pointer' }}>
+          + New task
+        </button>
       </header>
 
-      <div className="rounded-xl border border-slate-200 bg-white p-2">
-        <ListView key={reload} objectName="showcase_task"
-          fields={['title', 'assignee', 'status', 'priority']}
-          navigation={{ mode: 'none' }} onRowClick={(r) => setEditId(r.id)} />
-      </div>
+      <ListView key={reload} objectName="showcase_task"
+        fields={['title', 'assignee', 'status', 'priority']}
+        navigation={{ mode: 'none' }} onRowClick={(r) => setEditId(r.id)} />
 
-      {/* Drawer — edit an existing task */}
-      {editId ? (
-        <div className="fixed inset-0 z-40">
-          <div className="absolute inset-0 bg-slate-900/30" onClick={closeAll} />
-          <div className="absolute inset-y-0 right-0 flex w-full max-w-md flex-col bg-white shadow-2xl">
-            <div className="flex items-center justify-between border-b border-slate-200 px-5 py-4">
-              <h2 className="text-base font-semibold text-slate-900">Edit task</h2>
-              <button onClick={closeAll} className="rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-600" aria-label="Close">✕</button>
-            </div>
-            <div className="flex-1 overflow-y-auto p-5">
-              <ObjectForm key={'edit:' + editId + ':' + reload} objectName="showcase_task" mode="edit"
-                recordId={editId} onSuccess={afterWrite} onCancel={closeAll} />
-            </div>
-          </div>
-        </div>
+      {/* Drawer — edit an existing task. Backdrop, Esc, slide animation are the component's. */}
+      {editId != null ? (
+        <ObjectForm formType="drawer" drawerSide="right" objectName="showcase_task" mode="edit"
+          recordId={editId} open title="Edit task"
+          onOpenChange={(o) => { if (!o) setEditId(null); }}
+          onSuccess={afterWrite} />
       ) : null}
 
-      {/* Modal — create a new task */}
+      {/* Modal — create a new task. */}
       {creating ? (
-        <div className="fixed inset-0 z-40 flex items-center justify-center p-4">
-          <div className="absolute inset-0 bg-slate-900/40" onClick={closeAll} />
-          <div className="relative w-full max-w-lg rounded-2xl bg-white p-6 shadow-2xl">
-            <div className="mb-4 flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-slate-900">New task</h2>
-              <button onClick={closeAll} className="rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-600" aria-label="Close">✕</button>
-            </div>
-            <ObjectForm key={'new:' + reload} objectName="showcase_task" mode="create"
-              onSuccess={afterWrite} onCancel={closeAll} />
-          </div>
-        </div>
+        <ObjectForm formType="modal" objectName="showcase_task" mode="create"
+          open title="New task"
+          onOpenChange={(o) => { if (!o) setCreating(false); }}
+          onSuccess={afterWrite} />
       ) : null}
     </div>
   );


### PR DESCRIPTION
## The bug

A `kind:'react'`/`'html'` page's `source` is **runtime metadata**, so the console's build-time Tailwind never scans it. Utility classes that don't *also* appear in the console's own source silently produce **no CSS** — exactly the ADR-0065 failure: styling that "works only by coincidence."

Caught on the live Task Desk page: the hand-rolled `bg-black/50` modal backdrop computed to `rgba(0,0,0,0)` (transparent), the form floated as unstyled black boxes with invisible labels, and light-theme `text-slate-900` headings were near-invisible on the dark theme.

<details><summary>Confirmed in the browser</summary>

`getComputedStyle` probe on the running console: `bg-black/50` → `rgba(0,0,0,0)` (no CSS), while `hsl(var(--card))` → `rgb(24,24,27)` ✓. The console's CSS tokens are HSL triplets that must be wrapped `hsl(var(--token))`.
</details>

## The fix

All six `kind:'react'` showcase pages now use **ZERO Tailwind**:

- **Overlays** use the platform's own `<ObjectForm formType="drawer"|"modal">` variant — a pre-styled Radix Sheet/Dialog with backdrop + animation, driven by `open`/`onOpenChange` — instead of hand-rolled `fixed inset-0` overlays.
- **Page chrome** (headers, KPI cards, tabs, badges, empty states) uses inline `style={{}}` with `hsl(var(--token))` theme colors — real CSS, theme-aware, always generated regardless of the build's content scan.

Pages: `task-desk`, `crm-workbench`, `inquiry-triage`, `account-cockpit`, `invoice-console`, `renewals-pipeline`.

## Verification

Browser-verified on a real `objectstack serve --dev` console (not a dev preview):
- Titles now legible (were dark-on-dark).
- **Task Desk** drawer + modal render the pre-styled ObjectForm overlay — proper dark backdrop + card + visible labels (vs the previous transparent, unstyled mess).
- **CRM Workbench** KPI cards and **Inquiry Triage** tabs/count-badges all theme-correct.
- `tsc --noEmit` green.

## Follow-up (same correction, next PRs)

- `command-center-jsx` (the `kind:'html'` page) off Tailwind.
- Correct the AI guidance — react-blocks contract / objectstack-ui SKILL / three-tier docs / ADR-0080·0081 still say "HTML + Tailwind"; that contradicts ADR-0065 and must point to inline styles + pre-styled components.
- Extend the styling lint to flag Tailwind `className` in react/html page source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)