### PR TITLE
ci: exempt Changesets pre-release (RC) mode from the no-major guard

### DIFF
--- a/scripts/check-changeset-no-major.mjs
+++ b/scripts/check-changeset-no-major.mjs
@@ -22,8 +22,17 @@
  * Exits with code 1 (and a clear list of offenders) if any changeset frontmatter
  * bumps a package `major`.
  *
- * ESCAPE HATCH: when a major release is genuinely intended, gate this check off
- * in CI with the `allow-major` PR label (see `.github/workflows/pr-automation.yml`).
+ * RC EXEMPTION: when Changesets is in pre-release mode (`.changeset/pre.json`
+ * with `"mode": "pre"`, entered via `changeset pre enter <tag>`), a `major`
+ * bump only ever produces a `X.0.0-<tag>.N` PRE-RELEASE version — nothing final
+ * publishes until `changeset pre exit`. Accumulating the next major's breaking
+ * changes is precisely what an RC window is FOR, so this guard stands aside for
+ * the duration and re-arms automatically once pre-mode is exited. The pending
+ * majors are still printed (informationally) so the RC curator can eyeball them.
+ *
+ * ESCAPE HATCH: outside pre-mode, when a major release is genuinely intended,
+ * gate this check off in CI with the `allow-major` PR label (see
+ * `.github/workflows/pr-automation.yml`).
  *
  * The script intentionally has zero third-party dependencies so it can run in
  * minimal CI environments before `pnpm install`.
@@ -80,6 +89,26 @@ for (const name of entries) {
 if (offenders.length === 0) {
   console.log('✓ No `major` bumps in pending changesets.');
   process.exit(0);
+}
+
+// RC exemption: in Changesets pre-release mode a `major` only yields a
+// `X.0.0-<tag>.N` pre-release — the intended product of an RC window — and
+// nothing final ships until `changeset pre exit`. Surface the pending majors
+// for the RC curator, but do not fail. The guard re-arms once pre-mode exits.
+try {
+  const pre = JSON.parse(readFileSync(join(changesetDir, 'pre.json'), 'utf8'));
+  if (pre?.mode === 'pre') {
+    console.log(
+      `✓ Changesets is in pre-release mode (tag: ${pre.tag ?? 'unknown'}) — ` +
+        '`major` bumps are the expected product of an RC window; skipping the no-major guard.',
+    );
+    for (const { file, majors } of offenders) {
+      console.log(`::notice file=${file}::pending major in ${file}: ${majors.join(', ')}`);
+    }
+    process.exit(0);
+  }
+} catch {
+  // No readable `.changeset/pre.json` → not in pre-mode → fall through to the guard.
 }
 
 console.error('⛔ Changeset(s) declare a `major` bump.\n');


### PR DESCRIPTION
## What

Make the launch-window **no-major guard** ([`scripts/check-changeset-no-major.mjs`](../blob/main/scripts/check-changeset-no-major.mjs)) stand aside while Changesets is in **pre-release (RC) mode**.

## Why

The guard scans **every pending changeset in the tree** (not the PR diff), so a single `major` changeset sitting on `main` makes the **Check Changeset** job red on *every subsequent PR* that lacks the `allow-major` label. That is exactly what is happening now: [`.changeset/remove-session-tenantid-alias.md`](../blob/main/.changeset/remove-session-tenantid-alias.md) (#3290) declares three `major` bumps.

But the repo is **currently in `changeset pre enter rc` mode** (`.changeset/pre.json` → `"mode": "pre"`, `"tag": "rc"`). In pre-release mode a `major` only ever produces a `X.0.0-rc.N` **pre-release** — nothing final publishes until `changeset pre exit`. Accumulating the next major's breaking changes is precisely what an RC window is *for*, so the guard should not fight its own release process by reding every PR with a per-PR `allow-major` toll.

## Change

- If `.changeset/pre.json` exists with `mode: "pre"`, the guard **prints the pending majors as `::notice::` annotations** (so the RC curator can still eyeball them) and **exits 0** instead of failing.
- Outside pre-mode the behavior is **unchanged**: any `major` still fails, escape hatch remains the `allow-major` label.
- The exemption keys off the Changesets state machine itself, so it **re-arms automatically** on `changeset pre exit` — zero per-PR maintenance.

## Verification (local, both branches)

```
# RC mode (pre.json present, one major changeset)
✓ Changesets is in pre-release mode (tag: rc) — skipping the no-major guard.
::notice ...pending major in .changeset/remove-session-tenantid-alias.md: @objectstack/spec, @objectstack/objectql, @objectstack/runtime
exit=0

# non-pre mode (pre.json moved aside)
⛔ Changeset(s) declare a `major` bump.  ... exit=1
```

CI-tooling-only change (no publishable package touched) → `skip-changeset`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)