### PR TITLE
docs(site): 官网首页 hero/metadata/结尾 CTA 对齐新口径

### DIFF
--- a/.changeset/docs-homepage-16k-hero.md
+++ b/.changeset/docs-homepage-16k-hero.md
@@ -1,0 +1,4 @@
+---
+---
+
+Docs-site homepage refresh: hero, page metadata, and closing CTA updated to the new positioning ("A complete business system in 16k tokens.", business-ontology framing, build & ask with Claude Code vs online via ObjectOS). Site copy only, so this releases nothing.

--- a/apps/docs/app/[lang]/page.tsx
+++ b/apps/docs/app/[lang]/page.tsx
@@ -18,10 +18,10 @@ const mono = IBM_Plex_Mono({
 
 export const metadata: Metadata = {
   title: {
-    absolute: 'ObjectStack — AI writes the app. ObjectStack is what it writes.',
+    absolute: 'ObjectStack — A complete business system in 16k tokens',
   },
   description:
-    'The open target format and runtime for AI-written business apps. Agents write compact typed metadata — a complete CRM is under 2,000 lines, so the whole app fits in an agent\'s context — strict TypeScript, Zod, and a validation gate catch mistakes at authoring time, and the runtime derives the database, REST API, UI, and MCP server. Your business ontology as an open protocol.',
+    'ObjectStack compresses an entire business app — data model, UI, workflows, permissions — into typed metadata an AI agent can hold in context, reason about, and refactor whole; a complete CRM is under 2,000 lines. That metadata is your business ontology — an open, versioned definition you own. Strict TypeScript, Zod, and a validation gate catch the agent\'s mistakes at authoring time, and the runtime derives the database, REST API, UI, and MCP server, enforcing permissions and audit on every call.',
 };
 
 const VOCABULARY: { tag: string; title: string; copy: string }[] = [
@@ -114,18 +114,19 @@ export default function HomePage() {
               className="mt-5 text-[2.6rem]/[1.06] font-bold tracking-tight text-balance md:text-6xl/[1.04]"
               style={{ fontFamily: 'var(--l-display)' }}
             >
-              AI writes the app.{' '}
+              A complete business system{' '}
               <span className="block bg-gradient-to-r from-indigo-500 to-purple-500 bg-clip-text text-transparent dark:from-indigo-400 dark:to-purple-400">
-                ObjectStack is what it writes.
+                in 16k tokens.
               </span>
             </h1>
             <p className="mt-6 max-w-xl text-lg text-fd-muted-foreground text-pretty">
-              The open target format and runtime for AI-written business apps. Your coding agent
-              writes models, UI, workflows, and permissions as compact typed metadata — a
-              complete CRM is under 2,000 lines, so the whole app fits in the agent's context —
-              and strict TypeScript, Zod schemas, and a validation gate catch its mistakes at
-              authoring time. The runtime derives the database, REST API, UI, and MCP server,
-              and enforces permissions and audit on every call.
+              ObjectStack compresses an entire app — data model, UI, workflows, permissions —
+              into typed metadata an AI agent can hold in context, reason about, and refactor
+              whole; a complete CRM is under 2,000 lines. That metadata is your business
+              ontology — an open, versioned definition you own. Strict TypeScript, Zod schemas,
+              and a validation gate catch the agent's mistakes at authoring time, and the
+              runtime derives the database, REST API, UI, and MCP server — permissions and
+              audit enforced on every call.
             </p>
             <div className="mt-8 flex flex-wrap items-center gap-3">
               <Link
@@ -332,7 +333,8 @@ export default function HomePage() {
               </a>
             </p>
             <p className="mt-3 text-sm text-fd-muted-foreground">
-              Want it governed and hosted, with Build &amp; Ask AI built in?{' '}
+              ObjectStack is build &amp; ask with Claude Code. Rather build &amp; ask online —
+              in the browser, nothing to install?{' '}
               <a
                 href="https://www.objectos.ai"
                 className="inline-flex items-center gap-1 font-medium text-fd-foreground underline underline-offset-4 transition-colors hover:text-fd-primary"


### PR DESCRIPTION
## 背景

README 新口径已合并(#3390),但 docs 官网首页(`apps/docs/app/[lang]/page.tsx`)的 hero 和页面 metadata 还是旧标语 "AI writes the app. ObjectStack is what it writes."。

## 改动(仅首页一个文件 + 空 changeset)

- **Hero 大标题**:改为 "A complete business system **in 16k tokens.**"(渐变色落在第二行,沿用原有排版结构)。
- **Hero 段落**:与 README 首屏同文——压缩为可整体装入智能体上下文的类型化元数据(完整 CRM 不到 2,000 行)+ business ontology(开放、可版本化、归你所有)+ 校验门 + 运行时派生与治理。
- **页面 `<title>` / description**:同步更新(SEO 与分享卡片一致)。
- **结尾 CTA**:改为 build &amp; ask 口径——"ObjectStack is build &amp; ask with Claude Code. Rather build &amp; ask online — in the browser, nothing to install? Try ObjectOS"。
- 结尾的 ontology 博客引用段保持不变(与新 hero 相互呼应)。

全站已 grep 确认旧标语无其他出现点;docs 内容页(index.mdx、getting-started)口径本就一致,未改动。文案数字(16k tokens、2,000 行)与 README、`how-ai-development-works.mdx` 现有声明一致。

## 验证

- 撇号等字符沿用文件现有 ASCII 风格(ESLint 在 main 上即如此通过)。
- 纯 JSX 文案替换,无结构/逻辑改动;Vercel 预览部署(rootDirectory: apps/docs)会构建本页,可直接目检。

## 建议

合并后请顺手看一眼 Vercel 预览确认排版(hero 第二行 "in 16k tokens." 的长度比旧句短,视觉上应更紧凑)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145qhfty9sRLm3HUvNBFxpk

---
_Generated by [Claude Code](https://claude.ai/code/session_0145qhfty9sRLm3HUvNBFxpk)_