### PR TITLE
fix(data): reject unknown list query params instead of reading them as zero-matching filters (#4134)

### DIFF
--- a/.changeset/rest-list-unknown-query-params.md
+++ b/.changeset/rest-list-unknown-query-params.md
@@ -1,0 +1,40 @@
+---
+"@objectstack/metadata-protocol": patch
+"@objectstack/rest": patch
+---
+
+fix(data): reject unknown list query parameters instead of reading them as zero-matching field filters (#4134)
+
+`GET /api/v1/data/:object` reads any parameter it does not reserve as a
+field-level equality filter — that is what makes `?status=done` shorthand for
+`?filter={"status":"done"}`. When the name matched **no** field the resulting
+predicate could only ever match nothing, so `?pageSize=5` on a 10-row object
+returned `200` + `total: 0`: structurally valid, and indistinguishable from
+"this object is empty". The write path already rejected the same unknown name
+loudly (`400 INVALID_FIELD`), so one piece of knowledge — does this field
+exist — was enforced on write and silently zeroed on read.
+
+The read path now answers the same way, in the same envelope:
+
+```json
+{
+  "error": "Unknown field 'pageSize' on object 'showcase_task'. Query parameters that are not reserved are read as field filters, so an unknown name can only match zero records. Did you mean the 'top' query parameter (OData spelling '$top')?",
+  "code": "INVALID_FIELD",
+  "field": "pageSize",
+  "object": "showcase_task"
+}
+```
+
+The rejection carries a suggestion — the canonical parameter for a known
+dialect (`pageSize` / `perPage` / `page` / `sortBy` / `q` → `top` / `skip` /
+`sort` / `search`), or the closest real field name when it reads like a typo —
+and fires whether or not an explicit `filter` rode along, so the failure never
+depends on which other parameters were sent.
+
+**What changes for callers:** a request sending a parameter that names no field
+now gets a `400` where it used to get an empty `200`. Page size is `top` /
+`$top` / `limit`; page offset is `skip` / `$skip` / `offset`. Every documented
+parameter, every `$`-prefixed OData alias, and the full `QueryAST` body of
+`POST /data/:object/query` are unaffected. An object with a field named after a
+reserved parameter (`count`, `cursor`, `object`, `top`, `search`, …) filters it
+through the explicit form: `?filter={"count":3}`.

--- a/content/docs/api/data-api.mdx
+++ b/content/docs/api/data-api.mdx
@@ -28,6 +28,35 @@ Query records with filtering, sorting, selection, and pagination.
 
 > **Note:** OData-style `$`-prefixed parameters (`$filter`, `$select`, `$orderby`, `$top`, `$skip`, `$expand`, `$count`, `$search`) are also accepted directly on this same endpoint as aliases — they're normalized internally to the parameter names above. There is no separate standalone OData endpoint.
 
+#### Any other parameter is a field filter — and must name a real field
+
+A query parameter the endpoint does not reserve is read as a field-level
+equality filter, so `?status=done` is shorthand for
+`?filter={"status":"done"}`. Because such a parameter *is* a predicate, one
+naming a field the object does not have could only ever match zero records —
+so the endpoint rejects it instead of returning an empty page:
+
+```http
+GET /api/v1/data/showcase_task?pageSize=5
+```
+```json
+{
+  "error": "Unknown field 'pageSize' on object 'showcase_task'. Query parameters that are not reserved are read as field filters, so an unknown name can only match zero records. Did you mean the 'top' query parameter (OData spelling '$top')?",
+  "code": "INVALID_FIELD",
+  "field": "pageSize",
+  "object": "showcase_task"
+}
+```
+
+This is the same `400 INVALID_FIELD` the write path returns for an unknown
+field name, and it applies whether or not an explicit `filter` rode along.
+Page size is `top` / `$top` / `limit` — `pageSize`, `page_size` and `perPage`
+are not accepted spellings.
+
+Reserved names cannot double as implicit filters. An object with a field
+literally called `count`, `cursor`, `distinct`, `object`, `search` or `top`
+filters it through the explicit form (`?filter={"count":3}`).
+
 **Response**:
 ```json
 {

--- a/content/docs/api/error-catalog.mdx
+++ b/content/docs/api/error-catalog.mdx
@@ -71,8 +71,14 @@ ObjectStack uses a structured error system with **9 error categories** and **53 
 ```
 
 ### `INVALID_FIELD`
-**Cause:** A field name in the request does not exist on the target object.  
-**Fix:** Check the object schema for valid field names. Use `os meta get object <name>` to inspect the object's fields.  
+**Cause:** A field name in the request does not exist on the target object. On a
+list read this also covers an unreserved query parameter — `GET /data/:object`
+reads those as field filters, so one naming no field could only match zero
+records and is rejected rather than answered with an empty page.  
+**Fix:** Check the object schema for valid field names. Use `os meta get object <name>` to inspect the object's fields. If the name was meant as a
+*parameter* rather than a field, use the real one — page size is `top` / `$top`
+/ `limit`, not `pageSize` / `perPage`; the response's `error` names the
+substitute. See the [Data API](/docs/api/data-api).  
 **Retry:** `no_retry`
 
 ### `MISSING_REQUIRED_FIELD`

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -18,7 +18,7 @@ import type {
 } from '@objectstack/spec/api';
 import type { MetadataCacheRequest, MetadataCacheResponse, ServiceInfo, ApiRoutes, WellKnownCapabilities } from '@objectstack/spec/api';
 import { readServiceSelfInfo } from '@objectstack/spec/api';
-import { parseFilterAST, isFilterAST, type DroppedFieldsEvent } from '@objectstack/spec/data';
+import { parseFilterAST, isFilterAST, type DroppedFieldsEvent, type QueryAST } from '@objectstack/spec/data';
 import { PLURAL_TO_SINGULAR, SINGULAR_TO_PLURAL } from '@objectstack/spec/shared';
 import { type FormView, isAggregatedViewContainer } from '@objectstack/spec/ui';
 import { METADATA_FORM_REGISTRY } from '@objectstack/spec/system';
@@ -710,6 +710,149 @@ function mergeDroppedFieldEvents(events: DroppedFieldsEvent[]): DroppedFieldsEve
         for (const f of ev.fields) bucket.fields.add(f);
     }
     return Array.from(byKey.values()).map((b) => ({ object: b.object, fields: Array.from(b.fields), reason: b.reason }));
+}
+
+/**
+ * The canonical `QueryAST` surface (`spec/data/query.zod.ts`), enumerated.
+ *
+ * Typed as `Record<keyof QueryAST, true>` so `tsc` pins it to the spec in BOTH
+ * directions: a key added there is a missing-property error here, a key removed
+ * there is an excess-property error here. That matters because the set below
+ * decides what is a query parameter and what is a field filter — silently
+ * drifting from the AST would resurrect exactly the #4134 failure for whatever
+ * key was added.
+ */
+const QUERY_AST_KEYS: Readonly<Record<keyof QueryAST, true>> = {
+    object: true, fields: true, where: true, search: true, orderBy: true,
+    limit: true, offset: true, top: true, cursor: true, joins: true,
+    aggregations: true, groupBy: true, having: true, windowFunctions: true,
+    distinct: true, expand: true,
+};
+
+/**
+ * [#4134] Every query-parameter name `findData` consumes itself, consulted
+ * AFTER the alias normalization in `findData` has run — so the wire spellings
+ * that get rewritten (`$top`→`top`→`limit`, `select`→`fields`, `sort`→
+ * `orderBy`, `filter`/`filters`/`$filter`→`where`, `populate`/`$expand`→
+ * `expand`, `skip`→`offset`, …) are already gone by this point and
+ * deliberately do NOT appear here. Anything still standing is either a name in
+ * this set or a candidate field filter.
+ *
+ * The structural AST keys (`object`, `joins`, `having`, `windowFunctions`)
+ * matter even though no querystring carries them: `POST /data/:object/query`
+ * hands its body in as `query`, and that body IS a `Partial<QueryAST>`. Without
+ * them, `client.data.query('task', { object: 'task', limit: 5 })` would have
+ * its `object` key read as a filter and match zero rows.
+ *
+ * A name in this set can never be used as an implicit field filter, so an
+ * object with a field genuinely called e.g. `count` or `cursor` must filter it
+ * through the explicit form (`?filter={"count":3}`). That trade-off predates
+ * #4134 for the original members; it is called out here so the next person to
+ * add one knows what they are spending.
+ */
+const RESERVED_LIST_QUERY_PARAMS: ReadonlySet<string> = new Set([
+    ...Object.keys(QUERY_AST_KEYS),
+    // Transport-only extras the normalizer consumes but the AST does not name.
+    'count',        // ?count / $count — response flag, not a projection
+    'searchFields', // ?searchFields / $searchFields — ADR-0061 override
+    // Server-derived, never caller input (stripped then re-set from `request`).
+    'context',
+]);
+
+/**
+ * [#4134] High-frequency wrong guesses → the parameter that actually works.
+ * Keys are normalized (lower-cased, `_`/`-` stripped) so `pageSize`,
+ * `page_size` and `PAGE-SIZE` all land on the same entry.
+ *
+ * This is a HINT table, not an alias table: nothing here is accepted as input.
+ * Adding an entry makes a rejection more helpful; it never makes a request
+ * succeed, so it does not create the second de-facto contract Prime Directive
+ * #12 warns about.
+ */
+const QUERY_PARAM_NEAR_MISS: Readonly<Record<string, string>> = {
+    // page-size dialects (the #4134 repro: `?pageSize=5` → 200 + empty list)
+    pagesize: 'top', persize: 'top', perpage: 'top', pagelimit: 'top',
+    rowsperpage: 'top', pagecount: 'top', size: 'top', take: 'top',
+    first: 'top', max: 'top', maxresults: 'top', maxrecords: 'top',
+    // page-offset dialects
+    page: 'skip', pageno: 'skip', pagenum: 'skip', pagenumber: 'skip',
+    pageindex: 'skip', start: 'skip', startindex: 'skip', startat: 'skip',
+    // sorting
+    sortby: 'sort', sortfield: 'sort', sortorder: 'sort', order: 'sort',
+    ordering: 'sort',
+    // search
+    q: 'search', keyword: 'search', keywords: 'search', term: 'search',
+    searchterm: 'search', querytext: 'search',
+    // filtering
+    filterby: 'filter', criteria: 'filter', conditions: 'filter',
+    // projection / relations
+    columns: 'select', include: 'expand', includes: 'expand', with: 'expand',
+};
+
+/**
+ * The OData spelling of each parameter {@link QUERY_PARAM_NEAR_MISS} points at.
+ * NOT derivable by prefixing `$` — `sort` is `$orderby`, and suggesting a
+ * `$sort` that the unsupported-`$` guard rejects would just hand the caller a
+ * second 400.
+ */
+const ODATA_SPELLING: Readonly<Record<string, string>> = {
+    top: '$top', skip: '$skip', sort: '$orderby', search: '$search',
+    filter: '$filter', select: '$select', expand: '$expand',
+};
+
+/** Fold a parameter name to its near-miss lookup key. */
+function nearMissKey(name: string): string {
+    return name.toLowerCase().replace(/[_-]/g, '');
+}
+
+/** Levenshtein distance, bailed out early once it exceeds `max`. */
+function editDistance(a: string, b: string, max: number): number {
+    if (Math.abs(a.length - b.length) > max) return max + 1;
+    let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+    for (let i = 1; i <= a.length; i++) {
+        const row = [i];
+        let best = i;
+        for (let j = 1; j <= b.length; j++) {
+            const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+            row[j] = Math.min(prev[j] + 1, row[j - 1] + 1, prev[j - 1] + cost);
+            if (row[j] < best) best = row[j];
+        }
+        if (best > max) return max + 1;
+        prev = row;
+    }
+    return prev[b.length];
+}
+
+/**
+ * [#4134] Actionable tail for an unknown list query parameter: the canonical
+ * spelling when the caller used a known dialect (`pageSize` → `$top`), else the
+ * closest real field name when it reads like a typo (`stauts` → `status`).
+ * Returns `''` when nothing is close enough to be worth guessing.
+ */
+function suggestQueryParam(param: string, knownFields: readonly string[]): string {
+    const canonical = QUERY_PARAM_NEAR_MISS[nearMissKey(param)];
+    if (canonical) {
+        const odata = ODATA_SPELLING[canonical];
+        return ` Did you mean the '${canonical}' query parameter`
+            + (odata ? ` (OData spelling '${odata}')` : '')
+            + '?';
+    }
+    const folded = nearMissKey(param);
+    // Only worth guessing for names long enough that a small distance is
+    // meaningful — at 3 chars everything is within 2 edits of everything.
+    if (folded.length >= 4) {
+        const max = folded.length <= 5 ? 1 : 2;
+        let best: string | undefined;
+        let bestDistance = max + 1;
+        for (const field of knownFields) {
+            const d = editDistance(folded, nearMissKey(field), max);
+            if (d < bestDistance) { bestDistance = d; best = field; }
+        }
+        if (best !== undefined && bestDistance <= max) {
+            return ` Did you mean the field '${best}'?`;
+        }
+    }
+    return '';
 }
 
 /**
@@ -2781,6 +2924,57 @@ export class ObjectStackProtocolImplementation implements
         throw err;
     }
 
+    /**
+     * [#4134] Read-path unknown-field gate for the implicit filters `findData`
+     * derives from leftover query parameters.
+     *
+     * Rejects with the SAME envelope the write path produces for the same
+     * mistake — `400 INVALID_FIELD` + `field` + `object` (see `mapDataError` in
+     * `@objectstack/rest`) — so "does this field exist" has one answer on both
+     * sides of the API instead of being enforced on write and silently
+     * zeroed on read.
+     *
+     * Tiering mirrors {@link assertObjectRegistered}, one level down:
+     *
+     * - **Schema present with a field map → authoritative.** An unlisted name
+     *   is a 400. The registry injects the audit/tenant/owner columns
+     *   (`created_at`, `created_by`, `updated_at`, `updated_by`,
+     *   `organization_id`, `owner_id`) into `fields`, so those filter normally;
+     *   `id` is added here because it is the primary key rather than a declared
+     *   field. Dotted paths are judged on their head segment only
+     *   (`owner_id.name`), matching how `engine.find()` validates projections.
+     * - **No registry, or a schema with no field map → skip.** Nothing to check
+     *   against (registry-less Lite/edge hosts, engine doubles, external
+     *   datasources whose columns are not mirrored locally). The
+     *   object-existence gate above already warns once when the registry itself
+     *   is missing, so this stays quiet rather than warning twice per process.
+     */
+    private assertQueryParamsAreFields(object: string, params: readonly string[]): void {
+        const schema: any = this.engine?.registry?.getObject?.(object);
+        const declared = schema?.fields;
+        if (!declared || typeof declared !== 'object') return;
+        const fieldNames = Object.keys(declared);
+        if (fieldNames.length === 0) return;
+        const known = new Set(fieldNames);
+        known.add('id');
+        const unknown = params.filter((p) => !known.has(String(p).split('.')[0]));
+        if (unknown.length === 0) return;
+        const first = unknown[0];
+        const err: any = new Error(
+            `Unknown field '${first}' on object '${object}'`
+            + (unknown.length > 1 ? ` (also: ${unknown.slice(1).join(', ')})` : '')
+            + '. Query parameters that are not reserved are read as field filters, so an '
+            + 'unknown name can only match zero records.'
+            + suggestQueryParam(first, fieldNames),
+        );
+        err.code = 'INVALID_FIELD';
+        err.status = 400;
+        err.field = first;
+        err.fields = unknown;
+        err.object = object;
+        throw err;
+    }
+
     async findData(request: { object: string, query?: any, context?: any }) {
         // [#3770] Existence first: an unregistered object is a 404 before any
         // query parameter is even parsed, so an unknown name can never be
@@ -2849,8 +3043,12 @@ export class ObjectStackProtocolImplementation implements
         }
         if (options.skip != null) {
             options.offset = Number(options.skip);
-            delete options.skip;
         }
+        // Deleted unconditionally, unlike `top` (a declared QueryAST key the
+        // engine aliases itself): `skip` is wire-only, so a null/undefined one
+        // left behind would reach the #4134 field gate below and be reported as
+        // an unknown FIELD — a confusing rejection for a real parameter.
+        delete options.skip;
         if (options.limit != null) options.limit = Number(options.limit);
         if (options.offset != null) options.offset = Number(options.offset);
 
@@ -2965,32 +3163,48 @@ export class ObjectStackProtocolImplementation implements
             throw err;
         }
 
+        // [#4134] A leftover key is about to be lowered into a field-equality
+        // predicate (or, when an explicit `where` won, dropped on the floor).
+        // Both readings are only sound if the key names a REAL field: a filter
+        // on a field that does not exist can never match, so `?pageSize=5`
+        // returned 200 + `total: 0` — indistinguishable from "no data". The
+        // write path already rejects the same input loudly (`INVALID_FIELD`);
+        // this is the read half of that one piece of knowledge, and the mirror
+        // of #3948's rule for driver-memory: an unapplied filter must not look
+        // like a satisfied one.
+        //
+        // Validated BEFORE the `!options.where` branch below, so a bad param is
+        // a 400 whether or not the caller also sent an explicit filter — the
+        // failure must not depend on which other params rode along.
+        const leftoverParams = Object.keys(options).filter((k) => !RESERVED_LIST_QUERY_PARAMS.has(k));
+        if (leftoverParams.length > 0) {
+            this.assertQueryParamsAreFields(request.object, leftoverParams);
+        }
+
         // Flat field filters: REST-style query params like ?id=abc&status=open
         // After extracting all known query parameters, any remaining keys are
         // treated as implicit field-level equality filters merged into `where`.
-        const knownParams = new Set([
-            'top', 'limit', 'offset',
-            'orderBy',
-            'fields',
-            'where',
-            'expand',
-            'distinct', 'count',
-            'aggregations', 'groupBy',
-            'search', 'searchFields', 'context', 'cursor',
-        ]);
+        // Every one of them is a verified field name by this point.
+        //
+        // The `!options.where` guard is #4134's deliberate scope edge: when an
+        // explicit filter won, a leftover REAL field name is still dropped
+        // silently (it rides on to `engine.find` as a stray AST key no driver
+        // reads). Same disease, opposite direction — over-returning rather than
+        // zeroing — and fixing it means choosing a semantics (AND-merge vs.
+        // reject the conflict), so it is filed as #4164 rather than smuggled in
+        // here. The UNKNOWN half is already loud: the gate above runs before
+        // this branch, so a bad name 400s either way.
         if (!options.where) {
             const implicitFilters: Record<string, unknown> = {};
-            for (const key of Object.keys(options)) {
-                if (!knownParams.has(key)) {
-                    implicitFilters[key] = options[key];
-                    delete options[key];
-                }
+            for (const key of leftoverParams) {
+                implicitFilters[key] = options[key];
+                delete options[key];
             }
             if (Object.keys(implicitFilters).length > 0) {
                 options.where = implicitFilters;
             }
         }
-        
+
         // Route to engine.aggregate() when the query has GROUP BY / aggregations.
         // engine.find() does not do in-memory aggregation fallback, so without
         // this branch a spec-shape aggregate request would silently return

--- a/packages/objectql/src/protocol-data.test.ts
+++ b/packages/objectql/src/protocol-data.test.ts
@@ -653,4 +653,212 @@ describe('ObjectStackProtocolImplementation - Data Operations', () => {
             expect(engine.find).toHaveBeenCalledOnce();
         });
     });
+
+    // ═══════════════════════════════════════════════════════════════
+    // #4134 — unknown query params were silently lowered into field filters
+    //
+    // `?pageSize=5` on a 10-row object returned 200 + `total: 0`: the param
+    // fell into the implicit-filter bucket as `where.pageSize = '5'`, a
+    // predicate no row can satisfy. The failure direction is "fewer", not
+    // "wrong", so it is indistinguishable from an empty table — and the write
+    // path rejects the SAME unknown name loudly (`INVALID_FIELD`). Mirror of
+    // #3948's rule for driver-memory: an unapplied filter must not look like a
+    // satisfied one.
+    // ═══════════════════════════════════════════════════════════════
+
+    describe('unknown query params are rejected, not lowered into filters (#4134)', () => {
+        const TASK_FIELDS = {
+            title: { type: 'text' },
+            status: { type: 'text' },
+            due_date: { type: 'date' },
+            owner_id: { type: 'lookup', reference: 'sys_user' },
+            created_at: { type: 'datetime' },
+        };
+
+        function makeProtocol(fields: Record<string, unknown> = TASK_FIELDS) {
+            const engine: any = {
+                find: vi.fn().mockResolvedValue([]),
+                findOne: vi.fn().mockResolvedValue(null),
+                count: vi.fn().mockResolvedValue(0),
+                registry: {
+                    getObject: vi.fn((name: string) => ({ name, fields })),
+                },
+            };
+            return { protocol: new ObjectStackProtocolImplementation(engine), engine };
+        }
+
+        it('rejects a param that names no field with 400 INVALID_FIELD, before the engine', async () => {
+            const { protocol, engine } = makeProtocol();
+            await expect(
+                protocol.findData({ object: 'showcase_task', query: { zzzz: '1' } }),
+            ).rejects.toMatchObject({
+                status: 400,
+                code: 'INVALID_FIELD',
+                field: 'zzzz',
+                object: 'showcase_task',
+            });
+            expect(engine.find).not.toHaveBeenCalled();
+        });
+
+        it('uses the write path\'s wording so one mistake reads the same on both sides', async () => {
+            const { protocol } = makeProtocol();
+            await expect(
+                protocol.findData({ object: 'showcase_task', query: { zzzz: '1' } }),
+            ).rejects.toThrow(/Unknown field 'zzzz' on object 'showcase_task'/);
+        });
+
+        it.each([
+            ['pageSize', 'top'],
+            ['page_size', 'top'],
+            ['perPage', 'top'],
+            ['page', 'skip'],
+            ['sortBy', 'sort'],
+            ['q', 'search'],
+        ])('points %s at the parameter that actually works (%s)', async (bad, canonical) => {
+            const { protocol } = makeProtocol();
+            await expect(
+                protocol.findData({ object: 'showcase_task', query: { [bad]: '5' } }),
+            ).rejects.toThrow(new RegExp(`Did you mean the '${canonical}' query parameter`));
+        });
+
+        it('only ever suggests spellings the endpoint really accepts', async () => {
+            // A hint that hands the caller a second 400 is worse than no hint.
+            // The trap here is `$sort`, which does not exist — sorting's OData
+            // spelling is `$orderby`, so the suggestion cannot be built by
+            // prefixing `$`.
+            const { protocol, engine } = makeProtocol();
+            const suggested = new Set<string>();
+            for (const bad of ['pageSize', 'page', 'sortBy', 'q', 'criteria', 'columns', 'include']) {
+                const err: any = await protocol
+                    .findData({ object: 'showcase_task', query: { [bad]: 'x' } })
+                    .then(() => undefined, (e: any) => e);
+                for (const m of String(err?.message).matchAll(/'(\$?[a-zA-Z]+)'/g)) {
+                    if (m[1] !== bad) suggested.add(m[1]);
+                }
+            }
+            expect(suggested.size).toBeGreaterThan(0);
+            for (const spelling of suggested) {
+                await expect(
+                    protocol.findData({ object: 'showcase_task', query: { [spelling]: spelling === 'top' || spelling === '$top' || spelling === 'skip' || spelling === '$skip' ? 1 : 'title' } }),
+                    `suggested '${spelling}' must be accepted`,
+                ).resolves.toBeDefined();
+            }
+            expect(engine.find).toHaveBeenCalledTimes(suggested.size);
+        });
+
+        it('suggests the closest real field when the param reads like a typo', async () => {
+            const { protocol } = makeProtocol();
+            await expect(
+                protocol.findData({ object: 'showcase_task', query: { stauts: 'done' } }),
+            ).rejects.toThrow(/Did you mean the field 'status'\?/);
+        });
+
+        it('names every offending param, not just the first', async () => {
+            const { protocol } = makeProtocol();
+            await expect(
+                protocol.findData({ object: 'showcase_task', query: { zzzz: '1', yyyy: '2' } }),
+            ).rejects.toMatchObject({ field: 'zzzz', fields: ['zzzz', 'yyyy'] });
+        });
+
+        it('leaves the known-field-plus-explicit-filter case alone (#4164)', async () => {
+            // The scope edge, pinned so a later change to it is deliberate: a
+            // REAL field name alongside an explicit filter is still dropped
+            // silently. #4134 made only the UNKNOWN half loud.
+            const { protocol, engine } = makeProtocol();
+            await protocol.findData({
+                object: 'showcase_task',
+                query: { filter: { status: 'open' }, owner_id: 'usr_1' },
+            });
+            expect(engine.find.mock.calls[0][1].where).toEqual({ status: 'open' });
+        });
+
+        it('rejects even when an explicit filter rode along — the 400 must not depend on it', async () => {
+            // Without this, `?filter={...}&pageSize=5` takes the `options.where`
+            // short-circuit: the bad param is neither applied nor reported, so
+            // the caller silently gets an unpaginated page.
+            const { protocol, engine } = makeProtocol();
+            await expect(
+                protocol.findData({
+                    object: 'showcase_task',
+                    query: { filter: { status: 'open' }, pageSize: '5' },
+                }),
+            ).rejects.toMatchObject({ code: 'INVALID_FIELD', field: 'pageSize' });
+            expect(engine.find).not.toHaveBeenCalled();
+        });
+
+        it('still lowers a REAL field name into an implicit equality filter', async () => {
+            const { protocol, engine } = makeProtocol();
+            await protocol.findData({ object: 'showcase_task', query: { status: 'done' } });
+            expect(engine.find.mock.calls[0][1].where).toEqual({ status: 'done' });
+        });
+
+        it('allows `id` — the primary key is not a declared field', async () => {
+            const { protocol, engine } = makeProtocol();
+            await protocol.findData({ object: 'showcase_task', query: { id: 'rec_1' } });
+            expect(engine.find.mock.calls[0][1].where).toEqual({ id: 'rec_1' });
+        });
+
+        it('judges a dotted path on its head segment, like engine.find() does for projections', async () => {
+            const { protocol, engine } = makeProtocol();
+            await protocol.findData({ object: 'showcase_task', query: { 'owner_id.name': 'Ada' } });
+            expect(engine.find.mock.calls[0][1].where).toEqual({ 'owner_id.name': 'Ada' });
+        });
+
+        it('never rejects a reserved parameter — every real spelling still works', async () => {
+            const { protocol, engine } = makeProtocol();
+            await protocol.findData({
+                object: 'showcase_task',
+                query: {
+                    $top: 5, $skip: 2, $orderby: 'title', $select: 'id,title',
+                    $search: 'x', $count: 'true', $expand: 'owner_id',
+                },
+            });
+            await protocol.findData({
+                object: 'showcase_task',
+                query: { top: 5, skip: 2, sort: '-title', select: 'id,title', populate: 'owner_id', search: 'x' },
+            });
+            expect(engine.find).toHaveBeenCalledTimes(2);
+            for (const call of engine.find.mock.calls) expect(call[1].where).toBeUndefined();
+        });
+
+        it('accepts the structural QueryAST keys the POST /query body carries', async () => {
+            // `client.data.query(object, query)` posts a `Partial<QueryAST>`,
+            // whose documented shape includes `object`. Treated as a field
+            // filter it would become `where.object` and match zero rows.
+            const { protocol, engine } = makeProtocol();
+            await protocol.findData({
+                object: 'showcase_task',
+                query: {
+                    object: 'showcase_task',
+                    limit: 5,
+                    joins: [],
+                    having: {},
+                    windowFunctions: [],
+                    distinct: true,
+                    cursor: { id: 'rec_1' },
+                },
+            });
+            expect(engine.find).toHaveBeenCalledOnce();
+            expect(engine.find.mock.calls[0][1].where).toBeUndefined();
+        });
+
+        it('stands down when the schema carries no field map — nothing to check against', async () => {
+            // External datasources / engine doubles whose columns are not
+            // mirrored locally. Same tiering as the #3770 object gate one level
+            // up: no source of truth ⇒ no verdict, so the old behavior stands.
+            const { protocol, engine } = makeProtocol({});
+            await protocol.findData({ object: 'external_thing', query: { zzzz: '1' } });
+            expect(engine.find.mock.calls[0][1].where).toEqual({ zzzz: '1' });
+        });
+
+        it('stands down when the engine exposes no registry at all', async () => {
+            const engine: any = {
+                find: vi.fn().mockResolvedValue([]),
+                count: vi.fn().mockResolvedValue(0),
+            };
+            const protocol = new ObjectStackProtocolImplementation(engine);
+            await protocol.findData({ object: 'showcase_task', query: { zzzz: '1' } });
+            expect(engine.find.mock.calls[0][1].where).toEqual({ zzzz: '1' });
+        });
+    });
 });

--- a/packages/objectql/src/protocol-unknown-query-param.test.ts
+++ b/packages/objectql/src/protocol-unknown-query-param.test.ts
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #4134 — the REST list path read ANY unrecognised query parameter as a field
+ * filter, so `?pageSize=5` became `where.pageSize = '5'`: a predicate no row
+ * can satisfy. The response was `200` + `total: 0` — structurally valid, and
+ * indistinguishable from "this object really is empty". It cost a real
+ * investigation, where an empty list was read as an RLS/org-scope visibility
+ * bug rather than a misspelled parameter.
+ *
+ * The asymmetry is the point: the WRITE path already rejects the same unknown
+ * name loudly (`400 INVALID_FIELD`). One piece of knowledge — does this field
+ * exist — was enforced on one side and silently zeroed on the other.
+ *
+ * These tests drive a REAL {@link ObjectQL} engine (same harness shape as
+ * `protocol-unregistered-object.test.ts`) rather than an engine double,
+ * because the gate's authority is the registry's field map — and that map is
+ * not what the author declared: `applySystemFields` injects the audit / tenant
+ * / owner columns at registration. Only a real registry can show that
+ * `?owner_id=…` still filters while `?pageSize=…` is refused.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ObjectStackProtocolImplementation } from '@objectstack/metadata-protocol';
+import { ObjectQL } from './engine.js';
+
+/** The issue's repro object: 10 rows, 2 of them `status: 'done'`. */
+const taskObject = {
+    name: 'showcase_task',
+    label: 'Task',
+    fields: {
+        id: { name: 'id', label: 'ID', type: 'text' as const, primaryKey: true },
+        title: { name: 'title', label: 'Title', type: 'text' as const, required: true },
+        status: { name: 'status', label: 'Status', type: 'text' as const },
+    },
+};
+
+function makeMemoryDriver() {
+    const stores = new Map<string, Map<string, Record<string, unknown>>>();
+    const storeFor = (obj: string) => {
+        let s = stores.get(obj);
+        if (!s) { s = new Map(); stores.set(obj, s); }
+        return s;
+    };
+    let nextId = 0;
+    const matchesWhere = (row: Record<string, unknown>, where: any): boolean => {
+        if (!where || typeof where !== 'object') return true;
+        for (const [k, v] of Object.entries(where)) {
+            if (k.startsWith('$')) continue;
+            const expected = (v && typeof v === 'object' && '$eq' in (v as any)) ? (v as any).$eq : v;
+            const a = row[k] === undefined ? null : row[k];
+            const b = expected === undefined ? null : expected;
+            if (a !== b) return false;
+        }
+        return true;
+    };
+    const driver: any = {
+        name: 'memory',
+        version: '0.0.0',
+        supports: {} as any,
+        async connect() {},
+        async disconnect() {},
+        async checkHealth() { return true; },
+        async execute() { return null; },
+        async find(object: string, ast: any) {
+            const all = Array.from(storeFor(object).values()).filter((r) => matchesWhere(r, ast?.where));
+            const from = typeof ast?.offset === 'number' ? ast.offset : 0;
+            return typeof ast?.limit === 'number' ? all.slice(from, from + ast.limit) : all.slice(from);
+        },
+        findStream() { throw new Error('not implemented'); },
+        async findOne(object: string, ast: any) {
+            for (const r of storeFor(object).values()) if (matchesWhere(r, ast?.where)) return r;
+            return null;
+        },
+        async create(object: string, data: Record<string, unknown>) {
+            nextId += 1;
+            const id = (data.id as string) ?? `r_${nextId}`;
+            const row = { ...data, id };
+            storeFor(object).set(id, row);
+            return row;
+        },
+        async update(object: string, id: string, data: Record<string, unknown>) {
+            const s = storeFor(object);
+            const cur = s.get(id);
+            if (!cur) throw new Error(`not found: ${object}/${id}`);
+            const updated = { ...cur, ...data, id };
+            s.set(id, updated);
+            return updated;
+        },
+        async upsert(object: string, data: Record<string, unknown>) {
+            const id = data.id as string | undefined;
+            if (id && storeFor(object).has(id)) return this.update(object, id, data);
+            return this.create(object, data);
+        },
+        async delete(object: string, id: string) { return storeFor(object).delete(id); },
+        async count(object: string, ast: any) {
+            return Array.from(storeFor(object).values()).filter((r) => matchesWhere(r, ast?.where)).length;
+        },
+        async aggregate(object: string, ast: any) { return [{ count: await this.count(object, ast) }]; },
+        async bulkCreate(object: string, rows: Record<string, unknown>[]) {
+            return Promise.all(rows.map((r) => this.create(object, r)));
+        },
+        async bulkUpdate() { return []; },
+        async bulkDelete() {},
+        async beginTransaction() { return { commit: async () => {}, rollback: async () => {} }; },
+        async commit() {},
+        async rollback() {},
+    };
+    return { driver, stores };
+}
+
+describe('#4134 — unknown list query params (real ObjectQL engine)', () => {
+    let engine: ObjectQL;
+    let protocol: ObjectStackProtocolImplementation;
+
+    beforeEach(async () => {
+        engine = new ObjectQL();
+        const { driver, stores } = makeMemoryDriver();
+        engine.registerDriver(driver, true);
+        await engine.init();
+        engine.registry.registerObject(taskObject as any, 'test-package');
+        protocol = new ObjectStackProtocolImplementation(engine);
+
+        const rows = new Map<string, Record<string, unknown>>();
+        for (let i = 1; i <= 10; i++) {
+            rows.set(`t${i}`, {
+                id: `t${i}`,
+                title: `Task ${i}`,
+                status: i <= 2 ? 'done' : 'open',
+                owner_id: 'usr_1',
+                created_at: '2026-07-30T00:00:00.000Z',
+            });
+        }
+        stores.set('showcase_task', rows);
+    });
+
+    // ─────────────────────────────────────────────────────────────
+    // The issue's own transcript, line for line
+    // ─────────────────────────────────────────────────────────────
+
+    it('baseline — no params returns every row', async () => {
+        await expect(protocol.findData({ object: 'showcase_task' }))
+            .resolves.toMatchObject({ total: 10 });
+    });
+
+    it('a real field still filters, and a real field with no match is still a legitimate 0', async () => {
+        await expect(protocol.findData({ object: 'showcase_task', query: { status: 'done' } }))
+            .resolves.toMatchObject({ total: 2 });
+        // The one empty list that MUST stay a 200: the predicate was applied
+        // and genuinely matched nothing.
+        await expect(protocol.findData({ object: 'showcase_task', query: { status: 'zzz' } }))
+            .resolves.toMatchObject({ total: 0 });
+    });
+
+    it.each(['zzzz', 'pageSize', 'page_size', 'perPage'])(
+        '?%s no longer returns 200 + an empty list — it is a 400',
+        async (param) => {
+            await expect(
+                protocol.findData({ object: 'showcase_task', query: { [param]: '5' } }),
+            ).rejects.toMatchObject({
+                status: 400,
+                code: 'INVALID_FIELD',
+                field: param,
+                object: 'showcase_task',
+            });
+        },
+    );
+
+    it('the real pagination spellings all still work', async () => {
+        for (const query of [{ $top: 5 }, { top: 5 }, { limit: 5 }]) {
+            const r: any = await protocol.findData({ object: 'showcase_task', query });
+            expect(r.records).toHaveLength(5);
+            expect(r.total).toBe(10);
+        }
+    });
+
+    // ─────────────────────────────────────────────────────────────
+    // The registry — not the author's declaration — is the authority
+    // ─────────────────────────────────────────────────────────────
+
+    it('filters on the system fields the registry injected, which the author never declared', async () => {
+        // `applySystemFields` adds these at registration; a gate reading only
+        // the authored field map would 400 on every one of them.
+        expect(taskObject.fields).not.toHaveProperty('owner_id');
+        for (const [field, value] of [
+            ['owner_id', 'usr_1'],
+            ['created_at', '2026-07-30T00:00:00.000Z'],
+        ] as const) {
+            await expect(
+                protocol.findData({ object: 'showcase_task', query: { [field]: value } }),
+            ).resolves.toMatchObject({ total: 10 });
+        }
+        await expect(protocol.findData({ object: 'showcase_task', query: { id: 't1' } }))
+            .resolves.toMatchObject({ total: 1 });
+    });
+
+    it('suggests the parameter that works instead of the one that was guessed', async () => {
+        await expect(protocol.findData({ object: 'showcase_task', query: { pageSize: '5' } }))
+            .rejects.toThrow(/Did you mean the 'top' query parameter/);
+        await expect(protocol.findData({ object: 'showcase_task', query: { stauts: 'done' } }))
+            .rejects.toThrow(/Did you mean the field 'status'/);
+    });
+
+    it('an unknown object stays a 404 — the field gate must not turn it into a 400', async () => {
+        await expect(
+            protocol.findData({ object: 'no_such_object', query: { pageSize: '5' } }),
+        ).rejects.toMatchObject({ status: 404, code: 'OBJECT_NOT_FOUND' });
+    });
+});

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -345,6 +345,25 @@ export function mapDataError(error: any, object?: string): { status: number; bod
             },
         };
     }
+    // [#4134] Unknown field named by a READ — the protocol's list normalizer
+    // refusing to lower a query parameter that matches no field into an
+    // implicit filter that could only ever match zero rows. Emitted in the SAME
+    // envelope as the driver-string branch below (which catches the write-path
+    // form of the identical mistake), so one condition has one wire shape no
+    // matter which layer noticed it. Must precede the generic 4xx passthrough,
+    // which would ship the message but drop `field`.
+    if (error?.code === 'INVALID_FIELD') {
+        const name = error?.object ?? object;
+        return {
+            status: 400,
+            body: {
+                error: String(error?.message ?? 'Request references a field that does not exist'),
+                code: 'INVALID_FIELD',
+                ...(typeof error?.field === 'string' && error.field ? { field: error.field } : {}),
+                ...(name ? { object: name } : {}),
+            },
+        };
+    }
     // Generic passthrough for domain errors that already carry an explicit
     // HTTP status (e.g. plugin-sharing's record-scope denial: status 403 +
     // code FORBIDDEN) — mirrors sendError's `.status` handling, which the
@@ -588,6 +607,17 @@ function sendError(res: any, error: any, object?: string): void {
  */
 function isExpectedDataStatus(status: number): boolean {
     return status === 403 || status === 404 || status === 409 || status === 502 || status === 503;
+}
+
+/**
+ * Malformed-query rejections from the list normalizer (`findData`). They are
+ * 400s the CALLER caused by naming a parameter the API does not have
+ * (`UNSUPPORTED_QUERY_PARAM`, #2926 ⑩) or a field the object does not have
+ * (`INVALID_FIELD`, #4134) — a client mistake the response already explains,
+ * not a server fault worth an "[REST] Unhandled error" line per request.
+ */
+function isExpectedQueryRejection(body: Record<string, unknown> | undefined): boolean {
+    return body?.code === 'UNSUPPORTED_QUERY_PARAM' || body?.code === 'INVALID_FIELD';
 }
 
 /**
@@ -3867,7 +3897,7 @@ export class RestServer {
                         res.json(result);
                     } catch (error: any) {
                         const mapped = mapDataError(error, req.params?.object);
-                        if (isExpectedDataStatus(mapped.status) || mapped.body?.code === 'UNSUPPORTED_QUERY_PARAM') {
+                        if (isExpectedDataStatus(mapped.status) || isExpectedQueryRejection(mapped.body)) {
                             res.status(mapped.status).json(mapped.body);
                         } else {
                             logError("[REST] Unhandled error:", error);
@@ -3977,7 +4007,9 @@ export class RestServer {
                         res.json(result);
                     } catch (error: any) {
                         const mapped = mapDataError(error, req.params?.object);
-                        if (!isExpectedDataStatus(mapped.status)) logError("[REST] Unhandled error:", error);
+                        if (!isExpectedDataStatus(mapped.status) && !isExpectedQueryRejection(mapped.body)) {
+                            logError("[REST] Unhandled error:", error);
+                        }
                         res.status(mapped.status).json(mapped.body);
                     }
                 },

--- a/packages/rest/src/rest.test.ts
+++ b/packages/rest/src/rest.test.ts
@@ -2340,6 +2340,43 @@ describe('mapDataError — schema/constraint envelopes', () => {
     expect(r.body.field).toBe('label');
   });
 
+  // #4134: the READ half of the same knowledge. The protocol's list normalizer
+  // throws a structured INVALID_FIELD rather than letting `?pageSize=5` become
+  // a `where.pageSize` predicate that can only return 200 + an empty list.
+  // The envelope must match the driver-string branch above field-for-field —
+  // one condition, one wire shape, whichever layer noticed it.
+  it('maps a structured read-path INVALID_FIELD → 400 with the field (same shape as the write path)', () => {
+    const r = mapDataError(
+      Object.assign(new Error("Unknown field 'pageSize' on object 'showcase_task'. Did you mean the 'top' query parameter?"), {
+        code: 'INVALID_FIELD',
+        status: 400,
+        field: 'pageSize',
+        fields: ['pageSize'],
+        object: 'showcase_task',
+      }),
+      'showcase_task',
+    );
+    expect(r.status).toBe(400);
+    expect(r.body.code).toBe('INVALID_FIELD');
+    expect(r.body.field).toBe('pageSize');
+    expect(r.body.object).toBe('showcase_task');
+    expect(String(r.body.error)).toContain("Unknown field 'pageSize'");
+  });
+
+  it('does not let the generic 4xx passthrough swallow INVALID_FIELD\'s `field`', () => {
+    // The passthrough branch keeps `code` but drops every structured field, so
+    // the dedicated branch has to win the ordering.
+    const r = mapDataError(
+      Object.assign(new Error("Unknown field 'zzzz' on object 'widget'"), {
+        code: 'INVALID_FIELD',
+        status: 400,
+        field: 'zzzz',
+      }),
+      'widget',
+    );
+    expect(r.body.field).toBe('zzzz');
+  });
+
   it('maps SQLite NOT NULL constraint → 400 VALIDATION_FAILED with required field', () => {
     const r = mapDataError(
       sqliteError(


### PR DESCRIPTION
Closes #4134。

## 问题

`GET /api/v1/data/:object` 把任何未保留的查询参数当作字段级等值过滤器 —— 这正是 `?status=done` 等价于 `?filter={"status":"done"}` 的机制。但当参数名对应不到任何字段时，这个谓词**永远不可能匹配**，于是 `?pageSize=5` 在一个有 10 条记录的对象上返回 `200` + `total: 0`：结构合法，且与「这个对象确实是空的」完全无法区分。

写路径对同一个未知字段名早就是大声拒绝的（`400 INVALID_FIELD`）。同一份知识 —— 这个字段存不存在 —— 一边强制、一边静默清零。

## 改动

`findData` 在把剩余参数降为隐式过滤器**之前**，先按对象元数据校验字段名，并抛出写路径自己的信封：`400 INVALID_FIELD` + `field` + `object`。这是 #3948 给 driver-memory 定的那条规则往上一层的镜像 —— *an unapplied filter must not look like a satisfied one*。

```json
{
  "error": "Unknown field 'pageSize' on object 'showcase_task'. Query parameters that are not reserved are read as field filters, so an unknown name can only match zero records. Did you mean the 'top' query parameter (OData spelling '$top')?",
  "code": "INVALID_FIELD",
  "field": "pageSize",
  "object": "showcase_task"
}
```

几个实现上的决定：

- **校验在 `!options.where` 分支之前**。否则 `?filter=…&pageSize=5` 会走短路分支，坏参数既不生效也不上报 —— 失败与否不该取决于旁边还传了什么。
- **拒绝时带建议**：已知方言给出规范参数（`pageSize`/`perPage`/`page`/`sortBy`/`q` → `top`/`skip`/`sort`/`search`），看起来像拼写错误就给最近的真实字段名（`stauts` → `status`）。OData 拼写是查表得到的，不是加 `$` 前缀拼出来的 —— 排序的 OData 拼写是 `$orderby` 而不是 `$sort`，建议一个会被 `$` 守卫拒掉的参数等于让调用方再吃一个 400。
- **保留参数集用 `Record<keyof QueryAST, true>` 钉死在 spec 上**，双向都由 `tsc` 把关：AST 新增一个 key 在这里是编译错误，而不是悄悄给那个新 key 重演一遍本 issue。集合里包含 `object` / `joins` / `having` / `windowFunctions` —— `POST /data/:object/query` 的 body 就是 `Partial<QueryAST>`，少了它们 `client.data.query('task', { object: 'task', limit: 5 })` 会把 `object` 读成过滤器然后匹配零行。
- **分级沿用 #3770 对象网关的做法，往下一层**：没有 registry、或 schema 没有字段表（无 registry 的 Lite/edge 宿主、engine 替身、列不在本地镜像的外部数据源）时无从判断，网关就让路。
- `skip` 现在在归一化阶段无条件删除 —— 它是纯传输别名，留下一个 null 的 `skip` 会被下面的字段网关报成「未知**字段**」，对一个真实参数来说是误导。

## 验证

**协议层**（`protocol-data.test.ts`，engine 替身钉决策规则）：拒绝形状与字段、多个坏参数、显式 filter 在场时仍拒绝、真实字段仍降为隐式过滤器、`id` 放行、点号路径按首段判断、每个保留参数与 `$` 别名都不受影响、POST body 的结构化 AST key 放行、两级让路条件，以及一条**「只建议真正接受的拼写」** —— 把每个建议回灌进 `findData` 确认它返回 200。

**真实引擎**（新增 `protocol-unknown-query-param.test.ts`，10 行 `showcase_task` + 真 registry）：因为网关的权威是 registry 的字段表，而那张表不是作者声明的那张 —— `applySystemFields` 在注册时注入了审计/租户/owner 列。只有真 registry 能证明 `?owner_id=` / `?created_at=` 仍然可过滤，而 `?pageSize=` 被拒。issue 里那份实测表格逐行钉住。

**REST 层**（`rest.test.ts`）：`mapDataError` 的新分支必须排在通用 4xx 透传之前，否则 `field` 会被吞掉。

**跑起来的服务器**（`pnpm dev -- --fresh -p 39847`，showcase，已自行关闭）—— issue 的实测表格逐行复现：

```
GET /data/showcase_task                 -> 200  total=10             ✅ 基线
GET /data/showcase_task?status=done     -> 200  total=2              ✅ 真实字段过滤
GET /data/showcase_task?status=zzz      -> 200  total=0              ✅ 真实字段无匹配，0 依然正确

GET /data/showcase_task?zzzz=1          -> 400  INVALID_FIELD zzzz     (曾经 200 + total=0)
GET /data/showcase_task?pageSize=5      -> 400  INVALID_FIELD pageSize
GET /data/showcase_task?page_size=5     -> 400  INVALID_FIELD page_size
GET /data/showcase_task?perPage=5       -> 400  INVALID_FIELD perPage

GET /data/showcase_task?$top=5 / ?top=5 / ?limit=5   -> 200  total=10 records=5   ✅ 未受影响
```

外加一轮全参数冒烟（`select` / `sort` / `expand` / `search` / `populate` / `filters` / `skip` / `count` / `distinct` / `owner_id` / `created_at` / `export`）全部 200，`POST /query` 带完整 QueryAST body（含 `object` 键）200，body 里塞垃圾键 400。

`pnpm test` 全绿（132/132 turbo 任务，含 dogfood），`eslint` 干净，`check:route-envelope` / `check:error-code-casing` / `check:doc-authoring` 等 gate 全部 PASS。未触碰 `packages/spec` 源码（只 import 了一个 type），所以生成物 gate 不涉及。

## 对调用方的影响

传了对不上任何字段的参数，现在拿到 `400` 而不是空的 `200`。分页是 `top` / `$top` / `limit`，偏移是 `skip` / `$skip` / `offset`。所有文档化参数、所有 `$` 前缀 OData 别名、`POST /data/:object/query` 的完整 `QueryAST` body 都不受影响。字段名恰好撞上保留参数（`count`、`cursor`、`object`、`top`、`search` …）的对象走显式形式：`?filter={"count":3}`。

顺带一提：jQuery 那种 `?_=1699999` 缓存击穿参数现在也会 400。仓库内的客户端都不发它，而「大声」正是本 issue 要的方向，所以没有为它开口子。

`../objectui` 无需改动 —— 它的数据适配器（`rawFindWithPopulate`）只发 `populate` / `top` / `skip` / `search` / `searchFields` / `select` / `sort` / `filter`，console 的审计日志页只发 `$filter` / `$orderby` / `$top` / `$skip`，marketplace 只发 `limit`，全部是规范拼写。

## 范围边界（Prime Directive #10）

issue 里问到「是否存在依赖未知参数被忽略的现存调用方」—— 排查下来仓库内没有，但顺带撞到一个**邻居 bug**：显式 `filter` 在场时，同时传的**真实**字段参数被静默丢弃（既不合并进 `where` 也不报错，作为野键留在 AST 上）。方向相反（多返回而非清零），病因同一个。本 PR 刻意没有动它 —— 修它要先定语义（AND 合并 vs 拒绝冲突），已开 #4164 跟踪，并在代码注释与测试里把这条边界钉住。


---
_Generated by [Claude Code](https://claude.ai/code/session_01CKsxtrsCwSL3uAcxAdVj83)_