### PR TITLE
fix(security): 级联 set_null 豁免属主转移守卫 (#3023)

### DIFF
--- a/.changeset/owner-guard-referential-cascade-exemption.md
+++ b/.changeset/owner-guard-referential-cascade-exemption.md
@@ -1,0 +1,23 @@
+---
+'@objectstack/plugin-security': patch
+'@objectstack/objectql': patch
+---
+
+fix(security): exempt engine referential FK clears from the owner_id transfer guard (#3023)
+
+Follow-up to the #3004 ownership-anchor guard. `owner_id` is a lookup to `sys_user`
+with the default `deleteBehavior: 'set_null'`, so deleting a `sys_user` makes
+`cascadeDeleteRelations` null `owner_id` on every dependent row. That cascade write
+re-entered the write middleware under the deleter's context, where the #3004 guard
+read the `owner_id = null` as a user-initiated disown and denied it — aborting the
+cascade mid-way (no transaction, so partial state) for any deleter without the
+transfer grant on the child object (e.g. a member clearing a `public_read_write`
+child that RLS would otherwise have allowed).
+
+The cascade FK clear is engine-mandated referential integrity consequent to an
+already-authorized parent delete, not a user ownership change. `cascadeDeleteRelations`
+now tags the `set_null` write with a server-derived `__referentialFieldClear` context
+marker (set by the engine, never built from a request — same trust model as
+`__expandRead`), and the ownership-anchor guard skips when that marker is present.
+Ordinary user writes are unaffected; the marker cannot be forged from client input,
+so it can never slip a real ownership transfer past the guard.

--- a/packages/objectql/src/engine-cascade-delete.test.ts
+++ b/packages/objectql/src/engine-cascade-delete.test.ts
@@ -138,4 +138,38 @@ describe('cascadeDeleteRelations — required FK escalates set_null → restrict
         expect(await engine.findOne('acct', { where: { id: a.id } })).toBeNull();
         expect(await engine.findOne('task', { where: { id: t.id } })).toBeNull();
     });
+
+    it('[#3023] tags the referential set_null write with __referentialFieldClear so the owner guard can exempt it', async () => {
+        // The cascade FK clear is an engine-internal integrity write. It must
+        // carry the server-set marker plugin-security's ownership-anchor guard
+        // keys off — otherwise nulling an owner_id-style FK would trip the
+        // #3004 transfer guard and abort the cascade. A user-driven update must
+        // NOT carry the marker (control).
+        const seen: Array<{ op: string; marker: unknown; where: unknown }> = [];
+        engine.registerMiddleware(async (opCtx: any, next: () => Promise<void>) => {
+            if (opCtx.operation === 'update') {
+                seen.push({
+                    op: opCtx.operation,
+                    marker: opCtx.context?.__referentialFieldClear,
+                    where: opCtx.data,
+                });
+            }
+            await next();
+        });
+
+        const a = await engine.insert('acct', { name: 'Acme' });
+        const n = await engine.insert('note', { body: 'hi', account: a.id });
+
+        // A normal user update — no marker.
+        await engine.update('note', { id: n.id, body: 'edited' }, { context: { userId: 'u1' } } as any);
+        // The cascade set_null when the parent is deleted — marked.
+        await engine.delete('acct', { where: { id: a.id }, context: { userId: 'u1' } } as any);
+
+        const userUpdate = seen.find((s) => (s.where as any)?.body === 'edited');
+        const cascadeClear = seen.find((s) => (s.where as any)?.account === null);
+        expect(userUpdate?.marker, 'user update carries no referential marker').toBeUndefined();
+        expect(cascadeClear?.marker, 'cascade FK clear carries the marker').toBe(true);
+        // And the cascade actually nulled the FK.
+        expect((await engine.findOne('note', { where: { id: n.id } }) as any).account).toBeNull();
+    });
 });

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -2631,7 +2631,16 @@ export class ObjectQL implements IDataEngine {
             // hooks and events fire.
             await this.delete(childName, { where: { id: depId }, context } as any);
           } else {
-            await this.update(childName, { id: depId, [fieldName]: null }, { context } as any);
+            // [#3023] Clear the FK as an engine-internal referential-integrity
+            // write, tagged so plugin-security's ownership-anchor guard (#3004)
+            // treats an `owner_id = null` cascade as integrity maintenance, not
+            // a user-initiated disown — otherwise deleting the referenced record
+            // trips the transfer guard and aborts the cascade mid-way. Marker
+            // rides a server-DERIVED context (set here, never from client input
+            // — same trust model as `__expandRead`), so it cannot be forged from
+            // a request to bypass the guard on an ordinary write.
+            const referentialCtx = { ...(context ?? {}), __referentialFieldClear: true } as ExecutionContext;
+            await this.update(childName, { id: depId, [fieldName]: null }, { context: referentialCtx } as any);
           }
         }
       }

--- a/packages/plugins/plugin-security/src/security-plugin.test.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.test.ts
@@ -369,6 +369,19 @@ describe('SecurityPlugin', () => {
       const opCtx: any = { object: 'task', operation: 'update', data, context: memberCtx() };
       await harness.run(opCtx); // must not throw — owner_id is not an own property
     });
+
+    it('[#3023] an engine referential FK clear (__referentialFieldClear) is exempt — owner_id:null cascade is allowed for a plain member', async () => {
+      // cascadeDeleteRelations nulls owner_id on dependents when the referenced
+      // sys_user is deleted; that integrity write must not be blocked by the
+      // disown guard. The same payload WITHOUT the marker is denied (covered
+      // by the disown test above).
+      const harness = await boot([memberSet], () => ({ id: 't1', owner_id: 'someone' }));
+      const opCtx: any = {
+        object: 'task', operation: 'update', data: { id: 't1', owner_id: null },
+        context: memberCtx({ __referentialFieldClear: true }),
+      };
+      await harness.run(opCtx); // must not throw — engine-internal referential clear
+    });
   });
 
   it('without org-scoping plugin — strips tenant_isolation RLS so find applies no tenant where', async () => {

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -1099,10 +1099,20 @@ export class SecurityPlugin implements Plugin {
       //
       // `organization_id` auto-injection has moved to
       // `@objectstack/organizations`; its forge guard is step 3.7 below.
+      //
+      // [#3023] EXEMPTION — the engine's referential-integrity FK clear. When a
+      // referenced record is deleted, `cascadeDeleteRelations` nulls the FK on
+      // every dependent (owner_id included). That `owner_id = null` is an
+      // integrity-mandated consequence of an already-authorized parent delete,
+      // NOT a user disown, so the transfer guard must not fire and abort the
+      // cascade. The marker rides a server-DERIVED context (never client-built —
+      // same trust model as `__expandRead`), so it cannot be forged from a
+      // request to slip an ordinary ownership write past the guard.
       if (
         (opCtx.operation === 'insert' || opCtx.operation === 'update') &&
         opCtx.data &&
-        typeof opCtx.data === 'object'
+        typeof opCtx.data === 'object' &&
+        !opCtx.context?.__referentialFieldClear
       ) {
         const isInsert = opCtx.operation === 'insert';
         const rows = (Array.isArray(opCtx.data) ? opCtx.data : [opCtx.data]) as Record<string, unknown>[];


### PR DESCRIPTION
## 背景

#3004(PR #3018)给 `owner_id` 加了属主锚点守卫:非特权写入者携带 `owner_id`(含置 `null` 的弃权)在无 transfer 授权时被拒。

`owner_id` 是指向 `sys_user` 的 `lookup`,默认 `deleteBehavior: 'set_null'`。删除一个 `sys_user` 时,`cascadeDeleteRelations` 会对每个引用它的子记录执行 `update(child, { id, owner_id: null }, { context })`,**沿用删除者的上下文**重新进入写中间件。守卫把这个 `owner_id = null` 当成用户发起的弃权而抛 `PermissionDeniedError` —— 由于没有事务包裹,级联**中途失败**留下部分置空的子记录。触发面:删除者缺少子对象上的 transfer 授权(典型如成员清理一个 `public_read_write` 子对象,RLS 本会放行、却被守卫拦下)。

## 修复

级联 `set_null` 是引擎内部的**引用完整性**写入,是已授权父删除的强制后果,不是用户的属主变更——不应被属主转移守卫拦截。

- **engine**(`cascadeDeleteRelations`):`set_null` 写入改带一个**服务端派生**的上下文标记 `__referentialFieldClear`(由引擎设置、绝不来自请求体——与既有的 `__expandRead` 同一信任模型)。
- **plugin-security**(step 3.5 属主守卫):当该标记存在时跳过守卫。

普通用户写路径不受影响;标记无法从客户端伪造(执行上下文由运行时按会话解析,不透传请求字段),因此永远无法借它把真正的属主转移偷渡过守卫。

**范围说明**:本 PR 精确修复 #3004 守卫对级联的**过度拦截**,不改变级联的可见性范围(`find` 仍按调用者上下文发现子记录)。“引用完整性是否应覆盖删除者不可见的子记录(系统级 find)”是更大的独立设计问题,不在本 PR。

## 验证

- **engine**(`engine-cascade-delete.test.ts`):证明级联 `set_null` 写入携带 `__referentialFieldClear`,而普通用户 update 不带(对照);且级联确实把 FK 置空。
- **plugin-security**(`security-plugin.test.ts`):证明带标记的 `owner_id: null` 被成员放行,不带标记仍被拒(既有弃权用例)。
- **回归**:objectql 899、plugin-security 462 全绿;相关 dogfood(owner-anchor-and-bulk-writes、private OWD、controlled-by-parent、authz-conformance)全绿。

## 关联

- Closes #3023
- 承接 #3004 / PR #3018 的对抗式审查发现。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017XdmUnzcjd8QCAP2jwwbYM)_