### PR TITLE
fix(showcase): stop passing a non-existent org column when seeding the phone demo user

### DIFF
--- a/examples/app-showcase/src/security/seed-approval-demo.ts
+++ b/examples/app-showcase/src/security/seed-approval-demo.ts
@@ -126,18 +126,16 @@ async function assignAdminPositions(
 }
 
 /** Provision a phone-based demo user (best-effort; renders the phone surfaces). */
-async function ensurePhoneDemoUser(ctx: ApprovalDemoContext, organizationId: string | null): Promise<void> {
+async function ensurePhoneDemoUser(ctx: ApprovalDemoContext): Promise<void> {
   const existing = await findOne(ctx, 'sys_user', { email: PHONE_DEMO_USER.email });
   if (existing) return;
   try {
-    await ctx.ql.insert(
-      'sys_user',
-      {
-        ...PHONE_DEMO_USER,
-        ...(organizationId ? { organization_id: organizationId } : {}),
-      },
-      { context: SYS },
-    );
+    // `sys_user` carries NO org column — org membership lives on `sys_member`
+    // (see the resolution in `run` below). An `organization_id` key here is not
+    // silently dropped: it reaches SQL as a real column and the insert dies with
+    // "table sys_user has no column named organization_id", so the demo user is
+    // never provisioned and the phone surfaces render empty.
+    await ctx.ql.insert('sys_user', { ...PHONE_DEMO_USER }, { context: SYS });
     ctx.logger?.info?.('[showcase] approval-demo phone user provisioned', { email: PHONE_DEMO_USER.email });
   } catch (err) {
     // Non-fatal: sign-in still needs a better-auth account; this row just makes
@@ -215,20 +213,18 @@ export function registerShowcaseApprovalDemo(ctx: ApprovalDemoContext): void {
       return;
     }
     const adminId = String(admin.id);
-    // The active org lives on the better-auth membership (`sys_member`), NOT on
-    // `sys_user.organization_id` (which is null for the dev admin). Both the
-    // position rows AND the requests must carry this org, or the org-scoped
-    // approver resolution (`sys_user_position` filtered by org) and `getRequest`
-    // (org-scoped read that the inbox drawer uses) silently return nothing.
-    let organizationId = (admin.organization_id as string | undefined) ?? null;
-    if (!organizationId) {
-      const ownerMember = await findOne(ctx, 'sys_member', { user_id: adminId, role: 'owner' });
-      const anyMember = ownerMember ?? (await findOne(ctx, 'sys_member', { user_id: adminId }));
-      organizationId = (anyMember?.organization_id as string | undefined) ?? null;
-    }
+    // The active org lives on the better-auth membership (`sys_member`).
+    // `sys_user` has no org column at all, so there is nothing to read off the
+    // admin row first. Both the position rows AND the requests must carry this
+    // org, or the org-scoped approver resolution (`sys_user_position` filtered
+    // by org) and `getRequest` (the org-scoped read behind the inbox drawer)
+    // silently return nothing.
+    const ownerMember = await findOne(ctx, 'sys_member', { user_id: adminId, role: 'owner' });
+    const anyMember = ownerMember ?? (await findOne(ctx, 'sys_member', { user_id: adminId }));
+    const organizationId = (anyMember?.organization_id as string | undefined) ?? null;
 
     await assignAdminPositions(ctx, adminId, organizationId);
-    await ensurePhoneDemoUser(ctx, organizationId);
+    await ensurePhoneDemoUser(ctx);
 
     let engine: AutomationEngineLike | undefined;
     try {


### PR DESCRIPTION
## The bug
`ensurePhoneDemoUser` (from #3364) inserted `sys_user` with an `organization_id` key. **`sys_user` has no such field** — not in the object definition (25 fields, none org/tenant), and not physically (26 columns, no `organization_id`). Org membership lives on `sys_member`.

The key is **not** silently dropped on the way down — it reaches SQL as a real column:

```
ERROR Insert operation failed {"object":"sys_user", …
  table sys_user has no column named organization_id}
```

Because the insert sits in a best-effort `try/catch`, this only ever showed up as a warn line plus an ERROR in the boot log. The consequence was invisible but total: **the phone demo user was never provisioned on any boot**, so #3358 §6 "Phone sign-in surfaces" (All Users list, record detail) had nothing to show.

## The fix
- Drop the `organization_id` key from the `sys_user` insert (and the now-unused param).
- Drop the dead `admin.organization_id` read in `run` — the same missing field made it permanently `undefined`, so only the `sys_member` fallback ever ran. Resolve from `sys_member` directly, and fix the comment that claimed the column existed but was null.

## Verified
On a wiped dev DB:
- boot log: **1 ERROR → 0**
- `sys_user` now holds `usr_showcase_phone_demo` · `Mei Phone (demo)` · `+8613800138000`
- approval fixtures unaffected: 2 pending requests + 3 admin positions (`finance`/`legal`/`manager`), all stamped with the org
- `tsc --noEmit` ✓

Follow-up to #3364. Found while collecting per-item evidence for #3358 §1. `@objectstack/example-showcase` is private → no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
