### PR TITLE
fix(plugin-hono-server): current-user 端点改由「拥有该请求的 kernel」应答 (cloud#927)

### DIFF
--- a/.changeset/current-user-endpoints-kernel-resolver.md
+++ b/.changeset/current-user-endpoints-kernel-resolver.md
@@ -1,0 +1,60 @@
+---
+"@objectstack/plugin-hono-server": minor
+---
+
+fix(plugin-hono-server): the current-user endpoints answer from the kernel that OWNS the request (cloud#927)
+
+`/api/v1/auth/me/permissions`, `/auth/me/localization` and `/me/apps` resolved
+their answer from the service locator captured at REGISTRATION time. On a
+single-environment host that is the only kernel, so it is right. On a
+**multi-tenant** host it is the routing shell — and identity is not there.
+cloud's `ArtifactKernelFactory` mounts `AuthPlugin` per environment, and its host
+kernel deliberately has none ("AuthPlugin is intentionally NOT injected on the
+host"), so `getService('auth')` threw, the session resolver fell to its catch, and
+every authenticated tenant caller got `{authenticated:false}`.
+
+That is worse than an error: objectui's `MePermissionsProvider` reads
+`authenticated:false` as ANONYMOUS and keeps its permissive default
+(`return data.authenticated !== true`), because a guest surface has no resolvable
+permissions by design. So the console's FLS / `apiOperations` hints were
+systematically wrong — not a bypass (the server still enforces per request), but
+exactly the client/server divergence `foldWildcardSuperUser` and
+`clampManagedObjectWrites` exist to close, one layer up.
+
+These endpoints now consult the host's ADR-0006 **`kernel-resolver`** seam per
+request — the same seam the runtime dispatcher has used since Phase 5, so
+multi-tenant routing has one strategy rather than two:
+
+- **No `kernel-resolver` registered** → unchanged. Single-environment hosts,
+  `os serve`, and the QA conformance host see no difference.
+- **A kernel** → that kernel's `auth` / `objectql` / `metadata` /
+  `security.permissions` answer.
+- **`undefined`** → the registration-time locator, which is the seam's contract
+  for an unscoped / control-plane request.
+- **A throw** → no answer at all: the thrown status when it carries one (cloud's
+  `KernelWarmingError` is 503 + `Retry-After`), else 503
+  `environment_unavailable`. Falling back to the default kernel would hand back a
+  confidently-wrong `{authenticated:false}` that the client fails OPEN on.
+
+The seam is read **lazily, per request**, never captured at registration — a host
+may register these routes before `kernel.bootstrap()` (to outrank an
+`/api/v1/auth/*` wildcard), which is before the plugin that registers the
+resolver has run its `init()`.
+
+**FROM → TO for host adapters.** `CurrentUserEndpointsContext` gains an optional
+`getKernel(): unknown`, the `defaultKernel` argument the seam takes. A
+`PluginContext` already satisfies it, so hosts that mount `HonoServerPlugin` need
+no change. A host passing a hand-rolled locator to
+`registerCurrentUserEndpoints` should add it:
+
+```diff
+ registerCurrentUserEndpoints({
+   rawApp: httpServer.getRawApp(),
+-  ctx: { getService: (n) => kernel.getService(n) },
++  ctx: { getService: (n) => kernel.getService(n), getKernel: () => kernel },
+ });
+```
+
+Without it a multi-tenant host cannot be asked which kernel owns the request and
+keeps the old provenance — a silent downgrade, so it is worth adding even where
+the host is single-environment today.

--- a/packages/plugins/plugin-hono-server/src/current-user-endpoints-multi-tenant.test.ts
+++ b/packages/plugins/plugin-hono-server/src/current-user-endpoints-multi-tenant.test.ts
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// cloud#927 — WHICH kernel answers the current-user endpoints.
+//
+// These three resolved their answer from the locator captured at REGISTRATION
+// time. On a single-environment host that is the only kernel and therefore
+// right. On a multi-tenant host it is the routing shell: cloud's
+// `ArtifactKernelFactory` mounts `AuthPlugin` per ENVIRONMENT, and its host
+// kernel deliberately has no `auth` at all ("AuthPlugin is intentionally NOT
+// injected on the host"). So `ctx.getService('auth')` threw there, `resolveCtx`
+// fell to its catch, and every authenticated tenant caller got
+// `{authenticated:false}` — which objectui's `MePermissionsProvider` reads as
+// ANONYMOUS and fails OPEN on (`return data.authenticated !== true`). The
+// server still enforces per request, so it was not a bypass; the client's FLS
+// hints were just systematically wrong.
+//
+// The framework already declares the seam for this: `kernel-resolver`
+// (ADR-0006 Phase 5), which the dispatcher has consulted since. These endpoints
+// not consulting it was the defect.
+
+import { describe, it, expect, vi } from 'vitest';
+import { Hono } from 'hono';
+import { registerCurrentUserEndpoints } from './current-user-endpoints';
+
+const ME_PERMISSIONS = '/api/v1/auth/me/permissions';
+const ME_LOCALIZATION = '/api/v1/auth/me/localization';
+const ME_APPS = '/api/v1/me/apps';
+
+/** A kernel stub whose `getService` throws for anything not seeded (like the real one). */
+function kernelWith(services: Record<string, any>) {
+    return {
+        getService: <T,>(name: string): T => {
+            if (!(name in services)) throw new Error(`[Kernel] Service '${name}' not found`);
+            return services[name] as T;
+        },
+    };
+}
+
+/** An `auth` service that resolves one fixed user. */
+const authFor = (userId: string, extra: Record<string, unknown> = {}) => ({
+    api: { getSession: vi.fn(async () => ({ user: { id: userId }, session: extra })) },
+});
+
+/**
+ * Mount on a bare Hono app over `hostServices`. `resolveKernel` is installed as
+ * the host's `kernel-resolver` service — after registration, so the tests also
+ * pin that the seam is read LAZILY (cloud registers these routes before
+ * `kernel.bootstrap()`, i.e. before the plugin that registers the resolver has
+ * run its `init()`; capturing the service at registration time would find
+ * nothing and silently keep the old behaviour).
+ */
+function mount(hostServices: Record<string, any>, resolveKernel?: (...a: any[]) => any) {
+    const app = new Hono();
+    const services: Record<string, any> = { ...hostServices };
+    const kernel = kernelWith(services);
+    const ctx = {
+        logger: { debug() {}, warn() {} },
+        getService: <T,>(name: string): T => kernel.getService<T>(name),
+        getKernel: () => kernel,
+    };
+
+    registerCurrentUserEndpoints({ rawApp: app, ctx });
+
+    // Registered AFTER — the lazy read is what makes this visible.
+    if (resolveKernel) services['kernel-resolver'] = { resolveKernel };
+
+    return { app, kernel, services };
+}
+
+const get = (app: any, path: string) =>
+    app.request(`http://tenant.example.com${path}`, { headers: { host: 'tenant.example.com' } });
+
+describe('the answer comes from the kernel that OWNS the request (cloud#927)', () => {
+    it('a resolved environment kernel answers, not the routing shell', async () => {
+        // The shell has no `auth` — exactly cloud's objectos host.
+        const envKernel = kernelWith({ auth: authFor('usr_env') });
+        const { app } = mount({}, async () => envKernel);
+
+        const res = await get(app, ME_PERMISSIONS);
+
+        expect(res.status).toBe(200);
+        // Before this, the shell's missing `auth` made this `{authenticated:false}`
+        // for every real caller — the fail-open the client then inherited.
+        expect(await res.json()).toMatchObject({ authenticated: true, userId: 'usr_env' });
+    });
+
+    it('prefers the environment kernel over a host that DOES have auth', async () => {
+        // Pins that resolution wins rather than merely filling a gap: a host with
+        // its own identity must not answer for a tenant request.
+        const envKernel = kernelWith({ auth: authFor('usr_env') });
+        const { app } = mount({ auth: authFor('usr_host') }, async () => envKernel);
+
+        expect(await (await get(app, ME_PERMISSIONS)).json()).toMatchObject({ userId: 'usr_env' });
+    });
+
+    it('routes /auth/me/localization and /me/apps through the same resolution', async () => {
+        const envKernel = kernelWith({
+            auth: authFor('usr_env'),
+            objectql: { _registry: { getAllApps: () => [{ name: 'env_app' }] } },
+        });
+        const { app } = mount({}, async () => envKernel);
+
+        expect(await (await get(app, ME_LOCALIZATION)).json()).toMatchObject({ authenticated: true });
+        expect(await (await get(app, ME_APPS)).json()).toEqual({ apps: [{ name: 'env_app' }] });
+    });
+
+    it('hands the resolver the prefix-stripped routePath the dispatcher would', async () => {
+        // cloud's resolver applies its own path policy to `routePath` (control-plane
+        // prefixes skip environment resolution), so the shape has to match.
+        const seen: any[] = [];
+        const envKernel = kernelWith({ auth: authFor('usr_env') });
+        const { app, kernel } = mount({}, async (context: any, defaultKernel: any) => {
+            seen.push({ routePath: context.routePath, isDefault: defaultKernel === kernel, headers: context.request?.headers });
+            return envKernel;
+        });
+
+        await get(app, ME_PERMISSIONS);
+        await get(app, ME_APPS);
+
+        expect(seen.map((s) => s.routePath)).toEqual(['/auth/me/permissions', '/me/apps']);
+        // The seam's second argument is the host kernel, as `KernelResolver` declares.
+        expect(seen.every((s) => s.isDefault)).toBe(true);
+        // Cloud's resolver reads `host` / `x-environment-id` off these.
+        expect(seen[0].headers).toBeInstanceOf(Headers);
+    });
+});
+
+describe('the default kernel still answers where the seam says it should', () => {
+    it('no kernel-resolver at all — single-environment hosts are untouched', async () => {
+        const { app } = mount({ auth: authFor('usr_host') });
+
+        expect(await (await get(app, ME_PERMISSIONS)).json()).toMatchObject({ userId: 'usr_host' });
+    });
+
+    it('resolver returns undefined — the contract for an unscoped request', async () => {
+        const { app } = mount({ auth: authFor('usr_host') }, async () => undefined);
+
+        expect(await (await get(app, ME_PERMISSIONS)).json()).toMatchObject({ userId: 'usr_host' });
+    });
+
+    it('resolver hands back the default kernel itself', async () => {
+        const { app, kernel } = mount({ auth: authFor('usr_host') }, async (_c: any, d: any) => d ?? kernel);
+
+        expect(await (await get(app, ME_PERMISSIONS)).json()).toMatchObject({ userId: 'usr_host' });
+    });
+
+    it('a locator with no getKernel cannot be asked, so it answers itself', async () => {
+        // Documented downgrade, not a neutral choice — a multi-tenant host that
+        // omits `getKernel` gets the old (wrong) provenance back.
+        const app = new Hono();
+        const kernel = kernelWith({ auth: authFor('usr_host'), 'kernel-resolver': { resolveKernel: vi.fn() } });
+        registerCurrentUserEndpoints({
+            rawApp: app,
+            ctx: { logger: { debug() {}, warn() {} }, getService: (n) => kernel.getService(n) },
+        });
+
+        expect(await (await get(app, ME_PERMISSIONS)).json()).toMatchObject({ userId: 'usr_host' });
+    });
+});
+
+describe('a kernel that cannot be reached is a retryable error, never a fake anonymous', () => {
+    it('surfaces a warming 503 with Retry-After', async () => {
+        // cloud's `KernelWarmingError` shape: a cold environment kernel past the
+        // wait budget. AuthProxyPlugin already answers 503 + Retry-After for it.
+        // Only `statusCode` + `retryAfterSeconds` are load-bearing — its `code` is
+        // read for the log line alone, so the fixture omits it rather than carry a
+        // lowercase literal in a `code:` position (ADR-0112 D1).
+        const warming = Object.assign(new Error('kernel warming'), {
+            statusCode: 503, retryAfterSeconds: 4,
+        });
+        const { app } = mount({}, async () => { throw warming; });
+
+        const res = await get(app, ME_PERMISSIONS);
+
+        expect(res.status).toBe(503);
+        expect(res.headers.get('Retry-After')).toBe('4');
+        expect(await res.json()).toMatchObject({ error: 'environment_unavailable' });
+    });
+
+    it('a resolver failure with no status is a 503, not a fall-back to the shell', async () => {
+        // Falling back would answer `{authenticated:false}` off the shell, which the
+        // client reads as anonymous and fails OPEN on — worse than a retryable error.
+        const { app } = mount({ auth: authFor('usr_host') }, async () => { throw new Error('registry down'); });
+
+        const res = await get(app, ME_PERMISSIONS);
+
+        expect(res.status).toBe(503);
+        expect(await res.json()).not.toMatchObject({ authenticated: false });
+    });
+
+    it('applies to all three endpoints', async () => {
+        const { app } = mount({}, async () => { throw new Error('registry down'); });
+
+        for (const path of [ME_PERMISSIONS, ME_LOCALIZATION, ME_APPS]) {
+            expect((await get(app, path)).status, path).toBe(503);
+        }
+    });
+
+    it('passes a 4xx from the resolver through unchanged', async () => {
+        const denied = Object.assign(new Error('nope'), { statusCode: 403 });
+        const { app } = mount({}, async () => { throw denied; });
+
+        expect((await get(app, ME_PERMISSIONS)).status).toBe(403);
+    });
+});

--- a/packages/plugins/plugin-hono-server/src/current-user-endpoints.ts
+++ b/packages/plugins/plugin-hono-server/src/current-user-endpoints.ts
@@ -65,6 +65,30 @@ export const DEFAULT_CURRENT_USER_PREFIX = '/api/v1';
 export interface CurrentUserEndpointsContext {
     getService<T>(name: string): T | undefined;
     logger?: Partial<Pick<Logger, 'debug' | 'warn'>>;
+    /**
+     * The kernel this locator reads from. Optional, and used for ONE thing: it
+     * is the `defaultKernel` argument the host's `kernel-resolver` seam takes
+     * (see {@link resolveRequestContext}). `PluginContext.getKernel` satisfies
+     * it; a host adapter should supply it too. Without it a multi-tenant host
+     * cannot be asked which kernel owns the request, and these endpoints answer
+     * from `getService` — which on such a host is the wrong kernel (#927 is the
+     * cloud-side record of that failure), so omitting it is a downgrade, not a
+     * neutral choice.
+     */
+    getKernel?(): unknown;
+}
+
+/**
+ * Minimal shape of the host's ADR-0006 kernel-resolution seam, as registered
+ * under the `kernel-resolver` service name. Structurally the framework's
+ * `KernelResolver` (`@objectstack/runtime`), declared here rather than imported
+ * so this package keeps no runtime dependency on the dispatcher.
+ */
+export interface KernelResolverLike {
+    resolveKernel(
+        context: { request: { headers: unknown }; routePath?: string; environmentId?: string },
+        defaultKernel: unknown,
+    ): Promise<unknown | undefined> | unknown | undefined;
 }
 
 /** Options for {@link registerCurrentUserEndpoints}. */
@@ -79,6 +103,93 @@ export interface RegisterCurrentUserEndpointsOptions {
     ctx: CurrentUserEndpointsContext;
     /** API prefix. @default '/api/v1' */
     prefix?: string;
+}
+
+/** Body returned when the request's environment kernel cannot be reached. */
+const ENVIRONMENT_UNAVAILABLE = {
+    error: 'environment_unavailable',
+    message: 'The environment serving this request is not available yet. Retry shortly.',
+} as const;
+
+/** A locator over an arbitrary kernel, for the per-request resolution below. */
+function contextForKernel(kernel: any, from: CurrentUserEndpointsContext): CurrentUserEndpointsContext {
+    return {
+        // Sync `getService`, like every other read on this surface. Per-environment
+        // kernels register `auth` / `objectql` / `metadata` /
+        // `security.permissions` as INSTANCES (their plugins register them in
+        // `init()`), so they are in the service map by the time a request arrives.
+        getService: <T>(name: string): T | undefined => kernel?.getService?.(name) as T | undefined,
+        logger: from.logger,
+        getKernel: () => kernel,
+    };
+}
+
+/**
+ * Which kernel's services answer THIS request.
+ *
+ * Single-environment hosts register no `kernel-resolver` and are unchanged: the
+ * registration-time locator is the answer. On a MULTI-TENANT host the seam is
+ * the whole point — identity lives on the per-environment kernel (cloud's
+ * `ArtifactKernelFactory` mounts `AuthPlugin` per environment; its host kernel is
+ * a routing shell with no `auth` at all), so resolving against the host kernel
+ * reports `{authenticated:false}` for every real caller and the console's
+ * permission layer silently falls open. The dispatcher has consulted this seam
+ * since ADR-0006 Phase 5; these three endpoints not consulting it was the defect
+ * (#927).
+ *
+ * Resolution is LAZY — the service is read per request, never captured at
+ * registration — because a host may register these routes before
+ * `kernel.bootstrap()` (to outrank an auth wildcard), which is before the plugin
+ * that registers the resolver has run its `init()`.
+ *
+ * Four outcomes, and the two failure ones are deliberate:
+ *   - no resolver (or no `getKernel`) → the registration-time locator.
+ *   - a kernel → that kernel's services. THE fix.
+ *   - `undefined` → the registration-time locator. That is the seam's contract
+ *     for "unscoped / control-plane / single-environment request", and on such a
+ *     host the default kernel really is the right answer.
+ *   - a throw → **no answer at all**, surfaced as the thrown status when it
+ *     carries one (cloud's `KernelWarmingError` is a 503 + `Retry-After`) else
+ *     503. Falling back to the default kernel here would hand back a
+ *     confidently-wrong `{authenticated:false}`, which the client reads as
+ *     "anonymous" and fails OPEN on — strictly worse than a retryable error.
+ */
+async function resolveRequestContext(
+    c: any,
+    ctx: CurrentUserEndpointsContext,
+    prefix: string,
+): Promise<{ ctx: CurrentUserEndpointsContext } | { response: Response }> {
+    const resolver = (() => {
+        try { return ctx.getService<KernelResolverLike>('kernel-resolver'); } catch { return undefined; }
+    })();
+    if (typeof resolver?.resolveKernel !== 'function' || typeof ctx.getKernel !== 'function') {
+        return { ctx };
+    }
+    const defaultKernel = ctx.getKernel();
+    // `routePath` is the API-prefix-stripped path, matching what the dispatcher
+    // hands the resolver — cloud's resolver applies its own path policy to it
+    // (control-plane prefixes skip environment resolution).
+    const path: string = c.req.path ?? '';
+    const routePath = path.startsWith(prefix) ? path.slice(prefix.length) || '/' : path;
+    try {
+        const resolved = await resolver.resolveKernel(
+            { request: { headers: c.req.raw.headers }, routePath },
+            defaultKernel,
+        );
+        if (!resolved || resolved === defaultKernel) return { ctx };
+        return { ctx: contextForKernel(resolved, ctx) };
+    } catch (err: any) {
+        const status = typeof err?.statusCode === 'number' && err.statusCode >= 400 && err.statusCode <= 599
+            ? err.statusCode
+            : 503;
+        ctx.logger?.warn?.('[hono] current-user endpoint: environment resolution failed', {
+            err: err?.message, code: err?.code, status, routePath,
+        });
+        if (typeof err?.retryAfterSeconds === 'number' && err.retryAfterSeconds > 0) {
+            try { c.header('Retry-After', String(Math.ceil(err.retryAfterSeconds))); } catch { /* best effort */ }
+        }
+        return { response: c.json(ENVIRONMENT_UNAVAILABLE, status) };
+    }
 }
 
 /** The three route paths this module owns, under `prefix`. */
@@ -520,7 +631,28 @@ export function registerCurrentUserEndpoints(
         ctx.logger?.debug?.('Current-user endpoints already registered — skipping', { prefix });
         return false;
     }
-    const resolveCtx = makeExecutionContextResolver(ctx);
+    /**
+     * Wrap a handler so it runs against the kernel that OWNS the request.
+     *
+     * The handler's `ctx` parameter deliberately shadows the registration-time
+     * locator: every `ctx.getService(...)` in the bodies below then reads the
+     * per-request kernel on a multi-tenant host and the same kernel as before on
+     * a single-environment one, with no per-read plumbing to keep in sync. Same
+     * for `resolveCtx` — the caller's identity must be resolved from the kernel
+     * that owns the session, not the routing shell in front of it.
+     */
+    const withRequestContext = (
+        handler: (
+            c: any,
+            ctx: CurrentUserEndpointsContext,
+            resolveCtx: ReturnType<typeof makeExecutionContextResolver>,
+        ) => Promise<Response>,
+    ) => async (c: any): Promise<Response> => {
+        const resolution = await resolveRequestContext(c, ctx, prefix);
+        if ('response' in resolution) return resolution.response;
+        return handler(c, resolution.ctx, makeExecutionContextResolver(resolution.ctx));
+    };
+
     // Effective permissions for the current user — single aggregation
     // endpoint that resolves session → roles → permission sets → merged
     // field/object permissions. Frontend Field-Level Security (FLS)
@@ -538,7 +670,7 @@ export function registerCurrentUserEndpoints(
     //
     // Returns `{authenticated:false}` (200) when no session is
     // present, so the frontend can distinguish anon from error.
-    rawApp.get(`${prefix}/auth/me/permissions`, async (c: any) => {
+    rawApp.get(`${prefix}/auth/me/permissions`, withRequestContext(async (c, ctx, resolveCtx) => {
         const execCtx = await resolveCtx(c);
         if (!execCtx?.userId) {
             return c.json({ authenticated: false });
@@ -738,7 +870,7 @@ export function registerCurrentUserEndpoints(
             ctx.logger?.warn?.('[hono] /auth/me/permissions failed', { err: err?.message });
             return c.json({ authenticated: true, userId: execCtx.userId, objects: {}, fields: {} });
         }
-    });
+    }));
 
     // GET /me/localization — the resolved regional defaults (currency /
     // locale / timezone) for the current request's tenant, exposed to EVERY
@@ -746,7 +878,7 @@ export function registerCurrentUserEndpoints(
     // `setup.access`, but the resolved defaults are needed by every renderer
     // to format currency/dates/numbers — so they ride on the request
     // ExecutionContext (ADR-0053) and are surfaced here without that gate.
-    rawApp.get(`${prefix}/auth/me/localization`, async (c: any) => {
+    rawApp.get(`${prefix}/auth/me/localization`, withRequestContext(async (c, ctx, resolveCtx) => {
         const execCtx = await resolveCtx(c);
         if (!execCtx?.userId) {
             return c.json({ authenticated: false });
@@ -757,7 +889,7 @@ export function registerCurrentUserEndpoints(
             locale: execCtx.locale ?? null,
             timezone: execCtx.timezone ?? null,
         });
-    });
+    }));
 
     // GET /me/apps — list apps the current user is allowed to enter.
     // Apps live in the ENGINE REGISTRY (runtime AppPlugin registerApp()),
@@ -771,7 +903,7 @@ export function registerCurrentUserEndpoints(
     //   2. ctx.tabPermissions[app.name] !== 'hidden'
     // Anonymous users get an empty array. When SecurityPlugin is absent
     // we fail-open and return every app (matches server behaviour).
-    rawApp.get(`${prefix}/me/apps`, async (c: any) => {
+    rawApp.get(`${prefix}/me/apps`, withRequestContext(async (c, ctx, resolveCtx) => {
         const execCtx = await resolveCtx(c);
         if (!execCtx?.userId) return c.json({ apps: [] });
         try {
@@ -870,7 +1002,7 @@ export function registerCurrentUserEndpoints(
             ctx.logger?.warn?.('[hono] /me/apps failed', { err: err?.message });
             return c.json({ apps: [] });
         }
-    });
+    }));
     ctx.logger?.debug?.('Registered current-user endpoints', { prefix });
     return true;
 }


### PR DESCRIPTION
cloud#927 的框架侧。#4144 补的是"**有没有**提供者"，这条是"**哪个 kernel** 提供"——两件不同的事，后者在多租户宿主上一直是错的。

## 问题：注册期的定位器 ≠ 拥有该请求的 kernel

这三条端点从**注册时**捕获的服务定位器解析答案。单环境宿主上那就是唯一的 kernel，因此正确。**多租户**宿主上那是路由外壳，而身份不在那里：

- cloud 的 `ArtifactKernelFactory` 把 `AuthPlugin` 挂在**每个环境**的 kernel 上（per-project HKDF secret）；
- 宿主 kernel 刻意不挂 —— `objectos-stack.ts` 原话："AuthPlugin is intentionally NOT injected on the host"；
- 全仓 `registerService('auth', …)` 只有 `plugin-auth` 一处。

于是 `ctx.getService('auth')` 在宿主上抛错 → `resolveCtx` 落到 catch → 返回 `undefined` → 端点走匿名分支：

```
GET https://os-<id>.objectos.app/api/v1/auth/me/permissions
→ 200 {"authenticated": false}          // 无论调用者是谁、有没有登录
```

**这比报错更糟**：objectui 的 `MePermissionsProvider` 把 `authenticated:false` 当作**匿名**并保持宽松默认（`return data.authenticated !== true`）—— 匿名/公开面没有可解析的权限是设计使然，锁死每个字段会把公开表单弄坏。所以已登录 tenant 用户的 console，其 FLS / `apiOperations` 提示是**系统性错误**的。不是权限绕过（ADR-0057 D10 起服务端才是权威闸门，仍然逐请求强制），但正是 `foldWildcardSuperUser` / `clampManagedObjectWrites` 那一整套整形逻辑存在的目的（让客户端提示与服务端实际强制一致），只不过错在上一层。

## 改法：走宿主已有的 `kernel-resolver` 缝

框架早就为这件事声明了规范缝：`kernel-resolver`（ADR-0006 Phase 5），dispatcher 从那时起一直在用。**这三条端点不查它，才是缺陷本身。** 现在改为逐请求查询，多租户路由从此只有一份策略而不是两份。

四种结果，两条失败路径都是刻意的：

| resolver | 行为 |
|:---|:---|
| **未注册** | 不变。单环境宿主、`os serve`、QA conformance 宿主零差异。 |
| 返回一个 kernel | 用**那个** kernel 的 `auth`/`objectql`/`metadata`/`security.permissions` 应答。**这就是修复。** |
| 返回 `undefined` | 用注册期定位器 —— 这正是该缝对"无 scope／控制面请求"的契约，那种宿主上默认 kernel 确实是对的答案。 |
| **抛错** | **不给答案**：错误自带 status 就用它（cloud 的 `KernelWarmingError` 是 503 + `Retry-After`），否则 503 `environment_unavailable`。退回默认 kernel 会交回一个自信而错误的 `{authenticated:false}`，客户端据此 fail-OPEN —— 严格劣于一个可重试的错误。 |

**逐请求惰性读取**，绝不在注册时捕获：宿主可能在 `kernel.bootstrap()` **之前**注册这些路由（为了抢在 `/api/v1/auth/*` 通配之前，见 cloud#924），而那早于注册 resolver 的插件跑 `init()`。测试里 resolver 是**在** `registerCurrentUserEndpoints` 之后才装进服务表的，正是为了钉住这一点。

三个 handler 用一层包装，让逐请求定位器**遮蔽**（shadow）注册期的 `ctx` —— handler 体一行未改，而不是逐个读去穿参数。

## 影响面 / FROM → TO

`CurrentUserEndpointsContext` 增加可选 `getKernel(): unknown`，即该缝需要的 `defaultKernel`。`PluginContext` 本来就满足，所以**挂 `HonoServerPlugin` 的宿主无需改动**；自己手写定位器的宿主应该补上：

```diff
 registerCurrentUserEndpoints({
   rawApp: httpServer.getRawApp(),
-  ctx: { getService: (n) => kernel.getService(n) },
+  ctx: { getService: (n) => kernel.getService(n), getKernel: () => kernel },
 });
```

不补的话，多租户宿主问不到"谁拥有这个请求"，就退回旧的（错误的）来源 —— 是**静默降级**而非中性选择，所以即使当下是单环境也值得补。

## 已知代价（issue 里点名要求评估的两条）

多租户宿主上每个这三条的请求现在都会走一次 `resolveKernel`，对 cloud 而言就是 `resolveByHostname`（冷分片会构建 tenant driver，可能数秒）+ `KernelManager.getOrCreate`（可能冷建 kernel）。两点判断：

1. **不是新增开销**：console 的其余数据调用本来就全部经过 dispatcher，走的是同一个缝。轮到取权限时环境 kernel 通常已经热。
2. **冷的时候答案是诚实的**：503 + `Retry-After` 正是同一宿主上 `/api/v1/auth/*`（`AuthProxyPlugin`）和 dispatcher 已经在给的形状，客户端可以重试；而旧行为是一个不可重试、静默 fail-open 的 200。

> 顺带记一笔（**不在本 PR 范围**）：objectui 的 `MePermissionsProvider` 在 fetch 失败时渲染 `errorFallback ?? loadingFallback`，而 console 没传 `errorFallback` —— 所以 503 期间 console 停在 LoadingScreen 而不会自动重试。它已经暴露了 `retry`，接上是 objectui 侧一个独立的小改动。

## 验证

| 范围 | 结果 |
|:---|:---|
| `plugin-hono-server` 全量 | 13 files / **149 passed**（新增 12） |
| `turbo run test --affected` | **73/73 packages** |
| ESLint job 全部门禁（含 `check:authz-resolver`、`check:wildcard-fallthrough`、`check:error-code-casing`） | PASS |
| `packages/spec` 八个生成物门禁 | PASS |
| `tsc --noEmit` | clean |

新增 12 例：

- 解析出的**环境 kernel 应答**（旧行为在这里是 `{authenticated:false}`）；
- 且在宿主**自己也有 `auth`** 时仍然**优先环境 kernel** —— 钉住"这是解析取胜"而不只是"填了个空洞"；
- 三条端点都走同一解析；
- resolver 收到的是**去掉 prefix 的 `routePath`**（cloud 的 resolver 对它施加控制面跳过策略）、第二参是**宿主 kernel**、headers 是真的 `Headers`；
- 未注册 resolver／返回 `undefined`／返回默认 kernel／没有 `getKernel` —— 四种都保持旧答案；
- warming 503 带 `Retry-After: 4`；
- 无 status 的失败是 503，并**显式断言不是** `{authenticated:false}`；
- resolver 抛 4xx 原样透传。

## 关联

- cloud#927（本 PR 的 issue）、cloud#924 / cloud#928（补上 serverless 路径的提供者，本 PR 的前置）；
- #4144（导出注册面）、#4073 / #4079、ADR-0006 Phase 5（`KernelResolver` 缝）。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gEeLZ4oTeSXG6fKG1r3vd


---
_Generated by [Claude Code](https://claude.ai/code/session_016gEeLZ4oTeSXG6fKG1r3vd)_