### PR TITLE
fix(analytics): ObjectQLStrategy 施加 timeDimensions[].dateRange —— date-granularity 图表必走的那条路 (#3650)

### DIFF
--- a/.changeset/objectql-strategy-daterange.md
+++ b/.changeset/objectql-strategy-daterange.md
@@ -1,0 +1,62 @@
+---
+"@objectstack/service-analytics": patch
+---
+
+fix(analytics): ObjectQLStrategy applies `timeDimensions[].dateRange` — the predicate every date-bucketed chart was missing (#3650)
+
+`ObjectQLStrategy.execute()` built its engine filter purely from
+`normalizeAnalyticsFilters(query)`, which reads only `query.where`. But
+`dateRange` is a **sibling** of `where`, never folded into it — so the window
+was dropped on the floor. No error, no warning: the chart rendered, and the
+numbers were for all of history.
+
+This was not a "some drivers only" corner. `NativeSQLStrategy.canHandle`
+declines any query carrying a `granularity`, so a **date-bucketed trend lands on
+the ObjectQL path on every driver**, Postgres and SQLite included — and a
+bucketed trend is precisely the shape that also carries a range ("last 12
+months", "this quarter"). The other two paths always applied it
+(`NativeSQLStrategy` as `BETWEEN`, `preview-evaluator` row-wise); only this one
+did not.
+
+**Two visible symptoms:**
+
+- A trend chart with a time filter plotted **every row ever recorded** instead
+  of the selected window.
+- `compareTo` (period-over-period) was **structurally dead**. `runCompare`
+  builds the comparison pass by shifting `dateRange` and changing nothing else,
+  so with the window ignored both passes issued a byte-identical aggregate:
+  every `<measure>__compare` column equalled its primary and the delta was a
+  flat 0%. And since `compareTo` requires a time dimension, it always took this
+  path.
+
+The window now lowers to an inclusive `{$gte, $lte}` on the resolved field — the
+same shape `NativeSQLStrategy` binds as `BETWEEN` and the memory driver builds
+as a `$match` — so one dashboard reads the same on every driver. No storage
+coercion is applied here on purpose: unlike the raw-SQL path (which had to learn
+about SQLite's INTEGER epoch in #2034), this path goes through
+`engine.aggregate()`, where the driver's own CRUD filter coercion already
+handles a `where` bound on that same column.
+
+**Same-field composition was fixed alongside it**, because the window makes it
+routine. Operands merged into one field entry by spreading, which silently kept
+whichever came last: a `where` bound and a window bound on `close_date` would
+have had one erase the other, and a `where` that names one field twice through
+`$and` (`{$and: [{stage: 'won'}, {stage: {$ne: 'lost'}}]}`) already lost its
+first operand today. Operands that name **different** operators still share one
+entry; colliding ones become their own `$and` conjunct, so the engine
+intersects them instead of the strategy picking a winner.
+
+`generateSql()` renders the window as a parameterised `BETWEEN` to match — its
+comment previously explained why a `BETWEEN` was deliberately absent, which was
+correct only while `execute()` dropped the window. Bounds bind as `$n`
+placeholders, never inlined: the echoed statement travels to the browser.
+
+A window on a **cross-object** time dimension is still rejected, and is now
+reported as the bucketing error it is rather than as the "cross-object filter"
+its lowered predicate would otherwise resemble. `execute()` and
+`/analytics/sql` continue to accept and reject the same set.
+
+Relative-phrase ranges ("Last 7 days") are still not resolved on this path, and
+a bare-string `dateRange` degenerates to a single point — both matching
+`NativeSQLStrategy` exactly, rather than inventing a second interpretation for
+the driver-independent path.

--- a/packages/plugins/driver-sql/src/sql-driver-aggregate-datetime-window.test.ts
+++ b/packages/plugins/driver-sql/src/sql-driver-aggregate-datetime-window.test.ts
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The load-bearing assumption behind #3650.
+ *
+ * `ObjectQLStrategy` lowers `timeDimensions[].dateRange` to `{$gte, $lte}` ISO
+ * strings and hands them to `engine.aggregate()` WITHOUT the storage coercion
+ * `NativeSQLStrategy` performs. The justification is that this path goes through
+ * the driver's own CRUD filter coercion, whereas the raw-SQL path binds straight
+ * into a statement and therefore had to learn about SQLite's INTEGER epoch
+ * itself (#2034).
+ *
+ * That is an assumption about the driver, not about the strategy — so it is
+ * pinned here against a real SQLite database. A `Field.datetime` column is
+ * stored as INTEGER epoch ms; an uncoerced ISO TEXT comparand matches NOTHING
+ * (TEXT sorts after every INTEGER), which would have made the #3650 fix a no-op
+ * on exactly the column type dashboards use most.
+ *
+ * `Field.date` (ISO TEXT storage) is covered alongside it, since a dataset may
+ * bucket on either.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SqlDriver } from '../src/index.js';
+
+const TABLE = 'opportunity';
+
+describe('SqlDriver.aggregate — ISO window over epoch-stored datetime (#3650)', () => {
+  let driver: SqlDriver;
+
+  beforeEach(async () => {
+    driver = new SqlDriver({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+
+    await driver.initObjects([
+      {
+        name: TABLE,
+        fields: {
+          closed_at: { type: 'datetime' }, // INTEGER epoch ms under better-sqlite3
+          closed_on: { type: 'date' }, // YYYY-MM-DD TEXT
+          amount: { type: 'number' },
+        },
+      },
+    ]);
+
+    // Inserted as real Date objects, the path the seed loader takes.
+    const rows = [
+      ['o1', '2025-11-15T09:00:00Z', '2025-11-15', 900], // before window
+      ['o2', '2026-01-10T09:00:00Z', '2026-01-10', 100], // inside
+      ['o3', '2026-01-20T09:00:00Z', '2026-01-20', 200], // inside
+      ['o4', '2026-02-14T09:00:00Z', '2026-02-14', 30], // inside (Feb)
+      ['o5', '2026-06-05T09:00:00Z', '2026-06-05', 700], // after window
+    ] as const;
+    for (const [id, at, on, amount] of rows) {
+      await driver.create(
+        TABLE,
+        { id, closed_at: new Date(at), closed_on: on, amount },
+        { bypassTenantAudit: true },
+      );
+    }
+  });
+
+  afterEach(async () => {
+    await driver.disconnect();
+  });
+
+  /** Exactly what the strategy emits: an inclusive ISO range, uncoerced. */
+  const window = (col: string) => ({
+    [col]: { $gte: '2026-01-01', $lte: '2026-02-28' },
+  });
+
+  it('confines a datetime aggregate to the window (the epoch-affinity trap)', async () => {
+    const rows = await driver.aggregate(TABLE, {
+      aggregations: [
+        { function: 'sum', field: 'amount', alias: 'total' },
+        { function: 'count', alias: 'n' },
+      ],
+      where: window('closed_at'),
+    } as any);
+
+    // 330 over 3 rows. An uncoerced TEXT-vs-INTEGER compare yields 0 rows;
+    // a dropped window yields 1930 over 5.
+    expect(Number(rows[0].total)).toBe(330);
+    expect(Number(rows[0].n)).toBe(3);
+  });
+
+  it('buckets a TEXT-stored date inside the window — the shape #3650 is about', async () => {
+    // A `granularity` is what makes NativeSQLStrategy decline, so window +
+    // bucketing together is the combination that reaches the ObjectQL path.
+    const rows = await driver.aggregate(TABLE, {
+      groupBy: [{ field: 'closed_on', dateGranularity: 'month' }],
+      aggregations: [{ function: 'sum', field: 'amount', alias: 'total' }],
+      where: window('closed_on'),
+    } as any);
+
+    const byMonth = Object.fromEntries(rows.map((r: any) => [r.closed_on, Number(r.total)]));
+    expect(byMonth).toEqual({ '2026-01': 300, '2026-02': 30 });
+  });
+
+  it('KNOWN GAP — bucketing an EPOCH-stored datetime collapses into one null bucket', async () => {
+    // Pre-existing, unrelated to #3650, and deliberately NOT fixed here — but
+    // it lands on the exact same query shape, so it is pinned rather than left
+    // to be rediscovered as "the dateRange fix did nothing".
+    //
+    // SQLite advertises `queryDateGranularity.month`, so `engine.aggregate`
+    // pushes the bucketing down to the driver — `engine.ts` only falls back to
+    // in-memory bucketing when a granularity is UNSUPPORTED or a non-UTC
+    // timezone is in play, neither of which applies here. The dialect
+    // expression is `strftime('%Y-%m', col)`, and SQLite reads a bare INTEGER
+    // as a Julian day number; an epoch-ms value is far outside the legal range,
+    // so every row buckets as NULL.
+    const rows = await driver.aggregate(TABLE, {
+      groupBy: [{ field: 'closed_at', dateGranularity: 'month' }],
+      aggregations: [{ function: 'sum', field: 'amount', alias: 'total' }],
+      where: window('closed_at'),
+    } as any);
+
+    // The WINDOW works — the total is the in-window 330, not the full 1930 —
+    // which is what #3650 is responsible for. The BUCKETS are what is broken.
+    // When that is fixed, this becomes `{ '2026-01': 300, '2026-02': 30 }`.
+    const byMonth = Object.fromEntries(rows.map((r: any) => [String(r.closed_at), Number(r.total)]));
+    expect(byMonth).toEqual({ null: 330 });
+  });
+
+  it('confines a date (TEXT-stored) aggregate to the same window', async () => {
+    const rows = await driver.aggregate(TABLE, {
+      aggregations: [{ function: 'sum', field: 'amount', alias: 'total' }],
+      where: window('closed_on'),
+    } as any);
+
+    expect(Number(rows[0].total)).toBe(330);
+  });
+
+  it('excludes the whole table when the window selects nothing', async () => {
+    const rows = await driver.aggregate(TABLE, {
+      aggregations: [{ function: 'count', alias: 'n' }],
+      where: { closed_at: { $gte: '2027-01-01', $lte: '2027-12-31' } },
+    } as any);
+
+    // An empty window must read as zero, not as "filter ignored → 5".
+    expect(Number(rows[0]?.n ?? 0)).toBe(0);
+  });
+});

--- a/packages/plugins/driver-sql/src/sql-driver-nested-and-filter.test.ts
+++ b/packages/plugins/driver-sql/src/sql-driver-nested-and-filter.test.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * A FilterCondition may carry a `$and` array ALONGSIDE plain field keys, and
+ * the `$and` elements may nest further. Both are legal per
+ * `FilterConditionSchema` (`$and` recurses; the schema intersects a record with
+ * the logical-operator object), and `applyFilterCondition` handles them by
+ * iterating every key — but nothing exercised the combination end-to-end, so
+ * "the compiler happens to iterate all keys" was an implementation detail
+ * rather than a contract.
+ *
+ * It became a contract with #3650: ObjectQLStrategy now AND-composes predicates
+ * that cannot share one field entry (a `where` bound colliding with a
+ * `timeDimensions[].dateRange` window) into `filter.$and`, and `withReadScope`
+ * then wraps THAT in another `$and` with the tenant predicate. The exact
+ * two-level shape below is what the analytics path hands the driver. Silently
+ * dropping either level would widen the query — the analytics path's read scope
+ * lives in the outer one.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SqlDriver } from '../src/index.js';
+
+/** One row survives all three predicates; each other row fails exactly one. */
+const FIXTURE = [
+  { id: 'a', close_date: '2026-01-05', organization_id: 'org_A', amount: 10 }, // fails inner-sibling $gte
+  { id: 'b', close_date: '2026-01-20', organization_id: 'org_A', amount: 20 }, // survives
+  { id: 'c', close_date: '2026-02-10', organization_id: 'org_A', amount: 40 }, // fails nested $lte
+  { id: 'd', close_date: '2026-01-20', organization_id: 'org_B', amount: 80 }, // fails outer tenant
+];
+
+/**
+ * `{ $and: [ {field…, $and: [ … ]}, {tenant} ] }` — a field key and a nested
+ * `$and` inside one branch of an outer `$and`.
+ */
+const NESTED_AND = {
+  $and: [
+    {
+      close_date: { $gte: '2026-01-15' },
+      $and: [{ close_date: { $gte: '2026-01-01', $lte: '2026-01-31' } }],
+    },
+    { organization_id: 'org_A' },
+  ],
+};
+
+describe('SqlDriver — field key alongside a nested $and (#3650)', () => {
+  let driver: SqlDriver;
+  let knex: any;
+
+  beforeEach(async () => {
+    driver = new SqlDriver({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    knex = (driver as any).knex;
+    await knex.schema.createTable('opportunity', (t: any) => {
+      t.string('id').primary();
+      t.string('close_date');
+      t.string('organization_id');
+      t.float('amount');
+    });
+    await knex('opportunity').insert(FIXTURE);
+  });
+
+  afterEach(async () => {
+    await knex.destroy();
+  });
+
+  it('intersects every level on find()', async () => {
+    const rows = await driver.find('opportunity', { where: NESTED_AND } as any);
+    expect(rows.map((r: any) => r.id)).toEqual(['b']);
+  });
+
+  it('intersects every level on aggregate() — the analytics path', async () => {
+    const rows = await driver.aggregate('opportunity', {
+      groupBy: ['organization_id'],
+      aggregations: [{ function: 'sum', field: 'amount', alias: 'total' }],
+      where: NESTED_AND,
+    } as any);
+
+    // 20 only. Dropping the nested `$and` would add row c (60); dropping the
+    // sibling field key would add row a (30); dropping the outer branch would
+    // add row d and split the grouping.
+    expect(rows).toEqual([{ organization_id: 'org_A', total: 20 }]);
+  });
+
+  it('keeps a bucketed aggregate scoped to the same intersection', async () => {
+    // The #3650 shape in its native habitat: a date-bucketed trend whose window
+    // and read scope both have to survive.
+    const rows = await driver.aggregate('opportunity', {
+      groupBy: [{ field: 'close_date', dateGranularity: 'month' }],
+      aggregations: [{ function: 'sum', field: 'amount', alias: 'total' }],
+      where: NESTED_AND,
+    } as any);
+
+    expect(rows).toEqual([{ close_date: '2026-01', total: 20 }]);
+  });
+});

--- a/packages/services/service-analytics/src/__tests__/objectql-daterange.test.ts
+++ b/packages/services/service-analytics/src/__tests__/objectql-daterange.test.ts
@@ -1,0 +1,471 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #3650 — `timeDimensions[].dateRange` reaches the ObjectQL aggregate path.
+ *
+ * The strategy built its engine filter purely from `normalizeAnalyticsFilters`,
+ * which reads only `where`. `dateRange` is a SIBLING of `where`, so the window
+ * was dropped on the floor: no error, just every row ever recorded.
+ *
+ * That is not a corner case. `NativeSQLStrategy.canHandle` declines any query
+ * carrying a `granularity`, so a date-bucketed trend lands here on EVERY driver
+ * — and a bucketed trend is exactly the shape that also carries a range ("last
+ * 12 months", "this quarter"). The chart rendered, the numbers were wrong.
+ *
+ * The bridge below is HONEST — it actually applies the filter it is handed — so
+ * a missing predicate produces real extra rows rather than an artifact of a
+ * permissive stub.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DatasetSchema } from '@objectstack/spec/ui';
+import type { ExecutionContext } from '@objectstack/spec/kernel';
+import { AnalyticsService } from '../analytics-service.js';
+import { compileDataset } from '../dataset-compiler.js';
+import { DatasetExecutor } from '../dataset-executor.js';
+
+const dataset = DatasetSchema.parse({
+  name: 'sales',
+  label: 'Sales',
+  object: 'opportunity',
+  dimensions: [
+    { name: 'close_date', field: 'close_date', type: 'date' },
+    { name: 'stage', field: 'stage', type: 'string' },
+  ],
+  measures: [{ name: 'revenue', aggregate: 'sum', field: 'amount' }],
+});
+
+/** Rows straddling the window, so a dropped bound shows up as extra revenue. */
+const TABLE = [
+  { id: 1, close_date: '2025-11-15', stage: 'won', amount: 900 }, // before
+  { id: 2, close_date: '2026-01-10', stage: 'won', amount: 100 }, // inside
+  { id: 3, close_date: '2026-01-20', stage: 'lost', amount: 200 }, // inside
+  { id: 4, close_date: '2026-02-14', stage: 'won', amount: 30 }, // inside (Feb)
+  { id: 5, close_date: '2026-06-05', stage: 'won', amount: 700 }, // after
+];
+
+const ctx = { tenantId: 'org_A', userId: 'u_a' } as ExecutionContext;
+const objectqlOnly = () => ({ nativeSql: false, objectqlAggregate: true, inMemory: false });
+
+type Row = Record<string, unknown>;
+type GroupByItem = string | { field: string; dateGranularity: string };
+type AggOpts = {
+  groupBy?: GroupByItem[];
+  aggregations?: Array<{ field: string; method: string; alias: string }>;
+  filter?: Record<string, unknown>;
+};
+
+/** Evaluate the FilterCondition subset these tests can produce. */
+function matches(row: Row, filter: Record<string, unknown>): boolean {
+  return Object.entries(filter).every(([key, cond]) => {
+    if (key === '$and') return (cond as Record<string, unknown>[]).every((sub) => matches(row, sub));
+    const v = row[key];
+    if (cond && typeof cond === 'object' && !Array.isArray(cond)) {
+      return Object.entries(cond as Record<string, unknown>).every(([op, operand]) => {
+        switch (op) {
+          case '$gte': return String(v) >= String(operand);
+          case '$lte': return String(v) <= String(operand);
+          case '$gt': return String(v) > String(operand);
+          case '$lt': return String(v) < String(operand);
+          case '$ne': return v !== operand;
+          default: throw new Error(`test bridge: unhandled operator ${op}`);
+        }
+      });
+    }
+    return v === cond;
+  });
+}
+
+/** `engine.aggregate()` stand-in: filters, buckets, sums — for real. */
+function makeAggregate(seen: AggOpts[], table: Row[] = TABLE) {
+  return async (_object: string, opts: AggOpts): Promise<Row[]> => {
+    seen.push(opts);
+    const rows = table.filter((r) => matches(r, opts.filter ?? {}));
+    const buckets = new Map<string, Row>();
+    for (const r of rows) {
+      const key: Row = {};
+      for (const g of opts.groupBy ?? []) {
+        if (typeof g === 'string') key[g] = r[g];
+        // Only `month` bucketing is exercised here.
+        else key[g.field] = String(r[g.field]).slice(0, 7);
+      }
+      const id = JSON.stringify(key);
+      const b = buckets.get(id) ?? { ...key };
+      for (const a of opts.aggregations ?? []) {
+        if (a.method === 'sum') b[a.alias] = Number(b[a.alias] ?? 0) + Number(r[a.field] ?? 0);
+        if (a.method === 'count') b[a.alias] = Number(b[a.alias] ?? 0) + 1;
+      }
+      buckets.set(id, b);
+    }
+    return [...buckets.values()];
+  };
+}
+
+function makeService(seen: AggOpts[], overrides: Record<string, unknown> = {}) {
+  const compiled = compileDataset(dataset);
+  return new AnalyticsService({
+    cubes: [compiled.cube],
+    queryCapabilities: objectqlOnly,
+    executeAggregate: makeAggregate(seen),
+    ...overrides,
+  });
+}
+
+describe('ObjectQLStrategy — timeDimensions[].dateRange (#3650)', () => {
+  it('confines a date-bucketed trend to the requested window', async () => {
+    const seen: AggOpts[] = [];
+    const result = await makeService(seen).query(
+      {
+        cube: 'sales',
+        dimensions: ['close_date'],
+        measures: ['revenue'],
+        timeDimensions: [
+          { dimension: 'close_date', granularity: 'month', dateRange: ['2026-01-01', '2026-02-28'] },
+        ],
+      },
+      ctx,
+    );
+
+    // The window reaches the engine as an inclusive range — the same shape
+    // NativeSQLStrategy binds as BETWEEN.
+    expect(seen[0].filter).toEqual({ close_date: { $gte: '2026-01-01', $lte: '2026-02-28' } });
+    // Nov (900) and Jun (700) are outside; before the fix all of history landed
+    // in the chart — 1930 across four buckets instead of 330 across two.
+    expect(result.rows).toEqual([
+      { close_date: '2026-01', revenue: 300 },
+      { close_date: '2026-02', revenue: 30 },
+    ]);
+  });
+
+  it('still buckets by month while the window applies', async () => {
+    const seen: AggOpts[] = [];
+    await makeService(seen).query(
+      {
+        cube: 'sales',
+        dimensions: ['close_date'],
+        measures: ['revenue'],
+        timeDimensions: [
+          { dimension: 'close_date', granularity: 'month', dateRange: ['2026-01-01', '2026-02-28'] },
+        ],
+      },
+      ctx,
+    );
+    // The window must not displace the granularity lowering — both travel.
+    expect(seen[0].groupBy).toEqual([{ field: 'close_date', dateGranularity: 'month' }]);
+  });
+
+  it('applies a window on a time dimension that is not also a selected dimension', async () => {
+    const seen: AggOpts[] = [];
+    const result = await makeService(seen).query(
+      {
+        cube: 'sales',
+        dimensions: ['stage'],
+        measures: ['revenue'],
+        timeDimensions: [{ dimension: 'close_date', dateRange: ['2026-01-01', '2026-01-31'] }],
+      },
+      ctx,
+    );
+
+    expect(seen[0].filter).toEqual({ close_date: { $gte: '2026-01-01', $lte: '2026-01-31' } });
+    expect(result.rows).toEqual([
+      { stage: 'won', revenue: 100 },
+      { stage: 'lost', revenue: 200 },
+    ]);
+  });
+
+  it('degenerates a bare-string dateRange to a single point, like NativeSQLStrategy', async () => {
+    const seen: AggOpts[] = [];
+    const result = await makeService(seen).query(
+      {
+        cube: 'sales',
+        dimensions: ['stage'],
+        measures: ['revenue'],
+        timeDimensions: [{ dimension: 'close_date', dateRange: '2026-01-20' }],
+      },
+      ctx,
+    );
+
+    expect(seen[0].filter).toEqual({ close_date: { $gte: '2026-01-20', $lte: '2026-01-20' } });
+    expect(result.rows).toEqual([{ stage: 'lost', revenue: 200 }]);
+  });
+
+  it('narrows rather than vanishes on a one-entry dateRange array', async () => {
+    const seen: AggOpts[] = [];
+    await makeService(seen).query(
+      {
+        cube: 'sales',
+        dimensions: ['stage'],
+        measures: ['revenue'],
+        // The schema types `dateRange` as a plain `string[]`, so this parses.
+        // `NativeSQLStrategy` drops such a window — but "drop the window" means
+        // "plot all of history", the very failure #3650 is about.
+        timeDimensions: [{ dimension: 'close_date', dateRange: ['2026-01-20'] }],
+      },
+      ctx,
+    );
+    expect(seen[0].filter).toEqual({ close_date: { $gte: '2026-01-20', $lte: '2026-01-20' } });
+  });
+
+  it('ANDs the read scope around the window rather than replacing it', async () => {
+    const seen: AggOpts[] = [];
+    const svc = makeService(seen, {
+      getReadScope: (_o: string, c?: ExecutionContext) =>
+        c?.tenantId ? { organization_id: c.tenantId } : undefined,
+    });
+    await svc.query(
+      {
+        cube: 'sales',
+        dimensions: ['stage'],
+        measures: ['revenue'],
+        timeDimensions: [{ dimension: 'close_date', dateRange: ['2026-01-01', '2026-01-31'] }],
+      },
+      ctx,
+    );
+
+    expect(seen[0].filter).toEqual({
+      $and: [
+        { close_date: { $gte: '2026-01-01', $lte: '2026-01-31' } },
+        { organization_id: 'org_A' },
+      ],
+    });
+  });
+
+  it('leaves a query without a dateRange unfiltered', async () => {
+    const seen: AggOpts[] = [];
+    await makeService(seen).query(
+      {
+        cube: 'sales',
+        dimensions: ['close_date'],
+        measures: ['revenue'],
+        timeDimensions: [{ dimension: 'close_date', granularity: 'month' }],
+      },
+      ctx,
+    );
+    // An empty filter stays absent — the window is the only thing that would
+    // have populated it, so a bucketed trend with no range still scans all.
+    expect(seen[0].filter).toBeUndefined();
+  });
+});
+
+describe('ObjectQLStrategy — window ∧ where on one field (#3650)', () => {
+  it('intersects a window with a disjoint-operator where bound', async () => {
+    const seen: AggOpts[] = [];
+    const result = await makeService(seen).query(
+      {
+        cube: 'sales',
+        dimensions: ['stage'],
+        measures: ['revenue'],
+        // `$gt` and the window's `$gte`/`$lte` name different operators, so they
+        // share one entry.
+        where: { close_date: { $gt: '2026-01-15' } },
+        timeDimensions: [{ dimension: 'close_date', dateRange: ['2026-01-01', '2026-01-31'] }],
+      },
+      ctx,
+    );
+
+    expect(seen[0].filter).toEqual({
+      close_date: { $gt: '2026-01-15', $gte: '2026-01-01', $lte: '2026-01-31' },
+    });
+    expect(result.rows).toEqual([{ stage: 'lost', revenue: 200 }]);
+  });
+
+  it('intersects a window with a COLLIDING where bound instead of widening', async () => {
+    const seen: AggOpts[] = [];
+    const result = await makeService(seen).query(
+      {
+        cube: 'sales',
+        dimensions: ['stage'],
+        measures: ['revenue'],
+        // A narrower `$gte` on the same field. Spreading the window over it
+        // would keep the window's looser `2026-01-01` and silently widen the
+        // query; the collision becomes its own conjunct instead.
+        where: { close_date: { $gte: '2026-01-15' } },
+        timeDimensions: [{ dimension: 'close_date', dateRange: ['2026-01-01', '2026-01-31'] }],
+      },
+      ctx,
+    );
+
+    expect(seen[0].filter).toEqual({
+      close_date: { $gte: '2026-01-15' },
+      $and: [{ close_date: { $gte: '2026-01-01', $lte: '2026-01-31' } }],
+    });
+    // Jan 10 (100) is excluded by the caller's own narrower bound.
+    expect(result.rows).toEqual([{ stage: 'lost', revenue: 200 }]);
+  });
+
+  it('keeps both operands when a bare equality meets an operator object', async () => {
+    const seen: AggOpts[] = [];
+    // `$and` in `where` flattens to two entries on one field — the shape that
+    // used to have the second silently replace the first.
+    await makeService(seen).query(
+      {
+        cube: 'sales',
+        dimensions: ['close_date'],
+        measures: ['revenue'],
+        where: { $and: [{ stage: 'won' }, { stage: { $ne: 'lost' } }] },
+      },
+      ctx,
+    );
+
+    expect(seen[0].filter).toEqual({
+      stage: 'won',
+      $and: [{ stage: { $ne: 'lost' } }],
+    });
+  });
+});
+
+describe('DatasetExecutor compareTo over the ObjectQL path (#3650)', () => {
+  it('shifts the comparison window instead of re-running the identical query', async () => {
+    const seen: AggOpts[] = [];
+    const compiled = compileDataset(dataset);
+    const svc = makeService(seen);
+
+    const res = await new DatasetExecutor(svc).execute(compiled, {
+      dimensions: ['stage'],
+      measures: ['revenue'],
+      timeDimensions: [{ dimension: 'close_date', dateRange: ['2026-01-01', '2026-01-31'] }],
+      compareTo: { kind: 'previousPeriod', dimension: 'close_date' },
+    });
+
+    // `runCompare` builds the comparison pass by shifting `dateRange` and
+    // nothing else. With the window dropped, the two passes were byte-identical
+    // — every `__compare` column equalled its primary and the delta was always
+    // a flat 0%.
+    expect(seen).toHaveLength(2);
+    expect(seen[0].filter).not.toEqual(seen[1].filter);
+    const windows = seen.map((s) => (s.filter?.close_date as Record<string, unknown>)?.$gte);
+    expect(windows).toEqual(['2026-01-01', '2025-12-01']);
+
+    // Dec 2025 holds no rows, so the comparison is genuinely empty — not a copy
+    // of the primary.
+    const won = res.rows.find((r) => r.stage === 'won')!;
+    expect(won.revenue).toBe(100);
+    expect(won.revenue__compare ?? 0).toBe(0);
+  });
+});
+
+describe('ObjectQLStrategy.generateSql — window rendering (#3650)', () => {
+  it('renders the window as a parameterised BETWEEN', async () => {
+    const seen: AggOpts[] = [];
+    const svc = makeService(seen);
+
+    const { sql, params } = await svc.generateSql!({
+      cube: 'sales',
+      dimensions: ['close_date'],
+      measures: ['revenue'],
+      timeDimensions: [
+        { dimension: 'close_date', granularity: 'month', dateRange: ['2026-01-01', '2026-02-28'] },
+      ],
+    });
+
+    // The preview used to omit the window deliberately, because `execute()`
+    // dropped it. Now that the window applies, omitting it would be the lie in
+    // the other direction.
+    expect(sql).toContain('close_date BETWEEN $1 AND $2');
+    expect(sql).toContain("date_trunc('month', close_date)");
+    // Bounds bind as parameters — the echoed string travels to the browser.
+    expect(params).toEqual(['2026-01-01', '2026-02-28']);
+    expect(sql).not.toContain('2026-01-01');
+  });
+
+  it('numbers window placeholders after the caller\'s own filters', async () => {
+    const seen: AggOpts[] = [];
+    const svc = makeService(seen);
+
+    const { sql, params } = await svc.generateSql!({
+      cube: 'sales',
+      dimensions: ['stage'],
+      measures: ['revenue'],
+      where: { stage: 'won' },
+      timeDimensions: [{ dimension: 'close_date', dateRange: ['2026-01-01', '2026-01-31'] }],
+    });
+
+    expect(sql).toContain('close_date BETWEEN $2 AND $3');
+    expect(params).toEqual(['won', '2026-01-01', '2026-01-31']);
+  });
+});
+
+describe('ObjectQLStrategy — cross-object FK-expand carries the window (#3650 × #3654)', () => {
+  const crossDataset = DatasetSchema.parse({
+    name: 'sales_by_account',
+    label: 'Sales by account',
+    object: 'opportunity',
+    include: ['account'],
+    dimensions: [
+      { name: 'region', field: 'account.region', type: 'string' },
+      { name: 'close_date', field: 'close_date', type: 'date' },
+    ],
+    measures: [{ name: 'revenue', aggregate: 'sum', field: 'amount' }],
+  });
+
+  it('scopes the BASE aggregate of an FK-expand to the window', async () => {
+    const calls: Array<{ object: string; filter?: unknown }> = [];
+    const compiled = compileDataset(crossDataset);
+    const svc = new AnalyticsService({
+      cubes: [compiled.cube],
+      queryCapabilities: objectqlOnly,
+      getAllowedRelationships: () => compiled.allowedRelationships,
+      executeAggregate: async (object, opts) => {
+        calls.push({ object, filter: opts.filter });
+        return object === 'opportunity'
+          ? [{ account: 'acc_w', revenue: 100 }]
+          : [{ id: 'acc_w', region: 'West' }];
+      },
+    });
+
+    const result = await svc.query(
+      {
+        cube: 'sales_by_account',
+        dimensions: ['region'],
+        measures: ['revenue'],
+        timeDimensions: [{ dimension: 'close_date', dateRange: ['2026-01-01', '2026-01-31'] }],
+      },
+      ctx,
+    );
+
+    const base = calls.find((c) => c.object === 'opportunity')!;
+    expect(base.filter).toEqual({ close_date: { $gte: '2026-01-01', $lte: '2026-01-31' } });
+    // The FK→attribute resolution is keyed by id and must NOT inherit the
+    // window — a related record has no `close_date`.
+    const ref = calls.find((c) => c.object === 'account')!;
+    expect(ref.filter).toEqual({ id: { $in: ['acc_w'] } });
+    expect(result.rows).toEqual([{ region: 'West', revenue: 100 }]);
+  });
+
+  it('rejects a window on a CROSS-OBJECT time dimension as a bucketing error', async () => {
+    const crossTime = DatasetSchema.parse({
+      name: 'sales_by_acct_date',
+      label: 'Sales by account date',
+      object: 'opportunity',
+      include: ['account'],
+      dimensions: [
+        { name: 'region', field: 'account.region', type: 'string' },
+        { name: 'acct_created', field: 'account.created_at', type: 'date' },
+      ],
+      measures: [{ name: 'revenue', aggregate: 'sum', field: 'amount' }],
+    });
+    const compiled = compileDataset(crossTime);
+    const svc = new AnalyticsService({
+      cubes: [compiled.cube],
+      queryCapabilities: objectqlOnly,
+      getAllowedRelationships: () => compiled.allowedRelationships,
+      executeAggregate: async () => [],
+    });
+
+    const query = {
+      cube: 'sales_by_acct_date',
+      dimensions: ['region'],
+      measures: ['revenue'],
+      timeDimensions: [{ dimension: 'acct_created', dateRange: ['2026-01-01', '2026-01-31'] }],
+    };
+    // Reported as a time-dimension bucketing error, not as the "cross-object
+    // filter" its lowered predicate would otherwise look like.
+    await expect(svc.query(query, ctx)).rejects.toThrow(
+      /cannot bucket a cross-object time dimension/,
+    );
+    // `/analytics/sql` rejects the same query, the same way.
+    await expect(svc.generateSql!(query)).rejects.toThrow(
+      /cannot bucket a cross-object time dimension/,
+    );
+  });
+});

--- a/packages/services/service-analytics/src/strategies/objectql-strategy.ts
+++ b/packages/services/service-analytics/src/strategies/objectql-strategy.ts
@@ -89,23 +89,29 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
       }
     }
 
-    // Build filter from query filters. A single field may carry MULTIPLE
-    // operators (e.g. a range `{$gte, $lte}` from `close_date` between two
-    // bounds). Merge same-field operator objects instead of overwriting, or a
-    // range would silently lose a bound (only the last operator would survive).
+    // Build the engine filter. Every predicate — the caller's `where` and the
+    // time-dimension windows alike — is contributed through
+    // `mergeFilterOperand`, because one field routinely carries MULTIPLE
+    // operators (a range `{$gte, $lte}` on `close_date`) and a plain assignment
+    // would keep only the last.
     const filter: Record<string, unknown> = {};
-    const normalizedFilters = normalizeAnalyticsFilters(query);
-    if (normalizedFilters.length > 0) {
-      for (const f of normalizedFilters) {
-        const fieldName = this.resolveFieldName(cube, f.member, 'any');
-        const converted = this.convertFilter(f.operator, f.values);
-        const existing = filter[fieldName];
-        const mergeable = (v: unknown): v is Record<string, unknown> =>
-          !!v && typeof v === 'object' && !Array.isArray(v);
-        filter[fieldName] = mergeable(existing) && mergeable(converted)
-          ? { ...existing, ...converted }
-          : converted;
-      }
+    // Operands that cannot merge into their field's entry without one silently
+    // replacing the other; ANDed in below so the engine intersects them.
+    const conjuncts: Record<string, unknown>[] = [];
+    for (const f of normalizeAnalyticsFilters(query)) {
+      const fieldName = this.resolveFieldName(cube, f.member, 'any');
+      const extra = this.mergeFilterOperand(filter, fieldName, this.convertFilter(f.operator, f.values));
+      if (extra) conjuncts.push(extra);
+    }
+    // #3650 — and the time-dimension WINDOWS, through the SAME merge, so a
+    // `dateRange` and a caller `where` bound on one field compose instead of
+    // clobbering each other.
+    for (const { field, bounds } of this.dateRangeBounds(cube, query)) {
+      const extra = this.mergeFilterOperand(filter, field, bounds);
+      if (extra) conjuncts.push(extra);
+    }
+    if (conjuncts.length > 0) {
+      filter.$and = [...(Array.isArray(filter.$and) ? filter.$and : []), ...conjuncts];
     }
 
     // #3654 — classify cross-object references. A cross-object DIMENSION within
@@ -270,11 +276,12 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
     // The cross-object guard runs here for the same reason: this must not
     // render SQL for a query `execute()` would reject outright (#3654).
     //
-    // Faithfulness cuts both ways: `execute()` does NOT apply
-    // `timeDimensions[].dateRange` on this path (only `where` reaches the
-    // engine), so neither does this. Rendering a BETWEEN here would invent a
-    // predicate the ObjectQL path never applies. That gap is real but separate
-    // — filed as #3650, not papered over here.
+    // Faithfulness cuts both ways: the time-dimension WINDOWS render too, from
+    // the same `dateRangeBounds` lowering `execute()` sends to the engine
+    // (#3650). This comment used to explain why a BETWEEN was deliberately
+    // absent — because `execute()` dropped the window and rendering one would
+    // have invented a predicate. Now that it applies the window, omitting it
+    // here would be the lie in the other direction.
     // (The cross-object envelope was already enforced by `planCrossObject` above,
     // so `/analytics/sql` rejects the same out-of-envelope set `execute()` does.)
 
@@ -287,6 +294,12 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
         params,
       );
       if (clause) whereParts.push(clause);
+    }
+    // Bounds bind as `$n` placeholders like every other comparand: this string
+    // travels to the browser, and a window can carry tenant-derived dates.
+    for (const { field, bounds } of this.dateRangeBounds(cube, query)) {
+      params.push(bounds.$gte, bounds.$lte);
+      whereParts.push(`${field} BETWEEN $${params.length - 1} AND $${params.length}`);
     }
     // Read scope last, so it reads as the outermost constraint. Compiled by the
     // same fail-closed compiler `NativeSQLStrategy` uses — it throws rather than
@@ -388,6 +401,19 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
   ): CrossObjectPlan | null {
     const baseObject = this.extractObjectName(cube);
 
+    // A date bucket over a related object's field is not supported. Checked
+    // FIRST: since #3650 a `dateRange` also lands in `filter`, so a cross-object
+    // time dimension would otherwise be reported as a "cross-object filter" —
+    // true of the lowered predicate, but not what the author wrote.
+    for (const td of query.timeDimensions ?? []) {
+      const field = this.resolveFieldName(cube, td.dimension, 'dimension');
+      if (this.isCrossObjectField(cube, field, baseObject)) {
+        throw new Error(
+          `[Analytics] ObjectQLStrategy cannot bucket a cross-object time dimension ("${field}").`,
+        );
+      }
+    }
+
     // A cross-object MEASURE or FILTER can only be evaluated with a real join.
     const nonDim = [
       ...(query.measures ?? []).map((m) => ({ where: 'measure', field: this.resolveMeasureAggregation(cube, m).field })),
@@ -415,15 +441,6 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
         );
       }
       crossDims.push({ outputName: dim, fkField: alias, attr, refObject: cube.joins?.[alias]?.name ?? alias });
-    }
-    // A date bucket over a related object's field is not supported.
-    for (const td of query.timeDimensions ?? []) {
-      const field = this.resolveFieldName(cube, td.dimension, 'dimension');
-      if (this.isCrossObjectField(cube, field, baseObject)) {
-        throw new Error(
-          `[Analytics] ObjectQLStrategy cannot bucket a cross-object time dimension ("${field}").`,
-        );
-      }
     }
 
     if (crossDims.length === 0) return null;
@@ -682,6 +699,99 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
       }
     }
     return { field: '*', method: 'count' };
+  }
+
+  /**
+   * AND one more operand onto `filter[field]`, merging operator objects rather
+   * than overwriting them. Returns a standalone conjunct when the two cannot
+   * share one entry, or `null` when the merge absorbed the operand.
+   *
+   * Every predicate this strategy contributes goes through here — the caller's
+   * `where` and the time-dimension `dateRange` alike. Two operands on one field
+   * are the normal case (`{$gte}` from a `where` plus `{$gte,$lte}` from a
+   * window on `close_date`), and a plain assignment would keep only the last:
+   * that is how a range used to lose a bound.
+   *
+   * Spreading is sound only while the operands name DIFFERENT operators. Where
+   * they collide — two `$gte` bounds on one field, which a window makes routine
+   * and which a `where` can already produce on its own through `$and` — the
+   * spread keeps whichever came last and WIDENS the query. Same for a bare
+   * equality meeting an operator object: neither can absorb the other. Those
+   * are handed back for the caller to AND in separately, so the engine
+   * intersects them instead of the strategy picking a winner.
+   */
+  private mergeFilterOperand(
+    filter: Record<string, unknown>,
+    field: string,
+    operand: unknown,
+  ): Record<string, unknown> | null {
+    const existing = filter[field];
+    if (existing === undefined) {
+      filter[field] = operand;
+      return null;
+    }
+    const mergeable = (v: unknown): v is Record<string, unknown> =>
+      !!v && typeof v === 'object' && !Array.isArray(v);
+    if (!mergeable(existing) || !mergeable(operand)) return { [field]: operand };
+    if (Object.keys(operand).some((op) => op in existing)) return { [field]: operand };
+    filter[field] = { ...existing, ...operand };
+    return null;
+  }
+
+  /**
+   * Lower `timeDimensions[].dateRange` into resolved-field bounds (#3650).
+   *
+   * `dateRange` states a WINDOW on a time dimension; it is a SIBLING of `where`,
+   * never folded into it. `normalizeAnalyticsFilters` reads only `where`, so
+   * this path used to drop the window on the floor — no error, just every row
+   * ever recorded. Nor is that a corner case: `NativeSQLStrategy.canHandle`
+   * declines any query carrying a `granularity`, so a date-bucketed trend lands
+   * HERE on every driver — and "bucketed trend" is precisely the shape that also
+   * carries a range ("last 12 months", "this quarter").
+   *
+   * Bounds are inclusive on both ends — the same `$gte`/`$lte` pair
+   * `NativeSQLStrategy` binds as `BETWEEN` and the memory driver builds as a
+   * `$match`, so one dashboard reads the same on every driver.
+   *
+   * Comparands are coerced by the SAME helper the `where` path uses, so an
+   * epoch-ms bound recovers as a number and an ISO string stays a string. No
+   * STORAGE coercion happens here, deliberately: `NativeSQLStrategy` needs
+   * `coerceTemporal` because it binds into raw SQL and had to learn that a
+   * SQLite `Field.datetime` is an INTEGER epoch (#2034); this path goes through
+   * `engine.aggregate()`, where the driver's own CRUD filter coercion applies —
+   * the very coercion that already makes a `where` bound on that same column
+   * work today.
+   *
+   * A bare-string `dateRange` degenerates to the single point `[s, s]`, matching
+   * `NativeSQLStrategy`. Relative phrases ("Last 7 days") are NOT resolved here;
+   * neither SQL path resolves them, and inventing a second interpretation on the
+   * driver-independent path is how the two would drift apart again.
+   *
+   * An oddly-sized array (the schema types `dateRange` as a plain `string[]`)
+   * takes its first two entries, a one-entry array degenerating to a point.
+   * `NativeSQLStrategy` drops such a window entirely — but "drop the window"
+   * means "plot all of history", which is the very failure this fixes, so the
+   * fallback here errs toward the narrower query instead.
+   */
+  private dateRangeBounds(
+    cube: Cube,
+    query: AnalyticsQuery,
+  ): Array<{ field: string; bounds: Record<string, unknown> }> {
+    const out: Array<{ field: string; bounds: Record<string, unknown> }> = [];
+    for (const td of query.timeDimensions ?? []) {
+      if (!td.dateRange) continue;
+      const range = Array.isArray(td.dateRange) ? td.dateRange : [td.dateRange, td.dateRange];
+      const [start, end = start] = range;
+      if (start == null) continue;
+      out.push({
+        field: this.resolveFieldName(cube, td.dimension, 'dimension'),
+        bounds: {
+          $gte: coerceFilterValueForObjectQL(String(start)),
+          $lte: coerceFilterValueForObjectQL(String(end)),
+        },
+      });
+    }
+    return out;
   }
 
   private convertFilter(operator: string, values?: string[]): unknown {


### PR DESCRIPTION
Closes #3650

## 问题

`ObjectQLStrategy.execute()` 的 filter 只来自 `normalizeAnalyticsFilters(query)`,而后者只读 `query.where`。`dateRange` 是 `where` 的**兄弟**,从不被折进去 —— 所以窗口谓词被整个丢掉。没有报错,图表照常渲染,只是画的是全量历史。

而且这不是"少数驱动才踩"的边角:`NativeSQLStrategy.canHandle` 对任何带 `granularity` 的查询直接 decline,所以**按天/周/月分桶的趋势图在任何驱动上都落到这条路**(Postgres、SQLite 都一样)—— 而"按时间分桶的趋势图"恰恰是最可能同时带 `dateRange` 的形态。另外两条路一直是好的(`NativeSQLStrategy` 编成 `BETWEEN`,`preview-evaluator` 逐行过滤),只有这条丢。

**issue 里没写到的第二个后果:`compareTo` 结构性死亡。** `runCompare` 生成对比期查询的唯一手段是 shift `dateRange`,其余参数逐字相同([dataset-executor.ts:615](packages/services/service-analytics/src/dataset-executor.ts:615))。窗口被忽略 ⇒ 主查询与对比查询发出**完全一样**的 aggregate ⇒ `<measure>__compare` 恒等于主列 ⇒ 同比/环比永远显示 0%。而 `compareTo` 必然带时间维度、必然走这条路,所以是 100% 命中而非概率问题。

## 修复

窗口下沉为解析后字段上的闭区间 `{$gte, $lte}` —— 与 NativeSQL 绑定的 `BETWEEN`、memory driver 构造的 `$match` 同形,于是同一个 dashboard 在任何驱动上读数一致。

**不做 storage 强转**,这是刻意的:`NativeSQLStrategy` 需要 `coerceTemporal` 是因为它绕过驱动直接绑进裸 SQL,才不得不知道 SQLite 的 `Field.datetime` 是 INTEGER epoch(#2034);这条路经 `engine.aggregate()`,驱动自己的 CRUD filter 强转会生效 —— 正是那条今天已经让同一列上的 `where` 边界能工作的强转。**这是关于驱动而非策略的假设,所以用真实 SQLite 钉住了**(见下)。

### 顺带修:同字段操作数的合并

窗口让这个碰撞变成常态,所以一并修了。原来的合并靠 `{...existing, ...converted}` 展开,后写的静默胜出:

- `close_date` 上一个 `where` 下界 + 一个窗口下界 → 其中一个被抹掉(窗口更松时**静默放宽查询**);
- `where` 自己通过 `$and` 两次点名同一字段(`{$and: [{stage: 'won'}, {stage: {$ne: 'lost'}}]}`)—— **今天就已经丢掉第一个操作数**。

现在:操作数名字**不同**的操作符仍然共用一个字段条目;**碰撞**的成为自己的 `$and` conjunct,由引擎取交集,而不是策略层挑一个赢家。

### 其余

- `generateSql()` 同步把窗口渲染成参数化 `BETWEEN`。原注释解释的是"为什么故意不渲染 BETWEEN" —— 那在 `execute()` 丢窗口时是对的,现在反过来了。边界值绑成 `$n` 占位符不内联(回显字符串会送到浏览器)。
- 跨对象时间维度上的窗口仍然被拒,但现在报的是它本来的**分桶**错误,而不是其降级谓词看起来像的 "cross-object filter"。`execute()` 与 `/analytics/sql` 继续接受/拒绝同一集合。
- 相对短语("Last 7 days")仍然不解析,裸字符串 `dateRange` 退化为一个点 —— 与 `NativeSQLStrategy` 完全一致,不在驱动无关的这条路上另发明一套解释。
- 唯一有意的分叉:**单元素数组**(schema 把 `dateRange` 定为裸 `string[]`,所以它能通过校验)。NativeSQL 会把这种窗口整个丢掉 —— 但"丢掉窗口"就是"画全量历史",正是本 PR 修的那个故障,所以这里退化为一个点,朝更窄的方向兜底。

## 验证

**新测试先证明能红。** 把 `objectql-strategy.ts` 还原到修复前,新增的 15 条里 **11 条红**(其余 4 条覆盖的是本来就工作的行为:granularity 下沉、无 dateRange、跨对象拒绝)。

```
× confines a date-bucketed trend to the requested window
× applies a window on a time dimension that is not also a selected dimension
× degenerates a bare-string dateRange to a single point, like NativeSQLStrategy
× ANDs the read scope around the window rather than replacing it
× intersects a window with a disjoint-operator where bound
× intersects a window with a COLLIDING where bound instead of widening
× keeps both operands when a bare equality meets an operator object
× shifts the comparison window instead of re-running the identical query
× renders the window as a parameterised BETWEEN
× numbers window placeholders after the caller's own filters
× scopes the BASE aggregate of an FK-expand to the window
```

测试用的 aggregate bridge 是**诚实的** —— 它真的施加拿到的 filter,所以缺谓词会产生真实的多余行,而不是被宽容 stub 掩盖的假象。

### 两处跨层验证:策略层绿 ≠ 真驱动对

本 PR 依赖两个**关于下游的**断言,都用内存 SQLite 钉住,而不是靠 stub 自证:

1. **`sql-driver-aggregate-datetime-window.test.ts` —— storage 强转假设。** `Field.datetime` 列在 better-sqlite3 上存 INTEGER epoch ms;未强转的 ISO TEXT 比较**什么都匹配不到**,那样本 PR 在 dashboard 最常用的列类型上就是个 no-op。**假设成立**:`datetime` 与 `date` 两种存储上窗口都正确生效。
2. **`sql-driver-nested-and-filter.test.ts` —— 新引入的 filter 形状。** 碰撞操作数落进 `filter.$and`,`withReadScope` 再包一层 `$and`,于是产生「同级字段键 + 嵌套 `$and`」。全仓此前**没有任何测试**把这个组合喂给真实的 filter 编译器(只有 schema 层的嵌套解析,和子对象只含单键的 `$or`)。数据构造成每层谓词各排除一行,任何一层被吞都会多出行。

这两个是**契约锁**而非回归门 —— 改动前后都绿,锁的是本 PR 依赖的下游行为。

**回归面**

| 范围 | 结果 |
|---|---|
| `service-analytics` 全包 | 22 files / 267 tests ✅ |
| `driver-sql` 全包 | 36 files / 333 tests ✅ |
| `turbo test` 两包全下游(含 dogfood 65 files / 369 tests) | 78 tasks ✅ |
| 类型门(**不带** `OS_SKIP_DTS` 的 `turbo build`) | 6 tasks ✅ DTS 通过 |

## ⚠️ 写验证时撞出的既存 bug(本 PR 不修,已 pin)

**SQLite 上,`Field.datetime` 列的日期分桶恒为 `NULL`** —— 所有记录塌进一个桶,趋势图只剩一根柱子。度量总额是对的,坏的只是分桶键。

- `buildDateBucketExpr` 对 SQLite 产出 `strftime('%Y-%m', ??)`,而 SQLite 把裸 INTEGER 当 **Julian day number** 解释,epoch-ms 远超合法范围 → NULL。
- **engine 不兜底**:[engine.ts:3576-3596](packages/objectql/src/engine.ts:3576) 只在「granularity 未被 `supports.queryDateGranularity` 声明」或「非 UTC 时区」时才回落到 in-memory 分桶。SQLite 声明了 `month/day/quarter/year`,所以 UTC 下必然下推,没有任何一层察觉。
- 现有 `sql-driver-date-bucket.test.ts` 漏掉它,是因为它建表用 `t.string('ts')` 存 ISO TEXT,从没走过 `initObjects({type: 'datetime'})` 那条真实路径。

与 #3650 无关、也不是本 PR 引入的,但**落在同一个查询形态上**:两者叠加时 SQLite 的按月趋势图 = 一根柱子 + 全量历史,本 PR 修掉后半截。已作为 `KNOWN GAP` 测试钉在 `sql-driver-aggregate-datetime-window.test.ts` 里,注释写明修复后该断言应变成什么 —— 免得日后被当成"dateRange 那个修复没用"重新发现。

## 另一处已知的相邻不一致(本 PR 不动)

`preview-evaluator` 对窗口上界用的是 inclusive-end-**day** 语义(`v <= \`${end}~\``),而两条执行路径(NativeSQL、现在的 ObjectQL)都是裸 `$lte`。对 `datetime` 列这意味着 `['2026-04-01','2026-06-30']` 会把 6/30 当天 00:00 之后的记录排除在执行结果外、却包含在草稿预览里。这是既存分叉,本 PR 让两条**执行**路径先对齐;要不要把 end 补齐成 end-of-day 是独立的语义决策,值得单开。

🤖 Generated with [Claude Code](https://claude.com/claude-code)