### PR TITLE
fix(spec,rest): enforce the batch-size cap, and give each bulk endpoint one Zod source (#3939)

### DIFF
--- a/.changeset/bulk-batch-size-cap.md
+++ b/.changeset/bulk-batch-size-cap.md
@@ -1,0 +1,67 @@
+---
+"@objectstack/spec": minor
+"@objectstack/rest": minor
+---
+
+fix(spec,rest): the batch-size cap is enforced now, and each bulk endpoint has one Zod source (#3939)
+
+`max 200` was declared in four places and enforced in one.
+
+`batch.zod.ts` put `.min(1).max(200)` on `BatchUpdateRequestSchema`,
+`UpdateManyRequestSchema` and `DeleteManyRequestSchema`, and the docs repeated
+it — but no per-object bulk route validated against those schemas, so
+`createMany` / `updateMany` / `deleteMany` / `/data/:object/batch` all accepted
+an unbounded list. The only route that capped anything was the cross-object
+`/batch`, and it checked the *configured* `maxBatchSize` rather than the
+hardcoded 200 — so even the one enforcement point disagreed with the schema.
+
+That stopped being cosmetic with #3897, which made `deleteMany` delete per id by
+primary key (so `deleteBehavior` cascades run and every row gets its own
+result). A 10k-id body is now 10k sequential engine round-trips inside a single
+request, where before it was one statement that mostly failed anyway.
+
+**The cap moved to the routes, and the schemas gave it up.** Batch size is
+deployment policy — `RestServerConfig.batch.maxBatchSize`, 1..1000, default 200
+— so a hardcoded bound in the spec could only ever be a second, wrong answer
+(a deployment raising the limit to 500 would still have been refused at 200).
+All five bulk routes now call one `enforceBatchSize` helper with the configured
+value and answer with one envelope:
+
+```json
+{ "error": "Batch too large: 500 records (max 200)", "code": "BATCH_TOO_LARGE",
+  "count": 500, "max": 200, "object": "account" }
+```
+
+The cross-object route is included: it used to answer with a bare `error` string
+and no `code` for a client to key on.
+
+**One Zod source per bulk endpoint (Prime Directive #7).** Each of these
+endpoints had *two* schemas, and they had already drifted into disagreeing about
+more than counts: `UpdateManyRequestSchema` described its rows with
+`BatchRecordSchema`, whose `id` and `data` are optional because the generic
+`/batch` route serves create (no id) and delete (no data) through the same
+shape — so the declared contract accepted `{}` rows that `updateManyData`, which
+reads `record.id` and `record.data` unconditionally, could never process. The
+enforced shape lived in the *other* copy, in `protocol.zod.ts`.
+
+The wire body is now the single source (`UpdateManyRequestSchema` /
+`DeleteManyRequestSchema`, with the new `UpdateManyRecordSchema` for a row), and
+the protocol schemas are that plus the `object` the route takes from the URL
+path (#3933) — `UpdateManyRequestSchema.extend({ object })`. The derivation runs
+that direction because `protocol.zod` already imports `batch.zod`; the reverse
+would be a cycle.
+
+**Behaviour changes.**
+
+- A bulk request over the configured cap is `400 BATCH_TOO_LARGE` instead of
+  being executed. Deployments that were quietly relying on unbounded batches
+  should raise `batch.maxBatchSize` (up to 1000) rather than discover the cap in
+  production.
+- `.min(1)` is gone with `.max(200)`: an empty batch is a no-op returning
+  `total: 0`, which is what these routes already did, rather than a validation
+  error the schema claimed but nothing raised.
+- `UpdateManyRequest` now types (and validates) `records` as
+  `{ id: string; data: Record<string, unknown> }[]`. Callers already had to send
+  that — the route has validated the strict shape since #3933 — but the declared
+  type was looser.
+- New export: `UpdateManyRecordSchema` / `UpdateManyRecord`.

--- a/content/docs/api/data-api.mdx
+++ b/content/docs/api/data-api.mdx
@@ -143,6 +143,25 @@ deleted one at a time by primary key, so each honours `deleteBehavior`
 (default) stops the run at the first failure; `atomic: false` with
 `continueOnError: true` processes the remaining ids and reports the failures.
 
+### Batch size
+
+Every bulk route above — `batch`, `createMany`, `updateMany`, `deleteMany` —
+caps how many records one request may carry. The limit is the deployment's
+`batch.maxBatchSize` (default **200**, configurable 1–1000); over it the request
+is rejected with `400 BATCH_TOO_LARGE` before anything is written:
+
+```json
+{
+  "error": "Batch too large: 500 records (max 200)",
+  "code": "BATCH_TOO_LARGE",
+  "count": 500,
+  "max": 200,
+  "object": "account"
+}
+```
+
+An empty batch is not an error — it is a no-op that returns `total: 0`.
+
 ---
 
 ### `POST /data/:object/:id/clone`

--- a/content/docs/protocol/kernel/http-protocol.mdx
+++ b/content/docs/protocol/kernel/http-protocol.mdx
@@ -645,7 +645,10 @@ Content-Type: application/json
 ```
 
 **Behavior:**
-- Maximum batch size: 200 operations by default (configurable via `maxBatchSize`)
+- Maximum batch size: 200 operations by default (configurable via `maxBatchSize`).
+  Over the cap is `400 BATCH_TOO_LARGE`, carrying the `count` sent and the `max`
+  allowed. The same cap and the same code apply to every bulk write route
+  (`createMany` / `updateMany` / `deleteMany` / per-object `batch`)
 - The entire batch runs inside **one engine transaction** — if any operation
   fails, all are rolled back (commit-all-or-nothing). The batch is always
   atomic; an explicit `"atomic": false` is rejected with `400 BATCH_NOT_ATOMIC`

--- a/content/docs/references/api/batch.mdx
+++ b/content/docs/references/api/batch.mdx
@@ -30,8 +30,8 @@ Industry alignment: Salesforce Bulk API, Microsoft Dynamics Bulk Operations
 ## TypeScript Usage
 
 ```typescript
-import { BatchConfig, BatchOperationResult, BatchOperationType, BatchOptions, BatchRecord, BatchUpdateRequest, BatchUpdateResponse, CrossObjectBatchDroppedFields, CrossObjectBatchOperation, CrossObjectBatchRequest, CrossObjectBatchResponse, DeleteManyRequest, UpdateManyRequest } from '@objectstack/spec/api';
-import type { BatchConfig, BatchOperationResult, BatchOperationType, BatchOptions, BatchRecord, BatchUpdateRequest, BatchUpdateResponse, CrossObjectBatchDroppedFields, CrossObjectBatchOperation, CrossObjectBatchRequest, CrossObjectBatchResponse, DeleteManyRequest, UpdateManyRequest } from '@objectstack/spec/api';
+import { BatchConfig, BatchOperationResult, BatchOperationType, BatchOptions, BatchRecord, BatchUpdateRequest, BatchUpdateResponse, CrossObjectBatchDroppedFields, CrossObjectBatchOperation, CrossObjectBatchRequest, CrossObjectBatchResponse, DeleteManyRequest, UpdateManyRecord, UpdateManyRequest } from '@objectstack/spec/api';
+import type { BatchConfig, BatchOperationResult, BatchOperationType, BatchOptions, BatchRecord, BatchUpdateRequest, BatchUpdateResponse, CrossObjectBatchDroppedFields, CrossObjectBatchOperation, CrossObjectBatchRequest, CrossObjectBatchResponse, DeleteManyRequest, UpdateManyRecord, UpdateManyRequest } from '@objectstack/spec/api';
 
 // Validate data
 const result = BatchConfig.parse(data);
@@ -114,7 +114,7 @@ const result = BatchConfig.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **operation** | `Enum<'create' \| 'update' \| 'upsert' \| 'delete'>` | ✅ | Type of batch operation |
-| **records** | `{ id?: string; data?: Record<string, any>; externalId?: string }[]` | ✅ | Array of records to process (max 200 per batch) |
+| **records** | `{ id?: string; data?: Record<string, any>; externalId?: string }[]` | ✅ | Array of records to process (server caps the count — see batch.maxBatchSize) |
 | **options** | `{ atomic: boolean; returnRecords: boolean; continueOnError: boolean; validateOnly: boolean }` | optional | Batch operation options |
 
 
@@ -198,8 +198,20 @@ A cross-object batch strip event: dropped fields plus the operation index
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **ids** | `string[]` | ✅ | Array of record IDs to delete (max 200) |
+| **ids** | `string[]` | ✅ | Array of record IDs to delete (server caps the count — see batch.maxBatchSize) |
 | **options** | `{ atomic: boolean; returnRecords: boolean; continueOnError: boolean; validateOnly: boolean }` | optional | Delete options |
+
+
+---
+
+## UpdateManyRecord
+
+### Properties
+
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| **id** | `string` | ✅ | Record ID |
+| **data** | `Record<string, any>` | ✅ | Fields to update |
 
 
 ---
@@ -210,7 +222,7 @@ A cross-object batch strip event: dropped fields plus the operation index
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **records** | `{ id?: string; data?: Record<string, any>; externalId?: string }[]` | ✅ | Array of records to update (max 200 per batch) |
+| **records** | `{ id: string; data: Record<string, any> }[]` | ✅ | Array of records to update (server caps the count — see batch.maxBatchSize) |
 | **options** | `{ atomic: boolean; returnRecords: boolean; continueOnError: boolean; validateOnly: boolean }` | optional | Update options |
 
 

--- a/content/docs/references/api/protocol.mdx
+++ b/content/docs/references/api/protocol.mdx
@@ -447,9 +447,9 @@ const result = AiAgentCapabilities.parse(data);
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **object** | `string` | ✅ | Object name |
-| **ids** | `string[]` | ✅ | Array of record IDs to delete |
+| **ids** | `string[]` | ✅ | Array of record IDs to delete (server caps the count — see batch.maxBatchSize) |
 | **options** | `{ atomic: boolean; returnRecords: boolean; continueOnError: boolean; validateOnly: boolean }` | optional | Delete options |
+| **object** | `string` | ✅ | Object name |
 
 
 ---
@@ -1403,9 +1403,9 @@ const result = AiAgentCapabilities.parse(data);
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **object** | `string` | ✅ | Object name |
-| **records** | `{ id: string; data: Record<string, any> }[]` | ✅ | Array of updates |
+| **records** | `{ id: string; data: Record<string, any> }[]` | ✅ | Array of records to update (server caps the count — see batch.maxBatchSize) |
 | **options** | `{ atomic: boolean; returnRecords: boolean; continueOnError: boolean; validateOnly: boolean }` | optional | Update options |
+| **object** | `string` | ✅ | Object name |
 
 
 ---

--- a/packages/rest/src/rest-batch-size-cap.test.ts
+++ b/packages/rest/src/rest-batch-size-cap.test.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// [#3939] "max 200" was declared on three Zod schemas and in the docs, and
+// enforced on exactly one route (the cross-object /batch, which checked the
+// CONFIGURED maxBatchSize rather than the hardcoded 200). Every per-object bulk
+// route took an unbounded list — which #3897 made expensive as well as rude,
+// since deleteMany now costs one engine round-trip per id.
+//
+// The cap now lives at the route, driven by `batch.maxBatchSize`, on all of
+// them, with one envelope.
+
+import { describe, it, expect, vi } from 'vitest';
+import { RestServer } from './rest-server';
+
+function createMockServer() {
+  return {
+    get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn(), use: vi.fn(),
+    listen: vi.fn().mockResolvedValue(undefined), close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeRes() {
+  const res: any = { statusCode: 200, body: undefined };
+  res.status = vi.fn((c: number) => { res.statusCode = c; return res; });
+  res.json = vi.fn((b: any) => { res.body = b; return res; });
+  res.setHeader = vi.fn(); res.write = vi.fn(); res.end = vi.fn();
+  return res;
+}
+
+function setup(maxBatchSize?: number) {
+  const spies = {
+    createManyData: vi.fn().mockResolvedValue({ object: 'invoice', records: [], count: 0 }),
+    updateManyData: vi.fn().mockResolvedValue({ success: true, total: 0, succeeded: 0, failed: 0, results: [] }),
+    deleteManyData: vi.fn().mockResolvedValue({ success: true, total: 0, succeeded: 0, failed: 0, results: [] }),
+    batchData: vi.fn().mockResolvedValue({ success: true, total: 0, succeeded: 0, failed: 0, results: [] }),
+  };
+  const protocol: any = {
+    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: { data: '', metadata: '', ui: '', auth: '/auth' } }),
+    getMetaTypes: vi.fn().mockResolvedValue([]),
+    getMetaItems: vi.fn().mockResolvedValue([{ name: 'invoice' }]),
+    getMetaItem: vi.fn().mockResolvedValue({}),
+    findData: vi.fn().mockResolvedValue([]),
+    ...spies,
+  };
+  // The cross-object /batch route 501s without an ObjectQL provider that can
+  // open a transaction, so give it one — the cap check sits behind that gate.
+  const ql = { transaction: vi.fn(async (fn: any) => fn({})) };
+  const rest = new RestServer(
+    createMockServer() as any,
+    protocol,
+    { api: { requireAuth: false }, ...(maxBatchSize !== undefined ? { batch: { maxBatchSize } } : {}) } as any,
+    undefined, undefined, undefined, undefined, // kernelManager, envRegistry, defaultEnvIdProvider, authServiceProvider
+    async () => ql,                             // objectQLProvider (positional arg #8)
+  );
+  rest.registerRoutes();
+  return { rest, ql, ...spies };
+}
+
+async function post(rest: any, path: string, body: any) {
+  const route = rest.getRoutes().find((r: any) => r.method === 'POST' && r.path === path);
+  if (!route) throw new Error(`route not registered: ${path}`);
+  const res = makeRes();
+  await route.handler({ method: 'POST', params: { object: 'invoice' }, query: {}, body }, res);
+  return res;
+}
+
+const ids = (n: number) => Array.from({ length: n }, (_, i) => `r${i}`);
+const updates = (n: number) => ids(n).map((id) => ({ id, data: { name: id } }));
+const creates = (n: number) => ids(n).map((id) => ({ name: id }));
+
+const DELETE_MANY = '/api/v1/data/:object/deleteMany';
+const UPDATE_MANY = '/api/v1/data/:object/updateMany';
+const CREATE_MANY = '/api/v1/data/:object/createMany';
+const OBJ_BATCH = '/api/v1/data/:object/batch';
+
+describe('bulk routes enforce the configured batch cap (#3939)', () => {
+  it('deleteMany: 201 ids against a default cap of 200 → 400, protocol never called', async () => {
+    const { rest, deleteManyData } = setup();
+    const res = await post(rest, DELETE_MANY, { ids: ids(201) });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toMatchObject({ code: 'BATCH_TOO_LARGE', count: 201, max: 200, object: 'invoice' });
+    expect(deleteManyData).not.toHaveBeenCalled();
+  });
+
+  it('updateMany: 201 records → 400, protocol never called', async () => {
+    const { rest, updateManyData } = setup();
+    const res = await post(rest, UPDATE_MANY, { records: updates(201) });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toMatchObject({ code: 'BATCH_TOO_LARGE', count: 201, max: 200 });
+    expect(updateManyData).not.toHaveBeenCalled();
+  });
+
+  it('createMany: 201 records (bare array body) → 400, protocol never called', async () => {
+    const { rest, createManyData } = setup();
+    const res = await post(rest, CREATE_MANY, creates(201));
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toMatchObject({ code: 'BATCH_TOO_LARGE', count: 201, max: 200 });
+    expect(createManyData).not.toHaveBeenCalled();
+  });
+
+  it('per-object batch: 201 records → 400, protocol never called', async () => {
+    const { rest, batchData } = setup();
+    const res = await post(rest, OBJ_BATCH, { operation: 'update', records: updates(201) });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toMatchObject({ code: 'BATCH_TOO_LARGE', count: 201, max: 200 });
+    expect(batchData).not.toHaveBeenCalled();
+  });
+
+  it('exactly at the cap still goes through', async () => {
+    const { rest, deleteManyData } = setup();
+    const res = await post(rest, DELETE_MANY, { ids: ids(200) });
+
+    expect(res.statusCode).toBe(200);
+    expect(deleteManyData).toHaveBeenCalledTimes(1);
+  });
+
+  it('the cap follows the deployment config, not a hardcoded 200', async () => {
+    // Raised: 500 is fine when the deployment says so.
+    const raised = setup(500);
+    expect((await post(raised.rest, DELETE_MANY, { ids: ids(300) })).statusCode).toBe(200);
+    expect(raised.deleteManyData).toHaveBeenCalledTimes(1);
+
+    // Lowered: 10 rejects what the default would have accepted.
+    const lowered = setup(10);
+    const res = await post(lowered.rest, DELETE_MANY, { ids: ids(11) });
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toMatchObject({ code: 'BATCH_TOO_LARGE', count: 11, max: 10 });
+    expect(lowered.deleteManyData).not.toHaveBeenCalled();
+  });
+
+  it('a shape error still wins over the size error', async () => {
+    // Both wrong: 201 entries AND the wrong entry type. The caller hears about
+    // the shape first — it is the more specific answer.
+    const { rest } = setup();
+    const res = await post(rest, DELETE_MANY, { ids: ids(201).map((id) => ({ id })) });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.code).toBe('VALIDATION_FAILED');
+  });
+});
+
+describe('cross-object batch reports the cap like everyone else (#3939)', () => {
+  it('carries BATCH_TOO_LARGE instead of a bare error string', async () => {
+    const { rest, ql } = setup(5);
+    const route = rest.getRoutes().find((r: any) => r.method === 'POST' && r.path === '/api/v1/batch');
+    const res = makeRes();
+    await route!.handler({
+      method: 'POST',
+      params: {},
+      query: {},
+      body: { operations: ids(6).map((id) => ({ object: 'invoice', action: 'delete', id })) },
+    }, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toMatchObject({ code: 'BATCH_TOO_LARGE', count: 6, max: 5 });
+    // Rejected before anything was written.
+    expect(ql.transaction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -1243,6 +1243,39 @@ export class RestServer {
     }
 
     /**
+     * [#3939] Enforce the deployment's batch-size cap on a bulk write route.
+     * Returns `true` when a response was sent (the caller must return).
+     *
+     * The cap was declared in three places in `batch.zod.ts` (`.max(200)` on
+     * `BatchUpdateRequestSchema` / `UpdateManyRequestSchema` /
+     * `DeleteManyRequestSchema`, plus "max 200" in the docs) and enforced in
+     * exactly one route — the cross-object `/batch`, which checked the
+     * CONFIGURED `maxBatchSize` rather than the hardcoded 200. Every per-object
+     * bulk route accepted an unbounded list.
+     *
+     * That went from nuisance to real with #3897: `deleteMany` now deletes per
+     * id by primary key (so `deleteBehavior` cascades run and each row gets its
+     * own result), which turns a 10k-id body into 10k sequential engine
+     * round-trips inside one request instead of one statement.
+     *
+     * The cap is deployment policy — `RestServerConfig.batch.maxBatchSize`
+     * (1..1000, default 200) — so it lives here and the schemas carry shape
+     * only. One place decides it, and it is the place that knows the
+     * deployment's configured value.
+     */
+    private enforceBatchSize(res: any, count: number, max: number, object?: string): boolean {
+        if (count <= max) return false;
+        res.status(400).json({
+            error: `Batch too large: ${count} records (max ${max})`,
+            code: 'BATCH_TOO_LARGE',
+            count,
+            max,
+            ...(object ? { object } : {}),
+        });
+        return true;
+    }
+
+    /**
      * [#3544] Enforce the USER-LEVEL export axis on a bulk-egress route, after
      * {@link enforceApiAccess} has cleared the object-level one. Returns `true`
      * when a response was sent (the caller must return).
@@ -6588,6 +6621,10 @@ export class RestServer {
         const isScoped = basePath.includes('/environments/:environmentId');
 
         const operations = batch.operations;
+        // [#3939] One cap, read once, applied by every bulk route below via
+        // {@link enforceBatchSize} — see that method for why it lives here and
+        // not in the Zod schemas.
+        const maxBatch = batch.maxBatchSize ?? 200;
 
         // POST /batch — cross-object transactional batch (issue #1604 / ADR-0034).
         // Runs heterogeneous create/update/delete across objects in ONE engine
@@ -6627,9 +6664,11 @@ export class RestServer {
                         res.status(400).json({ error: 'Cross-object batch is always atomic; use POST /data/:object/batch for non-atomic per-object batches', code: 'BATCH_NOT_ATOMIC' });
                         return;
                     }
-                    const max = batch.maxBatchSize ?? 200;
                     if (ops.length === 0) { res.json({ results: [] }); return; }
-                    if (ops.length > max) { res.status(400).json({ error: `Batch too large (max ${max})` }); return; }
+                    // [#3939] Same check, same envelope as every other bulk route
+                    // now — this one used to be the only one that capped at all,
+                    // and it answered without a `code` for clients to key on.
+                    if (this.enforceBatchSize(res, ops.length, maxBatch)) return;
 
                     // update/delete need a target id — the schema can't express this
                     // conditionally, so surface it as a 400 up front.
@@ -6772,6 +6811,11 @@ export class RestServer {
                         // [#3391] bulk ∧ child(body.operation) — the object must grant
                         // the `bulk` primitive AND the batched write kind.
                         if (await this.enforceApiAccess(req, res, p, environmentId, 'bulk', { bulkChild: req.body?.operation })) return;
+                        // [#3939] `BatchUpdateRequestSchema` declared `max(200)`,
+                        // but this route hands the body straight to the protocol
+                        // without validating it — so nothing enforced the bound.
+                        if (Array.isArray(req.body?.records)
+                            && this.enforceBatchSize(res, req.body.records.length, maxBatch, req.params?.object)) return;
                         const result = await p.batchData!({
                             object: req.params.object,
                             request: req.body,
@@ -6804,6 +6848,9 @@ export class RestServer {
                         if (this.enforceAuth(req, res, context)) return;
                         // [#3391] bulk ∧ create — createMany requires the `bulk` primitive.
                         if (await this.enforceApiAccess(req, res, p, environmentId, 'bulk', { bulkChild: 'create' })) return;
+                        // [#3939] Body IS the records array on this route.
+                        if (Array.isArray(req.body)
+                            && this.enforceBatchSize(res, req.body.length, maxBatch, req.params?.object)) return;
                         const result = await p.createManyData!({
                             object: req.params.object,
                             records: req.body || [],
@@ -6860,6 +6907,9 @@ export class RestServer {
                             });
                             return;
                         }
+                        // [#3939] Cap AFTER the shape check, so a caller gets the
+                        // more specific answer first.
+                        if (this.enforceBatchSize(res, parsedUpdate.data.records.length, maxBatch, req.params?.object)) return;
                         const result = await p.updateManyData!({
                             ...parsedUpdate.data,
                             ...(environmentId ? { environmentId } : {}),
@@ -6921,6 +6971,10 @@ export class RestServer {
                             });
                             return;
                         }
+                        // [#3939] The cap that matters most: since #3897 this
+                        // route deletes per id, so the list length IS the engine
+                        // round-trip count.
+                        if (this.enforceBatchSize(res, parsed.data.ids.length, maxBatch, req.params?.object)) return;
                         const result = await p.deleteManyData!({
                             ...parsed.data,
                             ...(environmentId ? { environmentId } : {}),

--- a/packages/spec/api-surface.json
+++ b/packages/spec/api-surface.json
@@ -3026,6 +3026,8 @@
     "UpdateManyDataRequestSchema (const)",
     "UpdateManyDataResponse (type)",
     "UpdateManyDataResponseSchema (const)",
+    "UpdateManyRecord (type)",
+    "UpdateManyRecordSchema (const)",
     "UpdateManyRequest (type)",
     "UpdateManyRequestSchema (const)",
     "UpdateNotificationPreferencesRequest (type)",

--- a/packages/spec/authorable-surface.json
+++ b/packages/spec/authorable-surface.json
@@ -2020,6 +2020,8 @@
     "api/UpdateManyDataResponse:succeeded",
     "api/UpdateManyDataResponse:success",
     "api/UpdateManyDataResponse:total",
+    "api/UpdateManyRecord:data",
+    "api/UpdateManyRecord:id",
     "api/UpdateManyRequest:options",
     "api/UpdateManyRequest:records",
     "api/UpdateNotificationPreferencesRequest:preferences",

--- a/packages/spec/json-schema.manifest.json
+++ b/packages/spec/json-schema.manifest.json
@@ -473,6 +473,7 @@
     "api/UpdateFlowResponse",
     "api/UpdateManyDataRequest",
     "api/UpdateManyDataResponse",
+    "api/UpdateManyRecord",
     "api/UpdateManyRequest",
     "api/UpdateNotificationPreferencesRequest",
     "api/UpdateNotificationPreferencesResponse",

--- a/packages/spec/src/api/batch.test.ts
+++ b/packages/spec/src/api/batch.test.ts
@@ -94,16 +94,21 @@ describe('BatchUpdateRequestSchema', () => {
     expect(request.options?.atomic).toBe(true);
   });
 
-  it('should require at least one record', () => {
+  // [#3939] The count bounds moved OUT of the schema. They were a second source
+  // of truth that never matched reality: the schema said 1..200 while the routes
+  // enforced nothing, and the one route that did cap read the deployment's
+  // configured `batch.maxBatchSize` (1..1000) instead. The cap is now enforced
+  // at the route from that config, and the schema carries shape only.
+  it('accepts an empty record list — an empty batch is a no-op, not a client error', () => {
     expect(() =>
       BatchUpdateRequestSchema.parse({
         operation: 'create',
         records: [],
       })
-    ).toThrow();
+    ).not.toThrow();
   });
 
-  it('should limit to 200 records', () => {
+  it('does not cap the record count — that is the route\'s job (batch.maxBatchSize)', () => {
     const records = Array(201)
       .fill(null)
       .map((_, i) => ({ id: String(i), data: {} }));
@@ -113,7 +118,7 @@ describe('BatchUpdateRequestSchema', () => {
         operation: 'update',
         records,
       })
-    ).toThrow();
+    ).not.toThrow();
   });
 
   it('should accept exactly 200 records', () => {
@@ -151,6 +156,49 @@ describe('UpdateManyRequestSchema', () => {
 
     expect(request.records).toHaveLength(1);
     expect(request.options).toBeUndefined();
+  });
+
+  // [#3939] This schema used to reuse `BatchRecordSchema`, whose `id`/`data` are
+  // optional because the generic /batch route serves create (no id) and delete
+  // (no data) through it. updateMany needs both on every row — `updateManyData`
+  // reads them unconditionally — so the declared contract accepted rows the
+  // implementation could not process.
+  it('requires id AND data on every row', () => {
+    expect(() => UpdateManyRequestSchema.parse({ records: [{}] })).toThrow();
+    expect(() => UpdateManyRequestSchema.parse({ records: [{ id: '1' }] })).toThrow();
+    expect(() => UpdateManyRequestSchema.parse({ records: [{ data: { name: 'x' } }] })).toThrow();
+  });
+});
+
+// [#3939] Prime Directive #7 — one Zod source per contract. The protocol-level
+// request schemas ARE the wire-body schemas plus the `object` the REST route
+// takes from the URL path (#3933). They used to be hand-maintained copies that
+// had already drifted: batch.zod's accepted `{}` rows, protocol.zod's required
+// id+data, and only the latter was ever enforced. Pin the relationship so a
+// future edit to one cannot silently fork them again.
+describe('protocol request schemas derive from the wire-body schemas (#3939)', () => {
+  it('updateMany: same record shape, plus object', async () => {
+    const { UpdateManyDataRequestSchema } = await import('./protocol.zod');
+    const records = [{ id: '1', data: { name: 'x' } }];
+
+    expect(() => UpdateManyDataRequestSchema.parse({ object: 'task', records })).not.toThrow();
+    // The object is required here and absent from the body schema.
+    expect(() => UpdateManyDataRequestSchema.parse({ records })).toThrow();
+    // Row shape is inherited, not re-declared.
+    expect(() => UpdateManyDataRequestSchema.parse({ object: 'task', records: [{ id: '1' }] })).toThrow();
+  });
+
+  it('deleteMany: same ids shape, plus object', async () => {
+    const { DeleteManyDataRequestSchema } = await import('./protocol.zod');
+
+    expect(() => DeleteManyDataRequestSchema.parse({ object: 'task', ids: ['1'] })).not.toThrow();
+    expect(() => DeleteManyDataRequestSchema.parse({ ids: ['1'] })).toThrow();
+    expect(() => DeleteManyDataRequestSchema.parse({ object: 'task', ids: [{ $ne: null }] })).toThrow();
+    // No count bound inherited either — the route owns that.
+    expect(() => DeleteManyDataRequestSchema.parse({
+      object: 'task',
+      ids: Array(201).fill(null).map((_, i) => String(i)),
+    })).not.toThrow();
   });
 });
 
@@ -285,15 +333,16 @@ describe('DeleteManyRequestSchema', () => {
     expect(request.options?.atomic).toBe(true);
   });
 
-  it('should require at least one ID', () => {
+  // [#3939] See BatchUpdateRequestSchema above — bounds live at the route now.
+  it('accepts an empty ID list — deleting nothing is a no-op, not an error', () => {
     expect(() =>
       DeleteManyRequestSchema.parse({
         ids: [],
       })
-    ).toThrow();
+    ).not.toThrow();
   });
 
-  it('should limit to 200 IDs', () => {
+  it('does not cap the ID count — that is the route\'s job (batch.maxBatchSize)', () => {
     const ids = Array(201)
       .fill(null)
       .map((_, i) => String(i));
@@ -302,7 +351,7 @@ describe('DeleteManyRequestSchema', () => {
       DeleteManyRequestSchema.parse({
         ids,
       })
-    ).toThrow();
+    ).not.toThrow();
   });
 });
 

--- a/packages/spec/src/api/batch.zod.ts
+++ b/packages/spec/src/api/batch.zod.ts
@@ -86,7 +86,13 @@ export type BatchOptions = z.infer<typeof BatchOptionsSchema>;
  */
 export const BatchUpdateRequestSchema = lazySchema(() => z.object({
   operation: BatchOperationType.describe('Type of batch operation'),
-  records: z.array(BatchRecordSchema).min(1).max(200).describe('Array of records to process (max 200 per batch)'),
+  // [#3939] No `.max()` here: the batch-size cap is DEPLOYMENT policy
+  // (`RestServerConfig.batch.maxBatchSize`, 1..1000, default 200), enforced at
+  // the route so one place decides it. A hardcoded bound in the spec was a
+  // second source of truth that never matched — it said 200 while the routes
+  // enforced nothing at all. `.min(1)` is gone too: an empty batch is a no-op
+  // (`total: 0`), not a client error.
+  records: z.array(BatchRecordSchema).describe('Array of records to process (server caps the count — see batch.maxBatchSize)'),
   options: BatchOptionsSchema.optional().describe('Batch operation options'),
 }));
 
@@ -106,8 +112,29 @@ export type BatchUpdateRequest = z.input<typeof BatchUpdateRequestSchema>;
  *   "options": { "atomic": true }
  * }
  */
+/**
+ * One row of an `updateMany` batch.
+ *
+ * [#3939] Deliberately NOT {@link BatchRecordSchema}, which makes `id` and
+ * `data` optional because the generic `/batch` route serves create (no id) and
+ * delete (no data) through the same shape. `updateMany` needs both on every
+ * row — `updateManyData` reads `record.id` and `record.data` unconditionally —
+ * so reusing the loose shape declared a contract that accepted `{}` and an
+ * implementation that could not. This is the shape the route actually
+ * validates; {@link UpdateManyDataRequestSchema} extends it with the object
+ * name from the URL path.
+ */
+export const UpdateManyRecordSchema = lazySchema(() => z.object({
+  id: z.string().describe('Record ID'),
+  data: RecordDataSchema.describe('Fields to update'),
+}));
+
+export type UpdateManyRecord = z.infer<typeof UpdateManyRecordSchema>;
+
 export const UpdateManyRequestSchema = lazySchema(() => z.object({
-  records: z.array(BatchRecordSchema).min(1).max(200).describe('Array of records to update (max 200 per batch)'),
+  // [#3939] Cap lives at the route (`batch.maxBatchSize`), not here — see
+  // BatchUpdateRequestSchema above.
+  records: z.array(UpdateManyRecordSchema).describe('Array of records to update (server caps the count — see batch.maxBatchSize)'),
   options: BatchOptionsSchema.optional().describe('Update options'),
 }));
 
@@ -208,7 +235,11 @@ export type BatchUpdateResponse = z.infer<typeof BatchUpdateResponseSchema>;
  * }
  */
 export const DeleteManyRequestSchema = lazySchema(() => z.object({
-  ids: z.array(z.string()).min(1).max(200).describe('Array of record IDs to delete (max 200)'),
+  // [#3939] Cap lives at the route (`batch.maxBatchSize`), not here — see
+  // BatchUpdateRequestSchema above. This matters more since #3897 made the
+  // route delete per id by primary key (for cascade + per-row results): an
+  // unbounded list is now N engine round-trips, not one statement.
+  ids: z.array(z.string()).describe('Array of record IDs to delete (server caps the count — see batch.maxBatchSize)'),
   options: BatchOptionsSchema.optional().describe('Delete options'),
 }));
 

--- a/packages/spec/src/api/protocol.zod.ts
+++ b/packages/spec/src/api/protocol.zod.ts
@@ -3,7 +3,12 @@
 import { z } from 'zod';
 import { ViewSchema } from '../ui/view.zod';
 import { DiscoverySchema } from './discovery.zod';
-import { BatchUpdateRequestSchema, BatchUpdateResponseSchema, BatchOptionsSchema } from './batch.zod';
+import {
+  BatchUpdateRequestSchema,
+  BatchUpdateResponseSchema,
+  UpdateManyRequestSchema,
+  DeleteManyRequestSchema,
+} from './batch.zod';
 import { MetadataCacheRequestSchema, MetadataCacheResponseSchema } from './http-cache.zod';
 import { QuerySchema } from '../data/query.zod';
 import { DroppedFieldsEventSchema } from '../data/data-engine.zod';
@@ -516,14 +521,16 @@ export const CreateManyDataResponseSchema = lazySchema(() => z.object({
 
 /**
  * Update Many Data Request
+ *
+ * [#3939] The wire body IS {@link UpdateManyRequestSchema} — one Zod source per
+ * contract (Prime Directive #7). This adds only `object`, which the REST route
+ * takes from the URL path and never from the body (#3933). The two used to be
+ * hand-maintained copies that had already drifted apart: the batch.zod one
+ * accepted `{}` rows, this one required `id` + `data`, and only this one was
+ * ever enforced.
  */
-export const UpdateManyDataRequestSchema = lazySchema(() => z.object({
+export const UpdateManyDataRequestSchema = lazySchema(() => UpdateManyRequestSchema.extend({
   object: z.string().describe('Object name'),
-  records: z.array(z.object({
-    id: z.string().describe('Record ID'),
-    data: z.record(z.string(), z.unknown()).describe('Fields to update'),
-  })).describe('Array of updates'),
-  options: BatchOptionsSchema.optional().describe('Update options'),
 }));
 
 /**
@@ -534,11 +541,13 @@ export const UpdateManyDataResponseSchema = lazySchema(() => BatchUpdateResponse
 
 /**
  * Delete Many Data Request
+ *
+ * [#3939] The wire body IS {@link DeleteManyRequestSchema}; this adds only the
+ * `object` the REST route takes from the URL path (#3933). See
+ * {@link UpdateManyDataRequestSchema} for why the copies were merged.
  */
-export const DeleteManyDataRequestSchema = lazySchema(() => z.object({
+export const DeleteManyDataRequestSchema = lazySchema(() => DeleteManyRequestSchema.extend({
   object: z.string().describe('Object name'),
-  ids: z.array(z.string()).describe('Array of record IDs to delete'),
-  options: BatchOptionsSchema.optional().describe('Delete options'),
 }));
 
 /**


### PR DESCRIPTION
Closes #3939。#3897 / #3933 的收尾。

## `max 200` 声明了四处,拦了零处

`batch.zod.ts` 在三个 schema 上写了 `.min(1).max(200)`,文档也跟着写,但**没有一条 per-object 批量路由拿这些 schema 校验**:

| 路由 | 实际校验 | 拦上限? |
|:--|:--|:--:|
| `createMany` | 无(`records: req.body \|\| []`) | ❌ |
| `updateMany` | `UpdateManyDataRequestSchema` | ❌ 那份没有 `.max()` |
| `deleteMany` | `DeleteManyDataRequestSchema` | ❌ 同上 |
| `:object/batch` | 无(body 直接透传) | ❌ |
| `/batch`(跨对象) | `CrossObjectBatchRequestSchema` | ✅ 但拦的是**配置值**,不是那个 200 |

唯一在拦的那条,拦的还和 schema 声明的不是一个数。

**#3897 之后这事从纸面变成了实的**:`deleteMany` 现在按 id 逐条删(为了 cascade 和逐条 `results`),一个 10k 的 `ids` 数组 = 一个请求里 10k 次顺序引擎往返。这是我上一个 PR 引入的债,一起还掉。

## 上限归路由,schema 交出边界

批量大小是**部署策略** —— `batch.maxBatchSize`,1..1000,默认 200。硬编码进 spec 只可能是第二个、而且是错的答案:一个把上限调到 500 的部署,照样会在 200 被 schema 拒掉。

五条路由现在统一走一个 `enforceBatchSize`,读配置值,一个信封:

```json
{ "error": "Batch too large: 500 records (max 200)", "code": "BATCH_TOO_LARGE",
  "count": 500, "max": 200, "object": "account" }
```

跨对象那条也并进来 —— 它此前答的是一个裸 `error` 字符串,没有 `code` 给客户端判。

`.min(1)` 一并去掉:空批次是 no-op,返回 `total: 0`,这本来就是这些路由的行为,schema 声明的那个校验错误从来没人抛过。

## 一个端点一份 Zod(PD #7)

这些端点各有**两份** schema,而且早已不只是数字上不一致:

`UpdateManyRequestSchema` 用 `BatchRecordSchema` 描述行 —— 那份的 `id` / `data` 都是可选的,因为通用 `/batch` 路由要用同一个形状承载 create(没有 id)和 delete(没有 data)。于是**声明的契约接受 `{}` 行,而 `updateManyData` 无条件读 `record.id` 和 `record.data`,根本处理不了**。真正在把关的形状在另一份拷贝里(`protocol.zod.ts`)。

现在 wire body 是唯一源(新增 `UpdateManyRecordSchema` 描述一行),protocol 那份 = 它 + 路径来的 `object`(#3933):

```ts
export const UpdateManyDataRequestSchema = lazySchema(() => UpdateManyRequestSchema.extend({
  object: z.string().describe('Object name'),
}));
```

派生方向只能是这个 —— `protocol.zod` 已经在 import `batch.zod`,反过来会成环。

顺带记一笔(**没修**):`plugin-rest-api.zod.ts:918` 的 `requestSchema: 'CreateManyRequestSchema'` 指着一个从未定义过的名字,已写进 #3939。

## 行为变更

- 超过配置上限的批量请求变成 `400 BATCH_TOO_LARGE`,而不是照跑。**原先依赖无上限批量的部署应该调高 `batch.maxBatchSize`(最高 1000),别在生产上才撞见这个上限。**
- `UpdateManyRequest` 的 `records` 类型收紧为 `{ id: string; data: Record<string, unknown> }[]`。调用方本来就必须这么发(#3933 之后路由校验的就是严格形状),只是声明的类型此前更松。
- 新增导出 `UpdateManyRecordSchema` / `UpdateManyRecord`。

## 验证

- 新增 8 条路由测试(`rest-batch-size-cap.test.ts`)+ 5 条 spec 测试(含一组把"protocol schema 由 wire schema 派生"这个性质钉死的)。**验过在未修代码上会红**:8 条里 6 条失败,含 `expected { error: 'Batch too large (max 5)' } to match object { code: 'BATCH_TOO_LARGE', … }`。
- 改的 4 条 spec 老测试是原来钉那两个边界的,改成断言新契约并写明了为什么。
- **真机跑过**(`pnpm dev:crm -- --fresh`):四条 per-object 路由发 201 条都拿到 `400 BATCH_TOO_LARGE` 且**一行都没写**;正好 200 条照常通过。dev 服务器已拆除。
- `spec` 6835 条、`rest` 440 条、`metadata-protocol` 82 条、`client` 192 条全绿;改动文件 ESLint 干净。
- 生成物已重跑并提交:`gen:docs`(`references/api/batch.mdx`、`protocol.mdx`)+ `gen:api-surface`。`check:authorable-surface` / `check:spec-changes` / `check:upgrade-guide` / `check:skill-docs` / `check:docs` 本地全过 —— 三个 snapshot 的 diff **只有新增,没有删除**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzLE9cw4gZKNyPN2ZP4iTt


---
_Generated by [Claude Code](https://claude.ai/code/session_01TzLE9cw4gZKNyPN2ZP4iTt)_