### PR TITLE
fix(cli): make the migrate occupancy check fire on the journal mode we ship (#3917 follow-up)

### DIFF
--- a/.changeset/migrate-occupancy-file-descriptor-signal.md
+++ b/.changeset/migrate-occupancy-file-descriptor-signal.md
@@ -1,0 +1,28 @@
+---
+'@objectstack/cli': patch
+---
+
+Make the `os migrate` occupancy check actually fire, and extend it to
+`files-to-references` (#3917 follow-up).
+
+The check shipped in #3924 relied on a SQL lock probe
+(`PRAGMA locking_mode = EXCLUSIVE` + `BEGIN IMMEDIATE`), which is correct on a
+WAL database — and blind on the journal mode the platform actually uses.
+ObjectStack's sqlite driver runs `journal_mode = delete`, where an idle
+connection holds no lock at all, so dogfooding against a real `os serve`
+holding a real project database showed `os migrate apply` reporting the
+database idle and running the migration unannounced: exactly the scenario the
+check was added to prevent. The unit tests missed it because they built their
+fixtures in WAL mode.
+
+The probe now leads with the signal that survives every journal mode: which
+processes hold the file open (`/proc` on Linux, `lsof` on macOS). It also names
+them — `is in use — it is open in pid 12367 (node)` — which is the actionable
+part. The SQL probe is kept as a second signal for WAL databases on platforms
+where process inspection is unavailable or the holder belongs to another user;
+either signal firing counts as busy.
+
+`os migrate files-to-references --apply` now takes the same gate (and the same
+`--force` escape hatch). It rewrites rows rather than schema, so a concurrent
+writer on the same file is at least as dangerous there; a dry run only warns,
+since its counts shift under a live writer but it writes nothing itself.

--- a/content/docs/deployment/cli.mdx
+++ b/content/docs/deployment/cli.mdx
@@ -523,19 +523,38 @@ A running `os dev` / `os serve` holding the same SQLite file open is the usual
 way a migration goes wrong: the migration itself is transactional and swaps
 tables *inside* the file, but the live server keeps prepared statements and a
 schema cookie that the migration invalidates, and its writes can collide as
-`SQLITE_BUSY`. Before booting, `os migrate` asks the database whether anyone
-else is attached (`PRAGMA locking_mode = EXCLUSIVE` under `busy_timeout = 0` —
-non-destructive, and unlike a WAL checkpoint it also sees a connection that is
-merely *open* rather than actively writing).
+`SQLITE_BUSY`. Before booting, `os migrate` checks two things:
+
+1. **Which processes hold the file open** (`/proc` on Linux, `lsof` on macOS).
+   This is the signal that fires in practice. ObjectStack's sqlite driver runs
+   `journal_mode = delete`, and a rollback-journal database keeps no record of
+   who is attached — an idle server holds no lock at all, so no SQL probe can
+   see it. An open file descriptor is what it does leave, and it names the
+   process to go and stop.
+2. **A SQL lock probe** (`PRAGMA locking_mode = EXCLUSIVE` under
+   `busy_timeout = 0`). On a WAL database this catches an attached connection
+   even when step 1 cannot run — a platform without process inspection, or a
+   database held by another user's process.
+
+Either one firing counts as busy. Both are non-destructive: no row is read or
+written.
+
+```text
+✗ .objectstack/data/standalone.db is in use — it is open in pid 12367 (node).
+⚠ Stop the process using it (a running "os dev"/"os serve" is the usual one)
+  and re-run, or pass --force to migrate anyway.
+```
 
 | Command | If the database is in use |
 |---------|---------------------------|
 | `os migrate plan` | Warns and continues — a plan writes nothing either way |
 | `os migrate apply` | **Refuses** (exit 1, `error: database_busy` under `--json`). Stop the other process, or pass `--force` |
+| `os migrate files-to-references --apply` | **Refuses** likewise — it rewrites rows, so a concurrent writer is at least as dangerous |
 
-The check applies to SQLite only. Postgres and MySQL take their own server-side
-locks, and a `-wal`/`-shm` left behind by a crashed process is deliberately not
-treated as occupancy on its own.
+The check applies to SQLite only: Postgres and MySQL take their own server-side
+locks. Only same-user processes are visible without elevated privileges, and a
+`-wal`/`-shm` left behind by a crashed process is deliberately never treated as
+occupancy on its own.
 
 | Category | Examples | Applied by |
 |----------|----------|------------|

--- a/packages/cli/src/commands/migrate/files-to-references.ts
+++ b/packages/cli/src/commands/migrate/files-to-references.ts
@@ -15,6 +15,8 @@ import {
   isExitSignal,
 } from '../../utils/format.js';
 import { bootSchemaStack } from '../../utils/schema-migrate.js';
+import { OCCUPANCY_HINT, probeMigrationTarget } from '../../utils/migrate-occupancy-gate.js';
+import { describeOccupancy } from '../../utils/sqlite-occupancy.js';
 import { loadConfig } from '../../utils/config.js';
 
 async function confirm(question: string): Promise<boolean> {
@@ -88,6 +90,7 @@ export default class MigrateFilesToReferences extends Command {
     '$ os migrate files-to-references --apply',
     '$ os migrate files-to-references --apply --yes --json',
     '$ os migrate files-to-references --object product --object article',
+    '$ os migrate files-to-references --apply --force',
   ];
 
   static override flags = {
@@ -101,6 +104,10 @@ export default class MigrateFilesToReferences extends Command {
       default: false,
     }),
     yes: Flags.boolean({ char: 'y', description: 'Skip the --apply confirmation prompt', default: false }),
+    force: Flags.boolean({
+      description: 'Apply even when another process is using the database (SQLite occupancy check)',
+      default: false,
+    }),
     object: Flags.string({
       description: 'Restrict to this object (repeatable; default: every object with a file field)',
       multiple: true,
@@ -123,6 +130,41 @@ export default class MigrateFilesToReferences extends Command {
 
     if (!flags.json) {
       printHeader('Migrate · files-to-references');
+    }
+
+    // Occupancy gate (#3917 follow-up) — this command rewrites ROWS, so a live
+    // writer on the same SQLite file is at least as dangerous here as it is for
+    // `os migrate apply`: both processes would be mutating the same records
+    // with no coordination. Probed before boot (afterwards our own pool is what
+    // the probe finds) and before the confirmation prompt, so an operator is
+    // never asked to confirm something we are about to refuse.
+    const occupancy = await probeMigrationTarget(flags['database-url']);
+    if (occupancy.status === 'busy' && apply && !flags.force) {
+      if (flags.json) {
+        await emitJson({
+          error: 'database_busy',
+          database: occupancy.filename,
+          signal: occupancy.signal,
+          detail: occupancy.detail,
+          hint: OCCUPANCY_HINT,
+        }, 0, { compact: true });
+        this.exit(1);
+        return;
+      }
+      printError(describeOccupancy(occupancy));
+      printWarning(OCCUPANCY_HINT);
+      this.exit(1);
+      return;
+    }
+    if (occupancy.status === 'busy' && !flags.json) {
+      // A dry run writes nothing, so it only ever warns — but it warns, because
+      // the numbers it reports are a moving target while another process writes.
+      printWarning(apply
+        ? `--force: ${describeOccupancy(occupancy)} Converting anyway — the live process may write records mid-scan.`
+        : `${describeOccupancy(occupancy)} The dry run below writes nothing, but its counts may shift while that process is running.`);
+    }
+    if (occupancy.status === 'unknown' && !flags.json) {
+      printWarning(`Could not check whether the database is in use — ${occupancy.detail}`);
     }
 
     // Confirmation gate — before boot, since an apply run starts writing as

--- a/packages/cli/src/utils/sqlite-occupancy.test.ts
+++ b/packages/cli/src/utils/sqlite-occupancy.test.ts
@@ -14,13 +14,19 @@ import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createRequire } from 'node:module';
 import Database from 'better-sqlite3';
 
 import { probeSqliteOccupancy, sqliteSidecars, describeOccupancy } from './sqlite-occupancy.js';
 import { probeMigrationTarget } from './migrate-occupancy-gate.js';
 
+/** Resolved here so the spawned holder can `require` it without a cwd guess. */
+const betterSqlitePath = createRequire(import.meta.url).resolve('better-sqlite3');
+
 let dir: string;
 const openHandles: any[] = [];
+const spawnedHolders: ChildProcess[] = [];
 
 function newDb(name: string, journalMode: 'wal' | 'delete'): string {
   const file = join(dir, name);
@@ -39,6 +45,36 @@ function attach(file: string): any {
   return db;
 }
 
+/**
+ * Open the database from a SEPARATE process and leave it idle, the way a
+ * running `os serve` does. Needed because the file-descriptor signal ignores
+ * our own pid — an in-process handle proves nothing about it.
+ */
+async function attachFromAnotherProcess(file: string): Promise<{ pid: number }> {
+  const child = spawn(
+    process.execPath,
+    [
+      '-e',
+      // Open, read once, then idle. `setInterval` keeps the loop alive; the
+      // parent kills us in afterEach.
+      `const D=require(${JSON.stringify(betterSqlitePath)});` +
+      `const d=new D(${JSON.stringify(file)});` +
+      `d.prepare('SELECT * FROM t').all();` +
+      `process.send&&process.send('ready');` +
+      `setInterval(()=>{},1000);`,
+    ],
+    { stdio: ['ignore', 'ignore', 'ignore', 'ipc'] },
+  );
+  spawnedHolders.push(child);
+  await new Promise<void>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error('holder process did not signal ready')), 15_000);
+    child.on('message', () => { clearTimeout(t); resolve(); });
+    child.on('error', (e) => { clearTimeout(t); reject(e); });
+    child.on('exit', (code) => { clearTimeout(t); reject(new Error(`holder exited early (${code})`)); });
+  });
+  return { pid: child.pid! };
+}
+
 beforeAll(() => {
   dir = mkdtempSync(join(tmpdir(), 'os-occupancy-'));
 });
@@ -46,6 +82,9 @@ beforeAll(() => {
 afterEach(() => {
   while (openHandles.length > 0) {
     try { openHandles.pop()?.close(); } catch { /* already closed */ }
+  }
+  while (spawnedHolders.length > 0) {
+    try { spawnedHolders.pop()?.kill('SIGKILL'); } catch { /* already gone */ }
   }
 });
 
@@ -120,9 +159,36 @@ describe('probeSqliteOccupancy', () => {
     if (res.status === 'busy') expect(res.signal).toBe('write_lock');
   });
 
-  it('reports idle for a rollback-journal database nobody is writing', async () => {
+  it('reports idle for a rollback-journal database nobody has open', async () => {
     const file = newDb('idle-journal.db', 'delete');
     expect((await probeSqliteOccupancy(file)).status).toBe('idle');
+  });
+
+  /**
+   * The dogfood regression. ObjectStack's sqlite driver runs
+   * `journal_mode = delete`, and an idle connection to a rollback-journal
+   * database holds NO lock — so the SQL probe reports idle and, before the
+   * file-descriptor signal existed, `os migrate apply` ran unannounced against
+   * a live `os serve`. Verified by hand against a real CRM project before this
+   * test was written; the test is what keeps it fixed.
+   */
+  it('reports busy for a ROLLBACK-JOURNAL database an idle connection holds open', async () => {
+    const file = newDb('busy-journal-idle.db', 'delete');
+    // Must be a SEPARATE process: the probe deliberately ignores its own pid,
+    // and an in-process handle would not reproduce the reported scenario
+    // (a dev server in another terminal) anyway.
+    const holder = await attachFromAnotherProcess(file);
+
+    const res = await probeSqliteOccupancy(file);
+    expect(res.status).toBe('busy');
+    if (res.status === 'busy') {
+      expect(res.signal).toBe('file_open');
+      // Naming the process is the point — "stop pid N" is actionable in a way
+      // that "the database is busy" is not.
+      expect(res.holders?.length).toBeGreaterThan(0);
+      expect(res.holders?.map((h) => h.pid)).toContain(holder.pid);
+      expect(describeOccupancy(res)).toMatch(/pid \d+/);
+    }
   });
 
   it('does not mistake crash-left sidecars for a live connection', async () => {

--- a/packages/cli/src/utils/sqlite-occupancy.ts
+++ b/packages/cli/src/utils/sqlite-occupancy.ts
@@ -12,57 +12,78 @@
  * `SQLITE_BUSY` mid-migration, stale prepared statements in the live server,
  * and schema-cookie churn under its feet.
  *
- * ## The probe
+ * ## Two independent signals, because neither covers the ground alone
  *
- * On a WAL database (the default for every ObjectStack sqlite deployment),
- * `PRAGMA locking_mode = EXCLUSIVE` followed by `BEGIN IMMEDIATE` under
- * `busy_timeout = 0`. Exclusive locking mode makes SQLite stop using the `-shm`
- * shared-memory file, which it can only do by taking exclusive locks on it —
- * so the first transaction after the pragma fails with `SQLITE_BUSY` when, and
- * only when, another connection is attached. Attached is the right question,
- * not writing: a dev server sitting idle between requests still holds prepared
- * statements and a schema cookie that a migration invalidates.
+ * **1. Which processes hold the file open** (`/proc` on Linux, `lsof` on
+ * macOS). This is the signal that actually fires in practice, and it took
+ * dogfooding to learn why: ObjectStack's sqlite driver runs
+ * `journal_mode = delete`, NOT WAL. A rollback-journal database keeps no
+ * persistent record of who is attached — locks exist only for the duration of
+ * a transaction — so an idle `os serve` holds no lock at all and no amount of
+ * SQL can see it. An open file descriptor is the only thing it does leave, and
+ * it names the culprit, which is what an operator needs anyway.
  *
- * Two rejected alternatives, both measured rather than assumed:
+ * **2. A SQL lock probe** — `PRAGMA locking_mode = EXCLUSIVE` then
+ * `BEGIN IMMEDIATE` under `busy_timeout = 0`. On WAL this catches an attached
+ * connection even when signal 1 cannot run (a foreign platform, a hardened
+ * container with no `/proc` visibility, a connection held by another *user's*
+ * process); on a rollback journal it narrows to "someone is mid-write". Kept
+ * because it is authoritative where it applies and costs a millisecond.
  *
- * - **`-wal` / `-shm` presence alone.** Correct while a connection is open
- *   (SQLite creates them with the first attach and removes them with the last
- *   clean close) but it cannot tell a live server from a crashed one, and
- *   refusing to migrate because a dead process left files behind is its own
- *   operational bug. Sidecars are reported as supporting evidence, never as the
- *   verdict.
+ * Either signal firing means busy. Three rejected alternatives, all measured
+ * rather than assumed:
+ *
+ * - **`-wal` / `-shm` presence alone.** Correct while a connection is open, but
+ *   it cannot tell a live server from a crashed one, and it does not exist at
+ *   all on a rollback journal — which is what we actually ship. Sidecars are
+ *   reported as supporting evidence, never as the verdict.
  * - **`PRAGMA wal_checkpoint(TRUNCATE)`.** Reports `busy = 1` only when a
- *   *writer* is mid-transaction — an attached-but-idle connection checkpoints
- *   cleanly. It misses precisely the common case.
+ *   *writer* is mid-transaction; an attached-but-idle connection checkpoints
+ *   cleanly. Misses precisely the common case.
+ * - **The SQL probe on its own.** What shipped first, and what dogfooding
+ *   caught: against a real `os serve` holding a real project database, it
+ *   reported idle and the migration ran unannounced. Correct on WAL, blind on
+ *   the mode the platform defaults to.
  *
- * A rollback-journal database has no persistent record of who is attached
- * (locks exist only for the duration of a transaction), so there the probe
- * degrades honestly to `BEGIN IMMEDIATE`: it detects an active writer and
- * nothing more.
- *
- * The probe is non-destructive — an empty transaction, rolled back, with
- * locking mode restored — and it reads and writes no row.
+ * Both probes are non-destructive: an empty transaction rolled back with
+ * locking mode restored, and read-only filesystem inspection. No row is read
+ * or written.
  *
  * ## What it deliberately does NOT do
  *
- * No conclusion is invented when the probe cannot run — a missing
- * `better-sqlite3`, an unreadable file, a non-SQLite target. Those return
- * `unknown` / `not_applicable`, and the caller proceeds (a warning at most).
- * Refusing a migration because we failed to look would be worse than the bug
- * this guards.
+ * No conclusion is invented when neither signal can run — a missing
+ * `better-sqlite3`, an unreadable file, a platform with no process inspection.
+ * Those return `unknown` / `not_applicable`, and the caller proceeds (a warning
+ * at most). Refusing a migration because we failed to look would be worse than
+ * the bug this guards.
  */
 
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync, readlinkSync, realpathSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 
 export type SqliteOccupancy =
   /** Not a SQLite file target (postgres, mongo, `:memory:`) — nothing to probe. */
   | { status: 'not_applicable' }
-  /** Probed successfully; no other connection is attached. */
+  /** Probed successfully; nothing else is using the database. */
   | { status: 'idle'; filename: string; sidecars: string[] }
-  /** Another connection is using this database right now. */
-  | { status: 'busy'; filename: string; signal: 'wal_attached' | 'write_lock'; detail: string; sidecars: string[] }
-  /** Could not tell — the probe itself failed. Never a reason to refuse. */
+  /** Something else is using this database right now. */
+  | {
+    status: 'busy';
+    filename: string;
+    signal: 'file_open' | 'wal_attached' | 'write_lock';
+    detail: string;
+    sidecars: string[];
+    /** Processes holding the file open, when the platform let us look. */
+    holders?: FileHolder[];
+  }
+  /** Could not tell — the probes themselves failed. Never a reason to refuse. */
   | { status: 'unknown'; filename: string; detail: string; sidecars: string[] };
+
+/** A process with the database file open. `name` is best-effort. */
+export interface FileHolder {
+  pid: number;
+  name?: string;
+}
 
 /** The `-wal` / `-shm` companions that exist next to `filename`, if any. */
 export function sqliteSidecars(filename: string): string[] {
@@ -70,11 +91,95 @@ export function sqliteSidecars(filename: string): string[] {
 }
 
 /**
- * Probe `filename` for other attached connections. Never throws: every failure
- * mode collapses into `unknown`.
+ * Processes other than this one holding `filename` open.
+ *
+ * The load-bearing signal for a rollback-journal database, where an idle
+ * connection is invisible to SQL. Returns `[]` when nothing holds it AND when
+ * the platform cannot answer — callers must not read an empty array as proof
+ * of absence, which is why the SQL probe still runs alongside.
+ *
+ * Only same-user processes are visible without elevated privileges. That is
+ * the case that matters (your own dev server), and a database held by another
+ * user's process still has the SQL probe as a backstop on WAL.
+ */
+export function processesHoldingFile(filename: string): FileHolder[] {
+  try {
+    const target = realpathSync(filename);
+    if (process.platform === 'linux') return holdersFromProc(target);
+    if (process.platform === 'darwin') return holdersFromLsof(target);
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+/** Linux: walk `/proc/<pid>/fd` and compare link targets. No subprocess. */
+function holdersFromProc(target: string): FileHolder[] {
+  const out: FileHolder[] = [];
+  let pids: string[];
+  try { pids = readdirSync('/proc'); } catch { return []; }
+  for (const entry of pids) {
+    if (!/^\d+$/.test(entry)) continue;
+    const pid = Number(entry);
+    if (pid === process.pid) continue;
+    let fds: string[];
+    // EACCES for another user's process, ENOENT for one that just exited —
+    // both mean "nothing to learn here", not "stop scanning".
+    try { fds = readdirSync(`/proc/${entry}/fd`); } catch { continue; }
+    for (const fd of fds) {
+      let link: string;
+      try { link = readlinkSync(`/proc/${entry}/fd/${fd}`); } catch { continue; }
+      if (link === target) {
+        out.push({ pid, name: procName(entry) });
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+function procName(pid: string): string | undefined {
+  try {
+    // `comm` is the short name ("node"); enough to recognise, and it cannot
+    // leak a command line that may carry secrets.
+    return readlinkSync(`/proc/${pid}/exe`).split('/').pop();
+  } catch {
+    return undefined;
+  }
+}
+
+/** macOS: no `/proc`, so shell out to `lsof` — bounded, and failure is silent. */
+function holdersFromLsof(target: string): FileHolder[] {
+  try {
+    const raw = execFileSync('lsof', ['-Fpc', '--', target], {
+      encoding: 'utf8',
+      timeout: 3000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const out: FileHolder[] = [];
+    let pid: number | undefined;
+    for (const line of raw.split('\n')) {
+      if (line.startsWith('p')) {
+        pid = Number(line.slice(1));
+        if (pid === process.pid) pid = undefined;
+        else if (Number.isFinite(pid)) out.push({ pid });
+      } else if (line.startsWith('c') && pid !== undefined && out.length > 0) {
+        out[out.length - 1].name = line.slice(1);
+      }
+    }
+    return out;
+  } catch {
+    // lsof absent, or it exits non-zero when nothing holds the file.
+    return [];
+  }
+}
+
+/**
+ * Probe `filename` for anything else using it. Never throws: every failure mode
+ * collapses into `unknown`.
  *
  * MUST run before the caller's own stack connects — once our pool is attached,
- * the probe is answering about us.
+ * both signals are answering about us.
  */
 export async function probeSqliteOccupancy(filename: string | null | undefined): Promise<SqliteOccupancy> {
   if (!filename || filename === ':memory:' || filename.startsWith(':')) {
@@ -84,6 +189,20 @@ export async function probeSqliteOccupancy(filename: string | null | undefined):
 
   // A database that does not exist yet cannot be occupied.
   if (!existsSync(filename)) return { status: 'idle', filename, sidecars };
+
+  // Signal 1, first because it is the one that fires on the journal mode the
+  // platform actually ships, and because it can name the process.
+  const holders = processesHoldingFile(filename);
+  if (holders.length > 0) {
+    return {
+      status: 'busy',
+      filename,
+      signal: 'file_open',
+      sidecars,
+      holders,
+      detail: `it is open in ${describeHolders(holders)}`,
+    };
+  }
 
   let Database: any;
   try {
@@ -169,10 +288,16 @@ function isBusyError(e: unknown): boolean {
     || /SQLITE_BUSY/i.test(message);
 }
 
+/** `pid 4821 (node)` / `pids 4821 (node), 4822` — whatever we could learn. */
+function describeHolders(holders: FileHolder[]): string {
+  const label = holders.length === 1 ? 'pid' : 'pids';
+  return `${label} ${holders.map((h) => (h.name ? `${h.pid} (${h.name})` : String(h.pid))).join(', ')}`;
+}
+
 /**
- * One line an operator can act on. Names the file and the evidence — the
- * sidecars are included because "which process?" is answered by looking for
- * whoever holds them open.
+ * One line an operator can act on. Names the file and the evidence — and, when
+ * the platform let us look, the process to go and stop, which is the single
+ * most useful thing this can tell them.
  */
 export function describeOccupancy(occupancy: SqliteOccupancy): string {
   if (occupancy.status !== 'busy') return '';


### PR DESCRIPTION
Follow-up to #3924. **The occupancy check that PR shipped did not actually fire.**

## What dogfooding found

Booted a real `os serve` against a real `examples/app-crm` database, then ran `os migrate apply` from another terminal. It reported the database idle and ran the migration — adding 4 columns under the live server. Exactly the scenario the check was added to prevent.

The cause: the SQL lock probe (`PRAGMA locking_mode = EXCLUSIVE` + `BEGIN IMMEDIATE`) is correct on WAL and **blind on `journal_mode = delete`**, which is what ObjectStack's sqlite driver actually runs. A rollback-journal database keeps no persistent record of who is attached — locks exist only for the duration of a transaction — so an idle server holds nothing for SQL to see. The unit tests missed it because they built their fixtures in WAL mode.

```
$ node -e "…" # against the live project DB
journal_mode = delete
tables       = 37
```

## The fix

The probe now leads with the signal that survives every journal mode: **which processes hold the file open** — `/proc` on Linux (no subprocess), `lsof` on macOS. It also names them, which is the part an operator can act on:

```text
✗ …/dogfood.db is in use — it is open in pid 12367 (node).
⚠ Stop the process using it (a running "os dev"/"os serve" is the usual one)
  and re-run, or pass --force to migrate anyway.
```

The SQL probe stays as a second signal for WAL databases where process inspection is unavailable or the holder belongs to another user. Either signal firing counts as busy; neither reads or writes a row.

Also extends the gate to **`os migrate files-to-references --apply`** with the same `--force` escape hatch — it rewrites rows rather than schema, so a concurrent writer is at least as dangerous there. Its dry run only warns (counts shift under a live writer, but it writes nothing itself).

## Verification

Terminal-verified end to end against `examples/app-crm`, which is what caught the bug in the first place:

| Scenario | Result |
|---|---|
| `plan` on a fresh DB | renders 11 pending creates, leaves **0 tables** |
| `apply` without `--yes` (non-TTY) | asks for confirmation, leaves **0 tables** |
| `apply --yes` | creates exactly **11**, `crm_account` has **0 rows** (seed suppressed) |
| `apply --yes` vs. live server | **refuses**, exit 1, names pid |
| `apply --yes --json` vs. live server | `{"error":"database_busy","signal":"file_open",…}` |
| `apply --yes --force` vs. live server | proceeds after warning |
| `files-to-references --apply` vs. live server | **refuses**; dry run warns only |

The regression test spawns a real second process — the probe deliberately ignores its own pid, and an in-process handle would not reproduce the reported scenario. CLI suite: 796 passed (76 files).

## Related finding, not fixed here

`journal_mode = delete` is itself questionable for a platform that expects a dev server and CLI tools to share a file — WAL would give better read/write concurrency and make the SQL probe authoritative. That is a driver-wide behaviour change with its own compatibility surface (WAL does not work on network filesystems), so it is filed separately rather than smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuPwgESj5s5LVSGqh2nWag

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuPwgESj5s5LVSGqh2nWag)_