### PR TITLE
feat(security): 让用户级 export 权限轴真正在服务端生效 (#3544)

### DIFF
--- a/.changeset/enforce-user-level-export-axis.md
+++ b/.changeset/enforce-user-level-export-axis.md
@@ -1,0 +1,48 @@
+---
+"@objectstack/spec": minor
+"@objectstack/plugin-security": minor
+"@objectstack/plugin-hono-server": patch
+"@objectstack/rest": minor
+---
+
+feat(security): ENFORCE the user-level export axis on the server (#3544)
+
+`allowExport` landed as a spec bit plus a `/me/permissions` annotation, which
+hid the client's Export button — and nothing else. Because `export ⊆ list`, the
+REST export route streams through `findData` and the engine middleware sees an
+ordinary `find` gated by `allowRead`, so no code path ever read the bit: a caller
+holding `allowExport: false` could still `curl
+/api/v1/data/:object/export` and drain the whole table. Declared, not enforced.
+
+- **plugin-security** `PermissionEvaluator.checkObjectPermission('export', …)` is
+  now a real decision: `export` = read granted ∧ not explicitly denied.
+  `allowExport` stays out of `OPERATION_TO_PERMISSION` on purpose — that map
+  means "the bit must be truthy", which would have denied export to every
+  permission set authored before the axis existed. The new exported
+  `resolveUserExportAllowed()` folds the tri-state across sets (`true` beats
+  `false` beats unset) exactly as the `/me/permissions` merge does.
+- **spec** `ISecurityService` gains `canExport(object, context)` — the question a
+  bulk-egress door outside the engine middleware has to ask before it reads.
+  Fails CLOSED; `isSystem` and an empty set resolution bypass, mirroring the
+  middleware.
+- **rest** `GET /data/:object/export` calls it and answers **403
+  `EXPORT_NOT_PERMITTED`** before the first chunk is fetched. Distinct from the
+  object-level 405 `OBJECT_API_METHOD_NOT_ALLOWED`, which still runs first: 405
+  says the object exposes no export, 403 says this caller may not use it. No
+  security service (no `plugin-security` ⇒ no permission sets) → allowed, the
+  same fail-open posture as every other permission gate in that layer; service
+  present but unable to answer → denied.
+- **plugin-hono-server** the `/me/permissions` annotation now falls back to the
+  `'*'` entry's export bit when a per-object entry declares none, matching the
+  evaluator's own wildcard fallback — so a set that denies export wholesale via
+  `'*'` no longer offers a button the server refuses.
+
+Backward-compatible: `allowExport` is still an opt-out with no default, so an
+unset bit inherits read and existing permission sets behave exactly as before.
+Only a permission set that explicitly sets `allowExport: false` changes — and it
+now changes on the server, which is the point.
+
+Implementers of `ISecurityService` outside this repo must add `canExport`; the
+interface member is required, matching how `getReadableFields` was added.
+Consumers still feature-detect (`typeof svc.canExport === 'function'`), so a
+partial implementation degrades rather than throwing.

--- a/content/docs/permissions/permission-sets.mdx
+++ b/content/docs/permissions/permission-sets.mdx
@@ -50,9 +50,40 @@ export const SalesUser = definePermissionSet({
 | Permission | Description |
 |------------|-------------|
 | `allowCreate` / `allowRead` / `allowEdit` / `allowDelete` | CRUD on records the user can see |
+| `allowExport` | Bulk data egress — narrows read, see below |
 | `allowTransfer` / `allowRestore` / `allowPurge` | Lifecycle class (RBAC-gated ahead of the M2 operations) |
 | `viewAllRecords` | Read ALL records regardless of ownership (super-user read) |
 | `modifyAllRecords` | Edit ALL records regardless of ownership (super-user write) |
+
+### `allowExport` — the export axis
+
+Read and export are not the same privilege. Reading a record on screen and
+pulling the whole table down as a CSV differ in blast radius, which is why
+Salesforce ("Export Reports"), Dynamics ("Export to Excel"), NetSuite
+("Export Lists") and SAP (`S_GUI` 61) all carry a separate export permission.
+`allowExport` is that axis here: `export = list ∧ allowExport`.
+
+It is a **tri-state**, and unset is not the same as `false`:
+
+| Value | Meaning |
+|------------|-------------|
+| unset | Inherit read — anyone who can list can export. The default, so adding the key changes nothing for existing permission sets. |
+| `false` | Deny export while **keeping** read. The reason the axis exists. |
+| `true` | Explicitly granted. |
+
+Across several permission sets the merge is most-permissive with an explicit
+deny in the middle: any set saying `true` wins, otherwise any set saying `false`
+wins, otherwise the bit stays unset and inherits read.
+
+It narrows read — it never widens it. A set granting `allowExport: true` without
+a read grant exports nothing, and a `modifyAllRecords` super-user wildcard does
+**not** override an explicit per-object `allowExport: false`.
+
+Enforcement is server-side: `GET /api/v1/data/:object/export` answers
+`403 EXPORT_NOT_PERMITTED` before it reads the first row. The same decision is
+published on `/me/permissions` as the object's effective `apiOperations`, which
+is what makes the client hide its Export button — the button and the refusal are
+one decision, not two.
 
 ## Access depth — `readScope` / `writeScope` (ADR-0057 D1)
 

--- a/packages/plugins/plugin-hono-server/src/effective-api-operations.test.ts
+++ b/packages/plugins/plugin-hono-server/src/effective-api-operations.test.ts
@@ -108,6 +108,47 @@ describe('annotateEffectiveApiOperations (#3391)', () => {
       }));
       expect(objects.deal.apiOperations).toContain('export');
     });
+
+    // The merge keeps `'*'` and named objects as independent keys, but the
+    // SERVER evaluator does not — `resolveObjectPermission` falls back to the
+    // wildcard for any object a set has no explicit entry for. Reading it here
+    // too is what keeps the hidden button and the refused request the same
+    // decision; without it a `'*': {allowExport:false}` set would still be
+    // offered an Export button that then 403s.
+    it("inherits the '*' export bit when the object entry declares none", () => {
+      const objects: Record<string, any> = {
+        '*': { allowRead: true, allowExport: false },
+        deal: { allowRead: true }, // no allowExport of its own
+      };
+      annotateEffectiveApiOperations(objects, schemaOf({
+        deal: { name: 'deal', enable: {} }, // unrestricted
+      }));
+      expect(objects.deal.apiOperations).toBeDefined();
+      expect(objects.deal.apiOperations).not.toContain('export');
+      expect(objects.deal.apiOperations).toContain('list');
+    });
+
+    it("an explicit per-object allowExport:true overrides a '*' deny", () => {
+      const objects: Record<string, any> = {
+        '*': { allowRead: true, allowExport: false },
+        deal: { allowRead: true, allowExport: true },
+      };
+      annotateEffectiveApiOperations(objects, schemaOf({
+        deal: { name: 'deal', enable: { apiMethods: ['get', 'list'] } },
+      }));
+      expect(objects.deal.apiOperations).toContain('export');
+    });
+
+    it("a '*' carrying no export bit changes nothing", () => {
+      const objects: Record<string, any> = {
+        '*': { modifyAllRecords: true },
+        deal: { allowRead: true },
+      };
+      annotateEffectiveApiOperations(objects, schemaOf({
+        deal: { name: 'deal', enable: {} },
+      }));
+      expect('apiOperations' in objects.deal).toBe(false);
+    });
   });
 });
 

--- a/packages/plugins/plugin-hono-server/src/hono-plugin.ts
+++ b/packages/plugins/plugin-hono-server/src/hono-plugin.ts
@@ -340,14 +340,26 @@ export function annotateEffectiveApiOperations(
     objects: Record<string, any>,
     schemaOf: (objectName: string) => ApiExposureSchemaLike | undefined,
 ): void {
+    // [#3544] The `'*'` entry's export bit is the FALLBACK for objects that do
+    // not declare one of their own. The merge keeps `'*'` and named objects as
+    // independent keys, but the server evaluator does not: its
+    // `resolveObjectPermission` falls back to the wildcard whenever a set has no
+    // explicit entry for the object, so a set that denies export wholesale via
+    // `'*': { allowExport: false }` really does deny it per-object. Reading the
+    // wildcard here keeps the button the client hides and the request the server
+    // refuses in agreement — the same class of client/server divergence
+    // `foldWildcardSuperUser` exists to close, on the export axis.
+    const wildExport = objects?.['*']?.allowExport;
     for (const [obj, acc] of Object.entries(objects) as Array<[string, any]>) {
         if (obj === '*' || !acc) continue;
         const schema = schemaOf(obj);
         if (!schema) continue; // schema missing → no annotation (client falls back)
         // [#3544] User-level export axis: `export` derives from `list ∧ this bit`.
-        // Unset → inherit read (backward-compatible: can-list ⇒ can-export);
-        // explicit `allowExport:false` → export removed from the effective set.
-        const userExportAllowed = acc.allowExport !== false;
+        // Unset → inherit the wildcard, then read (backward-compatible:
+        // can-list ⇒ can-export); explicit `false` → export removed from the
+        // effective set.
+        const exportBit = acc.allowExport ?? wildExport;
+        const userExportAllowed = exportBit !== false;
         const eff = resolveEffectiveApiMethods(schema.enable ?? undefined, { userExportAllowed });
         // Annotate when the object tightens via `apiMethods`, OR when the export
         // axis removes `export` from an otherwise-open object (so the client

--- a/packages/plugins/plugin-security/src/export-permission-axis.test.ts
+++ b/packages/plugins/plugin-security/src/export-permission-axis.test.ts
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #3544 — the user-level EXPORT axis, at the evaluator.
+ *
+ * `allowExport` shipped as a spec bit and a `/me/permissions` annotation, which
+ * hid the client's Export button but enforced nothing: `export ⊆ list`, so a
+ * bulk export reaches the engine middleware as an ordinary `find` gated by
+ * `allowRead`, and no code path ever read the bit. These pin the enforcement
+ * half — the evaluator's `export` branch and the tri-state fold it rests on.
+ *
+ * The fold must agree, case for case, with the `/me/permissions` per-object
+ * merge in `hono-plugin.ts` (`if (v === true) acc[k] = true; else if
+ * (acc[k] === undefined) acc[k] = v`, read back as `acc.allowExport !== false`).
+ * A divergence there is the same declared ≠ enforced bug, just inverted: the
+ * client would offer a button the server refuses.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { PermissionSet } from '@objectstack/spec/security';
+import { PermissionEvaluator, resolveUserExportAllowed } from './permission-evaluator';
+
+const evaluator = new PermissionEvaluator();
+
+/** A permission set granting `objects` as authored (defaults omitted). */
+const set = (name: string, objects: Record<string, any>): PermissionSet =>
+  ({ name, objects } as unknown as PermissionSet);
+
+/** The read-granting baseline every export case builds on. */
+const READER = { allowRead: true };
+
+describe('resolveUserExportAllowed — tri-state fold (#3544)', () => {
+  it('all sets unset → undefined (inherit read, backward-compatible)', () => {
+    expect(resolveUserExportAllowed('deal', [set('a', { deal: READER })])).toBeUndefined();
+  });
+
+  it('an explicit false → false', () => {
+    expect(
+      resolveUserExportAllowed('deal', [set('a', { deal: { ...READER, allowExport: false } })]),
+    ).toBe(false);
+  });
+
+  it('an explicit true → true', () => {
+    expect(
+      resolveUserExportAllowed('deal', [set('a', { deal: { ...READER, allowExport: true } })]),
+    ).toBe(true);
+  });
+
+  it('true outranks false regardless of set order (most-permissive merge)', () => {
+    const deny = set('deny', { deal: { ...READER, allowExport: false } });
+    const grant = set('grant', { deal: { ...READER, allowExport: true } });
+    expect(resolveUserExportAllowed('deal', [deny, grant])).toBe(true);
+    expect(resolveUserExportAllowed('deal', [grant, deny])).toBe(true);
+  });
+
+  it('false outranks silence — one opt-out set denies even alongside plain readers', () => {
+    expect(
+      resolveUserExportAllowed('deal', [
+        set('reader', { deal: READER }),
+        set('no_export', { deal: { ...READER, allowExport: false } }),
+      ]),
+    ).toBe(false);
+  });
+
+  it('is per-object — a deny on one object leaves another untouched', () => {
+    const sets = [set('a', { deal: { ...READER, allowExport: false }, lead: READER })];
+    expect(resolveUserExportAllowed('deal', sets)).toBe(false);
+    expect(resolveUserExportAllowed('lead', sets)).toBeUndefined();
+  });
+
+  it("reads the '*' wildcard when the set has no explicit entry for the object", () => {
+    const sets = [set('a', { '*': { ...READER, allowExport: false } })];
+    expect(resolveUserExportAllowed('deal', sets)).toBe(false);
+  });
+
+  it("an explicit per-object entry overrides the '*' wildcard", () => {
+    const sets = [set('a', { '*': { ...READER, allowExport: false }, deal: { ...READER, allowExport: true } })];
+    expect(resolveUserExportAllowed('deal', sets)).toBe(true);
+  });
+
+  it("a non-super-user '*' does not reach a PRIVATE object (ADR-0066 D2)", () => {
+    const sets = [set('a', { '*': { ...READER, allowExport: false } })];
+    expect(resolveUserExportAllowed('deal', sets, { isPrivate: true })).toBeUndefined();
+    // …but a super-user wildcard does.
+    const superSets = [set('a', { '*': { viewAllRecords: true, allowExport: false } as any })];
+    expect(resolveUserExportAllowed('deal', superSets, { isPrivate: true })).toBe(false);
+  });
+});
+
+describe("checkObjectPermission('export') — export ⊆ list ∧ allowExport (#3544)", () => {
+  const canExport = (sets: PermissionSet[], opts?: { isPrivate?: boolean }) =>
+    evaluator.checkObjectPermission('export', 'deal', sets, opts ?? {});
+
+  it('unset allowExport inherits read — a plain reader may still export', () => {
+    // The whole point of the opt-out default: every permission set authored
+    // before this axis existed keeps working unchanged.
+    expect(canExport([set('a', { deal: READER })])).toBe(true);
+  });
+
+  it('allowExport:false denies export while READ stays granted', () => {
+    const sets = [set('a', { deal: { ...READER, allowExport: false } })];
+    expect(canExport(sets)).toBe(false);
+    // The Salesforce "Export Reports" shape: read is untouched.
+    expect(evaluator.checkObjectPermission('find', 'deal', sets)).toBe(true);
+  });
+
+  it('allowExport:true grants export', () => {
+    expect(canExport([set('a', { deal: { ...READER, allowExport: true } })])).toBe(true);
+  });
+
+  it('no read grant → no export, even with allowExport:true (export ⊆ list)', () => {
+    // The axis NARROWS read; it is not an independent grant. A set that says
+    // "may export" but not "may read" exports nothing.
+    expect(canExport([set('a', { deal: { allowRead: false, allowExport: true } })])).toBe(false);
+  });
+
+  it('no matching grant at all → denied', () => {
+    expect(canExport([set('a', { other: READER })])).toBe(false);
+  });
+
+  it('viewAllRecords satisfies the read half', () => {
+    expect(canExport([set('a', { deal: { viewAllRecords: true } })])).toBe(true);
+  });
+
+  it('a super-user wildcard does NOT bypass an explicit per-object export deny', () => {
+    // modifyAllRecords is a bypass for the CRUD bits, not a licence to exfiltrate
+    // an object whose set explicitly opted out of export.
+    const sets = [
+      set('admin', { '*': { modifyAllRecords: true } }),
+      set('no_export', { deal: { ...READER, allowExport: false } }),
+    ];
+    expect(canExport(sets)).toBe(false);
+    expect(evaluator.checkObjectPermission('find', 'deal', sets)).toBe(true);
+  });
+
+  it('an empty set list denies (the middleware skips its CRUD gate in that case)', () => {
+    // Guard rail: the "no sets ⇒ unrestricted" decision belongs to the CALLER
+    // (SecurityPlugin.canExport), matching how the middleware guards its whole
+    // CRUD block. The evaluator itself never invents a grant.
+    expect(canExport([])).toBe(false);
+  });
+
+  it('other operations are untouched by the axis', () => {
+    const sets = [set('a', { deal: { allowRead: true, allowCreate: true, allowExport: false } })];
+    expect(evaluator.checkObjectPermission('find', 'deal', sets)).toBe(true);
+    expect(evaluator.checkObjectPermission('insert', 'deal', sets)).toBe(true);
+    expect(evaluator.checkObjectPermission('export', 'deal', sets)).toBe(false);
+  });
+});

--- a/packages/plugins/plugin-security/src/permission-evaluator.ts
+++ b/packages/plugins/plugin-security/src/permission-evaluator.ts
@@ -102,6 +102,41 @@ function resolveObjectPermission(
 }
 
 /**
+ * [#3544] Fold the user-level EXPORT axis across the resolved permission sets.
+ *
+ * `allowExport` is deliberately absent from {@link OPERATION_TO_PERMISSION}:
+ * that map's semantics are "the bit must be truthy", which would deny export to
+ * every permission set authored before the axis existed. The bit is a TRI-state
+ * instead, and this is its merge rule:
+ *
+ *   - any set `true`   → `true`  (an explicit grant outranks another set's deny)
+ *   - else any `false` → `false` (an explicit opt-out outranks silence)
+ *   - else all unset   → `undefined` (inherit read — the pre-#3544
+ *     "can-list ⇒ can-export" behaviour, so existing sets are unaffected)
+ *
+ * This is the same answer the `/me/permissions` per-object merge produces
+ * (`if (v === true) acc[k] = true; else if (acc[k] === undefined) acc[k] = v`,
+ * read back as `acc.allowExport !== false`). That equality is load-bearing, not
+ * incidental: the client hides its Export button on the merged map while this
+ * decides the server's 403, and the two disagreeing is exactly the
+ * `declared ≠ enforced` gap the axis exists to close.
+ */
+export function resolveUserExportAllowed(
+  objectName: string,
+  permissionSets: PermissionSet[],
+  opts: { isPrivate?: boolean } = {},
+): boolean | undefined {
+  let denied = false;
+  for (const ps of permissionSets) {
+    const objPerm = resolveObjectPermission(ps, objectName, opts.isPrivate ?? false);
+    const bit = objPerm?.allowExport;
+    if (bit === true) return true;
+    if (bit === false) denied = true;
+  }
+  return denied ? false : undefined;
+}
+
+/**
  * PermissionEvaluator
  * 
  * Runtime evaluator for PermissionSet definitions.
@@ -119,6 +154,17 @@ export class PermissionEvaluator {
     /** [ADR-0066 D2] When the object is `private`, the `'*'` wildcard only covers it if it is a super-user grant. */
     opts: { isPrivate?: boolean } = {},
   ): boolean {
+    // [#3544] User-level export axis. `export` is NOT a bit lookup: per the
+    // spec's derivation table (`API_METHOD_DERIVATION`) it is `list ∧
+    // userExportAllowed`, so it requires READ and is then vetoed by an explicit
+    // `allowExport: false`. Handled here rather than in OPERATION_TO_PERMISSION
+    // so an UNSET bit keeps inheriting read — otherwise every permission set
+    // written before the axis existed would silently lose export.
+    if (operation === 'export') {
+      if (resolveUserExportAllowed(objectName, permissionSets, opts) === false) return false;
+      return this.checkObjectPermission('find', objectName, permissionSets, opts);
+    }
+
     const permKey = OPERATION_TO_PERMISSION[operation];
     if (!permKey) {
       // Fail CLOSED for the destructive operation class (ADR-0049): an

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -643,6 +643,10 @@ export class SecurityPlugin implements Plugin {
         // route uses it to project columns instead of inferring readability
         // from already-masked data rows. See getReadableFields.
         getReadableFields: (object: string, context?: any) => this.getReadableFields(object, context),
+        // [#3544] User-level export axis. `export ⊆ list`, so a bulk export
+        // reaches the middleware as a plain `find` and `allowExport` would never
+        // be consulted — the REST export route asks HERE before it streams.
+        canExport: (object: string, context?: any) => this.canExport(object, context),
         // [ADR-0046 §6.7] Effective permission-set NAMES for a caller — the
         // primitive the REST read layer needs to evaluate a permission-set-
         // gated book/doc audience ({ permissionSet: '…' }). Same resolution
@@ -692,7 +696,7 @@ export class SecurityPlugin implements Plugin {
           dismissAudienceBindingSuggestion(suggestionDeps, callerContext, id),
       };
       ctx.registerService('security', securityService);
-      ctx.logger.info('[security] registered "security" service (getReadFilter, getReadableFields, explain, audience-binding suggestions) — ADR-0021 D-C / ADR-0090 D5/D6/D9 / #3547');
+      ctx.logger.info('[security] registered "security" service (getReadFilter, getReadableFields, canExport, explain, audience-binding suggestions) — ADR-0021 D-C / ADR-0090 D5/D6/D9 / #3544 / #3547');
     } catch (e) {
       ctx.logger.warn?.('[security] failed to register "security" service', {
         error: (e as Error).message,
@@ -2252,6 +2256,61 @@ export class SecurityPlugin implements Plugin {
     // enumerates fields it names) — the exact complement of maskResults' delete
     // set, so the export header matches list's readable columns by construction.
     return allFields.filter((f) => fieldPerms[f]?.readable !== false);
+  }
+
+  /**
+   * [#3544] Whether `context` may EXPORT `object` — the user-level export axis.
+   *
+   * Export is READ-DERIVED (`export ⊆ list`), so a bulk export reaches the
+   * engine middleware as an ordinary `find` and is gated by `allowRead` alone.
+   * The `allowExport` bit is therefore invisible to the middleware, and a door
+   * that streams a whole table out (the REST `GET /data/:object/export` route)
+   * has to ask this question itself, BEFORE it reads. Same resolution as the
+   * middleware — {@link resolvePermissionSetsForContext} → the evaluator's
+   * `export` branch — so the axis cannot drift from data-plane enforcement.
+   *
+   * Fails CLOSED (an access-narrowing answer): a dangling on-behalf-of delegator
+   * denies, and callers must treat a throw as a denial. `isSystem` bypasses, and
+   * so does an empty set resolution — the middleware skips its CRUD gate
+   * entirely for a caller with no permission sets, and reporting a denial the
+   * data path would not enforce is its own kind of drift.
+   */
+  async canExport(object: string, context?: any): Promise<boolean> {
+    const objectName = String(object ?? '');
+    if (!objectName) return false;
+    // System operations bypass (mirrors the middleware's isSystem skip).
+    if (context?.isSystem) return true;
+
+    const permissionSets = await this.resolvePermissionSetsForContext(context);
+    // No sets resolved (e.g. unauthenticated, or a deployment with no sets) →
+    // no permission-set restriction applies, exactly as the middleware treats it
+    // (`if (permissionSets.length > 0)` guards its whole CRUD gate).
+    if (permissionSets.length === 0) return true;
+
+    const { isPrivate } = await this.getObjectSecurityMeta(objectName);
+    if (!this.permissionEvaluator.checkObjectPermission('export', objectName, permissionSets, { isPrivate })) {
+      return false;
+    }
+
+    // [ADR-0090 D10] An on-behalf-of caller may never export past what the
+    // DELEGATOR could have exported themselves — intersect the delegator's own
+    // answer. A dangling delegator fails CLOSED, the same stance the CRUD
+    // middleware and {@link getReadableFields} take.
+    if (context?.onBehalfOf?.userId) {
+      const del = await resolveDelegatorContext(this.ql, context);
+      if (del.kind === 'missing') return false;
+      if (del.kind === 'resolved') {
+        const delegatorSets = await this.resolvePermissionSetsForContext(del.context);
+        if (
+          delegatorSets.length > 0 &&
+          !this.permissionEvaluator.checkObjectPermission('export', objectName, delegatorSets, { isPrivate })
+        ) {
+          return false;
+        }
+      }
+    }
+
+    return true;
   }
 
   /**

--- a/packages/rest/src/rest-export-permission-gate.test.ts
+++ b/packages/rest/src/rest-export-permission-gate.test.ts
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #3544 — the user-level EXPORT gate on `GET /data/:object/export`.
+ *
+ * The axis shipped as a spec bit plus a `/me/permissions` annotation, which hid
+ * the client's Export button and nothing more. `export ⊆ list`, so the route
+ * streams through `findData` and the engine middleware sees a plain `find`
+ * gated by `allowRead` — `allowExport` was never consulted on the wire, and a
+ * caller holding `allowExport: false` could still `curl` the whole table out.
+ *
+ * These pin the door itself: the 403, and — the assertion that actually matters
+ * — that `findData` is NEVER reached on a denial, so a refusal cannot leak the
+ * first chunk before it fires. Rows are stubbed on purpose; this is a test of
+ * the gate, not of the streaming path (`export-integration.test.ts` owns that).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { RestServer } from './rest-server';
+
+const TASK = {
+  name: 'task',
+  label: '任务',
+  fields: {
+    id: { type: 'text', label: 'ID' },
+    title: { type: 'text', label: '标题' },
+  },
+};
+
+const ROWS = [
+  { id: '1', title: '写代码' },
+  { id: '2', title: '写文档' },
+];
+
+function createMockServer() {
+  const noop = () => {};
+  return { get: noop, post: noop, put: noop, delete: noop, patch: noop, use: noop, listen: async () => {}, close: async () => {} };
+}
+
+function makeRes() {
+  const chunks: string[] = [];
+  const headers: Record<string, string> = {};
+  let status = 200;
+  const res: any = {
+    write: (s: string) => { chunks.push(typeof s === 'string' ? s : String(s)); return true; },
+    end: () => {},
+    header: (n: string, v: string) => { headers[n] = v; return res; },
+    status: (code: number) => { status = code; return res; },
+    json: (body: any) => { (res as any)._json = body; return res; },
+  };
+  return { res, chunks, headers, getStatus: () => status, getJson: () => (res as any)._json };
+}
+
+/**
+ * Boot the export route over a stub protocol, with `security` resolved from
+ * `securityServiceProvider` (the 18th positional ctor arg).
+ *
+ * `enable` is left undefined on the object so the OBJECT-level gate
+ * (`apiAccessDenialFromEnable`) is fully open — every denial these tests observe
+ * is therefore the USER-level axis, never the `apiMethods` whitelist.
+ */
+function boot(security: any) {
+  const findData = vi.fn().mockResolvedValue({ object: 'task', records: ROWS });
+  const protocol: any = {
+    getMetaItems: vi.fn().mockResolvedValue({ items: [TASK] }),
+    getMetaItem: vi.fn().mockResolvedValue({ type: 'object', name: 'task', item: TASK }),
+    findData,
+  };
+  const rest = new RestServer(
+    createMockServer() as any,
+    protocol as any,
+    { api: { requireAuth: false } } as any,
+    undefined, // kernelManager
+    undefined, // envRegistry
+    undefined, // defaultEnvironmentIdProvider
+    undefined, // authServiceProvider
+    undefined, // objectQLProvider
+    undefined, // emailServiceProvider
+    undefined, // sharingServiceProvider
+    undefined, // reportsServiceProvider
+    undefined, // approvalsServiceProvider
+    undefined, // sharingRulesServiceProvider
+    undefined, // i18nServiceProvider
+    undefined, // analyticsServiceProvider
+    undefined, // settingsServiceProvider
+    undefined, // serviceExistsProvider
+    security === undefined ? undefined : async () => security,
+  );
+  rest.registerRoutes();
+  const route = rest.getRoutes().find(
+    (r: any) => r.method === 'GET' && r.path === '/api/v1/data/:object/export',
+  );
+  expect(route).toBeDefined();
+  return { route, findData };
+}
+
+const run = async (route: any) => {
+  const out = makeRes();
+  await route.handler({ params: { object: 'task' }, query: { format: 'csv' } } as any, out.res);
+  return out;
+};
+
+describe('export route — user-level export axis (#3544)', () => {
+  it('canExport:false → 403 EXPORT_NOT_PERMITTED, and NOTHING is read', async () => {
+    const { route, findData } = boot({ canExport: async () => false });
+    const out = await run(route);
+
+    expect(out.getStatus()).toBe(403);
+    expect(out.getJson()).toMatchObject({ code: 'EXPORT_NOT_PERMITTED', object: 'task' });
+    // The whole point: the refusal lands BEFORE the first chunk is fetched, so
+    // a denied export cannot dribble rows out ahead of the status code.
+    expect(findData).not.toHaveBeenCalled();
+    expect(out.chunks.join('')).toBe('');
+  });
+
+  it('canExport:true → the export proceeds and streams rows', async () => {
+    const { route, findData } = boot({ canExport: async () => true });
+    const out = await run(route);
+
+    expect(out.getStatus()).toBe(200);
+    expect(findData).toHaveBeenCalled();
+    expect(out.chunks.join('')).toContain('写代码');
+  });
+
+  it('passes the object name and the request ExecutionContext to canExport', async () => {
+    // The decision is per-object AND per-caller: handing the service anything
+    // less would make it answer a different question than the one being asked.
+    const canExport = vi.fn().mockResolvedValue(true);
+    const { route } = boot({ canExport });
+    await run(route);
+
+    expect(canExport).toHaveBeenCalledTimes(1);
+    expect(canExport.mock.calls[0][0]).toBe('task');
+  });
+
+  it('no security service at all → allowed (deployment has no permission sets)', async () => {
+    // Matches every other permission gate in this layer, and `/me/permissions`'
+    // documented fail-open: without plugin-security there is nothing to enforce.
+    const { route, findData } = boot(undefined);
+    const out = await run(route);
+
+    expect(out.getStatus()).toBe(200);
+    expect(findData).toHaveBeenCalled();
+  });
+
+  it('service present but without canExport → allowed (feature-detected)', async () => {
+    // An older or partial implementation degrades instead of hard-failing —
+    // the contract's stated posture for the whole `security` surface.
+    const { route, findData } = boot({ getReadableFields: async () => undefined });
+    const out = await run(route);
+
+    expect(out.getStatus()).toBe(200);
+    expect(findData).toHaveBeenCalled();
+  });
+
+  it('canExport throws → 403 (fail CLOSED, ADR-0049)', async () => {
+    // It resolves permission sets to decide; a resolution failure must never
+    // read as a grant.
+    const { route, findData } = boot({
+      canExport: async () => { throw new Error('permission set resolution failed'); },
+    });
+    const out = await run(route);
+
+    expect(out.getStatus()).toBe(403);
+    expect(out.getJson()).toMatchObject({ code: 'EXPORT_NOT_PERMITTED' });
+    expect(findData).not.toHaveBeenCalled();
+  });
+
+  it('the object-level 405 still precedes the user-level 403', async () => {
+    // Two gates, two questions: `apiMethods` decides whether the OBJECT exposes
+    // export (405), this axis decides whether the CALLER may use it (403). An
+    // object that exposes no export must answer 405 whatever the user holds.
+    const findData = vi.fn().mockResolvedValue({ object: 'task', records: ROWS });
+    const protocol: any = {
+      getMetaItems: vi.fn().mockResolvedValue({ items: [{ ...TASK, enable: { apiMethods: ['get'] } }] }),
+      getMetaItem: vi.fn().mockResolvedValue({ type: 'object', name: 'task', item: TASK }),
+      findData,
+    };
+    const rest = new RestServer(
+      createMockServer() as any,
+      protocol as any,
+      { api: { requireAuth: false } } as any,
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined,
+      async () => ({ canExport: async () => false }),
+    );
+    rest.registerRoutes();
+    const route = rest.getRoutes().find(
+      (r: any) => r.method === 'GET' && r.path === '/api/v1/data/:object/export',
+    );
+    const out = await run(route);
+
+    expect(out.getStatus()).toBe(405);
+    expect(out.getJson()).toMatchObject({ code: 'OBJECT_API_METHOD_NOT_ALLOWED' });
+    expect(findData).not.toHaveBeenCalled();
+  });
+});

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -1148,6 +1148,53 @@ export class RestServer {
     }
 
     /**
+     * [#3544] Enforce the USER-LEVEL export axis on a bulk-egress route, after
+     * {@link enforceApiAccess} has cleared the object-level one. Returns `true`
+     * when a response was sent (the caller must return).
+     *
+     * The two gates answer different questions and so carry different statuses:
+     * `enforceApiAccess` is about the OBJECT ("does this object expose export at
+     * all" → 405), this one is about the CALLER ("may YOU export it" → 403).
+     *
+     * It has to exist as its own check because `export ⊆ list`: the export route
+     * streams through `findData`, which the engine middleware sees as a plain
+     * `find` and gates on `allowRead`. Nothing downstream ever looks at
+     * `allowExport`, so without this the bit would only hide the client's Export
+     * button while `curl` still drained the table — declared, not enforced
+     * (AGENTS.md Prime Directive #10).
+     *
+     * Fail stance mirrors the deployment's own posture. No security service (no
+     * `plugin-security`, so no permission sets exist anywhere) → allow, matching
+     * every other permission gate here and `/me/permissions`' documented
+     * fail-open. Service PRESENT but unable to answer → fail CLOSED: it resolves
+     * permission sets to decide, and a resolution failure must never read as a
+     * grant (ADR-0049).
+     */
+    private async enforceExportPermission(
+        req: any,
+        res: any,
+        environmentId: string | undefined,
+        objectName: string,
+        context: any,
+    ): Promise<boolean> {
+        const security = await this.resolveSecurityService(environmentId, req);
+        if (!security || typeof security.canExport !== 'function') return false;
+        let allowed: boolean;
+        try {
+            allowed = await security.canExport(objectName, context);
+        } catch {
+            allowed = false; // access-narrowing answer → a throw is a denial
+        }
+        if (allowed) return false;
+        res.status(403).json({
+            code: 'EXPORT_NOT_PERMITTED',
+            error: `Export is not permitted on object '${objectName}' for this user`,
+            object: objectName,
+        });
+        return true;
+    }
+
+    /**
      * Load the object metadata items for the current protocol/environment,
      * coerced to a plain array. Returns `[]` when metadata is unavailable so
      * callers fail OPEN (the data call itself needs the same metadata and will
@@ -4250,6 +4297,9 @@ export class RestServer {
                         return;
                     }
                     if (await this.enforceApiAccess(req, res, p, environmentId, 'export')) return;
+                    // [#3544] …then the USER-level one. The object may expose
+                    // export while THIS caller's permission sets deny it.
+                    if (await this.enforceExportPermission(req, res, environmentId, objectName, context)) return;
                     const q = req.query ?? {};
                     const fmtRaw = String(q.format ?? 'csv').toLowerCase();
                     const format: 'csv' | 'json' | 'xlsx' =

--- a/packages/spec/src/contracts/security-service.test.ts
+++ b/packages/spec/src/contracts/security-service.test.ts
@@ -17,6 +17,7 @@ function makeService(overrides: Partial<ISecurityService> = {}): ISecurityServic
   return {
     getReadFilter: async () => undefined,
     getReadableFields: async () => [],
+    canExport: async () => true,
     resolvePermissionSetNames: async () => [],
     explain: async () => ({}) as any,
     listAudienceBindingSuggestions: async () => ({
@@ -35,6 +36,7 @@ describe('Security Service Contract', () => {
     for (const m of [
       'getReadFilter',
       'getReadableFields',
+      'canExport',
       'resolvePermissionSetNames',
       'explain',
       'listAudienceBindingSuggestions',
@@ -43,6 +45,22 @@ describe('Security Service Contract', () => {
     ] as const) {
       expect(typeof service[m]).toBe('function');
     }
+  });
+
+  it('canExport: an access-narrowing answer — false denies, and absence is feature-detectable', async () => {
+    // [#3544] The bulk-egress question. It fails CLOSED, so a consumer must
+    // never read a `false` (or a throw) as "no restriction" the way it may
+    // read getReadFilter's `undefined`.
+    const denied = makeService({ canExport: async () => false });
+    await expect(denied.canExport('deal', { userId: 'u1' })).resolves.toBe(false);
+
+    const allowed = makeService({ canExport: async () => true });
+    await expect(allowed.canExport('deal', { userId: 'u1' })).resolves.toBe(true);
+
+    // A system context bypasses, mirroring the engine middleware's isSystem skip.
+    const service = makeService({ canExport: async (_object, context) => context?.isSystem === true });
+    await expect(service.canExport('deal', { isSystem: true })).resolves.toBe(true);
+    await expect(service.canExport('deal', { userId: 'u1' })).resolves.toBe(false);
   });
 
   it('getReadFilter: undefined means NO row restriction — the only thing it may mean', async () => {

--- a/packages/spec/src/contracts/security-service.ts
+++ b/packages/spec/src/contracts/security-service.ts
@@ -193,6 +193,31 @@ export interface ISecurityService {
   resolvePermissionSetNames(context?: SecurityContext): Promise<string[]>;
 
   /**
+   * [#3544] Whether `context` may EXPORT `object` — the user-level export axis
+   * (`ObjectPermissionSchema.allowExport`).
+   *
+   * Export is a READ-DERIVED operation (`export ⊆ list` in the spec's
+   * `API_METHOD_DERIVATION`), so it reaches the engine middleware as an ordinary
+   * `find` and is gated by `allowRead` alone. That makes the export axis
+   * invisible to the middleware: without this method a caller holding
+   * `allowExport: false` still streams the whole table out of the REST export
+   * route, and the bit only ever hid a button. Bulk-egress doors must ask this
+   * BEFORE they read.
+   *
+   * The answer folds the tri-state bit across the caller's resolved sets exactly
+   * as the `/me/permissions` merge does — `true` beats `false` beats unset, and
+   * unset inherits read — so the button the client hides and the request the
+   * server refuses are the same decision.
+   *
+   * **Fails CLOSED.** This is an access-narrowing answer: implementations return
+   * `false` (and callers must treat a throw as `false`) rather than degrading to
+   * "allowed". A system context bypasses and returns `true`; so does a caller
+   * with no resolved permission sets, mirroring the middleware, whose CRUD gate
+   * is skipped entirely when set resolution comes back empty.
+   */
+  canExport(object: string, context?: SecurityContext): Promise<boolean>;
+
+  /**
    * Explain WHY access is granted or denied — the decision plus the layers that
    * produced it (permission sets, object permissions, RLS, sharing, field mask).
    *


### PR DESCRIPTION
## 背景:#3553 只做了一半

#3553 已经把 #3544 的清单打勾了 —— spec 加了 `allowExport` 位,`/me/permissions` 按它计算 `userExportAllowed` 并下发 `apiOperations`,前端据此隐藏 Export 按钮。但**服务端一行都没有拦**。

因为 `export ⊆ list`:REST 导出路由 `GET /data/:object/export` 是通过 `findData` 流式读的,引擎安全中间件看到的是一次普通 `find`,只按 `allowRead` 放行。全仓没有任何代码路径读过 `allowExport`。所以今天:

```bash
# 权限集里 deal.allowExport = false —— 页面上 Export 按钮消失了
curl -H "Cookie: <该用户的会话>" \
  'http://localhost:3000/api/v1/data/deal/export?format=csv&limit=50000'
# → 200,整表 CSV 照样流出来
```

Issue 里写的「接上后,不再是『能 list 即能导出』」并没有成立 —— 少的正是 AGENTS.md 铁律 #10 说的那一层:**`declared ≠ enforced`,`case` 标签不是执法,要看调用点**。这个 PR 补的就是调用点。

## 改动

- **plugin-security** `checkObjectPermission('export', …)` 成为真正的判定:**读权限 ∧ 未被显式拒绝**。
  `allowExport` 刻意**不**进 `OPERATION_TO_PERMISSION` —— 那张表的语义是「该位必须为真」,套上去会让**所有在本轴之前写的权限集**瞬间失去导出。新导出的 `resolveUserExportAllowed()` 做三态折叠(`true` > `false` > 未设),与 `/me/permissions` 的对象合并逐例一致。
- **spec** `ISecurityService` 新增 `canExport(object, context)` —— 引擎中间件之外的批量出数据的门,在读之前必须问的那个问题。**fail CLOSED**;`isSystem` 与「解析出零个权限集」放行,与中间件的 `if (permissionSets.length > 0)` 保持一致。
- **rest** 导出路由在**取第一个 chunk 之前**返回 **403 `EXPORT_NOT_PERMITTED`**。与对象级 405 分开、且 405 仍在前:405 = 这个对象不暴露 export,403 = 你这个人不能用。
- **plugin-hono-server** 注解在对象条目没有自己的 `allowExport` 时回落到 `'*'` 条目的位 —— 服务端 `resolveObjectPermission` 本来就会回落到通配符,不跟上就会出现「按钮给你、请求 403」的客户端/服务端分歧(和 `foldWildcardSuperUser` 要解决的是同一类问题)。
- **docs** `content/docs/permissions/permission-sets.mdx` 的「对象权限位」表一直没有 `allowExport`(#3553 只重生成了 auto-gen 的 reference)。既然现在真的会执法了,把三态、跨权限集的合并规则、「只收窄不放宽」、以及「403 与前端隐藏按钮是同一个判定」写清楚。

## 兼容性

`allowExport` 仍是**无默认值的 opt-out**:未设 = 继承 read,现有权限集行为逐字不变。只有显式写了 `allowExport: false` 的权限集会变 —— 而且现在是在**服务端**变,这正是本 issue 的目的。

`ISecurityService` 的实现方需要补 `canExport`(接口成员为必选,与 #3547 加 `getReadableFields` 的做法一致);消费方仍然 feature-detect,部分实现是降级而不是抛错。

## 测试

新增 25 条,全部针对本轴:

- `plugin-security/src/export-permission-axis.test.ts`(18) —— 三态折叠(含 `'*'` 通配符回落、ADR-0066 D2 private 对象不吃非超级用户通配符)、`export ⊆ list`(给了 `allowExport:true` 但没有读权限 → 仍然拒)、超级用户通配符**不能**绕过显式的按对象 export 拒绝、拒绝 export 时 read 保持授予(Salesforce "Export Reports" 形状)。
- `rest/src/rest-export-permission-gate.test.ts`(7) —— 403 的同时**断言 `findData` 从未被调用**(拒绝不能先漏出第一个 chunk);无 security 服务 → 放行;服务在但没有 `canExport` → 放行;`canExport` 抛错 → 403(fail closed);对象级 405 仍然优先。

回归:spec 6687 / plugin-security 626 / rest 408 / plugin-hono-server 114 全绿;三个包 `tsc --noEmit` 干净;`check:api-surface`(surface unchanged)、`check:docs`(250 个生成文件 in sync)、`check:doc-authoring`(213 files clean)通过。

> `packages/rest/src/package-routes.ts` 上有两条 `string | string[]` 的 tsc 报错,是本分支之前就有的、与本次改动无关(该文件未被触碰,tsup DTS 构建通过)。

## 一个刻意留在范围外的发现 → #3710

`plugin-reports` 的定时报表会把 CSV 作为附件邮件发出(`report-service.ts` `dispatchDue`),它走的是报表所有者上下文 + RLS,**同样不经过本轴**。也就是说 `allowExport:false` 的用户仍可以建一张报表、定时把 CSV 发给自己。报表有自己的归属/共享模型(而且跨对象报表该判定哪个对象、判定 owner 还是建 schedule 的人,都得先定调),把导出轴延伸过去是另一件事,按铁律 #10 开了 **#3710**,没有在这里扩范围。

关联:#3544(本 issue)、#3553(前半程)、#3391、#3498、#3710(follow-up)、objectui#2823。