### PR TITLE
docs: point site links at canonical objectstack.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Ready for production? The scaffolded project is container-ready:
 docker build -t my-app . && docker compose up -d   # app + Postgres on the official runtime image
 ```
 
-See [Self-Hosted Deployment](https://docs.objectstack.ai/docs/deployment/self-hosting) for bare Node, Kubernetes, and the secrets you must pin.
+See [Self-Hosted Deployment](https://objectstack.ai/docs/deployment/self-hosting) for bare Node, Kubernetes, and the secrets you must pin.
 
 ### For Framework Contributors
 
@@ -314,7 +314,7 @@ Key standards:
 
 ## Documentation
 
-Full documentation: **[https://docs.objectstack.ai](https://docs.objectstack.ai)**
+Full documentation: **[https://objectstack.ai/docs](https://objectstack.ai/docs)**
 
 **Upgrading from 10.x?** See [Upgrading to ObjectStack 11](./docs/upgrading-to-11.md).
 

--- a/content/docs.site.json
+++ b/content/docs.site.json
@@ -29,7 +29,7 @@
       "links": [
         {
           "text": "Website",
-          "url": "https://www.objectstack.ai",
+          "url": "https://objectstack.ai",
           "external": true
         }
       ],

--- a/docker/README.md
+++ b/docker/README.md
@@ -56,7 +56,7 @@ straight from your release storage.
 **You must inject at runtime:** `OS_DATABASE_URL`, `OS_AUTH_SECRET`,
 `OS_SECRET_KEY` — never bake them into an image. Full variable catalog and
 reverse-proxy / multi-node guidance:
-[Self-Hosted Deployment](https://docs.objectstack.ai/docs/deployment/self-hosting).
+[Self-Hosted Deployment](https://objectstack.ai/docs/deployment/self-hosting).
 
 ## Local build of this image
 


### PR DESCRIPTION
## 背景

域名整合已完成:apex `objectstack.ai` 为主域(直出 docs 站 landing),`www` 与 `docs.objectstack.ai` 均 path-preserving 30x 过去。本 PR 把仓库内显著链接改指主域,不再经过跳转。

## 改动

- README.md:Full documentation 与 Self-Hosted Deployment 链接 → `objectstack.ai/docs*`
- docker/README.md:同上
- content/docs.site.json:navbar Website 链接 `www.objectstack.ai` → `objectstack.ai`

旧地址有 30x 兜底,本改动纯链接卫生,无行为变化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)