### PR TITLE
feat(sharing): pick-not-type Sharing Rule form via field widget hints

### DIFF
--- a/.changeset/sharing-rule-form-pickers.md
+++ b/.changeset/sharing-rule-form-pickers.md
@@ -1,0 +1,26 @@
+---
+"@objectstack/spec": minor
+"@objectstack/plugin-sharing": minor
+---
+
+Field metadata gains a `widget` override (`FieldSchema.widget`) — names a
+registered form component (resolved as `field:<widget>`) to render a field with,
+overriding the default widget derived from `type` and degrading back to it when
+unregistered. The generic object form already honored this hint (objectui
+`ObjectForm`/`form.tsx` resolve `widget || type`); this promotes it to a
+first-class, liveness-classified authoring property so any config object can ask
+for a picker instead of a raw input.
+
+`sys_sharing_rule` uses it so the Setup **New Sharing Rule** form is
+pick-not-type instead of asking admins to hand-enter machine data:
+
+- `object_name` → `object-ref` (choose a registered object by name)
+- `criteria_json` → `filter-condition` (visual criteria builder scoped to the
+  chosen object's fields; `dependsOn: object_name`)
+- `recipient_id` → `recipient-picker` (record picker whose target follows
+  `recipient_type`; `dependsOn: recipient_type`)
+
+Also removes the `queue` recipient type: it is declared-but-unenforced (the
+evaluator expands no users for it), so offering it authored a silently-inert rule
+(ADR-0078). i18n bundles regenerated. Requires the matching objectui widgets; the
+fields degrade to their `type` renderer where those aren't loaded.

--- a/packages/plugins/plugin-sharing/src/objects/sys-sharing-rule.object.ts
+++ b/packages/plugins/plugin-sharing/src/objects/sys-sharing-rule.object.ts
@@ -120,6 +120,10 @@ export const SysSharingRule = ObjectSchema.create({
       label: 'Object',
       required: true,
       maxLength: 100,
+      // Rendered as an object picker (choose a registered object by name)
+      // instead of a free-text machine-name input. Falls back to a text input
+      // when the `field:object-ref` widget is unavailable.
+      widget: 'object-ref',
       description: 'Short object name (e.g. opportunity, account)',
       group: 'Target',
     }),
@@ -127,12 +131,21 @@ export const SysSharingRule = ObjectSchema.create({
     criteria_json: Field.textarea({
       label: 'Criteria (FilterCondition JSON)',
       required: false,
+      // Rendered as a visual criteria builder scoped to the selected object's
+      // fields (dependsOn: object_name), storing the same JSON FilterCondition.
+      // An "Edit as JSON" fallback keeps hand-authored / advanced filters
+      // editable. Falls back to a textarea when the widget is unavailable.
+      widget: 'filter-condition',
+      dependsOn: ['object_name'],
       description: 'JSON FilterCondition matched against records of object_name. Empty = match all.',
       group: 'Target',
     }),
 
     recipient_type: Field.select(
-      ['user', 'team', 'business_unit', 'position', 'unit_and_subordinates', 'queue'],
+      // `queue` was removed: it is declared-but-unenforced (the evaluator returns
+      // no users for it), so offering it would author a silently-inert rule
+      // (ADR-0078). The five values below are the ones the evaluator expands.
+      ['user', 'team', 'business_unit', 'position', 'unit_and_subordinates'],
       {
         label: 'Recipient Type',
         required: true,
@@ -146,7 +159,14 @@ export const SysSharingRule = ObjectSchema.create({
       label: 'Recipient',
       required: true,
       maxLength: 200,
-      description: 'business-unit id / team id / position name / queue name / user id depending on recipient_type',
+      // Rendered as a record picker whose target object follows recipient_type
+      // (dependsOn: recipient_type): sys_user / sys_team / sys_business_unit /
+      // sys_position. Stores the value the evaluator matches on — a record id
+      // for user/team/business_unit, the position NAME for `position`. Falls
+      // back to a text input when the widget is unavailable.
+      widget: 'recipient-picker',
+      dependsOn: ['recipient_type'],
+      description: 'business-unit id / team id / position name / user id depending on recipient_type',
       group: 'Recipient',
     }),
 

--- a/packages/plugins/plugin-sharing/src/translations/en.objects.generated.ts
+++ b/packages/plugins/plugin-sharing/src/translations/en.objects.generated.ts
@@ -137,13 +137,12 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
           team: "team",
           business_unit: "business_unit",
           position: "position",
-          unit_and_subordinates: "unit_and_subordinates",
-          queue: "queue"
+          unit_and_subordinates: "unit_and_subordinates"
         }
       },
       recipient_id: {
         label: "Recipient",
-        help: "business unit id / team id / position name / queue name / user id depending on recipient_type"
+        help: "business unit id / team id / position name / user id depending on recipient_type"
       },
       access_level: {
         label: "Access Level",

--- a/packages/plugins/plugin-sharing/src/translations/es-ES.objects.generated.ts
+++ b/packages/plugins/plugin-sharing/src/translations/es-ES.objects.generated.ts
@@ -137,8 +137,7 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
           team: "Equipo",
           business_unit: "business_unit",
           position: "posición",
-          unit_and_subordinates: "unit_and_subordinates",
-          queue: "Cola"
+          unit_and_subordinates: "unit_and_subordinates"
         }
       },
       recipient_id: {

--- a/packages/plugins/plugin-sharing/src/translations/ja-JP.objects.generated.ts
+++ b/packages/plugins/plugin-sharing/src/translations/ja-JP.objects.generated.ts
@@ -137,8 +137,7 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
           team: "チーム",
           business_unit: "business_unit",
           position: "ポジション",
-          unit_and_subordinates: "unit_and_subordinates",
-          queue: "キュー"
+          unit_and_subordinates: "unit_and_subordinates"
         }
       },
       recipient_id: {

--- a/packages/plugins/plugin-sharing/src/translations/zh-CN.objects.generated.ts
+++ b/packages/plugins/plugin-sharing/src/translations/zh-CN.objects.generated.ts
@@ -137,8 +137,7 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
           team: "团队",
           business_unit: "business_unit",
           position: "岗位",
-          unit_and_subordinates: "unit_and_subordinates",
-          queue: "队列"
+          unit_and_subordinates: "unit_and_subordinates"
         }
       },
       recipient_id: {

--- a/packages/spec/liveness/field.json
+++ b/packages/spec/liveness/field.json
@@ -92,6 +92,10 @@
       "status": "live",
       "note": "renderer."
     },
+    "widget": {
+      "status": "live",
+      "note": "objectui generic form widget override. ObjectForm (packages/plugin-form/src/ObjectForm.tsx) threads `field.widget` into the renderer; form.tsx resolves `widget || type` and looks it up as `field:<widget>` in the ComponentRegistry (renderFieldComponent). Used to render pick-not-type controls for sys_sharing_rule (object-ref / filter-condition / recipient-picker) and sys_permission_set (capability-multiselect). Degrades to the `type` renderer when the widget is unregistered."
+    },
     "requiredPermissions": {
       "status": "live",
       "evidence": "packages/plugins/plugin-security/src/security-plugin.ts",

--- a/packages/spec/src/data/field.zod.ts
+++ b/packages/spec/src/data/field.zod.ts
@@ -597,6 +597,20 @@ export const FieldSchema = lazySchema(() => z.object({
    *  @deprecated Alias of `requiredWhen` — kept for back-compat. */
   conditionalRequired: ExpressionInputSchema.optional().describe('Predicate (CEL) — field is required when TRUE. Alias of `requiredWhen`.'),
 
+  /**
+   * Form widget override. Names a registered field/UI component to render this
+   * field with, overriding the default widget derived from `type`. Honored by
+   * the generic object form (objectui `ObjectForm`/`form.tsx` resolve
+   * `widget || type`, looking the value up as `field:<widget>` in the component
+   * registry). Use it when the raw `type` renderer would force a user to type
+   * machine data that should be *picked* instead — e.g. an object-name field
+   * (`widget: 'object-ref'`), a stored FilterCondition (`widget:
+   * 'filter-condition'`), or a recipient reference whose target depends on a
+   * sibling field (`widget: 'recipient-picker'`). Unknown/unregistered values
+   * fall back to the `type` renderer, so it degrades safely.
+   */
+  widget: z.string().optional().describe('Form widget override — names a registered field component (resolved as `field:<widget>`) to render this field instead of the `type` default. Degrades to the `type` renderer when unregistered. e.g. "object-ref", "filter-condition", "recipient-picker".'),
+
   /** Security & Visibility */
   hidden: z.boolean().default(false).describe('Hidden from default UI'),
   readonly: z.boolean().default(false).describe('Read-only in UI'),


### PR DESCRIPTION
## What & why

The Setup **New Sharing Rule** form made admins hand-type machine data — the object's machine name, a raw FilterCondition JSON, and a recipient id/name — where the platform should let them **select**. This makes those fields pickers.

The enabling mechanism is a new, first-class **`FieldSchema.widget`** override: it names a registered form component (resolved as `field:<widget>`) to render a field with, overriding the default widget derived from `type` and **degrading back to the `type` renderer when unregistered**. The generic object form already honored the hint (`widget || type`); this promotes it to an authored, liveness-classified property so *any* config object can request a picker instead of a raw input.

The matching widgets ship in **objectui** (`objectstack-ai/objectui#<pending>`, same branch). Because the fields degrade to their `type` renderer where the widgets aren't loaded, the two repos land independently.

## Changes

- **spec**: add `FieldSchema.widget` (+ liveness classification in `field.json`; `check:liveness` gate green).
- **plugin-sharing** — `sys_sharing_rule` declares widgets + `dependsOn`:
  - `object_name` → `object-ref` (object picker)
  - `criteria_json` → `filter-condition` (visual criteria builder, `dependsOn: object_name`)
  - `recipient_id` → `recipient-picker` (record picker, `dependsOn: recipient_type`)
- **plugin-sharing**: remove the `queue` recipient type — it is declared-but-unenforced (the evaluator expands no users for it), so offering it authored a silently-inert rule (ADR-0078). i18n bundles regenerated.

## Verification

- `@objectstack/spec` build ✅ · `check:liveness` gate ✅ (field fully classified)
- `@objectstack/plugin-sharing` build ✅ · tests **79/79** ✅
- The `queue` removal touches only the object's select options + regenerated i18n; the unrelated `expandPrincipal` queue path is untouched.

## Notes

- Storage contracts are unchanged: `criteria_json` still round-trips the MongoDB-style FilterCondition the evaluator spreads into `engine.find`; `recipient_id` still stores a record id (or the position **name** for `position`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013wGu7aa1YXhHseojW9CBRf)_