### PR TITLE
ci: bump downstream hotcrm smoke ref to v1.2.1 (ADR-0085 digestion)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,11 @@ jobs:
         # The deterministic in-repo floor is @objectstack/downstream-contract;
         # this is the live ceiling.
         env:
-          HOTCRM_REF: v1.2.0
+          # v1.2.1: hotcrm dropped the ObjectSchema `detail` block removed by
+          # ADR-0085 (hotcrm#423) — the intended break, explicitly digested
+          # downstream. Bump this ref whenever a deliberate spec surface
+          # removal ships a matching hotcrm release.
+          HOTCRM_REF: v1.2.1
         run: bash scripts/downstream-smoke.sh
 
       - name: Create Release Pull Request or Publish to npm


### PR DESCRIPTION
The Release pipeline's **Downstream backward-compat smoke** pins hotcrm at a published release (`HOTCRM_REF`). It correctly went red after #2521: hotcrm v1.2.0 authored the `ObjectSchema.detail` block that ADR-0085 removed — the one real downstream author our two-repo zero-authors scan missed.

Digestion chain, now complete:
- [hotcrm#423](https://github.com/objectstack-ai/hotcrm/pull/423) removed the block (proven no-op: the Reference Rail is off by default, the flag never did anything) — merged
- [hotcrm v1.2.1](https://github.com/objectstack-ai/hotcrm/releases/tag/v1.2.1) tagged with the fix
- this PR moves the pin → unblocks the Version Packages release for the ADR-0085 spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)