### PR TITLE
fix(runtime,webhooks): the path object wins on /data/:object/query, and the webhook envelope owns its keys (#3946)

### DIFF
--- a/.changeset/data-query-path-object.md
+++ b/.changeset/data-query-path-object.md
@@ -1,0 +1,37 @@
+---
+"@objectstack/runtime": patch
+"@objectstack/plugin-webhooks": patch
+---
+
+fix(runtime,webhooks): the path object wins on /data/:object/query, and the webhook envelope owns its keys (#3946)
+
+Follow-up sweep for the shape behind #3897 and #3933 — a trusted, server-derived
+value written into an object literal with a caller-controlled bag spread OVER
+it. Both of those were in the same block of REST code, so the pattern was swept
+across all 1313 non-test TypeScript files in `packages/`. Nine candidate sites;
+one real, one worth hardening, seven verified clean (recorded in #3946 so the
+next sweep does not re-litigate them).
+
+**`POST /data/:object/query` (runtime dispatcher).** The `/data` domain built
+`{ object: objectName, ...body }`, so `{"object":"other", …}` in the body moved
+the read to a different object than the URL named.
+
+This is NOT an authorization bypass, and the tests pin why: `callData` gates
+API exposure on `params.object`, so the gate followed the body and agreed with
+the read — an object hidden by `apiEnabled: false` was refused either way. What
+broke is that the URL stopped describing the operation (audit trails, logs, and
+anything keyed on the request path saw object A while object B was read), and
+that one endpoint spoke a second dialect of the contract the REST side had just
+standardised on: the path object wins. The other handlers in that file never had
+the problem — they nest caller data (`data: body`, `query: normalized`) instead
+of splatting it, and the GET-by-id branch already allowlists its query params
+against exactly this pollution.
+
+**Webhook delivery envelope.** `auto-enqueuer` built
+`{ object, recordId, action, timestamp, ...payload }`, letting an event payload
+rewrite the envelope a subscriber receives. Behaviour-neutral for the engine's
+own publishers — `data.record.*` payloads are `{ recordId, after, changes }`
+with record fields nested under `after`, so none of those four keys collide
+today — but the shape was wrong, and the `payload.id` fallback right above it
+suggests publishers that flatten record fields do exist. Envelope keys are
+written last now.

--- a/content/docs/automation/webhooks.mdx
+++ b/content/docs/automation/webhooks.mdx
@@ -304,16 +304,16 @@ same time.
 
 ## 5. Payload format
 
-The POST body is the realtime event payload with a small fixed prefix merged
+The POST body is the realtime event payload with a small fixed envelope merged
 on top:
 
 ```json
 {
+  // ...fields from the originating event payload
   "object": "account",
   "recordId": "acc_123",
   "action": "updated",
   "timestamp": "2024-10-27T00:00:00.000Z"
-  // ...remaining fields from the originating event payload
 }
 ```
 
@@ -326,7 +326,11 @@ Notes:
   unchanged from the originating realtime event's `timestamp` field — not
   an epoch-ms number).
 - Any additional fields the event carried (e.g. record snapshot data) are
-  spread in after these four.
+  spread in first. These four are written **last**, so the envelope always
+  describes the event even if a publisher's payload happens to carry a field
+  with one of these names (#3946). The platform's own `data.record.*` events
+  nest the record under `after` / `changes`, so nothing collides in practice —
+  the ordering is what guarantees it.
 
 Idempotency and event correlation are carried in **headers**, not the body.
 Every attempt sends:

--- a/packages/plugins/plugin-webhooks/src/auto-enqueuer.ts
+++ b/packages/plugins/plugin-webhooks/src/auto-enqueuer.ts
@@ -333,12 +333,21 @@ export class AutoEnqueuer {
                 headers: sub.headers,
                 signingSecret: sub.secret,
                 timeoutMs: sub.timeoutMs,
+                // [#3946] Envelope keys are written LAST so the event payload
+                // cannot rewrite them. Behaviour-neutral for the engine's own
+                // publishers — `data.record.*` payloads are
+                // `{ recordId, after, changes }`, with record fields nested
+                // under `after`, so none of these four keys collide today. It
+                // is the shape that was wrong: a publisher that flattened
+                // record fields into the payload (the `payload.id` fallback
+                // above suggests some do) would have silently rewritten the
+                // `object` / `action` / `timestamp` a subscriber receives.
                 payload: {
+                    ...payload,
                     object: event.object,
                     recordId,
                     action,
                     timestamp: event.timestamp,
-                    ...payload,
                 },
             }).catch((err) =>
                 this.logger.warn?.('[webhook-auto-enqueuer] enqueue failed', {

--- a/packages/runtime/src/domains/data-path-object.test.ts
+++ b/packages/runtime/src/domains/data-path-object.test.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// [#3946] `POST /data/:object/query` spread the request body OVER
+// `{ object: objectName }`, so a body `object` key moved the read to a
+// different object than the URL named — the same shape #3933 fixed on the REST
+// bulk routes, found by the follow-up sweep for that pattern.
+//
+// These run through the REAL `callData`, so they pin both halves at once: the
+// object the ADR-0049 exposure gate consults and the object actually queried
+// are the same one, and it is the one in the path.
+
+import { describe, it, expect, vi } from 'vitest';
+import { handleDataRequest } from './data.js';
+
+/** Records what the protocol service was asked for. */
+function setup(objectDefs: Record<string, any> = {}) {
+    const findData = vi.fn(async (req: any) => ({ object: req.object, records: [], total: 0 }));
+    const protocol = { findData };
+    const metadata = { getObject: async (name: string) => objectDefs[name] };
+    const deps: any = {
+        resolveService: async (name: string) => (name === 'protocol' ? protocol : name === 'metadata' ? metadata : null),
+        getService: () => null,
+        getObjectQL: async () => null,
+        getRequestKernelService: async () => null,
+        isMultiTenantHost: () => false,
+        success: (data: any) => ({ status: 200, body: data }),
+        error: (message: string, code = 500) => ({ status: code, body: { error: message } }),
+        routeNotFound: (route: string) => ({ status: 404, body: { route } }),
+        errorFromThrown: (e: any) => ({ status: e?.statusCode ?? e?.status ?? 500, body: { error: e?.message } }),
+        resolveActiveOrganizationId: async () => undefined,
+        announceKernelEvent: async () => {},
+    };
+    const context: any = { dataDriver: undefined, environmentId: undefined, executionContext: { userId: 'u1' } };
+    return { deps, context, findData };
+}
+
+const post = (deps: any, context: any, path: string, body: any) =>
+    handleDataRequest(deps, path, 'POST', body, {}, context);
+
+describe('POST /data/:object/query binds to the object in the path (#3946)', () => {
+    it('a body `object` cannot move the read to another object', async () => {
+        const { deps, context, findData } = setup();
+        const res = await post(deps, context, 'crm_account/query', {
+            object: 'sys_user',
+            where: { name: 'x' },
+        });
+
+        expect(res.handled).toBe(true);
+        expect(findData).toHaveBeenCalledTimes(1);
+        expect(findData.mock.calls[0][0].object).toBe('crm_account');
+    });
+
+    it('the exposure gate and the read agree on the path object', async () => {
+        // `sys_user` is hidden from the API; `crm_account` is not. Pointing the
+        // URL at the exposed object and naming the hidden one in the body must
+        // not read the hidden one — and must not be refused on its behalf
+        // either. Both decisions follow the path.
+        const { deps, context, findData } = setup({
+            crm_account: { apiEnabled: true },
+            sys_user: { apiEnabled: false },
+        });
+
+        const res: any = await post(deps, context, 'crm_account/query', { object: 'sys_user' });
+        expect(res.response.status).toBe(200);
+        expect(findData.mock.calls[0][0].object).toBe('crm_account');
+
+        // Addressed directly, the hidden object is still refused. The gate
+        // THROWS a `{ statusCode }` shape; the dispatcher above turns it into
+        // an envelope (`errorFromThrown`), so assert the throw here.
+        await expect(post(deps, context, 'sys_user/query', {})).rejects.toMatchObject({ statusCode: 404 });
+        expect(findData).toHaveBeenCalledTimes(1); // the refused call never read
+    });
+
+    it('still forwards the rest of the body as the query', async () => {
+        const { deps, context, findData } = setup();
+        await post(deps, context, 'crm_account/query', { where: { status: 'open' }, limit: 5 });
+
+        const req = findData.mock.calls[0][0];
+        expect(req.object).toBe('crm_account');
+        expect(req.query).toMatchObject({ where: { status: 'open' }, limit: 5 });
+    });
+
+    it('still honours an explicit `query` envelope', async () => {
+        const { deps, context, findData } = setup();
+        await post(deps, context, 'crm_account/query', { query: { where: { status: 'open' } } });
+
+        expect(findData.mock.calls[0][0].query).toEqual({ where: { status: 'open' } });
+    });
+
+    it('threads the caller execution context through unchanged', async () => {
+        const { deps, context, findData } = setup();
+        await post(deps, context, 'crm_account/query', { context: { userId: 'root', isSystem: true } });
+
+        expect(findData.mock.calls[0][0].context).toBe(context.executionContext);
+    });
+});

--- a/packages/runtime/src/domains/data.ts
+++ b/packages/runtime/src/domains/data.ts
@@ -52,8 +52,25 @@ export async function handleDataRequest(deps: DomainHandlerDeps, path: string, m
 
         // POST /data/:object/query
         if (action === 'query' && m === 'POST') {
-            // Spec: returns FindDataResponse = { object, records, total?, hasMore? }
-            const result = await actionExec.callData(deps, 'query', { object: objectName, ...body }, _context.dataDriver, _context.environmentId, _context.executionContext);
+            // [#3946] The PATH object is written LAST. The body used to be
+            // spread OVER `object: objectName`, so `{"object":"other", …}`
+            // moved the read to a different object than the URL named — the
+            // same shape #3933 fixed on the REST bulk routes, found by the
+            // follow-up sweep.
+            //
+            // Not an authorization bypass here: `callData` gates exposure on
+            // `params.object` (action-execution.ts), so the gate followed the
+            // body and agreed with the read. What broke is that the URL stopped
+            // describing the operation — audit trails, logs and anything keyed
+            // on the request path saw object A while object B was read — and
+            // that one endpoint spoke a second dialect of a contract the REST
+            // side had just standardised (path wins).
+            //
+            // The sibling handlers below never had this: they nest the caller's
+            // data (`data: body`, `query: normalized`) instead of splatting it,
+            // and the GET-by-id branch even allowlists its query params against
+            // exactly this kind of parameter pollution.
+            const result = await actionExec.callData(deps, 'query', { ...body, object: objectName }, _context.dataDriver, _context.environmentId, _context.executionContext);
             return { handled: true, response: deps.success(result) };
         }
 


### PR DESCRIPTION
Closes #3946。#3897 / #3933 的同类扫查。

## 扫查方法

两次事故是同一个形状:**受信任的值先写进对象字面量,调用者控制的 bag 展开在它之后**,而且都出在同一段代码里。所以按三个要素同时具备来扫全仓:

1. 受信任/服务端派生的值(`object` / `context` / `where` / `environmentId` / `userId` / `isSystem` / `id`);
2. 调用者控制的 bag(`req.body` / `query` / `params` / `args` / `input` / `options` / `payload`)展开在其**之后**;
3. 结果流向安全相关的消费端。

脚本扫 `git ls-files 'packages/**/*.ts'` 的全部 **1313** 个非测试文件,同时覆盖多行和单行字面量 —— 第一版只查多行,**漏了 runtime 那处**(它就写在一行里),补上才扫到。共 **9** 处候选,逐个走到消费端确认。

## 命中 1 处

`packages/runtime/src/domains/data.ts:56` —— dispatcher 的 `/data` 域:

```js
// POST /data/:object/query
callData(deps, 'query', { object: objectName, ...body }, …)
```

`{"object":"other", …}` 就把读挪到别的对象上。

**范围说准:不是越权,而且测试把这一点钉死了。** `callData` 的暴露闸门读 `params.object`(也就是 body 里那个),闸门跟着 body 走、和实际读的对象一致 —— `apiEnabled:false` 的对象两条路都会被拒。坏的是**URL 不再描述这次操作**:审计、日志、任何按路径归类的中间件看到 A,读的是 B;同时它让这个端点有了第二种方言 —— REST 那边刚统一成"路径对象说了算"。

同文件其他 handler 从来没这问题:它们把调用者数据**套一层**(`data: body` / `query: normalized`),GET-by-id 分支甚至专门 allowlist 了 query 参数,注释写着 *"prevent parameter pollution"*。这个文件知道这个坑,只是没应用到 POST body。

## 顺带一处加固(**不是活的 bug**)

`plugin-webhooks/auto-enqueuer.ts` 的出站信封 `{ object, recordId, action, timestamp, ...payload }` —— 自有键可被事件 payload 改写。

我核实过引擎自己的发布者不会撞:`data.record.*` 的 payload 是 `{ recordId, after, changes }`,记录字段嵌在 `after` 里。所以对现有发布者是**行为中性**的,改的是形状(紧邻的 `payload.id` 兜底暗示确实存在把记录字段平铺的发布者)。

## 已核实无问题的 7 处

写进 #3946 备查,免得下次重扫。其中最值得记的一条:

**`objectql/engine.ts:2656` `{ object, ...query }` 看着最吓人,但不是 bug** —— `ast.object` **没有任何驱动读**,`driver.find(object, ast, opts)` 的表名走独立的第一个参数(sql-driver `getBuilder(object)`、memory-driver `getTable(object)`),AST 上那个 key 是死字段。这条是我唯一一处一开始判成"可能很严重"、走完消费端才排除的。

其余:`rest-server.ts:4847`(受信任戳写在最后,注释明说的设计)、`plugin-auth/admin-import-users.ts:288`(**正确写法的范本** —— 受信任值写在展开之后)、`plugin-reports/report-service.ts:348`(`payload` 就地构造、不含 `id`)、`http-dispatcher.ts:1452/1464`(受信任的 `request` 写在最后)、`metadata/database-loader.ts`(内部 helper,非入口)、两处 `...(x ? {k:v} : {})` 条件展开惯用法。

## 没查的相邻面

`findData` 的 `expand` "高级用法"允许调用者直接传 `Record<string, QueryAST>`,每个子 AST 自带 `object`。**expand 是否对每个关联对象重跑暴露闸门 / RLS,我没有验证** —— 需要单独走一遍,不在这次的形状里。已写进 #3946。

## 验证

- 新增 5 条测试(`data-path-object.test.ts`),走**真实的 `callData`**(不 mock 内部),所以同时钉住两件事:闸门看的对象和实际读的对象是同一个,且是路径里那个。
- **验过在未修代码上会红**:5 条里 2 条失败(`expected 'sys_user' to be 'crm_account'`)。
- `runtime` 824 条、`plugin-webhooks` 25 条全绿;改动文件 ESLint 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzLE9cw4gZKNyPN2ZP4iTt


---
_Generated by [Claude Code](https://claude.ai/code/session_01TzLE9cw4gZKNyPN2ZP4iTt)_