### PR TITLE
test(auth): cover the lock itself and its expiry, not just the counter (#3624 follow-up)

### DIFF
--- a/.changeset/two-factor-lockout-extension.md
+++ b/.changeset/two-factor-lockout-extension.md
@@ -1,0 +1,4 @@
+---
+---
+
+test-only: extends the 2FA lockout dogfood cover (#3624 follow-up). No package changes, nothing to release.

--- a/packages/qa/dogfood/test/two-factor-lockout.dogfood.test.ts
+++ b/packages/qa/dogfood/test/two-factor-lockout.dogfood.test.ts
@@ -213,4 +213,78 @@ describe('#3624 follow-up: better-auth 2FA lockout counts wrong codes', () => {
     ).toBe(0);
     expect(after.lockedUntil ?? null).toBeNull();
   });
+
+  it('locks the account once the budget is spent, and refuses even a correct code', async () => {
+    // Two budgets stack here, and the test has to respect both. better-auth
+    // allows MAX_PER_CHALLENGE verifications per two-factor cookie
+    // (`beginAttempt(5)`) and MAX_FAILURES consecutive failures per ACCOUNT
+    // (`accountLockout.maxFailedAttempts`, default 10). Only the second one
+    // touches the columns under test, so reaching it takes a fresh challenge
+    // every MAX_PER_CHALLENGE tries. Both are better-auth's defaults — the
+    // auth manager passes no `accountLockout` config.
+    const MAX_PER_CHALLENGE = 5;
+    const MAX_FAILURES = 10;
+
+    expect((await lockoutState()).count, 'precondition: a clean budget').toBe(0);
+
+    let failures = 0;
+    while (failures < MAX_FAILURES) {
+      const cookie = await beginChallenge();
+      for (let i = 0; i < MAX_PER_CHALLENGE && failures < MAX_FAILURES; i++) {
+        const res = await verifyWithCookie(cookie, '000000');
+        expect(res.status, `wrong code #${failures + 1} produced a server error`).toBeLessThan(500);
+        failures++;
+        expect(
+          (await lockoutState()).count,
+          `the counter must advance on every failure (after #${failures})`,
+        ).toBe(failures);
+      }
+    }
+
+    const locked = await lockoutState();
+    expect(
+      locked.lockedUntil ?? null,
+      `budget spent (${MAX_FAILURES} failures) but locked_until was never stamped`,
+    ).not.toBeNull();
+    expect(new Date(String(locked.lockedUntil)).getTime()).toBeGreaterThan(Date.now());
+
+    // The lock has to bite BEFORE the code is checked — otherwise it is not a
+    // lockout, just a slower guess loop.
+    const cookie = await beginChallenge();
+    const rejected = await verifyWithCookie(cookie, totp(secret));
+    expect(
+      rejected.status,
+      `a locked account must refuse even a valid code: ${await rejected.clone().text()}`,
+    ).toBe(429);
+  });
+
+  it('lazily clears an expired lock on the next attempt', async () => {
+    const before = await lockoutState();
+    expect(before.lockedUntil ?? null, 'precondition: carries the lock from the previous test').not.toBeNull();
+
+    // Expire the lock rather than waiting out `durationSeconds` (900 by
+    // default). This is the one place the test reaches past the API: there is
+    // no endpoint that ages a lock.
+    const users = await ql.find('sys_user', { where: { email: adminEmail }, limit: 1 }, SYS);
+    const rows = await ql.find('sys_two_factor', { where: { user_id: String(users[0]?.id) }, limit: 1 }, SYS);
+    await ql.update(
+      'sys_two_factor',
+      { id: rows[0].id, locked_until: new Date(Date.now() - 60_000).toISOString() },
+      SYS,
+    );
+
+    // better-auth clears an expired lock through a GUARDED incrementOne —
+    // `where locked_until <= now`, `set { failedVerificationCount: 0,
+    // lockedUntil: null }`. That is the only place the adapter has to handle
+    // `lte` against a datetime, so this covers the operator as much as the
+    // columns: a driver that mishandled it would leave the user locked out
+    // forever with no error anywhere.
+    const cookie = await beginChallenge();
+    const ok = await verifyWithCookie(cookie, totp(secret));
+    expect(ok.status, `expired lock was not cleared: ${await ok.clone().text()}`).toBe(200);
+
+    const after = await lockoutState();
+    expect(after.lockedUntil ?? null, 'the expired lock must be cleared, not merely ignored').toBeNull();
+    expect(after.count, 'clearing an expired lock must reset the failure budget too').toBe(0);
+  });
 });


### PR DESCRIPTION
接 #3659。那个 PR 钉住了 2FA 失败预算的两端 —— 输错会被计数、输对会清零 —— 但停在了让它成为**锁定**而非单纯计数器的那几步转移上,而那才是真正保护账户的部分。

补三条断言:

**1. 锁真的会落。** 预算耗尽后 `locked_until` 被戳上一个未来时间。

走到这一步要同时尊重两个叠在一起的预算:better-auth 每个 two-factor cookie 只允许 5 次验证(`beginAttempt(5)`),每个**账户**允许 10 次连续失败(`accountLockout.maxFailedAttempts`)。**只有后者碰得到本次要测的两个列**,所以循环每 5 次就得换一个新 challenge。计数器在**每一次**失败后都断言,不是只在最后看一眼。

**2. 锁在验码之前就生效。** 已锁定的账户连**正确**的 TOTP 也拒(429)。没有这条,所谓"锁定"不过是一个慢一点的爆破循环。

**3. 过期的锁会自己清掉。** better-auth 清锁走的是一个**带 guard 的 `incrementOne`** —— `where locked_until <= now`,`set { failedVerificationCount: 0, lockedUntil: null }`。

这是整个适配器里**唯一**需要处理 `lte` 对 datetime 的地方,所以这条断言覆盖的不只是列,还有那个操作符:驱动一旦处理错,用户会被**永久**锁死,而且任何地方都不会报错。测试通过数据引擎把锁提前到过期(默认时长 900 秒,没有端点能加速它)—— 这是全文件唯一一处伸手绕过 API 的地方,已在注释里写明原因。

## 测试

`two-factor-lockout.dogfood.test.ts` 4 passed;连同 `org-create-default-team.dogfood.test.ts` 一起 5 passed。

纯测试改动,且 `@objectstack/dogfood` 是 private 包,所以配的是空 changeset(仓库认可的"本 PR 不发布任何东西"声明)。

Refs #3624, #3647, #3659。

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYLC8TfjzHGwatNxZKdX7H)_