### PR TITLE
test(runtime,objectql): the D12 honesty gate iterates the fake inventory, not spot checks (#3898)

### DIFF
--- a/.changeset/d12-fake-inventory-gate.md
+++ b/.changeset/d12-fake-inventory-gate.md
@@ -1,0 +1,7 @@
+---
+---
+
+test-only: the D12 honesty gate iterates the known-fake inventory — every
+`CORE_FALLBACK_FACTORIES` product registered slot-by-slot must come out of
+both discovery builders as `degraded`, never `available` (#3898 suggestion 4;
+`cache`/`queue`/`job` had no per-slot pin before). Releases nothing.

--- a/packages/objectql/src/protocol-discovery.test.ts
+++ b/packages/objectql/src/protocol-discovery.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ObjectStackProtocolImplementation } from '@objectstack/metadata-protocol';
-import { createMemoryMetadata } from '@objectstack/core';
+import { createMemoryMetadata, CORE_FALLBACK_FACTORIES } from '@objectstack/core';
 import { ObjectQL } from './engine.js';
 
 describe('ObjectStackProtocolImplementation - Dynamic Service Discovery', () => {
@@ -217,6 +217,31 @@ describe('ObjectStackProtocolImplementation - Dynamic Service Discovery', () => 
     expect(discovery.services.data.route).toBe('/api/v1/data');
     expect(discovery.services.data.provider).toBe('objectql');
     expect(discovery.services.data.message).toBeUndefined();
+  });
+
+  // ── The class-wide gate (#3898): the fake INVENTORY, not spot checks ──────
+  // Same gate as the dispatcher's: every in-memory fallback the kernel can
+  // auto-register (CORE_FALLBACK_FACTORIES — the complete fake inventory now
+  // that plugin-dev's stub table is retired, ADR-0115, and the `_fallback`
+  // marker was eliminated rather than recognized, #4058 step 1) goes through
+  // THIS builder too and must never come out `available`. Table-driven so a
+  // new fallback is gated the day it is added; cache/queue/job had no
+  // per-slot pin here either.
+  it('reports every CORE_FALLBACK_FACTORIES product as degraded, never available (#3898)', async () => {
+    expect(Object.keys(CORE_FALLBACK_FACTORIES).length).toBeGreaterThan(0);
+
+    for (const [slot, factory] of Object.entries(CORE_FALLBACK_FACTORIES)) {
+      const mockServices = new Map<string, any>();
+      mockServices.set(slot, factory());
+
+      protocol = new ObjectStackProtocolImplementation(engine, () => mockServices);
+      const reported = (await protocol.getDiscovery()).services[slot];
+
+      expect(reported, `services.${slot}`).toBeDefined();
+      expect(reported.enabled, `services.${slot}.enabled`).toBe(true);
+      expect(reported.status, `services.${slot}.status`).toBe('degraded');
+      expect(reported.message, `services.${slot}.message`).toBeTruthy();
+    }
   });
 
   // #3891 — the degraded ObjectQL fallback is retired. Analytics is an

--- a/packages/runtime/src/http-dispatcher.test.ts
+++ b/packages/runtime/src/http-dispatcher.test.ts
@@ -2653,6 +2653,38 @@ describe('HttpDispatcher', () => {
             expect(fromDispatcher.message).toBe(fromProtocol.message);
             expect(fromDispatcher.route).toBe(fromProtocol.route);
         });
+
+        // ── The class-wide gate (#3898): the fake INVENTORY, not spot checks ──
+        //
+        // Everything above pins one slot each. This iterates the actual list of
+        // in-memory fallbacks the kernel auto-registers — CORE_FALLBACK_FACTORIES
+        // is the complete fake inventory now that plugin-dev's stub table is
+        // retired (ADR-0115) and the third marker kind, `_fallback`, was
+        // eliminated rather than recognized (#4058 step 1) — and registers each
+        // product into its own slot: discovery must never call any of them
+        // `available`. Table-driven so the next fallback added to the table is
+        // gated the day it lands; this class of hole recurs with every new
+        // fallback. cache/queue/job had no per-slot pin before this — dropping
+        // their `svcAvailable(…, svc)` third argument, the exact #4130
+        // regression shape, was test-invisible.
+
+        it('reports every CORE_FALLBACK_FACTORIES product as degraded, never available (#3898)', async () => {
+            const { CORE_FALLBACK_FACTORIES } = await import('@objectstack/core');
+            expect(Object.keys(CORE_FALLBACK_FACTORIES).length).toBeGreaterThan(0);
+
+            for (const [slot, factory] of Object.entries(CORE_FALLBACK_FACTORIES)) {
+                const fallback = factory();
+                (kernel as any).getService = vi.fn().mockImplementation((n: string) => (n === slot ? fallback : null));
+                (kernel as any).services = new Map([[slot, fallback]]);
+
+                const info = await dispatcher.getDiscoveryInfo('/api/v1');
+                const reported = (info.services as Record<string, any>)[slot];
+                expect(reported, `services.${slot}`).toBeDefined();
+                expect(reported.enabled, `services.${slot}.enabled`).toBe(true);
+                expect(reported.status, `services.${slot}.status`).toBe('degraded');
+                expect(reported.message, `services.${slot}.message`).toBeTruthy();
+            }
+        });
     });
 
     // ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## 背景

#3898 盘点的三个洞,核对当前 main,已全部由已合并的 PR 修复:

| 洞 | 修复 | 路线 |
|:---|:---|:---|
| 洞 1 —— `_fallback` 标记不被 `readServiceSelfInfo` 识别 | #4082(#4058 step 1,即 issue #4089) | 走了与 #3898 建议 1 **相反且更优**的路线:不教 reader 认第三种标记,而是把五个内存兜底(`metadata`/`cache`/`queue`/`job`/`i18n`)全部改带标准 `__serviceInfo`,message 逐个点名缺什么,`_fallback` 从生产代码中消失。`app-plugin.ts` 的 i18n 诊断分支也改读 `readServiceSelfInfo` |
| 洞 2 —— `data` 槽位不传实例 | #4141(issue #4130) | `svcAvailable(routes.data, 'kernel', dataSvc)` 补上第三参,附跨 builder 一致性 pin |
| 洞 3 —— `metadata` 硬编码 degraded / `protocol.ts` 硬编码 available | #4114 | 两个 discovery builder 都改为读实现的 D12 自描述,方向相反的两个硬编码同时消灭 |

## 本 PR:补建议 4 的防复发门

现有测试是逐槽位 spot-check;`fallbacks.test.ts` 在**工厂层**遍历 `CORE_FALLBACK_FACTORIES`,但 **discovery 层** `cache`/`queue`/`job` 三个槽位没有任何 pin —— 把它们的 `svcAvailable(…, svc)` 第三参删掉(正是洞 2 的复发形态)不会有任何测试变红。

两个 discovery builder 的套件各加一条表驱动的门:遍历 `CORE_FALLBACK_FACTORIES`(plugin-dev stub 表按 ADR-0115 退役、`_fallback` 被消灭后,这就是完整的已知 fake 清单),逐一注册进各自槽位,断言 discovery 报 `degraded`、绝不 `available`。新增兜底进表当天即被门覆盖。

- `packages/runtime/src/http-dispatcher.test.ts` —— dispatcher builder(`getDiscoveryInfo`)
- `packages/objectql/src/protocol-discovery.test.ts` —— metadata-protocol builder(`getDiscovery`)

## 验证

- 负向验证门确实咬人:模拟删掉 `cache` 槽第三参 → `services.cache.status: expected 'available' to be 'degraded'`,还原后绿
- `@objectstack/runtime` 全套 955/955 通过;`@objectstack/objectql` 全套 1346/1346 通过
- 空 changeset(test-only,Releases nothing,循 #4283 惯例)

Closes #3898

🤖 Generated with [Claude Code](https://claude.com/claude-code)