### PR TITLE
fix(service-analytics): 按聚合种类填充「查询从未报告过的分组」,并补上 compareTo 这一道接缝 (#4708)

### DIFF
--- a/.changeset/analytics-empty-group-fill-compare-seam.md
+++ b/.changeset/analytics-empty-group-fill-compare-seam.md
@@ -1,0 +1,45 @@
+---
+"@objectstack/service-analytics": patch
+---
+
+fix(service-analytics): a measure a query never reported reads 0 for a count/sum on every merge seam (#4708)
+
+A dataset measure carrying its own `filter` runs as a separate grouped
+sub-query and is merged back onto the selected dimensions. A `GROUP BY` over a
+filtered row set emits **no group at all** for a dimension value the filter
+excludes entirely, so the measure comes back **absent**, not `0` — and
+`computeDerived` treats an absent operand as unknowable, so every ratio over it
+goes null too. The cell then renders blank, which is visually identical to "no
+data for this row" and means the opposite.
+
+The bias runs the worst possible way: the rows that blank are the ones whose
+numerator matched nothing — the **worst-performing rows**. A `lead_source` that
+won nothing rendered as "no data" while one that won everything rendered fine.
+
+The empty-group value is now filled **by aggregate kind** into every measure
+column the assembled grid lists but no query reported:
+
+| aggregate | over an excluded group | why |
+|:---|:---|:---|
+| `count`, `count_distinct` | `0` | "how many rows matched" has an exact answer when the answer is none |
+| `sum` | `0` | the identity element of the empty set |
+| `avg`, `min`, `max` | stays `null` | genuinely undefined — there is nothing to average |
+
+Filling all five with `0` would trade this lie for its mirror image, reporting a
+measurement nobody made, so the kinds are judged separately (via
+`emptyGroupValueFor`, shared with the authoring-side coherence checks).
+
+**Only cells are filled, never rows.** A dimension value no query reported at
+all has genuinely no data and stays out of the grid.
+
+**What changes beyond the measure-scoped seam.** The fill previously ran before
+the `compareTo` merge, and that merge *appends* a row for every bucket the
+PREVIOUS window had and this one does not. Every base measure on those rows —
+including unfiltered ones — was absent, so a lead source that sold last month
+and nothing this month rendered as "no data" instead of `0`: the same worst-row
+bias, one merge later. The fill now runs after every merge and covers all base
+measures plus their `<measure>__compare` columns.
+
+Widgets that worked around this with `?? 0` in the consumer or a `coalesce` in
+the measure can drop it; the coercion belongs in the executor, which is the only
+layer that knows which aggregate produced the gap.

--- a/.changeset/analytics-empty-group-fill-compare-seam.md
+++ b/.changeset/analytics-empty-group-fill-compare-seam.md
@@ -1,5 +1,5 @@
 ---
-"@objectstack/service-analytics": patch
+"@objectstack/service-analytics": minor
 ---
 
 fix(service-analytics): a measure a query never reported reads 0 for a count/sum on every merge seam (#4708)
@@ -43,3 +43,8 @@ measures plus their `<measure>__compare` columns.
 Widgets that worked around this with `?? 0` in the consumer or a `coalesce` in
 the measure can drop it; the coercion belongs in the executor, which is the only
 layer that knows which aggregate produced the gap.
+
+**New export.** `fillEmptyGroups(rows, columnAggregates)` is exported from the
+package root beside `mergeByDimensions`, so a host assembling a grid outside
+`DatasetExecutor` can apply the same aggregate-kind rule rather than
+reimplementing it — which is what makes this a `minor` rather than a `patch`.

--- a/packages/services/service-analytics/src/__tests__/dataset-empty-group-fill.test.ts
+++ b/packages/services/service-analytics/src/__tests__/dataset-empty-group-fill.test.ts
@@ -1,0 +1,273 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Empty-group fill (#4708, objectui#3136).
+ *
+ * A measure carrying its own `filter` runs as a separate grouped sub-query and
+ * is merged back by dimension key. A `GROUP BY` over a filtered row set emits
+ * NO group for a dimension value the filter excludes entirely, so the measure
+ * comes back ABSENT rather than `0` — and a derived ratio over an absent
+ * operand goes null, so the cell renders blank: visually identical to "no data
+ * for this row", which is the opposite of what the row means.
+ *
+ * The bias is what makes it worth a dedicated suite: the rows that blank are
+ * exactly the WORST-performing ones (nothing matched the numerator's filter),
+ * while a row that matched everything renders fine. A dashboard that hides its
+ * worst rows and shows its best is the least acceptable direction for the
+ * error to run, so `renders the worst row …` below asserts the asymmetry
+ * directly rather than only the individual cells.
+ *
+ * The fill is strictly by aggregate kind — over-filling would trade this lie
+ * for its mirror image (an `avg` of nothing reported as 0 is a measurement
+ * nobody made), so `does NOT fill avg/min/max` pins the other side.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { IAnalyticsService, AnalyticsQuery, AnalyticsResult } from '@objectstack/spec/contracts';
+import { DatasetSchema } from '@objectstack/spec/ui';
+import { compileDataset } from '../dataset-compiler.js';
+import { DatasetExecutor, fillEmptyGroups } from '../dataset-executor.js';
+
+function fakeService(handler: (q: AnalyticsQuery) => AnalyticsResult): IAnalyticsService {
+  return { query: vi.fn(async (q: AnalyticsQuery) => handler(q)), getMeta: async () => [] };
+}
+
+// ── the issue's reproduction, verbatim (hotcrm#593 / hotcrm#656) ─────────────
+
+const winRate = DatasetSchema.parse({
+  name: 'pipeline', label: 'Pipeline', object: 'opportunity',
+  dimensions: [{ name: 'lead_source', field: 'lead_source', type: 'string' }],
+  measures: [
+    { name: 'won_count', aggregate: 'count', filter: { stage: 'closed_won' } },
+    { name: 'lost_count', aggregate: 'count', filter: { stage: 'closed_lost' } },
+    { name: 'decided_count', aggregate: 'count', filter: { stage: { $in: ['closed_won', 'closed_lost'] } } },
+    { name: 'win_rate', derived: { op: 'ratio', of: ['won_count', 'decided_count'] } },
+  ],
+});
+
+/**
+ * The four lead sources of the issue's table. Each sub-query returns only the
+ * groups its filter left non-empty — which is what a real `GROUP BY` does:
+ *   - `partner` won everything      → absent from the `lost_count` result
+ *   - `cold_call` won nothing       → absent from the `won_count` result
+ */
+const winRateService = fakeService((q) => {
+  switch (q.measures[0]) {
+    case 'won_count':
+      return { rows: [
+        { lead_source: 'content', won_count: 2 },
+        { lead_source: 'referral', won_count: 1 },
+        { lead_source: 'partner', won_count: 1 },
+      ], fields: [] };
+    case 'lost_count':
+      return { rows: [
+        { lead_source: 'content', lost_count: 1 },
+        { lead_source: 'referral', lost_count: 1 },
+        { lead_source: 'cold_call', lost_count: 1 },
+      ], fields: [] };
+    case 'decided_count':
+      return { rows: [
+        { lead_source: 'content', decided_count: 3 },
+        { lead_source: 'referral', decided_count: 2 },
+        { lead_source: 'partner', decided_count: 1 },
+        { lead_source: 'cold_call', decided_count: 1 },
+      ], fields: [] };
+    default:
+      return { rows: [], fields: [] };
+  }
+});
+
+const runWinRate = () =>
+  new DatasetExecutor(winRateService).execute(compileDataset(winRate), {
+    dimensions: ['lead_source'],
+    measures: ['won_count', 'lost_count', 'decided_count', 'win_rate'],
+  });
+
+describe('empty-group fill — a filtered count that matched nothing (#4708)', () => {
+  it('reports 0 (not blank) for the group its filter excluded, so the ratio computes', async () => {
+    const rows = (await runWinRate()).rows;
+    const cold = rows.find((r) => r.lead_source === 'cold_call')!;
+    // cold_call won nothing and lost one. The correct answer is 0%, not blank.
+    expect(cold.won_count).toBe(0);
+    expect(cold.decided_count).toBe(1);
+    expect(cold.win_rate).toBe(0);
+  });
+
+  it('fills the mirror gap too — a source that never lost reads 0 losses', async () => {
+    const rows = (await runWinRate()).rows;
+    expect(rows.find((r) => r.lead_source === 'partner')).toMatchObject({
+      won_count: 1, lost_count: 0, decided_count: 1, win_rate: 1,
+    });
+  });
+
+  it('renders the worst row exactly as legibly as the best one (the asymmetry)', async () => {
+    const rows = (await runWinRate()).rows;
+    // The defect's signature: `partner` (won everything) rendered fine while
+    // `cold_call` (won nothing) rendered blank — the dashboard hid its worst
+    // row. No row may come back with an unmeasured cell.
+    for (const row of rows) {
+      expect(row.win_rate, `win_rate blank for ${row.lead_source}`).not.toBeNull();
+      expect(row.win_rate).toEqual(expect.any(Number));
+      for (const m of ['won_count', 'lost_count', 'decided_count']) {
+        expect(row[m], `${m} blank for ${row.lead_source}`).toEqual(expect.any(Number));
+      }
+    }
+    // …and the worst row is the one the reader must be able to act on.
+    const byRate = [...rows].sort((a, b) => Number(a.win_rate) - Number(b.win_rate));
+    expect(byRate[0]).toMatchObject({ lead_source: 'cold_call', win_rate: 0 });
+    expect(byRate[byRate.length - 1]).toMatchObject({ lead_source: 'partner', win_rate: 1 });
+  });
+
+  it('invents no group — a dimension value no query reported stays out of the grid', async () => {
+    const rows = (await runWinRate()).rows;
+    // Only the four sources some sub-query actually returned. `webinar` has no
+    // opportunities at all, so it is absent from every result and must not be
+    // materialised as a row of zeroes.
+    expect(rows.map((r) => r.lead_source).sort()).toEqual(['cold_call', 'content', 'partner', 'referral']);
+  });
+});
+
+// ── the other side: aggregates with no answer over an empty set ──────────────
+
+const amounts = DatasetSchema.parse({
+  name: 'deals', label: 'Deals', object: 'opportunity',
+  dimensions: [{ name: 'lead_source', field: 'lead_source', type: 'string' }],
+  measures: [
+    { name: 'won_count', aggregate: 'count', filter: { stage: 'closed_won' } },
+    { name: 'won_total', aggregate: 'sum', field: 'amount', filter: { stage: 'closed_won' } },
+    { name: 'won_avg', aggregate: 'avg', field: 'amount', filter: { stage: 'closed_won' } },
+    { name: 'won_min', aggregate: 'min', field: 'amount', filter: { stage: 'closed_won' } },
+    { name: 'won_max', aggregate: 'max', field: 'amount', filter: { stage: 'closed_won' } },
+    { name: 'all_count', aggregate: 'count' },
+  ],
+});
+
+describe('empty-group fill — strictly by aggregate kind (#4708)', () => {
+  it('does NOT fill avg/min/max: nothing to average over an empty group', async () => {
+    const svc = fakeService((q) => {
+      if (q.measures.includes('all_count')) {
+        return { rows: [
+          { lead_source: 'content', all_count: 4 },
+          { lead_source: 'cold_call', all_count: 1 },
+        ], fields: [] };
+      }
+      // every won_* sub-query: cold_call won nothing, so no group for it
+      const m = q.measures[0];
+      return { rows: [{ lead_source: 'content', [m]: 7 }], fields: [] };
+    });
+    const res = await new DatasetExecutor(svc).execute(compileDataset(amounts), {
+      dimensions: ['lead_source'],
+      measures: ['all_count', 'won_count', 'won_total', 'won_avg', 'won_min', 'won_max'],
+    });
+    const cold = res.rows.find((r) => r.lead_source === 'cold_call')!;
+    // Measured facts: no rows matched, so the count is 0 and the sum is 0.
+    expect(cold.won_count).toBe(0);
+    expect(cold.won_total).toBe(0);
+    // Genuinely unknown — filling these would report a measurement nobody made
+    // ("average deal size 0" is a different claim from "no deals").
+    for (const m of ['won_avg', 'won_min', 'won_max']) {
+      expect(cold[m] ?? null, `${m} must stay null`).toBeNull();
+      expect(cold[m], `${m} must not be flattened to 0`).not.toBe(0);
+    }
+    // The group that did have data is untouched.
+    expect(res.rows.find((r) => r.lead_source === 'content')).toMatchObject({
+      won_count: 7, won_total: 7, won_avg: 7, won_min: 7, won_max: 7,
+    });
+  });
+});
+
+// ── the compareTo seam: rows APPENDED by the comparison merge ────────────────
+
+const compareDs = DatasetSchema.parse({
+  name: 'trend', label: 'Trend', object: 'opportunity',
+  dimensions: [
+    { name: 'lead_source', field: 'lead_source', type: 'string' },
+    { name: 'close_date', field: 'close_date', type: 'date' },
+  ],
+  measures: [
+    { name: 'revenue', aggregate: 'sum', field: 'amount' },
+    { name: 'avg_deal', aggregate: 'avg', field: 'amount' },
+    { name: 'won_count', aggregate: 'count', filter: { stage: 'closed_won' } },
+  ],
+});
+
+describe('empty-group fill — buckets the comparison window added (#4708)', () => {
+  it('fills every base measure on a row only the previous period produced', async () => {
+    const svc = fakeService((q) => {
+      const shifted = JSON.stringify(q.timeDimensions ?? []).includes('2025-12');
+      if (shifted) {
+        return { rows: [
+          { lead_source: 'content', revenue: 80, avg_deal: 40, won_count: 2 },
+          { lead_source: 'cold_call', revenue: 10, avg_deal: 10, won_count: 1 },
+        ], fields: [] };
+      }
+      if (q.measures.includes('won_count')) {
+        return { rows: [{ lead_source: 'content', won_count: 3 }], fields: [] };
+      }
+      // this period, `cold_call` has no opportunities at all
+      return { rows: [{ lead_source: 'content', revenue: 100, avg_deal: 50 }], fields: [] };
+    });
+    const res = await new DatasetExecutor(svc).execute(compileDataset(compareDs), {
+      dimensions: ['lead_source'],
+      measures: ['revenue', 'avg_deal', 'won_count'],
+      timeDimensions: [{ dimension: 'close_date', dateRange: ['2026-01-01', '2026-01-31'] }],
+      compareTo: { kind: 'previousPeriod', dimension: 'close_date' },
+    });
+    const cold = res.rows.find((r) => r.lead_source === 'cold_call')!;
+    // The row exists because the comparison window had data for it; "how much
+    // did cold_call sell this period" therefore has an exact answer — none.
+    // Before #4708 the fill ran BEFORE this merge, so all three read blank.
+    expect(cold.revenue).toBe(0);
+    expect(cold.won_count).toBe(0);
+    expect(cold.avg_deal ?? null).toBeNull();
+    // the comparison columns are untouched — they were reported
+    expect(cold).toMatchObject({ revenue__compare: 10, won_count__compare: 1 });
+  });
+
+  it('fills a comparison column the previous window never reported', async () => {
+    const svc = fakeService((q) => {
+      const shifted = JSON.stringify(q.timeDimensions ?? []).includes('2025-12');
+      // the previous period knew nothing of `content`
+      if (shifted) return { rows: [], fields: [] };
+      if (q.measures.includes('won_count')) {
+        return { rows: [{ lead_source: 'content', won_count: 3 }], fields: [] };
+      }
+      return { rows: [{ lead_source: 'content', revenue: 100, avg_deal: 50 }], fields: [] };
+    });
+    const res = await new DatasetExecutor(svc).execute(compileDataset(compareDs), {
+      dimensions: ['lead_source'],
+      measures: ['revenue', 'avg_deal', 'won_count'],
+      timeDimensions: [{ dimension: 'close_date', dateRange: ['2026-01-01', '2026-01-31'] }],
+      compareTo: { kind: 'previousPeriod', dimension: 'close_date' },
+    });
+    expect(res.rows[0]).toMatchObject({
+      revenue: 100, won_count: 3,
+      // "sold nothing last month" — a fact, not a gap
+      revenue__compare: 0, won_count__compare: 0,
+    });
+    expect(res.rows[0].avg_deal__compare ?? null).toBeNull();
+  });
+});
+
+// ── the helper in isolation ─────────────────────────────────────────────────
+
+describe('fillEmptyGroups', () => {
+  it('fills count/count_distinct/sum, leaves avg/min/max and reported values alone', () => {
+    const rows = [
+      { g: 'a', c: 2, d: 1, s: 5, avg: 2.5, min: 1, max: 4 },
+      { g: 'b' },
+    ];
+    fillEmptyGroups(rows, {
+      c: 'count', d: 'count_distinct', s: 'sum', avg: 'avg', min: 'min', max: 'max',
+      unknown: undefined,
+    });
+    expect(rows[0]).toEqual({ g: 'a', c: 2, d: 1, s: 5, avg: 2.5, min: 1, max: 4 });
+    expect(rows[1]).toEqual({ g: 'b', c: 0, d: 0, s: 0 });
+  });
+
+  it('touches only the columns it is given, and never adds rows', () => {
+    const rows = [{ g: 'a' }];
+    expect(fillEmptyGroups(rows, { c: 'count' })).toHaveLength(1);
+    expect(rows[0]).toEqual({ g: 'a', c: 0 });
+  });
+});

--- a/packages/services/service-analytics/src/dataset-executor.ts
+++ b/packages/services/service-analytics/src/dataset-executor.ts
@@ -26,6 +26,8 @@ export type CompareTo = DatasetCompareTo;
  * runtime, then post-processes the results:
  *   - resolves the base measures a selection needs (including derived deps),
  *   - applies measure-scoped filters via supplementary grouped queries,
+ *   - fills the empty-group value into columns no query reported, by aggregate
+ *     kind (#4708) — a count/sum over an excluded group is 0, avg/min/max null,
  *   - evaluates derived measures (ratio/sum/difference/product) row-by-row (Q1),
  *   - shifts the query for `compareTo` (previousPeriod / previousYear) and
  *     attaches `<measure>__compare` columns,
@@ -147,6 +149,61 @@ export function evaluateDerivedMeasures(
     }
     return out;
   });
+}
+
+/**
+ * Fill the EMPTY-GROUP value into every measure column the assembled grid
+ * LISTS but no query REPORTED — by aggregate kind (#4708, objectui#3136).
+ *
+ * The grid is assembled from several results: the primary query, one
+ * supplementary query per measure-scoped filter, and (for `compareTo`) a
+ * shifted pass. {@link mergeByDimensions} writes a measure's column only onto
+ * rows its source result returned, and a `GROUP BY` over a filtered row set
+ * emits NO group at all for a dimension value the filter excludes entirely.
+ * The column therefore comes back **absent**, not `0` — and absent renders as
+ * "no data for this row", which for a count is the opposite of what the row
+ * means. A derived ratio over it goes null as well ({@link computeDerived}
+ * treats a missing operand as unknowable), so the blank spreads.
+ *
+ * The bias runs the worst possible way: the rows that blank are the ones whose
+ * numerator the filter excluded — the WORST-performing rows. A `lead_source`
+ * that won nothing renders as "no data" while one that won everything renders
+ * fine.
+ *
+ * **Filled strictly by aggregate kind**, never wholesale. `count` /
+ * `count_distinct` over an excluded group is unambiguously `0` ("how many rows
+ * matched" has an exact answer when the answer is none), and `sum` over the
+ * empty set is its identity `0`. `avg` / `min` / `max` are genuinely null —
+ * there is nothing to average — and flattening those to `0` would trade this
+ * lie for the opposite one, reporting a measurement nobody made. The
+ * kind→identity mapping is `emptyGroupValueFor` in `@objectstack/spec/data`,
+ * shared with the authoring-side coherence checks so the two cannot drift.
+ *
+ * **Only rows that already exist are touched** — no group is invented. A
+ * dimension value no query reported at all has genuinely no data and stays out
+ * of the grid; this fills the cell, never the row.
+ *
+ * Deliberately NOT a `?? 0` in the widget or a `coalesce` in the measure: a
+ * consumer-side patch must be repeated by every author of every ratio widget
+ * forever, and forgetting it is silent. Only the executor knows which aggregate
+ * produced the gap, so only the executor can tell `0` from unknown.
+ *
+ * Mutates `rows` in place (they are already this pipeline's own copies) and
+ * returns them for chaining.
+ *
+ * @param columnAggregates - Grid column → the aggregate that produced it.
+ *   Includes `<measure>__compare` columns, which merge through the same seam.
+ */
+export function fillEmptyGroups(
+  rows: Record<string, unknown>[],
+  columnAggregates: Record<string, string | undefined>,
+): Record<string, unknown>[] {
+  for (const [column, aggregate] of Object.entries(columnAggregates)) {
+    const empty = emptyGroupValueFor(aggregate);
+    if (empty === undefined) continue;
+    for (const row of rows) if (row[column] == null) row[column] = empty;
+  }
+  return rows;
 }
 
 function num(v: unknown): number | null {
@@ -554,23 +611,6 @@ export class DatasetExecutor {
       result.fields.push({ name: m, type: 'number' });
     }
 
-    // A measure-scoped filter can exclude EVERY row of a group the grid still
-    // lists, and the database reports that by omitting the group from the
-    // sub-result — indistinguishable, after the merge, from "not measured".
-    // For a count or a sum it IS measured: the answer is 0. Fill it in, so a
-    // "0 of 12 paid" group reads as 0 rather than blank and any ratio built on
-    // it computes instead of going null (objectui#3136). avg/min/max keep their
-    // null — there is nothing to average over an empty group.
-    //
-    // Runs after ALL supplementary merges, not inside the loop: a later
-    // measure's merge can append rows for dimension keys no earlier query saw,
-    // and those rows need the same fill.
-    for (const m of filtered) {
-      const empty = emptyGroupValueFor(compiled.cube.measures?.[m]?.type);
-      if (empty === undefined) continue;
-      for (const row of result.rows) if (row[m] == null) row[m] = empty;
-    }
-
     // compareTo — run a shifted query over the same base measures and attach.
     if (selection.compareTo) {
       const compareRows = await this.runCompare(compiled, selection, [...baseMeasures], dimensions, baseFilter, context);
@@ -582,6 +622,34 @@ export class DatasetExecutor {
       );
       for (const m of baseMeasures) result.fields.push({ name: `${m}__compare`, type: 'number' });
     }
+
+    // Empty-group fill (#4708) — a group a query never reported reads `0` for a
+    // count/sum and stays null for avg/min/max. See {@link fillEmptyGroups} for
+    // why this belongs to the executor and not to every widget author.
+    //
+    // Placed after EVERY merge and before the derived pass, because each merge
+    // is a place a column can go missing and `mergeByDimensions` APPENDS rows:
+    //   - a supplementary measure-scoped query omits the groups its filter
+    //     excluded (the "won nothing" rows — the original defect);
+    //   - a later supplementary query can append rows for dimension keys no
+    //     earlier query saw, and those need the same fill;
+    //   - the compareTo pass appends a row for every bucket that existed in the
+    //     PREVIOUS window and not in this one, on which *every* base measure is
+    //     absent — including unfiltered ones, which is why the fill covers all
+    //     base measures rather than only the filter-scoped ones.
+    // Running it before the compare merge left that last class blank, so a lead
+    // source that sold last month and nothing this month rendered as "no data"
+    // instead of 0 — the same worst-row bias, one merge later.
+    //
+    // Derived measures are evaluated AFTER, so a ratio over a filled 0 computes
+    // (0%) instead of being poisoned by an absent operand.
+    const fillColumns: Record<string, string | undefined> = {};
+    for (const m of baseMeasures) {
+      const aggregate = compiled.cube.measures?.[m]?.type;
+      fillColumns[m] = aggregate;
+      if (selection.compareTo) fillColumns[`${m}__compare`] = aggregate;
+    }
+    fillEmptyGroups(result.rows, fillColumns);
 
     // Derived measures (computed from base + compare columns already present).
     result.rows = evaluateDerivedMeasures(result.rows, selectedDerived);

--- a/packages/services/service-analytics/src/index.ts
+++ b/packages/services/service-analytics/src/index.ts
@@ -28,6 +28,7 @@ export {
   combineFilters,
   shiftRange,
   mergeByDimensions,
+  fillEmptyGroups,
 } from './dataset-executor.js';
 export type { DatasetSelection, CompareTo } from './dataset-executor.js';
 export { compileScopedFilterToSql } from './read-scope-sql.js';


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4708

按 issue 作者的推荐与 PM 裁定取**方向 1**(在 merge 时按聚合种类填充),不取方向 2(`missingAs: 'zero'`)。理由就是 issue 自己写的那条:方向 2 把决定重新分配给每一个未来的作者,而**忘记的失败模式是静默的** —— 对一个从邻近声明里模式匹配的 AI 作者来说,必须被记住的正确性开关等价于终将被漏掉的正确性开关。方向 1 没有这个表面积。

零改动:`packages/spec/**`。本 PR 只动 `packages/services/service-analytics`。

---

## 现场复核:一半已经在 main 上,另一半还在

先说一个必须讲清楚的事实,免得 reviewer 以为这个 PR 比实际大或比实际小。

issue 描述的机制里,**「measure 自带 filter 的那道接缝」在 main 上已经修好了** —— objectui#3136 曾经加过一段按聚合种类的填充(`emptyGroupValueFor`),就在 `executeSelection` 里。我用 issue 的复现表逐字跑了一遍真实 executor,四行全部正确:`cold_call` 的 `won_count` 是 0、`win_rate` 是 0%。

但那段代码**一个测试都没有**。issue 的验收标准 1/2/3 要求把这个行为钉死,而当时没有任何东西拦得住它回退 —— 事实上它下面就摆着一次回退的活证据(见下)。所以本 PR 的第一半是:把 issue 的复现表原样变成回归测试。

第二半是真正的代码修复:**同一个缺陷在下一道接缝上原封不动地活着**。

## 还活着的那一半:compareTo 追加出来的行

填充过去跑在 `compareTo` 合并**之前**。而那次合并是会**追加行**的(`mergeByDimensions` 对只在对比窗口出现的 bucket 做 outer-ish 追加,注释里写着「so comparison-only buckets still surface」)。被追加出来的行上,**每一个** base measure 都是缺失的 —— 包括没有 filter 的那些,因为主查询压根没返回过这个分组。

用假 service 跑真 executor,修复前的输出:

```
{ lead_source: 'content',   revenue: 100, avg_deal: 50, won_count: 3,
                            revenue__compare: 80, avg_deal__compare: 40, won_count__compare: 2 },
{ lead_source: 'cold_call', revenue__compare: 10, avg_deal__compare: 10, won_count__compare: 1 }
```

`cold_call` 上个周期卖过、这个周期一单没有 —— 这一行的 `revenue` / `won_count` 全是空白,而正确答案是 **0**。偏置方向和 issue 抓到的那条一模一样:**空白的恰好是表现最差的行**。上期有业绩、本期归零的渠道,在仪表盘上渲染成「无数据」,而不是「归零了」—— 后者才是要看的那个信号。

修复后同一组输入:`revenue: 0`、`won_count: 0`、`avg_deal: null`,`__compare` 三列原样不动。

顺带把镜像的一侧也一起覆盖了:本期存在、上期完全没有的 bucket,`revenue__compare` / `won_count__compare` 现在读 0 而不是空白(「上个月卖了 0」是事实,不是缺口)。这两列走的是**同一个** `mergeByDimensions` 调用、同一套聚合种类推理,分开修只会让下一个 issue 立刻开在隔壁那一行 —— 但它确实比 issue 的字面范围宽一点,所以在这里点名,reviewer 若认为该拆出去,砍掉三行即可。

## 严格按聚合种类,不一刀切

| aggregate | 分组被排除时 | 为什么 |
|:---|:---|:---|
| `count` / `count_distinct` | `0` | 「有多少行匹配」在没有匹配时有确切答案 |
| `sum` | `0` | 空集合上的单位元 |
| `avg` / `min` / `max` | 保持 `null` | 确实无定义 —— 没有东西可平均 |

一刀切填 0 会把「没有数据」和「平均值为零」混成一件事,制造一个方向相反的新谎。种类→单位元的映射仍然是 `@objectstack/spec/data` 的 `emptyGroupValueFor`(与 authoring 侧的一致性检查共用一个源,两边不会漂移),本 PR 没有碰它。

**只填格子,不造行**(验收标准 4):填充只遍历**已经存在**于网格里的行。某个维度值如果没有任何一个查询报告过,它就是真的没有数据,不会被凭空物化成一行 0。测试里有一条专门钉这个。

## 改了什么

- `dataset-executor.ts` — 新导出 `fillEmptyGroups(rows, columnAggregates)`,把原先内联在循环后的那段提出来;调用点从「supplementary 合并之后」移到「**所有**合并之后、derived 求值之前」,覆盖范围从 `filtered` 扩到全部 base measure 加它们的 `__compare` 列。
- `index.ts` — 导出 `fillEmptyGroups`(与既有的 `mergeByDimensions` 同级,便于直接单测)。
- `__tests__/dataset-empty-group-fill.test.ts` — 新增 9 条。
- 一个 changeset(patch,`@objectstack/service-analytics`)。

## 测试

`pnpm --filter @objectstack/service-analytics test` → **37 files / 502 tests passed**(含新增 9 条)。

新测试对**修复前**的 executor 跑过一遍,证明它们真的钉住了东西:

```
× fills every base measure on a row only the previous period produced
× fills a comparison column the previous window never reported
× fills count/count_distinct/sum, leaves avg/min/max and reported values alone
× touches only the columns it is given, and never adds rows
Tests  4 failed | 5 passed (9)
```

那 5 条修复前就通过 —— 它们正是 issue 复现表的回归钉,钉的是 objectui#3136 已经修好、但一直裸奔的行为。

`tsc --noEmit`:7 处报错,全部在本 PR 未触碰的既有测试文件里(`analytics-service.test.ts` 的 TS6133、`measure-source-field-gate.test.ts` 的 TS2339、`objectql-timedimension-projection.test.ts` 的 TS7053),我改动的三个文件 **0 报错**。该包在 `check-type-check-coverage.mjs` 里带 DEBT 条目,本 PR 不增不减。ESLint 对三个改动文件干净。

## ⚠️ 跨仓协调:hotcrm 侧会转红,这是设计好的信号

issue 说明 hotcrm 侧钉了一条**故意写成「平台修好后会失败」**的断言,用来把平台的修复暴露成一条红测试,而不是让仪表盘悄悄改变数字。

**本 PR 合并后,那条 app 侧测试会转红 —— 这是预期信号,不是回归,也不是撞车。** 我们不改那个仓;请对面按 hotcrm#656 的原计划把断言翻过来(顺带可以撤掉 `?? 0` 之类的消费侧兜底,以及把 `decided_count` 换回 `derived: { op: 'sum', of: ['won_count','lost_count'] }` 的写法 —— 现在 `lost_count` 会被填 0,那个「从没输过的销售分母变空」的坑不复存在了)。

相关:hotcrm#656、hotcrm#593、#4698。

## 顺手发现的、**没有**在本 PR 里修的两件事(Prime Directive #10)

- **#4820** — `compareTo` 完全丢弃 measure 级 filter:`runCompare` 只带 `baseFilter` 发一条 shifted 查询,`compiled.measureFilters` 从未被查阅。于是 `won_count__compare` 数的是上个周期的**全部**行,不是赢单行 —— 与它并排那一列是两个不同的度量。这是**数错**而不是**留白**,补法(按主路径拆成每个 filtered measure 一条 shifted 子查询)和影响面都不同,单独修。
- **#4821** — `mergeByDimensions` 的维度键用空串拼接(`.join('')`),多维度下 `'ab'|'c'` 与 `'a'|'bc'` 撞键,两个分组会合并成一行;`String(row[d] ?? '')` 还把 `null` 和 `''` 压成同一个键。隔壁 `cross-object-rebucket.ts` 已经用 JSON 编码解决过同一个问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Br2xsJsczFsTR9bvbh2Ny


---
_Generated by [Claude Code](https://claude.ai/code/session_015Br2xsJsczFsTR9bvbh2Ny)_