### PR TITLE
docs(automation): hooks-vs-flows 决策指引 — flow 是应用默认面,hook 是系统兜底

### DIFF
--- a/.changeset/hook-vs-flow-path-guidance.md
+++ b/.changeset/hook-vs-flow-path-guidance.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(automation): add a "Hooks vs flows" decision section to `hooks.mdx` — flow as the default application surface, hook as the system backstop — with a task→layer table and the two structural reasons (a flow's writes are lint-checked metadata while a hook body's write set is statically opaque, per the accepted gap in `hook-body.zod.ts`; a flow reviews as data). Reverse link from `flows.mdx` Related. The framing settled in the #4271 discussion; documentation only, releases nothing.

--- a/content/docs/automation/flows.mdx
+++ b/content/docs/automation/flows.mdx
@@ -1123,6 +1123,7 @@ To branch on **which** event fired, test `previous` — it is empty on create
 
 ## Related
 
+- [Hooks](/docs/automation/hooks) — data-layer interception below the node graph; [Hooks vs flows](/docs/automation/hooks#hooks-vs-flows) covers when to drop down to one
 - [Workflow Metadata](/docs/automation/workflows) — why there is no standalone Workflow Rule type, and what replaces it
 - [Object Metadata](/docs/data-modeling/objects) — Objects that flows operate on
 - [Validation Metadata](/docs/data-modeling/validation) — Data validation rules

--- a/content/docs/automation/hooks.mdx
+++ b/content/docs/automation/hooks.mdx
@@ -28,7 +28,7 @@ cannot express.
 | Anything that pauses: approvals, screens, timers, signals | **Flow** — a hook runs inline and cannot pause |
 | Scheduled or date-relative sweeps ("30 days before `end_date`") | **Flow** (`schedule` / `timeRelative`) |
 | Mutating the pending record in the same write, before it is saved | **Before hook** |
-| An invariant enforced on every write path, across objects, no matter who writes | **Hook** — the backstop role |
+| An invariant enforced on every write path, across objects, no matter who writes | **Hook** — the backstop duty itself |
 | Read-side interception (`beforeFind` / `afterFind`) | **Hook** — flows have no read events |
 
 Two structural reasons to prefer the flow when either could work:

--- a/content/docs/automation/hooks.mdx
+++ b/content/docs/automation/hooks.mdx
@@ -14,6 +14,40 @@ A hook targets one or more `object`s and subscribes to one or more lifecycle
 `beforeInsert`, `beforeUpdate`, `afterUpdate`, `afterDelete` (read-side events
 such as `beforeFind`/`afterFind` are also available).
 
+## Hooks vs flows
+
+Hooks and [flows](/docs/automation/flows) overlap on record-triggered logic —
+a flow's `record_change` trigger fires on the same lifecycle events — so pick
+the layer before writing either. The working rule: **a flow is the default
+surface for application logic; a hook is the backstop** for what a node graph
+cannot express.
+
+| You need… | Reach for |
+| :--- | :--- |
+| Side effects after a save — create records, notify, call HTTP, request approval | **Flow** (`record_change`) |
+| Anything that pauses: approvals, screens, timers, signals | **Flow** — a hook runs inline and cannot pause |
+| Scheduled or date-relative sweeps ("30 days before `end_date`") | **Flow** (`schedule` / `timeRelative`) |
+| Mutating the pending record in the same write, before it is saved | **Before hook** |
+| An invariant enforced on every write path, across objects, no matter who writes | **Hook** — the backstop role |
+| Read-side interception (`beforeFind` / `afterFind`) | **Hook** — flows have no read events |
+
+Two structural reasons to prefer the flow when either could work:
+
+- **A flow's writes are validatable metadata; a hook body is opaque code.** An
+  `update_record` node's `fields` is structural config that `os validate`
+  checks — readonly targets, template dialects, declared expression slots. A
+  hook body's write set is **not** statically checked (see
+  [Hook & Action Bodies](/docs/automation/hook-bodies#not-statically-checked-the-write-set)):
+  a misspelled field name runs green and writes nothing.
+- **A flow reviews as data.** The node graph diffs field-by-field and renders
+  in the Console designer with per-node run history; a hook body reviews as
+  code only.
+
+Logic that genuinely needs code still doesn't have to be a hook: a flow
+`script` node calling a function registered via `defineStack({ functions })`
+keeps the orchestration in checked metadata and the code in one named,
+testable unit.
+
 ## Before Hook
 
 Mutate the incoming record before it is saved. The engine exposes the pending


### PR DESCRIPTION
## 动机

「flow 是应用逻辑的默认面、hook 是系统兜底」这个分层共识,此前只存在于 #4271 的定题讨论里——作者(尤其 AI 作者)在 hooks / flows 两页文档里读不到任何选层指引,两个面在 record 触发逻辑上完全重叠,选错层的代价(hook body 写集静态全盲 vs flow 结构化 config 有 lint)也没有写在作者会看的地方。

## 改动

**`content/docs/automation/hooks.mdx`** — 紧跟页首概念段新增 **Hooks vs flows** 一节:

- 任务→层的决策表:存后副作用 / 可暂停节点(审批、屏幕、定时)/ 定时与日期相对扫描 → **flow**;同一写事务内改动待存记录 / 跨对象全写路径不变量 / 读侧拦截(`beforeFind`/`afterFind`,flow 无读事件)→ **hook**;
- 两条结构性理由:flow 的写是可校验的元数据(`update_record.fields` 受 `os validate` 检查:readonly、模板方言、表达式槽),hook body 的写集静态不可见(链接到 hook-bodies 页已有的 accepted-gap 锚点);flow 以数据形态可 diff 可审,hook body 只能按代码审;
- 收尾指出「需要代码也不必是 hook」:flow `script` 节点 + `defineStack({ functions })` 让编排留在受检元数据里。

**`content/docs/automation/flows.mdx`** — Related 列表加反向链接指到新节。

**`.changeset/hook-vs-flow-path-guidance.md`** — 空 changeset(docs-only 惯例,不发版)。

## 核实

- 表中每条能力主张都对照了两页现有内容:flow 的 `schedule`/`timeRelative`/暂停语义、`script` 节点两种形态、hook 的读侧事件与 inline 执行(不可暂停);
- 写集 gap 的措辞与 `hook-body.zod.ts:134-140` 的 schema 注释一致,锚点 `#not-statically-checked-the-write-set` 已验证存在;
- 纯散文 + 表格,无新增 `os:check` 代码示例,零 schema 漂移面。

关联:#4271(写集 lint 设计 issue)、#4001(母 issue)。

---
_Generated by [Claude Code](https://claude.ai/code/session_0147tNF4Snk7Ry1KGt4a5PY4)_