### PR TITLE
fix(rest): route batch creates through the create ingress so `readonly` is enforced (#3835)

### DIFF
--- a/.changeset/approval-lock-and-batch-write-observability.md
+++ b/.changeset/approval-lock-and-batch-write-observability.md
@@ -1,0 +1,40 @@
+---
+"@objectstack/plugin-approvals": minor
+"@objectstack/spec": minor
+"@objectstack/rest": minor
+---
+
+fix(approvals,rest): tell the truth about what a write did — `locks_record` on the request, `droppedFields` on the cross-object batch (#3794)
+
+Two halves of the same complaint: in an approval flow the platform reported
+record writability wrong in *both* directions — what you could change said
+"locked", and what you couldn't said "updated successfully".
+
+**`locks_record` on the approval request.** The lock hook reads one thing to
+decide whether a pending approval blocks writes: the node config snapshot's
+`lockRecord` (`=== false` ⇒ the update goes through). Nothing exposed that, so a
+client had only "a pending request exists" and had to guess — and the Console
+guessed "locked", every time. A `lockRecord: false` node exists precisely so the
+approver can amend the record while deciding on it; painting "Locked for
+approval" over that hides the whole feature, and approvers never try. Request
+rows (`getRequest` / `listRequests`, and therefore `GET /api/v1/approvals/requests`)
+now carry `locks_record`, read from the same snapshot the hook reads, with the
+same default-true. Absent on rows from an older server ⇒ assume locked.
+
+**`droppedFields` on `POST /batch`.** The engine strips writes to `readonly`
+(#2948) and `readonlyWhen`-locked (#3042) fields and completes the write without
+them. Every write path already reported which fields it dropped (#3431/#3455) —
+except the cross-object transactional batch, which never wired
+`onFieldsDropped` at all. That path is the Console record form's save for a
+master-detail record, so it is exactly where a *user* edits a `readonlyWhen`
+field: they changed it, the form said "updated successfully", the value never
+moved, and nothing anywhere said so. The response now carries a top-level
+`droppedFields` list, each event tagged with the `index` of the operation that
+produced it (`results` entries are bare record echoes with no envelope to hang a
+per-row list on). Omitted entirely when nothing was dropped, so the shape stays
+backward-compatible; the batch still commits either way — a strip is legal
+semantics, not an error.
+
+The Console half of both fixes ships in objectui: the detail band now
+distinguishes "in approval (editable)" from "locked for approval", and the
+write-warning toast fires on batch saves.

--- a/.changeset/batch-create-readonly-ingress.md
+++ b/.changeset/batch-create-readonly-ingress.md
@@ -1,0 +1,39 @@
+---
+"@objectstack/rest": minor
+---
+
+fix(rest): a batch create goes through the same create ingress as a single create (#3835)
+
+`readonly` meant two different things depending on which create endpoint you
+used. `POST /data/:object` runs the #3043 ingress strip, so a non-system caller
+cannot seed a read-only column — the field is dropped and reported. The
+cross-object transactional batch (`POST /batch`) called `ql.insert` directly and
+skipped that ingress entirely, and the engine's INSERT path is
+static-`readonly`-exempt **by design** (#3413, the strip lives one layer up), so
+nothing enforced it: the same forged `readonly` value that was rejected on one
+route was written through on the other.
+
+Measured on the showcase (`showcase_contact.lead_score`, `readonly: true`, same
+signed-in non-system user):
+
+| | before | after |
+|---|---|---|
+| `POST /data/showcase_contact` | `lead_score = null`, reported | unchanged |
+| `POST /batch` create | **`lead_score = 999` written, silent** | `null`, reported |
+
+The fix routes the batch's create ops through the protocol's `createData` rather
+than re-implementing the strip at the REST layer. That keeps **one** create
+ingress: a future change to its policy covers the batch for free, and the
+carve-outs already encoded there stay intact — notably the platform-object
+exemption (a `sys_`/`managedBy` object's own guard must *reject* a forged value
+with 403, not have it silently swallowed) and the `isSystem` exemption. The
+context passed through is the transaction context, so the insert still joins the
+batch transaction and rolls back with it, and `{ $ref: <opIndex> }` resolution is
+unaffected.
+
+`createData`'s `droppedFields` are folded into the batch response's per-op
+`droppedFields` list (#3794), so a batch create now reports its strips the same
+way an update does.
+
+Update ops are untouched: the engine enforces `readonly` and `readonlyWhen` on
+its own update path.

--- a/content/docs/references/api/batch.mdx
+++ b/content/docs/references/api/batch.mdx
@@ -30,8 +30,8 @@ Industry alignment: Salesforce Bulk API, Microsoft Dynamics Bulk Operations
 ## TypeScript Usage
 
 ```typescript
-import { BatchConfig, BatchOperationResult, BatchOperationType, BatchOptions, BatchRecord, BatchUpdateRequest, BatchUpdateResponse, CrossObjectBatchOperation, CrossObjectBatchRequest, CrossObjectBatchResponse, DeleteManyRequest, UpdateManyRequest } from '@objectstack/spec/api';
-import type { BatchConfig, BatchOperationResult, BatchOperationType, BatchOptions, BatchRecord, BatchUpdateRequest, BatchUpdateResponse, CrossObjectBatchOperation, CrossObjectBatchRequest, CrossObjectBatchResponse, DeleteManyRequest, UpdateManyRequest } from '@objectstack/spec/api';
+import { BatchConfig, BatchOperationResult, BatchOperationType, BatchOptions, BatchRecord, BatchUpdateRequest, BatchUpdateResponse, CrossObjectBatchDroppedFields, CrossObjectBatchOperation, CrossObjectBatchRequest, CrossObjectBatchResponse, DeleteManyRequest, UpdateManyRequest } from '@objectstack/spec/api';
+import type { BatchConfig, BatchOperationResult, BatchOperationType, BatchOptions, BatchRecord, BatchUpdateRequest, BatchUpdateResponse, CrossObjectBatchDroppedFields, CrossObjectBatchOperation, CrossObjectBatchRequest, CrossObjectBatchResponse, DeleteManyRequest, UpdateManyRequest } from '@objectstack/spec/api';
 
 // Validate data
 const result = BatchConfig.parse(data);
@@ -138,6 +138,22 @@ const result = BatchConfig.parse(data);
 
 ---
 
+## CrossObjectBatchDroppedFields
+
+A cross-object batch strip event: dropped fields plus the operation index
+
+### Properties
+
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| **object** | `string` | ✅ | Object the write targeted (resolved object name) |
+| **fields** | `string[]` | ✅ | Caller-supplied field names the engine removed from the write payload |
+| **reason** | `Enum<'readonly' \| 'readonly_when'>` | ✅ | Why the fields were dropped: static readonly (#2948) or a TRUE readonlyWhen predicate (#3042) |
+| **index** | `integer` | ✅ | Index of the operation in the request `operations` array |
+
+
+---
+
 ## CrossObjectBatchOperation
 
 ### Properties
@@ -171,6 +187,7 @@ const result = BatchConfig.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **results** | `any[]` | ✅ | Per-operation result, index-aligned with the request operations |
+| **droppedFields** | `{ object: string; fields: string[]; reason: Enum<'readonly' \| 'readonly_when'>; index: integer }[]` | optional | Write-observability (#3407/#3431/#3455/#3794): caller-supplied fields the engine LEGALLY stripped from an operation before it was written — static `readonly` (#2948) or a TRUE `readonlyWhen` predicate (#3042). This endpoint is the console record form's save path (master-detail writes parent + children in one transaction), so without it the ONE surface where a user edits a `readonlyWhen` field reported plain success while the value never landed. Each event carries the `index` of its operation. Present ONLY when ≥1 field was dropped; the batch still committed without them (results/success semantics unchanged). Optional — omit-when-empty keeps the shape backward-compatible. |
 
 
 ---

--- a/packages/plugins/plugin-approvals/src/approval-service.test.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.test.ts
@@ -183,6 +183,38 @@ describe('ApprovalService (node era)', () => {
     expect(JSON.parse(raw.node_config_json)).toMatchObject({ behavior: 'first_response', lockRecord: true });
   });
 
+  // #3794 — the row tells a client whether THIS node locks the record, so
+  // "pending" and "locked" stop being the same signal. Read from the same
+  // snapshot key the `beforeUpdate` lock hook reads, with the same default.
+  it('rows surface locks_record from the node config (default true)', async () => {
+    const req = await svc.openNodeRequest(openInput(['u9']), CTX);
+    expect(req.locks_record).toBe(true);
+    const [listed] = await svc.listRequests({ status: 'pending' }, SYS);
+    expect(listed.locks_record).toBe(true);
+  });
+
+  it('rows surface locks_record=false for a lockRecord:false node', async () => {
+    const req = await svc.openNodeRequest(
+      openInput(['u9'], {}, { lockRecord: false }),
+      CTX,
+    );
+    expect(req.locks_record).toBe(false);
+    const [listed] = await svc.listRequests({ status: 'pending' }, SYS);
+    expect(listed.locks_record).toBe(false);
+    const fetched = await svc.getRequest(req.id, SYS);
+    expect(fetched?.locks_record).toBe(false);
+  });
+
+  it('locks_record defaults to true when the node config omits lockRecord', async () => {
+    // A node that says nothing about locking locks — matching the hook, which
+    // only returns early on an explicit `lockRecord === false`.
+    const req = await svc.openNodeRequest(
+      openInput(['u9'], {}, { lockRecord: undefined }),
+      CTX,
+    );
+    expect(req.locks_record).toBe(true);
+  });
+
   it('openNodeRequest: deduplicates a pending request per (object, record)', async () => {
     await svc.openNodeRequest(openInput(['u9']), CTX);
     await expect(svc.openNodeRequest(openInput(['u9'], { runId: 'run_2' }), CTX))

--- a/packages/plugins/plugin-approvals/src/approval-service.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.ts
@@ -280,6 +280,11 @@ function rowFromRequest(row: any): ApprovalRequestRow {
     payload: parseJson(row.payload_json, undefined),
     flow_run_id: row.flow_run_id ?? undefined,
     flow_node_id: row.flow_node_id ?? undefined,
+    // #3794: the node's record-lock policy, read from the SAME config snapshot
+    // the `beforeUpdate` lock hook reads (`lockRecord === false` ⇒ allow), so a
+    // client can tell "pending" from "locked" instead of assuming every pending
+    // request locks. Default-true mirrors the hook's default.
+    locks_record: cfg?.lockRecord !== false,
     completed_at: row.completed_at ?? undefined,
     created_at: row.created_at ?? undefined,
     updated_at: row.updated_at ?? undefined,

--- a/packages/rest/src/rest-batch-endpoint.test.ts
+++ b/packages/rest/src/rest-batch-endpoint.test.ts
@@ -219,6 +219,45 @@ describe('POST {basePath}/batch — cross-object transactional batch', () => {
     expect(ql.transaction).not.toHaveBeenCalled();
   });
 
+  // ── write observability (#3794) ───────────────────────────────────────────
+  //
+  // The console's record form saves a master-detail record through THIS route,
+  // so a `readonlyWhen`-locked field edited in that form was stripped by the
+  // engine and the response said nothing — the user saw "updated successfully"
+  // over a value that never changed. Every other write path already reports its
+  // strips (#3431/#3455); this one now does too.
+
+  it('surfaces engine-stripped fields as droppedFields tagged with the op index', async () => {
+    const ql = makeQl({
+      update: vi.fn(async (_object: string, data: any, opts: any) => {
+        opts?.onFieldsDropped?.({ object: 'invoice', fields: ['tax_rate'], reason: 'readonly_when' });
+        const { tax_rate: _stripped, ...kept } = data;
+        return kept;
+      }),
+    });
+    const { route } = buildServer({ ql });
+    const res = await post(route, {
+      operations: [
+        { object: 'account', action: 'create', data: { name: 'Acme' } },
+        { object: 'invoice', action: 'update', id: 'inv_1', data: { status: 'paid', tax_rate: 9 } },
+      ],
+    });
+    expect(res.statusCode).toBe(200);
+    // The batch still committed — a strip is legal semantics, not an error.
+    expect(res.body.results).toHaveLength(2);
+    expect(res.body.droppedFields).toEqual([
+      { object: 'invoice', fields: ['tax_rate'], reason: 'readonly_when', index: 1 },
+    ]);
+  });
+
+  it('omits droppedFields entirely when nothing was stripped', async () => {
+    const ql = makeQl();
+    const { route } = buildServer({ ql });
+    const res = await post(route, { operations: [{ object: 'account', data: { name: 'Acme' } }] });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).not.toHaveProperty('droppedFields');
+  });
+
   // ── request validation ────────────────────────────────────────────────────
 
   it('rejects a non-atomic request (this endpoint is always atomic)', async () => {

--- a/packages/rest/src/rest-batch-endpoint.test.ts
+++ b/packages/rest/src/rest-batch-endpoint.test.ts
@@ -42,13 +42,42 @@ function makeQl(overrides: Partial<Record<'insert' | 'update' | 'delete', any>> 
   return ql;
 }
 
+/**
+ * A fake `createData` standing in for the protocol's create ingress (#3835):
+ * the batch's create ops go through it rather than calling `ql.insert`, so the
+ * #3043 static-`readonly` strip applies to a batch create exactly as it does to
+ * `POST /data/:object`. Delegates to the same `ql.insert` the other ops use, so
+ * assertions about what reached the engine still read off `ql.insert`.
+ */
+function makeCreateData(ql: any, opts: { readonlyFields?: string[] } = {}) {
+  const readonlyFields = opts.readonlyFields ?? [];
+  return vi.fn(async (request: any) => {
+    const supplied = request?.data ?? {};
+    const stripped: string[] = readonlyFields.filter((f) => f in supplied);
+    const data = { ...supplied };
+    for (const f of stripped) delete data[f];
+    const record = await ql.insert(request.object, data, { context: request.context });
+    return {
+      object: request.object,
+      id: record?.id,
+      record,
+      ...(stripped.length > 0
+        ? { droppedFields: [{ object: request.object, fields: stripped, reason: 'readonly' }] }
+        : {}),
+    };
+  });
+}
+
 /** Build a RestServer with an optional ObjectQL provider and object metadata. */
-function buildServer(opts: { ql?: any; objects?: any[] } = {}) {
+function buildServer(opts: { ql?: any; objects?: any[]; readonlyFields?: string[] } = {}) {
   const server = mockServer();
   const protocol: any = {
     getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: {} }),
     getMetaTypes: vi.fn().mockResolvedValue([]),
     getMetaItems: vi.fn().mockResolvedValue(opts.objects ?? []),
+    createData: opts.ql
+      ? makeCreateData(opts.ql, { readonlyFields: opts.readonlyFields ?? [] })
+      : vi.fn(),
   };
   const objectQLProvider = opts.ql ? async () => opts.ql : undefined;
   const rest = new RestServer(
@@ -256,6 +285,64 @@ describe('POST {basePath}/batch — cross-object transactional batch', () => {
     const res = await post(route, { operations: [{ object: 'account', data: { name: 'Acme' } }] });
     expect(res.statusCode).toBe(200);
     expect(res.body).not.toHaveProperty('droppedFields');
+  });
+
+  // ── create ingress parity (#3835) ─────────────────────────────────────────
+  //
+  // The engine's INSERT path is static-`readonly`-exempt by design (#3413), so
+  // the #3043 strip that stops a non-system caller from seeding a read-only
+  // column lives at the protocol's create ingress. This route used to call
+  // `ql.insert` directly and skip it, so `readonly` meant two different things
+  // depending on which create endpoint you used.
+
+  it('routes create ops through the protocol create ingress, not ql.insert', async () => {
+    const ql = makeQl();
+    const { route, protocol } = buildServer({ ql });
+    const res = await post(route, {
+      operations: [{ object: 'account', action: 'create', data: { name: 'Acme' } }],
+    });
+    expect(res.statusCode).toBe(200);
+    expect(protocol.createData).toHaveBeenCalledTimes(1);
+    const request = protocol.createData.mock.calls[0][0];
+    expect(request).toMatchObject({ object: 'account', data: { name: 'Acme' } });
+    // The ingress must run INSIDE this transaction — same context the other ops
+    // bind, or the create would commit independently of the rollback.
+    expect(request.context).toMatchObject({ __trx: true });
+  });
+
+  it('strips a caller-forged readonly column on a batch create and reports it', async () => {
+    const ql = makeQl();
+    const { route } = buildServer({ ql, readonlyFields: ['approval_status'] });
+    const res = await post(route, {
+      operations: [
+        { object: 'account', action: 'create', data: { name: 'Acme', approval_status: 'approved' } },
+      ],
+    });
+    expect(res.statusCode).toBe(200);
+    // Never reached the engine…
+    expect(ql.insert).toHaveBeenCalledWith('account', { name: 'Acme' }, expect.anything());
+    // …and the caller is told, tagged with the op that dropped it.
+    expect(res.body.droppedFields).toEqual([
+      { object: 'account', fields: ['approval_status'], reason: 'readonly', index: 0 },
+    ]);
+  });
+
+  it('keeps $ref resolution working through the ingress', async () => {
+    // `results` now holds the ingress's echoed record rather than the raw
+    // engine return — a later op must still resolve `{ $ref: 0 }` to its id.
+    const ql = makeQl();
+    const { route } = buildServer({ ql });
+    const res = await post(route, {
+      operations: [
+        { object: 'project', action: 'create', data: { name: 'Apollo' } },
+        { object: 'task', action: 'create', data: { title: 'Kickoff', project: { $ref: 0 } } },
+      ],
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.results[0].id).toBe('id_1');
+    expect(ql.insert).toHaveBeenLastCalledWith(
+      'task', { title: 'Kickoff', project: 'id_1' }, expect.anything(),
+    );
   });
 
   // ── request validation ────────────────────────────────────────────────────

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -6594,15 +6594,27 @@ export class RestServer {
                         return result;
                     };
 
+                    // [#3794] Write-observability on THIS surface too. The engine
+                    // strips `readonly` / `readonlyWhen` writes silently, and every
+                    // other write path already reports what it dropped (#3431/#3455)
+                    // — but this one did not, and it is precisely the path the
+                    // console's record form takes for a master-detail save. Result:
+                    // a user edited a `readonlyWhen`-locked field, got "updated
+                    // successfully", and the value never changed with nothing said
+                    // (#3794 problem 2). Each event is tagged with its operation
+                    // index, since `results` entries are bare record echoes with no
+                    // envelope to hang a per-row list on.
+                    const dropped: Array<DroppedFieldsEvent & { index: number }> = [];
                     const results = await ql.transaction(async (trxCtx: any) => {
                         const out: any[] = [];
-                        for (const op of ops) {
+                        for (const [index, op] of ops.entries()) {
                             const data = resolveRefs(op.data, out);
+                            const onFieldsDropped = (e: DroppedFieldsEvent) => { dropped.push({ ...e, index }); };
                             if (op.action === 'create') {
-                                out.push(await ql.insert(op.object, data, { context: trxCtx }));
+                                out.push(await ql.insert(op.object, data, { context: trxCtx, onFieldsDropped }));
                             } else if (op.action === 'update') {
                                 const id = op.id ?? data?.id;
-                                out.push(await ql.update(op.object, { ...data, id }, { context: trxCtx }));
+                                out.push(await ql.update(op.object, { ...data, id }, { context: trxCtx, onFieldsDropped }));
                             } else { // 'delete'
                                 out.push(await ql.delete(op.object, { where: { id: op.id }, context: trxCtx }));
                             }
@@ -6610,7 +6622,7 @@ export class RestServer {
                         return out;
                     }, context);
 
-                    res.json({ results });
+                    res.json({ results, ...(dropped.length > 0 ? { droppedFields: dropped } : {}) });
                 } catch (error: any) {
                     // Log only genuine server faults; client 4xx (validation,
                     // unresolved ref, atomic rollback of a bad op) are expected.

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -6609,10 +6609,36 @@ export class RestServer {
                         const out: any[] = [];
                         for (const [index, op] of ops.entries()) {
                             const data = resolveRefs(op.data, out);
-                            const onFieldsDropped = (e: DroppedFieldsEvent) => { dropped.push({ ...e, index }); };
                             if (op.action === 'create') {
-                                out.push(await ql.insert(op.object, data, { context: trxCtx, onFieldsDropped }));
+                                // [#3835] Go through the protocol's create ingress —
+                                // the SAME one `POST /data/:object` uses — rather than
+                                // calling `ql.insert` directly. The engine's INSERT path
+                                // is static-`readonly`-exempt by design (#3413), so the
+                                // #3043 strip that stops a non-system caller from seeding
+                                // a read-only column lives at that ingress. Bypassing it
+                                // here made `readonly` mean two different things on two
+                                // create paths: rejected on the single route, written
+                                // through the batch. `createData` also owns the platform-
+                                // object carve-out (a `sys_`/`managedBy` object's own
+                                // guard must REJECT a forged value, not silently swallow
+                                // it), which is why this routes to the ingress instead of
+                                // re-implementing the strip here — one create ingress,
+                                // and a future change to its policy covers the batch for
+                                // free. `trxCtx` carries the caller's context (including
+                                // `isSystem`) plus the open transaction, so the strip
+                                // decides exactly as it does on the single route and the
+                                // insert still joins this transaction.
+                                const created: any = await p.createData({ object: op.object, data, context: trxCtx } as any);
+                                for (const e of (created?.droppedFields ?? []) as DroppedFieldsEvent[]) {
+                                    dropped.push({ ...e, index });
+                                }
+                                out.push(created?.record);
                             } else if (op.action === 'update') {
+                                // Update needs no ingress detour: the engine enforces
+                                // both static `readonly` (#2948) and `readonlyWhen`
+                                // (#3042) on its own update path, and reports them
+                                // through this listener.
+                                const onFieldsDropped = (e: DroppedFieldsEvent) => { dropped.push({ ...e, index }); };
                                 const id = op.id ?? data?.id;
                                 out.push(await ql.update(op.object, { ...data, id }, { context: trxCtx, onFieldsDropped }));
                             } else { // 'delete'

--- a/packages/spec/json-schema.manifest.json
+++ b/packages/spec/json-schema.manifest.json
@@ -152,6 +152,7 @@
     "api/CreateRequest",
     "api/CreateViewRequest",
     "api/CreateViewResponse",
+    "api/CrossObjectBatchDroppedFields",
     "api/CrossObjectBatchOperation",
     "api/CrossObjectBatchRequest",
     "api/CrossObjectBatchResponse",

--- a/packages/spec/src/api/batch.zod.ts
+++ b/packages/spec/src/api/batch.zod.ts
@@ -299,12 +299,36 @@ export const CrossObjectBatchRequestSchema = lazySchema(() => z.object({
 export type CrossObjectBatchRequest = z.input<typeof CrossObjectBatchRequestSchema>;
 
 /**
+ * One strip event on a cross-object batch, tagged with the operation it
+ * belongs to (#3794). The per-object bulk paths hang `droppedFields` on their
+ * per-row result object; this batch's `results` entries are the raw record
+ * echoes (`z.unknown()`), with no envelope to hang anything on — so the events
+ * ride a parallel top-level list and carry `index` to point back at the
+ * operation that produced them.
+ */
+export const CrossObjectBatchDroppedFieldsSchema = lazySchema(() => DroppedFieldsEventSchema.extend({
+  index: z.number().int().min(0).describe('Index of the operation in the request `operations` array'),
+}).describe('A cross-object batch strip event: dropped fields plus the operation index'));
+
+export type CrossObjectBatchDroppedFields = z.infer<typeof CrossObjectBatchDroppedFieldsSchema>;
+
+/**
  * Response for the cross-object transactional batch — one result per operation,
  * index-aligned with the request `operations` (create/update echo the record,
  * delete echoes the driver's delete result).
  */
 export const CrossObjectBatchResponseSchema = lazySchema(() => z.object({
   results: z.array(z.unknown()).describe('Per-operation result, index-aligned with the request operations'),
+  droppedFields: z.array(CrossObjectBatchDroppedFieldsSchema).optional().describe(
+    'Write-observability (#3407/#3431/#3455/#3794): caller-supplied fields the engine LEGALLY ' +
+    'stripped from an operation before it was written — static `readonly` (#2948) or a TRUE ' +
+    '`readonlyWhen` predicate (#3042). This endpoint is the console record form\'s save path ' +
+    '(master-detail writes parent + children in one transaction), so without it the ONE surface ' +
+    'where a user edits a `readonlyWhen` field reported plain success while the value never ' +
+    'landed. Each event carries the `index` of its operation. Present ONLY when ≥1 field was ' +
+    'dropped; the batch still committed without them (results/success semantics unchanged). ' +
+    'Optional — omit-when-empty keeps the shape backward-compatible.'
+  ),
 }));
 
 export type CrossObjectBatchResponse = z.infer<typeof CrossObjectBatchResponseSchema>;

--- a/packages/spec/src/contracts/approval-service.ts
+++ b/packages/spec/src/contracts/approval-service.ts
@@ -70,6 +70,27 @@ export interface ApprovalRequestRow {
     type?: 'text' | 'user' | 'department' | 'position' | 'team';
     multiple?: boolean;
   }>;
+  /**
+   * Whether THIS request's node locks the target record for writes (#3794).
+   * Mirrors the one policy the `beforeUpdate` lock hook actually enforces:
+   * the node config snapshot's `lockRecord`, defaulting to `true` when the
+   * node says nothing (`lockRecord === false` ⇒ the hook returns early and
+   * the record stays editable while the request is pending).
+   *
+   * Surfaced because "a pending request exists" and "the record is locked"
+   * are NOT the same statement, and a client that conflates them tells the
+   * user the opposite of the truth in one direction or the other: a console
+   * that renders "Locked for approval" on every pending request hides a
+   * `lockRecord: false` node's whole point (the approver is meant to edit
+   * while deciding), and one that renders nothing lets a user fill a form
+   * that the hook will reject with `RECORD_LOCKED`. Read it instead of
+   * re-deriving from the record's `approval_status` mirror — that field says
+   * "in approval", never "locked", and some flows never materialize it.
+   *
+   * Optional only for version skew (a row from an older server has no
+   * opinion); the service always emits it. Absent ⇒ assume locked.
+   */
+  locks_record?: boolean;
   completed_at?: string;
   created_at?: string;
   updated_at?: string;


### PR DESCRIPTION
Closes #3835.

> **Stacked on #3834** — it touches the same `/batch` handler block and this branch is cut from it, so the diff shows both until #3834 lands. Merge #3834 first; I'll rebase this to a single commit.

## `readonly` meant two different things depending on which create endpoint you used

`POST /data/:object` runs the #3043 ingress strip, so a non-system caller cannot seed a read-only column — the field is dropped and reported. The cross-object transactional batch called `ql.insert` directly and skipped that ingress, and the engine's INSERT path is static-`readonly`-exempt **by design** (#3413 — the strip deliberately lives one layer up). So nothing enforced it on that route.

Measured on the showcase, `showcase_contact.lead_score` (`readonly: true`), same signed-in non-system user, identical payload:

| | before | after |
|---|---|---|
| `POST /data/showcase_contact` | `lead_score = null`, `droppedFields` reported | unchanged |
| `POST /batch` (`action: 'create'`) | **`lead_score = 999` written, nothing said** | `null`, `droppedFields` reported |

## Why route to the ingress instead of re-applying the strip here

Reading `stripReadonlyForInsert` turned up a **deliberate scope carve-out** that a second copy would have lost: platform objects (`sys_` / `managedBy`) are exempt on purpose, because their own guards must **reject** a forged value with 403 (ADR-0086's `managed_by`/`package_id`, #3004's `owner_id` anchor) — silently swallowing it would eat the very payload the guard exists to refuse. `isSystem` is exempt for the same class of reason.

That rules out the "sink the strip into the engine" option I floated in the issue: the engine has no notion of that boundary. So the batch's create ops now go through `p.createData` — the ingress itself. One create ingress, and a future change to its policy covers the batch for free (AGENTS.md PD #12: fix the producer, don't grow a second de-facto contract).

Mechanics that had to keep working, and do:

- **Transaction** — `trxCtx` is passed as the context, so the insert joins this batch's transaction and rolls back with it (asserted in a test: the ingress receives the trx context, not a bare one).
- **`{ $ref: <opIndex> }`** — `results` now holds the ingress's echoed record instead of the raw engine return; `$ref` resolves off `.id` either way. Verified live: an invoice + line batch produced a line whose `invoice` points at the invoice created in the same request.
- **`droppedFields`** — the ingress's events fold into the batch's per-op list (#3794), so a batch create reports strips the way an update does.

Update ops are untouched — the engine enforces `readonly` (#2948) and `readonlyWhen` (#3042) on its own update path.

## Tests

3 new in `rest-batch-endpoint.test.ts`: create ops go through the ingress with the transaction context; a forged `readonly` column never reaches the engine and comes back in `droppedFields` tagged with its op index; `$ref` still resolves through the ingress. The harness's protocol mock gained a `createData` that delegates to the same `ql.insert`, so existing assertions still read off `ql.insert`.

`rest`: 413 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)