### PR TITLE
fix(security,approvals,metadata-core): 补上派生契约漏掉的 8 个对象的 `bulk` 原语 (#3026)

### DIFF
--- a/.changeset/rbac-objects-bulk-primitive.md
+++ b/.changeset/rbac-objects-bulk-primitive.md
@@ -1,0 +1,36 @@
+---
+"@objectstack/plugin-security": patch
+"@objectstack/plugin-approvals": patch
+"@objectstack/metadata-core": patch
+---
+
+fix(security,approvals,metadata-core): restore batch routes on the eight objects the #3391 P1 companion fix missed (#3026)
+
+The #3391 P1 contract made the bulk gate `bulk ∧ derived(child)`: a batch
+request is admitted only when the object grants the `bulk` **primitive** and the
+batched child operation is itself allowed. Before that, the `*Many` routes
+checked only the child verb, so a boilerplate CRUD-five whitelist
+(`['get','list','create','update','delete']`) batched fine.
+
+The companion fix — adding the `bulk` primitive wherever an explicit whitelist
+survived — was applied only inside `platform-objects`. Eight objects carrying
+the same boilerplate live in other packages and kept the gap, so `/batch`,
+`createMany`, `updateMany` and `deleteMany` answered `405
+OBJECT_API_METHOD_NOT_ALLOWED` on objects whose single-record create/update/
+delete were wide open. `data-objectstack` rethrows that 405 without falling back
+to per-row writes, which surfaced as a hard error on multi-select delete in the
+Setup grids.
+
+Objects reclaimed (whitelist now `['get','list','create','update','delete','bulk']`):
+`sys_capability`, `sys_permission_set`, `sys_position`,
+`sys_position_permission_set`, `sys_user_permission_set`, `sys_user_position`
+(plugin-security); `sys_approval_delegation` (plugin-approvals);
+`sys_view_definition` (metadata-core).
+
+No new authority is granted: `bulk` only permits batching verbs each object
+already exposes one record at a time, and every batched row still passes the
+same row- and field-level permission checks. The whitelists stay explicit rather
+than being deleted — seven of the eight are `managedBy`, and
+`reconcileManagedApiMethods` (ADR-0103 D3) early-returns on a non-array
+`apiMethods`, so dropping the line would silently disable the managed-write
+backstop.

--- a/packages/metadata-core/src/objects/sys-view-definition.object.test.ts
+++ b/packages/metadata-core/src/objects/sys-view-definition.object.test.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #3026 follow-up — `sys_view_definition` must expose the BATCH shape of the
+ * write verbs it already grants.
+ *
+ * Since the #3391 P1 contract made the bulk gate `bulk ∧ derived(child)`, a
+ * boilerplate CRUD-five whitelist (`get,list,create,update,delete`) denies
+ * `/batch`, `createMany`, `updateMany` and `deleteMany` while leaving the same
+ * verbs open one record at a time. The companion fix that added the `bulk`
+ * primitive to explicitly-whitelisted objects covered `platform-objects` only,
+ * so this one — the sole object carrying a whitelist in `metadata-core` — kept
+ * the gap.
+ *
+ * Unlike the RBAC objects reclaimed alongside it, this object has no
+ * `managedBy`, so the ADR-0103 D3 reconciliation never applies and deleting the
+ * whitelist would be behaviourally equivalent. It stays explicit on purpose: a
+ * metadata-plane object that is ALSO reachable through the generic data API is
+ * worth naming its exposed surface rather than inheriting whatever the
+ * primitive set grows into.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { resolveEffectiveApiMethods, isApiOperationAllowed } from '@objectstack/spec/data';
+import { SysViewDefinitionObject } from './sys-view-definition.object.js';
+
+describe('sys_view_definition — batch exposure (#3026 / #3391 P1 companion)', () => {
+  it('grants the bulk primitive alongside its single-record write verbs', () => {
+    expect(SysViewDefinitionObject.enable?.apiMethods).toContain('bulk');
+    for (const verb of ['get', 'list', 'create', 'update', 'delete'] as const) {
+      expect(SysViewDefinitionObject.enable?.apiMethods, `must keep ${verb}`).toContain(verb);
+    }
+  });
+
+  it('admits createMany / updateMany / deleteMany and /batch', () => {
+    const eff = resolveEffectiveApiMethods(SysViewDefinitionObject.enable);
+    expect(eff.mode).toBe('restricted');
+    for (const child of ['create', 'update', 'delete'] as const) {
+      expect(isApiOperationAllowed(eff, 'bulk', { bulkChild: child }), `batch ${child}`).toBe(true);
+    }
+  });
+});

--- a/packages/metadata-core/src/objects/sys-view-definition.object.ts
+++ b/packages/metadata-core/src/objects/sys-view-definition.object.ts
@@ -138,6 +138,8 @@ export const SysViewDefinitionObject = ObjectSchema.create({
     trackHistory: true,
     searchable: false,
     apiEnabled: true,
-    apiMethods: ['get', 'list', 'create', 'update', 'delete'],
+    // `bulk` = the batch shape of the verbs above; the gate is `bulk ∧ child`
+    // (#3391 P1), so omitting it 405s /batch and the *Many routes (#3026).
+    apiMethods: ['get', 'list', 'create', 'update', 'delete', 'bulk'],
   },
 });

--- a/packages/plugins/plugin-approvals/src/sys-approval-delegation.object.test.ts
+++ b/packages/plugins/plugin-approvals/src/sys-approval-delegation.object.test.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #3026 follow-up — `sys_approval_delegation` must expose the BATCH shape of
+ * the write verbs it already grants.
+ *
+ * The object is `managedBy: 'system'` but opens generic writes deliberately
+ * (`userActions: { create, edit, delete }` — an out-of-office rule is authored
+ * by its own user through the plain data endpoint), so the ADR-0103 D3
+ * reconciliation strips nothing and its boilerplate CRUD-five whitelist reaches
+ * the REST gate as authored. Since the #3391 P1 contract made bulk
+ * `bulk ∧ derived(child)`, that whitelist — which never named the `bulk`
+ * primitive — 405s every batch route while the single-record verbs stay open.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { resolveEffectiveApiMethods, isApiOperationAllowed } from '@objectstack/spec/data';
+import { SysApprovalDelegation } from './sys-approval-delegation.object';
+
+describe('sys_approval_delegation — batch exposure (#3026 / #3391 P1 companion)', () => {
+  it('grants the bulk primitive alongside its single-record write verbs', () => {
+    expect(SysApprovalDelegation.enable?.apiMethods).toContain('bulk');
+    for (const verb of ['get', 'list', 'create', 'update', 'delete'] as const) {
+      expect(SysApprovalDelegation.enable?.apiMethods, `must keep ${verb}`).toContain(verb);
+    }
+  });
+
+  it('admits createMany / updateMany / deleteMany and /batch', () => {
+    const eff = resolveEffectiveApiMethods(SysApprovalDelegation.enable);
+    expect(eff.mode).toBe('restricted');
+    for (const child of ['create', 'update', 'delete'] as const) {
+      expect(isApiOperationAllowed(eff, 'bulk', { bulkChild: child }), `batch ${child}`).toBe(true);
+    }
+  });
+
+  it('keeps the whitelist explicit so the ADR-0103 D3 backstop still runs', () => {
+    // `reconcileManagedApiMethods` early-returns on a non-array `apiMethods`.
+    // For a `managedBy` object, deleting the whitelist would silently disable
+    // managed-write stripping — it is not an equivalent refactor.
+    expect(Array.isArray(SysApprovalDelegation.enable?.apiMethods)).toBe(true);
+  });
+});

--- a/packages/plugins/plugin-approvals/src/sys-approval-delegation.object.ts
+++ b/packages/plugins/plugin-approvals/src/sys-approval-delegation.object.ts
@@ -135,6 +135,8 @@ export const SysApprovalDelegation = ObjectSchema.create({
     trackHistory: true,
     searchable: true,
     apiEnabled: true,
-    apiMethods: ['get', 'list', 'create', 'update', 'delete'],
+    // `bulk` = the batch shape of the verbs above; the gate is `bulk ∧ child`
+    // (#3391 P1), so omitting it 405s /batch and the *Many routes (#3026).
+    apiMethods: ['get', 'list', 'create', 'update', 'delete', 'bulk'],
   },
 });

--- a/packages/plugins/plugin-security/src/objects/sys-capability.object.ts
+++ b/packages/plugins/plugin-security/src/objects/sys-capability.object.ts
@@ -214,6 +214,8 @@ export const SysCapability = ObjectSchema.create({
     trackHistory: true,
     searchable: true,
     apiEnabled: true,
-    apiMethods: ['get', 'list', 'create', 'update', 'delete'],
+    // `bulk` = the batch shape of the verbs above; the gate is `bulk ∧ child`
+    // (#3391 P1), so omitting it 405s /batch and the *Many routes (#3026).
+    apiMethods: ['get', 'list', 'create', 'update', 'delete', 'bulk'],
   },
 });

--- a/packages/plugins/plugin-security/src/objects/sys-permission-set.object.ts
+++ b/packages/plugins/plugin-security/src/objects/sys-permission-set.object.ts
@@ -299,6 +299,8 @@ export const SysPermissionSet = ObjectSchema.create({
     trackHistory: true,
     searchable: true,
     apiEnabled: true,
-    apiMethods: ['get', 'list', 'create', 'update', 'delete'],
+    // `bulk` = the batch shape of the verbs above; the gate is `bulk ∧ child`
+    // (#3391 P1), so omitting it 405s /batch and the *Many routes (#3026).
+    apiMethods: ['get', 'list', 'create', 'update', 'delete', 'bulk'],
   },
 });

--- a/packages/plugins/plugin-security/src/objects/sys-position-permission-set.object.ts
+++ b/packages/plugins/plugin-security/src/objects/sys-position-permission-set.object.ts
@@ -77,6 +77,8 @@ export const SysPositionPermissionSet = ObjectSchema.create({
     trackHistory: true,
     searchable: true,
     apiEnabled: true,
-    apiMethods: ['get', 'list', 'create', 'update', 'delete'],
+    // `bulk` = the batch shape of the verbs above; the gate is `bulk ∧ child`
+    // (#3391 P1), so omitting it 405s /batch and the *Many routes (#3026).
+    apiMethods: ['get', 'list', 'create', 'update', 'delete', 'bulk'],
   },
 });

--- a/packages/plugins/plugin-security/src/objects/sys-position.object.ts
+++ b/packages/plugins/plugin-security/src/objects/sys-position.object.ts
@@ -275,6 +275,8 @@ export const SysPosition = ObjectSchema.create({
     trackHistory: true,
     searchable: true,
     apiEnabled: true,
-    apiMethods: ['get', 'list', 'create', 'update', 'delete'],
+    // `bulk` = the batch shape of the verbs above; the gate is `bulk ∧ child`
+    // (#3391 P1), so omitting it 405s /batch and the *Many routes (#3026).
+    apiMethods: ['get', 'list', 'create', 'update', 'delete', 'bulk'],
   },
 });

--- a/packages/plugins/plugin-security/src/objects/sys-user-permission-set.object.ts
+++ b/packages/plugins/plugin-security/src/objects/sys-user-permission-set.object.ts
@@ -135,6 +135,8 @@ export const SysUserPermissionSet = ObjectSchema.create({
     trackHistory: true,
     searchable: true,
     apiEnabled: true,
-    apiMethods: ['get', 'list', 'create', 'update', 'delete'],
+    // `bulk` = the batch shape of the verbs above; the gate is `bulk ∧ child`
+    // (#3391 P1), so omitting it 405s /batch and the *Many routes (#3026).
+    apiMethods: ['get', 'list', 'create', 'update', 'delete', 'bulk'],
   },
 });

--- a/packages/plugins/plugin-security/src/objects/sys-user-position.object.ts
+++ b/packages/plugins/plugin-security/src/objects/sys-user-position.object.ts
@@ -156,6 +156,8 @@ export const SysUserPosition = ObjectSchema.create({
     trackHistory: true,
     searchable: true,
     apiEnabled: true,
-    apiMethods: ['get', 'list', 'create', 'update', 'delete'],
+    // `bulk` = the batch shape of the verbs above; the gate is `bulk ∧ child`
+    // (#3391 P1), so omitting it 405s /batch and the *Many routes (#3026).
+    apiMethods: ['get', 'list', 'create', 'update', 'delete', 'bulk'],
   },
 });

--- a/packages/plugins/plugin-security/src/rbac-objects-bulk-exposure.test.ts
+++ b/packages/plugins/plugin-security/src/rbac-objects-bulk-exposure.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #3026 follow-up — the RBAC config objects must expose the BATCH shape of the
+ * write verbs they already grant.
+ *
+ * The #3391 P1 contract made the bulk gate `bulk ∧ derived(child)`: a batch
+ * request is admitted only when the object grants the `bulk` PRIMITIVE *and*
+ * the batched child operation is itself allowed. Before that, the `*Many`
+ * routes only checked the child verb, so a boilerplate CRUD-five whitelist
+ * (`get,list,create,update,delete`) batched fine. The companion fix — adding
+ * the `bulk` primitive to every object carrying an explicit whitelist — was
+ * applied only to the `platform-objects` package; these six RBAC objects live
+ * in `plugin-security` and were missed, leaving `/batch`, `createMany`,
+ * `updateMany` and `deleteMany` answering 405 on objects whose single-record
+ * create/update/delete are wide open. `data-objectstack` rethrows that 405
+ * without falling back to per-row writes, so multi-select delete in the Setup
+ * grids surfaced it as a hard error.
+ *
+ * These pin the batch shape for each object. `bulk` is a legitimate PERMANENT
+ * primitive declaration (#3543 kept it out of the legacy-verb reclaim), and an
+ * explicit whitelist is deliberately retained here rather than deleted: all six
+ * are `managedBy` (`config` or `system`), and `reconcileManagedApiMethods`
+ * (ADR-0103 D3) early-returns on a non-array `apiMethods` — dropping the
+ * whitelist would take the managed-write backstop with it.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { resolveEffectiveApiMethods, isApiOperationAllowed } from '@objectstack/spec/data';
+import { SysCapability } from './objects/sys-capability.object';
+import { SysPermissionSet } from './objects/sys-permission-set.object';
+import { SysPosition } from './objects/sys-position.object';
+import { SysPositionPermissionSet } from './objects/sys-position-permission-set.object';
+import { SysUserPermissionSet } from './objects/sys-user-permission-set.object';
+import { SysUserPosition } from './objects/sys-user-position.object';
+
+const RBAC_OBJECTS = [
+  ['sys_capability', SysCapability],
+  ['sys_permission_set', SysPermissionSet],
+  ['sys_position', SysPosition],
+  ['sys_position_permission_set', SysPositionPermissionSet],
+  ['sys_user_permission_set', SysUserPermissionSet],
+  ['sys_user_position', SysUserPosition],
+] as const;
+
+describe('RBAC config objects — batch exposure (#3026 / #3391 P1 companion)', () => {
+  for (const [name, obj] of RBAC_OBJECTS) {
+    describe(name, () => {
+      it('grants the bulk primitive alongside its single-record write verbs', () => {
+        // The gap this closes: CRUD-five without `bulk` denies every batch
+        // route while permitting the very same verbs one record at a time.
+        expect(obj.enable?.apiMethods).toContain('bulk');
+        for (const verb of ['get', 'list', 'create', 'update', 'delete'] as const) {
+          expect(obj.enable?.apiMethods, `${name} must keep ${verb}`).toContain(verb);
+        }
+      });
+
+      it('admits createMany / updateMany / deleteMany and /batch', () => {
+        const eff = resolveEffectiveApiMethods(obj.enable);
+        expect(eff.mode).toBe('restricted');
+        for (const child of ['create', 'update', 'delete'] as const) {
+          expect(
+            isApiOperationAllowed(eff, 'bulk', { bulkChild: child }),
+            `${name} batch ${child}`,
+          ).toBe(true);
+        }
+      });
+
+      it('keeps the whitelist explicit so the ADR-0103 D3 backstop still runs', () => {
+        // `reconcileManagedApiMethods` bails on a non-array `apiMethods`, so an
+        // absent whitelist silently disables managed-write stripping for these
+        // objects. Deleting the line is NOT an equivalent refactor here.
+        expect(Array.isArray(obj.enable?.apiMethods)).toBe(true);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## 背景

#3391 P1 把 bulk 门禁改成 **`bulk ∧ derived(child)`**(`api-derivation.ts:324`、`rest-server.ts:6633-6729`):批量请求只有在对象授予 `bulk` **原语** 且被批量的子操作本身也被允许时才放行。在此之前 `*Many` 路由只查子动词,所以 CRUD 五件套样板白名单(`['get','list','create','update','delete']`)批量是通的。

配套修复(「给还留着显式白名单的对象补 `bulk` 原语」)当时只在 `platform-objects` 包内做了。**同样样板的 8 个对象在别的包里,没被扫到** —— 于是 `/batch`、`createMany`、`updateMany`、`deleteMany` 在这些对象上返回 405 `OBJECT_API_METHOD_NOT_ALLOWED`,而它们的单条 create/update/delete 完全开放。objectui 的 `data-objectstack` 适配器对这两个方法的 405 是直接 rethrow、不回退逐行写,所以 Setup 网格里多选删除会直接报错。

## 改动

8 个对象的白名单追加 `'bulk'`(每处带两行注释说明门禁语义):

| 包 | 对象 |
|---|---|
| `plugin-security` | `sys_capability`、`sys_permission_set`、`sys_position`、`sys_position_permission_set`、`sys_user_permission_set`、`sys_user_position` |
| `plugin-approvals` | `sys_approval_delegation` |
| `metadata-core` | `sys_view_definition` |

## 判据:这 8 个都不是刻意收紧

- 6 个是 `managedBy:'config'` 或 `'system'` 且带 `userActions: { create: true, edit: true, delete: true }` → `resolveCrudAffordances` 全放行 → ADR-0103 D3 的 `reconcileManagedApiMethods` **一个动词都不剥**,白名单原样到达 REST gate。
- `sys_approval_delegation` 同上(`managedBy:'system'` + userActions 全开,注释里明确写了「RLS/权限集才是 authz」)。
- `sys_view_definition` 根本没有 `managedBy` → platform 桶 → D3 直接早退。

**不新增任何权限**:`bulk` 只是这些对象已经逐条开放的动词的批量形态,每一行仍然过同一套行级/字段级权限中间件。

## 为什么保留显式白名单而不是整行删掉

#3543 对「等价全开」的样板白名单是**整行删除**(BU / BUM / user-preference)。这里不能照搬:`reconcileManagedApiMethods`(`registry.ts:448-449`)在 `apiMethods` 非数组时**早退**——

```ts
const methods = (schema as any).enable?.apiMethods;
if (!Array.isArray(methods) || methods.length === 0) return schema;
```

删掉白名单等于**顺手关掉这 7 个 `managedBy` 对象的 managed-write 兜底**:今天它们靠 `userActions` 全开所以剥不掉东西、行为一致,但将来谁去掉 `userActions`,有白名单时 D3 会剥掉 create/update/delete,没白名单时 D3 完全不跑。所以显式保留 + 补 `bulk`。`sys_view_definition` 没有 `managedBy`,两种做法等价,为统一口径也保留显式声明(测试注释里写明了这一点)。

## 测试(先红后绿)

新增 3 个测试文件,共 23 条断言:

- `packages/plugins/plugin-security/src/rbac-objects-bulk-exposure.test.ts`(6 对象 × 3 组)
- `packages/plugins/plugin-approvals/src/sys-approval-delegation.object.test.ts`
- `packages/metadata-core/src/objects/sys-view-definition.object.test.ts`

**防假绿**:改对象之前先跑,如实变红 —— `isApiOperationAllowed(eff, 'bulk', { bulkChild: 'create'|'update'|'delete' })` 在全部 8 个对象上都返回 `false`(plugin-security 那份:12 failed | 6 passed)。改完全绿。

## 验证

- `@objectstack/plugin-security` 31 files / **653 tests** 全过
- `@objectstack/plugin-approvals` 7 files / **239 tests** 全过
- `@objectstack/metadata-core` 8 files / **102 tests** 全过
- `tsc --noEmit` 三个包 0 错(`plugin-approvals/src/action-link-pages.ts` 的 `replaceAll` 报错是裸 `tsc -p` 的 lib 配置导致的**既有**问题,该文件不在本 diff 内)

changeset:三包 `patch`。

## 关联

- #3026(设计契约,本 PR 是其落地的最后一处缺口)、#3391(P1 契约)、#3543(P2 枚举收缩)
- ADR-0103 D3(`reconcileManagedApiMethods`)、ADR-0049

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkdX2VCuKfcsFBbvtATe7V)_