### PR TITLE
feat(cli): surface the MCP endpoint in the server-ready banner (#3167)

### DIFF
--- a/.changeset/mcp-dev-connect-hint.md
+++ b/.changeset/mcp-dev-connect-hint.md
@@ -1,0 +1,13 @@
+---
+'@objectstack/cli': patch
+---
+
+feat(cli): surface the MCP endpoint in the server-ready banner (#3167)
+
+The MCP server (`/api/v1/mcp`) is a default-on core capability, but nothing in
+the `os dev` / `os serve` boot output pointed to it — a developer had to already
+know it was there to connect an AI client. The server-ready banner now prints
+the MCP URL and the `SKILL.md` pointer whenever the surface is enabled
+(`isMcpServerEnabled()`, the same switch that auto-loads the plugin and gates
+the route), so an agent can operate the running app straight from the dev loop.
+Hidden when `OS_MCP_SERVER_ENABLED=false`.

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -2455,6 +2455,11 @@ export default class Serve extends Command {
         multiTenant: resolveMultiOrgEnabled(),
         seededAdmin,
         automation: automationSummary,
+        // #3167 — surface the default-on MCP endpoint in the dev loop, where an
+        // AI client can connect to operate the running app. Same decision point
+        // that auto-loads the plugin + gates the route, so the banner never
+        // advertises an endpoint that isn't served.
+        mcpEnabled: isMcpServerEnabled(),
       });
 
       // ── Publish the actually-bound port ────────────────────────────

--- a/packages/cli/src/utils/format.ts
+++ b/packages/cli/src/utils/format.ts
@@ -203,6 +203,14 @@ export interface ServerReadyOptions {
    * armed. Collected from the live engine after runtime.start().
    */
   automation?: AutomationReadySummary;
+  /**
+   * Whether the MCP server surface (`/api/v1/mcp`) is on (#3167). Default-on
+   * core capability, but nothing in the dev loop surfaces it — an AI client
+   * (Claude Code, Cursor, …) can operate the running app the instant a
+   * developer knows the endpoint is there. The banner is where they look, so
+   * print the URL + the SKILL.md pointer when it's live.
+   */
+  mcpEnabled?: boolean;
 }
 
 export interface AutomationReadySummary {
@@ -232,6 +240,10 @@ export function printServerReady(opts: ServerReadyOptions) {
   console.log(chalk.cyan('  ➜') + chalk.bold('  API:       ') + chalk.cyan(base + '/'));
   if (opts.uiEnabled && opts.consolePath) {
     console.log(chalk.cyan('  ➜') + chalk.bold('  Console:   ') + chalk.cyan(base + opts.consolePath + '/'));
+  }
+  if (opts.mcpEnabled) {
+    console.log(chalk.cyan('  ➜') + chalk.bold('  MCP:       ') + chalk.cyan(base + '/api/v1/mcp'));
+    console.log(chalk.dim(`      connect an AI client (Claude Code, Cursor, …) · skill: ${base}/api/v1/mcp/skill`));
   }
   if (opts.seededAdmin) {
     console.log('');


### PR DESCRIPTION
#3167 的最后一项(可选 DX)。也是这条线**最初动机的兑现**:#3167 开篇讲的就是 *"discoverability is zero exactly where the platform's pitch is strongest — the dev loop"*——MCP 端点默认开着、能用、还自我广播(RFC 9728 + `/mcp/skill`),但 `os dev` / `os serve` 的启动输出里**没有任何指引**,开发者得先知道它在才连得上。

## 变更

`printServerReady` 横幅在 MCP 启用时多打一行 URL + `SKILL.md` 指引:

```
  ✓ Server is ready

  ➜  API:       http://localhost:3000/
  ➜  MCP:       http://localhost:3000/api/v1/mcp
      connect an AI client (Claude Code, Cursor, …) · skill: http://localhost:3000/api/v1/mcp/skill
```

- 门控在 `isMcpServerEnabled()`——**与自动加载插件、门住路由的同一决策点**,所以横幅绝不会广播一个没在服务的端点;`OS_MCP_SERVER_ENABLED=false` 时不显示。
- 与横幅既有的 API / Console 行同风格,归在端点 URL 组。

## 验证
运行时验证:开→渲染 URL + skill 行;关→无 MCP 行(见下)。CLI 构建干净、lint 干净、changeset(`@objectstack/cli` patch)。

```
=== mcpEnabled: true ===
  ➜  MCP:       http://localhost:3000/api/v1/mcp
      connect an AI client (Claude Code, Cursor, …) · skill: http://localhost:3000/api/v1/mcp/skill
=== mcpEnabled: false ===
  (无 MCP 行)
```

合并后 **#3167 的四个决策 + 可选 DX 全部完成**,建议随之关闭 #3167。

Refs #3167、#3202、#3225。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pbmw3pMqNJfPbkvwh9Fkjs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pbmw3pMqNJfPbkvwh9Fkjs)_