### PR TITLE
fix(approvals): a schedule-triggered run can write its own locked record (#3712)

### DIFF
--- a/.changeset/approval-dead-run-record-lock.md
+++ b/.changeset/approval-dead-run-record-lock.md
@@ -20,8 +20,8 @@ Both halves are now closed.
 
 **Prevention — the owning run may write its own record.** The automation engine
 stamps `flowRunId` onto the run context at setup, alongside `runAs`, and it
-travels with every data node's ObjectQL context into `ctx.session`. The lock hook
-exempts a write whose `flowRunId` matches the pending request's `flow_run_id`.
+travels with every data node's ObjectQL context into `ctx.provenance`. The lock
+hook exempts a write whose `flowRunId` matches the pending request's `flow_run_id`.
 It is keyed on run identity rather than elevation on purpose: a `runAs:'user'`
 run stays fully RLS-scoped while it writes. `flowRunId` is pure provenance —
 server-constructed like `isSystem`, never client-supplied, evaluated by no
@@ -49,9 +49,9 @@ entries under one id, so every suspend-then-finish run — every approval, scree
 and wait flow — reported itself as `paused` forever, both on the Runs
 observability surface and to this sweep.
 
-Residual, deliberately not changed here: a `runAs:'user'` run with no trigger
-user (a schedule) passes no ObjectQL context at all, so it carries no
-`flowRunId` and is still subject to the lock. Manufacturing a context just to
-carry the run id would flip that run from its documented unscoped fail-open
-(#1888) to baseline-member RLS — a separate, larger change. The sweep is what
-recovers that shape.
+One shape was left out here and closed separately in #3712: a `runAs:'user'` run
+with no trigger user (a schedule) resolved no ObjectQL context at all, so it
+carried no `flowRunId` and stayed subject to the lock. It now passes a
+provenance-only context — the run id and nothing the security middleware keys on
+— so it is attributable without acquiring a principal, and its documented
+unscoped posture (#1888) is unchanged.

--- a/.changeset/approval-lock-schedule-run-provenance.md
+++ b/.changeset/approval-lock-schedule-run-provenance.md
@@ -1,0 +1,50 @@
+---
+"@objectstack/service-automation": patch
+"@objectstack/plugin-approvals": patch
+"@objectstack/objectql": patch
+"@objectstack/spec": patch
+---
+
+fix(approvals): a schedule-triggered run can write its own locked record (#3712)
+
+#3456 let the run that opened a pending approval write its own target record,
+keyed on `flowRunId`. It worked for every run that resolves an identity and
+missed the one that doesn't: an effective `runAs:'user'` run with **no trigger
+user** — a schedule being the canonical case — passed no ObjectQL context at
+all, so nothing carried the run id and the run still died on its own
+`RECORD_LOCKED`.
+
+The blocker was never the lock. It was that "no identity" and "no context" were
+the same thing on the wire, so a run could not say *who it was* without also
+claiming *what it was allowed to do*.
+
+**A run with no principal now passes provenance alone.**
+`resolveRunDataContext` returns `{ flowRunId }` — no `userId`, no `positions`,
+no `permissions`, not even `isSystem: false`. Every principal gate keys on one
+of those fields (the elevation short-circuit on `isSystem`, the ADR-0103
+engine-owned write guard and the ADR-0090 D12 delegated-admin gate on `userId`,
+the empty-principal fall-open on all three), so this context authorizes
+**identically to no context at all**. The run keeps the documented #1888
+unscoped posture, its loud `[runAs]` warning, and the
+`flow-schedule-runas-unscoped` build-time lint. Nothing about what it may touch
+changed — only that it can now be attributed.
+
+**Provenance moved out of the hook session, into `ctx.provenance`.** `session`
+answers *who is calling* and is absent when no identity envelope was supplied —
+a distinction real gates depend on (the attachment access gate skips bare-kernel
+writes on exactly that test). Folding a run id into `session` would have forced
+an identity-less run to present an empty session, silently turning "no caller"
+into "an anonymous caller" and narrowing the #1888 fail-open for attachments
+alone. `HookContext.provenance.flowRunId` says what produced the write; the
+approvals lock reads it there.
+
+Also relaxes `BaseEngineOptionsSchema.context` to a partial envelope
+(`ExecutionContextInput`). `positions`/`permissions`/`isSystem` carry parse-time
+defaults, which made them *required* on a caller-supplied option and asserted
+something untrue — that every data-engine context carries a principal. Callers
+have always passed slices (`{ isSystem: true }` for a system read); the type now
+says so.
+
+Migration: nothing to change unless you read the run id inside a hook. If you
+wrote `ctx.session.flowRunId`, read `ctx.provenance.flowRunId` instead — the
+field never shipped under the old name.

--- a/content/docs/kernel/contracts/data-engine.mdx
+++ b/content/docs/kernel/contracts/data-engine.mdx
@@ -94,9 +94,14 @@ interface EngineQueryOptions {
   search?: FullTextSearch;                   // Full-text search
   expand?: Record<string, QueryAST>;         // Recursive relation loading
   distinct?: boolean;                        // SELECT DISTINCT
-  context?: ExecutionContext;                 // Identity, tenant, transaction
+  context?: ExecutionContextInput;            // Identity, tenant, transaction — any subset
 }
 ```
+
+`ExecutionContextInput` is `ExecutionContext` with every field optional — supply
+what you have, the engine reads what it needs. A system read passes
+`{ isSystem: true }`; an automation run with no resolvable identity passes only
+its run id (`{ flowRunId }`), a context that deliberately carries no principal.
 
 ### FilterCondition (where)
 
@@ -191,7 +196,7 @@ const tasks = await engine.insert('task', [
 ```typescript
 interface DataEngineInsertOptions {
   returning?: boolean;          // Return inserted record(s)? Default: true
-  context?: ExecutionContext;    // Identity, tenant, transaction
+  context?: ExecutionContextInput;  // Identity, tenant, transaction — any subset
 }
 ```
 
@@ -218,7 +223,7 @@ interface EngineUpdateOptions {
   upsert?: boolean;             // Insert if not found? Default: false
   multi?: boolean;              // Update multiple records? Default: false
   returning?: boolean;          // Return updated record(s)? Default: false
-  context?: ExecutionContext;
+  context?: ExecutionContextInput;
 }
 ```
 
@@ -268,7 +273,7 @@ await engine.delete('task', {
 interface EngineDeleteOptions {
   where?: FilterCondition;      // Filter to identify records (WHERE)
   multi?: boolean;              // Delete multiple records? Default: false
-  context?: ExecutionContext;
+  context?: ExecutionContextInput;
 }
 ```
 
@@ -306,7 +311,7 @@ interface EngineAggregateOptions {
   where?: FilterCondition;                 // Pre-aggregation filter (WHERE)
   groupBy?: string[];                      // GROUP BY fields
   aggregations?: AggregationNode[];        // Aggregation definitions
-  context?: ExecutionContext;
+  context?: ExecutionContextInput;
 }
 
 interface AggregationNode {

--- a/content/docs/references/data/hook.mdx
+++ b/content/docs/references/data/hook.mdx
@@ -38,6 +38,7 @@ const result = HookContext.parse(data);
 | **result** | `any` | optional | Operation result (After hooks only) |
 | **previous** | `Record<string, any>` | optional | Record state before operation |
 | **session** | `{ userId?: string; organizationId?: string; roles?: string[]; accessToken?: string; … }` | optional | Current session context |
+| **provenance** | `{ flowRunId?: string }` | optional | Server-stamped write provenance (never client-supplied, never an authorization input) |
 | **transaction** | `any` | optional | Database transaction handle |
 | **ql** | `any` | ✅ | ObjectQL Engine Reference |
 | **api** | `any` | optional | Cross-object data access (ScopedContext) |

--- a/packages/objectql/src/engine.test.ts
+++ b/packages/objectql/src/engine.test.ts
@@ -527,6 +527,77 @@ describe('ObjectQL Engine', () => {
         });
     });
 
+    /**
+     * #3712 — write PROVENANCE (what produced the write) is surfaced separately
+     * from the SESSION (who is calling), because a writer can have the first and
+     * none of the second: a schedule-triggered flow run resolves no principal but
+     * still owns its writes. Folding the two together would have forced such a run
+     * to present an empty session, silently converting "no caller" into "an
+     * anonymous caller" for every hook that skips when `ctx.session` is absent.
+     */
+    describe('hook provenance is separate from the hook session (#3712)', () => {
+        beforeEach(async () => {
+            engine.registerDriver(mockDriver, true);
+            await engine.init();
+            vi.mocked(SchemaRegistry.getObject).mockReturnValue({ name: 'task', fields: {} } as any);
+        });
+
+        const capture = () => {
+            const seen: { session?: any; provenance?: any } = {};
+            engine.registerHook('beforeInsert', async (ctx: any) => {
+                seen.session = ctx.session;
+                seen.provenance = ctx.provenance;
+            }, { object: 'task' });
+            return seen;
+        };
+
+        it('a provenance-only context yields provenance and NO session', async () => {
+            const seen = capture();
+
+            await engine.insert('task', { title: 'x' }, { context: { flowRunId: 'run_1' } as any });
+
+            expect(seen.provenance).toEqual({ flowRunId: 'run_1' });
+            // The whole point: `!ctx.session` still means "no identity envelope
+            // was supplied", so caller-gating hooks keep skipping for this write.
+            expect(seen.session).toBeUndefined();
+        });
+
+        it('an identity-bearing run carries both', async () => {
+            const seen = capture();
+
+            await engine.insert('task', { title: 'y' }, { context: { userId: 'u1', flowRunId: 'run_2' } as any });
+
+            expect(seen.provenance).toEqual({ flowRunId: 'run_2' });
+            expect(seen.session).toMatchObject({ userId: 'u1' });
+            // Provenance is NOT identity — it must not reappear inside the session.
+            expect(seen.session).not.toHaveProperty('flowRunId');
+        });
+
+        it('no context at all yields neither', async () => {
+            const seen = capture();
+
+            await engine.insert('task', { title: 'z' });
+
+            expect(seen.provenance).toBeUndefined();
+            expect(seen.session).toBeUndefined();
+        });
+
+        it('an anonymous transport request still yields a session (it has a caller)', async () => {
+            // The shape resolveExecutionContext builds for a signed-out HTTP
+            // request: no userId, but a resolved (empty) principal. That is an
+            // anonymous CALLER, not the absence of one — hooks must keep gating it.
+            const seen = capture();
+
+            await engine.insert('task', { title: 'w' }, {
+                context: { isSystem: false, positions: [], permissions: [] } as any,
+            });
+
+            expect(seen.session).toBeDefined();
+            expect(seen.session.userId).toBeUndefined();
+            expect(seen.provenance).toBeUndefined();
+        });
+    });
+
     describe('execution context via the trailing options arg (read methods)', () => {
         // Regression: reads took context inside the query while writes took it in
         // a trailing options arg — so `find(obj, q, { context })` silently dropped

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -18,7 +18,7 @@ import {
   FILE_REFERENCES_MIGRATION_ID,
   isDataMigrationFlagVerified,
 } from '@objectstack/spec/system';
-import { ExecutionContext, ExecutionContextSchema } from '@objectstack/spec/kernel';
+import { ExecutionContext, ExecutionContextInput, ExecutionContextSchema } from '@objectstack/spec/kernel';
 import { IDataDriver, IDataEngine, Logger, createLogger, withTransientRetry, type RetryOptions } from '@objectstack/core';
 import { SummaryRecomputeError, type SummaryRecomputeFailure } from './summary-errors.js';
 
@@ -140,7 +140,7 @@ function planFormulaProjection(
 function applyFormulaPlan(
   plan: FormulaPlanEntry[],
   records: any[],
-  execCtx?: ExecutionContext,
+  execCtx?: ExecutionContextInput,
   nowSnapshot?: Date,
 ): void {
   if (!plan.length) return;
@@ -192,7 +192,7 @@ export interface OperationContext {
   ast?: QueryAST;
   data?: any;
   options?: any;
-  context?: ExecutionContext;
+  context?: ExecutionContextInput;
   result?: any;
 }
 
@@ -211,14 +211,14 @@ export interface OperationContext {
  * are given, `options.context` wins (it is the explicit channel).
  */
 export interface EngineReadOptions {
-  context?: ExecutionContext;
+  context?: ExecutionContextInput;
 }
 
 /** Merge read-path execution context from the query and the trailing options. */
 function mergeReadContext(
-  fromQuery?: ExecutionContext,
-  fromOptions?: ExecutionContext,
-): ExecutionContext | undefined {
+  fromQuery?: ExecutionContextInput,
+  fromOptions?: ExecutionContextInput,
+): ExecutionContextInput | undefined {
   if (fromOptions == null) return fromQuery;
   if (fromQuery == null) return fromOptions;
   return { ...fromQuery, ...fromOptions };
@@ -232,7 +232,7 @@ function mergeReadContext(
  * for a "historical" import) turns it off. Both are server-set, never
  * client-supplied.
  */
-function shouldSkipStateMachine(ctx?: ExecutionContext): boolean {
+function shouldSkipStateMachine(ctx?: ExecutionContextInput): boolean {
   return ctx?.seedReplay === true || ctx?.skipStateMachine === true;
 }
 
@@ -765,11 +765,21 @@ export class ObjectQL implements IDataEngine {
   }
 
   /**
-   * Build a HookContext.session from ExecutionContext
+   * Build a HookContext.session from ExecutionContext — WHO is calling.
+   *
+   * Returns `undefined` when the context yields nothing session-worthy, which
+   * keeps `!ctx.session` meaning exactly one thing for hooks: "no identity
+   * envelope was supplied" — the bare-kernel / programmatic call that
+   * caller-gating hooks skip for. A context carrying only write PROVENANCE
+   * (`{ flowRunId }`, all an identity-less flow run has — #3712) is such a
+   * case: it says what produced the write, not who is calling, and surfaces
+   * through {@link buildProvenance} instead. Every real transport resolves
+   * `positions` into the context, so an anonymous HTTP request still yields a
+   * session and stays gated.
    */
-  private buildSession(execCtx?: ExecutionContext): HookContext['session'] {
+  private buildSession(execCtx?: ExecutionContextInput): HookContext['session'] {
     if (!execCtx) return undefined;
-    return {
+    const session = {
       userId: execCtx.userId,
       // `organizationId` is the blessed developer-facing name for the caller's
       // active org (matches the `organization_id` column, `current_user`
@@ -783,12 +793,6 @@ export class ObjectQL implements IDataEngine {
       // Propagate system-elevated flag so hooks can distinguish engine
       // self-writes (e.g. approval status mirror) from genuine user writes.
       ...((execCtx as any).isSystem ? { isSystem: true } : {}),
-      // Propagate the owning flow run so a hook can recognize writes made BY a
-      // run it already knows about — the approvals record lock lets the run that
-      // opened a pending approval write its own target record (#3456). Pure
-      // provenance: it grants nothing, and unlike `isSystem` it does not widen
-      // the write's authorization, so a `runAs:'user'` run stays RLS-scoped.
-      ...((execCtx as any).flowRunId ? { flowRunId: String((execCtx as any).flowRunId) } : {}),
       // Propagate the automation-suppression flag so the record-change trigger
       // can skip flow dispatch for seed/bulk writes (ADR: seed loads end-state
       // data, not user events). `skipAutomations` implies `skipTriggers` —
@@ -803,6 +807,26 @@ export class ObjectQL implements IDataEngine {
       // stamping now (#3493). Opt-in, server-set only.
       ...((execCtx as any).preserveAudit ? { preserveAudit: true } : {}),
     } as HookContext['session'];
+    // Nothing to say about the caller → say nothing. An object whose every
+    // property is `undefined` conveys no more than no session at all, and
+    // returning it would turn "no caller" into "an anonymous caller".
+    return Object.values(session as Record<string, unknown>).some((v) => v !== undefined)
+      ? session
+      : undefined;
+  }
+
+  /**
+   * Build the HookContext.provenance envelope — WHAT produced this write.
+   *
+   * Deliberately separate from {@link buildSession}: provenance is server-
+   * stamped, evaluated by no security middleware, and can exist with no
+   * identity beside it. A schedule-triggered flow run resolves no principal
+   * yet still owns its writes, and that is the case the approvals record lock
+   * needs to recognize (#3456 / #3712).
+   */
+  private buildProvenance(execCtx?: ExecutionContextInput): HookContext['provenance'] {
+    const flowRunId = (execCtx as any)?.flowRunId;
+    return flowRunId ? { flowRunId: String(flowRunId) } : undefined;
   }
 
   /**
@@ -812,7 +836,7 @@ export class ObjectQL implements IDataEngine {
    * system / unauthenticated writes, where membership predicates then fail-open.
    */
   private buildEvalUser(
-    execCtx?: ExecutionContext,
+    execCtx?: ExecutionContextInput,
   ): { id: string; positions: string[]; organizationId: string | null } | undefined {
     if (!execCtx || execCtx.userId == null) return undefined;
     return {
@@ -833,7 +857,7 @@ export class ObjectQL implements IDataEngine {
    * hooks that need an org regardless of a resolved user read
    * `ctx.session.organizationId`, which is populated whenever a session is.
    */
-  private buildUser(execCtx?: ExecutionContext): HookContext['user'] {
+  private buildUser(execCtx?: ExecutionContextInput): HookContext['user'] {
     if (!execCtx || execCtx.userId == null) return undefined;
     return {
       id: String(execCtx.userId),
@@ -865,7 +889,7 @@ export class ObjectQL implements IDataEngine {
    * `tenantId` themselves on the resulting object; this helper does not
    * mask the system path.
    */
-  private buildDriverOptions(object: string, execCtx?: ExecutionContext, base?: any): any {
+  private buildDriverOptions(object: string, execCtx?: ExecutionContextInput, base?: any): any {
     // The open transaction may arrive explicitly via the context, or ambiently
     // via txStore when an internal query runs during a transactional write
     // (ADR-0034). Explicit wins; ambient is the safety net.
@@ -926,8 +950,8 @@ export class ObjectQL implements IDataEngine {
    * Falls back to a system-elevated empty context when no execCtx
    * is supplied (e.g. system-triggered hooks).
    */
-  private buildHookApi(execCtx?: ExecutionContext): ScopedContext {
-    const safeCtx: ExecutionContext = execCtx ?? ({ isSystem: true } as any);
+  private buildHookApi(execCtx?: ExecutionContextInput): ScopedContext {
+    const safeCtx: ExecutionContextInput = execCtx ?? ({ isSystem: true } as any);
     return new ScopedContext(safeCtx, this as unknown as IDataEngine);
   }
 
@@ -954,7 +978,7 @@ export class ObjectQL implements IDataEngine {
   private applyFieldDefaults(
     object: string,
     record: Record<string, unknown>,
-    execCtx?: ExecutionContext,
+    execCtx?: ExecutionContextInput,
     nowSnapshot?: Date,
   ): Record<string, unknown> {
     const schema = this.getSchema(object);
@@ -1026,7 +1050,7 @@ export class ObjectQL implements IDataEngine {
   private async applyAutonumbers(
     object: string,
     record: Record<string, unknown>,
-    execCtx?: ExecutionContext,
+    execCtx?: ExecutionContextInput,
     driverOwnsAutonumber?: boolean,
   ): Promise<void> {
     if (driverOwnsAutonumber) return; // driver generates persistently in create()
@@ -1077,7 +1101,7 @@ export class ObjectQL implements IDataEngine {
     object: string,
     field: string,
     prefix: string,
-    execCtx?: ExecutionContext,
+    execCtx?: ExecutionContextInput,
   ): Promise<number> {
     try {
       const rows = await this.find(object, {
@@ -1547,7 +1571,7 @@ export class ObjectQL implements IDataEngine {
   private async encryptSecretFields(
     object: string,
     row: Record<string, unknown>,
-    context: ExecutionContext | undefined,
+    context: ExecutionContextInput | undefined,
     driverOptions: unknown,
   ): Promise<void> {
     if (!row || typeof row !== 'object') return;
@@ -1943,7 +1967,7 @@ export class ObjectQL implements IDataEngine {
           const rows = await this.find(DATA_MIGRATION_FLAG_OBJECT, {
             where: { id: FILE_REFERENCES_MIGRATION_ID },
             limit: 1,
-            context: { isSystem: true } as ExecutionContext,
+            context: { isSystem: true } as ExecutionContextInput,
           });
           const row: any = rows?.[0];
           if (!row || row.id !== FILE_REFERENCES_MIGRATION_ID) return false;
@@ -2094,7 +2118,7 @@ export class ObjectQL implements IDataEngine {
     childObject: string,
     records: any,
     previous: any,
-    execCtx?: ExecutionContext,
+    execCtx?: ExecutionContextInput,
   ): Promise<SummaryRecomputeFailure[]> {
     const descriptors = this.getSummaryDescriptors(childObject);
     if (descriptors.length === 0) return [];
@@ -2160,7 +2184,7 @@ export class ObjectQL implements IDataEngine {
     records: any[],
     expand: Record<string, QueryAST>,
     depth: number = 0,
-    execCtx?: ExecutionContext,
+    execCtx?: ExecutionContextInput,
   ): Promise<any[]> {
     if (!records || records.length === 0) return records;
     if (depth >= ObjectQL.MAX_EXPAND_DEPTH) return records;
@@ -2239,7 +2263,7 @@ export class ObjectQL implements IDataEngine {
             where,
             ...(nestedAST.fields ? { fields: nestedAST.fields as any } : {}),
             ...(nestedAST.orderBy ? { orderBy: nestedAST.orderBy as any } : {}),
-            context: { ...(execCtx ?? {}), __expandRead: true } as ExecutionContext,
+            context: { ...(execCtx ?? {}), __expandRead: true } as ExecutionContextInput,
           },
         ) ?? [];
 
@@ -2311,7 +2335,7 @@ export class ObjectQL implements IDataEngine {
   private async resolveFileReferences(
     objectName: string,
     records: any[],
-    execCtx?: ExecutionContext,
+    execCtx?: ExecutionContextInput,
   ): Promise<any[]> {
     if (!records || records.length === 0) return records;
     // A caller whose subject is the STORED form — the ADR-0104 backfill /
@@ -2360,7 +2384,7 @@ export class ObjectQL implements IDataEngine {
     try {
       fileRows = (await this.find(
         'sys_file',
-        { where: { id: { $in: uniqueIds } }, context: { ...(execCtx ?? {}), __expandRead: true } as ExecutionContext },
+        { where: { id: { $in: uniqueIds } }, context: { ...(execCtx ?? {}), __expandRead: true } as ExecutionContextInput },
       )) ?? [];
     } catch {
       return records; // sys_file unregistered / unreadable — leave ids as-is
@@ -2497,6 +2521,7 @@ export class ObjectQL implements IDataEngine {
           event: 'beforeFind',
           input: { ast: opCtx.ast, options: opCtx.options },
           session: this.buildSession(opCtx.context),
+          provenance: this.buildProvenance(opCtx.context),
           user: this.buildUser(opCtx.context),
           api: this.buildHookApi(opCtx.context),
           transaction: opCtx.context?.transaction,
@@ -2587,6 +2612,7 @@ export class ObjectQL implements IDataEngine {
           event: 'beforeFind',
           input: { ast: opCtx.ast, options: opCtx.options },
           session: this.buildSession(opCtx.context),
+          provenance: this.buildProvenance(opCtx.context),
           user: this.buildUser(opCtx.context),
           api: this.buildHookApi(opCtx.context),
           transaction: opCtx.context?.transaction,
@@ -2686,6 +2712,7 @@ export class ObjectQL implements IDataEngine {
           event: 'beforeInsert',
           input: { data: row, options: opCtx.options },
           session: this.buildSession(opCtx.context),
+          provenance: this.buildProvenance(opCtx.context),
           user: this.buildUser(opCtx.context),
           api: this.buildHookApi(opCtx.context),
           transaction: opCtx.context?.transaction,
@@ -2986,6 +3013,7 @@ export class ObjectQL implements IDataEngine {
           event: 'beforeUpdate',
           input: { id, data: opCtx.data, options: opCtx.options },
           session: this.buildSession(opCtx.context),
+          provenance: this.buildProvenance(opCtx.context),
           user: this.buildUser(opCtx.context),
           api: this.buildHookApi(opCtx.context),
           transaction: opCtx.context?.transaction,
@@ -3184,7 +3212,7 @@ export class ObjectQL implements IDataEngine {
   private async cascadeDeleteRelations(
     object: string,
     id: string | number,
-    context?: ExecutionContext,
+    context?: ExecutionContextInput,
     depth = 0,
   ): Promise<void> {
     if (id == null || depth >= ObjectQL.MAX_CASCADE_DEPTH) return;
@@ -3269,7 +3297,7 @@ export class ObjectQL implements IDataEngine {
             // rides a server-DERIVED context (set here, never from client input
             // — same trust model as `__expandRead`), so it cannot be forged from
             // a request to bypass the guard on an ordinary write.
-            const referentialCtx = { ...(context ?? {}), __referentialFieldClear: true } as ExecutionContext;
+            const referentialCtx = { ...(context ?? {}), __referentialFieldClear: true } as ExecutionContextInput;
             await this.update(childName, { id: depId, [fieldName]: null }, { context: referentialCtx } as any);
           }
         }
@@ -3321,6 +3349,7 @@ export class ObjectQL implements IDataEngine {
           event: 'beforeDelete',
           input: { id, options: opCtx.options },
           session: this.buildSession(opCtx.context),
+          provenance: this.buildProvenance(opCtx.context),
           user: this.buildUser(opCtx.context),
           api: this.buildHookApi(opCtx.context),
           transaction: opCtx.context?.transaction,
@@ -3978,7 +4007,7 @@ export class ObjectQL implements IDataEngine {
 export class ObjectRepository {
   constructor(
     private objectName: string,
-    private context: ExecutionContext,
+    private context: ExecutionContextInput,
     private engine: IDataEngine & { executeAction?: (o: string, a: string, c: any) => Promise<any> }
   ) {}
 
@@ -4075,7 +4104,7 @@ export class ObjectRepository {
  */
 export class ScopedContext {
   constructor(
-    private executionContext: ExecutionContext,
+    private executionContext: ExecutionContextInput,
     private engine: IDataEngine
   ) {}
 

--- a/packages/plugins/plugin-approvals/package.json
+++ b/packages/plugins/plugin-approvals/package.json
@@ -24,6 +24,7 @@
     "@objectstack/spec": "workspace:*"
   },
   "devDependencies": {
+    "@objectstack/objectql": "workspace:*",
     "@objectstack/service-automation": "workspace:*",
     "@types/node": "^26.1.1",
     "typescript": "^6.0.3",

--- a/packages/plugins/plugin-approvals/src/approval-service.test.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.test.ts
@@ -1570,7 +1570,22 @@ describe('record-lock hook (node era)', () => {
         input: { id: 'opp1', data: { amount: 200 } },
         // Neither elevated nor admin — the exemption rides on run identity
         // alone, so a `runAs:'user'` run stays RLS-scoped while it writes.
-        session: { isSystem: false, positions: [], userId: 'u1', flowRunId: 'run_1' },
+        session: { isSystem: false, positions: [], userId: 'u1' },
+        provenance: { flowRunId: 'run_1' },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  // #3712 — the residual #3703 left open. A schedule-triggered run resolves NO
+  // principal, so it arrives with no session at all; provenance is the only
+  // thing it carries, and the exemption must key on that rather than on an
+  // identity the run does not have.
+  it('allows an identity-less (schedule-triggered) owning run — no session at all', async () => {
+    await expect(
+      engine.fire('beforeUpdate', {
+        object: 'opportunity',
+        input: { id: 'opp1', data: { amount: 200 } },
+        provenance: { flowRunId: 'run_1' },
       }),
     ).resolves.toBeUndefined();
   });
@@ -1580,7 +1595,18 @@ describe('record-lock hook (node era)', () => {
       engine.fire('beforeUpdate', {
         object: 'opportunity',
         input: { id: 'opp1', data: { amount: 200 } },
-        session: { isSystem: false, positions: [], userId: 'u1', flowRunId: 'run_other' },
+        session: { isSystem: false, positions: [], userId: 'u1' },
+        provenance: { flowRunId: 'run_other' },
+      }),
+    ).rejects.toThrow(/RECORD_LOCKED/);
+  });
+
+  it('still blocks an identity-less caller with no provenance at all', async () => {
+    // The bare-kernel / no-context write. Nothing to match, nothing exempted.
+    await expect(
+      engine.fire('beforeUpdate', {
+        object: 'opportunity',
+        input: { id: 'opp1', data: { amount: 200 } },
       }),
     ).rejects.toThrow(/RECORD_LOCKED/);
   });
@@ -1593,7 +1619,8 @@ describe('record-lock hook (node era)', () => {
       engine.fire('beforeUpdate', {
         object: 'opportunity',
         input: { id: 'opp1', data: { amount: 200 } },
-        session: { isSystem: false, positions: [], userId: 'u1', flowRunId: 'run_1' },
+        session: { isSystem: false, positions: [], userId: 'u1' },
+        provenance: { flowRunId: 'run_1' },
       }),
     ).rejects.toThrow(/RECORD_LOCKED/);
   });

--- a/packages/plugins/plugin-approvals/src/lifecycle-hooks.ts
+++ b/packages/plugins/plugin-approvals/src/lifecycle-hooks.ts
@@ -106,7 +106,13 @@ export function bindApprovalLockHook(engine: MinimalEngine, logger?: MinimalLogg
     // (never client-supplied, like `isSystem`) and it grants nothing by itself —
     // the only write it permits is to the one record this very run already holds
     // a pending request against.
-    const writerRun = (ctx?.session as any)?.flowRunId;
+    //
+    // Read off `provenance`, not `session`: provenance says WHAT produced the
+    // write, and a run can own its writes while resolving no principal at all.
+    // A schedule-triggered run is exactly that — it reaches here with NO
+    // session, and that shape is the one that used to die on its own lock
+    // (#3712).
+    const writerRun = (ctx?.provenance as any)?.flowRunId;
     if (writerRun && pending.flow_run_id && String(writerRun) === String(pending.flow_run_id)) return;
 
     const config = parseJson<any>(pending.node_config_json, {});

--- a/packages/plugins/plugin-approvals/src/record-lock-schedule-run.integration.test.ts
+++ b/packages/plugins/plugin-approvals/src/record-lock-schedule-run.integration.test.ts
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #3712 — a schedule-triggered run may write its own locked record.
+ *
+ * #3703 exempted "the run that opened the pending request" from the approvals
+ * record lock, keyed on `flowRunId`. It worked for every run that resolved an
+ * identity and silently missed the one that doesn't: an effective
+ * `runAs:'user'` run with no trigger user — a schedule — passed NO ObjectQL
+ * context at all, so nothing carried the run id and the run still died on its
+ * own `RECORD_LOCKED`.
+ *
+ * That miss was a HAND-OFF gap, not a logic gap: every hop worked in isolation.
+ * So this test refuses to stub any hop. It runs the real
+ * `resolveRunDataContext` from the automation runtime, feeds its output to a
+ * real {@link ObjectQL} engine, and lets the real lock hook decide — the same
+ * three layers, in the same order, as a live deployment.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ObjectQL } from '@objectstack/objectql';
+import { resolveRunDataContext } from '@objectstack/service-automation';
+import { bindApprovalLockHook } from './lifecycle-hooks.js';
+
+const opportunity = {
+  name: 'opportunity',
+  label: 'Opportunity',
+  fields: {
+    id: { name: 'id', type: 'text' as const, primaryKey: true },
+    name: { name: 'name', type: 'text' as const },
+    amount: { name: 'amount', type: 'number' as const },
+  },
+};
+
+/** The lock hook reads pending requests off this object. */
+const approvalRequest = {
+  name: 'sys_approval_request',
+  label: 'Approval Request',
+  fields: {
+    id: { name: 'id', type: 'text' as const, primaryKey: true },
+    object_name: { name: 'object_name', type: 'text' as const },
+    record_id: { name: 'record_id', type: 'text' as const },
+    status: { name: 'status', type: 'text' as const },
+    flow_run_id: { name: 'flow_run_id', type: 'text' as const },
+    node_config_json: { name: 'node_config_json', type: 'text' as const },
+  },
+};
+
+function makeMemoryDriver() {
+  const stores = new Map<string, Map<string, Record<string, unknown>>>();
+  const storeFor = (o: string) => {
+    let s = stores.get(o);
+    if (!s) { s = new Map(); stores.set(o, s); }
+    return s;
+  };
+  let nextId = 0;
+  const matches = (row: Record<string, unknown>, where: any): boolean => {
+    if (!where || typeof where !== 'object') return true;
+    for (const [k, v] of Object.entries(where)) {
+      if (k.startsWith('$')) continue;
+      const exp = (v && typeof v === 'object' && '$eq' in (v as any)) ? (v as any).$eq : v;
+      if ((row[k] ?? null) !== (exp ?? null)) return false;
+    }
+    return true;
+  };
+  const driver: any = {
+    name: 'memory', version: '0.0.0', supports: {},
+    async connect() {}, async disconnect() {}, async checkHealth() { return true; }, async execute() { return null; },
+    async find(o: string, ast: any) { return Array.from(storeFor(o).values()).filter((r) => matches(r, ast?.where)); },
+    findStream() { throw new Error('ns'); },
+    async findOne(o: string, ast: any) { for (const r of storeFor(o).values()) if (matches(r, ast?.where)) return r; return null; },
+    async create(o: string, data: Record<string, unknown>) {
+      nextId += 1;
+      const id = (data.id as string) ?? `r_${nextId}`;
+      const row = { ...data, id };
+      storeFor(o).set(id, row);
+      return row;
+    },
+    async update(o: string, id: string, data: Record<string, unknown>) {
+      const s = storeFor(o);
+      const cur = s.get(id);
+      if (!cur) throw new Error(`nf ${o}/${id}`);
+      const up = { ...cur, ...data, id };
+      s.set(id, up);
+      return up;
+    },
+    async upsert(o: string, data: Record<string, unknown>) {
+      const id = data.id as string | undefined;
+      return id && storeFor(o).has(id) ? this.update(o, id, data) : this.create(o, data);
+    },
+    async delete(o: string, id: string) { return storeFor(o).delete(id); },
+    async count(o: string, ast: any) { return (await this.find(o, ast)).length; },
+    async bulkCreate(o: string, rows: Record<string, unknown>[]) { return Promise.all(rows.map((r) => this.create(o, r))); },
+    async bulkUpdate() { return []; },
+    async bulkDelete() {},
+    async beginTransaction() { return { commit: async () => {}, rollback: async () => {} }; },
+    async commit() {}, async rollback() {},
+  };
+  return driver;
+}
+
+/** The run context a schedule trigger produces: an event, and no user. */
+const SCHEDULE_RUN = (flowRunId: string) => ({ runAs: 'user' as const, flowRunId });
+
+describe('a schedule-triggered run and the approvals record lock (#3712)', () => {
+  let engine: ObjectQL;
+  let oppId: string;
+
+  beforeEach(async () => {
+    engine = new ObjectQL();
+    engine.registerDriver(makeMemoryDriver(), true);
+    await engine.init();
+    for (const o of [opportunity, approvalRequest]) engine.registry.registerObject(o as any);
+
+    const opp = await engine.insert('opportunity', { name: 'Deal', amount: 100 });
+    oppId = String(opp.id);
+    await engine.insert('sys_approval_request', {
+      object_name: 'opportunity',
+      record_id: oppId,
+      status: 'pending',
+      flow_run_id: 'run_1',
+      node_config_json: JSON.stringify({ lockRecord: true }),
+    });
+
+    bindApprovalLockHook(engine as any);
+  });
+
+  const writeAs = (context: unknown) =>
+    engine.update('opportunity', { id: oppId, amount: 200 }, { context } as any);
+
+  it('lets the OWNING schedule run write its own target record', async () => {
+    // The full hand-off, unstubbed: the automation runtime resolves the run's
+    // ObjectQL context, the engine turns it into hook provenance, the lock hook
+    // matches it against the pending request it opened.
+    const dataCtx = resolveRunDataContext(SCHEDULE_RUN('run_1'));
+    expect(dataCtx, 'the run resolved no context — nothing could carry the run id').toEqual({
+      flowRunId: 'run_1',
+    });
+
+    await expect(writeAs(dataCtx)).resolves.toBeDefined();
+    const row = await engine.findOne('opportunity', { where: { id: oppId } });
+    expect(row.amount).toBe(200);
+  });
+
+  it('still blocks a DIFFERENT schedule run', async () => {
+    await expect(writeAs(resolveRunDataContext(SCHEDULE_RUN('run_other'))))
+      .rejects.toThrow(/RECORD_LOCKED/);
+  });
+
+  it('still blocks an ordinary user edit', async () => {
+    await expect(writeAs({ isSystem: false, userId: 'u1', positions: [], permissions: [] }))
+      .rejects.toThrow(/RECORD_LOCKED/);
+  });
+
+  it('still blocks a context-less write', async () => {
+    await expect(writeAs(undefined)).rejects.toThrow(/RECORD_LOCKED/);
+  });
+
+  it('the exempted write presents NO principal — the lock was opened by provenance, not privilege', async () => {
+    // The exemption must not have been bought with elevation. Nothing the
+    // security middleware keys on is present, so the run's authorization is the
+    // same unscoped #1888 posture it had before this fix.
+    const dataCtx = resolveRunDataContext(SCHEDULE_RUN('run_1')) as Record<string, unknown>;
+    for (const key of ['isSystem', 'userId', 'positions', 'permissions', 'tenantId']) {
+      expect(dataCtx, `the exemption rode in on '${key}'`).not.toHaveProperty(key);
+    }
+  });
+});

--- a/packages/plugins/plugin-security/src/delegated-admin-gate.test.ts
+++ b/packages/plugins/plugin-security/src/delegated-admin-gate.test.ts
@@ -129,6 +129,15 @@ describe('DelegatedAdminGate — tenant admins and outsiders', () => {
     })).rejects.toThrow(/authenticated administrator/);
   });
 
+  // #3712 — a schedule-triggered flow run reaches the data layer carrying only
+  // its run id. That is PROVENANCE, not a principal: it must not buy the write
+  // anything the same write would not get with no context at all.
+  it('a provenance-only context is still principal-less — no run id opens this gate', async () => {
+    await expect(insertAssignment({ flowRunId: 'run_1' }, {
+      user_id: 'u_east_1', position: 'sales_rep', business_unit_id: 'bu_es',
+    })).rejects.toThrow(/authenticated administrator/);
+  });
+
   it('reads and non-governed objects are untouched', async () => {
     await expect(h.gate.assert({ object: 'sys_user_position', operation: 'find', context: {} }))
       .resolves.toBeUndefined();

--- a/packages/plugins/plugin-security/src/system-write-guard.test.ts
+++ b/packages/plugins/plugin-security/src/system-write-guard.test.ts
@@ -75,6 +75,15 @@ describe('assertEngineOwnedWriteAllowed (ADR-0103)', () => {
         expect(() => assertEngineOwnedWriteAllowed(engineOwned, op, undefined)).not.toThrow();
       }
     });
+
+    // #3712 — a schedule-triggered flow run carries only its run id. The guard
+    // keys on the PRINCIPAL, so provenance alone reads exactly like no context:
+    // the run id neither admits nor refuses a write on its own.
+    it('treats a provenance-only context exactly like no context', () => {
+      for (const op of ['insert', 'update', 'delete']) {
+        expect(() => assertEngineOwnedWriteAllowed(engineOwned, op, { flowRunId: 'run_1' })).not.toThrow();
+      }
+    });
   });
 
   describe('the writable set (system + userActions)', () => {

--- a/packages/services/service-automation/src/builtin/crud-runas.test.ts
+++ b/packages/services/service-automation/src/builtin/crud-runas.test.ts
@@ -188,22 +188,50 @@ describe('resolveRunDataContext (#1888 unit)', () => {
     });
   });
 
-  it('returns undefined for a user-mode run with no user (e.g. schedule trigger)', () => {
+  it('returns undefined for a user-mode run with no user AND no run id', () => {
     expect(resolveRunDataContext({ runAs: 'user' })).toBeUndefined();
     expect(resolveRunDataContext(undefined)).toBeUndefined();
+  });
+
+  // #3712 — a user-mode run with no user still HAS a run. It carries the run id
+  // and nothing else, so it becomes attributable without acquiring a principal.
+  it('maps a user-less run WITH a run id to a provenance-only context', () => {
+    const ctx = resolveRunDataContext({ runAs: 'user', flowRunId: 'run_1' });
+    expect(ctx).toEqual({ flowRunId: 'run_1' });
+    // Exhaustive on purpose: every field below is one the security middleware
+    // keys on. Any of them appearing here would change the run's authorization,
+    // which this fix must not do — the #1888 unscoped posture is unchanged.
+    expect(Object.keys(ctx!)).toEqual(['flowRunId']);
+    for (const key of ['isSystem', 'userId', 'positions', 'permissions', 'tenantId']) {
+      expect(ctx, `provenance-only context leaked '${key}' — it now presents a principal`)
+        .not.toHaveProperty(key);
+    }
   });
 });
 
 /**
  * #1888 FOLLOW-UP — the user-less fail-open. A schedule-triggered run carries no
  * trigger user, so an effective `runAs:'user'` (the default) resolves no identity
- * → CRUD nodes omit `options.context` → the data security middleware skips → the
+ * → CRUD nodes present no principal → the data security middleware skips → the
  * run executes UNSCOPED (effectively elevated). Denying would break legitimate
  * scheduled CRUD and silently elevating would hide the author's intent, so the
  * engine keeps the run working but makes the fail-open AUDIBLE: one clear warning
  * per run, recommending `runAs:'system'` (ADR-0049). These tests pin both the
  * (unchanged, non-breaking) data behavior AND the new warning.
  */
+
+/**
+ * The op ran with NO principal — the #1888 unscoped posture. Since #3712 such a
+ * run DOES carry a context, but a provenance-only one: the run id and nothing
+ * the security middleware keys on. Asserting "no context at all" would pin the
+ * transport instead of the property that matters.
+ */
+function expectUnscoped(ctx: any, op: string): void {
+  for (const key of ['isSystem', 'userId', 'positions', 'permissions', 'tenantId']) {
+    expect(ctx?.[key], `${op} should be unscoped — it presented '${key}'`).toBeUndefined();
+  }
+}
+
 function recordingLogger(): { logger: any; warns: string[] } {
   const warns: string[] = [];
   const l: any = { info() {}, warn: (m: string) => warns.push(m), error() {}, debug() {} };
@@ -224,9 +252,13 @@ describe('schedule/user-less runs surface the unscoped fail-open (#1888 follow-u
     const res = await engine.execute('sched', { event: 'schedule', params: { jobId: 'j1' } });
     expect(res.success).toBe(true);
 
-    // Non-breaking: the run still executes, but every data op is UNSCOPED (no ctx).
+    // Non-breaking: the run still executes, and every data op is UNSCOPED — it
+    // presents no principal, only its own run id (#3712).
     expect(calls.length).toBeGreaterThan(0);
-    for (const c of calls) expect(c.ctx, `${c.op} should be unscoped (no identity)`).toBeUndefined();
+    for (const c of calls) {
+      expectUnscoped(c.ctx, c.op);
+      expect(c.ctx?.flowRunId, `${c.op} carried no run provenance`).toBeTruthy();
+    }
 
     // ...and the fail-open is AUDIBLE: exactly one runAs warning, naming the flow + the fix.
     const w = runAsWarns(warns);
@@ -374,7 +406,7 @@ describe("runAs:'user' resolves the triggering user's grants at run setup (#3356
     engine.setUserGrantsResolver(() => { called++; return { positions: [], permissions: [] }; });
     await engine.execute('sched', { event: 'schedule' });
     expect(called).toBe(0);
-    for (const c of calls) expect(c.ctx, `${c.op} should stay unscoped`).toBeUndefined();
+    for (const c of calls) expectUnscoped(c.ctx, c.op);
   });
 
   it('fail-safe: a resolver error warns and keeps the bare user — never elevates', async () => {

--- a/packages/services/service-automation/src/index.ts
+++ b/packages/services/service-automation/src/index.ts
@@ -52,7 +52,7 @@ export type { AutomationServicePluginOptions } from './plugin.js';
 // ObjectQL `context` its data nodes pass — `system` → elevated/RLS-bypassing,
 // `user` → the triggering user. Exported for hosts building custom data nodes.
 export { resolveRunDataContext } from './runtime-identity.js';
-export type { RunDataContext } from './runtime-identity.js';
+export type { RunDataContext, RunIdentityContext, RunProvenanceContext } from './runtime-identity.js';
 
 // Built-in node executors (ADR-0018). These are seeded by AutomationServicePlugin
 // and exported for advanced hosts that build a custom engine. They are functions,

--- a/packages/services/service-automation/src/runtime-identity.ts
+++ b/packages/services/service-automation/src/runtime-identity.ts
@@ -3,13 +3,14 @@
 import type { AutomationContext } from '@objectstack/spec/contracts';
 
 /**
- * The identity envelope a flow's data nodes pass to ObjectQL as `options.context`.
- * A structural subset of the kernel `ExecutionContext` — it always carries the
- * three fields the security middleware keys on (`isSystem`, `positions`,
- * `permissions`) so it is directly assignable to the engine's `context` option,
- * plus the optional `userId`/`tenantId` of the acting user.
+ * The IDENTITY envelope a flow's data nodes pass to ObjectQL as
+ * `options.context` when the run resolves a principal. A structural subset of
+ * the kernel `ExecutionContext` — it always carries the three fields the
+ * security middleware keys on (`isSystem`, `positions`, `permissions`) so it is
+ * directly assignable to the engine's `context` option, plus the optional
+ * `userId`/`tenantId` of the acting user.
  */
-export interface RunDataContext {
+export interface RunIdentityContext {
   /** Elevated, RLS-bypassing system principal (full access) when true. */
   isSystem: boolean;
   /** Acting user id — drives owner/role RLS for `runAs:'user'` runs. */
@@ -30,6 +31,31 @@ export interface RunDataContext {
 }
 
 /**
+ * The PROVENANCE-ONLY envelope, for a run that resolves NO principal — an
+ * effective `runAs:'user'` run with no trigger user, a schedule being the
+ * canonical case (#3712).
+ *
+ * It names the run that made the write and carries nothing else: no `userId`,
+ * no `positions`, no `permissions`, not even `isSystem: false`. That absence is
+ * the point. Every principal gate in the data security middleware keys on one
+ * of those fields — the elevation short-circuit on `isSystem`, the ADR-0103
+ * engine-owned write guard and the ADR-0090 D12 delegated-admin gate on
+ * `context.userId`, the empty-principal fall-open on
+ * `positions`/`permissions`/`userId` (and the delegated-admin gate normalizes a
+ * missing context to `{}` before testing it) — so this envelope is
+ * indistinguishable from passing no context at all. The run's authorization
+ * stays EXACTLY the documented #1888 unscoped fail-open it was before; only
+ * provenance rides along.
+ */
+export interface RunProvenanceContext {
+  /** The run performing this operation. The whole envelope (#3712). */
+  flowRunId: string;
+}
+
+/** What a flow's data nodes pass to ObjectQL as `options.context`. */
+export type RunDataContext = RunIdentityContext | RunProvenanceContext;
+
+/**
  * Translate a flow run's {@link AutomationContext} into the ObjectQL `context`
  * its CRUD nodes must pass, honoring `runAs` (ADR-0049 / #1888):
  *
@@ -40,11 +66,11 @@ export interface RunDataContext {
  *    enforces that user's row-level security. The run can never exceed the
  *    triggering user's grants. Empty `positions` falls back to the platform's
  *    baseline permission set, exactly like a fresh member's own REST request.
- *
- * Returns `undefined` when neither elevation nor a user identity applies (e.g. a
- * schedule-triggered `user`-mode run with no user). The CRUD node then omits the
- * `context` and the data engine applies its no-identity default — unchanged from
- * the pre-#1888 behavior for that (identity-less) case.
+ *  - neither (an effective `runAs:'user'` run with no trigger user — a
+ *    schedule) → a {@link RunProvenanceContext}: the run id and nothing else,
+ *    so the middleware still sees no principal and the run still executes under
+ *    the documented #1888 unscoped fail-open, while hooks can tell whose run
+ *    made the write (#3712). `undefined` only when there is no run id either.
  *
  * The engine sets {@link AutomationContext.runAs} on the run context at setup;
  * this function is the single place that maps it to an ObjectQL context, shared
@@ -55,17 +81,19 @@ export function resolveRunDataContext(context: AutomationContext | undefined): R
   if (context?.runAs === 'system') {
     return { isSystem: true, positions: [], permissions: [], ...(flowRunId ? { flowRunId } : {}) };
   }
-  // NOTE (#3456 residual, tracked as #3712): the identity-less case below returns
-  // `undefined`, so a schedule-triggered `runAs:'user'` run with no user carries
-  // NO context at all — and therefore no `flowRunId` either, leaving it subject
-  // to the approvals record lock on its own target record. Manufacturing a
-  // context here just to carry the run id would flip that run from the
-  // documented unscoped fail-open (#1888) to baseline-member RLS — a separate,
-  // larger behavior change. The dead-run sweep in plugin-approvals is what
-  // recovers this shape.
-  if (!context?.userId) return undefined;
+  if (!context?.userId) {
+    // #3712 — no identity to present, but there IS a run. Carry the run id
+    // ALONE (see {@link RunProvenanceContext}): provenance without a principal,
+    // so the approvals record lock can recognise the owning run's write to its
+    // own target record (#3456) while the security middleware sees exactly what
+    // it saw before — nothing to key on. Manufacturing a *principal* here (even
+    // `{ isSystem: false, positions: [], permissions: [] }`) would be the wrong
+    // tool: it would tie this fix to the #1888 fail-open's fate instead of
+    // leaving that decision open.
+    return flowRunId ? { flowRunId } : undefined;
+  }
   // `context` is now narrowed to a defined AutomationContext with a userId.
-  const out: RunDataContext = {
+  const out: RunIdentityContext = {
     isSystem: false,
     userId: context.userId,
     positions: Array.isArray(context.positions) ? context.positions : [],
@@ -100,10 +128,12 @@ export function flowTouchesData(flow: { nodes?: ReadonlyArray<{ type?: string }>
  * effective `runAs:'user'` (explicit or defaulted) with NO resolvable trigger
  * user — e.g. a schedule-triggered run, which has no user to scope to (#1888).
  *
- * {@link resolveRunDataContext} returns `undefined` for this case, so the CRUD
- * node omits `options.context` and the data security middleware — which *skips*
- * when there is no identity (delegating auth to the auth layer) — runs the
- * operation UNSCOPED (effectively elevated). An author who left `runAs` at the
+ * {@link resolveRunDataContext} resolves no principal for this case — the CRUD
+ * node passes either no `options.context` at all or a provenance-only one
+ * (#3712), neither of which presents an identity — and the data security
+ * middleware, which *skips* when there is no identity (delegating auth to the
+ * auth layer), runs the operation UNSCOPED (effectively elevated). An author
+ * who left `runAs` at the
  * `'user'` default expecting a restricted run instead gets an unscoped one. The
  * engine uses this predicate to surface the footgun at run time (a loud warning,
  * not a silent elevation); the build-time lint `flow-schedule-runas-unscoped`

--- a/packages/services/service-storage/src/attachment-access-hooks.test.ts
+++ b/packages/services/service-storage/src/attachment-access-hooks.test.ts
@@ -100,6 +100,21 @@ describe('attachment access — beforeInsert (parent visibility + provenance)', 
     await expect(beforeInsert(insertCtx({ parent_object: 'x', parent_id: 'r' }, {}))).resolves.toBeUndefined();
   });
 
+  // #3712 — a schedule-triggered flow run has provenance but no caller. This
+  // gate reads `!ctx.session` as "no identity envelope was supplied", so write
+  // provenance is deliberately kept OUT of the session: had such a run
+  // presented an empty session instead, this bypass would have silently become
+  // a 403 and narrowed the #1888 fail-open for attachments alone.
+  it('still bypasses a flow run that carries provenance but no session', async () => {
+    const { beforeInsert } = install({ sharing: { canEdit: async () => false } });
+    await expect(
+      beforeInsert({
+        ...insertCtx({ parent_object: 'x', parent_id: 'r' }, {}),
+        provenance: { flowRunId: 'run_1' },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   // #2970 item 3 — with a sharing service present, attach requires EDIT
   // (canEdit), not merely read visibility.
   it('with sharing: rejects attaching when the caller cannot EDIT the parent (even if readable)', async () => {

--- a/packages/spec/api-surface.json
+++ b/packages/spec/api-surface.json
@@ -1437,6 +1437,7 @@
     "EventWebhookConfig (type)",
     "EventWebhookConfigSchema (const)",
     "ExecutionContext (type)",
+    "ExecutionContextInput (type)",
     "ExecutionContextSchema (const)",
     "ExtensionPoint (type)",
     "ExtensionPointSchema (const)",

--- a/packages/spec/src/contracts/automation-service.ts
+++ b/packages/spec/src/contracts/automation-service.ts
@@ -75,7 +75,9 @@ export interface AutomationContext {
      * middleware keys on it. A hook uses it to recognize writes made BY a given
      * run — the approvals record lock (#3456) lets the run that opened a pending
      * approval write its own target record, which it otherwise cannot tell apart
-     * from an unrelated user's edit.
+     * from an unrelated user's edit. A run with no resolvable principal (a
+     * schedule) carries this and nothing else into the data engine, so it is
+     * attributable without presenting an identity it does not have (#3712).
      *
      * Callers do NOT set this — the engine derives it, exactly like {@link runAs}.
      */

--- a/packages/spec/src/data/data-engine.zod.ts
+++ b/packages/spec/src/data/data-engine.zod.ts
@@ -54,8 +54,20 @@ export const DataEngineSortSchema = lazySchema(() => z.union([
  * an optional ExecutionContext for identity, tenant, and transaction propagation.
  */
 export const BaseEngineOptionsSchema = lazySchema(() => z.object({
-  /** Execution context (identity, tenant, transaction) */
-  context: ExecutionContextSchema.optional(),
+  /**
+   * Execution context (identity, tenant, transaction) — any SUBSET of the
+   * envelope.
+   *
+   * `ExecutionContextSchema` gives `positions`/`permissions`/`isSystem`
+   * parse-time defaults, which makes them REQUIRED in its inferred output
+   * type. On a caller-supplied option that asserts something untrue: that
+   * every data-engine context carries a principal. Callers routinely pass a
+   * slice — `{ isSystem: true }` for a system read — and a flow run that
+   * resolves no identity passes provenance alone (`{ flowRunId }`, #3712), a
+   * context deliberately carrying no principal at all. `.partial()` states the
+   * real contract: supply what you have, the engine reads what it needs.
+   */
+  context: ExecutionContextSchema.partial().optional(),
 }));
 
 // ==========================================================================

--- a/packages/spec/src/data/hook.zod.ts
+++ b/packages/spec/src/data/hook.zod.ts
@@ -209,6 +209,13 @@ export const HookContextSchema = lazySchema(() => z.object({
   /**
    * Execution Session
    * Contains authentication and organization/tenancy information.
+   *
+   * WHO is calling. Absent when the operation carried no identity envelope at
+   * all — a bare-kernel / programmatic call — which is why hooks that gate on
+   * the caller (the attachment access gate, for one) skip when it is missing.
+   * Write PROVENANCE deliberately lives outside it, in {@link provenance}, so
+   * an identity-less writer can still be attributed without manufacturing a
+   * caller that was never there (#3712).
    */
   session: z.object({
     userId: z.string().optional(),
@@ -228,11 +235,30 @@ export const HookContextSchema = lazySchema(() => z.object({
     roles: z.array(z.string()).optional(),
     accessToken: z.string().optional(),
     isSystem: z.boolean().optional().describe('True when the call was made with an elevated system context (engine self-writes)'),
-    flowRunId: z.string().optional().describe('Id of the automation flow run performing this write, when it originates from a flow data node. Provenance only — grants nothing, no security middleware keys on it. Lets a hook tell the run that OWNS some externalized state (e.g. a pending approval) from an unrelated caller (#3456).'),
     skipTriggers: z.boolean().optional().describe('True when record-change automation (flow triggers) must be suppressed for this write — e.g. package seed replay. Lifecycle hooks still run.'),
     skipAutomations: z.boolean().optional().describe('True when metadata-bound automation hooks must be suppressed for this write — e.g. data import with "run automations" unchecked, or import undo. Implies skipTriggers; code-registered system hooks (audit, security) still run.'),
   }).optional().describe('Current session context'),
-  
+
+  /**
+   * Write Provenance
+   * WHAT produced this write, as opposed to WHO is calling ({@link session}).
+   *
+   * Server-stamped and never client-supplied. It is not an identity: nothing
+   * here is evaluated by any security middleware, and it neither widens nor
+   * narrows what the write may touch. It exists so a hook can tell "the actor
+   * that OWNS some externalized state" from "an unrelated caller".
+   *
+   * Kept OUT of `session` on purpose. A writer can have provenance and no
+   * identity at all — a schedule-triggered flow run resolves no principal — and
+   * folding the two together would have forced such a run to present an empty
+   * session, silently turning "no caller" into "an anonymous caller" for every
+   * hook that gates on `session` being absent (#3712).
+   */
+  provenance: z.object({
+    flowRunId: z.string().optional().describe('Id of the automation flow run performing this write, when it originates from a flow data node. Lets a hook recognize the run that OWNS state that run itself opened — the approvals record lock exempts the run holding the pending request (#3456).'),
+  }).optional().describe('Server-stamped write provenance (never client-supplied, never an authorization input)'),
+
+
   /**
    * Transaction Handle
    * If the operation is part of a transaction, use this handle for side-effects.

--- a/packages/spec/src/kernel/execution-context.zod.ts
+++ b/packages/spec/src/kernel/execution-context.zod.ts
@@ -205,6 +205,14 @@ export const ExecutionContextSchema = lazySchema(() => z.object({
    * (#3456) uses it to let the run that opened a pending approval still write
    * its own target record, which `isSystem` cannot express for a
    * `runAs:'user'` run without elevating it.
+   *
+   * It may be the ONLY populated field of the envelope. A run that resolves no
+   * principal (a schedule-triggered `runAs:'user'` run) passes exactly
+   * `{ flowRunId }`: every principal gate keys on `isSystem`/`userId`/
+   * `positions`/`permissions`, so such a context authorizes identically to no
+   * context at all, and the run keeps the #1888 unscoped posture it already had
+   * while becoming attributable (#3712). Surfaced to hooks as
+   * `HookContext.provenance`, deliberately not folded into `session`.
    */
   flowRunId: z.string().optional(),
 
@@ -329,3 +337,20 @@ export const ExecutionContextSchema = lazySchema(() => z.object({
 }));
 
 export type ExecutionContext = z.infer<typeof ExecutionContextSchema>;
+
+/**
+ * The CALLER-SUPPLIED form of {@link ExecutionContext} — any subset of the
+ * envelope.
+ *
+ * `positions`/`permissions`/`isSystem` carry parse-time defaults, so they are
+ * required in the inferred *output* type ({@link ExecutionContext}) even though
+ * a caller never has to write them. This is the *input* side: what a data
+ * operation may actually be handed. Use it wherever a context arrives from a
+ * caller rather than out of a parse — `options.context` and everything the
+ * engine threads it into.
+ *
+ * Some callers have no principal to state at all: a system read passes
+ * `{ isSystem: true }`, and a flow run with no resolvable identity passes
+ * provenance alone (`{ flowRunId }`, #3712).
+ */
+export type ExecutionContextInput = z.input<typeof ExecutionContextSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1252,6 +1252,9 @@ importers:
         specifier: workspace:*
         version: link:../../spec
     devDependencies:
+      '@objectstack/objectql':
+        specifier: workspace:*
+        version: link:../../objectql
       '@objectstack/service-automation':
         specifier: workspace:*
         version: link:../../services/service-automation


### PR DESCRIPTION
Closes #3712. Residual of #3456, left open by #3703.

## The problem

#3703 exempted *the run that opened the pending request* from the approvals record lock, keyed on `flowRunId`. It worked for every run that resolves an identity, and missed the one that doesn't: an effective `runAs:'user'` run with **no trigger user** — a schedule being the canonical case — passed no ObjectQL context at all, so nothing carried the run id and the run still died on its own `RECORD_LOCKED`.

The blocker was never the lock. It was that **"no identity" and "no context" were the same thing on the wire**, so a run could not say *who it was* without also claiming *what it was allowed to do*.

The issue framed that as a choice: manufacture a principal (option 1, accepting a flip to baseline-member RLS), or resolve the #1888 fail-open first (option 2). This takes neither — it takes the third door the issue left open: *carry `flowRunId` without presenting an identity the middleware keys on*. The fail-open decision stays exactly where it was, unprejudiced.

## What changed

**A run with no principal passes provenance alone.** `resolveRunDataContext` returns `{ flowRunId }` — no `userId`, no `positions`, no `permissions`, not even `isSystem: false`. That absence is load-bearing. Every principal gate keys on one of those fields:

| gate | keys on |
|:--|:--|
| elevation short-circuit | `context.isSystem` |
| ADR-0103 engine-owned write guard | `context.userId` |
| ADR-0090 D12 delegated-admin gate | `context.userId` (missing context normalized to `{}` first) |
| empty-principal fall-open | `positions` / `permissions` / `userId` |

So the envelope is indistinguishable from passing no context at all. The run keeps its documented #1888 unscoped posture, its loud `[runAs]` warning, and the `flow-schedule-runas-unscoped` build-time lint. Nothing about what it may touch changed — only that it can now be attributed.

**Provenance moved out of the hook session, into `ctx.provenance`.** `session` answers *who is calling*, and is absent when no identity envelope was supplied — a distinction real gates depend on (the attachment access gate skips bare-kernel writes on exactly that test). Folding a run id into `session` would have forced an identity-less run to present an empty session, silently turning "no caller" into "an anonymous caller" and narrowing the #1888 fail-open **for attachments alone**. An inconsistent partial tightening is worse than either extreme, so `HookContext.provenance.flowRunId` now says what produced the write and the lock reads it there. `buildSession` returns `undefined` when a context yields nothing session-worthy; every real transport resolves `positions`, so an anonymous HTTP request still yields a session and stays gated.

**`BaseEngineOptionsSchema.context` relaxed to a partial envelope** (`ExecutionContextInput`). Parse-time defaults on `positions`/`permissions`/`isSystem` made them *required* on a caller-supplied option — asserting something untrue, that every data-engine context carries a principal. Callers have always passed slices (`{ isSystem: true }` for a system read); the type now says so.

## Testing

`pnpm build` (71/71) · `pnpm test` (132/132) · `pnpm lint` — all green.

The #3703 miss was a **hand-off gap, not a logic gap**: every hop worked in isolation. So the new integration test (`record-lock-schedule-run.integration.test.ts`) stubs no hop — real `resolveRunDataContext`, real ObjectQL engine, real lock hook, in the order a live deployment runs them. It fails on `main`.

Also pinned:
- the provenance-only context carries **only** `flowRunId` — every principal field asserted absent by name;
- the two gates that could have been moved by it (`assertEngineOwnedWriteAllowed`, `DelegatedAdminGate`) treat it exactly like no context;
- `ctx.session` stays `undefined` for a provenance-only write, and stays *defined* for an anonymous transport request;
- the attachment access gate still bypasses a flow run with provenance and no session — the regression this design exists to prevent;
- the #1888 fail-open assertions now check "presents no principal" rather than "carries no context", which is the property that actually mattered.

## Notes

- `session.flowRunId` never shipped — #3703's changeset is still pending — so the move costs no consumer a migration. Its stale "residual, deliberately not changed here" paragraph is updated in the same commit, since both ship in one release.
- `content/docs/references/data/hook.mdx` is regenerated, not hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFUmz96zRXzfypG4Fa9BXJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFUmz96zRXzfypG4Fa9BXJ)_