### PR TITLE
fix(docs): the schema-extension FAQ rotted in reverse — pin the claim in the checked block this time

### DIFF
--- a/.changeset/docs-extend-faq-reversed-rot.md
+++ b/.changeset/docs-extend-faq-reversed-rot.md
@@ -1,0 +1,27 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(docs): the schema-extension FAQ rotted in reverse — `.extend()` works on `FieldSchema` again since protocol 17
+
+The #3890 fix taught that `FieldSchema` / `ObjectSchema` / `ActionSchema` are all
+`ZodPipe`s and that `FieldSchema.extend` throws. True when written; protocol 17
+(#3855) then retired the deprecated aliases whose lowering was the whole reason
+for the field/object transforms, the pipes collapsed to plain `ZodObject`s, and
+both prose claims inverted within days: `.extend` works, and the recommended
+`FieldSchema.in` is now `undefined` — following the FAQ was once again the only
+way to hit an error. Only `ActionSchema` (whose `requiresFeature` → `visible`
+lowering is still live) remains a pipe.
+
+The example gate never noticed because the checked block used only `.parse()` —
+deliberately shape-agnostic after CI rejected the first #3890 attempt. That made
+the code durable and left the PROSE as the only load-bearing surface, which is
+where the rot settled.
+
+So the rewrite moves the claim into the checked block: it now calls
+`FieldSchema.extend({ … })` directly, so if the schema ever grows a transform
+again the gate goes red instead of the prose going quietly wrong. Composition
+stays as the shape-agnostic default, `ActionSchema` is documented as the pipe
+case with the `.in.extend` caveat, and the FAQ teaches the one-line probe
+(`typeof SomeSchema.extend === 'function'`) instead of a table of shapes that
+history says will not stay true.

--- a/content/docs/deployment/troubleshooting.mdx
+++ b/content/docs/deployment/troubleshooting.mdx
@@ -364,34 +364,44 @@ Yes. All schemas work with plain JavaScript. You lose compile-time type checking
 
 ### How do I extend a built-in schema?
 
-**Not with `.extend()` on the schema itself.** Several built-in schemas —
-`FieldSchema`, `ObjectSchema`, `ActionSchema` — carry a `.transform()` that lowers
-author-facing sugar at parse time, which makes the exported value a **`ZodPipe`,
-not a `ZodObject`**. `FieldSchema.extend` is `undefined`, so calling it throws
-`is not a function`.
-
-Compose instead: parse with the built-in schema, and validate your additions
-alongside it. This keeps the transform running, which `.extend()` would discard.
+It depends on whether the schema you are extending carries a parse-time
+`.transform()`. A plain schema (`FieldSchema`, `ObjectSchema` since protocol 17
+retired their alias-lowering transforms, #3855) is a `ZodObject` and takes
+`.extend()` directly. The composition form works in **either** case, and is the
+safe default when you don't want to track which is which:
 
 {/* os:check */}
 ```typescript
 import { z } from 'zod';
 import { FieldSchema } from '@objectstack/spec/data';
 
-const CustomProps = z.object({ customProperty: z.string().optional() });
+// Plain object schema: .extend() works directly. (This line is what pins the
+// claim — if FieldSchema ever grows a transform again and becomes a ZodPipe,
+// .extend vanishes and this example fails CI instead of the prose going stale.)
+const CustomFieldSchema = FieldSchema.extend({
+  customProperty: z.string().optional(),
+});
+CustomFieldSchema.parse({ name: 'code', type: 'text', customProperty: 'x' });
 
+// Composition: parse with the built-in schema, validate additions alongside.
+// Shape-agnostic — works for plain schemas AND transform-carrying pipes.
+const CustomProps = z.object({ customProperty: z.string().optional() });
 function parseCustomField(input: unknown) {
   return { ...FieldSchema.parse(input), ...CustomProps.parse(input) };
 }
-
 parseCustomField({ name: 'code', type: 'text', customProperty: 'x' });
 ```
 
-If you genuinely need one merged schema object, `FieldSchema.in` is the
-`ZodObject` the pipe wraps, so `FieldSchema.in.extend({ … })` builds one — but
-the result **skips the transform**, so author-facing sugar the pipe would have
-lowered stays raw. Prefer the composition above unless you specifically want the
-untransformed shape.
+A schema that still lowers author-facing sugar at parse time — `ActionSchema`
+(its `requiresFeature` → `visible` lowering) is one, as of protocol 17 — is a
+**`ZodPipe`**, where `.extend` does not exist: prefer the composition form.
+Reaching the inner object via `.in.extend({ … })` builds a merged schema but
+**skips the transform**, so the sugar the pipe would have lowered stays raw.
+
+A quick check when unsure: `typeof SomeSchema.extend === 'function'` — a pipe
+reports `undefined`. This page once asserted the shapes the other way around;
+the schemas moved under it within days (#3890 → #3855), which is why the
+load-bearing claim above now lives in a CI-checked block rather than prose.
 
 ### Where are the JSON Schemas for IDE autocomplete?
 


### PR DESCRIPTION
Re-audit of the open items from the #3714 → #3890 thread against current `main`. Most resolved themselves — the #3896 close-out removed the remaining tool/flow/view dead keys, `verifiedAt` adoption went from 3 to 224 dated entries, and the FieldSchema declaration/runtime divergence dissolved outright. One item **inverted into new rot**, and it's mine.

## The reversal

#3890 fixed a FAQ that recommended `FieldSchema.extend()` when `FieldSchema` was a `ZodPipe` (`.extend` was `undefined`). The fix taught: all three schemas are pipes, `.extend` throws, use `.in` for the inner object.

**Every one of those claims is now false on `main`.** Protocol 17 (#3855, `acbf364a0`) retired the deprecated aliases whose lowering was the whole reason for the field/object transforms — no aliases, no transform, and the pipes collapsed to plain `ZodObject`s. Verified against a clean build:

```
FieldSchema   bound ZodObject  .extend: function   .in: undefined
ObjectSchema  bound ZodObject  .extend: function   .in: undefined
ActionSchema  bound ZodPipe    .extend: undefined  .in: ZodObject
```

So the FAQ's `.extend` warning was wrong again, and its recommended `FieldSchema.in` was now the call that throws. The doc rotted **in reverse, within days** — the same "a claim with a timestamp, code moves under it in both directions" failure this whole thread has been unwinding, this time against my own fix.

## Why the gate didn't catch it

#3890's checked block deliberately used only `.parse()` — shape-agnostic, after CI rejected the `.in.extend` attempt (the DTS/runtime divergence, since dissolved). That made the *code* durable and left the **prose** as the only load-bearing surface. Prose is exactly where rot settles: the gate compiles code, not claims.

## The fix — move the claim into the checked block

The rewritten FAQ's checked example now calls `FieldSchema.extend({ … })` **directly**. If the schema ever grows a transform again, `.extend` vanishes and **CI goes red** — the tripwire the prose could never be. Alongside it:

- composition (`FieldSchema.parse` + validate additions) stays as the shape-agnostic default;
- `ActionSchema` is documented as the pipe case (its `requiresFeature` → `visible` lowering is still live per the ledger), with the `.in.extend` skips-the-transform caveat;
- the FAQ teaches the one-line probe — `typeof SomeSchema.extend === 'function'` — instead of a table of shapes that history says will not stay true, and says openly that this page got it wrong twice.

## Verification

- `pnpm --filter @objectstack/spec check:skill-examples` — `✅ 202 prose examples type-check` (includes the new direct-`.extend` block).
- Runtime: `FieldSchema.extend(...).parse(...)` executes and returns the extended key; `ActionSchema` confirmed `ZodPipe` / `.extend` `undefined` / `.in` `ZodObject` — every claim in the rewritten FAQ was executed, not just type-checked.
- `pnpm check:doc-authoring` — 215 files clean.

## Re-audit summary (the rest of the old list)

| Item | Status on current main |
|---|---|
| tool dead props (`category`/`permissions`/`active`/`builtIn`) | removed by the #3896 close-out — done |
| `verifiedAt` backfill | 224 dated (was 3) — actively adopted, no push needed |
| FieldSchema DTS/runtime divergence | dissolved by #3855 (schema genuinely a `ZodObject` now) |
| docs-drift bot symbol-level matching | still package-name heuristic (`affected-docs.mjs`) — worth an issue, not a drive-by |
| `form-widget-resolution` proof | still the one proofless high-risk class |
| example-harness `paths` beyond `@objectstack/spec` | still spec-only |
| `undoable` in-browser dogfood | still open; evidence pinned at `objectui @732b1bf`, `verifiedAt` within window |


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ajwvrmd1hDC9RBofYBhGuR)_