### PR TITLE
fix(runtime): carry the capability channel onto AI-route req.user (#4705)

### DIFF
--- a/.changeset/ai-route-user-system-permissions.md
+++ b/.changeset/ai-route-user-system-permissions.md
@@ -1,0 +1,43 @@
+---
+"@objectstack/runtime": patch
+---
+
+fix(runtime): carry the capability channel onto an AI route's `req.user` (#4705)
+
+`/ai/*` was the one route domain in the platform where a capability check could
+not be written. The dispatcher builds `req.user` from the request's
+ExecutionContext, and `resolveAuthzContext` resolves a caller into **two** lists
+that look alike and are not:
+
+| ExecutionContext field | Carries |
+|---|---|
+| `permissions` | permission-**set names** (`admin_full_access`, `organization_admin`, `member_default`) plus the synthesized `ai_seat` |
+| `systemPermissions` | **capabilities** — `manage_metadata`, `studio.access`, `setup.access`, … — the union of every resolved set's `systemPermissions[]` |
+
+Only the first was copied. Every other surface gates on the second
+(`domains/meta.ts`'s `manage_metadata` check, `action-execution.ts`,
+`rest-server.ts`), so the same test written against an AI route's
+`req.user.permissions` was **permanently false** — a gate built on it would not
+have tightened the route, it would have closed it on platform admins too. That
+is what blocked the capability gate on
+`POST /api/v1/ai/tools/:toolName/execute`, where any authenticated user can
+currently run any registered tool (`create_object`, `apply_blueprint`,
+`create_seed`) in the default configuration.
+
+`req.user` now carries `systemPermissions` alongside `permissions`, with the
+same fail-closed default the neighbouring fields use: a non-array — or an
+ExecutionContext that has none, since the field is optional — becomes `[]`,
+never `undefined`. The two channels are copied **side by side and never merged**:
+flattening either into the other would corrupt every existing reader of
+`permissions` while appearing to fix this.
+
+This is transport only. No route in this package gates on the new field, and the
+declared-but-unenforced `route.permissions` mechanism is untouched — consumers
+decide policy, on the platform's existing `systemPermissions` contract.
+
+The other producer of an AI-route `req.user` — `dispatcher-plugin`'s
+`resolveRequestUser`, backing the concrete per-route mounts — has no
+ExecutionContext to read and stays capability-less on purpose. It now says so in
+the same shape (`systemPermissions: []`, spelled out rather than omitted) so a
+consumer never sees `undefined` on one path and `[]` on the other, and so needs
+no fallback of its own to tell them apart.

--- a/packages/runtime/src/dispatcher-plugin.ts
+++ b/packages/runtime/src/dispatcher-plugin.ts
@@ -1164,6 +1164,25 @@ export function createDispatcherPlugin(config: DispatcherPluginConfig = {}): Plu
                     // populated from the ExecutionContext by the /ai/* dispatch path
                     // (http-dispatcher → resolveExecutionContext, the single scope-correct
                     // source). This concrete-route resolver returns an empty set.
+                    //
+                    // [#4705] `systemPermissions` — the CAPABILITY channel
+                    // (`manage_metadata`, `studio.access`, …) that domains/ai.ts
+                    // now carries across from the ExecutionContext — is spelled
+                    // out here as an empty array for the same reason
+                    // `permissions` is: this resolver has no ExecutionContext to
+                    // read, and inventing a capability source for it would hand
+                    // out authority the platform never granted. Written
+                    // explicitly rather than omitted so the two producers of an
+                    // AI-route `req.user` agree on the SHAPE: a consumer sees
+                    // "holds no capabilities", never `undefined`, so it never
+                    // needs a `?? []` of its own to tell the two apart.
+                    //
+                    // Reachability, for the record: these concrete mounts are
+                    // shadowed in practice — `registerAIRoutes` mounts the
+                    // `${prefix}/ai/*` method-wildcards through
+                    // `dispatcher.dispatch()` EARLIER in this same `start()`, so
+                    // the ExecutionContext-backed path is the one that answers a
+                    // real `/api/v1/ai/...` request.
                     return {
                         userId,
                         id: userId,
@@ -1171,6 +1190,7 @@ export function createDispatcherPlugin(config: DispatcherPluginConfig = {}): Plu
                         email: sessionData?.user?.email,
                         positions: [],
                         permissions: [],
+                        systemPermissions: [],
                         organizationId: sessionData?.session?.activeOrganizationId,
                     };
                 } catch {

--- a/packages/runtime/src/domains/ai-request-user-capability-channel.test.ts
+++ b/packages/runtime/src/domains/ai-request-user-capability-channel.test.ts
@@ -1,0 +1,261 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #4705 — the AI routes' `req.user` must carry the CAPABILITY channel, and it
+ * must stay a channel of its own.
+ *
+ * `resolveAuthzContext` resolves a caller into two lists that look alike and
+ * are not (core/src/security/resolve-authz-context.ts):
+ *
+ *   - `permissions`       — permission-SET NAMES (`admin_full_access`,
+ *                           `organization_admin`, `member_default`) plus the
+ *                           synthesized `ai_seat`.
+ *   - `systemPermissions` — CAPABILITIES (`manage_metadata`, `studio.access`,
+ *                           `setup.access`, …), the union of every resolved
+ *                           set's `systemPermissions[]`.
+ *
+ * `resolveExecutionContext` surfaces both, side by side. `domains/ai.ts` copied
+ * only the first onto `req.user`, which made `/ai/*` the single route domain in
+ * the repo where a capability gate could not be written: every other surface
+ * tests `systemPermissions` (`domains/meta.ts`'s `manage_metadata` gate,
+ * `action-execution.ts`, `rest/src/rest-server.ts`), so the same test written
+ * against an AI route's `req.user.permissions` is permanently false — which
+ * shuts the route on platform admins instead of tightening it. That is the
+ * blocker cloud#1015 hit when it went to gate
+ * `POST /api/v1/ai/tools/:toolName/execute`.
+ *
+ * These tests pin the transport, not a policy: no route in this repo gates on
+ * the field. Three things must hold, and the third is why the first two are not
+ * enough on their own —
+ *
+ *   1. a capability held on the ExecutionContext ARRIVES on
+ *      `req.user.systemPermissions`;
+ *   2. a caller holding none gets `[]`, never `undefined` (fail-closed, and it
+ *      spares every consumer a `?? []` of its own);
+ *   3. `permissions` still carries set names + `ai_seat` VERBATIM — the two
+ *      channels are copied side by side, never merged. Flattening one into the
+ *      other would corrupt every existing reader of `permissions` while looking
+ *      like it fixed this.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { handleAIRequest } from './ai.js';
+import { createDispatcherPlugin } from '../dispatcher-plugin.js';
+import type { DomainHandlerDeps } from '../domain-handler-registry.js';
+import type { HttpProtocolContext } from '../http-dispatcher.js';
+
+const TOOL_ROUTE = '/api/v1/ai/tools/:toolName/execute';
+
+/** Captures the `req` the AI route handler is dispatched with. */
+function makeDeps(seen: { req?: any }): DomainHandlerDeps {
+    const aiService: any = { chat: async () => ({ text: 'ok' }) };
+    return {
+        resolveService: (async (name: string) => (name === 'ai' ? aiService : undefined)) as any,
+        getRegisteredAiRoutes: () => [
+            {
+                method: 'POST',
+                path: TOOL_ROUTE,
+                auth: true,
+                handler: async (req: any) => {
+                    seen.req = req;
+                    return { status: 200, body: { success: true, data: { ok: true } } };
+                },
+            },
+        ],
+        success: (data: any) => ({ status: 200, body: { success: true, data } }),
+        error: (message: string, httpStatus = 500) => ({ status: httpStatus, body: { success: false, error: { message } } }),
+        routeNotFound: (route: string) => ({ status: 404, body: { success: false, error: { code: 'ROUTE_NOT_FOUND', route } } }),
+    } as unknown as DomainHandlerDeps;
+}
+
+/** Dispatch `POST /ai/tools/create_object/execute` under `executionContext`. */
+async function dispatchToolExecute(executionContext: any) {
+    const seen: { req?: any } = {};
+    const context = { executionContext } as unknown as HttpProtocolContext;
+    const result = await handleAIRequest(
+        makeDeps(seen),
+        '/ai/tools/create_object/execute',
+        'POST',
+        {},
+        {},
+        context,
+    );
+    return { result, user: seen.req?.user, req: seen.req };
+}
+
+describe('#4705 — /ai/* req.user carries the capability channel', () => {
+    it('surfaces ec.systemPermissions on req.user.systemPermissions', async () => {
+        // A platform admin as `resolveAuthzContext` actually resolves one: the
+        // set NAME in `permissions`, the capabilities it grants in
+        // `systemPermissions` (plugin-security's `admin_full_access` declares
+        // `manage_metadata` / `studio.access` / `setup.access` there).
+        const { user, result } = await dispatchToolExecute({
+            userId: 'usr_admin',
+            userEmail: 'admin@objectos.ai',
+            positions: ['platform_admin'],
+            permissions: ['admin_full_access', 'ai_seat'],
+            systemPermissions: ['manage_users', 'manage_metadata', 'studio.access', 'setup.access'],
+            tenantId: 'org_1',
+        });
+
+        expect(result.handled).toBe(true);
+        // The whole point of the issue: a capability gate on an AI route can
+        // now be written and can actually pass for someone who holds it.
+        expect(user.systemPermissions).toEqual([
+            'manage_users', 'manage_metadata', 'studio.access', 'setup.access',
+        ]);
+        expect(new Set<string>(user.systemPermissions).has('manage_metadata')).toBe(true);
+    });
+
+    it('keeps `permissions` = permission-set names + ai_seat, unmerged with capabilities', async () => {
+        const { user } = await dispatchToolExecute({
+            userId: 'usr_admin',
+            permissions: ['admin_full_access', 'ai_seat'],
+            systemPermissions: ['manage_metadata', 'studio.access'],
+            positions: ['platform_admin'],
+        });
+
+        // Verbatim — the set-name channel is untouched by the addition, and
+        // `ai_seat` (synthesized by resolveExecutionContext) still rides it.
+        expect(user.permissions).toEqual(['admin_full_access', 'ai_seat']);
+        expect(user.roles).toEqual(['platform_admin']);
+        // …and neither list has absorbed the other. A capability must NOT be
+        // readable off `permissions`, nor a set name off `systemPermissions`:
+        // that conflation is the failure mode this issue exists to prevent.
+        expect(user.permissions).not.toContain('manage_metadata');
+        expect(user.systemPermissions).not.toContain('admin_full_access');
+        expect(user.systemPermissions).not.toContain('ai_seat');
+    });
+
+    it('gives a caller with no capabilities [] — not undefined', async () => {
+        // An ordinary member: holds an AI seat, holds no capability. The
+        // ExecutionContext omits the field entirely (it is optional on
+        // `ExecutionContextSchema`), which is the shape a consumer would
+        // otherwise have to tolerate with a `?? []` of its own.
+        const { user } = await dispatchToolExecute({
+            userId: 'usr_member',
+            permissions: ['member_default', 'ai_seat'],
+            positions: ['member'],
+        });
+
+        expect(user.systemPermissions).toEqual([]);
+        expect(user.systemPermissions).not.toBeUndefined();
+        expect(new Set<string>(user.systemPermissions).has('manage_metadata')).toBe(false);
+    });
+
+    it('fails closed when ec.systemPermissions is not an array', async () => {
+        const { user } = await dispatchToolExecute({
+            userId: 'usr_member',
+            permissions: ['member_default'],
+            // A malformed/stringified value must never become authority.
+            systemPermissions: 'manage_metadata',
+        });
+
+        expect(user.systemPermissions).toEqual([]);
+    });
+});
+
+// ── The OTHER producer of an AI-route `req.user` ────────────────────────────
+// `dispatcher-plugin`'s `resolveRequestUser` backs the concrete per-route
+// mounts. It has no ExecutionContext to read, so it stays capability-less on
+// purpose — but it must say so in the SAME shape, otherwise a consumer sees
+// `undefined` on one path and `[]` on the other and reaches for a fallback to
+// paper over the difference.
+
+function makeFakeServer() {
+    const routes: string[] = [];
+    const handlers: Record<string, (req: any, res: any) => any> = {};
+    const rec = (verb: string) => (path: string, handler: any) => {
+        routes.push(`${verb} ${path}`);
+        handlers[`${verb} ${path}`] = handler;
+    };
+    return {
+        routes,
+        handlers,
+        server: {
+            get: rec('GET'), post: rec('POST'), put: rec('PUT'),
+            delete: rec('DELETE'), patch: rec('PATCH'),
+        },
+    };
+}
+
+function makeCtx(fakeServer: any, aiRoutes: any[], onRequest: (req: any) => void) {
+    const kernel: any = {
+        getService: () => undefined,
+        getServiceAsync: async () => undefined,
+        // The AIServicePlugin's cross-plugin cache the dispatcher recovers
+        // routes from when the `ai:routes` hook fired before it was listening.
+        __aiRoutes: aiRoutes.map((r) => ({
+            ...r,
+            handler: async (req: any) => { onRequest(req); return { status: 200, body: { ok: true } }; },
+        })),
+    };
+    const authService: any = {
+        api: {
+            getSession: async () => ({
+                user: { id: 'usr_admin', name: 'Admin', email: 'admin@objectos.ai' },
+                session: { activeOrganizationId: 'org_1' },
+            }),
+        },
+    };
+    return {
+        getKernel: () => kernel,
+        getService: (name: string) =>
+            name === 'http.server' ? fakeServer : name === 'auth' ? authService : undefined,
+        environmentId: undefined,
+        logger: { info() {}, warn() {}, error() {}, debug() {} },
+        hook: () => {},
+        on: () => {},
+    } as any;
+}
+
+describe('#4705 — the concrete-mount producer agrees on the shape', () => {
+    it('resolveRequestUser emits systemPermissions: [] (fail-closed, never undefined)', async () => {
+        const { server, handlers } = makeFakeServer();
+        let seen: any;
+        const ctx = makeCtx(
+            server,
+            [{ method: 'POST', path: '/ai/tools/:toolName/execute', description: 'x', auth: true }],
+            (req) => { seen = req; },
+        );
+        const plugin = createDispatcherPlugin({ prefix: '/api/v1', securityHeaders: false });
+        await plugin.start?.(ctx);
+
+        const handler = handlers[`POST ${TOOL_ROUTE}`];
+        expect(handler).toBeTypeOf('function');
+        const res = { status() { return res; }, header() { return res; }, json() { return res; } } as any;
+        await handler({ headers: {}, body: {}, params: { toolName: 'create_object' }, query: {} }, res);
+
+        expect(seen.user.userId).toBe('usr_admin');
+        // No ExecutionContext here → no authority, stated explicitly. Same
+        // shape as the dispatch path, so a consumer needs no `?? []`.
+        expect(seen.user.permissions).toEqual([]);
+        expect(seen.user.systemPermissions).toEqual([]);
+    });
+
+    it('mounts the /ai/* dispatch wildcard BEFORE the concrete AI routes', async () => {
+        // Why the capability-less resolver above is not the live path: the
+        // method-wildcards `registerAIRoutes` mounts go through
+        // `dispatcher.dispatch()` → `domains/ai.ts`, i.e. the
+        // ExecutionContext-backed `req.user`. They are registered earlier in
+        // `start()`, so they answer a real `/api/v1/ai/...` request first.
+        // Reordering these two would silently hand `/ai/*` back to the
+        // capability-less producer — and a gate built on cloud#1015's contract
+        // would start 403-ing platform admins again.
+        const { server, routes } = makeFakeServer();
+        const ctx = makeCtx(
+            server,
+            [{ method: 'POST', path: '/ai/tools/:toolName/execute', description: 'x', auth: true }],
+            () => {},
+        );
+        const plugin = createDispatcherPlugin({ prefix: '/api/v1', securityHeaders: false });
+        await plugin.start?.(ctx);
+
+        const wildcard = routes.indexOf('POST /api/v1/ai/*');
+        const concrete = routes.indexOf(`POST ${TOOL_ROUTE}`);
+        expect(wildcard).toBeGreaterThanOrEqual(0);
+        expect(concrete).toBeGreaterThanOrEqual(0);
+        expect(wildcard).toBeLessThan(concrete);
+    });
+});

--- a/packages/runtime/src/domains/ai.ts
+++ b/packages/runtime/src/domains/ai.ts
@@ -142,6 +142,35 @@ export async function handleAIRequest(deps: DomainHandlerDeps, subPath: string, 
         // `ai_seat` is synthesized into ec.permissions by resolveExecutionContext
         // (the single, scope-correct source — security/resolve-execution-context.ts),
         // so it flows through here with no extra per-request lookup.
+        //
+        // [#4705] `permissions` and `systemPermissions` are TWO channels, and
+        // both have to cross this seam — they are not interchangeable and must
+        // never be flattened into one another:
+        //
+        //   - `ec.permissions`       → permission-SET NAMES (`admin_full_access`,
+        //                              `organization_admin`, `member_default`) plus
+        //                              the synthesized `ai_seat`.
+        //                              (core/src/security/resolve-authz-context.ts,
+        //                              `grants.permissions.push(ps.name)`)
+        //   - `ec.systemPermissions` → CAPABILITIES (`manage_metadata`,
+        //                              `studio.access`, `setup.access`, …), the
+        //                              union of every resolved permission set's
+        //                              `systemPermissions[]`. (same file, the
+        //                              `grants.systemPermissions.push(p)` loop)
+        //
+        // Only the first used to be copied, which made `/ai/*` the one route
+        // domain in the repo where a capability check was impossible: every
+        // other surface reads `systemPermissions` (domains/meta.ts, the
+        // `manage_metadata` gate; action-execution.ts; rest-server.ts), so a
+        // capability test written against `req.user.permissions` is
+        // permanently false — closing the route on platform admins too rather
+        // than tightening it. Copying the channel through is transport only:
+        // no route in THIS repo gates on it; the consumer decides.
+        //
+        // Fail-closed default, same as `roles`/`permissions`: a non-array (or
+        // absent — `ExecutionContext.systemPermissions` is optional) becomes
+        // `[]`, never `undefined`, so a consumer reads "holds nothing" instead
+        // of having to tolerate a missing field.
         const user = ec?.userId
             ? {
                 userId: ec.userId,
@@ -150,6 +179,7 @@ export async function handleAIRequest(deps: DomainHandlerDeps, subPath: string, 
                 email: ec.userEmail,
                 roles: Array.isArray(ec.positions) ? ec.positions : [],
                 permissions: Array.isArray(ec.permissions) ? ec.permissions : [],
+                systemPermissions: Array.isArray(ec.systemPermissions) ? ec.systemPermissions : [],
                 organizationId: ec.tenantId,
             }
             : undefined;


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4705

## 问题

`packages/runtime/src/domains/ai.ts` 的 `handleAIRequest()` 从 ExecutionContext 构造 `req.user` 时，只拷了**权限集名**通道，没拷 **capability** 通道。这两类东西在平台上是两个字段，形状像但语义完全不同：

| ExecutionContext 字段 | 承载内容 | 来源 |
|---|---|---|
| `permissions` | 权限**集名**（`admin_full_access` / `organization_admin` / `member_default`）+ 合成的 `ai_seat` | `core/src/security/resolve-authz-context.ts` 的 `grants.permissions.push(ps.name)` |
| `systemPermissions` | **capability**（`manage_metadata`、`studio.access`、`setup.access` …），即用户所有已解析权限集 `systemPermissions[]` 的并集 | 同文件的 `grants.systemPermissions.push(p)` 循环 |

结果是 **`/ai/*` 成了全仓唯一无法做 capability gate 的路由域**：平台其他每一处 capability 判断读的都是 `systemPermissions`（`domains/meta.ts` 的 `manage_metadata` 门禁、`action-execution.ts`、`rest/src/rest-server.ts`），而 AI 路由的 handler 只拿得到集名，所以任何写在 `req.user.permissions` 上的 capability 判断**恒为 false**——那不是「收紧」，是把路由对所有人（含平台管理员）关死。这正是 objectstack-ai/cloud#1015 想给 `POST /api/v1/ai/tools/:toolName/execute` 加门禁时撞上的阻塞项（该路由在默认配置下允许任何登录用户执行任意已注册工具，含 `create_object` / `apply_blueprint` / `create_seed`）。

## 改动

**只做透传，不含任何策略。** 本仓没有任何路由因此开始判 capability，`route.permissions` 那套（声明了从不执行）一行未动。

1. `domains/ai.ts` — `req.user` 增加 `systemPermissions`，与 `roles` / `permissions` 完全同款的 fail-closed 缺省：非数组（或 ExecutionContext 上根本没有该字段——它在 `ExecutionContextSchema` 上是 optional）一律变成 `[]`，绝不是 `undefined`。

   ```ts
   systemPermissions: Array.isArray(ec.systemPermissions) ? ec.systemPermissions : [],
   ```

   两条通道**并排拷贝、绝不合并**。把任一条压进另一条会在「看起来修好了」的同时污染 `permissions` 的每一个既有消费者。

2. `dispatcher-plugin.ts` 的 `resolveRequestUser`（另一条挂载路径，服务于逐路由的具体挂载）——它没有 ExecutionContext 可取，**继续保持 fail-closed，没有为它编造任何 capability 来源**。这里只是把 `systemPermissions: []` **显式写出来**而不是省略，让 AI 路由 `req.user` 的两个生产者在**形状**上一致：消费者看到的永远是「不持有任何 capability」，而不是一边 `[]` 一边 `undefined`——否则消费者迟早要自己写个 `?? []` 去抹平两者，那正是 Prime Directive #12 要避免的宽容 fallback。

### 关于「这个字段在真实请求里到底有没有值」

issue 里最该被证伪的一点，先说结论：**有**。

- `/api/v1/ai/*` 的真实请求走的是 `dispatcher-plugin` 里 `registerAIRoutes` 挂的 method-wildcard，经 `dispatcher.dispatch()` → `domains/ai.ts`，而 `dispatch()` 在此之前已经通过 `timedResolveExecutionContext` → `resolveExecutionContext` 填好了 `context.executionContext`；后者在 `security/resolve-execution-context.ts` 把 `authz.permissions` 与 `authz.systemPermissions` 两个字段**并列**挂上。
- 这些 wildcard 在同一个 `start()` 里**先于** `mountAiRoute` 的具体路由注册，所以答请求的是带 ExecutionContext 的那条路径。这一点已被测试钉住（见下），避免将来有人调换注册顺序、把 `/ai/*` 悄悄交还给没有 capability 的那个生产者。
- capability 确实到得了平台管理员手上：`plugin-security` 的 `admin_full_access` 在 `systemPermissions` 里声明了 `manage_metadata` / `studio.access` / `setup.access`，经 `resolve-authz-context.ts` 汇聚进 `grants.systemPermissions`。所以 cloud#1015 的门禁按平台既有契约判时，管理员会通过而不是被 403。

## 测试

新增 `packages/runtime/src/domains/ai-request-user-capability-channel.test.ts`，6 个用例：

- ExecutionContext 上持有的 capability **到达** `req.user.systemPermissions`；
- `permissions` 仍**逐字**是集名 + `ai_seat`，`roles` 仍是 positions——并断言两条通道互不含有对方的元素（capability 读不到 `permissions` 上，集名 / `ai_seat` 也读不到 `systemPermissions` 上）；
- 不持有任何 capability 的调用方拿到 `[]`，不是 `undefined`；
- `ec.systemPermissions` 是畸形值（如字符串）时同样 fail-closed 成 `[]`；
- `resolveRequestUser` 这条路径同样给出 `systemPermissions: []`；
- `/ai/*` wildcard 先于具体 AI 路由挂载（上面那条可达性论证的回归钉子）。

**没有本 PR 的改动时，这个测试文件 6 个用例里会挂 5 个**（唯一通过的是挂载顺序那条，它本就不依赖本改动）。实测输出：

```
AssertionError: expected undefined to deeply equal []
 ❯ src/domains/ai-request-user-capability-channel.test.ts:155:40
Test Files  1 failed (1)
     Tests  5 failed | 1 passed (6)
```

加上改动后的完整门禁（均在本地实跑）：

```
pnpm --filter @objectstack/runtime exec vitest run --maxWorkers=2
  Test Files  80 passed (80)
       Tests  1092 passed (1092)

npx turbo run typecheck --filter=@objectstack/runtime... --concurrency=2
  Tasks:    44 successful, 44 total

npx eslint packages/runtime/src/domains/ai.ts packages/runtime/src/dispatcher-plugin.ts \
           packages/runtime/src/domains/ai-request-user-capability-channel.test.ts --no-inline-config
  (无输出，exit 0)

pnpm check:type-check-coverage
  OK — 60/77 workspace packages type-checked …
```

`@objectstack/runtime` 本身在 `#4311` 的 DEBT 账本里没有 `typecheck` 脚本，所以编译层证据取自它的 `build`：tsup 的 DTS 步骤对 src 跑完整 `tsc`，`DTS ⚡️ Build success`。

## 影响面

- 用户可见（AI 路由 handler 的 `req.user` 多了一个字段），已附 changeset `.changeset/ai-route-user-system-permissions.md`。
- 未改 `content/docs/releases/**`。
- 解除 objectstack-ai/cloud#1015 的阻塞：那边的门禁可以照平台既有 `systemPermissions` 契约写，不需要在消费侧做任何宽容处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TYoxKa8yFLiDDh7tkBqtu


---
_Generated by [Claude Code](https://claude.ai/code/session_019TYoxKa8yFLiDDh7tkBqtu)_