### PR TITLE
fix(service-settings): drop hard-coded USD platform default for workspace currency

### DIFF
--- a/.changeset/localization-no-default-currency.md
+++ b/.changeset/localization-no-default-currency.md
@@ -1,0 +1,9 @@
+---
+'@objectstack/service-settings': minor
+---
+
+Localization: drop the hard-coded `USD` platform default for the workspace **Default currency** setting.
+
+Previously the `localization.currency` setting defaulted to `'USD'`, and that value was applied to any `currency`-typed field that omits its own code — so every code-less amount surfaced a `$`/`US$` symbol even when nothing (field, measure, or workspace) actually named a currency. The setting now has **no platform default**: a code-less currency amount renders as a plain number unless the workspace explicitly picks a default currency (or the field declares its own).
+
+Migration: a workspace that relied on the implicit USD default and wants to keep showing `$` should set **Settings → Localization → Default currency** to `USD` explicitly. Fields/measures that declare their own currency code are unaffected.

--- a/packages/services/service-settings/src/manifests/localization.manifest.test.ts
+++ b/packages/services/service-settings/src/manifests/localization.manifest.test.ts
@@ -21,7 +21,10 @@ describe('localizationSettingsManifest', () => {
     const byKey = (k: string) => specs.find((s) => s.key === k);
     expect(byKey('timezone').default).toBe('UTC');
     expect(byKey('locale').default).toBe('en-US');
-    expect(byKey('currency').default).toBe('USD');
+    // No platform default currency: a code-less currency field renders as a
+    // plain number unless the workspace explicitly sets one (avoids surfacing
+    // an unwanted "$"/"US$" on every amount that omits its own code).
+    expect(byKey('currency').default).toBeUndefined();
     expect(byKey('date_format').default).toBe('YYYY-MM-DD');
     expect(byKey('first_day_of_week').default).toBe('monday');
     expect(byKey('fiscal_year_start').default).toBe('january');

--- a/packages/services/service-settings/src/manifests/localization.manifest.ts
+++ b/packages/services/service-settings/src/manifests/localization.manifest.ts
@@ -111,8 +111,13 @@ export const localizationSettingsManifest: SettingsManifest = {
     // ── Finance ───────────────────────────────────────────────────────────
     { type: 'group', id: 'finance', label: 'Finance', required: false },
     {
-      type: 'select', key: 'currency', label: 'Default currency', required: false, default: 'USD',
-      description: 'ISO 4217 code applied when a currency field omits its own.',
+      type: 'select', key: 'currency', label: 'Default currency', required: false,
+      // No platform default: when a currency field omits its own code AND the
+      // workspace has not set a default here, amounts render as plain numbers
+      // rather than inheriting a guessed symbol (previously hard-defaulted to
+      // 'USD', which surfaced an unwanted "$"/"US$" on every code-less amount).
+      // A workspace can still pick a default to apply org-wide.
+      description: 'ISO 4217 code applied when a currency field omits its own. Leave unset to render code-less amounts as plain numbers.',
       options: [
         { value: 'USD', label: 'USD — US Dollar' },
         { value: 'EUR', label: 'EUR — Euro' },


### PR DESCRIPTION
## What & why

The workspace **Default currency** setting (`localization.currency`) hard-defaulted to `'USD'`, and that value is applied to any `currency`-typed field that omits its own code. The chain:

`localization.currency` (manifest default `USD`) → resolved onto the execution context (`resolve-execution-context.ts`, `rest-server.ts`: `...(localization.currency ? { currency } : {})`) → stamped onto dataset **measure** fields and read by field/cell renderers.

So every code-less amount surfaced a `$` / `US$` symbol even when nothing — field, measure, or workspace — actually named a currency.

This was reported on the HotCRM **Executive Overview** dashboard: the `Total Revenue (YTD)` KPI showed `US$2,528,600`. Traced end-to-end (live app), the `total_amount` dataset measure came back from `/api/v1/analytics/dataset/query` stamped `currency: "USD"` purely because HotCRM's `amount` field is `Field.currency()` with no code of its own → it inherited this platform default.

## Change

Remove the `default: 'USD'` from the `currency` spec in the localization manifest. With no platform default, a code-less currency amount renders as a plain number unless:
- the field declares its own code (`currency` / `currencyConfig.defaultCurrency`), or
- the workspace explicitly sets **Settings → Localization → Default currency**.

Both the execution-context resolver and the rest-server stamp already gate on truthiness, so an unset value simply falls away — no other code change needed.

## Migration

A workspace that relied on the implicit USD default and wants to keep showing `$` should set **Settings → Localization → Default currency = USD** explicitly. Fields/measures that declare their own currency code are unaffected.

## Testing

- `pnpm --filter @objectstack/service-settings test` → **129 passed** (incl. the updated manifest assertion: `currency` default is now `undefined`).
- The execution-context resolution tests set `localization.currency` explicitly (EUR/CNY/JPY/junk) and don't rely on the removed default — unaffected.

## Note for reviewers

This addresses the *platform default* half of the HotCRM currency report. The HotCRM `Total Revenue` **measure** additionally uses `format: '$0,0'` (a literal `$`), so that specific tile will still show a `$` from the format string until the measure format is changed in the HotCRM app metadata (separate, app-side follow-up). This PR ensures the platform no longer *invents* a currency for code-less amounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWr8Sgey8LY5nbWYPaYH6z

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWr8Sgey8LY5nbWYPaYH6z)_