### PR TITLE
fix(spec): variant/doc 闸门对 YAML 是瞎的,而一条豁免正把这个盲区记录成文档缺口

### DIFF
--- a/.changeset/variant-docs-exemption-audit.md
+++ b/.changeset/variant-docs-exemption-audit.md
@@ -1,0 +1,9 @@
+---
+'@objectstack/spec': patch
+---
+
+The variant/doc gate's coverage matcher now recognises a YAML mapping line (`type: npm`), not only the quoted (`type: 'npm'`) and backticked (`` `npm` ``) forms.
+
+Found by auditing the ledger's seven `generated-reference-only` exemptions — a class that does not say "this variant is un-authorable", only "nobody wrote a guide for it". One of the seven was not a doc gap at all: `protocol/objectui/widget-contract.mdx` has documented `inline` / `npm` / `remote` in a "Widget Source" section the whole time, in YAML examples the matcher could not see. That entry is now governed, so the page is under the ratchet. Two more (tenant isolation strategy, settings-manifest handler) were reclassified `not-authorable` — their own reasons already said `operator-set` and `consumed by Setup/Studio`. The remaining exemptions now state their gap plainly instead of pointing at the generated reference as if it settled the question; connector authentication is flagged as the one worth acting on, being tenant-authored (ADR-0097) with no hand-written connector guide anywhere in the repo.
+
+The YAML form is anchored to a full line (trailing `# comment` allowed), so it stays as tight as the quoted form — a bare word in prose still does not count.

--- a/packages/spec/scripts/check-variant-docs.mts
+++ b/packages/spec/scripts/check-variant-docs.mts
@@ -26,13 +26,25 @@
 // renamed union) both fail: no new undeclared surface, no stale claims.
 //
 // WHAT "MENTIONED" MEANS — and what this gate does NOT prove. A variant counts as
-// documented if the bound doc contains either `<discriminator>: '<variant>'` (the code-
-// sample form) or `` `<variant>` `` (the prose/table form). The second form is
-// deliberately loose, and for short generic variants (`object`, `api`, `value`) it can
-// match an unrelated sentence — so a pass here means "the page at least says the word",
-// NOT "the page documents it correctly". This gate catches the omission that shipped for
-// months; it is not a substitute for reading the page. Tightening the loose form would
-// cost more false failures than the precision is worth.
+// documented if the bound doc contains any of three forms:
+//
+//   `<discriminator>: '<variant>'`   the quoted code-sample form (JS/TS/JSON)
+//   `` `<variant>` ``                the prose/table form
+//   `<discriminator>: <variant>`     a whole YAML mapping line (optionally + `# comment`)
+//
+// The YAML form was added after the widget-implementation union (#4001 audit) showed the
+// cost of leaving it out: `protocol/objectui/widget-contract.mdx` carries a "Widget Source"
+// section documenting all three of `npm` / `remote` / `inline` in YAML examples — and the
+// gate could not see any of them, because YAML does not quote scalar values. The entry sat
+// exempt as "generated-reference-only", i.e. the ledger recorded a doc gap that did not
+// exist while the real gap — a matcher blind to half the repo's example dialect — stayed
+// invisible. It is anchored to a full line so it stays as tight as the quoted form.
+//
+// The prose form is deliberately loose, and for short generic variants (`object`, `api`,
+// `value`) it can match an unrelated sentence — so a pass here means "the page at least
+// says the word", NOT "the page documents it correctly". This gate catches the omission
+// that shipped for months; it is not a substitute for reading the page. Tightening the
+// loose form would cost more false failures than the precision is worth.
 //
 // Usage:
 //   tsx check-variant-docs.mts          # fail on undeclared/orphaned/undocumented
@@ -186,7 +198,10 @@ for (const e of ledger.entries) {
   const undocumented = u.variants.filter((v) => {
     const anchored = new RegExp(`${esc(u.disc)}\\s*:\\s*['"\`]${esc(v)}['"\`]`);
     const token = new RegExp('`' + esc(v) + '`');
-    return !anchored.test(blob) && !token.test(blob);
+    // YAML mapping line: unquoted scalar, so it must be anchored to the whole
+    // line (trailing `# comment` allowed) to stay as tight as the quoted form.
+    const yaml = new RegExp(`^\\s*${esc(u.disc)}\\s*:\\s*${esc(v)}\\s*(#.*)?$`, 'm');
+    return !anchored.test(blob) && !token.test(blob) && !yaml.test(blob);
   });
   if (undocumented.length) {
     errors.push(

--- a/packages/spec/variant-docs.json
+++ b/packages/spec/variant-docs.json
@@ -13,7 +13,22 @@
     "  generated-reference-only — the type is documented solely under content/docs/references/,",
     "      which build-docs.ts generates FROM these schemas. Generated docs cannot drift.",
     "  not-authorable — wire protocol, engine RPC, or a runtime-derived discriminator. Nobody",
-    "      hand-writes the variant, so no hand-written doc owes it a mention."
+    "      hand-writes the variant, so no hand-written doc owes it a mention.",
+    "",
+    "AUDIT NOTE (#4001 follow-up). `generated-reference-only` is the weaker of the two: it",
+    "does not say the variant is un-authorable, only that nobody has written a guide for it.",
+    "Every such entry was re-checked against the docs tree, which moved four of the original",
+    "seven:",
+    "  - widget implementation became GOVERNED. protocol/objectui/widget-contract.mdx has",
+    "    documented all three variants in a `Widget Source` section the whole time; the gate",
+    "    could not see them because its matcher was blind to YAML. Fixed in the matcher.",
+    "  - tenant isolation and settings-manifest handler became NOT-AUTHORABLE. Both reasons",
+    "    already said the words (`operator-set`, `consumed by Setup/Studio`); the label just",
+    "    disagreed with them.",
+    "  - the remaining exemptions now state the gap plainly instead of pointing at the",
+    "    generated page as if it settled the question. Connector authentication is the one",
+    "    worth acting on: it is tenant-authored (ADR-0097 declarative `connectors:`) and the",
+    "    repo has no hand-written connector guide at all."
   ],
   "entries": [
     {
@@ -53,44 +68,44 @@
     {
       "key": "type:inline|npm|remote",
       "label": "widget implementation",
-      "exempt": "generated-reference-only",
-      "reason": "Documented at content/docs/references/ui/widget.mdx, generated from WidgetManifestSchema."
+      "docs": ["content/docs/protocol/objectui/widget-contract.mdx"],
+      "note": "Was exempt as generated-reference-only until the #4001 audit: the page's `Widget Source` section documents all three variants, but in YAML examples, which the coverage matcher could not see. The exemption was recording a gate blind-spot as a doc gap."
     },
     {
       "key": "type:cron|interval|once",
       "label": "job schedule",
       "exempt": "generated-reference-only",
-      "reason": "Documented at content/docs/references/system/job.mdx."
+      "reason": "No hand-written guide covers the Job type; content/docs/references/system/job.mdx is generated from JobSchema. Note that automation/flows.mdx's `schedule: { type: 'cron' }` is a DIFFERENT surface — a flow start node's own config (flow.zod.ts tombstones a top-level `schedule`) — so it neither documents nor governs this union."
     },
     {
       "key": "type:api-key|basic|bearer|none|oauth2",
       "label": "connector authentication",
       "exempt": "generated-reference-only",
-      "reason": "Documented at content/docs/references/integration/connector-auth.mdx."
+      "reason": "DOCUMENTATION GAP, not a non-authorable surface — the strongest candidate among the exemptions for a real guide. Connector auth IS tenant-authored (ADR-0097 materializes a declarative `connectors:` entry naming a `provider` into a live connector at boot), but the repo has no hand-written connector page at all: the only prose is one paragraph inside automation/flows.mdx about the `connector_action` node. Until a guide exists there is nothing for this entry to bind to; when one is written, bind it and delete this exemption."
     },
     {
       "key": "type:api-key|basic|bearer|none",
       "label": "connector auth (environment-artifact projection)",
       "exempt": "generated-reference-only",
-      "reason": "Narrower projection of the connector-auth union carried in the deploy artifact; same generated reference."
+      "reason": "The declarative connector-instance auth shape (ADR-0097), reached via EnvironmentArtifactSchema.metadata.connectors[].auth. It carries a `credentialRef` rather than an inline secret, and omits `oauth2` because the authorization-code/refresh lifecycle is the enterprise tier (ADR-0015) — not because the artifact narrows it. Inherits the gap above; a connector guide would govern both."
     },
     {
       "key": "strategy:isolated_db|isolated_schema|shared_schema",
       "label": "tenant isolation strategy",
-      "exempt": "generated-reference-only",
-      "reason": "Documented at content/docs/references/system/tenant.mdx. Operator-set, not tenant-authored."
+      "exempt": "not-authorable",
+      "reason": "Chosen by the operator when a tenant is provisioned, not written into any tenant's metadata — so no hand-written authoring page owes it a mention. (Was labelled generated-reference-only, though its own reason already said `operator-set`; the generated page at content/docs/references/system/tenant.mdx remains the reference.)"
     },
     {
       "key": "type:cast|constant|javascript|lookup|map",
       "label": "sync mapping transform",
       "exempt": "generated-reference-only",
-      "reason": "Generated reference only; no hand-written page covers the sync transform set yet."
+      "reason": "DOCUMENTATION GAP. `mappings:` is authored on a stack (releases/v12.mdx records `defineMapping`), but no hand-written page covers the transform set — the only prose that names a mapping at all is protocol/kernel/config-resolution.mdx, on a different subject. Lower priority than the connector gap: the transforms are a closed, self-describing set. Bind a page here when one is written."
     },
     {
       "key": "kind:action|http|navigate",
       "label": "settings-manifest handler",
-      "exempt": "generated-reference-only",
-      "reason": "Generated reference only; consumed by Setup/Studio, not tenant-authored metadata."
+      "exempt": "not-authorable",
+      "reason": "Declared by a settings manifest that Setup/Studio ships and consumes; it is not part of the metadata a tenant authors. (Was labelled generated-reference-only, though its own reason already said so.)"
     },
     {
       "key": "viewKind:form|list",


### PR DESCRIPTION
## 起因

审计 `variant-docs.json` 里 7 条 `generated-reference-only` 豁免。这是 ledger 两种豁免里较弱的一种 —— 它**并不主张变体不可授权**,只说「还没人给它写指南」。所以每一条要么是真缺口、要么是错归档,而它们自写下之后从未复核过。

## 发现

**一条两者都不是。** `content/docs/protocol/objectui/widget-contract.mdx` 有一节 **Widget Source**,把 `inline` / `npm` / `remote` 三个变体逐个写了完整示例 —— 而且一直都有。但写法是 YAML,闸门的覆盖匹配器只认 `type: 'npm'`(带引号)和 `` `npm` ``(反引号)。**YAML 不给标量加引号**,所以闸门什么也看不见,ledger 于是记录了一个**并不存在的文档缺口**,而真正的缺口 —— 一个对仓库半数示例方言视而不见的匹配器 —— 始终不可见。

这条豁免掩盖的是闸门自己的 bug,不是文档的问题。

## 改动

**1. 匹配器补 YAML 形式**(`scripts/check-variant-docs.mts`)
新增第三种「已提及」形式:整行的 YAML 映射(允许尾随 `# 注释`)。锚定到行首行尾,和带引号形式一样紧。

**2. widget implementation → governed**,绑定 `widget-contract.mdx`。治理数 **5 → 6**,该页正式进入棘轮。

**3. 两条重分类为 `not-authorable`** —— tenant isolation strategy 与 settings-manifest handler。它们自己的 reason 早就写着 `operator-set` 和 `consumed by Setup/Studio`,只是标签跟内容不一致。

**4. 其余豁免把缺口写实**,不再拿生成参考页当作已经回答了问题:
- **connector authentication ×2** —— 标为**最值得动手**的一条。ADR-0097 让声明式 `connectors:` 成为租户手写内容,auth type 明确是作者写的,但**仓库里根本没有任何手写的连接器页**(唯一的散文是 `flows.mdx` 里关于 `connector_action` 节点的一段)。另外顺手纠正了一处:窄版 union(`EnvironmentArtifactSchema.metadata.connectors[].auth`)缺 `oauth2` 是因为 authorization-code/refresh 属**企业层(ADR-0015)**,不是因为部署产物做了收窄 —— 我最初的推断是错的,查了 `connector-auth.zod.ts` 才写实。
- **job schedule** —— 真空缺,并写明 `flows.mdx` 里的 `schedule: { type: 'cron' }` 是**另一个面**(flow start 节点自己的 config;`flow.zod.ts` 还专门给顶层 `schedule` 立了墓碑),既不记录也不治理这个 union,免得下一个人重复我刚做的排查。
- **sync mapping transform** —— 真空缺,优先级低于连接器(变体集封闭且自解释)。

**5. ledger 顶部 `$comment` 增加审计说明**,记录这次复核的结论与判据,让下一次复核有起点。

## 验证

- `check:variant-docs` **通过**:20 个 union → **6 governed / 14 exempt**(此前 5 / 15)
- **验证新形式真的咬得住**(两条失败路径):
  1. 删掉 YAML 里 `type: inline` 一行 → 闸门报 `1 variant(s) … never mentions: inline` ✅
  2. 同一变体改成散文裸词 + 句中嵌入的 `type: inline` → **仍然报缺失** ✅(证明没有宽到把散文当数据)
- `@objectstack/spec` **276 文件 / 7169 用例全过**
- `packages/spec` **12 个闸门全 OK**;`check:role-word` / `check:doc-authoring` OK
- 期间 `check:api-surface` 与 `check:skill-examples` 一度报 `defineHook` 缺失 —— 查证是本地 `dist/` 陈旧:`defineHook()` 已由 #4273 落地(即我在 #4269 提的那份),`pnpm build` 后两项恢复 OK。**未**提交任何重新生成的快照。

## 范围说明

写一份完整的连接器授权指南远超本次审计 PR 的范围,所以我把它作为**结论**写进 ledger(连同「写好后绑上并删掉这条豁免」的指示),而不是顺手补一份半成品。

关联:#4001(母 issue)、#4177(闸门本体)、ADR-0097 / ADR-0015。

---
_Generated by [Claude Code](https://claude.ai/code/session_0147tNF4Snk7Ry1KGt4a5PY4)_