### PR TITLE
feat(security): ADR-0090 P2 — everyone/guest audience anchors, additive baseline, anchor binding gate

### DIFF
--- a/.changeset/adr-0090-p2-audience-anchors.md
+++ b/.changeset/adr-0090-p2-audience-anchors.md
@@ -1,0 +1,25 @@
+---
+'@objectstack/spec': minor
+'@objectstack/core': minor
+'@objectstack/runtime': minor
+'@objectstack/plugin-security': minor
+---
+
+ADR-0090 P2 — audience anchors: `everyone`/`guest` builtin positions.
+
+- `EVERYONE_POSITION` / `GUEST_POSITION` constants in `@objectstack/spec`;
+  both anchors seeded (system-managed) alongside the builtin identity names.
+- Every authenticated principal implicitly holds `everyone` in
+  `ctx.positions`, so sets bound to it resolve as ordinary position-bound
+  grants — ADDITIVE. The fallback CLIFF is abolished: the configured
+  baseline (`fallbackPermissionSet`, default `member_default`) now applies
+  in addition to explicit grants instead of only when the user had none,
+  and is also seeded as an `everyone` binding (same table/audit/explain
+  path as admin-authored defaults).
+- Sessionless HTTP principals resolve as `principalKind: 'guest'` holding
+  exactly `['guest']`; internal bare contexts are untouched.
+- Audience-anchor binding gate: `sys_position_permission_set` writes that
+  would bind a high-privilege set (VAMA, delete/purge/transfer, system
+  permissions, `'*'` wildcard) to `everyone`/`guest` are rejected at the
+  data layer, unconditionally (`describeHighPrivilegeBits` predicate is
+  exported and shared with the seed-time validation).

--- a/packages/core/src/security/resolve-authz-context.test.ts
+++ b/packages/core/src/security/resolve-authz-context.test.ts
@@ -169,3 +169,24 @@ describe('resolveLocalizationContext — batched fallback read (#2409)', () => {
     expect(loc.currency).toBeUndefined();
   });
 });
+
+describe('audience anchors in the resolver (ADR-0090 D5)', () => {
+  it('every authenticated principal implicitly holds `everyone` (additive, no cliff)', async () => {
+    const ql = makeQl({
+      sys_member: [{ user_id: 'u1', role: 'member', organization_id: 'o1' }],
+      sys_user_position: [{ user_id: 'u1', position: 'contributor', organization_id: null }],
+    });
+    const ctx = await resolveAuthzContext({ ql, headers: H(), getSession: session('u1', { org: 'o1' }) });
+    // holding an explicit position must NOT cost the baseline anchor
+    expect(ctx.positions).toContain('contributor');
+    expect(ctx.positions).toContain('everyone');
+  });
+
+  it('anonymous resolution never gains `everyone`', async () => {
+    const ql = makeQl({});
+    const ctx = await resolveAuthzContext({ ql, headers: H(), getSession: async () => undefined });
+    expect(ctx.positions).not.toContain('everyone');
+    expect(ctx.userId).toBeUndefined();
+  });
+});
+

--- a/packages/core/src/security/resolve-authz-context.ts
+++ b/packages/core/src/security/resolve-authz-context.ts
@@ -204,6 +204,12 @@ export async function resolveAuthzContext(input: ResolveAuthzInput): Promise<Res
   );
   let hasPlatformAdminGrant = false;
 
+  // 5b. [ADR-0090 D5] Audience anchor: every AUTHENTICATED member implicitly
+  //     holds the built-in `everyone` position, so sets bound to it resolve
+  //     below exactly like any other position-bound grant — ADDITIVE, with no
+  //     "only when the user has nothing else" cliff.
+  if (!ctx.positions.includes('everyone')) ctx.positions.push('everyone');
+
   // 6a. Position-bound permission sets (sys_position_permission_set): a position
   //     carries its permission sets.
   if (ctx.positions.length > 0) {

--- a/packages/plugins/plugin-security/src/audience-anchors.test.ts
+++ b/packages/plugins/plugin-security/src/audience-anchors.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+// ADR-0090 D5/D9 — audience anchors: everyone/guest seeding and the
+// high-privilege binding gate.
+
+import { describe, it, expect } from 'vitest';
+import { bootstrapBuiltinRoles } from './bootstrap-builtin-positions';
+import { describeHighPrivilegeBits } from './security-plugin';
+
+function makeQl() {
+  const tables: Record<string, any[]> = { sys_position: [] };
+  return {
+    tables,
+    async find(object: string, opts: any) {
+      const where = opts?.where ?? {};
+      return (tables[object] ?? []).filter((r) =>
+        Object.entries(where).every(([k, v]) => (r as any)[k] === v),
+      );
+    },
+    async insert(object: string, data: any) {
+      (tables[object] ??= []).push(data);
+      return data;
+    },
+    async update(object: string, data: any) {
+      const t = tables[object] ?? [];
+      const i = t.findIndex((r) => r.id === data.id);
+      if (i >= 0) t[i] = { ...t[i], ...data };
+      return t[i];
+    },
+  } as any;
+}
+
+describe('audience anchors (ADR-0090 D5/D9)', () => {
+  it('seeds everyone and guest alongside the builtin identity names', async () => {
+    const ql = makeQl();
+    const res = await bootstrapBuiltinRoles(ql);
+    const names = ql.tables.sys_position.map((r: any) => r.name);
+    expect(names).toEqual(
+      expect.arrayContaining(['platform_admin', 'org_owner', 'org_admin', 'org_member', 'everyone', 'guest']),
+    );
+    expect(res.seeded).toBe(6);
+    // system-managed, undeletable posture
+    for (const r of ql.tables.sys_position) expect(r.managed_by).toBe('system');
+  });
+
+  it('re-seed is idempotent (updates, no duplicates)', async () => {
+    const ql = makeQl();
+    await bootstrapBuiltinRoles(ql);
+    const res2 = await bootstrapBuiltinRoles(ql);
+    expect(res2.seeded).toBe(0);
+    expect(ql.tables.sys_position.filter((r: any) => r.name === 'everyone')).toHaveLength(1);
+  });
+});
+
+describe('describeHighPrivilegeBits (anchor-binding predicate)', () => {
+  it('flags VAMA, destructive bits, wildcards and system permissions', () => {
+    expect(describeHighPrivilegeBits({ objects: { a: { viewAllRecords: true } } })).toMatch(/View\/Modify All/);
+    expect(describeHighPrivilegeBits({ objects: { a: { modifyAllRecords: true } } })).toMatch(/View\/Modify All/);
+    expect(describeHighPrivilegeBits({ objects: { a: { allowDelete: true } } })).toMatch(/delete\/purge\/transfer/);
+    expect(describeHighPrivilegeBits({ objects: { a: { allowPurge: true } } })).toMatch(/delete\/purge\/transfer/);
+    expect(describeHighPrivilegeBits({ objects: { a: { allowTransfer: true } } })).toMatch(/delete\/purge\/transfer/);
+    expect(describeHighPrivilegeBits({ objects: { '*': { allowRead: true } } })).toMatch(/wildcard/);
+    expect(describeHighPrivilegeBits({ systemPermissions: ['manage_users'], objects: {} })).toMatch(/system permissions/);
+  });
+
+  it('accepts a low-privilege self-service set (the intended anchor shape)', () => {
+    expect(
+      describeHighPrivilegeBits({
+        objects: { crm_account: { allowRead: true }, helpdesk_ticket: { allowCreate: true, allowRead: true, allowEdit: true } },
+      }),
+    ).toBeNull();
+  });
+
+  it('reads the sys_permission_set ROW shape too (JSON string columns, snake_case)', () => {
+    expect(describeHighPrivilegeBits({ objects: JSON.stringify({ a: { modifyAllRecords: true } }) })).toMatch(/View\/Modify All/);
+    expect(describeHighPrivilegeBits({ system_permissions: ['setup.access'] })).toMatch(/system permissions/);
+    expect(describeHighPrivilegeBits({ objects: JSON.stringify({ a: { allowRead: true } }) })).toBeNull();
+  });
+});

--- a/packages/plugins/plugin-security/src/bootstrap-builtin-positions.ts
+++ b/packages/plugins/plugin-security/src/bootstrap-builtin-positions.ts
@@ -17,7 +17,26 @@
  * the platform-admin and declared-role bootstraps.
  */
 
-import { BUILTIN_IDENTITY_NAMES, BUILTIN_IDENTITY_METADATA } from '@objectstack/spec';
+import { BUILTIN_IDENTITY_NAMES, BUILTIN_IDENTITY_METADATA, EVERYONE_POSITION, GUEST_POSITION } from '@objectstack/spec';
+
+/**
+ * [ADR-0090 D5/D9] Audience anchors seeded alongside the identity names.
+ * `everyone` — implicit for every authenticated member; its bindings are the
+ * tenant's default grants. `guest` — implicit for unauthenticated principals.
+ * Both are system-managed and undeletable like the identity rows.
+ */
+const AUDIENCE_ANCHOR_METADATA: Record<string, { label: string; description: string }> = {
+  [EVERYONE_POSITION]: {
+    label: 'Everyone',
+    description:
+      'Built-in audience anchor: every authenticated member holds this position implicitly. Permission sets bound to it are the default grants for the tenant (ADR-0090 D5). High-privilege sets cannot be bound here.',
+  },
+  [GUEST_POSITION]: {
+    label: 'Guest',
+    description:
+      'Built-in audience anchor: unauthenticated principals hold this position implicitly and exclusively. Bindings face the strictest checks — named objects only, read-mostly, never a wildcard (ADR-0090 D9).',
+  },
+};
 
 const SYSTEM_CTX = { isSystem: true };
 
@@ -53,19 +72,22 @@ export async function bootstrapBuiltinRoles(
   }
   let seeded = 0;
   let updated = 0;
-  for (const name of BUILTIN_IDENTITY_NAMES) {
-    const meta = BUILTIN_IDENTITY_METADATA[name];
+  const rows: Array<[string, { label: string; description: string }]> = [
+    ...BUILTIN_IDENTITY_NAMES.map((n) => [n, BUILTIN_IDENTITY_METADATA[n]] as [string, { label: string; description: string }]),
+    ...Object.entries(AUDIENCE_ANCHOR_METADATA),
+  ];
+  for (const [name, meta] of rows) {
     const fields = { label: meta.label, description: meta.description, managed_by: 'system' };
     const existing = await tryFind(ql, 'sys_position', { name }, 1);
     if (existing[0]?.id) {
       if (await tryUpdate(ql, 'sys_position', { id: existing[0].id, ...fields })) updated += 1;
     } else {
       const created = await tryInsert(ql, 'sys_position', {
-        id: genId('role'), name, ...fields, active: true, is_default: false,
+        id: genId('position'), name, ...fields, active: true, is_default: false,
       });
       if (created) seeded += 1;
     }
   }
-  options.logger?.info?.('[security] built-in identity roles seeded into sys_position', { seeded, updated, total: BUILTIN_IDENTITY_NAMES.length });
+  options.logger?.info?.('[security] built-in identity names + audience anchors seeded into sys_position', { seeded, updated, total: rows.length });
   return { seeded, updated };
 }

--- a/packages/plugins/plugin-security/src/objects/default-permission-sets.ts
+++ b/packages/plugins/plugin-security/src/objects/default-permission-sets.ts
@@ -304,17 +304,26 @@ export const defaultPermissionSets: PermissionSet[] = [
       // verified against the target row before the mutation). Objects that
       // model transferable ownership with a dedicated owner field should
       // override these with a per-object policy.
+      // [ADR-0090 P2] Applicability domain made EXPLICIT: with the baseline
+      // resolving additively for every authenticated principal (the
+      // `everyone` anchor — no more fallback cliff), these members-only
+      // write restrictions must say who they bind. `org_member` is the
+      // rank-and-file membership identity; org admins/owners and platform
+      // admins are outside the domain, matching the pre-anchor behavior
+      // where they simply never resolved this set.
       {
         name: 'owner_only_writes',
         object: '*',
         operation: 'update',
         using: 'created_by == current_user.id',
+        positions: ['org_member'],
       },
       {
         name: 'owner_only_deletes',
         object: '*',
         operation: 'delete',
         using: 'created_by == current_user.id',
+        positions: ['org_member'],
       },
       // ── better-auth system tables that lack `organization_id` and would
       //    otherwise be left unprotected by the wildcard rule above. ────

--- a/packages/plugins/plugin-security/src/rls-compiler.ts
+++ b/packages/plugins/plugin-security/src/rls-compiler.ts
@@ -277,7 +277,9 @@ export class RLSCompiler {
   getApplicablePolicies(
     objectName: string,
     operation: string,
-    allPolicies: RowLevelSecurityPolicy[]
+    allPolicies: RowLevelSecurityPolicy[],
+    /** [ADR-0090 P2] Caller's held positions — enforces the policy `positions` applicability domain (formerly an unenforced property; ADR-0049 enforce-or-remove). */
+    heldPositions?: string[],
   ): RowLevelSecurityPolicy[] {
     // Map engine operation to RLS operation type
     const rlsOp = this.mapOperationToRLS(operation);
@@ -285,6 +287,18 @@ export class RLSCompiler {
     return allPolicies.filter(policy => {
       // Check object match
       if (policy.object !== objectName && policy.object !== '*') return false;
+
+      // [ADR-0090 P2] Applicability domain: a policy that declares
+      // `positions` applies only to callers holding one of them. With the
+      // `everyone` anchor making the baseline set resolve for ALL
+      // authenticated principals, this domain is what keeps a
+      // members-only restriction (e.g. owner-scoped writes, #1985) from
+      // handcuffing admins who resolve the baseline additively.
+      const domain = (policy as { positions?: string[] }).positions;
+      if (Array.isArray(domain) && domain.length > 0) {
+        const held = heldPositions ?? [];
+        if (!domain.some((d) => held.includes(d))) return false;
+      }
 
       // Check operation match
       if (policy.operation === 'all') return true;

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -127,6 +127,29 @@ export interface SecurityPluginOptions {
  * - objectql service (ObjectQL engine with middleware support)
  * - metadata service (MetadataFacade for reading permission sets and RLS policies)
  */
+/**
+ * [ADR-0090 D5/D9] Does a permission-set definition (authored shape OR
+ * sys_permission_set row shape with JSON-ish columns) carry bits too
+ * dangerous for an audience anchor? Returns a human-readable description of
+ * the first offending bit, or null when the set is anchor-safe.
+ */
+export function describeHighPrivilegeBits(def: any): string | null {
+  if (!def || typeof def !== 'object') return null;
+  const sys = def.systemPermissions ?? def.system_permissions;
+  if (Array.isArray(sys) && sys.length > 0) return 'system permissions';
+  let objects: any = def.objects;
+  if (typeof objects === 'string') { try { objects = JSON.parse(objects); } catch { objects = undefined; } }
+  if (objects && typeof objects === 'object') {
+    for (const [objName, rawPerm] of Object.entries(objects)) {
+      const p: any = rawPerm ?? {};
+      if (p.viewAllRecords || p.modifyAllRecords) return `View/Modify All Data on '${objName}'`;
+      if (p.allowDelete || p.allowPurge || p.allowTransfer) return `delete/purge/transfer on '${objName}'`;
+      if (objName === '*') return "a '*' wildcard grant";
+    }
+  }
+  return null;
+}
+
 export class SecurityPlugin implements Plugin {
   name = 'com.objectstack.security';
   type = 'standard';
@@ -410,6 +433,14 @@ export class SecurityPlugin implements Plugin {
       // already short-circuited the whole middleware above, so the seeder and
       // the publish materializer pass straight through.
       await this.assertPackageManagedWriteGate(opCtx);
+
+      // [ADR-0090 D5/D9] Audience-anchor binding guard — like the package
+      // gate above, an unconditional data-layer boundary: a permission set
+      // carrying high-privilege bits must never be bound to the `everyone`
+      // or `guest` positions, no matter who asks. (Boot/system writes carry
+      // `isSystem` and short-circuited above; the dev-mode default binding
+      // is validated at seed time by the same predicate.)
+      await this.assertAudienceAnchorBindingGate(opCtx);
 
       const roles = opCtx.context?.positions ?? [];
       const explicitPermissionSets = opCtx.context?.permissions ?? [];
@@ -844,6 +875,45 @@ export class SecurityPlugin implements Plugin {
         } catch (e) {
           ctx.logger.warn('[security] declared-permission seeding failed', { error: (e as Error).message });
         }
+
+        // [ADR-0090 D5] Bind the configured baseline set to the `everyone`
+        // audience anchor (idempotent). This makes the CLI/dev fallback
+        // (`fallbackPermissionSet` — the app's `isDefault` suggestion) visible
+        // as an ordinary position binding: same table, same audit path, same
+        // explain surface as any admin-authored default grant. The binding is
+        // validated with the SAME high-privilege predicate the write gate
+        // enforces — a dangerous baseline is refused loudly, never seeded.
+        try {
+          if (this.fallbackPermissionSet) {
+            const boot = this.bootstrapPermissionSets.find((p) => p.name === this.fallbackPermissionSet);
+            const offending = boot ? describeHighPrivilegeBits(boot) : null;
+            if (offending) {
+              ctx.logger.warn('[security] refusing to bind fallback set to everyone — high-privilege bits', {
+                set: this.fallbackPermissionSet, offending,
+              });
+            } else {
+              const everyoneRows = await ql.find('sys_position', { where: { name: 'everyone' }, limit: 1, context: { isSystem: true } });
+              const everyone: any = Array.isArray(everyoneRows) && everyoneRows[0] ? everyoneRows[0] : null;
+              const setRows = await ql.find('sys_permission_set', { where: { name: this.fallbackPermissionSet }, limit: 1, context: { isSystem: true } });
+              const set: any = Array.isArray(setRows) && setRows[0] ? setRows[0] : null;
+              if (everyone?.id && set?.id) {
+                const existing = await ql.find('sys_position_permission_set', {
+                  where: { position_id: everyone.id, permission_set_id: set.id }, limit: 1, context: { isSystem: true },
+                });
+                if (!(Array.isArray(existing) && existing[0])) {
+                  await ql.insert('sys_position_permission_set', {
+                    id: `pps_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`,
+                    position_id: everyone.id,
+                    permission_set_id: set.id,
+                  }, { context: { isSystem: true } });
+                  ctx.logger.info('[security] baseline set bound to everyone anchor (ADR-0090 D5)', { set: this.fallbackPermissionSet });
+                }
+              }
+            }
+          }
+        } catch (e) {
+          ctx.logger.warn('[security] everyone-anchor baseline binding failed (non-fatal)', { error: (e as Error).message });
+        }
         // [ADR-0086 P2 — 块1] Register the publish-time materializer so a
         // permission set authored/edited through the PACKAGE door (saved as a
         // `permission` draft, then published) lands in sys_permission_set with
@@ -1067,13 +1137,17 @@ export class SecurityPlugin implements Plugin {
   private async resolvePermissionSetsForContext(
     context: any,
   ): Promise<PermissionSet[]> {
-    const roles = context?.positions ?? [];
+    const positions = context?.positions ?? [];
     const explicitPermissionSets = context?.permissions ?? [];
-    const requested = [...roles, ...explicitPermissionSets];
-    // Implicit baseline: an authenticated request that named no roles/perms
-    // still gets the configured baseline (default `member_default`) so tenant +
-    // owner RLS apply before an admin assigns a profile.
-    if (requested.length === 0 && context?.userId && this.fallbackPermissionSet) {
+    const requested = [...positions, ...explicitPermissionSets];
+    // [ADR-0090 D5] Baseline is ADDITIVE, always: the configured baseline set
+    // (default `member_default`) applies to every authenticated request IN
+    // ADDITION to whatever else resolved. The former "only when the user has
+    // nothing else" conditional was the fallback CLIFF — receiving your first
+    // explicit grant silently cost you the entire baseline. The `everyone`
+    // audience anchor carries the same semantics for admin-authored defaults;
+    // this keeps the CLI-configured baseline coherent with it.
+    if (context?.userId && this.fallbackPermissionSet && !requested.includes(this.fallbackPermissionSet)) {
       requested.push(this.fallbackPermissionSet);
     }
     let permissionSets = await this.permissionEvaluator.resolvePermissionSets(
@@ -1122,6 +1196,57 @@ export class SecurityPlugin implements Plugin {
    * here (the middleware short-circuits on `isSystem`), so the seeder and the
    * publish materializer are unaffected.
    */
+  /**
+   * [ADR-0090 D5/D9] Reject binding a HIGH-PRIVILEGE permission set to an
+   * audience anchor (`everyone` / `guest`). The anchors are implicit for
+   * whole principal classes, so a dangerous binding here is an instant
+   * tenant-wide (or anonymous-wide) grant — the one shape the model must
+   * make unrepresentable rather than merely discouraged.
+   */
+  private async assertAudienceAnchorBindingGate(opCtx: any): Promise<void> {
+    if (opCtx?.object !== 'sys_position_permission_set') return;
+    if (!['insert', 'update'].includes(opCtx.operation)) return;
+    const rows = Array.isArray(opCtx.data)
+      ? opCtx.data
+      : (opCtx.data && typeof opCtx.data === 'object' ? [opCtx.data] : []);
+    if (rows.length === 0) return;
+
+    const ql = this.ql;
+    for (const row of rows) {
+      const positionId = (row as any)?.position_id;
+      if (!positionId || !ql?.find) continue;
+      let positionName = '';
+      try {
+        const posRows = await ql.find('sys_position', { where: { id: positionId }, limit: 1, context: { isSystem: true } });
+        positionName = String((Array.isArray(posRows) && posRows[0] ? (posRows[0] as any).name : '') ?? '');
+      } catch { positionName = ''; }
+      if (positionName !== 'everyone' && positionName !== 'guest') continue;
+
+      // Resolve the target set definition (bootstrap sets by name, else the
+      // sys_permission_set row itself carries the authored definition).
+      const setId = (row as any)?.permission_set_id;
+      let setName = '';
+      let setDef: any = null;
+      try {
+        const setRows = await ql.find('sys_permission_set', { where: { id: setId }, limit: 1, context: { isSystem: true } });
+        const sr: any = Array.isArray(setRows) && setRows[0] ? setRows[0] : null;
+        if (sr) {
+          setName = String(sr.name ?? '');
+          setDef = sr;
+        }
+      } catch { /* fall through to bootstrap lookup below */ }
+      const boot = this.bootstrapPermissionSets.find((p) => p.name === setName);
+      const offending = describeHighPrivilegeBits(boot ?? setDef);
+      if (offending) {
+        throw new PermissionDeniedError(
+          `[Security] Access denied: permission set '${setName || setId}' cannot be bound to the '${positionName}' audience anchor — it carries ${offending} (ADR-0090 D5/D9). ` +
+            `Audience anchors accept low-privilege sets only; grant powerful sets through ordinary positions instead.`,
+          { operation: opCtx.operation, object: opCtx.object, position: positionName, permissionSet: setName || setId },
+        );
+      }
+    }
+  }
+
   private async assertPackageManagedWriteGate(opCtx: any): Promise<void> {
     if (opCtx?.object !== 'sys_permission_set') return;
     const op = opCtx.operation;

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -1359,7 +1359,7 @@ export class SecurityPlugin implements Plugin {
         : this.permissionEvaluator.hasSuperuserReadBypass(object, permissionSets, { isPrivate: meta.isPrivate });
       if (bypass) return null;
     }
-    const allRlsPolicies = this.collectRLSPolicies(permissionSets, object, operation);
+    const allRlsPolicies = this.collectRLSPolicies(permissionSets, object, operation, (context?.positions ?? []) as string[]);
     if (allRlsPolicies.length === 0) return null;
     // Field-existence safety: wildcard policies (`object: '*'`) target fields
     // like `organization_id` that may not exist on every object. Treat such a
@@ -1573,7 +1573,8 @@ export class SecurityPlugin implements Plugin {
   private collectRLSPolicies(
     permissionSets: PermissionSet[],
     objectName: string,
-    operation: string
+    operation: string,
+    heldPositions?: string[],
   ): RowLevelSecurityPolicy[] {
     const allPolicies: RowLevelSecurityPolicy[] = [];
 
@@ -1602,7 +1603,7 @@ export class SecurityPlugin implements Plugin {
       }
     }
 
-    return this.rlsCompiler.getApplicablePolicies(objectName, operation, allPolicies);
+    return this.rlsCompiler.getApplicablePolicies(objectName, operation, allPolicies, heldPositions);
   }
 
   /**

--- a/packages/runtime/src/security/resolve-execution-context.test.ts
+++ b/packages/runtime/src/security/resolve-execution-context.test.ts
@@ -127,7 +127,9 @@ describe('resolveExecutionContext — API key verify path', () => {
     const ctx = await resolveExecutionContext(makeOpts([], {}));
     expect(ctx.userId).toBeUndefined();
     expect(ctx.isSystem).toBe(false);
-    expect(ctx.positions).toEqual([]);
+    // ADR-0090 D9: a sessionless HTTP principal is a guest — it holds the
+    // built-in guest position implicitly (and exclusively).
+    expect(ctx.positions).toEqual(['guest']);
     expect(ctx.permissions).toEqual([]);
   });
 
@@ -331,3 +333,23 @@ describe('resolveExecutionContext — platform-scoped (null-org) grants (ADR-006
     expect(ctx.systemPermissions).not.toContain('should_not_appear');
   });
 });
+
+describe('principal taxonomy at the HTTP entry (ADR-0090 D9/D10)', () => {
+  it('a sessionless request resolves as a guest principal holding only the guest position', async () => {
+    const ctx = await resolveExecutionContext(makeOpts([], {}));
+    expect(ctx.principalKind).toBe('guest');
+    expect(ctx.positions).toEqual(['guest']);
+    expect(ctx.userId).toBeUndefined();
+    expect(ctx.isSystem).toBe(false);
+  });
+
+  it('an authenticated (API-key) request resolves as a human principal, never guest', async () => {
+    const raw = 'osk_p2_anchor_test';
+    const rows = [{ id: 'k1', key: hashApiKey(raw), revoked: false, user_id: 'u9', expires_at: FUTURE }];
+    const ctx = await resolveExecutionContext(makeOpts(rows, { 'x-api-key': raw }));
+    expect(ctx.principalKind).toBe('human');
+    expect(ctx.userId).toBe('u9');
+    expect(ctx.positions).not.toContain('guest');
+  });
+});
+

--- a/packages/runtime/src/security/resolve-execution-context.ts
+++ b/packages/runtime/src/security/resolve-execution-context.ts
@@ -82,6 +82,18 @@ export async function resolveExecutionContext(opts: ResolveOptions): Promise<Exe
     systemPermissions: authz.systemPermissions,
     isSystem: false,
   };
+  // [ADR-0090 D9/D10] Principal taxonomy at the HTTP entry: a session-backed
+  // request is a human principal; a sessionless one is a guest, holding the
+  // built-in `guest` position implicitly and exclusively. Internal engine
+  // calls that construct bare contexts are untouched (they never pass
+  // through this resolver), so the security plugin's empty-context skip
+  // path keeps its meaning.
+  if (authz.userId) {
+    ctx.principalKind = 'human';
+  } else {
+    ctx.principalKind = 'guest';
+    ctx.positions = ['guest'];
+  }
   if (authz.userId) ctx.userId = authz.userId;
   if (authz.tenantId) ctx.tenantId = authz.tenantId;
   if (authz.email) ctx.email = authz.email;

--- a/packages/spec/api-surface.json
+++ b/packages/spec/api-surface.json
@@ -1,6 +1,7 @@
 {
   ".": [
     "ADMIN_FULL_ACCESS (const)",
+    "AUDIENCE_ANCHOR_POSITIONS (const)",
     "Agent (type)",
     "BUILTIN_IDENTITY_METADATA (const)",
     "BUILTIN_IDENTITY_NAMES (const)",
@@ -17,6 +18,7 @@
     "DatasourceMappingRule (type)",
     "DatasourceMappingRuleSchema (const)",
     "DefineStackOptions (interface)",
+    "EVERYONE_POSITION (const)",
     "EvalUser (type)",
     "EvalUserInput (type)",
     "EvalUserSchema (const)",
@@ -30,6 +32,7 @@
     "ExpressionMetaSchema (const)",
     "ExpressionSchema (const)",
     "F (const)",
+    "GUEST_POSITION (const)",
     "MAP_SUPPORTED_FIELDS (const)",
     "METADATA_ALIASES (const)",
     "MapSupportedField (type)",
@@ -4165,6 +4168,7 @@
   ],
   "./identity": [
     "ADMIN_FULL_ACCESS (const)",
+    "AUDIENCE_ANCHOR_POSITIONS (const)",
     "AUTH_CONSTANTS (const)",
     "AUTH_ERROR_CODES (const)",
     "Account (type)",
@@ -4181,9 +4185,11 @@
     "BUILTIN_IDENTITY_ORG_OWNER (const)",
     "BUILTIN_IDENTITY_PLATFORM_ADMIN (const)",
     "BuiltinIdentityName (type)",
+    "EVERYONE_POSITION (const)",
     "EvalUser (type)",
     "EvalUserInput (type)",
     "EvalUserSchema (const)",
+    "GUEST_POSITION (const)",
     "Invitation (type)",
     "InvitationSchema (const)",
     "InvitationStatus (type)",

--- a/packages/spec/src/identity/position.zod.ts
+++ b/packages/spec/src/identity/position.zod.ts
@@ -48,6 +48,18 @@ export const PositionSchema = lazySchema(() => z.object({
   description: z.string().optional(),
 }));
 
+/**
+ * [ADR-0090 D5/D9] Built-in AUDIENCE ANCHOR positions. `everyone` is held
+ * implicitly by every authenticated org member — sets bound to it are the
+ * tenant's default grants (resolved per-request; additive, no fallback
+ * cliff). `guest` is held implicitly (and exclusively) by unauthenticated
+ * principals; its bindings face the strictest lint tier. Packages SUGGEST
+ * bindings to these anchors at install time — never auto-bind.
+ */
+export const EVERYONE_POSITION = 'everyone';
+export const GUEST_POSITION = 'guest';
+export const AUDIENCE_ANCHOR_POSITIONS = [EVERYONE_POSITION, GUEST_POSITION] as const;
+
 export type Position = z.infer<typeof PositionSchema>;
 /** Authoring input for {@link Position} — defaulted fields are optional. */
 export type PositionInput = z.input<typeof PositionSchema>;

--- a/packages/spec/src/index.ts
+++ b/packages/spec/src/index.ts
@@ -88,7 +88,7 @@ export { defineSkill } from './ai/skill.zod';
 export { defineDatasource } from './data/datasource.zod';
 export { defineConnector } from './integration/connector.zod';
 export { defineSharingRule } from './security/sharing.zod';
-export { definePosition } from './identity/position.zod';
+export { definePosition, EVERYONE_POSITION, GUEST_POSITION, AUDIENCE_ANCHOR_POSITIONS } from './identity/position.zod';
 export { definePermissionSet } from './security/permission.zod';
 export { defineEmailTemplateDefinition } from './system/email-template.zod';
 export { defineReport } from './ui/report.zod';


### PR DESCRIPTION
Implements **ADR-0090 P2** (D5 + D9; follows #2697's P1 wave). Tracks #2696.

## What

- **Anchor constants** — `EVERYONE_POSITION` / `GUEST_POSITION` / `AUDIENCE_ANCHOR_POSITIONS` exported from `@objectstack/spec` (`identity/position.zod.ts`).
- **Seeding** — both anchors seeded system-managed alongside the four builtin identity names (`bootstrap-builtin-positions`), idempotently.
- **`everyone` is implicit for every authenticated principal** (`resolve-authz-context` pushes it before position→set resolution), so sets bound to it resolve as ordinary position-bound grants — additive, per-request, no materialized copies.
- **Fallback cliff abolished** — the configured baseline (`fallbackPermissionSet`, default `member_default`) applies **in addition to** explicit grants (the old "only when the user had nothing else" conditional meant your first real grant silently cost you the baseline). The baseline is also seeded as an `everyone` binding so it lives in the same table / audit / explain path as admin-authored defaults — validated by the same high-privilege predicate before seeding.
- **Guest principal at the HTTP entry** — a sessionless request resolves `principalKind: 'guest'` holding exactly `['guest']` (`resolve-execution-context`); internal bare contexts are untouched, so the engine's empty-context semantics keep their meaning.
- **Audience-anchor binding gate** — an unconditional data-layer boundary next to the ADR-0086 package gate: `sys_position_permission_set` writes binding a set that carries VAMA, delete/purge/transfer, system permissions, or a `'*'` wildcard to `everyone`/`guest` are rejected (`describeHighPrivilegeBits` exported and shared with seed-time validation).

## Out of scope (per ADR phasing)

Install-time suggestion prompt UI (objectui, ships with the major-13 alignment); guest-position enforcement surfaces for portals; P3 linter family / delegated admin.

## Verification

New behavior tests: anchor seeding + idempotency + predicate matrix (5, plugin-security `audience-anchors.test.ts`), everyone-additive + anonymous-never-everyone (2, core resolver), guest/human principal at the HTTP entry (2, runtime). Affected suites green locally: plugin-security 198, core 313, runtime exec-ctx 21. Full monorepo build + `--continue` test sweep running as the PR's own CI verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oLzaP8n7A3YKFmgaHWC8H

---
_Generated by [Claude Code](https://claude.ai/code/session_012oLzaP8n7A3YKFmgaHWC8H)_