### PR TITLE
docs(hook-bodies): 写集一节改为准确的覆盖面描述 —— #4305/#4344 之后"没有静态检查"已不成立 (#4351)

### DIFF
--- a/.changeset/hook-bodies-write-set-docs.md
+++ b/.changeset/hook-bodies-write-set-docs.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(hook-bodies): the write-set section said the write side had no static checking, which #4305/#4344 made false (#4351) — rewritten as an accurate coverage description (three literal patterns, advisory `hook-body-write-unknown-field` / `action-body-write-unknown-field`, and the shapes the parser must skip, so a missing warning is not read as proof of correctness), the "accepted gap with no planned closure" conclusion retracted (#3700 stays accurate history; the gap was closed from the other end, by parsing the write set), the runtime paragraph corrected against measured behaviour, and the three now-stale cross-links in `hooks.mdx` updated to the renamed anchor. Releases nothing.

--- a/content/docs/automation/hook-bodies.mdx
+++ b/content/docs/automation/hook-bodies.mdx
@@ -116,20 +116,49 @@ The CLI builder **rejects** any source that uses:
 
 Need outbound HTTP? Define a **Connector recipe** as metadata and call it via `ctx.connector(...)`. (Connector spec is tracked separately and ships after L1+L2 stabilises.)
 
-### Not statically checked: the write set
+### Write-set checking
 
 Static validation around a hook is asymmetric, and it is worth knowing exactly where the line is:
 
 - **Checked — read side.** `hook.condition` is validated at build time against the target object's fields by the expression validator (`@objectstack/lint`), including array-valued `hook.object` targets. A condition referencing a nonexistent field fails the lint.
 - **Checked — capability side.** `body.capabilities` gates which `ctx` APIs the body may call at all; the sandbox throws on an undeclared call.
-- **Not checked — write side.** Nothing validates *which fields* your body writes. `body.source` is an opaque JS string: the fields it assigns (`ctx.input.foo = …`) or writes cross-object (`ctx.api.object('x').update(id, { foo })`) are not represented anywhere in metadata, so no lint can verify they exist. This is an **accepted gap** with no planned closure — a structured `writes` declaration was considered and dropped ([#3700](https://github.com/objectstack-ai/objectstack/issues/3700), closed as not planned).
+- **Checked — write side, advisory and literal-only.** Since [#4271](https://github.com/objectstack-ai/objectstack/issues/4271), `body.source` is **parsed** (never executed, never type-checked) and the field names it writes are resolved against the target object's declarations. An unknown field raises `hook-body-write-unknown-field` — a **warning** carrying a did-you-mean suggestion, which never blocks a build. Action bodies get the same check on their `ctx.api` writes (`action-body-write-unknown-field`). Both run under `os validate`, `os lint` and `os compile`.
 
-Writing a field the target object doesn't have is not caught at runtime either — the write-path validator skips unknown keys. On a SQL driver the stray column reaches the database and the whole operation fails with a driver-level error, far from the authoring mistake; a schemaless driver (memory, MongoDB) silently persists the stray key.
+Three literal write shapes are recognized, and only these:
 
-Because the write set carries no static checking:
+| Write shape | Hook body | Action body |
+|---|---|---|
+| `ctx.input.<field> = …` / `ctx.input['<field>'] ⟨op⟩= …` (including `+=`, `??=`, …) | checked | not checked — an action's `ctx.input` is its **params bag**, not a record |
+| `Object.assign(ctx.input, { <field>: … })` | checked | not checked — same surface |
+| `ctx.api.object('<literal>').insert\|create\|update({ <field>: … })`, `.updateById(id, { <field>: … })` | checked | checked |
 
-- **Check your write targets by hand.** Every field the body assigns must exist on the target object(s) — for an array or `"*"` hook, on every target.
-- **Prefer a flow `update_record` node when the write set is fixed.** Flow nodes declare their writes structurally in `fields`, so they get the static checking hook bodies can't.
+**A missing warning is not a clean bill of health.** The rule bails *silently* on everything it cannot resolve statically, deliberately preferring a missed finding to a false one — a false positive kills an advisory lint, while a miss just leaves the gap open a little longer:
+
+- computed keys (`ctx.input[k] = …`), spreads, and non-literal payloads;
+- dynamic object names (`ctx.api.object(name)`);
+- `ctx.input` writes in a wildcard (`object: '*'`) hook — there is no single target to resolve against;
+- multi-target hooks where the field exists on *some* target: a body may legitimately branch per object, so only a field missing on **every** named target is flagged;
+- objects declared by another package;
+- aliased input (`const doc = ctx.input; doc.x = 1`) — v1 does no data-flow analysis.
+
+System/audit columns and the flat-input envelope keys (`id`, `options`, `ast`, `data`) are never flagged.
+
+A structured `writes` declaration was considered and dropped ([#3700](https://github.com/objectstack-ai/objectstack/issues/3700), closed as not planned) — but the gap it left was closed from the other end, by parsing the write set out of the source. The practical consequence of that route: coverage is bounded by what a parser can see, not by what an author remembered to declare.
+
+#### What still happens at runtime
+
+An unknown field is **not** caught at runtime, and it does not fail quietly either. The write-path validator walks the object's *declared* fields, so an undeclared key is neither rejected nor stripped, and the sandbox's mutations are copied back onto the payload verbatim. What happens next is the driver's call:
+
+- **SQL drivers** put the stray column into the statement, so the **whole write fails** with a driver-level error (`table deal has no column named stagee`) — nothing is stored, and the error surfaces far from the authoring mistake.
+- **Schemaless drivers** (memory, MongoDB) silently persist the stray key alongside the real ones.
+
+Neither outcome is the one you wanted, and the advisory warning is the earliest signal you get.
+
+Because the checking is advisory and literal-only:
+
+- **Treat `hook-body-write-unknown-field` as a build failure by convention.** It does not gate, but the rule is tuned for near-zero false positives — in practice a warning is a real typo.
+- **Check by hand what the parser cannot see.** Computed keys, spreads, aliased input and dynamic object names are invisible to the rule; for an array or `"*"` hook, every field must exist on every target.
+- **Prefer a flow `update_record` node when the write set is fixed — but not for *this* check.** A flow node's writes are structured config: they diff field-by-field, render in the Console designer, and a write to a `readonly:true` field is a **gating error** (`flow-update-readonly-field`) that hooks have no counterpart for. What an `update_record` node does *not* get today is a field-existence check — writing a field the object never declares is currently reported by nothing at all. On that one axis an L2 body is now the better-checked surface.
 - **Exercise the hook against a real object before shipping** — on SQL drivers the mistake surfaces on the first write; schemaless drivers won't tell you.
 
 ### Signature conventions

--- a/content/docs/automation/hooks.mdx
+++ b/content/docs/automation/hooks.mdx
@@ -33,12 +33,15 @@ cannot express.
 
 Two structural reasons to prefer the flow when either could work:
 
-- **A flow's writes are validatable metadata; a hook body is opaque code.** An
+- **A flow's writes are structured metadata; a hook body is code.** An
   `update_record` node's `fields` is structural config that `os validate`
   checks — readonly targets, template dialects, declared expression slots. A
-  hook body's write set is **not** statically checked (see
-  [Hook & Action Bodies](/docs/automation/hook-bodies#not-statically-checked-the-write-set)):
-  a misspelled field name runs green and writes nothing.
+  hook body's write set is checked too, but only for the literal patterns a
+  parser can recognise and only as an advisory warning (see
+  [Hook & Action Bodies](/docs/automation/hook-bodies#write-set-checking)).
+  Note the one axis where this reverses: writing a field the target object never
+  declares warns in a hook body, and is reported nowhere in an `update_record`
+  node.
 - **A flow reviews as data.** The node graph diffs field-by-field and renders
   in the Console designer with per-node run history; a hook body reviews as
   code only.
@@ -84,9 +87,10 @@ a hook can be, so review it as such:
   belongs behind a `condition` (evaluated before the handler) rather than an
   early `return` inside the body.
 - **Reads and writes both widen.** A wildcard hook holding an L2 body with
-  `api.write` can write anywhere. Whether the fields it writes exist is
-  [not statically checked](/docs/automation/hook-bodies#not-statically-checked-the-write-set),
-  so a wildcard write set is the least verifiable shape in the system.
+  `api.write` can write anywhere. Its `ctx.input` writes are also the one shape
+  the [write-set lint](/docs/automation/hook-bodies#write-set-checking) has to
+  skip — with no single target object there is nothing to resolve field names
+  against — so a wildcard write set is the least verifiable shape in the system.
 
 Where a wildcard is the honest answer, say so in `description` — it is the one
 place a reviewer can find out why the broad target was chosen.
@@ -179,8 +183,9 @@ ctx = {
 - Use `ctx.api.object('x')` for cross-object access so writes stay in scope
 - Handle errors gracefully
 - Verify every field your hook writes exists on the target object(s) — the
-  write set of a hook body is **not statically validated**, unlike `condition`
-  (see [Hook & Action Bodies](/docs/automation/hook-bodies#not-statically-checked-the-write-set))
+  write-set lint catches the literal cases, but it is advisory, and computed
+  keys, spreads and aliased input are invisible to it (see
+  [Hook & Action Bodies](/docs/automation/hook-bodies#write-set-checking))
 
 ❌ **DON'T:**
 - Query in loops


### PR DESCRIPTION
Closes #4351.

## 问题

`content/docs/automation/hook-bodies.mdx` 的 "Not statically checked: the write set" 一节声称写面**完全没有**静态检查,并称其为 "accepted gap with no planned closure"。自 #4305(`validateHookBodyWrites`)与 #4344(action 侧姊妹规则)起,这不成立 —— `hook-body-write-unknown-field` / `action-body-write-unknown-field` 会解析 L2 body,把字面写集拿去和目标对象声明的字段比对,未知字段带 did-you-mean 告警。

"declared ≠ enforced" 的镜像:**enforced ≠ declared** —— 能力已交付,文档还在说没有。作者按文档放弃一个真实存在的护栏,和按文档相信一个不存在的护栏,代价是对称的。

## 改动

**`hook-bodies.mdx`** —— `### Not statically checked: the write set` → `### Write-set checking`

- 覆盖面写准:三种字面写法按 hook / action 分列成表(action 的 `ctx.input` 是 params bag,只有 `api-crud-literal` 过继),advisory `warning` 不 gate,跑在 `os validate` / `os lint` / `os compile`。
- 单列 **"A missing warning is not a clean bill of health"**:computed key、spread、动态对象名、wildcard `ctx.input`、多目标部分命中、跨包对象、aliased input —— 静态不可知的一律静默跳过,所以**告警的缺席不等于正确**。
- #3700(结构化 `writes`,closed as not planned)保留为准确历史,但撤回 "accepted gap" 的结论:缺口是从另一头(解析写集)关的,不是没关。

**`hooks.mdx`** —— 三处交叉链接指向被改名的锚点,且都在复述已撤回的说法,一并更新。wildcard 那条反而更锐利:wildcard hook 的 `ctx.input` 写恰恰是 lint **必须**跳过的那一种。

## 两条前提按实测修正,而非照抄

原 issue 的清单里有两条建立在错误前提上。我实测后按事实写,并各开了独立跟进项。

**1. flow `update_record` 根本没有未知字段检查。**

原文档建议"优先用 flow `update_record`,它有 hook body 没有的静态检查"—— 在这条轴上现在正好反了。同一 stack 三个面写同一个不存在字段 `stagee`,`validateReferenceIntegrity` 的实际输出:

| 写面 | 结果 |
|---|---|
| hook body `ctx.input.stagee = …` | `hook-body-write-unknown-field` (warning) |
| action body `ctx.api.object('deal').update({stagee})` | `action-body-write-unknown-field` (warning) |
| flow `update_record` `fields: { stagee }` | **什么都不报** |

`validate-readonly-flow-writes.ts` 是唯一走 `update_record.fields` 的规则,而它显式跳过未知字段(`if (!meta) continue; // unknown field — a form/field-layout lint concern, not this rule's`)。建议予以保留(结构化 diff、gating 的 `flow-update-readonly-field` 仍然成立),但把 gap 点明。

**2. "silently never lands" 两个方向都不对。**

lint 自己的诊断文案说未知列静默消失。实测:没有任何一层剥离它 —— `applyMutationsToInput` 是裸 `Object.assign`,`validateRecord` 只遍历已声明字段 —— 所以它一路到驱动:

- **SQL 驱动**:未知列进入 knex 语句,**整条写失败**(better-sqlite3 实测 `table deal has no column named stagee`,零行落库);
- **schemaless 驱动**(memory / MongoDB):杂散键**确实**被持久化。

文档原来那段运行时描述是对的,予以保留并按驱动族拆开写细。lint 的文案问题属代码缺陷,单独跟进。

## 边界

`ctx.record` 那一半不属于本 PR —— 那是 #4345,已在同名 PR 里连同 sandbox-surface 表和 signature-conventions 一起处理。

## 验证

- 两个 MDX 经 `@mdx-js/mdx` + `remark-gfm` 编译通过;`fumadocs-mdx` 生成通过。
- 新表经 remark 解析确认每行 3 列,`\|` 正确渲染为字面 `|`。
- 全仓已无 `not-statically-checked-the-write-set` 锚点残留,亦无 "accepted gap" / "not statically validated" 等旧说法。
- `content/docs/automation/` 为手写目录(生成的只有 `content/docs/references/`),不受 `check:docs` 影响。

纯文档,无行为变更,空 changeset。

🤖 Generated with [Claude Code](https://claude.com/claude-code)