### PR TITLE
fix(formula,spec,core): the RLS write-side `check` evaluator honours calendar-day upper bounds (ADR-0053 D-D)

### DIFF
--- a/.changeset/calendar-day-primitive-to-spec.md
+++ b/.changeset/calendar-day-primitive-to-spec.md
@@ -1,0 +1,32 @@
+---
+"@objectstack/spec": minor
+"@objectstack/formula": patch
+"@objectstack/core": patch
+---
+
+fix(formula,spec,core): the RLS write-side `check` evaluator honours calendar-day upper bounds (ADR-0053 D-D)
+
+`@objectstack/formula`'s `matchesFilterCondition` — the evaluator behind RLS
+write-side `check` policies (ADR-0058 D4) — compared a bare `YYYY-MM-DD` `$lte`
+bound literally. On a `datetime` post-image that meant a policy of the shape
+`{ signed_on: { $lte: '{today}' } }` **denied every write made after 00:00**:
+the write-side twin of the read-side data loss #3777 fixed, and the last of the
+platform's filter backends that disagreed about what a bare day means as a
+bound.
+
+`$lte` and a `$between` max now evaluate half-open against the next calendar
+day, matching the SQL compiler, the memory and mongo drivers, and the analytics
+preview evaluator. Unchanged, per the same semantics table: full-ISO bounds keep
+exact-instant semantics, `$gte`/`$gt`/`$lt` keep their midnight anchoring, and a
+plain `YYYY-MM-DD` value compares identically (string ordering makes the two
+forms equivalent). The evaluator stays fail-closed on a null bound.
+
+**Where the rule now lives.** `nextUtcCalendarDay` moved from
+`@objectstack/core` to `@objectstack/spec/data` — beside `date-macros.zod.ts`,
+whose vocabulary it interprets. `formula` cannot depend on `core`, and a second
+copy of the rule is exactly the divergence #3777 catalogued; `spec` is the one
+package all six consumers already depend on, so this adds no dependency edge.
+
+No import changes are required: `@objectstack/core` re-exports the symbol, so
+existing `import { nextUtcCalendarDay } from '@objectstack/core'` keeps working.
+New code should prefer `@objectstack/spec/data`.

--- a/content/docs/data-modeling/queries.mdx
+++ b/content/docs/data-modeling/queries.mdx
@@ -83,7 +83,7 @@ disagree about shape:
 | Field type | Canonical comparand | Semantics |
 |:---|:---|:---|
 | `date` | `YYYY-MM-DD` | Timezone-naive calendar day. A `Date` collapses to its UTC day; a longer ISO string is truncated to its leading date. |
-| `datetime` | `YYYY-MM-DDTHH:MM:SS.sssZ` | A UTC instant. A `Date`, an epoch-millisecond number, a bare `YYYY-MM-DD` (→ midnight UTC) and a zone-naive `YYYY-MM-DD HH:MM:SS` (→ read as UTC) all fold to this one form. |
+| `datetime` | `YYYY-MM-DDTHH:MM:SS.sssZ` | A UTC instant. A `Date`, an epoch-millisecond number, a bare `YYYY-MM-DD` (→ midnight UTC, but see the whole-day rule below) and a zone-naive `YYYY-MM-DD HH:MM:SS` (→ read as UTC) all fold to this one form. |
 | `time` | `HH:MM:SS`, with `.fff` **only** when the milliseconds are non-zero | Timezone-naive wall clock. `'14:30'` and `'14:30:00'` canonicalise identically, so they are the same filter. |
 
 ```typescript
@@ -96,6 +96,32 @@ disagree about shape:
   }
 }
 ```
+
+### A bare calendar day as an UPPER bound means the whole day
+
+Canonicalisation settles a comparand's *shape*; which **instant** a bare
+`YYYY-MM-DD` denotes additionally depends on the side of the comparison it sits on:
+
+| Operator | A bare `YYYY-MM-DD` means |
+|:---|:---|
+| `$gte` / `$gt` / `$lt` | that day's `00:00:00.000` |
+| `$lte`, and the max of a `$between` | the **whole** day — compiled half-open, as `< next day` |
+
+So `{ created_at: { $gte: '2026-01-01', $lte: '2026-03-31' } }` includes
+everything recorded *on* March 31st, not just the instant it began. Without
+that rule a dashboard window ending "today" silently dropped every row created
+after midnight (#3777). Pass a full ISO timestamp when you want an exact
+instant — only the day-granular *string* carries whole-day intent:
+
+```typescript
+{ created_at: { $lte: '2026-03-31' } }              // through all of March 31st
+{ created_at: { $lte: '2026-03-31T12:00:00.000Z' } } // up to noon exactly
+```
+
+On a `date` field the two forms are equivalent (`< next day` and `<= day` order
+identically over `YYYY-MM-DD` text), so the rule needs no special handling
+there. It applies uniformly across the SQL drivers, the in-memory and MongoDB
+drivers, analytics windows, and the RLS write-side `check` evaluator.
 
 <Callout type="info">
 Canonicalisation runs on **every SQL dialect**, not just SQLite — a zone-naive string bound

--- a/docs/adr/0053-date-and-datetime-semantics.md
+++ b/docs/adr/0053-date-and-datetime-semantics.md
@@ -782,8 +782,36 @@ cover lives in `mongodb-datetime-storage.test.ts` (against a real MongoDB via
 `mongodb-memory-server`) and `memory-datetime-storage.test.ts`. Still open
 under D-A3: the relative-token × live-driver × timezone combinations.
 
-One evaluator remains unaligned on both the D-D and D-E rules:
+~~One evaluator remains unaligned on both the D-D and D-E rules:
 `@objectstack/formula`'s `matchesFilterCondition` (the RLS write-side `check`
 path), which cannot depend on `@objectstack/core` for the shared primitive.
 Deciding its home — a private copy, as `formula` already keeps for `today()`,
-or lowering the utility into `spec`/`types` — is the remaining piece.
+or lowering the utility into `spec`/`types` — is the remaining piece.~~
+Closed 2026-07-30 — see D-D2 below.
+
+### D-D2 — The primitive lives in `spec`, beside the vocabulary it interprets
+
+`nextUtcCalendarDay` moved from `@objectstack/core` to
+`@objectstack/spec/data` (`calendar-day.ts`), next to `date-macros.zod.ts`.
+The two are halves of one contract: the macros define which bare days an author
+can *name*, D-D defines what such a day *denotes* as a bound. That is protocol,
+not business logic — the same species as the pure helpers `spec/data` already
+owns (`parseDateMacroParam`, `canonicalAstOperator`, `parseAutonumberFormat`),
+so Prime Directive #2 is satisfied.
+
+Chosen over `@objectstack/types` because **it adds no dependency edge**: every
+consumer already depends on `spec`, whereas `core` does not depend on `types`
+and would have needed a new one. `core` re-exports the symbol, so the published
+`@objectstack/core` surface — which the drivers and analytics strategies import
+from — is unchanged.
+
+Rejected: a private copy in `formula` (the precedent it would cite, `formula`'s
+own `today()`, is debt rather than a pattern). Six backends now share one
+definition: the SQL compiler, the memory and mongo drivers, the analytics
+raw-SQL strategy, the dataset preview evaluator, and `matchesFilterCondition`.
+
+The write-side gap this closed was not cosmetic. A `check` policy of the shape
+`{ signed_on: { $lte: '{today}' } }` evaluated against a `datetime` post-image
+**denied every write made after 00:00** — the write-side twin of the read-side
+loss #3777 fixed, on the one surface where the failure direction is a rejected
+write rather than a missing row.

--- a/packages/core/src/utils/datetime.test.ts
+++ b/packages/core/src/utils/datetime.test.ts
@@ -61,28 +61,14 @@ describe('zonedDateStartToUtcMs — round-trips to the day boundary in the zone'
   }
 });
 
-describe('nextUtcCalendarDay — the exclusive upper bound of a bare calendar day (#3777)', () => {
-  it('advances one day, rolling month, year and leap boundaries', () => {
+describe('nextUtcCalendarDay — re-exported from @objectstack/spec (ADR-0053 D-D)', () => {
+  it('is still reachable from this package, with the same semantics', () => {
+    // The rule itself now lives in spec (six backends share it, and
+    // `@objectstack/formula` cannot depend on core) — its thorough coverage is
+    // `packages/spec/src/data/calendar-day.test.ts`. What this asserts is the
+    // re-export the drivers and analytics strategies import from HERE, so
+    // dropping it would break them loudly rather than at their call sites.
     expect(nextUtcCalendarDay('2026-07-28')).toBe('2026-07-29');
-    expect(nextUtcCalendarDay('2026-07-31')).toBe('2026-08-01');
-    expect(nextUtcCalendarDay('2026-12-31')).toBe('2027-01-01');
-    expect(nextUtcCalendarDay('2024-02-28')).toBe('2024-02-29'); // leap year
-    expect(nextUtcCalendarDay('2025-02-28')).toBe('2025-03-01');
-    expect(nextUtcCalendarDay(' 2026-07-28 ')).toBe('2026-07-29'); // trimmed
-  });
-
-  it('returns null for anything that is not a valid bare calendar day', () => {
-    // Instants keep instant semantics — never widened.
     expect(nextUtcCalendarDay('2026-07-28T12:00:00Z')).toBeNull();
-    expect(nextUtcCalendarDay(new Date('2026-07-28T00:00:00Z'))).toBeNull();
-    // Impossible days are rejected, not rolled into an invented bound.
-    expect(nextUtcCalendarDay('2026-02-30')).toBeNull();
-    expect(nextUtcCalendarDay('2026-13-01')).toBeNull();
-    // Non-strings / junk.
-    expect(nextUtcCalendarDay(1753660800000)).toBeNull();
-    expect(nextUtcCalendarDay(null)).toBeNull();
-    expect(nextUtcCalendarDay(undefined)).toBeNull();
-    expect(nextUtcCalendarDay('7/28/2026')).toBeNull();
-    expect(nextUtcCalendarDay('2026-7-28')).toBeNull(); // not zero-padded → not the canonical shape
   });
 });

--- a/packages/core/src/utils/datetime.ts
+++ b/packages/core/src/utils/datetime.ts
@@ -103,37 +103,16 @@ export function zonedDateStartToUtcMs(ymd: string, tz?: string): number {
 }
 
 /**
- * The calendar day after a bare `YYYY-MM-DD` string — the exclusive upper
- * bound of that day, for compiling "through day X" into the half-open
- * `[X, X+1)` a `datetime` column needs (#3777).
+ * Calendar-day bound semantics (ADR-0053 D-D) now live in `@objectstack/spec`,
+ * beside the date-macro vocabulary they give meaning to — the fifth consumer
+ * (`@objectstack/formula`'s RLS write-side `check` evaluator) cannot depend on
+ * this package, and a second copy of the rule is exactly the divergence #3777
+ * catalogued.
  *
- * A bare calendar day used as an upper bound (`$lte`, a `dateRange` end, a
- * `{current_month_end}` token) always carries whole-day intent — the author
- * means "including everything that happened on X", never "up to the stroke of
- * midnight that begins X". On a `date` column `<= X` already says that; on a
- * `datetime` column it silently drops every instant after 00:00. The correct
- * translation is the half-open pair `>= start AND < nextUtcCalendarDay(end)`
- * — the same shape the analytics drill ranges already emit — rather than an
- * inclusive `23:59:59.999` constant, which re-opens the gap at whatever
- * precision the dialect stores beyond milliseconds.
- *
- * `< nextUtcCalendarDay(X)` is also *equivalent* to `<= X` for a `date` column
- * (plain `YYYY-MM-DD` text ordering), so emitters that cannot see the column
- * type (raw-SQL strategies, the dataset preview evaluator) can apply it
- * unconditionally to a bare-day bound and be right on both column types.
- *
- * Returns `null` for anything that is not a valid bare calendar day — full
- * ISO timestamps keep instant semantics and must NOT be widened, and an
- * impossible day (`2026-02-30`) is rejected the same way
- * {@link bucketKeyToCalendarRange} rejects it, so a caller falls back to the
- * untranslated comparand instead of inventing a bound.
+ * Re-exported here so the published `@objectstack/core` surface is unchanged
+ * for the drivers and analytics strategies that already import it from here.
  */
-export function nextUtcCalendarDay(value: unknown): string | null {
-  if (typeof value !== 'string') return null;
-  const day = value.trim();
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return null;
-  return bucketKeyToCalendarRange(day, 'day')?.end ?? null;
-}
+export { nextUtcCalendarDay } from '@objectstack/spec/data';
 
 /**
  * Granularity of a canonical date-bucket key. Mirrors `@objectstack/spec`'s

--- a/packages/formula/src/matches-filter.test.ts
+++ b/packages/formula/src/matches-filter.test.ts
@@ -108,3 +108,55 @@ describe('matchesFilterCondition — FAIL CLOSED', () => {
     expect(m(rec, 'nope' as never)).toBe(false);
   });
 });
+
+describe('matchesFilterCondition — calendar-day upper bounds (ADR-0053 D-D, #3777)', () => {
+  // A `check` policy of this shape on a datetime post-image used to DENY every
+  // write made after 00:00 of the bound day — the write-side twin of the
+  // read-side data loss #3777 fixed. The four other filter backends already
+  // share this rule; this evaluator was the last one that disagreed.
+  const at = (created_at: string) => ({ created_at });
+
+  it('a bare-day $lte admits the whole day', () => {
+    expect(m(at('2026-07-28T00:00:00.000Z'), { created_at: { $lte: '2026-07-28' } })).toBe(true);
+    expect(m(at('2026-07-28T09:15:00.000Z'), { created_at: { $lte: '2026-07-28' } })).toBe(true);
+    expect(m(at('2026-07-28T23:59:59.999Z'), { created_at: { $lte: '2026-07-28' } })).toBe(true);
+  });
+
+  it('…and stops at the next day', () => {
+    expect(m(at('2026-07-29T00:00:00.000Z'), { created_at: { $lte: '2026-07-28' } })).toBe(false);
+  });
+
+  it('a plain calendar-day value is unchanged (string ordering is equivalent)', () => {
+    expect(m({ signed_on: '2026-07-28' }, { signed_on: { $lte: '2026-07-28' } })).toBe(true);
+    expect(m({ signed_on: '2026-07-29' }, { signed_on: { $lte: '2026-07-28' } })).toBe(false);
+  });
+
+  it('a full-ISO bound keeps exact-instant semantics — never widened', () => {
+    expect(m(at('2026-07-28T09:15:00.000Z'), { created_at: { $lte: '2026-07-28T12:00:00.000Z' } })).toBe(true);
+    expect(m(at('2026-07-28T21:40:00.000Z'), { created_at: { $lte: '2026-07-28T12:00:00.000Z' } })).toBe(false);
+  });
+
+  it('$gte / $gt / $lt keep their midnight anchoring', () => {
+    expect(m(at('2026-07-28T09:15:00.000Z'), { created_at: { $gte: '2026-07-28' } })).toBe(true);
+    expect(m(at('2026-07-27T23:59:59.999Z'), { created_at: { $gte: '2026-07-28' } })).toBe(false);
+    expect(m(at('2026-07-28T09:15:00.000Z'), { created_at: { $lt: '2026-07-28' } })).toBe(false);
+  });
+
+  it('$between inherits the rule on its max, and still bounds the min', () => {
+    expect(m(at('2026-07-28T21:40:00.000Z'), { created_at: { $between: ['2026-04-29', '2026-07-28'] } })).toBe(true);
+    expect(m(at('2026-07-29T00:00:00.000Z'), { created_at: { $between: ['2026-04-29', '2026-07-28'] } })).toBe(false);
+    expect(m(at('2026-04-28T23:00:00.000Z'), { created_at: { $between: ['2026-04-29', '2026-07-28'] } })).toBe(false);
+  });
+
+  it('an impossible day is not rolled over — the bound stays as written', () => {
+    // `2026-02-30` is rejected by the primitive, so the comparison falls back
+    // to the literal `<=` rather than silently querying March 2nd.
+    expect(m({ signed_on: '2026-02-30' }, { signed_on: { $lte: '2026-02-30' } })).toBe(true);
+    expect(m({ signed_on: '2026-03-01' }, { signed_on: { $lte: '2026-02-30' } })).toBe(false);
+  });
+
+  it('stays fail-closed on a null bound', () => {
+    expect(m(at('2026-07-28T09:15:00.000Z'), { created_at: { $lte: null } as never })).toBe(false);
+    expect(m(at('2026-07-28T09:15:00.000Z'), { created_at: { $between: ['2026-04-29', null] } as never })).toBe(false);
+  });
+});

--- a/packages/formula/src/matches-filter.ts
+++ b/packages/formula/src/matches-filter.ts
@@ -17,6 +17,7 @@
  */
 
 import type { FilterCondition } from '@objectstack/spec/data';
+import { nextUtcCalendarDay } from '@objectstack/spec/data';
 
 /** True iff `record` satisfies `filter`. A null/empty filter matches everything. */
 export function matchesFilterCondition(record: Record<string, unknown>, filter: FilterCondition | null | undefined): boolean {
@@ -72,12 +73,12 @@ function evalOp(actual: unknown, op: string, raw: unknown, record: Record<string
     case '$gt': return actual != null && v != null && (actual as never) > (v as never);
     case '$gte': return actual != null && v != null && (actual as never) >= (v as never);
     case '$lt': return actual != null && v != null && (actual as never) < (v as never);
-    case '$lte': return actual != null && v != null && (actual as never) <= (v as never);
+    case '$lte': return actual != null && v != null && lteBound(actual, v);
     case '$in': return Array.isArray(v) && v.some((x) => looseEq(actual, x));
     case '$nin': return Array.isArray(v) && !v.some((x) => looseEq(actual, x));
     case '$between':
-      return Array.isArray(v) && v.length === 2 && actual != null
-        && (actual as never) >= (v[0] as never) && (actual as never) <= (v[1] as never);
+      return Array.isArray(v) && v.length === 2 && actual != null && v[0] != null && v[1] != null
+        && (actual as never) >= (v[0] as never) && lteBound(actual, v[1]);
     case '$contains': return typeof actual === 'string' && typeof v === 'string' && actual.includes(v);
     case '$notContains': return !(typeof actual === 'string' && typeof v === 'string' && actual.includes(v));
     case '$startsWith': return typeof actual === 'string' && typeof v === 'string' && actual.startsWith(v);
@@ -86,6 +87,31 @@ function evalOp(actual: unknown, op: string, raw: unknown, record: Record<string
     case '$exists': return v === true ? actual !== undefined : actual === undefined;
     default: return false; // unknown operator → fail closed
   }
+}
+
+/**
+ * The inclusive-upper-bound comparison, with the calendar-day rule the rest of
+ * the platform applies (ADR-0053 D-D, #3777): a bare `YYYY-MM-DD` bound means
+ * "through that whole day", so it is evaluated half-open against the next day
+ * rather than against that day's midnight.
+ *
+ * Without this, a `check` policy of the shape `{ signed_on: { $lte: '{today}' } }`
+ * evaluated on a `datetime` post-image **denied every write made after 00:00** —
+ * the write-side twin of the read-side data loss #3777 fixed, and the reason
+ * this evaluator had to stop being the one backend that disagreed. The four
+ * other backends (SQL compiler, memory, mongo, the analytics preview) already
+ * share this rule via the same primitive.
+ *
+ * String ordering makes `< nextDay` equivalent to `<= day` for a plain
+ * `YYYY-MM-DD` value, so no field-type lookup is needed — which matters here,
+ * because this evaluator sees a bare record and has no schema to consult.
+ * A full-ISO or non-string bound keeps exact-instant semantics.
+ */
+function lteBound(actual: unknown, bound: unknown): boolean {
+  if (bound == null) return false;
+  const nextDay = nextUtcCalendarDay(bound);
+  if (nextDay != null) return (actual as never) < (nextDay as never);
+  return (actual as never) <= (bound as never);
 }
 
 /** Resolve a `{ $field: 'path' }` reference against the record; else passthrough. */

--- a/packages/spec/api-surface.json
+++ b/packages/spec/api-surface.json
@@ -582,6 +582,7 @@
     "isTitleEligible (function)",
     "isUniqueDeclared (function)",
     "missingFieldValues (function)",
+    "nextUtcCalendarDay (function)",
     "objectForm (const)",
     "objectTitleCompleteness (function)",
     "parseAutonumberFormat (function)",

--- a/packages/spec/src/data/calendar-day.test.ts
+++ b/packages/spec/src/data/calendar-day.test.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The calendar-day bound primitive (ADR-0053 D-D). It lives in spec because six
+ * backends now share it — the SQL compiler, the memory and mongo drivers, the
+ * analytics raw-SQL strategy, the dataset preview evaluator, and `formula`'s
+ * RLS write-side `check` evaluator. Its refusals are as load-bearing as its
+ * answers: every `null` below is a case some backend must NOT widen.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { nextUtcCalendarDay } from './calendar-day';
+
+describe('nextUtcCalendarDay', () => {
+  it('advances one calendar day', () => {
+    expect(nextUtcCalendarDay('2026-07-28')).toBe('2026-07-29');
+    expect(nextUtcCalendarDay(' 2026-07-28 ')).toBe('2026-07-29'); // trimmed
+  });
+
+  it('rolls month, year and leap boundaries', () => {
+    expect(nextUtcCalendarDay('2026-07-31')).toBe('2026-08-01');
+    expect(nextUtcCalendarDay('2026-12-31')).toBe('2027-01-01');
+    expect(nextUtcCalendarDay('2024-02-28')).toBe('2024-02-29'); // leap year
+    expect(nextUtcCalendarDay('2024-02-29')).toBe('2024-03-01');
+    expect(nextUtcCalendarDay('2025-02-28')).toBe('2025-03-01'); // non-leap
+  });
+
+  it('refuses instants — they keep exact-instant semantics', () => {
+    expect(nextUtcCalendarDay('2026-07-28T12:00:00Z')).toBeNull();
+    expect(nextUtcCalendarDay('2026-07-28T00:00:00.000Z')).toBeNull();
+    expect(nextUtcCalendarDay(new Date('2026-07-28T00:00:00Z'))).toBeNull();
+    expect(nextUtcCalendarDay(1753660800000)).toBeNull();
+  });
+
+  it('refuses impossible days rather than rolling them over', () => {
+    // `Date.UTC(2026, 1, 30)` is March 2nd — returning that would query a date
+    // the author never wrote, so the round-trip check rejects it.
+    expect(nextUtcCalendarDay('2026-02-30')).toBeNull();
+    expect(nextUtcCalendarDay('2025-02-29')).toBeNull(); // not a leap year
+    expect(nextUtcCalendarDay('2026-13-01')).toBeNull();
+    expect(nextUtcCalendarDay('2026-00-10')).toBeNull();
+    expect(nextUtcCalendarDay('2026-07-32')).toBeNull();
+  });
+
+  it('refuses anything that is not the canonical bare-day shape', () => {
+    expect(nextUtcCalendarDay('2026-7-28')).toBeNull(); // not zero-padded
+    expect(nextUtcCalendarDay('7/28/2026')).toBeNull();
+    expect(nextUtcCalendarDay('2026-07')).toBeNull();
+    expect(nextUtcCalendarDay('')).toBeNull();
+    expect(nextUtcCalendarDay(null)).toBeNull();
+    expect(nextUtcCalendarDay(undefined)).toBeNull();
+    expect(nextUtcCalendarDay({})).toBeNull();
+  });
+
+  it('the result is itself a valid bare day — the rule composes', () => {
+    // Chaining is not a use case, but a returned value that the primitive
+    // would reject would mean the two halves disagree about the shape.
+    const next = nextUtcCalendarDay('2026-12-31')!;
+    expect(nextUtcCalendarDay(next)).toBe('2027-01-02');
+  });
+});

--- a/packages/spec/src/data/calendar-day.ts
+++ b/packages/spec/src/data/calendar-day.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Calendar-day bound semantics — what a bare `YYYY-MM-DD` MEANS on each side of
+ * a comparison (ADR-0053 D-D, #3777).
+ *
+ * This lives beside `date-macros.zod.ts` because it is the semantic companion of
+ * that vocabulary: the macros define which bare days an author can *name*
+ * (`{today}`, `{current_month_end}`, …), and this defines what such a day
+ * *denotes* when it lands on one side of a filter operator. Both halves are
+ * protocol, so both belong to the one contract every producer and consumer
+ * shares — the alternative is each backend re-deriving the rule, which is how
+ * the four divergent implementations #3777 catalogued came about.
+ *
+ * The rule, per field type and operator:
+ *
+ * | Operator | A bare `YYYY-MM-DD` on a `datetime` column means |
+ * |---|---|
+ * | `$gte` / `$gt` / `$lt` | that day's `00:00:00.000` — already correct as written |
+ * | `$lte`, a `$between` max, a `dateRange` end | the WHOLE day → compile `< nextUtcCalendarDay(day)` |
+ *
+ * Half-open, never an inclusive `23:59:59.999`: the latter re-opens the gap at
+ * whatever sub-millisecond precision a dialect keeps (Postgres stores
+ * microseconds), and `[gte, lt)` is the shape the analytics drill ranges (#1752)
+ * already emit. On a `date` column `< nextDay` is order-equivalent to
+ * `<= day` under plain `YYYY-MM-DD` text ordering, which is what lets emitters
+ * that cannot see the column type apply it unconditionally.
+ */
+
+/**
+ * The calendar day after a bare `YYYY-MM-DD` string — the exclusive upper bound
+ * of that day.
+ *
+ * Returns `null` for anything that is not a valid bare calendar day. That
+ * refusal is load-bearing in two directions:
+ *   - a full ISO timestamp or a `Date` keeps **instant** semantics and must not
+ *     be widened, so callers get `null` and compile their original bound;
+ *   - an impossible day (`2026-02-30`, `2026-13-01`) is rejected rather than
+ *     rolled over, so a caller falls back to the untranslated comparand instead
+ *     of silently querying a date the author never wrote.
+ */
+export function nextUtcCalendarDay(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const day = value.trim();
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(day);
+  if (!m) return null;
+  const [y, mo, d] = [Number(m[1]), Number(m[2]), Number(m[3])];
+  const start = new Date(Date.UTC(y, mo - 1, d));
+  // Reject a shape-valid but impossible day: `Date.UTC` rolls 2026-02-30 into
+  // March, so the round-trip is what proves the input was a real calendar day.
+  if (fmtUtcDay(start) !== day) return null;
+  return fmtUtcDay(new Date(Date.UTC(y, mo - 1, d + 1)));
+}
+
+/** `YYYY-MM-DD` of an instant's UTC calendar day. */
+function fmtUtcDay(dt: Date): string {
+  return (
+    `${String(dt.getUTCFullYear()).padStart(4, '0')}-` +
+    `${String(dt.getUTCMonth() + 1).padStart(2, '0')}-` +
+    `${String(dt.getUTCDate()).padStart(2, '0')}`
+  );
+}

--- a/packages/spec/src/data/index.ts
+++ b/packages/spec/src/data/index.ts
@@ -7,6 +7,7 @@ export * from './filter.zod';
 // against, so they cannot drift apart again (#3774).
 export * from './filter-logic-conformance';
 export * from './date-macros.zod';
+export * from './calendar-day';
 // Session-scoped filter placeholders ({current_user_id} / {current_org_id}) —
 // the sibling vocabulary to date macros. Presentation scope only; RLS is the
 // enforcement boundary. See context-tokens.zod.ts.


### PR DESCRIPTION
收尾 #3777 / #4042 / #4047 那条线上最后一个未对齐的求值面。无 issue —— 它是 ADR-0053 **D-E4 明确记录的未决项**，本 PR 关闭它。

## 为什么值得单独一个 PR：这一面的失败方向是「拒绝写入」

`matchesFilterCondition` 是 RLS **写侧** `check` 策略（ADR-0058 D4）的求值器。它对裸 `YYYY-MM-DD` 的 `$lte` 做字面比较，所以打在 `datetime` post-image 上时，`{ signed_on: { $lte: '{today}' } }` 这类策略**拒绝掉当天 00:00 之后的每一次写入**。

前面三个 PR 修的都是读窗口「少了几行」；这一面错了是策略判定错——本该放行的写被拒（或反向）。这也是平台五个 filter 后端里最后一个对「裸日期作上界是什么意思」持不同意见的。

## 变更

`$lte` 与 `$between` 的 max 改为对次日半开求值，与 SQL 编译器、memory/mongo 驱动、analytics preview 一致。**刻意不动**（同一张语义表）：完整 ISO 边界保持精确瞬时、`$gte`/`$gt`/`$lt` 保持午夜锚定、纯 `YYYY-MM-DD` 值比较结果不变（字符串序下两种形式等价）、null 边界仍 fail-closed。

## 归属决策（这是本 PR 的实质部分）

`nextUtcCalendarDay` 从 `@objectstack/core` 迁到 **`@objectstack/spec/data`**（新文件 `calendar-day.ts`），紧邻 `date-macros.zod.ts`。

理由：两者是同一份契约的两半——macros 定义作者能**命名**哪些裸日期，D-D 定义这样一个日期作为边界**指代**什么。这是协议，不是业务逻辑，与 `spec/data` 已有的 `parseDateMacroParam` / `canonicalAstOperator` / `parseAutonumberFormat` 同species，因此 Prime Directive #2 成立。

选 spec 而非 `@objectstack/types` 的决定性理由：**零新增依赖边**。所有消费者已依赖 spec；而 `core` 目前**不**依赖 `types`，走 types 需要新建一条 `core → types` 边。

**拒绝**在 formula 里放私有拷贝：它能援引的先例（formula 自己的 `today()`）是债不是模式，而这条规则的第二份拷贝正是 #3777 编目的那种分歧。现在六个后端共用一个定义。

**无需改动任何 import**：`core` 继续再导出该符号，驱动与 analytics 策略现有的 `from '@objectstack/core'` 照常工作；新代码建议直接用 `@objectstack/spec/data`。

## 覆盖

- **formula 10 条对齐用例**：整天纳入、次日截断、纯日期值等价、完整 ISO 不放宽、`$gte`/`$gt`/`$lt` 不变性、`$between` 下界仍生效、不可能日期（`2026-02-30`）不被翻滚、null 边界 fail-closed。
- **原语的详尽覆盖迁到 spec**（`calendar-day.test.ts`，含闰年/月末/年末翻转与全部拒绝分支）；**core 保留一条再导出门**——它断言的是驱动与策略实际 import 的那个surface，去掉会在别处才报错。

## 测试

`spec` 6943 ✅ / `core` 414 ✅ / `formula` 273 ✅（含新 10）/ `driver-sql` 508 ✅ / `driver-memory` 194 ✅ / `driver-mongodb` 107 ✅ / `service-analytics` 329 ✅ —— 七个包全绿，既有断言零改动（迁移对下游是透明的）。三包带 dts 构建 ✅；改动文件 eslint 干净（`spec/**` 不在 eslint 配置范围内，是既有状况，非本 PR 引入）。

## 关联

- ADR-0053 新增 **D-D2**（归属决策与被拒方案），D-E4 的未决项标记为已关闭。
- 至此 ADR-0053 D-D/D-E 覆盖全部六个求值面。仍开放（与本 PR 无关）：**D-A3 一致性矩阵**从未立项，以及 **mongo 存量 collection 的迁移路径**（#4060 有意未做自动 backfill）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkL3RGJrzjLEGURsLxfS2f

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkL3RGJrzjLEGURsLxfS2f)_