### PR TITLE
fix(validation): remove polynomial ReDoS in email regexes

### DIFF
--- a/.changeset/redos-email-regex-validators.md
+++ b/.changeset/redos-email-regex-validators.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/objectql": patch
+"@objectstack/plugin-email": patch
+---
+
+fix(validation): remove polynomial ReDoS in email validation regexes
+
+The email validators used `/^[^\s@]+@[^\s@]+\.[^\s@]+$/`, whose quantifiers
+around `\.` overlap (the literal dot is also matched by `[^\s@]`) and backtrack
+polynomially on adversarial input. The domain part is rewritten as
+`[^\s@.]+(?:\.[^\s@.]+)+` so labels exclude `.` and matching is linear. Valid
+addresses (including multi-label domains) are unaffected; addresses with an
+empty label such as `a@b..c` are now correctly rejected.

--- a/packages/objectql/src/validation/record-validator.ts
+++ b/packages/objectql/src/validation/record-validator.ts
@@ -43,7 +43,11 @@ const SKIP_FIELDS = new Set<string>([
   'id', 'created_at', 'created_by', 'updated_at', 'updated_by',
 ]);
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// Linear-time email check. Domain labels exclude '.', so the quantifiers on
+// either side of each '.' can't overlap — this avoids the polynomial
+// backtracking (ReDoS) of the naive `[^\s@]+\.[^\s@]+` shape while still
+// requiring a local part, an '@', and a dotted domain.
+const EMAIL_RE = /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/;
 // Permissive URL pattern: accept any scheme:// + non-empty body so that
 // non-HTTP URIs used by drivers (libsql://, postgres://, mysql://, file://, s3://, …)
 // pass field-level validation. Stricter per-field checks can be enforced

--- a/packages/objectql/src/validation/rule-validator.test.ts
+++ b/packages/objectql/src/validation/rule-validator.test.ts
@@ -303,6 +303,33 @@ describe('format enforcement', () => {
     ).not.toThrow();
   });
 
+  it('accepts multi-label domains and rejects malformed / empty-label emails', () => {
+    const emailSchema = schema({ field: 'email', format: 'email' });
+    const ok = (v: string) =>
+      expect(() => evaluateValidationRules(emailSchema, { email: v }, 'insert')).not.toThrow();
+    const bad = (v: string) =>
+      expect(() => evaluateValidationRules(emailSchema, { email: v }, 'insert')).toThrow(ValidationError);
+
+    ok('a@b.co.uk');
+    ok('x.y+z@sub.domain.io');
+    bad('a@b'); // no dot in domain
+    bad('a@b.'); // empty trailing label
+    bad('a@.com'); // empty leading label
+    bad('a@b..c'); // consecutive dots -> empty label
+    bad('a b@c.com'); // whitespace in local part
+  });
+
+  it('validates an email in linear time (no ReDoS on adversarial input)', () => {
+    // Overlapping-quantifier email regexes backtrack polynomially on a long
+    // run of domain-ish chars with no valid terminator. This must stay fast.
+    const attack = `a@${'a'.repeat(50_000)}${'.'.repeat(50_000)}!`;
+    const start = performance.now();
+    expect(() =>
+      evaluateValidationRules(schema({ field: 'email', format: 'email' }), { email: attack }, 'insert'),
+    ).toThrow(ValidationError);
+    expect(performance.now() - start).toBeLessThan(1_000);
+  });
+
   it('validates url / phone / json named formats', () => {
     expect(() => evaluateValidationRules(schema({ field: 'site', format: 'url' }), { site: 'nope' }, 'insert')).toThrow(ValidationError);
     expect(() => evaluateValidationRules(schema({ field: 'site', format: 'url' }), { site: 'https://x.io' }, 'insert')).not.toThrow();

--- a/packages/objectql/src/validation/rule-validator.ts
+++ b/packages/objectql/src/validation/rule-validator.ts
@@ -530,7 +530,11 @@ function checkPredicate(
   return null;
 }
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// Linear-time email check. Domain labels exclude '.', so the quantifiers on
+// either side of each '.' can't overlap — this avoids the polynomial
+// backtracking (ReDoS) of the naive `[^\s@]+\.[^\s@]+` shape while still
+// requiring a local part, an '@', and a dotted domain.
+const EMAIL_RE = /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/;
 // Lenient phone matcher: optional leading +, then 7–20 digits with spaces,
 // dashes, dots and parens allowed as separators. Intentionally permissive —
 // strict national formats belong in a `regex`.

--- a/packages/plugins/plugin-email/src/email-service.ts
+++ b/packages/plugins/plugin-email/src/email-service.ts
@@ -26,7 +26,10 @@ export interface EmailPersistence {
  * Naive RFC-5322 validator — good enough to catch obvious typos.
  * Defers full validation to the transport / receiving MTA.
  */
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// Linear-time email check. Domain labels exclude '.', so the quantifiers on
+// either side of each '.' can't overlap — this avoids the polynomial
+// backtracking (ReDoS) of the naive `[^\s@]+\.[^\s@]+` shape.
+const EMAIL_REGEX = /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/;
 
 /**
  * Format an EmailAddress (string or {name,address}) into the canonical


### PR DESCRIPTION
## Summary

Fixes the CodeQL **polynomial regex (ReDoS)** finding (#2681) in the email
validators.

All three copies of the email pattern used:

```
/^[^\s@]+@[^\s@]+\.[^\s@]+$/
```

Because the literal `.` is itself a member of `[^\s@]`, the quantifiers on
either side of `\.` overlap, so the engine backtracks **polynomially** on
adversarial input (a long run of domain-ish characters with no valid
terminator).

The domain part is rewritten so labels exclude `.`:

```
/^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/
```

Now the quantifiers around each dot no longer overlap and matching is
**linear**. Semantics are preserved for valid addresses (local part `@`
dotted domain; multi-label domains like `a@b.co.uk` still accepted). The
only behavioural change is that consecutive dots — an empty, invalid label
such as `a@b..c` — are now correctly rejected.

## Changes

- `packages/objectql/src/validation/record-validator.ts` — `EMAIL_RE`
- `packages/objectql/src/validation/rule-validator.ts` — `EMAIL_RE`
- `packages/plugins/plugin-email/src/email-service.ts` — `EMAIL_REGEX`
  (same pattern, same vulnerability — fixed for consistency)
- `packages/objectql/src/validation/rule-validator.test.ts` — new tests
  for multi-label domains, empty-label rejection, and a linear-time
  (no-ReDoS) adversarial-input guard.

## Verification

- `objectql` validator suites: **48 passing** (incl. new tests)
- `plugin-email` suites: **61 passing**
- `objectql` builds cleanly (ESM/CJS/DTS)
- Direct timing check: the new pattern runs linearly on 50k+ adversarial
  input where the old one backtracks.

Note: `content/docs/protocol/objectui/concept.mdx` shows the old pattern as
an illustrative example only (docs, not shipped code) and is intentionally
left unchanged. `service-messaging/recipient-resolver.ts` already uses a
hand-rolled linear check and documents this exact concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CajRFHqgkDMjV6xxDKbPec

---
_Generated by [Claude Code](https://claude.ai/code/session_01CajRFHqgkDMjV6xxDKbPec)_