### PR TITLE
docs(ui,protocol): 补齐六个此前只被"点过名"的变体

### DIFF
--- a/.changeset/document-weak-pass-variants.md
+++ b/.changeset/document-weak-pass-variants.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(ui,protocol): document the six navigation / knowledge-source variants that the #4177 variant/doc gate was only ever name-checking. `apps.mdx` enumerated nine navigation item types but gave `report`, `action` and `component` a single shared sentence instead of sections; `knowledge.mdx` named `object` / `file` / `http` in a table with no example of any, leaving the per-kind keys undocumented. Each example was parsed against the real schema (`NavigationItemSchema`, `KnowledgeSourceKindSchema`) before landing. Documentation only; releases nothing.

--- a/content/docs/protocol/knowledge.mdx
+++ b/content/docs/protocol/knowledge.mdx
@@ -119,6 +119,34 @@ Three source kinds:
 | `file`   | A folder in `IStorageService`                       | Onboarded PDFs, uploads         |
 | `http`   | A list of remote URLs                               | External docs, RSS, sitemaps    |
 
+`kind` is the discriminator, and each kind carries its own keys — a key from one
+kind is rejected on another:
+
+```typescript
+// object — content comes from the named fields of each matching record
+source: {
+  kind: 'object',
+  object: 'kb_article',
+  contentFields: ['title', 'body'],       // at least one, required
+  metadataFields: ['category', 'author'], // optional, carried onto the document
+  where: { status: 'published' },         // optional ObjectQL filter
+}
+
+// file — every object under a storage prefix
+source: {
+  kind: 'file',
+  prefix: 'knowledge/handbook/',
+  mimeTypes: ['application/pdf', 'text/markdown'], // optional; omit to take all
+}
+
+// http — an explicit URL list (each must be a valid URL)
+source: {
+  kind: 'http',
+  urls: ['https://docs.example.com/guide', 'https://docs.example.com/faq'],
+  userAgent: 'ObjectStack-KnowledgeBot/1.0', // optional
+}
+```
+
 Every source binds to a named **adapter id** (e.g. `'ragflow'`,
 `'memory'`). The adapter id is resolved at runtime by the plugin that
 registers itself with that name. Adapter config (endpoint, dataset id,

--- a/content/docs/ui/apps.mdx
+++ b/content/docs/ui/apps.mdx
@@ -57,7 +57,11 @@ const crmApp = {
 
 ## Navigation Items
 
-The navigation tree supports nine item types, combined to create rich menu structures. The most common are shown below (`object`, `dashboard`, `page`, `url`, `group`, `separator`); the spec also defines `report`, `action`, and `component` items.
+The navigation tree supports nine item types, combined to create rich menu structures: `object`, `dashboard`, `page`, `url`, `report`, `action`, `component`, `group` and `separator`. Each is documented below.
+
+`type` is the discriminator: a value outside that list is rejected with the full
+set of valid ones, and every other key is checked against the branch you picked
+rather than against all nine.
 
 ### Object Navigation
 
@@ -120,6 +124,48 @@ Groups items into collapsible sections with children:
   ],
 }
 ```
+
+### Report Navigation
+
+Links to a saved report:
+
+```typescript
+{ id: 'nav_pipeline', type: 'report', label: 'Pipeline Report', reportName: 'sales_pipeline', icon: 'file-bar-chart' }
+```
+
+### Action Navigation
+
+Runs an action instead of navigating to a surface. The reference lives in a
+nested `actionDef` block — `actionName` is **not** a top-level key on the item:
+
+```typescript
+{
+  id: 'nav_import',
+  type: 'action',
+  label: 'Import Records',
+  icon: 'upload',
+  actionDef: {
+    actionName: 'bulk_import',
+    params: { objectName: 'account', mode: 'upsert' },
+  },
+}
+```
+
+`actionDef` accepts only `actionName` and `params`. `params` itself is **open by
+design** — the action owns its own parameter contract, so the app schema does
+not validate what goes inside it.
+
+### Component Navigation
+
+Renders a registered component. `componentRef` is a component-registry key, not
+a file path:
+
+```typescript
+{ id: 'nav_directory', type: 'component', label: 'Directory', componentRef: 'metadata:directory', icon: 'contact' }
+```
+
+`params` is handed to the component as props and is **open by design** — the
+props are the component's own contract.
 
 ### Separator
 


### PR DESCRIPTION
#4177 变体/文档闸门的后续,用的正是它产出的信号。

那道闸门判定一个变体"已记录"的条件是:页面里出现 `<判别键>: '<变体>'` **或**出现裸的 `` `变体` ``。它的头注写得很直白:**第二种形态是宽松的,通过只代表页面说了这个词,不代表它记录了这件事。**

有六个变体正是只靠宽松形态通过的——那就是闸门自己产出的"弱通过"清单,也是一份精确的工作单。

## apps.mdx:列举了九种,只记录了六种

`report`、`action`、`component` 共享一句话——"the spec also defines …"——而另外六种各有独立小节和示例。现在它们也有了,导言也不再暗示存在"半支持的第二梯队"。

`action` 那节尤其值得写:**`actionName` 位于嵌套的 `actionDef` 块里,不是顶层键**——这恰恰是读者最容易猜错的形状。

`action` 和 `component` 都点明了哪个子对象是**刻意开放**的(`actionDef.params`、`component.params`):那是兄弟契约的地盘,而在 #4165 之后它们周围的一切都已经是 strict。

## knowledge.mdx:有表格,零示例

原本有一张表点名 `object` / `file` / `http`,但一个示例都没有,于是三种 kind 各自的键(`contentFields` vs `prefix` vs `urls`)在文档里根本无处可见。各补了一个示例。

## 每个示例都对着真实 schema 解析过

提交前用 `NavigationItemSchema` 和 `KnowledgeSourceKindSchema` 逐个 `safeParse`,**六个全过**。

凭记忆写文档正是 #4218 里那个 region 示例用上不存在的 `id` 键的原因——不重复同一个错误。

## 度量

| 项 | 之前 | 之后 |
|---|---|---|
| app navigation item 锚定形态 | 6/9 | **9/9** |
| knowledge source kind 锚定形态 | 0/3 | **3/3** |

`check:variant-docs`、`check:docs`、`check-doc-authoring`、`check:strictness-ledger` 全绿;`content/docs/references` 零变动。

## 更正:changeset

这份描述最初写的是「纯文档改动,无 changeset」。**那是错的**,`Check Changeset` 随即失败并给出了正解:该闸门要求每个 PR 都有 changeset,而「不发布任何东西的改动用空 changeset 即可」。

仓库里已经有 **72 个**空 changeset——那正是文档类工作在不 bump 任何包的前提下留下记录的方式。已按该形式补上(空 frontmatter + 描述)。

闸门提示的另一个选项 `skip-changeset` 标签被我放弃了:它是**压制**记录而不是**写下**记录,对一个在发布说明里确实有话可说的改动来说是错误的取舍。

Refs #4001, #4177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147tNF4Snk7Ry1KGt4a5PY4