### PR TITLE
fix(plugin-auth): land OAuth callback errors on the console login page (objectui#2458 item 1)

### DIFF
--- a/packages/plugins/plugin-auth/src/auth-manager.test.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.test.ts
@@ -886,6 +886,30 @@ describe('AuthManager', () => {
     });
   });
 
+  describe('onAPIError.errorURL (objectui#2458 item 1)', () => {
+    it('points browser-flow errors at the console login page so ?error= is surfaced', async () => {
+      let capturedConfig: any;
+      (betterAuth as any).mockImplementation((config: any) => {
+        capturedConfig = config;
+        return { handler: vi.fn(), api: {} };
+      });
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const manager = new AuthManager({
+        secret: 'test-secret-at-least-32-chars-long',
+        baseUrl: 'http://localhost:3000',
+      });
+      await manager.getAuthInstance();
+      warnSpy.mockRestore();
+
+      // Default error redirect (`${baseURL}/error` → `/?error=…`) loses the
+      // query on the root→console bounce; the login page renders it instead.
+      expect(capturedConfig.onAPIError).toEqual({
+        errorURL: 'http://localhost:3000/_console/login',
+      });
+    });
+  });
+
   describe('emailAndPassword passthrough', () => {
     it('should default emailAndPassword to enabled: true', async () => {
       let capturedConfig: any;

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -1169,6 +1169,17 @@ export class AuthManager {
         }),
       },
 
+      // Where better-auth redirects a browser flow that fails server-side —
+      // most importantly an OAuth callback error (expired/replayed `state`,
+      // IdP error). The default is `${baseURL}/error`, which bounces to
+      // `/?error=<code>`; the root→console redirect then DROPS the query, so
+      // the user lands on a silent login form right after a successful IdP
+      // sign-in (objectui#2458 item 1). Point it at the console login page,
+      // which renders `?error=` as an inline banner.
+      onAPIError: {
+        errorURL: this.getConsolePageUrl('/login'),
+      },
+
       // Trusted origins for CSRF protection (supports wildcards like "https://*.example.com")
       // Auto-includes origins from OS_CORS_ORIGIN env var so CORS and CSRF stay in sync.
       ...(() => {


### PR DESCRIPTION
Paired with objectstack-ai/objectui#2468 (merge that UI PR first — this redirect targets the error banner it adds; without it the login page still receives the param but shows nothing, which is no worse than today).

## Problem

A failed OAuth callback (expired/replayed `state` after the 10-minute signed-params window, IdP error) redirects through better-auth's default error URL: `/api/v1/auth/error?error=state_mismatch` → `/?error=state_mismatch`. The runtime's root→`/_console/` redirect **drops the query string**, so a user who just signed in successfully at the IdP lands on a silent login form with no explanation — reproduced live as the "login silent failure" in objectui#2458 item 1.

## Change

Set `onAPIError.errorURL` in the betterAuth config to `getConsolePageUrl('/login')` — the same console-page helper already used for the oidc `loginPage`/`consentPage`. better-auth's generic-oauth callback (and core error route) then lands the browser on `/_console/login?error=<code>`, which the console login page renders as a visible banner (objectui#2468).

Unit test asserts the config wiring; full `auth-manager.test.ts` suite green (171 tests). End-to-end redirect chain traced live on the run-stack rig: env callback 302 → `/api/v1/auth/error?error=state_mismatch` → `/?error=state_mismatch` (query lost today); with this change the target is the login page and the banner was verified rendering via direct navigation to `/_console/login?error=state_mismatch`.

Refs objectstack-ai/objectui#2458 (item 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)