### PR TITLE
fix(cli): the boot merge no longer discards the authored api block (#4002)

### DIFF
--- a/.changeset/boot-api-merge.md
+++ b/.changeset/boot-api-merge.md
@@ -1,0 +1,40 @@
+---
+"@objectstack/cli": patch
+---
+
+fix(cli): the boot merge no longer discards the authored `api` block (#4002)
+
+`objectstack serve` (and `dev`, which spawns it) assembled the effective config as
+`{ ...authored, ...bootResult }`. `createStandaloneStack()` /
+`createDefaultHostConfig()` return an `api` block carrying only the
+environment-scoping decision — `{ enableProjectScoping: false, projectResolution:
+'none' }` — and under a shallow spread that object REPLACED the author's entire
+`api`, silently dropping every key it did not itself set.
+
+Two of those keys are live knobs the CLI reads a few lines later:
+
+- **`api.requireAuth`** — the documented one-line opt-out for serving data
+  publicly (ADR-0056 D2; the v12 migration note presents it as the whole
+  migration). Authoring it did nothing: the value never reached the REST or
+  dispatcher plugin, so anonymous requests kept getting `401` **and** the boot
+  warning that exists to make a fail-open posture visible never fired either.
+- **`api.enforceProjectMembership`** — the ADR-0024 D9 opt-out from the
+  `sys_environment_member` 403 gate. Silently fell back to the dispatcher default.
+
+`api` now merges per key, via a small pure `mergeBootConfig` helper: the author's
+declarations survive, and the boot builder still wins on the keys it actually
+decides (environment scoping is not the author's call on a standalone host).
+Every other top-level key keeps the previous whole-value semantics — the
+artifact-serve path deliberately serves the boot result's `objects` /
+`permissions` / `manifest` / `plugins`, so those are untouched.
+
+The auth-less carve-out was never affected and is unchanged: it lives in the
+`?? ((tierEnabled('auth') || hasAuthPlugin) ? true : false)` fallback, which fired
+precisely *because* the authored value had gone missing. Only an explicitly
+authored value was lost.
+
+Verified end to end: with `api: { requireAuth: false }` on the CRM example, an
+anonymous `POST /data/crm_account/query` returned `401` before and returns records
+after. Worth knowing what the working flag does — the same anonymous caller can
+then read `sys_user` — which is the flag's documented meaning ("serve data
+publicly"), and the argument for retiring it (#3963).

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -7,6 +7,7 @@ import net from 'net';
 import chalk from 'chalk';
 import { bundleRequire } from 'bundle-require';
 import { loadConfig, BUNDLE_REQUIRE_EXTERNALS } from '../utils/config.js';
+import { mergeBootConfig } from '../utils/merge-boot-config.js';
 import { isHostConfig, shouldBootWithLibrary } from '../utils/plugin-detection.js';
 import { resolveDriverType, resolveStorageDefinition, UnsupportedDriverError } from '../utils/storage-driver.js';
 import { readEnvWithDeprecation, resolveMultiOrgEnabled, resolveTenancyPosture, resolveAllowDegradedTenancy, isMcpServerEnabled, resolveSearchPinyinEnabled, isModuleNotFoundError } from '@objectstack/types';
@@ -655,7 +656,10 @@ export default class Serve extends Command {
           // can later install marketplace apps at runtime.
           const { createDefaultHostConfig } = await import('@objectstack/runtime');
           const bootResult = await createDefaultHostConfig({ requireArtifact: !useEmptyBoot, dev: isDev });
-          config = { ...originalConfig, ...bootResult } as any;
+          // [#4002] `api` merges per key — see mergeBootConfig. A shallow spread
+          // let the boot builder's two scoping keys wipe the author's whole `api`
+          // block, silently dropping `requireAuth` / `enforceProjectMembership`.
+          config = mergeBootConfig(originalConfig as any, bootResult as any) as any;
         } else if (resolvedMode === 'standalone') {
           const { createStandaloneStack } = await import('@objectstack/runtime');
           // Anchor the default sqlite database under the project folder
@@ -669,7 +673,8 @@ export default class Serve extends Command {
             dev: isDev,
           };
           const bootResult = await createStandaloneStack(standaloneInput);
-          config = { ...originalConfig, ...bootResult } as any;
+          // [#4002] Per-key `api` merge — see mergeBootConfig.
+          config = mergeBootConfig(originalConfig as any, bootResult as any) as any;
         } else {
           throw new Error(
             `Boot mode '${resolvedMode}' is not available in the open-core CLI.\n`

--- a/packages/cli/src/utils/merge-boot-config.test.ts
+++ b/packages/cli/src/utils/merge-boot-config.test.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { mergeBootConfig } from './merge-boot-config.js';
+
+/** What `createStandaloneStack()` actually returns for the `api` block. */
+const BOOT_API = { enableProjectScoping: false, projectResolution: 'none' } as const;
+
+describe('mergeBootConfig (#4002)', () => {
+    it('keeps the authored api keys the boot result does not set', () => {
+        const merged: any = mergeBootConfig(
+            { api: { requireAuth: false, enforceProjectMembership: false } },
+            { api: { ...BOOT_API }, plugins: [] },
+        );
+
+        // The two live knobs the CLI reads a few lines later — both were dropped
+        // by the old shallow spread.
+        expect(merged.api.requireAuth).toBe(false);
+        expect(merged.api.enforceProjectMembership).toBe(false);
+    });
+
+    it('lets the boot result win on the keys it decides', () => {
+        // Environment scoping is not the author's call on a standalone host.
+        const merged: any = mergeBootConfig(
+            { api: { enableProjectScoping: true, projectResolution: 'auto', requireAuth: false } },
+            { api: { ...BOOT_API } },
+        );
+
+        expect(merged.api.enableProjectScoping).toBe(false);
+        expect(merged.api.projectResolution).toBe('none');
+        expect(merged.api.requireAuth).toBe(false); // untouched by boot → survives
+    });
+
+    it('still replaces every other top-level key wholesale', () => {
+        // The artifact-serve path deliberately serves the boot result's objects /
+        // permissions / plugins, so those keep the previous semantics.
+        const merged: any = mergeBootConfig(
+            { objects: [{ name: 'authored' }], plugins: ['authored'] },
+            { objects: [{ name: 'from_artifact' }], plugins: ['from_boot'] },
+        );
+
+        expect(merged.objects).toEqual([{ name: 'from_artifact' }]);
+        expect(merged.plugins).toEqual(['from_boot']);
+    });
+
+    it('does not invent an api block when neither side has one', () => {
+        const merged: any = mergeBootConfig({ objects: [] }, { plugins: [] });
+        expect('api' in merged).toBe(false);
+    });
+
+    it('carries an api block through when only one side has one', () => {
+        expect((mergeBootConfig({ api: { requireAuth: false } }, {}) as any).api)
+            .toEqual({ requireAuth: false });
+        expect((mergeBootConfig({}, { api: { ...BOOT_API } }) as any).api)
+            .toEqual({ ...BOOT_API });
+    });
+
+    it('ignores a non-object api on either side rather than spreading it', () => {
+        // Defensive: a malformed authored `api` must not throw or produce
+        // character-indexed keys from a string spread.
+        expect((mergeBootConfig({ api: 'nonsense' as any }, { api: { ...BOOT_API } }) as any).api)
+            .toEqual({ ...BOOT_API });
+        expect((mergeBootConfig({ api: { requireAuth: false } }, { api: null as any }) as any).api)
+            .toEqual({ requireAuth: false });
+    });
+
+    it('does not mutate either input', () => {
+        const authored = { api: { requireAuth: false } };
+        const boot = { api: { ...BOOT_API } };
+        mergeBootConfig(authored, boot);
+
+        expect(authored).toEqual({ api: { requireAuth: false } });
+        expect(boot).toEqual({ api: { ...BOOT_API } });
+    });
+});

--- a/packages/cli/src/utils/merge-boot-config.ts
+++ b/packages/cli/src/utils/merge-boot-config.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#4002] Merge a boot result over the authored stack config.
+ *
+ * `objectstack serve` (and `dev`, which spawns it) assembles the effective
+ * config as `{ ...authored, ...bootResult }`, where `bootResult` comes from
+ * `createStandaloneStack()` / `createDefaultHostConfig()`. Those builders return
+ * an `api` block carrying only the environment-scoping decision:
+ *
+ * ```js
+ * api: { enableProjectScoping: false, projectResolution: 'none' }
+ * ```
+ *
+ * Under a shallow spread that object REPLACED the author's entire `api` block,
+ * silently discarding every key it did not itself set. Two of those keys are
+ * live knobs the CLI reads a few lines later:
+ *
+ * - `api.requireAuth` — the documented one-line opt-out for serving data
+ *   publicly (ADR-0056 D2, the v12 migration note). Authoring it did nothing:
+ *   the value never reached the REST plugin, so the boot warning that is supposed
+ *   to make a fail-open posture visible never fired either.
+ * - `api.enforceProjectMembership` — the ADR-0024 D9 opt-out from the
+ *   `sys_environment_member` 403 gate. Silently fell back to the dispatcher
+ *   default.
+ *
+ * So `api` merges PER KEY: the author's declarations survive, and the boot
+ * builder still wins on the keys it actually decides (scoping is not the
+ * author's call on a standalone host). Every other top-level key keeps the
+ * previous whole-value semantics — for `objects` / `permissions` / `manifest` /
+ * `plugins` the artifact-serve path deliberately serves the boot result's
+ * version, so those are not swept into this change.
+ */
+export function mergeBootConfig<A extends object, B extends object>(authored: A, bootResult: B): A & B {
+    const merged = { ...authored, ...bootResult } as any;
+    const authoredApi = (authored as any)?.api;
+    const bootApi = (bootResult as any)?.api;
+    // Only synthesize the key when at least one side has one, so a config with
+    // no `api` block anywhere does not gain an empty object.
+    if (isPlainObject(authoredApi) || isPlainObject(bootApi)) {
+        merged.api = {
+            ...(isPlainObject(authoredApi) ? authoredApi : {}),
+            ...(isPlainObject(bootApi) ? bootApi : {}),
+        };
+    }
+    return merged as A & B;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+    return typeof v === 'object' && v !== null && !Array.isArray(v);
+}


### PR DESCRIPTION
Closes #4002。这是 #3963 第 2 节"值丢在哪一环"的答案,已实测定位。

## 根因

`serve.ts`(`dev` 是 spawn 它的子进程)这样拼有效配置:

```js
config = { ...originalConfig, ...bootResult }     // ← 浅展开
```

而 `createStandaloneStack()` / `createDefaultHostConfig()` 返回的 `api` 只携带 environment scoping 的决定:

```js
api: { enableProjectScoping: false, projectResolution: 'none' }
```

浅展开下这个对象**整块替换**掉作者写的 `api`,把它自己没设的键全部静默丢掉。

## 丢掉的是两个活着的旋钮

| 键 | 后果 |
|:--|:--|
| **`api.requireAuth`** | ADR-0056 D2 的公开托管开关 —— **v12 把它当成"一行迁移"来文档化**。写了等于没写:值到不了 REST / dispatcher 插件,匿名照旧 401,**而那句"让 fail-open 姿态可见"的启动告警也从来没打过** |
| **`api.enforceProjectMembership`** | ADR-0024 D9 那个 `sys_environment_member` 403 门的 opt-out,静默退回 dispatcher 默认 |

## 实测证据

在 `examples/app-crm` 写 `api: { requireAuth: false }`,在 `serve.ts:1745` 打点:

```
[DBG] configKeys= actions,api,apps,...            ← api 键在
[DBG] apiConfig= {"enableProjectScoping":false,"projectResolution":"none"}
      | resolved requireAuth= true
```

`apiConfig` 没有 `requireAuth`,还带着一个 schema 枚举(`'required'|'optional'|'auto'`)根本不允许的 `"none"` —— 那是 boot 的对象,不是作者的。

**修复后端到端复验**:同样的配置,匿名 `POST /data/crm_account/query` **修复前 401、修复后返回记录**。

## 修法

新增一个纯函数 `mergeBootConfig`:`api` **按键合并**,作者的声明留下,boot 仍然在它真正负责的键上取胜(standalone 主机上 scoping 不是作者的选择)。其余顶层键**保持整值语义** —— artifact-serve 路径就是要用产物里的 `objects` / `permissions` / `manifest` / `plugins`,所以没有一并改动。

## 两点需要说清的边界

**1. auth-less stack 的兜底从来没受影响,也没有改。** 它在 `?? ((tierEnabled('auth') || hasAuthPlugin) ? true : false)` 这个 fallback 里 —— 而它之所以一直生效,**恰恰是因为**作者的值不见了。丢的只有显式写的值。这也消解了我在 #3963 里担心的"那类 stack 可能已经砖了"。

**2. `projectResolution: 'none'` 我没有动。** 它不在 `ObjectStackDefinitionSchema.api.projectResolution` 的枚举里,但 `enableProjectScoping: false` 时它是惰性的;改它要么把 `'none'` 加进作者可写的枚举(反而拓宽了面),要么去动另一个包的契约却换不来任何行为收益。已在 #4002 记录,留待单独判断。

## 顺带:#3960 的可达性终于补齐了

这个开关一旦真的能用,我就有了一个匿名可达的部署来验证 #3960 那个我标注"未实测"的一半 —— **带上对照组**跑了一遍:

```
匿名读 sys_user,不带 context      → 1 行
匿名 + 伪造 context.isSystem      → 1 行
匿名 + 伪造 context.__expandRead  → 1 行
```

三组完全一样,所以:**#3960 的修复成立**(伪造的 `context` 被剥掉了,什么都没做成);`sys_user` 被读到纯粹是 `requireAuth: false` 本身的语义。

顺便也说明了这个开关**能用的时候会做什么** —— 同一个匿名调用者可以读身份表。这正是 #3963 主张退役它的理由,现在是实测出来的,不是推演的。

## 验证

- 新增 7 条单测(`merge-boot-config.test.ts`):作者键留存、boot 在自己负责的键上取胜、其余顶层键仍整值替换、两侧都没有 `api` 时不凭空造一个、单侧有时透传、非对象 `api` 不被展开成字符索引、不修改入参;
- `@objectstack/cli` **835 条全绿**;改动文件 ESLint 干净;
- 诊断探针与临时配置改动均已清理,未提交。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzLE9cw4gZKNyPN2ZP4iTt


---
_Generated by [Claude Code](https://claude.ai/code/session_01TzLE9cw4gZKNyPN2ZP4iTt)_