### PR TITLE
docs(adr): ADR-0101 — MCP stdio principal admission (env API-key identity, fail-closed, no system bypass)

### DIFF
--- a/docs/adr/0101-mcp-stdio-principal-admission.md
+++ b/docs/adr/0101-mcp-stdio-principal-admission.md
@@ -1,0 +1,152 @@
+# ADR-0101: MCP stdio Principal Admission — env-supplied API-key identity, fail-closed, no system bypass
+
+**Status**: Proposed (2026-07-19)
+**Deciders**: ObjectStack Protocol Architects
+**Builds on**: [ADR-0096](./0096-execution-surface-identity-admission.md) (execution-surface identity admission — this ADR closes its last unadmitted transport), [ADR-0024](./0024-mcp-connectors.md) §4 (trust model), [ADR-0036](./0036-app-as-rest-api-and-mcp-server.md) (the app *as* an MCP server — the surface being admitted), [ADR-0099](./0099-posture-adjudicated-tiering-and-external-rung.md) (posture rides the `ExecutionContext` this ADR threads)
+**Composes with**: framework#3055 (consume-side declarative stdio **spawn** policy — the sibling trust decision: #3055 gates *who may start* a local MCP process from metadata; this ADR gates *as whom* our own stdio server reads data), [ADR-0097](./0097-declarative-connector-instances.md)
+**Tracking**: framework#3246 (v1 implementation) · framework#3167 (parent decision issue — deferred this) · PR #3217 / #3228 (PR-B, landed: switch split + HTTP e2e proof)
+**Consumers**: `@objectstack/mcp` (`MCPServerPlugin.start()`, `bridgeResources`), `@objectstack/core` (`resolveApiKeyPrincipal` / `resolveAuthzContext` — the shared verify chain), `@objectstack/qa` dogfood (`mcp-stdio-authority` matrix row)
+
+---
+
+## TL;DR
+
+The long-lived MCP **stdio** transport bridges the RAW metadata service + data
+engine with **no per-request principal** — a stdio-attached client reads
+metadata and records with full, unscoped authority (no RLS / FLS / tenant).
+The `mcp-stdio-authority` conformance row records this as `experimental` with
+an explicit ADMISSION REQUIREMENT before stdio can ever be promoted or served
+beyond a single-operator local tool.
+
+Three decisions close it:
+
+1. **D1 — stdio's identity is an env-supplied API key.** `OS_MCP_STDIO_API_KEY=osk_...`
+   is resolved through the **one shared verify chain** (`@objectstack/core`
+   `resolveApiKeyPrincipal` → `resolveAuthzContext`, the same path the HTTP
+   dispatcher and REST use), yielding the `ExecutionContext` every stdio data
+   read runs under. Re-resolved **per call**, so revocation applies to a live
+   session.
+2. **D2 — fail-closed.** stdio auto-start without a valid key **refuses to
+   start** (loud configuration fault). The HTTP surface is unaffected.
+3. **D3 — there is NO `system` bypass mode.** Full authority is obtained the
+   same way any authority is: provision an identity (platform admin, or better
+   a dedicated service identity) and mint a key for it. A supplied credential —
+   never a mode that skips identity.
+
+## Context
+
+Two transports, two postures — pinned by ADR-0096's matrix (rows added in
+PR #3202, #3167 PR-A):
+
+- **HTTP `/api/v1/mcp`** — `enforced`: `handleMcp` denies anonymous (401),
+  OAuth scopes narrow tool families, `buildMcpBridge(context)` threads the
+  caller `ExecutionContext` into every data op. End-to-end proven
+  (`showcase-mcp-http-identity.dogfood.test.ts`, PR #3228).
+- **stdio** — `experimental`: `MCPServerPlugin.start()` bridges resources onto
+  the long-lived server from the raw services. The `record_by_id` resource
+  calls `dataEngine.findOne(...)` with **no context** — RLS/FLS/tenant never
+  run. Opt-in only (`OS_MCP_STDIO_ENABLED` / `autoStart`, split from the HTTP
+  switch in PR #3217 precisely because the shared switch silently attached
+  this unscoped transport).
+
+Today's posture is *bounded*: stdio is opt-in, local, single-operator — whoever
+can attach stdio already owns the process and its dev database. This ADR is
+not an incident response; it is the hardening that must precede any promotion
+(default-on, multi-user, hosted) and the removal of the platform's last
+identity-less execution path.
+
+### Why the transport itself stays credential-less (and that is correct)
+
+The MCP specification splits the problem into two layers:
+
+- **Transport auth (client ↔ server)**: HTTP transports SHOULD implement the
+  MCP Authorization spec; **stdio SHOULD NOT** — the server is a child process
+  of the client, and transport trust is inherited from local process execution.
+  We comply: no OAuth handshake is added to stdio.
+- **Backend identity (server ↔ data)**: the spec's guidance is that stdio
+  servers take credentials **from the environment** and act with *that
+  credential's* authority. This is exactly how the ecosystem's backend-shaped
+  servers behave: a Postgres MCP server connects with the supplied role's
+  grants (superuser only if you supplied superuser); the GitHub MCP server acts
+  as the PAT's user with the PAT's scopes. Anthropic's own agent-identity model
+  is the same shape — agents run under **admin-provisioned, scoped, revocable
+  service identities**, never an identity-less full-authority mode.
+
+ObjectStack's stdio today is *weaker than all of these*: it demands no
+credential and grants full authority. The native ObjectStack analogue of
+`POSTGRES_PASSWORD` / `GITHUB_TOKEN` is an **`osk_` API key**. Use it.
+
+## Decisions
+
+### D1 — `OS_MCP_STDIO_API_KEY` is the stdio principal, resolved via the shared chain
+
+At `MCPServerPlugin.start()` (stdio auto-start path only):
+
+- Read `OS_MCP_STDIO_API_KEY`. Resolve it through
+  `resolveApiKeyPrincipal(ql, { 'x-api-key': key })` →
+  `resolveAuthzContext(...)` in `@objectstack/core` — the **same** verify +
+  context chain the HTTP dispatcher and REST `/data` use (`@objectstack/mcp`
+  already depends on `core`; no new auth surface is invented).
+- Build the `ExecutionContext` mirroring the runtime's
+  `resolve-execution-context` mapping (userId, tenantId, permissions →
+  posture per ADR-0099), and thread it into a **principal-bound resource
+  bridge**: `record_by_id` and every other data-touching resource goes through
+  the engine **with `{ context }`** — never the raw `dataEngine`.
+- **Per-call re-resolution**: each resource read re-verifies the key (indexed
+  at-rest-hash lookup — cheap). A revoked or expired key takes effect on the
+  next call of a *live* stdio session, matching HTTP semantics. No long-lived
+  cached authority.
+
+### D2 — Fail-closed on a missing/invalid key
+
+`OS_MCP_STDIO_ENABLED=true` (or `autoStart`) **without** a resolvable key is a
+configuration fault: stdio does not start, the error says exactly how to mint
+a key (Setup → Connect an Agent, or `POST /api/v1/keys`). The HTTP surface —
+default-on, independently admitted — is untouched. Fall-open (start unscoped
+anyway) is exactly the ADR-0096 failure class this ADR exists to remove.
+
+### D3 — No `system` bypass (rejected alternative: `OS_MCP_STDIO_IDENTITY=system`)
+
+A configurable "run as system" mode was considered as a local-dev escape hatch
+and **rejected**. Against the native alternative — mint a key for a
+platform-admin or dedicated service identity — it is strictly worse:
+
+| | admin/service `osk_` key | `OS_MCP_STDIO_IDENTITY=system` |
+|---|---|---|
+| Audit | attributable to a real identity/key | synthetic `system`, attributable to no one |
+| Revocation | revoke the key, access ends | no credential to revoke; edit config + restart |
+| Rotation / expiry | supported (`sys_api_key`) | none |
+| Scope | that identity's grants, under posture rules (ADR-0099) | `isSystem` skips *everything*, incl. the tenant wall |
+| Nature | a supplied credential (industry shape) | an RLS bypass switch |
+
+The deeper reason: "run as superuser" in the Postgres analogy means *you
+supplied a superuser credential* — it does not mean *the server offers a mode
+that skips authentication and disables RLS*. No mainstream backend MCP server
+ships the latter. And `OS_MCP_SERVER_ENABLED=true` silently attaching an
+unscoped transport was the footgun PR #3217 just closed; a blessed
+`IDENTITY=system` env var recreates it with a nicer name. Naming a fall-open
+does not make it not a fall-open.
+
+Full authority remains available — by provisioning it: mint a key for a
+platform-admin identity, or (better, matching the agent-identity pattern) a
+dedicated service identity with exactly the grants the agent needs.
+
+## Consequences
+
+- **`mcp-stdio-authority` graduates** `experimental` → `enforced` when #3246
+  lands: the surface admits a declared principal, fail-closed. The
+  `bridgeResources(metadataService, dataEngine)` probe key goes STALE by
+  design — the re-classification this forces in CI *is* the change.
+- **Bootstrap friction, accepted**: a fresh database needs a minted key before
+  stdio can start (log in once, mint). Same class as "create a role before
+  connecting to Postgres". The common dev loop is unaffected — the HTTP
+  surface (OAuth as the dev admin, principal-bound, default-on) already covers
+  "point a coding agent at the running app", and `os dev` prints exactly that.
+- **v2 conveniences (tracked in #3246, not blocking)**: `os dev` may auto-mint
+  and print a local, scoped, revocable dev key from the seeded dev-admin — a
+  credential, not a bypass — and named service identities / restricted
+  permission sets + rotation guidance address the static-token failure mode.
+- **One identity model across transports**: HTTP = per-request caller
+  credential; stdio = per-process env credential; both resolve through the
+  same chain to the same `ExecutionContext` shape. Every future transport
+  inherits the rule: *no principal, no data*.


### PR DESCRIPTION
## What & why

记录关闭平台**最后一个无身份执行面**的决策:长驻 MCP **stdio** 传输——它把裸 metadata 服务 + data engine 桥到长驻 server(`record_by_id` resource 直接 `dataEngine.findOne(...)`,无 ExecutionContext → 绕过 RLS/FLS/租户)。这正是 `mcp-stdio-authority` 矩阵行 note 里写明的 ADMISSION REQUIREMENT。

**纯文档(ADR),Status: Proposed**——先把决策摆上桌评审;实现(v1)单独走,tracked in **#3246**。

## 三个决策

- **D1**:stdio 的身份 = env 供给的 API key(`OS_MCP_STDIO_API_KEY`),经 `@objectstack/core` 与 HTTP/REST **同一条** verify 链解析成 EC,线进每次 stdio 数据读(逐调用重解析,吊销即时生效)。
- **D2**:**fail-closed**——开了 stdio auto-start 但无有效 key → 拒绝启动 stdio;HTTP 面不受影响。
- **D3**:**不提供 `system` 旁路**。要满权就给平台管理员/专用 service 身份 mint 一个 key(可审计、可吊销、可轮换、按 posture scope),而不是一个跳过身份的开关。ADR 里用一张对比表 + "naming a fall-open doesn't make it not a fall-open" 记录了否决理由,避免半年后有人重新发明 `OS_MCP_STDIO_IDENTITY=system`。

## 三方证据(ADR 内引用)

MCP 规范(stdio 不做传输认证、后端凭据从 env 供给)· Postgres/GitHub MCP server(按供给凭据 scope,superuser 也得显式供给)· Anthropic agent-identity 模型(admin 预置的 scoped、可吊销 service 身份)。ObjectStack 当前 stdio 比这三者都松(无凭据即满权)——本决策把它拉齐。

## 关系

- 扩展 [ADR-0096](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0096-execution-surface-identity-admission.md)(执行面身份准入);与消费侧 stdio spawn 策略门 #3055 是同一信任讨论的两半(#3055 管"谁能启动本地进程",本 ADR 管"我们自己的 stdio server 以谁的身份读数据")。
- 承接 #3167(母题决策,PR-B 已由 #3217 / #3228 落地);本项是 #3167 明确 defer 的最后一块。

## 验收

ADR 合入 = 决策 Accepted;随后 #3246 落地 v1 时 `mcp-stdio-authority` 从 `experimental` → `enforced`。

Refs #3246(实现)、#3167、#3217、#3228、#3055、ADR-0096、ADR-0036。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115eg8dAaCfWaDYYAm3ma36

---
_Generated by [Claude Code](https://claude.ai/code/session_0115eg8dAaCfWaDYYAm3ma36)_