### PR TITLE
fix(actions): dispatch on the declared action type over REST (#3915)

### DIFF
--- a/.changeset/rest-actions-type-dispatch.md
+++ b/.changeset/rest-actions-type-dispatch.md
@@ -1,0 +1,49 @@
+---
+"@objectstack/runtime": minor
+---
+
+fix(actions): dispatch on the declared action `type` over REST — flow actions are no longer MCP-only (#3915)
+
+`POST /api/v1/actions/:object/:action` had **no action-type branching at all**.
+Whatever an action declared, the route went straight to `ql.executeAction` — the
+script-handler registry — while the MCP `run_action` bridge had implemented the
+`flow` branch since #2849. The spec is unambiguous that every non-`script` type
+dispatches on `target` (`packages/spec/src/ui/action.zod.ts`), so a REST/SDK
+caller who followed it and invoked a `type: 'flow'` action got
+
+```
+Action '' on object '*' not found
+```
+
+and had to know, out of band, to call `POST /api/v1/automation/:target/trigger`
+itself. Worse for the Studio-authored case: `resyncAuthoredActions` deliberately
+registers **no** handler for a flow-typed action ("no body (target/flow/url
+action)"), so there was never anything for the registry to find.
+
+The two headless surfaces now share one dispatch:
+
+- **`flow`** → `automation.execute(action.target, …)` via the new
+  `dispatchFlowAction`, which the MCP path now calls too. The caller's identity
+  (`userId` / `positions` / `permissions` / `tenantId`) is forwarded, so a
+  `runAs: 'user'` flow enforces RLS as the invoker instead of falling into the
+  user-less UNSCOPED path (ADR-0049). A flow action on a kernel with no
+  automation service reports **503**, not a `{ success: false }` body.
+- **`script`** → the handler registry, unchanged. An action with no resolvable
+  declaration is handler-only by definition and keeps that path.
+- **`url` / `modal` / `form` / `api`** → **400** naming the type and the
+  prescription (for `api`, the `target` endpoint to call directly) instead of a
+  registry miss that reads like the action does not exist.
+
+The route also resolves **standalone declarations** now — `defineAction`
+artifacts in the ObjectQL registry and Studio-authored `action` metadata rows,
+neither of which appears inside any object's `actions[]`. They were invisible
+to this route before, which is why a flow-typed one could not be dispatched —
+and, separately, why its `requiredPermissions` were declared-but-unenforced on
+REST while MCP honoured them. The ADR-0066 D4 gate still runs **before** the
+type check, so an unauthorized caller learns nothing about how an action
+dispatches.
+
+**Migration:** a caller invoking a `url`/`modal`/`form`/`api` action through
+this endpoint used to receive `{ success: false, error: "Action '' on object
+'*' not found" }` (HTTP 200) and now receives a 400 that says what to call
+instead. No spec-faithful action changes behavior.

--- a/content/docs/ui/actions.mdx
+++ b/content/docs/ui/actions.mdx
@@ -233,6 +233,16 @@ curl -b cookies.txt -X POST \
 Global (object-less) actions post to `/api/v1/actions/global/:action`. For
 credentials, see [API Authentication](/docs/api#authentication).
 
+The endpoint dispatches on the **declared `type`**, exactly like the MCP
+`run_action` tool — so the same URL invokes a script handler or a flow:
+
+| `type` | Over REST |
+|:---|:---|
+| `script` | Runs the registered handler / inline body. |
+| `flow` | Runs `target` on the automation engine, with your identity forwarded (a `runAs: 'user'` flow enforces RLS as you). Equivalent to `POST /api/v1/automation/:target/trigger`, without having to know the flow name. |
+| `api` | **400** — it dispatches on `target`; call that endpoint directly. |
+| `url` / `modal` / `form` | **400** — client-side navigation; there is nothing for the server to run. |
+
 ## Expose it to AI (MCP)
 
 Actions are **not** AI-visible by default. Opting in takes two fields — and
@@ -256,6 +266,7 @@ and [Connect an MCP Client](/docs/ai/connect-mcp).
 |:---|:---|
 | Button doesn't appear | `locations` doesn't include the surface; or the `visible` CEL throws (e.g. a bare, unprefixed field name) and fail-closed hides it; or the user fails `requiredPermissions` |
 | Click → `Action 'x' … not found` | `target`-style script with no registered handler — add the `registerAction` call in `onEnable` (Path B above) |
+| REST → 400 naming the action's `type` | The type has no server dispatch (`url`/`modal`/`form`/`api`) — open its `target` in the client, or call that endpoint directly |
 | Appears in UI, missing from `list_actions` (MCP) | `ai.exposed` not `true`, `ai.description` under 40 characters, or the type isn't headless-callable |
 | Runs but the list looks stale | Add `refreshAfter: true` |
 

--- a/packages/runtime/src/action-execution.ts
+++ b/packages/runtime/src/action-execution.ts
@@ -260,6 +260,114 @@ export function isHeadlessInvokableAction(deps: ActionExecutionDeps, action: any
     return false;
 }
 
+/**
+ * The action types a headless caller can actually invoke through a server
+ * dispatch — the two {@link isHeadlessInvokableAction} accepts. Kept next to
+ * it so the predicate and the explanation below can never drift apart.
+ */
+const SERVER_DISPATCHED_ACTION_TYPES: ReadonlySet<string> = new Set(['script', 'flow']);
+
+/**
+ * Explain why a declared action has NO server-side dispatch — `null` when it
+ * does have one (`script` / `flow`).
+ *
+ * The spec is explicit (`packages/spec/src/ui/action.zod.ts`): every
+ * non-`script` type dispatches on `target`, and only `flow` has a server-side
+ * runner (the automation engine). `url` / `modal` / `form` are renderer
+ * navigation and `api` names a *different* endpoint the client calls itself —
+ * none of them is the script-handler registry. Pre-#3915 the REST route had
+ * no type branching at all, so every one of them fell through to
+ * `executeAction` and came back as the misleading
+ * `Action '' on object '*' not found`. Naming the type and the prescription
+ * turns that dead end into an actionable 400.
+ */
+export function headlessActionTypeError(deps: ActionExecutionDeps, action: any, objectName?: string): string | null {
+    const type: string = action?.type ?? 'script';
+    if (SERVER_DISPATCHED_ACTION_TYPES.has(type)) return null;
+    const name: string = action?.name ?? 'unknown';
+    const on = objectName ? ` on '${objectName}'` : '';
+    const target: string | undefined = typeof action?.target === 'string' ? action.target : undefined;
+    if (type === 'api') {
+        return (
+            `Action '${name}'${on} is \`type: 'api'\` — it dispatches on \`target\`, ` +
+            `not through the action registry. Call ${target ? `\`${target}\`` : 'its `target` endpoint'} directly` +
+            `${typeof action?.method === 'string' ? ` (${action.method})` : ''}.`
+        );
+    }
+    return (
+        `Action '${name}'${on} is \`type: '${type}'\` — a client-side action with no server dispatch. ` +
+        `The renderer opens its \`target\`${target ? ` ('${target}')` : ''}; there is nothing for the server to run.`
+    );
+}
+
+/**
+ * The automation service when this kernel has a usable one, else `null` —
+ * the single availability probe behind `type: 'flow'` dispatch (both the
+ * headless-invokability filter and the two invoke paths ask through it).
+ */
+export async function resolveAutomationService(deps: ActionExecutionDeps, envId?: string): Promise<any | null> {
+    try {
+        const svc: any = await deps.resolveService('automation', envId);
+        return svc && typeof svc.execute === 'function' ? svc : null;
+    } catch {
+        return null; // no automation service on this kernel
+    }
+}
+
+/** Message for a flow action on a kernel with no automation service (a 503-shaped condition). */
+export function flowActionUnavailableError(action: any): string {
+    return `Action '${action?.name ?? 'unknown'}' is a flow but no automation service is available`;
+}
+
+/**
+ * Dispatch a `type: 'flow'` action through the automation service.
+ *
+ * The ONE implementation both headless surfaces share — the MCP `run_action`
+ * tool and the REST `/actions/:object/:action` route (#3915, which is exactly
+ * the asymmetry that let this branch exist on only one of them). Throws on a
+ * missing automation service and converts a `{ success: false }` engine result
+ * into a throw so both callers report failure the same way; returns the raw
+ * automation result otherwise.
+ *
+ * Forwarding the caller's identity (rather than just executing the flow) is
+ * what lets a `runAs: 'user'` flow enforce RLS as the invoker instead of
+ * falling into the user-less UNSCOPED path (#2849, ADR-0049 / #1888; mirrors
+ * the record-change trigger's context shape).
+ */
+export async function dispatchFlowAction(deps: ActionExecutionDeps,
+    action: any,
+    wiring: {
+        objectName: string;
+        record: Record<string, unknown>;
+        params: Record<string, unknown>;
+        ec: any;
+        envId?: string;
+    },
+): Promise<any> {
+    const { objectName, record, params, ec, envId } = wiring;
+    const automation = await resolveAutomationService(deps, envId);
+    if (!automation) {
+        throw new Error(flowActionUnavailableError(action));
+    }
+    // Pass a proper AutomationContext (the engine never read the former
+    // `triggerData` envelope).
+    const result: any = await automation.execute(action.target, {
+        record,
+        ...(objectName !== 'global' ? { object: objectName } : {}),
+        userId: ec?.userId,
+        ...(Array.isArray(ec?.positions) && ec.positions.length ? { positions: ec.positions } : {}),
+        ...(Array.isArray(ec?.permissions) && ec.permissions.length ? { permissions: ec.permissions } : {}),
+        ...(ec?.tenantId ? { tenantId: ec.tenantId } : {}),
+        // Record fields seed flows' named `isInput` variables (like the
+        // record-change trigger); explicit action params win on clash.
+        params: { ...record, ...params },
+    });
+    if (result && typeof result === 'object' && 'success' in result && result.success === false) {
+        throw new Error(`Flow '${action.target}' failed: ${result.error ?? 'unknown error'}`);
+    }
+    return result ?? null;
+}
+
 export function actionLooksDestructive(deps: ActionExecutionDeps, action: any): boolean {
     if (action?.ai?.requiresConfirmation !== undefined) return Boolean(action.ai.requiresConfirmation);
     return Boolean(action?.confirmText || action?.mode === 'delete' || action?.variant === 'danger');
@@ -486,7 +594,7 @@ export async function invokeBusinessAction(deps: ActionExecutionDeps,
     if (isSystemObjectName(objectName)) {
         throw new Error(`Action '${name}' is on a system object and is not exposed via MCP`);
     }
-    const hasAutomation = Boolean(await deps.resolveService('automation', envId).catch(() => null));
+    const hasAutomation = Boolean(await resolveAutomationService(deps, envId));
     if (!isHeadlessInvokableAction(deps, action, hasAutomation)) {
         throw new Error(
             `Action '${name}' (type='${action?.type ?? 'script'}') cannot be invoked via MCP`,
@@ -535,32 +643,10 @@ export async function invokeBusinessAction(deps: ActionExecutionDeps,
           }
         : { id: 'system', name: 'system' };
 
-    // ── flow dispatch ──
+    // ── flow dispatch ── (shared with the REST /actions route, #3915)
     if (action.type === 'flow') {
-        const automation: any = await deps.resolveService('automation', envId).catch(() => null);
-        if (!automation || typeof automation.execute !== 'function') {
-            throw new Error(`Action '${name}' is a flow but no automation service is available`);
-        }
-        // Pass a proper AutomationContext (the engine never read the former
-        // `triggerData` envelope). Forwarding the caller's identity is what
-        // lets a `runAs:'user'` flow enforce RLS as the invoker instead of
-        // falling into the user-less UNSCOPED path (#2849, ADR-0049 / #1888;
-        // mirrors the record-change trigger's context shape).
-        const result: any = await automation.execute(action.target, {
-            record,
-            ...(objectName !== 'global' ? { object: objectName } : {}),
-            userId: ec?.userId,
-            ...(Array.isArray(ec?.positions) && ec.positions.length ? { positions: ec.positions } : {}),
-            ...(Array.isArray(ec?.permissions) && ec.permissions.length ? { permissions: ec.permissions } : {}),
-            ...(ec?.tenantId ? { tenantId: ec.tenantId } : {}),
-            // Record fields seed flows' named `isInput` variables (like the
-            // record-change trigger); explicit action params win on clash.
-            params: { ...record, ...params },
-        });
-        if (result && typeof result === 'object' && 'success' in result && result.success === false) {
-            throw new Error(`Flow '${action.target}' failed: ${result.error ?? 'unknown error'}`);
-        }
-        return { ok: true, action: action.name, objectName, ...(recordId ? { recordId } : {}), result: result ?? null };
+        const result = await dispatchFlowAction(deps, action, { objectName, record, params, ec, envId });
+        return { ok: true, action: action.name, objectName, ...(recordId ? { recordId } : {}), result };
     }
 
     // ── script/body dispatch via the engine's executeAction ──
@@ -695,4 +781,68 @@ export function standaloneActionObjectName(deps: ActionExecutionDeps, action: an
     if (typeof action?.objectName === 'string' && action.objectName.length > 0) return action.objectName;
     if (typeof action?.object === 'string' && action.object.length > 0) return action.object;
     return 'global';
+}
+
+/**
+ * Resolve the DECLARATION behind a `<object>/<action>` route pair — the
+ * single source the REST `/actions` route reads for the ADR-0066 D4
+ * permission gate, the ADR-0104 param contract, and (since #3915) the action
+ * TYPE it must dispatch on.
+ *
+ * Three sources, in the same precedence the execution layer uses:
+ *  1. the object's own `actions[]` (bundle/artifact objects + authored object
+ *     rows) — object-embedded wins, mirroring `collectActionDeclarations`;
+ *  2. the ObjectQL registry's standalone `action` items — `defineAction`
+ *     artifacts and rehydrated authored rows, which never appear inside any
+ *     object definition;
+ *  3. the metadata service's standalone `action` rows — the env-scoped
+ *     kernels where the registry carries no copy.
+ *
+ * Sources 2 and 3 are what the route was missing: a Studio-authored or
+ * standalone `defineAction` declaration was invisible here, so its declared
+ * `type` (and its `requiredPermissions`) were never read on the REST path
+ * even though the MCP path honoured both. A standalone declaration is
+ * accepted only when it belongs to the routed object or to the `'global'`
+ * wildcard — the same `<object>:<name>` / `'*'` key rotation the handler
+ * lookup performs.
+ */
+export async function resolveRouteActionDeclaration(deps: ActionExecutionDeps,
+    args: { ql: any; objectName: string; actionName: string; envId?: string },
+): Promise<{ action: any; obj: any } | undefined> {
+    const { ql, objectName, actionName, envId } = args;
+
+    let obj: any;
+    try {
+        obj =
+            (typeof ql?.getSchema === 'function' ? ql.getSchema(objectName) : undefined) ??
+            ql?.registry?.getObject?.(objectName);
+    } catch {
+        obj = undefined; // schema unresolved → handler-only action
+    }
+    const embedded = Array.isArray(obj?.actions)
+        ? obj.actions.find((a: any) => a?.name === actionName)
+        : undefined;
+    if (embedded) return { action: embedded, obj };
+
+    const ownsRoute = (action: any): boolean => {
+        const owner = standaloneActionObjectName(deps, action);
+        return owner === objectName || owner === 'global';
+    };
+
+    try {
+        const fromRegistry: any = ql?.registry?.getItem?.('action', actionName);
+        if (fromRegistry && ownsRoute(fromRegistry)) return { action: fromRegistry, obj };
+    } catch {
+        /* registry without an item lookup → fall through to the metadata service */
+    }
+
+    try {
+        const meta: any = await deps.resolveService('metadata', envId);
+        const fromMeta: any = await meta?.load?.('action', actionName);
+        if (fromMeta && ownsRoute(fromMeta)) return { action: fromMeta, obj };
+    } catch {
+        /* no metadata service on this kernel → no declaration to resolve */
+    }
+
+    return obj ? { action: undefined, obj } : undefined;
 }

--- a/packages/runtime/src/domains/actions.ts
+++ b/packages/runtime/src/domains/actions.ts
@@ -13,6 +13,13 @@
  *  - `POST /actions/:object/:action`              — record-scoped action
  *  - `POST /actions/:object/:action/:recordId`    — record-scoped action with id in URL
  *  - `POST /actions/global/:action`               — wildcard ("*") action
+ *
+ * The route dispatches on the declared action TYPE (#3915), the same way the
+ * MCP `run_action` bridge does — `script` through the handler registry,
+ * `flow` through the automation service. Before that it was script-only, so
+ * a spec-faithful REST/SDK caller could not invoke a `type: 'flow'` action at
+ * all: it fell through to the registry and came back as
+ * `Action '' on object '*' not found`.
  */
 
 import * as actionExec from '../action-execution.js';
@@ -43,6 +50,15 @@ export function createActionsDomain(deps: DomainHandlerDeps): DomainRoute {
  *   `{ record, user, engine, params }`
  * where `engine` exposes the slimmed CRUD surface used by CRM handlers
  * (`insert`, `update`, `delete`, `find`).
+ *
+ * Dispatch follows the DECLARED action type (#3915):
+ *  - `script` (and any action with no resolvable declaration, which is
+ *    handler-only by definition) → the registered handler, as before;
+ *  - `flow` → `automation.execute(action.target, …)` with the caller's
+ *    identity forwarded, so `runAs: 'user'` enforces RLS as the invoker;
+ *  - `url` / `modal` / `form` / `api` → 400. They dispatch on `target` in the
+ *    client (or at another endpoint entirely) and have no server dispatch
+ *    here; saying so beats the registry's `not found`.
  */
 export async function handleActionsRequest(deps: DomainHandlerDeps, path: string, method: string, body: any, _context: HttpProtocolContext): Promise<HttpDispatcherResult> {
     if (method.toUpperCase() !== 'POST') {
@@ -87,18 +103,47 @@ export async function handleActionsRequest(deps: DomainHandlerDeps, path: string
     let actionSchema: any;
     let actionDef: any;
     try {
-        actionSchema =
-            (typeof ql.getSchema === 'function' ? ql.getSchema(objectName) : undefined) ??
-            ql.registry?.getObject?.(objectName);
-        actionDef = Array.isArray(actionSchema?.actions)
-            ? actionSchema.actions.find((a: any) => a?.name === actionName)
-            : undefined;
+        // Standalone declarations (ObjectQL registry artifacts / Studio-
+        // authored `action` rows) resolve here too, so a route whose action
+        // never appears inside an object definition is gated and dispatched
+        // like any other (#3915).
+        const declaration = await actionExec.resolveRouteActionDeclaration(deps, {
+            ql,
+            objectName,
+            actionName,
+            envId: _context?.environmentId,
+        });
+        actionSchema = declaration?.obj;
+        actionDef = declaration?.action;
         const gateError = actionExec.actionPermissionError(deps, actionDef, _context?.executionContext, objectName);
         if (gateError) {
             return { handled: true, response: deps.error(gateError, 403) };
         }
     } catch {
         /* schema unresolved → no declared gate to enforce (handler-only action) */
+    }
+
+    // [#3915] Action-TYPE dispatch. Per spec every non-`script` type
+    // dispatches on `target`, and only `flow` has a server-side runner — so
+    // a `url`/`modal`/`form`/`api` action reaching this endpoint has nowhere
+    // to go. It used to fall through to the script registry and come back as
+    // the misleading `Action '' on object '*' not found`; reject it with the
+    // prescription instead. `script` — and an UNDECLARED action, which is
+    // handler-only by definition — keeps the registry path below; `flow` is
+    // dispatched to the automation service once the param contract and the
+    // record load have run, exactly as the MCP `run_action` path does.
+    const actionType: string = typeof actionDef?.type === 'string' ? actionDef.type : 'script';
+    if (actionDef) {
+        const typeError = actionExec.headlessActionTypeError(deps, actionDef, objectName);
+        if (typeError) {
+            return { handled: true, response: deps.error(typeError, 400) };
+        }
+    }
+    // A flow action on a kernel with no automation service is a deployment
+    // gap, not a business failure — report it like the missing data engine
+    // above (503) instead of burying it in a `{ success: false }` body.
+    if (actionType === 'flow' && !(await actionExec.resolveAutomationService(deps, _context?.environmentId))) {
+        return { handled: true, response: deps.error(actionExec.flowActionUnavailableError(actionDef), 503) };
     }
 
     // Resolve the handler — fall back to wildcard '*' if the object-specific key is missing.
@@ -183,13 +228,31 @@ export async function handleActionsRequest(deps: DomainHandlerDeps, path: string
         params: { ...reqParams, recordId, objectName },
     };
 
-    // [#2849] Same trusted-mode elevation as the MCP path — keep it audible.
-    console.info(
-        `[action-audit] REST action '${objectName}/${actionName}' — body executes TRUSTED ` +
-        `(context-less engine, RLS/FLS-bypassing) for user '${userFromAuth.id}'`,
-    );
-
     try {
+        // ── flow dispatch (#3915) ── the same `dispatchFlowAction` the MCP
+        // `run_action` path uses: the automation engine runs `action.target`
+        // with the caller's identity forwarded, so a `runAs: 'user'` flow
+        // enforces RLS as the invoker (ADR-0049). No trusted-mode audit line
+        // here — RLS/FLS-bypassing elevation is a script-BODY property, and a
+        // flow does not get it.
+        if (actionType === 'flow') {
+            const result = await actionExec.dispatchFlowAction(deps, actionDef, {
+                objectName,
+                record,
+                params: reqParams,
+                ec,
+                envId: _context?.environmentId,
+            });
+            return { handled: true, response: deps.success({ success: true, data: result }) };
+        }
+
+        // [#2849] Same trusted-mode elevation as the MCP path — keep it audible.
+        console.info(
+            `[action-audit] REST action '${objectName}/${actionName}' — body executes TRUSTED ` +
+            `(context-less engine, RLS/FLS-bypassing) for user '${userFromAuth.id}'`,
+        );
+
+        // ── script/body dispatch ──
         // Try object-specific first; on "not found" error, fall back to wildcard.
         let result: any;
         try {

--- a/packages/runtime/src/domains/mcp.ts
+++ b/packages/runtime/src/domains/mcp.ts
@@ -376,9 +376,7 @@ export function buildMcpBridge(deps: DomainHandlerDeps, context: HttpProtocolCon
         // identity forwarded. No `@objectstack/service-ai`.
         listActions: async () => {
             const meta: any = await getMeta();
-            const hasAutomation = Boolean(
-                await deps.resolveService('automation', envId).catch(() => null),
-            );
+            const hasAutomation = Boolean(await actionExec.resolveAutomationService(deps, envId));
             const out: any[] = [];
             for (const { action, objectName, obj } of await actionExec.collectActionDeclarations(deps, meta)) {
                 if (!objectName || isSystemObjectName(objectName)) continue; // fail-closed on sys_*

--- a/packages/runtime/src/http-dispatcher.actions-type-dispatch.test.ts
+++ b/packages/runtime/src/http-dispatcher.actions-type-dispatch.test.ts
@@ -1,0 +1,334 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * REST `/actions/:object/:action` — action TYPE dispatch (#3915).
+ *
+ * The spec dispatches every non-`script` action on `target`
+ * (`packages/spec/src/ui/action.zod.ts`), and the MCP `run_action` bridge has
+ * implemented the `flow` branch since #2849. The REST route had NO type
+ * branching at all: every action, whatever its declared type, went to
+ * `ql.executeAction` — the script-handler registry — so a spec-faithful
+ * REST/SDK caller invoking a `type: 'flow'` action got
+ * `Action '' on object '*' not found` and had to know to call
+ * `POST /api/v1/automation/:target/trigger` itself.
+ *
+ * These tests pin the ported dispatch: `flow` → the automation service with
+ * the caller's identity forwarded, `script` → the registry (unchanged), and
+ * the client-side types → an actionable 400 instead of a registry miss.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { HttpDispatcher } from './http-dispatcher.js';
+
+const flowAction = {
+    name: 'convert_lead',
+    label: 'Convert Lead',
+    objectName: 'crm_lead',
+    type: 'flow',
+    target: 'crm_convert_lead_wizard',
+};
+
+/**
+ * A dispatcher whose ObjectQL carries `objectDef` as the routed object's
+ * schema. `standaloneAction` (when given) is served from the metadata
+ * service's `load('action', …)` — the Studio-authored shape that never
+ * appears inside any object definition.
+ */
+function makeDispatcher(opts: {
+    objectDef?: any;
+    automation?: any;
+    standaloneAction?: any;
+    registryAction?: any;
+    record?: any;
+} = {}) {
+    const executeAction = vi.fn(async () => ({ ran: 'script' }));
+    const objectDef = opts.objectDef ?? { name: 'crm_lead', actions: [] };
+    const ql: any = {
+        executeAction,
+        getSchema: (name: string) => (name === objectDef.name ? objectDef : undefined),
+        registry: {
+            getObject: (name: string) => (name === objectDef.name ? objectDef : undefined),
+            getItem: (type: string, name: string) =>
+                type === 'action' && opts.registryAction?.name === name ? opts.registryAction : undefined,
+        },
+        find: vi.fn(async () => (opts.record ? [opts.record] : [])),
+        insert: vi.fn(), update: vi.fn(), delete: vi.fn(),
+    };
+    const metadata: any = {
+        load: vi.fn(async (type: string, name: string) =>
+            type === 'action' && opts.standaloneAction?.name === name ? opts.standaloneAction : null),
+        listObjects: vi.fn(async () => [objectDef]),
+        getObject: vi.fn(async () => objectDef),
+    };
+    const kernel: any = {
+        context: {
+            getService: (n: string) =>
+                n === 'objectql' || n === 'data' ? ql
+                : n === 'metadata' ? metadata
+                : n === 'automation' ? (opts.automation ?? null)
+                : null,
+        },
+    };
+    return { dispatcher: new HttpDispatcher(kernel), executeAction, ql };
+}
+
+const ctxFor = (executionContext: any = { userId: 'u1', systemPermissions: [] }): any => ({
+    request: {},
+    environmentId: 'platform',
+    executionContext,
+});
+
+describe('REST /actions — flow dispatch (#3915)', () => {
+    it('dispatches a `type: flow` action to the automation service instead of the script registry', async () => {
+        const execute = vi.fn(async () => ({ success: true, output: { converted: true } }));
+        const { dispatcher, executeAction } = makeDispatcher({
+            objectDef: { name: 'crm_lead', actions: [flowAction] },
+            automation: { execute },
+            record: { id: 'lead_1', status: 'open' },
+        });
+
+        const res = await dispatcher.handleActions(
+            '/crm_lead/convert_lead/lead_1',
+            'POST',
+            { params: { reason: 'qualified' } },
+            ctxFor(),
+        );
+
+        expect(executeAction).not.toHaveBeenCalled();
+        expect(execute).toHaveBeenCalledWith(
+            'crm_convert_lead_wizard',
+            expect.objectContaining({
+                object: 'crm_lead',
+                record: expect.objectContaining({ id: 'lead_1' }),
+                // Record fields seed the flow's named `isInput` variables;
+                // explicit action params win on clash (parity with MCP).
+                params: expect.objectContaining({ reason: 'qualified', id: 'lead_1' }),
+            }),
+        );
+        expect(res.response.status).toBe(200);
+        expect(res.response.body.data).toEqual({ success: true, data: { success: true, output: { converted: true } } });
+    });
+
+    it('forwards the caller identity so a `runAs: user` flow enforces RLS as the invoker', async () => {
+        const execute = vi.fn(async () => ({ success: true }));
+        const { dispatcher } = makeDispatcher({
+            objectDef: { name: 'crm_lead', actions: [flowAction] },
+            automation: { execute },
+        });
+
+        await dispatcher.handleActions('/crm_lead/convert_lead', 'POST', {}, ctxFor({
+            userId: 'user_42',
+            positions: ['sales_rep'],
+            permissions: ['convert_lead'],
+            tenantId: 'org_acme',
+            systemPermissions: [],
+        }));
+
+        expect(execute).toHaveBeenCalledWith(
+            'crm_convert_lead_wizard',
+            expect.objectContaining({
+                userId: 'user_42',
+                positions: ['sales_rep'],
+                permissions: ['convert_lead'],
+                tenantId: 'org_acme',
+            }),
+        );
+    });
+
+    it('omits `object` for a wildcard (`/actions/global/:action`) flow action', async () => {
+        const execute = vi.fn(async () => ({ success: true }));
+        const globalFlow = { name: 'nightly_sync', type: 'flow', target: 'sync_flow' };
+        const { dispatcher } = makeDispatcher({
+            objectDef: { name: 'global', actions: [globalFlow] },
+            automation: { execute },
+        });
+
+        await dispatcher.handleActions('/global/nightly_sync', 'POST', {}, ctxFor());
+
+        const passed = execute.mock.calls[0]?.[1] as any;
+        expect(passed).not.toHaveProperty('object');
+    });
+
+    it('surfaces a flow failure through the action error envelope', async () => {
+        const execute = vi.fn(async () => ({ success: false, error: 'lead already converted' }));
+        const { dispatcher } = makeDispatcher({
+            objectDef: { name: 'crm_lead', actions: [flowAction] },
+            automation: { execute },
+        });
+
+        const res = await dispatcher.handleActions('/crm_lead/convert_lead', 'POST', {}, ctxFor());
+
+        expect(res.response.body.data.success).toBe(false);
+        expect(res.response.body.data.error).toMatch(/crm_convert_lead_wizard.*lead already converted/i);
+    });
+
+    it('reports a missing automation service as 503, not as a business failure', async () => {
+        const { dispatcher, executeAction } = makeDispatcher({
+            objectDef: { name: 'crm_lead', actions: [flowAction] },
+            automation: null,
+        });
+
+        const res = await dispatcher.handleActions('/crm_lead/convert_lead', 'POST', {}, ctxFor());
+
+        expect(res.response.status).toBe(503);
+        expect(res.response.body.error.message).toMatch(/no automation service/i);
+        expect(executeAction).not.toHaveBeenCalled();
+    });
+});
+
+describe('REST /actions — client-side action types (#3915)', () => {
+    const cases: Array<[string, any, RegExp]> = [
+        ['modal', { name: 'quick_view', type: 'modal', target: 'lead_gallery' }, /type: 'modal'/],
+        ['url', { name: 'open_docs', type: 'url', target: 'https://docs.example' }, /type: 'url'/],
+        ['form', { name: 'log_time', type: 'form', target: 'crm_lead.edit' }, /type: 'form'/],
+    ];
+
+    for (const [type, action, expected] of cases) {
+        it(`rejects a \`type: ${type}\` action with an actionable 400 instead of a registry miss`, async () => {
+            const { dispatcher, executeAction } = makeDispatcher({
+                objectDef: { name: 'crm_lead', actions: [action] },
+            });
+
+            const res = await dispatcher.handleActions(`/crm_lead/${action.name}`, 'POST', {}, ctxFor());
+
+            expect(res.response.status).toBe(400);
+            expect(res.response.body.error.message).toMatch(expected);
+            expect(res.response.body.error.message).not.toMatch(/not found/i);
+            expect(executeAction).not.toHaveBeenCalled();
+        });
+    }
+
+    it('keeps the ADR-0066 D4 gate AHEAD of the type check (403 wins over 400)', async () => {
+        // An unauthorized caller must not learn how an action dispatches.
+        const { dispatcher } = makeDispatcher({
+            objectDef: {
+                name: 'crm_lead',
+                actions: [{
+                    name: 'quick_view',
+                    type: 'modal',
+                    target: 'lead_gallery',
+                    requiredPermissions: ['manage_platform_settings'],
+                }],
+            },
+        });
+
+        const res = await dispatcher.handleActions('/crm_lead/quick_view', 'POST', {}, ctxFor());
+
+        expect(res.response.status).toBe(403);
+    });
+
+    it('points a `type: api` action at the endpoint it actually dispatches on', async () => {
+        const apiAction = {
+            name: 'create_team',
+            type: 'api',
+            target: '/api/v1/auth/organization/create-team',
+            method: 'POST',
+        };
+        const { dispatcher, executeAction } = makeDispatcher({
+            objectDef: { name: 'sys_team', actions: [apiAction] },
+        });
+
+        const res = await dispatcher.handleActions('/sys_team/create_team', 'POST', {}, ctxFor());
+
+        expect(res.response.status).toBe(400);
+        expect(res.response.body.error.message).toContain('/api/v1/auth/organization/create-team');
+        expect(executeAction).not.toHaveBeenCalled();
+    });
+});
+
+describe('REST /actions — script dispatch is unchanged (#3915 regression guard)', () => {
+    it('still runs a declared `type: script` action through the handler registry', async () => {
+        const { dispatcher, executeAction } = makeDispatcher({
+            objectDef: {
+                name: 'crm_lead',
+                actions: [{ name: 'mark_done', type: 'script', target: 'markDone' }],
+            },
+        });
+
+        const res = await dispatcher.handleActions('/crm_lead/mark_done', 'POST', {}, ctxFor());
+
+        expect(executeAction).toHaveBeenCalledTimes(1);
+        expect(res.response.body.data).toEqual({ success: true, data: { ran: 'script' } });
+    });
+
+    it('still runs an UNDECLARED action through the handler registry (handler-only actions)', async () => {
+        // `engine.registerAction(...)` with no metadata declaration anywhere —
+        // the type dispatch must not turn these into a 400.
+        const { dispatcher, executeAction } = makeDispatcher({ objectDef: { name: 'crm_lead', actions: [] } });
+
+        const res = await dispatcher.handleActions('/crm_lead/handler_only', 'POST', {}, ctxFor());
+
+        expect(executeAction).toHaveBeenCalledTimes(1);
+        expect(res.response.body.data.success).toBe(true);
+    });
+});
+
+describe('REST /actions — standalone declarations (#3915)', () => {
+    // A `defineAction` artifact / Studio-authored `action` row never appears in
+    // any object's `actions[]`, and `resyncAuthoredActions` registers NO handler
+    // for a flow-typed one ("no body (target/flow/url action)") — so before the
+    // fix these were exactly the reported symptom: dispatch fell to the registry
+    // and 'not found' came back.
+    it('dispatches a flow action declared as a standalone ObjectQL registry artifact', async () => {
+        const execute = vi.fn(async () => ({ success: true }));
+        const { dispatcher, executeAction } = makeDispatcher({
+            objectDef: { name: 'crm_lead', actions: [] },
+            registryAction: flowAction,
+            automation: { execute },
+        });
+
+        await dispatcher.handleActions('/crm_lead/convert_lead', 'POST', {}, ctxFor());
+
+        expect(execute).toHaveBeenCalledWith('crm_convert_lead_wizard', expect.anything());
+        expect(executeAction).not.toHaveBeenCalled();
+    });
+
+    it('dispatches a flow action declared as a Studio-authored `action` metadata row', async () => {
+        const execute = vi.fn(async () => ({ success: true }));
+        const { dispatcher, executeAction } = makeDispatcher({
+            objectDef: { name: 'crm_lead', actions: [] },
+            standaloneAction: flowAction,
+            automation: { execute },
+        });
+
+        await dispatcher.handleActions('/crm_lead/convert_lead', 'POST', {}, ctxFor());
+
+        expect(execute).toHaveBeenCalledWith('crm_convert_lead_wizard', expect.anything());
+        expect(executeAction).not.toHaveBeenCalled();
+    });
+
+    it('ignores a standalone declaration owned by a DIFFERENT object', async () => {
+        const execute = vi.fn(async () => ({ success: true }));
+        const { dispatcher, executeAction } = makeDispatcher({
+            objectDef: { name: 'crm_contact', actions: [] },
+            standaloneAction: flowAction, // objectName: 'crm_lead'
+            automation: { execute },
+        });
+
+        await dispatcher.handleActions('/crm_contact/convert_lead', 'POST', {}, ctxFor());
+
+        expect(execute).not.toHaveBeenCalled();
+        expect(executeAction).toHaveBeenCalledTimes(1); // falls through to the registry, as before
+    });
+
+    it('enforces the ADR-0066 D4 capability gate on a standalone declaration too', async () => {
+        // The gate read only `object.actions[]` before, so a standalone
+        // declaration's `requiredPermissions` was declared-but-unenforced on
+        // REST while MCP honoured it.
+        const execute = vi.fn(async () => ({ success: true }));
+        const { dispatcher, executeAction } = makeDispatcher({
+            objectDef: { name: 'crm_lead', actions: [] },
+            standaloneAction: { ...flowAction, requiredPermissions: ['manage_platform_settings'] },
+            automation: { execute },
+        });
+
+        const res = await dispatcher.handleActions('/crm_lead/convert_lead', 'POST', {}, ctxFor({
+            userId: 'u1',
+            systemPermissions: [],
+        }));
+
+        expect(res.response.status).toBe(403);
+        expect(execute).not.toHaveBeenCalled();
+        expect(executeAction).not.toHaveBeenCalled();
+    });
+});

--- a/packages/runtime/src/http-dispatcher.test.ts
+++ b/packages/runtime/src/http-dispatcher.test.ts
@@ -2598,7 +2598,12 @@ describe('HttpDispatcher', () => {
 
 
 describe('HttpDispatcher — ADR-0066 D4 action requiredPermissions gate', () => {
-  const gated = { name: 'issue_and_sign', label: 'Issue', type: 'api', requiredPermissions: ['manage_platform_settings'] };
+  // `type: 'script'` (with a handler `target`) is what this fixture needs: the
+  // gate is type-agnostic, but since #3915 the route dispatches on the declared
+  // type, and a `type: 'api'` action never reaches `executeAction` at all — it
+  // dispatches on `target`, at another endpoint. The permitted cases below
+  // assert the handler DID run, so the declaration has to be a dispatchable one.
+  const gated = { name: 'issue_and_sign', label: 'Issue', type: 'script', target: 'issueAndSign', requiredPermissions: ['manage_platform_settings'] };
   const make = (actionDef: any, execCtx: any) => {
     const executeAction = vi.fn().mockResolvedValue({ ran: true });
     const schemaOf = (name: string) => ({ name, actions: actionDef ? [actionDef] : [] });


### PR DESCRIPTION
Closes #3915.

## The gap

`POST /api/v1/actions/:object/:action` had **no action-type branching at all** — every action went to `ql.executeAction`, the script-handler registry — while the MCP `run_action` bridge has implemented the `flow` branch since #2849 (`action-execution.ts`). The spec is unambiguous that every non-`script` type dispatches on `target` (`packages/spec/src/ui/action.zod.ts`), so a REST/SDK caller who followed it and invoked a `type: 'flow'` action got

```
Action '' on object '*' not found
```

and had to know, out of band, to call `POST /api/v1/automation/:target/trigger` themselves.

It is worse than "the branch is missing" for the Studio-authored case: `resyncAuthoredActions` deliberately registers **no** handler for a flow-typed action (`skippedNoHandler`, "no body (target/flow/url action)"), so there was never anything in the registry to find.

A second, related gap surfaced while fixing it: the route resolved declarations **only** from `object.actions[]`, so a standalone declaration's `requiredPermissions` was declared-but-unenforced on REST while MCP honoured it (ADR-0066 D4, Prime Directive #10 "declared ≠ enforced").

## The fix

Both headless surfaces now share **one** dispatch implementation.

| `type` | Over REST |
|:---|:---|
| `script` | Handler registry — unchanged. An action with no resolvable declaration is handler-only by definition and keeps this path. |
| `flow` | `automation.execute(action.target, …)` via the new shared `dispatchFlowAction` (the MCP path now calls it too). The caller's identity (`userId`/`positions`/`permissions`/`tenantId`) is forwarded, so a `runAs: 'user'` flow enforces RLS as the invoker instead of falling into the user-less UNSCOPED path (ADR-0049). No automation service on the kernel → **503**, not a `{ success: false }` body. |
| `api` | **400** naming the `target` endpoint to call directly. |
| `url` / `modal` / `form` | **400** — client-side navigation, nothing for the server to run. |

The route also resolves **standalone declarations**: `defineAction` artifacts in the ObjectQL registry and Studio-authored `action` metadata rows, neither of which appears in any object's `actions[]`. A standalone declaration is accepted only when it belongs to the routed object or to the `'global'` wildcard — the same key rotation the handler lookup performs.

Ordering is deliberate: the **ADR-0066 D4 gate still runs before the type check**, so an unauthorized caller learns nothing about how an action dispatches (pinned by a test). The trusted-mode `[action-audit]` line stays on the script branch only — RLS/FLS-bypassing elevation is a script-**body** property; a flow does not get it.

## Files

- `packages/runtime/src/action-execution.ts` — new `dispatchFlowAction` (extracted from the MCP path, which now calls it), `headlessActionTypeError`, `resolveAutomationService` / `flowActionUnavailableError`, `resolveRouteActionDeclaration` (3-source declaration resolution).
- `packages/runtime/src/domains/actions.ts` — type dispatch + the new declaration source.
- `packages/runtime/src/domains/mcp.ts` — `listActions` uses the shared automation probe (which also requires a usable `.execute`, closing a latent "service present but not usable" hole).
- `content/docs/ui/actions.mdx` — "Call it over REST" now documents the per-type behaviour + a troubleshooting row.
- `.changeset/rest-actions-type-dispatch.md`.

## Tests

New `packages/runtime/src/http-dispatcher.actions-type-dispatch.test.ts` (16 cases): flow dispatch instead of the registry, identity forwarding, no `object` key for `/actions/global/:action`, flow-failure envelope, the 503, the four client-side types' 400s, the gate-before-type ordering, `script` + undeclared-action regression guards, standalone declarations via both the registry and the metadata service, a cross-object standalone that must **not** match, and the 403 on a standalone `requiredPermissions`.

One existing fixture was corrected: the ADR-0066 D4 gate suite declared its gated action as `type: 'api'` with no `target` (not spec-valid) and asserted the handler ran — now `type: 'script'` + `target`, since an `api` action legitimately never reaches `executeAction`.

Local runs, all green: `runtime` 736/736 · `objectql` 1163/1163 · `spec` 6823/6823 · `rest` 419/419 · `turbo build` (incl. DTS typecheck) · eslint on the changed files.

## Behaviour change to note

A caller invoking a `url`/`modal`/`form`/`api` action through this endpoint used to get `{ success: false, error: "Action '' on object '*' not found" }` (HTTP 200) and now gets a 400 that says what to call instead. No spec-faithful action changes behaviour.

Out of scope: the HTTP-200 error envelope (#3913) is untouched — a flow's business failure still returns the existing `{ success: false }` 200 envelope, consistent with the script path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTTKgYriDB6RVrkYjxxnG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTTKgYriDB6RVrkYjxxnG1)_