### PR TITLE
fix(security): pin @better-auth/scim to 1.7.0-rc.1 (clears GHSA-j8v8-g9cx-5qf4 high)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   tar@>=2.0.0 <7.5.11: ^7.5.11
   form-data@<4.0.6: '>=4.0.6'
   undici@>=7.23.0 <7.28.0: ^7.28.0
+  '@better-auth/scim@<1.7.0-rc.1': 1.7.0-rc.1
 
 importers:
 
@@ -1295,8 +1296,8 @@ importers:
         specifier: ^1.6.23
         version: 1.6.23(127fc2f6c00e1dc42ebbf1a0bd829040)
       '@better-auth/scim':
-        specifier: ^1.6.23
-        version: 1.6.23(93112be2b6a9196dc1ab66407acf9ed0)
+        specifier: 1.7.0-rc.1
+        version: 1.7.0-rc.1(93112be2b6a9196dc1ab66407acf9ed0)
       '@better-auth/sso':
         specifier: ^1.6.23
         version: 1.6.23(127fc2f6c00e1dc42ebbf1a0bd829040)
@@ -2480,12 +2481,12 @@ packages:
       prisma:
         optional: true
 
-  '@better-auth/scim@1.6.23':
-    resolution: {integrity: sha512-I8/m2x/eEcFufNEQMM6nZqwhZrp5OdSMxL9t8EalTVAIfD3hRPz9n1kzbAYy3ArzxXJBkSZ+Os5E+k/yaxoesg==}
+  '@better-auth/scim@1.7.0-rc.1':
+    resolution: {integrity: sha512-pcnliU2eewYq2SF4cRDn1XvQ2I7+WhufoDv5lx9yH7fmrfsU6mYQpZX3mu2Fj/AFCHauCI7Ld617pnz5+yTtOw==}
     peerDependencies:
-      '@better-auth/core': ^1.6.23
+      '@better-auth/core': ^1.7.0-rc.1
       '@better-auth/utils': 0.4.2
-      better-auth: ^1.6.23
+      better-auth: ^1.7.0-rc.1
       better-call: 1.3.7
 
   '@better-auth/sso@1.6.23':
@@ -9295,7 +9296,7 @@ snapshots:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260520.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/scim@1.6.23(93112be2b6a9196dc1ab66407acf9ed0)':
+  '@better-auth/scim@1.7.0-rc.1(93112be2b6a9196dc1ab66407acf9ed0)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260520.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,9 +28,15 @@ onlyBuiltDependencies:
 #     dropped requestTls in SOCKS5 ProxyAgent. Pulled 7.27.2 through
 #     @vscode/vsce > cheerio (declares undici ^7.19.0); force the patched
 #     7.28.0 line (stays in the 7.x major cheerio supports). CI audit gate.
+#   - @better-auth/scim: GHSA-j8v8-g9cx-5qf4 (high) — account/provider
+#     takeover. `plugin-auth` depends on ^1.6.23 (the `latest` dist-tag), but
+#     the advisory is patched only in >=1.7.0-beta.4 — there is NO stable
+#     patched release yet. Pin to the newest pre-release (1.7.0-rc.1) to clear
+#     the CI audit gate; revert to a stable `^1.7.x` line the moment one ships.
 overrides:
   esbuild: '>=0.28.1'
   'minimatch@<10.2.3': '10.2.3'
   'tar@>=2.0.0 <7.5.11': '^7.5.11'
   'form-data@<4.0.6': '>=4.0.6'
   'undici@>=7.23.0 <7.28.0': '^7.28.0'
+  '@better-auth/scim@<1.7.0-rc.1': '1.7.0-rc.1'


### PR DESCRIPTION
## Problem
The CI `Validate Package Dependencies` gate (`pnpm audit --audit-level=high`) now fails on **`@better-auth/scim`** — GHSA-j8v8-g9cx-5qf4, **account/provider takeover (high)**. `plugin-auth` depends on `^1.6.23`, which is the package's `latest` dist-tag, so **`main` is on the vulnerable line too** and its audit gate fails post-disclosure. This blocks every open framework PR.

## The catch
The advisory is **patched only in `>=1.7.0-beta.4`** — there is **no stable patched release**:
```
latest = 1.6.23 (vulnerable) · newest = 1.7.0-rc.1 · dist-tags: beta=1.7.0-beta.10, rc=1.7.0-rc.1
```
So clearing the high advisory means moving to a **pre-release**. This PR is deliberately isolated so that trade-off is reviewed on its own.

## Change
Pin `@better-auth/scim` to `1.7.0-rc.1` (newest pre-release) via a `pnpm-workspace.yaml` override — the same mechanism already used for the esbuild / form-data / undici advisories.

## Verification
- `pnpm audit --audit-level=high` → **high count 0** (was `1 high`; now `2 low | 7 moderate`, gate passes).
- `@objectstack/plugin-auth` **builds** and its **full suite (230 tests) passes** against rc.1 — the SCIM API is compatible.

## Follow-up
Revert to a stable `^1.7.x` line the moment one ships (`latest` moves off 1.6.23).

**Reviewer decision**: this accepts a SCIM **release candidate** as a production dependency to close a high CVE. If you'd rather keep 1.6.23 and allowlist the advisory instead, say so and I'll swap the approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)