### PR TITLE
feat(spec): add userActions.refresh toggle to ListView (objectui#2634)

### DIFF
--- a/content/docs/references/ui/page.mdx
+++ b/content/docs/references/ui/page.mdx
@@ -56,7 +56,7 @@ Interface-level page configuration (Airtable parity)
 | **sourceView** | `string` | optional | @deprecated Legacy named-view inheritance. Define columns/sort/filterBy on the page instead. |
 | **appearance** | `{ showDescription: boolean; allowedVisualizations?: Enum<'grid' \| 'kanban' \| 'gallery' \| 'calendar' \| 'timeline' \| 'gantt' \| 'map' \| 'chart' \| 'tree'>[] }` | optional | Appearance and visualization configuration |
 | **userFilters** | `{ element: Enum<'dropdown' \| 'tabs' \| 'toggle'>; fields?: { field: string; label?: string; type?: Enum<'select' \| 'multi-select' \| 'boolean' \| 'date-range' \| 'text'>; options?: { value: string \| number \| boolean; label: string; color?: string }[]; … }[]; tabs?: { name: string; label?: string; icon?: string; view?: string; … }[]; showAllRecords?: boolean }` | optional | End-user quick-filter bar for this page (overrides the source view's userFilters) |
-| **userActions** | `{ sort: boolean; search: boolean; filter: boolean; rowHeight: boolean; … }` | optional | User action toggles |
+| **userActions** | `{ sort: boolean; search: boolean; filter: boolean; refresh: boolean; … }` | optional | User action toggles |
 | **addRecord** | `{ enabled: boolean; position: Enum<'top' \| 'bottom' \| 'both'>; mode: Enum<'inline' \| 'form' \| 'modal'>; formView?: string }` | optional | Add record entry point configuration |
 | **buttons** | `string[]` | optional | Toolbar buttons — names of the source object's actions to surface in the page toolbar |
 | **recordAction** | `Enum<'drawer' \| 'page' \| 'modal' \| 'none'>` | optional | How clicking a record opens its detail (drawer \| page \| modal \| none). Default: drawer |

--- a/content/docs/references/ui/view.mdx
+++ b/content/docs/references/ui/view.mdx
@@ -374,7 +374,7 @@ List chart view configuration
 | **conditionalFormatting** | `{ condition: string \| { dialect: Enum<'cel' \| 'js' \| 'cron' \| 'template'>; source?: string; ast?: any; meta?: object }; style: Record<string, string> }[]` | optional | Conditional formatting rules for list rows |
 | **inlineEdit** | `boolean` | optional | Allow inline editing of records directly in the list view |
 | **exportOptions** | `Enum<'csv' \| 'xlsx' \| 'pdf' \| 'json'>[]` | optional | Available export format options |
-| **userActions** | `{ sort?: boolean; search?: boolean; filter?: boolean; rowHeight?: boolean; … }` | optional | User action toggles for the view toolbar |
+| **userActions** | `{ sort?: boolean; search?: boolean; filter?: boolean; refresh?: boolean; … }` | optional | User action toggles for the view toolbar |
 | **appearance** | `{ showDescription?: boolean; allowedVisualizations?: Enum<'grid' \| 'kanban' \| 'gallery' \| 'calendar' \| 'timeline' \| 'gantt' \| 'map' \| 'chart' \| 'tree'>[] }` | optional | Appearance and visualization configuration |
 | **tabs** | `{ name: string; label?: string; icon?: string; view?: string; … }[]` | optional | Tab definitions for multi-tab view interface |
 | **addRecord** | `{ enabled?: boolean; position?: Enum<'top' \| 'bottom' \| 'both'>; mode?: Enum<'inline' \| 'form' \| 'modal'>; formView?: string }` | optional | Add record entry point configuration |
@@ -462,7 +462,7 @@ List chart view configuration
 | **conditionalFormatting** | `{ condition: string \| { dialect: Enum<'cel' \| 'js' \| 'cron' \| 'template'>; source?: string; ast?: any; meta?: object }; style: Record<string, string> }[]` | optional | Conditional formatting rules for list rows |
 | **inlineEdit** | `boolean` | optional | Allow inline editing of records directly in the list view |
 | **exportOptions** | `Enum<'csv' \| 'xlsx' \| 'pdf' \| 'json'>[]` | optional | Available export format options |
-| **userActions** | `{ sort?: boolean; search?: boolean; filter?: boolean; rowHeight?: boolean; … }` | optional | User action toggles for the view toolbar |
+| **userActions** | `{ sort?: boolean; search?: boolean; filter?: boolean; refresh?: boolean; … }` | optional | User action toggles for the view toolbar |
 | **appearance** | `{ showDescription?: boolean; allowedVisualizations?: Enum<'grid' \| 'kanban' \| 'gallery' \| 'calendar' \| 'timeline' \| 'gantt' \| 'map' \| 'chart' \| 'tree'>[] }` | optional | Appearance and visualization configuration |
 | **tabs** | `{ name: string; label?: string; icon?: string; view?: string; … }[]` | optional | Tab definitions for multi-tab view interface |
 | **addRecord** | `{ enabled?: boolean; position?: Enum<'top' \| 'bottom' \| 'both'>; mode?: Enum<'inline' \| 'form' \| 'modal'>; formView?: string }` | optional | Add record entry point configuration |
@@ -584,6 +584,7 @@ User action toggles for the view toolbar
 | **sort** | `boolean` | ✅ | Allow users to sort records |
 | **search** | `boolean` | ✅ | Allow users to search records |
 | **filter** | `boolean` | ✅ | Allow users to filter records |
+| **refresh** | `boolean` | ✅ | Allow users to reload the view data from the backend without a full page reload |
 | **rowHeight** | `boolean` | ✅ | Allow users to toggle row height/density |
 | **addRecordForm** | `boolean` | ✅ | Add records through a form instead of inline |
 | **editInline** | `boolean` | ✅ | Allow users to edit records inline — click a cell to edit it with the field's type-aware widget (the same control the form uses). Off by default: the list is read-only unless the author opts in. |

--- a/packages/spec/liveness/view.json
+++ b/packages/spec/liveness/view.json
@@ -41,7 +41,7 @@
         "conditionalFormatting": { "status": "live", "note": "objectui: ObjectGrid.tsx (audit L15)." },
         "inlineEdit": { "status": "live", "note": "objectui: ObjectGrid.tsx (audit L15)." },
         "exportOptions": { "status": "live", "note": "objectui: ObjectGrid.tsx (audit L15)." },
-        "userActions": { "status": "live", "note": "objectui: ListView.tsx:374 toolbarFlags (search/sort/filters/density/hide-fields/group/color + addRecordForm). Sub-key userActions.buttons has NO reader (audit L20, re-verified objectui@fb35e48) — dead sub-surface, enforce-or-remove worklist." },
+        "userActions": { "status": "live", "note": "objectui: ListView.tsx:374 toolbarFlags (search/sort/filters/refresh/density/hide-fields/group/color + addRecordForm). Sub-key userActions.refresh drives the manual toolbar Refresh button (objectui#2634). Sub-key userActions.buttons has NO reader (audit L20, re-verified objectui@fb35e48) — dead sub-surface, enforce-or-remove worklist." },
         "appearance": { "status": "live", "note": "objectui: allowedVisualizations gates the view-type switcher (audit L15); showDescription gates ListView.tsx:1728." },
         "tabs": { "status": "live", "note": "objectui: TabBar.tsx — icon/visible/pinned/filter wired (audit L15). Sub-key tabs[].order is NOT used for sorting (audit L20) — dead sub-surface." },
         "addRecord": { "status": "live", "note": "objectui: ListView.tsx:374 (addRecord + userActions.addRecordForm drive the add-record flow). Sub-keys addRecord.mode / addRecord.formView have NO reader (audit L20, re-verified objectui@fb35e48) — dead sub-surface." },

--- a/packages/spec/src/ui/view.test.ts
+++ b/packages/spec/src/ui/view.test.ts
@@ -2126,6 +2126,7 @@ describe('UserActionsConfigSchema', () => {
     expect(config.sort).toBe(true);
     expect(config.search).toBe(true);
     expect(config.filter).toBe(true);
+    expect(config.refresh).toBe(true);
     expect(config.rowHeight).toBe(true);
     expect(config.addRecordForm).toBe(false);
     expect(config.editInline).toBe(false);
@@ -2335,11 +2336,13 @@ describe('ListViewSchema — Airtable Interface parity fields', () => {
         sort: true,
         search: true,
         filter: false,
+        refresh: false,
         rowHeight: false,
       },
     });
     expect(listView.userActions?.sort).toBe(true);
     expect(listView.userActions?.filter).toBe(false);
+    expect(listView.userActions?.refresh).toBe(false);
   });
 
   it('should accept list view with appearance', () => {

--- a/packages/spec/src/ui/view.zod.ts
+++ b/packages/spec/src/ui/view.zod.ts
@@ -240,6 +240,7 @@ export const UserActionsConfigSchema = lazySchema(() => z.object({
   sort: z.boolean().default(true).describe('Allow users to sort records'),
   search: z.boolean().default(true).describe('Allow users to search records'),
   filter: z.boolean().default(true).describe('Allow users to filter records'),
+  refresh: z.boolean().default(true).describe('Allow users to reload the view data from the backend without a full page reload'),
   rowHeight: z.boolean().default(true).describe('Allow users to toggle row height/density'),
   addRecordForm: z.boolean().default(false).describe('Add records through a form instead of inline'),
   editInline: z.boolean().default(false).describe('Allow users to edit records inline — click a cell to edit it with the field\'s type-aware widget (the same control the form uses). Off by default: the list is read-only unless the author opts in.'),


### PR DESCRIPTION
## Background

The ListView `UserActionsConfig` exposes toolbar toggles for `sort` / `search` / `filter` / `rowHeight` / `addRecordForm` / `editInline`, but had **no toggle for a manual data-refresh action**. Consumers therefore had no spec-canonical way to declare/gate a "reload the list without a full page reload" affordance (objectui#2634).

## Change

- **`src/ui/view.zod.ts`** — add `refresh: z.boolean().default(true)` to `UserActionsConfigSchema`, alongside the existing toggles (allows opt-out; visible by default).
- **`src/ui/view.test.ts`** — assert the default (`true`) and that `userActions.refresh: false` round-trips.
- **`liveness/view.json`** — update the `userActions` liveness note to record `refresh` as a live sub-key (consumed by objectui `ListView.tsx` toolbar; objectui#2634).

## Consumer

objectui's `ListView` reads `userActions.refresh` to gate its new toolbar Refresh button — see `objectstack-ai/objectui` branch `claude/defect-list-refresh-entry-i9qw1s`. That side ships independently of a spec release (runtime-defensive read + legacy `showRefresh` fallback); this PR makes the toggle first-class in the protocol so the type layer aligns after publish.

## Verification

- `packages/spec` full test suite: 6895 passed ✅
- `check:liveness`: all governed-type properties classified ✅
- `check:spec-changes`: up to date ✅
- No generated-artifact drift (`api-surface.json` tracks public exports, unaffected by an internal field; docs/skill-refs don't enumerate `userActions` sub-keys)

## Related

- objectui#2634

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7Z2cbcb14wb99upTD6LNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7Z2cbcb14wb99upTD6LNw)_