### PR TITLE
feat(showcase): per-line Receipt attachment on invoice lines (upload-in-grid demo)

### DIFF
--- a/examples/app-showcase/src/data/objects/invoice.object.ts
+++ b/examples/app-showcase/src/data/objects/invoice.object.ts
@@ -210,6 +210,11 @@ export const InvoiceLine = ObjectSchema.create({
       min: 0,
       readonlyWhen: P`parent.status == 'paid'`,
     }),
+    // Per-line attachment (objectui#2360): the inline line-item grid renders a
+    // real upload cell for `file` fields — the "attach the receipt to each
+    // expense line" pattern. Exercises upload-in-grid end-to-end (auto-derived
+    // column, compact picker, persistence through the storage service).
+    receipt: Field.file({ label: 'Receipt' }),
     // Amount = Qty × Unit Price. Kept as a *stored* currency column (so the
     // parent Invoice.total summary can roll it up — summary aggregation reads
     // stored columns, not on-read formula fields), but the `expression` makes


### PR DESCRIPTION
Companion to objectstack-ai/objectui#2585 (fixes objectstack-ai/objectui#2360).

Adds `receipt: Field.file({ label: 'Receipt' })` to `showcase_invoice_line`, so the showcase's canonical master-detail inline grid (`inlineEdit: 'grid'`) demonstrates and continuously exercises **file upload in a line-item grid** — the "attach the receipt to each expense line" pattern the issue came from.

## Dogfood verification (browser, this example)

Booted this example fresh (`objectstack dev --seed-admin --fresh -p 4010`) with the objectui console dev server (`VITE_SERVER_URL`/`DEV_PROXY_TARGET` → :4010) and drove it with Playwright as admin:

1. New Invoice form auto-derives a **Receipt** column into the Line Items grid (no explicit columns config).
2. The cell renders a real `input[type=file]` + compact upload button — no text-input degradation.
3. Picking a file uploads through the console's `createObjectStackUploadAdapter` and shows a removable chip.
4. Save goes through `/api/v1/batch`; the line persists `receipt` with a canonical `/api/v1/storage/files/<fileId>` URL (verified via the data API, and the URL round-trips the uploaded bytes).
5. Reopening the invoice's edit form renders the stored receipt as a chip.

`pnpm validate` passes for the example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5tsBSEhsDZmdcHBvfymYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5tsBSEhsDZmdcHBvfymYC)_