### PR TITLE
fix(cli): hide platform i18n baseline from os lint by default

### DIFF
--- a/.changeset/lint-hide-platform-baseline.md
+++ b/.changeset/lint-hide-platform-baseline.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/cli": patch
+---
+
+`os lint` no longer buries the user's own signal under the platform i18n baseline. A fresh scaffold reported 800+ `i18n/missing-metadataForm` errors — translation keys for platform built-in metadata forms (email_template, …) that the platform packages already ship at runtime. Those are now hidden by default and folded into one summary line (`platform built-ins: N i18n issue(s) hidden`); pass `--include-platform` to audit them, and read `hiddenPlatform` in `--json` output. User-authored metadata coverage is reported unchanged.

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -6,7 +6,7 @@ import { bundleRequire } from 'bundle-require';
 import { normalizeStackInput } from '@objectstack/spec';
 import { PROTOCOL_MAJOR } from '@objectstack/spec/kernel';
 import { loadConfig, BUNDLE_REQUIRE_EXTERNALS } from '../utils/config.js';
-import { computeI18nCoverage } from '../utils/i18n-coverage.js';
+import { computeI18nCoverage, type CoverageIssue } from '../utils/i18n-coverage.js';
 import { lintDataModel } from '../lint/data-model-rules.js';
 import { validateWidgetBindings } from '@objectstack/lint';
 import { validateRecordTitle, validateSemanticRoles, validateCapabilityReferences, validateSecurityPosture, validateApprovalApprovers } from '@objectstack/lint';
@@ -34,6 +34,34 @@ interface LintIssue {
   message: string;
   path: string;
   fix?: string;
+}
+
+// Fold i18n coverage issues into lint issues, separating the platform
+// baseline from the user's own metadata. `metadataForm` issues come from
+// walking the static platform registries (DEFAULT_METADATA_TYPE_REGISTRY +
+// METADATA_FORM_REGISTRY) — ~850 Studio-form keys that the platform packages
+// already translate at runtime. On a fresh project they would drown every
+// user-authored signal (15.1 third-party eval: 848/848 errors were platform
+// noise), so they are hidden unless explicitly requested.
+export function foldCoverageIssues(
+  coverageIssues: CoverageIssue[],
+  includePlatform: boolean,
+): { folded: LintIssue[]; hiddenPlatform: number } {
+  const folded: LintIssue[] = [];
+  let hiddenPlatform = 0;
+  for (const c of coverageIssues) {
+    if (!includePlatform && c.source === 'metadataForm') {
+      hiddenPlatform++;
+      continue;
+    }
+    folded.push({
+      severity: c.severity === 'error' ? 'error' : 'warning',
+      rule: `i18n/missing-${c.source}`,
+      message: c.message,
+      path: `translations.${c.locale}.${c.key}`,
+    });
+  }
+  return { folded, hiddenPlatform };
 }
 
 // ─── Rules ──────────────────────────────────────────────────────────
@@ -441,6 +469,10 @@ export default class Lint extends Command {
       default: 75,
     }),
     'skip-i18n': Flags.boolean({ description: 'Skip translation coverage checks' }),
+    'include-platform': Flags.boolean({
+      description:
+        'Also report i18n coverage for platform built-in metadata forms (hidden by default — the platform packages ship those translations)',
+    }),
     'i18n-strict': Flags.boolean({
       description: 'Treat missing translations in non-default locales as errors',
     }),
@@ -486,19 +518,18 @@ export default class Lint extends Command {
       }
 
       // ── Translation coverage ──
+      let hiddenPlatform = 0;
       if (!flags['skip-i18n']) {
         const coverage = computeI18nCoverage(normalized, {
           defaultLocale: flags['default-locale'],
           strict: flags['i18n-strict'],
         });
-        for (const c of coverage.issues) {
-          issues.push({
-            severity: c.severity === 'error' ? 'error' : 'warning',
-            rule: `i18n/missing-${c.source}`,
-            message: c.message,
-            path: `translations.${c.locale}.${c.key}`,
-          });
-        }
+        const { folded, hiddenPlatform: hidden } = foldCoverageIssues(
+          coverage.issues,
+          flags['include-platform'] ?? false,
+        );
+        hiddenPlatform = hidden;
+        issues.push(...folded);
       }
 
       // Metadata-quality score (the lint rubric expressed as 0–100).
@@ -515,6 +546,7 @@ export default class Lint extends Command {
           errors: errors.length,
           warnings: warnings.length,
           suggestions: suggestions.length,
+          ...(hiddenPlatform > 0 ? { hiddenPlatform } : {}),
           ...(score ? { score: score.score, grade: score.grade } : {}),
           issues,
           duration: timer.elapsed(),
@@ -525,8 +557,19 @@ export default class Lint extends Command {
 
       console.log('');
 
+      const printHiddenPlatform = () => {
+        if (hiddenPlatform > 0) {
+          console.log(
+            chalk.dim(
+              `  platform built-ins: ${hiddenPlatform} i18n issue(s) hidden — rerun with --include-platform to audit them`,
+            ),
+          );
+        }
+      };
+
       if (issues.length === 0) {
         printSuccess(`All checks passed ${chalk.dim(`(${timer.display()})`)}`);
+        printHiddenPlatform();
         if (score) this.printScore(score);
         console.log('');
         return;
@@ -578,6 +621,7 @@ export default class Lint extends Command {
       if (warnings.length > 0) parts.push(chalk.yellow(`${warnings.length} warning(s)`));
       if (suggestions.length > 0) parts.push(chalk.blue(`${suggestions.length} suggestion(s)`));
       console.log(`  ${parts.join(', ')} ${chalk.dim(`(${timer.display()})`)}`);
+      printHiddenPlatform();
 
       if (score) this.printScore(score);
 

--- a/packages/cli/test/lint-platform-fold.test.ts
+++ b/packages/cli/test/lint-platform-fold.test.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+//
+// `os lint` platform-noise fold (15.1 third-party eval): a fresh scaffold
+// reported 848 errors, all `i18n/missing-metadataForm` — keys expected by the
+// static platform registries and already translated by the platform packages
+// at runtime. They must not drown the user's own i18n signal: hidden by
+// default, surfaced only under --include-platform, always counted.
+
+import { describe, it, expect } from 'vitest';
+import { foldCoverageIssues } from '../src/commands/lint';
+import type { CoverageIssue } from '../src/utils/i18n-coverage';
+
+const userIssue: CoverageIssue = {
+  severity: 'error',
+  locale: 'en',
+  key: 'objects.blank_note.label',
+  message: "Missing en translation for object 'blank_note' label",
+  source: 'object',
+};
+
+const platformIssue: CoverageIssue = {
+  severity: 'error',
+  locale: 'en',
+  key: 'metadataForms.email_template.fields.subject.label',
+  message: 'Missing en translation for metadata form email_template',
+  source: 'metadataForm',
+};
+
+describe('foldCoverageIssues', () => {
+  it('hides platform metadata-form issues by default and counts them', () => {
+    const { folded, hiddenPlatform } = foldCoverageIssues(
+      [userIssue, platformIssue, { ...platformIssue, locale: 'zh-CN', severity: 'warning' }],
+      false,
+    );
+    expect(hiddenPlatform).toBe(2);
+    expect(folded).toHaveLength(1);
+    expect(folded[0]).toMatchObject({
+      severity: 'error',
+      rule: 'i18n/missing-object',
+      path: 'translations.en.objects.blank_note.label',
+    });
+  });
+
+  it('keeps the user signal intact when nothing is platform-sourced', () => {
+    const { folded, hiddenPlatform } = foldCoverageIssues([userIssue], false);
+    expect(hiddenPlatform).toBe(0);
+    expect(folded).toHaveLength(1);
+  });
+
+  it('surfaces everything under --include-platform', () => {
+    const { folded, hiddenPlatform } = foldCoverageIssues(
+      [userIssue, platformIssue],
+      true,
+    );
+    expect(hiddenPlatform).toBe(0);
+    expect(folded).toHaveLength(2);
+    expect(folded.map((i) => i.rule).sort()).toEqual([
+      'i18n/missing-metadataForm',
+      'i18n/missing-object',
+    ]);
+    expect(folded[1].severity).toBe('error');
+  });
+});


### PR DESCRIPTION
## 问题(15.1 第三方评估 P2 #2)

`os lint` 在 create-objectstack 新项目上开箱报 848 个错误(现版 821),全部是 `i18n/missing-metadataForm` —— 平台内置元数据表单(email_template 等)的翻译键,来自 lint 无条件遍历静态注册表(`DEFAULT_METADATA_TYPE_REGISTRY` + `METADATA_FORM_REGISTRY`)。这些翻译平台包(`packages/platform-objects` 的 4 个 locale bundle)在运行时本来就提供,对用户项目纯属噪声,把用户自己的 lint 信号完全淹没。

## 修复

「给平台补翻译」不适用——翻译已存在,只是 lint 把平台基线错算到用户项目头上。故收敛 lint 作用域:

- 新增 `foldCoverageIssues()`:`source === 'metadataForm'`(lint 时唯一且充分的平台判据,静态注册表遍历是它唯一来源)的问题默认隐藏并计数
- 新 flag `--include-platform` 恢复全量审计
- 人类输出加一行 dim 摘要:`platform built-ins: N i18n issue(s) hidden — rerun with --include-platform to audit them`
- `--json` 输出加 `hiddenPlatform` 字段
- 用户 authored 元数据(object/field/view/action)的 i18n 覆盖报告不变

## 真机验证(脚手架新项目)

| 命令 | 结果 |
|:--|:--|
| 发布版 `npx os lint` | 821 error(s),全是 metadataForm 噪声(复现) |
| 补丁版默认 | **4 error(s)**(用户自己对象的真实 i18n 信号)+ `platform built-ins: 817 i18n issue(s) hidden` |
| 补丁版 `--include-platform` | 821 error(s) |
| 补丁版 `--json` | `hiddenPlatform: 817`,`total: 4` |

单测:新增 `lint-platform-fold.test.ts`;`pnpm --filter @objectstack/cli test` 516 → 519 全绿(新增 lint-platform-fold 3 例);tsc build 干净。

注:blank 模板自身还有 4 条真实的用户侧 i18n 缺口(模板不带翻译 bundle),属于另一个模板 DX 问题,不在本 PR 扩散——已单独记 issue。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
