### PR TITLE
ci(changeset-check): gate on changesets the PR adds, not a non-empty dir

### DIFF
--- a/.changeset/viewfilterrule-operator-enum-3373.md
+++ b/.changeset/viewfilterrule-operator-enum-3373.md
@@ -1,0 +1,14 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): enforce the `ViewFilterRule` operator enum with legacy-alias
+normalization (#3373)
+
+`ViewFilterRule.operator` was previously an open string, so views could persist
+operators the runtime cannot evaluate. The Zod schema now constrains it to the
+supported operator enum and normalizes the known legacy aliases to their
+canonical form on parse. This is a public spec/api-surface change
+(`packages/spec/api-surface.json`) that landed on `main` in #3373 without a
+changeset; this backfills it so the fix ships in the next release instead of
+being silently stranded.

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -71,19 +71,31 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Check for changesets
+      - name: Check for a changeset added by this PR
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           if [ ! -d ".changeset" ]; then
             echo "::warning::.changeset directory not found. Skipping changeset check."
             exit 0
           fi
-          CHANGESET_COUNT=$(find .changeset -name '*.md' ! -name 'README.md' | wc -l)
-          if [ "$CHANGESET_COUNT" -eq 0 ]; then
-            echo "::error::No changeset found. Add one with 'pnpm changeset' if this PR includes user-facing changes, or apply the 'skip-changeset' label if it doesn't."
+          # Count changesets THIS PR adds (diff against the base commit), NOT
+          # the whole .changeset directory. A global `find | wc -l` is unsound:
+          # in pre-release (RC) mode `changeset version` RETAINS every consumed
+          # .md file, so the directory is permanently non-empty and the gate can
+          # never go red. #3373 merged a real spec/api-surface fix with no
+          # changeset while this step happily reported "Found 104 changeset(s)".
+          # Diffing against BASE_SHA ignores that residue and sees only what the
+          # PR itself introduced. An empty-frontmatter changeset still counts —
+          # it is the sanctioned "this PR releases nothing" declaration, on par
+          # with the skip-changeset label.
+          ADDED=$(git diff --name-only --diff-filter=A "$BASE_SHA" HEAD -- '.changeset/*.md' \
+                  | grep -v '/README\.md$' | wc -l | tr -d '[:space:]')
+          if [ "$ADDED" -eq 0 ]; then
+            echo "::error::This PR adds no changeset. Run 'pnpm changeset' (an empty changeset is fine for changes that release nothing), or apply the 'skip-changeset' label if it does not need one."
             exit 1
-          else
-            echo "Found $CHANGESET_COUNT changeset(s)"
           fi
+          echo "This PR adds $ADDED changeset(s)."
 
       - name: Guard against accidental major bumps (launch window)
         # Every publishable package is in one Changesets "fixed" (lockstep) group,


### PR DESCRIPTION
## Why

`changeset 是不是坏了` — no. But the **`Check Changeset` gate is falsely green**, which is why real changes (e.g. the #3373 spec fix) slipped onto `main` with no changeset and won't be released.

The gate counted every `.md` in `.changeset/`:

```bash
CHANGESET_COUNT=$(find .changeset -name '*.md' ! -name 'README.md' | wc -l)
```

That only asserts the **directory is non-empty** — never that *this PR* added a changeset. In **pre-release (RC) mode** `changeset version` **retains** consumed changeset files, so the directory is permanently non-empty and the gate can **never go red**. Evidence: [#3373](https://github.com/objectstack-ai/framework/pull/3373) merged a real `@objectstack/spec` / `api-surface.json` fix with **no changeset** while this step reported `Found 104 changeset(s)`.

## What

- **Rewrite the check to diff against the base commit** and count only the changesets the PR itself adds (`git diff --diff-filter=A "$BASE_SHA" HEAD -- '.changeset/*.md'`). RC residue no longer masks a missing changeset. An empty-frontmatter changeset still counts — it is the sanctioned "this PR releases nothing" declaration, on par with the `skip-changeset` label.
- **Backfill the missing #3373 changeset** (`@objectstack/spec` patch) so the ViewFilterRule operator-enum fix actually ships in the next RC instead of being stranded on `main`.

## Proof it can go red (防假绿)

Ran the new one-liner against real commits:

| Diff | Added changesets | Verdict |
|---|---|---|
| old gate @ main HEAD | `find` = 104 | always **GREEN** (the bug) |
| #3373 `d419826a8^..d419826a8` (spec fix, no changeset) | 0 | **RED** ✅ |
| #3360 `2b5d7258d^..2b5d7258d` (adds a changeset) | 1 | **GREEN** ✅ |

This PR adds its own changeset, so it passes its own gate.

> Note: `Check Changeset` is not a *required* status check, so it still won't hard-block merges on its own — but it will now actually go red and show up as a failed check instead of silently passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)