### PR TITLE
fix(metadata-protocol): findData must not take its execution context from the request (#3960)

### DIFF
--- a/.changeset/find-data-wire-context.md
+++ b/.changeset/find-data-wire-context.md
@@ -1,0 +1,46 @@
+---
+"@objectstack/metadata-protocol": patch
+---
+
+fix(metadata-protocol): findData must not take its execution context from the request (#3960)
+
+Came out of the #3946 sweep's leftover question — whether `expand`'s "advanced
+usage" (a caller-supplied `Record<string, QueryAST>` whose sub-ASTs each carry an
+`object`) is a cross-object read channel. **It is not**, and that needs saying
+because the answer is load-bearing: `expandRelatedRecords` takes its target from
+the parent schema (the expand KEY must be a real `reference` field; the sub-AST's
+`object` is never read), re-enters `engine.find` so the referenced object's RLS +
+FLS both run, `$and`-merges a nested `where` instead of spreading it over the id
+filter, and caps depth. No change needed there.
+
+What the investigation did turn up is one layer down. `findData` built its engine
+options as `{ ...request.query }` and then assigned `context` from
+`request.context` **conditionally**:
+
+- `request.query` is the caller's raw bag on every ingress — the REST
+  `POST /data/:object/query` route passes `req.body` straight in as `query`;
+- `context` sits in the known-params set, so it was not swept into the
+  implicit-filter bucket either — it survived the spread untouched;
+- so when no server context resolved, the caller's `context` *became* the
+  operation's execution context.
+
+Everything hangs off that value. plugin-security's middleware opens with
+`if (opCtx.context?.isSystem) return next()` — the entire RLS / FLS / CRUD chain
+skipped — and `__expandRead: true` collects the #2850 waiver on the object-level
+CRUD gate. Neither is ever schema-stripped on the read path:
+`ExecutionContextSchema.parse` runs only in `engine.createContext`, which reads
+do not use.
+
+Route-level `enforceAuth` is what kept this unreachable: anonymous data requests
+are refused unless a deployment sets `requireAuth: false`. That makes it a
+fail-OPEN default rather than a live exploit — and not something the protocol
+should delegate upward. `findData` now drops any inbound `context`
+unconditionally before the assignment, so the execution context can only come
+from `request.context`.
+
+Verified end-to-end at the protocol layer (a forged
+`{ isSystem, userId, __expandRead }` reached `engine.find` verbatim before, is
+dropped after). The anonymous HTTP reachability half is NOT verified — see #3960
+for exactly what was and was not reproduced. No caller regresses: the only
+in-repo builder of these args (`rest/src/import-runner.ts` `findArgsBase`) passes
+`context` at the top level, never inside `query`.

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -2659,6 +2659,29 @@ export class ObjectStackProtocolImplementation implements
         // probed for query-shape validity (nor reach the driver as a table).
         this.assertObjectRegistered(request.object);
         const options: any = { ...request.query };
+        // The execution context is SERVER-DERIVED and never caller input.
+        //
+        // `request.query` is the raw request bag on every ingress that reaches
+        // here — the REST `POST /data/:object/query` route hands `req.body`
+        // straight in as `query`. `context` is in the known-params set below, so
+        // it was not swept into the implicit-filter bucket either: a caller's
+        // `context` survived this spread and, because the assignment below is
+        // conditional, became the operation's execution context whenever no
+        // server context resolved (an anonymous request on a deployment that
+        // set `requireAuth: false`).
+        //
+        // What rides on it is total: plugin-security's middleware opens with
+        // `if (opCtx.context?.isSystem) return next()` — the entire RLS / FLS /
+        // CRUD chain skipped — and `__expandRead` waives the object-level CRUD
+        // gate for public objects (#2850). Neither is ever schema-stripped on
+        // this path: `ExecutionContextSchema.parse` runs only in
+        // `engine.createContext`, which the read path does not use.
+        //
+        // Route-level `enforceAuth` is what kept that from being reachable, so
+        // this was a fail-OPEN default one layer down. Drop any inbound
+        // `context` unconditionally: the protocol must not depend on a gate
+        // above it staying switched on.
+        delete options.context;
         // Forward the dispatcher's ExecutionContext so RBAC/RLS middleware
         // can apply per-request enforcement. The protocol layer is purely
         // a normalizer — it must never strip security context.

--- a/packages/metadata-protocol/src/protocol.wire-context.test.ts
+++ b/packages/metadata-protocol/src/protocol.wire-context.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// The execution context must never come off the wire.
+//
+// `findData` built its engine options as `{ ...request.query }` and then
+// overwrote `context` from `request.context` ONLY when that was defined. The
+// query bag is caller-controlled on every ingress that reaches here (the REST
+// `POST /data/:object/query` route hands `req.body` straight in as `query`), and
+// `context` is in the schema's known-params set, so it was NOT swept into the
+// implicit-filter bucket — it survived into `engine.find` as the operation's
+// execution context whenever no server context resolved.
+//
+// What rides on that context is total: plugin-security's middleware opens with
+// `if (opCtx.context?.isSystem) return next()` — the whole RLS/FLS/CRUD chain
+// skipped — and `__expandRead` waives the object-level CRUD gate for public
+// objects. Neither is ever schema-stripped on the read path
+// (`ExecutionContextSchema.parse` runs only in `createContext`).
+//
+// The auth gate is what stands between that and a live exploit: `enforceAuth`
+// refuses anonymous data requests unless a deployment sets `requireAuth: false`.
+// That makes this a fail-OPEN default one layer down — the protocol should not
+// depend on a route-level gate staying on. These tests pin the invariant at the
+// layer that owns it.
+
+import { describe, it, expect, vi } from 'vitest';
+import { ObjectStackProtocolImplementation } from './protocol.js';
+
+const SCHEMA = { name: 'invoice', fields: { title: { name: 'title', type: 'text' } } };
+
+function makeProtocol() {
+    const find = vi.fn(async () => []);
+    const count = vi.fn(async () => 0);
+    const engine = {
+        registry: { getObject: (n: string) => (n === 'invoice' ? SCHEMA : undefined) },
+        find,
+        count,
+    };
+    return { p: new ObjectStackProtocolImplementation(engine as any), find };
+}
+
+/** The engine options `findData` handed to `engine.find`. */
+const optionsFrom = (find: any) => find.mock.calls[0][1];
+
+describe('findData never takes its execution context from the caller', () => {
+    it('drops a body-supplied context when no server context resolved (the anonymous shape)', async () => {
+        const { p, find } = makeProtocol();
+        await p.findData({
+            object: 'invoice',
+            query: { context: { isSystem: true, userId: 'root', __expandRead: true } },
+        } as any);
+
+        expect(find).toHaveBeenCalledTimes(1);
+        expect(optionsFrom(find).context).toBeUndefined();
+    });
+
+    it('the resolved context wins and is not merged with the caller\'s', async () => {
+        const { p, find } = makeProtocol();
+        const resolved = { userId: 'u1', positions: [] };
+        await p.findData({
+            object: 'invoice',
+            query: { context: { isSystem: true } },
+            context: resolved,
+        } as any);
+
+        expect(optionsFrom(find).context).toBe(resolved);
+        expect((optionsFrom(find).context as any).isSystem).toBeUndefined();
+    });
+
+    it('a caller `context` does not become an implicit field filter either', async () => {
+        // It must be dropped, not folded into `where` as `where.context` — that
+        // would turn a forged principal into a query against a column that does
+        // not exist (a confusing 400 instead of a clean ignore).
+        const { p, find } = makeProtocol();
+        await p.findData({ object: 'invoice', query: { context: { isSystem: true } } } as any);
+
+        const opts = optionsFrom(find);
+        expect(opts.where).toBeUndefined();
+        expect(opts.context).toBeUndefined();
+    });
+
+    it('still forwards a real query alongside a forged context', async () => {
+        const { p, find } = makeProtocol();
+        await p.findData({
+            object: 'invoice',
+            query: { where: { title: 'x' }, limit: 5, context: { isSystem: true } },
+        } as any);
+
+        const opts = optionsFrom(find);
+        expect(opts.where).toEqual({ title: 'x' });
+        expect(opts.limit).toBe(5);
+        expect(opts.context).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Closes #3960。查的是 #3946 留下的那条尾巴。

## 先给 expand 的结论:**干净的,不用改**

原本的怀疑是:`expand` 的"高级用法"允许调用者直传 `Record<string, QueryAST>`,每个子 AST 自带 `object` —— 会不会是跨对象越权读?**不是**,`expandRelatedRecords` 四道防线都在:

1. **目标对象不由调用者决定** —— expand 的**键**必须是父 schema 上真实存在、带 `reference`、类型为 `lookup`/`master_detail`/`user` 的字段;读的目标取 `fieldDef.reference`,**从 schema 来**。子 AST 里那个 `object` 键根本没人读(和 #3946 排除 `ast.object` 同理)。
2. **走引擎自己的 `this.find`**(#2850 有意如此)→ 被引用对象的 RLS + FLS 照跑。
3. **id 谓词顶不掉** —— 子 AST 的 `where` 用显式 `$and` 合并,注释里还专门写了"浅展开会 clobber 掉 id 约束"—— 正是本系列那个坑,这里早就防住了。
4. 深度上限 3;`__expandRead` 豁免面很窄(只 `find`、只非 private,只免对象级 CRUD 闸门,RLS 注入和 FLS 掩码照跑)。

这条结论是**承重的**,所以值得写下来:下次再有人怀疑 expand,可以直接看这段。

## 但第 4 条依赖的那句前提不成立

`__expandRead` 的安全性写在注释里:*"a server-set marker; `executionContext` is never client-built"*。而 `protocol.ts:2661`:

```js
const options: any = { ...request.query };
if (request.context !== undefined) {      // ← 条件赋值
    options.context = request.context;
}
```

- `request.query` 在每个入口上都是**调用者的原始 bag**(REST `POST /data/:object/query` 直接把 `req.body` 当 `query` 传进来);
- `context` 在 `knownParams` 里,所以**也不会**被扫进隐式过滤桶,原样留着;
- 赋值是**条件的** → 没有服务端 context 解析出来时,调用者那个 `context` 就是这次操作的执行上下文。

而它承载的是全部:

```js
// plugin-security/src/security-plugin.ts:722
if (opCtx.context?.isSystem) return next();   // 整条 RLS / FLS / CRUD 链跳过
```

`__expandRead: true` 同样能拿到 #2850 的豁免。**两者在读路径上都不会被 schema 剥掉** —— `ExecutionContextSchema.parse` 只在 `engine.createContext()` 里用,读写热路径不走它。

## 可达性:一半实测,一半**没做成,如实说明**

- ✅ **已实测**(协议层,真实 `ObjectStackProtocolImplementation` + 假引擎):按匿名形状调用,伪造的 `{ isSystem, userId, __expandRead }` **原样到达 `engine.find`**;
- ✅ **已代码确认**:`isSystem` 短路整条中间件;读路径无 schema 剥离;
- ❌ **未实测**:匿名 HTTP 请求在真实部署上确实可达。这一环要求 `requireAuth: false`。我在 `examples/app-crm` 上加了 `api: { requireAuth: false }` 起服务器实打,**没生效** —— `dev` 命令这条路径没读 stack 的 `api` 键(`serve.ts:1724` 读它,但 `dev` 不走那段),四个探测仍全是 401。

所以准确的说法是:**一个被上层闸门挡住的 fail-open 默认**,不是当场可打的洞。但协议层不该把这个不变量委托给上面那道闸门 —— 它自己就拥有这个不变量。

## 修法

赋值**之前**无条件 `delete options.context`。执行上下文只能来自 `request.context`。

已核对不破坏任何合法调用方:仓库里唯一构造这些参数的地方(`rest/src/import-runner.ts:245` 的 `findArgsBase`)把 `context` 放**顶层**、不在 `query` 里。`getData` 等兄弟方法从零构造 options,不受影响 —— **只有 `findData` 是"调用者 bag 就是 options bag"**。

## 验证

- 新增 4 条测试。**验过在未修代码上会红**:4 条里 3 条失败,断言消息就是 `expected { isSystem: true } to be undefined`。
- `metadata-protocol` 99 条、`rest` 440 条、`runtime` 837 条、`objectql` 1163 条全绿;改动文件 ESLint 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzLE9cw4gZKNyPN2ZP4iTt


---
_Generated by [Claude Code](https://claude.ai/code/session_01TzLE9cw4gZKNyPN2ZP4iTt)_