### PR TITLE
feat(platform-objects): surface phone number in create_user result dialog

### DIFF
--- a/.changeset/create-user-result-dialog-phone.md
+++ b/.changeset/create-user-result-dialog-phone.md
@@ -1,0 +1,12 @@
+---
+'@objectstack/platform-objects': minor
+---
+
+feat(platform-objects): surface phone number in the create_user result dialog
+
+`sys_user`'s `create_user` action now declares `user.phoneNumber` in its
+`resultDialog.fields`, so admins creating phone-based accounts see the
+sign-in phone number alongside the email and temporary password. The
+create-user response carries `phoneNumber` only for phone-based users;
+objectui's ActionResultDialog skips declared fields whose path is absent
+from the payload, so email-only users see no extra row.

--- a/packages/platform-objects/src/identity/sys-user.object.ts
+++ b/packages/platform-objects/src/identity/sys-user.object.ts
@@ -187,7 +187,11 @@ export const SysUser = ObjectSchema.create({
           'Copy the temporary password now — it is shown only once and never stored.',
         acknowledge: 'I have saved this password',
         fields: [
+          // The dialog skips fields whose path is absent from the response, so
+          // conditional keys are safe to declare: phoneNumber only exists for
+          // phone-based users, temporaryPassword only when the server minted one.
           { path: 'user.email', label: 'Email', format: 'text' },
+          { path: 'user.phoneNumber', label: 'Phone Number', format: 'text' },
           { path: 'temporaryPassword', label: 'Temporary Password', format: 'secret' },
         ],
       },


### PR DESCRIPTION
Closes #3260

## What

Adds `{ path: 'user.phoneNumber', label: 'Phone Number', format: 'text' }` to `sys_user.create_user`'s `resultDialog.fields`, so an admin creating a phone-based account sees the normalized E.164 sign-in number alongside the email and temporary password. The create-user response builds `user.phoneNumber` conditionally (`packages/plugins/plugin-auth/src/admin-user-endpoints.ts`) — it exists only for phone-based accounts.

## Merge order

Depends on objectstack-ai/objectui#2674 (skip resultDialog fields whose path does not resolve). On older objectui, email-only users would get a dirty **Phone Number** row rendering `undefined` — merge the objectui fix first.

## Verification

`@objectstack/platform-objects` tests: 213 passed. Changeset included (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)