### PR TITLE
docs(search): 拼音召回 — 明确 sys_user/选人器覆盖与存量数据回填(#2486 文档补遗)

### DIFF
--- a/content/docs/data-modeling/queries.mdx
+++ b/content/docs/data-modeling/queries.mdx
@@ -380,6 +380,17 @@ the expanded filter; `fields` semantics, `searchableFields`, and drivers are unc
 (ADR-0097). Relevance ranking and typo tolerance remain Tier-2 (native FTS) and are not
 part of this.
 
+**Coverage** — every object with a resolvable display/name field gets the companion,
+**including `sys_user`**: the people picker (which sends a plain `$search` against
+`sys_user`) finds users by pinyin with zero per-object or per-field configuration. Users
+created through any write path — sign-up, admin rename, engine writes — are searchable
+immediately.
+
+**Pre-existing rows** are reconciled automatically: the first boot after the switch turns
+on runs a paged, idempotent backfill over every object that carries the companion column.
+For bulk imports that bypassed write hooks at runtime, `rebuildSearchCompanion` (exported
+by `@objectstack/plugin-pinyin-search`) recomputes the column on demand.
+
 ---
 
 ## Window Functions

--- a/content/docs/deployment/environment-variables.mdx
+++ b/content/docs/deployment/environment-variables.mdx
@@ -253,6 +253,13 @@ OS_SEARCH_PINYIN_ENABLED=false os start   # force off (e.g. a zh-locale stack th
 |:---|:---|:---|:---|
 | `OS_SEARCH_PINYIN_ENABLED` | boolean | locale-derived | Pinyin search recall. When unset, the default derives from the stack's configured locales (`i18n.defaultLocale` / `supportedLocales` / `fallbackLocale`): any `zh-*` locale turns it on; an explicit value always wins. Gates both the compile-time `__search` companion column and the `plugin-pinyin-search` populate hooks, so there is no half-state. Off ⇒ no extra column, and `pinyin-pro` is never loaded. |
 
+Coverage includes `sys_user` — the people picker finds users by pinyin with no
+per-object configuration. Rows that predate the switch are backfilled automatically
+on the first boot after it turns on (paged, idempotent); for runtime bulk imports
+that bypassed write hooks, `rebuildSearchCompanion` (from
+`@objectstack/plugin-pinyin-search`) recomputes the column on demand. See
+[Queries → Pinyin recall](/docs/data-modeling/queries#pinyin-recall-chinese-deployments).
+
 ---
 
 ## Marketplace & Metadata


### PR DESCRIPTION
#3034 合并后的文档补遗:回答读者(以及维护者实际问到的)两个已有文档没写清的问题。

## 补充内容(2 个文件,+18 行,纯文档)

**`queries.mdx` → Pinyin recall 小节**新增两段:
- **Coverage**:所有带可解析名称字段的对象都有伴随列,**明确包括 `sys_user`** —— 选人器只发 `$search`,零配置即可拼音搜人;经任何写路径(sign-up / 管理员改名 / engine 写入)创建的用户立即可搜。
- **存量数据**:开关首次开启后的下一次启动自动分批幂等回填;运行期绕过 hook 的批量导入可用 `@objectstack/plugin-pinyin-search` 导出的 `rebuildSearchCompanion` 按需重建。

**`environment-variables.mdx` → Search 章节**:同样补一段 sys_user 覆盖 + 回填说明,并互链到 queries 文档。

## 依据(非推测,已实测)

在最新 main 的 showcase 真机上验证过:通过 better-auth `sign-up` 注册中文名用户"张伟",行上 `__search` 立即物化为 `"zhangwei zw"`,`$search=zhangwei` / `zw` 无需重启即命中;管理员把用户改名为"王小明"后 `wxm` / `wangxiaoming` 同样立即命中。

纯文档改动,无需 changeset。

Refs #2486, #3027, #3034, ADR-0097

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMugRriiNv3nsnmLczfhuY

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMugRriiNv3nsnmLczfhuY)_