### PR TITLE
feat(spec): 未在手写文档中出现的 schema 变体让 CI 失败（#4165 反向漂移闸门）

### DIFF
--- a/.changeset/variant-doc-drift-gate.md
+++ b/.changeset/variant-doc-drift-gate.md
@@ -1,0 +1,25 @@
+---
+"@objectstack/spec": patch
+---
+
+Add a gate that fails CI when a discriminated-union variant the schema declares is
+never mentioned in the hand-written doc bound to it.
+
+The liveness gate asks whether a property does anything; `check-doc-authoring` asks
+whether docs use the right authoring form. Neither asked the inverse-drift question:
+does a variant the schema declares appear in the prose at all? `content/docs/references/`
+is generated from the schemas and cannot drift, but the hand-written pages are typed by
+humans and do.
+
+The founding case shipped for months: `content/docs/ui/apps.mdx` said the navigation
+tree "supports eight item types" and enumerated eight. The schema had nine — `separator`
+was added to match the objectui renderer and no hand-written page ever learned about it.
+Making `NavigationItemSchema` a discriminated union raised the cost of that gap, because
+a mistyped `type` now answers with the list of valid discriminators and the doc's
+enumeration is what an author checks it against.
+
+`packages/spec/variant-docs.json` classifies all 20 unions: 5 governed (every variant
+must be mentioned in a bound doc), 15 exempt as either generated-reference-only or
+not-authorable. The ledger key is the discriminator plus its sorted variant set, so
+adding or removing a variant changes the key and sends the author back through the
+ledger — and therefore back to the doc.

--- a/.github/workflows/spec-liveness-check.yml
+++ b/.github/workflows/spec-liveness-check.yml
@@ -18,6 +18,9 @@ on:
     paths:
       - 'packages/spec/**'
       - 'packages/qa/dogfood/**'
+      # The variant/doc gate reads hand-written pages, so editing one can break it
+      # without touching packages/spec at all.
+      - 'content/docs/**'
 
 permissions:
   contents: read
@@ -50,3 +53,11 @@ jobs:
       # commonest authoring error, and it must not also be the widest grant.
       - name: Check empty-state semantics
         run: pnpm --filter @objectstack/spec check:empty-state
+
+      # #4165 follow-up. Those two gates ask what a property does and what its empty
+      # value means. This asks the inverse-drift question neither covers: does a variant
+      # the schema declares appear in the hand-written doc at all? references/ is
+      # generated and cannot drift; the hand-written pages are typed by humans and do.
+      # apps.mdx said the nav tree had "eight item types" while the schema had nine.
+      - name: Check discriminated-union variants are documented
+        run: pnpm --filter @objectstack/spec check:variant-docs

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -207,6 +207,7 @@
     "test:coverage": "vitest run --coverage",
     "check:liveness": "tsx scripts/liveness/check-liveness.mts",
     "check:empty-state": "tsx scripts/liveness/check-empty-state.mts",
+    "check:variant-docs": "tsx scripts/check-variant-docs.mts",
     "gen:react-blocks": "tsx scripts/build-react-blocks-contract.ts",
     "check:react-blocks": "tsx scripts/build-react-blocks-contract.ts --check",
     "check:react-conformance": "tsx scripts/check-react-blocks-conformance.ts",

--- a/packages/spec/scripts/check-variant-docs.mts
+++ b/packages/spec/scripts/check-variant-docs.mts
@@ -1,0 +1,209 @@
+#!/usr/bin/env tsx
+// Discriminated-union variant → hand-written doc gate.
+//
+// WHY THIS EXISTS (#4165). The liveness gate asks whether a schema property does
+// anything, and check-doc-authoring asks whether docs use the right authoring form.
+// Neither asks the inverse-drift question: does a variant the SCHEMA declares appear
+// in the hand-written doc at all? content/docs/references/ is generated from these
+// schemas and so cannot drift, but the hand-written pages are typed by humans and do.
+//
+// The founding case: content/docs/ui/apps.mdx said the navigation tree "supports eight
+// item types" and enumerated eight. The schema had nine — `separator` had been added to
+// match the objectui renderer (#1878/#1891/#1894) and no hand-written page ever learned
+// about it. Nothing failed, because nothing was looking in this direction.
+//
+// #4165 raised the cost of that gap: NavigationItemSchema is now discriminated on `type`,
+// so a mistyped discriminator answers with "Invalid discriminator value. Expected ..." —
+// the doc's enumeration is precisely what an author checks that list against. And
+// SeparatorNavItemSchema is .strict() over only type/id/order, so the base props the doc
+// promised "all navigation items" share are hard errors on a separator.
+//
+// THE RATCHET. `key` is '<discriminator>:<variants sorted, pipe-joined>' — not a source
+// path, because a union is reachable by several paths and the walk order picks one, which
+// would churn. Keying on the variant set means adding or removing a variant CHANGES THE
+// KEY, so the ledger no longer matches and CI sends the author back to variant-docs.json
+// — and from there to the doc. An unknown key (new union) and an orphaned key (deleted or
+// renamed union) both fail: no new undeclared surface, no stale claims.
+//
+// WHAT "MENTIONED" MEANS — and what this gate does NOT prove. A variant counts as
+// documented if the bound doc contains either `<discriminator>: '<variant>'` (the code-
+// sample form) or `` `<variant>` `` (the prose/table form). The second form is
+// deliberately loose, and for short generic variants (`object`, `api`, `value`) it can
+// match an unrelated sentence — so a pass here means "the page at least says the word",
+// NOT "the page documents it correctly". This gate catches the omission that shipped for
+// months; it is not a substitute for reading the page. Tightening the loose form would
+// cost more false failures than the precision is worth.
+//
+// Usage:
+//   tsx check-variant-docs.mts          # fail on undeclared/orphaned/undocumented
+//   tsx check-variant-docs.mts --list   # print every discovered union and its key
+
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+// Safe to set here despite ESM hoisting: the only static imports above are node
+// built-ins, and every schema module is pulled in via dynamic `await import()`
+// below — i.e. after this line runs. Keeps the script correct when invoked
+// directly (`tsx scripts/check-variant-docs.mts`), not just via the pnpm script.
+process.env.OS_EAGER_SCHEMAS ??= '1';
+
+const HERE = path.dirname(url.fileURLToPath(import.meta.url));
+const SPEC = path.resolve(HERE, '..');
+const REPO = path.resolve(SPEC, '../..');
+const SRC = path.join(SPEC, 'src');
+const LEDGER = path.join(SPEC, 'variant-docs.json');
+const LIST = process.argv.includes('--list');
+
+type Entry = {
+  key: string; label: string;
+  docs?: string[]; exempt?: string; reason?: string; note?: string;
+};
+
+const defOf = (s: any) => s?._zod?.def ?? s?._def;
+
+function zodFiles(dir: string, acc: string[] = []): string[] {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) zodFiles(p, acc);
+    else if (e.name.endsWith('.zod.ts')) acc.push(p);
+  }
+  return acc;
+}
+
+const seen = new Set<any>();
+const found = new Map<string, { disc: string; variants: string[]; path: string }>();
+
+function walk(s: any, p: string, depth: number): void {
+  if (!s || typeof s !== 'object' || depth > 14 || seen.has(s)) return;
+  seen.add(s);
+  const d = defOf(s);
+  if (!d) return;
+
+  if (d.type === 'union' && d.discriminator) {
+    const variants: string[] = [];
+    for (const o of d.options ?? []) {
+      const od = defOf(o);
+      const shape = typeof od?.shape === 'function' ? od.shape() : od?.shape;
+      const dd = defOf(shape?.[d.discriminator]);
+      const vals = dd?.values ?? (dd?.value !== undefined ? [dd.value] : []);
+      for (const v of vals) variants.push(String(v));
+    }
+    if (variants.length) {
+      const key = `${d.discriminator}:${[...variants].sort().join('|')}`;
+      if (!found.has(key)) found.set(key, { disc: d.discriminator, variants, path: p });
+    }
+  }
+
+  // Structural recursion. Wrapped in try/catch because a lazy getter can reference a
+  // module that is still initialising mid-import; an unresolvable branch must not abort
+  // the whole sweep (it will be reached again via another path).
+  try {
+    if (typeof d.getter === 'function') walk(d.getter(), p, depth + 1);
+    const shape = typeof d.shape === 'function' ? d.shape() : d.shape;
+    if (shape) for (const [k, v] of Object.entries(shape)) walk(v, `${p}.${k}`, depth + 1);
+    if (d.element) walk(d.element, `${p}[]`, depth + 1);
+    if (d.innerType) walk(d.innerType, p, depth + 1);
+    if (d.valueType) walk(d.valueType, `${p}{}`, depth + 1);
+    if (d.left) walk(d.left, p, depth + 1);
+    if (d.right) walk(d.right, p, depth + 1);
+    if (d.in) walk(d.in, p, depth + 1);
+    if (d.out) walk(d.out, p, depth + 1);
+    for (const o of d.options ?? []) walk(o, p, depth + 1);
+    for (const t of d.items ?? []) walk(t, p, depth + 1);
+  } catch { /* unresolvable branch — reached via another path if it matters */ }
+}
+
+const files = zodFiles(SRC).sort();
+for (const f of files) {
+  let mod: Record<string, unknown>;
+  try { mod = await import(url.pathToFileURL(f).href); } catch { continue; }
+  const rel = path.relative(SRC, f).replace(/\.zod\.ts$/, '');
+  for (const [name, val] of Object.entries(mod)) {
+    if (val && typeof val === 'object' && defOf(val)) walk(val, `${rel}#${name}`, 0);
+  }
+}
+
+if (LIST) {
+  const rows = [...found.entries()].sort((a, b) => a[1].path.localeCompare(b[1].path));
+  console.log(`${rows.length} discriminated union(s):\n`);
+  for (const [key, v] of rows) console.log(`${v.path}\n    key: ${key}\n    ${v.variants.join(', ')}\n`);
+  process.exit(0);
+}
+
+const ledger: { entries: Entry[] } = JSON.parse(fs.readFileSync(LEDGER, 'utf-8'));
+const byKey = new Map(ledger.entries.map((e) => [e.key, e]));
+const errors: string[] = [];
+
+// Duplicate keys in the ledger would let one entry silently shadow another.
+const dupes = ledger.entries.map((e) => e.key).filter((k, i, a) => a.indexOf(k) !== i);
+for (const k of new Set(dupes)) errors.push(`duplicate ledger key: ${k}`);
+
+// Ratchet A — every discovered union must be declared.
+for (const [key, v] of found) {
+  if (byKey.has(key)) continue;
+  errors.push(
+    `undeclared discriminated union at ${v.path}\n` +
+    `    key: ${key}\n` +
+    `    variants (${v.variants.length}): ${v.variants.join(', ')}\n` +
+    `    → add it to packages/spec/variant-docs.json: bind \`docs\` (and make sure each variant\n` +
+    `      is mentioned there), or declare \`exempt\` with a reason.`,
+  );
+}
+
+// Ratchet B — every ledger entry must still correspond to a real union. A changed
+// variant set surfaces here as an orphan plus an undeclared entry above.
+for (const e of ledger.entries) {
+  if (!found.has(e.key)) {
+    errors.push(
+      `orphaned ledger entry "${e.label}"\n` +
+      `    key: ${e.key}\n` +
+      `    → no union with this discriminator/variant set exists any more. If variants changed,\n` +
+      `      update the key AND re-check the bound doc; if the union is gone, delete the entry.`,
+    );
+  }
+}
+
+// Coverage — every variant of a governed union must be mentioned in a bound doc.
+const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+let governed = 0, exempt = 0;
+for (const e of ledger.entries) {
+  const u = found.get(e.key);
+  if (!u) continue;
+  if (e.exempt) { exempt++; continue; }
+  if (!e.docs?.length) {
+    errors.push(`ledger entry "${e.label}" declares neither \`docs\` nor \`exempt\`.`);
+    continue;
+  }
+  governed++;
+
+  const missingDocs = e.docs.filter((d) => !fs.existsSync(path.join(REPO, d)));
+  if (missingDocs.length) {
+    errors.push(`ledger entry "${e.label}" binds doc(s) that do not exist: ${missingDocs.join(', ')}`);
+    continue;
+  }
+  const blob = e.docs.map((d) => fs.readFileSync(path.join(REPO, d), 'utf-8')).join('\n');
+  const undocumented = u.variants.filter((v) => {
+    const anchored = new RegExp(`${esc(u.disc)}\\s*:\\s*['"\`]${esc(v)}['"\`]`);
+    const token = new RegExp('`' + esc(v) + '`');
+    return !anchored.test(blob) && !token.test(blob);
+  });
+  if (undocumented.length) {
+    errors.push(
+      `"${e.label}" — ${undocumented.length} variant(s) the schema declares but the doc never mentions:\n` +
+      `    ${undocumented.join(', ')}\n` +
+      `    doc(s): ${e.docs.join(', ')}\n` +
+      `    → document them, or if they are genuinely not author-facing, re-classify the entry.`,
+    );
+  }
+}
+
+if (errors.length) {
+  console.error(`\n✗ variant/doc gate: ${errors.length} problem(s)\n`);
+  for (const e of errors) console.error(`  ${e}\n`);
+  process.exit(1);
+}
+console.log(
+  `✓ variant/doc gate: ${found.size} discriminated union(s) — ` +
+  `${governed} governed (every variant mentioned in a bound doc), ${exempt} exempt.`,
+);

--- a/packages/spec/variant-docs.json
+++ b/packages/spec/variant-docs.json
@@ -1,0 +1,144 @@
+{
+  "$comment": [
+    "Discriminated-union variant → hand-written doc ledger. See scripts/check-variant-docs.mts.",
+    "",
+    "`key` is the union's identity: '<discriminator>:<variants sorted, pipe-joined>'. It is",
+    "deliberately NOT a source path — a union is reachable by several paths and the walk order",
+    "decides which one you see, so a path would churn. Keying on the variant set instead means",
+    "adding or removing a variant CHANGES THE KEY, which fails the ratchet and forces the author",
+    "back through this file — and therefore back to the doc. That is the whole point.",
+    "",
+    "Each entry either binds `docs` (governed: every variant must appear in at least one of them)",
+    "or declares `exempt` with a reason. Two exemption classes are in use:",
+    "  generated-reference-only — the type is documented solely under content/docs/references/,",
+    "      which build-docs.ts generates FROM these schemas. Generated docs cannot drift.",
+    "  not-authorable — wire protocol, engine RPC, or a runtime-derived discriminator. Nobody",
+    "      hand-writes the variant, so no hand-written doc owes it a mention."
+  ],
+  "entries": [
+    {
+      "key": "type:action|component|dashboard|group|object|page|report|separator|url",
+      "label": "app navigation item",
+      "docs": ["content/docs/ui/apps.mdx"],
+      "note": "The gate's founding case: apps.mdx claimed eight types and omitted `separator` (#4165)."
+    },
+    {
+      "key": "provider:api|object|schema|value",
+      "label": "view data provider",
+      "docs": [
+        "content/docs/ui/views.mdx",
+        "content/docs/ui/forms.mdx",
+        "content/docs/data-modeling/fields.mdx"
+      ]
+    },
+    {
+      "key": "type:conditional|cross_field|format|json_schema|script|state_machine",
+      "label": "validation rule",
+      "docs": [
+        "content/docs/data-modeling/validation-rules.mdx",
+        "content/docs/data-modeling/validation.mdx"
+      ]
+    },
+    {
+      "key": "language:expression|js",
+      "label": "hook body language",
+      "docs": ["content/docs/automation/hook-bodies.mdx"]
+    },
+    {
+      "key": "kind:file|http|object",
+      "label": "knowledge source kind",
+      "docs": ["content/docs/protocol/knowledge.mdx"]
+    },
+
+    {
+      "key": "type:inline|npm|remote",
+      "label": "widget implementation",
+      "exempt": "generated-reference-only",
+      "reason": "Documented at content/docs/references/ui/widget.mdx, generated from WidgetManifestSchema."
+    },
+    {
+      "key": "type:cron|interval|once",
+      "label": "job schedule",
+      "exempt": "generated-reference-only",
+      "reason": "Documented at content/docs/references/system/job.mdx."
+    },
+    {
+      "key": "type:api-key|basic|bearer|none|oauth2",
+      "label": "connector authentication",
+      "exempt": "generated-reference-only",
+      "reason": "Documented at content/docs/references/integration/connector-auth.mdx."
+    },
+    {
+      "key": "type:api-key|basic|bearer|none",
+      "label": "connector auth (environment-artifact projection)",
+      "exempt": "generated-reference-only",
+      "reason": "Narrower projection of the connector-auth union carried in the deploy artifact; same generated reference."
+    },
+    {
+      "key": "strategy:isolated_db|isolated_schema|shared_schema",
+      "label": "tenant isolation strategy",
+      "exempt": "generated-reference-only",
+      "reason": "Documented at content/docs/references/system/tenant.mdx. Operator-set, not tenant-authored."
+    },
+    {
+      "key": "type:cast|constant|javascript|lookup|map",
+      "label": "sync mapping transform",
+      "exempt": "generated-reference-only",
+      "reason": "Generated reference only; no hand-written page covers the sync transform set yet."
+    },
+    {
+      "key": "kind:action|http|navigate",
+      "label": "settings-manifest handler",
+      "exempt": "generated-reference-only",
+      "reason": "Generated reference only; consumed by Setup/Studio, not tenant-authored metadata."
+    },
+    {
+      "key": "viewKind:form|list",
+      "label": "view item kind",
+      "exempt": "not-authorable",
+      "reason": "Loader-derived. Authors write the `list` / `listViews` / `formViews` containers; the loader expands them and stamps `viewKind`. No author ever types it."
+    },
+    {
+      "key": "type:ack|cursor|edit|error|event|ping|pong|presence|subscribe|unsubscribe",
+      "label": "websocket message",
+      "exempt": "not-authorable",
+      "reason": "Wire protocol between client and gateway."
+    },
+    {
+      "key": "status:approved|expired|pending",
+      "label": "device-token response status",
+      "exempt": "not-authorable",
+      "reason": "API response envelope, not authored metadata."
+    },
+    {
+      "key": "method:aggregate|batch|count|delete|execute|find|findOne|insert|update|vectorFind",
+      "label": "data-engine request",
+      "exempt": "not-authorable",
+      "reason": "Engine RPC contract."
+    },
+    {
+      "key": "method:aggregate|count|delete|execute|find|findOne|insert|update|vectorFind",
+      "label": "data-engine batch request item",
+      "exempt": "not-authorable",
+      "reason": "Engine RPC contract; the batch member set excludes `batch` itself."
+    },
+    {
+      "key": "type:delete|insert|retain",
+      "label": "collaboration op component",
+      "exempt": "not-authorable",
+      "reason": "CRDT operation encoding."
+    },
+    {
+      "key": "type:g-counter|lww-register|or-set|pn-counter|text",
+      "label": "CRDT merge state",
+      "exempt": "not-authorable",
+      "reason": "CRDT internal state encoding."
+    },
+    {
+      "key": "type:add_field|create_object|delete_object|execute_sql|modify_field|remove_field|rename_object",
+      "label": "migration changeset operation",
+      "exempt": "not-authorable",
+      "reason": "Emitted by the diff engine, not hand-written."
+    }
+  ]
+}


### PR DESCRIPTION
补一道现有闸门族里缺失的方向。liveness 闸门问「这个属性做不做事」，`check-doc-authoring` 问「文档用的授权形式对不对」——**没有一个问：schema 声明的变体，手写文档里到底提没提过。**

`content/docs/references/` 由 `build-docs.ts` 从 schema 生成，天然不会漂移；手写页面是人打出来的，会漂。

## 缘起：一条漂了几个月的漏检

`apps.mdx` 写导航树「supports **eight** item types」并列举了八个。schema 有**九个**——`separator` 是当年为对齐 objectui 渲染器的 `item.type === 'separator'` 分支加进来的（#1878/#1891/#1894），而**没有任何手写页面知道它存在**。没有任何闸门失败，因为没有闸门朝这个方向看。

#4165 把这个缺口的代价抬高了：`NavigationItemSchema` 现在按 `type` 判别，写错判别键会回一句「Invalid discriminator value. Expected ...」——而**文档里那个枚举，正是作者拿来核对这份清单的东西**。同时 `SeparatorNavItemSchema` 是只含 `type`/`id`/`order` 的 `.strict()`，文档承诺「所有导航项共享」的基础属性，写在 separator 上现在是硬错误。

（该文档已在 #4165 修好，所以本 PR 是**纯增闸门、零文档改动**。）

## 身份与棘轮

条目身份是 `<判别键>:<变体排序后拼接>`，**刻意不用源码路径**——一个 union 可由多条路径抵达，遍历顺序决定你看到哪条，路径会抖动。实测：导航 union 的发现路径是 `api/metadata#AppDefinitionResponseSchema.data.navigation[]`，而不是 `ui/app`。

以变体集合为身份的好处正是棘轮效应：**增删任何一个变体都会改变 key**，账本随即对不上，CI 把作者推回 `variant-docs.json`，从而推回文档。

- **棘轮 A**：发现了但账本没声明的 union → 失败（不留未申报面）
- **棘轮 B**：账本有但已不存在的 union → 失败（不留过期声明）

## 分类

反射扫出 20 个判别 union，与源码 `grep -c 'z.discriminatedUnion('` 的计数**完全吻合**（两种方法互为交叉验证）。

- **治理 5 条**（每个变体必须在绑定文档中出现）：app 导航项、view data provider、validation rule、hook body language、knowledge source kind
- **豁免 15 条**，两类理由：
  - `generated-reference-only`——只在 `references/` 下有文档，而那是生成的（widget implementation、job schedule、connector auth ×2、tenant strategy、sync mapping transform、settings-manifest handler）
  - `not-authorable`——线协议 / 引擎 RPC / 加载器派生判别键（websocket、data-engine ×2、device-token status、CRDT ×2、migration changeset，以及 `viewKind`：作者写的是 `list`/`listViews`/`formViews` 容器，`viewKind` 是加载器展开后盖上去的，没有作者会手打它）

## 验证它真的会咬人，而不只是会通过

绿灯本身不算证据，三条失败路径逐条实测：

| 场景 | 结果 |
|---|---|
| 从 `apps.mdx` 移除 `separator` 提及 | 失败，退出码 1，点名该变体 |
| 删掉一条账本条目 | 失败：undeclared union（棘轮 A） |
| 改动某条 key（等同新增变体） | 同时报 orphan + undeclared——正是作者加变体时会看到的那一对 |

## 已知局限（已写进脚本头注，不藏着）

变体算「已记录」的判定是：文档中出现 `<判别键>: '<变体>'`，**或**出现 `` `<变体>` ``。第二种形态是宽松的，对 `object`/`api`/`value` 这类通用短词可能匹配到无关句子——**通过只代表页面提到了这个词，不代表页面写对了**。收紧它带来的误报成本高于精度收益。这道闸门抓的是「漂了几个月的彻底遗漏」，不替代人读文档。

## 接入与影响

- `pnpm --filter @objectstack/spec check:variant-docs`（脚本自包含，直接 `tsx` 跑也对）
- 挂在既有的 Spec Liveness Check workflow 上（复用其 install），并把 `content/docs/**` 加进触发路径——改文档同样可能打破它
- `scripts/` 不在 spec 的 tsconfig `include` 内（与现有 liveness `.mts` 一致），不影响类型检查
- 无运行时代码改动

Refs #4001, #4165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147tNF4Snk7Ry1KGt4a5PY4

---
_Generated by [Claude Code](https://claude.ai/code/session_0147tNF4Snk7Ry1KGt4a5PY4)_