### PR TITLE
docs: remove stray -- from fresh-backend dev commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,14 +28,14 @@ pnpm docs:dev         # docs site
 | Scenario | Command | Notes |
 |:---|:---|:---|
 | **Frontend debug** (UI in `../objectui` calls backend) | `PORT=3000 pnpm dev` | `pnpm dev` = the **showcase** kitchen-sink app (default; best for exercising the platform). Port **must** be 3000 (UI hard-wired); persistent state; leave running. For the minimal CRM app instead: `PORT=3000 pnpm dev:crm`. |
-| **Backend-only debug** | `pnpm dev -- --fresh -p <random>` | Random high port; ephemeral tempdir; **you must kill it** when done |
+| **Backend-only debug** | `pnpm dev --fresh -p <random>` | Random high port; ephemeral tempdir; **you must kill it** when done |
 
 `--fresh`: ephemeral tempdir (auto-deleted on exit) + `--seed-admin` (POSTs sign-up, prints creds — default `admin@objectos.ai` / `admin123`, override via `--admin-email`/`--admin-password`). The seeded admin is auto-promoted to **platform admin** (the system seed identity `usr_system` is skipped), so Setup/Studio are reachable on first login.
 
-Rules: never run two backends on port 3000; for backend tasks pick a random port and tear it down; **never kill a server you didn't start** (other agents/the user may be using it — see Multi-agent discipline §8); always use a `pnpm dev`/`dev:crm`/`dev:showcase` script (flags after `--` are forwarded), not raw `pnpm --filter`.
+Rules: never run two backends on port 3000; for backend tasks pick a random port and tear it down; **never kill a server you didn't start** (other agents/the user may be using it — see Multi-agent discipline §8); always use a `pnpm dev`/`dev:crm`/`dev:showcase` script (flags are forwarded as-is — no `--` separator, pnpm passes it through and the CLI rejects it), not raw `pnpm --filter`.
 
 ```bash
-pnpm dev:crm -- --fresh -p 38421   # start; debug via curl
+pnpm dev:crm --fresh -p 38421      # start; debug via curl
 kill $(lsof -ti tcp:38421)         # tear down — tempdir auto-deletes
 ```
 
@@ -113,7 +113,7 @@ own worktree, operate defensively:
 8. **Testing needs a server? Start your own temporary one — never stop someone
    else's.** A running dev server you didn't start probably belongs to another
    agent or the user; killing it (or its port) breaks their in-flight work. Spin
-   up your own instance on a random high port (`pnpm dev -- --fresh -p <random>`)
+   up your own instance on a random high port (`pnpm dev --fresh -p <random>`)
    and **shut it down yourself when the task is done**
    (`kill $(lsof -ti tcp:<port>)`). Don't leave orphan servers behind.
 

--- a/content/docs/deployment/index.mdx
+++ b/content/docs/deployment/index.mdx
@@ -24,7 +24,7 @@ Use the repo scripts for framework development:
 
 ```bash
 OS_PORT=3000 pnpm dev
-pnpm dev:crm -- --fresh -p 38421
+pnpm dev:crm --fresh -p 38421
 pnpm docs:dev
 ```
 

--- a/content/docs/deployment/single-project-mode.mdx
+++ b/content/docs/deployment/single-project-mode.mdx
@@ -64,7 +64,7 @@ From the framework repo:
 OS_PORT=3000 pnpm dev
 # showcase example, persistent state, console at /_console
 
-pnpm dev:crm -- --fresh -p 38421
+pnpm dev:crm --fresh -p 38421
 # minimal CRM example with an ephemeral tempdir
 ```
 

--- a/docs/adr/0015-external-datasource-federation.md
+++ b/docs/adr/0015-external-datasource-federation.md
@@ -639,7 +639,7 @@ export default defineObject({
 os datasource validate warehouse
 # ✓ wh_order matches warehouse.mart.fact_orders (5/14 mapped, 9 unmapped — ok)
 
-pnpm dev:crm -- --fresh -p 38421
+pnpm dev:crm --fresh -p 38421
 # [info] external-validation: 1 datasource, 1 object, 0 mismatches
 ```
 


### PR DESCRIPTION
## Summary

The documented fresh-backend command `pnpm dev -- --fresh -p <port>` fails: pnpm passes the `--` separator through to the script verbatim, so the CLI receives `objectstack dev --seed-admin -- --fresh -p <port>`, treats everything after `--` as positional arguments, and exits with `Unexpected arguments: -p, <port>` (exit code 2) before binding the port.

This PR removes the stray `--` from every documented occurrence (6 commands across 4 files) and fixes the AGENTS.md note that claimed "flags after `--` are forwarded" — that claim was the root cause of the wrong examples.

- **AGENTS.md**: dev-server table, forwarding note, `dev:crm` example, multi-agent discipline §8
- **content/docs/deployment/index.mdx** and **single-project-mode.mdx**: local runtime examples
- **docs/adr/0015-external-datasource-federation.md**: example command in the validation walkthrough

## Verification

- With `--`: reproduced — CLI prints usage and exits 2 (matches the issue's 2/2 failures).
- Without `--`: `pnpm --filter @objectstack/example-showcase dev --fresh -p 38423` boots a fresh backend; `/api/v1/health` returns 200. Server torn down after verification.
- `grep -rn -- '-- --fresh'` over AGENTS.md, content/, docs/ returns no matches.

Docs-only change; no CLI or runtime behavior touched.

Fixes #2801

🤖 Generated with [Claude Code](https://claude.com/claude-code)