### PR TITLE
fix(create-objectstack): exclude CHANGELOG.md from the skills-catalog-boundary ratchet (unblocks main Test Core)

### DIFF
--- a/packages/create-objectstack/src/template-consistency.test.ts
+++ b/packages/create-objectstack/src/template-consistency.test.ts
@@ -318,6 +318,12 @@ describe('skills catalog boundary', () => {
       'packages/create-objectstack',
       // this file mentions the bare form on purpose (needle + error message)
       ':(exclude)packages/create-objectstack/src/template-consistency.test.ts',
+      // CHANGELOGs are auto-generated from changeset prose and legitimately
+      // quote a removed command in past tense while documenting its removal
+      // (#3101: "…advertised `skills add objectstack-ai/framework --all` … now
+      // scoped to the /skills subpath"). Documenting a fix is not advertising
+      // the anti-pattern — only real customer-facing surfaces count.
+      ':(exclude)**/CHANGELOG.md',
     ];
     let candidates = '';
     try {


### PR DESCRIPTION
## Problem — `Test Core` is red on `main`

The required **Test Core** gate has been failing on `main` since before the current head (first seen at `e412fb676` / `631debac5`; last green `629fbae80`). One test fails:

`create-objectstack › template-consistency.test.ts › skills catalog boundary › no customer-facing surface advertises a repo-root skills install`

### Root cause

The guard greps `content/docs` / `skills` / `packages/create-objectstack` for `skills add objectstack-ai/framework` **not** followed by `/skills`, excluding only the test file — **not `CHANGELOG.md`**.

When Changesets versioned `create-objectstack` in RC mode, it baked **#3101**'s changeset prose into `packages/create-objectstack/CHANGELOG.md:99`. That entry documents the fix by quoting the *removed* command in past tense:

> "…the scaffolder (and the docs) advertised `npx skills add objectstack-ai/framework --all` … All install commands are now scoped to the published catalog via the `/skills` subpath…"

The ratchet flagged that historical quote as a live advertisement. Every real advertising surface (`content/docs/**`, `README.md`, `src/index.ts`, `templates/AGENTS.md`) already uses the correct `/skills` subpath — the CHANGELOG is the only "offender", and it's a false positive.

### Fix

Exclude `**/CHANGELOG.md` from the guard's grep surfaces. A changelog documenting the **removal** of an anti-pattern is not advertising it. One line + rationale comment.

## Verification

`pnpm --filter create-objectstack test` → **18/18 pass** (was 1 failing). Reproduced the single offender locally and confirmed the `:(exclude)**/CHANGELOG.md` pathspec drops it (1 → 0 matches).

## Notes

- Pre-existing failure, unrelated to #3298/#3345 (discovery capability) — that PR's own Test Core was green pre-merge; its post-merge run was *cancelled* (superseded by #3344), not failed.
- `skip-changeset`: test-infra only, nothing shipped in the published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)