### PR TITLE
docs: the compactLayout alias is retired, not accepted (#2536 follow-up)

### DIFF
--- a/content/docs/guides/data-modeling.mdx
+++ b/content/docs/guides/data-modeling.mdx
@@ -67,7 +67,7 @@ export const MyObject = ObjectSchema.create({
 | `icon` | string | Icon identifier | `'building'` |
 | `description` | string | Help text | `'Companies...'` |
 | `titleFormat` | string | Record title template (`{{record.field}}` interpolation) | `'{{record.name}} - {{record.id}}'` |
-| `highlightFields` | string[] | Most-important fields, in priority order (default columns, cards, previews, detail highlight strip; ADR-0085 — formerly `compactLayout`, still accepted as an alias) | `['name', 'status']` |
+| `highlightFields` | string[] | Most-important fields, in priority order (default columns, cards, previews, detail highlight strip; ADR-0085 — formerly `compactLayout`; the old spelling was retired and is now rejected) | `['name', 'status']` |
 
 ### Enable Features
 

--- a/content/docs/guides/metadata/object.mdx
+++ b/content/docs/guides/metadata/object.mdx
@@ -68,7 +68,7 @@ export const Account = ObjectSchema.create({
 | :--- | :--- | :--- | :--- |
 | `displayNameField` | `string` | optional | Field used as record display name (defaults to `'name'`) |
 | `titleFormat` | `string` | optional | Title expression (e.g. `'{name} - {code}'`) |
-| `highlightFields` | `string[]` | optional | Most-important fields in priority order — default list columns, cards, previews, detail highlight strip (ADR-0085; formerly `compactLayout`, accepted as an alias) |
+| `highlightFields` | `string[]` | optional | Most-important fields in priority order — default list columns, cards, previews, detail highlight strip (ADR-0085; formerly `compactLayout` — the old spelling was retired and is now rejected) |
 | `stageField` | `string \| false` | optional | Linear lifecycle field; `false` declares the status field non-linear and suppresses stage heuristics (ADR-0085) |
 | `recordName` | `object` | optional | Record name auto-generation config |
 


### PR DESCRIPTION
[framework#2539](https://github.com/objectstack-ai/framework/pull/2539) retired the `compactLayout` alias; two guides (data-modeling, metadata/object) still said the old spelling is "accepted as an alias" — a 422 generator for AI authors who copy docs verbatim. Reworded to "retired and now rejected". The generated reference's "formerly compactLayout" wording is historical (not a teaching) and untouched, as are ADRs/changelogs.

`check:doc-authoring` clean (171 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)