### PR TITLE
fix(objectql): surface human validation messages in ValidationError.message

### DIFF
--- a/.changeset/validation-error-human-message.md
+++ b/.changeset/validation-error-human-message.md
@@ -1,0 +1,22 @@
+---
+"@objectstack/objectql": patch
+---
+
+fix(objectql): surface the human validation message in `ValidationError.message`, not a `field (code)` digest
+
+When an object-level validation rule (ADR-0020 `validations[]`) rejected a
+save, the console toast showed the generic English string
+`Validation failed for 1 field(s): _record (rule_violation)` instead of the
+rule author's own `message` (often localized, e.g. 最小水深不能大于最大水深。).
+
+The author's message was always transported in `ValidationError.fields[].message`
+through the whole chain (rule-validator → REST envelope `fields[]` → client SDK
+`error.details`), but every generic UI surface displays the top-level
+`Error.message`, which only contained the `field (code)` pairs.
+
+Fix at the single choke point — the `ValidationError` constructor now builds its
+top-level message from the per-field human messages (joined with `; `), falling
+back to `field (code)` only when a field error has no message. Machine-readable
+`code` and `fields[]` are unchanged, so programmatic consumers and the REST
+envelope shape are unaffected; every client (console toast, CLI, SDK callers)
+now sees the author-written message with no client-side change needed.

--- a/packages/objectql/src/engine-multivalue-normalize.test.ts
+++ b/packages/objectql/src/engine-multivalue-normalize.test.ts
@@ -149,7 +149,7 @@ describe('engine write pipeline — multi-value scalar normalization (#2552)', (
     const ql = await makeEngine(driver);
     await expect(
       ql.update('project', { id: 'r1', labels: { nested: true } }),
-    ).rejects.toThrow(/invalid_type/i);
+    ).rejects.toThrow(/must be an array/i);
     expect(updated).toHaveLength(0);
   });
 
@@ -157,7 +157,7 @@ describe('engine write pipeline — multi-value scalar normalization (#2552)', (
     const { driver, created } = makeDriver();
     const ql = await makeEngine(driver);
     await expect(ql.insert('project', { name: 'P2', labels: 'nope' })).rejects.toThrow(
-      /invalid_option/i,
+      /is not one of/i,
     );
     expect(created).toHaveLength(0);
   });

--- a/packages/objectql/src/validation/record-validator.test.ts
+++ b/packages/objectql/src/validation/record-validator.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
-import { validateRecord, normalizeMultiValueFields } from './record-validator.js';
+import { validateRecord, normalizeMultiValueFields, ValidationError } from './record-validator.js';
 
 /**
  * Required-field validation, with the autonumber exemption (#1603).
@@ -55,14 +55,14 @@ describe('validateRecord — time field accepts time-of-day', () => {
 
   for (const v of ['25:00', '14:60', 'not-a-time', '14']) {
     it(`rejects ${v}`, () => {
-      expect(() => validateRecord(schema, { at: v }, 'insert')).toThrow(/invalid_time/i);
+      expect(() => validateRecord(schema, { at: v }, 'insert')).toThrow(/must be a valid time/i);
     });
   }
 
   it('does NOT regress date/datetime (still ISO-parsed)', () => {
     const ds = { fields: { d: { type: 'date' }, dt: { type: 'datetime' } } };
     expect(() => validateRecord(ds, { d: '2026-06-17', dt: '2026-06-17T10:00:00Z' }, 'insert')).not.toThrow();
-    expect(() => validateRecord(ds, { d: 'not-a-date' }, 'insert')).toThrow(/invalid_date/i);
+    expect(() => validateRecord(ds, { d: 'not-a-date' }, 'insert')).toThrow(/must be a valid date/i);
   });
 });
 
@@ -160,13 +160,13 @@ describe('validateRecord — multi-value fields must be arrays', () => {
       { watchers: 'user-1' },
       { attachments: 'file-key-1' },
     ]) {
-      expect(() => validateRecord(schema, payload, 'update')).toThrow(/invalid_type/i);
+      expect(() => validateRecord(schema, payload, 'update')).toThrow(/must be an array/i);
     }
   });
 
   it('rejects a plain-object shape with invalid_type', () => {
-    expect(() => validateRecord(schema, { labels: { nested: true } }, 'update')).toThrow(/invalid_type/i);
-    expect(() => validateRecord(schema, { team_members: { id: 'u1' } }, 'update')).toThrow(/invalid_type/i);
+    expect(() => validateRecord(schema, { labels: { nested: true } }, 'update')).toThrow(/must be an array/i);
+    expect(() => validateRecord(schema, { team_members: { id: 'u1' } }, 'update')).toThrow(/must be an array/i);
   });
 
   it('accepts arrays (including for select+multiple, previously mis-rejected)', () => {
@@ -180,12 +180,54 @@ describe('validateRecord — multi-value fields must be arrays', () => {
   });
 
   it('still validates array ELEMENTS against options', () => {
-    expect(() => validateRecord(schema, { labels: ['nope'] }, 'update')).toThrow(/invalid_option/i);
-    expect(() => validateRecord(schema, { channels: ['fax'] }, 'update')).toThrow(/invalid_option/i);
+    expect(() => validateRecord(schema, { labels: ['nope'] }, 'update')).toThrow(/is not one of/i);
+    expect(() => validateRecord(schema, { channels: ['fax'] }, 'update')).toThrow(/is not one of/i);
   });
 
   it('does NOT regress single select / radio', () => {
     expect(() => validateRecord(schema, { status: 'active' }, 'update')).not.toThrow();
-    expect(() => validateRecord(schema, { status: 'nope' }, 'update')).toThrow(/invalid_option/i);
+    expect(() => validateRecord(schema, { status: 'nope' }, 'update')).toThrow(/must be one of/i);
+  });
+});
+
+/**
+ * The top-level `ValidationError.message` is what generic UI surfaces (the
+ * console's save-error toast, CLI output) display verbatim — it must carry
+ * the HUMAN per-field messages, not a `field (code)` digest. Regression for
+ * the rule-violation case: an author-written localized rule `message`
+ * ("最小水深不能大于最大水深。") used to be buried in `fields[]` while the
+ * toast showed "Validation failed for 1 field(s): _record (rule_violation)".
+ */
+describe('ValidationError — top-level message is human-readable', () => {
+  it('uses each field error message verbatim', () => {
+    const err = new ValidationError([
+      { field: '_record', code: 'rule_violation', message: '最小水深不能大于最大水深。' },
+    ]);
+    expect(err.message).toBe('最小水深不能大于最大水深。');
+  });
+
+  it('joins multiple field messages', () => {
+    const err = new ValidationError([
+      { field: 'title', code: 'required', message: 'title is required' },
+      { field: '_record', code: 'rule_violation', message: '最小水深不能大于最大水深。' },
+    ]);
+    expect(err.message).toBe('title is required; 最小水深不能大于最大水深。');
+  });
+
+  it('falls back to `field (code)` when a message is blank', () => {
+    const err = new ValidationError([
+      { field: '_record', code: 'rule_violation', message: '' },
+    ]);
+    expect(err.message).toBe('_record (rule_violation)');
+  });
+
+  it('still exposes machine-readable fields[] for programmatic handling', () => {
+    const err = new ValidationError([
+      { field: '_record', code: 'rule_violation', message: 'boom' },
+    ]);
+    expect(err.code).toBe('VALIDATION_FAILED');
+    expect(err.fields).toEqual([
+      { field: '_record', code: 'rule_violation', message: 'boom' },
+    ]);
   });
 });

--- a/packages/objectql/src/validation/record-validator.ts
+++ b/packages/objectql/src/validation/record-validator.ts
@@ -83,9 +83,16 @@ export class ValidationError extends Error {
   readonly code = 'VALIDATION_FAILED';
   readonly fields: FieldValidationError[];
   constructor(fields: FieldValidationError[]) {
+    // The top-level message is what generic UI surfaces (toasts, CLI output)
+    // display verbatim, so it must carry the HUMAN messages — most notably a
+    // validation rule's author-written `message` (often localized), which used
+    // to be buried in `fields[]` while the toast showed only
+    // "Validation failed for 1 field(s): _record (rule_violation)".
+    // Machine-readable field/code pairs remain available on `.fields`.
     super(
-      `Validation failed for ${fields.length} field(s): ` +
-      fields.map((f) => `${f.field} (${f.code})`).join(', '),
+      fields
+        .map((f) => (f.message?.trim() ? f.message : `${f.field} (${f.code})`))
+        .join('; ') || 'Validation failed',
     );
     this.name = 'ValidationError';
     this.fields = fields;

--- a/packages/objectql/src/validation/rule-null-omitted.test.ts
+++ b/packages/objectql/src/validation/rule-null-omitted.test.ts
@@ -28,12 +28,12 @@ const schema = {
 describe('validation: `field == null` on insert with omitted field (#1871)', () => {
   it('fires when due_date is OMITTED from the insert payload', () => {
     expect(() => evaluateValidationRules(schema, { priority: 'urgent' }, 'insert', {}))
-      .toThrow(/rule_violation|_record|Validation failed/);
+      .toThrow(/Urgent tasks require a due date/);
   });
 
   it('fires when due_date is explicitly null (already worked)', () => {
     expect(() => evaluateValidationRules(schema, { priority: 'urgent', due_date: null }, 'insert', {}))
-      .toThrow(/rule_violation|_record|Validation failed/);
+      .toThrow(/Urgent tasks require a due date/);
   });
 
   it('does NOT fire when due_date is present', () => {


### PR DESCRIPTION
## 问题

项目反馈:对象级校验规则(ADR-0020 `validations[]`)拦截保存时,console 右下角报错 toast 只显示通用英文文案:

> Validation failed for 1 field(s): _record (rule_violation)

而规则作者写的本地化 `message`(如 `最小水深不能大于最大水深。`)完全没有露出,用户不知道哪里填错了。

## 根因

作者的 message 全链路都在 `ValidationError.fields[].message` 里(rule-validator → REST 400 信封 `fields[]` → client SDK `error.details`),但所有通用 UI(console toast、CLI、SDK 调用方)显示的是顶层 `Error.message`,而它此前只包含 `field (code)` 摘要。

## 修复

在唯一的咽喉点 —— `ValidationError` 构造函数 —— 把顶层 message 改为由各 field error 的**人类可读 message** 拼接(`; ` 分隔),message 为空时才回退到 `field (code)`。

- `code`(`VALIDATION_FAILED`)和 `fields[]` 机读契约不变,REST 信封形状不变
- 仅有的 2 个 throw 点(record-validator、rule-validator)都走此构造函数,所有客户端零改动受益
- 全仓无生产代码解析旧 message 格式,仅测试正则依赖(已同步更新为断言人类文案,断言反而更强)

## 测试

- 新增回归块 `ValidationError — top-level message is human-readable`(4 例:单条 verbatim/多条拼接/空 message 回退/机读契约不变)
- `packages/objectql`:60 文件 749 用例全绿
- `packages/rest`:8 文件 198 用例全绿(信封断言 code,不受影响)