### PR TITLE
fix(driver-sql): don't dump a scary ERR_DLOPEN stack for the native→wasm probe

### DIFF
--- a/.changeset/driver-sql-quiet-dlopen-probe.md
+++ b/.changeset/driver-sql-quiet-dlopen-probe.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/driver-sql": patch
+---
+
+Log a concise one-liner instead of the full `ERR_DLOPEN_FAILED` stack trace when native `better-sqlite3` cannot load (an ABI / `NODE_MODULE_VERSION` mismatch after a Node upgrade, or the native addon was never built). The native → wasm SQLite step-down is unchanged — this only stops a handled, non-fatal fallback from reading like a fatal crash in the dev console, and points at `pnpm rebuild better-sqlite3` for native speed. Any other `PRAGMA` failure keeps its full warning.

--- a/packages/plugins/driver-sql/src/sql-driver.ts
+++ b/packages/plugins/driver-sql/src/sql-driver.ts
@@ -580,7 +580,33 @@ export class SqlDriver implements IDataDriver {
       try {
         await this.knex.raw('PRAGMA auto_vacuum = INCREMENTAL');
       } catch (e) {
-        this.logger.warn('Failed to set PRAGMA auto_vacuum=INCREMENTAL', e);
+        // A native better-sqlite3 load failure surfaces HERE first — this PRAGMA
+        // is the first query that forces the lazy `.node` addon to load. Two
+        // real-world variants, both handled by `resolveSqliteDriver`'s probe,
+        // which catches the failure and steps down to wasm SQLite with a clean
+        // one-line notice (#2229):
+        //   • ABI mismatch  — `ERR_DLOPEN_FAILED` / "…NODE_MODULE_VERSION 127…"
+        //                      (a stale prebuilt binary after a Node upgrade)
+        //   • not built     — "Could not locate the bindings file" (native addon
+        //                      never compiled, e.g. a fresh clone / blocked build)
+        // Dumping the full multi-line stack for either looks like a fatal crash
+        // to the reader (it isn't), so log a concise, actionable one-liner and
+        // let the step-down message that follows explain the outcome. Any OTHER
+        // PRAGMA failure keeps the full warning (with stack) as before.
+        const code = (e as { code?: string } | null | undefined)?.code;
+        const msg = e instanceof Error ? e.message : String(e);
+        const isNativeLoadFailure =
+          code === 'ERR_DLOPEN_FAILED' ||
+          code === 'MODULE_NOT_FOUND' ||
+          code === 'ERR_MODULE_NOT_FOUND' ||
+          /NODE_MODULE_VERSION|could not locate the bindings|was compiled against a different/i.test(msg);
+        if (isNativeLoadFailure) {
+          this.logger.warn(
+            'native better-sqlite3 unavailable (ABI mismatch or not built) — will step down to wasm SQLite; run `pnpm rebuild better-sqlite3` for native speed',
+          );
+        } else {
+          this.logger.warn('Failed to set PRAGMA auto_vacuum=INCREMENTAL', e);
+        }
       }
     }
   }


### PR DESCRIPTION
## Context

Follow-up to #2890. That PR fixed the **fatal** `pnpm dev` crash on a `better-sqlite3` ABI mismatch (the showcase fixture now steps down to wasm instead of bricking app-plugin boot). But the dev console still *looked* broken: the native-load failure was logged with the full multi-line `ERR_DLOPEN_FAILED` / `NODE_MODULE_VERSION` stack trace — twice — so a **handled, non-fatal** step-down reads as a fatal crash.

```
Failed to set PRAGMA auto_vacuum=INCREMENTAL Error: The module '…better_sqlite3.node'
was compiled against a different Node.js version using NODE_MODULE_VERSION 127 …
    at Object..node (node:internal/modules/cjs/loader:1996:18)
    at new Database (…/better-sqlite3/lib/database.js:48:64)
    … (10+ stack frames) …
  ⚠ native better-sqlite3 unavailable … dev using wasm SQLite
```

## Why it surfaces there

`SqlDriver.connect()` runs a best-effort `PRAGMA auto_vacuum = INCREMENTAL`. That PRAGMA is the *first query* to force `better-sqlite3`'s lazily-loaded `.node` addon to load, so a native ABI/build failure lands in its `catch` first — where it was logged with the full error object (stack and all) — before `resolveSqliteDriver`'s probe catches the follow-on failure and prints its clean one-line step-down notice.

## Fix

In that one `catch`, detect the native-load-failure family and log a concise, actionable one-liner instead of the stack. Covers both real-world variants the step-down already handles:

- **ABI mismatch** — `code === 'ERR_DLOPEN_FAILED'` / `…NODE_MODULE_VERSION…` (stale prebuilt binary after a Node upgrade)
- **not built** — `Could not locate the bindings file` / `MODULE_NOT_FOUND` (native addon never compiled)

Any *other* PRAGMA failure keeps the full warning (with stack) unchanged. Purely a log-noise change — control flow and the fallback behavior are untouched.

**Before → After** (native disabled, reproducing the ABI mismatch):
```
  (10+ line ERR_DLOPEN stack, ×2)
      ↓
native better-sqlite3 unavailable (ABI mismatch or not built) — will step down to wasm SQLite; run `pnpm rebuild better-sqlite3` for native speed
  ⚠ native better-sqlite3 unavailable (ABI mismatch or not built) — dev using wasm SQLite (real SQL, slower).
```

## Verification

- `@objectstack/driver-sql` test suite: **275/275 pass** (31 files).
- End-to-end `pnpm dev` with the native binary disabled: **0** stack-trace lines remain, the concise one-liner appears, and the server still boots (API listening, no `Plugin startup failed`).
- driver-sql builds cleanly (incl. `.d.ts`).

Note: the definitive fix on an affected machine is still `pnpm rebuild better-sqlite3` (restores the native driver at full speed) — this PR just makes the fallback's console output honest about being non-fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUWGgTT5s7XgBb2eLtzhfU)_