### PR TITLE
docs(agents): list which spec artifact each CI gate guards, and how to regenerate it

### DIFF
--- a/.changeset/agents-spec-generated-artifacts-map.md
+++ b/.changeset/agents-spec-generated-artifacts-map.md
@@ -1,0 +1,13 @@
+---
+---
+
+Docs only — no package changes, nothing to release.
+
+AGENTS.md now maps each `packages/spec` change to the generated artifact it
+invalidates and the CI gate that catches it. The eight gates live in two jobs that
+run them sequentially, so the first stale artifact masks the rest — #4040 got one
+red build per artifact (a `.describe()` string via `check:docs`, then five new
+exports via `check:api-surface`) with no logic error involved either time.
+
+Also records the `check:api-surface` trap: it reads the built `dist/*.d.ts`, so a
+stale `dist` reports exports as REMOVED when nothing was removed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,49 @@ Root also exports: `defineStack`, `composeStacks`, `defineView`, `defineApp`, `d
 | `content/docs/getting-started/` | hand-written | ✅ |
 | `content/docs/protocol/` | hand-written | ✅ |
 
+### Touched `packages/spec`? Regenerate its artifacts BEFORE pushing
+
+`packages/spec` has **eight** checked-in generated artifacts, each with its own CI gate.
+They live in two different jobs (`TypeScript Type Check` in `lint.yml`, `Check Generated
+Artifacts` in `ci.yml`), and each job runs its gates **sequentially** — so the first
+stale artifact masks every one behind it, and you get one red build per artifact instead
+of one for all of them. Match the change to the gate and regenerate up front:
+
+| You changed | Gate that fails | Regenerate with `pnpm --filter @objectstack/spec …` |
+|:---|:---|:---|
+| A `.describe()` / TSDoc on any schema | `check:docs` | `gen:schema && gen:docs` |
+| A public export (added / removed / renamed) | `check:api-surface` | `gen:api-surface` |
+| An authorable key on a metadata schema | `check:authorable-surface` | `gen:schema` |
+| An ADR-0087 conversion / migration registry | `check:spec-changes`, `check:upgrade-guide` | `gen:spec-changes`, `gen:upgrade-guide` |
+| A `SKILL.md` (frontmatter or body) | `check:skill-docs`, `check:skill-refs` | `gen:skill-docs`, `gen:skill-refs` |
+| The react-blocks contract | `check:react-blocks` | `gen:react-blocks` |
+
+A `.describe()` string counts — it is not "just a comment", it lands in
+`content/docs/references/`. Adding one export counts — it lands in `api-surface.json`.
+Both were learned the hard way in #4040: two separate red builds, neither a logic error.
+
+Cheapest way to be sure, since a gate is just its generator in `--check` mode — run the
+whole set and let it tell you which artifact is stale:
+
+```bash
+cd packages/spec
+pnpm build            # REQUIRED first — see the dist caveat below
+for c in check:docs check:api-surface check:authorable-surface check:spec-changes \
+         check:upgrade-guide check:skill-refs check:skill-docs check:react-blocks; do
+  printf '%-28s ' "$c"; pnpm -s $c >/dev/null 2>&1 && echo PASS || echo FAIL
+done
+```
+
+⚠️ **`check:api-surface` reads the built `dist/*.d.ts`, not `src/`.** A stale `dist`
+makes it report exports as **removed** — "N breaking (removed/narrowed)" — when nothing
+was removed at all: the snapshot is simply newer than your build. Rebuild before you
+believe it, and before you file a bug about `main` being red. (Two phantom "breaking
+removals" this way while writing this section.)
+
+`check:liveness`, `check:empty-state`, `check:skill-examples` and
+`check:react-conformance` are pure checks with no generator — a failure there is a real
+finding to fix, not an artifact to regenerate.
+
 ---
 
 ## Context Routing — apply the right role per path


### PR DESCRIPTION
Follow-up to #4040 — the DX gap that PR hit twice. Docs only, no code.

## Why

`packages/spec` has **eight** checked-in generated artifacts, each with its own CI gate, split across two jobs (`TypeScript Type Check` in `lint.yml`, `Check Generated Artifacts` in `ci.yml`). Each job runs its gates **sequentially**, so the first stale artifact masks every one behind it — you get one red build *per artifact*, not one for all of them.

AGENTS.md documents the auto-gen boundary ("never hand-edit `content/docs/references/`") but never maps *a change* to *the generator it invalidates*. So the mapping gets rediscovered from red CI.

#4040 paid it twice, neither time a logic error:

1. Correcting a `.describe()` string → stale `content/docs/references/automation/node-executor.mdx` → `check:docs` red.
2. Fixed that, pushed → **now** `check:api-surface` red, because five new exports weren't in `api-surface.json`. Invisible until the first was fixed.

A `.describe()` reads like a comment and lands in published docs; adding one export lands in a snapshot. Neither is obvious from the diff.

## What this adds

A change → gate → regenerate table:

| You changed | Gate that fails | Regenerate with |
|:---|:---|:---|
| A `.describe()` / TSDoc on any schema | `check:docs` | `gen:schema && gen:docs` |
| A public export (added / removed / renamed) | `check:api-surface` | `gen:api-surface` |
| An authorable key on a metadata schema | `check:authorable-surface` | `gen:schema` |
| An ADR-0087 conversion / migration registry | `check:spec-changes`, `check:upgrade-guide` | `gen:spec-changes`, `gen:upgrade-guide` |
| A `SKILL.md` | `check:skill-docs`, `check:skill-refs` | `gen:skill-docs`, `gen:skill-refs` |
| The react-blocks contract | `check:react-blocks` | `gen:react-blocks` |

Plus a copy-pasteable loop that runs all eight, so the tooling says which artifact is stale instead of CI saying it one push at a time.

It also records that `check:liveness`, `check:empty-state`, `check:skill-examples` and `check:react-conformance` have **no** generator — a failure there is a real finding to fix, not an artifact to regenerate. Worth stating, because the reflex after reading the table would be to look for a `gen:` counterpart that doesn't exist.

## A trap found while verifying this section

Running the loop on a **clean checkout of merged `main`** reported:

```
@objectstack/spec public API changed: 2 breaking (removed/narrowed), 0 added.
  ./data   - canonicalAstOperator (function)
  ./api    - FieldErrorCode (type)
```

Nothing had been removed. `check:api-surface` reads the built `dist/*.d.ts`, not `src/` — and my `dist` predated the merge, so the newer checked-in snapshot looked like it had lost exports. `pnpm build` and it passes.

That is exactly the shape of a bug someone would otherwise file against `main`, so the caveat is now in the section, the loop starts with `pnpm build`, and the phantom pair is named so the next person recognises it.

## Test plan

Every command in the new section was run as written, from a clean checkout of merged `main` (`e4c61a7`) after `pnpm build`:

```
check:docs                   PASS
check:api-surface            PASS
check:authorable-surface     PASS
check:spec-changes           PASS
check:upgrade-guide          PASS
check:skill-refs             PASS
check:skill-docs             PASS
check:react-blocks           PASS
```

Single file, +43/−0, no code touched.

## Note on the branch

The designated branch's previous PR (#4040) is merged and GitHub auto-deleted the branch, so this is a fresh branch of the same name off merged `main` (`e4c61a7`) with one new commit — not stacked on merged history, and no force-push involved.

## Not done here

An aggregate `gen:all` / `check:generated` script would beat a documented loop, but it adds a script name and a maintenance surface to a repo with strong conventions — worth your call rather than my guess. Say the word and I'll add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoA8AV99Ss1RRkLLAYmDzq

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoA8AV99Ss1RRkLLAYmDzq)_