### PR TITLE
fix(spec): declare summaryOperations sub-fields in the Field metadata form (#3257)

### DIFF
--- a/.changeset/field-form-summary-subfields.md
+++ b/.changeset/field-form-summary-subfields.md
@@ -1,0 +1,16 @@
+---
+'@objectstack/spec': patch
+---
+
+fix(spec): declare `summaryOperations` sub-fields in the Field metadata form (#3257)
+
+`fieldForm` (the registered metadata form for editing a Field) previously
+declared `summaryOperations` as a bare `composite` with no sub-fields, so a
+protocol-driven renderer had to fall back to a raw JSON editor. It now declares
+the inner shape explicitly — `object` (`ref:object`), `function` (select),
+`field`, `relationshipField`, and `filter` (bound to `widget: 'filter-condition'`)
+— mirroring the `summaryOperations` Zod schema and surfacing the roll-up `filter`
+added in #1868. Also gates the block to `data.type == 'summary'`.
+
+Small step toward #3257 (making the Studio field designer metadata-driven rather
+than hand-coded); the live objectui inspector already edits these fields.

--- a/packages/spec/src/data/field.form.ts
+++ b/packages/spec/src/data/field.form.ts
@@ -56,7 +56,35 @@ export const fieldForm = defineForm({
       collapsed: true,
       fields: [
         { field: 'expression', widget: 'textarea', helpText: 'CEL expression to calculate this field (makes it read-only)' },
-        { field: 'summaryOperations', type: 'composite', helpText: 'Roll-up summary configuration (for parent-child relationships)' },
+        {
+          field: 'summaryOperations',
+          type: 'composite',
+          visibleWhen: "data.type == 'summary'",
+          helpText: 'Roll-up summary configuration (for parent-child relationships)',
+          // Declare the composite's inner shape so the protocol-driven form
+          // renders structured sub-fields (not a raw JSON blob). Mirrors the
+          // `summaryOperations` Zod schema in field.zod.ts; `filter` is bound to
+          // the FilterCondition widget so only matching child rows aggregate.
+          fields: [
+            { field: 'object', widget: 'ref:object', required: true, helpText: 'Child object to aggregate' },
+            {
+              field: 'function',
+              type: 'select',
+              required: true,
+              options: [
+                { label: 'Count', value: 'count' },
+                { label: 'Sum', value: 'sum' },
+                { label: 'Min', value: 'min' },
+                { label: 'Max', value: 'max' },
+                { label: 'Average', value: 'avg' },
+              ],
+              helpText: 'Aggregation function',
+            },
+            { field: 'field', required: true, helpText: 'Child field to aggregate (ignored for count)' },
+            { field: 'relationshipField', helpText: 'Child FK back to this parent (auto-detected when omitted)' },
+            { field: 'filter', widget: 'filter-condition', helpText: 'Only child rows matching this predicate are aggregated (e.g. status == received)' },
+          ],
+        },
       ],
     },
     {


### PR DESCRIPTION
Small, concrete step toward #3257 (making the Studio field designer metadata-driven instead of hand-coded). Follows the filtered roll-up work in #1868 / #3227 (merged).

## Problem

`fieldForm` — the registered metadata form for editing a Field (`packages/spec/src/data/field.form.ts`, wired via `metadata-form-registry.ts`) — declared `summaryOperations` as a **bare `composite`** with no sub-fields:

```ts
{ field: 'summaryOperations', type: 'composite', helpText: '…' }
```

So any protocol-driven renderer of `fieldForm` falls back to a **raw JSON editor** for the roll-up config — and there was no protocol-level surface for the `filter` added in #1868.

## Change

Declare the composite's inner shape explicitly (`FormFieldSchema.fields` already supports this), mirroring the `summaryOperations` Zod schema:

- `object` → `widget: 'ref:object'` (required)
- `function` → `select` (count / sum / min / max / avg, required)
- `field` (required)
- `relationshipField` (optional; auto-detected when omitted)
- `filter` → `widget: 'filter-condition'` — the roll-up predicate from #1868

Also gates the whole block to `visibleWhen: data.type == 'summary'` (matching the `configuration` section's type-conditional pattern).

The protocol path now renders **structured** sub-fields instead of a raw JSON blob. The live objectui inspector (`ObjectFieldInspector` — objectstack-ai/objectui#2669, merged) already edits these fields; this closes the gap on the *metadata* side that the #3257 investigation found.

## Scope

This is only the small `fieldForm` completeness fix. The larger convergence — objectui's Studio rendering `fieldForm` from `metadata-form-registry` and declaring the design-time widgets (`filter-condition` row editor, dependent child-field picker, CEL editors) in the protocol — is tracked in **#3257** and deliberately out of scope here.

## Verification

- `tsc --noEmit` (@objectstack/spec) — clean.
- Form tests — 16/16.
- `check:docs`, `check:skill-refs` — in sync. (`check:api-surface` is unaffected — the exports don't change; a stale local `dist` produced a false positive that reproduces on pristine `main`.)
- Changeset added (`@objectstack/spec` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbK4FqcHwp9jSwdhTtxYuC)_