### PR TITLE
fix(dx): per-package lint scripts stop existing where they can only mislead (#4276)

### DIFF
--- a/.changeset/drop-per-package-lint-scripts.md
+++ b/.changeset/drop-per-package-lint-scripts.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(dx): remove the per-package `lint` scripts (`eslint src`) from `@objectstack/verify`, `@objectstack/cli` and `@objectstack/lint` (#4276). A standalone run resolves the root flat config but honors the inline directives the root gate's `--no-inline-config` exists to ignore, so it fails on rules the config never registers — verify was red on a clean HEAD. Lint only from the root; the scoped recipe is documented in `eslint.config.mjs`. Dev scripts only; releases nothing.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,13 @@ import tsParser from '@typescript-eslint/parser';
 // import guard), and the flag ignores them so the guard runs clean. The only
 // active rule (no-restricted-imports) should never need a local opt-out — it
 // prevents a ~1.2GB RSS regression.
+//
+// Lint ONLY from the root. Per-package `lint` scripts (`eslint src`) were
+// removed in #4276: a standalone run resolves this same config but honors the
+// inline directives `--no-inline-config` exists to ignore, so it fails on
+// rules this config never registers ("Definition for rule … was not found").
+// Don't add such a script back — scope a local run from the root instead:
+// `pnpm exec eslint --no-inline-config packages/verify/src`.
 
 const SUBPATH_NAMES = [
   'Data', 'UI', 'System', 'AI', 'API', 'Automation',

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,8 +11,7 @@
   "scripts": {
     "build": "if [ -n \"$OS_SKIP_DTS\" ]; then tsc -p tsconfig.build.json --noCheck --declaration false --declarationMap false; else tsc -p tsconfig.build.json; fi",
     "dev": "tsc -p tsconfig.build.json --watch",
-    "test": "vitest run",
-    "lint": "eslint src"
+    "test": "vitest run"
   },
   "keywords": [
     "objectstack",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -16,7 +16,6 @@
   "scripts": {
     "build": "tsup --config ../../tsup.config.ts",
     "dev": "tsc -w",
-    "lint": "eslint src",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/verify/package.json
+++ b/packages/verify/package.json
@@ -16,7 +16,6 @@
   "scripts": {
     "build": "tsup --config ../../tsup.config.ts",
     "dev": "tsc -w",
-    "lint": "eslint src",
     "test": "vitest run"
   },
   "dependencies": {


### PR DESCRIPTION
Closes #4276

## 问题

在干净 HEAD 上运行 `pnpm --filter @objectstack/verify lint`(包内 `eslint src`)报 7 个错,全部是 `Definition for rule '@typescript-eslint/no-explicit-any' was not found`(本 PR 分支上已复现确认)。

根因:从包目录起跑时 flat-config 向上查找**能**找到根 `eslint.config.mjs`,配置本身解析正常——但该配置只注册了 TS parser,从未注册 `@typescript-eslint` 插件。根门禁 `pnpm lint` = `eslint . --no-inline-config`,靠 `--no-inline-config` 忽略源码里遗留的 disable 注释;而包内脚本没带这个 flag,inline 注释被处理,引用的规则不存在,于是必红。

## 修法(采用 issue 里的第二个方案)

统一只从根跑 lint,删掉 per-package `lint` 脚本:

- **`packages/verify`**:删除 `lint` 脚本(7 个报错的直接来源)。
- **`packages/cli`、`packages/lint`**:按 issue 建议 grep 盘点,全仓只有这两个包还带同样的 `eslint src` 脚本。它们今天能过只是因为 src 里**还**没有 disable 注释——语义上同样偏离门禁(honor inline config vs 门禁的 `--no-inline-config`),加一条注释就红,一并删除。
- **`eslint.config.mjs`**:在原有 `--no-inline-config` 说明旁补注了本决定与 scoped 跑法(`pnpm exec eslint --no-inline-config packages/verify/src`),防止脚本被加回来。

没选第一个方案(包内脚本显式指向根配置)的原因:`--config` 解决不了问题——配置本来就找得到,缺的是 `--no-inline-config`;而在三个 package.json 里复制这个 flag 会与根脚本形成漂移,等于维护第二套 lint 方言。

## 验证

- `pnpm --filter @objectstack/verify lint` 干净 HEAD 复现 7 错;`cli`/`lint` 独立跑通过(印证"尚未失败但同类")。
- turbo.json 无 `lint` task,CI 无任何 job 调用 per-package lint,全仓 grep 无其他引用(`packages/lint/package.json` 里剩下的 `"lint"` 命中是 `keywords` 数组,非脚本)。
- 修改后:根门禁 `pnpm lint` 绿;scoped 跑法 `pnpm exec eslint --no-inline-config packages/verify/src` 绿。

纯 DX 修复,不涉及发布产物行为,无 changeset。

---
_Generated by [Claude Code](https://claude.ai/code/session_0195He4CTy2BvCVMDTJ6NkVY)_