### PR TITLE
test(driver-sql): 把 pagination / filter-logic 两条共享矩阵也跑到 driver 轴上 (#4714)

### DIFF
--- a/.changeset/pagination-filter-logic-driver-axis.md
+++ b/.changeset/pagination-filter-logic-driver-axis.md
@@ -1,0 +1,21 @@
+---
+---
+
+Test-only: run the two remaining `@objectstack/spec/data` shared matrices
+`driver-sql` consumes — `PAGINATION_CASES` / `PAGINATION_UNORDERED_CASES` and
+`FILTER_LOGIC_CASES` — across the ADR-0053 D-A3 DRIVER axis (`driver {SQLite,
+Postgres at minimum}`) instead of a hard-coded `better-sqlite3` client (#4714,
+finishing what #4245 started for the temporal matrix). Both files now sweep once
+per cell of `DIALECT_CELLS` — SQLite always, live Postgres and MySQL whenever
+`OS_TEST_POSTGRES_URL` / `OS_TEST_MYSQL_URL` are provisioned — over the same
+cases, asserting the same row-id sets cell for cell, with issue-prefixed table
+names so parallel suites cannot collide on a live server. The paged-read
+property test is the one that gains: on SQLite it passes with or without the
+tie-breaker (a twelve-row table hands ties back in rowid order every time),
+while on live Postgres removing the tie-breaker makes it serve one row twice and
+another never — objectui#3106 verbatim. `declareUnprovisionedCell` moves into
+`live-dialect-matrix.testkit.ts` so all three matrices share one non-vacuity
+guard: a missing URL is a named skip, and a red under
+`OS_EXPECT_LIVE_DIALECT_MATRIX=1`. No new CI job — the existing
+`Temporal Conformance (live PG + MySQL)` workflow already runs this whole
+package against both servers. Releases nothing.

--- a/packages/plugins/driver-sql/src/live-dialect-matrix.testkit.ts
+++ b/packages/plugins/driver-sql/src/live-dialect-matrix.testkit.ts
@@ -42,7 +42,7 @@
  * Test-only: not exported from `index.ts`.
  */
 
-import { expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import type { SqlDriver, SqlDriverConfig } from './sql-driver.js';
 
 /** The dialects `driver-sql` speaks that the matrices are run across. */
@@ -133,6 +133,37 @@ export const DIALECT_CELLS: readonly DialectCell[] = [
 
 /** The live cells only — the ones the server-timezone axis applies to. */
 export const LIVE_DIALECT_CELLS = DIALECT_CELLS.filter((c) => c.live);
+
+/**
+ * Declare a cell nobody provisioned: REPORTED, never omitted.
+ *
+ * A named skip locally (so `it was not run` is readable in the output), a
+ * failure under `OS_EXPECT_LIVE_DIALECT_MATRIX=1` — which is what stops the
+ * `Temporal Conformance (live PG + MySQL)` job from quietly degrading to
+ * SQLite-only coverage if its `env:` block is ever dropped.
+ *
+ * Lives here rather than in each consumer for the same reason `DIALECT_CELLS`
+ * does: a guard copy-pasted per suite is a guard that can weaken in one copy
+ * and nowhere else — and "the matrix silently found zero cells and reported
+ * OK" is the failure #4646 already paid for once.
+ *
+ * @param matrix which matrix this cell belongs to, e.g. `temporal conformance`
+ *   — it names both the suite and the failure message.
+ */
+export function declareUnprovisionedCell(cell: DialectCell, matrix: string): void {
+  describe(`sql-driver — ${matrix} matrix (${cell.label})`, () => {
+    it.skipIf(!EXPECT_LIVE_DIALECTS)(
+      `is provisioned — set ${cell.env} to run this cell of the D-A3 driver axis`,
+      () => {
+        expect.fail(
+          `${cell.env} is unset while OS_EXPECT_LIVE_DIALECT_MATRIX=1: this runner declared it ` +
+            `provisions live Postgres and MySQL, so the ${cell.label} cell of the ${matrix} ` +
+            `matrix must not be skipped (ADR-0053 D-A3 "Postgres at minimum").`,
+        );
+      },
+    );
+  });
+}
 
 /** What a server reports about its own timezone. */
 export interface ServerZone {

--- a/packages/plugins/driver-sql/src/sql-driver-or-filter.test.ts
+++ b/packages/plugins/driver-sql/src/sql-driver-or-filter.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * Filter logical-combinator conformance for the SQL compiler, on a real engine
- * (in-memory better-sqlite3).
+ * Filter logical-combinator conformance for the SQL compiler, on real engines.
  *
  * The shared cases come from `@objectstack/spec/data` so this backend,
  * `driver-memory`, `formula`'s `matchesFilterCondition` and `read-scope-sql`
@@ -18,96 +17,156 @@
  * The SQL-specific cases below the conformance sweep cover ground the shared
  * table deliberately leaves out: a real DATE-typed column, and columns whose
  * values are not the shared fixture's plain strings.
+ *
+ * # The DRIVER axis (#4714, ADR-0053 D-A3)
+ *
+ * D-A3 declares the matrix over `driver {SQLite, Postgres at minimum}`. This
+ * suite used to hard-code `client: 'better-sqlite3'` — its describe was even
+ * named `(SQLite)` — so what it proved was that ONE engine executes the
+ * compiled predicate as the table says, while `where`-clause grouping and
+ * three-valued logic are precisely where dialects are free to differ. A
+ * compiler bug that only Postgres or MySQL can see had nothing to fail.
+ *
+ * So the sweep runs once per cell of `DIALECT_CELLS` — SQLite always, live
+ * Postgres and MySQL when `OS_TEST_POSTGRES_URL` / `OS_TEST_MYSQL_URL` are
+ * provisioned — over the SAME `FILTER_LOGIC_CASES`, asserting the SAME row-id
+ * sets cell for cell. A cell nobody provisioned is a named skip, and a red under
+ * `OS_EXPECT_LIVE_DIALECT_MATRIX=1` (`declareUnprovisionedCell`): a matrix that
+ * silently found zero live cells must not report OK (#4646). No new CI job — the
+ * `Temporal Conformance (live PG + MySQL)` workflow already runs this whole
+ * package against both servers.
+ *
+ * The shared cases are consumed here, never edited: if a live cell goes red the
+ * finding is that dialect's compile, not the case. (Nothing here is temporal, so
+ * the D-B3 server-timezone axis does not apply — requiring a non-UTC server
+ * would only manufacture reds that say nothing about `$or`.)
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { FILTER_LOGIC_CASES, FILTER_LOGIC_ROWS } from '@objectstack/spec/data';
 import { SqlDriver } from '../src/index.js';
+import {
+  DIALECT_CELLS,
+  declareUnprovisionedCell,
+  type DialectCell,
+} from './live-dialect-matrix.testkit.js';
 
-describe('SqlDriver filter logic conformance (SQLite)', () => {
-  let driver: SqlDriver;
-  let knexInstance: any;
+/**
+ * Issue-prefixed table names: the live cells share one database with every
+ * other suite in this package (and with each other's runs), so the bare `t` /
+ * `task` this suite used while it was SQLite-only would be a collision waiting
+ * to be read as a conformance failure.
+ */
+const FILTER_TABLE = 'os4714_filter_logic';
+const DATE_WINDOW_TABLE = 'os4714_filter_logic_windows';
 
-  beforeEach(async () => {
-    driver = new SqlDriver({
-      client: 'better-sqlite3',
-      connection: { filename: ':memory:' },
-      useNullAsDefault: true,
-    });
-    knexInstance = (driver as any).knex;
+// ── The driver axis ─────────────────────────────────────────────────────────
 
-    await knexInstance.schema.createTable('t', (t: any) => {
-      t.string('id').primary();
-      t.string('a');
-      t.string('b');
-      t.string('c');
-      t.string('owner');
-      t.string('status');
-      t.string('parent_object');
-      t.string('parent_id');
-    });
-    await knexInstance('t').insert([...FILTER_LOGIC_ROWS]);
-  });
+for (const cell of DIALECT_CELLS) {
+  if (!cell.available) {
+    declareUnprovisionedCell(cell, 'filter-logic conformance');
+    continue;
+  }
+  declareFilterLogicSweep(cell);
+}
 
-  afterEach(async () => {
-    await knexInstance.destroy();
-  });
+function declareFilterLogicSweep(cell: DialectCell): void {
+  describe(`SqlDriver filter logic conformance (${cell.label})`, () => {
+    let driver: SqlDriver;
+    let knexInstance: any;
 
-  describe('shared conformance cases', () => {
-    for (const c of FILTER_LOGIC_CASES) {
-      it(c.name, async () => {
-        const rows = await driver.find('t', { object: 't', where: c.filter });
-        const got = rows
-          .map((r: any) => String(r.id))
-          .sort((x: string, y: string) => x.localeCompare(y));
-        expect(got, c.note).toEqual(c.expected);
-      });
-    }
-  });
+    beforeAll(async () => {
+      driver = new SqlDriver(cell.config());
+      knexInstance = (driver as any).knex;
 
-  /**
-   * The abutting-window pattern the automation skill docs recommend and the CLI
-   * flow linter blesses (`lint-flow-patterns`): each tier is one field carrying
-   * two operators. "Windows tile the timeline so each record matches exactly one
-   * tier" only holds if those operators AND — under the old compile every tier
-   * degenerated to `d >= lo OR d < hi`, i.e. matched every row.
-   *
-   * The shared table pins this shape on plain strings; this pins it on a real
-   * date column, where value coercion also runs.
-   */
-  describe('multi-operator date windows inside $or', () => {
-    beforeEach(async () => {
-      await knexInstance.schema.createTable('task', (t: any) => {
+      // Live cells reuse one database, so the sweep starts from a dropped table.
+      await knexInstance.schema.dropTableIfExists(FILTER_TABLE);
+      await knexInstance.schema.createTable(FILTER_TABLE, (t: any) => {
         t.string('id').primary();
-        t.date('end_date');
+        t.string('a');
+        t.string('b');
+        t.string('c');
+        t.string('owner');
+        t.string('status');
+        t.string('parent_object');
+        t.string('parent_id');
       });
-      await knexInstance('task').insert([
-        { id: 'd07', end_date: '2026-08-07' },
-        { id: 'd15', end_date: '2026-08-15' },
-        { id: 'd30', end_date: '2026-08-30' },
-        { id: 'd60', end_date: '2026-09-29' },
-      ]);
+      await knexInstance(FILTER_TABLE).insert([...FILTER_LOGIC_ROWS]);
     });
 
-    it('matches only the rows inside the abutting windows', async () => {
-      const rows = await driver.find('task', {
-        object: 'task',
-        where: {
-          $or: [
-            { end_date: { $gte: '2026-08-07', $lt: '2026-08-08' } },
-            { end_date: { $gte: '2026-08-30', $lt: '2026-08-31' } },
-          ],
-        },
-      });
-      expect(rows.map((r: any) => r.id).sort()).toEqual(['d07', 'd30']);
+    afterAll(async () => {
+      await knexInstance?.schema.dropTableIfExists(FILTER_TABLE).catch(() => {});
+      await driver?.disconnect?.();
     });
 
-    it('keeps a window AND-ed with a sibling key in the same branch', async () => {
-      const rows = await driver.find('task', {
-        object: 'task',
-        where: { $or: [{ id: 'nope' }, { end_date: { $gte: '2026-08-07', $lt: '2026-08-31' }, id: 'd15' }] },
+    describe('shared conformance cases', () => {
+      for (const c of FILTER_LOGIC_CASES) {
+        it(c.name, async () => {
+          const rows = await driver.find(FILTER_TABLE, { object: FILTER_TABLE, where: c.filter });
+          const got = rows
+            .map((r: any) => String(r.id))
+            .sort((x: string, y: string) => x.localeCompare(y));
+          expect(got, c.note).toEqual(c.expected);
+        });
+      }
+    });
+
+    /**
+     * The abutting-window pattern the automation skill docs recommend and the CLI
+     * flow linter blesses (`lint-flow-patterns`): each tier is one field carrying
+     * two operators. "Windows tile the timeline so each record matches exactly one
+     * tier" only holds if those operators AND — under the old compile every tier
+     * degenerated to `d >= lo OR d < hi`, i.e. matched every row.
+     *
+     * The shared table pins this shape on plain strings; this pins it on a real
+     * date column, where value coercion also runs — and now on each dialect's own
+     * DATE type, which is where a bare `YYYY-MM-DD` comparand stops being one
+     * agreed thing (the D-B2 divergence, measured on PG @ Asia/Shanghai).
+     */
+    describe('multi-operator date windows inside $or', () => {
+      beforeAll(async () => {
+        await knexInstance.schema.dropTableIfExists(DATE_WINDOW_TABLE);
+        await knexInstance.schema.createTable(DATE_WINDOW_TABLE, (t: any) => {
+          t.string('id').primary();
+          t.date('end_date');
+        });
+        await knexInstance(DATE_WINDOW_TABLE).insert([
+          { id: 'd07', end_date: '2026-08-07' },
+          { id: 'd15', end_date: '2026-08-15' },
+          { id: 'd30', end_date: '2026-08-30' },
+          { id: 'd60', end_date: '2026-09-29' },
+        ]);
       });
-      expect(rows.map((r: any) => r.id)).toEqual(['d15']);
+
+      afterAll(async () => {
+        await knexInstance?.schema.dropTableIfExists(DATE_WINDOW_TABLE).catch(() => {});
+      });
+
+      it('matches only the rows inside the abutting windows', async () => {
+        const rows = await driver.find(DATE_WINDOW_TABLE, {
+          object: DATE_WINDOW_TABLE,
+          where: {
+            $or: [
+              { end_date: { $gte: '2026-08-07', $lt: '2026-08-08' } },
+              { end_date: { $gte: '2026-08-30', $lt: '2026-08-31' } },
+            ],
+          },
+        });
+        expect(rows.map((r: any) => r.id).sort()).toEqual(['d07', 'd30']);
+      });
+
+      it('keeps a window AND-ed with a sibling key in the same branch', async () => {
+        const rows = await driver.find(DATE_WINDOW_TABLE, {
+          object: DATE_WINDOW_TABLE,
+          where: {
+            $or: [
+              { id: 'nope' },
+              { end_date: { $gte: '2026-08-07', $lt: '2026-08-31' }, id: 'd15' },
+            ],
+          },
+        });
+        expect(rows.map((r: any) => r.id)).toEqual(['d15']);
+      });
     });
   });
-});
+}

--- a/packages/plugins/driver-sql/src/sql-driver-pagination-conformance.test.ts
+++ b/packages/plugins/driver-sql/src/sql-driver-pagination-conformance.test.ts
@@ -13,13 +13,11 @@
  *     a future driver has to satisfy however it chooses to.
  *
  *  2. **The clause** — assert the SQL that actually reached the database
- *     carries the ordering. The property test cannot be trusted on its own
- *     *here*: SQLite over a twelve-row table hands back both ties and wholly
- *     unordered rows in rowid order every time, so the partition check passes
- *     with or without the fix. It is a real check on MongoDB (where the
- *     reshuffle is documented and observable) and a regression lock on the
- *     memory driver; on SQL it would pass the day someone deletes the feature.
- *     The emitted-SQL assertion is the half that fails then.
+ *     carries the ordering. On the embedded cell the property test cannot be
+ *     trusted on its own: SQLite over a twelve-row table hands back both ties
+ *     and wholly unordered rows in rowid order every time, so the partition
+ *     check passes with or without the fix. The emitted-SQL assertion is the
+ *     half that fails then.
  *
  * That asymmetry is the point rather than an apology for it: the property is
  * the contract, and the clause is how this backend happens to keep it.
@@ -29,9 +27,44 @@
  * distinction is load-bearing: a test that rebuilds the ORDER BY itself asserts
  * only that the helper works, and stays green on the day `find()` stops calling
  * it — which is precisely the day this file exists for.
+ *
+ * # The DRIVER axis (#4714, ADR-0053 D-A3)
+ *
+ * D-A3 declares the matrix over `driver {SQLite, Postgres at minimum}`. Both
+ * describes above used to hard-code `client: 'better-sqlite3'`, so the shared
+ * `PAGINATION_CASES` / `PAGINATION_UNORDERED_CASES` only ever ran on the one
+ * backend whose head note (above) says the property half proves nothing there.
+ * That is the asymmetry stated as a permanent excuse rather than as the local
+ * fact it is: on a real server the partition check is the half with teeth,
+ * because a plan that reshuffles ties across two statements is what objectui#3106
+ * was actually reported as.
+ *
+ * So both halves now run once per cell of `DIALECT_CELLS` — SQLite always, live
+ * Postgres and MySQL when `OS_TEST_POSTGRES_URL` / `OS_TEST_MYSQL_URL` are
+ * provisioned — over the SAME cases, asserting the SAME row-id sets cell for
+ * cell. A cell nobody provisioned is a named skip, and a red under
+ * `OS_EXPECT_LIVE_DIALECT_MATRIX=1` (`declareUnprovisionedCell`): a matrix that
+ * silently found zero live cells must not report OK (#4646). No new CI job — the
+ * `Temporal Conformance (live PG + MySQL)` workflow already runs this whole
+ * package against both servers.
+ *
+ * Two things this file deliberately does NOT do:
+ *
+ *   - **No server-timezone axis.** D-B3's three-way skew guard belongs to the
+ *     temporal matrix, whose answers a zone can move; nothing here compares an
+ *     instant, so requiring a non-UTC server would only manufacture reds that
+ *     say nothing about pagination.
+ *   - **No tie-breaking added to the fixture to keep a dialect green.** The
+ *     shared rows repeat their sort keys on purpose; a live cell that goes red
+ *     over them is the finding this axis exists to surface, not a case to
+ *     soften. (`@objectstack/spec/data` is consumed here, never edited.)
+ *
+ * Honest limit of the live cells: twelve rows is one seq scan, so a server MAY
+ * hand ties back in a steady order anyway and pass without the tie-breaker.
+ * The clause half — now also per dialect — is what stays sharp in that case.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import {
   PAGINATION_ALL_IDS,
   PAGINATION_CASES,
@@ -40,6 +73,60 @@ import {
 } from '@objectstack/spec/data';
 import type { QueryAST } from '@objectstack/spec/data';
 import { SqlDriver } from '../src/index.js';
+import {
+  DIALECT_CELLS,
+  declareUnprovisionedCell,
+  type DialectCell,
+} from './live-dialect-matrix.testkit.js';
+
+/**
+ * One table per sweep, issue-prefixed: the live cells share a database with
+ * every other suite in this package (and with each other's runs), so a name
+ * collision would show up as a pagination failure in whichever suite lost the
+ * race.
+ */
+const PAGED_TABLE = 'os4714_pagination';
+const CLAUSE_TABLE = 'os4714_pagination_clause';
+
+/**
+ * How each dialect spells a quoted identifier — knex's own quoting, which is
+ * what the emitted SQL carries. The clause assertions match on the quoted form
+ * rather than a bare word so `id` cannot be satisfied by an unrelated
+ * substring, exactly as they did when this file was SQLite-only.
+ */
+const IDENTIFIER_QUOTE: Record<DialectCell['id'], string> = {
+  sqlite: '`',
+  pg: '"',
+  mysql: '`',
+};
+
+/** `/order by .*"status" asc,.*"id" asc/i` for the cell's quoting. */
+function orderedBy(cell: DialectCell, ...keys: Array<[string, 'asc' | 'desc']>): RegExp {
+  const q = IDENTIFIER_QUOTE[cell.id];
+  return new RegExp(`order by ${keys.map(([f, d]) => `.*${q}${f}${q} ${d}`).join(',')}`, 'i');
+}
+
+/** Live cells reuse one database, so every sweep starts from a dropped table. */
+async function freshTable(
+  driver: SqlDriver,
+  shape: { name: string; fields: Record<string, { type: string }> },
+): Promise<void> {
+  await driver.execute(`drop table if exists ${shape.name}`).catch(() => {});
+  await driver.initObjects([shape as any]);
+}
+
+async function dropTable(driver: SqlDriver | undefined, table: string): Promise<void> {
+  await driver?.execute(`drop table if exists ${table}`).catch(() => {});
+}
+
+const ticketShape = (name: string) => ({
+  name,
+  fields: {
+    status: { type: 'string' },
+    rank: { type: 'integer' },
+    name: { type: 'string' },
+  },
+});
 
 /**
  * Records the SQL of every statement this driver sends, so a test can assert
@@ -54,257 +141,288 @@ class InspectableSqlDriver extends SqlDriver {
     });
   }
 
-  /** The SQL of the single statement issued while running `run`. */
-  async sqlOf(run: () => Promise<unknown>): Promise<string> {
+  /**
+   * The SQL of the single statement `run` issued **against `table`**.
+   *
+   * Scoped to the table rather than "the only statement of the run" because a
+   * live cell's connection is pooled and a dialect may introspect on first use;
+   * neither is the statement under test. Two statements against the same table
+   * still fail here, which is the assertion's actual job.
+   */
+  async sqlOf(table: string, run: () => Promise<unknown>): Promise<string> {
     const from = this.statements.length;
     await run();
-    const issued = this.statements.slice(from);
-    expect(issued, 'expected exactly one statement').toHaveLength(1);
+    const issued = this.statements.slice(from).filter((sql) => sql.includes(table));
+    expect(issued, `expected exactly one statement against ${table}`).toHaveLength(1);
     return issued[0]!;
   }
 }
 
-describe('SqlDriver — paged reads are a partition of the result set (objectui#3106)', () => {
-  let driver: SqlDriver;
+// ── The driver axis ─────────────────────────────────────────────────────────
 
-  beforeEach(async () => {
-    driver = new SqlDriver({
-      client: 'better-sqlite3',
-      connection: { filename: ':memory:' },
-      useNullAsDefault: true,
-    });
+for (const cell of DIALECT_CELLS) {
+  if (!cell.available) {
+    declareUnprovisionedCell(cell, 'paged-read conformance');
+    continue;
+  }
+  declarePartitionSweep(cell);
+  declareClauseSweep(cell);
+}
 
-    await driver.initObjects([
-      {
-        name: 'ticket',
-        fields: {
-          status: { type: 'string' },
-          rank: { type: 'integer' },
-          name: { type: 'string' },
-        },
-      },
-    ]);
+// ── Half 1: the property, over the shared cases ─────────────────────────────
 
-    for (const row of PAGINATION_ROWS) {
-      await driver.create('ticket', { ...row }, { bypassTenantAudit: true });
-    }
-  });
+function declarePartitionSweep(cell: DialectCell): void {
+  describe(`SqlDriver — paged reads are a partition of the result set (objectui#3106) (${cell.label})`, () => {
+    let driver: SqlDriver;
 
-  afterEach(async () => {
-    await driver.disconnect();
-  });
+    beforeAll(async () => {
+      driver = new SqlDriver(cell.config());
+      await freshTable(driver, ticketShape(PAGED_TABLE));
 
-  for (const testCase of PAGINATION_CASES) {
-    it(`visits every row exactly once — ${testCase.name}`, async () => {
-      const seen: string[] = [];
-      for (let offset = 0; offset < PAGINATION_ROWS.length; offset += testCase.pageSize) {
-        const page = await driver.find(
-          'ticket',
-          { object: 'ticket', orderBy: [...testCase.orderBy], limit: testCase.pageSize, offset },
-          { bypassTenantAudit: true },
-        );
-        seen.push(...page.map((r) => String(r.id)));
+      for (const row of PAGINATION_ROWS) {
+        await driver.create(PAGED_TABLE, { ...row }, { bypassTenantAudit: true });
       }
-
-      expect(seen).toHaveLength(PAGINATION_ALL_IDS.length);
-      expect(new Set(seen).size).toBe(PAGINATION_ALL_IDS.length);
-      expect([...seen].sort()).toEqual([...PAGINATION_ALL_IDS].sort());
     });
 
-    it(`orders pages consistently with the requested sort — ${testCase.name}`, async () => {
+    afterAll(async () => {
+      await dropTable(driver, PAGED_TABLE);
+      await driver?.disconnect?.();
+    });
+
+    const walk = async (query: Omit<QueryAST, 'object'>, pageSize: number) => {
       const paged: Array<Record<string, unknown>> = [];
-      for (let offset = 0; offset < PAGINATION_ROWS.length; offset += testCase.pageSize) {
+      for (let offset = 0; offset < PAGINATION_ROWS.length; offset += pageSize) {
         const page = await driver.find(
-          'ticket',
-          { object: 'ticket', orderBy: [...testCase.orderBy], limit: testCase.pageSize, offset },
+          PAGED_TABLE,
+          { object: PAGED_TABLE, ...query, limit: pageSize, offset },
           { bypassTenantAudit: true },
         );
         paged.push(...page);
       }
+      return paged;
+    };
 
-      // Concatenating the pages must reproduce the same order an unpaged read
-      // of the whole set gives — that the page boundaries are invisible is the
-      // user-facing half of the guarantee.
-      const whole = await driver.find(
-        'ticket',
-        { object: 'ticket', orderBy: [...testCase.orderBy] },
+    for (const testCase of PAGINATION_CASES) {
+      it(`visits every row exactly once — ${testCase.name}`, async () => {
+        const seen = (await walk({ orderBy: [...testCase.orderBy] }, testCase.pageSize)).map((r) =>
+          String(r.id),
+        );
+
+        expect(seen).toHaveLength(PAGINATION_ALL_IDS.length);
+        expect(new Set(seen).size).toBe(PAGINATION_ALL_IDS.length);
+        expect([...seen].sort()).toEqual([...PAGINATION_ALL_IDS].sort());
+      });
+
+      it(`orders pages consistently with the requested sort — ${testCase.name}`, async () => {
+        const paged = await walk({ orderBy: [...testCase.orderBy] }, testCase.pageSize);
+
+        // Concatenating the pages must reproduce the same order an unpaged read
+        // of the whole set gives — that the page boundaries are invisible is the
+        // user-facing half of the guarantee.
+        const whole = await driver.find(
+          PAGED_TABLE,
+          { object: PAGED_TABLE, orderBy: [...testCase.orderBy] },
+          { bypassTenantAudit: true },
+        );
+        expect(paged.map((r) => r.id)).toEqual(whole.map((r) => r.id));
+      });
+    }
+
+    for (const testCase of PAGINATION_UNORDERED_CASES) {
+      it(`visits every row exactly once with NO orderBy at all — ${testCase.name}`, async () => {
+        const seen = (await walk({}, testCase.pageSize)).map((r) => String(r.id));
+
+        expect(seen).toHaveLength(PAGINATION_ALL_IDS.length);
+        expect(new Set(seen).size).toBe(PAGINATION_ALL_IDS.length);
+        expect([...seen].sort()).toEqual([...PAGINATION_ALL_IDS].sort());
+      });
+
+      it(`walks an unsorted read in id order — ${testCase.name}`, async () => {
+        const paged = (await walk({}, testCase.pageSize)).map((r) => String(r.id));
+
+        // The fixture's ids are shuffled relative to insertion order, so id order
+        // is visibly an order this driver chose rather than the one the table
+        // would have handed back anyway.
+        expect(paged).toEqual([...PAGINATION_ALL_IDS].sort());
+      });
+    }
+
+    it('leaves an UNPAGED unordered read alone — no sort is imposed on a caller who asked for none', async () => {
+      // The carve-out (objectstack#4363): with no `limit`/`offset` the caller
+      // receives the whole matching set, so no slice can be wrong, and an
+      // imposed ORDER BY would only change plan selection.
+      const rows = await driver.find(
+        PAGED_TABLE,
+        { object: PAGED_TABLE },
         { bypassTenantAudit: true },
       );
-      expect(paged.map((r) => r.id)).toEqual(whole.map((r) => r.id));
-    });
-  }
+      expect([...rows.map((r) => String(r.id))].sort()).toEqual([...PAGINATION_ALL_IDS].sort());
 
-  for (const testCase of PAGINATION_UNORDERED_CASES) {
-    it(`visits every row exactly once with NO orderBy at all — ${testCase.name}`, async () => {
-      const seen: string[] = [];
-      for (let offset = 0; offset < PAGINATION_ROWS.length; offset += testCase.pageSize) {
-        const page = await driver.find(
-          'ticket',
-          { object: 'ticket', limit: testCase.pageSize, offset },
-          { bypassTenantAudit: true },
-        );
-        seen.push(...page.map((r) => String(r.id)));
+      // WHICH order those rows arrive in is the dialect's own answer, and the
+      // one thing #4363 promises about this shape is that the driver adds
+      // nothing to it — so only the embedded cell, whose plan is fixed, pins the
+      // exact sequence (insertion order, visibly not the shuffled ids' order).
+      // MySQL hands back InnoDB primary-key order and Postgres its heap order;
+      // pinning either would assert the server's plan as if it were our
+      // contract. The contract half — that no ORDER BY was emitted at all — is
+      // asserted per dialect in the clause sweep below.
+      if (!cell.live) {
+        expect(rows.map((r) => r.id)).toEqual(PAGINATION_ROWS.map((r) => r.id));
       }
+    });
+  });
+}
 
-      expect(seen).toHaveLength(PAGINATION_ALL_IDS.length);
-      expect(new Set(seen).size).toBe(PAGINATION_ALL_IDS.length);
-      expect([...seen].sort()).toEqual([...PAGINATION_ALL_IDS].sort());
+// ── Half 2: the ORDER BY that reaches the database ──────────────────────────
+
+function declareClauseSweep(cell: DialectCell): void {
+  describe(`SqlDriver — the ORDER BY that reaches the database (${cell.label})`, () => {
+    let driver: InspectableSqlDriver;
+
+    beforeAll(async () => {
+      driver = new InspectableSqlDriver(cell.config());
+      await freshTable(driver, {
+        name: CLAUSE_TABLE,
+        fields: { status: { type: 'string' }, rank: { type: 'integer' } },
+      });
+      // One warm-up read before the recorder is installed: a live dialect may
+      // introspect on first use, and that statement is not the one under test.
+      await driver.find(CLAUSE_TABLE, { object: CLAUSE_TABLE }, { bypassTenantAudit: true });
+      driver.captureStatements();
     });
 
-    it(`walks an unsorted read in id order — ${testCase.name}`, async () => {
-      const paged: string[] = [];
-      for (let offset = 0; offset < PAGINATION_ROWS.length; offset += testCase.pageSize) {
-        const page = await driver.find(
-          'ticket',
-          { object: 'ticket', limit: testCase.pageSize, offset },
-          { bypassTenantAudit: true },
-        );
-        paged.push(...page.map((r) => String(r.id)));
-      }
-
-      // The fixture's ids are shuffled relative to insertion order, so id order
-      // is visibly an order this driver chose rather than the one the table
-      // would have handed back anyway.
-      expect(paged).toEqual([...PAGINATION_ALL_IDS].sort());
+    afterAll(async () => {
+      await dropTable(driver, CLAUSE_TABLE);
+      await driver?.disconnect?.();
     });
-  }
 
-  it('leaves an UNPAGED unordered read alone — no sort is imposed on a caller who asked for none', async () => {
-    // The carve-out (objectstack#4363): with no `limit`/`offset` the caller
-    // receives the whole matching set, so no slice can be wrong, and an imposed
-    // ORDER BY would only change plan selection. The order below is SQLite's
-    // own answer, not one this driver asked for — which the shuffled fixture
-    // ids make visible.
-    const rows = await driver.find('ticket', { object: 'ticket' }, { bypassTenantAudit: true });
-    expect(rows.map((r) => r.id)).toEqual(PAGINATION_ROWS.map((r) => r.id));
-  });
-});
-
-describe('SqlDriver — the ORDER BY that reaches the database', () => {
-  let driver: InspectableSqlDriver;
-
-  beforeEach(async () => {
-    driver = new InspectableSqlDriver({
-      client: 'better-sqlite3',
-      connection: { filename: ':memory:' },
-      useNullAsDefault: true,
-    });
-    await driver.initObjects([
-      { name: 'ticket', fields: { status: { type: 'string' }, rank: { type: 'integer' } } },
-    ]);
-    driver.captureStatements();
-  });
-
-  afterEach(async () => {
-    await driver.disconnect();
-  });
-
-  const sqlOfFind = (query: Omit<QueryAST, 'object'>) =>
-    driver.sqlOf(() => driver.find('ticket', { object: 'ticket', ...query }, { bypassTenantAudit: true }));
-
-  it('appends `id` after a non-unique sort key', async () => {
-    const sql = await sqlOfFind({ orderBy: [{ field: 'status', order: 'asc' }] });
-    expect(sql).toMatch(/order by .*`status` asc, .*`id` asc/i);
-  });
-
-  it('appends `id` in the LAST key\'s direction, so one index pass can serve it', async () => {
-    const sql = await sqlOfFind({
-      orderBy: [
-        { field: 'status', order: 'asc' },
-        { field: 'rank', order: 'desc' },
-      ],
-    });
-    expect(sql).toMatch(/order by .*`status` asc, .*`rank` desc, .*`id` desc/i);
-  });
-
-  it('does not repeat `id` when the caller already sorted by it', async () => {
-    const sql = await sqlOfFind({ orderBy: [{ field: 'id', order: 'desc' }], limit: 5, offset: 5 });
-    expect(sql.match(/`id`/g) ?? []).toHaveLength(1);
-  });
-
-  it('orders a paged read by `id` when the caller sent no orderBy (objectstack#4363)', async () => {
-    expect(await sqlOfFind({ limit: 5, offset: 5 })).toMatch(/order by .*`id` asc/i);
-  });
-
-  it('counts `limit` alone as paged — page one must agree with pages two onward', async () => {
-    // A list view's first request is routinely `limit=50` with no offset at
-    // all. Ordering only the offset-carrying pages would cut page one from a
-    // different arrangement than the rest of the walk: the defect intact,
-    // wearing a fix.
-    expect(await sqlOfFind({ limit: 5 })).toMatch(/order by .*`id` asc/i);
-    expect(await sqlOfFind({ offset: 5 })).toMatch(/order by .*`id` asc/i);
-    expect(await sqlOfFind({ orderBy: [], limit: 5 })).toMatch(/order by .*`id` asc/i);
-  });
-
-  it('emits no ORDER BY for an unpaged read with no orderBy', async () => {
-    expect(await sqlOfFind({})).not.toMatch(/order by/i);
-    expect(await sqlOfFind({ where: { status: 'open' } })).not.toMatch(/order by/i);
-    expect(await sqlOfFind({ orderBy: [] })).not.toMatch(/order by/i);
-  });
-
-  it('leaves `findOne` unordered — its `limit: 1` is not page one of a walk', async () => {
-    // `findOne` promises *a* matching record, not a position in a sequence, so
-    // there is no partition to keep. Reading its `limit: 1` as a page would
-    // impose `ORDER BY id LIMIT 1` on the hottest read in the system, which is
-    // the shape that makes a planner abandon the predicate's own index: on a
-    // 2M-row Postgres table `WHERE owner_id = ? LIMIT 1` measured 0.08 ms
-    // unordered and 7.8 ms with `ORDER BY id`. `MongoDBDriver.findOne` has
-    // never sorted either — this keeps the two drivers saying the same thing.
-    const sql = await driver.sqlOf(() =>
-      driver.findOne('ticket', { object: 'ticket', where: { status: 'open' } }, {
-        bypassTenantAudit: true,
-      }),
-    );
-    expect(sql).not.toMatch(/order by/i);
-    expect(sql).toMatch(/limit/i);
-  });
-
-  it('still honors an orderBy the caller gave findOne, tie-breaker and all', async () => {
-    const sql = await driver.sqlOf(() =>
-      driver.findOne('ticket', { object: 'ticket', orderBy: [{ field: 'status', order: 'desc' }] }, {
-        bypassTenantAudit: true,
-      }),
-    );
-    expect(sql).toMatch(/order by .*`status` desc, .*`id` desc/i);
-  });
-
-  it('adds nothing for an object this driver did not create', () => {
-    // A federated table (ADR-0015) may have no `id` column at all. Sorting by a
-    // column that isn't there raises an unknown-column error, which the #3821
-    // ladder answers by retrying with NO ORDER BY — so a guess here would cost
-    // the caller their whole sort to fix a reshuffle among ties. It costs even
-    // more on the unsorted paged read: there is no requested sort to fall back
-    // to, so a wrong guess turns a reshuffle into a failed read.
-    expect(driver['paginationTieBreaker']('some_remote_table')).toBeNull();
-    expect(driver['orderKeysFor']('some_remote_table', { object: 'some_remote_table', limit: 5, offset: 5 })).toEqual([]);
-  });
-
-  it('says so, once, when it cannot keep the guarantee on a table it did not create', () => {
-    // Behavior is unchanged for these tables — the statement goes out exactly
-    // as before. What changes is that the gap is announced instead of being
-    // left for a user counting records to find, which is the same reason the
-    // rule exists at all.
-    const warn = vi.spyOn(driver['logger'], 'warn').mockImplementation(() => {});
-    try {
-      driver['orderKeysFor']('some_remote_table', { object: 'some_remote_table', limit: 5, offset: 5 });
-      driver['orderKeysFor']('some_remote_table', { object: 'some_remote_table', limit: 5, offset: 10 });
-      expect(warn, 'once per object, not per query').toHaveBeenCalledTimes(1);
-      const message = warn.mock.calls[0]![0];
-      expect(message, 'names the object').toContain('some_remote_table');
-      expect(message, 'names the consequence').toMatch(/NOT deterministic/);
-      expect(message, 'names a remedy').toMatch(/orderBy/);
-
-      // A managed table keeps the guarantee, so it must stay quiet.
-      driver['orderKeysFor']('ticket', { object: 'ticket', limit: 5, offset: 5 });
-      // So must an unpaged read, and a sorted one: neither is the silent case.
-      driver['orderKeysFor']('some_remote_table', { object: 'some_remote_table' });
-      driver['orderKeysFor'](
-        'some_remote_table',
-        { object: 'some_remote_table', orderBy: [{ field: 'status', order: 'asc' }], limit: 5 },
+    const sqlOfFind = (query: Omit<QueryAST, 'object'>) =>
+      driver.sqlOf(CLAUSE_TABLE, () =>
+        driver.find(CLAUSE_TABLE, { object: CLAUSE_TABLE, ...query }, { bypassTenantAudit: true }),
       );
-      expect(warn).toHaveBeenCalledTimes(1);
-    } finally {
-      warn.mockRestore();
-    }
+
+    it('appends `id` after a non-unique sort key', async () => {
+      const sql = await sqlOfFind({ orderBy: [{ field: 'status', order: 'asc' }] });
+      expect(sql).toMatch(orderedBy(cell, ['status', 'asc'], ['id', 'asc']));
+    });
+
+    it("appends `id` in the LAST key's direction, so one index pass can serve it", async () => {
+      const sql = await sqlOfFind({
+        orderBy: [
+          { field: 'status', order: 'asc' },
+          { field: 'rank', order: 'desc' },
+        ],
+      });
+      expect(sql).toMatch(orderedBy(cell, ['status', 'asc'], ['rank', 'desc'], ['id', 'desc']));
+    });
+
+    it('does not repeat `id` when the caller already sorted by it', async () => {
+      const sql = await sqlOfFind({ orderBy: [{ field: 'id', order: 'desc' }], limit: 5, offset: 5 });
+      const q = IDENTIFIER_QUOTE[cell.id];
+      expect(sql.match(new RegExp(`${q}id${q}`, 'g')) ?? []).toHaveLength(1);
+    });
+
+    it('orders a paged read by `id` when the caller sent no orderBy (objectstack#4363)', async () => {
+      expect(await sqlOfFind({ limit: 5, offset: 5 })).toMatch(orderedBy(cell, ['id', 'asc']));
+    });
+
+    it('counts `limit` alone as paged — page one must agree with pages two onward', async () => {
+      // A list view's first request is routinely `limit=50` with no offset at
+      // all. Ordering only the offset-carrying pages would cut page one from a
+      // different arrangement than the rest of the walk: the defect intact,
+      // wearing a fix.
+      expect(await sqlOfFind({ limit: 5 })).toMatch(orderedBy(cell, ['id', 'asc']));
+      expect(await sqlOfFind({ offset: 5 })).toMatch(orderedBy(cell, ['id', 'asc']));
+      expect(await sqlOfFind({ orderBy: [], limit: 5 })).toMatch(orderedBy(cell, ['id', 'asc']));
+    });
+
+    it('emits no ORDER BY for an unpaged read with no orderBy', async () => {
+      expect(await sqlOfFind({})).not.toMatch(/order by/i);
+      expect(await sqlOfFind({ where: { status: 'open' } })).not.toMatch(/order by/i);
+      expect(await sqlOfFind({ orderBy: [] })).not.toMatch(/order by/i);
+    });
+
+    it('leaves `findOne` unordered — its `limit: 1` is not page one of a walk', async () => {
+      // `findOne` promises *a* matching record, not a position in a sequence, so
+      // there is no partition to keep. Reading its `limit: 1` as a page would
+      // impose `ORDER BY id LIMIT 1` on the hottest read in the system, which is
+      // the shape that makes a planner abandon the predicate's own index: on a
+      // 2M-row Postgres table `WHERE owner_id = ? LIMIT 1` measured 0.08 ms
+      // unordered and 7.8 ms with `ORDER BY id`. `MongoDBDriver.findOne` has
+      // never sorted either — this keeps the two drivers saying the same thing.
+      const sql = await driver.sqlOf(CLAUSE_TABLE, () =>
+        driver.findOne(
+          CLAUSE_TABLE,
+          { object: CLAUSE_TABLE, where: { status: 'open' } },
+          { bypassTenantAudit: true },
+        ),
+      );
+      expect(sql).not.toMatch(/order by/i);
+      expect(sql).toMatch(/limit/i);
+    });
+
+    it('still honors an orderBy the caller gave findOne, tie-breaker and all', async () => {
+      const sql = await driver.sqlOf(CLAUSE_TABLE, () =>
+        driver.findOne(
+          CLAUSE_TABLE,
+          { object: CLAUSE_TABLE, orderBy: [{ field: 'status', order: 'desc' }] },
+          { bypassTenantAudit: true },
+        ),
+      );
+      expect(sql).toMatch(orderedBy(cell, ['status', 'desc'], ['id', 'desc']));
+    });
+
+    it('adds nothing for an object this driver did not create', () => {
+      // A federated table (ADR-0015) may have no `id` column at all. Sorting by a
+      // column that isn't there raises an unknown-column error, which the #3821
+      // ladder answers by retrying with NO ORDER BY — so a guess here would cost
+      // the caller their whole sort to fix a reshuffle among ties. It costs even
+      // more on the unsorted paged read: there is no requested sort to fall back
+      // to, so a wrong guess turns a reshuffle into a failed read.
+      expect(driver['paginationTieBreaker']('some_remote_table')).toBeNull();
+      expect(
+        driver['orderKeysFor']('some_remote_table', {
+          object: 'some_remote_table',
+          limit: 5,
+          offset: 5,
+        }),
+      ).toEqual([]);
+    });
+
+    it('says so, once, when it cannot keep the guarantee on a table it did not create', () => {
+      // Behavior is unchanged for these tables — the statement goes out exactly
+      // as before. What changes is that the gap is announced instead of being
+      // left for a user counting records to find, which is the same reason the
+      // rule exists at all.
+      //
+      // Its own object name, because "once" is counted per object for the LIFE
+      // of the driver and this sweep shares one driver across its tests (a live
+      // cell cannot afford a fresh connection per assertion). Reusing the name
+      // the test above already paged would measure that suite's leftovers.
+      const remote = 'warned_remote_table';
+      const warn = vi.spyOn(driver['logger'], 'warn').mockImplementation(() => {});
+      try {
+        driver['orderKeysFor'](remote, { object: remote, limit: 5, offset: 5 });
+        driver['orderKeysFor'](remote, { object: remote, limit: 5, offset: 10 });
+        expect(warn, 'once per object, not per query').toHaveBeenCalledTimes(1);
+        const message = warn.mock.calls[0]![0];
+        expect(message, 'names the object').toContain(remote);
+        expect(message, 'names the consequence').toMatch(/NOT deterministic/);
+        expect(message, 'names a remedy').toMatch(/orderBy/);
+
+        // A managed table keeps the guarantee, so it must stay quiet.
+        driver['orderKeysFor'](CLAUSE_TABLE, { object: CLAUSE_TABLE, limit: 5, offset: 5 });
+        // So must an unpaged read, and a sorted one: neither is the silent case.
+        driver['orderKeysFor'](remote, { object: remote });
+        driver['orderKeysFor'](remote, {
+          object: remote,
+          orderBy: [{ field: 'status', order: 'asc' }],
+          limit: 5,
+        });
+        expect(warn).toHaveBeenCalledTimes(1);
+      } finally {
+        warn.mockRestore();
+      }
+    });
   });
-});
+}

--- a/packages/plugins/driver-sql/src/sql-driver-temporal-conformance.test.ts
+++ b/packages/plugins/driver-sql/src/sql-driver-temporal-conformance.test.ts
@@ -78,8 +78,8 @@ import { SqlDriver } from '../src/index.js';
 import { LegacyStorageDriver } from './legacy-datetime-storage.testkit.js';
 import {
   DIALECT_CELLS,
-  EXPECT_LIVE_DIALECTS,
   assertThreeWayZoneSkew,
+  declareUnprovisionedCell,
   readServerZone,
   type DialectCell,
   type ServerZone,
@@ -133,7 +133,11 @@ async function dropTable(driver: SqlDriver | undefined, table: string): Promise<
 
 for (const cell of DIALECT_CELLS) {
   if (!cell.available) {
-    declareUnprovisionedCell(cell);
+    // Reported, never omitted — a named skip locally, a red under
+    // `OS_EXPECT_LIVE_DIALECT_MATRIX=1`. The guard is the testkit's (shared with
+    // the pagination and filter-logic matrices, #4714) so it cannot weaken in
+    // one consumer's copy alone.
+    declareUnprovisionedCell(cell, 'temporal conformance');
     continue;
   }
   if (cell.live) declareServerTimezoneAxis(cell);
@@ -141,27 +145,6 @@ for (const cell of DIALECT_CELLS) {
   declareLegacyDatetimeSweep(cell);
   declareTimeSweep(cell);
   declareLegacyTimeSweep(cell);
-}
-
-/**
- * A cell nobody provisioned is REPORTED, not omitted: a named skip locally, a
- * failure under `OS_EXPECT_LIVE_DIALECT_MATRIX=1` — which is what stops the CI
- * job from quietly degrading to SQLite-only coverage if its `env:` block is
- * ever dropped.
- */
-function declareUnprovisionedCell(cell: DialectCell): void {
-  describe(`sql-driver — temporal conformance matrix (${cell.label})`, () => {
-    it.skipIf(!EXPECT_LIVE_DIALECTS)(
-      `is provisioned — set ${cell.env} to run this cell of the D-A3 driver axis`,
-      () => {
-        expect.fail(
-          `${cell.env} is unset while OS_EXPECT_LIVE_DIALECT_MATRIX=1: this runner declared it ` +
-            `provisions live Postgres and MySQL, so the ${cell.label} cell of the temporal ` +
-            `conformance matrix must not be skipped (ADR-0053 D-A3 "Postgres at minimum").`,
-        );
-      },
-    );
-  });
 }
 
 /**


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4714

#4245（PR #4713）把 D-A3 的 driver 轴补到了 temporal 矩阵，并留下 `live-dialect-matrix.testkit.ts`。本 PR 照抄那个形状，把 `driver-sql` 还在消费的另外两条 `@objectstack/spec/data` 共享矩阵也搬上同一根轴：

| 文件 | 共享矩阵 | 之前 | 现在 |
|:--|:--|:--|:--|
| `sql-driver-pagination-conformance.test.ts` | `PAGINATION_CASES` / `PAGINATION_UNORDERED_CASES` | 两个 describe 都钉死 `client: 'better-sqlite3'` | `for (const cell of DIALECT_CELLS)` |
| `sql-driver-or-filter.test.ts` | `FILTER_LOGIC_CASES` | 同上，describe 名字就叫 `(SQLite)` | 同上 |

## 结论先说：格子存在，而且**真的会咬人** —— 但当前实现是绿的

按 issue 的验收，「红了是交付」。这一轮的实测结果是：**三个方言 46 条用例逐格一致，全绿**。这不是因为断言被放松了，而是因为 `paginationTieBreaker` 的修复在真服务器上确实成立。为了证明这一格不是空转，我做了一次**破坏性实验**（临时把 `paginationTieBreaker` 改成对 managed 表也返回 `null`，测完已 `git checkout` 还原，未进入本 PR 的 diff）：

| 格子 | 破坏后失败数 | 失败的是哪一半 |
|:--|:--|:--|
| `sqlite` | 8 | **性质断言的有序用例一条都没红**；红的只有 3 条 unordered walk + 5 条 emitted-SQL |
| `live postgres` | **15** | **性质断言红了 7 条** —— `visits every row exactly once` 报 `expected 11 to be 12`（一行被翻了两次、另一行一次都没出现），`orders pages consistently` 红 4 条 |
| `live mysql` | 5 | 只有 emitted-SQL 那一半（InnoDB 主键序全表扫描在 12 行上恰好稳定） |

PG 上那句 `expected 11 to be 12` 就是 objectui#3106 的原始故障，一字不差 —— 这正是文件头注自己说 SQLite 上证不出来的那半边。换句话说：**在补上这根轴之前，删掉分页修复只会让 emitted-SQL 那半边红；性质断言在唯一跑得到的方言上是恒真的。**

破坏实验的 PG 证据：

```
FAIL ... (live postgres) > visits every row exactly once — single ascending key with 4-row ties
AssertionError: expected 11 to be 12 // Object.is equality
FAIL ... (live postgres) > orders pages consistently with the requested sort — single ascending key with 4-row ties
- Expected      + Received
-   "r09",          "r02",
    "r02",          "r10",
    "r10",          "r03",
    "r03",      +   "r09",
-   "r06",      +   "r12",
```

（`r06` 整趟走丢，`r12` 出现两次。）

## 实测环境与逐格证据

本地起了真服务器，配置与 CI 的 `Temporal Conformance (live PG + MySQL)` job 对齐：PostgreSQL **16.13 @ `Asia/Shanghai`**、MariaDB **10.11.14 @ `+08:00`**，进程 `TZ=America/New_York`，并开 `OS_EXPECT_LIVE_DIALECT_MATRIX=1`。

```
$ TZ=America/New_York OS_TEST_POSTGRES_URL=... OS_TEST_MYSQL_URL=... \
  OS_EXPECT_LIVE_DIALECT_MATRIX=1 vitest run \
  src/sql-driver-pagination-conformance.test.ts src/sql-driver-or-filter.test.ts

sqlite         passed: 46
live postgres  passed: 46
live mysql     passed: 46
 Test Files  2 passed (2)
      Tests  138 passed (138)
```

三格用例数完全相同（46 × 3 = 138），行 id 集合逐格一致。整包（CI 形状，含 temporal 矩阵与全部 live 套件）：

```
$ pnpm --filter @objectstack/driver-sql test        # 无 URL
 Test Files  55 passed | 4 skipped (59)
      Tests  636 passed | 44 skipped (680)

$ TZ=... OS_TEST_*_URL=... OS_EXPECT_LIVE_DIALECT_MATRIX=1 pnpm --filter @objectstack/driver-sql test
 Test Files  59 passed (59)
      Tests  844 passed (844)
```

**说明**：MariaDB 10.11 不等于 CI 的 MySQL 8.0（容器里没有 docker daemon，只能用系统自带的 server）。仓库注释里说 #3942 的手工验证正是跑在 MariaDB 10.11 上，两者互为补充；MySQL 8.0 那一格由 CI 上这个 job 给出。

## 非空转守卫（没有退化）

缺 URL → **具名 skip**，不是静默跳过：

```
↓ ... > sql-driver — paged-read conformance matrix (live postgres) > is provisioned — set OS_TEST_POSTGRES_URL to run this cell of the D-A3 driver axis
↓ ... > sql-driver — filter-logic conformance matrix (live mysql) > is provisioned — set OS_TEST_MYSQL_URL to run this cell of the D-A3 driver axis
```

`OS_EXPECT_LIVE_DIALECT_MATRIX=1` 且缺 URL → 直接红（实测 4 条）：

```
FAIL ... > sql-driver — paged-read conformance matrix (live postgres) > is provisioned — ...
AssertionError: OS_TEST_POSTGRES_URL is unset while OS_EXPECT_LIVE_DIALECT_MATRIX=1: this runner
declared it provisions live Postgres and MySQL, so the live postgres cell of the paged-read
conformance matrix must not be skipped (ADR-0053 D-A3 "Postgres at minimum").
```

这个守卫从 temporal 文件里**上提到了 testkit**（`declareUnprovisionedCell(cell, matrix)`），三条矩阵共用一份定义 —— 复制三份的守卫可以在其中一份里悄悄变弱，而「巡检发现零个 cell 却报 OK」正是 #4646 已经付过一次学费的形状。temporal 文件的调用点同步改掉，行为与文案逐字不变。

## 几处刻意的判断（请重点看这三条）

1. **不加 server-timezone 轴。** D-B3 的三方错开守卫属于 temporal 矩阵 —— 那里的答案会被时区搬动。分页和 `$or` 里没有任何一个 instant 参与比较，硬要求非 UTC 服务器只会制造出与本矩阵无关的红。
2. **unpaged + 无 orderBy 的那条，精确顺序只钉 SQLite。** #4363 承诺的是「driver 对这个形状不追加任何东西」，不是「服务器按某个顺序返回」。MySQL 给的是 InnoDB 主键序、PG 给的是堆序，把任何一个钉死都是把**服务器的执行计划**当成我们的契约来断言。三个格子共同断言的是「整集合原样返回」，而契约那一半（**没有** ORDER BY 发出去）现在逐方言断言。
3. **emitted-SQL 那一半也参数化了**，按方言的标识符引号（PG `"`，SQLite/MySQL `` ` ``）构造断言 —— 于是「ORDER BY 真的到达了数据库」这句话在三个真引擎上分别成立，而不只是在 knex 的 SQLite 编译结果上。

诚实的边界：12 行只是一次 seq scan，真服务器**也可能**恰好稳定返回（本轮 MySQL 就是这样）。所以 emitted-SQL 那一半仍然是必要的，两半互相兜底 —— 头注里写清楚了。

## 约束遵守情况

- ⛔ 只动 `packages/plugins/driver-sql/**`；`@objectstack/spec/data` 只消费不修改 —— **没有**为了变绿给 fixture 加 tiebreaker、改用例或放宽断言。
- ⛔ `packages/spec/**` 零改动；`content/docs/releases/` 未碰；**无新增 CI job**（现有 job 已经在跑整包）。
- 表名全部带 issue 前缀（`os4714_pagination` / `os4714_pagination_clause` / `os4714_filter_logic` / `os4714_filter_logic_windows`），替换掉原来裸的 `t` / `task` —— 共享 live 库上裸表名会和并行套件抢，抢输的那边会表现为一次假的 conformance 失败。

## 一处脚手架 bug（自己的，已修）

从 `beforeEach`（每条用例一个 `:memory:` driver）改成 `beforeAll`（live cell 承担不起每条断言一个连接）之后，`nondeterministicPagingWarned` 这个「每个 object 只警告一次」的账本开始跨用例共享，导致 `says so, once, ...` 数到 0 次。修法是给那条用例自己的 object 名，而不是去清账本 —— 属于 issue 里说的「红的是脚手架自身，那是你的 bug」。

## 关联

#4245 / PR #4713（driver 轴 + server-timezone 轴，temporal 矩阵）、#4081、#4363、objectui#3106、#3774、#4646；ADR-0053 D-A3。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Br2xsJsczFsTR9bvbh2Ny

---
_Generated by [Claude Code](https://claude.ai/code/session_015Br2xsJsczFsTR9bvbh2Ny)_