### PR TITLE
docs(builder-ui): document Automation/Interface as built + design Access/Settings (#2506)

### DIFF
--- a/docs/design/builder-ui.md
+++ b/docs/design/builder-ui.md
@@ -16,6 +16,16 @@ visual target and, because its DOM maps to the component tree and its regions ar
 tagged `data-build` / `data-reuse`, the implementation blueprint (see
 [Mockups](#mockups)). The ASCII sketches inline below are for quick reading.
 
+> **Implementation status (2026-07).** The builder is live in the console as
+> `StudioDesignSurface` (routed at `/studio/:packageId/:tab`). Shipping **today**:
+> three pillars — **Data · Automation · Interface** — each composed around existing
+> renderers, plus draft → publish. **Not yet built:** the **Access** and **Settings**
+> pillars (designed below, §7–§8), and part of the Data pillar's own v1 scope (the
+> `Fields` form designer, the `Validations` rules list, object `Settings`, and the
+> left-rail search / New object — §4). Where the built UI deliberately improved on an
+> earlier sketch, this doc has been updated to the built shape (noted inline). Each
+> per-pillar surface below is marked **[built]** or **[designed]**.
+
 ---
 
 ## 1. Core constraints — AI-first, human-confirmable, reuse-first
@@ -87,7 +97,9 @@ Mockup: [`builder-ui/data-pillar.html`](./builder-ui/data-pillar.html) (open in 
 
 - **Top bar** — the four pillar tabs (Data / Automation / Interface / Access), the
   ⚙ Settings entry, the app switcher, and the draft indicator + Save draft /
-  Publish (draft-gated, ADR-0033).
+  Publish (draft-gated, ADR-0033). *(Built today: three tabs — Access and ⚙ pending;
+  the package name stands in for the app switcher; Save draft / Publish currently
+  render per-pillar rather than in the top bar. Target remains as drawn.)*
 - **Left rail** — the current pillar's primary entities (objects / automations /
   surfaces / roles), with search and New. Collapsible.
 - **Main** — the pillar's primary work surface, shaped to the pillar (Data = grid,
@@ -169,9 +181,12 @@ and both configure a selected field through the *same* right-hand **field editor
 
 - **`Records` — grid / list style (data-forward).** The functional grid: columns =
   fields, rows = real records. Preview and inline-edit data, `+` add a column
-  (= add a field), select a column header to configure that field's properties in
-  the inspector, `+ New record`. Ephemeral filter / sort / hide / group for looking
-  at the data (not saved — saved views are Interface).
+  (= add a field), select a column's **edit (pencil) affordance** to configure that
+  field's properties in the inspector, `+ New record`. Ephemeral filter / sort / hide
+  / group for looking at the data (not saved — saved views are Interface). *(A bare
+  header click **sorts** — the grid is the runtime `ListView`, so the header's native
+  gesture wins; field config is opened by the per-column pencil, not the header. This
+  is the built behaviour, corrected from the earlier "click the header" sketch.)*
 - **`Fields` — form style (layout-forward).** The field designer as a form canvas:
   drag to reorder fields, group them into sections, and configure field properties.
   No data rows — this is where the object's default field layout (order + grouping)
@@ -225,24 +240,152 @@ union of six declarative rule types (`packages/spec/src/data/validation.zod.ts`)
   form-style designer (reorder + grouping + field editor, incl. field-level
   validation) · `Validations` (condition builder) · object `Settings` (label / icon /
   name field / compact / search). Relationships via the `lookup` field type.
+- **Built so far** (2026-07): owned-objects rail · `Records` grid with inline data,
+  add-column / add-field, drag-reorder columns, and the reused object/field inspector
+  (field-level required · unique · options · default · help). Draft → publish wired.
+- **Still to build** (v1 gap — the facet tabs never landed): left-rail **search + New
+  object** · the `Fields` **form-style layout designer** · the `Validations` **rules
+  list + condition builder** · the object **`Settings`** facet. These are the
+  Phase-B build (tracked against this doc); each reuses an existing Studio panel.
 - **Defer**: Extended objects (objectExtensions) · External objects (datasources) ·
   the ERD / model view · formal `Lifecycle` (v1 status = a select field) · `Indexes` ·
   seed-data UI · saved views / kanban / calendar (presentation → Interface).
 
 ---
 
-## 5. Other pillars (to design — same shell)
+## 5. Automation pillar · **[built]**
 
-- **Automation** — left: automations grouped by trigger (record-change / scheduled /
-  API / manual action); main: the flow **canvas**; inspector: the selected node's
-  config; a Runs view for execution history.
-- **Interface** — left: surfaces (Apps · Pages · Views · Dashboards · Reports);
-  main: the page **builder** (structured canvas) or **source + preview** (html/react
-  pages); inspector: component props.
-- **Access** — left: roles; main: the permission **matrix** (objects × CRUD + record
-  scope); inspector: role / field-level detail.
-- **Settings** (⚙) — General (app basic info) and Advanced (Code: hooks · functions;
-  Connections: datasources), grouped by audience.
+Automation is the **behaviour workbench**: the package's flows, each edited on the
+same flow **canvas** the runtime engine executes. Nothing here is a new editor — the
+canvas and node config are the existing Studio flow builder, dropped into the shell.
+
+Mockup: [`builder-ui/automation-pillar.html`](./builder-ui/automation-pillar.html).
+
+```
+┌ flows ────┬ 可视化编排 · flow · showcase_task_completed ──────────┬ inspector ┐
+│ Notify… ◄ │ Trigger: autolaunched · draft · Run as: user · v1     │ Node       │
+│ Reassign  │ [Variables] [Runs] [Problems] [Debug]   + 添加节点     │ config     │
+│ Approval  │ ┌ On Task Update (START) ┐                             │            │
+│ Digest…   │ └──────────┬─────────────┘                            │ [reused    │
+│ + …       │ ┌ Send Completion Email (SCRIPT) ┐ → End              │  node form]│
+└───────────┴──────────────────────────────────────────────────────┴────────────┘
+```
+
+- **Left rail** — the package's flows. *Built today: a **flat list** (`client.list('flow')`).
+  The design target is **grouped by trigger** (record-change / scheduled / API / manual) —
+  that grouping is a pending refinement, not yet applied.*
+- **Main** — the flow **canvas** = reused `FlowCanvas` (the Studio flow builder). Top
+  strip: Trigger · Status · Run as · version, plus **Variables · Runs · Problems ·
+  Debug** and add-node / zoom. Flows land **default OFF — review-then-enable**.
+- **Right inspector** — the selected node's config, reused (`getMetadataInspector('flow')`).
+- **Runs** — a canvas-strip toggle showing execution history *inside the builder*. This
+  is the read-only peek that reconciles [ADR-0084](../adr/0084-application-builder-information-architecture.md)
+  ("flow runs live in **Operate**, out of the builder"): the builder gets a glance;
+  the full run inspector stays in Operate.
+- **Build boundary** — rail + shell = built; **canvas = reused `FlowCanvas`**;
+  **inspector = reused node config**.
+
+---
+
+## 6. Interface pillar · **[built]**
+
+Interface is the **presentation workbench**: the app's surfaces (pages · dashboards ·
+reports · views), each rendered by the **same renderer the end user gets** — edit the
+live artifact, not a proxy.
+
+Mockup: [`builder-ui/interface-pillar.html`](./builder-ui/interface-pillar.html).
+
+```
+┌ app nav ─┬ 预览即运行 · page · showcase_start_here ────────┬ inspector ┐
+│ Workspace│ ┌ source (JSX) ─────┐ ┌ live preview ─────────┐ │ Component  │
+│  Start ◄ │ │ <flex dir="col">  │ │  Pick the right page   │ │ props      │
+│ Data     │ │   <div …>Showcase │ │  authoring model       │ │            │
+│  Tasks   │ │   …               │ │  [Decision tree]       │ │ [reused    │
+│ Analytics│ └───────────────────┘ └────────────────────────┘ │  props]    │
+└──────────┴─────────────────────────────────────────────────┴────────────┘
+```
+
+- **Left rail** — the app's **real navigation tree** (groups + typed leaves:
+  page / object / dashboard / report / view), read from the App metadata. *This
+  **supersedes** the earlier "Apps · Pages · Views · Dashboards · Reports" by-type
+  sketch: the built rail shows the app's actual IA (what a builder edits), which is
+  truer than a type index. A by-type filter can be a later lens.*
+- **Main** — two modes, auto-selected by the surface:
+  - **source + live preview** for react / html pages — a code editor beside a live
+    `SchemaRenderer` ("预览即运行 · 同一渲染器" = preview *is* runtime; ADR-0080/0081).
+  - **structured canvas** for dashboards / slotted pages — widget blocks with
+    `+ add widget`, edited by selecting a block.
+- **Right inspector** — component / block props, reused.
+- **Build boundary** — rail (`NavTree` / `AppNavCanvas`) = built; **main = reused
+  `SchemaRenderer` (react/html) or the dashboard/page renderer (structured)**;
+  **inspector = reused component props**.
+
+---
+
+## 7. Access pillar · **[designed]**
+
+Access is the **permission workbench**: who can do what to which object. Its natural
+shape is a **matrix** (roles × objects × CRUD + record scope), which already exists as
+a Studio panel — so the pillar is that matrix dropped into the shell, nothing new.
+
+Mockup: [`builder-ui/access-pillar.html`](./builder-ui/access-pillar.html).
+
+```
+┌ roles ───┬ Permission matrix · role: Sales Rep ──────────────────┬ inspector ┐
+│ Admin    │        Create  Read   Update  Delete   Record scope    │ Role       │
+│ Sales ◄  │ Account  ☑      ☑      ☑       ☐       Owned + team     │ detail     │
+│ Support  │ Contact  ☑      ☑      ☑       ☐       Owned            │            │
+│ Viewer   │ Invoice  ☐      ☑      ☐       ☐       All              │ [reused    │
+│ + New    │ Task     ☑      ☑      ☑       ☑       Owned            │  role form]│
+└──────────┴───────────────────────────────────────────────────────┴────────────┘
+```
+
+- **Left rail** — roles (and permission sets), with search + New role.
+- **Main** — the permission **matrix** = reused `PermissionMatrixEditor`: rows =
+  objects, columns = **C / R / U / D** plus a **record-scope** column (owned / team /
+  all). Toggling a cell edits the role's object-permission metadata as a draft.
+- **Right inspector** — the selected role (or object-permission) detail = reused
+  protocol form for `role`, with `RolePreview` / `PermissionPreview` for a live "what
+  this role can see" read-out.
+- **Build boundary** — rail + shell = built; **matrix = reused `PermissionMatrixEditor`**;
+  **inspector = reused `role` protocol form + `RolePreview`/`PermissionPreview`**.
+- **v1 scope** — roles × objects **CRUD + record scope**. **Defer**: the field-level
+  permission matrix, sharing rules, and capability / permission-set *composition*
+  (the "concept overload" risk — v1 stays at roles × objects × CRUD, one clear grid).
+
+---
+
+## 8. Settings (⚙) · **[designed]**
+
+Settings is **not** a content pillar — it is the app's own configuration, split by
+**audience** (ADR-0084 §5): a builder opening Settings for app info must not land in
+code. Every panel is a reused protocol form; the area only composes them.
+
+Mockup: [`builder-ui/settings.html`](./builder-ui/settings.html).
+
+```
+┌ ⚙ Settings ─────────────────────────────────────────────────────────────────┐
+│  General            │  the app's identity & defaults   [reused app form]      │
+│   · Basics          │    name · id · icon · description · branding            │
+│   · Navigation      │    default landing · nav structure                      │
+│  ─────────────────  │                                                         │
+│  Advanced  (devs)   │  Code       Hooks (v1) · functions · components (later)  │
+│   · Code            │             [reused hooks list + hook form]             │
+│   · Connections     │  Connections  datasource · connector · webhook (later)  │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+- **General** — the app's identity and defaults: name · id · icon · description ·
+  branding · default landing · navigation structure. This is the `app` definition →
+  reused **`app` protocol form**.
+- **Advanced** — the technical tier, kept visually separate from General so a builder
+  isn't dropped into code. Sub-grouped **Code** (v1: **Hooks** — a hooks list + reused
+  hook protocol form; later: functions, custom components, custom field types) and
+  **Connections** (later: datasources, connectors, webhooks, mappings).
+- **Build boundary** — the ⚙ area chrome + audience grouping = built; **every panel =
+  reused protocol form** (`app`, `hook`, …).
+- **v1 scope** — **General + Advanced/Hooks only** (ADR-0084 §7). The rest of Advanced
+  is deferred.
 
 ---
 
@@ -265,8 +408,13 @@ still to design:
 
 Open any `*.html` in a browser to view it. Current mockups:
 
-| Surface | Mockup |
-|---|---|
-| Data pillar | [`data-pillar.html`](./builder-ui/data-pillar.html) |
+| Surface | Mockup | Status |
+|---|---|---|
+| Data pillar | [`data-pillar.html`](./builder-ui/data-pillar.html) | built (partial — see §4) |
+| Automation pillar | [`automation-pillar.html`](./builder-ui/automation-pillar.html) | built |
+| Interface pillar | [`interface-pillar.html`](./builder-ui/interface-pillar.html) | built |
+| Access pillar | [`access-pillar.html`](./builder-ui/access-pillar.html) | designed |
+| Settings (⚙) | [`settings.html`](./builder-ui/settings.html) | designed |
 
-More are added per pillar as they are designed.
+The **built** mockups depict the shipped `StudioDesignSurface` (2026-07); the
+**designed** ones are the target for the not-yet-built pillars (§7–§8).

--- a/docs/design/builder-ui/access-pillar.html
+++ b/docs/design/builder-ui/access-pillar.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Builder — Access pillar</title>
+  <link rel="stylesheet" href="shell.css">
+</head>
+<body>
+<!-- Access pillar [designed]: who can do what to which object. Natural shape = matrix
+     (roles x objects x CRUD + record scope). Role "Sales Rep" selected -> role detail.
+     data-build="shell"  = built in the builder (composition/chrome)
+     data-reuse="<comp>" = existing Studio/objectui component, dropped in unchanged -->
+<div class="builder">
+
+  <!-- ===== top bar (built) ===== -->
+  <div class="topbar" data-build="shell">
+    <span class="app">app &#9662;</span>
+    <nav class="pilltabs">
+      <a href="#">Data</a>
+      <a href="#">Automation</a>
+      <a href="#">Interface</a>
+      <a class="active" href="#">Access</a>
+    </nav>
+    <div class="right">
+      <span>&#9881;</span>
+      <span>Save draft</span>
+      <button class="btn-publish">Publish</button>
+    </div>
+  </div>
+
+  <div class="body">
+
+    <!-- ===== left rail: roles (built) ===== -->
+    <aside class="rail" data-build="shell">
+      <div class="label">ROLES</div>
+      <div class="search">Search</div>
+      <ul>
+        <li>Admin</li>
+        <li class="active">Sales Rep</li>
+        <li>Support</li>
+        <li>Viewer</li>
+      </ul>
+      <div class="new">+ New role</div>
+    </aside>
+
+    <!-- ===== main: permission matrix ===== -->
+    <main class="main">
+      <div class="toolbar" data-build="shell">
+        <span>Permission matrix</span>
+        <span>role &middot; Sales Rep</span>
+      </div>
+      <div class="workarea">
+        <div class="reuse" data-reuse="PermissionMatrixEditor">
+          <table class="matrix">
+            <thead>
+              <tr><th>Object</th><th>Create</th><th>Read</th><th>Update</th><th>Delete</th><th>Record scope</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>Account</td><td><span class="ck on"></span></td><td><span class="ck on"></span></td><td><span class="ck on"></span></td><td><span class="ck"></span></td><td><span class="scope">Owned + team</span></td></tr>
+              <tr><td>Contact</td><td><span class="ck on"></span></td><td><span class="ck on"></span></td><td><span class="ck on"></span></td><td><span class="ck"></span></td><td><span class="scope">Owned</span></td></tr>
+              <tr><td>Invoice</td><td><span class="ck"></span></td><td><span class="ck on"></span></td><td><span class="ck"></span></td><td><span class="ck"></span></td><td><span class="scope">All</span></td></tr>
+              <tr><td>Task</td><td><span class="ck on"></span></td><td><span class="ck on"></span></td><td><span class="ck on"></span></td><td><span class="ck on"></span></td><td><span class="scope">Owned</span></td></tr>
+            </tbody>
+          </table>
+          <div class="grid-add">Toggle a cell to edit this role's object permission (draft)</div>
+          <span class="reuse-tag">matrix = existing PermissionMatrixEditor (reused)</span>
+        </div>
+      </div>
+    </main>
+
+    <!-- ===== right inspector: role detail = reused form + preview ===== -->
+    <aside class="inspector" data-build="shell">
+      <div class="eyebrow">ROLE</div>
+      <h3>Sales Rep</h3>
+      <hr>
+      <div class="reuse form" data-reuse="protocol-form:role">
+        <div class="flabel">Label</div>
+        <div class="field">Sales Rep</div>
+        <div class="flabel">API name</div>
+        <div class="field">sales_rep</div>
+        <div class="flabel">Description</div>
+        <div class="field">Front-line sellers</div>
+        <div class="flabel">Preview &mdash; can see</div>
+        <div class="chips">
+          <span class="chip">Accounts</span>
+          <span class="chip">Contacts</span>
+          <span class="chip">Own tasks</span>
+        </div>
+        <span class="reuse-tag">role form + RolePreview (reused)</span>
+      </div>
+    </aside>
+  </div>
+
+  <!-- ===== legend ===== -->
+  <div class="legend">
+    <span><span class="sw built"></span>solid = shell / composition (built in the builder)</span>
+    <span><span class="sw reused"></span>dashed = existing Studio component (reused, not rebuilt)</span>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/design/builder-ui/automation-pillar.html
+++ b/docs/design/builder-ui/automation-pillar.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Builder — Automation pillar</title>
+  <link rel="stylesheet" href="shell.css">
+</head>
+<body>
+<!-- Automation pillar [built]: the package's flows on the same canvas the engine runs.
+     Flow "Notify on Task Completed" selected; "Send Completion Email" node selected
+     -> node config in the inspector.
+     data-build="shell"  = built in the builder (composition/chrome)
+     data-reuse="<comp>" = existing Studio/objectui component, dropped in unchanged -->
+<div class="builder">
+
+  <!-- ===== top bar (built) ===== -->
+  <div class="topbar" data-build="shell">
+    <span class="app">app &#9662;</span>
+    <nav class="pilltabs">
+      <a href="#">Data</a>
+      <a class="active" href="#">Automation</a>
+      <a href="#">Interface</a>
+      <a href="#">Access</a>
+    </nav>
+    <div class="right">
+      <span>&#9881;</span>
+      <span>Save draft</span>
+      <button class="btn-publish">Publish</button>
+    </div>
+  </div>
+
+  <div class="body">
+
+    <!-- ===== left rail: flows (built) — flat list today; target = grouped by trigger ===== -->
+    <aside class="rail" data-build="shell">
+      <div class="label">AUTOMATIONS</div>
+      <div class="search">Search</div>
+      <ul>
+        <li class="active">Notify on Task Completed</li>
+        <li>Reassign Task</li>
+        <li>Project Budget Approval</li>
+        <li>Scheduled Project Digest</li>
+        <li>Inbound Task Webhook</li>
+      </ul>
+      <div class="new">+ New flow</div>
+    </aside>
+
+    <!-- ===== main: canvas strip + flow canvas ===== -->
+    <main class="main">
+
+      <!-- canvas strip (built chrome around the reused canvas) -->
+      <div class="canvas-strip" data-build="shell">
+        <span>Trigger: <b>autolaunched</b></span>
+        <span>Status: <b>draft</b></span>
+        <span>Run as: <b>user</b></span>
+        <span>v1</span>
+        <span class="pill on">Variables</span>
+        <span class="pill">Runs</span>
+        <span class="pill">Problems</span>
+        <span class="pill">Debug</span>
+        <span class="spacer"></span>
+        <span class="add">+ Add node</span>
+        <span>100%</span>
+      </div>
+
+      <!-- flow canvas = reused FlowCanvas -->
+      <div class="canvas-wrap">
+        <div class="canvas reuse" data-reuse="FlowCanvas">
+          <div class="node">
+            <span class="ic">&#9654;</span>
+            <span><span class="nlabel">On Task Update</span><br><span class="kind">START &middot; status == "done"</span></span>
+          </div>
+          <div class="node-link"></div>
+          <div class="node">
+            <span class="ic">&lt;/&gt;</span>
+            <span><span class="nlabel">Send Completion Email</span><br><span class="kind">SCRIPT &middot; email</span></span>
+          </div>
+          <div class="node-link"></div>
+          <div class="node">
+            <span class="ic">&#9673;</span>
+            <span><span class="nlabel">End</span><br><span class="kind">END</span></span>
+          </div>
+          <span class="reuse-tag">flow canvas = existing FlowCanvas (reused)</span>
+        </div>
+      </div>
+    </main>
+
+    <!-- ===== right inspector: node config = reused form ===== -->
+    <aside class="inspector" data-build="shell">
+      <div class="eyebrow">NODE</div>
+      <h3>Send Completion Email</h3>
+      <hr>
+      <div class="reuse form" data-reuse="node-config:flow">
+        <div class="flabel">Type</div>
+        <div class="field">Script &#9662;</div>
+        <div class="flabel">Email template</div>
+        <div class="field">task_completed &#9662;</div>
+        <div class="flabel">To</div>
+        <div class="field">{{record.owner.email}}</div>
+        <div class="toggle-row"><span>Continue on error</span><span class="toggle"></span></div>
+        <span class="reuse-tag">node config form (reused)</span>
+      </div>
+    </aside>
+  </div>
+
+  <!-- ===== legend ===== -->
+  <div class="legend">
+    <span><span class="sw built"></span>solid = shell / composition (built in the builder)</span>
+    <span><span class="sw reused"></span>dashed = existing Studio component (reused, not rebuilt)</span>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/design/builder-ui/interface-pillar.html
+++ b/docs/design/builder-ui/interface-pillar.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Builder — Interface pillar</title>
+  <link rel="stylesheet" href="shell.css">
+</head>
+<body>
+<!-- Interface pillar [built]: the app's surfaces on the same renderer the end user gets.
+     Left rail = the app's REAL navigation tree (not a by-type list). React page
+     "Start Here" selected -> source + live preview; a component selected -> props.
+     data-build="shell"  = built in the builder (composition/chrome)
+     data-reuse="<comp>" = existing Studio/objectui component, dropped in unchanged -->
+<div class="builder">
+
+  <!-- ===== top bar (built) ===== -->
+  <div class="topbar" data-build="shell">
+    <span class="app">app &#9662;</span>
+    <nav class="pilltabs">
+      <a href="#">Data</a>
+      <a href="#">Automation</a>
+      <a class="active" href="#">Interface</a>
+      <a href="#">Access</a>
+    </nav>
+    <div class="right">
+      <span>&#9881;</span>
+      <span>Save draft</span>
+      <button class="btn-publish">Publish</button>
+    </div>
+  </div>
+
+  <div class="body">
+
+    <!-- ===== left rail: the app's real navigation tree (built) ===== -->
+    <aside class="rail" data-build="shell">
+      <div class="label">SHOWCASE &middot; NAV</div>
+      <div class="group">Workspace</div>
+      <ul>
+        <li class="active">Start Here</li>
+        <li>My Work</li>
+        <li>Approvals</li>
+      </ul>
+      <div class="group">Data model</div>
+      <ul>
+        <li>Projects <span class="kind">object</span></li>
+        <li>Tasks <span class="kind">object</span></li>
+      </ul>
+      <div class="group">Analytics</div>
+      <ul>
+        <li>Delivery Ops <span class="kind">dashboard</span></li>
+        <li>Hours by Status <span class="kind">report</span></li>
+      </ul>
+    </aside>
+
+    <!-- ===== main: source + live preview (react/html pages) ===== -->
+    <main class="main">
+      <div class="toolbar" data-build="shell">
+        <span>&#128065; preview = runtime</span>
+        <span>page &middot; showcase_start_here</span>
+      </div>
+      <div class="workarea">
+        <div class="reuse" data-reuse="SchemaRenderer" style="height:100%">
+          <div class="split">
+            <div class="code">&lt;flex dir="col" gap={8}&gt;
+  &lt;div style={{ fontWeight: 600,
+    textTransform: "uppercase" }}&gt;
+    ObjectStack Showcase
+  &lt;/div&gt;
+  &lt;div style={{ fontSize: 32,
+    fontWeight: 700 }}&gt;
+    Pick the right page
+    authoring model
+  &lt;/div&gt;
+  &lt;card&gt; Decision tree &hellip; &lt;/card&gt;
+&lt;/flex&gt;</div>
+            <div class="preview">
+              <div class="eyebrow">OBJECTSTACK SHOWCASE</div>
+              <h2>Pick the right page authoring model</h2>
+              <div class="card">Every page has two axes &mdash; its <b>type</b> (home &middot; record &middot; list &middot; app) and its <b>kind</b> (how you author it).</div>
+              <div class="card">Decision tree &middot; full/slotted &rarr; html &rarr; react</div>
+            </div>
+          </div>
+          <span class="reuse-tag">source + preview = SchemaRenderer (reused)</span>
+        </div>
+      </div>
+    </main>
+
+    <!-- ===== right inspector: component props = reused form ===== -->
+    <aside class="inspector" data-build="shell">
+      <div class="eyebrow">COMPONENT</div>
+      <h3>flex &rsaquo; div</h3>
+      <hr>
+      <div class="reuse form" data-reuse="component-props">
+        <div class="flabel">Font size</div>
+        <div class="field">32</div>
+        <div class="flabel">Font weight</div>
+        <div class="field">700 &#9662;</div>
+        <div class="flabel">Color</div>
+        <div class="field">foreground &#9662;</div>
+        <div class="flabel">Max width</div>
+        <div class="field">680</div>
+        <span class="reuse-tag">component props (reused)</span>
+      </div>
+    </aside>
+  </div>
+
+  <!-- ===== legend ===== -->
+  <div class="legend">
+    <span><span class="sw built"></span>solid = shell / composition (built in the builder)</span>
+    <span><span class="sw reused"></span>dashed = existing Studio component (reused, not rebuilt)</span>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/design/builder-ui/settings.html
+++ b/docs/design/builder-ui/settings.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Builder — Settings (⚙)</title>
+  <link rel="stylesheet" href="shell.css">
+</head>
+<body>
+<!-- Settings [designed]: NOT a content pillar — the app's own config, split by AUDIENCE.
+     General (builder) vs Advanced (developers). Every panel is a reused protocol form;
+     the area only composes them.
+     data-build="shell"  = built in the builder (composition/chrome)
+     data-reuse="<comp>" = existing Studio/objectui component, dropped in unchanged -->
+<div class="builder">
+
+  <!-- ===== top bar (built) — none of the 4 pillar tabs active; the gear is ===== -->
+  <div class="topbar" data-build="shell">
+    <span class="app">app &#9662;</span>
+    <nav class="pilltabs">
+      <a href="#">Data</a>
+      <a href="#">Automation</a>
+      <a href="#">Interface</a>
+      <a href="#">Access</a>
+    </nav>
+    <div class="right">
+      <span style="color:var(--accent);font-weight:600">&#9881; Settings</span>
+      <span>Save draft</span>
+      <button class="btn-publish">Publish</button>
+    </div>
+  </div>
+
+  <div class="body">
+
+    <!-- ===== left rail: settings sections (built) ===== -->
+    <aside class="rail" data-build="shell">
+      <div class="label">SETTINGS</div>
+      <div class="group">General</div>
+      <ul>
+        <li class="active">Basics</li>
+        <li>Navigation</li>
+      </ul>
+      <div class="group">Advanced</div>
+      <ul>
+        <li>Code <span class="kind">dev</span></li>
+        <li>Connections <span class="kind">dev</span></li>
+      </ul>
+    </aside>
+
+    <!-- ===== main: audience-grouped panels ===== -->
+    <div class="settings">
+
+      <!-- General — builder audience -->
+      <div class="sgroup">
+        <h4>General <span class="aud">Builder</span></h4>
+        <div class="sub">
+          <div class="subhead">Basics</div>
+          <div class="reuse form" data-reuse="protocol-form:app" style="padding-top:0">
+            <div class="flabel">Name</div>
+            <div class="field">Showcase</div>
+            <div class="flabel">App id</div>
+            <div class="field">com.example.showcase</div>
+            <div class="flabel">Icon</div>
+            <div class="field">&#9670; layout-dashboard</div>
+            <div class="flabel">Default landing</div>
+            <div class="field">Start Here &#9662;</div>
+            <span class="reuse-tag">app protocol form (reused)</span>
+          </div>
+        </div>
+        <div class="sub">
+          <div class="subhead">Navigation</div>
+          <div class="reuse" data-reuse="nav-editor" style="padding:12px 12px 26px">
+            <div style="font-size:11.5px;color:var(--muted)">Workspace &middot; Data model &middot; Analytics &mdash; drag to reorder groups &amp; items</div>
+            <span class="reuse-tag">app navigation editor (reused)</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Advanced — developer audience -->
+      <div class="sgroup">
+        <h4>Advanced <span class="aud">Developers</span></h4>
+        <div class="sub">
+          <div class="subhead">Code <span class="tag">v1: Hooks</span></div>
+          <div class="reuse" data-reuse="protocol-form:hook" style="padding:12px">
+            <div style="font-size:11.5px;color:var(--muted)">
+              Hooks &mdash; before/after write-path logic. Select a hook &rarr; reused hook form.
+            </div>
+            <div class="chips" style="margin-top:8px">
+              <span class="chip">beforeInsert: stampOwner</span>
+              <span class="chip">afterUpdate: notify</span>
+              <span class="add">+ add</span>
+            </div>
+            <span class="reuse-tag">hooks list + hook form (reused)</span>
+          </div>
+          <div class="subhead later" style="margin-top:10px">functions &middot; custom components &middot; custom field types &mdash; later</div>
+        </div>
+        <div class="sub">
+          <div class="subhead">Connections</div>
+          <div class="later" style="font-size:11.5px">datasource &middot; connector &middot; webhook &middot; mapping &mdash; later</div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- ===== legend ===== -->
+  <div class="legend">
+    <span><span class="sw built"></span>solid = shell / composition (built in the builder)</span>
+    <span><span class="sw reused"></span>dashed = existing Studio component (reused, not rebuilt)</span>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/design/builder-ui/shell.css
+++ b/docs/design/builder-ui/shell.css
@@ -97,3 +97,58 @@ table.grid th.col-selected { color: var(--accent); }
 .legend .sw { display: inline-block; width: 14px; height: 12px; vertical-align: -1px; margin-right: 6px; }
 .legend .sw.built { border: 1px solid var(--text); }
 .legend .sw.reused { border: 1px dashed #c8ccd2; }
+
+/* ================================================================
+   Pillar-specific primitives — composed by the automation / interface
+   / access / settings mockups. Same tokens; one shared look. */
+
+/* ---- rail sub-groups + kind badges (interface nav tree, access, settings) ---- */
+.rail .group { font-size: 10px; letter-spacing: .5px; color: var(--faint); text-transform: uppercase; margin: 14px 0 4px; }
+.rail li { display: flex; align-items: center; gap: 6px; }
+.rail li .kind { margin-left: auto; font-size: 8px; color: var(--faint); background: var(--chip); border-radius: 6px; padding: 1px 5px; text-transform: uppercase; letter-spacing: .3px; }
+
+/* ---- flow canvas (automation) ---- */
+.canvas-strip { display: flex; align-items: center; gap: 12px; padding: 7px 16px; border-bottom: 1px solid var(--border); color: var(--muted); font-size: 11px; }
+.canvas-strip .pill { border: 1px solid var(--border); border-radius: 5px; padding: 2px 8px; }
+.canvas-strip .pill.on { color: var(--accent); border-color: var(--accent); background: var(--accent-bg); }
+.canvas-strip .spacer { flex: 1; }
+.canvas-strip .add { color: var(--accent); font-weight: 600; }
+.canvas-wrap { flex: 1; padding: 0 16px 16px; overflow: auto; }
+.canvas { position: relative; height: 100%; border: 1px dashed #c8ccd2; border-radius: var(--radius); padding: 28px 12px;
+  background-image: radial-gradient(var(--border) 1px, transparent 1px); background-size: 16px 16px; }
+.canvas .reuse-tag { position: absolute; left: 10px; bottom: 6px; font-size: 9.5px; font-style: italic; color: var(--faint); background: var(--surface-1); padding: 0 4px; }
+.node { width: 260px; margin: 0 auto; background: var(--surface-1); border: 1px solid var(--border); border-radius: 8px; padding: 11px 13px; display: flex; gap: 10px; align-items: center; box-shadow: 0 1px 2px rgba(0,0,0,.04); }
+.node .ic { width: 26px; height: 26px; border-radius: 7px; background: var(--accent-bg); color: var(--accent); display: flex; align-items: center; justify-content: center; font-size: 13px; flex-shrink: 0; }
+.node .nlabel { font-weight: 600; font-size: 12px; }
+.node .kind { font-size: 9px; letter-spacing: .5px; color: var(--muted); text-transform: uppercase; }
+.node-link { width: 1px; height: 22px; background: var(--border); margin: 0 auto; }
+
+/* ---- source + live preview split (interface) ---- */
+.split { display: flex; height: 100%; }
+.split .code { flex: 1; background: #f6f8fa; border-right: 1px solid var(--border); padding: 12px 14px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 10.5px; color: #4b5563; white-space: pre; overflow: auto; line-height: 1.75; }
+.split .preview { flex: 1; padding: 16px 18px; overflow: auto; }
+.split .preview .eyebrow { font-size: 9px; letter-spacing: 1px; color: var(--muted); text-transform: uppercase; }
+.split .preview h2 { font-size: 19px; margin: 6px 0 10px; }
+.split .preview .card { border: 1px solid var(--border); border-radius: var(--radius); padding: 12px 14px; margin-top: 10px; font-size: 11px; color: var(--muted); }
+
+/* ---- permission matrix (access) ---- */
+table.matrix { width: 100%; border-collapse: collapse; font-size: 11.5px; }
+table.matrix th { text-align: center; background: var(--surface-2); color: var(--muted); font-weight: 600; padding: 8px 10px; border-bottom: 1px solid var(--border); }
+table.matrix th:first-child { text-align: left; }
+table.matrix td { padding: 9px 10px; border-bottom: 1px solid var(--line); text-align: center; }
+table.matrix td:first-child { text-align: left; font-weight: 500; }
+.ck { display: inline-block; width: 15px; height: 15px; border-radius: 4px; border: 1px solid #cfd4da; vertical-align: -2px; }
+.ck.on { background: var(--accent); border-color: var(--accent); position: relative; }
+.ck.on::after { content: "\2713"; color: #fff; font-size: 10px; line-height: 15px; position: absolute; left: 2.5px; top: -1px; }
+.scope { font-size: 10px; color: var(--muted); background: var(--chip); border-radius: 10px; padding: 2px 9px; }
+
+/* ---- settings (audience groups) ---- */
+.settings { flex: 1; padding: 18px 22px; overflow: auto; }
+.settings .sgroup { border: 1px solid var(--border); border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+.settings .sgroup > h4 { margin: 0; padding: 9px 14px; background: var(--surface-2); border-bottom: 1px solid var(--border); font-size: 12px; display: flex; align-items: center; gap: 8px; }
+.settings .sgroup > h4 .aud { margin-left: auto; font-size: 9px; color: var(--faint); background: var(--chip); border-radius: 6px; padding: 1px 7px; text-transform: uppercase; letter-spacing: .4px; }
+.settings .sub { padding: 12px 14px; border-bottom: 1px solid var(--line); }
+.settings .sub:last-child { border-bottom: 0; }
+.settings .sub .subhead { font-size: 10.5px; color: var(--muted); text-transform: uppercase; letter-spacing: .5px; margin-bottom: 9px; display: flex; align-items: center; gap: 8px; }
+.settings .later { color: var(--faint); font-style: italic; }
+.settings .tag { font-size: 8.5px; color: var(--muted); background: var(--chip); border-radius: 7px; padding: 1px 6px; }


### PR DESCRIPTION
Follow-up to ADR-0084 and the living `docs/design/builder-ui.md` (merged in #2503). Closes the remaining-pillars design tracked in #2506.

## What

- **Writeback** the Data pillar + shell sections to the **shipped** `StudioDesignSurface` reality: the field-edit affordance is the per-column **pencil** (a bare header click sorts — the grid is the runtime `ListView`); three pillars ship first (Access/⚙ pending); Save/Publish render per-pillar; the Interface rail is the app's real nav tree. Added an honest **Implementation status** note and per-surface **[built] / [designed]** markers.
- Replace the §5 *"to design"* stub with **four real sections**:
  - **§5 Automation [built]** — flow canvas (`FlowCanvas`) + node inspector + Runs peek.
  - **§6 Interface [built]** — source+preview (`SchemaRenderer`) / structured canvas + component props.
  - **§7 Access [designed]** — permission matrix (`PermissionMatrixEditor`) + role protocol form.
  - **§8 Settings [designed]** — General (`app` form) + Advanced/Code (hooks), grouped by audience.
- Each pillar gets an annotated HTML **mockup** under `builder-ui/` composed from `shell.css`, every region tagged `data-build="shell"` or `data-reuse="<component>"` (dashed = reused). Added the shared canvas / matrix / split / settings primitives to `shell.css`.

## Scope

Docs only. Deliberately **excludes** the unrelated `console-sha-drift-guard` changes present in the working tree — this PR is the six builder-ui doc files only.

Closes #2506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)