### PR TITLE
ci: drop the OS_SANDBOX_HOOK_TIMEOUT_MS=10000 floor — redundant after ADR-0102 D1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,6 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# The QuickJS sandbox compiles a fresh WASM module per hook/action invocation
-# (and a nested hook compiles another inside the parent's budget). Hosted runners
-# are 4-vCPU and the test job oversubscribes them (`turbo --concurrency=4` + each
-# vitest worker), so that fixed VM-creation cost alone intermittently tripped the
-# 250ms hook default even while the VM was progressing — a load flake unrelated to
-# the change under test (#3259). Raise the sandbox hook budget for the whole
-# workflow; production keeps the 250ms default (this only sets it in CI). Real
-# hangs are still bounded by each test's own vitest timeout.
-env:
-  OS_SANDBOX_HOOK_TIMEOUT_MS: '10000'
-
 jobs:
   filter:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to the ADR-0102 sandbox work (#3275). Removes the workflow-wide `env: OS_SANDBOX_HOOK_TIMEOUT_MS: '10000'` added in #3270.

## Why it's now redundant

#3270 raised the sandbox hook budget across the whole CI workflow to paper over the #3259 flake: on an oversubscribed 4-vCPU runner, the fixed per-invocation WASM-creation cost alone tripped the 250ms **wall-clock** hook deadline while the VM was still progressing.

**ADR-0102 D1 (#3301)** changed the budget to **script CPU-time**: VM creation and idle host-await time are no longer charged. So the 250ms default is meaningful again on a loaded runner, and this global floor is dead weight.

## This doubles as an end-to-end validation of D1

With the floor gone, the sandbox suite runs at the **stock 250ms CPU budget** on CI — including the nested-write integration tests (which were switched to the stock default in Phase 1). If **Test Core stays green**, that proves the #3259 flake is fixed at the root (VM-creation cost isn't charged to a CPU budget), not merely masked by a larger number.

- Tests that assert a specific budget set it explicitly (`hookTimeoutMs` / body `timeoutMs`) and are unaffected.
- Production always kept the 250ms/5000ms defaults; the `OS_SANDBOX_*_TIMEOUT_MS` / `OS_SANDBOX_WALL_CEILING_MS` env overrides remain available for constrained hardware.

## Notes

- CI-only config; no package change, no changeset.
- Uses `allow-major` to bypass the unrelated pre-existing `@objectstack/console: major` changeset on `main`.

**Please don't fast-merge** — the point is to watch **Test Core** go green at the stock budget first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011iJLjqToxNv1aYP3syQtRp)_