### PR TITLE
docs(agents): the two multi-agent failure modes that cost this branch the most rounds

### DIFF
--- a/.changeset/agents-md-worktree-staleness.md
+++ b/.changeset/agents-md-worktree-staleness.md
@@ -1,0 +1,28 @@
+---
+---
+
+Two additions to AGENTS.md's multi-agent discipline. Deliberately empty
+frontmatter: documentation, this releases nothing.
+
+**#9 — refresh a long-lived worktree's build state after merging `main`.** Four
+distinct stale artefacts each fail *as if your change broke something*, naming
+other people's exports, other packages' files, or config you never touched:
+`packages/spec/dist` (makes `check:api-surface` report someone else's exports as
+breaking, and `check:i18n-coverage` reject a valid example config), `node_modules`
+(a package cannot resolve a dependency it plainly declares), `packages/runtime/
+.objectstack/` (fixture rows accumulating across runs), and `.cache/objectui-*`
+(dozens of lint errors in files you have never opened). None is CI-visible — CI
+checks out fresh — so the cost lands entirely on whoever is debugging. Also notes
+that `OS_SKIP_DTS=1` leaves no `.d.ts`, which makes `gen:api-surface` impossible
+rather than merely slow.
+
+**#10 — a clean merge is not a working merge.** Git conflicts on overlapping
+lines; nothing warns when two changes are individually fine and jointly wrong.
+Both examples are real and recent: a test pinning a response body's exact shape
+landed while that shape was being changed elsewhere, and a domain file was deleted
+while another agent's guard still declared it. The first merged clean and failed
+CI; the second was caught only because the guard existed. Hence: pull `main` and
+re-run before opening a PR, and again before merging.
+
+Written from one branch's lifetime — every row is a failure that cost a debugging
+round, so the list is what was actually hit rather than what might happen.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,37 @@ own worktree, operate defensively:
    up your own instance on a random high port (`pnpm dev -- --fresh -p <random>`)
    and **shut it down yourself when the task is done**
    (`kill $(lsof -ti tcp:<port>)`). Don't leave orphan servers behind.
+9. **After pulling `main` into a long-lived worktree, refresh its build state
+   before you trust a single test or gate.** A worktree that has been open across
+   several merges accumulates artefacts that are stale relative to the source, and
+   every one of them fails **as if your change broke something** — naming other
+   people's exports, other packages' files, or config you never touched:
+
+   | stale artefact | how it presents | why it lies |
+   |---|---|---|
+   | `packages/spec/dist` | `check:api-surface` reports *other people's* exports as "N breaking (removed/narrowed)"; `check:i18n-coverage` rejects an example config for a value the spec allows | both read the built `.d.ts`, not `src/` |
+   | `node_modules` | a package fails to resolve a dependency it plainly declares (`Cannot find package 'hono'`) | the merge moved `pnpm-lock.yaml` |
+   | `packages/runtime/.objectstack/` | `datasource-autoconnect` sees each row 6× | gitignored fixture state accumulating across runs |
+   | `.cache/objectui-*` | `pnpm lint` reports dozens of errors in files you have never opened | a full objectui checkout left by `build-console.sh`, linted as if it were ours |
+
+   So after any `git merge origin/main`:
+   `pnpm install --frozen-lockfile && pnpm build && rm -rf packages/runtime/.objectstack`
+   (add `rm -rf .cache` if you have run the console build). Note `OS_SKIP_DTS=1`
+   keeps a build fast but leaves no `.d.ts`, so `gen:api-surface` cannot run at
+   all under it — that one needs a real build.
+
+   None of this is CI-visible: CI checks out fresh and installs clean. It costs
+   only *your* time, which is exactly why it is worth recognising in one step
+   rather than re-diagnosing per gate.
+10. **A clean merge is not a working merge.** Git conflicts on overlapping lines;
+   nothing warns you when two changes are individually fine and jointly wrong.
+   Real examples from one branch's lifetime: a test asserting a response body's
+   exact shape landed while that shape was being changed elsewhere (merged clean,
+   failed CI); a domain file was deleted while another agent's guard still
+   declared it. **Before opening a PR, and again before merging, pull `main` and
+   re-run the suite** — the second CI round is where these surface, and the guards
+   in `scripts/check-*.mjs` exist largely because this class of breakage is
+   invisible to `git merge`.
 
 ---
 


### PR DESCRIPTION
Docs only — two entries appended to AGENTS.md § *Multi-agent working discipline*. Both written from one branch's lifetime (the #3843 envelope line, 16 PRs), so every row is something that actually happened rather than something that might.

## #9 — refresh a long-lived worktree's build state after merging `main`

Four distinct stale artefacts, each of which fails **as if your change broke something** — naming other people's exports, other packages' files, or config you never touched:

| stale artefact | how it presents |
|---|---|
| `packages/spec/dist` | `check:api-surface` reports *other people's* exports as "5 breaking (removed/narrowed)"; `check:i18n-coverage` rejects an example config for a chart type the spec allows |
| `node_modules` | a package fails to resolve a dependency it plainly declares (`Cannot find package 'hono'`) |
| `packages/runtime/.objectstack/` | `datasource-autoconnect` sees each row 6× |
| `.cache/objectui-*` | `pnpm lint` reports 61 errors in files you have never opened |

I hit the first one **three separate times** before writing it down, and diagnosed it from scratch on two of them. The message that names someone else's export as a breaking change is a genuinely alarming thing to read on your own PR.

Also records that `OS_SKIP_DTS=1` — the flag that keeps local builds fast — leaves no `.d.ts`, so `gen:api-surface` cannot run under it *at all*, failing with `Could not resolve module symbol … Is the package built?`. That reads as a broken build rather than a missing flag.

None of this is CI-visible: CI checks out fresh and installs clean. The entire cost lands on whoever is debugging, which is the argument for recognising it in one step rather than re-diagnosing per gate.

## #10 — a clean merge is not a working merge

Git conflicts on overlapping lines. Nothing warns you when two changes are individually fine and jointly wrong. Two real cases from this branch:

- **#4058** added a test asserting `/ai/agents`'s body is exactly `{ agents: [] }` while #4053 was enveloping that body one commit earlier. Merged clean, failed CI.
- **#4112** deleted `runtime/src/domains/storage.ts` while `check-route-envelope.mjs`'s table still declared it — caught only because that guard exists and treats an undeclared/missing module as an error.

A third was a genuine textual conflict (#4133 and I both removed the same stale ledger entry), and that one git *did* flag — which is the contrast worth internalising: **the conflicts git catches are the ones where two people touched the same line, not the ones where the result is broken.**

So: pull `main` and re-run before opening a PR, and again before merging. Much of `scripts/check-*.mjs` exists precisely because this class of breakage is invisible to `git merge`.

## Verification

`check:doc-authoring` · `check:role-word` · `check:org-identifier` · `check:nul-bytes` · `check:release-notes` — all clean. Empty changeset: docs, releases nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYbS3kS8xzsHNXFTzp4e2z)_