### PR TITLE
fix(example-showcase): route external-datasource fixture through the sqlite fallback

### DIFF
--- a/examples/app-showcase/package.json
+++ b/examples/app-showcase/package.json
@@ -27,6 +27,7 @@
     "@objectstack/connector-slack": "workspace:*",
     "@objectstack/driver-sql": "workspace:*",
     "@objectstack/runtime": "workspace:*",
+    "@objectstack/service-datasource": "workspace:*",
     "@objectstack/spec": "workspace:*"
   },
   "devDependencies": {

--- a/examples/app-showcase/src/system/datasources/external-fixture.ts
+++ b/examples/app-showcase/src/system/datasources/external-fixture.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { SqlDriver } from '@objectstack/driver-sql';
+import { resolveSqliteDriver } from '@objectstack/service-datasource';
 
 /**
  * Fixture provisioning for the external-datasource federation demo
@@ -10,6 +10,14 @@ import { SqlDriver } from '@objectstack/driver-sql';
  * SQLite file with `customers` / `orders` tables + a little seed data (a MANAGED
  * driver — DDL allowed) so `os dev` needs no external server. It runs from the
  * stack's `onEnable` hook at boot.
+ *
+ * The MANAGED driver is built via the shared `resolveSqliteDriver` step-down
+ * (#2229) rather than a raw `new SqlDriver({ client: 'better-sqlite3' })`: in dev
+ * a native `better-sqlite3` ABI/load failure (e.g. a `NODE_MODULE_VERSION`
+ * mismatch after a Node upgrade) steps down to wasm SQLite instead of throwing.
+ * Without this, an ABI mismatch here crashed the whole `onEnable` hook —
+ * bricking `plugin.app.<showcase>` boot even though the default datasource had
+ * already fallen back to wasm.
  *
  * **It no longer registers a driver or syncs object schemas (ADR-0062 D8).** The
  * declared `external` datasource (see `showcase-external.datasource.ts`) now
@@ -71,11 +79,17 @@ interface OnEnableContext {
  * datasource auto-connects at boot (ADR-0062 D1/D8).
  */
 export async function setupShowcaseExternalDatasource(ctx: OnEnableContext): Promise<void> {
-  const fixture = new SqlDriver({
-    client: 'better-sqlite3',
-    connection: { filename: EXTERNAL_DB_FILE },
-    useNullAsDefault: true,
-  }) as unknown as {
+  // Build the managed provisioning driver through the shared native → wasm →
+  // in-memory step-down (#2229). In dev, a native better-sqlite3 ABI/load
+  // failure steps down to wasm SQLite (real SQL + on-disk persistence) so the
+  // fixture — and therefore `onEnable` / app-plugin boot — never crashes on a
+  // `NODE_MODULE_VERSION` mismatch; in production it returns the native driver
+  // unprobed (fail-closed), preserving the historical behavior.
+  const resolved = await resolveSqliteDriver({
+    filename: EXTERNAL_DB_FILE,
+    warn: (m: string) => ctx.logger?.warn?.(m),
+  });
+  const fixture = resolved.driver as unknown as {
     name: string;
     connect: () => Promise<void>;
     disconnect: () => Promise<void>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       '@objectstack/runtime':
         specifier: workspace:*
         version: link:../../packages/runtime
+      '@objectstack/service-datasource':
+        specifier: workspace:*
+        version: link:../../packages/services/service-datasource
       '@objectstack/spec':
         specifier: workspace:*
         version: link:../../packages/spec


### PR DESCRIPTION
## Symptom

`pnpm dev` in the showcase crashes at boot with the app plugin rolled back:

```
2026-… ERROR Plugin startup failed: plugin.app.com.example.showcase
  The module '…/better-sqlite3/build/Release/better_sqlite3.node' was compiled against a
  different Node.js version using NODE_MODULE_VERSION 127. This version of Node.js requires
  NODE_MODULE_VERSION 141. … (ERR_DLOPEN_FAILED)
  ✗ Plugin plugin.app.com.example.showcase failed to start - rollback complete
```

…even though the **default** datasource had already logged the graceful step-down
(`native better-sqlite3 unavailable … dev using wasm SQLite`).

## Root cause

`setupShowcaseExternalDatasource` (invoked from the showcase app's `onEnable` at boot, in
`examples/app-showcase/src/system/datasources/external-fixture.ts`) built its MANAGED
provisioning driver with a raw `new SqlDriver({ client: 'better-sqlite3' })`.

`better-sqlite3` loads its native addon **lazily** at first query, so a `NODE_MODULE_VERSION`
ABI mismatch (e.g. after a Node upgrade) surfaces as `ERR_DLOPEN_FAILED` right here. The error
propagates through `onEnable` → `AppPlugin.start()` and bricks `plugin.app.com.example.showcase`.

Issue #2229 hoisted every SQLite construction site onto the shared `resolveSqliteDriver`
native → wasm → in-memory step-down. This fixture site was the one that got missed — so the
platform's own fallback machinery couldn't save it.

## Fix

Route the fixture through the same `resolveSqliteDriver` helper (`@objectstack/service-datasource`):

- **Dev:** a native ABI/load failure steps down to wasm SQLite (real SQL + on-disk persistence)
  instead of throwing, so `onEnable` / app-plugin boot survives — consistent with the default
  datasource and the declared `showcase_external` datasource, which already use this helper.
- **Production:** returns the native driver unprobed (fail-closed) — historical behavior unchanged.

Adds `@objectstack/service-datasource` (which exports `resolveSqliteDriver`) to the example's
dependencies.

## Verification

- `tsc --noEmit` on `@objectstack/example-showcase`: **0 errors** (after building the workspace deps).
- `objectstack compile` on the showcase config: succeeds (import chain resolves at bundle time).
- End-to-end `objectstack serve --dev`: app plugin starts, the fixture provisions
  `showcase_external.db`, server listens — **0** `Plugin startup failed` / `ERR_DLOPEN` /
  `NODE_MODULE_VERSION` occurrences (native happy path unbroken).
- `@objectstack/service-datasource` test suite: **93/93 pass**, including the sqlite-driver
  fallback tests that back this step-down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUWGgTT5s7XgBb2eLtzhfU)_