### PR TITLE
fix(approvals)!: 审批请求按参与者可见,而不是整个租户可见 (#3590)

### DIFF
--- a/.changeset/approval-participant-visibility.md
+++ b/.changeset/approval-participant-visibility.md
@@ -1,0 +1,39 @@
+---
+"@objectstack/plugin-approvals": patch
+---
+
+fix(approvals)!: an approval request is visible to its participants, not to the whole tenant (#3590)
+
+`getRequest` / `listRequests` / `countRequests` deliberately query with
+`SYSTEM_CTX` to bypass RLS — as the code comments say, the approver-visibility
+rule spans identity forms RLS cannot model cleanly, so it has to be expressed in
+the service. Only the **tenant** half of that rule was ever applied. The
+participant half was named in the comment and never written, so **any
+authenticated user could read any approval request in their tenant** — its
+payload snapshot, its full decision history, and (once decision attachments
+derived their access from the request, #3580) its files.
+
+`approverId` on `listRequests` is a *filter*, not authorization: omitting it
+returned the whole tenant.
+
+A caller now sees a request when they are a participant — the submitter, a
+current approver (via the normalized approver index, so every identity form the
+write path recorded is covered), or someone who has already acted on it (a past
+approver whose slot has moved on, a commenter). Admins with override authority
+keep the unrestricted view the "all requests" console surface depends on, and a
+tokenless context sees nothing.
+
+Keying on the concrete user id is sufficient rather than an approximation:
+position/team/manager/field approvers are resolved to concrete user ids at open
+time, and the `type:value` literal is only the fallback for a spec that resolved
+to *nobody* — a slot no one can act on either way. So this cannot hide a request
+from someone who could actually act on it.
+
+**A write path's own result is not re-gated.** Every operation echoes back the
+request it just changed; the operation already authorized itself, and re-asking
+would answer wrong for a context carrying no `userId` (a flow-driven resume, a
+service-to-service call), turning a successful write into `null`.
+
+Marked breaking because a client that listed requests without an `approverId`
+filter and expected the whole tenant will now receive only its own — which is
+the point.

--- a/content/docs/automation/approvals.mdx
+++ b/content/docs/automation/approvals.mdx
@@ -245,6 +245,20 @@ Other filters: `status`, `object`, `recordId`, `submitterId`, `q`, `limit`,
 `offset`.
 
 <Callout type="warn">
+**`approverId` is a filter, not authorization.** What you may see is decided
+separately: a request is visible to its **participants** — the submitter, a
+current approver, and anyone who has already acted on it (a past approver whose
+slot has moved on, a commenter). So omitting `approverId` returns *your*
+requests, not every request in the tenant. Admins with override authority
+(`admin_full_access`, or `organization_admin` within their org) see all of them
+— that is what the "all requests" view is for.
+
+The same rule governs a decision's files: an attachment is exactly as readable
+as the decision it hangs off, never more (`sys_approval_action` delegates that
+question back to this service via `fileAccessDelegate`).
+</Callout>
+
+<Callout type="warn">
 **Opening a request notifies nobody.** There is no built-in "you have an
 approval waiting" message today — an approver only discovers it by looking at
 the queue. If people need to be told, do one of: add a `notify` node next to

--- a/packages/plugins/plugin-approvals/src/approval-service.test.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.test.ts
@@ -740,8 +740,10 @@ describe('ApprovalService (node era)', () => {
     expect(asApprover!.viewer).toEqual({ can_act: true, is_submitter: false, can_override: false });
     const asSubmitter = await svc.getRequest(req.id, { userId: 'u1', tenantId: 't1' } as any);
     expect(asSubmitter!.viewer).toEqual({ can_act: false, is_submitter: true, can_override: false });
-    const asOther = await svc.getRequest(req.id, { userId: 'u_stranger', tenantId: 't1' } as any);
-    expect(asOther!.viewer).toEqual({ can_act: false, is_submitter: false, can_override: false });
+    // #3590: a same-tenant stranger participates in nothing, so the request is
+    // not readable at all — previously it came back with an all-false viewer
+    // block, which meant every authenticated user could read every request.
+    expect(await svc.getRequest(req.id, { userId: 'u_stranger', tenantId: 't1' } as any)).toBeNull();
   });
 
   it('getRequest: viewer.can_act drops to false once the request is finalized', async () => {
@@ -1477,11 +1479,21 @@ describe('ApprovalService — admin override (#3424)', () => {
     const req = await svc.openNodeRequest(stuckInput(), CTX);
     const asAdmin = await svc.getRequest(req.id, TENANT_ADMIN);
     expect(asAdmin!.viewer).toMatchObject({ can_act: false, can_override: true });
-    const asMember = await svc.getRequest(req.id, MEMBER);
-    expect(asMember!.viewer!.can_override).toBe(false);
+    // Someone who CAN see the request but holds no override privilege — the
+    // submitter. `can_override` is about the privilege, not about access, so
+    // the check needs a participant rather than a stranger.
+    const asSubmitter = await svc.getRequest(req.id, CTX);
+    expect(asSubmitter!.viewer!.can_override).toBe(false);
     await svc.decide(req.id, { decision: 'approve', actorId: 'owner' }, TENANT_ADMIN);
     const after = await svc.getRequest(req.id, TENANT_ADMIN);
     expect(after!.viewer!.can_override).toBe(false);
+  });
+
+  // #3590: a plain member who participates in nothing now sees nothing — a
+  // request is no longer readable merely because you are in the same tenant.
+  it('a non-participant member cannot read the request at all', async () => {
+    const req = await svc.openNodeRequest(stuckInput(), CTX);
+    expect(await svc.getRequest(req.id, MEMBER)).toBeNull();
   });
 });
 
@@ -2112,5 +2124,103 @@ describe('ApprovalService — authorizeFileRead delegate (ADR-0104 D3 wave 2)', 
   it('sys_approval_action declares the delegate, so the storage gate asks the service', async () => {
     const { SysApprovalAction } = await import('./sys-approval-action.object.js');
     expect((SysApprovalAction as any).fileAccessDelegate).toBe('approvals');
+  });
+});
+
+// ── Participant visibility (#3590) ───────────────────────────────────
+//
+// getRequest/listRequests deliberately query with SYSTEM_CTX (the
+// approver-visibility rule spans identity forms RLS cannot model), but only
+// the TENANT half of that rule was ever applied — so any authenticated user
+// could read any request in their tenant, and after #3580 its decision
+// attachments too. These lock in the participant half.
+describe('ApprovalService — participant visibility (#3590)', () => {
+  const svcFor = (engine: any) => {
+    let n = 0;
+    return new ApprovalService({ engine, clock: { now: () => new Date(1757000000000 + (n++) * 1000) } });
+  };
+  const asUser = (userId: string) => ({ userId, tenantId: 't1', positions: [], permissions: [] } as any);
+  const ADMIN = { userId: 'root', tenantId: 't1', positions: [], permissions: ['admin_full_access'] } as any;
+
+  it('the submitter and a pending approver can read it; a same-tenant stranger cannot', async () => {
+    const engine = makeFakeEngine();
+    const svc = svcFor(engine);
+    const req = await svc.openNodeRequest(openInput(['u9']), CTX); // submitter u1, approver u9
+
+    expect(await svc.getRequest(req.id, asUser('u1'))).not.toBeNull();
+    expect(await svc.getRequest(req.id, asUser('u9'))).not.toBeNull();
+    expect(await svc.getRequest(req.id, asUser('u_stranger'))).toBeNull();
+  });
+
+  it('someone who already acted keeps access after their slot moves on', async () => {
+    const engine = makeFakeEngine();
+    const svc = svcFor(engine);
+    const req = await svc.openNodeRequest(openInput(['u9']), CTX);
+    await svc.decideNode(req.id, { decision: 'approve', actorId: 'u9' }, SYS);
+
+    // u9 is no longer a pending approver, but the decision is theirs — the
+    // audit trail (and its attachments) must not vanish from under them.
+    expect(await svc.getRequest(req.id, asUser('u9'))).not.toBeNull();
+  });
+
+  it('an override admin keeps the unrestricted view the console depends on', async () => {
+    const engine = makeFakeEngine();
+    const svc = svcFor(engine);
+    const req = await svc.openNodeRequest(openInput(['u9']), CTX);
+
+    expect(await svc.getRequest(req.id, ADMIN)).not.toBeNull();
+  });
+
+  it('a tokenless context sees nothing — the gate fails closed', async () => {
+    const engine = makeFakeEngine();
+    const svc = svcFor(engine);
+    const req = await svc.openNodeRequest(openInput(['u9']), CTX);
+
+    expect(await svc.getRequest(req.id, { tenantId: 't1', positions: [], permissions: [] } as any)).toBeNull();
+  });
+
+  it('listRequests no longer returns the whole tenant when no approverId filter is passed', async () => {
+    const engine = makeFakeEngine();
+    const svc = svcFor(engine);
+    const mine = await svc.openNodeRequest(openInput(['u9']), CTX);            // submitter u1
+    await svc.openNodeRequest(openInput(['u7'], { recordId: 'opp2', record: { id: 'opp2' } }), asUser('u_other')); // unrelated to u1
+
+    // The old behaviour: omit approverId and receive every request in the
+    // tenant. `approverId` is a filter, never authorization.
+    const seen = await svc.listRequests(undefined, asUser('u1'));
+    expect(seen.map(r => r.id)).toEqual([mine.id]);
+
+    const strangerSees = await svc.listRequests(undefined, asUser('u_stranger'));
+    expect(strangerSees).toEqual([]);
+
+    // The admin console still sees everything.
+    expect((await svc.listRequests(undefined, ADMIN)).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('countRequests agrees with the list it paginates', async () => {
+    const engine = makeFakeEngine();
+    const svc = svcFor(engine);
+    await svc.openNodeRequest(openInput(['u9']), CTX);
+    await svc.openNodeRequest(openInput(['u7'], { recordId: 'opp2', record: { id: 'opp2' } }), asUser('u_other'));
+
+    expect(await svc.countRequests(undefined, asUser('u_stranger'))).toBe(0);
+    expect(await svc.countRequests(undefined, asUser('u1'))).toBe(1);
+  });
+
+  it('a write path still echoes back its own result when the context has no userId', async () => {
+    const engine = makeFakeEngine();
+    const svc = svcFor(engine);
+    const req = await svc.openNodeRequest(openInput(['u9']), CTX);
+
+    // Flow-driven resumes and service-to-service calls carry no userId. The
+    // operation authorized itself; re-gating the echo would turn a successful
+    // write into a null result.
+    const res = await svc.decideNode(
+      req.id,
+      { decision: 'approve', actorId: 'u9' },
+      { isSystem: false, positions: [], permissions: [] } as any,
+    );
+    expect(res.request).not.toBeNull();
+    expect(res.request.status).toBe('approved');
   });
 });

--- a/packages/plugins/plugin-approvals/src/approval-service.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.ts
@@ -1377,7 +1377,7 @@ export class ApprovalService implements IApprovalService {
           } : {}),
         }, { context: SYSTEM_CTX });
         await this.syncApproverIndex(requestId, stillPending, org, now);
-        const fresh = await this.getRequest(requestId, context);
+        const fresh = await this.readBackRequest(requestId, context);
         return { request: fresh!, runId, nodeId, finalized: false, decision: input.decision };
       }
     }
@@ -1400,7 +1400,7 @@ export class ApprovalService implements IApprovalService {
     if (config.approvalStatusField) {
       await this.mirrorStatusField(raw.object_name, raw.record_id, config.approvalStatusField, finalStatus);
     }
-    const fresh = await this.getRequest(requestId, context);
+    const fresh = await this.readBackRequest(requestId, context);
     return { request: fresh!, runId, nodeId, finalized: true, decision: input.decision, outputs: mergedOutputs };
   }
 
@@ -1535,7 +1535,7 @@ export class ApprovalService implements IApprovalService {
       }
     }
 
-    const fresh = await this.getRequest(requestId, context);
+    const fresh = await this.readBackRequest(requestId, context);
     return { request: fresh!, runId, resumed };
   }
 
@@ -1634,7 +1634,7 @@ export class ApprovalService implements IApprovalService {
           },
         });
       }
-      const fresh = await this.getRequest(requestId, context);
+      const fresh = await this.readBackRequest(requestId, context);
       return { request: fresh!, runId, resumed, autoRejected: true };
     }
 
@@ -1675,7 +1675,7 @@ export class ApprovalService implements IApprovalService {
       });
     }
 
-    const fresh = await this.getRequest(requestId, context);
+    const fresh = await this.readBackRequest(requestId, context);
     return { request: fresh!, runId, resumed };
   }
 
@@ -1748,7 +1748,7 @@ export class ApprovalService implements IApprovalService {
       }
     }
 
-    const fresh = await this.getRequest(requestId, context);
+    const fresh = await this.readBackRequest(requestId, context);
     return { request: fresh!, runId, resumed };
   }
 
@@ -1876,7 +1876,7 @@ export class ApprovalService implements IApprovalService {
       },
     });
 
-    const fresh = await this.getRequest(requestId, context);
+    const fresh = await this.readBackRequest(requestId, context);
     return { request: fresh! };
   }
 
@@ -1959,7 +1959,7 @@ export class ApprovalService implements IApprovalService {
       });
     }
 
-    const fresh = await this.getRequest(requestId, context);
+    const fresh = await this.readBackRequest(requestId, context);
     return { request: fresh!, notified };
   }
 
@@ -2098,7 +2098,7 @@ export class ApprovalService implements IApprovalService {
       });
     }
 
-    const fresh = await this.getRequest(requestId, context);
+    const fresh = await this.readBackRequest(requestId, context);
     return { request: fresh! };
   }
 
@@ -2140,7 +2140,7 @@ export class ApprovalService implements IApprovalService {
       },
     });
 
-    const fresh = await this.getRequest(requestId, context);
+    const fresh = await this.readBackRequest(requestId, context);
     return { request: fresh! };
   }
 
@@ -2691,6 +2691,98 @@ export class ApprovalService implements IApprovalService {
     return [...new Set<string>(list.map(r => String(r.request_id)))];
   }
 
+  /**
+   * The request ids this caller is a PARTICIPANT of, or `null` for a caller
+   * who may see everything in scope (#3590).
+   *
+   * These reads deliberately run with `SYSTEM_CTX` to bypass RLS — the
+   * approver-visibility rule spans several identity forms that RLS cannot model
+   * cleanly, which is why it has to be expressed here. Until now only the
+   * TENANT half of that rule was applied, so any authenticated user could read
+   * any request in their tenant (and, once attachments derived their access
+   * from the request, its files too). This adds the participant half.
+   *
+   * A participant is the submitter, a current approver, or someone who has
+   * already acted on the request (a past approver whose slot has moved on, a
+   * commenter). Admins with override authority keep the unrestricted view the
+   * "all requests" console surface depends on.
+   *
+   * Keying on the concrete user id is sufficient rather than an approximation:
+   * position/team/manager/field approvers are resolved to concrete user ids at
+   * open time, and the `type:value` literal is only the fallback for a spec
+   * that resolved to NOBODY — a slot no one can act on either way (`can_act`
+   * is a plain membership test over the resolved ids). So this cannot hide a
+   * request from someone who could actually act on it.
+   */
+  private async visibleRequestIds(
+    context: SharingExecutionContext,
+    tenantOrg: string | null,
+  ): Promise<Set<string> | null> {
+    if (this.isOverrideActor(context, tenantOrg)) return null;
+    const uid = (context as any)?.userId != null ? String((context as any).userId) : '';
+    // A tokenless/anonymous caller participates in nothing. Fail closed.
+    if (!uid) return new Set<string>();
+
+    const ids = new Set<string>();
+    const cap = ApprovalService.APPROVER_INDEX_CAP;
+    const add = (rows: unknown, key: string) => {
+      const list: any[] = Array.isArray(rows) ? rows : [];
+      for (const r of list) if (r?.[key] != null) ids.add(String(r[key]));
+      if (list.length >= cap) {
+        this.logger?.warn?.(
+          '[approvals] participant-visibility probe hit its window — some requests may be hidden from a legitimate participant',
+          { cap, key },
+        );
+      }
+    };
+
+    try {
+      // Current approver — via the normalized index, so every identity form
+      // the write path recorded is covered.
+      for (const id of (await this.approverRequestIds([uid], tenantOrg)) ?? []) ids.add(id);
+
+      const orgWhere = tenantOrg ? { organization_id: tenantOrg } : {};
+      add(
+        await this.engine.find('sys_approval_request', {
+          where: { submitter_id: uid, ...orgWhere },
+          fields: ['id'], limit: cap, context: SYSTEM_CTX,
+        }),
+        'id',
+      );
+      // Already acted on it: a past approver whose slot has moved on, or a
+      // commenter. They saw it legitimately; keep it that way.
+      add(
+        await this.engine.find('sys_approval_action', {
+          where: { actor_id: uid },
+          fields: ['request_id'], limit: cap, context: SYSTEM_CTX,
+        }),
+        'request_id',
+      );
+    } catch (err) {
+      // Never widen on error: a failed probe yields whatever was collected.
+      this.logger?.warn?.('[approvals] participant-visibility probe failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return ids;
+  }
+
+  /** Intersect an existing `where.id` constraint with the participant set. */
+  private applyVisibility(where: any, visible: Set<string> | null): boolean {
+    if (!visible) return true;
+    if (visible.size === 0) return false;
+    let allowed = [...visible];
+    const current = where.id;
+    if (typeof current === 'string') allowed = allowed.filter((x) => x === current);
+    else if (current && typeof current === 'object' && Array.isArray(current.$in)) {
+      const set = new Set(current.$in.map((v: unknown) => String(v)));
+      allowed = allowed.filter((x) => set.has(x));
+    }
+    if (allowed.length === 0) return false;
+    where.id = allowed.length === 1 ? allowed[0] : { $in: allowed };
+    return true;
+  }
+
   async listRequests(
     filter: {
       object?: string;
@@ -2717,6 +2809,11 @@ export class ApprovalService implements IApprovalService {
       if (ids.length === 0) return [];
       where.id = ids.length === 1 ? ids[0] : { $in: ids };
     }
+
+    // #3590: the caller-supplied `approverId` is a FILTER, not authorization —
+    // omitting it used to return every request in the tenant. Intersect with
+    // what this caller actually participates in.
+    if (!this.applyVisibility(where, await this.visibleRequestIds(context, tenantOrg))) return [];
 
     const findOpts: any = {
       where,
@@ -2753,6 +2850,9 @@ export class ApprovalService implements IApprovalService {
       where.id = ids.length === 1 ? ids[0] : { $in: ids };
     }
 
+    // #3590 — the count must agree with the list it paginates.
+    if (!this.applyVisibility(where, await this.visibleRequestIds(context, tenantOrg))) return 0;
+
     const countFn = (this.engine as any).count;
     if (typeof countFn === 'function') {
       try {
@@ -2769,7 +2869,33 @@ export class ApprovalService implements IApprovalService {
     return Array.isArray(rows) ? rows.length : 0;
   }
 
+  /**
+   * Read the request a write path just changed, to echo back as its result.
+   *
+   * NOT participant-gated (#3590), deliberately: the operation authorized
+   * itself by its own rule before writing, so re-asking "may you see this?"
+   * for the echo answers a question that has already been settled — and would
+   * answer it WRONG for a caller context that carries no `userId` (a
+   * flow-driven resume, a service-to-service call), turning a successful write
+   * into a `null` result. Gating belongs on the read API, not on an
+   * operation's own return value.
+   */
+  private async readBackRequest(
+    requestId: string,
+    context: SharingExecutionContext,
+  ): Promise<ApprovalRequestRow | null> {
+    return this.loadRequest(requestId, context, false);
+  }
+
   async getRequest(requestId: string, context: SharingExecutionContext): Promise<ApprovalRequestRow | null> {
+    return this.loadRequest(requestId, context, true);
+  }
+
+  private async loadRequest(
+    requestId: string,
+    context: SharingExecutionContext,
+    enforceVisibility: boolean,
+  ): Promise<ApprovalRequestRow | null> {
     if (!requestId) return null;
     const where: any = { id: requestId };
     const tenantOrg = (context as any)?.organizationId ?? (context as any)?.tenantId;
@@ -2778,6 +2904,13 @@ export class ApprovalService implements IApprovalService {
       where, limit: 1, context: SYSTEM_CTX,
     });
     if (!Array.isArray(rows) || !rows[0]) return null;
+    // #3590: tenant scoping alone let any authenticated user read any request
+    // — and, once decision attachments derived their access from the request
+    // (#3580), its files too. Participation is the rest of the rule.
+    if (enforceVisibility) {
+      const visible = await this.visibleRequestIds(context, tenantOrg ?? null);
+      if (visible && !visible.has(String(rows[0].id))) return null;
+    }
     const row = rowFromRequest(rows[0]);
     await this.enrichRows([row]);
     await this.attachFlowSteps(row);


### PR DESCRIPTION
Fixes #3590。

## 问题

`getRequest` / `listRequests` / `countRequests` **故意用 `SYSTEM_CTX` 查询以绕过 RLS**——代码自己的注释说明了原因:

> we deliberately query with SYSTEM_CTX to bypass RLS on the engine (**the approver-visibility rule spans three identity forms, which RLS can't model cleanly**)

但绕过 RLS 之后,**只实现了「租户」那一半**。注释点名的「审批人可见性」那一半**从来没有被写出来**。

后果:**同租户内任何登录用户可以读取任意审批请求**——它的 payload 快照、完整决策历史,以及在 #3580 让决策附件从请求派生访问权之后,**它的文件**。

而 `listRequests` 上的 `approverId` 是**过滤器,不是授权**:不传它就返回整个租户。

## 修法

新增参与者判定:**提交人 / 当前审批人(走归一化审批人索引,覆盖写路径记录的每种身份形态)/ 已经在其上行动过的人**(槽位已流转的历史审批人、评论者)。具备 override 权限的管理员保留不受限视图(「所有请求」控制台视图依赖它);无 token 的上下文什么都看不到。

**为什么用具体 user id 就够,而不是近似?** 这点必须说清楚,因为这里**授权不足会静默隐藏别人必须处理的审批**:

- position / team / manager / field 类审批人在**开单时就已解析成具体 user id**
- `type:value` 字面量**只是解析到「无人」时的兜底**——那种槽位任何人都无法行动(`can_act` 就是对已解析 id 的朴素成员测试)

所以这条规则**不可能把请求从真正能处理它的人眼前藏起来**。

## ⚠️ 写路径的返回值不再次判权

每个操作都会通过 `getRequest` 回读它刚改过的请求作为返回值。操作在写之前**已经用自己的规则授过权**,再问一次是在重复回答一个已定的问题——而且对**不带 `userId` 的上下文**(flow 驱动的 resume、服务间调用)会答**错**,把一次成功的写入变成 `null` 结果。

**4 个既有测试正好抓到了这个**,所以回读改走 `readBackRequest`。这不是为了让测试变绿——是我第一版实现真的有这个缺陷。

## 浏览器验证(app-showcase)

| 场景 | 修复前 | 修复后 |
|---|---|---|
| Ada(非管理员,只是 expense 的审批人)不带过滤器列请求 | 3 条(整个租户) | ✅ **1 条**(只有她的) |
| Dev Admin 列请求 | 3 条 | ✅ **3 条**(控制台视图保留) |
| Ada 下载自己经手请求的附件 | 200 | ✅ **200**,真实 PDF 字节(**#3580 正常复合**) |
| Ada 读她无关请求的时间线 | 200,2 行 | ✅ **空** |

## 测试

`approval-service.test.ts` **+8**:提交人/审批人可读、同租户陌生人不可读、行动过的人在槽位流转后保留访问、override 管理员不受限、无 token fail closed、`listRequests` 不带过滤器不再返回整租户、`countRequests` 与列表一致、**无 `userId` 的写路径仍能回显自己的结果**。

另外修正了两条断言旧(泄漏)行为的既有测试——其中 `can_override` 那条改用**提交人**而不是陌生人,保留它原本要验的语义(权限有无,而不是访问有无)。

全量:plugin-approvals **210** ✅ · service-storage **173** ✅ · spec **6733** ✅ · lint ✅ · nul-bytes ✅

## 破坏性

标 `!`:此前不带 `approverId` 列请求并期望拿到整个租户的客户端,现在只会拿到自己的——**这正是修复的目的**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHpGw3GBA9aFpfwVArRWfd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHpGw3GBA9aFpfwVArRWfd)_