### PR TITLE
docs(approvals): unblock main — drop duplicated role warning, generalize approver literal

### DIFF
--- a/content/docs/automation/approvals.mdx
+++ b/content/docs/automation/approvals.mdx
@@ -130,14 +130,11 @@ record is **locked** against edits while pending (`lockRecord`, default `true`),
 and the flow run parks until a decision arrives.
 
 Only `approvers` is required on the node; everything else has a default
-(`behavior: 'first_response'`, `lockRecord: true`, `maxRevisions: 3`).
-
-<Callout type="warn">
-**`type: 'role'` is not a position.** In an approver entry, `role` means the
-better-auth membership tier (`owner` / `admin` / `member`). Naming a business
-role like `sales_manager` there matches nobody and the request silently has no
-approvers — use `{ type: 'position', value: 'sales_manager' }`.
-</Callout>
+(`behavior: 'first_response'`, `lockRecord: true`, `maxRevisions: 3`). An
+approver entry that resolves to nobody is not an error: the request opens with
+an empty `pending_approvers` and nothing can move it, so the run parks forever.
+The approver-type trap that causes this is covered under
+**3. The approval node** above.
 
 ### The approver finds it in their queue
 
@@ -150,8 +147,10 @@ curl -b cookies.txt \
   "https://your-app.example.com/api/v1/approvals/requests?status=pending&approverId=usr_123"
 ```
 
-`approverId` accepts a user id, an email, or `role:<r>` — and takes several
-values (comma-separated or repeated) to cover a person's identities in one call.
+`approverId` accepts a user id, an email, or a `<type>:<value>` approver literal
+(`position:finance_manager` — the form an entry falls back to when it resolves
+to no users) — and takes several values (comma-separated or repeated) to cover
+a person's identities in one call.
 Other filters: `status`, `object`, `recordId`, `submitterId`, `q`, `limit`,
 `offset`.
 


### PR DESCRIPTION
## Why

`lint.yml` has been **red on `main`** since #3113 — the *Reserved-word ("role") docs ratchet* step fails, so **every open PR inherits it** (e.g. #3116). Reproduces from a clean `origin/main`:

```
check-role-word: 1 problem(s)
  • content/docs/automation/approvals.mdx: role-word count grew 5 → 9. New occurrences are banned (ADR-0090 D3).
```

#3113 added four occurrences to `content/docs/automation/approvals.mdx` without ratcheting the baseline.

## The decision: reword, not a baseline bump

Both obvious framings turned out to be wrong, so the evidence is worth stating.

**"`role` is deprecated, so reword it away" — false.** `role` is live and load-bearing:

- `packages/spec/src/automation/approval.zod.ts` still enumerates `'role'` **alongside** `'position'` in `ApproverType` — they coexist and mean different things; neither is a migration half.
- `packages/spec/src/automation/approval.test.ts` explicitly asserts `'role'` parses.
- `expandRoleUsers` resolves it against `sys_member.role` at runtime.
- No deprecation marker anywhere on it.

`role` here is the **better-auth org-membership tier** (`sys_member.role`: `owner`/`admin`/`member`) — precisely ADR-0090 D3's *single documented exception* ("third-party schema we do not own"). #2738 (216fa9ad2) did not deprecate it; it **added** `position` beside it and documented `role` as "the membership tier it actually is".

**"They're legitimate, so bump the baseline 5 → 9" — legitimate, but not necessary.** Three of the four are a near-verbatim **duplicate** of the callout 80 lines earlier, and that earlier one is *better* (it names the `approval-role-not-membership-tier` lint rule). The fourth was an over-narrow API description. The baseline is for occurrences that can't be removed **without losing accuracy** — these can.

## What changed

- **Removed the duplicated warning** in the lifecycle Steps. Kept the fact that section actually needs (an approver entry resolving to nobody parks the run forever — the *consequence*) and cross-referenced the authoritative warning under *3. The approval node*.
- **Generalized `approverId`**: it was documented as accepting `role:<r>`. The runtime falls back to a generic `` `${a.type}:${a.value}` `` literal for **every** approver type (`expandApprovers`), and `rest-server.ts` only splits on commas — it never validates the prefix. `<type>:<value>` is the real contract; `role:<r>` described one arbitrary instance of it.

Net: same information, one authoritative home, **no accuracy lost**, and the reserved-word surface shrinks back to 5 instead of freezing 4 avoidable occurrences. The surviving 5 are the one better-auth boundary callout — deliberately untouched, since renaming a third-party identifier we don't own would make the docs wrong.

## Verification

```
$ node scripts/check-role-word.mjs
check-role-word: OK (49 baselined file(s), no new occurrences).
```

`scripts/role-word-baseline.json` is **unmodified** — the diff is one file. The sibling `lint.yml` doc gates also pass locally:

- `check:doc-authoring` → `199 files clean`
- `check:release-notes` → `OK`

## Notes for the reviewer

- Docs-only → `skip-changeset`.
- ⚠️ There is an **uncommitted, unpushed** draft of the same fix in a sibling worktree on branch `fix/role-word-approvals` (no PR opened). It reaches a similar conclusion but cross-references a broken anchor (`#the-approval-node`; the heading is `### 3. The approval node`). If that agent is still active, close whichever of these lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)