### PR TITLE
fix(release): hotcrm compat gate is advisory in RC pre-mode — unblock the v17 train

### DIFF
--- a/.changeset/release-hotcrm-gate-premode.md
+++ b/.changeset/release-hotcrm-gate-premode.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI-only: the live-hotcrm backward-compat gate in release.yml is advisory while changesets pre-mode is active, so the RC train can form its Version Packages PR; it re-arms automatically at `changeset pre exit`. Releases nothing.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,18 @@ jobs:
         # typecheck + `objectstack validate`. A red here blocks the publish.
         # The deterministic in-repo floor is @objectstack/downstream-contract;
         # this is the live ceiling.
+        #
+        # RC pre-mode amendment (#3600): while .changeset/pre.json says
+        # mode:"pre", the smoke still runs and reports but does NOT block. A
+        # major train exists precisely to ship deliberate surface removals, and
+        # a hotcrm release migrated off them cannot exist until the rc.N
+        # artifacts it would migrate against are published — blocking here
+        # deadlocks the train (observed 2026-07-27: every Release run red on
+        # the v17 window's removals, so the changesets step never even created
+        # the Version Packages PR). The gate re-arms by itself the moment
+        # `changeset pre exit` lands (mode flips / pre.json is consumed) —
+        # exactly when a migrated hotcrm must exist and HOTCRM_REF gets bumped
+        # per the note below.
         env:
           # v2.1.0: hotcrm upgraded to ObjectStack 14.7 (hotcrm#448) and
           # dropped the agent `visibility` field that spec 15 removes as
@@ -79,7 +91,17 @@ jobs:
           # Bump this ref whenever a deliberate spec surface removal ships a
           # matching hotcrm release.
           HOTCRM_REF: v2.1.0
-        run: bash scripts/downstream-smoke.sh
+        run: |
+          if [ "$(jq -r '.mode // empty' .changeset/pre.json 2>/dev/null)" = "pre" ]; then
+            echo "::notice::Changesets pre-mode active — the hotcrm smoke is advisory (reported, non-blocking) until 'changeset pre exit'."
+            if bash scripts/downstream-smoke.sh; then
+              echo "::notice::hotcrm@${HOTCRM_REF} is still compatible with the pre-release train."
+            else
+              echo "::warning::hotcrm@${HOTCRM_REF} is incompatible with the pre-release train — expected for the window's deliberate removals. Ship a migrated hotcrm release and bump HOTCRM_REF before 'changeset pre exit' re-arms this gate."
+            fi
+          else
+            bash scripts/downstream-smoke.sh
+          fi
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
## Why — every Release run on main is red, and the train is deadlocked

Every push to main today fails the Release workflow at **"Downstream backward-compat smoke (live hotcrm)"**. The gate typechecks hotcrm@v2.1.0 (a real third-party consumer on ObjectStack 14.7) against the unreleased spec, and it fails on exactly the surface the v17 major deliberately removes:

- first the localization-config narrowing (`fileOrganization` no longer accepted where hotcrm's `objectstack.config.ts` puts it),
- then the #3543 ApiMethod enum shrink (`"search"` / `"export"` / `"aggregate"` gone from 10 object files).

#3600 entered changesets pre-mode (tag `rc`) this morning specifically so the accumulated breaking window computes to `17.0.0-rc.0` and rc.N pre-releases can go out for downstream validation. But this gate sits **before** `changesets/action`, so the job dies before the Version Packages PR is even created — while a hotcrm release migrated off the removals cannot exist until the rc.N artifacts it would migrate against are published. Chicken-and-egg: the gate can never go green inside the window it is blocking.

## What

While `.changeset/pre.json` declares `mode:"pre"`, the smoke still runs — clone, install, overlay, typecheck, validate — and reports its outcome via `::notice`/`::warning`, but it no longer fails the job. With `pre.json` absent or `mode:"exit"` (the moment `changeset pre exit` lands), the gate blocks exactly as before — which is also exactly when a migrated hotcrm release must exist and `HOTCRM_REF` gets bumped per the step's existing protocol comment.

No script changes; `scripts/downstream-smoke.sh` is untouched. An empty changeset declares the PR releases nothing.

## Verification

All four guard paths simulated locally with a stubbed smoke script and real `pre.json` fixtures:

| pre.json | smoke result | step outcome |
|---|---|---|
| `mode:"pre"` | fail | `::warning`, **exit 0** (train unblocked) |
| `mode:"pre"` | pass | `::notice`, exit 0 |
| absent | fail | **exit 1** (gate blocks, unchanged) |
| `mode:"exit"` | fail | **exit 1** (gate re-armed) |

YAML parses cleanly. The real proof lands on the first main push after merge: the Release run should proceed past the smoke (with a `::warning`) and let `changesets/action` create the `chore: version packages` PR for `17.0.0-rc.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECTCrcCdZpCHw5zFSgcmGt

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECTCrcCdZpCHw5zFSgcmGt)_