### PR TITLE
fix(objectql): apply defaultValue on explicit null at insert (#2706)

### DIFF
--- a/.changeset/objectql-default-explicit-null.md
+++ b/.changeset/objectql-default-explicit-null.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/objectql": patch
+---
+
+fix(objectql): apply field `defaultValue` when a field is explicitly `null` on insert, not only when omitted (#2706)
+
+`applyFieldDefaults` previously skipped any field whose value was not
+`undefined`, so a form that serialized an unpicked control as `null` (rather
+than omitting it) fell through and stored `null` — the `current_user` token and
+static defaults never filled in. Both an omitted field and an explicit `null`
+now count as "no value supplied" and receive the default. This runs on the
+insert path only, so a deliberate "set to null" on update is untouched; an
+explicit empty string `''` is still respected as a real value.

--- a/packages/objectql/src/engine.test.ts
+++ b/packages/objectql/src/engine.test.ts
@@ -319,6 +319,50 @@ describe('ObjectQL Engine', () => {
             expect(arg.owner).toBeUndefined();
         });
 
+        it('backfills a default when the field is EXPLICITLY null, not just omitted (#2706)', async () => {
+            vi.mocked(SchemaRegistry.getObject).mockImplementation((name) => {
+                if (name === 'ticket') return {
+                    name: 'ticket',
+                    fields: {
+                        title: { type: 'text' },
+                        owner: { type: 'user', reference: 'sys_user', defaultValue: 'current_user' },
+                        status: { type: 'text', defaultValue: 'planned' },
+                    },
+                } as any;
+                if (name === 'sys_user') return { name: 'sys_user', fields: { name: { type: 'text' } } } as any;
+                return undefined;
+            });
+
+            // A form serializes an unpicked control as explicit `null` (not
+            // omission) — both the dynamic `current_user` token and a static
+            // default must still fill in.
+            await engine.insert('ticket', { title: 'T1', owner: null, status: null }, { context: { userId: 'u-42' } as any });
+
+            expect(mockDriver.create).toHaveBeenCalledWith(
+                'ticket',
+                expect.objectContaining({ title: 'T1', owner: 'u-42', status: 'planned' }),
+                expect.anything(),
+            );
+        });
+
+        it('respects an explicit empty-string value and does not overwrite it with the default (#2706)', async () => {
+            vi.mocked(SchemaRegistry.getObject).mockImplementation((name) => {
+                if (name === 'ticket') return {
+                    name: 'ticket',
+                    fields: {
+                        title: { type: 'text' },
+                        status: { type: 'text', defaultValue: 'planned' },
+                    },
+                } as any;
+                return undefined;
+            });
+
+            await engine.insert('ticket', { title: 'T1', status: '' });
+
+            const arg = (mockDriver.create as any).mock.calls.at(-1)[1];
+            expect(arg.status).toBe('');
+        });
+
         it('resolves field defaults BEFORE beforeInsert so a hook can derive from them (#2703)', async () => {
             vi.mocked(SchemaRegistry.getObject).mockImplementation((name) => {
                 if (name === 'ticket') return {

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -779,6 +779,14 @@ export class ObjectQL implements IDataEngine {
    * defaults are applied verbatim. Records that already supplied a value for a
    * field are left untouched.
    *
+   * "Supplied a value" means the field is present with a non-null value. Both an
+   * OMITTED field (`undefined`) and an EXPLICIT `null` are treated as "not
+   * supplied" and get the default. This runs on the INSERT path only, where a
+   * `null` from a form (an unpicked control serializes to `null`, not omission)
+   * unambiguously means "no value"; the UPDATE path never calls this, so a
+   * deliberate "set to null" on update is preserved (#2706). Empty string `''`
+   * is a real, user-entered value and is left as-is.
+   *
    * Implements ROADMAP §M9.9b — `defaultValue` accepts Expression so authors
    * can replace "write a hook to default to today/current-user" with a
    * declarative `defaultValue: cel\`today()\``.
@@ -799,7 +807,11 @@ export class ObjectQL implements IDataEngine {
     const out = { ...record };
     const now = nowSnapshot ?? new Date();
     for (const f of fieldEntries) {
-      if (out[f.name] !== undefined) continue;
+      // Apply the default when the field is either OMITTED (`undefined`) or an
+      // EXPLICIT `null` — both mean "no value supplied" on insert (#2706). A
+      // real value (including `''`) is respected. Insert-only path, so an
+      // intentional "set to null" on update is never touched here.
+      if (out[f.name] != null) continue;
       if (f.defaultValue == null) continue;
       const dv = f.defaultValue;
       if (typeof dv === 'object' && dv !== null && (dv as any).dialect && typeof (dv as any).source === 'string') {


### PR DESCRIPTION
## 背景

修复 #2706 中归属本仓库(objectql)的子问题。

## 排查结论

- **#1 解析顺序晚于 beforeInsert hook** — 已由 #2703 / #2748 修复(`applyFieldDefaults` 现已在 `beforeInsert` 之前执行),含回归测试,**本次无需再动**。
- **#2 显式 `null` 不回填** — 本 PR 修复。
- **#3 创建表单不预填 `current_user`** — 归属 objectui,本仓库不涉及。

## 改动

`applyFieldDefaults` 原判据为 `out[f.name] !== undefined`,只有"省略"字段才回填 default;表单把未选控件序列化成显式 `null` 时会落库 `null`(`current_user` 令牌与静态默认都不生效)。

- 判据改为 `out[f.name] != null`:insert 时"省略"与"显式 null"一视同仁,都视为"未提供值"并回填 default。
- 空串 `''` 仍视为真实值,不覆盖。
- **仅影响 insert 路径**:`applyFieldDefaults` 只在 `insert()` 调用,`update()` 从不调用它,因此 update 的"置 null"语义完全不受影响。
- 更新函数文档注释,明确 omitted / explicit null 均按"未提供"处理的语义。

## 测试

新增两条回归测试(`engine.test.ts`):
- 显式 `owner:null, status:null` → 回填 `current_user` + 静态默认;
- 显式 `status:''` → 保留空串不覆盖。

`packages/objectql` 全部 48 条测试通过。

Refs #2706(本仓库子项 #1/#2;#3 归 objectui,保留 issue 开启)