### PR TITLE
test(showcase): a specimen for legacy string rowActions (objectui#2960)

### DIFF
--- a/.changeset/showcase-legacy-rowactions-specimen.md
+++ b/.changeset/showcase-legacy-rowactions-specimen.md
@@ -1,0 +1,10 @@
+---
+---
+
+test(showcase): a specimen for legacy string rowActions (objectui#2960)
+
+Releases nothing. The change is confined to `@objectstack/example-showcase`,
+which is `"private": true` and never published — it adds the
+`showcase_task.legacy_row_actions` view (a fixture for the objectui#2960 bug
+class) and `recordIdParam` on `showcase_recalc_estimate`, so no consumer-facing
+package changes.

--- a/examples/app-showcase/src/ui/actions/index.ts
+++ b/examples/app-showcase/src/ui/actions/index.ts
@@ -109,6 +109,11 @@ export const RecalcEstimateAction = defineAction({
   target: '/api/v1/showcase/recalc',
   successMessage: 'Estimate recalculated.',
   locations: ['record_more', 'record_section'],
+  // The endpoint is record-scoped and rejects a body without an id. On a
+  // record surface the page supplies it; invoked from a LIST ROW (see the
+  // `legacy_row_actions` view) nothing else can, so name the body key the
+  // clicked row's id should be written to.
+  recordIdParam: 'recordId',
   refreshAfter: true,
 });
 

--- a/examples/app-showcase/src/ui/views/task.view.ts
+++ b/examples/app-showcase/src/ui/views/task.view.ts
@@ -83,6 +83,30 @@ export const TaskViews = defineView({
       filter: [{ field: 'status', operator: 'equals', value: 'done' }],
     },
 
+    // ── Legacy `rowActions: string[]` coverage (objectui#2960) ──────────
+    // The pre-`rowActionDefs` authoring form: the row menu is declared as bare
+    // action NAMES rather than defs. Both cases the client has to handle are
+    // present here on purpose:
+    //
+    //   `showcase_recalc_estimate` — declared on the object at `record_more` /
+    //     `record_section`, i.e. NOT a `list_item` action, so nothing derives a
+    //     def for it. The client must resolve the name against the object's
+    //     actions or the entry is a dead menu item.
+    //
+    //   `showcase_quick_view` — already a `list_item` action, so the client
+    //     derives a def for it independently. Naming it here too must NOT
+    //     produce a second, dead copy alongside the working one.
+    //
+    // Kept as a fixture: this is the only view in the showcase authored the
+    // legacy way, and it is what makes the regression visible in a browser.
+    legacy_row_actions: {
+      label: 'Legacy Row Actions',
+      type: 'grid',
+      data,
+      columns: [{ field: 'title' }, { field: 'project' }, { field: 'assignee' }, { field: 'status' }],
+      rowActions: ['showcase_recalc_estimate', 'showcase_quick_view'],
+    },
+
     // 0 ── Tabular ───────────────────────────────────────────────────────
     // ADR-0021 Phase 2: replaces the former `showcase_task_list` report
     // (a flat record list — a ListView concern, not analytics).


### PR DESCRIPTION
Specimen for the bug class objectui#2960 fixed in objectui#2996. Showcase had no view authored the legacy way, so this whole class was invisible here.

## 背景

列表视图声明 `rowActions: ['<action 名>']`（`rowActionDefs` 之前的老写法）时，行菜单里那一项点下去**零网络请求却报成功**；如果对象还在 `list_item` 声明了同名 action，菜单里会并排出现**一个能用、一个是死的**。

## 加了什么

`showcase_task.legacy_row_actions` —— 用对象已有的 action，一次覆盖客户端必须处理的两种情况：

| action | locations | 为什么在这里 |
|---|---|---|
| `showcase_recalc_estimate` | `record_more`, `record_section` | **不是** `list_item` action，不会派生出 def。客户端必须拿名字去对象的 actions 里解析，否则这一项就是死的。 |
| `showcase_quick_view` | `list_item` | 已经会独立派生出 def。这里再写一次名字，**不能**产生第二个死副本。 |

另外给 `showcase_recalc_estimate` 补了 `recordIdParam: 'recordId'`。它的端点是 record-scoped 的、body 里没 id 就拒绝；在 record 界面上由页面提供，但**从列表行调用时没有任何东西能提供** —— 行 id 只会注入给声明了 body key 的 action。不补的话这个 specimen 自己的 action 从行上点会返回 400 `recordId required`。对 record 界面是纯增量（那里 id 本来就有）。

## 浏览器实测

拿这个 specimen 配 objectui #2996 的控制台跑过：

行菜单实际 DOM ——

```
row-action-builtin-edit              编辑
row-action-builtin-delete            删除
row-action-showcase_bulk_reassign    Reassign…
row-action-showcase_quick_view       Quick View            ← 只有一个，无死副本
row-action-showcase_recalc_estimate  Recalculate Estimate  ← 名字解析成功
```

点击 `Recalculate Estimate` → `POST /api/v1/showcase/recalc` → **200 OK**，toast 是 action 自己声明的 `successMessage`「Estimate recalculated.」，而不是 runner 的通用「Action completed successfully」—— 后者正是这个 bug 过去弹的东西，所以文案本身就能区分真假。

补 `recordIdParam` 之前，同一次点击返回 400，红色 toast 如实显示服务端的「recordId required」。两种结局都验证过了。

## 检查

- `check:i18n-coverage`：665，none new（`listViews` 的 label 不在 i18n lint 作用域，实测 0 条 issue 提及 `legacy_row_actions`，不引入新债）
- `os lint`：0 errors
- `@objectstack/example-showcase`：10 文件 / 60 测试全过

纯 fixture + 一处示例修正，无 changeset（非 feature）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)