### PR TITLE
fix(spec): PROTOCOL_VERSION 13.0.0 → 14.0.0 — re-lockstep with the released major

### DIFF
--- a/packages/spec/src/kernel/protocol-version.ts
+++ b/packages/spec/src/kernel/protocol-version.ts
@@ -15,7 +15,7 @@
  * Kept in lockstep with the package's own major; `protocol-version.test.ts`
  * asserts it against `package.json` so the two cannot drift.
  */
-export const PROTOCOL_VERSION = '13.0.0';
+export const PROTOCOL_VERSION = '14.0.0';
 
 /** The protocol major as an integer — the value the handshake compares. */
 export const PROTOCOL_MAJOR: number = Number.parseInt(PROTOCOL_VERSION.split('.')[0]!, 10);


### PR DESCRIPTION
The #2736 changesets release bumped `@objectstack/spec` to 14.0.0 without regenerating the `PROTOCOL_VERSION` handshake constant, so the lockstep guard (`protocol-version.test.ts`) fails on main for EVERY branch right now. One-line re-sync; the 3 protocol-version tests pass.

No changeset: version-constant sync for an already-released major (the release itself carried the changesets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)