### PR TITLE
fix(example-todo,docs): a modal action is client-only — defer/reminder are script actions (#3959)

### DIFF
--- a/.changeset/modal-actions-are-client-only.md
+++ b/.changeset/modal-actions-are-client-only.md
@@ -1,0 +1,21 @@
+---
+'@objectstack/example-todo': patch
+---
+
+**[#3959] `app-todo`'s `defer_task` / `set_reminder` are `type: 'script'`, not `type: 'modal'`.**
+
+Both declared `type: 'modal'` with a `target` naming a modal page that does not
+exist (`defer_task_modal`, `set_reminder_modal`), while their handlers sat
+registered under `deferTask` / `setReminder` — keys no declaration could
+address. A `modal` action has no server dispatch (`headlessActionTypeError`
+rejects it over REST), so neither handler had ever executed: the example
+shipped business logic that could not run, and ADR-0110 D5's boot inventory
+flagged both on its first pass.
+
+Both already declared the `params` their handlers read, so they were always
+"collect input, then run server-side" actions — which is `type: 'script'` with
+`params`. The runner collects the same dialog and the handler now actually runs.
+
+The action-type table in `content/docs/ui/actions.mdx` said `modal` meant
+"collect input, then submit to a handler", contradicting the same page's own
+REST table (`modal` → 400, nothing for the server to run). Corrected.

--- a/content/docs/ui/actions.mdx
+++ b/content/docs/ui/actions.mdx
@@ -19,7 +19,7 @@ The types you'll actually use:
 | `script` *(default)* | Run server-side logic | Inline `body` **or** a handler registered via `target` |
 | `flow` | Launch a flow (e.g. a screen-flow wizard) | `target` names the flow |
 | `url` | Navigate / open a link | `target` is the URL (`${ctx.record.id}` interpolation supported) |
-| `modal` | Open a modal page to collect input, then submit to a handler | `target` names the modal page |
+| `modal` | Open a modal page — client-side only, no server dispatch | `target` names the modal page (to collect input *and* run logic, use `script` + `params`) |
 | `api` | Call an HTTP endpoint directly | `target` is the endpoint; `method` / `bodyShape` / `bodyExtra` shape the request |
 | `form` | Open a form view, prefilled with the current record | `target` names the FormView; routed to `/forms/:target?recordId=…` |
 

--- a/examples/app-todo/src/actions/task.actions.ts
+++ b/examples/app-todo/src/actions/task.actions.ts
@@ -36,14 +36,25 @@ export const StartTaskAction = defineAction({
   },
 });
 
-/** Defer Task */
+/**
+ * Defer Task — collect input, then run server-side.
+ *
+ * [ADR-0110] This is `type: 'script'` with `params`, NOT `type: 'modal'`. A
+ * `modal` action's `target` names a page to OPEN and has no server dispatch
+ * (`headlessActionTypeError` rejects it), so the old
+ * `type: 'modal', target: 'defer_task_modal'` pointed at a page that does not
+ * exist while `deferTask` sat registered under a key no declaration could
+ * address — business logic that had never once executed (#3959). `script` +
+ * `params` is the supported shape: the runner collects the same dialog, then
+ * the handler runs with those values.
+ */
 export const DeferTaskAction = defineAction({
   name: 'defer_task',
   label: 'Defer Task',
   objectName: 'todo_task',
   icon: 'clock',
-  type: 'modal',
-  target: 'defer_task_modal',
+  type: 'script',
+  target: 'deferTask',
   locations: ['record_header'],
   params: [
     {
@@ -63,14 +74,14 @@ export const DeferTaskAction = defineAction({
   refreshAfter: true,
 });
 
-/** Set Reminder */
+/** Set Reminder — collect input, then run server-side (see DeferTaskAction). */
 export const SetReminderAction = defineAction({
   name: 'set_reminder',
   label: 'Set Reminder',
   objectName: 'todo_task',
   icon: 'bell',
-  type: 'modal',
-  target: 'set_reminder_modal',
+  type: 'script',
+  target: 'setReminder',
   locations: ['record_header', 'list_item'],
   params: [
     {

--- a/examples/app-todo/src/actions/task.handlers.ts
+++ b/examples/app-todo/src/actions/task.handlers.ts
@@ -82,7 +82,7 @@ export async function deleteCompletedTasks(ctx: ActionContext): Promise<void> {
   }
 }
 
-/** Defer a task by updating its due date (modal form submission handler) */
+/** Defer a task by updating its due date (params collected by the action dialog) */
 export async function deferTask(ctx: ActionContext): Promise<void> {
   const { record, engine, params } = ctx;
   await engine.update('todo_task', record.id as string, {
@@ -92,7 +92,7 @@ export async function deferTask(ctx: ActionContext): Promise<void> {
   });
 }
 
-/** Set a reminder on a task (modal form submission handler) */
+/** Set a reminder on a task (params collected by the action dialog) */
 export async function setReminder(ctx: ActionContext): Promise<void> {
   const { record, engine, params } = ctx;
   await engine.update('todo_task', record.id as string, {


### PR DESCRIPTION
Resolves #3959 by **option 2**: `modal` stays client-only, and the two actions that wanted a server half are declared as what they always were.

Ships with objectstack-ai/objectui#2973 (the client half removes the fallthrough). Order does not matter here — neither half depends on the other, since the path being removed never worked.

## What was broken

`examples/app-todo` declared both actions as `type: 'modal'` pointing at modal pages that do not exist, while `task.handlers.ts` registered their handlers under keys no declaration could address:

| Handler key | Declaration | Its `target` | Reachable? |
|---|---|---|---|
| `deferTask` | `defer_task` (`type: 'modal'`) | `defer_task_modal` | ❌ never |
| `setReminder` | `set_reminder` (`type: 'modal'`) | `set_reminder_modal` | ❌ never |

A `modal` action has no server dispatch — `headlessActionTypeError` rejects it over REST with a 400 — so neither handler had **ever executed**. The example shipped business logic that could not run, and taught the pattern to every app scaffolded from it. ADR-0110 D5's boot inventory flagged both on its first pass, which is how this surfaced.

## The fix

Both actions already declared the exact `params` their handlers read (`new_due_date` / `reason`, `reminder_date`), so they were always "collect input, then run server-side" — which is `type: 'script'` with `params`. Changing the type and pointing `target` at the real handler key is the whole change; the runner collects the same dialog and the handler now actually runs.

Reconciling app-todo with the same key derivation dispatch uses, after the change:

```
registered:            cloneTask, completeTask, deferTask, deleteCompletedTasks,
                       exportTasksToCSV, massCompleteTasks, setReminder, startTask
UNDECLARED handlers:   none
script declarations with NO handler: none
```

Clean in both directions — the example no longer trips the `[action-governance]` warning it was about to start emitting.

## Docs

The action-type table said `modal` meant *"Open a modal page to collect input, then submit to a handler"*, contradicting the same page's REST table (`modal` → **400**, "there is nothing for the server to run") and the `body`-belongs-to-`script` callout below it. That inconsistency is what made the wrong shape look sanctioned. Corrected to name `script` + `params` as the way to collect input and run logic.

## Verification

`runtime` 857 · `lint` 540 · `app-todo` `tsc --noEmit` — each run separately and checked by exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTTKgYriDB6RVrkYjxxnG1