### PR TITLE
docs(liveness): record tenancy.strategy/crossTenantAccess removal decision (#2763)

### DIFF
--- a/.changeset/tenancy-removal-decision-note.md
+++ b/.changeset/tenancy-removal-decision-note.md
@@ -1,0 +1,13 @@
+---
+'@objectstack/spec': patch
+---
+
+docs(liveness): record the tenancy.strategy / crossTenantAccess removal decision (#2763)
+
+Owner decision 2026-07-10: the platform has exactly two multi-tenancy
+modes — per-tenant database (environment-level, zero object config) and
+shared-DB organization row isolation (`tenancy.enabled` + `tenantField`).
+Object-level isolation strategy has no requirement, so `strategy` and
+`crossTenantAccess` are slated for removal at the next spec major.
+Ledger notes + compile-time authorHints now state the decision and point
+authors at the two real mechanisms.

--- a/packages/spec/liveness/object.json
+++ b/packages/spec/liveness/object.json
@@ -129,9 +129,9 @@
         "strategy": {
           "status": "dead",
           "evidence": "inert — only tenancy.enabled is read",
-          "note": "part of the live tenancy block (sql-driver reads enabled+tenantField); verify before touching.",
+          "note": "REMOVAL DECIDED (#2763, owner 2026-07-10): the platform has exactly two tenancy modes — per-tenant database (environment-level, zero object config) and shared-DB org row isolation (enabled+tenantField). Object-level isolation strategy has no requirement; remove at the next spec major.",
           "authorWarn": true,
-          "authorHint": "Only tenancy.enabled + tenantField are read (sql-driver row scoping) — 'shared'/'isolated'/'hybrid' changes nothing. Do not expect per-tenant databases from this knob."
+          "authorHint": "No requirement — removal decided (#2763). Library-level isolation is an environment/deployment choice; row-level isolation is tenancy.enabled + tenantField. This knob changes nothing."
         },
         "tenantField": {
           "status": "live",
@@ -141,9 +141,9 @@
         "crossTenantAccess": {
           "status": "dead",
           "evidence": "inert",
-          "note": "part of the live tenancy block; verify before touching.",
+          "note": "REMOVAL DECIDED (#2763, owner 2026-07-10): cross-visibility governance lives in sharing/OWD (ADR-0056), externalSharingModel (ADR-0090 D11) and access posture; a blanket boolean has no requirement. Remove at the next spec major.",
           "authorWarn": true,
-          "authorHint": "Inert — setting it true does NOT grant (or gate) cross-tenant access. Tenant isolation is enforced solely via tenancy.enabled row scoping."
+          "authorHint": "No requirement — removal decided (#2763). Setting it true grants nothing; use sharing rules / externalSharingModel for cross-visibility."
         }
       }
     },


### PR DESCRIPTION
#2763 决策记录落进 ledger:owner 定向(2026-07-10)——平台只有两种多租户模式(租户独立库=环境级零配置;共享库=组织行级隔离 `enabled`+`tenantField`),对象级隔离策略无需求。`tenancy.strategy`/`crossTenantAccess` 定为下个 spec major 移除。

本 PR 只改 ledger note/authorHint:编译期告警文案从泛泛的"inert"升级为"已决策移除(#2763),真实机制是 X"——作者在 major 到来前每次编译都能看到明确指向。

验证:`check:liveness` ✓、cli lint 契约测试 14 ✓。

🤖 Generated with [Claude Code](https://claude.com/claude-code)