### PR TITLE
fix(plugin-approvals): ship _actions translations for the decision actions (objectui#2762 P0-3)

### DIFF
--- a/.changeset/approval-actions-translation-bundle.md
+++ b/.changeset/approval-actions-translation-bundle.md
@@ -1,0 +1,25 @@
+---
+"@objectstack/plugin-approvals": patch
+---
+
+fix(plugin-approvals): localize the declared decision-action labels (objectui#2762 P0-3)
+
+The Approval Center's decision drawer rendered the `sys_approval_request`
+declared actions with their literal metadata labels — English **Approve /
+Reject / Reassign / Send back / Request info** in a zh-CN workspace, sitting
+next to the same page's localized 通过 / 拒绝 inbox buttons. The plugin's
+translation bundle covered fields and views but had no `_actions` node, so
+the console's `_actions.<name>.label` resolution had nothing to hit.
+
+- Re-ran `os i18n extract` against the plugin's config: the bundles now carry
+  `_actions` translations (label, confirmText, successMessage, param labels
+  and helpText) for all eight decision actions — `approval_approve`,
+  `approval_reject`, `approval_reassign`, `approval_send_back`,
+  `approval_request_info`, `approval_remind`, `approval_recall`,
+  `approval_resubmit` — in zh-CN, ja-JP and es-ES (en keeps the metadata
+  literals).
+- The extract also surfaced other untranslated gaps, now filled in all three
+  locales: the `returned` status option, the `sys_approval_action.action`
+  audit options (`reassign` / `remind` / `request_info` / `comment` /
+  `revise` / `resubmit` / `ooo_substitute`), the `attachments` field, and the
+  `my_pending` / `recent` view empty states.

--- a/packages/plugins/plugin-approvals/src/translations/en.objects.generated.ts
+++ b/packages/plugins/plugin-approvals/src/translations/en.objects.generated.ts
@@ -44,7 +44,8 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
           pending: "pending",
           approved: "approved",
           rejected: "rejected",
-          recalled: "recalled"
+          recalled: "recalled",
+          returned: "returned"
         }
       },
       current_step: {
@@ -86,7 +87,11 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
     },
     _views: {
       my_pending: {
-        label: "My Pending"
+        label: "My Pending",
+        emptyState: {
+          title: "No pending approvals",
+          message: "You're all caught up."
+        }
       },
       submitted_by_me: {
         label: "I Submitted"
@@ -96,6 +101,92 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
       },
       all_requests: {
         label: "All"
+      }
+    },
+    _actions: {
+      approval_approve: {
+        label: "Approve",
+        successMessage: "Approved.",
+        params: {
+          comment: {
+            label: "Comment"
+          },
+          attachments: {
+            label: "Attachments"
+          }
+        }
+      },
+      approval_reject: {
+        label: "Reject",
+        confirmText: "Reject this request? A rejection is final for every approver.",
+        successMessage: "Rejected.",
+        params: {
+          comment: {
+            label: "Comment"
+          },
+          attachments: {
+            label: "Attachments"
+          }
+        }
+      },
+      approval_reassign: {
+        label: "Reassign",
+        successMessage: "Reassigned.",
+        params: {
+          to: {
+            label: "New approver",
+            helpText: "User to hand this step to"
+          },
+          comment: {
+            label: "Comment"
+          }
+        }
+      },
+      approval_send_back: {
+        label: "Send back",
+        successMessage: "Sent back for revision.",
+        params: {
+          comment: {
+            label: "Reason"
+          }
+        }
+      },
+      approval_request_info: {
+        label: "Request info",
+        successMessage: "Information requested.",
+        params: {
+          comment: {
+            label: "What do you need?"
+          }
+        }
+      },
+      approval_remind: {
+        label: "Send reminder",
+        successMessage: "Reminder sent.",
+        params: {
+          comment: {
+            label: "Note"
+          }
+        }
+      },
+      approval_recall: {
+        label: "Recall",
+        confirmText: "Recall this request? Approvers can no longer act on it and the record is unlocked.",
+        successMessage: "Recalled.",
+        params: {
+          comment: {
+            label: "Comment"
+          }
+        }
+      },
+      approval_resubmit: {
+        label: "Resubmit",
+        successMessage: "Resubmitted.",
+        params: {
+          comment: {
+            label: "What changed?"
+          }
+        }
       }
     }
   },
@@ -128,7 +219,14 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
           approve: "approve",
           reject: "reject",
           recall: "recall",
-          escalate: "escalate"
+          escalate: "escalate",
+          reassign: "reassign",
+          remind: "remind",
+          request_info: "request_info",
+          comment: "comment",
+          revise: "revise",
+          resubmit: "resubmit",
+          ooo_substitute: "ooo_substitute"
         }
       },
       actor_id: {
@@ -137,13 +235,21 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
       comment: {
         label: "Comment"
       },
+      attachments: {
+        label: "Attachments",
+        help: "Files supporting this action — e.g. a signed contract or evidence (#3266)."
+      },
       created_at: {
         label: "Created At"
       }
     },
     _views: {
       recent: {
-        label: "Recent"
+        label: "Recent",
+        emptyState: {
+          title: "No approval actions yet",
+          message: "Actions are logged automatically when approvals progress."
+        }
       },
       by_actor: {
         label: "By Actor"
@@ -179,7 +285,7 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
       },
       reason: {
         label: "Reason",
-        help: "Why the delegation exists (e.g. \"Annual leave 5/26\u20135/30\"). Recorded on the substitution audit row."
+        help: "Why the delegation exists (e.g. \"Annual leave 5/26–5/30\"). Recorded on the substitution audit row."
       },
       organization_id: {
         label: "Organization",

--- a/packages/plugins/plugin-approvals/src/translations/es-ES.objects.generated.ts
+++ b/packages/plugins/plugin-approvals/src/translations/es-ES.objects.generated.ts
@@ -44,7 +44,8 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
           pending: "Pendiente",
           approved: "Aprobada",
           rejected: "Rechazada",
-          recalled: "Retirada"
+          recalled: "Retirada",
+          returned: "Devuelta para revisión"
         }
       },
       current_step: {
@@ -86,7 +87,11 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
     },
     _views: {
       my_pending: {
-        label: "Mis pendientes"
+        label: "Mis pendientes",
+        emptyState: {
+          title: "Sin aprobaciones pendientes",
+          message: "Estás al día: nada espera tu aprobación."
+        }
       },
       submitted_by_me: {
         label: "Enviadas por mí"
@@ -96,6 +101,92 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
       },
       all_requests: {
         label: "Todas"
+      }
+    },
+    _actions: {
+      approval_approve: {
+        label: "Aprobar",
+        successMessage: "Aprobada.",
+        params: {
+          comment: {
+            label: "Comentario"
+          },
+          attachments: {
+            label: "Adjuntos"
+          }
+        }
+      },
+      approval_reject: {
+        label: "Rechazar",
+        confirmText: "¿Rechazar esta solicitud? Un rechazo es definitivo para todos los aprobadores.",
+        successMessage: "Rechazada.",
+        params: {
+          comment: {
+            label: "Comentario"
+          },
+          attachments: {
+            label: "Adjuntos"
+          }
+        }
+      },
+      approval_reassign: {
+        label: "Reasignar",
+        successMessage: "Reasignada.",
+        params: {
+          to: {
+            label: "Nuevo aprobador",
+            helpText: "Usuario al que se entrega este paso"
+          },
+          comment: {
+            label: "Comentario"
+          }
+        }
+      },
+      approval_send_back: {
+        label: "Devolver",
+        successMessage: "Devuelta para revisión.",
+        params: {
+          comment: {
+            label: "Motivo"
+          }
+        }
+      },
+      approval_request_info: {
+        label: "Pedir información",
+        successMessage: "Información solicitada.",
+        params: {
+          comment: {
+            label: "¿Qué necesitas?"
+          }
+        }
+      },
+      approval_remind: {
+        label: "Enviar recordatorio",
+        successMessage: "Recordatorio enviado.",
+        params: {
+          comment: {
+            label: "Nota"
+          }
+        }
+      },
+      approval_recall: {
+        label: "Retirar",
+        confirmText: "¿Retirar esta solicitud? Los aprobadores ya no podrán actuar sobre ella y el registro se desbloqueará.",
+        successMessage: "Retirada.",
+        params: {
+          comment: {
+            label: "Comentario"
+          }
+        }
+      },
+      approval_resubmit: {
+        label: "Reenviar",
+        successMessage: "Reenviada.",
+        params: {
+          comment: {
+            label: "¿Qué ha cambiado?"
+          }
+        }
       }
     }
   },
@@ -128,7 +219,14 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
           approve: "Aprobar",
           reject: "Rechazar",
           recall: "Retirar",
-          escalate: "Escalar"
+          escalate: "Escalar",
+          reassign: "Reasignación",
+          remind: "Recordatorio",
+          request_info: "Petición de información",
+          comment: "Comentario",
+          revise: "Devolución",
+          resubmit: "Reenvío",
+          ooo_substitute: "Sustitución por ausencia"
         }
       },
       actor_id: {
@@ -137,13 +235,21 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
       comment: {
         label: "Comentario"
       },
+      attachments: {
+        label: "Adjuntos",
+        help: "Archivos que respaldan esta acción, p. ej. un contrato firmado o pruebas (#3266)."
+      },
       created_at: {
         label: "Creado el"
       }
     },
     _views: {
       recent: {
-        label: "Recientes"
+        label: "Recientes",
+        emptyState: {
+          title: "Aún no hay acciones de aprobación",
+          message: "Las acciones se registran automáticamente a medida que avanza la aprobación."
+        }
       },
       by_actor: {
         label: "Por actor"
@@ -179,7 +285,7 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
       },
       reason: {
         label: "Reason",
-        help: "Why the delegation exists (e.g. \"Annual leave 5/26\u20135/30\"). Recorded on the substitution audit row."
+        help: "Why the delegation exists (e.g. \"Annual leave 5/26–5/30\"). Recorded on the substitution audit row."
       },
       organization_id: {
         label: "Organization",

--- a/packages/plugins/plugin-approvals/src/translations/ja-JP.objects.generated.ts
+++ b/packages/plugins/plugin-approvals/src/translations/ja-JP.objects.generated.ts
@@ -44,7 +44,8 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
           pending: "保留中",
           approved: "承認済み",
           rejected: "却下済み",
-          recalled: "取り消し済み"
+          recalled: "取り消し済み",
+          returned: "差し戻し済み"
         }
       },
       current_step: {
@@ -86,7 +87,11 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
     },
     _views: {
       my_pending: {
-        label: "自分の保留中"
+        label: "自分の保留中",
+        emptyState: {
+          title: "承認待ちはありません",
+          message: "すべて処理済みです。あなたの承認を待つリクエストはありません。"
+        }
       },
       submitted_by_me: {
         label: "自分が送信"
@@ -96,6 +101,92 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
       },
       all_requests: {
         label: "すべて"
+      }
+    },
+    _actions: {
+      approval_approve: {
+        label: "承認",
+        successMessage: "承認しました。",
+        params: {
+          comment: {
+            label: "コメント"
+          },
+          attachments: {
+            label: "添付ファイル"
+          }
+        }
+      },
+      approval_reject: {
+        label: "却下",
+        confirmText: "このリクエストを却下しますか？却下はすべての承認者に対して最終決定になります。",
+        successMessage: "却下しました。",
+        params: {
+          comment: {
+            label: "コメント"
+          },
+          attachments: {
+            label: "添付ファイル"
+          }
+        }
+      },
+      approval_reassign: {
+        label: "再割り当て",
+        successMessage: "再割り当てしました。",
+        params: {
+          to: {
+            label: "新しい承認者",
+            helpText: "このステップを引き継ぐユーザー"
+          },
+          comment: {
+            label: "コメント"
+          }
+        }
+      },
+      approval_send_back: {
+        label: "差し戻し",
+        successMessage: "修正のため差し戻しました。",
+        params: {
+          comment: {
+            label: "理由"
+          }
+        }
+      },
+      approval_request_info: {
+        label: "追加情報を依頼",
+        successMessage: "追加情報を依頼しました。",
+        params: {
+          comment: {
+            label: "何が必要ですか？"
+          }
+        }
+      },
+      approval_remind: {
+        label: "リマインダー送信",
+        successMessage: "リマインダーを送信しました。",
+        params: {
+          comment: {
+            label: "メモ"
+          }
+        }
+      },
+      approval_recall: {
+        label: "取り下げ",
+        confirmText: "このリクエストを取り下げますか？承認者は操作できなくなり、レコードのロックが解除されます。",
+        successMessage: "取り下げました。",
+        params: {
+          comment: {
+            label: "コメント"
+          }
+        }
+      },
+      approval_resubmit: {
+        label: "再提出",
+        successMessage: "再提出しました。",
+        params: {
+          comment: {
+            label: "何を変更しましたか？"
+          }
+        }
       }
     }
   },
@@ -128,7 +219,14 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
           approve: "承認",
           reject: "却下",
           recall: "取消",
-          escalate: "エスカレーション"
+          escalate: "エスカレーション",
+          reassign: "再割り当て",
+          remind: "リマインダー",
+          request_info: "追加情報依頼",
+          comment: "コメント",
+          revise: "差し戻し",
+          resubmit: "再提出",
+          ooo_substitute: "不在時代理"
         }
       },
       actor_id: {
@@ -137,13 +235,21 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
       comment: {
         label: "コメント"
       },
+      attachments: {
+        label: "添付ファイル",
+        help: "この操作を裏付けるファイル——署名済み契約書や証憑など（#3266）。"
+      },
       created_at: {
         label: "作成日時"
       }
     },
     _views: {
       recent: {
-        label: "最近"
+        label: "最近",
+        emptyState: {
+          title: "承認操作はまだありません",
+          message: "承認が進むと操作は自動的に記録されます。"
+        }
       },
       by_actor: {
         label: "操作者別"
@@ -179,7 +285,7 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
       },
       reason: {
         label: "Reason",
-        help: "Why the delegation exists (e.g. \"Annual leave 5/26\u20135/30\"). Recorded on the substitution audit row."
+        help: "Why the delegation exists (e.g. \"Annual leave 5/26–5/30\"). Recorded on the substitution audit row."
       },
       organization_id: {
         label: "Organization",

--- a/packages/plugins/plugin-approvals/src/translations/zh-CN.objects.generated.ts
+++ b/packages/plugins/plugin-approvals/src/translations/zh-CN.objects.generated.ts
@@ -44,7 +44,8 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
           pending: "待处理",
           approved: "已批准",
           rejected: "已拒绝",
-          recalled: "已撤回"
+          recalled: "已撤回",
+          returned: "已退回修改"
         }
       },
       current_step: {
@@ -86,7 +87,11 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
     },
     _views: {
       my_pending: {
-        label: "我的待办"
+        label: "我的待办",
+        emptyState: {
+          title: "暂无待办审批",
+          message: "全部处理完毕，没有等待你审批的请求。"
+        }
       },
       submitted_by_me: {
         label: "我提交的"
@@ -96,6 +101,92 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
       },
       all_requests: {
         label: "全部"
+      }
+    },
+    _actions: {
+      approval_approve: {
+        label: "通过",
+        successMessage: "已通过。",
+        params: {
+          comment: {
+            label: "审批意见"
+          },
+          attachments: {
+            label: "附件"
+          }
+        }
+      },
+      approval_reject: {
+        label: "拒绝",
+        confirmText: "拒绝该请求？拒绝对所有审批人立即生效。",
+        successMessage: "已拒绝。",
+        params: {
+          comment: {
+            label: "审批意见"
+          },
+          attachments: {
+            label: "附件"
+          }
+        }
+      },
+      approval_reassign: {
+        label: "转签",
+        successMessage: "已转签。",
+        params: {
+          to: {
+            label: "新审批人",
+            helpText: "将此审批步骤转交给的用户"
+          },
+          comment: {
+            label: "备注"
+          }
+        }
+      },
+      approval_send_back: {
+        label: "退回修改",
+        successMessage: "已退回修改。",
+        params: {
+          comment: {
+            label: "原因"
+          }
+        }
+      },
+      approval_request_info: {
+        label: "退回补充",
+        successMessage: "已退回给申请人补充材料。",
+        params: {
+          comment: {
+            label: "需要申请人补充什么？"
+          }
+        }
+      },
+      approval_remind: {
+        label: "催办",
+        successMessage: "已发送催办。",
+        params: {
+          comment: {
+            label: "备注"
+          }
+        }
+      },
+      approval_recall: {
+        label: "撤回",
+        confirmText: "撤回该请求？撤回后审批人将无法继续处理，记录随即解锁。",
+        successMessage: "已撤回。",
+        params: {
+          comment: {
+            label: "备注"
+          }
+        }
+      },
+      approval_resubmit: {
+        label: "重新提交",
+        successMessage: "已重新提交。",
+        params: {
+          comment: {
+            label: "你修改了什么？"
+          }
+        }
       }
     }
   },
@@ -128,7 +219,14 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
           approve: "批准",
           reject: "拒绝",
           recall: "撤回",
-          escalate: "升级"
+          escalate: "升级",
+          reassign: "转签",
+          remind: "催办",
+          request_info: "要求补充材料",
+          comment: "评论",
+          revise: "退回修改",
+          resubmit: "重新提交",
+          ooo_substitute: "不在岗改派"
         }
       },
       actor_id: {
@@ -137,13 +235,21 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
       comment: {
         label: "评论"
       },
+      attachments: {
+        label: "附件",
+        help: "支持该操作的文件——例如已签署的合同或证明材料（#3266）。"
+      },
       created_at: {
         label: "创建时间"
       }
     },
     _views: {
       recent: {
-        label: "最近"
+        label: "最近",
+        emptyState: {
+          title: "暂无审批操作记录",
+          message: "审批推进时会自动记录操作。"
+        }
       },
       by_actor: {
         label: "按执行人"


### PR DESCRIPTION
## Summary

Framework half of objectstack-ai/objectui#2762 **P0-3 (动作标签 i18n)**: the Approval Center drawer showed English **Approve / Reject / Reassign / Send back / Request info** in a zh-CN workspace because `@objectstack/plugin-approvals`' translation bundle covered fields and views but had **no `_actions` node** — the console's `_actions.<name>.label` resolution had nothing to hit. (The UI half — `DeclaredActionsBar` actually resolving those keys — is objectstack-ai/objectui#2789.)

- Re-ran the sanctioned extract (`os i18n extract packages/plugins/plugin-approvals/scripts/i18n-extract.config.ts --locales=zh-CN,ja-JP,es-ES --fill=default --objects-only --out=…`), which merged `_actions` scaffolding for all eight `sys_approval_request` decision actions into the four generated bundles, preserving every existing hand translation.
- Translated the new leaves for **zh-CN / ja-JP / es-ES**: action `label` / `confirmText` / `successMessage` plus param labels/helpText for `approval_approve`, `approval_reject`, `approval_reassign`, `approval_send_back`, `approval_request_info`, `approval_remind`, `approval_recall`, `approval_resubmit`. zh-CN terms match the console's existing vocabulary (通过 / 拒绝 / 转签 / 退回修改 / 退回补充 / 催办 / 撤回 / 重新提交).
- The merge also surfaced older gaps, now filled in all three locales: the `returned` status option, the `sys_approval_action.action` audit options (`reassign`/`remind`/`request_info`/`comment`/`revise`/`resubmit`/`ooo_substitute`), the `attachments` field label/help, and the `my_pending` / `recent` view empty states.

## Verification

- `pnpm turbo build test --filter=@objectstack/plugin-approvals` green (8/8 tasks)
- Generated files only touched via the extractor + leaf-value translation (structure untouched)
- Changeset: patch × 1

Refs objectstack-ai/objectui#2762, objectstack-ai/objectui#2789

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cu48mLFUdRBmMh8Z8R3CVz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu48mLFUdRBmMh8Z8R3CVz)_