### PR TITLE
docs(adr): ADR-0092 标记 Accepted，关联实现 issue #2816 / #2817

### DIFF
--- a/docs/adr/0092-sys-user-profile-field-delegation.md
+++ b/docs/adr/0092-sys-user-profile-field-delegation.md
@@ -1,7 +1,8 @@
 # ADR-0092: Identity-table write guard — engine-enforced `managedBy: 'better-auth'`, with sys_user profile fields as the first whitelist
 
-- **Status:** Proposed
-- **Date:** 2026-07-10 (proposed) · 2026-07-11 (revised: D2 generalized from a sys_user-only hook to a registry-driven guard over every better-auth-managed object, per review)
+- **Status:** Accepted
+- **Date:** 2026-07-10 (proposed) · 2026-07-11 (revised: D2 generalized from a sys_user-only hook to a registry-driven guard over every better-auth-managed object, per review) · 2026-07-11 (accepted)
+- **Implementation:** #2816 (generic identity write guard — D2/D3/D6) → #2817 (sys_user edit affordance + form field gating — D4, gated on #2816)
 - **Deciders:** ObjectStack Protocol Architects
 - **Relates to:** [ADR-0010](./0010-metadata-protection-model.md) (identity tables managed by better-auth), [ADR-0049](./0049-no-unenforced-security-properties.md) (no unenforced security properties), [ADR-0068](./0068-unified-user-context-and-built-in-identity-roles.md) (platform-admin gate), [ADR-0069](./0069-enterprise-authentication-hardening.md) (system-managed auth stamps), #2766 / PR #2771 (admin user management + identity import), #2784 (originating RFC)
 


### PR DESCRIPTION
## 概要

按维护者决定将 ADR-0092 状态从 Proposed 改为 **Accepted**（2026-07-11），并在头部新增 Implementation 行关联两个已立的实现 issue：

- #2816 — 实现 A：通用身份表写守卫（D2/D3/D6，关键路径，同时堵全家族裸写洞）
- #2817 — 实现 B：sys_user edit affordance 翻转 + 表单字段只读治理（D4，硬依赖 #2816，ADR-0049 时序约束）

仅文档头部 3 行变更，决策正文不动。

## 相关

- 决策落地轨迹：#2787（首版）→ #2808（D2 通用化修订）→ 本 PR（接受）
- 源 RFC：#2784

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGAN5VvvBi4YRGwpNT6e21

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGAN5VvvBi4YRGwpNT6e21)_