### PR TITLE
test(lint): give the lazy-deps dist probes the same cold-load timeout as their sibling (#3662)

### DIFF
--- a/.changeset/lazy-deps-dist-probe-timeout.md
+++ b/.changeset/lazy-deps-dist-probe-timeout.md
@@ -1,0 +1,13 @@
+---
+---
+
+test(lint): give the lazy-deps dist probes the same cold-load timeout as their sibling (#3662)
+
+The two dist probes in `lazy-deps.test.ts` spawn a child `node` that cold-loads
+sucrase (~1.5 MB) and typescript (~9 MB) to prove neither arrives at import time.
+That cold load alone exceeds vitest's default 5s timeout under a whole-repo
+`pnpm test` (dozens of parallel turbo tasks), so the ESM probe was observed
+failing at 5928ms on `execFileSync` — pure latency, not a contract failure. The
+in-process sibling already carried an explicit 30s timeout; hoisted that rationale
+into one named `COLD_LOAD_TIMEOUT_MS` shared by all three cold-loading cases.
+Test-only flake fix; releases nothing.

--- a/packages/lint/src/lazy-deps.test.ts
+++ b/packages/lint/src/lazy-deps.test.ts
@@ -36,6 +36,12 @@ const LAZY_DEPS = ['typescript', 'sucrase'];
 const depLoaded = (cache: Record<string, unknown> | undefined, dep: string) =>
   Object.keys(cache ?? {}).some((p) => p.split(/[/\\]/).join('/').includes(`/node_modules/${dep}/`));
 
+// Every case below cold-loads sucrase + typescript (~1.5 MB / ~9 MB) — in-process
+// for the behavioral case, in a spawned child `node` for the dist probes. On a
+// loaded runner (dozens of parallel turbo tasks) that alone takes >5s, so vitest's
+// default 5s timeout flakes while the assertion set is pure contract, not latency.
+const COLD_LOAD_TIMEOUT_MS = 30_000;
+
 describe('lazy dependency loading (kernel boot-path contract)', () => {
   it('no src file eagerly imports a lazy dep (import type only)', () => {
     // Static `import`/`export ... from '<dep>'` executes at module init in
@@ -85,7 +91,7 @@ describe('lazy dependency loading (kernel boot-path contract)', () => {
       { encoding: 'utf8' },
     );
     expect(out).toContain('OK');
-  });
+  }, COLD_LOAD_TIMEOUT_MS);
 
   it.skipIf(!existsSync(join(distDir, 'index.js')))('built ESM dist does not load a lazy dep until a react page is validated', () => {
     const out = execFileSync(
@@ -101,7 +107,7 @@ describe('lazy dependency loading (kernel boot-path contract)', () => {
       { encoding: 'utf8' },
     );
     expect(out).toContain('OK');
-  });
+  }, COLD_LOAD_TIMEOUT_MS);
 
   it('loads each dep lazily in-process and the gates still work', async () => {
     const req = createRequire(import.meta.url);
@@ -129,8 +135,5 @@ describe('lazy dependency loading (kernel boot-path contract)', () => {
     });
     expect(depLoaded(req.cache, 'typescript')).toBe(true);
     expect(props.some((f) => f.rule === 'react-prop-missing-required' && /objectName/.test(f.message))).toBe(true);
-    // Cold-loading sucrase + typescript in-process takes >5s on a loaded CI
-    // runner (dozens of parallel turbo tasks) — the default 5s timeout flakes
-    // there while the assertion set is pure contract, not latency.
-  }, 30_000);
+  }, COLD_LOAD_TIMEOUT_MS);
 });


### PR DESCRIPTION
Closes #3662.

## 问题

`packages/lint/src/lazy-deps.test.ts` 的两条 dist 探针(行 81 / 行 90)各自 spawn 一个子 `node`,在子进程里冷加载 `sucrase`(~1.5 MB)与 `typescript`(~9 MB),用来证明这两个依赖不会在 import 时被带进来。这个冷加载本身在整仓 `pnpm test`(几十个 turbo 任务并行)下就会超过 vitest 默认的 5s ——issue 里实测 ESM 那条在 `execFileSync` 上耗时 **5928ms**。

失败纯粹是延迟:断言只检查"子进程的 require cache 里最终有哪些依赖",与耗时无关。

同一文件的 in-process 兄弟用例早就知道这件事,显式带了 `30_000` 并写了注释;两条 dist 探针做同样的冷加载却沿用默认 5s。

## 改动

把那段说明提成一个具名常量 `COLD_LOAD_TIMEOUT_MS = 30_000`,三条冷加载用例(两条 dist 探针 + in-process 兄弟)统一引用它。理由只写一次,不会再出现"兄弟改了、探针没改"的漂移。断言一行未动。

```diff
+// Every case below cold-loads sucrase + typescript (~1.5 MB / ~9 MB) — in-process
+// for the behavioral case, in a spawned child `node` for the dist probes. On a
+// loaded runner (dozens of parallel turbo tasks) that alone takes >5s, so vitest's
+// default 5s timeout flakes while the assertion set is pure contract, not latency.
+const COLD_LOAD_TIMEOUT_MS = 30_000;
```

## 验证

先 `pnpm --filter @objectstack/lint... build` 把 dist 构建出来,让两条 `skipIf` 探针**真的跑起来**而不是被跳过:

```
✓ built CJS dist does not load a lazy dep until a react page is validated  908ms
✓ built ESM dist does not load a lazy dep until a react page is validated  751ms
✓ loads each dep lazily in-process and the gates still work              3211ms
```

空载机器上 in-process 那条已经 3.2s,离 5s 很近 —— 与 issue 描述的负载下越界一致。

另外单独验证了"第三参数超时经由 `it.skipIf(...)` 确实生效"(vitest 4.1.10),用一次性探针跑同一段 6.5s 的 body:

```
✓ skipIf still honors a third-arg timeout (>5s default)   6509ms   ← 带 30_000
× control: same body with the default 5s timeout must fail 5008ms  → Test timed out in 5000ms.
```

该探针文件已删除,不在本 PR 内。

包内全量:`32 test files / 447 tests passed`;`eslint packages/lint/src/lazy-deps.test.ts` 干净。

## 关于 changeset

纯测试稳定性修复,不涉及运行时行为,按 AGENTS.md Post-Task Checklist #3 本身不需要发版说明。但 `Check Changeset` 门禁要求每个 PR **至少新增一个** changeset 文件,所以补了一个**空 frontmatter** 的 —— 工作流注释里明确把它列为"this PR releases nothing"的认可写法(仓库既有先例:`.changeset/authz-ledger-flow-runas.md`,同样是 test-only)。它声明的正是"不发版",与上面那条并不冲突。