### PR TITLE
feat(showcase): enable the record History tab on Account

### DIFF
--- a/examples/app-showcase/src/data/objects/account.object.ts
+++ b/examples/app-showcase/src/data/objects/account.object.ts
@@ -40,6 +40,14 @@ export const Account = ObjectSchema.create({
   // every surface, no per-page config.
   highlightFields: ['status', 'industry', 'annual_revenue'],
 
+  // Show the record **History tab** (audit-trail UI). The console gates the tab
+  // on object-level `enable.trackHistory` (RecordDetailView) — audit *capture*
+  // is always on, but the tab is opt-in — so without this the tab never renders
+  // and the feature is undemonstrable. Paired with the per-field `trackHistory`
+  // on `industry` / `status` below so those changes get summarized diffs
+  // (display values, not raw ids; computed fields excluded — #2691/#3293).
+  enable: { trackHistory: true },
+
   fields: {
     name: Field.text({ label: 'Account Name', required: true, searchable: true, maxLength: 200 }),
     industry: Field.select({


### PR DESCRIPTION
## Why
The #3358 v16 sweep (§4 "Record History tab") couldn't exercise the tab: no showcase object opted in. The console gates the History tab on **object-level `enable.trackHistory`** (`RecordDetailView`) — audit *capture* is always on, but the *tab* is opt-in — and the showcase only set `trackHistory` at the **field** level (industry/status), which merely selects which diffs get summarized. So the tab never rendered anywhere, and #2691/#3293 (display-value diffs, computed-field exclusion) were undemonstrated.

## What
`enable: { trackHistory: true }` on **Account** — which already declares field-level `trackHistory` on `industry`/`status`, so those changes summarize cleanly.

## Verified in the running app
- The Account detail now shows a **历史 / History** tab (it didn't before).
- After editing `industry`, the tab renders **"Dev Admin · UPDATE · 行业: ~~Retail~~ → Technology"** — the field label + the select **display values** (not raw codes/ids), a single real change, no phantom value→null rows.
- `os validate` ✓ · `tsc --noEmit` ✓.

Follow-up to #3364 / #3393; from the #3358 sweep §4. `@objectstack/example-showcase` is private → no changeset (skip-changeset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
