### PR TITLE
test(objectql): de-flake hook-binder fire-and-forget assertion (#2744)

### DIFF
--- a/packages/objectql/src/hook-binder.test.ts
+++ b/packages/objectql/src/hook-binder.test.ts
@@ -219,9 +219,13 @@ describe('wrapDeclarativeHook', () => {
       },
     };
     const wrapped = wrapDeclarativeHook(meta, meta.handler as any);
-    const t0 = Date.now();
     await wrapped(makeCtx({ event: 'afterInsert' }));
-    expect(Date.now() - t0).toBeLessThan(20); // returned before handler finished
+    // Ordering, not wall clock (#2744): if the wrapper had awaited the
+    // handler, `calls` would already hold 'done' here — the 30ms timer is a
+    // macrotask and cannot fire between the wrapper's resolution and this
+    // synchronous check, no matter how slow the runner is. The old
+    // `< 20ms` wall-clock assertion was flaky on shared CI machines.
+    expect(calls).toEqual([]); // returned before handler finished
     await new Promise((r) => setTimeout(r, 60));
     expect(calls).toEqual(['done']);
   });


### PR DESCRIPTION
Closes #2744。

`hook-binder.test.ts` 的 fire-and-forget 用例用墙钟阈值(`<20ms`)证明"未 await handler",共享 CI runner 慢一点就随机红(PR #2742 实测 23ms,重跑即绿)。改为**顺序性断言**:wrapper resolve 后同步检查 `calls` 仍为空——handler 的 30ms timer 是宏任务,不可能在 wrapper 的 promise 链与同步断言之间触发,与机器快慢无关;而 wrapper 若真 await 了 handler,`calls` 此处必然已是 `['done']`,照样红。测试后半段(60ms 后 `['done']`)不变。

纯测试改动;`vitest run src/hook-binder.test.ts` 15/15 ✓。

🤖 Generated with [Claude Code](https://claude.com/claude-code)