### PR TITLE
feat(spec): reject unknown keys on an action param instead of stripping them (#3405)

### DIFF
--- a/.changeset/action-param-strict-unknown-keys.md
+++ b/.changeset/action-param-strict-unknown-keys.md
@@ -1,0 +1,40 @@
+---
+"@objectstack/spec": minor
+---
+
+feat(spec): reject unknown keys on an action param instead of stripping them (#3405)
+
+`ActionParamSchema` was zod-default `.strip`: any key it does not declare was
+**discarded silently** and the param went on parsing. That is the mechanism
+behind the `reference` bug — an author wrote a correct, clearly intended
+`reference: 'sys_user'`, the key was eaten, and the param dialog rendered a text
+box asking a human to paste a UUID. Adding `reference` fixed that one key; the
+mechanism that swallowed it stayed, so the next mis-spelled key would fail the
+same way, with the same zero feedback (ADR-0078 no-silently-inert-metadata,
+ADR-0049 enforce-or-remove).
+
+An action param is now `.strict()`. An undeclared key is a parse error naming the
+offending key, and — when the key is a recognisable spelling of a declared one —
+the canonical key to use instead:
+
+```
+Unrecognized key(s) on this action param: `reference_to`. Until #3405 these were
+dropped silently — the param still parsed, so a mis-spelled config shipped as a
+control that quietly ignored it. Did you mean `reference_to` → `reference`?
+```
+
+**Migration.** A param that previously carried an extra key now fails to parse.
+The fix is to correct or remove that key; the error names it. Common mappings —
+case/underscore slips are matched automatically, these are the ones that need a
+different word:
+
+| Wrote | Use |
+|---|---|
+| `reference_to` / `referenceTo` / `targetObject` | `reference` |
+| `visibleWhen` / `visibleOn` / `visibility` | `visible` |
+| `description` / `help` | `helpText` |
+| `default` | `defaultValue` |
+
+Declared keys are unchanged: `name`, `field`, `objectOverride`, `label`, `type`,
+`required`, `options`, `placeholder`, `helpText`, `defaultValue`, `multiple`,
+`accept`, `maxSize`, `reference`, `defaultFromRow`, `visible`, `requiresFeature`.

--- a/packages/spec/src/ui/action.test.ts
+++ b/packages/spec/src/ui/action.test.ts
@@ -108,6 +108,73 @@ describe('ActionParamSchema', () => {
       expect(ActionParamSchema.parse({ name: 'note', type: 'textarea' as const }).reference).toBeUndefined();
     });
   });
+
+  // #3405 part 3 — the root cause behind the `reference` bug was not the missing
+  // key, it was that an undeclared key was dropped *silently*: the param went on
+  // parsing and shipped a control that ignored the author's config. Strict mode
+  // turns that class of typo into a loud, fixable parse error
+  // (ADR-0078 no-silently-inert-metadata, ADR-0049 enforce-or-remove).
+  describe('unknown keys are rejected, not stripped (#3405 part 3)', () => {
+    const unknownKeyIssue = (param: Record<string, unknown>) => {
+      const result = ActionParamSchema.safeParse(param);
+      expect(result.success).toBe(false);
+      return result.error!.issues.find((i) => i.code === 'unrecognized_keys');
+    };
+
+    it('rejects an undeclared key instead of silently dropping it', () => {
+      const issue = unknownKeyIssue({ name: 'p', type: 'text', notAKey: 'x' });
+      expect(issue).toBeDefined();
+      expect(issue!.message).toContain('`notAKey`');
+    });
+
+    it('points a snake_case mis-spelling at the declared camelCase key', () => {
+      // FieldSchema-adjacent metadata is snake_case, so this is the likely slip.
+      expect(unknownKeyIssue({ name: 'p', type: 'text', help_text: 'hi' })!.message)
+        .toContain('`help_text` → `helpText`');
+      expect(unknownKeyIssue({ name: 'p', type: 'text', default_value: 1 })!.message)
+        .toContain('`default_value` → `defaultValue`');
+    });
+
+    it('points the runtime lookup-target spellings at `reference` (the #3405 slip)', () => {
+      for (const key of ['reference_to', 'referenceTo', 'targetObject']) {
+        expect(unknownKeyIssue({ name: 'p', type: 'lookup', reference: 'sys_user', [key]: 'sys_user' })!.message)
+          .toContain(`\`${key}\` → \`reference\``);
+      }
+    });
+
+    it('points `visibleWhen` at `visible` so a capability gate cannot go inert', () => {
+      // ADR-0089 made `visibleWhen` canonical on view/page schemas; borrowing it
+      // here used to strip the gate and render the param unconditionally.
+      expect(unknownKeyIssue({ name: 'p', type: 'text', visibleWhen: 'features.x == true' })!.message)
+        .toContain('`visibleWhen` → `visible`');
+    });
+
+    it('still reports an unrecognisable key without a bogus suggestion', () => {
+      const message = unknownKeyIssue({ name: 'p', type: 'text', wibble: 1 })!.message;
+      expect(message).toContain('`wibble`');
+      expect(message).not.toContain('Did you mean');
+    });
+
+    it('accepts every key the schema declares (guards ACTION_PARAM_KEYS drift)', () => {
+      // If a declared key were missing from the suggestion list, or a listed key
+      // were removed from the schema, one of these probes would be rejected.
+      const probes: Record<string, unknown> = {
+        name: 'p', field: 'inspector', objectOverride: 'sys_member', label: 'P',
+        type: 'lookup', required: true, options: [{ label: 'A', value: 'a' }],
+        placeholder: 'ph', helpText: 'help', defaultValue: 'd', multiple: true,
+        accept: ['image/*'], maxSize: 1024, reference: 'sys_user',
+        defaultFromRow: true, visible: 'features.phoneNumber == true',
+        requiresFeature: 'phoneNumber',
+      };
+      for (const [key, value] of Object.entries(probes)) {
+        const result = ActionParamSchema.safeParse({ name: 'p', [key]: value });
+        const unknown = result.success
+          ? undefined
+          : result.error.issues.find((i) => i.code === 'unrecognized_keys');
+        expect(unknown, `\`${key}\` should be a declared ActionParam key`).toBeUndefined();
+      }
+    });
+  });
 });
 
 // #2874 P1 — declarative `requiresFeature` sugar, lowered at parse time into

--- a/packages/spec/src/ui/action.zod.ts
+++ b/packages/spec/src/ui/action.zod.ts
@@ -9,6 +9,85 @@ import { HookBodySchema } from '../data/hook-body.zod';
 // Imported file-directly (not via the kernel barrel): the module is
 // deliberately import-free, so this cannot introduce a cycle.
 import { PUBLIC_AUTH_FEATURE_NAMES, lowerRequiresFeature } from '../kernel/public-auth-features';
+import { findClosestMatches } from '../shared/suggestions.zod';
+
+/**
+ * Keys `ActionParamSchema` declares.
+ *
+ * Kept beside the schema rather than derived from `.shape`: the schema body is
+ * allocated lazily (see `lazySchema`), and the error map below has to name a
+ * canonical key *while* that first parse is still in flight. `action.zod.test.ts`
+ * asserts every entry here is really accepted, so the list cannot rot silently.
+ */
+const ACTION_PARAM_KEYS = [
+  'name', 'field', 'objectOverride', 'label', 'type', 'required', 'options',
+  'placeholder', 'helpText', 'defaultValue', 'multiple', 'accept', 'maxSize',
+  'reference', 'defaultFromRow', 'visible', 'requiresFeature',
+] as const;
+
+/**
+ * Semantic near-misses — a different **word** for the same intent, usually
+ * borrowed from a neighbouring schema where that word is correct. Edit distance
+ * cannot reach these (`visibleWhen` → `visible` is 4 apart), so they are named
+ * explicitly; plain case/underscore slips (`help_text` → `helpText`) are left to
+ * {@link findClosestMatches}. Mirrors the `FIELD_TYPE_ALIASES` pattern in
+ * `shared/suggestions.zod.ts`.
+ *
+ * Keys are normalised by {@link aliasProbe} — lowercase, separators removed.
+ */
+const ACTION_PARAM_KEY_ALIASES: Readonly<Record<string, string>> = {
+  // The objectql/runtime field shape spells a lookup target `reference_to`, and
+  // objectui's resolved param calls it `referenceTo`. Dropping either is the
+  // exact #3405 failure: a targetless picker degrades to a raw-UUID text box.
+  referenceto: 'reference',
+  referenceobject: 'reference',
+  referencedobject: 'reference',
+  targetobject: 'reference',
+  // ADR-0089 made `visibleWhen` the canonical predicate on view/page schemas.
+  // An author who learned it there would silently lose a param's capability
+  // gate here — the param would render unconditionally.
+  visiblewhen: 'visible',
+  visibleon: 'visible',
+  visibility: 'visible',
+  description: 'helpText',
+  help: 'helpText',
+  default: 'defaultValue',
+};
+
+/** `reference_to` / `referenceTo` / `Reference-To` all collapse onto one probe. */
+const aliasProbe = (key: string): string => key.toLowerCase().replace(/[_\-\s]/g, '');
+
+/**
+ * Custom zod `error` for the `.strict()` {@link ActionParamSchema} (#3405 part 3).
+ *
+ * Before this, the schema was zod-default `.strip`: a key it does not declare was
+ * **silently discarded**, and the param went on parsing. That is how a correctly
+ * intended `reference: 'sys_user'` became a text box asking a human to paste a
+ * UUID, with no error anywhere — the config was eaten and the UI lied about why
+ * (ADR-0078 no-silently-inert-metadata, ADR-0049 enforce-or-remove).
+ *
+ * Strict alone would only say "unrecognized key". This map makes the rejection
+ * *fixable*: it names the offending key(s) and, when one is a recognisable
+ * spelling of a declared key, points at the canonical one.
+ */
+export const actionParamUnknownKeyError: z.core.$ZodErrorMap = (issue) => {
+  if (issue.code !== 'unrecognized_keys') return undefined;
+  const keys = (issue as { keys?: readonly string[] }).keys ?? [];
+  const suggestions = keys.flatMap((key) => {
+    // Length-relative bound, matching `suggestKey` in `data/object.zod.ts`: a
+    // flat distance of 3 is noise on a short key (`wibble` → `visible`).
+    const maxDistance = Math.max(2, Math.floor(key.length / 3));
+    const canonical =
+      ACTION_PARAM_KEY_ALIASES[aliasProbe(key)] ??
+      findClosestMatches(key, ACTION_PARAM_KEYS, maxDistance, 1)[0];
+    return canonical && canonical !== key ? [`\`${key}\` → \`${canonical}\``] : [];
+  });
+  const base =
+    `Unrecognized key(s) on this action param: ${keys.map((k) => `\`${k}\``).join(', ')}. ` +
+    `Until #3405 these were dropped silently — the param still parsed, so a mis-spelled ` +
+    `config shipped as a control that quietly ignored it.`;
+  return suggestions.length ? `${base} Did you mean ${suggestions.join(', ')}?` : base;
+};
 
 /**
  * Action Parameter Schema
@@ -45,6 +124,7 @@ import { PUBLIC_AUTH_FEATURE_NAMES, lowerRequiresFeature } from '../kernel/publi
  * to the field name and is used as the request-body key).
  */
 import { lazySchema } from '../shared/lazy-schema';
+
 export const ActionParamSchema = lazySchema(() => z.object({
   /** Request-body key. Defaults to `field` when `field` is set. */
   name: z.string().optional(),
@@ -123,7 +203,7 @@ export const ActionParamSchema = lazySchema(() => z.object({
    * enum-checked and the gate/registry stay in lockstep.
    */
   requiresFeature: z.enum(PUBLIC_AUTH_FEATURE_NAMES).optional().describe('Public auth feature flag gating this param; lowered into `visible` at parse time.'),
-}).refine(
+}, { error: actionParamUnknownKeyError }).strict().refine(
   (p) => Boolean(p.name) || Boolean(p.field),
   { message: 'ActionParam requires either "name" or "field"' },
 ).refine(

--- a/packages/spec/src/ui/action.zod.ts
+++ b/packages/spec/src/ui/action.zod.ts
@@ -106,7 +106,7 @@ const aliasProbe = (key: string): string => key.toLowerCase().replace(/[_\-\s]/g
  * *fixable*: it names the offending key(s) and, when one is a recognisable
  * spelling of a declared key, points at the canonical one.
  */
-export const actionParamUnknownKeyError: z.core.$ZodErrorMap = (issue) => {
+const actionParamUnknownKeyError: z.core.$ZodErrorMap = (issue) => {
   if (issue.code !== 'unrecognized_keys') return undefined;
   const keys = (issue as { keys?: readonly string[] }).keys ?? [];
   const suggestions = keys.flatMap((key) => {

--- a/packages/spec/src/ui/action.zod.ts
+++ b/packages/spec/src/ui/action.zod.ts
@@ -12,6 +12,42 @@ import { PUBLIC_AUTH_FEATURE_NAMES, lowerRequiresFeature } from '../kernel/publi
 import { findClosestMatches } from '../shared/suggestions.zod';
 
 /**
+ * Action Parameter Schema
+ *
+ * Defines inputs required before executing an action.
+ *
+ * Two declaration modes:
+ *
+ * 1. **Field-backed** (preferred) — reference an existing object field; the
+ *    runtime resolves the field's label (i18n), type, validation rules,
+ *    options, placeholder, help text, and widget mapping from object
+ *    metadata. Cross-object references use `objectOverride`.
+ *
+ *    ```ts
+ *    params: [
+ *      { field: 'email' },                                 // same object
+ *      { field: 'role', objectOverride: 'sys_member' },    // different object
+ *    ]
+ *    ```
+ *
+ * 2. **Inline** (legacy / bespoke) — declare `name`, `label`, `type` etc.
+ *    inline when no matching object field exists. Inline values may also be
+ *    used alongside `field` to override individual properties. A `lookup` /
+ *    `master_detail` param declared this way MUST name its target object via
+ *    `reference` — there is no field to inherit it from:
+ *
+ *    ```ts
+ *    params: [
+ *      { name: 'inspector', label: 'Inspector', type: 'lookup', reference: 'sys_user' },
+ *    ]
+ *    ```
+ *
+ * `name` is required unless `field` is provided (in which case it defaults
+ * to the field name and is used as the request-body key).
+ */
+import { lazySchema } from '../shared/lazy-schema';
+
+/**
  * Keys `ActionParamSchema` declares.
  *
  * Kept beside the schema rather than derived from `.shape`: the schema body is
@@ -89,41 +125,6 @@ export const actionParamUnknownKeyError: z.core.$ZodErrorMap = (issue) => {
   return suggestions.length ? `${base} Did you mean ${suggestions.join(', ')}?` : base;
 };
 
-/**
- * Action Parameter Schema
- *
- * Defines inputs required before executing an action.
- *
- * Two declaration modes:
- *
- * 1. **Field-backed** (preferred) — reference an existing object field; the
- *    runtime resolves the field's label (i18n), type, validation rules,
- *    options, placeholder, help text, and widget mapping from object
- *    metadata. Cross-object references use `objectOverride`.
- *
- *    ```ts
- *    params: [
- *      { field: 'email' },                                 // same object
- *      { field: 'role', objectOverride: 'sys_member' },    // different object
- *    ]
- *    ```
- *
- * 2. **Inline** (legacy / bespoke) — declare `name`, `label`, `type` etc.
- *    inline when no matching object field exists. Inline values may also be
- *    used alongside `field` to override individual properties. A `lookup` /
- *    `master_detail` param declared this way MUST name its target object via
- *    `reference` — there is no field to inherit it from:
- *
- *    ```ts
- *    params: [
- *      { name: 'inspector', label: 'Inspector', type: 'lookup', reference: 'sys_user' },
- *    ]
- *    ```
- *
- * `name` is required unless `field` is provided (in which case it defaults
- * to the field name and is used as the request-body key).
- */
-import { lazySchema } from '../shared/lazy-schema';
 
 export const ActionParamSchema = lazySchema(() => z.object({
   /** Request-body key. Defaults to `field` when `field` is set. */

--- a/skills/objectstack-data/references/_index.md
+++ b/skills/objectstack-data/references/_index.md
@@ -27,6 +27,7 @@ from `node_modules` — there is no local copy in the skill bundle.
 - `node_modules/@objectstack/spec/src/shared/http.zod.ts` — Shared HTTP Schemas
 - `node_modules/@objectstack/spec/src/shared/identifiers.zod.ts` — System Identifier Schema
 - `node_modules/@objectstack/spec/src/shared/protection.zod.ts` — Package-level metadata protection (ADR-0010 §3.7 — Phase 4.3)
+- `node_modules/@objectstack/spec/src/shared/suggestions.zod.ts` — "Did you mean?" Suggestion Utilities
 - `node_modules/@objectstack/spec/src/ui/action.zod.ts` — Action Parameter Schema
 - `node_modules/@objectstack/spec/src/ui/i18n.zod.ts` — I18n Object Schema
 - `node_modules/@objectstack/spec/src/ui/responsive.zod.ts` — Breakpoint Name Enum

--- a/skills/objectstack-platform/references/_index.md
+++ b/skills/objectstack-platform/references/_index.md
@@ -32,6 +32,7 @@ from `node_modules` — there is no local copy in the skill bundle.
 - `node_modules/@objectstack/spec/src/shared/expression.zod.ts` — Expression Protocol
 - `node_modules/@objectstack/spec/src/shared/identifiers.zod.ts` — System Identifier Schema
 - `node_modules/@objectstack/spec/src/shared/protection.zod.ts` — Package-level metadata protection (ADR-0010 §3.7 — Phase 4.3)
+- `node_modules/@objectstack/spec/src/shared/suggestions.zod.ts` — "Did you mean?" Suggestion Utilities
 - `node_modules/@objectstack/spec/src/system/tenant.zod.ts` — Tenant Schema (Multi-Tenant Architecture)
 - `node_modules/@objectstack/spec/src/ui/action.zod.ts` — Action Parameter Schema
 - `node_modules/@objectstack/spec/src/ui/app.zod.ts` — Base Navigation Item Schema

--- a/skills/objectstack-ui/references/_index.md
+++ b/skills/objectstack-ui/references/_index.md
@@ -34,6 +34,7 @@ from `node_modules` — there is no local copy in the skill bundle.
 - `node_modules/@objectstack/spec/src/shared/http.zod.ts` — Shared HTTP Schemas
 - `node_modules/@objectstack/spec/src/shared/identifiers.zod.ts` — System Identifier Schema
 - `node_modules/@objectstack/spec/src/shared/protection.zod.ts` — Package-level metadata protection (ADR-0010 §3.7 — Phase 4.3)
+- `node_modules/@objectstack/spec/src/shared/suggestions.zod.ts` — "Did you mean?" Suggestion Utilities
 - `node_modules/@objectstack/spec/src/ui/i18n.zod.ts` — I18n Object Schema
 - `node_modules/@objectstack/spec/src/ui/responsive.zod.ts` — Breakpoint Name Enum
 - `node_modules/@objectstack/spec/src/ui/sharing.zod.ts` — Sharing & Embedding Protocol


### PR DESCRIPTION
Closes **part 3** of #3405 — the item #3406 deferred as「单独评估、必要时拆出去做」。

## 问题

#3406 / objectui#2786 修的是症状:给内联 record-picker 参数加了 `reference` 键,并让缺目标的参数在解析期报错。**导致它的机制原样留着** —— `ActionParamSchema` 是 zod 默认 `.strip`,任何它没声明的键都被**静默丢弃**,参数照常 parse 通过。

作者写了一个语义完全正确、且与 `FieldSchema.reference` 同名的键,得到的唯一反馈是一个要求粘 UUID 的文本框。下一个写错键名的作者会以同样的方式失败,同样毫无声音。

这一条不修,#3405 修的就只是一个键,不是那个坑。

## 改动

`ActionParamSchema` 改为 `.strict()`,并配一个让拒绝**可修**而不只是**大声**的 error map:

- **大小写 / 下划线走形**(`help_text` → `helpText`、`default_value` → `defaultValue`)交给共享的 `findClosestMatches`,距离上界沿用 `data/object.zod.ts` 里 `suggestKey` 的**长度相对**公式 —— 固定距离 3 会给 `wibble` 推荐 `visible`。
- **编辑距离够不到的语义近义键**按 `FIELD_TYPE_ALIASES` 的风格显式列出:
  - `reference_to` / `referenceTo` / `targetObject` → `reference`(运行时字段形状是前者,objectui 解析后的参数是后者 —— 正是 #3405 那次被丢的两种拼法)
  - `visibleWhen` / `visibleOn` / `visibility` → `visible`

最后这条是这个 PR 超出「防错别字」的价值所在:ADR-0089 把 `visibleWhen` 定为 view/page schema 的正统拼法,**在这里借用它,过去会把参数的能力开关整个剥掉,让它无条件渲染** —— 一个静默失效的权限门。

遵循 ADR-0078(no-silently-inert-metadata)与 ADR-0049(enforce-or-remove),做法与 ADR-0089 D3a 对 view/page schema 的处理一致。

## 影响面(issue 里担心的那一点)

issue 原文说这条「影响面比前两条大得多,可能踩到其他既有元数据」。实测**本仓零破坏**:

- `@objectstack/spec` 全量 **258 文件 / 6716 用例通过**
- `tsc --noEmit` 干净
- **app-showcase / app-crm / app-todo 三个示例应用全部 `validate` 通过** —— 仓库里没有任何既有元数据带着未声明的参数键
- 下游消费包回归:`lint` 467 例、`metadata` 276 例、`metadata-core` 100 例、`platform-objects` 223 例、`metadata-protocol` 70 例、`sdui-parser` 6 例,全过

## 验证

在 showcase 的内联 picker 参数上**实种一个坏键**(保留合法的 `reference`,只加一个 `visibleWhen`,以隔离本 PR 的新行为):

```
✗ "code": "unrecognized_keys",
  "message": "Unrecognized key(s) on this action param: `visibleWhen`. Until #3405
  these were dropped silently — the param still parsed, so a mis-spelled config
  shipped as a control that quietly ignored it. Did you mean `visibleWhen` → `visible`?"
```

去掉后 `✓ Validation passed`。`reference_to` 同样命中 `→ reference`。

## 破坏性说明

带多余键的既有参数现在会 parse 失败。这正是本 PR 的意图 —— 那些键本来就没有生效,只是坏得没声音。错误信息直接点名该键并给出正确拼法,changeset 里附了 FROM → TO 对照表。

## 遗留(不在本 PR)

#3405 验收里的 PLAT-DEF-005 真机回归仍**卡在发版**:npm 上 `@objectstack/spec` 最新是 **16.1.0(2026-07-22T01:06Z)**,早于 #3406 合并(同日 20:46Z)。我拉 16.1.0 的 tarball 确认过,`dist/` 里没有 `reference` 的校验。天顺 EHR 那行 `reference: 'sys_user'` 至今仍被服务端 strip。#3406 的 changeset 也还挂在 `.changeset/` 里未消费 —— 同一个佐证。**需要发一次 spec 版本**才能收尾。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkvDs4y4gveyB5NJZKxaZt

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkvDs4y4gveyB5NJZKxaZt)_