### PR TITLE
fix(spec): PROTOCOL_VERSION 12→13 — restore package-major lockstep (unbreaks main)

### DIFF
--- a/.changeset/protocol-version-13.md
+++ b/.changeset/protocol-version-13.md
@@ -1,0 +1,13 @@
+---
+'@objectstack/spec': patch
+---
+
+fix(spec): bump `PROTOCOL_VERSION` to 13.0.0 — restore lockstep with the package major
+
+The ADR-0090 P1 breaking wave took the platform to 13.0.0, but the protocol
+constant (the value the `engines.protocol` handshake compares) stayed at
+12.0.0, tripping the lockstep guard in `protocol-version.test.ts` and turning
+`Test Core` red on main for every PR. Protocol 13 is semantically correct:
+the P1 renames (`roles:` → `positions:`, kind `role`/`profile` → `position`,
+no aliases) are exactly the kind of authorable-surface break the handshake
+exists to refuse across majors.

--- a/packages/spec/src/kernel/protocol-version.ts
+++ b/packages/spec/src/kernel/protocol-version.ts
@@ -15,7 +15,7 @@
  * Kept in lockstep with the package's own major; `protocol-version.test.ts`
  * asserts it against `package.json` so the two cannot drift.
  */
-export const PROTOCOL_VERSION = '12.0.0';
+export const PROTOCOL_VERSION = '13.0.0';
 
 /** The protocol major as an integer — the value the handshake compares. */
 export const PROTOCOL_MAJOR: number = Number.parseInt(PROTOCOL_VERSION.split('.')[0]!, 10);


### PR DESCRIPTION
**Main is red**: `Test Core` fails on every PR since the 13.0.0 release (#2720) — the ADR-0090 P1 major shipped without bumping `PROTOCOL_VERSION` (still `12.0.0`), and `protocol-version.test.ts` (the lockstep guard built for exactly this) caught it.

One-line fix: `PROTOCOL_VERSION` → `13.0.0`.

Protocol 13 is semantically correct, not just test-appeasement: the P1 wave's alias-free renames (`roles:` → `positions:`, kinds `role`/`profile` → `position`, OWD legacy values dropped) are precisely the authorable-surface break the `engines.protocol` handshake exists to refuse across majors — a package authored for `^12` genuinely won't load right on 13.

Verified: spec 6672 ✓ (incl. the lockstep guard), metadata-core 100 ✓ (handshake consumer). No `^12` pins exist in examples/templates in-repo.

Unblocks #2728 and every other open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
