### PR TITLE
test(objectql): 补上运行时汇总字段修复的三个邻近路径 (#4427 后续)

### DIFF
--- a/packages/objectql/src/summary-rollup.test.ts
+++ b/packages/objectql/src/summary-rollup.test.ts
@@ -283,3 +283,113 @@ describe('roll-up summary index — a roll-up registered at RUNTIME still comput
     expect(parent.completed_task_count).toBe(1);
   });
 });
+
+// Sibling cases to the one above (#4427). That one pins the headline path: an
+// object registered after the index was built. These pin three neighbours the
+// same revision counter is responsible for, none of which it exercises —
+// re-registering an EXISTING object, unregistering one, and the guarantee that
+// the child's own insert was already correct (rather than a later write
+// quietly repairing it, which is what made the original bug so slippery).
+describe('roll-up summary index — neighbours of the runtime-registration path', () => {
+  let engine: ObjectQL;
+  let storeFor: ReturnType<typeof makeDriver>['storeFor'];
+
+  beforeEach(async () => {
+    engine = new ObjectQL();
+    const d = makeDriver();
+    storeFor = d.storeFor;
+    engine.registerDriver(d.driver, true);
+    await engine.init();
+  });
+
+  /** A write against an unrelated object, so the index is built and cached
+   *  BEFORE the objects under test are registered. */
+  const warmSummaryIndex = async () => {
+    engine.registry.registerObject({ name: 'unrelated', fields: { name: { type: 'text' } } } as any);
+    await engine.insert('unrelated', { name: 'warms the index' });
+  };
+
+  const project = (id: string) => storeFor('project').get(id);
+
+  it('does not need a second write to the child to catch up', async () => {
+    await warmSummaryIndex();
+    engine.registry.registerObject({
+      name: 'project',
+      fields: {
+        name: { type: 'text' },
+        estimated_total_hours: { type: 'summary', summaryOperations: { object: 'task', field: 'hours', function: 'sum' } },
+      },
+    } as any, 'sys_metadata');
+    engine.registry.registerObject({
+      name: 'task',
+      fields: { hours: { type: 'number' }, project: { type: 'master_detail', reference: 'project' } },
+    } as any, 'sys_metadata');
+
+    const p = await engine.insert('project', { name: '新品发布' });
+    const t = await engine.insert('task', { project: p.id, hours: 4 });
+    const afterInsert = { ...project(p.id) };
+
+    // The pre-fix workaround was a no-op PATCH on the child, which recomputed
+    // against a by-then-rebuilt index. The insert alone must already be right,
+    // so touching the child must not CHANGE anything.
+    await engine.update('task', { id: t.id, hours: 4 });
+
+    expect(afterInsert.estimated_total_hours).toBe(4);
+    expect(project(p.id).estimated_total_hours).toBe(afterInsert.estimated_total_hours);
+  });
+
+  it('picks up a summary field added to an ALREADY-registered parent', async () => {
+    // Incremental authoring: the object is already live, then `update_metadata`
+    // re-registers it carrying a new roll-up field. Re-registration replaces an
+    // existing contributor rather than adding a new object.
+    engine.registry.registerObject({ name: 'project', fields: { name: { type: 'text' } } } as any, 'sys_metadata');
+    engine.registry.registerObject({
+      name: 'task',
+      fields: { hours: { type: 'number' }, project: { type: 'master_detail', reference: 'project' } },
+    } as any, 'sys_metadata');
+
+    const p = await engine.insert('project', { name: '迁移' });
+    await engine.insert('task', { project: p.id, hours: 3 }); // index built here, no summaries yet
+
+    engine.registry.registerObject({
+      name: 'project',
+      fields: {
+        name: { type: 'text' },
+        estimated_total_hours: { type: 'summary', summaryOperations: { object: 'task', field: 'hours', function: 'sum' } },
+      },
+    } as any, 'sys_metadata');
+
+    await engine.insert('task', { project: p.id, hours: 5 });
+    expect(project(p.id).estimated_total_hours).toBe(8);
+  });
+
+  it('stops recomputing a roll-up whose parent was unregistered', async () => {
+    await warmSummaryIndex();
+    engine.registry.registerObject({
+      name: 'project',
+      fields: {
+        name: { type: 'text' },
+        estimated_total_hours: { type: 'summary', summaryOperations: { object: 'task', field: 'hours', function: 'sum' } },
+      },
+    } as any, 'sys_metadata');
+    engine.registry.registerObject({
+      name: 'task',
+      fields: { hours: { type: 'number' }, project: { type: 'master_detail', reference: 'project' } },
+    } as any, 'sys_metadata');
+
+    const p = await engine.insert('project', { name: '待卸载' });
+    await engine.insert('task', { project: p.id, hours: 2 });
+    expect(project(p.id).estimated_total_hours).toBe(2);
+
+    // Uninstalling the package must drop its descriptors too — the mirror of
+    // the bug: a stale index would keep writing to a parent that is gone.
+    engine.registry.unregisterObjectsByPackage('sys_metadata', true);
+    engine.registry.registerObject({
+      name: 'task',
+      fields: { hours: { type: 'number' }, project: { type: 'lookup', reference: 'project' } },
+    } as any, 'other_package');
+
+    await expect(engine.insert('task', { project: p.id, hours: 100 })).resolves.toBeTruthy();
+    expect(project(p.id).estimated_total_hours).toBe(2); // untouched
+  });
+});


### PR DESCRIPTION
> **原本这个 PR 带着一份和 #4427 等价的实现**（同样在 registry 上加单调 revision、同样那 5 处 bump、引擎同样记 revision 重建）——两边是并行做的。#4427 先落地，所以这里把实现全部去掉，**只留 #4427 没有覆盖到的测试**。现在是纯测试改动。

## 补什么

#4427 钉住了主路径：**索引建好之后**才注册的对象能算对。同一个 revision 计数器还负责另外三条邻近路径，那个 PR 都没有测到，而在修复前它们**各自独立地坏着**：

1. **给已经注册过的对象追加汇总字段** —— `update_metadata` 增量编辑那条路。对象已经上线了，所以这走的是「替换已有 contributor」，不是「新增对象」。
2. **父对象注销之后要停止重算** —— 这个 bug 的反面：陈旧索引会继续往一个已经不存在的父对象上写。
3. **子记录自己那次 insert 就得是对的**，而不是靠后续某次写入悄悄补上 —— 这正是原缺陷最难抓的地方：那个 no-op `PATCH` 绕过办法**每次都给出正确答案**，于是很容易误判成「偶发」而不是「时序」。

## 这些用例不是白写的

把 #4427 对 `getSummaryDescriptors` 的改动回退掉，**三个全部失败**（roll-up 读到 `undefined`），和它自己那个用例一起挂。恢复后 12/12 通过。

- objectql：1504 通过
- `tsc --noEmit` 干净
- 仅改 `summary-rollup.test.ts`，无实现改动

## 附：#4427 的修复在真机上确认有效

`run-stack.sh --prod-like --seed` 跑同一句「项目任务管理」提示词，带负控制：

| | 任务总数 | 已完成任务数（带 filter） | 预估总工时 |
|---|---|---|---|
| **带修复** | 12/12 与子表吻合 | 完全吻合 | 完全吻合 |
| **回退修复** | 全 NULL | 全 NULL | 全 NULL |

两次子表数据都正常。（这份 E2E 是在 #4427 合并前、对等价实现跑的；机制相同。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
