### PR TITLE
fix(spec,runtime): 槽查找 any 规则补上类型实参形态并把作用域扩到全部 packages(#4251 第一批)

### DIFF
--- a/.changeset/retire-inert-driver-plugin-options.md
+++ b/.changeset/retire-inert-driver-plugin-options.md
@@ -1,0 +1,33 @@
+---
+"@objectstack/runtime": major
+"@objectstack/cli": patch
+---
+
+feat(runtime)!: retire the inert `DriverPluginOptions` — `DriverPlugin` takes `(driver, driverName?)` (#4320)
+
+`new DriverPlugin(driver, { datasourceName, registerAsDefault })` never did
+what it promised: both options configured a datasource-registration block in
+`start()` gated on `metadata.addDatasource`, a method **no metadata service
+implements** — so the block early-returned on every boot since inception and
+the options were dead weight (found while typing service lookups for #4251).
+
+**Migration** — delete the options argument; nothing changes at runtime
+because nothing ever happened:
+
+- FROM `new DriverPlugin(driver, { datasourceName: 'x', registerAsDefault: false })`
+  TO `new DriverPlugin(driver)`
+- FROM `new DriverPlugin(driver, 'name', options)` TO `new DriverPlugin(driver, 'name')`
+- The string second argument (`new DriverPlugin(driver, 'memory')`) is unchanged.
+
+If you passed `datasourceName` expecting routing to a named auxiliary driver:
+that routing never came from the option. It keys off the **driver name** —
+`DriverPlugin.init()` registers `driver.<name>`, ObjectQL's discovery loop
+adopts it, and the engine's lifecycle/datasource resolution looks the name up
+(see the telemetry provision in `os serve` for the pattern: stamp
+`driver.name`, register the plugin, done). For Setup → Datasources visibility,
+declare the datasource through `DatasourceConnectionService` /
+`registerInMemory('datasource', …)` (ADR-0062).
+
+The `DriverPluginOptions` interface was module-local (never exported from the
+package root), so the only public break is the constructor's second/third
+argument shape.

--- a/.changeset/slot-lookup-type-argument-ratchet.md
+++ b/.changeset/slot-lookup-type-argument-ratchet.md
@@ -1,0 +1,32 @@
+---
+"@objectstack/spec": patch
+"@objectstack/runtime": patch
+---
+
+fix(spec,runtime): the service-lookup `any` guard now sees the type-argument form, and its scope stops at nothing under `packages/` (#4251)
+
+The #4127/#4214 rule banned `: any` and `as any` on a service-lookup result but
+not `getService<any>('data')` — the form the codebase actually used (80 sites,
+zero matches), erasing the slot contract identically. And the rule's `files`
+covered only `packages/runtime`, leaving the composition roots (rest,
+plugins/*, services/*) that hold most lookups unlinted. Both gaps closed: a
+third AST selector catches the type-argument form, the scope is now all of
+`packages/`, and the 40 not-yet-swept files are grandfathered in a visible,
+shrinking ratchet list (`SLOT_LOOKUP_UNSWEPT`) — enumerated at 180 sites by
+running the widened rule with the list emptied. `http.server` joins
+`UNCONTRACTED_SLOTS` (three providers, no written contract).
+
+Typing the three in-scope runtime sites surfaced its first yield: both
+`addDatasource` datasource-registration branches (DefaultDatasourcePlugin,
+DriverPlugin) probed a method **no metadata service implements**, so they had
+never run on any boot — deleted rather than typed against a phantom shape. The
+inert `DriverPluginOptions` they configured are tracked in #4320.
+`registerInMemory('datasource', …)` is the actual visibility path (#3827).
+
+Contract members declared from evidence, both optional: `IDataEngine` gains
+`getDefaultDriverName?()` / `getDriverByName?()` (ObjectQL's driver registry —
+the surface `os migrate` and serve's storage detection reach through
+`driver.<name>` services), `IMetadataService` gains `registerInMemory?()`
+(MetadataManager's boot-time seeding primitive). Callers that supplied `<any>`
+to these lookups should pass the slot's contract type instead — or nothing:
+an unmapped slot deliberately resolves to `unknown`, not `any`.

--- a/content/docs/kernel/contracts/data-engine.mdx
+++ b/content/docs/kernel/contracts/data-engine.mdx
@@ -52,6 +52,10 @@ export interface IDataEngine {
 
   // Raw Command Escape Hatch (optional)
   execute?(command: any, options?: Record<string, any>): Promise<any>;
+
+  // Driver Registry (optional — engines that own named drivers)
+  getDefaultDriverName?(): string | undefined;
+  getDriverByName?(name: string): IDataDriver | undefined;
 }
 ```
 
@@ -364,6 +368,21 @@ const result = await engine.execute?.(
   { params: ['open'] }
 );
 ```
+
+### getDefaultDriverName / getDriverByName (Driver Registry)
+
+Look up the engine's registered drivers. Only engines that own a named-driver
+registry implement these (ObjectQL does; test fakes and remote/virtual engines
+need not) — always probe with `?.`:
+
+```typescript
+const driverName = engine.getDefaultDriverName?.();
+const driver = driverName ? engine.getDriverByName?.(driverName) : undefined;
+```
+
+This is the surface the runtime uses to re-register the default driver as a
+`driver.<name>` kernel service, which is where `os migrate` and serve's storage
+detection locate drivers.
 
 ---
 

--- a/content/docs/kernel/contracts/metadata-service.mdx
+++ b/content/docs/kernel/contracts/metadata-service.mdx
@@ -30,6 +30,7 @@ definition for a type.
 export interface IMetadataService {
   // Core CRUD (by type + name)
   register(type: string, name: string, data: unknown): Promise<void>;
+  registerInMemory?(type: string, name: string, data: unknown): void;
   get(type: string, name: string): Promise<unknown | undefined>;
   list(type: string): Promise<unknown[]>;
   unregister(type: string, name: string): Promise<void>;
@@ -165,6 +166,26 @@ await metadataService.unregister('object', 'project');
 <Callout type="tip">
 To inspect what would break before removing an item, call `getDependents('object', 'project')` — it returns the items that reference this one.
 </Callout>
+
+### registerInMemory
+
+Optional. Seeds an item into the in-memory registry **only** — never persisted
+to the DB store, never announced to `watch` subscribers. This is the boot-time
+path for source-control-owned artefacts that must be *listable* without
+creating DB drift — e.g. code-defined datasources (`origin: 'code'`), which is
+how the default datasource appears in Setup → Datasources:
+
+```typescript
+metadataService.registerInMemory?.('datasource', 'default', {
+  name: 'default',
+  label: 'Default',
+  driver: 'sqlite',
+  origin: 'code',
+});
+```
+
+Callers that mutate metadata mid-run want `register`, which persists and
+announces.
 
 ---
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,16 +59,82 @@ const SLOT_LOOKUPS = ['resolveService', 'getService', 'getRequestKernelService']
 // eslint-disable comments on purpose: exceptions belong in one reviewable
 // place, not sprinkled through the code. Deleting a name from this list is how
 // the exemption ends once that contract gets written.
-const UNCONTRACTED_SLOTS = ['protocol', 'mcp', 'kernel-resolver', 'scope-manager'].join('|');
+//
+// Entries are spliced into a regex, so escape metacharacters (`http\\.server`).
+// `http.server` is served by three providers (plugin-hono-server, runtime's
+// config.server path, qa's node-plugin) and no IHttpServer contract exists;
+// callers read only `getPort()`.
+const UNCONTRACTED_SLOTS = ['protocol', 'mcp', 'kernel-resolver', 'scope-manager', 'http\\.server'].join('|');
 
 const SLOT_LOOKUP_ANY_MESSAGE =
-  'Do not annotate a service-lookup result as `any` — the lookup already returns ' +
-  'the slot\'s contract (#4168/#4176/#4202), and this switches that checking off ' +
+  'Do not erase a service-lookup result to `any` (`: any`, `as any`, or a ' +
+  '`getService<any>(…)` type argument) — the lookup already returns the slot\'s ' +
+  'contract (#4168/#4176/#4202), and this switches that checking off ' +
   'for the call site while looking identical to code that has it. Every such ' +
   'annotation found so far was hiding a real gap, including a project-membership ' +
-  'gate that silently stopped gating. If the slot genuinely has no contract, add ' +
-  'its name to UNCONTRACTED_SLOTS in eslint.config.mjs with a note, so the ' +
-  'exemption is reviewed once and visible in one place — see issue #4127.';
+  'gate that silently stopped gating and two datasource-registration branches ' +
+  'probing a method no metadata service has (#4251). Pass the slot\'s contract ' +
+  'type instead (`getService<IDataEngine>(\'data\')`). If the slot genuinely has ' +
+  'no contract, add its name to UNCONTRACTED_SLOTS in eslint.config.mjs with a ' +
+  'note, so the exemption is reviewed once and visible in one place — see ' +
+  'issues #4127 and #4251.';
+
+// [#4251] The sweep ratchet. These files hold pre-existing lookup-erasure
+// sites — `getService<any>(…)`, `: any`, or `as any` — that predate the rule
+// reaching them: the rule's scope was packages/runtime only until #4251
+// widened it, and the type-argument selector did not exist. Enumerated by
+// running this config with this list emptied: 180 sites in 44 files (the
+// issue's 80 was the non-test `<any>` form alone; the annotation forms and
+// test files the old selectors would have caught under a wider scope roughly
+// double it). They are grandfathered BY FILE, here, for the same reason
+// UNCONTRACTED_SLOTS is central: `--no-inline-config` means the escape must
+// live in config, and a shrinking list in one place is the ratchet made
+// visible. Batches remove entries as they sweep (see #4214 for the batch
+// pattern and its yield — these sites are where the erased contracts live).
+// NEVER add an entry: a new file starts covered, and a new violation in a
+// listed file rides an existing entry only until its batch.
+const SLOT_LOOKUP_UNSWEPT = [
+  'packages/cli/src/commands/migrate/files-to-references.ts',
+  'packages/cli/src/commands/migrate/value-shapes.ts',
+  'packages/cli/src/commands/serve.ts',
+  'packages/client/src/client.hono.test.ts',
+  'packages/cloud-connection/src/cloud-connection-plugin.ts',
+  'packages/cloud-connection/src/marketplace-install-local-plugin.ts',
+  'packages/core/examples/kernel-features-example.ts',
+  'packages/metadata-protocol/src/plugin.ts',
+  'packages/metadata/src/plugin.ts',
+  'packages/objectql/src/plugin.integration.test.ts',
+  'packages/objectql/src/plugin.ts',
+  'packages/plugins/plugin-approvals/src/approvals-plugin.ts',
+  'packages/plugins/plugin-approvals/src/status-mirror-cascade.integration.test.ts',
+  'packages/plugins/plugin-audit/src/audit-plugin.ts',
+  'packages/plugins/plugin-auth/src/auth-plugin.ts',
+  'packages/plugins/plugin-email/src/email-plugin.ts',
+  'packages/plugins/plugin-hono-server/src/current-user-endpoints.ts',
+  'packages/plugins/plugin-pinyin-search/src/pinyin-search-plugin.ts',
+  'packages/plugins/plugin-reports/src/reports-plugin.ts',
+  'packages/plugins/plugin-security/src/security-plugin.ts',
+  'packages/plugins/plugin-sharing/src/sharing-plugin.ts',
+  'packages/plugins/plugin-webhooks/src/webhook-outbox-plugin.ts',
+  'packages/qa/dogfood/test/showcase-agent-intersection.dogfood.test.ts',
+  'packages/qa/dogfood/test/showcase-bu-hierarchy-sharing.dogfood.test.ts',
+  'packages/qa/dogfood/test/showcase-d3-d4-capabilities.dogfood.test.ts',
+  'packages/qa/dogfood/test/showcase-permission-zoo.dogfood.test.ts',
+  'packages/rest/src/external-datasource-routes.ts',
+  'packages/rest/src/rest-api-plugin.ts',
+  'packages/services/service-datasource/src/admin-routes.ts',
+  'packages/services/service-job/src/job-service-plugin.ts',
+  'packages/services/service-messaging/src/messaging-service-plugin.test.ts',
+  'packages/services/service-messaging/src/messaging-service-plugin.ts',
+  'packages/services/service-queue/src/queue-service-plugin.ts',
+  'packages/services/service-realtime/src/realtime-service-plugin.ts',
+  'packages/services/service-settings/src/settings-service-plugin.ts',
+  'packages/services/service-sms/src/sms-plugin.ts',
+  'packages/services/service-storage/src/storage-service-plugin.ts',
+  'packages/triggers/trigger-record-change/src/formula-context.test.ts',
+  'packages/triggers/trigger-record-change/src/multilookup-context.test.ts',
+  'packages/triggers/trigger-record-change/src/record-change-integration.test.ts',
+];
 
 export default [
   {
@@ -193,6 +259,13 @@ export default [
   // having — a deliberate gap is a reviewed line in this file, a careless one
   // is a build failure, and the two stop looking identical in the code.
   //
+  // [#4251] Scope is all of packages/ — the rule shipped scoped to
+  // packages/runtime while the composition roots (rest, plugins/*, services/*)
+  // held 77 of the 80 known sites, an unlinted majority that looked covered.
+  // Per-package curation would recreate that gap one package at a time, so the
+  // scope is total and the not-yet-swept files are grandfathered individually
+  // in SLOT_LOOKUP_UNSWEPT above — a shrinking list, not a silent boundary.
+  //
   // KNOWN RESIDUAL: a wrapper whose own return type is annotated
   // (`const getEngine = async (): Promise<any> => …resolveService(…)`) erases
   // the slot type just as effectively, and this selector cannot see it — the
@@ -200,8 +273,8 @@ export default [
   // existed (share-links `getEngine`, fixed in batch 4). Catching that shape
   // needs type information, so it belongs to a typed-lint pass, not here.
   {
-    files: ['packages/runtime/**/*.{ts,mts,cts}'],
-    ignores: ['**/node_modules/**', '**/dist/**'],
+    files: ['packages/**/*.{ts,tsx,mts,cts}'],
+    ignores: ['**/node_modules/**', '**/dist/**', ...SLOT_LOOKUP_UNSWEPT],
     languageOptions: {
       parser: tsParser,
       parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
@@ -222,6 +295,17 @@ export default [
             'TSAsExpression[typeAnnotation.type="TSAnyKeyword"]' +
             `:has(CallExpression[callee.property.name=/^(${SLOT_LOOKUPS})$/]` +
             `:not(:has(Literal[value=/^(${UNCONTRACTED_SLOTS})$/])))`,
+          message: SLOT_LOOKUP_ANY_MESSAGE,
+        },
+        {
+          // `ctx.getService<any>('data')` — the type-argument form (#4251).
+          // No annotation, no `as`, and the contract is erased all the same;
+          // this is the shape 80 sites actually used while the two selectors
+          // above matched zero of them.
+          selector:
+            `CallExpression[callee.property.name=/^(${SLOT_LOOKUPS})$/]` +
+            '[typeArguments.params.0.type="TSAnyKeyword"]' +
+            `:not(:has(Literal[value=/^(${UNCONTRACTED_SLOTS})$/]))`,
           message: SLOT_LOOKUP_ANY_MESSAGE,
         },
       ],

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1003,9 +1003,15 @@ export default class Serve extends Command {
                    });
                    if (telemetry.engine !== 'memory') {
                      // The engine keys datasources by driver name — the
-                     // lifecycle router looks this exact name up.
+                     // lifecycle router looks this exact name up. The driver
+                     // name is the WHOLE wiring: DriverPlugin.init registers
+                     // `driver.telemetry`, ObjectQL's discovery loop adopts
+                     // it, and lifecycle-classed objects route to it. (An
+                     // options bag once also asked for `datasourceName:
+                     // 'telemetry'` metadata registration — inert since
+                     // inception, retired in #4320.)
                      Object.defineProperty(telemetry.driver, 'name', { value: 'telemetry' });
-                     await kernel.use(new DriverPlugin(telemetry.driver, { datasourceName: 'telemetry', registerAsDefault: false }));
+                     await kernel.use(new DriverPlugin(telemetry.driver));
                      trackPlugin('TelemetryDatasource');
                      console.log(chalk.dim(`  telemetry datasource: ${telemetryPath} (lifecycle-classed system data; OS_TELEMETRY_DB=0 to disable)`));
                    }

--- a/packages/runtime/src/default-datasource-plugin.test.ts
+++ b/packages/runtime/src/default-datasource-plugin.test.ts
@@ -7,6 +7,7 @@
 // the real kernel (init-all → start-all) with the real driver factory.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { IDataEngine } from '@objectstack/spec/contracts';
 import { Runtime } from './runtime.js';
 import { DefaultDatasourcePlugin } from './default-datasource-plugin.js';
 import { AppPlugin } from './app-plugin.js';
@@ -64,10 +65,10 @@ describe('DefaultDatasourcePlugin — the default datasource as a declaration (#
     });
     try {
       await kernel.bootstrap();
-      const engine = kernel.getService<any>('data');
+      const engine = kernel.getService<IDataEngine>('data');
       // The driver keeps its NATURAL name (no 'default' stamping) — routing to
       // `default` goes through the engine's default-driver fallback.
-      expect(engine.getDriverByName('default')).toBeUndefined();
+      expect(engine.getDriverByName?.('default')).toBeUndefined();
       await engine.insert('note', { title: 'through-the-default' });
       const rows = await engine.find('note');
       expect(rows.map((r: any) => r.title)).toContain('through-the-default');
@@ -93,7 +94,7 @@ describe('DefaultDatasourcePlugin — the default datasource as a declaration (#
     const kernel = await assemble({ withAdminPlugin: false });
     try {
       await kernel.bootstrap();
-      const engine = kernel.getService<any>('data');
+      const engine = kernel.getService<IDataEngine>('data');
       await engine.insert('sys_metadata', undefined as never).catch(() => { /* shape probe only */ });
       // The default driver exists and the engine can answer a trivial query path.
       expect(typeof engine.find).toBe('function');
@@ -133,8 +134,8 @@ describe('DefaultDatasourcePlugin — the default datasource as a declaration (#
     });
     try {
       await expect(kernel.bootstrap()).resolves.not.toThrow();
-      const engine = kernel.getService<any>('data');
-      expect(engine.getDefaultDriverName()).toBeDefined();
+      const engine = kernel.getService<IDataEngine>('data');
+      expect(engine.getDefaultDriverName?.()).toBeDefined();
     } finally {
       try { await (kernel as any)?.stop?.(); } catch { /* noop */ }
     }
@@ -158,11 +159,11 @@ describe('DefaultDatasourcePlugin — the default datasource as a declaration (#
     });
     try {
       await kernel.bootstrap();
-      const engine = kernel.getService<any>('data');
-      const defaultName = engine.getDefaultDriverName();
+      const engine = kernel.getService<IDataEngine>('data');
+      const defaultName = engine.getDefaultDriverName?.();
       expect(defaultName).toBeDefined();
       // Identity, not equivalence: the engine's default driver IS the host's instance.
-      expect(engine.getDriverByName(defaultName)).toBe(hostBuilt);
+      expect(engine.getDriverByName?.(defaultName!)).toBe(hostBuilt);
       await engine.insert('note', { title: 'through-the-adopted-default' });
       const rows = await engine.find('note');
       expect(rows.map((r: any) => r.title)).toContain('through-the-adopted-default');
@@ -197,8 +198,10 @@ describe('DefaultDatasourcePlugin — the default datasource as a declaration (#
   it('kernel teardown disconnects an OWNED (factory-built) default through the one service (#3993)', async () => {
     const kernel = await assemble({});
     await kernel.bootstrap();
-    const engine = kernel.getService<any>('data');
-    const drv = engine.getDriverByName(engine.getDefaultDriverName());
+    const engine = kernel.getService<IDataEngine>('data');
+    // The real engine carries the driver registry; `!` asserts exactly that,
+    // and a missing surface fails the test rather than sliding past it.
+    const drv = engine.getDriverByName!(engine.getDefaultDriverName!()!)!;
     let disconnects = 0;
     const orig = drv.disconnect?.bind(drv);
     drv.disconnect = async () => { disconnects += 1; return orig?.(); };

--- a/packages/runtime/src/default-datasource-plugin.ts
+++ b/packages/runtime/src/default-datasource-plugin.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 import type { Plugin, PluginContext } from '@objectstack/core';
+import type { IDataEngine, IMetadataService } from '@objectstack/spec/contracts';
 import {
   DatasourceConnectionService,
   createDefaultDatasourceDriverFactory,
@@ -160,7 +161,7 @@ export class DefaultDatasourcePlugin implements Plugin {
     // call registerDriver again — the engine's skip-if-present guard makes
     // that a no-op for the same driver name.
     try {
-      const engine = ctx.getService<any>('data');
+      const engine = ctx.getService<IDataEngine>('data');
       const driverName = engine?.getDefaultDriverName?.();
       const driver = driverName ? engine?.getDriverByName?.(driverName) : undefined;
       if (driver) {
@@ -216,17 +217,20 @@ export class DefaultDatasourcePlugin implements Plugin {
   };
 
   /**
-   * Two registries, two consumers:
-   *  - `registerInMemory('datasource', …)` feeds the datasource-admin list
-   *    (`metadata.list('datasource')`), so Setup → Datasources shows the
-   *    primary DB — and, via the retained connect verdict, its REAL status
-   *    (#3827). Stamped `origin:'code'` → read-only in the admin UI.
-   *  - `addDatasource(…)` keeps parity with what DriverPlugin.start() used to
-   *    register for legacy `getDatasources()` consumers.
+   * `registerInMemory('datasource', …)` feeds the datasource-admin list
+   * (`metadata.list('datasource')`), so Setup → Datasources shows the
+   * primary DB — and, via the retained connect verdict, its REAL status
+   * (#3827). Stamped `origin:'code'` → read-only in the admin UI.
+   *
+   * A second branch used to probe `metadata.addDatasource(…)` "for legacy
+   * `getDatasources()` consumers" — typing this lookup (#4251) showed no
+   * metadata service implements either method, in this repo or its history's
+   * reach, so the probe never fired and the branch advertised parity it never
+   * delivered. registerInMemory IS the datasource-visibility path.
    */
   private async registerVisibility(ctx: PluginContext): Promise<void> {
     try {
-      const metadata = ctx.getService<any>('metadata');
+      const metadata = ctx.getService<IMetadataService>('metadata');
       if (typeof metadata?.registerInMemory === 'function') {
         metadata.registerInMemory('datasource', 'default', {
           name: 'default',
@@ -234,13 +238,6 @@ export class DefaultDatasourcePlugin implements Plugin {
           driver: this.def.driver,
           origin: 'code',
         });
-      }
-      if (typeof metadata?.addDatasource === 'function') {
-        const existing = typeof metadata.getDatasources === 'function' ? metadata.getDatasources() : [];
-        const hasDefault = Array.isArray(existing) && existing.some((ds: any) => ds?.name === 'default');
-        if (!hasDefault) {
-          await metadata.addDatasource({ name: 'default', driver: this.def.driver });
-        }
       }
     } catch (e) {
       ctx.logger.debug('[DefaultDatasourcePlugin] metadata service unavailable — default not listed', { error: e });

--- a/packages/runtime/src/driver-plugin.ts
+++ b/packages/runtime/src/driver-plugin.ts
@@ -16,6 +16,15 @@ import { Plugin, PluginContext } from '@objectstack/core';
  * const driverPlugin = new DriverPlugin(memoryDriver, 'memory');
  * kernel.use(driverPlugin);
  */
+/**
+ * ⚠️ Both options are INERT. They configured start()'s datasource
+ * registration, which probed `metadata.addDatasource` — a method no metadata
+ * service implements — so the guarded block never ran on any boot and was
+ * removed when typing the lookup surfaced it (#4251). The one live caller
+ * that passes them (`serve.ts`, `datasourceName: 'telemetry'`) has never
+ * gotten the registration it asks for. Kept only for source compatibility;
+ * revive-or-remove is tracked in #4320.
+ */
 export interface DriverPluginOptions {
     /**
      * If set, registers a named datasource so packages declaring
@@ -36,12 +45,13 @@ export class DriverPlugin implements Plugin {
     version = '1.0.0';
 
     private driver: any;
-    private options: DriverPluginOptions;
 
-    constructor(driver: any, driverNameOrOptions?: string | DriverPluginOptions, options?: DriverPluginOptions) {
+    // Options are accepted (source compatibility for existing callers) but no
+    // longer stored — nothing reads them since the dead datasource block left
+    // start(); see the DriverPluginOptions doc.
+    constructor(driver: any, driverNameOrOptions?: string | DriverPluginOptions, _options?: DriverPluginOptions) {
         this.driver = driver;
         const driverName = typeof driverNameOrOptions === 'string' ? driverNameOrOptions : undefined;
-        this.options = (typeof driverNameOrOptions === 'object' ? driverNameOrOptions : options) ?? {};
         this.name = `com.objectstack.driver.${driverName || driver.name || 'unknown'}`;
     }
 
@@ -55,33 +65,15 @@ export class DriverPlugin implements Plugin {
         });
     }
 
+    // start() used to hold a named/default datasource registration block,
+    // gated on `metadata.addDatasource` — a method no metadata service
+    // implements, here or anywhere in the repo — so the guard's early return
+    // made every line behind it (and the options above) unreachable on every
+    // boot. Typing the lookup (#4251) surfaced that; the dead block is gone
+    // rather than typed against a phantom shape. Datasource declaration and
+    // visibility live in ADR-0062's DatasourceConnectionService +
+    // `registerInMemory('datasource', …)` path — see DefaultDatasourcePlugin.
     start = async (ctx: PluginContext) => {
-        try {
-            const metadata = ctx.getService<any>('metadata');
-            if (!metadata?.addDatasource) return;
-
-            // Register a named datasource for this driver (e.g. 'cloud').
-            if (this.options.datasourceName) {
-                await metadata.addDatasource({
-                    name: this.options.datasourceName,
-                    driver: this.driver.name,
-                });
-                ctx.logger.info(`[DriverPlugin] Registered named datasource '${this.options.datasourceName}'`, { driver: this.driver.name });
-            }
-
-            // Auto-register as 'default' datasource unless explicitly disabled.
-            if (this.options.registerAsDefault !== false) {
-                const datasources = metadata.getDatasources ? metadata.getDatasources() : [];
-                const hasDefault = datasources.some((ds: any) => ds.name === 'default');
-                if (!hasDefault) {
-                    ctx.logger.info(`[DriverPlugin] No 'default' datasource found — registering '${this.driver.name}' as default.`);
-                    await metadata.addDatasource({ name: 'default', driver: this.driver.name });
-                }
-            }
-        } catch (e) {
-            ctx.logger.debug('[DriverPlugin] Failed to configure datasource (metadata service missing?)', { error: e });
-        }
-
         ctx.logger.debug('Driver plugin started', { driverName: this.driver.name || 'unknown' });
     }
 }

--- a/packages/runtime/src/driver-plugin.ts
+++ b/packages/runtime/src/driver-plugin.ts
@@ -16,29 +16,6 @@ import { Plugin, PluginContext } from '@objectstack/core';
  * const driverPlugin = new DriverPlugin(memoryDriver, 'memory');
  * kernel.use(driverPlugin);
  */
-/**
- * ⚠️ Both options are INERT. They configured start()'s datasource
- * registration, which probed `metadata.addDatasource` — a method no metadata
- * service implements — so the guarded block never ran on any boot and was
- * removed when typing the lookup surfaced it (#4251). The one live caller
- * that passes them (`serve.ts`, `datasourceName: 'telemetry'`) has never
- * gotten the registration it asks for. Kept only for source compatibility;
- * revive-or-remove is tracked in #4320.
- */
-export interface DriverPluginOptions {
-    /**
-     * If set, registers a named datasource so packages declaring
-     * `defaultDatasource: '<name>'` resolve to this driver.
-     */
-    datasourceName?: string;
-    /**
-     * If `true` (default), registers this driver as the `default` datasource
-     * when none exists. Set to `false` for proxy drivers (e.g. cloud proxy)
-     * that should never become the default.
-     */
-    registerAsDefault?: boolean;
-}
-
 export class DriverPlugin implements Plugin {
     name: string;
     type = 'driver';
@@ -46,12 +23,17 @@ export class DriverPlugin implements Plugin {
 
     private driver: any;
 
-    // Options are accepted (source compatibility for existing callers) but no
-    // longer stored — nothing reads them since the dead datasource block left
-    // start(); see the DriverPluginOptions doc.
-    constructor(driver: any, driverNameOrOptions?: string | DriverPluginOptions, _options?: DriverPluginOptions) {
+    // A `DriverPluginOptions` bag (`datasourceName` / `registerAsDefault`)
+    // used to be accepted here. Both options configured start()'s datasource
+    // registration, which probed `metadata.addDatasource` — a method no
+    // metadata service implements — so they were inert on every boot since
+    // inception; retired via #4320 (found by #4251). Routing to a named
+    // auxiliary driver needs only the DRIVER name: init() registers
+    // `driver.<name>`, ObjectQL's discovery loop adopts it, and the engine's
+    // lifecycle/datasource resolution keys off that name (see serve.ts's
+    // telemetry provision for the pattern).
+    constructor(driver: any, driverName?: string) {
         this.driver = driver;
-        const driverName = typeof driverNameOrOptions === 'string' ? driverNameOrOptions : undefined;
         this.name = `com.objectstack.driver.${driverName || driver.name || 'unknown'}`;
     }
 
@@ -68,10 +50,11 @@ export class DriverPlugin implements Plugin {
     // start() used to hold a named/default datasource registration block,
     // gated on `metadata.addDatasource` — a method no metadata service
     // implements, here or anywhere in the repo — so the guard's early return
-    // made every line behind it (and the options above) unreachable on every
-    // boot. Typing the lookup (#4251) surfaced that; the dead block is gone
-    // rather than typed against a phantom shape. Datasource declaration and
-    // visibility live in ADR-0062's DatasourceConnectionService +
+    // made every line behind it (and the options that configured it)
+    // unreachable on every boot. Typing the lookup (#4251) surfaced that; the
+    // dead block is gone rather than typed against a phantom shape, and the
+    // options followed it (#4320). Datasource declaration and visibility live
+    // in ADR-0062's DatasourceConnectionService +
     // `registerInMemory('datasource', …)` path — see DefaultDatasourcePlugin.
     start = async (ctx: PluginContext) => {
         ctx.logger.debug('Driver plugin started', { driverName: this.driver.name || 'unknown' });

--- a/packages/runtime/src/notifications.hono.integration.test.ts
+++ b/packages/runtime/src/notifications.hono.integration.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { IDataEngine } from '@objectstack/spec/contracts';
 import { ObjectKernel, Plugin, PluginContext } from '@objectstack/core';
 import { HonoServerPlugin } from '@objectstack/plugin-hono-server';
 import { ObjectQLPlugin } from '@objectstack/objectql';
@@ -164,7 +165,7 @@ describe('in-app notifications over a real hono server (integration, #3362)', ()
 
     // The receipts were actually persisted as `read` (not merely a view-layer
     // computation) — the server-side state the console poll re-reads.
-    const data = kernel.getService<any>('data');
+    const data = kernel.getService<IDataEngine>('data');
     const receipts = await data.find('sys_notification_receipt', {
       where: { user_id: TEST_USER, channel: 'inbox' },
     });

--- a/packages/spec/src/contracts/data-engine.ts
+++ b/packages/spec/src/contracts/data-engine.ts
@@ -10,6 +10,7 @@ import {
   DataEngineRequest,
   DroppedFieldsEvent,
 } from '../data/index.js';
+import type { IDataDriver } from './data-driver.js';
 
 /**
  * In-process write-observability hooks for `insert`/`update` (#3407).
@@ -71,4 +72,19 @@ export interface IDataEngine {
    * Execute raw command (Escape hatch)
    */
   execute?(command: any, options?: Record<string, any>): Promise<any>;
+
+  /**
+   * Driver registry — optional: only engines that own a named-driver registry.
+   *
+   * [#4251] Declared because the binding is evidenced, not to fill the table:
+   * ObjectQL implements both (`packages/objectql/src/engine.ts`, the `drivers`
+   * map), and DefaultDatasourcePlugin reads them to re-register the default
+   * driver as a `driver.<name>` kernel service — the surface `os migrate`
+   * (SQL_DRIVER_SERVICES) and serve's storage detection locate drivers
+   * through. Optional because `IDataEngine` is also satisfied by engines with
+   * no such registry (test fakes, remote/virtual engines); callers probe with
+   * `?.`, which is what the runtime caller already did while typed `any`.
+   */
+  getDefaultDriverName?(): string | undefined;
+  getDriverByName?(name: string): IDataDriver | undefined;
 }

--- a/packages/spec/src/contracts/metadata-service.ts
+++ b/packages/spec/src/contracts/metadata-service.ts
@@ -167,6 +167,25 @@ export interface IMetadataService {
     register(type: string, name: string, data: unknown, options?: MetadataWriteOptions): Promise<void>;
 
     /**
+     * Register a metadata item in memory only — never persisted, never
+     * announced to `subscribe(type, …)` watchers.
+     *
+     * [#4251] Declared from the evidenced binding: `MetadataManager`
+     * implements it (`packages/metadata/src/metadata-manager.ts`) as the
+     * boot-time seeding primitive for source-control-owned artefacts that must
+     * be *listable* without leaking into the runtime DB store (`origin:'code'`
+     * datasources, ADR-0015 Addendum), and DefaultDatasourcePlugin calls it to
+     * surface the primary DB in Setup → Datasources (#3827). Optional: the
+     * in-memory registry is `MetadataManager`'s split, not something every
+     * occupant of the `metadata` slot must carry.
+     *
+     * @param type - Metadata type (e.g. 'datasource')
+     * @param name - Item name/identifier (snake_case)
+     * @param data - The metadata definition to register
+     */
+    registerInMemory?(type: string, name: string, data: unknown): void;
+
+    /**
      * Get a metadata item by type and name
      * @param type - Metadata type
      * @param name - Item name/identifier


### PR DESCRIPTION
Refs #4251(#4127 工作线,承接 #4214 的批次模式)。Closes #4320。本 PR 是新清扫线的**第一批**:规则补全 + 棘轮落地 + 规则现有作用域内的站点全部清零,以及对首个产出(#4320)的收尾。

## 1. 两个缺口,如 issue 所述

**选择器缺口。** 原有两个选择器只匹配变量注解(`: any`)和 `as any`,而代码库实际使用的形态是**类型实参**——`ctx.getService<any>('data')`——80 个非测试站点,零匹配。新增第三个选择器(`typeArguments.params.0.type="TSAnyKeyword"`),纯 AST,无需类型信息,`UNCONTRACTED_SLOTS` 豁免机制原样沿用。

**作用域缺口。** `files` 原来止步于 `packages/runtime`。现扩到 **`packages/**`** —— 不是 issue 建议的"按包点名",理由写进了配置注释:按包圈定会把这次的缺口按包再造一遍;全量作用域 + 逐文件祖父名单,新包生来就在规则之下。

## 2. 棘轮(可见的)

以清空名单跑一遍扩域后的规则做的全量枚举:**180 个站点、44 个文件**(issue 的 80 只数了非测试的 `<any>` 形态;注解形态和测试文件让它翻倍)。其中 4 个 runtime 文件本批清零,**40 个文件进 `SLOT_LOOKUP_UNSWEPT`** ——集中一处、只减不增、每批删几行的那种名单(`--no-inline-config` 下逃生口本来就只能住在 config 里)。`http\.server` 进 `UNCONTRACTED_SLOTS`:三个 provider,无书面契约,调用方只读 `getPort()`。

## 3. ⚠️ 本批的产出:两条从未执行过的数据源注册分支 → #4320 一并收尾

给 runtime 的三个站点补类型时发现:`DefaultDatasourcePlugin` 的 parity 分支和 `DriverPlugin.start()` 的整个函数体都探测 `metadata.addDatasource` ——**整个仓库没有任何 metadata 服务实现过这个方法**(`getDatasources` 同理,唯二引用就是这两个探测点自身)。守卫恒假/恒提前返回,每一次启动都没跑过;`DriverPlugin.start()` 的提前返回甚至连它自己收尾的 debug 日志都一并跳过。

处理:**删除死代码**,而不是给幻影方法编一个本地类型(那是 #4127 编目过的"第二份没人校验的契约")。`registerInMemory('datasource', …)` 才是现行可见性路径(#3827),它就活在被删分支的上方两行。

**#4320 的 enforce-or-remove 取证与裁决(第三个 commit)**:issue 问"遥测是否需要真正的具名数据源可见性"。取证答案:**具名辅助驱动的路由从来不经过那个选项** ——引擎按 **driver 名**路由(`DriverPlugin.init()` 注册 `driver.<name>` → ObjectQL 发现循环收编 → `engine.ts` 的 `LIFECYCLE_DATASOURCE = 'telemetry'` 在 `this.drivers` 里查这个名字),这正是选项一直无效而 serve 的遥测分库一直**工作正常**的原因。故走 **remove**:

- `DriverPluginOptions` 删除(模块内类型,从未从包根导出),构造函数收窄为 `(driver, driverName?)`;
- `serve.ts` 去掉选项实参,遥测接线注释改为明说 driver-name 机制;
- `@objectstack/runtime` major changeset 携带 FROM → TO 迁移说明;行为零变化(被配置的代码从未运行过)。

这正是 issue 预告的"产出不只是外观":`<any>` 一天在,编译器一天看不见这两条死分支。

## 4. 按证据补的契约成员(全部 optional)

| 契约 | 新增 | 证据 |
|---|---|---|
| `IDataEngine` | `getDefaultDriverName?` / `getDriverByName?` | ObjectQL 实现(engine.ts 的 drivers 注册表);DefaultDatasourcePlugin 经它们把默认 driver 重注册为 `driver.<name>` 服务,`os migrate`(SQL_DRIVER_SERVICES)和 serve 的存储探测都从那里定位 driver |
| `IMetadataService` | `registerInMemory?` | `MetadataManager` 实现(metadata-manager.ts:379),启动期种子原语,GitOps 工件可列出但不落 DB(ADR-0015 Addendum、#3827) |

Optional 的理由:`IDataEngine` 还有测试假引擎和远端/虚拟引擎这类不带 driver 注册表的占用者;runtime 调用点本来就用 `?.` 探测,补类型后一行未改。测试站点(真实 ObjectQL 引擎)用 `?.` / `!` 显式断言该表面存在——缺了就 fail,而不是滑过去。两篇契约参考文档(`data-engine.mdx` / `metadata-service.mdx`,docs drift check 点名)已同步。

## 5. runtime 作用域内清零明细

- 3 个 src 站点(issue 点名的那三个)→ 传契约类型;
- 6 个 test 站点的 `data` 查找 → `IDataEngine`;
- 5 个 test 站点的 `http.server` 查找 → 槽豁免,零代码改动。

## 验证

| 项 | 结果 |
|---|---|
| `pnpm lint`(`--no-inline-config`) | clean |
| `@objectstack/spec` check:generated | 8/8 up to date |
| 全量 turbo build | 71 包全绿 |
| spec / objectql / runtime / metadata / plugin-webhooks / cli | 7137/277 · 1345/85 · 954/67 · 281/13 · 25/3 · 628/64 全绿 |
| changeset | `slot-lookup-type-argument-ratchet.md`(spec、runtime patch);`retire-inert-driver-plugin-options.md`(runtime **major**、cli patch,含迁移说明) |

后续批次:按 `SLOT_LOOKUP_UNSWEPT` 逐文件清扫(rest-api-plugin 14 处、auth-plugin 20 处是大头),每批删名单若干行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWW5xEALZNU5VBXfGyWPGz