### PR TITLE
fix(rest): undo of a historical import preserves the audit timeline (#3549)

### DIFF
--- a/.changeset/import-undo-preserveaudit.md
+++ b/.changeset/import-undo-preserveaudit.md
@@ -1,0 +1,17 @@
+---
+"@objectstack/rest": patch
+---
+
+fix(rest): undo of a historical import now preserves the audit timeline (#3549)
+
+A `treatAsHistorical` import writes with `preserveAudit` (#3493), keeping the
+original `updated_at`/`updated_by` and business `readonly` fields instead of
+stamping-now / stripping them. Its undo route, however, restored the captured
+pre-import snapshot with a plain write context — so the audit auto-stamp
+re-wrote `updated_at`/`updated_by` to "now", silently corrupting the very
+timeline the historical import had preserved.
+
+The undo write context now mirrors the import's own: it carries
+`preserveAudit` iff the job row is flagged `treat_as_historical`, so restoring
+`u.before` re-writes the snapshotted audit/timestamp values verbatim. A normal
+import's undo is unchanged (default stamp/strip).

--- a/packages/rest/src/import-job-integration.test.ts
+++ b/packages/rest/src/import-job-integration.test.ts
@@ -96,6 +96,7 @@ const SYS_IMPORT_JOB = {
     write_mode: { name: 'write_mode', type: 'text' as const },
     dry_run: { name: 'dry_run', type: 'boolean' as const },
     run_automations: { name: 'run_automations', type: 'boolean' as const },
+    treat_as_historical: { name: 'treat_as_historical', type: 'boolean' as const },
     error: { name: 'error', type: 'textarea' as const },
     results: { name: 'results', type: 'json' as const },
     started_at: { name: 'started_at', type: 'text' as const },
@@ -386,5 +387,67 @@ describe('async import job — real engine + protocol integration', () => {
   it('404s undo for an unknown job id', async () => {
     const res = await callJob(ctx.undo, 'imp_nope');
     expect(res._status).toBe(404);
+  });
+
+  // #3549 — the undo write context must mirror the import's own write context.
+  // A historical import carries `preserveAudit` (#3493) so it keeps the original
+  // `updated_at`/`updated_by` (and business `readonly` fields) instead of
+  // stamping-now / stripping them. The undo restores the captured pre-import
+  // snapshot; if that restore write does NOT also carry `preserveAudit`, the
+  // audit auto-stamp re-writes `updated_at`/`updated_by` to "now" — silently
+  // corrupting the very timeline the historical import preserved. So undo of a
+  // historical import must set `preserveAudit`, and undo of a normal import
+  // must not. We assert on the write context the route hands the protocol.
+  function spyUpdateContexts() {
+    const seen: Array<{ object: string; context: any }> = [];
+    const orig = (ctx.protocol as any).updateData.bind(ctx.protocol);
+    (ctx.protocol as any).updateData = async (args: any) => {
+      seen.push({ object: args.object, context: args.context });
+      return orig(args);
+    };
+    return seen;
+  }
+
+  it('undo of a historical import carries preserveAudit on the restore write (#3549)', async () => {
+    // Seed an existing row so the historical upsert updates it (populates the undo log).
+    await ctx.protocol.createData({ object: 'task', data: { id: 'h_existing', title: 'orig', score: 1 } });
+
+    const created = await callCreate(ctx.create, {
+      format: 'json', writeMode: 'upsert', matchFields: ['id'], treatAsHistorical: true,
+      rows: [{ id: 'h_existing', title: 'historical', score: 42 }],
+    });
+    const jobId = created._json.jobId;
+    const done = await waitForTerminal(ctx.progress, jobId);
+    expect(done).toMatchObject({ status: 'succeeded', updated: 1 });
+    expect(done.undoable).toBe(true);
+
+    // Observe only the undo phase.
+    const seen = spyUpdateContexts();
+    const u = await callJob(ctx.undo, jobId);
+    expect(u._json).toMatchObject({ success: true, restored: 1 });
+
+    const restoreWrites = seen.filter((s) => s.object === 'task');
+    expect(restoreWrites.length).toBeGreaterThan(0);
+    for (const w of restoreWrites) expect(w.context?.preserveAudit).toBe(true);
+  });
+
+  it('undo of a normal import does NOT set preserveAudit — default stamp/strip (#3549)', async () => {
+    await ctx.protocol.createData({ object: 'task', data: { id: 'n_existing', title: 'orig', score: 1 } });
+
+    const created = await callCreate(ctx.create, {
+      format: 'json', writeMode: 'upsert', matchFields: ['id'], // treatAsHistorical omitted
+      rows: [{ id: 'n_existing', title: 'updated', score: 7 }],
+    });
+    const jobId = created._json.jobId;
+    const done = await waitForTerminal(ctx.progress, jobId);
+    expect(done).toMatchObject({ status: 'succeeded', updated: 1 });
+
+    const seen = spyUpdateContexts();
+    const u = await callJob(ctx.undo, jobId);
+    expect(u._json).toMatchObject({ success: true, restored: 1 });
+
+    const restoreWrites = seen.filter((s) => s.object === 'task');
+    expect(restoreWrites.length).toBeGreaterThan(0);
+    for (const w of restoreWrites) expect(w.context?.preserveAudit).toBeUndefined();
   });
 });

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -4049,7 +4049,20 @@ export class RestServer {
                     // re-writes the row's earlier state, which need not be a legal
                     // transition from where it is now — an undo reinstates an established
                     // fact, it does not walk the FSM.
-                    const writeCtx = { ...(context ?? {}), skipAutomations: true, skipStateMachine: true };
+                    //
+                    // For a historical import (#3493/#3549), the undo write must mirror
+                    // the import's own write context: carry `preserveAudit` so restoring
+                    // `u.before` re-writes the captured `updated_at`/`updated_by` (and any
+                    // business `readonly` fields in the snapshot) verbatim, rather than
+                    // stamping-now / stripping them. Without this, undoing a historical
+                    // import would silently rewrite the audit timeline the import took
+                    // pains to preserve. A normal import keeps the default (stamp/strip).
+                    const writeCtx = {
+                        ...(context ?? {}),
+                        skipAutomations: true,
+                        skipStateMachine: true,
+                        ...(row.treat_as_historical ? { preserveAudit: true } : {}),
+                    };
                     let deleted = 0, restored = 0, failed = 0;
 
                     // Delete created records first (they didn't exist before).


### PR DESCRIPTION
## 背景 / 问题

关闭 #3549。

`treatAsHistorical`（历史数据导入）在 #3493/#3497 中获得了「另一半」能力：导入的写上下文携带 `preserveAudit`，因此会**保留**原始 `updated_at`/`updated_by` 以及业务 `readonly` 字段（`closed_at`、`resolved_by` 等），而不是「盖上当前时间 / 剥离」。

但**撤销（undo）路径**被遗漏了。撤销一个已完成的导入作业时（`POST /data/import/jobs/:jobId/undo`），它会用捕获的导入前快照 `u.before` 还原被更新的行——却使用了一个**普通**写上下文：

```ts
const writeCtx = { ...(context ?? {}), skipAutomations: true, skipStateMachine: true };
```

于是审计自动戳（audit auto-stamp）会把 `updated_at`/`updated_by` 重写为「现在」，**悄悄破坏了历史导入刻意保留的那条审计时间线**。换句话说：导入保留了原始时间戳，撤销却把它抹掉了——撤销本应是「还原」，结果反而改写了事实。

## 改动

撤销的写上下文现在**镜像导入自身的写上下文**：当作业行标记了 `treat_as_historical` 时，携带 `preserveAudit`，从而把快照里的审计/时间戳值（以及任何业务 `readonly` 字段）原样写回。

```ts
const writeCtx = {
    ...(context ?? {}),
    skipAutomations: true,
    skipStateMachine: true,
    ...(row.treat_as_historical ? { preserveAudit: true } : {}),
};
```

- `row.treat_as_historical` 已经持久化在导入作业行上（`rest-server.ts` 创建作业时写入 `treat_as_historical: prepared.treatAsHistorical`），因此撤销时无需额外查询即可判定。
- **普通导入的撤销行为完全不变**（默认 stamp/strip）——`preserveAudit` 仅在历史导入时按条件加入。
- 条件式合并对齐了 `import-runner.ts` 里导入自身写上下文的写法（`treatAsHistorical ? { skipStateMachine: true, preserveAudit: true } : {}`）。

## 为什么这是「保留」而非「特权」

- `captureBefore` 只快照导入负载里出现过的键，所以撤销写回的就是导入前的确切值；带上 `preserveAudit` 只是让这些值被**原样**写回，而不是被审计钩子覆盖。
- 审计溯源不受影响：撤销本身仍会记录（`sys_audit_log` + 作业行上的 `reverted_at`），所以「谁在何时撤销」这条事实依然可查——被保留的只是被还原行的业务时间线。

## 测试

`packages/rest/src/import-job-integration.test.ts` 新增两条回归测试（真实 ObjectQL 引擎 + 内存驱动 + RestServer，全链路走真实的 create-job / worker / undo 路由）：

1. **历史导入的撤销**：断言还原写（`updateData`）的上下文携带 `preserveAudit: true`。
2. **普通导入的撤销**：断言还原写的上下文**不含** `preserveAudit`（默认 stamp/strip）。

为让 `treat_as_historical` 标志在作业行上往返，测试的 `sys_import_job` 镜像补充了该字段。

```
Test Files  3 passed (3)   # import-integration + import-runner-historical + import-job-integration
     Tests  42 passed (42)
```

（`import-job-integration.test.ts` 单独运行：13 passed，含 2 条新增。）

## 影响面

- 仅改动撤销路由的写上下文构造 + 测试；无接口/schema 变更。
- Changeset：`@objectstack/rest` patch（行为修复）。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5rdfBKjkbcoEif4KUV6xE

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5rdfBKjkbcoEif4KUV6xE)_