### PR TITLE
fix(spec): 给 packages/spec 的 vitest 设 testTimeout 60s —— 止血,不再把无关 PR 踢出合并队列 (#4850)

### DIFF
--- a/.changeset/spec-vitest-testtimeout.md
+++ b/.changeset/spec-vitest-testtimeout.md
@@ -1,0 +1,38 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): give this package's vitest run a 60s `testTimeout` — stop evicting unrelated PRs from the merge queue (#4850)
+
+`packages/spec/vitest.config.ts` never set `testTimeout`, so every case in the
+package ran under vitest's **5000ms** default. Twelve tests in `src/` load the
+TypeScript compiler inside the case and type-resolve the whole export surface —
+`ts.createProgram` + `getTypeChecker`, then unalias each symbol and chase
+`originOf` — which is seconds of work by construction, not a hang:
+
+```
+api/rest-server · automation/state-machine · automation/sync-retirement · cloud/tenant
+data/driver · integration/connector · kernel/package-dependency-dual-source
+studio/action-location-retirement · system/environment-artifact · system/notification
+ui/app · ui/view
+```
+
+Measured on an idle runner the slowest of these cases takes **3.4s** against a
+5000ms budget — enough margin to stay green on a PR branch, and not enough on a
+merge-queue runner building several PRs' batches at once. That is exactly the
+observed signature: five failures in one night, all inside the queue, none on a
+PR branch, each one evicting a PR that had nothing to do with `spec` (#4755,
+#4788, #4823, #4822 twice).
+
+`testTimeout: 60_000` matches the value PR #4506 gave these same cases
+case-by-case, but applied once at the config layer so all twelve are covered —
+and so a thirteenth added later is covered on arrival instead of leaking through
+the way the per-case list did. 60s is ~17x the slowest measured case, so it
+absorbs queue contention without masking a genuine hang.
+
+This is a **stop-the-bleeding** change, not a fix for the underlying cost: 88% of
+those twelve files' test time is TypeScript compilation, ~39s of it, repeated per
+run. Hoisting the export-surface resolution into a build-time artifact is tracked
+separately in #4796, which stays open.
+
+No runtime, schema or public API change — test configuration only.

--- a/packages/spec/vitest.config.ts
+++ b/packages/spec/vitest.config.ts
@@ -7,6 +7,12 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
+    // 12 tests in this package load the TypeScript compiler and type-resolve the
+    // whole export surface (ts.createProgram + getTypeChecker). That is seconds of
+    // work per case, and vitest's 5000ms default left no headroom on a loaded merge
+    // queue runner — see #4850. Set at the config layer so all 12 (and any future
+    // one) are covered, rather than per-case as PR #4506 did. Related: #4796.
+    testTimeout: 60_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4850

Related: #4796(**保持打开** —— 方向 2「把导出面解析提成构建期产物」仍归 spec 车道,本单只是它的止血)

## 改了什么

`packages/spec/vitest.config.ts` 的 `test` 块加一行 `testTimeout: 60_000`(带注释),外加一个 patch changeset。**改动面仅此两个文件**,不碰任何 `.zod.ts`、测试逻辑、`spec-changes.json`、liveness 台账与生成基线。

## 根因复核(我自己重新取证了一遍,不是照抄 issue)

三条都在 `origin/main` 上确认过:

1. **确实没有 `testTimeout`** —— `git show origin/main:packages/spec/vitest.config.ts` 里 `test` 块只有 `globals` / `environment` / `include` / `coverage`,吃 vitest 默认 5000ms。
2. **确实是 12 个文件**在用例内 `(await import('typescript')).default` 并 `ts.createProgram` + `getTypeChecker`。我遍历 `origin/main` 上全部 282 个 spec 测试文件逐个 grep,命中数正好 12,与 issue 列的清单完全一致。
   ⚠️ 顺带一个坑:共享检出当时落后 `origin/main` 63 个提交,直接在工作树里 grep 只会命中 0 个(那几段是后来的提交加的)。这类核查必须对 `origin/main` 做。
3. **没有别处在给这个包设超时** —— 仓库根没有 `vitest.config.*` 也没有 `vitest.workspace.ts`;`packages/spec` 的 test 脚本是裸 `vitest run`(无 `--testTimeout`);`turbo.json` 的 `test` task 不传参;workflows 里没有任何 `VITEST_*` / `TEST_TIMEOUT` 覆盖。全仓已有 `testTimeout` 的 5 个包(`metadata-fs`、`qa/http-conformance`、`client`、`driver-mongodb`、`plugin-auth`)都是各自的包内配置,管不到 spec。所以这一行是真正生效的那一层,不是被更高优先级配置盖掉的空操作。

## 验证「它真的生效了」

没有只靠读配置。临时加了一条 `await new Promise(r => setTimeout(r, 6000))` 的探针用例:

- **改之前**:`Error: Test timed out in 5000ms.` —— vitest 自己在报错里提示 `configure it globally with "testTimeout"`。
- **改之后**:`Test Files 1 passed (1)`,`Duration 6.36s`。

探针用例**已删除**,不在提交里(`git status` 干净,diff 只有上述两个文件)。

## 这 12 个用例的实际耗时(issue 要求先测量再定数)

空载 runner 上跑这 12 个文件:`12 passed / 497 tests`,用 JSON reporter 取单用例耗时:

| 指标 | 实测 |
|:---|:---|
| 最慢单用例 | **3425ms**(`system/environment-artifact` 的导出面解析) |
| 超过 3000ms 的用例 | 5 条 |
| 超过 5000ms 的用例 | **0 条**(空载时) |
| 60s 相对最慢用例的余量 | **约 17.5 倍** |

**结论:60s 余量充足,不薄。** 同时这组数字正好解释了 issue 里那个「PR 分支一次没红过、5 次全发生在队列里」的现象 —— 空载最慢 3.4s 顶 5000ms 的预算,余量只有约 1.46 倍,队列 runner 同时构建多个 PR 批次时轻易被吃掉;而 60s 要被吃掉需要 17 倍的减速,属于真挂起才会触发,不会把真 bug 盖住。

**但请注意方向 2 的紧迫性没有被这一行降低:** 这 12 个文件里,耗时超过 800ms 的 16 条用例合计 **39.0s**,占这 12 个文件全部用例耗时(44.2s)的 **88%** —— 每次 CI 跑一遍就是近 40 秒纯 TypeScript 编译,而且随导出面增长。止血归止血,#4796 的本体仍然值得做。

## 为什么设在配置层而不是逐条加

PR #4506 就是逐条 `{ timeout: … }`,只覆盖了当时红的那几条;池子有 12 个,而且新增的照样漏。配置层一次覆盖全部,第 13 个到达即被覆盖。60s 沿用 #4506 当初给同族用例定的值,不引入新数字。

## 测试

均在 `flock -w 7200 /tmp/os-heavy-verify.lock` 下、带 `NODE_OPTIONS=--max-old-space-size=4096` 与 `--maxWorkers=2` 执行:

- `pnpm --filter @objectstack/spec test` → `Test Files 294 passed (294)` / `Tests 7362 passed (7362)`,`Duration 102.26s`
- `pnpm --filter @objectstack/spec typecheck` → `tsc --noEmit` 无输出(通过)

未触及任何生成物对应的输入面(`.describe()`、公共导出、authorable key、ADR-0087 registry、SKILL.md、react-blocks),故未重新生成 spec 的生成物。

## 跨车道说明

`packages/spec/**` 常态归另一个 PM 车道,本单是经维护者批准的跨车道止血,因此改动面严格限死在 `vitest.config.ts` 一行 + changeset。过程中在别处看到的问题一律只写进报告,未动手。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Br2xsJsczFsTR9bvbh2Ny

---
_Generated by [Claude Code](https://claude.ai/code/session_015Br2xsJsczFsTR9bvbh2Ny)_