### PR TITLE
fix(spec): ToolExecutionContext fails closed on missing actor — system is an explicit isSystem opt-in (#2991)

### DIFF
--- a/.changeset/ai-toolexecutioncontext-fail-closed.md
+++ b/.changeset/ai-toolexecutioncontext-fail-closed.md
@@ -1,0 +1,5 @@
+---
+'@objectstack/spec': minor
+---
+
+Security (#2991): the AI `ToolExecutionContext` contract no longer documents system-level execution as the missing-actor default. A missing `toolExecutionContext` / `actor` now means an unauthenticated (RLS-on, sees-nothing) principal — executors MUST fail closed to anonymous, never fall open to system. System execution becomes an explicit, greppable opt-in via the new `ToolExecutionContext.isSystem?: boolean` field (same convention as `IDataEngine` / `IKnowledgeService`), reserved for trusted server-side invocations and ignored when an `actor` is present. Migration for internal callers that relied on the old omission default (cron, migrations, server jobs): pass `toolExecutionContext: { isSystem: true }` explicitly.

--- a/content/docs/ai/actions-as-tools.mdx
+++ b/content/docs/ai/actions-as-tools.mdx
@@ -228,9 +228,13 @@ authenticated principal from `req.user` — both cookie session
 `aiService.chatWithTools(...)` as
 `toolExecutionContext: { actor, conversationId, environmentId }`. That threads the
 same RLS context through the runtime's built-in data tools and its
-`action_<name>` tools. From a custom server route you opt in by passing the actor
-explicitly; omit `toolExecutionContext` to keep system-level behaviour (cron
-jobs, internal callers).
+`action_<name>` tools. From a custom server route you pass the actor explicitly.
+Omitting `toolExecutionContext` (or its `actor`) is **not** a system fallback:
+the contract fails closed and data tools run as an unauthenticated, RLS-on
+principal that sees nothing (#2991). Trusted internal callers (cron jobs,
+migrations) that genuinely need full authority opt in explicitly with
+`toolExecutionContext: { isSystem: true }` — a deliberate, greppable elevation,
+never the consequence of a forgotten field.
 
 ```typescript
 await aiService.chatWithTools(messages, tools, {

--- a/packages/spec/src/contracts/ai-service.ts
+++ b/packages/spec/src/contracts/ai-service.ts
@@ -366,14 +366,20 @@ export interface ChatWithToolsOptions extends AIRequestOptions {
     onToolError?: (toolCall: ToolCallPart, error: string) => 'continue' | 'abort';
     /**
      * Per-call execution context threaded into every tool handler the
-     * loop dispatches. The HTTP route should populate this from
+     * loop dispatches. The HTTP route MUST populate this from
      * `req.user` (and any conversation/environment headers) so that
      * built-in data tools forward the actor into ObjectQL's
      * `ExecutionContext` and row-level security automatically scopes
      * what the LLM can see or change.
      *
-     * Optional for backward compatibility — when omitted, tools fall
-     * back to system-level behaviour.
+     * Optional at the type level only — a missing context is NOT a
+     * grant of authority (#2991). When omitted, executors MUST run
+     * data-touching tools as an unauthenticated (RLS-on, sees-nothing)
+     * principal, exactly as if an empty context had been passed; they
+     * MUST NOT fall back to system-level behaviour. Trusted internal
+     * callers (cron, migrations, server jobs) that genuinely need full
+     * authority opt in explicitly via
+     * {@link ToolExecutionContext.isSystem}.
      */
     toolExecutionContext?: ToolExecutionContext;
 }
@@ -383,12 +389,30 @@ export interface ChatWithToolsOptions extends AIRequestOptions {
  * by {@link ChatWithToolsOptions}. Mirrors {@link ExecutionContext}
  * but is tailored to the AI tool boundary (no transaction handle, no
  * raw access token — those live on the engine call site).
+ *
+ * ## Identity semantics (fail-closed, #2991)
+ *
+ * "No identity" is never a grant of authority. Executors MUST derive
+ * the ObjectQL `ExecutionContext` for data-touching tools as:
+ *
+ * - `actor` present → that user's context (RLS scopes reads/writes).
+ * - `isSystem: true` → system context (RLS bypass) — an explicit,
+ *   greppable elevation, same convention as `IDataEngine` /
+ *   `IKnowledgeService`.
+ * - neither → an anonymous, unauthenticated context (RLS on, sees
+ *   nothing). NEVER system.
  */
 export interface ToolExecutionContext {
     /**
      * Authenticated end user on whose behalf the LLM is acting.
      * Built-in tools promote this into the ObjectQL `ExecutionContext`
-     * so RLS engages. Omit for internal/system invocations.
+     * so RLS engages.
+     *
+     * A missing actor means an UNAUTHENTICATED caller (#2991):
+     * executors MUST run data-touching tools with an anonymous
+     * (RLS-on, sees-nothing) context — never as system. System
+     * execution is only ever the explicit {@link isSystem} opt-in,
+     * not the consequence of a forgotten field.
      */
     actor?: {
         id: string;
@@ -396,6 +420,18 @@ export interface ToolExecutionContext {
         positions?: string[];
         permissions?: string[];
     };
+    /**
+     * Explicit, deliberate elevation: run tool handlers with a
+     * system-level (RLS-bypassing) `ExecutionContext` — the same
+     * convention as `IDataEngine` / `IKnowledgeService`
+     * (`isSystem: true`). Reserved for trusted server-side invocations
+     * (cron, migrations, internal jobs); MUST be set by trusted server
+     * code only, never derived from request input, and ignored when an
+     * {@link actor} is present. This flag is the ONLY way to obtain
+     * system behaviour from the tool loop — a merely absent actor
+     * fails closed to anonymous instead (#2991).
+     */
+    isSystem?: boolean;
     /** Conversation id for trace/HITL correlation. */
     conversationId?: string;
     /**


### PR DESCRIPTION
修复 #2991(ADR-0096 E4 收敛出的合同级 fall-open)。

## 问题

AI 工具执行合同(`packages/spec/src/contracts/ai-service.ts`)把 **system 级(绕过 RLS)执行** 文档化为缺失 `actor` / `toolExecutionContext` 时的默认行为,覆盖所有内置数据工具(query/get/create/update/delete/run_action)。任何忘记从 `req.user` 填充 actor 的 cloud 或自定义路由,都会让 LLM 的工具以完全权限运行——违反 D1 不变式("无身份绝不等于授权")。

## 修改内容

- **`ChatWithToolsOptions.toolExecutionContext`**:省略不再意味着回退到 system 级行为。合同现在要求执行器在缺失上下文时以**未认证(RLS 生效、什么都看不到)主体**运行数据工具——fail-closed,绝不 fall-open。
- **`ToolExecutionContext`**:接口文档新增身份推导规则(`actor` → 用户上下文;`isSystem` → system;两者皆无 → 匿名,**绝不是 system**),并新增显式 `isSystem?: boolean` 字段,镜像 `IDataEngine` / `IKnowledgeService` 的 `isSystem` 约定——"以 system 运行"从此是一个可 grep 的、深思熟虑的选择,而不是漏填字段的后果。`actor` 存在时 `isSystem` 被忽略(最小权限优先)。
- **`content/docs/ai/actions-as-tools.mdx`**:文档不再宣传"省略 `toolExecutionContext` 以保持 system 级行为(cron、内部调用)",改为指向显式的 `isSystem: true` 选择加入。
- **changeset**(`@objectstack/spec` minor):含迁移说明——依赖旧省略默认值的内部调用方(cron、迁移、服务端任务)需显式传 `toolExecutionContext: { isSystem: true }`。

保持 `actor` 可选(而非强制):内部调用方合法地没有终端用户,它们现在通过显式 `isSystem` 表达意图。

## 与 #2981 / ADR-0096 的关系

这是 #2981(knowledge/RAG fail-closed 修复)在合同层的镜像——framework 没有 `chatWithTools` 执行器(grep 确认合同仅在 `ai-service.ts` 中出现),所以诚实的修复位置就是合同本身。**Cloud 侧(跨仓库)** 仍需:(a) 每个 AI 路由从 `req.user` 填充 `actor`;(b) 缺失 actor 时默认匿名/拒绝的 `ExecutionContext`,绝不 `isSystem`。

## 验证

- `packages/spec` 类型检查通过(`tsc --noEmit`)
- `pnpm build` + `check:api-surface` 通过(公共 API 面无变化——新增字段在既有接口内)
- `pnpm test`:254 个测试文件、6883 个用例全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rao3tuTpJ8HPQV5fyxBoz

---
_Generated by [Claude Code](https://claude.ai/code/session_019rao3tuTpJ8HPQV5fyxBoz)_