### PR TITLE
feat(auth): 身份导入默认不设密码（passwordPolicy: 'none'）

### DIFF
--- a/.changeset/import-users-none-policy.md
+++ b/.changeset/import-users-none-policy.md
@@ -1,0 +1,22 @@
+---
+"@objectstack/plugin-auth": minor
+---
+
+feat(auth): `passwordPolicy: 'none'` is the identity import's new default — import provisions identity, not credentials
+
+`POST /api/v1/auth/admin/import-users` now supports (and defaults to)
+`passwordPolicy: 'none'`: accounts are created without a credential record
+(better-auth's optional-password create), so no password material is
+generated, returned, or distributed at all. Users first sign in through a
+channel — phone OTP, magic link, or a password-reset link — and the Console's
+existing credential-less detection (`hasLocalPassword()` → set-initial-password)
+nudges them to set a password afterwards.
+
+The `invite` policy also no longer mints a throwaway password: it creates the
+same credential-less account and sends the set-your-password invitation
+(better-auth's reset flow creates the credential record on first set).
+`temporary` is unchanged and remains the fallback for deployments without
+email/SMS infrastructure.
+
+Breaking-ish note: `passwordPolicy` was previously required — requests that
+omitted it got a 400. They now succeed with the `none` behavior.

--- a/content/docs/permissions/authentication.mdx
+++ b/content/docs/permissions/authentication.mdx
@@ -683,12 +683,17 @@ SSO-onboarded users who never had a local password.
 generic data import (`rows[]` / `csv` / `xlsxBase64`, `dryRun`), but writes
 every row through better-auth so the accounts are login-capable:
 
-- `passwordPolicy: 'invite'` — rows need a reachable identity: a real email
-  (invitation goes out as a set-your-password email; requires an email
-  service) or, for phone-only rows, a wired SMS service (invitation SMS +
-  phone-OTP first sign-in).
-- `passwordPolicy: 'temporary'` — per-row generated temporary passwords,
-  returned once in the response, with `mustChangePassword` enforced.
+- `passwordPolicy: 'none'` (**default**) — identity only: accounts are created
+  without a credential record. Users first sign in through a channel (phone
+  OTP, magic link, or a password-reset link) and the Console detects the
+  missing password (`hasLocalPassword()`) and offers set-initial-password.
+- `passwordPolicy: 'invite'` — `none` plus an invitation per created account:
+  rows need a reachable identity — a real email (set-your-password email;
+  requires an email service) or, for phone-only rows, a wired SMS service
+  (invitation SMS + phone-OTP first sign-in).
+- `passwordPolicy: 'temporary'` — the no-infrastructure fallback (no email,
+  no SMS): per-row generated temporary passwords, returned once in the
+  response, with `mustChangePassword` enforced.
 - `mode: 'insert' | 'upsert'` with `matchBy: 'email' | 'phone'`. Upsert
   updates only touch profile fields (`name`, `phone_number`, `role`) — a
   re-imported file can never modify an existing user's email or reset their

--- a/packages/plugins/plugin-auth/src/admin-import-users.test.ts
+++ b/packages/plugins/plugin-auth/src/admin-import-users.test.ts
@@ -64,11 +64,26 @@ function expectNoPasswordLeak(m: ReturnType<typeof makeDeps>, passwords: string[
 }
 
 describe('runAdminImportUsers — request validation', () => {
-  it('rejects a missing/invalid passwordPolicy', async () => {
+  it('rejects an unknown passwordPolicy', async () => {
     const m = makeDeps();
-    const res = await runAdminImportUsers(m.deps, makeRequest({ format: 'json', rows: [] }), ACTOR);
+    const res = await runAdminImportUsers(
+      m.deps,
+      makeRequest({ passwordPolicy: 'plaintext', format: 'json', rows: [] }),
+      ACTOR,
+    );
     expect(res.status).toBe(400);
     expect(m.createUser).not.toHaveBeenCalled();
+  });
+
+  it('defaults to the none policy when passwordPolicy is omitted', async () => {
+    const m = makeDeps();
+    const res = await runAdminImportUsers(
+      m.deps,
+      makeRequest({ format: 'json', rows: [{ email: 'a@b.co' }] }),
+      ACTOR,
+    );
+    expect(res.status).toBe(200);
+    expect((res.body.data as any).summary.passwordPolicy).toBe('none');
   });
 
   it('rejects matchBy phone when the phoneNumber plugin is off', async () => {
@@ -171,6 +186,52 @@ describe('runAdminImportUsers — row validation (also on dryRun)', () => {
       ACTOR,
     );
     expect((res2.body.data as any).rows[0].code).toBe('INVALID_PHONE');
+  });
+});
+
+describe('runAdminImportUsers — none policy (default: identity only, no credentials)', () => {
+  it('creates credential-less accounts: no password sent to better-auth, no stamps, no invitations', async () => {
+    const m = makeDeps({ phoneEnabled: true });
+    const res = await runAdminImportUsers(
+      m.deps,
+      makeRequest({
+        passwordPolicy: 'none', format: 'json',
+        rows: [
+          { email: 'a@x.co', name: 'A' },
+          { phone_number: '+8613800000001', name: 'B' },
+        ],
+      }),
+      ACTOR,
+    );
+    expect(res.status).toBe(200);
+    const data = res.body.data as any;
+    expect(data.summary.created).toBe(2);
+    expect(data.summary.passwordPolicy).toBe('none');
+
+    // better-auth receives NO password key at all → credential-less account.
+    for (const call of m.createUser.mock.calls) {
+      expect('password' in call[0].body).toBe(false);
+    }
+    // Phone-only row still gets a placeholder email.
+    expect(m.createUser.mock.calls[1][0].body.email).toMatch(/@placeholder\.invalid$/);
+
+    // No must_change_password stamps, no temporary passwords, no invitations.
+    expect(m.update.mock.calls.filter((c) => c[1]?.must_change_password === true).length).toBe(0);
+    expect(m.noteMustChangePasswordIssued).not.toHaveBeenCalled();
+    expect(data.rows.every((r: any) => r.temporaryPassword === undefined)).toBe(true);
+    expect(m.requestPasswordReset).not.toHaveBeenCalled();
+    expect(m.sendInviteSms).not.toHaveBeenCalled();
+  });
+
+  it('does not require an email or SMS service (unlike invite)', async () => {
+    const m = makeDeps({ emailAvailable: false, smsInviteAvailable: false });
+    const res = await runAdminImportUsers(
+      m.deps,
+      makeRequest({ passwordPolicy: 'none', format: 'json', rows: [{ email: 'a@b.co' }] }),
+      ACTOR,
+    );
+    expect(res.status).toBe(200);
+    expect((res.body.data as any).summary.created).toBe(1);
   });
 });
 

--- a/packages/plugins/plugin-auth/src/admin-import-users.ts
+++ b/packages/plugins/plugin-auth/src/admin-import-users.ts
@@ -14,15 +14,25 @@
  * `ImportProtocolLike` whose `createData` drives `auth.api.createUser`.
  *
  * Password policies:
- *  - `invite`     — every row needs a reachable identity. Accounts are created
- *                   with a random throwaway password the user never sees, then
- *                   a "set your password" invitation goes out per created
- *                   account: a reset-password email for rows with a REAL
- *                   email (requires a wired EmailService), or — #2780 — an
- *                   invitation SMS for phone-only rows (requires a wired,
+ *  - `none`       — THE DEFAULT. No password is set at all: better-auth
+ *                   creates the account without a credential record, and the
+ *                   user's first sign-in is channel-based (phone OTP, magic
+ *                   link, or an email reset link). The Console already
+ *                   detects credential-less accounts (`hasLocalPassword()`)
+ *                   and offers `set-initial-password`, so users are nudged to
+ *                   set a password after their first OTP sign-in. Import's
+ *                   job is identity — credentials are the auth domain's.
+ *  - `invite`     — like `none` (credential-less creation; better-auth's
+ *                   reset-password creates the credential account on first
+ *                   set), plus a "set your password" invitation goes out per
+ *                   created account: a reset-password email for rows with a
+ *                   REAL email (requires a wired EmailService), or — #2780 —
+ *                   an invitation SMS for phone-only rows (requires a wired,
  *                   deliverable SmsService + the phoneNumber plugin; the user
  *                   first signs in via phone OTP and then sets a password).
- *  - `temporary`  — each created account gets a generated temporary password,
+ *                   Rows are validated per-channel reachability.
+ *  - `temporary`  — the no-infrastructure fallback (no email, no SMS): each
+ *                   created account gets a generated temporary password,
  *                   `must_change_password` is stamped (403 PASSWORD_EXPIRED
  *                   until changed), and the passwords are returned ONCE in the
  *                   HTTP response, one per row. Never persisted, never logged.
@@ -95,7 +105,7 @@ interface RowIdentity {
 function resolveRowIdentity(
   row: Record<string, any>,
   opts: {
-    policy: 'invite' | 'temporary';
+    policy: 'none' | 'invite' | 'temporary';
     phoneEnabled: boolean;
     emailInviteOk: boolean;
     smsInviteOk: boolean;
@@ -162,9 +172,12 @@ export async function runAdminImportUsers(
   });
 
   // ── Request-level validation ─────────────────────────────────────────
-  const policy = body?.passwordPolicy;
-  if (policy !== 'invite' && policy !== 'temporary') {
-    return fail(400, 'invalid_request', 'passwordPolicy must be "invite" or "temporary"');
+  // Default policy: `none` — import provisions identity, not credentials.
+  // Users first sign in via a channel (phone OTP / magic link / reset link)
+  // and the Console's hasLocalPassword() flow nudges them to set a password.
+  const policy = body?.passwordPolicy === undefined ? 'none' : body.passwordPolicy;
+  if (policy !== 'none' && policy !== 'invite' && policy !== 'temporary') {
+    return fail(400, 'invalid_request', 'passwordPolicy must be "none" (default), "invite", or "temporary"');
   }
   const mode = body?.mode === 'upsert' ? 'upsert' : body?.mode === 'insert' || body?.mode === undefined ? 'insert' : undefined;
   if (!mode) return fail(400, 'invalid_request', 'mode must be "insert" or "upsert"');
@@ -254,7 +267,7 @@ export async function runAdminImportUsers(
       const data: Record<string, any> = args?.data ?? {};
       const email: string = typeof data.email === 'string' && data.email.length > 0
         ? data.email
-        : generatePlaceholderEmail(); // temporary policy only — invite rows were validated to carry one
+        : generatePlaceholderEmail(); // phone-only rows (none/temporary, or invite via SMS)
       const placeholder = !(typeof data.email === 'string' && data.email.length > 0);
       const phone: string | undefined = typeof data.phone_number === 'string' && data.phone_number.length > 0 ? data.phone_number : undefined;
       const name: string = typeof data.name === 'string' && data.name.trim().length > 0
@@ -262,16 +275,17 @@ export async function runAdminImportUsers(
         : placeholder ? (phone as string) : email.split('@')[0];
       const role: string | undefined = typeof data.role === 'string' && data.role.length > 0 ? data.role : undefined;
 
-      // Both policies create with a generated password: `temporary` hands it
-      // to the caller; `invite` throws it away (the user sets their own via
-      // the reset link) — the account is never password-less.
-      const password = generateTemporaryPassword();
+      // Only the `temporary` policy sets a password. `none`/`invite` create
+      // credential-less accounts (better-auth: omitted password → no
+      // credential record); the credential is minted later by the user via
+      // set-initial-password / the reset flow, which creates it on demand.
+      const password = policy === 'temporary' ? generateTemporaryPassword() : undefined;
 
       const created = await authApi.createUser({
         body: {
           email,
           name,
-          password,
+          ...(password ? { password } : {}),
           ...(role ? { role } : {}),
           ...(phone ? { data: { phoneNumber: phone } } : {}),
         },
@@ -280,16 +294,17 @@ export async function runAdminImportUsers(
       if (!id) throw Object.assign(new Error('better-auth returned no user id'), { code: 'CREATE_FAILED' });
 
       if (policy === 'temporary') {
-        temporaryPasswords.set(id, password);
+        temporaryPasswords.set(id, password as string);
         try {
           await engine.update('sys_user', { id, must_change_password: true }, { context: SYSTEM_CTX } as any);
           deps.noteMustChangePasswordIssued();
         } catch (e) {
           deps.logger?.warn(`[AuthPlugin] import-users: failed to stamp must_change_password for ${id}: ${(e as Error)?.message ?? e}`);
         }
-      } else {
+      } else if (policy === 'invite') {
         createdEmails.set(id, { email, placeholder, ...(phone ? { phone } : {}) });
       }
+      // `none`: nothing else to do — identity only.
       return { id };
     },
 


### PR DESCRIPTION
设计讨论结论（#2766 后续）：**导入的职责是身份，不是凭据**。验证码/魔法链接登录 + Console 已有的无密码检测（`hasLocalPassword()` → `/set-password` 引导，SSO 入职同款流程）意味着导入根本不需要生成密码。

## 变更

- **新增 `passwordPolicy: 'none'` 并设为默认**：建号时不传 password（better-auth 可选密码 → 无 credential 记录），零密码材料生成/返回/分发。用户经手机 OTP / 魔法链接 / 重置链接首登，Console 检测到无密码后引导 `set-initial-password`。
- **`invite` 不再生成丢弃式密码**：改为同样无凭据建号 + 发送邀请。依据：better-auth 1.6.23 的 reset-password 对无凭据账号会**自动创建 credential 记录**（`api/routes/password.mjs` 已核实），语义完全等价且更干净。
- **`temporary` 不变**：保留为"无邮件/短信基建部署"的显式兜底。
- 行为变化说明：`passwordPolicy` 原为必填（缺失 400），现在缺失 = `none`。
- 文档（authentication.mdx）与 changeset 同步更新。

## 测试

- plugin-auth 全套 372 测试通过（新增 4 个 none 策略用例：createUser 请求体断言**无 password 键**、无强制改密打戳、无邀请发送、不依赖邮件/短信服务；原"缺失策略 400"用例改为"未知策略 400 + 缺省即 none"）。
- `tsc --noEmit` 干净；`check-role-word` 通过。

## 三种策略的最终定位

| 策略 | 定位 | 密码 |
|---|---|---|
| `none`（默认） | 有 OTP/魔法链接渠道的常规入职 | 无——用户首登后自设（Console 引导已存在） |
| `invite` | 需要主动推送入职通知 | 无——邀请链接/短信 OTP 首登自设 |
| `temporary` | 无邮件/短信基建的兜底 | 服务端生成，一次性返回 + 强制改密 |

Ref #2766, #2782（向导适配器将把 `none` 作为默认选项）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016r6eiJzivw1CkwTDSGho1o

---
_Generated by [Claude Code](https://claude.ai/code/session_016r6eiJzivw1CkwTDSGho1o)_