### PR TITLE
fix(metadata-protocol): deleteMany/updateMany 的 atomic 要么为真、要么拒绝 (#4620)

### DIFF
--- a/.changeset/many-data-atomic-real-or-refused.md
+++ b/.changeset/many-data-atomic-real-or-refused.md
@@ -1,5 +1,5 @@
 ---
-"@objectstack/metadata-protocol": patch
+"@objectstack/metadata-protocol": minor
 ---
 
 fix(metadata-protocol): `deleteMany` / `updateMany` honour `atomic` for real, or refuse it (#4620)

--- a/.changeset/many-data-atomic-real-or-refused.md
+++ b/.changeset/many-data-atomic-real-or-refused.md
@@ -1,0 +1,40 @@
+---
+"@objectstack/metadata-protocol": patch
+---
+
+fix(metadata-protocol): `deleteMany` / `updateMany` honour `atomic` for real, or refuse it (#4620)
+
+ADR-0119 D4 made `batchData`'s `atomic` flag a real guarantee. Its two siblings
+in the same file were out of that PR's confirmed scope and kept the defect:
+
+- **`deleteManyData` was fake-atomic.** `atomic: true` opened no transaction; it
+  only `break`-ed the loop, so every row deleted before the failure stayed
+  **deleted** while the response called itself atomic and reported those rows
+  `success: true`. Worse than the `batchData` case it was copied from, because a
+  partial delete has no natural undo — a client cannot reconstruct the rows from
+  its own request.
+- **`updateManyData` ignored `atomic` entirely.** The option was accepted,
+  declared in `BatchOptionsSchema` with an all-or-nothing contract, and never
+  read: a caller asking for atomicity silently got best-effort, with no signal.
+
+Both now run the **same** atomic arm as `batchData`, extracted into one shared
+runner so a fourth copy of transaction handling cannot drift into a fourth lie:
+
+- `atomic: true` runs the whole batch inside ONE `engine.transaction()`; the
+  first failure rolls back every prior write.
+- A rolled-back batch reports **zero successes**. Rows that had succeeded are
+  marked `ROLLED_BACK: record <i> failed — <cause>`, rows never reached are
+  `NOT_ATTEMPTED: atomic batch aborted by record <i>`, and the causal row keeps
+  its own error — so a client can tell "attempted, undone" from "never ran".
+- `atomic` outranks `continueOnError`, whose contract text already scoped it to
+  `atomic=false`.
+
+**Behaviour change to be aware of:** a runtime that cannot roll back (no
+`engine.transaction()`, or a default driver without `beginTransaction`) now
+**refuses** an `atomic: true` `deleteMany` / `updateMany` with `501
+NOT_IMPLEMENTED` instead of silently running best-effort — the same fail-closed
+gate `batchData` uses. That silent downgrade is the defect class this fixes; if
+you want best-effort, ask for it (`atomic: false`, or omit the option), or probe
+the runtime's transaction support before sending. Non-atomic behaviour of both
+endpoints — including the `continueOnError` interaction and their response
+shapes — is unchanged.

--- a/packages/metadata-protocol/src/protocol.delete-many.test.ts
+++ b/packages/metadata-protocol/src/protocol.delete-many.test.ts
@@ -145,15 +145,19 @@ describe('deleteManyData — partial-failure semantics (#3897)', () => {
     expect(res).toMatchObject({ success: false, total: 3, succeeded: 2, failed: 1 });
   });
 
-  it('atomic aborts the remaining ids on the first failure', async () => {
+  // [#4620] This used to pin the fake-atomic: `atomic: true` merely broke the
+  // loop, so `a` stayed DELETED and the response reported `succeeded: 1` under
+  // a flag whose one job is to guarantee it was undone. On this engine — no
+  // `transaction()` at all — the honest answer is a refusal, not a half-batch.
+  // Real rollback is pinned in protocol.many-data-atomic.test.ts.
+  it('atomic REFUSES on an engine that cannot roll back, deleting nothing (#4620)', async () => {
     const { p, del } = failOn('b');
-    const res: any = await p.deleteManyData({
+    await expect(p.deleteManyData({
       object: 'invoice',
       ids: ['a', 'b', 'c'],
       options: { atomic: true, continueOnError: true },
-    } as any);
+    } as any)).rejects.toMatchObject({ status: 501, code: 'NOT_IMPLEMENTED' });
 
-    expect(del).toHaveBeenCalledTimes(2);
-    expect(res.succeeded).toBe(1);
+    expect(del).not.toHaveBeenCalled();
   });
 });

--- a/packages/metadata-protocol/src/protocol.many-data-atomic.test.ts
+++ b/packages/metadata-protocol/src/protocol.many-data-atomic.test.ts
@@ -1,0 +1,353 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// #4620 — `deleteManyData` and `updateManyData` get the same `atomic` contract
+// ADR-0119 D4 gave `batchData`: REAL or REFUSED, never silent best-effort.
+//
+// Before this, the two siblings of the fixed method — in the same file, sharing
+// its response type — were:
+//
+//   * `deleteManyData`: fake-atomic. `if (options?.atomic) break;` opened no
+//     transaction; every row deleted before the failure stayed deleted while the
+//     response called itself atomic. Worse than the `batchData` case it was
+//     copied from, because a partial delete has no natural undo — the caller
+//     cannot reconstruct the rows from the request.
+//   * `updateManyData`: `atomic` never appeared in the method at all. Accepted,
+//     never read, no signal — declared ≠ enforced on a write-path guarantee.
+//
+// The pins that matter most here are the STATE ones: `succeeded: 0` in a
+// response is cheap to produce; rows that are still readable after a failed
+// atomic delete are the actual guarantee. So the fake engine below is a real
+// little store with snapshot/restore transaction semantics, and each rollback
+// test reads the store back afterwards.
+
+import { describe, it, expect, vi } from 'vitest';
+import { ObjectStackProtocolImplementation } from './protocol.js';
+
+const SCHEMA = { name: 'invoice', fields: { title: { name: 'title', type: 'text' } } };
+
+/** Marks an update the fake engine should reject, so a failure lands at a chosen index. */
+const POISON = '__explode__';
+
+/**
+ * A fake engine backed by an in-memory store whose `transaction()` mirrors the
+ * real `ObjectQL.transaction` contract: run the callback on a handle-carrying
+ * context, COMMIT on resolve, ROLL BACK (restore the pre-call snapshot) and
+ * re-throw on reject. Anything that survives a rollback here would survive it
+ * in a database too.
+ */
+function makeStoreEngine(opts: { driverCanTransact?: boolean; hasTransaction?: boolean } = {}) {
+    const { driverCanTransact = true, hasTransaction = true } = opts;
+    const rows = new Map<string, any>([
+        ['a', { id: 'a', title: 'a-old' }],
+        ['b', { id: 'b', title: 'b-old' }],
+        ['c', { id: 'c', title: 'c-old' }],
+    ]);
+    const commits: unknown[] = [];
+    const rollbacks: unknown[] = [];
+    const handle = { id: 'trx-1' };
+
+    const update = vi.fn(async (_object: string, data: any, options?: any) => {
+        const id = options?.where?.id;
+        const current = rows.get(id);
+        if (!current) throw new Error(`no such record: ${id}`);
+        if (data?.title === POISON) throw new Error('update exploded');
+        const next = { ...current, ...data };
+        rows.set(id, next);
+        return next;
+    });
+    // Contract per #4435: `false` is the positive not-found value.
+    const del = vi.fn(async (_object: string, options?: any) => {
+        const id = options?.where?.id;
+        if (!rows.has(id)) return false;
+        rows.delete(id);
+        return { deleted: 1 };
+    });
+
+    const engine: any = {
+        registry: { getObject: (n: string) => (n === 'invoice' ? SCHEMA : undefined) },
+        update,
+        delete: del,
+        findOne: vi.fn(async (_object: string, options?: any) => rows.get(options?.where?.id)),
+        getDefaultDriverName: () => 'default',
+        getDriverByName: () => (driverCanTransact ? { beginTransaction: async () => handle } : {}),
+    };
+    if (hasTransaction) {
+        engine.transaction = vi.fn(async (callback: (ctx: any) => Promise<any>, baseContext?: any) => {
+            const snapshot = new Map(rows);
+            const trxCtx = { ...(baseContext ?? {}), transaction: handle };
+            try {
+                const result = await callback(trxCtx);
+                commits.push(handle);
+                return result;
+            } catch (err) {
+                rows.clear();
+                for (const [k, v] of snapshot) rows.set(k, v);
+                rollbacks.push(handle);
+                throw err;
+            }
+        });
+    }
+    return { engine, update, del, rows, commits, rollbacks, handle };
+}
+
+describe('deleteManyData atomic — the deletes are actually undone (#4620)', () => {
+    it('rolls the whole batch back on the first failure: the earlier rows are STILL THERE', async () => {
+        const t = makeStoreEngine();
+        const p = new ObjectStackProtocolImplementation(t.engine);
+
+        // 'missing' does not exist, so `engine.delete` answers `false` and the
+        // row fails — after 'a' has already been deleted inside the transaction.
+        const res: any = await p.deleteManyData({
+            object: 'invoice',
+            ids: ['a', 'missing', 'c'],
+            options: { atomic: true },
+        } as any);
+
+        // THE CRUX. A partial delete has no natural undo, so this — not the
+        // response body — is what `atomic` was promising all along.
+        expect(t.rows.has('a')).toBe(true);
+        expect(t.rows.get('a')).toEqual({ id: 'a', title: 'a-old' });
+        expect(t.rows.has('c')).toBe(true);
+
+        expect(t.engine.transaction).toHaveBeenCalledTimes(1);
+        expect(t.rollbacks).toHaveLength(1);
+        expect(t.commits).toHaveLength(0);
+        expect(t.del).toHaveBeenCalledTimes(2); // 'c' never attempted
+
+        // Nothing persisted, so nothing may report success.
+        expect(res.success).toBe(false);
+        expect(res.succeeded).toBe(0);
+        expect(res.failed).toBe(3);
+        expect(res.total).toBe(3);
+        expect(res.results.every((r: any) => r.success === false)).toBe(true);
+
+        // A client must be able to tell "attempted, undone" from "never ran".
+        expect(res.results[0].id).toBe('a');
+        expect(res.results[0].error).toMatch(/^ROLLED_BACK:/);
+        expect(res.results[1].error).toMatch(/not found/i); // the causal row, verbatim
+        expect(res.results[2].error).toMatch(/^NOT_ATTEMPTED:/);
+    });
+
+    it('commits when every id deletes, and every delete runs on the transaction handle', async () => {
+        const t = makeStoreEngine();
+        const p = new ObjectStackProtocolImplementation(t.engine);
+
+        const res: any = await p.deleteManyData({
+            object: 'invoice',
+            ids: ['a', 'b'],
+            options: { atomic: true },
+            context: { userId: 'u1' },
+        } as any);
+
+        expect(t.commits).toHaveLength(1);
+        expect(t.rollbacks).toHaveLength(0);
+        expect(t.rows.has('a')).toBe(false);
+        expect(t.rows.has('b')).toBe(false);
+        expect(res).toMatchObject({ success: true, operation: 'delete', total: 2, succeeded: 2, failed: 0 });
+
+        // Writes must carry the OPEN transaction, not the caller's bare context —
+        // otherwise they commit outside the batch and a rollback would spare them.
+        for (const call of t.del.mock.calls) {
+            expect(call[1].context.transaction).toBe(t.handle);
+            expect(call[1].context.userId).toBe('u1');
+        }
+    });
+
+    it('atomic outranks continueOnError: the rest is never attempted and nothing lands', async () => {
+        const t = makeStoreEngine();
+        const p = new ObjectStackProtocolImplementation(t.engine);
+
+        const res: any = await p.deleteManyData({
+            object: 'invoice',
+            ids: ['missing', 'b', 'c'],
+            options: { atomic: true, continueOnError: true },
+        } as any);
+
+        expect(t.del).toHaveBeenCalledTimes(1);
+        expect(t.rows.size).toBe(3);
+        expect(res.succeeded).toBe(0);
+        expect(res.results[1].error).toMatch(/^NOT_ATTEMPTED:/);
+    });
+});
+
+describe('updateManyData atomic — the option is finally read (#4620)', () => {
+    it('rolls back prior updates to their previous values', async () => {
+        const t = makeStoreEngine();
+        const p = new ObjectStackProtocolImplementation(t.engine);
+
+        const res: any = await p.updateManyData({
+            object: 'invoice',
+            records: [
+                { id: 'a', data: { title: 'a-new' } },
+                { id: 'b', data: { title: POISON } },
+                { id: 'c', data: { title: 'c-new' } },
+            ],
+            options: { atomic: true },
+        } as any);
+
+        // Row 'a' DID update against the engine; the rollback restored it.
+        expect(t.rows.get('a')).toEqual({ id: 'a', title: 'a-old' });
+        expect(t.rows.get('c')).toEqual({ id: 'c', title: 'c-old' });
+
+        expect(t.engine.transaction).toHaveBeenCalledTimes(1);
+        expect(t.rollbacks).toHaveLength(1);
+        expect(t.update).toHaveBeenCalledTimes(2); // 'c' never attempted
+
+        expect(res.success).toBe(false);
+        expect(res.operation).toBe('update');
+        expect(res.succeeded).toBe(0);
+        expect(res.failed).toBe(3);
+        expect(res.results[0].id).toBe('a');
+        expect(res.results[0].error).toMatch(/^ROLLED_BACK:/);
+        expect(res.results[0].error).toContain('update exploded'); // carries the cause
+        expect(res.results[1].error).toBe('update exploded');      // the causal row, verbatim
+        expect(res.results[2].error).toMatch(/^NOT_ATTEMPTED:/);
+        // Nothing persisted, so no reverted write may be reported as a success
+        // or carry a record payload.
+        expect(res.results.every((r: any) => r.success === false)).toBe(true);
+    });
+
+    it('commits when every row updates, on the transaction handle', async () => {
+        const t = makeStoreEngine();
+        const p = new ObjectStackProtocolImplementation(t.engine);
+
+        const res: any = await p.updateManyData({
+            object: 'invoice',
+            records: [{ id: 'a', data: { title: 'a-new' } }, { id: 'b', data: { title: 'b-new' } }],
+            options: { atomic: true },
+            context: { userId: 'u1' },
+        } as any);
+
+        expect(t.commits).toHaveLength(1);
+        expect(t.rows.get('a')).toEqual({ id: 'a', title: 'a-new' });
+        expect(res).toMatchObject({ success: true, total: 2, succeeded: 2, failed: 0 });
+        for (const call of t.update.mock.calls) {
+            expect(call[2].context.transaction).toBe(t.handle);
+            expect(call[2].context.userId).toBe('u1');
+        }
+    });
+
+    it('atomic outranks continueOnError here too', async () => {
+        const t = makeStoreEngine();
+        const p = new ObjectStackProtocolImplementation(t.engine);
+
+        const res: any = await p.updateManyData({
+            object: 'invoice',
+            records: [
+                { id: 'a', data: { title: POISON } },
+                { id: 'b', data: { title: 'b-new' } },
+            ],
+            options: { atomic: true, continueOnError: true },
+        } as any);
+
+        expect(t.update).toHaveBeenCalledTimes(1);
+        expect(t.rows.get('b')).toEqual({ id: 'b', title: 'b-old' });
+        expect(res.succeeded).toBe(0);
+        expect(res.results[1].error).toMatch(/^NOT_ATTEMPTED:/);
+    });
+});
+
+describe('many-data atomic — refuses rather than degrading (#4620)', () => {
+    // The silent downgrade is the exact defect class this issue is about: a
+    // caller who asked for atomicity is precisely the caller who must not
+    // receive best-effort without being told.
+    for (const [label, opts] of [
+        ['the engine has no transaction()', { hasTransaction: false }],
+        ['the default driver cannot beginTransaction()', { driverCanTransact: false }],
+    ] as const) {
+        it(`deleteManyData refuses with 501 when ${label}, deleting nothing`, async () => {
+            const t = makeStoreEngine(opts);
+            const p = new ObjectStackProtocolImplementation(t.engine);
+
+            await expect(p.deleteManyData({
+                object: 'invoice', ids: ['a', 'b'], options: { atomic: true },
+            } as any)).rejects.toMatchObject({ status: 501, code: 'NOT_IMPLEMENTED' });
+
+            expect(t.del).not.toHaveBeenCalled();
+            expect(t.rows.size).toBe(3);
+        });
+
+        it(`updateManyData refuses with 501 when ${label}, updating nothing`, async () => {
+            const t = makeStoreEngine(opts);
+            const p = new ObjectStackProtocolImplementation(t.engine);
+
+            await expect(p.updateManyData({
+                object: 'invoice',
+                records: [{ id: 'a', data: { title: 'a-new' } }],
+                options: { atomic: true },
+            } as any)).rejects.toMatchObject({ status: 501, code: 'NOT_IMPLEMENTED' });
+
+            expect(t.update).not.toHaveBeenCalled();
+            expect(t.rows.get('a')).toEqual({ id: 'a', title: 'a-old' });
+        });
+    }
+});
+
+describe('many-data non-atomic — unchanged (#4620 regression net)', () => {
+    it('updateManyData opens no transaction and keeps prior successes when atomic is absent', async () => {
+        const t = makeStoreEngine();
+        const p = new ObjectStackProtocolImplementation(t.engine);
+
+        const res: any = await p.updateManyData({
+            object: 'invoice',
+            records: [
+                { id: 'a', data: { title: 'a-new' } },
+                { id: 'b', data: { title: POISON } },
+                { id: 'c', data: { title: 'c-new' } },
+            ],
+        } as any);
+
+        expect(t.engine.transaction).not.toHaveBeenCalled();
+        expect(t.rows.get('a')).toEqual({ id: 'a', title: 'a-new' }); // committed, and kept
+        expect(res).toMatchObject({ success: false, operation: 'update', total: 3, succeeded: 1, failed: 1 });
+        expect(res.results).toHaveLength(2); // stops without continueOnError
+        expect(res.results[0]).toMatchObject({ id: 'a', success: true });
+        expect(res.results[1]).toMatchObject({ id: 'b', success: false, error: 'update exploded' });
+    });
+
+    it('updateManyData continueOnError still processes every row', async () => {
+        const t = makeStoreEngine();
+        const p = new ObjectStackProtocolImplementation(t.engine);
+
+        const res: any = await p.updateManyData({
+            object: 'invoice',
+            records: [
+                { id: 'a', data: { title: POISON } },
+                { id: 'b', data: { title: 'b-new' } },
+                { id: 'c', data: { title: 'c-new' } },
+            ],
+            options: { continueOnError: true },
+        } as any);
+
+        expect(t.engine.transaction).not.toHaveBeenCalled();
+        expect(t.update).toHaveBeenCalledTimes(3);
+        expect(res).toMatchObject({ succeeded: 2, failed: 1 });
+    });
+
+    it('deleteManyData atomic:false is best-effort, not a refusal, even with no transaction()', async () => {
+        const t = makeStoreEngine({ hasTransaction: false });
+        const p = new ObjectStackProtocolImplementation(t.engine);
+
+        const res: any = await p.deleteManyData({
+            object: 'invoice', ids: ['a', 'missing', 'c'], options: { atomic: false, continueOnError: true },
+        } as any);
+
+        expect(t.del).toHaveBeenCalledTimes(3);
+        expect(t.rows.has('a')).toBe(false); // stays deleted — that is the contract when not atomic
+        expect(res).toMatchObject({ success: false, total: 3, succeeded: 2, failed: 1 });
+    });
+
+    it('updateManyData atomic:false is best-effort on a non-transactional engine too', async () => {
+        const t = makeStoreEngine({ hasTransaction: false });
+        const p = new ObjectStackProtocolImplementation(t.engine);
+
+        const res: any = await p.updateManyData({
+            object: 'invoice',
+            records: [{ id: 'a', data: { title: 'a-new' } }],
+            options: { atomic: false },
+        } as any);
+
+        expect(res.succeeded).toBe(1);
+        expect(t.rows.get('a')).toEqual({ id: 'a', title: 'a-new' });
+    });
+});

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -5349,6 +5349,41 @@ export class ObjectStackProtocolImplementation implements
         context: any;
     }): Promise<BatchUpdateResponse> {
         const { object, operation, records, options, batchSchema, context } = args;
+        return await this.runAtomicBatch({
+            object,
+            context,
+            runLoop: (trxCtx) => this.runBatchDataLoop({ object, operation, records, options, batchSchema, context: trxCtx, atomic: true }),
+            onCommit: (outcome) => this.buildBatchDataResponse(operation, records, options, outcome),
+            onRollback: (outcome) => this.buildRolledBackBatchResponse(operation, records, outcome),
+        });
+    }
+
+    /**
+     * The atomic arm, shared by every bulk-write surface on this protocol
+     * (#4620): `batchData` (ADR-0119 D4), `updateManyData` and
+     * `deleteManyData`.
+     *
+     * D4 fixed `batchData` alone, and its two siblings in this file carried the
+     * same class of defect — `deleteManyData` `break`-ed the loop and left every
+     * prior delete committed under a response that called itself atomic (worse
+     * than the `batchData` case: a partial delete has no natural undo), while
+     * `updateManyData` never read `atomic` at all. Fixed by giving all three ONE
+     * runner rather than a third and fourth copy of transaction handling —
+     * copies are exactly how the next sibling drifts back into a lie.
+     *
+     * Each caller supplies only what differs: the per-record loop, and the two
+     * response builders. Everything that makes `atomic` a guarantee — the
+     * fail-closed capability gate, the single `engine.transaction()`, the abort
+     * sentinel, the zero-successes rollback response — lives here, once.
+     */
+    private async runAtomicBatch(args: {
+        object: string;
+        context: any;
+        runLoop: (trxCtx: any) => Promise<BatchDataLoopOutcome>;
+        onCommit: (outcome: BatchDataLoopOutcome) => BatchUpdateResponse;
+        onRollback: (outcome: BatchDataLoopOutcome) => BatchUpdateResponse;
+    }): Promise<BatchUpdateResponse> {
+        const { object, context, runLoop, onCommit, onRollback } = args;
 
         // Two-level probe, shared with the ADR-0119 D2 migration-journal runner
         // as `engineCanRollBack` (#4617). `engine.transaction()` runs the
@@ -5389,16 +5424,16 @@ export class ObjectStackProtocolImplementation implements
         let aborted: BatchDataLoopOutcome | undefined;
         try {
             return await engineTx(async (trxCtx: any) => {
-                const outcome = await this.runBatchDataLoop({ object, operation, records, options, batchSchema, context: trxCtx, atomic: true });
+                const outcome = await runLoop(trxCtx);
                 if (outcome.failed > 0) {
                     aborted = outcome;
                     throw ABORT;
                 }
-                return this.buildBatchDataResponse(operation, records, options, outcome);
+                return onCommit(outcome);
             }, context);
         } catch (err) {
             if (err === ABORT && aborted) {
-                return this.buildRolledBackBatchResponse(operation, records, aborted);
+                return onRollback(aborted);
             }
             throw err;
         }
@@ -5550,7 +5585,11 @@ export class ObjectStackProtocolImplementation implements
      */
     private buildRolledBackBatchResponse(
         operation: BatchUpdateRequest['operation'],
-        records: BatchUpdateRequest['records'],
+        // Only `length` and `id` are read, so `updateManyData`'s rows and the
+        // id list `deleteManyData` rolls back reuse this verbatim (#4620) —
+        // the marking a client reconciles against must be one implementation,
+        // not three that agree today.
+        records: ReadonlyArray<{ id?: string }>,
         outcome: BatchDataLoopOutcome,
     ): BatchUpdateResponse {
         const attempted = outcome.results;
@@ -5661,7 +5700,46 @@ export class ObjectStackProtocolImplementation implements
     async updateManyData(request: UpdateManyDataRequest & { context?: any }): Promise<BatchUpdateResponse> {
         const { object, records, options, context } = request;
         this.assertObjectRegistered(object); // [#3770]
-        const results: Array<{ id?: string; success: boolean; error?: string; record?: any; droppedFields?: DroppedFieldsEvent[] }> = [];
+
+        // [#4620] `atomic` used not to appear ANYWHERE in this method: the
+        // option was accepted, declared in `BatchOptionsSchema` with a contract
+        // that promises all-or-nothing, and never read — a caller asking for
+        // atomicity silently got best-effort with no signal at all. Same
+        // enforcement shape as `batchData` (ADR-0119 D4), same runner, so the
+        // three bulk-write surfaces cannot drift apart again. `=== true` is the
+        // deliberate opt-in from D4: absent/false keeps today's semantics
+        // exactly.
+        if (options?.atomic === true) {
+            return await this.runAtomicBatch({
+                object,
+                context,
+                runLoop: (trxCtx) => this.runUpdateManyLoop({ object, records, options, context: trxCtx, atomic: true }),
+                onCommit: (outcome) => this.buildUpdateManyResponse(records, outcome),
+                onRollback: (outcome) => this.buildRolledBackBatchResponse('update', records, outcome),
+            });
+        }
+
+        const outcome = await this.runUpdateManyLoop({ object, records, options, context, atomic: false });
+        return this.buildUpdateManyResponse(records, outcome);
+    }
+
+    /**
+     * The per-record loop of {@link updateManyData}, shared by both arms
+     * (#4620) so atomic and non-atomic cannot drift apart. `atomic` changes
+     * exactly one thing: it aborts on the first failure regardless of
+     * `continueOnError` — whose own contract text already scopes it to
+     * `atomic=false`, and which has nothing to continue toward when every write
+     * so far is about to be undone.
+     */
+    private async runUpdateManyLoop(args: {
+        object: string;
+        records: UpdateManyDataRequest['records'];
+        options: UpdateManyDataRequest['options'];
+        context: any;
+        atomic: boolean;
+    }): Promise<BatchDataLoopOutcome> {
+        const { object, records, options, context, atomic } = args;
+        const results: BatchDataRowResult[] = [];
         let succeeded = 0;
         let failed = 0;
 
@@ -5683,12 +5761,30 @@ export class ObjectStackProtocolImplementation implements
             } catch (err: any) {
                 results.push({ id: record.id, success: false, error: err.message });
                 failed++;
+                if (atomic) {
+                    // Abort on the first failure; the caller rolls back.
+                    break;
+                }
                 if (!options?.continueOnError) {
                     break;
                 }
             }
         }
 
+        return { results, succeeded, failed };
+    }
+
+    /**
+     * The ordinary (committed) `updateMany` response. Deliberately NOT
+     * {@link buildBatchDataResponse}: this surface has never honoured
+     * `returnRecords`, and quietly starting to would change the default
+     * (non-atomic) path's payload while fixing an unrelated bug (#4620).
+     */
+    private buildUpdateManyResponse(
+        records: UpdateManyDataRequest['records'],
+        outcome: BatchDataLoopOutcome,
+    ): BatchUpdateResponse {
+        const { results, succeeded, failed } = outcome;
         return {
             success: failed === 0,
             operation: 'update',
@@ -5750,6 +5846,12 @@ export class ObjectStackProtocolImplementation implements
      *   - the declared {@link BatchUpdateResponse} contract (per-record results,
      *     `atomic` / `continueOnError`) was unimplementable from a bulk row
      *     count. It is now actually delivered.
+     *
+     * [#4620] That last bullet over-claimed for one member: `atomic` was
+     * per-record, but it only stopped the loop — no transaction, no rollback,
+     * every earlier delete left committed under a response titled atomic. It is
+     * delivered for real now, through the shared {@link runAtomicBatch}, and
+     * refused (501 `NOT_IMPLEMENTED`) on a runtime that cannot roll back.
      */
     async deleteManyData(request: DeleteManyDataRequest & { context?: any }): Promise<BatchUpdateResponse> {
         const { object, options, context } = request;
@@ -5771,7 +5873,40 @@ export class ObjectStackProtocolImplementation implements
             throw err;
         }
 
-        const results: Array<{ id?: string; success: boolean; error?: string }> = [];
+        // [#4620] `atomic` here was the same fake-atomic `batchData` carried
+        // before ADR-0119 D4 — it only `break`-ed the loop, so every row deleted
+        // before the failure stayed DELETED while the response called itself
+        // atomic. Worse than the `batchData` case, because a partial delete has
+        // no natural undo: the caller cannot reconstruct the rows from the
+        // request. Same runner, same fail-closed gate, same row marking.
+        if (options?.atomic === true) {
+            const rows = ids.map((id) => ({ id: String(id) }));
+            return await this.runAtomicBatch({
+                object,
+                context,
+                runLoop: (trxCtx) => this.runDeleteManyLoop({ object, ids, options, context: trxCtx, atomic: true }),
+                onCommit: (outcome) => this.buildDeleteManyResponse(ids, outcome),
+                onRollback: (outcome) => this.buildRolledBackBatchResponse('delete', rows, outcome),
+            });
+        }
+
+        const outcome = await this.runDeleteManyLoop({ object, ids, options, context, atomic: false });
+        return this.buildDeleteManyResponse(ids, outcome);
+    }
+
+    /**
+     * The per-id loop of {@link deleteManyData}, shared by both arms (#4620) —
+     * see {@link runUpdateManyLoop} for why `atomic` outranks `continueOnError`.
+     */
+    private async runDeleteManyLoop(args: {
+        object: string;
+        ids: unknown[];
+        options: DeleteManyDataRequest['options'];
+        context: any;
+        atomic: boolean;
+    }): Promise<BatchDataLoopOutcome> {
+        const { object, ids, options, context, atomic } = args;
+        const results: BatchDataRowResult[] = [];
         let succeeded = 0;
         let failed = 0;
         const ctxOpt = context !== undefined ? { context } : {};
@@ -5787,20 +5922,29 @@ export class ObjectStackProtocolImplementation implements
                 // single-record path: the contract's positive not-found value,
                 // never an inference from a falsy return.
                 const deleted = await this.engine.delete(object, { where: { id }, ...ctxOpt } as any);
-                if (deleted === false) throw recordNotFoundError(object, id);
+                // `id` is `unknown` to this helper only because the caller's
+                // fail-closed `isScalarId` guard is what proves it scalar.
+                if (deleted === false) throw recordNotFoundError(object, id as string | number);
                 results.push({ id: String(id), success: true });
                 succeeded++;
             } catch (err: any) {
                 results.push({ id: String(id), success: false, error: err?.message });
                 failed++;
                 // Same stop semantics as `batchData`: `atomic` aborts the rest on
-                // the first failure, and without `continueOnError` a failure ends
-                // the run rather than silently ploughing on.
-                if (options?.atomic) break;
+                // the first failure (the caller rolls back), and without
+                // `continueOnError` a failure ends the run rather than silently
+                // ploughing on.
+                if (atomic) break;
                 if (!options?.continueOnError) break;
             }
         }
 
+        return { results, succeeded, failed };
+    }
+
+    /** The ordinary (committed) `deleteMany` response — every id reports what it did. */
+    private buildDeleteManyResponse(ids: unknown[], outcome: BatchDataLoopOutcome): BatchUpdateResponse {
+        const { results, succeeded, failed } = outcome;
         return {
             success: failed === 0,
             operation: 'delete',


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4620

ADR-0119 D4 把 `batchData` 的 `atomic` 修成了真承诺。同一文件里的两个同胞当时不在那次 PR 的确认范围内,缺陷原样留着 —— 本 PR 只做 issue 的第 1、2 节。

## 修了什么

**1. `deleteManyData` 的假原子**(`protocol.ts`)

`if (options?.atomic) break;` 只是跳出循环:没有事务、没有回滚。失败前已删掉的行**保持已删除**,而响应以原子自居并把它们报成 `success: true`。这比 `batchData` 那次更糟 —— 部分删除没有自然的撤销手段,客户端无法从自己的请求里把行重建回来。

**2. `updateManyData` 完全不读 `atomic`**

选项被接受、在 `BatchOptionsSchema` 里被声明成「全有或全无」,却从未被读取。调用方要原子性,拿到的是 best-effort,且没有任何信号 —— 典型的 declared ≠ enforced,而且是写路径上的保证。

## 怎么修的:复用,不重新推导

D4 的三块料(原子臂、共享逐记录循环、fail-closed 能力闸门、`ROLLED_BACK:` / `NOT_ATTEMPTED:` 行标记)都已在 `main` 上,本 PR 一律复用。为避免出现第三、第四份事务处理代码(抄写正是下一个同胞漂移回谎言的路径),把 `batchData` 原子臂里**除**「逐记录循环 + 两个响应构造器」以外的部分抽成一个共享 runner `runAtomicBatch`,三个入口共用:

- `atomic: true` → 整批跑在**一个** `engine.transaction()` 里,首个失败回滚此前全部写入;
- 回滚批次报告**零成功**:成功过的行标 `ROLLED_BACK: record < i > failed — < cause >`,没轮到的行标 `NOT_ATTEMPTED: atomic batch aborted by record < i >`,致因行保留自己的原始错误 —— 客户端能区分「已尝试但被撤销」与「从未执行」;
- `atomic` 优先于 `continueOnError`(后者的契约文本本来就把自己限定在 `atomic=false`);
- 无法回滚的运行时(无 `engine.transaction()`,或默认 driver 无 `beginTransaction`)→ **501 `NOT_IMPLEMENTED`**,而不是静默降级成 best-effort。静默降级正是本 issue 的缺陷类别,所以这里 fail closed。

`batchData` 的行为**一点没动**,其既有测试文件未作任何修改仍全部通过。

## 行为变更(需要知会使用者)

`atomic: true` 的 `deleteMany` / `updateMany` 在不能回滚的运行时上从「静默 best-effort」变成 501 拒绝。想要 best-effort 就明确要 —— `atomic: false` 或不传。changeset 里写了这条。

非原子路径(含 `continueOnError` 交互与两个端点的响应形状)保持不变,并加了回归钉。

## 测试

新增 `packages/metadata-protocol/src/protocol.many-data-atomic.test.ts`(14 例,均引用 #4620)。假引擎是一个带快照/恢复事务语义的内存 store,所以回滚是**真回滚**:

- `deleteMany` 原子 + 中途失败:**回滚后 `a`、`c` 两行仍可读**(这是本 issue 的关键 —— 部分删除没有自然撤销),零成功,行标 `ROLLED_BACK:` / `NOT_ATTEMPTED:`;
- `updateMany` 原子 + 中途失败:先前的更新被恢复成旧值,同样零成功、同样标记;
- 两个端点在无事务能力的 engine / driver 上均 501,且**一次写都没发生**;
- 非原子路径逐条钉住:不开事务、保留此前成功、`continueOnError` 交互不变。

`protocol.delete-many.test.ts` 里原先钉住假原子的那一例(`atomic aborts the remaining ids on the first failure`,断言 `succeeded: 1`)改成钉拒绝语义 —— 它钉的正是本次要修掉的行为。

```
pnpm --filter @objectstack/metadata-protocol test
 Test Files  31 passed (31)
      Tests  260 passed (260)

npx vitest run src/protocol.many-data-atomic.test.ts
 Test Files  1 passed (1)
      Tests  14 passed (14)

pnpm turbo run build --filter=@objectstack/metadata-protocol   # tsup dts = tsc 类型检查,通过
packages/rest: rest-batch-size-cap + rest-delete-many-ingress   15 passed
```

## 刻意没做

issue 第 3 节(逐行结果形状 `{ id, success, error, record }` 与 `BatchOperationResultSchema` 的 `{ errors, data }` 分歧)**未触碰**。那是公开 wire 契约的方向决定,两个方向对已发布客户端的影响相反;ADR-0119 D4 当时刻意没让它搭在 bug fix 上,让它搭在这次修复上会是同一种静默兼容性破坏。已由单独的决策 issue 承接。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018iARDqtrhQgz6fVHDeDkbQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018iARDqtrhQgz6fVHDeDkbQ)_