### PR TITLE
fix(analytics): make the read-scope auto-bridge order-independent + first real e2e RLS gate (#3618)

### DIFF
--- a/.changeset/analytics-read-scope-bridge-order.md
+++ b/.changeset/analytics-read-scope-bridge-order.md
@@ -1,0 +1,28 @@
+---
+"@objectstack/service-analytics": patch
+---
+
+fix(analytics): the read-scope auto-bridge no longer depends on plugin order (#3618)
+
+`getReadScope` was only wired when the `security` service already existed at this
+plugin's `init()`. The closure itself resolved lazily, but the ASSIGNMENT was
+gated on an init-time probe — so a kernel that registers `AnalyticsServicePlugin`
+before the security plugin got **no read-scope provider at all**, and every
+analytics strategy ran unscoped with only a WARN to show for it.
+
+Both sibling bridges (`executeAggregate`, `executeRawSql`) are wired
+unconditionally and resolve at call time, and this one's own comment claimed the
+same. Now it actually does: the probe only decides the log wording.
+
+The CLI (`os serve`) registers security before analytics, so that path was
+already correct. The exposure was for embedders composing their own kernel — and
+for this repo's own `bootStack` harness, which registers analytics first, meaning
+the entire dogfood/verify suite had analytics RLS silently disabled and any RLS
+assertion written there passed vacuously.
+
+Also corrects the WARN text: with no provider, scoping is absent on ALL paths and
+ALL objects, not just "the raw-SQL path" and "joined objects" as it claimed.
+
+Adds `analytics-rls.dogfood.test.ts`: an owner-scoped RLS fixture driven over real
+HTTP as a real non-admin, asserting the rows a member's aggregate actually
+returns. Reverting either this fix or the #3597 strategy fix turns it red.

--- a/packages/qa/dogfood/test/analytics-rls.dogfood.test.ts
+++ b/packages/qa/dogfood/test/analytics-rls.dogfood.test.ts
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// END-TO-END gate for #3597 — "analytics aggregates are scoped to the caller",
+// proven through the REAL stack: HTTP → REST execution context → SecurityPlugin
+// → the AnalyticsServicePlugin auto-bridges → ObjectQL/NativeSQL strategies.
+//
+// #3597 was a cross-tenant disclosure: ObjectQLStrategy never consumed
+// `getReadScope`, and the `executeAggregate` bridge passes no ExecutionContext,
+// so plugin-security's principal-less fall-open skipped its own RLS injection
+// too. Both belts were off at once and an authenticated non-admin received
+// aggregates computed over every row in the table.
+//
+// Every pre-existing analytics RLS test injects `getReadScope` as a fake into a
+// hand-built AnalyticsService. NONE booted the real plugin, so the
+// `getReadScope → security.getReadFilter` auto-bridge (plugin.ts:291-305) had
+// zero coverage — which is how the gap shipped. This test closes that: it
+// asserts on ROWS RETURNED to a real non-admin over HTTP, not on a filter object.
+//
+// Owner-scoped (`created_by`), not org-scoped, on purpose: a wildcard
+// `organization_id` policy is STRIPPED when the enterprise `org-scoping` service
+// is absent, which it is in this OSS workspace. An owner policy references
+// `current_user.id` and survives single-tenant boots — so this gate actually
+// bites on every CI run instead of silently passing.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { bootStack, type VerifyStack } from '@objectstack/verify';
+import {
+  rlsFixtureStack,
+  ownerScopedMemberSet,
+  rlsFixtureSecurity,
+} from './fixtures/rls-owner-fixture.js';
+
+const ADMIN_NOTES = 3;
+const MEMBER_NOTES = 2;
+
+/**
+ * Date-bucketed dataset. The granularity is what makes this interesting:
+ * `NativeSQLStrategy.canHandle` DECLINES any query carrying a
+ * `dateGranularity` (native-sql-strategy.ts:30), so this routes to
+ * ObjectQLStrategy — the leaking path — even on a SQL-capable driver.
+ */
+const notesByDay = {
+  name: 'notes_by_day',
+  label: 'Notes by day',
+  object: 'rls_note',
+  dimensions: [
+    { name: 'created', label: 'Created', field: 'created_at', type: 'date', dateGranularity: 'day' },
+  ],
+  measures: [{ name: 'cnt', label: 'Count', aggregate: 'count' }],
+};
+
+/** Same object, NO granularity → stays on NativeSQLStrategy. The control. */
+const notesTotal = {
+  name: 'notes_total',
+  label: 'Notes total',
+  object: 'rls_note',
+  dimensions: [],
+  measures: [{ name: 'cnt', label: 'Count', aggregate: 'count' }],
+};
+
+describe('dogfood: analytics aggregates are RLS-scoped to the caller (#3597)', () => {
+  let stack: VerifyStack;
+  let adminToken: string;
+  let memberToken: string;
+
+  beforeAll(async () => {
+    stack = await bootStack(rlsFixtureStack as never, {
+      security: rlsFixtureSecurity(ownerScopedMemberSet),
+    });
+
+    // First user is the seeded dev admin; every later sign-up is a plain member
+    // that falls back to the owner-scoped fixture permission set.
+    adminToken = await stack.signIn();
+    memberToken = await stack.signUp('analytics-rls@verify.test');
+
+    // Author through HTTP as each principal so `created_by` is stamped with the
+    // real caller — the whole point of an owner policy.
+    for (let i = 0; i < ADMIN_NOTES; i++) {
+      const r = await stack.apiAs(adminToken, 'POST', '/data/rls_note', {
+        name: `admin-note-${i}`,
+        body: 'owned by admin',
+      });
+      expect(r.status).toBeLessThan(300);
+    }
+    for (let i = 0; i < MEMBER_NOTES; i++) {
+      const r = await stack.apiAs(memberToken, 'POST', '/data/rls_note', {
+        name: `member-note-${i}`,
+        body: 'owned by member',
+      });
+      expect(r.status).toBeLessThan(300);
+    }
+
+    // Premise check — if the owner policy is not actually biting on the plain
+    // read path, an analytics assertion below would pass for the wrong reason.
+    const list = await stack.apiAs(memberToken, 'GET', '/data/rls_note');
+    const listed = (await list.json()) as { records?: Array<{ name: string }> };
+    expect(listed.records ?? []).toHaveLength(MEMBER_NOTES);
+    expect((listed.records ?? []).every((r) => r.name.startsWith('member-note'))).toBe(true);
+  }, 90_000);
+
+  afterAll(async () => {
+    await stack?.stop();
+  });
+
+  async function totalFor(token: string, dataset: unknown, dimensions: string[]): Promise<number> {
+    const res = await stack.apiAs(token, 'POST', '/analytics/dataset/query', {
+      dataset,
+      selection: { dimensions, measures: ['cnt'] },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { rows?: Array<Record<string, number>> };
+    return (body.rows ?? []).reduce((sum, row) => sum + Number(row.cnt ?? 0), 0);
+  }
+
+  it('ObjectQL path (date-bucketed): a member counts ONLY their own rows', async () => {
+    // Before #3601 this returned ADMIN_NOTES + MEMBER_NOTES — the member saw a
+    // count over rows RLS forbids them from reading.
+    const seen = await totalFor(memberToken, notesByDay, ['created']);
+    expect(seen).toBe(MEMBER_NOTES);
+  });
+
+  it('NativeSQL path (no granularity): a member counts ONLY their own rows', async () => {
+    const seen = await totalFor(memberToken, notesTotal, []);
+    expect(seen).toBe(MEMBER_NOTES);
+  });
+
+  it('the two strategies agree for the same principal', async () => {
+    const viaObjectql = await totalFor(memberToken, notesByDay, ['created']);
+    const viaNativeSql = await totalFor(memberToken, notesTotal, []);
+    expect(viaObjectql).toBe(viaNativeSql);
+  });
+
+  it('the rows the member cannot see DO exist — scoping, not an empty table', async () => {
+    // Ground truth straight from the engine under a system context: the table
+    // really holds every note. Without this, "member counts 2" would also pass
+    // on a broken setup that simply never persisted the admin's rows.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ql = await stack.kernel.getServiceAsync<any>('objectql');
+    const all = (await ql.find('rls_note', { context: { isSystem: true } })) as unknown[];
+    expect(all).toHaveLength(ADMIN_NOTES + MEMBER_NOTES);
+
+    const memberSees = await totalFor(memberToken, notesByDay, ['created']);
+    expect(memberSees).toBe(MEMBER_NOTES);
+    expect(memberSees).toBeLessThan(all.length);
+  });
+});

--- a/packages/services/service-analytics/src/plugin.ts
+++ b/packages/services/service-analytics/src/plugin.ts
@@ -290,6 +290,7 @@ export class AnalyticsServicePlugin implements Plugin {
     }
     let getReadScope = this.options.getReadScope;
     let autoBridgedReadScope = false;
+    let securityPresentAtInit = false;
     if (!getReadScope) {
       const trySecurity = (): SecurityReadFilter | undefined => {
         try {
@@ -299,10 +300,17 @@ export class AnalyticsServicePlugin implements Plugin {
           return undefined;
         }
       };
-      if (trySecurity()) {
-        getReadScope = (object, context) => trySecurity()?.getReadFilter(object, context);
-        autoBridgedReadScope = true;
-      }
+      // ALWAYS wire the bridge — resolution happens at call time, mirroring the
+      // executeAggregate / executeRawSql auto-bridges above. Gating the
+      // ASSIGNMENT on an init-time probe (as this did) made analytics RLS
+      // silently plugin-ORDER-DEPENDENT: a kernel that registers this plugin
+      // before the security plugin got NO read-scope provider at all, so every
+      // strategy ran unscoped and only a WARN marked it. The repo's own
+      // `bootStack` harness registers in exactly that order, which is why no
+      // dogfood test could ever observe analytics RLS.
+      securityPresentAtInit = !!trySecurity();
+      getReadScope = (object, context) => trySecurity()?.getReadFilter(object, context);
+      autoBridgedReadScope = true;
     }
 
     // ADR-0021 — relationship → target-object resolver. A dataset's `include`
@@ -457,12 +465,20 @@ export class AnalyticsServicePlugin implements Plugin {
       draftRowsResolver,
     };
 
-    if (autoBridgedReadScope) {
+    if (autoBridgedReadScope && securityPresentAtInit) {
       ctx.logger.info('[Analytics] Auto-bridged getReadScope → "security" service (getReadFilter)');
+    } else if (autoBridgedReadScope) {
+      // The bridge IS wired and will resolve at call time — this is only a
+      // heads-up that security had not registered yet at our init. It becomes a
+      // real problem only if no security service ever appears.
+      ctx.logger.info(
+        '[Analytics] getReadScope bridged to the "security" service; that service is not ' +
+        'registered yet at init and will be resolved per query (plugin order is not significant).',
+      );
     } else if (!getReadScope) {
       ctx.logger.warn(
         '[Analytics] No getReadScope configured and no "security" service with getReadFilter found — ' +
-        'the raw-SQL analytics path will NOT enforce tenant/RLS scoping on joined objects (ADR-0021 D-C). ' +
+        'analytics queries will NOT enforce tenant/RLS scoping (ADR-0021 D-C). ' +
         'Supply getReadScope or register a security service in multi-tenant deployments.',
       );
     }


### PR DESCRIPTION
Closes #3618. 端到端补上 #3597 我明确说过**没做**的那一环。

## 起因:门先红了,但不是为 #3597 红的

给 #3597 写真实栈端到端门时,member 的聚合在**两条 strategy 上都**返回全表 5 行 —— 连 #3601 刚修好的 NativeSQL 路径也漏。前提检查是过的(`GET /data/rls_note` 只返回 member 自己的 2 条),说明 owner 策略在普通读路径上生效。

日志给出了答案:

```
WARN [Analytics] No getReadScope configured and no "security" service with getReadFilter found
INFO [Analytics] Auto-bridged executeAggregate → "data" service
INFO [Analytics] Auto-bridged executeRawSql → "data" service
```

另外两个桥都接上了,**只有 read-scope 桥没接**。

## 缺陷:代码和它自己的注释矛盾

`plugin.ts:277-306` 注释写着 *"resolved at call time so plugin-init order does not matter"*,但:

```ts
if (trySecurity()) {                                        // ← 卡在 init 时刻的探测
  getReadScope = (object, context) => trySecurity()?.getReadFilter(object, context);
}
```

闭包是懒的,可**赋值本身**被 init 时刻的探测卡住了。security 晚注册 ⇒ `getReadScope` 恒 `undefined` ⇒ `callCtx` 在 `analytics-service.ts:332` 直接 `return this.baseCtx` ⇒ 两条 strategy 都不加 scope。

两个兄弟桥都是对的,只有它不是 —— `executeRawSql` 的注释甚至明写 *"**Always wire the bridge**... plugin-init order does not matter"*。

## 影响面(诚实划界)

**生产 CLI 不受影响**:`os serve` 里 SecurityPlugin 在 `serve.ts:1658`,analytics 由 capability resolver 在其之后加载,顺序正确。

受影响的是:

1. **自建 kernel 的 embedder** —— 框架按库分发,谁把 analytics 排在 security 前面就静默失去 analytics RLS,唯一提示是一条措辞还偏小的 WARN。
2. **仓库自己的 `bootStack`** —— analytics 在 `harness.ts:159`,security 在 `:232`。**整个 dogfood/verify 套件的 analytics RLS 一直是关的**,那里写的任何 analytics RLS 断言都是空过的。

## 修复

`getReadScope` 无条件接线,探测只用来决定日志措辞 —— 与两个兄弟桥一致。顺带改掉 WARN 的错误措辞(原文说只影响 "raw-SQL path" 的 "joined objects";实际没 provider 时所有路径所有对象都不加 scope)。

## 新增的门

`packages/qa/dogfood/test/analytics-rls.dogfood.test.ts` —— **第一个真正跑通 `getReadScope → security.getReadFilter` 自动桥的测试**。此前所有 analytics RLS 测试都是往手搓的 `AnalyticsService` 注入假 `getReadScope`,所以这条桥零覆盖,这也正是缺陷能活下来的原因。

断言的是**真实非管理员经 HTTP 拿到的行**,不是某个 filter 对象:

- ObjectQL 路径(带 `dateGranularity`,NativeSQL 会声明失败)→ member 只数到自己的 2 行
- NativeSQL 路径(无 granularity)→ 同样 2 行
- 两条路径互相一致
- **地基断言**:系统上下文下全表确有 5 行 —— 排除"member 数到 2 是因为表里本来就只有 2 行"这种假绿

用 owner-scoped(`created_by`)而非 org-scoped 是刻意的:没有企业版 `org-scoping` 服务时,wildcard `organization_id` 策略会被**剥掉**,门会静默常绿。owner 策略引用 `current_user.id`,单租户 boot 下依然生效。

## 验证

- 新门 4/4 绿;**回退本 PR 的 `plugin.ts` 改动 → 红 3 个**;回退 #3601 的 strategy 改动 → ObjectQL 那条红。
- `@objectstack/service-analytics` **179 passed**。
- **完整 dogfood 门:61 files / 355 tests 全绿**(本地全仓 build 后跑的)。
- `tsc --noEmit` 未引入新错误(该包 2 个存量错误在我没碰的测试文件里)。

## 待核

`cloud` 是独立仓库,我没检查它的插件注册顺序。**若任何已发布 composition 用了不利顺序,#3618 应升级到 p1。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
