### PR TITLE
feat(spec): let an inline `lookup` action param declare its reference target (#3405)

### DIFF
--- a/.changeset/action-param-inline-lookup-reference.md
+++ b/.changeset/action-param-inline-lookup-reference.md
@@ -1,0 +1,22 @@
+---
+"@objectstack/spec": patch
+---
+
+feat(spec): let an inline `lookup` action param declare its reference target (#3405)
+
+`ActionParamSchema` had no way to name the object an inline record-picker param
+should search. Authors reasonably wrote the same key the field schema uses —
+`{ name: 'inspector', type: 'lookup', reference: 'sys_user' }` — and the schema
+stripped it as an unknown key, without an error. Downstream, the param dialog
+saw a picker with no target and degraded it to a "paste the record id (UUID)"
+text input. The authored intent was dropped silently and the user was handed a
+control that a human cannot reasonably operate.
+
+- Added `reference` to `ActionParamSchema`, spelled to match
+  `FieldSchema.reference` so one spelling works in both places. It sits with the
+  existing inline widget config (`multiple` / `accept` / `maxSize`), which had
+  covered the file/image params but not the picker ones.
+- A `lookup` / `master_detail` param declared **inline** with no `reference` is
+  now a parse-time error pointing at the missing key, instead of degrading at
+  render time. Field-backed params are unaffected: they inherit the target from
+  the referenced field's metadata, which is not visible at parse time.

--- a/.changeset/regenerate-ui-action-reference-doc.md
+++ b/.changeset/regenerate-ui-action-reference-doc.md
@@ -1,0 +1,7 @@
+---
+---
+
+docs(spec): regenerate the `ui/action` reference doc for the inline lookup
+`reference` key. Generated output only — the release for this change is
+declared by the `@objectstack/spec` changeset in #3406, so this PR itself
+releases nothing.

--- a/content/docs/references/ui/action.mdx
+++ b/content/docs/references/ui/action.mdx
@@ -35,7 +35,21 @@ params: [
 
 inline when no matching object field exists. Inline values may also be
 
-used alongside `field` to override individual properties.
+used alongside `field` to override individual properties. A `lookup` /
+
+`master_detail` param declared this way MUST name its target object via
+
+`reference` — there is no field to inherit it from:
+
+```ts
+
+params: [
+
+\{ name: 'inspector', label: 'Inspector', type: 'lookup', reference: 'sys_user' \},
+
+]
+
+```
 
 `name` is required unless `field` is provided (in which case it defaults
 
@@ -153,6 +167,7 @@ const result = Action.parse(data);
 | **multiple** | `boolean` | optional | Allow multiple values (array value shape); mirrors FieldSchema.multiple. |
 | **accept** | `string[]` | optional | Accepted upload types (MIME types / extensions) for file/image params. |
 | **maxSize** | `integer` | optional | Max upload size in bytes for file/image params. |
+| **reference** | `string` | optional | Reference target object for inline lookup/master_detail params; mirrors FieldSchema.reference. |
 | **defaultFromRow** | `boolean` | optional |  |
 | **visible** | `string \| { dialect: Enum<'cel' \| 'cron' \| 'template'>; source?: string; ast?: any; meta?: object }` | optional | Param visibility predicate (CEL); omits the param when false. |
 | **requiresFeature** | `Enum<'twoFactor' \| 'passkeys' \| 'magicLink' \| 'organization' \| 'multiOrgEnabled' \| 'degradedTenancy' \| 'oidcProvider' \| 'sso' \| 'ssoEnforced' \| 'deviceAuthorization' \| 'admin' \| 'phoneNumber' \| 'phoneNumberOtp'>` | optional | Public auth feature flag gating this param; lowered into `visible` at parse time. |

--- a/examples/app-showcase/src/ui/actions/index.ts
+++ b/examples/app-showcase/src/ui/actions/index.ts
@@ -204,6 +204,14 @@ export const ActionParamGalleryAction = defineAction({
       ],
     },
     { name: 'p_date', type: 'date', label: 'Effective date' },
+    // #3405 — an INLINE record picker. `reference` names the object the picker
+    // searches; without it the param would degrade to a "paste the record id
+    // (UUID)" text box, which is what shipped before. Accounts are seeded with
+    // enough volume (incl. a CJK name) to exercise search here.
+    {
+      name: 'p_account', type: 'lookup', reference: 'showcase_account', label: 'Related account',
+      helpText: 'Inline lookup param — searchable record picker, no UUID typing.',
+    },
     { name: 'p_color', type: 'color', label: 'Accent color', defaultValue: '#7C3AED' },
     // Spec `autonumber` param → the AutoNumber widget (read-only, auto-assigned).
     { name: 'p_reference', type: 'autonumber', label: 'Reference #' },

--- a/packages/spec/src/ui/action.test.ts
+++ b/packages/spec/src/ui/action.test.ts
@@ -74,6 +74,40 @@ describe('ActionParamSchema', () => {
       expect(() => ActionParamSchema.parse({ name: 'p', label: 'P', type })).not.toThrow();
     }
   });
+
+  // #3405 — an inline record-picker param carries its own target object.
+  // Before this, `reference` was an unknown key: zod stripped it silently and
+  // the param dialog degraded to a "paste the record id (UUID)" text input,
+  // with no signal that the authored config had been dropped.
+  describe('inline lookup reference target (#3405)', () => {
+    it('keeps `reference` on an inline lookup param', () => {
+      const result = ActionParamSchema.parse({
+        name: 'inspector',
+        label: 'Inspector',
+        type: 'lookup' as const,
+        reference: 'sys_user',
+        required: true,
+      });
+      expect(result.reference).toBe('sys_user');
+    });
+
+    it('rejects an inline lookup/master_detail param with no reference target', () => {
+      for (const type of ['lookup', 'master_detail'] as const) {
+        const result = ActionParamSchema.safeParse({ name: 'owner', label: 'Owner', type });
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0]?.path).toEqual(['reference']);
+      }
+    });
+
+    it('allows a field-backed lookup param to omit it (inherited from the field at runtime)', () => {
+      expect(() => ActionParamSchema.parse({ field: 'inspector', type: 'lookup' as const })).not.toThrow();
+      expect(() => ActionParamSchema.parse({ field: 'inspector' })).not.toThrow();
+    });
+
+    it('leaves `reference` undefined for non-picker params', () => {
+      expect(ActionParamSchema.parse({ name: 'note', type: 'textarea' as const }).reference).toBeUndefined();
+    });
+  });
 });
 
 // #2874 P1 — declarative `requiresFeature` sugar, lowered at parse time into
@@ -368,6 +402,7 @@ describe('ActionSchema', () => {
             name: 'new_owner',
             label: 'New Owner',
             type: 'lookup',
+            reference: 'sys_user',
             required: true,
           },
           {
@@ -497,6 +532,7 @@ describe('ActionSchema', () => {
             name: 'new_owner',
             label: 'New Owner',
             type: 'lookup',
+            reference: 'sys_user',
             required: true,
           },
           {

--- a/packages/spec/src/ui/action.zod.ts
+++ b/packages/spec/src/ui/action.zod.ts
@@ -31,7 +31,15 @@ import { PUBLIC_AUTH_FEATURE_NAMES, lowerRequiresFeature } from '../kernel/publi
  *
  * 2. **Inline** (legacy / bespoke) — declare `name`, `label`, `type` etc.
  *    inline when no matching object field exists. Inline values may also be
- *    used alongside `field` to override individual properties.
+ *    used alongside `field` to override individual properties. A `lookup` /
+ *    `master_detail` param declared this way MUST name its target object via
+ *    `reference` — there is no field to inherit it from:
+ *
+ *    ```ts
+ *    params: [
+ *      { name: 'inspector', label: 'Inspector', type: 'lookup', reference: 'sys_user' },
+ *    ]
+ *    ```
  *
  * `name` is required unless `field` is provided (in which case it defaults
  * to the field name and is used as the request-body key).
@@ -77,6 +85,19 @@ export const ActionParamSchema = lazySchema(() => z.object({
   /** Max upload size in bytes for `file`/`image` params. */
   maxSize: z.number().int().positive().optional().describe('Max upload size in bytes for file/image params.'),
   /**
+   * Reference target for an inline `lookup` / `master_detail` param — the
+   * object whose records the picker searches. Field-backed params inherit it
+   * from the referenced field, so it is only needed inline.
+   *
+   * Without it the dialog cannot query anything and degrades to a plain text
+   * input asking for a raw record id, which is unusable for a human — hence
+   * the `.refine()` below rejects a targetless lookup param at parse time.
+   *
+   * Key name deliberately mirrors `FieldSchema.reference` so the same spelling
+   * works in both places.
+   */
+  reference: SnakeCaseIdentifierSchema.optional().describe('Reference target object for inline lookup/master_detail params; mirrors FieldSchema.reference.'),
+  /**
    * When true, the param's default value is pulled from the current row record
    * (key = the resolved field name) when the action runs from a list_item
    * context. Useful for edit dialogs that pre-fill from the selected row.
@@ -105,6 +126,16 @@ export const ActionParamSchema = lazySchema(() => z.object({
 }).refine(
   (p) => Boolean(p.name) || Boolean(p.field),
   { message: 'ActionParam requires either "name" or "field"' },
+).refine(
+  // An INLINE record-picker param must name its target object. Only inline
+  // params are checked: a field-backed one inherits the target from the
+  // referenced field's metadata, which is not visible at parse time.
+  (p) => !(!p.field && (p.type === 'lookup' || p.type === 'master_detail') && !p.reference),
+  {
+    path: ['reference'],
+    message:
+      'ActionParam with type "lookup"/"master_detail" requires "reference" (the target object) when declared inline — without it the param dialog degrades to a raw record-id text input. Set `reference: \'<object>\'`, or use a field-backed param (`{ field: \'<lookup_field>\' }`) to inherit it.',
+  },
 ).transform((p, ctx) => lowerRequiresFeature(p, ctx)));
 
 /**


### PR DESCRIPTION
Closes part 1 + 2 of #3405. Companion UI change: objectstack-ai/objectui#2786

## 问题

`ActionParamSchema` 没有任何键可以指定内联 record-picker 参数要搜哪个对象。作者很自然地写了字段 schema 同名的键：

```ts
params: [
  { name: 'inspector', label: '质检员', type: 'lookup', reference: 'sys_user', required: true },
]
```

schema 是 `.strip`，`reference` 作为未知键被**静默丢弃**，不报错。下游的动作参数弹窗看到一个没有目标的 picker，降级成「粘贴记录 ID（UUID）」文本框。作者写对了，配置被吃掉了，用户拿到一个真人没法用的控件。

真机场景（PLAT-DEF-005，天顺 EHR）：质检主管点【指派】/【转派】要选质检员，得先跑到别处把人的 UUID 复制出来再粘回去。同一套引用字段在新建/编辑弹窗里是正常的搜索式选择器。

讽刺的是 schema 里已经有一段「Widget config for inline params」的注释，把 `multiple` / `accept` / `maxSize` 专门补给了内联参数 —— 唯独漏了 picker 需要的那一个。file/image 类内联参数能配全，lookup 配不全。

## 改动

- **`ActionParamSchema` 增加 `reference`**，键名对齐 `FieldSchema.reference`，让同一个拼法在两处都成立 —— 租户已经写出来的代码原样就合法，不需要为平台再学第二种拼法。位置就放在现有的内联 widget config 那一组。
- **内联 `lookup` / `master_detail` 缺 `reference` → 解析期报错**，错误 `path` 指向 `reference`，message 同时给出两条出路（补 `reference` 或改成字段引用式）。挂在现有 `.refine()` 链上。
  **字段引用式参数不受影响** —— 它从被引用字段的元数据继承目标，那在解析期不可见。
- app-showcase 的动作参数 gallery 补上以前表达不出来的内联 picker 标本。

## 验证

`objectstack validate`（app-showcase）：

- 删掉 `reference` → `✗ ["reference"] ActionParam with type "lookup"/"master_detail" requires "reference" (the target object) when declared inline …`
- 加回去 → `✓ Validation passed`

真机 UI（framework showcase :5311 + objectui console 指过去）：`GET /api/v1/meta/objects/showcase_field_zoo` 里 `p_account` 带上了 `reference: showcase_account`；弹窗渲染出搜索式选择器，`GET /api/v1/data/showcase_account?top=50&search=华宁` 服务端过滤命中，选中后按记录 ID 回填。全程不接触 UUID。

`@objectstack/spec` 全量测试：256 文件 / 6822 用例通过。

## 破坏性说明

内联 `lookup` 参数漏配 `reference` 的既有元数据，之前是静默降级成文本框，现在会在 `validate` / 解析期报错。这正是本 PR 的意图 —— 那些参数本来就是坏的，只是坏得没声音。修法就是错误信息里给的两条。

🤖 Generated with [Claude Code](https://claude.com/claude-code)