### PR TITLE
fix(plugin-security): 约束 self-delegation position anchor 防横向可见性越权（#830 follow-up）

### DIFF
--- a/.changeset/authz-secfix-self-deleg-anchor.md
+++ b/.changeset/authz-secfix-self-deleg-anchor.md
@@ -1,0 +1,26 @@
+---
+'@objectstack/plugin-security': patch
+---
+
+Security fix: constrain self-delegation (D3) position anchor to prevent lateral
+visibility escalation (cloud#830 follow-up).
+
+cloud#830 (C1 position-anchor) made `sys_user_position.business_unit_id`
+visibility **load-bearing** — it is the readScope depth anchor, so a
+`unit`/`unit_and_below` holder sees the owner set rooted at that BU (and, for
+`unit_and_below`, its whole subtree). The delegated-admin gate's self-service
+delegation path (`assertSelfDelegation`) stamped this anchor with **no
+subtree/source constraint**: a holder of a delegatable, non-admin-scope position
+anchored at a LOW business unit could delegate it to a co-conspirator with an
+**ancestor / arbitrary-high** anchor, leaking that BU's whole subtree of member
+records — visibility beyond the delegator's own range. Mutual delegation could
+grant it both ways.
+
+The gate now requires a self-delegated `business_unit_id` to fall inside the
+delegator's **own effective anchor** for that position (the subtree of their own
+direct holding's anchor, or of their member BU when the holding is unanchored) —
+the same "assignments must target your subtree" spirit as the D12
+delegated-admin boundary. Fail-closed: an anchor that cannot be proven inside the
+delegator's range is rejected. Unanchored delegation rows keep prior behavior
+(the delegate resolves to their own member BU — not a widening). The
+"anchoring only narrows, never widens" invariant now holds on the D3 path too.

--- a/packages/plugins/plugin-security/src/delegated-admin-gate.test.ts
+++ b/packages/plugins/plugin-security/src/delegated-admin-gate.test.ts
@@ -474,3 +474,136 @@ describe('DelegatedAdminGate — self-service delegation of duty (ADR-0091 D3)',
       .rejects.toThrow(/audience anchor/);
   });
 });
+
+// ── [cloud#830 follow-up] Self-delegation anchor containment ────────────────
+//
+// cloud#830 (C1 position-anchor) made sys_user_position.business_unit_id
+// visibility LOAD-BEARING: it is the readScope depth anchor, so a
+// `unit`/`unit_and_below` holder sees the owner set rooted at that BU (and, for
+// unit_and_below, its whole subtree). The self-delegation (D3) path stamped the
+// anchor without any subtree/source constraint, so a holder of a delegatable
+// non-admin position anchored at a LOW BU could delegate it to a co-conspirator
+// with an ANCESTOR/arbitrary-high anchor — leaking that BU's whole subtree,
+// beyond the delegator's own range (lateral visibility escalation). The fix
+// requires the delegated anchor to fall inside the delegator's OWN effective
+// anchor for the position (same spirit as the D12 delegated-admin subtree
+// check), fail-closed.
+//
+// Topology:
+//   hq (bu_hq)
+//   ├── east (bu_east)          ← u_boss's own approver anchor
+//   │   └── east_sales (bu_es)
+//   └── west (bu_west)
+function makeAnchoredDelegationHarness(nowMs = T0) {
+  const tables: Record<string, any[]> = {
+    sys_business_unit: [
+      { id: 'bu_hq', name: 'hq', parent_business_unit_id: null },
+      { id: 'bu_east', name: 'east', parent_business_unit_id: 'bu_hq' },
+      { id: 'bu_es', name: 'east_sales', parent_business_unit_id: 'bu_east' },
+      { id: 'bu_west', name: 'west', parent_business_unit_id: 'bu_hq' },
+    ],
+    sys_position: [{ id: 'p_appr', name: 'approver', delegatable: true }],
+    sys_permission_set: [{ id: 's_appr', name: 'approve_set' }],
+    sys_position_permission_set: [{ id: 'b_appr', position_id: 'p_appr', permission_set_id: 's_appr' }],
+    // u_boss holds approver DIRECTLY, anchored at east.
+    sys_user_position: [{ id: 'ha', user_id: 'u_boss', position: 'approver', business_unit_id: 'bu_east' }],
+    sys_business_unit_member: [{ id: 'm_boss', user_id: 'u_boss', business_unit_id: 'bu_es' }],
+    sys_user: [{ id: 'u_boss' }, { id: 'u_deleg' }],
+  };
+  const matches = (row: any, where: any): boolean =>
+    Object.entries(where ?? {}).every(([k, v]) => {
+      if (v && typeof v === 'object' && Array.isArray((v as any).$in)) return (v as any).$in.includes(row[k]);
+      return row[k] === v;
+    });
+  const ql = {
+    tables,
+    async find(object: string, opts: any) {
+      const rows = (tables[object] ?? []).filter((r) => matches(r, opts?.where));
+      return typeof opts?.limit === 'number' ? rows.slice(0, opts.limit) : rows;
+    },
+    async findOne(object: string, opts: any) {
+      return (tables[object] ?? []).filter((r) => matches(r, opts?.where))[0] ?? null;
+    },
+  } as any;
+  const gate = new DelegatedAdminGate({
+    ql,
+    resolveSets: async () => [{ name: 'member_default', objects: {} }],
+    now: () => nowMs,
+  });
+  const delegate = (userId: string, row: any) =>
+    gate.assert({ object: 'sys_user_position', operation: 'insert', data: row, context: { userId, positions: [] } });
+  const base = (extra: any) => ({
+    user_id: 'u_deleg', position: 'approver', delegated_from: 'u_boss',
+    valid_until: iso(nowMs + 5 * DAY), reason: 'coverage', ...extra,
+  });
+  return { gate, ql, tables, delegate, base };
+}
+
+describe('DelegatedAdminGate — self-delegation anchor containment (cloud#830 follow-up)', () => {
+  it('anchor equal to the delegator\'s own anchor (east) is allowed', async () => {
+    const d = makeAnchoredDelegationHarness();
+    await expect(d.delegate('u_boss', d.base({ business_unit_id: 'bu_east' }))).resolves.toBeUndefined();
+  });
+
+  it('anchor inside the delegator\'s own subtree (east_sales) is allowed — narrowing', async () => {
+    const d = makeAnchoredDelegationHarness();
+    await expect(d.delegate('u_boss', d.base({ business_unit_id: 'bu_es' }))).resolves.toBeUndefined();
+  });
+
+  it('anchor at an ANCESTOR BU (hq) is DENIED — a delegation may not widen visibility', async () => {
+    const d = makeAnchoredDelegationHarness();
+    await expect(d.delegate('u_boss', d.base({ business_unit_id: 'bu_hq' })))
+      .rejects.toThrow(/only narrows|never widen/);
+  });
+
+  it('anchor at an UNRELATED sibling BU (west) is DENIED — outside your own effective anchor', async () => {
+    const d = makeAnchoredDelegationHarness();
+    await expect(d.delegate('u_boss', d.base({ business_unit_id: 'bu_west' })))
+      .rejects.toThrow(/outside your own effective anchor/);
+  });
+
+  it('an unanchored delegation row keeps prior behavior (no anchor to widen)', async () => {
+    const d = makeAnchoredDelegationHarness();
+    await expect(d.delegate('u_boss', d.base({}))).resolves.toBeUndefined();
+  });
+
+  it('mutual delegation cannot cross ranges: neither direction may hand out the other\'s BU', async () => {
+    // u_boss anchored east may not delegate a west anchor…
+    const d = makeAnchoredDelegationHarness();
+    await expect(d.delegate('u_boss', d.base({ business_unit_id: 'bu_west' })))
+      .rejects.toThrow(/outside your own effective anchor/);
+    // …and a would-be west holder cannot reach east either (no east holding to source it).
+    d.tables.sys_user_position.push({ id: 'hb', user_id: 'u_deleg', position: 'approver', business_unit_id: 'bu_west' });
+    await expect(d.delegate('u_deleg', { user_id: 'u_boss', position: 'approver', delegated_from: 'u_deleg', valid_until: iso(T0 + 5 * DAY), reason: 'x', business_unit_id: 'bu_east' }))
+      .rejects.toThrow(/outside your own effective anchor/);
+  });
+
+  it('when the delegator holds the position UNANCHORED, the anchor is bounded by their MEMBER BU', async () => {
+    const d = makeAnchoredDelegationHarness();
+    // Drop the anchor on u_boss's own holding; boss is a member of east_sales.
+    d.tables.sys_user_position.find((r: any) => r.id === 'ha').business_unit_id = null;
+    // Member-BU (east_sales) or below is allowed…
+    await expect(d.delegate('u_boss', d.base({ business_unit_id: 'bu_es' }))).resolves.toBeUndefined();
+    // …but the parent (east) — above the member BU — is not.
+    await expect(d.delegate('u_boss', d.base({ business_unit_id: 'bu_east' })))
+      .rejects.toThrow(/outside your own effective anchor/);
+  });
+
+  it('fail-closed: an anchor that cannot be validated (delegator has no resolvable range) is refused', async () => {
+    const d = makeAnchoredDelegationHarness();
+    // Boss holds approver unanchored AND has no BU membership → no provable range.
+    d.tables.sys_user_position.find((r: any) => r.id === 'ha').business_unit_id = null;
+    d.tables.sys_business_unit_member.length = 0;
+    await expect(d.delegate('u_boss', d.base({ business_unit_id: 'bu_es' })))
+      .rejects.toThrow(/cannot be validated/);
+  });
+
+  it('a holding acquired VIA delegation cannot source an anchored re-delegation (chains stay cut)', async () => {
+    const d = makeAnchoredDelegationHarness();
+    // u_relay holds approver only via delegation, anchored east.
+    d.tables.sys_user.push({ id: 'u_relay' });
+    d.tables.sys_user_position.push({ id: 'hd', user_id: 'u_relay', position: 'approver', business_unit_id: 'bu_east', delegated_from: 'u_boss', valid_until: iso(T0 + 20 * DAY) });
+    await expect(d.delegate('u_relay', { user_id: 'u_deleg', position: 'approver', delegated_from: 'u_relay', valid_until: iso(T0 + 5 * DAY), reason: 'x', business_unit_id: 'bu_es' }))
+      .rejects.toThrow(/only via delegation/);
+  });
+});

--- a/packages/plugins/plugin-security/src/delegated-admin-gate.ts
+++ b/packages/plugins/plugin-security/src/delegated-admin-gate.ts
@@ -259,7 +259,10 @@ export class DelegatedAdminGate {
    *     re-delegatable (chains are cut);
    *  5. the position is `delegatable: true`;
    *  6. the position distributes NO `adminScope`-carrying set (administration
-   *     is never self-delegated — that would bypass the D12 containment gate).
+   *     is never self-delegated — that would bypass the D12 containment gate);
+   *  7. [cloud#830 follow-up] if the delegation carries a `business_unit_id`
+   *     anchor, that anchor falls inside the delegator's OWN effective anchor
+   *     for the position — a delegation may NARROW visibility, never widen it.
    * The writer is stamped into `granted_by` (dual audit: `granted_by` = writer,
    * `delegated_from` = authority source).
    */
@@ -321,6 +324,36 @@ export class DelegatedAdminGate {
         deny(`you do not currently hold '${positionName}' — only a current holder may delegate it`, { position: positionName });
       }
 
+      // 4b. [cloud#830 follow-up] Anchor containment. `business_unit_id` is
+      //     visibility LOAD-BEARING (cloud#830 made it the readScope depth
+      //     anchor: a `unit`/`unit_and_below` holder sees the owner set rooted
+      //     at this BU). "Anchoring only narrows, never widens" must therefore
+      //     hold on THIS path too — otherwise a holder anchored at a low BU
+      //     could hand a co-conspirator an ANCESTOR BU and leak that whole
+      //     subtree's records, exceeding the delegator's own range (lateral
+      //     escalation). So a delegated anchor must fall inside the delegator's
+      //     OWN effective anchor for this position — same spirit as the D12
+      //     delegated-admin subtree check (assertAssignmentWrite). Fail-closed:
+      //     an anchor we cannot prove is inside the delegator's range is
+      //     refused. An unanchored delegation row keeps the prior behavior (the
+      //     delegate resolves to their own member BU — not a widening).
+      const rowAnchor =
+        row?.business_unit_id != null && row.business_unit_id !== '' ? String(row.business_unit_id) : null;
+      if (rowAnchor) {
+        const allowed = await this.delegatorAnchorSubtree(
+          String(ctx.userId),
+          holdings.filter((hd) => hd.direct),
+        );
+        if (!allowed.has(rowAnchor)) {
+          deny(
+            allowed.size === 0
+              ? `business unit anchor '${rowAnchor}' cannot be validated against your own '${positionName}' anchor — an anchor that cannot be proven within your own range is refused (cloud#830: anchoring only narrows)`
+              : `business unit anchor '${rowAnchor}' is outside your own effective anchor for '${positionName}' — a delegation may only narrow visibility, never widen it (cloud#830: anchoring only narrows)`,
+            { position: positionName, businessUnitId: rowAnchor },
+          );
+        }
+      }
+
       // 5. The position must opt in to delegation.
       if (!(await this.positionIsDelegatable(positionName))) {
         deny(`position '${positionName}' is not delegatable — set delegatable: true on the position to allow it`, { position: positionName });
@@ -341,12 +374,15 @@ export class DelegatedAdminGate {
 
   /** The actor's holdings of `positionName` that are inside their validity
    *  window, tagged `direct` when the holding itself did NOT arrive via
-   *  delegation (only a direct holding is re-delegatable). */
+   *  delegation (only a direct holding is re-delegatable) and carrying each
+   *  holding's own `businessUnitId` anchor (null = unanchored). The anchor of a
+   *  direct holding bounds what a self-delegation of that position may hand out
+   *  (cloud#830 — the anchor is visibility load-bearing). */
   private async activeHoldings(
     userId: string,
     positionName: string,
     now: number,
-  ): Promise<Array<{ direct: boolean }>> {
+  ): Promise<Array<{ direct: boolean; businessUnitId: string | null }>> {
     const ql = this.deps.ql;
     if (!ql?.find) return [];
     let rows: any[] = [];
@@ -361,7 +397,11 @@ export class DelegatedAdminGate {
     }
     return (Array.isArray(rows) ? rows : [])
       .filter((r) => isGrantActive(r, now))
-      .map((r) => ({ direct: r?.delegated_from == null || r.delegated_from === '' }));
+      .map((r) => ({
+        direct: r?.delegated_from == null || r.delegated_from === '',
+        businessUnitId:
+          r?.business_unit_id != null && r.business_unit_id !== '' ? String(r.business_unit_id) : null,
+      }));
   }
 
   private async positionIsDelegatable(positionName: string): Promise<boolean> {
@@ -690,18 +730,28 @@ export class DelegatedAdminGate {
 
   /** BU name → covered BU-id set (root + descendants when includeSubtree). */
   private async resolveSubtree(businessUnitName: string, includeSubtree: boolean): Promise<Set<string>> {
-    const ids = new Set<string>();
     const ql = this.deps.ql;
-    if (!ql?.find) return ids;
+    if (!ql?.find) return new Set<string>();
     let root: any = null;
     try {
       const roots = await ql.find('sys_business_unit', { where: { name: businessUnitName }, limit: 1, context: SYSTEM_CTX });
       root = Array.isArray(roots) && roots[0] ? roots[0] : null;
     } catch { root = null; }
-    if (!root?.id) return ids; // misconfigured scope → approves nothing (fail closed)
-    ids.add(String(root.id));
-    if (!includeSubtree) return ids;
-    let frontier: string[] = [String(root.id)];
+    if (!root?.id) return new Set<string>(); // misconfigured scope → approves nothing (fail closed)
+    if (!includeSubtree) return new Set<string>([String(root.id)]);
+    return this.resolveSubtreeById(String(root.id));
+  }
+
+  /** BU id → covered BU-id set (root id + all descendants). Subtree is always
+   *  walked: the delegator's readScope depth is not known on the delegation
+   *  path, so the whole subtree is the containment bound — matching the D12
+   *  admin subtree check. Fail-closed on unresolvable ids (empty set). */
+  private async resolveSubtreeById(rootId: string): Promise<Set<string>> {
+    const ids = new Set<string>();
+    const ql = this.deps.ql;
+    if (!ql?.find || !rootId) return ids;
+    ids.add(String(rootId));
+    let frontier: string[] = [String(rootId)];
     for (let depth = 0; depth < MAX_TREE_DEPTH && frontier.length > 0; depth++) {
       let children: any[] = [];
       try {
@@ -719,6 +769,34 @@ export class DelegatedAdminGate {
       frontier = next;
     }
     return ids;
+  }
+
+  /** [cloud#830 follow-up] The union BU-subtree covered by the delegator's OWN
+   *  DIRECT holdings of a position: subtree(anchor) for each anchored holding,
+   *  plus subtree(member BU) for each unanchored holding (an unanchored holding
+   *  resolves the depth anchor to the holder's own membership). A self-delegated
+   *  `business_unit_id` anchor must fall inside this set. Fail-closed:
+   *  unresolvable holdings/memberships contribute nothing, so an anchor that
+   *  can't be proven inside the delegator's range is refused upstream. */
+  private async delegatorAnchorSubtree(
+    userId: string,
+    directHoldings: Array<{ businessUnitId: string | null }>,
+  ): Promise<Set<string>> {
+    const allowed = new Set<string>();
+    let memberSubtreeResolved = false;
+    for (const h of directHoldings) {
+      if (h.businessUnitId) {
+        for (const id of await this.resolveSubtreeById(h.businessUnitId)) allowed.add(id);
+      } else if (!memberSubtreeResolved) {
+        // An unanchored direct holding resolves to the delegator's own member
+        // BU(s); resolve those once (they don't vary by holding).
+        memberSubtreeResolved = true;
+        for (const bu of await this.businessUnitsOfUser(userId)) {
+          for (const id of await this.resolveSubtreeById(bu)) allowed.add(id);
+        }
+      }
+    }
+    return allowed;
   }
 
   /** Rows targeted by this write: `{ next, prev }` per row (prev = pre-image on update/delete). */


### PR DESCRIPTION
## 漏洞（MEDIUM，横向可见性越权 / lateral escalation）

cloud#830（C1 position-anchor，已合并）把 `sys_user_position.business_unit_id` 从「reserved」变成**可见性 load-bearing**：它是 `readScope` 的深度锚定，`unit`/`unit_and_below` 的持有者可见的 owner 集合以该 BU 为根（`unit_and_below` 覆盖整棵子树）。

委派管理员的自助代理（**D3 self-delegation**）路径 `assertSelfDelegation`（`packages/plugins/plugin-security/src/delegated-admin-gate.ts`）此前对 `business_unit_id` **没有任何 subtree/来源约束**。后果：

- Alice 只需直接持有一个 `delegatable: true`、带 `unit`/`unit_and_below` readScope 的**非 admin-scope** position P（锚定在低层 BU）。
- 她把 P 代理给同谋 Bob，并把 `business_unit_id` 设成**任意高层 / 祖先 BU**。
- Bob 遂获得该 BU（及 `unit_and_below` 整棵子树）成员记录的可见性——**超出 Alice 自己的范围**。
- 互相代理可双向获得。

resolver 的「锚定只收窄不放宽」断言在 anchor 是成员 BU 祖先时不成立——而 D3 路径正是唯一没堵住这条的地方。主攻击面（直接自写 `sys_user_position`、自我代理、委派管理员路径的 anchor 落自己 subtree）此前均已封死。

## 修法选择与理由

采用任务的**首选方案**（约束而非禁止），理由：产品语义上 D3 代理本就允许携带 anchor（例如把「华东销售经理」职务代理给某人、锚定在华东某子单元）——一刀切禁止 anchor 会砍掉合法用法。改为强制**收窄不放宽**：

> self-delegation 的 `business_unit_id` 必须落在**委派人自己对该 position 的有效 anchor** 之内。

「有效 anchor」= 委派人自己**直接持有**该 position 的行的 anchor 子树；若该直接持有行本身无 anchor，则回退到委派人**成员 BU** 的子树（无锚持有解析到本人成员 BU）。这与 D12 委派管理员路径「assignments 必须落自己 subtree」（`assertAssignmentWrite`，L392-402）**同精神、复用同款 subtree 逻辑**。

- **Fail-closed**：无法证明落在委派人范围内的 anchor（范围不可解析）一律拒。
- **无 anchor 的代理行保持原行为**：代理人解析到自己的成员 BU，不构成放宽。

实现：`activeHoldings` 现返回每个持有行的 `businessUnitId`；新增 `resolveSubtreeById` / `delegatorAnchorSubtree`（`resolveSubtree` 重构复用之，行为不变）；`assertSelfDelegation` 新增步骤 4b anchor 收窄校验。

## 测试矩阵（实测全绿，401 passed）

| 场景 | 期望 | 结果 |
|---|---|---|
| anchor = 委派人自己 anchor（east） | 放行 | ✅ |
| anchor 落委派人子树内（east_sales，收窄） | 放行 | ✅ |
| anchor = 祖先 BU（hq，放宽） | **拒**（never widen） | ✅ |
| anchor = 无关兄弟 BU（west） | **拒**（outside your own effective anchor） | ✅ |
| 无 anchor 的 D3 行 | 原行为，放行 | ✅ |
| 互相代理跨范围（双向） | 两个方向都**拒** | ✅ |
| 委派人无锚持有 → 用成员 BU 兜底：成员 BU 及以下放行、其父拒 | 收窄成立 | ✅ |
| fail-closed：委派人无可解析范围 | **拒**（cannot be validated） | ✅ |
| 经代理获得的持有行不能再作源做带锚再代理 | **拒**（chains cut，原有 D3 校验先命中） | ✅ |
| 委派管理员路径（非 delegation write）不受影响 | 原行为 | ✅（既有测试） |
| 直接自写 `sys_user_position` 仍封禁 | 原行为 | ✅（既有测试） |

`pnpm --filter @objectstack/plugin-security test` → 18 files / 401 tests passed；`tsc --noEmit` 0 error；`build` 通过。

## 是否彻底堵住

对 **load-bearing 的 `unit_and_below`** 情形：Bob 的 owner 集合 ⊆ Alice 的 owner 集合，「锚定只收窄不放宽」不变量在 D3 路径重建。祖先 / 任意高层 / 无关 BU 的锚定被 fail-closed 拒绝，主向量关闭。

## 存疑点 / reviewer 注意

1. **`unit`（单层，非 `_and_below`）readScope 下的子孙 anchor**：本修复用 **subtree 包含**作边界（与 D12 admin 路径一致）。若 P 的 readScope 是纯 `unit`，Alice 锚定 east 只看 east 一层，而允许 Bob 锚定 east 的子孙 `east_sales` 在严格意义上让 Bob 看到 Alice 看不到的一层（横向而非放宽）。这与 D12 委派管理员路径既有的同一边界取舍一致（该路径也用 subtree），且**主向量（祖先/高层放宽）已完全关闭**。若要对纯 `unit` 也精确收敛，需在 gate 里解析 position 所分发各 set 的 per-object readScope——依赖 cloud enterprise resolver 语义，超出本 follow-up 范围，建议单独 issue 跟踪。
2. **anchor 是 BU id（lookup）而非 name**：故新增 `resolveSubtreeById`（既有 `resolveSubtree` 按 name 解析根后同样走子树遍历，已重构复用）。
3. cloud resolver（`security-enterprise/hierarchy/resolver.ts` 的 `anchoredBusinessUnits`）不在本仓库 checkout 内，anchor→owner 语义依 ADR-0090 Addendum 与任务描述推断；建议 reviewer 对照 cloud#830 确认「无 anchor = 解析到持有者成员 BU」这一回退语义无误（本修复的成员 BU 兜底依赖它）。

## Reviewer checklist

- [ ] 确认 anchor 收窄边界（subtree 包含）符合 cloud#830 的 anchor→owner 语义
- [ ] 确认「无 anchor D3 = 原行为」是期望的产品语义（未收紧无锚代理）
- [ ] 确认成员 BU 兜底（无锚直接持有）符合 resolver 的无锚回退
- [ ] 确认存疑点 1（纯 `unit` 子孙 anchor）取舍可接受，或决定单开 issue
- [ ] fail-closed 分支（范围不可解析→拒）无误伤合法路径

## 关联

- 起因：cloud#830（C1 position-anchor，已合并）
- 跟踪：framework#2920（本横向越权向量）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QRUvVfpvSycAHMMF2xTxs