### PR TITLE
fix(release): rename stale @objectstack/create-objectstack refs in pending changesets

### DIFF
--- a/.changeset/better-auth-1-7-0-rc-2-and-prod-dep-batch.md
+++ b/.changeset/better-auth-1-7-0-rc-2-and-prod-dep-batch.md
@@ -3,7 +3,7 @@
 "@objectstack/platform-objects": major
 "@objectstack/client": major
 "@objectstack/cli": patch
-"@objectstack/create-objectstack": patch
+"create-objectstack": patch
 "@objectstack/plugin-hono-server": patch
 "@objectstack/plugin-pinyin-search": patch
 "@objectstack/hono": patch

--- a/.changeset/fix-stale-scaffolder-changeset-refs.md
+++ b/.changeset/fix-stale-scaffolder-changeset-refs.md
@@ -1,0 +1,4 @@
+---
+---
+
+Repo-plumbing only: two pending changesets referenced the scaffolder by its old `@objectstack/create-objectstack` name, which `changeset version` rejects because the workspace package is named `create-objectstack`. Renamed the entries; releases nothing by itself.

--- a/.changeset/osv-batch-2026-07-dep-bumps.md
+++ b/.changeset/osv-batch-2026-07-dep-bumps.md
@@ -1,5 +1,5 @@
 ---
-"@objectstack/create-objectstack": patch
+"create-objectstack": patch
 "@objectstack/metadata": patch
 ---
 


### PR DESCRIPTION
## Why — the v17 train's next (and only remaining) blocker

With the hotcrm gate now advisory in pre-mode (#3627), the Release run on main got past the smoke for the first time all day — and immediately hit the next failure, inside `pnpm run version`:

```
🦋 error Error: Found changeset better-auth-1-7-0-rc-2-and-prod-dep-batch
   for package @objectstack/create-objectstack which is not in the workspace
```

`changeset version` hard-fails on any changeset that names a package not present in the workspace. Two pending changesets still reference the scaffolder by its old scoped name `@objectstack/create-objectstack`, while the workspace package (and its `pre.json` initialVersions entry) is named **`create-objectstack`**:

- `.changeset/better-auth-1-7-0-rc-2-and-prod-dep-batch.md`
- `.changeset/osv-batch-2026-07-dep-bumps.md`

A full sweep of every `.changeset/*.md` frontmatter against `pnpm m ls` (78 workspace packages) found exactly these two stale references — nothing else.

## What

Renamed the two entries to `"create-objectstack": patch` (the bump intent is preserved — both batches touch scaffolder deps). Added an empty changeset to satisfy the Check Changeset gate; it releases nothing.

## Verification

- `pnpm exec changeset status` reproduced the exact CI error before the rename, and assembles the release plan cleanly after it.
- Full end-to-end run of the CI command `pnpm run version` (`changeset version` + protocol/template sync scripts) completes cleanly and computes **`17.0.0-rc.0`** across the fixed group, including the blank-template lockstep sync (8 `@objectstack/*` ranges → `^17.0.0`, `engines.protocol` → `^17`). Version artifacts were discarded after verification; only the changeset renames ship.

After merge, the next Release run on main should finally create the `chore: version packages` PR for `17.0.0-rc.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECTCrcCdZpCHw5zFSgcmGt

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECTCrcCdZpCHw5zFSgcmGt)_