### PR TITLE
docs(readme): 新首屏标语 "A complete business system in 16k tokens" 并融入 ontology 叙事

### DIFF
--- a/.changeset/readme-hero-16k-ontology.md
+++ b/.changeset/readme-hero-16k-ontology.md
@@ -1,0 +1,4 @@
+---
+---
+
+README-only rewrite of the hero tagline ("A complete business system in 16k tokens.") weaving in the business-ontology narrative. Docs only, so this releases nothing.

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@
 `Fits in an agent's context` · `Typed, validated, governed` · `Self-host anywhere` · Apache-2.0
 
 **Everything in this repo is the open stack** — protocol, microkernel, SDK,
-CLI, and the production runtime, Apache-2.0 with no open-core asterisks. You
-can build, ship, and self-host real apps from here alone. Rather have the
-platform run for you, AI Builder and governance included? That's
-**[ObjectOS](https://github.com/objectstack-ai/objectos)**, the commercial
-runtime environment built on this stack.
+CLI, and the production runtime, Apache-2.0 with no open-core asterisks. The
+workflow here is **build & ask with Claude Code** (or any coding agent): the
+agent writes the metadata in your repo, and operates the running app over
+MCP. Rather **build & ask online** — in the browser, nothing to install?
+That's **[ObjectOS](https://github.com/objectstack-ai/objectos)**, the
+commercial runtime environment built on this stack.
 
 <p align="center">
   <img src="docs/screenshots/architecture.png" width="940" alt="ObjectStack architecture: author typed Zod metadata (objects, flows, views, policies); the microkernel compiles it into a versioned JSON artifact and loads plugins, drivers, and services; it generates a REST API, client SDK, Console and Studio UI, and MCP tools used by developers and AI agents, governed by Auth, RBAC, RLS, FLS, and audit, over PostgreSQL, MySQL, SQLite, or MongoDB">

--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue.svg)
 ![Tests](https://img.shields.io/badge/tests-6%2C507%20passing-brightgreen.svg)
 
-> ## AI writes the app. ObjectStack is what it writes.
+> ## A complete business system in 16k tokens.
 >
-> The open target format and runtime for AI-written business apps. Your coding
-> agent writes models, UI, workflows, and permissions as compact typed metadata —
-> [a complete CRM is under 2,000 lines](#why-the-mistakes-dont-ship), so the whole
-> app fits in the agent's context — and strict TypeScript, Zod schemas, and a
-> validation gate catch its mistakes at authoring time. The runtime derives the
-> database, REST API, UI, and MCP server, and enforces permissions and audit on
-> every call.
+> ObjectStack compresses an entire app — data model, UI, workflows,
+> permissions — into typed metadata an AI agent can hold in context, reason
+> about, and refactor whole ([a complete CRM is under 2,000
+> lines](#why-the-mistakes-dont-ship)). That metadata is your **business
+> ontology** — an open, versioned definition of your objects, permissions, and
+> flows that you own, not code scattered across a framework. Strict TypeScript,
+> Zod schemas, and a validation gate catch the agent's mistakes at authoring
+> time; the runtime derives the database, REST API, UI, and MCP server, and
+> enforces permissions and audit on every call.
 
 `Fits in an agent's context` · `Typed, validated, governed` · `Self-host anywhere` · Apache-2.0
 


### PR DESCRIPTION
## 背景

原首屏标语 "AI writes the app. ObjectStack is what it writes." 过于自我指涉,没有类别、受众和收益,信息量不足。经讨论选定 "16k tokens" 路线,并要求在 README 中体现 ontology 叙事,以及与 objectos 的核心区别口径(build &amp; ask with Claude Code vs online)。

## 改动

- 首屏大标语改为:**A complete business system in 16k tokens.**
- 首屏引言重写:整个应用(数据模型、UI、工作流、权限)压缩为 AI 智能体可整体装入上下文、推理和重构的类型化元数据(完整 CRM 不到 2,000 行);并点明这份元数据就是企业自有的 **business ontology**(开放、可版本化的对象/权限/流程定义)。
- 定位段落更新为核心区别口径:本仓库的工作流是 **build &amp; ask with Claude Code**(智能体在你的仓库里写元数据、经 MCP 操作运行中的应用);想 **build &amp; ask online**(浏览器内、零安装)则是商业平台 [ObjectOS](https://github.com/objectstack-ai/objectos)(objectos 侧对应改动:objectos#55)。
- 数字(16k tokens、2,000 行)均出自正文 "Why the mistakes don't ship" 一节,无新增声明。附空 changeset(README-only,不发版)。

## 建议同步更新仓库 About(需管理员修改)

> A complete business system in 16k tokens. ObjectStack compresses an entire app — data model, UI, workflows, permissions — into typed metadata an AI agent can hold in context, reason about, and refactor whole. Open source, Apache-2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145qhfty9sRLm3HUvNBFxpk