### PR TITLE
fix(plugin-auth,plugin-webhooks): retire a dead degrade branch and an implicit transitive dependency (#4187)

### DIFF
--- a/.changeset/adr-0116-followups.md
+++ b/.changeset/adr-0116-followups.md
@@ -1,0 +1,42 @@
+---
+"@objectstack/plugin-auth": patch
+"@objectstack/plugin-webhooks": patch
+---
+
+fix(plugin-auth,plugin-webhooks): retire a dead degrade branch and an implicit transitive dependency (ADR-0116 follow-ups, #4187)
+
+Two concrete findings from the ADR-0116 consumer-side audit, plus the
+authoring rule that would have prevented both.
+
+**`plugin-auth` claimed a fallback it did not have.** `init()` ran
+`const dataEngine = ctx.getService('data'); if (!dataEngine) { warn('No data
+engine service found - auth will use in-memory storage') }`. That branch could
+never execute: `getService` **throws** for an unregistered service rather than
+returning `undefined`, and this plugin declares a hard dependency on ObjectQL
+(which registers `data` unconditionally), so a kernel without the engine fails
+even earlier with `Dependency … not found`. The branch is removed and the real
+contract is declared — `requiresServices: ['data', 'manifest']` — which also
+replaces a trailing `// manifest service required` comment with the
+machine-checked form of the same claim. `AuthManager` keeps its own optional
+`dataEngine` guards: it is usable outside the plugin.
+
+**`plugin-webhook-outbox` was protected only transitively.** It resolves
+`manifest` in `init()` with no fallback while depending on
+`com.objectstack.service.messaging`, which in turn depends on ObjectQL, the
+actual provider. That works today and would have broken silently the day
+messaging stopped depending on the engine — surfacing as a crash inside an
+unrelated plugin's init. It now declares `requiresServices: ['manifest']`
+directly.
+
+Neither change alters ordering or boot outcomes on any current composition:
+both plugins were already ordered correctly. What changes is what a broken
+composition *says*, and that the guarantees are now checked rather than
+inherited.
+
+Docs: `content/docs/plugins/anatomy.mdx` gains the three ADR-0116 fields and
+the decision rule for resolving a service inside `init()` (hard dependency vs
+`optionalDependencies` + `requiresServices`), including the two traps behind
+these fixes — don't rely on a transitive provider, and don't write an
+`if (!svc)` fallback after a bare `getService`. The api-registry example
+declares the contract on all seven of its plugins instead of relying on
+`kernel.use()` order.

--- a/content/docs/plugins/anatomy.mdx
+++ b/content/docs/plugins/anatomy.mdx
@@ -131,8 +131,31 @@ export interface Plugin {
      * Dependencies (Optional)
      * List of other plugin names that this plugin depends on.
      * The kernel ensures these plugins are initialized before this one.
+     * A name that is not composed on the kernel fails the boot.
      */
     dependencies?: string[];
+
+    /**
+     * Soft dependencies (Optional) — order-if-present, ADR-0116.
+     * Hoisted ahead exactly like `dependencies` when composed, silently
+     * skipped when absent. For plugins that degrade without the dependency
+     * but must never initialize before it.
+     */
+    optionalDependencies?: string[];
+
+    /**
+     * Services this plugin resolves SYNCHRONOUSLY during init() (ADR-0116).
+     * Validated before Phase 1 and again immediately before this plugin's
+     * init, so a misordered composition fails with a named error instead of
+     * crashing inside your init.
+     */
+    requiresServices?: string[];
+
+    /**
+     * Services this plugin's init() registers UNCONDITIONALLY (ADR-0116).
+     * Never declare an option-gated registration.
+     */
+    providesServices?: string[];
 
     /**
      * Init Phase (REQUIRED)
@@ -241,6 +264,47 @@ Plugins follow a strict three-phase lifecycle managed by the kernel:
 1. **init()** — Called during kernel initialization. Register services that other plugins may depend on.
 2. **start()** — Called after *all* plugins have initialized. Start servers, connect to databases, or execute main logic.
 3. **destroy()** — Called during shutdown, in reverse order. Clean up connections, timers, and resources.
+
+### Resolving a service inside `init()` — declare it
+
+`kernel.use()` **registration order is not a contract**. Init order comes from
+the dependency graph, so "it works because I registered it later" is luck, and
+it is the recipe behind two production bugs (a server that booted with no
+tables, then [#4085](https://github.com/objectstack-ai/objectstack/issues/4085)).
+Anything you resolve in `start()` needs no declaration — Phase 1 completes
+before any `start()` runs. For `init()`, pick one of two:
+
+| Your plugin… | Declare |
+| :--- | :--- |
+| **cannot work** without the provider | `dependencies: ['<provider plugin>']` — plus `requiresServices` to say which service, and why |
+| **degrades** without it, but must init after it when present | `optionalDependencies: ['<provider plugin>']` + `requiresServices: ['<service>']` |
+
+Resolving a service in `init()` while declaring **neither** is the bug shape:
+it works until someone composes the stack in a different order, and then fails
+inside your `init()` with an error that names the service but not the cause.
+
+```ts
+class MyPlugin implements Plugin {
+  // Hard: the engine is always composed with this plugin.
+  dependencies = ['com.objectstack.engine.objectql'];
+  requiresServices = ['manifest'];        // what the dependency is FOR
+
+  async init(ctx: PluginContext) {
+    ctx.getService<{ register(m: any): void }>('manifest').register(mySchema);
+  }
+}
+```
+
+Two rules worth stating explicitly, because both have already caused bugs:
+
+- **Declare the requirement directly, not transitively.** Depending on a plugin
+  that *happens* to depend on the real provider works until that plugin's own
+  dependencies change, and the breakage then surfaces in your `init()`.
+- **A service you probe behind `try`/`catch` is not a requirement.** Put only
+  hard, no-fallback needs in `requiresServices` — and if you write a fallback
+  branch, make sure it can actually run: `getService` **throws** for a missing
+  service, it never returns `undefined`, so `if (!svc) { /* degrade */ }` after
+  a bare `getService` is dead code advertising a mode you do not have.
 
 ## Next Steps
 

--- a/packages/core/examples/api-registry-example.ts
+++ b/packages/core/examples/api-registry-example.ts
@@ -24,6 +24,12 @@ async function example1_BasicApiRegistration() {
   const customerPlugin: Plugin = {
     name: 'customer-plugin',
     version: '1.0.0',
+    // init() resolves `api-registry` synchronously with no fallback, so the
+    // ordering requirement is DECLARED rather than left to the `kernel.use()`
+    // order above (ADR-0116). Registration order is not a contract — the
+    // kernel orders from this graph.
+    dependencies: ['com.objectstack.core.api-registry'],
+    requiresServices: ['api-registry'],
     init: async (ctx) => {
       const registry = ctx.getService<ApiRegistry>('api-registry');
 
@@ -163,6 +169,8 @@ async function example2_MultiPluginDiscovery() {
   // Data Plugin - REST APIs
   const dataPlugin: Plugin = {
     name: 'data-plugin',
+    dependencies: ['com.objectstack.core.api-registry'],
+    requiresServices: ['api-registry'],
     init: async (ctx) => {
       const registry = ctx.getService<ApiRegistry>('api-registry');
 
@@ -212,6 +220,8 @@ async function example2_MultiPluginDiscovery() {
   // Analytics Plugin - Beta API
   const analyticsPlugin: Plugin = {
     name: 'analytics-plugin',
+    dependencies: ['com.objectstack.core.api-registry'],
+    requiresServices: ['api-registry'],
     init: async (ctx) => {
       const registry = ctx.getService<ApiRegistry>('api-registry');
 
@@ -282,6 +292,8 @@ async function example3_ConflictResolution() {
   // Core Plugin - High priority
   const corePlugin: Plugin = {
     name: 'core-plugin',
+    dependencies: ['com.objectstack.core.api-registry'],
+    requiresServices: ['api-registry'],
     init: async (ctx) => {
       const registry = ctx.getService<ApiRegistry>('api-registry');
 
@@ -310,6 +322,8 @@ async function example3_ConflictResolution() {
   // Custom Plugin - Medium priority
   const customPlugin: Plugin = {
     name: 'custom-plugin',
+    dependencies: ['com.objectstack.core.api-registry'],
+    requiresServices: ['api-registry'],
     init: async (ctx) => {
       const registry = ctx.getService<ApiRegistry>('api-registry');
 
@@ -361,6 +375,8 @@ async function example4_CustomProtocol() {
 
   const websocketPlugin: Plugin = {
     name: 'websocket-plugin',
+    dependencies: ['com.objectstack.core.api-registry'],
+    requiresServices: ['api-registry'],
     init: async (ctx) => {
       const registry = ctx.getService<ApiRegistry>('api-registry');
 
@@ -431,6 +447,8 @@ async function example5_DynamicSchemas() {
 
   const dynamicPlugin: Plugin = {
     name: 'dynamic-plugin',
+    dependencies: ['com.objectstack.core.api-registry'],
+    requiresServices: ['api-registry'],
     init: async (ctx) => {
       const registry = ctx.getService<ApiRegistry>('api-registry');
 

--- a/packages/plugins/plugin-auth/src/auth-plugin.ts
+++ b/packages/plugins/plugin-auth/src/auth-plugin.ts
@@ -144,8 +144,19 @@ export class AuthPlugin implements Plugin {
   providesServices = ['auth', 'tenancy'];
   type = 'standard';
   version = '1.0.0';
-  dependencies: string[] = ['com.objectstack.engine.objectql']; // manifest service required
-  
+  dependencies: string[] = ['com.objectstack.engine.objectql'];
+  /**
+   * What that dependency is FOR, stated so the kernel can check it (#4187).
+   * `init()` resolves both synchronously with no fallback: `data` builds the
+   * AuthManager config, `manifest` registers the auth objects. ObjectQL
+   * registers both unconditionally and the hard dependency above hoists it
+   * ahead, so this never changes whether the boot succeeds — it changes what
+   * a broken composition SAYS, and replaces the trailing `// manifest service
+   * required` comment with the machine-checked form of the same claim.
+   */
+  requiresServices = ['data', 'manifest'];
+
+
   private options: AuthPluginOptions;
   private authManager: AuthManager | null = null;
   /** ADR-0093 D4 — the tenancy service registered in init(); reused at kernel:ready. */
@@ -199,11 +210,19 @@ export class AuthPlugin implements Plugin {
       throw new Error('AuthPlugin: secret is required');
     }
 
-    // Get data engine service for database operations
+    // Get data engine service for database operations. This plugin declares a
+    // hard dependency on ObjectQL (which registers `data` unconditionally), so
+    // the service is always present here.
+    //
+    // There used to be an `if (!dataEngine) warn('…auth will use in-memory
+    // storage')` guard under this line. It could never fire and the fallback it
+    // named did not exist: `getService` THROWS for an unregistered service, it
+    // does not return undefined, and the hard dependency means a kernel without
+    // the engine fails earlier still with "Dependency … not found". A branch
+    // that advertises a tolerance the composition forbids is worse than no
+    // branch — it reads as a supported degraded mode (#4187). AuthManager keeps
+    // its own `dataEngine?` guards because it is usable outside this plugin.
     const dataEngine = ctx.getService<any>('data');
-    if (!dataEngine) {
-      ctx.logger.warn('No data engine service found - auth will use in-memory storage');
-    }
 
     const authConfig: AuthManagerOptions & AuthPluginOptions = {
       ...this.options,

--- a/packages/plugins/plugin-webhooks/src/webhook-outbox-plugin.ts
+++ b/packages/plugins/plugin-webhooks/src/webhook-outbox-plugin.ts
@@ -62,6 +62,16 @@ export class WebhookOutboxPlugin implements Plugin {
     version = '2.0.0';
     type = 'standard' as const;
     dependencies = ['com.objectstack.service.messaging'];
+    /**
+     * `init()` registers this plugin's schema through `manifest` with no
+     * fallback. Until #4187 that was safe only TRANSITIVELY — messaging happens
+     * to depend on ObjectQL, which provides `manifest` — so the guarantee would
+     * have evaporated silently the day messaging stopped depending on the
+     * engine, and the failure would have surfaced as an unrelated plugin's
+     * init crash. Declaring the requirement directly makes the kernel check it
+     * regardless of what messaging depends on.
+     */
+    requiresServices = ['manifest'];
 
     private autoEnqueuer: AutoEnqueuer | undefined;
     /** Engine the provenance hook was bound to, so `dispose()` can unbind it. */


### PR DESCRIPTION
收尾 #4187 的第 1–3 项（第 4 项见文末）。两处具体缺陷 + 一条本可以预防它们的编写规则。

## 1. `plugin-auth` 宣称了一个它并不具备的降级模式

`init()` 里原本是：

```ts
const dataEngine = ctx.getService<any>('data');
if (!dataEngine) {
  ctx.logger.warn('No data engine service found - auth will use in-memory storage');
}
```

这条分支**永远不会执行**，两重原因叠加：

- `getService` 在服务未注册时是**抛错**，不会返回 `undefined`；
- 该插件硬依赖 `com.objectstack.engine.objectql`，而后者无条件注册 `data`。没有引擎的内核会更早死在 `Dependency 'com.objectstack.engine.objectql' not found`。

也就是说它宣传的 "in-memory storage" 是一个**组装方式本身就禁止**的模式。删掉分支，并把真实契约声明出来：`requiresServices: ['data', 'manifest']`——顺带把原来那句行尾注释 `// manifest service required` 换成了机器可校验的同一主张。

`AuthManager` 内部的 `dataEngine?` 判空**保留不动**：它可以脱离本插件独立使用，那些判空在别的调用场景下是有意义的。

## 2. `plugin-webhook-outbox` 只被传递依赖保护着

它在 `init()` 里无兜底地取 `manifest`，却只声明 `dependencies: ['com.objectstack.service.messaging']`——靠 messaging 恰好依赖 ObjectQL 才成立。这条链哪天断了（messaging 不再依赖引擎），故障会以"另一个插件 init 崩溃"的形式出现，排查方向完全错位。改为直接声明 `requiresServices: ['manifest']`。

**两处改动都不改变任何现有组装的排序或启动结果**——它们本来就排对了。改变的是组装出错时的报错内容，以及这份保证从"继承来的"变成"被校验的"。

## 3. 把规则写进文档

`content/docs/plugins/anatomy.mdx`：补上 ADR-0116 的三个字段，以及"在 `init()` 里同步取服务该怎么声明"的二选一表格（硬 `dependencies` vs `optionalDependencies` + `requiresServices`），并明确写进促成本 PR 两个修复的两个坑：

- 别依赖**传递** provider；
- 别在裸 `getService` 后面写 `if (!svc) { 降级 }`——那是死代码，宣传了一个不存在的模式。

顺手把 `api-registry-example.ts` 里 **7 个**插件全部补上声明。原先它们全靠 `kernel.use()` 顺序工作，而示例正是模式被复制的源头；只改其中 2 个会让示例自相矛盾，所以要么都改要么都不改。

## 4. D4（服务声明自动推导排序）本次仍不做

证据继续支持"不做"：provider 侧刚补齐（#4185），消费方侧 12 个**一致地**选择了硬依赖，说明"硬依赖排序 + 服务声明校验/诊断"这套两级机制已经覆盖了真实用法。等出现第二、第三个像 `AppPlugin` 那样的软依赖消费方再回头看。#4187 保持 open 记录这一项。

## 验证

- `pnpm build` 71/71 通过。
- 全仓 `pnpm test` 运行中（退出码写入独立文件，不走管道——本次会话早先在这上面误报过一次）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DQuJBNpwStpJvo3owBw2B

---
_Generated by [Claude Code](https://claude.ai/code/session_014DQuJBNpwStpJvo3owBw2B)_