### PR TITLE
fix(plugin-auth): 每号码 OTP 发送预算改用惰性解析的共享计数存储 —— 多节点下不再按节点数倍增 (#4790)

### DIFF
--- a/.changeset/auth-otp-budget-shared-counter-store.md
+++ b/.changeset/auth-otp-budget-shared-counter-store.md
@@ -1,0 +1,41 @@
+---
+"@objectstack/plugin-auth": patch
+---
+
+fix(plugin-auth): 每号码 OTP 发送预算改用惰性解析的共享计数存储 —— 多节点下不再按节点数倍增 (#4790)
+
+#2780 的「每号码 OTP 发送预算」（60s 冷却 + 每小时 5 条）此前**只有宿主显式提供
+better-auth `secondaryStorage` 时才跨节点共享**：`AuthManager.getOtpSendGuard()` 唯一的
+存储来源就是 `AuthManagerOptions.secondaryStorage`，而标准 `serve` 组合里没有任何一处
+提供它（#4788 之后 `AuthPlugin` 也明确不再从 cache 服务派生它）。于是预算落在**每个进程
+一份**：N 个节点的部署，一个号码实际能收到的是声明值的 N 倍，而且**没有任何信号**告诉你
+它没兑现（ADR-0049 声明 ≠ 强制）。这里的计价单位是**真金白银的短信**。
+
+这是 #4772 那条限流洞的同类，但是独立的一处：#4788 修的是 better-auth 自己的 `rateLimit`
+计数器（走 `rateLimit.customStorage`），OTP 预算是 ObjectStack 在 `AuthManager` 里自己实现
+的另一套计数，行为未被 #4788 改变。
+
+**修法：复用 #4788 建好的那条路径，而不是再写一份。** `rate-limit-storage.ts` 中把「惰性
+解析 → 绑定即宣告 → 解析不到就降级到有界的进程内存储并响亮告警」抽成
+`createLazyCounterStore()`（`createLazyCacheRateLimitStorage()` 现在就是它的一层薄封装），
+OTP 预算经由新的 `AuthManagerOptions.sharedCounterStore` 接同一条路径：
+
+- **存储在每次发送校验时才解析**，因此 `CacheServicePlugin` 晚于 `AuthPlugin` 注册也照样
+  绑定得上（插件启动顺序不再决定任何事）—— 这正是 #4772 冻结结论造成的那个洞；
+- 配了 cache 的多节点部署，每号码预算**现在真的是一份**，换节点不会重新获得冷却额度；
+- 没有 cache 服务的部署**仍然限额**，只是降级为进程内计数，并在第一次真正计数时打一条
+  点名代价的 warn（「an N-node deployment can send up to N× the configured number of PAID
+  SMS to one number」）—— 降级不是关闭，两种情况在日志里可区分（绑定打 info，降级打 warn）。
+
+**刻意不引入 `secondaryStorage` 来修它**（#4785）：那会把会话的记录之处搬进缓存，静默废掉
+ADR-0069 D4 的三个会话管控。宿主自己提供的 `secondaryStorage` 对这个预算仍然优先且行为不变。
+
+冷却与滚动小时窗的语义**未做任何改动**：计数依旧是按号码的时间戳滚动窗口，只是换了它所在的
+存储。（固定窗口计数器无法表达「距上一次发送满 N 秒」，把它改成定窗会在窗口边界放行两倍突发
+——用一种倍增换另一种倍增。）
+
+对使用者的影响：
+
+- 新增 `AuthManagerOptions.sharedCounterStore`，`AuthPlugin` 自动填充，一般宿主无需感知；
+- 新增导出 `createLazyCounterStore()` 与 `counterStoreFromKv()`；
+- `OtpSendGuard` 新增 `resolveStore` 选项，原有的 `storage`（字符串 KV）选项保持可用。

--- a/packages/plugins/plugin-auth/src/auth-manager.test.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.test.ts
@@ -1734,6 +1734,88 @@ describe('AuthManager', () => {
       await manager.assertPhoneOtpSendAllowed(PHONE);
     });
 
+    // ── #4790 — the budget is only global if its STORE is ─────────────────
+    describe('where the per-number budget is counted (#4790)', () => {
+      const makeCache = () => {
+        const store = new Map<string, unknown>();
+        return {
+          store,
+          get: vi.fn(async (k: string) => (store.has(k) ? store.get(k) : undefined)),
+          set: vi.fn(async (k: string, v: unknown, _ttl?: number) => { store.set(k, v); }),
+        };
+      };
+      const bootNode = async (sharedCounterStore: any) => {
+        const { manager } = await bootOtp({ sharedCounterStore });
+        manager.setSmsService(fakeSms().service);
+        return manager;
+      };
+
+      it('spends ONE budget across nodes when a shared counter store is wired', async () => {
+        const { createLazyCounterStore } = await import('./rate-limit-storage.js');
+        const cache = makeCache();
+        // Two nodes: separate managers, separate resolvers, one cache.
+        const nodeStore = () =>
+          createLazyCounterStore({ resolveCache: async () => cache as any, subject: 'otp-budget' });
+        const nodeA = await bootNode(nodeStore());
+        const nodeB = await bootNode(nodeStore());
+
+        await nodeA.assertPhoneOtpSendAllowed(PHONE);
+        // Rotating nodes no longer buys a fresh cooldown.
+        await expect(nodeB.assertPhoneOtpSendAllowed(PHONE))
+          .rejects.toThrow(/Too many verification codes/);
+        expect(cache.store.size).toBe(1);
+        expect([...cache.store.keys()][0]).toContain(PHONE);
+      });
+
+      it('resolves the store per check, so a cache registered after boot still binds', async () => {
+        const { createLazyCounterStore } = await import('./rate-limit-storage.js');
+        const cache = makeCache();
+        let registered = false;
+        const manager = await bootNode(
+          createLazyCounterStore({
+            resolveCache: async () => (registered ? (cache as any) : undefined),
+            subject: 'otp-budget',
+          }),
+        );
+        registered = true; // CacheServicePlugin comes up after plugin-auth.
+        await manager.assertPhoneOtpSendAllowed(PHONE);
+        expect(cache.store.size).toBe(1);
+      });
+
+      it('a host-supplied secondaryStorage keeps owning the budget', async () => {
+        const kv = new Map<string, string>();
+        const secondaryStorage = {
+          get: async (k: string) => kv.get(k) ?? null,
+          set: async (k: string, v: string) => { kv.set(k, v); },
+          delete: async (k: string) => { kv.delete(k); },
+        };
+        const cache = makeCache();
+        const { manager } = await bootOtp({
+          secondaryStorage,
+          sharedCounterStore: async () => cache as any,
+        });
+        manager.setSmsService(fakeSms().service);
+        await manager.assertPhoneOtpSendAllowed(PHONE);
+        expect(kv.size).toBe(1);
+        expect(cache.store.size).toBe(0);
+      });
+
+      it('without any shared store the budget is per-manager — degraded, still enforced', async () => {
+        const { manager: nodeA } = await bootOtp();
+        const { manager: nodeB } = await bootOtp();
+        nodeA.setSmsService(fakeSms().service);
+        nodeB.setSmsService(fakeSms().service);
+
+        await nodeA.assertPhoneOtpSendAllowed(PHONE);
+        // Enforced on its own node…
+        await expect(nodeA.assertPhoneOtpSendAllowed(PHONE))
+          .rejects.toThrow(/Too many verification codes/);
+        // …and not on the other one: exactly the N× multiplication #4790 is
+        // about, which is why AuthPlugin warns loudly when it has to do this.
+        await nodeB.assertPhoneOtpSendAllowed(PHONE);
+      });
+    });
+
     it('features.phoneNumberOtp requires plugin + deliverable SMS', async () => {
       const { manager } = await bootOtp();
       expect((manager.getPublicConfig() as any).features.phoneNumberOtp).toBe(false);

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -26,6 +26,7 @@ import { isPlaceholderEmail } from './placeholder-email.js';
 import { reconcileMembership, type MembershipPolicy } from './reconcile-membership.js';
 import type { TenancyService } from './tenancy-service.js';
 import { OtpSendGuard } from './otp-send-guard.js';
+import type { CounterStore } from './rate-limit-storage.js';
 import {
   PHONE_SMS_TOPICS,
   builtinPhoneSmsBody,
@@ -620,6 +621,26 @@ export interface AuthManagerOptions extends Partial<AuthConfig> {
    * drop the store.
    */
   rateLimitStorage?: NonNullable<BetterAuthOptions['rateLimit']>['customStorage'];
+
+  /**
+   * ADR-0069 D2 (#4790) — the store ObjectStack's OWN cross-node counters
+   * count in, resolved LAZILY (called per count, not at construction). Today
+   * that is the #2780 per-number OTP send budget; {@link rateLimitStorage}
+   * covers better-auth's own per-IP counters, which never pass through here.
+   *
+   * `AuthPlugin` supplies `createLazyCounterStore(...)` over the kernel `cache`
+   * service (`rate-limit-storage.ts`) — the same resolution the rate-limit
+   * counters use, so plugin start order decides nothing and a deployment
+   * WITHOUT a cache still counts, per process, and is told so. Absent → the
+   * budget is per-process silently, which is the pre-#4790 behaviour and is
+   * why this option exists.
+   *
+   * NOT `secondaryStorage`: handing better-auth one of those also relocates the
+   * session of record into the cache and silently disables the ADR-0069 D4
+   * session controls (#4785). A host that supplies `secondaryStorage`
+   * deliberately still wins for this budget — see `getOtpSendGuard`.
+   */
+  sharedCounterStore?: () => Promise<CounterStore>;
 }
 
 /**
@@ -2511,12 +2532,22 @@ export class AuthManager {
   private getOtpSendGuard(): OtpSendGuard {
     if (!this._otpSendGuard) {
       const otpCfg = this.config.phoneOtp ?? {};
+      // WHERE the budget is counted decides whether it is a budget at all
+      // (#4790): counted per process, a declared "5 per hour" is 5×N across N
+      // nodes. Precedence, most deliberate first:
+      //  1. a host-supplied `secondaryStorage` — an explicit cross-node KV;
+      //  2. `sharedCounterStore` — AuthPlugin's lazily-resolved kernel `cache`,
+      //     which also announces the degraded (no cache) case loudly;
+      //  3. neither → the guard's own bounded per-process store.
+      const storeOption = this.config.secondaryStorage
+        ? { storage: this.config.secondaryStorage }
+        : this.config.sharedCounterStore
+          ? { resolveStore: this.config.sharedCounterStore }
+          : {};
       this._otpSendGuard = new OtpSendGuard({
         ...(otpCfg.cooldownSeconds != null ? { cooldownSeconds: otpCfg.cooldownSeconds } : {}),
         ...(otpCfg.maxPerHour != null ? { maxPerHour: otpCfg.maxPerHour } : {}),
-        // Share better-auth's cross-node KV when wired (ADR-0069 D2) so the
-        // per-number budget is enforced against ONE store across nodes.
-        ...(this.config.secondaryStorage ? { storage: this.config.secondaryStorage } : {}),
+        ...storeOption,
       });
     }
     return this._otpSendGuard;

--- a/packages/plugins/plugin-auth/src/auth-plugin.test.ts
+++ b/packages/plugins/plugin-auth/src/auth-plugin.test.ts
@@ -1319,5 +1319,69 @@ describe('AuthPlugin', () => {
       const { manager } = await bootWith(async () => cache);
       expect((manager as any).config.secondaryStorage).toBeUndefined();
     });
+
+    // ── #4790 — the SECOND counter with the same hole: ObjectStack's own
+    // per-number OTP send budget (#2780). It shared state only through a
+    // host-supplied `secondaryStorage`, which the standard `serve` composition
+    // never supplies, so the declared per-number cap was cap×N across N nodes —
+    // in paid SMS. Same cure, same resolution path, deliberately NOT
+    // `secondaryStorage` (#4785).
+    describe('per-number OTP send budget (#2780 / #4790)', () => {
+      const PHONE = '+8613800000000';
+      const deliverableSms = { async send() { return { id: 'x', status: 'sent' }; }, isConfigured: () => true };
+
+      it('counts the budget in a cache registered AFTER auth init', async () => {
+        const cache = makeCache();
+        let registered = false;
+        const { ctx, manager } = await bootWith(async () => (registered ? cache : undefined));
+        expect((manager as any).config.sharedCounterStore).toBeTypeOf('function');
+
+        // CacheServicePlugin comes up 21ms later.
+        registered = true;
+        manager.setSmsService(deliverableSms as any);
+
+        await manager.assertPhoneOtpSendAllowed(PHONE);
+        // The send landed in the SHARED store — this is the assertion the
+        // pre-#4790 wiring could not satisfy in any standard composition.
+        expect([...cache.store.keys()]).toEqual([`phone-otp-sends:${PHONE}`]);
+        await expect(manager.assertPhoneOtpSendAllowed(PHONE))
+          .rejects.toThrow(/Too many verification codes/);
+
+        // Bound → an info line and NO warning: the operator must be able to
+        // tell "shared" from "degraded" without reading the code.
+        const info = (ctx.logger.info as any).mock.calls.map((c: any[]) => String(c[0]));
+        expect(info.some((m: string) => m.includes('per-number OTP send budget (#2780) bound to the kernel cache service'))).toBe(true);
+        expect((ctx.logger.warn as any).mock.calls
+          .map((c: any[]) => String(c[0]))
+          .filter((m: string) => m.includes('per-number OTP send budget'))).toEqual([]);
+      });
+
+      it('warns loudly at counting time when there is no cache — degraded, never disabled', async () => {
+        const { ctx, manager } = await bootWith(async () => undefined);
+        manager.setSmsService(deliverableSms as any);
+        const otpWarnings = () =>
+          (ctx.logger.warn as any).mock.calls
+            .map((c: any[]) => String(c[0]))
+            .filter((m: string) => m.includes('per-number OTP send budget'));
+
+        // Nothing is said at boot — a deployment that never sends an OTP is not
+        // warned about a store it never needs.
+        expect(otpWarnings()).toEqual([]);
+
+        await manager.assertPhoneOtpSendAllowed(PHONE);
+        // Still enforced, in-process.
+        await expect(manager.assertPhoneOtpSendAllowed(PHONE))
+          .rejects.toThrow(/Too many verification codes/);
+
+        expect(otpWarnings()).toHaveLength(1);
+        expect(otpWarnings()[0]).toContain('PAID SMS');
+        expect(otpWarnings()[0]).toContain('no `cache` service registered at all');
+        // Degraded → a warning and NO "bound" info line; the mirror image of
+        // the cache-present case above.
+        expect((ctx.logger.info as any).mock.calls
+          .map((c: any[]) => String(c[0]))
+          .filter((m: string) => m.includes('per-number OTP send budget'))).toEqual([]);
+      });
+    });
   });
 });

--- a/packages/plugins/plugin-auth/src/auth-plugin.ts
+++ b/packages/plugins/plugin-auth/src/auth-plugin.ts
@@ -41,6 +41,7 @@ import { MANAGED_EXTENSION_EDITABLE_FIELDS } from './managed-extension-fields.js
 import { runSetInitialPassword } from './set-initial-password.js';
 import { runRegisterSsoProviderFromForm, runRegisterSamlProviderFromForm, runRequestDomainVerification, runVerifyDomain } from './register-sso-provider.js';
 import { runResendVerificationEmail } from './send-verification-email.js';
+import type { CounterStore } from './rate-limit-storage.js';
 import {
   authIdentityObjects,
   authPluginManifestHeader,
@@ -356,24 +357,51 @@ export class AuthPlugin implements Plugin {
     // Whether the session of record should live in the cache at all is #4785.
     // A host that supplies `secondaryStorage` itself still wins and keeps
     // better-auth's own `storage: 'secondary-storage'` counters.
-    if (!authConfig.secondaryStorage) {
-      const { createLazyCacheRateLimitStorage } = await import('./rate-limit-storage.js');
-      authConfig.rateLimitStorage = createLazyCacheRateLimitStorage({
-        // The `cache` service is registered ASYNC — `getService` throws for it,
-        // so resolve via `getServiceAsync` and treat any failure (not
-        // registered, or not yet ready) as "no shared cache, ask again later".
-        resolveCache: async () => {
-          let cache: any;
-          try {
-            cache = await (ctx as { getServiceAsync?: (n: string) => Promise<unknown> })
-              .getServiceAsync?.('cache');
-          } catch {
-            return undefined;
-          }
-          if (cache && typeof cache.get === 'function' && typeof cache.set === 'function') return cache;
-          return undefined;
-        },
+    //
+    // The SAME resolution carries ObjectStack's own per-number OTP send budget
+    // (#2780) below — that counter had the identical hole (#4790): it counted
+    // in `secondaryStorage` when a host supplied one and per-process otherwise,
+    // which under the standard `serve` composition (nobody supplies one) meant
+    // every node granted the same phone number its own cooldown + hourly cap.
+    // The currency there is paid SMS, so an N-node deployment was billed for up
+    // to N× the declared budget.
+    //
+    // The `cache` service is registered ASYNC — `getService` throws for it, so
+    // resolve via `getServiceAsync` and treat any failure (not registered, or
+    // not yet ready) as "no shared cache, ask again later".
+    const resolveCache = async (): Promise<CounterStore | undefined> => {
+      let cache: any;
+      try {
+        cache = await (ctx as { getServiceAsync?: (n: string) => Promise<unknown> })
+          .getServiceAsync?.('cache');
+      } catch {
+        return undefined;
+      }
+      if (cache && typeof cache.get === 'function' && typeof cache.set === 'function') return cache;
+      return undefined;
+    };
+
+    {
+      const { createLazyCacheRateLimitStorage, createLazyCounterStore } = await import(
+        './rate-limit-storage.js'
+      );
+      if (!authConfig.secondaryStorage) {
+        authConfig.rateLimitStorage = createLazyCacheRateLimitStorage({
+          resolveCache,
+          logger: ctx.logger,
+        });
+      }
+      // #4790 — ObjectStack's own counters. Wired even when the host supplied a
+      // `secondaryStorage` (AuthManager prefers that store for the budget and
+      // then never calls this resolver), so the two decisions stay independent.
+      authConfig.sharedCounterStore = createLazyCounterStore({
+        resolveCache,
         logger: ctx.logger,
+        subject: 'per-number OTP send budget (#2780)',
+        degradedImpact:
+          'The budget is still enforced, but PER NODE: every node grants the same phone number its own ' +
+          'cooldown and hourly cap, so an N-node deployment can send up to N× the configured number of ' +
+          'PAID SMS to one number (#4790)',
       });
     }
 

--- a/packages/plugins/plugin-auth/src/otp-send-guard.test.ts
+++ b/packages/plugins/plugin-auth/src/otp-send-guard.test.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { OtpSendGuard, type OtpGuardStorage } from './otp-send-guard.js';
+import { createLazyCounterStore } from './rate-limit-storage.js';
 
 const PHONE = '+8613800000000';
 
@@ -77,5 +78,153 @@ describe('OtpSendGuard', () => {
     const guard = new OtpSendGuard({ cooldownSeconds: 60, storage });
     expect((await guard.checkAndRecord(PHONE)).ok).toBe(true);
     expect((await guard.checkAndRecord(PHONE)).ok).toBe(true);
+  });
+});
+
+// ── #4790 — WHERE the budget is counted ─────────────────────────────────────
+//
+// The budget was shared across nodes only when a host supplied better-auth's
+// `secondaryStorage`, which the standard `serve` composition never does — so
+// the declared per-number cap was really cap×N in an N-node deployment, and
+// nothing said so. Same defect class as #4772's rate-limit counters, and now
+// the same cure: the store is resolved lazily, per check, from the kernel
+// `cache` service.
+describe('OtpSendGuard — where the budget is counted (#4790)', () => {
+  /** Minimal in-memory ICacheService stand-in (no TTL eviction — tests drive the clock). */
+  const makeCache = () => {
+    const store = new Map<string, unknown>();
+    return {
+      store,
+      get: vi.fn(async (k: string) => (store.has(k) ? store.get(k) : undefined)),
+      set: vi.fn(async (k: string, v: unknown, _ttl?: number) => { store.set(k, v); }),
+    };
+  };
+  const makeLogger = () => ({ info: vi.fn(), warn: vi.fn() });
+  const OTP_SUBJECT = 'per-number OTP send budget (#2780)';
+
+  it('resolves the store at CHECK time — a cache registered AFTER the guard is still used', async () => {
+    // The exact ordering that made #4772 permanent: plugin-auth builds the
+    // guard during init(), CacheServicePlugin registers `cache` afterwards.
+    const c = clock();
+    const cache = makeCache();
+    let registered = false;
+    const logger = makeLogger();
+    const guard = new OtpSendGuard({
+      cooldownSeconds: 60,
+      now: c.now,
+      resolveStore: createLazyCounterStore({
+        resolveCache: async () => (registered ? (cache as any) : undefined),
+        logger,
+        subject: OTP_SUBJECT,
+      }),
+    });
+
+    registered = true; // …21ms later, in a showcase cold start.
+
+    expect((await guard.checkAndRecord(PHONE)).ok).toBe(true);
+    // The send really was recorded in the shared store, not in this process.
+    expect(cache.store.size).toBe(1);
+    expect([...cache.store.keys()][0]).toBe(`phone-otp-sends:${PHONE}`);
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info.mock.calls[0][0]).toContain(`${OTP_SUBJECT} bound to the kernel cache service`);
+  });
+
+  it('is ONE budget across nodes when the cache is shared', async () => {
+    const c = clock();
+    const cache = makeCache();
+    // Two nodes = two processes = two resolvers over one cache.
+    const nodeStore = () =>
+      createLazyCounterStore({ resolveCache: async () => cache as any, subject: OTP_SUBJECT });
+    const nodeA = new OtpSendGuard({ cooldownSeconds: 60, maxPerHour: 5, now: c.now, resolveStore: nodeStore() });
+    const nodeB = new OtpSendGuard({ cooldownSeconds: 60, maxPerHour: 5, now: c.now, resolveStore: nodeStore() });
+
+    expect((await nodeA.checkAndRecord(PHONE)).ok).toBe(true);
+    // Rotating to another node does NOT buy a fresh cooldown — the point of #4790.
+    const denied = await nodeB.checkAndRecord(PHONE);
+    expect(denied.ok).toBe(false);
+    expect(denied.retryAfterSeconds).toBeGreaterThan(0);
+
+    // …and the hourly cap is one cap, spent from either node.
+    c.advance(61_000);
+    for (const node of [nodeA, nodeB, nodeA, nodeB]) {
+      expect((await node.checkAndRecord(PHONE)).ok).toBe(true);
+      c.advance(61_000);
+    }
+    expect((await nodeA.checkAndRecord(PHONE)).ok).toBe(false);
+    expect(cache.store.size).toBe(1);
+  });
+
+  it('without any cache service the budget is DEGRADED, not disabled — and said out loud', async () => {
+    const c = clock();
+    const logger = makeLogger();
+    const guard = new OtpSendGuard({
+      cooldownSeconds: 60,
+      now: c.now,
+      resolveStore: createLazyCounterStore({
+        resolveCache: async () => undefined,
+        logger,
+        subject: OTP_SUBJECT,
+        degradedImpact: 'up to N× the configured number of PAID SMS (#4790)',
+      }),
+    });
+
+    // Nothing is logged until a send is actually checked.
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    expect((await guard.checkAndRecord(PHONE)).ok).toBe(true);
+    expect((await guard.checkAndRecord(PHONE)).ok).toBe(false); // still enforced, in-process
+    expect((await guard.checkAndRecord('+15005550006')).ok).toBe(true);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const msg = logger.warn.mock.calls[0][0] as string;
+    expect(msg).toContain(OTP_SUBJECT);
+    expect(msg).toContain('per-process store');
+    expect(msg).toContain('PAID SMS');
+    // The two cases must be distinguishable: bound → info, degraded → warn.
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it('an explicit resolveStore wins over a host KV, as the option documents', async () => {
+    const c = clock();
+    const cache = makeCache();
+    const kv = new Map<string, string>();
+    const storage: OtpGuardStorage = {
+      get: (k) => kv.get(k) ?? null,
+      set: (k, v) => { kv.set(k, v); },
+    };
+    const guard = new OtpSendGuard({
+      cooldownSeconds: 60,
+      storage,
+      resolveStore: async () => cache as any,
+      now: c.now,
+    });
+    expect((await guard.checkAndRecord(PHONE)).ok).toBe(true);
+    expect(cache.store.size).toBe(1);
+    expect(kv.size).toBe(0);
+  });
+
+  it('fails OPEN when the resolved store breaks mid-flight', async () => {
+    const guard = new OtpSendGuard({
+      cooldownSeconds: 60,
+      resolveStore: async () => ({
+        get: async () => { throw new Error('redis down'); },
+        set: async () => { throw new Error('redis down'); },
+      }),
+    });
+    expect((await guard.checkAndRecord(PHONE)).ok).toBe(true);
+    expect((await guard.checkAndRecord(PHONE)).ok).toBe(true);
+  });
+
+  it('reads a history handed back as an array (memory cache) as well as a string (Redis)', async () => {
+    const c = clock();
+    const cache = makeCache();
+    // The memory cache adapter returns the stored value as-is.
+    cache.store.set(`phone-otp-sends:${PHONE}`, [c.now() - 1_000]);
+    const guard = new OtpSendGuard({
+      cooldownSeconds: 60,
+      now: c.now,
+      resolveStore: async () => cache as any,
+    });
+    expect((await guard.checkAndRecord(PHONE)).ok).toBe(false);
   });
 });

--- a/packages/plugins/plugin-auth/src/otp-send-guard.ts
+++ b/packages/plugins/plugin-auth/src/otp-send-guard.ts
@@ -13,23 +13,61 @@
  *  - **Cooldown**: at most one send per number per `cooldownSeconds`.
  *  - **Hourly cap**: at most `maxPerHour` sends per number per rolling hour.
  *
- * State lives in better-auth's `secondaryStorage` when wired (one shared
- * store across nodes — same reasoning as the rate-limit counters, ADR-0069
- * D2) and falls back to an in-process map otherwise. Counting is
- * best-effort (no cross-node atomicity), which is fine for an anti-abuse
- * throttle — the budget is small either way.
+ * ## Where the budget is counted (#4790)
+ *
+ * A budget is only worth what its STORE is worth: counted per process, a
+ * declared "5 sends per number per hour" is really 5×N in an N-node
+ * deployment, and nothing says so (ADR-0049 — declared ≠ enforced). The store
+ * is therefore resolved through {@link CounterStore}, lazily, at the moment a
+ * send is checked:
+ *
+ *  - the kernel `cache` service when one is registered — shared across nodes
+ *    iff the cache is (Redis via `@objectstack/service-cache`);
+ *  - a host-supplied better-auth `secondaryStorage`, when the host wired one
+ *    deliberately (adapted by {@link counterStoreFromKv});
+ *  - otherwise a bounded per-process store — still enforced, per node, and
+ *    announced loudly by the resolver (`createLazyCounterStore`).
+ *
+ * Lazy on purpose: `AuthPlugin.init()` runs BEFORE `CacheServicePlugin`
+ * registers `cache`, so anything resolved at init freezes a "no shared store"
+ * answer for the life of the process — the #4772 defect, of which this guard
+ * was the second instance.
+ *
+ * Counting stays best-effort (read-modify-write, no cross-node atomicity),
+ * which is fine for an anti-abuse throttle — the budget is small either way,
+ * and a shared store that occasionally admits one extra is still bounded,
+ * unlike N independent budgets.
  *
  * Keys carry only the phone number and timestamps — never OTP codes.
  */
 
+import { InProcessCounterStore, type CounterStore } from './rate-limit-storage.js';
+
 /**
  * Subset of better-auth's SecondaryStorage the guard needs. Return types are
  * deliberately loose (`unknown`) to stay assignable from better-auth's own
- * interface across versions; `load()` type-checks what comes back.
+ * interface across versions; {@link parseHistory} type-checks what comes back.
  */
 export interface OtpGuardStorage {
   get(key: string): unknown;
   set(key: string, value: string, ttl?: number): unknown;
+}
+
+/**
+ * Adapt a string-valued KV (better-auth `secondaryStorage`) to the
+ * {@link CounterStore} the guard counts in, so there is ONE store abstraction
+ * inside the guard instead of a branch per backing store.
+ */
+export function counterStoreFromKv(kv: OtpGuardStorage): CounterStore {
+  return {
+    get: async <T = unknown>(key: string): Promise<T | undefined> => {
+      const raw = await kv.get(key);
+      return (raw ?? undefined) as T | undefined;
+    },
+    set: async <T = unknown>(key: string, value: T, ttl?: number): Promise<void> => {
+      await kv.set(key, typeof value === 'string' ? value : JSON.stringify(value), ttl);
+    },
+  };
 }
 
 export interface OtpSendGuardOptions {
@@ -37,7 +75,19 @@ export interface OtpSendGuardOptions {
   cooldownSeconds?: number;
   /** Max sends per number per rolling hour. Default 5. `0` disables. */
   maxPerHour?: number;
-  /** Shared cross-node store (better-auth secondaryStorage). Optional. */
+  /**
+   * Resolve the store the budget is counted in — called on EVERY check, so a
+   * shared cache that registers after this guard was constructed is picked up
+   * on the next send rather than never (#4790). `AuthPlugin` supplies
+   * `createLazyCounterStore(...)` (rate-limit-storage.ts), which memoises the
+   * handle, falls back to a bounded per-process store and says which of the
+   * two it got. Omitted → per-process, silently (the guard used standalone).
+   */
+  resolveStore?: () => Promise<CounterStore>;
+  /**
+   * Host-supplied cross-node KV (better-auth `secondaryStorage`). Adapted to a
+   * {@link CounterStore}; ignored when {@link resolveStore} is given.
+   */
   storage?: OtpGuardStorage;
   /** Clock override for tests. */
   now?: () => number;
@@ -52,19 +102,49 @@ export interface OtpSendDecision {
 const KEY_PREFIX = 'phone-otp-sends:';
 const HOUR_MS = 3_600_000;
 
+/**
+ * Read back a send history. Cache adapters differ on whether a stored value
+ * comes back as the JSON string (Redis) or as the original array (memory), so
+ * both are accepted — the same tolerance `parseCounter` applies to the
+ * rate-limit envelope. Anything else (absent, foreign, unparseable) counts as
+ * an empty history: a budget that throws on a junk key would take sign-in down
+ * with it, which is the opposite of the trade this guard makes.
+ */
+function parseHistory(raw: unknown): number[] {
+  let value: unknown = raw;
+  if (typeof raw === 'string') {
+    if (raw.length === 0) return [];
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      return [];
+    }
+  }
+  return Array.isArray(value) ? value.filter((t): t is number => typeof t === 'number') : [];
+}
+
 export class OtpSendGuard {
   private readonly cooldownMs: number;
   private readonly maxPerHour: number;
-  private readonly storage?: OtpGuardStorage;
   private readonly now: () => number;
-  /** In-process fallback store: phone → send timestamps (ms). */
-  private readonly local = new Map<string, number[]>();
+  /**
+   * Per-process fallback, used only when no store was supplied at all (the
+   * guard constructed standalone). The SAME `InProcessCounterStore` the
+   * rate-limit counters degrade to — one bounded fallback implementation, not
+   * two (#4790).
+   */
+  private readonly fallback = new InProcessCounterStore();
+  /** Resolves the store this guard counts in, per check — see the options doc. */
+  private readonly resolveStore: () => Promise<CounterStore>;
 
   constructor(options: OtpSendGuardOptions = {}) {
     this.cooldownMs = Math.max(0, Math.floor(options.cooldownSeconds ?? 60)) * 1000;
     this.maxPerHour = Math.max(0, Math.floor(options.maxPerHour ?? 5));
-    this.storage = options.storage;
     this.now = options.now ?? Date.now;
+    const hostKv = options.storage ? counterStoreFromKv(options.storage) : undefined;
+    this.resolveStore =
+      options.resolveStore ??
+      (hostKv ? async () => hostKv : async () => this.fallback);
   }
 
   /**
@@ -76,8 +156,9 @@ export class OtpSendGuard {
     if (this.cooldownMs === 0 && this.maxPerHour === 0) return { ok: true };
     const now = this.now();
     try {
+      const store = await this.resolveStore();
       const key = KEY_PREFIX + phoneNumber;
-      const history = (await this.load(key)).filter((t) => now - t < HOUR_MS);
+      const history = parseHistory(await store.get(key)).filter((t) => now - t < HOUR_MS);
 
       const last = history.length ? Math.max(...history) : undefined;
       if (this.cooldownMs > 0 && last !== undefined && now - last < this.cooldownMs) {
@@ -89,42 +170,11 @@ export class OtpSendGuard {
       }
 
       history.push(now);
-      await this.save(key, history);
+      // TTL = the rolling window; the entry self-expires once irrelevant.
+      await store.set(key, JSON.stringify(history), Math.ceil(HOUR_MS / 1000));
       return { ok: true };
     } catch {
       return { ok: true }; // fail open — see doc comment
-    }
-  }
-
-  private async load(key: string): Promise<number[]> {
-    if (this.storage) {
-      const raw = await this.storage.get(key);
-      if (typeof raw !== 'string' || raw.length === 0) return [];
-      try {
-        const parsed = JSON.parse(raw);
-        return Array.isArray(parsed) ? parsed.filter((t) => typeof t === 'number') : [];
-      } catch {
-        return [];
-      }
-    }
-    return this.local.get(key) ?? [];
-  }
-
-  private async save(key: string, history: number[]): Promise<void> {
-    if (this.storage) {
-      // TTL = the rolling window; the entry self-expires once irrelevant.
-      await this.storage.set(key, JSON.stringify(history), Math.ceil(HOUR_MS / 1000));
-      return;
-    }
-    this.local.set(key, history);
-    // Opportunistic pruning keeps the fallback map bounded under abuse.
-    if (this.local.size > 10_000) {
-      const cutoff = this.now() - HOUR_MS;
-      for (const [k, v] of this.local) {
-        const alive = v.filter((t) => t > cutoff);
-        if (alive.length === 0) this.local.delete(k);
-        else this.local.set(k, alive);
-      }
     }
   }
 }

--- a/packages/plugins/plugin-auth/src/rate-limit-storage.test.ts
+++ b/packages/plugins/plugin-auth/src/rate-limit-storage.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   createLazyCacheRateLimitStorage,
+  createLazyCounterStore,
   incrementFixedWindow,
   InProcessCounterStore,
 } from './rate-limit-storage.js';
@@ -208,6 +209,77 @@ describe('createLazyCacheRateLimitStorage — no cache service at all (#4772 acc
       logger: {},
     });
     await expect(storage.consume('k', { window: 1, max: 1 })).resolves.toBeTruthy();
+  });
+});
+
+// #4790 — the resolution half, extracted so ObjectStack's OWN counters (the
+// #2780 per-number OTP send budget) reach the shared cache through the same
+// path as better-auth's, instead of a second copy of it.
+describe('createLazyCounterStore (#4790 — one lazy resolution, many counters)', () => {
+  it('names the subject in both log lines, so two degraded budgets are distinguishable', async () => {
+    const logger = makeLogger();
+    const resolve = createLazyCounterStore({
+      resolveCache: async () => undefined,
+      logger,
+      subject: 'per-number OTP send budget (#2780)',
+      degradedImpact: 'an N-node deployment can send N× the configured PAID SMS',
+    });
+    await resolve();
+    const warned = logger.warn.mock.calls[0][0] as string;
+    expect(warned).toContain('per-number OTP send budget (#2780)');
+    expect(warned).toContain('no `cache` service registered at all');
+    expect(warned).toContain('N× the configured PAID SMS');
+
+    const bound = createLazyCounterStore({
+      resolveCache: async () => makeCache() as any,
+      logger,
+      subject: 'per-number OTP send budget (#2780)',
+    });
+    await bound();
+    expect(logger.info.mock.calls[0][0]).toContain(
+      'per-number OTP send budget (#2780) bound to the kernel cache service',
+    );
+  });
+
+  it('hands back ONE fallback instance, so the degraded path still counts per node', async () => {
+    const resolve = createLazyCounterStore({ resolveCache: async () => undefined, subject: 'x' });
+    const first = await resolve();
+    const second = await resolve();
+    expect(first).toBe(second);
+    expect(first).toBeInstanceOf(InProcessCounterStore);
+  });
+
+  it('keeps asking until the cache is there, then memoises it', async () => {
+    const cache = makeCache();
+    let registered = false;
+    const resolveCache = vi.fn(async () => (registered ? (cache as any) : undefined));
+    const resolve = createLazyCounterStore({ resolveCache, subject: 'x' });
+
+    expect(await resolve()).toBeInstanceOf(InProcessCounterStore);
+    registered = true;
+    expect(await resolve()).toBe(cache);
+    await resolve();
+    // One miss + one hit; once resolved the handle is never looked up again.
+    expect(resolveCache).toHaveBeenCalledTimes(2);
+  });
+
+  it('warns once and survives a logger without warn/info', async () => {
+    const logger = makeLogger();
+    const resolve = createLazyCounterStore({ resolveCache: async () => undefined, logger, subject: 'x' });
+    await resolve();
+    await resolve();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+
+    const bare = createLazyCounterStore({ resolveCache: async () => undefined, logger: {}, subject: 'x' });
+    await expect(bare()).resolves.toBeInstanceOf(InProcessCounterStore);
+  });
+
+  it('treats a throwing resolver as "no shared store right now"', async () => {
+    const resolve = createLazyCounterStore({
+      resolveCache: async () => { throw new Error('service registry exploded'); },
+      subject: 'x',
+    });
+    await expect(resolve()).resolves.toBeInstanceOf(InProcessCounterStore);
   });
 });
 

--- a/packages/plugins/plugin-auth/src/rate-limit-storage.ts
+++ b/packages/plugins/plugin-auth/src/rate-limit-storage.ts
@@ -147,6 +147,73 @@ export interface LazyCacheRateLimitStorageOptions {
   logger?: LoggerLike;
 }
 
+export interface LazyCounterStoreOptions extends LazyCacheRateLimitStorageOptions {
+  /**
+   * What is being counted, named verbatim in both log lines (e.g.
+   * `'rate-limit counters'`, `'per-number OTP send budget (#2780)'`). Two
+   * surfaces that degrade for the same reason must still be distinguishable in
+   * the log — an operator has to know WHICH budget stopped being global.
+   */
+  subject: string;
+  /**
+   * Optional extra sentence appended to the degraded warning, naming what the
+   * per-process fallback actually costs for this surface. "Degraded" is not
+   * self-explanatory when the currency is paid SMS.
+   */
+  degradedImpact?: string;
+}
+
+/**
+ * ADR-0069 D2 — resolve the store a cross-node counter counts in, **lazily, at
+ * the moment the counter is consumed**, with a bounded per-process fallback and
+ * a one-shot announcement of whichever branch was taken.
+ *
+ * This is the shared half of {@link createLazyCacheRateLimitStorage} (#4772),
+ * extracted in #4790 so the OTP send budget rides the SAME resolution path
+ * rather than a second copy of it. Everything in the "why lazy" story below
+ * applies to any ObjectStack counter that wants to be global: plugin start
+ * order decides nothing, because nothing is resolved at start.
+ *
+ * The returned function memoises the cache handle once it resolves, keeps
+ * exactly one in-process fallback per call site (so the degraded path still
+ * counts, per node), announces the bind once and warns about the degradation
+ * once. It never throws: a resolver that explodes is "no shared cache right
+ * now", asked again on the next count.
+ */
+export function createLazyCounterStore(opts: LazyCounterStoreOptions): () => Promise<CounterStore> {
+  const fallback = new InProcessCounterStore();
+  let cache: CounterStore | undefined;
+  let boundAnnounced = false;
+  let degradedWarned = false;
+
+  return async (): Promise<CounterStore> => {
+    if (!cache) {
+      try {
+        cache = (await opts.resolveCache()) ?? undefined;
+      } catch {
+        cache = undefined;
+      }
+      if (cache && !boundAnnounced) {
+        boundAnnounced = true;
+        opts.logger?.info?.(
+          `[auth] ${opts.subject} bound to the kernel cache service — enforced against ONE store across nodes iff the cache is shared (ADR-0069 D2)`,
+        );
+      }
+    }
+    if (cache) return cache;
+    if (!degradedWarned) {
+      degradedWarned = true;
+      opts.logger?.warn?.(
+        `[auth] ${opts.subject}: no cache service to count in — falling back to a per-process store. ` +
+          'This deployment has no `cache` service registered at all; a multi-node deployment needs a shared cache ' +
+          '(Redis via @objectstack/service-cache) or each node enforces the limit independently (ADR-0069 D2)' +
+          (opts.degradedImpact ? `. ${opts.degradedImpact}` : ''),
+      );
+    }
+    return fallback;
+  };
+}
+
 /**
  * ADR-0069 D2 — better-auth `rateLimit.customStorage` backed by the kernel
  * `cache` service, resolved **lazily, at the moment a counter is consumed**.
@@ -171,40 +238,17 @@ export interface LazyCacheRateLimitStorageOptions {
  * Scope note: this wires the RATE-LIMIT COUNTERS only. better-auth's
  * `secondaryStorage` (session snapshots) is a separate, deliberately untouched
  * decision — see the comment in `auth-plugin.ts` and `secondary-storage.ts`.
+ * ObjectStack's own per-number OTP budget counts through the same
+ * {@link createLazyCounterStore} resolution, one layer down (#4790).
  */
 export function createLazyCacheRateLimitStorage(
   opts: LazyCacheRateLimitStorageOptions,
 ): BetterAuthRateLimitStorage {
-  const fallback = new InProcessCounterStore();
-  let cache: CounterStore | undefined;
-  let boundAnnounced = false;
-  let degradedWarned = false;
-
-  const resolveStore = async (): Promise<CounterStore> => {
-    if (!cache) {
-      try {
-        cache = (await opts.resolveCache()) ?? undefined;
-      } catch {
-        cache = undefined;
-      }
-      if (cache && !boundAnnounced) {
-        boundAnnounced = true;
-        opts.logger?.info?.(
-          '[auth] rate-limit counters bound to the kernel cache service — enforced against ONE store across nodes iff the cache is shared (ADR-0069 D2)',
-        );
-      }
-    }
-    if (cache) return cache;
-    if (!degradedWarned) {
-      degradedWarned = true;
-      opts.logger?.warn?.(
-        '[auth] rate-limit counters have no cache service to count in — falling back to a per-process store. ' +
-          'This deployment has no `cache` service registered at all; a multi-node deployment needs a shared cache ' +
-          '(Redis via @objectstack/service-cache) or each node enforces the limit independently (ADR-0069 D2)',
-      );
-    }
-    return fallback;
-  };
+  const resolveStore = createLazyCounterStore({
+    resolveCache: opts.resolveCache,
+    ...(opts.logger ? { logger: opts.logger } : {}),
+    subject: 'rate-limit counters',
+  });
 
   return {
     consume: async (key, rule) => {


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4790

## 一、先核实(PM 指令 #1):issue 成立,现象与描述一致

按要求先验证再动手,结论是**该洞真实存在**,且存储来源确实就是 `AuthManagerOptions.secondaryStorage`:

1. **唯一存储来源** —— `AuthManager.getOtpSendGuard()`(`auth-manager.ts`,改动前)构造 `OtpSendGuard` 时,只有这一处会传 store:

   ```ts
   ...(this.config.secondaryStorage ? { storage: this.config.secondaryStorage } : {}),
   ```

   `OtpSendGuard` 内部 `load()/save()` 是二选一分支:有 `storage` 走共享 KV,没有就落到实例内的 `private readonly local = new Map()`。**没有第三条路径**,也没有任何地方从 `cache` 服务取过它。

2. **默认组合下确实为空** —— 全仓检索 `secondaryStorage` 的赋值点,`packages/plugins/plugin-auth/src` 之外只剩各包的 `CHANGELOG.md` 命中,没有任何宿主代码提供它;`packages/cli/src/commands/serve.ts` 的 `new AuthPlugin({...})` 不传;而 #4788 之后 `AuthPlugin.init()` 明确**不再**从 kernel cache 派生 `secondaryStorage`(注释写明:那会把会话的记录之处搬进缓存,废掉 ADR-0069 D4)。所以标准 `serve` 组合下 `storage === undefined`,预算落在**每进程一份**的 `local` Map 里。

3. **无任何信号** —— 这条路径上一句 warn 都没有,配置里能写每号码预算,多节点下不兑现,而运维看不到任何提示(ADR-0049 声明 ≠ 强制)。

4. **确属 #4788 未覆盖的独立一处** —— #4788 改的是 better-auth 的 `rateLimit.customStorage`;OTP 预算是 ObjectStack 自己在 `AuthManager` 里的另一套计数,行为未被 #4788 改变。

结论:issue 不需要关单,按原方向修。

## 二、修法:复用 #4788 那条路径,不写第二份

`rate-limit-storage.ts` 里把「惰性解析 → 绑定即宣告 → 解析不到就降级到有界进程内存储并响亮告警」这半边抽成 `createLazyCounterStore()`;`createLazyCacheRateLimitStorage()` 现在是它的一层薄封装(行为、日志文案对限流侧保持不变,#4788 的断言原样通过)。OTP 预算经新增的 `AuthManagerOptions.sharedCounterStore` 接同一条路径,由 `AuthPlugin` 用**同一个 `resolveCache` 闭包**填充。

- **不引入 `secondaryStorage`**(PM 指令 #3 / #4785):走 `cache` 惰性解析,会话的记录之处不动。宿主自己显式提供的 `secondaryStorage` 对这个预算仍然优先,行为不变。
- **进程内降级复用 `InProcessCounterStore`**:删掉了 guard 自己那份 `local` Map + 手写剪枝,只剩一个有界 fallback 实现。
- **未改 cache 服务本身,也未动 kernel 服务注册表**;改动全部在 `packages/plugins/plugin-auth`,`packages/spec/**` 零改动。

### 一处对 PM 指令 #2 的偏离,请复核

指令说复用 `createLazyCacheRateLimitStorage()` / `incrementFixedWindow`。我复用了前者的**解析路径**(抽出共用),但**没有**把 OTP 的计数改成 `incrementFixedWindow` 的定窗计数,理由:

- 定窗计数器表达不了「距上一次发送满 N 秒」这个**冷却**语义;
- 把「每滚动小时 5 条」改成定窗,会在窗口边界放行 2 倍突发(59:59 五条 + 60:01 五条)。本单的主题正是「预算被倍增」,用一种倍增换另一种倍增不划算,而且会静默改掉 #2780 声明并已有测试钉住的语义。

所以时间戳滚动窗口的算法原样保留,**只换了它所在的存储**——这正是本单的缺陷所在。若维护者更希望统一到定窗计数(接受上述语义变化),这部分可以单独再改。

## 三、验收对应

| 验收项 | 证据 |
|:---|:---|
| 配了 cache 的多节点部署,预算真正跨节点共享 | `otp-send-guard.test.ts` "is ONE budget across nodes when the cache is shared":两个 guard(两套 resolver)共用一个 cache,A 发过之后 B 立刻被拒;小时额度也是一份 |
| cache 在 auth 之后注册,计数仍落到共享 cache | `auth-plugin.test.ts` "counts the budget in a cache registered AFTER auth init":init 时 `cache` 不在注册表,之后再注册,第一次发送就落进共享 store(`phone-otp-sends:+86...`),并打出 bound 的 info |
| 没有 cache 的部署仍然限额,降级不是关闭 | `auth-plugin.test.ts` "warns loudly at counting time…":第二次发送仍被 429;warn 只在**真正计数时**打一次,含 `PAID SMS` 与 `no cache service registered at all` |
| 两种情况必须能区分 | 绑定 → info 且无 warn;降级 → warn 且无 info(两条断言分别钉在上面两个用例里) |

## 四、#2814 短信配额闸的核对(PM 指令 #4)

**不是同一套计数,无需另立 issue。** `packages/services/service-sms/src/` 下(`sms-service.ts` / `sms-plugin.ts` / `transports/`)检索 `quota` / `daily` 均无命中,#2814 目前**尚未实施**——`daily_quota` / `daily_quota_per_tenant` 都还不存在,因此不存在「建立在进程内计数上、上线即失效」的第二个闸。本 PR 抽出的 `createLazyCounterStore()` 正好是 #2814 落地时该用的那条路径(#2814 正文第 4 点要求的就是这个降级策略)。

## 五、验证

```
pnpm --filter @objectstack/plugin-auth test   → Test Files 29 passed (29) / Tests 649 passed (649)
pnpm --filter @objectstack/plugin-auth typecheck → tsc --noEmit,无输出(通过)
pnpm --filter @objectstack/plugin-auth build  → ESM/CJS/DTS build success
```

已加 changeset:`.changeset/auth-otp-budget-shared-counter-store.md`。


---
_Generated by [Claude Code](https://claude.ai/code/session_015Br2xsJsczFsTR9bvbh2Ny)_