### PR TITLE
docs(changeset): C5 收敛的 changeset 补上与 #4664 `placement` 的区分说明 (#4653)

### DIFF
--- a/.changeset/converge-activation-event-schema.md
+++ b/.changeset/converge-activation-event-schema.md
@@ -70,6 +70,20 @@ enum 取**两侧 v17 前词表的并集**,共 9 个值:
 
 手工迁移步骤:按上表把每个字符串改写成 `{ type, pattern }`。**漏改会在 parse 处响亮失败** —— `StudioPluginManifestSchema` 是 `strictObject`,字符串遇到对象 schema 直接抛错,不存在静默吞掉或强制转换。
 
+## 不要与同窗口的 #4509 / #4664 退休项混淆
+
+v17 同窗口的 #4664 退休了五个键。其中 **`app.contextSelectors[].placement`** 与本条变更**毫无关系**,但很容易被读成有关系 —— 那条退休说明里写着「`location` 曾是 `placement` 的别名」,而 Studio 插件的面板贡献点**恰好也有一个 `location` 键**:
+
+| | 被 #4664 退休的 | 本次变更**未动**的 |
+|:--|:--|:--|
+| 键 | `ui/App.contextSelectors[].placement`(`location` 是它的别名) | `studio/PanelContribution.location` |
+| 语义 | app 的上下文选择器渲染在哪(`sidebar_header` / `topbar`) | Studio 插件的辅助面板停靠在哪(`bottom` / `right` / `modal`) |
+| 状态 | 已删除 | **原样保留**,仍是可作者化键 |
+
+两者在不同 schema 上、取值域不同、互不相关。写 Studio 插件的作者**不需要**因为 #4664 去动 `contributes.panels[].location`。
+
+其余四个退休键(`mapping.extractQuery` / `mapping.errorPolicy` / `mapping.batchSize` / `app.contextSelectors[].includeAll`)与 `activationEvents` 无任何语义交叉;同窗口的 #4668(ADR-0119 D2 migration journal)亦然。
+
 ## 其它影响
 
 - `@objectstack/spec/studio` 现在**额外导出** `ActivationEvent` 类型(此前只有 schema),与 `./kernel` 指向同一份声明。


### PR DESCRIPTION
跟进 #4653 / PR #4662(已合并为 `65ca83a58`)。**Changeset-only,零代码改动。**

## 为什么有这个 PR

协调者要求在 changeset 里交代「#4664 退的五个 key 与 `activationEvents` 是否有语义交叉」(参照 C8 对 `mapping.errorPolicy` 的处理)。我查出了一个**确实容易被误读**的near-miss 并写好了说明,但那次编辑还处于**未提交**状态时 PR #4662 就被合并、worktree 随即被清理,这段文字因此没能随 #4662 落地。补上。

## 补的是什么

同窗口的 #4664 退休了 `app.contextSelectors[].placement`,其退休说明里写着「`location` 曾是 `placement` 的别名」。而 Studio 插件的面板贡献点**恰好也有一个 `location` 键**:

| | 被 #4664 退休的 | C5 未动的 |
|:--|:--|:--|
| 键 | `ui/App.contextSelectors[].placement`(别名 `location`) | `studio/PanelContribution.location` |
| 语义 | app 上下文选择器渲染在哪(`sidebar_header` / `topbar`) | Studio 插件辅助面板停靠在哪(`bottom` / `right` / `modal`) |
| 状态 | 已删除 | **原样保留**,仍是可作者化键 |

对着 v17 release notes 逐条读的插件作者很容易把两件事连起来,以为 `contributes.panels[].location` 也要跟着改 —— 实际不需要。changeset 主动挡掉这个误解。

同时记下:另外四个退休键(`mapping.extractQuery` / `mapping.errorPolicy` / `mapping.batchSize` / `app.contextSelectors[].includeAll`)以及 #4668(ADR-0119 D2 migration journal)与 `activationEvents` **均无语义交叉**(已逐一核过,#4668 全 diff 对 `ActivationEvent` / `activationEvents` 零命中)。

## 时效

`.changeset/pre.json` 仍是 `mode: pre` / `tag: rc`,`converge-activation-event-schema.md` 尚未被消费,所以这段文字仍能进入 v17 release notes。`changeset pre exit` 之后就来不及了。

## 顺带汇报:main 上 C5 的落地状态已复核,健康

PR #4662 经合并队列 rebase 后落在 main 为 `65ca83a58`(SHA 与我推的 `52a5de34a` 不同,内容一致)。队列替我解了 `authorable-surface.json` / `api-surface.json` 两个生成物的冲突 —— 我在 main 上重新验了一遍:

- **字节级 round-trip**:`build` → `gen:schema` → `gen:api-surface` 后 `git diff` **空**,即 main 上这两个生成物**确实是生成器的输出**,队列的自动解决没有产生漂移(这正是我在 #4663 里建议的那条检查)。
- **三方内容都在**:我的 `studio/ActivationEvent:pattern` / `:type` 在;#4664 退的五个键正确缺席;#4668 的 `system/Migration*` 键在。总计 8260 个 key。
- `check:dual-source-exports` → `21 accepted dual-source`,基线文件 21 行。
- 两个被 pin 的测试文件 58/58 绿。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9uWvoEp9CoLzYjNExj9sL

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9uWvoEp9CoLzYjNExj9sL)_