### PR TITLE
fix(cloud-connection): align the marketplace seed test's timeout with its sibling (#3785)

### DIFF
--- a/.changeset/marketplace-seed-test-budget.md
+++ b/.changeset/marketplace-seed-test-budget.md
@@ -1,0 +1,32 @@
+---
+"@objectstack/cloud-connection": patch
+---
+
+fix(cloud-connection): align the marketplace seed test's timeout with its sibling (#3785)
+
+`marketplace-install-local-state-machine-exempt.test.ts` failed under a
+full-repo `pnpm test` at 30s, while passing every time the package ran alone.
+
+Both marketplace seed tests drive `MarketplaceInstallLocalPlugin`, whose
+seeding path dynamically imports the real `@objectstack/runtime` (unmocked on
+purpose, twice: `recordSeedSummary` and `mergeSeedDatasetsIntoKernel`). That
+cold import costs seconds by itself and multiples of that under a fully
+parallel turbo run, and it is charged to whichever test triggers it first.
+
+Its sibling `marketplace-install-local-seed-lookup.test.ts` was diagnosed as
+exactly this — *"an import stall, not a hang"* — and raised to 120s. This file
+was left at 30s and kept flaking the same way. The budget is now aligned, with
+the rationale stated locally rather than only in the sibling.
+
+The flaky set turns out to be exactly the intersection of "does not mock
+`@objectstack/runtime`" and "actually drives seeding":
+
+| test | mocks runtime | drives seeding | budget |
+| :--- | :--- | :--- | :--- |
+| `conflict`, `bundle` | no | **no** — never reaches the import | default |
+| `reseed`, `heal` | **yes** | yes | default |
+| `seed-lookup` | no | yes | 120s (already) |
+| `state-machine-exempt` | no | yes | 120s (this change) |
+
+So the two tests #3785 recorded are the only two that can hit this, and no
+other file needs the same treatment. A genuine hang still fails — later.

--- a/packages/cloud-connection/src/marketplace-install-local-state-machine-exempt.test.ts
+++ b/packages/cloud-connection/src/marketplace-install-local-state-machine-exempt.test.ts
@@ -208,7 +208,16 @@ beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'mil-fsm-exempt-')); });
 afterEach(() => { rmSync(dir, { recursive: true, force: true }); vi.restoreAllMocks(); });
 
 describe('marketplace install — state_machine initialStates exemption (#3433)', () => {
-    it('lands every mid-lifecycle seed row (no initialStates rejection on the marketplace seam)', { timeout: 30_000 }, async () => {
+    // Same budget, same reason, as `marketplace-install-local-seed-lookup.test.ts`
+    // (#3785): both drive `MarketplaceInstallLocalPlugin`, whose install handler
+    // dynamically imports the real @objectstack/runtime (unmocked on purpose).
+    // That cold import costs seconds on its own and multiples of that under a
+    // fully parallel turbo run, where this file competes with every other
+    // package's suite for cores. The sibling was diagnosed as exactly this —
+    // "an import stall, not a hang" — and raised to 120s; this one was left at
+    // 30s and kept flaking the same way (observed again at 30076ms). A genuine
+    // hang still fails here, just later.
+    it('lands every mid-lifecycle seed row (no initialStates rejection on the marketplace seam)', { timeout: 120_000 }, async () => {
         const { engine, store, registry } = makeEngine();
         const rawApp = makeRawApp();
         const { ctx, fire } = makeCtx(rawApp, {


### PR DESCRIPTION
收尾 #3785 的后一半（前一半 plugin-audit 已由 #4193 修复）。

## 诊断

`marketplace-install-local-state-machine-exempt.test.ts` 在整仓 `pnpm test` 下失败（30076ms 超时），单独跑该包必过（12 文件 / 64 用例）。

根因与兄弟用例同源：两个用例都驱动 `MarketplaceInstallLocalPlugin`，而它的**播种路径**上有两处 `await import('@objectstack/runtime')`（`recordSeedSummary` 与 `mergeSeedDatasetsIntoKernel`，故意不 mock）。这笔冷导入本身就要数秒，在全并行 turbo 下要吃掉数倍，且会被记到**第一个触发它的用例**头上。

**兄弟用例 `marketplace-install-local-seed-lookup.test.ts` 早就被诊断过并修好了**，注释原文：*"an import stall, not a hang"*，预算提到 120s。本文件被落下，仍是 30s，于是继续以同样方式 flaky。本 PR 把预算对齐，并把理由写在本地，而不是只存在于兄弟文件里。

## 为什么恰好是这两个用例

flaky 集合正好等于 **{不 mock runtime} ∩ {真正驱动播种}**：

| 测试 | mock runtime | 驱动播种 | 预算 |
|:---|:---|:---|:---|
| `conflict`、`bundle` | 否 | **否** —— 根本走不到那两处 import | 默认 |
| `reseed`、`heal` | **是** | 是 | 默认 |
| `seed-lookup` | 否 | 是 | 120s（已有） |
| `state-machine-exempt` | 否 | 是 | 120s（本 PR） |

所以 #3785 记录的那两个用例，正是全仓仅有的两个会撞上这条路径的；其余四个各有各的免疫理由，**没有第三处需要同样处理**。

## 为什么判定是预算不足而非竞态

- **断言通过**，不是 #3785 原文担心的"seed 行未落全"那种错误数据；
- 在产生 30076ms 失败的同一种满并行负载下，本次实测耗时 **15696ms**；
- 兄弟用例成本结构完全相同，实测需要 120s 才稳。

⚠️ 需要如实说明一处：**15.7s 低于原来的 30s 预算，所以这一次运行即使不改也会通过**——单次通过并不构成修复有效的证明。真正的论据是**比例**：一个在负载下典型耗时 ~15s、且已被观测到超过 30s 的成本，不可能安全地住在 30s 预算里（抖动 2 倍以上）。120s 与兄弟对齐，同时保证真正的 hang 仍然会失败，只是晚一些。

## 验证

- 整仓 `pnpm test`：**132/132 任务成功，退出码 0**（退出码直接捕获，未走管道）。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DQuJBNpwStpJvo3owBw2B

---
_Generated by [Claude Code](https://claude.ai/code/session_014DQuJBNpwStpJvo3owBw2B)_