### PR TITLE
fix(plugin-audit): stop charging a cold module load to one test's timeout (#4186)

### DIFF
--- a/.changeset/audit-test-static-imports.md
+++ b/.changeset/audit-test-static-imports.md
@@ -1,0 +1,23 @@
+---
+"@objectstack/plugin-audit": patch
+---
+
+fix(plugin-audit): the localized-summary tests stop charging a cold module load to one test's timeout (#4186)
+
+`audit-writers.test.ts` resolved `@objectstack/core` and its translation
+bundle with `await import(...)` inside the first localized test's helper, so
+that single test paid the whole cold-start cost — resolution plus vite
+transform of a large barrel — while every later case ran warmed in ~1ms.
+
+That cost is real work being billed to a per-test timeout budget. The file
+already carried a `{ timeout: 20_000 }` override for exactly this reason (its
+comment measured the cold start at ~5s on a 4-vCPU runner). Under a full-repo
+`pnpm test`, where a dozen packages' vitest workers compete, the cold start
+grew past that bound too and the case failed at 20s — reproducibly in CI-like
+load, never in isolation, which is the worst shape a red test can have: it
+tracks machine load rather than code.
+
+Both imports are now static. The same work happens during collection, which no
+single test's timeout is charged for, so the previously failing case runs in
+1ms and the timeout override is gone — the default timeout is now an honest
+bound, and a case that exceeds it is a real hang rather than a slow import.

--- a/packages/plugins/plugin-audit/src/audit-writers.test.ts
+++ b/packages/plugins/plugin-audit/src/audit-writers.test.ts
@@ -2,6 +2,16 @@
 
 import { describe, it, expect } from 'vitest';
 import { installAuditWriters } from './audit-writers.js';
+// STATIC on purpose (#4186). These were `await import(...)` inside the first
+// localized test's helper, so that one test paid the whole cold-start cost of
+// resolving + transforming @objectstack/core and the translation bundle, while
+// every later case ran warmed in ~1ms. That is a per-test timeout budget spent
+// on module loading: it grew past the 20s override this file used to carry and
+// failed the suite under parallel load. As module-level imports the same work
+// happens during collection, which no single test's timeout is charged for.
+// Do not make these lazy again.
+import { createMemoryI18n } from '@objectstack/core';
+import { AuditTranslations } from './translations/index.js';
 
 /**
  * Regression coverage for #1532 — on single-tenant stacks the
@@ -530,20 +540,15 @@ describe('audit writers — update diff hygiene (objectui detail-history report)
   });
 });
 
-// timeout: the FIRST localized case pays the one-off cost of dynamically
-// importing @objectstack/core + the shipped translation bundle (and, with the
-// #3071 src aliases, their vite transforms). On a shared 4-vCPU CI runner that
-// cold start alone was measured at ~5s — right at vitest's default timeout —
-// while every warmed case runs in ~1ms. 20s bounds the cold start without
-// masking a real hang.
-describe('audit writers — localized activity summaries (framework#3039)', { timeout: 20_000 }, () => {
+// No timeout override: the cold-start cost that used to need one moved to this
+// file's static imports (#4186). Every case here runs in ~1ms, so the default
+// timeout is the honest bound — a case that exceeds it is a real hang.
+describe('audit writers — localized activity summaries (framework#3039)', () => {
   // Real memory i18n (what the kernel registers as the 'i18n' fallback) loaded
   // with this plugin's shipped bundle plus an app-contributed object label —
   // exercises the actual key shapes (`messages.activityCreated`,
   // `objects.{name}.label`) end to end.
-  async function makeI18n() {
-    const { createMemoryI18n } = await import('@objectstack/core');
-    const { AuditTranslations } = await import('./translations/index.js');
+  function makeI18n() {
     const i18n = createMemoryI18n();
     for (const [locale, data] of Object.entries(AuditTranslations)) {
       i18n.loadTranslations(locale, data as Record<string, any>);
@@ -580,7 +585,7 @@ describe('audit writers — localized activity summaries (framework#3039)', { ti
   });
 
   it('localizes verb + object label to the workspace locale (zh-CN)', async () => {
-    const { fire, created } = setup('zh-CN', await makeI18n());
+    const { fire, created } = setup('zh-CN', makeI18n());
 
     await fire('afterInsert', insertCtx());
     await fire('afterDelete', { ...insertCtx(), result: null, __previous: { id: 'q-1', name: 'OC-00001' } });
@@ -590,7 +595,7 @@ describe('audit writers — localized activity summaries (framework#3039)', { ti
   });
 
   it('localizes the generic update fallback', async () => {
-    const { fire, created } = setup('zh-CN', await makeI18n());
+    const { fire, created } = setup('zh-CN', makeI18n());
     await fire('afterUpdate', {
       ...insertCtx(),
       __previous: { id: 'q-1', name: 'OC-00001', status: 'draft' },
@@ -605,7 +610,7 @@ describe('audit writers — localized activity summaries (framework#3039)', { ti
     // localized, label falls back to the authored def label.
     const { fire, created } = setup(
       'zh-CN',
-      await makeI18n(),
+      makeI18n(),
       { crm_lead: { label: 'Lead' } },
       { ...SINGLE_TENANT, crm_lead: ['id', 'name'] },
     );
@@ -631,7 +636,7 @@ describe('audit writers — localized activity summaries (framework#3039)', { ti
   });
 
   it('memoizes the locale lookup per tenant/user scope (hot-path guard)', async () => {
-    const { fire, localeCalls } = setup('zh-CN', await makeI18n());
+    const { fire, localeCalls } = setup('zh-CN', makeI18n());
     await fire('afterInsert', insertCtx());
     await fire('afterInsert', { ...insertCtx(), result: { id: 'q-2', name: 'OC-00002' } });
     expect(localeCalls()).toBe(1);
@@ -662,7 +667,7 @@ describe('audit writers — localized activity summaries (framework#3039)', { ti
   }
 
   it('localizes the @mention notification title to the recipient locale', async () => {
-    const { fire, emits } = setupWithMessaging('zh-CN', await makeI18n());
+    const { fire, emits } = setupWithMessaging('zh-CN', makeI18n());
     await fire('afterInsert', {
       object: 'sys_comment',
       input: {},


### PR DESCRIPTION
Closes #4186。

## 问题

`audit-writers.test.ts` 的 `makeI18n()` 里用 `await import(...)` 取 `@objectstack/core` 和翻译包，于是**全文件第一个**调用它的用例独自承担了整个冷启动代价（解析 + 一个大 barrel 的 vite transform），而其后调用同一 helper 的用例都是热的、约 1ms。

这是把真实工作量记在**单个用例的超时预算**上。在全仓 `pnpm test`（十几个包的 vitest worker 互相抢 CPU）下，该用例耗时 20094ms 撞上超时，**在负载下可复现、单独跑必过**——这是红灯最糟糕的一种形态：它反映的是机器负载，不是代码。

## 这不是第一次

文件里原本就有一段注释和一个 `{ timeout: 20_000 }` 覆盖，写明：

> the FIRST localized case pays the one-off cost of dynamically importing @objectstack/core + the shipped translation bundle … On a shared 4-vCPU CI runner that cold start alone was measured at ~5s … 20s bounds the cold start without masking a real hang.

也就是说**当年已经诊断对了，处置是放宽超时**。现在冷启动在更高并行度下涨过了 20s，这个 band-aid 被撑破。再放宽一次只会重复同一循环，所以这次拔根因。

## 改动

两个 import 提为顶层静态；删掉 timeout 覆盖；`makeI18n` 随之变为同步函数，5 处调用点去掉 `await`。顶层留了注释说明为何必须保持静态，防止后人改回懒加载。

**为什么静态是安全的**（动手前查过，动机不是规避循环依赖）：`plugin-audit` 的 `package.json` 里正常依赖 `@objectstack/core`；core 不反向依赖 plugin-audit；且本包自己的生产源码 `audit-plugin.ts` **本来就静态 import 它**。

## 验证

改后单跑该文件（`--reporter=verbose`）：

```
✓ … localizes verb + object label to the workspace locale (zh-CN)  1ms      ← 原 20094ms（超时）
✓ … localizes the generic update fallback                          0ms
Duration 3.89s (transform 2.87s, import 3.67s, tests 23ms)
```

机制吻合诊断：冷启动成本原封不动地转移到了 collection 阶段的 import/transform，而那部分不计入任何单个用例的超时预算，所以用例本身回到 1ms。`plugin-audit` 全包 4 文件 / 46 用例通过。全仓 `pnpm test` 在并行压力下的复验正在跑，结果会跟评论补上。

顺带扫了一遍：全仓没有第二个测试文件同时具备"timeout 覆盖 + 动态导入"这一组合，是孤例，不需要成规模整改。（测试里裸用 `await import()` 常常是合法的模块 mock 手法，所以有意义的信号是它与放宽超时的**共现**，而该集合为空。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DQuJBNpwStpJvo3owBw2B

---
_Generated by [Claude Code](https://claude.ai/code/session_014DQuJBNpwStpJvo3owBw2B)_