### PR TITLE
fix(rest): give the bare 501 exits a machine code — NOT_IMPLEMENTED (#4067)

### DIFF
--- a/.changeset/cross-object-batch-501-code.md
+++ b/.changeset/cross-object-batch-501-code.md
@@ -1,0 +1,22 @@
+---
+"@objectstack/rest": patch
+---
+
+fix(rest): give the bare 501 error exits a machine `code` (#4067)
+
+Most REST error exits already carry a typed `code` (`VALIDATION_FAILED`,
+`BATCH_NOT_ATOMIC`, `BATCH_TOO_LARGE`, `PERMISSION_DENIED`), and the clone /
+search 501s already answer `{ error, code: 'NOT_IMPLEMENTED' }`. Four 501 exits
+still returned a bare `{ error: '<string>' }` with no code, so a client could
+only key on the prose:
+
+- the cross-object transactional batch route (`POST {basePath}/batch`) when the
+  runtime has no `transaction()` — the last untyped exit on that route, whose
+  siblings (`BATCH_NOT_ATOMIC`, `VALIDATION_FAILED`, the `enforceBatchSize`
+  `BATCH_TOO_LARGE`) were already typed by the #3897 / #3933 / #3939 line;
+- the two `saveMetaItem`-unsupported exits;
+- the UI-view-resolution-unsupported exit.
+
+Each now carries `code: 'NOT_IMPLEMENTED'`, matching the clone / search 501s.
+Additive only — the `error` message is unchanged and no status changes — so
+existing clients are unaffected; new ones can branch on the code.

--- a/packages/rest/src/rest-batch-endpoint.test.ts
+++ b/packages/rest/src/rest-batch-endpoint.test.ts
@@ -109,10 +109,12 @@ describe('POST {basePath}/batch — cross-object transactional batch', () => {
     expect(route!.metadata?.tags).toEqual(expect.arrayContaining(['data', 'batch']));
   });
 
-  it('returns 501 when the runtime has no transactional ObjectQL', async () => {
+  it('returns 501 with a NOT_IMPLEMENTED code when the runtime has no transactional ObjectQL', async () => {
     const { route } = buildServer({}); // no ql provider
     const res = await post(route, { operations: [{ object: 'account', data: {} }] });
     expect(res.statusCode).toBe(501);
+    // Typed like every other 501 (#4067) so clients key on the code, not the prose.
+    expect(res.body.code).toBe('NOT_IMPLEMENTED');
   });
 
   // ── happy path ───────────────────────────────────────────────────────────

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -3334,7 +3334,7 @@ export class RestServer {
                     const environmentId = isScoped ? req.params?.environmentId : undefined;
                     const p = await this.resolveProtocol(environmentId, req);
                     if (!p.saveMetaItem) {
-                        res.status(501).json({ error: 'Save operation not supported by protocol implementation' });
+                        res.status(501).json({ error: 'Save operation not supported by protocol implementation', code: 'NOT_IMPLEMENTED' });
                         return;
                     }
 
@@ -3717,7 +3717,7 @@ export class RestServer {
                     const environmentId = isScoped ? req.params?.environmentId : undefined;
                     const p = await this.resolveProtocol(environmentId, req);
                     if (!p.saveMetaItem) {
-                        res.status(501).json({ error: 'Save operation not supported by protocol implementation' });
+                        res.status(501).json({ error: 'Save operation not supported by protocol implementation', code: 'NOT_IMPLEMENTED' });
                         return;
                     }
 
@@ -3780,7 +3780,7 @@ export class RestServer {
                         } as any);
                         res.json(view);
                     } else {
-                        res.status(501).json({ error: 'UI View resolution not supported by protocol implementation' });
+                        res.status(501).json({ error: 'UI View resolution not supported by protocol implementation', code: 'NOT_IMPLEMENTED' });
                     }
                 } catch (error: any) {
                     logError("[REST] Unhandled error:", error);
@@ -6877,7 +6877,9 @@ export class RestServer {
                     if (this.enforceAuth(req, res, context)) return;
                     const ql = this.objectQLProvider ? await this.objectQLProvider(environmentId) : undefined;
                     if (!ql || typeof ql.transaction !== 'function') {
-                        res.status(501).json({ error: 'Transactional batch not supported by this runtime' });
+                        // Typed like every other 501 on this server (clone/search,
+                        // #4067) so a client can key on the code, not the prose.
+                        res.status(501).json({ error: 'Transactional batch not supported by this runtime', code: 'NOT_IMPLEMENTED' });
                         return;
                     }
 


### PR DESCRIPTION
Closes #4067。批量 API 契约一致性清扫线(承 #3897 / #3933 / #3939)的收官项 —— 补齐 REST 层最后几处裸串 501。

## 背景

REST 层的错误出口绝大多数已带类型化 `code`(`VALIDATION_FAILED` / `BATCH_NOT_ATOMIC` / `BATCH_TOO_LARGE` / `PERMISSION_DENIED`),clone 与 search 的 501 也已是 `{ error, code: 'NOT_IMPLEMENTED' }`。但**四处 501 出口仍返回裸 `{ error: '<string>' }`**,客户端只能按文案区分:

| 位置 | 出口 |
|------|------|
| `rest-server.ts` 跨对象批量 `POST {basePath}/batch` | 运行时无 `transaction()` —— **该路由最后一处未类型化的出口**;其余(`BATCH_NOT_ATOMIC`、`VALIDATION_FAILED`、`enforceBatchSize` 的 `BATCH_TOO_LARGE`)都已在 #3897 / #3933 / #3939 里类型化 |
| `saveMetaItem` ×2 | `'Save operation not supported by protocol implementation'` |
| UI View 解析 | `'UI View resolution not supported by protocol implementation'` |

跨对象批量那处即本轮待办的 **#3**;另三处是同形的 501 NOT_IMPLEMENTED 裸串,顺手一起收(与 #2 折进 validateOnly PR 同理),使"每个 501 都带它兄弟早已有的机器码"这一致性真正闭合。

## 改动

四处 501 一律补 `code: 'NOT_IMPLEMENTED'`,对齐 clone/search 的扁平信封 `{ error: '<message>', code }`。**纯新增字段** —— `error` 文案与 status 均不变,现有客户端不受影响,新客户端可按 code 分支。

扩展跨对象批量路由的 501 测试:从只断言 `status(501)` 增加断言 `res.body.code === 'NOT_IMPLEMENTED'`。

## 测试

- `@objectstack/rest` 全绿:35 文件 / 505 测试(含扩展后的批量 501 断言)。
- 现有其余 501 测试只断言 status,新增 `code` 不影响。
- changeset:`@objectstack/rest` **patch**(additive)。

## 审阅指引

改动集中在 `packages/rest/src/rest-server.ts` 的四处 `res.status(501).json(...)`,以及 `rest-batch-endpoint.test.ts` 的一条断言。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzLE9cw4gZKNyPN2ZP4iTt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzLE9cw4gZKNyPN2ZP4iTt)_