### PR TITLE
fix(cli): tolerate the `--` separator pnpm injects when forwarding script args (#3114)

### DIFF
--- a/.changeset/cli-strip-arg-separator.md
+++ b/.changeset/cli-strip-arg-separator.md
@@ -1,0 +1,30 @@
+---
+"@objectstack/cli": patch
+---
+
+fix(cli): tolerate the `--` separator pnpm injects when forwarding script args (#3114)
+
+The AGENTS.md-documented backend-debug flow `pnpm dev -- --fresh -p <port>` failed at
+the repo root with an opaque `Unexpected arguments: -p, 44637` (exit 2 + a help dump).
+
+pnpm appends forwarded args to a script **verbatim, including the `--`**, and each
+nested `pnpm --filter` hop preserves it, so the showcase's `objectstack dev
+--seed-admin` ran as `objectstack dev --seed-admin -- --fresh -p 44637`. oclif reads
+`--` as POSIX end-of-flags, so everything after it became positional: `--fresh` was
+silently swallowed as the `package` arg and `-p 44637` overflowed the arg list. Every
+flag the user asked for was dropped — the failure was opaque precisely because the
+`--` looks inert.
+
+A `preparse` hook now drops `--` separators before oclif parses argv, so the
+npm-style `-- <flags>` form and the bare form behave identically, for every command
+and both bins (`run.js`, `run-dev.js`). No `os` command takes passthrough args (none
+sets `strict = false`, none reads raw argv), so a `--` carries no meaning here and is
+always a package-manager artifact.
+
+Note this is not fixable via oclif's `'--': false` parser option: that keeps
+flag-parsing on past the separator but re-appends the `--` into argv, so strict
+commands fail with `Unexpected argument: --` instead.
+
+Tradeoff: a `-`-prefixed token can no longer be forced to parse as a positional
+value. Every `os` positional is a config path, a metadata / datasource / package
+name, or an id — none start with `-`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,9 @@
       "target": "./dist/commands",
       "glob": "**/*.js"
     },
+    "hooks": {
+      "preparse": "./dist/hooks/preparse/strip-arg-separator.js"
+    },
     "plugins": [
       "@oclif/plugin-help",
       "@oclif/plugin-plugins"

--- a/packages/cli/src/hooks/preparse/strip-arg-separator.test.ts
+++ b/packages/cli/src/hooks/preparse/strip-arg-separator.test.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { Parser } from '@oclif/core';
+import Dev from '../../commands/dev.js';
+import hook from './strip-arg-separator.js';
+
+/** Run the preparse hook the way oclif's Command.parse does. */
+const preparse = async (argv: string[]): Promise<string[]> =>
+  (await (hook as unknown as (opts: { argv: string[] }) => Promise<string[]>)({ argv })) ?? argv;
+
+const parseDev = (argv: string[]) =>
+  Parser.parse(argv, { flags: Dev.flags, args: Dev.args, strict: true });
+
+describe('preparse: strip `--` argument separators', () => {
+  it('drops a pnpm-injected separator', async () => {
+    expect(await preparse(['dev', '--seed-admin', '--', '--fresh', '-p', '44637'])).toEqual([
+      'dev',
+      '--seed-admin',
+      '--fresh',
+      '-p',
+      '44637',
+    ]);
+  });
+
+  it('leaves argv without a separator untouched', async () => {
+    const argv = ['dev', '--seed-admin', '--fresh', '-p', '44637'];
+    expect(await preparse(argv)).toEqual(argv);
+  });
+
+  it('does not touch flags that merely contain dashes', async () => {
+    const argv = ['dev', '--log-level', 'debug', '--admin-email', 'a@b.co'];
+    expect(await preparse(argv)).toEqual(argv);
+  });
+
+  // The actual bug (#3114): `pnpm dev -- --fresh -p <port>` reaches the CLI as
+  // `dev --seed-admin -- --fresh -p <port>`. Assert against the real Dev flags.
+  it('makes `os dev --seed-admin -- --fresh -p N` parse identically to the bare form', async () => {
+    const withSeparator = await parseDev(
+      await preparse(['--seed-admin', '--', '--fresh', '-p', '44637']),
+    );
+    const bare = await parseDev(['--seed-admin', '--fresh', '-p', '44637']);
+
+    expect(withSeparator.flags).toEqual(bare.flags);
+    expect(withSeparator.flags.fresh).toBe(true);
+    expect(withSeparator.flags['seed-admin']).toBe(true);
+    expect(withSeparator.flags.port).toBe('44637');
+    // `--fresh` must not be swallowed as the `package` positional.
+    expect(withSeparator.args.package).toBe('all');
+  });
+
+  it('regression: without the hook the same argv loses --fresh and throws', async () => {
+    await expect(parseDev(['--seed-admin', '--', '--fresh', '-p', '44637'])).rejects.toThrow(
+      /Unexpected argument/,
+    );
+  });
+});

--- a/packages/cli/src/hooks/preparse/strip-arg-separator.ts
+++ b/packages/cli/src/hooks/preparse/strip-arg-separator.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { Hook } from '@oclif/core';
+
+/**
+ * Drop `--` argument separators before oclif parses argv.
+ *
+ * pnpm appends forwarded args to a script *verbatim, including the `--`*, and
+ * every nested `pnpm --filter` hop preserves it. So the documented
+ * `pnpm dev -- --fresh -p 44637` reaches us as:
+ *
+ *   objectstack dev --seed-admin -- --fresh -p 44637
+ *
+ * oclif reads `--` as POSIX end-of-flags, so everything after it becomes
+ * positional: `--fresh` is silently swallowed as the `package` arg and the
+ * command dies with the opaque `Unexpected arguments: -p, 44637` (exit 2 +
+ * a help dump). The flags the user asked for are simply dropped.
+ *
+ * No `os` command takes passthrough args — none sets `strict = false`, and none
+ * reads raw argv — so a `--` carries no meaning here and is always a
+ * package-manager artifact. Dropping it makes the npm-style `-- <flags>` form
+ * and the bare form behave identically.
+ *
+ * The tradeoff: you can no longer force a `-`-prefixed token to be read as a
+ * positional value. Every `os` positional is a config path, a metadata /
+ * datasource / package name, or an id, none of which start with `-`. Revisit
+ * this if a command ever needs true passthrough (e.g. wrapping another CLI).
+ *
+ * Note this cannot be fixed with oclif's `'--': false` parser option: that
+ * option keeps flag-parsing on past the separator but then re-appends the `--`
+ * into argv, so strict commands fail with `Unexpected argument: --` instead.
+ */
+const hook: Hook<'preparse'> = async ({ argv }) => argv.filter((arg) => arg !== '--');
+
+export default hook;


### PR DESCRIPTION
Fixes #3114.

## The bug

The AGENTS.md-documented backend-debug flow fails at the repo root:

```
$ pnpm dev -- --fresh -p 44637
 ›   Error: Unexpected arguments: -p, 44637
Exit status 2   # + a help dump
```

This is the canonical multi-agent flow, so **every agent following AGENTS.md hits it**.

## Root cause

pnpm appends forwarded args to a script **verbatim, including the `--`**, and each nested `pnpm --filter` hop preserves it. Confirmed by isolating each hop:

| invocation | script receives |
|:---|:---|
| `pnpm run x -- --fresh -p N` | `-- --fresh -p N` ← **pnpm keeps the `--`** |
| `pnpm run x --fresh -p N` | `--fresh -p N` |
| `pnpm --filter c dev --fresh -p N` | clean — the filter hop is not the culprit |
| `pnpm --filter c dev -- --fresh -p N` | `--` preserved verbatim |

So the showcase's `objectstack dev --seed-admin` runs as:

```
objectstack dev --seed-admin -- --fresh -p 44637
```

oclif reads `--` as POSIX end-of-flags, so everything after it becomes **positional**. The failure is worse than the issue reports: `--fresh` is *silently swallowed as the `package` arg* (note the error only names `-p, 44637`), so even the flags oclif accepts are dropped. It's opaque precisely because the `--` looks inert.

## Fix

A `preparse` hook drops `--` separators before oclif parses argv — a single choke point covering **every command and both bins** (`run.js`, `run-dev.js`), including future commands.

No `os` command takes passthrough args (none sets `strict = false`, none reads raw argv), so a `--` carries no meaning here and is always a package-manager artifact.

### Why not the fix suggested in the issue

The issue proposed oclif's `'--'` passthrough option. **I tested it against the real parser — it does not work**, it just trades one error for another:

```
pnpm-injected --  | default        => ERR  Unexpected arguments: -p, 44637
pnpm-injected --  | '--': false    => ERR  Unexpected argument: --      ← still broken
pnpm-injected --  | preparse-strip => OK   fresh=true port=44637 package=all
```

`'--': false` keeps flag-parsing on past the separator but then re-appends the `--` into argv ([parse.js#L188](https://github.com/oclif/core/blob/main/src/parser/parse.ts)), so strict commands fail on it instead.

The docs need no change — this makes the documented row true. Keeping the `--` form is also the *safer* pnpm form: it guarantees pnpm forwards flags verbatim rather than eating ones that collide with its own.

### Tradeoff

A `-`-prefixed token can no longer be forced to parse as a positional value. Every `os` positional is a config path, a metadata/datasource/package name, or an id — none start with `-`. Noted in the hook for whoever adds a passthrough command later.

## Verification

Ran the exact documented command end-to-end. It is still **invoked with the `--` present** (`objectstack dev --seed-admin -- --fresh -p 44639`), yet all three flags now take effect:

```
  ✓ Server is ready
  ➜  API:       http://localhost:44639/          ← -p applied
  🔑  Dev admin: admin@objectos.ai / admin123     ← --seed-admin applied
  Driver:  SqlDriver(sqlite) → file:/var/.../T/objectstack-dev-do0JMm/data/dev.db   ← --fresh ephemeral tempdir
```

Live probe returned HTTP 401 from `/api/v1/meta/object` (server up, auth enforced); server torn down after.

- 5 new tests, asserted against the **real `Dev` command's flags** through oclif's actual parser — including a regression test proving the failure without the hook.
- `@objectstack/cli`: build/typecheck ✅ · lint ✅ · 538 tests ✅
- `dev:crm` / `dev:todo` use the same `objectstack dev` path and are fixed by the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)