### PR TITLE
fix(automation): put a screen field's `visibleWhen` on the wire (#3528)

### DIFF
--- a/.changeset/screen-field-visible-when-on-the-wire.md
+++ b/.changeset/screen-field-visible-when-on-the-wire.md
@@ -1,0 +1,41 @@
+---
+"@objectstack/spec": minor
+"@objectstack/service-automation": minor
+---
+
+fix(automation): a screen field's `visibleWhen` reaches the client (#3528)
+
+`visibleWhen` has been on the `screen` node's designer form since #3304 —
+declared as an expression (`xExpression`), documented as bare CEL, offered to
+authors in Studio. The executor never put it on the wire. `ScreenFieldSpec`
+carried `name` / `label` / `type` / `required` / `options` / `defaultValue` /
+`placeholder` and nothing else, so no client could honour a predicate it never
+received. Authors wrote conditional visibility; every field rendered
+unconditionally; nothing errored.
+
+That is worse than a cosmetic miss, because `required` **is** honoured. A field
+that is optional-by-design but required *when shown* becomes permanently
+required once its predicate is dropped — and a runner that validates the full
+field list then blocks Submit on input the user was never asked for. No resume
+request is issued and the run sits paused forever. HotCRM's lead-conversion
+screen is exactly that shape:
+
+```ts
+{ name: 'createOpportunity', type: 'boolean', required: true },
+{ name: 'opportunityName',   type: 'text', required: true,
+  visibleWhen: 'createOpportunity == true' },
+```
+
+Leave the checkbox unticked and `opportunityName` — which should not be on
+screen at all — blocks the whole conversion.
+
+- `ScreenFieldSpec.visibleWhen` is now part of the contract, documented as
+  client-evaluated bare CEL over the screen's own field names, with the
+  `required`-must-follow-visibility rule stated where implementors will read it.
+- The `screen` executor forwards it **raw**, deliberately uninterpolated: the
+  predicate is re-evaluated per keystroke against values only the client has, so
+  resolving it server-side against flow variables would freeze the field.
+- Covered by tests — the screen wire payload had none for this key.
+
+Clients must evaluate the predicate and skip hidden fields when enforcing
+`required`. Honouring one without the other reproduces the dead-end above.

--- a/content/docs/automation/flows.mdx
+++ b/content/docs/automation/flows.mdx
@@ -210,9 +210,50 @@ rather than evaluating an arbitrary JavaScript string:
 }
 ```
 
+**Screen (flat fields):**
+
+The default shape. Each field is collected as a **bare flow variable**, so a
+later node reads `{subject}`, not `{screen_1.subject}`.
+
+```typescript
+{
+  id: 'screen_1',
+  type: 'screen',
+  label: 'Conversion Details',
+  config: {
+    fields: [
+      { name: 'createOpportunity', label: 'Create Opportunity?', type: 'boolean',
+        required: true, defaultValue: false },
+      { name: 'opportunityName', label: 'Opportunity Name', type: 'text',
+        required: true,
+        visibleWhen: 'createOpportunity == true' },
+    ],
+  },
+}
+```
+
+`visibleWhen` is **bare CEL over the screen's own field names** — not the `{var}`
+template dialect the rest of a node's `config` uses. The client re-evaluates it
+as the user types, against the values collected so far, which is why it cannot
+be a server-interpolated template. Omit it for a field that is always visible.
+
+A hidden field is not collected, and is **not enforced as `required`** — so
+`required` on a `visibleWhen` field means "required *when shown*". That is what
+lets the example above ask for an opportunity name only when one is being
+created.
+
+Two things worth knowing:
+
+- **Give a `required` boolean a `defaultValue`.** An untouched checkbox holds no
+  value at all, which counts as unanswered — without `defaultValue: false` the
+  user cannot express "no" by leaving it clear.
+- **A broken predicate fails open** (the field stays visible) rather than hiding
+  an input the flow may be waiting on. Nothing validates the expression at
+  author time yet, so a typo shows up as a field that never hides.
+
 **Screen (object form):**
 
-A `screen` node normally renders a flat `fields` list. Set `config.objectName`
+Set `config.objectName`
 to instead render an object's **entire** create/edit form — including any
 master-detail child grids (`inlineEdit`) — as one wizard step. The client
 renders the object form and, on save, **persists the record itself** (parent +

--- a/packages/services/service-automation/src/builtin/screen-nodes.test.ts
+++ b/packages/services/service-automation/src/builtin/screen-nodes.test.ts
@@ -151,3 +151,89 @@ it('resolves config.functionName as an alias for function (#1870 DX)', async () 
         expect(seen).toEqual([{ cat: 'billing', conf: 0.9 }]);
     });
 });
+
+/** A one-`screen`-node flow whose screen node carries `config`. */
+function screenFlow(config: Record<string, unknown>) {
+    return {
+        name: 'screen_flow',
+        label: 'Screen Flow',
+        type: 'screen' as const,
+        nodes: [
+            { id: 'start', type: 'start' as const, label: 'Start' },
+            { id: 'collect', type: 'screen' as const, label: 'Collect', config },
+            { id: 'end', type: 'end' as const, label: 'End' },
+        ],
+        edges: [
+            { id: 'e1', source: 'start', target: 'collect' },
+            { id: 'e2', source: 'collect', target: 'end' },
+        ],
+    };
+}
+
+describe('screen node — the field wire payload (#3528)', () => {
+    let engine: AutomationEngine;
+
+    beforeEach(() => {
+        engine = new AutomationEngine(createTestLogger());
+        registerScreenNodes(engine, createCtx());
+    });
+
+    /**
+     * `visibleWhen` has been on the screen node's designer form since #3304 but
+     * was dropped when the executor built the paused payload, so it reached no
+     * client and nothing honoured it. HotCRM's lead-conversion screen is the
+     * shape that made it fatal: an optional-by-design field that is `required`
+     * *when shown*. Rendered unconditionally, it blocks Submit on input the
+     * user was never asked for, and the run never resumes.
+     */
+    it('forwards visibleWhen to the paused screen so the client can honour it', async () => {
+        engine.registerFlow('screen_flow', screenFlow({
+            title: 'Conversion Details',
+            fields: [
+                { name: 'createOpportunity', label: 'Create Opportunity?', type: 'boolean', required: true },
+                { name: 'opportunityName', label: 'Opportunity Name', type: 'text', required: true, visibleWhen: 'createOpportunity == true' },
+                { name: 'opportunityAmount', label: 'Opportunity Amount', type: 'currency', visibleWhen: 'createOpportunity == true' },
+            ],
+        }) as any);
+
+        const paused = await engine.execute('screen_flow');
+        expect(paused.status).toBe('paused');
+        const fields = paused.screen!.fields;
+        expect(fields.map((f) => f.visibleWhen)).toEqual([
+            undefined,
+            'createOpportunity == true',
+            'createOpportunity == true',
+        ]);
+        // The conditional field keeps `required` — it is required *when shown*.
+        // Honouring one without the other is what dead-ends the run.
+        expect(fields[1]).toMatchObject({ name: 'opportunityName', required: true });
+    });
+
+    it('leaves visibleWhen undefined when the author declared none', async () => {
+        engine.registerFlow('screen_flow', screenFlow({
+            fields: [{ name: 'subject', label: 'Subject', type: 'text', required: true }],
+        }) as any);
+
+        const paused = await engine.execute('screen_flow');
+        expect(paused.screen!.fields[0].visibleWhen).toBeUndefined();
+    });
+
+    /**
+     * The predicate is re-evaluated by the client on every keystroke against
+     * the values collected so far, which the server cannot see. Interpolating
+     * it here would bake in a verdict from flow variables and freeze the field.
+     */
+    it('forwards the predicate RAW — it is not interpolated against flow variables', async () => {
+        engine.registerFlow('screen_flow', screenFlow({
+            fields: [
+                { name: 'tier', label: 'Tier', type: 'text' },
+                // `{recordId}` is a live flow variable; were the predicate
+                // interpolated it would come back with the value substituted.
+                { name: 'note', label: 'Note', type: 'text', visibleWhen: 'tier == "gold" && "{recordId}" != ""' },
+            ],
+        }) as any);
+
+        const paused = await engine.execute('screen_flow', { params: { recordId: 'lead_1' } } as any);
+        expect(paused.screen!.fields[1].visibleWhen).toBe('tier == "gold" && "{recordId}" != ""');
+    });
+});

--- a/packages/services/service-automation/src/builtin/screen-nodes.ts
+++ b/packages/services/service-automation/src/builtin/screen-nodes.ts
@@ -137,6 +137,20 @@ export function registerScreenNodes(engine: AutomationEngine, ctx: PluginContext
           options: Array.isArray(f.options) ? (f.options as Array<{ value: unknown; label: string }>) : undefined,
           defaultValue: f.defaultValue !== undefined ? interpolate(f.defaultValue, variables, context) : undefined,
           placeholder: f.placeholder != null ? String(f.placeholder) : undefined,
+          // Forwarded RAW — deliberately not interpolated. `visibleWhen` is a
+          // predicate the client re-evaluates on every keystroke against the
+          // values collected SO FAR; the server has no view of those, so
+          // resolving it here (to a constant, against flow variables) would
+          // freeze the field visible-or-hidden for the life of the screen.
+          //
+          // It was declared on the designer form from the start but never put
+          // on the wire, so no client could honour it: authors wrote a
+          // predicate, Studio offered the input, and the field rendered
+          // unconditionally. Where that field was also `required`, a runner
+          // validating the full list blocked Submit on a field the user was
+          // never shown — the run then sat paused with no resume request ever
+          // issued (#3528).
+          visibleWhen: f.visibleWhen != null ? String(f.visibleWhen) : undefined,
         })).filter((f) => f.name.length > 0);
         return {
           success: true,

--- a/packages/spec/src/contracts/automation-service.ts
+++ b/packages/spec/src/contracts/automation-service.ts
@@ -95,6 +95,21 @@ export interface ScreenFieldSpec {
     options?: Array<{ value: unknown; label: string }>;
     defaultValue?: unknown;
     placeholder?: string;
+    /**
+     * Conditional-visibility predicate (ADR-0089's canonical key), evaluated by
+     * the CLIENT against the screen's live collected values — not by the server,
+     * which has no view of what the user has typed so far.
+     *
+     * Bare CEL over the screen's own field names, e.g. `createOpportunity ==
+     * true` shows the field only once that checkbox is ticked. Omit = always
+     * visible.
+     *
+     * A hidden field is not collected, so it must not be enforced as `required`
+     * either — a client that renders this predicate but validates over the full
+     * field list dead-ends the run: Submit blocks on a field the user was never
+     * shown, and no resume is ever issued (#3528).
+     */
+    visibleWhen?: string;
 }
 
 /**


### PR DESCRIPTION
Server half of #3528. Console half: objectui#2899.

## The reported issue was triaged as explained, but the explanation did not fit the reporter's app

#3528 was attributed to the `object-form` lazy-chunk teardown fixed in objectui#2830. That mechanism cannot fire on HotCRM's flows:

| Claim in triage | HotCRM's actual metadata |
|---|---|
| "a lead-conversion `object-form` wizard" | `lead_conversion` / `schedule_followup` are **flat-field** screens — no `object-form` step |
| lazy field widgets suspend → host remounts | the flat path (`ScreenView.FieldInput`) renders statically-imported `Input`/`Select`/`Checkbox`/`Textarea` — nothing suspends |
| `refreshAfter: true` racing the pause | already guarded at the 16.1.0 console pin `cf2d56e`: `flowHandler` returns early on `paused` without refreshing |

So the reporter's path had a different cause, still live. I reproduced it in Chromium against a real HotCRM dev server — **on both the console shipped with 16.1.0 and current objectui main** (HMR console pointed at the same backend). Identical:

```
→ POST /api/v1/automation/lead_conversion/trigger      200 {status: paused, screen}
   dialog renders: ["Create Opportunity? *", "Opportunity Name *", "Opportunity Amount"]
   click Submit (checkbox untouched)
→ (nothing)
RESUME calls: 0        dialog still open: true
```

Zero network requests on Submit, run paused forever — the reported symptom exactly.

## Root cause: a declared property that never reached the wire

`visibleWhen` has been on the `screen` node's designer form since #3304 — `screen-nodes.ts:66`, typed `xExpression`, documented one comment above as bare CEL, offered to authors in Studio. The executor's field mapper built the paused payload from `name` / `label` / `type` / `required` / `options` / `defaultValue` / `placeholder` and **dropped it**. `ScreenFieldSpec` in the contract stopped at `placeholder` too — objectui's client-side type mirrors it exactly, because it is a faithful copy of what the server actually sends.

So no client was ignoring the predicate; none ever received it. Authors wrote conditional visibility, every field rendered unconditionally, and nothing errored anywhere. The key had zero test coverage.

**Why this is fatal rather than cosmetic:** `required` *is* honoured. A field that is optional-by-design but required *when shown* becomes permanently required once its predicate is dropped, and a runner validating the full field list blocks Submit on input the user was never asked for. HotCRM's screen is precisely that shape:

```ts
{ name: 'createOpportunity', type: 'boolean', required: true },
{ name: 'opportunityName',   type: 'text', required: true,
  visibleWhen: 'createOpportunity == true' },
```

Leave the checkbox unticked and `opportunityName` — which should not be on screen at all — dead-ends the flagship lead-conversion journey.

## This PR

- **`ScreenFieldSpec.visibleWhen`** joins the contract (`@objectstack/spec`), documented as **client-evaluated bare CEL** over the screen's own field names, and states the rule an implementor needs: a hidden field is not collected, so it must not be enforced as `required`. Honouring one without the other is the dead-end above.
- **The `screen` executor forwards it raw** — deliberately uninterpolated. The predicate is re-evaluated on every keystroke against values only the client holds; resolving it here against flow variables would bake in one verdict and freeze the field for the life of the screen. A test pins that (a predicate embedding a live `{recordId}` token comes back verbatim).
- **Tests for the screen wire payload**, which had none for this key.

No engine, route, or resume-path changes — those halves work, and `automation.resume` has been on the SDK since #3552.

## Test plan

- `packages/services/service-automation` — **368 passed** (33 files), 3 new.
- `packages/spec` contracts + automation — **523 passed** (45 files).
- Both new forwarding assertions **verified to fail without the fix**: deleting the one added line yields `expected [undefined, undefined, undefined]` and `expected undefined to be 'tier == "gold" && "{recordId}" != ""'`.
- ESLint clean on all changed files.

**End-to-end, with this change applied to the running server** (equivalent patch into HotCRM's installed 16.1.0 dist) plus objectui#2899 and the HotCRM authoring fixes:

```
→ POST .../lead_conversion/trigger                 (paused)
   rendered: ["Create Opportunity? *"]              ← conditional fields correctly hidden
   click Submit
→ POST .../runs/run_63d43c4c.../resume  {"inputs":{"createOpportunity":false}}
   toast "Done", dialog closed, 0 server errors     ← flow ran to completion
```

## Follow-ups, not in this PR

- **objectui** must evaluate the predicate and skip hidden fields when enforcing `required` — objectui#2899. Until it ships, this change is inert on that surface: the field arrives but nothing reads it.
- **HotCRM authored the wrong dialect** — `'{createOpportunity} == true'` (flow `{var}` interpolation) rather than the bare CEL this key declares — and its `create_account` node copies `industry` into an enum that holds only 6 of the lead's 15 values, aborting conversion for nine industries. Both fixed in a HotCRM PR.
- **`FlowNodeSchema.config` is `z.record(z.unknown())`**, so nothing validates screen field keys at author time. A `visibleWhen` typo — or the wrong dialect above — is silently accepted today. That is the gap that let HotCRM ship a predicate no layer would ever have complained about.

### Correction

An earlier revision of this description claimed the blocked-Submit path surfaces no toast. That was wrong — a measurement artifact. My probe polled 5s after the click and sonner's error toast lasts ~4s. Polling tightly shows it at ~250ms: `"Please fill: What is the next step?, Due Date"`. There is no separate silent-block defect; the real signal was always the zero network requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122xvfanLmniNbsAPtg5hk3