### PR TITLE
feat(setup): Packages entry in Setup's Apps group

### DIFF
--- a/.changeset/setup-packages-nav.md
+++ b/.changeset/setup-packages-nav.md
@@ -1,0 +1,11 @@
+---
+"@objectstack/platform-objects": patch
+---
+
+feat(setup): Packages entry in Setup's Apps group
+
+Package administration (install / inspect / manage) is an operator concern
+(ADR-0084: packages are Operate, out of the builder), so it gains a home in the
+Setup app: `group_apps` now carries a **Packages** entry bound to the console's
+existing `developer:packages` page. Building apps remains a separate journey
+(the Home builder cover → `/studio`); this entry is for administration.

--- a/packages/platform-objects/src/apps/setup-nav.contributions.ts
+++ b/packages/platform-objects/src/apps/setup-nav.contributions.ts
@@ -38,9 +38,19 @@ export const SETUP_NAV_CONTRIBUTIONS: NavigationContribution[] = [
       { id: 'nav_system_overview', type: 'dashboard', label: 'System Overview', dashboardName: 'system_overview', icon: 'activity' },
     ],
   },
-  // No group_apps contribution left here — both marketplace entries moved
-  // out (see header note); the group_apps shell anchor in setup.app.ts is
-  // filled entirely by capability plugins now.
+  {
+    // Package ADMINISTRATION is a platform/operator concern (ADR-0084:
+    // packages are Operate, out of the builder) — so its home is Setup, not
+    // the application builder. The console binds `developer:packages` to the
+    // existing package-management page. Building/creating apps is a separate
+    // journey (Home cover → /studio); this entry is for install/inspect/admin.
+    app: 'setup',
+    group: 'group_apps',
+    priority: BASE_PRIORITY,
+    items: [
+      { id: 'nav_packages', type: 'component', label: 'Packages', componentRef: 'developer:packages', icon: 'package' },
+    ],
+  },
   {
     app: 'setup',
     group: 'group_people_org',


### PR DESCRIPTION
Companion to objectui#2176 (Home builder cover + builder→app bridge), implementing the settled journey split: **Home cover = creation, /studio = 设计界面, the app = published front-end, Setup = administration**.

Package administration is an operator concern (ADR-0084: packages are Operate, out of the builder) — so `group_apps` in the Setup app gains a **Packages** entry bound to the console's existing `developer:packages` page, alongside the capability-plugin marketplace entries (Browse Marketplace / Installed Apps / Cloud Connection).

Per owner direction the classic Studio app is **not** removed in this step.

**Browser-verified** (worktree build, fresh db): Setup › Apps shows Packages first; the page renders (package list + New Package + Import). `platform-objects` tests **63/63** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)