### PR TITLE
fix(data): resolve field defaultValues before beforeInsert hook (#2703)

### DIFF
--- a/.changeset/objectql-defaults-before-beforeinsert-2703.md
+++ b/.changeset/objectql-defaults-before-beforeinsert-2703.md
@@ -1,0 +1,28 @@
+---
+'@objectstack/objectql': patch
+---
+
+fix(data): resolve field `defaultValue`s BEFORE the `beforeInsert` hook (#2703)
+
+Declarative field defaults (including the `current_user` token) were resolved
+by `applyFieldDefaults` *after* the user `beforeInsert` hook ran. A hook that
+DERIVED one field from another therefore read a stale `null` for any field that
+was about to be defaulted — e.g. `sales_person: Field.user({ defaultValue:
+'current_user' })` left `sales_person == null` inside the hook, so a derived
+`current_status` computed to `unassigned` unless the client passed the field
+explicitly.
+
+`applyFieldDefaults` now runs at record-initialization time, before
+`beforeInsert`, matching the industry-standard order of execution (Salesforce
+field defaults / ServiceNow dictionary defaults are populated before before-
+triggers; engine-owned generation — autonumber sequences, encryption, timestamps
+— stays after the hook). The hook still has final say: it runs after and may
+override any defaulted field. Defaults still only fill fields left `undefined`,
+so client-supplied values are untouched, and the caller's input object is no
+longer mutated in place.
+
+Behavior note: a `beforeInsert` hook can no longer distinguish "client omitted
+field X" from "field X received its default" for fields that declare a
+`defaultValue` — the hook now always sees the resolved default. This matches how
+Salesforce/ServiceNow behave (before logic sees a fully-initialized record) and
+is the intended fix.

--- a/packages/objectql/src/engine.test.ts
+++ b/packages/objectql/src/engine.test.ts
@@ -319,6 +319,36 @@ describe('ObjectQL Engine', () => {
             expect(arg.owner).toBeUndefined();
         });
 
+        it('resolves field defaults BEFORE beforeInsert so a hook can derive from them (#2703)', async () => {
+            vi.mocked(SchemaRegistry.getObject).mockImplementation((name) => {
+                if (name === 'ticket') return {
+                    name: 'ticket',
+                    fields: {
+                        title: { type: 'text' },
+                        owner: { type: 'user', reference: 'sys_user', defaultValue: 'current_user' },
+                        current_status: { type: 'text' },
+                    },
+                } as any;
+                if (name === 'sys_user') return { name: 'sys_user', fields: { name: { type: 'text' } } } as any;
+                return undefined;
+            });
+
+            // A beforeInsert hook that DERIVES `current_status` from the defaulted
+            // `owner` field — the exact os-tianshun-mtc#29 scenario.
+            engine.registerHook('beforeInsert', async (ctx: any) => {
+                const data = ctx.input.data;
+                data.current_status = data.owner ? 'assigned' : 'unassigned';
+            }, { object: 'ticket' });
+
+            await engine.insert('ticket', { title: 'T1' }, { context: { userId: 'u-42' } as any });
+
+            expect(mockDriver.create).toHaveBeenCalledWith(
+                'ticket',
+                expect.objectContaining({ title: 'T1', owner: 'u-42', current_status: 'assigned' }),
+                expect.anything(),
+            );
+        });
+
         it('should execute find operation', async () => {
             const result = await engine.find('task', {});
             expect(mockDriver.find).toHaveBeenCalled();

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -2131,10 +2131,23 @@ export class ObjectQL implements IDataEngine {
     };
 
     await this.executeWithMiddleware(opCtx, async () => {
+      // Resolve field `defaultValue`s (including the `current_user` token)
+      // BEFORE the beforeInsert hook runs, so a hook that DERIVES one field
+      // from another can read the defaulted value instead of a stale `null`
+      // (#2703). The hook still has final say — it runs after and may override
+      // any defaulted field. `applyFieldDefaults` returns a fresh copy and only
+      // fills fields left `undefined`, so client-supplied values are untouched.
+      const nowSnap = new Date();
+      const defaultedData = Array.isArray(opCtx.data)
+        ? (opCtx.data as any[]).map((row) =>
+            this.applyFieldDefaults(object, row as Record<string, unknown>, opCtx.context, nowSnap),
+          )
+        : this.applyFieldDefaults(object, opCtx.data as Record<string, unknown>, opCtx.context, nowSnap);
+
       const hookContext: HookContext = {
           object,
           event: 'beforeInsert',
-          input: { data: opCtx.data, options: opCtx.options },
+          input: { data: defaultedData, options: opCtx.options },
           session: this.buildSession(opCtx.context),
           api: this.buildHookApi(opCtx.context),
           transaction: opCtx.context?.transaction,
@@ -2150,16 +2163,14 @@ export class ObjectQL implements IDataEngine {
 
       try {
         let result;
-        const nowSnap = new Date();
         const schemaForValidation = this._registry.getObject(object);
         // When the driver generates autonumbers natively (persistent SQL
         // sequence), the engine defers to it — see #1603.
         const driverOwnsAutonumber = (driver as any)?.supports?.autonumber === true;
         if (Array.isArray(hookContext.input.data)) {
-          // Bulk Create — apply defaults per row
-          const rows = (hookContext.input.data as any[]).map((row) =>
-            this.applyFieldDefaults(object, row as Record<string, unknown>, opCtx.context, nowSnap),
-          );
+          // Defaults are already resolved above (pre-hook, #2703); the hook may
+          // have overridden or added fields — take its data as-is.
+          const rows = hookContext.input.data as Array<Record<string, unknown>>;
           for (const r of rows) {
             await this.applyAutonumbers(object, r as Record<string, unknown>, opCtx.context, driverOwnsAutonumber);
           }
@@ -2178,12 +2189,8 @@ export class ObjectQL implements IDataEngine {
                result = await Promise.all(rows.map((item) => driver.create(object, item, hookContext.input.options as any)));
           }
         } else {
-          const row = this.applyFieldDefaults(
-            object,
-            hookContext.input.data as Record<string, unknown>,
-            opCtx.context,
-            nowSnap,
-          );
+          // Defaults already resolved pre-hook (#2703); use the hook's data.
+          const row = hookContext.input.data as Record<string, unknown>;
           await this.applyAutonumbers(object, row, opCtx.context, driverOwnsAutonumber);
           await this.encryptSecretFields(object, row, opCtx.context, hookContext.input.options);
           normalizeMultiValueFields(schemaForValidation, row);


### PR DESCRIPTION
## 概述

修复 #2703:字段 `defaultValue`(含 `Field.user({ defaultValue: 'current_user' })`)由运行时在用户 `beforeInsert` hook **之后**才解析,导致「从被默认的字段派生第二个字段」的 hook 读到还未填充的 `null`。

## 根因

`packages/objectql/src/engine.ts` 的 `insert()` 里执行顺序颠倒:
- `triggerHooks('beforeInsert', …)` 先跑用户 hook
- `applyFieldDefaults(…)` 才回填默认值

于是 `sales_person: Field.user({ defaultValue: 'current_user' })` 在 POST 不带该字段时,hook 内读到 `sales_person == null`,派生的 `current_status` 被算成 `unassigned`;显式传值才正确。

## 改动

把 `applyFieldDefaults`(单条 + 批量两条路径)提前到 `beforeInsert` hook **之前**,回填后的数据喂给 `hookContext.input.data`:

- 派生 hook 现在读得到默认值(含 `current_user`)。
- Hook 仍有最终话语权 —— 它在默认值之后运行,可覆盖/新增任何字段。
- 默认值只填 `undefined` 字段,客户端显式传值不受影响;调用方入参对象不再被就地改写。
- **顺序其余不变**:`applyAutonumbers` / `encryptSecretFields` / 校验仍在 hook 之后 —— 自增号格式里插值的默认字段照样先解析出来。

## 为什么这是平台级正确(执行顺序对齐)

关键区分:**声明式默认值 ≠ 引擎生成值**,成熟平台把二者插在 before-hook 两侧:

- 声明式/元数据默认值(`defaultValue`、`current_user`)属于「记录初始化」,在 before 逻辑**之前**。
- 引擎自有生成值(自增号序列、加密、时间戳)在 before 逻辑**之后**。

各家参照:
- **Salesforce**:字段默认值(含 `$User.Id`,正对应 `current_user`)在记录实例化时填好,before trigger 的 `Trigger.new` 已带默认值;Auto-Number 在 save 阶段生成、before trigger 取不到。→ 本 PR 的新顺序(默认值在前、autonumber 在后)与其**完全一致**。
- **ServiceNow**:dictionary default 在 `initialize()` 时套用,`before` business rule 天然看得到。
- **Rails / Django**:模型层默认值在实例化时套用,`before_create` / `pre_save` 看得到;仅 DB 级 default 滞后。

之前「默认值晚于 before hook」才是异类;本 PR 把 ObjectQL 挪回标准分层:`默认值 → before hook → autonumber/加密 → 校验 → 持久化`。

## Breaking note

`beforeInsert` hook **再也无法区分「客户端没传字段」与「默认值填的字段」**(对声明 `defaultValue` 的字段,hook 总是看到已解析的默认值)。这与 Salesforce/ServiceNow 行为一致(before 逻辑看到的是已初始化的记录),是本次修复的**预期语义**。依赖「字段 `undefined` = 客户端未传」来分支的下游自定义 hook 需改判。

## 测试

- 新增回归测试(`engine.test.ts`),复刻 steedos-labs/os-tianshun-mtc#29:一个 `beforeInsert` hook 从默认回填的 `owner` 派生 `current_status`,断言落库为 `assigned`。
- `@objectstack/objectql` 全量 **63 文件 / 805 tests 全通过**。

## 后续(本 PR 不含)

- 建议把这条执行顺序沉淀为公开契约(ADR / spec),对齐 issue 里「或至少文档明确顺序」的诉求。
- 建议后续核对 `update` 路径的默认值处理是否遵循同样「声明式在前」原则,避免 insert/update 两套顺序。

Closes #2703
