### PR TITLE
fix(automation)!: getSuspendedScreen 读取持久化存储，而不只是内存热缓存 (#4515)

### DIFF
--- a/.changeset/durable-suspended-screen-refetch.md
+++ b/.changeset/durable-suspended-screen-refetch.md
@@ -1,0 +1,25 @@
+---
+'@objectstack/spec': minor
+'@objectstack/service-automation': minor
+'@objectstack/runtime': minor
+---
+
+**BREAKING**: `IAutomationService.getSuspendedScreen(runId)` is now **async** — it returns `Promise<ScreenSpec | null>` instead of `ScreenSpec | null` (#4515).
+
+FROM → TO for anyone calling or implementing it:
+
+```ts
+// caller
+- const screen = automationService.getSuspendedScreen(runId);
++ const screen = await automationService.getSuspendedScreen(runId);
+
+// implementer
+- getSuspendedScreen(runId: string): ScreenSpec | null
++ async getSuspendedScreen(runId: string): Promise<ScreenSpec | null>
+```
+
+One-line fix: `await` the call (the enclosing function is almost certainly already `async`), and make any test double resolve rather than return (`mockResolvedValue`, not `mockReturnValue`).
+
+Why it had to change: the method could only ever read the engine's in-memory hot cache, because a synchronous signature cannot consult the durable suspended-run store. `SuspendedRun.screen` *is* persisted (`sys_automation_run.screen_json`) and `resume()` cold-reads it back, so after a process restart a still-suspended screen run could be resumed (`POST …/runs/:runId/resume` → 200) while `GET …/runs/:runId/screen` returned 404 “No pending screen for run” — the refresh-safe re-fetch failing in exactly the situation it exists for (page refresh, another device), and the rendering half of ADR-0019's durable-suspend promise missing while the resuming half shipped.
+
+`AutomationEngine.getSuspendedScreen` now takes the hot cache as its fast path and falls through to the store via the same loader `resume()` rehydrates from. A run that does not exist, is no longer suspended, or paused at a non-screen node still resolves to `null`, so `GET …/runs/:runId/screen` keeps returning 404 for genuinely absent runs. No sync variant of the method remains on the contract.

--- a/docs/design/screen-flow-runtime.md
+++ b/docs/design/screen-flow-runtime.md
@@ -26,7 +26,7 @@ interface ScreenSpec { nodeId: string; title?: string; description?: string; fie
 - **screen executor**: suspend when `waitForInput === true` **or** (`config.fields` non-empty **and** `waitForInput !== false`). When suspending, return `{ success:true, suspend:true, screen: { nodeId, title, description, fields } }` built from `node.config`.
 - **suspend plumbing**: `NodeExecutionResult.screen` → `FlowSuspendSignal.screen` → `SuspendedRun.screen` → paused `AutomationResult.screen`.
 - **resume**: apply `signal.variables` as **bare** variables (`variables.set(name, value)`) in addition to the existing `signal.output` (`${nodeId}.key`). If the continuation suspends at another screen, return that screen (multi-screen wizards).
-- `getSuspendedScreen(runId)` getter so HTTP can re-fetch the current screen.
+- `async getSuspendedScreen(runId)` getter so HTTP can re-fetch the current screen. Durable (#4515): hot cache first, then the `SuspendedRunStore` via the same loader `resume` rehydrates from, so a screen run that survived a restart renders as well as it resumes.
 
 ### HTTP (`runtime/http-dispatcher.ts` `handleAutomation`)
 - **Launch**: existing `POST /api/v1/automation/:name/trigger` — when the run pauses at a screen, the response includes `{ status:'paused', runId, screen }`.

--- a/packages/qa/dogfood/test/flow-durable-suspend.dogfood.test.ts
+++ b/packages/qa/dogfood/test/flow-durable-suspend.dogfood.test.ts
@@ -291,6 +291,42 @@ describe('objectstack verify FLOW: a suspended run survives a real cold boot (#4
     expect(JSON.parse(String(rec.variables_json)).noteId).toBe(noteId);
   });
 
+  it('the cold kernel RE-FETCHES the screen — refresh-safe rendering, not just resuming (#4515)', async () => {
+    // The rendering half of the same promise, and the half that was missing.
+    // `GET …/runs/:runId/screen` exists so a user who refreshes the page — or
+    // picks the flow up on another device — gets the form back. It was backed
+    // by `AutomationEngine.getSuspendedScreen`, which was SYNCHRONOUS and so
+    // structurally could only read the in-memory hot cache: after this cold
+    // boot the run was resumable (the test below) yet its screen 404'd, i.e.
+    // the route failed in exactly the situation it was built for. Fixed by
+    // making the contract method async and falling through to the same
+    // suspended-run store `resume` rehydrates from.
+    const res = await cold!.apiAs(coldToken, 'GET', `/automation/flow_durable_suspend/runs/${runId}/screen`);
+    expect(res.status, `screen re-fetch after cold boot: ${await res.clone().text()}`).toBe(200);
+    const body = (await res.json()) as any;
+    const payload = body.data ?? body;
+    expect(payload.runId).toBe(runId);
+
+    // The screen served by a kernel that never rendered it must be the screen
+    // the flow declared — read back out of `screen_json`, field contract intact
+    // (that contract is what the resume below is validated against, #4477).
+    const screen = payload.screen;
+    expect(screen.nodeId).toBe('ask');
+    expect(screen.fields.map((f: any) => f.name)).toContain('resolution');
+    expect(screen.fields.find((f: any) => f.name === 'resolution').required).toBe(true);
+
+    // Read-only: re-fetching must not consume the pause, or a refresh would
+    // destroy the very run it is trying to display.
+    const again = await cold!.apiAs(coldToken, 'GET', `/automation/flow_durable_suspend/runs/${runId}/screen`);
+    expect(again.status).toBe(200);
+    const row = await cold!.apiAs(coldToken, 'GET', `/data/sys_automation_run/${runId}`);
+    expect(row.status).toBe(200);
+
+    // A genuinely absent run still 404s — durable ≠ credulous.
+    const missing = await cold!.apiAs(coldToken, 'GET', '/automation/flow_durable_suspend/runs/run_nope/screen');
+    expect(missing.status).toBe(404);
+  });
+
   it('the cold kernel RESUMES the run and takes the right branch', async () => {
     // The one assertion #4470 was written for. The second kernel never
     // executed a node of this run: it has to rebuild the continuation from
@@ -313,6 +349,12 @@ describe('objectstack verify FLOW: a suspended run survives a real cold boot (#4
     const history = await cold!.apiAs(coldToken, 'GET', `/data/sys_automation_run/run_${runId}`);
     expect(history.status).toBe(200);
     expect((((await history.json()) as any).record ?? {}).status).toBe('completed');
+
+    // …and with the suspension consumed there is no screen left to render:
+    // the durable fallback answers for runs that are SUSPENDED, not for every
+    // id that was ever suspended (#4515).
+    const screen = await cold!.apiAs(coldToken, 'GET', `/automation/flow_durable_suspend/runs/${runId}/screen`);
+    expect(screen.status).toBe(404);
   });
 
   it('the resumed result is itself durable — a THIRD boot still reads it', async () => {

--- a/packages/runtime/src/domains/automation.ts
+++ b/packages/runtime/src/domains/automation.ts
@@ -370,7 +370,7 @@ export async function handleAutomationRequest(deps: DomainHandlerDeps, path: str
         // (refresh-safe re-fetch for the UI flow-runner).
         if (parts[1] === 'runs' && parts[2] && parts[3] === 'screen' && m === 'GET') {
             if (typeof automationService.getSuspendedScreen === 'function') {
-                const screen = automationService.getSuspendedScreen(parts[2]);
+                const screen = await automationService.getSuspendedScreen(parts[2]);
                 if (!screen) return { handled: true, response: deps.error('No pending screen for run', 404) };
                 return { handled: true, response: deps.success({ runId: parts[2], screen }) };
             }

--- a/packages/runtime/src/http-dispatcher.test.ts
+++ b/packages/runtime/src/http-dispatcher.test.ts
@@ -188,8 +188,11 @@ describe('HttpDispatcher', () => {
                 listRuns: vi.fn().mockResolvedValue([{ id: 'run_1', status: 'completed' }]),
                 getRun: vi.fn().mockResolvedValue({ id: 'run_1', status: 'completed' }),
                 resume: vi.fn().mockResolvedValue({ success: true, output: {}, durationMs: 7 }),
-                // Sync per IAutomationService — `ScreenSpec | null`, not a promise.
-                getSuspendedScreen: vi.fn().mockReturnValue({ nodeId: 'collect', fields: [] }),
+                // ASYNC per IAutomationService (#4515) — `Promise<ScreenSpec | null>`.
+                // It has to be: a screen re-fetch answers for any genuinely
+                // suspended run, which after a restart means reading the
+                // durable suspended-run store, not just the hot cache.
+                getSuspendedScreen: vi.fn().mockResolvedValue({ nodeId: 'collect', fields: [] }),
                 getActionDescriptors: vi.fn().mockReturnValue([
                     { type: 'decision', name: 'Decision', category: 'logic', paradigms: ['flow'], source: 'builtin' },
                     { type: 'http_request', name: 'HTTP Request', category: 'io', paradigms: ['flow', 'approval'], source: 'builtin' },
@@ -444,7 +447,7 @@ describe('HttpDispatcher', () => {
         });
 
         it('should return 404 when the run is not awaiting a screen', async () => {
-            mockAutomationService.getSuspendedScreen.mockReturnValue(null);
+            mockAutomationService.getSuspendedScreen.mockResolvedValue(null);
             const result = await dispatcher.handleAutomation('flow_a/runs/run_1/screen', 'GET', {}, { request: {} });
             expect(result.handled).toBe(true);
             expect(result.response?.status).toBe(404);

--- a/packages/services/service-automation/src/builtin/screen-resume-validation.test.ts
+++ b/packages/services/service-automation/src/builtin/screen-resume-validation.test.ts
@@ -140,7 +140,7 @@ describe('screen resume validation (#4477)', () => {
         const bad = await engine.resume(runId, { variables: {} });
         expect(bad.success).toBe(false);
         // The screen is still fetchable…
-        expect(engine.getSuspendedScreen(runId)?.nodeId).toBe('ask');
+        expect((await engine.getSuspendedScreen(runId))?.nodeId).toBe('ask');
         // …and the legitimate submission still lands.
         const good = await engine.resume(runId, { variables: { kind: 'normal' } });
         expect(good.success).toBe(true);

--- a/packages/services/service-automation/src/builtin/subflow-node.test.ts
+++ b/packages/services/service-automation/src/builtin/subflow-node.test.ts
@@ -245,7 +245,7 @@ describe('subflow node executor', () => {
     expect(r2.status).toBe('paused');
     expect(r2.runId).toBe(parentRunId); // UI keeps one stable run id
     expect(r2.screen).toEqual(s2); // next wizard screen
-    expect(engine.getSuspendedScreen(parentRunId)).toEqual(s2); // refresh-safe re-fetch
+    expect(await engine.getSuspendedScreen(parentRunId)).toEqual(s2); // refresh-safe re-fetch
 
     const r3 = await engine.resume(parentRunId, { variables: { other: 'x' } });
     expect(r3.success).toBe(true);

--- a/packages/services/service-automation/src/engine.test.ts
+++ b/packages/services/service-automation/src/engine.test.ts
@@ -581,13 +581,13 @@ describe('AutomationEngine', () => {
             expect(paused.screen!.fields[0]).toMatchObject({ name: 'new_assignee', required: true, type: 'text' });
             expect(captured).toBe('UNSET'); // downstream not run yet
             // Re-fetchable for a refreshed client.
-            expect(engine.getSuspendedScreen(paused.runId!)).toMatchObject({ nodeId: 'collect' });
+            expect(await engine.getSuspendedScreen(paused.runId!)).toMatchObject({ nodeId: 'collect' });
 
             const done = await engine.resume(paused.runId!, { variables: { new_assignee: 'ada@example.com' } });
             expect(done.success).toBe(true);
             expect(done.status).toBeUndefined();
             expect(captured).toBe('ada@example.com'); // bare var set on resume → downstream read it
-            expect(engine.getSuspendedScreen(paused.runId!)).toBeNull();
+            expect(await engine.getSuspendedScreen(paused.runId!)).toBeNull();
         });
 
         it('passes a field-less screen straight through (no pause)', async () => {

--- a/packages/services/service-automation/src/engine.ts
+++ b/packages/services/service-automation/src/engine.ts
@@ -3186,9 +3186,20 @@ export class AutomationEngine implements IAutomationService {
      * The screen a paused run is currently waiting on (screen-flow runtime), or
      * `null` if the run isn't suspended / didn't pause at a screen node. Lets a
      * UI flow-runner re-fetch the form after a refresh.
+     *
+     * Durable (#4515): the hot cache is the fast path, and a miss falls through
+     * to the {@link SuspendedRunStore} via the same {@link loadSuspendedRun}
+     * that {@link resume} rehydrates from — one loader, two callers. Without
+     * that fallback a screen run that survived a restart could be *resumed* but
+     * not *rendered*, which is precisely when a refresh-safe re-fetch matters.
+     *
+     * Best-effort by design: a store outage reads as "no such run" (`null`),
+     * matching the 404 this backs. A caller that must distinguish "gone" from
+     * "unknown" before writing anything wants {@link hasSuspendedRun}, which
+     * throws instead.
      */
-    getSuspendedScreen(runId: string): ScreenSpec | null {
-        return this.suspendedRuns.get(runId)?.screen ?? null;
+    async getSuspendedScreen(runId: string): Promise<ScreenSpec | null> {
+        return (await this.loadSuspendedRun(runId))?.screen ?? null;
     }
 
     // ── DAG Traversal Core ──────────────────────────────────

--- a/packages/services/service-automation/src/suspended-screen-durability.test.ts
+++ b/packages/services/service-automation/src/suspended-screen-durability.test.ts
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `getSuspendedScreen` answers for any run that is genuinely suspended — across
+ * a process restart (#4515).
+ *
+ * `SuspendedRun.screen` has always been persisted (`sys_automation_run.
+ * screen_json`), and `resume` cold-reads it back through `loadSuspendedRun` on
+ * a cache miss. But `getSuspendedScreen` was SYNCHRONOUS, so it structurally
+ * could not consult the store — it read the in-memory hot cache and nothing
+ * else. The result, for a durably suspended screen run after a restart:
+ * `POST …/runs/:runId/resume` worked while `GET …/runs/:runId/screen` returned
+ * 404 "No pending screen for run". The route exists precisely so a user can
+ * refresh the page or continue on another device, and it failed exactly when
+ * it was needed most — the rendering half of ADR-0019's durable-suspend
+ * promise missing while the resuming half shipped.
+ *
+ * A shared {@link InMemorySuspendedRunStore} stands in for the database: the
+ * run suspends on engine A, then a brand-new engine B backed by the same store
+ * is the cold boot. The store JSON round-trips on save/load, so it exercises
+ * the same serialization boundary `sys_automation_run` imposes.
+ *
+ * REVERT-PROOF: drop the store fallback in `AutomationEngine.getSuspendedScreen`
+ * (back to `this.suspendedRuns.get(runId)?.screen ?? null`) and the cold-boot
+ * case below fails while the hot-cache case still passes — which is the whole
+ * bug, stated as a test.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { AutomationEngine } from './engine.js';
+import { registerScreenNodes } from './builtin/screen-nodes.js';
+import { InMemorySuspendedRunStore } from './suspended-run-store.js';
+import type { SuspendedRunStore } from './engine.js';
+
+function silentLogger() {
+    return { info() {}, warn() {}, error() {}, debug() {}, child() { return silentLogger(); } } as any;
+}
+
+/** A screen flow whose single screen collects one required field. */
+const SCREEN_FLOW = {
+    name: 'onboard',
+    label: 'Onboard',
+    type: 'screen',
+    nodes: [
+        { id: 'start', type: 'start', label: 'Start' },
+        {
+            id: 'collect', type: 'screen', label: 'Your details',
+            config: {
+                title: 'Your details',
+                fields: [{ name: 'full_name', label: 'Full name', type: 'text', required: true }],
+            },
+        },
+        { id: 'end', type: 'end', label: 'End' },
+    ],
+    edges: [
+        { id: 'e1', source: 'start', target: 'collect' },
+        { id: 'e2', source: 'collect', target: 'end' },
+    ],
+} as any;
+
+/** A fresh engine over `store` — one per simulated process lifetime. */
+function buildEngine(store?: SuspendedRunStore) {
+    const e = new AutomationEngine(silentLogger(), store);
+    registerScreenNodes(e, { logger: silentLogger() } as any);
+    e.registerFlow('onboard', SCREEN_FLOW);
+    return e;
+}
+
+describe('getSuspendedScreen is durable (#4515)', () => {
+    it('hot path: the screen is re-fetchable from the engine that paused it', async () => {
+        const store = new InMemorySuspendedRunStore();
+        const engine = buildEngine(store);
+
+        const paused = await engine.execute('onboard');
+        expect(paused.status).toBe('paused');
+
+        // Same process — served from the in-memory hot cache, no store read
+        // needed. (Async now, but the answer is identical.)
+        const screen = await engine.getSuspendedScreen(paused.runId!);
+        expect(screen).toMatchObject({ nodeId: 'collect', title: 'Your details' });
+        expect(screen!.fields[0]).toMatchObject({ name: 'full_name', required: true });
+    });
+
+    it('THE BUG: after a restart the screen still re-fetches from the durable store', async () => {
+        const store = new InMemorySuspendedRunStore();
+
+        // Process lifetime #1 — the run suspends at the screen node.
+        const engineA = buildEngine(store);
+        const paused = await engineA.execute('onboard');
+        expect(paused.status).toBe('paused');
+        const runId = paused.runId!;
+
+        // Process lifetime #2 — a cold-booted engine. Nothing in its hot cache…
+        const engineB = buildEngine(store);
+        expect(engineB.listSuspendedRuns()).toHaveLength(0);
+
+        // …yet the run is genuinely suspended, so its screen must render.
+        const screen = await engineB.getSuspendedScreen(runId);
+        expect(screen).not.toBeNull();
+        expect(screen).toMatchObject({ nodeId: 'collect', title: 'Your details' });
+        expect(screen!.fields[0]).toMatchObject({ name: 'full_name', required: true, type: 'text' });
+        // The screen the fresh engine serves is the screen the run paused on.
+        expect(screen).toEqual(paused.screen);
+
+        // Read-only: the suspension is not consumed, so the resume that the
+        // refreshed UI submits next still lands.
+        expect(await engineB.getSuspendedScreen(runId)).toEqual(paused.screen);
+        const done = await engineB.resume(runId, { variables: { full_name: 'Ada' } });
+        expect(done.success).toBe(true);
+        expect(done.status).toBeUndefined();
+
+        // Once the run is terminal there is no screen to render any more.
+        expect(await engineB.getSuspendedScreen(runId)).toBeNull();
+    });
+
+    it('a genuinely absent run is still null (the 404 stays a 404)', async () => {
+        const store = new InMemorySuspendedRunStore();
+        const engine = buildEngine(store);
+        expect(await engine.getSuspendedScreen('run_does_not_exist')).toBeNull();
+
+        // …and so is a suspension that carries no screen (paused at a
+        // non-screen node): durable ≠ "invent a screen".
+        const e = new AutomationEngine(silentLogger(), store);
+        e.registerNodeExecutor({
+            type: 'pause_node',
+            async execute() { return { success: true, suspend: true }; },
+        });
+        e.registerFlow('approval', {
+            name: 'approval', label: 'Approval', type: 'autolaunched',
+            nodes: [
+                { id: 'start', type: 'start', label: 'Start' },
+                { id: 'pause', type: 'pause_node', label: 'Wait' },
+                { id: 'end', type: 'end', label: 'End' },
+            ],
+            edges: [
+                { id: 'e1', source: 'start', target: 'pause' },
+                { id: 'e2', source: 'pause', target: 'end' },
+            ],
+        } as any);
+        const paused = await e.execute('approval');
+        expect(paused.status).toBe('paused');
+        // Cold engine over the same store: the run IS suspended, but not at a
+        // screen — `null`, not a throw and not a fabricated form.
+        expect(await buildEngine(store).getSuspendedScreen(paused.runId!)).toBeNull();
+    });
+
+    it('a store outage reads as "no pending screen", never as a throw', async () => {
+        // Best-effort by design: this backs a 404, and the caller that must
+        // tell "gone" from "unknown" before writing uses `hasSuspendedRun`,
+        // which throws instead.
+        const brokenStore: SuspendedRunStore = {
+            async save() {},
+            async load() { throw new Error('sqlite: database is locked'); },
+            async delete() {},
+            async list() { return []; },
+        };
+        const engine = buildEngine(brokenStore);
+        await expect(engine.getSuspendedScreen('run_x')).resolves.toBeNull();
+        await expect(engine.hasSuspendedRun('run_x')).rejects.toThrow(/database is locked/);
+    });
+
+    it('with no store at all, behaviour is unchanged (in-memory only)', async () => {
+        const engine = buildEngine(); // no store
+        const paused = await engine.execute('onboard');
+        expect(await engine.getSuspendedScreen(paused.runId!)).toMatchObject({ nodeId: 'collect' });
+        // A different engine has no way to know about it — nothing was persisted.
+        expect(await buildEngine().getSuspendedScreen(paused.runId!)).toBeNull();
+    });
+});

--- a/packages/spec/src/contracts/automation-service.ts
+++ b/packages/spec/src/contracts/automation-service.ts
@@ -494,7 +494,19 @@ export interface IAutomationService {
     /**
      * The screen a paused run is currently awaiting (screen-flow runtime), or
      * `null` if the run isn't suspended at a `screen` node. Lets a UI flow-runner
-     * re-fetch the form (e.g. after a page refresh).
+     * re-fetch the form (e.g. after a page refresh, or on another device).
+     *
+     * **Durable, like {@link resume} (#4515).** The answer covers any run that
+     * is genuinely suspended, not just the ones this process paused: the
+     * in-memory hot cache is the fast path, and a miss falls back to the
+     * suspended-run store the same way `resume` rehydrates. So a screen run
+     * that survives a restart re-fetches its screen exactly as it resumes —
+     * the rendering half of ADR-0019's durable-suspend promise. Async for that
+     * reason; a synchronous reading of this method can only ever answer for the
+     * current process lifetime.
+     *
+     * A run that does not exist, is no longer suspended, or paused at a
+     * non-screen node still resolves to `null`.
      */
-    getSuspendedScreen?(runId: string): ScreenSpec | null;
+    getSuspendedScreen?(runId: string): Promise<ScreenSpec | null>;
 }


### PR DESCRIPTION
Fixes #4515

## 问题

`AutomationEngine.getSuspendedScreen` 是**同步**方法，因此它在结构上就不可能去查挂起运行存储 —— 它只能读内存热缓存：

```ts
return this.suspendedRuns.get(runId)?.screen ?? null;
```

但 `SuspendedRun.screen` **是**被持久化的（`sys_automation_run.screen_json`），而 `resume()` 在缓存未命中时会通过 `loadSuspendedRun` 冷读回来。于是对一个进程重启后仍然活着的挂起 screen run，出现了这个割裂：

- `POST …/runs/:runId/resume` → 正常工作
- `GET …/runs/:runId/screen` → 404 `No pending screen for run`

而这条路由存在的**唯一理由**就是刷新安全的重新拉取（用户刷新页面、换一台设备继续）—— 它恰恰在最需要它的场景下失效。这是 ADR-0019「持久挂起」承诺的**渲染那一半**：恢复那一半已经上线了，渲染这一半一直缺席。

## 改动

按维护者决定的 Plan A（Plan B 的「异步孪生方法」已被明确否决，契约上不保留任何同步变体）：

**契约**（`packages/spec/src/contracts/automation-service.ts`）
`getSuspendedScreen?(runId): ScreenSpec | null` → `Promise<ScreenSpec | null>`，TSDoc 写明持久语义：热缓存快路径 + 存储回退，该方法对**任何真正处于挂起状态**的 run 都能作答，跨重启依然如此。

**引擎**（`packages/services/service-automation/src/engine.ts`）

```ts
async getSuspendedScreen(runId: string): Promise<ScreenSpec | null> {
    return (await this.loadSuspendedRun(runId))?.screen ?? null;
}
```

复用 `resume` 走的同一个加载器 —— 一个 loader、两个调用方，不复制 rehydration 逻辑。事实上 `loadSuspendedRun` 的 TSDoc 早就把「a screen fetch」列为它的目标调用方之一，只是当时没有调用方能用上它。

语义边界保持不变：不存在的 run、已不再挂起的 run、停在非 screen 节点的 run，仍然是 `null`，所以路由对真正不存在的 run 依旧返回 404。存储故障降级为 `null`（这条路由本来就以 404 作答）；需要区分「已消失」和「未知」的调用方仍然用会抛错的 `hasSuspendedRun`。

**全部消费方同步迁移**（一次改完，不留同步残留）：runtime automation domain 路由、受契约类型检查的 http-dispatcher mock（`mockReturnValue` → `mockResolvedValue`）、三处引擎测试调用点。

## 测试

新增 `packages/services/service-automation/src/suspended-screen-durability.test.ts`，共享一个 `InMemorySuspendedRunStore` 当作数据库，engine A 挂起、engine B 冷启动：

- 热路径：暂停它的那个引擎能重新拉到 screen
- **bug 本身**：重启后缓存未命中 + 持久化行 → screen 仍然返回，且只读不消费挂起，后续 resume 照常落地
- 真正不存在的 run → `null`（404 保持 404）；停在非 screen 节点的 run → `null`（持久 ≠ 凭空造一个表单）
- 存储故障 → `null` 而不是抛错，同时 `hasSuspendedRun` 仍然抛错
- 完全没有 store 时行为不变（纯内存）

`packages/qa/dogfood/test/flow-durable-suspend.dogfood.test.ts` 补上 dogfood 层的真实冷启动断言（#4564 已合入 main，所以现在可测）：真实 `stop()` → 冷 `bootStack` 之后，`GET …/runs/:runId/screen` 必须返回持久化的 screen，字段契约完整；重复拉取不消费挂起；不存在的 run 仍 404；run 被消费后 screen 也随之 404。

**Revert-proof（已实测）**：把引擎里的回退改回 `this.suspendedRuns.get(runId)?.screen ?? null`，

- 单测：`AssertionError: expected null not to be null`（1 failed | 4 passed）
- dogfood：`screen re-fetch after cold boot: {"success":false,"error":{"code":"RESOURCE_NOT_FOUND","message":"No pending screen for run","httpStatus":404}}: expected 404 to be 200` —— 正是 issue 记录的那个 404。

热路径用例在两种情况下都通过，所以失败的确实只有这个 bug。

### 实际输出

```
pnpm typecheck                    → Tasks: 122 successful, 122 total
@objectstack/spec               test →  Test Files 286 passed   Tests 7265 passed
@objectstack/service-automation test →  Test Files  53 passed   Tests  649 passed
@objectstack/runtime            test →  Test Files  74 passed   Tests 1046 passed
dogfood flow-durable-suspend         →  Test Files   1 passed   Tests   11 passed  (原 9 + 新增 2)
pnpm --filter @objectstack/spec check:generated → ✓ All 8 generated artifacts are up to date.
eslint（改动文件）               → 无输出
```

已在合入 origin/main（含 #4564）之后按 AGENTS.md §9 重跑：`pnpm install --frozen-lockfile && pnpm build && rm -rf packages/runtime/.objectstack`。

## Changeset

`.changeset/durable-suspended-screen-refetch.md` —— **minor**（发布窗口策略：breaking 以 minor 发布），正文显式标注 BREAKING，并带上 FROM → TO 迁移：调用方 `await`，实现方改签名，测试替身用 `mockResolvedValue`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_012C2cd7tL8QDoZ2QKN3djJ5)_