### PR TITLE
fix(i18n): clear the accumulated drift in the generated translation bundles

### DIFF
--- a/.changeset/i18n-bundle-drift-sweep.md
+++ b/.changeset/i18n-bundle-drift-sweep.md
@@ -1,0 +1,30 @@
+---
+"@objectstack/platform-objects": patch
+---
+
+fix(i18n): clear the accumulated drift in the generated translation bundles
+
+The committed bundles had fallen behind the spec on three independent axes.
+`os i18n extract` (merge mode — every existing translation is preserved)
+reconciles all of them:
+
+**Keys the spec no longer has**, still carrying translations in
+`*.metadata-forms.generated.ts`. All three were removed deliberately and are
+now *rejected* by the schema, so their entries were dead weight:
+
+- `capabilities.trash` / `capabilities.mru` — `enable.trash`/`enable.mru`
+  retired in the 16.x line (#2377), with tombstone guidance in
+  `UNKNOWN_KEY_GUIDANCE`.
+- agent `visibility` — removed 2026-07 (#1901).
+
+**Keys the spec gained** but the bundles never learned: the
+`summaryOperations.*` sub-fields (`object` / `function` / `field` /
+`relationshipField` / `filter`), and `sys_invitation.business_unit_id` /
+`positions` from the ADR-0105 D8 placement work.
+
+**Objects stuck on empty strings.** `sys_migration`'s labels and help text were
+committed as `""` in the ja-JP and es-ES bundles, which renders as *blank* in
+those locales rather than falling back to anything readable. They now carry the
+schema text like every other untranslated key.
+
+No API or schema change — this only affects what the UI displays.

--- a/packages/platform-objects/src/apps/translations/en.metadata-forms.generated.ts
+++ b/packages/platform-objects/src/apps/translations/en.metadata-forms.generated.ts
@@ -248,12 +248,6 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
       "capabilities.activities": {
         label: "Activities"
       },
-      "capabilities.trash": {
-        label: "Trash"
-      },
-      "capabilities.mru": {
-        label: "Mru"
-      },
       "capabilities.clone": {
         label: "Clone"
       },
@@ -427,6 +421,26 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
       summaryOperations: {
         label: "Summary Operations",
         helpText: "Roll-up summary configuration (for parent-child relationships)"
+      },
+      "summaryOperations.object": {
+        label: "Object",
+        helpText: "Child object to aggregate"
+      },
+      "summaryOperations.function": {
+        label: "Function",
+        helpText: "Aggregation function"
+      },
+      "summaryOperations.field": {
+        label: "Field",
+        helpText: "Child field to aggregate (ignored for count)"
+      },
+      "summaryOperations.relationshipField": {
+        label: "Relationship Field",
+        helpText: "Child FK back to this parent (auto-detected when omitted)"
+      },
+      "summaryOperations.filter": {
+        label: "Filter",
+        helpText: "Only child rows matching this predicate are aggregated (e.g. status == received)"
       },
       externalId: {
         label: "External Id",
@@ -1611,10 +1625,6 @@ export const enMetadataForms: NonNullable<TranslationData['metadataForms']> = {
       knowledge: {
         label: "Knowledge",
         helpText: "RAG knowledge access configuration"
-      },
-      visibility: {
-        label: "Visibility",
-        helpText: "Scope: global, organization, or private"
       },
       access: {
         label: "Access",

--- a/packages/platform-objects/src/apps/translations/en.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/en.objects.generated.ts
@@ -664,6 +664,14 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
       team_id: {
         label: "Team",
         help: "Optional team to assign upon acceptance"
+      },
+      business_unit_id: {
+        label: "Placement Business Unit",
+        help: "Business unit the invitee is placed under on acceptance (ADR-0105 D8). Must lie inside the issuer's delegated subtree."
+      },
+      positions: {
+        label: "Placement Positions",
+        help: "sys_position names assigned on acceptance (ADR-0105 D8). Every position's permission sets must be allowlisted by the issuer's adminScope."
       }
     },
     _views: {

--- a/packages/platform-objects/src/apps/translations/es-ES.metadata-forms.generated.ts
+++ b/packages/platform-objects/src/apps/translations/es-ES.metadata-forms.generated.ts
@@ -248,12 +248,6 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
       "capabilities.activities": {
         label: "Actividades"
       },
-      "capabilities.trash": {
-        label: "Papelera"
-      },
-      "capabilities.mru": {
-        label: "Uso reciente"
-      },
       "capabilities.clone": {
         label: "Clonar"
       },
@@ -427,6 +421,26 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
       summaryOperations: {
         label: "Operaciones de resumen",
         helpText: "Configuración de resumen roll-up (para relaciones padre-hijo)"
+      },
+      "summaryOperations.object": {
+        label: "Object",
+        helpText: "Child object to aggregate"
+      },
+      "summaryOperations.function": {
+        label: "Function",
+        helpText: "Aggregation function"
+      },
+      "summaryOperations.field": {
+        label: "Field",
+        helpText: "Child field to aggregate (ignored for count)"
+      },
+      "summaryOperations.relationshipField": {
+        label: "Relationship Field",
+        helpText: "Child FK back to this parent (auto-detected when omitted)"
+      },
+      "summaryOperations.filter": {
+        label: "Filter",
+        helpText: "Only child rows matching this predicate are aggregated (e.g. status == received)"
       },
       externalId: {
         label: "ID externo",
@@ -1611,10 +1625,6 @@ export const esESMetadataForms: NonNullable<TranslationData['metadataForms']> = 
       knowledge: {
         label: "Conocimiento",
         helpText: "Configuración de acceso a conocimiento RAG"
-      },
-      visibility: {
-        label: "Visibilidad",
-        helpText: "Ámbito: global, organization o private"
       },
       access: {
         label: "Acceso",

--- a/packages/platform-objects/src/apps/translations/es-ES.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/es-ES.objects.generated.ts
@@ -664,6 +664,14 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
       team_id: {
         label: "Equipo",
         help: "Equipo opcional que se asignará al aceptar."
+      },
+      business_unit_id: {
+        label: "Placement Business Unit",
+        help: "Business unit the invitee is placed under on acceptance (ADR-0105 D8). Must lie inside the issuer's delegated subtree."
+      },
+      positions: {
+        label: "Placement Positions",
+        help: "sys_position names assigned on acceptance (ADR-0105 D8). Every position's permission sets must be allowlisted by the issuer's adminScope."
       }
     },
     _views: {
@@ -3072,43 +3080,43 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
     }
   },
   sys_migration: {
-    label: "",
-    pluralLabel: "",
-    description: "",
+    label: "Data Migration",
+    pluralLabel: "Data Migrations",
+    description: "Deployment-level data-migration flags: which gated data migrations ran here and whether their self-check passed.",
     fields: {
       id: {
-        label: "",
-        help: ""
+        label: "Migration ID",
+        help: "Well-known migration id (e.g. adr-0104-file-references). One row per migration."
       },
       last_run_at: {
-        label: "",
-        help: ""
+        label: "Last Run At",
+        help: "When this migration last completed a gated (apply-mode) run on this deployment."
       },
       verified_at: {
-        label: "",
-        help: ""
+        label: "Verified At",
+        help: "When the self-check last PASSED. Null until it does, and cleared again by a later failing run — a regression closes the gate. Consumers require this to be set AND blocking = 0."
       },
       applied_at: {
-        label: "",
-        help: ""
+        label: "Applied At",
+        help: "When the backfill last ran in apply mode (writes enabled)."
       },
       blocking: {
-        label: "",
-        help: ""
+        label: "Blocking Discrepancies",
+        help: "Blocking discrepancies reported by the last self-check. The gate requires 0."
       },
       advisory: {
-        label: "",
-        help: ""
+        label: "Advisory Findings",
+        help: "Advisory findings from the last run (external URLs, stale owners, …) — cost storage or need a modelling decision, never block the gate."
       },
       details: {
-        label: "",
-        help: ""
+        label: "Details (JSON)",
+        help: "JSON-encoded counts from the last run, for diagnostics."
       },
       created_at: {
-        label: ""
+        label: "Created At"
       },
       updated_at: {
-        label: ""
+        label: "Updated At"
       }
     }
   }

--- a/packages/platform-objects/src/apps/translations/ja-JP.metadata-forms.generated.ts
+++ b/packages/platform-objects/src/apps/translations/ja-JP.metadata-forms.generated.ts
@@ -248,12 +248,6 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
       "capabilities.activities": {
         label: "活動"
       },
-      "capabilities.trash": {
-        label: "ごみ箱"
-      },
-      "capabilities.mru": {
-        label: "最近使用"
-      },
       "capabilities.clone": {
         label: "複製"
       },
@@ -427,6 +421,26 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
       summaryOperations: {
         label: "集計操作",
         helpText: "ロールアップ集計設定（親子関係用）"
+      },
+      "summaryOperations.object": {
+        label: "Object",
+        helpText: "Child object to aggregate"
+      },
+      "summaryOperations.function": {
+        label: "Function",
+        helpText: "Aggregation function"
+      },
+      "summaryOperations.field": {
+        label: "Field",
+        helpText: "Child field to aggregate (ignored for count)"
+      },
+      "summaryOperations.relationshipField": {
+        label: "Relationship Field",
+        helpText: "Child FK back to this parent (auto-detected when omitted)"
+      },
+      "summaryOperations.filter": {
+        label: "Filter",
+        helpText: "Only child rows matching this predicate are aggregated (e.g. status == received)"
       },
       externalId: {
         label: "外部 ID",
@@ -1611,10 +1625,6 @@ export const jaJPMetadataForms: NonNullable<TranslationData['metadataForms']> = 
       knowledge: {
         label: "ナレッジ",
         helpText: "RAG ナレッジアクセス設定"
-      },
-      visibility: {
-        label: "可視範囲",
-        helpText: "スコープ: global, organization, または private"
       },
       access: {
         label: "アクセス",

--- a/packages/platform-objects/src/apps/translations/ja-JP.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/ja-JP.objects.generated.ts
@@ -664,6 +664,14 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
       team_id: {
         label: "チーム",
         help: "承認時に割り当てるオプションのチーム"
+      },
+      business_unit_id: {
+        label: "Placement Business Unit",
+        help: "Business unit the invitee is placed under on acceptance (ADR-0105 D8). Must lie inside the issuer's delegated subtree."
+      },
+      positions: {
+        label: "Placement Positions",
+        help: "sys_position names assigned on acceptance (ADR-0105 D8). Every position's permission sets must be allowlisted by the issuer's adminScope."
       }
     },
     _views: {
@@ -3072,43 +3080,43 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
     }
   },
   sys_migration: {
-    label: "",
-    pluralLabel: "",
-    description: "",
+    label: "Data Migration",
+    pluralLabel: "Data Migrations",
+    description: "Deployment-level data-migration flags: which gated data migrations ran here and whether their self-check passed.",
     fields: {
       id: {
-        label: "",
-        help: ""
+        label: "Migration ID",
+        help: "Well-known migration id (e.g. adr-0104-file-references). One row per migration."
       },
       last_run_at: {
-        label: "",
-        help: ""
+        label: "Last Run At",
+        help: "When this migration last completed a gated (apply-mode) run on this deployment."
       },
       verified_at: {
-        label: "",
-        help: ""
+        label: "Verified At",
+        help: "When the self-check last PASSED. Null until it does, and cleared again by a later failing run — a regression closes the gate. Consumers require this to be set AND blocking = 0."
       },
       applied_at: {
-        label: "",
-        help: ""
+        label: "Applied At",
+        help: "When the backfill last ran in apply mode (writes enabled)."
       },
       blocking: {
-        label: "",
-        help: ""
+        label: "Blocking Discrepancies",
+        help: "Blocking discrepancies reported by the last self-check. The gate requires 0."
       },
       advisory: {
-        label: "",
-        help: ""
+        label: "Advisory Findings",
+        help: "Advisory findings from the last run (external URLs, stale owners, …) — cost storage or need a modelling decision, never block the gate."
       },
       details: {
-        label: "",
-        help: ""
+        label: "Details (JSON)",
+        help: "JSON-encoded counts from the last run, for diagnostics."
       },
       created_at: {
-        label: ""
+        label: "Created At"
       },
       updated_at: {
-        label: ""
+        label: "Updated At"
       }
     }
   }

--- a/packages/platform-objects/src/apps/translations/zh-CN.metadata-forms.generated.ts
+++ b/packages/platform-objects/src/apps/translations/zh-CN.metadata-forms.generated.ts
@@ -248,12 +248,6 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
       "capabilities.activities": {
         label: "活动"
       },
-      "capabilities.trash": {
-        label: "回收站"
-      },
-      "capabilities.mru": {
-        label: "最近使用"
-      },
       "capabilities.clone": {
         label: "克隆"
       },
@@ -427,6 +421,26 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
       summaryOperations: {
         label: "汇总操作",
         helpText: "父子关系下的汇总聚合配置"
+      },
+      "summaryOperations.object": {
+        label: "Object",
+        helpText: "Child object to aggregate"
+      },
+      "summaryOperations.function": {
+        label: "Function",
+        helpText: "Aggregation function"
+      },
+      "summaryOperations.field": {
+        label: "Field",
+        helpText: "Child field to aggregate (ignored for count)"
+      },
+      "summaryOperations.relationshipField": {
+        label: "Relationship Field",
+        helpText: "Child FK back to this parent (auto-detected when omitted)"
+      },
+      "summaryOperations.filter": {
+        label: "Filter",
+        helpText: "Only child rows matching this predicate are aggregated (e.g. status == received)"
       },
       externalId: {
         label: "外部 ID",
@@ -1611,10 +1625,6 @@ export const zhCNMetadataForms: NonNullable<TranslationData['metadataForms']> = 
       knowledge: {
         label: "知识",
         helpText: "RAG 知识访问配置"
-      },
-      visibility: {
-        label: "可见范围",
-        helpText: "范围：全局、组织或私有"
       },
       access: {
         label: "访问",

--- a/packages/platform-objects/src/apps/translations/zh-CN.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/zh-CN.objects.generated.ts
@@ -664,6 +664,14 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
       team_id: {
         label: "团队",
         help: "接受邀请后可选分配的团队"
+      },
+      business_unit_id: {
+        label: "Placement Business Unit",
+        help: "Business unit the invitee is placed under on acceptance (ADR-0105 D8). Must lie inside the issuer's delegated subtree."
+      },
+      positions: {
+        label: "Placement Positions",
+        help: "sys_position names assigned on acceptance (ADR-0105 D8). Every position's permission sets must be allowlisted by the issuer's adminScope."
       }
     },
     _views: {


### PR DESCRIPTION
收尾 #3659 刻意留下的那一块。

那个 PR 只重新生成了 `*.objects.generated.ts`,**明确排除了** metadata-forms 的四个 bundle —— 因为同一次 extract 会**删除**一些 key,而当时我还没核实它是不是在丢弃已经翻好的内容。

现在核实了:**没有丢。** 整个 diff 里的删除只有三条,全都是 spec 已经移除、作者**再也写不出来**的 key:

| 被删的 key | 状态 |
|:---|:---|
| `capabilities.trash` / `capabilities.mru` | `enable.trash`/`enable.mru` 在 16.x 线被移除(#2377),schema 现在**直接拒绝**,并在 `UNKNOWN_KEY_GUIDANCE` 里留了 tombstone 指引 |
| agent `visibility` | 2026-07 移除(#1901) |

## 同一次扫描还补上了 bundle 从没学会的 key

- `summaryOperations.{object,function,field,relationshipField,filter}` —— 字段汇总配置的子项,spec 里一直有(`field.zod.ts:440`)
- `sys_invitation.{business_unit_id,positions}` —— ADR-0105 D8 的 placement 字段

## 以及第三个、独立的问题:空字符串

`sys_migration` 的 label 和 help 在 **ja-JP 和 es-ES** 两个 bundle 里是以**空字符串**提交的。

空字符串不等于"未翻译的 key" —— 它会**渲染成空白**,所以那个对象在这两个 locale 下**根本没有可读的标签**。现在它和其他未翻译 key 一样带上 schema 原文。

## 安全性

以 merge 模式运行(`--no-merge` 未传),所有既有翻译都保留;整个 diff 里的删除只有上面那三条死 key。

## 测试

`@objectstack/platform-objects` 223 passed (6 files) —— 含 bundle-ownership 守卫。

Refs #3624, #3659, #2377, #1901。

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYLC8TfjzHGwatNxZKdX7H)_