### PR TITLE
ci(temporal): the non-SQL backends run under a skewed process zone too

### DIFF
--- a/.changeset/adr-0053-temporal-matrix-skewed-zone.md
+++ b/.changeset/adr-0053-temporal-matrix-skewed-zone.md
@@ -1,0 +1,17 @@
+---
+---
+
+ci(temporal): run the non-SQL temporal backends under a skewed process zone too (#4081)
+
+The `temporal-conformance` job pinned `TZ: America/New_York` on the live
+Postgres/MySQL sweep only. `core`, `formula`, `driver-memory`, `driver-mongodb`
+and `service-analytics` — the backends where a stray `getFullYear()` or a
+local-midnight `new Date(y, m, d)` is easiest to write and hardest to see — kept
+running in the runner's default UTC, where every offset bug is invisible because
+the offset is zero.
+
+They now run in the same skewed zone, and both TZ-skewed steps carry a
+non-vacuity guard that fails the job if the process zone is UTC or the offset is
+zero, so the coverage cannot silently evaporate if the runner image changes.
+
+CI configuration only; releases nothing.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,17 @@ jobs:
   # Every timezone here is deliberately DIFFERENT: servers at +08:00, the Node
   # process at America/New_York, assertions in UTC. Both suites assert they
   # are pointed at a non-UTC server, so a mis-provisioned service fails loudly
-  # instead of letting the job pass vacuously.
+  # instead of letting the job pass vacuously — and each test step now asserts
+  # the PROCESS zone too, which nothing did before: a dropped `TZ:` line
+  # silently returned the whole job to UTC coverage with everything still
+  # green.
+  #
+  # The job also carries the non-SQL half of that axis (core, formula,
+  # driver-memory, driver-mongodb, service-analytics) — the other backends the
+  # temporal conformance matrix holds to one standard. Its NAME still says
+  # "live PG + MySQL" on purpose: the name IS the required check, so renaming
+  # it would silently drop the gate wherever branch protection lists it — the
+  # same trap the dogfood shards note below.
   temporal-conformance:
     name: Temporal Conformance (live PG + MySQL)
     needs: filter
@@ -317,7 +327,55 @@ jobs:
           TZ: America/New_York
           OS_TEST_POSTGRES_URL: postgres://postgres:postgres@127.0.0.1:5432/postgres
           OS_TEST_MYSQL_URL: mysql://root:root@127.0.0.1:3306/conformance
-        run: pnpm --filter @objectstack/driver-sql test
+        run: |
+          # The axis is only real if the zone actually took. Without this, a
+          # dropped `TZ:` line silently returns the job to UTC coverage and
+          # everything still passes — the same vacuous-pass hole the live-server
+          # suites close by asserting a non-UTC SERVER.
+          node -e "const tz=Intl.DateTimeFormat().resolvedOptions().timeZone,off=new Date().getTimezoneOffset();if(!tz||tz==='UTC'||off===0){console.error('process zone is '+tz+' (offset '+off+') — this job must run skewed');process.exit(1)}console.log('process zone: '+tz+' (offset '+off+')')"
+          pnpm --filter @objectstack/driver-sql test
+
+      # The non-SQL half of the same axis. `driver-sql` has run under a skewed
+      # process zone since #3979, but the other backends the temporal
+      # conformance matrix holds to that standard never did — and they are the
+      # ones whose correctness rests ENTIRELY on process-zone independence,
+      # since they have no server to blame: `storageDatetimeValue` /
+      # `storageTimeValue` fold an instant through UTC getters, the filter-token
+      # resolver derives "today" from UTC calendar parts, and the analytics
+      # bucketer does the same. Swap one `getUTC*` for its local twin and every
+      # one of those silently shifts by the host's offset — the exact defect
+      # ADR-0053 D-C1 records for a `Date` bound to a Postgres TIME column.
+      #
+      # Measured before adding this: all five suites already pass under
+      # America/New_York (-5/-4, with DST), Asia/Kolkata (+05:30) and
+      # Pacific/Chatham (+12:45). So this found nothing on the day it landed,
+      # which is what a ratchet is for — it makes the property enforced rather
+      # than incidental.
+      - name: Build the non-SQL temporal backends
+        run: >-
+          pnpm exec turbo run build
+          --filter=@objectstack/service-analytics...
+          --filter=@objectstack/driver-memory...
+          --filter=@objectstack/driver-mongodb...
+          --filter=@objectstack/formula...
+          --concurrency=4
+
+      - name: Run the non-SQL temporal backends under the skewed process zone
+        env:
+          TZ: America/New_York
+        run: |
+          # The axis is only real if the zone actually took. Without this, a
+          # dropped `TZ:` line silently returns the job to UTC coverage and
+          # everything still passes — the same vacuous-pass hole the live-server
+          # suites close by asserting a non-UTC SERVER.
+          node -e "const tz=Intl.DateTimeFormat().resolvedOptions().timeZone,off=new Date().getTimezoneOffset();if(!tz||tz==='UTC'||off===0){console.error('process zone is '+tz+' (offset '+off+') — this job must run skewed');process.exit(1)}console.log('process zone: '+tz+' (offset '+off+')')"
+          pnpm \
+            --filter @objectstack/core \
+            --filter @objectstack/formula \
+            --filter @objectstack/driver-memory \
+            --filter @objectstack/driver-mongodb \
+            --filter @objectstack/service-analytics \
+            test
 
   dogfood:
     # Sharded 2-way: the suite is ~60 independent test files, each booting its


### PR DESCRIPTION
补上温度一致性矩阵的最后一条环境轴：非 SQL 后端此前从未在偏移的进程时区下跑过。

## 为什么这几个包更需要

`driver-sql` 自 #3979 起就在 `TZ=America/New_York` 下运行，但矩阵同样约束的另外几个后端从来没有——而**恰恰是它们的正确性完全依赖「与进程时区无关」**，因为它们没有服务器可以推责：

- `storageDatetimeValue` / `storageTimeValue` 用 UTC getter 折算瞬间
- filter-token 解析器用 UTC 日历部件推导「今天」
- analytics 的分桶器同理

把其中任何一个 `getUTC*` 换成本地版本，全都会**按宿主偏移悄悄平移**——正是 ADR-0053 D-C1 记录的那个缺陷（`Date` 绑到 Postgres TIME 列时按进程时区序列化）。

所以 core、formula、driver-memory、driver-mongodb、service-analytics 现在都在同一个 job、同一个偏移时区下运行。跑**整包**而不只是时间相关的文件，理由与 driver-sql 那一步给出的一致：包里任何一处对时区的隐含假设，都应该在发布前先在这里红掉。

## 顺带堵掉一个空转风险

两个测试步骤现在都会**断言进程时区确实是偏移的**。此前没有任何东西做这件事——删掉一行 `TZ:`，整个 job 会退回 UTC 覆盖而依然全绿。这与活库套件在**服务器**侧断言非 UTC 是同一条纪律，只是进程侧一直缺着。

守卫已实测：`TZ=UTC` 与未设置 TZ 都以退出码 1 拦下，`America/New_York` 放行。

## 诚实的结论：今天它什么也没抓到

落地前我先在本地量过：五个套件在 **America/New_York**（−5/−4，含 DST）、**Asia/Kolkata**（+05:30）、**Pacific/Chatham**（+12:45）三个时区下**全部通过**。

所以这是**棘轮而非捉虫**——它把「折算一律走 UTC」这条性质从「碰巧正确」变成「被强制」。这一点值得写明，而不是把 job 说得像发现了什么。

## 一处刻意不改

job 的名称仍是「Temporal Conformance (live PG + MySQL)」，尽管它现在也跑非服务器的包。**名称就是 required check**，改名会在分支保护引用它的地方悄悄丢掉这道闸——该文件自己在 dogfood 分片处就警告过这个陷阱。已在 job 注释里写明范围已扩大。

无包变更，故无 changeset。

Refs #4081、ADR-0053 D-A3 / D-C1。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqqZmPS5a4gJGBoCTwipFr

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqqZmPS5a4gJGBoCTwipFr)_