### PR TITLE
demo(app-showcase): 批量编辑增强的可操作示例(多选/日期/可搜索选人)(#2185)

### DIFF
--- a/examples/app-showcase/src/objects/project.object.ts
+++ b/examples/app-showcase/src/objects/project.object.ts
@@ -56,6 +56,24 @@ export const Project = ObjectSchema.create({
     start_date: Field.date({ label: 'Start Date' }),
     end_date: Field.date({ label: 'Target End Date' }),
     owner: Field.text({ label: 'Owner', maxLength: 200 }),
+    // Multi-value fields — the payload for the grid's *bulk-edit* showcase. A
+    // multiselect (fixed options) and a multi-user field are exactly the two
+    // shapes that, before #2185, the bulk dialog could not set: its people /
+    // select picker collapsed to a single value and overwrote the array. The
+    // list view's `bulkActionDefs` below now sets both with real multi-select
+    // controls, writing an array patch.
+    labels: {
+      type: 'multiselect',
+      label: 'Labels',
+      options: [
+        { label: 'Frontend', value: 'frontend', color: '#3B82F6' },
+        { label: 'Backend', value: 'backend', color: '#8B5CF6' },
+        { label: 'Design', value: 'design', color: '#EC4899' },
+        { label: 'QA', value: 'qa', color: '#F59E0B' },
+        { label: 'DevOps', value: 'devops', color: '#10B981' },
+      ],
+    },
+    team_members: Field.user({ label: 'Team Members', multiple: true }),
     // Roll-up summaries — recomputed server-side whenever a child task is
     // inserted / updated / deleted (FK auto-detected: showcase_task.project).
     task_count: Field.summary({

--- a/examples/app-showcase/src/views/project.view.ts
+++ b/examples/app-showcase/src/views/project.view.ts
@@ -15,9 +15,80 @@ export const ProjectViews = defineView({
       { field: 'account' },
       { field: 'status' },
       { field: 'health' },
+      { field: 'labels' },
+      { field: 'team_members' },
       { field: 'budget' },
       { field: 'budget_remaining' },
       { field: 'end_date' },
+    ],
+    // Rich bulk-edit definitions (#2185) — select rows, then "set the same
+    // value on all of them" through the BulkActionDialog. Each def exercises a
+    // control the dialog gained in #2185:
+    //   • set_labels    → multi-select on a `select` param (fixed options)
+    //   • assign_team   → multi-select on a `lookup` param (users; array patch)
+    //   • reschedule    → the new `date` control + a single-select together
+    // A def with no `multiple` still renders a single-select, unchanged.
+    bulkActionDefs: [
+      {
+        name: 'set_labels',
+        label: 'Set Labels',
+        operation: 'update',
+        confirmText: 'Set these labels on every selected project?',
+        params: [
+          {
+            name: 'labels',
+            label: 'Labels',
+            type: 'select',
+            multiple: true,
+            required: true,
+            options: [
+              { label: 'Frontend', value: 'frontend' },
+              { label: 'Backend', value: 'backend' },
+              { label: 'Design', value: 'design' },
+              { label: 'QA', value: 'qa' },
+              { label: 'DevOps', value: 'devops' },
+            ],
+          },
+        ],
+      },
+      {
+        name: 'assign_team',
+        label: 'Assign Team',
+        operation: 'update',
+        confirmText: 'Assign these team members to every selected project?',
+        params: [
+          {
+            name: 'team_members',
+            label: 'Team Members',
+            type: 'lookup',
+            object: 'sys_user',
+            multiple: true,
+            labelField: 'name',
+            required: true,
+          },
+        ],
+      },
+      {
+        name: 'reschedule',
+        label: 'Reschedule',
+        operation: 'update',
+        confirmText: 'Apply this schedule/status to every selected project?',
+        params: [
+          { name: 'end_date', label: 'Target End Date', type: 'date' },
+          {
+            name: 'status',
+            label: 'Status',
+            type: 'select',
+            options: [
+              { label: 'Planned', value: 'planned' },
+              { label: 'Active', value: 'active' },
+              { label: 'On Hold', value: 'on_hold' },
+              { label: 'Completed', value: 'completed' },
+              { label: 'Cancelled', value: 'cancelled' },
+            ],
+          },
+        ],
+      },
     ],
   },
   listViews: {

--- a/examples/app-showcase/src/views/project.view.ts
+++ b/examples/app-showcase/src/views/project.view.ts
@@ -26,8 +26,9 @@ export const ProjectViews = defineView({
     // control the dialog gained in #2185:
     //   • set_labels    → multi-select on a `select` param (fixed options)
     //   • assign_team   → multi-select on a `lookup` param (users; array patch)
+    //   • reassign_account → single-select on a `lookup` param (searchable
+    //                     reference picker, not a bare dropdown)
     //   • reschedule    → the new `date` control + a single-select together
-    // A def with no `multiple` still renders a single-select, unchanged.
     bulkActionDefs: [
       {
         name: 'set_labels',
@@ -63,6 +64,22 @@ export const ProjectViews = defineView({
             type: 'lookup',
             object: 'sys_user',
             multiple: true,
+            labelField: 'name',
+            required: true,
+          },
+        ],
+      },
+      {
+        name: 'reassign_account',
+        label: 'Reassign Account',
+        operation: 'update',
+        confirmText: 'Move every selected project to this account?',
+        params: [
+          {
+            name: 'account',
+            label: 'Account',
+            type: 'lookup',
+            object: 'showcase_account',
             labelField: 'name',
             required: true,
           },


### PR DESCRIPTION
## 目的

给 objectui #2185 的批量编辑增强(多选/日期控件、单选可搜索选人组件)在 framework 的 `examples/app-showcase` 里加一套**可真实操作**的示例,方便 dogfood 和回归。对应 objectui 侧:PR #2186(已合并)+ #2190(嵌套下拉/选人组件的关闭行为修复)。

## 改动

**`examples/app-showcase/src/objects/project.object.ts`**
- 新增 `labels`(多选,固定选项)
- 新增 `team_members: Field.user({ multiple: true })`

**`examples/app-showcase/src/views/project.view.ts`** — Project 列表网格上加了四个 `bulkActionDefs`,每个都覆盖 #2185 新增的一种控件:
- **Set Labels** → `select` 多选(固定选项)
- **Assign Team** → `lookup` 多选(用户;数组补丁)
- **Reassign Account** → `lookup` 单选(可搜索的 reference 选人组件,不是裸下拉)
- **Reschedule** → 新的 `date` 控件 + 单选 `select` 同屏

## 验证

在 `objectstack dev` 起的 showcase 上,用真实后端逐个跑通并查库核对持久化:

- Set Labels:`labels: ["frontend","devops"]` 落到 5 行 ✓
- Assign Team:`team_members` 数组落到 5 行 ✓
- Reassign Account:`account` 单值(非数组)落到 5 行 ✓
- Reschedule:`end_date: "2026-12-31"` 落到 5 行 ✓

> 注:此 PR 只含 showcase 示例源码(objects/views),不含任何 `dist` 构建产物。
