### PR TITLE
docs(spec): SystemFieldName says which columns are actually injected

### DIFF
--- a/.changeset/system-field-name-injected-columns.md
+++ b/.changeset/system-field-name-injected-columns.md
@@ -1,0 +1,41 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): SystemFieldName says which columns are actually injected (#4430)
+
+`SystemFieldName` presents itself as the canonical protocol-level names for
+system fields, but it was neither the injected set nor a complete one — and it
+had the most load-bearing entry backwards. `TENANT_ID` was documented as
+"Tenant isolation key" while the column the registry actually provisions is
+`organization_id`, which had no constant at all. Nor did `created_by` /
+`updated_by`, the other half of the audit-provenance family. Two of the seven
+entries (`user_id`, `deleted_at`) are not injected either, with nothing in the
+table saying so.
+
+Consumers hand-copying a system-field list read the table as the injection set
+and drifted accordingly. cloud#982 found three such copies in one package
+carrying `tenant_id`, `org_id` and `space` between them — three spellings no
+injection site produces — and cloud#979 was one of those copies claiming a
+business field named `owner`, so every seeded row of a user's app shipped its
+负责人 column blank.
+
+**Additive only. No entry removed, no value changed**, so existing
+`SystemFieldName.X` references are unaffected.
+
+- Adds `ORGANIZATION_ID`, `CREATED_BY` and `UPDATED_BY` — the three injected
+  columns the table was missing.
+- Records per entry whether open-core actually injects it, so the legacy
+  (`tenant_id`, stamped from the session's *organization* id only on an object
+  that declares it) and authored (`user_id`) names can no longer be mistaken
+  for provisioned ones.
+- States in the module doc that this is a NAME registry, not the injected set.
+  `applySystemFields` decides that per object from `ownership` / `tenancy` /
+  `systemFields`, so the same name is a system column on one object and
+  business data on the next. A consumer asking "is this field system-managed on
+  THIS object" branches on `Field.system` — already published for exactly that
+  purpose, and now pointed at from here.
+
+`@objectstack/lint`'s `SYSTEM_FIELDS` is unchanged in content: it unions this
+table with `FIELD_GROUP_SYSTEM_FIELDS`, which already carried all three added
+names.

--- a/packages/spec/src/system/constants/system-names.test.ts
+++ b/packages/spec/src/system/constants/system-names.test.ts
@@ -78,8 +78,11 @@ describe('SystemFieldName', () => {
   it('should expose all expected field names', () => {
     expect(SystemFieldName.ID).toBe('id');
     expect(SystemFieldName.CREATED_AT).toBe('created_at');
+    expect(SystemFieldName.CREATED_BY).toBe('created_by');
     expect(SystemFieldName.UPDATED_AT).toBe('updated_at');
+    expect(SystemFieldName.UPDATED_BY).toBe('updated_by');
     expect(SystemFieldName.OWNER_ID).toBe('owner_id');
+    expect(SystemFieldName.ORGANIZATION_ID).toBe('organization_id');
     expect(SystemFieldName.TENANT_ID).toBe('tenant_id');
     expect(SystemFieldName.USER_ID).toBe('user_id');
     expect(SystemFieldName.DELETED_AT).toBe('deleted_at');
@@ -89,6 +92,30 @@ describe('SystemFieldName', () => {
     const names: readonly string[] = Object.values(SystemFieldName);
     expect(names).toContain('id');
     expect(names).toContain('owner_id');
+  });
+
+  // The gap this table carried until #4443: `applySystemFields` injects
+  // `organization_id` as THE tenant key and `created_by` / `updated_by` as
+  // audit provenance, yet none of the three had a canonical constant — while
+  // `tenant_id`, which open-core never injects, was documented as "Tenant
+  // isolation key". Consumers hand-copying a system-field list read that as
+  // gospel and drifted: cloud#982 found three copies carrying `tenant_id`,
+  // `org_id` and `space`, none of which any injection site produces.
+  it('names every column the registry actually injects', () => {
+    const names: readonly string[] = Object.values(SystemFieldName);
+    // Mirrors applySystemFields' injection set (objectql registry). That
+    // package's own conformance test enumerates the set from the live code;
+    // this one only asserts the protocol table has a spelling for each member.
+    for (const injected of [
+      'organization_id',
+      'created_at',
+      'created_by',
+      'updated_at',
+      'updated_by',
+      'owner_id',
+    ]) {
+      expect(names, injected).toContain(injected);
+    }
   });
 });
 

--- a/packages/spec/src/system/constants/system-names.ts
+++ b/packages/spec/src/system/constants/system-names.ts
@@ -110,13 +110,47 @@ export type SystemUserId = typeof SystemUserId[keyof typeof SystemUserId];
 /**
  * System Field Names — Protocol Layer Constants
  *
- * These constants define the canonical, protocol-level names for common system fields.
- * All API calls, SDK references, and permission checks MUST use these constants
- * instead of hardcoded strings or physical column names.
+ * The canonical, protocol-level SPELLING of each column the platform manages
+ * rather than the author. All API calls, SDK references, and permission checks
+ * MUST use these constants instead of hardcoded strings or physical column
+ * names.
  *
  * The physical storage column always equals the field key (the driver does not
  * support per-field column overrides; external objects map columns via
  * `external.columnMap`, ADR-0062 D7 / ADR-0015).
+ *
+ * ## ⚠️ This is a NAME registry, not the injected-column SET
+ *
+ * WHICH of these columns exists on a given object is decided PER OBJECT by
+ * `applySystemFields()` (`@objectstack/objectql` registry), from that object's
+ * own declarations: `ownership: 'org' | 'none'` withholds `owner_id`,
+ * `tenancy.enabled: false` withholds `organization_id`, and
+ * `systemFields: false` / `managedBy: 'better-auth'` disable the pass
+ * entirely. So the SAME NAME can be a system column on one object and an
+ * ordinary authored business field on another — a business field named
+ * `owner`, say (cloud#979, an observed failure: it was treated as a system
+ * column, so seeded rows left it blank).
+ *
+ * A consumer asking **"is this field system-managed ON THIS OBJECT?"** must
+ * therefore NOT test membership in this table. Branch on the per-field
+ * `Field.system` flag (`@objectstack/spec/data`) — `applySystemFields` stamps
+ * it on every column it injects, and no authored field carries it. That flag
+ * is the per-object answer; this table only answers "what is the canonical
+ * spelling of the column that plays role X".
+ *
+ * Related declarations, each with a different job — do not conflate them:
+ * - `FIELD_GROUP_SYSTEM_FIELDS` (`@objectstack/spec/data`) — names excluded
+ *   from a default form/detail layout.
+ * - `PUBLIC_FORM_SERVER_MANAGED_FIELDS` (`@objectstack/spec/security`) — names
+ *   never client-suppliable on the anonymous surface, pinned by objectql's
+ *   `system-managed-fields-conformance.test.ts` to be exactly (what open-core
+ *   injects ∪ documented reserved names).
+ *
+ * Every entry below records whether open-core actually INJECTS it, because
+ * that is the distinction hand-copied lists keep getting wrong
+ * (framework#4330, cloud#982 — where three copies had drifted onto
+ * `tenant_id`/`org_id`/`space`, two of which no injection site has ever
+ * produced).
  *
  * @example
  * ```ts
@@ -129,19 +163,44 @@ export type SystemUserId = typeof SystemUserId[keyof typeof SystemUserId];
  * ```
  */
 export const SystemFieldName = {
-  /** Primary key */
+  /** Primary key. Provisioned by the driver, not by `applySystemFields`. */
   ID: 'id',
-  /** Record creation timestamp */
+  /** Record creation timestamp. INJECTED (audit provenance). */
   CREATED_AT: 'created_at',
-  /** Record last-updated timestamp */
+  /** User who created the record (lookup to user). INJECTED (audit provenance). */
+  CREATED_BY: 'created_by',
+  /** Record last-updated timestamp. INJECTED (audit provenance). */
   UPDATED_AT: 'updated_at',
-  /** Record owner (lookup to user) */
+  /** User who last modified the record (lookup to user). INJECTED (audit provenance). */
+  UPDATED_BY: 'updated_by',
+  /** Record owner (lookup to user). INJECTED unless `ownership: 'org' | 'none'`. */
   OWNER_ID: 'owner_id',
-  /** Tenant isolation key */
+  /**
+   * THE tenant isolation key — a lookup to `sys_organization`. INJECTED unless
+   * tenancy is disabled for the object; org-scoping populates it on insert and
+   * it stays NULL on single-tenant stacks.
+   */
+  ORGANIZATION_ID: 'organization_id',
+  /**
+   * Legacy / enterprise tenant alias. **NOT injected by open-core** — nothing
+   * provisions this column. It is stamped (from the session's *organization*
+   * id, `objectql` plugin) only on an object that DECLARES it, and it stays on
+   * the public-form denylist as defense-in-depth. Use
+   * {@link SystemFieldName.ORGANIZATION_ID} for tenant scoping; this constant
+   * exists so the legacy spelling still has one canonical reference.
+   */
   TENANT_ID: 'tenant_id',
-  /** Foreign key to user on session / account objects */
+  /**
+   * Foreign key to user on session / account objects. **Authored**, not
+   * injected — an ordinary business object may legitimately declare its own
+   * `user_id` lookup, so this name must never be used to classify a column as
+   * system-managed.
+   */
   USER_ID: 'user_id',
-  /** Soft-delete timestamp */
+  /**
+   * Soft-delete timestamp. **NOT injected by `applySystemFields`** — written by
+   * the lifecycle / trash layer at runtime.
+   */
   DELETED_AT: 'deleted_at',
 } as const;
 


### PR DESCRIPTION
## 问题

`SystemFieldName` 自称是 system fields 的 canonical 协议级名字表，但它既不是注入集，也不是「所有系统字段」集，而且对最关键的一项**记反了**：

| 常量 | 文档说法 | 实际 |
|---|---|---|
| `TENANT_ID` | "Tenant isolation key" | open-core **从不注入**。`applySystemFields` provisions 的租户列是 `organization_id`（lookup → `sys_organization`）。objectql plugin 只在对象**自己声明了** `tenant_id` 时才 stamp，且填进去的值就是 `session.organizationId`。这个仓自己的 `system-managed-fields-conformance.test.ts` 已经把它归类为 "legacy/enterprise tenant key (not injected by open-core)" |
| **缺** `ORGANIZATION_ID` | — | 真·注入列，且是真正的租户隔离键，表里没有 |
| **缺** `CREATED_BY` / `UPDATED_BY` | — | 真·注入列（`AUDIT_PROVENANCE_FIELDS` 的一半），表里没有 |
| `USER_ID` | "Foreign key to user on session / account objects" | 是**声明**字段，业务对象也会合法声明它；不是注入列，但没写 |
| `DELETED_AT` | "Soft-delete timestamp" | 由 lifecycle / trash 层写，`applySystemFields` 不注入；没写 |

## 后果（已实测）

下游消费方把这张表当注入集手抄，然后各自漂移。cloud#982 在 cloud 一个包里查出**三份**手抄清单，分别带着 `tenant_id`、`org_id`、`space` —— 三个拼写**没有任何注入点会产生**。其中一份的漂移已经发作成用户可见故障（cloud#979）：清单里的 `owner` 让一个业务字段被当成系统列，种子生成器双重跳过它，**每一行种子数据的「负责人」列都是空的**。

根因是这张表**混装了三类东西**（真注入 / 遗留别名 / 声明字段）却只给了一个名字，且缺了三个真注入列。

## 改动

**纯增量 —— 不删任何条目、不改任何取值。**

- 补 `ORGANIZATION_ID` / `CREATED_BY` / `UPDATED_BY` 三个缺失的注入列常量；
- 每条注明 open-core **是否真的注入**，让遗留（`tenant_id`）和声明（`user_id`）拼写不再可能被误当成 provisioned 列；
- 模块 doc 说清这是**名字注册表，不是注入集**：注入是 `applySystemFields` **按对象**从 `ownership` / `tenancy` / `systemFields` 算出来的，所以同一个名字在 A 对象上是系统列、在 B 对象上是业务字段。要回答「这个字段在**这个对象**上是不是系统列」，应该 branch 在 `Field.system` 上 —— 那个标志本来就是为这件事发布的（`field.zod.ts` 的 describe 原文就是这么说的），doc 现在指过去；
- 测试补上三个新常量的断言，外加一条「表里必须有 registry 真实注入的每一列」的断言，说明它当初为什么会漏。

## 兼容性

- `@objectstack/lint` 的 `SYSTEM_FIELDS` **内容不变**：它是本表与 `FIELD_GROUP_SYSTEM_FIELDS` 的并集，而后者已经含这三个新增名字。其 "contains nothing BEYOND the two spec declarations" 断言照过。
- 无删除、无改值，因此对现有 `SystemFieldName.X` 引用零影响。

## 验证

```
pnpm --filter @objectstack/spec test        # 285 files / 7229 tests 全绿
pnpm --filter @objectstack/spec typecheck   # 干净
pnpm --filter @objectstack/lint test        # 43 files / 729 tests 全绿
pnpm --filter @objectstack/objectql test    # 92 files / 1506 tests 全绿
```

## 相关

- cloud#982 —— 消费侧的对应修复（cloud 改为逐对象判定 + 一条会响亮失败的对账门）。该 PR **不消费本表**，所以两者互不阻塞。
- cloud#979 —— 这个歧义的一次用户可见发作。

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRXTo7QC2A6EXXxJ5GKwsS)_