### PR TITLE
feat(spec,platform-objects): action param 'visible' predicate; gate create-user phone on features.phoneNumber

### DIFF
--- a/.changeset/action-param-visible.md
+++ b/.changeset/action-param-visible.md
@@ -1,0 +1,8 @@
+---
+'@objectstack/spec': patch
+'@objectstack/platform-objects': patch
+---
+
+**Action params gain a `visible` predicate; the create-user `phoneNumber` param is gated on `features.phoneNumber`.**
+
+`ActionParamSchema` gains an optional `visible` (CEL, `ExpressionInputSchema`) evaluated against the same scope as action `visible` (`current_user`/`app`/`data`/`features`); a UI that honors it omits the param when it's false. The `sys_user` `create_user` action's `phoneNumber` param now carries `visible: 'features.phoneNumber == true'`, so the form no longer offers a Phone Number field when the opt-in `phoneNumber` auth plugin is off — otherwise the endpoint rejects it with "Phone numbers require the phoneNumber auth plugin". Pairs with the objectui `ActionParamDialog` change that evaluates `param.visible`.

--- a/packages/platform-objects/src/identity/sys-user.object.ts
+++ b/packages/platform-objects/src/identity/sys-user.object.ts
@@ -153,6 +153,11 @@ export const SysUser = ObjectSchema.create({
           type: 'text',
           required: false,
           helpText: 'Sign-in phone number (E.164, e.g. +8613800000000). Required when no email is given.',
+          // Only offer phone when the opt-in phoneNumber auth plugin is loaded —
+          // otherwise the create-user endpoint rejects a phone with
+          // "Phone numbers require the phoneNumber auth plugin". `features.phoneNumber`
+          // is served in /api/v1/auth/config (getPublicConfig).
+          visible: 'features.phoneNumber == true',
         },
         { field: 'name', required: false },
         {

--- a/packages/spec/src/ui/action.zod.ts
+++ b/packages/spec/src/ui/action.zod.ts
@@ -66,6 +66,15 @@ export const ActionParamSchema = lazySchema(() => z.object({
    * context. Useful for edit dialogs that pre-fill from the selected row.
    */
   defaultFromRow: z.boolean().optional(),
+  /**
+   * Visibility predicate (CEL) — same scope as the action-level `visible`
+   * (`current_user` / `app` / `data` / `features`). When it evaluates false the
+   * dialog omits this param entirely. Use it to hide a param that the backend
+   * only accepts under an opt-in capability, e.g. the create-user `phoneNumber`
+   * param gated on `features.phoneNumber` so the form never offers a field the
+   * default backend rejects. Absent = always visible.
+   */
+  visible: ExpressionInputSchema.optional().describe('Param visibility predicate (CEL); omits the param when false.'),
 }).refine(
   (p) => Boolean(p.name) || Boolean(p.field),
   { message: 'ActionParam requires either "name" or "field"' },


### PR DESCRIPTION
## What

The create-user form offers a **Phone Number** field that the default backend rejects — `{"code":"invalid_request","message":"Phone numbers require the phoneNumber auth plugin (auth.plugins.phoneNumber)"}` — because `phoneNumber` is an opt-in better-auth plugin (off by default), yet the `sys_user` `create_user` action statically advertises the param. This makes the form *follow the plugin*: no phone field unless the plugin is loaded.

## How

- **`ActionParamSchema`** (`spec/ui/action.zod.ts`) gains an optional **`visible`** predicate (`ExpressionInputSchema` / CEL), evaluated against the same scope as action-level `visible` (`current_user` / `app` / `data` / `features`). A dialog that honors it omits the param when it's false.
- **`sys_user.create_user`** (`platform-objects/identity/sys-user.object.ts`) gates its `phoneNumber` param on **`features.phoneNumber == true`**. `features.phoneNumber` is already served in `/api/v1/auth/config` (getPublicConfig), so the client can evaluate it.

Back-compat: `visible` is optional; params without it are unaffected.

## Verified

- `ActionParamSchema.safeParse({...visible})` parses + preserves the predicate; a param without `visible` still parses.
- Paired objectui change (`ActionParamDialog` honoring `param.visible`) is unit-tested (6 tests: feature-off hides, feature-on shows, absent-flag hides, malformed fails open, and the normalized `{dialect,source}` served form) with a browser regression showing the create-user dialog renders cleanly.

## Pairs with

objectui **objectstack-ai/objectui#2406** — `ActionParamDialog` evaluates `param.visible`. Both must land for the phone field to hide (spec adds the field; objectui honors it).

_Alternative considered — default-loading the phoneNumber plugin — was rejected: it turns an opt-in auth/sign-in surface (with an SMS-provider dependency for OTP) on for every deployment. "Form follows plugin" is the conservative fix._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
