### PR TITLE
fix(showcase): CRM Workbench KPI cards read adapter.find().data not .records

### DIFF
--- a/examples/app-showcase/src/ui/pages/crm-workbench.page.ts
+++ b/examples/app-showcase/src/ui/pages/crm-workbench.page.ts
@@ -31,11 +31,13 @@ function Page() {
   const refreshStats = React.useCallback(async () => {
     if (!adapter) return;
     try {
-      // Canonical QueryOptionsV2 keys only (limit, not the legacy top alias
-      // removed in 11.0) — the KPI cards silently stuck at 0 whenever adapter.find
-      // rejected on the unrecognized param, and the empty catch hid the failure.
+      // useAdapter() is the console's ObjectStackAdapter — its find() resolves to
+      // a normalized QueryResult with a "data" array, NOT the REST envelope with
+      // a "records" array. Reading .records here always missed, so the KPI cards
+      // silently stuck at 0 even though the ListView beside them showed the same
+      // rows. Read .data first, with .records/array fallbacks for robustness.
       const all = await adapter.find('showcase_project', { limit: 200 });
-      const rows = Array.isArray(all) ? all : (all && all.records) || [];
+      const rows = Array.isArray(all) ? all : (all && (all.data || all.records)) || [];
       setStats({ total: rows.length, active: rows.filter((r) => r.status === 'active').length });
     } catch (e) { console.warn('[CRM Workbench] failed to refresh stats', e); }
   }, [adapter]);


### PR DESCRIPTION
## What

The **CRM Workbench** KPI strip (`Total projects` / `Active`) rendered **0** even though the `<ListView>` beside it — backed by the same `showcase_project` object — showed all 5 rows. This fixes the count so the cards show the real totals.

Before → After (same page, freshly-built showcase):

| | Total projects | Active |
|---|---|---|
| before | 0 | 0 |
| after | **5** | **2** |

## Why

The stats callback read `all.records` from `adapter.find('showcase_project', …)`:

```js
const all = await adapter.find('showcase_project', { limit: 200 });
const rows = Array.isArray(all) ? all : (all && all.records) || [];
```

But `useAdapter()` in the console is the **ObjectStackAdapter**, whose `find()` normalizes its result to a `QueryResult` with a **`data`** array — *not* the REST envelope's `records`. (`normalizeQueryResult` in `@object-ui/data-objectstack` returns `{ data, total, … }`.) So `all.records` was always `undefined`, `rows` fell back to `[]`, and both counts stuck at 0. The empty `catch` never fired because the promise resolved fine — it was a shape mismatch, not a rejection.

The fix reads `.data` first, keeping `.records`/array fallbacks for robustness across adapter shapes:

```js
const rows = Array.isArray(all) ? all : (all && (all.data || all.records)) || [];
```

> Note: the earlier attempt at this in #2621 changed the query param `top`→`limit`. That was not the cause — the result-shape mismatch was. This corrects it.

## Verification

- Booted a freshly-built showcase (`objectstack dev --ui --seed-admin`), logged in as admin, drove the CRM Workbench in a real browser (Chromium): cards now read **Total 5 / Active 2**; selecting a row still updates **Editing** without disturbing the counts.
- `pnpm --filter @objectstack/example-showcase test` → **53 passed**.

## Scope

One-line behavioral fix in a single private example page (`examples/app-showcase`), so no changeset (consistent with prior showcase-only commits).

## Out of scope — belong in objectui, not this repo

While re-verifying the [#2616](https://github.com/objectstack-ai/framework/issues/2616) findings against latest `main`, I confirmed #2621 already resolved the REST `fields` crash, the `/ai/agents` 404 spam, the unbound page-header **Mark Done**, and the offline (picsum) seed images. The following remain and are **objectui**-side (vendored console / SDUI renderer), not fixable in framework metadata — filing separately:

- **Sidebar nav labels** show the singular object label (`Project`, `Setting`) instead of the app-nav's own `label` (`Projects`, `Settings`) — `UnifiedSidebar`/`useObjectLabel` treats the nav label as fallback and the i18n object label wins.
- **Record detail `START DATE`** renders `Overdue Nd` for any past date — `formatRelativeDate` applies the "Overdue" wording to every past date, ignoring the `dueLike` flag it already computes for the red color.
- **Wizard post-submit** — `submitBehavior: { kind: 'thank-you' }` is a valid spec prop but the in-console `object-form` block doesn't consume it (only public-forms' `EmbeddableForm` does), so the wizard still resets in place after Create.
- **Command Center** chart panels collapse to ~135px on the left third — the SDUI `flex` block renders `items-start` and a region-root component's `responsiveStyles` (incl. `alignItems`) is stripped at build, so a column's children can't be made to stretch from metadata. The `integerYAxis` config (`yAxis:[{stepSize:1}]`) is also not honored by `object-chart` (axis still shows 0.5/1.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192Bo4EN62r2kgM35FsBiCp

---
_Generated by [Claude Code](https://claude.ai/code/session_0192Bo4EN62r2kgM35FsBiCp)_