### PR TITLE
docs(readme): 定位区点名 FDE(前沿部署工程师)受众

### DIFF
--- a/.changeset/readme-fde-audience.md
+++ b/.changeset/readme-fde-audience.md
@@ -1,0 +1,4 @@
+---
+---
+
+README-only: call out forward-deployed engineers as an audience in the positioning section. Docs only, so this releases nothing.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ MCP. Rather **build & ask online** — in the browser, nothing to install?
 That's **[ObjectOS](https://github.com/objectstack-ai/objectos)**, the
 commercial runtime environment built on this stack.
 
+**Forward-deployed engineer?** This is the ontology-first toolkit you own:
+sit with the client, model their business as typed metadata with your coding
+agent, and hand over a governed app *and* its definition — ordinary files in
+their repo, an open Apache-2.0 format, no platform seat to sell them.
+
 <p align="center">
   <img src="docs/screenshots/architecture.png" width="940" alt="ObjectStack architecture: author typed Zod metadata (objects, flows, views, policies); the microkernel compiles it into a versioned JSON artifact and loads plugins, drivers, and services; it generates a REST API, client SDK, Console and Studio UI, and MCP tools used by developers and AI agents, governed by Auth, RBAC, RLS, FLS, and audit, over PostgreSQL, MySQL, SQLite, or MongoDB">
   <br><sub>One typed definition → database · REST API · client SDK · UI · MCP tools.</sub>


### PR DESCRIPTION
## 背景

FDE(Forward Deployed Engineer)是 2026 年企业 AI 增长最快的岗位(招聘量同比 +1000%,OpenAI 为此注资 $40 亿成立 Deployment Company),其方法论核心正是 Palantir 式的 **ontology-first**——先为客户构建业务本体,再交付 AI 应用。这与本仓库"typed metadata = business ontology"的定位天然契合,且开放格式恰好解决 Palantir 模式的最大痛点(本体锁在平台里)。

## 改动

README 定位段之后新增一段 FDE 受众召唤(仅此一段 + 空 changeset):

> **Forward-deployed engineer?** This is the ontology-first toolkit you own: sit with the client, model their business as typed metadata with your coding agent, and hand over a governed app *and* its definition — ordinary files in their repo, an open Apache-2.0 format, no platform seat to sell them.

卖点全部为既有能力(类型化元数据、治理运行时、Apache-2.0、客户仓库中的普通文件),无新增声明。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145qhfty9sRLm3HUvNBFxpk

---
_Generated by [Claude Code](https://claude.ai/code/session_0145qhfty9sRLm3HUvNBFxpk)_