### PR TITLE
docs(readme): 拆分后在 README 首屏明确本仓库与 ObjectOS 的定位

### DIFF
--- a/.changeset/readme-objectos-split-positioning.md
+++ b/.changeset/readme-objectos-split-positioning.md
@@ -1,0 +1,4 @@
+---
+---
+
+README-only update after the objectos / objectstack repository split: state the "this repo = open-source framework, ObjectOS = commercial runtime environment" positioning on the first screen and cross-link the objectos repo. Docs only, so this releases nothing.

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@
 
 `Fits in an agent's context` · `Typed, validated, governed` · `Self-host anywhere` · Apache-2.0
 
-**This repository is the open-source framework** — the protocol
-(`@objectstack/spec`), microkernel, SDK, CLI, and production runtime,
-Apache-2.0 end to end. Prefer the platform operated for you? That's
+**Everything in this repo is the open stack** — protocol, microkernel, SDK,
+CLI, and the production runtime, Apache-2.0 with no open-core asterisks. You
+can build, ship, and self-host real apps from here alone. Rather have the
+platform run for you, AI Builder and governance included? That's
 **[ObjectOS](https://github.com/objectstack-ai/objectos)**, the commercial
-runtime environment built on it.
+runtime environment built on this stack.
 
 <p align="center">
   <img src="docs/screenshots/architecture.png" width="940" alt="ObjectStack architecture: author typed Zod metadata (objects, flows, views, policies); the microkernel compiles it into a versioned JSON artifact and loads plugins, drivers, and services; it generates a REST API, client SDK, Console and Studio UI, and MCP tools used by developers and AI agents, governed by Auth, RBAC, RLS, FLS, and audit, over PostgreSQL, MySQL, SQLite, or MongoDB">

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@
 
 `Fits in an agent's context` · `Typed, validated, governed` · `Self-host anywhere` · Apache-2.0
 
+**This repository is the open-source framework** — the protocol
+(`@objectstack/spec`), microkernel, SDK, CLI, and production runtime,
+Apache-2.0 end to end. Prefer the platform operated for you? That's
+**[ObjectOS](https://github.com/objectstack-ai/objectos)**, the commercial
+runtime environment built on it.
+
 <p align="center">
   <img src="docs/screenshots/architecture.png" width="940" alt="ObjectStack architecture: author typed Zod metadata (objects, flows, views, policies); the microkernel compiles it into a versioned JSON artifact and loads plugins, drivers, and services; it generates a REST API, client SDK, Console and Studio UI, and MCP tools used by developers and AI agents, governed by Auth, RBAC, RLS, FLS, and audit, over PostgreSQL, MySQL, SQLite, or MongoDB">
   <br><sub>One typed definition → database · REST API · client SDK · UI · MCP tools.</sub>
@@ -171,7 +177,8 @@ derived from that one source. See [ARCHITECTURE.md](./ARCHITECTURE.md).
 
 **Want it governed and hosted, with Build & Ask AI built in?**
 [ObjectOS](https://www.objectos.ai) is the commercial runtime for these
-definitions.
+definitions — [objectstack-ai/objectos](https://github.com/objectstack-ai/objectos)
+is its public home (docs, issue tracker, trademark policy).
 
 ## Ship it
 


### PR DESCRIPTION
## 背景

objectos / objectstack 已完成拆分。本仓库 README 的正文虽已更新,但首屏没有说明"本仓库=开源框架、ObjectOS=商业产品"的分工,读者要滚动到很靠后的 "This repo" 一节才能看到。

## 改动

- 在 README 顶部(标语行之后)新增一段定位简介,采用 benefit-led 写法:整个仓库都是开放技术栈(协议、微内核、SDK、CLI、生产运行时),Apache-2.0、无 open-core 附加条件,单靠本仓库即可构建、发布、自托管真实应用;想要托管运营(含 AI Builder 与治理)则指向商业产品仓库 [objectstack-ai/objectos](https://github.com/objectstack-ai/objectos)。
- "This repo" 一节中的 ObjectOS 链接补充其 GitHub 公开仓库(文档、issue、商标政策所在地)。
- 补充空 changeset(README-only,不发版)以通过 Check Changeset。

## 建议同步更新仓库 About 简介(需管理员在仓库设置中修改)

当前 About 还是拆分前的旧文案。建议改为:

> AI writes the app. ObjectStack is what it writes — a complete business app as ~2,000 lines of typed, validated metadata, run as database, REST API, UI, and MCP tools. Open source, Apache-2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145qhfty9sRLm3HUvNBFxpk