### PR TITLE
feat(client): pass `overwrite` through packages.install for upgrade flows

### DIFF
--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1179,3 +1179,28 @@ describe('HTTP error shaping', () => {
         expect(caught.httpStatus).toBe(500);
     });
 });
+
+describe('packages.install', () => {
+    const MANIFEST = { id: 'com.acme.crm', name: 'Acme CRM', version: '1.0.0', type: 'app' };
+
+    it('POSTs the manifest and omits `overwrite` unless requested', async () => {
+        const { client, fetchMock } = createMockClient({ success: true, data: { package: { manifest: MANIFEST } } });
+        await client.packages.install(MANIFEST, { enableOnInstall: true });
+
+        expect(fetchMock).toHaveBeenCalledWith('http://localhost:3000/api/v1/packages', expect.any(Object));
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.manifest).toEqual(MANIFEST);
+        expect(body.enableOnInstall).toBe(true);
+        // Duplicate-id guard semantics: never send `overwrite` implicitly —
+        // the server must keep 409ing on an existing id by default.
+        expect('overwrite' in body).toBe(false);
+    });
+
+    it('passes `overwrite: true` through for intentional upgrade / re-install', async () => {
+        const { client, fetchMock } = createMockClient({ success: true, data: { package: { manifest: MANIFEST } } });
+        await client.packages.install(MANIFEST, { overwrite: true });
+
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.overwrite).toBe(true);
+    });
+});

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -592,8 +592,16 @@ export class ObjectStackClient {
 
     /**
      * Install a new package from its manifest.
+     *
+     * By default the server rejects a manifest whose `id` is already
+     * installed with **409 Conflict** (duplicate-id guard) instead of
+     * silently overwriting the existing package. Intentional upgrade /
+     * re-install flows opt back in with `overwrite: true`.
      */
-    install: async (manifest: any, options?: { settings?: Record<string, any>; enableOnInstall?: boolean }) => {
+    install: async (
+        manifest: any,
+        options?: { settings?: Record<string, any>; enableOnInstall?: boolean; overwrite?: boolean },
+    ) => {
         const route = this.getRoute('packages');
         const res = await this.fetch(`${this.baseUrl}${route}`, {
             method: 'POST',
@@ -601,6 +609,7 @@ export class ObjectStackClient {
                 manifest,
                 settings: options?.settings,
                 enableOnInstall: options?.enableOnInstall,
+                ...(options?.overwrite !== undefined ? { overwrite: options.overwrite } : {}),
             }),
         });
         return this.unwrapResponse<{ package: any; message?: string }>(res);


### PR DESCRIPTION
## Why
#2971 made `POST /packages` return **409 Conflict** on a duplicate package id (with an `overwrite: true` escape hatch for intentional upgrade / re-install). The SDK's `client.packages.install()` had no way to set that flag, so any future upgrade/re-install flow built on the SDK would hit the 409 with no recourse. (409-blast-radius audit found no current caller — this is future-proofing the API surface, tracked in objectui#2555.)

## What
- `packages.install(manifest, options)` options bag gains `overwrite?: boolean`, passed through the POST body **only when explicitly set** — the default request body stays byte-identical, so the server keeps rejecting duplicate ids by default.
- JSDoc documents the 409 semantics.

## Tests
First SDK tests for `packages.install` (`client.test.ts`, existing `createMockClient` harness):
1. default POST body carries manifest/enableOnInstall and **omits** `overwrite`;
2. `{ overwrite: true }` carries the flag.

`client.test.ts`: 91/91 pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)