### PR TITLE
fix(cli): resolve http.server via getServiceAsync in console/runtime-assets plugins

### DIFF
--- a/.changeset/console-http-server-async.md
+++ b/.changeset/console-http-server-async.md
@@ -1,0 +1,23 @@
+---
+'@objectstack/cli': patch
+---
+
+fix(cli): resolve `http.server` asynchronously in the console / runtime-assets static plugins
+
+`createConsoleStaticPlugin` and `createRuntimeAssetsPlugin` fetched the
+`http.server` service with the **synchronous** `ctx.getService('http.server')`.
+When `http.server` is registered as an async factory (the console /
+schema-migration boot path), that accessor throws
+`Service 'http.server' is async - use await`; because the call sat outside
+any try/catch, the throw escaped the plugin's `start()` and rolled back
+kernel bootstrap — crashing the CONSOLE/migration boot
+(`Plugin startup failed: com.objectstack.runtime-assets`). The runtime
+`serve` path, where `http.server` is registered synchronously, was
+unaffected, which is why only the control-plane migration boot broke.
+
+Resolve both plugins' `http.server` through a shared `resolveHttpServer`
+helper that prefers the async accessor (`getServiceAsync`, which resolves a
+sync- or async-registered service) and falls back to the sync one, mirroring
+plugin-auth's async `cache` lookup. The helper never throws, so these
+optional static-asset plugins skip cleanly when no HTTP server is present
+instead of taking down boot.

--- a/packages/cli/src/utils/console.ts
+++ b/packages/cli/src/utils/console.ts
@@ -329,6 +329,38 @@ export function warnOnConsoleShaDrift(
 // ─── Plugin Factory ─────────────────────────────────────────────────
 
 /**
+ * Resolve the `http.server` service from a plugin context, tolerating both
+ * ways it can be registered:
+ *
+ *   - **synchronously** — the runtime `serve` path, where `Runtime` registers
+ *     the concrete server instance; and
+ *   - as an **async factory** — the console / schema-migration boot path,
+ *     for which the *synchronous* `getService` throws
+ *     `Service 'http.server' is async - use await`. Without this the throw
+ *     escaped these static-asset plugins' `start()` and aborted kernel
+ *     bootstrap (`com.objectstack.runtime-assets` failed to start), taking
+ *     down the CONSOLE/migration boot entirely.
+ *
+ * Prefer the async accessor (`getServiceAsync`, which resolves either kind),
+ * falling back to the sync one — mirroring plugin-auth's async `cache` lookup.
+ * Never throws: an unavailable server resolves to `undefined`, so these
+ * optional static-asset plugins skip cleanly instead of crashing boot.
+ */
+async function resolveHttpServer(ctx: any): Promise<any> {
+  try {
+    const svc = await ctx.getServiceAsync?.('http.server');
+    if (svc) return svc;
+  } catch {
+    // fall through to the synchronous accessor
+  }
+  try {
+    return ctx.getService?.('http.server');
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Create a lightweight kernel plugin that serves the pre-built Console
  * portal static files at `/_console/*`.
  *
@@ -347,7 +379,7 @@ export function createConsoleStaticPlugin(distPath: string, options?: { isDev?: 
     init: async () => {},
 
     start: async (ctx: any) => {
-      const httpServer = ctx.getService?.('http.server');
+      const httpServer = await resolveHttpServer(ctx);
       if (!httpServer?.getRawApp) {
         ctx.logger?.warn?.('Console static: http.server service not found — skipping');
         return;
@@ -468,7 +500,7 @@ export function createRuntimeAssetsPlugin(distPath: string) {
     init: async () => {},
 
     start: async (ctx: any) => {
-      const httpServer = ctx.getService?.('http.server');
+      const httpServer = await resolveHttpServer(ctx);
       if (!httpServer?.getRawApp) return;
 
       const app = httpServer.getRawApp();


### PR DESCRIPTION
## Problem

The `com.objectstack.runtime-assets` and `com.objectstack.console-static` plugins (`packages/cli/src/utils/console.ts`) fetch the `http.server` service with the **synchronous** `ctx.getService('http.server')`.

When `http.server` is registered as an **async factory** — the console / schema-migration boot path — `getService` throws `Service 'http.server' is async - use await`. Because the call sat outside any try/catch, the throw escaped the plugin's `start()` and rolled back kernel bootstrap:

```
ERROR Plugin startup failed: com.objectstack.runtime-assets
  Service 'http.server' is async - use await
    at Object.getService (packages/core/dist/index.js:1355)
    at Object.start (packages/cli/src/utils/console.ts:471)
```

This crashed the **cloud control-plane schema-migration boot** (the deploy's "Schema migration — production DB" step). The runtime `serve` path, where `Runtime` registers `http.server` synchronously, was unaffected — so only the console/migration boot path broke.

## Fix

Resolve `http.server` through a shared `resolveHttpServer()` helper that prefers the async accessor (`getServiceAsync`, which resolves a sync- **or** async-registered service) and falls back to the sync accessor — mirroring `plugin-auth`'s async `cache` lookup. The helper never throws, so these optional static-asset plugins skip cleanly when no HTTP server is present instead of aborting boot.

These two are the only hard-crash consumers of `http.server`: every other consumer (`serve.ts` unknown-hostname-guard, `metadata`, `rest`, `dispatcher`) already wraps the sync `getService` in try/catch and degrades gracefully.

## Base / scope

Branched from `cb662a5f` (the commit cloud currently pins) so the change is exactly `cb662a5f` + this fix — minimal drift, keeping the objectos-prod image byte-identical apart from this boot-safety fix. `console.ts` is byte-identical at `cb662a5f` and `main`, so it applies cleanly to `main` too.

> Merge with a **merge commit** (not squash) so the cloud-pinned commit `decd1746` stays reachable in `main` history, matching the `cb662a5f` precedent.

## Test plan

- [ ] framework CI (typecheck + tests) green
- [ ] cloud re-pins `.framework-sha` → `decd1746`; cloud `build-and-test` builds framework@decd1746 + boot-smoke green
- [ ] cloud-staging deploy boots the console/migration path cleanly (no `runtime-assets` crash)
- [ ] deploy-cloud-prod "Schema migration" step boots the kernel cleanly + "Deploy PRODUCTION" runs

---
_Generated by [Claude Code](https://claude.ai/code/session_01QsVkwjvWDBRiYb1HNGfcXr)_