### PR TITLE
fix(hono): allow If-Match in default CORS headers so cross-origin OCC saves work (objectui#2572)

### DIFF
--- a/.changeset/cors-allow-if-match.md
+++ b/.changeset/cors-allow-if-match.md
@@ -1,0 +1,13 @@
+---
+'@objectstack/plugin-hono-server': patch
+'@objectstack/hono': patch
+---
+
+CORS default `allowHeaders` now includes `If-Match`. The REST record update
+accepts the OCC token as an `If-Match` header (objectui's record-level inline
+edit sends it on every save), but the preflight allow-list omitted it — so on
+any split-origin deployment (console dev server against a backend on another
+origin) the browser failed the preflight and every inline-edit save died with
+"Failed to fetch". Found live while dogfooding objectui#2572; same
+split-origin failure class as the #2548 Bearer fixes. Explicit user-supplied
+`allowHeaders` still win unchanged.

--- a/packages/adapters/hono/src/index.ts
+++ b/packages/adapters/hono/src/index.ts
@@ -186,7 +186,9 @@ export function createHonoApp(options: ObjectStackHonoOptions): Hono {
       app.use('*', cors({
         origin: origin as any,
         allowMethods: corsOpts.methods || ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'],
-        allowHeaders: corsOpts.allowHeaders || ['Content-Type', 'Authorization', 'X-Requested-With', 'X-Tenant-ID', 'X-Environment-Id'],
+        // Keep in sync with plugin-hono-server's defaultAllowHeaders — `If-Match`
+        // carries the OCC token on cross-origin record PATCHes (objectui#2572).
+        allowHeaders: corsOpts.allowHeaders || ['Content-Type', 'Authorization', 'X-Requested-With', 'X-Tenant-ID', 'X-Environment-Id', 'If-Match'],
         exposeHeaders,
         credentials,
         maxAge,

--- a/packages/plugins/plugin-hono-server/src/hono-plugin.test.ts
+++ b/packages/plugins/plugin-hono-server/src/hono-plugin.test.ts
@@ -255,6 +255,18 @@ describe('HonoServerPlugin', () => {
             expect(corsConfigCapture.last.allowHeaders).toContain('Authorization');
         });
 
+        it('should allow If-Match by default (OCC token on cross-origin record PATCHes)', async () => {
+            corsConfigCapture.last = undefined;
+
+            const plugin = new HonoServerPlugin();
+            await plugin.init(context as PluginContext);
+
+            // objectui#2572 dogfood find: the record-level inline edit sends the
+            // OCC token as an `If-Match` header; a preflight that doesn't allow
+            // it makes every split-origin save fail with "Failed to fetch".
+            expect(corsConfigCapture.last.allowHeaders).toContain('If-Match');
+        });
+
         it('should merge user-supplied exposeHeaders with set-auth-token default', async () => {
             corsConfigCapture.last = undefined;
 

--- a/packages/plugins/plugin-hono-server/src/hono-plugin.ts
+++ b/packages/plugins/plugin-hono-server/src/hono-plugin.ts
@@ -279,7 +279,12 @@ export class HonoServerPlugin implements Plugin {
                 // the better-auth `bearer()` plugin can deliver rotated
                 // session tokens to cross-origin clients (see plugin-auth).
                 // User-supplied exposeHeaders are merged with this default.
-                const defaultAllowHeaders = ['Content-Type', 'Authorization', 'X-Requested-With', 'X-Tenant-ID', 'X-Environment-Id'];
+                // `If-Match` carries the OCC token on record PATCHes (objectui's
+                // record-level inline edit, REST `update` with `ifMatch`) — without
+                // it in the preflight allow-list, every cross-origin save fails in
+                // the browser with "Failed to fetch" (objectui#2572 dogfood find;
+                // same split-origin class as the #2548 Bearer fixes).
+                const defaultAllowHeaders = ['Content-Type', 'Authorization', 'X-Requested-With', 'X-Tenant-ID', 'X-Environment-Id', 'If-Match'];
                 const defaultExposeHeaders = ['set-auth-token'];
                 const allowHeaders = corsOpts.allowHeaders ?? defaultAllowHeaders;
                 const exposeHeaders = Array.from(new Set([


### PR DESCRIPTION
## What

Adds `If-Match` to the **default CORS `allowHeaders`** in both places the default list lives:

- `packages/plugins/plugin-hono-server/src/hono-plugin.ts` (`defaultAllowHeaders` — the `objectstack dev`/`serve` path)
- `packages/adapters/hono/src/index.ts` (same default, kept in sync)

Explicit user-supplied `allowHeaders` still win unchanged. New unit test pins `If-Match` in the default list (16/16 green in `plugin-hono-server`).

## Why

The REST record PATCH accepts the OCC token as an `If-Match` header, and objectui's record-level inline edit (objectui#2407/#2572) sends it on **every** save. The preflight allow-list omitted it, so on any split-origin deployment — console dev server on one origin, backend on another — the browser failed the CORS preflight and every inline-edit save died with `Failed to fetch`, while same-origin (`/_console`) setups never noticed. Same split-origin failure class as the #2548 Bearer fixes.

## How it was found

Live dogfood of objectui#2572 on the showcase stack: console dev (`:5191`, objectui HMR) against `examples/app-showcase` (`:4022`). The saved-fix stack was then re-verified end-to-end — preflight now returns `access-control-allow-headers: …, If-Match` and the atomic inline-edit PATCH (carrying only the edited key + `If-Match`) succeeds, triggering `showcase_budget_approval` as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQjNZDdqmz2QHGQndpjZrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQjNZDdqmz2QHGQndpjZrR)_