### PR TITLE
feat(cli): lint the contradictory uniqueness double-declaration (#3991)

### DIFF
--- a/.changeset/lint-unique-double-declaration.md
+++ b/.changeset/lint-unique-double-declaration.md
@@ -1,0 +1,37 @@
+---
+"@objectstack/cli": patch
+---
+
+feat(cli): lint the contradictory uniqueness double-declaration (#3991)
+
+New advisory rule `unique/double-declaration`, reported by `os lint` and
+`os build`. It fires when one column carries BOTH a field-level `unique: true`
+and an object-level single-column unique index:
+
+```ts
+email: Field.email({ unique: true }),           // per-tenant since #3696
+indexes: [{ fields: ['email'], unique: true }], // platform-wide, verbatim
+```
+
+The two spellings deliberately mean different things (see `IndexSchema`), and
+each is legitimate alone. Together on one column they never are:
+
+- On a **tenant-scoped** object they contradict. The stricter one wins
+  physically, so the global index enforces uniqueness and the per-tenant
+  composite becomes a constraint nothing can trip — one of the two authored
+  intents is silently discarded. Worse, it hides the #3696 semantic change:
+  the switch from global to per-tenant has *no observable effect* while the
+  declared index still enforces the old behaviour, so the author never learns
+  their tenancy model and their real constraint disagree — until a second
+  tenant reuses the value and is rejected.
+- On a **tenancy-less** object they are the same index declared twice.
+
+Tenancy is deliberately not inferred at authoring time (`organization_id` is
+injected by the kernel at registration, not authored), so the message names
+both readings and the fix spells out the choice: `unique: 'global'` plus
+dropping the index for platform-wide, or dropping the index for per-tenant
+(or writing it out as `fields: ['organization_id', 'email']`).
+
+A field already declared `unique: 'global'` is exempt — the index restates
+that intent rather than losing it. Advisory only: the artifact is well-defined,
+so this never fails a build.

--- a/content/docs/data-modeling/indexing.mdx
+++ b/content/docs/data-modeling/indexing.mdx
@@ -24,6 +24,51 @@ indexes: [
 ]
 ```
 
+## Two ways to say "unique" — and they mean different things
+
+Uniqueness can be declared in two places, and the choice is not cosmetic:
+
+| Declaration | Materializes as | Scope |
+|:---|:---|:---|
+| Field-level `unique: true` | `(organization_id, field)` | Unique **within** an organization |
+| Field-level `unique: 'global'` | `(field)` | Platform-wide |
+| Declared index `{ fields: ['email'], unique: true }` | `(email)` — exactly the listed columns | Platform-wide |
+
+A field-level `unique: true` is **tenant-scoped**. It has no syntax for a
+composite, so the platform supplies the tenant column for you — which is what
+a multi-tenant application almost always wants: two organizations may each
+have a contact `john@acme.com`.
+
+A **declared index is taken verbatim**. No tenant column is injected, because
+many declared indexes are legitimately platform-wide (a DNS hostname, a
+reserved slug, an external provider id). To scope one per tenant, list the
+column yourself: `{ fields: ['organization_id', 'email'], unique: true }`.
+
+<Callout type="warn">
+**Do not declare both on the same column.** The stricter one wins physically,
+so the platform-wide index enforces uniqueness and the per-tenant constraint
+can never be reached — one of the two intents you wrote is silently discarded:
+
+```typescript
+// ⚠️ contradictory — the global index wins, the per-tenant scope is dead
+email: Field.email({ unique: true }),
+indexes: [{ fields: ['email'], unique: true }],
+```
+
+`os lint` / `os build` report this as `unique/double-declaration`. Pick one:
+set `unique: 'global'` on the field and drop the index for platform-wide
+uniqueness, or drop the index for per-tenant uniqueness (the field-level
+declaration already builds the composite).
+</Callout>
+
+<Callout type="warn">
+**Never put a platform-wide unique index on an `autonumber` field.** The
+autonumber sequence is per tenant — every organization counts from `1` — so a
+global unique index rejects the second organization's `CASE-00001` on insert.
+Use `{ fields: ['organization_id', 'case_number'], unique: true }` so the
+constraint matches the sequence that feeds it.
+</Callout>
+
 ### When to Add Indexes
 
 ✅ **Add indexes for:**

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -19,6 +19,7 @@ import { validateSecurityPosture, validateOrgAxisRedLines, buildAccessMatrix, di
 import { validateReadonlyFlowWrites } from '@objectstack/lint';
 import { lintFlowPatterns } from '../utils/lint-flow-patterns.js';
 import { lintAutonumberFormats } from '../utils/lint-autonumber-formats.js';
+import { lintUniqueDeclarations } from '../lint/data-model-rules.js';
 import { lintLivenessProperties } from '../utils/lint-liveness-properties.js';
 import { lintViewRefs } from '../utils/lint-view-refs.js';
 import { preflightRequiredCapabilities, renderCapabilityMessage } from '../utils/capability-preflight.js';
@@ -495,6 +496,28 @@ export default class Compile extends Command {
         for (const f of autonumberWarnings) {
           printWarning(`${f.where}: ${f.message}`);
           console.log(chalk.dim(`    ${f.hint}`));
+          console.log(chalk.dim(`    rule: ${f.rule}`));
+        }
+      }
+
+      // 3d-quinquies. Contradictory uniqueness declarations (#3991). A column
+      //     carrying BOTH a field-level `unique: true` and a single-column
+      //     declared unique index has two intents, of which exactly one takes
+      //     effect: since #3696 the field-level form is per-tenant while a
+      //     declared index is platform-wide, so the global index wins and the
+      //     tenant composite becomes unreachable. Advisory — the artifact is
+      //     well-defined; the cost is a declaration that does nothing. Shares
+      //     `lintUniqueDeclarations` with `os lint` so both agree.
+      const uniqueLint = lintUniqueDeclarations(
+        Array.isArray((result.data as Record<string, unknown>).objects)
+          ? ((result.data as Record<string, unknown>).objects as any[])
+          : [],
+      );
+      if (uniqueLint.length > 0 && !flags.json) {
+        console.log('');
+        for (const f of uniqueLint) {
+          printWarning(`${f.path}: ${f.message}`);
+          if (f.fix) console.log(chalk.dim(`    ${f.fix}`));
           console.log(chalk.dim(`    rule: ${f.rule}`));
         }
       }

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -24,6 +24,7 @@ import { validateFlowTriggerReadiness } from '@objectstack/lint';
 import { validateReadonlyFlowWrites } from '@objectstack/lint';
 import { lintFlowPatterns } from '../utils/lint-flow-patterns.js';
 import { lintAutonumberFormats } from '../utils/lint-autonumber-formats.js';
+import { lintUniqueDeclarations } from '../lint/data-model-rules.js';
 import { lintLivenessProperties } from '../utils/lint-liveness-properties.js';
 import { lintViewRefs } from '../utils/lint-view-refs.js';
 import { preflightRequiredCapabilities, renderCapabilityMessage } from '../utils/capability-preflight.js';
@@ -592,12 +593,24 @@ export default class Validate extends Command {
       const viewRefErrors = viewRefLint.filter((f) => f.severity === 'error');
       const viewRefWarnings = viewRefLint.filter((f) => f.severity !== 'error');
 
+      // Contradictory uniqueness declarations (#3991) — a column carrying both a
+      // field-level `unique: true` and a single-column declared unique index has
+      // two intents, of which exactly one takes effect. Advisory. Mapped into the
+      // `{ where, hint }` shape the shared renderer below expects; the rule lives
+      // in `lint/data-model-rules.ts` so `os lint` reports the same finding.
+      const uniqueLintWarnings = lintUniqueDeclarations(
+        Array.isArray((result.data as Record<string, unknown>).objects)
+          ? ((result.data as Record<string, unknown>).objects as any[])
+          : [],
+      ).map((f) => ({ where: f.path, message: f.message, hint: f.fix ?? '', rule: f.rule, severity: 'warning' as const }));
+
       const authoringLintErrors = [...flowLintErrors, ...autonumberErrors, ...viewRefErrors];
       const authoringLintWarnings = [
         ...flowLintWarnings,
         ...livenessLint,
         ...autonumberWarnings,
         ...viewRefWarnings,
+        ...uniqueLintWarnings,
       ];
       if (authoringLintErrors.length > 0) {
         if (flags.json) {

--- a/packages/cli/src/lint/data-model-rules.ts
+++ b/packages/cli/src/lint/data-model-rules.ts
@@ -69,6 +69,92 @@ function refOf(def: any): string | undefined {
   return def?.reference || def?.reference_to;
 }
 
+// ─── Uniqueness declarations ────────────────────────────────────────
+
+export const UNIQUE_DOUBLE_DECLARATION = 'unique/double-declaration';
+
+/** Is `unique` declared at all? Mirrors `isUniqueDeclared` in @objectstack/spec/data. */
+function uniqueDeclared(u: unknown): boolean {
+  return u === true || u === 'global';
+}
+
+/**
+ * R10 — the same column carries BOTH a field-level `unique: true` and an
+ * object-level single-column unique index (#3991).
+ *
+ * The two spellings are deliberately different (see `IndexSchema`): field-level
+ * `unique: true` is tenant-scoped since #3696 — it materializes as
+ * `(organization_id, col)`, unique *within* the tenant — while a declared index
+ * is materialized over exactly the columns listed, i.e. platform-wide. Both are
+ * legitimate on their own; together on one column they are never right:
+ *
+ *   - On a tenant-scoped object they CONTRADICT. The stricter one wins
+ *     physically, so the global index enforces uniqueness and the tenant
+ *     composite becomes a constraint nothing can ever trip. One of the two
+ *     intents the author wrote is silently discarded.
+ *   - On a tenancy-less object they are exactly REDUNDANT — both describe the
+ *     same single-column unique index, under the same generated name.
+ *
+ * Tenancy is deliberately NOT inferred here: `organization_id` is injected by
+ * the kernel at registration rather than authored, so an authoring-time guess
+ * would be wrong half the time. The combination is worth flagging either way,
+ * and the message names both readings so the author picks the one they meant.
+ *
+ * A field declared `unique: 'global'` is exempt: it already says
+ * platform-wide, so the declared index restates the same intent rather than
+ * contradicting it (still redundant, but not a silent loss of meaning).
+ *
+ * Advisory. The resulting stack is well-defined — the cost is an intent that
+ * never takes effect, not a broken artifact — so this never fails a build.
+ */
+export function lintUniqueDeclarations(objects: any[]): LintIssue[] {
+  const issues: LintIssue[] = [];
+  if (!Array.isArray(objects) || objects.length === 0) return issues;
+
+  for (let i = 0; i < objects.length; i++) {
+    const obj = objects[i];
+    if (!obj?.name) continue;
+    const declaredIndexes = Array.isArray(obj.indexes) ? obj.indexes : [];
+    if (declaredIndexes.length === 0) continue;
+
+    // Columns covered by a declared SINGLE-column unique index. A composite
+    // (`['organization_id', 'email']`) is the explicit tenant-scoped spelling —
+    // it agrees with the field-level default rather than fighting it.
+    const singleColumnUniqueIndexes = new Map<string, any>();
+    for (const idx of declaredIndexes) {
+      if (!uniqueDeclared(idx?.unique)) continue;
+      const cols = Array.isArray(idx?.fields) ? idx.fields.filter((f: unknown) => typeof f === 'string') : [];
+      if (cols.length !== 1) continue;
+      if (!singleColumnUniqueIndexes.has(cols[0])) singleColumnUniqueIndexes.set(cols[0], idx);
+    }
+    if (singleColumnUniqueIndexes.size === 0) continue;
+
+    for (const { name, def } of fieldEntries(obj.fields)) {
+      if (!uniqueDeclared(def?.unique)) continue;
+      if (def.unique === 'global') continue; // already says platform-wide — no lost intent
+      const idx = singleColumnUniqueIndexes.get(name);
+      if (!idx) continue;
+      const indexLabel = typeof idx?.name === 'string' && idx.name.trim() ? ` '${idx.name.trim()}'` : '';
+      issues.push({
+        severity: 'warning',
+        rule: UNIQUE_DOUBLE_DECLARATION,
+        message:
+          `"${obj.name}.${name}" declares field-level \`unique: true\` AND a single-column unique index${indexLabel} on the same column. ` +
+          `Since #3696 the field-level form is scoped per tenant — \`(tenant, ${name})\` — while a declared index is materialized ` +
+          `over exactly its \`fields\`, i.e. platform-wide. On a tenant-scoped object the global index wins and the per-tenant ` +
+          `constraint can never be reached; on a tenancy-less object the two are the same index declared twice. Either way one of ` +
+          `the two declarations has no effect.`,
+        path: `objects[${i}]`,
+        fix:
+          `Pick the intent: for platform-wide uniqueness set \`unique: 'global'\` on '${name}' and drop the duplicate index; ` +
+          `for per-tenant uniqueness drop the index (the field-level declaration already builds the tenant composite), ` +
+          `or spell the index out as \`fields: ['organization_id', '${name}']\` if you want it explicit.`,
+      });
+    }
+  }
+  return issues;
+}
+
 // ─── Rule engine ────────────────────────────────────────────────────
 
 /**
@@ -77,7 +163,9 @@ function refOf(def: any): string | undefined {
  * metadata-generation scorer.
  */
 export function lintDataModel(objects: any[]): LintIssue[] {
-  const issues: LintIssue[] = [];
+  // R10 lives in its own exported function so `os build` can run that ONE rule
+  // without pulling in the whole best-practice sweep (#3991).
+  const issues: LintIssue[] = lintUniqueDeclarations(objects);
   if (!Array.isArray(objects) || objects.length === 0) return issues;
 
   // Index: parent object name → child relationships pointing at it.

--- a/packages/cli/test/data-model-rules.test.ts
+++ b/packages/cli/test/data-model-rules.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { lintDataModel } from '../src/lint/data-model-rules';
+import { lintDataModel, lintUniqueDeclarations } from '../src/lint/data-model-rules';
 import { lintConfig } from '../src/commands/lint';
 
 const rulesOf = (issues: { rule: string }[]) => issues.map((i) => i.rule);
@@ -171,5 +171,121 @@ describe('lintConfig integration', () => {
     });
     const dataModel = issues.filter((i) => i.rule.startsWith('relationship/') || i.rule.startsWith('rollup/') || i.rule.startsWith('field/') || i.rule.startsWith('object/'));
     expect(dataModel.filter((i) => i.severity !== 'suggestion')).toEqual([]);
+  });
+});
+
+// #3991 — the same column declared unique twice, in two spellings that mean
+// different things. One of the two intents is always discarded.
+describe('lintUniqueDeclarations — contradictory uniqueness (#3991)', () => {
+  const RULE = 'unique/double-declaration';
+
+  const withBoth = [
+    {
+      name: 'crm_contact',
+      fields: { email: { type: 'email', unique: true } },
+      indexes: [{ fields: ['email'], unique: true }],
+    },
+  ];
+
+  it('returns [] for empty input', () => {
+    expect(lintUniqueDeclarations([])).toEqual([]);
+    expect(lintUniqueDeclarations(undefined as any)).toEqual([]);
+  });
+
+  it('flags field-level unique + a single-column unique index on the same column', () => {
+    const issues = lintUniqueDeclarations(withBoth);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe(RULE);
+    expect(issues[0].severity).toBe('warning'); // advisory — never fails a build
+    expect(issues[0].message).toContain('crm_contact.email');
+    // The message must name BOTH readings, since tenancy is not inferred here.
+    expect(issues[0].message).toMatch(/per tenant|tenant/i);
+    expect(issues[0].message).toMatch(/platform-wide/i);
+    // And the fix must spell out both ways to resolve it.
+    expect(issues[0].fix).toContain("unique: 'global'");
+    expect(issues[0].fix).toContain('organization_id');
+  });
+
+  it('surfaces through lintDataModel too, so `os lint` reports it', () => {
+    expect(has(lintDataModel(withBoth), RULE)).toBe(true);
+  });
+
+  // ── Shapes that must stay quiet ──────────────────────────────────────
+
+  it("exempts unique: 'global' — the index restates the intent, it does not lose it", () => {
+    const issues = lintUniqueDeclarations([
+      {
+        name: 'runtime',
+        fields: { hostname: { type: 'text', unique: 'global' } },
+        indexes: [{ fields: ['hostname'], unique: true }],
+      },
+    ]);
+    expect(issues).toEqual([]);
+  });
+
+  it('exempts an explicit tenant COMPOSITE index — that agrees with the field-level default', () => {
+    const issues = lintUniqueDeclarations([
+      {
+        name: 'crm_contact',
+        fields: { email: { type: 'email', unique: true } },
+        indexes: [{ fields: ['organization_id', 'email'], unique: true }],
+      },
+    ]);
+    expect(issues).toEqual([]);
+  });
+
+  it('ignores a NON-unique index on the same column', () => {
+    const issues = lintUniqueDeclarations([
+      {
+        name: 'crm_contact',
+        fields: { email: { type: 'email', unique: true } },
+        indexes: [{ fields: ['email'] }],
+      },
+    ]);
+    expect(issues).toEqual([]);
+  });
+
+  it('ignores a unique index on a DIFFERENT column', () => {
+    const issues = lintUniqueDeclarations([
+      {
+        name: 'crm_contact',
+        fields: { email: { type: 'email', unique: true }, code: { type: 'text' } },
+        indexes: [{ fields: ['code'], unique: true }],
+      },
+    ]);
+    expect(issues).toEqual([]);
+  });
+
+  it('is quiet when only one of the two spellings is used', () => {
+    expect(lintUniqueDeclarations([
+      { name: 'a', fields: { email: { type: 'email', unique: true } } },
+    ])).toEqual([]);
+    expect(lintUniqueDeclarations([
+      { name: 'b', fields: { email: { type: 'email' } }, indexes: [{ fields: ['email'], unique: true }] },
+    ])).toEqual([]);
+  });
+
+  it('names the declared index when it carries an explicit name', () => {
+    const issues = lintUniqueDeclarations([
+      {
+        name: 'crm_product',
+        fields: { sku: { type: 'text', unique: true } },
+        indexes: [{ name: 'uniq_product_sku', fields: ['sku'], unique: true }],
+      },
+    ]);
+    expect(issues[0].message).toContain("'uniq_product_sku'");
+  });
+
+  it('reports each offending column once, across several objects', () => {
+    const issues = lintUniqueDeclarations([
+      ...withBoth,
+      {
+        name: 'crm_lead',
+        fields: { email: { type: 'email', unique: true }, sku: { type: 'text', unique: true } },
+        indexes: [{ fields: ['email'], unique: true }, { fields: ['sku'], unique: true }],
+      },
+    ]);
+    expect(issues.map((i) => i.message.match(/"([^"]+)"/)?.[1]).sort())
+      .toEqual(['crm_contact.email', 'crm_lead.email', 'crm_lead.sku']);
   });
 });


### PR DESCRIPTION
修复 #3991 —— #3955/#3981 的 authoring 侧收尾。那个 PR 止住了「一列两种唯一性声明」在漂移检测里引发的运行时 churn;**产生这个组合的 metadata 本身仍然被无声接受**。

## 问题

两种写法刻意不同(见 `IndexSchema` 的注释):字段级 `unique: true` 自 #3696 起是**租户内**唯一 —— 物化为 `(organization_id, col)`;而声明索引严格按 `fields` 物化,即**跨租户全局**唯一。各自单独用都合法。同一列上同时出现时,**恰好只有一个生效**:

- **租户作用域对象上二者矛盾**。物理上全局索引更严格,它生效,字段级的租户复合约束成为永远触发不到的死约束 —— 作者写下的两个意图,有一个被静默丢弃。

  更隐蔽的是它**掩盖了 #3696 的语义变更**:字段级从全局改成租户作用域这件事,对这类对象**完全没有可观察效果**(全局约束仍由声明索引兜着),于是作者永远不会发现自己的租户模型和实际约束对不上 —— 直到第二个租户复用同一值被拒绝。
- **无租户对象上二者完全重复** —— 同一个单列唯一索引声明了两遍,连生成的名字都一样。

## 规则

新增 advisory 规则 `unique/double-declaration`,落在 `lint/data-model-rules.ts`,因此:

- `os lint` 直接获得;
- **元数据生成评分器**也获得 —— AI 生成的 stack 会被同一把尺子量(该模块本就双用);
- 以独立函数导出,让 `os build` / `os validate` 只跑这一条而非整套 best-practice 扫描 —— 两条路径都接了,这由 #3782 的 build/validate parity 门禁强制(第一版只接了 compile.ts,门禁当场把我拦下)。

**租户身份刻意不做推断**:`organization_id` 是内核在注册时注入的,不是作者写的,authoring 期猜测会有一半猜错。所以提示语同时给出两种读法,修法明确二选一:

> 想要全局唯一 → 字段级改 `unique: 'global'` 并删掉重复索引;想要租户内唯一 → 删掉索引(字段级本就会建租户复合),或显式写成 `fields: ['organization_id', 'email']`。

`unique: 'global'` 的字段**豁免** —— 声明索引是在复述该意图而非丢失它。始终 advisory:产物是良定义的,代价是一个不生效的声明而非坏产物,所以不阻断构建。

## 验证

单测 11 例(`packages/cli/test/data-model-rules.test.ts`),覆盖命中与必须保持沉默的形状:`unique: 'global'` 豁免、显式租户复合索引豁免、非唯一索引、不同列、只写其中一种、命名索引的提示文案、多对象去重。

**真实 stack 端到端**:

- `examples/app-crm` 干净 → `os validate` 无命中(不误报);注入 HotCRM 的同款形状 → 立刻命中。
- **真实 HotCRM** → 精确命中人工审计出的那三处(`crm_contact.email`、`crm_lead.email`、`crm_product.sku`),对只声明索引、无字段级 unique 的三个对象(`crm_account.name`、`crm_case.case_number`、`crm_competitor.name`)保持沉默。HotCRM 侧的修正见 objectstack-ai/hotcrm#550,应用后命中数 3 → 0。

`@objectstack/cli` 全量 847/847 通过(含新增 11 例与 parity 门禁)。

## 一处规则暂未覆盖的邻近缺陷

复核 HotCRM 时发现 `crm_case.case_number` 是 **autonumber 字段挂全局唯一索引**。autonumber 序列按租户计数(每个组织从 1 开始),所以第二个组织的 `CASE-00001` 会被全局索引拒绝 —— 正是 #3696 要消除的碰撞。本规则抓不到它(它没有字段级 `unique`,不构成"双声明")。已在 hotcrm#550 里直接修掉;是否把「autonumber 上的全局唯一索引」也纳入本 lint,值得单独讨论 —— 我倾向于值得,但那是另一条规则,不在本 PR 扩大范围。

Closes #3991

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FcphmGzBuWwF8SaYPSCtCw

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcphmGzBuWwF8SaYPSCtCw)_