### PR TITLE
feat(approvals): declare file attachments on approve/reject decisions

### DIFF
--- a/.changeset/approvals-decision-attachments.md
+++ b/.changeset/approvals-decision-attachments.md
@@ -1,0 +1,18 @@
+---
+"@objectstack/plugin-approvals": minor
+---
+
+feat(approvals): declare file attachments on approve/reject decisions
+
+The declared `approval_approve` / `approval_reject` actions on
+`sys_approval_request` gain an optional multi-file `attachments` param
+(`type: 'file'`, `multiple`). The console renders `type:'file'` action params
+through the shared upload widget (objectui ADR-0059) and POSTs the resolved
+`attachments: string[]`, so a reviewer can attach supporting files to a
+decision through the generic declared-action dialog — letting the approvals
+inbox retire its hand-wired attachment composer (objectui#2698).
+
+Purely additive metadata: the decision route already forwards
+`body.attachments` to `ApprovalService.decide`, and the
+`sys_approval_action.attachments` column (file, multiple) already persists them
+(#3266/#3274). No service or route change.

--- a/packages/plugins/plugin-approvals/src/sys-approval-request.object.test.ts
+++ b/packages/plugins/plugin-approvals/src/sys-approval-request.object.test.ts
@@ -91,4 +91,12 @@ describe('sys_approval_request declared actions', () => {
       expect(c.required ?? false).toBe(false);
     }
   });
+
+  it('approve/reject collect optional multi-file decision attachments', () => {
+    for (const name of ['approval_approve', 'approval_reject']) {
+      const att = byName(name).params.find((p: any) => p.name === 'attachments');
+      expect(att, `${name}.attachments`).toMatchObject({ type: 'file', multiple: true });
+      expect(att.required ?? false).toBe(false);
+    }
+  });
 });

--- a/packages/plugins/plugin-approvals/src/sys-approval-request.object.ts
+++ b/packages/plugins/plugin-approvals/src/sys-approval-request.object.ts
@@ -248,6 +248,10 @@ export const SysApprovalRequest = ObjectSchema.create({
       target: '/api/v1/approvals/requests/{id}/approve',
       params: [
         { name: 'comment', label: 'Comment', type: 'textarea', required: false },
+        // Decision attachments (#3266). The console renders `type:'file'` params
+        // through the shared upload widget and POSTs the resolved `attachments:
+        // string[]`; the decision route persists them on `sys_approval_action`.
+        { name: 'attachments', label: 'Attachments', type: 'file', multiple: true, required: false },
       ],
       visible: 'record.status == "pending"',
       locations: ['record_section', 'list_item'],
@@ -263,6 +267,7 @@ export const SysApprovalRequest = ObjectSchema.create({
       target: '/api/v1/approvals/requests/{id}/reject',
       params: [
         { name: 'comment', label: 'Comment', type: 'textarea', required: false },
+        { name: 'attachments', label: 'Attachments', type: 'file', multiple: true, required: false },
       ],
       visible: 'record.status == "pending"',
       confirmText: 'Reject this request? A rejection is final for every approver.',


### PR DESCRIPTION
Backend half of retiring the approvals inbox's hand-wired attachment composer (objectui#2698). Pairs with the objectui PR that removes the composer and renders decisions purely through `DeclaredActionsBar`.

## What

Add an optional multi-file **`attachments`** param to the declared `approval_approve` / `approval_reject` actions on `sys_approval_request`:

```ts
{ name: 'attachments', label: 'Attachments', type: 'file', multiple: true, required: false }
```

The console renders `type:'file'` action params through the shared upload widget (objectui ADR-0059 / #2700) and POSTs the resolved `attachments: string[]`, so a reviewer attaches supporting files to a decision through the generic declared-action dialog — no bespoke composer.

## Why it's this small

**No service or route change.** The decision route already forwards `body.attachments` to `ApprovalService.decide` (`packages/rest/src/rest-server.ts`), and the `sys_approval_action.attachments` column (`Field.file`, `multiple`) already persists them (#3266 / #3274). This PR only surfaces the capability as declared metadata. The spec already accepts `type:'file'` + `multiple` (`ActionParamSchema`), so no spec change either.

## Verification

- `plugin-approvals` suite green (144 tests), incl. a new contract test pinning the `attachments` param (type `file`, `multiple`, optional) on both actions.
- End-to-end (with the objectui PR, against a live backend): the declared Approve dialog renders a file-upload widget, and staging a file + confirming POSTs `{comment, attachments:["<fileId>"]}` — the upload id serialized correctly. (The persist path is the pre-existing, already-tested `decide` → `sys_approval_action.attachments`.)

## Refs
objectui#2698 (composer retirement) · #3266 / #3274 (attachments column + route passthrough) · framework#3300 (declared action set) · #2678 (P2-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ypkQikZ55oWUHUnMebwXA)_