### PR TITLE
fix(plugin-approvals): give the decision actions a visual hierarchy (objectui#2762 P1-5)

### DIFF
--- a/.changeset/approval-action-hierarchy.md
+++ b/.changeset/approval-action-hierarchy.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/plugin-approvals": patch
+---
+
+fix(plugin-approvals): give the decision actions a visual hierarchy (objectui#2762 P1-5)
+
+The `sys_approval_request` decision actions all declared as equal-weight
+buttons, so the drawer's action bar rendered five identical outlined
+buttons with no emphasis on the primary path. `approval_approve` now
+declares `variant: 'primary'` and `approval_reject` declares
+`variant: 'danger'`, so a metadata-driven renderer highlights Approve and
+styles Reject as destructive — matching the hierarchy the mobile card
+already has. Pure metadata; the secondary levers stay unstyled (tertiary).

--- a/packages/plugins/plugin-approvals/src/sys-approval-request.object.ts
+++ b/packages/plugins/plugin-approvals/src/sys-approval-request.object.ts
@@ -247,6 +247,10 @@ export const SysApprovalRequest = ObjectSchema.create({
       name: 'approval_approve',
       label: 'Approve',
       icon: 'check-circle',
+      // Primary decision — the console renders this filled/highlighted so it
+      // stands out from the secondary levers in the drawer's action bar,
+      // matching the mobile card hierarchy (objectui#2762 P1-5).
+      variant: 'primary',
       type: 'api',
       method: 'POST',
       target: '/api/v1/approvals/requests/{id}/approve',
@@ -266,6 +270,9 @@ export const SysApprovalRequest = ObjectSchema.create({
       name: 'approval_reject',
       label: 'Reject',
       icon: 'x-circle',
+      // Destructive decision — rendered in the console's danger styling so it
+      // reads as the irreversible action it is (objectui#2762 P1-5).
+      variant: 'danger',
       type: 'api',
       method: 'POST',
       target: '/api/v1/approvals/requests/{id}/reject',


### PR DESCRIPTION
## Summary

Framework half of objectstack-ai/objectui#2762 **P1-5 (flat action hierarchy)**: the `sys_approval_request` decision actions all rendered as equal-weight outlined buttons in the drawer's action bar, so the primary Approve didn't stand out and Reject didn't read as destructive.

- `approval_approve` now declares `variant: 'primary'`
- `approval_reject` now declares `variant: 'danger'`

Both values are from the existing `ActionSchema.variant` enum (`primary | secondary | danger | ghost | link`). A metadata-driven renderer maps them onto its button styles — the objectui companion PR (objectstack-ai/objectui#2803) teaches `DeclaredActionsBar` to map `primary` → filled default and `danger` → destructive — so Approve is highlighted and Reject reads as the irreversible action it is, matching the hierarchy the mobile card already has. Pure metadata; the secondary levers (reassign / send-back / request-info / remind / recall / resubmit) stay unstyled as tertiary.

## Verification

- `pnpm turbo build test --filter=@objectstack/plugin-approvals` green (8/8)
- Changeset: patch × 1

Refs objectstack-ai/objectui#2762, objectstack-ai/objectui#2803

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cu48mLFUdRBmMh8Z8R3CVz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu48mLFUdRBmMh8Z8R3CVz)_