### PR TITLE
docs: fix cache-service frontmatter, knowledge dead links, TCK glossary term (#1880 follow-up)

### DIFF
--- a/content/docs/getting-started/glossary.mdx
+++ b/content/docs/getting-started/glossary.mdx
@@ -157,4 +157,4 @@ The default sharing level (Security Protocol) for records in an object. Determin
 A hierarchical access control model (Security Protocol) that grants data access based on geographic or organizational boundaries.
 
 ### TCK (Technology Compatibility Kit)
-A suite of tests that validates if a Driver or Renderer complies with the official ObjectStack Protocol. If a new driver passes the TCK, it is certified as compatible.
+A **planned** suite of tests that would validate whether a Driver or Renderer complies with the official ObjectStack Protocol, certifying a passing driver as compatible. _Not yet implemented — there is no TCK program or certification mechanism in the codebase today._

--- a/content/docs/kernel/contracts/cache-service.mdx
+++ b/content/docs/kernel/contracts/cache-service.mdx
@@ -1,6 +1,6 @@
 ---
 title: ICacheService Contract
-description: Reference for the Cache Service contract — key-value caching with TTL support, namespaces, and bulk operations
+description: Reference for the Cache Service contract — key-value caching with TTL support
 ---
 
 # ICacheService Contract

--- a/content/docs/protocol/knowledge.mdx
+++ b/content/docs/protocol/knowledge.mdx
@@ -169,7 +169,7 @@ interface IKnowledgeService {
 
 `KnowledgeSearchOptions` includes `sourceIds`, `topK`, `filter`, and
 the all-important `executionContext` (from the permission-aware tool
-execution work — see `ai-capabilities.mdx`). `KnowledgeReindexOptions`
+execution work — see `actions-as-tools.mdx`). `KnowledgeReindexOptions`
 accepts `dryRun` and `limit`; `reindexSource` returns a
 `KnowledgeReindexResult` (`indexed`, `discovered`, `ok`, …).
 
@@ -255,7 +255,7 @@ IKnowledgeService.search(q, { executionContext, sourceIds })
 ```
 
 This is the same pattern as the existing permission-aware data tools
-(see `ai-capabilities.mdx#permission-aware-execution-rls-for-agents`).
+(see `actions-as-tools.mdx`).
 No matter how aggressive an adapter's retrieval is, the user never
 sees a chunk extracted from a record they can't read.
 
@@ -347,7 +347,7 @@ internally (RAGFlow, Dify, Vectara).
 
 ## 10. Related documents
 
-- `ai-capabilities.mdx#permission-aware-execution-rls-for-agents` —
+- `actions-as-tools.mdx` —
   the `ExecutionContext` threading the Knowledge Protocol reuses.
 - `architecture.mdx` — overall service / plugin layering.
 - `packages/spec/src/ai/embedding.zod.ts` — pre-existing embedding /


### PR DESCRIPTION
Small doc-accuracy follow-up to the #1880 implementation-accuracy audit (PR #3243, now merged). These three fixes were **surfaced by that audit but its hard rules blocked them** — preserve-frontmatter and no-fabrication — so they were carved out into this separate PR.

## Fixes
- **`kernel/contracts/cache-service.mdx` frontmatter** — dropped "namespaces, and bulk operations" from the `description`. The `ICacheService` contract only exposes `get` / `set` (with optional `ttl`) / `delete` / `has` / `clear` / `stats` (`packages/spec/src/contracts/cache-service.ts:35-68`); TTL is real, namespaces and bulk ops are not. (The body Callout already said as much — the frontmatter was the last place still over-promising.) The audit couldn't touch this under the preserve-frontmatter rule.
- **`protocol/knowledge.mdx`** — repointed 3 references from `ai-capabilities.mdx` (a dead link since the docs reorg removed that file) to the real `actions-as-tools.mdx`, which covers permission-aware execution (its "Permission model" section). Dropped the stale `#permission-aware-execution-rls-for-agents` anchor rather than guess a new one — the audit's no-fabrication rule had left these untouched.
- **`getting-started/glossary.mdx`** — qualified the "TCK (Technology Compatibility Kit)" entry as **planned / not-yet-implemented**. "TCK" / "Technology Compatibility Kit" is grep-empty across `packages/` — there is no such certification mechanism today.

Surgical, frontmatter-and-slug preserving; 3 files, ±5 lines. Draft for maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012urEihGTAsQP2xizAqfCwt

---
_Generated by [Claude Code](https://claude.ai/code/session_012urEihGTAsQP2xizAqfCwt)_