### PR TITLE
test(runtime): the dispatcher envelope check uses the shared predicate (#4090 follow-up)

### DIFF
--- a/.changeset/dispatcher-envelope-shared-predicate.md
+++ b/.changeset/dispatcher-envelope-shared-predicate.md
@@ -1,0 +1,17 @@
+---
+---
+
+`domain-handler-registry.test.ts` now uses `envelopeViolations` instead of its own
+copy of the rule. Deliberately empty frontmatter: test-only, this releases nothing.
+
+That test hand-rolled "no key beside the envelope's own may hold the payload" for
+#4038. #4090 promoted the rule into the spec so it would stop having two
+definitions; leaving the local copy would have recreated the exact failure this
+line has been closing — one rule, two places, only one updated next time.
+
+The two were also not equivalent. The local set allowed any body whose top-level
+keys were `success` / `data` / `meta`, so it passed a success body with no `data`
+at all and one carrying an `error` beside `success: true`. The shared predicate
+rejects both, which makes this a strict tightening rather than a refactor:
+injecting `{ success: true }` into the producer now fails the suite, and used to
+pass it.

--- a/packages/runtime/src/domain-handler-registry.test.ts
+++ b/packages/runtime/src/domain-handler-registry.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
+import { envelopeViolations } from '@objectstack/spec/api';
 import { HttpDispatcher } from './http-dispatcher.js';
 import { DomainHandlerRegistry } from './domain-handler-registry.js';
 import type { DomainHandler } from './domain-handler-registry.js';
@@ -391,9 +392,15 @@ describe('HttpDispatcher extracted domains (PR-4: share-links)', () => {
     });
 
     it('every success body carries its payload under `data` and nowhere else', async () => {
-        // The general form of the two assertions above, over all four success
-        // routes: no key beside the envelope's own may hold the payload.
-        const ENVELOPE_KEYS = new Set(['success', 'data', 'meta']);
+        // The general form of the two assertions above, over all the success
+        // routes — and `envelopeViolations` (#4090) is now where that general form
+        // lives. This test hand-rolled it first, for #4038; extracting it into the
+        // spec meant the same rule stopped having two definitions that could drift
+        // apart, which is the failure this whole line has been closing.
+        //
+        // The shared one is also stricter than what stood here: the local set
+        // allowed any body whose keys were `success`/`data`/`meta`, so it passed a
+        // success body with no `data` at all and one carrying an `error`.
         const shareLinks = {
             createLink: vi.fn().mockResolvedValue(LINK),
             listLinks: vi.fn().mockResolvedValue([LINK]),
@@ -407,9 +414,7 @@ describe('HttpDispatcher extracted domains (PR-4: share-links)', () => {
         ];
         for (const body of bodies) {
             expect(body?.success).toBe(true);
-            for (const key of Object.keys(body ?? {})) {
-                expect(ENVELOPE_KEYS.has(key), `body carries a non-envelope top-level key: ${key}`).toBe(true);
-            }
+            expect(envelopeViolations(body), `not the declared envelope: ${JSON.stringify(body)}`).toEqual([]);
         }
     });
 


### PR DESCRIPTION
The caller that motivated #4090's extraction, now actually using it. One file, one test body.

## Why this isn't cosmetic

`domain-handler-registry.test.ts` hand-rolled "no key beside the envelope's own may hold the payload" when I wrote it for #4038. #4090 promoted that rule into `envelopeViolations` precisely so it would stop having two definitions. Leaving the local copy in place would have recreated the failure this whole line has been closing — **one rule, two places, and only one of them updated next time**.

It also wasn't the same rule. The local version was:

```ts
const ENVELOPE_KEYS = new Set(['success', 'data', 'meta']);
for (const key of Object.keys(body ?? {})) {
  expect(ENVELOPE_KEYS.has(key), …).toBe(true);
}
```

That passes any body whose top-level keys fall in the set — including a success body with **no `data` at all**, and one carrying an `error` alongside `success: true`. The shared predicate rejects both.

## Verified as a strict improvement, not a refactor

I broke the producer two ways and checked the suite catches each:

| injected body | old local check | shared predicate |
|---|---|---|
| `{ success: true, data: link, link }` (the #4049 drift) | caught | **caught** |
| `{ success: true }` (no payload) | **passed** ❌ | **caught** ✅ |

Both now fail the suite; the second is the one that used to slip through.

## Verification

`@objectstack/runtime` **914 passed**. All ten gates in the TypeScript Type Check job, plus the six `check:*` guards — 16 total, all green.

**Stale-dist note, worth recording because it cost me a round and reads as a real failure.** After restarting this branch onto the newer `main`, two gates failed against a stale `packages/spec/dist`:

- `check:api-surface` reported `- strictUnknownKeyError`, `+ AggregationFunction` … "3 breaking, 8 added" — *other people's* exports, because the built `.d.ts` predated their commits.
- `check:i18n-coverage` rejected `examples/app-showcase/objectstack.config.ts` for a `'combo'` chart type — which the fresh spec allows.

Neither is a real failure and neither is mine; rebuilding spec cleared both, and I confirmed the i18n one passes identically with and without my change. Related: `gen:api-surface` reads `dist/index.d.ts`, so it cannot run under `OS_SKIP_DTS=1` at all.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYbS3kS8xzsHNXFTzp4e2z)_