### PR TITLE
fix(vscode): drop invalid `ownership: 'own'` from object snippet; document the field (#3175)

### DIFF
--- a/content/docs/data-modeling/objects.mdx
+++ b/content/docs/data-modeling/objects.mdx
@@ -262,6 +262,7 @@ indexes: [
 | `abstract` | `boolean` | Abstract base, cannot be instantiated (default: `false`) |
 | `sharingModel` | `enum` | Org-Wide Default record visibility (ADR-0055/0056/0090). Canonical four only: `'private'`, `'public_read'`, `'public_read_write'`, `'controlled_by_parent'` (detail visibility derived from its master). The legacy aliases (`'read'`, `'read_write'`, `'full'`) were removed from the enum (ADR-0090 D4) — authoring rejects them. Unset on a custom object resolves to `'private'` (ADR-0090 D1) |
 | `keyPrefix` | `string` | Short prefix for record IDs (e.g. `'001'`) |
+| `ownership` | `enum` | Record-ownership model: `'user'` (default — injects the reassignable `owner_id` lookup, engaging owner-scoped RLS, "My" views and owner reports), `'org'`, or `'none'` (no per-record owner — Dataverse-style catalog / junction tables, skips `owner_id`). Distinct from the package `own`/`extend` contribution kind. |
 | `validations` | `ValidationRule[]` | Object-level validation rules (see [Validation](/docs/data-modeling/validation)) |
 
 ## Naming Conventions

--- a/packages/vscode-objectstack/snippets/objectstack.json
+++ b/packages/vscode-objectstack/snippets/objectstack.json
@@ -9,7 +9,6 @@
       "  name: '${2:my_object}',",
       "  label: '${3:My Object}',",
       "  pluralLabel: '${3:My Object}s',",
-      "  ownership: 'own',",
       "  fields: {",
       "    name: {",
       "      type: 'text',",


### PR DESCRIPTION
## Context

Follow-up to #3185 (#3175). That PR made `ownership` a typed `'user' | 'org' | 'none'` enum and removed the now-invalid `ownership: 'own'` from the CLI `generate` scaffold — but the **VS Code `os-object` snippet** carried the same value and was missed. Expanding the snippet produced an object that fails typecheck / `ObjectSchema.create()` with the new enum.

## Changes

- **vscode** — remove the `ownership: 'own'` line from the `os-object` snippet (owner injection is the default; nothing to declare). This was the last authorable surface still emitting the invalid value — a repo sweep confirms none remain outside historical CHANGELOG entries and the unrelated package-contribution (`own`/`extend`) records.
- **docs** — document the now first-class `ownership` record-ownership knob in the object *Additional Properties* table (`content/docs/data-modeling/objects.mdx`). The generated reference (`object.mdx`) was already updated in #3185; no other hand-written doc referenced the field, so nothing else needed correcting.

No library/runtime change — a tooling snippet fix plus a docs row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014343Qv6DFAykuAJc9yjANb

---
_Generated by [Claude Code](https://claude.ai/code/session_014343Qv6DFAykuAJc9yjANb)_