### PR TITLE
test(objectql): guard overlay-only cross-package collision provenance (ADR-0048 #1828)

### DIFF
--- a/packages/objectql/src/protocol-meta.test.ts
+++ b/packages/objectql/src/protocol-meta.test.ts
@@ -891,6 +891,30 @@ describe('ObjectStackProtocolImplementation - Metadata Persistence', () => {
             expect(byPkg['com.globex.crm']).toBe('Globex (overlay)');
         });
 
+        it('keeps both colliding rows when NEITHER package ships an artifact — overlay-only (ADR-0048 #1828)', async () => {
+            // The case unit tests missed and dogfooding caught: two packages with
+            // ONLY a sys_metadata overlay each (NO registered artifact — registry
+            // stays empty for `page`). The list-decorate step grafts each row's
+            // artifact via getArtifactItem(type, name, <row's own package>); with no
+            // composite artifact it must NOT fall back to the OTHER package's
+            // bare-key hydrated overlay, or both rows get stamped with the
+            // last-hydrated package's `_packageId` (the exact provenance bug the
+            // getArtifactItem package-scope fix closes).
+            mockEngine.find.mockResolvedValue([
+                { type: 'page', name: 'home', state: 'active', package_id: 'com.acme.crm', metadata: JSON.stringify({ name: 'home', label: 'Acme home' }) },
+                { type: 'page', name: 'home', state: 'active', package_id: 'com.globex.crm', metadata: JSON.stringify({ name: 'home', label: 'Globex home' }) },
+            ]);
+
+            const result = await protocol.getMetaItems({ type: 'page' });
+            const homes = (result.items as any[]).filter((i) => i.name === 'home');
+
+            expect(homes).toHaveLength(2);
+            const byPkg = Object.fromEntries(homes.map((h: any) => [h._packageId, h.label]));
+            // Each row keeps its OWN package — not both stamped with one id.
+            expect(byPkg['com.acme.crm']).toBe('Acme home');
+            expect(byPkg['com.globex.crm']).toBe('Globex home');
+        });
+
         it('single-package env-wide (package-less) overlay still overlays the artifact (ADR-0005 unchanged, #1828)', async () => {
             // A package-less overlay (package_id IS NULL) must still WIN over the
             // one artifact it customizes and stay a single row — the package-aware


### PR DESCRIPTION
Test-only follow-up to #3231 (ADR-0048 #1828, already merged).

## Why

#3231 fixed the unscoped metadata list collapse **and** a provenance bug in `SchemaRegistry.getArtifactItem` — but that second bug was invisible to the unit suite and only surfaced by dogfooding a real collision against the running server. The unit tests added in #3231 all register a backing **artifact** for the colliding name, so the list-decorate step resolves each row's provenance via the composite artifact and never exercises the bare-key fallback that was broken.

This adds the missing case so the fix is locked at the unit level.

## What

A `getMetaItems` test with two packages that have **only** a `sys_metadata` overlay each (no registered artifact) shipping the same `type/name`:

- The list-decorate step grafts each row's artifact via `getArtifactItem(type, name, <row's own package>)`.
- With no composite artifact, it must **not** fall back to the *other* package's bare-key hydrated overlay — otherwise both rows get stamped with the last-hydrated package's `_packageId`.

Reverting the `getArtifactItem` package-scope guard fails this test (`expected 'Globex home' to be 'Acme home'`), so it genuinely guards the fix — not a vacuous assertion.

## Verification

- `protocol-meta.test.ts` — **78 passed** (the new test + the existing #1828 suite).
- Negative check: with the `getArtifactItem` guard reverted, the new test fails as expected; restored → green.

Test-only; no runtime change, so no changeset (the PR carries `skip-changeset`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKFjwN2EVXPB2CJwNzPs8c

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKFjwN2EVXPB2CJwNzPs8c)_