### PR TITLE
feat(spec)!: retire BatchOptions.validateOnly — a dry-run flag never implemented (#4052)

### DIFF
--- a/.changeset/retire-batch-validate-only.md
+++ b/.changeset/retire-batch-validate-only.md
@@ -1,0 +1,38 @@
+---
+"@objectstack/spec": major
+---
+
+feat(spec)!: retire `BatchOptions.validateOnly` — a dry-run flag that was never implemented (#4052)
+
+`BatchOptions.validateOnly` promised a dry-run — "validate records without
+persisting changes" — but no batch surface ever read it. `updateManyData`,
+`deleteManyData` and `batchData` all persist regardless, so a caller sending
+`options.validateOnly: true` to PREVIEW a mutation got it executed. That is the
+dangerous direction of "declared ≠ enforced": a flag lying about a data-safety
+guarantee, not merely an inert no-op.
+
+There is no dry-run today. Rather than back-fill an implementation to match a
+promise nothing kept — a real no-commit batch has its own design space (cascade
+and constraint semantics under rollback, a response contract that reports each
+row's would-succeed verdict) — the key is retired so it can be reintroduced
+deliberately when there is a real need.
+
+**Breaking change.**
+
+- `BatchOptions.validateOnly` is a retired key. It is tombstoned (`retiredKey`)
+  in `BatchOptionsSchema`, so authoring it now fails with a fix-it prescription
+  rather than being silently stripped (the ADR-0104 / #3733 quiet-failure class).
+  The `BatchOptions` type's `validateOnly` becomes `never`.
+- The retirement is HTTP-only (the key never appeared in stored stack metadata),
+  so it is recorded as a semantic migration on the protocol-18 chain step
+  (`batch-options-validate-only-retired`) — a TODO for API callers, not a stack
+  conversion.
+
+**Migration.** Stop sending `options.validateOnly` on `/batch`, `/updateMany`
+and `/deleteMany`. It never previewed anything; removing it changes no behaviour.
+If you need to validate a batch without writing, follow #4052 so a real
+no-commit preview can be designed.
+
+Also fixes a dangling documentation reference: the `/createMany` route
+registration named `requestSchema: 'CreateManyRequestSchema'`, a schema no
+module ever exported — pointed at the real `CreateManyDataRequestSchema`.

--- a/content/docs/api/client-sdk.mdx
+++ b/content/docs/api/client-sdk.mdx
@@ -225,7 +225,6 @@ const batchResult = await client.data.batch('account', {
     atomic: true,
     returnRecords: true,
     continueOnError: false,
-    validateOnly: false,
   },
 });
 
@@ -499,7 +498,6 @@ The `find` method accepts an options object with **canonical** (recommended) fie
 | `atomic` | `boolean` | `true` | Rollback entire batch on any failure |
 | `returnRecords` | `boolean` | `false` | Include full records in response |
 | `continueOnError` | `boolean` | `false` | Continue after errors (when atomic=false) |
-| `validateOnly` | `boolean` | `false` | Dry-run mode — validate without persisting |
 
 ---
 

--- a/content/docs/api/data-api.mdx
+++ b/content/docs/api/data-api.mdx
@@ -92,8 +92,7 @@ Execute a batch operation (create / update / upsert / delete) on multiple record
   "options": {
     "atomic": true,
     "returnRecords": true,
-    "continueOnError": false,
-    "validateOnly": false
+    "continueOnError": false
   }
 }
 ```

--- a/content/docs/api/wire-format.mdx
+++ b/content/docs/api/wire-format.mdx
@@ -484,8 +484,7 @@ Process many records of a **single** operation type in one request. The body car
   ],
   "options": {
     "atomic": true,
-    "continueOnError": false,
-    "validateOnly": false
+    "continueOnError": false
   }
 }
 ```

--- a/content/docs/references/api/batch.mdx
+++ b/content/docs/references/api/batch.mdx
@@ -47,7 +47,7 @@ const result = BatchConfig.parse(data);
 | :--- | :--- | :--- | :--- |
 | **enabled** | `boolean` | ✅ | Enable batch operations |
 | **maxRecordsPerBatch** | `integer` | ✅ | Maximum records per batch |
-| **defaultOptions** | `{ atomic: boolean; returnRecords: boolean; continueOnError: boolean; validateOnly: boolean }` | optional | Default batch options |
+| **defaultOptions** | `{ atomic: boolean; returnRecords: boolean; continueOnError: boolean; validateOnly?: any }` | optional | Default batch options |
 
 
 ---
@@ -89,7 +89,7 @@ const result = BatchConfig.parse(data);
 | **atomic** | `boolean` | ✅ | If true, rollback entire batch on any failure (transaction mode) |
 | **returnRecords** | `boolean` | ✅ | If true, return full record data in response |
 | **continueOnError** | `boolean` | ✅ | If true (and atomic=false), continue processing remaining records after errors |
-| **validateOnly** | `boolean` | ✅ | If true, validate records without persisting changes (dry-run mode) |
+| **validateOnly** | `any` | optional | [REMOVED] `options.validateOnly` was removed from BatchOptions in @objectstack/spec (#4052). It was never implemented: the batch surfaces persisted regardless, so a "dry-run" would have silently executed. There is no dry-run today — drop the key. If you need to preview a batch without writing, open an issue so it can be designed (no-commit cascade / constraint semantics) and reintroduced as a flag that actually holds. |
 
 
 ---
@@ -115,7 +115,7 @@ const result = BatchConfig.parse(data);
 | :--- | :--- | :--- | :--- |
 | **operation** | `Enum<'create' \| 'update' \| 'upsert' \| 'delete'>` | ✅ | Type of batch operation |
 | **records** | `{ id?: string; data?: Record<string, any>; externalId?: string }[]` | ✅ | Array of records to process (server caps the count — see batch.maxBatchSize) |
-| **options** | `{ atomic: boolean; returnRecords: boolean; continueOnError: boolean; validateOnly: boolean }` | optional | Batch operation options |
+| **options** | `{ atomic: boolean; returnRecords: boolean; continueOnError: boolean; validateOnly?: any }` | optional | Batch operation options |
 
 
 ---
@@ -199,7 +199,7 @@ A cross-object batch strip event: dropped fields plus the operation index
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **ids** | `string[]` | ✅ | Array of record IDs to delete (server caps the count — see batch.maxBatchSize) |
-| **options** | `{ atomic: boolean; returnRecords: boolean; continueOnError: boolean; validateOnly: boolean }` | optional | Delete options |
+| **options** | `{ atomic: boolean; returnRecords: boolean; continueOnError: boolean; validateOnly?: any }` | optional | Delete options |
 
 
 ---
@@ -223,7 +223,7 @@ A cross-object batch strip event: dropped fields plus the operation index
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **records** | `{ id: string; data: Record<string, any> }[]` | ✅ | Array of records to update (server caps the count — see batch.maxBatchSize) |
-| **options** | `{ atomic: boolean; returnRecords: boolean; continueOnError: boolean; validateOnly: boolean }` | optional | Update options |
+| **options** | `{ atomic: boolean; returnRecords: boolean; continueOnError: boolean; validateOnly?: any }` | optional | Update options |
 
 
 ---

--- a/content/docs/references/api/protocol.mdx
+++ b/content/docs/references/api/protocol.mdx
@@ -448,7 +448,7 @@ const result = AiAgentCapabilities.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **ids** | `string[]` | ✅ | Array of record IDs to delete (server caps the count — see batch.maxBatchSize) |
-| **options** | `{ atomic: boolean; returnRecords: boolean; continueOnError: boolean; validateOnly: boolean }` | optional | Delete options |
+| **options** | `{ atomic: boolean; returnRecords: boolean; continueOnError: boolean; validateOnly?: any }` | optional | Delete options |
 | **object** | `string` | ✅ | Object name |
 
 
@@ -1404,7 +1404,7 @@ const result = AiAgentCapabilities.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **records** | `{ id: string; data: Record<string, any> }[]` | ✅ | Array of records to update (server caps the count — see batch.maxBatchSize) |
-| **options** | `{ atomic: boolean; returnRecords: boolean; continueOnError: boolean; validateOnly: boolean }` | optional | Update options |
+| **options** | `{ atomic: boolean; returnRecords: boolean; continueOnError: boolean; validateOnly?: any }` | optional | Update options |
 | **object** | `string` | ✅ | Object name |
 
 

--- a/packages/spec/authorable-surface.json
+++ b/packages/spec/authorable-surface.json
@@ -682,7 +682,7 @@
     "api/BatchOptions:atomic",
     "api/BatchOptions:continueOnError",
     "api/BatchOptions:returnRecords",
-    "api/BatchOptions:validateOnly",
+    "api/BatchOptions:validateOnly [RETIRED]",
     "api/BatchRecord:data",
     "api/BatchRecord:externalId",
     "api/BatchRecord:id",

--- a/packages/spec/src/api/batch.test.ts
+++ b/packages/spec/src/api/batch.test.ts
@@ -57,7 +57,6 @@ describe('BatchOptionsSchema', () => {
     expect(options.atomic).toBe(true);
     expect(options.returnRecords).toBe(false);
     expect(options.continueOnError).toBe(false);
-    expect(options.validateOnly).toBe(false);
   });
 
   it('should accept custom options', () => {
@@ -65,13 +64,21 @@ describe('BatchOptionsSchema', () => {
       atomic: false,
       returnRecords: true,
       continueOnError: true,
-      validateOnly: true,
     });
 
     expect(options.atomic).toBe(false);
     expect(options.returnRecords).toBe(true);
     expect(options.continueOnError).toBe(true);
-    expect(options.validateOnly).toBe(true);
+  });
+
+  it('rejects the retired `validateOnly` key with its prescription (#3963 follow-up)', () => {
+    // Never implemented — a "dry-run" that silently persisted. Tombstoned so
+    // writing it is audible rather than silently stripped (ADR-0104 / PD #10).
+    const result = BatchOptionsSchema.safeParse({ validateOnly: true });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toMatch(/validateOnly.*removed|never implemented/i);
+    }
   });
 });
 

--- a/packages/spec/src/api/batch.zod.ts
+++ b/packages/spec/src/api/batch.zod.ts
@@ -3,6 +3,7 @@
 import { z } from 'zod';
 import { ApiErrorSchema, BaseResponseSchema, RecordDataSchema } from './contract.zod';
 import { DroppedFieldsEventSchema } from '../data/data-engine.zod';
+import { retiredKey } from '../shared/retired-key';
 
 /**
  * Batch Operations API
@@ -61,7 +62,22 @@ export const BatchOptionsSchema = lazySchema(() => z.object({
   atomic: z.boolean().optional().default(true).describe('If true, rollback entire batch on any failure (transaction mode)'),
   returnRecords: z.boolean().optional().default(false).describe('If true, return full record data in response'),
   continueOnError: z.boolean().optional().default(false).describe('If true (and atomic=false), continue processing remaining records after errors'),
-  validateOnly: z.boolean().optional().default(false).describe('If true, validate records without persisting changes (dry-run mode)'),
+  // `validateOnly` promised a dry-run — "validate records without persisting" —
+  // but no batch surface ever read it (`updateManyData` / `deleteManyData` /
+  // `batchData` all persist regardless). A caller sending `validateOnly: true`
+  // to preview a mutation got it EXECUTED: a declared flag actively lying about
+  // a data-safety guarantee, the worst shape of "declared ≠ enforced" (PD #10).
+  // Retired rather than half-implemented: a real dry-run has its own design
+  // space (cascade / constraint semantics under no-commit, response contract)
+  // and should be reintroduced deliberately, not back-filled to match a promise
+  // nothing kept. Tombstoned so writing it is audible, not silently stripped.
+  validateOnly: retiredKey(
+    '`options.validateOnly` was removed from BatchOptions in @objectstack/spec (#4052). '
+    + 'It was never implemented: the batch surfaces persisted regardless, so a "dry-run" would have '
+    + 'silently executed. There is no dry-run today — drop the key. If you need to preview a batch '
+    + 'without writing, open an issue so it can be designed (no-commit cascade / constraint semantics) '
+    + 'and reintroduced as a flag that actually holds.',
+  ),
 }));
 
 export type BatchOptions = z.infer<typeof BatchOptionsSchema>;

--- a/packages/spec/src/api/plugin-rest-api.zod.ts
+++ b/packages/spec/src/api/plugin-rest-api.zod.ts
@@ -915,7 +915,10 @@ export const DEFAULT_BATCH_ROUTES: RestApiRouteRegistration = {
       summary: 'Batch create',
       description: 'Create multiple records in a single operation',
       tags: ['Batch'],
-      requestSchema: 'CreateManyRequestSchema',
+      // Was 'CreateManyRequestSchema' — a name no schema ever exported (the real
+      // request contract is CreateManyDataRequestSchema in protocol.zod.ts). A
+      // dangling documentation reference; point it at the schema that exists.
+      requestSchema: 'CreateManyDataRequestSchema',
       responseSchema: 'BatchUpdateResponseSchema',
       permissions: ['data.create', 'data.batch'],
       timeout: 60000,

--- a/packages/spec/src/migrations/registry.ts
+++ b/packages/spec/src/migrations/registry.ts
@@ -467,9 +467,30 @@ const step18: MigrationStep = {
     + "(read as SYSTEM), and `book.audience: 'public'` (ADR-0046 §6.7). The key is dropped "
     + 'with a notice rather than mapped — there is no replacement value, only a different '
     + 'way to publish (by declaration). A stack that mounts no auth at all now fails at boot '
-    + 'when it would serve a data API, instead of receiving an implicit fail-open.',
+    + 'when it would serve a data API, instead of receiving an implicit fail-open.\n\n'
+    + 'The same major retires `BatchOptions.validateOnly` (#4052): a batch "dry-run" flag that '
+    + 'was declared but never implemented — every batch surface (`updateManyData` / '
+    + '`deleteManyData` / `batchData`) persisted regardless, so a caller sending it to PREVIEW a '
+    + 'mutation got it executed. That is the dangerous direction of declared ≠ enforced: a flag '
+    + 'lying about a data-safety guarantee. No dry-run exists today; the schema tombstones the '
+    + 'key with the prescription. It is HTTP-only (never stored in stack metadata), so the '
+    + 'change is one semantic TODO for API callers rather than a stack conversion.',
   conversionIds: ['stack-api-require-auth-removed'],
-  semantic: [],
+  semantic: [
+    {
+      id: 'batch-options-validate-only-retired',
+      surface: 'api.batchOptions.validateOnly',
+      replacement: '(removed — no dry-run today; open an issue to design a no-commit batch preview)',
+      reason:
+        'The `validateOnly` key promised a dry-run ("validate records without persisting") but no '
+        + 'batch surface ever read it — updateManyData / deleteManyData / batchData persist '
+        + 'regardless. There is no behaviour to preserve and nothing stored to rewrite (it only '
+        + 'ever appeared in an HTTP request body). Callers must stop sending it.',
+      acceptanceCriteria:
+        'No /batch, /updateMany or /deleteMany call sends `options.validateOnly`; a request that '
+        + 'includes it answers 400 VALIDATION_FAILED with the retirement prescription.',
+    },
+  ],
 };
 
 export const MIGRATIONS_BY_MAJOR: Readonly<Record<number, MigrationStep>> = {


### PR DESCRIPTION
Closes #4052。承 #3963 一线的"声明 ≠ 强制"(PD #10)清扫,收两处批量 API 的悬空契约。

## 主项:退役 `BatchOptions.validateOnly`

`validateOnly` 声明了 dry-run —— "validate records without persisting changes" —— 但**运行时没有任何一处读它**。`updateManyData` / `deleteManyData` / `batchData` 全部无条件落库。一个调用者发 `options.validateOnly: true` 想**预演**一次改动,实际会被**执行**。

对比同组三个兄弟(都真实生效),唯独它悬空:

| 选项 | 运行时消费点 |
|------|------|
| `atomic` | `protocol.ts:3482` + `rest-server.ts:6607` |
| `returnRecords` | `protocol.ts:3501` |
| `continueOnError` | `protocol.ts:3486,3610` |
| **`validateOnly`** | **无** |

这是 PD #10 里危害最高的一类:不是能力缺失,而是**契约主动误导数据安全**。选择**退役**而非仓促实现 —— 真正的 no-commit 批量有独立设计空间(rollback 下的 cascade/约束语义、逐行 would-succeed 的响应契约),应在有真实需求时单独立项做对。

## 破坏性变更

- `BatchOptionsSchema` 里 `validateOnly` → `retiredKey()` 墓碑:写它 → 解析报错并给出处方,而非静默剥除(ADR-0104 / #3733)。`BatchOptions` 类型该键变为 `never`。
- 纯 HTTP 请求体、从不进入 stack metadata,故登记为 protocol-18 迁移链 step18 的**一条 semantic 记录**(`batch-options-validate-only-retired`)—— 与 `analytics-query-request-format-retired` 同型:声明但从未实现、无存储可改写,是给 API 调用者的 semantic TODO 而非 stack conversion。
- 重跑生成物:`authorable-surface.json`([RETIRED] 标记)、`content/docs/references/api/{batch,protocol}.mdx`;major changeset(仅 `@objectstack/spec`,随同一未发布的 major 18)。

## 顺带:#2 悬空文档引用

`plugin-rest-api.zod.ts:918` 的 `/createMany` 路由声明 `requestSchema: 'CreateManyRequestSchema'` —— **从未有 schema 导出此名**(真实契约是 `protocol.zod.ts` 的 `CreateManyDataRequestSchema`)。该字符串运行时和 OpenAPI 生成都不消费,是文档字符串失真。改指向真实存在的 `CreateManyDataRequestSchema`。

## 迁移

停止在 `/batch`、`/updateMany`、`/deleteMany` 上发送 `options.validateOnly`。它从不预演任何东西,删掉不改变任何行为。若确需"校验不落库",跟进 #4052 单独设计一个真正的 no-commit 预览。

## 测试

- `packages/spec` 全绿:266 文件 / 6937 测试通过(含 `batch.test.ts` 新增的"退役键被拒并给出处方"断言、`migrations` 链重放、`conversions`)。
- 生成物守门全绿:`check:authorable-surface` / `check:api-surface`(surface 无变化)/ `check:spec-changes`(major 18 未发布,不投影,与 #4043 一致)/ `check:upgrade-guide` / `check:docs` / `check:skill-docs` / `check:skill-refs`。
- 无下游消费者:全仓 `validateOnly` 仅出现在 `batch.zod.ts` 与 `batch.test.ts`,类型变 `never` 不影响任何构造点。

## 审阅指引

- 契约核心:`packages/spec/src/api/batch.zod.ts`(retiredKey 墓碑)。
- 退役登记:`packages/spec/src/migrations/registry.ts` 的 `step18.semantic[]`。
- #2:`packages/spec/src/api/plugin-rest-api.zod.ts:918`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzLE9cw4gZKNyPN2ZP4iTt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzLE9cw4gZKNyPN2ZP4iTt)_