### PR TITLE
feat(storage): surface sys_file id on upload-complete — ADR-0104 D3 wave 2 (PR-1)

### DIFF
--- a/.changeset/adr-0104-d3w2-pr1-upload-complete-fileid.md
+++ b/.changeset/adr-0104-d3w2-pr1-upload-complete-fileid.md
@@ -1,0 +1,18 @@
+---
+"@objectstack/spec": patch
+"@objectstack/service-storage": patch
+"@objectstack/client": patch
+---
+
+feat(storage): surface the sys_file id on upload-complete — ADR-0104 D3 wave 2 (PR-1)
+
+`POST /api/v1/storage/upload/complete` now returns the opaque `sys_file` id
+(`data.fileId`), and `client.storage.upload()` surfaces it on the returned
+`FileMetadata`. Previously the commit response omitted the id — the caller
+could not learn which id to persist after committing an upload, so a file
+field could never store a reference.
+
+Additive and non-breaking (new optional `fileId` on `FileMetadataSchema`; the
+client falls back to the presigned id when talking to an older server). This is
+the enabling foundation for file-as-reference; the storage model itself is
+unchanged in this PR.

--- a/content/docs/references/system/object-storage.mdx
+++ b/content/docs/references/system/object-storage.mdx
@@ -99,6 +99,7 @@ const result = AccessControlConfig.parse(data);
 | **lastModified** | `string` | ✅ | Last modified timestamp |
 | **created** | `string` | ✅ | Creation timestamp |
 | **etag** | `string` | optional | Entity tag |
+| **fileId** | `string` | optional | Opaque sys_file id (ADR-0104 D3 file-as-reference) |
 
 
 ---

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -2048,8 +2048,15 @@ export class ObjectStackClient {
             method: 'POST',
             body: JSON.stringify(completeReq)
         });
-        
-        return completeRes.json();
+
+        // Surface the opaque sys_file id so the caller can store it in a file
+        // field (ADR-0104 D3). The server now returns it; fall back to the
+        // presigned id for an older server that does not.
+        const completeJson = (await completeRes.json()) as FileUploadResponse;
+        if (completeJson?.data && completeJson.data.fileId == null) {
+            completeJson.data.fileId = presigned.fileId;
+        }
+        return completeJson;
     },
     
     getDownloadUrl: async (fileId: string): Promise<string> => {

--- a/packages/services/service-storage/src/storage-routes.test.ts
+++ b/packages/services/service-storage/src/storage-routes.test.ts
@@ -140,6 +140,9 @@ describe('Storage REST Routes', () => {
       expect(completeRes._status).toBe(200);
       expect(completeRes._json.data.name).toBe('test.txt');
       expect(completeRes._json.data.mimeType).toBe('text/plain');
+      // ADR-0104 D3 PR-1: the commit response surfaces the opaque sys_file id
+      // so a caller can persist it in a file field.
+      expect(completeRes._json.data.fileId).toBe(fileId);
     });
 
     it('should 404 for unknown fileId', async () => {

--- a/packages/services/service-storage/src/storage-routes.ts
+++ b/packages/services/service-storage/src/storage-routes.ts
@@ -230,6 +230,10 @@ export function registerStorageRoutes(
 
       res.json({
         data: {
+          // The opaque sys_file id — the value a file field stores as a
+          // reference (ADR-0104 D3). Previously omitted, so a caller could not
+          // learn the id to persist after committing an upload.
+          fileId: updated!.id ?? fileId,
           path: updated!.key,
           name: updated!.name,
           size: updated!.size ?? 0,

--- a/packages/spec/src/system/object-storage.zod.ts
+++ b/packages/spec/src/system/object-storage.zod.ts
@@ -53,6 +53,11 @@ export const FileMetadataSchema = lazySchema(() => z.object({
   lastModified: z.string().datetime().describe('Last modified timestamp'),
   created: z.string().datetime().describe('Creation timestamp'),
   etag: z.string().optional().describe('Entity tag'),
+  // The opaque `sys_file` id (ADR-0104 D3): the value a file/image/avatar/
+  // video/audio field will store as a reference. Surfaced on the upload-complete
+  // response so a caller can persist it; optional because generic file-metadata
+  // reads (getInfo/list) do not always carry it.
+  fileId: z.string().optional().describe('Opaque sys_file id (ADR-0104 D3 file-as-reference)'),
 }));
 
 export type FileMetadata = z.infer<typeof FileMetadataSchema>;


### PR DESCRIPTION
ADR-0104 D3 **wave 2**(file-as-reference,搭 v17)的 **PR-1**——安全的附加地基。跟踪:#3459。

## 问题

`POST /api/v1/storage/upload/complete` 的响应**不含 `fileId`**(`storage-routes.ts`),`client.storage.upload()` 明明手里有 `presigned.fileId` 却把它丢了、原样返回不含 id 的 complete 响应。结果:**上传提交后调用方拿不到该存进文件字段的那个 id**——文件字段永远无法存引用。这是 wave 2 一切下游的前置。

## 改动(附加、非破坏)

- `FileMetadataSchema`(`object-storage.zod.ts`)新增可选 `fileId`。
- `/upload/complete` 响应 `data` 带上 `fileId`(= 已提交的 `sys_file.id`)。
- `client.storage.upload()` 在返回的 `FileMetadata` 上透出 `fileId`;对**旧服务端**回退到 `presigned.fileId`,所以新客户端连旧服务端也拿得到 id。

存储模型本身**未改**——本 PR 只是补上"提交后能拿到 id"这一环。

## 测试

- service-storage **99** ✓(complete 响应含 `fileId` 已断言)
- spec storage schemas ✓ · client typecheck 干净
- 生成的 `object-storage` 参考文档已同步

## 序列位置

PR-1/7。下一步 PR-2:读路径 `fileId → FileValueSchema` 解析(批量、禁 N+1)+ 遗留内联 blob 双读归一。破坏性/不可逆步骤(PR-5 写切换+GC、PR-6 迁移)排最后,带 R4/R5/R6 门。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHpGw3GBA9aFpfwVArRWfd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHpGw3GBA9aFpfwVArRWfd)_