### PR TITLE
fix(spec): correct skill `surface` comment — `ask` is not the open-source/free surface

### DIFF
--- a/packages/spec/src/ai/skill.zod.ts
+++ b/packages/spec/src/ai/skill.zod.ts
@@ -77,7 +77,9 @@ export const SkillSchema = lazySchema(() => z.object({
    * matches either); the runtime enforces this at load time. An agent's
    * tool set is the union of its surface-compatible skills' tools — there
    * is no global fall-through (ADR-0064). Defaults to `'ask'`, the
-   * open-source/free surface.
+   * data-console surface. (Both the `ask` and `build` in-product agent
+   * runtimes ship in the cloud / Enterprise distribution per ADR-0025;
+   * the surface value here is authoring metadata, not an edition gate.)
    */
   surface: z.enum(['ask', 'build', 'both']).default('ask').describe(
     "Agent surface this skill binds to ('ask' | 'build' | 'both') — ADR-0063 §3",


### PR DESCRIPTION
## 背景

`packages/spec/src/ai/skill.zod.ts` 里 `SkillSchema.surface` 的 JSDoc 把默认值 `'ask'` 注释为 **"the open-source/free surface"** —— 这是错的。

按 cloud **ADR-0025**,`ask` 与 `build` 两个 in-product agent **运行时**都属 **cloud / Enterprise** 分发,开源版是 MCP-only(BYO-AI),并没有内置的 `ask` 聊天。因此把 `ask` 说成"开源/免费 surface"与实际相反。

这个矛盾此前在文档 PR #2649 里作为 finding 提示过;本 PR 在源头修正它。

## 改动

- `skill.zod.ts` 的 `surface` 字段 JSDoc:去掉错误的 "open-source/free surface" 说法,改为准确描述——`ask` 是 data-console surface;并点明 `ask`/`build` 的 in-product 运行时按 ADR-0025 均属 cloud/Enterprise,`surface` 值是**授权元数据**(某 skill 绑定到哪个 agent),不是版本门槛。

仅改注释:Zod 的 `.describe()` 字符串与 schema 本身未变,生成的 reference 文档与运行时行为不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHQscZJ8NvXceSmsPNdTZd

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHQscZJ8NvXceSmsPNdTZd)_