### PR TITLE
ci(temporal-conformance): 两个 skewed-zone 测试步骤挂上 run-with-stall-guard (#4331)

### DIFF
--- a/.changeset/temporal-conformance-stall-guard.md
+++ b/.changeset/temporal-conformance-stall-guard.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: wrap the Temporal Conformance job's two skewed-zone test steps in run-with-stall-guard (#4331). CI-only — releases nothing.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,6 +312,19 @@ jobs:
       # The whole driver-sql suite runs under the skewed process zone — not
       # just the live-server files — so a TZ-sensitive assumption anywhere in
       # the driver's tests fails here before it can ship.
+      #
+      # run-with-stall-guard: same wiring as Test Core (see the comment there;
+      # #4250). Both of this job's test legs have hit the same nondeterministic
+      # stall (#4331) — once frozen mid-file in core's kernel.test, once silent
+      # for 24 minutes AFTER every suite printed `Done` (a process that never
+      # exited) — and each burned the full 30-minute job timeout to end as an
+      # uninformative "The operation was canceled". The guard watches output
+      # silence, so both shapes become a labeled red naming the last line after
+      # 10 quiet minutes, and its process-group kill takes down whatever
+      # refused to exit. `--log` is the guard's own tee (mandatory); no
+      # completeness guard reads these files yet. The zone-assert `node -e`
+      # stays outside the wrapper: a one-shot print cannot stall, and the
+      # guard should time the suite only.
       - name: Run driver-sql suite against both live servers
         env:
           TZ: America/New_York
@@ -323,7 +336,8 @@ jobs:
           # everything still passes — the same vacuous-pass hole the live-server
           # suites close by asserting a non-UTC SERVER.
           node -e "const tz=Intl.DateTimeFormat().resolvedOptions().timeZone,off=new Date().getTimezoneOffset();if(!tz||tz==='UTC'||off===0){console.error('process zone is '+tz+' (offset '+off+') — this job must run skewed');process.exit(1)}console.log('process zone: '+tz+' (offset '+off+')')"
-          pnpm --filter @objectstack/driver-sql test
+          node scripts/run-with-stall-guard.mjs --log "$RUNNER_TEMP/temporal-driver-sql.log" --stall-minutes 10 -- \
+            pnpm --filter @objectstack/driver-sql test
 
       # The non-SQL half of the same axis. `driver-sql` has run under a skewed
       # process zone since #3979, but the other backends the temporal
@@ -359,13 +373,17 @@ jobs:
           # everything still passes — the same vacuous-pass hole the live-server
           # suites close by asserting a non-UTC SERVER.
           node -e "const tz=Intl.DateTimeFormat().resolvedOptions().timeZone,off=new Date().getTimezoneOffset();if(!tz||tz==='UTC'||off===0){console.error('process zone is '+tz+' (offset '+off+') — this job must run skewed');process.exit(1)}console.log('process zone: '+tz+' (offset '+off+')')"
-          pnpm \
-            --filter @objectstack/core \
-            --filter @objectstack/formula \
-            --filter @objectstack/driver-memory \
-            --filter @objectstack/driver-mongodb \
-            --filter @objectstack/service-analytics \
-            test
+          # Stall guard: same wiring and rationale as the driver-sql step above
+          # (#4250/#4331) — the "silent after every suite printed Done"
+          # occurrence was on THIS leg.
+          node scripts/run-with-stall-guard.mjs --log "$RUNNER_TEMP/temporal-non-sql.log" --stall-minutes 10 -- \
+            pnpm \
+              --filter @objectstack/core \
+              --filter @objectstack/formula \
+              --filter @objectstack/driver-memory \
+              --filter @objectstack/driver-mongodb \
+              --filter @objectstack/service-analytics \
+              test
 
   dogfood:
     # Sharded 2-way: the suite is ~60 independent test files, each booting its


### PR DESCRIPTION
## 变更内容

#4298 给 Test Core 挂上 `scripts/run-with-stall-guard.mjs` 之后,**Temporal Conformance (live PG + MySQL)** 的两个测试步骤仍在裸跑,#4331 实测了后果:mid-suite stall 每次烧满 30 分钟 job 超时,以毫无信息量的「The operation was canceled」收场。本 PR 给这两个步骤包上与 Test Core 完全相同的 guard 接线:

- `Run driver-sql suite against both live servers`
- `Run the non-SQL temporal backends under the skewed process zone`

均为 `node scripts/run-with-stall-guard.mjs --log "$RUNNER_TEMP/<leg>.log" --stall-minutes 10 -- …`(与 Test Core 同参数)。

## 说明

- **两种 stall 形态都被覆盖**:guard 盯的是输出静默,所以 #4331 run 1(kernel.test 执行中途冻结)和 run 2(五个包全部打完 `Done` 后零输出 24 分钟、进程不退出)都会在静默 10 分钟后转成带「last line」标注的快速失败;guard 的 process-group kill 也正好兜住 run 2 那种句柄泄漏不退出的形态,**无需改动 guard 脚本**。
- **`node -e` 时区断言留在 guard 之外**:一次性打印不可能 stall,guard 只计时真正的 suite。
- **`--log` 是 guard 必填参数**(guard 自己负责 tee);该 job 目前没有 completeness guard 消费这些日志,注释里已写明。
- 非 SQL 步骤的多行 `pnpm --filter … test` 保持反斜杠续行,整体缩进一级放入 guard 之后;已本地验证 YAML 解析、`bash -n` 续行语法、以及 guard 以相同参数干跑(exit 0)。

Closes #4331

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXjVcohpYTsZY7D5p91dJQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXjVcohpYTsZY7D5p91dJQ)_