### PR TITLE
fix(security): getReadFilter 对 on-behalf-of 读 fail-closed 哨兵（#2852 Gap 1 潜伏面）

### DIFF
--- a/.changeset/authz-2852-readfilter-onbehalfof-sentinel.md
+++ b/.changeset/authz-2852-readfilter-onbehalfof-sentinel.md
@@ -1,0 +1,17 @@
+---
+'@objectstack/plugin-security': patch
+---
+
+fix(security): fail-closed sentinel for on-behalf-of reads on getReadFilter (#2852)
+
+`getReadFilter` (the read-scope provider the analytics/raw-SQL path binds to)
+resolves only the caller's own ceiling — the ADR-0090 D10 delegator RLS
+intersection that the engine middleware applies to find/count/aggregate is not
+implemented on this path. Computing a filter here for a delegated (on-behalf-of)
+context would therefore silently widen the read past the delegator's scope.
+
+Until the intersection is threaded through `computeRlsFilter` (tracked with
+#2920 B1 / ADR-0095 D1), `getReadFilter` now denies fail-closed (deny sentinel +
+error log) when `context.onBehalfOf.userId` is set. System on-behalf-of bypasses
+ahead of the guard, and no agent surface reaches analytics today, so this is a
+latent-invariant guard rather than a live-traffic behavior change.

--- a/packages/plugins/plugin-security/src/security-plugin.test.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.test.ts
@@ -776,6 +776,42 @@ describe('SecurityPlugin', () => {
       expect(filter).toEqual(RLS_DENY_FILTER);
     });
 
+    it('[#2852] fail-closed on an on-behalf-of (delegated) context — no D10 intersection on this path', async () => {
+      // getReadFilter resolves only the CALLER's ceiling; the delegator RLS
+      // intersection the engine middleware applies is absent here. A delegated
+      // read must DENY rather than silently return the agent's (wider) own
+      // scope. Latent today (no agent surface reaches analytics) but the
+      // invariant is enforced regardless.
+      const plugin = new SecurityPlugin({ fallbackPermissionSet: 'member_default' });
+      const harness = makeMiddlewareCtx({ permissionSets: [tenantPolicySet], orgScoping: true });
+      await plugin.init(harness.ctx);
+      await plugin.start(harness.ctx);
+      const filter = await plugin.getReadFilter('task', {
+        userId: 'agent-1',
+        tenantId: 'org-1',
+        positions: [],
+        permissions: ['member_default'],
+        onBehalfOf: { userId: 'user-1' },
+      });
+      expect(filter).toEqual(RLS_DENY_FILTER);
+      expect(harness.ctx.logger.error).toHaveBeenCalled();
+    });
+
+    it('[#2852] a system on-behalf-of context bypasses before the deny sentinel', async () => {
+      // isSystem short-circuits to `undefined` (no scope) ahead of the
+      // on-behalf-of guard — engine self-invocation must not be denied.
+      const plugin = new SecurityPlugin({ fallbackPermissionSet: 'member_default' });
+      const harness = makeMiddlewareCtx({ permissionSets: [tenantPolicySet], orgScoping: true });
+      await plugin.init(harness.ctx);
+      await plugin.start(harness.ctx);
+      const filter = await plugin.getReadFilter('task', {
+        isSystem: true,
+        userId: 'agent-1',
+        onBehalfOf: { userId: 'user-1' },
+      });
+      expect(filter).toBeUndefined();
+    });
+
     it('[#2936] fail-closed on a CANONICAL `==` wildcard policy targeting a missing column → deny sentinel', async () => {
       // The `=`-form twin above is the L692 test. This is its canonical-CEL
       // sibling: pre-#2936 `extractTargetField` did not recognize `==`, so the

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -1769,6 +1769,27 @@ export class SecurityPlugin implements Plugin {
     if (positions.length === 0 && explicit.length === 0 && !context?.userId) {
       return undefined;
     }
+    // [#2852] D10 delegator intersection is NOT implemented on this path.
+    // The engine middleware (find/count/aggregate) intersects an on-behalf-of
+    // read with the DELEGATOR's own RLS (resolveDelegatorContext, ~L689), but
+    // getReadFilter — the read-scope provider bound by the analytics/raw-SQL
+    // path — resolves only the CALLER's ceiling. Computing a filter here for a
+    // delegated (agent) context would therefore SILENTLY WIDEN the read past
+    // the delegator's scope (the confused-deputy widening D10 prevents on the
+    // CRUD path). Until the intersection is threaded through computeRlsFilter
+    // (tracked with #2920 B1 / ADR-0095 D1), FAIL CLOSED: a delegated read on
+    // this path denies rather than under-scopes. System on-behalf-of already
+    // returned above; today no agent surface reaches analytics, so this is a
+    // latent-invariant guard, not a live-traffic change.
+    if (context?.onBehalfOf?.userId) {
+      this.logger.error?.(
+        `[security] getReadFilter received an on-behalf-of context for object ` +
+          `'${object}' (agent ${context?.userId ?? 'unknown'} on behalf of ` +
+          `${context.onBehalfOf.userId}) — the D10 delegator intersection is not ` +
+          `implemented on the read-scope path; denying (fail-closed, #2852)`,
+      );
+      return { ...RLS_DENY_FILTER };
+    }
     try {
       const permissionSets = await this.resolvePermissionSetsForContext(context);
       const filter = await this.computeRlsFilter(permissionSets, object, 'find', context);


### PR DESCRIPTION
## 目的

关闭 #2852 剩余的 Gap 1 的**潜伏面**（Gap 2 `/analytics/query` 无 context 已在 #2956 修复）。`getReadFilter`——analytics/raw-SQL 路径绑定的 read-scope 提供者——只解析**调用方自身** ceiling；engine middleware 对 find/count/aggregate 施加的 **ADR-0090 D10 delegator RLS 交集**（`resolveDelegatorContext`，`security-plugin.ts:689`）在这条路径上**缺位**。因此对一个 delegated（`onBehalfOf`）上下文在这里算 filter 会**静默放宽**到 agent 自身（更宽）的 scope，正是 D10 在 CRUD 路径上防住的 confused-deputy 放宽。

## 改动（哨兵，非完整交集）

`getReadFilter` 在 `context.onBehalfOf.userId` 存在时 **fail-closed**：返回 `RLS_DENY_FILTER` + 响亮 error 日志，而不是 under-scope。与该函数已有的 fail-closed 风格（解析失败分支）一致。

- **system on-behalf-of 豁免**：`isSystem` 短路在哨兵之前（engine 自调用不被拒）。
- **当前无 live 流量**：OAuth agent 只能到 `/mcp`，不暴露 analytics——这是**潜伏不变量守卫**，不是 live 行为变更。把「将来某人把 analytics 桥进 agent 面时静默放宽」提前变成「显式拒绝 + 报错」。

## 为什么是哨兵而非完整交集

完整修复要把 delegator 交集**下沉进 `computeRlsFilter`/共享 helper**（单缝，避免复制 middleware↔service 分叉），而 #2920 B1（租户隔离拆 Layer 0，ADR-0095 D1）会重构同一条缝。现在精雕会与 B1 冲突/白做，故只落 fail-closed 哨兵，完整交集随 B1（issue #2852 已记录两档计划）。

## 验证

- `@objectstack/plugin-security`：**441 passed**（新增 2：delegated context → deny sentinel + 日志；system on-behalf-of → 豁免放行）
- turbo build（plugin-security + deps）✓ · ESLint（改动文件）✓ · changeset：plugin-security patch

## 关联

#2852（read-scope D10 缺口，Gap 2 已修）· ADR-0090 D10 · #2920 B1 / ADR-0095 D1（computeRlsFilter 重构缝，完整交集落点）· #2949（explain-vs-enforcement 分叉先例）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012RE5oFswe4DUvExuAgvbg2

---
_Generated by [Claude Code](https://claude.ai/code/session_012RE5oFswe4DUvExuAgvbg2)_