### PR TITLE
docs(ai): describe cloud data-tool registration in prose, not an uninstallable import

### DIFF
--- a/content/docs/ai/natural-language-queries.mdx
+++ b/content/docs/ai/natural-language-queries.mdx
@@ -52,21 +52,12 @@ model is prompted with the available objects and translates the user's question
 into `query_records` calls at runtime.
 
 <Callout type="info">
-**Cloud / Enterprise — bundled in-product chat.** The cloud tier's in-UI AI
-runtime (`@objectstack/service-ai`, the `ask` data-query assistant, and the
-`/api/v1/ai/*` chat endpoints) registers these data tools — plus the
-group-by/roll-up `aggregate_data` tool — into its chat loop via
-`registerDataTools`:
-
-```typescript
-import { registerDataTools } from '@objectstack/service-ai';
-
-ctx.hook('ai:ready', async (ai) => {
-  registerDataTools(ai.toolRegistry, { dataEngine: ctx.getService('data') });
-});
-```
-
-This is the cloud runtime, not the open path. On the open edition, use
+**Cloud / Enterprise — bundled in-product chat.** The cloud tier ships an in-UI
+AI runtime (`@objectstack/service-ai`, closed) — the `ask` data-query assistant
+and the `/api/v1/ai/*` chat endpoints — that registers these same data tools,
+plus the group-by/roll-up `aggregate_data` tool, into its own chat loop. That
+package is not part of the open framework and is documented separately in the
+cloud docs; this page covers the open path only. On the open edition, use
 `@objectstack/mcp` above to get the same natural-language querying with your
 own AI.
 </Callout>


### PR DESCRIPTION
Follow-up to #2812, closing the last (subtlest) open/cloud honesty gap the agent-capability audit flagged.

The Natural Language Queries page pasted:

```ts
import { registerDataTools } from '@objectstack/service-ai';  // closed cloud package
```

— installable-looking code for a package an open-edition reader **cannot install** (`@objectstack/service-ai` is closed cloud/EE). A reader who copies it and runs `pnpm add @objectstack/service-ai` hits a 404. That's the most subtle form of "declared ≠ delivered."

Replaced the code block with a prose description of what the cloud runtime does + a pointer to the cloud docs. The open `@objectstack/mcp` example earlier on the page (the thing that actually works on the open edition) is unchanged.

Per the open-core doc rule this whole thread settled on: **fence EE features (name + boundary + pointer), don't paste uninstallable code as if it were open.** Docs-only, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)