### PR TITLE
feat(identity): sys_user 放开档案字段标准编辑 affordance（ADR-0092 D4，closes #2817）

### DIFF
--- a/.changeset/console-5da9905b30fc.md
+++ b/.changeset/console-5da9905b30fc.md
@@ -1,0 +1,9 @@
+---
+"@objectstack/console": patch
+---
+
+Console (objectui) refreshed to `5da9905b30fc`. Frontend changes in this range:
+
+- fix(plugin-form): honor userActions.edit on managed objects, don't blanket-disable fields (ADR-0092 D4) (#2395)
+
+objectui range: `6fa8e6aeb67c...5da9905b30fc`

--- a/.changeset/me-permissions-wildcard-fold.md
+++ b/.changeset/me-permissions-wildcard-fold.md
@@ -2,7 +2,7 @@
 "@objectstack/plugin-hono-server": patch
 ---
 
-fix(security): `/me/permissions` folds the `'*'` wildcard super-user grant into per-object FLS, matching server enforcement (ADR-0057 D10)
+fix(security): `/me/permissions` now reflects permission-set ∩ identity-write-guard, matching real server enforcement (ADR-0057 D10)
 
 The `/api/v1/auth/me/permissions` per-object map merged each permission set's
 explicit `objects` entries most-permissively per key, but treated `'*'` and
@@ -13,14 +13,25 @@ enforcement (`PermissionEvaluator.checkObjectPermission` allows as soon as any
 set grants, including via the `'*'` modifyAll/viewAll super-user bypass, with
 no deny-wins).
 
-Concretely: a platform admin (`admin_full_access` → `'*': {modifyAllRecords}`)
-who also holds `organization_admin` (which denies writes on identity tables)
-resolved to `sys_user.allowEdit:false` in this payload, so the Console disabled
-the standard edit form — even though the server accepts the write (`PATCH
-/data/sys_user {name}` → 200). The new `foldWildcardSuperUser` post-pass lifts
-each per-object entry's read/write bits when the merged wildcard is a
-super-user grant, so the client mirrors the server (never broader — the
-super-user grant already covers private/managed objects server-side). This
-unblocks the ADR-0092 D4 `sys_user` profile-edit affordance for platform
-admins; the identity write guard still restricts the actual write to
-`{name, image}`.
+The real effective answer for a user-context caller is `permission-set grant ∩
+identity-write-guard policy`, and the payload now computes both:
+
+1. `foldWildcardSuperUser` lifts each per-object entry's read/write bits when
+   the merged `'*'` is a super-user grant — fixing the false-NEGATIVE where a
+   platform admin (`admin_full_access` `'*': {modifyAllRecords}`) who also holds
+   `organization_admin` (explicit identity denies) resolved to
+   `sys_user.allowEdit:false` and a disabled edit form, though the server
+   accepts the write (`PATCH /data/sys_user {name}` → 200).
+2. `clampManagedObjectWrites` re-clamps `managedBy: 'better-auth'` objects by
+   their write affordance — fixing the false-POSITIVE the fold would otherwise
+   introduce: the identity write guard (ADR-0092 D2) blocks user-context writes
+   on identity tables except where the object opted in (`userActions.edit`), so
+   `sys_member` / `sys_account` / `sys_session` stay `allowEdit:false` for the
+   admin (read stays granted). Only `better-auth` objects are clamped — the
+   guard covers only them; `system`/`config`/`append-only` objects have no such
+   guard and their permission-set result stands.
+
+Net: the Console's per-object FLS now equals real server enforcement — the
+ADR-0092 D4 `sys_user` profile-edit affordance is unblocked for platform admins
+(the guard still narrows the write to `{name, image}`), and no other identity
+table is shown as editable when the guard would reject it.

--- a/.changeset/me-permissions-wildcard-fold.md
+++ b/.changeset/me-permissions-wildcard-fold.md
@@ -1,0 +1,26 @@
+---
+"@objectstack/plugin-hono-server": patch
+---
+
+fix(security): `/me/permissions` folds the `'*'` wildcard super-user grant into per-object FLS, matching server enforcement (ADR-0057 D10)
+
+The `/api/v1/auth/me/permissions` per-object map merged each permission set's
+explicit `objects` entries most-permissively per key, but treated `'*'` and
+named objects as independent keys — so a wildcard "Modify/View All Data" grant
+was never propagated into a per-object entry another set explicitly denied.
+That made the client's field-level security STRICTER than the server's actual
+enforcement (`PermissionEvaluator.checkObjectPermission` allows as soon as any
+set grants, including via the `'*'` modifyAll/viewAll super-user bypass, with
+no deny-wins).
+
+Concretely: a platform admin (`admin_full_access` → `'*': {modifyAllRecords}`)
+who also holds `organization_admin` (which denies writes on identity tables)
+resolved to `sys_user.allowEdit:false` in this payload, so the Console disabled
+the standard edit form — even though the server accepts the write (`PATCH
+/data/sys_user {name}` → 200). The new `foldWildcardSuperUser` post-pass lifts
+each per-object entry's read/write bits when the merged wildcard is a
+super-user grant, so the client mirrors the server (never broader — the
+super-user grant already covers private/managed objects server-side). This
+unblocks the ADR-0092 D4 `sys_user` profile-edit affordance for platform
+admins; the identity write guard still restricts the actual write to
+`{name, image}`.

--- a/.changeset/sys-user-edit-affordance.md
+++ b/.changeset/sys-user-edit-affordance.md
@@ -1,0 +1,26 @@
+---
+"@objectstack/platform-objects": minor
+---
+
+feat(identity): open the standard Edit affordance on sys_user for profile fields (ADR-0092 D4)
+
+`sys_user` now sets `userActions: { edit: true }`, so the generic row-edit
+form is available (create / import / delete stay off). The two profile fields
+(`name`, `image`) are editable; every other column — `email`, `role`, ban
+state, phone, and all system-managed stamps — is marked `readonly` so the
+standard edit form renders it non-editable.
+
+This is safe because the server boundary is the identity write guard shipped
+in the previous change (ADR-0092 D2): a user-context update to `sys_user` may
+only touch `{name, image}` regardless of what any form submits; everything
+else is stripped or rejected. The `readonly` flags here are UX only.
+
+The dedicated action dialogs are unaffected — `create_user` / `invite_user` /
+`set_user_role` reference `email` and `role` as action **params** (their own
+inputs), which do not inherit the field-level `readonly` and stay editable
+(verified in the running Console).
+
+Note: the Console's record-form renderer must honor `userActions.edit` +
+per-field `readonly` on `managedBy:'better-auth'` objects for the edit form to
+be functional; that is an objectui-side change vendored via `objectui:refresh`
+and tracked separately.

--- a/.objectui-sha
+++ b/.objectui-sha
@@ -1,1 +1,1 @@
-6fa8e6aeb67c53169b7c9c4bbc1ef7cf897d0cbf
+5da9905b30fc06fa2d262fbcbccbcf881f9da360

--- a/packages/platform-objects/src/identity/sys-user.object.ts
+++ b/packages/platform-objects/src/identity/sys-user.object.ts
@@ -20,6 +20,15 @@ export const SysUser = ObjectSchema.create({
   icon: 'user',
   isSystem: true,
   managedBy: 'better-auth',
+  // ADR-0092 D4 — the ONE generic affordance opened on an identity table:
+  // standard row editing. Safe because the plugin-auth identity write guard
+  // (ADR-0092 D2) enforces the profile whitelist server-side — a user-context
+  // update may only touch SYS_USER_PROFILE_EDIT_FIELDS ({name, image});
+  // everything else is stripped/rejected regardless of what a form submits.
+  // The permission layer still decides WHO may edit (platform admins only by
+  // default; member/org-admin sets keep allowEdit: false). create / import /
+  // delete stay bucket-default (off).
+  userActions: { edit: true },
   // ADR-0010 §3.7 — identity table is managed by better-auth; schema must not drift.
   protection: {
     lock: 'full',
@@ -462,9 +471,14 @@ export const SysUser = ObjectSchema.create({
       group: 'Identity',
     }),
 
+    // ADR-0092 D4 — with the generic edit affordance open, every non-profile
+    // field is readonly so the standard edit form renders it non-editable.
+    // This is UX only; the server boundary is the plugin-auth identity write
+    // guard (ADR-0092 D2), which strips/rejects these regardless.
     email: Field.email({
       label: 'Email',
       required: true,
+      readonly: true, // login identity — change flows through better-auth change-email verification
       searchable: true,
       group: 'Identity',
     }),
@@ -472,12 +486,14 @@ export const SysUser = ObjectSchema.create({
     email_verified: Field.boolean({
       label: 'Email Verified',
       defaultValue: false,
+      readonly: true,
       group: 'Identity',
     }),
 
     two_factor_enabled: Field.boolean({
       label: 'Two-Factor Enabled',
       defaultValue: false,
+      readonly: true,
       group: 'Identity',
       description: 'Whether two-factor authentication is enabled for this user. Maintained by the better-auth `twoFactor` plugin.',
     }),
@@ -486,6 +502,7 @@ export const SysUser = ObjectSchema.create({
     role: Field.text({
       label: 'Platform Role',
       required: false,
+      readonly: true, // ADR-0092 — set via the Set Platform Role action, never the edit form
       maxLength: 64,
       group: 'Admin',
       description: 'Platform-level role (admin, user, …). Set via the Set Platform Role action.',
@@ -494,6 +511,7 @@ export const SysUser = ObjectSchema.create({
     banned: Field.boolean({
       label: 'Banned',
       defaultValue: false,
+      readonly: true, // ADR-0092 — toggled via Ban/Unban actions (session side effects)
       group: 'Admin',
       description: 'When true, the user cannot sign in. Toggle via Ban User / Unban User actions.',
     }),
@@ -501,6 +519,7 @@ export const SysUser = ObjectSchema.create({
     ban_reason: Field.text({
       label: 'Ban Reason',
       required: false,
+      readonly: true, // ADR-0092 — written by the Ban User action
       maxLength: 255,
       group: 'Admin',
     }),
@@ -508,6 +527,7 @@ export const SysUser = ObjectSchema.create({
     ban_expires: Field.datetime({
       label: 'Ban Expires',
       required: false,
+      readonly: true, // ADR-0092 — written by the Ban User action
       group: 'Admin',
       description: 'When set, the ban auto-clears at this time.',
     }),
@@ -618,6 +638,7 @@ export const SysUser = ObjectSchema.create({
     ai_access: Field.boolean({
       label: 'AI Access',
       defaultValue: false,
+      readonly: true, // ADR-0092 — a licensed-seat grant; flows through the AiSeatPlugin enforcement path
       group: 'Admin',
       description:
         'Whether this user holds an AI seat — grants access to the in-UI AI ' +
@@ -639,6 +660,7 @@ export const SysUser = ObjectSchema.create({
     manager_id: Field.lookup('sys_user', {
       label: 'Manager',
       required: false,
+      readonly: true, // ADR-0092 — drives own_and_reports RLS scope; org-structure maintenance is its own surface
       group: 'Organization',
       description: "This user's direct manager. Forms the reporting chain the `own_and_reports` hierarchy scope walks (ADR-0057 / @objectstack/security-enterprise).",
     }),
@@ -646,6 +668,7 @@ export const SysUser = ObjectSchema.create({
     primary_business_unit_id: Field.lookup('sys_business_unit', {
       label: 'Primary Business Unit',
       required: false,
+      readonly: true, // ADR-0092 — denormalised projection maintained by plugin-sharing; never hand-edited
       group: 'Organization',
       description: "The user's primary business unit — a denormalised projection of sys_business_unit_member.is_primary, maintained by plugin-sharing (ADR-0057 addendum D12). Lets a user-lookup filter candidates by business unit without traversing the membership junction. Do not edit directly; set it via business-unit membership.",
     }),

--- a/packages/plugins/plugin-hono-server/src/fold-wildcard-superuser.test.ts
+++ b/packages/plugins/plugin-hono-server/src/fold-wildcard-superuser.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
-import { foldWildcardSuperUser } from './hono-plugin.js';
+import { foldWildcardSuperUser, clampManagedObjectWrites, type ManagedSchemaLike } from './hono-plugin.js';
 
 /**
  * ADR-0057 D10 / ADR-0092 D5 — the `/me/permissions` per-object FLS map must
@@ -46,5 +46,62 @@ describe('foldWildcardSuperUser', () => {
     const objects: Record<string, any> = { sys_user: { allowEdit: false } };
     foldWildcardSuperUser(objects);
     expect(objects.sys_user.allowEdit).toBe(false);
+  });
+});
+
+/**
+ * ADR-0092 D2 — the identity write guard is a second enforcement layer the
+ * permission sets don't model. The client hint must reflect permission ∩ guard:
+ * managed (`better-auth`) objects are user-context-writable only where the
+ * object opened the affordance; others (system/config/…) are untouched.
+ */
+describe('clampManagedObjectWrites', () => {
+  const SCHEMAS: Record<string, ManagedSchemaLike> = {
+    sys_user: { managedBy: 'better-auth', userActions: { edit: true } },
+    sys_member: { managedBy: 'better-auth' },
+    sys_session: { managedBy: 'better-auth' },
+    sys_automation_run: { managedBy: 'system' }, // NOT better-auth → not guarded
+    crm_lead: { managedBy: 'platform' },
+  };
+  const schemaOf = (n: string) => SCHEMAS[n];
+
+  it('keeps write on a managed object that opened the edit affordance (sys_user)', () => {
+    const objects: Record<string, any> = { sys_user: { allowRead: true, allowEdit: true, allowCreate: true, allowDelete: true } };
+    clampManagedObjectWrites(objects, schemaOf);
+    // edit opted-in stays; create/delete were NOT opted in → clamped off.
+    expect(objects.sys_user).toMatchObject({ allowRead: true, allowEdit: true, allowCreate: false, allowDelete: false });
+  });
+
+  it('clamps write to false on managed objects the guard blocks (sys_member, sys_session)', () => {
+    const objects: Record<string, any> = {
+      sys_member: { allowRead: true, allowEdit: true, allowCreate: true, allowDelete: true },
+      sys_session: { allowRead: true, allowEdit: true },
+    };
+    clampManagedObjectWrites(objects, schemaOf);
+    expect(objects.sys_member).toMatchObject({ allowRead: true, allowEdit: false, allowCreate: false, allowDelete: false });
+    expect(objects.sys_session.allowEdit).toBe(false);
+    expect(objects.sys_session.allowRead).toBe(true); // read never clamped
+  });
+
+  it('leaves non-better-auth managed buckets untouched (system objects have no write guard)', () => {
+    const objects: Record<string, any> = { sys_automation_run: { allowEdit: true }, crm_lead: { allowEdit: true } };
+    clampManagedObjectWrites(objects, schemaOf);
+    expect(objects.sys_automation_run.allowEdit).toBe(true);
+    expect(objects.crm_lead.allowEdit).toBe(true);
+  });
+
+  it('fold + clamp compose to permission ∩ guard for a platform admin', () => {
+    // As produced for a platform admin (admin_full_access '*' modifyAll) who
+    // also holds organization_admin (explicit managed denies).
+    const objects: Record<string, any> = {
+      '*': { allowRead: true, allowEdit: true, viewAllRecords: true, modifyAllRecords: true },
+      sys_user: { allowRead: true, allowEdit: false, allowCreate: false, allowDelete: false },
+      sys_member: { allowRead: true, allowEdit: false, allowCreate: false, allowDelete: false },
+    };
+    foldWildcardSuperUser(objects);
+    clampManagedObjectWrites(objects, schemaOf);
+    expect(objects.sys_user.allowEdit).toBe(true);   // opened + admin → editable
+    expect(objects.sys_member.allowEdit).toBe(false); // guard blocks → not editable
+    expect(objects.sys_member.allowRead).toBe(true);  // read still granted by super-user
   });
 });

--- a/packages/plugins/plugin-hono-server/src/fold-wildcard-superuser.test.ts
+++ b/packages/plugins/plugin-hono-server/src/fold-wildcard-superuser.test.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { foldWildcardSuperUser } from './hono-plugin.js';
+
+/**
+ * ADR-0057 D10 / ADR-0092 D5 — the `/me/permissions` per-object FLS map must
+ * mirror the server's actual enforcement, which grants writes via a `'*'`
+ * modifyAll super-user bypass regardless of another set's explicit per-object
+ * deny (most-permissive merge, no deny-wins).
+ */
+describe('foldWildcardSuperUser', () => {
+  it('lifts an explicit per-object deny when the wildcard is a modifyAll super-user grant', () => {
+    const objects: Record<string, any> = {
+      '*': { allowRead: true, allowEdit: true, viewAllRecords: true, modifyAllRecords: true },
+      // As produced when admin_full_access ('*') composes with organization_admin
+      // (explicit sys_user deny) — the naive merge leaves allowEdit:false.
+      sys_user: { allowRead: true, allowEdit: false, allowCreate: false, allowDelete: false },
+    };
+    foldWildcardSuperUser(objects);
+    expect(objects.sys_user).toMatchObject({ allowRead: true, allowEdit: true, allowCreate: true, allowDelete: true });
+    // The wildcard entry itself is untouched.
+    expect(objects['*'].modifyAllRecords).toBe(true);
+  });
+
+  it('viewAll-only wildcard lifts read but NOT write', () => {
+    const objects: Record<string, any> = {
+      '*': { allowRead: true, viewAllRecords: true },
+      sys_session: { allowRead: false, allowEdit: false },
+    };
+    foldWildcardSuperUser(objects);
+    expect(objects.sys_session.allowRead).toBe(true);
+    expect(objects.sys_session.allowEdit).toBe(false);
+  });
+
+  it('no-ops when the wildcard is not a super-user grant', () => {
+    const objects: Record<string, any> = {
+      '*': { allowRead: true, allowEdit: true }, // plain allow, no view/modifyAll
+      sys_user: { allowRead: true, allowEdit: false },
+    };
+    foldWildcardSuperUser(objects);
+    expect(objects.sys_user.allowEdit).toBe(false); // untouched — no super-user bypass
+  });
+
+  it('no-ops when there is no wildcard entry', () => {
+    const objects: Record<string, any> = { sys_user: { allowEdit: false } };
+    foldWildcardSuperUser(objects);
+    expect(objects.sys_user.allowEdit).toBe(false);
+  });
+});

--- a/packages/plugins/plugin-hono-server/src/hono-plugin.ts
+++ b/packages/plugins/plugin-hono-server/src/hono-plugin.ts
@@ -120,6 +120,46 @@ export function foldWildcardSuperUser(objects: Record<string, any>): void {
     }
 }
 
+/** Minimal schema shape the managed-write clamp needs. */
+export interface ManagedSchemaLike {
+    managedBy?: string;
+    userActions?: { create?: boolean; edit?: boolean; delete?: boolean } | null;
+}
+
+/**
+ * Re-clamp a `/me/permissions` `objects` map by the SECOND server-side
+ * enforcement layer that permission sets don't model: the identity write guard
+ * (ADR-0092 D2). The guard fail-closed rejects USER-CONTEXT insert/update/delete
+ * on every `managedBy: 'better-auth'` object except where the object opted a
+ * write affordance in (`userActions.{create,edit,delete}` — e.g. sys_user opens
+ * `edit` for its profile fields; the field-level `readonly` flags then narrow it
+ * to `{name, image}`).
+ *
+ * Without this clamp, {@link foldWildcardSuperUser} would report `allowEdit:true`
+ * for a platform admin on identity tables the guard actually blocks (sys_member,
+ * sys_account, …) — a false-POSITIVE that mirrors, inverted, the false-negative
+ * the fold fixes. The real effective answer for a user-context caller is
+ * `permission-set grant ∩ guard policy`, and the guard policy for a managed
+ * object is exactly its resolved CRUD affordance. Only `better-auth` objects are
+ * clamped — the guard covers only them; `system`/`config`/`append-only` objects
+ * have no such guard, so their permission-set result stands (an admin CAN write
+ * them via the data API, and the hint must not under-report that).
+ */
+export function clampManagedObjectWrites(
+    objects: Record<string, any>,
+    schemaOf: (objectName: string) => ManagedSchemaLike | undefined,
+): void {
+    for (const [obj, acc] of Object.entries(objects) as Array<[string, any]>) {
+        if (obj === '*' || !acc) continue;
+        const schema = schemaOf(obj);
+        if (schema?.managedBy !== 'better-auth') continue;
+        const ua = schema.userActions ?? {};
+        if (ua.edit !== true) acc.allowEdit = false;
+        if (ua.create !== true) acc.allowCreate = false;
+        if (ua.delete !== true) acc.allowDelete = false;
+    }
+}
+
 export class HonoServerPlugin implements Plugin {
     name = 'com.objectstack.server.hono';
     type = 'server';
@@ -835,10 +875,21 @@ export class HonoServerPlugin implements Plugin {
                         }
                     }
                 }
-                // Fold the `'*'` wildcard super-user grant into every per-object
-                // entry (see foldWildcardSuperUser) so the client's per-object FLS
-                // matches the server's actual enforcement (ADR-0057 D10).
+                // Make the client's per-object FLS reflect the server's ACTUAL
+                // effective enforcement = permission-set grant ∩ identity write
+                // guard (ADR-0057 D10). (1) Fold the `'*'` super-user grant into
+                // every object so an admin's wildcard is not shadowed by another
+                // set's explicit deny; (2) re-clamp `better-auth` managed objects
+                // by their write affordance, since the guard (ADR-0092 D2) blocks
+                // user-context writes there except where the object opted in
+                // (sys_user → edit). Together these remove both the false-negative
+                // (admin sees sys_user editable) and the false-positive (admin does
+                // NOT see sys_member editable, matching the guard).
                 foldWildcardSuperUser(objects);
+                clampManagedObjectWrites(objects, (name) => {
+                    try { return ql?.getSchema?.(name) as ManagedSchemaLike | undefined; }
+                    catch { return undefined; }
+                });
                 return c.json({
                     authenticated: true,
                     userId: execCtx.userId,

--- a/packages/plugins/plugin-hono-server/src/hono-plugin.ts
+++ b/packages/plugins/plugin-hono-server/src/hono-plugin.ts
@@ -81,6 +81,45 @@ export interface HonoPluginOptions {
  * - `@objectstack/rest` → CRUD, metadata, discovery, UI, batch
  * - `createDispatcherPlugin()` → auth, graphql, analytics, packages, etc.
  */
+
+/**
+ * Fold the `'*'` wildcard super-user grant into every per-object entry of a
+ * `/me/permissions` `objects` map, mutating it in place.
+ *
+ * The endpoint merges each resolved permission set's explicit `objects` entries
+ * most-permissively per key, but treats `'*'` and named objects as independent
+ * keys — so a wildcard "Modify/View All Data" grant is never propagated into a
+ * per-object entry another set explicitly denied. That makes the client's
+ * per-object FLS STRICTER than the server's actual enforcement
+ * (`PermissionEvaluator.checkObjectPermission`, which returns allow as soon as
+ * ANY set grants — including via the `'*'` modifyAll/viewAll super-user bypass,
+ * with no deny-wins). The mismatch surfaces for a platform admin
+ * (`admin_full_access` `'*': {modifyAllRecords}`) who ALSO holds
+ * `organization_admin` (which denies writes on identity tables): the client
+ * would see `sys_user.allowEdit:false` and disable a form the server accepts
+ * (verified: `PATCH /data/sys_user {name}` → 200). ADR-0057 D10 makes the
+ * server the authoritative gate; the client must mirror it, never diverge.
+ *
+ * The super-user grant covers private/managed objects on the server, so folding
+ * it here is exactly as broad as real enforcement — never broader.
+ */
+export function foldWildcardSuperUser(objects: Record<string, any>): void {
+    const wild = objects?.['*'];
+    if (!wild) return;
+    const superRead = wild.viewAllRecords === true || wild.modifyAllRecords === true;
+    const superWrite = wild.modifyAllRecords === true;
+    if (!superRead && !superWrite) return;
+    for (const [obj, acc] of Object.entries(objects) as Array<[string, any]>) {
+        if (obj === '*' || !acc) continue;
+        if (superRead) acc.allowRead = true;
+        if (superWrite) {
+            acc.allowEdit = true;
+            acc.allowCreate = true;
+            acc.allowDelete = true;
+        }
+    }
+}
+
 export class HonoServerPlugin implements Plugin {
     name = 'com.objectstack.server.hono';
     type = 'server';
@@ -796,6 +835,10 @@ export class HonoServerPlugin implements Plugin {
                         }
                     }
                 }
+                // Fold the `'*'` wildcard super-user grant into every per-object
+                // entry (see foldWildcardSuperUser) so the client's per-object FLS
+                // matches the server's actual enforcement (ADR-0057 D10).
+                foldWildcardSuperUser(objects);
                 return c.json({
                     authenticated: true,
                     userId: execCtx.userId,


### PR DESCRIPTION
## 概要

ADR-0092 D4（#2817）—— `sys_user` 档案字段经标准编辑表单可编辑,**运行中的 Console 端到端验证通过**(编辑 name → 落库;email/role 只读)。守卫 #2828 仍确保用户上下文只能改 `{name, image}`。

三块协同改动:

1. **sys_user schema**（`platform-objects`）— `userActions:{edit:true}`;`name`/`image` 可编辑,其余标 `readonly`。
2. **`/me/permissions` 提示 = 权限 ∩ 守卫**（`plugin-hono-server`,新增 `foldWildcardSuperUser` + `clampManagedObjectWrites` + 8 单测)。
3. **`.objectui-sha` → 5da9905** — 拉入 objectui #2395（`ObjectForm` 按 `userActions.edit` 逐字段渲染)。

## 根因与完整修复（浏览器验证中发现,逐层查明)

放开 affordance 后表单仍全禁用,原因是**两个独立门**:
- objectui 一刀切禁用 managed 对象 → **#2395 已修**(已合并)。
- `/me/permissions` 客户端 FLS 与服务端强制不一致。

服务端对身份表有**两层**强制:**权限集**(`checkObjectPermission`,最宽松合成、无 deny-wins,admin 的 `modifyAllRecords` 通配符放行)**∩** **身份写守卫 #2828**(全 `managedBy:'better-auth'` 表默认拒用户上下文写,仅 `sys_user` 开 `edit`)。`/me/permissions` 原来两层都没反映,于是:

1. `foldWildcardSuperUser` 折入通配符超级用户位 → 修**假阴性**(admin 看不到 sys_user 可编辑,但 `PATCH /data/sys_user{name}`→200 证明服务端放行)。
2. `clampManagedObjectWrites` 按守卫策略夹回 → 修 fold 引入的**假阳性**:`sys_member`/`sys_account`/`sys_session` 等无白名单托管表夹回 `allowEdit:false`(read 保留),与守卫一致。仅夹 `better-auth` 对象(守卫只管它们);system/config/append-only 无此守卫,权限集结果照旧(admin 可经 data API 写,提示不得漏报)。

**结果:客户端 per-object FLS = 真实服务端强制(权限 ∩ 守卫)**,双向不一致均消除。此前担心的"admin 在所有 system 表看到编辑按钮"的影响面已由 clamp 消除。

## 验证

- 单测:`foldWildcardSuperUser`+`clampManagedObjectWrites`(8 例)、objectui `ObjectForm.managedEdit`(3 例,随 #2395)、身份守卫(随 #2828)。plugin-hono-server 全套 64、platform-objects 76 通过。
- 浏览器 e2e(showcase + seeded admin):Edit → 仅 Name/Profile Image 可编辑 → Update → `/data/sys_user` 落库;email/role 不可编辑;Create/Invite 弹窗不受影响。
- `/me/permissions` 实测:`sys_user.allowEdit` true(可编辑)、`sys_member/session/account.allowEdit` false(read 保留)—— 与守卫逐表一致。

## 相关

ADR-0092 D4/D5 · closes #2817 · 修复 #2836（权限合成 finding）· 依赖已合并 #2828、objectui #2395 · 关联 #2833

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGAN5VvvBi4YRGwpNT6e21