### PR TITLE
fix(spec): 不再承诺根本不会跑的校验，并让严格性账本闸门看见嵌套目录（#4001）

### DIFF
--- a/.changeset/strictness-ledger-recursive-coverage.md
+++ b/.changeset/strictness-ledger-recursive-coverage.md
@@ -1,0 +1,13 @@
+---
+'@objectstack/spec': patch
+---
+
+Datasource unknown-key guidance no longer promises validation that does not happen, and the #4001 strictness ledger sees nested schema directories.
+
+Two related corrections to the #4001 unknown-key campaign, both about a check reporting more coverage than it had.
+
+**The `config` prescription was false.** When `DatasourceSchema` rejects a connection detail written at the top level, it prescribed: "Move it to `config: { host: … }`; the driver's own configSchema validates it there." Nothing validates it there — `DriverDefinitionSchema.configSchema` is a `z.record` that both bundled driver specs set to `{}`, and no consumer reads it. The message therefore took an author who had made a recoverable mistake at a place that now catches it and pointed them at a slot where the same mistake is silent again: `config: { hostname: … }` is dropped and the datasource connects on localhost. The guidance now names the per-driver shape to write against (`PostgresConfigSchema` / `MongoConfigSchema` / `MemoryConfigSchema`) instead of promising a gate. Enforcement is tracked in #4410. The same false claim is removed from `data/driver/mongo.zod.ts`, whose header advertised that the Platform validates `datasource.config` with it.
+
+No authorable key changed — this is error-message and documentation text only.
+
+**The ledger gate's coverage walk was one level deep.** `check:strictness-ledger` promises that every `*.zod.ts` with sites in a triaged directory carries a classification row. It listed each directory non-recursively, so `data/driver/` — three per-driver config files, nine authorable sites — was invisible to it while it printed "no undeclared schema files". The walk is now recursive (nested files declare as `driver/postgres.zod.ts`), those three files are classified in the ledger, and `scripts/strictness-ledger.test.ts` pins the recursion — necessary because with the rows in place the gate itself passes either way and cannot catch its own regression.

--- a/content/docs/releases/v17.mdx
+++ b/content/docs/releases/v17.mdx
@@ -412,8 +412,12 @@ schema to the two highest-risk authorable surfaces, per the triage in
 - **Datasources** — `DatasourceSchema` with its `pool` / `healthCheck` / `ssl` /
   `retryPolicy` blocks, the ADR-0015 `external` federation settings and their
   `validation` policy, `DatasourceCapabilities`, and `DriverDefinitionSchema`.
-  `config` and `readReplicas` stay **open** records: their shape is per-driver
-  and the driver's own `configSchema` validates them. That openness is why the
+  `config` and `readReplicas` stay **open** records: their shape is per-driver.
+  Nothing validates *inside* them — an earlier version of this note said the
+  driver's own `configSchema` did, which was wrong; the per-driver schemas exist
+  (`PostgresConfigSchema` and siblings) but nothing parses `config` against
+  them, tracked as #4410. So a misspelling one level *down* is still silent
+  today. That openness is why the
   top level had to close — a connection key written one level too high (`host`
   next to `driver` instead of inside `config`) was stripped, and the datasource
   then connected on driver defaults rather than failing. Those keys now

--- a/docs/audits/2026-07-unknown-key-strictness-ledger.md
+++ b/docs/audits/2026-07-unknown-key-strictness-ledger.md
@@ -101,6 +101,18 @@ dropped at parse, and nothing failed.
    now aliases to `expanded`. Note where this one was found: not in a tenant
    project, but in first-party platform metadata that had been shipping for
    releases.
+7. **This campaign's own fix signposted the way into the failure mode it
+   exists to kill.** The strict rejection on a misplaced `host` prescribed:
+   "Move it to `config: { host: … }`; the driver's own configSchema validates
+   it there." False twice over — `DriverDefinitionSchema.configSchema` is a
+   `z.record` that both bundled driver specs set to `{}`, and nothing in the
+   repo reads it. So an author who made a *recoverable* mistake at a place that
+   now catches it was directed, with the platform's authority, at a slot where
+   the same mistake is silent again: `config: { hostname: … }` is stripped and
+   the datasource connects on localhost — #4001's original bug verbatim, one
+   level down. Corrected to name the per-driver shape instead of promising a
+   gate; enforcement is #4410. **A wrong instruction is worse than none**, and
+   worst for an AI author, whose only signal is whether the parse complained.
 
 This is the empirical argument for the ratchet: the inference "no metadata in
 the repo carries unknown keys" was **false three times over**, and only the
@@ -146,7 +158,7 @@ tightening (the #4001 "sharing-rule lesson": candidates, not verdicts).
 | `notification.zod.ts` / `offline.zod.ts` / `report.zod.ts` | 3 ea | authorable (p) | |
 | `sharing.zod.ts` | 2 | authorable (p) | public-sharing config |
 
-### `data/` — 149 sites
+### `data/` — 158 sites
 
 | File | Sites | Class | Note |
 |---|---|---|---|
@@ -157,7 +169,8 @@ tightening (the #4001 "sharing-rule lesson": candidates, not verdicts).
 | `field.zod.ts` | 11 | authorable | partially strict |
 | `filter.zod.ts` / `query.zod.ts` | 11+5 | open | query dialect — user data flows through; validated semantically elsewhere. `query.zod.ts` dropped one site in #4196: `FieldNodeSchema`'s nested-select object form was declared-but-inert and narrowed to `z.string()`, so the union's second member is gone. Four more left in #4286 with the `joins`/`windowFunctions` removals: `JoinNodeBaseSchema`, `WindowFunctionNodeSchema`, and `WindowSpecSchema`'s two blocks (outer + `frame`) were deleted with their clusters. Class unchanged |
 | `driver-nosql.zod.ts` / `driver.zod.ts` / `driver-sql.zod.ts` | 10+9+2 | wire | driver capability contracts |
-| `datasource.zod.ts` | 9 | authorable | **strict as of #4001 data step** — all 9: `DatasourceSchema` (+ `pool` / `healthCheck` / `ssl` / `retryPolicy`), `ExternalDatasourceSettingsSchema` (+ `validation`), `DatasourceCapabilities`, `DriverDefinitionSchema`. `config` + `readReplicas` stay `z.record` by construction (per-driver shapes; the driver's own `configSchema` validates them) — which is precisely why the top level had to close: a connection key written one level too high was stripped, and the datasource then connected on driver defaults instead of failing |
+| `datasource.zod.ts` | 9 | authorable | **strict as of #4001 data step** — all 9: `DatasourceSchema` (+ `pool` / `healthCheck` / `ssl` / `retryPolicy`), `ExternalDatasourceSettingsSchema` (+ `validation`), `DatasourceCapabilities`, `DriverDefinitionSchema`. `config` + `readReplicas` stay `z.record` by construction (per-driver shapes — see the `driver/` row below). This row used to add "the driver's own `configSchema` validates them"; **it does not, and never did** — corrected, and the gap is #4410. Which is precisely why the top level had to close: a connection key written one level too high was stripped, and the datasource then connected on driver defaults instead of failing |
+| `driver/memory.zod.ts` / `driver/mongo.zod.ts` / `driver/postgres.zod.ts` | 6+1+2 | authorable | The per-driver shapes for the `config` slot — what an author actually writes under `datasource.config` (`host`, `port`, `filename`, pool sizes). **Undeclared here until the coverage walk went recursive** (see below): a subdirectory was invisible to the gate, so these nine sites sat outside the map while the map reported full coverage. Authorable by the rule, but they are **contract-only exports today** — nothing parses `datasource.config` against them and both `*DriverSpec.configSchema` literals are `{}` (#4410). Strictness here would therefore enforce nothing; this row is blocked on #4410 giving it a parse site, not on a verification pass |
 | `analytics.zod.ts` | 8 | mixed (p) | |
 | `document.zod.ts` | 8 | wire (p) | |
 | `hook.zod.ts` / `hook-body.zod.ts` | 6+2 | mixed | **strict as of #4001 data step** for the AUTHORING shapes: `HookSchema` (+ `retryPolicy`) and both body branches (`ExpressionBodySchema` / `ScriptBodySchema`). `HookContextSchema` and its `session` / `provenance` / `user` blocks are the RUNTIME shape the engine hands a handler — they stay tolerant, and must: strictness there would make an engine-internal enrichment (as `provenance` was in #3712) a breaking change for anyone parsing a context they were given. The file's old blanket `authorable (p)` was too wide — verification split it |
@@ -219,6 +232,32 @@ tightening (the #4001 "sharing-rule lesson": candidates, not verdicts).
 1. Let the warning layer run in the wild for a release, then schedule the v18
    strict close-out on what it actually reports — which is the whole point of
    having built it. Nothing more to do here until there is field data.
+
+   **This wait has a decision point, deliberately.** "Wait for field data" with
+   no way to tell when it has arrived is how a ratchet stops without anyone
+   choosing to stop it — and this file would go on describing an in-flight
+   campaign either way. So the wait is discharged by an answerable question, not
+   by a date: *has `lintUnknownAuthoringKeys` reported an unknown key on any
+   surface outside this repo yet?* Three outcomes, each with a next action:
+   - **Findings exist** → they are the close-out worklist. Tighten the shapes
+     they name first; that is the evidence the whole layer was built to produce.
+   - **Zero findings, and the layer is reaching real authors** → the tail is
+     cheaper than feared and the remaining directories can be batched by class
+     rather than one shape at a time.
+   - **Zero findings because nothing is reporting back** → then the layer is not
+     instrumented, and *that* is the next task, not more strictness. This is the
+     outcome to actually check for: it is indistinguishable from success at a
+     glance, which is this campaign's own subject matter.
+
+   Whoever reads this next: answer the question and record the answer here, even
+   if the answer is "still nothing". A wait that is never re-examined is
+   indistinguishable from an abandoned one.
+
+2. `studio/` is the largest untouched authorable block — 27 sites, **0 strict**,
+   and all three files still carry a provisional `(p)` from the original triage.
+   Not blocked on field data (Studio-written JSON is our own producer, so the
+   downstream risk is the lowest on the board); it is simply unstarted. If the
+   step-1 question comes back "nothing is reporting", start here instead.
 
 Done in step 2: `security/rls.zod.ts` + `security/sharing.zod.ts` strict;
 `PositionSchema` strict with the protection envelope declared (closing the
@@ -303,9 +342,11 @@ checkable, so this map cannot go stale in silence again:
   matches means schemas were added or removed under a `Class` verdict nobody
   re-examined. Touching a file forces you back through this ledger.
 - **Coverage.** Every `*.zod.ts` in a triaged directory that HAS sites must have
-  a row. A new one is undeclared surface. Zero-site files (pure enum/token
-  modules like `data/date-macros.zod.ts`) are skipped — there is nothing to
-  classify — and become reportable the day they grow their first `z.object(`.
+  a row. A new one is undeclared surface. The walk is **recursive**; nested files
+  are declared by their path relative to the section directory
+  (`driver/postgres.zod.ts`). Zero-site files (pure enum/token modules like
+  `data/date-macros.zod.ts`) are skipped — there is nothing to classify — and
+  become reportable the day they grow their first `z.object(`.
 - **Section totals**, and that any row claiming "strict as of" names a file that
   really contains `.strict()`.
 
@@ -336,5 +377,23 @@ precisely the intended behaviour: the file arrived, so someone had to classify
 it. It is now a row. Every existing count survived that merge unchanged, so the
 failure was exactly as narrow as it should have been.
 
+**And then the gate turned out to have the ledger's own disease.** Its coverage
+walk listed each triaged directory exactly one level deep, so `data/driver/` —
+three per-driver connection-config files, nine sites — was invisible to the check
+whose entire promise is "no undeclared surface". The gate printed *"no undeclared
+schema files"* while nine authorable sites sat outside the map. Fixed by making
+the walk recursive; the three files are now a row.
+
+Read that next to this file's own opening argument — *a map that drifts is worse
+than no map, because it is followed*. The same asymmetry applies one level up,
+and harder: **a gate that under-reports is worse than no gate, because it
+converts "I should classify this" into "it is already classified."** No gate
+leaves a reader suspicious; a green gate retires their suspicion. That is the
+identical shape to the silent strip this whole campaign is about — a success
+signal covering an omission — reproduced in the instrument built to detect it.
+So when a check claims coverage, prove it sees something it is supposed to see
+before trusting the green: this one was verified by watching it go red on
+`data/driver/` and green again only once the rows existed.
+
 Long tail stays gated on a verification pass per shape — never a one-shot
-"make all ~453 sites strict" (ADR-0054 ratchet; #4001's own recommendation).
+"make all ~500 sites strict" (ADR-0054 ratchet; #4001's own recommendation).

--- a/packages/spec/scripts/check-strictness-ledger.mts
+++ b/packages/spec/scripts/check-strictness-ledger.mts
@@ -23,10 +23,14 @@
 //      touching a file forces you back through the ledger.
 //   2. Coverage. Every `*.zod.ts` under a triaged directory that HAS `z.object(` sites
 //      must appear in that directory's table. A new one is undeclared surface —
-//      exactly what the ledger exists to prevent. Files with zero sites (pure enum /
-//      token modules like `data/date-macros.zod.ts`) are skipped: the ledger classifies
-//      sites, and they have none to classify. This is not a hole — the day such a file
-//      grows its first `z.object(` it becomes undeclared and this gate says so.
+//      exactly what the ledger exists to prevent. The walk is RECURSIVE; nested files
+//      are declared by their path relative to the section directory
+//      (`driver/postgres.zod.ts`). It was not recursive at first, and `data/driver/`
+//      sat undeclared behind that — see the ledger's note on it. Files with zero sites
+//      (pure enum / token modules like `data/date-macros.zod.ts`) are skipped: the
+//      ledger classifies sites, and they have none to classify. This is not a hole —
+//      the day such a file grows its first `z.object(` it becomes undeclared and this
+//      gate says so.
 //   3. Section totals. `### \`ui/\` — 192 sites` must equal the sum of its rows.
 //      Cheap, and it catches a row edited without updating the header.
 //   4. Strictness claims. A row whose note says "strict as of" must name a file that
@@ -47,6 +51,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import url from 'node:url';
+
+import { countSites, listSchemaFiles } from './lib/strictness-ledger';
 
 const HERE = path.dirname(url.fileURLToPath(import.meta.url));
 const SPEC = path.resolve(HERE, '..');
@@ -77,11 +83,6 @@ function parseCounts(cell: string, fileCount: number): number[] | null {
   const nums = parts.map(Number);
   if (nums.length === 1 && fileCount > 1) return null;
   return nums.length === fileCount ? nums : null;
-}
-
-/** `z.object(` occurrences — the ledger's own stated counting method. */
-function countSites(file: string): number {
-  return (fs.readFileSync(file, 'utf-8').match(/z\.object\(/g) ?? []).length;
 }
 
 const md = fs.readFileSync(LEDGER, 'utf-8').split('\n');
@@ -169,7 +170,10 @@ for (const row of rows) {
 for (const [d, declared] of declaredByDir) {
   const dirPath = path.join(SRC, d);
   if (!fs.existsSync(dirPath)) continue;
-  const onDisk = fs.readdirSync(dirPath).filter((f) => f.endsWith('.zod.ts'));
+  // Recursive — see lib/strictness-ledger.ts for why that is load-bearing.
+  // Nested files are declared by their path relative to the section directory
+  // (`driver/postgres.zod.ts`), which the row parser already accepts.
+  const onDisk = listSchemaFiles(dirPath);
   // Zero-site files carry nothing to classify (see the header note). They become
   // reportable the moment they grow a `z.object(`.
   const missing = onDisk.filter((f) => !declared.has(f) && countSites(path.join(dirPath, f)) > 0);

--- a/packages/spec/scripts/lib/strictness-ledger.ts
+++ b/packages/spec/scripts/lib/strictness-ledger.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Shared pieces of the #4001 strictness-ledger gate
+ * (`../check-strictness-ledger.mts`), extracted so the gate and its regression
+ * test cannot drift apart on the one property that already broke silently:
+ * whether the coverage walk descends into subdirectories.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** `z.object(` occurrences — the ledger's own stated counting method. */
+export function countSites(file: string): number {
+  return (fs.readFileSync(file, 'utf-8').match(/z\.object\(/g) ?? []).length;
+}
+
+/**
+ * Every `*.zod.ts` under `dir`, **recursively**, as `/`-separated paths relative
+ * to `dir` (so a nested file reads `driver/postgres.zod.ts` — exactly how the
+ * ledger declares it).
+ *
+ * The recursion is the whole point of this function existing. The gate's first
+ * version listed each triaged directory one level deep, which made
+ * `data/driver/` — three per-driver connection-config files, nine authorable
+ * sites — invisible to the check whose entire promise is "no undeclared
+ * surface". It printed "no undeclared schema files" and was believed.
+ *
+ * A gate that under-reports is worse than no gate: it converts "I should
+ * classify this" into "it is already classified". Keep the walk recursive, and
+ * see `strictness-ledger.test.ts`, which fails if it stops being.
+ */
+export function listSchemaFiles(dir: string): string[] {
+  return fs
+    .readdirSync(dir, { recursive: true })
+    .map((f) => String(f).split(path.sep).join('/'))
+    .filter((f) => f.endsWith('.zod.ts'))
+    .sort();
+}

--- a/packages/spec/scripts/strictness-ledger.test.ts
+++ b/packages/spec/scripts/strictness-ledger.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Regression cover for the #4001 strictness-ledger gate's coverage walk.
+ *
+ * The gate protects the ledger from going stale. Nothing protected the gate,
+ * and it shipped with a one-level-deep directory listing that hid
+ * `data/driver/` — nine authorable sites — while reporting "no undeclared
+ * schema files". The failure was invisible for the same reason the silent key
+ * strip this whole campaign is about is invisible: a success signal covering an
+ * omission.
+ *
+ * So these tests assert the gate can see the thing it once could not, rather
+ * than only that it passes today. A green check that has never been shown to go
+ * red proves nothing.
+ *
+ * MEASURED, and the reason this file is not redundant with the gate: with the
+ * `data/driver/` rows now present in the ledger, reverting the walk to
+ * non-recursive leaves `check:strictness-ledger` **passing** — a one-level walk
+ * finds nothing missing once nothing nested is missing. The gate cannot detect
+ * its own regression. These tests can, and did (`descends into subdirectories`
+ * is the one that fails). Deleting them silently restores the blind spot.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { countSites, listSchemaFiles } from './lib/strictness-ledger';
+
+const HERE = path.dirname(url.fileURLToPath(import.meta.url));
+const SPEC = path.resolve(HERE, '..');
+const SRC = path.join(SPEC, 'src');
+const LEDGER = path.resolve(SPEC, '../../docs/audits/2026-07-unknown-key-strictness-ledger.md');
+
+/** The directories the ledger triages file-by-file. */
+const TRIAGED = ['ui', 'data', 'automation', 'security', 'studio'] as const;
+
+describe('strictness-ledger coverage walk', () => {
+  it('descends into subdirectories', () => {
+    const files = listSchemaFiles(path.join(SRC, 'data'));
+
+    // The exact surface the non-recursive walk hid. If this ever fails because
+    // the files moved, re-point it at whatever nested schema exists — do not
+    // delete it, or the blind spot comes back unobserved.
+    expect(files).toContain('driver/postgres.zod.ts');
+    expect(files).toContain('driver/mongo.zod.ts');
+    expect(files).toContain('driver/memory.zod.ts');
+  });
+
+  it('returns paths relative to the directory, as the ledger declares them', () => {
+    for (const file of listSchemaFiles(path.join(SRC, 'data'))) {
+      expect(file.startsWith('/')).toBe(false);
+      expect(file).not.toContain('\\');
+    }
+  });
+
+  it.each(TRIAGED)('declares every sited schema file under %s/', (dir) => {
+    const ledger = fs.readFileSync(LEDGER, 'utf-8');
+    const dirPath = path.join(SRC, dir);
+
+    const undeclared = listSchemaFiles(dirPath)
+      .filter((f) => countSites(path.join(dirPath, f)) > 0)
+      // Backticked exactly as the triage tables write it.
+      .filter((f) => !ledger.includes(`\`${f}\``));
+
+    // A second, independent statement of the gate's coverage rule — deliberately
+    // not sharing the gate's table parser, so a bug in that parser cannot make
+    // both agree on a wrong answer.
+    expect(undeclared).toEqual([]);
+  });
+});

--- a/packages/spec/src/data/datasource.zod.ts
+++ b/packages/spec/src/data/datasource.zod.ts
@@ -20,8 +20,9 @@ import { strictUnknownKeyError } from '../shared/suggestions.zod';
  *
  * TWO ESCAPE HATCHES STAY OPEN, and must:
  *   - `config` is per-driver by construction (a sqlite `filename` and a
- *     postgres `host`/`port` share no shape), so it stays `z.record`. The
- *     driver's own `configSchema` is what validates it.
+ *     postgres `host`/`port` share no shape), so it stays `z.record`.
+ *     NOTHING VALIDATES INSIDE IT TODAY — see {@link belongsInConfig}, which
+ *     used to claim otherwise. Tracked as #4410.
  *   - `readReplicas` carries the same per-driver config objects.
  *
  * That openness is exactly why the TOP level had to close. Before this, a
@@ -63,10 +64,31 @@ const SSL_KEYS = ['enabled', 'rejectUnauthorized', 'ca', 'cert', 'key'] as const
 /** Keys the datasource `retryPolicy` block declares (drift-guarded by datasource.test.ts). */
 const DATASOURCE_RETRY_POLICY_KEYS = ['maxRetries', 'baseDelayMs', 'maxDelayMs', 'backoffMultiplier'] as const;
 
-/** A connection detail written one level too high — it belongs inside `config`. */
+/**
+ * A connection detail written one level too high — it belongs inside `config`.
+ *
+ * This prescription stops at *where to put it* and deliberately does NOT promise
+ * that the move gets validated. It used to: the sentence read "the driver's own
+ * configSchema validates it there", and that was false twice over —
+ * {@link DriverDefinitionSchema}'s `configSchema` is a `z.record` that both
+ * bundled driver specs set to `{}`, and nothing in this repo reads it (#4410).
+ *
+ * Which made this the worst line in the module: it took an author who had made a
+ * recoverable mistake at a place that now catches it, and pointed them — with the
+ * platform's authority — at a slot where the same mistake is silent again.
+ * `config: { hostname: … }` is stripped in silence and the datasource connects on
+ * localhost, which is #4001's original bug verbatim, one level down. A wrong
+ * instruction is worse than none, and worst of all for an AI author, whose only
+ * check on "did that work?" is whether the parse complained.
+ *
+ * Naming the per-driver schema is the honest form: it is the shape to write
+ * against, and a reader can check themselves against it even while nothing
+ * enforces it. Restore a validation claim here only when #4410 makes one true.
+ */
 const belongsInConfig = (key: string) =>
   `\`${key}\` is a driver connection detail — it belongs inside \`config\`, not at the top `
-  + `level. Move it to \`config: { ${key}: … }\`; the driver's own configSchema validates it there.`;
+  + `level. Move it to \`config: { ${key}: … }\`, matching your driver's config shape `
+  + `(\`PostgresConfigSchema\` / \`MongoConfigSchema\` / \`MemoryConfigSchema\` in \`data/driver/\`).`;
 
 const driverDefinitionUnknownKeyError = strictUnknownKeyError({
   surface: 'this driver definition',

--- a/packages/spec/src/data/driver/mongo.zod.ts
+++ b/packages/spec/src/data/driver/mongo.zod.ts
@@ -5,9 +5,14 @@ import { DriverDefinitionSchema } from '../datasource.zod';
 
 /**
  * MongoDB Standard Driver Protocol
- * 
- * Defines the strict schema for MongoDB connection and capabilities.
- * This is used by the Platform to validate `datasource.config` when `driver: 'mongo'`.
+ *
+ * Describes the MongoDB connection settings and capabilities.
+ *
+ * CONTRACT ONLY — nothing parses `datasource.config` against this. This block
+ * used to claim it was "used by the Platform to validate `datasource.config`
+ * when `driver: 'mongo'`", which was never true: the config slot is a `z.record`
+ * and this schema has no consumer (#4410). It is the shape to author against,
+ * not a gate that runs. Say "validates" here again only once #4410 lands.
  */
 
 // ==========================================================================
@@ -64,7 +69,10 @@ export const MongoDriverSpec = DriverDefinitionSchema.parse({
   label: 'MongoDB',
   description: 'Official MongoDB Driver for ObjectStack. Supports rich queries, aggregation, and atomic updates.',
   icon: 'database',
-  configSchema: {}, // Will be populated with JSON Schema version of MongoConfigSchema at runtime
+  // Empty, and nothing fills it. This comment used to promise the field would be
+  // "populated with a JSON Schema version of MongoConfigSchema at runtime" — no
+  // such code exists here or in any consumer (#4410).
+  configSchema: {},
   capabilities: {
     transactions: true,
     // Query


### PR DESCRIPTION
对 #4001 战役的两处修正。**两处都是这场战役要消灭的那个缺陷本身——一个成功信号盖住了一处遗漏——只不过这次出现在战役自己的产物里。**

起因是一次「#4001 到底做完了没有」的核查。结论是没有（长尾 ~416/500 站点仍是默认 strip，`studio/` 27 站点 0 strict），但核查过程中发现了两处比长尾更该先修的东西。

## 1. `config` 的处方是假的 —— 而且有四份拷贝

#4207 把 `DatasourceSchema` 收紧成 `.strict()` 时，把 `config` 留开。于是一个把连接细节写在顶层的作者，会收到这样的拒绝：

> `` `host` `` is a driver connection detail — it belongs inside `config` … Move it to `config: { host: … }`; **the driver's own configSchema validates it there.**

**没有任何东西在那里校验。** 这句话在两个独立层面上都不成立：

- `DriverDefinitionSchema.configSchema` 是个 `z.record`，而仓库里仅有的两个驱动定义都把它设成 `{}`（`driver/mongo.zod.ts` 那行还带着「will be populated … at runtime」的注释，没有任何代码执行它）
- 本仓没有任何读取点；四个驱动插件也都没有拿 schema parse 过自己的 config

所以这句话把一个**在会报错的位置**犯了可恢复错误的作者，以平台的口吻，指引到了一个**同样的错误重新变静默**的槽里：`config: { hostname: … }` 被静默丢弃，数据源连到 localhost —— 这就是 #4001 的原始 bug，逐字同构，只低了一层。**一条错误的指令比没有指令更坏**，对 AI 作者尤其如此，它判断「这样对不对」的唯一信号就是解析有没有抱怨。

同一句话在仓库里有 **4 份拷贝**，全部改掉：

| 位置 | 性质 |
|---|---|
| `datasource.zod.ts` 模块注释 | 内部 |
| `datasource.zod.ts` `belongsInConfig` | **作者会看到的错误信息** |
| `driver/mongo.zod.ts` 头部 | 内部（「used by the Platform to validate `datasource.config`」）|
| `content/docs/releases/v17.mdx` | **用户会看到的发布说明** |

第 4 份是被本 PR 自己的 docs-drift 机器人找出来的 —— 它按包级启发式列了 107 篇文档，其中真正需要改的正好一篇，而那一篇恰好是读者真会看的那份。

处方改成指向 per-driver 的形状（`PostgresConfigSchema` / `MongoConfigSchema` / `MemoryConfigSchema`），不再声称任何执行力。**没有改动任何可授权键** —— 只是错误信息与文档文字。真正的执行（对惰性 `configSchema` 做 enforce-or-remove）另立 **#4410** 追踪。

## 2. 账本闸门的覆盖扫描只有一层深

`check:strictness-ledger`（#4232 建立）承诺：被分类目录下每一个有站点的 `*.zod.ts` 都必须带一行分类。它用非递归的目录列举实现这个承诺，于是 `data/driver/` —— 三个 per-driver 配置文件、**九个可授权站点** —— 对它完全不可见，而它照常打印 *"no undeclared schema files"*。

这正是账本自己开头那句话的升级版：*会漂移的地图比没有地图更坏，因为它会被人照着走*。**一个漏报的闸门比没有闸门更坏，因为它把「我该分类一下」变成了「已经分类过了」。** 没有闸门时读者还会保持怀疑；绿色的闸门会解除这份怀疑。

- 扫描改为递归（嵌套文件以 `driver/postgres.zod.ts` 形式申报，行解析器本来就接受）
- 三个文件在账本中分类归档：**authorable**，但注明它们今天是**仅契约导出** —— 没有任何东西拿它们 parse `datasource.config`，所以此刻收紧不会执行任何东西；这一行的棘轮卡在 #4410 给它一个 parse 点上，而不是卡在验证上
- `data/` 分区计数 149 → 158

### 为什么单独加了测试

`scripts/strictness-ledger.test.ts` 钉住递归这件事，**它和闸门不重复**——实测：在账本行已经补齐之后，把扫描改回非递归，`check:strictness-ledger` **依然是绿的**（一层深的扫描在「没有嵌套文件缺失」时确实找不到缺失）。**闸门抓不住自己的回归。** 这个测试可以，并且我先让它红、再让它绿地验证过。

按同样的道理，账本里也记下了这条：任何声称覆盖的检查，在信它之前得先证明它看得见它该看见的东西。

## 3. 顺带：给「等田野数据」加了决策点

账本的 Next steps 只剩一条，而且是无限期的等待（「等告警层跑一个 release」）。没有到期条件的等待，会安静地变成永久停摆，而这份文件会一直显示战役进行中。现在它由一个**可回答的问题**来解除，而不是日期，并列出三种结果各自的下一步 —— 其中要重点排查的那种是「零发现，因为根本没有任何东西在回报」，它和成功在表面上无法区分，正是这场战役自己的主题。

同时把 `studio/`（27 站点、0 strict、三个文件全是未验证的 `(p)`）显式列为不依赖田野数据的备选起点。

## 验证

- `@objectstack/spec`：**283 文件 / 7205 用例通过**，`tsc --noEmit` 干净
- **下游消费包全绿**：`lint` / `metadata` / `platform-objects` / `metadata-core` / `metadata-protocol` —— turbo **17/17 任务成功，0 失败**
- **8 个生成物闸门全部 up-to-date**（无需重新生成 —— 证实这些 JSDoc 改动没有让参考文档漂移，即 #3746 踩过的那个坑没有复现）
- **全部 `check:*` 闸门绿**：docs / skill-refs / skill-docs / api-surface / spec-changes / upgrade-guide / authorable-surface / react-blocks / liveness / empty-state / variant-docs / strictness-ledger / exported-any / react-conformance / skill-examples
- 闸门行为双向实证：在 `data/driver/` 未申报时变红、补齐后变绿；植入一处分区合计漂移仍能抓到；把递归改回去后新测试变红而闸门仍绿（这就是新测试存在的理由）
- 全仓确认：被改掉的旧错误信息文本没有任何测试或文档依赖，且假声明已无残留拷贝

## 参考

- #4001（未知键静默剥离战役）、#4207（datasource 收紧那一步）、#4232（账本闸门）
- **#4410**（本 PR 开出的后续：驱动 `configSchema` 的 enforce-or-remove）
- ADR-0049 enforce-or-remove、ADR-0078 no-silently-inert-metadata、ADR-0054 棘轮范式
- AGENTS.md Prime Directive #10（never advertise a capability the runtime doesn't actually deliver）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnqGjQFQMqd5k81LYV8SCY