### PR TITLE
fix(showcase): call ctx.log.info/.warn in hook bodies — sandbox ctx.log is an object

### DIFF
--- a/examples/app-showcase/src/data/hooks/index.ts
+++ b/examples/app-showcase/src/data/hooks/index.ts
@@ -47,7 +47,7 @@ export const AuditTaskCompletionHook = {
   condition: "record.done == true",
   body: {
     language: 'js' as const,
-    source: "var r = ctx.result || ctx.input || {}; if (typeof ctx.log === 'function') ctx.log('task completed: ' + (r.title || r.id || 'unknown'));",
+    source: "var r = ctx.result || ctx.input || {}; ctx.log.info('task completed: ' + (r.title || r.id || 'unknown'));",
     capabilities: ['log'] as ('log')[],
   },
   async: true,
@@ -70,7 +70,7 @@ export const WarnOverBudgetHook = {
   condition: "has(record.spent) && has(record.budget) && record.spent > record.budget",
   body: {
     language: 'js' as const,
-    source: "var r = ctx.result || ctx.input || {}; if (typeof ctx.log === 'function') ctx.log('project over budget: ' + (r.name || r.id || 'unknown') + ' (' + r.spent + ' / ' + r.budget + ')');",
+    source: "var r = ctx.result || ctx.input || {}; ctx.log.warn('project over budget: ' + (r.name || r.id || 'unknown') + ' (' + r.spent + ' / ' + r.budget + ')');",
     capabilities: ['log'] as ('log')[],
   },
   async: true,


### PR DESCRIPTION
## 背景

`examples/app-showcase` 的两个 hook body 用 `if (typeof ctx.log === 'function') ctx.log(...)` 守卫日志行,但沙箱 hook 运行时把 `ctx.log` 装成**对象** `{ info, warn, error }`(见 `packages/runtime/src/sandbox/quickjs-runner.ts` 的 `installCtx` 与 `script-runner.ts` 的 `ScriptContext.log`),所以 `typeof ctx.log === 'function'` **恒为 false**,这两行审计/告警日志是**死代码**,从不触发。

## 改动

改用正确的对象方法 API:

| Hook | 改后 |
|---|---|
| `AuditTaskCompletionHook`(审计) | `ctx.log.info(...)` |
| `WarnOverBudgetHook`(告警) | `ctx.log.warn(...)` |

两个 hook 都已声明 `capabilities: ['log']`,无需改能力。body 保持极简(去掉死守卫后更短,便于当文档阅读)。

> 说明:告警 hook 用了语义匹配的 `.warn`(hook 名 `WarnOverBudget`、描述 "Emits a warning"),它与 `.info` 同属正确 API,还顺带在 showcase 里演示了第二个日志级别,契合本文件"exercise the full hook designer surface / read as documentation"的定位。

`ctx.log` 的发射本身是 best-effort(转发到 `ctx.log?.[level]?.()`,hook 路径下 host logger 可能缺省 → 静默 no-op),所以本改动修的是"调对 API",不改变可观测性;未把它们改造成写数据的 hook(超出范围)。纯 bug 修复,无需 changeset(AGENTS.md §263)。

## 验证

- `os validate` 通过(showcase 全量,仅有与本改动无关的预存权限/master-detail 警告)。
- showcase `vitest run`:9 文件 / 55 测试全绿。
- 契约核对:`quickjs-runner.ts` installCtx 把 `ctx.log` 装为对象、每 level 转发 `ctx.log?.[level]?.(...)`;`ScriptContext.log` 类型为 `{ info, warn, error }`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)