### PR TITLE
feat(runtime): seed-replayer reports `skipped` so hosts can stamp seed-once on progress (cloud#853)

### DIFF
--- a/.changeset/seed-replayer-skipped.md
+++ b/.changeset/seed-replayer-skipped.md
@@ -1,0 +1,19 @@
+---
+"@objectstack/runtime": patch
+---
+
+feat(runtime): seed-replayer reports `skipped` so hosts can stamp seed-once on progress
+
+The `seed-replayer` kernel service returned `{ inserted, updated, errors }` but
+not `skipped`. A cloud host therefore could not tell an **all-skip replay**
+(the env's seed data is already present — a no-op) apart from the
+zero-summary early-returns that never ran the loader (no organization, no
+metadata service, no datasets). Both looked like `inserted = updated = 0`, so
+the host could not safely stamp its seed-once record for the all-skip case and
+re-ran the full remote replay on every cold boot.
+
+Add `skipped: result.summary.totalSkipped` to the replayer's return; the
+early-returns report `skipped: 0`. This lets a host (cloud#853's
+`decideSeedStamp`) stamp on progress — including an all-skip replay — while
+still declining to stamp a genuine no-loader zero-summary. Additive and
+backward compatible; existing consumers ignore the new field.

--- a/packages/runtime/src/app-plugin.ts
+++ b/packages/runtime/src/app-plugin.ts
@@ -765,17 +765,17 @@ export class AppPlugin implements Plugin {
                  const metadataNow = ctx.getService('metadata') as IMetadataService | undefined;
                  const loggerRef = ctx.logger;
                  const replayer = async (organizationId: string) => {
-                     if (!organizationId) return { inserted: 0, updated: 0, errors: [] as any[] };
+                     if (!organizationId) return { inserted: 0, updated: 0, skipped: 0, errors: [] as any[] };
                      const md = metadataNow ?? (ctx.getService('metadata') as IMetadataService | undefined);
                      if (!md) {
                          loggerRef.warn('[seed-replayer] metadata service unavailable');
-                         return { inserted: 0, updated: 0, errors: [] as any[] };
+                         return { inserted: 0, updated: 0, skipped: 0, errors: [] as any[] };
                      }
                      const datasetsNow = (() => {
                          try { return kernel?.getService?.('seed-datasets'); } catch { return merged; }
                      })() ?? merged;
                      if (!Array.isArray(datasetsNow) || datasetsNow.length === 0) {
-                         return { inserted: 0, updated: 0, errors: [] as any[] };
+                         return { inserted: 0, updated: 0, skipped: 0, errors: [] as any[] };
                      }
                      const seedLoader = new SeedLoaderService(ql, md, loggerRef);
                      const { SeedLoaderRequestSchema } = await import('@objectstack/spec/data');
@@ -796,6 +796,12 @@ export class AppPlugin implements Plugin {
                      return {
                          inserted: result.summary.totalInserted,
                          updated: result.summary.totalUpdated,
+                         // `skipped` lets a cloud host distinguish an all-skip
+                         // replay (data already present) from the zero-summary
+                         // early-returns above (which never ran the loader), so
+                         // it can stamp its seed-once record on progress rather
+                         // than re-replaying every cold boot (cloud#853).
+                         skipped: result.summary.totalSkipped,
                          errors: result.errors,
                      };
                  };


### PR DESCRIPTION
## Summary

Tiny enabling change for **cloud#853** (already merged, forward-compatible): the `seed-replayer` kernel service now reports `skipped`.

The replayer returned `{ inserted, updated, errors }`. A cloud host consuming it (cloud's `decideSeedStamp`) could not tell an **all-skip replay** — the env's seed data is already present, a no-op — apart from the zero-summary *early-returns* that never ran the loader (no organization, no metadata service, no datasets). Both read as `inserted = updated = 0`, so the host could not safely stamp its seed-once record for the all-skip case, and re-ran the full remote seed replay on **every cold boot**.

## Change

```diff
   const result = await seedLoader.load(request);
   return {
     inserted: result.summary.totalInserted,
     updated: result.summary.totalUpdated,
+    skipped: result.summary.totalSkipped,
     errors: result.errors,
   };
```

- The main return adds `skipped` (a `SeedLoadResult.summary` field already consumed elsewhere in this file, at the inline-seed log).
- The three zero-summary early-returns (no org / no metadata / no datasets) now report `skipped: 0`, so a host can distinguish "loader ran, everything already present" (`skipped > 0` → stamp) from "loader never ran" (`skipped: 0` → don't stamp).

This closes the all-skip case of cloud#853 end-to-end: with a `.framework-sha` bump, cloud's `decideSeedStamp` (already merged, already honors `skipped`) stamps once and stops re-replaying, while still declining a genuine no-loader zero summary.

Additive and backward compatible — existing consumers (`organizations-plugin`) ignore the new field.

## Verification

- `pnpm --filter @objectstack/runtime build` — typecheck clean.
- `pnpm --filter @objectstack/runtime test` — 554/554 pass.

No dedicated replayer-service test is added: the codebase has none (the service is registered inside `AppPlugin`'s boot closure with no injection seam), the change is a one-line pass-through of an already-consumed summary field, and the consumer (`decideSeedStamp`) is fully unit-tested on the cloud side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APnSDJneEDRh3Z51KGCLga

---
_Generated by [Claude Code](https://claude.ai/code/session_01APnSDJneEDRh3Z51KGCLga)_