### PR TITLE
docs(authz): 两道门分离已落地(从 roadmap 缺口移到 provenance 章节 · ADR-0086 P2)

### DIFF
--- a/content/docs/concepts/authorization.mdx
+++ b/content/docs/concepts/authorization.mdx
@@ -106,6 +106,35 @@ package (metadata); subject bindings and env-specific values stay as config.**
   (`bootstrapDeclaredRoles`, ADR-0057 D6) — a declarable-but-never-seeded
   array is exactly the inert-metadata smell ADR-0078 prohibits.
 
+### Two doors, one metadata (ADR-0086 D6/D7)
+
+The `managedBy` provenance axis is not just descriptive — the platform
+**populates and gates on it**, so editing a permission set flows through exactly
+one of two doors, each writing only what it owns:
+
+- **Package door** (studio `/studio/:packageId/access`) — a package's own set is
+  **metadata**, so edits are saved as a **draft** stamped with the `packageId`
+  (`saveMetaItem` `mode:'draft'`) and go live with the package's atomic
+  **Publish**, exactly like Data and Interfaces. On publish, a registered
+  materializer (`registerPublishMaterializer`) projects the published body into
+  `sys_permission_set` as `managedBy:'package'` + `packageId`, reusing the same
+  upsert as the boot seeder (`upsertPackagePermissionSet`). Enforcement is
+  unaffected while a set is still a draft (drafts never enter the active
+  resolve).
+- **Environment-admin door** (`metadata-admin`) — the cross-package all-objects
+  matrix plus subject **assignment** (`sys_user_permission_set`,
+  `sys_role_permission_set`), edited **live** (config). It owns env-authored
+  sets (`managedBy` `platform`/`user`) and assignments — not package sets.
+- **Data-layer write gate** — the security middleware **refuses** any admin-door
+  write to a `managedBy:'package'` `sys_permission_set` row, and refuses a
+  payload that forges that provenance (insert or update, single or array). It
+  fails closed ahead of the CRUD check — even a `modifyAllRecords` super-user is
+  blocked — so the door separation is a real boundary, not a UI hint. System /
+  boot writes carry `isSystem` and bypass it, so the seeder and materializer are
+  never self-blocked. An environment adjusts a packaged set through the
+  ADR-0005 overlay / muting subtract layer (below), never by editing the base
+  record.
+
 ## Lifecycle coverage (five stages)
 
 | Stage | What holds today | Owned by |
@@ -145,10 +174,13 @@ The complete, prioritized gap map lives in issue **#2561** (the production
   references (ADR-0066 ⑨).
 - **Per-operation `requiredPermissions`** (ADR-0066 ⑤) — read-open /
   write-gated objects.
-- **Enterprise authentication** (ADR-0069) — password policy, lockout,
-  enforced MFA (P1); session lifecycle, IP allowlists (P2); SSO/SCIM (P3).
-- **Two doors** (ADR-0086 D6/D7) — package Access door under draft/publish;
-  env-admin door live, cross-package.
+- **Deny/muting subtract layer** (ADR-0005 overlay; ADR-0066 precedence step 4)
+  — how an environment adjusts a *packaged* set without forking it; deferred
+  until proven need (ADR-0086 P2).
+- **Enterprise authentication** (ADR-0069) — password policy, lockout, enforced
+  MFA (P1) and session lifecycle + global IP allowlist + shared multi-node
+  rate-limit store (P2) are **landed**; the remaining gap is per-org
+  `allowed_ip_ranges` (#2571). SSO/SCIM is P3.
 
 ## ADR index
 


### PR DESCRIPTION
## 概述

纯文档准确性修正。`content/docs/concepts/authorization.mdx` 把「Two doors (ADR-0086 D6/D7)」列在 **Known gaps & roadmap**,但框架半边(#2573,发布物化 + `managed_by` 数据层写门)和 objectui 半边(objectui#2225,包 Access 门 draft/publish)**都已合并**——这条已不是缺口(ADR-0049 honesty:不把已落地的说成待办)。

## 变更

- **新增** ADR-0086 provenance 章节下的「**Two doors, one metadata**」小节,如实描述已落地的三件事:
  - 包门(`/studio/:packageId/access`)= 草稿 → Publish → 物化进 `sys_permission_set`(`managedBy:'package'`),复用 `registerPublishMaterializer` + `upsertPackagePermissionSet`;
  - env-admin 门 = live,跨包矩阵 + 分配(`sys_user/role_permission_set`);
  - 数据层写门 = 硬拒绝管理门写/伪造 `managed_by:'package'` 行,fail-closed 于 CRUD 检查之前(超级用户亦挡),`isSystem` 短路。
- **移除** roadmap 里的「Two doors」缺口条(已落地)。
- **刷新** 企业认证 roadmap 条:P1 + P2(会话/全局 IP/多节点共享限流 store)已落地,剩余仅 per-org `allowed_ip_ranges`(#2571)。
- **补** ADR-0005 deny/muting subtract 层作为 ADR-0086 P2 真正 deferred 的剩余项。

## 范围说明

- 检查过:**只有 authorization.mdx 一处**把两道门当缺口/roadmap;其余 hand-written 文档无 now-false 声明。
- **Skills 无需改动**——两个 published skill(objectstack-ui/objectstack-data)只泛泛引用权限集,`permission` 已按 draftable 类型处理,无关于旧「实时保存」的过时声明。

## 关联

- ADR-0086 D6/D7 · 实现:framework#2573(P2 框架)+ objectui#2225(P2 objectui)· #2561 上线地图

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014y5kiH3aPLWtRRRGcVrXcT

---
_Generated by [Claude Code](https://claude.ai/code/session_014y5kiH3aPLWtRRRGcVrXcT)_