### PR TITLE
docs(releases): v17 upgrade checklist — the raw watcher values are gone from MetadataWatchEvent.type (#4536)

### DIFF
--- a/.changeset/v17-watch-event-raw-values-note.md
+++ b/.changeset/v17-watch-event-raw-values-note.md
@@ -1,0 +1,7 @@
+---
+---
+
+Releases nothing — docs-only. Corrects the v17 upgrade checklist sentence that
+still told upgraders `MetadataWatchEvent.type` carries the raw watcher values
+(`add`/`change`/`unlink`); they were removed in #4536 with zero producers. No
+package ships from this change.

--- a/content/docs/releases/v17.mdx
+++ b/content/docs/releases/v17.mdx
@@ -2120,9 +2120,11 @@ covers are folded into the list below rather than left to the changelog.)
   from `@objectstack/spec/kernel`, change the path to `@objectstack/spec/system`
   — same names, and that copy is the one the runtime has always emitted. It is
   the *looser* of the two, so a reader may need new narrowing: notably
-  `MetadataWatchEvent.type` also carries the raw watcher values
-  `add`/`change`/`unlink`, and `metadataType`/`name`/`timestamp` are optional
-  there. Nothing to migrate at runtime — the values were always these.
+  `metadataType`/`name`/`timestamp` are optional there. (`MetadataWatchEvent.type`
+  briefly also declared the raw watcher values `add`/`change`/`unlink`; they had
+  zero producers — both emit sites normalize — and were removed in #4536, so the
+  enum now carries exactly `added`/`changed`/`deleted`.) Nothing to migrate at
+  runtime — the values the runtime emits were always these.
 - **Multi-org:** the `group` posture requires the enterprise runtime — deployments
   relying on it self-activating must install `@objectstack/organizations` or move
   to `isolated`.


### PR DESCRIPTION
docs-only。v17 升级 checklist 的 #4411 条目告诉升级者 system 版 "also carries the raw watcher values `add`/`change`/`unlink`" —— 写下时为真,#4536(PR #4545)删掉三个零生产者原始值后为假:照这句话做的读者会为 schema 现在**拒绝**的值加收窄分支。

改为:说明可选字段照旧,原始值曾短暂声明、零生产者、已于 #4536 移除,枚举现为恰好 `added`/`changed`/`deleted`。

按 releases-freeze 规则(CLAUDE.md,#4490)走**专门 docs-only PR** —— releases 页的事实性修正不搭代码 PR 便车。这条 stale 是 #4545 的 docs-drift advisory 逐条核查抓出来的(107 个扇出文件里唯一真命中)。

关联:#4536、#4545、#4535

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9uWvoEp9CoLzYjNExj9sL)_