### PR TITLE
docs(driver-sql): say why `applyFilterCondition` keeps `logicalOp` after #3776

### DIFF
--- a/.changeset/driver-sql-logicalop-retention-note.md
+++ b/.changeset/driver-sql-logicalop-retention-note.md
@@ -1,0 +1,26 @@
+---
+---
+
+docs(driver-sql): record why `applyFilterCondition` keeps its `logicalOp` parameter
+
+Comment-only; no behavior change, and this changeset releases nothing.
+
+#3776 made `logicalOp === 'or'` unreachable. All four call sites now pass
+`'and'` — the sole external caller plus the `$and`/`$or`/`$not` arms — because
+every key inside one filter object AND-s at every depth, and the `orWhere` that
+OR-s `$or`'s branches is applied to each branch's own sub-builder rather than
+handed down as `logicalOp`. Handing it down was the #3774 miscompile that
+widened every `$or` filter.
+
+That leaves ~15 `logicalOp === 'or'` ternaries that nothing in the repo can
+reach. They are kept deliberately: `applyFilterCondition` is `protected`, so it
+is subclass API (`SqliteWasmDriver` here, `TursoDriver` downstream), and the
+flag is the seam an override needs to attach a condition into an OR group.
+Removing it would be source-breaking for any subclass that overrides the
+four-parameter signature, which in this repo's lockstep versioning costs a
+whole-stack major — a steep price for deleting a flag that changes no behavior.
+
+The method-level TSDoc now states both halves, so the arms read as unreachable
+*by design* instead of as dead code inviting a "fix" that makes a branch
+propagate `'or'` again. `sql-driver-or-filter.test.ts` (19 cases) pins the
+semantics that made the flag dead.

--- a/packages/plugins/driver-sql/src/sql-driver.ts
+++ b/packages/plugins/driver-sql/src/sql-driver.ts
@@ -3721,6 +3721,22 @@ export class SqlDriver implements IDataDriver {
     }
   }
 
+  /**
+   * Compiles a Filter Protocol condition onto `builder`.
+   *
+   * `logicalOp` controls only how this condition attaches to `builder`
+   * (`where` vs `orWhere`) — never how its contents combine. It is never
+   * `'or'` on any in-repo path: the sole caller passes `'and'` and every
+   * combinator recurses with `'and'`, because all keys in one filter object
+   * AND at every depth. The `orWhere` that OR-s `$or`'s branches is applied
+   * to each branch's own sub-builder; handing `'or'` down instead is exactly
+   * what widened every `$or` filter (#3774 — see sql-driver-or-filter.test.ts).
+   *
+   * So the `logicalOp === 'or'` arms below are unreachable **by design**, not
+   * dead weight to prune: the method is `protected`, i.e. subclass API, and
+   * the flag is the seam an override needs to attach a condition into an OR
+   * group. Do not "fix" them by making a branch propagate `'or'` again.
+   */
   protected applyFilterCondition(builder: Knex.QueryBuilder, condition: any, logicalOp: 'and' | 'or' = 'and', tableHint?: string | null) {
     if (!condition || typeof condition !== 'object') return;
     const table = tableHint ?? this.coercionKey(builder);


### PR DESCRIPTION
Follow-up to #3776 / #3774. **Comment-only — no behavior change.**

## What #3776 left behind

The `$or` arm was `logicalOp`'s only producer. Now that it recurses with `'and'`, all four call sites pass `'and'`:

| Site | Arg |
|---|---|
| `applyQueryFilters` (sole external caller) | `'and'` |
| `$and` arm | `'and'` |
| `$or` arm | `'and'` |
| `$not` arm | `'and'` |

So `logicalOp === 'or'` is unreachable, and the ~15 ternaries spanning `$eq`/`$ne`/`$gt`/`$gte`/`$lt`/`$lte`/`$in`/`$nin`/`$between`/`$null`/`$exists` and the bare-value path are dead code.

## Decision: keep the parameter, document it

I considered removing it. Blast radius is genuinely small — across `framework`, `objectui` and `cloud` there are **zero external callers and zero overrides**; the only references are the four above. But:

- `applyFilterCondition` is `protected`, so it is **subclass API**. Real subclasses exist (`SqliteWasmDriver` here, `TursoDriver` in `cloud`), and out-of-repo ones may too.
- TypeScript rejects an override declaring *more* parameters than the base, so removal is **source-breaking** for any subclass on the four-parameter signature. Under this repo's lockstep versioning that is a **whole-stack major** — steep for deleting a flag that changes no behavior.
- The edit would touch ~15 lines of a security-critical filter compiler for zero gain, immediately after a security fix. Every one of those lines is a chance to reintroduce exactly the #3774 class of bug.
- The flag is a real composition seam: an override attaching a condition into an OR group needs it.

The hazard worth closing is the *other* one — that a future reader sees fifteen unreachable arms and "fixes" them by making a branch propagate `'or'` again, which **is** the #3774 miscompile. A method-level note closes that at a fraction of the risk.

## Verification

- `sql-driver-or-filter.test.ts` — **19/19 pass** (the cases that pin the semantics making the flag dead)
- full `driver-sql` suite — **386/386 across 39 files**
- type gate — `turbo build` **without** `OS_SKIP_DTS` (that env skips dts/typecheck), DTS built clean
- ESLint — clean

Empty-frontmatter changeset, the sanctioned "releases nothing" declaration per the Check Changeset gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)