### PR TITLE
fix(driver-sql): the plan must not promise columns the apply can never create (#3978)

### DIFF
--- a/.changeset/preview-omits-virtual-fields.md
+++ b/.changeset/preview-omits-virtual-fields.md
@@ -1,0 +1,21 @@
+---
+"@objectstack/driver-sql": patch
+---
+
+fix(driver-sql): `os migrate plan` no longer promises columns the apply can never create (#3978)
+
+`previewDeferredSchemaWork()` listed every declared field name when computing
+pending `create_table` / `add_columns` work, but `createColumn` returns early
+for a virtual `formula` field — no column is ever created for it.
+
+So a formula field showed up as pending `add_columns` that `apply` reported as
+performed without doing anything, and the very next `plan` reported it again.
+A freshly-applied database looked permanently un-migrated, with no invocation
+able to clear the finding. On `examples/app-crm` that was 4 columns
+(`crm_contact.full_name`, `crm_lead.is_closed`, `crm_opportunity.expected_revenue`,
+`crm_opportunity.days_to_close`) reported forever.
+
+The preview now filters through `fieldHasColumn` — the same helper `createColumn`
+and the column differ already answer "does this field materialize a column?"
+with — so the plan and the flush cannot disagree. `multiple` fields are
+unaffected: they materialize as a JSON column and are still reported.

--- a/packages/plugins/driver-sql/src/schema-drift.ts
+++ b/packages/plugins/driver-sql/src/schema-drift.ts
@@ -110,6 +110,11 @@ export interface PendingSchemaWork {
   /**
    * Declared columns for a create; the missing ones for an add; the columns
    * being converged for the two datetime steps.
+   *
+   * The additive kinds name only fields that MATERIALIZE a column
+   * ({@link fieldHasColumn}) — a virtual `formula` field never appears. The
+   * promise above cuts both ways: a plan may not promise work `apply` cannot
+   * deliver either, or the finding can never be cleared (#3978).
    */
   columns: string[];
   /**

--- a/packages/plugins/driver-sql/src/sql-driver-deferred-ddl.test.ts
+++ b/packages/plugins/driver-sql/src/sql-driver-deferred-ddl.test.ts
@@ -136,4 +136,79 @@ describe('SqlDriver deferred schema DDL (#3917)', () => {
     expect(driver.deferredSchemaObjectCount).toBe(0);
     expect(await driver.previewDeferredSchemaWork()).toEqual([]);
   });
+
+  // ── #3978: the plan may only promise work the flush can deliver ───────────
+  //
+  // The mirror image of #3954. That one closed "the plan understates what apply
+  // does"; this closes "the plan promises what apply cannot do". `createColumn`
+  // returns early for a virtual `formula` field — no column is ever created —
+  // but the preview listed every declared field name regardless, so a formula
+  // field showed up as pending `add_columns` that `apply` reported as performed
+  // without doing anything, and the next `plan` reported it again, forever.
+  // Both sides must answer "does this field become a column?" the same way.
+  describe('virtual fields are never promised as pending work (#3978)', () => {
+    const CONTACT = {
+      name: 'contacts',
+      fields: {
+        first_name: { type: 'text' },
+        last_name: { type: 'text' },
+        // Virtual — computed on read, no physical column (see createColumn).
+        full_name: { type: 'formula', expression: 'record.first_name' },
+        // `multiple` is NOT virtual: it materializes as a JSON column.
+        tags: { type: 'text', multiple: true },
+      },
+    };
+
+    it('omits the formula field from a create_table preview, keeps the JSON column', async () => {
+      driver = makeDriver();
+      driver.setDeferredDdl(true);
+      await driver.initObjects([CONTACT]);
+
+      expect(await driver.previewDeferredSchemaWork()).toEqual([
+        { table: 'contacts', kind: 'create_table', columns: ['first_name', 'last_name', 'tags'] },
+      ]);
+    });
+
+    it('omits it from an add_columns preview too', async () => {
+      driver = makeDriver();
+      await driver.initObjects([{ name: 'contacts', fields: { first_name: { type: 'text' } } }]);
+
+      driver.setDeferredDdl(true);
+      await driver.initObjects([CONTACT]);
+
+      expect(await driver.previewDeferredSchemaWork()).toEqual([
+        { table: 'contacts', kind: 'add_columns', columns: ['last_name', 'tags'] },
+      ]);
+    });
+
+    it('converges: after a flush the next preview is empty', async () => {
+      // The defect proper. Pre-fix the second preview still reported
+      // `add_columns: ['full_name']` — a freshly-applied database looking
+      // permanently un-migrated, with no apply able to clear it.
+      driver = makeDriver();
+      driver.setDeferredDdl(true);
+      await driver.initObjects([CONTACT]);
+      await driver.flushDeferredSchemaDdl();
+
+      driver.setDeferredDdl(true);
+      await driver.initObjects([CONTACT]);
+      expect(await driver.previewDeferredSchemaWork()).toEqual([]);
+    });
+
+    it('what flush REPORTS having done matches the columns it actually created', async () => {
+      driver = makeDriver();
+      driver.setDeferredDdl(true);
+      await driver.initObjects([CONTACT]);
+
+      const performed = await driver.flushDeferredSchemaDdl();
+      const create = performed.find((p) => p.kind === 'create_table')!;
+      const physical = new Set(Object.keys(await (driver as any).knex('contacts').columnInfo()));
+
+      // Every promised column exists...
+      for (const c of create.columns) expect(physical.has(c)).toBe(true);
+      // ...and the virtual one was neither promised nor created.
+      expect(create.columns).not.toContain('full_name');
+      expect(physical.has('full_name')).toBe(false);
+    });
+  });
 });

--- a/packages/plugins/driver-sql/src/sql-driver.ts
+++ b/packages/plugins/driver-sql/src/sql-driver.ts
@@ -20,6 +20,7 @@ import {
   diffManagedTable,
   driftKey,
   expectedIndexes,
+  fieldHasColumn,
   isIndexDriftOp,
   legacyUniqueReplacements,
   uniqueIndexesFromFields,
@@ -2864,11 +2865,22 @@ export class SqlDriver implements IDataDriver {
    * a database that has not been migrated yet. That is the right trade for a
    * command the operator ran to be told the size of the job — and it is paid
    * once, by `plan`/`apply`, never on a normal boot.
+   *
+   * The obligation runs both ways (#3978). #3954 closed "the plan understates
+   * what apply does"; this closes its mirror image — the plan must not promise
+   * work apply CANNOT do. Only fields that materialize a column are listed,
+   * decided by {@link fieldHasColumn}, the same helper `createColumn` and the
+   * column differ use. A virtual `formula` field has no column, so listing it
+   * produced an `add_columns` entry `apply` reported as performed without doing
+   * anything and the next `plan` reported again: a finding no invocation could
+   * ever clear, making a freshly-applied database look un-migrated.
    */
   async previewDeferredSchemaWork(): Promise<PendingSchemaWork[]> {
     const out: PendingSchemaWork[] = [];
     for (const [tableName, obj] of this.deferredSchemaObjects) {
-      const declared = Object.keys(obj.fields ?? {});
+      const declared = Object.entries<any>(obj.fields ?? {})
+        .filter(([, field]) => fieldHasColumn(field ?? {}))
+        .map(([name]) => name);
       if (!(await this.knex.schema.hasTable(tableName))) {
         // A table that does not exist yet is created empty, so nothing to converge.
         out.push({ table: tableName, kind: 'create_table', columns: declared });


### PR DESCRIPTION
修复 #3978 —— #3954 的**镜像缺陷**。#3954 关掉的是"计划**少报**了 apply 会做的事";这里关掉的是另一个方向:**计划承诺了 apply 根本做不到的事**。

## 现象

对一个刚由 `os migrate apply` 完整创建、随后未做任何改动的数据库再次 `plan`(examples/app-crm):

```
  New (additive — created when you apply)
    + crm_contact [add_columns: full_name]
    + crm_lead [add_columns: is_closed]
    + crm_opportunity [add_columns: expected_revenue, days_to_close]

  ℹ 0 table(s) to create, 4 column(s) to add
```

这四个全是 `Field.formula(...)` 虚拟字段。每次 plan 都报、每次 apply 都"执行"却什么也不发生 —— **永远无法收敛**。刚 apply 完立刻 plan 就是上面这个输出,操作者会以为 apply 没生效。

## 根因

`previewDeferredSchemaWork()` 算待办列时用的是

```ts
const declared = Object.keys(obj.fields ?? {});
```

而真正执行 DDL 的 `createColumn` 对 `formula` 是直接 `return`(虚拟字段,读取时计算,不建列)。两条路径对"哪些字段会变成列"的判断不一致,于是 preview 报告了 flush 永远不会做的工作。

## 修复

判定收敛到 `fieldHasColumn` —— **`createColumn` 与列差异检测本来就在用**的那个 helper(其注释明写 "Mirrors `SqlDriver.createColumn` exactly"),preview 是唯一漏用的一处。这样计划与执行不可能再分歧。

- `multiple` 字段不受影响:它确实物化为 JSON 列,照常上报;
- `PendingSchemaWork.columns` 的契约注释补上这条约束,与 #3954 留下的「凡进入 `initObjects` 物理路径的工作都必须可在此表达」并排 —— 两个方向的义务写在一起。

## 验证

`packages/plugins/driver-sql/src/sql-driver-deferred-ddl.test.ts` 新增 4 例,**去掉过滤后 4 例全红**:

1. create_table 预览排除 formula,但保留 JSON 列;
2. add_columns 预览同理;
3. flush 之后再预览为空 —— 即 issue 要求的收敛性;
4. flush **报告**做过的列 = 物理上真正建出的列(formula 既未承诺也未创建)。

端到端(examples/app-crm,即 issue 的原始现场):`apply` 后立即 `plan` 现在输出 `Physical schema is in sync with metadata — nothing to migrate`。

根 `pnpm test` **132/132 task 全绿**。

## 说明

本 PR 从最新 main(`be7945a`)起分支,已包含 #3954 落地后的新形状(`PendingSchemaWorkKind` 联合与 `previewDatetimeConvergence`);缺陷本身在重构后原样存在,与 #3981(#3955 的修复)无重叠、可独立合并。

Closes #3978

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FcphmGzBuWwF8SaYPSCtCw

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcphmGzBuWwF8SaYPSCtCw)_