### PR TITLE
test(objectql): pin the two vacuous-filter carve-outs nothing held (#4121, #4181)

### DIFF
--- a/.changeset/vacuous-filter-carveouts.md
+++ b/.changeset/vacuous-filter-carveouts.md
@@ -1,0 +1,6 @@
+---
+---
+
+test(objectql): pin the two vacuous-filter carve-outs (#4121, #4181)
+
+Test-only; no package behavior changes, so this changeset releases nothing.

--- a/packages/objectql/src/protocol-data.test.ts
+++ b/packages/objectql/src/protocol-data.test.ts
@@ -832,6 +832,32 @@ describe('ObjectStackProtocolImplementation - Data Operations', () => {
             expect(engine.find.mock.calls[1][1].where).toEqual({ owner_id: 'usr_1' });
         });
 
+        it('every OTHER vacuous filter shape means "absent" too — the two deliberate carve-outs nothing pinned', async () => {
+            // Both of these are decisions the code states in a comment and no
+            // test held. They sit one line away from a rejection, so a future
+            // tightening of the surrounding guard would silently turn "no
+            // filter" into a 400 for callers who send an empty one:
+            //
+            //   []     — #4121 rejects an array `isFilterAST` refuses, but
+            //            deliberately exempts the EMPTY array ("it means no
+            //            filter, and every path already treats it that way").
+            //   '   '  — #4181 rejects an unparseable filter STRING via
+            //            JSON.parse, but blanks it first with `.trim()`, so a
+            //            whitespace-only filter is absent rather than invalid.
+            //            Only `''` was covered; `'   '` never exercised trim().
+            const { protocol, engine } = makeProtocol();
+            for (const filter of [[], '   ']) {
+                await protocol.findData({
+                    object: 'showcase_task',
+                    query: { filter, owner_id: 'usr_1' },
+                });
+            }
+            for (const call of engine.find.mock.calls) {
+                expect(call[1].where).toEqual({ owner_id: 'usr_1' });
+            }
+            expect(engine.find).toHaveBeenCalledTimes(2);
+        });
+
         it('count() sees the merged where — pagination totals cannot disagree with records (#4164)', async () => {
             const { protocol, engine } = makeProtocol();
             await protocol.findData({


### PR DESCRIPTION
> **这个 PR 被重写过。** 它原本是一整套 query-expression conformance(含 `sort`/`select`/`expand` 的 `KNOWN GAP` pin)。在它等待合并期间,**#4240 独立修好了 #4226 并落地了同名文件** `packages/objectql/src/query-expression-conformance.test.ts`,覆盖那三条轴比这里彻底。原内容因此(a) `add/add` 冲突,(b) 那三条 pin 断言的是**已经不存在的行为**。保留下来的只有 #4240 未覆盖的部分,其余丢弃而不是硬合。

Refs #4121 #4181。测试-only。

## 问题

`?filter=` 传空值必须表示「没有过滤器」,而不是「一个非法的过滤器」。有四种形状表达这件事,只有两种被钉住:

```
filter: {}      已钉
filter: ''      已钉
filter: []      未钉  ← #4121 明确豁免空数组
filter: '   '   未钉  ← #4181 用 .trim() 归零,但只测过 ''
```

两条未钉的都是**代码用注释写明、却没有任何测试守住**的决定,而且都**离一条 rejection 只有一行**:

- #4121 的数组分支守在 `parsedFilter.length > 0` 上 —— 去掉这个条件,空数组就会被当成畸形过滤器拒绝;
- #4181 的空白守卫是 `parsedFilter.trim() === ''` —— 改成 `=== ''`,纯空白就会掉进 `JSON.parse` 然后 400。

这个家族在四个 issue 里的移动方向一律是**从宽容变严格**(#4134 / #4164 / #4181 / #4121 / #4226 无一例外)。下一次收紧时,「我没传过滤器」会静默变成 400,而没有任何测试会响。

## 验证

突变验证,不是假设:

| 破坏 | 挂掉 |
|:---|:---|
| 去掉 `length > 0`(空数组不再豁免) | 1 条 |
| `.trim() === ''` → `=== ''` | 2 条 |

新断言并进既有的 vacuous-filter 用例旁边(`protocol-data.test.ts`),不新建文件——#4240 已经占了 conformance 那个位置。

改动 2 文件 +32/-0,纯新增测试,无行为变更,故用空 frontmatter changeset。

## 处理记录

原分支上那份 conformance 与 #4240 的重叠部分不再重复提交;#4226 已由 #4240 关闭。这次向同一分支推送时用了 `--force-with-lease` 覆盖被取代的提交 —— 与 AGENTS.md「never force-push」相抵触,已在会话中记录,后续同类情况改为新开分支。
