### PR TITLE
chore(cli,plugin-dev): drop unused @objectstack/studio dependency

### DIFF
--- a/.changeset/drop-studio-dep-cli-plugin-dev.md
+++ b/.changeset/drop-studio-dep-cli-plugin-dev.md
@@ -1,0 +1,6 @@
+---
+"@objectstack/cli": patch
+"@objectstack/plugin-dev": patch
+---
+
+Drop the `@objectstack/studio` dependency from `cli` and `plugin-dev`. Since Studio is no longer default-loaded by `os dev` / `os start` / `os serve` (the console hosts it at `/_console/studio/...`), neither package imports it at runtime any more. The only remaining consumer was the ADR-0048 app-split test in `cli`, which now exercises the identical one-app-package code path via Setup + Account. The `@objectstack/studio` package itself is unchanged and still registerable explicitly.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -79,7 +79,6 @@
     "@objectstack/service-storage": "workspace:*",
     "@objectstack/setup": "workspace:*",
     "@objectstack/spec": "workspace:*",
-    "@objectstack/studio": "workspace:*",
     "@objectstack/trigger-api": "workspace:*",
     "@objectstack/trigger-record-change": "workspace:*",
     "@objectstack/trigger-schedule": "workspace:*",

--- a/packages/cli/src/adr-0048-app-split.test.ts
+++ b/packages/cli/src/adr-0048-app-split.test.ts
@@ -7,13 +7,18 @@
  * Boots a real ObjectQL engine, runs each app package's plugin `start()` against
  * a manifest service backed by `engine.registerApp` (exactly what the kernel
  * wires — see objectql plugin.ts: `register(m) => ql.registerApp(m)`), and
- * asserts each app resolves under `com.objectstack.{studio,setup,account}` and
- * that all three coexist (the multi-app-package ambiguity is gone).
+ * asserts each app resolves under `com.objectstack.{setup,account}` and that
+ * they coexist (the multi-app-package ambiguity is gone).
+ *
+ * Studio is one of the same one-app packages but is no longer default-loaded
+ * (it now lives in the console at `/_console/studio/...`), so cli/plugin-dev no
+ * longer depend on `@objectstack/studio`. Setup + Account exercise the identical
+ * app-split code path; asserting them keeps this regression intact without cli
+ * re-taking a dependency purely for the test.
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ObjectQL } from '@objectstack/objectql';
-import { createStudioAppPlugin } from '@objectstack/studio';
 import { createSetupAppPlugin } from '@objectstack/setup';
 import { createAccountAppPlugin } from '@objectstack/account';
 
@@ -35,16 +40,13 @@ describe('ADR-0048 — platform apps as one-app packages', () => {
     engine = new ObjectQL();
     engine.registry.logLevel = 'silent';
     const ctx = makeCtx(engine);
-    for (const plugin of [createSetupAppPlugin(), createStudioAppPlugin(), createAccountAppPlugin()]) {
+    for (const plugin of [createSetupAppPlugin(), createAccountAppPlugin()]) {
       await plugin.init?.(ctx);
       await plugin.start(ctx);
     }
   });
 
   it('registers each app under its OWN package id', () => {
-    expect(engine.registry.getItem<any>('app', 'studio', 'com.objectstack.studio')?._packageId).toBe(
-      'com.objectstack.studio',
-    );
     expect(engine.registry.getItem<any>('app', 'setup', 'com.objectstack.setup')?._packageId).toBe(
       'com.objectstack.setup',
     );
@@ -53,23 +55,20 @@ describe('ADR-0048 — platform apps as one-app packages', () => {
     );
   });
 
-  it('all three apps coexist and resolve by name (getApp)', () => {
-    expect(engine.registry.getApp('studio')?.name).toBe('studio');
+  it('the apps coexist and resolve by name (getApp)', () => {
     expect(engine.registry.getApp('setup')?.name).toBe('setup');
     expect(engine.registry.getApp('account')?.name).toBe('account');
   });
 
   it('each app package owns a distinct namespace (no install-gate conflict)', () => {
-    expect(engine.registry.getNamespaceOwners('studio')).toEqual(['com.objectstack.studio']);
     expect(engine.registry.getNamespaceOwners('setup')).toEqual(['com.objectstack.setup']);
     expect(engine.registry.getNamespaceOwners('account')).toEqual(['com.objectstack.account']);
   });
 
-  it('records all three as installed packages', () => {
+  it('records the app packages as installed', () => {
     const ids = engine.registry.getAllPackages().map((p: any) => p.manifest.id);
     expect(ids).toEqual(
       expect.arrayContaining([
-        'com.objectstack.studio',
         'com.objectstack.setup',
         'com.objectstack.account',
       ]),

--- a/packages/plugins/plugin-dev/package.json
+++ b/packages/plugins/plugin-dev/package.json
@@ -30,7 +30,6 @@
     "@objectstack/service-i18n": "workspace:^",
     "@objectstack/setup": "workspace:^",
     "@objectstack/spec": "workspace:*",
-    "@objectstack/studio": "workspace:^",
     "@objectstack/types": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,9 +444,6 @@ importers:
       '@objectstack/spec':
         specifier: workspace:*
         version: link:../spec
-      '@objectstack/studio':
-        specifier: workspace:*
-        version: link:../apps/studio
       '@objectstack/trigger-api':
         specifier: workspace:*
         version: link:../triggers/trigger-api
@@ -1367,9 +1364,6 @@ importers:
       '@objectstack/spec':
         specifier: workspace:*
         version: link:../../spec
-      '@objectstack/studio':
-        specifier: workspace:^
-        version: link:../../apps/studio
       '@objectstack/types':
         specifier: workspace:*
         version: link:../../types


### PR DESCRIPTION
## What

Follow-up to [`3b9fd940`](https://github.com/objectstack-ai/framework/commit/3b9fd940f1d7688db8382fc3d83db74a34461250), which stopped `os dev` / `os start` / `os serve` from default-loading the Studio app (the console now hosts it at `/_console/studio/<pkg>/<pillar>`).

With the default registration removed, neither `cli` nor `plugin-dev` imports `@objectstack/studio` at runtime any more, so the dependency was dead weight. This drops it from both.

## Changes

- **`packages/cli/package.json` + `packages/plugins/plugin-dev/package.json`** — remove the `@objectstack/studio` dependency.
- **`packages/cli/src/adr-0048-app-split.test.ts`** — the last remaining consumer imported `createStudioAppPlugin`. It now exercises the identical one-app-package split via **Setup + Account** (same code path; the regression's intent — distinct package ids / coexistence / distinct namespaces — is preserved).
- changeset (`cli` + `plugin-dev` patch).

The `@objectstack/studio` package itself is unchanged and still registerable explicitly.

## Verification

- `vitest run adr-0048-app-split.test.ts` → 4 passed.
- `cli` and `plugin-dev` build green after the dep removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)