### PR TITLE
fix(spec,service-automation): registerFlow's remaining validators cover structured regions (#4389)

### DIFF
--- a/.changeset/region-validator-coverage.md
+++ b/.changeset/region-validator-coverage.md
@@ -1,0 +1,43 @@
+---
+'@objectstack/spec': patch
+'@objectstack/service-automation': patch
+---
+
+`registerFlow`'s remaining validators cover structured regions (#4389).
+
+#4347 closed the conversion and predicate halves of "metadata behaves differently
+depending on how deep it sits". Three validators were left walking `flow.nodes` only, so
+the same class stayed open one layer over: an ADR-0031 container keeps a whole sub-graph
+in its open `config`, and each of these checked *part* of the flow while reporting on all
+of it.
+
+- **`validateControlFlow` recurses.** A container nested inside another container's region
+  was never validated at registration — it reached run time, where `runRegion` →
+  `findRegionEntry` throws mid-iteration, after the enclosing loop has begun and its side
+  effects have landed. This cannot break a working flow: everything newly rejected was
+  already guaranteed to throw on execution. It also closes cycle detection over nested
+  regions, since region bodies are cycle-checked by `analyzeRegion` here rather than by
+  `detectCycles`.
+- **`validateNodeTypes` covers region nodes.** Soft-fail. A node in a `loop` body is as
+  executable as one beside it, so the warning that exists to predict `NO_EXECUTOR` went
+  quiet on exactly the nodes whose run-time failure is hardest to place.
+- **`validateNodeConfigKeys` covers region nodes.** Hard-fail. `visibleIf` is the typo
+  #4277 exists to catch, and moving the node into a region restored the silence #4277
+  closed. Violations carry the region (`loop 'sweep' body · node 'w' …`). No
+  double-reporting from the container side: all three container descriptors declare their
+  region slot as a bare `nodes: { type: 'array' }` with no `items`, so the schema-lockstep
+  walk stops there instead of descending twice.
+
+**Measured before extending the two hard-fail checks**, since widening a rejecting
+validator is a behaviour change rather than a bugfix: registering every flow in
+`app-showcase`, `app-crm` and `app-todo` through the real `registerFlow` and re-running
+each validator's own code over all 9 region graphs produced **0 new findings**. Nothing
+that registers today stops registering, so the checks land at their existing severity
+rather than staged through a warning window.
+
+`validateNodeInputSchemas` is deliberately **not** extended. It declares 0 uses across all
+159 example flow nodes, and its check compares a config value's runtime type against the
+declared one — so extending it would newly fail a region node carrying a `{var}` template
+string in a `number`-typed slot, which is a live authoring shape. Widening a check with a
+known false-positive mode and no demonstrated reader is not worth it; the traversal gap is
+noted on #4389 instead.

--- a/packages/services/service-automation/src/engine.ts
+++ b/packages/services/service-automation/src/engine.ts
@@ -2923,6 +2923,11 @@ export class AutomationEngine implements IAutomationService {
      * warned about (not rejected) so flows authored against a temporarily
      * absent plugin still register; the runtime surfaces a hard NO_EXECUTOR
      * error if such a node is actually executed.
+     *
+     * Covers nodes inside ADR-0031 regions (#4389). A node in a `loop` body is
+     * as executable as one beside it, so leaving regions out meant the warning
+     * that exists to predict NO_EXECUTOR went quiet on exactly the nodes whose
+     * failure is hardest to place at run time.
      */
     private validateNodeTypes(flowName: string, flow: FlowParsed): void {
         const known = new Set<string>([
@@ -2931,7 +2936,9 @@ export class AutomationEngine implements IAutomationService {
             ...this.actionDescriptors.keys(),
         ]);
         const unknown = [...new Set(
-            flow.nodes.map(n => n.type).filter(t => !known.has(t)),
+            collectFlowGraphs(flow)
+                .flatMap(g => g.nodes.map(n => n.type))
+                .filter(t => !known.has(t)),
         )];
         if (unknown.length > 0) {
             this.logger.warn(
@@ -2995,13 +3002,23 @@ export class AutomationEngine implements IAutomationService {
      */
     private validateNodeConfigKeys(flowName: string, flow: FlowParsed): void {
         const violations: string[] = [];
-        for (const node of flow.nodes) {
-            // `assignment` config keys are the author's variable names — see the
-            // exemption note above.
-            if (node.type === 'assignment') continue;
-            const schema = this.actionDescriptors.get(node.type)?.configSchema as ConfigSchemaNode | undefined;
-            if (!schema) continue;
-            this.collectUndeclaredConfigKeys(node, schema, node.config, 'config', violations);
+        // #4389 — every graph, not just the flow's own. `visibleIf` is the typo
+        // this check exists to catch, and moving the node into a `loop` body
+        // used to restore the silence #4277 closed. No double-reporting from the
+        // container side: all three container descriptors declare their region
+        // slot as a bare `nodes: { type: 'array' }` with no `items`, so the
+        // schema-lockstep walk stops there rather than descending twice.
+        for (const graph of collectFlowGraphs(flow)) {
+            const scoped: string[] = [];
+            for (const node of graph.nodes) {
+                // `assignment` config keys are the author's variable names — see the
+                // exemption note above.
+                if (node.type === 'assignment') continue;
+                const schema = this.actionDescriptors.get(node.type)?.configSchema as ConfigSchemaNode | undefined;
+                if (!schema) continue;
+                this.collectUndeclaredConfigKeys(node, schema, node.config, 'config', scoped);
+            }
+            for (const v of scoped) violations.push(graph.scope ? `${graph.scope} · ${v}` : v);
         }
         if (violations.length > 0) {
             throw new Error(

--- a/packages/services/service-automation/src/nested-region-parity.test.ts
+++ b/packages/services/service-automation/src/nested-region-parity.test.ts
@@ -21,9 +21,20 @@ import { AutomationEngine } from './engine.js';
 import type { NodeExecutor } from './engine.js';
 import { registerLoopNode } from './builtin/loop-node.js';
 import { registerLogicNodes } from './builtin/logic-nodes.js';
+import { registerCrudNodes } from './builtin/crud-nodes.js';
 
 function silentLogger() {
   return { info() {}, warn() {}, error() {}, debug() {}, child() { return silentLogger(); } } as any;
+}
+
+/** A logger that records `warn` lines, for the soft-fail validators. */
+function recordingLogger(sink: string[]) {
+  const l: any = {
+    info() {}, error() {}, debug() {},
+    warn(msg: string) { sink.push(String(msg)); },
+    child() { return l; },
+  };
+  return l;
 }
 function ctx() {
   return { logger: silentLogger(), getService() { return undefined; } } as any;
@@ -212,6 +223,126 @@ describe('#4347 — predicate validation covers region graphs', () => {
   it('rejects the SAME brace trap inside a loop body, naming the region', () => {
     expect(() => engine.registerFlow('trap', braceTrapFlow(true))).toThrow(/invalid expression/i);
     expect(() => engine.registerFlow('trap', braceTrapFlow(true))).toThrow(/loop 'loop' body/);
+  });
+});
+
+/**
+ * #4389 — the three registration validators #4347 left walking `flow.nodes`
+ * only. Same parity shape: identical bad metadata at the top level and one
+ * level in must get the identical verdict.
+ *
+ * Measured before extending them: 0 new findings across app-showcase / app-crm
+ * / app-todo (9 region graphs), so nothing that registers today stops.
+ */
+describe('#4389 — registration validators cover region graphs', () => {
+  /** Wrap `nodes` in a loop body when `nested`, else splice them in flat. */
+  const flowWith = (nested: boolean, bodyNodes: Array<Record<string, unknown>>) => ({
+    name: 'sweep', label: 'Sweep', type: 'schedule' as const, status: 'active' as const, runAs: 'system' as const,
+    nodes: [
+      { id: 'start', type: 'start', label: 'Start', config: { schedule: '0 0 * * *' } },
+      ...(nested
+        ? [{
+            id: 'loop', type: 'loop', label: 'Loop',
+            config: {
+              collection: [1], iteratorVariable: 'row',
+              body: { nodes: bodyNodes, edges: [] },
+            },
+          }]
+        : bodyNodes),
+    ],
+    edges: [{ id: 'e1', source: 'start', target: nested ? 'loop' : String(bodyNodes[0]!.id), type: 'default' as const }],
+  });
+
+  describe('validateNodeConfigKeys (hard-fail)', () => {
+    let engine: AutomationEngine;
+    beforeEach(() => {
+      engine = new AutomationEngine(silentLogger());
+      registerLoopNode(engine, ctx());
+      registerCrudNodes(engine, ctx());
+    });
+
+    // `fieldz` is not on the `create_record` descriptor — the #4277 typo class.
+    const typoNode = [{ id: 'w', type: 'create_record', label: 'W', config: { objectName: 'lead', fieldz: { a: 1 } } }];
+
+    it('rejects an undeclared config key at the top level (unchanged)', () => {
+      expect(() => engine.registerFlow('sweep', flowWith(false, typoNode))).toThrow(/undeclared config key/);
+    });
+
+    it('rejects the SAME key inside a loop body, naming the region', () => {
+      expect(() => engine.registerFlow('sweep', flowWith(true, typoNode))).toThrow(/undeclared config key/);
+      expect(() => engine.registerFlow('sweep', flowWith(true, typoNode))).toThrow(/loop 'loop' body · node 'w'/);
+    });
+
+    it('reports each nested key ONCE — the container config physically contains it', () => {
+      try {
+        engine.registerFlow('sweep', flowWith(true, typoNode));
+        throw new Error('expected a rejection');
+      } catch (err) {
+        const msg = (err as Error).message;
+        expect(msg).toMatch(/1 undeclared config key/);
+        expect(msg.match(/`fieldz`/g)).toHaveLength(1);
+      }
+    });
+
+    it('leaves a correct region alone', () => {
+      const ok = [{ id: 'w', type: 'create_record', label: 'W', config: { objectName: 'lead', fields: { a: 1 } } }];
+      expect(() => engine.registerFlow('sweep', flowWith(true, ok))).not.toThrow();
+    });
+  });
+
+  describe('validateNodeTypes (soft-fail)', () => {
+    const unknownNode = [{ id: 'x', type: 'no_such_node_type', label: 'X' }];
+
+    const warningsFor = (nested: boolean) => {
+      const warnings: string[] = [];
+      const engine = new AutomationEngine(recordingLogger(warnings));
+      registerLoopNode(engine, ctx());
+      engine.registerFlow('sweep', flowWith(nested, unknownNode));
+      return warnings.filter(w => w.includes('no registered executor'));
+    };
+
+    it('warns about an unknown node type at the top level (unchanged)', () => {
+      expect(warningsFor(false)).toHaveLength(1);
+    });
+
+    it('warns about the SAME type inside a loop body', () => {
+      const warnings = warningsFor(true);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('no_such_node_type');
+    });
+  });
+
+  describe('validateControlFlow (hard-fail)', () => {
+    let engine: AutomationEngine;
+    beforeEach(() => {
+      engine = new AutomationEngine(silentLogger());
+      registerLoopNode(engine, ctx());
+      engine.registerNodeExecutor({ type: 'mark', async execute() { return { success: true }; } } as NodeExecutor);
+    });
+
+    /** A two-entry (malformed) region — `analyzeRegion`'s single-entry rule. */
+    const malformed = { nodes: [{ id: 'a', type: 'mark', label: 'A' }, { id: 'b', type: 'mark', label: 'B' }], edges: [] };
+    const innerLoop = { id: 'inner', type: 'loop', label: 'Inner', config: { collection: [1], body: malformed } };
+
+    it('rejects a malformed region on a top-level container (unchanged)', () => {
+      expect(() => engine.registerFlow('sweep', flowWith(false, [innerLoop]))).toThrow(/single-entry/);
+    });
+
+    it('rejects a malformed region on a NESTED container, naming both levels', () => {
+      // Previously this registered clean and threw mid-run from `findRegionEntry`
+      // — after the outer loop had begun iterating.
+      expect(() => engine.registerFlow('sweep', flowWith(true, [innerLoop]))).toThrow(/single-entry/);
+      expect(() => engine.registerFlow('sweep', flowWith(true, [innerLoop])))
+        .toThrow(/loop 'loop' body → loop 'inner' body/);
+    });
+
+    it('leaves a well-formed nested container alone', () => {
+      const wellFormed = {
+        id: 'inner', type: 'loop', label: 'Inner',
+        config: { collection: [1], body: { nodes: [{ id: 'a', type: 'mark', label: 'A' }], edges: [] } },
+      };
+      expect(() => engine.registerFlow('sweep', flowWith(true, [wellFormed]))).not.toThrow();
+    });
   });
 });
 

--- a/packages/spec/src/automation/control-flow.zod.ts
+++ b/packages/spec/src/automation/control-flow.zod.ts
@@ -375,35 +375,52 @@ const MAX_REGION_DEPTH = 32;
 /**
  * Validate every structured control-flow construct in a flow, throwing on the
  * first malformed region (ADR-0031 — "reject the malformed before run"). Covers
- * `loop` bodies, `parallel` branches, and `try_catch` try/catch regions. Only
- * validates the *nested structure* when present, so legacy flat-graph `loop`
- * nodes (no `config.body`) are untouched — the constructs are additive.
+ * `loop` bodies, `parallel` branches, and `try_catch` try/catch regions —
+ * **at every depth** (#4389), so a container nested inside another container's
+ * region is checked too. Only validates the *nested structure* when present, so
+ * legacy flat-graph `loop` nodes (no `config.body`) are untouched — the
+ * constructs are additive.
  *
- * Intended to be called from `registerFlow()` after DAG cycle detection.
+ * The recursion is not extra strictness looking for work: a malformed nested
+ * region already failed, just later and worse. `runRegion` calls
+ * `findRegionEntry`, which throws mid-run — after the enclosing container has
+ * begun iterating and its side effects have landed. Refusing it at
+ * `registerFlow` is what ADR-0031's "reject the malformed before it can run"
+ * asks for, and it cannot break a flow that works today: everything newly
+ * rejected here was already guaranteed to throw on execution.
+ *
+ * Intended to be called from `registerFlow()` after DAG cycle detection. Region
+ * bodies are cycle-checked here rather than by `detectCycles` — `analyzeRegion`
+ * carries its own DAG pass — so this recursion is also what closes cycle
+ * detection over nested regions.
  */
 export function validateControlFlow(flow: { nodes: FlowNodeParsed[] }): void {
-  for (const node of flow.nodes) {
-    const cfg = node.config as Record<string, unknown> | undefined;
-    if (!cfg) continue;
-    if (node.type === PARALLEL_NODE_TYPE && Array.isArray(cfg.branches) && cfg.branches.length < 2) {
-      throw new Error(`parallel '${node.id}': a parallel block needs at least 2 branches`);
-    }
-    for (const slot of regionSlotsOf(node)) {
-      const parsed = slot.schema.safeParse(slot.raw);
-      if (!parsed.success) {
-        throw new Error(
-          `${slot.label}: invalid region — ${parsed.error.issues.map(i => i.message).join('; ')}`,
-        );
+  for (const graph of collectFlowGraphs(flow)) {
+    for (const node of graph.nodes) {
+      const cfg = node.config as Record<string, unknown> | undefined;
+      if (!cfg) continue;
+      if (node.type === PARALLEL_NODE_TYPE && Array.isArray(cfg.branches) && cfg.branches.length < 2) {
+        throw new Error(`parallel '${node.id}': a parallel block needs at least 2 branches`);
       }
-      // Both region schemas produce `{ nodes, edges }` (a parallel branch adds
-      // `name` — a superset); `z.ZodTypeAny` just cannot say so.
-      const analysis = analyzeRegion(parsed.data as { nodes: FlowNodeParsed[]; edges?: FlowEdgeParsed[] });
-      if (analysis.errors.length > 0) {
-        throw new Error(`${slot.label}: ${analysis.errors.join('; ')}`);
+      for (const slot of regionSlotsOf(node)) {
+        const where = graph.scope ? `${graph.scope} → ${slot.label}` : slot.label;
+        const parsed = slot.schema.safeParse(slot.raw);
+        if (!parsed.success) {
+          throw new Error(
+            `${where}: invalid region — ${parsed.error.issues.map(i => i.message).join('; ')}`,
+          );
+        }
+        // Both region schemas produce `{ nodes, edges }` (a parallel branch adds
+        // `name` — a superset); `z.ZodTypeAny` just cannot say so.
+        const analysis = analyzeRegion(parsed.data as { nodes: FlowNodeParsed[]; edges?: FlowEdgeParsed[] });
+        if (analysis.errors.length > 0) {
+          throw new Error(`${where}: ${analysis.errors.join('; ')}`);
+        }
       }
     }
   }
 }
+
 
 // ─── Region normalization ────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #4389. 接 #4347 / #4381。

## 问题

#4347 修掉了「元数据随嵌套深度而变」的**转换**和**谓词校验**两半。`registerFlow` 里还剩三个校验器只遍历 `flow.nodes` —— ADR-0031 容器把整张子图放在自己开放的 `config` 里,于是它们各自都在「只校验了一部分、却按整个 flow 汇报」。

## 先量,再改

两个是 hard-fail。**扩大一个会拒绝的校验器的遍历范围是行为变更,不是 bugfix** —— 所以先测量,而不是先动手。

测量方式是把三个 example app 的全部 flow 通过**真正的 `registerFlow`** 注册(转换 + parse + region 归一化都走完),再用 `collectFlowGraphs` 取出每个非顶层 graph,对它跑**各校验器自己的代码**(私有方法直接调用,不重写检查逻辑):

```
━━━ examples/app-crm        flows 1/1     region graphs 0
━━━ examples/app-showcase   flows 29/29   region graphs 9
━━━ examples/app-todo       flows 4/4     region graphs 0

━━━ TOTAL
    validateControlFlow      0
    validateNodeTypes        0
    validateNodeConfigKeys   0
    validateNodeInputSchemas 0
```

**0 新增违规**。所以三个校验器按现有严重级别直接落地,不需要走 #4059 → #4277 那条 warn-then-error 阶梯。

样本确实薄(9 个 region graph / 9 个 region 节点),但风险不对称地小,理由见下。

## 改动

### `validateControlFlow` 递归(hard-fail)

嵌套在别的容器 region 里的容器,注册期从来没被校验过 —— 它会一路走到运行时,由 `runRegion` → `findRegionEntry` 在**迭代中途**抛出,此时外层 loop 已经开跑、副作用已经落地。这正是 ADR-0031 的「reject the malformed before it can run」要避免的。

**这一条不可能弄坏能正常工作的 flow**:新被拒绝的东西本来就注定在执行时抛异常,只是从「跑到一半炸」提前成「注册期拒绝」。

顺带补上了嵌套 region 的环检测 —— region body 的环是由 `analyzeRegion` 查的(不是 `detectCycles`),所以这次递归同时把那个洞也关了,`detectCycles` 不需要单独改。

### `validateNodeTypes` 覆盖 region 节点(soft-fail)

零风险。loop body 里的节点和它旁边的节点一样会被执行,漏掉 region 意味着这条「预测 `NO_EXECUTOR`」的警告恰好在最难定位运行时失败的那批节点上失声。

### `validateNodeConfigKeys` 覆盖 region 节点(hard-fail)

`visibleIf` 正是 #4277 要抓的拼写错误,而把节点挪进 region 就能恢复 #4277 关掉的那种静默。违规信息带上 region:

```
loop 'sweep' body · node 'w' (create_record): unknown config key `fieldz` at config.fieldz — did you mean `fields`?
```

**不会从容器侧重复报**:三个容器 descriptor 都把 region 槽声明成裸的 `nodes: { type: 'array' }`(无 `items`),所以 schema 对位遍历到那里就停,不会再下探一遍。有测试钉住这一点。

## 刻意不改 `validateNodeInputSchemas`

它同样只走顶层,但**不扩**,两个理由:

1. 三个 app 的 **159 个 flow 节点里声明 `inputSchema` 的是 0 个** —— 没有实证读者。
2. 它拿 config 值的运行时类型和声明类型比(`actualType !== paramDef.type`)。扩进 region 会让一个在 `number` 类型槽里写 `{var}` 模板字符串的 region 节点**新失败** —— 而那是活着的作者写法。

给一个已知有误报模式、又没有实证价值的检查扩大范围不划算。这个遍历缺口记在 #4389 上,没有顺手做。

## 测试

`nested-region-parity.test.ts` 新增 9 个用例(该文件共 22 个),每组都是**对称性对照** —— 同一份坏元数据,一次放顶层、一次放 loop body,判定必须一致:

- `validateNodeConfigKeys`:顶层拒 / region 里也拒且带 region 名 / **每个嵌套键只报一次** / 正确的 region 不动
- `validateNodeTypes`:顶层警告 / region 里也警告
- `validateControlFlow`:顶层容器的畸形 region 被拒 / **嵌套**容器的畸形 region 也被拒且路径带两层(`loop 'loop' body → loop 'inner' body`)/ 良构的嵌套容器不动

**非空断言已验证**:把两个源文件 stash 掉重新构建后跑,恰好这 4 个嵌套用例失败、18 个通过。

## 验证

| gate | 结果 |
|:---|:---|
| `pnpm build` | 71/71 ✅ |
| `pnpm test` | 132/132 ✅ |
| `pnpm typecheck` | 119/119 ✅ |
| `pnpm lint` | ✅ |
| `check:generated` | 8/8 ✅ |

## 另注:三份 region 槽位表

#4388(晚 8 分钟合入)在 `packages/lint/src/flow-walk.ts` 引入了第三份「region 住在哪里」的声明,和 `spec/conversions/walk.ts` 的 `FLOW_REGION_SLOTS`、`spec/automation/control-flow.zod.ts` 的 `regionSlotsOf` 并存;lint 包内部现在也是两个 walker 并行(`validate-expressions.ts` 用 `collectFlowGraphs`,另外四条规则用 `flow-walk.ts`)。

本 PR **没有动它** —— 那是另一条轴上的问题,而且是别人刚落地的模块。会另开 issue 提合并方案。

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSBbKMdDgHjGpQdrvQUQXj)_