### PR TITLE
feat(automation): notify node click-through target (source_object/source_id) (#2675)

### DIFF
--- a/.changeset/notify-click-through-target.md
+++ b/.changeset/notify-click-through-target.md
@@ -1,0 +1,9 @@
+---
+'@objectstack/service-automation': minor
+---
+
+Flow `notify` node: support a click-through target so inbox notifications can be clicked into the related record (#2675).
+
+The `notify` node now reads `sourceObject` / `sourceId` (or the nested `source: { object, id }` form) and `actorId` from its config and forwards them to the messaging service, which persists `sys_notification.source_object` / `source_id` / `actor_id` and synthesizes a `/{object}/{id}` inbox deep-link. Both keys interpolate flow variables (e.g. `sourceId: '{new_quotation.id}'`), and a half-specified target (object without id, or vice versa) is dropped so the inbox never renders a dead link. `url` is now accepted as an alias for `actionUrl` (an explicit URL still overrides the synthesized link). The node also publishes a `configSchema` documenting all accepted keys for the Studio form.
+
+Previously the node consumed only `recipients` / `title` / `message` / `channels`, so every notification it emitted had `source_object` / `source_id` = `null` and could not be clicked through to a record.

--- a/packages/services/service-automation/src/builtin/notify-node.test.ts
+++ b/packages/services/service-automation/src/builtin/notify-node.test.ts
@@ -117,6 +117,72 @@ describe('notify (baseline node)', () => {
             expect(result.output).toMatchObject({ 'notify.delivered': 2 });
         });
 
+        it('forwards a click-through target via sourceObject/sourceId, interpolating the id (#2675)', async () => {
+            engine.registerFlow('notify_flow', notifyFlow({
+                recipients: ['user_1'],
+                title: 'Quote {dealName} approved',
+                message: 'Fill in the line items',
+                channels: ['inbox'],
+                sourceObject: 'mtc_quotation',
+                sourceId: '{dealId}',
+            }));
+
+            const result = await engine.execute('notify_flow', {
+                params: { dealName: 'Acme', dealId: 'q_42' },
+            } as any);
+
+            expect(result.success).toBe(true);
+            expect(messaging.emitted[0]).toMatchObject({
+                source: { object: 'mtc_quotation', id: 'q_42' },
+            });
+        });
+
+        it('accepts the nested source:{object,id} form and forwards actorId', async () => {
+            engine.registerFlow('notify_flow', notifyFlow({
+                recipients: ['user_1'],
+                title: 'Assigned to you',
+                source: { object: 'opportunity', id: '{dealId}' },
+                actorId: '{dealName}',
+            }));
+
+            const result = await engine.execute('notify_flow', {
+                params: { dealName: 'user_boss', dealId: '99' },
+            } as any);
+
+            expect(result.success).toBe(true);
+            expect(messaging.emitted[0]).toMatchObject({
+                source: { object: 'opportunity', id: '99' },
+                actorId: 'user_boss',
+            });
+        });
+
+        it('drops a half-specified target (object without id) rather than emitting a dead link', async () => {
+            engine.registerFlow('notify_flow', notifyFlow({
+                recipients: ['user_1'],
+                title: 'Heads up',
+                sourceObject: 'opportunity',
+                // no sourceId
+            }));
+
+            const result = await engine.execute('notify_flow');
+            expect(result.success).toBe(true);
+            expect(messaging.emitted[0].source).toBeUndefined();
+        });
+
+        it('accepts `url` as an alias for actionUrl', async () => {
+            engine.registerFlow('notify_flow', notifyFlow({
+                recipients: ['user_1'],
+                title: 'Heads up',
+                url: '/opps/{dealId}',
+            }));
+
+            const result = await engine.execute('notify_flow', {
+                params: { dealId: '7' },
+            } as any);
+            expect(result.success).toBe(true);
+            expect(messaging.emitted[0].payload).toMatchObject({ url: '/opps/7' });
+        });
+
         it('accepts a single recipient string and the subject/to aliases', async () => {
             engine.registerFlow('notify_flow', notifyFlow({
                 to: 'user_9',

--- a/packages/services/service-automation/src/builtin/notify-node.ts
+++ b/packages/services/service-automation/src/builtin/notify-node.ts
@@ -1,9 +1,10 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import type { PluginContext } from '@objectstack/core';
+import type { AutomationContext } from '@objectstack/spec/contracts';
 import { defineActionDescriptor } from '@objectstack/spec/automation';
 import type { AutomationEngine } from '../engine.js';
-import { interpolate } from './template.js';
+import { interpolate, type VariableMap } from './template.js';
 
 /**
  * Structural view of `@objectstack/service-messaging`'s service (ADR-0012),
@@ -31,6 +32,33 @@ function toStringList(value: unknown): string[] {
     if (Array.isArray(value)) return value.map((v) => String(v)).filter(Boolean);
     if (typeof value === 'string' && value.trim()) return [value.trim()];
     return [];
+}
+
+/** Coerce an interpolated config value to a non-empty trimmed string, else undefined. */
+function toStr(value: unknown): string | undefined {
+    if (value == null) return undefined;
+    const s = String(value).trim();
+    return s.length > 0 ? s : undefined;
+}
+
+/**
+ * Resolve the click-through target record from the node config, if any.
+ *
+ * Accepts the flat `sourceObject`/`sourceId` keys (canonical — mirrors the
+ * `sys_notification.source_object`/`source_id` columns) or the nested
+ * `source: { object, id }` form (mirrors the messaging `emit()` surface). A
+ * target is produced only when BOTH object and id resolve — a half-specified
+ * link is dropped so the inbox never renders a dead deep-link.
+ */
+function resolveSource(
+    cfg: Record<string, unknown>,
+    variables: VariableMap,
+    context: AutomationContext,
+): { object: string; id: string } | undefined {
+    const src = (cfg.source ?? null) as { object?: unknown; id?: unknown } | null;
+    const object = toStr(interpolate(cfg.sourceObject ?? src?.object, variables, context));
+    const id = toStr(interpolate(cfg.sourceId ?? src?.id, variables, context));
+    return object && id ? { object, id } : undefined;
 }
 
 /**
@@ -68,6 +96,46 @@ export function registerNotifyNode(engine: AutomationEngine, ctx: PluginContext)
             // emit → sys_notification_delivery), so it inherits retry/dead-letter.
             needsOutbox: true,
             paradigms: ['flow', 'approval'],
+            // Drives the Studio form + documents the accepted keys. Extra keys
+            // are still tolerated (JSON Schema allows additional properties) —
+            // this is discoverability, not a lockdown.
+            configSchema: {
+                // No `required` array: `recipients`/`title` each accept an alias
+                // (`to`/`subject`), which a strict required-check would reject.
+                // The node enforces "title + ≥1 recipient" at execute time.
+                type: 'object',
+                properties: {
+                    recipients: {
+                        description: 'Recipient user id(s) / audience selector(s); alias: `to`',
+                    },
+                    title: { type: 'string', description: 'Notification title; alias: `subject`' },
+                    message: { type: 'string', description: 'Notification body; alias: `body`' },
+                    channels: {
+                        type: 'array', items: { type: 'string' },
+                        description: 'Channels to fan out to (default: inbox)',
+                    },
+                    topic: { type: 'string', description: 'Event topic (default: "notify")' },
+                    severity: { type: 'string', description: 'info | warning | critical' },
+                    // ── Click-through target (#2675) ─────────────────────────
+                    sourceObject: {
+                        type: 'string',
+                        description: 'Object name of the record the notification links to (writes sys_notification.source_object). Requires sourceId.',
+                    },
+                    sourceId: {
+                        type: 'string',
+                        description: 'Record id the notification links to (writes sys_notification.source_id). Requires sourceObject. The inbox synthesizes a `/{object}/{id}` deep-link from these.',
+                    },
+                    actorId: {
+                        type: 'string',
+                        description: 'User id that caused the event (writes sys_notification.actor_id)',
+                    },
+                    url: {
+                        type: 'string',
+                        description: 'Explicit click-through URL; overrides the link synthesized from sourceObject/sourceId. Alias: `actionUrl`.',
+                    },
+                    payload: { type: 'object', description: 'Extra template inputs merged into the notification payload' },
+                },
+            },
         }),
         async execute(node, variables, context) {
             const cfg = (node.config ?? {}) as Record<string, unknown>;
@@ -78,12 +146,20 @@ export function registerNotifyNode(engine: AutomationEngine, ctx: PluginContext)
             const channels = toStringList(cfg.channels);
             const topic = cfg.topic ? String(cfg.topic) : undefined;
             const severity = cfg.severity ? String(cfg.severity) : undefined;
-            const actionUrl = cfg.actionUrl
-                ? String(interpolate(cfg.actionUrl, variables, context) ?? '')
+            const urlCfg = cfg.actionUrl ?? cfg.url;
+            const actionUrl = urlCfg
+                ? String(interpolate(urlCfg, variables, context) ?? '')
                 : undefined;
             const payload = cfg.payload
                 ? (interpolate(cfg.payload, variables, context) as Record<string, unknown>)
                 : undefined;
+
+            // Click-through target: forwarding `source` lets the messaging
+            // service persist sys_notification.source_object/source_id and
+            // synthesize a `/{object}/{id}` deep-link for the inbox (#2675). An
+            // explicit `actionUrl`/`url` still wins over the synthesized link.
+            const source = resolveSource(cfg, variables, context);
+            const actorId = toStr(interpolate(cfg.actorId, variables, context));
 
             if (!title) return { success: false, error: 'notify: title (or subject) is required' };
             if (recipients.length === 0) {
@@ -111,6 +187,8 @@ export function registerNotifyNode(engine: AutomationEngine, ctx: PluginContext)
                     audience: recipients,
                     payload: { ...(payload ?? {}), title, body, url: actionUrl },
                     severity,
+                    source,
+                    actorId,
                     channels: channels.length ? channels : undefined,
                 });
                 return {


### PR DESCRIPTION
## 问题

Fixes #2675.

Flow 的 `notify` 节点无法给通知附带点击跳转目标——生成的 `sys_notification.source_object` / `source_id` 恒为 `null`，inbox 里点通知无处可跳。节点此前只消费 `recipients` / `title` / `message` / `channels`，写出的 payload 只有 `{ title, body }`。

根因很窄：下游 messaging 服务的 `emit()` **早已支持** `source: { object, id }` / `actorId`，会把它们写进 `sys_notification.source_object` / `source_id` / `actor_id`，并在无显式 URL 时合成 `/{object}/{id}` 的 inbox 深链（`actionUrlFor`）。缺口只在 **notify 节点从不把这些从 config 转发进 `emit()`**。

## 改动

`packages/services/service-automation/src/builtin/notify-node.ts`:

- 从 config 读取跳转目标并转发给 `messaging.emit({ source, actorId })`：
  - 扁平键 `sourceObject` / `sourceId`(canonical，对齐 DB 列名)
  - 或嵌套 `source: { object, id }`(对齐 emit 契约)
  - `actorId`
- 两个键都走 `interpolate`，支持 `sourceId: '{new_quotation.id}'` 这类流程变量。
- **半指定即丢弃**(只给 object 不给 id，或反之)——inbox 绝不渲染死链。
- 显式 `actionUrl` / `url` 仍优先于合成链;新增 `url` 作为 `actionUrl` 别名。
- 给 descriptor 补 `configSchema`,让 Studio 表单可发现这些键(不加 `required`,不锁死额外键——纯 discoverability)。

用法(即 issue 的期望):

```ts
{ type: 'notify', config: {
  recipients: ['{record.sales_person}'],
  title: '转报价申请已通过',
  message: '…请到报价单补全明细',
  channels: ['inbox'],
  sourceObject: 'mtc_quotation',
  sourceId: '{new_quotation.id}',
  // 或显式 url: '/…/mtc_quotation/record/{new_quotation.id}'
}}
```

## 验证

- 新增 4 个 notify 节点单测(sourceObject/sourceId 转发+插值、嵌套 `source` 形式 + actorId、半指定丢弃、`url` 别名)。
- `service-automation` 全套 **256 passed**;`service-messaging` `emit()` 已有测试覆盖 `source` → `source_object`/`source_id` 落库 + `/{object}/{id}` 深链合成,整条链路端到端有据。
- 包 build(tsup + DTS 严格类型门)通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)