### PR TITLE
docs(approvals): drop reserved word "role" from lifecycle copy (ADR-0090 D3)

### DIFF
--- a/content/docs/automation/approvals.mdx
+++ b/content/docs/automation/approvals.mdx
@@ -130,14 +130,10 @@ record is **locked** against edits while pending (`lockRecord`, default `true`),
 and the flow run parks until a decision arrives.
 
 Only `approvers` is required on the node; everything else has a default
-(`behavior: 'first_response'`, `lockRecord: true`, `maxRevisions: 3`).
-
-<Callout type="warn">
-**`type: 'role'` is not a position.** In an approver entry, `role` means the
-better-auth membership tier (`owner` / `admin` / `member`). Naming a business
-role like `sales_manager` there matches nobody and the request silently has no
-approvers — use `{ type: 'position', value: 'sales_manager' }`.
-</Callout>
+(`behavior: 'first_response'`, `lockRecord: true`, `maxRevisions: 3`). An
+approver entry that resolves to no users falls back to a literal `<type>:<value>`
+slot that no one matches, so the request opens and then stalls — see the
+approver-type warning under [The approval node](#3-the-approval-node).
 
 ### The approver finds it in their queue
 
@@ -150,10 +146,10 @@ curl -b cookies.txt \
   "https://your-app.example.com/api/v1/approvals/requests?status=pending&approverId=usr_123"
 ```
 
-`approverId` accepts a user id, an email, or `role:<r>` — and takes several
-values (comma-separated or repeated) to cover a person's identities in one call.
-Other filters: `status`, `object`, `recordId`, `submitterId`, `q`, `limit`,
-`offset`.
+`approverId` accepts a user id, an email, or a `<type>:<value>` approver literal
+(`position:finance_manager`) — and takes several values (comma-separated or
+repeated) to cover a person's identities in one call. Other filters: `status`,
+`object`, `recordId`, `submitterId`, `q`, `limit`, `offset`.
 
 <Callout type="warn">
 **Opening a request notifies nobody.** There is no built-in "you have an


### PR DESCRIPTION
Fixes the red **Lint & Type Check** on `main`. Docs-only — hence `skip-changeset`.

## What broke

[#3113](https://github.com/objectstack-ai/framework/pull/3113) (`25a19be72`) added the approval-lifecycle walkthrough, including **4 new occurrences of the reserved word "role"** in `content/docs/automation/approvals.mdx` (5 → 9), without updating `scripts/role-word-baseline.json`. `pnpm check:role-word` has failed on **every push to main since** — the last 4 runs of `lint.yml` are red — so every open PR inherits a failing ESLint check and real failures are masked.

## Why not bump the baseline

Per **ADR-0090 D3** the word is *reserved-forbidden* and new occurrences are **banned**; `--update` exists to ratchet the baseline **down** when a file improves. So the baseline stays at **5** and the copy is reworded.

## The fix

**Three of the four were a duplicate.** The new callout under *The request opens, the run pauses* restated the already-baselined `position` vs `role` callout ~80 lines above it on the same page — which says the same thing in more detail (it names the `os lint` rule). Removed in favour of a cross-reference.

While rewording I also tightened the claim to match [`expandApprovers()`](https://github.com/objectstack-ai/framework/blob/main/packages/plugins/plugin-approvals/src/approval-service.ts): an unresolvable approver entry does **not** leave `pending_approvers` empty — it falls back to a literal `<type>:<value>` slot that no user matches, which is *why* the request stalls.

**The fourth** documented `approverId` accepting `role:<r>`. That literal is real, but it is one of several (`team:` / `department:` / `position:` / `role:` / `manager:`), so naming only the `role:` form was both off-vocabulary and needlessly narrow. Generalized to `<type>:<value>` with a `position:finance_manager` example, matching the page’s existing `finance_manager` sample.

**The surviving 5 are the documented D3 exception** — the better-auth boundary (`sys_member.role`), which the `role` approver type genuinely resolves against via `expandRoleUsers()`. Left untouched.

## Verification

- `pnpm check:role-word` → exit **0**, approvals.mdx back to **5**, `role-word-baseline.json` **unmodified**.
- `pnpm lint`, `check:doc-authoring`, `check:authz-resolver`, `check:release-notes` → all pass.
  <sub>(Local `eslint` OOMs at the default heap on node 25 — an environment artifact, not this change; it is clean under `--max-old-space-size=8192`, and CI runs node 20.)</sub>
- **Rendered the page in the docs site**: the `<Steps>` block keeps all 4 step headings after the callout removal, the reworded `approverId` sentence renders (`<type>:<value>` survives MDX as inline code), and the new `#3-the-approval-node` cross-reference resolves to the right heading — no console or server errors. Worth checking by hand since no CI job validates anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)