### PR TITLE
fix(authz): carry derived posture rung on ExecutionContext (#2947)

### DIFF
--- a/.changeset/authz-2947-posture-plumb.md
+++ b/.changeset/authz-2947-posture-plumb.md
@@ -1,0 +1,20 @@
+---
+'@objectstack/spec': minor
+'@objectstack/runtime': patch
+'@objectstack/rest': patch
+---
+
+fix(authz): carry the derived posture rung on ExecutionContext (#2947)
+
+The ADR-0095 D2 posture ladder (`PLATFORM_ADMIN > TENANT_ADMIN > MEMBER >
+EXTERNAL`) is derived once by the shared authz resolver from capability grants,
+but both HTTP/MCP entry points that build the `ExecutionContext` dropped it —
+so any enforcement-side reader of `context.posture` always saw `undefined`
+(the same drop that forced the explain layer to re-derive it, #2949).
+
+`ExecutionContextSchema` now carries an optional `posture` field, and both
+`rest-server` and the runtime `resolveExecutionContext` plumb the resolver's
+value through. Additive and **behavior-preserving**: no enforcement decision
+consumes `posture` yet — whether the hot path evaluates *by* posture remains a
+larger ADR-level decision — this only stops the already-computed value from
+being discarded, so enforcement and explain read the same derived rung.

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -1202,6 +1202,10 @@ export class RestServer {
                 permissions: authz.permissions,
                 systemPermissions: authz.systemPermissions,
                 ...(authz.tabPermissions ? { tabPermissions: authz.tabPermissions } : {}),
+                // [ADR-0095 D2 / #2947] Carry the derived posture rung so the
+                // enforcement side reads the SAME value the resolver computed,
+                // instead of dropping it here (the boundary this issue closes).
+                ...(authz.posture ? { posture: authz.posture } : {}),
                 isSystem: false,
                 org_user_ids: authz.org_user_ids,
                 ...(authGate ? { authGate } : {}),

--- a/packages/runtime/src/security/resolve-execution-context.test.ts
+++ b/packages/runtime/src/security/resolve-execution-context.test.ts
@@ -323,6 +323,9 @@ describe('resolveExecutionContext — platform-scoped (null-org) grants (ADR-006
     expect(ctx.tenantId).toBe('orgA');
     expect(ctx.permissions).toContain('admin_full_access');
     expect(ctx.systemPermissions).toContain('manage_platform_settings');
+    // [#2947] the derived posture rung is now CARRIED on the ctx (previously
+    // dropped at this entry). An unscoped admin_full_access grant → PLATFORM_ADMIN.
+    expect(ctx.posture).toBe('PLATFORM_ADMIN');
   });
 
   it('still drops a grant scoped to a DIFFERENT org', async () => {
@@ -331,6 +334,60 @@ describe('resolveExecutionContext — platform-scoped (null-org) grants (ADR-006
     expect(ctx.permissions).toContain('admin_full_access'); // global grant kept
     expect(ctx.permissions).not.toContain('other_org_set'); // foreign-org grant dropped
     expect(ctx.systemPermissions).not.toContain('should_not_appear');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// [#2947 / ADR-0095 D2] The derived posture rung must be CARRIED down the HTTP /
+// MCP entry, not dropped. The rung itself is derived from CAPABILITY grants by
+// the shared authz resolver (asserted exhaustively in the posture-ladder tests);
+// here we only prove the value survives the ExecutionContext construction — i.e.
+// the enforcement side reads the SAME value the resolver computed.
+// ---------------------------------------------------------------------------
+describe('resolveExecutionContext — posture plumbing (#2947)', () => {
+  const RAW = 'osk_posture';
+  function makeQlFor(permissionSets: any[], userPermSets: any[]) {
+    const tables: Record<string, any[]> = {
+      sys_api_key: [{ id: 'k1', key: hashApiKey(RAW), revoked: false, user_id: 'u1', organization_id: 'orgA', expires_at: FUTURE }],
+      sys_member: [{ user_id: 'u1', organization_id: 'orgA', role: 'member' }],
+      sys_user_permission_set: userPermSets,
+      sys_permission_set: permissionSets,
+      sys_position: [], sys_position_permission_set: [], sys_user_position: [],
+    };
+    return {
+      async find(object: string, opts: any) {
+        const rows = tables[object] ?? [];
+        const where = opts?.where ?? {};
+        return rows.filter((row) => {
+          for (const [k, v] of Object.entries(where)) {
+            if (v !== null && typeof v === 'object') {
+              if (Array.isArray((v as any).$in) && !(v as any).$in.includes(row[k])) return false;
+              continue;
+            }
+            if ((v ?? null) !== (row[k] ?? null)) return false;
+          }
+          return true;
+        });
+      },
+    };
+  }
+  const opts = (ql: any) => ({ getService: async () => undefined, getQl: async () => ql, request: { headers: { 'x-api-key': RAW } } });
+
+  it('carries MEMBER for an ordinary principal (no admin / org-admin capability)', async () => {
+    const ql = makeQlFor(
+      [{ id: 'ps_basic', name: 'sales_rep', system_permissions: '[]', object_permissions: '{}' }],
+      [{ id: 'ups1', user_id: 'u1', permission_set_id: 'ps_basic', organization_id: null }],
+    );
+    const ctx = await resolveExecutionContext(opts(ql));
+    expect(ctx.userId).toBe('u1');
+    expect(ctx.permissions).not.toContain('admin_full_access');
+    expect(ctx.posture).toBe('MEMBER');
+  });
+
+  it('leaves posture UNSET for an anonymous (guest) request — no principal, no rung', async () => {
+    const ctx = await resolveExecutionContext(makeOpts([], {}));
+    expect(ctx.userId).toBeUndefined();
+    expect(ctx.posture).toBeUndefined();
   });
 });
 

--- a/packages/runtime/src/security/resolve-execution-context.ts
+++ b/packages/runtime/src/security/resolve-execution-context.ts
@@ -203,6 +203,10 @@ export async function resolveExecutionContext(opts: ResolveOptions): Promise<Exe
   if (authz.email) ctx.email = authz.email;
   if (authz.accessToken) ctx.accessToken = authz.accessToken;
   if (authz.tabPermissions) ctx.tabPermissions = authz.tabPermissions;
+  // [ADR-0095 D2 / #2947] Carry the derived posture rung down the runtime /
+  // MCP entry too, so this path and the REST path present enforcement the same
+  // value. Present only for an authenticated principal (guest → absent).
+  if (authz.posture) ctx.posture = authz.posture;
   (ctx as any).org_user_ids = authz.org_user_ids;
 
   // OAuth provenance: surface the token's granted scopes so the MCP

--- a/packages/spec/src/kernel/execution-context.zod.ts
+++ b/packages/spec/src/kernel/execution-context.zod.ts
@@ -18,6 +18,7 @@ import { z } from 'zod';
  *   engine.find('account', { context: { userId: '...', tenantId: '...' } })
  */
 import { lazySchema } from '../shared/lazy-schema';
+import { AuthzPostureSchema } from '../security/explain.zod';
 export const ExecutionContextSchema = lazySchema(() => z.object({
   /** Current user ID (resolved from session) */
   userId: z.string().optional(),
@@ -91,6 +92,19 @@ export const ExecutionContextSchema = lazySchema(() => z.object({
    * 'internal'.
    */
   audience: z.enum(['internal', 'external']).optional(),
+
+  /**
+   * [ADR-0095 D2/B2 — posture ladder] The monotonic authorization rung the
+   * principal evaluated at (`PLATFORM_ADMIN > TENANT_ADMIN > MEMBER > EXTERNAL`),
+   * derived once by the shared authz resolver from capability grants — never a
+   * better-auth role. Carried here so enforcement/explain read the SAME derived
+   * value instead of each re-deriving it (the divergence #2949 patched at the
+   * explain boundary; #2947 closes the enforcement-boundary drop). Additive and
+   * behavior-preserving: no enforcement decision consumes it yet — whether the
+   * hot path evaluates BY posture is a larger ADR-level decision. Absent for
+   * contexts resolved before the ladder existed or where no principal resolved.
+   */
+  posture: AuthzPostureSchema.optional(),
 
   /**
    * [ADR-0090 D10 — P1 shape] Delegation link for agent/service principals


### PR DESCRIPTION
## 目的

关闭 #2947 —— B2/B4 posture 阶梯（ADR-0095 D2：`PLATFORM_ADMIN > TENANT_ADMIN > MEMBER > EXTERNAL`）由共享 authz 解析器从 **capability 授予**派生（`resolve-authz-context.ts:303`），但**两个构建 `ExecutionContext` 的入口都把它丢弃了**，导致 enforcement 侧任何读 `context.posture` 的代码永远拿到 `undefined`（也是 explain 层不得不自己重算 posture、#2949 修补的那处分叉的根因）。

## 改动（全部加法、行为不变）

- **spec** — `ExecutionContextSchema` 新增可选 `posture` 字段（复用 `AuthzPostureSchema`，无循环依赖）。api-surface 无变化（schema 作为 const 导出，字段不计入表面）。
- **rest** — `rest-server.ts` 构建 ctx 时携带 `authz.posture`（present 时）。
- **runtime** — `resolveExecutionContext` 同样透传（guest → 不设，符合「仅认证主体有 rung」）。
- **tests** — `resolve-execution-context.test.ts` 断言 PLATFORM_ADMIN / MEMBER 被携带、guest 保持 unset（29 passed）。

## 为什么安全

**行为完全保持**：当前**没有任何 enforcement 裁决消费 `posture`**——是否让热路径「按 posture 裁决」是更大的 ADR 级决策，本 PR 不涉及。这里只是**停止丢弃已算好的值**，让 enforcement 与 explain 读到同一个派生 rung，为后续把 #2946 的「平台专属能力探针」收敛成直接读 `ctx.posture` 铺路。

## 验证

- `@objectstack/spec` build ✓ · api-surface `--check` unchanged ✓
- `@objectstack/runtime` + `@objectstack/rest` build（tsc typecheck）✓
- `resolve-execution-context.test.ts` — 29 passed ✓
- `check:role-word` ✓ · ESLint（改动文件）✓

changeset：`spec: minor`（新增公共字段）+ `runtime/rest: patch`。非破坏，无需 `allow-major`。

关联：ADR-0095 D2 · #2949（explain 侧分叉）· #2946（未来收敛点）· tracking #2920。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QRUvVfpvSycAHMMF2xTxs

---
_Generated by [Claude Code](https://claude.ai/code/session_019QRUvVfpvSycAHMMF2xTxs)_