### PR TITLE
fix(cli): include readonly flow-write warnings in `os validate --json` (#3465 follow-up)

### DIFF
--- a/.changeset/readonly-flow-write-json-warning.md
+++ b/.changeset/readonly-flow-write-json-warning.md
@@ -1,0 +1,11 @@
+---
+"@objectstack/cli": patch
+---
+
+fix(cli): include readonly flow-write warnings in `os validate --json` output
+
+The `readonlyWhen` flow-write advisory (`validateReadonlyFlowWrites`, #3465) was
+printed in human mode but omitted from the `--json` summary's `warnings` array,
+where every other advisory category is aggregated. `os validate --json`
+consumers (CI, editors) therefore never saw those warnings. Added
+`...readonlyWriteWarnings` to the summary array so JSON and human output agree.

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -562,7 +562,7 @@ export default class Validate extends Command {
           valid: true,
           manifest: config.manifest,
           stats,
-          warnings: [...exprWarnings, ...widgetWarnings, ...actionRefWarnings, ...styleWarnings, ...jsxWarnings, ...capWarnings, ...flowReadinessWarnings, ...flowTemplateWarnings, ...securityAdvisories, ...capProviderWarnings],
+          warnings: [...exprWarnings, ...widgetWarnings, ...actionRefWarnings, ...styleWarnings, ...jsxWarnings, ...capWarnings, ...flowReadinessWarnings, ...flowTemplateWarnings, ...readonlyWriteWarnings, ...securityAdvisories, ...capProviderWarnings],
           conversions: conversionNotices,
           specVersionGap: specGap,
           duration: timer.elapsed(),


### PR DESCRIPTION
Small follow-up to #3465 (spotted while merging #3472).

## Problem

`validateReadonlyFlowWrites` (added in #3465) surfaces two things: **errors** for a static-`readonly` + literal write (a certain silent no-op — these gate and exit), and **warnings** for a `readonlyWhen` field (per-record-state → advisory). The warnings are printed in human mode:

```ts
if (!flags.json) {
  for (const f of readonlyWriteWarnings.slice(0, 50)) { … }
}
```

…but `readonlyWriteWarnings` was **omitted from the `--json` summary's `warnings` array**, where every *other* advisory category is aggregated:

```ts
warnings: [...exprWarnings, …, ...flowReadinessWarnings, ...flowTemplateWarnings, ...securityAdvisories, ...capProviderWarnings],
```

So `os validate --json` consumers (CI gates, editor integrations) silently never saw the readonly `readonlyWhen` warnings, while human output showed them — the two modes disagreed.

## Fix

Add `...readonlyWriteWarnings` to the JSON summary array, positioned by execution order (right after `...flowTemplateWarnings`, before the security advisories). One line; mirrors the nine existing warning spreads exactly.

## Testing
- `@objectstack/cli`: `tsc --noEmit` clean.
- No behavior change in human mode; JSON mode now includes the readonly advisory that was already computed and printed. (The CLI's JSON `warnings` aggregation has no dedicated test seam — none of the other nine categories is asserted there either; each underlying validator, including `validateReadonlyFlowWrites`, is unit-tested in `@objectstack/lint`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)