### PR TITLE
fix(metadata-protocol,rest): deleteMany selects on the id list only, and bulk writes bind to the path object (#3897, #3933)

### DIFF
--- a/.changeset/bulk-writes-bind-to-path-object.md
+++ b/.changeset/bulk-writes-bind-to-path-object.md
@@ -1,0 +1,47 @@
+---
+"@objectstack/rest": minor
+---
+
+fix(rest): bulk writes bind to the object in the path, not the one in the body (#3933)
+
+`POST /data/:object/updateMany` spread the request body over the value it had
+just taken from the URL:
+
+```js
+const result = await p.updateManyData!({
+    object: req.params.object,   // trusted, written first
+    ...req.body,                 // …and spread over it
+    ...
+});
+```
+
+The gate on the line above reads the PATH object — `enforceApiAccess` starts
+with `const objectName = req?.params?.object` — so `enable.apiEnabled` /
+`enable.apiMethods` (ADR-0049 / #1889) was enforced on the object in the URL
+while the object named in the body got written. Measured on a stock CRM dev
+deployment: `POST /data/crm_account/updateMany` with
+`{"object":"crm_contact", "records":[…]}` returned `succeeded: 1` and changed
+the `crm_contact` row. Point the URL at any exposed object, name a hidden one in
+the body, and the gate clears the wrong object every time.
+
+This is not a row-authorization bypass — the engine middleware still evaluates
+RLS/FLS against the object actually written, and `assertObjectRegistered` (#3770)
+still resolves it. What it defeats is the object-level exposure policy, the layer
+ADR-0049 exists to make enforceable rather than advisory.
+
+The path object is now written LAST, after the body, so the object the gate
+cleared is the object that gets written — a property of the code rather than of
+the caller declining to send that key. The body is parsed against
+`UpdateManyDataRequestSchema` first, which (Zod strips unknown keys) also stops a
+body `context` from becoming the execution context on a deployment where none
+resolves — `requireAuth: false` plus an anonymous caller, the one case where the
+trailing `...(context ? { context } : {})` has nothing to overwrite it with.
+
+`deleteMany` gets the same ordering: #3897 moved it behind a schema parse, but
+fed that parse `{ object: req.params.object, ...req.body }` — still body-wins.
+`createMany` (`records: req.body || []`) and `batch` (`request: req.body`) never
+splatted the body at the top level and are unaffected.
+
+**Behaviour change.** A malformed `updateMany` body is now `400
+VALIDATION_FAILED` naming the offending path, instead of reaching the protocol
+and failing further in. A body `object` key is ignored rather than honoured.

--- a/.changeset/delete-many-id-predicate.md
+++ b/.changeset/delete-many-id-predicate.md
@@ -1,0 +1,63 @@
+---
+"@objectstack/metadata-protocol": minor
+"@objectstack/rest": minor
+---
+
+fix(metadata-protocol,rest): the id list is the only thing deleteMany can select on (#3897)
+
+`deleteManyData` built the predicate its endpoint is named after and then spread
+the caller's `options` **over** it:
+
+```js
+return this.engine.delete(request.object, {
+    where: { id: { $in: request.ids } },
+    ...request.options          // ← lands after `where`, so it can replace it
+});
+```
+
+`request.options` is caller-supplied — `POST /data/:object/deleteMany` splatted
+the whole request body into the protocol request (`{ object, ...req.body }`) —
+so one body key rewrote the operation:
+
+```json
+{"ids":["a"], "options":{"multi":true,"where":{}}}
+```
+
+reached `engine.delete` as an unscoped bulk delete. The engine's write
+middleware still composes RLS/sharing predicates onto the AST, so the blast
+radius is not automatically the whole table: it is **everything the caller is
+allowed to delete**. For an ordinary user with delete permission that is the
+difference between the 3 records they asked for and every record they can see;
+measured on a stock CRM dev deployment, that payload against one id removed all
+8 rows in the object and returned the raw driver count (`8`). The same spread
+also accepted `context`, i.e. a forged principal wherever the route is reachable
+without auth.
+
+**The id set is now authoritative, structurally.** The engine options are built
+from the validated id list and nothing else — caller `options` is a
+`BatchOptions` bag (`atomic` / `returnRecords` / `continueOnError` /
+`validateOnly`) that carries nothing `engine.delete` consumes, so merging it
+could only ever smuggle in engine keys. Ids must be scalars, so an operator
+object (`{"ids":[{"$ne":null}]}`) cannot reach `where.id` either; a malformed
+list is a `400 VALIDATION_FAILED` instead of a wider delete. The REST route
+parses the body against `DeleteManyDataRequestSchema` first, one hop earlier —
+Zod object schemas strip unknown keys, so `options.where`, top-level `where` and
+a body `context` no longer survive the ingress at all.
+
+**The endpoint also works now.** `deleteManyData` never set `multi`, so a
+correctly-formed `{"ids":[…]}` hit the engine's
+`'Delete requires an ID or options.multi=true'` throw — only the requests that
+triggered the override above ever completed. Deletes now go one id at a time by
+primary key, the same shape `batchData`'s `delete` case uses, which closes two
+gaps behind that: the bulk branch skips `cascadeDeleteRelations`, so
+`deleteBehavior` (`cascade` / `set_null` / `restrict`) was not honoured for the
+rows it removed; and the declared `BatchUpdateResponse` contract (per-record
+`results`, `atomic`, `continueOnError`) was unimplementable from a bulk row
+count. Both are delivered rather than declared.
+
+**Behaviour change.** The endpoint returns a `BatchUpdateResponse`
+(`{ success, operation, total, succeeded, failed, results }`) where it
+previously returned the driver's raw delete count — on the paths where it
+returned anything at all. The caller's execution context is threaded to every
+delete, so RLS/FLS now run under the caller here as they do on the single-record
+route.

--- a/content/docs/api/data-api.mdx
+++ b/content/docs/api/data-api.mdx
@@ -126,7 +126,16 @@ Batch update multiple records.
 
 Batch delete records by ID list.
 
-**Body**: `{ ids: ["1", "2", "3"] }`
+**Body**: `{ "ids": ["1", "2", "3"], "options": { "atomic": true } }` — `options` is
+the same `BatchOptions` bag `/batch` takes. The body is validated against the
+contract and unknown keys are dropped: the id list is the *only* thing that
+selects rows, so no body key can widen the delete into a filter.
+
+**Response**: `BatchUpdateResponse` — one `results` entry per id. Records are
+deleted one at a time by primary key, so each honours `deleteBehavior`
+(`cascade` / `set_null` / `restrict`) on relations pointing at it. `atomic`
+(default) stops the run at the first failure; `atomic: false` with
+`continueOnError: true` processes the remaining ids and reports the failures.
 
 ---
 

--- a/content/docs/api/data-api.mdx
+++ b/content/docs/api/data-api.mdx
@@ -122,6 +122,12 @@ Batch update multiple records.
 }
 ```
 
+The body is validated against the contract and unknown keys are dropped. The
+target object always comes from the URL — an `object` key in the body is
+ignored, on this route and on `deleteMany`.
+
+**Response**: `BatchUpdateResponse`, one `results` entry per record.
+
 ### `POST /data/:object/deleteMany`
 
 Batch delete records by ID list.

--- a/packages/metadata-protocol/src/protocol.delete-many.test.ts
+++ b/packages/metadata-protocol/src/protocol.delete-many.test.ts
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// [#3897] `deleteManyData` used to spread the caller-supplied `options` OVER
+// the id predicate it had just built, so a request body could replace `where`
+// outright and widen "delete these ids" into "delete everything this caller is
+// allowed to delete". The same spread could also smuggle in `context` (a forged
+// principal) and `multi`. These tests pin the three properties that make that
+// impossible now: the id set is authoritative, caller `options` never reaches
+// the engine, and the happy path actually deletes (it used to throw
+// `'Delete requires an ID or options.multi=true'` because `multi` was never set).
+
+import { describe, it, expect, vi } from 'vitest';
+import { ObjectStackProtocolImplementation } from './protocol.js';
+
+const SCHEMA = { name: 'invoice', fields: { title: { name: 'title', type: 'text' } } };
+
+function makeProtocol(deleteImpl?: (object: string, options: any) => Promise<any>) {
+  const del = vi.fn(deleteImpl ?? (async () => ({ deleted: true })));
+  const engine = {
+    registry: { getObject: (n: string) => (n === 'invoice' ? SCHEMA : undefined) },
+    delete: del,
+  };
+  return { p: new ObjectStackProtocolImplementation(engine as any), del };
+}
+
+describe('deleteManyData — the id set is the contract (#3897)', () => {
+  it('deletes exactly the supplied ids and reports a BatchUpdateResponse', async () => {
+    const { p, del } = makeProtocol();
+    const res: any = await p.deleteManyData({ object: 'invoice', ids: ['a', 'b', 'c'] } as any);
+
+    expect(del).toHaveBeenCalledTimes(3);
+    expect(del.mock.calls.map((c) => c[1].where)).toEqual([
+      { id: 'a' }, { id: 'b' }, { id: 'c' },
+    ]);
+    expect(res).toMatchObject({
+      success: true, operation: 'delete', total: 3, succeeded: 3, failed: 0,
+    });
+    expect(res.results).toEqual([
+      { id: 'a', success: true }, { id: 'b', success: true }, { id: 'c', success: true },
+    ]);
+  });
+
+  it('the happy path no longer trips the engine\'s "ID or options.multi=true" guard', async () => {
+    // Stand in for engine.delete's real dispatch: a scalar `where.id` is a
+    // by-id delete; anything else needs `options.multi` or it throws. The
+    // pre-#3897 implementation produced `{ id: { $in: [...] } }` with no
+    // `multi`, so a well-formed request could only ever hit the throw.
+    const { p } = makeProtocol(async (_object, options) => {
+      const id = options?.where?.id;
+      const scalar = typeof id === 'string' || typeof id === 'number';
+      if (!scalar && !options?.multi) throw new Error('Delete requires an ID or options.multi=true');
+      return { id };
+    });
+
+    const res: any = await p.deleteManyData({ object: 'invoice', ids: ['a'] } as any);
+    expect(res.success).toBe(true);
+    expect(res.failed).toBe(0);
+  });
+
+  it('a body-supplied options.where cannot replace the id predicate', async () => {
+    const { p, del } = makeProtocol();
+    // The exploit payload from the issue, verbatim.
+    await p.deleteManyData({
+      object: 'invoice',
+      ids: ['a'],
+      options: { multi: true, where: {} },
+    } as any);
+
+    expect(del).toHaveBeenCalledTimes(1);
+    const opts = del.mock.calls[0][1];
+    expect(opts.where).toEqual({ id: 'a' });
+    expect(opts.multi).toBeUndefined();
+  });
+
+  it('a body-supplied options.context cannot forge the caller principal', async () => {
+    const { p, del } = makeProtocol();
+    await p.deleteManyData({
+      object: 'invoice',
+      ids: ['a'],
+      options: { context: { userId: 'root', roles: ['admin'] } },
+    } as any);
+
+    expect(del.mock.calls[0][1].context).toBeUndefined();
+  });
+
+  it('threads the resolved execution context to every engine delete', async () => {
+    const { p, del } = makeProtocol();
+    const ctx = { userId: 'u1' };
+    await p.deleteManyData({ object: 'invoice', ids: ['a', 'b'], context: ctx } as any);
+
+    expect(del.mock.calls[0][1].context).toBe(ctx);
+    expect(del.mock.calls[1][1].context).toBe(ctx);
+  });
+
+  it('rejects non-scalar ids instead of letting an operator object reach where.id', async () => {
+    const { p, del } = makeProtocol();
+    await expect(
+      p.deleteManyData({ object: 'invoice', ids: [{ $ne: null }] } as any),
+    ).rejects.toMatchObject({ code: 'VALIDATION_FAILED', status: 400 });
+    expect(del).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing / non-array ids rather than deleting unscoped', async () => {
+    const { p, del } = makeProtocol();
+    await expect(
+      p.deleteManyData({ object: 'invoice', options: { multi: true } } as any),
+    ).rejects.toMatchObject({ code: 'VALIDATION_FAILED', status: 400 });
+    expect(del).not.toHaveBeenCalled();
+  });
+
+  it('an empty id list deletes nothing', async () => {
+    const { p, del } = makeProtocol();
+    const res: any = await p.deleteManyData({ object: 'invoice', ids: [] } as any);
+    expect(del).not.toHaveBeenCalled();
+    expect(res).toMatchObject({ success: true, total: 0, succeeded: 0, failed: 0, results: [] });
+  });
+});
+
+describe('deleteManyData — partial-failure semantics (#3897)', () => {
+  function failOn(badId: string) {
+    return makeProtocol(async (_object, options) => {
+      if (options.where.id === badId) throw new Error('RLS: not visible');
+      return { id: options.where.id };
+    });
+  }
+
+  it('stops at the first failure by default and reports it per row', async () => {
+    const { p, del } = failOn('b');
+    const res: any = await p.deleteManyData({ object: 'invoice', ids: ['a', 'b', 'c'] } as any);
+
+    expect(del).toHaveBeenCalledTimes(2);
+    expect(res).toMatchObject({ success: false, total: 3, succeeded: 1, failed: 1 });
+    expect(res.results[1]).toEqual({ id: 'b', success: false, error: 'RLS: not visible' });
+  });
+
+  it('continueOnError keeps going and still marks the batch unsuccessful', async () => {
+    const { p, del } = failOn('b');
+    const res: any = await p.deleteManyData({
+      object: 'invoice',
+      ids: ['a', 'b', 'c'],
+      options: { atomic: false, continueOnError: true },
+    } as any);
+
+    expect(del).toHaveBeenCalledTimes(3);
+    expect(res).toMatchObject({ success: false, total: 3, succeeded: 2, failed: 1 });
+  });
+
+  it('atomic aborts the remaining ids on the first failure', async () => {
+    const { p, del } = failOn('b');
+    const res: any = await p.deleteManyData({
+      object: 'invoice',
+      ids: ['a', 'b', 'c'],
+      options: { atomic: true, continueOnError: true },
+    } as any);
+
+    expect(del).toHaveBeenCalledTimes(2);
+    expect(res.succeeded).toBe(1);
+  });
+});

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -3805,13 +3805,92 @@ export class ObjectStackProtocolImplementation implements
         throw new Error('triggerAutomation requires plugin-automation service. Install and register a plugin that provides the "automation" service.');
     }
 
-    async deleteManyData(request: DeleteManyDataRequest): Promise<any> {
-        this.assertObjectRegistered(request.object); // [#3770]
-        // This expects deleting by IDs.
-        return this.engine.delete(request.object, {
-            where: { id: { $in: request.ids } },
-            ...request.options
-        });
+    /**
+     * Bulk delete by id — the `POST /data/:object/deleteMany` ingress.
+     *
+     * [#3897] This used to build `{ where: { id: { $in: ids } } }` and then
+     * spread `...request.options` OVER it. `options` is caller-supplied (the
+     * REST route splats the whole request body into the protocol request), so
+     * a body key replaced the predicate the endpoint is named after:
+     *
+     *   {"ids":["a"],"options":{"multi":true,"where":{}}}
+     *
+     * reached `engine.delete` as an unscoped bulk delete — widening "delete
+     * these 3 records" into "delete everything this caller is allowed to
+     * delete" (RLS/sharing middleware still composes onto the AST, so the blast
+     * radius is the caller's visible set, not the whole table). The same spread
+     * could smuggle in `context`, i.e. a forged principal on any deployment
+     * where the route is reachable without auth.
+     *
+     * The fix is structural rather than a re-ordered spread: caller `options`
+     * is a `BatchOptions` bag (`atomic` / `returnRecords` /
+     * `continueOnError` / `validateOnly`) and carries NOTHING `engine.delete`
+     * consumes, so it is never merged into the engine options. The engine call
+     * is built here from the validated id list alone, and each id is deleted by
+     * scalar primary key — the same shape `batchData`'s `delete` case uses.
+     *
+     * Deleting per id (instead of one `$in` bulk delete) also fixes the second
+     * half of #3897 and two silent gaps behind it:
+     *   - the endpoint's happy path never worked at all — `deleteManyData` never
+     *     set `multi`, so a well-formed `{"ids":[…]}` hit engine.ts's
+     *     `'Delete requires an ID or options.multi=true'` throw, and ONLY the
+     *     requests that triggered the override above got through;
+     *   - the bulk branch skips `cascadeDeleteRelations`, so `deleteBehavior`
+     *     (`cascade` / `set_null` / `restrict`) was not honoured for the rows it
+     *     removed;
+     *   - the declared {@link BatchUpdateResponse} contract (per-record results,
+     *     `atomic` / `continueOnError`) was unimplementable from a bulk row
+     *     count. It is now actually delivered.
+     */
+    async deleteManyData(request: DeleteManyDataRequest & { context?: any }): Promise<BatchUpdateResponse> {
+        const { object, options, context } = request;
+        this.assertObjectRegistered(object); // [#3770]
+
+        // Fail CLOSED on anything that is not a list of scalar ids. A non-scalar
+        // entry (`{"ids":[{"$ne":null}]}`) must never reach `where.id` as an
+        // operator object — that is the same "predicate widening" this endpoint
+        // was just hardened against, one layer down.
+        const isScalarId = (v: unknown) =>
+            (typeof v === 'string' && v.length > 0) || typeof v === 'number' || typeof v === 'bigint';
+        const ids = request.ids as unknown;
+        if (!Array.isArray(ids) || ids.some((id) => !isScalarId(id))) {
+            const err: any = new Error(
+                `deleteMany on '${object}' requires 'ids' to be an array of record ids`,
+            );
+            err.code = 'VALIDATION_FAILED';
+            err.status = 400;
+            throw err;
+        }
+
+        const results: Array<{ id?: string; success: boolean; error?: string }> = [];
+        let succeeded = 0;
+        let failed = 0;
+        const ctxOpt = context !== undefined ? { context } : {};
+
+        for (const id of ids) {
+            try {
+                await this.engine.delete(object, { where: { id }, ...ctxOpt } as any);
+                results.push({ id: String(id), success: true });
+                succeeded++;
+            } catch (err: any) {
+                results.push({ id: String(id), success: false, error: err?.message });
+                failed++;
+                // Same stop semantics as `batchData`: `atomic` aborts the rest on
+                // the first failure, and without `continueOnError` a failure ends
+                // the run rather than silently ploughing on.
+                if (options?.atomic) break;
+                if (!options?.continueOnError) break;
+            }
+        }
+
+        return {
+            success: failed === 0,
+            operation: 'delete',
+            total: ids.length,
+            succeeded,
+            failed,
+            results,
+        } as BatchUpdateResponse;
     }
 
     /**

--- a/packages/rest/src/rest-bulk-path-object.test.ts
+++ b/packages/rest/src/rest-bulk-path-object.test.ts
@@ -132,6 +132,11 @@ describe('updateMany ingress validation (#3933)', () => {
 
     expect(res.statusCode).toBe(400);
     expect(res.body.code).toBe('VALIDATION_FAILED');
+    // The documented data-surface envelope (`fields[]`, wire-format §7), not a
+    // second per-route shape.
+    expect(res.body.fields).toEqual([
+      { field: 'records.0.id', code: 'invalid_type', message: expect.any(String) },
+    ]);
     expect(updateManyData).not.toHaveBeenCalled();
   });
 });

--- a/packages/rest/src/rest-bulk-path-object.test.ts
+++ b/packages/rest/src/rest-bulk-path-object.test.ts
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// [#3933] The bulk write routes used to spread the request body OVER
+// `object: req.params.object`, so a body key moved the write to a different
+// object than the one in the URL. `enforceApiAccess` gates on `req.params.object`
+// — so `enable.apiEnabled` / `enable.apiMethods` (ADR-0049 / #1889) was enforced
+// on the object in the PATH while the object in the BODY got written. The path
+// object is now written last, and the body is parsed against the spec contract
+// (which also strips a body `context`).
+
+import { describe, it, expect, vi } from 'vitest';
+import { RestServer } from './rest-server';
+
+const UPDATE_MANY = '/api/v1/data/:object/updateMany';
+const DELETE_MANY = '/api/v1/data/:object/deleteMany';
+
+function createMockServer() {
+  return {
+    get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn(), use: vi.fn(),
+    listen: vi.fn().mockResolvedValue(undefined), close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeRes() {
+  const res: any = { statusCode: 200, body: undefined };
+  res.status = vi.fn((c: number) => { res.statusCode = c; return res; });
+  res.json = vi.fn((b: any) => { res.body = b; return res; });
+  res.setHeader = vi.fn(); res.write = vi.fn(); res.end = vi.fn();
+  return res;
+}
+
+/**
+ * `open` is exposed to the API; `locked` is not. The exploit points the URL at
+ * `open` (so the gate clears) and names `locked` in the body.
+ */
+function setup() {
+  const updateManyData = vi.fn().mockResolvedValue({
+    success: true, operation: 'update', total: 1, succeeded: 1, failed: 0, results: [],
+  });
+  const deleteManyData = vi.fn().mockResolvedValue({
+    success: true, operation: 'delete', total: 1, succeeded: 1, failed: 0, results: [],
+  });
+  const protocol: any = {
+    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: { data: '', metadata: '', ui: '', auth: '/auth' } }),
+    getMetaTypes: vi.fn().mockResolvedValue([]),
+    getMetaItems: vi.fn().mockResolvedValue([
+      { name: 'open' },
+      { name: 'locked', enable: { apiEnabled: false } },
+    ]),
+    getMetaItem: vi.fn().mockResolvedValue({}),
+    findData: vi.fn().mockResolvedValue([]),
+    updateManyData,
+    deleteManyData,
+  };
+  const rest = new RestServer(createMockServer() as any, protocol, { api: { requireAuth: false } } as any);
+  rest.registerRoutes();
+  return { rest, updateManyData, deleteManyData };
+}
+
+async function post(rest: any, path: string, object: string, body: any) {
+  const route = rest.getRoutes().find((r: any) => r.method === 'POST' && r.path === path);
+  if (!route) throw new Error(`route not registered: ${path}`);
+  const res = makeRes();
+  await route.handler({ method: 'POST', params: { object }, query: {}, body }, res);
+  return res;
+}
+
+const ONE_UPDATE = [{ id: 'r1', data: { name: 'x' } }];
+
+describe('bulk writes bind to the object in the PATH (#3933)', () => {
+  it('updateMany: a body `object` cannot redirect the write', async () => {
+    const { rest, updateManyData } = setup();
+    const res = await post(rest, UPDATE_MANY, 'open', { object: 'locked', records: ONE_UPDATE });
+
+    expect(res.statusCode).toBe(200);
+    expect(updateManyData.mock.calls[0][0].object).toBe('open');
+  });
+
+  it('deleteMany: a body `object` cannot redirect the delete', async () => {
+    const { rest, deleteManyData } = setup();
+    const res = await post(rest, DELETE_MANY, 'open', { object: 'locked', ids: ['r1'] });
+
+    expect(res.statusCode).toBe(200);
+    expect(deleteManyData.mock.calls[0][0].object).toBe('open');
+  });
+
+  it('the apiEnabled gate cannot be bypassed by naming the locked object in the body', async () => {
+    const { rest, updateManyData, deleteManyData } = setup();
+    // Sanity: addressed directly, `locked` is hidden (404, ADR-0049).
+    expect((await post(rest, UPDATE_MANY, 'locked', { records: ONE_UPDATE })).statusCode).toBe(404);
+    expect((await post(rest, DELETE_MANY, 'locked', { ids: ['r1'] })).statusCode).toBe(404);
+    expect(updateManyData).not.toHaveBeenCalled();
+    expect(deleteManyData).not.toHaveBeenCalled();
+
+    // Via the exploit: the gate clears `open`, and `open` is what gets written.
+    await post(rest, UPDATE_MANY, 'open', { object: 'locked', records: ONE_UPDATE });
+    await post(rest, DELETE_MANY, 'open', { object: 'locked', ids: ['r1'] });
+    expect(updateManyData.mock.calls.every((c) => c[0].object === 'open')).toBe(true);
+    expect(deleteManyData.mock.calls.every((c) => c[0].object === 'open')).toBe(true);
+  });
+});
+
+describe('updateMany ingress validation (#3933)', () => {
+  it('strips a body-supplied context so the principal cannot be forged', async () => {
+    const { rest, updateManyData } = setup();
+    // `requireAuth: false` → no execution context resolves, so a body `context`
+    // used to be the only one the protocol (and then the engine) ever saw.
+    await post(rest, UPDATE_MANY, 'open', {
+      records: ONE_UPDATE,
+      context: { userId: 'nobody', isSystem: true, roles: ['admin'] },
+    });
+
+    expect(updateManyData.mock.calls[0][0].context).toBeUndefined();
+  });
+
+  it('forwards a well-formed request unchanged', async () => {
+    const { rest, updateManyData } = setup();
+    const res = await post(rest, UPDATE_MANY, 'open', {
+      records: ONE_UPDATE,
+      options: { atomic: false, continueOnError: true },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const req = updateManyData.mock.calls[0][0];
+    expect(req.records).toEqual(ONE_UPDATE);
+    expect(req.options).toMatchObject({ atomic: false, continueOnError: true });
+  });
+
+  it('rejects a malformed records list with 400 VALIDATION_FAILED', async () => {
+    const { rest, updateManyData } = setup();
+    const res = await post(rest, UPDATE_MANY, 'open', { records: [{ data: { name: 'x' } }] });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.code).toBe('VALIDATION_FAILED');
+    expect(updateManyData).not.toHaveBeenCalled();
+  });
+});

--- a/packages/rest/src/rest-delete-many-ingress.test.ts
+++ b/packages/rest/src/rest-delete-many-ingress.test.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// [#3897] `POST /data/:object/deleteMany` used to splat the raw request body
+// into the protocol request (`{ object, ...req.body }`), and the protocol then
+// spread that body's `options` over its own `where` — so `options.where` /
+// `options.multi` from the body reached `engine.delete` and turned "delete
+// these ids" into "delete everything this caller can see". The route now parses
+// the body against `DeleteManyDataRequestSchema`; Zod object schemas STRIP
+// unknown keys, so the engine-level keys never survive the ingress.
+
+import { describe, it, expect, vi } from 'vitest';
+import { RestServer } from './rest-server';
+
+const DELETE_MANY = '/api/v1/data/:object/deleteMany';
+
+function createMockServer() {
+  return {
+    get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn(), use: vi.fn(),
+    listen: vi.fn().mockResolvedValue(undefined), close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeRes() {
+  const res: any = { statusCode: 200, body: undefined };
+  res.status = vi.fn((c: number) => { res.statusCode = c; return res; });
+  res.json = vi.fn((b: any) => { res.body = b; return res; });
+  res.setHeader = vi.fn(); res.write = vi.fn(); res.end = vi.fn();
+  return res;
+}
+
+function setup() {
+  const deleteManyData = vi.fn().mockResolvedValue({
+    success: true, operation: 'delete', total: 1, succeeded: 1, failed: 0, results: [],
+  });
+  const protocol: any = {
+    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: { data: '', metadata: '', ui: '', auth: '/auth' } }),
+    getMetaTypes: vi.fn().mockResolvedValue([]),
+    getMetaItems: vi.fn().mockResolvedValue([{ name: 'invoice' }]),
+    getMetaItem: vi.fn().mockResolvedValue({}),
+    findData: vi.fn().mockResolvedValue([]),
+    deleteManyData,
+  };
+  const rest = new RestServer(createMockServer() as any, protocol, { api: { requireAuth: false } } as any);
+  rest.registerRoutes();
+  return { rest, deleteManyData };
+}
+
+async function post(rest: any, body: any) {
+  const route = rest.getRoutes().find((r: any) => r.method === 'POST' && r.path === DELETE_MANY);
+  if (!route) throw new Error('deleteMany route not registered');
+  const res = makeRes();
+  await route.handler({ method: 'POST', params: { object: 'invoice' }, query: {}, body }, res);
+  return res;
+}
+
+describe('POST /data/:object/deleteMany — ingress validation (#3897)', () => {
+  it('forwards a well-formed request with the object taken from the path', async () => {
+    const { rest, deleteManyData } = setup();
+    const res = await post(rest, { ids: ['a', 'b'] });
+
+    expect(res.statusCode).toBe(200);
+    expect(deleteManyData).toHaveBeenCalledTimes(1);
+    const req = deleteManyData.mock.calls[0][0];
+    expect(req.object).toBe('invoice');
+    expect(req.ids).toEqual(['a', 'b']);
+  });
+
+  it('strips engine-level keys smuggled through options (the issue payload)', async () => {
+    const { rest, deleteManyData } = setup();
+    const res = await post(rest, { ids: ['a'], options: { multi: true, where: {} } });
+
+    expect(res.statusCode).toBe(200);
+    const req = deleteManyData.mock.calls[0][0];
+    expect(req.options?.where).toBeUndefined();
+    expect(req.options?.multi).toBeUndefined();
+    expect(req.ids).toEqual(['a']);
+  });
+
+  it('strips a body-supplied top-level where / multi', async () => {
+    const { rest, deleteManyData } = setup();
+    await post(rest, { ids: ['a'], where: {}, multi: true });
+
+    const req = deleteManyData.mock.calls[0][0];
+    expect(req.where).toBeUndefined();
+    expect(req.multi).toBeUndefined();
+  });
+
+  it('strips a body-supplied context so the principal cannot be forged', async () => {
+    const { rest, deleteManyData } = setup();
+    // This route is reachable with `requireAuth: false`, so no execution
+    // context is resolved — a body `context` would previously have been the
+    // only one the protocol saw.
+    await post(rest, { ids: ['a'], context: { userId: 'root', roles: ['admin'] } });
+
+    expect(deleteManyData.mock.calls[0][0].context).toBeUndefined();
+  });
+
+  it('keeps the legitimate BatchOptions keys', async () => {
+    const { rest, deleteManyData } = setup();
+    await post(rest, { ids: ['a'], options: { atomic: false, continueOnError: true } });
+
+    const req = deleteManyData.mock.calls[0][0];
+    expect(req.options).toMatchObject({ atomic: false, continueOnError: true });
+  });
+
+  it('rejects a malformed body with 400 VALIDATION_FAILED and never calls the protocol', async () => {
+    const { rest, deleteManyData } = setup();
+    const res = await post(rest, { ids: [{ $ne: null }] });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.code).toBe('VALIDATION_FAILED');
+    expect(deleteManyData).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing ids list rather than forwarding an unscoped delete', async () => {
+    const { rest, deleteManyData } = setup();
+    const res = await post(rest, { options: { multi: true } });
+
+    expect(res.statusCode).toBe(400);
+    expect(deleteManyData).not.toHaveBeenCalled();
+  });
+});

--- a/packages/rest/src/rest-delete-many-ingress.test.ts
+++ b/packages/rest/src/rest-delete-many-ingress.test.ts
@@ -109,6 +109,12 @@ describe('POST /data/:object/deleteMany — ingress validation (#3897)', () => {
 
     expect(res.statusCode).toBe(400);
     expect(res.body.code).toBe('VALIDATION_FAILED');
+    // Same `fields[]` envelope a validator-thrown VALIDATION_FAILED uses
+    // (#3918 / wire-format §7) — one shape per code on the wire.
+    expect(res.body.fields).toEqual([
+      { field: 'ids.0', code: 'invalid_type', message: expect.any(String) },
+    ]);
+    expect(res.body.object).toBe('invoice');
     expect(deleteManyData).not.toHaveBeenCalled();
   });
 

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -6849,15 +6849,40 @@ export class RestServer {
                         if (this.enforceAuth(req, res, context)) return;
                         // [#3391] bulk ∧ delete — deleteMany requires the `bulk` primitive.
                         if (await this.enforceApiAccess(req, res, p, environmentId, 'bulk', { bulkChild: 'delete' })) return;
-                        const result = await p.deleteManyData!({
+                        // [#3897] Validate against the spec contract instead of
+                        // splatting the raw body into the protocol request. Zod
+                        // object schemas STRIP unknown keys, which is what makes
+                        // this a security boundary and not just an error message:
+                        // `options` is narrowed to `BatchOptions`, so a body key
+                        // (`options.where`, `options.multi`) can no longer ride
+                        // into the engine's delete options, and a top-level
+                        // `context` can no longer forge the caller's principal on
+                        // a route reachable without auth. The protocol layer
+                        // refuses the same shapes independently (defence in
+                        // depth) — this stops them one hop earlier, with a 400
+                        // the caller can act on.
+                        const { DeleteManyDataRequestSchema } = await import('@objectstack/spec/api');
+                        const parsed = (DeleteManyDataRequestSchema as any).safeParse({
                             object: req.params.object,
-                            ...req.body,
+                            ...(req.body ?? {}),
+                        });
+                        if (!parsed.success) {
+                            res.status(400).json({
+                                error: 'Invalid deleteMany request',
+                                code: 'VALIDATION_FAILED',
+                                object: req.params?.object,
+                                issues: parsed.error?.issues,
+                            });
+                            return;
+                        }
+                        const result = await p.deleteManyData!({
+                            ...parsed.data,
                             ...(environmentId ? { environmentId } : {}),
                             ...(context ? { context } : {}),
                         } as any);
                         res.json(result);
                     } catch (error: any) {
-                        logError("[REST] Unhandled error:", error);
+                        if (error?.code !== 'VALIDATION_FAILED') logError("[REST] Unhandled error:", error);
                         sendError(res, error, req.params?.object);
                     }
                 },

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -6817,15 +6817,38 @@ export class RestServer {
                         if (this.enforceAuth(req, res, context)) return;
                         // [#3391] bulk ∧ update — updateMany requires the `bulk` primitive.
                         if (await this.enforceApiAccess(req, res, p, environmentId, 'bulk', { bulkChild: 'update' })) return;
-                        const result = await p.updateManyData!({
+                        // [#3933] Validate against the spec contract, and write the
+                        // PATH object last. The body used to be spread over
+                        // `object: req.params.object`, so `{"object":"other", …}`
+                        // moved the write to a different object than the one
+                        // `enforceApiAccess` had just cleared — that gate reads
+                        // `req.params.object`, so `enable.apiEnabled` / `apiMethods`
+                        // (ADR-0049) was enforced on A while B was written. Zod also
+                        // strips unknown keys, which keeps a body `context` from
+                        // becoming the execution context on a deployment where none
+                        // resolves (anonymous-reachable `requireAuth: false`).
+                        const { UpdateManyDataRequestSchema } = await import('@objectstack/spec/api');
+                        const parsedUpdate = (UpdateManyDataRequestSchema as any).safeParse({
+                            ...(req.body ?? {}),
                             object: req.params.object,
-                            ...req.body,
+                        });
+                        if (!parsedUpdate.success) {
+                            res.status(400).json({
+                                error: 'Invalid updateMany request',
+                                code: 'VALIDATION_FAILED',
+                                object: req.params?.object,
+                                issues: parsedUpdate.error?.issues,
+                            });
+                            return;
+                        }
+                        const result = await p.updateManyData!({
+                            ...parsedUpdate.data,
                             ...(environmentId ? { environmentId } : {}),
                             ...(context ? { context } : {}),
                         } as any);
                         res.json(result);
                     } catch (error: any) {
-                        logError("[REST] Unhandled error:", error);
+                        if (error?.code !== 'VALIDATION_FAILED') logError("[REST] Unhandled error:", error);
                         sendError(res, error, req.params?.object);
                     }
                 },
@@ -6861,10 +6884,14 @@ export class RestServer {
                         // refuses the same shapes independently (defence in
                         // depth) — this stops them one hop earlier, with a 400
                         // the caller can act on.
+                        // [#3933] The PATH object is written LAST for the same
+                        // reason: `enforceApiAccess` gates on `req.params.object`,
+                        // so a body `object` would move the delete to an object
+                        // whose exposure policy was never checked.
                         const { DeleteManyDataRequestSchema } = await import('@objectstack/spec/api');
                         const parsed = (DeleteManyDataRequestSchema as any).safeParse({
-                            object: req.params.object,
                             ...(req.body ?? {}),
+                            object: req.params.object,
                         });
                         if (!parsed.success) {
                             res.status(400).json({

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -76,6 +76,25 @@ const TRANSLATABLE_META_TYPES = new Set(['view', 'action', 'object', 'app', 'das
  * not permitted …" — trips the `'<obj>' … not` substring check and
  * returns a misleading 404.
  */
+/**
+ * Zod issues → the data surface's `fields[]` validation envelope
+ * (`{ field, code, message }`, docs/api/wire-format §7).
+ *
+ * A schema `.parse()` at a route ingress must report failures in the SAME shape
+ * a validator-thrown `VALIDATION_FAILED` does through {@link mapDataError}
+ * (#3918) — otherwise a client keying on `fields` has to learn a second shape
+ * per route, and `code: 'VALIDATION_FAILED'` stops meaning one thing on the
+ * wire.
+ */
+export function zodIssuesToFields(issues: unknown): Array<{ field: string; code: string; message: string }> {
+    if (!Array.isArray(issues)) return [];
+    return issues.map((i: any) => ({
+        field: Array.isArray(i?.path) ? i.path.join('.') : String(i?.path ?? ''),
+        code: String(i?.code ?? 'invalid'),
+        message: String(i?.message ?? 'Invalid value'),
+    }));
+}
+
 export function mapDataError(error: any, object?: string): { status: number; body: Record<string, unknown> } {
     // Referential-integrity restrict on delete → 409 with the dependent count.
     // Surfaced FIRST so the structured fields survive the generic catch-alls.
@@ -6836,8 +6855,8 @@ export class RestServer {
                             res.status(400).json({
                                 error: 'Invalid updateMany request',
                                 code: 'VALIDATION_FAILED',
+                                fields: zodIssuesToFields(parsedUpdate.error?.issues),
                                 object: req.params?.object,
-                                issues: parsedUpdate.error?.issues,
                             });
                             return;
                         }
@@ -6897,8 +6916,8 @@ export class RestServer {
                             res.status(400).json({
                                 error: 'Invalid deleteMany request',
                                 code: 'VALIDATION_FAILED',
+                                fields: zodIssuesToFields(parsed.error?.issues),
                                 object: req.params?.object,
-                                issues: parsed.error?.issues,
                             });
                             return;
                         }


### PR DESCRIPTION
Closes #3897,closes #3933。

两个 issue 是同一个教训的两半:**受信任的值先写、body 展开在它之后**。#3897 覆盖掉的是 `where`,#3933 覆盖掉的是路径上的 `object`,而且就在同一段代码里。

---

## #3897 — deleteMany:body 可以替换掉 id 谓词

```js
return this.engine.delete(request.object, {
    where: { id: { $in: request.ids } },
    ...request.options          // ← 展开在 where 之后
});
```

`request.options` 是调用者给的(REST 路由把整个 body 摊进协议请求),所以 `{"ids":["a"],"options":{"multi":true,"where":{}}}` 到达引擎时是一次无谓词的 bulk delete。

**实跑量化了 issue 里标注"未确认"的那部分** —— 在修复前的构建上,CRM dev 环境、admin 身份:

```
ids=[T-1] + options:{multi:true, where:{}}  → 响应 8,对象里 8 行全没了
ids=[T-2, T-3]  (正常用法)                  → "Delete requires an ID or options.multi=true"
```

RLS 会把范围收敛到调用者可见集,这里 admin 的可见集就是全部。happy path 确实不通。

### 修法

没有只把展开顺序倒过来 —— 那样 `options` 仍然会流进引擎选项,`context`(伪造 principal)照样能挤进去。改成结构上不可能:

- **协议层**:引擎选项只从校验过的 id 列表构造,调用者的 `options` 根本不参与合并(`BatchOptions` 的四个键没有一个是 `engine.delete` 认识的,合并它只可能夹带引擎键)。id 必须是标量,`{"ids":[{"$ne":null}]}` 这种低一层的谓词放大也堵掉。
- **REST 入口**:按 `DeleteManyDataRequestSchema` `.parse()`,Zod 剥未知键,`options.where` / 顶层 `where` / body 里的 `context` 活不过 ingress。

两处都做,正如 issue 里建议的。

### 顺带修好的 happy path

改成**按 id 逐条删**(和 `batchData` 的 `delete` 分支、`updateManyData` 的循环一致),而不是补一个 `multi: true`。这样连带补上两个原本埋着的洞:

1. bulk 分支不走 `cascadeDeleteRelations` —— 就算当初补上 `multi`,`deleteBehavior` 的 `cascade`/`set_null`/`restrict` 依然不会生效;
2. 声明的 `BatchUpdateResponse` 契约(逐条 `results`、`atomic`、`continueOnError`)从一个 bulk 行数里根本实现不出来。

---

## #3933 — updateMany:body 可以替换掉路径上的 object

修 #3897 时发现的。同一个展开覆盖的不只是 `context`:

```js
object: req.params.object,   // 受信任的值,先写
...req.body,                 // ← 展开在它之后
```

而上一行的 `enforceApiAccess` 读的是 `req.params.object`(`rest-server.ts:1211`)。**闸门在 A 上判,写落在 B 上。**

实跑复现(已登录的普通调用者):

```
POST /api/v1/data/crm_account/updateMany
{"object":"crm_contact","records":[{"id":"gg92…","data":{"last_name":"PWNED"}}]}
→ succeeded:1,crm_contact 那条记录真的变成了 PWNED
```

路径挑一个 `apiEnabled` 开着的对象,body 里填一个关掉的,ADR-0049 那层就绕过去了。这不是越权写(RLS/FLS 仍按 B 跑,`assertObjectRegistered` 也按 B 查),破的是对象级暴露策略 —— PD #10 里"声明了就必须拦得住"的那一层。

**#3897 的修复本身也中了同一招**:`safeParse({ object: req.params.object, ...req.body })` —— body 里的 `object` 照样赢,实跑验过 contact 被删掉了。同一个 PR 里一起修:路径对象**最后写**。

`context` 那条也一起堵了,但范围要说清楚:已登录时真 context 会盖回去(实跑确认 `updated_by` 是真实用户 id),**只有 `requireAuth:false` + 匿名那一档**才是唯一 context。那一档我没有实跑复现,是从 `?:` 短路条件读出来的,issue 里如实标注了。

### 未受影响

| 路由 | body 怎么进的 | 覆盖 `object`? | 覆盖 `context`? |
|:--|:--|:--|:--|
| `updateMany` | `...req.body` | 是 → 已修 | 是 → 已修 |
| `deleteMany` | `...req.body` | 是 → 已修 | 是 → 已修 |
| `createMany` | `records: req.body \|\| []` | 否 | 否 |
| `batch` | `request: req.body`(套一层) | 否 | 否 |

---

## 行为变更

- `deleteMany` 返回 `BatchUpdateResponse`(`{success, operation, total, succeeded, failed, results}`),此前返回驱动的裸行数 —— 在它有返回值的那些路径上。
- 调用者的执行 context 现在会透传到每一次 delete,RLS/FLS 在这条路径上终于跑在调用者身份下。
- `updateMany` / `deleteMany` 的畸形 body 现在是 `400 VALIDATION_FAILED`,此前会更深地失败在协议层。
- body 里的 `object` 键从"生效"变成"被忽略"。

## 顺带对齐的信封形状

两个新入口最初把 Zod 失败报成 `issues[]`(照抄 cross-object batch 路由),但数据面 `VALIDATION_FAILED` 的**文档化**信封是 `fields[]`(`{field, code, message}`,wire-format §7),也是 `mapDataError` 对校验器抛出的那种所发的形状(#3918)。一个 wire code 两种形状,意味着按 `fields` 取值的客户端在这两条路由上会静默地什么都读不到。新增 `zodIssuesToFields`,两处统一 —— `code: 'VALIDATION_FAILED'` 在数据面只有一个意思,不管是哪一层发现的。

## 验证

- 新增 24 条测试:`protocol.delete-many.test.ts`(11)、`rest-delete-many-ingress.test.ts`(7)、`rest-bulk-path-object.test.ts`(6,其中一条直接把 apiEnabled 闸门绕过演出来)。
- **验过新测试在未修代码上会红** —— #3933 那 6 条里 5 条失败(`expected 'locked' to be 'open'` 等),第 6 条是正常路径两边都绿。
- `@objectstack/rest` 432 条、`@objectstack/metadata-protocol` 82 条全绿;改动文件 ESLint 干净。
- 两个 issue 的载荷都在真机(`pnpm dev:crm -- --fresh`)上跑过修复前 / 修复后的对照,数字见上文。dev 服务器已自行拆除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzLE9cw4gZKNyPN2ZP4iTt
