### PR TITLE
fix(analytics): scope /analytics/query + /sql to the caller (RLS) (#2852)

### DIFF
--- a/.changeset/analytics-query-rls-context.md
+++ b/.changeset/analytics-query-rls-context.md
@@ -1,0 +1,11 @@
+---
+'@objectstack/runtime': patch
+---
+
+**Security fix (#2852): `/analytics/query` and `/analytics/sql` now run scoped to the caller.**
+
+`handleAnalytics` dropped the request's execution context — `analyticsService.query(body)` was called with no context, so the analytics service's per-object read-scope provider (`getReadScope` → security `getReadFilter`) received `undefined` and applied **no tenant/RLS filter**. An authenticated caller could query analytics datasets and receive rows their row-level security would otherwise hide.
+
+Fix: thread `context.executionContext` into `analyticsService.query(…)` and `generateSql(…)` (both already accept it), so each object in the query is scoped by its per-object read filter.
+
+Note: the analytics read-scope provider (`getReadFilter`) does not yet apply the ADR-0090 D10 agent delegator intersection — latent today because analytics is not reachable over the OAuth `/mcp` surface; tracked in #2852 for when it is.

--- a/packages/runtime/src/http-dispatcher.test.ts
+++ b/packages/runtime/src/http-dispatcher.test.ts
@@ -383,6 +383,26 @@ describe('HttpDispatcher', () => {
                 expect(mockAnalytics.query).toHaveBeenCalled();
             });
 
+            // [#2852] The execution context must reach the analytics service so
+            // it scopes each object by its per-object read filter (tenant + RLS).
+            // Previously it was dropped and the query ran UNSCOPED.
+            it('threads the execution context into analytics.query and generateSql (RLS scoping)', async () => {
+                const mockAnalytics = {
+                    query: vi.fn().mockResolvedValue({ rows: [], total: 0 }),
+                    generateSql: vi.fn().mockResolvedValue({ sql: 'SELECT 1', params: [] }),
+                };
+                (kernel as any).getService = vi.fn().mockImplementation((name: string) =>
+                    name === 'analytics' ? mockAnalytics : null,
+                );
+                const ec = { userId: 'u1', positions: [], permissions: [], tenantId: 'org-1' };
+
+                await dispatcher.handleAnalytics('query', 'POST', { cube: 'leads' }, { request: {}, executionContext: ec } as any);
+                expect(mockAnalytics.query).toHaveBeenCalledWith({ cube: 'leads' }, ec);
+
+                await dispatcher.handleAnalytics('sql', 'POST', { cube: 'leads' }, { request: {}, executionContext: ec } as any);
+                expect(mockAnalytics.generateSql).toHaveBeenCalledWith({ cube: 'leads' }, ec);
+            });
+
             it('should handle POST /analytics/sql with async service', async () => {
                 const mockAnalytics = {
                     generateSql: vi.fn().mockResolvedValue({ sql: 'SELECT * FROM t' }),

--- a/packages/runtime/src/http-dispatcher.ts
+++ b/packages/runtime/src/http-dispatcher.ts
@@ -2040,7 +2040,7 @@ export class HttpDispatcher {
      * Handles Analytics requests
      * path: sub-path after /analytics/
      */
-    async handleAnalytics(path: string, method: string, body: any, _context: HttpProtocolContext): Promise<HttpDispatcherResult> {
+    async handleAnalytics(path: string, method: string, body: any, context: HttpProtocolContext): Promise<HttpDispatcherResult> {
         const analyticsService = await this.getService(CoreServiceName.enum.analytics);
         if (!analyticsService) return { handled: false }; // 404 handled by caller if unhandled
 
@@ -2049,7 +2049,12 @@ export class HttpDispatcher {
 
         // POST /analytics/query
         if (subPath === 'query' && m === 'POST') {
-            const result = await analyticsService.query(body);
+            // [#2852] Pass the request's execution context so the analytics
+            // service scopes each object by its per-object read filter (tenant +
+            // RLS). Without it, `getReadScope(object, undefined)` returned no
+            // filter and the query ran UNSCOPED — an authenticated caller saw
+            // rows RLS would otherwise hide.
+            const result = await analyticsService.query(body, context?.executionContext);
             return { handled: true, response: this.success(result) };
         }
 
@@ -2061,8 +2066,9 @@ export class HttpDispatcher {
 
         // POST /analytics/sql (Dry-run or debug)
         if (subPath === 'sql' && m === 'POST') {
-             // Assuming service has generateSql method
-             const result = await analyticsService.generateSql(body);
+             // [#2852] Scope the generated SQL to the caller too, so a preview
+             // reflects the same per-object read filter the real query applies.
+             const result = await analyticsService.generateSql(body, context?.executionContext);
              return { handled: true, response: this.success(result) };
         }
 


### PR DESCRIPTION
Closes the reachable part of #2852. Found by the ADR-0090 D10 adversarial security review.

## The hole

`handleAnalytics` (the `/api/v1/analytics/*` dispatcher) received the request context as `_context` (unused) and called `analyticsService.query(body)` with **no execution context**. The analytics service's per-object read-scope provider (`getReadScope` → security `getReadFilter`) therefore got `undefined` and applied **no tenant/RLS filter** — so an authenticated caller hitting `POST /analytics/query` received rows their row-level security would otherwise hide.

## The fix

Thread `context.executionContext` into `analyticsService.query(…)` and `generateSql(…)` — both already accept an optional `ExecutionContext`. Each object in the query is now scoped by its per-object read filter (tenant + RLS), matching the `/analytics/dataset/query` bridge path which already threads it.

## Residual (tracked in #2852)

The analytics read-scope provider (`getReadFilter` in plugin-security) does not yet apply the ADR-0090 **D10 agent delegator intersection**. This is latent today — analytics is not reachable over the OAuth `/mcp` surface, so no agent principal drives it — but it should be brought in lock-step with the engine middleware when analytics becomes agent-reachable.

## Tests

- Dispatcher test asserts the execution context now reaches `query` and `generateSql`.
- `runtime` http-dispatcher suite **165** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)