### PR TITLE
docs(spec,metadata-protocol): the code is the record for platform `agent` definitions (#4507)

### DIFF
--- a/.changeset/agent-code-is-the-record.md
+++ b/.changeset/agent-code-is-the-record.md
@@ -1,0 +1,33 @@
+---
+---
+
+docs(spec,metadata-protocol): record why platform `agent` definitions have no metadata change log (#4507)
+
+Comment-only — no behaviour changes, nothing to release.
+
+`agent` is the only authorable metadata type with no governed write path
+(`allowOrgOverride` and `allowRuntimeCreate` are both `false` per ADR-0063 §2,
+which closes `*.agent.ts` to third parties). Its rows are written by the
+shipping plugin at boot — `AIStudioPlugin.registerMeta` → `metadataService.register()`
+→ `MetadataManager.register` → `DatabaseLoader.save` — which writes
+`sys_metadata` directly with a fresh checksum and appends no
+`sys_metadata_history` row. So a shipped agent definition that changes between
+releases leaves no metadata-side change log.
+
+That is accepted rather than overlooked, and the reasoning now sits beside the
+declaration instead of in an issue: the two definitions live in version control
+(`@objectstack/service-ai-studio` in the `cloud` repo), so git already holds the
+full reviewable history. A second history in `sys_metadata` would be a *worse*
+record — it would capture only the boots where a given deployment happened to
+see the checksum move, so two deployments on the same release would carry
+different "histories" of an identical, code-fixed definition.
+
+Two consequences that read as bugs and are not are named explicitly: the
+`skipped` outcome `os migrate meta --stored` reports for `agent` rows is correct
+and permanent for this type, and Studio showing no History tab for an agent is
+the absence of anything to show. `migrateStoredMetadata`'s TSDoc now points at
+the note rather than leaving its skip reason to be read as a to-do.
+
+The note also states its own expiry: if `agent` is ever opened to tenant
+authoring, an author-owned definition has no git to fall back on, so opening the
+type and giving it a real history path become the same piece of work.

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -6610,6 +6610,14 @@ export class ObjectStackProtocolImplementation implements
      *   raw-engine branch, which records no history and forces `state:
      *   'active'` — a historyless rewrite that could also promote a draft is
      *   not what this pass promises, so it declines instead.
+     *
+     *   Today that is exactly one type, `agent`, and its skip is **permanent
+     *   by design, not a to-do** (#4507): ADR-0063 §2 closes `*.agent.ts` to
+     *   third parties, so the only agent definitions in existence are the two
+     *   the platform ships from version control — where git, not
+     *   `sys_metadata_history`, is the change log. See the note beside the
+     *   `agent` entry in `metadata-plugin.zod.ts` before treating this branch
+     *   as a gap to close.
      * - **Rows that still fail the current schema after conversion.**
      *   `saveMetaItem` rejects them (422) and that rejection is correct: the
      *   body is a genuine contract violation, not chain-owned history. They

--- a/packages/spec/src/kernel/metadata-plugin.zod.ts
+++ b/packages/spec/src/kernel/metadata-plugin.zod.ts
@@ -695,6 +695,40 @@ export const DEFAULT_METADATA_TYPE_REGISTRY: MetadataTypeRegistryEntry[] = [
   // allowRuntimeCreate:false (no runtime "create agent") and
   // allowOrgOverride:false (no per-org agent fork). The runtime catalog
   // additionally filters out any non-platform agent record (see service-ai).
+  //
+  // FOR AGENTS, THE CODE IS THE RECORD — and that is the whole answer to
+  // "where is this type's change log?" (#4507). Because the two flags above
+  // are false, `agent` is the one authorable type with NO governed write
+  // path: `saveMetaItem` would route it down the legacy raw-engine branch,
+  // and nothing calls it. The rows are written instead by the shipping
+  // plugin at boot — `AIStudioPlugin.registerMeta` → `metadataService
+  // .register()` → `MetadataManager.register` → `DatabaseLoader.save` —
+  // which writes `sys_metadata` directly with a fresh checksum and appends
+  // NO `sys_metadata_history` row. So an agent definition that changes
+  // between releases leaves no metadata-side change log, and there is no
+  // metadata-side rollback.
+  //
+  // That is accepted, not overlooked. These definitions live in version
+  // control (`@objectstack/service-ai-studio`, `cloud` repo:
+  // `agents/ask-agent.ts`, `agents/metadata-assistant-agent.ts`), so git
+  // already holds the full, reviewable history of every change. A second
+  // history in `sys_metadata` would be a WORSE record, not a better one: it
+  // would capture only the boots where a given deployment happened to see
+  // the checksum move, so two deployments on the same release would carry
+  // different "histories" of an identical, code-fixed definition. Do not add
+  // one to close a perceived gap.
+  //
+  // Two consequences that look like bugs and are not:
+  //  - `migrateStoredMetadata` reports `agent` rows `skipped` ("no repository
+  //    write path"). That is CORRECT AND PERMANENT for this type, not a
+  //    to-do — the pass declines rather than performing a historyless
+  //    rewrite that could also promote a draft.
+  //  - Studio surfaces no History tab for an agent. There is nothing to show;
+  //    the answer to "what changed" is the `cloud` commit log.
+  //
+  // If `agent` is ever OPENED to tenant authoring, this note stops applying:
+  // an author-owned definition has no git to fall back on, so opening the
+  // type and giving it a real history path are the same piece of work.
   { type: 'agent', label: 'AI Agent', filePatterns: ['**/*.agent.ts', '**/*.agent.yml'], supportsOverlay: false, allowOrgOverride: false, allowRuntimeCreate: false, supportsVersioning: true, executionPinned: true, loadOrder: 90, domain: 'ai' },
   { type: 'tool', label: 'AI Tool', filePatterns: ['**/*.tool.ts', '**/*.tool.yml'], supportsOverlay: true, allowOrgOverride: true, allowRuntimeCreate: true, supportsVersioning: false, executionPinned: false, loadOrder: 85, domain: 'ai' },
   { type: 'skill', label: 'AI Skill', filePatterns: ['**/*.skill.ts', '**/*.skill.yml'], supportsOverlay: true, allowOrgOverride: true, allowRuntimeCreate: true, supportsVersioning: false, executionPinned: false, loadOrder: 88, domain: 'ai' },


### PR DESCRIPTION
Closes #4507. Comment-only — no behaviour changes, empty changeset.

## Why

#4507 started as "the `agent` type has no change log — fix the write path." Checking it out produced the opposite conclusion, so this PR writes the conclusion down where the next person will hit it instead of leaving it in a closed issue.

`agent` is the only authorable metadata type with **no governed write path**. `packages/spec/src/kernel/metadata-plugin.zod.ts` already explained the flags:

> ADR-0063 §2 — `*.agent.ts` is CLOSED to third parties. The kernel ships exactly two platform-owned agents (`ask`/`build`); tenants extend the platform by authoring skills + tools, never agents.

What it did not explain is the consequence. Because both `allowOrgOverride` and `allowRuntimeCreate` are `false`, `saveMetaItem` would route an agent down the legacy raw-engine branch — and nothing calls it. The rows are written instead by the shipping plugin at boot:

```
AIStudioPlugin.registerMeta → metadataService.register()
  → MetadataManager.register → DatabaseLoader.save
```

`DatabaseLoader.save` writes the `sys_metadata` row directly with a fresh `checksum` and appends **no** `sys_metadata_history` row. So a shipped agent definition that changes between releases leaves no metadata-side change log and has no metadata-side rollback. The plugin's own log line is the tell: `refreshed (shipped definition changed)`.

## The position, now recorded

That is accepted, not overlooked, and the note says why in a way that should survive re-discovery:

- The definitions live in version control — `@objectstack/service-ai-studio` in the `cloud` repo (`agents/ask-agent.ts`, `agents/metadata-assistant-agent.ts`). **Git already holds the full, reviewable history of every change.**
- A second history in `sys_metadata` would be a **worse** record, not a better one. It would capture only the boots where a given deployment happened to see the checksum move — so two deployments on the same release would carry different "histories" of an identical, code-fixed definition. The note says explicitly: do not add one to close a perceived gap.

It also names the two consequences that look like bugs and are not:

| Looks like | Actually |
| :--- | :--- |
| `os migrate meta --stored` reports `agent` rows `skipped` | Correct **and permanent** for this type — the pass declines rather than performing a historyless rewrite that could also promote a draft |
| Studio shows no History tab for an agent | There is nothing to show; the answer to "what changed" is the `cloud` commit log |

And it states its own expiry: if `agent` is ever opened to tenant authoring, an author-owned definition has no git to fall back on — so opening the type and giving it a real history path become the same piece of work.

## Second edit

`migrateStoredMetadata`'s TSDoc is where this looked like a gap in the first place — its skip reason reads as a to-do. It now points at the note beside the declaration, so the migration's refusal is read as a design decision rather than an unfinished branch.

## Verification

Comment-only. `packages/spec` rebuilt with **no generated-artifact drift** (the change lives in a comment inside the type-registry array literal, so nothing propagates to the 8 generated artifacts). Spec kernel suite green (33 files / 689 tests), `eslint` clean on both files, `check:doc-authoring` and `check:slot-lookup` pass.

Empty-frontmatter changeset — the sanctioned "this PR releases nothing" declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoZPKPDqJ7WB7z84xk9y3f

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoZPKPDqJ7WB7z84xk9y3f)_