### PR TITLE
test(spec): 把「有单条写就必须有批量」做成全仓棘轮,防 #3745 复发 (#3026)

### DIFF
--- a/.changeset/apimethods-batch-conformance-ratchet.md
+++ b/.changeset/apimethods-batch-conformance-ratchet.md
@@ -1,0 +1,10 @@
+---
+---
+
+test(spec): ratchet the "single-record writes imply batch" invariant across every `*.object.ts` (#3026)
+
+Test-only — releases nothing. Adds the monorepo-wide scan that would have
+caught #3745 before it shipped: the eight objects that kept 405-ing `/batch`
+and the `*Many` routes after the #3391 P1 bulk gate became `bulk ∧ child`,
+because the sweep that added the `bulk` primitive was scoped to one package
+while the gap lived in three others.

--- a/packages/spec/src/data/api-methods-batch-conformance.test.ts
+++ b/packages/spec/src/data/api-methods-batch-conformance.test.ts
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// Conformance ratchet: a tightened `apiMethods` whitelist that grants
+// single-record writes must also grant the `bulk` primitive (#3026 follow-up).
+//
+// The #3391 P1 contract made the bulk gate `bulk ∧ derived(child)`: a batch
+// request is admitted only when the object grants the `bulk` PRIMITIVE and the
+// batched child operation is itself allowed. Before that, the `*Many` routes
+// checked only the child verb, so a boilerplate CRUD-five whitelist batched
+// fine. Every object carrying an explicit whitelist therefore needed `bulk`
+// added — and the sweep that did it was scoped to `platform-objects`, so eight
+// objects in `plugin-security`, `plugin-approvals` and `metadata-core` silently
+// kept 405-ing `/batch`, `createMany`, `updateMany` and `deleteMany` while
+// their single-record writes stayed wide open (fixed in #3745).
+//
+// The bug was not a wrong judgement — it was an audit whose SCOPE was a package
+// name while the gap lived in packages nobody thought to open. This test
+// replaces that manual sweep with a scan of every `*.object.ts` in the
+// monorepo, so a new declaration anywhere is covered by construction. Scanning
+// source (rather than importing the packages) keeps the check next to the
+// derivation table without inverting the spec → * dependency direction — the
+// same technique as `system/constants/platform-object-names.test.ts`.
+//
+// If this fails, pick one deliberately:
+//   - the object should batch  → add `'bulk'` to its `apiMethods`;
+//   - it genuinely must not    → register it in SINGLE_RECORD_WRITE_ONLY below
+//                                with the reason, so the choice is on the record.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { API_PRIMITIVES } from './api-derivation';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+/** …/packages/spec/src/data → repo root */
+const REPO_ROOT = resolve(HERE, '../../../..');
+const PACKAGES_DIR = join(REPO_ROOT, 'packages');
+
+/** The single-record write primitives whose batch shape `bulk` unlocks. */
+const WRITE_PRIMITIVES = ['create', 'update', 'delete'] as const;
+
+/**
+ * Objects that deliberately expose single-record writes but NO batch route,
+ * keyed by object name with the reason. Empty today: every tightened whitelist
+ * in the monorepo either grants `bulk` or grants no write verb at all.
+ *
+ * Adding an entry is a real decision — batch denial is invisible until a user
+ * multi-selects rows and `data-objectstack` rethrows the 405 without falling
+ * back to per-row writes. Write down why the object is worth that.
+ */
+const SINGLE_RECORD_WRITE_ONLY: Record<string, string> = {};
+
+/** Every `*.object.ts` under `packages/`, skipping build output and deps. */
+function walkObjectFiles(dir: string, out: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (entry === 'node_modules' || entry === 'dist' || entry.startsWith('.')) continue;
+    const full = join(dir, entry);
+    let isDir: boolean;
+    try {
+      isDir = statSync(full).isDirectory();
+    } catch {
+      continue;
+    }
+    if (isDir) walkObjectFiles(full, out);
+    else if (entry.endsWith('.object.ts')) out.push(full);
+  }
+  return out;
+}
+
+/** The object name declared by `ObjectSchema.create({ name: '…' })`, if any. */
+function declaredObjectName(source: string): string | undefined {
+  return source.match(/ObjectSchema\.create\(\{[\s\S]{0,600}?name:\s*'([a-z0-9_]+)'/)?.[1];
+}
+
+interface Whitelist {
+  object: string;
+  file: string;
+  methods: string[];
+}
+
+/**
+ * Every authored `apiMethods: [...]` array literal under `packages/`. Legacy /
+ * unknown strings are kept as authored — the resolver ignores them, and this
+ * check only reasons about primitives.
+ */
+function collectWhitelists(): Whitelist[] {
+  const out: Whitelist[] = [];
+  for (const file of walkObjectFiles(PACKAGES_DIR)) {
+    const source = readFileSync(file, 'utf8');
+    const object = declaredObjectName(source) ?? '(unnamed)';
+    for (const match of source.matchAll(/apiMethods:\s*\[([^\]]*)\]/g)) {
+      out.push({
+        object,
+        file: file.slice(REPO_ROOT.length + 1),
+        methods: [...match[1].matchAll(/'([a-z]+)'/g)].map((m) => m[1]),
+      });
+    }
+  }
+  return out;
+}
+
+const WHITELISTS = collectWhitelists();
+
+describe('apiMethods conformance — single-record writes imply batch (#3026)', () => {
+  it('scans a plausible number of declarations (guards a silently empty sweep)', () => {
+    // A scan that matches nothing passes every assertion below vacuously — the
+    // exact failure mode this file exists to prevent. Pin a floor instead.
+    expect(WHITELISTS.length).toBeGreaterThan(40);
+  });
+
+  it('only authors the six primitives (legacy verbs are derived, never declared)', () => {
+    // Since the #3543 enum shrink a legacy verb in a whitelist is stripped at
+    // parse and ignored by the resolver, so declaring one is silently dead
+    // metadata — catch it at the source instead.
+    const primitives = new Set<string>(API_PRIMITIVES);
+    const offenders = WHITELISTS.flatMap(({ object, file, methods }) =>
+      methods.filter((m) => !primitives.has(m)).map((m) => `${object} declares '${m}' (${file})`),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it('grants bulk wherever it grants create / update / delete', () => {
+    const offenders = WHITELISTS.filter(({ object, methods }) => {
+      if (SINGLE_RECORD_WRITE_ONLY[object] !== undefined) return false;
+      const grantsWrite = WRITE_PRIMITIVES.some((verb) => methods.includes(verb));
+      return grantsWrite && !methods.includes('bulk');
+    }).map(
+      ({ object, file, methods }) =>
+        `${object}: [${methods.join(', ')}] grants single-record writes but not 'bulk' — ` +
+        `/batch and the *Many routes will 405 (${file})`,
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps the exemption list free of stale entries', () => {
+    // An exemption that no longer describes a real single-record-write-only
+    // object reads as a documented decision while documenting nothing.
+    const stale = Object.keys(SINGLE_RECORD_WRITE_ONLY).filter((object) => {
+      const declared = WHITELISTS.filter((w) => w.object === object);
+      if (declared.length === 0) return true;
+      return declared.every(
+        (w) => w.methods.includes('bulk') || !WRITE_PRIMITIVES.some((v) => w.methods.includes(v)),
+      );
+    });
+    expect(stale).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 背景

#3745 修掉了 8 个对象「单条写全开、批量路由 405」的缺口。**根因不是判断错,而是审计范围**:#3391 P1 把 bulk 门禁改成 `bulk ∧ derived(child)` 后,配套的「给显式白名单补 `bulk` 原语」被写成了「`platform-objects` 包审计」,而缺口在 `plugin-security` / `plugin-approvals` / `metadata-core` —— 三个没人想到要打开的包。

同类问题会再犯:今天全仓 58 处 `apiMethods` 声明散在多个包里,靠人再扫一遍不可靠。本 PR 把这次的人工排查换成 CI 每次都跑的扫描。

## 改动

新增 `packages/spec/src/data/api-methods-batch-conformance.test.ts` —— 扫描 `packages/**` 下**每一个** `*.object.ts`,提取 `apiMethods` 数组字面量,断言三条不变量:

1. **有单条写就必须有批量** —— 白名单授予 `create`/`update`/`delete` 任一,就必须同时授予 `bulk`;否则必须登记进 `SINGLE_RECORD_WRITE_ONLY` 并写明理由(**今天为空**:全仓要么授予了 `bulk`,要么根本不授予写)。
2. **只能声明 6 个原语** —— #3543 收缩后,legacy 动词在 parse 期就被 strip、resolver 也忽略,声明了等于**静默的死元数据**,在源头拦掉。
3. **豁免清单不许留陈旧条目** —— 一条不再对应真实"只单条写"对象的豁免,读起来像"有据可依"实则什么都没记录。

外加一条**扫描量下限**断言(`> 40`):扫不到文件的实现会让上面三条全部真空通过 —— 那正是本文件要防的失败模式。

## 为什么扫源码而不是 import

跟 `system/constants/platform-object-names.test.ts` 同一套技术:import 全部对象包会**反转 spec → \* 的依赖方向**,而扫源码能把检查放在派生表旁边,且**新包新对象自动被覆盖**(这次缺口的形状正是"新包没人扫")。

## 防假绿

不是绿橡皮图章 —— 把 `sys_permission_set` 的 `'bulk'` 拿掉重跑,棘轮如实变红,失败信息直接给出对象名、白名单内容和文件路径:

```
sys_permission_set: [get, list, create, update, delete] grants single-record writes
but not 'bulk' — /batch and the *Many routes will 405
(packages/plugins/plugin-security/src/objects/sys-permission-set.object.ts)
```

随后已还原。

## 验证

- `@objectstack/spec` 259 files / **6721 tests** 全过(含新增 4 条)
- 扫描当前 main:58 处声明,**0 违规**

changeset:空 changeset(test-only,不发布任何包)。

## 关联

- #3026(设计契约)、#3745(本棘轮要防复发的那个缺口)、#3391 P1(bulk 门禁语义)、#3543(枚举收缩)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkdX2VCuKfcsFBbvtATe7V)_