### PR TITLE
feat(data): enable.feeds/activities real opt-out gates + trackHistory contract (#2707)

### DIFF
--- a/.changeset/enable-capability-gates-2707.md
+++ b/.changeset/enable-capability-gates-2707.md
@@ -1,0 +1,39 @@
+---
+'@objectstack/spec': minor
+'@objectstack/plugin-audit': minor
+'@objectstack/rest': patch
+'@objectstack/cli': patch
+---
+
+feat(data): make object `enable.feeds`/`enable.activities` real opt-out gates; define the `enable.trackHistory` contract (#2707)
+
+`ObjectSchema.enable.{files,trackHistory,activities,feeds}` were parsed but
+(mostly) unconsumed — an author setting them got nothing, silently. Per the
+enforce-or-remove doctrine, each flag now has a defined enforcement contract:
+
+- `enable.activities` — opt-OUT writer gate. Spec default flips
+  `false → true`; plugin-audit keeps mirroring CRUD into the `sys_activity`
+  timeline unless the object declares an explicit `activities: false`
+  (behavior-preserving for every existing stack; the off-switch is the
+  per-object lever for activity-row growth, ADR-0057). The compliance
+  `sys_audit_log` row is NOT gated.
+- `enable.feeds` — opt-OUT with server-side enforcement. Spec default flips
+  `false → true`; an explicit `feeds: false` now rejects `sys_comment`
+  creation targeting that object at the engine hook seam
+  (403 `FEEDS_DISABLED`, fail-closed like `CLONE_DISABLED`).
+- `enable.trackHistory` — was misclassified `dead` in the liveness ledger:
+  the console has gated the record History tab on it since 2026-05.
+  Reclassified live with the two-grain contract documented (object flag =
+  History-tab master switch; per-field `trackHistory` = diff selector; audit
+  *capture* stays unconditional as a compliance ledger).
+- `enable.files` — stays dead + authorWarn (reserved for the future generic
+  Attachments panel; use `Field.file`/`Field.image` meanwhile). Its
+  `describe()` now says so instead of advertising a capability that
+  doesn't exist.
+
+The default flips can't be avoided: with `default(false)`, compiled output
+materializes `false` for every object with an `enable` block, making
+"author explicitly opted out" indistinguishable from "schema default" — so
+opt-out semantics require the default to be `true` (same posture as
+`trash`/`mru`/`clone`). Liveness ledger + reference docs regenerated;
+compile-time authorWarn now fires only for `enable.files`.

--- a/content/docs/references/data/object.mdx
+++ b/content/docs/references/data/object.mdx
@@ -77,13 +77,13 @@ const result = ApiMethod.parse(data);
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **trackHistory** | `boolean` | ✅ | Enable field history tracking for audit compliance |
+| **trackHistory** | `boolean` | ✅ | Show the record History tab (audit-trail UI). Pair with per-field trackHistory to pick which field diffs are summarized; audit capture itself is always on for compliance |
 | **searchable** | `boolean` | ✅ | Index records for global search |
 | **apiEnabled** | `boolean` | ✅ | Expose object via automatic APIs |
 | **apiMethods** | `Enum<'get' \| 'list' \| 'create' \| 'update' \| 'delete' \| 'upsert' \| 'bulk' \| 'aggregate' \| 'history' \| 'search' \| 'restore' \| 'purge' \| 'import' \| 'export'>[]` | optional | Whitelist of allowed API operations |
-| **files** | `boolean` | ✅ | Enable file attachments and document management |
-| **feeds** | `boolean` | ✅ | Enable social feed, comments, and mentions (Chatter-like) |
-| **activities** | `boolean` | ✅ | Enable standard tasks and events tracking |
+| **files** | `boolean` | ✅ | RESERVED (no runtime effect yet) — use Field.file/Field.image for attachments; this flag will gate the future generic Attachments panel |
+| **feeds** | `boolean` | ✅ | Record comments/collaboration feed. Default on; explicit false hides the feed UI and rejects new comments for this object |
+| **activities** | `boolean` | ✅ | Record activity timeline (sys_activity mirror of CRUD). Default on; explicit false stops mirroring and hides the timeline |
 | **trash** | `boolean` | ✅ | Enable soft-delete with restore capability |
 | **mru** | `boolean` | ✅ | Track Most Recently Used (MRU) list for users |
 | **clone** | `boolean` | ✅ | Allow record deep cloning |

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -250,7 +250,7 @@ export default class Compile extends Command {
 
       // 3d-bis. Liveness author-warning lint — close the spec-liveness loop on
       //     the author side: an authored property the ledger marks dead-and-
-      //     misleading (e.g. `object.enable.feeds`, `field.columnName`) or
+      //     misleading (e.g. `object.enable.files`, `field.columnName`) or
       //     experimental is set hopefully but does nothing / isn't enforced at
       //     runtime. Advisory only; ledger-driven (entries opt in via
       //     `authorWarn`), so it's high-signal and NEVER fails the build.

--- a/packages/cli/src/utils/lint-liveness-properties.test.ts
+++ b/packages/cli/src/utils/lint-liveness-properties.test.ts
@@ -9,7 +9,7 @@ import {
 /**
  * These run against the REAL ledgers shipped by `@objectstack/spec` (the same
  * files the gate enforces), so they double as a contract test: if an
- * `authorWarn` annotation is removed from `enable.feeds` / `columnName` / etc.,
+ * `authorWarn` annotation is removed from `enable.files` / `columnName` / etc.,
  * the matching assertion fails.
  */
 
@@ -18,19 +18,30 @@ const rules = (findings: { rule: string }[]) => findings.map((f) => f.rule);
 const paths = (findings: { message: string }[]) => findings.map((f) => f.message);
 
 describe('lintLivenessProperties', () => {
-  it('warns on an authored dead capability flag (enable.feeds: true)', () => {
-    const findings = lintLivenessProperties(objStack({ enable: { feeds: true } }));
+  it('warns on an authored dead capability flag (enable.files: true)', () => {
+    const findings = lintLivenessProperties(objStack({ enable: { files: true } }));
     expect(findings.length).toBeGreaterThan(0);
-    const feeds = findings.find((f) => f.message.includes('enable.feeds'));
-    expect(feeds).toBeDefined();
-    expect(feeds!.rule).toBe(LIVENESS_DEAD_PROPERTY);
-    expect(feeds!.where).toBe("object 'widget'");
-    expect(feeds!.hint.length).toBeGreaterThan(0);
+    const files = findings.find((f) => f.message.includes('enable.files'));
+    expect(files).toBeDefined();
+    expect(files!.rule).toBe(LIVENESS_DEAD_PROPERTY);
+    expect(files!.where).toBe("object 'widget'");
+    expect(files!.hint.length).toBeGreaterThan(0);
   });
 
   it('does NOT warn on a default-on flag the author left alone (enable.trash: true)', () => {
     const findings = lintLivenessProperties(objStack({ enable: { trash: true } }));
     expect(paths(findings).some((m) => m.includes('enable.trash'))).toBe(false);
+  });
+
+  // #2707: feeds/activities/trackHistory went LIVE (opt-out writer/UI gates +
+  // History-tab master switch) — authoring them must no longer warn.
+  it('does NOT warn on the now-live capability flags (feeds/activities/trackHistory)', () => {
+    const findings = lintLivenessProperties(
+      objStack({ enable: { feeds: true, activities: true, trackHistory: true } }),
+    );
+    expect(paths(findings).some((m) => m.includes('enable.feeds'))).toBe(false);
+    expect(paths(findings).some((m) => m.includes('enable.activities'))).toBe(false);
+    expect(paths(findings).some((m) => m.includes('enable.trackHistory'))).toBe(false);
   });
 
   it('does NOT warn when a dead boolean flag is explicitly false (enable.files: false)', () => {
@@ -72,7 +83,7 @@ describe('lintLivenessProperties', () => {
 
   it('handles objects as a keyed record (not just arrays)', () => {
     const findings = lintLivenessProperties({
-      objects: { widget: { name: 'widget', enable: { feeds: true } } },
+      objects: { widget: { name: 'widget', enable: { files: true } } },
     });
     expect(rules(findings)).toContain(LIVENESS_DEAD_PROPERTY);
   });

--- a/packages/plugins/plugin-audit/src/audit-writers.test.ts
+++ b/packages/plugins/plugin-audit/src/audit-writers.test.ts
@@ -294,3 +294,94 @@ describe('audit writers — declarative milestones (ADR-0052 §5b.2)', () => {
     expect(activity?.row.summary).toBe('Stage: proposal → Negotiation');
   });
 });
+
+describe('audit writers — enable.activities opt-out gate (#2707)', () => {
+  const SCHEMA = {
+    sys_audit_log: SINGLE_TENANT.sys_audit_log,
+    sys_activity: SINGLE_TENANT.sys_activity,
+    crm_lead: ['id', 'name'],
+  };
+
+  it('mirrors CRUD into sys_activity by default (absent enable block)', async () => {
+    const { engine, fire, created } = makeEngine(SCHEMA);
+    installAuditWriters(engine as any, 'test.audit');
+
+    await fire('afterInsert', {
+      object: 'crm_lead',
+      input: { id: 'lead-1' },
+      result: { id: 'lead-1', name: 'Acme' },
+      session: {},
+    });
+
+    expect(created.some((c) => c.object === 'sys_audit_log')).toBe(true);
+    expect(created.some((c) => c.object === 'sys_activity')).toBe(true);
+  });
+
+  it('skips ONLY the sys_activity mirror on explicit activities:false — audit row still written', async () => {
+    const { engine, fire, created } = makeEngine(SCHEMA, {
+      crm_lead: { enable: { activities: false } },
+    });
+    installAuditWriters(engine as any, 'test.audit');
+
+    await fire('afterInsert', {
+      object: 'crm_lead',
+      input: { id: 'lead-1' },
+      result: { id: 'lead-1', name: 'Acme' },
+      session: {},
+    });
+
+    // Compliance ledger is NOT gated by the capability flag…
+    expect(created.some((c) => c.object === 'sys_audit_log')).toBe(true);
+    // …but the timeline mirror is.
+    expect(created.some((c) => c.object === 'sys_activity')).toBe(false);
+  });
+});
+
+describe('audit writers — enable.feeds server-side enforcement (#2707)', () => {
+  const SCHEMA = {
+    sys_audit_log: SINGLE_TENANT.sys_audit_log,
+    sys_activity: SINGLE_TENANT.sys_activity,
+    crm_lead: ['id', 'name'],
+  };
+
+  const commentInsert = (threadId?: unknown) => ({
+    object: 'sys_comment',
+    input: { data: { thread_id: threadId, body: 'hello' } },
+    session: {},
+  });
+
+  it('rejects sys_comment creation targeting an object with explicit feeds:false (403 FEEDS_DISABLED)', async () => {
+    const { engine, fire } = makeEngine(SCHEMA, {
+      crm_lead: { enable: { feeds: false } },
+    });
+    installAuditWriters(engine as any, 'test.audit');
+
+    await expect(fire('beforeInsert', commentInsert('crm_lead:rec-1'))).rejects.toMatchObject({
+      code: 'FEEDS_DISABLED',
+      status: 403,
+      object: 'crm_lead',
+    });
+  });
+
+  it('allows comments when feeds is absent (opt-out default) or explicitly true', async () => {
+    const absent = makeEngine(SCHEMA);
+    installAuditWriters(absent.engine as any, 'test.audit');
+    await expect(absent.fire('beforeInsert', commentInsert('crm_lead:rec-1'))).resolves.toBeUndefined();
+
+    const explicit = makeEngine(SCHEMA, { crm_lead: { enable: { feeds: true } } });
+    installAuditWriters(explicit.engine as any, 'test.audit');
+    await expect(explicit.fire('beforeInsert', commentInsert('crm_lead:rec-1'))).resolves.toBeUndefined();
+  });
+
+  it('lets unconventional/missing thread_id through (capability gate, not access control)', async () => {
+    const { engine, fire } = makeEngine(SCHEMA, {
+      crm_lead: { enable: { feeds: false } },
+    });
+    installAuditWriters(engine as any, 'test.audit');
+
+    await expect(fire('beforeInsert', commentInsert(undefined))).resolves.toBeUndefined();
+    await expect(fire('beforeInsert', commentInsert('free-form-thread'))).resolves.toBeUndefined();
+    // Unknown target object → no def → allowed.
+    await expect(fire('beforeInsert', commentInsert('ghost_object:rec-9'))).resolves.toBeUndefined();
+  });
+});

--- a/packages/plugins/plugin-audit/src/audit-writers.ts
+++ b/packages/plugins/plugin-audit/src/audit-writers.ts
@@ -488,10 +488,17 @@ export function installAuditWriters(
       activityRow.organization_id = tenantId ?? null;
     }
 
+    // `enable.activities` is an opt-OUT capability (#2707): absent block/flag
+    // = mirror on (spec default `true`), explicit `false` = this object's CRUD
+    // is not mirrored into the sys_activity timeline. This is the per-object
+    // lever for activity-row growth (ADR-0057). The compliance audit row is
+    // NOT gated — sys_audit_log capture stays unconditional.
+    const activitiesEnabled = getObjectDef(ctx.object)?.enable?.activities !== false;
+
     try {
       const sys = api.sudo();
       await sys.object('sys_audit_log').create(auditRow);
-      await sys.object('sys_activity').create(activityRow);
+      if (activitiesEnabled) await sys.object('sys_activity').create(activityRow);
       // M10.8 / ADR-0030: notify the assignee. Best-effort; never throws into
       // the user-facing CRUD path. Goes through the messaging single ingress
       // (`emit`) — the inbox channel materializes the bell row — rather than
@@ -520,6 +527,40 @@ export function installAuditWriters(
   engine.registerHook('afterInsert', writeAudit, { packageId });
   engine.registerHook('afterUpdate', writeAudit, { packageId });
   engine.registerHook('afterDelete', writeAudit, { packageId });
+
+  /**
+   * `enable.feeds` server-side enforcement (#2707). Comments are created
+   * through the generic data path (`dataSource.create('sys_comment', …)`),
+   * so the engine hook seam is the one gate every caller crosses — REST,
+   * SDK, and feed-service alike. Opt-OUT semantics matching `enable.clone`
+   * (cloneData in metadata-protocol): absent block/flag = allowed, only an
+   * explicit `feeds: false` on the *target* object rejects. The thrown
+   * error carries `.status`, which the REST layer's `sendError` forwards
+   * verbatim → 403 FEEDS_DISABLED, fail-closed like CLONE_DISABLED.
+   *
+   * The target object is resolved from `thread_id` (conventionally
+   * `{object}:{record_id}` — see sys-comment.object.ts). A missing or
+   * unconventional thread_id is allowed through: this is capability
+   * gating, not access control, and free-form threads have no object to
+   * gate on.
+   */
+  const enforceFeedsCapability = async (ctx: HookContext) => {
+    const data: any = (ctx.input as any)?.data;
+    const threadId = data?.thread_id;
+    if (typeof threadId !== 'string') return;
+    const sep = threadId.indexOf(':');
+    if (sep <= 0) return;
+    const targetObject = threadId.slice(0, sep);
+    const def = getObjectDef(targetObject);
+    if (def?.enable?.feeds === false) {
+      const err: any = new Error(`Comments are disabled for object '${targetObject}' (enable.feeds: false)`);
+      err.code = 'FEEDS_DISABLED';
+      err.status = 403;
+      err.object = targetObject;
+      throw err;
+    }
+  };
+  engine.registerHook('beforeInsert', enforceFeedsCapability, { object: 'sys_comment', packageId });
 
   /**
    * M10.8: Dedicated hook on `sys_comment` afterInsert that parses the

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -104,6 +104,22 @@ export function mapDataError(error: any, object?: string): { status: number; bod
             },
         };
     }
+    // Capability gate (#2707): the target object opted out of comments
+    // (`enable.feeds: false`) — plugin-audit's engine hook rejects the
+    // sys_comment insert fail-closed. 403 like CLONE_DISABLED; surfaced by
+    // `code` because the generic data routes map through here (they never
+    // reach sendError's `.status` passthrough). `error.object` names the
+    // gated TARGET object (not sys_comment), so prefer it.
+    if (error?.code === 'FEEDS_DISABLED') {
+        return {
+            status: 403,
+            body: {
+                error: error?.message ?? 'Comments are disabled for this object',
+                code: 'FEEDS_DISABLED',
+                ...(error?.object || object ? { object: error?.object ?? object } : {}),
+            },
+        };
+    }
     // Short-circuit: explicit security denial → 403. Match by `code` /
     // `name` to avoid pulling a runtime dependency on plugin-security.
     if (

--- a/packages/rest/src/rest.test.ts
+++ b/packages/rest/src/rest.test.ts
@@ -1927,6 +1927,26 @@ describe('mapDataError — schema/constraint envelopes', () => {
   const sqliteError = (message: string, code = 'SQLITE_ERROR') =>
     Object.assign(new Error(message), { code });
 
+  // #2707: plugin-audit's engine hook rejects sys_comment creation when the
+  // TARGET object declares `enable.feeds: false`. The generic data routes map
+  // errors through mapDataError (not sendError's `.status` passthrough), so
+  // the code needs its own branch — without it the 403 degraded to the
+  // catch-all 400 (caught live in the runtime smoke test).
+  it('maps FEEDS_DISABLED → 403 with the gated target object', () => {
+    const r = mapDataError(
+      Object.assign(new Error("Comments are disabled for object 'gate_probe' (enable.feeds: false)"), {
+        code: 'FEEDS_DISABLED',
+        status: 403,
+        object: 'gate_probe',
+      }),
+      'sys_comment',
+    );
+    expect(r.status).toBe(403);
+    expect(r.body.code).toBe('FEEDS_DISABLED');
+    // Prefers the gated target object over the route's object (sys_comment).
+    expect(r.body.object).toBe('gate_probe');
+  });
+
   it('maps SQLite "has no column named" → 400 INVALID_FIELD with the field', () => {
     const r = mapDataError(
       sqliteError(

--- a/packages/spec/liveness/README.md
+++ b/packages/spec/liveness/README.md
@@ -105,7 +105,7 @@ Signal over noise is the whole point, so warnings are **opt-in per entry**:
 Two rules keep it false-positive-free, **both of which the marker author must respect**:
 
 1. **Only mark genuinely *misleading* dead props** — ones that imply a capability/behavior
-   that doesn't exist (`enable.feeds`, `field.columnName`, `versioning`). Benign display/doc
+   that doesn't exist (`enable.files`, `field.columnName`, `versioning`). Benign display/doc
    metadata that's "dead" (no runtime reader) — `description`, `tags`, `icon` — must NOT be
    marked; an author isn't misled by them.
 2. **Booleans: only mark `default(false)` flags.** The lint warns on a boolean only when set
@@ -163,7 +163,7 @@ The governed set is `GOVERNED` at the top of `check-liveness.mts`. To add a type
 
 | Type | live | exp | dead | Notes |
 |---|---|---|---|---|
-| object | 31 | – | 17 | `enable`/ObjectCapabilities + versioning/partitioning/cdc tier dead; `apiEnabled` unenforced |
+| object | 34 | – | 14 | versioning/partitioning/cdc tier dead; ObjectCapabilities mostly live post-#2707 (`apiEnabled`/`apiMethods` enforced #1937; `feeds`/`activities` opt-out gates + `trackHistory` UI master switch); `enable.files` reserved/dead |
 | field | 34 | – | 39 | ~half dead — aspirational enhanced-type + governance config; naming-drift props server-live/client-snake |
 | flow | 29 | 1 | 7 | `runAs` experimental (unenforced identity switch); status/active gate nothing; FlowNodeAction enum out of sync |
 | action | 26 | – | 5 | `disabled` CEL ignored (renderers read non-spec `enabled`); type:'form'/shortcut/bulkEnabled dead |

--- a/packages/spec/liveness/object.json
+++ b/packages/spec/liveness/object.json
@@ -156,10 +156,8 @@
           "note": "enforced by enforceApiAccess — operations outside the whitelist → 405."
         },
         "trackHistory": {
-          "status": "dead",
-          "evidence": "no behavior-changing reader (database-loader.trackHistory is a separate ctor option)",
-          "authorWarn": true,
-          "authorHint": "Per-field history is live via `Field.trackHistory` (plugin-audit, ADR-0052) — set it on the fields you want tracked instead of this object flag."
+          "status": "live",
+          "evidence": "objectui app-shell RecordDetailView gates the record History tab on enable.trackHistory === true (historyEnabled memo); pairs with per-field trackHistory (plugin-audit renderTrackedChangeSummary, packages/plugins/plugin-audit/src/audit-writers.ts) which selects the field diffs. Audit CAPTURE into sys_audit_log is deliberately unconditional (compliance ledger) — the flag gates the UI surface, not the ledger (#2707)."
         },
         "searchable": {
           "status": "dead",
@@ -168,21 +166,17 @@
         },
         "files": {
           "status": "dead",
-          "evidence": "no behavior-changing reader",
+          "evidence": "no behavior-changing reader in framework or objectui — reserved for the generic Attachments related-list (Salesforce Notes & Attachments parity), tracked in #2727",
           "authorWarn": true,
-          "authorHint": "File attachments are modeled with a `Field.file`/`Field.image` (or the sys_attachment object), not this object flag — it enables nothing on its own."
+          "authorHint": "File attachments are modeled with a `Field.file`/`Field.image` (or the sys_attachment object), not this object flag — it enables nothing on its own yet (reserved for the future generic Attachments panel)."
         },
         "feeds": {
-          "status": "dead",
-          "evidence": "no behavior-changing reader",
-          "authorWarn": true,
-          "authorHint": "Comments/collaboration live on the dedicated sys_comment object (plugin-audit), not this flag — it enables no feed at runtime."
+          "status": "live",
+          "evidence": "packages/plugins/plugin-audit/src/audit-writers.ts (enforceFeedsCapability beforeInsert hook: explicit feeds:false on the target object rejects sys_comment creation, 403 FEEDS_DISABLED); objectui RecordDetailView hides the record feed on explicit false. Opt-out — spec default true (#2707)."
         },
         "activities": {
-          "status": "dead",
-          "evidence": "no behavior-changing reader",
-          "authorWarn": true,
-          "authorHint": "Tasks/events live on the dedicated sys_activity object (plugin-audit), not this flag — it enables no activity suite at runtime."
+          "status": "live",
+          "evidence": "packages/plugins/plugin-audit/src/audit-writers.ts (writeAudit: explicit activities:false skips the sys_activity timeline mirror; audit row unaffected); objectui RecordDetailView skips the timeline merge on explicit false. Opt-out — spec default true; the per-object lever for activity-row growth, ADR-0057 (#2707)."
         },
         "trash": {
           "status": "dead",

--- a/packages/spec/src/data/object.test.ts
+++ b/packages/spec/src/data/object.test.ts
@@ -9,8 +9,10 @@ describe('ObjectCapabilities', () => {
     expect(result.searchable).toBe(true);
     expect(result.apiEnabled).toBe(true);
     expect(result.files).toBe(false);
-    expect(result.feeds).toBe(false);
-    expect(result.activities).toBe(false);
+    // feeds/activities are opt-OUT capabilities (#2707): default on, consumers
+    // gate on explicit `false` only — same posture as trash/mru/clone.
+    expect(result.feeds).toBe(true);
+    expect(result.activities).toBe(true);
     expect(result.trash).toBe(true);
     expect(result.mru).toBe(true);
     expect(result.clone).toBe(true);

--- a/packages/spec/src/data/object.zod.ts
+++ b/packages/spec/src/data/object.zod.ts
@@ -29,45 +29,79 @@ export type ApiMethod = z.infer<typeof ApiMethod>;
 /**
  * Capability Flags
  * Defines what system features are enabled for this object.
- * 
- * Optimized based on industry standards (Salesforce, ServiceNow):
- * - Added `activities` (Tasks/Events)
- * - Added `mru` (Recent Items)
- * - Added `feeds` (Social/Chatter)
- * - Grouped API permissions
- * 
+ *
+ * Modeled on industry standards (Salesforce "Allow Activities"/"Track Field
+ * History"/"Enable Feed Tracking", Dataverse table options). Each flag has a
+ * defined enforcement contract (#2707); a flag with no runtime consumer is a
+ * bug, not a reservation — see `@objectstack/spec/liveness/object.json`.
+ *
+ * Opt-out flags (`feeds`, `activities`, `trash`, `mru`, `clone`, `searchable`,
+ * `apiEnabled`) default to `true`: absent block/flag = enabled, and consumers
+ * gate on explicit `false` only. Opt-in flags (`trackHistory`, `files`)
+ * default to `false`.
+ *
  * @example
  * {
  *   trackHistory: true,
  *   searchable: true,
  *   apiEnabled: true,
- *   files: true
+ *   activities: false
  * }
  */
 export const ObjectCapabilities = z.object({
-  /** Enable history tracking (Audit Trail) */
-  trackHistory: z.boolean().default(false).describe('Enable field history tracking for audit compliance'),
-  
+  /**
+   * History tracking (Audit Trail) master switch — opt-in.
+   *
+   * Contract: `true` surfaces the record History tab (audit-trail UI) in the
+   * console. Pair with per-field `trackHistory: true` to select which field
+   * diffs render as human-readable timeline summaries (ADR-0052 §5b). Audit
+   * *capture* into `sys_audit_log` is a compliance ledger and stays on
+   * regardless of this flag; retention is governed by data lifecycle
+   * (ADR-0057), not by hiding the UI.
+   */
+  trackHistory: z.boolean().default(false).describe('Show the record History tab (audit-trail UI). Pair with per-field trackHistory to pick which field diffs are summarized; audit capture itself is always on for compliance'),
+
   /** Enable global search indexing */
   searchable: z.boolean().default(true).describe('Index records for global search'),
-  
+
   /** Enable REST/GraphQL API access */
   apiEnabled: z.boolean().default(true).describe('Expose object via automatic APIs'),
 
-  /** 
+  /**
    * API Supported Operations
    * Granular control over API exposure.
    */
   apiMethods: z.array(ApiMethod).optional().describe('Whitelist of allowed API operations'),
-  
-  /** Enable standard attachments/files engine */
-  files: z.boolean().default(false).describe('Enable file attachments and document management'),
-  
-  /** Enable social collaboration (Comments, Mentions, Feeds) */
-  feeds: z.boolean().default(false).describe('Enable social feed, comments, and mentions (Chatter-like)'),
-  
-  /** Enable standard Activity suite (Tasks, Calendars, Events) */
-  activities: z.boolean().default(false).describe('Enable standard tasks and events tracking'),
+
+  /**
+   * Standard attachments/files engine — opt-in, NOT YET CONSUMED at runtime.
+   *
+   * Reserved for the generic Attachments related-list (Salesforce
+   * "Notes & Attachments" parity). Until that ships, model attachments with
+   * `Field.file` / `Field.image` (or relate to `sys_attachment`) — setting
+   * this flag alone enables nothing, and the compile-time liveness lint
+   * warns on it.
+   */
+  files: z.boolean().default(false).describe('RESERVED (no runtime effect yet) — use Field.file/Field.image for attachments; this flag will gate the future generic Attachments panel'),
+
+  /**
+   * Social collaboration (Comments, Mentions, Feeds) — opt-out.
+   *
+   * Contract: default on. An explicit `false` hides the record feed UI and
+   * rejects new `sys_comment` rows targeting this object (403
+   * FEEDS_DISABLED, enforced at the engine hook seam by plugin-audit).
+   */
+  feeds: z.boolean().default(true).describe('Record comments/collaboration feed. Default on; explicit false hides the feed UI and rejects new comments for this object'),
+
+  /**
+   * Activity timeline (sys_activity mirror of create/update/delete) — opt-out.
+   *
+   * Contract: default on. An explicit `false` stops plugin-audit from
+   * mirroring this object's CRUD into `sys_activity` (the record timeline)
+   * and hides the timeline merge in the console. The off-switch is also the
+   * per-object lever for activity-row growth (ADR-0057).
+   */
+  activities: z.boolean().default(true).describe('Record activity timeline (sys_activity mirror of CRUD). Default on; explicit false stops mirroring and hides the timeline'),
 
   /** Enable Recycle Bin / Soft Delete */
   trash: z.boolean().default(true).describe('Enable soft-delete with restore capability'),


### PR DESCRIPTION
Closes #2707。按"分 flag 接线(enforce),不移除"处置——评估结论:四个 flag 并不同质,移除方案不可行(trackHistory 实为 live;spec 在 fixed 组移字段=全平台 major;examples/下游有真实使用)。

## 分 flag 处置

| flag | 处置 | 契约 |
|---|---|---|
| `activities` | **接线为 opt-out writer 闸门** | spec 默认 `false→true`;显式 `false` 时 plugin-audit 只跳过 sys_activity 时间线镜像(**审计行不受影响**)。行为兼容;同时是 ADR-0057 想要的按对象 activity 增长控制杆 |
| `feeds` | **接线为 opt-out + 服务端强制** | spec 默认 `false→true`;显式 `false` → 引擎 hook 缝拒绝 sys_comment 创建,403 `FEEDS_DISABLED`(fail-closed,复用 `CLONE_DISABLED` 模式)+ `mapDataError` 专属分支(通用 data 路由不走 `sendError` 的 `.status` 透传——运行时冒烟抓到 403 退化成 400 后补) |
| `trackHistory` | **ledger 纠错→live + 契约成文** | ledger 定性"dead"是错的:objectui 自 2026-05 起用它门控 History 标签页(按 ledger 自己的规则 objectui 消费者算 live 证据)。旧 authorWarn hint("改用 Field.trackHistory")照做会丢 History 标签页——已替换为两级契约:对象 flag=History 标签页总开关;`Field.trackHistory`=diff 选择器;审计**采集**保持无条件(合规账本) |
| `files` | **保持 dead+authorWarn,roadmap #2727** | 唯一两层都无消费者的 flag。`describe()` 改为如实标注 RESERVED,不再宣传不存在的能力 |

默认值翻转是必须的:`default(false)` 会把"没设"编译成显式 `false`,opt-out 语义无法区分"作者显式关"和"默认"——与 `trash`/`mru`/`clone` 同姿态。

## 为什么不把 lint 升级成 error

advisory-only 是 lint-liveness-properties 文件头写明的设计决定(signal over noise);修复路线是把 flag 变 live(enforce-or-remove 里选 enforce),不是把警告变错误。收口后 authorWarn 只剩 `enable.files` 一个,警告面从 4 降到 1。

## 验证

- 单测:plugin-audit 28 ✓(含新增 opt-out/403 gate 测试)、rest 217+1 ✓、cli 468 ✓(lint 契约测试更新)、objectql 804 ✓、spec 6671 ✓(唯一红=存量 #2729,与本 PR 无关,已单独报)
- 闸门:`check:liveness` ✓、`check:api-surface` ✓(表面无变化)
- 编译期:app-todo(四 flag 全 true)编译告警从 4 条降到 1 条(仅 `enable.files`,hint 已更新)
- **运行时端到端**(fresh showcase):默认对象=activity 镜像 ✓ + 评论 201 ✓;探针对象(`feeds:false, activities:false`)=0 条 activity 镜像 + 1 条审计行 + 评论 403 `FEEDS_DISABLED` ✓
- 文档:references/data/object.mdx 由 gen:docs 再生成(仅本表)

## 配套

- objectui PR: objectstack-ai/objectui#2370(渲染层同契约闸门 + 错误注释修正)
- Roadmap: #2727(enable.files → 通用 Attachments related-list)
- 顺带发现并单独报:#2729(PROTOCOL_MAJOR 12 vs package major 13,main 上存量红测试)

🤖 Generated with [Claude Code](https://claude.com/claude-code)