### PR TITLE
fix(setup): relabel the sys_position nav entry to Positions (ADR-0090 D3 vocabulary)

### DIFF
--- a/.changeset/setup-positions-nav-label.md
+++ b/.changeset/setup-positions-nav-label.md
@@ -1,0 +1,6 @@
+---
+"@objectstack/plugin-security": patch
+"@objectstack/platform-objects": patch
+---
+
+Setup navigation: the Access Control menu entry for `sys_position` is now labeled "Positions" (was still "Roles" after the ADR-0090 D3 rename) — `nav_roles` → `nav_positions`, with zh-CN 岗位 / ja-JP ポジション / es-ES Posiciones translations updated to match the position vocabulary.

--- a/packages/platform-objects/src/apps/setup-nav.contributions.ts
+++ b/packages/platform-objects/src/apps/setup-nav.contributions.ts
@@ -13,7 +13,7 @@
  * that owns the underlying objects rather than living here (ADR-0029 K2):
  *   - `group_integrations` → `@objectstack/plugin-webhooks` (K2.a)
  *   - `group_approvals`     → `@objectstack/plugin-approvals` (K2.b)
- *   - `group_access_control` Roles / Permission Sets → `@objectstack/plugin-security`
+ *   - `group_access_control` Positions / Permission Sets → `@objectstack/plugin-security`
  *   - `group_access_control` Sharing Rules / Record Shares → `@objectstack/plugin-sharing`
  * As each remaining domain moves to its capability plugin, its entries move out
  * of this file into that plugin the same way.
@@ -78,12 +78,12 @@ export const SETUP_NAV_CONTRIBUTIONS: NavigationContribution[] = [
   {
     app: 'setup',
     group: 'group_access_control',
-    // Priority 300 keeps API Keys after plugin-security's Roles / Permission
+    // Priority 300 keeps API Keys after plugin-security's Positions / Permission
     // Sets (100) and plugin-sharing's Sharing Rules / Record Shares (200),
     // preserving the original menu order.
     priority: 300,
     items: [
-      // Roles / Permission Sets are contributed by @objectstack/plugin-security
+      // Positions / Permission Sets are contributed by @objectstack/plugin-security
       // and Sharing Rules / Record Shares by @objectstack/plugin-sharing
       // (ADR-0029 K2). Only API Keys (sys_api_key, an identity object owned by
       // plugin-auth) remains a platform-objects base entry here.

--- a/packages/platform-objects/src/apps/translations/en.ts
+++ b/packages/platform-objects/src/apps/translations/en.ts
@@ -70,7 +70,7 @@ export const en: TranslationData = {
         nav_invitations: { label: 'Invitations' },
 
         // Access Control
-        nav_roles: { label: 'Roles' },
+        nav_positions: { label: 'Positions' },
         nav_permission_sets: { label: 'Permission Sets' },
         nav_sharing_rules: { label: 'Sharing Rules' },
         nav_record_shares: { label: 'Record Shares' },

--- a/packages/platform-objects/src/apps/translations/es-ES.ts
+++ b/packages/platform-objects/src/apps/translations/es-ES.ts
@@ -51,7 +51,7 @@ export const esES: TranslationData = {
         nav_organizations: { label: 'Organizaciones' },
         nav_invitations: { label: 'Invitaciones' },
 
-        nav_roles: { label: 'Roles' },
+        nav_positions: { label: 'Posiciones' },
         nav_permission_sets: { label: 'Conjuntos de Permisos' },
         nav_sharing_rules: { label: 'Reglas de Compartición' },
         nav_record_shares: { label: 'Registros Compartidos' },

--- a/packages/platform-objects/src/apps/translations/ja-JP.ts
+++ b/packages/platform-objects/src/apps/translations/ja-JP.ts
@@ -51,7 +51,7 @@ export const jaJP: TranslationData = {
         nav_organizations: { label: '組織' },
         nav_invitations: { label: '招待' },
 
-        nav_roles: { label: 'ロール' },
+        nav_positions: { label: 'ポジション' },
         nav_permission_sets: { label: '権限セット' },
         nav_sharing_rules: { label: '共有ルール' },
         nav_record_shares: { label: 'レコード共有' },

--- a/packages/platform-objects/src/apps/translations/zh-CN.ts
+++ b/packages/platform-objects/src/apps/translations/zh-CN.ts
@@ -52,7 +52,7 @@ export const zhCN: TranslationData = {
         nav_organizations: { label: '组织' },
         nav_invitations: { label: '邀请' },
 
-        nav_roles: { label: '角色' },
+        nav_positions: { label: '岗位' },
         nav_capabilities: { label: '能力' },
         nav_permission_sets: { label: '权限集' },
         nav_sharing_rules: { label: '共享规则' },

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -252,7 +252,7 @@ export class SecurityPlugin implements Plugin {
           group: 'group_access_control',
           priority: 100,
           items: [
-            { id: 'nav_roles', type: 'object', label: 'Roles', objectName: 'sys_position', icon: 'shield-check' },
+            { id: 'nav_positions', type: 'object', label: 'Positions', objectName: 'sys_position', icon: 'shield-check' },
             { id: 'nav_capabilities', type: 'object', label: 'Capabilities', objectName: 'sys_capability', icon: 'badge-check' },
             { id: 'nav_permission_sets', type: 'object', label: 'Permission Sets', objectName: 'sys_permission_set', icon: 'lock' },
           ],

--- a/packages/spec/src/ui/app.test.ts
+++ b/packages/spec/src/ui/app.test.ts
@@ -268,10 +268,10 @@ describe('NavigationItemSchema (Recursive)', () => {
               objectName: 'user',
             },
             {
-              id: 'nav_roles',
-              label: 'Roles',
+              id: 'nav_positions',
+              label: 'Positions',
               type: 'object' as const,
-              objectName: 'role',
+              objectName: 'position',
             },
           ],
         },


### PR DESCRIPTION
## Summary

Found while answering "does Setup have management UI for assignments": the Setup app's **Access Control** group still shows **"Roles"** for the `sys_position` object list — a leftover of the ADR-0090 P1 rename that the P3 vocabulary sweep missed (the nav lives in `security-plugin.ts`'s `navigationContributions`, not in the `objects/` directory the sweep covered). The object pointer itself was already correct (`sys_position`), so this is a label/id fix, not a dead link.

- `nav_roles` → `nav_positions`; label `Roles` → `Positions` (`plugin-security/src/security-plugin.ts`)
- Locale labels updated: zh-CN `角色`→`岗位`, ja-JP `ロール`→`ポジション`, es-ES `Roles`→`Posiciones`, en `Roles`→`Positions` (`platform-objects/src/apps/translations/*`)
- Stale `Roles / Permission Sets` comments in `setup-nav.contributions.ts` and the `spec` app.test fixture aligned to the frozen vocabulary

## Verification

- `pnpm turbo build --filter=@objectstack/plugin-security --filter=@objectstack/platform-objects` green
- `packages/spec` `src/ui/app.test.ts` 62/62
- Changeset: patch × 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oLzaP8n7A3YKFmgaHWC8H

---
_Generated by [Claude Code](https://claude.ai/code/session_012oLzaP8n7A3YKFmgaHWC8H)_