### PR TITLE
ci: faster Test Core — affected-only PR tests, single spec suite run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,13 @@ on:
     branches:
       - main
 
+# Superseded runs on the same PR/branch waste runners and delay feedback;
+# cancel them. Push runs to main group by commit ref as well, so an in-flight
+# main run is cancelled only by a newer main push.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   filter:
     runs-on: ubuntu-latest
@@ -56,6 +63,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          # Full history so `turbo --affected` can diff against the PR base.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -93,13 +103,29 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run all tests
-        run: pnpm turbo run test
+      # PRs: only test packages affected by the diff against the PR base.
+      # spec sits at the root of the dependency graph, so spec-touching PRs
+      # still run (close to) everything — but the many PRs that don't touch
+      # spec skip the bulk of the 75-package matrix.
+      - name: Run affected tests (PR)
+        if: github.event_name == 'pull_request'
+        env:
+          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+        run: pnpm turbo run test --affected
+
+      # Push to main: full run, but exclude spec's plain test task — the
+      # coverage step below executes the exact same 250-file spec suite once,
+      # with coverage. Previously the spec suite ran twice per push.
+      - name: Run all tests (push)
+        if: github.event_name == 'push'
+        run: pnpm turbo run test --filter=!@objectstack/spec
 
       - name: Generate coverage report
+        if: github.event_name == 'push'
         run: pnpm --filter @objectstack/spec test:coverage
 
       - name: Upload coverage reports
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v7
         with:
           name: coverage-report

--- a/packages/apps/account/package.json
+++ b/packages/apps/account/package.json
@@ -13,8 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
-    "test": "vitest run --passWithNoTests"
+    "build": "tsup"
   },
   "dependencies": {
     "@objectstack/platform-objects": "workspace:*",

--- a/packages/apps/setup/package.json
+++ b/packages/apps/setup/package.json
@@ -13,8 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
-    "test": "vitest run --passWithNoTests"
+    "build": "tsup"
   },
   "dependencies": {
     "@objectstack/platform-objects": "workspace:*",

--- a/packages/apps/studio/package.json
+++ b/packages/apps/studio/package.json
@@ -13,8 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
-    "test": "vitest run --passWithNoTests"
+    "build": "tsup"
   },
   "dependencies": {
     "@objectstack/platform-objects": "workspace:*",


### PR DESCRIPTION
## Why

Test Core is the CI critical path at ~12 min per run (`turbo run test` alone is 10m20s; a recent main run executed 129 tasks with only 3 turbo cache hits). Log analysis of run [29339722865](https://github.com/objectstack-ai/framework/actions/runs/29339722865) showed two structural wastes:

1. **The 250-file `@objectstack/spec` suite runs twice per run** — once inside `turbo run test` (~53 s), then again in full under `test:coverage` (~38 s) just to collect coverage for `*.zod.ts`.
2. **Every PR runs the full 75-package matrix**, even when the diff can't affect most of it.

## What

- **PRs:** `turbo run test --affected` (with `TURBO_SCM_BASE` pinned to the PR base SHA, checkout at `fetch-depth: 0`). Spec-touching PRs still fan out to (almost) everything since spec is the graph root; PRs that don't touch spec skip the bulk of the matrix. Verified locally: this PR's own diff resolves to 9 affected test tasks instead of 75.
- **Pushes to main:** unchanged full run, except `@objectstack/spec` is excluded from the plain test pass — the coverage step executes the identical suite once, with coverage. Coverage generation + artifact upload are now push-only (they previously also ran on PRs).
- **Concurrency:** superseded runs on the same PR/branch are cancelled (same group expression objectui already uses).
- **Empty test scripts dropped:** `packages/apps/{account,setup,studio}` have zero test files but each booted a `vitest run --passWithNoTests` process every run. Verified turbo treats the missing script as `<NONEXISTENT>` and skips it.

## Expected effect

Push runs: ~1 min faster (single spec pass + no vitest no-op boots). Non-spec PRs: several minutes faster depending on the affected subgraph. No test is deleted or weakened — PR coverage collection moves to push-only, which matches how objectui already gates Codecov.

## Not in this PR (follow-ups from the CI-time evaluation)

- Sharing `bootStack` across dogfood suites (44 full-stack boots dominate the 7-min Dogfood job).
- De-duplicating the ~11 dogfood RLS fixtures vs `objectstack verify --rls` + unit-layer RLS tests.
- Moving `example-showcase:test` (141 s, import-dominated) off the Test Core critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128mspMLGhBrCzww6jmVUaR

---
_Generated by [Claude Code](https://claude.ai/code/session_0128mspMLGhBrCzww6jmVUaR)_