### PR TITLE
test(showcase): exercise the spec bare-string sort form on a real list view

### DIFF
--- a/examples/app-showcase/src/ui/views/task.view.ts
+++ b/examples/app-showcase/src/ui/views/task.view.ts
@@ -98,6 +98,13 @@ export const TaskViews = defineView({
         { field: 'estimate_hours' },
       ],
 
+      // @objectstack/spec ListViewSchema.sort accepts a bare STRING
+      // ("field [asc|desc]"), not only the {field,order}[] array form. This
+      // is the exact shape that used to crash the renderer with
+      // "schema.sort.map is not a function" (objectui#2601) — kept here as a
+      // live coverage fixture so a real list view exercises the string form.
+      sort: 'estimate_hours desc',
+
       // ADR-0053 — NO `userFilters` here: on an object list view ("views"
       // mode) the console suppresses them by design (the view switcher is
       // the only nav control; objectui warns since #2220). End-user filter


### PR DESCRIPTION
## Summary

Regression fixture from the browser verification of the ListView bare-string sort fix (objectstack-ai/objectui#2601).

The spec↔objectui shape-mismatch audit that produced #2601 found the showcase had **zero** list views using `@objectstack/spec` `ListViewSchema.sort`'s bare **string** form (`"field [asc|desc]"`) — every view used the `{field, order}[]` array form. That gap is exactly why the `"schema.sort.map is not a function"` crash lurked undetected through green unit tests: nothing in the running app exercised the string shape.

This adds `sort: 'estimate_hours desc'` to the Task List (`tabular`) view — one line — so the string form is now exercised by any browser dogfood or coverage pass over the showcase.

## Browser verification (latest main, both repos)

Reproduced end-to-end against a live stack (framework backend + objectui console dev, both on latest `main`):

- backend boots with **zero errors** — the bare-string sort passes spec load-time validation;
- `GET /api/v1/meta/view/showcase_task` confirms the server sends `sort: "estimate_hours desc"` as a **plain string** (the exact shape that crashed pre-#2601 objectui);
- the Task List renders 10 records with **no crash, no error boundary, no `sort.map` error**, and the Estimate column is correctly **descending**: 60 → 40 → 30 → 24 → 20 → 18 → 16 → 16 → 12 → 8. The toolbar Sort control shows "1" active sort.

## Testing

- `pnpm test` in `examples/app-showcase` — 55/55 passing.
- No changeset — `@objectstack/example-showcase` is private/unpublished.

Refs objectstack-ai/objectui#2601, objectstack-ai/objectui#2578

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HG5LQnPbQbjAAyofghzz3Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG5LQnPbQbjAAyofghzz3Z)_