### PR TITLE
fix: correct JSON field serialization for PostgreSQL vs SQLite

### DIFF
--- a/packages/plugins/driver-sql/src/sql-driver.ts
+++ b/packages/plugins/driver-sql/src/sql-driver.ts
@@ -3162,17 +3162,32 @@ export class SqlDriver implements IDataDriver {
       }
     }
 
-    if (!this.isSqlite) return copy;
-
-    const fields = this.jsonFields[object];
-    if (fields && fields.length > 0) {
-      if (!copied) { copy = { ...copy }; copied = true; }
-      for (const field of fields) {
-        if (copy[field] !== undefined && typeof copy[field] === 'object' && copy[field] !== null) {
+    // JSON field serialisation: PostgreSQL native jsonb columns require
+    // valid JSON for ALL values (strings, numbers, booleans, objects).
+    // SQLite stores JSON as plain TEXT so only objects/arrays need
+    // stringification (better-sqlite3 can only bind primitives).
+    const jsonFields = this.jsonFields[object];
+    if (jsonFields && jsonFields.length > 0) {
+      for (const field of jsonFields) {
+        if (copy[field] === undefined || copy[field] === null) continue;
+        if (this.isSqlite) {
+          // SQLite: only objects/arrays need JSON.stringify; primitives
+          // are stored as-is and re-parsed on read by formatOutput.
+          if (typeof copy[field] === 'object') {
+            if (!copied) { copy = { ...copy }; copied = true; }
+            copy[field] = JSON.stringify(copy[field]);
+          }
+        } else {
+          // PostgreSQL: every value must be valid JSON so the native
+          // jsonb column accepts it. JSON.stringify wraps strings in
+          // quotes, leaves numbers/booleans unchanged as literals.
+          if (!copied) { copy = { ...copy }; copied = true; }
           copy[field] = JSON.stringify(copy[field]);
         }
       }
     }
+
+    if (!this.isSqlite) return copy;
 
     // Safety net: better-sqlite3 can only bind numbers/strings/bigints/buffers/
     // null. Any value still an array or plain object here (a field type not


### PR DESCRIPTION
## Summary
- PostgreSQL native `jsonb` columns now correctly receive `JSON.stringify` for all values (strings, numbers, booleans, objects)
- SQLite path unchanged: only objects/arrays are stringified (SQLite TEXT storage)
- Previously the SQLite-only path was incorrectly applied to PostgreSQL, causing primitives in `jsonb` columns to be silently rejected

## Test plan
- [ ] Verify `jsonb` column writes with string/number/boolean values work on PostgreSQL
- [ ] Verify existing SQLite JSON field behavior is unchanged

Made with [Cursor](https://cursor.com)