### PR TITLE
docs(adr): ADR-0104 的 meta 广告位条款按实际落地修订（#3438 后续）

### DIFF
--- a/.changeset/adr-0104-meta-advertisement-as-implemented.md
+++ b/.changeset/adr-0104-meta-advertisement-as-implemented.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(adr-0104): amend the upgrade-path advertisement clause to record how it landed (#4253/#4284) — `os migrate meta` names the migrations without gate status, because gate status is per deployment (2026-07-27 addendum) while `meta` acts on source, which deploys to zero-or-N of them; status is reported where a datastore is actually open. Releases nothing.

--- a/docs/adr/0104-field-runtime-value-shape-contract.md
+++ b/docs/adr/0104-field-runtime-value-shape-contract.md
@@ -830,7 +830,15 @@ os migrate value-shapes
   and a deployment booting ≥17 with covered fields and no
   `adr-0104-value-shapes` row logs one line at startup saying warn-mode is in
   effect and which command ends it. A gate nobody is told about is served by
-  nobody.
+  nobody. *(Amended as implemented, #4253/#4284: `meta` names the migrations
+  **without** gate status. The status half was a category error this ADR had
+  already corrected — per the 2026-07-27 addendum the gate is per
+  **deployment**, and `meta` acts on **source**, which deploys to zero-or-N of
+  them, so "its" status has no referent at meta time. Status is reported where
+  a datastore is actually open: each migration command reports before it
+  writes, and the boot line carries the live verdict — after #4284, only where
+  that line is true: counting only fields a write would check, silent when an
+  env switch already settled the posture.)*
 
 ### Fresh datastores attest at creation — both flags
 


### PR DESCRIPTION
## 修订 ADR-0104 L826–833：`os migrate meta`「with their gate status」那半句

2026-07-30 addendum 的 rollout 条款写着 `os migrate meta --from 16` 收尾时列出两个数据迁移「**with their gate status**」。#4253 落地时**有意**没做加粗那半，但理由只活在它的提交说明里——决策记录本身仍在向下一个实现者开错误的处方，而且已经骗过一次：#4284 的第一稿就是照这句做的，后来在 PR 里论证撤回。

### 为什么修订 ADR 而不是补代码

那半句是这份 ADR **自己在两个 addendum 之前刚纠正过的范畴错误**：2026-07-27（later）addendum 定了 evidence gate 是 per **deployment** 的事实（一条 `sys_migration` 行），而 `meta` 作用于**源码**——一份源码树对应零到 N 个部署，所以「its gate status」在 meta 时刻**没有所指**。main 上的 `meta.ts:95` 已经把这个区分打印成了字面：`Then, against each deployment's database:`（复数）。

补代码的变体（best-effort：数据库可达就显示）比不显示更糟：沉默变歧义（连不上库还是门已开？）、输出随环境摇摆破坏 e2e 确定性、只读命令多一条数据库不可达时挂死的路径。状态在数据库本来就打开的地方报告：两条迁移命令写任何东西之前先报，boot 行带活判定——#4284 之后只在成立时发声。

### 改法

按本 ADR 自己的修订惯例（L428 式带日期 inline 括注，原文保留）在 L833 之后加括注，把论证链写在现场（07-27 原则 → 无所指 → 状态归属何处），读者不必翻两个 PR 的提交说明。

空 changeset 按 `adr-0104-attestation-adr-note` 先例。Releases nothing。

### 验证

`check:doc-authoring`：215 files clean。改动为 1 个 ADR 文件 + 1 个空 changeset。

### 关联

#3438 收尾时留给「维护者定夺」的那一处；维护者已确认按此方向修订。本体实现见 #4253，缺陷修正见 #4284。

---
_Generated by [Claude Code](https://claude.ai/code/session_016zgA8CQMJeJbFEjnbib1Uv)_