### PR TITLE
chore(packaging): CHANGELOG.md ships in every npm tarball (#4261)

### DIFF
--- a/.changeset/changelog-ships-in-tarball.md
+++ b/.changeset/changelog-ships-in-tarball.md
@@ -1,0 +1,100 @@
+---
+"@objectstack/account": patch
+"@objectstack/cli": patch
+"@objectstack/client": patch
+"@objectstack/client-react": patch
+"@objectstack/cloud-connection": patch
+"@objectstack/connector-mcp": patch
+"@objectstack/connector-openapi": patch
+"@objectstack/connector-rest": patch
+"@objectstack/connector-slack": patch
+"@objectstack/console": patch
+"@objectstack/core": patch
+"@objectstack/driver-memory": patch
+"@objectstack/driver-mongodb": patch
+"@objectstack/driver-sql": patch
+"@objectstack/driver-sqlite-wasm": patch
+"@objectstack/embedder-openai": patch
+"@objectstack/formula": patch
+"@objectstack/hono": patch
+"@objectstack/knowledge-memory": patch
+"@objectstack/knowledge-ragflow": patch
+"@objectstack/lint": patch
+"@objectstack/mcp": patch
+"@objectstack/metadata": patch
+"@objectstack/metadata-core": patch
+"@objectstack/metadata-fs": patch
+"@objectstack/metadata-protocol": patch
+"@objectstack/objectql": patch
+"@objectstack/observability": patch
+"@objectstack/platform-objects": patch
+"@objectstack/plugin-approvals": patch
+"@objectstack/plugin-audit": patch
+"@objectstack/plugin-auth": patch
+"@objectstack/plugin-dev": patch
+"@objectstack/plugin-email": patch
+"@objectstack/plugin-hono-server": patch
+"@objectstack/plugin-pinyin-search": patch
+"@objectstack/plugin-reports": patch
+"@objectstack/plugin-security": patch
+"@objectstack/plugin-sharing": patch
+"@objectstack/plugin-webhooks": patch
+"@objectstack/rest": patch
+"@objectstack/runtime": patch
+"@objectstack/sdui-parser": patch
+"@objectstack/service-analytics": patch
+"@objectstack/service-automation": patch
+"@objectstack/service-cache": patch
+"@objectstack/service-cluster": patch
+"@objectstack/service-cluster-redis": patch
+"@objectstack/service-datasource": patch
+"@objectstack/service-i18n": patch
+"@objectstack/service-job": patch
+"@objectstack/service-knowledge": patch
+"@objectstack/service-messaging": patch
+"@objectstack/service-package": patch
+"@objectstack/service-queue": patch
+"@objectstack/service-realtime": patch
+"@objectstack/service-settings": patch
+"@objectstack/service-sms": patch
+"@objectstack/service-storage": patch
+"@objectstack/setup": patch
+"@objectstack/studio": patch
+"@objectstack/trigger-api": patch
+"@objectstack/trigger-record-change": patch
+"@objectstack/trigger-schedule": patch
+"@objectstack/types": patch
+"@objectstack/verify": patch
+"create-objectstack": patch
+"objectstack-vscode": patch
+---
+
+chore(packaging): CHANGELOG.md ships in every npm tarball (#4261)
+
+The AGENTS.md post-task checklist requires breaking changesets to carry their
+FROM → TO migration because "this text ships to consumers as `CHANGELOG.md`
+inside the npm package and is what an upgrading agent greps after the tombstone
+error." That delivery path was severed for 68 of the 69 publishable packages:
+npm packs `package.json` / `README*` / `LICENSE*` unconditionally but — unlike
+older npm versions — not `CHANGELOG.md`, and the canonical
+`"files": ["dist", "README.md"]` whitelist never named it. Measured on npm
+10.9.7: `npm pack --dry-run` on `@objectstack/types` shipped 3 files while its
+70KB `CHANGELOG.md` stayed behind. Only `@objectstack/spec` listed it
+explicitly.
+
+The tombstone-error scenario is precisely the one where the repo is out of
+reach — the upgrading agent has `node_modules` and nothing else — so the
+migration text has to ride in the tarball. Every publishable package now
+declares `CHANGELOG.md` in `files`, and the canonical whitelist is
+`["dist", "README.md", "CHANGELOG.md"]`.
+
+The other half is the gate: `check:published-files` gains a fifth invariant,
+COMPLETE — a whitelist that fails to cover `CHANGELOG.md` fails the
+always-required lint job, so the next package cannot silently sever the path
+again. `@objectstack/spec`'s per-package EXTRA_ENTRIES exemption dissolves
+into the canonical set.
+
+Consumer-visible change: one more file per install (the package's changelog,
+e.g. 70.8KB for `@objectstack/types`), and `grep -r "removed key"
+node_modules/@objectstack/*/CHANGELOG.md` now finds the migration it was
+promised.

--- a/packages/adapters/hono/package.json
+++ b/packages/adapters/hono/package.json
@@ -51,7 +51,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/apps/account/package.json
+++ b/packages/apps/account/package.json
@@ -43,7 +43,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/apps/setup/package.json
+++ b/packages/apps/setup/package.json
@@ -43,7 +43,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/apps/studio/package.json
+++ b/packages/apps/studio/package.json
@@ -43,7 +43,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -124,7 +124,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/client-react/package.json
+++ b/packages/client-react/package.json
@@ -47,7 +47,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -51,7 +51,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/cloud-connection/package.json
+++ b/packages/cloud-connection/package.json
@@ -49,7 +49,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/connectors/connector-mcp/package.json
+++ b/packages/connectors/connector-mcp/package.json
@@ -38,6 +38,7 @@
   ],
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/connectors/connector-openapi/package.json
+++ b/packages/connectors/connector-openapi/package.json
@@ -36,6 +36,7 @@
     ],
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/connectors/connector-rest/package.json
+++ b/packages/connectors/connector-rest/package.json
@@ -35,6 +35,7 @@
   ],
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/connectors/connector-slack/package.json
+++ b/packages/connectors/connector-slack/package.json
@@ -35,6 +35,7 @@
   ],
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -17,7 +17,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "exports": {
     "./package.json": "./package.json"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/create-objectstack/package.json
+++ b/packages/create-objectstack/package.json
@@ -42,7 +42,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/formula/package.json
+++ b/packages/formula/package.json
@@ -44,6 +44,7 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -50,7 +50,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -51,7 +51,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/metadata-core/package.json
+++ b/packages/metadata-core/package.json
@@ -20,7 +20,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/metadata-fs/package.json
+++ b/packages/metadata-fs/package.json
@@ -15,7 +15,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/metadata-protocol/package.json
+++ b/packages/metadata-protocol/package.json
@@ -15,7 +15,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -25,7 +25,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/objectql/package.json
+++ b/packages/objectql/package.json
@@ -55,7 +55,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -47,7 +47,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/platform-objects/package.json
+++ b/packages/platform-objects/package.json
@@ -97,7 +97,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/plugins/driver-memory/package.json
+++ b/packages/plugins/driver-memory/package.json
@@ -47,7 +47,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/plugins/driver-mongodb/package.json
+++ b/packages/plugins/driver-mongodb/package.json
@@ -50,7 +50,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/plugins/driver-sql/package.json
+++ b/packages/plugins/driver-sql/package.json
@@ -71,7 +71,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/plugins/driver-sqlite-wasm/package.json
+++ b/packages/plugins/driver-sqlite-wasm/package.json
@@ -54,7 +54,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/plugins/embedder-openai/package.json
+++ b/packages/plugins/embedder-openai/package.json
@@ -39,6 +39,7 @@
   ],
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/plugins/knowledge-memory/package.json
+++ b/packages/plugins/knowledge-memory/package.json
@@ -36,6 +36,7 @@
   ],
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/plugins/knowledge-ragflow/package.json
+++ b/packages/plugins/knowledge-ragflow/package.json
@@ -35,6 +35,7 @@
   ],
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/plugins/plugin-approvals/package.json
+++ b/packages/plugins/plugin-approvals/package.json
@@ -40,6 +40,7 @@
   ],
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/plugins/plugin-audit/package.json
+++ b/packages/plugins/plugin-audit/package.json
@@ -46,7 +46,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/plugins/plugin-auth/package.json
+++ b/packages/plugins/plugin-auth/package.json
@@ -57,7 +57,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/plugins/plugin-dev/package.json
+++ b/packages/plugins/plugin-dev/package.json
@@ -58,7 +58,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/plugins/plugin-email/package.json
+++ b/packages/plugins/plugin-email/package.json
@@ -35,6 +35,7 @@
   ],
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/plugins/plugin-hono-server/package.json
+++ b/packages/plugins/plugin-hono-server/package.json
@@ -42,7 +42,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/plugins/plugin-pinyin-search/package.json
+++ b/packages/plugins/plugin-pinyin-search/package.json
@@ -36,6 +36,7 @@
   ],
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/plugins/plugin-reports/package.json
+++ b/packages/plugins/plugin-reports/package.json
@@ -36,6 +36,7 @@
   ],
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/plugins/plugin-security/package.json
+++ b/packages/plugins/plugin-security/package.json
@@ -48,7 +48,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/plugins/plugin-sharing/package.json
+++ b/packages/plugins/plugin-sharing/package.json
@@ -38,6 +38,7 @@
   ],
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/plugins/plugin-webhooks/package.json
+++ b/packages/plugins/plugin-webhooks/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -55,7 +55,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -71,7 +71,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/sdui-parser/package.json
+++ b/packages/sdui-parser/package.json
@@ -40,6 +40,7 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/services/service-analytics/package.json
+++ b/packages/services/service-analytics/package.json
@@ -48,7 +48,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/services/service-automation/package.json
+++ b/packages/services/service-automation/package.json
@@ -47,7 +47,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/services/service-cache/package.json
+++ b/packages/services/service-cache/package.json
@@ -46,7 +46,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/services/service-cluster-redis/package.json
+++ b/packages/services/service-cluster-redis/package.json
@@ -44,6 +44,7 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/services/service-cluster/package.json
+++ b/packages/services/service-cluster/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/services/service-datasource/package.json
+++ b/packages/services/service-datasource/package.json
@@ -62,6 +62,7 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/services/service-i18n/package.json
+++ b/packages/services/service-i18n/package.json
@@ -47,7 +47,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/services/service-job/package.json
+++ b/packages/services/service-job/package.json
@@ -48,7 +48,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/services/service-knowledge/package.json
+++ b/packages/services/service-knowledge/package.json
@@ -47,7 +47,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/services/service-messaging/package.json
+++ b/packages/services/service-messaging/package.json
@@ -47,7 +47,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/services/service-package/package.json
+++ b/packages/services/service-package/package.json
@@ -47,7 +47,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/services/service-queue/package.json
+++ b/packages/services/service-queue/package.json
@@ -47,7 +47,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/services/service-realtime/package.json
+++ b/packages/services/service-realtime/package.json
@@ -47,7 +47,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/services/service-settings/package.json
+++ b/packages/services/service-settings/package.json
@@ -46,7 +46,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/services/service-sms/package.json
+++ b/packages/services/service-sms/package.json
@@ -34,6 +34,7 @@
   ],
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/services/service-storage/package.json
+++ b/packages/services/service-storage/package.json
@@ -61,7 +61,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/triggers/trigger-api/package.json
+++ b/packages/triggers/trigger-api/package.json
@@ -33,6 +33,7 @@
   ],
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/packages/triggers/trigger-record-change/package.json
+++ b/packages/triggers/trigger-record-change/package.json
@@ -48,7 +48,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/triggers/trigger-schedule/package.json
+++ b/packages/triggers/trigger-schedule/package.json
@@ -48,7 +48,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -42,7 +42,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/verify/package.json
+++ b/packages/verify/package.json
@@ -60,7 +60,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.0.0"

--- a/packages/vscode-objectstack/package.json
+++ b/packages/vscode-objectstack/package.json
@@ -78,6 +78,7 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/scripts/check-published-files.mjs
+++ b/scripts/check-published-files.mjs
@@ -27,18 +27,26 @@
 //   node scripts/check-published-files.mjs
 //   node scripts/check-published-files.mjs --self-test
 //
-// Four invariants, per non-private workspace package:
+// Five invariants, per non-private workspace package:
 //
 //   DECLARED    `files` exists and is a non-empty array of strings.
+//   COMPLETE    the whitelist covers `CHANGELOG.md` (#4261). AGENTS.md requires
+//               breaking changesets to carry their FROM -> TO migration because
+//               that text ships to consumers inside the npm package and is what
+//               an upgrading agent greps after a tombstone error -- but npm does
+//               not pack CHANGELOG.md unconditionally, so a whitelist that
+//               omits it silently severs that delivery path. 68 of 69 packages
+//               had it severed when #4261 measured.
 //   SUFFICIENT  every path the manifest points at (types, module, exports
 //               subpaths) is covered by it. A whitelist that omits a real entry
 //               point ships a package that cannot resolve -- the opposite
 //               failure, and one this guard would otherwise encourage.
 //   MINIMAL     nothing the whitelist admits is a test, a test-harness config
 //               or build-time tooling.
-//   REGISTERED  any entry beyond `dist` / `README.md` carries a reason in
-//               EXTRA_ENTRIES, reconciled in BOTH directions so a stale
-//               exemption is an error rather than dead text.
+//   REGISTERED  any entry beyond the canonical `dist` / `README.md` /
+//               `CHANGELOG.md` carries a reason in EXTRA_ENTRIES, reconciled in
+//               BOTH directions so a stale exemption is an error rather than
+//               dead text.
 //
 // Deliberately NOT checked: the contents of dist/. It does not exist in a fresh
 // checkout and the lint job does not build, so reading it would make the
@@ -55,9 +63,18 @@ const ROOT = resolve(import.meta.dirname, '..');
 const WORKSPACE_FILE = 'pnpm-workspace.yaml';
 const SELF = 'scripts/check-published-files.mjs';
 
-// Entries every package may declare without justifying itself: the build output
-// and the readme. Anything else is a deliberate decision and needs a reason.
-const CANONICAL = new Set(['dist', 'README.md']);
+// Entries every package may declare without justifying itself: the build
+// output, the readme and the changelog. Anything else is a deliberate decision
+// and needs a reason.
+const CANONICAL = new Set(['dist', 'README.md', 'CHANGELOG.md']);
+
+// Entries every package MUST cover, not merely may declare. CHANGELOG.md is the
+// delivery path the AGENTS.md post-task checklist promises: breaking changesets
+// write their FROM -> TO migration there, and an upgrading agent with only
+// node_modules on disk -- the tombstone-error scenario -- can grep nothing
+// else. npm stopped packing CHANGELOG unconditionally (see ALWAYS_PACKED), so
+// only an explicit `files` entry keeps that promise true (#4261).
+const REQUIRED = ['CHANGELOG.md'];
 
 // Package name -> { files entry -> why it is published }. Reconciled against
 // the manifests on every run: an entry here for a pattern no longer declared is
@@ -72,8 +89,6 @@ const EXTRA_ENTRIES = {
     'llms.txt': 'Protocol summary for LLM consumers.',
     'src/**/*.zod.ts':
       'The Zod schemas are themselves the contract (Prime Directive #1); downstream code imports them directly, so these sources are product rather than build input. Narrowed to *.zod.ts so no test or helper rides along.',
-    'CHANGELOG.md':
-      'Breaking changesets carry their FROM -> TO migration here, which is what an upgrading agent greps after hitting a tombstone error (AGENTS.md post-task checklist).',
     'api-surface.json': 'Export snapshot used by downstream compatibility checks.',
     'spec-changes.json': 'Machine-readable spec change log driving the upgrade guide.',
   },
@@ -110,8 +125,9 @@ const FORBIDDEN = [
 // them would flag packages that work. Measured on npm 10.9.7: packing
 // @objectstack/types with `["dist","README.md"]` yielded LICENSE, README.md and
 // package.json, and @objectstack/cli's `bin/run.js` shipped although `files`
-// never names bin/. CHANGELOG.md is deliberately absent from this set -- npm
-// does not pack it, which is why @objectstack/spec has to list it explicitly.
+// never names bin/. CHANGELOG.md is deliberately absent from this set -- older
+// npm packed it unconditionally, current npm does not -- which is exactly why
+// COMPLETE demands an explicit `files` entry for it (#4261).
 const ALWAYS_PACKED = [
   /^package\.json$/,
   /^readme(\.[^/]+)?$/i,
@@ -242,6 +258,12 @@ function selfTest() {
     ['dist', 'src/index.ts', false],
     ['README.md', 'README.md', true],
     ['README.md', 'docs/README.md', false],
+    // The COMPLETE invariant resolves through this same matcher, so the exact
+    // shapes it depends on are pinned: the literal entry, a directory that
+    // must NOT swallow it, and the near-miss name.
+    ['CHANGELOG.md', 'CHANGELOG.md', true],
+    ['dist', 'CHANGELOG.md', false],
+    ['CHANGELOG.md', 'CHANGELOG.mdx', false],
     ['src/**/*.zod.ts', 'src/data/object.zod.ts', true],
     ['src/**/*.zod.ts', 'src/index.zod.ts', true],
     ['src/**/*.zod.ts', 'src/data/object.test.ts', false],
@@ -327,7 +349,7 @@ for (const dir of workspaceDirs()) {
         'declares no `files` field, so npm packs the whole directory -- src/,',
         'unit tests and build tooling included, with dist/ added on top rather',
         'than instead of them.',
-        'Fix: add "files": ["dist", "README.md"] to its package.json.',
+        'Fix: add "files": ["dist", "README.md", "CHANGELOG.md"] to its package.json.',
       ],
     });
     continue;
@@ -353,6 +375,17 @@ for (const dir of workspaceDirs()) {
   }
 
   const matchers = files.map((f) => ({ pattern: f, match: matcher(f) }));
+
+  // --- COMPLETE ------------------------------------------------------------
+  for (const required of REQUIRED) {
+    if (matchers.some((m) => m.match(required))) continue;
+    lines.push(
+      `omits "${required}" from \`files\`, and npm does not pack it unconditionally, so the`,
+      'migration text breaking changesets are required to carry (AGENTS.md post-task',
+      'checklist) never reaches the consumer an upgrading agent greps for it (#4261).',
+      `Fix: add "${required}" to \`files\`.`,
+    );
+  }
 
   // --- REGISTERED ----------------------------------------------------------
   const registered = EXTRA_ENTRIES[name] ?? {};
@@ -446,7 +479,9 @@ if (problems.length > 0) {
   console.error(
     'Without a `files` whitelist npm packs the whole package directory, so consumers\n' +
       'install TypeScript sources, unit tests and build-time tooling alongside dist/.\n' +
-      'The canonical whitelist is ["dist", "README.md"]; anything more needs a reason.',
+      'The canonical whitelist is ["dist", "README.md", "CHANGELOG.md"]; anything more\n' +
+      'needs a reason, and dropping CHANGELOG.md severs the migration-text delivery\n' +
+      'path AGENTS.md promises (#4261).',
   );
   process.exit(1);
 }
@@ -454,7 +489,7 @@ if (problems.length > 0) {
 const withExtras = [...declaredExtrasByPackage.values()].filter((s) => s.size > 0).length;
 console.log(
   `✓ check:published-files — ${publishable} publishable package(s) of ${members} workspace ` +
-    'member(s) declare a `files` whitelist that covers every entry point and admits no test, ' +
-    `test-harness config or build script; ${withExtras} publish more than dist/ + README.md, ` +
-    'each with a registered reason.',
+    'member(s) declare a `files` whitelist that covers every entry point plus CHANGELOG.md ' +
+    `and admits no test, test-harness config or build script; ${withExtras} publish more ` +
+    'than dist/ + README.md + CHANGELOG.md, each with a registered reason.',
 );


### PR DESCRIPTION
Closes #4261.

## 问题

`AGENTS.md` 的 Post-Task Checklist 要求 breaking changeset 写清 FROM → TO 迁移,理由是这段文字「ships to consumers as `CHANGELOG.md` inside the npm package and is what an upgrading agent greps after the tombstone error」。但这条送达路径在 69 个可发布包里断了 68 条:npm 无条件打包的只有 `package.json` / `README*` / `LICENSE*`(老版本 npm 曾包含 CHANGELOG,现在不含),而 canonical 白名单 `["dist", "README.md"]` 从未列过它。实测(npm 10.9.7)`@objectstack/types`:tarball 3 个文件,70KB 的 `CHANGELOG.md` 留在了仓库里。只有 `@objectstack/spec` 显式列了它。

撞到 tombstone 报错的场景恰恰是「本地只有 `node_modules`、没有仓库」的场景 —— 迁移说明必须坐在 tarball 里才 grep 得到。按 issue 的方向 1 落地:**让约定成真**,而不是改写约定。

## 改了什么

**1. 68 个包的 `files` 补上 `"CHANGELOG.md"`**,canonical 白名单变为 `["dist", "README.md", "CHANGELOG.md"]`。每个包磁盘上都已有 CHANGELOG.md(changesets 维护),无一例外。

**2. `check:published-files` 新增第五条不变量 COMPLETE**:白名单没有覆盖 `CHANGELOG.md` 的包直接挂在始终必跑的 `lint` job 上,报错正文带 #4261 的因果和一行修法 —— 下一个新包不可能再静默切断这条路径。

- `CHANGELOG.md` 进入 CANONICAL 集合(声明无需理由),同时进入新的 REQUIRED 集合(不声明就报错)。两者分开:CANONICAL 是「可以」,REQUIRED 是「必须」。
- `@objectstack/spec` 在 `EXTRA_ENTRIES` 里的 CHANGELOG.md 登记随之溶解进 canonical 集合(双向核对会把留下的死条目当错误,所以必须删)。
- `ALWAYS_PACKED` 的注释同步改写:CHANGELOG 不在 npm 无条件打包集里,正是 COMPLETE 存在的原因。

## 验证

- `--self-test`:21 个模式断言 + 11 个分类断言,新增 3 个钉住 COMPLETE 所依赖的匹配形状(字面量命中、`dist` 不吞它、`CHANGELOG.mdx` 近似名不误命中)。
- `pnpm check:published-files`:69 个可发布包全绿。
- 反向测试:删掉任一包的该条目,门禁如期报错并给出修法。
- `npm pack --dry-run` on `@objectstack/types`:tarball 现在含 70.8kB `CHANGELOG.md`(issue 里实测缺失的正是它);`@objectstack/spec` 不回归。
- `pnpm lint`(改动脚本零告警)、`check:nul-bytes` / `check:doc-authoring` / `check:role-word` / `check:org-identifier` / `check:release-notes`、`check-changeset-no-major`(本 changeset 全 patch)、`check-changeset-fixed` 均通过。
- changeset 覆盖全部 68 个改动包(patch);`changeset status` 解析通过。

## 顺带发现,未塞进本 PR

`.changeset/adapter-hono-auth-wildcard-yields.md` 仍引用改名前的 `@objectstack/adapter-hono`(现为 `@objectstack/hono`),`changeset status` / `changeset version` 会在它上面崩 —— 预存在于 main,与本 PR 无关,已另行处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)