### PR TITLE
docs(ai): connect-mcp — `api` actions have no headless dispatch either

### DIFF
--- a/content/docs/ai/connect-mcp.mdx
+++ b/content/docs/ai/connect-mcp.mdx
@@ -103,8 +103,10 @@ Two exposure rules to know:
   are blocked fail-closed.
 - **Actions require the author's opt-in**: `ai: { exposed: true }` plus an
   `ai.description` of at least 40 characters, and the action must be callable
-  without a UI (`script` with a body or registered handler, or `flow`).
-  See [Actions as Tools](/docs/ai/actions-as-tools) and
+  without a UI. In the open framework that means exactly two types — `script`
+  (with an inline body or a registered handler) and `flow` (with the automation
+  service registered). `url`, `modal`, `form`, and `api` have no headless
+  dispatch here. See [Actions as Tools](/docs/ai/actions-as-tools) and
   [Actions](/docs/ui/actions).
 
 ## The security model
@@ -148,7 +150,7 @@ skill and a guided `/objectstack:connect` command.
 | `501 Not Implemented` | The MCP plugin isn't part of this build — check your stack's plugins |
 | `401` on every call | Anonymous or invalid credentials. Interactive clients: complete the browser login (the `WWW-Authenticate` header advertises the OAuth metadata). Headless: check the `osk_` key and header spelling |
 | `403 insufficient_scope` | The OAuth token lacks the scope for that tool family (e.g. writes without `data:write`) — reconnect and grant the scope |
-| An action is missing from `list_actions` | `ai.exposed` is not `true`, `ai.description` is shorter than 40 characters, the type isn't headless-callable (`url` / `modal` / `form` never appear), it targets a `sys_*` object, or the caller fails its `requiredPermissions` |
+| An action is missing from `list_actions` | `ai.exposed` is not `true`, `ai.description` is shorter than 40 characters, the type isn't headless-callable here (only `script` with a body/handler and `flow` with an automation service are — `url`, `modal`, `form`, and `api` never appear), it targets a `sys_*` object, or the caller fails its `requiredPermissions` |
 | Reads return few rows / writes denied | Working as designed — the caller's permissions and RLS apply. Verify with the same user in the Console |
 
 ## Related


### PR DESCRIPTION
自查发现 #3093 新增的 `ai/connect-mcp.mdx` 有一处不完整:暴露规则与排错表把"永远不出现在 `list_actions`"的类型列为 `url`/`modal`/`form`,**漏了 `api`**。

源码 `packages/runtime/src/http-dispatcher.ts:895-901` `isHeadlessInvokableAction` 只放行两种:`script`(需 `target` 或 `body`)与 `flow`(需 `target` + automation 服务),**其余一律 false**——注释也明写 "UI-only types (`url`, `modal`, `form`) and `api` have no server dispatch here"。

(`api` 的 HTTP 派发只存在于 ObjectOS 的 bridge,`actions-as-tools.mdx:110` 已正确标注为 "**ObjectOS** runtime only",无需改。)

现改为正面表述:开源框架里恰好两种类型可 headless 调用,并列全不可调用的四种。

🤖 Generated with [Claude Code](https://claude.com/claude-code)