### PR TITLE
chore(spec): regenerate stale ADR-0087 artifacts (spec-changes.json + upgrade guide)

### DIFF
--- a/docs/protocol-upgrade-guide.md
+++ b/docs/protocol-upgrade-guide.md
@@ -3,7 +3,7 @@
 
 # Metadata protocol upgrade guide
 
-Current protocol: **15.0.0** · chain support floor: **protocol 10** · generated from the ADR-0087 registries (`@objectstack/spec` `conversions/` + `migrations/`).
+Current protocol: **16.0.0** · chain support floor: **protocol 10** · generated from the ADR-0087 registries (`@objectstack/spec` `conversions/` + `migrations/`).
 
 ## How to upgrade — from any past major
 
@@ -103,6 +103,16 @@ Protocol 15 unified the conditional-visibility predicate under `visibleWhen` (AD
 - **`ui-schemas-strict-unknown-keys`** — `view form fields/sections · page components (undeclared keys)` → declared keys only (`visibleWhen` for visibility predicates)
   - Why not automatic: The `.strict()` flip (ADR-0089 D3a) turns a previously silently-stripped unknown key into a parse error. There is no mapping target for an arbitrary unknown key — auto-deleting it would be exactly the silent data loss ADR-0078 bans — so each occurrence needs the author to decide: fix the typo, move it to the right layer, or delete dead metadata.
   - Done when: `objectstack validate` passes with no unknown-key parse errors on form fields, form sections, or page components.
+
+## Protocol 15 → 16
+
+Protocol 16 flipped `DashboardWidgetSchema` to `.strict()` (framework#3251, ADR-0021 endpoint): an undeclared top-level widget key is now a loud parse error instead of a silent strip (ADR-0049 enforce-or-remove, ADR-0078 no-silently-inert). The inline analytics shape it most often catches (`object`+`categoryField`+`valueField`+`aggregate`, pivot `rowField`/`columnField`) was already removed at protocol 9, so no mechanical rewrite applies; the residue is the strictness itself, delegated to the author because an arbitrary unknown key has no lossless canonical target.
+
+### Semantic (delegated to you, with acceptance criteria)
+
+- **`dashboard-widget-strict-unknown-keys`** — `dashboard widgets (undeclared top-level keys — legacy inline analytics, objectui-internal `component`/`data`, or typos)` → declared keys only (`dataset` + `dimensions` + `values` for analytics; `options` for renderer-specific extras)
+  - Why not automatic: The `.strict()` flip turns a previously silently-stripped unknown key into a parse error. There is no mapping target for an arbitrary unknown key — auto-deleting it would be exactly the silent data loss ADR-0078 bans — so each occurrence needs the author to decide: bind a `dataset` and select `dimensions`/`values`, move a renderer setting under `options`, or delete the dead key.
+  - Done when: `objectstack validate` passes with no unknown-key parse errors on dashboard widgets.
 
 ---
 

--- a/packages/spec/spec-changes.json
+++ b/packages/spec/spec-changes.json
@@ -1,11 +1,11 @@
 {
   "$comment": "GENERATED (ADR-0087 D4) — do not edit. Regenerate with: pnpm --filter @objectstack/spec gen:spec-changes. A projection of the D2 conversion table + D3 migration chain; the upgrade guide and the MCP spec_changes tool derive from this same data.",
-  "protocolVersion": "15.0.0",
+  "protocolVersion": "16.0.0",
   "supportFloor": 10,
   "migrateCommand": "objectstack migrate meta --from <N>  (N >= 10)",
   "aggregate": {
     "from": 10,
-    "to": 15,
+    "to": 16,
     "added": [],
     "converted": [
       {
@@ -132,6 +132,13 @@
         "migrationId": "ui-schemas-strict-unknown-keys",
         "toMajor": 15,
         "rationale": "The `.strict()` flip (ADR-0089 D3a) turns a previously silently-stripped unknown key into a parse error. There is no mapping target for an arbitrary unknown key — auto-deleting it would be exactly the silent data loss ADR-0078 bans — so each occurrence needs the author to decide: fix the typo, move it to the right layer, or delete dead metadata."
+      },
+      {
+        "surface": "dashboard widgets (undeclared top-level keys — legacy inline analytics, objectui-internal `component`/`data`, or typos)",
+        "replacement": "declared keys only (`dataset` + `dimensions` + `values` for analytics; `options` for renderer-specific extras)",
+        "migrationId": "dashboard-widget-strict-unknown-keys",
+        "toMajor": 16,
+        "rationale": "The `.strict()` flip turns a previously silently-stripped unknown key into a parse error. There is no mapping target for an arbitrary unknown key — auto-deleting it would be exactly the silent data loss ADR-0078 bans — so each occurrence needs the author to decide: bind a `dataset` and select `dimensions`/`values`, move a renderer setting under `options`, or delete the dead key."
       }
     ],
     "removed": []
@@ -304,6 +311,22 @@
           "migrationId": "ui-schemas-strict-unknown-keys",
           "toMajor": 15,
           "rationale": "The `.strict()` flip (ADR-0089 D3a) turns a previously silently-stripped unknown key into a parse error. There is no mapping target for an arbitrary unknown key — auto-deleting it would be exactly the silent data loss ADR-0078 bans — so each occurrence needs the author to decide: fix the typo, move it to the right layer, or delete dead metadata."
+        }
+      ],
+      "removed": []
+    },
+    {
+      "from": 15,
+      "to": 16,
+      "added": [],
+      "converted": [],
+      "migrated": [
+        {
+          "surface": "dashboard widgets (undeclared top-level keys — legacy inline analytics, objectui-internal `component`/`data`, or typos)",
+          "replacement": "declared keys only (`dataset` + `dimensions` + `values` for analytics; `options` for renderer-specific extras)",
+          "migrationId": "dashboard-widget-strict-unknown-keys",
+          "toMajor": 16,
+          "rationale": "The `.strict()` flip turns a previously silently-stripped unknown key into a parse error. There is no mapping target for an arbitrary unknown key — auto-deleting it would be exactly the silent data loss ADR-0078 bans — so each occurrence needs the author to decide: bind a `dataset` and select `dimensions`/`values`, move a renderer setting under `options`, or delete the dead key."
         }
       ],
       "removed": []


### PR DESCRIPTION
Two **generated** ADR-0087 artifacts went stale on `main` — never regenerated when the protocol moved to major **16** (the dashboard-widget `.strict()` migration, `dashboard-widget-strict-unknown-keys`, changeset `dashboard-widget-strict-3251`). Both are enforced by the **Check Generated Artifacts** CI job, so it fails on **every open PR** — a `main`-health issue surfaced while validating the ADR-0102 sandbox work (#3275 / #3328).

## Stale artifacts (both pure projections of the ADR-0087 registries)

1. `packages/spec/spec-changes.json` — the machine-readable change manifest (ADR-0087 D4) · `check:spec-changes`
2. `docs/protocol-upgrade-guide.md` — the human upgrade guide · `check:upgrade-guide` (the job fails fast on #1, so this only surfaced once #1 was fixed)

## Fix

Regenerated both with the committed generators — pure re-projection of already-merged registries, no source or behaviour change:

- `pnpm --filter @objectstack/spec gen:spec-changes` → `protocolVersion` 15.0.0 → 16.0.0; aggregate `to` 15 → 16; new 15→16 `migrated` record
- `pnpm --filter @objectstack/spec gen:upgrade-guide` → current protocol 15.0.0 → 16.0.0; new "Protocol 15 → 16" section

All three checks in the job (`check:skill-docs`, `check:spec-changes`, `check:upgrade-guide`) pass locally.

## Notes

- **No new changeset**: the underlying migration already shipped its own (`dashboard-widget-strict-3251`); this is a generated-artifact re-sync only.
- `allow-major` bypasses the unrelated pre-existing `@objectstack/console: major` changeset already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iJLjqToxNv1aYP3syQtRp