### PR TITLE
docs(pm-dispatch): domain 车道 —— 按修复落点划域,支持同仓多 PM 并发 (#4819)

### DIFF
--- a/.changeset/pm-dispatch-domain-lanes.md
+++ b/.changeset/pm-dispatch-domain-lanes.md
@@ -1,0 +1,16 @@
+---
+---
+
+docs(pm-dispatch): domain 车道协议 —— 按「修复落点的包」划域,支持同仓多 PM 并发 (#4819)
+
+`.claude/skills/pm-dispatch/SKILL.md` 新增「Domain lanes(同仓多 PM 并发)」一节:
+锚定规则(每个包恰好属于一个 domain,`domain:*` 标签取**修复落点所在包**的域,分诊时
+读代码后打,不从标题词汇猜 —— #4775 的 hook condition 概念属 automation,落点却是
+`packages/objectql/src/hook-wrappers.ts`,故归 `domain:engine`)、六域分类表、标签纪律
+(打标 ≠ 认领;未打标不得认领)、认领范围(在 #4604 登记 domain 集合)、跨域单与借单
+规则、选批时的全局在飞检查,以及合并队列仍是全体共享串行资源的提醒(flaky 税,#4796)。
+认领注释模板加「域」「文件面」两行(跨域与借单必填);Multi-repo coordination 规则 4 的
+「同队列多 PM 一律禁止」改为「仅在 domain 车道协议生效时允许」,repo 分片阶梯保留,
+domain 车道作为第三级。
+
+仅改内部 agent 协议文本,不发布任何包。

--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -102,11 +102,13 @@ known case: accepting a `repo:objectui` PR ⇒ file a `pm:queue` issue in
 `objectstack` — "run `pnpm objectui:refresh` and land the console bump",
 referencing the merged PR, blocked-by it until it actually merges.
 
-**4. Multiple PM sessions shard by repo — never share one queue.** The
-claim protocol makes concurrent PMs *safe*, not *useful*: batch
-independence (file-disjointness) is only checked within one PM's view, so
-two PMs on the same queue can claim different issues that collide on
-shared files, and the merge queue is one lane regardless. Scaling order:
+**4. Multiple PM sessions shard by repo; one shared queue only under
+domain lanes.** The claim protocol makes concurrent PMs *safe*, not
+*useful* on its own: batch independence (file-disjointness) is only checked
+within one PM's view, so two PMs on the same queue can claim different
+issues that collide on shared files, and the merge queue is one lane
+regardless. Making that check **global** is exactly what the next section
+does. Scaling order:
 
 1. One PM, bigger batch (`batch:5` is the maintainer's chosen operating
    point, riding on the resource discipline above), heavy tasks via
@@ -115,7 +117,13 @@ shared files, and the merge queue is one lane regardless. Scaling order:
    repo** as its shard (`/pm-dispatch repo:objectstack-ai/objectui`) —
    file universes are disjoint by construction. A sharded PM states its
    shard in every claim comment and **never claims outside it**.
-3. Multiple PMs on the SAME queue: prohibited — all cost, no throughput.
+3. Multiple PMs on the SAME queue: **prohibited unless the Domain-lanes
+   protocol (next section) is active** — every PM in its own session and
+   its own container, domain sets registered in the registry issue, label
+   discipline observed, and the global in-flight check run at every batch
+   selection. Without that protocol the ban stands as written: all cost,
+   no throughput, and the collision stays invisible to both PMs until the
+   merge.
 
 **Shard ownership is registered, never assumed.** A registry issue in the
 main backlog (`[PM] 分片分工登记表`) records which session owns which
@@ -158,6 +166,81 @@ machine; an org-level GitHub Project pulling issues/PRs from all three repos
 gives the maintainer a single view (filter by `repo:*` and `pm:*`). The PM
 maintains no tracking state outside GitHub — that invariant is what keeps
 the loop resumable and the board honest.
+
+## Domain lanes(同仓多 PM 并发)
+
+Rule 4's ladder ran out at one PM per repo because file-disjointness is only
+ever checked inside one PM's own view. Domain lanes are the **third rung**:
+one PM's triage verdict is cached as a `domain:*` label every other PM can
+read, so batch selection filters at the label layer instead of at the merge.
+Premise: each PM is its **own session in its own container** — adding a PM
+adds compute, not contention — and collisions are prevented by the
+domain→package mapping, not by hoping two PMs pick different work.
+
+**Anchoring rule.** The whole scheme rests on this one sentence:
+
+> Every package belongs to exactly **one** domain; an issue's `domain:*`
+> label is the domain of **the package the fix lands in**, decided at triage
+> by reading the code — **never guessed from the issue's title vocabulary**.
+
+The counter-example that makes it a rule: #4775 is a hook `condition`, which
+reads as automation, but the fix lands in
+`packages/objectql/src/hook-wrappers.ts` ⇒ `domain:engine`. Labeling by topic
+would have routed it to a different PM than the one already inside that
+package — the exact collision lanes exist to prevent. If you cannot say which
+file the fix touches, you have not triaged it yet, and it is not labelable.
+
+| 标签 | 包家族 |
+|:--|:--|
+| `domain:engine` | `packages/objectql`、`packages/metadata*`、`packages/platform-objects`、`packages/core`、`packages/plugins/driver-*` |
+| `domain:services` | `packages/services/*`、`packages/plugins/plugin-approvals`、`plugin-webhooks`、`packages/connectors/*` |
+| `domain:identity` | `packages/plugins/plugin-auth`、`plugin-security`、`plugin-sharing`、`plugin-audit` |
+| `domain:devx` | `packages/lint`、`skills/**`、`content/docs/**`、`scripts/`(门禁类) |
+| `domain:spec` | `packages/spec` 及其生成物(现 spec 车道不变) |
+| `domain:cli` | `packages/cli`、`runtime`、`verify`、`qa`、`types` |
+
+`examples/**` belongs to the subsystem it exercises; anything that fits
+nowhere is judged at triage by its principal landing site. A package missing
+from the table is classified the first time it is triaged and the table
+updated **by PR** — the taxonomy evolves deliberately, never per-claim.
+
+**Label discipline.** `domain:*` is applied during the backlog sweep (round
+loop step 0) by whichever PM triages the issue. **Labeling ≠ claiming**: any
+PM may label any issue, including ones it will never claim — the label is
+shared routing, not a reservation. An **unlabeled issue may not be claimed by
+anyone**: triage and label it first, or selection has silently gone back to
+happening inside one PM's private view.
+
+**Claim scope.** Each PM session registers its **domain set** in the registry
+issue (`[PM] 分片分工登记表`, #4604 — the same registry that records repo
+shards) and claims only issues whose label falls inside that set. A set, not
+a single domain: lanes are a routing table, not a job title.
+
+**Cross-domain issues.** Prefer the contract-first split of rule 2 — one
+sub-issue per domain, each carrying its own `domain:*` label, ordered with
+`Blocked-by:`. When a split costs more than it buys, a single PM claims the
+whole issue and **declares the full file surface** in its claim comment, so
+every other PM's in-flight check can see all of it.
+
+**Borrowing.** An idle PM may claim outside its registered set when all three
+hold: (a) that domain's PM has not claimed the issue, (b) the claim comment
+declares the file surface, (c) the global in-flight check below passes.
+Borrowing is a one-issue exception, not a lane transfer — the registry entry
+does not change, so nobody has to guess who owns the domain afterwards.
+
+**Global in-flight check — run it at batch selection (step 3).** List every
+`pm:dispatched` issue across the repo, read the file-surface declaration on
+each one's latest claim comment, and require your candidates to be disjoint
+from all of them. This is step 3's independence test raised from your batch
+to the whole repo; skip it and two individually-independent batches are
+jointly dependent, which is precisely the failure the same-queue ban was
+protecting against.
+
+**The merge queue is still one shared serial resource.** Lanes buy parallel
+authorship, not parallel landing: the flaky-test tax (#4796) scales linearly
+with the number of PMs, and a red queue blocks every lane at once. Queue
+health is therefore a shared duty — a PM that notices a flake fixes or files
+it rather than re-queuing past it, whichever lane it came from.
 
 ## The round loop
 
@@ -280,6 +363,12 @@ execute atomically, in order:
    > 会话:`session_<id>`
    > 分支:`claude/issue-<n>-<slug>`
    > Worktree:`<repo>-issue-<n>`
+   > 域:`domain:<x>`
+   > 文件面:`<预计触碰的目录列表>`(越界即停,报告说明)
+
+   「文件面」is **required** for cross-domain and borrowed claims and
+   **recommended** for ordinary same-domain ones — it is the only input
+   another PM's global in-flight check has to read.
 3. **Race check**: assignment is idempotent, so two agents can both
    "succeed". Re-read the comments; if an earlier claim comment with a
    *different* session ID or branch name exists, you lost — touch nothing of


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4819

维护者已拍板采用 domain 车道方案支持同仓多 PM 并发。本 PR 只做一件事:把协议文本落到 `.claude/skills/pm-dispatch/SKILL.md`,不改任何代码。

## 三处改动

**1. 新增「Domain lanes(同仓多 PM 并发)」一节**,紧接在「Multi-repo coordination」之后、「The round loop」之前:

- **前提**:每个 PM = 独立会话 + 独立容器,加 PM 即加算力;冲突由 domain→包映射防止,而不是靠两个 PM 碰巧挑到不同的活。
- **锚定规则**(原文照写):每个包恰好属于一个 domain;issue 的 `domain:*` 标签 = 修复落点所在包的 domain,分诊时读代码后打,绝不从标题词汇猜。
- **#4775 反例**:hook `condition` 读起来是 automation,落点却在 `packages/objectql/src/hook-wrappers.ts`,故归 `domain:engine` —— 按题目猜会把它路由给另一个 PM,而那个包里已经有人在干活,正是车道要避免的相撞。补一句可操作的判据:说不出落在哪个文件,就是还没分诊,也就不可打标。
- **六域分类表**:照抄 issue,未增删。`examples/**` 随其锻炼的子系统归域;表里没有的包在首次分诊时归类并**走 PR 更新此表**(分类演化是刻意的,不随认领漂移)。
- **标签纪律**:`domain:*` 在 backlog sweep(round loop 第 0 步)打;打标 ≠ 认领,任何 PM 可为任何 issue 打标;未打标的 issue 任何人不得认领。
- **认领范围**:每个 PM 会话在 #4604 登记自己的 domain **集合**,只认领集合内的 issue。
- **跨域单**:优先按规则 2 的 contract-first 拆分;不拆则单个 PM 认领并在认领注释里声明**全部**文件面。
- **借单**:空闲 PM 可跨域借单,三条同时成立才行(该域 PM 未认领 / 声明文件面 / 全局在飞检查通过);借单是一次性例外,不改登记表。
- **全局在飞检查**:选批时列出全仓 `pm:dispatched`,读其最新认领注释的文件面声明,要求与本批候选不相交 —— 这就是把第 3 步的批内独立性检查提升到全仓。
- **合并队列**:仍是全体共享的串行资源,flaky 税(#4796)随 PM 数线性放大,队列健康是全体的共同责任。

**2. 认领注释模板(round loop 第 4 步)加两行**:`域:` 与 `文件面:`(越界即停)。跨域单与借单**必填**,同域普通单建议填 —— 它是别的 PM 做全局在飞检查时唯一能读到的输入。

**3. 修订「Multi-repo coordination」规则 4**:阶梯第 3 级由「同队列多 PM:一律禁止」改为「**仅在 domain 车道协议生效时允许**」(独立会话独立容器 + 登记 domain 集合 + 标签纪律 + 全局在飞检查);协议不生效时禁令原样成立。repo 分片阶梯保留,domain 车道作为第三级。

## 验证

- **章节结构未破坏**:改动前后 `grep '^#\{1,4\} '` 的标题列表逐行 diff,唯一差异是新增的 `## Domain lanes(同仓多 PM 并发)` 一行,既有标题的文字与层级一字未改(该文件被多个在跑会话引用,这是硬要求)。
- **分类表逐字比对**:与 issue 正文的表格做 `diff`,完全一致(6 个域,未增删)。
- **Markdown 结构自检**:代码围栏成对、表格列数一致(唯一「不齐」的是既有的 Arguments 表,其中 `mode:subagent \| mode:cloud` 用了转义竖线,非本次改动)、frontmatter 完整、无行尾空白、认领模板 6 行齐全。
- 无代码改动:`pnpm lint`(eslint)不覆盖 markdown,`.claude/skills/` 也不在 `check:skill-docs` / `check:role-word` 的扫描根内(二者分别只读 `skills/` 与 `content/docs` + `skills`),因此没有需要重新生成的产物。

changeset 用空 frontmatter(先例:PR #4803 对 scripts-only 改动的做法)—— 只改内部 agent 协议文本,不发布任何包。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Br2xsJsczFsTR9bvbh2Ny

---
_Generated by [Claude Code](https://claude.ai/code/session_015Br2xsJsczFsTR9bvbh2Ny)_