### PR TITLE
feat(auth): 身份表写守卫 — managedBy:'better-auth' 引擎级强制（ADR-0092 D2/D3/D6，closes #2816）

### DIFF
--- a/.changeset/identity-write-guard.md
+++ b/.changeset/identity-write-guard.md
@@ -1,0 +1,37 @@
+---
+"@objectstack/plugin-auth": minor
+---
+
+feat(auth): identity write guard — `managedBy: 'better-auth'` is now enforced at the engine (ADR-0092 D2/D3/D6)
+
+Every object whose schema declares `managedBy: 'better-auth'` (`sys_user`,
+`sys_member`, `sys_session`, `sys_api_key`, …) is now protected by engine
+`beforeInsert` / `beforeUpdate` / `beforeDelete` hooks registered by
+plugin-auth: **user-context** writes through the generic data path are
+rejected fail-closed with `403 PERMISSION_DENIED`, closing the hole where a
+wildcard admin permission set could raw-write any identity column (including
+`email` and credential stamps) via the data API. Internal writes are
+unaffected — the better-auth adapter, `isSystem` plugin/system contexts, and
+the identity import keep working unchanged.
+
+The only opening is a per-object update whitelist
+(`registerManagedUpdateWhitelist(object, fields)`): non-whitelisted fields are
+stripped from the payload, and a payload that strips to nothing throws. The
+first registration ships here: `sys_user → { name, image }` (pure profile
+fields), backed by the new shared `SYS_USER_PROFILE_EDIT_FIELDS` /
+`SYS_USER_IMPORT_UPDATE_FIELDS` constants — the import upsert's field
+discipline is now derived from the same module (subset-by-construction, no
+drift).
+
+After a guarded profile edit, an `afterUpdate` companion hook re-writes the
+user's cached `{session, user}` snapshots in better-auth's secondary storage
+(same TTL, mirror of better-auth's own `refreshUserSessions`) so session
+reads stay coherent; it rewrites rather than deletes, and no-ops when no
+secondary storage is wired.
+
+Migration note: server-side scripts that previously updated identity tables
+with a **user** execution context must either run with a system context
+(`{ isSystem: true }`) if they are genuinely internal, or move to the
+dedicated auth endpoints (invite / create-user / set-user-password / ban /
+better-auth APIs). Flows and automations that wrote non-profile `sys_user`
+columns under a user identity are now filtered the same way.

--- a/packages/dogfood/test/single-tenant-identity-create.dogfood.test.ts
+++ b/packages/dogfood/test/single-tenant-identity-create.dogfood.test.ts
@@ -3,10 +3,20 @@
 /**
  * ADR-0057 — org-scoped identity objects must be creatable in SINGLE-TENANT.
  *
- * Single-tenant deployments have no `sys_organization` row and no auto-stamp
- * (OrgScopingPlugin is multi-tenant-only), so a `required` `organization_id`
- * made sys_business_unit / sys_team uncreatable (VALIDATION_FAILED). The field
- * is now optional; this proves the create path works with no org.
+ * Single-tenant deployments have no auto-stamp (OrgScopingPlugin is
+ * multi-tenant-only), so a `required` `organization_id` made
+ * sys_business_unit / sys_team uncreatable (VALIDATION_FAILED). The field is
+ * now optional; this proves the create path works single-tenant.
+ *
+ * ADR-0092 update: `sys_team` is `managedBy: 'better-auth'`, so its generic
+ * data-API insert is now REJECTED fail-closed for user contexts by the
+ * identity write guard. The canonical user surfaces are better-auth's team
+ * endpoints (see sys_team.actions), which the schema itself gates to
+ * multi-org mode — single-org hides every team-mutation affordance. The
+ * ADR-0057 property (optional `organization_id`) therefore matters for the
+ * writers that remain legitimate single-tenant: SYSTEM-context writes.
+ * sys_business_unit is plugin-security's table (not better-auth-managed) and
+ * keeps the generic create path.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -31,8 +41,27 @@ describe('ADR-0057: org-scoped identity creatable single-tenant', () => {
     expect(body.record?.organization_id ?? null).toBeNull();
   });
 
-  it('creates a sys_team with no organization_id', async () => {
-    const res = await stack.apiAs(token, 'POST', '/data/sys_team', { name: 'Tiger Team' });
-    expect(res.status).toBe(201);
+  it('sys_team: generic insert is guarded for users; org_id stays optional for system writes', async () => {
+    // ADR-0092 D2 — sys_team is managedBy:'better-auth', so a USER-context
+    // insert through the generic data API is rejected fail-closed (the
+    // canonical surfaces are better-auth's team endpoints, which the schema
+    // gates to multi-org mode — in single-org the affordances are hidden).
+    const direct = await stack.apiAs(token, 'POST', '/data/sys_team', { name: 'Tiger Team' });
+    expect(direct.status).toBe(403);
+    const denied: any = await direct.json();
+    expect(denied.code).toBe('PERMISSION_DENIED');
+
+    // ADR-0057's actual regression target — `organization_id` is OPTIONAL at
+    // the schema level, so a single-tenant (no org row) write does not die
+    // with VALIDATION_FAILED. System-context writes (org-structure sync,
+    // seeding) are the writers that remain legitimate post-ADR-0092.
+    const ql = await stack.kernel.getServiceAsync<any>('objectql');
+    const row = await ql.insert(
+      'sys_team',
+      { name: 'Tiger Team' },
+      { context: { isSystem: true } },
+    );
+    expect(row?.id).toBeTruthy();
+    expect(row?.organization_id ?? null).toBeNull();
   });
 });

--- a/packages/plugins/plugin-auth/src/admin-import-users.ts
+++ b/packages/plugins/plugin-auth/src/admin-import-users.ts
@@ -57,11 +57,17 @@ import type {
 import { prepareImportRequest, runImport } from '@objectstack/rest';
 import { generatePlaceholderEmail, isPlaceholderEmail } from './placeholder-email.js';
 import { generateTemporaryPassword, normalizePhoneNumber, isLikelyEmail, type AdminActor, type EndpointResult } from './admin-user-endpoints.js';
+import { SYS_USER_IMPORT_UPDATE_FIELDS } from './sys-user-writable-fields.js';
 
 export const IMPORT_USERS_MAX_ROWS = 500;
 
-/** Profile fields an upsert row may modify on an EXISTING user. */
-const UPDATE_ALLOWED_FIELDS = new Set(['name', 'phone_number', 'role']);
+/**
+ * Profile fields an upsert row may modify on an EXISTING user — shared with
+ * the identity write guard's Tier-1 whitelist via sys-user-writable-fields.ts
+ * (ADR-0092 D3: one file, one derivation; the import surface is a strict
+ * superset that additionally allows `phone_number` / `role`).
+ */
+const UPDATE_ALLOWED_FIELDS = SYS_USER_IMPORT_UPDATE_FIELDS;
 
 export interface IdentityImportEngine {
   find(objectName: string, query?: any): Promise<any[]>;

--- a/packages/plugins/plugin-auth/src/auth-plugin.ts
+++ b/packages/plugins/plugin-auth/src/auth-plugin.ts
@@ -18,6 +18,12 @@ import {
   type AuthManagerOptions,
 } from './auth-manager.js';
 import { ensureDefaultOrganization } from './ensure-default-organization.js';
+import {
+  registerIdentityWriteGuard,
+  registerManagedUpdateWhitelist,
+  type SecondaryStorageLike,
+} from './identity-write-guard.js';
+import { SYS_USER_PROFILE_EDIT_FIELDS } from './sys-user-writable-fields.js';
 import { runSetInitialPassword } from './set-initial-password.js';
 import { runRegisterSsoProviderFromForm, runRegisterSamlProviderFromForm, runRequestDomainVerification, runVerifyDomain } from './register-sso-provider.js';
 import { runResendVerificationEmail } from './send-verification-email.js';
@@ -125,6 +131,10 @@ export class AuthPlugin implements Plugin {
   private options: AuthPluginOptions;
   private authManager: AuthManager | null = null;
   private configuredSocialProviders: SocialProviderConfig | undefined;
+  // ADR-0092 D6 — the EFFECTIVE better-auth secondaryStorage (host-supplied or
+  // the kernel-cache adapter wired in init). The identity write guard's
+  // session-snapshot refresh reads through this; undefined = refresh no-ops.
+  private effectiveSecondaryStorage: AuthManagerOptions['secondaryStorage'];
 
   constructor(options: AuthPluginOptions = {}) {
     this.options = {
@@ -221,6 +231,9 @@ export class AuthPlugin implements Plugin {
 
     // Initialize auth manager with data engine
     this.authManager = new AuthManager(authConfig);
+    // ADR-0092 D6 — remember the storage better-auth will actually use so the
+    // identity write guard can keep cached session snapshots coherent.
+    this.effectiveSecondaryStorage = authConfig.secondaryStorage;
 
     // Register auth service
     ctx.registerService('auth', this.authManager);
@@ -532,6 +545,29 @@ export class AuthPlugin implements Plugin {
         ctx.logger.info('Identity-source afterInsert stamp registered on sys_account (SCIM-safe)');
       } catch {
         // Engine not available — skip; OAuth path still stamps via databaseHooks.
+      }
+    });
+
+    // ADR-0092 D2/D6 — generic identity write guard. Every object whose
+    // schema declares `managedBy: 'better-auth'` gets fail-closed protection
+    // against USER-CONTEXT writes through the generic data path; the only
+    // opening is the per-object update whitelist (sys_user → profile fields).
+    // Internal writes (better-auth adapter, isSystem plugin/system contexts)
+    // bypass — see identity-write-guard.ts for the full contract.
+    ctx.hook('kernel:ready', async () => {
+      try {
+        const engine: any = ctx.getService<any>('objectql');
+        if (!engine || typeof engine.registerHook !== 'function') return;
+        registerManagedUpdateWhitelist(SystemObjectName.USER, SYS_USER_PROFILE_EDIT_FIELDS);
+        registerIdentityWriteGuard(engine, {
+          packageId: 'com.objectstack.plugin-auth.identity-write-guard',
+          logger: ctx.logger,
+          getSecondaryStorage: () =>
+            this.effectiveSecondaryStorage as SecondaryStorageLike | undefined,
+        });
+      } catch {
+        // Engine not available (mock mode) — permission-set defaults remain
+        // the only gate, exactly the pre-guard status quo.
       }
     });
 

--- a/packages/plugins/plugin-auth/src/identity-write-guard.test.ts
+++ b/packages/plugins/plugin-auth/src/identity-write-guard.test.ts
@@ -1,0 +1,299 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ADR-0092 D2/D6 — identity write guard.
+ *
+ * The guard is exercised through a fake engine that records registerHook
+ * calls, so each registered handler is driven directly with synthetic
+ * HookContext shapes matching what ObjectQLEngine builds (session from
+ * buildSession, input.{id,data,options}).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  registerIdentityWriteGuard,
+  registerManagedUpdateWhitelist,
+  getManagedUpdateWhitelist,
+} from './identity-write-guard.js';
+import {
+  SYS_USER_PROFILE_EDIT_FIELDS,
+  SYS_USER_IMPORT_UPDATE_FIELDS,
+} from './sys-user-writable-fields.js';
+
+type Handler = (ctx: any) => Promise<void>;
+
+/** Fake engine capturing hook registrations, with a static schema registry. */
+function makeEngine(schemas: Record<string, any>) {
+  const handlers: Record<string, Array<{ handler: Handler; options: any }>> = {};
+  return {
+    handlers,
+    getSchema: (name: string) => schemas[name],
+    registerHook: (event: string, handler: Handler, options: any) => {
+      (handlers[event] ??= []).push({ handler, options });
+    },
+  };
+}
+
+const SCHEMAS = {
+  sys_user: { name: 'sys_user', managedBy: 'better-auth' },
+  sys_member: { name: 'sys_member', managedBy: 'better-auth' },
+  sys_session: { name: 'sys_session', managedBy: 'better-auth' },
+  crm_lead: { name: 'crm_lead' },
+  sys_automation_run: { name: 'sys_automation_run', managedBy: 'system' },
+};
+
+/** Session shapes as ObjectQLEngine.buildSession produces them. */
+const USER_SESSION = { userId: 'usr_1', positions: [] };
+const SYSTEM_SESSION = { userId: 'usr_1', isSystem: true };
+
+function guardOn(engine: ReturnType<typeof makeEngine>, event: string): Handler {
+  const entry = engine.handlers[event]?.find(
+    (h) => h.options?.packageId?.includes('identity-write-guard'),
+  );
+  if (!entry) throw new Error(`no guard handler registered for ${event}`);
+  return entry.handler;
+}
+
+function freshEngine() {
+  const engine = makeEngine(SCHEMAS);
+  registerManagedUpdateWhitelist('sys_user', SYS_USER_PROFILE_EDIT_FIELDS);
+  registerIdentityWriteGuard(engine, { packageId: 'test.identity-write-guard' });
+  return engine;
+}
+
+describe('identity write guard — insert/delete (ADR-0092 D2)', () => {
+  let engine: ReturnType<typeof makeEngine>;
+  beforeEach(() => {
+    engine = freshEngine();
+  });
+
+  it('rejects a user-context insert on every managedBy:better-auth table', async () => {
+    for (const object of ['sys_user', 'sys_member', 'sys_session']) {
+      await expect(
+        guardOn(engine, 'beforeInsert')({ object, session: USER_SESSION, input: { data: {} } }),
+      ).rejects.toMatchObject({ code: 'PERMISSION_DENIED', status: 403, object });
+    }
+  });
+
+  it('rejects a user-context delete, with a message pointing at the dedicated surfaces', async () => {
+    await expect(
+      guardOn(engine, 'beforeDelete')({ object: 'sys_member', session: USER_SESSION, input: { id: 'm1' } }),
+    ).rejects.toThrow(/managed by better-auth.*dedicated auth surface/s);
+  });
+
+  it('bypasses system-context and context-less (better-auth adapter) writes', async () => {
+    for (const event of ['beforeInsert', 'beforeDelete']) {
+      await expect(
+        guardOn(engine, event)({ object: 'sys_user', session: SYSTEM_SESSION, input: {} }),
+      ).resolves.toBeUndefined();
+      await expect(
+        guardOn(engine, event)({ object: 'sys_user', session: undefined, input: {} }),
+      ).resolves.toBeUndefined();
+    }
+  });
+
+  it('ignores objects that are not managed by better-auth (incl. other managedBy buckets)', async () => {
+    for (const object of ['crm_lead', 'sys_automation_run', 'not_registered']) {
+      await expect(
+        guardOn(engine, 'beforeInsert')({ object, session: USER_SESSION, input: { data: {} } }),
+      ).resolves.toBeUndefined();
+    }
+  });
+});
+
+describe('identity write guard — update whitelist (ADR-0092 D2)', () => {
+  let engine: ReturnType<typeof makeEngine>;
+  beforeEach(() => {
+    engine = freshEngine();
+  });
+
+  it('strips non-whitelisted fields in place and lets whitelisted ones through', async () => {
+    const data: any = { id: 'u1', name: 'New Name', image: 'https://x/a.png', email: 'evil@x', role: 'admin' };
+    await guardOn(engine, 'beforeUpdate')({
+      object: 'sys_user',
+      session: USER_SESSION,
+      input: { id: 'u1', data },
+    });
+    expect(data).toEqual({ id: 'u1', name: 'New Name', image: 'https://x/a.png' });
+  });
+
+  it('throws when every submitted field is non-whitelisted (loud failure, not a silent no-op)', async () => {
+    const data: any = { id: 'u1', email: 'evil@x', must_change_password: false };
+    await expect(
+      guardOn(engine, 'beforeUpdate')({ object: 'sys_user', session: USER_SESSION, input: { id: 'u1', data } }),
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED', status: 403 });
+    // The error names what IS editable so the caller can fix the payload.
+    await expect(
+      guardOn(engine, 'beforeUpdate')({ object: 'sys_user', session: USER_SESSION, input: { id: 'u1', data: { email: 'e@x' } } }),
+    ).rejects.toThrow(/Editable fields: name, image/);
+  });
+
+  it('passes engine-stamped lifecycle columns through, but they never satisfy the whitelist alone', async () => {
+    // The REST data routes stamp updated_at on every update — a legit
+    // profile edit must keep it (audit freshness)…
+    const ok: any = { id: 'u1', name: 'N', updated_at: '2026-07-11T00:00:00Z' };
+    await guardOn(engine, 'beforeUpdate')({ object: 'sys_user', session: USER_SESSION, input: { id: 'u1', data: ok } });
+    expect(ok).toEqual({ id: 'u1', name: 'N', updated_at: '2026-07-11T00:00:00Z' });
+    // …but an email-only PATCH must still fail loudly, not degrade into a
+    // timestamp touch.
+    await expect(
+      guardOn(engine, 'beforeUpdate')({
+        object: 'sys_user',
+        session: USER_SESSION,
+        input: { id: 'u1', data: { email: 'evil@x', updated_at: '2026-07-11T00:00:00Z' } },
+      }),
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('rejects updates to managed tables with NO registered whitelist (default-deny)', async () => {
+    await expect(
+      guardOn(engine, 'beforeUpdate')({
+        object: 'sys_member',
+        session: USER_SESSION,
+        input: { id: 'm1', data: { role: 'owner' } },
+      }),
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED', object: 'sys_member' });
+  });
+
+  it('filters the payload of multi-row updates too (input.id undefined)', async () => {
+    const data: any = { banned: true, name: 'Bulk Rename' };
+    await guardOn(engine, 'beforeUpdate')({
+      object: 'sys_user',
+      session: USER_SESSION,
+      input: { id: undefined, data, options: { multi: true } },
+    });
+    expect(data).toEqual({ name: 'Bulk Rename' });
+  });
+
+  it('bypasses system-context and context-less updates entirely (no stripping)', async () => {
+    const data: any = { id: 'u1', must_change_password: true };
+    await guardOn(engine, 'beforeUpdate')({ object: 'sys_user', session: SYSTEM_SESSION, input: { id: 'u1', data } });
+    expect(data).toEqual({ id: 'u1', must_change_password: true });
+    await guardOn(engine, 'beforeUpdate')({ object: 'sys_user', session: undefined, input: { id: 'u1', data } });
+    expect(data).toEqual({ id: 'u1', must_change_password: true });
+  });
+
+  it('exposes the registered whitelist for introspection', () => {
+    expect(getManagedUpdateWhitelist('sys_user')).toEqual(new Set(['name', 'image']));
+    expect(getManagedUpdateWhitelist('sys_session')).toBeUndefined();
+  });
+});
+
+describe('identity write guard — session snapshot refresh (ADR-0092 D6)', () => {
+  const NOW = Date.now();
+  const EXPIRES = new Date(NOW + 3600_000).toISOString();
+
+  function makeStorage(userId: string, tokens: string[]) {
+    const store = new Map<string, string>();
+    store.set(
+      `active-sessions-${userId}`,
+      JSON.stringify(tokens.map((token) => ({ token, expiresAt: NOW + 3600_000 }))),
+    );
+    for (const token of tokens) {
+      store.set(
+        token,
+        JSON.stringify({
+          session: { token, userId, expiresAt: EXPIRES },
+          user: { id: userId, name: 'Old Name', image: null, email: 'a@b.c' },
+        }),
+      );
+    }
+    const ttls: Record<string, number | undefined> = {};
+    return {
+      store,
+      ttls,
+      get: vi.fn(async (k: string) => store.get(k) ?? null),
+      set: vi.fn(async (k: string, v: string, ttl?: number) => {
+        store.set(k, v);
+        ttls[k] = ttl;
+      }),
+      delete: vi.fn(async (k: string) => void store.delete(k)),
+    };
+  }
+
+  function engineWithStorage(storage: any) {
+    const engine = makeEngine(SCHEMAS);
+    registerManagedUpdateWhitelist('sys_user', SYS_USER_PROFILE_EDIT_FIELDS);
+    registerIdentityWriteGuard(engine, {
+      packageId: 'test.identity-write-guard',
+      getSecondaryStorage: () => storage,
+    });
+    return engine;
+  }
+
+  it('re-writes every live cached session with the changed profile fields (same user, keeps TTL, never deletes)', async () => {
+    const storage = makeStorage('u1', ['tok-a', 'tok-b']);
+    const engine = engineWithStorage(storage);
+    await guardOn(engine, 'afterUpdate')({
+      object: 'sys_user',
+      session: USER_SESSION,
+      input: { id: 'u1', data: { name: 'New Name' } },
+    });
+    for (const token of ['tok-a', 'tok-b']) {
+      const entry = JSON.parse(storage.store.get(token)!);
+      expect(entry.user).toMatchObject({ id: 'u1', name: 'New Name', email: 'a@b.c' });
+      expect(entry.session.token).toBe(token);
+      expect(storage.ttls[token]).toBeGreaterThan(0);
+    }
+    expect(storage.delete).not.toHaveBeenCalled();
+  });
+
+  it('no-ops without secondary storage, without a whitelisted change, or for system writes', async () => {
+    const storage = makeStorage('u1', ['tok-a']);
+    // System write — better-auth's own paths already refresh.
+    let engine = engineWithStorage(storage);
+    await guardOn(engine, 'afterUpdate')({
+      object: 'sys_user',
+      session: SYSTEM_SESSION,
+      input: { id: 'u1', data: { name: 'X' } },
+    });
+    expect(storage.set).not.toHaveBeenCalled();
+    // Non-whitelisted change only (nothing survived the guard anyway).
+    await guardOn(engine, 'afterUpdate')({
+      object: 'sys_user',
+      session: USER_SESSION,
+      input: { id: 'u1', data: { last_login_ip: '1.2.3.4' } },
+    });
+    expect(storage.set).not.toHaveBeenCalled();
+    // No storage wired.
+    engine = engineWithStorage(undefined);
+    await expect(
+      guardOn(engine, 'afterUpdate')({
+        object: 'sys_user',
+        session: USER_SESSION,
+        input: { id: 'u1', data: { name: 'X' } },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('survives storage failures without breaking the write', async () => {
+    const storage = {
+      get: vi.fn(async () => {
+        throw new Error('redis down');
+      }),
+      set: vi.fn(),
+      delete: vi.fn(),
+    };
+    const engine = engineWithStorage(storage);
+    await expect(
+      guardOn(engine, 'afterUpdate')({
+        object: 'sys_user',
+        session: USER_SESSION,
+        input: { id: 'u1', data: { name: 'X' } },
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('sys-user writable-field tiers (ADR-0092 D3)', () => {
+  it('import whitelist is a strict superset of the profile whitelist', () => {
+    for (const f of SYS_USER_PROFILE_EDIT_FIELDS) {
+      expect(SYS_USER_IMPORT_UPDATE_FIELDS.has(f)).toBe(true);
+    }
+    expect(SYS_USER_IMPORT_UPDATE_FIELDS.has('phone_number')).toBe(true);
+    expect(SYS_USER_IMPORT_UPDATE_FIELDS.has('role')).toBe(true);
+    // The profile tier stays profile-only.
+    expect(SYS_USER_PROFILE_EDIT_FIELDS.has('role')).toBe(false);
+    expect(SYS_USER_PROFILE_EDIT_FIELDS.has('email')).toBe(false);
+  });
+});

--- a/packages/plugins/plugin-auth/src/identity-write-guard.ts
+++ b/packages/plugins/plugin-auth/src/identity-write-guard.ts
@@ -1,0 +1,280 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ADR-0092 D2 — generic identity write guard.
+ *
+ * `managedBy: 'better-auth'` promises that identity tables are only written
+ * through the better-auth pipeline, but until this guard that promise was
+ * enforced by nothing except UI affordances and default permission sets —
+ * `admin_full_access` (wildcard, no RLS) could raw-write any column of any
+ * identity table through the generic data API (ADR-0049 violation).
+ *
+ * The guard registers engine `beforeInsert` / `beforeUpdate` / `beforeDelete`
+ * hooks that fail-closed reject USER-CONTEXT writes to every object whose
+ * registered schema declares `managedBy: 'better-auth'`. The flag is read
+ * from the schema registry at evaluation time — there is no hardcoded table
+ * list to drift from the schemas.
+ *
+ * What passes untouched:
+ *  - the better-auth adapter (its engine calls carry no caller context);
+ *  - plugin / system writes (`isSystem` contexts, e.g. import, sign-in
+ *    stamps, provenance hooks).
+ *
+ * The only opening is a per-object UPDATE whitelist
+ * ({@link registerManagedUpdateWhitelist}); non-whitelisted keys are
+ * stripped, and a payload that strips to nothing throws — a loud failure,
+ * not a silent no-op. First (and currently only) registration:
+ * `sys_user → SYS_USER_PROFILE_EDIT_FIELDS` (name, image).
+ *
+ * Rejections use `code: 'PERMISSION_DENIED'` + `status: 403`, which the REST
+ * layer's `mapDataError` / `sendError` already translate — same pattern as
+ * plugin-audit's FEEDS_DISABLED / FILES_DISABLED capability gates.
+ *
+ * ADR-0092 D6 — a companion `afterUpdate` hook keeps better-auth's
+ * secondary-storage session snapshots coherent after a guarded profile edit,
+ * mirroring better-auth's own `refreshUserSessions`: each cached
+ * `{session, user}` entry for the affected user is re-written (same TTL)
+ * with the changed fields merged in. It rewrites, never deletes — deleting
+ * would sign the user out when sessions live only in the cache.
+ */
+
+type LoggerLike = {
+  info(msg: string): void;
+  warn(msg: string): void;
+  debug?(msg: string): void;
+};
+
+/** Shape of better-auth's `secondaryStorage` (see secondary-storage.ts). */
+export interface SecondaryStorageLike {
+  get(key: string): Promise<string | null | undefined>;
+  set(key: string, value: string, ttl?: number): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+export interface IdentityWriteGuardOptions {
+  packageId: string;
+  logger?: LoggerLike;
+  /**
+   * Resolves the EFFECTIVE better-auth secondaryStorage (kernel cache
+   * adapter or host-supplied). Undefined / throwing = session caching not
+   * wired = the D6 refresh is a no-op (single-node memory cache TTLs the
+   * stale snapshot out).
+   */
+  getSecondaryStorage?: () => SecondaryStorageLike | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Update whitelist registry (ADR-0092 D2)
+// ---------------------------------------------------------------------------
+
+const updateWhitelists = new Map<string, ReadonlySet<string>>();
+
+/**
+ * Open a per-object UPDATE whitelist on a better-auth-managed table. The
+ * listed fields become editable through the generic data path for callers
+ * the permission layer already admits; everything else stays stripped.
+ * Registering is the ONLY way to open a managed table — absence = deny.
+ */
+export function registerManagedUpdateWhitelist(object: string, fields: Iterable<string>): void {
+  updateWhitelists.set(object, new Set(fields));
+}
+
+/** Test seam / introspection. */
+export function getManagedUpdateWhitelist(object: string): ReadonlySet<string> | undefined {
+  return updateWhitelists.get(object);
+}
+
+// ---------------------------------------------------------------------------
+// Guard internals
+// ---------------------------------------------------------------------------
+
+/**
+ * A write is user-context when the operation context carries a real user and
+ * is not system-elevated. better-auth's own adapter calls pass no context at
+ * all (no session → not user-context), and plugin/system writes stamp
+ * `isSystem` — both bypass by construction.
+ */
+function isUserContextWrite(session: any): boolean {
+  return Boolean(session?.userId) && session?.isSystem !== true;
+}
+
+function forbidden(object: string, message: string): Error {
+  const err: any = new Error(`PERMISSION_DENIED: ${message}`);
+  err.code = 'PERMISSION_DENIED';
+  err.status = 403;
+  err.object = object;
+  return err;
+}
+
+const DEDICATED_SURFACE_HINT =
+  'use the dedicated auth surface instead (invite / create-user / admin endpoints, or the better-auth API)';
+
+/**
+ * Engine-owned lifecycle stamps the WRITE PATH itself injects (the REST data
+ * routes stamp `updated_at`/`updated_by` on every update, for every object).
+ * They pass through the whitelist filter — stripping them would freeze the
+ * row's audit freshness on guarded edits — but they do NOT count as "a field
+ * the caller may edit": an update whose only surviving keys are lifecycle
+ * stamps is still rejected, otherwise an email-only PATCH would silently
+ * degrade into a timestamp touch instead of failing loudly.
+ */
+const LIFECYCLE_PASSTHROUGH = new Set(['updated_at', 'updated_by']);
+
+/**
+ * Register the identity write guard on an ObjectQL engine. Idempotent per
+ * package: callers re-binding after hot reload should first run
+ * `engine.unregisterHooksByPackage(packageId)` (the engine's standard
+ * re-bind contract).
+ *
+ * Priority 10 (< default 100) so a rejection fires before plugin-audit's
+ * `beforeUpdate` prior-snapshot fetch and any other default-priority hooks
+ * spend work on a doomed write.
+ */
+export function registerIdentityWriteGuard(engine: any, opts: IdentityWriteGuardOptions): void {
+  const { packageId, logger } = opts;
+
+  const isManaged = (object: string): boolean => {
+    try {
+      return engine.getSchema?.(object)?.managedBy === 'better-auth';
+    } catch {
+      return false;
+    }
+  };
+
+  const rejectWrite = (operation: 'create' | 'delete') => async (ctx: any) => {
+    if (!isManaged(ctx.object) || !isUserContextWrite(ctx.session)) return;
+    throw forbidden(
+      ctx.object,
+      `Identity table '${ctx.object}' is managed by better-auth (ADR-0092): ` +
+        `direct ${operation} via the data API is disabled — ${DEDICATED_SURFACE_HINT}.`,
+    );
+  };
+
+  const guardUpdate = async (ctx: any) => {
+    if (!isManaged(ctx.object) || !isUserContextWrite(ctx.session)) return;
+
+    const whitelist = updateWhitelists.get(ctx.object);
+    if (!whitelist) {
+      throw forbidden(
+        ctx.object,
+        `Identity table '${ctx.object}' is managed by better-auth (ADR-0092): ` +
+          `direct update via the data API is disabled — ${DEDICATED_SURFACE_HINT}.`,
+      );
+    }
+
+    const data: Record<string, unknown> = (ctx.input?.data ?? {}) as Record<string, unknown>;
+    const stripped: string[] = [];
+    let editableRemaining = 0;
+    for (const key of Object.keys(data)) {
+      // `id` is the row address, not a field write — the engine has already
+      // extracted it into `input.id`; leaving it in place changes nothing.
+      if (key === 'id') continue;
+      if (LIFECYCLE_PASSTHROUGH.has(key)) continue;
+      if (whitelist.has(key)) {
+        editableRemaining += 1;
+      } else {
+        delete data[key];
+        stripped.push(key);
+      }
+    }
+
+    if (editableRemaining === 0) {
+      throw forbidden(
+        ctx.object,
+        `None of the submitted fields (${stripped.join(', ') || '—'}) are editable on ` +
+          `'${ctx.object}' via the data API (ADR-0092). Editable fields: ` +
+          `${[...whitelist].join(', ')}. For anything else, ${DEDICATED_SURFACE_HINT}.`,
+      );
+    }
+    if (stripped.length > 0) {
+      logger?.warn(
+        `[IdentityWriteGuard] stripped non-whitelisted field(s) from user-context update to ` +
+          `'${ctx.object}': ${stripped.join(', ')} (ADR-0092)`,
+      );
+    }
+  };
+
+  engine.registerHook('beforeInsert', rejectWrite('create'), { priority: 10, packageId });
+  engine.registerHook('beforeUpdate', guardUpdate, { priority: 10, packageId });
+  engine.registerHook('beforeDelete', rejectWrite('delete'), { priority: 10, packageId });
+
+  // ── ADR-0092 D6 — session-snapshot coherence after guarded profile edits ──
+  //
+  // better-auth caches `{session, user}` per session token in secondary
+  // storage, plus an `active-sessions-${userId}` index. Its OWN update paths
+  // re-write those snapshots (internal-adapter `refreshUserSessions`); a
+  // guarded engine write bypasses that, so we mirror it here for the fields
+  // the guard let through. sys_user Tier-1 columns map 1:1 onto better-auth
+  // user-model field names (name → name, image → image); anything that would
+  // need a snake_case → camelCase translation is not whitelisted today, and
+  // widening the whitelist must extend this mapping deliberately.
+  const refreshSessionSnapshots = async (ctx: any) => {
+    try {
+      if (ctx.object !== 'sys_user' || !isUserContextWrite(ctx.session)) return;
+      const storage = opts.getSecondaryStorage?.();
+      if (!storage) return;
+
+      const data: Record<string, unknown> = (ctx.input?.data ?? {}) as Record<string, unknown>;
+      const whitelist = updateWhitelists.get('sys_user');
+      const changed: Record<string, unknown> = {};
+      for (const key of Object.keys(data)) {
+        if (key !== 'id' && whitelist?.has(key)) changed[key] = data[key];
+      }
+      if (Object.keys(changed).length === 0) return;
+
+      const userId = ctx.input?.id ?? data.id;
+      if (!userId) {
+        // Multi-row user-context update — no single user to refresh. Rare
+        // (bulk profile edits); snapshots then age out on their TTL.
+        logger?.warn(
+          '[IdentityWriteGuard] multi-row sys_user update: session snapshots not refreshed (TTL will age them out)',
+        );
+        return;
+      }
+
+      const listRaw = await storage.get(`active-sessions-${String(userId)}`);
+      if (!listRaw) return;
+      let list: Array<{ token: string; expiresAt: number }> = [];
+      try {
+        list = JSON.parse(listRaw) ?? [];
+      } catch {
+        return;
+      }
+      const now = Date.now();
+      await Promise.all(
+        list
+          .filter((s) => s && typeof s.token === 'string' && s.expiresAt > now)
+          .map(async ({ token }) => {
+            const cached = await storage.get(token);
+            if (!cached) return;
+            let parsed: any;
+            try {
+              parsed = JSON.parse(cached);
+            } catch {
+              return;
+            }
+            if (!parsed?.session || !parsed?.user) return;
+            const ttl = Math.floor((new Date(parsed.session.expiresAt).getTime() - now) / 1000);
+            if (!Number.isFinite(ttl) || ttl <= 0) return;
+            await storage.set(
+              token,
+              JSON.stringify({ session: parsed.session, user: { ...parsed.user, ...changed } }),
+              ttl,
+            );
+          }),
+      );
+    } catch (e) {
+      // Snapshot refresh must never fail the write — worst case the cached
+      // profile is stale until the session entry's TTL expires.
+      logger?.warn(
+        `[IdentityWriteGuard] session snapshot refresh failed: ${(e as Error)?.message ?? e}`,
+      );
+    }
+  };
+
+  engine.registerHook('afterUpdate', refreshSessionSnapshots, { object: 'sys_user', packageId });
+
+  logger?.info(
+    '[IdentityWriteGuard] managedBy:better-auth write guard registered (ADR-0092 D2/D6)',
+  );
+}

--- a/packages/plugins/plugin-auth/src/index.ts
+++ b/packages/plugins/plugin-auth/src/index.ts
@@ -15,6 +15,8 @@ export * from './set-initial-password.js';
 export * from './admin-user-endpoints.js';
 export * from './placeholder-email.js';
 export * from './admin-import-users.js';
+export * from './identity-write-guard.js';
+export * from './sys-user-writable-fields.js';
 export * from './otp-send-guard.js';
 export * from './register-sso-provider.js';
 export * from './send-verification-email.js';

--- a/packages/plugins/plugin-auth/src/sys-user-writable-fields.ts
+++ b/packages/plugins/plugin-auth/src/sys-user-writable-fields.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ADR-0092 D1/D3 — the single source of truth for which `sys_user` columns
+ * generic write surfaces may touch.
+ *
+ * Two tiers, subset-by-construction (a spread, not two hand-maintained
+ * lists), because the two surfaces intentionally differ:
+ *
+ *  - the standard edit form / data API may only touch pure profile fields
+ *    (enforced server-side by the identity write guard, ADR-0092 D2);
+ *  - the admin bulk-identity import may additionally upsert `phone_number`
+ *    (sign-in identifier — bulk identity onboarding is that surface's
+ *    purpose) and `role`. Import runs under a system context, so it passes
+ *    the guard by context, not by whitelist — this constant is its own
+ *    field discipline.
+ *
+ * Everything not listed here is either admin-surface-only (role/ban columns,
+ * `manager_id`, `ai_access`, …) or never-direct (email, credentials, every
+ * system-managed stamp). See ADR-0092 D1 for the full tier table. Adding a
+ * field to `sys_user` never silently opens it — absence means denied.
+ */
+
+/** Tier 1 — standard form / data-API editable (identity write guard whitelist). */
+export const SYS_USER_PROFILE_EDIT_FIELDS: ReadonlySet<string> = new Set(['name', 'image']);
+
+/** Import-upsert may additionally touch these (admin bulk-identity surface). */
+export const SYS_USER_IMPORT_UPDATE_FIELDS: ReadonlySet<string> = new Set([
+  ...SYS_USER_PROFILE_EDIT_FIELDS,
+  'phone_number',
+  'role',
+]);


### PR DESCRIPTION
## 概要

ADR-0092 实现 A（#2816）：`managedBy: 'better-auth'` 从"文档承诺"变为引擎真实边界。

- **identity-write-guard.ts** — plugin-auth 在 `kernel:ready` 注册 `before{Insert,Update,Delete}` hook（priority 10，先于审计快照）。判定按 schema registry 的 `managedBy === 'better-auth'` 标志（无硬编码表清单）；**用户上下文**写入 default-deny，403 `PERMISSION_DENIED` 且错误信息指路专用端点。better-auth adapter（无 context）与 `isSystem` 写入直通。
- **白名单 registry** — `registerManagedUpdateWhitelist(object, fields)` 是唯一开口；首条目 `sys_user → {name, image}`。名单外字段剥离；剥空抛错（响亮失败）。引擎盖章的生命周期列（`updated_at`/`updated_by`）直通但不计入白名单判定 —— 否则纯 email PATCH 会退化成时间戳触碰而非报错（dogfood 中发现并修复）。
- **sys-user-writable-fields.ts**（D3）— 共享字段分层：档案白名单 `{name, image}` 与 import 超集 `{+phone_number, role}`（spread 派生防漂移）；`admin-import-users.ts` 的 `UPDATE_ALLOWED_FIELDS` 改为共享常量。
- **D6** — `afterUpdate` hook 镜像 better-auth `refreshUserSessions`：守卫放行的档案编辑后，按原 TTL **重写**（绝不删除，避免误登出）secondary storage 中该用户的 `{session, user}` 快照。

## 验证

**单测**（新增 15 项，plugin-auth 全套 387 项通过）：逐表用户上下文 insert/delete/update 拒绝、白名单剥离与空包抛错、system/无 context 直通、multi-update 过滤、生命周期列直通、D6 快照重写/无 storage no-op/storage 故障不破坏写入、字段分层超集关系。

**真机验证**（`--fresh` CRM 后端 + seeded platform admin，curl）：

| 操作 | 结果 |
|:---|:---|
| PATCH `sys_user` name | ✅ 200，持久化，`updated_at` 刷新 |
| PATCH 仅 email | ✅ 403 + "Editable fields: name, image" 指路 |
| PATCH name+role+must_change_password | ✅ 200，role/mcp 剥离未落库 |
| POST / DELETE `sys_user` | ✅ 403 |
| `/admin/create-user`（临时密码 + mcp 盖章） | ✅ 正常 |
| `/admin/set-user-password` | ✅ 正常 |
| 自助 `/update-user` | ✅ 正常（better-auth 路径） |
| `/admin/import-users` upsert 更新 | ✅ 正常（SYSTEM_CTX 直通） |

注：`/admin/ban-user` 返回 better-auth 原生 `YOU_ARE_NOT_ALLOWED_TO_BAN_USERS`（stock 插件只认 role 标量，seeded admin role=user）—— 既有行为，与本守卫无关（错误码可区分）。

**调用点扫描**：全仓身份表写调用点（plugin-auth × 9、plugin-sharing × 2）全部已是 `SYSTEM_CTX`，无需迁移。

## 迁移说明（见 changeset）

以用户上下文直写身份表的服务端脚本需改 system context（真内部写）或走专用端点；flow/automation 以用户身份写非档案 `sys_user` 列的同样被过滤。

## 相关

ADR-0092（Accepted）· closes #2816 · 后续：#2817（affordance 翻转，依赖本 PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGAN5VvvBi4YRGwpNT6e21

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGAN5VvvBi4YRGwpNT6e21)_