### PR TITLE
docs(docs-audit): record why CHANGELOG.md is NOT added to the drift exclusion

### DIFF
--- a/.changeset/docs-audit-changelog-non-exclusion.md
+++ b/.changeset/docs-audit-changelog-non-exclusion.md
@@ -1,0 +1,18 @@
+---
+---
+
+Docs only — no package changes, nothing to release.
+
+Records why `packages/*/CHANGELOG.md` is **not** added to the docs-drift mapper's test-file
+exclusion (#4091). It reads as the obvious next narrowing and is a provable no-op:
+
+- `chore: version packages` is the only PR class that mass-touches those files, and it runs
+  no GitHub Actions — `changesets/action` opens it with the repo `GITHUB_TOKEN`, which by
+  design triggers no workflow runs. Measured on #3910: one check run, Vercel's own app.
+  The version bump is still verified, just post-merge (`ci.yml` / `lint.yml` on `push: main`,
+  and `release.yml` gates publish on a green build).
+- `changeset version` writes `package.json` beside every `CHANGELOG.md` it appends to
+  (45 vs 46 on page 1 of #3910's diff), so excluding the CHANGELOGs would leave the derived
+  package-root set bit-identical anyway.
+
+Written down so the next reader does not spend a PR rediscovering it as a gap.

--- a/scripts/docs-audit/README.md
+++ b/scripts/docs-audit/README.md
@@ -41,6 +41,24 @@ the PR where it is right. The count of excluded files is reported in the summary
 pins the matcher against paths that must and must not match (`commands/test.ts` is
 implementation; `foo.conformance.test.ts` is not).
 
+**And one deliberate non-exclusion:** `packages/*/CHANGELOG.md` stays counted, even though
+release notes define behaviour no more than a test does. Extending the exclusion there
+looks like the obvious next step and is a provable no-op, for two independent reasons:
+
+1. The only PR class that mass-touches those files is `chore: version packages`, and it
+   runs **no GitHub Actions at all** — `changesets/action` opens it with the repo's
+   `GITHUB_TOKEN`, and GitHub does not trigger workflow runs from `GITHUB_TOKEN`-authored
+   events. Measured on #3910: one check run, from Vercel's own app. So this gate never
+   sees a release PR to be noisy on. (The bump is still verified — `ci.yml` and `lint.yml`
+   both run on `push: main`, and `release.yml` gates publish on a green build.)
+2. Even if it did run, `changeset version` writes `package.json` next to every
+   `CHANGELOG.md` it appends to — 45 of the former against 46 of the latter on the first
+   page of #3910's diff — so dropping the CHANGELOGs would leave the derived package-root
+   set bit-identical.
+
+A hand-edited CHANGELOG outside a release is also close to nonexistent in practice. Left
+counted, and recorded here so the idea is not rediscovered as a gap.
+
 ## 2. CI gate — `.github/workflows/docs-drift-check.yml`
 
 On any PR that touches `packages/**`, runs `affected-docs.mjs` against the base branch


### PR DESCRIPTION
纯文档，无代码改动。把一个「看起来显然该做、实测是空操作」的后续记下来，省掉下一位读者的一个 PR。

## 背景

#4091 让 drift 映射器在推导变更包根之前丢掉测试文件 —— 测试观察行为、不定义行为，改不出实现文档的陈旧。按同一条理由，`packages/*/CHANGELOG.md` 是下一个显然的候选：发布日志定义行为的程度还不如测试。

我本来准备把它做掉。先量了一下，结论是**不该做** —— 两条彼此独立的理由：

### 1. 唯一会批量动这些文件的 PR 类型，压根不跑 Actions

`chore: version packages` 由 `changesets/action` 用仓库自带的 `GITHUB_TOKEN` 开出，而 GitHub 不会为 `GITHUB_TOKEN` 产生的事件创建 workflow run。实测 #3910：**一个** check run，来自 Vercel 自己的 App，零个 Actions。

这不是路径过滤的问题 —— `ci.yml` 是 `pull_request: branches: [main]`、无路径过滤，那个 150 文件的 PR 它无条件匹配，仍然一次没跑。所以 drift 这道闸门根本没机会在 release PR 上吵。

### 2. 就算跑了，包根集合也一模一样

`changeset version` 在每个追加了 `CHANGELOG.md` 的包旁边同时写 `package.json`（#3910 diff 第一页：45 个 package.json 对 46 个 CHANGELOG.md）。`package.json` 不在排除范围内，所以丢掉 CHANGELOG 之后推导出的包根集合逐位相同。

另外，在 release 之外手改 CHANGELOG 的提交实际上近乎不存在。

## 顺带澄清一件容易误读的事

「version PR 上没有任何 check」看着像个洞，其实不是：`ci.yml` 和 `lint.yml` 都挂在 `push: main` 上，`release.yml` 也把 publish 卡在一个绿色的 `pnpm run build` 之后。版本 bump 是被验证的，只是验证发生在合入之后而不是之前 —— 而 bump 只改版本号和内部依赖区间，坏区间会直接让 install/build 挂掉。所以我**没有**为此开 issue：那正是我这个会话里已经拦下三次的假报形状。

## 验证

- `node scripts/docs-audit/affected-docs.mjs --self-test` → 14 cases pass
- 本分支对 `origin/main` → `0 docs affected by 0 changed package(s)`，即 #4091 为「守卫自身被守卫」预期的那条良性结论
- 本 PR 只碰 `scripts/docs-audit/**`，所以 drift 工作流会在它自己身上跑一遍，并贴出 `0 changed package(s) ✅`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoA8AV99Ss1RRkLLAYmDzq


---
_Generated by [Claude Code](https://claude.ai/code/session_01QoA8AV99Ss1RRkLLAYmDzq)_