### PR TITLE
feat(spec): page variable source renders as a component picker (objectui#2328)

### DIFF
--- a/.changeset/page-var-source-component-picker.md
+++ b/.changeset/page-var-source-component-picker.md
@@ -1,0 +1,13 @@
+---
+'@objectstack/spec': minor
+---
+
+feat(spec): page variable `source` renders as a component picker (objectui#2328)
+
+The page metadata form's `variables` repeater now declares explicit sub-fields
+and pins `{ field: 'source', widget: 'ref:component' }`. A page variable's
+`source` names the component (by `id`) that writes it, so Studio can offer it as
+a dropdown of the components actually placed on the page — mirroring how the
+sibling `object` field uses `ref:object` — instead of a free-text input the
+author has to type an id into by hand. The `ref:component` widget itself lives
+in objectui (app-shell metadata-admin); this change is the form-spec trigger.

--- a/packages/spec/src/ui/page.form.ts
+++ b/packages/spec/src/ui/page.form.ts
@@ -52,7 +52,21 @@ export const pageForm = defineForm({
       visibleWhen: "data.type != 'list'",
       fields: [
         { field: 'object', widget: 'ref:object', helpText: 'Bound object (for Record pages)' },
-        { field: 'variables', type: 'repeater', helpText: 'Local page state variables' },
+        {
+          field: 'variables',
+          type: 'repeater',
+          helpText: 'Local page state variables',
+          // Explicit sub-fields so `source` can use the `ref:component` picker —
+          // a variable's `source` names the component (by `id`) that writes it,
+          // so it's chosen from the page's real canvas components, not typed by
+          // hand. Keep in sync with PageVariableSchema.
+          fields: [
+            { field: 'name', required: true, helpText: 'Variable name — exposed to expressions as `page.<name>`' },
+            { field: 'type', helpText: 'Value type' },
+            { field: 'defaultValue', helpText: 'Initial value (defaults to a type-appropriate empty value)' },
+            { field: 'source', widget: 'ref:component', helpText: 'Component (by id) that writes this variable — e.g. an element:record_picker' },
+          ],
+        },
       ],
     },
     {


### PR DESCRIPTION
## What

The page metadata form's `variables` repeater now declares explicit sub-fields and pins `{ field: 'source', widget: 'ref:component' }`.

A page variable's `source` names the component (by `id`) that *writes* it. Previously the form rendered `source` as a plain text input, forcing authors to type a component id by hand. This pins the `ref:component` widget so Studio offers a dropdown of the components actually placed on the page — mirroring how the sibling `object` field uses `ref:object`.

This is the **form-spec trigger**; the `ref:component` widget itself lives in objectui (app-shell metadata-admin) — see objectui#2328 companion PR.

## Details
- `variables` sub-fields are now explicit (`name`, `type`, `defaultValue`, `source`), kept in sync with `PageVariableSchema`.
- `widget: z.string()` already accepts arbitrary widget names, and nested repeater `fields` are already supported — no schema change needed.

## Testing
- `packages/spec` `page.test.ts` — 73/73 pass.
- Verified `pageForm` parses with the new `ref:component` sub-field (defineForm Zod validation at import).

Resolves the framework half of objectui#2328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)