### PR TITLE
docs(adr): ADR-0104 附录 —— #3438 剩余两个 strict 翻转的证据来源方案（v17 姿态）

### DIFF
--- a/.changeset/adr-0104-remaining-flips-evidence.md
+++ b/.changeset/adr-0104-remaining-flips-evidence.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(adr): ADR-0104 addendum — evidence for the remaining #3438 strict flips (D1 references/structured JSON gate on a per-deployment `os migrate value-shapes` scan; fresh datastores attest both flags at creation; the D2 action-param flip rides the 18.0 major with an escape hatch) — releases nothing.

--- a/docs/adr/0104-field-runtime-value-shape-contract.md
+++ b/docs/adr/0104-field-runtime-value-shape-contract.md
@@ -3,7 +3,9 @@
 - **Status**: Accepted (2026-07-22) — staged per D4. D1 landed (#3429), D2
   landed (#3432); D3 refined into two waves by the 2026-07-24 addendum below,
   and wave 2's ownership model settled by the 2026-07-27 addendum.
-  Strict-default flip of D1/D2 tracked in #3438; wave 2 sequence in #3459.
+  Strict-default flip of D1/D2 tracked in #3438 — the media half flips per
+  deployment (#3681); evidence for the remaining halves decided by the
+  2026-07-30 addendum. Wave 2 sequence in #3459.
 - **Date**: 2026-07-22
 - **Issue**: design follow-up generalizing #3405 / #3406 (inline lookup param
   silently stripped); relates #3407 (silently dropped writes), #1878 / #1891
@@ -716,3 +718,155 @@ separate ADRs, because each settles *how* D3's already-accepted "field values
 point into `sys_file`" reaches production rather than revisiting whether to do
 it. A future choice that stands on its own (say, a chunked-migration protocol,
 or byte-layer content dedup) would earn its own ADR.
+
+## Addendum (2026-07-30) — evidence for the remaining flips: a scan gate for references / structured JSON; the action-param flip rides a declared major
+
+The 2026-07-27 amendment split #3438 into three and settled only the first:
+media value shapes flip per deployment, on the `adr-0104-file-references` flag
+(#3681). The other two were left "blocked on someone deciding what would
+constitute evidence." This addendum decides — differently for the two, because
+their facts have different epistemic reach — and fixes the release vehicle for
+each around the v17 major.
+
+One timeline fact frames everything: **warn-first itself first reaches stable
+deployments in 17.0.** D1 and D2 ride the v17 train (their changesets sit in
+the same pre-mode window as this addendum), so no stable deployment has served
+a single day of the warn window yet. Whatever the right gate is, 17.0 cannot
+flip any default version-wide without deleting the warn window R2/R3 promised
+— independent of the per-deployment argument.
+
+### D1 references + structured JSON: the evidence can exist, so build it
+
+The fact strict enforcement needs is: *no stored value of the covered classes
+fails `valueSchemaFor(field, 'stored')`.* The covered classes are exactly the
+validator's own non-media branch — `REFERENCE_VALUE_TYPES` (single-value
+`lookup` / `master_detail` / `user` / `tree`) and `STRUCTURED_JSON_TYPES`
+(`location` / `address` / `composite` / `repeater` / `record` / `vector`;
+`json`'s derived schema is deliberately `z.unknown()`, so it can yield no
+findings). Unlike caller behaviour, data at rest is enumerable: a scan that
+walks every row is **complete** evidence, with the same epistemic standing the
+file reconciliation has. So the gate takes the #3617 shape, minus the
+backfill:
+
+```
+os migrate value-shapes
+  1. scan every object's covered fields against valueSchemaFor(field, 'stored')
+  2. report violations per (object, field, type): count, sample record ids,
+     first parse issue — the per-deployment form of R1's stored-data audit
+  3. zero blocking findings + --apply → record sys_migration
+       { id: 'adr-0104-value-shapes', verified_at, blocking: 0 }
+  4. strict enforcement of the covered classes reads THAT row, never the
+     version number
+```
+
+- **There is nothing to convert.** A malformed `location` payload, or an
+  expanded object stored where an id belongs, is an application-data fix only
+  its owner can make: the command reports and prescribes; the operator fixes
+  and re-runs until green. (A mechanical normaliser — say, collapsing a stored
+  expanded-lookup object to its `id` — is deliberately *not* built until real
+  reports show the shape common enough to justify one; a normaliser that
+  guesses is how silently-wrong values got here.) With no conversions,
+  `--apply`'s only write is the flag row — which keeps the #3617 invariant
+  intact: a dry run changes nothing, and whether a run changed the
+  deployment's posture never depends on what the run found.
+- **The scanner and the validator share one predicate.** Same class sets,
+  same cached `valueSchemaFor`, same skip rules (`system` / `readonly` /
+  lifecycle columns are never validated, so they are never scanned): the scan
+  must count exactly what strict mode would reject on that record's next
+  rewrite, and nothing else. Imported, not re-derived — hand-copied value
+  knowledge is the disease this ADR exists to cure.
+- **Gate consumption mirrors the media half verbatim**: the engine reads the
+  flag once per process (memoized), an object declaring no covered field never
+  consults it, `ValidateRecordOptions` gains the parallel option beside
+  `mediaValueShapeStrict`, and a later failing run clears `verified_at` — a
+  regression closes its own gate.
+- **Precedence, and the one new env var**: `OS_ALLOW_LAX_VALUE_SHAPES` (an
+  `OS_ALLOW_*` escape hatch per Prime Directive #9, scoped to these classes —
+  media keeps its own `OS_ALLOW_LAX_MEDIA_VALUES`) beats
+  `OS_DATA_VALUE_SHAPE_STRICT_ENABLED` (unchanged: still the all-class
+  opt-in) beats the flag. Same contradictory-config rule as
+  `mediaStrictEffective`, for the same reason: wrongly lax costs a warning,
+  wrongly strict stops a working app.
+
+### Fresh datastores attest at creation — both flags
+
+Today nothing records a flag except a migration run, which leaves a gap at
+the other end of a deployment's life: a deployment born on ≥17 starts **lax**
+and stays lax until its operator thinks to run a migration that is, for them,
+a no-op. The warn regime would never die out — every new deployment re-enters
+it.
+
+So the bootstrap that creates an empty datastore records both rows
+(`adr-0104-file-references`, `adr-0104-value-shapes`) at creation time. This
+is not version-gating in disguise: the fact recorded — *no legacy value
+exists here* — is **observed** (the store is empty by construction at the
+moment of creation), the same observed-transition discipline the GC gate runs
+on. An existing database upgrading to 17 is non-empty at boot, gets no
+attestation, and keeps producing its evidence by scan. A later legacy import
+into a born-strict deployment is rejected loudly at the write path — the
+correct outcome; an operator who must temporarily admit such data has the
+escape hatch, and re-verifies by re-running the scan. The exact seam is the
+implementing PR's decision (candidates: the system seed that first creates
+`sys_migration`, or the engine's schema bootstrap), with one hard
+requirement: it fires only for a store it is itself creating from empty,
+never for one it found.
+
+Born-strict deployments also make the platform's own dogfood the standing
+canary for R2 (a codified shape stricter than some legitimate client's
+writes): showcase/CRM boots are fresh datastores, so they enforce from birth,
+and a false rejection fails our suites before any customer sees it.
+
+### D2 action params: the evidence cannot exist, so the honest gate is a declared major
+
+What per-deployment evidence would have to prove is: *no caller of this
+deployment still depends on the lax contract.* Callers are not enumerable —
+an integration that fires monthly, a script in a cron nobody remembers, an AI
+agent constructing each call fresh. Data at rest can be scanned to
+completion; future calls cannot. A "quiet for N days" flag would assert a
+completeness it cannot have — the unlocatable-gate error of the 2026-07-27
+addendum, reproduced one layer down. A gate must not claim evidence that
+cannot exist, and we decline to build the theatre of one.
+
+What remains is the failure-mode calculus that already sequenced wave 2: a
+strict rejection here is **loud** (a 400 naming the offending param and the
+declared list), **caller-facing** (a developer or an AI mid-integration — not
+an end user stranded in a form above data they cannot fix), **recoverable**
+(fix the call), and **reversible** (the escape hatch below). No data is
+stranded, no byte is deleted. That is precisely the class of break wave 2's
+step 4 was allowed to ride a declared major for, while step 6 waits on
+evidence.
+
+So, owned explicitly rather than smuggled: **the D2 flip is a version flip —
+on the major *after* the warn window, not this one.** 17.0 ships warn-first
+(first exposure) and announces the coming default in its release notes; 18.0
+flips `actionParamsStrict()` to default-true. The v17→v18 gap is every
+deployment's own warn window, served on its own upgrade schedule; the warn
+line already names `OS_ACTION_PARAMS_STRICT_ENABLED=1`, which is the
+per-deployment act of opting into tomorrow's default today. Version-wide
+flips remain wrong where per-deployment evidence is *possible* (D1); where it
+is impossible in principle, a declared major with a served warn window and an
+escape hatch is what honest looks like. The alternative — warn forever —
+permanently un-enforces the declared contract at exactly the surface (AI/MCP
+callers) D2 was built for, where a 400 is corrective feedback the caller
+consumes and a server-side warn is feedback nobody sees.
+
+Mechanics at 18.0: `OS_ACTION_PARAMS_STRICT_ENABLED` stays accepted — it
+becomes a redundant opt-in to the default; its semantics never change, so no
+`readEnvWithDeprecation` rename, the same conclusion the media half reached.
+A new `OS_ALLOW_LAX_ACTION_PARAMS` opt-out wins over everything (the
+contradictory-config rule again), and the dogfood contract suite
+(`action-params-contract.dogfood.test.ts`) flips its duals so the *default*
+path is the strict one and the escape hatch is the explicitly-set case.
+
+### What rides where
+
+| vehicle | change |
+|---|---|
+| 17.0 | warn-first first ships (D1 non-media + D2). `os migrate value-shapes` + the `adr-0104-value-shapes` gate wiring. Fresh-datastore attestation of both flags. Release notes announce the 18.0 D2 default. **No version-wide default changes.** |
+| each deployment, ≥17.0 | runs `os migrate value-shapes --apply` (or is born attested) → its own D1 non-media classes flip to strict. |
+| 18.0 | D2 strict by default + `OS_ALLOW_LAX_ACTION_PARAMS`; dogfood duals flip. |
+
+#3438 then tracks two work items instead of an open question: the scan
+migration (command, engine wiring, creation-time attestation) targeting the
+17.0 train, and the D2 flip parked for the 18.0 train with its release-note
+announcement landing now.


### PR DESCRIPTION
## 方案（针对 #3438，准备 v17 大版本发布）

#3438 的三块中，第 1 块（D1 媒体类型）已由 #3681 按部署翻转落地；本 PR 以 ADR-0104 附录（2026-07-30）的形式，为剩下两块提出方案。**纯设计文档，不改任何运行时行为，不发布任何包**（changeset 为空 frontmatter，沿用 `adr-0104-design-doc-only` 先例）。

### 先立一个时间线事实

warn-first 本身是**随 17.0 首发**的——D1/D2 的 changeset 都还在本次 pre-mode 发版窗口里，没有任何稳定版部署经历过哪怕一天的告警窗口。所以无论采用哪种门禁，**17.0 都不能按版本号翻转任何默认值**——那会直接吞掉 R2/R3 承诺的 warn 窗口，这一点独立于「按部署生效」的论证而成立。

### D1 引用 + 结构化 JSON：证据可以存在，所以把它建出来

要证明的事实是「本部署存量数据中没有会被 `valueSchemaFor(field, 'stored')` 拒绝的值」。与调用方行为不同，**存量数据是可枚举的**——全量扫描即为完备证据，与 file-as-reference 的对账在认识论上同级。因此复用 #3617 的门禁形状（去掉回填步骤）：

```
os migrate value-shapes        # dry run：只报告，不写任何东西
os migrate value-shapes --apply  # 零阻断项 → 记录 adr-0104-value-shapes 标记
```

- **没有可转换的东西**：畸形 `location`、存成展开对象的 lookup 只能由应用作者修，命令负责报告+处方，修完重跑到绿。`--apply` 唯一的写入就是标记行，保住 #3617 的不变量（dry run 零写入；posture 是否改变从不取决于扫描结果）。机械归一化器（如展开对象折回 id）**刻意不先建**，等真实报告证明该形态足够普遍再说。
- **扫描器与校验器共用同一个谓词**（同类集合、同 `valueSchemaFor`、同 skip 规则），import 而非重推导——手抄值知识正是本 ADR 要治的病。
- **门禁消费与媒体半边逐字对齐**：引擎 memoized 读取、无相关字段的对象零开销、失败重跑清除 `verified_at`。新增逃生阀 `OS_ALLOW_LAX_VALUE_SHAPES`（PD#9 的 `OS_ALLOW_*` 形态），优先级同 `mediaStrictEffective`。

### 新建数据库在创建时直接记账（两个标记都记）

现在只有迁移运行会记标记，导致 ≥17 新生部署永远从 lax 起步、warn 体制永不消亡。方案：**创建空数据库的引导路径在创建时刻记录两个标记行**。这不是变相按版本判断——被记录的事实（「此处不存在遗留值」）是**被观察到的**（创建时刻库确实为空），与 GC 门禁的 observed-transition 纪律同源。升级上来的老库非空、不记账、仍走扫描取证。附带收益：showcase/CRM 的 fresh 启动天生 strict，平台自己的 dogfood 成为 R2（契约比现实更严）的常驻金丝雀。

### D2 动作参数：证据在原理上不可能存在，诚实的门禁是「声明过的大版本」

要证明的是「本部署没有调用方还依赖宽松契约」——**调用方不可枚举**（每月才跑的集成、无人记得的 cron、每次现构造调用的 AI agent）。存量数据可以扫完，未来的调用不能。任何「静默 N 天」标记都在断言它不可能拥有的完备性——这正是 2026-07-27 附录清除的「无处安放的门禁」错误在下一层的复现。**我们拒绝建一个表演性的门禁。**

剩下的就是 wave 2 已经用过的失败模式演算：D2 拒绝是**响亮的**（400 点名违规参数和声明清单）、**面向调用方的**（开发者/AI，不是被表单卡死的最终用户）、**可恢复且可回退的**（逃生阀）。不搁浅数据、不删字节——这正是 wave 2 第 4 步（写入切换）被允许骑大版本、而第 6 步（GC）必须等证据的那一类。

所以**明确认账**：D2 是按版本翻转，但在 **warn 窗口之后的那个大版本（18.0）**，不是 17.0。17.0 首发 warn-first 并在发版说明中预告；17→18 的间隔就是每个部署按自己节奏经历的 warn 窗口（告警行已点名 `OS_ACTION_PARAMS_STRICT_ENABLED=1`，即「今天就选进明天默认值」的部署级动作）。18.0 翻转默认值，新增 `OS_ALLOW_LAX_ACTION_PARAMS` 逃生阀；`OS_ACTION_PARAMS_STRICT_ENABLED` 语义不变故无需改名（与媒体半边同一结论）；dogfood 对偶用例翻转为「默认即严格」。

### 各版本承载什么

| 载体 | 内容 |
|---|---|
| 17.0 | warn-first 首发；`os migrate value-shapes` + 门禁接线；新库创建时记账；发版说明预告 18.0 的 D2 默认值。**无任何按版本号的默认值翻转** |
| 各部署 ≥17.0 | 跑 `os migrate value-shapes --apply`（或生而记账）→ 自己的 D1 非媒体类翻 strict |
| 18.0 | D2 默认 strict + `OS_ALLOW_LAX_ACTION_PARAMS` |

### 后续工作项（本 PR 合并后从 #3438 拆出）

1. `os migrate value-shapes` 命令 + 引擎门禁接线 + 创建时记账（17.0 车次）
2. 17.0 发版说明补 D2 预告段
3. 18.0 车次：D2 翻转 + dogfood 对偶

Closes nothing — #3438 保持打开作为两个工作项的跟踪。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zgA8CQMJeJbFEjnbib1Uv

---
_Generated by [Claude Code](https://claude.ai/code/session_016zgA8CQMJeJbFEjnbib1Uv)_