### PR TITLE
feat(client): 类型化 data.batchTransaction() —— master-detail 保存统一走原子跨对象批量(#1604 / ADR-0034 item 4)

### DIFF
--- a/.changeset/client-batch-transaction-sdk.md
+++ b/.changeset/client-batch-transaction-sdk.md
@@ -1,0 +1,19 @@
+---
+'@objectstack/client': minor
+---
+
+feat(client): typed `data.batchTransaction()` for the atomic cross-object batch (#1604 / ADR-0034 item 4)
+
+Adds `client.data.batchTransaction(operations)` (and the environment-scoped
+`client.project(id).data.batchTransaction`) — a typed SDK surface for
+`POST {basePath}/batch`, the all-or-nothing cross-object transactional batch
+that master-detail saves go through. Reuses `CrossObjectBatchOperation` /
+`CrossObjectBatchRequest` / `CrossObjectBatchResponse` from
+`@objectstack/spec/api` (also re-exported from the client for convenience);
+supports `{ $ref: <opIndex> }` intra-batch parent references.
+
+The method is always atomic and deliberately exposes no `atomic` flag — the
+endpoint rejects `atomic: false` with `400 BATCH_NOT_ATOMIC`. Non-atomic
+per-object bulk writes stay on `data.batch()` / `createMany` / `updateMany`,
+so any best-effort fallback is isolated in the caller's adapter (the ObjectUI
+`masterDetailTx` adapter), not in the SDK.

--- a/content/docs/api/client-sdk.mdx
+++ b/content/docs/api/client-sdk.mdx
@@ -206,7 +206,20 @@ await client.data.updateMany('account', [
   { id: '2', data: { status: 'closed' } },
 ]);
 await client.data.deleteMany('account', ['1', '2', '3']);
+
+// Atomic cross-object batch (master-detail save) — runs every operation in
+// ONE server-side transaction (POST /api/v1/batch): commit all or roll back
+// all. `{ $ref: <op index> }` lets a child reference a parent created earlier
+// in the same request. Always atomic — unlike per-object `data.batch()`,
+// there is no partial-success mode.
+const { results } = await client.data.batchTransaction([
+  { object: 'project', action: 'create', data: { name: 'Apollo' } },
+  { object: 'task', action: 'create', data: { title: 'Kickoff', project: { $ref: 0 } } },
+]);
 ```
+
+See [Batch Operations](/docs/protocol/kernel/http-protocol#batch-operations)
+for the underlying endpoint contract.
 
 ### `client.analytics` — BI Queries
 

--- a/content/docs/protocol/kernel/http-protocol.mdx
+++ b/content/docs/protocol/kernel/http-protocol.mdx
@@ -607,6 +607,9 @@ atomic transaction.
 POST /api/v1/batch
 ```
 
+The typed SDK surface for this route is
+[`client.data.batchTransaction(operations)`](/docs/api/client-sdk#clientdata--crud-operations).
+
 Each operation specifies an `action` (`create`, `update`, or `delete`), the
 target `object`, and the relevant `data` / `id`. A field value of
 `{ "$ref": <earlier op index> }` resolves to the id created by an earlier

--- a/docs/adr/0034-transactional-writes-and-ambient-transaction.md
+++ b/docs/adr/0034-transactional-writes-and-ambient-transaction.md
@@ -118,6 +118,18 @@ Once (1)+(2) land and a multi-write transaction test suite is green:
 - Point ObjectUI `masterDetailTx` at it and delete the client-side best-effort
   cleanup (a smell that exists only because server atomicity was missing).
 
+> **Status (framework side: done).** The endpoint landed as
+> `POST {basePath}/batch` (`rest-server.ts` `registerBatchEndpoints`, spec
+> contract `CrossObjectBatchRequestSchema` in `spec/src/api/batch.zod.ts`),
+> and the SDK exposes it as `client.data.batchTransaction(operations)`
+> (plus the environment-scoped mirror). The SDK method is always atomic and
+> exposes no `atomic` flag — non-atomic per-object bulk writes stay on
+> `data.batch()`/`createMany`/`updateMany`, so any best-effort fallback must
+> be isolated in the caller's adapter. Remaining (objectui repo): repoint
+> `masterDetailTx` at `batchTransaction` and delete the client-side
+> best-effort cleanup, keeping the non-atomic fallback inside the
+> `data-objectstack` adapter only.
+
 ---
 
 ## Consequences

--- a/packages/client/src/client.batch-transaction.test.ts
+++ b/packages/client/src/client.batch-transaction.test.ts
@@ -1,0 +1,151 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Integration test — atomic cross-object batch through the typed SDK
+ * (`client.data.batchTransaction`, issue #1604 / ADR-0034 item 4).
+ *
+ * Boots a real Hono server (LiteKernel + ObjectQLPlugin + createRestApiPlugin,
+ * same pattern as client.environment-scoping.test.ts) and proves the full
+ * client → hono → rest → engine chain:
+ *   1. Parent + child with `{ $ref: 0 }` commit in one request and the child's
+ *      FK equals the parent's generated id.
+ *   2. The environment-scoped mirror resolves `/environments/:id/batch`.
+ *   3. An unresolvable `$ref` rejects and the client error carries
+ *      `code: 'BATCH_UNRESOLVED_REF'` (error-mapping proof).
+ *   4. `atomic: false` is rejected with 400 BATCH_NOT_ATOMIC — the contract
+ *      reason the SDK method exposes no `atomic` flag.
+ *
+ * NOTE on atomicity: the InMemoryDriver's `transaction()` is a passthrough
+ * (no rollback), so all-or-nothing semantics are NOT asserted here — they are
+ * covered by objectql/src/engine-ambient-transaction.test.ts and
+ * rest/src/rest-batch-endpoint.test.ts against transactional drivers.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { LiteKernel } from '@objectstack/core';
+import { ObjectQL, ObjectQLPlugin } from '@objectstack/objectql';
+import { InMemoryDriver } from '@objectstack/driver-memory';
+import { HonoServerPlugin } from '@objectstack/plugin-hono-server';
+import { createRestApiPlugin } from '@objectstack/runtime';
+import { ObjectStackClient } from './index';
+
+describe('data.batchTransaction (live Hono, #1604)', () => {
+    let baseUrl: string;
+    let kernel: LiteKernel;
+    let client: ObjectStackClient;
+
+    beforeAll(async () => {
+        kernel = new LiteKernel();
+        kernel.use(new ObjectQLPlugin());
+
+        kernel.use(
+            new HonoServerPlugin({
+                port: 0,
+                // Skip hardcoded hono CRUD routes so createRestApiPlugin owns
+                // route registration (including the root /batch route).
+                registerStandardEndpoints: false,
+            }),
+        );
+
+        kernel.use(
+            createRestApiPlugin({
+                api: {
+                    api: {
+                        // Routing test, no auth stack mounted — opt out of the
+                        // secure-by-default anonymous deny (ADR-0056 D2).
+                        requireAuth: false,
+                        enableProjectScoping: true,
+                        projectResolution: 'auto',
+                    } as any,
+                },
+            }),
+        );
+
+        await kernel.bootstrap();
+
+        const ql = kernel.getService<ObjectQL>('objectql');
+        ql.registerDriver(new InMemoryDriver(), true);
+
+        ql.registerObject({
+            name: 'project',
+            label: 'Project',
+            fields: {
+                name: { type: 'text', label: 'Name' },
+            },
+        });
+        ql.registerObject({
+            name: 'task',
+            label: 'Task',
+            fields: {
+                title: { type: 'text', label: 'Title' },
+                project: { type: 'lookup', reference_to: 'project', label: 'Project' },
+            },
+        });
+
+        const httpServer = kernel.getService<any>('http.server');
+        baseUrl = `http://localhost:${httpServer.getPort()}`;
+        client = new ObjectStackClient({ baseUrl });
+    }, 30_000);
+
+    afterAll(async () => {
+        if (kernel) {
+            await Promise.race([
+                kernel.shutdown(),
+                new Promise<void>((resolve) => setTimeout(resolve, 10_000)),
+            ]);
+        }
+    }, 30_000);
+
+    it('creates parent + child in one request; { $ref: 0 } resolves to the parent id', async () => {
+        const { results } = await client.data.batchTransaction([
+            { object: 'project', action: 'create', data: { name: 'Apollo' } },
+            { object: 'task', action: 'create', data: { title: 'Kickoff', project: { $ref: 0 } } },
+        ]);
+
+        expect(results).toHaveLength(2);
+        const parent = results[0] as any;
+        const child = results[1] as any;
+        expect(parent.id).toBeDefined();
+        expect(child.project).toBe(parent.id);
+
+        // Both rows are readable afterwards through the ordinary data API.
+        const storedChild = await client.data.get<any>('task', child.id);
+        expect((storedChild as any).project ?? (storedChild as any).record?.project).toBeDefined();
+    });
+
+    it('is mirrored on the environment-scoped client (/environments/:id/batch)', async () => {
+        const scoped = client.project('proj-alpha');
+        const { results } = await scoped.data.batchTransaction([
+            { object: 'project', action: 'create', data: { name: 'Scoped' } },
+        ]);
+        expect((results[0] as any).id).toBeDefined();
+    });
+
+    it('rejects an unresolvable $ref with BATCH_UNRESOLVED_REF surfaced on the client error', async () => {
+        let caught: any;
+        try {
+            await client.data.batchTransaction([
+                { object: 'task', action: 'create', data: { title: 'orphan', project: { $ref: 5 } } },
+            ]);
+        } catch (e) {
+            caught = e;
+        }
+        expect(caught).toBeDefined();
+        expect(caught.httpStatus).toBe(400);
+        expect(caught.code).toBe('BATCH_UNRESOLVED_REF');
+    });
+
+    it('rejects atomic:false with 400 BATCH_NOT_ATOMIC (why the SDK has no atomic flag)', async () => {
+        const res = await fetch(`${baseUrl}/api/v1/batch`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                operations: [{ object: 'project', action: 'create', data: { name: 'nope' } }],
+                atomic: false,
+            }),
+        });
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.code).toBe('BATCH_NOT_ATOMIC');
+    });
+});

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1203,3 +1203,84 @@ describe('packages.install', () => {
         expect(body.overwrite).toBe(true);
     });
 });
+
+// ==========================================
+// Atomic cross-object batch (#1604 / ADR-0034 item 4)
+// ==========================================
+
+describe('data.batchTransaction', () => {
+    const OPS = [
+        { object: 'project', action: 'create' as const, data: { name: 'Apollo' } },
+        { object: 'task', action: 'create' as const, data: { title: 'Kickoff', project: { $ref: 0 } } },
+    ];
+
+    it('POSTs { operations, atomic: true } to the root /batch route', async () => {
+        const { client, fetchMock } = createMockClient({ results: [{ id: 'p1' }, { id: 't1' }] });
+        const res = await client.data.batchTransaction(OPS);
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            'http://localhost:3000/api/v1/batch',
+            expect.objectContaining({ method: 'POST' }),
+        );
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.operations).toHaveLength(2);
+        // Always atomic — the SDK never exposes a non-atomic variant; the
+        // server 400s on `atomic: false` (BATCH_NOT_ATOMIC).
+        expect(body.atomic).toBe(true);
+        expect(res.results).toEqual([{ id: 'p1' }, { id: 't1' }]);
+    });
+
+    it('serializes intra-batch { $ref } parent references verbatim', async () => {
+        const { client, fetchMock } = createMockClient({ results: [] });
+        await client.data.batchTransaction(OPS);
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.operations[1].data.project).toEqual({ $ref: 0 });
+    });
+
+    it('unwraps both the bare and the enveloped response shape', async () => {
+        // Bare `{ results }` (what the endpoint sends today)
+        const bare = createMockClient({ results: [{ id: 'a' }] });
+        expect((await bare.client.data.batchTransaction(OPS)).results).toEqual([{ id: 'a' }]);
+
+        // `{ success, data }` envelope (BaseResponse-wrapped variant)
+        const wrapped = createMockClient({ success: true, data: { results: [{ id: 'b' }] } });
+        expect((await wrapped.client.data.batchTransaction(OPS)).results).toEqual([{ id: 'b' }]);
+    });
+
+    it('derives the batch route from a discovery-overridden data route', async () => {
+        const { client, fetchMock } = createMockClient({ results: [] });
+        (client as any)['discoveryInfo'] = { routes: { data: '/custom/v9/data' } };
+        await client.data.batchTransaction(OPS);
+        expect(fetchMock).toHaveBeenCalledWith(
+            'http://localhost:3000/custom/v9/batch',
+            expect.any(Object),
+        );
+    });
+
+    it('surfaces server rejections with code/status attached (BATCH_UNRESOLVED_REF)', async () => {
+        const { client } = createMockClient(
+            { error: "Unresolved $ref 5 on field 'project'", code: 'BATCH_UNRESOLVED_REF' },
+            400,
+        );
+        let caught: any;
+        try {
+            await client.data.batchTransaction(OPS);
+        } catch (e) {
+            caught = e;
+        }
+        expect(caught).toBeDefined();
+        expect(caught.code).toBe('BATCH_UNRESOLVED_REF');
+        expect(caught.httpStatus).toBe(400);
+    });
+
+    it('is mirrored on the environment-scoped client', async () => {
+        const { client, fetchMock } = createMockClient({ results: [] });
+        await client.project('proj-1').data.batchTransaction(OPS);
+        expect(fetchMock).toHaveBeenCalledWith(
+            'http://localhost:3000/api/v1/environments/proj-1/batch',
+            expect.objectContaining({ method: 'POST' }),
+        );
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.atomic).toBe(true);
+    });
+});

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -78,6 +78,9 @@ import {
   ListImportJobsRequest,
   ListImportJobsResponse,
   UndoImportJobResponse,
+  CrossObjectBatchOperation,
+  CrossObjectBatchRequest,
+  CrossObjectBatchResponse,
 } from '@objectstack/spec/api';
 import type {
   ApprovalRequestRow,
@@ -3019,6 +3022,49 @@ export class ObjectStackClient {
     },
 
     /**
+     * Atomic cross-object batch — the canonical master-detail save path
+     * (issue #1604 / ADR-0034 item 4).
+     *
+     * Executes heterogeneous create/update/delete operations across MULTIPLE
+     * objects in ONE server-side engine transaction: commit all or roll back
+     * all. A field value of `{ $ref: <earlier op index> }` resolves to the id
+     * created by that earlier operation, so a child row can reference a
+     * parent created in the same request:
+     *
+     * ```ts
+     * const { results } = await client.data.batchTransaction([
+     *   { object: 'project', action: 'create', data: { name: 'Apollo' } },
+     *   { object: 'task', action: 'create', data: { title: 'Kickoff', project: { $ref: 0 } } },
+     * ]);
+     * ```
+     *
+     * This method is always atomic and deliberately exposes no `atomic`
+     * flag — the endpoint rejects `atomic: false` with `400 BATCH_NOT_ATOMIC`.
+     * Non-atomic, partial-success bulk writes stay on the per-object
+     * {@link batch} / {@link createMany} / {@link updateMany} surface;
+     * callers that need a best-effort fallback (e.g. against servers
+     * predating this route, which respond 404 — check `error.httpStatus`)
+     * must isolate it in their own adapter rather than here.
+     *
+     * URL note: the server mounts this route at the PARENT of the data
+     * prefix (`POST {basePath}/batch` vs `{basePath}/data/...`, see
+     * rest-server `registerBatchEndpoints`), so the path is derived by
+     * dropping the last segment of the resolved data route.
+     */
+    batchTransaction: async (
+      operations: CrossObjectBatchOperation[],
+    ): Promise<CrossObjectBatchResponse> => {
+        const dataRoute = this.getRoute('data');
+        const base = dataRoute.replace(/\/[^/]+\/?$/, '') || '/api/v1';
+        const request: CrossObjectBatchRequest = { operations, atomic: true };
+        const res = await this.fetch(`${this.baseUrl}${base}/batch`, {
+            method: 'POST',
+            body: JSON.stringify(request),
+        });
+        return this.unwrapResponse<CrossObjectBatchResponse>(res);
+    },
+
+    /**
      * Update multiple records (simplified batch update)
      * Convenience method for batch updates without full BatchUpdateRequest
      */
@@ -3469,6 +3515,21 @@ export class ScopedProjectClient {
       });
       return this.parent._unwrap<BatchUpdateResponse>(res);
     },
+    /**
+     * Atomic cross-object batch, environment-scoped
+     * (`POST /api/v1/environments/:id/batch`).
+     * See {@link ObjectStackClient} `data.batchTransaction` for semantics.
+     */
+    batchTransaction: async (
+      operations: CrossObjectBatchOperation[],
+    ): Promise<CrossObjectBatchResponse> => {
+      const request: CrossObjectBatchRequest = { operations, atomic: true };
+      const res = await this.parent._fetch(this.url('/batch'), {
+        method: 'POST',
+        body: JSON.stringify(request),
+      });
+      return this.parent._unwrap<CrossObjectBatchResponse>(res);
+    },
     updateMany: async <T = any>(
       object: string,
       records: Array<{ id: string; data: Partial<T> }>,
@@ -3631,6 +3692,9 @@ export type {
   ListImportJobsRequest,
   ListImportJobsResponse,
   UndoImportJobResponse,
+  CrossObjectBatchOperation,
+  CrossObjectBatchRequest,
+  CrossObjectBatchResponse,
 } from '@objectstack/spec/api';
 
 // Approval runtime types (ADR-0019) — surfaced so SDK consumers can type the


### PR DESCRIPTION
## 背景

承接 #1604 与 ADR-0034 item 4:服务端原子跨对象批量端点(`POST {basePath}/batch`,单引擎事务、`{ $ref: <opIndex> }` 批内父引用、逐对象 API 曝光鉴权)已落地,但 `@objectstack/client` SDK 没有对应的类型化方法——objectui 的 `masterDetailTx` 适配器要走原子路径只能手写 fetch。本 PR 补上 framework 侧缺口,让原子 batchTransaction 成为 master-detail 保存的一等公民 SDK API。

## 改动

- **`packages/client/src/index.ts`**:新增 `client.data.batchTransaction(operations)` 与环境作用域镜像 `client.project(id).data.batchTransaction(operations)`。
  - 复用并 re-export spec 契约类型 `CrossObjectBatchOperation/Request/Response`(`@objectstack/spec/api`)。
  - **恒原子、不暴露 `atomic` 参数**——类型上无法表达非原子请求(服务端对 `atomic:false` 也会 400 `BATCH_NOT_ATOMIC`)。非原子 per-object 批量保留在 `data.batch()`/`createMany`/`updateMany`;best-effort 回退只能隔离在调用方(ObjectUI `masterDetailTx`)适配器里,SDK 不承载——这是"非原子回退隔离进适配器"的类型化表达。
  - URL 推导:端点按构造挂在 data 前缀的父级(`${basePath}/batch`),客户端从 `getRoute('data')` 去末段推导,兼容 discovery 覆写的自定义路由;不给 `ApiRoutesSchema` 加 key(避免 3+ 个 discovery 生产方同步、declared-but-unpopulated 路由)。
- **测试**:
  - 单测 6 例(`client.test.ts`):URL/payload、`$ref` 透传、裸/信封双响应形态解包、discovery 路由推导、错误整形(`code`/`httpStatus`)、scoped 镜像。
  - 端到端 4 例(新文件 `client.batch-transaction.test.ts`,LiteKernel + Hono 真实服务):父+子 `$ref` 落库且 FK 等于父 id、scoped 路由、`BATCH_UNRESOLVED_REF` 全链路错误映射、`atomic:false` → 400 `BATCH_NOT_ATOMIC` 契约 pin。文件头注明 InMemoryDriver 事务为 passthrough,回滚原子性由 `engine-ambient-transaction.test.ts` / `rest-batch-endpoint.test.ts` 覆盖。
- **文档**:`content/docs/api/client-sdk.mdx` 增加原子跨对象批量示例并互链 `http-protocol.mdx` Batch Operations;ADR-0034 §4 补状态注(framework 侧完成)。
- **Changeset**:`@objectstack/client` minor。

## 验证

- `pnpm --filter @objectstack/client build` ✅(DTS 通过)
- `pnpm --filter @objectstack/client test` ✅ 4 files / 109 tests(含新增 10 例)
- `pnpm --filter @objectstack/rest test` ✅ 19 files / 323 tests(相邻回归)

## 跨仓库 follow-up(不在本 PR)

objectui 仓库:`masterDetailTx` / `data-objectstack` 适配器改为调用 `client.data.batchTransaction`(以 `$ref` 组 operations),删除客户端 best-effort 清理;非原子顺序回退(面向无该端点的旧服务器,按 `error.httpStatus === 404` 特性探测)只保留在该适配器内部。

> 注:任务标题所引 #2679 在 framework 为不相关 issue(userFilters),应为 objectui 侧编号;本 PR 按 #1604 / ADR-0034 item 4 的实质内容执行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCrTB7b5qFX2yyHJEGB5xa

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCrTB7b5qFX2yyHJEGB5xa)_