### PR TITLE
fix(platform-objects): allow import/export on sys_business_unit_member (#3025 / #3391 P0)

### DIFF
--- a/.changeset/business-unit-member-import-export.md
+++ b/.changeset/business-unit-member-import-export.md
@@ -1,0 +1,32 @@
+---
+"@objectstack/platform-objects": patch
+---
+
+fix(platform-objects): allow import/export on sys_business_unit_member (#3025 / #3391 P0)
+
+Completes the #3025 point-fix. #3392 unblocked `sys_business_unit`'s Import/Export
+buttons (405 `OBJECT_API_METHOD_NOT_ALLOWED`) by adding `'import'`/`'export'` to its
+`enable.apiMethods` whitelist, but the HRIS org-tree sync scenario imports **two
+tables together** — the units *and* their memberships — and the sibling
+`sys_business_unit_member` was left on the CRUD-only whitelist, so the membership
+Import/Export path still 405'd. #3391's P0 checklist pairs both tables; this is the
+half #3392 missed.
+
+- `packages/platform-objects/src/identity/sys-business-unit-member.object.ts`:
+  `apiMethods` gains `'import'`, `'export'`. Import reuses the object's
+  already-granted create/update affordances; export is a bulk read.
+- Reconcile-safe: the object is `managedBy:'platform'`, but
+  `reconcileManagedApiMethods` only strips generic write verbs
+  (`create/update/upsert/delete/purge` — `MANAGED_WRITE_VERB_AFFORDANCE`). It never
+  touches `import`/`export`, so the declared whitelist reaches the REST gate intact
+  (no false-green: the static whitelist the regression test asserts IS what
+  `apiAccessDenialFromEnable` enforces at runtime).
+- Regression test (`platform-objects.test.ts`) locks `import`/`export` presence and
+  CRUD retention. Proven red-before-green: reverting the object edit fails with
+  `expected [...] to include 'import'`.
+
+Transitional: #3391 P2 replaces per-object `import`/`export` declarations with a
+single derived mapping (import ⊆ create/update, export ⊆ list) and reclaims the
+explicit entries on both business-unit objects together.
+
+Refs #3025, #3391.

--- a/packages/platform-objects/src/identity/sys-business-unit-member.object.ts
+++ b/packages/platform-objects/src/identity/sys-business-unit-member.object.ts
@@ -101,7 +101,14 @@ export const SysBusinessUnitMember = ObjectSchema.create({
     trackHistory: true,
     searchable: true,
     apiEnabled: true,
-    apiMethods: ['get', 'list', 'create', 'update', 'delete'],
+    // import/export complete the HRIS org-tree sync scenario: the units
+    // (sys_business_unit, #3025/#3392) and their memberships are imported
+    // together as one bulk operation. Import reuses the already-granted
+    // create/update affordances; export is a bulk read. Transitional — #3391
+    // P2 derives these from create/update|list and reclaims the explicit
+    // entries. Reconcile-safe: import/export are not generic write verbs, so
+    // reconcileManagedApiMethods (managedBy:'platform') never strips them.
+    apiMethods: ['get', 'list', 'create', 'update', 'delete', 'import', 'export'],
     trash: true,
     mru: false,
   },

--- a/packages/platform-objects/src/platform-objects.test.ts
+++ b/packages/platform-objects/src/platform-objects.test.ts
@@ -5,6 +5,7 @@ import {
   SysAccount,
   SysApiKey,
   SysBusinessUnit,
+  SysBusinessUnitMember,
   SysDeviceCode,
   SysInvitation,
   SysJwks,
@@ -245,6 +246,27 @@ describe('@objectstack/platform-objects', () => {
       for (const verb of ['get', 'list', 'create', 'update', 'delete'] as const) {
         expect(SysBusinessUnit.enable?.apiMethods).toContain(verb);
       }
+    });
+
+    it('sys_business_unit_member allows import/export and keeps CRUD (#3391 P0)', () => {
+      // HRIS org-tree sync imports TWO tables together — the units (above) AND
+      // their memberships. The sibling membership table carries the same kind
+      // of restrictive whitelist, so it needs import/export too or the
+      // membership import path 405s (OBJECT_API_METHOD_NOT_ALLOWED). #3391's P0
+      // checklist pairs both tables; this is the half #3392 did not cover.
+      const methods = SysBusinessUnitMember.enable?.apiMethods ?? [];
+      expect(methods).toContain('import');
+      expect(methods).toContain('export');
+      // CRUD must remain — import writes reuse create/update; the membership
+      // grid depends on the rest.
+      for (const verb of ['get', 'list', 'create', 'update', 'delete'] as const) {
+        expect(methods).toContain(verb);
+      }
+      // Transitional: #3391 P2 derives import/export (import ⊆ create/update,
+      // export ⊆ list) and reclaims both objects' explicit entries together.
+      // Reconcile-safe: import/export are not generic write verbs, so
+      // reconcileManagedApiMethods (managedBy:'platform') never strips them —
+      // this static whitelist IS what apiAccessDenialFromEnable enforces.
     });
   });
 


### PR DESCRIPTION
## 背景

延续 #3025 / PR #3392。#3392 给 `sys_business_unit` 补上了 `enable.apiMethods` 白名单里的 `'import'`/`'export'`,解掉了业务单元列表页 Import/Export 按钮的 405(`OBJECT_API_METHOD_NOT_ALLOWED`)。但 **HRIS 组织树同步的完整场景是「单元表 + 成员表」两张一起批量导入**——`sys_business_unit_member` 仍停在 CRUD-only 白名单上,成员导入/导出路径照样 405。#3391 的 P0 清单本就把两张表配对,本 PR 补上 #3392 漏掉的那一半。

## 改动

- `packages/platform-objects/src/identity/sys-business-unit-member.object.ts:104` — `apiMethods` 追加 `'import'`, `'export'`。导入复用对象已授予的 `create`/`update` affordance,导出是批量读。
- 回归测试(`platform-objects.test.ts`):锁死 `import`/`export` 存在 + 保留 CRUD 五件套。**已防假绿**:回退对象改动后测试如实变红(`expected [...] to include 'import'`)。
- **Reconcile 安全**:该对象 `managedBy:'platform'`,但 `reconcileManagedApiMethods` 只剥通用写动词(`create/update/upsert/delete/purge` — `MANAGED_WRITE_VERB_AFFORDANCE`);`import`/`export` 不在其中,永不被剥离,声明的白名单原样到达 REST gate(`apiAccessDenialFromEnable`),故静态测试断言即运行时行为,无假绿。

## 过渡态

按 **#3391 P2**,per-object 的 `import`/`export` 显式声明将被一张派生映射表替代(import ⊆ create/update、export ⊆ list),届时两张业务单元对象的显式条目一起回收。测试与对象注释均已写明此过渡语义,防止后续被当样板回退。

## 验证

- `pnpm -C packages/platform-objects exec vitest run` → 214/214 全过。
- `tsc --noEmit` → 0 错。

---

## 附:全仓「显式 apiMethods 白名单」对象盘点(#3026 §4 缺口盘点)

扫描 `packages/**`(`cloud/` 在本仓无 `apiMethods` 声明;`objectui` 为独立仓,其 ImportWizard 405 兜底已由 #3391 P0 objectui 项跟踪)。判据:import ≈ 批量 create/upsert,export ≈ 批量 read;区分**无意缺口**(补)vs **刻意限制**(留,通常带注释/测试锁死)。

### ✅ 本 PR 放开(无意缺口,#3391 P0 已授权)
| 对象 | 原白名单 | 处置 |
|---|---|---|
| `sys_business_unit` | CRUD | #3392 已放开 |
| **`sys_business_unit_member`** | CRUD | **本 PR 放开** |

### ⏸ 全 CRUD 但**不宜现在显式加**——等 #3391 P1/P2 派生契约统一处理
`sys_user_position`、`sys_user_permission_set`、`sys_position_permission_set`、`sys_position`、`sys_capability`、`sys_permission_set`(RBAC 配置/授权)、`sys_approval_delegation`、`sys_user_preference`、`sys_view_definition`(元数据走 metadata protocol)。

> 理由:#3391 已定稿契约明确「显式声明模式全仓 60+ 对象 100% 遗漏」,长期方案是**派生**而非继续堆显式声明;逐个加只会增加 #3391 P2 待回收的过渡债。**且 #3025 开发计划把 `sys_permission_set` 用作反例控制项(必须继续 405)**——现在给 RBAC 对象加 import/export 会与该反例冲突。这些留给 P1 派生表统一放开更稳。

### 🔒 刻意限制 / 天然不该导入——保持封死
- **完全封死** `apiMethods: []`:`sys_jwks`、`sys_oauth_resource`、`sys_oauth_client_resource`、`sys_oauth_access_token`、`sys_oauth_consent`、`sys_oauth_client_assertion`、`sys_oauth_refresh_token`(OAuth/密钥/令牌内部件)。
- **凭据/认证敏感**:`sys_api_key`、`sys_two_factor`、`sys_secret`、`sys_device_code`、`sys_verification`、`sys_account`、`sys_session`、`sys_scim_provider`、`sys_sso_provider`。
- **身份走认证/邀请流**:`sys_user`(`get,list,update`——创建/删除走邀请+auth,另有专用批量用户导入流 #3236,不走通用 data import)、`sys_member`、`sys_organization`、`sys_invitation`。
- **运行时/作业记录**:`sys_job`、`sys_job_run`、`sys_job_queue`、`sys_automation_run`、`sys_import_job`(**有 ADR-0103 引擎自持锁死注释**,导入「导入作业」本身无意义)。
- **审计/日志(只读)**:`sys_email`、`sys_notification`、`sys_setting`、`sys_setting_audit`、`sys_audit_log`、`sys_activity`、`sys_metadata*`。
- **消息 outbox**:`notification_receipt`、`notification_delivery`、`http_delivery`。
- **其它运行时**:`sys_presence`、`sys_record_share`、`sys_share_link`、`sys_approval_request/approver/token/action`、`sys_audience_binding_suggestion`、`sys_team`、`sys_team_member`。
- **OAuth 应用** `sys_oauth_application`:刻意锁死(注释 + `platform-objects.test.ts` 断言 `not.toContain('create'/'update'/'delete')`,所有写经 better-auth 包装器)。

> 通用「UI 按钮 ↔ apiMethods 前后端一致性」设计问题已有独立 issue **#3391**(契约 **#3026**)跟踪,本 PR 不撞车、只做具体对象白名单补齐。

Refs #3025, #3391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)