### PR TITLE
feat(spec): conditional tabs — page:tabs items accept a visibleWhen CEL predicate (#2606)

### DIFF
--- a/.changeset/page-tabs-item-visible-when.md
+++ b/.changeset/page-tabs-item-visible-when.md
@@ -1,0 +1,9 @@
+---
+"@objectstack/spec": minor
+---
+
+Conditional tabs (#2606): `page:tabs` items accept an optional `visibleWhen` CEL predicate. When it evaluates FALSE the whole tab — header **and** panel — is omitted from the tab strip, unlike a child component's own `visibleWhen`, which hides only the panel content and leaves an empty tab header behind. The predicate binds the same environment as page-component `visibleWhen` (`record` + `current_user`, plus page state as `page.<var>`) and is re-evaluated live when page variables change.
+
+Per ADR-0089 the key uses the canonical `*When` name from day one — the deprecated `visibility` / `visibleOn` aliases are **not** accepted on tab items (this surface is new; there is no legacy metadata to alias for).
+
+Additive and back-compatible: items without `visibleWhen` behave exactly as before.

--- a/packages/dogfood/test/expression-conformance.ledger.ts
+++ b/packages/dogfood/test/expression-conformance.ledger.ts
@@ -125,6 +125,11 @@ export const EXPRESSION_SURFACE: ExprSurface[] = [
       'ui/view.zod.ts:visibleWhen',
       'ui/view.zod.ts:visibleOn',
       'ui/component.zod.ts:onSubmit',
+      // Conditional tabs (framework#2606): `page:tabs` item-level visibility.
+      // Canonical ADR-0089 `visibleWhen` from day one (no deprecated alias on
+      // this new surface). Interpreted by the objectui page:tabs renderer to
+      // omit the whole tab (header + panel) when FALSE.
+      'ui/component.zod.ts:visibleWhen',
       'system/settings-manifest.zod.ts:visible',
     ],
   },

--- a/packages/spec/src/ui/component.test.ts
+++ b/packages/spec/src/ui/component.test.ts
@@ -75,6 +75,46 @@ describe('PageTabsProps', () => {
   it('should reject tabs without items', () => {
     expect(() => PageTabsProps.parse({})).toThrow();
   });
+
+  // Conditional tabs (#2606) — item-level `visibleWhen` (ADR-0089 canonical name).
+  it('should accept an item-level visibleWhen predicate (bare CEL string → envelope)', () => {
+    const result = PageTabsProps.parse({
+      items: [
+        { label: 'Contracts', visibleWhen: 'record.status == "customer"', children: [] },
+        { label: 'Details', children: [] },
+      ],
+    });
+    expect(result.items[0].visibleWhen).toEqual({
+      dialect: 'cel',
+      source: 'record.status == "customer"',
+    });
+    // Items without the predicate are untouched — additive, back-compatible.
+    expect(result.items[1].visibleWhen).toBeUndefined();
+  });
+
+  it('should accept an item-level visibleWhen Expression envelope', () => {
+    const result = PageTabsProps.parse({
+      items: [
+        {
+          label: 'Contracts',
+          visibleWhen: { dialect: 'cel', source: "page.mode != ''" },
+          children: [],
+        },
+      ],
+    });
+    expect(result.items[0].visibleWhen).toEqual({ dialect: 'cel', source: "page.mode != ''" });
+  });
+
+  it('does NOT accept the deprecated `visibility` alias on tab items (new surface, canonical key only)', () => {
+    // ADR-0089 D2 aliases exist for keys with legacy metadata; tab items never
+    // had a visibility key, so only canonical `visibleWhen` is declared. The
+    // alias is not folded — it is dropped by parse like any unknown key.
+    const result = PageTabsProps.parse({
+      items: [{ label: 'Contracts', visibility: 'record.status == "customer"', children: [] }],
+    });
+    expect(result.items[0].visibleWhen).toBeUndefined();
+    expect('visibility' in result.items[0]).toBe(false);
+  });
 });
 
 describe('PageCardProps', () => {

--- a/packages/spec/src/ui/component.zod.ts
+++ b/packages/spec/src/ui/component.zod.ts
@@ -35,6 +35,19 @@ export const PageTabsProps = z.object({
   items: z.array(z.object({
     label: I18nLabelSchema,
     icon: z.string().optional(),
+    /**
+     * Conditional tab (CEL, #2606): when the predicate evaluates FALSE the
+     * whole tab — header *and* panel — is omitted from the strip. This is the
+     * item-level complement to a child component's own `visibleWhen`, which
+     * hides only the panel content and would leave an empty tab header behind.
+     * Binds the same environment as page-component `visibleWhen`: `record` +
+     * `current_user`, plus page state as `page.<var>` (re-evaluated live).
+     * Canonical `*When` name per ADR-0089 — this key is new, so the deprecated
+     * `visibility` / `visibleOn` aliases are NOT accepted on tab items.
+     */
+    visibleWhen: ExpressionInputSchema.optional().describe(
+      'Visibility predicate (CEL) — the whole tab (header + panel) is omitted when FALSE; the renderer falls back to the first visible tab when the active one is hidden. Binds `record`, `current_user`, `page.<var>`. ADR-0089 canonical name (`visibility`/`visibleOn` aliases are not accepted here).',
+    ),
     children: z.array(z.unknown()).describe('Child components')
   })),
   /** ARIA accessibility */


### PR DESCRIPTION
## 背景:基于 ADR-0089 对 #2606 的重新评估

#2606(2026-07-05)提出给 `page:tabs` 的 item 加 **`visibility`**(CEL)。该提案早于 ADR-0089(2026-07-14 接受),重新评估结论:

- **提案本身依然成立**:Tier 2(page 层)能力、复用 `ExpressionInputSchema`(CEL)、不进对象层、加性可选字段 → minor。这些设计边界与 ADR-0085 / #2579 一致,不受 ADR-0089 影响。
- **唯一需要修正的是字段名**:ADR-0089 D1 已把条件显隐谓词统一为规范名 **`visibleWhen`**,`visibility` / `visibleOn` 降级为 `@deprecated` alias(仅为存量元数据保留)。因此本字段从第一天起就叫 `visibleWhen`。
- **新表面不接受 alias**:ADR-0089 D2 的 alias 机制服务于*已有*键的存量元数据;tab item 此前没有任何 visibility 键,不存在需要兼容的存量 → 只声明规范键,不加 `visibility`/`visibleOn` alias(Prime Directive #12:一个严格契约优于 N 种方言)。测试中显式固化了这一点。

## 改动

`PageTabsProps.items[]` 新增可选 `visibleWhen: ExpressionInputSchema`:

- **语义**:谓词求值为 FALSE → 整条 tab(头 + 面板)从 tab 条移除;区别于子组件自身的 `visibleWhen`(只隐藏面板内容、留下空 tab 头)。
- **求值环境**:与页面组件级 `visibleWhen` 一致 —— `record` + `current_user`,外加 `page.<var>`(page 变量变化时响应式重算)。
- 加性、向后兼容:不带 `visibleWhen` 的 item 行为完全不变。

## 测试

- 裸 CEL 字符串 → 规范化为 `{ dialect: 'cel', source }` 信封;信封形式直接接受。
- 不带谓词的 item 不受影响。
- `visibility` alias 在 tab item 上**不**被折叠(新表面只认规范键)。
- spec 全量:251 files / 6790 tests 通过;`@objectstack/spec` build(含 DTS)通过。

## 配套

渲染器落地在 objectui 同名分支 PR(item 过滤 + 激活 tab 被隐藏时回落到第一个可见 tab)。

Closes #2606. Refs #2579, ADR-0089.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FmuuXkuW3JH9LYXHHRnoQV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmuuXkuW3JH9LYXHHRnoQV)_