### PR TITLE
fix(metadata-protocol): drop internal ADR path from read-only package error

### DIFF
--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -3843,9 +3843,8 @@ export class ObjectStackProtocolImplementation implements ObjectStackProtocol {
             ) {
                 const err = new Error(
                     `[writable_package_required] Cannot author ${singularTypeForRepo}/${request.name} into `
-                    + `'${request.packageId}': it is a read-only code/installed package, not a writable base. `
-                    + `Create or select a writable base (package) first, then retry. `
-                    + `See docs/adr/0070-package-first-authoring.md.`,
+                    + `'${request.packageId}': it is a read-only package. `
+                    + `Switch to or create a writable package, then retry.`,
                 );
                 (err as any).code = 'writable_package_required';
                 (err as any).status = 422;


### PR DESCRIPTION
## Summary

Addresses the one framework-side item from #2615 (Studio package-create UX dogfood follow-ups). All other items in that tracking issue are `objectui` console-side and out of scope here.

- The `writable_package_required` rejection thrown when authoring runtime-only metadata into a read-only code/installed package cited an internal doc path (`See docs/adr/0070-package-first-authoring.md.`), which is meaningless to Studio/API callers.
- Rewrote the message as user-facing remediation guidance ("it is a read-only package. Switch to or create a writable package, then retry.") instead of pointing at internal ADR docs.

## Test plan

- [x] `pnpm --filter @objectstack/metadata-protocol build && pnpm --filter @objectstack/metadata-protocol test` — 8/8 passing
- [x] `vitest run test/package-first-authoring.dogfood.test.ts` (packages/dogfood) — the golden regression test covering this exact error path — 5/5 passing (asserts on `error.code`, not message text, so unaffected by the copy change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013BbaPwnFiwZc3wKgqf4GSt)_