### PR TITLE
feat(spec)!: prune dead aria/performance from ReportSchema + dogfood the live report chart (report-liveness close-out)

### DIFF
--- a/.changeset/prune-report-aria-performance.md
+++ b/.changeset/prune-report-aria-performance.md
@@ -1,0 +1,26 @@
+---
+"@objectstack/spec": minor
+---
+
+feat(spec)!: prune the dead `aria` / `performance` props from ReportSchema (report-liveness close-out)
+
+Follow-up to the #3463 report cleanup. The 2026-06 ReportSchema liveness audit
+flagged `aria` and `performance` as dead — declared on `ReportSchema` (and
+editable in the Studio report form) but read by **no renderer**. This removes
+them. Every other finding from that audit is now closed too: `chart` turned out
+to be **live** (`DatasetReportRenderer` plots `chart.xAxis`/`yAxis` via
+`DatasetReportChart`), and the obsolete sub-schemas / naming-drift / joined-preview
+items were resolved by #3463 and earlier work.
+
+- Removed `ReportSchema.aria` (`AriaPropsSchema`) and `ReportSchema.performance`
+  (`PerformanceConfigSchema`), dropping the now-orphan imports. Both schemas
+  remain exported and are still used by other metadata types (views, pages,
+  charts) — only the report's use of them is removed. `ReportChart` keeps its
+  own `aria` (inherited from `ChartConfigSchema`).
+- No manifest key or public export changes (`aria`/`performance` were properties,
+  not schemas); `report.mdx` regenerated.
+
+**Migration**: nothing an author writes changes — no first-party or example
+report set `aria`/`performance`. Reports carry no ARIA/performance overrides;
+use the dataset/view surface for those concerns. Ships as `minor` per the
+launch-window breaking-as-minor policy.

--- a/content/docs/references/ui/report.mdx
+++ b/content/docs/references/ui/report.mdx
@@ -60,8 +60,6 @@ const result = JoinedReportBlock.parse(data);
 | **runtimeFilter** | `any` | optional | Render-time scope filter |
 | **drilldown** | `boolean` | ✅ | Click-through to underlying records |
 | **chart** | `{ type: Enum<'bar' \| 'horizontal-bar' \| 'column' \| 'line' \| 'area' \| 'pie' \| 'donut' \| 'funnel' \| 'scatter' \| 'treemap' \| 'sankey' \| 'gauge' \| 'solid-gauge' \| 'metric' \| 'kpi' \| 'bullet' \| 'radar' \| 'table' \| 'pivot'>; title?: string; subtitle?: string; description?: string; … }` | optional | Embedded chart configuration |
-| **aria** | `{ ariaLabel?: string; ariaDescribedBy?: string; role?: string }` | optional | ARIA accessibility attributes |
-| **performance** | `{ lazyLoad?: boolean; virtualScroll?: object; cacheStrategy?: Enum<'none' \| 'cache-first' \| 'network-first' \| 'stale-while-revalidate'>; prefetch?: boolean; … }` | optional | Performance optimization settings |
 | **blocks** | `{ name: string; label?: string; description?: string; type: Enum<'tabular' \| 'summary' \| 'matrix'>; … }[]` | optional | Sub-reports for type=joined |
 | **protection** | `{ lock: Enum<'none' \| 'no-overlay' \| 'no-delete' \| 'full'>; reason: string; docsUrl?: string }` | optional | Package author protection block — lock policy for this report. |
 | **_lock** | `Enum<'none' \| 'no-overlay' \| 'no-delete' \| 'full'>` | optional | Item-level lock — controls overlay & delete (ADR-0010). |

--- a/docs/audits/2026-06-reportschema-property-liveness.md
+++ b/docs/audits/2026-06-reportschema-property-liveness.md
@@ -2,6 +2,13 @@
 
 **Date**: 2026-06-15 · **Scope**: `packages/spec/src/ui/report.zod.ts` (ADR-0021 single-form). **Live path**: `objectui` `ReportRenderer`→`DatasetReportRenderer` (dataset-bound). Pre-9.0 object/columns-query renderers retired; old JSON limps through the lossy `specReportToPresentation` bridge.
 
+> **✅ Fully resolved — 2026-07-25** (#3463 + follow-up). Every finding below has since been actioned; the dated body is kept as the point-in-time snapshot.
+> - **`chart` — WIRED, not dead.** `DatasetReportRenderer` now plots `report.chart.xAxis`/`yAxis` over the bound dataset via `DatasetReportChart` (`DatasetReportRenderer.tsx:429-465,773-786`); #3441 corrected the `.describe()`, and the showcase gained a `chart`-bearing report (`showcase_hours_by_status_chart`) so the path is dogfooded.
+> - **`aria`, `performance` — PRUNED** from `ReportSchema` (2026-07 report-liveness close-out).
+> - **`ReportColumnSchema` / `ReportGroupingSchema` (+ objectui `SpecReportColumn*`/`SpecReportGrouping*` re-exports) — REMOVED** (#3463 → framework #3488 / objectui #2816).
+> - **`ReportChartSchema` naming drift — RESOLVED**: the legacy `ReportViewer` chart branch that read `xAxisField`/`yAxisFields` was retired (objectui #2816); the live renderer reads the spec's `xAxis`/`yAxis`; the unread `groupBy` was pruned (#3488).
+> - **Studio joined preview — FIXED**: `ReportPreview` branches on `dataset || blocks` (`isJoinedWithBlocks`).
+
 ## LIVE & well-wired (dataset shape — the canonical path)
 `name`, `label`, `description`, `type` (summary/tabular/matrix/joined), `dataset`, `rows`, `columns` (matrix-across only, matches spec), `values`, `runtimeFilter` (`?? filter`, ANDed via `mergeFilters`), `drilldown` (default-on; cells clickable), `blocks` (joined, per-block dataset/rows/columns/values/runtimeFilter). Evidence: `DatasetReportRenderer.tsx:486-575`, `:493-543`. Wired types: tabular/summary/matrix (true cross-tab + server totals + drill)/joined.
 

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -38,7 +38,9 @@ The most serious cluster — properties that imply a security boundary but enfor
 - **Role `parent`** / **SharingRuleSchema** — manager rollup & spec sharing rules disconnected from the live engine.
 
 ### 2. 🔴 ADR-0021 analytics migration debt
-Spec moved to `dataset`+`values`/`dimensions`, but: the **chart view variant** + **dashboard renderer + Studio WidgetConfigPanel** still read the *removed* legacy `object/valueField/categoryField/aggregate` shape; **report `chart`** is dead; `ReportColumn`/`ReportGrouping` are obsolete re-exports. (Same debt that invalidated the showcase dashboard/report seeds.)
+Spec moved to `dataset`+`values`/`dimensions`, but: the **chart view variant** + **dashboard renderer + Studio WidgetConfigPanel** still read the *removed* legacy `object/valueField/categoryField/aggregate` shape. (Same debt that invalidated the showcase dashboard/report seeds.)
+
+**✅ Report slice resolved (#3463 + 2026-07 close-out).** `report.chart` is **wired** (`DatasetReportRenderer` plots `chart.xAxis`/`yAxis` via `DatasetReportChart`, now dogfooded by the showcase `…_chart` report); `ReportColumn`/`ReportGrouping` (+ objectui `SpecReport*` re-exports) and the unread `chart.groupBy` + dead `aria`/`performance` are **removed**; the legacy `ReportViewer` chart fallback is **retired**. See [`2026-06-reportschema-property-liveness.md`](./2026-06-reportschema-property-liveness.md). The **chart-view / dashboard / WidgetConfigPanel** legacy-shape readers above remain open.
 
 ### 3. 🟠 Naming drift → silent no-ops (spec key ≠ consumed key)
 field `maxLength`/`minLength`/`referenceFilters`/`maxRating`; page `type`→`pageType` & `label`→`title` & `visibility`; dashboard `title` vs `label`; app `accentColor`/`badgeVariant`/`separator` (renderer reads, **not in spec**); action `disabled`→`enabled`; flow `http` vs `http_request`; skill `requiredPermissions` vs `permissions`; agent `knowledge.{topics→sources}`; webhook `object`→`object_name`, `isActive`→`active`.

--- a/examples/app-showcase/src/ui/apps/index.ts
+++ b/examples/app-showcase/src/ui/apps/index.ts
@@ -95,6 +95,7 @@ export const ShowcaseApp = App.create({
         { id: 'nav_charts', type: 'dashboard', dashboardName: 'showcase_chart_gallery', label: 'Chart Gallery', icon: 'layout-dashboard' },
         { id: 'nav_report_tabular', type: 'object', objectName: 'showcase_task', viewName: 'tabular', label: 'Task List', icon: 'table' },
         { id: 'nav_report_summary', type: 'report', reportName: 'showcase_hours_by_status', label: 'Hours by Status', icon: 'sigma' },
+        { id: 'nav_report_chart', type: 'report', reportName: 'showcase_hours_by_status_chart', label: 'Hours by Status (Chart)', icon: 'bar-chart-3' },
         { id: 'nav_report_matrix', type: 'report', reportName: 'showcase_status_priority_matrix', label: 'Status × Priority', icon: 'grid-3x3' },
         { id: 'nav_report_joined', type: 'report', reportName: 'showcase_task_overview', label: 'Task Overview', icon: 'layers' },
       ],

--- a/examples/app-showcase/src/ui/reports/index.ts
+++ b/examples/app-showcase/src/ui/reports/index.ts
@@ -68,8 +68,29 @@ export const TaskOverviewReport = defineReport({
   ],
 });
 
+/** 5 ── Summary with an embedded chart. Exercises the live `DatasetReportChart`
+ *  path: `chart.xAxis`/`yAxis` name the bound dataset's dimension/measure and
+ *  are plotted via a second `queryDataset` call (ADR-0021). */
+export const HoursByStatusChartReport = defineReport({
+  name: 'showcase_hours_by_status_chart',
+  label: 'Hours by Status (Chart)',
+  description: 'Estimated hours by status, plotted as a bar chart.',
+  type: 'summary',
+  drilldown: true,
+  dataset: 'showcase_task_metrics',
+  rows: ['status'],
+  values: ['est_hours'],
+  chart: {
+    // Chart type from ChartConfig; xAxis = dataset dimension, yAxis = measure.
+    type: 'bar',
+    xAxis: 'status',
+    yAxis: 'est_hours',
+  },
+});
+
 export const allReports = [
   HoursByStatusReport,
   StatusPriorityMatrixReport,
   TaskOverviewReport,
+  HoursByStatusChartReport,
 ];

--- a/examples/app-showcase/test/seed.test.ts
+++ b/examples/app-showcase/test/seed.test.ts
@@ -22,9 +22,9 @@ describe('showcase stack', () => {
     expect((stack.views ?? []).length).toBeGreaterThan(0);
     expect((stack.dashboards ?? []).length).toBeGreaterThan(0);
     // ADR-0021 single-form: the former flat `tabular` TaskListReport was
-    // reclassified as a ListView (a flat list is a row lens, not analytics),
-    // leaving 3 dataset-bound analytics reports.
-    expect((stack.reports ?? []).length).toBe(3);
+    // reclassified as a ListView (a flat list is a row lens, not analytics).
+    // Four dataset-bound analytics reports: summary, chart, matrix, joined.
+    expect((stack.reports ?? []).length).toBe(4);
     expect((stack.flows ?? []).length).toBeGreaterThan(0);
     // Nine flat positions (contributor/manager/exec/auditor/ops/
     // field_ops_delegate/client_portal_user, plus finance/legal for the v16

--- a/packages/spec/src/ui/report.zod.ts
+++ b/packages/spec/src/ui/report.zod.ts
@@ -6,8 +6,7 @@ import { MetadataProtectionFields } from '../kernel/metadata-protection.zod';
 import { FilterConditionSchema } from '../data/filter.zod';
 import { ChartConfigSchema } from './chart.zod';
 import { SnakeCaseIdentifierSchema } from '../shared/identifiers.zod';
-import { I18nLabelSchema, AriaPropsSchema } from './i18n.zod';
-import { PerformanceConfigSchema } from './responsive.zod';
+import { I18nLabelSchema } from './i18n.zod';
 
 /**
  * Report Type Enum
@@ -125,12 +124,6 @@ export const ReportSchema = lazySchema(() => z.object({
 
   /** Visualization */
   chart: ReportChartSchema.optional().describe('Embedded chart configuration'),
-
-  /** ARIA accessibility attributes */
-  aria: AriaPropsSchema.optional().describe('ARIA accessibility attributes'),
-
-  /** Performance optimization settings */
-  performance: PerformanceConfigSchema.optional().describe('Performance optimization settings'),
 
   /**
    * Joined report blocks — only meaningful when `type: 'joined'`.


### PR DESCRIPTION
Report-liveness close-out — follow-up to #3463. Closes out the 2026-06 ReportSchema liveness audit (`docs/audits/2026-06-reportschema-property-liveness.md`), whose remaining findings were re-verified against current code.

## What changed

**1. Prune dead `aria` / `performance` from `ReportSchema`** (spec, breaking→`minor`)
The audit flagged both as dead — declared on `ReportSchema` (editable in the Studio report form) but read by **no renderer**. Confirmed still dead in objectui (zero readers on the render path). Removed them + the now-orphan `AriaPropsSchema` / `PerformanceConfigSchema` imports. Both schemas stay exported (still used by views/pages/charts); `ReportChart` keeps its own `aria` from `ChartConfigSchema`. No manifest-key or public-export change; `report.mdx` regenerated.

**2. Refresh the stale audit doc + index**
Every finding in the 2026-06 audit is now resolved, and one was **wrong**: `report.chart` is *live*, not dead — `DatasetReportRenderer` plots `chart.xAxis`/`yAxis` via `DatasetReportChart` (`DatasetReportRenderer.tsx:429-465,773-786`). Added a resolution banner (chart=WIRED, aria/performance=pruned, re-exports=removed via #3463, joined-preview=fixed) and annotated the audits README section 2 (leaving the still-open chart-view/dashboard debt untouched).

**3. Dogfood the live report chart**
`report.chart` had **no showcase coverage** — none of the three showcase reports declared a `chart`. Added `showcase_hours_by_status_chart` (a `summary` report with a `chart` block: `est_hours` by `status`, bar) + an Analytics nav item, so the `DatasetReportChart` path is exercised by the showcase smoke.

## Verification

- `@objectstack/spec` build + 6850 tests pass; `check:api-surface` (unchanged — properties, not exports) ✓; `check:docs` (report.mdx in sync) ✓.
- `examples/app-showcase` typecheck clean; backend boots with the new report (valid `chart` shape parses).
- **Browser-verified** against the showcase backend: the new **Hours by Status (Chart)** report renders a bar chart (In Progress 100, In Review 54, …) via `DatasetReportChart`, with the summary table below; `POST /api/v1/analytics/dataset/query` all 200.

Refs #3463, #1878, #1890.

🤖 Generated with [Claude Code](https://claude.com/claude-code)