### PR TITLE
feat(auth): AuthPlugin 自派生 app 组织角色 —— 宿主零接线 (#3723 后续, cloud#897)

### DIFF
--- a/.changeset/auth-org-roles-self-derived.md
+++ b/.changeset/auth-org-roles-self-derived.md
@@ -1,0 +1,31 @@
+---
+'@objectstack/plugin-auth': minor
+'@objectstack/plugin-dev': patch
+'@objectstack/verify': patch
+'@objectstack/cli': patch
+---
+
+feat(auth): AuthPlugin derives app-declared organization roles itself — hosts pass nothing (#3723 follow-up, cloud#897)
+
+Five hosts boot `AuthPlugin` from a stack, and per-host `additionalOrgRoles`
+wiring proved to be the defect pattern: three of them (the verify harness,
+`DevPlugin`, cloud's `ArtifactKernelFactory`) at some point forgot it, and the
+failure is silent — app-declared roles are simply absent. One host (cloud)
+mounts `AuthPlugin` before the app metadata even exists, so no init-time walk
+could ever cover it.
+
+`AuthPlugin` now derives the roles in its own `kernel:ready` hook — the one
+point that fires after all metadata is registered in every host — via the new
+`collectRegisteredOrgRoles(engine, metadataService?)` (the late-bound twin of
+`collectStackOrgRoles`). Both consumers are updated from the derived union:
+better-auth's org-plugin roles map (`applyConfigPatch`; the instance builds
+lazily) and the `sys_invitation.role` / `sys_member.role` select options
+(re-registration under the same package id — a supported registry path; no
+DDL, options are validator/picker metadata).
+
+`objectstack serve`, the `@objectstack/verify` harness and `DevPlugin` no
+longer pass `additionalOrgRoles` — deliberately, so the dogfood invite gate
+only stays green if the auto-derivation works. The option remains for roles
+declared OUTSIDE stack metadata; explicit entries are unioned with the derived
+set. `collectStackOrgRoles` stays exported for hosts that want an init-time
+walk of a raw stack object.

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1396,7 +1396,7 @@ export default class Serve extends Command {
       if (!hasAuthPlugin && tierEnabled('auth')) {
         try {
           const authPkg = '@objectstack/plugin-auth';
-          const { AuthPlugin, collectStackOrgRoles } = await import(/* webpackIgnore: true */ authPkg);
+          const { AuthPlugin } = await import(/* webpackIgnore: true */ authPkg);
 
           // In dev, fall back to a stable local secret so users don't have
           // to set OS_AUTH_SECRET just to try the login/register flow.
@@ -1491,22 +1491,17 @@ export default class Serve extends Command {
               if (!trustedOrigins.includes(wildcard)) trustedOrigins.push(wildcard);
             }
 
-            // Collect application-defined org roles from the stack so
-            // Better-Auth's organization plugin accepts invitations to
-            // those names (otherwise it 400s with `ROLE_NOT_FOUND`) AND the
-            // `sys_invitation.role` / `sys_member.role` selects accept them on
-            // write. #3723: the walk lives in plugin-auth so `serve`, the
-            // `@objectstack/verify` harness and any embedder derive the list
-            // identically — a second copy of it here is how the harness came to
-            // boot without app roles while `serve` had them.
-            const additionalOrgRoles = collectStackOrgRoles(config);
-
+            // App-declared organization roles (positions / permission sets)
+            // need no wiring here: AuthPlugin derives them from the registered
+            // metadata in its own kernel:ready hook (#3723 / cloud#897) — the
+            // per-host walk was the defect pattern (three of five hosts forgot
+            // it). `additionalOrgRoles` remains available for roles OUTSIDE
+            // the stack metadata, which this host has none of.
             await kernel.use(new AuthPlugin({
               secret,
               baseUrl,
               socialProviders: Object.keys(socialProviders).length > 0 ? socialProviders : undefined,
               trustedOrigins: trustedOrigins.length ? trustedOrigins : undefined,
-              ...(additionalOrgRoles.length > 0 ? { additionalOrgRoles } : {}),
               // Enable the admin plugin by default so the Setup app's
               // ban/unban/set-password/impersonate/set-role row actions
               // resolve to real endpoints. The plugin self-gates by role

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -404,8 +404,11 @@ export interface AuthManagerOptions extends Partial<AuthConfig> {
    * Better-Auth's `member` role) so it cannot inadvertently grant org-level
    * admin capabilities.
    *
-   * Typical source: `collectStackOrgRoles(stack)` — the one walk every host
-   * shares (`objectstack serve`, the verify harness, DevPlugin).
+   * Rarely needed since the kernel:ready self-derivation (#3723 follow-up):
+   * AuthPlugin reads the registered `position` / `permission` metadata itself
+   * via `collectRegisteredOrgRoles`, so stack-declared roles arrive with NO
+   * host wiring. Pass this only for roles that exist OUTSIDE stack metadata
+   * (the derived set and this list are unioned).
    *
    * Accepts a bare name, or `{ name, label }` to carry the declaring
    * metadata's own display label into the role picker (#3723) — without it the

--- a/packages/plugins/plugin-auth/src/auth-plugin.ts
+++ b/packages/plugins/plugin-auth/src/auth-plugin.ts
@@ -82,10 +82,12 @@ export interface AuthPluginOptions extends Partial<AuthConfig> {
   manifestDatasource?: string;
 
   /**
-   * Application-specific organization roles to register with Better-Auth's
-   * organization plugin so invitations to those roles aren't rejected with
-   * ROLE_NOT_FOUND. Forwarded as-is to AuthManager. See
-   * {@link AuthManagerOptions.additionalOrgRoles} for details.
+   * EXTRA organization roles to register with Better-Auth's organization
+   * plugin, beyond the ones AuthPlugin derives itself: stack-declared
+   * `position` / `permission` names arrive automatically via the
+   * kernel:ready self-derivation (#3723 follow-up), so most hosts pass
+   * nothing. Only roles that exist OUTSIDE stack metadata need this; the
+   * two sets are unioned. See {@link AuthManagerOptions.additionalOrgRoles}.
    */
   additionalOrgRoles?: OrgRoleInput[];
 

--- a/packages/plugins/plugin-auth/src/auth-plugin.ts
+++ b/packages/plugins/plugin-auth/src/auth-plugin.ts
@@ -32,10 +32,17 @@ import { runSetInitialPassword } from './set-initial-password.js';
 import { runRegisterSsoProviderFromForm, runRegisterSamlProviderFromForm, runRequestDomainVerification, runVerifyDomain } from './register-sso-provider.js';
 import { runResendVerificationEmail } from './send-verification-email.js';
 import {
+  AUTH_PLUGIN_ID,
   authIdentityObjects,
   authPluginManifestHeader,
 } from './manifest.js';
-import { normalizeAdditionalOrgRoles, withMembershipRoleOptions, type OrgRoleInput } from './org-roles.js';
+import {
+  MEMBERSHIP_ROLE_OBJECTS,
+  collectRegisteredOrgRoles,
+  normalizeAdditionalOrgRoles,
+  withMembershipRoleOptions,
+  type OrgRoleInput,
+} from './org-roles.js';
 
 /**
  * Auth Plugin Options
@@ -396,6 +403,74 @@ export class AuthPlugin implements Plugin {
             ],
           }
         : {}),
+    });
+
+    // [#3723 / cloud#897] Late-bound organization roles — hosts pass nothing.
+    //
+    // Five hosts boot AuthPlugin from a stack; three of them (verify harness,
+    // DevPlugin, cloud's ArtifactKernelFactory) at some point forgot to wire
+    // `additionalOrgRoles`, and the failure is silent: app-declared roles are
+    // simply absent, no error anywhere. Per-host wiring is the defect pattern;
+    // this hook removes the need for it. cloud is also ORDER-hostile: it
+    // mounts AuthPlugin before the app metadata exists, so no init-time walk
+    // could ever cover it — `kernel:ready` is the one point that fires after
+    // all metadata is registered in every host.
+    //
+    // What happens when app roles are found beyond the explicit config:
+    //  - better-auth side: `applyConfigPatch` merges them; the instance is
+    //    built lazily (or reset by the patch), so the org-plugin roles map is
+    //    rebuilt with the full set on next use.
+    //  - select side: `sys_invitation` / `sys_member` are re-registered with
+    //    widened `role` options under the SAME package id — an explicitly
+    //    supported re-registration path (the registry replaces the owner
+    //    contribution and invalidates the merge cache). No DDL: options are
+    //    validator/picker metadata, the column stays TEXT.
+    //
+    // Explicit `additionalOrgRoles` remains as override/extra — the union is
+    // what both consumers see, preserving the one-list invariant.
+    ctx.hook('kernel:ready', async () => {
+      try {
+        // PluginContext has no getServiceAsync — the sync getService is the
+        // API (it throws for unknown names, hence the guard). At kernel:ready
+        // the engine is long registered in every real boot; `undefined` only
+        // in mock/Lite kernels, where the metadata facade below still serves
+        // the better-auth half and the select half has no engine to update.
+        const engine = (() => {
+          try { return ctx.getService?.('objectql') as unknown; } catch { return undefined; }
+        })();
+        const metadataService = (() => {
+          try { return ctx.getService?.('metadata') as { list?: (t: string) => unknown } | undefined; }
+          catch { return undefined; }
+        })();
+        if (!engine && !metadataService) return; // mock/Lite boots — nothing to derive from
+
+        const registered = await collectRegisteredOrgRoles(engine, metadataService, ctx.logger);
+        if (registered.length === 0) return;
+
+        const known = new Set(additionalOrgRoles.map((d) => d.name));
+        const discovered = registered.filter((d) => !known.has(d.name));
+        if (discovered.length === 0) return;
+
+        const merged = [...additionalOrgRoles, ...discovered];
+        this.authManager?.applyConfigPatch({ additionalOrgRoles: merged });
+
+        const ql = engine as { registerObject?: (s: unknown, pkg?: string, ns?: string) => string } | undefined;
+        if (typeof ql?.registerObject === 'function') {
+          const widened = withMembershipRoleOptions(authIdentityObjects, merged)
+            .filter((o) => (MEMBERSHIP_ROLE_OBJECTS as readonly string[]).includes((o as { name?: string })?.name ?? ''));
+          for (const schema of widened) {
+            ql.registerObject(schema, AUTH_PLUGIN_ID, authPluginManifestHeader.namespace);
+          }
+        }
+        ctx.logger.info('[auth] app-declared organization roles derived from registered metadata', {
+          discovered: discovered.map((d) => d.name),
+          total: merged.length,
+        });
+      } catch (e) {
+        // Derivation is additive — a failure leaves the explicit config in
+        // force, which is exactly the pre-hook behavior. Loud, not fatal.
+        ctx.logger.warn('[auth] organization-role derivation failed', { error: (e as Error).message });
+      }
     });
 
     ctx.logger.info('Auth Plugin initialized successfully');

--- a/packages/plugins/plugin-auth/src/org-roles.test.ts
+++ b/packages/plugins/plugin-auth/src/org-roles.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { BUILTIN_MEMBERSHIP_ROLE_OPTIONS } from '@objectstack/spec/identity';
 import { SysInvitation, SysMember, SysUser } from '@objectstack/platform-objects/identity';
 import {
+  collectRegisteredOrgRoles,
   collectStackOrgRoles,
   membershipRoleLabel,
   membershipRoleOptions,
@@ -223,5 +224,65 @@ describe('#3723 collectStackOrgRoles — one walk for every host', () => {
     const roles = collectStackOrgRoles(stack);
     const [, member] = withMembershipRoleOptions([SysUser, SysMember], roles);
     expect(values(roleOptionsOf(member))).toContain('sales_user');
+  });
+});
+
+describe('#3723/cloud#897 collectRegisteredOrgRoles — the late-bound twin', () => {
+  it('reads position + permission items from the engine registry', async () => {
+    const engine = {
+      _registry: {
+        listItems: (type: string) =>
+          type === 'position'
+            ? [{ content: { name: 'sales_rep', label: '销售代表' } }]
+            : type === 'permission'
+              ? [{ name: 'sales_user' }] // bare item (no content wrapper) — both shapes occur
+              : [],
+      },
+    };
+    expect(await collectRegisteredOrgRoles(engine)).toEqual([
+      { name: 'sales_rep', label: '销售代表' },
+      { name: 'sales_user' },
+    ]);
+  });
+
+  it('falls back to the metadata-service facade when the registry has nothing', async () => {
+    const metadataService = {
+      list: (type: string) =>
+        Promise.resolve(type === 'position' ? [{ name: 'ops', label: 'Operations' }] : []),
+    };
+    expect(await collectRegisteredOrgRoles(undefined, metadataService)).toEqual([
+      { name: 'ops', label: 'Operations' },
+    ]);
+  });
+
+  it('registry wins over the facade per type — no double counting', async () => {
+    const engine = { _registry: { listItems: (t: string) => (t === 'position' ? [{ name: 'ops' }] : []) } };
+    const metadataService = {
+      list: (t: string) => (t === 'position' ? [{ name: 'ops' }, { name: 'ghost' }] : [{ name: 'sales_user' }]),
+    };
+    // position served by the registry (facade ignored for it); permission
+    // empty in the registry → facade serves it.
+    expect(await collectRegisteredOrgRoles(engine, metadataService)).toEqual([
+      { name: 'ops' },
+      { name: 'sales_user' },
+    ]);
+  });
+
+  it('normalizes like every other entry point — built-ins and bad names drop', async () => {
+    const engine = {
+      _registry: {
+        listItems: (t: string) =>
+          t === 'position' ? [{ name: 'owner' }, { name: 'bad.name' }, { name: 'ok_role' }] : [],
+      },
+    };
+    expect(await collectRegisteredOrgRoles(engine)).toEqual([{ name: 'ok_role' }]);
+  });
+
+  it('nothing to read from → empty, never a throw', async () => {
+    expect(await collectRegisteredOrgRoles(undefined, undefined)).toEqual([]);
+    expect(await collectRegisteredOrgRoles({}, {})).toEqual([]);
+    expect(
+      await collectRegisteredOrgRoles({ _registry: { listItems: () => { throw new Error('boom'); } } }),
+    ).toEqual([]);
   });
 });

--- a/packages/plugins/plugin-auth/src/org-roles.ts
+++ b/packages/plugins/plugin-auth/src/org-roles.ts
@@ -292,3 +292,57 @@ export function collectStackOrgRoles(stack: unknown, logger?: OrgRoleLogger): Or
   }
   return normalizeAdditionalOrgRoles(entries, logger);
 }
+
+/**
+ * Collect the organization roles REGISTERED in the running kernel — the
+ * late-bound twin of {@link collectStackOrgRoles}.
+ *
+ * `collectStackOrgRoles` needs the raw stack object in the host's hand, which
+ * is exactly why it kept being forgotten: five hosts booted `AuthPlugin` from
+ * a stack, and three of them (verify harness, DevPlugin, cloud's
+ * ArtifactKernelFactory) never wired the walk — a capability silently absent,
+ * no error anywhere. Worse, one host (cloud) mounts `AuthPlugin` BEFORE the
+ * app metadata even exists, so no init-time walk could ever cover it.
+ *
+ * This variant instead reads the `position` / `permission` metadata already
+ * registered with the engine, at whatever point it is called — `AuthPlugin`
+ * calls it from its own `kernel:ready` hook, which in every host fires after
+ * ALL plugins (and therefore all app metadata) are in. Hosts pass nothing.
+ *
+ * Dual read, same as `bootstrapDeclaredPositions`: the engine's
+ * SchemaRegistry (`_registry.listItems`) is populated by `manifest.register`
+ * in every boot path; the metadata-service facade is the fallback for boots
+ * where the registry shape differs.
+ */
+export async function collectRegisteredOrgRoles(
+  engine: unknown,
+  metadataService?: { list?: (type: string) => unknown },
+  logger?: OrgRoleLogger,
+): Promise<OrgRoleDescriptor[]> {
+  const entries: OrgRoleInput[] = [];
+  const push = (items: unknown) => {
+    if (!Array.isArray(items)) return;
+    for (const raw of items) {
+      const item = (raw as { content?: unknown })?.content ?? raw;
+      if (item && typeof (item as { name?: unknown }).name === 'string') {
+        const { name, label } = item as { name: string; label?: unknown };
+        entries.push(typeof label === 'string' ? { name, label } : { name });
+      }
+    }
+  };
+  for (const type of ['position', 'permission']) {
+    let items: unknown = undefined;
+    try {
+      const reg = (engine as { _registry?: { listItems?: (t: string) => unknown } })?._registry;
+      if (typeof reg?.listItems === 'function') items = reg.listItems(type);
+    } catch { /* fall through to the facade */ }
+    if (!Array.isArray(items) || items.length === 0) {
+      try {
+        const listed = metadataService?.list?.(type);
+        items = typeof (listed as Promise<unknown>)?.then === 'function' ? await listed : listed;
+      } catch { items = undefined; }
+    }
+    push(items);
+  }
+  return normalizeAdditionalOrgRoles(entries, logger);
+}

--- a/packages/plugins/plugin-dev/src/dev-plugin.ts
+++ b/packages/plugins/plugin-dev/src/dev-plugin.ts
@@ -522,21 +522,15 @@ export class DevPlugin implements Plugin {
     let authMounted = false;
     if (enabled('auth')) {
       try {
-        const { AuthPlugin, collectStackOrgRoles } = await import('@objectstack/plugin-auth') as any;
-        // [#3723] The same stack walk `objectstack serve` and the verify
-        // harness use. DevPlugin advertises itself as equivalent to the full
-        // stack, so a stack whose declared positions / permission sets are
-        // invitable under `serve` must be invitable here too — otherwise
-        // "equivalent" quietly excludes app-declared organization roles.
-        // Guarded: an older plugin-auth on disk simply yields none.
-        const additionalOrgRoles: string[] =
-          typeof collectStackOrgRoles === 'function'
-            ? collectStackOrgRoles(this.options.stack, ctx.logger)
-            : [];
+        const { AuthPlugin } = await import('@objectstack/plugin-auth') as any;
+        // [#3723] App-declared organization roles need no wiring: AuthPlugin
+        // derives them from the registered metadata in its own kernel:ready
+        // hook, so DevPlugin's "equivalent to the full stack" claim holds
+        // without this host having to remember a parameter (it was one of the
+        // three hosts that forgot it).
         const authPlugin = new AuthPlugin({
           secret: this.options.authSecret,
           baseUrl: this.options.authBaseUrl,
-          ...(additionalOrgRoles.length > 0 ? { additionalOrgRoles } : {}),
         });
         this.childPlugins.push(authPlugin);
         authMounted = true;

--- a/packages/verify/src/harness.ts
+++ b/packages/verify/src/harness.ts
@@ -25,7 +25,7 @@ import { ObjectQLPlugin } from '@objectstack/objectql';
 import { SqliteWasmDriver } from '@objectstack/driver-sqlite-wasm';
 import { HonoServerPlugin } from '@objectstack/plugin-hono-server';
 import { createRestApiPlugin } from '@objectstack/rest';
-import { AuthPlugin, collectStackOrgRoles } from '@objectstack/plugin-auth';
+import { AuthPlugin } from '@objectstack/plugin-auth';
 import { SecurityPlugin } from '@objectstack/plugin-security';
 import { SharingServicePlugin } from '@objectstack/plugin-sharing';
 import { SettingsServicePlugin, LocalCryptoProvider } from '@objectstack/service-settings';
@@ -182,15 +182,15 @@ export async function bootStack(
   // create, ADR-0062 federation, ADR-0086 two-doors). The bootstrap itself is
   // covered by plugin-auth unit tests + browser E2E.
   //
-  // [#3723] `additionalOrgRoles` IS derived here, from the same
-  // `collectStackOrgRoles` walk `objectstack serve` uses. The harness used to
-  // omit it, so a dogfood proof booted a stack whose declared roles better-auth
-  // had never heard of — the one surface that drives the real HTTP route was
-  // blind to the exact class of bug it exists to catch.
+  // [#3723] App-declared organization roles need no wiring: AuthPlugin derives
+  // them from the registered metadata in its own kernel:ready hook. The
+  // harness passing NOTHING is deliberate and is itself part of the proof —
+  // the dogfood invite gate only stays green if the auto-derivation works,
+  // which is exactly the guarantee per-host wiring could never give (this
+  // harness was one of the three hosts that forgot it).
   await kernel.use(new AuthPlugin({
     secret: opts.authSecret ?? DEFAULT_AUTH_SECRET,
     autoDefaultOrganization: false,
-    additionalOrgRoles: collectStackOrgRoles(config),
   }));
 
   // ADR-0062 — datasource connection service (registers 'datasource-connection'),


### PR DESCRIPTION
#3723 (PR #3747) 的后续。关联 objectstack-ai/cloud#897(为它解除 framework 侧前提,但不关闭它 —— 注意本描述**刻意不写** Closes:cloud#897 的收尾要等 pin bump 后在 cloud 侧验证)。

## 为什么还要一步

#3747 把「一份角色清单喂两个消费方」做对了,但生产侧仍是**按宿主接线**:五个从 stack 启动 `AuthPlugin` 的宿主,每个都得记得传 `additionalOrgRoles`。事实证明这就是缺陷模式 —— 五个里**三个**曾经忘了传(verify harness、DevPlugin、cloud 的 ArtifactKernelFactory),而且失效是安静的:没有报错,app 角色只是凭空缺席。

cloud 还额外**顺序不友好**:它在 `:380` 挂 AuthPlugin、`:792` 才挂 AppPlugin —— 任何 init 时的 stack 遍历都注定拿不到元数据。

## 方案:kernel:ready 自派生

`kernel:ready` 是所有宿主里唯一保证「全部元数据已注册」的时点。AuthPlugin 在自己的 hook 里:

1. 经新增的 `collectRegisteredOrgRoles`(`collectStackOrgRoles` 的晚绑定孪生;读取路径照抄 `bootstrapDeclaredPositions` 的既有范式 —— engine registry 优先,metadata-service facade 兜底)读取已注册的 `position` / `permission` 元数据;
2. 与显式传入的 `additionalOrgRoles` 取并集(显式项保留为「stack 元数据之外的角色」的覆盖口);
3. 两个消费方从同一并集更新:
   - **better-auth 侧**:`applyConfigPatch` —— 实例本就 lazy 构建(或被 patch 重置),下次使用即携带完整 roles map;
   - **select 侧**:以**同 packageId** 重注册 `sys_invitation` / `sys_member` —— registry 明确支持的路径(owner contribution 替换 + merge cache 失效)。无 DDL:options 是校验器/picker 元数据,列类型不变。

## 证明方式:宿主接线全部拆除

`serve` / verify harness / `DevPlugin` **不再传** `additionalOrgRoles` —— 刻意的:dogfood 邀请闸门(app-org-role-invite + delegated-admin-invite,10 条)现在**只有自派生生效才会绿**。这是「构造上不可能忘」的端到端证据,而不是又一层「记得接线」。

对 cloud#897 的意义:ArtifactKernelFactory **一行都不用改** —— 它的 kernel:ready 同样在 AppPlugin(bundle) 之后触发,positions 经 cloud#898 已能到达托管环境,pin bump 后此路径自动打通。

## 调试中抓到并修掉的一个真 bug(值得记录)

hook 最初用 `ctx.getServiceAsync('objectql')` 取引擎 —— **PluginContext 根本没有这个方法**(只有同步 `getService`)。可选链让它静默得到 `undefined`:metadata facade 撑起了 better-auth 半边,select 半边被无声跳过,派生日志照打成功而邀请继续 400。定位靠给 `SchemaRegistry.prototype.registerObject` 挂探针记录 boot 全程对 `sys_member` 的注册序列,发现 hook 的那次注册**从未发生**。教训:可选链 + 猜测的 API 名 = 静默半残,恰是本 PR 要消灭的那类失效。

## 验证

- **dogfood 邀请闸门 10/10,宿主零接线**(harness 不传任何角色参数);
- `org-roles.test.ts` 29 条(新增 5 条覆盖 `collectRegisteredOrgRoles`:registry 优先、facade 兜底、`content` 包装两种形状、归一化一致、永不抛);
- plugin-auth 603 / cli 667 / verify 7 / plugin-dev 7 / spec 6736 全过;全量 dogfood 375 passed;
- 全量 `turbo build`(除 docs)71/71。

## 后续

- cloud 侧:pin bump 到含本 PR 的 SHA 后,在托管环境验证邀请路径,然后关 cloud#897(其 `control-plane-preset.ts:389` 的顺手确认仍待做);
- `collectStackOrgRoles` 保留导出(仍是合法的 init 时遍历入口),但不再是任何宿主的必需品。

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnxCZD2RScLGbX2iZdFBGm)_