### PR TITLE
fix(platform-objects): sys_sso_provider resultDialog paths address the inner data payload

### DIFF
--- a/.changeset/sso-resultdialog-inner-data-path.md
+++ b/.changeset/sso-resultdialog-inner-data-path.md
@@ -1,0 +1,9 @@
+---
+'@objectstack/platform-objects': patch
+---
+
+`sys_sso_provider` domain-verification `resultDialog` paths now address the
+inner `data` payload (`dnsRecordType`, not `data.dnsRecordType`), matching every
+other object. Pairs with the objectui `apiHandler` envelope-unwrap fix
+(objectui#2396) — the old `data.` prefix compensated for a runtime bug and would
+blank the dialog once the runtime unwraps correctly.

--- a/packages/platform-objects/src/identity/sys-sso-provider.object.ts
+++ b/packages/platform-objects/src/identity/sys-sso-provider.object.ts
@@ -132,9 +132,13 @@ export const SysSsoProvider = ObjectSchema.create({
       // for a one-time DNS-TXT challenge and reveals the ready-to-paste record
       // ONCE via `resultDialog`. Routed through the env bridge (plugin-auth /
       // cloud AuthProxyPlugin) which reshapes the `{domainVerificationToken}`
-      // response into the `{ data: { dnsRecordName, dnsRecordValue } }` envelope
-      // the dialog reads. When the feature is OFF the bridge returns a clear
-      // "not enabled for this environment" error instead of a bare 404.
+      // response into a `{ success, data: { dnsRecordName, dnsRecordValue } }`
+      // envelope. The console action runtime unwraps that envelope, so the
+      // `resultDialog` field paths are relative to the inner `data` payload
+      // (`dnsRecordName`, not `data.dnsRecordName`) — consistent with every
+      // other object's resultDialog (create_user, two-factor, OAuth). When the
+      // feature is OFF the bridge returns a clear "not enabled for this
+      // environment" error instead of a bare 404.
       target: '/api/v1/auth/admin/sso/request-domain-verification',
       params: [
         { name: 'providerId', field: 'provider_id', defaultFromRow: true, required: true },
@@ -146,9 +150,9 @@ export const SysSsoProvider = ObjectSchema.create({
           'Add the DNS TXT record below at your domain’s DNS provider, then run “Verify Domain”. The token is shown once.',
         acknowledge: 'Done',
         fields: [
-          { path: 'data.dnsRecordType', label: 'Record type', format: 'text' },
-          { path: 'data.dnsRecordName', label: 'Name / Host', format: 'secret' },
-          { path: 'data.dnsRecordValue', label: 'Value', format: 'secret' },
+          { path: 'dnsRecordType', label: 'Record type', format: 'text' },
+          { path: 'dnsRecordName', label: 'Name / Host', format: 'secret' },
+          { path: 'dnsRecordValue', label: 'Value', format: 'secret' },
         ],
       },
     },

--- a/packages/platform-objects/src/platform-objects.test.ts
+++ b/packages/platform-objects/src/platform-objects.test.ts
@@ -14,6 +14,7 @@ import {
   SysOrganization,
   SysScimProvider,
   SysSession,
+  SysSsoProvider,
   SysTeam,
   SysTeamMember,
   SysTwoFactor,
@@ -171,6 +172,23 @@ describe('@objectstack/platform-objects', () => {
       expect(SysOauthApplication.enable?.apiMethods).not.toContain('delete');
       expect(SysOauthApplication.enable?.apiMethods).not.toContain('update');
       expect(SysOauthApplication.enable?.apiMethods).not.toContain('create');
+    });
+
+    it('SysSsoProvider request_domain_verification resultDialog paths address the inner data payload (no `data.` prefix)', () => {
+      // The console action runtime unwraps the `{ success, data }` envelope
+      // before resolving resultDialog field paths (same as create_user,
+      // two-factor and OAuth). These paths must therefore be relative to the
+      // INNER data — a `data.` prefix double-nests and blanks the dialog.
+      // Regression guard for the "temporary password / DNS record shows empty"
+      // class of bug.
+      const action = (SysSsoProvider.actions ?? []).find(
+        (a) => a.target === '/api/v1/auth/admin/sso/request-domain-verification',
+      );
+      expect(action?.resultDialog?.fields?.map((f) => f.path)).toEqual([
+        'dnsRecordType',
+        'dnsRecordName',
+        'dnsRecordValue',
+      ]);
     });
   });
 


### PR DESCRIPTION
## Problem

The console action runtime unwraps the `{ success, data }` response envelope before resolving `resultDialog` field paths — so paths address the **inner** `data` payload (as `create_user`, two-factor and OAuth all do). `sys_sso_provider`'s domain-verification dialog was the **only** spec written with a `data.` prefix, compensating for a runtime bug where `apiHandler` leaked the whole envelope.

## Change

Drop the redundant `data.` prefix from the 3 DNS-record field paths in `sys-sso-provider.object.ts`:

- `data.dnsRecordType` → `dnsRecordType`
- `data.dnsRecordName` → `dnsRecordName`
- `data.dnsRecordValue` → `dnsRecordValue`

Now consistent with every other object's `resultDialog`. Adds a regression assertion in `platform-objects.test.ts`.

## ⚠️ Release-coupled

Must ship **together** with the objectui runtime fix (companion PR: **objectstack-ai/objectui#2396**), which makes `apiHandler` unwrap the envelope. Once that lands, the old `data.` prefix double-nests and blanks this dialog; before it lands, dropping the prefix blanks it. Either half alone temporarily breaks the opt-in (`OS_SSO_DOMAIN_VERIFICATION`) SSO domain-verification reveal dialog — a niche admin surface.

## Test

`pnpm --filter @objectstack/platform-objects exec vitest run src/platform-objects.test.ts` → **64/64 pass** (incl. the new `SysSsoProvider` path assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
