### PR TITLE
ci(release): restore blocking live-hotcrm smoke — v2 adoption shipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,18 +62,6 @@ jobs:
         run: bash scripts/build-console.sh
 
       - name: Downstream backward-compat smoke (live hotcrm)
-        # TEMPORARY (ADR-0090 v2 launch window) — advisory, not blocking.
-        # ADR-0090 P1 (#2697) removed the sharing recipients `role` /
-        # `role_and_subordinates` from @objectstack/spec with NO compatibility
-        # aliases (docs/adr/0090 D3 — a deliberate, launch-window break). The
-        # latest published hotcrm tag (v1.2.2) still authors those values, so
-        # this gate necessarily goes red on a break the spec took on purpose,
-        # and no adopting hotcrm release exists yet to bump HOTCRM_REF to. Keep
-        # the step running for signal, but don't let it block the v2 publish.
-        # RESTORE (make blocking again): once hotcrm ships a release adopting
-        # the v2 recipient vocabulary, bump HOTCRM_REF below to that tag and
-        # delete this `continue-on-error` line so a red here blocks publish.
-        continue-on-error: true
         # Pre-publish gate (#2035): the about-to-publish @objectstack/spec must
         # not break a real third-party consumer pinned to a published release.
         # Clones objectstack-ai/hotcrm@${HOTCRM_REF}, installs it (published
@@ -82,11 +70,12 @@ jobs:
         # The deterministic in-repo floor is @objectstack/downstream-contract;
         # this is the live ceiling.
         env:
-          # v1.2.1: hotcrm dropped the ObjectSchema `detail` block removed by
-          # ADR-0085 (hotcrm#423) — the intended break, explicitly digested
-          # downstream. Bump this ref whenever a deliberate spec surface
-          # removal ships a matching hotcrm release.
-          HOTCRM_REF: v1.2.2
+          # v2.0.0: hotcrm adopted the ADR-0090 Permission Model v2 vocabulary
+          # (role→position recipients, profiles removed, explicit OWD —
+          # hotcrm#438), closing the launch-window advisory period from #2719.
+          # Bump this ref whenever a deliberate spec surface removal ships a
+          # matching hotcrm release.
+          HOTCRM_REF: v2.0.0
         run: bash scripts/downstream-smoke.sh
 
       - name: Create Release Pull Request or Publish to npm


### PR DESCRIPTION
## What

Restores the `Downstream backward-compat smoke (live hotcrm)` step to **blocking**, executing the restore condition documented in #2719:

- `HOTCRM_REF`: `v1.2.2` → `v2.0.0` (the release adopting the ADR-0090 v2 vocabulary — objectstack-ai/hotcrm#438)
- delete the `continue-on-error: true` escape hatch and its `TEMPORARY` comment block

## ⚠️ Merge order

**Blocked on the `v2.0.0` tag existing in objectstack-ai/hotcrm** — merge hotcrm#438, tag `v2.0.0`, then merge this. Merging early makes the smoke fail on a missing ref.

Part of the ADR-0090 tracking issue #2696.

## Testing

- `release.yml` parses clean (yaml)
- hotcrm#438 was verified locally against the published 13.0.0: typecheck ✓, `objectstack validate` ✓, build incl. D7 posture check ✓, 17/17 tests ✓ — the same commands the smoke runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)