### PR TITLE
fix(sharing)!: a rule with no criteria shares NOTHING, not every record (#3896)

### DIFF
--- a/.changeset/sharing-rule-criteria-required.md
+++ b/.changeset/sharing-rule-criteria-required.md
@@ -1,0 +1,57 @@
+---
+"@objectstack/plugin-sharing": minor
+"@objectstack/rest": patch
+"@objectstack/spec": patch
+---
+
+fix(security)!: a sharing rule with no criteria now shares NOTHING instead of every record (#3896)
+
+`SharingRuleSchema` has always required `condition`, and its doc is explicit
+that a predicate the compiler cannot lower is *"skipped and logged — never
+seeded as a permissive match-all (ADR-0049)"*. The declared/seed path honoured
+that. The two other ways to create a rule did not:
+
+- **`POST {basePath}/sharing/rules`** plucks its body field-by-field into
+  `SharingRuleService.defineRule`, which validated `name` / `label` / `object` /
+  `recipientType` / `recipientId` — and not `criteria`. A missing, `null`, or
+  **misspelled** key (`criterias`) was stored as `criteria_json: null`, answered
+  `201` with no warning, and evaluated as
+  `find(object, { filter: {}, context: SYSTEM_CTX })`: every record of the
+  object, up to 5000, granted to the recipient. Triggering it took a typo, not
+  an attacker.
+- **Authoring a rule in Setup** is a direct `sys_sharing_rule` insert, which
+  never reaches `defineRule` at all.
+
+Empty criteria is now rejected everywhere a rule can be written, and — because
+rules created before this gate are already in the table — the evaluator refuses
+to act on one regardless of how it got there.
+
+- **`defineRule` rejects a match-all criteria** with
+  `VALIDATION_FAILED: criteria is required …`, alongside its other required
+  fields. Covers the REST endpoint, programmatic callers, and the seeder.
+  Rejected shapes: missing / `null` / `''` / `{}` / `[]` / `{ $and: [] }` /
+  unparsable JSON (e.g. a CEL source typed into the Criteria box).
+- **The evaluator matches nothing** for such a rule and logs why, so a row
+  stored before this release under-shares instead of over-sharing: the next
+  reconcile *revokes* the grants it had materialised. Both evaluation paths are
+  covered — the bulk `evaluateRule` and the per-record write-hook path.
+- **`bindRuleCriteriaGuard`** fails `sys_sharing_rule` inserts with no
+  criteria as a field-level `VALIDATION_FAILED` (a 400 naming `criteria_json`),
+  so the Setup path reports the problem instead of saving an inert rule
+  (ADR-0078). Updates are checked only when the patch supplies
+  `criteria_json` — switching an over-broad legacy rule off must not require
+  inventing a criteria for it first.
+- **The seed bootstrap's "empty condition = match-all" branch is gone**: a
+  missing or empty `condition` is now skipped and logged like any other
+  non-lowerable one.
+- `POST {basePath}/sharing/rules` also accepts `criteria_json` as an alias for
+  `criteria`, matching the snake_case aliases the endpoint already takes for
+  `object_name` / `recipient_type` / `access_level`.
+
+**Migration.** There is no "share every record" sharing rule, and there never
+usefully was one — the shape existed only as a failure mode. A rule that
+relied on it must state its predicate (`criteria: { stage: 'won' }`), or, if
+the object really should be readable by everyone, use the object's
+organization-wide default (`sharingModel`) instead. Rules already stored with
+a null `criteria_json` need no data migration: they stop granting on the next
+evaluation and their existing grants are revoked.

--- a/content/docs/permissions/sharing-rules.mdx
+++ b/content/docs/permissions/sharing-rules.mdx
@@ -149,6 +149,24 @@ compiler. A condition the compiler cannot lower is **skipped and logged —
 never seeded as a permissive match-all** (ADR-0049): a bad condition
 under-shares rather than over-shares.
 
+### There is no "share every record" rule
+
+The predicate is **mandatory on every authoring path**, whether you declare
+the rule in code, `POST` it to the REST API, or build it in Setup:
+
+- `defineSharingRule({...})` — `condition` is required by the schema.
+- `POST {basePath}/sharing/rules` — a request whose `criteria` is missing,
+  `null`, empty (`{}`), or unparsable fails with `400 VALIDATION_FAILED`. So
+  does a **misspelled** key such as `criterias`, which would otherwise be
+  indistinguishable from "no criteria" (#3896).
+- Creating the rule in Setup — an empty **Criteria** field is rejected.
+
+A rule that reached the table without a criteria — one stored before this gate
+existed — shares **nothing** and logs why: the next evaluation revokes the
+grants it had issued rather than re-granting the whole object. If you really
+do want everyone to read every record of an object, that is the object's
+organization-wide default (`sharingModel`), not a sharing rule.
+
 > **Retired shapes.** The pre-ADR-0090 `group` recipient was renamed to
 > `team`, and the `guest` recipient was removed — anonymous access is served
 > by the [public-form grant](/docs/permissions/authorization) and share

--- a/docs/audits/2026-06-metadata-functional-completeness.md
+++ b/docs/audits/2026-06-metadata-functional-completeness.md
@@ -91,6 +91,8 @@ Investigator 4 flagged, as a P0 security hole, that a criteria sharing rule with
 
 So the natural authoring path **cannot** silently drop the predicate. Residual: only a hand-crafted `{dialect,source:''}` envelope or a direct `sys_sharing_rule` row could reach the match-all branch — worth a one-line belt-and-suspenders guard, **not a P0**. This is consistent with ADR-0049 already being *applied* to `SharingRuleSchema` (#1887). 
 
+> **Update (2026-07, #3896) — the residual was bigger than "hand-crafted", and is now closed.** The correction above is right about the *declared* path and wrong about the size of what it left over. The residual was not only a hand-crafted envelope: `POST {basePath}/sharing/rules` plucks its body field-by-field into `SharingRuleService.defineRule`, which validated `name` / `label` / `object` / `recipientType` / `recipientId` and **not** `criteria` — so a missing, `null`, or *misspelled* (`criterias`) key stored `criteria_json: null`, returned `201`, and evaluated as `find(object, { filter: {} })`. Authoring in Setup is a direct `sys_sharing_rule` insert, which reached the same place. Neither needs malice, only a typo. Closed by gating `defineRule` and the table's `beforeInsert`, and by making the evaluator match **nothing** on a match-all criteria so rows already stored under-share instead. The lesson below still holds — but it cuts both ways: "the schema requires it" is a claim about the schema, not about every entry that writes the same row.
+
 **Lesson** (it sets the disposition for the whole catalog): the audit produces *candidates*, not confirmed bugs. The scariest one collapsed on a 3-file read. Every Tier-A/B item gets a verification pass before it becomes a lint rule.
 
 ---

--- a/packages/plugins/plugin-sharing/src/bootstrap-declared-sharing-rules.ts
+++ b/packages/plugins/plugin-sharing/src/bootstrap-declared-sharing-rules.ts
@@ -17,6 +17,9 @@
  *   - a CEL `condition` the canonical compiler cannot lower (functions,
  *     cross-object traversal) — ADR-0058 D2. Compound predicates (AND/OR,
  *     comparisons, null, in) DO lower and are enforced (ADR-0058 D3, #1887).
+ *   - a missing or empty `condition`, which lowers to no predicate at all
+ *     (#3896). It used to seed a rule with `criteria_json: null` — the exact
+ *     permissive match-all the rest of this file exists to prevent.
  *   - defensively, any stale pre-built package that still registers an old
  *     `owner`-type / unmapped-recipient shape.
  *
@@ -28,6 +31,7 @@
 import type { SharingRuleService } from './sharing-rule-service.js';
 import type { SharingRuleRecipientType, ShareAccessLevel } from '@objectstack/spec/contracts';
 import { compileCelToFilter } from '@objectstack/formula';
+import { isMatchAllCriteria } from './rule-criteria.js';
 
 const SYSTEM_CTX = { isSystem: true, positions: [], permissions: [] } as const;
 
@@ -111,16 +115,20 @@ export async function bootstrapDeclaredSharingRules(
       logger?.warn?.('[sharing-rule] skipped owner-based rule (retired authoring shape — use a criteria rule)', { rule: r.name });
       skipped += 1; continue;
     }
-    // criteria rules: translate CEL → filter. Empty condition = match-all (intentional).
-    let criteria: Record<string, unknown> | undefined;
-    if (r.condition != null && String(r.condition).trim() !== '') {
-      const f = celToFilter(r.condition);
-      if (!f) {
-        logger?.warn?.('[sharing-rule] skipped (untranslatable CEL condition) [experimental]', { rule: r.name, condition: r.condition });
-        skipped += 1; continue;
-      }
-      criteria = f;
+    // criteria rules: translate CEL → filter. [#3896] A missing / empty
+    // condition used to fall through this branch with `criteria` undefined,
+    // which `defineRule` stored as `criteria_json: null` and the evaluator
+    // read as the empty filter — the one outcome this file's header forbids.
+    // It is now skipped like any other non-lowerable condition: the authoring
+    // schema requires `condition`, so reaching here means a hand-crafted
+    // `{ dialect, source: '' }` envelope or a stale pre-built package, and
+    // neither earns a match-all.
+    const f = celToFilter(r.condition);
+    if (!f || isMatchAllCriteria(f)) {
+      logger?.warn?.('[sharing-rule] skipped (missing or untranslatable CEL condition — never seeded as match-all) [experimental]', { rule: r.name, condition: r.condition });
+      skipped += 1; continue;
     }
+    const criteria: Record<string, unknown> = f;
     try {
       await ruleService.defineRule({
         name: r.name,

--- a/packages/plugins/plugin-sharing/src/index.ts
+++ b/packages/plugins/plugin-sharing/src/index.ts
@@ -30,7 +30,19 @@ export {
 } from './share-link-routes.js';
 export { TeamGraphService, expandPrincipal, type TeamGraphOptions } from './team-graph.js';
 export { BusinessUnitGraphService, type BusinessUnitGraphOptions } from './business-unit-graph.js';
-export { bindRuleHooks, unbindAllRuleHooks, SHARING_RULE_HOOK_PACKAGE } from './rule-hooks.js';
+export {
+  bindRuleHooks,
+  unbindAllRuleHooks,
+  bindRuleCriteriaGuard,
+  SHARING_RULE_HOOK_PACKAGE,
+  RULE_CRITERIA_GUARD_PACKAGE,
+} from './rule-hooks.js';
+export {
+  parseCriteria,
+  isMatchAllCriteria,
+  MATCH_ALL_CRITERIA_MESSAGE,
+  SharingCriteriaValidationError,
+} from './rule-criteria.js';
 export {
   bindRuleProvenanceStamp,
   unbindRuleProvenanceStamp,

--- a/packages/plugins/plugin-sharing/src/objects/sys-sharing-rule.object.ts
+++ b/packages/plugins/plugin-sharing/src/objects/sys-sharing-rule.object.ts
@@ -136,6 +136,12 @@ export const SysSharingRule = ObjectSchema.create({
 
     criteria_json: Field.textarea({
       label: 'Criteria',
+      // [#3896] Mandatory in substance, `required: false` in metadata: the
+      // column is nullable in every already-deployed tenant (rows predating
+      // this gate), and flipping it to `required` would only translate into a
+      // destructive NOT NULL migration that those nulls block. The invariant
+      // is enforced where it can also explain itself — `bindRuleCriteriaGuard`
+      // fails the INSERT, and `defineRule` fails the API call.
       required: false,
       // Rendered as a visual criteria builder scoped to the selected object's
       // fields (dependsOn: object_name), storing the same JSON FilterCondition.
@@ -143,7 +149,10 @@ export const SysSharingRule = ObjectSchema.create({
       // editable. Falls back to a textarea when the widget is unavailable.
       widget: 'filter-condition',
       dependsOn: ['object_name'],
-      description: 'Which records to share. Leave empty to share every record of the object.',
+      // Deliberately NOT "leave empty to share everything" (#3896): an empty
+      // criteria never shared everything on purpose, it just failed open —
+      // ADR-0049 forbids the shape, and a rule saved without one is rejected.
+      description: 'Which records to share. Required — a rule must narrow the records it shares, so there is no "share every record" setting.',
       group: 'Target',
     }),
 

--- a/packages/plugins/plugin-sharing/src/rule-criteria.ts
+++ b/packages/plugins/plugin-sharing/src/rule-criteria.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Sharing-rule criteria normalisation + the ADR-0049 match-all guard (#3896).
+ *
+ * A sharing rule's `criteria` is the ONLY thing standing between a recipient
+ * and every row of the target object: the evaluator feeds it straight to
+ * `engine.find(object, { filter, context: SYSTEM_CTX })`. An absent or empty
+ * predicate is therefore not "no constraint" — it is **share everything**,
+ * which is exactly the shape `SharingRuleSchema` forbids:
+ *
+ * > A `condition` the compiler cannot lower … is skipped and logged — never
+ * > seeded as a permissive match-all (ADR-0049).
+ *
+ * The seed path honoured that; `defineRule` (and through it
+ * `POST {basePath}/sharing/rules`) and direct `sys_sharing_rule` writes did
+ * not — a missing, `null`, or misspelled (`criterias`) key was stored as
+ * `criteria_json: null` and evaluated as `{}`. These helpers are the single
+ * definition of "this predicate constrains nothing", used by every authoring
+ * entry (reject) and by the evaluator itself (match nothing, log) so rows
+ * written before the gate existed cannot over-share either.
+ */
+
+/**
+ * Normalise a stored / submitted criteria value into an engine
+ * `FilterCondition`, or `undefined` when it carries no usable predicate.
+ *
+ * A string is JSON-parsed; an unparsable one (most likely a CEL source typed
+ * into the Setup textarea, which the v1 evaluator does not lower) yields
+ * `undefined` rather than being passed through — the engine would ignore it
+ * and match every row.
+ */
+export function parseCriteria(raw: unknown): unknown | undefined {
+  if (raw == null || raw === '') return undefined;
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return undefined;
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      // Treat unparsable strings as opaque — most likely a CEL source
+      // that v1's evaluator doesn't grok yet; rule will match nothing.
+      return undefined;
+    }
+  }
+  return raw;
+}
+
+/**
+ * Does this criteria select EVERY record of its object?
+ *
+ * True for the shapes that reach the engine as an unconstrained filter:
+ * missing / `null` / `''` / unparsable JSON / `{}` / `[]` / a non-object
+ * scalar, and the empty or vacuous boolean combinators (`{ $and: [] }`,
+ * `{ $or: [ {} ] }`). Any concrete field predicate makes it false.
+ *
+ * Conservative by design: it answers "could this fail open?", so an
+ * ambiguous shape counts as match-all. Both consequences of a false positive
+ * are safe — an authoring call is rejected with a message naming the field,
+ * and an already-stored rule under-shares instead of over-sharing.
+ */
+export function isMatchAllCriteria(raw: unknown): boolean {
+  const parsed = parseCriteria(raw);
+  if (parsed == null) return true;
+  // An array is the implicit-AND condition list: empty (or all-vacuous)
+  // constrains nothing.
+  if (Array.isArray(parsed)) return parsed.every((c) => isMatchAllCriteria(c));
+  // A scalar (`true`, a number, …) is not a predicate the engine narrows on.
+  if (typeof parsed !== 'object') return true;
+
+  const entries = Object.entries(parsed as Record<string, unknown>);
+  if (entries.length === 0) return true;
+  for (const [key, value] of entries) {
+    if (key === '$and') {
+      // AND of nothing / of vacuous branches ⇒ still everything.
+      if (!Array.isArray(value) || value.every((c) => isMatchAllCriteria(c))) continue;
+      return false;
+    }
+    if (key === '$or') {
+      // OR is match-all as soon as ONE branch is; an empty OR has no
+      // portable meaning, so treat it as unconstrained too.
+      if (!Array.isArray(value) || value.length === 0 || value.some((c) => isMatchAllCriteria(c))) continue;
+      return false;
+    }
+    // A named field predicate — this narrows the result set.
+    return false;
+  }
+  return true;
+}
+
+/**
+ * The authoring rejection message. Names the offending shape rather than just
+ * "required": the reported trigger (#3896) was a typo — `criterias` instead of
+ * `criteria` — which a bare "field missing" would not explain.
+ */
+export const MATCH_ALL_CRITERIA_MESSAGE =
+  'criteria is required and must narrow the records it shares — missing, empty, ' +
+  'or unparsable criteria would share every record of the object, which a sharing ' +
+  'rule must never do (ADR-0049). Check for a misspelled key (e.g. `criterias`).';
+
+/**
+ * Field-level rejection for the data-API path.
+ *
+ * Structurally what `@objectstack/objectql`'s `ValidationError` is — REST maps
+ * on `code === 'VALIDATION_FAILED' || name === 'ValidationError'` and forwards
+ * `fields[]` — but declared locally so a security guard in a plugin never
+ * depends on another package's build output at runtime.
+ */
+export class SharingCriteriaValidationError extends Error {
+  readonly code = 'VALIDATION_FAILED';
+  readonly fields: Array<{ field: string; code: string; message: string }>;
+  constructor(field = 'criteria_json', message = MATCH_ALL_CRITERIA_MESSAGE) {
+    super(message);
+    this.name = 'ValidationError';
+    this.fields = [{ field, code: 'required', message }];
+  }
+}

--- a/packages/plugins/plugin-sharing/src/rule-hooks.ts
+++ b/packages/plugins/plugin-sharing/src/rule-hooks.ts
@@ -2,6 +2,7 @@
 
 import type { SharingRuleService } from './sharing-rule-service.js';
 import type { SharingRuleRow } from '@objectstack/spec/contracts';
+import { isMatchAllCriteria, SharingCriteriaValidationError } from './rule-criteria.js';
 
 const SYSTEM_CTX = { isSystem: true, positions: [], permissions: [] } as const;
 
@@ -14,6 +15,12 @@ export const SHARING_RULE_HOOK_PACKAGE = 'plugin-sharing:rules';
  * tear down the triggers that drive it.
  */
 export const RULE_REBIND_TRIGGER_PACKAGE = 'plugin-sharing:rule-rebind';
+
+/**
+ * Package id for the `sys_sharing_rule` criteria guard (#3896). Separate from
+ * both packages above so neither rebind can unregister it.
+ */
+export const RULE_CRITERIA_GUARD_PACKAGE = 'plugin-sharing:rule-criteria-guard';
 
 interface MinimalEngine {
   registerHook(event: string, handler: (ctx: any) => any | Promise<any>, options?: {
@@ -69,4 +76,41 @@ export function bindRuleHooks(
 
 export function unbindAllRuleHooks(engine: MinimalEngine): number {
   return engine.unregisterHooksByPackage(SHARING_RULE_HOOK_PACKAGE);
+}
+
+/**
+ * [#3896] Reject `sys_sharing_rule` writes whose criteria would share every
+ * record of the target object.
+ *
+ * `SharingRuleService.defineRule` gates the programmatic + REST
+ * (`POST {basePath}/sharing/rules`) entries, but authoring a rule in Setup is
+ * a plain data INSERT on this table — it never reaches that method. Without
+ * this hook the UI path keeps producing rules the evaluator now refuses to
+ * act on: safe, but silently inert, which is its own authoring trap
+ * (ADR-0078). Failing the write instead tells the admin the criteria is
+ * missing while they are still looking at the form.
+ *
+ * Update semantics are deliberately narrower than insert: only a patch that
+ * SUPPLIES `criteria_json` is checked. An existing row left over from before
+ * this guard has a null criteria, and an admin must still be able to
+ * `active: false` it — demanding a criteria to switch off an over-broad rule
+ * would be exactly backwards.
+ */
+export function bindRuleCriteriaGuard(engine: MinimalEngine, logger?: MinimalLogger): void {
+  if (typeof engine.registerHook !== 'function') return;
+  if (typeof engine.unregisterHooksByPackage === 'function') {
+    engine.unregisterHooksByPackage(RULE_CRITERIA_GUARD_PACKAGE);
+  }
+  const guard = (insert: boolean) => (ctx: any) => {
+    const data = ctx?.input?.data;
+    if (!data || typeof data !== 'object' || Array.isArray(data)) return;
+    const supplied = Object.prototype.hasOwnProperty.call(data, 'criteria_json');
+    if (!insert && !supplied) return;
+    if (!isMatchAllCriteria(data.criteria_json)) return;
+    throw new SharingCriteriaValidationError();
+  };
+  const opts = { object: 'sys_sharing_rule', packageId: RULE_CRITERIA_GUARD_PACKAGE, priority: 100 };
+  engine.registerHook('beforeInsert', guard(true), opts);
+  engine.registerHook('beforeUpdate', guard(false), opts);
+  logger?.info?.('[sharing-rule] criteria guard bound on sys_sharing_rule (ADR-0049)');
 }

--- a/packages/plugins/plugin-sharing/src/sharing-plugin.ts
+++ b/packages/plugins/plugin-sharing/src/sharing-plugin.ts
@@ -10,7 +10,7 @@ import { SharingService, type SharingEngine } from './sharing-service.js';
 import { SharingRuleService } from './sharing-rule-service.js';
 import { ShareLinkService } from './share-link-service.js';
 import { registerShareLinkRoutes } from './share-link-routes.js';
-import { bindRuleHooks, unbindAllRuleHooks, RULE_REBIND_TRIGGER_PACKAGE } from './rule-hooks.js';
+import { bindRuleHooks, unbindAllRuleHooks, bindRuleCriteriaGuard, RULE_REBIND_TRIGGER_PACKAGE } from './rule-hooks.js';
 import { bindRuleProvenanceStamp, unbindRuleProvenanceStamp } from './sharing-rule-provenance.js';
 import { bindPrimaryBuHooks, backfillPrimaryBu } from './primary-bu-projection.js';
 import { bootstrapDeclaredSharingRules } from './bootstrap-declared-sharing-rules.js';
@@ -449,6 +449,11 @@ export class SharingServicePlugin implements Plugin {
             unbindAllRuleHooks(engine);
             bindRuleHooks(engine, this.ruleService, rules, ctx.logger as any);
             this.bindRuleRebindTriggers(engine, ctx);
+
+            // [#3896] Authoring a rule in Setup is a plain INSERT on
+            // sys_sharing_rule — it bypasses defineRule's validation, so the
+            // match-all criteria gate has to sit on the table itself too.
+            bindRuleCriteriaGuard(engine, ctx.logger as any);
 
             // [#2909 T1] Stamp `customized` on admin edits of seeded rules so
             // the boot seeder stops overwriting them (seed-not-clobber).

--- a/packages/plugins/plugin-sharing/src/sharing-rule-service.ts
+++ b/packages/plugins/plugin-sharing/src/sharing-rule-service.ts
@@ -12,6 +12,7 @@ import type {
 import type { SharingEngine } from './sharing-service.js';
 import type { SharingService } from './sharing-service.js';
 import { normalizeAccessLevel, normalizeStoredAccessLevel } from './access-level.js';
+import { parseCriteria, isMatchAllCriteria, MATCH_ALL_CRITERIA_MESSAGE } from './rule-criteria.js';
 import { TeamGraphService } from './team-graph.js';
 import { PositionGraphService } from './position-graph.js';
 import { BusinessUnitGraphService } from './business-unit-graph.js';
@@ -22,22 +23,6 @@ function uid(prefix: string): string {
   const g: any = globalThis as any;
   if (g.crypto?.randomUUID) return `${prefix}_${g.crypto.randomUUID()}`;
   return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
-}
-
-function parseCriteria(raw: unknown): unknown | undefined {
-  if (raw == null || raw === '') return undefined;
-  if (typeof raw === 'string') {
-    const trimmed = raw.trim();
-    if (!trimmed) return undefined;
-    try {
-      return JSON.parse(trimmed);
-    } catch {
-      // Treat unparsable strings as opaque — most likely a CEL source
-      // that v1's evaluator doesn't grok yet; rule will match nothing.
-      return undefined;
-    }
-  }
-  return raw;
 }
 
 function rowFromRule(row: any): SharingRuleRow {
@@ -95,6 +80,18 @@ export class SharingRuleService implements ISharingRuleService {
     if (!input.object) throw new Error('VALIDATION_FAILED: object is required');
     if (!input.recipientType) throw new Error('VALIDATION_FAILED: recipientType is required');
     if (!input.recipientId) throw new Error('VALIDATION_FAILED: recipientId is required');
+    // [#3896] `criteria` is as required as the fields above — and for a
+    // sharper reason. Omitting `recipientId` yields a rule that shares with
+    // nobody; omitting `criteria` used to yield one that shares EVERYTHING
+    // (stored as `criteria_json: null`, evaluated as the empty filter `{}`
+    // against SYSTEM_CTX). `SharingRuleSchema` has always forbidden that
+    // shape — "never seeded as a permissive match-all (ADR-0049)" — but this
+    // entry, which `POST {basePath}/sharing/rules` plucks its body into, never
+    // ran the schema, so a missing / null / misspelled (`criterias`) key
+    // sailed through with a 201 and no warning.
+    if (isMatchAllCriteria(input.criteria)) {
+      throw new Error(`VALIDATION_FAILED: ${MATCH_ALL_CRITERIA_MESSAGE}`);
+    }
 
     const orgId = (context as any)?.organizationId ?? (context as any)?.tenantId ?? null;
     const now = new Date().toISOString();
@@ -267,7 +264,26 @@ export class SharingRuleService implements ISharingRuleService {
 
   // ── internals ─────────────────────────────────────────────────────
 
+  /**
+   * [#3896] ADR-0049 backstop, evaluated on EVERY pass rather than only at
+   * authoring time: `defineRule` now rejects a match-all criteria, but rows
+   * predating that gate — or written straight to `sys_sharing_rule` through
+   * the data API (what the Setup UI's create action issues) — are already in
+   * the table. Such a rule matches NOTHING and says so in the log, so the
+   * next reconcile revokes whatever it had granted instead of re-granting the
+   * whole object. Under-sharing loudly beats over-sharing silently.
+   */
+  private isInertMatchAll(rule: SharingRuleRow): boolean {
+    if (!isMatchAllCriteria(rule.criteria)) return false;
+    this.logger?.warn?.(
+      '[sharing-rule] rule has no usable criteria — matching NO records instead of every record (ADR-0049)',
+      { rule: rule.name, object: rule.object_name },
+    );
+    return true;
+  }
+
   private async findMatchingRecords(rule: SharingRuleRow): Promise<string[]> {
+    if (this.isInertMatchAll(rule)) return [];
     const filter = (rule.criteria ?? {}) as any;
     try {
       const rows = await this.engine.find(rule.object_name, {
@@ -284,6 +300,7 @@ export class SharingRuleService implements ISharingRuleService {
   }
 
   private async recordMatches(rule: SharingRuleRow, recordId: string): Promise<boolean> {
+    if (this.isInertMatchAll(rule)) return false;
     const filter = { ...((rule.criteria ?? {}) as any), id: recordId };
     try {
       const rows = await this.engine.find(rule.object_name, {

--- a/packages/plugins/plugin-sharing/src/sharing-rule.test.ts
+++ b/packages/plugins/plugin-sharing/src/sharing-rule.test.ts
@@ -1,13 +1,21 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { SharingService } from './sharing-service.js';
 import { SharingRuleService } from './sharing-rule-service.js';
 import { TeamGraphService, expandPrincipal } from './team-graph.js';
 import { BusinessUnitGraphService } from './business-unit-graph.js';
 import { celToFilter } from './bootstrap-declared-sharing-rules.js';
+import { isMatchAllCriteria } from './rule-criteria.js';
+import { bindRuleCriteriaGuard } from './rule-hooks.js';
 
 interface Row { [k: string]: any }
+
+/** Stored criteria of a rule row, parsed back out of `criteria_json`. */
+function rowCriteria(engine: { _tables: Record<string, Row[]> }, id: string): unknown {
+  const row = (engine._tables.sys_sharing_rule ?? []).find((r) => r.id === id);
+  return row?.criteria_json == null ? undefined : JSON.parse(row.criteria_json);
+}
 
 function makeEngine() {
   const tables: Record<string, Row[]> = {};
@@ -226,8 +234,8 @@ describe('SharingRuleService', () => {
   });
 
   it('defineRule upserts on duplicate name within org', async () => {
-    await rules.defineRule({ name: 'x', label: 'X', object: 'opportunity', recipientType: 'user', recipientId: 'a' }, SYS);
-    await rules.defineRule({ name: 'x', label: 'X-renamed', object: 'opportunity', recipientType: 'user', recipientId: 'b' }, SYS);
+    await rules.defineRule({ name: 'x', label: 'X', object: 'opportunity', criteria: { amount: 200000 }, recipientType: 'user', recipientId: 'a' }, SYS);
+    await rules.defineRule({ name: 'x', label: 'X-renamed', object: 'opportunity', criteria: { amount: 200000 }, recipientType: 'user', recipientId: 'b' }, SYS);
     expect(engine._tables.sys_sharing_rule).toHaveLength(1);
     expect(engine._tables.sys_sharing_rule[0].label).toBe('X-renamed');
     expect(engine._tables.sys_sharing_rule[0].recipient_id).toBe('b');
@@ -332,9 +340,10 @@ describe('SharingRuleService', () => {
   });
 
   it('listRules filters by object + activeOnly', async () => {
-    await rules.defineRule({ name: 'a', label: 'A', object: 'opportunity', recipientType: 'user', recipientId: 'x' }, SYS);
-    await rules.defineRule({ name: 'b', label: 'B', object: 'account',     recipientType: 'user', recipientId: 'y' }, SYS);
-    await rules.defineRule({ name: 'c', label: 'C', object: 'opportunity', recipientType: 'user', recipientId: 'z', active: false }, SYS);
+    const anyOpen = { stage: 'open' };
+    await rules.defineRule({ name: 'a', label: 'A', object: 'opportunity', criteria: anyOpen, recipientType: 'user', recipientId: 'x' }, SYS);
+    await rules.defineRule({ name: 'b', label: 'B', object: 'account',     criteria: anyOpen, recipientType: 'user', recipientId: 'y' }, SYS);
+    await rules.defineRule({ name: 'c', label: 'C', object: 'opportunity', criteria: anyOpen, recipientType: 'user', recipientId: 'z', active: false }, SYS);
     const opps = await rules.listRules({ object: 'opportunity' }, SYS);
     expect(opps).toHaveLength(2);
     const active = await rules.listRules({ object: 'opportunity', activeOnly: true }, SYS);
@@ -411,5 +420,216 @@ describe('#1887 — compound sharing condition compiled + enforced (ADR-0058 D3)
       .filter((sh: any) => sh.recipient_id === 'alice')
       .map((sh: any) => sh.record_id);
     expect(shared).toEqual(['opp1']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #3896 — a rule with no criteria must share NOTHING, never everything
+//
+// `SharingRuleSchema` requires `condition` and its doc is explicit: a
+// predicate the compiler cannot lower is "skipped and logged — never seeded as
+// a permissive match-all (ADR-0049)". The seed path honoured that; the two
+// other ways to create a rule did not:
+//
+//   1. `defineRule` — which `POST {basePath}/sharing/rules` plucks its body
+//      into without ever running the schema. A missing, null, or MISSPELLED
+//      (`criterias`) key stored `criteria_json: null`, returned 201, and then
+//      evaluated as `find(object, { filter: {}, context: SYSTEM_CTX })` —
+//      every record of the object, granted to the recipient.
+//   2. A direct `sys_sharing_rule` insert, which is what authoring a rule in
+//      the Setup UI issues.
+//
+// Both are now refused, and the evaluator refuses to act on such a row
+// regardless of how it got there — so rules stored before this gate existed
+// under-share instead of over-sharing.
+// ---------------------------------------------------------------------------
+describe('#3896 — missing criteria never becomes "share every record" (ADR-0049)', () => {
+  let engine: ReturnType<typeof makeEngine>;
+  let sharing: SharingService;
+  let rules: SharingRuleService;
+  const SYS = { isSystem: true, organizationId: 'org1' } as any;
+  const BASE = {
+    name: 'won_deals', label: 'Won Deals', object: 'opportunity',
+    recipientType: 'position' as const, recipientId: 'sales_rep', accessLevel: 'read' as const,
+  };
+
+  beforeEach(() => {
+    engine = makeEngine();
+    engine._tables.opportunity = [
+      { id: 'opp1', stage: 'won',  amount: 200000 },
+      { id: 'opp2', stage: 'lost', amount: 150000 },
+      { id: 'opp3', stage: 'open', amount: 5000 },
+    ];
+    sharing = new SharingService({ engine: engine as any });
+    rules = new SharingRuleService({ engine: engine as any, sharing });
+  });
+
+  describe('isMatchAllCriteria', () => {
+    it('flags every shape that reaches the engine as an unconstrained filter', () => {
+      for (const shape of [undefined, null, '', '   ', {}, [], '{}', '[]', true, 42,
+                           { $and: [] }, { $or: [] }, { $and: [{}] }, { $or: [{ a: 1 }, {}] },
+                           'record.stage == "won"' /* CEL, not JSON — engine ignores it */]) {
+        expect(isMatchAllCriteria(shape), `${JSON.stringify(shape) ?? String(shape)} should be match-all`).toBe(true);
+      }
+    });
+
+    it('passes anything that actually narrows the result set', () => {
+      for (const shape of [{ stage: 'won' }, '{"stage":"won"}', { amount: { $gte: 1 } },
+                           [{ stage: 'won' }], { $and: [{ stage: 'won' }] }, { $or: [{ a: 1 }, { b: 2 }] }]) {
+        expect(isMatchAllCriteria(shape), `${JSON.stringify(shape)} should NOT be match-all`).toBe(false);
+      }
+    });
+  });
+
+  describe('defineRule (the REST + programmatic entry)', () => {
+    it('rejects the reported typo — `criterias` instead of `criteria` — instead of sharing everything', async () => {
+      // Verbatim from the issue: the author means "share won deals" and the
+      // extra key is dropped by the REST pluck, leaving criteria undefined.
+      await expect(
+        rules.defineRule({ ...BASE, criterias: { stage: 'won' } } as any, SYS),
+      ).rejects.toThrow(/VALIDATION_FAILED/);
+      expect(engine._tables.sys_sharing_rule ?? []).toHaveLength(0);
+    });
+
+    it('rejects every match-all criteria shape, writing no row', async () => {
+      for (const criteria of [undefined, null, '', {}, [], '{}', { $and: [] }, 'record.stage == "won"']) {
+        await expect(
+          rules.defineRule({ ...BASE, criteria } as any, SYS),
+          `criteria=${JSON.stringify(criteria) ?? 'undefined'}`,
+        ).rejects.toThrow(/VALIDATION_FAILED: criteria is required/);
+      }
+      expect(engine._tables.sys_sharing_rule ?? []).toHaveLength(0);
+    });
+
+    it('names the field and the misspelling risk so the 400 is actionable', async () => {
+      await expect(rules.defineRule({ ...BASE } as any, SYS)).rejects.toThrow(/criterias/);
+    });
+
+    it('still accepts a real predicate (the guard is not a blanket refusal)', async () => {
+      const r = await rules.defineRule({ ...BASE, criteria: { stage: 'won' } }, SYS);
+      expect(r.criteria).toEqual({ stage: 'won' });
+      const res = await rules.evaluateRule(r.id, SYS);
+      expect(res.matchedRecords).toBe(1);
+    });
+
+    it('rejects an UPSERT that would widen an existing rule to match-all', async () => {
+      const r = await rules.defineRule({ ...BASE, criteria: { stage: 'won' } }, SYS);
+      await expect(rules.defineRule({ ...BASE, criteria: {} } as any, SYS)).rejects.toThrow(/VALIDATION_FAILED/);
+      // The stored rule keeps its original narrow criteria.
+      expect(rowCriteria(engine, r.id)).toEqual({ stage: 'won' });
+    });
+  });
+
+  describe('evaluator backstop (rows that predate the gate / bypass defineRule)', () => {
+    /** A row as the Setup UI's data-API insert would leave it: no criteria. */
+    function seedRawRule(overrides: Record<string, any> = {}): string {
+      const id = 'srule_legacy';
+      (engine._tables.sys_sharing_rule ??= []).push({
+        id, organization_id: 'org1', name: 'legacy_all', label: 'Legacy',
+        object_name: 'opportunity', criteria_json: null,
+        recipient_type: 'user', recipient_id: 'alice',
+        access_level: 'read', active: true, ...overrides,
+      });
+      return id;
+    }
+
+    it('THE GATE: a rule with missing criteria produces NO sys_record_share row', async () => {
+      const id = seedRawRule();
+      const res = await rules.evaluateRule(id, SYS);
+      expect(res.matchedRecords).toBe(0);
+      expect(res.grantsCreated).toBe(0);
+      expect(engine._tables.sys_record_share ?? []).toHaveLength(0);
+    });
+
+    it('revokes grants a match-all rule had already materialised', async () => {
+      const id = seedRawRule();
+      // Pretend a pre-fix boot had already shared the whole object.
+      for (const recordId of ['opp1', 'opp2', 'opp3']) {
+        await sharing.grant({
+          object: 'opportunity', recordId, recipientType: 'user', recipientId: 'alice',
+          accessLevel: 'read', source: 'rule', sourceId: id, reason: 'rule:legacy_all',
+        } as any, SYS);
+      }
+      expect(engine._tables.sys_record_share).toHaveLength(3);
+      const res = await rules.evaluateRule(id, SYS);
+      expect(res.grantsRevoked).toBe(3);
+      expect(engine._tables.sys_record_share).toHaveLength(0);
+    });
+
+    it('logs the refusal rather than failing silently', async () => {
+      const warn = vi.fn();
+      const svc = new SharingRuleService({ engine: engine as any, sharing, logger: { warn } });
+      await svc.evaluateRule(seedRawRule(), SYS);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('ADR-0049'), expect.objectContaining({ rule: 'legacy_all' }));
+    });
+
+    it('the per-record path (write hooks) refuses too — recordMatches is not a second hole', async () => {
+      seedRawRule();
+      const res = await rules.evaluateAllForRecord('opportunity', 'opp1', SYS);
+      expect(res[0].matchedRecords).toBe(0);
+      expect(res[0].grantsCreated).toBe(0);
+      expect(engine._tables.sys_record_share ?? []).toHaveLength(0);
+    });
+
+    it('an unparsable criteria_json (a CEL source typed into the textarea) is inert, not match-all', async () => {
+      const id = seedRawRule({ criteria_json: 'record.stage == "won"' });
+      const res = await rules.evaluateRule(id, SYS);
+      expect(res.matchedRecords).toBe(0);
+      expect(engine._tables.sys_record_share ?? []).toHaveLength(0);
+    });
+  });
+
+  describe('bindRuleCriteriaGuard (the Setup UI data-API entry)', () => {
+    function makeHookEngine() {
+      const hooks: Array<{ event: string; handler: (ctx: any) => any; options: any }> = [];
+      return {
+        hooks,
+        registerHook(event: string, handler: (ctx: any) => any, options: any = {}) { hooks.push({ event, handler, options }); },
+        unregisterHooksByPackage(packageId: string) {
+          let removed = 0;
+          for (let i = hooks.length - 1; i >= 0; i--) if (hooks[i].options.packageId === packageId) { hooks.splice(i, 1); removed++; }
+          return removed;
+        },
+        async fire(event: string, data: any, id?: string) {
+          for (const h of hooks.filter((x) => x.event === event)) await h.handler({ input: { data, id } });
+        },
+      };
+    }
+
+    it('fails the INSERT of a rule with no criteria_json', async () => {
+      const e = makeHookEngine();
+      bindRuleCriteriaGuard(e as any);
+      await expect(e.fire('beforeInsert', { name: 'all_opps', object_name: 'opportunity', recipient_id: 'alice' }))
+        .rejects.toThrow(/criteria is required/);
+      await expect(e.fire('beforeInsert', { name: 'all_opps', criteria_json: '{}' })).rejects.toThrow(/criteria is required/);
+    });
+
+    it('reports the failure as a field-level VALIDATION_FAILED (a 400, not a 500)', async () => {
+      const e = makeHookEngine();
+      bindRuleCriteriaGuard(e as any);
+      const err = await e.fire('beforeInsert', { name: 'all_opps' }).catch((x: any) => x);
+      expect(err.code).toBe('VALIDATION_FAILED');
+      expect(err.fields).toEqual([expect.objectContaining({ field: 'criteria_json' })]);
+    });
+
+    it('allows an insert that carries a real predicate', async () => {
+      const e = makeHookEngine();
+      bindRuleCriteriaGuard(e as any);
+      await expect(e.fire('beforeInsert', { name: 'won', criteria_json: '{"stage":"won"}' })).resolves.toBeUndefined();
+    });
+
+    it('lets an admin DEACTIVATE a legacy criteria-less rule (patch does not supply criteria_json)', async () => {
+      const e = makeHookEngine();
+      bindRuleCriteriaGuard(e as any);
+      // The whole point of the update carve-out: switching off an over-broad
+      // rule must not require first inventing a criteria for it.
+      await expect(e.fire('beforeUpdate', { active: false }, 'srule_legacy')).resolves.toBeUndefined();
+    });
+
+    it('still rejects an update that BLANKS the criteria of a live rule', async () => {
+      const e = makeHookEngine();
+      bindRuleCriteriaGuard(e as any);
+      await expect(e.fire('beforeUpdate', { criteria_json: '' }, 'srule_1')).rejects.toThrow(/criteria is required/);
+    });
   });
 });

--- a/packages/plugins/plugin-sharing/src/translations/en.objects.generated.ts
+++ b/packages/plugins/plugin-sharing/src/translations/en.objects.generated.ts
@@ -126,7 +126,7 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
       },
       criteria_json: {
         label: "Criteria",
-        help: "Which records to share. Leave empty to share every record of the object."
+        help: "Which records to share. Required \u2014 a rule must narrow the records it shares, so there is no \"share every record\" setting."
       },
       recipient_type: {
         label: "Recipient Type",

--- a/packages/plugins/plugin-sharing/src/translations/en.objects.generated.ts
+++ b/packages/plugins/plugin-sharing/src/translations/en.objects.generated.ts
@@ -126,7 +126,7 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
       },
       criteria_json: {
         label: "Criteria",
-        help: "Which records to share. Required \u2014 a rule must narrow the records it shares, so there is no \"share every record\" setting."
+        help: "Which records to share. Required — a rule must narrow the records it shares, so there is no \"share every record\" setting."
       },
       recipient_type: {
         label: "Recipient Type",

--- a/packages/plugins/plugin-sharing/src/translations/es-ES.objects.generated.ts
+++ b/packages/plugins/plugin-sharing/src/translations/es-ES.objects.generated.ts
@@ -126,7 +126,7 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
       },
       criteria_json: {
         label: "Criterios",
-        help: "Qué registros se comparten. Déjalo vacío para compartir todos los registros del objeto."
+        help: "Qué registros se comparten. Obligatorio: una regla debe acotar los registros que comparte, por lo que no existe la opción de «compartir todos los registros»."
       },
       recipient_type: {
         label: "Tipo de destinatario",

--- a/packages/plugins/plugin-sharing/src/translations/ja-JP.objects.generated.ts
+++ b/packages/plugins/plugin-sharing/src/translations/ja-JP.objects.generated.ts
@@ -126,7 +126,7 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
       },
       criteria_json: {
         label: "条件",
-        help: "どのレコードを共有するか。空欄にすると、そのオブジェクトのすべてのレコードを共有します。"
+        help: "どのレコードを共有するか。必須です。ルールは共有範囲を必ず絞り込む必要があるため、「すべてのレコードを共有する」設定はありません。"
       },
       recipient_type: {
         label: "受信者タイプ",

--- a/packages/plugins/plugin-sharing/src/translations/zh-CN.objects.generated.ts
+++ b/packages/plugins/plugin-sharing/src/translations/zh-CN.objects.generated.ts
@@ -126,7 +126,7 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
       },
       criteria_json: {
         label: "条件",
-        help: "共享哪些记录。留空表示共享该对象的全部记录。"
+        help: "共享哪些记录。必填 —— 规则必须缩小共享范围，因此没有「共享全部记录」这一选项。"
       },
       recipient_type: {
         label: "接收方类型",

--- a/packages/qa/dogfood/package.json
+++ b/packages/qa/dogfood/package.json
@@ -19,6 +19,7 @@
     "@objectstack/plugin-audit": "workspace:*",
     "@objectstack/plugin-auth": "workspace:*",
     "@objectstack/plugin-security": "workspace:*",
+    "@objectstack/plugin-sharing": "workspace:*",
     "@objectstack/plugin-webhooks": "workspace:*",
     "@objectstack/service-analytics": "workspace:*",
     "@objectstack/service-messaging": "workspace:*",

--- a/packages/qa/dogfood/test/sharing-rule-criteria-required.dogfood.test.ts
+++ b/packages/qa/dogfood/test/sharing-rule-criteria-required.dogfood.test.ts
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// #3896 — `POST /api/v1/sharing/rules` must not turn a missing criteria into
+// "share every record of this object". (The issue calls the route
+// `/data/sharing/rules`; sharing-rule routes are actually anchored on the API
+// base, since they administer rules tenant-wide rather than acting on one CRUD
+// object. Same handler, same bug.)
+//
+// The endpoint plucks its body field-by-field into
+// `SharingRuleService.defineRule`; `SharingRuleSchema` is never on that path.
+// So a rule authored with a MISSPELLED criteria key (`criterias`) — or none at
+// all — used to be stored with `criteria_json: null`, answered 201 with no
+// warning, and then evaluated as `find(object, { filter: {} })` under the
+// system context: every record of the object, granted to the recipient.
+// `SharingRuleSchema` forbids exactly that shape ("never seeded as a
+// permissive match-all", ADR-0049); the seed path honoured it and this entry
+// did not.
+//
+// Driven over real HTTP against a booted stack, because the bug lived in the
+// gap between the schema and the transport — a unit test on the schema is what
+// missed it the first time.
+//
+// @proof: sharing-rule-criteria-required
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import showcaseStack from '@objectstack/example-showcase';
+import { bootStack, type VerifyStack } from '@objectstack/verify';
+
+// Sharing-rule routes are anchored on the API base, not under `/data/:object`
+// (they administer rules tenant-wide) — `/api/v1/sharing/rules`.
+const RULES = '/sharing/rules';
+const SYS = { isSystem: true } as const;
+const OBJECT = 'showcase_project';
+/** Package id of the sys_sharing_rule criteria guard (plugin-sharing). */
+const GUARD_PACKAGE = 'plugin-sharing:rule-criteria-guard';
+
+describe('#3896 — a sharing rule POSTed without criteria is rejected, never made match-all', () => {
+  let stack: VerifyStack;
+  let ql: any;
+  let admin: string;
+
+  beforeAll(async () => {
+    stack = await bootStack(showcaseStack);
+    admin = await stack.signIn();
+    ql = await stack.kernel.getServiceAsync('objectql');
+  }, 90_000);
+
+  afterAll(async () => { await stack?.stop(); });
+
+  /** Rule rows currently stored for the target object. */
+  const storedRules = async () =>
+    (await ql.find('sys_sharing_rule', { where: { object_name: OBJECT }, context: SYS })) ?? [];
+
+  it('THE REPORTED CASE: `criterias` (typo) is a 400, not a 201 sharing the whole object', async () => {
+    const before = (await storedRules()).length;
+    const res = await stack.apiAs(admin, 'POST', RULES, {
+      name: 'won_deals_3896',
+      label: 'Won Deals',
+      object: OBJECT,
+      recipientType: 'position',
+      recipientId: 'sales_rep',
+      // The typo from the issue: intent is "share red projects", but the key
+      // the endpoint reads is `criteria`, so this one is dropped.
+      criterias: { health: 'red' },
+    });
+
+    expect(res.status, 'misspelled criteria must not be accepted').toBe(400);
+    const body: any = await res.json();
+    expect(body.code).toBe('VALIDATION_FAILED');
+    expect(String(body.error)).toMatch(/criteria/i);
+
+    // Nothing was stored, so nothing can be evaluated into grants later.
+    expect(await storedRules()).toHaveLength(before);
+  });
+
+  it('an omitted criteria is a 400 too (the forgot-a-field and half-filled-form cases)', async () => {
+    for (const body of [
+      { name: 'no_criteria_3896', label: 'No criteria', object: OBJECT, recipientType: 'position', recipientId: 'sales_rep' },
+      { name: 'null_criteria_3896', label: 'Null criteria', object: OBJECT, recipientType: 'position', recipientId: 'sales_rep', criteria: null },
+      { name: 'empty_criteria_3896', label: 'Empty criteria', object: OBJECT, recipientType: 'position', recipientId: 'sales_rep', criteria: {} },
+    ]) {
+      const res = await stack.apiAs(admin, 'POST', RULES, body);
+      expect(res.status, `${body.name} must be rejected`).toBe(400);
+      expect((await res.json() as any).code).toBe('VALIDATION_FAILED');
+    }
+  });
+
+  it('a rule WITH a criteria still saves and evaluates (the gate is not a blanket refusal)', async () => {
+    const res = await stack.apiAs(admin, 'POST', RULES, {
+      name: 'red_projects_3896',
+      label: 'Red projects',
+      object: OBJECT,
+      recipientType: 'position',
+      recipientId: 'sales_rep',
+      criteria: { health: 'red' },
+      accessLevel: 'read',
+    });
+    expect(res.status, 'a real predicate is accepted').toBe(201);
+    const row: any = await res.json();
+    expect(row.criteria).toEqual({ health: 'red' });
+
+    const evaluated = await stack.apiAs(admin, 'POST', `${RULES}/${row.id}/evaluate`, {});
+    expect(evaluated.status).toBeLessThan(300);
+
+    // Every record it shared actually satisfies the predicate — the rule did
+    // not quietly widen to the whole object.
+    const shares = await ql.find('sys_record_share', {
+      where: { source: 'rule', source_id: row.id }, context: SYS,
+    });
+    for (const share of shares ?? []) {
+      const rec = await ql.findOne(OBJECT, { where: { id: share.record_id }, context: SYS });
+      expect(rec?.health, 'every shared record satisfies the predicate').toBe('red');
+    }
+  });
+
+  it('the criteria guard is live on the real engine — a direct insert is refused too', async () => {
+    // This is the Setup UI's authoring path: a plain data insert that never
+    // reaches defineRule.
+    await expect(ql.insert('sys_sharing_rule', {
+      id: 'srule_3896_direct',
+      name: 'direct_match_all_3896',
+      label: 'Direct match-all',
+      object_name: OBJECT,
+      recipient_type: 'position',
+      recipient_id: 'sales_rep',
+      access_level: 'read',
+      active: true,
+    }, { context: SYS })).rejects.toThrow(/criteria is required/);
+  });
+
+  it('a criteria-less rule already IN the table shares nothing and loses its grants', async () => {
+    // Reproduce a row from BEFORE the guard existed: drop the guard hooks,
+    // write the row, put them back. Nothing else can produce this shape now —
+    // which is the point of the previous test.
+    const id = 'srule_3896_legacy';
+    ql.unregisterHooksByPackage(GUARD_PACKAGE);
+    try {
+      await ql.insert('sys_sharing_rule', {
+        id,
+        name: 'legacy_match_all_3896',
+        label: 'Legacy match-all',
+        object_name: OBJECT,
+        criteria_json: null,
+        recipient_type: 'position',
+        recipient_id: 'sales_rep',
+        access_level: 'read',
+        active: true,
+      }, { context: SYS });
+    } finally {
+      const { bindRuleCriteriaGuard } = await import('@objectstack/plugin-sharing');
+      bindRuleCriteriaGuard(ql);
+    }
+
+    const res = await stack.apiAs(admin, 'POST', `${RULES}/${id}/evaluate`, {});
+    expect(res.status).toBeLessThan(300);
+    const result: any = await res.json();
+    expect(result.matchedRecords ?? result.data?.matchedRecords, 'matches NO records, not every record').toBe(0);
+
+    const shares = await ql.find('sys_record_share', {
+      where: { source: 'rule', source_id: id }, context: SYS,
+    });
+    expect(shares ?? [], 'no grants materialised from a match-all rule').toHaveLength(0);
+  });
+});

--- a/packages/qa/dogfood/test/showcase-bu-hierarchy-sharing.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-bu-hierarchy-sharing.dogfood.test.ts
@@ -56,13 +56,16 @@ describe('showcase: business-unit hierarchy sharing rule (ADR-0057 D6 / #2077)',
       noteId = row?.id;
     }
 
-    // Define a sharing rule: share ALL private notes with the PARENT business
+    // Define a sharing rule: share the BU-shared note with the PARENT business
     // unit (and, via the tree, its descendants). Recipient = business_unit.
+    // The criteria is not optional — a rule without one would share every
+    // record of the object, which defineRule now rejects (#3896).
     const rules: any = stack.kernel.getService('sharingRules');
     await rules.defineRule({
       name: 'share_notes_with_region',
       label: 'Notes → Region (BU subtree)',
       object: 'showcase_private_note',
+      criteria: { title: 'BU-shared note' },
       recipientType: 'business_unit',
       recipientId: 'bu_h_parent',
       accessLevel: 'read',

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -5778,12 +5778,20 @@ export class RestServer {
                     const svc = await resolveService(environmentId);
                     if (!svc) return respond501(res);
                     const body = req.body ?? {};
+                    // Field-by-field pluck (not a schema parse): the authoring
+                    // spec shape — CEL `condition` + `sharedWith{type,value}` —
+                    // is not the runtime shape this endpoint takes, so unknown
+                    // keys are dropped rather than rejected. [#3896] That made
+                    // a typo (`criterias`) indistinguishable from "no criteria",
+                    // which used to mean "share every record". `defineRule` now
+                    // refuses a match-all criteria, so the typo surfaces as a
+                    // 400 naming the field instead of a silent 201.
                     const input = {
                         name: body.name,
                         label: body.label,
                         description: body.description,
                         object: body.object ?? body.object_name,
-                        criteria: body.criteria,
+                        criteria: body.criteria ?? body.criteria_json,
                         recipientType: body.recipientType ?? body.recipient_type,
                         recipientId: body.recipientId ?? body.recipient_id,
                         accessLevel: body.accessLevel ?? body.access_level,

--- a/packages/spec/src/security/sharing.zod.ts
+++ b/packages/spec/src/security/sharing.zod.ts
@@ -146,6 +146,17 @@ export const CriteriaSharingRuleSchema = lazySchema(() => BaseSharingRuleSchema.
  * (functions, cross-object traversal) is skipped and logged — never seeded as
  * a permissive match-all (ADR-0049).
  *
+ * That last sentence is a claim about the RUNTIME, not merely about this
+ * schema, and #3896 found the two entries that were not holding it up: the
+ * REST `POST {basePath}/sharing/rules` → `SharingRuleService.defineRule` path
+ * (which plucks a body rather than parsing it here, so a missing or misspelled
+ * `criteria` became `criteria_json: null` → the empty filter → every record of
+ * the object), and a direct `sys_sharing_rule` insert, which is what authoring
+ * a rule in Setup issues. Both now reject a match-all criteria, and the
+ * evaluator treats one as matching NOTHING — see `plugin-sharing`'s
+ * `rule-criteria.ts`. Anything added to this surface owes the same check: an
+ * authoring shape is only as safe as the least-validating path that writes it.
+ *
  * Kept as the `SharingRuleType`-discriminated form so a future enforced rule
  * type (e.g. membership-reactive owner-based) re-joins as a union member.
  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1610,6 +1610,9 @@ importers:
       '@objectstack/plugin-security':
         specifier: workspace:*
         version: link:../../plugins/plugin-security
+      '@objectstack/plugin-sharing':
+        specifier: workspace:*
+        version: link:../../plugins/plugin-sharing
       '@objectstack/plugin-webhooks':
         specifier: workspace:*
         version: link:../../plugins/plugin-webhooks


### PR DESCRIPTION
Closes #3896.

## The bug, and where it actually was

`SharingRuleSchema` requires `condition` and states the invariant plainly: a predicate the compiler cannot lower is *"skipped and logged — never seeded as a permissive match-all (ADR-0049)"*. The seed path honoured that. **Three** other paths did not:

1. **`SharingRuleService.defineRule`** — validated `name` / `label` / `object` / `recipientType` / `recipientId`, and not `criteria`. This is what `POST /api/v1/sharing/rules` plucks its body into; the schema is never on that path. A missing, `null`, or misspelled (`criterias`) key was stored as `criteria_json: null`, answered `201` with no warning, and evaluated as `find(object, { filter: {} })` under `SYSTEM_CTX` — every record of the object, up to 5000, granted to the recipient.
2. **A direct `sys_sharing_rule` insert** — which is what authoring a rule in Setup issues. It never reaches `defineRule` at all, so fixing only the REST entry would have left this open.
3. **The seed bootstrap's own `// Empty condition = match-all (intentional)` branch** — the one line contradicting its file header.

Same failure mode, one more way in: a CEL source typed into the Criteria textarea. `parseCriteria` returns `undefined` for unparsable strings, so it also evaluated as match-all.

Triggering any of these took a typo, not an attacker.

**Route correction for anyone following the issue:** it is `POST /api/v1/sharing/rules`, not `/api/v1/data/sharing/rules` as the title says — sharing-rule routes anchor on the API base because they administer rules tenant-wide rather than acting on one CRUD object. Same handler, same bug.

## The fix

Three layers, because the three entries fail differently:

- **`defineRule` rejects a match-all criteria** with `VALIDATION_FAILED`, alongside its other required fields. Covers the REST endpoint, programmatic callers, and the seeder. Rejected: missing / `null` / `''` / `{}` / `[]` / `{ $and: [] }` / unparsable JSON.
- **The evaluator matches NOTHING** for such a rule and logs why — in both `findMatchingRecords` and `recordMatches`. This is the layer that matters for already-deployed tenants: a row stored before this gate under-shares instead of over-sharing, and the next reconcile *revokes* the grants it had materialised.
- **`bindRuleCriteriaGuard`** fails `sys_sharing_rule` inserts as a field-level `VALIDATION_FAILED` (a 400 naming `criteria_json`), so Setup reports the problem instead of saving a rule that merely does nothing (ADR-0078). Updates are checked only when the patch supplies `criteria_json` — switching an over-broad legacy rule *off* must not require inventing a criteria for it first.

Plus: the bootstrap's empty-condition branch is gone, and the endpoint now accepts `criteria_json` as an alias for `criteria`, matching the snake_case aliases it already took for the other fields.

## Is empty criteria ever legitimate? No — and now it says so

The issue asked for this to be adjudicated. There is no "share every record" sharing rule; that shape only ever existed as a failure mode. Object-wide read is the object's organization-wide default (`sharingModel`).

`criteria_json` stays `required: true`-in-substance but `required: false` in metadata, **deliberately**: the column is nullable in every deployed tenant, so flipping it produces a *destructive* `NOT NULL` migration that those very nulls block (`schema-drift.ts` classifies it as `severity: error` / `category: destructive`). The invariant is enforced in the two places that can also explain themselves. Its field description — and all four locale bundles — said *"leave empty to share every record"*; that was never a feature, only a name for the bug.

`docs/audits/2026-06-metadata-functional-completeness.md` closed this candidate as "verified false" with a residual of *"only a hand-crafted envelope or a direct row could reach the match-all branch — not a P0"*. The residual was larger than that; the audit note now records what it missed and why.

## Verification

- **17 new unit tests** in `sharing-rule.test.ts`, including the gate the issue asked for — a criteria-less rule produces no `sys_record_share` row — plus revocation of grants an already-materialised match-all rule had issued, and the reported `criterias` typo.
- **A new dogfood test** POSTs the issue's exact body against a booted showcase stack. It caught something a unit test could not: the engine guard rejected my own attempt to seed a legacy row, which is itself proof the Setup path is closed. (The legacy-row case now reproduces by dropping the guard hooks for one insert.)
- **Full dogfood suite: 163 files, 400 passed, 0 failed.** plugin-sharing 151/151, spec 6823/6823, rest and downstream-contract green. `tsc --noEmit` and eslint clean on every changed file.

## Migration

A rule that relied on the empty shape must state its predicate (`criteria: { stage: 'won' }`), or — if the object really should be readable by everyone — use `sharingModel`. Rows already stored with a null `criteria_json` need **no data migration**: they stop granting on the next evaluation and their existing grants are revoked. One example fixture was updated accordingly (`showcase-bu-hierarchy-sharing`, which had been relying on match-all to share "all private notes").

## Known follow-ups (not in this PR)

- **The Setup form lives in `objectui` / `cloud`**, outside this repo. The server now rejects an empty Criteria field, so unless that form marks it required, admins will hit a server-side 400 rather than client-side validation.
- **Log volume on legacy rows**: the per-record write-hook path warns on every evaluation, so a tenant with one null-criteria rule logs a warning on *every write* to that object. The behaviour is correct (loud beats silent), but if a boot-time aggregate report plus per-rule dedupe is preferred, that is a small change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QuViRSR1j6GJjf9qGbnqFX)_