### PR TITLE
fix(trigger-record-change): 让 record-change 流程种子记录携带公式(formula)字段 (#3426)

### DIFF
--- a/.changeset/record-change-hydrate-formula-fields.md
+++ b/.changeset/record-change-hydrate-formula-fields.md
@@ -1,0 +1,36 @@
+---
+"@objectstack/trigger-record-change": patch
+---
+
+fix(trigger-record-change): hydrate read-time formula fields onto the seeded flow record (#3426)
+
+A `formula` field is a read-time virtual — the engine evaluates it post-fetch on
+`find`/`findOne`, never on the write path — so it was absent from the raw
+after-create/after-update row a record-change flow is seeded with. A notify
+node template like `{record.full_name}` (or a start condition on the same field)
+therefore resolved to an empty string, silently emitting notifications such as
+`"New lead to assign: "` with the name missing.
+
+The record-change trigger now re-reads the just-written record through the data
+engine, so the seeded `record` carries the same computed fields a data-API read
+returns. The fix is at the trigger (the producer of the flow's `record`), so it
+benefits the whole flow — start condition, every node, and notify `title`/`body`
+templates — not just the notify node.
+
+Deliberately conservative:
+
+- Runs only for `afterInsert` / `afterUpdate` (the row exists in its post-write
+  state); `before*` and `afterDelete` keep the raw hook record untouched.
+- Reads as an elevated system principal, so it can only ADD computed fields,
+  never let RLS/FLS on the re-read shrink the snapshot the flow already saw.
+- Raw hook fields win on merge, preserving trigger-time scalar values and the
+  #1872 multi-lookup input overlay; the re-read only fills in keys the raw row
+  lacks (the formula virtuals).
+- Any failure (no read surface, no id, a throw, an empty read) falls back to the
+  raw record — hydration never breaks the flow it feeds.
+
+Lookup **traversal** (`{record.account.name}`) is intentionally not hydrated: a
+default data-API read does not expand relations either, and expanding would turn
+`record.account` from its scalar FK id into an object, breaking templates and
+conditions that use the bare id (e.g. #1872's `{record.target_channels.0}`).
+That traversal remains tracked on #3426.

--- a/packages/triggers/trigger-record-change/src/formula-context.test.ts
+++ b/packages/triggers/trigger-record-change/src/formula-context.test.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #3426 — a `formula` field is a READ-time virtual: the engine evaluates it
+ * post-fetch on `find`/`findOne`, never on the write path, so it is absent from
+ * the raw after-create/after-update row a record-change flow is seeded with.
+ * `{record.full_name}` in a notify template (or a start condition) therefore
+ * resolved to an empty string. The trigger now re-reads the written record
+ * through the data engine, so the seeded `record` carries the same computed
+ * fields a data-API read returns.
+ *
+ * This exercises the whole stack (real ObjectQL + automation + record-change
+ * trigger) with a formula field, proving the seeded record resolves it. The
+ * notify node interpolates the very same variable map, so a formula that
+ * resolves for `update_record` here resolves for a notify `title`/`body` too.
+ */
+import { describe, it, expect } from 'vitest';
+import { ObjectKernel } from '@objectstack/core';
+import { ObjectQLPlugin } from '@objectstack/objectql';
+import { AutomationServicePlugin, type AutomationEngine } from '@objectstack/service-automation';
+import { RecordChangeTriggerPlugin } from './plugin.js';
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Memory driver storing full rows. Formula virtuals are computed by the
+ *  ENGINE post-fetch, never by the driver — so `full_name` is never stored. */
+function makeDriver(): any {
+  const store = new Map<string, Record<string, unknown>>();
+  let n = 0;
+  const matches = (row: any, where: any): boolean => {
+    if (!where || typeof where !== 'object') return true;
+    for (const [k, v] of Object.entries(where)) {
+      if (k.startsWith('$')) continue;
+      const exp = v && typeof v === 'object' && '$eq' in (v as any) ? (v as any).$eq : v;
+      if ((row[k] ?? null) !== (exp ?? null)) return false;
+    }
+    return true;
+  };
+  return {
+    name: 'memory', version: '0', supports: {},
+    async connect() {}, async disconnect() {}, async checkHealth() { return true; },
+    async execute() { return null; }, async syncSchema() {},
+    async create(_o: string, data: any) {
+      n += 1; const id = data.id ?? `r_${n}`;
+      const full = { ...data, id };
+      store.set(id, full);
+      return { ...full };
+    },
+    async update(_o: string, id: string, data: any) { const cur = store.get(id) ?? {}; const u = { ...cur, ...data, id }; store.set(id, u); return { ...u }; },
+    async find(_o: string, ast: any) { return [...store.values()].filter((r) => matches(r, ast?.where)).map((r) => ({ ...r })); },
+    async findOne(_o: string, ast: any) { for (const r of store.values()) if (matches(r, ast?.where)) return { ...r }; return null; },
+    async delete(_o: string, id: string) { return store.delete(id); },
+    async count(_o: string, ast: any) { return (await this.find(_o, ast)).length; },
+    async upsert(_o: string, d: any) { return this.create(_o, d); },
+    async bulkCreate(_o: string, rows: any[]) { return Promise.all(rows.map((r) => this.create(_o, r))); },
+    async bulkUpdate() { return []; }, async bulkDelete() {},
+    async beginTransaction() { return { commit: async () => {}, rollback: async () => {} }; },
+    async commit() {}, async rollback() {},
+  };
+}
+
+describe('record-change context hydrates read-time formula fields (#3426)', () => {
+  it('resolves a formula field ({record.full_name}) in a seeded flow record', async () => {
+    const kernel = new ObjectKernel({ logLevel: 'silent' });
+    await kernel.use(new ObjectQLPlugin());
+    await kernel.use(new AutomationServicePlugin());
+    await kernel.use(new RecordChangeTriggerPlugin());
+    await kernel.bootstrap();
+
+    const objectql = kernel.getService('objectql') as any;
+    const data = kernel.getService('data') as any;
+    const automation = kernel.getService<AutomationEngine>('automation');
+    objectql.registerDriver(makeDriver(), true);
+    objectql.registry.registerObject({
+      name: 'crm_lead', label: 'Lead',
+      fields: {
+        first_name: { name: 'first_name', label: 'First', type: 'text' },
+        last_name: { name: 'last_name', label: 'Last', type: 'text' },
+        // Read-time formula virtual — never present on the raw written row.
+        full_name: {
+          name: 'full_name', label: 'Full name', type: 'formula',
+          expression: { dialect: 'cel', source: 'record.first_name + " " + record.last_name' },
+        },
+        greeting: { name: 'greeting', label: 'Greeting', type: 'text' },
+      },
+    }, 'test', 'test');
+
+    // On create, stamp `greeting` from the formula field. Before the fix this
+    // stamped '' because `{record.full_name}` was blank in the seeded record.
+    automation.registerFlow('lead_greeting', {
+      name: 'lead_greeting', label: 'Greeting', type: 'autolaunched',
+      nodes: [
+        { id: 'start', type: 'start', label: 'Start', config: { objectName: 'crm_lead', triggerType: 'record-after-create' } },
+        { id: 'stamp', type: 'update_record', label: 'Stamp', config: { objectName: 'crm_lead', filter: { id: '{record.id}' }, fields: { greeting: 'Hello, {record.full_name}!' } } },
+        { id: 'end', type: 'end', label: 'End' },
+      ],
+      edges: [ { id: 'e1', source: 'start', target: 'stamp' }, { id: 'e2', source: 'stamp', target: 'end' } ],
+    } as any);
+
+    const created = await data.insert('crm_lead', { first_name: 'Ada', last_name: 'Lovelace' });
+    const id = Array.isArray(created) ? created[0]?.id : created?.id ?? created;
+    await sleep(200);
+    const row = await data.findOne('crm_lead', { where: { id } });
+    expect(row?.full_name).toBe('Ada Lovelace'); // read-path sanity
+    expect(row?.greeting).toBe('Hello, Ada Lovelace!'); // flow saw the formula
+  }, 15000);
+});

--- a/packages/triggers/trigger-record-change/src/record-change-trigger.test.ts
+++ b/packages/triggers/trigger-record-change/src/record-change-trigger.test.ts
@@ -258,6 +258,148 @@ describe('RecordChangeTrigger', () => {
     });
 });
 
+// ─── computed-field hydration (#3426) ───────────────────────────────
+
+describe('RecordChangeTrigger computed-field hydration (#3426)', () => {
+    interface FindOneCall {
+        object: string;
+        options: { where?: Record<string, unknown>; fields?: string[]; context?: unknown };
+    }
+
+    /** fakeEngine + a `findOne` that records its calls and returns `row`. */
+    function fakeEngineWithRead(row: Record<string, unknown> | null | undefined) {
+        const base = fakeEngine();
+        const calls: FindOneCall[] = [];
+        const engine: RecordChangeDataEngine = {
+            ...base.engine,
+            async findOne(object, options) {
+                calls.push({ object, options });
+                return row;
+            },
+        };
+        return { engine, hooks: base.hooks, calls };
+    }
+
+    it('hydrates a formula field the raw hook row lacks (after-create)', async () => {
+        // The re-read returns the formula virtual `full_name` (absent from the
+        // written row) plus a field only the read path carries. After the merge
+        // the flow sees the formula, and raw scalars still win.
+        const { engine, hooks, calls } = fakeEngineWithRead({
+            id: 'r1',
+            first_name: 'Ada',
+            last_name: 'Lovelace',
+            full_name: 'Ada Lovelace',
+            company: 'Analytical Engines',
+        });
+        const trigger = new RecordChangeTrigger(engine, silentLogger());
+        let captured: AutomationContext | undefined;
+
+        trigger.start(
+            binding({ object: 'crm_lead', event: 'record-after-create' }),
+            async (ctx) => { captured = ctx; },
+        );
+        await hooks[0].handler(
+            hookCtx({ event: 'afterInsert', result: { id: 'r1', first_name: 'Ada', last_name: 'Lovelace' } }),
+        );
+
+        // Formula virtual is now resolvable on the seeded record…
+        expect((captured?.record as Record<string, unknown>).full_name).toBe('Ada Lovelace');
+        expect((captured?.record as Record<string, unknown>).company).toBe('Analytical Engines');
+        // …and params mirrors the same hydrated record.
+        expect((captured?.params as Record<string, unknown>)?.full_name).toBe('Ada Lovelace');
+        // Re-read was a system-elevated findOne scoped to the written row.
+        expect(calls).toHaveLength(1);
+        expect(calls[0].object).toBe('crm_lead');
+        expect(calls[0].options.where).toEqual({ id: 'r1' });
+        expect((calls[0].options.context as { isSystem?: boolean }).isSystem).toBe(true);
+    });
+
+    it('lets raw hook fields win over the re-read (trigger-time fidelity + #1872)', async () => {
+        // A concurrent read could observe a newer scalar or drop a multi-lookup
+        // array the driver echoed into the raw row; the raw value must survive.
+        const { engine, hooks } = fakeEngineWithRead({
+            id: 'r1',
+            status: 'stale',
+            target_channels: undefined,
+            full_name: 'Ada Lovelace',
+        });
+        const trigger = new RecordChangeTrigger(engine, silentLogger());
+        let captured: AutomationContext | undefined;
+
+        trigger.start(binding({ object: 'crm_lead', event: 'record-after-update' }), async (ctx) => { captured = ctx; });
+        await hooks[0].handler(
+            hookCtx({ event: 'afterUpdate', result: { id: 'r1', status: 'fresh', target_channels: ['ch_1'] } }),
+        );
+
+        const rec = captured?.record as Record<string, unknown>;
+        expect(rec.status).toBe('fresh'); // raw wins
+        expect(rec.target_channels).toEqual(['ch_1']); // #1872 array preserved
+        expect(rec.full_name).toBe('Ada Lovelace'); // formula added
+    });
+
+    it('does not re-read for before-* events (row not yet persisted)', async () => {
+        const { engine, hooks, calls } = fakeEngineWithRead({ id: 'r1', full_name: 'x' });
+        const trigger = new RecordChangeTrigger(engine, silentLogger());
+
+        trigger.start(binding({ object: 'crm_lead', event: 'record-before-update' }), async () => {});
+        await hooks[0].handler(hookCtx({ event: 'beforeUpdate', result: { id: 'r1' } }));
+
+        expect(calls).toHaveLength(0);
+    });
+
+    it('does not re-read for after-delete (row is gone)', async () => {
+        const { engine, hooks, calls } = fakeEngineWithRead({ id: 'r1', full_name: 'x' });
+        const trigger = new RecordChangeTrigger(engine, silentLogger());
+
+        trigger.start(binding({ object: 'crm_lead', event: 'record-after-delete' }), async () => {});
+        await hooks[0].handler(hookCtx({ event: 'afterDelete', result: { id: 'r1' } }));
+
+        expect(calls).toHaveLength(0);
+    });
+
+    it('does not re-read when the record has no id', async () => {
+        const { engine, hooks, calls } = fakeEngineWithRead({ id: 'r1', full_name: 'x' });
+        const trigger = new RecordChangeTrigger(engine, silentLogger());
+        let captured: AutomationContext | undefined;
+
+        trigger.start(binding({ object: 'crm_lead', event: 'record-after-create' }), async (ctx) => { captured = ctx; });
+        await hooks[0].handler(hookCtx({ event: 'afterInsert', result: { first_name: 'Ada' } }));
+
+        expect(calls).toHaveLength(0);
+        expect((captured?.record as Record<string, unknown>).first_name).toBe('Ada');
+    });
+
+    it('falls back to the raw record when the re-read throws', async () => {
+        const base = fakeEngine();
+        const engine: RecordChangeDataEngine = {
+            ...base.engine,
+            async findOne() { throw new Error('db down'); },
+        };
+        const debug = vi.fn();
+        const trigger = new RecordChangeTrigger(engine, { info: () => {}, warn: () => {}, debug });
+        let captured: AutomationContext | undefined;
+
+        trigger.start(binding({ object: 'crm_lead', event: 'record-after-create' }), async (ctx) => { captured = ctx; });
+        await base.hooks[0].handler(hookCtx({ event: 'afterInsert', result: { id: 'r1', first_name: 'Ada' } }));
+
+        // Flow still runs with the raw record; the failure is a debug note only.
+        expect((captured?.record as Record<string, unknown>).first_name).toBe('Ada');
+        expect((captured?.record as Record<string, unknown>).full_name).toBeUndefined();
+        expect(debug).toHaveBeenCalled();
+    });
+
+    it('is a no-op on engines with no findOne surface (older cores)', async () => {
+        const { engine, hooks } = fakeEngine(); // no findOne
+        const trigger = new RecordChangeTrigger(engine, silentLogger());
+        let captured: AutomationContext | undefined;
+
+        trigger.start(binding({ object: 'crm_lead', event: 'record-after-create' }), async (ctx) => { captured = ctx; });
+        await hooks[0].handler(hookCtx({ event: 'afterInsert', result: { id: 'r1', first_name: 'Ada' } }));
+
+        expect((captured?.record as Record<string, unknown>).first_name).toBe('Ada');
+    });
+});
+
 // ─── RecordChangeTriggerPlugin ──────────────────────────────────────
 
 describe('RecordChangeTriggerPlugin', () => {

--- a/packages/triggers/trigger-record-change/src/record-change-trigger.ts
+++ b/packages/triggers/trigger-record-change/src/record-change-trigger.ts
@@ -51,6 +51,20 @@ export interface RecordChangeDataEngine {
      * (2026-07-17 third-party eval).
      */
     getObject?(name: string): unknown;
+    /**
+     * Optional record re-read (the ObjectQL engine's `findOne`). When present,
+     * {@link RecordChangeTrigger} uses it to hydrate the seeded `record` with
+     * the read-time computed fields the raw lifecycle-hook row never carries —
+     * chiefly `formula` virtual fields, which are evaluated post-fetch on the
+     * READ path, not stored on the row. Without this, a flow's start condition
+     * and every `{record.<field>}` template that names a formula field resolve
+     * empty (#3426). Signature mirrors `IDataEngine.findOne`; typed structurally
+     * so this plugin keeps its zero build-time dependency on objectql.
+     */
+    findOne?(
+        object: string,
+        options: { where?: Record<string, unknown>; fields?: string[]; context?: unknown },
+    ): Promise<Record<string, unknown> | null | undefined>;
 }
 
 /** Minimal logger surface (matches core's `ctx.logger`). */
@@ -157,7 +171,7 @@ export class RecordChangeTrigger implements FlowTrigger {
                 if ((ctx.session as { skipTriggers?: boolean } | undefined)?.skipTriggers) {
                     return;
                 }
-                const automationCtx = this.buildContext(binding, ctx);
+                const automationCtx = await this.buildContext(binding, ctx);
                 await callback(automationCtx);
             } catch (err) {
                 // Error isolation: a flow failure must NEVER break the CRUD write
@@ -199,8 +213,11 @@ export class RecordChangeTrigger implements FlowTrigger {
      * record comes from `ctx.result` (after-hooks) or falls back to the
      * mutation input doc / previous row; the old record from `ctx.previous`
      * (with the `__previous` stash audit also uses as a fallback).
+     *
+     * Async because the seeded `record` is hydrated with read-time computed
+     * fields (see {@link hydrateComputedFields}) via a data-engine re-read.
      */
-    private buildContext(binding: FlowTriggerBinding, ctx: HookContext): AutomationContext {
+    private async buildContext(binding: FlowTriggerBinding, ctx: HookContext): Promise<AutomationContext> {
         // objectql lifecycle hooks carry the written row under `input.data` (insert /
         // update payload); `id` is on update. (`doc` kept only as a defensive alias.)
         const input = (ctx.input ?? {}) as { data?: Record<string, unknown>; doc?: Record<string, unknown>; id?: unknown };
@@ -227,10 +244,17 @@ export class RecordChangeTrigger implements FlowTrigger {
 
         const session = (ctx.session ?? {}) as { userId?: string; organizationId?: string };
 
+        const object = binding.object ?? ctx.object;
+
+        // Hydrate read-time computed fields (formula virtuals) onto the seeded
+        // record so the flow's start condition and every `{record.<field>}`
+        // template resolve them — the raw hook row never carries them (#3426).
+        const hydrated = await this.hydrateComputedFields(object, ctx.event, record);
+
         return {
-            record,
+            record: hydrated,
             previous,
-            object: binding.object ?? ctx.object,
+            object,
             event: binding.event,
             userId: session.userId,
             // Forward the writer's identity so a `runAs:'user'` flow enforces RLS
@@ -249,7 +273,64 @@ export class RecordChangeTrigger implements FlowTrigger {
             ...(session.organizationId ? { tenantId: session.organizationId } : {}),
             // Expose the record as params too, so flows with named `isInput`
             // variables matching record fields get them seeded.
-            params: record,
+            params: hydrated,
         };
+    }
+
+    /**
+     * Re-read the just-written record through the data engine so the seeded
+     * `record` carries the SAME read-time computed fields the data API returns —
+     * chiefly `formula` virtual fields, which lifecycle-hook rows never include
+     * because they are evaluated on the READ path, not stored on the row
+     * (#3426). Without this, `{record.full_name}` (a formula) in a notify
+     * template, or a start condition referencing one, silently renders blank.
+     *
+     * Deliberately conservative:
+     *  - Runs only for `afterInsert` / `afterUpdate`, where the row exists in
+     *    its post-write state. `before*` rows are not yet persisted and
+     *    `afterDelete` rows are gone; both keep the raw hook record untouched.
+     *  - Reads as an elevated SYSTEM principal so it can only ADD computed
+     *    fields, never let RLS/FLS on the re-read shrink the snapshot the flow
+     *    was already going to see from the raw (unmasked) write-path row.
+     *  - Raw hook fields WIN over the re-read on merge, preserving trigger-time
+     *    scalar values and the #1872 multi-lookup input overlay; the re-read
+     *    only fills in keys the raw row lacks (the formula virtuals).
+     *  - Lookup TRAVERSAL (`{record.account.name}`) is intentionally NOT
+     *    hydrated: a default data-API read does not expand relations either, and
+     *    expanding would turn `record.account` from its scalar FK id into an
+     *    object, breaking templates/conditions that use the bare id (e.g.
+     *    #1872's `{record.target_channels.0}`). Tracked separately on #3426.
+     *
+     * Any failure (no read surface, no id, a throw, an empty read) falls back to
+     * the raw record — hydration must never break the flow it feeds.
+     */
+    private async hydrateComputedFields(
+        object: string | undefined,
+        hookEvent: string | undefined,
+        record: Record<string, unknown>,
+    ): Promise<Record<string, unknown>> {
+        if (typeof this.engine.findOne !== 'function') return record;
+        if (hookEvent !== 'afterInsert' && hookEvent !== 'afterUpdate') return record;
+        if (!object) return record;
+        const id = (record as { id?: unknown }).id;
+        if (id == null || id === '') return record;
+        try {
+            const full = await this.engine.findOne(object, {
+                where: { id },
+                // Elevated read: adds computed fields without RLS/FLS masking the
+                // ones the raw row already carried.
+                context: { isSystem: true, positions: [], permissions: [] },
+            });
+            if (full && typeof full === 'object') {
+                // Raw hook fields win; the re-read only contributes keys the raw
+                // row lacks (the formula virtuals + any other read-time field).
+                return { ...(full as Record<string, unknown>), ...record };
+            }
+        } catch (err) {
+            this.logger.debug?.(
+                `[record-change] computed-field hydration skipped for '${object}': ${(err as Error)?.message ?? String(err)}`,
+            );
+        }
+        return record;
     }
 }


### PR DESCRIPTION
## 问题

`notify` 节点模板里的 `{record.full_name}`(一个 `formula` 公式字段)在 `record_change` 流程里被解析成 **空字符串**,于是收件箱里出现 `"New lead to assign: "` 这类缺名字的通知,而且没有任何构建期/运行期信号。同一条记录上的普通标量列(`{record.company}`、`{record.first_name}`)却能正常插值。见 #3426。

## 根因

`formula` 是**读取时(read-time)虚拟字段**:引擎只在 `find`/`findOne` 取数后用 `applyFormulaPlan` 计算它,**写入路径不会计算、也不落库**。而 record-change 触发器给流程种子的 `record` 直接来自生命周期钩子的原始行(`ctx.result` 叠加输入 doc,见 #1872),这一行**根本不含公式字段**。因此流程上下文里 `record.full_name` 是 `undefined`,插值时被渲染为 `''`。

这不是消费端(notify 节点)的问题,而是 `record` 这个**生产者**(触发器)喂进来的数据本身就缺字段——所以修复放在触发器,整条流程(开始条件、所有节点、notify 的 `title`/`body`)都受益,而不是只给 notify 打补丁。

## 方案

`RecordChangeTrigger` 在组装种子 `record` 后,通过数据引擎**回读**刚写入的记录,让种子 `record` 与「用数据 API 读这条记录」拿到的计算字段保持一致。

刻意保守:

- **仅** 对 `afterInsert` / `afterUpdate` 生效(行已处于写后状态);`before*`(行尚未落库)与 `afterDelete`(行已删除)保持原始钩子记录不变。
- 以**系统(isSystem)身份**回读,因此只会**新增**计算字段,绝不会因回读侧的 RLS/FLS 把流程本来能看到的(未脱敏的写路径行)字段**抹掉**。
- 合并时**原始钩子字段优先**,保留触发时刻的标量值与 #1872 的多值 lookup 输入叠加;回读只补齐原始行缺失的键(公式虚拟字段)。
- 任何失败(引擎无 `findOne`、无 `id`、抛错、读到空)都回退到原始记录——补水绝不能弄坏它所服务的流程。

## 取舍:lookup 遍历暂不处理

`{record.account.name}` 这类 **lookup 跨表遍历**有意**不**做补水:数据 API 的默认读取本身也不展开关联;而一旦展开,`record.account` 就会从标量外键 id 变成对象,反而破坏那些把它当 id 用的模板/条件(例如 #1872 的 `{record.target_channels.0}`)。因此本 PR 让种子记录严格对齐「数据 API 默认读取」的语义——公式字段补齐、关联不展开。lookup 遍历(以及构建期对不可解析路径的告警)仍留在 #3426 跟踪。

## 测试

- 新增 7 个针对 `hydrateComputedFields` 的单元测试:after-create 补齐公式字段、原始字段优先(触发时刻保真 + #1872)、`before*`/`afterDelete`/无 id/无 `findOne` 时不回读、回读抛错时回退。
- 新增一个端到端集成测试 `formula-context.test.ts`:用真实 ObjectQL + automation + record-change 栈注册一个公式字段,证明 `{record.full_name}` 在种子流程记录里能被解析(修复前会渲染成空)。
- `@objectstack/trigger-record-change`(33 tests)与 `@objectstack/service-automation`(347 tests)全绿;类型构建 + lint 通过;附带 changeset。

关联 #3426。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StfHcpZduPXA6zSAG6beFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01StfHcpZduPXA6zSAG6beFR)_