### PR TITLE
chore(ci): cut PR wall-clock ~9.5min → ~5-6min — dedupe dogfood, shard it, cache lint's build

### DIFF
--- a/.changeset/ci-performance-optimization.md
+++ b/.changeset/ci-performance-optimization.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI-only: exclude the dogfood suite from Test Core (the dedicated Dogfood job runs it), shard the Dogfood gate 2-way, add the missing turbo cache to lint's typecheck job, and cancel superseded lint/CodeQL runs. Releases nothing.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,18 +130,25 @@ jobs:
       # --concurrency=4: turbo's default (10) oversubscribes the 4-vCPU
       # hosted runner; matching the core count bounds peak memory and the
       # job is CPU-bound anyway.
+      # !@objectstack/dogfood: the ~7½-minute dogfood suite is the dedicated
+      # Dogfood job's whole purpose, and both jobs run under the same `core`
+      # filter — without the exclusion every core PR executed the suite twice
+      # in parallel, and it dominated this job's critical path. The exclusion
+      # subtracts from the affected set (verified: turbo unions inclusive
+      # filters, then applies `!` negations to the result).
       - name: Run affected tests (PR)
         if: github.event_name == 'pull_request'
         env:
           TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
-        run: pnpm turbo run test --affected --concurrency=4
+        run: pnpm turbo run test --affected --filter=!@objectstack/dogfood --concurrency=4
 
       # Push to main: full run, but exclude spec's plain test task — the
       # coverage step below executes the exact same 250-file spec suite once,
-      # with coverage. Previously the spec suite ran twice per push.
+      # with coverage. Previously the spec suite ran twice per push. Dogfood is
+      # excluded for the same reason as the PR step: the Dogfood job runs it.
       - name: Run all tests (push)
         if: github.event_name == 'push'
-        run: pnpm turbo run test --filter=!@objectstack/spec --concurrency=4
+        run: pnpm turbo run test --filter=!@objectstack/spec --filter=!@objectstack/dogfood --concurrency=4
 
       - name: Generate coverage report
         if: github.event_name == 'push'
@@ -156,12 +163,22 @@ jobs:
           retention-days: 30
 
   dogfood:
-    name: Dogfood Regression Gate
+    # Sharded 2-way: the suite is ~60 independent test files, each booting its
+    # own in-process app, and a single 4-vCPU runner needed ~7½ minutes for the
+    # lot — the longest pole in the whole workflow. vitest partitions the file
+    # list deterministically across shards; both shards must pass. If branch
+    # protection lists "Dogfood Regression Gate" as a required check, it must be
+    # updated to the two sharded check names.
+    name: Dogfood Regression Gate (${{ matrix.shard }}/2)
     needs: filter
     if: needs.filter.outputs.core == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
 
     steps:
       - name: Checkout repository
@@ -191,14 +208,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-v3-
 
+      # Shard-scoped key: the turbo test hash differs per shard (pass-through
+      # args are part of the task hash), and two same-named matrix jobs would
+      # otherwise race to save one cache entry per sha.
       - name: Setup Turbo cache
         uses: actions/cache@v6
         with:
           path: .turbo/cache
-          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.shard }}-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-turbo-${{ github.job }}-${{ github.ref_name }}-
-            ${{ runner.os }}-turbo-${{ github.job }}-
+            ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.shard }}-${{ github.ref_name }}-
+            ${{ runner.os }}-turbo-${{ github.job }}-${{ matrix.shard }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -206,15 +226,19 @@ jobs:
       # Boots real example apps in-process (in-memory SQLite) and exercises them
       # through the real HTTP + service stack — catches runtime regressions that
       # build / unit tests / spec-liveness pass over (e.g. the #2018 tz-bucketing
-      # break, which was green on every static gate).
+      # break, which was green on every static gate). The `--` args reach the
+      # package's `vitest run` and are hashed into the turbo task, so each
+      # shard caches independently.
       - name: Boot example apps and exercise real user flows
-        run: pnpm turbo run test --filter=@objectstack/dogfood
+        run: pnpm turbo run test --filter=@objectstack/dogfood -- --shard=${{ matrix.shard }}/2
 
       # Replaces the former auto-verify dogfood tests: runs the published
       # `objectstack verify` engine over each example app through the CLI —
       # auto-derived CRUD round-trip fidelity + the cross-owner RLS invariant.
       # Exits non-zero on a real runtime failure, so it gates like the tests did.
+      # Not shard-dependent, so shard 1 alone runs it.
       - name: Verify example apps via the `objectstack verify` CLI
+        if: matrix.shard == 1
         run: |
           pnpm turbo run build --filter=@objectstack/cli
           for app in examples/app-crm examples/app-showcase; do

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,13 @@ on:
     # Run at 02:00 UTC every Monday
     - cron: '0 2 * * 1'
 
+# A superseded analysis of an outdated commit has no value — cancel it. PR runs
+# group by PR number; push/schedule runs group by ref, so a newer main push
+# cancels only an in-flight main analysis (the newer commit gets analyzed).
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,13 @@ on:
     branches:
       - main
 
+# Same policy as ci.yml: superseded runs on the same PR/branch waste runners
+# and delay feedback; cancel them. Push runs to main group by commit ref, so an
+# in-flight main run is cancelled only by a newer main push.
+concurrency:
+  group: lint-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   lint:
@@ -132,6 +139,20 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-v3-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-v3-
+
+      # This job runs the full workspace build below ("Build workspace
+      # packages"); without a restored turbo cache that step rebuilt every
+      # package from scratch on every run (~4½ min) while ci.yml's jobs — which
+      # do carry this cache — finished the same build in under a minute. Same
+      # key scheme as ci.yml so the fallback prefix can also hit main's caches.
+      - name: Setup Turbo cache
+        uses: actions/cache@v6
+        with:
+          path: .turbo/cache
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.job }}-${{ github.ref_name }}-
+            ${{ runner.os }}-turbo-${{ github.job }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Why

Job-level timing of recent PR runs shows where the time actually goes:

| Job | Wall time | Long pole |
|---|---|---|
| CI / Test Core | 9m21s | `turbo run test --affected` — 8m35s |
| CI / Dogfood Regression Gate | 8m41s | dogfood suite — 7m34s |
| Lint / TypeScript Type Check | 6m09s | `turbo run build` — 4m38s (no cache) |
| CodeQL | ~4m | analysis (parallel, acceptable) |

Two structural problems dominate: **the dogfood suite ran twice per core PR** (once in its dedicated job, once again inside Test Core's affected set, in parallel on two runners), and **lint's typecheck job is the only build-running job with no turbo cache**, so it rebuilt the entire workspace from scratch on every run — the identical build takes 51s in ci.yml's cached Build Core job.

## What

1. **Exclude `@objectstack/dogfood` from Test Core** (both the PR `--affected` run and the push run). The dedicated Dogfood job — gated on the same `core` filter — remains the sole, unconditional runner of the suite. Verified locally: turbo unions inclusive filters and then subtracts `!` negations, so `--affected --filter=!@objectstack/dogfood` is exactly "affected minus dogfood" (140 → 137 tasks, nothing else dropped).

2. **Shard the Dogfood job 2-way** (`vitest run --shard=N/2`, ~60 independent test files, deterministic file-level partition). The shard arg passes through turbo and is part of the turbo task hash, so each shard caches independently (verified: distinct hashes). The `objectstack verify` CLI step is shard-independent and runs on shard 1 only. Turbo cache keys are shard-scoped so the two matrix jobs don't race on one cache entry.

3. **Add the missing turbo cache step to lint's typecheck job** — same key scheme as ci.yml, so the fallback prefix also hits caches saved by main pushes.

4. **Add `concurrency` cancel-in-progress to lint.yml and codeql.yml** (ci.yml already has it). Both trigger on every PR sync; superseded runs were burning runners and delaying the queue.

## Expected effect

- CI workflow: ~9.5min → **~5–6min** (Test Core sheds the duplicated 7.5-min suite; Dogfood halves to ~4–5min per shard).
- Lint workflow: ~6min → **~2–2.5min** on warm cache.
- Meaningful runner-minute savings per PR sync from de-duplication + cancellation.

## Verification

- `turbo run test --affected --filter=!@objectstack/dogfood --dry=json` with a spec change: dogfood excluded, all other affected tasks intact.
- `vitest run --shard=1/30` in `packages/qa/dogfood`: 3 files / 13 tests, green — sharding partitions and runs correctly.
- Full-chain smoke of the exact CI command shape: `turbo run test --filter=@objectstack/dogfood -- --shard=1/30` → 61 tasks successful, exit 0.
- `--dry=json` task-hash comparison between `--shard=1/2` and `--shard=2/2`: hashes differ, so per-shard turbo caching is safe.
- All three YAML files parse.

## ⚠️ Action needed at merge time

If branch protection lists **"Dogfood Regression Gate"** as a required status check, it must be updated to the two sharded check names (`Dogfood Regression Gate (1/2)` / `Dogfood Regression Gate (2/2)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECTCrcCdZpCHw5zFSgcmGt

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECTCrcCdZpCHw5zFSgcmGt)_