### PR TITLE
feat(showcase): 演示作用于选中记录的批量 action

### DIFF
--- a/.changeset/showcase-bulk-actions-example.md
+++ b/.changeset/showcase-bulk-actions-example.md
@@ -1,0 +1,7 @@
+---
+---
+
+Showcase-only: a `bulk_actions` view on `showcase_task` demonstrating
+`bulkActions` (declared object actions fanned out over the selected records),
+plus the UI tour note distinguishing it from `bulkActionDefs`. Releases
+nothing — `@objectstack/example-showcase` is private.

--- a/examples/app-showcase/src/docs/showcase_tour_ui.md
+++ b/examples/app-showcase/src/docs/showcase_tour_ui.md
@@ -57,6 +57,12 @@ canonical example of each linked from that page.
   surface.
 - `src/ui/actions/` — the ActionType × location matrix (script / url /
   modal / flow / api / form), visible as buttons across Task screens.
+- Actions over a SELECTION come in two flavours, one view each: Task's
+  **Bulk Actions** names declared actions in `bulkActions`, and each selected
+  record is fanned out through the action runner (a script and a custom
+  endpoint, neither of them a field patch); Project's `bulkActionDefs` instead
+  mass-EDITS through the data API. `action.bulkEnabled` is not a third way —
+  it was retired in spec 17 and its tombstone points at `bulkActions`.
 
 ## Themes
 

--- a/examples/app-showcase/src/system/translations/index.ts
+++ b/examples/app-showcase/src/system/translations/index.ts
@@ -231,6 +231,7 @@ export const ShowcaseTranslationBundle = {
           map: { label: '工作地点地图' },
           chart: { label: '工时按状态分布' },
           legacy_row_actions: { label: '旧式行操作' },
+          bulk_actions: { label: '批量操作' },
         },
       },
       showcase_account: {

--- a/examples/app-showcase/src/ui/views/task.view.ts
+++ b/examples/app-showcase/src/ui/views/task.view.ts
@@ -107,6 +107,42 @@ export const TaskViews = defineView({
       rowActions: ['showcase_recalc_estimate', 'showcase_quick_view'],
     },
 
+    // ── Bulk actions — one declared action over the SELECTED records ──────
+    // The selection-bar twin of `legacy_row_actions` above, and — unlike that
+    // fixture — the CANONICAL authoring form, not a legacy one. `bulkActions`
+    // is the only way to declare a bulk action: `action.bulkEnabled` was
+    // retired in spec 17 (#3896 close-out) precisely because nothing ever
+    // consumed it, and its tombstone prescribes this key instead.
+    //
+    // Complements `project.view.ts`'s `bulkActionDefs`, which is the OTHER
+    // bulk vocabulary: inline defs that mass-EDIT records through the data
+    // API (`operation: 'update'` + a patch). Here the selected records are
+    // instead fanned out through the action runner, one dispatch each, so an
+    // action that is not a field patch at all — a script, a custom endpoint —
+    // works over a selection. Both names are already declared on the object:
+    //
+    //   `showcase_mark_done`       — type `script`; its sandboxed body flips
+    //     `done`/`progress` per record via the platform action route.
+    //   `showcase_recalc_estimate` — type `api`; POSTs the showcase's own
+    //     `/api/v1/showcase/recalc`, with `recordIdParam: 'recordId'` (already
+    //     declared for the row surface) carrying each record's id.
+    //
+    // Neither declares `list_toolbar`: a bulk action is not a toolbar action,
+    // it needs a selection. Naming it here is the whole declaration.
+    bulk_actions: {
+      label: 'Bulk Actions',
+      type: 'grid',
+      data,
+      columns: [
+        { field: 'title' },
+        { field: 'assignee' },
+        { field: 'estimate_hours' },
+        { field: 'progress' },
+        { field: 'done' },
+      ],
+      bulkActions: ['showcase_mark_done', 'showcase_recalc_estimate'],
+    },
+
     // 0 ── Tabular ───────────────────────────────────────────────────────
     // ADR-0021 Phase 2: replaces the former `showcase_task_list` report
     // (a flat record list — a ListView concern, not analytics).


### PR DESCRIPTION
showcase 里一直没有 `bulkActions` 的例子 —— 而它恰恰是**声明批量 action 的唯一方式**：`action.bulkEnabled` 在 spec 17 的 #3896 收尾里被退役（#4054），正因为从来没有消费方，它的墓碑给的处方就是这个 key。

## 改动

在 `showcase_task` 上加一个 `bulk_actions` 命名视图 —— 既有 `legacy_row_actions` fixture 的**选择栏孪生**。两个名字都是对象上已声明的 action，故意各取一种形态：

| action | type | 走的路 |
|---|---|---|
| `showcase_mark_done` | `script` | 沙箱 body 经平台 action 路由，逐条翻 `done`/`progress` |
| `showcase_recalc_estimate` | `api` | POST showcase 自己的 `/api/v1/showcase/recalc`，靠已声明的 `recordIdParam` 带上每条记录的 id |

**两者都不是字段 patch** —— 这正是它和 `project.view.ts` 里 `bulkActionDefs` 的分工：那边是经数据 API 批量**改字段**（`operation: 'update'` + patch），这边是把选中记录逐条派发给 action runner，于是「不是字段赋值」的 action（脚本、自定义端点）也能作用于一批记录。

顺带在 UI 导览里写清这两种 bulk 词汇的分工，并点明 `bulkEnabled` 不是第三条路。

## 验证

在本 app 的真实后端 + console 里点完整流程：

- **Bulk Actions** 视图出现在视图切换器，列（预计工时 / 进度 / 已完成）正常渲染。
- 全选 10 条 → 两个按钮都带 action 自己的标签和图标。
- **Mark Done** → 10 个 `POST /api/v1/actions/showcase_task/showcase_mark_done`，全 200；10 条记录 已完成 = ✓、进度 = 100。
- **Recalculate Estimate** → 10 个 `POST /api/v1/showcase/recalc`，全 200（`recordIdParam` 确实带上了 id，没有 400）；预计工时逐条重算并刷新。
- 运行全程 **0 控制台错误**（页面早期引导阶段有既存噪声，与本视图无关）。

`pnpm validate` / `pnpm typecheck` / `pnpm test`（10 文件 60 测试）全绿。

纯示例 + 文档，不动任何运行时代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
