### PR TITLE
fix(runtime): notifications 域尾斜杠正则 polynomial-redos 修复（#3507 暴露的 CodeQL high）

### DIFF
--- a/.changeset/notifications-redos-fix.md
+++ b/.changeset/notifications-redos-fix.md
@@ -1,0 +1,12 @@
+---
+"@objectstack/runtime": patch
+---
+
+fix(runtime): replace the polynomial-redos trailing-slash regex in the notifications domain with split+filter (CodeQL high, surfaced by #3507)
+
+The legacy `path.replace(/\/+$/, '')` in the notifications handler had
+carried a polynomial-backtracking regex over request-controlled input since
+ADR-0030; the domain extraction (#3507) made the line "changed code" and
+CodeQL flagged it. Same split+filter treatment the security domain already
+uses for the identical pattern. Redundant slashes in the sub-path now
+collapse (`//read//` → `read`), matching the security domain's semantics.

--- a/packages/runtime/src/domain-handler-registry.test.ts
+++ b/packages/runtime/src/domain-handler-registry.test.ts
@@ -187,6 +187,14 @@ describe('HttpDispatcher extracted domains (PR-2)', () => {
         expect(notification.listInbox).toHaveBeenCalledWith('u1', expect.objectContaining({ limit: 5 }));
     });
 
+    it('/notifications tolerates redundant slashes in the sub-path (split+filter, CodeQL redos fix)', async () => {
+        const notification = { listInbox: vi.fn(), markRead: vi.fn().mockResolvedValue({ updated: 1 }), markAllRead: vi.fn() };
+        const context: any = { executionContext: { userId: 'u1' } };
+        const result = await makeDispatcher({ notification }).handleNotification('//read//', 'POST', { ids: ['n1'] }, {}, context);
+        expect(result.response?.status).toBe(200);
+        expect(notification.markRead).toHaveBeenCalledWith('u1', ['n1']);
+    });
+
     it('/security responds 503 when no security service is wired (legacy in-handler semantics)', async () => {
         const result = await makeDispatcher().dispatch('GET', '/security/suggested-bindings', undefined, {}, {} as any);
         expect(result.handled).toBe(true);

--- a/packages/runtime/src/domains/notifications.ts
+++ b/packages/runtime/src/domains/notifications.ts
@@ -49,7 +49,12 @@ export async function handleNotificationRequest(
     }
 
     const m = method.toUpperCase();
-    const subPath = path.replace(/^\/+/, '').replace(/\/+$/, '');
+    // split+filter drops leading/trailing/duplicate slashes without a regex
+    // over request-controlled input (CodeQL js/polynomial-redos) — same
+    // treatment the security domain got for the identical latent pattern.
+    // Surfaced when the extraction (#3507) made this line "changed code":
+    // the legacy `.replace(/\/+$/, '')` had carried the trap since ADR-0030.
+    const subPath = path.split('/').filter(Boolean).join('/');
 
     // GET /notifications — list the user's inbox joined with read-state.
     if (subPath === '' && m === 'GET') {


### PR DESCRIPTION
## 背景

#3507 把 handleNotification 体逐字搬进 `domains/notifications.ts`，搬迁让这行成为"changed code"，CodeQL 首次扫到 `path.replace(/\/+$/, '')` 的 `js/polynomial-redos`（high）——该模式自 ADR-0030 就潜伏在原方法里，security 域的同款早已被拦并改为 split+filter（注释里就引用了这条规则），notifications 一直漏网。

## 修复

照 security 域先例：`path.split('/').filter(Boolean).join('/')`——不再对请求可控输入跑带量词回溯的正则。语义微差：子路径中的冗余斜杠折叠（`//read//` → `read`），与 security 域一致、方向更宽容，新增测试锁定。

## 验证

接缝套件 19 测试、runtime 全量 624 绿、DTS build 绿。

关联 #2462 / #3507。

🤖 Generated with [Claude Code](https://claude.com/claude-code)