### PR TITLE
chore(release): exit RC pre-release mode → stable 16.0.0

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "rc",
   "initialVersions": {
     "@objectstack/docs": "4.2.1",


### PR DESCRIPTION
## What

Flips `.changeset/pre.json` mode `pre` → `exit` — equivalent to `changeset pre exit`. This ends the 16.0 RC cycle.

Once this merges, the `Release` workflow's `changeset version` step rolls **every changeset accumulated during the RC window** into a **single stable bump** and opens a `chore: version packages` PR:

- whole lockstep `fixed` group: **15.1.1 → 16.0.0** (no `-rc` suffix)
- publishes to the `latest` dist-tag instead of `rc`

## Breaking change driving the major

The only `major` changeset is `remove-session-tenantid-alias.md` — removes the deprecated `session.tenantId` alias on `@objectstack/spec` / `@objectstack/objectql` / `@objectstack/runtime` (use `organizationId`). Because the group versions in lockstep, that single major promotes the whole stack to 16.0.0. Everything else accumulated as `minor`/`patch` per the launch-window convention.

## Labels / gates

- `skip-changeset`: this is a release-process flip, not a package change, so it adds no `.md` changeset. The label skips the whole `Check Changeset` job — which also stands down the **no-major guard** that re-arms the moment `pre.json` leaves `mode: pre`. The whole-stack major is intentional here.

## After merge

The stable `chore: version packages` PR (16.0.0) will appear. **Merging THAT PR is the actual npm publish** — held for explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)