### PR TITLE
feat(spec)!: book audience gates by permission set — retire the { profile } arm (ADR-0090)

### DIFF
--- a/.changeset/book-audience-permission-set.md
+++ b/.changeset/book-audience-permission-set.md
@@ -1,0 +1,13 @@
+---
+'@objectstack/spec': major
+---
+
+`BookAudience` gated arm renamed: `{ profile: string }` → `{ permissionSet: string }`.
+
+ADR-0090 D2 removed the Profile concept, but `book.audience` (ADR-0046 §6.7)
+still modelled its gated arm as a profile reference. Books ship in packages,
+and packages own permission sets but never positions (ADR-0090 D9), so the
+gate is a capability reference — a permission-set name the reader must hold,
+e.g. `{ permissionSet: 'crm_admin' }`. Pre-launch one-step rename, no alias:
+the zod union now rejects `{ profile }` at parse time. `'org'` and `'public'`
+literals are unchanged (`'public'` ≡ the built-in `guest` position, D9).

--- a/content/docs/references/security/explain.mdx
+++ b/content/docs/references/security/explain.mdx
@@ -1,0 +1,136 @@
+---
+title: Explain
+description: Explain protocol schemas
+---
+
+{/* ⚠️  AUTO-GENERATED — DO NOT EDIT. Run build-docs.ts to regenerate. Hand-written docs live in the module folders under content/docs/. */}
+
+[ADR-0090 D6] Access-explanation contract — `explain(principal, object,
+
+operation)` as a first-class API.
+
+The explain engine (`@objectstack/plugin-security`) walks the SAME code
+
+paths as the enforcement middleware — the same permission-set resolution,
+
+the same evaluator, the same RLS compiler — and reports what each layer of
+
+the evaluation pipeline contributed to the final decision. "Explained by
+
+construction": the report can never drift from enforcement because it IS
+
+enforcement, minus the throw.
+
+Layer order mirrors the runtime pipeline:
+
+principal → required_permissions → object_crud → fls → owd_baseline →
+
+depth → sharing → vama_bypass → rls.
+
+<Callout type="info">
+**Source:** `packages/spec/src/security/explain.zod.ts`
+</Callout>
+
+## TypeScript Usage
+
+```typescript
+import { AccessMatrix, AccessMatrixEntry, ExplainDecision, ExplainLayer, ExplainOperation, ExplainRequest } from '@objectstack/spec/security';
+import type { AccessMatrix, AccessMatrixEntry, ExplainDecision, ExplainLayer, ExplainOperation, ExplainRequest } from '@objectstack/spec/security';
+
+// Validate data
+const result = AccessMatrix.parse(data);
+```
+
+---
+
+## AccessMatrix
+
+### Properties
+
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| **version** | `number` | ✅ |  |
+| **entries** | `Object[]` | ✅ |  |
+
+
+---
+
+## AccessMatrixEntry
+
+### Properties
+
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| **permissionSet** | `string` | ✅ |  |
+| **object** | `string` | ✅ |  |
+| **create** | `boolean` | ✅ |  |
+| **read** | `boolean` | ✅ |  |
+| **edit** | `boolean` | ✅ |  |
+| **delete** | `boolean` | ✅ |  |
+| **viewAllRecords** | `boolean` | ✅ |  |
+| **modifyAllRecords** | `boolean` | ✅ |  |
+| **readScope** | `string` | optional |  |
+| **writeScope** | `string` | optional |  |
+| **sharingModel** | `string` | optional |  |
+
+
+---
+
+## ExplainDecision
+
+### Properties
+
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| **allowed** | `boolean` | ✅ |  |
+| **object** | `string` | ✅ |  |
+| **operation** | `Enum<'read' \| 'create' \| 'update' \| 'delete' \| 'transfer' \| 'restore' \| 'purge'>` | ✅ |  |
+| **principal** | `Object` | ✅ |  |
+| **layers** | `Object[]` | ✅ |  |
+| **readFilter** | `any` | optional |  |
+
+
+---
+
+## ExplainLayer
+
+### Properties
+
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| **layer** | `Enum<'principal' \| 'required_permissions' \| 'object_crud' \| 'fls' \| 'owd_baseline' \| 'depth' \| 'sharing' \| 'vama_bypass' \| 'rls'>` | ✅ |  |
+| **verdict** | `Enum<'grants' \| 'denies' \| 'narrows' \| 'widens' \| 'neutral' \| 'not_applicable'>` | ✅ |  |
+| **detail** | `string` | ✅ |  |
+| **contributors** | `Object[]` | ✅ |  |
+
+
+---
+
+## ExplainOperation
+
+### Allowed Values
+
+* `read`
+* `create`
+* `update`
+* `delete`
+* `transfer`
+* `restore`
+* `purge`
+
+
+---
+
+## ExplainRequest
+
+### Properties
+
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| **object** | `string` | ✅ |  |
+| **operation** | `Enum<'read' \| 'create' \| 'update' \| 'delete' \| 'transfer' \| 'restore' \| 'purge'>` | ✅ |  |
+| **userId** | `string` | optional |  |
+
+
+---
+

--- a/content/docs/references/security/index.mdx
+++ b/content/docs/references/security/index.mdx
@@ -6,6 +6,7 @@ description: Complete reference for all security protocol schemas
 This section contains all protocol schemas for the security layer of ObjectStack.
 
 <Cards>
+  <Card href="/docs/references/security/explain" title="Explain" description="Source: packages/spec/src/security/explain.zod.ts" />
   <Card href="/docs/references/security/permission" title="Permission" description="Source: packages/spec/src/security/permission.zod.ts" />
   <Card href="/docs/references/security/rls" title="Rls" description="Source: packages/spec/src/security/rls.zod.ts" />
   <Card href="/docs/references/security/sharing" title="Sharing" description="Source: packages/spec/src/security/sharing.zod.ts" />

--- a/content/docs/references/security/meta.json
+++ b/content/docs/references/security/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Security Protocol",
   "pages": [
+    "explain",
     "permission",
     "rls",
     "sharing",

--- a/content/docs/references/security/permission.mdx
+++ b/content/docs/references/security/permission.mdx
@@ -24,12 +24,28 @@ Refined with enterprise data lifecycle controls:
 ## TypeScript Usage
 
 ```typescript
-import { FieldPermission, ObjectAccessScope, ObjectPermission, PermissionSet } from '@objectstack/spec/security';
-import type { FieldPermission, ObjectAccessScope, ObjectPermission, PermissionSet } from '@objectstack/spec/security';
+import { AdminScope, FieldPermission, ObjectAccessScope, ObjectPermission, PermissionSet } from '@objectstack/spec/security';
+import type { AdminScope, FieldPermission, ObjectAccessScope, ObjectPermission, PermissionSet } from '@objectstack/spec/security';
 
 // Validate data
-const result = FieldPermission.parse(data);
+const result = AdminScope.parse(data);
 ```
+
+---
+
+## AdminScope
+
+### Properties
+
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| **businessUnit** | `string` | ✅ | [ADR-0090 D12] Delegation boundary: sys_business_unit.name of the subtree root |
+| **includeSubtree** | `boolean` | ✅ | Cover descendant business units too (default true) |
+| **manageAssignments** | `boolean` | ✅ | Manage user↔position assignments within the subtree |
+| **manageBindings** | `boolean` | ✅ | Manage position↔permission-set bindings within the subtree |
+| **authorEnvironmentSets** | `boolean` | ✅ | Author environment-owned permission sets |
+| **assignablePermissionSets** | `string[]` | ✅ | Allowlist of permission-set names the delegate may hand out |
+
 
 ---
 
@@ -96,6 +112,7 @@ const result = FieldPermission.parse(data);
 | **tabPermissions** | `Record<string, Enum<'visible' \| 'hidden' \| 'default_on' \| 'default_off'>>` | optional | App/tab visibility: visible, hidden, default_on (shown by default), default_off (available but hidden initially) |
 | **rowLevelSecurity** | `Object[]` | optional | Row-level security policies (see rls.zod.ts for full spec) |
 | **contextVariables** | `Record<string, any>` | optional | Context variables for RLS evaluation |
+| **adminScope** | `Object` | optional | [ADR-0090 D12] Scoped delegated-administration grant (BU subtree + assignable-set allowlist) |
 
 
 ---

--- a/content/docs/references/system/book.mdx
+++ b/content/docs/references/system/book.mdx
@@ -94,7 +94,7 @@ Type: `string`
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **profile** | `string` | ✅ |  |
+| **permissionSet** | `string` | ✅ |  |
 
 ---
 

--- a/packages/spec/src/system/book.test.ts
+++ b/packages/spec/src/system/book.test.ts
@@ -25,9 +25,12 @@ describe('BookSchema (ADR-0046 §6)', () => {
     expect(() => BookSchema.parse({ name: 'crm_guide', groups: [{ key: 'Start', label: 'x' }] })).toThrow();
   });
   it('accepts audience variants', () => {
-    for (const audience of ['org', 'public', { profile: 'admin' }] as const) {
+    for (const audience of ['org', 'public', { permissionSet: 'crm_admin' }] as const) {
       expect(() => BookSchema.parse({ name: 'b', audience, groups: [] })).not.toThrow();
     }
+  });
+  it('rejects the removed { profile } audience shape (ADR-0090 D2)', () => {
+    expect(() => BookSchema.parse({ name: 'b', audience: { profile: 'admin' }, groups: [] })).toThrow();
   });
 });
 
@@ -151,7 +154,7 @@ describe('deriveImplicitPackageBook + audience', () => {
   it('isPublicAudience only true for public', () => {
     expect(isPublicAudience('public')).toBe(true);
     expect(isPublicAudience('org')).toBe(false);
-    expect(isPublicAudience({ profile: 'admin' })).toBe(false);
+    expect(isPublicAudience({ permissionSet: 'crm_admin' })).toBe(false);
     expect(isPublicAudience(undefined)).toBe(false);
   });
 });

--- a/packages/spec/src/system/book.zod.ts
+++ b/packages/spec/src/system/book.zod.ts
@@ -82,15 +82,22 @@ export type BookGroup = {
   pages?: BookNode[];
 };
 
-/** Access audience for a book — a reference into the permission model (ADR-0046 §6.7). */
+/**
+ * Access audience for a book — a reference into the permission model
+ * (ADR-0046 §6.7, vocabulary per ADR-0090). The gate is a capability
+ * reference (a permission-set name), never a distribution one: books ship in
+ * packages, and packages own permission sets but never positions (ADR-0090
+ * D9) — a package gating its Admin Guide to its own `crm_admin` set keeps
+ * provenance and uninstall semantics intact (ADR-0086).
+ */
 export const BookAudienceSchema = lazySchema(() =>
   z.union([
     z.literal('org'), // default — inherits the package grant (§3.6)
-    z.literal('public'), // ≡ the data-layer `guest` profile (anonymous, indexable)
-    z.object({ profile: z.string() }), // role-gated, e.g. { profile: 'admin' }
+    z.literal('public'), // ≡ the built-in `guest` position (ADR-0090 D9): anonymous, indexable
+    z.object({ permissionSet: z.string() }), // capability-gated, e.g. { permissionSet: 'crm_admin' }
   ]),
 );
-export type BookAudience = 'org' | 'public' | { profile: string };
+export type BookAudience = 'org' | 'public' | { permissionSet: string };
 
 export const BookSchema = lazySchema(() =>
   z.object({


### PR DESCRIPTION
# Summary

`BookAudienceSchema` (`packages/spec/src/system/book.zod.ts`) still modelled its gated arm as `{ profile: string }` — a reference to the Profile concept ADR-0090 D2 deleted — with pre-D3 vocabulary ("role-gated", "guest profile") in the comments. This PR retires it with a launch-window one-step rename, no aliases.

## Decision: permission set, not position

The gated arm becomes **`{ permissionSet: string }`**, a capability reference, for three reasons grounded in ADR-0090:

1. **Package ownership (D9).** Books ship in packages; packages own permission sets but **never** positions/BUs/teams — those are environment-owned. A book gating to a position name would reference an entity the package cannot know, which is exactly the environment-ownership argument (D2 #1) that removed profiles.
2. **D9's admin stance is this shape.** App-level admin is "an ordinary package set (`crm_admin`) the customer binds to a position of their own choosing" — so a CRM package's Admin Guide gates to `{ permissionSet: 'crm_admin' }`, keeping ADR-0086 provenance and uninstall semantics intact.
3. **Vocabulary axis (D3).** "Who may read this book" is a capability question; capability = `permission_set`. Positions are distribution. The two literals already map to the D9 anchors: `'org'` inherits the package grant (authenticated members), `'public'` ≡ the built-in `guest` position.

ADR-0046 §6.7 itself glossed the arm as "gates a book to a profile / permission set", so this lands on the reading that survived ADR-0090.

## Changes

- `book.zod.ts` — union arm renamed; comments rewritten to D3 vocabulary (`guest` position, capability-gated); doc comment records the D9 rationale. The zod union now **rejects** `{ profile }` at parse time (contract-first, no lenient dialect, per the D4 discipline).
- `book.test.ts` — audience variants updated; new test asserting `{ profile }` is rejected.
- `content/docs/references/**` — regenerated (`gen:schema` + `gen:docs`). This also catches up `security/*` with the `AdminScope` (D12) and `explain` (D6) shapes that landed in #2711/#2716 without a docs regen.
- Changeset: major bump for `@objectstack/spec`.

The REST read layer only evaluates `isPublicAudience` (anonymous gate), so no runtime evaluation code changes; enforcement of the gated arm remains the ADR-0046 Phase D item it already was.

## Companion PR

ObjectUI mirrors this shape in three places (metadata-admin JSON schema `oneOf`, `BookPreview` audience chip, book list-column renderer) — companion PR in objectstack-ai/objectui updates them to `{ permissionSet }`.

## Why the D3 forbidden-word lint didn't catch this

The D3 lint (`security-role-word`, `packages/lint/src/validate-security-posture.ts`, shipped in P3 #2711) validates **published stack metadata** — names/labels of objects, fields, actions, permission sets, positions, and apps. It could not have caught this because:

1. The violation lives in **spec source code** (a TS comment and a zod key), which no lint scans for the word ban — the ADR's "identifiers, UI copy, and docs" scope is enforced for metadata only; source hygiene relied on the P1 rename sweep (#2697), which was identifier-driven (`sys_role`, `isProfile`, …) and missed this file because the arm was spelled `profile`, not `role`.
2. Even as metadata, **books are not among the kinds the lint scans** — and `profile` (unlike `role`) is not a banned word, so a book authored with `{ profile: ... }` drew no finding. After this PR the schema itself rejects the shape, which is the stronger, contract-first gate.

Possible follow-ups (not in this PR): a source/docs-level `\brole\b` sweep check (e.g. `content/docs/ui/role-based-interfaces.mdx` still violates the D3 docs ban), and adding book name/label to the lint's role-word scan now that book audience is a permission-model reference. Two more D2 leftovers found in objectui's `default-schemas.ts` (`role` and `profile` metadata-type entries mirroring the framework's `metadata-form-registry.ts` `profile: permissionForm` row) are flagged in the companion PR rather than fixed, since removing them needs a coordinated registry change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ph4jEAfWDh6taMbZweWhom

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ph4jEAfWDh6taMbZweWhom)_