### PR TITLE
docs(ai): link framework AI docs' cloud pointers to the new cloud AI section

### DIFF
--- a/content/docs/ai/index.mdx
+++ b/content/docs/ai/index.mdx
@@ -20,7 +20,7 @@ AI in ObjectStack is a **cross-protocol capability layer**: agents, tools, and k
 - **Knowledge & RAG → the Knowledge Protocol + adapter plugins** (`knowledge-memory`, `knowledge-ragflow`, `embedder-openai`) — permission-aware retrieval over your own objects.
 - **Agents, tools, skills → typed metadata** (`defineAgent` / `defineTool` / `defineSkill`) plus the Model Registry. Author them as source (`*.agent.ts`, `*.tool.ts`, …) with your own AI coding agent (Claude Code, Cursor), aided by the ObjectStack [skills](/docs/ai/skills-reference) and MCP introspection.
 
-The **cloud / Enterprise** tier adds an in-product chat *runtime* on top of these same primitives — the `ask` data-query assistant, the `build` Studio authoring assistant, and the `/api/v1/ai/*` chat endpoints (`@objectstack/service-ai`, cloud [ADR-0025](https://github.com/objectstack-ai/cloud/blob/main/docs/adr/0025-service-ai-to-cloud-open-mcp-only.md)). The open edition has no built-in in-product chat.
+The **cloud / Enterprise** tier adds an in-product chat *runtime* on top of these same primitives — the `ask` data-query assistant, the `build` Studio authoring assistant, and the `/api/v1/ai/*` chat endpoints (`@objectstack/service-ai`, cloud [ADR-0025](https://github.com/objectstack-ai/cloud/blob/main/docs/adr/0025-service-ai-to-cloud-open-mcp-only.md)). The open edition has no built-in in-product chat — that runtime is documented in the [cloud AI & Agents docs](https://docs.objectos.app/docs/ai).
 </Callout>
 
 ## What's in this module

--- a/content/docs/ai/natural-language-queries.mdx
+++ b/content/docs/ai/natural-language-queries.mdx
@@ -57,7 +57,8 @@ AI runtime (`@objectstack/service-ai`, closed) — the `ask` data-query assistan
 and the `/api/v1/ai/*` chat endpoints — that registers these same data tools,
 plus the group-by/roll-up `aggregate_data` tool, into its own chat loop. That
 package is not part of the open framework and is documented separately in the
-cloud docs; this page covers the open path only. On the open edition, use
+[cloud docs](https://docs.objectos.app/docs/ai); this page covers the open path
+only. On the open edition, use
 `@objectstack/mcp` above to get the same natural-language querying with your
 own AI.
 </Callout>


### PR DESCRIPTION
Now that the cloud docs ship a complete **AI & Agents** section at [docs.objectos.app/docs/ai](https://docs.objectos.app/docs/ai) (cloud PR #806), turn the framework AI docs' two "documented separately in the cloud docs" / "no built-in in-product chat" prose pointers into concrete cross-site links.

This fulfills the cross-reference the open-edition honesty pass (#2812/#2813) promised: the framework side fences EE features and points at the cloud docs; those docs now exist and are linked. Two-site open-core doc model, end-to-end.

- `content/docs/ai/natural-language-queries.mdx` — "the cloud docs" → link.
- `content/docs/ai/index.mdx` — "that runtime is documented in the cloud AI & Agents docs" → link.

Docs-only, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)