### PR TITLE
docs(plugin-spec): the migration example no longer teaches the retired onUpgrade hook

### DIFF
--- a/.changeset/docs-plugin-spec-onupgrade-example.md
+++ b/.changeset/docs-plugin-spec-onupgrade-example.md
@@ -1,0 +1,5 @@
+---
+---
+
+docs: fix the plugin-spec CHANGELOG example that still taught the retired
+`onUpgrade` hook as running automatically (#4212 family). Releases nothing.

--- a/content/docs/protocol/kernel/plugin-spec.mdx
+++ b/content/docs/protocol/kernel/plugin-spec.mdx
@@ -859,8 +859,8 @@ Always include migration guide in CHANGELOG.md for major versions.
 - `account.owner` field (use `account.owner_id` instead)
 
 ### Migration
-The `onUpgrade` lifecycle hook runs automatically when the package is upgraded
-to v2.0.0 and renames the field on existing records.
+Upgrading to v2.0.0 applies the metadata migration that renames the field on
+existing records (ADR-0087). No plugin code runs at upgrade.
 ```
 
 ### 3. Pin Core Dependencies


### PR DESCRIPTION
## What

Two lines in `content/docs/protocol/kernel/plugin-spec.mdx`. The page carries a warn Callout stating the `onInstall`/`onEnable`/`onDisable`/`onUninstall`/`onUpgrade` family never existed and was retired (#4212) — and then, 600 lines further down, its CHANGELOG example told the reader:

> The `onUpgrade` lifecycle hook runs automatically when the package is upgraded to v2.0.0 and renames the field on existing records.

A reader who copies that example writes a hook that never runs — the exact failure mode #4212 set out to end. Replaced with the mechanism the same page already documents 320 lines above: upgrade applies metadata migrations (ADR-0087), and no plugin code runs at install/uninstall/upgrade.

## Why this is the whole diff

This closes out the docs-accuracy question raised by the drift-check advisory on #4242. The retired surfaces were swept against every hand-written doc first — the 17 never-fired event names from #4241 (`plugin:started`, `plugin:error`, `service:registered`, …), `ObjectQLHostContext`, `ITypedEventEmitter`, `PluginLifecycleEventType`, and `engine.use(` — and they appear in exactly one place: the v17 release notes that document them as removed. `kernel/events.mdx` lists only events in the surviving 14.

The `onEnable` mentions elsewhere were checked against code and are **correct** — the app-bundle `onEnable` is a live contract dispatched by `AppPlugin.start()` (`packages/runtime/src/app-plugin.ts:593`), and the `ctx.drivers.register(driver)` facade `data-modeling/external-datasources.mdx` documents is built there too (`app-plugin.ts:604`). No change needed in those docs.

## Verification

- `node scripts/check-doc-authoring.mjs` — 214 files clean.
- Prose-only change inside a fenced example; no code paths touched.

## Noted, not addressed here

`content/docs/kernel/cluster.mdx` describes a cluster coordinator that wraps `onEnable` and releases a lock on `onDisable`. `leader-elected` resolves only to `packages/spec/src/kernel/cluster.zod.ts` and its test — no runtime implementation found. That looks like a separate declared-but-unbuilt surface needing its own ADR-0049 enforce-or-remove pass, not a docs edit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrRNgrWaRtggzmrHpbomyh)_