### PR TITLE
docs(releases): drop reserved word "role" from v15 kanban note

### DIFF
--- a/content/docs/releases/v15.mdx
+++ b/content/docs/releases/v15.mdx
@@ -410,7 +410,7 @@ The pinned Console picks up the objectui 14.1 line (94 commits). Highlights:
   inline (#2568); the connector picker lists runtime-dispatchable connectors and
   marks declarative instances (#2563); positions as approver/escalateTo references
   (#2515).
-- **Kanban:** lanes honor the ADR-0085 `stageField` role, cards default to
+- **Kanban:** lanes honor the ADR-0085 `stageField` setting, cards default to
   `highlightFields`, conditional formatting accepts CEL rules (#2596/#2541/#2550).
 - **Record header:** metadata-driven multi-button layout (3 desktop / 1 mobile,
   `order` + `variant:'primary'` tie-break, ⋯ overflow menu) (#2574).


### PR DESCRIPTION
## Problem

The `check:role-word` ratchet (ADR-0090 D3) is failing on `main` — [run 29542732386](https://github.com/objectstack-ai/framework/actions/runs/29542732386/job/87768128168):

> `content/docs/releases/v15.mdx`: NEW use of the reserved word "role" (1 occurrence(s)).

## Root cause

#3079 ("curate the 15.1 line") added a generic-English *"lanes honor the ADR-0085 `stageField` role"* to `content/docs/releases/v15.mdx`. That file isn't in `scripts/role-word-baseline.json`, so the ratchet flags it as a new occurrence and fails the ESLint job on every subsequent push.

## Fix

Reword to *"the `stageField` **setting**"*. The sentence is about which field drives kanban lanes — not the authz concept — so this is a plain reword, not a genuine boundary; no baseline entry needed.

Verified locally: `node scripts/check-role-word.mjs` → `OK (49 baselined file(s), no new occurrences)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)