### PR TITLE
fix(datasource): a `memory` datasource is ephemeral, and each pool gets its own store (#4083)

### DIFF
--- a/.changeset/memory-datasource-ephemeral-per-pool.md
+++ b/.changeset/memory-datasource-ephemeral-per-pool.md
@@ -1,0 +1,51 @@
+---
+"@objectstack/service-datasource": patch
+---
+
+fix(datasource): a `memory` datasource is ephemeral again, and each pool gets its own store (#4083)
+
+The shared driver factory built `new InMemoryDriver()` for `driver: 'memory'` with
+no config, so the pool inherited that driver's own `persistence: 'auto'` default —
+in Node, a file adapter at the **relative, process-global** path
+`.objectstack/data/memory-driver.json`. Two consequences, neither intended:
+
+- **It was not ephemeral.** The pool flushed its whole store into the server's
+  working directory (on an unref'd 2s autosave timer, and again at teardown) and
+  reloaded it on the next boot. That is the opposite of what the driver id
+  promises the operator who asks for it — `OS_DATABASE_DRIVER=memory` is
+  documented as *ephemeral, not real SQL* — and it means a "throwaway" datasource
+  left state in the deploy directory.
+- **Every memory pool in a process shared one destination.** The default path
+  carries no per-datasource component, so two `driver: 'memory'` datasources
+  loaded and saved the same file: each saw the other's tables, and the last
+  teardown to flush clobbered the other's rows.
+
+Both were visible as an intermittent test failure. The ADR-0062 D1 federated-read
+acceptance seeds 2 rows into an auto-connected external memory datasource and
+reads them back; it returned 2 rows on a clean checkout and 2×N on the Nth run in
+the same tree — passing in CI (always run #1, always a fresh checkout) and
+failing locally for anyone who ran it twice. Whether a given run leaked depended
+on the autosave timer, which is what made it look flaky rather than wrong.
+
+- The factory now builds the memory pool with **`persistence: false` by default**.
+- It also **honors the datasource's own `config`**, which was previously dropped
+  entirely: `initialData` and `strictMode` never reached the driver.
+- When an author *does* opt into persistence (`config.persistence`), the default
+  destination is **scoped to the datasource** —
+  `.objectstack/data/memory-<name>.json` / `objectstack:memory-db:<name>` — so
+  pools stay independent. An explicit `path`/`key`, or a custom `adapter`, is
+  left exactly as written.
+- The dev-only sqlite step-down's last-resort in-memory driver
+  (`resolveSqliteDriver`, #2229) is built the same way, making its own
+  "not persistent" contract true.
+
+`InMemoryDriver`'s documented defaults are unchanged — constructing one directly
+still auto-detects persistence. Only the datasource-scoped pools this factory
+builds changed.
+
+**Migration.** A deployment relying on `driver: 'memory'` state surviving a
+restart was relying on a bug, and should declare it: set
+`config: { persistence: 'file' }` on the datasource (now written to a
+per-datasource file), or use a real driver — `sqlite`/`sqlite-wasm` give durable
+storage with real SQL. Existing `.objectstack/data/memory-driver.json` files are
+no longer read; delete them.

--- a/packages/runtime/src/datasource-autoconnect.test.ts
+++ b/packages/runtime/src/datasource-autoconnect.test.ts
@@ -12,6 +12,8 @@
 // without any native driver dependency.
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 import { Runtime } from './runtime.js';
 import { DriverPlugin } from './driver-plugin.js';
 import { AppPlugin } from './app-plugin.js';
@@ -71,7 +73,10 @@ async function boot(opts: { connectPolicy?: DatasourceConnectPolicy } = {}) {
 
   const runtime = new Runtime({ cluster: false });
   const kernel = runtime.getKernel();
-  await kernel.use(new DriverPlugin(new InMemoryDriver())); // default driver
+  // `persistence: false` keeps the acceptance hermetic. The driver's own default
+  // is `'auto'` — in Node a file adapter at `.objectstack/data/…` under the CWD,
+  // which both reloads and rewrites ambient state between runs (#4083).
+  await kernel.use(new DriverPlugin(new InMemoryDriver({ persistence: false }))); // default driver
   await kernel.use(new ObjectQLPlugin());
   await kernel.use(new AppPlugin(artifact()));
   await kernel.use(
@@ -129,6 +134,64 @@ describe('ADR-0062 declared-datasource auto-connect', () => {
     const rows = await engine.find('ext_note');
     expect(rows.map((r) => r.title).sort()).toEqual(['first', 'second']);
   });
+});
+
+// #4083 — the acceptance above passed on a clean checkout and failed on every
+// subsequent run, reading 2×N rows on the Nth: the auto-connected `memory`
+// datasource inherited `InMemoryDriver`'s `persistence: 'auto'` default, so it
+// flushed `ext_note` into `.objectstack/data/memory-driver.json` under the CWD
+// and the next boot's connect() loaded those rows back before this file seeded
+// its own. CI never caught it because CI always runs #1 on a fresh checkout.
+//
+// The intermittency ("passes once in four") came from WHEN the flush lands: the
+// file adapter writes on a 2s unref'd autosave timer, so a run short enough to
+// finish first left nothing behind. `flush()` below stands in for that timer, so
+// this pins the property that was actually broken — a federated in-memory pool
+// leaves nothing behind and does not outlive its kernel — without a timing race
+// and without depending on run-to-run state.
+describe('ADR-0062 D1 — the auto-connected in-memory pool leaves nothing behind (#4083)', () => {
+  const STATE_DIR = join(process.cwd(), '.objectstack');
+  const clearState = () => { try { rmSync(STATE_DIR, { recursive: true, force: true }); } catch { /* noop */ } };
+  // Clear on both sides: a leftover from elsewhere would make this pass for the
+  // wrong reason, and a failure that DID write must not leak into the next run
+  // (that leak is the bug under test).
+  beforeAll(clearState);
+  afterAll(clearState);
+
+  async function seedAndRead(kernel: Awaited<ReturnType<typeof boot>>) {
+    const engine = kernel.getService<{
+      getDriverByName(n: string): any;
+      find(object: string, query?: any): Promise<any[]>;
+    }>('data');
+    const driver = engine.getDriverByName('autoconn_ext');
+    await driver.bulkCreate('ext_note', [
+      { id: 'n1', title: 'first' },
+      { id: 'n2', title: 'second' },
+    ]);
+    const titles = (await engine.find('ext_note')).map((r) => r.title).sort();
+    // Whatever the autosave timer would have written, written now.
+    await driver.flush?.();
+    return titles;
+  }
+
+  it('writes no state file, and a second boot in the same process starts empty', async () => {
+    const first = await boot();
+    try {
+      expect(await seedAndRead(first)).toEqual(['first', 'second']);
+      // The seeded rows must not have reached the host filesystem at all.
+      expect(existsSync(STATE_DIR)).toBe(false);
+    } finally {
+      try { await (first as any)?.stop?.(); } catch { /* noop */ }
+    }
+
+    const second = await boot();
+    try {
+      // Was ['first','first','second','second'] — the first boot's rows, reloaded.
+      expect(await seedAndRead(second)).toEqual(['first', 'second']);
+    } finally {
+      try { await (second as any)?.stop?.(); } catch { /* noop */ }
+    }
+  }, BOOT_TIMEOUT);
 });
 
 describe('ADR-0062 credentials fail-closed (D3)', () => {

--- a/packages/services/service-datasource/src/__tests__/default-datasource-driver-factory.test.ts
+++ b/packages/services/service-datasource/src/__tests__/default-datasource-driver-factory.test.ts
@@ -6,7 +6,7 @@
 // kind. These are the first direct tests of the factory's id → driver mapping.
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createDefaultDatasourceDriverFactory } from '../default-datasource-driver-factory.js';
@@ -74,5 +74,96 @@ describe('createDefaultDatasourceDriverFactory — mysql construction', () => {
     // Construction must not open a socket — no connect() was called.
     expect(typeof handle.connect).toBe('function');
     try { await handle.disconnect?.(); } catch { /* pool never opened */ }
+  });
+});
+
+// #4083 — the `memory` id built a bare `new InMemoryDriver()`, inheriting that
+// driver's own `persistence: 'auto'` default: in Node a file adapter at the
+// RELATIVE, process-global path `.objectstack/data/memory-driver.json`. So a
+// "memory" datasource flushed its store into the server's CWD at teardown and
+// reloaded it on the next boot, and every memory pool in the process aliased the
+// same file. That is what made the ADR-0062 D1 federated-read acceptance read 2
+// rows on a clean checkout and 2×N on the Nth run.
+describe('createDefaultDatasourceDriverFactory — memory construction (#4083)', () => {
+  const STATE_DIR = join(process.cwd(), '.objectstack');
+
+  // Nothing here may write to the CWD. Asserting that directory's absence is the
+  // point, so clear it on both sides: a leftover from another test file would
+  // make this pass for the wrong reason, and a failure that DID create it must
+  // not leak into the next run (that leak is the very bug under test).
+  const clearState = () => { try { rmSync(STATE_DIR, { recursive: true, force: true }); } catch { /* noop */ } };
+  beforeAll(clearState);
+  afterAll(clearState);
+
+  async function pool(spec: { name?: string; config?: Record<string, unknown> } = {}) {
+    const handle: any = await factory().create({
+      driver: 'memory',
+      config: spec.config ?? {},
+      ...(spec.name ? { name: spec.name } : {}),
+    });
+    const driver = handle.driver ?? handle;
+    expect(driver?.constructor?.name).toMatch(/InMemoryDriver$/);
+    await handle.connect?.();
+    return { handle, driver };
+  }
+
+  it('is ephemeral: a pool writes nothing to disk and a restart starts empty', async () => {
+    const first = await pool({ name: 'ext' });
+    await first.driver.bulkCreate('ext_note', [{ id: 'n1', title: 'first' }, { id: 'n2', title: 'second' }]);
+    expect(await first.driver.find('ext_note', {})).toHaveLength(2);
+    // Teardown is where the file adapter flushed. It must produce no file…
+    await first.handle.disconnect?.();
+    expect(existsSync(STATE_DIR)).toBe(false);
+
+    // …and the next boot of the SAME datasource must not inherit those rows.
+    const second = await pool({ name: 'ext' });
+    try {
+      expect(await second.driver.find('ext_note', {})).toEqual([]);
+    } finally {
+      await second.handle.disconnect?.();
+    }
+  });
+
+  it('gives two memory datasources independent stores', async () => {
+    const a = await pool({ name: 'ext_a' });
+    const b = await pool({ name: 'ext_b' });
+    try {
+      await a.driver.create('ext_note', { id: 'a1', title: 'only-in-a' });
+      expect(await a.driver.find('ext_note', {})).toHaveLength(1);
+      expect(await b.driver.find('ext_note', {})).toEqual([]);
+    } finally {
+      await a.handle.disconnect?.();
+      await b.handle.disconnect?.();
+    }
+  });
+
+  it("honors the datasource's own memory config (previously dropped entirely)", async () => {
+    const { handle, driver } = await pool({
+      name: 'seeded',
+      config: { initialData: { ext_note: [{ id: 'seed', title: 'from-config' }] }, strictMode: true },
+    });
+    try {
+      const rows = (await driver.find('ext_note', {})) as Array<{ title?: string }>;
+      expect(rows.map((r) => r.title)).toEqual(['from-config']);
+    } finally {
+      await handle.disconnect?.();
+    }
+  });
+
+  it('scopes an OPT-IN persistence destination to the datasource, not the process', async () => {
+    // The one white-box assertion here, and deliberately so: what needs pinning
+    // is the destination handed to the driver, and the alternative (letting two
+    // pools actually write) means writing into the repo checkout's CWD.
+    const { handle, driver } = await pool({ name: 'warehouse', config: { persistence: 'file' } });
+    const persistence = (driver as { config: { persistence: { type?: string; path?: string; key?: string } } }).config.persistence;
+    expect(persistence.type).toBe('file');
+    expect(persistence.path).toBe(join('.objectstack', 'data', 'memory-warehouse.json'));
+    expect(persistence.key).toBe('objectstack:memory-db:warehouse');
+    // Author-supplied destinations are theirs — never rewritten.
+    const explicit = await pool({ name: 'warehouse', config: { persistence: { type: 'file', path: join(tmpdir(), 'os-4083-explicit.json') } } });
+    expect((explicit.driver as { config: { persistence: { path?: string } } }).config.persistence.path)
+      .toBe(join(tmpdir(), 'os-4083-explicit.json'));
+    await handle.disconnect?.();
+    await explicit.handle.disconnect?.();
   });
 });

--- a/packages/services/service-datasource/src/default-datasource-driver-factory.ts
+++ b/packages/services/service-datasource/src/default-datasource-driver-factory.ts
@@ -16,7 +16,8 @@
  *   - `sqlite-wasm` / `wasm-sqlite`    → `@objectstack/driver-sqlite-wasm` (pure-JS)
  *   - `mysql` / `mysql2`               → `@objectstack/driver-sql` (client `mysql2`)
  *   - `mongodb` / `mongo`             → `@objectstack/driver-mongodb` (peer dep)
- *   - `memory` / `inmemory`           → `@objectstack/driver-memory`
+ *   - `memory` / `inmemory`           → `@objectstack/driver-memory` (ephemeral,
+ *     per-datasource — see {@link buildMemoryConfig})
  *
  * `sqlite-wasm` joined for ADR-0062 D1 (#3826): the standalone stack's
  * `default` datasource is a *declared definition* connected through the shared
@@ -30,6 +31,7 @@
  * is never persisted or logged here.
  */
 
+import { join } from 'node:path';
 import type {
   IDatasourceDriverFactory,
   DatasourceConnectionSpec,
@@ -124,6 +126,78 @@ function buildMysqlConnection(spec: DatasourceConnectionSpec): unknown {
     ...(spec.secret ? { password: spec.secret } : cfg.password ? { password: cfg.password } : {}),
     ...(cfg.ssl != null ? { ssl: cfg.ssl } : {}),
   };
+}
+
+/**
+ * Host-composition keys the CLI/standalone stack stamps into a `default`
+ * datasource's `config` for the SQL builders (#3826). They are not memory-driver
+ * config, so they are stripped before the rest of `config` is handed through.
+ */
+const NON_MEMORY_CONFIG_KEYS = ['schemaMode', 'autoMigrate', 'persist'] as const;
+
+/** `.objectstack/data/memory-<datasource>.json` — one file per pool, never one for all. */
+function memoryStatePath(datasource: string): string {
+  return join('.objectstack', 'data', `memory-${datasource}.json`);
+}
+
+/** `objectstack:memory-db:<datasource>` — the localStorage equivalent of the above. */
+function memoryStateKey(datasource: string): string {
+  return `objectstack:memory-db:${datasource}`;
+}
+
+/**
+ * Scope a REQUESTED persistence mode to one datasource.
+ *
+ * `InMemoryDriver`'s own persistence defaults are process-global — one file
+ * (`.objectstack/data/memory-driver.json`), one localStorage key — so two
+ * `driver: 'memory'` datasources in the same process load and save the SAME
+ * store: each sees the other's tables, and the last teardown to flush clobbers
+ * the other's rows. Expanding the string forms (`'auto'`/`'file'`/`'local'`) to
+ * the object form is what lets the default path/key carry the datasource name.
+ * An author-supplied `path`/`key` is theirs and is left alone, as is a custom
+ * `adapter` — they chose the destination.
+ */
+function scopeMemoryPersistence(persistence: unknown, datasource: string): unknown {
+  if (persistence === false) return false;
+  if (typeof persistence === 'string') {
+    return { type: persistence, path: memoryStatePath(datasource), key: memoryStateKey(datasource) };
+  }
+  if (persistence && typeof persistence === 'object' && !('adapter' in persistence)) {
+    const p = persistence as { path?: string; key?: string };
+    return {
+      ...p,
+      ...(p.path ? {} : { path: memoryStatePath(datasource) }),
+      ...(p.key ? {} : { key: memoryStateKey(datasource) }),
+    };
+  }
+  return persistence;
+}
+
+/**
+ * Build the `InMemoryDriver` config for a `memory` datasource (#4083).
+ *
+ * Two things the bare `new InMemoryDriver()` this replaces got wrong:
+ *
+ *  - **It was not ephemeral.** `InMemoryDriver`'s own `persistence` default is
+ *    `'auto'`, which in Node resolves to a file adapter at the *relative* path
+ *    `.objectstack/data/memory-driver.json`. Every memory datasource therefore
+ *    flushed its whole store into the server's CWD at teardown and reloaded it
+ *    on the next boot — the opposite of what this driver id promises the
+ *    operator who asks for it ("ephemeral, not real SQL", see
+ *    `cli/src/utils/storage-driver.ts`), and why the ADR-0062 D1 federated-read
+ *    acceptance read 2 rows on a clean checkout and 2×N on the Nth run (#4083).
+ *  - **Every pool shared one destination.** See {@link scopeMemoryPersistence}.
+ *
+ * So: default to no persistence, honor the datasource's own `config` (dropped on
+ * the floor entirely before — `initialData`/`strictMode` never reached the
+ * driver), and scope the destination per datasource when an author *does* ask
+ * for persistence without naming a path/key of their own.
+ */
+function buildMemoryConfig(spec: DatasourceConnectionSpec): Record<string, unknown> {
+  const cfg = { ...((spec.config ?? {}) as Record<string, unknown>) };
+  for (const key of NON_MEMORY_CONFIG_KEYS) delete cfg[key];
+  if (cfg.persistence === undefined) return { ...cfg, persistence: false };
+  return { ...cfg, persistence: scopeMemoryPersistence(cfg.persistence, spec.name ?? 'default') };
 }
 
 /** Build a mongodb connection URL from a spec's config + secret. */
@@ -256,9 +330,10 @@ export function createDefaultDatasourceDriverFactory(
         return toHandle(driver);
       }
 
-      // memory
+      // memory — ephemeral per datasource unless the author opts into
+      // persistence, and then into a destination of its own (#4083).
       const { InMemoryDriver } = await import('@objectstack/driver-memory');
-      return toHandle(new InMemoryDriver());
+      return toHandle(new InMemoryDriver(buildMemoryConfig(spec)));
     },
   };
 }

--- a/packages/services/service-datasource/src/sqlite-driver-fallback.ts
+++ b/packages/services/service-datasource/src/sqlite-driver-fallback.ts
@@ -189,7 +189,15 @@ export async function resolveSqliteDriver(
   }
 
   // 3. In-memory (mingo) — dev-only last resort. Not real SQL, not persistent.
+  // `persistence: false` is what makes that second half true: the driver's own
+  // default is `'auto'`, which in Node flushes the whole store to
+  // `.objectstack/data/memory-driver.json` in the CWD and reloads it next boot —
+  // a shared file that every memory pool in the process would alias (#4083).
   const { InMemoryDriver } = await import('@objectstack/driver-memory');
   warn(NATIVE_SQLITE_MEMORY_FALLBACK_WARNING);
-  return { driver: new InMemoryDriver(), engine: 'memory', label: 'InMemoryDriver' };
+  return {
+    driver: new InMemoryDriver({ persistence: false }),
+    engine: 'memory',
+    label: 'InMemoryDriver',
+  };
 }


### PR DESCRIPTION
Closes #4083.

## 复核结论：在第二台机器上复现了,而且 CI 绿不是运气,是**结构性**的

在一台全新容器(非 issue 报告者的容器)上复现,并且拿到了和 issue 里**逐字一致**的断言消息:

```
RUN 1(全新 checkout)      → 10 passed          ✅
RUN 2                      → expected [ Array(4) ] to deeply equal [ 'first', 'second' ]
RUN 3                      → expected [ 'first', 'first', 'first', …(3) ] to deeply equal [ 'first', 'second' ]   ← issue 里的那一行
RUN 4(带 -t 只跑这一条)   → …(5) → 8 行
```

行数不是 3 份/6 份拷贝,是**每跑一次 +2**。所以 issue 里的 6 行 = 第 3 次跑,12 行 = 第 6 次跑;"1 次通过 / 3 次失败"就是第 1 次通过、之后再也不会通过。CI 永远是全新 checkout 上的第 1 次运行,所以它永远绿——这条测试保护的 ADR-0062 D1 验收**确实没在保护**。

## 根因:所谓的 "in-memory" driver 会写盘,而且所有 pool 共用同一个文件

跑完第 1 次之后,工作区里多了这个文件:

```
packages/runtime/.objectstack/data/memory-driver.json
{ "ext_note": [ { "id": "n1", "title": "first", … }, { "id": "n2", "title": "second", … } ] }
```

链路是:`createDefaultDatasourceDriverFactory()` 的 `memory` 分支建的是裸的 `new InMemoryDriver()`,于是继承了该 driver 自己的 `persistence: 'auto'` 默认值 —— 在 Node 下解析成一个 `FileSystemPersistenceAdapter`,路径是**相对的、进程全局的** `.objectstack/data/memory-driver.json`。`connect()` 会把文件里的行 load 回 `this.db`,写入会 `markDirty()`,而 flush 发生在 teardown 和一个 2 秒的 unref'd autosave 定时器上。

由此掉出两个缺陷:

1. **它根本不是 ephemeral 的。** `storage-driver.ts:245-247` 明确写着 "an operator asking for `memory` gets the mingo InMemoryDriver (**ephemeral**, not real SQL)" —— 而它其实把整个 store 写进了服务进程的 CWD,下次 boot 再读回来。这就是 2 → 2×N 的来源。
2. **进程内所有 memory pool 共用一个目的地。** 默认路径里没有任何 per-datasource 成分,所以两个 `driver: 'memory'` 的数据源 load/save 的是**同一个文件**:互相看得见对方的表,最后 flush 的那个把对方的行覆盖掉。这个测试里 default driver 和 `autoconn_ext` 就正好是这种关系。新增的测试把它抓了个正着 —— 未修复时 `ext_b` 读到 `['first', 'second', 'only-in-a']`。

issue 里"像是同一份数据被多个 driver 实例重复读出"的方向判断是对的方向,只是机制不在联邦读那一侧,而在 driver 的构造参数上。

**关于"偶发"**:flush 落盘的时机取决于那个 2 秒定时器,所以短到在定时器之前就跑完的那次运行不会留下东西 —— 这就是它看起来像 flaky 而不是像"错了"的原因。整包跑耗时长,定时器更容易触发。

## 改动

- 工厂现在用 **`persistence: false`** 构造 memory pool(默认 ephemeral)。
- 同时**接受数据源自己的 `config`** —— 之前被整个丢掉了,`initialData` / `strictMode` 从来没到达过 driver。
- 作者**确实**要持久化时(`config.persistence`),默认目的地按数据源作用域化:`.objectstack/data/memory-<name>.json` / `objectstack:memory-db:<name>`,pool 之间保持独立。显式写的 `path`/`key` 或自定义 `adapter` 一律原样保留。
- dev-only 的 sqlite step-down 兜底(`resolveSqliteDriver`,#2229)同样处理 —— 它上面那句 "Not real SQL, **not persistent**" 的注释现在才成立。

`InMemoryDriver` 自己的文档化默认值**没有改动**:直接 `new InMemoryDriver()` 仍然自动探测持久化。只有这个工厂构造的 datasource-scoped pool 变了。ADR / spec 未触及,因此没有生成物需要重新生成。

## 测试

新增 4 条工厂测试(ephemeral、pool 相互独立、config 透传、opt-in 目的地作用域化)+ 1 条 runtime 测试,后者钉住真正坏掉的性质:联邦 in-memory pool 不写状态文件,同进程内第二次 boot 从空开始。测试里显式调 `flush()` 顶替那个 autosave 定时器,所以它在**未修复时确定性失败**,而不是靠竞态。

before / after 都验证过:

| | 工厂测试 | runtime 测试 |
|:---|:---|:---|
| 把工厂那一行还原成 `new InMemoryDriver()` | **4 failed** | **1 failed** |
| 带修复 | 10 passed | 11 passed |

连跑 3 次 `datasource-autoconnect.test.ts` 全绿,且工作区不再产生 `.objectstack/`(修复前每次运行都会写)。

已跑的套件:`@objectstack/service-datasource` 158 passed(10 files)、`@objectstack/runtime` 915 passed(65 files)、`@objectstack/driver-memory` 194 passed(7 files)。`@objectstack/cli` 有 15 个文件 collect 失败 + 1 条失败,已确认与本改动无关 —— 原因是这个 worktree 只 build 了 runtime 的依赖图,`@objectstack/lint` 等没有 dist(`Failed to resolve entry for package "@objectstack/lint"`);把本 PR 的改动 `git stash` 掉后同样失败。

## 顺带发现(未在本 PR 处理)

`packages/spec` 的 `MemoryConfigSchema` 声明了 `indexes` 和 `maxRecords`,但 `InMemoryDriverConfig` / `InMemoryDriver` 两者都不读 —— declared ≠ enforced。本 PR 把整个 `config` 透传给 driver(而不是白名单),所以它们至少已经**到达** driver 了;要按 Prime Directive #10 处理的话,应当另开 issue 走 enforce-or-remove。请示意是否需要我开。

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVUpPzE2cJCwGr6H9xjiDT)_