### PR TITLE
docs(skills): teach the real feature-flags surface, not a fake defineStack key

### DIFF
--- a/skills/objectstack-platform/SKILL.md
+++ b/skills/objectstack-platform/SKILL.md
@@ -1033,31 +1033,49 @@ const metrics = kernel.getPluginMetrics();
 
 ## Feature Flags
 
-```typescript
-import { defineStack } from '@objectstack/spec';
+Feature flags are a **protocol shape, not a config key**. `FeatureFlagSchema` (from
+`@objectstack/spec/kernel`) defines the flag document; in the protocol it appears only on
+the runtime capabilities descriptor (`ObjectStackCapabilities.system.features`) that a
+platform serves for introspection. There is **no `featureFlags:` / `features:` key on
+`defineStack`** — strict parsing silently strips unknown keys, so such config would be a
+no-op.
 
-export default defineStack({
-  featureFlags: [
-    {
-      name: 'experimental_ai_copilot',
-      label: 'AI Copilot',
-      enabled: true,
-      strategy: 'percentage',
-      conditions: { percentage: 25 },   // 25% of users
-      environment: ['production'],
-    },
-    {
-      name: 'beta_kanban_view',
-      label: 'Kanban View',
-      enabled: true,
-      strategy: 'group',
-      conditions: { groups: ['beta_testers'] },
-    },
-  ],
+<!-- os:check -->
+```typescript
+import { FeatureFlag } from '@objectstack/spec/kernel';
+import type { ObjectStackCapabilities } from '@objectstack/spec';
+
+// FeatureFlag.create() gives you a compile-checked flag value:
+const aiCopilot = FeatureFlag.create({
+  name: 'experimental_ai_copilot',
+  label: 'AI Copilot',
+  enabled: true,
+  strategy: 'percentage',
+  conditions: { percentage: 25 },   // 25% of users
+  environment: 'prod',              // 'dev' | 'staging' | 'prod' | 'all' (default 'all')
 });
+
+// Where flags live in the protocol — the runtime capabilities descriptor:
+type SystemFeatures = NonNullable<ObjectStackCapabilities['system']['features']>;
+const features: SystemFeatures = [
+  aiCopilot,
+  {
+    name: 'beta_kanban_view',
+    label: 'Kanban View',
+    enabled: true,
+    strategy: 'group',
+    conditions: { groups: ['beta_testers'] },
+    environment: 'all',
+  },
+];
 ```
 
 Strategies: `boolean` | `percentage` | `user_list` | `group` | `custom`
+
+Looking for live, resolvable toggles today? Those are different surfaces, not
+`FeatureFlagSchema`: the `feature_flags` settings manifest
+(`@objectstack/service-settings`, env-overridable via `OS_FEATURE_FLAGS_*`) and auth
+capability gates (`requiresFeature` → `PUBLIC_AUTH_FEATURES`).
 
 ---
 ---


### PR DESCRIPTION
## Summary

Fixes the `## Feature Flags` section of `skills/objectstack-platform/SKILL.md`, which taught `defineStack({ featureFlags: [...] })` — an authoring surface that does not exist. The block was deliberately left untagged by the `check:skill-examples` gate (#3224) because the fix was structural, not a rename.

Closes #3248

## What was wrong (verified against the spec)

1. **`featureFlags` is not a key** on `ObjectStackDefinitionSchema` (`packages/spec/src/stack.zod.ts` — none of its 42 top-level keys is `featureFlags` or `features`). `defineStack` strict parsing **silently strips** unknown keys, so the example config was a no-op at runtime and TS2353 at compile time for consumers.
2. The only place `FeatureFlagSchema[]` appears in the protocol is `KernelCapabilitiesSchema.features` → `ObjectStackCapabilities.system.features` — the **runtime capabilities descriptor** (an introspection/read surface), never referenced by the definition schema. Feature flags have no authoring home in `objectstack.config.ts`; nothing in the codebase produces or evaluates them at runtime (the schema's only consumers are its own unit tests). Adding a top-level authoring key was therefore deliberately **not** done here — that's a spec/product decision for the surface owner (per the issue), and it would ship authored-but-inert config.
3. **`environment: ['production']`** was the wrong shape *and* value: `FeatureFlagSchema.environment` is a scalar `z.enum(['dev','staging','prod','all'])` (default `'all'`).

## The rewrite

- Teaches the surface that actually exists: `FeatureFlag.create()` from `@objectstack/spec/kernel` (compile-checked flag values) and the flags' protocol home, `ObjectStackCapabilities.system.features`.
- States explicitly that this is **not** a `defineStack` key and why authored `featureFlags:` is a silent no-op.
- Points readers who want live, resolvable toggles to the real surfaces: the `feature_flags` settings manifest (`@objectstack/service-settings`, `OS_FEATURE_FLAGS_*` env overrides) and auth capability gates (`requiresFeature` → `PUBLIC_AUTH_FEATURES`) — explicitly distinct from `FeatureFlagSchema`.
- Re-tags the block with `<!-- os:check -->` per the issue's definition of done, so the gate covers it from now on.

## Verification

```
pnpm --filter @objectstack/spec build
pnpm --filter @objectstack/spec run check:skill-examples
# ✅ 20 skill examples type-check against @objectstack/spec
# (was 19 — the new block at skills/objectstack-platform/SKILL.md:1045 is now covered)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011omKdw59exYDNh3GekqFZq

---
_Generated by [Claude Code](https://claude.ai/code/session_011omKdw59exYDNh3GekqFZq)_