### PR TITLE
refactor(security): migrate handleSecurity admin gate to shouldDenyAnonymous (#2567 follow-up)

### DIFF
--- a/.changeset/authz-2567-handlesecurity-seam.md
+++ b/.changeset/authz-2567-handlesecurity-seam.md
@@ -1,0 +1,17 @@
+---
+'@objectstack/runtime': patch
+---
+
+refactor(security): migrate the handleSecurity admin gate to shouldDenyAnonymous (#2567 follow-up)
+
+The dispatcher's `/security/suggested-bindings` admin surface was the last HTTP
+seam still hand-rolling the `!userId && !isSystem → 401` check. It now delegates
+to the shared `shouldDenyAnonymous` decision like every other seam — with
+`requireAuth: true` hardcoded, preserving its UNCONDITIONAL semantics (an admin
+surface denies anonymous callers even on a `requireAuth: false` demo deployment).
+The 401 body adopts the shared shape (`code: 'unauthenticated'`).
+
+Deliberately NOT migrated: `handleNotification`'s `!userId` check — that is a
+"needs a user identity" predicate (the inbox is keyed by userId; a system
+context has no inbox), not an anonymous-posture decision; migrating it would
+change semantics.

--- a/packages/runtime/src/http-dispatcher.test.ts
+++ b/packages/runtime/src/http-dispatcher.test.ts
@@ -558,10 +558,15 @@ describe('HttpDispatcher', () => {
 
             it('401s an anonymous request without touching the service', async () => {
                 const service = makeService();
+                // NOTE: no options — requireAuth defaults false, yet the admin
+                // surface still denies anonymous (the gate is UNCONDITIONAL,
+                // hardcoded requireAuth:true into shouldDenyAnonymous — #2567).
                 const d = new HttpDispatcher(secKernel(service));
                 const result = await d.handleSecurity('/suggested-bindings', 'GET', undefined, {}, ctx());
                 expect(result.handled).toBe(true);
                 expect(result.response?.status).toBe(401);
+                // Shared anonymous-deny body shape (locks the seam migration).
+                expect(result.response?.body?.error?.details?.code).toBe('unauthenticated');
                 expect(service.listAudienceBindingSuggestions).not.toHaveBeenCalled();
             });
 

--- a/packages/runtime/src/http-dispatcher.ts
+++ b/packages/runtime/src/http-dispatcher.ts
@@ -2337,8 +2337,16 @@ export class HttpDispatcher {
         }
 
         const ec = context.executionContext;
-        if (!ec?.userId && !ec?.isSystem) {
-            return { handled: true, response: this.error('Authentication required', 401) };
+        // Admin surface — anonymous is denied UNCONDITIONALLY (`requireAuth:
+        // true` hardcoded), independent of the deployment posture: even a
+        // `requireAuth: false` demo must not let anonymous callers list or
+        // confirm audience bindings. Shares the decision + body with every
+        // other HTTP seam (#2567).
+        if (shouldDenyAnonymous({ requireAuth: true, userId: ec?.userId, isSystem: ec?.isSystem })) {
+            return {
+                handled: true,
+                response: this.error(ANONYMOUS_DENY_MESSAGE, ANONYMOUS_DENY_STATUS, { code: ANONYMOUS_DENY_CODE }),
+            };
         }
 
         const m = method.toUpperCase();


### PR DESCRIPTION
Final #2567 follow-up (Phases 1/2/docs merged as #2973 / #2987 / #2993). **One-seam refactor — no behavior change beyond the 401 body adopting the shared shape.**

## Change

`handleSecurity` (`/security/suggested-bindings`, the ADR-0090 D5/D9 admin surface) was the **last HTTP seam** still hand-rolling the `!userId && !isSystem → 401` check. It now delegates to the shared `shouldDenyAnonymous` decision like every other seam.

**Semantics preserved deliberately:** this gate is UNCONDITIONAL — `requireAuth: true` is hardcoded into the call, because an admin surface must deny anonymous callers even on a `requireAuth: false` demo deployment. The existing test pins this (dispatcher constructed with **no options**, where `requireAuth` defaults false, still expects 401); it now also asserts the shared body's `code: 'unauthenticated'`.

**Triage — deliberately NOT migrated:** `handleNotification`'s `!userId` check. That is a "needs a user identity" predicate (the inbox is keyed by `userId`; a system context has no inbox), not an anonymous-posture decision — migrating it would let `isSystem` pass the gate and then query with an undefined `userId`.

## Realtime "fourth door" investigation (no code — findings recorded here)

Also per the #2567 wrap-up, we audited whether a realtime/WebSocket/SSE surface constitutes an ungated fourth door. **Verdict: no such door exists.**

- `service-realtime` is an **in-process pub/sub bus only** (`registerService('realtime')` + the `sys_presence` object; the contract's optional `handleUpgrade` WebSocket hook is unimplemented). It registers **zero HTTP routes**.
- The dispatcher has no `/realtime` branch and no `handleRealtime`; neither the dispatcher-plugin nor the hono plugin mounts any realtime route — `/api/v1/realtime` falls through to the semantic 404.
- Producers publish **after** the engine's security middleware; consumers (webhooks auto-enqueuer, knowledge sync) are in-process. No inbound request path reaches the bus.
- AI SSE streaming enters exclusively through the gated `handleAI` path.
- The conformance ratchet correctly omits realtime — there is no entry point to enumerate.

One cosmetic defect found (tracked separately, not in this PR): discovery advertises `realtime: ${prefix}/realtime` even though the route 404s, and `metadata-protocol` references a nonexistent `plugin-realtime` provider.

## Verification

- `http-dispatcher` + `http-dispatcher.requireauth` suites: **185/185** (401 case now also asserts the shared body code)
- Lint clean; `check:single-authz-resolver` intact; changeset added (`@objectstack/runtime` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShknNUYoSTspJLBiqorD8V

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShknNUYoSTspJLBiqorD8V)_