### PR TITLE
feat(showcase): add the action disabled-predicate specimen (Archive)

### DIFF
--- a/.changeset/showcase-action-disabled-specimen.md
+++ b/.changeset/showcase-action-disabled-specimen.md
@@ -1,0 +1,4 @@
+---
+---
+
+feat(showcase): add the action `disabled`-predicate specimen (`showcase_archive_task`) — greyed until `record.done`, contrasting `visible` (hide) with `disabled` (grey). Examples-only; releases nothing.

--- a/examples/app-showcase/src/ui/actions/index.ts
+++ b/examples/app-showcase/src/ui/actions/index.ts
@@ -235,6 +235,37 @@ export const ActionParamGalleryAction = defineAction({
   refreshAfter: false,
 });
 
+/**
+ * script — the `disabled` predicate specimen. Where `visible` HIDES an action
+ * (see MarkDoneAction), `disabled` keeps it ON SCREEN but greyed until its
+ * precondition holds: Archive stays visible on every task and only becomes
+ * clickable once the task is done. Same authoring rules as `visible`
+ * (`record.`-prefixed, single comparison; disabled when the CEL is TRUE).
+ * Exercises the renderer-side wiring (objectui: DeclaredActionsBar +
+ * action:button/group/icon/menu) that #1885's follow-through completed.
+ */
+export const ArchiveTaskAction = defineAction({
+  name: 'showcase_archive_task',
+  label: 'Archive',
+  icon: 'archive',
+  objectName: task,
+  type: 'script',
+  body: {
+    language: 'js',
+    // No destructive side effect — the specimen's value is the disabled
+    // behavior itself; echo which record would be archived.
+    source:
+      "var id = ctx.recordId || (ctx.record && ctx.record.id) || input.recordId;" +
+      "return { ok: true, archived: id };",
+    capabilities: [],
+  },
+  successMessage: 'Task archived (demo — no data changed).',
+  // Disabled while the task is not done — visible either way.
+  disabled: 'record.done != true',
+  locations: ['record_header', 'record_section'],
+  refreshAfter: false,
+});
+
 export const allActions = [
   MarkDoneAction,
   OpenDocsAction,
@@ -245,4 +276,5 @@ export const allActions = [
   NewTaskAction,
   SubmitForSignoffAction,
   ActionParamGalleryAction,
+  ArchiveTaskAction,
 ];

--- a/examples/app-showcase/src/ui/pages/task-detail.page.ts
+++ b/examples/app-showcase/src/ui/pages/task-detail.page.ts
@@ -61,7 +61,10 @@ export const TaskDetailPage = definePage({
           properties: {
             location: 'record_section',
             align: 'start',
-            actionNames: ['showcase_mark_done', 'showcase_log_time'],
+            // showcase_archive_task is the `disabled`-predicate specimen:
+            // visible on every task, greyed until `record.done` (contrast with
+            // showcase_mark_done's `visible`, which HIDES once done).
+            actionNames: ['showcase_mark_done', 'showcase_log_time', 'showcase_archive_task'],
           },
         },
         {


### PR DESCRIPTION
Companion to objectui `fix/action-disabled-all-renderers` (the #1885 follow-through). Refs #1878 (§3 naming-drift item "action `disabled`").

## What

`showcase_archive_task` — the `disabled`-predicate specimen. Where MarkDone's `visible: '!record.done'` **hides** once done, Archive's `disabled: 'record.done != true'` stays on screen and **greys** until the task is done. Added to the task-detail `record:quick_actions` bar (`actionNames` is an explicit list — a new action doesn't surface without being named; that discovery cost one round of dogfooding).

## Why

`report.chart` taught us the lesson (#3496): a live path with no showcase coverage rots invisibly. The spec `disabled` field had **zero** first-party usage, which is exactly why five objectui rendering surfaces could ignore it undetected. This specimen keeps the wire hot.

## Verification

Browser-verified against the objectui fix worktree:
- **In-progress task** (Build homepage): Archive rendered **disabled** (greyed), Mark Done / Log Time active.
- **Done task** (Audit current IA): Archive **clickable**; Mark Done hidden by its own `visible` — the hide-vs-grey contrast on one screen.
- Showcase suite 58/58 green (coverage test walks `allActions` and picked the new action up automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)