### PR TITLE
test(showcase): specimens for the inline picker and the record-backed approvers (#3405, #3508)

### DIFF
--- a/.changeset/showcase-approver-and-picker-specimens.md
+++ b/.changeset/showcase-approver-and-picker-specimens.md
@@ -1,0 +1,4 @@
+---
+---
+
+test(showcase): dogfood specimens for the inline record picker (#3405) and the record-backed approver kinds (#3508) — releases nothing. Both live in `@objectstack/example-showcase`, which is private.

--- a/examples/app-showcase/src/automation/flows/approver-bindings.flow.ts
+++ b/examples/app-showcase/src/automation/flows/approver-bindings.flow.ts
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { defineFlow } from '@objectstack/spec';
+
+/**
+ * #3508 dogfood: one node per RECORD-BACKED approver kind.
+ *
+ * The designer's Approvers → Value control used to query the metadata registry
+ * (`GET /api/v1/meta/:type`) for every kind. `user` / `team` / `department` /
+ * `position` are DATA rows in the platform's directory objects, not registry
+ * entries, so candidates came back empty and the control degraded to a free-text
+ * box — the author could only hand-type a userid. `APPROVER_VALUE_BINDINGS`
+ * now publishes the data contract per kind (`xRef.sources`), and the designer
+ * renders a real record lookup off it.
+ *
+ * This flow is the authoring specimen for that surface: every kind whose control
+ * changed gets a node, so opening it in the flow designer exercises each one.
+ * The existing approval flows in `./index.ts` already cover `position` heavily
+ * (it is the kind showcase actually routes on) and `./dynamic-approval.flow.ts`
+ * covers `org_membership_level` + `expression`; the kinds below are the ones no
+ * other flow declares.
+ *
+ * ## Why `draft`
+ *
+ * Deliberate, not an oversight. The record-backed kinds point at rows a fresh
+ * boot does not have: `sys_user` holds only the seeded admin, `sys_team` is
+ * empty (the seeded `Team` rows are the DEMO `showcase_team` object), and both
+ * unit membership (`sys_business_unit_member`) and position assignment
+ * (`sys_user_position`) are runtime admin actions by design — see the seed
+ * notes in `src/data/seed/index.ts`. An `active` flow over them would resolve
+ * to nobody, which is precisely the silent dead slot #3508 exists to remove.
+ * Shipping that as a demo would re-teach the bug. `draft` keeps it out of the
+ * runtime while still loading in the designer, which is the surface under test.
+ *
+ * `queue` is absent on purpose: #3536 made it non-authorable
+ * (`NON_AUTHORABLE_APPROVER_TYPES` → `xEnumDeprecated`) because the engine has
+ * no queue branch, so the designer no longer offers it.
+ */
+export const ApproverBindingsFlow = defineFlow({
+  name: 'showcase_approver_bindings',
+  label: 'Approver Binding Specimens (#3508)',
+  description:
+    'Authoring specimen: one approval node per record-backed approver kind, so the designer '
+    + 'renders each Value control. Draft on purpose — a fresh org has no rows for these kinds.',
+  type: 'autolaunched',
+  status: 'draft',
+  nodes: [
+    {
+      id: 'start',
+      type: 'start',
+      label: 'On Field Zoo Updated',
+      config: {
+        objectName: 'showcase_field_zoo',
+        triggerType: 'record-after-update',
+      },
+    },
+    {
+      id: 'by_user',
+      type: 'approval',
+      label: 'Named user',
+      config: {
+        // `sys_user` row id. The most portable-hostile choice there is — an id
+        // does not survive an environment migration and dies with the person —
+        // which is why the designer's Type dropdown lists it LAST.
+        approvers: [{ type: 'user', value: '' }],
+        behavior: 'first_response',
+      },
+    },
+    {
+      id: 'by_team',
+      type: 'approval',
+      label: 'Team members',
+      config: {
+        // `sys_team` row id; the engine expands it through `sys_team_member`.
+        approvers: [{ type: 'team', value: '' }],
+        behavior: 'first_response',
+      },
+    },
+    {
+      id: 'by_department',
+      type: 'approval',
+      label: 'Department members',
+      config: {
+        // `sys_business_unit` row id — NOT `sys_department`. The seeded org tree
+        // (bu_acme / bu_field_ops / bu_west_coast / …) is what this picker lists.
+        approvers: [{ type: 'department', value: '' }],
+        behavior: 'first_response',
+      },
+    },
+    {
+      id: 'by_position',
+      type: 'approval',
+      label: 'Position holders',
+      config: {
+        // Commits the position's machine NAME, not its row id: the engine routes
+        // on `sys_user_position.position`, and a machine name is what stays
+        // valid across environments. `manager` is a showcase position.
+        approvers: [{ type: 'position', value: 'manager' }],
+        behavior: 'first_response',
+      },
+    },
+    {
+      id: 'by_manager',
+      type: 'approval',
+      label: "Submitter's manager",
+      config: {
+        // Resolved at run time from the submitter — there is no value to author,
+        // so the designer disables the cell instead of offering a free-text box.
+        approvers: [{ type: 'manager' }],
+        behavior: 'first_response',
+      },
+    },
+    {
+      id: 'by_field',
+      type: 'approval',
+      label: 'User in a trigger field',
+      config: {
+        // Value is a FIELD NAME on the trigger object, not a record reference —
+        // so this one keeps the object-field selector rather than a record
+        // lookup. `f_user` is Field Zoo's single-value `sys_user` reference.
+        approvers: [{ type: 'field', value: 'f_user' }],
+        behavior: 'first_response',
+      },
+    },
+    { id: 'approved', type: 'end', label: 'Approved' },
+    { id: 'rejected', type: 'end', label: 'Rejected' },
+  ],
+  edges: [
+    { id: 'e1', source: 'start', target: 'by_user' },
+    { id: 'e2', source: 'by_user', target: 'by_team', label: 'approve' },
+    { id: 'e3', source: 'by_team', target: 'by_department', label: 'approve' },
+    { id: 'e4', source: 'by_department', target: 'by_position', label: 'approve' },
+    { id: 'e5', source: 'by_position', target: 'by_manager', label: 'approve' },
+    { id: 'e6', source: 'by_manager', target: 'by_field', label: 'approve' },
+    { id: 'e7', source: 'by_field', target: 'approved', label: 'approve' },
+    { id: 'e8', source: 'by_user', target: 'rejected', label: 'reject' },
+    { id: 'e9', source: 'by_team', target: 'rejected', label: 'reject' },
+    { id: 'e10', source: 'by_department', target: 'rejected', label: 'reject' },
+    { id: 'e11', source: 'by_position', target: 'rejected', label: 'reject' },
+    { id: 'e12', source: 'by_manager', target: 'rejected', label: 'reject' },
+    { id: 'e13', source: 'by_field', target: 'rejected', label: 'reject' },
+  ],
+});

--- a/examples/app-showcase/src/automation/flows/index.ts
+++ b/examples/app-showcase/src/automation/flows/index.ts
@@ -2,6 +2,7 @@
 
 import { defineFlow } from '@objectstack/spec';
 import { DynamicApprovalFlow } from './dynamic-approval.flow';
+import { ApproverBindingsFlow } from './approver-bindings.flow';
 
 /**
  * Task Completed → Notify — an autolaunched, record-triggered flow that fires
@@ -1635,4 +1636,8 @@ export const allFlows = [
   InboundTaskWebhookFlow,
   // #3447 P2 dogfood: expression approvers + decision outputs, end to end.
   DynamicApprovalFlow,
+  // #3508 dogfood: one approval node per record-backed approver kind, so the
+  // designer's Value control has a specimen for each. Draft on purpose — see
+  // the module docstring.
+  ApproverBindingsFlow,
 ];

--- a/examples/app-showcase/src/system/translations/index.ts
+++ b/examples/app-showcase/src/system/translations/index.ts
@@ -267,6 +267,23 @@ export const ShowcaseTranslationBundle = {
       showcase_field_zoo: {
         label: '字段动物园', pluralLabel: '字段动物园',
         fields: { f_lookups: { label: '查找 → 客户（多值）' } },
+        // #3405 — the inline system-object picker specimen. Translated at birth
+        // because `check-i18n-coverage` ratchets this example at its current
+        // untranslated count: a newly declared label that skips zh-CN pushes the
+        // count up and fails the gate. (The gallery's older params sit inside
+        // that baseline; this one is not allowed to widen it.) `负责人` matches
+        // what the bundle already renders for `showcase_task.assignee`, rather
+        // than introducing a second word for the same idea.
+        _actions: {
+          showcase_action_param_gallery: {
+            params: {
+              p_assignee: {
+                label: '负责人',
+                helpText: '指向系统对象的内联查找 —— 可按姓名或邮箱搜索,无需填写 UUID。',
+              },
+            },
+          },
+        },
       },
     },
   },

--- a/examples/app-showcase/src/ui/actions/index.ts
+++ b/examples/app-showcase/src/ui/actions/index.ts
@@ -212,6 +212,15 @@ export const ActionParamGalleryAction = defineAction({
       name: 'p_account', type: 'lookup', reference: 'showcase_account', label: 'Related account',
       helpText: 'Inline lookup param — searchable record picker, no UUID typing.',
     },
+    // #3405 — the same inline picker aimed at a SYSTEM object. This is the
+    // shape the bug was reported against (PLAT-DEF-005: "assign an inspector"
+    // handed the supervisor a box wanting a pasted UUID), so it earns its own
+    // specimen: `sys_user` is not one of the app's own objects, and a person is
+    // the reference a human is least able to identify by id.
+    {
+      name: 'p_assignee', type: 'lookup', reference: 'sys_user', label: 'Assignee',
+      helpText: 'Inline lookup at a system object — searchable by name/email, never a UUID.',
+    },
     { name: 'p_color', type: 'color', label: 'Accent color', defaultValue: '#7C3AED' },
     // Spec `autonumber` param → the AutoNumber widget (read-only, auto-assigned).
     { name: 'p_reference', type: 'autonumber', label: 'Reference #' },


### PR DESCRIPTION
#3405 和 #3508 的平台修复都已合并并随 `@objectstack/spec@17.0.0-rc.0` 发布,但两边验收各剩最后一条「真机逐一验证」,而 showcase 对这两种形状**都没有标本** —— 控件回归了也没人会发现。

## 改动

**#3405 —— `p_assignee`,指向 `sys_user` 的内联 `lookup`**

gallery 已有一个指向应用自有对象的内联 picker(`p_account` → `showcase_account`)。但报障的形状(PLAT-DEF-005:点【指派】要选质检员,拿到的是要求粘 UUID 的文本框)是指向**系统对象**的 picker,而「人」恰恰是人类最无法凭 id 辨认的引用 —— 本机 `sys_user` 的 id 就是 `dvgfa2883S1Ht7Q01q4zJ0vOvI6V6sXI` 这种 32 位不透明串。这值得单独一个标本,而不是搭在 account 那个上。

**#3508 —— `showcase_approver_bindings`,每种记录型 approver 一个审批节点**

现有流程里 `position` 覆盖得很密,`dynamic-approval` 覆盖 `org_membership_level` + `expression`;而 `user` / `team` / `department` / `manager` / `field` **一个标本都没有** —— 这正是设计器 Value 控件能悄悄回归的原因。`queue` 故意不含:#3536 已把它移出可授权枚举。

### 为什么是 `draft`

这是刻意的,不是漏了。记录型 approver 指向的行在全新启动时并不存在:`sys_team` 没有种子(种子里的 `Team` 是 DEMO 对象 `showcase_team`),而单位成员关系与岗位分配按设计都是**运行时管理动作**(见 `src/data/seed/index.ts` 的种子注释)。一个 `active` 流程压在它们上面会解析到「没有人」—— 那恰恰是 #3508 要消灭的静默死槽,当作 demo 发出去等于把这个 bug 再教一遍。`draft` 让它不进运行时,但仍能在设计器里打开,而设计器才是被测面。

## 真机验证

showcase `:5411`(自有端口 + 自有 DB)+ objectui HEAD 的 console dev `:5412`(`/_console` 是 vendored 旧构建,验 objectui 改动必须用它自己的 dev server)。

**#3405**
- 服务端两个内联 picker 参数都带上了 `reference`:`p_account`→`showcase_account`、`p_assignee`→`sys_user`
- 动作参数弹窗里 Assignee 渲染成可搜索 picker;输入「Dev」发出 `GET /api/v1/data/sys_user?top=50&search=Dev`,下拉给出 **Dev Admin / admin@objectos.ai**(名字 + 邮箱副标题,people-picker 形状)
- 全程零 `ActionParamDialog` 降级告警 —— 没有任何参数掉回 UUID 文本框

**#3508** —— 逐类型扫过设计器,数据契约取自发布的 `xRef.sources`:

| Type | 控件 | 实测 |
|---|---|---|
| `user` | 记录 picker | `GET /api/v1/data/sys_user?top=25` |
| `team` | 记录 picker | `sys_team?top=50`(0 行,`sys_team` 无种子 —— 控件仍是 picker) |
| `department` | 记录 picker | `sys_business_unit?top=50`,**列出真实种子组织树**:Acme Corporation / Field Operations / West Coast / East Coast / HQ Finance |
| `position` | 记录 picker | 见下方遗留项 |
| `manager` | 禁用输入 + 「Resolved automatically」 | ✅ 无自由文本框 |
| `field` | 触发对象字段选择器 | ✅ 列出 `f_textarea` / `f_email` / … |
| Type 下拉 | `Manager｜Position｜Department｜Team｜Field｜Expression｜Org Membership Level｜User` | **无 queue**;且 `user` 垫底(间接绑定优先) |

全程**没有任何 `/api/v1/meta/:type` 注册表请求** —— 即 #3508 报的那条坏路径已不复存在。

发布契约本身也逐条核过(`ApprovalNodeApprover.json` 的 `xRef.sources`):`position` → `{source:'data', object:'sys_position', valueField:'name'}`(**存 name**)、`department` → `sys_business_unit`(**不是** sys_department)、`queue` → `unsupported`、`xEnumDeprecated: ['role','queue']`。DATA API 侧 `sys_position` 的 `name` 列实测就是 `manager`/`exec`/`contributor` 这类机器名,`sys_business_unit` 5 行 `bu_*` id,与契约一致。

## ⚠️ 一条未定论的观察(不在本 PR 修)

`position` approver 存了 `manager`,但**设计器 Value 控件有时不显示这个已存值**,而是显示字段描述;该次渲染只请求了 `/api/v1/meta/object/sys_position`(对象 schema),**没有**请求 `/api/v1/data/sys_position`(行),所以机器名没被回填成显示标签。

不敢定论,因为不稳定:第一轮扫描确实在该控件旁抓到了 **"Project Manager"**(`manager` 的显示标签),后续两轮干净复现都只有描述文案。已排除的干扰项:published 与 draft 两层的值都完好(`{type:'position', value:'manager'}`),所以不是值被我点掉了。

这正是 objectui#2834 声称修掉的那一类(`id_field` 非主键时回填走 `findOne(主键)` 永远查不到、已存值显示为空)—— 可能是没修全,也可能只是我的探针在不同渲染下抓到了不同的 DOM 祖先。**建议单独看一眼**;若属实,作者打开流程会看到一个已配置的审批人显示为空,是会误导人的。

## 备注

本 PR 只动 `examples/app-showcase`(两个标本 + 注册),无包代码改动,故无 changeset。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkvDs4y4gveyB5NJZKxaZt

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkvDs4y4gveyB5NJZKxaZt)_