### PR TITLE
perf(dogfood): worker-shared plain-showcase boot — one boot per worker, not per file

### DIFF
--- a/.changeset/dogfood-shared-boot.md
+++ b/.changeset/dogfood-shared-boot.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI/test-only: dogfood suite splits into a `shared-showcase` vitest project (12 eligible files share one plain showcase boot per worker via `isolate: false`) and an `isolated` project keeping vitest defaults. Measured: ~93% of the gate's compute was per-file boot overhead. Releases nothing.

--- a/packages/qa/dogfood/test/form-self-auth.dogfood.test.ts
+++ b/packages/qa/dogfood/test/form-self-auth.dogfood.test.ts
@@ -9,9 +9,9 @@
 // while staying least-privilege. Proven at the engine boundary (the same
 // middleware the HTTP form-submit route flows through).
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import showcaseStack from '@objectstack/example-showcase';
-import { bootStack, type VerifyStack } from '@objectstack/verify';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { type VerifyStack } from '@objectstack/verify';
+import { getSharedShowcase } from './shared-showcase.js';
 
 const idOf = (r: any) => r?.id ?? r?.record?.id ?? r?.data?.id ?? r;
 
@@ -21,12 +21,10 @@ describe('ADR-0056 Option A — public-form grant (declaration-derived)', () => 
   let ql: any;
 
   beforeAll(async () => {
-    stack = await bootStack(showcaseStack);
+    stack = await getSharedShowcase();
     await stack.signIn();
     ql = await stack.kernel.getServiceAsync('objectql');
   }, 60_000);
-
-  afterAll(async () => { await stack?.stop(); });
 
   it('authorizes CREATE on exactly the declared object (no userId / no guest_portal)', async () => {
     const ctx = { publicFormGrant: { object: 'showcase_private_note' } };

--- a/packages/qa/dogfood/test/shared-showcase.ts
+++ b/packages/qa/dogfood/test/shared-showcase.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// Worker-scoped shared showcase stack for the `shared-showcase` vitest project.
+//
+// A plain `bootStack(showcaseStack)` costs ~7.8s per test file (~3.5s TS module
+// graph + ~4.1s kernel assembly, metadata parse, security/seed bootstrap) —
+// measured on a 4-vCPU class host. With the default isolated pool, each of the
+// files that boot the IDENTICAL plain showcase paid that price separately:
+// ~29 boots per suite run, ~25% of the whole gate's compute.
+//
+// The `shared-showcase` project runs with `isolate: false`, so files assigned
+// to the same worker share one module registry — this module's memoized boot
+// then runs once per WORKER (≤4 per run) instead of once per file. The suite
+// process tears the worker down at the end of the run; the stack is in-memory
+// SQLite, so no explicit stop() is needed (and shared files must NOT call
+// stack.stop() — that would kill the instance under the worker's later files).
+//
+// ELIGIBILITY — a file may use the shared stack ONLY if all of these hold:
+//   1. It boots `bootStack(showcaseStack)` or `bootStack(showcaseStack, {})` —
+//      no custom security/plugins/automation/multiTenant options.
+//   2. It does not mutate shared global surfaces: no /meta writes, no
+//      organization/business-unit creation, no permission-set metadata edits.
+//   3. Its assertions tolerate other files' rows existing in shared objects:
+//      no exact-count / exhaustive-list assertions over data it didn't create.
+//      Scope every list assertion to records the file itself created (unique
+//      emails / name prefixes).
+// Anything else stays in the `isolated` project (plain vitest defaults).
+import showcaseStack from '@objectstack/example-showcase';
+import { bootStack, type VerifyStack } from '@objectstack/verify';
+
+let booted: Promise<VerifyStack> | undefined;
+
+/** Boot (once per worker) and return the shared plain-showcase stack. */
+export function getSharedShowcase(): Promise<VerifyStack> {
+  booted ??= bootStack(showcaseStack).then(async (stack) => {
+    // First sign-in provisions the dev admin; later files' own signIn() calls
+    // are idempotent (~0.16s) and just mint fresh admin tokens.
+    await stack.signIn();
+    return stack;
+  });
+  return booted;
+}

--- a/packages/qa/dogfood/test/showcase-agent-intersection.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-agent-intersection.dogfood.test.ts
@@ -18,9 +18,9 @@
 //
 // @proof: showcase-agent-intersection
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import showcaseStack from '@objectstack/example-showcase';
-import { bootStack, type VerifyStack } from '@objectstack/verify';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { type VerifyStack } from '@objectstack/verify';
+import { getSharedShowcase } from './shared-showcase.js';
 
 const SYS = { isSystem: true } as const;
 
@@ -35,7 +35,7 @@ describe('showcase: ADR-0090 D10 agent intersection (served engine)', () => {
     (await ql.findOne('sys_user', { where: { email }, context: SYS }))?.id;
 
   beforeAll(async () => {
-    stack = await bootStack(showcaseStack);
+    stack = await getSharedShowcase();
     await stack.signIn(); // admin (ensures bootstrap)
     ownerTok = await stack.signUp('int-owner@verify.test');
     await stack.signUp('int-agent@verify.test');
@@ -65,10 +65,6 @@ describe('showcase: ADR-0090 D10 agent intersection (served engine)', () => {
       ?? (await ql.findOne('showcase_private_note', { where: { title: "delegator's own note" }, context: SYS }))?.id;
     expect(delsNoteId, "delegator's note id").toBeTruthy();
   }, 120_000);
-
-  afterAll(async () => {
-    await stack?.stop();
-  });
 
   // Agent context as it reaches the engine middleware (auth layer resolved the
   // agent's own grants into `permissions`; the delegator's are reconstructed

--- a/packages/qa/dogfood/test/showcase-agent-scope-ceiling.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-agent-scope-ceiling.dogfood.test.ts
@@ -18,9 +18,9 @@
 //
 // @proof: showcase-agent-scope-ceiling
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import showcaseStack from '@objectstack/example-showcase';
-import { bootStack, type VerifyStack } from '@objectstack/verify';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { type VerifyStack } from '@objectstack/verify';
+import { getSharedShowcase } from './shared-showcase.js';
 
 const SYS = { isSystem: true } as const;
 const idOf = (r: any): string => r?.id ?? r?.record?.id;
@@ -36,7 +36,7 @@ describe('showcase: ADR-0090 D10 agent scope ceiling (served engine)', () => {
     (await ql.findOne('sys_user', { where: { email }, context: SYS }))?.id;
 
   beforeAll(async () => {
-    stack = await bootStack(showcaseStack);
+    stack = await getSharedShowcase();
     await stack.signIn(); // admin bootstrap
     aliceTok = await stack.signUp('scope-alice@verify.test');
     ql = await stack.kernel.getServiceAsync('objectql');
@@ -49,10 +49,6 @@ describe('showcase: ADR-0090 D10 agent scope ceiling (served engine)', () => {
       ?? (await ql.findOne('showcase_private_note', { where: { title: 'Alice note' }, context: SYS }))?.id;
     expect(noteId, 'note id resolved').toBeTruthy();
   }, 120_000);
-
-  afterAll(async () => {
-    await stack?.stop();
-  });
 
   // The agent context exactly as the producer emits it: acting on behalf of
   // Alice, whose OWN grants are the scope-derived ceiling (no member baseline).

--- a/packages/qa/dogfood/test/showcase-anonymous-deny-surfaces.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-anonymous-deny-surfaces.dogfood.test.ts
@@ -12,9 +12,9 @@
 // is what a fresh production deployment gets) and asserts every surface denies
 // an anonymous caller with 401 while an authenticated member is unaffected.
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import showcaseStack from '@objectstack/example-showcase';
-import { bootStack, type VerifyStack } from '@objectstack/verify';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { type VerifyStack } from '@objectstack/verify';
+import { getSharedShowcase } from './shared-showcase.js';
 
 const OBJ = '/data/showcase_private_note';
 
@@ -23,12 +23,10 @@ describe('showcase: anonymous posture is uniform across surfaces (#2567)', () =>
   let memberToken: string;
 
   beforeAll(async () => {
-    stack = await bootStack(showcaseStack); // platform default (deny anonymous)
+    stack = await getSharedShowcase(); // platform default (deny anonymous)
     await stack.signIn();
     memberToken = await stack.signUp('surfaces-member@verify.test');
   }, 60_000);
-
-  afterAll(async () => { await stack?.stop(); });
 
   // ── /meta ──────────────────────────────────────────────────────────────
   it('anonymous GET /meta is denied (401)', async () => {
@@ -40,7 +38,6 @@ describe('showcase: anonymous posture is uniform across surfaces (#2567)', () =>
     const r = await stack.apiAs(memberToken, 'GET', '/meta');
     expect(r.status, 'authenticated metadata read must clear the auth gate').not.toBe(401);
   });
-
 
   // ── /data (surface-level; raw-hono handler proven in plugin-hono-server) ──
   it('anonymous READ of the data surface is denied (401)', async () => {

--- a/packages/qa/dogfood/test/showcase-anonymous-deny.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-anonymous-deny.dogfood.test.ts
@@ -9,9 +9,9 @@
 // Public forms survive the same default via the declaration-derived
 // publicFormGrant — see showcase-public-form.dogfood.test.ts.
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import showcaseStack from '@objectstack/example-showcase';
-import { bootStack, type VerifyStack } from '@objectstack/verify';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { type VerifyStack } from '@objectstack/verify';
+import { getSharedShowcase } from './shared-showcase.js';
 
 const OBJ = '/data/showcase_private_note';
 
@@ -20,12 +20,10 @@ describe('showcase: anonymous default-deny (ADR-0056 D2)', () => {
   let memberToken: string;
 
   beforeAll(async () => {
-    stack = await bootStack(showcaseStack); // harness boots on the platform default (deny anonymous)
+    stack = await getSharedShowcase(); // harness boots on the platform default (deny anonymous)
     await stack.signIn();
     memberToken = await stack.signUp('d2-member@verify.test'); // anonymous /auth call → proves control-plane is open
   }, 60_000);
-
-  afterAll(async () => { await stack?.stop(); });
 
   it('control-plane is open for anonymous (sign-up succeeded without a token)', () => {
     expect(memberToken, 'anonymous /auth/sign-up returned a token').toBeTruthy();

--- a/packages/qa/dogfood/test/showcase-declarative-rbac-seeding.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-declarative-rbac-seeding.dogfood.test.ts
@@ -7,20 +7,19 @@
 //
 // @proof: showcase-declarative-rbac-seeding
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import showcaseStack from '@objectstack/example-showcase';
-import { bootStack, type VerifyStack } from '@objectstack/verify';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { type VerifyStack } from '@objectstack/verify';
+import { getSharedShowcase } from './shared-showcase.js';
 
 describe('showcase: declarative RBAC seeding (ADR-0057 D6 / #2077)', () => {
   let stack: VerifyStack;
   let ql: any;
 
   beforeAll(async () => {
-    stack = await bootStack(showcaseStack);
+    stack = await getSharedShowcase();
     await stack.signIn();
     ql = await stack.kernel.getServiceAsync('objectql');
   }, 60_000);
-  afterAll(async () => { await stack?.stop(); });
 
   it('declared roles land in sys_position (was count = 0)', async () => {
     const roles = await ql.find('sys_position', { where: {}, context: { isSystem: true } });

--- a/packages/qa/dogfood/test/showcase-permission-zoo.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-permission-zoo.dogfood.test.ts
@@ -10,9 +10,9 @@
 //
 // @proof: showcase-permission-zoo
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import showcaseStack from '@objectstack/example-showcase';
-import { bootStack, type VerifyStack } from '@objectstack/verify';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { type VerifyStack } from '@objectstack/verify';
+import { getSharedShowcase } from './shared-showcase.js';
 
 const SYS = { isSystem: true } as const;
 
@@ -28,7 +28,7 @@ describe('showcase: ADR-0090 permission-model zoo', () => {
     (await ql.findOne('sys_user', { where: { email }, context: SYS }))?.id;
 
   beforeAll(async () => {
-    stack = await bootStack(showcaseStack);
+    stack = await getSharedShowcase();
     adminTok = await stack.signIn();
     ownerTok = await stack.signUp('zoo-owner@verify.test');
     plainTok = await stack.signUp('zoo-plain@verify.test');
@@ -74,10 +74,6 @@ describe('showcase: ADR-0090 permission-model zoo', () => {
     }
     expect(noteId, 'probe note id resolved').toBeTruthy();
   }, 120_000);
-
-  afterAll(async () => {
-    await stack?.stop();
-  });
 
   // ── The app seed can plant the platform org tree ─────────────────────────
   it('seeds the sys_business_unit tree with explicit ids and parent links', async () => {

--- a/packages/qa/dogfood/test/showcase-private-owd.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-private-owd.dogfood.test.ts
@@ -8,9 +8,9 @@
 // `owner_id`. This is the canonical "declare one word, get owner isolation"
 // capability — proven end-to-end through the real HTTP stack.
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import showcaseStack from '@objectstack/example-showcase';
-import { bootStack, type VerifyStack } from '@objectstack/verify';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { type VerifyStack } from '@objectstack/verify';
+import { getSharedShowcase } from './shared-showcase.js';
 
 const OBJ = '/data/showcase_private_note';
 const idOf = (b: any) => b?.id ?? b?.record?.id ?? b?.data?.id ?? b?.recordId;
@@ -23,7 +23,7 @@ describe('showcase: declarative private OWD (ADR-0056)', () => {
   let bNoteId: string;
 
   beforeAll(async () => {
-    stack = await bootStack(showcaseStack);
+    stack = await getSharedShowcase();
     await stack.signIn(); // seed dev admin (first user)
     aToken = await stack.signUp('owd-alice@verify.test');
     bToken = await stack.signUp('owd-bob@verify.test');
@@ -40,8 +40,6 @@ describe('showcase: declarative private OWD (ADR-0056)', () => {
     expect(aNoteId, 'alice note id').toBeTruthy();
     expect(bNoteId, 'bob note id').toBeTruthy();
   }, 60_000);
-
-  afterAll(async () => { await stack?.stop(); });
 
   it('owner_id is auto-stamped (no manual assignment, no predicate)', async () => {
     const ql: any = await stack.kernel.getServiceAsync('objectql');

--- a/packages/qa/dogfood/test/showcase-public-read-owd.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-public-read-owd.dogfood.test.ts
@@ -7,9 +7,9 @@
 // sibling of the `private` proof: same owner-write protection, but rows are
 // VISIBLE across owners (the read-visibility axis of OWD).
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import showcaseStack from '@objectstack/example-showcase';
-import { bootStack, type VerifyStack } from '@objectstack/verify';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { type VerifyStack } from '@objectstack/verify';
+import { getSharedShowcase } from './shared-showcase.js';
 
 const OBJ = '/data/showcase_announcement';
 const idOf = (b: any) => b?.id ?? b?.record?.id ?? b?.data?.id ?? b?.recordId;
@@ -21,7 +21,7 @@ describe('showcase: public-read OWD (ADR-0056)', () => {
   let aAnnId: string;
 
   beforeAll(async () => {
-    stack = await bootStack(showcaseStack);
+    stack = await getSharedShowcase();
     await stack.signIn();
     aToken = await stack.signUp('pr-alice@verify.test');
     bToken = await stack.signUp('pr-bob@verify.test');
@@ -31,8 +31,6 @@ describe('showcase: public-read OWD (ADR-0056)', () => {
     aAnnId = idOf(await a.json());
     expect(aAnnId).toBeTruthy();
   }, 60_000);
-
-  afterAll(async () => { await stack?.stop(); });
 
   it('every member READS another owner’s announcement (public-read)', async () => {
     const byId = await stack.apiAs(bToken, 'GET', `${OBJ}/${aAnnId}`);

--- a/packages/qa/dogfood/test/showcase-search.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-search.dogfood.test.ts
@@ -9,9 +9,9 @@
 // executor's security posture is pinned at the HTTP level, not just in
 // `search-filter.test.ts` unit tests.
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import showcaseStack from '@objectstack/example-showcase';
-import { bootStack, type VerifyStack } from '@objectstack/verify';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { type VerifyStack } from '@objectstack/verify';
+import { getSharedShowcase } from './shared-showcase.js';
 
 describe('showcase: $search over the HTTP API (ADR-0061 conformance proof)', () => {
   let stack: VerifyStack;
@@ -25,10 +25,9 @@ describe('showcase: $search over the HTTP API (ADR-0061 conformance proof)', () 
   };
 
   beforeAll(async () => {
-    stack = await bootStack(showcaseStack);
+    stack = await getSharedShowcase();
     token = await stack.signIn();
   }, 60_000);
-  afterAll(async () => { await stack?.stop(); });
 
   it('multi-field match: "retail" returns Northwind via industry, not name', async () => {
     const records = await query({ search: 'retail' });

--- a/packages/qa/dogfood/test/showcase-static-readonly.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-static-readonly.dogfood.test.ts
@@ -26,9 +26,9 @@
 // is the stand-in for the #3003 approval/status/amount columns — readonly,
 // "computed by scoring rules — not user-editable", never on the create form.
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import showcaseStack from '@objectstack/example-showcase';
-import { bootStack, type VerifyStack } from '@objectstack/verify';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { type VerifyStack } from '@objectstack/verify';
+import { getSharedShowcase } from './shared-showcase.js';
 
 const OBJ = '/data/showcase_contact';
 const idOf = (b: any) => b?.id ?? b?.record?.id ?? b?.data?.id ?? b?.recordId;
@@ -40,7 +40,7 @@ describe('showcase: static readonly write enforcement (#2948 / #3003 / #3043)', 
   let contactId: string;
 
   beforeAll(async () => {
-    stack = await bootStack(showcaseStack);
+    stack = await getSharedShowcase();
     await stack.signIn();
     token = await stack.signUp('ro-worker@verify.test');
 
@@ -57,8 +57,6 @@ describe('showcase: static readonly write enforcement (#2948 / #3003 / #3043)', 
     contactId = idOf(await created.json());
     expect(contactId).toBeTruthy();
   }, 60_000);
-
-  afterAll(async () => { await stack?.stop(); });
 
   it('INSERT forging the readonly field is silently stripped — the forged value never persists (#3043)', async () => {
     const res = await stack.apiAs(token, 'GET', `${OBJ}/${contactId}`);

--- a/packages/qa/dogfood/test/two-doors-permission.dogfood.test.ts
+++ b/packages/qa/dogfood/test/two-doors-permission.dogfood.test.ts
@@ -16,9 +16,9 @@
 //        owning the row, and "delete" resets to the shipped declaration.
 //        Forging package provenance through the admin door stays refused.
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import showcaseStack from '@objectstack/example-showcase';
-import { bootStack, type VerifyStack } from '@objectstack/verify';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { type VerifyStack } from '@objectstack/verify';
+import { getSharedShowcase } from './shared-showcase.js';
 
 describe('two-doors permission separation (ADR-0086 P2)', () => {
   let stack: VerifyStack;
@@ -27,12 +27,11 @@ describe('two-doors permission separation (ADR-0086 P2)', () => {
   let adminToken: string;
 
   beforeAll(async () => {
-    stack = await bootStack(showcaseStack);
+    stack = await getSharedShowcase();
     adminToken = await stack.signIn();
     ql = await stack.kernel.getServiceAsync('objectql');
     protocol = await stack.kernel.getServiceAsync('protocol');
   }, 60_000);
-  afterAll(async () => { await stack?.stop(); });
 
   const findSet = async (name: string) =>
     (await ql.find('sys_permission_set', { where: { name } }, { context: { isSystem: true } }))?.[0];

--- a/packages/qa/dogfood/vitest.config.ts
+++ b/packages/qa/dogfood/vitest.config.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// Two projects, one suite (#3622 follow-up: dogfood boot-overhead surgery).
+//
+// Measured on this suite: test BODIES are ~61s of aggregate compute while
+// per-file setup (TS module graph ~3.5s + kernel boot ~4.1s + hooks) is
+// ~800s — ~93% of the gate's cost was booting the same app over and over.
+//
+// `shared-showcase` runs the files that boot the IDENTICAL plain showcase
+// stack with `isolate: false`: files on the same worker share one module
+// registry, so test/shared-showcase.ts memoizes ONE boot per worker instead
+// of one per file. Eligibility rules live in that helper's header — files
+// with custom boot options, /meta writes, org/BU mutation, exact-count
+// assertions over shared objects, or process.env toggles stay isolated.
+//
+// `isolated` keeps vitest defaults (fresh fork registry per file) for
+// everything else — fixture stacks, custom security/plugins, env-flag files.
+import { defineConfig } from 'vitest/config';
+
+// Files proven eligible for the worker-shared plain showcase stack.
+const SHARED_SHOWCASE = [
+  'test/form-self-auth.dogfood.test.ts',
+  'test/showcase-agent-intersection.dogfood.test.ts',
+  'test/showcase-agent-scope-ceiling.dogfood.test.ts',
+  'test/showcase-anonymous-deny.dogfood.test.ts',
+  'test/showcase-anonymous-deny-surfaces.dogfood.test.ts',
+  'test/showcase-declarative-rbac-seeding.dogfood.test.ts',
+  'test/showcase-permission-zoo.dogfood.test.ts',
+  'test/showcase-private-owd.dogfood.test.ts',
+  'test/showcase-public-read-owd.dogfood.test.ts',
+  'test/showcase-search.dogfood.test.ts',
+  'test/showcase-static-readonly.dogfood.test.ts',
+  'test/two-doors-permission.dogfood.test.ts',
+];
+
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        test: {
+          name: 'shared-showcase',
+          include: SHARED_SHOWCASE,
+          isolate: false,
+        },
+      },
+      {
+        test: {
+          name: 'isolated',
+          include: ['test/**/*.test.ts'],
+          exclude: SHARED_SHOWCASE,
+        },
+      },
+    ],
+  },
+});


### PR DESCRIPTION
## Why — the measurement

The Dogfood gate is now the sole long pole of PR CI (~5–6 min per shard). Instrumented the suite before touching anything:

- Test **bodies**: ~61s of aggregate compute (367 tests)
- Per-file **setup** (TS module graph ~3.5s + `bootStack` kernel assembly ~4.1s + hooks): **~800s — ~93% of the suite's compute is booting the identical app over and over** (63 full boots per run)
- Single plain boot, measured 3-field: imports 3.54s, boot 4.13s, signIn 0.16s

## What

`vitest.config.ts` now defines two projects:

- **`shared-showcase`** — 12 files that boot the *identical* plain `bootStack(showcaseStack)` run with `isolate: false`; a memoized helper (`test/shared-showcase.ts`) boots **once per worker** (≤4 per run) instead of once per file. Migrated files drop their own `bootStack` call and their `afterAll(stop)` (stopping a shared instance would kill it under the worker's later files).
- **`isolated`** — everything else, untouched vitest defaults (fresh fork registry per file).

## Eligibility was audited, not assumed

Candidates required ALL of: plain boot (no custom security/plugins/automation/multiTenant), zero `/meta` writes, zero org/BU mutation, zero exact-count assertions over shared objects, zero `process.env` toggles. The audit caught two near-misses a naive migration would have shipped: `action-params-contract` and `two-factor-lockout` look plain but flip boot-time env flags — both stayed isolated. Files with count-asserts (`membership-reconciler`, `me-apps-and-everyone-baseline`, …), meta writes (`meta-types-create-seed`, `dashboard-designer-roundtrip`), and org mutations (`org-create-default-team`, …) also stayed isolated. The eligibility rules are documented in the helper's header for future authors.

## Verification

- Full suite under the new config: **green, 367 tests, identical pass/skip profile to baseline** (364/3) — no state bleed.
- Wall: **216s → 190s** locally (4 workers); boots 63 → 54.
- `--shard` composes with projects (`--shard=1/8`: 9 files, green) — CI's 2-way shard matrix is unaffected.
- `eslint` clean on all touched files.

## Deliberately not done

- The `scope-depth` pair (~30s of genuine test body — half of all test-body time) boots three custom-security worlds *by design*: one `isDefault` profile per boot IS the proof. Rewriting that for speed would change what the gate proves.
- The other 17 plain-boot files with audit flags can migrate later, file by individually-reviewed file — the mechanism and rules are now in place, which is as much the deliverable as today's seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECTCrcCdZpCHw5zFSgcmGt

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECTCrcCdZpCHw5zFSgcmGt)_