### PR TITLE
fix(ci): 恢复稳定的 "Dogfood Regression Gate" 必需检查名 — 全仓 PR 死锁修复

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,35 @@ jobs:
             echo "::endgroup::"
           done
 
+  dogfood-gate:
+    # Stable required-check name for a SHARDED job (#3622 follow-up).
+    #
+    # Branch protection requires the context "Dogfood Regression Gate". Once
+    # the job became a 2-way matrix its checks publish as "Dogfood Regression
+    # Gate (1/2)" / "(2/2)" — the bare context could never appear again, so
+    # EVERY pull request in the repo sat permanently BLOCKED (mergeable, all
+    # checks green, merge button dead). #3622's own comment called for updating
+    # branch protection; keeping the contract HERE instead means a future
+    # shard-count change cannot deadlock the repo a second time.
+    #
+    # `if: always()` + result inspection so a legitimately skipped matrix (the
+    # `filter` job says no core paths changed) still satisfies the gate.
+    name: Dogfood Regression Gate
+    needs: dogfood
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Verify dogfood shard results
+        run: |
+          result="${{ needs.dogfood.result }}"
+          echo "dogfood matrix aggregate result: $result"
+          case "$result" in
+            success|skipped) echo "Dogfood gate satisfied." ;;
+            *) echo "::error::Dogfood shards did not pass (aggregate result: $result)"; exit 1 ;;
+          esac
+
   build-core:
     name: Build Core
     needs: filter


### PR DESCRIPTION
## 事故：全仓所有开放 PR 卡死

复现：任取一个开放 PR，`mergeable: MERGEABLE`、所有 check 绿、`mergeStateStatus: BLOCKED`，合并按钮不可用（实测 #3637/#3638/#3639/#3640/#3401 全中）。

**根因**：#3622 把 dogfood job 分片成 2 路矩阵，check 名变为 `Dogfood Regression Gate (1/2)` / `(2/2)`；而分支保护要求的是**裸名** `Dogfood Regression Gate`——现在没有任何 job 产出这个名字，该必需项**永远无法满足**。#3622 自己的注释写了"若分支保护要求该名，必须更新为两个分片名"，但那步没有执行。

## 修法：契约留在代码里，不动保护设置

新增一个极小的聚合 job 承载稳定名 `Dogfood Regression Gate`，`needs: dogfood`，按矩阵聚合结果判定：

- `success` / `skipped`（filter 判定未触及 core 路径时矩阵合法跳过）→ 通过；
- 其余 → 失败并打印聚合结果。

好处：**将来再改分片数不会二次死锁**（不必每次同步改保护设置），且无需管理员改仓库配置。

## 合并说明

本 PR 修的正是"阻止一切合并"的那个门，存在鸡生蛋问题——需以管理员权限合入一次，此后所有 PR（含本 PR 之后的）恢复正常合并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)