### PR TITLE
fix(service-messaging): SQL outbox 的 UPDATE 不再写 `updated_at` —— `pnpm dev` 控制台停止刷屏 (#4765)

### DIFF
--- a/.changeset/messaging-outbox-no-updated-at-on-update.md
+++ b/.changeset/messaging-outbox-no-updated-at-on-update.md
@@ -1,0 +1,31 @@
+---
+'@objectstack/service-messaging': patch
+---
+
+fix(service-messaging): stop the SQL outboxes from writing `updated_at` on UPDATE — `pnpm dev` no longer floods the console
+
+An idle dev server printed the same warning 48 times a second, forever:
+
+```
+WARN Field 'updated_at' is read-only — ignoring incoming change (#2948)
+```
+
+`SqlNotificationOutbox.claim()` / `.claimDigest()` and `SqlHttpOutbox.claim()`
+open with an unconditional "reap stale in_flight" UPDATE — visibility-timeout
+recovery that runs on every dispatcher tick whether or not any row is actually
+stale — and every one of those payloads carried `updated_at`. That column is
+`readonly` and owned by ObjectQL's builtin `sys_stamp_audit_update` hook, so the
+value was stripped by `stripReadonlyFields` and re-stamped by the platform: a
+no-op write that cost one warning per call. Three claim paths × 8 partitions ×
+the dispatcher's 500 ms tick = 48 identical lines a second, which buried every
+real warning and error in the dev log.
+
+`updated_at` is now gone from every UPDATE payload in both outboxes (`claim`,
+`claimDigest`, `ack`, `redeliver`); the platform hook keeps stamping it, so
+stored rows are unchanged. INSERT still writes both audit columns, as `Date`s —
+`created_at` is caller-owned there, and a native `TIMESTAMP` column rejects a
+bare epoch-ms number on Postgres.
+
+That last point was also a latent bug this removes: `enqueue()` correctly used
+`new Date()`, but the UPDATE paths passed epoch-ms numbers. Nothing broke only
+because the strip discarded them before they reached the driver.

--- a/packages/services/service-messaging/src/sql-http-outbox.ts
+++ b/packages/services/service-messaging/src/sql-http-outbox.ts
@@ -63,6 +63,13 @@ interface DeliveryRow {
  * `UPDATE WHERE status='pending'` for the exactly-once claim; precomputed
  * `partition_key`; SELECT-then-INSERT dedup converging on the unique index).
  * Dedup uniqueness is `(source, dedup_key)`; partition affinity is on `ref_id`.
+ *
+ * **No UPDATE here writes `updated_at`** (#4765) — same rule, same reason as
+ * {@link SqlNotificationOutbox}: the platform's `sys_stamp_audit_update` hook
+ * owns that column, a caller-supplied value is stripped as `readonly` (#2948)
+ * with a WARN per call, and `claim()`'s unconditional reap UPDATE runs on every
+ * dispatcher tick — so writing it turned an idle dev server into a console
+ * firehose while changing nothing about the stored row.
  */
 export class SqlHttpOutbox implements IHttpOutbox {
     private readonly objectName: string;
@@ -127,7 +134,7 @@ export class SqlHttpOutbox implements IHttpOutbox {
         // 1. Reap stale in_flight rows — visibility-timeout recovery.
         await this.engine.update(
             this.objectName,
-            { status: 'pending', claimed_by: null, claimed_at: null, updated_at: now },
+            { status: 'pending', claimed_by: null, claimed_at: null },
             {
                 where: {
                     status: 'in_flight',
@@ -155,7 +162,7 @@ export class SqlHttpOutbox implements IHttpOutbox {
         // 3. Atomic claim. WHERE status='pending' rejects rows another worker took.
         await this.engine.update(
             this.objectName,
-            { status: 'in_flight', claimed_by: opts.nodeId, claimed_at: now, updated_at: now },
+            { status: 'in_flight', claimed_by: opts.nodeId, claimed_at: now },
             { where: { id: { $in: ids }, status: 'pending' }, multi: true },
         );
 
@@ -205,7 +212,6 @@ export class SqlHttpOutbox implements IHttpOutbox {
                 response_body: result.responseBody ?? null,
                 next_retry_at: nextRetryAt,
                 error,
-                updated_at: now,
             },
             { where: { id }, multi: false },
         );
@@ -230,7 +236,6 @@ export class SqlHttpOutbox implements IHttpOutbox {
                 'DELIVERY_NOT_ELIGIBLE',
             );
         }
-        const now = Date.now();
         await this.engine.update(
             this.objectName,
             {
@@ -243,7 +248,6 @@ export class SqlHttpOutbox implements IHttpOutbox {
                 response_code: null,
                 response_body: null,
                 error: null,
-                updated_at: now,
             },
             { where: { id, status: { $in: ['success', 'failed', 'dead'] } }, multi: false },
         );

--- a/packages/services/service-messaging/src/sql-outbox-audit-columns.test.ts
+++ b/packages/services/service-messaging/src/sql-outbox-audit-columns.test.ts
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #4765 — the SQL outboxes must never put `updated_at` in an UPDATE payload.
+ *
+ * ObjectQL's builtin `sys_stamp_audit_update` hook owns that column on every
+ * update, and the column is `readonly`, so a caller-supplied value is stripped
+ * by `stripReadonlyFields` (#2948) — which WARNs once per call. `claim()` and
+ * `claimDigest()` open with an unconditional "reap stale in_flight" UPDATE that
+ * runs on every dispatcher tick whether or not a row is stale, so the write was
+ * both a no-op (stripped, then re-stamped) and, at 3 claim paths × 8 partitions
+ * × a 500 ms tick, 48 identical warnings a second on an idle `pnpm dev`.
+ *
+ * INSERT is a different path (no strip, and `created_at` IS caller-owned): it
+ * keeps writing both audit columns, as `Date`s — a native TIMESTAMP column
+ * rejects a bare epoch-ms number on Postgres (see `audit-timestamp.ts`).
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { IDataEngine } from '@objectstack/spec/contracts';
+import { SqlNotificationOutbox } from './sql-outbox.js';
+import { SqlHttpOutbox } from './sql-http-outbox.js';
+
+interface RecordedUpdate {
+    object: string;
+    data: Record<string, unknown>;
+}
+
+/**
+ * Minimal recording `IDataEngine`. `find` replays a scripted queue of result
+ * sets so a claim can be driven all the way through candidate-select →
+ * atomic-claim → read-back; everything else is inert.
+ */
+function makeEngine(findResults: Array<Array<Record<string, unknown>>> = []) {
+    const updates: RecordedUpdate[] = [];
+    const inserts: Array<{ object: string; data: Record<string, unknown> }> = [];
+    let findCall = 0;
+
+    const engine = {
+        async insert(object: string, data: Record<string, unknown>) {
+            inserts.push({ object, data });
+            return data;
+        },
+        async update(object: string, data: Record<string, unknown>) {
+            updates.push({ object, data });
+            return { matched: 0, modified: 0 };
+        },
+        async find(_object: string) {
+            return findResults[findCall++] ?? [];
+        },
+        async findOne(_object: string, opts?: { fields?: string[] }) {
+            // `ack()` reads the current attempt count; `enqueue()` probes for a
+            // dedup winner and must miss so the insert path runs.
+            if (opts?.fields?.includes('attempts')) return { attempts: 2 };
+            return null;
+        },
+        async delete() { return { matched: 0, modified: 0 }; },
+    } as unknown as IDataEngine;
+
+    return { engine, updates, inserts };
+}
+
+/** Every audit column an UPDATE payload must leave to the platform. */
+const PLATFORM_OWNED_ON_UPDATE = ['updated_at'];
+
+function expectNoPlatformAuditColumns(updates: RecordedUpdate[]) {
+    expect(updates.length).toBeGreaterThan(0);
+    for (const u of updates) {
+        for (const column of PLATFORM_OWNED_ON_UPDATE) {
+            expect(
+                Object.prototype.hasOwnProperty.call(u.data, column),
+                `UPDATE on ${u.object} must not write '${column}' — keys: ${Object.keys(u.data).join(', ')}`,
+            ).toBe(false);
+        }
+    }
+}
+
+describe('SqlNotificationOutbox — audit columns on UPDATE (#4765)', () => {
+    it('claim() writes no updated_at (reap + atomic claim)', async () => {
+        // find #1 → candidate ids; find #2 → read-back of the rows we own.
+        const { engine, updates } = makeEngine([[{ id: 'd1' }], []]);
+        const outbox = new SqlNotificationOutbox(engine, { partitionCount: 8 });
+
+        await outbox.claim({ nodeId: 'n1', limit: 10, claimTtlMs: 1000 });
+
+        // Both the unconditional reap and the atomic claim ran.
+        expect(updates).toHaveLength(2);
+        expectNoPlatformAuditColumns(updates);
+        // The claim still stamps its OWN columns — this is not a blanket strip.
+        expect(updates[1].data).toMatchObject({ status: 'in_flight', claimed_by: 'n1' });
+        expect(updates[1].data.claimed_at).toEqual(expect.any(Number));
+    });
+
+    it('claim() writes no updated_at even when nothing is claimable', async () => {
+        // The reap UPDATE fires on every tick regardless — that is the firehose.
+        const { engine, updates } = makeEngine([[]]);
+        const outbox = new SqlNotificationOutbox(engine, { partitionCount: 8 });
+
+        await outbox.claim({ nodeId: 'n1', limit: 10, claimTtlMs: 1000 });
+
+        expect(updates).toHaveLength(1);
+        expectNoPlatformAuditColumns(updates);
+    });
+
+    it('claimDigest() writes no updated_at', async () => {
+        const { engine, updates } = makeEngine([[{ id: 'd1' }], []]);
+        const outbox = new SqlNotificationOutbox(engine, { partitionCount: 8 });
+
+        await outbox.claimDigest({ nodeId: 'n1', limit: 10, claimTtlMs: 1000 });
+
+        expect(updates).toHaveLength(2);
+        expectNoPlatformAuditColumns(updates);
+    });
+
+    it('ack() writes no updated_at but still bumps its own columns', async () => {
+        const { engine, updates } = makeEngine();
+        const outbox = new SqlNotificationOutbox(engine, { partitionCount: 8 });
+
+        await outbox.ack('d1', { success: false, error: 'boom', nextAttemptAt: 123 });
+
+        expectNoPlatformAuditColumns(updates);
+        expect(updates[0].data).toMatchObject({
+            status: 'pending',
+            attempts: 3, // 2 (read back) + 1
+            error: 'boom',
+            next_attempt_at: 123,
+        });
+    });
+
+    it('enqueue() still writes both audit columns as Dates on INSERT', async () => {
+        const { engine, inserts } = makeEngine();
+        const outbox = new SqlNotificationOutbox(engine, { partitionCount: 8 });
+
+        await outbox.enqueue({ notificationId: 'n1', recipientId: 'u1', channel: 'email', payload: {} });
+
+        expect(inserts).toHaveLength(1);
+        expect(inserts[0].data.created_at).toBeInstanceOf(Date);
+        expect(inserts[0].data.updated_at).toBeInstanceOf(Date);
+    });
+});
+
+describe('SqlHttpOutbox — audit columns on UPDATE (#4765)', () => {
+    const enqueueInput = {
+        source: 'flow',
+        refId: 'r1',
+        dedupKey: 'd1',
+        url: 'https://example.test/hook',
+        payload: { hello: 'world' },
+    };
+
+    it('claim() writes no updated_at (reap + atomic claim)', async () => {
+        const { engine, updates } = makeEngine([[{ id: 'h1' }], []]);
+        const outbox = new SqlHttpOutbox(engine, { partitionCount: 8 });
+
+        await outbox.claim({ nodeId: 'n1', limit: 10, claimTtlMs: 1000 });
+
+        expect(updates).toHaveLength(2);
+        expectNoPlatformAuditColumns(updates);
+        expect(updates[1].data).toMatchObject({ status: 'in_flight', claimed_by: 'n1' });
+    });
+
+    it('claim() writes no updated_at even when nothing is claimable', async () => {
+        const { engine, updates } = makeEngine([[]]);
+        const outbox = new SqlHttpOutbox(engine, { partitionCount: 8 });
+
+        await outbox.claim({ nodeId: 'n1', limit: 10, claimTtlMs: 1000 });
+
+        expect(updates).toHaveLength(1);
+        expectNoPlatformAuditColumns(updates);
+    });
+
+    it('ack() writes no updated_at but still bumps its own columns', async () => {
+        const { engine, updates } = makeEngine();
+        const outbox = new SqlHttpOutbox(engine, { partitionCount: 8 });
+
+        await outbox.ack('h1', {
+            success: false,
+            error: 'boom',
+            httpStatus: 503,
+            nextRetryAt: 456,
+            durationMs: 12,
+        });
+
+        expectNoPlatformAuditColumns(updates);
+        expect(updates[0].data).toMatchObject({
+            status: 'pending',
+            attempts: 3,
+            error: 'boom',
+            response_code: 503,
+            next_retry_at: 456,
+        });
+    });
+
+    it('enqueue() still writes both audit columns as Dates on INSERT', async () => {
+        const { engine, inserts } = makeEngine();
+        const outbox = new SqlHttpOutbox(engine, { partitionCount: 8 });
+
+        await outbox.enqueue(enqueueInput);
+
+        expect(inserts).toHaveLength(1);
+        expect(inserts[0].data.created_at).toBeInstanceOf(Date);
+        expect(inserts[0].data.updated_at).toBeInstanceOf(Date);
+    });
+});

--- a/packages/services/service-messaging/src/sql-outbox.ts
+++ b/packages/services/service-messaging/src/sql-outbox.ts
@@ -53,6 +53,18 @@ interface DeliveryRow {
  * `UPDATE … WHERE status='pending'` claim. `partition_key` is precomputed on
  * enqueue (ObjectQL has no portable `hash()` in WHERE). Mirrors
  * `SqlWebhookOutbox`.
+ *
+ * **No UPDATE here writes `updated_at`** (#4765). ObjectQL's builtin
+ * `sys_stamp_audit_update` hook stamps it on every update unconditionally, and
+ * `updated_at` is `readonly`, so a caller-supplied value is stripped by
+ * `stripReadonlyFields` (#2948) before it reaches the driver — with a WARN per
+ * call. `claim()` / `claimDigest()` start with an unconditional reap UPDATE that
+ * runs whether or not a row is stale, so on an idle dev server the three claim
+ * paths × 8 partitions × a 500 ms dispatcher tick spammed 48 identical warnings
+ * a second and drowned the console. Writing the column was already a no-op
+ * (stripped, then re-stamped); passing it as epoch-ms would also have been the
+ * wrong shape for a native TIMESTAMP column (see `toEpochMs`) had it ever
+ * survived the strip. Leave it to the platform.
  */
 export class SqlNotificationOutbox implements INotificationOutbox {
     private readonly objectName: string;
@@ -114,7 +126,7 @@ export class SqlNotificationOutbox implements INotificationOutbox {
         // 1. Reap stale in_flight rows (visibility-timeout recovery).
         await this.engine.update(
             this.objectName,
-            { status: 'pending', claimed_by: null, claimed_at: null, updated_at: now },
+            { status: 'pending', claimed_by: null, claimed_at: null },
             { where: { status: 'in_flight', claimed_at: { $lt: now - opts.claimTtlMs } }, multi: true } as any,
         );
 
@@ -137,7 +149,7 @@ export class SqlNotificationOutbox implements INotificationOutbox {
         // 3. Atomic claim — WHERE status='pending' rejects rows another worker took.
         await this.engine.update(
             this.objectName,
-            { status: 'in_flight', claimed_by: opts.nodeId, claimed_at: now, updated_at: now },
+            { status: 'in_flight', claimed_by: opts.nodeId, claimed_at: now },
             { where: { id: { $in: ids }, status: 'pending' }, multi: true } as any,
         );
 
@@ -154,7 +166,7 @@ export class SqlNotificationOutbox implements INotificationOutbox {
         // 1. Reap stale in_flight (same as claim).
         await this.engine.update(
             this.objectName,
-            { status: 'pending', claimed_by: null, claimed_at: null, updated_at: now },
+            { status: 'pending', claimed_by: null, claimed_at: null },
             { where: { status: 'in_flight', claimed_at: { $lt: now - opts.claimTtlMs } }, multi: true } as any,
         );
 
@@ -177,7 +189,7 @@ export class SqlNotificationOutbox implements INotificationOutbox {
         // 3. Atomic claim.
         await this.engine.update(
             this.objectName,
-            { status: 'in_flight', claimed_by: opts.nodeId, claimed_at: now, updated_at: now },
+            { status: 'in_flight', claimed_by: opts.nodeId, claimed_at: now },
             { where: { id: { $in: ids }, status: 'pending' }, multi: true } as any,
         );
 
@@ -224,7 +236,6 @@ export class SqlNotificationOutbox implements INotificationOutbox {
                 claimed_at: null,
                 next_attempt_at: nextAttemptAt,
                 error,
-                updated_at: now,
             },
             { where: { id }, multi: false } as any,
         );


### PR DESCRIPTION
Closes #4765.

## 现象

`pnpm dev`（showcase）启动后，控制台**永远停不下来**地循环输出同一行 WARN，稳定 **48 行/秒**：

```
2026-08-03T03:49:37.101Z WARN Field 'updated_at' is read-only — ignoring incoming change (#2948)
```

空闲、没人访问、没有浏览器连上来的 dev server 也照刷不误。真正的 warn / error 瞬间被冲走。

## 根因

告警来自 `stripReadonlyFields`（`packages/objectql/src/validation/rule-validator.ts`，#2948）：调用方在非 system 上下文的 UPDATE 里显式带了 `readonly` 字段，平台剥掉它并 warn 一次。

用 `--stack-trace-limit=80` 抓到的调用方是 `@objectstack/service-messaging` 的两个 SQL outbox：

- `SqlNotificationOutbox.claim`
- `SqlNotificationOutbox.claimDigest`
- `SqlHttpOutbox.claim`

三处 `claim*()` 的第一步都是**无条件的「reap stale in_flight」谓词 UPDATE**（visibility-timeout 回收），payload 里带了 `updated_at`。而 `stripReadonlyFields` 是按 **payload 的字段**告警的，不看命中了几行 —— 所以哪怕 outbox 是空的、一行都没 reap 到，每次调用照样 warn 一次。

算式正好对得上：`NotificationDispatcher` 每 tick 跑 `claim` + `claimDigest`，`HttpDispatcher` 每 tick 跑 `claim`，各自遍历 8 个 partition → 每 tick `(2 + 1) × 8 = 24` 次；dispatcher 默认 `intervalMs = 500` → **48 行/秒**。

而 `updated_at` 本来就轮不到调用方写：ObjectQL 内建 hook `sys_stamp_audit_update` 在每一次 update 上无条件盖 `record.updated_at = now`。outbox 传的值是**先被剥掉、再被平台盖回去** —— 纯冗余，行为上完全是 no-op，只剩噪音。

## 改动

从两个 outbox 的**所有 UPDATE payload** 里删掉 `updated_at`（`claim` / `claimDigest` / `ack` / `redeliver`），交给平台 hook 盖。存进去的行没有任何变化。

INSERT 路径（`enqueue()`）**不动**：那里 `created_at` 是调用方拥有的，且 insert 不走 `stripReadonlyFields`，两个审计列继续写成 `Date`。

两个类的 docstring 里都留了原因（#4765 + #2948 + 那个 48/秒的算式），免得下一个作者"好心"把字段加回来。

### 顺带清掉的一个隐患

`packages/services/service-messaging/src/audit-timestamp.ts` 写得很清楚：`created_at` / `updated_at` 在 Postgres/MySQL 上是原生 `TIMESTAMP` 列，**必须写 `Date`，写裸 epoch-ms 数字会被真·timestamp 列拒绝**（就是当初弄坏 `sys_notification_delivery` 保留期清理的那个 bug）。

`enqueue()` 一直守着这条规矩（`const now = new Date()`），但 `claim()` / `claimDigest()` / `ack()` / `redeliver()` 传的是 `opts.now ?? Date.now()` —— epoch-ms **数字**。之所以没炸，仅仅因为它在 UPDATE 路径上被剥掉了，从没到达 driver。一旦这些写入哪天改走 system 上下文（system 上下文跳过剥离），这个数字就会直接落到 Postgres 上。删掉字段同时解决了这个。

顺带确认过 `DbQueueAdapter` 有同样形状的写法但**没有**这个问题：它的每一次写都带 `context: SYSTEM_CTX`，system 上下文本来就跳过剥离。messaging 的两个 outbox 是唯一没走 system 上下文的那个。

## 测试

新增 `packages/services/service-messaging/src/sql-outbox-audit-columns.test.ts`（9 例）：用一个记录型的假 `IDataEngine` 断言两个 outbox 交给 engine 的 UPDATE payload 里不出现 `updated_at`，同时锁住

- **「一行都不可 claim」的场景** —— 无条件 reap 正是刷屏的来源，这一例专门盯它；
- claim 仍然写自己的列（`status` / `claimed_by` / `claimed_at`），不是无差别地删；
- `ack()` 仍然递增 `attempts`、写 `error` / `next_attempt_at`；
- INSERT 仍写两个审计列，且是 `Date` 实例。

把 `updated_at` 加回任一处，测试就红（已实测：2 failed）。

```
pnpm --filter @objectstack/service-messaging test       # 15 files, 160 passed
pnpm --filter @objectstack/service-messaging typecheck  # clean
eslint packages/services/service-messaging/src          # clean
```

## 真机验证

在真实 `pnpm dev`（`examples/app-showcase`）上跑过：

| | 输出行数 | 其中该条 WARN |
|---|---|---|
| 修复前（120s） | 5469 | **5378** |
| 修复后（90s） | 102 | **0** |

修复后启动完成（约 4 秒）之后控制台**不再有任何输出**，直到 Ctrl+C。

## 不在本 PR 范围内

修复后剩下的 102 行全是一次性的启动诊断，都是既有的、与本 bug 无关的问题，没有一条会循环：

- showcase 种子数据里 `showcase_task.cover` 的 image 值不是 opaque `sys_file` id → 10 条记录写入失败；
- 8 个 flow 引用了没有注册 executor 的 `approval` 节点类型；
- `showcase.export_data` capability 没有 owning package。

看着都值得单独开 issue，但塞进这个 PR 只会让 diff 失焦。

---
_Generated by [Claude Code](https://claude.ai/code/session_018ipMgdweHC9LFSUdLByizr)_