### PR TITLE
fix(tooling): drop the retired /storage mount from the wildcard gate — main is red

### DIFF
--- a/.changeset/unbreak-wildcard-gate.md
+++ b/.changeset/unbreak-wildcard-gate.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(tooling): drop the retired `/storage` mount from the wildcard fall-through gate (#4116). #4122 added the guard declaring `packages/adapters/hono/src/index.ts:all ${prefix}/storage/*` in its `MOUNTS` ratchet; #4112 had already retired that mount, so the declaration pointed at nothing and the ESLint job failed on `main` — every open PR inheriting a red check it did not cause. Removing the entry is what the guard's own message asks for; nothing is un-ratcheted, because the mount it described no longer exists. Tooling only; releases nothing.

--- a/scripts/check-wildcard-fallthrough.mjs
+++ b/scripts/check-wildcard-fallthrough.mjs
@@ -155,9 +155,6 @@ const MOUNTS = {
   'packages/adapters/hono/src/index.ts:all `${prefix}/auth/*`': {
     ratchet: '#4117 — terminal, same shape as #4088; adapter has no in-repo consumer',
   },
-  'packages/adapters/hono/src/index.ts:all `${prefix}/storage/*`': {
-    ratchet: '#4117 — terminal, same shape as #4088; adapter has no in-repo consumer',
-  },
 };
 
 /** HTTP-verb registrars plus `use`; anything that can claim a path pattern. */


### PR DESCRIPTION
**`main` is currently red, and every open PR inherits it.** Three lines.

## What happened

#4122 added the wildcard fall-through guard with a `MOUNTS` ratchet declaring:

```js
'packages/adapters/hono/src/index.ts:all `${prefix}/storage/*`': {
  ratchet: '#4117 — terminal, same shape as #4088; adapter has no in-repo consumer',
},
```

#4112 (*"retire the /storage dispatcher bridge — it never spoke the storage contract"*) had already removed that mount. What survives at `packages/adapters/hono/src/index.ts:351` is a comment about it:

```ts
// This used to be `app.all(prefix + '/storage/*')` feeding …
```

The two PRs landed in an order that left the declaration pointing at nothing, so the guard fails:

```
✗ wildcard fall-through guard (#4116)

  packages/adapters/hono/src/index.ts:all `${prefix}/storage/*`
    DECLARED but not found by the scan. Moved, renamed or deleted? Update MOUNTS.

1 problem(s).
```

That is the `ESLint` job, which runs `pnpm check:wildcard-fallthrough`. Reproduced on a pristine `origin/main` worktree, and on an unrelated PR branch (objectstack-ai/objectstack#4135, which touches only `packages/spec/src/ui/**`) — this is not caused by any open change.

## The fix

Remove the entry, which is exactly what the guard's own message asks for. Nothing is being un-ratcheted: the mount it described no longer exists, so there is no fall-through left to classify.

## Verification

```
✓ wildcard fall-through: 6 yielding / 1 ratcheted / 5 exempt (12 namespace-claiming mounts)
```

The script's own 15-case self-test (`--self-test`) still passes, and it is the first half of the CI command, so both halves are covered.

No changeset — tooling-only, no published package affected.

Refs #4116, #4122, #4112

🤖 Generated with [Claude Code](https://claude.com/claude-code)