### PR TITLE
test(dogfood): strengthen MCP HTTP e2e + prove serve-side self-connection (#3167)

### DIFF
--- a/packages/qa/dogfood/test/showcase-mcp-http-identity.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-mcp-http-identity.dogfood.test.ts
@@ -30,6 +30,8 @@ describe('showcase: MCP HTTP surface is identity-admitted (ADR-0096 / #3167)', (
   let stack: VerifyStack;
   let aliceToken: string;
   let bobToken: string;
+  let aliceNoteId: string;
+  let bobNoteId: string;
 
   /** POST /api/v1/mcp with the Streamable-HTTP Accept header; `token` null = anonymous. */
   const mcp = (token: string | null, body: unknown) =>
@@ -70,9 +72,12 @@ describe('showcase: MCP HTTP surface is identity-admitted (ADR-0096 / #3167)', (
 
     const a = await stack.apiAs(aliceToken, 'POST', OBJ, { title: 'Alice MCP note' });
     expect(a.status, 'alice creates note').toBeLessThan(300);
-    expect(idOf(await a.json()), 'alice note id').toBeTruthy();
+    aliceNoteId = idOf(await a.json());
+    expect(aliceNoteId, 'alice note id').toBeTruthy();
     const b = await stack.apiAs(bobToken, 'POST', OBJ, { title: 'Bob MCP note' });
     expect(b.status, 'bob creates note').toBeLessThan(300);
+    bobNoteId = idOf(await b.json());
+    expect(bobNoteId, 'bob note id').toBeTruthy();
   }, 60_000);
 
   afterAll(async () => {
@@ -107,5 +112,45 @@ describe('showcase: MCP HTTP surface is identity-admitted (ADR-0096 / #3167)', (
     const names: string[] = (rpc.result?.tools ?? []).map((t: any) => t.name);
     expect(names).toContain('query_records');
     expect(names).toContain('describe_object');
+  });
+
+  // #3167 — MCP and REST are ONE admission, not two independently-scoped ones.
+  it('MCP query_records scopes IDENTICALLY to REST /data for the same principal', async () => {
+    const idsOf = (r: any): Set<string> =>
+      new Set((r.records ?? r.data ?? r.rows ?? []).map((x: any) => String(x.id)));
+
+    const mcpIds = idsOf(await callTool(aliceToken, 'query_records', { objectName: 'showcase_private_note' }));
+    const restRes = await stack.apiAs(aliceToken, 'GET', OBJ);
+    expect(restRes.status).toBe(200);
+    const restIds = idsOf(await restRes.json());
+
+    expect(mcpIds, 'MCP and REST must return the same rows for the same caller').toEqual(restIds);
+    // Non-vacuous: the shared set is exactly alice's own row, never bob's.
+    expect(mcpIds.has(String(aliceNoteId))).toBe(true);
+    expect(mcpIds.has(String(bobNoteId))).toBe(false);
+  });
+
+  // The by-id read path (bridge.get → callData('get', …, ec)) is RLS-scoped too,
+  // not just the list query.
+  it('by-id get_record is RLS-scoped — a member cannot fetch another owner\'s row', async () => {
+    // Alice fetches Bob's private note by id → denied (not-found under owner RLS),
+    // surfaced as an MCP tool error, not a leaked row.
+    const denied: any = await (
+      await mcp(aliceToken, mcpBody('tools/call', {
+        name: 'get_record',
+        arguments: { objectName: 'showcase_private_note', recordId: bobNoteId },
+      }))
+    ).json();
+    expect(
+      denied.result?.isError,
+      `alice get_record on bob's row must be denied: ${JSON.stringify(denied.result)}`,
+    ).toBe(true);
+
+    // ...but she reads her own by id.
+    const own = await callTool(aliceToken, 'get_record', {
+      objectName: 'showcase_private_note',
+      recordId: aliceNoteId,
+    });
+    expect(String(own.id)).toBe(String(aliceNoteId));
   });
 });

--- a/packages/qa/dogfood/test/showcase-mcp-self-connection.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-mcp-self-connection.dogfood.test.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// #3167 optional extension — "the platform connecting to itself". Proves the
+// full serve↔consume loop end-to-end in ONE process: the app's own MCP HTTP
+// surface (`/api/v1/mcp`, ADR-0096 / #3228) is reachable by an MCP *client*
+// (connector-mcp) that authenticates with an `osk_` API key (ADR-0101 —
+// anonymous is denied even to itself), and that client can discover and call
+// the app's own generated tools.
+//
+// Deliberately HAND-WIRED (connect AFTER boot), NOT the declarative
+// `provider: 'mcp'` at boot: #3167 warns the dogfood gate must not become
+// timing-sensitive, and a declarative self-connection races the boot order
+// (automation `start()` runs before the HTTP server listens) and heals only via
+// the #3049 degrade+retry. This test sidesteps that race entirely — it connects
+// once the server is listening and a key exists — so it proves the capability
+// without a flaky gate. The declarative-at-boot form (with #3049 heal) remains a
+// separate, carefully-gated follow-up.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import showcaseStack from '@objectstack/example-showcase';
+import { bootStack, type VerifyStack } from '@objectstack/verify';
+import { MCPServerPlugin } from '@objectstack/mcp';
+import { createMcpConnector } from '@objectstack/connector-mcp';
+
+describe('showcase: the platform connects to its OWN MCP endpoint (#3167 self-connection)', () => {
+  let stack: VerifyStack;
+  let selfUrl: string;
+  let apiKey: string;
+
+  beforeAll(async () => {
+    // Serve side up (isMcpServerEnabled default-on; the lean harness injects the
+    // plugin the way `os dev`/`serve` auto-load it).
+    stack = await bootStack(showcaseStack, { extraPlugins: [new MCPServerPlugin()] });
+    const adminToken = await stack.signIn();
+
+    // Mint an osk_ key — the self-connection's identity (acts AS the admin caller).
+    const keyRes = await stack.apiAs(adminToken, 'POST', '/keys', { name: 'self-mcp' });
+    expect(keyRes.status, `mint key: ${keyRes.status} ${await keyRes.clone().text()}`).toBe(201);
+    apiKey = ((await keyRes.json()) as { data?: { key?: string } }).data?.key ?? '';
+    expect(apiKey, 'raw osk_ key returned once').toMatch(/^osk_/);
+
+    // The app really listens on an ephemeral port (HonoServerPlugin({ port: 0 })),
+    // so the connector reaches it over real HTTP exactly like an external client.
+    const httpServer = await stack.kernel.getServiceAsync<{ getPort(): number }>('http-server');
+    const port = httpServer.getPort();
+    expect(port, 'app bound a real port').toBeGreaterThan(0);
+    selfUrl = `http://127.0.0.1:${port}/api/v1/mcp`;
+  }, 60_000);
+
+  afterAll(async () => {
+    await stack?.stop();
+  });
+
+  it('refuses an UNAUTHENTICATED self-connection (identity admission holds even to itself)', async () => {
+    await expect(
+      createMcpConnector({ name: 'self_anon', transport: { kind: 'http', url: selfUrl } }),
+    ).rejects.toThrow();
+  });
+
+  it('connects to itself with an osk_ key and discovers its own generated tools', async () => {
+    const bundle = await createMcpConnector({
+      name: 'self_mcp',
+      transport: { kind: 'http', url: selfUrl, headers: { 'x-api-key': apiKey } },
+    });
+    try {
+      const toolKeys = bundle.def.actions?.map((a) => a.key) ?? [];
+      // The app's own generated CRUD spine, discovered over the self-connection.
+      expect(toolKeys, `self tools: ${JSON.stringify(toolKeys)}`).toContain('list_objects');
+      expect(toolKeys).toContain('query_records');
+      expect(toolKeys).toContain('describe_object');
+    } finally {
+      await bundle.close();
+    }
+  });
+
+  it('operates itself end-to-end — a self tools/call round-trips the app\'s own schema', async () => {
+    const bundle = await createMcpConnector({
+      name: 'self_mcp_call',
+      transport: { kind: 'http', url: selfUrl, headers: { 'x-api-key': apiKey } },
+    });
+    try {
+      const handler = bundle.handlers['list_objects'];
+      expect(handler, 'list_objects handler present').toBeDefined();
+      const result = await handler!({});
+      // The app's own object list, round-tripped back through its own MCP surface.
+      expect(JSON.stringify(result), `self list_objects result: ${JSON.stringify(result)}`).toContain('showcase_');
+    } finally {
+      await bundle.close();
+    }
+  });
+});


### PR DESCRIPTION
## What & why

两个 dogfood 增强,收尾 #3167 serve 侧 MCP 的证明面。**纯测试改动**(私有 `@objectstack/dogfood` 门包,无 changeset)。

### P3 — 强化 HTTP 身份准入 e2e(`showcase-mcp-http-identity.dogfood.test.ts`)

给 `mcp-http-identity` 的证明补两条此前缺失的断言:
- **MCP == REST 同一准入**:同一 principal 下 MCP `query_records` 的 id 集合 == REST `GET /data` 的 id 集合(不是"各自被裁剪",而是"可证等价");非空校验(只含自己的行、不含另一 owner 的)。
- **by-id `get_record` 也被 RLS 裁剪**:member 取另一 owner 的私有行 → 被拒(tool error),取自己的 → 正常。补上了此前只覆盖 list 查询、未覆盖 by-id 读路径的缺口。

### P2 — serve 侧自连接(`showcase-mcp-self-connection.dogfood.test.ts`,新增)

#3167 的 optional extension「平台连自己」,在**一个进程内**证明 serve↔consume 全链路:
- mint 一个 `osk_` key → 用 `connector-mcp` 通过**真实 HTTP** 连到 app 自己的 `/api/v1/mcp` → 发现并调用 app 自己的工具(`list_objects`/`query_records`/…)round-trip;
- **未认证的自连接被拒**(ADR-0101 的身份准入对"自己"也成立)。

> **为什么是 hand-wired、不是声明式 boot 时自连接**:#3167 明确要求 dogfood gate **不能变 timing-sensitive**。声明式 `provider:'mcp'` 在 boot 时自连接会撞 boot 顺序(automation `start()` 早于 HTTP listen),只能靠 #3049 degrade+retry 几秒后自愈——这正是时序脆弱的来源。本测试在 **boot 后**、服务已 listen、key 已存在时才连接,完全绕开该竞态,非 flaky。声明式-at-boot 形态(带 #3049 自愈)仍作为单独、谨慎 gating 的 follow-up。
>
> 可行性关键:`bootStack` 的 `HonoServerPlugin({ port: 0 })` 绑定真实 ephemeral socket,自 `fetch` 可达;端口经 `stack.kernel.getServiceAsync('http-server').getPort()` 取得——无需改 harness。

## 验证(本地)
- MCP dogfood **11/11**:`showcase-mcp-http-identity`(6,含 2 新)+ `showcase-mcp-self-connection`(3,新)+ `showcase-declarative-mcp`(2,回归)。
- eslint 干净。

Refs #3167、ADR-0096、ADR-0101。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115eg8dAaCfWaDYYAm3ma36

---
_Generated by [Claude Code](https://claude.ai/code/session_0115eg8dAaCfWaDYYAm3ma36)_