### PR TITLE
feat(protocol): surface silently-stripped write fields on the update response (#3431)

### DIFF
--- a/.changeset/rest-update-dropped-fields.md
+++ b/.changeset/rest-update-dropped-fields.md
@@ -1,0 +1,29 @@
+---
+"@objectstack/spec": minor
+"@objectstack/metadata-protocol": minor
+---
+
+feat(protocol): surface silently-stripped write fields on the update response (#3431)
+
+`PATCH /data/:object/:id` returned `200 + record` even when the data layer
+legally stripped some of the caller's write — a static `readonly` field
+(#2948) or one locked by a TRUE `readonlyWhen` predicate (#3042). The strip is
+correct semantics, but it was **silent** on this surface: the only signal lived
+in a server-side WARN log, so an API client's partial write "just didn't save"
+with no way to detect it. This is the same gap #3407/#3413 closed for the flow
+engine, one surface over — REST — reusing the engine's existing
+`onFieldsDropped` observability channel.
+
+- **spec** — `UpdateDataResponseSchema` gains an optional `droppedFields`:
+  `DroppedFieldsEvent[]` (`{ object, fields, reason: 'readonly' | 'readonly_when' }`),
+  present only when ≥1 field was dropped. Purely additive — existing clients
+  reading `.record` are unaffected; `success` semantics are unchanged (the
+  strip is surfaced, not escalated to a failure).
+- **metadata-protocol** — `updateData` threads an `onFieldsDropped` collector
+  into `engine.update` and attaches the collected events to its response
+  envelope, so the REST PATCH handler's `res.json(result)` carries them.
+
+Not wired on `createData`/POST: `insert` is readonly-exempt by design (INSERT
+may set read-only columns), so it produces no dropped events — wiring it would
+be inert. If insert ever gains a silent strip, wire it then. Bulk / batch /
+GraphQL write paths remain follow-ups.

--- a/content/docs/references/api/protocol.mdx
+++ b/content/docs/references/api/protocol.mdx
@@ -1179,6 +1179,7 @@ const result = AiInsightsRequest.parse(data);
 | **object** | `string` | ✅ | Object name |
 | **id** | `string` | ✅ | Updated record ID |
 | **record** | `Record<string, any>` | ✅ | Updated record |
+| **droppedFields** | `{ object: string; fields: string[]; reason: Enum<'readonly' \| 'readonly_when'> }[]` | optional | Advisory: caller-supplied fields the data layer legally stripped before persistence — static `readonly` (#2948) or a TRUE `readonlyWhen` predicate (#3042). Present only when ≥1 field was dropped. The update still succeeds (the strip is legitimate semantics), so this is the only signal that part of the write did not land — the strip was previously silent on this surface (#3431). |
 
 
 ---

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -17,6 +17,7 @@ import type {
 import type { MetadataCacheRequest, MetadataCacheResponse, ServiceInfo, ApiRoutes, WellKnownCapabilities } from '@objectstack/spec/api';
 import { readServiceSelfInfo } from '@objectstack/spec/api';
 import { parseFilterAST, isFilterAST } from '@objectstack/spec/data';
+import type { DroppedFieldsEvent } from '@objectstack/spec/data';
 import { PLURAL_TO_SINGULAR, SINGULAR_TO_PLURAL } from '@objectstack/spec/shared';
 import { type FormView, isAggregatedViewContainer } from '@objectstack/spec/ui';
 import { METADATA_FORM_REGISTRY } from '@objectstack/spec/system';
@@ -2928,11 +2929,20 @@ export class ObjectStackProtocolImplementation implements ObjectStackProtocol {
         await this.assertVersionMatch(request.object, request.id, request.expectedVersion, request.context);
         const opts: any = { where: { id: request.id } };
         if (request.context !== undefined) opts.context = request.context;
+        // [#3431] Capture fields the data layer legally strips (static `readonly`
+        // #2948 / conditional `readonlyWhen` #3042) so the caller learns which of
+        // its writes didn't land. The PATCH response was previously `200 + record`
+        // with no signal a field was dropped — the same silent-strip gap #3407
+        // closed for the flow engine, one surface over. `success` is unchanged;
+        // the strip is legitimate semantics, surfaced not escalated.
+        const dropped: DroppedFieldsEvent[] = [];
+        opts.onFieldsDropped = (event: DroppedFieldsEvent) => { dropped.push(event); };
         const result = await this.engine.update(request.object, request.data, opts);
         return {
             object: request.object,
             id: request.id,
-            record: result
+            record: result,
+            ...(dropped.length > 0 ? { droppedFields: dropped } : {}),
         };
     }
 

--- a/packages/objectql/src/protocol-data.test.ts
+++ b/packages/objectql/src/protocol-data.test.ts
@@ -468,6 +468,64 @@ describe('ObjectStackProtocolImplementation - Data Operations', () => {
     });
 
     // ═══════════════════════════════════════════════════════════════
+    // Dropped-field observability (#3431) — updateData surfaces the
+    // fields the engine legally strips (readonly / readonlyWhen) on its
+    // response, so the PATCH caller learns a write didn't land instead
+    // of receiving a silent 200 + record.
+    // ═══════════════════════════════════════════════════════════════
+    describe('dropped-field observability (#3431)', () => {
+        beforeEach(() => {
+            mockEngine.update = vi.fn().mockResolvedValue({ id: 'r1', updated_at: '2026-05-22T07:14:33.000Z' });
+        });
+
+        it('passes an onFieldsDropped listener into the engine update options', async () => {
+            await protocol.updateData({ object: 'task', id: 'r1', data: { name: 'New' } });
+            const opts = mockEngine.update.mock.calls[0][2];
+            expect(typeof opts.onFieldsDropped).toBe('function');
+        });
+
+        it('surfaces engine-dropped fields on the response, keeping the record', async () => {
+            // The engine strips a readonly field and reports it via the listener.
+            mockEngine.update.mockImplementation(async (_obj: string, _data: any, opts: any) => {
+                opts?.onFieldsDropped?.({ object: 'crm_opportunity', fields: ['approval_status'], reason: 'readonly' });
+                return { id: 'r1', updated_at: '2026-05-22T07:14:33.000Z' };
+            });
+
+            const res: any = await protocol.updateData({
+                object: 'crm_opportunity',
+                id: 'r1',
+                data: { approval_status: 'approved', notes: 'ok' },
+            });
+
+            // The write still succeeds (record returned) AND the dropped field is
+            // reported structurally — no longer silent on this surface.
+            expect(res.record).toMatchObject({ id: 'r1' });
+            expect(res.droppedFields).toEqual([
+                { object: 'crm_opportunity', fields: ['approval_status'], reason: 'readonly' },
+            ]);
+        });
+
+        it('collects multiple strip passes (readonly + readonlyWhen)', async () => {
+            mockEngine.update.mockImplementation(async (_obj: string, _data: any, opts: any) => {
+                opts?.onFieldsDropped?.({ object: 'crm_case', fields: ['locked_at'], reason: 'readonly_when' });
+                opts?.onFieldsDropped?.({ object: 'crm_case', fields: ['created_by'], reason: 'readonly' });
+                return { id: 'r1' };
+            });
+
+            const res: any = await protocol.updateData({ object: 'crm_case', id: 'r1', data: {} });
+
+            expect(res.droppedFields).toHaveLength(2);
+            expect(res.droppedFields.map((e: any) => e.reason)).toEqual(['readonly_when', 'readonly']);
+        });
+
+        it('omits droppedFields entirely when nothing was stripped', async () => {
+            const res: any = await protocol.updateData({ object: 'task', id: 'r1', data: { name: 'New' } });
+            expect(res.record).toMatchObject({ id: 'r1' });
+            expect(res).not.toHaveProperty('droppedFields');
+        });
+    });
+
+    // ═══════════════════════════════════════════════════════════════
     // cloneData — duplicate a record, gated by enable.clone
     // ═══════════════════════════════════════════════════════════════
 

--- a/packages/spec/src/api/protocol.zod.ts
+++ b/packages/spec/src/api/protocol.zod.ts
@@ -6,6 +6,7 @@ import { DiscoverySchema } from './discovery.zod';
 import { BatchUpdateRequestSchema, BatchUpdateResponseSchema, BatchOptionsSchema } from './batch.zod';
 import { MetadataCacheRequestSchema, MetadataCacheResponseSchema } from './http-cache.zod';
 import { QuerySchema } from '../data/query.zod';
+import { DroppedFieldsEventSchema } from '../data/data-engine.zod';
 import { 
   AnalyticsQueryRequestSchema,  
   AnalyticsResultResponseSchema, 
@@ -426,6 +427,14 @@ export const UpdateDataResponseSchema = lazySchema(() => z.object({
   object: z.string().describe('Object name'),
   id: z.string().describe('Updated record ID'),
   record: z.record(z.string(), z.unknown()).describe('Updated record'),
+  droppedFields: z.array(DroppedFieldsEventSchema).optional().describe(
+    'Advisory: caller-supplied fields the data layer legally stripped before ' +
+    'persistence — static `readonly` (#2948) or a TRUE `readonlyWhen` predicate ' +
+    '(#3042). Present only when ≥1 field was dropped. The update still succeeds ' +
+    '(the strip is legitimate semantics), so this is the only signal that part ' +
+    'of the write did not land — the strip was previously silent on this ' +
+    'surface (#3431).'
+  ),
 }));
 
 /**


### PR DESCRIPTION
Closes #3431.

## 问题

`PATCH /data/:object/:id` 返回 `200 + record`,即使数据层把调用方写入的部分字段合法剥离 —— 静态 `readonly`(#2948)或被 TRUE `readonlyWhen`(#3042)锁住的字段。剥离是**正确语义**,但在 REST 这个面上**沉默**:唯一信号躺在服务端 WARN 日志里,API 客户端的部分写入「就是没保存」,且无从察觉。

这正是 #3407/#3413 为流程引擎关掉的同一个缺口,挪到 **REST** 这一个面 —— 复用引擎已有的 `onFieldsDropped` 可观测性通道,不新造机制。

## 方案

调研发现 `updateData` 的返回**本就是信封** `{ object, id, record }`,所以加一个字段是**纯增量、非破坏** —— 无需我在 issue 里提的「响应头 vs 信封」取舍(信封已存在)。

- **spec**(`@objectstack/spec`,契约)— `UpdateDataResponseSchema` 新增可选 `droppedFields`:`DroppedFieldsEvent[]`(`{ object, fields, reason: 'readonly' | 'readonly_when' }`),仅当剥离 ≥1 字段时出现。复用 #3413 落地的 `DroppedFieldsEventSchema`(PD #7 单一 Zod 源)。既有客户端读 `.record` 不受影响;**`success` 语义不变**(剥离被暴露、不升级为失败)。
- **metadata-protocol** — `updateData` 把 `onFieldsDropped` 收集器透传进 `engine.update`,把收集到的事件挂到返回信封上;REST PATCH handler 的 `res.json(result)` 原样带出。

## 边界 / 范围

- **`createData`/POST 不接线**:`insert` 按既有语义豁免 readonly(INSERT 可以设只读列),不产生剥离事件 —— 接线只会是 inert 代码。若将来 insert 新增静默剥离,再接。这与 #3413 的诚实取舍一致(不造空通道)。
- **bulk / batch / GraphQL** 写路径保留为 follow-up。
- 内部 system-context 写入(import-job / undo,`isSystem: true`)本就跳过 readonly 剥离,不受影响。

## 测试

- `packages/objectql/src/protocol-data.test.ts` 新增 4 例:透传 `onFieldsDropped` 监听器 / 剥离字段结构化出现在响应且保留 record / 多趟剥离(readonly + readonlyWhen)聚合 / 无剥离时不带 `droppedFields` 键;
- 回归:objectql 1054 ✓ / rest 331 ✓ / spec api 1079 ✓;
- 生成物:`gen:docs` 再生 `content/docs/references/api/protocol.mdx`,`check:docs` / `check:api-surface` / `check:spec-changes` / `check:upgrade-guide` 全部 in-sync;`@objectstack/rest` 全链 turbo build 绿。

含 changeset(spec / metadata-protocol 各 minor)。

## 关联

- #3407(流程侧缺口)/ #3413(数据层 `onFieldsDropped` 通道,已合并)
- objectui #2802(Studio Runs 面板渲染 step warnings,已合并)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaofCZbsPTHE2oJedvKd77

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaofCZbsPTHE2oJedvKd77)_