### PR TITLE
fix(verify): multiTenant boot requests the isolated tenancy posture — ADR-0105 D1

### DIFF
--- a/.changeset/verify-multitenant-requests-isolated-posture.md
+++ b/.changeset/verify-multitenant-requests-isolated-posture.md
@@ -1,0 +1,19 @@
+---
+'@objectstack/verify': patch
+---
+
+`bootStack({ multiTenant: true })` now REQUESTS the `isolated` tenancy posture
+for the boot (ADR-0105 D1), restoring the request on `stop()` and respecting an
+explicit caller-provided `OS_TENANCY_POSTURE`.
+
+Since #3559 a walled posture is an explicit operator request resolved from env
+when AuthPlugin registers the `tenancy` service — mounting the enterprise
+organizations plugin only ENTITLES it. The harness's multi-tenant opt-in
+predates that split and only mounted the plugin, so multi-org fixtures silently
+booted `single`: no Layer 0 wall, D3 default-org write stamping, and every
+cross-tenant proof asserting against the wrong posture (first surfaced by
+cloud's security-enterprise multi-org integration test, which runs the licensed
+path open-core CI cannot).
+
+The verify package also gains a `test` script so its suite actually runs under
+`turbo run test`, including the new regression pin for this contract.

--- a/packages/verify/package.json
+++ b/packages/verify/package.json
@@ -16,7 +16,8 @@
   "scripts": {
     "build": "tsup --config ../../tsup.config.ts",
     "dev": "tsc -w",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "test": "vitest run"
   },
   "dependencies": {
     "@objectstack/core": "workspace:*",
@@ -36,7 +37,8 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
   },
   "keywords": [
     "objectstack",

--- a/packages/verify/src/harness.posture.test.ts
+++ b/packages/verify/src/harness.posture.test.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// bootStack({ multiTenant: true }) must REQUEST the `isolated` tenancy posture
+// (ADR-0105 D1). Since #3559, mounting the enterprise organizations plugin only
+// ENTITLES a walled posture — activation is an explicit operator request, read
+// from env when AuthPlugin registers the `tenancy` service. A harness that
+// mounts the plugin without requesting a posture silently boots `single` (no
+// wall, default-org write stamping) and every multi-org fixture asserts against
+// the wrong posture — the regression this file pins. The enterprise package is
+// not installable in this workspace, so a fake stands in for it, registering
+// the same `org-scoping` service + entitlement surface; the proof that the REAL
+// plugin walls tenants lives in cloud's security-enterprise multi-org
+// integration test.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { bootStack } from './harness';
+
+class FakeOrganizationsPlugin {
+  readonly name = 'fake-organizations';
+  readonly version = '0.0.0';
+  readonly supportedPostures = ['group', 'isolated'] as const;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async init(ctx: any): Promise<void> {
+    ctx.registerService('org-scoping', this);
+  }
+}
+
+// The factory runs lazily, on the harness's dynamic import — after this module
+// body has executed, so referencing the class above is safe.
+vi.mock('@objectstack/organizations', () => ({
+  OrganizationsPlugin: FakeOrganizationsPlugin,
+}));
+
+const app = {
+  manifest: {
+    id: 'com.example.posture',
+    namespace: 'posture',
+    version: '0.0.1',
+    type: 'app',
+    name: 'Posture Fixture',
+  },
+  objects: [],
+};
+
+interface TenancyShape {
+  posture: string;
+  requestedPosture: string;
+  isolationActive: boolean;
+}
+
+afterEach(() => {
+  delete process.env.OS_TENANCY_POSTURE;
+});
+
+// Each case boots the full in-process stack — well beyond the 5s default, and a
+// timed-out boot keeps running past its case, so its deferred stop() would race
+// the NEXT case's env expectations. Generous per-case timeouts keep the boots
+// inside their own cases.
+const BOOT_TIMEOUT = 120_000;
+
+describe('bootStack multiTenant — tenancy posture request (ADR-0105 D1)', () => {
+  it(
+    'requests `isolated` for the boot and restores the env on stop()',
+    async () => {
+      expect(process.env.OS_TENANCY_POSTURE).toBeUndefined();
+      const stack = await bootStack(app, { multiTenant: true });
+      try {
+        expect(process.env.OS_TENANCY_POSTURE).toBe('isolated');
+        const tenancy = await stack.kernel.getServiceAsync<TenancyShape>('tenancy');
+        expect(tenancy.requestedPosture).toBe('isolated');
+        expect(tenancy.posture).toBe('isolated');
+        expect(tenancy.isolationActive).toBe(true);
+      } finally {
+        await stack.stop();
+      }
+      expect(process.env.OS_TENANCY_POSTURE).toBeUndefined();
+    },
+    BOOT_TIMEOUT,
+  );
+
+  it(
+    'never overrides an explicit caller-provided OS_TENANCY_POSTURE',
+    async () => {
+      process.env.OS_TENANCY_POSTURE = 'group';
+      const stack = await bootStack(app, { multiTenant: true });
+      try {
+        const tenancy = await stack.kernel.getServiceAsync<TenancyShape>('tenancy');
+        expect(tenancy.requestedPosture).toBe('group');
+      } finally {
+        await stack.stop();
+      }
+      // stop() must not clear a posture the harness did not set.
+      expect(process.env.OS_TENANCY_POSTURE).toBe('group');
+    },
+    BOOT_TIMEOUT,
+  );
+
+  it(
+    'restores the env when the enterprise package is missing and the boot throws',
+    async () => {
+      // `vi.resetModules()` alone cannot evict a `vi.mock` factory result, so
+      // re-mock with `vi.doMock` (re-evaluated on the next import) and clear the
+      // module cache: the harness's dynamic import now rejects like a genuinely
+      // missing package.
+      vi.resetModules();
+      vi.doMock('@objectstack/organizations', () => {
+        throw new Error("Cannot find module '@objectstack/organizations'");
+      });
+      await expect(bootStack(app, { multiTenant: true })).rejects.toThrow(
+        /requires the enterprise @objectstack\/organizations/,
+      );
+      expect(process.env.OS_TENANCY_POSTURE).toBeUndefined();
+    },
+    BOOT_TIMEOUT,
+  );
+});

--- a/packages/verify/src/harness.ts
+++ b/packages/verify/src/harness.ts
@@ -81,6 +81,10 @@ export interface BootOptions {
    * `collectRLSPolicies`). This exercises the org-scoped isolation real apps
    * rely on, rather than the single-tenant default where every tenant policy is
    * stripped and a member sees every row. Default `false`.
+   *
+   * Also REQUESTS the `isolated` tenancy posture (ADR-0105 D1) for the boot,
+   * unless the caller already set `OS_TENANCY_POSTURE` — mounting the plugin
+   * entitles a walled posture but no longer activates one by itself.
    */
   multiTenant?: boolean;
   /**
@@ -116,6 +120,25 @@ export async function bootStack(
   opts: BootOptions = {},
 ): Promise<VerifyStack> {
   process.env.NODE_ENV = 'development';
+
+  // [ADR-0105 D1] `multiTenant: true` REQUESTS the hard organization wall —
+  // posture `isolated`, what `OS_MULTI_ORG_ENABLED=true` historically meant.
+  // Since #3559 a walled posture is an explicit operator request resolved from
+  // env when AuthPlugin registers the `tenancy` service; mounting the
+  // enterprise plugin only ENTITLES it. Without the request the fixture
+  // silently boots `single` — no wall, default-org write stamping — and every
+  // multi-org proof asserts against the wrong posture. Must be set BEFORE
+  // AuthPlugin snapshots the requested posture; an explicit caller-provided
+  // OS_TENANCY_POSTURE wins; restored on stop() (and on a failed multi-tenant
+  // boot) so later single-tenant boots in the same worker are unaffected.
+  const prevTenancyPosture = process.env.OS_TENANCY_POSTURE;
+  const requestIsolatedPosture = !!opts.multiTenant && !prevTenancyPosture;
+  if (requestIsolatedPosture) process.env.OS_TENANCY_POSTURE = 'isolated';
+  const restoreTenancyPosture = () => {
+    if (!requestIsolatedPosture) return;
+    if (prevTenancyPosture === undefined) delete process.env.OS_TENANCY_POSTURE;
+    else process.env.OS_TENANCY_POSTURE = prevTenancyPosture;
+  };
 
   const kernel = new ObjectKernel();
 
@@ -181,6 +204,7 @@ export async function bootStack(
     try {
       mod = await import(/* webpackIgnore: true */ organizationsPkg);
     } catch (e) {
+      restoreTenancyPosture();
       throw new Error(
         'verify: multiTenant=true requires the enterprise @objectstack/organizations package (migrated from plugin-org-scoping, ADR-0081 D2). ' +
           `Install/link it in this workspace to run multi-org fixtures. (${(e as Error).message})`,
@@ -309,6 +333,7 @@ export async function bootStack(
     } catch {
       /* best-effort */
     }
+    restoreTenancyPosture();
   };
 
   return { kernel, api, raw, signIn, signUp, apiAs, stop };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2326,6 +2326,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.2)(msw@2.14.6(@types/node@26.1.1)(typescript@6.0.3))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/vscode-objectstack:
     devDependencies:


### PR DESCRIPTION
## Root cause

Since #3559 (ADR-0105 Phase 0/1), a walled tenancy posture is an explicit operator request — resolved from `OS_TENANCY_POSTURE` / `OS_MULTI_ORG_ENABLED` when AuthPlugin registers the `tenancy` service — and mounting the enterprise organizations plugin only **entitles** it (#3570, D12). `bootStack`'s `multiTenant: true` opt-in predates that split: it mounted the plugin but requested nothing, so multi-org fixtures silently boot **`single`** — no Layer 0 wall, D3 default-org write stamping — and every cross-tenant proof asserts against the wrong posture.

First surfaced by cloud's `security-enterprise` multi-org integration test (the licensed path open-core CI cannot run): 3/4 assertions fail against any framework checkout at or past #3559 — writes get stamped into the ADR-0081 default org (`org_<ts><rand>`) instead of the caller's active org, and an org admin's scoped `viewAllRecords` grant sees `[]`. Cloud CI stays green only because its `.objectstack-sha` pin predates #3559 — **any pin bump past #3559 without this fix turns cloud CI red.**

## Fix

`bootStack({ multiTenant: true })` now sets `OS_TENANCY_POSTURE=isolated` (the posture `OS_MULTI_ORG_ENABLED=true` historically meant) before AuthPlugin snapshots the requested posture:

- an explicit caller-provided `OS_TENANCY_POSTURE` always wins;
- the request is restored on `stop()` and on a failed multi-tenant boot, so later single-tenant boots in the same worker are unaffected.

The verify package also gains a `test` script — `turbo run test` never ran its suite before (the existing `derive.test.ts` was dead weight in CI) — so the new regression pin actually gates.

## Verification

- `packages/verify`: 7/7 pass (3 new posture-contract cases with a faked `org-scoping` entitlement surface + 4 existing derive cases), rebased on latest `main` (post-#3581) with the chain rebuilt.
- Cross-repo E2E: cloud's `multi-org-tenant-isolation.integration.test.ts` run against this branch's verify (temp alias, live `@objectstack/organizations` with its D12 posture declaration): **4/4 pass with no external env** — previously 3/4 failed. The Layer 0 fail-closed UPDATE denial logs confirm the wall is real.
- `pnpm --filter @objectstack/verify lint` reports 7 pre-existing "Definition for rule '@typescript-eslint/no-explicit-any' was not found" errors on a pristine checkout too (package-level lint config gap, untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)