### PR TITLE
docs(releases): record the #4212-family plugin-API retirements in the v17 notes and status matrix

### DIFF
--- a/.changeset/docs-v17-plugin-retirement-notes.md
+++ b/.changeset/docs-v17-plugin-retirement-notes.md
@@ -1,0 +1,5 @@
+---
+---
+
+docs-only: record the #4212-family plugin-API retirements (#4241/#4242) in the
+v17 release notes and the implementation-status matrix. Releases nothing.

--- a/content/docs/releases/implementation-status.mdx
+++ b/content/docs/releases/implementation-status.mdx
@@ -8,7 +8,7 @@ description: Detailed status of protocol implementations across ObjectStack pack
 This document provides a comprehensive overview of which protocols from `@objectstack/spec` have been implemented in the ObjectStack packages.
 
 <Callout type="info">
-**Last Updated**: June 2026
+**Last Updated**: July 2026
 
 This matrix is generated from actual codebase analysis and represents the current implementation status.
 </Callout>
@@ -42,8 +42,8 @@ This matrix is generated from actual codebase analysis and represents the curren
 
 **Notes:**
 - Core package provides complete microkernel implementation
-- Plugin system supports lifecycle hooks, dependency resolution, and service injection
-- Event bus enables inter-plugin communication
+- Plugin system supports the `init`/`start`/`destroy` lifecycle, dependency resolution, and service injection — the `onInstall`/`onEnable`-style hook family was retired in v17 as never-implemented (#4212)
+- Event bus enables inter-plugin communication; `IPluginLifecycleEvents` registers the 14 lifecycle events that actually fire, and `LifecycleEventName` soft-types `hook`/`trigger` (#4241)
 - ObjectQL serves as the **example kernel** — a reference implementation that will be modularized into plugins
 
 ### Data Infrastructure

--- a/content/docs/releases/v17.mdx
+++ b/content/docs/releases/v17.mdx
@@ -904,6 +904,7 @@ import or the authored key.
 | `dashboard.aria` / `.performance` / widget `performance` (+ `PerformanceConfigSchema`) | no renderer applied them; virtual scrolling is the live top-level `virtualScroll` (#3896 close-out) |
 | `agent.knowledge` (+ `AIKnowledgeSchema`) | declaring sources/indexes never scoped retrieval — `search_knowledge` takes `sourceIds` from the LLM's tool-call arguments (#3896 close-out) |
 | `PluginLifecycleSchema` (`onInstall`/`onEnable`/`onDisable`/`onUninstall`/`onUpgrade`) + `UpgradeContextSchema` + the `ObjectStackPlugin` interface family (`@objectstack/spec/system`) | a plugin lifecycle the kernel never implemented — the real contract is `init`/`start`/`destroy`; code written against the hooks silently never ran (#4212) |
+| The typed-event cluster (`kernel` plugin-lifecycle-events.zod — ten payload schemas (`PluginRegisteredEvent`, `HookTriggeredEvent`, `KernelReadyEvent`, …), the 21-name `PluginLifecycleEventType` enum, `ITypedEventEmitter`) | a typed-event system that was never built: zero consumers, and the enum was wrong in both directions — 17 names nothing fires, 10 real events missing. `IPluginLifecycleEvents` is now the registry of the 14 events with a real emitter, and the new `LifecycleEventName` union soft-types `PluginContext.hook`/`trigger` (#4212 follow-up, #4241) |
 | `skill.triggerPhrases` | phrases were never matched; activation is `triggerConditions` + the agent's `skills[]` allowlist (#3896 close-out) |
 | `DEFAULT_DISPATCHER_ROUTES` | dead route table |
 | Aspirational config on Theme / Translation / Webhook | still-dead after #3494 |
@@ -941,6 +942,18 @@ from `@objectstack/spec` directly.
   Fix: write `{ strategy: 'retry', maxRetries: 3 }`, or `strategy: 'fail'` if no
   retry was intended. `maxRetries: 0` stays legal under `'fail'` / `'continue'`,
   which never read it.
+- **`ObjectQLEngine.use()` and `ObjectQLHostContext` are removed** (#4212
+  follow-up, #4242). The engine's own plugin loader — register a manifest
+  part, then dispatch the runtime part's `onEnable` over an
+  `ObjectQLHostContext` — had zero callers repo-wide, and its `onEnable` was
+  the engine-level twin of the #4212 disease: a lifecycle entry point that
+  reads as a contract and never runs. Fix: `engine.use(manifest)` →
+  `engine.registerApp(manifest)`; `engine.use(_, { onEnable })` → a kernel
+  plugin (`kernel.use({ name, init(ctx) { … } })`, engine via
+  `ctx.getService('objectql')`, drivers via `engine.registerDriver()`).
+  `new ObjectQL({ logger })` and `ObjectQLPlugin`'s `hostContext` option keep
+  working, and the *app-bundle* `onEnable` module export (dispatched by
+  AppPlugin at boot) is a different, real contract — unchanged.
 
 ## New capabilities in 17.0.0
 


### PR DESCRIPTION
## What

Docs-only follow-up to #4241 / #4242 (the #4212 leftovers): the v17 release notes carried the original #4212 row but neither follow-up, and the status matrix still claimed the retired capability.

- **`content/docs/releases/v17.mdx` — "Dead spec clusters removed"**: adds the #4241 row — the never-built typed-event cluster (ten payload schemas, the 21-name `PluginLifecycleEventType` enum that was wrong in both directions, `ITypedEventEmitter`), and what replaced it: `IPluginLifecycleEvents` as the enforced registry of the 14 events with a real emitter, plus the `LifecycleEventName` soft union on `PluginContext.hook`/`trigger`.
- **`content/docs/releases/v17.mdx` — "Smaller breaking changes"**: adds the #4242 entry — `ObjectQLEngine.use()` / `ObjectQLHostContext` removal with the FROM → TO migration (`registerApp` / kernel plugin via `ctx.getService('objectql')`), and the explicit note that the app-bundle `onEnable` module export is a different, live contract that is unchanged.
- **`content/docs/releases/implementation-status.mdx`**: stops claiming "lifecycle hooks" as a plugin-system capability (that family never ran and is retired in v17); states the real `init`/`start`/`destroy` contract and the #4241 event registry; bumps Last Updated.

## Why

Both follow-ups are `major` changesets shipping in the 17.0.0 train — the hand-written release narrative and the status matrix should tell the same story as the CHANGELOG. Also addresses the docs-drift advisory on #4242 for the release docs.

## Verification

- `node scripts/check-doc-authoring.mjs` — 214 files clean.
- Downstream sweep of `objectui` and `cloud` (fresh clones/`origin/main`) for every removed symbol (`ObjectQLHostContext`, `ITypedEventEmitter`, `PluginLifecycleEventType`, all `*EventSchema`/event types, `engine.use(`) — zero references; cloud's only `.use(` is the supported `kernel.use()` path.

Prose-only change; no code paths touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrRNgrWaRtggzmrHpbomyh)_