### PR TITLE
fix(plugin-security): #2936 — RLS field-existence/tenancyDisabled 网识别 canonical ==

### DIFF
--- a/.changeset/authz-2936-rls-eq-recognition.md
+++ b/.changeset/authz-2936-rls-eq-recognition.md
@@ -1,0 +1,34 @@
+---
+"@objectstack/plugin-security": patch
+---
+
+fix(plugin-security): #2936 — RLS field-existence / tenancy-disabled safety nets now recognize canonical `==`
+
+`extractTargetField` (the lightweight left-hand-field parser feeding the Layer 1
+**field-existence** net and the **tenancy-disabled** skip net in
+`computeLayeredRlsFilter`) only matched the legacy single-`=` / `IN` shape. It
+returned `null` for canonical CEL `==` (`field == …`), which is how real seeds
+and business policies author equality. A `null` target field means "keep the
+policy", so both safety nets were **inert** for every `==` policy: a wildcard
+policy targeting a column the object lacks was NOT failed closed, and a
+`==`-form `organization_id` policy on a `tenancy.enabled:false` object was NOT
+skipped. The regex now recognizes `==` (listed before `=` so the ordered
+alternation does not mis-match the first `=`), alongside the existing `=`/`IN`.
+Recognition is only **extended** — the net semantics are unchanged, and
+`!=`/`>`/`<`/`>=`/`<=` still return `null` (conservative keep), matching prior
+behavior for any unmatched shape.
+
+Behavior delta (fail-closed strengthening, same effective visibility): the
+wildcard `owner_only_writes` / `owner_only_deletes` seed policies
+(`created_by == current_user.id`) now correctly fail closed on an object that
+lacks a `created_by` column (platform-global / system tables). Previously they
+slipped the net and compiled to a phantom `{ created_by: … }` filter against a
+missing column — a driver-dependent, effectively-deny result; now the net drops
+the sole applicable write policy and yields the deny sentinel. A member could not
+by-id write such a column-less object either way, so the visible/writable row set
+is unchanged; only the mechanism is now an explicit fail-closed deny. All ordinary
+tenant/business objects carry `created_by`, so they are unaffected (proven green by
+the dogfood authz-conformance + RLS matrices). The tenancy-disabled skip net has no
+effect on any current seed (no `==` seed policy targets `organization_id` on a
+tenancy-disabled object). The tenant wall itself is Layer 0 (`tenant-layer.ts`),
+which never used this parser, so tenant isolation is unaffected (ADR-0095 D1).

--- a/packages/plugins/plugin-security/src/authz-matrix-gate.test.ts
+++ b/packages/plugins/plugin-security/src/authz-matrix-gate.test.ts
@@ -203,11 +203,22 @@ const EXPECTED_MATRIX: Record<string, Record<string, { read: unknown; write: unk
     org_admin: { read: null, write: 'BYPASS(no-write-filter)' },
     // [D1 accepted delta (c)] A member reading a `tenancy.enabled:false` global
     // object: Layer 0 treats it as a NON-tenant object (no phantom org filter) →
-    // the global catalog is VISIBLE (read: null). The write drops the dead
-    // org-disjunct to plain owner scope (same visibility, no org column exists).
-    member: { read: null, write: [{ created_by: 'u1' }] },
-    // [D1 accepted delta (c)] no-org member likewise sees the global catalog (was deny-sentinel).
-    no_org_member: { read: null, write: [{ created_by: 'u2' }] },
+    // the global catalog is VISIBLE (read: null).
+    // [#2936] WRITE now fail-closes to the DENY sentinel. `sys_package` has no
+    // `created_by` column, and the wildcard `owner_only_writes` policy authors
+    // its predicate as `created_by == current_user.id` (canonical `==`).
+    // Pre-#2936 `extractTargetField` did not recognize `==`, so the
+    // field-existence net let the policy through and it compiled to a phantom
+    // `{ created_by: … }` filter against a column the object lacks — a
+    // driver-dependent, effectively-deny result. Now the net recognizes `==`,
+    // sees `created_by` is absent, and drops the only applicable write policy →
+    // deny sentinel (fail-closed). SAME effective visibility (a member cannot
+    // by-id write a column-less global object either way); the mechanism is now
+    // an explicit fail-closed deny instead of a phantom-column filter.
+    member: { read: null, write: [{ id: DENY }] },
+    // [#2936] no-org member: same fail-closed deny on the write (see above); the
+    // global catalog stays VISIBLE on read (Layer 0 non-tenant, delta (c)).
+    no_org_member: { read: null, write: [{ id: DENY }] },
   },
   better_auth: {
     // [W2] better-auth-managed posture → superuser read bypass → null.

--- a/packages/plugins/plugin-security/src/security-plugin.test.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.test.ts
@@ -702,6 +702,34 @@ describe('SecurityPlugin', () => {
       expect(filter).toEqual(RLS_DENY_FILTER);
     });
 
+    it('[#2936] fail-closed on a CANONICAL `==` wildcard policy targeting a missing column → deny sentinel', async () => {
+      // The `=`-form twin above is the L692 test. This is its canonical-CEL
+      // sibling: pre-#2936 `extractTargetField` did not recognize `==`, so the
+      // field-existence net was INERT for it — the policy slipped through and
+      // compiled to a phantom `{ organization_id: … }` filter against a column
+      // the object lacks. The net now recognizes `==` and fails closed here,
+      // exactly as it always did for the legacy `=` form. Real seeds/business
+      // policies author equality as `==`, so this is the path that mattered.
+      const eqPolicySet: PermissionSet = {
+        name: 'member_default',
+        label: 'Member',
+        objects: { '*': { allowRead: true, allowCreate: true, allowEdit: true, allowDelete: true } },
+        rowLevelSecurity: [
+          { name: 'tenant_isolation', object: '*', operation: 'all', using: 'organization_id == current_user.organization_id' },
+        ],
+      } as any;
+      const plugin = new SecurityPlugin({ fallbackPermissionSet: 'member_default' });
+      const harness = makeMiddlewareCtx({
+        permissionSets: [eqPolicySet],
+        objectFields: ['id', 'name'], // no organization_id, tenancy not opted out
+        orgScoping: true,
+      });
+      await plugin.init(harness.ctx);
+      await plugin.start(harness.ctx);
+      const filter = await plugin.getReadFilter('task', { userId: 'u1', tenantId: 'org-1', positions: [], permissions: [] });
+      expect(filter).toEqual(RLS_DENY_FILTER);
+    });
+
     it('tenancy opt-out → undefined (not denied), matching the find-path', async () => {
       const plugin = new SecurityPlugin({ fallbackPermissionSet: 'member_default' });
       const harness = makeMiddlewareCtx({

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -2487,12 +2487,21 @@ export class SecurityPlugin implements Plugin {
    */
   private extractTargetField(using?: string): string | null {
     if (!using) return null;
-    // Match `field =` or `field IN`/`in`. Note: `\b` is omitted after `=`
-    // because `=` is non-word and the next char (space) is non-word too —
-    // a word boundary cannot exist between two non-word chars, so `=\b`
-    // would never match. We instead require the alternation token to be
-    // followed by whitespace or `(`.
-    const m = using.match(/^\s*([a-z_][a-z0-9_]*)\s*(?:=|IN|in)(?=\s|\()/);
+    // Match `field ==` (canonical CEL), `field =` (legacy SQL-ish), or
+    // `field IN`/`in`. [#2936] `==` MUST be listed before `=` in the
+    // alternation: alternation is ordered, so a bare `=` branch would match
+    // the first `=` of `==` and then the `(?=\s|\()` lookahead — seeing the
+    // SECOND `=`, not whitespace — would fail, leaving `==` unrecognized (the
+    // original bug: real seeds/business policies author equality as `==`, so
+    // the field-existence and tenancy-disabled safety nets that consume this
+    // were inert for them). `\b` is omitted after the operator because `=` is
+    // non-word and the next char (space) is non-word too — a word boundary
+    // cannot exist between two non-word chars — so we require the operator to
+    // be followed by whitespace or `(` instead. `!=`/`>`/`<`/`>=`/`<=` are
+    // deliberately NOT recognized: returning `null` keeps such a policy (the
+    // conservative default), matching the pre-#2936 behavior for any shape the
+    // regex did not match.
+    const m = using.match(/^\s*([a-z_][a-z0-9_]*)\s*(?:==|=|IN|in)(?=\s|\()/);
     return m ? m[1] : null;
   }
 }


### PR DESCRIPTION
Closes #2936

## 背景

`extractTargetField`(security-plugin.ts)是 Layer 1 两张安全网的轻量前置字段解析器,喂给 `computeLayeredRlsFilter`:

- **field-existence 网**:通配策略 target 字段在对象上不存在 → fail-closed(全部 drop → deny 哨兵)。
- **tenancyDisabled 跳过网**:`tenancy.enabled:false` 对象上 `organization_id` 策略被跳过。

原正则 `/^\s*([a-z_][a-z0-9_]*)\s*(?:=|IN|in)(?=\s|\()/` 只识别 legacy 单 `=` / `IN`。对 canonical CEL `field == …`,第一个 `=` 后紧跟第二个 `=`(不满足 `(?=\s|\()` 前瞻)→ 返回 `null`。`null` = 「保留该策略」,于是**两张网对真实种子/业务策略(一律用 `==`)实质失效**。

租户墙本身是 Layer 0(`tenant-layer.ts`,ADR-0095 D1),**从不使用这个解析器**,故租户隔离不受影响——本 PR 修的是 Layer 1 侧残留。

## 修法

```diff
- const m = using.match(/^\s*([a-z_][a-z0-9_]*)\s*(?:=|IN|in)(?=\s|\()/);
+ const m = using.match(/^\s*([a-z_][a-z0-9_]*)\s*(?:==|=|IN|in)(?=\s|\()/);
```

- `==` **必须排在 `=` 之前**:有序 alternation,否则 `=` 分支会先吃掉 `==` 的第一个 `=`,前瞻见到第二个 `=` 而非空白 → 失败 → `==` 仍无法识别(即原 bug)。
- **只扩展识别,不改两张网语义**。`!=` / `>` / `<` / `>=` / `<=` 仍返回 `null`(保守保留),与修前对任何未匹配 shape 的行为一致。

## 受影响策略逐条分析

仓内 `object: '*'` 且 `using` 用 `==` 的**通配业务策略**只有两条(均在 `member_default`,`positions:['org_member']`):

| 策略 | operation | using | target 字段 |
|---|---|---|---|
| `owner_only_writes` | update | `created_by == current_user.id` | `created_by` |
| `owner_only_deletes` | delete | `created_by == current_user.id` | `created_by` |

其余 `==` 策略(`sys_*_self` / `sys_*_org`)全部是**按对象**策略,只作用于自身对象,且 target 字段(`id` / `user_id` / `organization_id`)在该对象上均存在 → field-existence 网保留,无变化。

**field-existence 网** 对上述两条通配策略新生效的场景:对象**缺 `created_by` 列**时(仅平台全局 / 系统表,如 `sys_package`),member 的 by-id update/delete:
- 修前:`==` 逃过网 → 编译成幻影 `{created_by: …}`(引用不存在的列,driver-dependent,实质 deny)。
- 修后:网识别 `==` → 唯一适用写策略被 drop → deny 哨兵(fail-closed)。
- **同一有效可见性**:member 两种情况下都写不了该列缺失的全局对象;仅**机制**从「幻影列过滤器」变为「显式 fail-closed deny」。属于**加固**,非收窄/放宽。

**普通租户/业务对象**都带 `created_by`(引擎在每条记录 stamp)→ `owner_only_writes/deletes` 照常生效,**零变化**(dogfood 全绿佐证)。

**tenancyDisabled 跳过网**:对当前所有种子**零作用**——没有任何 `==` 种子策略在 tenancy-disabled 对象上 target `organization_id`(`sys_member/sys_invitation/sys_team` 均未 `tenancy.enabled:false`;`sys_sso_provider`/`sys_package` 无此类策略)。

## 行为 delta

仅两格(单测矩阵 `platform_global`):

| cell | before | after |
|---|---|---|
| `platform_global` / `member` / write | `[{ created_by: 'u1' }]` | `[{ id: DENY }]` |
| `platform_global` / `no_org_member` / write | `[{ created_by: 'u2' }]` | `[{ id: DENY }]` |

均为「幻影列过滤器 → 显式 deny 哨兵」的加固,有效可见性不变。已在 `authz-matrix-gate.test.ts` 更新期望并加 `[#2936]` 注释。**无意外收窄/放宽,无需人工决策的授权 delta。**

## 验证(实测)

- `pnpm --filter @objectstack/plugin-security test` → **392 passed**(含 authz-matrix-gate 与新增 `==` fail-closed 回归)。
- `tsc --noEmit` → 0 error;`build` → 通过。
- dogfood 行为裁判:`authz-conformance` 绿;`rls-fixture` / `rls-multitenant` / `rls-runner` / `showcase-permission-*` / `single-tenant-identity` / `two-doors` → **37 passed / 2 skipped**(真实 app boot)。零 dogfood delta。

## 改动结构

- `security-plugin.ts` — `extractTargetField` 正则加 `==`(+ 注释说明顺序与保守边界)。
- `authz-matrix-gate.test.ts` — 两格 `platform_global` write 期望更新为 deny 哨兵 + `[#2936]` 注释。
- `security-plugin.test.ts` — 新增 L692 field-existence fail-closed 测试的 `==` 孪生用例(证明此前失效的网现已生效)。
- `.changeset/authz-2936-rls-eq-recognition.md` — patch(安全/正确性修复 + delta callout)。

## Reviewer checklist

- [ ] 确认 `==` 先于 `=` 的 alternation 顺序推理正确。
- [ ] 认同 `platform_global` 两格 delta 是「同可见性加固」(幻影列 → deny 哨兵),而非语义变更。
- [ ] 确认真实种子中无其他 `==` 通配业务策略、无 tenancy-disabled 对象上的 `==` organization_id 策略(即 dogfood 零 delta 成立)。
- [ ] 与 #2937(step 3.7 insert 租户检查)无冲突(insert 无 `==` 通配策略作用)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QRUvVfpvSycAHMMF2xTxs

---
_Generated by [Claude Code](https://claude.ai/code/session_019QRUvVfpvSycAHMMF2xTxs)_