### PR TITLE
docs(client): drop the retired validateOnly batch option from the README (#4052)

### DIFF
--- a/.changeset/client-readme-retired-validate-only.md
+++ b/.changeset/client-readme-retired-validate-only.md
@@ -1,0 +1,25 @@
+---
+'@objectstack/client': patch
+---
+
+docs(client): drop the retired `validateOnly` batch option from the README (#4052)
+
+The Batch Options section still documented `validateOnly` as a working dry-run —
+"validate records without persisting changes" — but the key was retired in #4052
+precisely because nothing ever read it. Every batch surface (`updateManyData` /
+`deleteManyData` / `batchData`) persisted regardless, so a caller who sent it to
+preview a mutation got that mutation **executed**.
+
+`BatchOptionsSchema` has carried a `retiredKey(...)` tombstone since #4052, so the
+schema already refuses the key loudly. The README was the last place still
+promising it — declared-but-not-enforced in prose rather than in code, aimed at
+exactly the readers who cannot see the tombstone.
+
+Released as a patch rather than declared release-nothing because `README.md` is in
+this package's `files`: the corrected text only reaches the people who hit the
+problem — readers on npmjs.com — if the package ships.
+
+Replaced with a pointer to `docs/protocol-upgrade-guide.md`
+(`batch-options-validate-only-retired`). No behaviour change; there is no batch
+dry-run today. Write-path validate-only was evaluated in #4372 and closed as not
+planned — no current consumer justifies the surface.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -134,7 +134,10 @@ Batch operations support the following options:
 - `atomic`: If true, rollback entire batch on any failure (default: true).
 - `returnRecords`: If true, return full record data in response (default: false).
 - `continueOnError`: If true (and atomic=false), continue processing remaining records after errors.
-- `validateOnly`: If true, validate records without persisting changes (dry-run mode).
+
+> `validateOnly` was retired in #4052 — it was never implemented and batch surfaces persisted
+> regardless, so there is no batch dry-run today. Drop the key; see
+> `docs/protocol-upgrade-guide.md` (`batch-options-validate-only-retired`).
 
 ### Error Handling
 The client provides standardized error handling with machine-readable error codes:


### PR DESCRIPTION
## 问题

`packages/client/README.md` 的 Batch Options 一节至今仍把 `validateOnly` 文档化为可用的 dry-run:

```
- `validateOnly`: If true, validate records without persisting changes (dry-run mode).
```

这个 key 在 #4052 已经退役,`BatchOptionsSchema` 里是 `retiredKey(...)` 墓碑。退役的理由恰恰是它从未被实现——批量写入面(`updateManyData` / `deleteManyData` / `batchData`)一律照常落库,调用方发 `validateOnly: true` 想预览一次变更,拿到的是**真的执行了**。README 继续承诺它可用,是同一个「declared ≠ enforced」(PD #10)的文档版本:读 README 的调用方会写下一个数据安全保证,而那个保证不存在。

## 改动

删掉那一行,替换为指向墓碑的说明,措辞与 `docs/protocol-upgrade-guide.md` 的 `batch-options-validate-only-retired` 条目一致:

&gt; `validateOnly` was retired in #4052 — it was never implemented and batch surfaces persisted
&gt; regardless, so there is no batch dry-run today. Drop the key; see
&gt; `docs/protocol-upgrade-guide.md` (`batch-options-validate-only-retired`).

Batch Options 列表其余三项(`atomic` / `returnRecords` / `continueOnError`)不动。

## 背景

这处不一致是在评估 #4372(写路径 validate-only / dry-run 模式)时发现的。该 issue 已按产品评估关闭为 not planned——没有当前消费者,而没有消费者的写路径 data-safety flag 正是 #4052 的失败模式。既然结论是「今天没有 dry-run」,文档就不该继续说有。

## 范围与验证

纯文档改动,无代码、无 spec、无生成物变更。

带 `@objectstack/client: patch` changeset,而不是「releases nothing」的空 changeset:`README.md` 在本包 `package.json` 的 `files` 里,**随包发布**——改对的文字只有在包发布后才真正送达受影响的读者(npmjs.com 上读 README 的调用方)。仓内既有的空 changeset 先例都是 ADR / 设计文档这类不随包发布的东西,与此不同。

验证方式:复核 diff 仅涉及目标行,以及新文案与 upgrade-guide、`batch.zod.ts` 墓碑三处措辞一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zx2NHsRkFzpKoefPEWZxD

---
_Generated by [Claude Code](https://claude.ai/code/session_016zx2NHsRkFzpKoefPEWZxD)_