### PR TITLE
feat(lint): flag an action nobody placed — ADR-0078 Phase 3 `action-locations`

### DIFF
--- a/.changeset/action-no-placement-lint.md
+++ b/.changeset/action-no-placement-lint.md
@@ -1,0 +1,45 @@
+---
+"@objectstack/lint": minor
+"@objectstack/cli": minor
+"@objectstack/metadata-protocol": minor
+---
+
+Lint an action nobody placed (ADR-0078 Phase 3, Tier-A `action-locations`).
+
+New advisory rule `action-no-placement`: an action that declares no
+`locations` and that no list view places by name renders on **no** surface —
+it parses, publishes, and appears in Setup, while no user can ever click it.
+ADR-0078 names this shape in its opening paragraph and Phase 3 asks for
+exactly this rule; the shared completeness predicate it envisioned was never
+built, so this lands standalone, one verified shape at a time.
+
+What made it verifiable now: objectui#3142 collapsed four disagreeing
+renderers onto one placement predicate. Before that, `action:bar` and the
+record header rendered an *undeclared* action anyway, so the shape only looked
+inert on paper. As of objectui 17.1 it is measurably inert.
+
+Two things are deliberately **not** flagged:
+
+- **`locations: []`** — the documented headless action (callable over REST /
+  MCP / AI, no UI surface). ADR-0110 D3 refuses an undeclared handler, so a
+  headless declaration is the only legal way to expose one. The rule therefore
+  distinguishes "nowhere, deliberately" (`[]`) from an unstated placement (key
+  absent) and only reports the latter.
+- **Actions a view places by name** — `bulkActions`, `bulkActionDefs`
+  (including `execution: 'aggregate'` defs, whose whole point is an action with
+  no single-record home) and `rowActions`, across all three list-view tiers:
+  `views[i].list`, `views[i].listViews.<key>` and the object-embedded
+  `objects[i].listViews.<key>`.
+
+Advisory, never fatal — a view in another installed package may be the one
+placing the action, the same reason `validateSemanticRoles` and
+`lintLivenessProperties` warn rather than gate.
+
+Also: the action form schema in `@objectstack/metadata-protocol` no longer
+declares `shortcut` / `bulkEnabled`. Both were retired as `retiredKey()`
+tombstones in spec 17, and this schema is what the Studio designer renders its
+fallback form from — so advertising them handed authors two inputs that could
+only ever produce an unsaveable draft (objectui#3145 removed the matching
+dedicated controls). And `content/docs/ui/actions.mdx` now says which surface
+is the exception to location filtering, instead of a blanket claim its own
+showcase contradicted.

--- a/content/docs/ui/actions.mdx
+++ b/content/docs/ui/actions.mdx
@@ -210,9 +210,17 @@ defineView({
 ```
 
 <Callout type="info">
-Naming an action in a widget does **not** bypass location filtering — the
+Naming an action in a **widget** does not bypass location filtering — the
 engine still requires the action to declare the matching location (that's why
 `MarkDoneAction` above includes `record_section`).
+
+The **selection bar is the exception**, and the only one: an action named in a
+list view's `bulkActions` or `bulkActionDefs` is placed by that declaration,
+not by `locations`. That is what the retired `action.bulkEnabled` tombstone
+prescribes ("the multi-select toolbar is driven by the LIST VIEW's
+`bulkActions` / `bulkActionDefs`"), and it is what lets an aggregate bulk
+action — one that acts on a whole selection and has no single-record home by
+construction — exist at all.
 </Callout>
 
 ## Collect input and shape the UX

--- a/packages/cli/src/lint/authoring-rules.ts
+++ b/packages/cli/src/lint/authoring-rules.ts
@@ -94,6 +94,7 @@ import {
   validateVisibilityPredicates,
   validateSecurityPosture,
   validateOrgAxisRedLines,
+  validateActionLocations,
 } from '@objectstack/lint';
 import { lintFlowPatterns } from '../utils/lint-flow-patterns.js';
 import { lintLivenessProperties } from '../utils/lint-liveness-properties.js';
@@ -384,6 +385,20 @@ export const AUTHORING_RULES: readonly AuthoringRule[] = [
     commands: ALL,
     source: 'packages/lint/src/validate-semantic-roles.ts',
     run: (stack) => validateSemanticRoles(stack),
+  },
+  // ADR-0078 Phase 3 (Tier-A `action-locations`) — an action that declares no
+  // `locations` and that no view places by name renders on no surface at all.
+  // objectui#3142 made that measurable: four renderers used to show an
+  // undeclared action anyway, and now none does. Advisory: a view in another
+  // installed package may be the one placing it, and `locations: []` (the
+  // documented headless shape) is deliberately never flagged.
+  {
+    name: 'validateActionLocations',
+    tier: 'advisory',
+    input: 'parsed',
+    commands: ALL,
+    source: 'packages/lint/src/validate-action-locations.ts',
+    run: (stack) => validateActionLocations(stack),
   },
   // framework#3434 — seeds replay on every boot, so a `mode: 'insert'` dataset
   // duplicates its table on every restart.

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -207,6 +207,9 @@ export type {
 export { validateActionNameRefs, ACTION_NAME_UNDEFINED } from './validate-action-name-refs.js';
 export type { ActionNameRefFinding, ActionNameRefSeverity } from './validate-action-name-refs.js';
 
+export { validateActionLocations, ACTION_NO_PLACEMENT } from './validate-action-locations.js';
+export type { ActionLocationsFinding, ActionLocationsSeverity } from './validate-action-locations.js';
+
 export { validatePageFieldBindings, PAGE_FIELD_UNKNOWN } from './validate-page-field-bindings.js';
 export type { PageFieldFinding, PageFieldSeverity } from './validate-page-field-bindings.js';
 

--- a/packages/lint/src/validate-action-locations.test.ts
+++ b/packages/lint/src/validate-action-locations.test.ts
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { validateActionLocations, ACTION_NO_PLACEMENT } from './validate-action-locations.js';
+
+/** A stack whose single action declares a real placement. */
+const placed = () => ({
+  objects: [{ name: 'crm_lead', fields: { name: { type: 'text' } } }],
+  actions: [
+    {
+      name: 'crm_convert_lead',
+      label: 'Convert',
+      type: 'script',
+      locations: ['record_header'],
+    },
+  ],
+});
+
+/** The same action with the placement key absent. */
+const unplaced = () => ({
+  objects: [{ name: 'crm_lead', fields: { name: { type: 'text' } } }],
+  actions: [{ name: 'crm_convert_lead', label: 'Convert', type: 'script' }],
+});
+
+describe('validateActionLocations', () => {
+  it('flags an action that declares no locations and that no view places', () => {
+    const findings = validateActionLocations(unplaced());
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+    expect(findings[0].rule).toBe(ACTION_NO_PLACEMENT);
+    expect(findings[0].path).toBe('actions[0]');
+    expect(findings[0].where).toBe('action "crm_convert_lead"');
+    expect(findings[0].message).toContain('renders on no surface');
+    expect(findings[0].hint).toContain('locations: []');
+  });
+
+  it('accepts a declared placement', () => {
+    expect(validateActionLocations(placed())).toEqual([]);
+  });
+
+  it('walks object-embedded actions too', () => {
+    const findings = validateActionLocations({
+      objects: [
+        {
+          name: 'crm_lead',
+          actions: [{ name: 'crm_score', label: 'Score', type: 'script' }],
+        },
+      ],
+    });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].path).toBe('objects[0].actions[0]');
+  });
+
+  it('ignores a nameless action — that is action-name-*’s problem, not this rule’s', () => {
+    expect(validateActionLocations({ actions: [{ label: 'Nameless', type: 'script' }] })).toEqual([]);
+  });
+
+  describe('— headless actions (`locations: []`) are never flagged', () => {
+    it('accepts an explicitly empty placement', () => {
+      // `content/docs/ui/actions.mdx` documents the empty array as the way to
+      // declare a REST/MCP/AI-callable action with no UI surface. ADR-0110 D3
+      // refuses an UNdeclared handler, so this is the only legal shape for one
+      // — flagging it would fight that ADR.
+      const findings = validateActionLocations({
+        actions: [{ name: 'crm_sync_remote', label: 'Sync', type: 'script', locations: [] }],
+      });
+      expect(findings).toEqual([]);
+    });
+
+    it('distinguishes "nowhere, deliberately" from an unstated placement', () => {
+      const findings = validateActionLocations({
+        actions: [
+          { name: 'said_nowhere', type: 'script', locations: [] },
+          { name: 'said_nothing', type: 'script' },
+        ],
+      });
+      expect(findings.map((f) => f.where)).toEqual(['action "said_nothing"']);
+    });
+  });
+
+  describe('— a view that places the action by NAME exempts it', () => {
+    it('exempts an action named in a list view’s bulkActions', () => {
+      const findings = validateActionLocations({
+        ...unplaced(),
+        views: [{ name: 'crm_lead', list: { bulkActions: ['crm_convert_lead'] } }],
+      });
+      expect(findings).toEqual([]);
+    });
+
+    it('exempts an action named in a bulkActionDefs entry (incl. aggregate defs)', () => {
+      // objectui#3139: an aggregate bulk action has no single-record location
+      // by construction — the view naming it IS the placement.
+      const findings = validateActionLocations({
+        ...unplaced(),
+        views: [
+          {
+            name: 'crm_lead',
+            list: {
+              bulkActionDefs: [
+                { name: 'crm_convert_lead', operation: 'custom', execution: 'aggregate' },
+              ],
+            },
+          },
+        ],
+      });
+      expect(findings).toEqual([]);
+    });
+
+    it('exempts an action named in rowActions', () => {
+      const findings = validateActionLocations({
+        ...unplaced(),
+        views: [{ name: 'crm_lead', list: { rowActions: ['crm_convert_lead'] } }],
+      });
+      expect(findings).toEqual([]);
+    });
+
+    it('exempts via a named listViews entry, not just the default list', () => {
+      const findings = validateActionLocations({
+        ...unplaced(),
+        views: [{ name: 'crm_lead', listViews: { hot: { bulkActions: ['crm_convert_lead'] } } }],
+      });
+      expect(findings).toEqual([]);
+    });
+
+    it('exempts via an OBJECT-embedded list view — an object has no top-level `list`', () => {
+      const findings = validateActionLocations({
+        objects: [
+          {
+            name: 'crm_lead',
+            listViews: { all: { bulkActions: ['crm_convert_lead'] } },
+          },
+        ],
+        actions: [{ name: 'crm_convert_lead', label: 'Convert', type: 'script' }],
+      });
+      expect(findings).toEqual([]);
+    });
+
+    it('still flags an action no view names, alongside one that is named', () => {
+      const findings = validateActionLocations({
+        actions: [
+          { name: 'named_one', type: 'script' },
+          { name: 'orphan_one', type: 'script' },
+        ],
+        views: [{ name: 'crm_lead', list: { bulkActions: ['named_one'] } }],
+      });
+      expect(findings.map((f) => f.where)).toEqual(['action "orphan_one"']);
+    });
+  });
+
+  describe('— floor', () => {
+    it('returns nothing for a clean stack', () => {
+      expect(validateActionLocations(placed())).toEqual([]);
+    });
+
+    it('returns nothing for an empty stack', () => {
+      expect(validateActionLocations({})).toEqual([]);
+    });
+
+    it('returns nothing for a null stack', () => {
+      expect(validateActionLocations(null as unknown as Record<string, unknown>)).toEqual([]);
+    });
+  });
+});

--- a/packages/lint/src/validate-action-locations.ts
+++ b/packages/lint/src/validate-action-locations.ts
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [ADR-0078 Phase 3 — Tier-A `action-locations`] An action nobody placed.
+ *
+ * `locations` is an action's placement declaration. An action that omits it —
+ * and that no view names in `bulkActions` / `bulkActionDefs` / `rowActions` —
+ * has no surface at all: it parses, it publishes, Setup lists it, and no user
+ * can ever click it. ADR-0078 names this shape in its opening paragraph ("a
+ * `summary` with no `summaryOperations`; **an `action` with no `locations`**;
+ * … Each parses, 'renders', reports success — and does nothing") and Phase 3
+ * asks for exactly this rule, one verified shape at a time.
+ *
+ * The renderer half is now unambiguous: objectui#3142 collapsed four
+ * disagreeing renderers onto one predicate — an action renders at a location
+ * only if it DECLARES that location. Before that, `action:bar` and the record
+ * header showed an undeclared action *everywhere*, which is what made this
+ * shape look alive; it is measurably inert as of objectui 17.1.
+ *
+ * ## What is NOT flagged, and why
+ *
+ * **`locations: []` — a deliberate headless action.** `content/docs/ui/
+ * actions.mdx` ("Headless actions: declare it, then hide it") documents the
+ * empty array as a first-class shape: the action stays callable over REST /
+ * MCP / AI and keeps its capability gate, param contract and audit trail,
+ * while claiming no UI surface. ADR-0110 D3 refuses an *undeclared* handler,
+ * so a headless declaration is the only legal way to expose such an action —
+ * flagging it would fight that ADR. The distinction this rule draws is
+ * therefore between an author who said "nowhere, deliberately" (`[]`) and one
+ * who never said anything at all (key absent).
+ *
+ * **Actions a view places by NAME.** Naming an action in a list view's
+ * `bulkActions` or `bulkActionDefs` IS its placement — the selection bar is
+ * driven by the view, never by `locations` (that is what the retired
+ * `action.bulkEnabled` tombstone prescribes, and what objectui#3139's
+ * aggregate bulk mode relies on: an action that only makes sense over a
+ * selection has no single-record location by construction). `rowActions` is
+ * exempted on the same zero-false-positive posture (ADR-0072 D1): it is the
+ * same field pair on the same container, and an author who named an action
+ * there has stated an intent — a name that resolves to nothing is already
+ * `action-name-undefined`'s job, not this rule's.
+ *
+ * Scope note: this rule asks only "did anyone place this action?". It
+ * deliberately does NOT check that a declared location is one a renderer
+ * actually serves, nor that a view's named action belongs to that view's
+ * object — distinct classes with their own rules. Cross-package placement (a
+ * view in another installed package naming this action) is the one legitimate
+ * miss, which is why this is a **warning**: like every other "declared but
+ * does nothing" finding in this package (`validateSemanticRoles`,
+ * `lintLivenessProperties`), it is high-signal and never fatal.
+ */
+
+export const ACTION_NO_PLACEMENT = 'action-no-placement';
+
+export type ActionLocationsSeverity = 'error' | 'warning';
+
+export interface ActionLocationsFinding {
+  /** Always `warning` — cross-package placement is a legitimate miss. */
+  severity: ActionLocationsSeverity;
+  /** Diagnostic rule id. */
+  rule: string;
+  /** Human-readable location, e.g. `action "crm_convert_lead"`. */
+  where: string;
+  /** Config path, e.g. `actions[2]` or `objects[0].actions[1]`. */
+  path: string;
+  /** What is wrong. */
+  message: string;
+  /** How to fix it. */
+  hint: string;
+}
+
+type AnyRec = Record<string, unknown>;
+
+function asArray(v: unknown): AnyRec[] {
+  if (Array.isArray(v)) return v as AnyRec[];
+  if (v && typeof v === 'object') {
+    return Object.entries(v as AnyRec).map(([name, def]) => ({ name, ...(def as AnyRec) }));
+  }
+  return [];
+}
+
+function strName(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+function strList(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string' && x.length > 0) : [];
+}
+
+/**
+ * Every action name a view places by NAME, across all three list-view tiers:
+ * `views[i].list`, `views[i].listViews.<key>`, and the object-embedded
+ * `objects[i].listViews.<key>` (an object has no top-level `list`). Missing
+ * the object-embedded tier would flag actions that an object's own view
+ * places — the trap `validate-list-view-mode.ts` already walks around.
+ */
+function collectNamePlacedActions(stack: AnyRec): Set<string> {
+  const placed = new Set<string>();
+
+  const harvest = (container: unknown): void => {
+    if (!container || typeof container !== 'object') return;
+    const list = container as AnyRec;
+    for (const key of ['rowActions', 'bulkActions'] as const) {
+      for (const n of strList(list[key])) placed.add(n);
+    }
+    // A `bulkActionDefs` entry is a loose record; its `name` is the action it
+    // dispatches. Inline field-patch defs (`operation: 'update'`) carry a name
+    // that matches no action — harmless here, since an unmatched name simply
+    // never exempts anything.
+    for (const def of asArray(list.bulkActionDefs)) {
+      const n = strName(def?.name);
+      if (n) placed.add(n);
+    }
+  };
+
+  const harvestListViews = (listViews: unknown): void => {
+    if (!listViews || typeof listViews !== 'object' || Array.isArray(listViews)) return;
+    for (const lv of Object.values(listViews as AnyRec)) harvest(lv);
+  };
+
+  for (const view of asArray(stack.views)) {
+    if (!view || typeof view !== 'object') continue;
+    harvest(view.list);
+    harvestListViews(view.listViews);
+  }
+  for (const obj of asArray(stack.objects)) {
+    if (!obj || typeof obj !== 'object') continue;
+    harvestListViews(obj.listViews);
+  }
+
+  return placed;
+}
+
+/**
+ * Flag every action that declares no placement and that no view places by
+ * name. Returns findings (empty = clean).
+ */
+export function validateActionLocations(stack: AnyRec): ActionLocationsFinding[] {
+  const findings: ActionLocationsFinding[] = [];
+  if (!stack || typeof stack !== 'object') return findings;
+
+  const namePlaced = collectNamePlacedActions(stack);
+
+  const check = (action: AnyRec | undefined, path: string): void => {
+    if (!action || typeof action !== 'object') return;
+    // `[]` is the documented headless shape — the author said "nowhere" on
+    // purpose. Only a MISSING key is unstated placement.
+    if ('locations' in action) return;
+    const name = strName(action.name);
+    if (!name) return; // nameless actions are `action-name-*`'s problem
+    if (namePlaced.has(name)) return;
+
+    findings.push({
+      severity: 'warning',
+      rule: ACTION_NO_PLACEMENT,
+      where: `action "${name}"`,
+      path,
+      message:
+        `Action "${name}" declares no \`locations\` and no view places it by name, ` +
+        'so it renders on no surface — the button exists in metadata and nowhere in the UI.',
+      hint:
+        'Add the surface it belongs on, e.g. `locations: [\'record_header\']` (or `list_item`, ' +
+        '`list_toolbar`, `record_more`, `record_section`, `record_related`, `global_nav`); or ' +
+        "place it from a list view's `bulkActions` / `bulkActionDefs` if it acts on a selection. " +
+        'If it is meant to be callable over REST / MCP / AI with no UI surface, say so explicitly ' +
+        'with `locations: []` — an empty array is the documented headless shape and is never flagged.',
+    });
+  };
+
+  const actions = asArray(stack.actions);
+  for (let i = 0; i < actions.length; i++) check(actions[i], `actions[${i}]`);
+
+  const objects = asArray(stack.objects);
+  for (let oi = 0; oi < objects.length; oi++) {
+    const obj = objects[oi];
+    if (!obj || typeof obj !== 'object') continue;
+    const own = asArray(obj.actions);
+    for (let ai = 0; ai < own.length; ai++) check(own[ai], `objects[${oi}].actions[${ai}]`);
+  }
+
+  return findings;
+}

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -207,8 +207,14 @@ const HAND_CRAFTED_SCHEMAS: Record<string, Record<string, unknown>> = {
             component: { type: 'string' },
             visible: { type: 'string' },
             disabled: { type: 'string' },
-            shortcut: { type: 'string' },
-            bulkEnabled: { type: 'boolean', default: false },
+            // No `shortcut` / `bulkEnabled`: spec 17 retired both as
+            // `retiredKey()` tombstones, so authoring either is a hard parse
+            // rejection. This schema is what the Studio designer renders its
+            // fallback form from, so leaving them here handed authors two
+            // inputs that could only ever produce an unsaveable draft
+            // (objectui#3145 removed the matching dedicated controls).
+            // `bulkEnabled`'s replacement is the list view's `bulkActions` /
+            // `bulkActionDefs`; `shortcut` has none.
             aiExposed: { type: 'boolean', default: false },
             recordIdParam: { type: 'string' },
             recordIdField: { type: 'string' },


### PR DESCRIPTION
objectui 侧配套:objectstack-ai/objectui#3154(移除同两个退役 key 的授权控件)。

## 新规则 `action-no-placement`(advisory)

一个动作**既没声明 `locations`、也没有任何列表视图按名字放置它**,就渲染不到任何表面 —— 它能解析、能发布、在 Setup 里能看到,而没有任何用户点得到它。

ADR-0078 开篇就点名了这个形态(「a `summary` with no `summaryOperations`; **an `action` with no `locations`**; … Each parses, "renders", reports success — and does nothing」),Phase 3 要的正是这条规则。ADR 设想的**共享完整性谓词从未被建造**(其 Status 行自陈),所以本次按 Phase 3 自己的说法「one verified shape at a time」独立落地。

**为什么现在才可验证**:objectui#3142 之前,`action:bar` 和记录头部会把**未声明**的动作照样渲染出来 —— 这个形态在纸面上看着 inert,实际不是。四个渲染器统一到一条放置规则之后(objectui 17.1),它才真正可测量地 inert。

## 两处刻意不报

- **`locations: []`** —— 文档化的 headless 动作(`actions.mdx` 的「Headless actions: declare it, then hide it」:保留能力门、参数契约、审计轨迹,只是不占 UI 表面)。ADR-0110 D3 又拒绝**未声明**的 handler,所以 headless 声明是暴露这类动作的唯一合法写法,报它等于和那条 ADR 打架。规则因此区分「**明确说了哪都不放**(`[]`)」与「**根本没说**(key 缺失)」,只报后者。
- **被视图按名字放置的动作** —— `bulkActions`、`bulkActionDefs`(含 `execution: 'aggregate'` 的定义,这类动作按构造就没有单记录位置)、`rowActions`,覆盖三层列表视图:`views[i].list`、`views[i].listViews.<key>`,以及**对象内嵌**的 `objects[i].listViews.<key>`(对象没有顶层 `list`,漏掉这层会误报对象自己视图放置的动作)。

## 严重度

`warning` / `tier: 'advisory'`,与 `validateSemanticRoles`、`lintLivenessProperties` 同类 —— 另一个已安装包里的视图可能才是放置方。ADR-0078 §1 也规定「`error` 只用于完全 inert,degrade 的用 `warning`」,而这里存在真实的跨包漏报面。

## 一并修掉的两处

- **`metadata-protocol` 的动作表单 schema 不再声明 `shortcut` / `bulkEnabled`**。两者都是 spec 17 的 `retiredKey()` 墓碑,而这份 schema 正是 Studio 设计器渲染回退表单的依据 —— 继续声明等于给作者两个只能产出**存不下去的草稿**的输入框(objectui#3154 删的是与之配对的专用控件)。
- **`content/docs/ui/actions.mdx` 的一句话过宽**:它断言"在 widget 里命名动作不绕过位置过滤",而 showcase 自己的 `task.view.ts` 写着 bulk 场景"命名它就是全部声明"。两者其实都对 —— 选中条是**唯一**的例外(这正是 `action.bulkEnabled` 墓碑的原话所规定的)。现在文档说准了,不再与自己的示例互相矛盾。

## 测试与验证

- 新增 15 项规则测试:三层视图放置的豁免、`[]` 与缺失的区分、对象内嵌动作、无名动作跳过,以及模板要求的 floor(clean / `{}` / `null`)。
- **接线守卫 17 项通过**(`authoring-rule-wiring.test.ts` 会读规则源码校验 advisory 声明是否自洽、`source` 路径是否存在、是否被命令文件直接 import)。
- `packages/lint` **744** 项、`packages/cli` **689** 项全通过;全量构建通过。
- **零误报实测**:对 `app-showcase` / `app-crm` / `app-todo` 跑 `objectstack lint`,该规则均无输出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9aiswZBzoVYsyLKRuGByE

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9aiswZBzoVYsyLKRuGByE)_