### PR TITLE
fix(plugin-auth): the issuer is the provider's to declare — Google links stop resolving under a synthesized one

### DIFF
--- a/packages/plugins/plugin-auth/src/account-issuer-parity.test.ts
+++ b/packages/plugins/plugin-auth/src/account-issuer-parity.test.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import {
+  socialProviderList,
+  socialProviders as socialProviderFactories,
+} from '@better-auth/core/social-providers';
+import { backfillAccountIssuer, oauthIssuerFor } from './backfill-account-issuer.js';
+
+/**
+ * Account-issuer parity gate.
+ *
+ * better-auth 1.7 keys every account on `(issuer, providerAccountId)`, and the
+ * issuer is the PROVIDER's to declare: `resolveOAuthAccountKey` takes
+ * `provider.accountIssuer` when there is one and synthesizes
+ * `local:oauth:<id>` only when there is not. A boot-time backfill that stamps a
+ * different value than sign-in looks the row up under does not merely fail to
+ * help — it hides the account and parks it on the `(provider_id, account_id)`
+ * unique slot the correct row needs, which is how a working Google login turned
+ * into `?error=unable_to_link_account`.
+ *
+ * So this gate asserts the two agree, provider by provider, against better-auth's
+ * OWN factory list. A dependency bump that gives another provider an issuer of
+ * its own (or takes one away) turns this red instead of silently mis-stamping
+ * that provider's users on the next boot.
+ */
+
+/** Enough options to construct every factory; unused keys are ignored. */
+const PROBE_OPTIONS = {
+  clientId: 'probe-client-id',
+  clientSecret: 'probe-client-secret',
+  tenantId: 'probe-tenant',
+  region: 'us-east-1',
+  userPoolId: 'pool-1',
+  domain: 'probe.example.com',
+  issuer: 'https://probe.example.com',
+} as const;
+
+interface ProbedProvider {
+  id: string;
+  accountIssuer: unknown;
+}
+
+function instantiateAll(): ProbedProvider[] {
+  const probed: ProbedProvider[] = [];
+  const broken: string[] = [];
+  for (const id of socialProviderList) {
+    const factory = (socialProviderFactories as any)[id];
+    try {
+      const provider = factory(PROBE_OPTIONS as any);
+      probed.push({ id: provider.id, accountIssuer: provider.accountIssuer });
+    } catch (e) {
+      broken.push(`${id}: ${(e as Error)?.message}`);
+    }
+  }
+  // A factory this probe can no longer construct is a provider the gate stops
+  // covering — fail loudly rather than shrink the checked set in silence.
+  expect(broken, 'social provider factories the parity probe could not construct').toEqual([]);
+  return probed;
+}
+
+/** What better-auth will key an account by, per `resolveOAuthAccountKey`. */
+function issuerBetterAuthWillUse(provider: ProbedProvider): string | 'per-login' {
+  const declared = provider.accountIssuer;
+  if (declared === undefined) return oauthIssuerFor(provider.id);
+  if (typeof declared === 'string') return declared;
+  return 'per-login';
+}
+
+/** Minimal ObjectQL stand-in — one account row, `update` patches in place. */
+function makeQl(row: Record<string, any>) {
+  const tables: Record<string, any[]> = { sys_account: [row] };
+  return {
+    tables,
+    update: async (object: string, data: any) => {
+      const target = (tables[object] ?? []).find((r) => r.id === data.id);
+      if (target) Object.assign(target, data);
+      return target;
+    },
+    find: async (object: string, query: any) => {
+      const where = query?.where ?? {};
+      return (tables[object] ?? []).filter((r) =>
+        Object.entries(where).every(([field, value]) =>
+          value === null ? r[field] == null : r[field] === value,
+        ),
+      );
+    },
+  };
+}
+
+describe('account issuer parity — the backfill stamps what sign-in looks up', () => {
+  it('covers every social provider better-auth ships', () => {
+    const probed = instantiateAll();
+    expect(probed.length).toBe(socialProviderList.length);
+  });
+
+  it('agrees with better-auth on the issuer for every provider that has a fixed one', async () => {
+    const mismatches: Array<{ provider: string; betterAuth: string; backfill: string | null }> = [];
+
+    for (const provider of instantiateAll()) {
+      const expected = issuerBetterAuthWillUse(provider);
+      if (expected === 'per-login') continue;
+
+      const ql = makeQl({
+        id: 'a1',
+        provider_id: provider.id,
+        account_id: 'subject-1',
+        issuer: null,
+      });
+      await backfillAccountIssuer(ql, { socialProviders: [provider] });
+
+      const stamped = ql.tables.sys_account[0].issuer ?? null;
+      if (stamped !== expected) {
+        mismatches.push({ provider: provider.id, betterAuth: expected, backfill: stamped });
+      }
+    }
+
+    expect(mismatches, 'providers whose backfilled issuer differs from the one sign-in resolves').toEqual([]);
+  });
+
+  it('never invents an issuer for a provider that resolves one per login', async () => {
+    for (const provider of instantiateAll()) {
+      if (issuerBetterAuthWillUse(provider) !== 'per-login') continue;
+
+      const ql = makeQl({
+        id: 'a1',
+        provider_id: provider.id,
+        account_id: 'subject-1',
+        issuer: null,
+      });
+      const res = await backfillAccountIssuer(ql, { socialProviders: [provider] });
+
+      expect(ql.tables.sys_account[0].issuer, `${provider.id} must stay unstamped`).toBeNull();
+      expect(res.unresolved).toEqual([{ providerId: provider.id, count: 1 }]);
+    }
+  });
+
+  it('repairs a synthetic stamp on every provider that declares a real issuer', async () => {
+    const declaring = instantiateAll().filter((p) => typeof p.accountIssuer === 'string');
+    // Guards the guard: if better-auth ever ships none of these, the repair
+    // case above proves nothing and this gate has quietly stopped testing.
+    expect(declaring.length).toBeGreaterThan(0);
+
+    for (const provider of declaring) {
+      const ql = makeQl({
+        id: 'a1',
+        provider_id: provider.id,
+        account_id: 'subject-1',
+        issuer: oauthIssuerFor(provider.id),
+      });
+      const res = await backfillAccountIssuer(ql, { socialProviders: [provider] });
+
+      expect(res.repaired, `${provider.id} mis-stamp should be repaired`).toBe(1);
+      expect(ql.tables.sys_account[0].issuer).toBe(provider.accountIssuer);
+    }
+  });
+
+  it('google — the provider this defect shipped on — resolves to its real issuer', () => {
+    const google = (socialProviderFactories as any).google(PROBE_OPTIONS as any);
+    expect(google.accountIssuer).toBe('https://accounts.google.com');
+    expect(oauthIssuerFor('google')).toBe('local:oauth:google');
+  });
+});

--- a/packages/plugins/plugin-auth/src/auth-plugin.ts
+++ b/packages/plugins/plugin-auth/src/auth-plugin.ts
@@ -27,6 +27,7 @@ import {
   type AuthManagerOptions,
 } from './auth-manager.js';
 import { ensureDefaultOrganization } from './ensure-default-organization.js';
+import type { ResolvedSocialProvider } from './backfill-account-issuer.js';
 import { createTenancyService, type TenancyService } from './tenancy-service.js';
 import { backfillMemberships, type MembershipPolicy } from './reconcile-membership.js';
 import {
@@ -258,6 +259,35 @@ export class AuthPlugin implements Plugin {
         enabled: true,
       };
       config.socialProviders = socialProviders;
+    }
+  }
+
+  /**
+   * The social providers better-auth built for this runtime, straight off its
+   * own context — each one carrying the `accountIssuer` it will key its
+   * accounts by. Read rather than reconstructed: reconstructing it from the
+   * configured ids is exactly the guess that mis-stamped Google links.
+   *
+   * Returns `undefined` when the instance cannot be reached (auth not built
+   * yet, or a host-supplied instance that exposes no context) — the backfill
+   * then falls back to the id-derived issuers and reports what it cannot
+   * resolve, which is the pre-existing behaviour, not a new failure.
+   */
+  private async resolveInstantiatedSocialProviders(
+    ctx: PluginContext,
+  ): Promise<ResolvedSocialProvider[] | undefined> {
+    try {
+      const auth = await this.authManager?.getAuthInstance();
+      const context = await (auth as any)?.$context;
+      const providers = context?.socialProviders;
+      if (!Array.isArray(providers)) return undefined;
+      return providers.filter((p: any) => typeof p?.id === 'string' && p.id);
+    } catch (e) {
+      ctx.logger.warn?.(
+        '[auth] could not read better-auth\'s instantiated social providers — account issuers fall back to the id-derived values',
+        { error: (e as Error)?.message },
+      );
+      return undefined;
     }
   }
 
@@ -684,7 +714,13 @@ export class AuthPlugin implements Plugin {
     // better-auth 1.7 resolves every account by (issuer, providerAccountId).
     // Rows written before the upgrade have no issuer and are therefore
     // invisible to sign-in, so stamp them once at boot. Idempotent: a database
-    // whose rows already carry an issuer costs one empty query.
+    // whose rows already carry the right issuer costs one empty query.
+    //
+    // The providers are handed over as better-auth INSTANTIATED them, because
+    // the issuer is theirs to declare and only they know it — Google names
+    // `https://accounts.google.com`, GitHub names nothing and takes the
+    // synthetic fallback. Deriving it from the configured ids instead is what
+    // stamped Google links with a value sign-in never looks them up under.
     ctx.hook('kernel:ready', async () => {
       try {
         const ql = ctx.getService<IDataEngine>('objectql');
@@ -692,6 +728,7 @@ export class AuthPlugin implements Plugin {
         const { backfillAccountIssuer } = await import('./backfill-account-issuer.js');
         await backfillAccountIssuer(ql, {
           logger: ctx.logger,
+          socialProviders: await this.resolveInstantiatedSocialProviders(ctx),
           socialProviderIds: Object.keys(this.configuredSocialProviders ?? {}),
           oidcProviderIssuers: Object.fromEntries(
             (this.options.oidcProviders ?? [])

--- a/packages/plugins/plugin-auth/src/backfill-account-issuer.test.ts
+++ b/packages/plugins/plugin-auth/src/backfill-account-issuer.test.ts
@@ -48,7 +48,7 @@ describe('backfillAccountIssuer (better-auth 1.7 account identity)', () => {
     expect(CREDENTIAL_ISSUER).toBe('local:credential');
   });
 
-  it('stamps configured social providers with the synthetic local:oauth issuer', async () => {
+  it('stamps a provider that declares no issuer with the synthetic local:oauth one', async () => {
     const ql = makeQl({
       sys_account: [{ id: 'a1', provider_id: 'github', account_id: '4242', issuer: null }],
     });
@@ -58,6 +58,36 @@ describe('backfillAccountIssuer (better-auth 1.7 account identity)', () => {
     expect(res.stamped).toBe(1);
     expect(ql.tables.sys_account[0].issuer).toBe('local:oauth:github');
     expect(oauthIssuerFor('github')).toBe('local:oauth:github');
+  });
+
+  it('stamps a provider that declares its own issuer with THAT issuer', async () => {
+    const ql = makeQl({
+      sys_account: [{ id: 'a1', provider_id: 'google', account_id: 'sub-1', issuer: null }],
+    });
+
+    const res = await backfillAccountIssuer(ql, {
+      socialProviders: [{ id: 'google', accountIssuer: 'https://accounts.google.com' }],
+    });
+
+    expect(res.stamped).toBe(1);
+    expect(ql.tables.sys_account[0].issuer).toBe('https://accounts.google.com');
+  });
+
+  it('leaves a per-login issuer underivable rather than synthesizing one', async () => {
+    // Microsoft Entra reads the tenant's `iss` off each login's profile, so
+    // there is no boot-time answer — and a guess would be the whole bug.
+    const ql = makeQl({
+      sys_account: [{ id: 'a1', provider_id: 'microsoft', account_id: 'oid-1', issuer: null }],
+    });
+
+    const res = await backfillAccountIssuer(ql, {
+      socialProviders: [{ id: 'microsoft', accountIssuer: ({ profile }: any) => profile.iss }],
+      socialProviderIds: ['microsoft'],
+    });
+
+    expect(res).toMatchObject({ scanned: 1, stamped: 0, repaired: 0 });
+    expect(res.unresolved).toEqual([{ providerId: 'microsoft', count: 1 }]);
+    expect(ql.tables.sys_account[0].issuer).toBeNull();
   });
 
   it('uses the registered SSO provider\'s real issuer for federated accounts', async () => {
@@ -143,5 +173,98 @@ describe('backfillAccountIssuer (better-auth 1.7 account identity)', () => {
   it('no-ops on an engine that cannot query', async () => {
     await expect(backfillAccountIssuer(undefined)).resolves.toMatchObject({ scanned: 0, stamped: 0 });
     await expect(backfillAccountIssuer({} as any)).resolves.toMatchObject({ scanned: 0, stamped: 0 });
+  });
+});
+
+/**
+ * The shipped defect: an earlier pass stamped `local:oauth:google` on links
+ * better-auth resolves under `https://accounts.google.com`. The row went
+ * invisible at sign-in, the callback fell through to "link this provider", and
+ * the insert hit the `(provider_id, account_id)` unique index the invisible row
+ * was holding — `?error=unable_to_link_account`.
+ */
+describe('backfillAccountIssuer — repairing a mis-stamped synthetic issuer', () => {
+  it('re-stamps a synthetic issuer with the one its provider declares', async () => {
+    const log = logger();
+    const ql = makeQl({
+      sys_account: [
+        { id: 'a1', provider_id: 'google', account_id: 'sub-1', issuer: 'local:oauth:google' },
+      ],
+    });
+
+    const res = await backfillAccountIssuer(ql, {
+      logger: log,
+      socialProviders: [{ id: 'google', accountIssuer: 'https://accounts.google.com' }],
+    });
+
+    expect(res).toMatchObject({ scanned: 1, stamped: 0, repaired: 1, unresolved: [] });
+    expect(ql.tables.sys_account[0].issuer).toBe('https://accounts.google.com');
+    expect(log.info).toHaveBeenCalled();
+  });
+
+  it('is idempotent — the repaired row is not touched again', async () => {
+    const ql = makeQl({
+      sys_account: [
+        { id: 'a1', provider_id: 'google', account_id: 'sub-1', issuer: 'local:oauth:google' },
+      ],
+    });
+    const opts = { socialProviders: [{ id: 'google', accountIssuer: 'https://accounts.google.com' }] };
+
+    await backfillAccountIssuer(ql, opts);
+    ql.update.mockClear();
+    const second = await backfillAccountIssuer(ql, opts);
+
+    expect(second).toMatchObject({ scanned: 0, repaired: 0 });
+    expect(ql.update).not.toHaveBeenCalled();
+  });
+
+  it('leaves the synthetic issuer alone when it IS what the provider mints', async () => {
+    const ql = makeQl({
+      sys_account: [
+        { id: 'a1', provider_id: 'github', account_id: '4242', issuer: 'local:oauth:github' },
+      ],
+    });
+
+    const res = await backfillAccountIssuer(ql, { socialProviders: [{ id: 'github' }] });
+
+    expect(res).toMatchObject({ scanned: 0, stamped: 0, repaired: 0 });
+    expect(ql.tables.sys_account[0].issuer).toBe('local:oauth:github');
+  });
+
+  it('rewrites ONLY the synthetic value — a row already holding a real issuer stands', async () => {
+    const ql = makeQl({
+      sys_account: [
+        { id: 'a1', provider_id: 'google', account_id: 'sub-1', issuer: 'https://accounts.google.com' },
+        { id: 'a2', provider_id: 'google', account_id: 'sub-2', issuer: 'https://some-other.example' },
+      ],
+    });
+
+    const res = await backfillAccountIssuer(ql, {
+      socialProviders: [{ id: 'google', accountIssuer: 'https://accounts.google.com' }],
+    });
+
+    expect(res).toMatchObject({ scanned: 0, repaired: 0 });
+    expect(ql.tables.sys_account[1].issuer).toBe('https://some-other.example');
+  });
+
+  it('reports a repair the database refuses instead of counting it', async () => {
+    // A duplicate row can already occupy (issuer, account_id) on a deployment
+    // that acquired one before the unique index existed.
+    const log = logger();
+    const ql = makeQl({
+      sys_account: [
+        { id: 'a1', provider_id: 'google', account_id: 'sub-1', issuer: 'local:oauth:google' },
+      ],
+    });
+    ql.update.mockRejectedValueOnce(new Error('unique constraint'));
+
+    const res = await backfillAccountIssuer(ql, {
+      logger: log,
+      socialProviders: [{ id: 'google', accountIssuer: 'https://accounts.google.com' }],
+    });
+
+    expect(res).toMatchObject({ scanned: 1, repaired: 0 });
+    expect(res.unresolved).toEqual([{ providerId: 'google', count: 1 }]);
+    expect(log.warn).toHaveBeenCalled();
   });
 });

--- a/packages/plugins/plugin-auth/src/backfill-account-issuer.ts
+++ b/packages/plugins/plugin-auth/src/backfill-account-issuer.ts
@@ -15,9 +15,13 @@ import { createLocalAccountIssuer, createOAuthAccountIssuer } from '@better-auth
  *
  * What an issuer looks like is not ours to invent — better-auth mints it:
  *   - password accounts       → `local:credential`
- *   - social providers        → `local:oauth:<providerId>` (the built-in
- *     providers declare no issuer of their own, so better-auth synthesizes
- *     exactly this)
+ *   - social providers        → whatever the PROVIDER declares. A provider that
+ *     names its own authority carries it (`google` →
+ *     `https://accounts.google.com`, `apple` → `https://appleid.apple.com`);
+ *     only a provider that declares none falls back to better-auth's synthetic
+ *     `local:oauth:<providerId>`. This is the same either/or better-auth itself
+ *     applies in `resolveOAuthAccountKey`, which is why the resolved providers
+ *     are READ (`socialProviders`) rather than derived from their ids.
  *   - federated OIDC / SAML   → the IdP's real `iss`, which for registered SSO
  *     providers this environment already stores on `sys_sso_provider.issuer`
  *
@@ -27,8 +31,19 @@ import { createLocalAccountIssuer, createOAuthAccountIssuer } from '@better-auth
  * that the correct row needs. They are reported instead, with the provider ids
  * an operator needs to resolve them.
  *
- * Idempotent: it only ever touches rows with no issuer, so re-running it after
- * a partial pass (or on every boot) converges and then does nothing.
+ * That hazard is not hypothetical — it shipped. An earlier revision synthesized
+ * `local:oauth:<id>` for EVERY social provider, so a Google link written before
+ * the 1.7 upgrade was stamped `local:oauth:google` while sign-in looked it up
+ * under `https://accounts.google.com`. The row was invisible, the callback fell
+ * through to "link this provider", and the insert collided with that very row on
+ * the `(provider_id, account_id)` unique index — surfacing to the user as
+ * `?error=unable_to_link_account`. Correcting the derivation alone does not
+ * repair a database already stamped that way, so the pass also RE-STAMPS rows
+ * carrying the synthetic issuer for a provider that declares a real one.
+ *
+ * Idempotent: it only ever touches rows whose issuer is missing or provably
+ * wrong, so re-running it after a partial pass (or on every boot) converges and
+ * then does nothing.
  */
 
 interface BackfillLogger {
@@ -36,11 +51,36 @@ interface BackfillLogger {
   warn: (message: string, meta?: Record<string, any>) => void;
 }
 
+/**
+ * The shape of a social provider better-auth has already INSTANTIATED
+ * (`authContext.socialProviders`). `accountIssuer` is the authority the
+ * provider names for itself: a string for the providers that have one, a
+ * function of the OAuth response for the ones that read it per login
+ * (Microsoft Entra takes the tenant's `iss` from the profile), and absent for
+ * the providers that have none.
+ */
+export interface ResolvedSocialProvider {
+  id: string;
+  accountIssuer?: unknown;
+}
+
 export interface BackfillAccountIssuerOptions {
   logger?: BackfillLogger;
   /**
-   * Provider ids wired as better-auth `socialProviders` (google, github, …).
-   * Their accounts carry the synthetic `local:oauth:<id>` issuer.
+   * The social providers better-auth instantiated. PREFER this over
+   * `socialProviderIds`: the issuer is read from the provider, so a provider
+   * that names its own authority is stamped with it instead of the synthetic
+   * fallback.
+   */
+  socialProviders?: readonly ResolvedSocialProvider[];
+  /**
+   * Provider ids wired as better-auth `socialProviders` (google, github, …),
+   * for callers that cannot reach the resolved providers.
+   *
+   * Ids alone cannot say whether a provider declares an issuer, so this path
+   * can only synthesize `local:oauth:<id>` — correct for the providers that
+   * declare none, WRONG for the ones that do. Ids covered by `socialProviders`
+   * are resolved from there; the rest are synthesized, as before.
    */
   socialProviderIds?: readonly string[];
   /**
@@ -54,10 +94,15 @@ export interface BackfillAccountIssuerOptions {
 }
 
 export interface BackfillAccountIssuerResult {
-  /** Rows found with no issuer. */
+  /** Rows found whose issuer is missing or provably wrong. */
   scanned: number;
   /** Rows stamped with a derived issuer. */
   stamped: number;
+  /**
+   * Rows whose synthetic `local:oauth:<id>` issuer was corrected to the real
+   * one their provider declares (counted in `scanned`, not in `stamped`).
+   */
+  repaired: number;
   /** Provider ids whose issuer could not be derived, with their row counts. */
   unresolved: Array<{ providerId: string; count: number }>;
 }
@@ -87,20 +132,33 @@ export async function backfillAccountIssuer(
 ): Promise<BackfillAccountIssuerResult> {
   const limit = options.limit ?? 5000;
   const logger = options.logger;
-  const result: BackfillAccountIssuerResult = { scanned: 0, stamped: 0, unresolved: [] };
+  const result: BackfillAccountIssuerResult = { scanned: 0, stamped: 0, repaired: 0, unresolved: [] };
   if (!ql || typeof ql.find !== 'function' || typeof ql.update !== 'function') return result;
 
-  // A driver that stores "no value" as '' rather than NULL is just as invisible
-  // to better-auth, so both shapes are collected.
-  const rows = [
-    ...(await tryFind(ql, 'sys_account', { issuer: null }, limit)),
-    ...(await tryFind(ql, 'sys_account', { issuer: '' }, limit)),
-  ];
-  const pending = rows.filter((r) => r?.id && !r.issuer);
-  result.scanned = pending.length;
-  if (pending.length === 0) return result;
+  // ── Which issuer each provider actually mints ────────────────────────────
+  //
+  // Read from the instantiated providers where they are available; a provider
+  // whose `accountIssuer` is a FUNCTION reads the authority off each login's
+  // OAuth response (Entra takes the tenant `iss` from the profile), so it is
+  // not derivable at boot and is deliberately left to the unresolved report
+  // rather than guessed.
+  const socialIssuers = new Map<string, string>();
+  const perLoginIssuers = new Set<string>();
+  for (const provider of options.socialProviders ?? []) {
+    const id = provider?.id;
+    if (typeof id !== 'string' || !id) continue;
+    const declared = provider.accountIssuer;
+    if (typeof declared === 'function') perLoginIssuers.add(id);
+    else if (typeof declared === 'string' && declared.trim()) socialIssuers.set(id, declared);
+    else socialIssuers.set(id, oauthIssuerFor(id));
+  }
+  // Ids named without a resolved provider behind them keep the historical
+  // synthetic fallback — see the `socialProviderIds` doc comment for why that
+  // is a second best.
+  for (const id of options.socialProviderIds ?? []) {
+    if (!socialIssuers.has(id) && !perLoginIssuers.has(id)) socialIssuers.set(id, oauthIssuerFor(id));
+  }
 
-  const social = new Set(options.socialProviderIds ?? []);
   const configuredIssuers = options.oidcProviderIssuers ?? {};
 
   // Registered SSO providers carry the IdP's real `iss` — the one issuer that
@@ -118,9 +176,39 @@ export async function backfillAccountIssuer(
     if (providerId === 'credential') return CREDENTIAL_ISSUER;
     if (ssoIssuers.has(providerId)) return ssoIssuers.get(providerId);
     if (configuredIssuers[providerId]) return configuredIssuers[providerId];
-    if (social.has(providerId)) return oauthIssuerFor(providerId);
+    if (socialIssuers.has(providerId)) return socialIssuers.get(providerId);
     return undefined;
   };
+
+  // A driver that stores "no value" as '' rather than NULL is just as invisible
+  // to better-auth, so both shapes are collected.
+  const unstamped = [
+    ...(await tryFind(ql, 'sys_account', { issuer: null }, limit)),
+    ...(await tryFind(ql, 'sys_account', { issuer: '' }, limit)),
+  ].filter((r) => r?.id && !r.issuer);
+
+  // Rows an earlier pass stamped `local:oauth:<id>` for a provider that turns
+  // out to name a real authority are exactly as unresolvable at sign-in as
+  // unstamped ones, and they hold the unique slot the correct row needs. Only
+  // this one wrong-by-construction value is rewritten: a row already carrying
+  // the real issuer, or any other value, is left alone.
+  const misstamped: any[] = [];
+  for (const [providerId, realIssuer] of socialIssuers) {
+    const synthetic = oauthIssuerFor(providerId);
+    if (realIssuer === synthetic) continue;
+    for (const row of await tryFind(
+      ql,
+      'sys_account',
+      { provider_id: providerId, issuer: synthetic },
+      limit,
+    )) {
+      if (row?.id && row.issuer === synthetic) misstamped.push(row);
+    }
+  }
+
+  const pending = [...unstamped, ...misstamped];
+  result.scanned = pending.length;
+  if (pending.length === 0) return result;
 
   const unresolved = new Map<string, number>();
   for (const row of pending) {
@@ -130,9 +218,15 @@ export async function backfillAccountIssuer(
       unresolved.set(providerId || '(none)', (unresolved.get(providerId || '(none)') ?? 0) + 1);
       continue;
     }
+    if (issuer === row.issuer) continue;
+    // Read before the write: an engine is free to hand back (or patch in
+    // place) the row it just updated, and this must classify the row as it
+    // was, not as it became.
+    const wasMisstamped = Boolean(row.issuer);
     try {
       await ql.update('sys_account', { id: row.id, issuer }, { context: SYSTEM_CTX });
-      result.stamped++;
+      if (wasMisstamped) result.repaired++;
+      else result.stamped++;
     } catch (e: any) {
       unresolved.set(providerId, (unresolved.get(providerId) ?? 0) + 1);
       logger?.warn('[auth] could not stamp sys_account.issuer', {
@@ -148,6 +242,11 @@ export async function backfillAccountIssuer(
   if (result.stamped > 0) {
     logger?.info(
       `[auth] stamped issuer on ${result.stamped} pre-1.7 sys_account row(s) — better-auth 1.7 resolves accounts by (issuer, account_id)`,
+    );
+  }
+  if (result.repaired > 0) {
+    logger?.info(
+      `[auth] corrected the issuer on ${result.repaired} sys_account row(s) stamped with the synthetic local:oauth:<provider> value for a provider that declares its own — those links resolve at sign-in again`,
     );
   }
   if (result.unresolved.length > 0) {


### PR DESCRIPTION
## What broke

Google sign-in on the hosted control plane returns
`/_console/login?...&error=unable_to_link_account` — on **staging and production
both**, for accounts that had signed in with Google before.

## Root cause

better-auth 1.7 keys every account on `(issuer, providerAccountId)`, and the
issuer is the **provider's** to declare: `resolveOAuthAccountKey` takes
`provider.accountIssuer` and synthesizes `local:oauth:<id>` *only* for a
provider that declares none.

`backfillAccountIssuer` synthesized that value for **every** social provider. So
a Google link written before the 1.7 upgrade got stamped `local:oauth:google`,
while sign-in looks it up under `https://accounts.google.com`:

1. `findAccountOwnerByKey({issuer, providerAccountId})` misses the row.
2. `findUserByEmail` still finds the user, but no `linkedAccount` matches.
3. The callback falls through to "link this provider".
4. `linkAccount` INSERTs and collides with that very row on the
   `(provider_id, account_id)` unique index.
5. `handleOAuthUserInfo` catches it → `error: "unable to link account"` →
   `?error=unable_to_link_account`.

Only returning users are affected; a first-ever Google login writes the correct
issuer and works. Seven of better-auth's built-in providers declare their own
issuer — `google`, `apple`, `facebook`, `cognito`, `line`, `paybin` as strings
and `microsoft` (Entra) as a per-login function — so all seven were mis-stamped.
`google` is the one wired on the hosted control plane.

The file's own doc comment predicted this exactly: *"a wrong issuer is
indistinguishable from a missing one at sign-in, and it also occupies the
(provider_id, account_id) unique slot that the correct row needs."*

## The fix

- **Read the issuer, don't derive it.** The backfill now takes the providers
  better-auth *instantiated* (`authContext.socialProviders`, reached through
  `authManager.getAuthInstance()`) and reads `accountIssuer` off each one —
  the same either/or better-auth applies itself. A provider whose
  `accountIssuer` is a function resolves it per login (Entra reads the tenant
  `iss` off the profile); that stays underivable at boot and is **reported, not
  guessed**.
- **Repair, not just stamp.** Correcting the derivation does nothing for a
  database already stamped wrong, so the pass re-stamps rows carrying the
  synthetic issuer for a provider that declares a real one. Only that one
  wrong-by-construction value is rewritten — a row holding the real issuer, or
  anything else, is left alone. Counted separately as `result.repaired`.
- **A parity gate that gets its assertion from upstream.**
  `account-issuer-parity.test.ts` walks better-auth's own `socialProviderList`
  and asserts the backfilled issuer equals the one sign-in will resolve. A
  dependency bump that gives another provider an issuer of its own turns this
  red instead of silently mis-stamping that provider's users on the next boot.

## Verification

- `plugin-auth`: 593 tests pass, `tsc --noEmit` clean.
- **Negative control on the new gate**: reverting the derivation to the old
  synthesize-always behaviour reddens it, naming all six fixed-issuer providers
  (`apple`, `cognito`, `facebook`, `google`, `line`, `paybin`).
- Probed separately that the backfill's `{ issuer: null }` predicate does reach
  the driver intact (engine passes it through; the SQL driver compiles `IS
  NULL`), so the NULL-row scan is not a second dormant path.

## Rollout

Needs a cloud `.objectstack-sha` bump to reach staging/prod; the repair then
runs on the next control-plane boot. An operator wanting to unblock sooner can
correct the rows directly:

```sql
UPDATE sys_account SET issuer = 'https://accounts.google.com'
WHERE provider_id = 'google' AND (issuer IS NULL OR issuer = 'local:oauth:google');
```

(A unique-constraint error there would mean duplicate rows already exist and
need de-duplicating first.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)