### PR TITLE
docs(spec): regenerate ui/action reference for inline lookup `reference` (fixes #3406 CI)

### DIFF
--- a/.changeset/regenerate-ui-action-reference-doc.md
+++ b/.changeset/regenerate-ui-action-reference-doc.md
@@ -1,0 +1,7 @@
+---
+---
+
+docs(spec): regenerate the `ui/action` reference doc for the inline lookup
+`reference` key. Generated output only — the release for this change is
+declared by the `@objectstack/spec` changeset in #3406, so this PR itself
+releases nothing.

--- a/content/docs/references/ui/action.mdx
+++ b/content/docs/references/ui/action.mdx
@@ -35,7 +35,21 @@ params: [
 
 inline when no matching object field exists. Inline values may also be
 
-used alongside `field` to override individual properties.
+used alongside `field` to override individual properties. A `lookup` /
+
+`master_detail` param declared this way MUST name its target object via
+
+`reference` — there is no field to inherit it from:
+
+```ts
+
+params: [
+
+\{ name: 'inspector', label: 'Inspector', type: 'lookup', reference: 'sys_user' \},
+
+]
+
+```
 
 `name` is required unless `field` is provided (in which case it defaults
 
@@ -153,6 +167,7 @@ const result = Action.parse(data);
 | **multiple** | `boolean` | optional | Allow multiple values (array value shape); mirrors FieldSchema.multiple. |
 | **accept** | `string[]` | optional | Accepted upload types (MIME types / extensions) for file/image params. |
 | **maxSize** | `integer` | optional | Max upload size in bytes for file/image params. |
+| **reference** | `string` | optional | Reference target object for inline lookup/master_detail params; mirrors FieldSchema.reference. |
 | **defaultFromRow** | `boolean` | optional |  |
 | **visible** | `string \| { dialect: Enum<'cel' \| 'cron' \| 'template'>; source?: string; ast?: any; meta?: object }` | optional | Param visibility predicate (CEL); omits the param when false. |
 | **requiresFeature** | `Enum<'twoFactor' \| 'passkeys' \| 'magicLink' \| 'organization' \| 'multiOrgEnabled' \| 'degradedTenancy' \| 'oidcProvider' \| 'sso' \| 'ssoEnforced' \| 'deviceAuthorization' \| 'admin' \| 'phoneNumber' \| 'phoneNumberOtp'>` | optional | Public auth feature flag gating this param; lowered into `visible` at parse time. |


### PR DESCRIPTION
## What

Regenerates the generated reference doc `content/docs/references/ui/action.mdx` so it reflects the new `reference` key added to `ActionParamSchema` in #3406.

## Why

#3406 added `reference` to `ActionParamSchema` (and a `.refine()` requiring it on inline `lookup`/`master_detail` params) but did not regenerate the derived docs. The **TypeScript Type Check** job's `check:docs` step (`pnpm gen:schema && tsx scripts/build-docs.ts --check`) therefore failed:

```
✗ content/docs/references/ui/action.mdx (out of date)
```

These files are generated — do not hand-edit — so the fix is to run the generator and commit the result.

## Change

- Ran `pnpm --filter @objectstack/spec gen:schema && pnpm --filter @objectstack/spec gen:docs`.
- Only `content/docs/references/ui/action.mdx` changed: the new inline-lookup prose block and a `reference` row in the params table. JSON-schema output under `packages/spec/json-schema/` is gitignored, so nothing else needed committing.

## Verification

- `pnpm --filter @objectstack/spec check:docs` → `✅ 254 generated files in sync with packages/spec` (exit 0), the exact step that was failing.
- `pnpm --filter @objectstack/spec test` → 256 files / 6822 tests pass.

Merging this into `fix/action-param-inline-lookup-3405` turns #3406's CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011W4a1eVS3aaYVRxKut68hK)_