### PR TITLE
fix(dev): eliminate three fixed startup log warnings so official examples boot clean (#3420)

### DIFF
--- a/.changeset/startup-log-noise-cleanup.md
+++ b/.changeset/startup-log-noise-cleanup.md
@@ -21,4 +21,6 @@ with zero example-side changes — training users to ignore warnings.
   false positive (printed twice); silencing it removes both.
 - **objectql** — route the Registry's re-register / package-overwrite lines
   (normal rebuild / HMR / seed-replay paths) through a new debug-only
-  `SchemaRegistry.debug()` so they stay out of the default `info` boot log.
+  `SchemaRegistry.debug()` so they stay out of the default `info` boot log. Adds
+  a `logLevel` construction option (and matching `OS_REGISTRY_LOG` env var) so
+  the debug-gated housekeeping is discoverable for troubleshooting.

--- a/.changeset/startup-log-noise-cleanup.md
+++ b/.changeset/startup-log-noise-cleanup.md
@@ -1,0 +1,24 @@
+---
+"@objectstack/spec": patch
+"@objectstack/objectql": patch
+"@objectstack/plugin-auth": patch
+---
+
+fix(dev): eliminate three fixed startup log warnings so official examples boot clean (#3420)
+
+`os dev` on the stock showcase printed three fixed noise sources on every boot,
+with zero example-side changes — training users to ignore warnings.
+
+- **spec** — add a field-level `ackPlaintextMasking: true` opt-out for the
+  generic `password` author-time warning (ADR-0100). A deliberately-masked
+  field (like field-zoo's `f_password`) can now affirm intent instead of
+  printing an un-actionable "safe to ignore" on every boot; the warning text
+  points authors at the flag.
+- **plugin-auth** — pass better-auth's documented
+  `silenceWarnings.oauthAuthServerConfig` to `oauthProvider(...)`. We already
+  mount the `/.well-known/oauth-authorization-server` documents ourselves at
+  the issuer root, so the plugin's "please ensure it exists" reminder was a
+  false positive (printed twice); silencing it removes both.
+- **objectql** — route the Registry's re-register / package-overwrite lines
+  (normal rebuild / HMR / seed-replay paths) through a new debug-only
+  `SchemaRegistry.debug()` so they stay out of the default `info` boot log.

--- a/content/docs/references/data/field.mdx
+++ b/content/docs/references/data/field.mdx
@@ -147,6 +147,7 @@ const result = Address.parse(data);
 | **hidden** | `boolean` | optional | Hidden from default UI |
 | **readonly** | `boolean` | optional | Read-only — never editable in forms, AND server-enforced on BOTH write paths: a non-system write to this field is silently dropped from the payload on UPDATE (#2948/#3003) and on INSERT (#3043; a create can no longer directly seed e.g. `approval_status: "approved"`), symmetric with `readonlyWhen`. A stripped INSERT field still falls back to its `defaultValue`; system-context writes (import, seed replay, migration) are exempt. |
 | **requiredPermissions** | `string[]` | optional | [ADR-0066 D3] Capabilities required to read/edit this field (mask on read, deny on write; AND-gate). |
+| **ackPlaintextMasking** | `boolean` | optional | [ADR-0100] Affirm a generic `password` field's plaintext-at-rest / masked-on-read contract is intended, silencing the author-time warning (#3420). No effect on non-password fields. |
 | **system** | `boolean` | optional | Auto-injected system/audit field (e.g. created_at, updated_by, organization_id). Tools that surface system fields separately from author-declared business fields should branch on this flag. |
 | **sortable** | `boolean` | optional | Whether field is sortable in list views |
 | **inlineHelpText** | `string` | optional | Help text displayed below the field in forms |

--- a/docs/adr/0100-credential-field-channels.md
+++ b/docs/adr/0100-credential-field-channels.md
@@ -95,6 +95,15 @@ rest but masked on read**:
    would be self-inflicted breakage. Raw `.parse()` stays silent, since it also
    loads persisted metadata and `create()` is the authoring surface (ADR-0077).
 
+   **Opt-out — `ackPlaintextMasking: true` (#3420).** A deliberate `password`
+   field (like field-zoo's `f_password`) can affirm intent with a field-level
+   `ackPlaintextMasking: true`; the warning then skips that field. The original
+   text said the warning was "safe to ignore" but offered no way to *express*
+   that intent, so the official showcase booted with an unavoidable warning —
+   training users to ignore warnings. The flag is the documented affirmation and
+   lets the stock example start warning-free. It is diagnostic-only: masking,
+   the echoed-mask guard, and the better-auth exemption are all unchanged by it.
+
 ### C. Shared mechanism
 
 Both channels share one read-mask collector — `collectMaskedReadFields`

--- a/examples/app-crm/test/smoke.test.ts
+++ b/examples/app-crm/test/smoke.test.ts
@@ -95,6 +95,23 @@ describe('app-crm minimal metadata bundle', () => {
     expect(rules.some((r) => r.type === 'owner')).toBe(true);
   });
 
+  // #3420 — official examples must boot warning-free. A generic (non-better-auth)
+  // `password` field trips the ADR-0100 author-time warning unless it affirms
+  // intent with `ackPlaintextMasking: true`. crm ships none today; this guard
+  // fails loudly if one is ever added without the acknowledgment.
+  it('has no un-acknowledged generic password fields (#3420)', () => {
+    const offenders: string[] = [];
+    for (const obj of (stack.objects ?? []) as any[]) {
+      if (obj?.managedBy === 'better-auth') continue;
+      for (const [fieldName, def] of Object.entries((obj?.fields ?? {}) as Record<string, any>)) {
+        if (def?.type === 'password' && def?.ackPlaintextMasking !== true) {
+          offenders.push(`${obj.name}.${fieldName}`);
+        }
+      }
+    }
+    expect(offenders, `un-acknowledged generic password field(s): ${offenders.join(', ')}`).toEqual([]);
+  });
+
 });
 
 describe('Pipeline dashboard', () => {

--- a/examples/app-showcase/src/data/objects/field-zoo.object.ts
+++ b/examples/app-showcase/src/data/objects/field-zoo.object.ts
@@ -35,7 +35,10 @@ export const FieldZoo = ObjectSchema.create({
     f_email: Field.email({ label: 'Email', searchable: true }),
     f_url: Field.url({ label: 'URL' }),
     f_phone: Field.phone({ label: 'Phone' }),
-    f_password: Field.password({ label: 'Password (masked on read)' }),
+    // field-zoo intentionally exercises every field type, so the generic
+    // `password` contract (plaintext at rest, masked on read — ADR-0100) is
+    // deliberate here. Affirm it so the official example boots warning-free (#3420).
+    f_password: Field.password({ label: 'Password (masked on read)', ackPlaintextMasking: true }),
     f_secret: Field.secret({ label: 'Secret (encrypted at rest)' }),
 
     // ── Rich content ─────────────────────────────────────────────────────

--- a/examples/app-showcase/test/no-startup-warnings.test.ts
+++ b/examples/app-showcase/test/no-startup-warnings.test.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import stack from '../objectstack.config.js';
+
+/**
+ * #3420 — the official examples must boot with ZERO warnings so users don't get
+ * trained to ignore them. A generic (non-`better-auth`) `password` field trips a
+ * non-fatal `ObjectSchema.create()` warning at author time (ADR-0100: plaintext
+ * at rest, masked on read); the documented way to affirm intent is
+ * `ackPlaintextMasking: true`. This guard fails if a new or edited object
+ * reintroduces an un-acknowledged generic password field — keeping the showcase
+ * boot log clean without silencing the diagnostic for real authors.
+ *
+ * The other two boot-noise sources from #3420 are framework-level and guarded in
+ * their own packages: the better-auth `oauthAuthServerConfig` false positive
+ * (@objectstack/plugin-auth auth-manager.mcp-oauth.test.ts) and the registry
+ * re-register lines (@objectstack/objectql registry-log-level.test.ts).
+ */
+describe('showcase boots without ADR-0100 password warnings (#3420)', () => {
+  it('every generic password field affirms ackPlaintextMasking', () => {
+    const offenders: string[] = [];
+    for (const obj of (stack.objects ?? []) as any[]) {
+      if (obj?.managedBy === 'better-auth') continue;
+      for (const [fieldName, def] of Object.entries((obj?.fields ?? {}) as Record<string, any>)) {
+        if (def?.type === 'password' && def?.ackPlaintextMasking !== true) {
+          offenders.push(`${obj.name}.${fieldName}`);
+        }
+      }
+    }
+    expect(offenders, `un-acknowledged generic password field(s): ${offenders.join(', ')}`).toEqual([]);
+  });
+});

--- a/packages/objectql/src/registry-log-level.test.ts
+++ b/packages/objectql/src/registry-log-level.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SchemaRegistry, REGISTRY_LOG_LEVELS } from './registry';
+
+/**
+ * #3420 — the registry's expected-but-noisy housekeeping (re-registering an
+ * owned object, overwriting a package manifest on a rebuild / HMR / multi-project
+ * seed-replay) must NOT reach a stock `os dev` boot log. It used to be emitted
+ * via `console.warn` (always on) and looked like an error, though it is a normal
+ * path. It is now emitted at `debug`, so it stays out of the default `info` level
+ * but `OS_REGISTRY_LOG=debug` (or `{ logLevel: 'debug' }`) makes it discoverable.
+ *
+ * This is the regression guard: if either line ever regresses back to `warn`
+ * (or to the always-on `log`/`console.log`), the "silent at info" assertions
+ * fail — keeping the official examples' boot log clean.
+ */
+describe('SchemaRegistry log-level gating (#3420)', () => {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+  beforeEach(() => { warn.mockClear(); debug.mockClear(); });
+  afterEach(() => { delete process.env.OS_REGISTRY_LOG; });
+
+  const reRegisterSameOwner = (r: SchemaRegistry) => {
+    r.registerObject({ name: 'sys_thing', fields: {} } as any, 'com.acme.app', 'sys', 'own');
+    r.registerObject({ name: 'sys_thing', fields: {} } as any, 'com.acme.app', 'sys', 'own');
+  };
+
+  it('at the default (info) level, re-registering an owned object is silent — no warn, no debug', () => {
+    const r = new SchemaRegistry({ multiTenant: false });
+    reRegisterSameOwner(r);
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('Re-registering owned object'));
+    expect(debug).not.toHaveBeenCalledWith(expect.stringContaining('Re-registering owned object'));
+  });
+
+  it('at debug level, the re-register line is emitted via console.debug (never console.warn)', () => {
+    const r = new SchemaRegistry({ multiTenant: false, logLevel: 'debug' });
+    reRegisterSameOwner(r);
+    expect(debug).toHaveBeenCalledWith(expect.stringContaining('Re-registering owned object: sys_thing'));
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('Re-registering owned object'));
+  });
+
+  it('overwriting a package manifest is debug-gated the same way', () => {
+    const manifest = { id: 'com.test', name: 'Test', namespace: 'test', version: '1.0.0' } as any;
+
+    const info = new SchemaRegistry({ multiTenant: false });
+    info.installPackage(manifest);
+    info.installPackage(manifest); // same-package reload → "Overwriting package"
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('Overwriting package'));
+    expect(debug).not.toHaveBeenCalledWith(expect.stringContaining('Overwriting package'));
+
+    debug.mockClear();
+    const dbg = new SchemaRegistry({ multiTenant: false, logLevel: 'debug' });
+    dbg.installPackage(manifest);
+    dbg.installPackage(manifest);
+    expect(debug).toHaveBeenCalledWith(expect.stringContaining('Overwriting package: com.test'));
+  });
+
+  it('resolves the level from OS_REGISTRY_LOG when no explicit option is given', () => {
+    process.env.OS_REGISTRY_LOG = 'debug';
+    expect(new SchemaRegistry({ multiTenant: false }).logLevel).toBe('debug');
+  });
+
+  it('falls back to info for an unrecognized OS_REGISTRY_LOG value', () => {
+    process.env.OS_REGISTRY_LOG = 'chatty';
+    expect(new SchemaRegistry({ multiTenant: false }).logLevel).toBe('info');
+  });
+
+  it('an explicit logLevel option wins over the env var', () => {
+    process.env.OS_REGISTRY_LOG = 'debug';
+    expect(new SchemaRegistry({ multiTenant: false, logLevel: 'silent' }).logLevel).toBe('silent');
+  });
+
+  it('exposes the full level vocabulary for validation', () => {
+    expect(REGISTRY_LOG_LEVELS).toEqual(['debug', 'info', 'warn', 'error', 'silent']);
+  });
+});

--- a/packages/objectql/src/registry.ts
+++ b/packages/objectql/src/registry.ts
@@ -121,6 +121,11 @@ function mergeObjectDefinitions(base: ServiceObject, extension: Partial<ServiceO
  */
 export type RegistryLogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent';
 
+/** All valid {@link RegistryLogLevel} values — used to validate `OS_REGISTRY_LOG`. */
+export const REGISTRY_LOG_LEVELS: readonly RegistryLogLevel[] = [
+  'debug', 'info', 'warn', 'error', 'silent',
+];
+
 /**
  * Construction options for {@link SchemaRegistry}.
  */
@@ -172,6 +177,19 @@ export interface SchemaRegistryOptions {
    * package ids are always disambiguable by package-scoped resolution.)
    */
   collisionPolicy?: 'error' | 'warn';
+
+  /**
+   * Verbosity of the registry's own `[Registry] …` log lines. Sourced from the
+   * `OS_REGISTRY_LOG` env var when not set explicitly (default `'info'`).
+   *
+   * The point of the env seam is discoverability (#3420): expected-but-noisy
+   * housekeeping — re-registering an owned object / overwriting a package
+   * manifest on a rebuild/HMR/seed-replay — is emitted at `'debug'`, so it stays
+   * out of a stock `info` boot log but a developer chasing a registration issue
+   * can surface it with `OS_REGISTRY_LOG=debug`. An unrecognized value falls
+   * back to `'info'`.
+   */
+  logLevel?: RegistryLogLevel;
 }
 
 /**
@@ -529,6 +547,16 @@ export class SchemaRegistry {
     this.collisionPolicy =
       options.collisionPolicy ??
       ((process.env.OS_METADATA_COLLISION ?? '').toLowerCase() === 'warn' ? 'warn' : 'error');
+
+    // #3420 — env-driven verbosity so debug-level registry housekeeping
+    // (re-register / package overwrite) is discoverable without a code change.
+    // Unrecognized OS_REGISTRY_LOG values fall back to the 'info' default.
+    const envLevel = (process.env.OS_REGISTRY_LOG ?? '').toLowerCase();
+    this._logLevel =
+      options.logLevel ??
+      (REGISTRY_LOG_LEVELS.includes(envLevel as RegistryLogLevel)
+        ? (envLevel as RegistryLogLevel)
+        : this._logLevel);
   }
 
   get logLevel(): RegistryLogLevel { return this._logLevel; }

--- a/packages/objectql/src/registry.ts
+++ b/packages/objectql/src/registry.ts
@@ -539,6 +539,17 @@ export class SchemaRegistry {
     console.log(msg);
   }
 
+  /**
+   * Debug-only diagnostic: emitted solely when `logLevel === 'debug'`, so it
+   * stays out of the default (`'info'`) boot log. Use for expected-but-noisy
+   * housekeeping — e.g. re-registration on a metadata rebuild / HMR reload,
+   * which looks like an error (`console.warn`) but is a normal path (#3420).
+   */
+  private debug(msg: string): void {
+    if (this._logLevel !== 'debug') return;
+    console.debug(msg);
+  }
+
   // ==========================================
   // Object-specific storage (Ownership Model)
   // ==========================================
@@ -731,7 +742,10 @@ export class SchemaRegistry {
       const idx = contributors.findIndex(c => c.packageId === packageId && c.ownership === 'own');
       if (idx !== -1) {
         contributors.splice(idx, 1);
-        console.warn(`[Registry] Re-registering owned object: ${fqn} from ${packageId}`);
+        // Normal path (metadata rebuild / HMR / multi-project seed replays the
+        // same owned object), not an error — keep it at debug so a stock boot
+        // stays warning-free (#3420).
+        this.debug(`[Registry] Re-registering owned object: ${fqn} from ${packageId}`);
       }
     } else {
       // extend mode: remove existing extension from same package
@@ -1329,7 +1343,9 @@ export class SchemaRegistry {
     }
     const collection = this.metadata.get('package')!;
     if (collection.has(manifest.id)) {
-      console.warn(`[Registry] Overwriting package: ${manifest.id}`);
+      // Re-install of an already-registered package manifest (rebuild / HMR) is
+      // a normal path, not an error — keep it at debug (#3420).
+      this.debug(`[Registry] Overwriting package: ${manifest.id}`);
     }
     collection.set(manifest.id, pkg);
     this.log(`[Registry] Installed package: ${manifest.id} (${manifest.name})`);

--- a/packages/plugins/plugin-auth/src/auth-manager.mcp-oauth.test.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.mcp-oauth.test.ts
@@ -302,6 +302,16 @@ describe('oauthProvider plugin wiring (DCR + scopes + audiences)', () => {
     expect(opts.validAudiences).toContain('https://acme.example.com/api/v1/auth');
   });
 
+  it('silences the false-positive oauthAuthServerConfig warning (#3420)', async () => {
+    // registerOidcDiscoveryRoutes mounts /.well-known/oauth-authorization-server
+    // (and the /api/v1/auth path-insertion variant) at the issuer ROOT ourselves,
+    // so better-auth's boot-time "Please ensure … exists" reminder is a false
+    // positive. It must be silenced via the documented option, or the stock
+    // showcase prints it (twice) on every `os dev`. Regression guard for the fix.
+    const opts = await capturePluginOpts({ OS_MCP_SERVER_ENABLED: 'true' });
+    expect(opts.silenceWarnings).toEqual({ oauthAuthServerConfig: true });
+  });
+
   it('OS_OIDC_DCR_ENABLED=false forces DCR off even with MCP on', async () => {
     const opts = await capturePluginOpts({ OS_MCP_SERVER_ENABLED: 'true', OS_OIDC_DCR_ENABLED: 'false' });
     expect(opts.allowDynamicClientRegistration).toBe(false);

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -1853,11 +1853,18 @@ export class AuthManager {
         // mount ourselves at the issuer ROOT (RFC 8414 §3 requires them there,
         // not under the auth basePath) — registerOidcDiscoveryRoutes serves
         // /.well-known/oauth-authorization-server AND the path-insertion variant
-        // (`…/api/v1/auth`) the notice names. Its boot-time "Please ensure …
-        // exists" reminder is therefore a false positive that fires on every
-        // stock example (twice — jwt+oauthProvider init runs it per instance);
-        // silence the one requirement we've already satisfied so an official
-        // dev boot stays warning-free (#3420).
+        // (`…/api/v1/auth`) the notice names. Its "Please ensure … exists"
+        // reminder is therefore a false positive on every stock example.
+        //
+        // #3420 root cause of the DOUBLE print: the notice fires in the
+        // oauth-provider plugin's `init(ctx)`, which better-auth runs once per
+        // `betterAuth()` construction — and the instance is built more than once
+        // at boot (an initial lazy build, then a rebuild once boot-time auth
+        // *settings* are applied — applyConfigPatch() nulls the cached instance
+        // so the next request rebuilds with the new policy). Gating the emitter
+        // here silences the one requirement we've already satisfied across every
+        // build path, independent of how many times auth is constructed, so an
+        // official dev boot stays warning-free.
         silenceWarnings: { oauthAuthServerConfig: true },
         // ── MCP OAuth track (#2698) ────────────────────────────────
         // Coarse tool-family scopes for the platform's own MCP endpoint,

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -1849,6 +1849,16 @@ export class AuthManager {
         loginPage: this.getConsolePageUrl('/login'),
         consentPage: this.getConsolePageUrl('/oauth/consent'),
         schema: buildOauthProviderPluginSchema(),
+        // better-auth's oauth-provider cannot see the well-known documents we
+        // mount ourselves at the issuer ROOT (RFC 8414 §3 requires them there,
+        // not under the auth basePath) — registerOidcDiscoveryRoutes serves
+        // /.well-known/oauth-authorization-server AND the path-insertion variant
+        // (`…/api/v1/auth`) the notice names. Its boot-time "Please ensure …
+        // exists" reminder is therefore a false positive that fires on every
+        // stock example (twice — jwt+oauthProvider init runs it per instance);
+        // silence the one requirement we've already satisfied so an official
+        // dev boot stays warning-free (#3420).
+        silenceWarnings: { oauthAuthServerConfig: true },
         // ── MCP OAuth track (#2698) ────────────────────────────────
         // Coarse tool-family scopes for the platform's own MCP endpoint,
         // advertised alongside the standard OIDC scopes. Names are

--- a/packages/spec/liveness/field.json
+++ b/packages/spec/liveness/field.json
@@ -104,6 +104,11 @@
       "evidence": "packages/plugins/plugin-security/src/security-plugin.ts",
       "note": "ADR-0066 D3 field-level capability gate. getObjectSecurityMeta reads field.requiredPermissions; foldFieldRequiredPermissions forces non-readable+non-editable when the caller's systemPermissions don't cover them, so FieldMasker masks on read + detectForbiddenWrites denies on write (AND-gate). Unit-proven in packages/plugins/plugin-security/src/security-plugin.test.ts."
     },
+    "ackPlaintextMasking": {
+      "status": "live",
+      "evidence": "packages/spec/src/data/object.zod.ts",
+      "note": "ADR-0100 author-time diagnostic gate (#3420). warnGenericPasswordFields (object.zod.ts) reads field.ackPlaintextMasking and skips the generic-password plaintext-at-rest/masked-on-read warning for a field that affirms intent, so a deliberate demo (showcase field-zoo f_password, which exercises every field type) boots warning-free instead of printing an un-actionable 'safe to ignore'. Diagnostic-only: masking, the echoed-mask write guard, and the better-auth exemption are unchanged. Proven in packages/spec/src/data/object.test.ts (ADR-0100 password-field author warning suite: ackPlaintextMasking suppresses, partial-ack still warns about the un-acked field, warning text names the flag)."
+    },
     "system": {
       "status": "live",
       "evidence": "packages/objectql/src/engine.ts"

--- a/packages/spec/src/data/field.zod.ts
+++ b/packages/spec/src/data/field.zod.ts
@@ -511,6 +511,18 @@ export const FieldSchema = lazySchema(() => z.object({
    * over permission-set field grants. Enforced by plugin-security's FieldMasker.
    */
   requiredPermissions: z.array(z.string()).optional().describe('[ADR-0066 D3] Capabilities required to read/edit this field (mask on read, deny on write; AND-gate).'),
+
+  /**
+   * [ADR-0100] Author's explicit acknowledgment that a generic (non-auth)
+   * `password` field is stored PLAINTEXT at rest and masked to SECRET_MASK on
+   * read — it is NOT one-way hashed (that lives only in the auth subsystem).
+   * Set `true` to affirm the masking contract is intended; this is the
+   * documented way to express "this is intended" and silences the non-fatal
+   * `ObjectSchema.create()` author-time warning so a deliberate demo/design
+   * starts clean (#3420). No runtime effect beyond the diagnostic; ignored on
+   * non-`password` fields.
+   */
+  ackPlaintextMasking: z.boolean().optional().describe("[ADR-0100] Affirm a generic `password` field's plaintext-at-rest / masked-on-read contract is intended, silencing the author-time warning (#3420). No effect on non-password fields."),
   system: z.boolean().optional().describe('Auto-injected system/audit field (e.g. created_at, updated_by, organization_id). Tools that surface system fields separately from author-declared business fields should branch on this flag.'),
   sortable: z.boolean().optional().default(true).describe('Whether field is sortable in list views'),
   inlineHelpText: z.string().optional().describe('Help text displayed below the field in forms'),

--- a/packages/spec/src/data/object.test.ts
+++ b/packages/spec/src/data/object.test.ts
@@ -1486,4 +1486,38 @@ describe('ObjectSchema.create() password-field author warning (ADR-0100)', () =>
     });
     expect(warn).not.toHaveBeenCalled();
   });
+
+  it('does NOT warn when the field affirms intent with ackPlaintextMasking (#3420)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    ObjectSchema.create({
+      name: 'adr0100_acked_pw',
+      fields: { admin_password: { type: 'password', ackPlaintextMasking: true } },
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('still warns about un-acknowledged password fields when only some opt in', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    ObjectSchema.create({
+      name: 'adr0100_partial_ack',
+      fields: {
+        acked_pw: { type: 'password', ackPlaintextMasking: true },
+        raw_pw: { type: 'password' },
+      },
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    const msg = warn.mock.calls[0]?.[0] as string;
+    expect(msg).toContain('raw_pw');
+    expect(msg).not.toContain('acked_pw');
+  });
+
+  it('points authors at the ackPlaintextMasking opt-out in the warning text', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    ObjectSchema.create({
+      name: 'adr0100_hint_pw',
+      fields: { pw: { type: 'password' } },
+    });
+    const msg = warn.mock.calls[0]?.[0] as string;
+    expect(msg).toContain('ackPlaintextMasking');
+  });
 });

--- a/packages/spec/src/data/object.zod.ts
+++ b/packages/spec/src/data/object.zod.ts
@@ -1262,7 +1262,10 @@ const warnedPasswordObjects = new Set<string>();
  * A warning, not an error: `password` now has a defined generic-path contract,
  * and the field-zoo example intentionally exercises every field type — a hard
  * error would be self-inflicted breakage. Deduped per object name so a schema
- * imported many times warns once. `managedBy: 'better-auth'` objects are exempt.
+ * imported many times warns once. `managedBy: 'better-auth'` objects are exempt,
+ * as are fields that opt in with `ackPlaintextMasking: true` — the author's
+ * explicit "this is intended" acknowledgment (#3420), which lets a deliberate
+ * demo/design (e.g. the showcase field-zoo) start with zero warnings.
  */
 function warnGenericPasswordFields(
   objectName: unknown,
@@ -1271,8 +1274,10 @@ function warnGenericPasswordFields(
 ): void {
   if (managedBy === 'better-auth') return;
   if (!fields || typeof fields !== 'object') return;
-  const passwordFields = Object.entries(fields as Record<string, { type?: string }>)
-    .filter(([, def]) => def && def.type === 'password')
+  const passwordFields = Object.entries(
+    fields as Record<string, { type?: string; ackPlaintextMasking?: boolean }>,
+  )
+    .filter(([, def]) => def && def.type === 'password' && def.ackPlaintextMasking !== true)
     .map(([fieldName]) => fieldName);
   if (passwordFields.length === 0) return;
   const name = typeof objectName === 'string' && objectName.length > 0 ? objectName : '<unnamed>';
@@ -1285,7 +1290,7 @@ function warnGenericPasswordFields(
     'it is NOT one-way hashed (that is owned by the auth subsystem, for its identity ' +
     "tables only). Use `Field.secret(...)` for reversible machine credentials, or model " +
     'login credentials on the auth user object. If this is intended, the masking contract ' +
-    'now applies and this warning is safe to ignore.',
+    'applies — affirm it with `ackPlaintextMasking: true` on the field to silence this warning.',
   );
 }
 


### PR DESCRIPTION
## Summary

Closes #3420. `os dev` on the stock showcase printed **three fixed noise sources** on every boot, with zero example-side changes — training users to ignore warnings (cry-wolf). This clears all three so an official example boots warning-free, adds regression guards so it *stays* clean, and makes the debug output discoverable — without weakening any real diagnostic.

Repro: `pnpm -C examples/app-showcase exec objectstack dev --ui --seed-admin`.

## The three fixes

### 1. field-zoo `password` warning → field-level opt-out
`ObjectSchema.create('showcase_field_zoo')` warned that `f_password` uses `password` on a non-auth object (plaintext-at-rest, masked-on-read — ADR-0100). The text said *"if this is intended … safe to ignore"* but gave authors **no way to express that intent**.

- Add a field-level **`ackPlaintextMasking: true`** opt-out (`packages/spec/src/data/field.zod.ts`). When set on a `password` field, `warnGenericPasswordFields` skips it; the warning text now points authors at the flag.
- Set it on field-zoo's deliberately-exhaustive demo field.
- Diagnostic-only: masking, the echoed-mask write guard, and the `better-auth` exemption are unchanged.

### 2. Better Auth well-known warning (printed twice) → silence the false positive
`@better-auth/oauth-provider` emitted *"Please ensure `/.well-known/oauth-authorization-server/api/v1/auth` exists. Upon completion, clear with `silenceWarnings.oauthAuthServerConfig`."* — but `registerOidcDiscoveryRoutes` **already mounts those documents** at the issuer root (RFC 8414 §3 requires them there, outside better-auth's own routing, so the plugin can't see them).

- Pass the documented **`silenceWarnings: { oauthAuthServerConfig: true }`** to `oauthProvider(...)`. Verified against `@better-auth/oauth-provider@1.7.0-rc.1`: the option is a member of `OAuthOptions` and gates the exact `logger.warn`.
- **Root cause of the double print** (investigated): the notice fires in oauth-provider's `init(ctx)`, run once per `betterAuth()` construction, and the auth instance is built more than once at boot — an initial lazy build, then a rebuild after boot-time auth *settings* are applied (`applyConfigPatch` nulls the cached instance so the next request rebuilds with the new policy). Gating the emitter covers **every** build path, so the count no longer matters.

### 3. Registry re-register output → debug level
`[Registry] Overwriting package: …` and `Re-registering owned object: …` are normal rebuild / HMR / seed-replay paths, but were emitted via `console.warn` (always on) and looked like errors.

- Add a debug-only `SchemaRegistry.debug()` (emits only at `logLevel === 'debug'`) and route both lines through it.
- Make it discoverable: a new `logLevel` construction option resolved from **`OS_REGISTRY_LOG`** (unknown value → `info`), so a developer chasing a registration issue can surface the lines with `OS_REGISTRY_LOG=debug`.

## Regression guards (keep the boot log at zero)
- **password** — examples assert every generic (non-better-auth) `password` field affirms `ackPlaintextMasking` (`examples/app-showcase/test/no-startup-warnings.test.ts`; `examples/app-crm/test/smoke.test.ts`, future-proofing an example with none today).
- **better-auth** — `auth-manager.mcp-oauth.test.ts` asserts `oauthProvider` is wired with `silenceWarnings.oauthAuthServerConfig: true`.
- **registry** — `registry-log-level.test.ts` asserts the re-register / package-overwrite lines are silent at the default `info` level and only emit via `console.debug` at `debug` (never `console.warn`), plus the `OS_REGISTRY_LOG` resolution.

## Other examples
Only showcase declared a generic password field; the better-auth and registry fixes are framework-level, so `app-crm` / `app-todo` inherit clean boots. `app-crm` now carries the same password guard; `app-todo` ships no password fields and uses the custom `objectstack test` runner (no vitest guard added there).

## Docs
- ADR-0100 §B5 records the `ackPlaintextMasking` opt-out and its rationale; the generated `content/docs/references/data/field.mdx` and the spec liveness ledger (`field/ackPlaintextMasking`) are updated; a changeset covers the three packages.

## Verification (local, real test runner)
- `packages/spec` — `object.test.ts` + `field.test.ts`: **200 passed** (incl. 3 new: ack suppresses, partial-ack still warns about the un-acked field, warning text names the flag).
- `packages/objectql` — registry suites: **122 passed** (incl. new `registry-log-level.test.ts`).
- `packages/plugins/plugin-auth` — auth-manager suites (incl. mcp-oauth, which builds the real `oauthProvider`): **215 passed**.
- `examples/app-showcase` (1) + `examples/app-crm` (20) guards: **pass** — confirms `ackPlaintextMasking` survives `ObjectSchema.create` end-to-end.
- Spec `check:liveness` + `check:docs`: green. ESLint on changed files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXHXXHnquzVUjeQYPs9bmy