### PR TITLE
docs(releases): v17 checklist — Metadata*Options now come from contracts, not system (#4538)

### DIFF
--- a/.changeset/v17-metadata-options-pointer.md
+++ b/.changeset/v17-metadata-options-pointer.md
@@ -1,0 +1,8 @@
+---
+---
+
+Releases nothing — docs-only. The v17 upgrade checklist pointed kernel
+importers of `MetadataExportOptions` / `MetadataImportOptions` at
+`@objectstack/spec/system`; since #4538 deleted the zero-consumer system-side
+bags, the correct source is `@objectstack/spec/contracts`. No package ships
+from this change.

--- a/content/docs/releases/v17.mdx
+++ b/content/docs/releases/v17.mdx
@@ -2114,11 +2114,15 @@ covers are folded into the list below rather than left to the changelog.)
 - **Type importers:** replace `ObjectStackProtocol` / `ObjectStackProtocolSchema`
   with the narrowest per-domain slices; drop GraphQL types and any of the removed
   dead spec clusters. If you imported `MetadataFormat`, `MetadataStats`,
-  `MetadataLoadOptions`, `MetadataSaveOptions`, `MetadataExportOptions`,
-  `MetadataImportOptions`, `MetadataLoadResult`, `MetadataSaveResult`,
-  `MetadataWatchEvent`, `MetadataCollectionInfo` or `MetadataLoaderContract`
-  from `@objectstack/spec/kernel`, change the path to `@objectstack/spec/system`
-  — same names, and that copy is the one the runtime has always emitted. It is
+  `MetadataLoadOptions`, `MetadataSaveOptions`, `MetadataLoadResult`,
+  `MetadataSaveResult`, `MetadataWatchEvent`, `MetadataCollectionInfo` or
+  `MetadataLoaderContract` from `@objectstack/spec/kernel`, change the path to
+  `@objectstack/spec/system` — same names, and that copy is the one the runtime
+  has always emitted. (`MetadataExportOptions` / `MetadataImportOptions` moved
+  again in #4538: the system-side option bags turned out to have zero consumers
+  and were deleted, so those two names now come from
+  `@objectstack/spec/contracts` — the shape `MetadataManager` actually
+  implements.) It is
   the *looser* of the two, so a reader may need new narrowing: notably
   `metadataType`/`name`/`timestamp` are optional there. (`MetadataWatchEvent.type`
   briefly also declared the raw watcher values `add`/`change`/`unlink`; they had


### PR DESCRIPTION
docs-only。v17 升级 checklist 让 `@objectstack/spec/kernel` 的导入者把 11 个名字改从 `@objectstack/spec/system` 导入 —— #4538(PR #4568)删除了 system 侧零消费的 `MetadataExportOptions`/`MetadataImportOptions` 后,这两个名字的正确来源变为 `@objectstack/spec/contracts`(`MetadataManager` 实际实现的形状)。checklist 相应改写,其余 9 个名字指向不变。

按 releases-freeze 规则(CLAUDE.md,#4490)走专门 docs-only PR。这是流水线自身进展第二次 stale 掉该 checklist(前次 #4549),均由 PM 审查环节的针对性 docs 核查抓出。

关联:#4538、#4568、#4535

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9uWvoEp9CoLzYjNExj9sL)_