### PR TITLE
docs(create-objectstack): correct a bogus issue reference in the pnpm-build-approvals comments

### DIFF
--- a/packages/create-objectstack/src/template-consistency.test.ts
+++ b/packages/create-objectstack/src/template-consistency.test.ts
@@ -74,10 +74,10 @@ describe('blank template manifest engines.protocol (ADR-0087 D1)', () => {
 
 // pnpm 11 turned an unapproved dependency build script from a warning into a
 // hard error, so the template declaring nothing meant `npx create-objectstack`
-// + `pnpm install` exited 1 for every user on a current pnpm (#3110). Both keys
+// + `pnpm install` exited 1 for every user on a current pnpm (#3119). Both keys
 // are load-bearing and read by different pnpm versions: pnpm 11 honours only
 // `allowBuilds`, while pnpm 10.0–10.30 understand only `onlyBuiltDependencies`.
-describe('blank template pnpm build approvals (#3110)', () => {
+describe('blank template pnpm build approvals (#3119)', () => {
   const wsPath = path.join(pkgRoot, 'src', 'templates', 'blank', 'pnpm-workspace.yaml');
   const APPROVED = ['better-sqlite3', 'esbuild'];
   // Strip comments: the prose below explains these keys and must not satisfy

--- a/scripts/publish-smoke.sh
+++ b/scripts/publish-smoke.sh
@@ -48,7 +48,7 @@
 # create-objectstack template needs updating. It has already happened once:
 # pnpm 11 turned unapproved build scripts from a warning into a hard error, so
 # every `npx create-objectstack` + `pnpm install` exited 1 until the template
-# started declaring `allowBuilds` (#3110).
+# started declaring `allowBuilds` (#3119).
 #
 # Usage:
 #   bash scripts/publish-smoke.sh
@@ -129,7 +129,7 @@ if [ "$SMOKE_MODE" = "pack" ]; then
   # Appending, not overwriting, is load-bearing: the template's build-approval
   # block (allowBuilds / onlyBuiltDependencies) is part of what a user gets, so
   # it has to be part of what this gate tests. This script used to hand-write
-  # the whole file, declaring the approvals itself — which is exactly how #3110
+  # the whole file, declaring the approvals itself — which is exactly how #3119
   # stayed invisible here: a locally-authored declaration proves nothing about
   # what the template ships.
   #


### PR DESCRIPTION
## What

#3119 cited **#3110** in four comments as the pnpm 11 build-approvals bug. That reference is wrong: **#3110 is "ObjectLogger file destination silently no-ops in ESM builds"** — unrelated, already closed, fixed by #3116.

The citation was fabricated on my part. The pnpm 11 scaffold breakage was found while diagnosing the red Publish Smoke gate and has **no issue of its own**, so the correct pointer is the PR that fixed it: #3119.

## Why it matters

Comment-only, but it left a wrong pointer in the two places most likely to be read by whoever next touches this:

- `scripts/publish-smoke.sh:51` — the "why is the smoke's pnpm deliberately unpinned" rationale, i.e. the exact spot someone lands on when a future pnpm major turns the gate red.
- `template-consistency.test.ts:80` — the ratchet guarding the template, where the describe name is what shows up in a failing test run.

Following either to #3110 leads to an ESM logger bug and wastes the reader's time.

## Verification

- `grep -rn 3110` over `scripts/publish-smoke.sh`, `packages/create-objectstack/`, `.changeset/` — no remaining references.
- `bash -n scripts/publish-smoke.sh` clean; `vitest run` 13/13.
- The template `pnpm-workspace.yaml` and the changeset never cited it, so nothing user-facing shipped with the bad reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)