### PR TITLE
chore(liveness): flip `report.order` to live now that objectui lowers it (#3916)

### DIFF
--- a/.changeset/report-order-liveness-live.md
+++ b/.changeset/report-order-liveness-live.md
@@ -1,0 +1,23 @@
+---
+"@objectstack/spec": patch
+---
+
+chore(liveness): `report.order` is live — objectui now lowers it onto the selection (#3916)
+
+`ReportSchema.order` shipped as `planned` + `authorWarn`: the framework half was
+complete (schema, `reportSelectionOrder`, executor), but objectui's
+`DatasetReportRenderer` built the selection it posted and never carried the
+declaration into it, so an authored ordering reached no query. Marking it `live`
+then would have been the exact failure the gate exists to catch.
+
+objectui#2964 landed that wiring — `useDatasetRows`, the single fetch choke point
+behind every report path, now carries the lowered ordering across all four call
+sites (grouped table, embedded chart, matrix cross-tab, each joined block), with
+the ordering in the refetch signature and scoped per sub-selection so the
+chart's narrower x/y query cannot post a key it never selected.
+
+So the ledger entry flips to `live`, gains the framework evidence paths, and
+drops `authorWarn` / `authorHint` — an authored `order` now does what it says,
+and the advisory that it did not is no longer true.
+
+No behaviour change in this repo; the ledger is the deliverable.

--- a/packages/spec/liveness/report.json
+++ b/packages/spec/liveness/report.json
@@ -39,10 +39,10 @@
       "note": "objectui: render-time scope filter ANDed at query time (`?? filter`, mergeFilters) — DatasetReportRenderer."
     },
     "order": {
-      "status": "planned",
-      "authorWarn": true,
-      "authorHint": "A selected date dimension is ALREADY chronological (ascending) without `order` — that default is live server-side. Only the explicit declaration is pending its renderer wiring.",
-      "note": "[planned] framework#3916. The FRAMEWORK half is complete and live: the schema accepts `order`, `reportSelectionOrder` (ui/report.zod.ts) lowers it to `DatasetSelection.order`, and the executor applies that ordering over the assembled grid (services/service-analytics/src/dataset-executor.ts, resolveOrdering/applyOrdering). What is NOT yet wired is the objectui side — `DatasetReportRenderer` builds the selection it posts and does not carry `report.order` into it, so an authored `order` does not reach the server yet. Marked `planned` + authorWarn until objectui lowers it, per enforce-or-mark. NOTE the separate, already-live default this issue also shipped: a selected TIME dimension defaults to ascending server-side, so month/quarter matrix columns are chronological with no `order` declared at all."
+      "status": "live",
+      "verifiedAt": "2026-07-29",
+      "evidence": "packages/spec/src/ui/report.zod.ts (reportSelectionOrder), packages/services/service-analytics/src/dataset-executor.ts (resolveOrdering/applyOrdering)",
+      "note": "framework#3916. Authored ordering, most significant key first; each `by` names a `rows`/`columns` dimension or a `values` measure the report selects (validated by the schema's superRefine; a `joined` report orders per block). `reportSelectionOrder` lowers the list to `DatasetSelection.order` and the executor applies it over the ASSEMBLED grid — after measure-scoped filters merge, `__compare` columns attach and derived measures evaluate — so a derived measure is a valid sort key. objectui: `DatasetReportRenderer`'s `useDatasetRows` (the single fetch choke point) carries it onto the posted selection across all four paths — grouped table, embedded chart, matrix cross-tab, per joined block — with `readOrder` lowering and `scopeOrder` narrowing it to each sub-selection, plus the ordering in the refetch signature (objectui#2964). Flipped from `planned` + authorWarn once that landed. Separate and independently live: a selected TIME dimension defaults to ascending server-side, so month/quarter matrix columns are chronological with no `order` declared at all."
     },
     "drilldown": {
       "status": "live",


### PR DESCRIPTION
#3916 的收尾。#3921 的后续，不是它的重开——那个 PR 已经合并，这是一次全新改动。

## 背景

`ReportSchema.order` 在 #3921 里是以 `planned` + `authorWarn` 上线的，因为当时它只有一半：schema 接受声明、`reportSelectionOrder` 负责降级、executor 会应用排序，但 objectui 的 `DatasetReportRenderer` 自己构造它 post 的 selection，从来没把 `report.order` 带进去——所以作者写的排序到不了任何查询。

当时把它标成 `live` 就正是这个闸门存在的意义所要拦下的那种谎报。

## 现在

objectui#2964 已合并（`85294442`），补上了那一半：`useDatasetRows` 作为所有报表路径背后唯一的取数收口，现在把降级后的排序带上了四个调用点——分组表、内嵌图表、matrix 交叉表、每个 joined block——排序进入 refetch signature，并按子选择收窄，以免图表更窄的 x/y 查询 post 一个它没选的键。

所以 ledger 条目：

- `status` 从 `planned` 翻成 `live`；
- 补上两条框架侧 evidence 路径（`reportSelectionOrder` 与 `resolveOrdering`/`applyOrdering`，都能在本 checkout 里解析）和 `verifiedAt` 时间戳；
- 去掉 `authorWarn` / `authorHint` —— 那条 advisory 说的是「你写了这个但运行时什么都不做」，现在不成立了，留着反而误导。

`note` 里同时记下了 objectui 侧的落地位置，供下次复核。

## 与时间轴默认排序无关

这次 issue 同时发的另一个东西——选中的时间维度在服务端默认升序——不受影响，它从一开始就独立 live，不需要任何渲染器改动。月/季度的 matrix 列不声明任何 `order` 也是按时间顺序的。

## 验证

`pnpm --filter @objectstack/spec check:liveness`：

```
report      21 classified (live 21)
evidence paths: 158 resolved against this checkout, 36 attributed to another repo
✓ all governed-type properties are classified; all bound high-risk proofs resolve.
```

（此前是 `live 20, planned 1`，evidence 156。）

本仓无行为变更，ledger 本身就是交付物。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYJ5WSiCgd522s1zCWtmFT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYJ5WSiCgd522s1zCWtmFT)_