### PR TITLE
test(approvals): pin the ordering invariant the dead-run sweep rests on (#3456 follow-up)

### DIFF
--- a/.changeset/approval-dead-run-ordering-invariant.md
+++ b/.changeset/approval-dead-run-ordering-invariant.md
@@ -1,0 +1,11 @@
+---
+---
+
+test(approvals): pin the ordering invariant the dead-run sweep rests on (#3456
+follow-up) — releases nothing.
+
+Tests plus one comment reference; no runtime behaviour changes, so no package
+needs a version bump. The new coverage asserts that every in-band approval
+transition moves its request out of `pending` before it hands the run back —
+the unenforced premise `releaseDeadRunRequests` relies on to tell an orphaned
+request from a live one.

--- a/packages/plugins/plugin-approvals/src/approval-service.test.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.test.ts
@@ -2390,3 +2390,124 @@ describe('ApprovalService — participant visibility (#3590)', () => {
     expect(res.request.status).toBe('approved');
   });
 });
+
+// ── The ordering invariant the dead-run sweep rests on (#3456) ─────────
+//
+// `releaseDeadRunRequests` recalls a PENDING request whose owning run has
+// reached a TERMINAL state, on the premise that such a pair can only be an
+// orphan. That premise is not self-evident — it holds only because every
+// in-band transition moves the request OUT of `pending` before it hands the run
+// back. Resume first and a run that finishes promptly afterwards would be
+// indistinguishable from an orphan, so the sweep would cancel a LIVE approval —
+// precisely the one failure mode it is built never to have.
+//
+// Nothing enforces that ordering: it is a convention spread across four public
+// methods and seven resume/cancelRun call sites, any of which a refactor could
+// reorder without a single existing test going red. So pin the invariant
+// itself rather than the call order of any one method — at the instant the run
+// is handed back, no request owned by that run may still be `pending`.
+describe('in-band transitions finalise before they resume (#3456 invariant)', () => {
+  let engine: ReturnType<typeof makeFakeEngine>;
+  let svc: ApprovalService;
+  let n = 0;
+  const baseTime = new Date('2026-01-15T10:00:00Z').getTime();
+  /** One entry per hand-back, with any still-pending requests owned by the run. */
+  let handoffs: Array<{ hook: string; stillPending: string[] }>;
+
+  /** A flow whose approval node declares the `revise` out-edge send-back needs. */
+  const REVISE_FLOW = {
+    name: 'deal_approval',
+    edges: [{ id: 'e_rev', source: 'approve_step', target: 'wait_revision', label: 'revise' }],
+  };
+
+  function recordHandoff(hook: string) {
+    const rows = (engine._tables['sys_approval_request'] ?? []) as any[];
+    handoffs.push({
+      hook,
+      stillPending: rows
+        .filter(r => String(r.flow_run_id ?? '') === 'run_1' && r.status === 'pending')
+        .map(r => String(r.id)),
+    });
+  }
+
+  /** Assert every hand-back this scenario made was clean. */
+  function expectCleanHandoffs() {
+    expect(
+      handoffs.length,
+      'the run was never handed back — this scenario did not exercise the invariant',
+    ).toBeGreaterThan(0);
+    for (const h of handoffs) {
+      expect(
+        h.stillPending,
+        `${h.hook}() handed run_1 back while it still owned a pending request — `
+        + 'the dead-run sweep would treat that as an orphan and cancel a live approval',
+      ).toEqual([]);
+    }
+  }
+
+  beforeEach(async () => {
+    engine = makeFakeEngine();
+    n = 0;
+    handoffs = [];
+    svc = new ApprovalService({ engine: engine as any, clock: { now: () => new Date(baseTime + (n++) * 1000) } });
+    svc.attachAutomation({
+      async resume() { recordHandoff('resume'); },
+      async cancelRun() { recordHandoff('cancelRun'); },
+      async getFlow() { return REVISE_FLOW; },
+    } as any);
+    engine._tables['opportunity'] = [{ id: 'opp1', amount: 100 }];
+  });
+
+  const open = (configExtra: Record<string, any> = {}) =>
+    svc.openNodeRequest(openInput(['u9'], {}, configExtra), CTX);
+
+  it('decide(approve) finalises before resuming', async () => {
+    const req = await open();
+    await svc.decide(req.id, { decision: 'approve', actorId: 'u9' }, SYS);
+    expectCleanHandoffs();
+  });
+
+  it('decide(reject) finalises before resuming', async () => {
+    const req = await open();
+    await svc.decide(req.id, { decision: 'reject', actorId: 'u9' }, SYS);
+    expectCleanHandoffs();
+  });
+
+  it('recall finalises before resuming', async () => {
+    const req = await open();
+    await svc.recall(req.id, { actorId: 'u1' }, CTX);
+    expectCleanHandoffs();
+  });
+
+  it('sendBack finalises before resuming', async () => {
+    const req = await open();
+    await svc.sendBack(req.id, { actorId: 'u9', comment: 'fix the totals' }, CTX);
+    expectCleanHandoffs();
+  });
+
+  it('sendBack past the revision budget auto-rejects before resuming', async () => {
+    // `maxRevisions: 0` takes the ADR-0044 loop-guard branch on the first
+    // send-back — a separate resume site from the normal path above.
+    const req = await open({ maxRevisions: 0 });
+    const out = await svc.sendBack(req.id, { actorId: 'u9' }, CTX);
+    expect(out.autoRejected, 'expected the auto-reject branch').toBe(true);
+    expectCleanHandoffs();
+  });
+
+  it('recall inside the revise window cancels the run without a pending request', async () => {
+    const req = await open();
+    await svc.sendBack(req.id, { actorId: 'u9' }, CTX);
+    handoffs = [];                                   // isolate the recall's own hand-back
+    await svc.recall(req.id, { actorId: 'u1' }, CTX);
+    expect(handoffs.map(h => h.hook)).toContain('cancelRun');
+    expectCleanHandoffs();
+  });
+
+  it('resubmit re-enters the node without leaving the old request pending', async () => {
+    const req = await open();
+    await svc.sendBack(req.id, { actorId: 'u9' }, CTX);
+    handoffs = [];                                   // isolate the resubmit's own hand-back
+    await svc.resubmit(req.id, { actorId: 'u1' }, CTX);
+    expectCleanHandoffs();
+  });
+});

--- a/packages/services/service-automation/src/runtime-identity.ts
+++ b/packages/services/service-automation/src/runtime-identity.ts
@@ -55,13 +55,14 @@ export function resolveRunDataContext(context: AutomationContext | undefined): R
   if (context?.runAs === 'system') {
     return { isSystem: true, positions: [], permissions: [], ...(flowRunId ? { flowRunId } : {}) };
   }
-  // NOTE (#3456): the identity-less case below returns `undefined`, so a
-  // schedule-triggered `runAs:'user'` run with no user carries NO context at all
-  // — and therefore no `flowRunId` either, leaving it subject to the approvals
-  // record lock on its own target record. Manufacturing a context here just to
-  // carry the run id would flip that run from the documented unscoped fail-open
-  // (#1888) to baseline-member RLS — a separate, larger behavior change. The
-  // dead-run sweep in plugin-approvals is what recovers this shape.
+  // NOTE (#3456 residual, tracked as #3712): the identity-less case below returns
+  // `undefined`, so a schedule-triggered `runAs:'user'` run with no user carries
+  // NO context at all — and therefore no `flowRunId` either, leaving it subject
+  // to the approvals record lock on its own target record. Manufacturing a
+  // context here just to carry the run id would flip that run from the
+  // documented unscoped fail-open (#1888) to baseline-member RLS — a separate,
+  // larger behavior change. The dead-run sweep in plugin-approvals is what
+  // recovers this shape.
   if (!context?.userId) return undefined;
   // `context` is now narrowed to a defined AutomationContext with a userId.
   const out: RunDataContext = {


### PR DESCRIPTION
Follow-up to #3703 (which closed #3456). Test-and-comment only — no behaviour change.

## The unguarded assumption

`releaseDeadRunRequests` recalls a **pending** request whose owning run has reached a **terminal** state, on the premise that such a pair can only be an orphan. That premise is not self-evident. It holds only because every in-band transition moves the request out of `pending` **before** it hands the run back.

Reverse that order anywhere and a run that finishes promptly after the hand-back becomes indistinguishable from an orphan — so the sweep would cancel a **live** approval. That is precisely the one failure mode the sweep was built never to have, and #3703 leaned on the ordering to justify putting `completed` in the terminal set at all.

Nothing enforced it. It was a convention spread across four public methods and **seven** `resume`/`cancelRun` call sites, any of which a refactor could reorder without a single test going red.

## What this adds

Rather than pin any one method's call order — which would just re-encode the convention in a second place — it pins **the invariant itself**: at the instant the run is handed back, no request owned by that run may still be `pending`.

The probe stands in as the automation surface, records every `resume`/`cancelRun` hand-back with the run's still-pending requests at that moment, and asserts the set is empty. Seven scenarios cover all seven sites:

| scenario | site |
|---|---|
| `decide(approve)` / `decide(reject)` | resume after `decideNode` finalises |
| `recall` on a pending request | resume down the reject edge |
| `recall` inside the revise window | `cancelRun` (ADR-0044 — no reject edge to resume down) |
| `sendBack` | resume down the revise edge |
| `sendBack` past the revision budget | the ADR-0044 auto-reject branch, a separate resume site |
| `resubmit` | resume back into the approval node |

## Why I believe the test is load-bearing

Verified with a **reorder-only** mutation of `recall` — `resume`/`cancelRun` moved ahead of the finalise, **end state identical**:

```
× recall finalises before resuming
  Tests  1 failed | 235 passed (236)
```

Exactly one failure, the new test. That is the result worth having: it shows the test catches pure reordering (not just a changed outcome), and — since the other 235 stayed green — that **no existing test covered this ordering**, which is the whole justification for adding it.

An earlier, cruder mutation that changed the terminal *status* instead broke a dozen unrelated tests and proved nothing about ordering; it was discarded.

## Also here

`resolveRunDataContext`'s residual comment now points at **#3712**, filed to track the remaining #3456 gap: a schedule-triggered `runAs:'user'` run with no trigger user passes no ObjectQL context, so it carries no `flowRunId` and is still subject to the lock. Previously that residual lived only in a code comment, the changeset, and a merged PR body — nothing anyone would find.

## Verification

`plugin-approvals` **236** passed (229 before, +7), `service-automation` **365** passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGXCuBt5mSXbN3Gc8yfbRv)_