### PR TITLE
feat(spec)!: 媒体字段 accept/maxSize 声明并强制 + 存储形态收窄为引用 — ADR-0104 D3 wave 2 (PR-5a)

### DIFF
--- a/.changeset/adr-0104-d3w2-pr5a-write-cutover.md
+++ b/.changeset/adr-0104-d3w2-pr5a-write-cutover.md
@@ -1,0 +1,42 @@
+---
+"@objectstack/spec": minor
+"@objectstack/service-storage": minor
+---
+
+feat(spec)!: media fields declare accept/maxSize, and the stored form is a file reference — ADR-0104 D3 wave 2 (PR-5a)
+
+**`accept` and `maxSize` are now declared on `FieldSchema`, and enforced on the
+server.** Both were already read by the upload widgets — `field.accept`,
+`field.maxSize` — while the spec did not declare them, so an author who wrote
+them had the keys silently stripped at parse and the constraint simply never
+existed. That is exactly the ADR-0104 failure class (a declaration accepted in
+source, dropped from the contract, with no feedback).
+
+Now that the platform owns the file, `sys_file` carries the authoritative MIME
+type and byte size, so a record write is re-checked against the declaration
+where it actually binds rather than only in the browser — a client-side check is
+a convenience, not a control, since any caller talking to the API directly
+bypasses it. Violations raise `FileConstraintError` and fail the write. An entry
+is only judged against metadata the file actually reports: a file with no
+recorded MIME type cannot fail an `accept` test, and one with no recorded size
+cannot fail `maxSize` — "we don't know" must not become "not permitted".
+
+**The stored form of a media field narrows to an opaque `sys_file` id.**
+`valueSchemaFor(field, 'stored')` now yields an id for `file`/`image`/`avatar`/
+`video`/`audio`; the inline `{url, name, size, …}` blob becomes the `'expanded'`
+read form, which also still admits an unresolved id (storage service absent,
+file not committed) exactly as an unexpanded lookup id stays valid.
+
+Two legacy forms therefore stop conforming, both deliberately:
+
+- the **inline blob**, which is no longer stored but derived;
+- an **external URL**, which was never a managed file — ADR-0104 R7 retires it
+  toward an explicit `url` field, and under AI authoring that is the point: it
+  stops "managed file" and "external link" being the same declaration.
+
+**Not a breaking change today.** Value-shape checking is warn-first
+(ADR-0104 R1/R2): a not-yet-backfilled row still writes and the author gets a
+warning naming the field. Hard rejection arrives only when a deployment opts
+into `OS_DATA_VALUE_SHAPE_STRICT_ENABLED` — which it should do after running the
+backfill and confirming reconciliation. The `!` marks the contract change for
+the v17 window, not a runtime break on upgrade.

--- a/content/docs/references/data/field-value.mdx
+++ b/content/docs/references/data/field-value.mdx
@@ -58,8 +58,8 @@ this contract has (ADR-0104 performance budget).
 ## TypeScript Usage
 
 ```typescript
-import { AddressValue, CalendarDateValue, ClockTimeValue, FileLikeValue, FileValue, InstantValue, LocationValue, ReferenceIdValue } from '@objectstack/spec/data';
-import type { AddressValue, CalendarDateValue, ClockTimeValue, FileLikeValue, FileValue, InstantValue, LocationValue, ReferenceIdValue } from '@objectstack/spec/data';
+import { AddressValue, CalendarDateValue, ClockTimeValue, FileLikeValue, FileReferenceIdValue, FileValue, InstantValue, LocationValue, ReferenceIdValue } from '@objectstack/spec/data';
+import type { AddressValue, CalendarDateValue, ClockTimeValue, FileLikeValue, FileReferenceIdValue, FileValue, InstantValue, LocationValue, ReferenceIdValue } from '@objectstack/spec/data';
 
 // Validate data
 const result = AddressValue.parse(data);
@@ -114,6 +114,9 @@ Type: `string`
 | **mimeType** | `string` | optional |  |
 | **alt** | `string` | optional |  |
 | **duration** | `number` | optional |  |
+
+---
+
 
 ---
 

--- a/content/docs/references/data/field.mdx
+++ b/content/docs/references/data/field.mdx
@@ -113,6 +113,8 @@ const result = Address.parse(data);
 | **scale** | `number` | optional | Decimal places |
 | **min** | `number` | optional | Minimum value |
 | **max** | `number` | optional | Maximum value |
+| **accept** | `string[]` | optional | Permitted upload types for media fields, as MIME types or extensions (e.g. ["image/*", ".pdf"]). Offered to the file picker AND enforced on write. |
+| **maxSize** | `integer` | optional | Maximum permitted file size in BYTES for media fields. Enforced on write against the stored file size, not just checked in the browser. |
 | **options** | `{ label: string; value: string; color?: string; default?: boolean; … }[]` | optional | Static options for select/multiselect |
 | **reference** | `string` | optional | Target object name (snake_case) for lookup/master_detail fields. Required for relationship types. Used by $expand to resolve foreign key IDs into full objects. |
 | **deleteBehavior** | `Enum<'set_null' \| 'cascade' \| 'restrict'>` | optional | What happens if referenced record is deleted |

--- a/packages/objectql/src/validation/record-validator.test.ts
+++ b/packages/objectql/src/validation/record-validator.test.ts
@@ -372,11 +372,23 @@ describe('validateRecord — ADR-0104 value shapes (warn-first / strict)', () =>
     const data = {
       account: 'acc_0001',
       geo: { lat: 37.77, lng: -122.42 },
-      doc: { url: 'https://cdn/f.pdf', name: 'f.pdf', size: 1024 },
+      // The STORED form of a media field is an opaque sys_file id (ADR-0104 D3
+      // wave 2); the inline blob is now the expanded READ form.
+      doc: 'file_01HXYZ',
       dims: [0.1, 0.2],
     };
     expect(() => validateRecord(schema, { ...data }, 'update')).not.toThrow();
     withStrict(() => expect(() => validateRecord(schema, { ...data }, 'update')).not.toThrow());
+  });
+
+  it('warn-first keeps a legacy inline blob writable until strict is opted into', () => {
+    // The migration path that makes narrowing the stored form safe to ship: a
+    // not-yet-backfilled row still saves and the author gets a value-shape
+    // warning naming the field, rather than the write failing on data that was
+    // valid when it was written.
+    const legacy = { doc: { url: 'https://cdn/f.pdf', name: 'f.pdf', size: 1024 } };
+    expect(() => validateRecord(schema, { ...legacy }, 'update')).not.toThrow();
+    withStrict(() => expect(() => validateRecord(schema, { ...legacy }, 'update')).toThrow());
   });
 
   it('warn-first: malformed shapes pass by default (legacy rows must not strand records)', () => {

--- a/packages/qa/dogfood/test/field-zoo.matrix.ts
+++ b/packages/qa/dogfood/test/field-zoo.matrix.ts
@@ -73,15 +73,20 @@ export const MATRIX: FieldCase[] = [
   { field: 'f_vector', type: 'vector', check: { kind: 'equal', write: [0.1, 0.2, 0.3] } },
   // object-valued types that must store/parse as JSON, not stringify to TEXT
   { field: 'f_record', type: 'record', check: { kind: 'equal', write: { home: '+1', work: '+2' } } },
-  { field: 'f_video', type: 'video', check: { kind: 'equal', write: { url: 'https://cdn/v.mp4', duration: 12 } } },
-  { field: 'f_audio', type: 'audio', check: { kind: 'equal', write: { url: 'https://cdn/a.mp3', duration: 30 } } },
+  // media — the STORED form is an opaque sys_file id (ADR-0104 D3 wave 2); the
+  // inline `{url, …}` blob is the expanded READ form, derived by the resolver
+  // rather than written. These ids match no sys_file row here, which is the
+  // point: the round-trip must return the stored id verbatim when there is
+  // nothing to expand it into.
+  { field: 'f_video', type: 'video', check: { kind: 'equal', write: 'file_zoo_video' } },
+  { field: 'f_audio', type: 'audio', check: { kind: 'equal', write: 'file_zoo_audio' } },
   { field: 'f_composite', type: 'composite', check: { kind: 'equal', write: { label: 'x', n: 1 } } },
   { field: 'f_repeater', type: 'repeater', check: { kind: 'equal', write: [{ a: 1 }, { a: 2 }] } },
   { field: 'f_location', type: 'location', check: { kind: 'equal', write: { lat: 37.77, lng: -122.42 } } },
   { field: 'f_address', type: 'address', check: { kind: 'equal', write: { street: '1 Main', city: 'SF', country: 'US' } } },
-  { field: 'f_image', type: 'image', check: { kind: 'equal', write: { url: 'https://cdn/i.png', alt: 'i' } } },
-  { field: 'f_file', type: 'file', check: { kind: 'equal', write: { url: 'https://cdn/f.pdf', name: 'f.pdf', size: 1024 } } },
-  { field: 'f_avatar', type: 'avatar', check: { kind: 'equal', write: { url: 'https://cdn/a.png' } } },
+  { field: 'f_image', type: 'image', check: { kind: 'equal', write: 'file_zoo_image' } },
+  { field: 'f_file', type: 'file', check: { kind: 'equal', write: 'file_zoo_doc' } },
+  { field: 'f_avatar', type: 'avatar', check: { kind: 'equal', write: 'file_zoo_avatar' } },
   // relational — store a reference id as a string and read it back verbatim.
   // FK enforcement is off in this harness, so this asserts value fidelity
   // (id string → id string), not referential integrity / $expand (covered

--- a/packages/services/service-storage/src/file-reference-lifecycle.test.ts
+++ b/packages/services/service-storage/src/file-reference-lifecycle.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   installFileReferenceHooks,
   FileReferenceCopyError,
+  FileConstraintError,
   type FileReferenceEngine,
 } from './file-reference-lifecycle.js';
 
@@ -491,6 +492,109 @@ describe('File Reference Ownership (ADR-0104 D3 wave 2)', () => {
       // and hand its read authorisation to a different parent record.
       expect(engine.tables.sys_file[0]).toMatchObject({ ref_id: 'p1', ref_field: 'image' });
       expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+
+  // ── Declared media constraints (ADR-0104 D3 wave 2) ──────────────
+  describe('accept / maxSize enforcement', () => {
+    const constrained = (over: Record<string, any> = {}) => ({
+      sys_file: REGISTRY.sys_file,
+      product: {
+        name: 'product',
+        fields: {
+          id: { type: 'text' },
+          image: { type: 'image', accept: ['image/*'], maxSize: 1000, ...over },
+          gallery: { type: 'image', multiple: true },
+        },
+      },
+    });
+
+    it('rejects a file larger than the declared maxSize', async () => {
+      const engine = fakeEngine({
+        files: [file({ size: 5000 })],
+        registry: constrained(),
+      });
+      install(engine);
+
+      await expect(driveInsert(engine, 'product', { image: 'file_a' }, 'p1')).rejects.toThrow(
+        FileConstraintError,
+      );
+      // The write failed, so nothing was claimed.
+      expect(engine.tables.sys_file[0].ref_id).toBeUndefined();
+    });
+
+    it('rejects a file whose MIME type is outside the declared accept list', async () => {
+      const engine = fakeEngine({
+        files: [file({ mime_type: 'application/pdf', name: 'a.pdf', size: 10 })],
+        registry: constrained(),
+      });
+      install(engine);
+
+      await expect(driveInsert(engine, 'product', { image: 'file_a' }, 'p1')).rejects.toThrow(
+        /not permitted by the accept list/,
+      );
+    });
+
+    it('accepts a file that satisfies both declarations', async () => {
+      const engine = fakeEngine({ files: [file({ size: 10 })], registry: constrained() });
+      install(engine);
+
+      await driveInsert(engine, 'product', { image: 'file_a' }, 'p1');
+
+      expect(engine.tables.sys_file[0].ref_id).toBe('p1');
+    });
+
+    it.each([
+      [['image/png'], 'image/png', 'a.png', true],
+      [['image/*'], 'image/jpeg', 'a.jpg', true],
+      [['.pdf'], 'application/pdf', 'report.pdf', true],
+      [['.pdf'], 'application/pdf', 'report.txt', false],
+      [['image/png'], 'image/jpeg', 'a.jpg', false],
+      [['*/*'], 'anything/at-all', 'x', true],
+    ])('accept %j vs %s/%s → %s', async (accept, mime, name, allowed) => {
+      const engine = fakeEngine({
+        files: [file({ mime_type: mime, name, size: 10 })],
+        registry: constrained({ accept, maxSize: undefined }),
+      });
+      install(engine);
+
+      const write = driveInsert(engine, 'product', { image: 'file_a' }, 'p1');
+      if (allowed) {
+        await write;
+        expect(engine.tables.sys_file[0].ref_id).toBe('p1');
+      } else {
+        await expect(write).rejects.toThrow(FileConstraintError);
+      }
+    });
+
+    /**
+     * Missing metadata is not evidence of a violation — a sys_file row with no
+     * recorded size or MIME type must not be rejected by a constraint it
+     * cannot be tested against.
+     */
+    it('does not reject a file whose size or MIME type is unrecorded', async () => {
+      const engine = fakeEngine({
+        files: [{ id: 'file_a', key: 'user/file_a', name: 'file_a', status: 'committed' }],
+        registry: constrained(),
+      });
+      install(engine);
+
+      await driveInsert(engine, 'product', { image: 'file_a' }, 'p1');
+
+      expect(engine.tables.sys_file[0].ref_id).toBe('p1');
+    });
+
+    it('leaves a field with no declared constraints alone', async () => {
+      const engine = fakeEngine({
+        files: [file({ mime_type: 'application/pdf', size: 10_000_000 })],
+        registry: constrained(),
+      });
+      install(engine);
+
+      // `gallery` declares neither accept nor maxSize.
+      await driveInsert(engine, 'product', { gallery: ['file_a'] }, 'p1');
+
+      expect(engine.tables.sys_file[0].ref_field).toBe('gallery');
     });
   });
 

--- a/packages/services/service-storage/src/file-reference-lifecycle.ts
+++ b/packages/services/service-storage/src/file-reference-lifecycle.ts
@@ -103,6 +103,18 @@ export class FileReferenceCopyError extends Error {
   }
 }
 
+/**
+ * Raised when a referenced file violates its field's declared `accept` /
+ * `maxSize`. Fails the write: a stored value that breaks its own field's
+ * declaration is the "declared but not enforced" state ADR-0104 removes.
+ */
+export class FileConstraintError extends Error {
+  readonly code = 'ERR_FILE_CONSTRAINT';
+  constructor(message: string) {
+    super(message);
+  }
+}
+
 function asIdList(id: unknown): Array<string | number> | null {
   if (typeof id === 'string' || typeof id === 'number') return [id];
   if (id && typeof id === 'object' && Array.isArray((id as any).$in)) {
@@ -118,6 +130,83 @@ function fileFieldsOf(engine: FileReferenceEngine, objectName: string): string[]
   return Object.entries(schema.fields)
     .filter(([, def]: [string, any]) => def && FILE_REFERENCE_TYPES.has(def.type))
     .map(([name]) => name);
+}
+
+/** One field's definition, or undefined. */
+function fieldDefOf(engine: FileReferenceEngine, objectName: string, field: string): any {
+  return (engine.getObject(objectName) as any)?.fields?.[field];
+}
+
+/**
+ * Does `mime` satisfy one `accept` entry? Accepts the same vocabulary the file
+ * picker does: an exact MIME type, a `type/*` wildcard, or a `.ext` suffix
+ * (matched against the file NAME, since a browser-supplied extension is what
+ * the author is describing).
+ */
+function matchesAcceptEntry(entry: string, mime: string, name: string): boolean {
+  const e = entry.trim().toLowerCase();
+  if (!e) return false;
+  if (e === '*' || e === '*/*') return true;
+  if (e.startsWith('.')) return name.toLowerCase().endsWith(e);
+  if (e.endsWith('/*')) return mime.startsWith(e.slice(0, -1));
+  return mime === e;
+}
+
+/**
+ * Enforce a media field's declared `accept` / `maxSize` against the file the
+ * record is about to reference.
+ *
+ * The upload widget checks both before uploading, but that check is a
+ * convenience rather than a control — any caller talking to the API directly
+ * bypasses it. Now that the platform owns the file, `sys_file` carries the
+ * authoritative MIME type and byte size, so the constraint can be re-checked
+ * where it actually binds. Throws {@link FileConstraintError}, failing the
+ * write, because a stored value violating its own field's declaration is
+ * exactly the "declared but not enforced" state ADR-0104 exists to remove.
+ *
+ * Only checks what the file actually reports: a `sys_file` row with no
+ * `mime_type` cannot fail an `accept` test, and one with no `size` cannot fail
+ * `maxSize`. Missing metadata is not evidence of a violation.
+ */
+function assertFileConstraints(
+  fieldDef: any,
+  field: string,
+  file: Record<string, unknown>,
+): void {
+  const accept: unknown = fieldDef?.accept;
+  const maxSize: unknown = fieldDef?.maxSize;
+
+  if (typeof maxSize === 'number' && maxSize > 0 && typeof file.size === 'number') {
+    if (file.size > maxSize) {
+      throw new FileConstraintError(
+        `File exceeds the maximum size declared for '${field}' ` +
+          `(${file.size} bytes > ${maxSize} bytes)`,
+      );
+    }
+  }
+
+  if (Array.isArray(accept) && accept.length > 0) {
+    const mime = typeof file.mime_type === 'string' ? file.mime_type.toLowerCase() : '';
+    const name = typeof file.name === 'string' ? file.name : '';
+    const hasExtension = name.includes('.');
+
+    // An entry can only be judged against metadata the file actually reports:
+    // a MIME entry needs a recorded MIME type, an extension entry needs a name
+    // carrying an extension. Entries that cannot be evaluated are not failures
+    // — rejecting on them would turn "we don't know" into "not permitted".
+    const testable = accept.filter((e): e is string => {
+      if (typeof e !== 'string' || !e.trim()) return false;
+      return e.trim().startsWith('.') ? hasExtension : !!mime;
+    });
+    if (testable.length === 0) return;
+
+    if (!testable.some((e) => matchesAcceptEntry(e, mime, name))) {
+      throw new FileConstraintError(
+        `File type '${mime || name}' is not permitted by the accept list declared for ` +
+          `'${field}' (${accept.join(', ')})`,
+      );
+    }
+  }
 }
 
 /** The id tokens a field value carries (a `multiple: true` field holds an
@@ -207,9 +296,15 @@ async function copyOwnedFile(
 
 /**
  * Rewrite, in place, any id in `data` that is already owned by a different
- * slot so it points at a fresh copy instead. Runs in the BEFORE hooks, where
- * mutating `input.data` is what the driver goes on to persist — so the record
- * never transiently holds a reference it does not own.
+ * slot so it points at a fresh copy instead, and enforce each referenced
+ * file's declared `accept` / `maxSize` on the way past. Runs in the BEFORE
+ * hooks, where mutating `input.data` is what the driver goes on to persist —
+ * so the record never transiently holds a reference it does not own, and never
+ * persists one that violates its field's declaration.
+ *
+ * The constraint check rides here because this pass already loads every
+ * referenced `sys_file` row; enforcing it anywhere else would mean a second
+ * read of the same rows.
  *
  * `recordId` is null on insert: a new record can never be the current owner,
  * so every already-owned id is copied.
@@ -238,6 +333,11 @@ async function applyCopyOnClaim(
       // Unknown id: not a file this platform manages (external/legacy value).
       // Left verbatim — the read resolver ignores it for the same reason.
       if (!row) continue;
+
+      // The file is real and about to be referenced by this field, so its
+      // declared constraints bind now — before ownership, before any copy.
+      assertFileConstraints(fieldDefOf(engine, object, field), field, row);
+
       // Unclaimed: the after-hook will claim it for this slot. Nothing to copy.
       if (row.ref_id == null) continue;
       // Already ours (an update rewriting the same value) — no-op.

--- a/packages/services/service-storage/src/index.ts
+++ b/packages/services/service-storage/src/index.ts
@@ -14,7 +14,11 @@ export type { StorageRoutesOptions, FileReadVerdict } from './storage-routes.js'
 export { SystemFile, SystemUploadSession } from './objects/index.js';
 export { installAttachmentLifecycleHooks, createSysFileReapGuard, createUploadSessionReapGuard } from './attachment-lifecycle.js';
 export type { AttachmentLifecycleEngine, AttachmentLifecycleLogger } from './attachment-lifecycle.js';
-export { installFileReferenceHooks, FileReferenceCopyError } from './file-reference-lifecycle.js';
+export {
+  installFileReferenceHooks,
+  FileReferenceCopyError,
+  FileConstraintError,
+} from './file-reference-lifecycle.js';
 export type { FileReferenceEngine, FileReferenceLogger } from './file-reference-lifecycle.js';
 export {
   verifyFileReferences,

--- a/packages/spec/api-surface.json
+++ b/packages/spec/api-surface.json
@@ -341,6 +341,7 @@
     "FieldSchema (const)",
     "FieldType (type)",
     "FileLikeValueSchema (const)",
+    "FileReferenceIdValueSchema (const)",
     "FileValueSchema (const)",
     "Filter (type)",
     "FilterCondition (type)",

--- a/packages/spec/json-schema.manifest.json
+++ b/packages/spec/json-schema.manifest.json
@@ -760,6 +760,7 @@
     "data/FieldReference",
     "data/FieldType",
     "data/FileLikeValue",
+    "data/FileReferenceIdValue",
     "data/FileValue",
     "data/FilterCondition",
     "data/FormatValidation",

--- a/packages/spec/liveness/field.json
+++ b/packages/spec/liveness/field.json
@@ -251,6 +251,16 @@
       "status": "live",
       "evidence": "packages/plugins/plugin-audit/src/audit-writers.ts",
       "note": "ADR-0052 §5b — the audit-writer renders tracked-field diffs as human-readable activity summaries (renderTrackedChangeSummary + getFieldDefs read field.trackHistory). Reintroduces the pruned auditTrail concept WITH a runtime consumer, satisfying enforce-or-remove (ADR-0049)."
+    },
+    "accept": {
+      "status": "live",
+      "evidence": "packages/services/service-storage/src/file-reference-lifecycle.ts (assertFileConstraints)",
+      "note": "ADR-0104 D3 wave 2. Offered to the file picker AND enforced server-side on record write: once a media field references a sys_file, the stored mime_type/name is re-checked against the declared list, because a client-side check is bypassed by any caller talking to the API directly. Entries are only judged against metadata the file actually reports — an unrecorded MIME type cannot fail the test."
+    },
+    "maxSize": {
+      "status": "live",
+      "evidence": "packages/services/service-storage/src/file-reference-lifecycle.ts (assertFileConstraints)",
+      "note": "ADR-0104 D3 wave 2. Enforced server-side on record write against sys_file.size, not merely checked in the browser. A file with no recorded size cannot fail it."
     }
   }
 }

--- a/packages/spec/src/data/field-value.test.ts
+++ b/packages/spec/src/data/field-value.test.ts
@@ -154,24 +154,41 @@ describe('valueSchemaFor — stored form (field-zoo reality)', () => {
     ok({ type: 'lookup' }, 'acc_1', 'expanded'); // unresolvable ids stay ids
   });
 
-  it('file-likes admit the transitional inline object OR an opaque id/url string (pre-D3-wave-2)', () => {
-    ok({ type: 'file' }, { url: 'https://cdn/f.pdf', name: 'f.pdf', size: 1024 });
-    ok({ type: 'image' }, { url: 'https://cdn/i.png', alt: 'i' });
-    ok({ type: 'file' }, { url: 'https://cdn/f.pdf', mimeType: 'application/pdf' });
+  it('D3 wave 2: the STORED media form is an opaque sys_file id', () => {
     ok({ type: 'file' }, 'file_01HXYZ');
-    ok({ type: 'image', multiple: true }, ['a.png', 'b.png']);
+    ok({ type: 'file' }, '0e2f4c1a-9b7d-4e3f-8a1b-2c3d4e5f6a7b');
+    ok({ type: 'image', multiple: true }, ['file_a', 'file_b']);
     bad({ type: 'file' }, 42);
     bad({ type: 'file' }, {});
+    // The inline blob is no longer STORED — it is the expanded read form.
+    bad({ type: 'file' }, { url: 'https://cdn/f.pdf', name: 'f.pdf', size: 1024 });
+    // An external URL was never a managed file; ADR-0104 R7 retires it toward
+    // an explicit `url` field. Both of these reach authors as warn-first
+    // value-shape warnings, not hard failures, until strict is opted into.
+    bad({ type: 'file' }, 'https://cdn/f.pdf');
+    bad({ type: 'image' }, '/api/v1/storage/files/file_a');
+    bad({ type: 'image' }, 'data:image/png;base64,aGk=');
+  });
+
+  it('D3 wave 2: the EXPANDED media form is the resolved object, or a still-unresolved id', () => {
+    ok({ type: 'file' }, { url: 'https://cdn/f.pdf', name: 'f.pdf', size: 1024 }, 'expanded');
+    ok({ type: 'image' }, { url: 'https://cdn/i.png', alt: 'i' }, 'expanded');
+    ok({ type: 'file' }, { url: 'https://cdn/f.pdf', mimeType: 'application/pdf' }, 'expanded');
+    // Expansion may not have happened — storage service absent, file not
+    // committed — exactly as an unexpanded lookup id stays valid.
+    ok({ type: 'file' }, 'file_01HXYZ', 'expanded');
+    bad({ type: 'file' }, 42, 'expanded');
   });
 
   it('D3 wave 1: the media object form requires a url — a url-less fragment is no longer waved through', () => {
-    // The whole FILE_REFERENCE_TYPES class shares the one contract.
+    // The whole FILE_REFERENCE_TYPES class shares the one contract, now carried
+    // by the expanded form (wave 2 moved the object out of `stored`).
     for (const type of ['file', 'image', 'avatar', 'video', 'audio']) {
-      ok({ type }, { url: 'https://cdn/x' });
-      bad({ type }, { name: 'x' });        // object without url — the tightening
-      bad({ type }, { size: 10 });         // ditto
+      ok({ type }, { url: 'https://cdn/x' }, 'expanded');
+      bad({ type }, { name: 'x' }, 'expanded');   // object without url — the tightening
+      bad({ type }, { size: 10 }, 'expanded');    // ditto
     }
-    ok({ type: 'video' }, { url: 'https://cdn/v.mp4', duration: 12 });
+    ok({ type: 'video' }, { url: 'https://cdn/v.mp4', duration: 12 }, 'expanded');
   });
 
   it('structured JSON types', () => {

--- a/packages/spec/src/data/field-value.zod.ts
+++ b/packages/spec/src/data/field-value.zod.ts
@@ -214,9 +214,34 @@ export const FileValueSchema = lazySchema(() => z.looseObject({
 }));
 
 /**
- * Media/attachment STORED value — TRANSITIONAL (pre-D3-wave-2): an opaque
- * file-id / url string, or the declared inline metadata object
- * ({@link FileValueSchema}). Wave 2 narrows this to a `sys_file` id string.
+ * Media/attachment STORED value (ADR-0104 D3 wave 2) — an opaque `sys_file` id.
+ *
+ * Deliberately id-SHAPED rather than any non-empty string. The two legacy forms
+ * a file field used to hold are both strings-or-objects that this rejects, and
+ * rejecting them is the point:
+ *
+ *  - an **inline metadata blob** is no longer the stored form; it is the
+ *    `expanded` READ form ({@link FileValueSchema}), derived rather than stored;
+ *  - an **external URL** was never a managed file. ADR-0104 R7 retires it toward
+ *    an explicit `url` field, which under AI authoring is what stops "managed
+ *    file" and "external link" from being the same declaration.
+ *
+ * Both surface through the warn-first value-shape rollout (R1/R2) rather than
+ * as hard failures, so a deployment sees exactly which values still need the
+ * backfill before it opts into strict enforcement.
+ */
+export const FileReferenceIdValueSchema = lazySchema(() =>
+  z.string().regex(/^[A-Za-z0-9_-]{1,64}$/, 'Expected an opaque sys_file id'),
+);
+
+/**
+ * Media/attachment value in either form — the TRANSITIONAL union that was the
+ * stored contract before wave 2.
+ *
+ * @deprecated The stored form is {@link FileReferenceIdValueSchema}; the
+ * expanded read form is {@link FileValueSchema}. Retained for consumers that
+ * genuinely need to accept both during the migration window, so they say so
+ * explicitly rather than by default.
  */
 export const FileLikeValueSchema = lazySchema(() => z.union([
   z.string().min(1),
@@ -267,7 +292,15 @@ export function valueSchemaFor(def: ValueShapeFieldDef, form: ValueForm = 'store
         ? z.union([ReferenceIdValueSchema, z.record(z.string(), z.unknown())])
         : ReferenceIdValueSchema;
     }
-    if (FILE_REFERENCE_TYPES.has(t)) return FileLikeValueSchema;
+    if (FILE_REFERENCE_TYPES.has(t)) {
+      // Expanded form: the read path replaces a stored id in place with the
+      // resolved `{ id, name, size, mimeType, url }` — same polymorphism the
+      // reference types have, and for the same reason, so an unresolved id
+      // (storage service absent, file not committed) stays valid.
+      return form === 'expanded'
+        ? z.union([FileReferenceIdValueSchema, FileValueSchema])
+        : FileReferenceIdValueSchema;
+    }
     if (t === 'location') return LocationValueSchema;
     if (t === 'address') return AddressValueSchema;
     if (t === 'composite') return z.record(z.string(), z.unknown());

--- a/packages/spec/src/data/field.zod.ts
+++ b/packages/spec/src/data/field.zod.ts
@@ -288,6 +288,32 @@ export const FieldSchema = lazySchema(() => z.object({
   min: z.number().optional().describe('Minimum value'),
   max: z.number().optional().describe('Maximum value'),
 
+  /**
+   * Media Constraints (ADR-0104 D3 wave 2)
+   *
+   * Apply to the media family — `file`, `image`, `avatar`, `video`, `audio`.
+   * Declared here rather than only in the upload widget because the client's
+   * check is a convenience, not a control: it can be bypassed by any caller
+   * that talks to the API directly. Once the platform owns the file (`sys_file`
+   * carries its MIME type and byte size), the server re-checks a record write
+   * against these declarations authoritatively.
+   *
+   * Both were read by the upload widgets long before this — `field.accept`,
+   * `field.maxSize` — while `FieldSchema` did not declare them, so an author
+   * writing them had them silently stripped at parse and the constraint simply
+   * never existed. That is the ADR-0104 failure class (a declaration accepted
+   * in source, dropped in the contract, with no feedback); declaring them here
+   * and enforcing them server-side is what closes it.
+   */
+  accept: z.array(z.string()).optional().describe(
+    'Permitted upload types for media fields, as MIME types or extensions '
+    + '(e.g. ["image/*", ".pdf"]). Offered to the file picker AND enforced on write.',
+  ),
+  maxSize: z.number().int().positive().optional().describe(
+    'Maximum permitted file size in BYTES for media fields. Enforced on write against '
+    + 'the stored file size, not just checked in the browser.',
+  ),
+
   /** Selection Options */
   options: z.array(SelectOptionSchema).optional().describe('Static options for select/multiselect'),
 


### PR DESCRIPTION
wave 2 的写切换。配对的客户端采纳 objectui#2828 **已合并**。

## 1. `accept` / `maxSize`:声明并强制

上传 widget **一直在读** `field.accept` 和 `field.maxSize`,而 `FieldSchema` **从未声明它们**——所以作者写了这两个键,会在 parse 时被 `.strip` 静默丢掉,约束**根本不存在**,而且没有任何反馈。

这正是 ADR-0104 要消灭的那类失败:**声明在源码里被接受、在契约里被丢弃、全程无提示**。

现在平台拥有文件了,`sys_file` 带着权威的 MIME 类型和字节大小,所以记录写入会在**约束真正生效的地方**复核,而不只是在浏览器里。客户端检查是**便利,不是控制**——任何直接调 API 的调用方都能绕过。违反时抛 `FileConstraintError`,**写入失败**。

两个实现细节:
- 检查搭在**已经在加载每个被引用 `sys_file` 行**的那一趟上,不增加额外读取。
- **只用文件真正报告的元数据来判定**:没记录 MIME 的文件不可能失败 `accept`,没记录 size 的不可能失败 `maxSize`。"我们不知道"绝不能变成"不允许"——这个区分我第一版写错了,被测试抓了出来。

## 2. 存储形态收窄为 `sys_file` id

`valueSchemaFor(field, 'stored')` 对整个媒体家族现在给出 **id**;inline `{url, name, size, …}` blob 变成 **`'expanded'` 读形态**,并且展开形态**同时仍接受未解析的 id**(存储服务缺席、文件未 committed)——和未展开的 lookup id 依然有效完全同理。

两种遗留形态因此不再符合契约,都是**故意的**:

| 形态 | 为什么不再符合 |
|---|---|
| inline blob | 它不再是**存储**的东西,而是**派生**出来的读形态 |
| 外部 URL | 它从来就不是受管文件。R7 把它导向显式的 `url` 字段——在 AI 写元数据的语境下这正是重点:**让"受管文件"和"外部链接"不再是同一个声明** |

## ⚠️ 今天不是破坏性变更

值形态检查是 **warn-first**(ADR-0104 R1/R2):还没回填的行**照样写得进去**,作者拿到的是一条**指名字段**的告警。硬拒绝只在部署方主动打开 `OS_DATA_VALUE_SHAPE_STRICT_ENABLED` 时才发生——而那应该在跑完回填(#3535)并用 `verifyFileReferences()`(#3534)确认对账之后再做。

标题里的 `!` 标的是**为 v17 窗口而言的契约变更**,不是升级即刻的运行时破坏。

## 测试

- spec `field-value.test.ts`:重写媒体契约断言——存储形态接受 id 与 uuid、拒绝 inline blob / 外部 URL / resolver URL / `data:` URI;展开形态接受解析后的对象**和**未解析的 id;wave-1 的"对象必须有 url"收紧迁到展开形态。
- `record-validator.test.ts`:符合契约的值改为 id;**新增**一条锁定迁移路径的用例——遗留 inline blob 在默认模式下**仍可写入**,只有 strict 才拒绝。
- `file-reference-lifecycle.test.ts` **+10**:超 maxSize 拒绝(且未被认领)、MIME 不在 accept 内拒绝、两者都满足则通过、6 组 accept 匹配矩阵(精确 MIME / `image/*` / `.ext` / `.ext` 不匹配 / MIME 不匹配 / `*/*`)、**元数据缺失不判违规**、未声明约束的字段不受影响。
- field-zoo 矩阵:5 个媒体类型的写入值改为 id,并注明"这些 id 匹配不到任何 sys_file 行,正是要验证无可展开时原样返回"。
- 全量:spec **6842** ✅ · objectql **1082** ✅ · service-storage **168** ✅ · field-zoo dogfood **91** ✅ · build ✅ · lint ✅ · nul-bytes ✅ · check:api-surface ✅ · check:docs ✅

## wave 2 剩余

只剩 **PR-5b 开启回收**(🔒 gated、不可逆),前置条件按 #3459:回填 + `verifyFileReferences` 在真实租户数据上连续 ≥7 天零阻断项,且放松护栏与扩展 reap guard 复核必须同一个 change。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHpGw3GBA9aFpfwVArRWfd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHpGw3GBA9aFpfwVArRWfd)_