### PR TITLE
fix(identity): close generic-write apiMethods hole on sys_presence & sys_metadata (#3220)

### DIFF
--- a/.changeset/reconcile-system-append-only-api-methods.md
+++ b/.changeset/reconcile-system-append-only-api-methods.md
@@ -1,0 +1,33 @@
+---
+"@objectstack/service-realtime": patch
+"@objectstack/metadata-core": patch
+---
+
+fix(identity): close the generic-write apiMethods hole on sys_presence and sys_metadata (#3220)
+
+Follow-through on #1591/#3213 (better-auth apiMethods reconciliation) for two
+non-better-auth managed objects that shipped the same contradiction: their
+`enable.apiMethods` advertised generic `create`/`update`/`delete` while their
+`managedBy` bucket forbids user-context writes, leaving the generic `/data`
+route open to a write the bucket does not permit.
+
+- `sys_presence` (`managedBy: 'append-only'`) advertised `create`/`update`/`delete`
+  (update/delete on an append-only object at that) but is written only over the
+  realtime websocket/in-memory path, never through ObjectQL. Narrowed to
+  `['get', 'list']`.
+- `sys_metadata` (`managedBy: 'system'`) advertised full CRUD but customization
+  overlays are authored only through the metadata-protocol RPC (engine writes
+  carry a transaction context, not a user session); neither the framework nor
+  the Console (objectui) POSTs `/data/sys_metadata`. Narrowed to `['get', 'list']`.
+
+Reads stay open. The metadata-protocol / realtime write paths are engine-level
+and bypass the HTTP exposure gate, so they are unaffected — verified by the
+metadata-authoring dogfood and the objectql overlay tests.
+
+A blast-radius audit confirmed the broader `system`/`append-only` buckets are NOT
+safe to guard wholesale: several `system` objects (`sys_user_position`,
+`sys_user_permission_set`, `sys_position_permission_set`, `sys_user_preference`,
+`sys_import_job`) are legitimately user-writable by design (delegated
+administration, user preferences, imports). Generalizing the engine write guard
+to those buckets is intentionally NOT done here — see #3220 for the bucket-taxonomy
+root cause.

--- a/packages/metadata-core/src/objects/sys-metadata.object.ts
+++ b/packages/metadata-core/src/objects/sys-metadata.object.ts
@@ -227,7 +227,13 @@ export const SysMetadataObject = ObjectSchema.create({
     trackHistory: true,
     searchable: false,
     apiEnabled: true,
-    apiMethods: ['get', 'list', 'create', 'update', 'delete'],
+    // #3220 — sys_metadata is `managedBy: 'system'`: customization overlays are
+    // authored ONLY through the metadata-protocol RPC (its engine writes carry a
+    // transaction context, not a user session), never the generic /data route.
+    // Neither the framework nor the Console (objectui) POSTs /data/sys_metadata,
+    // so the generic write verbs were a latent hole for a user-context raw write
+    // the bucket forbids. Reads stay open for the Setup "Data Model" grids.
+    apiMethods: ['get', 'list'],
     trash: false,
   },
 

--- a/packages/services/service-realtime/src/objects/sys-presence.object.test.ts
+++ b/packages/services/service-realtime/src/objects/sys-presence.object.test.ts
@@ -70,4 +70,12 @@ describe('SysPresence object definition', () => {
   it('should have API enabled', () => {
     expect(SysPresence.enable?.apiEnabled).toBe(true);
   });
+
+  it('exposes reads only — append-only, written over the realtime path, never /data (#3220)', () => {
+    expect(SysPresence.enable?.apiMethods).toEqual(['get', 'list']);
+    // Guard against re-introducing a generic write verb on an append-only object.
+    for (const verb of ['create', 'update', 'delete', 'upsert']) {
+      expect(SysPresence.enable?.apiMethods).not.toContain(verb);
+    }
+  });
 });

--- a/packages/services/service-realtime/src/objects/sys-presence.object.ts
+++ b/packages/services/service-realtime/src/objects/sys-presence.object.ts
@@ -113,7 +113,13 @@ export const SysPresence = ObjectSchema.create({
     trackHistory: false,
     searchable: false,
     apiEnabled: true,
-    apiMethods: ['get', 'list', 'create', 'update', 'delete'],
+    // #3220 — sys_presence is `managedBy: 'append-only'` and is written only
+    // over the realtime (websocket/in-memory) path, never through ObjectQL.
+    // Advertising create/update/delete here (and update/delete on an
+    // append-only object at that) was a latent hole: it left the generic
+    // /data route open for a user-context write the bucket forbids. Reads
+    // stay open for diagnostic list views.
+    apiMethods: ['get', 'list'],
     trash: false,
     mru: false,
   },


### PR DESCRIPTION
Addresses the concrete, safe slice of #3220 (the follow-through on #1591/#3213). A blast-radius audit determined the broad engine-level write guard over `system`/`append-only` is **not** worth building — near-zero real security gain, high regression risk to delegated administration — so this PR ships only the two genuine latent holes the audit confirmed.

## What & why

Two non-better-auth managed objects shipped the exact contradiction #3213 fixed for better-auth objects: `enable.apiMethods` advertised generic `create`/`update`/`delete` while their `managedBy` bucket forbids user-context writes — leaving the generic `/data` route open for a write the bucket does not permit.

- **`sys_presence`** (`managedBy: 'append-only'`) advertised `create`/`update`/`delete` — `update`/`delete` on an *append-only* object — but is written only over the realtime websocket/in-memory path, **never through ObjectQL**. → `['get', 'list']`.
- **`sys_metadata`** (`managedBy: 'system'`) advertised full CRUD, but customization overlays are authored only through the **metadata-protocol RPC** (its engine writes carry a transaction context, not a user session). Confirmed neither the framework nor the Console (**objectui**) POSTs `/data/sys_metadata`. → `['get', 'list']`.

Reads stay open. The metadata-protocol / realtime write paths are engine-level and bypass the HTTP exposure gate, so they are unaffected.

## Why not the broader guard

The audit found the `system` bucket is **overloaded**: several `system` objects are user-writable *by design* — `sys_user_position`, `sys_user_permission_set`, `sys_position_permission_set` (the whole `DelegatedAdminGate` is built on non-`isSystem` user writes), plus `sys_user_preference` and `sys_import_job`. A blanket affordance-driven engine guard would break delegated administration for near-zero gain (the genuinely engine-only tables already write via `isSystem`, and the key audit tables — `sys_audit_log`/`sys_activity` — are already `['get','list']`). The real fix is a bucket-taxonomy split, tracked as the root cause in #3220.

## Verification

- `service-realtime` sys-presence object suite (10 passed) — new assertion pins `apiMethods === ['get','list']` and rejects re-introducing a write verb.
- `metadata-core` (100 passed); `objectql` overlay engine-insert tests (6 passed) — confirm `sys_metadata` engine writes still work (they bypass the HTTP gate).
- **Metadata-authoring dogfood** `package-first-authoring` (5 passed) — end-to-end customization authoring unaffected.

Refs #3220. Follows #3213 / ADR-0049 / ADR-0092.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwY68hKVysP98BX7i5eUoE)_