### PR TITLE
fix(spec): sync PROTOCOL_VERSION to 14.0.0 after the major release — main is red without it

### DIFF
--- a/.changeset/protocol-version-14.md
+++ b/.changeset/protocol-version-14.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/spec": patch
+---
+
+Sync `PROTOCOL_VERSION` to `14.0.0` — the 14.0.0 release bumped `package.json` but the handshake constant still said 13, so `protocol-version.test.ts` failed on main for every PR. (Process note: the changesets Version PR cannot bump source constants; the protocol bump must accompany each major.)

--- a/packages/spec/src/kernel/protocol-version.ts
+++ b/packages/spec/src/kernel/protocol-version.ts
@@ -15,7 +15,7 @@
  * Kept in lockstep with the package's own major; `protocol-version.test.ts`
  * asserts it against `package.json` so the two cannot drift.
  */
-export const PROTOCOL_VERSION = '13.0.0';
+export const PROTOCOL_VERSION = '14.0.0';
 
 /** The protocol major as an integer — the value the handshake compares. */
 export const PROTOCOL_MAJOR: number = Number.parseInt(PROTOCOL_VERSION.split('.')[0]!, 10);


### PR DESCRIPTION
## Summary

**Unbreaks main.** The 14.0.0 Version Packages merge (#2736) bumped `packages/spec/package.json` to 14.0.0, but the ADR-0087 handshake constant `PROTOCOL_VERSION` still says `13.0.0` — so `protocol-version.test.ts` (which asserts the two stay in lockstep) fails on main and turns **every open PR's Test Core red** (first observed on #2770, reproduced twice, confirmed on a clean checkout of latest main).

- `PROTOCOL_VERSION` `'13.0.0'` → `'14.0.0'` (one line)
- Changeset: spec patch

**Process note**: the changesets Version PR cannot bump source constants, so the protocol bump must accompany each major release — worth folding into the release checklist (or a small guard that runs in the Version PR's CI rather than only post-merge).

## Verification

- `spec` `protocol-version.test.ts` 3/3
- `metadata-core` (handshake consumer) 100/100
- Docs-adjacent one-liner; no behavior change beyond the handshake advertising the correct major

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oLzaP8n7A3YKFmgaHWC8H

---
_Generated by [Claude Code](https://claude.ai/code/session_012oLzaP8n7A3YKFmgaHWC8H)_