### PR TITLE
feat(platform-objects): A3 — 用户页 Permission Sets + Business Units 分配入口 (#2920)

### DIFF
--- a/.changeset/a3-user-assignment-tabs.md
+++ b/.changeset/a3-user-assignment-tabs.md
@@ -1,0 +1,12 @@
+---
+'@objectstack/platform-objects': minor
+---
+
+feat(platform-objects): sys_user 记录页新增 Permission Sets 与 Business Units 两个一站式分配 tab (A3, #2920)
+
+管理员现在可在单个用户记录页完成三类分配:岗位(Positions,已有)、直接权限集授权(Permission Sets)、业务单元归属(Business Units)。两个新 tab 均为纯 SDUI 的 `record:related_list` + Add picker:
+
+- **Permission Sets** — junction `sys_user_permission_set`(id-keyed,`relationshipField: 'user_id'`),Add picker 绑定 `sys_permission_set`(`linkField: 'permission_set_id'`)。服务端 audience-anchor(D5/D9)与 delegated-admin(D12)门禁的拒绝原因会显示在 Add 对话框。
+- **Business Units** — junction `sys_business_unit_member`(id-keyed,`relationshipField: 'user_id'`),Add picker 绑定 `sys_business_unit`(`linkField: 'business_unit_id'`,按显示字段 `name` 标注)。
+
+tab 顺序为 Positions → Permission Sets → Business Units,四语言标签齐全。

--- a/packages/platform-objects/src/pages/sys-user.page.ts
+++ b/packages/platform-objects/src/pages/sys-user.page.ts
@@ -176,6 +176,83 @@ export const SysUserDetailPage: Page = {
             ],
           },
           {
+            // [ADR-0091 D1] Direct permission-set grants (直接授权) — pure SDUI.
+            // sys_user_permission_set is an ordinary id-keyed junction:
+            // user_id / permission_set_id are lookups keyed by record id, so
+            // the list keys on `relationshipField: 'user_id'` (no
+            // relationshipValueField). The Add picker binds a permission set by
+            // its id (linkField: 'permission_set_id'); server-side gates
+            // (audience-anchor D5/D9, delegated-admin D12) surface their denial
+            // reason in the Add dialog.
+            label: { en: 'Permission Sets', 'zh-CN': '权限集', 'ja-JP': '権限セット', 'es-ES': 'Conjuntos de permisos' },
+            icon: 'lock',
+            children: [
+              {
+                type: 'record:related_list',
+                properties: {
+                  objectName: 'sys_user_permission_set',
+                  relationshipField: 'user_id',
+                  columns: ['permission_set_id', 'organization_id', 'granted_by', 'created_at'],
+                  sort: [{ field: 'created_at', order: 'desc' }],
+                  limit: 25,
+                  showViewAll: true,
+                  title: { en: 'Permission Sets', 'zh-CN': '权限集', 'ja-JP': '権限セット', 'es-ES': 'Conjuntos de permisos' },
+                  add: {
+                    picker: {
+                      object: 'sys_permission_set',
+                      labelField: 'label',
+                    },
+                    linkField: 'permission_set_id',
+                    label: {
+                      en: 'Grant permission set',
+                      'zh-CN': '授予权限集',
+                      'ja-JP': '権限セットを付与',
+                      'es-ES': 'Otorgar conjunto de permisos',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+          {
+            // Business-unit membership (业务单元归属) — pure SDUI.
+            // sys_business_unit_member is an id-keyed junction: user_id /
+            // business_unit_id are lookups keyed by record id, so the list keys
+            // on `relationshipField: 'user_id'` (no relationshipValueField).
+            // The Add picker binds a BU by its id (linkField: 'business_unit_id');
+            // sys_business_unit has no `label` field so the picker labels rows by
+            // its display field `name`.
+            label: { en: 'Business Units', 'zh-CN': '业务单元', 'ja-JP': 'ビジネスユニット', 'es-ES': 'Unidades de negocio' },
+            icon: 'network',
+            children: [
+              {
+                type: 'record:related_list',
+                properties: {
+                  objectName: 'sys_business_unit_member',
+                  relationshipField: 'user_id',
+                  columns: ['business_unit_id', 'function_in_business_unit', 'is_primary', 'created_at'],
+                  sort: [{ field: 'created_at', order: 'desc' }],
+                  limit: 25,
+                  showViewAll: true,
+                  title: { en: 'Business Units', 'zh-CN': '业务单元', 'ja-JP': 'ビジネスユニット', 'es-ES': 'Unidades de negocio' },
+                  add: {
+                    picker: {
+                      object: 'sys_business_unit',
+                      labelField: 'name',
+                    },
+                    linkField: 'business_unit_id',
+                    label: {
+                      en: 'Add to business unit',
+                      'zh-CN': '加入业务单元',
+                      'ja-JP': 'ビジネスユニットに追加',
+                      'es-ES': 'Añadir a unidad de negocio',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+          {
             label: { en: 'Sessions', 'zh-CN': '会话', 'ja-JP': 'セッション', 'es-ES': 'Sesiones' },
             icon: 'monitor',
             children: [


### PR DESCRIPTION
## A3 — 用户页一站式分配入口 (tracking #2920)

让管理员在**单个 `sys_user` 记录页**完成三类分配。Positions tab 已存在,本 PR 补齐两个同款纯 SDUI tab,tab 顺序为 **Positions → Permission Sets → Business Units**。

### 改动
`packages/platform-objects/src/pages/sys-user.page.ts` — 在 Positions tab 之后新增两个 `record:related_list` + Add picker 的 tab:

1. **Permission Sets(直接授权)**
   - junction `sys_user_permission_set`(id-keyed 的 `Field.lookup`),`relationshipField: 'user_id'`(无 `relationshipValueField`)。
   - Add picker 绑定 `sys_permission_set`,`linkField: 'permission_set_id'`,`labelField: 'label'`。
   - 列:`permission_set_id / organization_id / granted_by / created_at`。
   - 服务端 audience-anchor(D5/D9)与 delegated-admin(D12)门禁的拒绝原因会显示在 Add 对话框(与 sys_position 页一致)。

2. **Business Units(业务单元归属)**
   - junction `sys_business_unit_member`(id-keyed 的 `Field.lookup`),`relationshipField: 'user_id'`(无 `relationshipValueField`)。
   - Add picker 绑定 `sys_business_unit`,`linkField: 'business_unit_id'`。`sys_business_unit` 无 `label` 字段,故 picker 按其显示字段 `name` 标注。
   - 列:`business_unit_id / function_in_business_unit / is_primary / created_at`。

两个 tab 均补齐 en / zh-CN / ja-JP / es-ES 四语言标签,与现有 Positions tab 处理方式一致。

### junction 字段类型确认
两个 junction 的 `user_id`(以及 `permission_set_id` / `business_unit_id`)都是 `Field.lookup(...)`,即 **id-keyed**,与 sys-user Positions tab、sys-position Permission Sets tab 的 id-keyed 模式一致 —— 因此**不需要** `relationshipValueField`(该字段仅用于 sys-position Holders 那种 name-keyed junction)。

### 验证
- `pnpm --filter "@objectstack/platform-objects..." build` ✅(CJS + ESM + DTS 全过;单独 build 时的 `metadata-core` 报错是仓库既有的依赖构建顺序问题,与本改动无关,带依赖构建即通过)。
- `pnpm --filter @objectstack/platform-objects test` ✅ 80/80 通过。

### changeset
`.changeset/a3-user-assignment-tabs.md`(minor)。

关联 #2920 · 这是 **A3(用户页一站式分配入口)**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QRUvVfpvSycAHMMF2xTxs

---
_Generated by [Claude Code](https://claude.ai/code/session_019QRUvVfpvSycAHMMF2xTxs)_