### PR TITLE
docs(adr): ADR-0091 accepted — grant lifecycle decisions confirmed; D3 gains the no-self-renewal rule

### DIFF
--- a/docs/adr/0091-grant-lifecycle-and-recertification.md
+++ b/docs/adr/0091-grant-lifecycle-and-recertification.md
@@ -1,8 +1,8 @@
 # ADR-0091: Grant lifecycle — effective-dated assignments, delegation, break-glass, recertification substrate
 
-- **Status:** Proposed
-- **Date:** 2026-07-09
-- **Deciders:** (pending review)
+- **Status:** Accepted
+- **Date:** 2026-07-09 (proposed) · 2026-07-10 (accepted)
+- **Deciders:** jack@objectstack.ai
 - **Relates to:** ADR-0090 (Permission Model v2 — named follow-up #1), ADR-0057 (assignment tables), ADR-0049 (no unenforced security properties), ADR-0016 (open-core boundary)
 
 ## TL;DR
@@ -106,8 +106,12 @@ A user may delegate a position they hold **without being an admin**, iff:
    checked by the same gate that owns assignment writes (D12 gate grows a
    self-service branch: delegator ≠ admin, but the write is scoped to
    positions they hold + delegatable + time-boxed);
-4. chains are cut: a row with `delegated_from` set is **not itself
-   delegatable** (no re-delegation);
+4. chains are cut TWO ways: a row with `delegated_from` set is **not itself
+   delegatable** (no re-delegation), and it is **not self-renewable** — the
+   delegate cannot extend `valid_until`; continuing past expiry requires the
+   delegator (or an admin) to issue a NEW delegation, leaving a fresh audit
+   record. A "temporary" grant that can be quietly rolled forever is a
+   permanent grant with extra steps;
 5. dual audit: the row carries both `granted_by` (writer) and
    `delegated_from` (authority source); explain reports "via delegation from
    张三, until …".


### PR DESCRIPTION
## Summary

Review outcome for ADR-0091 (#2751): **Status → Accepted** (decider recorded). All seven decisions confirmed as proposed:

- D3 delegation keeps **substitution (union)** semantics with the 30-day configurable ceiling;
- D4 break-glass stays **unapproved** with the 4h default window (pre-authorization list + loud alert + D5 review as the compensating controls);
- D1 scope stays confined to the two user-grant tables; D2 resolution-time filtering is the sole correctness mechanism.

One addition from review: **D3 rule 4 now cuts chains two ways** — a delegated row is not re-delegatable *and not self-renewable*. The delegate cannot extend `valid_until`; continuing past expiry requires a NEW delegation by the delegator (or an admin), leaving a fresh audit record. A "temporary" grant that can be quietly rolled forever is a permanent grant with extra steps.

Implementation (L1: spec columns + resolver filtering + tests) starts after this merges, targeting 13.1.

## Verification

Docs-only (one ADR file). No code, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oLzaP8n7A3YKFmgaHWC8H

---
_Generated by [Claude Code](https://claude.ai/code/session_012oLzaP8n7A3YKFmgaHWC8H)_