### PR TITLE
ci(publish-smoke): surface the app's resolved pnpm + build approvals before install (#3124)

### DIFF
--- a/scripts/publish-smoke.sh
+++ b/scripts/publish-smoke.sh
@@ -171,6 +171,26 @@ console.log(
 );
 EOF
 
+  # Diagnostics for the ERR_PNPM_IGNORED_BUILDS failure class (#3124). The
+  # scaffolded app declares NO packageManager field (deliberately — see the
+  # header), so the `pnpm` that runs HERE is NOT this repo's pinned 10.31.0:
+  # with corepack enabled, corepack resolves the LATEST pnpm for a directory
+  # with no pin (11.x today). That divergence is the whole reason #3124's local
+  # repro (pnpm 10.31/10.33 both honor the allowlist) never reproduced the CI
+  # red — CI runs a stricter pnpm major. Print the resolved version, the
+  # build-approval config pnpm actually parsed, and the file it parsed it from,
+  # so any future red run answers "which pnpm, and did it see the approvals?"
+  # on its own. Never let a diagnostic fail the smoke (|| true).
+  log "pnpm environment inside the app (no packageManager pin — corepack resolves latest)"
+  ( cd "$APP_DIR"
+    echo "  pnpm --version: $(pnpm --version 2>&1)"
+    echo "  build-approval config pnpm resolved (onlyBuiltDependencies):"
+    pnpm config list 2>/dev/null | grep -iE 'only-built|built-dependencies|strict-dep-builds' | sed 's/^/    /' \
+      || echo "    (no build-related config keys reported)"
+    echo "  pnpm-workspace.yaml as written:"
+    sed 's/^/    /' pnpm-workspace.yaml
+  ) || true
+
   log "Installing (pnpm, tarball-pinned)"
   (cd "$APP_DIR" && pnpm install --no-frozen-lockfile)
 


### PR DESCRIPTION
Closes #3124.

## What was actually happening

The `Publish Smoke` gate died at the smoke app's install with
`[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: better-sqlite3@…, esbuild@…`
— for the *exact two packages the allowlist names* — and it never reproduced
locally (pnpm 10.31.0 / 10.33.0 both honor the allowlist and exit 0).

The missing fact, confirmed by local reproduction here:

- The scaffolded app declares **no `packageManager` field** (deliberate — the
  gate must test what a *fresh user's* pnpm resolves, not this repo's pin).
- With `corepack enable` (the workflow does this), corepack resolves the
  **latest pnpm for a directory with no pin** — **pnpm 11.x**, not the repo's
  pinned `10.31.0`. Verified: `corepack pnpm --version` inside a `/tmp` app
  with no pin → `11.14.0`, while the same command in the repo → `10.31.0`.
- pnpm 11 turned an unapproved build script from a **warning into a hard
  error**. So the gate's local repro (pnpm 10.x, only warns) could never see
  the CI red (pnpm 11, hard error).

The app-side fix — declaring `allowBuilds` / `onlyBuiltDependencies` in the
scaffolded template so a fresh install passes on pnpm 11 — already landed in
**#3119**. I reproduced the full current flow (template `pnpm-workspace.yaml`
+ the script's appended `overrides:` block, `corepack pnpm@11.14.0`, fresh
store, `CI=true`, transitive `better-sqlite3` + direct `esbuild`) and it now
builds both and exits 0. The `ERR_PNPM_IGNORED_BUILDS` cause is resolved.

## What this PR adds

The one thing #3124 explicitly asked to land first — **visibility**. Right
before the tarball-pinned install, the script now prints, *from inside the app
dir*:

- `pnpm --version` — so the pnpm/corepack version divergence is never invisible
  again;
- the build-approval keys pnpm **actually resolved** (`only-built-dependencies`,
  which pnpm derives from either `allowBuilds` or `onlyBuiltDependencies`), so a
  red run answers "did pnpm even see the approvals?" directly;
- the `pnpm-workspace.yaml` as written.

Diagnostics only, wrapped in `|| true` — they can never fail the smoke. No
behavior change to the install itself.

## Testing

- `bash -n scripts/publish-smoke.sh` — clean.
- Ran the diagnostic block against a representative app dir; it prints the
  resolved version, the `only-built-dependencies[]` entries pnpm parsed from
  both approval keys, and the workspace file.
- Faithful install repro on `corepack pnpm@11.14.0` (fresh store, `CI=true`)
  with the current template + appended overrides: both `esbuild` and a
  transitive `better-sqlite3` build, exit 0 — the `ERR_PNPM_IGNORED_BUILDS`
  failure does not recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MN39HnZs8M92iDGqAMcvsK)_