### PR TITLE
feat(lint): flow-node-write-unknown-field 覆盖 create_record(#4271)

### DIFF
--- a/.changeset/flow-create-record-write-lint.md
+++ b/.changeset/flow-create-record-write-lint.md
@@ -1,0 +1,49 @@
+---
+"@objectstack/lint": patch
+---
+
+feat(lint): `flow-node-write-unknown-field` covers `create_record` too (#4271)
+
+#4369 shipped the flow write-set gate on `update_record` alone and parked
+`create_record` in `FLOW_WRITE_NODE_TYPES_DEFERRED` with its reason — a gating
+rule earning its severity one measured surface at a time, recorded as data
+rather than left as silence. This measures the other half and moves it across.
+
+**The INSERT path fails the same way, one notch harder.** Same literal
+`config.fields` map, same `objectName` binding, same journey to the driver — the
+engine hands an undeclared key to `driver.create` verbatim, alongside the audit
+stamps. On SQLite/knex it becomes `table deal has no column named stagee` and
+the statement is rejected whole, so the correctly named fields in the same
+payload never land either. The extra harm is what does *not* exist afterwards:
+the row is never created, so every later node reading `{<node>.id}` from that
+node's `outputVariable` is working from a record that was never written. An
+`update_record` failure at least leaves the record intact.
+
+So the message now names that consequence on `create_record` and only there —
+"…and the record is never created at all" — instead of one sentence blurred to
+fit both.
+
+Nothing else moves: same rule id, same `error` severity, the same silent bails
+(templated `objectName`, non-literal `fields`, cross-package objects, objects
+declaring no fields, dotted keys), and `runAs` is still not consulted. Each skip
+is now pinned on the create surface as well as the update one, so the two node
+types cannot drift into different behaviour.
+
+**`FLOW_WRITE_NODE_TYPES_DEFERRED` is now empty and deliberately kept.** The
+partition test derives the full `fields`-write-map set behaviourally from the
+spec's executor-written config schemas, so a node type that grows one later
+belongs to neither list and fails that test until someone classifies it.
+Deleting the empty array would turn that forced decision back into a default.
+
+Two non-members are now excluded on the shape of their failure rather than by
+omission, both stated in the module header and one pinned by a test:
+`get_record.fields` is a projection (`z.array(z.string())`) — a READ, where an
+unknown entry narrows the selection instead of breaking the statement — and
+`screen.defaults` is forwarded into the `ScreenSpec` the client renders, so an
+unknown key is a prefill the renderer ignores. That inert "skips it and renders
+the rest" case is exactly what this rule's `error` severity is defined against.
+
+Verified against the repo's own apps: app-crm, app-todo and app-showcase all
+still validate clean with `create_record` covered — including crm's
+convert-lead flow, which creates an account and an opportunity before updating
+the lead.

--- a/packages/lint/src/validate-flow-node-writes.test.ts
+++ b/packages/lint/src/validate-flow-node-writes.test.ts
@@ -97,13 +97,36 @@ describe('FLOW_WRITE_NODE_TYPES — the covered-node ledger', () => {
     expect(classified).toEqual(withWriteMap);
   });
 
+  // Every write-map node type is covered as of #4371, so the deferred list is
+  // empty and the two tests below are vacuous TODAY. Both are kept live because
+  // they are what makes a FUTURE deferral honest: the partition test above
+  // forces a new node type into one list or the other, and these decide what
+  // the uncovered list is allowed to mean.
+  it('every covered type actually reports — the ledger describes behaviour, not intent', () => {
+    for (const type of FLOW_WRITE_NODE_TYPES) {
+      const findings = validateFlowNodeWrites({
+        objects: [dealObject],
+        flows: [
+          {
+            name: 'f',
+            nodes: [{ id: 'n', type, config: { objectName: 'deal', fields: { stagee: 'won' } } }],
+          },
+        ],
+      });
+      expect(findings.map((f) => f.rule), `covered type '${type}' reports nothing`).toEqual([
+        FLOW_NODE_WRITE_UNKNOWN_FIELD,
+      ]);
+      expect(findings[0].severity).toBe('error');
+    }
+  });
+
   it('gives every deferral a non-empty reason', () => {
     for (const deferral of FLOW_WRITE_NODE_TYPES_DEFERRED) {
       expect(deferral.reason.length, `deferral '${deferral.type}' carries no reason`).toBeGreaterThan(0);
     }
   });
 
-  it('leaves every deferred type unchecked — the ledger describes behaviour, not intent', () => {
+  it('leaves every deferred type unchecked', () => {
     for (const deferral of FLOW_WRITE_NODE_TYPES_DEFERRED) {
       const findings = validateFlowNodeWrites({
         objects: [dealObject],
@@ -116,6 +139,26 @@ describe('FLOW_WRITE_NODE_TYPES — the covered-node ledger', () => {
       });
       expect(findings, `deferred type '${deferral.type}' is being checked`).toEqual([]);
     }
+  });
+
+  // A node type NOT in the ledger at all must stay silent — the guard that the
+  // covered set is an allowlist rather than "anything with a fields key".
+  it('ignores a fields-bearing node type outside the ledger', () => {
+    const findings = validateFlowNodeWrites({
+      objects: [dealObject],
+      flows: [
+        {
+          name: 'f',
+          nodes: [
+            // `screen` carries `defaults`/`fields`, but an object-form screen
+            // forwards them to the client renderer — an unknown key there is an
+            // ignored prefill, not a write that reaches storage.
+            { id: 'n', type: 'screen', config: { objectName: 'deal', fields: { stagee: 'won' } } },
+          ],
+        },
+      ],
+    });
+    expect(findings).toEqual([]);
   });
 });
 
@@ -266,6 +309,80 @@ describe('validateFlowNodeWrites', () => {
     expect(validateFlowNodeWrites({ objects: [dealObject], flows: [byIndex] })[0].where).toBe(
       'flow "#0" › node "#0"',
     );
+  });
+
+  // ── create_record — the same map on the INSERT surface (#4371) ───────
+  it('errors when a create_record node writes a field the object never declares', () => {
+    const flow = {
+      name: 'seed_deal',
+      nodes: [
+        { id: 'start', type: 'start', config: {} },
+        {
+          id: 'seed',
+          type: 'create_record',
+          label: 'Seed deal',
+          config: { objectName: 'deal', fields: { name: 'ACME', stagee: 'won' }, outputVariable: 'created' },
+        },
+      ],
+    };
+    const findings = validateFlowNodeWrites({ objects: [dealObject], flows: [flow] });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('error');
+    expect(findings[0].path).toBe('flows[0].nodes[1].config.fields.stagee');
+    expect(findings[0].where).toBe('flow "seed_deal" › node "Seed deal"');
+    // The INSERT consequence is strictly worse than the UPDATE one and the
+    // message says so: the row never exists, so `{created.id}` downstream is
+    // reading from a record that was never written.
+    expect(findings[0].message).toContain('the record is never created at all');
+  });
+
+  it('names only the UPDATE consequence for an update_record node', () => {
+    const findings = validateFlowNodeWrites({
+      objects: [dealObject],
+      flows: [flowWith({ stagee: 'won' })],
+    });
+    expect(findings[0].message).not.toContain('never created at all');
+  });
+
+  it('takes every skip on create_record too', () => {
+    const createFlow = (config: Record<string, unknown>) => ({
+      name: 'f',
+      nodes: [{ id: 'c', type: 'create_record', config }],
+    });
+    // templated object, non-literal fields, unknown object, fieldless object
+    expect(
+      validateFlowNodeWrites({
+        objects: [dealObject],
+        flows: [createFlow({ objectName: '{target}', fields: { stagee: 1 } })],
+      }),
+    ).toEqual([]);
+    expect(
+      validateFlowNodeWrites({ objects: [dealObject], flows: [createFlow({ objectName: 'deal', fields: '{all}' })] }),
+    ).toEqual([]);
+    expect(
+      validateFlowNodeWrites({ objects: [], flows: [createFlow({ objectName: 'deal', fields: { stagee: 1 } })] }),
+    ).toEqual([]);
+    expect(
+      validateFlowNodeWrites({
+        objects: [{ name: 'deal', external: true }],
+        flows: [createFlow({ objectName: 'deal', fields: { stagee: 1 } })],
+      }),
+    ).toEqual([]);
+  });
+
+  it('does NOT flag a readonly field on create_record — INSERT is engine-exempt from that strip', () => {
+    // The readonly rule skips create_record entirely (a create may legitimately
+    // seed readonly columns). This rule asks a different question, so a DECLARED
+    // readonly field is clean here for its own reason: it resolves to a column.
+    const withReadonly = {
+      name: 'deal',
+      fields: { stage: { type: 'text' }, approval_status: { type: 'text', readonly: true } },
+    };
+    const findings = validateFlowNodeWrites({
+      objects: [withReadonly],
+      flows: [{ name: 'f', nodes: [{ id: 'c', type: 'create_record', config: { objectName: 'deal', fields: { approval_status: 'approved' } } }] }],
+    });
+    expect(findings).toEqual([]);
   });
 
   // ── the family boundary ──────────────────────────────────────────────

--- a/packages/lint/src/validate-flow-node-writes.ts
+++ b/packages/lint/src/validate-flow-node-writes.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 //
-// Author-time write-set check for a flow `update_record` node's `fields` — the
+// Author-time write-set check for a flow CRUD node's `fields` write map — the
 // THIRD surface in the family #4271 opened, and the one the docs spent the
 // longest recommending as the safe alternative to the other two.
 //
@@ -29,22 +29,26 @@
 // advisory. Nothing between the node and storage removes the key: the flow
 // executor calls the data engine directly (bypassing the metadata-protocol
 // ingress, which strips `readonly` — not unknown — keys anyway), the engine's
-// UPDATE path strips only readonly/readonlyWhen, and the SQL driver's
+// write paths strip only readonly/readonlyWhen, and the SQL driver's
 // `formatInput` / `applyWriteColumnMap` pass an unrecognized key straight
-// through (`m[k] ?? k`). Both halves were measured, not inferred:
+// through (`m[k] ?? k`). Every branch below was measured, not inferred:
 //
-//   • Through the engine, an undeclared key reaches `driver.update` verbatim,
-//     alongside the audit stamps.
-//   • On SQLite/knex it then becomes `update "deal" set "name" = 'n2',
+//   • Through the engine, an undeclared key reaches `driver.update` /
+//     `driver.create` verbatim, alongside the audit stamps.
+//   • On SQLite/knex an UPDATE becomes `update "deal" set "name" = 'n2',
 //     "stagee" = 'won' … → no such column: stagee`. The statement is rejected
 //     WHOLE: `name` — spelled correctly, in the same payload — does not land
 //     either, and the step fails with a driver error naming a column, far from
 //     the authoring mistake.
+//   • An INSERT fails the same way (`table deal has no column named stagee`),
+//     and one notch harder: the row is never created at all, so every later
+//     node that expected `{<node>.id}` is working from a record that does not
+//     exist.
 //   • On a schemaless datasource (memory, MongoDB) nothing rejects it, so the
 //     stray key is persisted into a column the object never declares — where no
 //     schema-driven read surface will return it.
 //
-// Neither outcome is "the rest still works". That is the same call
+// No outcome is "the rest still works". That is the same call
 // `validate-searchable-fields` makes for a stale entry and
 // `validate-flow-template-paths` makes for a filter-position token: gate when
 // the miss breaks or corrupts the operation, advise when it merely narrows the
@@ -52,12 +56,20 @@
 //
 // ─── Scope ──────────────────────────────────────────────────────────────────
 //
-// {@link FLOW_WRITE_NODE_TYPES} — today `update_record` alone — with the
-// deliberate non-member (`create_record`) declared as data in
-// {@link FLOW_WRITE_NODE_TYPES_DEFERRED} rather than left as silence, and the
-// two halves partition-tested against the CRUD node types that carry a `fields`
-// write map. A node type that grows one later fails that test until someone
-// classifies it.
+// {@link FLOW_WRITE_NODE_TYPES} — every CRUD node type that carries a `fields`
+// WRITE map: `update_record` (#4369) and `create_record` (#4371). The deferred
+// half, {@link FLOW_WRITE_NODE_TYPES_DEFERRED}, is now empty, and the partition
+// test still derives the full set behaviourally from the spec's
+// executor-written config schemas — so a node type that grows a write map later
+// lands on neither side and fails that test until someone classifies it.
+//
+// `get_record.fields` is NOT a member and never will be: it is a projection
+// (`z.array(z.string())`), a READ, and an unknown entry there narrows the
+// selection rather than breaking the statement. `screen.defaults` is not one
+// either — an object-form screen forwards it into the `ScreenSpec` the client
+// renders, so an unknown key is a form prefill the renderer ignores: inert, the
+// "skips it and renders the rest" case this rule's severity is defined against.
+// Both are excluded on the shape of their failure, not by omission.
 //
 // `runAs` is deliberately NOT consulted, unlike its readonly sibling. A
 // `runAs:'system'` flow is elevated past the readonly strip, which is why that
@@ -101,7 +113,7 @@ export const FLOW_NODE_WRITE_UNKNOWN_FIELD = 'flow-node-write-unknown-field';
 // a write map later cannot land on the uncovered side by nobody noticing.
 
 /** Flow node types whose `config.fields` keys this rule resolves. */
-export const FLOW_WRITE_NODE_TYPES: readonly string[] = ['update_record'];
+export const FLOW_WRITE_NODE_TYPES: readonly string[] = ['update_record', 'create_record'];
 
 /** A `fields`-bearing node type this rule does NOT cover yet, and why. */
 export interface FlowWriteNodeDeferral {
@@ -112,24 +124,21 @@ export interface FlowWriteNodeDeferral {
 }
 
 /**
- * `fields`-bearing CRUD node types deliberately left out of v1.
+ * `fields`-bearing CRUD node types deliberately left uncovered.
  *
- * `create_record` fails identically — same literal map, same `objectName`
- * binding, same driver fate — and covering it is one entry in
- * {@link FLOW_WRITE_NODE_TYPES} plus its fixtures. It is out of scope here only
- * because the reported gap (#4001 family, the `update_record` surface the docs
- * recommended) is the UPDATE one, and a gating rule earns its severity one
- * measured surface at a time. Recorded rather than omitted so the remaining
- * half is a decision on the record, not a discovery someone makes twice.
+ * **Empty, and that is the point.** #4369 shipped `update_record` alone and
+ * parked `create_record` here with its reason — a gating rule earning its
+ * severity one measured surface at a time — rather than leaving the other half
+ * as silence. #4371 measured the INSERT path (`table deal has no column named
+ * stagee`, and the row never created at all), found it strictly worse than the
+ * UPDATE one, and moved it across.
+ *
+ * The slot stays because the partition test derives the full `fields`-write-map
+ * set from the spec's own config schemas: a node type that grows one later
+ * belongs to neither list and fails that test until someone puts it in one.
+ * Deleting this array would turn that forced decision back into a default.
  */
-export const FLOW_WRITE_NODE_TYPES_DEFERRED: readonly FlowWriteNodeDeferral[] = [
-  {
-    type: 'create_record',
-    reason:
-      "same literal `config.fields` map and same `objectName` binding as update_record, so the check carries " +
-      'over verbatim; deferred only to land the gating severity on one surface first',
-  },
-];
+export const FLOW_WRITE_NODE_TYPES_DEFERRED: readonly FlowWriteNodeDeferral[] = [];
 
 type AnyRec = Record<string, unknown>;
 
@@ -231,7 +240,9 @@ export function validateFlowNodeWrites(stack: AnyRec): FlowNodeWriteFinding[] {
             `${node.type} writes '${fieldName}', but object '${objectName}' declares no such field. Nothing ` +
             `between the node and storage removes the key: on a SQL datasource the driver rejects the whole ` +
             `statement ('no such column'), so the correctly named fields in this same payload never land ` +
-            `either; on a schemaless one the stray key is persisted into a column no read surface returns.`,
+            `either${
+              node.type === 'create_record' ? ' and the record is never created at all' : ''
+            }; on a schemaless one the stray key is persisted into a column no read surface returns.`,
           hint: fixHint(fieldName, [...known]),
         });
       }


### PR DESCRIPTION
## 背景

#4369 只把 flow write-set gate 落在 `update_record` 上,把 `create_record` 连同理由一起停在 `FLOW_WRITE_NODE_TYPES_DEFERRED` —— gating 规则一次只用一个**实测过**的面来赚它的严重级,而且把剩下那一半写成数据而不是留成沉默。

本 PR 实测另一半,并把它移过来。

## INSERT 的失败方式一样,而且更狠一档

同一张字面 `config.fields`、同一个 `objectName` 绑定、同一条到 driver 的路径:引擎把未声明的 key 连同审计戳原样交给 `driver.create`。SQLite/knex 上变成:

```
insert into `deal` (`created_at`, `id`, `name`, `stagee`, `updated_at`) values (…) returning *
  - table deal has no column named stagee
```

语句整条被拒,同 payload 里拼对的字段也没落库。**多出来的伤害是事后什么都不存在**:行根本没被创建,于是后面每个从该节点 `outputVariable` 读 `{<node>.id}` 的节点,都在使用一条从未写入的记录。`update_record` 失败至少还留着原记录。

所以 message 只在 `create_record` 上加上 "…and the record is never created at all",而不是把一句话糊成两边都能套。

## 其余不动

同一个 rule id、同一个 `error` 严重级、同一批静默 bail(模板化 `objectName`、非字面 `fields`、跨包对象、零字段对象、点号 key),`runAs` 依然不看。每条 skip 现在在 create 面上也各有一条测试钉住,两个节点类型不会各走各的。

## 空的 deferred 列表是刻意保留的

partition 测试是**行为式**地从 spec 里 executor 推导出的 config schema 求出"带 `fields` 写 map 的节点类型"全集,所以将来某个类型长出写 map,它两边都不在,测试直接失败逼人分类。把这个空数组删掉,就是把这次强制决策退回成默认值。

## 两个非成员改为按失败形状排除,而非省略

- `get_record.fields` 是 projection(`z.array(z.string())`)—— 一个**读**,未知项让选择变窄,不会打断语句;
- `screen.defaults` 被 object-form screen 转发进客户端渲染的 `ScreenSpec`,未知 key 是渲染器忽略的预填。

后者正是这条规则的 `error` 严重级用来对照定义的那个"跳过它、其余照常渲染"的惰性情形。新增一条测试钉住:ledger 之外的节点类型即使带 `fields` 也保持沉默。

## 验证

- `@objectstack/lint` 42 文件 / 660 测试全绿(新增 6 条);`typecheck`、`check:doc-authoring` 干净。
- **三个 example 在 create_record 纳入覆盖后依然全部通过** —— 包括 crm 的 convert-lead 流(先建 account 和 opportunity,再更新 lead)。

文档无需改动:#4369 落下的那两处措辞说的是 "prefer a flow `update_record` node … the field-existence check gates there too",本次扩大覆盖没有让其中任何一句变假。

🤖 Generated with [Claude Code](https://claude.com/claude-code)