### PR TITLE
feat(spec)!: MetadataWatchEvent.type carries only the values the runtime emits (#4536)

### DIFF
--- a/.changeset/metadata-watch-event-canonical-enum.md
+++ b/.changeset/metadata-watch-event-canonical-enum.md
@@ -1,0 +1,12 @@
+---
+"@objectstack/spec": major
+---
+
+`MetadataWatchEvent.type` now carries only the values the runtime emits: the enum narrows FROM `'add' | 'change' | 'unlink' | 'added' | 'changed' | 'deleted'` TO `'added' | 'changed' | 'deleted'` (#4536, follow-up to #4411).
+
+The three raw chokidar values had zero producers: both emit sites normalize before constructing the event — `packages/metadata/src/node-metadata-manager.ts` translates chokidar's `add`/`change`/`unlink` in the watcher callbacks (`handleFileEvent` accepts only the canonical three), and `packages/metadata/src/metadata-manager.ts` normalizes repository ops (`create`/`update`/`delete` → `added`/`changed`/`deleted`). Consumers parsing events therefore never received the raw values, and no runtime behavior changes.
+
+- FROM: an external implementor could construct events typed `'add'`/`'change'`/`'unlink'` and readers had to (needlessly) branch on six values.
+- TO: an implementor constructing events with the raw values must emit `added`/`changed`/`deleted` instead; readers may delete any branches on `add`/`change`/`unlink` — they were unreachable.
+
+No tombstone / ADR-0087 conversion: this is a runtime event envelope type, not authorable metadata — nothing parses it on a load path (the #4411 route).

--- a/content/docs/references/system/metadata-persistence.mdx
+++ b/content/docs/references/system/metadata-persistence.mdx
@@ -353,7 +353,7 @@ const result = MetadataCollectionInfo.parse(data);
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **type** | `Enum<'add' \| 'change' \| 'unlink' \| 'added' \| 'changed' \| 'deleted'>` | ✅ |  |
+| **type** | `Enum<'added' \| 'changed' \| 'deleted'>` | ✅ |  |
 | **path** | `string` | ✅ |  |
 | **name** | `string` | optional |  |
 | **stats** | `{ path?: string; size?: number; mtime?: string; hash?: string; … }` | optional |  |

--- a/packages/spec/src/contracts/metadata-service.ts
+++ b/packages/spec/src/contracts/metadata-service.ts
@@ -36,7 +36,7 @@
  */
 
 import type { MetadataQuery, MetadataQueryResult, MetadataValidationResult, MetadataBulkResult, MetadataDependency } from '../kernel/metadata-plugin.zod';
-// The PERSISTENCE-side watch event (`add`/`added`/`changed`/`deleted`/…, path +
+// The PERSISTENCE-side watch event (`added`/`changed`/`deleted`, path +
 // file stats) — what `MetadataManager.subscribe` relays, as opposed to the
 // registration-level events `watch` forwards (`MetadataWatchCallback` below).
 // Spec used to carry a second, differently-shaped `MetadataWatchEvent` on
@@ -423,7 +423,7 @@ export interface IMetadataService {
      * NOT {@link watch} with a different return shape: the two carry different
      * events. `watch` reports registration-level transitions
      * (`registered`/`updated`/`unregistered`); `subscribe` relays the loader
-     * pipeline's {@link MetadataWatchEvent} (`add`/`changed`/`deleted`, with
+     * pipeline's {@link MetadataWatchEvent} (`added`/`changed`/`deleted`, with
      * path and file stats) — the granularity ObjectQLPlugin's metadata bridge
      * re-syncs runtime-authored hooks/actions from. (The first draft of this
      * member reused `watch`'s callback type; `MetadataManager implements

--- a/packages/spec/src/system/metadata-persistence.test.ts
+++ b/packages/spec/src/system/metadata-persistence.test.ts
@@ -381,16 +381,26 @@ describe('MetadataSaveResultSchema', () => {
 });
 
 describe('MetadataWatchEventSchema', () => {
-  it('should accept valid event types', () => {
-    const types = ['add', 'change', 'unlink', 'added', 'changed', 'deleted'];
+  it('should accept the canonical event types', () => {
+    const types = ['added', 'changed', 'deleted'];
     types.forEach((type) => {
       expect(() => MetadataWatchEventSchema.parse({ type, path: '/test' })).not.toThrow();
     });
   });
 
+  // Pin (#4536): the raw chokidar vocabulary is translated in
+  // NodeMetadataManager's watcher callbacks and never reaches the event
+  // surface — the schema must reject it, not smuggle it back in.
+  it('should reject the raw chokidar event types', () => {
+    const rawTypes = ['add', 'change', 'unlink'];
+    rawTypes.forEach((type) => {
+      expect(() => MetadataWatchEventSchema.parse({ type, path: '/test' })).toThrow();
+    });
+  });
+
   it('should accept full event', () => {
     const event = MetadataWatchEventSchema.parse({
-      type: 'change',
+      type: 'changed',
       path: '/metadata/view.json',
       name: 'account_view',
       stats: { size: 512 },
@@ -408,7 +418,7 @@ describe('MetadataWatchEventSchema', () => {
   });
 
   it('should reject missing path', () => {
-    expect(() => MetadataWatchEventSchema.parse({ type: 'add' })).toThrow();
+    expect(() => MetadataWatchEventSchema.parse({ type: 'added' })).toThrow();
   });
 });
 

--- a/packages/spec/src/system/metadata-persistence.zod.ts
+++ b/packages/spec/src/system/metadata-persistence.zod.ts
@@ -275,9 +275,15 @@ export const MetadataSaveResultSchema = lazySchema(() => z.object({
 
 /**
  * Metadata Watch Event
+ *
+ * `type` carries only the values the runtime emits. The raw chokidar
+ * vocabulary (`add`/`change`/`unlink`) is translated in NodeMetadataManager's
+ * watcher callbacks (`packages/metadata/src/node-metadata-manager.ts`
+ * `handleFileEvent`) and never reaches the event surface — the raw values had
+ * zero producers when they were declared here (#4536, follow-up to #4411).
  */
 export const MetadataWatchEventSchema = lazySchema(() => z.object({
-  type: z.enum(['add', 'change', 'unlink', 'added', 'changed', 'deleted']),
+  type: z.enum(['added', 'changed', 'deleted']),
   path: z.string(),
   name: z.string().optional(),
   stats: MetadataStatsSchema.optional(),


### PR DESCRIPTION
Closes #4536(#4535 主单 A1 项)。

`MetadataWatchEvent.type` 从 6 值收紧到 `'added' | 'changed' | 'deleted'`。原始 chokidar 词汇(`add`/`change`/`unlink`)在 `NodeMetadataManager` 的监听回调里就被翻译(`node-metadata-manager.ts` `handleFileEvent`),另一处构造点 `metadata-manager.ts:1663` 把 repo op 归一 —— **三个原始值零生产者**,declared ≠ enforced(Prime Directive #10)。#4411 当时拒绝收紧的理由(「它确实发 add/change/unlink」)经查不成立。

## 改动

- `system/metadata-persistence.zod.ts`:枚举收窄 + 注释说明原始词汇为何到不了事件面
- `contracts/metadata-service.ts`:`subscribe?` TSDoc 与 import 处注释的混用词汇修正(后者是 brief 外同性质的顺带修)
- `metadata-persistence.test.ts`:三值通过 + **pin 三个原始值被拒**;fixture 移离原始值
- changeset `major`,FROM → TO 齐备;不带 tombstone / conversion(运行时信封类型,#4411 路线)

## 验证(开发 agent 执行,调度已复核 diff)

- 全仓 grep 确认无原始值写入方(命中均为 chokidar 层翻译前接线、`MetadataEvent` 这个不同事件类型、或无关词汇)
- spec `check:generated` 八件套 up to date;**api-surface 未动**(无导出增删)
- spec 7242 tests、metadata 281 tests、`pnpm typecheck` 122 tasks、`pnpm test` 132 tasks 全绿

关联:#4535(主单)、#4411、#4404

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9uWvoEp9CoLzYjNExj9sL)_