### PR TITLE
test(spec): pin `DecisionOutputDef.required` at the schema level (#4525)

### DIFF
--- a/.changeset/decision-output-required-pin.md
+++ b/.changeset/decision-output-required-pin.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only pin for `DecisionOutputDef.required` (#4525) — releases nothing.

--- a/packages/spec/src/automation/approval.test.ts
+++ b/packages/spec/src/automation/approval.test.ts
@@ -396,6 +396,38 @@ describe('unknown keys are rejected, not stripped (#4001)', () => {
       expect(unknownKeyIssue(DecisionOutputDefSchema, { key: 'k', widget: 'user' })!.message)
         .toContain('`widget` → `type`');
     });
+
+    /**
+     * #4525: `required` is the one decision-output key the RUNTIME enforces —
+     * `ApprovalService.decide()` refuses an approve whose required outputs are
+     * blank. The spec has declared it since objectui#2955, but nothing at the
+     * schema level pinned it: the schema is `.strict()`, so dropping the key
+     * would turn every author's `required: true` into an unknown-key rejection,
+     * and the only guard against that was `authorable-surface.json` — a
+     * REGENERATED baseline, which a `gen:schema` run silently rewrites. These
+     * cases fail loudly instead, which is what "declared = enforced" needs on
+     * the declaring side.
+     */
+    it('accepts `required` — the key the runtime enforces (#4525)', () => {
+      expect(DecisionOutputDefSchema.parse({ key: 'next_reviewers', required: true }))
+        .toEqual({ key: 'next_reviewers', required: true });
+      expect(DecisionOutputDefSchema.parse({ key: 'note', required: false }))
+        .toEqual({ key: 'note', required: false });
+    });
+
+    it('leaves `required` optional — an unflagged output stays unflagged', () => {
+      // Absent must stay absent rather than defaulting to `false`: the parsed
+      // shape is what `normalizeDecisionOutputs` ships to every decision UI.
+      expect(DecisionOutputDefSchema.parse({ key: 'note' })).toEqual({ key: 'note' });
+    });
+
+    it('rejects a non-boolean `required` instead of coercing it', () => {
+      // A truthy string is exactly how an AI-authored flow would spell it; the
+      // runtime compares `d.required === true`, so a coerced 'true' would
+      // declare a constraint the server then never enforces.
+      expect(() => DecisionOutputDefSchema.parse({ key: 'note', required: 'true' })).toThrow();
+      expect(() => DecisionOutputDefSchema.parse({ key: 'note', required: 1 })).toThrow();
+    });
   });
 
   it('publishes additionalProperties:false through the JSON schema (Studio + registerFlow)', () => {


### PR DESCRIPTION
Fixes #4525

## 结论先行：维护者拍板的选项 1 早已落地，issue 的前提是过期的

#4525 要求「spec 建模 `DecisionOutputDef.required`，让契约声明服务端已经在强制的约束」。核查后确认：**这件事在 issue 提出前 3 天就已经合并进 `main` 了**。

落地提交是 `cd6b9f202` —— `feat(approvals): decisionOutputs may be declared required (objectui#2955)`，2026-07-29。它一次性补齐了整套：

| 面 | 位置 | 状态 |
|:---|:---|:---|
| Zod 源 | `packages/spec/src/automation/approval.zod.ts:518` | ✅ `required: z.boolean().optional()` |
| 语义 TSDoc | 同文件 503–517 行 | ✅ 写明「approve 强制、reject 不强制」 |
| 严格未知键提示 | `decisionOutputUnknownKeyError.knownKeys` | ✅ 含 `required` |
| 归一化透传 | `normalizeDecisionOutputs` | ✅ `...(e.required === true ? ... )` |
| authorable 基线 | `authorable-surface.json:2232` | ✅ `automation/DecisionOutputDef:required` |
| 生成文档 | `content/docs/references/automation/approval.mdx:119` | ✅ |
| 服务端强制点 | `plugin-approvals/src/approval-service.ts:1773-1783` | ✅ 与 spec 语义一致 |
| changeset | `.changeset/required-decision-outputs.md` | ✅ 随该提交 |

issue 是从 objectui 台账燃尽批次 3 记录下来的，而 objectui 派生类型里那句注释「the spec does not model it yet」本身是对着**更早版本的 spec** 写的，记录时就已经过期。所以 `DecisionOutputDef` 的 spec 建模**没有任何增量可做**。

## 那本 PR 做了什么：补上真正缺失的那颗钉子

建模有了，**钉子没有**。这是一处真实的薄弱点：

`DecisionOutputDefSchema` 是 `.strict()` 的 —— 一旦 `required` 被摘掉，作者写的 `required: true` 会立刻变成 unknown-key 报错。而唯一拦着这件事的，只有 `authorable-surface.json` 这张**由 `gen:schema` 重新生成的基线** —— 它会被无声改写，不会喊。

变异测试实证了这个缺口：把 Zod 里的 `required` 一行注释掉后，**既有 40 条用例全绿**，包括那几条 `normalizeDecisionOutputs` 的 —— 因为那个归一化函数是手写的，从不读 schema。

```
 ❯ src/automation/approval.test.ts (41 tests | 1 failed)
       × accepts `required` — the key the runtime enforces (#4525)
   ZodError: Unrecognized key(s) on this decision-output declaration: `required`.
```

补的三条用例：

1. **`required` 能解析并原样回传** —— 摘掉即红（上方即为实证输出）。
2. **保持 optional** —— 缺省必须仍然缺省，不能变成 `required: false`。归一化后的形状就是 `decision_output_defs` 发给每个决策 UI 的东西。
3. **非布尔值拒绝而非强转** —— 这条针对 AI 作者：运行时比的是 `d.required === true`，一个被强转的 `'true'` 会声明一条服务端根本不会执行的约束，正是 #4525 想关掉的「声明 ≠ 强制」，只不过下沉了一层。

无行为变更；不加 changeset（功能本体的 changeset 已随 `cd6b9f202` 发出）。

## 验证

```
$ pnpm --filter @objectstack/spec test
 Test Files  286 passed (286)
      Tests  7268 passed (7268)

$ pnpm --filter @objectstack/spec typecheck
> tsc --noEmit          # 无输出

$ pnpm --filter @objectstack/spec check:generated
  ✓ check:spec-changes / upgrade-guide / skill-docs / skill-refs
  ✓ check:react-blocks / authorable-surface / api-surface / docs
✓ All 8 generated artifacts are up to date.

$ npx eslint packages/spec/src/automation/approval.test.ts
EXIT=0
```

生成物零漂移（本 PR 只动测试文件，符合预期）。

## 范围外

objectui 侧 `DecisionOutputDef extends SpecDecisionOutputDef { required?: boolean }` 现在已经是**纯冗余**——spec 早就有这个键了，该接口可以塌缩成纯 re-export，其 `__tests__/spec-symbol-parity.test.ts:246` 那条断言（`Exclude<keyof …> === 'required'`）需要同步反转。按派发约定，objectui 不在本 PR 范围内，由 PM 另开 follow-up。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012C2cd7tL8QDoZ2QKN3djJ5)_