### PR TITLE
docs(spec): scrub stale compactLayout teachings + orphaned defaultDetailForm JSDoc (ADR-0085 remnants)

### DIFF
--- a/.changeset/adr-0085-code-doc-remnants.md
+++ b/.changeset/adr-0085-code-doc-remnants.md
@@ -1,0 +1,14 @@
+---
+'@objectstack/spec': patch
+---
+
+Clean up two stale code-side doc remnants found during the ADR-0085 docs sweep (#2529):
+
+- `RecordDetailsProps` (ui/component.zod.ts) `layout`/`fields` descriptions taught the
+  deprecated `compactLayout` name — now teach the ADR-0085 canonical `highlightFields`
+  (`compactLayout` remains a supported alias). Regenerated
+  `skills/objectstack-ui/{contracts/react-blocks.contract.json,references/react-blocks.md}`.
+- Removed an orphaned JSDoc block in data/object.zod.ts describing `defaultDetailForm`,
+  a prop that was never implemented and was removed from the spec in #2402.
+
+Doc-text only; no schema shape or behavior change.

--- a/packages/spec/src/data/object.zod.ts
+++ b/packages/spec/src/data/object.zod.ts
@@ -650,17 +650,6 @@ const ObjectSchemaBase = z.object({
   listViews: z.record(z.string(), ListViewSchema).optional().describe('Built-in named list views (segmented tabs) shipped with the object schema'),
 
   /**
-   * Default FormView used when displaying a single record's detail page.
-   *
-   * Matches the named FormView under the same object's `ViewSchema.formViews`.
-   * When unset, the runtime falls back to the unnamed `form` view, then to
-   * an auto-generated layout. This is the Airtable-style "Interface form"
-   * binding — every record-detail screen renders through a FormView, so the
-   * same metadata drives both the public collection form and the operator's
-   * edit panel.
-   */
-
-  /** 
    * Search Engine Config 
    */
   searchableFields: z.array(z.string()).optional().describe('Fields the `$search` query matches against (ADR-0061). Canonical default for the record picker, list quick-search and global search; views may narrow it. When unset, search auto-defaults to the name/title field plus short-text fields.'),

--- a/packages/spec/src/ui/component.zod.ts
+++ b/packages/spec/src/ui/component.zod.ts
@@ -61,9 +61,9 @@ export const PageCardProps = z.object({
 
 export const RecordDetailsProps = z.object({
   columns: z.enum(['1', '2', '3', '4']).default('2').describe('Number of columns for field layout (1-4)'),
-  layout: z.enum(['auto', 'custom']).default('auto').describe('Layout mode: auto uses object compactLayout, custom uses explicit sections'),
+  layout: z.enum(['auto', 'custom']).default('auto').describe('Layout mode: auto uses object highlightFields, custom uses explicit sections'),
   sections: z.array(z.string()).optional().describe('Section IDs to show (required when layout is "custom")'),
-  fields: z.array(z.string()).optional().describe('Explicit field list to display (optional, overrides compactLayout)'),
+  fields: z.array(z.string()).optional().describe('Explicit field list to display (optional, overrides highlightFields)'),
   /** ARIA accessibility */
   aria: AriaPropsSchema.optional().describe('ARIA accessibility attributes'),
 });

--- a/skills/objectstack-ui/contracts/react-blocks.contract.json
+++ b/skills/objectstack-ui/contracts/react-blocks.contract.json
@@ -396,7 +396,7 @@
           "type": "'auto' | 'custom'",
           "kind": "data",
           "required": true,
-          "description": "Layout mode: auto uses object compactLayout, custom uses explicit sections"
+          "description": "Layout mode: auto uses object highlightFields, custom uses explicit sections"
         },
         {
           "name": "sections",
@@ -410,7 +410,7 @@
           "type": "string[]",
           "kind": "data",
           "required": false,
-          "description": "Explicit field list to display (optional, overrides compactLayout)"
+          "description": "Explicit field list to display (optional, overrides highlightFields)"
         }
       ]
     },

--- a/skills/objectstack-ui/references/react-blocks.md
+++ b/skills/objectstack-ui/references/react-blocks.md
@@ -89,9 +89,9 @@ Field-detail panel for the bound record. Config props from the spec RecordDetail
 | `objectName` | `string` | binding |  | The record’s object. |
 | `recordId` | `string \| number` | controlled |  | The record to show. |
 | `columns` | `'1' \| '2' \| '3' \| '4'` | data | ✓ | Number of columns for field layout (1-4) |
-| `layout` | `'auto' \| 'custom'` | data | ✓ | Layout mode: auto uses object compactLayout, custom uses explicit sections |
+| `layout` | `'auto' \| 'custom'` | data | ✓ | Layout mode: auto uses object highlightFields, custom uses explicit sections |
 | `sections` | `string[]` | data |  | Section IDs to show (required when layout is "custom") |
-| `fields` | `string[]` | data |  | Explicit field list to display (optional, overrides compactLayout) |
+| `fields` | `string[]` | data |  | Explicit field list to display (optional, overrides highlightFields) |
 
 ## `<RecordHighlights>` — `record:highlights`
 


### PR DESCRIPTION
## Summary

Follow-up to the ADR-0085 hand-written docs sweep (#2529). Two stale remnants live in **code** and regenerate into docs, so they survived the docs-only sweep:

1. **`RecordDetailsProps` (`packages/spec/src/ui/component.zod.ts`)** — the `layout` and `fields` prop descriptions taught the deprecated `compactLayout` name. Renamed to the ADR-0085 canonical `highlightFields` (`compactLayout` remains a supported alias per the bidirectional mirror in `object.zod.ts`). Regenerated `skills/objectstack-ui/contracts/react-blocks.contract.json` and `skills/objectstack-ui/references/react-blocks.md` via `pnpm gen:react-blocks`.
2. **`packages/spec/src/data/object.zod.ts`** — removed an orphaned JSDoc block describing `defaultDetailForm`, a prop that was never implemented and was removed from the spec in #2402. The comment had no property attached.

Doc-text only; no schema shape or behavior change. Patch changeset included.

Refs: ADR-0085, #2529, #2402

## Test plan

- `pnpm --filter @objectstack/spec build` ✅
- spec vitest: 245 files / 6666 tests passed ✅
- `pnpm gen:react-blocks` regenerated contract + reference doc (only the two description strings changed) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)