### PR TITLE
feat(studio): App Builder nav entry — pillar builder joins the login journey

### DIFF
--- a/.changeset/studio-app-builder-nav.md
+++ b/.changeset/studio-app-builder-nav.md
@@ -1,0 +1,11 @@
+---
+"@objectstack/platform-objects": patch
+---
+
+feat(studio): "App Builder" navigation entry — the pillar builder joins the journey
+
+The Studio app's Overview group gains an **App Builder** entry (componentRef
+`studio:builder`, bound by the console to the builder landing page). This makes the
+pillar application builder reachable from the moment a user logs in — Home → Studio
+→ App Builder → pick/create a writable base package → the full-screen builder at
+`/studio/:packageId/:tab` — instead of being a URL-only surface.

--- a/packages/platform-objects/src/apps/studio.app.ts
+++ b/packages/platform-objects/src/apps/studio.app.ts
@@ -85,6 +85,19 @@ export const STUDIO_APP: App = {
       icon: 'layout-dashboard',
       children: [
         {
+          // The application builder's front door (ADR-0080/0084): pick or
+          // create a writable base package, then design in the full-screen
+          // pillar builder (/studio/:packageId/:tab). The console binds
+          // `studio:builder` to the BuilderLanding page — this makes the
+          // builder reachable from login (Home → Studio → App Builder)
+          // instead of being a URL-only surface.
+          id: 'nav_app_builder',
+          type: 'component',
+          label: 'App Builder',
+          componentRef: 'studio:builder',
+          icon: 'hammer',
+        },
+        {
           id: 'nav_metadata_directory',
           type: 'component',
           label: 'All Metadata Types',


### PR DESCRIPTION
Companion to objectui#2175 (BuilderLanding + `studio:builder` component registration).

Adds an **App Builder** entry (componentRef `studio:builder`, first in the Overview group) to the Studio app's navigation, so the pillar application builder is reachable from the moment a user logs in:

**Login → Home → Studio app → App Builder → pick/create a writable base package → `/studio/:packageId/data`** (full-screen pillar builder) — previously the builder was a URL-only surface with zero inbound links.

Browser-verified end-to-end with a worktree build serving this nav: the sidebar entry appears (Overview: App Builder · All Metadata Types · Packages), the landing renders inside the Studio chrome, and creating 客服中心/com.example.support jumps straight into the full-screen builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)