### PR TITLE
fix(objectql,metadata-protocol): 租户自己写的覆盖层不该被当成代码包产物

### DIFF
--- a/.changeset/runtime-overlay-not-artifact.md
+++ b/.changeset/runtime-overlay-not-artifact.md
@@ -1,0 +1,28 @@
+---
+"@objectstack/objectql": patch
+"@objectstack/metadata-protocol": patch
+---
+
+fix(objectql,metadata-protocol): a tenant-authored overlay must not read back as a code artifact
+
+`saveMetaItem` refuses to write an artifact-backed item of a type that has not
+opted into overlay writes (`not_overridable`), and it asks
+`registry.getArtifactItem` who is artifact-backed. That answer was "anything
+whose `_packageId` is not the literal string `sys_metadata`" — a sentinel that
+only holds on the save path. The boot-time rehydration of `sys_metadata`
+registers each row under its REAL package id (`app.<slug>`), which every
+runtime-authored item has carried since packages became mandatory.
+
+So an app the user had just built through Studio (or the AI build agent) came
+back from the next kernel rebuild looking code-shipped, and the following edit
+was refused with a 403 — permanently. Live capture: two identical `modify_field`
+calls on the same object seconds apart, the first published LIVE and the second
+`not_overridable`, because the first one's auto-publish triggered the rebuild in
+between (cloud#970).
+
+Provenance is the axis that actually separates the two (ADR-0010 `_provenance`:
+`'package'` for loader-introduced items, `'org'` for tenant-authored), so ask it:
+the `sys_metadata` hydration now stamps `_provenance: 'org'`, and
+`getArtifactItem` no longer treats such an item as an artifact. An item with no
+provenance under a real package id is unchanged, so nothing that was protected
+becomes writable.

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -8163,7 +8163,19 @@ export class ObjectStackProtocolImplementation implements
                         );
                     }
                     if (normalizedType === 'object') {
-                        this.engine.registry.registerObject(data as any, record.packageId || 'sys_metadata');
+                        // Every row here came from `sys_metadata` — a TENANT-authored
+                        // overlay, whatever package it is bound to. Say so (ADR-0010
+                        // `_provenance: 'org'`), because the package id alone reads as
+                        // code provenance: registering under the real `app.<slug>`
+                        // made the registry's artifact lookup claim the row was
+                        // code-shipped, and `saveMetaItem`'s overlay gate then refused
+                        // the very next write with `not_overridable`. An app the user
+                        // had just built became un-editable at the first kernel
+                        // rebuild (cloud#970).
+                        this.engine.registry.registerObject(
+                            { ...(data as Record<string, unknown>), _provenance: 'org' } as any,
+                            record.packageId || 'sys_metadata',
+                        );
                     } else {
                         // Same envelope graft as the getMetaItems hydration:
                         // the plain-key entry shadows any packaged artifact,

--- a/packages/objectql/src/registry-tenant-authored-artifact.test.ts
+++ b/packages/objectql/src/registry-tenant-authored-artifact.test.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ADR-0010 provenance vs. the overlay gate — a tenant-authored overlay must not
+ * read back as a code artifact.
+ *
+ * `saveMetaItem` refuses to write an artifact-backed item of a type that has not
+ * opted into overlay writes (`not_overridable`), and it asks
+ * `registry.getArtifactItem` who is artifact-backed. That answer used to be
+ * "anything whose `_packageId` is not the string `sys_metadata`" — a sentinel
+ * that only ever holds on the save path. The boot-time rehydration of
+ * `sys_metadata` registers each row under its REAL package id (`app.<slug>`),
+ * which every runtime-authored item has carried since packages became
+ * mandatory. So a Studio/AI-built app came back from the next kernel rebuild
+ * looking code-shipped, and the following edit was refused 403 — permanently
+ * (cloud#970: two identical `modify_field` calls on the same object, seconds
+ * apart, the first LIVE and the second `not_overridable`).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SchemaRegistry } from './registry.js';
+
+const objectBody = (name: string, extra: Record<string, unknown> = {}) => ({
+  name,
+  fields: { title: { type: 'text' } },
+  ...extra,
+});
+
+describe('getArtifactItem — provenance decides, not the package id', () => {
+  it('does NOT report a tenant-authored object as artifact-backed, even under a real package id', () => {
+    const registry = new SchemaRegistry();
+    // Exactly what loadMetaFromDb does for a sys_metadata row of an AI-built app.
+    registry.registerObject(objectBody('eymm_project', { _provenance: 'org' }) as never, 'app.eymm');
+    expect(registry.getArtifactItem('object', 'eymm_project')).toBeUndefined();
+  });
+
+  it('still reports a code-shipped object as artifact-backed', () => {
+    const registry = new SchemaRegistry();
+    registry.registerObject(objectBody('billing_invoice', { _provenance: 'package' }) as never, 'com.acme.billing');
+    expect(registry.getArtifactItem('object', 'billing_invoice')).toBeDefined();
+  });
+
+  it('treats an object with no provenance under a real package id as an artifact (unchanged)', () => {
+    // The loader does not always stamp provenance; absence must keep the old
+    // answer so nothing that WAS protected silently becomes writable.
+    const registry = new SchemaRegistry();
+    registry.registerObject(objectBody('legacy_thing') as never, 'com.acme.legacy');
+    expect(registry.getArtifactItem('object', 'legacy_thing')).toBeDefined();
+  });
+
+  it('keeps the sys_metadata sentinel working', () => {
+    const registry = new SchemaRegistry();
+    registry.registerObject(objectBody('runtime_thing') as never, 'sys_metadata');
+    expect(registry.getArtifactItem('object', 'runtime_thing')).toBeUndefined();
+  });
+
+  it('applies the same rule to non-object metadata types', () => {
+    const registry = new SchemaRegistry();
+    registry.registerItem('view', { name: 'v_org', _packageId: 'app.eymm', _provenance: 'org' } as never, 'name' as never);
+    registry.registerItem('view', { name: 'v_pkg', _packageId: 'com.acme.billing', _provenance: 'package' } as never, 'name' as never);
+    expect(registry.getArtifactItem('view', 'v_org')).toBeUndefined();
+    expect(registry.getArtifactItem('view', 'v_pkg')).toBeDefined();
+  });
+});

--- a/packages/objectql/src/registry.ts
+++ b/packages/objectql/src/registry.ts
@@ -579,6 +579,25 @@ export class NamespaceConflictError extends Error {
   }
 }
 
+/**
+ * Is this registered item a TENANT-authored overlay rather than a code-shipped
+ * artifact? (ADR-0010 `_provenance`: `'package'` for loader-introduced items,
+ * `'org'` for tenant-authored.)
+ *
+ * `_packageId !== 'sys_metadata'` alone cannot answer it. That sentinel only
+ * holds on the save path; the boot-time rehydration of `sys_metadata` registers
+ * each row under its REAL package id (`app.<slug>`), which is exactly what every
+ * runtime-authored item has carried since packages became mandatory. So a
+ * tenant's own overlay came back from a kernel rebuild looking like a code
+ * artifact, and the protocol's overlay gate refused the next write to it with
+ * `not_overridable` — an app the user had just built through Studio/AI became
+ * permanently un-editable at the first kernel rebuild (cloud#970). Provenance is
+ * the axis that actually distinguishes the two, so ask it.
+ */
+function isTenantAuthored(item: unknown): boolean {
+  return (item as { _provenance?: unknown } | null | undefined)?._provenance === 'org';
+}
+
 export class SchemaRegistry {
   // ==========================================
   // Logging control
@@ -1314,7 +1333,7 @@ export class SchemaRegistry {
   getArtifactItem<T>(type: string, name: string, currentPackageId?: string): T | undefined {
     if (type === 'object' || type === 'objects') {
       const obj = this.getObject(name) as any;
-      return obj && obj._packageId && obj._packageId !== 'sys_metadata'
+      return obj && obj._packageId && obj._packageId !== 'sys_metadata' && !isTenantAuthored(obj)
         ? (obj as T)
         : undefined;
     }
@@ -1326,12 +1345,12 @@ export class SchemaRegistry {
     // iteration order.
     if (currentPackageId) {
       const local = collection.get(`${currentPackageId}:${name}`) as any;
-      if (local && local._packageId && local._packageId !== 'sys_metadata') return local as T;
+      if (local && local._packageId && local._packageId !== 'sys_metadata' && !isTenantAuthored(local)) return local as T;
     }
     for (const [key, item] of collection) {
       if (key !== name && key.endsWith(`:${name}`)) {
         const it = item as any;
-        if (it && it._packageId && it._packageId !== 'sys_metadata') return item as T;
+        if (it && it._packageId && it._packageId !== 'sys_metadata' && !isTenantAuthored(it)) return item as T;
       }
     }
     // Bare-key fallback: a runtime/DB overlay rehydrated under the plain name.
@@ -1344,7 +1363,7 @@ export class SchemaRegistry {
     // the legacy best-effort first-match.
     const direct = collection.get(name) as any;
     if (
-      direct && direct._packageId && direct._packageId !== 'sys_metadata' &&
+      direct && direct._packageId && direct._packageId !== 'sys_metadata' && !isTenantAuthored(direct) &&
       (!currentPackageId || direct._packageId === currentPackageId)
     ) {
       return direct as T;


### PR DESCRIPTION
## 问题

`saveMetaItem` 会拒绝写入「artifact-backed 且该类型没开启 overlay 写」的元数据（`not_overridable`），而它判断谁是 artifact-backed 靠的是 `registry.getArtifactItem`。这个判据一直是「`_packageId` 不等于字面量 `sys_metadata` 就算代码产物」—— 但这个哨兵**只在 save 路径上成立**。

启动时 `loadMetaFromDb` 把 `sys_metadata` 的每一行按它**真实的 packageId**（`app.<slug>`）注册进 registry，而自从 package 成为强制项之后，**所有运行时创作的条目都带着这样一个 packageId**。

结果：用户刚在 Studio（或 AI 搭建 agent）里建好的应用，经过下一次 kernel 重建之后，看起来就像是代码包发布的产物 —— 于是**之后对它的任何修改都被 403 拒绝，且是永久性的**。

线上实测（objectstack-ai/cloud#970）：对同一个对象、相隔几秒的两次 `modify_field`，第一次 `status: published` 成功上线，第二次直接 `[not_overridable]` —— 因为第一次的 auto-publish 在中间触发了 kernel 重建。

这也正是 AI 授权 skill 里那条「apply_blueprint 之后你必须 update_metadata 把汇总配置补上」的指示为什么是空话：它指向的那条路根本走不通。

## 改动

真正区分两者的轴是 **provenance**（ADR-0010：`'package'` = loader 引入，`'org'` = 租户自己写的），所以就问它：

- `loadMetaFromDb` 注册 object 时打上 `_provenance: 'org'` —— 这些行按定义就来自 `sys_metadata`，是租户的覆盖层。
- `getArtifactItem` 的四个分支都不再把 `_provenance === 'org'` 的条目当作 artifact。

**没有** provenance 的条目在真实 packageId 下维持原判定，所以本来受保护的东西不会悄悄变成可写。

## 测试

新增 `registry-tenant-authored-artifact.test.ts`（5 例）：租户覆盖层不再被当 artifact；代码包产物仍然是 artifact；无 provenance 维持原状；`sys_metadata` 哨兵仍生效；非 object 类型同理。**去掉 registry 改动后其中 2 例会失败**（已验证）。

`packages/objectql` 92 files / 1506 tests、`packages/metadata-protocol` 21 files / 139 tests 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)