### PR TITLE
feat(cli,client)!: drop `os environments create --template` and the `template_id` body field (#3731)

### DIFF
--- a/.changeset/drop-dead-env-template-flag.md
+++ b/.changeset/drop-dead-env-template-flag.md
@@ -1,0 +1,34 @@
+---
+"@objectstack/client": minor
+"@objectstack/cli": minor
+---
+
+feat(cli,client)!: drop `os environments create --template` and the
+`template_id` body field — no control plane has ever read them (#3731)
+
+The CLI advertised `--template` as *"Built-in template id (e.g. crm, todo,
+blank)"* and forwarded it as `template_id` on `projects.create()`. Nothing
+consumes it: `template_id` / `templateId` appears in **zero** non-test files in
+the `cloud` repo, `sys_environment` has no such column, and the create route
+whitelists what it reads (`displayName`, `organizationId`, `isDefault`,
+`hostname`, `metadata`, …) — `template_id` is not in the list. The
+`blank`/`crm`/`todo` registry the flag named was the `apps/server`
+`createTemplatesRoutePlugin` snapshot, removed when the control plane moved to
+`cloud`; the flag outlived it.
+
+So the flag was accepted, transmitted, and dropped — no seeding, no error, no
+stored trace. That is worse than the 404 its listing counterpart returned
+(`projects.listTemplates`, deleted in #3702): a 404 tells the caller something
+is wrong, a silently ignored flag reports success.
+
+**Migration.** `os environments create --template <id>` → drop the flag; it
+never did anything. Starter content comes from the App Marketplace: create the
+environment, then install the package (`sys_package` rows with
+`is_starter = true`, i.e. `client.projects.packages.install(envId, { packageId })`).
+Callers passing `template_id` to `client.projects.create()` should delete the
+property — TypeScript now rejects it, which is the point: an unknown field was
+being silently discarded on the wire.
+
+Note this is **not** the same `--template` as `os init` / `create-objectstack`
+(`app` / `plugin` / `empty` scaffolds) — those are local scaffolding templates
+and are untouched.

--- a/packages/cli/src/commands/environments/create.ts
+++ b/packages/cli/src/commands/environments/create.ts
@@ -31,7 +31,13 @@ export default class ProjectsCreate extends Command {
     name: Flags.string({ description: 'Display name', required: true }),
     plan: Flags.string({ description: 'Billing plan', default: 'free' }),
     driver: Flags.string({ description: 'Data-plane driver id' }),
-    template: Flags.string({ description: 'Built-in template id (e.g. crm, todo, blank)' }),
+    // No `--template`. It advertised "Built-in template id (e.g. crm, todo,
+    // blank)" and sent `template_id`, which the control plane has never read —
+    // the `blank`/`crm`/`todo` registry it named died with the `apps/server`
+    // templates route. Removed in #3731: an accepted-and-dropped flag reports
+    // success for work that never happened. Starter content is installed from
+    // the App Marketplace instead (`os packages install`, `sys_package` with
+    // `is_starter = true`).
     artifact: Flags.string({
       description: 'Path to a locally-compiled objectstack.json artifact to bind into this project',
     }),
@@ -80,7 +86,6 @@ export default class ProjectsCreate extends Command {
         display_name: flags.name,
         plan: flags.plan,
         driver: flags.driver,
-        template_id: flags.template,
         clone_from_environment_id: flags['clone-from'],
         ...(metadata ? { metadata } : {}),
       });

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1064,6 +1064,14 @@ export class ObjectStackClient {
     /**
      * Provision a new project. Delegates to
      * `ProjectProvisioningService.provisionProject` on the server.
+     *
+     * No `template_id`: it was removed in #3731 because no control plane has
+     * ever read it — the `blank`/`crm`/`todo` registry it addressed died with
+     * the `apps/server` templates route, and `sys_environment` has no such
+     * column, so the field was accepted, transmitted, and dropped. Starter
+     * content is installed from the App Marketplace (`sys_package` with
+     * `is_starter = true`), which `projects.packages.install` already does.
+     * Its listing counterpart went the same way in #3702.
      */
     create: async (req: {
       organization_id: string;
@@ -1078,7 +1086,6 @@ export class ObjectStackClient {
       is_system?: boolean;
       storage_limit_mb?: number;
       clone_from_environment_id?: string;
-      template_id?: string;
       metadata?: Record<string, unknown>;
     }) => {
       const res = await this.fetch(`${this.baseUrl}/api/v1/cloud/environments`, {


### PR DESCRIPTION
Closes #3731. Sibling of #3702 / #3730 — the same dead concept, other half.

## What was wrong

`#3702` removed `projects.listTemplates()` because nothing mounted its route. The **writing** half survived, and it fails worse:

- `packages/cli/src/commands/environments/create.ts` advertised `--template` as *"Built-in template id (e.g. `crm`, `todo`, `blank`)"* and forwarded it as `template_id`.
- `packages/client/src/index.ts` declared `template_id?: string` on the `projects.create()` body.

Nothing reads it:

- `template_id` / `templateId` appears in **zero** non-test `.ts` files in `cloud`.
- `sys_environment` has no such column — the value is not even stored.
- The create route whitelists what it consumes (`environment-lifecycle.ts`): `displayName`/`display_name`, `organizationId`/`organization_id`, `isDefault`, `hostname`, `metadata`, `environmentType`/`environment_type` — then hardcodes `driver: 'turso'`, `plan: FREE_PLAN`, `storageLimitMb: 1024`, `visibility: 'private'`. `template_id` is not in the list.
- `sys_package.object.ts` states the position: there "is no separate 'template' concept"; `apps/cloud/objectstack.config.ts`: *"No built-in environment templates: every environment is provisioned empty."*

The `blank`/`crm`/`todo` registry the flag named was the `apps/server` `createTemplatesRoutePlugin` snapshot (CHANGELOG ~L1143), removed when the control plane moved to `cloud`. The flag outlived the registry by an entire architecture.

So `os env create --name X --template crm` was accepted, sent, and dropped — no seeding, no error, no trace. **Worse than the 404** its listing counterpart returned: a 404 tells the caller something is wrong; a silently ignored flag reports success. That is the "never advertise a capability the runtime doesn't deliver" corollary of Prime Directive #10.

## Migration

`os environments create --template <id>` → drop the flag; it never did anything. Starter content comes from the App Marketplace: create the environment, then install the package (`sys_package` rows with `is_starter = true` — `client.projects.packages.install(envId, { packageId })`), which is what the console already does. TypeScript now rejects `template_id` on `projects.create()`, which is the point — the field was being discarded on the wire.

**Not** the same `--template` as `os init` / `create-objectstack` (`app` / `plugin` / `empty` scaffolds). Those are local scaffolding, alive, and untouched — including every doc that mentions them. No doc references `os environments create --template`, so there was nothing to sweep.

## Verification

- `packages/cli` — **62 files / 642 tests pass**; `packages/client` — **13 / 175 pass**.
- `pnpm build` 71/71 with dts on; `packages/client/dist/index.d.ts` no longer carries the property (the one remaining hit is the tombstone comment).
- Behavioural, on the built CLI: `--template` is gone from `environments create --help`, and `os environments create --org x --name y --template crm` now exits with `Error: Nonexistent flag: --template` instead of silently "succeeding".

## Found on the way, filed separately

The audit that produced this found that `template_id` is not the only unread field in that body — see #3739 for the full table (`clone_from_environment_id` unread, `is_default` sent in a dialect the handler does not accept, `env_type` likewise, `slug`/`region`/`project_type`/`is_system` never read, `driver`/`plan`/`storage_limit_mb` overridden by policy while typed as settable). That one needs decisions, not just a trim, and both route-level guards are blind to it because they compare URLs, not request bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
