### PR TITLE
fix(cli): stamp `engines.protocol` into scaffolds and example apps

### DIFF
--- a/.changeset/tender-hats-brush.md
+++ b/.changeset/tender-hats-brush.md
@@ -1,0 +1,9 @@
+---
+"@objectstack/cli": patch
+---
+
+`os init` scaffolds now stamp `engines: { protocol: '^<current major>' }` into the
+generated `objectstack.config.ts` (all three templates), so newly authored packages
+participate in the ADR-0087 load-time protocol handshake instead of being admitted
+under the "no-range" grandfathering warning. The bundled example apps (`app-todo`,
+`app-crm`, `app-showcase`) now declare the same range. (#4097)

--- a/content/docs/deployment/cli.mdx
+++ b/content/docs/deployment/cli.mdx
@@ -878,6 +878,8 @@ export default defineStack({
     type: 'app',
     name: 'My App',
     description: 'My ObjectStack application',
+    // Protocol major this app is authored against (ADR-0087 load-time check).
+    engines: { protocol: '^17' },
   },
 
   objects: Object.values(objects),

--- a/content/docs/getting-started/your-first-project.mdx
+++ b/content/docs/getting-started/your-first-project.mdx
@@ -113,6 +113,8 @@ export default defineStack({
     version: '0.1.0',
     type: 'app',
     name: 'My App',
+    // Protocol major this app is authored against (ADR-0087 load-time check).
+    engines: { protocol: '^17' },
   },
   // `automation` runs flows and, per ADR-0097, materializes declarative
   // `connectors:` entries at boot. The three generic executors below register

--- a/examples/app-crm/objectstack.config.ts
+++ b/examples/app-crm/objectstack.config.ts
@@ -44,6 +44,10 @@ export default defineStack({
     type: 'app',
     name: 'CRM (minimal example)',
     description: 'Minimal CRM workspace used by the framework to validate the metadata loading pipeline end-to-end.',
+    // Protocol major this package is authored against (ADR-0087). The kernel
+    // checks the range at load time and refuses a major-incompatible runtime
+    // with a structured diagnostic instead of failing deep in a schema parse.
+    engines: { protocol: '^17' },
   },
 
   // Auto-resolved by the CLI; `ui` enables the Studio shell, `automation`

--- a/examples/app-showcase/objectstack.config.ts
+++ b/examples/app-showcase/objectstack.config.ts
@@ -83,6 +83,10 @@ export default defineStack({
     type: 'app',
     name: 'ObjectStack Showcase',
     description: 'Kitchen-sink workspace covering all metadata types, all view types, and the major capability chains.',
+    // Protocol major this package is authored against (ADR-0087). The kernel
+    // checks the range at load time and refuses a major-incompatible runtime
+    // with a structured diagnostic instead of failing deep in a schema parse.
+    engines: { protocol: '^17' },
   },
 
   // Capability tokens the CLI resolves to platform plugins:

--- a/examples/app-todo/objectstack.config.ts
+++ b/examples/app-todo/objectstack.config.ts
@@ -36,6 +36,10 @@ export default defineStack({
     type: 'app',
     name: 'Todo Manager',
     description: 'A comprehensive Todo app demonstrating ObjectStack Protocol features including automation, dashboards, and reports',
+    // Protocol major this package is authored against (ADR-0087). The kernel
+    // checks the range at load time and refuses a major-incompatible runtime
+    // with a structured diagnostic instead of failing deep in a schema parse.
+    engines: { protocol: '^17' },
   },
 
   // Seed Data (top-level, registered as metadata)

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { Args, Command, Flags } from '@oclif/core';
+import { PROTOCOL_MAJOR } from '@objectstack/spec/kernel';
 import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
@@ -143,6 +144,8 @@ export default defineStack({
     type: 'app',
     name: '${toTitleCase(name)}',
     description: '${toTitleCase(name)} application built with ObjectStack',
+    // Protocol major this app is authored against (ADR-0087 load-time check).
+    engines: { protocol: '^${PROTOCOL_MAJOR}' },
   },
 
   objects: Object.values(objects),
@@ -215,6 +218,8 @@ export default defineStack({
     type: 'plugin',
     name: '${toTitleCase(name)} Plugin',
     description: 'ObjectStack Plugin: ${toTitleCase(name)}',
+    // Protocol major this plugin is authored against (ADR-0087 load-time check).
+    engines: { protocol: '^${PROTOCOL_MAJOR}' },
   },
 
   objects: Object.values(objects),
@@ -270,6 +275,8 @@ export default defineStack({
     type: 'app',
     name: '${toTitleCase(name)}',
     description: '',
+    // Protocol major this app is authored against (ADR-0087 load-time check).
+    engines: { protocol: '^${PROTOCOL_MAJOR}' },
   },
 });
 `,

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
+import { PROTOCOL_MAJOR } from '@objectstack/spec/kernel';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -169,6 +170,20 @@ describe('scaffold rendering — round-trip', () => {
       expect(namespace).toBe('my_app');
       const cfg = fs.readFileSync(path.join(tmpRoot, 'objectstack.config.ts'), 'utf8');
       expect(cfg).toMatch(/namespace: 'my_app'/);
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  // #4097 — every scaffold stamps an `engines.protocol` range admitting the
+  // protocol major it was generated under, so new projects never boot with
+  // the ADR-0087 handshake silently skipped ("no-range" grandfathering).
+  it('stamps engines.protocol with the current protocol major in every template', () => {
+    for (const key of Object.keys(TEMPLATES)) {
+      const { tmpRoot } = renderTemplate(key as keyof typeof TEMPLATES, 'my-app');
+      const cfg = fs.readFileSync(path.join(tmpRoot, 'objectstack.config.ts'), 'utf8');
+      expect(cfg, `template "${key}" must declare engines.protocol`).toContain(
+        `engines: { protocol: '^${PROTOCOL_MAJOR}' }`,
+      );
       fs.rmSync(tmpRoot, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
Closes #4097. Newly visible after #4084 unblocked boot-phase logging: every example app — and every project scaffolded by `os init` — booted with the ADR-0087 grandfathering warning, i.e. with the protocol compatibility handshake silently skipped on exactly the templates users copy.

## What changed

**`os init` (all three templates: app / plugin / empty)** — the generated `objectstack.config.ts` now stamps:

```ts
// Protocol major this app is authored against (ADR-0087 load-time check).
engines: { protocol: '^17' },
```

The major is interpolated from `PROTOCOL_MAJOR` (`@objectstack/spec/kernel`) **at scaffold time**, so the stamped literal is always the protocol the package was actually authored against, and the template needs no edit on future protocol bumps.

**Examples (`app-todo`, `app-crm`, `app-showcase`)** — declare a literal `engines: { protocol: '^17' }` with a comment explaining the check. A literal (not a computed value) is deliberate: the declaration means "authored against", and on a future major bump the handshake turns the stale examples into loud `OS_PROTOCOL_INCOMPATIBLE` boot failures instead of silent admits — forcing a conscious migration, which is the feature. (`embed-objectql` has no `defineStack` manifest, so nothing to declare there.)

**Test** — `init.test.ts` gains a round-trip assertion that every template stamps a range admitting the current major, guarding the scaffold against regressing to `no-range`.

## Deliberately unchanged

The issue's second question — whether an absent range should escalate from a boot warning to an `os compile` lint failure — is left as-is (warning at boot; `objectstack lint` already nudges). That's a policy decision maintainers can take separately; nothing in this diff blocks it.

## Verification

- `^17` → `checkProtocolCompat` returns `status: 'ok'` under runtime protocol `17.0.0`; absent range still returns `no-range` (parser semantics: caret pins the major).
- All three examples pass `os validate`; the compiled `app-todo` artifact carries `"engines": {"protocol":"^17"}` through to the boot manifest, so the handshake also runs on the artifact path.
- CLI suite: 89 files / 917 tests green (includes the new template assertion). Touched files lint clean.
- Changeset: `@objectstack/cli` patch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrRNgrWaRtggzmrHpbomyh)_