### PR TITLE
fix(service-storage): 无作用域的 sys_attachment 多行删除改为失败关闭 (#4757)

### DIFF
--- a/.changeset/attachment-unscoped-multi-delete.md
+++ b/.changeset/attachment-unscoped-multi-delete.md
@@ -1,0 +1,37 @@
+---
+"@objectstack/service-storage": patch
+---
+
+fix(service-storage): an UNSCOPED multi-delete of `sys_attachment` is refused instead of authorized (#4757)
+
+`installAttachmentAccessHooks`'s `beforeDelete` gate resolved the rows a delete
+matches in two ways — by `input.id`, or by `input.options.where` — and then
+short-circuited with `if (!rows.length) return`. A delete carrying **neither**
+an id **nor** a `where` took neither branch, so `rows` stayed empty and the gate
+returned *allow*. That is not "nothing matched": nothing was ever queried.
+
+The engine reads the same call as a bulk delete over everything — with no
+single id it seeds the delete AST as `{ object }` and hands that to
+`driver.deleteMany` — so `ql.delete('sys_attachment', { multi: true })` emptied
+the whole attachment table with the record-level gate having authorized exactly
+zero rows. Neither layer underneath catches it: plugin-sharing composes no
+row-scoping predicate for an object with no owner field (`sys_attachment`'s
+provenance column is `uploaded_by`), and plugin-security only refuses callers
+whose grants lack the delete bit on `sys_attachment` — an app shipping the
+domain grant the attachments panel requires passes RBAC and lands here.
+
+The gate now fails **closed** on that shape: no id and no `where` is refused
+with 403 `ATTACHMENT_DELETE_DENIED` ("Refusing an unscoped multi-delete of
+attachments — scope the delete to the rows you mean"), the posture #4630 gave
+`sys_comment` in `resolveTargetRows`. "Nothing to authorize" and "nothing was
+ever queried" are different verdicts, and reading the second as the first is
+fail-open.
+
+Scoped deletes are unchanged: an id-bound delete, a `where`-bound multi-delete,
+and even `where: {}` (which matches every row but is a real query) still resolve
+their rows and authorize each one uploader-or-parent-editor as before — a delete
+that legitimately matches no row still passes. Only the predicate-less call is
+newly refused. If you were relying on `ql.delete('sys_attachment', { multi:
+true })` to clear the table, pass a predicate (`{ multi: true, where: {} }`
+authorizes row-by-row) or perform the sweep under a system context, which
+bypasses the gate as before.

--- a/packages/services/service-storage/src/attachment-access-hooks.test.ts
+++ b/packages/services/service-storage/src/attachment-access-hooks.test.ts
@@ -198,4 +198,73 @@ describe('attachment access — beforeDelete (uploader or parent editor)', () =>
     await expect(beforeDelete(deleteCtx({ id: 'a1' }, { isSystem: true, userId: 'x' }))).resolves.toBeUndefined();
     await expect(beforeDelete(deleteCtx({ id: 'missing' }, { userId: 'x' }))).resolves.toBeUndefined();
   });
+
+  // #4757 — no id AND no `where` is not "nothing matched", it is "nothing was
+  // ever queried": the engine seeds `{ object }` as the delete AST and hands
+  // it to `driver.deleteMany`, which empties the table. The gate must refuse
+  // rather than fall through the empty-`rows` short-circuit.
+  describe('unscoped multi-delete (no id, no where) — #4757', () => {
+    const unscopedShapes: Array<[string, any]> = [
+      ['options.multi with no where', { options: { multi: true } }],
+      ['no id and no options at all', {}],
+      ['an explicitly null where', { options: { multi: true, where: null } }],
+      ['an explicitly undefined where', { options: { multi: true, where: undefined } }],
+    ];
+
+    for (const [label, input] of unscopedShapes) {
+      it(`refuses ${label} (403 ATTACHMENT_DELETE_DENIED)`, async () => {
+        const { beforeDelete } = install({ attachments: [row], sharing: { canEdit: async () => true } });
+        await expect(beforeDelete(deleteCtx(input, { userId: 'uploader' }))).rejects.toMatchObject({
+          code: 'ATTACHMENT_DELETE_DENIED',
+          status: 403,
+        });
+      });
+    }
+
+    it('refuses even the uploader of every matched row — the AST is unscoped, not row-scoped', async () => {
+      // The uploader shortcut is per RESOLVED row; with nothing resolved there
+      // is no row whose ownership could license emptying the table.
+      const canEdit = vi.fn(async () => true);
+      const { beforeDelete } = install({
+        attachments: [{ ...row, uploaded_by: 'uploader' }],
+        sharing: { canEdit },
+      });
+      await expect(
+        beforeDelete(deleteCtx({ options: { multi: true } }, { userId: 'uploader' })),
+      ).rejects.toMatchObject({ code: 'ATTACHMENT_DELETE_DENIED' });
+      expect(canEdit).not.toHaveBeenCalled();
+    });
+
+    it('still bypasses for system context and context-less calls', async () => {
+      const { beforeDelete } = install({ attachments: [row], sharing: { canEdit: async () => false } });
+      await expect(
+        beforeDelete(deleteCtx({ options: { multi: true } }, { isSystem: true, userId: 'x' })),
+      ).resolves.toBeUndefined();
+      await expect(beforeDelete(deleteCtx({ options: { multi: true } }, {}))).resolves.toBeUndefined();
+    });
+
+    // The scoped paths must be untouched by the fix: an id-bound delete and a
+    // `where`-bound one still authorize row-by-row and still ALLOW when they
+    // pass. `where: {}` matches every row but is a real query — every matched
+    // row is authorized, so it stays on the authorize path, not the refuse one.
+    it('leaves the legitimate scoped paths alone', async () => {
+      const { beforeDelete } = install({ attachments: [row], sharing: { canEdit: async () => true } });
+      await expect(beforeDelete(deleteCtx({ id: 'a1' }, { userId: 'stranger' }))).resolves.toBeUndefined();
+      await expect(
+        beforeDelete(
+          deleteCtx({ options: { where: { parent_object: 'att_secret' }, multi: true } }, { userId: 'stranger' }),
+        ),
+      ).resolves.toBeUndefined();
+      await expect(
+        beforeDelete(deleteCtx({ options: { where: {}, multi: true } }, { userId: 'stranger' })),
+      ).resolves.toBeUndefined();
+    });
+
+    it('an empty `where` still authorizes every matched row (one failing row denies)', async () => {
+      const { beforeDelete } = install({ attachments: [row], sharing: { canEdit: async () => false } });
+      await expect(
+        beforeDelete(deleteCtx({ options: { where: {}, multi: true } }, { userId: 'stranger' })),
+      ).rejects.toMatchObject({ code: 'ATTACHMENT_DELETE_DENIED' });
+    });
+  });
 });

--- a/packages/services/service-storage/src/attachment-access-hooks.ts
+++ b/packages/services/service-storage/src/attachment-access-hooks.ts
@@ -25,7 +25,10 @@ import type {
  *  - beforeDelete: the caller must be the uploader OR hold edit on the
  *    parent record (sharing service's `canEdit`; public-model parents are
  *    editable by design). Fail-closed 403 `ATTACHMENT_DELETE_DENIED`; a
- *    multi-delete requires EVERY matched row to pass.
+ *    multi-delete requires EVERY matched row to pass, and one carrying
+ *    NEITHER an id NOR a `where` is refused outright (#4757) — the engine
+ *    would hand `deleteMany` an AST over the whole table, and a gate that
+ *    resolved no rows for it would be authorizing exactly that.
  *
  * System-context operations (engine self-writes, seeds, lifecycle sweeps)
  * bypass both gates, as do context-less programmatic calls on bare kernels
@@ -151,9 +154,22 @@ export function installAttachmentAccessHooks(
           const row = await engine.findOne('sys_attachment', { where: { id }, context: { ...SYSTEM_CTX } });
           if (row) rows.push(row);
         }
-      } else if (ctx?.input?.options?.where) {
+      } else {
+        const where = ctx?.input?.options?.where;
+        if (where === undefined || where === null) {
+          // #4757 — no id AND no predicate: the engine hands `deleteMany` an
+          // AST of `{ object }`, i.e. the WHOLE table. Falling through here
+          // would authorize that by resolving zero rows, so refuse instead.
+          // "Nothing to authorize" and "nothing was ever queried" are not the
+          // same verdict; reading the second as the first is fail-open.
+          // (Mirrors #4630's `resolveTargetRows` for sys_comment.)
+          forbid(
+            'ATTACHMENT_DELETE_DENIED',
+            'Refusing an unscoped multi-delete of attachments — scope the delete to the rows you mean (an id or a where predicate)',
+          );
+        }
         rows = await engine.find('sys_attachment', {
-          where: ctx.input.options.where,
+          where,
           limit: MULTI_DELETE_AUTH_LIMIT + 1,
           context: { ...SYSTEM_CTX },
         });
@@ -164,7 +180,9 @@ export function installAttachmentAccessHooks(
           );
         }
       }
-      if (!rows.length) return; // nothing matched — nothing to authorize
+      // Reached only after a real resolve: the query ran and matched no row
+      // (or the ids name no live row), so there is genuinely nothing to gate.
+      if (!rows.length) return;
 
       const sharing = getSharing();
       const callerCtx = callerContext(ctx);


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4757

## 问题

`packages/services/service-storage/src/attachment-access-hooks.ts` 的 `beforeDelete` 守卫用两条路径解析「这次删除命中了哪些行」——按 `input.id`,或按 `input.options.where`——然后 `if (!rows.length) return`。

**既没有 id 也没有 `where`** 的删除两条分支都不进,`rows` 保持为空,守卫返回*放行*。但这不是「没命中任何行」,而是**从来没有查询过** —— 两者是不同的判断,把后者当前者就是典型的 fail open。

engine 那边把同一次调用当作全表批删:`packages/objectql/src/engine.ts` 的 delete 路径在没有标量 id 时把 AST 播种成 `{ object }`(没有 `where`),再交给 `driver.deleteMany`。于是 `ql.delete('sys_attachment', { multi: true })` 会清空整张附件表,而记录级守卫恰好授权了**零行**。

下面两层都接不住:

- **plugin-sharing** —— `buildWriteFilter` 对没有 owner 字段的对象返回 `null`,而 `sys_attachment` 的来源列是 `uploaded_by` 不是 `owner_id`,所以 AST 上不会被合成任何行级作用域谓词。
- **plugin-security** —— `member_default` 基线不带 `allowDelete`(ADR-0090 D5),普通成员会先被 RBAC 拒掉;但只要 app 发了一份带 `sys_attachment` 删除位的领域授权(附件面板本来就需要,`attachmentsFixture` 的 `att_attachment_manager` 正是这么建模的),就能通过 RBAC 直接落到这条没有守卫的路径上。

## 改动

按 issue 的建议失败关闭,姿势照抄 #4630 给 `sys_comment` 立的 `resolveTargetRows`:无 id 且无 `where` ⇒ 403 `ATTACHMENT_DELETE_DENIED`,而不是穿过空 `rows` 短路。

合法路径**完全未动**,这一点专门写了回归用例:

- 按 id 删除 —— 照旧逐行做 uploader-or-parent-editor 判定;
- 带 `where` 的多行删除 —— 照旧解析匹配行集合(1000 行上界不变)并逐行判定;
- `where: {}` —— 它匹配所有行,但**是一次真实查询**,所以仍然走「逐行授权」而不是「拒绝」:每一行都过才放行,有一行不过就 403;
- 谓词跑了但一行都没匹配到 —— 仍然放行(这才是真正的「没有东西需要授权」);
- `isSystem` 与无 session 的程序化调用 —— 旁路不变。

`.changeset/attachment-unscoped-multi-delete.md` 里写了迁移说明:如果确有清空附件表的需求,传谓词(`{ multi: true, where: {} }`,逐行授权)或者在 system context 下做。

## 测试

`packages/services/service-storage/src/attachment-access-hooks.test.ts` 在既有 `beforeDelete` 用例旁边新增一组 `#4757` 用例。先验证过它们**在未修复的源码上会红**(回退 src、保留 test:5 failed | 16 passed),打上修复后:

```
pnpm --filter @objectstack/service-storage exec vitest run --maxWorkers=2
 Test Files  19 passed (19)
      Tests  260 passed (260)
```

类型侧:该包在 `scripts/check-type-check-coverage.mjs` 里是 DEBT 条目(42 errors,没有 `typecheck` 脚本),`tsc --noEmit` 实测仍是 **42**,本次改动的两个文件零错误;`pnpm --filter @objectstack/service-storage build`(含 DTS)通过。

## 同形状排查(issue 末尾那句)

按要求全仓扫了一遍「没解析到行 ⇒ 放行」这个形状(`beforeDelete` 与 `beforeUpdate` 一类守卫,检索 `registerHook('before*'`、`input?.id`、`options?.where`、`if (!id) return`、`if (!rows.length)` 等)。发现的其它位置**都没有在本 PR 里修**,按 Prime Directive #10 另立了未认领 issue:

- **#4778** —— `plugin-approvals` 的审批记录锁 `bindApprovalLockHook`:`beforeUpdate` 开头 `const id = ...; if (!id) return;`,而 engine 只在 `where.id` 是标量时才提取 `input.id`,所以任何 `multi: true` 的谓词式更新都直接绕过 `RECORD_LOCKED`。这是本次排查里最实的一条,和 #4757 是同一个错误推理。
- **#4779** —— `plugin-sharing` 的 `rule-hooks`:`afterInsert`/`afterUpdate` 同样 `if (!id) return`,批量更新后 `sys_record_share` 不重算,本应被收回的共享行留在表里(授权侧的陈旧 fail open)。里面留了一个需要维护者裁定的点(超上界时拒绝写入还是告警补偿)。

以下位置形状相同但**不是授权守卫**,后果是数据/可观测性而非越权,且多数在注释里已声明为已知边界,只在 #4778 正文里记录、未单独立 issue:`plugin-audit` 的 `captureBefore`(批量写不留审计快照,注释写明「too costly」)、`plugin-webhooks`/`plugin-email`/`plugin-sharing` 三处 provenance 盖章(注释均写明 known boundary)、`plugin-sharing` 的 `primary-bu-projection` `beforeDelete`(投影 best-effort,靠下次写入或 boot backfill 自愈)。

明确排除的:`plugin-auth` 的 `identity-write-guard` —— 它的 `beforeDelete` 是无条件拒绝、`beforeUpdate` 走字段白名单,不依赖行解析,不属于这个形状。

## 范围

改动只落在 `packages/services/service-storage/`。issue 正文引用的 `packages/objectql/src/engine.ts` delete 路径只作为背景阅读,**未改动**(本轮 #4769 正在改 objectql);`plugin-auth`、`service-automation`、`plugin-approvals` 也只读未改。


---
_Generated by [Claude Code](https://claude.ai/code/session_015Br2xsJsczFsTR9bvbh2Ny)_