### PR TITLE
docs(skills): teach adaptive record presentation in objectstack-ui skill (#2578)

### DIFF
--- a/.changeset/adaptive-ui-skill-doc.md
+++ b/.changeset/adaptive-ui-skill-doc.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(skills): teach adaptive record presentation (surface/width/columns auto-derived) in the objectstack-ui skill (#2578)

--- a/skills/objectstack-ui/SKILL.md
+++ b/skills/objectstack-ui/SKILL.md
@@ -614,6 +614,38 @@ export const TaskWorkbenchPage = definePage({
 
 ---
 
+## Record Presentation — surface, width & columns are auto-derived
+
+A record's create / edit / detail **presents itself adaptively**. You do **not**
+author the surface, the overlay width, or the column count — all three are derived
+at runtime from how heavy the record is + the client viewport, because an author
+(especially an AI) cannot know the client's screen. **Write the data (fields,
+`fieldGroups`); let the platform lay it out.**
+
+- **Surface (page vs drawer).** Derived from field count: a field-heavy object
+  opens create/edit/detail as a **full page**; a light one as a **drawer**. Mobile
+  always pages. Don't set it. To force it for a specific object, set
+  `navigation.mode` (`page` | `drawer` | `modal`) on the list view (or object) — or,
+  for bespoke layout, assign a record `Page` (below).
+- **Field width.** Use the relative **`span: 'full'`** to make a field take the
+  whole row; otherwise **omit it** (`auto` sizes by widget type × current columns —
+  textarea / rich-text / file take the row automatically). Do **not** use the
+  absolute `colSpan` — it only lines up at one width and is deprecated.
+- **Overlay width.** Never author pixels. If you must nudge, use the **`size`**
+  bucket (`sm` | `md` | `lg` | `xl` | `full`) on `navigation`; the pixel
+  `width` / `drawerWidth` are deprecated (they can't be chosen without knowing the
+  client viewport).
+- **Column count.** Not authored. The form grid follows its **real rendered width**
+  via container queries — the same form is 1 column in a narrow drawer and up to 4
+  on a wide page. Author *grouping* with `fieldGroups` + `Field.group`; the columns
+  adapt themselves.
+
+> **Rule of thumb: presentation (surface / width / columns) is not metadata.**
+> Write fields + semantic roles; the renderer decides the pixels. Reach for
+> `navigation.mode` / `size` / a `Page` only to *override* — never as the default.
+
+---
+
 ## Pages — Lightning-Style Page Layouts
 
 A **Page** is a Salesforce-Lightning-style layout composed of **regions**


### PR DESCRIPTION
Docs follow-up to #2578 (code shipped: framework#2595 + objectui#2237, both merged & green).

Adds a **Record Presentation — surface, width & columns are auto-derived** section to the `objectstack-ui` authoring skill. Nothing in the docs taught the *deprecated* primitives, but the **new** model was untaught: since all metadata is AI-authored and the author can't know the client viewport, presentation (surface / overlay width / column count) is derived at runtime — authors write fields + `fieldGroups`, never presentation.

Teaches:
- surface (page vs drawer) auto-derived from field count; `navigation.mode` / a `Page` only to *override*
- `span: 'full'` over the deprecated absolute `colSpan`
- the `size` bucket over the deprecated pixel `width` / `drawerWidth`
- column count follows the real rendered width (container queries), not authored

`check:skill-docs` green. Empty changeset (docs-only, no release).

Refs #2578

🤖 Generated with [Claude Code](https://claude.com/claude-code)