### PR TITLE
refactor(metadata-core): 回收 sys_view_definition 的等价全开白名单 + 派生契约端到端实测 (#3026)

### DIFF
--- a/.changeset/sys-view-definition-default-open.md
+++ b/.changeset/sys-view-definition-default-open.md
@@ -1,0 +1,19 @@
+---
+"@objectstack/metadata-core": patch
+---
+
+refactor(metadata-core): drop `sys_view_definition`'s all-six `apiMethods` whitelist (#3026)
+
+#3745 completed this object's boilerplate CRUD-five whitelist to all six
+primitives so its batch routes stopped 405-ing. A whitelist naming all six is
+equivalent to no whitelist — except it stops tracking primitives the enum grows
+later — so the #3543 audit rule applies and the declaration is removed.
+
+No behaviour change: `undefined` resolves to `unrestricted`, whose effective
+operation set is identical to `restricted` holding all six.
+
+Removing it is safe HERE specifically because the object has no `managedBy`:
+`reconcileManagedApiMethods` (ADR-0103 D3) early-returns on a non-array
+`apiMethods`, so for a managed object an absent whitelist would take the
+managed-write backstop with it. That is why the RBAC objects reclaimed by #3745
+keep their explicit arrays and this one does not.

--- a/packages/metadata-core/src/objects/sys-view-definition.object.test.ts
+++ b/packages/metadata-core/src/objects/sys-view-definition.object.test.ts
@@ -1,42 +1,48 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * #3026 follow-up — `sys_view_definition` must expose the BATCH shape of the
- * write verbs it already grants.
+ * #3026 follow-up — `sys_view_definition` is default-open, and the derivation
+ * grants it every operation including the batch routes.
  *
- * Since the #3391 P1 contract made the bulk gate `bulk ∧ derived(child)`, a
- * boilerplate CRUD-five whitelist (`get,list,create,update,delete`) denies
- * `/batch`, `createMany`, `updateMany` and `deleteMany` while leaving the same
- * verbs open one record at a time. The companion fix that added the `bulk`
- * primitive to explicitly-whitelisted objects covered `platform-objects` only,
- * so this one — the sole object carrying a whitelist in `metadata-core` — kept
- * the gap.
+ * The #3391 P1 contract made the bulk gate `bulk ∧ derived(child)`, which turned
+ * this object's boilerplate CRUD-five whitelist into a silent denial of
+ * `/batch`, `createMany`, `updateMany` and `deleteMany` while the same verbs
+ * stayed open one record at a time. #3745 completed the whitelist to all six
+ * primitives; #3543's audit rule then applies — a whitelist naming all six is
+ * equivalent to no whitelist while NOT tracking future primitives — so the
+ * declaration is gone.
  *
- * Unlike the RBAC objects reclaimed alongside it, this object has no
- * `managedBy`, so the ADR-0103 D3 reconciliation never applies and deleting the
- * whitelist would be behaviourally equivalent. It stays explicit on purpose: a
- * metadata-plane object that is ALSO reachable through the generic data API is
- * worth naming its exposed surface rather than inheriting whatever the
- * primitive set grows into.
+ * Deleting it is safe HERE specifically because the object has no `managedBy`:
+ * `reconcileManagedApiMethods` (ADR-0103 D3) early-returns on a non-array
+ * `apiMethods`, so for a managed object an absent whitelist would take the
+ * managed-write backstop with it. That is why the RBAC objects reclaimed by
+ * #3745 keep their explicit arrays and this one does not.
  */
 
 import { describe, expect, it } from 'vitest';
 import { resolveEffectiveApiMethods, isApiOperationAllowed } from '@objectstack/spec/data';
 import { SysViewDefinitionObject } from './sys-view-definition.object.js';
 
-describe('sys_view_definition — batch exposure (#3026 / #3391 P1 companion)', () => {
-  it('grants the bulk primitive alongside its single-record write verbs', () => {
-    expect(SysViewDefinitionObject.enable?.apiMethods).toContain('bulk');
-    for (const verb of ['get', 'list', 'create', 'update', 'delete'] as const) {
-      expect(SysViewDefinitionObject.enable?.apiMethods, `must keep ${verb}`).toContain(verb);
-    }
+describe('sys_view_definition — API exposure (#3026 / #3543 audit)', () => {
+  it('carries no whitelist, so the resolver reports unrestricted', () => {
+    // Regression guard both ways: re-adding a whitelist naming all six
+    // primitives is a no-op that stops tracking future ones, and any narrower
+    // whitelist silently closes routes that are open today.
+    expect(SysViewDefinitionObject.enable?.apiMethods).toBeUndefined();
+    expect(resolveEffectiveApiMethods(SysViewDefinitionObject.enable).mode).toBe('unrestricted');
   });
 
   it('admits createMany / updateMany / deleteMany and /batch', () => {
     const eff = resolveEffectiveApiMethods(SysViewDefinitionObject.enable);
-    expect(eff.mode).toBe('restricted');
     for (const child of ['create', 'update', 'delete'] as const) {
       expect(isApiOperationAllowed(eff, 'bulk', { bulkChild: child }), `batch ${child}`).toBe(true);
+    }
+  });
+
+  it('derives the data-portability verbs from the primitives', () => {
+    const eff = resolveEffectiveApiMethods(SysViewDefinitionObject.enable);
+    for (const op of ['import', 'export', 'upsert', 'aggregate'] as const) {
+      expect(isApiOperationAllowed(eff, op), op).toBe(true);
     }
   });
 });

--- a/packages/metadata-core/src/objects/sys-view-definition.object.ts
+++ b/packages/metadata-core/src/objects/sys-view-definition.object.ts
@@ -138,8 +138,11 @@ export const SysViewDefinitionObject = ObjectSchema.create({
     trackHistory: true,
     searchable: false,
     apiEnabled: true,
-    // `bulk` = the batch shape of the verbs above; the gate is `bulk ∧ child`
-    // (#3391 P1), so omitting it 405s /batch and the *Many routes (#3026).
-    apiMethods: ['get', 'list', 'create', 'update', 'delete', 'bulk'],
+    // No `apiMethods` — default-open (#3543 audit). #3745 completed this
+    // object's whitelist to all six primitives, which is equivalent to no
+    // whitelist while NOT tracking future primitives. Unlike the RBAC objects
+    // reclaimed alongside it, this one has no `managedBy`, so there is no
+    // ADR-0103 D3 managed-write backstop that an explicit array keeps alive —
+    // nothing argues for keeping the declaration, so it goes.
   },
 });


### PR DESCRIPTION
## 改动

`sys_view_definition` 删除 `apiMethods` 声明(#3745 把它补成六原语后,已与"无白名单"等价),并重写其测试。

**零行为变化**:`undefined` 解析为 `unrestricted`,其有效操作集与"`restricted` 且持有全部六原语"完全相同(`resolveEffectiveApiMethods` 对两者走同一张 `computeOperations`,未映射的自定义 action 两种模式下也都放行)。

## 为什么这个对象删、#3745 的七个不删

不是双标,是**有没有兜底可保**:

`reconcileManagedApiMethods`(ADR-0103 D3)在 `apiMethods` 非数组时早退——

```ts
const methods = (schema as any).enable?.apiMethods;
if (!Array.isArray(methods) || methods.length === 0) return schema;
```

所以对 **`managedBy` 对象**,删掉白名单会连带关掉 managed-write 兜底(#3745 那七个都是 `managedBy`,故保留显式数组)。`sys_view_definition` **没有 `managedBy`** → D3 本就不适用 → 没有任何东西argues for保留声明 → 按 #3543 审计惯例(等价全开的样板直接删)回收。

测试改为双向守卫:白名单必须**保持缺席**(重新加回"全六个"是无操作且不再跟踪未来原语,加回更窄的则会静默关掉今天开着的路由),且 resolver 必须报 `unrestricted`;另加一条钉住它派生得到的数据可携带性动词。

## 派生契约端到端实测(本 PR 的另一半)

之前 #3745 / #3755 的结论都来自单测。这次按仓内 `dogfood-verification` 流程**起真实服务**(showcase + `--fresh --seed-admin`,独占端口 38977),以种子管理员登录后打真实 REST 面,**14/14 通过**:

| 检查 | 结果 |
|---|---|
| `/me/permissions` 下发 per-object `apiOperations` | 57 条,样本 `sys_user → [get,list,update,bulk,aggregate,history,search,import,export]` |
| 每个非通配符条目都被注解 | 57/57(`*` 按设计跳过) |
| `sys_permission_set` effective 含 `bulk` | ✅ #3745 的效果在真实下发里可见 |
| `sys_business_unit` export(白名单里从未声明过 export) | **200** —— export ⊆ list 派生成立 |
| `sys_business_unit` import(从未声明过 import) | 非 405(400 = 空 rows 校验)—— import ⊆ create∨update 成立 |
| `sys_permission_set` / `sys_position` / `sys_user_position` / **`sys_view_definition`** 的 `deleteMany` | 全部**非 405**(403/400,即请求已越过 API 门禁抵达引擎鉴权/校验层)—— 正是 #3745 与本 PR 要的效果 |
| `sys_api_key`(白名单 `[get,list]`)export | 200(派生自 list) |
| `sys_api_key` create / import / deleteMany | **405 / 405 / 405** —— 门禁的另一侧仍然关着 |
| `sys_oauth_consent`(`apiEnabled:false`) | **404** —— 404 优先于 405 的两轴顺序成立 |

> 过程中有一条断言先报 FAIL(`sys_business_unit` 在 `/me/permissions` 里查不到 `apiOperations`),按 dogfood 流程当作假设去证伪后确认是**我的断言写错了**:该对象整个条目就不在 map 里(map 只含调用方权限集显式命名的对象),而契约对"`apiOperations` 缺失 → 前端回退现行为"是明文规定,服务端也确实放行(上表 export 200 / import 非 405)。断言已改为"每个非通配符条目都必须被注解",重跑 14/14。

**未覆盖**:按钮显隐那一半在 objectui 仓,`packages/console/dist` 需要从该仓构建;本会话没有 objectui 接入,所以**前端渲染未做浏览器验证**,上表全部是服务端权威行为。

## 验证

- `@objectstack/metadata-core` 8 files / **103 tests** 全过
- #3755 的全仓棘轮仍绿(该对象删声明后不再被扫,57 处声明 0 违规)
- 端到端 14/14(见上),服务已按流程自行拆除(端口已释放)

changeset:`@objectstack/metadata-core` patch。

## 关联

#3026、#3745(补 `bulk` 的那批对象)、#3755(防复发棘轮)、#3543(P2 审计惯例)、ADR-0103 D3

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkdX2VCuKfcsFBbvtATe7V)_