### PR TITLE
feat(approvals): enrich inbox rows with payload_labels (snapshot field labels)

### DIFF
--- a/.changeset/approvals-payload-labels.md
+++ b/.changeset/approvals-payload-labels.md
@@ -1,0 +1,15 @@
+---
+"@objectstack/plugin-approvals": patch
+"@objectstack/spec": patch
+---
+
+feat(approvals): enrich inbox rows with `payload_labels` (snapshot field labels)
+
+The approvals inbox summary title-cased raw snapshot machine keys
+(`assessment_status` → "Assessment Status") because the API sent no field
+labels. `ApprovalService.enrichRows` now attaches `payload_labels` (snapshot
+field key → the target object's field label), symmetric with the existing
+`payload_display` (which resolves the values), and `ApprovalRequestRow` gains
+the field. For a single-locale project the schema label is already the
+localized string, so a client can render the human field name (e.g. "考核状态")
+instead of a prettified English key.

--- a/packages/plugins/plugin-approvals/src/approval-service.test.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.test.ts
@@ -598,6 +598,27 @@ describe('ApprovalService (node era)', () => {
     expect(rows[0].payload_display).toEqual({ account: 'Acme Corp' });
   });
 
+  it('enrichment maps snapshot field keys to the object field labels', async () => {
+    (engine as any).getSchema = (name: string) =>
+      name === 'opportunity'
+        ? {
+            label: 'Opportunity',
+            fields: {
+              id: {}, // no label → excluded from payload_labels
+              name: { label: 'Deal Name' },
+              amount: { label: 'Deal Amount' },
+            },
+          }
+        : undefined;
+    await svc.openNodeRequest(
+      openInput(['u9'], { record: { id: 'opp1', name: 'Acme Renewal', amount: 100 } }), CTX,
+    );
+    const rows = await svc.listRequests({ status: 'pending' }, SYS);
+    // Only keys present in the snapshot AND carrying a schema label are mapped;
+    // `id` (unlabeled) is dropped.
+    expect(rows[0].payload_labels).toEqual({ name: 'Deal Name', amount: 'Deal Amount' });
+  });
+
   it('enrichment maps user-id approvers to display names', async () => {
     engine._tables['sys_user'] = [{ id: 'u9', name: 'Grace Hopper', email: 'grace@example.com' }];
     await svc.openNodeRequest(openInput(['u9']), CTX);

--- a/packages/plugins/plugin-approvals/src/approval-service.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.ts
@@ -1969,10 +1969,30 @@ export class ApprovalService implements IApprovalService {
   }
 
   /**
+   * Field key → display label for an object's schema. Lets the inbox summary
+   * show a human field name ("考核状态") instead of a title-cased machine key
+   * ("Assessment Status"). For a single-locale project the schema label already
+   * IS the localized string; symmetric with `resolveDisplayField`/lookup
+   * resolution that power `payload_display`.
+   */
+  private resolveFieldLabels(object: string): Record<string, string> {
+    try {
+      const schema: any = (this.engine as any).getSchema?.(object);
+      const fields = schema?.fields ?? {};
+      const out: Record<string, string> = {};
+      for (const [key, f] of Object.entries<any>(fields)) {
+        if (f?.label) out[key] = String(f.label);
+      }
+      return out;
+    } catch { return {}; }
+  }
+
+  /**
    * Attach inbox display fields to rows so clients never render a raw
    * identifier: `record_title`, `submitter_name`, `object_label`,
-   * `pending_approver_names` (user-id approvers), and `payload_display`
-   * (lookup foreign keys in the snapshot → referenced record titles).
+   * `pending_approver_names` (user-id approvers), `payload_display`
+   * (lookup foreign keys in the snapshot → referenced record titles), and
+   * `payload_labels` (snapshot field keys → the target object's field labels).
    * Batched: one query per distinct object (target + referenced) plus one
    * `sys_user` lookup. Best-effort — a deleted record falls back to the
    * payload snapshot, and any failure leaves the field unset rather than
@@ -2011,9 +2031,13 @@ export class ApprovalService implements IApprovalService {
 
     // Lookup foreign keys inside payload snapshots → referenced record titles.
     const lookupFieldsByObject = new Map<string, Array<{ key: string; reference: string }>>();
+    // Field key → label per object, for the snapshot summary's field names.
+    const fieldLabelsByObject = new Map<string, Record<string, string>>();
     for (const object of byObject.keys()) {
       const lookups = this.resolveLookupFields(object);
       if (lookups.length) lookupFieldsByObject.set(object, lookups);
+      const labels = this.resolveFieldLabels(object);
+      if (Object.keys(labels).length) fieldLabelsByObject.set(object, labels);
     }
     const refIds = new Map<string, Set<string>>();
     for (const r of rows) {
@@ -2080,6 +2104,18 @@ export class ApprovalService implements IApprovalService {
           if (t) display[key] = t;
         }
         if (Object.keys(display).length) r.payload_display = display;
+      }
+
+      // Field labels for the snapshot keys the summary renders (only keys
+      // actually present in the payload — a deleted field's label is noise).
+      const fieldLabels = fieldLabelsByObject.get(r.object_name);
+      if (fieldLabels && r.payload && typeof r.payload === 'object') {
+        const labels: Record<string, string> = {};
+        for (const key of Object.keys(r.payload as Record<string, unknown>)) {
+          const l = fieldLabels[key];
+          if (l) labels[key] = l;
+        }
+        if (Object.keys(labels).length) r.payload_labels = labels;
       }
     }
   }

--- a/packages/spec/src/contracts/approval-service.ts
+++ b/packages/spec/src/contracts/approval-service.ts
@@ -91,6 +91,15 @@ export interface ApprovalRequestRow {
    */
   payload_display?: Record<string, string>;
   /**
+   * Display labels for `payload` fields (field key → target object's field
+   * label), so inbox summaries show the human field name (e.g. "考核状态")
+   * instead of a title-cased machine key ("Assessment Status"). Resolved from
+   * the target object's schema — for a single-locale project the schema label
+   * IS the localized string; symmetric with `payload_display` (which resolves
+   * the values). Absent keys fall back to the client's prettified key.
+   */
+  payload_labels?: Record<string, string>;
+  /**
    * SLA deadline, when the node config carries `escalation.timeoutHours`:
    * `created_at + timeoutHours`. Display-only for now — automatic escalation
    * needs a scheduler pass and is not yet wired.


### PR DESCRIPTION
Closes #3500

## 背景
审批收件箱摘要只拿得到快照的机器名字段 key,只能 `prettifyKey` 生造英文标签(`assessment_status` → "Assessment Status"),读不到目标对象真正的字段 label。中文项目里本该显示"考核状态"。后端富化已下发 `object_label` / `payload_display`,唯独没有字段 label。

## 改动
- `ApprovalRequestRow` contract 新增 `payload_labels?: Record<string,string>`。
- `ApprovalService.enrichRows` 按对象解析字段 label,只附带快照里实际存在的 key;与既有 `payload_display` 对称。单语言项目里 `schema.label` 本身即本地化串。
- 新增 service 测试。

> 声明式操作 i18n(`plugin-approvals` 的 `_actions` 翻译包)**不在本 PR**——framework main 已完整提供,勿重复。

## 验证
- `pnpm --filter @objectstack/plugin-approvals test` → 165 passed(含新增 payload_labels 用例)。
- 真机:`app-showcase`(seed-approval-demo)起后端,审批 API `/api/v1/approvals/requests/{id}` 返回 `payload_labels`,含 `name→"Invoice Number"`、`total→"Subtotal"`(≠ prettifyKey 的 "Name"/"Total"),经 objectui console dev 渲染在摘要卡片。

客户端消费 PR:objectstack-ai/objectui#2818。

🤖 Generated with [Claude Code](https://claude.com/claude-code)