### PR TITLE
docs(rest): correct the packages envelope suite's stale note on the code vocabulary (#3843 follow-up)

### DIFF
--- a/.changeset/packages-envelope-suite-comment.md
+++ b/.changeset/packages-envelope-suite-comment.md
@@ -1,0 +1,14 @@
+---
+---
+
+Comment-only correction in `packages/rest/src/package-envelope.conformance.test.ts`
+(#3843 follow-up). Deliberately empty frontmatter: this releases nothing.
+
+Two sentences in that suite's header were written while #3841 was still undecided —
+"why #3841 still owns the vocabulary" (ADR-0112 has since closed it) and "this
+module needed MINTED codes" (true only of the four registered ones; the three
+generic conditions reuse the standard catalog). `package-routes.ts` already carried
+the corrected note; this was the test file missed beside it.
+
+No published behaviour, type, or wire shape changes, so there is nothing for a
+consumer to read in a CHANGELOG.

--- a/packages/rest/src/package-envelope.conformance.test.ts
+++ b/packages/rest/src/package-envelope.conformance.test.ts
@@ -16,10 +16,18 @@
  *     res.status(400).json({ success: false, failed, cleanups });
  *     res.status(400).json({ success: false });
  *
- * i.e. a caller was told it failed and never told why. Those two are the reason
- * this module needed MINTED codes rather than carried-over ones: there was
- * nothing to carry. See `sendError`'s note in `package-routes.ts` for why the
- * SCREAMING_SNAKE dialect was chosen and why #3841 still owns the vocabulary.
+ * i.e. a caller was told it failed and never told why. They are also why this
+ * module had no codes to carry over: its `error` strings were human messages, so
+ * every code here had to be chosen rather than re-spelled.
+ *
+ * ADR-0112 (#3841) settled the vocabulary, so the choice was not free. Generic
+ * conditions reuse the STANDARD catalog — `MISSING_REQUIRED_FIELD`,
+ * `RESOURCE_NOT_FOUND`, `INTERNAL_ERROR` — and only the package-specific outcomes
+ * are registered in `ERROR_CODE_LEDGER` (`PACKAGE_MANIFEST_INVALID`,
+ * `PACKAGE_PUBLISH_FAILED`, `PACKAGE_DELETE_PARTIAL`, `PACKAGE_DELETE_FAILED`);
+ * see `sendError`'s note in `package-routes.ts`. `ApiErrorSchema.code` is a closed
+ * union now, so an unregistered code fails parse — which is what makes the
+ * `BaseResponseSchema.safeParse` assertions below catch an invented one.
  *
  * The three bodies that already had the flag kept their payload as SIBLINGS of
  * it (`{ success: true, message, package }`); the assertions below pin that they


### PR DESCRIPTION
Comment-only follow-up to #3972 (#3843). No behaviour change, no changeset.

Two sentences in `package-envelope.conformance.test.ts`'s header were written while #3841 was still undecided. #3843 landed *after* ADR-0112 settled it, and I updated the matching note in `package-routes.ts` but missed the one in the test file beside it.

Both sentences were left inaccurate:

| was | why it's wrong |
|---|---|
| "why #3841 **still owns** the vocabulary" | It doesn't — ADR-0112 (#3988) closed it, and `ApiErrorSchema.code` is a closed union now. |
| "this module needed **MINTED** codes" | Half true. It genuinely had nothing to carry over (its `error` strings were human messages), but only **four** of the codes here are registered — the three generic conditions reuse the standard catalog. |

The second one is the more useful correction: recording that generic conditions go to the standard catalog (`MISSING_REQUIRED_FIELD`, `RESOURCE_NOT_FOUND`, `INTERNAL_ERROR`) and only package-specific outcomes get registered (`PACKAGE_MANIFEST_INVALID`, `PACKAGE_PUBLISH_FAILED`, `PACKAGE_DELETE_PARTIAL`, `PACKAGE_DELETE_FAILED`) is what the ledger actually asks for, and it explains why the assertions below are load-bearing: an unregistered code fails parse, so `BaseResponseSchema.safeParse` is what would catch an invented one.

Branch restarted from `main` rather than reusing the merged one, per the repo's branch hygiene.

## Verification

`pnpm lint` clean · `pnpm check:route-envelope` 8 modules (5 conformant / 2 ratcheted / 1 exempt) + self-test green · `@objectstack/rest` 472 passed (33 files).

Also grepped the repo for the other stale phrasings of the same claim (`#3841's call`, `#3841 can pick`, `vocabulary wins is #3841`, …) — this was the only remaining one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYbS3kS8xzsHNXFTzp4e2z)_