### PR TITLE
fix(platform-objects): allow import/export on sys_business_unit (#3025)

### DIFF
--- a/.changeset/business-unit-import-export.md
+++ b/.changeset/business-unit-import-export.md
@@ -1,0 +1,17 @@
+---
+"@objectstack/platform-objects": patch
+---
+
+fix(platform-objects): allow import/export on sys_business_unit (#3025)
+
+The Business Units list (Setup → Business Units) surfaces Import/Export buttons,
+but `sys_business_unit` declared a restrictive `enable.apiMethods` whitelist of
+only the five CRUD verbs. The REST data plane gates import/export on that
+whitelist (ADR-0049), so both buttons returned `405 OBJECT_API_METHOD_NOT_ALLOWED`.
+
+This was an unintentional gap, not a deliberate restriction: the object's fields
+(`external_ref`, `effective_from/to`) are designed for HRIS batch sync, and the
+org tree is expected to support bulk import. Added `'import'` and `'export'` to
+the whitelist. Import reuses the `create`/`update` affordances the object already
+grants, and the managed-object reconciliation backstop leaves import/export
+untouched (it only strips write verbs). Regression test added.

--- a/packages/platform-objects/src/identity/sys-business-unit.object.ts
+++ b/packages/platform-objects/src/identity/sys-business-unit.object.ts
@@ -216,7 +216,10 @@ export const SysBusinessUnit = ObjectSchema.create({
     trackHistory: true,
     searchable: true,
     apiEnabled: true,
-    apiMethods: ['get', 'list', 'create', 'update', 'delete'],
+    // Data portability is expected for the org tree: fields like `external_ref`
+    // and `effective_from/to` are designed for HRIS batch sync (#3025). Import
+    // reuses the create/update affordances this object already grants.
+    apiMethods: ['get', 'list', 'create', 'update', 'delete', 'import', 'export'],
     trash: true,
     mru: false,
   },

--- a/packages/platform-objects/src/platform-objects.test.ts
+++ b/packages/platform-objects/src/platform-objects.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import {
   SysAccount,
   SysApiKey,
+  SysBusinessUnit,
   SysDeviceCode,
   SysInvitation,
   SysJwks,
@@ -226,6 +227,23 @@ describe('@objectstack/platform-objects', () => {
         expect(a, `${name} action must exist`).toBeTruthy();
         expect(a?.locations, `${name} locations`).toContain('list_item');
         expect(a?.locations, `${name} must also surface on the detail header`).toContain('record_header');
+      }
+    });
+  });
+
+  describe('data portability whitelist (#3025)', () => {
+    it('sys_business_unit allows import/export so the org tree can be batch-synced', () => {
+      // The Business Units list exposes Import/Export buttons and the object's
+      // schema (external_ref, effective_from/to) is designed for HRIS batch
+      // sync. The REST data plane gates these routes on `enable.apiMethods`
+      // (ADR-0049), so both verbs must be present or the buttons 405 with
+      // OBJECT_API_METHOD_NOT_ALLOWED. Regression guard for #3025.
+      expect(SysBusinessUnit.enable?.apiMethods).toContain('import');
+      expect(SysBusinessUnit.enable?.apiMethods).toContain('export');
+      // The five CRUD verbs it already granted must remain — import writes
+      // reuse the create/update affordances.
+      for (const verb of ['get', 'list', 'create', 'update', 'delete'] as const) {
+        expect(SysBusinessUnit.enable?.apiMethods).toContain(verb);
       }
     });
   });


### PR DESCRIPTION
## 问题

业务单元列表(Setup → Business Units)点「导入」/「导出」按钮报 405:

```
API operation 'import' is not allowed on object 'sys_business_unit'
(405, code: OBJECT_API_METHOD_NOT_ALLOWED)
```

## 根因

REST 数据面按 ADR-0049 用对象上的 `enable.apiMethods` 白名单门控。缺省语义是**无 `apiMethods` = 全放行**——支持导入的对象都是干脆不声明白名单。而 `sys_business_unit` 显式声明了限制性白名单,只有 CRUD 五件套,漏了 `import`/`export`:

```ts
// packages/platform-objects/src/identity/sys-business-unit.object.ts
apiMethods: ['get', 'list', 'create', 'update', 'delete'],
```

排查确认这是**无意的缺口而非刻意收紧**:ADR-0057 与提交注释均未提及;真正刻意收紧的对象(如 `sys_oauth_application`)都有注释 + 测试锁死。且该对象字段(`external_ref`、`effective_from/to`)明确为 HRIS 批量同步设计,组织树本就该支持批量导入。

405 的门控落点在 `packages/rest/src/rest-server.ts`(`apiAccessDenialFromEnable`),import/export 路由(`/data/:object/import`、`/data/:object/export`)在执行前 `enforceApiAccess(..., 'import'|'export')`,故受此白名单门控。

## 修复

白名单补上 `'import'`、`'export'`。

- 导入复用该对象已授予的 `create`/`update` affordance。
- 已验证扛得过 managed-object 白名单回收:`sys_business_unit` 是 `managedBy:'platform'`,`reconcileManagedApiMethods` 只剥写动词(`create/update/upsert/delete/purge`),不动 `import`/`export`。

## 测试

- 新增回归断言:`sys_business_unit` 白名单必须含 `import`/`export`(且保留 CRUD 五件套)。**已验证防假绿**:临时回退修复后该测试如实变红(`expected [...] to include 'import'`)。
- `@objectstack/platform-objects` 套件 214 条全过;`tsc --noEmit` 通过。

## 备注(不在本 PR 范围)

同类缺口:`sys_user`(`['get','list','update']`)、`sys_import_job`(`['get','list']`)等显式白名单对象同样不含 import/export。本 PR 按 #3025 单点修复 `sys_business_unit`;UI 按钮与白名单前后端一致性的通用设计问题按 issue 说明另开 issue 跟进。

Closes #3025

🤖 Generated with [Claude Code](https://claude.com/claude-code)