### PR TITLE
docs(auth): import-users 端点参考补 none 默认 + Console 向导入口

### DIFF
--- a/content/docs/permissions/authentication.mdx
+++ b/content/docs/permissions/authentication.mdx
@@ -713,6 +713,12 @@ every row through better-auth so the accounts are login-capable:
 - Synchronous only, at most 500 rows per request (password hashing is
   CPU-bound); split larger files into batches. Imports are not undoable.
 
+In the Console, platform admins reach this from the **Users list → Import**
+toolbar button (shown when the admin plugin is enabled). The import wizard
+uploads a CSV/Excel file, maps columns, previews with a dry-run, and — for
+the `temporary` policy — reveals the generated passwords once with a
+download, splitting files above 500 rows into batches automatically.
+
 ---
 
 ## Client Integration
@@ -836,7 +842,7 @@ All endpoints are available under `/api/v1/auth/*`:
 
 - `POST /api/v1/auth/admin/create-user` - Create a login-capable account (optional one-time temporary password + forced change)
 - `POST /api/v1/auth/admin/set-user-password` - Set/reset a user's password (also provisions a credential for SSO-onboarded users)
-- `POST /api/v1/auth/admin/import-users` - Bulk import users (CSV/JSON/XLSX; invite or temporary password policy; ≤500 rows, dry-run supported)
+- `POST /api/v1/auth/admin/import-users` - Bulk import users (CSV/JSON/XLSX; `none` (default) / `invite` / `temporary` password policy; ≤500 rows, dry-run supported)
 - `POST /api/v1/auth/admin/unlock-user` - Clear a brute-force lockout early
 
 For complete API documentation, see the [Better-Auth API Reference](https://www.better-auth.com/docs).


### PR DESCRIPTION
浏览器 dogfood 验证身份导入链路后发现的两处文档小缺口：

1. **端点参考行**（API Reference 小节）仍写 "invite or temporary password policy"——这是 #2820 之前的表述。详细的 Bulk Import 小节已正确列出 `none`（默认）/`invite`/`temporary`，只是这个一行摘要漏了 `none` 默认。
2. **无 Console 入口说明**——objectui 的导入向导（framework#2782）已上线，但文档只讲了 API，没提管理员在 Users 列表点 Import 走向导。补一段说明上传/映射/dryRun 预览/temporary 密码一次性展示/500 行自动分批。

均为文档修正，无代码变更。

## dogfood 验证记录（本 PR 的动因）

启动 showcase 服务器（admin 插件开启）+ objectui HMR 控制台，端到端验证了整条链路：

**后端（真实 HTTP）**：`features.admin` 门控、create-user（一次性临时密码 + must_change_password）、403 PASSWORD_EXPIRED gate、import `none` 默认（无凭据建号、密码登录 401）、`temporary`（每行密码 + 首登强制改密）、行级校验（NO_IDENTITY/INVALID_EMAIL）、dryRun 零写入——全部符合预期。

**前端（Playwright + 截图）**：Users 列表出现 Import + Create User 按钮（features.admin 门控）；向导 preview 步显示 "Sign-in setup" 面板与 "No password (recommended)" 默认；temporary 策略完整导入后结果页展示一次性密码 + CSV 下载，adapter 正确 POST 到 `/admin/import-users`。

Ref framework#2766 / #2820 / #2782。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016r6eiJzivw1CkwTDSGho1o

---
_Generated by [Claude Code](https://claude.ai/code/session_016r6eiJzivw1CkwTDSGho1o)_