### PR TITLE
fix(release): rename stale @objectstack/adapter-hono ref in pending changeset

### DIFF
--- a/.changeset/adapter-hono-auth-wildcard-yields.md
+++ b/.changeset/adapter-hono-auth-wildcard-yields.md
@@ -1,5 +1,5 @@
 ---
-"@objectstack/adapter-hono": patch
+"@objectstack/hono": patch
 ---
 
 fix(adapters/hono): the auth wildcard yields paths the auth service does not own (#4117)

--- a/.changeset/fix-stale-hono-changeset-ref.md
+++ b/.changeset/fix-stale-hono-changeset-ref.md
@@ -1,0 +1,4 @@
+---
+---
+
+Repo-plumbing only: the pending changeset `adapter-hono-auth-wildcard-yields` referenced the Hono adapter by its old `@objectstack/adapter-hono` name, which `changeset version` rejects because the workspace package is named `@objectstack/hono`. Renamed the entry; a full sweep of every other pending changeset (and `pre.json`) against the workspace found nothing else stale. Releases nothing by itself.


### PR DESCRIPTION
## Why

`changeset version` hard-fails on any changeset that names a package not present in the workspace, and one pending changeset still references the Hono adapter by its old scoped name:

```
🦋  error Error: Found changeset adapter-hono-auth-wildcard-yields
    for package @objectstack/adapter-hono which is not in the workspace
```

`.changeset/adapter-hono-auth-wildcard-yields.md` (the #4117 fix) says `@objectstack/adapter-hono`, while the workspace package at `packages/adapters/hono` is named **`@objectstack/hono`**. Same class of release blocker as #3635 (the scaffolder rename): `pnpm changeset status` and the version step of the v17 train die before the Version Packages PR can be created.

## What

- Renamed the frontmatter entry to `"@objectstack/hono": patch` — the bump intent is preserved (the #4117 fix lives in that package).
- Added an empty changeset (`fix-stale-hono-changeset-ref.md`) to satisfy the Check Changeset gate; it releases nothing, per the #3635 convention.

## Verification

- A sweep of all 559 pending `.changeset/*.md` frontmatters (974 package refs) plus `pre.json` `initialVersions` against the 77 workspace package names found exactly this one stale reference — nothing else.
- `pnpm changeset status` reproduced the exact error above with the old name, and exits cleanly after the rename.
- Full end-to-end run of the CI command `pnpm run version` (`changeset version` + protocol/template sync scripts) completes cleanly and computes **`17.0.0-rc.1`** across the fixed group, with the sync scripts reporting lockstep (`PROTOCOL_VERSION 17.0.0`, blank template `^17.0.0`, `engines.protocol '^17'`). Version artifacts were discarded after verification; only the changeset fix ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)