### PR TITLE
docs(hono): catch-all 现场裁决锚点 (#3608 归档前置)

### DIFF
--- a/packages/adapters/hono/src/index.ts
+++ b/packages/adapters/hono/src/index.ts
@@ -359,6 +359,16 @@ export function createHonoApp(options: ObjectStackHonoOptions): Hono {
   // ─── Catch-all: delegate to dispatcher.dispatch() ─────────────────────────
   // Handles meta, data, packages, analytics, automation, i18n, ui, openapi,
   // custom API endpoints, and any future routes added to HttpDispatcher.
+  //
+  // DELIBERATE SHAPE — read before "improving" this into explicit per-prefix
+  // mounts (ADR-0076 OQ#9 verdict, #3576 / #3608): dispatch() is a thin
+  // gates+registry pipeline (env resolution → identity → auth gate →
+  // membership → scope strip, then a first-match DomainHandlerRegistry
+  // lookup — enumerable via registry.list()). A naive split into
+  // `app.all(prefix + domain + '/*')` mounts bypasses those cross-cutting
+  // gate stages (the #2852 RLS-leak class: handlers running without an
+  // ExecutionContext). Revisit only if the gate stages are middleware-ized
+  // for an independent reason — reopen conditions are archived on #3608.
   app.all(`${prefix}/*`, async (c) => {
     try {
       const subPath = c.req.path.substring(prefix.length);


### PR DESCRIPTION
一行防撞锚点：想把 catch-all"改进"成显式 per-prefix 挂载的人，第一现场是这行代码而非 issue 列表。注释指向 ADR-0076 OQ#9 裁决（#3576）与 naive split 会触发的 #2852 RLS 泄漏类故障模式；重启条件归档于 #3608（本 PR 合并后按 deliberately-unscheduled 关闭）。

纯注释，零行为变化。skip-changeset。

🤖 Generated with [Claude Code](https://claude.com/claude-code)