### PR TITLE
fix(sharing,runtime): a `sort` passed straight to the engine never ordered anything; migrate in-repo call sites to canonical keys (#4346)

### DIFF
--- a/.changeset/engine-callsites-canonical-keys.md
+++ b/.changeset/engine-callsites-canonical-keys.md
@@ -1,0 +1,52 @@
+---
+"@objectstack/plugin-sharing": patch
+"@objectstack/runtime": patch
+"@objectstack/plugin-approvals": patch
+"@objectstack/plugin-auth": patch
+"@objectstack/plugin-reports": patch
+"@objectstack/plugin-webhooks": patch
+"@objectstack/spec": patch
+---
+
+fix(sharing,runtime): a `sort` passed straight to the engine never ordered anything; migrate every in-repo engine call to canonical QueryAST keys (#4346)
+
+Two changes with different weights, from one sweep of every in-repo engine
+call site that still speaks a deprecated alias.
+
+**The bug — three dropped sorts.** #4346 made the engine fold `filter`→`where`
+and `top`→`limit` on all six methods. The other four pairs in
+`RPC_QUERY_ALIAS_SLOTS` (`select`, `sort`, `skip`, `populate`) are folded at
+the RPC/wire layer only — their values need shape lowering that belongs to
+those layers — and a **direct `engine.find()` never crosses that layer**. Three
+call sites passed `sort` there, so it rode onto the AST untouched, every
+driver's `Array.isArray(query.orderBy)` guard declined to emit an ORDER BY, and
+the query returned an ordinary-looking, arbitrarily-ordered result:
+
+| call site | asked for | actually got |
+|---|---|---|
+| `share-link-routes.ts` | shared AI conversation messages, `created_at asc` | messages in arbitrary order |
+| `runtime/domains/share-links.ts` | same route, runtime-domain copy | same |
+| `share-link-service.ts` `listLinks` | the 200 most recent share links | an arbitrary 200 |
+
+All three combine the dropped sort with a `limit` — the "latest N" shape whose
+failure #4226 spelled out: an unapplied sort returns rows in arbitrary order,
+which `limit` then slices into an arbitrary page. #4226 fixed that in the wire
+normalizer; these calls sit one layer below it. `listLinks` had no test at all,
+which is why it went unnoticed. Now pinned — on the option bag the engine
+receives, not on row order, because the failure is that the key never becomes
+`orderBy` and a fake engine honouring either spelling would pass either way.
+
+**The cleanup — 27 no-op renames.** Every remaining in-repo engine call passing
+`filter` now passes `where` (approvals 5, auth 2, reports 6, sharing 11,
+webhooks 2, plus the one `filters` in a spec doc example). These are strict
+no-ops since #4346 folds the alias — the point is that the framework stops
+depending on a spelling it asks users to migrate off, which is a prerequisite
+for ever retiring the aliases. Service-level `filter` PARAMETERS (each
+service's own public API, e.g. `listRequests(filter)`) are deliberately
+untouched — those are not engine option bags.
+
+Two of the renamed calls were live victims of the #4346 bug rather than
+cosmetic: `auth-manager`'s `stampIdentitySource` read the table's first row via
+`findOne({filter})` and counted the whole table via `count({filter})`, so a
+federated sign-in never stamped `source: 'idp_provisioned'`. #4346 already
+corrected the behaviour; this makes the call say what it means.

--- a/packages/plugins/plugin-approvals/src/approval-service.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.ts
@@ -1053,7 +1053,7 @@ export class ApprovalService implements IApprovalService {
     let rows: any[] = [];
     try {
       rows = await this.engine.find('sys_team_member', {
-        filter: { team_id: teamId },
+        where: { team_id: teamId },
         fields: ['user_id'],
         limit: 10000,
         context: SYSTEM_CTX,
@@ -1096,7 +1096,7 @@ export class ApprovalService implements IApprovalService {
     // Seed sanity check: skip if dept doesn't exist or is inactive within tenant.
     try {
       const seed = await this.engine.find('sys_business_unit', {
-        filter: this.businessUnitOrgScope({ id: businessUnitId }, organizationId),
+        where: this.businessUnitOrgScope({ id: businessUnitId }, organizationId),
         fields: ['id', 'active'],
         limit: 1,
         context: SYSTEM_CTX,
@@ -1125,7 +1125,7 @@ export class ApprovalService implements IApprovalService {
     let rows: any[] = [];
     try {
       rows = await this.engine.find('sys_business_unit_member', {
-        filter: { business_unit_id: { $in: Array.from(seen) } },
+        where: { business_unit_id: { $in: Array.from(seen) } },
         fields: ['user_id'],
         limit: 10000,
         context: SYSTEM_CTX,
@@ -1184,7 +1184,7 @@ export class ApprovalService implements IApprovalService {
   private async lookupManager(userId: string): Promise<string | null> {
     try {
       const rows = await this.engine.find('sys_user', {
-        filter: { id: userId }, fields: ['id', 'manager_id'], limit: 1, context: SYSTEM_CTX,
+        where: { id: userId }, fields: ['id', 'manager_id'], limit: 1, context: SYSTEM_CTX,
       } as any);
       const row: any = Array.isArray(rows) ? rows[0] : null;
       return row?.manager_id ? String(row.manager_id) : null;
@@ -1240,7 +1240,7 @@ export class ApprovalService implements IApprovalService {
     let rows: any[] = [];
     try {
       rows = await this.engine.find('sys_approval_delegation', {
-        filter: { delegator_id: delegatorId },
+        where: { delegator_id: delegatorId },
         fields: ['id', 'delegator_id', 'delegate_id', 'valid_from', 'valid_until', 'reason', 'organization_id'],
         limit: 50,
         context: SYSTEM_CTX,

--- a/packages/plugins/plugin-approvals/src/approver-org-scope.test.ts
+++ b/packages/plugins/plugin-approvals/src/approver-org-scope.test.ts
@@ -35,7 +35,11 @@ function makeDeps(over: Partial<ApproverOrgScopeDeps> & { members?: Array<{ user
   const members = over.members ?? [];
   const engine = {
     find: vi.fn(async (object: string, opts: any) => {
-      const f = opts?.filter ?? {};
+      // Reads the CANONICAL key, like the engine's own post-fold AST. This
+      // double used to read `opts.filter`, which is why it kept passing while
+      // production spoke the deprecated spelling: both sides shared one
+      // dialect, so nothing forced the migration (#4346).
+      const f = opts?.where ?? {};
       if (object === 'sys_organization') {
         const rows = Object.values(ORGS).filter((o) =>
           (f.id === undefined || o.id === f.id) && (f.slug === undefined || o.slug === f.slug));
@@ -151,7 +155,7 @@ describe('resolveApproverDirectoryOrg — the guards', () => {
     const deps = makeDeps();
     (deps.engine.find as any) = vi.fn(async (object: string, opts: any) => {
       if (object !== 'sys_organization') return [];
-      const id = opts?.filter?.id;
+      const id = opts?.where?.id;
       // a → b → a
       if (id === 'a') return [{ id: 'a', slug: 'a', parent_organization_id: 'b' }];
       if (id === 'b') return [{ id: 'b', slug: 'b', parent_organization_id: 'a' }];

--- a/packages/plugins/plugin-approvals/src/approver-org-scope.ts
+++ b/packages/plugins/plugin-approvals/src/approver-org-scope.ts
@@ -62,7 +62,7 @@ async function findOrg(
 ): Promise<any | null> {
   try {
     const rows = await engine.find('sys_organization', {
-      filter: where,
+      where,
       fields: ['id', 'slug', 'parent_organization_id'],
       limit: 1,
       context: SYSTEM_CTX,
@@ -230,7 +230,7 @@ export async function filterApproversWhoCanRead(
   let members: any[] = [];
   try {
     members = await deps.engine.find('sys_member', {
-      filter: { organization_id: requestOrg, user_id: { $in: userIds } },
+      where: { organization_id: requestOrg, user_id: { $in: userIds } },
       fields: ['user_id'],
       limit: 10000,
       context: SYSTEM_CTX,

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -3481,7 +3481,7 @@ export class AuthManager {
         // Gained a local password → env-native. Only write if currently
         // managed (avoids a no-op history row on every local signup).
         const u = await engine.findOne('sys_user', {
-          filter: { id: userId }, fields: ['id', 'source'], context: SYSTEM_CTX,
+          where: { id: userId }, fields: ['id', 'source'], context: SYSTEM_CTX,
         } as any);
         if (u && u.source === 'idp_provisioned') {
           await engine.update('sys_user', { id: userId, source: 'env_native' }, { context: SYSTEM_CTX } as any);
@@ -3491,7 +3491,7 @@ export class AuthManager {
 
       // Federated link → managed, unless a local credential already exists.
       const credentialCount = await engine.count('sys_account', {
-        filter: { user_id: userId, provider_id: 'credential' },
+        where: { user_id: userId, provider_id: 'credential' },
         context: SYSTEM_CTX,
       } as any);
       if (typeof credentialCount === 'number' && credentialCount > 0) return;

--- a/packages/plugins/plugin-reports/src/report-service.ts
+++ b/packages/plugins/plugin-reports/src/report-service.ts
@@ -307,7 +307,7 @@ export class ReportService implements IReportService {
   /** Raw metadata read of a saved report by id (no authz — callers gate). */
   private async loadReportRow(reportId: string): Promise<any | null> {
     const rows = await this.engine.find('sys_saved_report', {
-      filter: { id: reportId }, limit: 1, context: SYSTEM_CTX,
+      where: { id: reportId }, limit: 1, context: SYSTEM_CTX,
     });
     return Array.isArray(rows) && rows[0] ? rows[0] : null;
   }
@@ -374,7 +374,7 @@ export class ReportService implements IReportService {
       f.owner_id = context.userId;
     }
     const rows = await this.engine.find('sys_saved_report', {
-      filter: f, limit: 500, orderBy: [{ field: 'updated_at', order: 'desc' }], context: SYSTEM_CTX,
+      where: f, limit: 500, orderBy: [{ field: 'updated_at', order: 'desc' }], context: SYSTEM_CTX,
     });
     return Array.isArray(rows) ? rows.map(rowFromSaved) : [];
   }
@@ -397,7 +397,7 @@ export class ReportService implements IReportService {
     }
     // Cascade — drop attached schedules first.
     const schedules = await this.engine.find('sys_report_schedule', {
-      filter: { report_id: reportId }, limit: 500, context: SYSTEM_CTX,
+      where: { report_id: reportId }, limit: 500, context: SYSTEM_CTX,
     });
     for (const s of (schedules ?? [])) {
       await this.engine.delete('sys_report_schedule', { where: { id: (s as any).id }, context: SYSTEM_CTX });
@@ -437,7 +437,7 @@ export class ReportService implements IReportService {
     const q = report.query ?? {};
     const limit = Math.min(q.limit ?? DEFAULT_LIMIT, this.maxRows);
     const rows = await this.engine.find(report.object_name, {
-      filter: q.filter,
+      where: q.filter,
       fields: q.fields,
       orderBy: q.orderBy,
       limit,
@@ -544,7 +544,7 @@ export class ReportService implements IReportService {
     const f: any = {};
     if (filter?.reportId) f.report_id = filter.reportId;
     const rows = await this.engine.find('sys_report_schedule', {
-      filter: f, limit: 500, orderBy: [{ field: 'next_run_at', order: 'asc' }], context: SYSTEM_CTX,
+      where: f, limit: 500, orderBy: [{ field: 'next_run_at', order: 'asc' }], context: SYSTEM_CTX,
     });
     return Array.isArray(rows) ? rows.map(rowFromSchedule) : [];
   }
@@ -554,7 +554,7 @@ export class ReportService implements IReportService {
   async dispatchDue(now?: Date): Promise<{ fired: number; failed: number; skipped: number }> {
     const ts = (now ?? this.clock.now()).toISOString();
     const due = await this.engine.find('sys_report_schedule', {
-      filter: { active: true },
+      where: { active: true },
       limit: 200,
       context: SYSTEM_CTX,
     });

--- a/packages/plugins/plugin-sharing/src/share-link-routes.ts
+++ b/packages/plugins/plugin-sharing/src/share-link-routes.ts
@@ -301,7 +301,7 @@ export function registerShareLinkRoutes(
       const SYSTEM_CTX = { isSystem: true, positions: [], permissions: [] } as const;
       const rows = await engine.find('ai_messages', {
         where: { conversation_id: resolved.link.record_id },
-        sort: [{ field: 'created_at', order: 'asc' }],
+        orderBy: [{ field: 'created_at', order: 'asc' }],
         limit: 500,
         context: SYSTEM_CTX,
       } as any);

--- a/packages/plugins/plugin-sharing/src/share-link-service.test.ts
+++ b/packages/plugins/plugin-sharing/src/share-link-service.test.ts
@@ -89,6 +89,33 @@ describe('ShareLinkService', () => {
     expect(engine._tables.sys_share_link).toHaveLength(1);
   });
 
+  // [#4346 follow-up] `listLinks` asked for "the 200 most recent links" with a
+  // `sort` key. The ENGINE folds only `where`/`filter` and `limit`/`top`
+  // (`RPC_QUERY_ALIAS_SLOTS`); `sort`→`orderBy` is folded at the RPC/wire layer,
+  // which a direct `engine.find()` never crosses. So `sort` rode onto the AST
+  // untouched, every driver's `Array.isArray(query.orderBy)` guard declined to
+  // emit an ORDER BY, and the "most recent 200" was an ARBITRARY 200 — with a
+  // perfectly ordinary-looking result over it (the #4226 failure mode, one
+  // layer below the normalizer #4226 fixed).
+  //
+  // Asserted on the OPTION BAG rather than on row order, because the failure is
+  // that the key never becomes `orderBy` — a fake engine that sorts by either
+  // spelling would pass while the real one drops it.
+  it('listLinks asks the engine for its ordering under the canonical key', async () => {
+    const seen: any[] = [];
+    const recording = {
+      ...engine,
+      async find(object: string, options?: any) { seen.push(options); return engine.find(object, options); },
+    };
+    const svc = new ShareLinkService({ engine: recording as any });
+    await svc.listLinks({}, { isSystem: true });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].orderBy, 'a `sort` key here is silently dropped by every driver')
+      .toEqual([{ field: 'created_at', order: 'desc' }]);
+    expect('sort' in seen[0], 'the deprecated spelling must not ride along').toBe(false);
+  });
+
   it('rejects objects that did not opt in', async () => {
     await expect(
       service.createLink(

--- a/packages/plugins/plugin-sharing/src/share-link-service.ts
+++ b/packages/plugins/plugin-sharing/src/share-link-service.ts
@@ -358,7 +358,7 @@ export class ShareLinkService implements IShareLinkService {
     const rows = await this.engine.find('sys_share_link', {
       where,
       limit: 200,
-      sort: [{ field: 'created_at', order: 'desc' }],
+      orderBy: [{ field: 'created_at', order: 'desc' }],
       context: context.isSystem ? SYSTEM_CTX : context,
     } as any);
     return Array.isArray(rows) ? (rows as ShareLink[]) : [];

--- a/packages/plugins/plugin-sharing/src/sharing-rule-provenance.ts
+++ b/packages/plugins/plugin-sharing/src/sharing-rule-provenance.ts
@@ -57,7 +57,7 @@ export function bindRuleProvenanceStamp(engine: MinimalEngine, logger?: MinimalL
         // current row ourselves (system ctx: this is a provenance check, not
         // an authorization decision).
         const rows = await engine.find('sys_sharing_rule', {
-          filter: { id },
+          where: { id },
           fields: ['id', 'managed_by', 'customized'],
           limit: 1,
           context: SYSTEM_CTX,

--- a/packages/plugins/plugin-sharing/src/sharing-rule-service.ts
+++ b/packages/plugins/plugin-sharing/src/sharing-rule-service.ts
@@ -135,7 +135,7 @@ export class SharingRuleService implements ISharingRuleService {
       : (typeof input.criteria === 'string' ? input.criteria : JSON.stringify(input.criteria));
 
     const existing = await this.engine.find('sys_sharing_rule', {
-      filter: orgId ? { name: input.name, organization_id: orgId } : { name: input.name },
+      where: orgId ? { name: input.name, organization_id: orgId } : { name: input.name },
       limit: 1,
       context: SYSTEM_CTX,
     });
@@ -214,7 +214,7 @@ export class SharingRuleService implements ISharingRuleService {
     const orgId = (context as any)?.organizationId ?? (context as any)?.tenantId;
     if (orgId) where.organization_id = orgId;
     const rows = await this.engine.find('sys_sharing_rule', {
-      filter: where,
+      where,
       orderBy: [{ field: 'name', order: 'asc' }],
       limit: 1000,
       context: SYSTEM_CTX,
@@ -227,13 +227,13 @@ export class SharingRuleService implements ISharingRuleService {
     if (!idOrName) return null;
     const orgId = (context as any)?.organizationId ?? (context as any)?.tenantId;
     const byId = await this.engine.find('sys_sharing_rule', {
-      filter: { id: idOrName },
+      where: { id: idOrName },
       limit: 1,
       context: SYSTEM_CTX,
     });
     if (Array.isArray(byId) && byId[0]) return rowFromRule(byId[0]);
     const byName = await this.engine.find('sys_sharing_rule', {
-      filter: orgId ? { name: idOrName, organization_id: orgId } : { name: idOrName },
+      where: orgId ? { name: idOrName, organization_id: orgId } : { name: idOrName },
       limit: 1,
       context: SYSTEM_CTX,
     });
@@ -408,7 +408,7 @@ export class SharingRuleService implements ISharingRuleService {
     users: string[],
   ): Promise<SharingRuleEvaluationResult> {
     const existing = await this.engine.find('sys_record_share', {
-      filter: { source: 'rule', source_id: rule.id },
+      where: { source: 'rule', source_id: rule.id },
       fields: ['id', 'record_id', 'recipient_id', 'access_level'],
       limit: 100000,
       context: SYSTEM_CTX,
@@ -485,7 +485,7 @@ export class SharingRuleService implements ISharingRuleService {
     users: string[],
   ): Promise<SharingRuleEvaluationResult> {
     const existing = await this.engine.find('sys_record_share', {
-      filter: { source: 'rule', source_id: rule.id, record_id: recordId },
+      where: { source: 'rule', source_id: rule.id, record_id: recordId },
       fields: ['id', 'record_id', 'recipient_id', 'access_level'],
       limit: 1000,
       context: SYSTEM_CTX,
@@ -555,7 +555,7 @@ export class SharingRuleService implements ISharingRuleService {
 
   private async purgeRuleGrants(ruleId: string): Promise<number> {
     const existing = await this.engine.find('sys_record_share', {
-      filter: { source: 'rule', source_id: ruleId },
+      where: { source: 'rule', source_id: ruleId },
       fields: ['id'],
       limit: 100000,
       context: SYSTEM_CTX,

--- a/packages/plugins/plugin-sharing/src/team-graph.ts
+++ b/packages/plugins/plugin-sharing/src/team-graph.ts
@@ -54,7 +54,7 @@ export class TeamGraphService implements ITeamGraphService {
     let rows: any[] = [];
     try {
       rows = await this.engine.find('sys_team_member', {
-        filter: { team_id: teamId },
+        where: { team_id: teamId },
         fields: ['user_id'],
         limit: 10000,
         context: SYSTEM_CTX,
@@ -97,7 +97,7 @@ export class TeamGraphService implements ITeamGraphService {
     let row: any = null;
     try {
       const rows = await this.engine.find('sys_user', {
-        filter: { id: userId },
+        where: { id: userId },
         fields: ['id', 'manager_id'],
         limit: 1,
         context: SYSTEM_CTX,

--- a/packages/plugins/plugin-webhooks/src/bootstrap-declared-webhooks.ts
+++ b/packages/plugins/plugin-webhooks/src/bootstrap-declared-webhooks.ts
@@ -123,7 +123,7 @@ export async function bootstrapDeclaredWebhooks(
 
     try {
       const existing = await engine.find(subscriptionsObject, {
-        filter: { name: wh.name },
+        where: { name: wh.name },
         limit: 1,
         context: SYSTEM_CTX,
       } as any);

--- a/packages/plugins/plugin-webhooks/src/webhook-provenance.ts
+++ b/packages/plugins/plugin-webhooks/src/webhook-provenance.ts
@@ -57,7 +57,7 @@ export function bindWebhookProvenanceStamp(engine: MinimalEngine, logger?: Minim
         // current row ourselves (system ctx: this is a provenance check, not
         // an authorization decision).
         const rows = await engine.find('sys_webhook', {
-          filter: { id },
+          where: { id },
           fields: ['id', 'managed_by', 'customized'],
           limit: 1,
           context: SYSTEM_CTX,

--- a/packages/runtime/src/domains/share-links.ts
+++ b/packages/runtime/src/domains/share-links.ts
@@ -187,7 +187,7 @@ export async function handleShareLinksRequest(
             const rows = engine
                 ? asArray(await engine.find('ai_messages', {
                     where: { conversation_id: resolved.link.record_id },
-                    sort: [{ field: 'created_at', order: 'asc' }],
+                    orderBy: [{ field: 'created_at', order: 'asc' }],
                     limit: 500,
                     context: SYSTEM_CTX,
                 } as any))

--- a/packages/spec/src/system/constants/system-names.ts
+++ b/packages/spec/src/system/constants/system-names.ts
@@ -124,7 +124,7 @@ export type SystemUserId = typeof SystemUserId[keyof typeof SystemUserId];
  *
  * // Use the constant to reference the owner field in queries
  * const myRecords = await engine.find('project', {
- *   filters: [SystemFieldName.OWNER_ID, '=', currentUserId],
+ *   where: { [SystemFieldName.OWNER_ID]: currentUserId },
  * });
  * ```
  */


### PR DESCRIPTION
#4346 的收尾清扫。原计划是"把仓内 `{filter}` 调用迁到 `where`"的机械 PR,但**扫描扫出了三个活 bug**,所以这个 PR 有两种性质的改动。

## 一、活 bug:直连引擎的 `sort` 从未排过序

#4346 让引擎在六个方法上折叠 `filter`→`where` 和 `top`→`limit`。`RPC_QUERY_ALIAS_SLOTS` 里**另外四对**(`select`/`sort`/`skip`/`populate`)只在 RPC/wire 层折叠——它们的值需要形状降级(`sort` 的 record 形式、`populate` 的名字列表),那属于那一层的职责——而**直接调 `engine.find()` 根本不经过那一层**。

三处调用在那里传了 `sort`,于是它原样骑在 AST 上,每个 driver 的 `Array.isArray(query.orderBy)` 守卫都拒绝生成 ORDER BY:

| 调用点 | 要的 | 实际拿到 |
|---|---|---|
| `share-link-routes.ts` | 分享出去的 AI 会话消息,`created_at asc` | **消息乱序** |
| `runtime/domains/share-links.ts` | 同一路由的 runtime 副本 | 同上 |
| `share-link-service.ts` `listLinks` | 最近 200 条分享链接 | **任意 200 条** |

三处都是"丢掉的排序 + `limit`"——正是 #4226 注释点名的 "latest N" 失败模式:未生效的排序返回任意顺序,`limit` 再把它切成任意一页,而响应看起来完全正常。#4226 修的是 wire 归一化器,这三处在它下面一层。

**如何确证的**(不靠读代码):写了运行时探针,用真实引擎 + 记录型 driver 打印引擎实际收到的 AST ——

```
>>> AST keys: object,sort,limit
>>> ast.orderBy = undefined
>>> ast.sort    = [{"field":"created_at","order":"asc"}]
```

**针脚**:`listLinks` 此前**没有任何测试**,这是它坏了这么久没人发现的原因。新针脚断言**引擎收到的选项包**而非行顺序——因为失败点是"这个键从未变成 `orderBy`",而一个两种拼写都认的测试替身无论如何都会通过。保留前先把修复临时回退,确认针脚会变红(`expected undefined to deeply equal [...]`),不是恒绿装饰。

## 二、清理:27 处空操作重命名

其余 27 处引擎调用的 `filter` 改为 `where`(approvals 5、auth 2、reports 6、sharing 11、webhooks 2,外加 spec 一处文档示例)。因 #4346 已折叠,**这些是严格的空操作**——意义在于框架不再依赖它要求用户迁离的拼写,这是将来退役别名的前置条件。

- spec 的 `system-names.ts` 示例教的是 `engine.find({ filters: [...] })` —— `filters` 是 **wire-only 别名,引擎层根本不折**,所以那个示例教的调用匹配全表。与 #4346 修掉的 hook 示例同一类。
- 各服务自身公开 API 的 `filter` **参数**(如 `listRequests(filter)`、`listLinks(filter)`)刻意不动——那不是引擎选项包。扫描器从**调用**出发遍历(而非 grep `filter:`),正是为了区分这两者:仓内 `filter:` 有数千处命中,绝大多数是无关的。

## 三、一处测试替身必须同步

`approver-org-scope` 的假引擎读 `opts.filter`,所以它一直通过**仅仅因为替身和生产代码讲同一种废弃方言**。这正是让整类问题得以长期存活的机制,值得单独记一笔。已改为读规范键。顺带全仓扫了其他替身:多数读 `opts.where ?? opts.filter`(有韧性),无其他需要同步的。

## 验证

plugin-sharing 226 ✅ / plugin-approvals 330 ✅ / plugin-auth 579 ✅ / plugin-reports 50 ✅ / plugin-webhooks 25 ✅ / runtime 974 ✅ / spec 7160 ✅ / objectql 1450 ✅;改动包 typecheck ✅;`check:docs` ✅(生成物无漂移)。

## 遗留

另外四对别名在引擎层依然静默失效——一个未来的调用者写 `select`/`skip`/`populate` 会踩同样的坑,而选项类型是 `any`,编译期抓不到。这个更深的缺口(引擎应当对无法理解的查询键报错而非静默忽略)会按 PD #10 单独开 issue,不在本 PR 扩大范围。

Refs #4346, #4226, #3795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
