### PR TITLE
ci: Temporal Conformance's two test steps run under the stall guard (#4331)

### DIFF
--- a/.changeset/temporal-conformance-stall-guard.md
+++ b/.changeset/temporal-conformance-stall-guard.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: the two Temporal Conformance test steps run under run-with-stall-guard, and the stall verdict names both stall shapes (#4331). CI-only — releases nothing.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,6 +312,17 @@ jobs:
       # The whole driver-sql suite runs under the skewed process zone — not
       # just the live-server files — so a TZ-sensitive assumption anywhere in
       # the driver's tests fails here before it can ship.
+      #
+      # run-with-stall-guard: same wiring and the same 10 minutes as Test Core
+      # (see the comment at that step). Both of this job's test steps ran bare
+      # until #4331, so a stall in either one sat in_progress for the full
+      # 30-minute job timeout and ended as "The operation was canceled" — a
+      # red with no failing test in it, on PRs whose diff had nothing to do
+      # with it. The occurrences #4331 recorded were all on the sibling
+      # non-SQL step; this step is guarded because it is the same job under
+      # the same timeout, not because it has been seen stalling. A healthy run
+      # of this job is 3–4 minutes end to end, so 10 minutes of dead air is
+      # not a slow suite.
       - name: Run driver-sql suite against both live servers
         env:
           TZ: America/New_York
@@ -323,7 +334,8 @@ jobs:
           # everything still passes — the same vacuous-pass hole the live-server
           # suites close by asserting a non-UTC SERVER.
           node -e "const tz=Intl.DateTimeFormat().resolvedOptions().timeZone,off=new Date().getTimezoneOffset();if(!tz||tz==='UTC'||off===0){console.error('process zone is '+tz+' (offset '+off+') — this job must run skewed');process.exit(1)}console.log('process zone: '+tz+' (offset '+off+')')"
-          pnpm --filter @objectstack/driver-sql test
+          node scripts/run-with-stall-guard.mjs --log "$RUNNER_TEMP/temporal-driver-sql.log" --stall-minutes 10 -- \
+            pnpm --filter @objectstack/driver-sql test
 
       # The non-SQL half of the same axis. `driver-sql` has run under a skewed
       # process zone since #3979, but the other backends the temporal
@@ -350,6 +362,13 @@ jobs:
           --filter=@objectstack/formula...
           --concurrency=4
 
+      # The leg #4331 actually caught stalling: twice on one PR whose diff
+      # touched none of these five packages, in both of the shapes the guard's
+      # silence watch covers — frozen partway through `core`'s kernel.test,
+      # and then, the next run, all five packages reporting Done and the
+      # process simply never exiting (a leaked handle, not a hung test). No
+      # output is no output, so one watchdog catches both; the last line it
+      # quotes is what tells them apart.
       - name: Run the non-SQL temporal backends under the skewed process zone
         env:
           TZ: America/New_York
@@ -359,7 +378,8 @@ jobs:
           # everything still passes — the same vacuous-pass hole the live-server
           # suites close by asserting a non-UTC SERVER.
           node -e "const tz=Intl.DateTimeFormat().resolvedOptions().timeZone,off=new Date().getTimezoneOffset();if(!tz||tz==='UTC'||off===0){console.error('process zone is '+tz+' (offset '+off+') — this job must run skewed');process.exit(1)}console.log('process zone: '+tz+' (offset '+off+')')"
-          pnpm \
+          node scripts/run-with-stall-guard.mjs --log "$RUNNER_TEMP/temporal-non-sql.log" --stall-minutes 10 -- \
+            pnpm \
             --filter @objectstack/core \
             --filter @objectstack/formula \
             --filter @objectstack/driver-memory \

--- a/scripts/run-with-stall-guard.mjs
+++ b/scripts/run-with-stall-guard.mjs
@@ -16,6 +16,16 @@
 // (EX_TEMPFAIL: the sanctioned response is a rerun -- every #4250 occurrence
 // passed on rerun of the same commit).
 //
+// Silence is deliberately the ONLY signal, because it catches both observed
+// shapes without having to tell them apart. #4331 hit Temporal Conformance in
+// the second shape: every package printed `Done`, turbo printed its summary,
+// and then the process never exited -- a leaked handle rather than a hung
+// test. No output is no output, so the same watchdog fires; the quoted last
+// line is what tells a reader which shape they got (a mid-test line vs. the
+// run's own summary). Note the exit path is `child.on('exit')`, not 'close':
+// the guard must not itself block waiting on stdio pipes a leaked grandchild
+// is still holding open.
+//
 //   node scripts/run-with-stall-guard.mjs --log <file> [--stall-minutes N] -- <command...>
 //
 // It also owns the log tee: combined stdout+stderr is forwarded to this
@@ -118,14 +128,18 @@ ${'═'.repeat(72)}
    frozen since : ${new Date(lastOutputAt).toISOString()}
    last line    : ${lastLine}
 
-   This is the #4250 failure mode -- the suite is STOPPED, not slow. A
-   healthy run prints continuously; only a hang goes silent this long.
-   Killing the test process group and failing the step now, instead of
-   sitting in_progress until the job timeout.
+   The run is STOPPED, not slow -- a healthy one prints continuously and
+   only a hang goes silent this long. Killing the test process group and
+   failing the step now, instead of sitting in_progress until the job
+   timeout.
 
-   Triage: every #4250 stall so far passed on a plain rerun of the same
-   commit -- rerun this job before suspecting the diff. If it stalls twice
-   at the same test file, add that occurrence to #4250.
+   Read the last line above to place it: a mid-test line means the suite
+   hung partway (#4250); the run's own completion summary means every
+   package finished and the process then failed to exit (#4331).
+
+   Triage: every stall so far passed on a plain rerun of the same commit --
+   rerun this job before suspecting the diff. If it stalls twice at the same
+   point, add that occurrence to #4250 (mid-suite) or #4331 (post-Done).
 ${'═'.repeat(72)}
 `;
   process.stdout.write(banner);


### PR DESCRIPTION
Closes #4331

## 改了什么

Temporal Conformance (live PG + MySQL) job 的两个测试步骤原来裸跑 `pnpm test`,现在和 Test Core(ci.yml:153/165)一样包上 `run-with-stall-guard`,参数相同(`--stall-minutes 10`):

| 步骤 | log |
|:--|:--|
| `Run driver-sql suite against both live servers` | `$RUNNER_TEMP/temporal-driver-sql.log` |
| `Run the non-SQL temporal backends under the skewed process zone` | `$RUNNER_TEMP/temporal-non-sql.log` |

**两步的 TZ 断言原样留在 guard 之前、不被包进去** —— 那个 `node -e` 必须能在任何测试启动前直接中断该步骤。已验证 `TZ=UTC` 时 step 在 `bash -e` 下于断言处退出 1,guard 根本不会被执行到。

10 分钟的取值:该 job 健康跑完是 3–4 分钟,10 分钟静默不可能是"慢",与 Test Core 保持一致。

## 关于 issue 里提的第二种形态 —— 结论是 guard 已经覆盖,不需要新检测器

issue 猜测「如果 guard 目前只盯输出静默,这一形态正好覆盖」,这个判断是对的,而且我实测确认了,没有只靠读代码:

- **形态 A(run 2:五个包全部 `Done`、进程不退出、零输出)** —— 子进程还活着但不再产出字节,watchdog 只看静默、不看子进程死活,所以照样在阈值处触发:判 stall → 杀整个进程组 → exit 75。判决里引用的 last line 正是 turbo 的完成摘要。
- **形态 B(顶层命令已退出、但残留孙进程仍握着 stdout/stderr 管道)** —— guard 走的是 `child.on('exit')` 而不是 `'close'`,所以是立即返回子进程真实退出码(实测 elapsed 0s),不会被泄漏的管道句柄吊住。这一条本来就是对的,我把它写进注释免得日后有人"顺手"改成 `'close'` 把洞开出来。

顺带确认退出码没被吞:红套件穿过 guard 仍然 exit 1。

因此脚本里**没有加任何兜底逻辑**,唯一的改动是判决文案:原文只描述了 mid-suite 那一种形态(「This is the #4250 failure mode」),在 post-Done 形态下会把人引去找一个根本不存在的卡死测试文件。现在它同时点名两种形态,并说明用 last line 来区分。

## 验证

CI 配置改动,靠机械验证而非跑真套件(guard 本身在 Test Core / Dogfood / 两个 nightly 上已在跑):

- YAML 解析通过;两个 step 的 `run` body 过 `bash -n`。
- 把 step body 抽出来、用一个打印 argv 的假 `pnpm` 执行,确认 `--` 之后传给 guard 的参数与原来的 pnpm 调用**逐字相同**(含第二步那串多行 `--filter` 续行),TZ 断言仍先跑并打印 skewed zone。
- `TZ=UTC` 时步骤在断言处退出 1,不进 guard。
- 形态 A / 形态 B / 红套件三个用例按上文实测。

未加 `check-test-completeness.mjs` 后置步骤(Test Core 和 Dogfood 有):issue 没有要求,是否适用于这两个套件的输出形态需要单独判断,不在本 PR 范围内扩。

changeset 为空 frontmatter(CI-only,releases nothing),沿用 `test-core-stall-guard.md` / `stall-guard-rollout.md` 的惯例。

🤖 Generated with [Claude Code](https://claude.com/claude-code)