### PR TITLE
fix(showcase): stretch Command Center's flex-column children to full width

### DIFF
--- a/examples/app-showcase/src/ui/pages/command-center.page.ts
+++ b/examples/app-showcase/src/ui/pages/command-center.page.ts
@@ -115,7 +115,7 @@ export const CommandCenterPage = definePage({
           type: 'flex',
           responsiveStyles: {
             large: {
-              minHeight: '100%', display: 'flex', flexDirection: 'column', gap: '16px',
+              minHeight: '100%', display: 'flex', flexDirection: 'column', alignItems: 'stretch', gap: '16px',
               padding: '22px 26px 32px',
               background:
                 'radial-gradient(1200px 540px at 50% -14%, hsl(192 86% 46% / 0.10) 0%, transparent 60%), ' +


### PR DESCRIPTION
## Summary

Fixes the last piece of the "D" (Command Center chart width) finding from #2616/#2620 — confirmed via live browser testing that `objectstack-ai/objectui#2254` did **not** actually fix this despite touching the same styling area (see `objectstack-ai/objectui#2268`).

**Root cause**: `showcase_command_center`'s outer container (`cc_root`, a `type:'flex'` node with `responsiveStyles` setting `display:'flex', flexDirection:'column'`) never set `alignItems`. The `flex` component's own default (`align:'start'` → Tailwind `items-start`) therefore applied. In a `flex-direction:column` container, `align-items:flex-start` means children size to their own intrinsic content width instead of stretching to fill the container — so each chart band (`cc_rowA`/`cc_rowB`, both `display:grid` with 3 equal-width tracks) collapsed to whatever width its charts naturally wanted (~100-130px per column) instead of filling the ~1100px available.

One-line fix: add `alignItems: 'stretch'` to `cc_root`'s `responsiveStyles`.

## Verification

Live-tested with Playwright against a real `--fresh --seed-admin` backend + the objectui console dev server (HMR against objectui main + my in-flight fix branch, to isolate this from the console-rebuild pipeline):

- **Before**: row-A chart `<svg>` bounding boxes measured **100px wide** each (`getBoundingClientRect()`, not eyeballed)
- **After**: same charts measured **350px wide** each — screenshot-confirmed all three charts (task status, project health, priority) now render at full readable width with correct axis/legend labels

## Test plan

- [x] `pnpm build` (showcase) — clean
- [x] Live Playwright verification (DOM bounding-box measurement before/after, screenshot)
- [x] `pnpm test` (showcase) — 52/53 passing; the 1 failure (`coverage.test.ts`, new registry kinds `trigger`/`router`/`function`/`service` not yet in `KIND_COVERAGE`) is confirmed pre-existing on `main` (reproduced with this change stashed out) and unrelated to this fix

Refs #2616, #2620, objectui#2254, objectui#2268.


---
_Generated by [Claude Code](https://claude.ai/code/session_012BjVb4Jx6bv9uX31vzEZau)_