### PR TITLE
ci: 第二个声明 Fixes 同一 issue 的 open PR 开出即挂红 —— #4555/#4559 重复开发的三重堵漏 (#4588)

### DIFF
--- a/.changeset/duplicate-fix-guard.md
+++ b/.changeset/duplicate-fix-guard.md
@@ -1,0 +1,32 @@
+---
+---
+
+ci: fail a PR at open time when an earlier open PR already declares a fix for
+the same issue (#4588)
+
+Release-nothing: adds `.github/workflows/duplicate-fix-guard.yml` and updates
+agent process docs (AGENTS.md, CLAUDE.md, pm-dispatch claim template) — no
+package code.
+
+GitHub lets any number of open PRs declare `Fixes #N` for the same issue.
+On 2026-08-02, #4555 and #4559 both declared `Fixes #4551` and both were
+implemented in full — 834 duplicate lines through the whole gate suite — with
+the duplication machine-detectable from the second PR's open (03:08) yet
+unnoticed by any human until 08:52. The shared GitHub identity made the
+issue's assignee useless as a warning: "assigned to os-zhuang" reads the same
+whether the claimant is you or another session.
+
+Three changes, one per hole:
+
+- **Duplicate Fix Guard workflow**: on PR opened/edited/reopened/synchronize,
+  parse same-repo closing keywords and fail the PR if an EARLIER open PR
+  (lower number) declares the same issue, naming it. First come, first
+  served — matching the pm-dispatch "first claim comment wins" convention.
+  The check is body-driven and re-runs on `edited`, so a red PR goes green
+  the moment the conflict is resolved either way.
+- **Claim comments must carry a session ID** (pm-dispatch template, AGENTS.md,
+  CLAUDE.md): under a shared identity, the comment's session line is the only
+  thing that makes "is this claim mine?" answerable.
+- **Branch naming `claude/issue-<n>-<slug>`** (AGENTS.md): puts the issue
+  number where `git ls-remote | grep issue-<n>` can find it; the workflow
+  warns (never fails) when a fix PR's branch names no declared issue.

--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -189,14 +189,20 @@ execute atomically, in order:
 1. **Assign** to yourself (`@me`) and add `pm:dispatched`. Skip — and drop
    from the batch — any issue that acquired an assignee since step 1.
 2. **Claim comment** (Chinese), fixed shape — the branch name is the key,
-   every later artifact (worktree, push, PR) hangs off it:
+   every later artifact (worktree, push, PR) hangs off it. The session ID is
+   NOT optional: under the shared identity it is the only line that lets a
+   later reader — including your own future self after a context reset —
+   answer "is this claim mine?". A claim without it caused the #4555/#4559
+   duplicate (#4588): the second session saw its own shared name as assignee
+   and could not tell the claim was someone else's.
    > 认领:PM 循环第 N 轮
+   > 会话:`session_<id>`
    > 分支:`claude/issue-<n>-<slug>`
    > Worktree:`<repo>-issue-<n>`
 3. **Race check**: assignment is idempotent, so two agents can both
    "succeed". Re-read the comments; if an earlier claim comment with a
-   *different* branch name exists, you lost — touch nothing of theirs,
-   reply 「已有认领,让行」, and pick another issue. First comment wins.
+   *different* session ID or branch name exists, you lost — touch nothing of
+   theirs, reply 「已有认领,让行」, and pick another issue. First comment wins.
 
 Dev agents push their branch early — a remote branch is the hardest evidence
 of work in flight, closing the gap between "claimed" and "PR exists".

--- a/.github/workflows/duplicate-fix-guard.yml
+++ b/.github/workflows/duplicate-fix-guard.yml
@@ -1,0 +1,129 @@
+# GitHub happily lets any number of open PRs declare `Fixes #N` for the same
+# issue. On 2026-08-02 that cost a full duplicate implementation: #4555 and
+# #4559 both declared `Fixes #4551`, both ran the whole gate suite green, and
+# the duplication sat machine-detectable from the moment the second PR opened
+# (03:08) until a human noticed it (08:52). All agents here share one GitHub
+# identity, so the issue's assignee could not warn the second author either —
+# "assigned to os-zhuang" reads the same whether it is you or another session.
+# Full post-mortem: #4588.
+#
+# This gate makes the second PR red at open time. First come, first served —
+# the EARLIER open PR (lower number) keeps its claim and stays green; the
+# later one fails with a pointer to it. That matches the pm-dispatch claim
+# convention ("first claim comment wins") already in .claude/skills/.
+#
+# Scope: same-repo references only (bare `#N` and qualified `<this repo>#N`).
+# Cross-repo references are the cross-repo-issue-closer's territory, and a
+# duplicate across repos cannot be resolved by failing one side's CI anyway.
+name: Duplicate Fix Guard
+
+# `edited` matters as much as `opened`: a PR that adds `Fixes #N` to its body
+# after the fact must re-run this check, and one that drops the line must be
+# able to go green again.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  duplicate-fix-guard:
+    name: No other open PR may claim the same issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check declared issues against other open PRs
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const thisRepo = `${context.repo.owner}/${context.repo.repo}`;
+
+            // GitHub's own closing-keyword set. The optional colon is part of
+            // GitHub's accepted syntax (`Fixes: #123`). Two same-repo forms:
+            // bare `#N` and qualified `owner/repo#N` naming THIS repo.
+            const KEYWORDS = 'close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved';
+            const pattern = new RegExp(
+              `\\b(?:${KEYWORDS}):?\\s+(?:([\\w.-]+)\\/([\\w.-]+))?#(\\d+)\\b`,
+              'gi',
+            );
+
+            const declaredIssues = (body) => {
+              const found = new Set();
+              for (const [, owner, repo, number] of (body || '').matchAll(pattern)) {
+                // A qualified reference to ANOTHER repo is not ours to judge.
+                if (owner && `${owner}/${repo}`.toLowerCase() !== thisRepo.toLowerCase()) continue;
+                found.add(Number(number));
+              }
+              return found;
+            };
+
+            const mine = declaredIssues(pr.body);
+            if (mine.size === 0) {
+              core.info('This PR declares no same-repo closing keywords — nothing to guard.');
+              return;
+            }
+            core.info(`This PR declares: ${[...mine].map((n) => `#${n}`).join(', ')}`);
+
+            // Branch-name convention (advisory, never red): a fix branch named
+            // `claude/issue-<n>-<slug>` is discoverable by the next session
+            // with one `git ls-remote | grep issue-<n>`. #4555 vs #4559
+            // happened partly because the branches shared no token to grep.
+            // Warning only — existing branches must not go red retroactively.
+            const branch = pr.head.ref;
+            if (![...mine].some((n) => branch.includes(`issue-${n}`))) {
+              core.warning(
+                `Branch \`${branch}\` does not name any declared issue. ` +
+                `Convention: claude/issue-<n>-<slug> (e.g. claude/issue-${[...mine][0]}-short-slug) ` +
+                `so parallel sessions can discover in-flight work with git ls-remote.`,
+              );
+            }
+
+            // Drafts count: a draft PR is work in flight, which is exactly
+            // what the second session needs to see.
+            const openPrs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const conflicts = [];
+            for (const other of openPrs) {
+              if (other.number === pr.number) continue;
+              const theirs = declaredIssues(other.body);
+              const shared = [...mine].filter((n) => theirs.has(n));
+              if (shared.length > 0) conflicts.push({ other, shared });
+            }
+
+            if (conflicts.length === 0) {
+              core.info('No other open PR declares these issues.');
+              return;
+            }
+
+            // First come, first served: only the LATER PR goes red. Failing
+            // both would leave the original author red through no action of
+            // their own; failing the earlier one would reward racing.
+            const older = conflicts.filter((c) => c.other.number < pr.number);
+            const newer = conflicts.filter((c) => c.other.number > pr.number);
+
+            for (const { other, shared } of newer) {
+              core.info(
+                `#${other.number} (newer) also declares ${shared.map((n) => `#${n}`).join(', ')} — ` +
+                `it will fail its own run of this guard; this PR keeps its claim.`,
+              );
+            }
+
+            if (older.length > 0) {
+              const lines = older.map(({ other, shared }) =>
+                `  - ${shared.map((n) => `#${n}`).join(', ')} is already claimed by #${other.number} ` +
+                `(${other.html_url}, branch \`${other.head.ref}\`${other.draft ? ', draft' : ''})`,
+              );
+              core.setFailed(
+                `Another open PR already declares a fix for the same issue(s):\n${lines.join('\n')}\n` +
+                `If this PR is the duplicate, close it and add anything it uniquely covers to the ` +
+                `earlier PR or a follow-up issue (that is what saved #4560 when #4559 was closed). ` +
+                `If the EARLIER one is abandoned, close it first — this check re-runs on 'edited' ` +
+                `and 'synchronize', and goes green once the conflict is gone.`,
+              );
+            }

--- a/.github/workflows/duplicate-fix-guard.yml
+++ b/.github/workflows/duplicate-fix-guard.yml
@@ -48,9 +48,20 @@ jobs:
               'gi',
             );
 
+            // Strip fenced blocks and inline code spans before matching.
+            // GitHub's own closing-keyword parser ignores code formatting, and
+            // this guard must not be stricter than the linker it protects:
+            // this very PR's first run counted its own DISCUSSION of
+            // `Fixes #4551` (in backticks, describing the incident) as a
+            // declaration. Benign there — #4551 is closed — but a prose
+            // mention of an issue some other open PR really fixes would have
+            // been a spurious red.
             const declaredIssues = (body) => {
+              const prose = (body || '')
+                .replace(/```[\s\S]*?```/g, ' ')
+                .replace(/`[^`\n]*`/g, ' ');
               const found = new Set();
-              for (const [, owner, repo, number] of (body || '').matchAll(pattern)) {
+              for (const [, owner, repo, number] of prose.matchAll(pattern)) {
                 // A qualified reference to ANOTHER repo is not ours to judge.
                 if (owner && `${owner}/${repo}`.toLowerCase() !== thisRepo.toLowerCase()) continue;
                 found.add(Number(number));

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,18 @@ then race to land conflicting shapes for the same problem, which is worse than
 either one alone. If it is already assigned to someone else it is taken — pick
 another, or say so and ask; never reassign it to yourself.
 
+Because every agent here shares one GitHub identity, the assignee field alone
+cannot answer "is this claim *mine*?" — seeing your own shared name on an issue
+is exactly what another session's claim looks like. So a claim is two acts, not
+one: assign, **and leave a claim comment carrying your session ID and branch
+name** (`claude/issue-<n>-<slug>`). Before writing code, re-read the issue's
+comments; an earlier claim comment with a different session ID or branch means
+the issue is taken no matter what the assignee field seems to say. Skipping
+this read is how #4551 got implemented twice in one morning (#4555 and #4559 —
+post-mortem in #4588), and misreading shared-identity state is also how a
+maintainer's manual ready-flip got reverted by an agent that assumed its own
+write had failed.
+
 The claim is also what makes the *finding* rule (Prime Directive #10) safe to
 follow. Once out-of-scope discoveries become issues, the issue list is a real
 queue other agents read, and a claim is the only thing separating "someone is on
@@ -129,7 +141,13 @@ Even inside your own worktree, operate defensively:
    reverts, or other agents' in-flight edits, and don't try to manage the whole
    working tree. If a file you didn't change shows as modified, leave it.
 2. **One feature branch + one PR per task.** Branch off `main`. **Never commit
-   task work straight to `main`.**
+   task work straight to `main`.** Name the branch after the issue it fixes:
+   `claude/issue-<n>-<slug>`. The issue number in the name is what makes
+   in-flight work *discoverable* — `git ls-remote --heads origin | grep
+   issue-<n>` is a one-command pre-check, and the Duplicate Fix Guard workflow
+   warns on fix PRs whose branch names no declared issue. The #4555/#4559
+   duplicate (#4588) stayed invisible partly because one branch carried the
+   issue number and the other didn't.
 3. **Never `git push --force` / `--force-with-lease`, and never push `main`.** A
    force-push can clobber a parallel agent's work; `main` is shared — land
    everything via PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,12 @@ conflicting shapes for one problem. Already assigned to someone else? It is take
 another or ask; never reassign it to yourself. File findings unassigned when you are only
 recording them; assign at the moment you start.
 
+All agents share one GitHub identity, so the assignee field can't tell you whether a claim
+is **yours** — a claim is assign **plus a claim comment with your session ID and branch**
+(`claude/issue-<n>-<slug>`), and before writing code you must re-read the comments: an
+earlier claim with a different session ID means it's taken, whatever the assignee says.
+(#4551 was implemented twice in one morning because this read was skipped — see #4588.)
+
 ## ⛔ Worktree-first — before your FIRST file edit (AGENTS.md Prime Directive #11)
 
 This repo — **and every sibling repo you touch (`objectui`, `cloud`)** — is edited by


### PR DESCRIPTION
Fixes #4588

## 背景

今天上午 #4551 被两个会话完整实现了两遍（#4555 与 #4559，834 行重复劳动、全套门禁各跑一轮）。重复从第二个 PR 开出那一刻（03:08）起就是机器可判定的——两个 open PR 同时声明了针对 #4551 的关闭关键字——却直到 08:52 才被人工发现。共享 GitHub 身份让 issue 的 assignee 起不到警示作用："assigned to os-zhuang" 无论认领者是不是你，读起来一模一样。

三个洞，三个对应的堵法，合在本 PR：

## A. `Duplicate Fix Guard` 工作流（新增，挂红的那道闸）

PR opened / edited / reopened / synchronize 时解析正文的**同仓库**关闭关键字（裸 `#N` 与限定 `objectstack-ai/objectstack#N`；跨仓库引用是 cross-repo-issue-closer 的领域，不归它管），逐一比对其它 open PR（**含 draft**——draft 恰恰是第二个会话最需要看见的在途工作）：

- 存在**更早**（编号更小）的 open PR 声明同一 issue → 本 PR `setFailed`，点名对方（链接 + 分支名）。
- 更**晚**的冲突方只记 info——它会在自己的运行里挂红。**先到先得**，与 pm-dispatch「首条认领评论获胜」的既有约定同向；两边都挂红会冤枉原作者，挂红更早那个则是奖励抢跑。
- 失败信息里写明出路：重复方关闭时把独有产出转移走（#4559 关闭时抢救出 #4560 正是这个动作），或先关掉被弃的早方——检查在 `edited`/`synchronize` 上重跑，冲突消失即转绿。
- 代码格式内的关键字**不算声明**：匹配前剥掉围栏代码块与行内反引号——GitHub 自己的关闭关键字解析器就忽略代码格式，闸门不能比它保护的链接器更严（这一条是首次真实运行发现后补的，见下）。

## B. 认领评论必须带会话 ID（pm-dispatch 模板 + AGENTS.md + CLAUDE.md）

共享身份下,「这条认领是不是我发的」只有评论里的会话 ID 能回答。模板新增一行 `会话:session_<id>`，race check 的判负条件同步改为「更早且**会话 ID 或分支名**不同」。AGENTS.md 与 CLAUDE.md 的认领规则补上同一条：认领 = assign **加**带会话 ID 的评论，动码前必须重读评论区。这一改动同时覆盖此前另一次同根因事故（agent 把共享身份的 `draft: false` 误读为自己写入失败，反手撤销了维护者的手动操作）。

## C. 分支名统一 `claude/issue-<n>-<slug>`（AGENTS.md 分支纪律）

issue 号进分支名，`git ls-remote --heads origin | grep issue-<n>` 就是一条命令的预检。#4555（`claude/issue-4551-…`）与 #4559（`claude/dangling-reference-sweep`）互相不可见，一半原因就是后者没带 issue 号。工作流对「声明了 Fixes 但分支名不含任何被声明 issue 号」的 PR 给 **warning，不挂红**——存量分支不应被追溯打红。

## 验证

| 项 | 状态 |
|:---|:---|
| YAML 解析 | ✅ |
| 脚本语法 —— **完整注入标识符集**包装（`github, context, core, exec, glob, io, fetch, require, octokit, __original_require__`），#4573 的教训 | ✅ |
| 关键字正则 16 组样本：冒号形、`prefixes #99` 不误报、跨仓库排除、大小写、多引用、代码格式剥离 | ✅ 16/16 |
| 分页（>100 open PRs）用 `github.paginate` | ✅（代码路径，未实测大仓） |
| **端到端真实运行** | ✅ **已在本 PR 上跑过并通过** —— `pull_request`（不同于 `pull_request_target`）从 merge ref 读工作流定义，所以新增的闸在自己的 PR 上就会跑。初版 PR 正文断言「合并前不会跑本文件」，**是错的**，已由第一次运行本身证伪。 |

**首次真实运行立刻暴露了一个真缺陷**：日志记下 `This PR declares: #4588, #4551`——正文里**用反引号讨论**事故的那句 `Fixes #4551` 被当成了声明。当时无害（#4551 已关闭、无其它 open PR 声明它），但若某个 open PR 真在修被讨论的 issue，这就是一次冤枉的挂红。第二个 commit 修复：匹配前剥离代码格式，与 GitHub 自身解析行为对齐。修复后的运行应记 `This PR declares: #4588`——这是可核验的预期，请以该次 Actions 日志为准。

changeset：`.changeset/duplicate-fix-guard.md`（空 frontmatter，release-nothing）。未触碰 `content/docs/releases/`。

## 边界

- **只管同仓库重复。** 跨仓库的重复实现（若有）无法靠单侧 CI 挂红解决，不在范围。
- **不改 objectui。** 该仓库的 AGENTS.md/认领约定是独立文件；等本 PR 的形状被真实运行验证过再镜像过去，避免把未经运行的工作流一次铺到两个仓库（cross-repo closer 就是这么放大故障面的）。
- pm-dispatch SKILL.md 的措辞改动不改变循环的结构，只改认领评论模板与判负条件。