### PR TITLE
test(drivers): filter-logic 标准收编第五个 backend —— driver-mongodb 与 driver-sqlite-wasm 两条 DEBT 同 PR 清账 (#4405)

### DIFF
--- a/.changeset/filter-logic-conformance-mongodb-wasm.md
+++ b/.changeset/filter-logic-conformance-mongodb-wasm.md
@@ -1,0 +1,53 @@
+---
+"@objectstack/driver-mongodb": patch
+"@objectstack/driver-sqlite-wasm": patch
+---
+
+test(drivers): the filter-logic standard now covers the backend it was counted without (#4405)
+
+`FILTER_LOGIC_CASES` (#3774) opens by calling itself the standard "the four
+independent FilterCondition backends are each checked against". Five backends
+exist. `driver-mongodb`'s `translateFilter` was missed, not excluded — an
+independent implementation whose `$and`/`$or`/`$not` translation shares no line
+of code with the SQL compiler or the in-memory matcher, and the only one whose
+target language cannot spell the standard directly: MongoDB has no
+document-level `$not` at all (the server answers `unknown top level operator:
+$not`), so a negation has to leave as `$nor`, and a branch's own keys have to
+stay in one document while `$and`/`$or` clauses are lifted beside them. That
+route was never checked against the shared cases. Both DEBT rows the #4363 gate
+recorded are now cleared, and `scripts/check-driver-conformance.mjs` reports
+`ok` for every cell of the matrix.
+
+**`driver-mongodb` runs the table twice, and the split is deliberate.**
+`mongodb-filter-logic-translation.test.ts` drives every shared case through
+`translateFilter` and evaluates the emitted MongoDB *document* over the shared
+fixture — a pure function, no server, so it always runs. That matters here more
+than anywhere: `mongodb-memory-server` downloads a ~123 MB binary from
+fastdl.mongodb.org, and a defect only a downloadable binary can catch is a
+defect nobody catches on a restricted network. Its in-process reader is strict
+by construction — every shape it does not model throws instead of evaluating to
+true, a document-level `$not` included — and its own discrimination is pinned by
+cases that require a widened document to FAIL the case it widens, so "all green"
+cannot mean "the reader says yes to everything".
+`mongodb-filter-logic-conformance.test.ts` runs the same table against a real
+mongod and answers the one question the first half cannot — does MongoDB agree?
+— skipping cleanly (never silently) when the binary is unreachable.
+
+**`driver-sqlite-wasm` runs the table through its own engine.** It inherits
+`SqlDriver`'s filter compiler, so nothing is re-implemented; what the suite pins
+is that a nested `(… AND …) OR (… AND …)` survives the custom sql.js dialect
+that compiles, binds and marshals it — the same seam its temporal and pagination
+suites cover for their clauses. Tracked as DEBT rather than EXEMPT because
+"inherits, therefore fine" is the assumption those suites exist to disprove; the
+suite is what disproves it.
+
+**No divergence was found.** `translateFilter` answers all seventeen shared
+cases correctly today, `$not`-inside-a-branch and nested `$and`-inside-`$or`
+included, so no translation change ships here — what changes is that the next
+edit to it cannot quietly widen a filter. Both suites were verified to be
+discriminating rather than decorative by reintroducing the #3774 miscompile
+(propagating `or` into a branch's own contents): 15 of the mongodb translation
+suite's 26 tests fail, and 13 of the wasm suite's 18.
+
+`packages/spec`'s `filter-logic-conformance.ts` header now says five and names
+the fifth — a code comment; no schema, export or generated artifact moved.

--- a/packages/plugins/driver-mongodb/src/mongodb-filter-logic-conformance.test.ts
+++ b/packages/plugins/driver-mongodb/src/mongodb-filter-logic-conformance.test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Filter logical-combinator conformance for the MongoDB driver, against a REAL
+ * mongod (#4405) — the half that answers whether MongoDB agrees.
+ *
+ * The shared cases come from `@objectstack/spec/data`, so this backend now
+ * stands beside `driver-sql`, `driver-memory`, `formula`'s
+ * `matchesFilterCondition` and `read-scope-sql` under one standard (#3774).
+ * `mongodb-filter.ts` reaches that standard by a completely separate route:
+ * MongoDB has no document-level `$not`, so a negation is emitted as `$nor`, and
+ * a branch's own keys have to stay inside one document while `$and`/`$or`
+ * clauses are lifted beside them. Whether that route arrives at the same rows
+ * is not a question a translator test can close — it is a question about the
+ * server's evaluation of the document, and this file is where it is asked.
+ *
+ * The same table is driven server-free by
+ * `mongodb-filter-logic-translation.test.ts`, which is the half that always
+ * runs. This one skips when the mongod binary cannot be fetched (the
+ * `createTestMongod` convention every suite in this package uses — a blocked or
+ * hanging download costs a skipped suite, not a stalled test job). **A skip is
+ * not a pass**: on a machine without the binary, the translation suite is the
+ * whole proof, which is exactly why it carries the priority half.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
+import { FILTER_LOGIC_CASES, FILTER_LOGIC_ROWS } from '@objectstack/spec/data';
+import { MongoDBDriver } from './mongodb-driver.js';
+import { createTestMongod } from './test-mongod.js';
+
+const sharedMongod: MongoMemoryServer | undefined = await createTestMongod('filter logic conformance');
+
+describe.skipIf(!sharedMongod)('driver-mongodb — filter logic conformance', () => {
+  const mongod = sharedMongod as MongoMemoryServer;
+  let driver: MongoDBDriver;
+
+  beforeAll(async () => {
+    driver = new MongoDBDriver({ url: mongod.getUri(), database: 'filter_logic_conformance' });
+    await driver.connect();
+    // Every fixture column is a plain string — the shared table keeps its
+    // predicates boring on purpose, so nothing here is about coercion. The
+    // declaration is still made, because that is how a real object reaches the
+    // driver and how its field kinds are resolved (#4047).
+    await driver.syncSchema('conformance', {
+      name: 'conformance',
+      fields: {
+        a: { type: 'string' },
+        b: { type: 'string' },
+        c: { type: 'string' },
+        owner: { type: 'string' },
+        status: { type: 'string' },
+        parent_object: { type: 'string' },
+        parent_id: { type: 'string' },
+      },
+    });
+    for (const row of FILTER_LOGIC_ROWS) {
+      await driver.create('conformance', { ...row });
+    }
+  }, 90_000);
+
+  afterAll(async () => {
+    if (driver) await driver.disconnect();
+    if (sharedMongod) await sharedMongod.stop();
+  });
+
+  for (const c of FILTER_LOGIC_CASES) {
+    it(c.name, async () => {
+      const rows = await driver.find('conformance', { object: 'conformance', where: c.filter } as any);
+      const got = (rows as any[])
+        .map((r) => String(r.id))
+        .sort((x, y) => x.localeCompare(y));
+      expect(got, c.note).toEqual([...c.expected]);
+    });
+  }
+
+  /**
+   * The fixture as a whole, so a case that returns nothing because the seed
+   * failed cannot read as a case that correctly excluded everything.
+   */
+  it('the fixture really is all four rows', async () => {
+    const rows = await driver.find('conformance', { object: 'conformance' } as any);
+    expect((rows as any[]).map((r) => String(r.id)).sort()).toEqual(['1', '2', '3', '4']);
+  });
+});

--- a/packages/plugins/driver-mongodb/src/mongodb-filter-logic-translation.test.ts
+++ b/packages/plugins/driver-mongodb/src/mongodb-filter-logic-translation.test.ts
@@ -1,0 +1,269 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Filter logical-combinator conformance for `translateFilter` — the MongoDB
+ * query documents it EMITS, asserted without a server (#4405).
+ *
+ * `mongodb-filter.ts` is an independent FilterCondition backend: the fifth one,
+ * and the one #3774 never enrolled when it named "the four". Its `$and` / `$or`
+ * / `$not` translation shares no line of code with the SQL compiler or the
+ * in-memory matcher, so nothing held it to the shared standard in
+ * `@objectstack/spec/data` — the standard that exists because a backend can
+ * widen a filter and still look like it is filtering (#3774 compiled
+ * `{$or:[{a,b}]}` to `a = ? OR b = ?`, and every read-visibility filter written
+ * that way returned rows the scope excluded).
+ *
+ * This is the half that must ALWAYS run. `translateFilter` is a pure function,
+ * and a driver defect only a downloadable 123 MB binary can catch is a defect
+ * nobody catches on a restricted network — the reason `test-mongod.ts` exists
+ * and the reason the #4419 suites split the same way. `mongodb-filter-logic-
+ * conformance.test.ts` runs the same shared cases against a real mongod and
+ * answers the question this file cannot: does MongoDB agree?
+ *
+ * ## Why there is a matcher in here at all
+ *
+ * A translator's output is a document, and the shared cases are stated in row
+ * ids, so something has to bridge the two. Pinning the emitted document
+ * literally for all eighteen cases would pin today's spelling rather than the
+ * semantics — the standard is "these ids, and no others", not "this JSON".
+ *
+ * So {@link matchDoc} evaluates the emitted document over
+ * {@link FILTER_LOGIC_ROWS} by MongoDB's documented semantics, and is
+ * deliberately **strict**: every shape it does not model is a thrown error, not
+ * a silently-true predicate. A stand-in more permissive than the real engine
+ * turns a suite into a green light for broken code, which is the hazard #4419
+ * called out. Its own discrimination is proved below (a widened document must
+ * FAIL the case it widens), so "all green" cannot mean "the matcher says yes to
+ * everything".
+ *
+ * The named risk areas from #4405 get literal wire-shape pins on top of the
+ * sweep, because they are where the two engines' vocabularies differ rather
+ * than where a row count differs: MongoDB has no document-level `$not` at all
+ * (the server answers `unknown top level operator: $not`), so a negation has to
+ * leave here as `$nor` or as a per-field `$not`, and a nested `$and` inside a
+ * `$or` branch must stay a nested document rather than being flattened into its
+ * parent.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { FILTER_LOGIC_CASES, FILTER_LOGIC_ROWS, type FilterLogicRow } from '@objectstack/spec/data';
+import { translateFilter } from './mongodb-filter.js';
+
+// ── A deliberately strict reader of the emitted document ────────────────────
+
+/** Thrown for any shape this matcher does not model — never swallowed. */
+class UnsupportedShape extends Error {}
+
+/**
+ * MongoDB orders values only WITHIN a BSON type bracket; across brackets a
+ * range predicate simply does not match. The shared fixture is all strings, so
+ * a cross-type comparison here means the translator produced a comparand the
+ * case never asked for.
+ */
+function compare(a: unknown, b: unknown): number | undefined {
+  if (typeof a !== typeof b) return undefined; // different bracket → no order
+  if (typeof a === 'string' || typeof a === 'number') {
+    return a === b ? 0 : (a as any) < (b as any) ? -1 : 1;
+  }
+  throw new UnsupportedShape(`unsupported comparand type: ${typeof a}`);
+}
+
+/** Operators applied to one field's value. */
+function matchOps(value: unknown, ops: Record<string, unknown>): boolean {
+  for (const [op, arg] of Object.entries(ops)) {
+    switch (op) {
+      case '$eq':
+        if (value !== arg) return false;
+        break;
+      case '$ne':
+        if (value === arg) return false;
+        break;
+      case '$gt':
+        if (!((compare(value, arg) ?? 0) > 0)) return false;
+        break;
+      case '$gte':
+        if (!((compare(value, arg) ?? -1) >= 0)) return false;
+        break;
+      case '$lt':
+        if (!((compare(value, arg) ?? 0) < 0)) return false;
+        break;
+      case '$lte':
+        if (!((compare(value, arg) ?? 1) <= 0)) return false;
+        break;
+      case '$in':
+        if (!Array.isArray(arg)) throw new UnsupportedShape('$in without an array');
+        if (!arg.includes(value)) return false;
+        break;
+      case '$nin':
+        if (!Array.isArray(arg)) throw new UnsupportedShape('$nin without an array');
+        if (arg.includes(value)) return false;
+        break;
+      case '$exists':
+        if ((value !== undefined) !== arg) return false;
+        break;
+      case '$not': {
+        // The per-field negation — the only `$not` MongoDB accepts, and it
+        // takes an operator document, never a plain value.
+        if (!arg || typeof arg !== 'object' || Array.isArray(arg)) {
+          throw new UnsupportedShape('per-field $not takes an operator document');
+        }
+        if (matchOps(value, arg as Record<string, unknown>)) return false;
+        break;
+      }
+      default:
+        throw new UnsupportedShape(`unsupported field operator '${op}'`);
+    }
+  }
+  return true;
+}
+
+/** One field key of a query document: a literal, or an operator document. */
+function matchField(value: unknown, cond: unknown): boolean {
+  if (cond !== null && typeof cond === 'object' && !Array.isArray(cond) && !(cond instanceof Date)) {
+    const keys = Object.keys(cond as Record<string, unknown>);
+    const ops = keys.filter((k) => k.startsWith('$'));
+    if (ops.length === keys.length && keys.length > 0) {
+      return matchOps(value, cond as Record<string, unknown>);
+    }
+    if (ops.length > 0) {
+      throw new UnsupportedShape(`mixed operator/literal keys on one field: ${keys.join(', ')}`);
+    }
+  }
+  return value === cond;
+}
+
+/**
+ * Evaluate an emitted MongoDB query document against one fixture row.
+ *
+ * Models exactly what MongoDB does for the vocabulary these cases can produce,
+ * and throws for everything else — including a document-level `$not`, which the
+ * server itself rejects.
+ */
+export function matchDoc(row: FilterLogicRow, doc: Record<string, unknown>): boolean {
+  for (const [key, value] of Object.entries(doc)) {
+    switch (key) {
+      case '$and':
+        if (!Array.isArray(value)) throw new UnsupportedShape('$and without an array');
+        if (!value.every((sub) => matchDoc(row, sub as Record<string, unknown>))) return false;
+        break;
+      case '$or':
+        if (!Array.isArray(value)) throw new UnsupportedShape('$or without an array');
+        if (!value.some((sub) => matchDoc(row, sub as Record<string, unknown>))) return false;
+        break;
+      case '$nor':
+        if (!Array.isArray(value)) throw new UnsupportedShape('$nor without an array');
+        if (value.some((sub) => matchDoc(row, sub as Record<string, unknown>))) return false;
+        break;
+      case '$not':
+        throw new UnsupportedShape(
+          'document-level $not — MongoDB has no such operator and answers '
+            + '`unknown top level operator: $not`; a negation must be emitted as $nor '
+            + 'or as a per-field $not',
+        );
+      default:
+        if (key.startsWith('$')) throw new UnsupportedShape(`unsupported document operator '${key}'`);
+        if (!matchField((row as any)[key], value)) return false;
+    }
+  }
+  return true;
+}
+
+/** Ids the emitted document selects from the shared fixture, ascending. */
+function select(doc: Record<string, unknown>): string[] {
+  return FILTER_LOGIC_ROWS.filter((row) => matchDoc(row, doc))
+    .map((row) => row.id)
+    .sort((x, y) => x.localeCompare(y));
+}
+
+/** Walk an emitted document, reporting every document-level `$not`. */
+function documentLevelNots(doc: unknown, path = '$'): string[] {
+  if (Array.isArray(doc)) return doc.flatMap((d, i) => documentLevelNots(d, `${path}[${i}]`));
+  if (!doc || typeof doc !== 'object') return [];
+  const found: string[] = [];
+  for (const [key, value] of Object.entries(doc as Record<string, unknown>)) {
+    if (key === '$not') found.push(path);
+    // Only logical operators carry further query DOCUMENTS; anything under a
+    // field key is an operator document, where `$not` is legal.
+    if (key === '$and' || key === '$or' || key === '$nor') {
+      found.push(...documentLevelNots(value, `${path}.${key}`));
+    }
+  }
+  return found;
+}
+
+// ── The shared standard ─────────────────────────────────────────────────────
+
+describe('translateFilter — filter logic conformance, without a server (#4405)', () => {
+  for (const c of FILTER_LOGIC_CASES) {
+    it(c.name, () => {
+      const doc = translateFilter(c.filter) as Record<string, unknown>;
+      expect(select(doc), `${c.note ?? ''}\nemitted: ${JSON.stringify(doc)}`).toEqual([
+        ...c.expected,
+      ]);
+    });
+  }
+});
+
+// ── The vocabulary gap the row counts cannot show ───────────────────────────
+
+describe('translateFilter — the shapes MongoDB spells differently', () => {
+  it('never emits a document-level $not: the server rejects it outright', () => {
+    for (const c of FILTER_LOGIC_CASES) {
+      const doc = translateFilter(c.filter) as Record<string, unknown>;
+      expect(documentLevelNots(doc), `${c.name} emitted ${JSON.stringify(doc)}`).toEqual([]);
+    }
+  });
+
+  it('$not becomes a $nor that AND-s with the sibling keys of its own branch', () => {
+    // The #4405 risk area, stated literally: the negation is a `$nor`, and it
+    // joins `b: 'zz'` with `$and` rather than replacing it.
+    expect(translateFilter({ $or: [{ c: 'nope' }, { $not: { a: 'x' }, b: 'zz' }] })).toEqual({
+      $or: [{ c: 'nope' }, { $and: [{ b: 'zz' }, { $nor: [{ a: 'x' }] }] }],
+    });
+  });
+
+  it('a nested $and inside a $or branch stays nested, and keeps the branch key beside it', () => {
+    expect(translateFilter({ $or: [{ c: 'nope' }, { $and: [{ a: 'qq' }], b: 'y' }] })).toEqual({
+      $or: [{ c: 'nope' }, { $and: [{ b: 'y' }, { $and: [{ a: 'qq' }] }] }],
+    });
+  });
+
+  it('a multi-key $or branch stays ONE document — the shape #3774 flattened', () => {
+    expect(translateFilter({ $or: [{ a: 'x', b: 'y' }] })).toEqual({
+      $or: [{ a: 'x', b: 'y' }],
+    });
+  });
+});
+
+// ── The matcher is not the thing being tested, so it gets tested ────────────
+
+describe('the in-process matcher discriminates', () => {
+  it('a widened document FAILS the case it widens (the #3774 miscompile)', () => {
+    // `{$or:[{a:'x',b:'y'}]}` must select row 1 alone. This is what OR-ing the
+    // branch's own keys would have emitted instead — if the sweep above can
+    // pass with this, it is proving nothing.
+    expect(select({ $or: [{ a: 'x' }, { b: 'y' }] })).toEqual(['1', '2', '3']);
+    expect(select({ $or: [{ a: 'x', b: 'y' }] })).toEqual(['1']);
+  });
+
+  it('a widened operator window FAILS too', () => {
+    expect(select({ b: { $gte: 'y', $lt: 'z' } })).toEqual(['1', '3']);
+    expect(select({ $or: [{ b: { $gte: 'y' } }, { b: { $lt: 'z' } }] })).toEqual(['1', '2', '3', '4']);
+  });
+
+  it('refuses a document-level $not instead of quietly evaluating one', () => {
+    expect(() => matchDoc(FILTER_LOGIC_ROWS[0], { $not: { a: 'x' } })).toThrow(
+      /document-level \$not/,
+    );
+  });
+
+  it('refuses any operator it does not model, rather than treating it as true', () => {
+    expect(() => matchDoc(FILTER_LOGIC_ROWS[0], { a: { $regex: 'x' } })).toThrow(/unsupported/);
+    expect(() => matchDoc(FILTER_LOGIC_ROWS[0], { $expr: {} })).toThrow(/unsupported/);
+  });
+
+  it('honours $nor and the per-field $not the translator is allowed to emit', () => {
+    expect(select({ $nor: [{ a: 'x' }] })).toEqual(['3', '4']);
+    expect(select({ a: { $not: { $eq: 'x' } } })).toEqual(['3', '4']);
+  });
+});

--- a/packages/plugins/driver-sqlite-wasm/src/sqlite-wasm-filter-logic-conformance.test.ts
+++ b/packages/plugins/driver-sqlite-wasm/src/sqlite-wasm-filter-logic-conformance.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Filter logical-combinator conformance for the wasm driver (#3774, #4405) —
+ * the shared `@objectstack/spec/data` cases, run through this driver's own
+ * pipeline.
+ *
+ * `SqliteWasmDriver extends SqlDriver`, so the `$and` / `$or` / `$not`
+ * compilation is inherited and nothing here re-implements it. What this pins is
+ * the other half, the same half its temporal and pagination suites pin: the
+ * compiled predicate has to survive a different **engine**. This driver swaps
+ * knex's transport for a custom sql.js dialect (`Client_WasmSqlite`) that
+ * compiles the statement, binds its parameters and marshals the rows back
+ * through its own path. A dialect that mis-bound the parameters of a nested
+ * `(… AND …) OR (… AND …)` would produce precisely the failure the shared
+ * standard exists to rule out — a filter that looks applied and selects the
+ * wrong rows — and it would fail in no other suite in the repo.
+ *
+ * "It inherits the compiler, therefore it is fine" is the assumption those two
+ * suites exist to disprove; #4405 recorded this cell as DEBT rather than EXEMPT
+ * for exactly that reason. This file clears it.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { FILTER_LOGIC_CASES, FILTER_LOGIC_ROWS } from '@objectstack/spec/data';
+import { SqliteWasmDriver } from './index.js';
+
+describe('driver-sqlite-wasm — filter logic conformance', () => {
+  let driver: SqliteWasmDriver;
+
+  beforeAll(async () => {
+    driver = new SqliteWasmDriver({ filename: ':memory:' });
+    await driver.initObjects([
+      {
+        name: 'conformance',
+        fields: {
+          a: { type: 'string' },
+          b: { type: 'string' },
+          c: { type: 'string' },
+          owner: { type: 'string' },
+          status: { type: 'string' },
+          parent_object: { type: 'string' },
+          parent_id: { type: 'string' },
+        },
+      },
+    ]);
+    for (const row of FILTER_LOGIC_ROWS) {
+      await driver.create('conformance', { ...row }, { bypassTenantAudit: true } as any);
+    }
+  });
+
+  afterAll(async () => {
+    await driver.disconnect();
+  });
+
+  for (const c of FILTER_LOGIC_CASES) {
+    it(c.name, async () => {
+      const rows = await driver.find(
+        'conformance',
+        { object: 'conformance', where: c.filter } as any,
+        { bypassTenantAudit: true } as any,
+      );
+      const got = (rows as any[])
+        .map((r) => String(r.id))
+        .sort((x, y) => x.localeCompare(y));
+      expect(got, c.note).toEqual([...c.expected]);
+    });
+  }
+
+  /**
+   * The fixture as a whole, so a case that returns nothing because the seed
+   * failed cannot read as a case that correctly excluded everything.
+   */
+  it('the fixture really is all four rows', async () => {
+    const rows = await driver.find('conformance', {} as any, { bypassTenantAudit: true } as any);
+    expect((rows as any[]).map((r) => String(r.id)).sort()).toEqual(['1', '2', '3', '4']);
+  });
+});

--- a/packages/spec/src/data/filter-logic-conformance.ts
+++ b/packages/spec/src/data/filter-logic-conformance.ts
@@ -6,7 +6,7 @@
  *
  * ## Why this exists
  *
- * `FilterCondition` is evaluated by four independent implementations, and they
+ * `FilterCondition` is evaluated by five independent implementations, and they
  * had drifted:
  *
  * | Backend | Where |
@@ -15,6 +15,14 @@
  * | In-memory matcher | `driver-memory` `memory-matcher` |
  * | Record-at-a-time evaluator | `formula` `matchesFilterCondition` (RLS write-side `check`) |
  * | Read-scope SQL lowering | `service-analytics` `read-scope-sql` |
+ * | MongoDB query translator | `driver-mongodb` `translateFilter` |
+ *
+ * #3774 said "four" and enrolled four: `translateFilter` was missed, not
+ * excluded, and ran unchecked against this standard until #4405 — the one
+ * backend whose target language has no document-level `$not` at all, so a
+ * negation leaves it as `$nor`. `driver-sqlite-wasm` runs the table too; it
+ * *inherits* the SQL compiler, so what its suite adds is the sql.js engine
+ * executing the compiled predicate rather than a sixth way of building one.
  *
  * In #3774 the SQL compiler OR-ed the contents *within* a `$or` branch instead
  * of AND-ing them, so every `$or` filter matched more rows than it should —

--- a/packages/spec/src/data/index.ts
+++ b/packages/spec/src/data/index.ts
@@ -3,8 +3,9 @@
 export * from './query.zod';
 export * from './filter.zod';
 // Canonical conformance cases for the filter logical combinators — the shared
-// standard the four independent FilterCondition backends are each checked
-// against, so they cannot drift apart again (#3774).
+// standard the five independent FilterCondition backends are each checked
+// against, so they cannot drift apart again (#3774; the fifth — MongoDB's
+// `translateFilter` — was enrolled by #4405).
 export * from './filter-logic-conformance';
 export * from './temporal-conformance';
 // Canonical conformance cases for deterministic paged reads — the standard

--- a/scripts/check-driver-conformance.mjs
+++ b/scripts/check-driver-conformance.mjs
@@ -109,31 +109,29 @@ const CASE_SETS = [
 // One entry per uncovered (driver x case-set) cell. `kind` is DEBT (should be
 // covered, is not yet) or EXEMPT (cannot meaningfully apply). Both are measured
 // claims; neither is a default.
+//
+// EMPTY, as of #4405 — every cell of the matrix is covered by a suite. The two
+// FILTER_LOGIC_CASES rows this ledger opened with are both cleared:
+//
+//   driver-mongodb      `translateFilter` was the independent fifth backend
+//                       #3774 never enrolled when it named "the four". It now
+//                       drives the shared cases twice: server-free over the
+//                       MongoDB documents it emits (the half that always runs,
+//                       because the mongod binary is not always fetchable), and
+//                       against a real mongod.
+//   driver-sqlite-wasm  Inherits SqlDriver's filter compiler, so what its suite
+//                       pins is the sql.js dialect executing the compiled
+//                       predicate — the same seam its temporal and pagination
+//                       suites cover for their clauses. It was tracked as DEBT
+//                       rather than EXEMPT because "inherits, therefore fine" is
+//                       the assumption those suites exist to disprove; the suite
+//                       is what disproves it, not the entry.
+//
+// An empty ledger is the intended steady state, not a reason to delete the
+// mechanism: the next driver that arrives uncovered fails CONSUMED and lands
+// its measured entry here.
 
-const LEDGER = [
-  {
-    driver: 'driver-mongodb',
-    marker: 'FILTER_LOGIC_CASES',
-    kind: 'DEBT',
-    issue: 'https://github.com/objectstack-ai/objectstack/issues/4405',
-    why:
-      "`mongodb-filter.ts`'s `translateFilter` is an independent FilterCondition "
-      + 'backend — the fifth, and the one #3774 never enrolled when it named "the four". '
-      + 'Its $and/$or/$not translation shares no code with the SQL or in-memory paths.',
-  },
-  {
-    driver: 'driver-sqlite-wasm',
-    marker: 'FILTER_LOGIC_CASES',
-    kind: 'DEBT',
-    issue: 'https://github.com/objectstack-ai/objectstack/issues/4405',
-    why:
-      'Inherits SqlDriver\'s filter compiler, so the risk is the sql.js dialect executing '
-      + 'the compiled predicate, not the predicate being built wrong — the same risk its '
-      + 'temporal and pagination suites already cover for their clauses. Lower value than '
-      + 'the mongodb row above, tracked with it rather than exempted, because "inherits, '
-      + 'therefore fine" is exactly the assumption those two suites exist to disprove.',
-  },
-];
+const LEDGER = [];
 
 // ── Discovery ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #4405

## 问题

`FILTER_LOGIC_CASES`(#3774)的开篇说自己是「the four independent FilterCondition backends are each checked against」的共享标准。实际上有**五个**:`driver-mongodb` 的 `translateFilter` 是完全独立的第五个实现,`$and` / `$or` / `$not` 的翻译跟 SQL 编译器、内存匹配器一行代码都不共用 —— 它是被漏掉的,不是被排除的。而且它是唯一一个**目标语言拼不出这套标准**的 backend:MongoDB 根本没有文档级 `$not`(服务端直接回 `unknown top level operator: $not`),所以否定必须以 `$nor` 出去,分支自己的 key 必须留在同一个文档里、`$and`/`$or` 子句被抬到它旁边。这条路线从来没被共享用例验证过。

`driver-sqlite-wasm` 继承 `SqlDriver` 的过滤编译器,但从没让这张表走过它自己的 sql.js 引擎。

`scripts/check-driver-conformance.mjs` 里的两条 DEBT 就是这两格,本 PR 同时清掉 —— 只删条目不写套件会挂 `CONSUMED`,写了套件不删条目会挂 `RECONCILED`,所以必须同一个 PR。

## 改了什么

**`driver-mongodb` 把这张表跑两遍,拆分是刻意的:**

- `mongodb-filter-logic-translation.test.ts` —— **无服务器,永远会跑**。把每条共享用例喂给 `translateFilter`,再把它**吐出来的 MongoDB 查询文档**在共享 fixture 上求值。`translateFilter` 是纯函数,而 `mongodb-memory-server` 要从 fastdl.mongodb.org 下 ~123 MB 二进制 —— 「只有能下二进制的机器才抓得到的缺陷」在受限网络上等于没人抓得到,这也正是 `test-mongod.ts` 和 #4419 那对套件存在的理由。
  文件里那个进程内的求值器是**刻意严格**的:任何它没建模的形状一律 `throw`,而不是悄悄判 true —— 文档级 `$not` 会带着服务端的原话抛出来。比真实引擎更宽松的替身会把套件变成坏代码的绿灯(#4419 点名的那个坑),所以它自己的判别力也被钉住了:有几条用例要求「被放宽的文档必须让它所放宽的那条用例失败」,这样「全绿」就不可能等于「求值器对什么都点头」。
  #4405 点名的两个风险区还额外有字面 wire-shape 断言:`$not` → `$nor`(且与同分支的兄弟 key 以 `$and` 相连)、`$or` 分支里的嵌套 `$and` 保持嵌套而不是被摊平。
- `mongodb-filter-logic-conformance.test.ts` —— 同一张表打**真 mongod**(`createTestMongod`),回答前一半答不了的那个问题:MongoDB 同不同意。二进制拉不到时**干净地跳过**(不是静默通过);本环境 403 拉不到,所以本地是 skip,CI 会真跑。

**`driver-sqlite-wasm`** 的 `sqlite-wasm-filter-logic-conformance.test.ts` 让同一张表走它自己的引擎。编译器是继承来的,这里不重新实现任何东西;钉住的是另一半:嵌套的 `(… AND …) OR (… AND …)` 必须活着穿过那个自定义 sql.js dialect 的编译、绑参和回程 —— 跟它的 temporal / pagination 套件为各自子句覆盖的是同一个接缝。之所以当初记 DEBT 而不是 EXEMPT:「继承了所以没问题」正是那两个套件要否证的假设,而否证它的是套件,不是 ledger 条目。

## 没有发现翻译分歧

`translateFilter` 今天对全部 17 条共享用例的回答都是对的,`$not` 在分支内、`$and` 嵌在 `$or` 里都包括在内,所以**本 PR 不改任何翻译逻辑**。变的是:下一次改它的人没法悄悄放宽一个过滤条件。

两个套件都验证过是**有判别力**而非装饰:把 #3774 的误编译重新引入(把 `or` 传进分支自身的内容),mongodb 翻译套件 26 条里挂 15 条,wasm 套件 18 条里挂 13 条。另外把 `$nor` 换成文档级 `$not`(也就是「MongoDB 有 $not 吧」这种想当然的改法)时,那条专门的不变量断言会点名报错。

## 验证

```
$ node scripts/check-driver-conformance.mjs
  driver              FILTER_LOGIC  TEMPORAL  TEMPORAL_TIME  PAGINATION  PAGINATION_UNORDERED
  driver-memory       ok            ok        ok             ok          ok
  driver-mongodb      ok            ok        ok             ok          ok
  driver-sql          ok            ok        ok             ok          ok
  driver-sqlite-wasm  ok            ok        ok             ok          ok
check-driver-conformance: OK — 20 covered cell(s), 0 in the DEBT ledger, 0 exempt.

$ pnpm --filter @objectstack/driver-mongodb test
 Test Files  7 passed | 5 skipped (12)
      Tests  132 passed | 121 skipped (253)      # 5 skipped = 拉不到 mongod 的套件

$ pnpm --filter @objectstack/driver-sqlite-wasm test
 Test Files  16 passed (16)
      Tests  232 passed (232)

$ pnpm --filter @objectstack/driver-mongodb typecheck        # tsc --noEmit,无输出
$ pnpm --filter @objectstack/driver-sqlite-wasm typecheck    # 同上
$ pnpm --filter @objectstack/spec check:generated            # ✓ All 8 generated artifacts are up to date
$ pnpm --filter @objectstack/spec test
 Test Files  287 passed (287)
      Tests  7270 passed (7270)
```

ledger gate 的两个反向对照(都如注释所述地挂了):把 wasm 套件挪走 → `CONSUMED: driver-sqlite-wasm does not run FILTER_LOGIC_CASES`;套件在但把条目加回去 → `RECONCILED: driver-mongodb now runs FILTER_LOGIC_CASES …, but the ledger still carries a DEBT entry for it. Delete the entry.`。`--self-test` 也是绿的。

**CI 上要看的一点:** 本地 mongod 拉不到,`mongodb-filter-logic-conformance.test.ts` 是 skip 的 —— 请在本 PR 的 CI 上确认它真的跑了(18 条,而不是 18 skipped)。

## 顺带

`packages/spec` 里 `filter-logic-conformance.ts` 的头注释和 `data/index.ts` 的导出注释原来写「four backends」,现在写五个并点名第五个 —— 纯注释,没有 schema、导出或生成物变化(`check:generated` 全绿佐证)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012C2cd7tL8QDoZ2QKN3djJ5)_