### PR TITLE
feat(runtime): /analytics 路由按能力条件挂载——没装 service-analytics 连 405 都不再有（#3891 收尾，ADR-0076 D11）

### DIFF
--- a/.changeset/analytics-capability-conditional-mounting.md
+++ b/.changeset/analytics-capability-conditional-mounting.md
@@ -1,0 +1,31 @@
+---
+"@objectstack/runtime": minor
+---
+
+feat(runtime): mount /analytics routes only when the capability exists (#3891 follow-through, ADR-0076 D11)
+
+`createDispatcherPlugin` used to mount `POST /analytics/query`,
+`GET /analytics/meta` and `POST /analytics/sql` on the `IHttpServer`
+unconditionally — so a deployment without `@objectstack/service-analytics`
+still had the routes in its table: a `PUT` answered `405` with
+`Allow: POST`, advertising a method on an API that wasn't there (the `POST`
+itself answered 404 since #3989).
+
+The mounts are now capability-conditional. Plugin `start()` runs after the
+kernel's Phase-1 init, so service presence is authoritative:
+
+- **single-kernel mode, `analytics` not registered** — the three routes are
+  NOT mounted; every method on `/api/v1/analytics/*` answers the adapter's
+  shared not-found contract (`404 { "error": "Not found" }`), and a boot log
+  names the fix (`Install @objectstack/service-analytics`);
+- **single-kernel mode, `analytics` registered** — unchanged;
+- **multi-tenant host** (a `kernel-resolver` is wired) — mounted
+  unconditionally, because mounts are host-global while the analytics service
+  lives in each per-project kernel: capability presence is a per-request
+  question, answered by the analytics domain's existing `handled:false` → 404
+  (new public `HttpDispatcher.isMultiTenantHost()` exposes the mode).
+
+With this, the `/analytics` API surface exists exactly when the capability is
+installed — completing the #3891 arc: #3989 emptied the slot (no more
+unscoped-aggregate shim), #4010 made the body contract strict at the entry,
+and this change removes the last wire-level residue of the uninstalled API.

--- a/content/docs/api/index.mdx
+++ b/content/docs/api/index.mdx
@@ -109,8 +109,7 @@ Returns the full discovery manifest.
   "apiName": "ObjectStack API",
   "routes": {
     "data": "/api/v1/data",
-    "metadata": "/api/v1/meta",
-    "analytics": "/api/v1/analytics"
+    "metadata": "/api/v1/meta"
   },
   "services": {
     "metadata": {
@@ -120,7 +119,7 @@ Returns the full discovery manifest.
       "provider": "objectql"
     },
     "data": { "enabled": true, "status": "available", "route": "/api/v1/data", "provider": "objectql" },
-    "analytics": { "enabled": true, "status": "available", "route": "/api/v1/analytics", "provider": "objectql" },
+    "analytics": { "enabled": false, "status": "unavailable", "message": "Install service-analytics to enable" },
     "auth": { "enabled": false, "status": "unavailable", "message": "Install plugin-auth to enable" }
   },
   "capabilities": {
@@ -131,7 +130,7 @@ Returns the full discovery manifest.
 }
 ```
 
-Disabled/uninstalled route keys (e.g. `auth`, `workflow`) are omitted from `routes` entirely rather than set to `null`; check `services` to tell "not installed" apart from "installed but not yet mounted here."
+Disabled/uninstalled route keys (e.g. `auth`, `analytics`, `workflow`) are omitted from `routes` entirely rather than set to `null`; check `services` to tell "not installed" apart from "installed but not yet mounted here." The sample above shows a minimal install: `analytics` reports `unavailable` and advertises no route until `@objectstack/service-analytics` registers the engine — the dispatcher then also mounts `/api/v1/analytics/*` (the routes are capability-conditional; an uninstalled capability answers 404 for every method).
 
 ### `GET /.well-known/objectstack`
 

--- a/packages/qa/http-conformance/src/conformance.integration.test.ts
+++ b/packages/qa/http-conformance/src/conformance.integration.test.ts
@@ -36,10 +36,29 @@ const ADAPTERS: AdapterCase[] = [
 /**
  * Boot the full HTTP stack (ObjectQL engine + REST generator + dispatcher
  * bridge) on the given adapter and return its base URL + kernel.
+ *
+ * `withAnalytics` (default true) registers a minimal in-memory `analytics`
+ * service so the capability-conditional `/analytics` routes mount (#3891
+ * follow-through) — the transport contracts under test (405 method mismatch,
+ * parity) need the routes to exist. Pass false to exercise the
+ * capability-absent posture: no mounts, shared 404.
  */
-async function bootStack(makePlugin: () => any) {
+async function bootStack(makePlugin: () => any, opts: { withAnalytics?: boolean } = {}) {
     const kernel = new LiteKernel();
     kernel.use(new ObjectQLPlugin());
+    if (opts.withAnalytics !== false) {
+        kernel.use({
+            name: 'com.test.analytics-stub',
+            version: '0.0.0',
+            init: (c: any) => {
+                c.registerService('analytics', {
+                    query: async () => ({ rows: [], fields: [] }),
+                    getMeta: async () => ({ cubes: [] }),
+                    generateSql: async () => ({ sql: null, params: [] }),
+                });
+            },
+        } as any);
+    }
     kernel.use(makePlugin());
     kernel.use(createRestApiPlugin({
         api: {
@@ -161,11 +180,53 @@ describe.each(ADAPTERS)('IHttpServer conformance on $label adapter', ({ makePlug
     });
 
     it('405s a method mismatch with an Allow header', async () => {
-        // /api/v1/analytics/query is registered POST-only by the bridge.
+        // /api/v1/analytics/query is registered POST-only by the bridge —
+        // mounted here because bootStack registers the analytics stub
+        // (capability-conditional since #3891 follow-through).
         const res = await fetch(`${base}/api/v1/analytics/query`, { method: 'PUT' });
         expect(res.status).toBe(405);
         expect(res.headers.get('allow')).toContain('POST');
         expect((await res.json()).code).toBe('METHOD_NOT_ALLOWED');
+    });
+});
+
+/**
+ * [#3891 follow-through] Capability-conditional mounting: without an
+ * `analytics` service the routes are NOT mounted, so the path answers the
+ * adapter's shared not-found contract — for EVERY method. No 405 Allow hint
+ * may leak for an API that isn't there. Single adapter suffices: the
+ * conditional lives in the dispatcher plugin, above the adapter seam.
+ */
+describe('analytics capability-conditional mounting (no service installed)', () => {
+    let stack: { kernel: LiteKernel; base: string };
+
+    beforeAll(async () => {
+        stack = await bootStack(ADAPTERS[0].makePlugin, { withAnalytics: false });
+    }, 30_000);
+
+    afterAll(async () => {
+        if (stack?.kernel) {
+            await Promise.race([
+                stack.kernel.shutdown(),
+                new Promise<void>((resolve) => setTimeout(resolve, 10_000)),
+            ]);
+        }
+    }, 30_000);
+
+    it.each(['POST', 'PUT', 'GET'])('%s /api/v1/analytics/query answers the shared 404', async (method) => {
+        const res = await fetch(`${stack.base}/api/v1/analytics/query`, { method });
+        expect(res.status).toBe(404);
+        expect(await res.json()).toEqual({ error: 'Not found' });
+    });
+
+    it('GET /api/v1/analytics/meta answers the shared 404 too', async () => {
+        const res = await fetch(`${stack.base}/api/v1/analytics/meta`);
+        expect(res.status).toBe(404);
+    });
+
+    it('a sibling dispatcher route is still mounted (the absence is analytics-scoped)', async () => {
+        const res = await fetch(`${stack.base}/api/v1/health`);
+        expect(res.status).toBe(200);
     });
 });
 

--- a/packages/runtime/src/dispatcher-plugin.routes.test.ts
+++ b/packages/runtime/src/dispatcher-plugin.routes.test.ts
@@ -111,7 +111,62 @@ describe('createDispatcherPlugin — HTTP route registration', () => {
     const plugin = createDispatcherPlugin({ prefix: '/api/v1', securityHeaders: false });
     await plugin.start?.(makeCtx(server));
 
-    expect(routes).toContain('POST /api/v1/analytics/query');
+    expect(routes).toContain('GET /api/v1/i18n/locales');
+  });
+
+  // [#3891 follow-through] The /analytics wire surface exists only when the
+  // capability does: with no `analytics` service registered (and no
+  // kernel-resolver), the three routes are NOT mounted — the path answers the
+  // adapter's shared 404, with no 405 Allow hint for an API that isn't there.
+  describe('capability-conditional /analytics mounting', () => {
+    const ANALYTICS_ROUTES = [
+      'POST /api/v1/analytics/query',
+      'GET /api/v1/analytics/meta',
+      'POST /api/v1/analytics/sql',
+    ];
+
+    function ctxWithServices(fakeServer: any, services: Record<string, any>) {
+      const kernel = {
+        getService: (name: string) => services[name],
+        getServiceAsync: async (name: string) => services[name],
+      };
+      return {
+        getKernel: () => kernel,
+        getService: (name: string) => (name === 'http.server' ? fakeServer : undefined),
+        environmentId: undefined,
+        logger: { info() {}, warn() {}, error() {}, debug() {} },
+        hook: () => {}, on: () => {},
+      } as any;
+    }
+
+    it('does NOT mount /analytics when no analytics service is registered', async () => {
+      const { server, routes } = makeFakeServer();
+      const plugin = createDispatcherPlugin({ prefix: '/api/v1', securityHeaders: false });
+      await plugin.start?.(makeCtx(server));
+
+      for (const r of ANALYTICS_ROUTES) expect(routes).not.toContain(r);
+    });
+
+    it('mounts /analytics when the analytics service is registered', async () => {
+      const { server, routes } = makeFakeServer();
+      const plugin = createDispatcherPlugin({ prefix: '/api/v1', securityHeaders: false });
+      await plugin.start?.(ctxWithServices(server, { analytics: { query: async () => ({ rows: [] }) } }));
+
+      for (const r of ANALYTICS_ROUTES) expect(routes).toContain(r);
+    });
+
+    it('mounts /analytics unconditionally on a multi-tenant host (kernel-resolver wired)', async () => {
+      // Host-global mounts, per-project services: presence is a per-request
+      // question the analytics domain answers (`handled:false` → 404), so the
+      // mount must not depend on the DEFAULT kernel's service registry.
+      const { server, routes } = makeFakeServer();
+      const plugin = createDispatcherPlugin({ prefix: '/api/v1', securityHeaders: false });
+      await plugin.start?.(ctxWithServices(server, {
+        'kernel-resolver': { resolveKernel: async (_ctx: any, def: any) => def },
+      }));
+
+      for (const r of ANALYTICS_ROUTES) expect(routes).toContain(r);
+    });
   });
 
   it('honours a custom prefix', async () => {

--- a/packages/runtime/src/dispatcher-plugin.ts
+++ b/packages/runtime/src/dispatcher-plugin.ts
@@ -666,35 +666,67 @@ export function createDispatcherPlugin(config: DispatcherPluginConfig = {}): Plu
 
 
             // ── Analytics ───────────────────────────────────────────────
+            // [#3891 follow-through / ADR-0076 D11] The /analytics wire
+            // surface exists only when the capability does. Phase-1 init has
+            // completed by the time this start() runs, so in single-kernel
+            // mode "is the `analytics` service registered" is authoritative:
+            // absent ⇒ the routes are NOT mounted and the path answers the
+            // adapter's shared not-found contract — no route-table entry, no
+            // 405 Allow hint for an API that isn't there. A multi-tenant host
+            // (kernel-resolver wired) mounts unconditionally: mounts are
+            // host-global while the analytics service lives in the per-project
+            // kernel, so presence is a per-request question — answered by the
+            // analytics domain's existing `handled:false` → 404.
+            //
             // Route via dispatch() (not handleAnalytics directly) so the host
-            // dispatcher's project-aware kernel swap runs first — the per-project
-            // kernel owns the `analytics` service (registered by ObjectQLPlugin).
-            server.post(`${prefix}/analytics/query`, async (req: any, res: any) => {
+            // dispatcher's project-aware kernel swap runs first — the
+            // per-project kernel owns the `analytics` service.
+            const analyticsInstalled = dispatcher.isMultiTenantHost() || await (async () => {
+                const k: any = kernel;
                 try {
-                    const result = await dispatcher.dispatch('POST', '/analytics/query', req.body, req.query, { request: req });
-                    sendResult(result, res);
-                } catch (err: any) {
-                    errorResponse(err, res);
+                    if (k && typeof k.getServiceAsync === 'function') {
+                        const svc = await k.getServiceAsync('analytics').catch(() => undefined);
+                        if (svc) return true;
+                    }
+                    return !!k?.getService?.('analytics');
+                } catch {
+                    return false;
                 }
-            });
+            })();
 
-            server.get(`${prefix}/analytics/meta`, async (req: any, res: any) => {
-                try {
-                    const result = await dispatcher.dispatch('GET', '/analytics/meta', undefined, req.query, { request: req });
-                    sendResult(result, res);
-                } catch (err: any) {
-                    errorResponse(err, res);
-                }
-            });
+            if (analyticsInstalled) {
+                server.post(`${prefix}/analytics/query`, async (req: any, res: any) => {
+                    try {
+                        const result = await dispatcher.dispatch('POST', '/analytics/query', req.body, req.query, { request: req });
+                        sendResult(result, res);
+                    } catch (err: any) {
+                        errorResponse(err, res);
+                    }
+                });
 
-            server.post(`${prefix}/analytics/sql`, async (req: any, res: any) => {
-                try {
-                    const result = await dispatcher.dispatch('POST', '/analytics/sql', req.body, req.query, { request: req });
-                    sendResult(result, res);
-                } catch (err: any) {
-                    errorResponse(err, res);
-                }
-            });
+                server.get(`${prefix}/analytics/meta`, async (req: any, res: any) => {
+                    try {
+                        const result = await dispatcher.dispatch('GET', '/analytics/meta', undefined, req.query, { request: req });
+                        sendResult(result, res);
+                    } catch (err: any) {
+                        errorResponse(err, res);
+                    }
+                });
+
+                server.post(`${prefix}/analytics/sql`, async (req: any, res: any) => {
+                    try {
+                        const result = await dispatcher.dispatch('POST', '/analytics/sql', req.body, req.query, { request: req });
+                        sendResult(result, res);
+                    } catch (err: any) {
+                        errorResponse(err, res);
+                    }
+                });
+            } else {
+                ctx.logger?.info?.(
+                    '[dispatcher] /analytics not mounted — no `analytics` service is registered. ' +
+                    'Install @objectstack/service-analytics to enable the analytics API.',
+                );
+            }
 
             // ── MCP (Streamable HTTP) + API keys (ADR-0036) ─────────────
             // Mounted explicitly (there is no catch-all) and routed through

--- a/packages/runtime/src/http-dispatcher.ts
+++ b/packages/runtime/src/http-dispatcher.ts
@@ -283,6 +283,19 @@ export class HttpDispatcher {
     };
 
     /**
+     * Whether this dispatcher serves a multi-tenant host (a `kernel-resolver`
+     * is wired, so each request may resolve to a different per-project
+     * kernel). Consulted by the dispatcher plugin's capability-conditional
+     * route mounting (#3891 follow-through): on a multi-tenant host, route
+     * mounts are host-global while optional services live per project kernel,
+     * so "is the capability installed" is a per-request question the domain
+     * handler answers — never a mount-time one.
+     */
+    isMultiTenantHost(): boolean {
+        return !!this.kernelResolver;
+    }
+
+    /**
      * ADR-0076 D11 step ③ — seed the domain registry with the domains lifted
      * out of the `dispatch()` if-chain. Bodies of the four service-backed
      * domains live under `./domains/` (PR-2); `/health` + `/ready` stay

--- a/packages/runtime/src/route-ledger.ts
+++ b/packages/runtime/src/route-ledger.ts
@@ -109,6 +109,10 @@ export const ROUTE_LEDGER: readonly RouteLedgerEntry[] = [
   { route: 'GET /discovery', domain: '/discovery', disposition: 'sdk', client: 'connect' },
 
   // ── analytics ─────────────────────────────────────────────────────────────
+  // Capability-conditional (#3891 follow-through): the plugin mounts these
+  // only when an `analytics` service is registered (or on a multi-tenant
+  // host). The ledger row is the SDK-expressibility claim, not a mount
+  // guarantee — see the header's "A ROW HERE IS NOT A WIRE GUARANTEE".
   { route: 'POST /analytics/query', domain: '/analytics', disposition: 'sdk', client: 'analytics.query' },
   { route: 'GET /analytics/meta', domain: '/analytics', disposition: 'sdk', client: 'analytics.meta',
     note: 'optional ?cube= filter honored server-side; was mismatch — the client called /meta/:cube, a shape no server ever mounted (#3584)' },


### PR DESCRIPTION
#3891 系列的收尾（PR B of 2；PR A 是 #4010）。回答维护者的问题"这个 API 不应该是装了服务才有吗"——现在是了，连 wire 层最后的残留也没了。

## 问题

dispatcher-plugin 无条件挂载 `/analytics` 三条路由。#3989 之后未装 service-analytics 的部署 `POST` 已经 404，但路由表条目还在：`PUT /analytics/query` 返回 **405 + `Allow: POST`**——给一个不存在的 API 宣传方法。

## 修法：挂载以能力在位为条件

Plugin `start()` 运行在内核 Phase-1 init 全部完成之后，服务在位判定是权威的：

| 装配 | 行为 |
|:--|:--|
| 单内核，未装 `analytics` | **三条路由不挂载**——任何方法都是 adapter 共享 404 契约（`{"error":"Not found"}`），无 405 Allow 泄漏；boot 日志指出安装 `@objectstack/service-analytics` |
| 单内核，已装 | 不变 |
| 多租户宿主（`kernel-resolver` 在场） | **无条件挂载**——挂载是宿主全局的，而 analytics 服务住在 per-project kernel 里，能力在位是请求期问题，由 analytics 域既有的 `handled:false` → 404 回答。新公共方法 `HttpDispatcher.isMultiTenantHost()` 暴露该模式 |

时序安全性：`kernel-resolver` 由宿主在 init 阶段注册、dispatcher 构造时解析（`http-dispatcher.ts:228`），先于任何挂载决策。

## 为什么不是"把 handler 搬进 service-analytics"

实施前核实过三件事，放弃了代码所有权整体搬迁：
1. service-analytics 依赖仅 `core`+`spec`；`DomainRoute`/信封助手是 runtime 内部类型——搬迁需要把域契约提升进 spec 或让 service 依赖 runtime（分层倒退）；
2. **身份解析（#2852 的 RLS 线程）住在 dispatcher**——第三面模式（service-i18n 自主挂载）对 analytics 意味着复制安全关键的 ExecutionContext 解析，绝对不做；
3. 用户可见语义（"API 与安装绑定"）用条件挂载即完整交付。transport 留在拥有身份解析的 runtime，符合 D11 "port 归 runtime、能力归插件"的分界。

## 测试

- `dispatcher-plugin.routes.test.ts`：未装不挂 / 装了挂 / 多租户恒挂三条新用例；sanity 路由改用 `/i18n/locales`；
- conformance：bootStack 增加 analytics stub（405 与 parity 契约保持原语义），新增独立 boot 钉住"未装 → 每个方法共享 404、兄弟路由不受影响"；
- route-ledger 注记（ledger 行是 SDK 可表达性声明，非挂载保证——沿用表头既有措辞）；
- 本地全量 `pnpm test`：**132/132 绿**。

## 遗留

- hono `registerStandardEndpoints` 的静态 discovery 整表硬编码路由（非默认路径的 D12 残留）→ 已开 #4018；
- plugin-dev analytics stub 填槽 → #4000（先前已开）。

关联：#3891、#3989、#4010、ADR-0076 D11/D12。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WZBR9XyhXoqKCU6qQVyjx

---
_Generated by [Claude Code](https://claude.ai/code/session_017WZBR9XyhXoqKCU6qQVyjx)_