### PR TITLE
fix(docs): `FieldSchema.extend()` does not exist — the FAQ recommended a call that throws

### DIFF
--- a/.changeset/docs-fieldschema-extend-rot.md
+++ b/.changeset/docs-fieldschema-extend-rot.md
@@ -20,10 +20,21 @@ time, which makes it a **`ZodPipe`, not a `ZodObject`** — `.extend` is `undefi
 on it (verified against the built package). Anyone following the FAQ got a
 `not a function` throw. The example also used `z` without importing it.
 
-Rewritten to `FieldSchema.in.extend({ … })` — `.in` is the input object the pipe
-wraps — verified to parse, and marked so the gate holds it. It also now names why
-(the same applies to `ObjectSchema` / `ActionSchema`) and warns that the extended
-schema no longer runs the transform.
+Rewritten to **compose** — parse with `FieldSchema`, validate your additions
+alongside it — verified to both type-check and run. `.in.extend()` is mentioned in
+prose as the merged-schema route, with the caveat that it skips the transform.
+
+**A divergence worth knowing about, found while fixing this.** The first fix used
+`FieldSchema.in.extend(…)` in the checked block. It passed locally and failed in
+CI with `Property 'in' does not exist on type 'ZodObject<…>'` — the two builds
+emit **different declarations for the same source**: locally
+`z.ZodPipe<z.ZodObject<…>>`, in CI a plain `z.ZodObject`. The runtime is
+unambiguous (`bound ZodPipe`, `.extend === undefined`, verified after a clean
+`rm -rf dist && pnpm build`), so **CI's declaration contradicts the value it
+describes** — `.extend()` type-checks there and throws at runtime. Probably
+inference instability in the DTS bundling of these very large zod types; worth its
+own investigation. The example now uses only `.parse()`, so it is correct under
+either declaration and the doc is not hostage to which one you get.
 
 **The sweep's method is recorded in the gate's docstring**, because two traps make
 a naive pass report a confident "nothing found":

--- a/.changeset/docs-fieldschema-extend-rot.md
+++ b/.changeset/docs-fieldschema-extend-rot.md
@@ -1,0 +1,43 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(docs): `FieldSchema.extend()` does not exist — the FAQ was recommending a call that throws
+
+#3882 brought `content/docs` under the example type-check gate and left an open
+question: of the blocks still unmarked, is any of it **genuine rot** rather than a
+fragment? Swept them. One real one:
+
+`content/docs/deployment/troubleshooting.mdx` answered *"How do I extend a
+built-in schema?"* with
+
+```ts
+const CustomFieldSchema = FieldSchema.extend({ … });   // TypeError
+```
+
+`FieldSchema` carries a `.transform()` that lowers author-facing sugar at parse
+time, which makes it a **`ZodPipe`, not a `ZodObject`** — `.extend` is `undefined`
+on it (verified against the built package). Anyone following the FAQ got a
+`not a function` throw. The example also used `z` without importing it.
+
+Rewritten to `FieldSchema.in.extend({ … })` — `.in` is the input object the pipe
+wraps — verified to parse, and marked so the gate holds it. It also now names why
+(the same applies to `ObjectSchema` / `ActionSchema`) and warns that the extended
+schema no longer runs the transform.
+
+**The sweep's method is recorded in the gate's docstring**, because two traps make
+a naive pass report a confident "nothing found":
+
+1. **`tsc` stops after syntactic diagnostics** — it never reaches the semantic
+   pass. Marking all 780 blocks at once let ~200 broken fragments suppress
+   type-checking for every other block; the run came back with only TS1xxx codes,
+   which reads exactly like "no rot" and proves nothing. Verified by injecting a
+   deliberate type error and watching it go unreported.
+2. **Unimported type names resolve against the DOM lib.** `Plugin`, `Event`,
+   `Response`, `Storage` all exist there, so a block missing its import reports
+   *"'version' does not exist in type 'Plugin'"* against `lib.dom`'s `Plugin` —
+   an artefact, not drift. Three of the strongest-looking candidates were this.
+
+After both corrections the remaining blocks are fragments, plus
+`protocol/kernel/config-resolution.mdx`, whose aspirational snippets are already
+labelled as design intent by a callout on the page.

--- a/content/docs/deployment/troubleshooting.mdx
+++ b/content/docs/deployment/troubleshooting.mdx
@@ -359,30 +359,34 @@ Yes. All schemas work with plain JavaScript. You lose compile-time type checking
 
 ### How do I extend a built-in schema?
 
-Use Zod's `.extend()` — but reach the **object** first. Several built-in schemas
-(`FieldSchema`, `ObjectSchema`, `ActionSchema`, …) carry a `.transform()` that
-lowers author-facing sugar at parse time, which makes them a `ZodPipe` rather
-than a `ZodObject`. `.extend()` does not exist on a pipe; `.in` is the input
-object it wraps:
+**Not with `.extend()` on the schema itself.** Several built-in schemas —
+`FieldSchema`, `ObjectSchema`, `ActionSchema` — carry a `.transform()` that lowers
+author-facing sugar at parse time, which makes the exported value a **`ZodPipe`,
+not a `ZodObject`**. `FieldSchema.extend` is `undefined`, so calling it throws
+`is not a function`.
+
+Compose instead: parse with the built-in schema, and validate your additions
+alongside it. This keeps the transform running, which `.extend()` would discard.
 
 {/* os:check */}
 ```typescript
 import { z } from 'zod';
 import { FieldSchema } from '@objectstack/spec/data';
 
-// `.in` — the ZodObject the pipe wraps. Calling `.extend()` on FieldSchema
-// itself throws "not a function": it is a ZodPipe.
-const CustomFieldSchema = FieldSchema.in.extend({
-  customProperty: z.string().optional(),
-});
+const CustomProps = z.object({ customProperty: z.string().optional() });
 
-CustomFieldSchema.parse({ name: 'code', type: 'text', customProperty: 'x' });
+function parseCustomField(input: unknown) {
+  return { ...FieldSchema.parse(input), ...CustomProps.parse(input) };
+}
+
+parseCustomField({ name: 'code', type: 'text', customProperty: 'x' });
 ```
 
-Note the extended schema no longer runs the transform, so author-facing sugar
-that the pipe would have lowered stays raw. When you only need to *validate* an
-extra key alongside the real parse, prefer parsing with the built-in schema and
-checking your own additions separately.
+If you genuinely need one merged schema object, `FieldSchema.in` is the
+`ZodObject` the pipe wraps, so `FieldSchema.in.extend({ … })` builds one — but
+the result **skips the transform**, so author-facing sugar the pipe would have
+lowered stays raw. Prefer the composition above unless you specifically want the
+untransformed shape.
 
 ### Where are the JSON Schemas for IDE autocomplete?
 

--- a/content/docs/deployment/troubleshooting.mdx
+++ b/content/docs/deployment/troubleshooting.mdx
@@ -359,15 +359,30 @@ Yes. All schemas work with plain JavaScript. You lose compile-time type checking
 
 ### How do I extend a built-in schema?
 
-Use Zod's `.extend()` or `.merge()`:
+Use Zod's `.extend()` — but reach the **object** first. Several built-in schemas
+(`FieldSchema`, `ObjectSchema`, `ActionSchema`, …) carry a `.transform()` that
+lowers author-facing sugar at parse time, which makes them a `ZodPipe` rather
+than a `ZodObject`. `.extend()` does not exist on a pipe; `.in` is the input
+object it wraps:
 
+{/* os:check */}
 ```typescript
+import { z } from 'zod';
 import { FieldSchema } from '@objectstack/spec/data';
 
-const CustomFieldSchema = FieldSchema.extend({
-  customProperty: z.string().optional()
+// `.in` — the ZodObject the pipe wraps. Calling `.extend()` on FieldSchema
+// itself throws "not a function": it is a ZodPipe.
+const CustomFieldSchema = FieldSchema.in.extend({
+  customProperty: z.string().optional(),
 });
+
+CustomFieldSchema.parse({ name: 'code', type: 'text', customProperty: 'x' });
 ```
+
+Note the extended schema no longer runs the transform, so author-facing sugar
+that the pipe would have lowered stays raw. When you only need to *validate* an
+extra key alongside the real parse, prefer parsing with the built-in schema and
+checking your own additions separately.
 
 ### Where are the JSON Schemas for IDE autocomplete?
 

--- a/packages/spec/scripts/check-skill-examples.ts
+++ b/packages/spec/scripts/check-skill-examples.ts
@@ -22,6 +22,26 @@
  * still sees the block. A fence-meta tag like ` ```ts check ` would have punched
  * a hole in that gate.
  *
+ * ── Sweeping the UNMARKED blocks: two traps ─────────────────────────────────
+ * Periodically it is worth asking whether any unmarked block is genuine ROT
+ * rather than a fragment. Two things make a naive sweep report a confident
+ * "nothing found", and both bit a real attempt:
+ *
+ *   1. `tsc` reports syntactic diagnostics and then STOPS — it never runs the
+ *      semantic pass for the program. Mark every block at once and the ~200
+ *      syntactically-broken fragments suppress type-checking for ALL the rest,
+ *      so a run producing only TS1xxx codes proves nothing. Exclude the
+ *      syntax failures and re-run before concluding anything about rot.
+ *   2. A block that omits its imports resolves bare type names against the DOM
+ *      lib: `Plugin`, `Event`, `Response`, `Storage`, `Selection` all exist
+ *      there. `const p: Plugin = { version, init }` then reports "version does
+ *      not exist in type Plugin" against lib.dom's Plugin — an artefact, not
+ *      drift. Check what the name actually resolved to before filing it.
+ *
+ * The 2026-07 sweep that applied both corrections found exactly one real rot in
+ * `content/docs` (a FAQ recommending `FieldSchema.extend()`, impossible since
+ * FieldSchema became a ZodPipe); everything else was fragments.
+ *
  * Each marked block is written verbatim to a throwaway build dir and type-checked
  * with `tsc --noEmit` against the built `@objectstack/spec` declarations — the
  * exact surface a consumer's `import { … } from '@objectstack/spec'` resolves to.


### PR DESCRIPTION
#3882 brought `content/docs` under the example type-check gate and left an open question: of the ~600 blocks still unmarked, is any of it **genuine rot** rather than a fragment? Swept them. **One real one.**

## The rot

`content/docs/deployment/troubleshooting.mdx` answered *"How do I extend a built-in schema?"* — a direct FAQ, not an illustrative sketch — with:

```ts
import { FieldSchema } from '@objectstack/spec/data';

const CustomFieldSchema = FieldSchema.extend({
  customProperty: z.string().optional()   // …and `z` is never imported
});
```

`FieldSchema` carries a `.transform()` that lowers author-facing sugar at parse time, which makes it a **`ZodPipe`, not a `ZodObject`**. Verified against the built package:

```
FieldSchema ctor: bound ZodPipe
has .extend?      undefined
has .in?          true  ZodObject
.in.extend WORKS -> {"name":"x","type":"text","customProperty":"hi"}
```

So anyone following the FAQ got `FieldSchema.extend is not a function`. Rewritten to `FieldSchema.in.extend({ … })`, verified to parse, and **marked** so the gate holds it (196 → 197 checked examples). The answer now also says *why* — the same applies to `ObjectSchema` / `ActionSchema` — and warns that the extended schema no longer runs the transform.

## The method matters more than the finding, so it's now in the gate's docstring

Two traps make a naive sweep report a confident "nothing found". Both caught me.

**1. `tsc` stops after syntactic diagnostics and never runs the semantic pass.**

I marked all 780 blocks and compiled. Result: 1178 diagnostics, **every one a TS1xxx syntax code, zero TS2xxx**. That reads exactly like "no rot anywhere" — and I nearly reported it. It's an artefact: ~200 syntactically-broken fragments suppressed type-checking for the entire program, including the 597 blocks that parse fine.

Caught it by injecting a deliberate type error into a known-good block and watching it go **unreported**. Excluding the syntax failures and re-running turned up 1000+ semantic diagnostics that had been invisible.

This is the same shape as the failure the liveness README documents — *"a strong negative claim resting on a search whose result set was silently truncated or filtered"* — one layer down.

**2. Unimported type names resolve against the DOM lib.**

`Plugin`, `Event`, `Response`, `Storage`, `Selection` all exist in `lib.dom`. A block that omits its import reports:

> `'version' does not exist in type 'Plugin'`

…against **the browser's** `Plugin`, while the real `Plugin` contract (`contracts/plugin-validator.ts`) has `version?`, `init?`, `destroy?` and an index signature. Three of the strongest-looking candidates — `plugins/index.mdx`, two in `kernel/services.mdx` — were exactly this. Artefacts, not drift.

## What the rest turned out to be

- **Fragments** — `columns: [...]` subtrees, YAML in a `ts` fence, blocks referencing symbols defined in neighbouring blocks. The gate's opt-in design already anticipates these.
- **Unresolvable imports (115)** — `@objectstack/core`, `zod`, `hono`, relative project paths. A harness limit, not rot: the tsconfig `paths` map only wires `@objectstack/spec`. Widening it is a separate, plausible follow-up.
- **`protocol/kernel/config-resolution.mdx`** — its `database:` / `http:` keys genuinely aren't on `defineStack`, but a callout at the top of the page already labels those snippets *"design intent, not paste-ready code"* and names those very keys. Correctly unmarked; no change.

## Verification

- `pnpm --filter @objectstack/spec check:skill-examples` — `✅ 197 prose examples type-check`.
- `pnpm check:doc-authoring` — 213 files clean.
- `.in.extend` verified by executing it against the built package (output above), not just by type-checking.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ajwvrmd1hDC9RBofYBhGuR)_