### PR TITLE
chore(plugins,services): declare providesServices on the remaining init-time providers (ADR-0116, #4131)

### DIFF
--- a/.changeset/plugin-ordering-provider-declarations.md
+++ b/.changeset/plugin-ordering-provider-declarations.md
@@ -1,0 +1,50 @@
+---
+"@objectstack/core": patch
+"@objectstack/plugin-auth": patch
+"@objectstack/plugin-email": patch
+"@objectstack/plugin-hono-server": patch
+"@objectstack/plugin-security": patch
+"@objectstack/service-storage": patch
+"@objectstack/service-settings": patch
+"@objectstack/service-realtime": patch
+"@objectstack/service-i18n": patch
+"@objectstack/service-analytics": patch
+"@objectstack/service-messaging": patch
+"@objectstack/service-cluster": patch
+"@objectstack/service-sms": patch
+"@objectstack/service-cache": patch
+"@objectstack/service-queue": patch
+"@objectstack/service-job": patch
+"@objectstack/service-datasource": patch
+"@objectstack/service-automation": patch
+"@objectstack/mcp": patch
+---
+
+chore(plugins,services): declare `providesServices` on the 20 remaining init-time service providers (ADR-0116 follow-up, #4131)
+
+ADR-0116 gave the kernel a declared ordering contract, but only
+`ObjectQLPlugin` and `MetadataPlugin` had declared what their `init()`
+registers. The pre-Phase-1 ordering check can only *name a provider* for
+services someone declared, so its coverage was two plugins wide.
+
+An audit of every plugin's `init()` body (brace-matched, comments stripped,
+each call classified by whether it sits inside a `try`/`if`) found 20 plugins
+that register a service on every path without declaring it. All 20 now
+declare `providesServices`. Purely additive: no ordering changes, no new
+failure modes — a `providesServices` entry only lets the kernel say *who*
+provides a service when it reports a misordering, and enriches the Phase-1
+`getService` miss diagnostic.
+
+Three needed a closer read before declaring, because they register the same
+service from several branches (`cache`, `queue`, `job`): each early-return
+branch plus the fallback registers it, so every path does — the declaration
+is honest. ADR-0116's rule that a *conditionally* registered service must
+never be declared is unchanged and was applied throughout.
+
+The same audit found 12 plugins that hard-resolve a service during `init()`
+(11 of them `manifest`) without declaring `requiresServices`. None is a live
+exposure — every one already declares a hard `dependencies` entry on the
+provider, so the kernel orders them correctly today. Those are tracked
+separately: with a hard dependency in place, `requiresServices` mostly
+restates what the kernel already enforces, and its real value is on
+*soft*-dependency consumers, of which `AppPlugin` is currently the only one.

--- a/packages/core/src/api-registry-plugin.ts
+++ b/packages/core/src/api-registry-plugin.ts
@@ -66,6 +66,11 @@ export function createApiRegistryPlugin(
 
   return {
     name: 'com.objectstack.core.api-registry',
+    /**
+     * Services init() registers on every path (ADR-0116, #4131) — lets the
+     * kernel name this plugin when a consumer requires one before it inits.
+     */
+    providesServices: ['api-registry'],
     type: 'standard',
     version: '1.0.0',
 

--- a/packages/mcp/src/plugin.ts
+++ b/packages/mcp/src/plugin.ts
@@ -93,6 +93,11 @@ export interface MCPServerPluginOptions {
  */
 export class MCPServerPlugin implements Plugin {
   name = 'com.objectstack.mcp';
+  /**
+   * Services init() registers on every path (ADR-0116, #4131) — lets the
+   * kernel name this plugin when a consumer requires one before it inits.
+   */
+  providesServices = ['mcp'];
   version = '1.0.0';
   type = 'standard' as const;
   dependencies: string[] = [];

--- a/packages/plugins/plugin-auth/src/auth-plugin.ts
+++ b/packages/plugins/plugin-auth/src/auth-plugin.ts
@@ -137,6 +137,11 @@ export interface AuthPluginOptions extends Partial<AuthConfig> {
  */
 export class AuthPlugin implements Plugin {
   name = 'com.objectstack.auth';
+  /**
+   * Services init() registers on every path (ADR-0116, #4131) — lets the
+   * kernel name this plugin when a consumer requires one before it inits.
+   */
+  providesServices = ['auth', 'tenancy'];
   type = 'standard';
   version = '1.0.0';
   dependencies: string[] = ['com.objectstack.engine.objectql']; // manifest service required

--- a/packages/plugins/plugin-email/src/email-plugin.ts
+++ b/packages/plugins/plugin-email/src/email-plugin.ts
@@ -57,6 +57,11 @@ export interface EmailServicePluginOptions {
  */
 export class EmailServicePlugin implements Plugin {
   name = 'com.objectstack.service.email';
+  /**
+   * Services init() registers on every path (ADR-0116, #4131) — lets the
+   * kernel name this plugin when a consumer requires one before it inits.
+   */
+  providesServices = ['email'];
   version = '1.0.0';
   type = 'standard';
   dependencies = ['com.objectstack.engine.objectql'];

--- a/packages/plugins/plugin-hono-server/src/hono-plugin.ts
+++ b/packages/plugins/plugin-hono-server/src/hono-plugin.ts
@@ -242,6 +242,11 @@ const DISCOVERY_ROUTE_SEGMENTS: Partial<Record<keyof ApiRoutes, string>> = {
  */
 export class HonoServerPlugin implements Plugin {
     name = 'com.objectstack.server.hono';
+    /**
+     * Services init() registers on every path (ADR-0116, #4131) — lets the
+     * kernel name this plugin when a consumer requires one before it inits.
+     */
+    providesServices = ['http.server', 'http-server'];
     type = 'server';
     version = '0.9.0';
 

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -296,6 +296,11 @@ export { describeHighPrivilegeBits } from '@objectstack/spec/security';
 
 export class SecurityPlugin implements Plugin {
   name = 'com.objectstack.security';
+  /**
+   * Services init() registers on every path (ADR-0116, #4131) — lets the
+   * kernel name this plugin when a consumer requires one before it inits.
+   */
+  providesServices = ['security.permissions', 'security.rls', 'security.fieldMasker', 'security.bootstrapPermissionSets', 'security.fallbackPermissionSet'];
   type = 'standard';
   version = '1.0.0';
   dependencies = ['com.objectstack.engine.objectql'];

--- a/packages/services/service-analytics/src/plugin.ts
+++ b/packages/services/service-analytics/src/plugin.ts
@@ -153,6 +153,11 @@ export interface AnalyticsServicePluginOptions {
  */
 export class AnalyticsServicePlugin implements Plugin {
   name = 'com.objectstack.service-analytics';
+  /**
+   * Services init() registers on every path (ADR-0116, #4131) — lets the
+   * kernel name this plugin when a consumer requires one before it inits.
+   */
+  providesServices = ['analytics'];
   version = '1.0.0';
   type = 'standard' as const;
   dependencies: string[] = [];

--- a/packages/services/service-automation/src/plugin.ts
+++ b/packages/services/service-automation/src/plugin.ts
@@ -313,6 +313,11 @@ export function findInertDeclaredConnectors(
  */
 export class AutomationServicePlugin implements Plugin {
     name = 'com.objectstack.service-automation';
+    /**
+     * Services init() registers on every path (ADR-0116, #4131) — lets the
+     * kernel name this plugin when a consumer requires one before it inits.
+     */
+    providesServices = ['automation'];
     version = '1.0.0';
     type = 'standard' as const;
     // Soft dependency on metadata: we look it up at start() and tolerate absence.

--- a/packages/services/service-cache/src/cache-service-plugin.ts
+++ b/packages/services/service-cache/src/cache-service-plugin.ts
@@ -61,6 +61,11 @@ export interface CacheServicePluginOptions {
  */
 export class CacheServicePlugin implements Plugin {
   name = 'com.objectstack.service.cache';
+  /**
+   * Services init() registers on every path (ADR-0116, #4131) — lets the
+   * kernel name this plugin when a consumer requires one before it inits.
+   */
+  providesServices = ['cache'];
   version = '1.0.0';
   type = 'standard';
 

--- a/packages/services/service-cluster/src/cluster-service-plugin.ts
+++ b/packages/services/service-cluster/src/cluster-service-plugin.ts
@@ -41,6 +41,11 @@ export interface ClusterServicePluginOptions {
  */
 export class ClusterServicePlugin implements Plugin {
     name = 'com.objectstack.service.cluster';
+    /**
+     * Services init() registers on every path (ADR-0116, #4131) — lets the
+     * kernel name this plugin when a consumer requires one before it inits.
+     */
+    providesServices = ['cluster'];
     version = '1.0.0';
     type = 'standard';
 

--- a/packages/services/service-datasource/src/datasource-admin-plugin.ts
+++ b/packages/services/service-datasource/src/datasource-admin-plugin.ts
@@ -167,6 +167,11 @@ export interface DatasourceAdminServicePluginOptions {
  */
 export class DatasourceAdminServicePlugin implements Plugin {
   name = 'com.objectstack.service-datasource-admin';
+  /**
+   * Services init() registers on every path (ADR-0116, #4131) — lets the
+   * kernel name this plugin when a consumer requires one before it inits.
+   */
+  providesServices = ['datasource-connection', 'datasource-admin'];
   version = '1.0.0';
   type = 'standard' as const;
   dependencies: string[] = [];

--- a/packages/services/service-datasource/src/plugin.ts
+++ b/packages/services/service-datasource/src/plugin.ts
@@ -44,6 +44,11 @@ export interface ExternalDatasourceServicePluginOptions {
  */
 export class ExternalDatasourceServicePlugin implements Plugin {
   name = 'com.objectstack.service-external-datasource';
+  /**
+   * Services init() registers on every path (ADR-0116, #4131) — lets the
+   * kernel name this plugin when a consumer requires one before it inits.
+   */
+  providesServices = ['external-datasource'];
   version = '1.0.0';
   type = 'standard' as const;
   dependencies: string[] = [];

--- a/packages/services/service-i18n/src/i18n-service-plugin.ts
+++ b/packages/services/service-i18n/src/i18n-service-plugin.ts
@@ -106,6 +106,11 @@ export interface I18nServicePluginOptions {
  */
 export class I18nServicePlugin implements Plugin {
   name = 'com.objectstack.service.i18n';
+  /**
+   * Services init() registers on every path (ADR-0116, #4131) — lets the
+   * kernel name this plugin when a consumer requires one before it inits.
+   */
+  providesServices = ['i18n'];
   version = '1.0.0';
   type = 'standard';
 

--- a/packages/services/service-job/src/job-service-plugin.ts
+++ b/packages/services/service-job/src/job-service-plugin.ts
@@ -43,6 +43,11 @@ export interface JobServicePluginOptions {
  */
 export class JobServicePlugin implements Plugin {
   name = 'com.objectstack.service.job';
+  /**
+   * Services init() registers on every path (ADR-0116, #4131) — lets the
+   * kernel name this plugin when a consumer requires one before it inits.
+   */
+  providesServices = ['job'];
   version = '1.1.0';
   type = 'standard';
 

--- a/packages/services/service-messaging/src/messaging-service-plugin.ts
+++ b/packages/services/service-messaging/src/messaging-service-plugin.ts
@@ -71,6 +71,11 @@ export interface MessagingServicePluginOptions {
  */
 export class MessagingServicePlugin implements Plugin {
     name = 'com.objectstack.service.messaging';
+    /**
+     * Services init() registers on every path (ADR-0116, #4131) — lets the
+     * kernel name this plugin when a consumer requires one before it inits.
+     */
+    providesServices = ['messaging', 'notification'];
     version = '1.0.0';
     type = 'standard' as const;
     dependencies = ['com.objectstack.engine.objectql'];

--- a/packages/services/service-queue/src/queue-service-plugin.ts
+++ b/packages/services/service-queue/src/queue-service-plugin.ts
@@ -36,6 +36,11 @@ export interface QueueServicePluginOptions {
  */
 export class QueueServicePlugin implements Plugin {
   name = 'com.objectstack.service.queue';
+  /**
+   * Services init() registers on every path (ADR-0116, #4131) — lets the
+   * kernel name this plugin when a consumer requires one before it inits.
+   */
+  providesServices = ['queue'];
   version = '1.1.0';
   type = 'standard';
 

--- a/packages/services/service-realtime/src/realtime-service-plugin.ts
+++ b/packages/services/service-realtime/src/realtime-service-plugin.ts
@@ -45,6 +45,11 @@ export interface RealtimeServicePluginOptions {
  */
 export class RealtimeServicePlugin implements Plugin {
   name = 'com.objectstack.service.realtime';
+  /**
+   * Services init() registers on every path (ADR-0116, #4131) — lets the
+   * kernel name this plugin when a consumer requires one before it inits.
+   */
+  providesServices = ['realtime'];
   version = '1.0.0';
   type = 'standard';
   dependencies = ['com.objectstack.engine.objectql'];

--- a/packages/services/service-settings/src/settings-service-plugin.ts
+++ b/packages/services/service-settings/src/settings-service-plugin.ts
@@ -73,6 +73,11 @@ export interface SettingsServicePluginOptions {
  */
 export class SettingsServicePlugin implements Plugin {
   name = SETTINGS_PLUGIN_ID;
+  /**
+   * Services init() registers on every path (ADR-0116, #4131) — lets the
+   * kernel name this plugin when a consumer requires one before it inits.
+   */
+  providesServices = ['settings'];
   version = SETTINGS_PLUGIN_VERSION;
   type = 'standard' as const;
 

--- a/packages/services/service-sms/src/sms-plugin.ts
+++ b/packages/services/service-sms/src/sms-plugin.ts
@@ -87,6 +87,11 @@ function providerFromSettings(values: Record<string, unknown>): {
  */
 export class SmsServicePlugin implements Plugin {
   name = 'com.objectstack.service.sms';
+  /**
+   * Services init() registers on every path (ADR-0116, #4131) — lets the
+   * kernel name this plugin when a consumer requires one before it inits.
+   */
+  providesServices = ['sms'];
   version = '1.0.0';
   type = 'standard' as const;
 

--- a/packages/services/service-storage/src/storage-service-plugin.ts
+++ b/packages/services/service-storage/src/storage-service-plugin.ts
@@ -115,6 +115,11 @@ export interface StorageServicePluginOptions {
  */
 export class StorageServicePlugin implements Plugin {
   name = 'com.objectstack.service.storage';
+  /**
+   * Services init() registers on every path (ADR-0116, #4131) — lets the
+   * kernel name this plugin when a consumer requires one before it inits.
+   */
+  providesServices = ['file-storage'];
   version = '1.0.0';
   type = 'standard';
 


### PR DESCRIPTION
ADR-0116（#4163）落地后的第一步补齐。ADR 给了内核一套**声明式**排序契约，但当时只有 `ObjectQLPlugin` 与 `MetadataPlugin` 声明了自己 `init()` 注册什么——所以 Phase 1 前置校验能"指名 provider"的覆盖面只有两个插件宽。

## 做法：先审计，再声明

写了一个一次性审计脚本，对每个插件**大括号配对**提取 `init()` 方法体（先剥离注释），再按调用是否位于 `try`/`if` 内分类。两个方法论上的坑值得记下来，因为第一版都踩了：

- 正则要求 `)` 后直接跟 `{`，漏掉了本仓库主流写法 `async init(ctx: PluginContext): Promise<void> {`（中间隔着返回类型标注）——修正后覆盖从 10 个文件涨到 35 个。
- 不剥离注释时，TSDoc 里的 `ctx.getService('manifest')` 会被当成真实依赖。

## A. 20 个 provider 补上声明（本 PR）

审计出 20 个插件在 `init()` 里**每条路径都会**注册服务却没声明。全部补上 `providesServices`：

| 插件 | 声明 |
|:---|:---|
| `com.objectstack.auth` | `auth`, `tenancy` |
| `com.objectstack.security` | `security.permissions`, `security.rls`, `security.fieldMasker`, `security.bootstrapPermissionSets`, `security.fallbackPermissionSet` |
| `com.objectstack.server.hono` | `http.server`, `http-server` |
| `com.objectstack.service.messaging` | `messaging`, `notification` |
| `com.objectstack.service-datasource-admin` | `datasource-connection`, `datasource-admin` |
| 其余 15 个 | 各自单一槽位（`email` / `api-registry` / `file-storage` / `settings` / `realtime` / `mcp` / `i18n` / `analytics` / `cluster` / `sms` / `cache` / `queue` / `job` / `external-datasource` / `automation`） |

**纯增量**：不改变任何排序，也不引入新的失败模式——`providesServices` 只让内核在报告顺序错误时能**指名**是谁提供该服务，并丰富 Phase 1 期间 `getService` miss 的诊断信息。

`cache` / `queue` / `job` 三个下手前逐条读了控制流：它们从多个分支注册同名服务（若干提前 return 分支 + 兜底分支），确认**每条路径都会注册**，所以声明是诚实的。ADR-0116 那条"条件注册的服务绝不能声明"的规则未变，全程遵守（脚本也会把条件注册单独列出来提示不要声明）。

## B. 12 个消费方：**不是**活的暴露，本 PR 不动

同一次审计发现 12 个插件在 `init()` 里同步硬取服务（其中 11 个取 `manifest`）却没声明 `requiresServices`。**逐个查证后确认全都已经通过 `dependencies` 硬依赖被正确排序**，没有一个是活的 #4085 类暴露。

这里记一次我自己的误判修正：中途一度判定 `plugin-auth` 与 `metadata-protocol` "无任何依赖声明"，是 grep 模式的问题——前者写作 `dependencies: string[] = [...]`（带类型标注），后者写作对象字面量的 `dependencies: [...]`（冒号非等号），都被漏掉了。

这个结论反过来收窄了后续范围：**对已声明硬依赖的消费方，`requiresServices` 价值有限**（内核本来就会先报 `Dependency ... not found`）。它真正有价值的地方是**软依赖**消费方——目前全仓只有 `AppPlugin` 一个。所以这批不做批量补，详情与清单见随后的 issue。

## 验证

- 全仓 `pnpm build` 71/71 通过（退出码直接捕获）。
- 全仓 `pnpm test`：除 `@objectstack/plugin-audit` 外全部通过。该失败与本 PR 无关，且已定位到机制——`audit-writers.test.ts` 的 `makeI18n()` 里有 `await import('@objectstack/core')`，失败的 `localizes verb + object label to the workspace locale (zh-CN)` 是全文件第一个触发这次**冷加载**的用例（耗时 20094ms，撞上 20s testTimeout），紧随其后调用同一 helper 的用例只要 104ms（模块已缓存）。单独跑 `plugin-audit` 46/46 稳过。已另开 issue 记录，不在本 PR 处理——本 PR 的 diff 是 20 个其它文件的声明，该用例一个都没 import。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DQuJBNpwStpJvo3owBw2B

---
_Generated by [Claude Code](https://claude.ai/code/session_014DQuJBNpwStpJvo3owBw2B)_