### PR TITLE
feat(approvals): declare decision actions on sys_approval_request (objectui#2678 P2-4)

### DIFF
--- a/packages/plugins/plugin-approvals/src/sys-approval-request.object.ts
+++ b/packages/plugins/plugin-approvals/src/sys-approval-request.object.ts
@@ -229,4 +229,62 @@ export const SysApprovalRequest = ObjectSchema.create({
     { fields: ['status', 'updated_at'] },
     { fields: ['submitter_id', 'status'] },
   ],
+
+  // Server-declared decision actions (objectui#2678 P2-4). The console's
+  // generic action runtime renders and executes these wherever this object is
+  // surfaced — the approvals inbox included — so new decision capabilities
+  // (and their params) ship as metadata, not as hand-written buttons. Each
+  // targets the existing approvals REST route; `{id}` resolves from the row
+  // and `actorId` defaults to the caller server-side. The service remains the
+  // authority on who may act (pending-approver check) — `visible` only trims
+  // the obvious non-pending case.
+  actions: [
+    {
+      name: 'approval_approve',
+      label: 'Approve',
+      icon: 'check-circle',
+      type: 'api',
+      method: 'POST',
+      target: '/api/v1/approvals/requests/{id}/approve',
+      params: [
+        { name: 'comment', label: 'Comment', type: 'textarea', required: false },
+      ],
+      visible: 'record.status == "pending"',
+      locations: ['record_section', 'list_item'],
+      successMessage: 'Approved.',
+      refreshAfter: true,
+    },
+    {
+      name: 'approval_reject',
+      label: 'Reject',
+      icon: 'x-circle',
+      type: 'api',
+      method: 'POST',
+      target: '/api/v1/approvals/requests/{id}/reject',
+      params: [
+        { name: 'comment', label: 'Comment', type: 'textarea', required: false },
+      ],
+      visible: 'record.status == "pending"',
+      confirmText: 'Reject this request? A rejection is final for every approver.',
+      locations: ['record_section', 'list_item'],
+      successMessage: 'Rejected.',
+      refreshAfter: true,
+    },
+    {
+      name: 'approval_reassign',
+      label: 'Reassign',
+      icon: 'arrow-right-left',
+      type: 'api',
+      method: 'POST',
+      target: '/api/v1/approvals/requests/{id}/reassign',
+      params: [
+        { name: 'to', label: 'New approver (user id)', type: 'text', required: true },
+        { name: 'comment', label: 'Comment', type: 'textarea', required: false },
+      ],
+      visible: 'record.status == "pending"',
+      locations: ['record_section'],
+      successMessage: 'Reassigned.',
+      refreshAfter: true,
+    },
+  ],
 });


### PR DESCRIPTION
Framework half of **objectui#2678 P2-4** (inbox action SDUI-ification). The UI counterpart (a generic `DeclaredActionsBar` consuming these) rides a parallel objectui PR.

## What

`sys_approval_request` now **declares** its decision actions as metadata — `approval_approve`, `approval_reject`, `approval_reassign` — each a `type:'api'` action targeting the existing approvals REST route:

- `{id}` in the target resolves from the row; `actorId` defaults to the caller server-side (existing route behavior).
- Typed params render the console's generic param dialog: optional `comment` (textarea) on all three; required `to` on reassign.
- `visible: 'record.status == "pending"'` trims finished requests — **display-only**; the service's pending-approver check stays authoritative.
- Reject carries a `confirmText`; all three `refreshAfter`.
- Locations: `record_section` (+ `list_item` for approve/reject quick actions).

## Why

This is the structural fix for the "hand-edit the inbox per feature" anti-pattern (#2678 调研判定): with the actions declared on the object, the console's generic action runtime renders and executes them wherever the object is surfaced — so future decision capabilities (enterprise act-as, cloud#861 included) ship as **metadata**, with zero bespoke frontend.

## Tests
Full `plugin-approvals` suite green (137) with the declaration in place (object schema parses eagerly at import, so an invalid action shape would fail every test).

## Refs
objectui#2678 (P2-4) · follows #3274 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ypkQikZ55oWUHUnMebwXA)_