### PR TITLE
fix(security): bulk 写谓词守卫按调用者谓词判定 + pre-image 读取去重(#3018 审查后续)

### DIFF
--- a/.changeset/predicate-guard-caller-scope-and-preimage-dedup.md
+++ b/.changeset/predicate-guard-caller-scope-and-preimage-dedup.md
@@ -1,0 +1,29 @@
+---
+'@objectstack/plugin-security': patch
+---
+
+fix(security): scope the bulk-write predicate guard to the caller's own filter, and dedupe pre-image reads (#3018 review follow-ups)
+
+Two hardening follow-ups from the #3018 adversarial review.
+
+**Predicate guard is now middleware-order-independent for writes.** #2982 made bulk
+`update`/`delete` carry an `opCtx.ast`, which brought them under the step-2.9
+anti-oracle predicate guard for the first time. That guard is documented to run
+against the *caller's own* predicate — RLS / sharing filters legitimately reference
+fields the caller cannot read (e.g. `owner_id`). But for a bulk write it inspected
+`opCtx.ast.where`, which a sibling middleware (`plugin-sharing`) may have already had
+an `owner_id` owner-match composed into — and the two middlewares' registration order
+is not contractually guaranteed. On an object whose `owner_id` is FLS-hidden, that
+could 403 a legitimate bulk write purely because the injected filter named the field.
+The guard now inspects `opCtx.options.where` (the caller's untouched predicate) for
+`update`/`delete`, so it can never mistake an injected owner/RLS filter for a caller
+probe, independent of middleware order. Reads are unchanged (the read seed is the
+caller's query verbatim and the guard runs before this middleware's own injection).
+
+**Pre-image reads deduplicated.** The by-id "read the target row" pattern was inlined
+at ~5 gates with slightly divergent shapes; a single `readRowById` helper (fail-closed:
+missing engine / null id / thrown read → `null`, which always denies) now backs the
+provenance gates, and a memoized `getCallerPreImage` collapses the owner-anchor echo
+check (3.5) and the RLS `check` post-image (3.6) — which read the identical
+`(object, id, caller-context)` row — into one read per operation. No behavior change;
+the read shape can no longer drift across sites.

--- a/packages/plugins/plugin-security/src/security-plugin.test.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.test.ts
@@ -1223,6 +1223,48 @@ describe('SecurityPlugin', () => {
     });
   });
 
+  it('[#2982 follow-up] bulk-write predicate guard inspects the CALLER predicate, not injected owner/RLS filters', async () => {
+    // The anti-oracle guard (2.9) must reject a caller filtering on an
+    // FLS-hidden field, but must NOT reject an owner_id predicate a sibling
+    // middleware (plugin-sharing) composed onto opCtx.ast — otherwise a bulk
+    // write on an object whose owner_id is FLS-hidden 403s purely because the
+    // injected filter mentions it, and the result depends on middleware order.
+    const ownerHiddenSet: PermissionSet = {
+      name: 'member_default',
+      label: 'Member',
+      objects: { '*': { allowRead: true, allowCreate: true, allowEdit: true, allowDelete: true } },
+      fields: { 'task.owner_id': { readable: false, editable: false }, 'task.ssn': { readable: false, editable: false } },
+    } as any;
+    const boot = async () => {
+      const plugin = new SecurityPlugin({ fallbackPermissionSet: 'member_default' });
+      const harness = makeMiddlewareCtx({ permissionSets: [ownerHiddenSet], objectFields: ['id', 'owner_id', 'name', 'ssn', 'status'] });
+      await plugin.init(harness.ctx);
+      await plugin.start(harness.ctx);
+      return harness;
+    };
+    const ctx = { userId: 'u1', tenantId: 'org-1', positions: [], permissions: ['member_default'] };
+
+    // Injected owner_id in the AST, but the caller's own predicate is clean → allowed.
+    const injected: any = await boot();
+    const okCtx: any = {
+      object: 'task', operation: 'update', data: { name: 'renamed' },
+      options: { where: { status: 'open' }, multi: true },
+      ast: { where: { $and: [{ status: 'open' }, { owner_id: 'u1' }] } }, // as plugin-sharing would compose
+      context: ctx,
+    };
+    await injected.run(okCtx); // must NOT throw — owner_id is only in the injected filter
+
+    // The caller's OWN predicate references a hidden field → still rejected.
+    const probing: any = await boot();
+    const denyCtx: any = {
+      object: 'task', operation: 'update', data: { name: 'renamed' },
+      options: { where: { ssn: 'guess' }, multi: true },
+      ast: { where: { ssn: 'guess' } },
+      context: ctx,
+    };
+    await expect(probing.run(denyCtx)).rejects.toThrow(/filter oracle|not readable/);
+  });
+
   it('FLS write — the record echoed back by an update is masked (no read-leak of hidden fields)', async () => {
     // Regression: a caller with edit-but-not-field-read must not be able to
     // read a read-protected field back out of the mutation response. The write

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -1195,7 +1195,7 @@ export class SecurityPlugin implements Plugin {
                       // closes the owner-enumeration oracle a system read would
                       // open (a caller who can't read the row gets null → deny,
                       // indistinguishable from a non-owner).
-                      const pre: any = await this.ql.findOne(opCtx.object, { where: { id: targetId }, context: opCtx.context });
+                      const pre = await this.getCallerPreImage(opCtx, targetId);
                       unchanged = !!pre && pre.owner_id != null && String(pre.owner_id) === String(row.owner_id);
                     } catch {
                       unchanged = false; // fail closed
@@ -1257,13 +1257,10 @@ export class SecurityPlugin implements Plugin {
               );
               postImage = null;
             } else if (this.ql) {
-              let pre: any = null;
-              try {
-                pre = await this.ql.findOne(opCtx.object, { where: { id: targetId }, context: opCtx.context });
-              } catch {
-                pre = null;
-              }
-              if (pre && typeof pre === 'object') postImage = { ...(pre as Record<string, unknown>), ...(opCtx.data as Record<string, unknown>) };
+              // Shares the memoized caller pre-image with the step-3.5 owner
+              // echo check — the identical (object, id, caller-context) row.
+              const pre = await this.getCallerPreImage(opCtx, targetId);
+              if (pre) postImage = { ...pre, ...(opCtx.data as Record<string, unknown>) };
             }
           }
           if (postImage && !checkParts.every((f) => matchesFilterCondition(postImage as any, f as any))) {
@@ -1366,9 +1363,10 @@ export class SecurityPlugin implements Plugin {
       // sorting / grouping on it (row presence is the oracle; the objectui
       // /data surface makes URL-driven predicates first-class). Reject such
       // queries outright — silent predicate dropping would change query
-      // semantics unpredictably. MUST run against the CALLER's AST, before
-      // the RLS injection below: RLS policies legitimately reference fields
-      // the caller cannot read (e.g. owner_id).
+      // semantics unpredictably. MUST run against the CALLER's OWN predicate,
+      // before the RLS injection below: RLS / sharing filters legitimately
+      // reference fields the caller cannot read (e.g. owner_id) and must not be
+      // rejected.
       if (opCtx.ast) {
         let guardPerms = this.permissionEvaluator.getFieldPermissions(opCtx.object, permissionSets);
         guardPerms = this.foldFieldRequiredPermissions(guardPerms, secMeta.fieldRequiredPermissions, permissionSets);
@@ -1380,7 +1378,22 @@ export class SecurityPlugin implements Plugin {
           guardPerms = intersectFieldMasks(guardPerms, delGuard);
         }
         if (Object.keys(guardPerms).length > 0) {
-          assertReadableQueryFields(opCtx.ast as unknown as Record<string, unknown>, guardPerms, opCtx.object);
+          // [#2982 follow-up] For a bulk WRITE the caller's own predicate is
+          // `opCtx.options.where` (untouched); `opCtx.ast.where` may ALREADY
+          // carry an owner-match that plugin-sharing's write branch composed in
+          // — and plugin-sharing is a SIBLING middleware whose registration
+          // order relative to this one is not guaranteed. Guarding the injected
+          // AST would 403 a legitimate bulk write on an object whose owner_id is
+          // FLS-hidden, purely because a sibling filter mentioned it. Inspect
+          // the caller's own predicate so the guard is independent of middleware
+          // order and never mistakes an injected filter for a probe. Reads keep
+          // guarding the ast: the read seed is the caller's query verbatim and
+          // this middleware runs before its own RLS injection.
+          const guardTarget: Record<string, unknown> =
+            opCtx.operation === 'update' || opCtx.operation === 'delete'
+              ? { where: opCtx.options?.where }
+              : (opCtx.ast as unknown as Record<string, unknown>);
+          assertReadableQueryFields(guardTarget, guardPerms, opCtx.object);
         }
       }
 
@@ -2156,9 +2169,7 @@ export class SecurityPlugin implements Plugin {
       return;
     }
 
-    const existing = await this.ql
-      .findOne('sys_permission_set', { where: { id: targetId }, context: { isSystem: true } })
-      .catch(() => null);
+    const existing = await this.readRowById('sys_permission_set', targetId, { isSystem: true });
     if (existing && (existing as Record<string, unknown>).managed_by === 'package') {
       const row = existing as Record<string, unknown>;
       throw new PermissionDeniedError(
@@ -2264,9 +2275,7 @@ export class SecurityPlugin implements Plugin {
       return;
     }
 
-    const existing = await this.ql
-      .findOne(opCtx.object, { where: { id: targetId }, context: { isSystem: true } })
-      .catch(() => null);
+    const existing = await this.readRowById(opCtx.object, targetId, { isSystem: true });
     const existingManagedBy = existing
       ? String((existing as Record<string, unknown>).managed_by ?? '')
       : '';
@@ -2295,6 +2304,40 @@ export class SecurityPlugin implements Plugin {
       return (where as any).id;
     }
     return null;
+  }
+
+  /**
+   * By-id row read with the standard FAIL-CLOSED contract (missing engine,
+   * null id, or a thrown read → `null`), shared by every provenance / pre-image
+   * gate. Centralising the read SHAPE keeps a future change (soft-delete filter,
+   * field projection) from drifting across the ~5 call sites that used to
+   * inline it (#3018 review — Reuse). A `null` return always DENIES downstream;
+   * it never bypasses a gate.
+   */
+  private async readRowById(object: string, id: unknown, context: any): Promise<Record<string, unknown> | null> {
+    if (id == null || typeof this.ql?.findOne !== 'function') return null;
+    try {
+      const row = await this.ql.findOne(object, { where: { id }, context });
+      return row && typeof row === 'object' ? (row as Record<string, unknown>) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * The single-id write PRE-IMAGE read under the CALLER's context, memoized per
+   * operation. The owner-anchor echo check (step 3.5) and the RLS `check`
+   * post-image (step 3.6) read the IDENTICAL `(object, id, caller-context)` row;
+   * this collapses the two reads into one. Safe: no write to the row happens
+   * between the gates (the driver write runs after the whole middleware pass),
+   * so the pre-image is stable within the operation.
+   */
+  private async getCallerPreImage(opCtx: any, id: unknown): Promise<Record<string, unknown> | null> {
+    if (id == null) return null;
+    if (opCtx.__preImage && opCtx.__preImage.id === id) return opCtx.__preImage.row;
+    const row = await this.readRowById(opCtx.object, id, opCtx.context);
+    opCtx.__preImage = { id, row };
+    return row;
   }
 
   /**
@@ -2597,14 +2640,9 @@ export class SecurityPlugin implements Plugin {
     } else {
       const targetId = this.extractSingleId(opCtx);
       if (targetId == null) return; // bulk write — scoped by the read filter on the AST
-      let row: any = null;
-      try {
-        row = await this.ql.findOne(object, { where: { id: targetId }, context: { isSystem: true } });
-      } catch {
-        row = null;
-      }
+      const row = await this.readRowById(object, targetId, { isSystem: true });
       if (!row) deny('target record not found', targetId);
-      masterId = row[rel!.fk];
+      masterId = row![rel!.fk];
     }
     if (masterId == null) deny('detail record has no master reference');
 


### PR DESCRIPTION
承接 PR #3018 那轮对抗式审查里记录、未在当时处理的两个加固点。

## ① bulk 写的反-oracle 谓词守卫改为顺序无关(潜在残留漏洞坐实并修复)

#2982 让 bulk `update`/`delete` 开始携带 `opCtx.ast`,于是它们**首次**进入 step 2.9 的反 filter-oracle 谓词守卫。该守卫的契约(见 `predicate-guard.ts` 文档注释)是**对调用者自己的谓词**判定——RLS / sharing 注入的过滤器合法地引用调用者不可读的字段(如 `owner_id`),不应被拒。

但对 bulk 写,守卫检查的是 `opCtx.ast.where`,而 `plugin-sharing` 的写分支可能**已经**把 `owner_id` 属主匹配 AND-合成进了 `ast.where`;两个中间件的注册顺序**没有契约保证**。核查结论:当前 verify 栈与生产栈都是 **security 先于 sharing**(security 外层),所以 2.9 在 sharing 注入前跑、目前是安全的(读路径同形、长期无 bug 也印证了这点)。但这是**依赖注册顺序的隐性脆弱**——一旦某对象把 `owner_id` 设为 FLS 不可读,且未来顺序被调整,该 private 对象上的所有 bulk 写会因注入的 `owner_id` 被 403。

**修复**:对 `update`/`delete`,守卫改看 `opCtx.options.where`(调用者**未被改动**的原始谓词),从此与中间件顺序无关,也绝不会把注入的属主/RLS 过滤器误判为探测。读路径不变(读的 seed 就是调用者查询原文,且本中间件在其自身 RLS 注入前运行)。

## ② pre-image 读取去重(维护性 + 少量性能)

同文件里“按 id 读目标行”的模式在 ~5 个门里各自内联、形态略有分歧(#3018 审查的 Reuse/Efficiency 项)。

- 抽 `readRowById(object, id, context)` 统一读取形态(fail-closed:引擎缺失 / id 为空 / 读抛错 → `null`,`null` 一律 DENY,绝不放行),回填到几个 provenance 门(package-managed / system-row / controlled-by-parent)。
- 抽 `getCallerPreImage`,把属主锚点回显检查(3.5)与 RLS `check` 后像(3.6)读取的**同一** `(object, id, 调用者上下文)` 行按操作**记忆化**为一次读取。安全:两门之间没有对该行的写入(驱动写在整个中间件链之后),pre-image 在本操作内稳定。

纯行为等价重构;读取形态从此不会在各站点漂移。

## 验证

- **单测**:plugin-security **463**(+1 新:注入到 AST 的 `owner_id` 不再触发守卫;调用者自己过滤隐藏字段仍被拒)。既有全部门测试通过 → ② 去重行为等价。
- **dogfood**:owner-anchor-and-bulk-writes / two-doors-permission / controlled-by-parent / showcase-invoice-cbp / showcase-private-owd 共 **27** 全绿。
- 已加 changeset(`plugin-security` patch)。

## 关联

- 承接 #3004 / #2982 / PR #3018 的审查发现(非新功能,纯加固)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017XdmUnzcjd8QCAP2jwwbYM)_