### PR TITLE
docs(adr): renumber pinyin-search ADR 0097 → 0098 — resolve the second 0097 collision

### DIFF
--- a/.changeset/pinyin-search-companion.md
+++ b/.changeset/pinyin-search-companion.md
@@ -5,7 +5,7 @@
 '@objectstack/cli': minor
 ---
 
-Generic pinyin search recall (#2486, ADR-0097): a locale-gated
+Generic pinyin search recall (#2486, ADR-0098): a locale-gated
 `OS_SEARCH_PINYIN_ENABLED` switch (auto-on when the stack configures any
 `zh-*` locale) provisions a hidden `__search` companion column for each
 object's display/name field at compile time, the new

--- a/content/docs/deployment/environment-variables.mdx
+++ b/content/docs/deployment/environment-variables.mdx
@@ -237,7 +237,7 @@ OS_MCP_SERVER_ENABLED=true os start     # additionally auto-start the stdio tran
 
 ## Search
 
-Pinyin recall for `$search` (ADR-0097): with the switch on, every object's
+Pinyin recall for `$search` (ADR-0098): with the switch on, every object's
 display/name field gets a hidden, platform-maintained companion column storing
 full pinyin + initials ("张伟" → "zhangwei zw"), so lookup pickers, list
 quick-search and ⌘K match `zhangwei` / `zw` against CJK names — transparently,

--- a/docs/adr/0098-pinyin-search-companion-column.md
+++ b/docs/adr/0098-pinyin-search-companion-column.md
@@ -1,4 +1,4 @@
-# ADR-0097: Pinyin Search via a Locale-Gated Companion Column
+# ADR-0098: Pinyin Search via a Locale-Gated Companion Column
 
 - **Status**: Accepted
 - **Date**: 2026-07-16


### PR DESCRIPTION
解决 ADR 编号的第二次撞号:#3032 的状态治理把连接器 ADR 从 0096 改号到 0097(执行面身份准入 ADR 保留 0096),但**同日落地的拼音搜索 ADR 也占了 0097**——同一冲突在上一个编号槽位复现。

## 处置(沿用 #3032 的同一决策规则)
- **连接器 ADR 保留 0097**:它的改号已经传播进代码注释、测试标题、zod describe/message 字符串(全仓 125 处引用),再动它代价大且无收益;
- **更新的拼音 ADR 迁往空闲的 0098**。

## 变更(3 文件,纯文档/元数据)
| 文件 | 变更 |
|---|---|
| `docs/adr/0097-pinyin-search-companion-column.md` → `0098-...` | 重命名 + 标题行 `ADR-0097:` → `ADR-0098:` |
| `content/docs/deployment/environment-variables.mdx` | `OS_SEARCH_PINYIN_ENABLED` 条目的 `(ADR-0097)` → `(ADR-0098)` |
| `.changeset/pinyin-search-companion.md` | `(#2486, ADR-0097)` → `(#2486, ADR-0098)`(**未发布**的 changeset,可安全编辑) |

## 审计说明
全仓 grep 分类了每一处 `ADR-0097` 引用:拼音语义的**只有上述 3 处**;拼音实现的代码注释只引用 ADR-0045/0049/0061/0079/0093(无需改代码);125 处连接器语义引用全部保留;CHANGELOG 按 #3032 惯例作为历史记录不动;`docs/PRIORITIZATION.md` 及其他 ADR 无拼音 ADR 交叉引用;0098 槽位确认空闲。

Refs #3032(第一次撞号的处置)、#2486(拼音 ADR 的跟踪 issue)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pbmw3pMqNJfPbkvwh9Fkjs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pbmw3pMqNJfPbkvwh9Fkjs)_