### PR TITLE
fix(driver-sql): bound a connection attempt at 10s, correct the "no reconnection" claim (#3769)

### DIFF
--- a/.changeset/driver-connect-bound-and-reconnect-correction.md
+++ b/.changeset/driver-connect-bound-and-reconnect-correction.md
@@ -1,0 +1,58 @@
+---
+"@objectstack/driver-sql": minor
+"@objectstack/objectql": patch
+"@objectstack/types": patch
+---
+
+fix(driver-sql): bound a connection attempt at 10s, and correct the "no reconnection" claim (#3769, #3759)
+
+Two related corrections, both from measuring what #3741/#3751/#3765 had only asserted.
+
+**The claim was wrong.** #3751 and #3765 shipped several statements that drivers
+never reconnect — "there is no lazy reconnection", "NOT retried and NOT
+reconnected", "stays disconnected for the process lifetime". Measured, both
+drivers recover on their own:
+
+- driver-mongodb: killing a real `mongod` and restarting it on the same port,
+  the *same* driver instance served the next write successfully (13ms), with no
+  reconnect call from us — the official driver's topology monitor handles it.
+- driver-sql: a knex/pg pool is not poisoned by an outage. Its error tracks live
+  server state (`ECONNREFUSED` while down → a handshake error once a listener is
+  back → `ECONNREFUSED` again), i.e. every acquire opens a fresh connection.
+  `storage-driver.ts` also configures `pool.min: 0`, so no stale idle
+  connections are held.
+
+The original reasoning grepped this repo for `reconnect`, found nothing, and
+concluded recovery does not happen — but the recovery lives in the client
+libraries, not in our code. The claims are now corrected in `DriverConnectError`,
+the `DEGRADED BOOT` banner, `resolveAllowDriverConnectFailure`'s docs, and the
+drivers / self-hosting pages.
+
+**Fail-fast at boot is unchanged and still correct** — the reason is just
+different. It is not that the connection can never return; it is that the *boot
+sequence* never re-runs. A driver that missed `init()` also missed
+`syncRegisteredSchemas()`, so its tables can simply not exist even after the
+database comes back. The banner now says that.
+
+**The real defect underneath.** `SqlDriver` passed its config to knex untouched,
+so a database endpoint that accepts TCP but never completes the handshake — an
+overloaded instance, a half-open firewall, a load balancer mid-failover — made
+every query wait out tarn's 30s default, then fail with `Timeout acquiring a
+connection. The pool is probably full`, pointing an operator at pool sizing
+instead of the network. With a small `pool.max` a few such queries saturate the
+pool and everything else queues.
+
+`SqlDriver` now defaults `pool.createTimeoutMillis` to **10s**, matching
+driver-mongodb's existing `connectTimeoutMS ?? 10_000` so both drivers give up on
+an unreachable server at the same point. A host that sets its own
+`createTimeoutMillis` is left alone.
+
+**Migration.** None for a healthy datasource. A deployment that deliberately
+relies on connection establishment taking longer than 10s (a slow cross-region
+replica) should set `pool.createTimeoutMillis` explicitly on its `SqlDriver`
+config.
+
+Not fixed here, tracked in #3769: knex still reports the bounded wait as "the
+pool is probably full". An accurate message needs a dialect-specific connect
+timeout (pg's `connectionTimeoutMillis`), which changes the shape of `connection`
+and would regress the startup banner's URL display.

--- a/content/docs/data-modeling/drivers.mdx
+++ b/content/docs/data-modeling/drivers.mdx
@@ -78,17 +78,24 @@ bootstrap. If any `connect()` rejects, the boot is **refused**
 ([#3741](https://github.com/objectstack-ai/objectstack/issues/3741)) — the error
 names each failed driver and its cause, and `objectstack serve` exits 1.
 
-There is no lazy reconnection. A driver that did not connect at startup stays
-disconnected for the process lifetime, so booting anyway would produce a server
-that reports itself started, answers health checks, and then fails every request
-with an error nothing like *the database is unreachable* — while the schema sync
-that follows `init()` issues DDL against a datasource that isn't there.
+Booting without a reachable datasource would produce a server that reports
+itself started, answers health checks, and then fails every request with an
+error nothing like *the database is unreachable* — while the schema sync that
+follows `init()` issues DDL against a datasource that isn't there.
+
+The reason is **not** that the connection can never come back. Client libraries
+do re-establish connections on their own — the MongoDB driver's topology monitor
+reconnects, and knex/pg opens a fresh connection per acquire (verified in
+[#3759](https://github.com/objectstack-ai/objectstack/issues/3759)). What never
+comes back is the **boot sequence that was skipped**: nothing re-runs the schema
+sync, so those objects can be left with no tables even after the database
+returns.
 
 <Callout type="warn">
 `OS_ALLOW_DRIVER_CONNECT_FAILURE=1` boots anyway, in an explicitly degraded
-state announced by a `DEGRADED BOOT` banner. The failed drivers are never
-retried and never reconnected: every query and every schema sync routed to them
-fails until the process restarts. Do not set it in production.
+state announced by a `DEGRADED BOOT` banner. Queries to a failed driver fail
+until the datasource becomes reachable, and its boot-time schema sync is skipped
+for good. Do not set it in production.
 </Callout>
 
 ### Writing a driver: `connect()` is where you refuse to start

--- a/content/docs/deployment/self-hosting.mdx
+++ b/content/docs/deployment/self-hosting.mdx
@@ -298,13 +298,14 @@ cleanly and a replica that lost its database stops receiving traffic instead of
 serving 500s. Before setting `replicas > 1`, read the multi-node note below.
 
 <Callout type="info">
-Drivers do **not** reconnect on their own
-([#3759](https://github.com/objectstack-ai/objectstack/issues/3759)). Once a
-connection is lost the process stays broken until it restarts, so on Kubernetes
-the readiness probe above is what removes the replica — pair it with your
-normal restart policy. Without an orchestrator (bare `os serve`, systemd, a
-single container with no health check), plan for a supervisor that restarts on
-a failing `/api/v1/ready`.
+A replica **does** recover on its own once the database returns — client
+libraries re-establish connections without help (the MongoDB driver's topology
+monitor; knex/pg opening a fresh connection per acquire, verified in
+[#3759](https://github.com/objectstack-ai/objectstack/issues/3759)). So a
+transient outage — a failover, a maintenance window — needs no restart: the
+readiness probe drains the replica while the database is away and re-admits it
+afterwards. Restart only when the process is genuinely stuck, and note that a
+replica which *booted* without its database never re-runs its schema sync.
 </Callout>
 
 ## Reverse proxy & TLS

--- a/packages/objectql/src/driver-connect-errors.ts
+++ b/packages/objectql/src/driver-connect-errors.ts
@@ -67,10 +67,10 @@ export class DriverConnectError extends Error {
     super(
       `${failures.length} of ${totalDrivers} data driver(s) failed to connect — refusing to boot.\n` +
       `${detail}\n` +
-      `A driver that did not connect cannot serve queries (there is no lazy reconnection) and the ` +
-      `schema sync that runs right after init would issue DDL against it. Fix the datasource ` +
-      `configuration (e.g. OS_DATABASE_URL), or set OS_ALLOW_DRIVER_CONNECT_FAILURE=1 to boot anyway ` +
-      `in an explicitly degraded state where every query to those drivers fails.`,
+      `A driver that did not connect cannot serve queries, and the schema sync that runs right ` +
+      `after init would issue DDL against it. Fix the datasource configuration (e.g. ` +
+      `OS_DATABASE_URL), or set OS_ALLOW_DRIVER_CONNECT_FAILURE=1 to boot anyway and serve errors ` +
+      `until the datasource becomes reachable.`,
     );
     this.name = 'DriverConnectError';
     if (failures[0]?.error instanceof Error) {

--- a/packages/objectql/src/engine-driver-connect-failfast.test.ts
+++ b/packages/objectql/src/engine-driver-connect-failfast.test.ts
@@ -132,7 +132,9 @@ describe('ObjectQL.init() — driver connect fail-fast (framework#3741)', () => 
     await expect(engine.init()).resolves.toBeUndefined();
     const warned = warnings.join('\n');
     expect(warned).toContain('DEGRADED BOOT');
-    expect(warned).toContain('NOT reconnected');
+    // The durable consequence is the SKIPPED SCHEMA SYNC, not a dead connection:
+    // the client reconnects on its own, but nothing re-runs the DDL (#3759).
+    expect(warned).toContain('SKIPPED FOR GOOD');
     expect(warned).toContain('sql');
   });
 

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -1891,13 +1891,15 @@ export class ObjectQL implements IDataEngine {
    * `connect()` rejects, this throws {@link DriverConnectError} and kernel
    * bootstrap aborts. Two reasons, both load-bearing:
    *
-   *  1. A driver that did not connect never recovers — there is no lazy
-   *     reconnection anywhere in `driver-sql` / `driver-mongodb`. Booting
-   *     anyway produces a server that reports itself started, may even answer
-   *     health checks, and then 500s every request with an error that reads
+   *  1. Booting without a reachable datasource produces a server that reports
+   *     itself started and then 500s every request with an error that reads
    *     nothing like "the database is unreachable". The caller immediately
    *     makes it worse: `ObjectQLPlugin.start()` runs `syncRegisteredSchemas()`
-   *     right after this, issuing DDL against a driver that isn't there.
+   *     right after this, issuing DDL against a driver that isn't there — so
+   *     the boot leaves the schema half-applied even if the database appears
+   *     a second later. Recovery is not the point: the underlying clients DO
+   *     re-establish connections on their own (framework#3759 verified this),
+   *     but nothing re-runs the boot sequence that was skipped.
    *  2. Swallowing the rejection removed a driver's ability to REFUSE STARTUP.
    *     Any fatal startup check — licence, server version, incompatible
    *     configuration, missing capability, not just an unreachable socket — is
@@ -1935,9 +1937,10 @@ export class ObjectQL implements IDataEngine {
       const banner =
         `⚠️ DEGRADED BOOT: ${failures.length} of ${this.drivers.size} driver(s) failed to connect ` +
         `(${failedDrivers.join(', ')}), but OS_ALLOW_DRIVER_CONNECT_FAILURE is set — starting anyway. ` +
-        `These drivers are NOT retried and NOT reconnected: every query and every schema sync routed ` +
-        `to them fails for the lifetime of this process. Unset OS_ALLOW_DRIVER_CONNECT_FAILURE to ` +
-        `restore fail-fast boot.`;
+        `Every query routed to them fails until the datasource becomes reachable, and the boot-time ` +
+        `schema sync is SKIPPED FOR GOOD — the client will reconnect on its own, but nothing re-runs ` +
+        `the DDL, so those objects may have no tables even after the database comes back. Unset ` +
+        `OS_ALLOW_DRIVER_CONNECT_FAILURE to restore fail-fast boot.`;
       this.logger.warn(banner, { failedDrivers });
       // …and again on a channel the host cannot silence — see the helper's note
       // on `os serve`'s boot-quiet stdout capture.

--- a/packages/plugins/driver-sql/src/sql-driver-connect-bound.test.ts
+++ b/packages/plugins/driver-sql/src/sql-driver-connect-bound.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// framework#3769: a database endpoint that accepts the TCP connection but never
+// completes the handshake (overloaded instance, half-open firewall, LB mid-
+// failover) makes every query WAIT rather than fail. Left to tarn's default that
+// wait is 30s per query on the request path. SqlDriver now bounds it by default,
+// while leaving a host's own choice alone.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import net from 'node:net';
+import { SqlDriver } from './sql-driver.js';
+
+/** A listener that accepts sockets and then says nothing, ever. */
+function blackHole() {
+  const held: net.Socket[] = [];
+  const server = net.createServer((sock) => { sock.on('error', () => {}); held.push(sock); });
+  return {
+    listen: () => new Promise<number>((resolve) => {
+      server.listen(0, '127.0.0.1', () => resolve((server.address() as net.AddressInfo).port));
+    }),
+    close: () => { held.forEach((s) => s.destroy()); server.close(); },
+  };
+}
+
+const drivers: SqlDriver[] = [];
+const make = (cfg: any) => { const d = new SqlDriver(cfg); drivers.push(d); return d; };
+
+afterEach(async () => {
+  await Promise.all(drivers.splice(0).map((d) => d.disconnect().catch(() => {})));
+});
+
+describe('SqlDriver — connection-attempt bound (framework#3769)', () => {
+  it('applies a default createTimeoutMillis when the host sets no pool config', () => {
+    const d = make({ client: 'pg', connection: 'postgres://u:p@127.0.0.1:1/d' });
+    expect((d as any).knex.client.config.pool.createTimeoutMillis).toBe(10_000);
+  });
+
+  it('applies it alongside a host pool config without clobbering min/max', () => {
+    const d = make({
+      client: 'pg',
+      connection: 'postgres://u:p@127.0.0.1:1/d',
+      pool: { min: 0, max: 5 },
+    });
+    const pool = (d as any).knex.client.config.pool;
+    expect(pool).toMatchObject({ min: 0, max: 5, createTimeoutMillis: 10_000 });
+  });
+
+  it("leaves a host's explicit createTimeoutMillis alone", () => {
+    const d = make({
+      client: 'pg',
+      connection: 'postgres://u:p@127.0.0.1:1/d',
+      pool: { min: 0, max: 5, createTimeoutMillis: 45_000 },
+    });
+    expect((d as any).knex.client.config.pool.createTimeoutMillis).toBe(45_000);
+  });
+
+  it('actually bounds a query against a black-holing endpoint', async () => {
+    const bh = blackHole();
+    const port = await bh.listen();
+    try {
+      // 700ms so the assertion is decisive: unbounded is 30s.
+      const d = make({
+        client: 'pg',
+        connection: `postgres://u:p@127.0.0.1:${port}/d`,
+        pool: { min: 0, max: 2, createTimeoutMillis: 700 },
+      });
+      const started = Date.now();
+      await expect((d as any).knex.raw('SELECT 1')).rejects.toThrow();
+      expect(Date.now() - started).toBeLessThan(5_000);
+    } finally {
+      bh.close();
+    }
+  }, 20_000);
+
+  it('does not disturb a working sqlite connection', async () => {
+    const d = make({ client: 'better-sqlite3', connection: { filename: ':memory:' }, useNullAsDefault: true });
+    await expect(d.checkHealth()).resolves.toBe(true);
+  });
+});

--- a/packages/plugins/driver-sql/src/sql-driver.ts
+++ b/packages/plugins/driver-sql/src/sql-driver.ts
@@ -569,8 +569,40 @@ export class SqlDriver implements IDataDriver {
     this.schemaMode = schemaMode ?? 'managed';
     this.autoMigrate = autoMigrate ?? 'off';
     this.config = knexConfig;
-    this.knex = knex(knexConfig);
+    this.knex = knex(SqlDriver.withConnectBound(knexConfig));
     this.installQueryTiming();
+  }
+
+  /**
+   * Default bound on establishing ONE connection (framework#3769).
+   *
+   * A database endpoint that accepts the TCP connection but never completes the
+   * handshake — an overloaded instance, a half-open firewall, a load balancer
+   * mid-failover — is the failure mode that hurts most, because nothing fails:
+   * the query just waits. Left to tarn's default that wait is **30 seconds**,
+   * per query, on the request path; with a small `pool.max` a handful of them
+   * saturate the pool and everything queues behind it.
+   *
+   * 10s matches driver-mongodb's existing `connectTimeoutMS ?? 10_000`, so both
+   * drivers give up on an unreachable server at the same point. A host that
+   * knows better (a deliberately slow cross-region replica) sets its own
+   * `pool.createTimeoutMillis` and this leaves it alone.
+   *
+   * NOTE this bounds the wait but not the diagnosis: knex reports it as
+   * "Timeout acquiring a connection. The pool is probably full", which points
+   * at pool sizing rather than the network. Making the message accurate needs a
+   * dialect-specific connect timeout (pg's `connectionTimeoutMillis`), which
+   * changes the shape of `connection` — tracked in #3769.
+   */
+  private static readonly DEFAULT_CREATE_TIMEOUT_MS = 10_000;
+
+  private static withConnectBound(knexConfig: Record<string, any>): Record<string, any> {
+    const pool = knexConfig.pool as Record<string, any> | undefined;
+    if (pool?.createTimeoutMillis !== undefined) return knexConfig; // host chose its own
+    return {
+      ...knexConfig,
+      pool: { ...(pool ?? {}), createTimeoutMillis: SqlDriver.DEFAULT_CREATE_TIMEOUT_MS },
+    };
   }
 
   /**

--- a/packages/types/src/env.ts
+++ b/packages/types/src/env.ts
@@ -179,9 +179,11 @@ export function resolveAllowDegradedTenancy(): boolean {
  *
  * Setting this to a truthy value (`true`/`1`/`on`/`yes`, case-insensitive)
  * boots anyway, in an explicitly degraded state that is logged loudly at
- * startup. There is NO reconnection: the drivers that failed stay dead for the
- * process lifetime and every query routed to them fails. Defaults OFF — an
- * unset flag means "fail fast".
+ * startup. Every query routed to a failed driver fails until the datasource
+ * becomes reachable — the underlying clients do re-establish connections on
+ * their own (framework#3759) — but the boot-time schema sync those drivers
+ * missed is never re-run, so their tables may simply not exist afterwards.
+ * Defaults OFF — an unset flag means "fail fast".
  */
 export function resolveAllowDriverConnectFailure(): boolean {
   const raw = readEnvWithDeprecation('OS_ALLOW_DRIVER_CONNECT_FAILURE', [], { silent: true });


### PR DESCRIPTION
部分关闭 #3769,并订正 #3751 / #3765 里我基于错误前提写下的声明。#3759 已按 not_planned 关闭(前提被实测推翻)。

## 一、我之前的声明是错的

#3751 和 #3765 里我写了多处"driver 不会重连" —— `there is no lazy reconnection`、`NOT retried and NOT reconnected`、`stays disconnected for the process lifetime`。**实测下来两个驱动都会自行恢复。**

**driver-mongodb**(真 mongod,杀掉后原端口+原 dbpath 重启,同一个 driver 实例,我们不调用任何 reconnect):

```
[2] SIGKILL       create FAILED MongoServerSelectionError (3001ms)
[3] 原端口重启
[4] recovery-1    create -> OK (13ms)      ← 第一次尝试就成功
```

**driver-sql**(TCP 层判定"池是否被永久毒死"):

```
while DOWN  : connect ECONNREFUSED
while UP    : Connection terminated unexpectedly   ← 错误随服务端实时状态变化
DOWN again  : connect ECONNREFUSED
```

每次获取都在开新连接。配置侧印证:`storage-driver.ts` 是 `pool.min = 0`,不驻留空闲连接。

**我当初为什么错了:** grep 自己的源码没看到 `reconnect` 实现,就推断"不会恢复"。但恢复行为在**底层客户端库**里 —— mongodb 官方 driver 的拓扑监控、knex/tarn 的按需获取。"我们没写这段代码" ≠ "这个行为不会发生"。这是方法论错误,记在 #3759 的关闭说明里。

*边界:* mongo 那个是真 mongod,结论硬;sql 那个没有真 postgres,证明的是"持续建新连接",不是"一次真实 failover 完整恢复"。

## 二、启动期 fail-fast 不变 —— 但理由变了

**不是**"连接再也回不来",而是**启动序列不会重跑**。错过 `init()` 的 driver 同时错过了 `syncRegisteredSchemas()`,所以即使数据库随后恢复,那些对象也可能压根没有表。`DEGRADED BOOT` banner 现在说的是这个,而不是一句关于死连接的假话。

订正了 4 处:`DriverConnectError` 消息、banner、`resolveAllowDriverConnectFailure()` 文档、drivers/self-hosting 两个文档页。

## 三、底下的真缺陷:连接尝试没有我们自己设的上限

`SqlDriver` 把配置原样透传给 knex,于是面对**接受 TCP 但不完成握手**的端点(过载实例、半开防火墙、failover 中途的 LB),每个查询等满 tarn 默认的 **30 秒**,然后报 `Timeout acquiring a connection. The pool is probably full` —— 池并没有满,运维会被引去调池子大小而不是查网络。`pool.max: 5` 下几个这样的查询就把池占满,后续请求开始排队,那时候"pool is full"才变成真的,但那是继发症状。

实测四种配置(真 knex/pg + 黑洞监听器):

```
today (no bound)              30024ms  Knex: Timeout acquiring a connection…
acquireConnectionTimeout 3s    3003ms  Knex: Timeout acquiring a connection…
pool.createTimeoutMillis 3s    3004ms  Knex: Timeout acquiring a connection…
connectionTimeoutMillis 3s     3006ms  timeout expired                        ← 唯一准确的诊断
```

`SqlDriver` 现在默认 `pool.createTimeoutMillis = 10s`,与 driver-mongodb 既有的 `connectTimeoutMS ?? 10_000` 对齐,两个驱动在同一点放弃。宿主自己设了就不动它。

**没在本 PR 做的:** 消息准确性需要 dialect 专属的 `connectionTimeoutMillis`(上表最后一行),而它会把 `connection` 从字符串改成对象,导致 `serve.ts` 启动横幅的 URL 显示退化成 `(unknown)`。留在 #3769,并已在代码注释里写明,免得下一个人以为已经解决。

## 验证

- 新增 `sql-driver-connect-bound.test.ts`(5 例):默认值生效 / 不覆盖宿主的 `min`&`max` / 宿主显式设置被尊重 / **真的限住了对黑洞端点的查询** / sqlite 正常连接不受干扰。
- 更新 `engine-driver-connect-failfast.test.ts` 的 banner 断言 —— 从 `NOT reconnected` 改为 `SKIPPED FOR GOOD`(持久后果是被跳过的 schema sync,不是死连接)。
- `pnpm build` 71/71 绿。受影响的包全绿:types 26、driver-sql 330、objectql 1126、runtime 661、cli 667。

**关于本地全量 `pnpm test`,如实说明:** 这台机器上它现在不稳定,**干净的 main 也一样**(131/132,dogfood 挂)。抓到的唯一真实失败是 cloud-connection 的 2 个用例 **30s 超时**,而那个文件自己的注释就写着 "cold import can eat several seconds on a fresh CI runner";turbo 随即取消其余在跑任务,所以每次"失败集合"都不同。4 核并行下的竞争,与本改动无关 —— 但这一条我没法在本地完全排除,以 CI 为准。

## 关联

- #3759(已关闭;本 PR 订正基于它的错误前提所写的声明)
- #3769(本 PR 部分关闭;消息准确性仍开着)
- #3741 / #3751(启动期 fail-fast)、#3756 / #3765(`/ready` 探针)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9VBCNvg9Zixrf1A9Rnwdd)_