### PR TITLE
chore(spec): the field-file collection proof stops being an orphan tag

### DIFF
--- a/.changeset/register-field-file-collection-proof.md
+++ b/.changeset/register-field-file-collection-proof.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(spec): register the `adr0104-field-file-collection` dogfood proof tag in the ADR-0054 registry, honestly unbound — the collection contract it guards is `lifecycle` on the system `sys_file` object, already bound to `data-lifecycle`. Gate-only (`packages/spec/scripts/`, not published), so this releases nothing.

--- a/packages/spec/scripts/liveness/proof-registry.mts
+++ b/packages/spec/scripts/liveness/proof-registry.mts
@@ -482,6 +482,30 @@ export const HIGH_RISK_CLASSES: HighRiskClass[] = [
       + 'one entry would misrepresent both what it covers and what that entry is proven by. The '
       + 'per-property bindings above carve out the parts that do have a single owner.',
   },
+  {
+    id: 'field-file-collection',
+    label: 'Field-file collection (ADR-0104 PR-5b)',
+    summary:
+      'a field file released by its ONE owning record is tombstoned, and the sweep reclaims the row AND '
+      + 'the storage bytes once the declared window passes — with both vetoes intact: a tombstone that '
+      + 'regained an owner is un-tombstoned rather than reaped, and a REGRESSED migration flag stops '
+      + 'collection immediately (the guard re-reads the flag at sweep time instead of trusting the '
+      + 'memoized read the release path uses). This is the only code on the platform that deletes a '
+      + "user's bytes, and its sibling lineage — attachments — has had an end-to-end proof since #2755 "
+      + 'while field files, which reach collection by a different route (exclusive ownership, released '
+      + 'by the write path, gated per deployment), had none.',
+    proofId: 'adr0104-field-file-collection',
+    proofRef: 'packages/qa/dogfood/test/field-file-collection.dogfood.test.ts#adr0104-field-file-collection',
+    bound: false,
+    ledgerBindings: [],
+    blockedReason:
+      'the collection contract it guards is the `lifecycle` ttl declared on the SYSTEM object `sys_file` '
+      + '(service-storage), not an authorable per-type property — and `object.lifecycle` is already bound '
+      + 'to `data-lifecycle`, which carries one `proof` ref. The rest of the route (exclusive ownership, '
+      + 'release-on-write, the per-deployment migration gate) is service code with no authorable surface '
+      + 'to govern, so there is no other entry to bind instead. It runs unconditionally in the dogfood '
+      + 'suite.',
+  },
 ];
 
 /** Bound ledger paths → the class that binds them. Key: `<type>/<path>`. */


### PR DESCRIPTION
Follow-up hygiene spotted while verifying #4094: the liveness gate has been printing a warning on every run since #4285 landed the field-file collection dogfood test.

## The warning

```
⚠ 1 unregistered dogfood proof tag(s) — add to proof-registry.mts:
    @proof: adr0104-field-file-collection (in packages/qa/dogfood/test/field-file-collection.dogfood.test.ts)
```

That is the registry's **reverse-integrity leg** doing exactly its job. An orphan `@proof:` tag means a proof was written but never wired into the ADR-0054 high-risk-class list — so nothing connects the test to the surface it guards, and the test's standing as a *proof* is asserted only by its own header comment.

## Registered honestly unbound, not bound

`bound: true` requires **both** a runtime proof and a governed ledger entry to carry it. This class has the first and not the second:

- the collection contract the proof exercises is the `lifecycle` ttl declared on the **system** object `sys_file` (`packages/services/service-storage/src/objects/system-file.object.ts`), not an authorable per-type property;
- `object.lifecycle` is already bound to `data-lifecycle` (`adr0057-lifecycle-bounded-growth`), and a ledger entry carries **one** `proof` ref;
- the rest of the route — exclusive ownership, release-on-write, the per-deployment migration gate — is service code with no authorable surface to govern.

So there is no other entry to bind instead. Faking a binding would misrepresent both what the proof covers and what that entry is proven by, so `blockedReason` records the reason — the same shape as `flow-runas-userless` and `scope-depth-cli-fallback`, which are blocked for the identical one-entry-one-ref reason.

## Enforcement is unchanged

`BOUND_PROOF_PATHS` skips unbound classes, so the bound-class list and the pinned path map in `proof-registry.test.ts` are byte-identical — no new CI obligation lands on any ledger entry. The only behavioural change is that the gate runs clean.

## Verification

- `pnpm check:liveness` — green, warning gone; the `prove-it-runs` bound-class line is unchanged (still the same 17 labels).
- Liveness script suite **98/98**, including the two registry invariants this entry has to satisfy (`unbound classes record an honest blockedReason`, `every class proofId is in KNOWN_PROOF_IDS`).
- Spec suite **277 files / 7128 tests**; `tsc --noEmit` clean.
- Gate-only change under `packages/spec/scripts/`, which is not in the package's published `files` — empty changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)