### PR TITLE
docs(formula): say why the RLS check evaluator has no token axis

### DIFF
--- a/packages/formula/src/matches-filter-temporal-conformance.test.ts
+++ b/packages/formula/src/matches-filter-temporal-conformance.test.ts
@@ -27,3 +27,25 @@ describe('matchesFilterCondition — temporal conformance', () => {
     });
   }
 });
+
+/**
+ * Why the token axis is absent here.
+ *
+ * `TemporalCase` carries a `tokenFilter` — the same filter spelled with
+ * `{today}` / `{current_month_end}` placeholders — which the driver and
+ * analytics suites resolve through `resolveFilterTokens` before asserting. This
+ * suite deliberately runs only `c.filter`, and that is an architectural fact
+ * rather than a coverage hole:
+ *
+ * an RLS `check` is a **CEL expression** (`PermissionSet.check` is a string,
+ * compiled by `rlsCompiler.compileFilter`), where a relative date is the
+ * *function* `today()` evaluated during compilation. A `{token}` string never
+ * reaches this evaluator — `resolveFilterTokens` runs on the ObjectQL **read**
+ * path (`engine.ts` resolves `ast.where`), and the write-side check does not go
+ * through it (`plugin-security` never calls the resolver).
+ *
+ * Asserting `tokenFilter` here would therefore test an input this backend
+ * cannot be handed. If that ever changes — if a `check` gains a token-bearing
+ * filter form — this comment is the thing to delete, and the axis is already
+ * sitting in the shared table ready to be consumed.
+ */


### PR DESCRIPTION
#4109 之后的一条小补充——**仅注释，无行为改动**。

## 问题

#4109 给温度一致性矩阵的每个 case 都加了 `tokenFilter`（同一 filter 的 token 拼写），driver 与 analytics 的套件都会先 `resolveFilterTokens` 再断言。`formula` 的套件只跑字面量 `filter`，且**没有任何说明**。

这样读起来像疏漏。下一个看到的人只有两种反应，都是错的：把它当漏测去"补"（会写出一个这个后端根本收不到的输入的测试），或者默认它已被覆盖（而那种覆盖不可能存在）。

## 为什么它不可能有 token 轴（实查，非推断）

RLS `check` 是 **CEL 表达式**——`PermissionSet.check` 是字符串，经 `rlsCompiler.compileFilter` 编译，其中相对日期是**函数** `today()`，在编译期求值。`{token}` 字符串到不了这个求值器：`resolveFilterTokens` 只在 ObjectQL **读**路径运行（`engine.ts` 解析 `ast.where`），写侧 check 不经过它——`plugin-security` 全文没有调用该解析器，这一点我 grep 确认过。

注释里同时写了失效条件：**若将来 `check` 支持带 token 的 filter 形态，删掉这段注释即可，轴已在共享表里备好。**

## 出处

本来是 #4125 的一部分。#4109 在评审期间落地了同一个 token 轴且更全（7 个消费者、16 个 case、`tokenFilter`+`dateRange` 两种拼写、`writerForm` 混合写入形态、pre-epoch 行、legacy-storage sweep），所以 #4125 已**关闭为 superseded**，不做重复实现。这段说明是那轮里 #4109 没有覆盖到的唯一增量，单独带过来。

## 测试

`formula` 该套件 13/13 不变（纯注释）；eslint 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkL3RGJrzjLEGURsLxfS2f

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkL3RGJrzjLEGURsLxfS2f)_