### PR TITLE
feat(verify): checkDateBucketParity —— 钉住「下推 SQL 分桶 ↔ 内存分桶」那条没人守的接缝 (#3773 收尾)

### DIFF
--- a/.changeset/date-bucket-parity-gate.md
+++ b/.changeset/date-bucket-parity-gate.md
@@ -1,0 +1,48 @@
+---
+"@objectstack/verify": minor
+---
+
+feat(verify): `checkDateBucketParity` — pin the seam between pushed-down and in-memory date bucketing
+
+A driver that advertises `supports.queryDateGranularity[g]` is telling
+`engine.aggregate` it may push `dateGranularity: g` down as SQL instead of
+fetching rows and bucketing them in JS. The two are then not two features but
+one feature with two implementations, and the engine picks between them per
+query — a granularity the driver advertises goes down as SQL, one it does not
+goes to `applyInMemoryAggregation`, and a non-UTC timezone forces the in-memory
+path regardless. A dashboard can cross that seam mid-drill-down.
+
+Nothing checked that they agree. That is how #3773 shipped: SQLite stores a
+`Field.datetime` as INTEGER epoch milliseconds, `strftime` read the bare integer
+as a Julian day number, and every row bucketed as NULL — a trend chart collapsed
+into a single bar while every gate stayed green. The driver's own bucket suites
+build their fixtures with `knex.schema.createTable` + `t.string(...)`, which is
+ISO TEXT — the half `strftime` parses natively — and the engine never
+second-guesses a granularity a driver claims to support.
+
+`checkDateBucketParity(driver)` rounds a fixture through the driver and, for
+every granularity it advertises, compares its pushed-down result against the
+REAL `applyInMemoryAggregation` over the driver's own `find()` rows. Both
+temporal storage forms are probed under one object (`Field.datetime` and
+`Field.date` naming the same calendar days), so a storage-form leak shows up as
+the two columns bucketing differently even when each is internally consistent.
+A granularity the driver does not advertise is skipped, never faulted.
+
+It follows `checkReadCoercion`: human-readable problems (empty = conformant), no
+test-runner dependency, driver taken structurally — so an out-of-tree driver
+runs the identical contract against itself. That matters most for cloud's
+`driver-turso`, which is remote SQLite with exactly the epoch storage that broke
+here.
+
+Wired up in `packages/qa/dogfood/test/date-bucket-parity-conformance.test.ts`
+against driver-sql and driver-sqlite-wasm, with negative controls that pin what
+the checker can detect. Verified against the real regression, not just fakes:
+reverting the #3773 fix turns the gate red on both drivers with a diagnostic
+naming the collapsed bucket.
+
+The three test files that hand-copy `bucketDateValue` (driver-sql cannot depend
+on objectql) now say what their `⚠️ Keep in sync` comments cannot enforce — a
+copy that stops tracking its original leaves the copy and the SQL agreeing with
+each other while both are wrong — and point at the executable check. The same
+pointer is on `bucketDateValue` itself, which is where an edit would start the
+drift.

--- a/packages/objectql/src/in-memory-aggregation.ts
+++ b/packages/objectql/src/in-memory-aggregation.ts
@@ -175,6 +175,20 @@ function toNumber(v: any): number {
  * Bucket a date-like value into an ISO-formatted period label. Weeks start
  * Monday and use ISO week numbering.
  *
+ * ⚠️ **This is one of two implementations of the same contract.** A driver that
+ * advertises `supports.queryDateGranularity[g]` buckets that granularity in SQL
+ * instead, and `engine.aggregate` picks between them per query — so a label
+ * produced here must equal the label that driver's SQL produces for the same
+ * instant, or a drill-down breaks when it crosses the seam. Editing the labels
+ * below means editing every driver's bucket expression too.
+ *
+ * The seam is enforced by `checkDateBucketParity` (@objectstack/verify), run
+ * against the real drivers in
+ * `packages/qa/dogfood/test/date-bucket-parity-conformance.test.ts`. Three
+ * driver test files also hand-copy this function for self-containment; those
+ * copies cannot detect their own drift, which is why the executable check
+ * exists.
+ *
  * `timezone` (ADR-0053 Phase 2) resolves the calendar day in a reference zone
  * so an instant near a tz day-boundary buckets where a user in that zone would
  * expect. An unset / `'UTC'` / invalid zone keeps the historical UTC bucketing.

--- a/packages/plugins/driver-sql/src/sql-driver-date-bucket-storage.test.ts
+++ b/packages/plugins/driver-sql/src/sql-driver-date-bucket-storage.test.ts
@@ -27,7 +27,16 @@ type Granularity = 'day' | 'month' | 'quarter' | 'year';
 /** Every granularity SQLite advertises natively (week is bucketed in-memory). */
 const GRANULARITIES: Granularity[] = ['day', 'month', 'quarter', 'year'];
 
-/** ⚠️ Keep in sync with `packages/objectql/src/in-memory-aggregation.ts#bucketDateValue` */
+/**
+ * ⚠️ Keep in sync with `packages/objectql/src/in-memory-aggregation.ts#bucketDateValue`.
+ *
+ * This copy exists because driver-sql cannot depend on objectql. Nothing here
+ * can detect it drifting from its original — a stale copy and the SQL agree
+ * with each other while both are wrong. The executable check is
+ * `checkDateBucketParity` (@objectstack/verify), run against the real drivers
+ * in `packages/qa/dogfood/test/date-bucket-parity-conformance.test.ts`, where
+ * the reference side is the REAL `applyInMemoryAggregation`.
+ */
 function bucketDateValue(value: unknown, g: Granularity): string {
   if (value == null) return '(null)';
   // A finite number is epoch milliseconds — SQLite's `Field.datetime` storage.

--- a/packages/plugins/driver-sql/src/sql-driver-date-bucket.test.ts
+++ b/packages/plugins/driver-sql/src/sql-driver-date-bucket.test.ts
@@ -17,7 +17,16 @@ import { SqlDriver } from '../src/index.js';
 
 type Granularity = 'day' | 'week' | 'month' | 'quarter' | 'year';
 
-/** ⚠️ Keep in sync with `packages/objectql/src/in-memory-aggregation.ts#bucketDateValue` */
+/**
+ * ⚠️ Keep in sync with `packages/objectql/src/in-memory-aggregation.ts#bucketDateValue`.
+ *
+ * This copy exists because driver-sql cannot depend on objectql. Nothing here
+ * can detect it drifting from its original — a stale copy and the SQL agree
+ * with each other while both are wrong. The executable check is
+ * `checkDateBucketParity` (@objectstack/verify), run against the real drivers
+ * in `packages/qa/dogfood/test/date-bucket-parity-conformance.test.ts`, where
+ * the reference side is the REAL `applyInMemoryAggregation`.
+ */
 function bucketDateValue(value: unknown, g: Granularity): string {
   if (value == null) return '(null)';
   // A finite number is epoch milliseconds — SQLite's `Field.datetime` storage.

--- a/packages/plugins/driver-sqlite-wasm/src/sqlite-wasm-driver-date-bucket.test.ts
+++ b/packages/plugins/driver-sqlite-wasm/src/sqlite-wasm-driver-date-bucket.test.ts
@@ -17,7 +17,16 @@ import { SqliteWasmDriver } from '../src/index.js';
 
 type Granularity = 'day' | 'week' | 'month' | 'quarter' | 'year';
 
-/** ⚠️ Keep in sync with `packages/objectql/src/in-memory-aggregation.ts#bucketDateValue` */
+/**
+ * ⚠️ Keep in sync with `packages/objectql/src/in-memory-aggregation.ts#bucketDateValue`.
+ *
+ * This copy exists because driver-sql cannot depend on objectql. Nothing here
+ * can detect it drifting from its original — a stale copy and the SQL agree
+ * with each other while both are wrong. The executable check is
+ * `checkDateBucketParity` (@objectstack/verify), run against the real drivers
+ * in `packages/qa/dogfood/test/date-bucket-parity-conformance.test.ts`, where
+ * the reference side is the REAL `applyInMemoryAggregation`.
+ */
 function bucketDateValue(value: unknown, g: Granularity): string {
   if (value == null) return '(null)';
   // A finite number is epoch milliseconds — SQLite's `Field.datetime` storage.

--- a/packages/qa/dogfood/package.json
+++ b/packages/qa/dogfood/package.json
@@ -30,6 +30,7 @@
     "@objectstack/core": "workspace:*",
     "@objectstack/driver-memory": "workspace:*",
     "@objectstack/driver-sql": "workspace:*",
+    "@objectstack/driver-sqlite-wasm": "workspace:*",
     "@types/node": "^26.1.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"

--- a/packages/qa/dogfood/test/date-bucket-parity-conformance.test.ts
+++ b/packages/qa/dogfood/test/date-bucket-parity-conformance.test.ts
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// Date-bucket parity conformance — exercises the reusable `checkDateBucketParity`
+// helper (from @objectstack/verify) against the framework's own SQL drivers.
+// A granularity a driver ADVERTISES via `supports.queryDateGranularity` must
+// bucket identically whether `engine.aggregate` pushes it down as SQL or falls
+// back to `applyInMemoryAggregation` — they are one feature with two
+// implementations, and the engine picks between them per query.
+//
+// This is the seam #3773 crossed silently. SQLite stores a `Field.datetime` as
+// INTEGER epoch ms; `strftime` read the bare integer as a Julian day number, so
+// every row bucketed as NULL and a trend chart collapsed into one bar. Every
+// existing gate was green: the driver's own bucket suites build their tables
+// with `knex.schema.createTable` + `t.string(...)` (ISO TEXT — the half
+// `strftime` parses natively), and the engine never second-guesses a
+// granularity a driver claims to support.
+//
+// It also closes the drift the `⚠️ Keep in sync` comments cannot: three test
+// files hand-copy `bucketDateValue` because driver-sql cannot depend on
+// objectql, and a copy that stops tracking its original leaves the copy and the
+// SQL agreeing with each other while both are wrong. Here the reference side is
+// the REAL `applyInMemoryAggregation`.
+
+import { describe, it, expect } from 'vitest';
+import { checkDateBucketParity } from '@objectstack/verify';
+import { SqlDriver } from '@objectstack/driver-sql';
+import { SqliteWasmDriver } from '@objectstack/driver-sqlite-wasm';
+
+const DRIVERS = [
+  {
+    name: 'driver-sql (better-sqlite3 :memory:)',
+    make: () =>
+      new SqlDriver({
+        client: 'better-sqlite3',
+        connection: { filename: ':memory:' },
+        useNullAsDefault: true,
+      }),
+  },
+  {
+    // Inherits `buildDateBucketExpr` from SqlDriver, so it inherited #3773 too —
+    // and resolves its base class from BUILT dist, which is its own way to drift.
+    name: 'driver-sqlite-wasm (:memory:)',
+    make: () => new SqliteWasmDriver({ filename: ':memory:' }),
+  },
+];
+
+describe.each(DRIVERS)('date-bucket parity conformance: $name', ({ make }) => {
+  it('buckets identically pushed-down and in-memory, on both storage forms', async () => {
+    const problems = await checkDateBucketParity(make() as never, {
+      createOptions: { bypassTenantAudit: true },
+    });
+    expect(problems).toEqual([]);
+  });
+});
+
+describe('checkDateBucketParity detects a driver whose SQL bucketing is wrong', () => {
+  // The negative control. A gate nobody has watched fail is a gate nobody knows
+  // is wired up — and this one is cheap to fake, because the #3773 shape is
+  // exactly "advertise the granularity, then bucket everything as NULL".
+  function brokenDriver(overrides: Record<string, unknown> = {}) {
+    const rows = [
+      { id: 'b1', at: '2024-01-15T10:00:00.000Z', on: '2024-01-15', n: 1 },
+      { id: 'b2', at: '2024-06-30T23:59:59.000Z', on: '2024-06-30', n: 1 },
+      { id: 'b3', at: '2024-07-01T00:00:00.000Z', on: '2024-07-01', n: 1 },
+      { id: 'b4', at: '2024-12-30T12:00:00.000Z', on: '2024-12-30', n: 1 },
+      { id: 'b5', at: '2025-01-01T00:00:00.000Z', on: '2025-01-01', n: 1 },
+      { id: 'b6', at: '2025-05-19T09:00:00.000Z', on: '2025-05-19', n: 1 },
+      { id: 'b7', at: '2025-05-19T22:30:00.000Z', on: '2025-05-19', n: 1 },
+    ];
+    return {
+      async connect() {},
+      async disconnect() {},
+      async syncSchema() {},
+      async create() {},
+      async find() {
+        return rows;
+      },
+      // Everything collapses into one null bucket — the pre-#3773 SQLite shape.
+      async aggregate(_object: string, query: any) {
+        const field = query.groupBy[0].field;
+        return [{ [field]: null, n: rows.length }];
+      },
+      supports: { queryDateGranularity: { day: true, month: true, quarter: true, year: true, week: false } },
+      ...overrides,
+    };
+  }
+
+  it('flags every advertised granularity on both columns', async () => {
+    const problems = await checkDateBucketParity(brokenDriver() as never);
+    // 4 advertised granularities × 2 storage forms = 8 disagreements, and the
+    // cross-column pass stays quiet because both columns are broken the same way.
+    expect(problems).toHaveLength(8);
+    expect(problems.join('\n')).toMatch(/Field\.datetime 'at' @ month/);
+    expect(problems.join('\n')).toMatch(/Field\.date 'on' @ year/);
+    expect(problems.join('\n')).toMatch(/pushed-down SQL and in-memory bucketing disagree/);
+  });
+
+  it('flags a driver that advertises a granularity it cannot actually run', async () => {
+    const problems = await checkDateBucketParity(
+      brokenDriver({
+        async aggregate() {
+          throw new Error("dateGranularity 'month' not supported on dialect");
+        },
+      }) as never,
+    );
+    expect(problems.join('\n')).toMatch(/advertises this granularity but aggregate\(\) threw/);
+  });
+
+  it('flags a storage-form leak — one column right, the other collapsed', async () => {
+    // The #3773 shape exactly: the TEXT-stored `date` column buckets fine while
+    // the epoch-stored `datetime` column does not.
+    const problems = await checkDateBucketParity(
+      brokenDriver({
+        async aggregate(_object: string, query: any) {
+          const field = query.groupBy[0].field;
+          if (field === 'on') {
+            return [
+              { on: '2024', n: 4 },
+              { on: '2025', n: 3 },
+            ];
+          }
+          return [{ at: null, n: 7 }];
+        },
+        supports: { queryDateGranularity: { year: true } },
+      }) as never,
+    );
+    expect(problems.join('\n')).toMatch(/Field\.datetime 'at' @ year/);
+    expect(problems.join('\n')).toMatch(
+      /describe the same days but bucket differently/,
+    );
+  });
+
+  it('stays quiet on a driver that advertises nothing', async () => {
+    const problems = await checkDateBucketParity(
+      brokenDriver({ supports: { queryDateGranularity: {} } }) as never,
+    );
+    // Nothing advertised ⇒ the engine buckets everything in-memory ⇒ nothing to
+    // disagree about. A driver is never faulted for declining.
+    expect(problems).toEqual([]);
+  });
+});

--- a/packages/verify/src/date-bucket-parity.ts
+++ b/packages/verify/src/date-bucket-parity.ts
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Date-bucket parity conformance — a reusable, driver-agnostic check.
+ *
+ * A driver that advertises `supports.queryDateGranularity[g]` is telling
+ * `engine.aggregate` it may push `dateGranularity: g` down as SQL instead of
+ * fetching rows and bucketing them in JS. The two must then be
+ * interchangeable: **the same rows bucketed either way must carry the same
+ * labels.** They are not two features, they are one feature with two
+ * implementations, and the engine picks between them per query — a granularity
+ * the driver advertises goes down as SQL, one it does not goes to
+ * `applyInMemoryAggregation`, and a non-UTC timezone forces the in-memory path
+ * regardless. A dashboard can cross that seam mid-drill-down.
+ *
+ * This is the invariant #3773 broke and nothing caught. SQLite stores a
+ * `Field.datetime` as INTEGER epoch milliseconds; `strftime` read the bare
+ * integer as a Julian day number, so every row bucketed as NULL and a trend
+ * chart collapsed into one bar. The driver's own suites were green because
+ * their fixtures built tables with `knex.schema.createTable` + `t.string(...)`
+ * — ISO TEXT, the half `strftime` parses natively — and the engine never
+ * second-guesses a granularity a driver claims to support.
+ *
+ * The reference side imports the REAL `applyInMemoryAggregation`. Three test
+ * files carry a hand-copied `bucketDateValue` for self-containment (driver-sql
+ * cannot depend on objectql), and a hand copy that stops tracking its original
+ * is the failure mode those `⚠️ Keep in sync` comments cannot detect: the copy
+ * and the SQL agree with each other, and both are wrong. This check is the one
+ * place the two implementations meet for real.
+ *
+ * Like {@link checkReadCoercion}, it returns human-readable problems (empty =
+ * conformant) and carries NO test-runner dependency, so an out-of-tree driver —
+ * cloud's `driver-turso`, which is remote SQLite with the same epoch storage —
+ * runs the identical contract against itself.
+ */
+
+import { applyInMemoryAggregation } from '@objectstack/objectql';
+
+/** The minimal driver surface this check drives. */
+export interface BucketableDriver {
+  connect?(): Promise<void>;
+  disconnect?(): Promise<void>;
+  syncSchema(object: string, schema: unknown, options?: unknown): Promise<void>;
+  create(object: string, data: Record<string, unknown>, options?: unknown): Promise<unknown>;
+  find(object: string, query: unknown, options?: unknown): Promise<any[]>;
+  aggregate(object: string, query: unknown, options?: unknown): Promise<any[]>;
+  supports?: { queryDateGranularity?: Record<string, boolean> };
+}
+
+export interface DateBucketParityOptions {
+  /** Object/table name to create for the probe. Default `date_bucket_probe`. */
+  object?: string;
+  /** Extra options threaded to `create` (e.g. `{ bypassTenantAudit: true }`). */
+  createOptions?: unknown;
+}
+
+type Granularity = 'day' | 'week' | 'month' | 'quarter' | 'year';
+
+const GRANULARITIES: Granularity[] = ['day', 'week', 'month', 'quarter', 'year'];
+
+/**
+ * Both temporal storage forms under one probe: `at` is a `Field.datetime`
+ * (epoch-stored on SQLite), `on` is a `Field.date` (ISO TEXT everywhere). Each
+ * row's two columns name the same calendar day, so any granularity must label
+ * them identically — a divergence between the columns is a storage-form leak.
+ */
+const FIELDS = {
+  at: { type: 'datetime' },
+  on: { type: 'date' },
+  n: { type: 'number' },
+} as const;
+
+/**
+ * Instants chosen to straddle every boundary the labels encode: year, quarter,
+ * month, ISO week (2024-12-30 is 2025-W01), and midnight in both directions.
+ *
+ * Deliberately NO null instant. A NULL group key is a known, pre-existing
+ * divergence — SQL yields SQL NULL where the in-memory path yields the literal
+ * `'(null)'` — that is orthogonal to bucketing correctness and equally true of a
+ * TEXT column. Including it would make this check fail for a reason it is not
+ * about; it is called out here so its absence reads as a decision, not an
+ * oversight.
+ */
+const FIXTURE: ReadonlyArray<{ id: string; iso: string }> = [
+  { id: 'b1', iso: '2024-01-15T10:00:00.000Z' }, // 2024 / Q1 / Jan / W03
+  { id: 'b2', iso: '2024-06-30T23:59:59.000Z' }, // last instant of Q2
+  { id: 'b3', iso: '2024-07-01T00:00:00.000Z' }, // first instant of Q3
+  { id: 'b4', iso: '2024-12-30T12:00:00.000Z' }, // Dec 2024, but ISO week 2025-W01
+  { id: 'b5', iso: '2025-01-01T00:00:00.000Z' }, // exact midnight, year boundary
+  { id: 'b6', iso: '2025-05-19T09:00:00.000Z' },
+  { id: 'b7', iso: '2025-05-19T22:30:00.000Z' }, // same day bucket as b6
+];
+
+/** `{label: count}` from aggregate rows keyed by `field`. */
+function labelCounts(rows: any[], field: string): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const row of rows ?? []) {
+    out[String(row?.[field])] = Number(row?.n ?? 0);
+  }
+  return out;
+}
+
+function describeDiff(a: Record<string, number>, b: Record<string, number>): string {
+  const keys = [...new Set([...Object.keys(a), ...Object.keys(b)])].sort();
+  return keys
+    .filter((k) => a[k] !== b[k])
+    .map((k) => `${k}: sql=${a[k] ?? '—'} in-memory=${b[k] ?? '—'}`)
+    .join(', ');
+}
+
+/**
+ * For every granularity the driver ADVERTISES, bucket the probe both ways and
+ * report any disagreement. Empty array = conformant.
+ *
+ * A granularity the driver does not advertise is skipped rather than probed:
+ * the engine routes it to the in-memory path by definition, so whether the
+ * driver could also have done it is not part of this contract.
+ */
+export async function checkDateBucketParity(
+  driver: BucketableDriver,
+  opts: DateBucketParityOptions = {},
+): Promise<string[]> {
+  const object = opts.object ?? 'date_bucket_probe';
+  const problems: string[] = [];
+
+  await driver.connect?.();
+  try {
+    await driver.syncSchema(object, { name: object, fields: FIELDS });
+    for (const { id, iso } of FIXTURE) {
+      // A real `Date` for the datetime column — the shape every normal write
+      // takes, and the one that produces epoch storage on SQLite.
+      await driver.create(
+        object,
+        { id, at: new Date(iso), on: iso.slice(0, 10), n: 1 },
+        opts.createOptions,
+      );
+    }
+
+    // The rows the in-memory path would see: whatever `find()` presents. Using
+    // the driver's own read output (rather than the fixture) is deliberate —
+    // that IS what `engine.aggregate` feeds `applyInMemoryAggregation` when it
+    // falls back, so a driver whose read form disagrees with its bucket form is
+    // exactly what this should catch.
+    const rows = await driver.find(object, { object, where: { id: { $in: FIXTURE.map((f) => f.id) } } });
+    if (!Array.isArray(rows) || rows.length !== FIXTURE.length) {
+      problems.push(
+        `find returned ${Array.isArray(rows) ? `${rows.length} rows` : typeof rows}, expected ${FIXTURE.length} — cannot compare bucketing`,
+      );
+      return problems;
+    }
+
+    const caps = driver.supports?.queryDateGranularity ?? {};
+
+    for (const field of ['at', 'on'] as const) {
+      const storage = field === 'at' ? 'Field.datetime' : 'Field.date';
+      for (const granularity of GRANULARITIES) {
+        if (caps[granularity] !== true) continue; // engine routes this in-memory
+
+        const ast = {
+          object,
+          groupBy: [{ field, dateGranularity: granularity }],
+          aggregations: [{ function: 'count', alias: 'n' }],
+        };
+
+        let pushedDown: any[];
+        try {
+          pushedDown = await driver.aggregate(object, ast);
+        } catch (err) {
+          problems.push(
+            `${storage} '${field}' @ ${granularity}: driver advertises this granularity but aggregate() threw: ${(err as Error)?.message ?? err}`,
+          );
+          continue;
+        }
+
+        const sql = labelCounts(pushedDown, field);
+        const inMemory = labelCounts(applyInMemoryAggregation(rows, ast as never), field);
+
+        if (JSON.stringify(sql) !== JSON.stringify(inMemory)) {
+          problems.push(
+            `${storage} '${field}' @ ${granularity}: pushed-down SQL and in-memory bucketing disagree — ${describeDiff(sql, inMemory)}`,
+          );
+        }
+      }
+    }
+
+    // Both columns describe the same calendar days, so a granularity that
+    // labels them differently is a storage-form leak even when each side is
+    // internally consistent with its own in-memory reference.
+    for (const granularity of GRANULARITIES) {
+      if (caps[granularity] !== true) continue;
+      const mk = (field: 'at' | 'on') =>
+        driver.aggregate(object, {
+          object,
+          groupBy: [{ field, dateGranularity: granularity }],
+          aggregations: [{ function: 'count', alias: 'n' }],
+        });
+      try {
+        const [byAt, byOn] = await Promise.all([mk('at'), mk('on')]);
+        const a = labelCounts(byAt, 'at');
+        const b = labelCounts(byOn, 'on');
+        if (JSON.stringify(a) !== JSON.stringify(b)) {
+          problems.push(
+            `@ ${granularity}: the datetime and date columns describe the same days but bucket differently — ${describeDiff(a, b)}`,
+          );
+        }
+      } catch {
+        // Already reported by the per-column pass above.
+      }
+    }
+  } finally {
+    await driver.disconnect?.();
+  }
+
+  return problems;
+}

--- a/packages/verify/src/index.ts
+++ b/packages/verify/src/index.ts
@@ -29,3 +29,9 @@ export type { ConformanceRow, ConformanceState, CheckLedgerOptions } from './con
 // Driver-agnostic — any driver, including out-of-tree ones, runs the same check.
 export { checkReadCoercion } from './read-coercion.js';
 export type { CoercibleDriver, ReadCoercionOptions } from './read-coercion.js';
+
+// Date-bucket parity conformance: a granularity a driver ADVERTISES must bucket
+// identically whether the engine pushes it down as SQL or falls back to
+// `applyInMemoryAggregation`. The seam #3773 crossed silently.
+export { checkDateBucketParity } from './date-bucket-parity.js';
+export type { BucketableDriver, DateBucketParityOptions } from './date-bucket-parity.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1638,6 +1638,9 @@ importers:
       '@objectstack/driver-sql':
         specifier: workspace:*
         version: link:../../plugins/driver-sql
+      '@objectstack/driver-sqlite-wasm':
+        specifier: workspace:*
+        version: link:../../plugins/driver-sqlite-wasm
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1


### PR DESCRIPTION
#3773 / #3797 的收尾:**把那道没人守的接缝钉住**,不修任何现有 bug。

## 先纠正我自己的提法

我原先说要加「文本一致性门」—— 假设三份 `bucketDateValue` 手抄件是逐字复制。**查了,不是。** 副本彼此逐字相同,但和 objectql 原版根本不同:原版带 `timezone` 参数、走 `calendarPartsInTzOrUtc`,副本是 UTC-only 内联版。文本门对着源头开箱就假阳性。

而真正的风险方向也不是"副本乱改":副本改坏了,驱动测试会**红**(SQL 对不上改坏的副本)。危险的是**改了 objectql 原版、副本没跟** —— 此时副本和 SQL 彼此自洽、双双是旧的,**全绿**。注释治不了这个,只有行为门能。

## 门是什么

`checkDateBucketParity(driver)`(`@objectstack/verify`):对驱动**声明支持**的每个粒度,拿它下推的 SQL 结果去比**真的** `applyInMemoryAggregation` 跑它自己 `find()` 行的结果。

契约的措辞很重要:驱动 `supports.queryDateGranularity[g]` 是在告诉 `engine.aggregate`「这个粒度可以下推」。于是它俩就**不是两个特性,是一个特性的两份实现**,引擎按查询逐次挑一份 —— 声明了的走 SQL,没声明的走内存,非 UTC 时区一律走内存。仪表盘的一次 drill-down 就能跨过这条缝。

- 两种存储形态在**同一个 probe 对象**下:`Field.datetime` 和 `Field.date` 指同一批日历日,于是"存储形态泄漏"会表现为**两列分桶不一致**,即使各自和自己的内存参考都自洽。
- 驱动**没声明**的粒度直接跳过,不追究 —— 引擎本来就把它路由到内存,驱动能不能做不属于这个契约。

形状照抄 `checkReadCoercion`:返回人类可读的 problems(空 = 合规)、不依赖 test runner、结构化接受任意驱动 —— 所以 **cloud 的 `driver-turso` 能拿去跑同一份契约**。这条最重要:Turso 是远程 SQLite,正是这次出事的那种 epoch 存储。

## 验红:拿真回归验,不是只拿假驱动

把 #3773 的修复退回去重跑,门在**两个驱动上都红**,诊断直接点名塌掉的桶:

```
Field.datetime 'at' @ month: pushed-down SQL and in-memory bucketing disagree
  — 2024-01: sql=— in-memory=1, …, null: sql=7 in-memory=—
```

跨列那道也同时开火(8 条 = 4 粒度 × 2 驱动),而 per-column 那道**只**点名 `'at'`,从没误伤 TEXT 存储的 `'on'`。恢复后全绿,`git diff` 对驱动源码为空。

另配 4 条反向对照钉住 checker 的能力边界:全塌成 null(#3773 原形)、声明了却抛错、一列对一列塌(存储形态泄漏)、**什么都不声明必须保持沉默**。

## 注释改了两处,分工写清楚

三份手抄件的 `⚠️ Keep in sync` 现在明说**它自己检测不了漂移**(副本和 SQL 会彼此自洽地一起错),并指向可执行的门。同样的指针也加在 `bucketDateValue` 本体上 —— **那才是漂移的起点**,改的人在那儿。

## 一处刻意不覆盖

fixture 里**没有** null 实例。NULL 分桶键是既有分歧(SQL 给 SQL NULL,内存给字面量 `'(null)'`),与分桶正确性正交、在 TEXT 列上同样成立。放进来会让门为一个它不负责的理由而红。这一点写在 fixture 注释里,好让"没有 null"读起来像决定而不是疏忽。

## 测试

新门 6 条 ✅(2 真驱动 + 4 反向对照);driver-sql 401 ✅ / objectql 1128 ✅ / sqlite-wasm 126 ✅ / verify 7 ✅;`turbo build --force`(绕缓存跑真 DTS)通过;eslint 干净。

dogfood 全量跑有 **2 条既有红**:`attachments-permission-matrix` 的两条 `AUTH_REQUIRED`。已用 `git stash` 隔离到**纯净 origin/main 上同样红**,与本 PR 无关(本分支基点 9e4bad509 正是改那个附件 harness 的提交)。
