### PR TITLE
test(cli): 钉住三个命令都跑 reference-integrity suite(#4384)

### DIFF
--- a/.changeset/reference-integrity-wiring-guard.md
+++ b/.changeset/reference-integrity-wiring-guard.md
@@ -1,0 +1,24 @@
+---
+---
+
+Test-only: a structural wiring guard so the drift #4394 just fixed cannot come
+back silently (#4384).
+
+#4394 removed the *instance* — `validateReadonlyFlowWrites` had been hand-wired
+into `os validate` and `os compile` and never into `os lint`, so an `error`-level
+gate left `os lint` passing stacks `os compile` refuses. It did not remove the
+*failure mode*: nothing stops the next rule from being wired into two commands
+out of three, and that defect produces no failing assertion anywhere — each
+command's tests pass, the rule's unit tests pass, and the only symptom is the
+three commands disagreeing about one stack. That is how the last one survived
+from #3425 until #4394.
+
+`reference-integrity-wiring.test.ts` asserts each of the three commands calls
+`validateReferenceIntegrity`, and that none of them imports a suite member
+directly — the import being what a second call site starts with. It scans source
+rather than spying, for the reason `lazy-deps.test.ts` does: vitest inlines
+imports, so a module-cache probe cannot prove which symbols a command file
+actually reaches for. Verified to FAIL on a reintroduced direct import, not
+merely to pass today.
+
+Releases nothing.

--- a/packages/cli/src/commands/reference-integrity-wiring.test.ts
+++ b/packages/cli/src/commands/reference-integrity-wiring.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// Structural wiring guard for the suite's whole reason to exist (#3583 §5 D5).
+//
+// ## Why a test and not a comment
+//
+// The defect this catches is not a wrong result — it is a MISSING CALL, and a
+// missing call produces no failing assertion anywhere. Every command's own
+// tests pass, the rule's unit tests pass, and the only symptom is that
+// `os validate`, `os lint` and `os compile` disagree about the same stack.
+//
+// That is not hypothetical. `validateReadonlyFlowWrites` was hand-wired into
+// `validate` and `compile` and never into `lint` from #3425 until #4394 — and
+// because it GATES (`flow-update-readonly-field` is an `error`), `os lint`
+// spent that whole time returning clean for stacks `os compile` refuses. The
+// suite's own header had been naming it as the standing proof of the drift the
+// suite exists to end, which is a comment doing a test's job. #4394 removed
+// that instance; this file removes the failure MODE, so the next rule cannot
+// repeat it silently (#4384).
+//
+// ## The invariant
+//
+// `os lint` ⊇ `os compile`'s gate set. `lint` is the cheap pre-flight and
+// `compile` is the gate; a green `lint` followed by a red `compile` makes the
+// pre-flight worthless — and for an agent it is worse than worthless, because
+// the remaining options are re-verifying everything (slow) or learning to
+// distrust the signal (dangerous).
+//
+// ## Why it scans source
+//
+// vitest inlines imports through its transform, so a spy on `@objectstack/lint`
+// cannot prove which symbols a command file actually reaches for — the same
+// reason `lazy-deps.test.ts` scans `src/` rather than probing a module cache.
+// Behavioural coverage of what the suite CONTAINS lives in
+// `@objectstack/lint`'s `reference-integrity-suite.test.ts`; this file guards
+// only the seam between that suite and the three call sites.
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+import { REFERENCE_INTEGRITY_RULES } from '@objectstack/lint';
+
+const commandsDir = dirname(fileURLToPath(import.meta.url));
+
+/** The three commands that must hold a stack to the same author-time bar. */
+const AUTHORING_COMMANDS = ['validate.ts', 'lint.ts', 'compile.ts'] as const;
+
+const sourceOf = (file: string) => readFileSync(join(commandsDir, file), 'utf8');
+
+describe('reference-integrity wiring (#3583 §5 D5, #4384)', () => {
+  it.each(AUTHORING_COMMANDS)('%s runs the suite', (file) => {
+    expect(sourceOf(file)).toMatch(/\bvalidateReferenceIntegrity\s*\(/);
+  });
+
+  // The regression itself. A second, per-rule call site is how a rule ends up
+  // on two commands out of three, and it always starts with importing that rule
+  // by name — so the import is what this asserts on. Catching the call instead
+  // would miss the window between adding the import and adding the second call.
+  it.each(AUTHORING_COMMANDS)('%s does not import a suite member directly', (file) => {
+    const source = sourceOf(file);
+    const reached = REFERENCE_INTEGRITY_RULES.map((r) => r.name).filter((name) =>
+      new RegExp(
+        String.raw`^\s*import\s[^;]*\b${name}\b[^;]*from\s*['"]@objectstack/lint['"]`,
+        'm',
+      ).test(source),
+    );
+    expect(
+      reached,
+      `${file} imports suite member(s) directly — run them via validateReferenceIntegrity instead, ` +
+        `or all three commands will drift the way validateReadonlyFlowWrites did (#4394)`,
+    ).toEqual([]);
+  });
+
+  // Guards the guard: were the suite ever emptied or the export renamed, the
+  // assertions above would pass vacuously while checking nothing.
+  it('the suite is non-empty, so the assertions above are not vacuous', () => {
+    expect(REFERENCE_INTEGRITY_RULES.length).toBeGreaterThan(0);
+    // The rule whose absence from `os lint` is the reason this file exists.
+    expect(REFERENCE_INTEGRITY_RULES.map((r) => r.name)).toContain('validateReadonlyFlowWrites');
+  });
+});


### PR DESCRIPTION
Closes #4384

## 这个 PR 补的是什么

[#4394](https://github.com/objectstack-ai/objectstack/pull/4394) 已经修掉了**那一例** —— `validateReadonlyFlowWrites` 手工接进 `os validate` 和 `os compile`,唯独漏了 `os lint`,而它是 **error 级**,于是 `os lint` 长期放行 `os compile` 会拒绝的 stack。

但它没有修掉**失败模式本身**:今天仍然没有任何东西能阻止下一条规则被接进三个命令里的两个。

而这类缺陷的特点是**不会有任何测试变红** —— 每个命令自己的测试都过,规则的单测也过,唯一症状就是三个命令对同一个 stack 给出不同答案。上一次就是这么从 #3425 一直活到 #4394 的,期间 suite 头注释里把它称作 "the standing proof of the drift the suite exists to end" —— **一条注释在干测试的活**。

## 钉住的不变量

**`os lint` ⊇ `os compile` 的门禁集。**

lint 是廉价预检,compile 是门禁。lint 绿、compile 红,预检就没有存在意义;对 agent 更糟 —— 剩下的选择只有"全量重验"(慢)或"学会不信任这个信号"(危险)。

## 三条断言

1. 三个命令都调用 `validateReferenceIntegrity`;
2. 三个命令都**不**直接 import suite 成员 —— 第二个调用点总是从这行 import 开始,所以卡 import 能堵住"加了 import 但还没加调用"的那个窗口;
3. suite 非空且含 `validateReadonlyFlowWrites` —— 防止前两条在 suite 被清空或导出改名后**空转通过**。

## 为什么扫源码而不是打桩

vitest 会把 import 内联进 transform,所以对 `@objectstack/lint` 打 spy 证明不了命令文件到底 reach 了哪些符号 —— 和 `lazy-deps.test.ts` 扫 `src/` 是同一个理由。

suite **内容**的行为覆盖在 `@objectstack/lint` 的 `reference-integrity-suite.test.ts`;本文件只守 suite 与三个调用点之间那道缝。

## 反向验证

不是"今天能过"就算数。在 `compile.ts` 里加回一行直接 import,它确实失败:

```
× compile.ts does not import a suite member directly
```

## 范围

纯测试,无运行时/行为变更。`@objectstack/cli` 65 文件 / 636 测试全绿,`typecheck` 干净。空 changeset。

---

顺带说明为什么只提这一条:我原本按 #4384 的分析做了一版"家族 + 组合层"(把 suite 的成员判据和"哪些命令跑"拆开),做到一半发现 #4394 已经先合入了。实测确认症状已消失(同一 fixture 下 `os lint` 现在 exit 1),所以那版重构的核心价值归零,我 abort 了。

剩下一个可以讨论但**不在本 PR 范围**的点:`validateReadonlyFlowWrites` 问的是"名字解析得到、但写会不会生效",而 suite 的判据写的是"名字能否解析"。#4394 的理由是"它走的是同一张 map"——这是邻近性论证。要不要为此调整 suite 的判据表述,是维护者的取舍,我没有在这里动它。

🤖 Generated with [Claude Code](https://claude.com/claude-code)