### PR TITLE
fix(spec): resolve multi-line and .js imports in skill-reference resolver (#3139)

### DIFF
--- a/packages/spec/scripts/build-skill-references.ts
+++ b/packages/spec/scripts/build-skill-references.ts
@@ -122,13 +122,24 @@ const SKILL_MAP: Record<string, string[]> = {
 function extractLocalImports(filePath: string): string[] {
   const content = fs.readFileSync(filePath, 'utf-8');
   const imports: string[] = [];
-  const re = /^import\s+.*\s+from\s+['"](\.[^'"]+)['"]/gm;
+  const dir = path.dirname(filePath);
+  // Match `import … from '<relative>'`, tolerating a multi-line import clause.
+  // The clause between `import` and `from` never contains a `;`, quote, or `(`,
+  // so excluding those keeps the non-greedy span from bridging across a
+  // statement boundary, a side-effect import (`import './x'`), or a dynamic
+  // `import(...)` into the wrong specifier. A plain `.` (the old pattern) does
+  // not cross newlines, so multi-line named imports were silently dropped.
+  const re = /^import\b[^;'"()]*?\bfrom\s*['"](\.[^'"]+)['"]/gm;
   let match: RegExpExecArray | null;
   while ((match = re.exec(content)) !== null) {
     const importSpec = match[1];
-    const dir = path.dirname(filePath);
     let resolved = path.resolve(dir, importSpec);
-    if (!resolved.endsWith('.ts')) resolved += '.ts';
+    // ESM specifiers may carry a `.js` extension that maps to a `.ts` source
+    // (`./types.js` → `./types.ts`); otherwise append `.ts` for an
+    // extensionless local specifier. Blindly appending `.ts` turned `.js`
+    // imports into a non-existent `foo.js.ts` that was then dropped.
+    if (resolved.endsWith('.js')) resolved = resolved.slice(0, -3) + '.ts';
+    else if (!resolved.endsWith('.ts')) resolved += '.ts';
     if (fs.existsSync(resolved)) {
       imports.push(path.relative(SPEC_SRC, resolved));
     }

--- a/skills/objectstack-platform/references/_index.md
+++ b/skills/objectstack-platform/references/_index.md
@@ -33,6 +33,7 @@ from `node_modules` — there is no local copy in the skill bundle.
 - `node_modules/@objectstack/spec/src/shared/identifiers.zod.ts` — System Identifier Schema
 - `node_modules/@objectstack/spec/src/shared/lazy-schema.ts` — Wrap a Zod schema constructor so its body is only evaluated on first use.
 - `node_modules/@objectstack/spec/src/shared/protection.zod.ts` — Package-level metadata protection (ADR-0010 §3.7 — Phase 4.3)
+- `node_modules/@objectstack/spec/src/system/tenant.zod.ts` — Tenant Schema (Multi-Tenant Architecture)
 - `node_modules/@objectstack/spec/src/ui/action.zod.ts` — Action Parameter Schema
 - `node_modules/@objectstack/spec/src/ui/app.zod.ts` — Base Navigation Item Schema
 - `node_modules/@objectstack/spec/src/ui/i18n.zod.ts` — I18n Object Schema


### PR DESCRIPTION
Fixes #3139.

## Problem

`extractLocalImports` in `packages/spec/scripts/build-skill-references.ts` builds each skill's transitive Zod-schema closure by scanning `import … from` statements. It had two blind spots that silently under-reported dependencies:

1. **Multi-line imports** — the pattern `/^import\s+.*\s+from\s+…/gm` uses `.`, which does not match newlines, so a named import that wraps across lines was never seen:
   ```ts
   import {
     FooSchema,
   } from './foo.zod';   // invisible to the resolver
   ```
2. **`.js` ESM specifiers** — the resolver appended `.ts` unconditionally, so `./types.js` became a non-existent `./types.js.ts`, failed `fs.existsSync`, and was dropped.

Both failure modes drop the dep with no warning — the file simply never enters the queue, and `skills/*/references/_index.md` (shipped to third parties via `npx skills add`) ends up advertising an incomplete schema graph.

## Fix

- Replace the regex with a multi-line-tolerant scan: `/^import\b[^;'"()]*?\bfrom\s*['"](\.[^'"]+)['"]/gm`. Excluding `;`, quotes, and `(` between `import` and `from` keeps the non-greedy span from bridging across a statement boundary, a side-effect import (`import './x'`), or a dynamic `import(...)` into the wrong specifier.
- Normalize `.js` specifiers to `.ts` before resolving (`./types.js` → `./types.ts`), instead of blindly appending `.ts`.

The regex was validated against single-line, multi-line, `type`-only, namespace, default+named, `.js`, side-effect, dynamic-import, commented-out, and bare-module (`'zod'`) cases — only the genuine relative imports are captured.

## Regenerated output

Ran `gen:skill-refs` with the fix in place. Exactly one new dependency surfaces across all skills: the **platform** skill now lists `system/tenant.zod.ts`, reached through the previously-invisible `.js` import in `kernel/context.zod.ts` (`import { TenantQuotaSchema } from '../system/tenant.zod.js'`) — confirming real reachability from a `SKILL_MAP` closure, which the issue flagged as worth checking. The other multi-line imports the issue enumerated are real but not reachable from any `SKILL_MAP` entry, so they produce no drift.

The `check:skill-refs` gate added in #3138 passes (`8 generated files in sync with packages/spec`).

## Notes

Per AGENTS.md, no changeset is included — this is a pure bug fix (the sibling #3138 in the same area likewise carried none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTjm38Bo2xUv1UUPWu4mC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTjm38Bo2xUv1UUPWu4mC5)_