### PR TITLE
test(runtime): 把「谁在服务 /data 与 /discovery」钉成事实，用证据挡住 #4073 的默认值翻转

### DIFF
--- a/.changeset/standard-endpoints-precedence-pin.md
+++ b/.changeset/standard-endpoints-precedence-pin.md
@@ -1,0 +1,23 @@
+---
+"@objectstack/runtime": patch
+---
+
+test(runtime): pin who actually serves `/data` and `/discovery`, blocking the #4073 default flip on evidence
+
+#4073 plans to retire `registerStandardEndpoints` by flipping its default to
+`false`, on the premise that everything it mounts is duplicate supply. Booted for
+real — real `HonoServerPlugin`, real dispatcher, real `createRestApiPlugin`, real
+listener, in `serve.ts`'s registration order — that premise holds for only one
+half of the surface:
+
+- **`/discovery` + `/.well-known/objectstack` — safe.** They cede by an explicit
+  `kernel.hasPlugin(rest|dispatcher)` check (#4018), so the dispatcher's computed
+  payload answers whether the flag is on or off. Order-independent.
+- **`/data/:object` — not safe.** There is no cede, and the shadowing was
+  asserted purely on "REST registers first and wins". With the flag OFF the path
+  returns **404**, with REST mounted or not. The flag's raw surface is the only
+  thing answering it in every composition this harness can boot.
+
+So the flip is not the no-op the plan describes. This adds the harness that says
+so, asserting the current matrix, so the next attempt has to confront it rather
+than re-derive the assumption. No production code changes.

--- a/packages/runtime/src/standard-endpoints-precedence.integration.test.ts
+++ b/packages/runtime/src/standard-endpoints-precedence.integration.test.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #4073 — is `registerStandardEndpoints` really all DUPLICATE supply?
+ *
+ * The retirement plan (flip the default to `false` → observe a release → delete
+ * `registerDiscoveryAndCrudEndpoints`) rests on that premise: every path the
+ * flag mounts is also served, more completely, by `@objectstack/rest` or the
+ * runtime dispatcher, so flipping the default changes nothing a caller can see.
+ *
+ * The premise is not uniform across the surface — the two halves reach it by
+ * different mechanisms, and only one of them holds:
+ *
+ *  - **`/discovery` + `/.well-known/objectstack` — ceded explicitly (#4018).**
+ *    `registerDiscoveryEndpoints` checks `kernel.hasPlugin(rest|dispatcher)` and
+ *    declines to register at all. That is order-independent, so it holds however
+ *    Hono resolves precedence. Verified below against the REAL dispatcher.
+ *
+ *  - **`/data/:object` — no such check.** Its shadowing is asserted purely on
+ *    "REST registers first and wins". Booted for real, that does not hold: with
+ *    the flag off the path is a 404, with REST mounted or not. The flag's raw
+ *    surface is the ONLY thing answering `/api/v1/data/:object` in every
+ *    composition this harness can boot.
+ *
+ * So the flip is NOT the no-op the plan describes, and this file exists to keep
+ * it from being made on the assumption. If you are here because you are about to
+ * flip the default: first make `rest=true, flag=OFF` serve `/data/:object`, then
+ * update these expectations in the same commit.
+ *
+ * Caveat, stated so the next reader does not over-read this: REST is mounted
+ * here with a minimal service set (`objectql` + `auth`). A fully provisioned
+ * `os serve` also has metadata/protocol services, and REST may mount `/data`
+ * only once those resolve. What is proven is narrower than "REST never serves
+ * `/data`" — it is "nothing in these compositions serves it once the flag is
+ * off", which is enough to block a default flip that assumes otherwise.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { LiteKernel } from '@objectstack/core';
+import { HonoServerPlugin } from '@objectstack/plugin-hono-server';
+import { createDispatcherPlugin } from './dispatcher-plugin.js';
+
+function stubServices() {
+    return {
+        name: 'com.objectstack.test.standard-endpoints-precedence',
+        version: '1.0.0',
+        init: async (ctx: any) => {
+            ctx.registerService('objectql', {
+                async find() { return [{ id: 'r1' }]; },
+                async findOne() { return { id: 'r1' }; },
+                async insert(_o: string, d: any) { return d; },
+            });
+            ctx.registerService('auth', {
+                async getSession() { return { user: { id: 'u1' }, session: {} }; },
+            });
+        },
+    };
+}
+
+async function boot(registerStandardEndpoints: boolean, withRest: boolean) {
+    const kernel = new LiteKernel();
+    kernel.use(stubServices());
+    // `serve.ts` order, real plugins: HonoServerPlugin (line 1173) long before
+    // REST (line 1872) and the dispatcher (line 1883).
+    kernel.use(new HonoServerPlugin({ port: 0, registerStandardEndpoints, cors: false }));
+    if (withRest) {
+        const { createRestApiPlugin } = await import('@objectstack/rest');
+        kernel.use(createRestApiPlugin({} as any));
+    }
+    kernel.use(createDispatcherPlugin({ prefix: '/api/v1', securityHeaders: false, requireAuth: false }));
+    await kernel.bootstrap();
+    const server = kernel.getService<any>('http.server');
+    return { kernel, baseUrl: `http://127.0.0.1:${server.getPort()}` };
+}
+
+let kernel: LiteKernel | undefined;
+afterEach(async () => {
+    if (kernel) await Promise.race([kernel.shutdown(), new Promise<void>((r) => setTimeout(r, 5_000))]);
+    kernel = undefined;
+});
+
+describe('#4073 — registerStandardEndpoints is not uniformly duplicate supply', () => {
+    for (const withRest of [true, false]) {
+        const label = withRest ? 'REST + dispatcher' : 'dispatcher only';
+
+        it(`${label}: with the flag ON, /data/:object is served and gated`, async () => {
+            const booted = await boot(true, withRest);
+            kernel = booted.kernel;
+            const res = await fetch(`${booted.baseUrl}/api/v1/data/account`);
+            // 401 — the anonymous-deny gate (#2567) fired, which proves the route
+            // is MOUNTED. A 404 would mean nothing is serving it.
+            expect(res.status, 'flag ON must mount /data/:object').toBe(401);
+        }, 30_000);
+
+        it(`${label}: with the flag OFF, /data/:object 404s — nothing else picks it up`, async () => {
+            const booted = await boot(false, withRest);
+            kernel = booted.kernel;
+            const res = await fetch(`${booted.baseUrl}/api/v1/data/account`);
+            expect(
+                res.status,
+                'if this is no longer 404, another plugin now serves /data — re-read #4073, the flip may be safe',
+            ).toBe(404);
+        }, 30_000);
+    }
+
+    /**
+     * The half of the surface that IS safe to retire: discovery cedes by an
+     * explicit `hasPlugin` check, so the dispatcher's computed payload answers
+     * whether the flag is on or off.
+     */
+    for (const flag of [true, false]) {
+        it(`discovery is the dispatcher's either way — flag ${flag ? 'ON' : 'OFF'} (#4018 cede)`, async () => {
+            const booted = await boot(flag, false);
+            kernel = booted.kernel;
+            const res = await fetch(`${booted.baseUrl}/api/v1/discovery`);
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            // `data.routes` is the dispatcher's shape; the flag's own payload is
+            // a flat `{ version, apiName, routes, capabilities }`.
+            expect(body?.data?.routes, 'the dispatcher must own discovery').toBeTruthy();
+        }, 30_000);
+    }
+});


### PR DESCRIPTION
#4073 的退役计划是：`registerStandardEndpoints` 默认翻 `false` → 观察一个 release → 删除 `registerDiscoveryAndCrudEndpoints`。**前置拆分已经完成**（#4144 把三条 `/me/*` 挪出了这个门），所以下一步本该是翻默认值。

我去做这一步，先验证它是不是计划所说的 no-op。**不是。**

## 实测

真实 `HonoServerPlugin` + 真实 dispatcher + 真实 `createRestApiPlugin`，真实监听端口，按 `serve.ts` 的注册顺序装配：

| REST | flag | `GET /api/v1/data/account` |
|:---:|:---:|:---|
| ✓ | ON | **401** —— 路由已挂载，#2567 匿名闸门生效 |
| ✓ | **OFF** | **404** —— 无人接手 |
| ✗ | ON | 401 |
| ✗ | **OFF** | **404** |

这个面的两半，性质完全不同：

- **`/discovery` + `/.well-known/objectstack` —— 安全。** 它们靠 `kernel.hasPlugin(rest|dispatcher)` **显式 cede**（#4018），与注册顺序无关，所以无论 flag 开关，应答的都是 dispatcher 计算出的 payload。本 PR 两个方向都验证了。
- **`/data/:object` —— 不安全。** 它**没有** cede 判断。它的"被遮蔽"完全建立在"REST 先注册先赢"这一条推断上，而真实监听器上不是这样：翻掉默认值不会把这条路径交给 REST，而是让它变成 **404**。

## 所以本 PR 只做一件事

不翻默认值。加上说明这一点的测试，断言当前矩阵，让下一次尝试**必须正面回应它**，而不是重新推导一遍那个假设。**无任何生产代码改动。**

`/data` 那两条断言的失败信息直接写了下一步该干什么：

```
if this is no longer 404, another plugin now serves /data — re-read #4073, the flip may be safe
```

## 边界（文件里也写了，免得被过度解读）

REST 在这个 harness 里只配了最小服务集（`objectql` + `auth`）。真实 `os serve` 还有 metadata/protocol 等服务，REST 可能要等这些解析完才挂 `/data`。所以本 PR 证明的是**「flag 关掉后，这些装配里没有任何东西服务 `/data`」**，不是「REST 从不服务 `/data`」。

但这已足以**挡住一个假设了相反前提的默认值翻转** —— 而且如果完整供给的 REST 确实会挂上这条路径，那条断言就会失败，那正是该回头重读 #4073 的信号。

这也正是 #4073 自己订正过一次的那类错误（"我当时查的是谁传这个选项，没查谁依赖这个默认值"）—— 这次是"查的是谁声称提供，没查真实监听器上谁应答"。

## 关联

#4073、#4018（cede 机制）、#2567（匿名闸门，401 的来源）、#4144（前置拆分，已合并）。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gEeLZ4oTeSXG6fKG1r3vd

---
_Generated by [Claude Code](https://claude.ai/code/session_016gEeLZ4oTeSXG6fKG1r3vd)_