### PR TITLE
fix(ci): dogfood gate passes cancelled runs through — a cancelled matrix is not a failed one

### DIFF
--- a/.changeset/dogfood-gate-cancelled-not-failure.md
+++ b/.changeset/dogfood-gate-cancelled-not-failure.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI-only: the Dogfood Regression Gate no longer reports a superseded (cancelled) run as a failure — `cancelled` joins the pass branch, backed by a fail-fast experiment showing a real shard failure always aggregates as `failure`. Releases nothing.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,8 +286,21 @@ jobs:
         run: |
           result="${{ needs.dogfood.result }}"
           echo "dogfood matrix aggregate result: $result"
+          # cancelled is a run-lifecycle state, not a shard verdict (#3668):
+          # with cancel-in-progress on, every superseded push cancelled the
+          # in-flight dogfood matrix — the longest job, so almost always the
+          # one still running — and the old `*)` fallthrough painted a false
+          # red on the old SHA. Verified experimentally (run 30271824408, a
+          # fail-fast matrix with one real failure + one cancelled sibling):
+          # a real shard failure DOMINATES the aggregate — it reads "failure",
+          # never "cancelled" — so "cancelled" here can only mean the whole
+          # run was stopped from outside (supersession, or a manual cancel —
+          # accepted trade-off), and passing it masks no regression.
+          # Deliberately NOT `if: !cancelled()` on the job instead: a skipped
+          # gate publishes no required-check context on the SHA, which is the
+          # #3622 merge-deadlock all over again.
           case "$result" in
-            success|skipped) echo "Dogfood gate satisfied." ;;
+            success|skipped|cancelled) echo "Dogfood gate satisfied ($result)." ;;
             *) echo "::error::Dogfood shards did not pass (aggregate result: $result)"; exit 1 ;;
           esac
 


### PR DESCRIPTION
Fixes #3668.

## Why

With `cancel-in-progress` on, every consecutive push cancels the in-flight run — and the dogfood matrix, as the longest job in the workflow, is almost always the one still running. The gate's catch-all `*)` branch turned `needs.dogfood.result == "cancelled"` into `exit 1`, painting a **false red on every superseded SHA** (two observed on #3660 alone, logs identical: `dogfood matrix aggregate result: cancelled`). False reds on a regression gate train people and agents to ignore the one check that must never be ignored.

## What

The issue's prescribed one-line fix: `cancelled` joins the pass branch —

```
success|skipped|cancelled) echo "Dogfood gate satisfied ($result)." ;;
```

— plus an inline comment recording the evidence and the rejected alternative.

## Safety premise — verified experimentally before landing, per the issue's own ask

The fix is only safe if a **real** shard failure can never surface as an aggregate `cancelled`. Ran the experiment ([run 30271824408](https://github.com/objectstack-ai/objectstack/actions/runs/30271824408), temporary workflow since removed from the branch): a `fail-fast: true` matrix where shard 1 exits 1 immediately and shard 2 sleeps until fail-fast cancels it mid-run — the harshest version of "failure and cancellation coexist".

Result: shard 1 concluded `failure`, shard 2 concluded `cancelled`, and the aggregate observer printed **`needs.matrix.result = failure`**. Failure dominates. An aggregate of `cancelled` therefore only occurs when the whole run is stopped from outside (concurrency supersession or manual cancel) with no leg having failed — passing it masks no regression.

Notes recorded in the inline comment:
- **Manual cancel of a head run now turns the gate green** — the issue's accepted trade-off (the superseded-SHA case, which is the overwhelming majority, is irrelevant to merging since branch protection evaluates the latest SHA).
- **`if: !cancelled()` on the job was deliberately rejected** (as the issue prescribes): a skipped gate publishes no required-check context on that SHA — the #3622 merge-deadlock again.
- `grep 'needs\..*\.result' .github/workflows/*.yml` confirms this is the only aggregate gate of this shape, so no sibling occurrences to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECTCrcCdZpCHw5zFSgcmGt