### PR TITLE
test(spec): 给 13 个 compiler-API 导出面 pin 一个符合真实工作量的超时 —— 今晨全部 CI 红的真因 (#4796)

### DIFF
--- a/.changeset/spec-compiler-pin-timeout.md
+++ b/.changeset/spec-compiler-pin-timeout.md
@@ -1,0 +1,18 @@
+---
+---
+
+test(spec): 给 13 个 compiler-API 导出面 pin 一个符合真实工作量的超时(#4796)
+
+发布面零变化 —— 只改 `packages/spec/vitest.config.ts` 的 `testTimeout`,不影响任何
+产物内容,故为空 changeset。
+
+这一族 pin(每个退役/双源 PR 各留一个,现有 13 个)都要对全部 16 个公共入口建一次
+`ts.createProgram`,天然是秒级工作。实测:空闲机器 ~2-3s;CI 分片上 turbo 把
+`@objectstack/spec#build` 与 `#test` 并发跑在同 4 vCPU 上,争抢把它推到
+5.0-5.6s —— 恰好骑在 vitest 默认 5s 超时线上。一个上午三条 pin 超时
+(state-machine / sync-retirement / tenant),每次都把一个不相干的 PR 踢出合并队列,
+并被误诊为构建 OOM(#4845 记录了那次误诊与更正)。
+
+30s 约为实测争抢峰值的 5 倍;真挂死仍由 CI 的 10 分钟 stall guard 兜底 —— 这个
+数字只阻止「健康但受争抢」的运行被读成失败。长期修法(把导出面做成构建期产物、
+pin 只比对不现场解析)在 #4796 跟踪。

--- a/packages/spec/vitest.config.ts
+++ b/packages/spec/vitest.config.ts
@@ -7,6 +7,20 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
+    // [#4796] This package carries 13 export-surface pin tests (one per
+    // retirement/dual-source PR) that each build a ts.createProgram over all
+    // 16 public entry points — inherently seconds-scale work. Measured cost:
+    // ~2-3s on an idle machine, 5.0-5.6s on a CI shard where turbo runs
+    // @objectstack/spec#build CONCURRENTLY on the same 4 vCPUs. vitest's 5s
+    // default sat exactly on that line: three pins timed out in one morning
+    // (state-machine / sync-retirement / tenant), each ejecting an unrelated
+    // PR from the merge queue. 30s is ~5x the measured contended worst case;
+    // genuine hangs are still caught by CI's 10-minute stall guard
+    // (run-with-stall-guard.mjs), which is the real hang detector — this
+    // number only stops healthy-but-contended runs from reading as failures.
+    // The durable fix — precompute the export surface as a build artifact and
+    // have the pins compare instead of re-resolving — is tracked in #4796.
+    testTimeout: 30_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
Fixes #4796
Refs #4845

## 真因(来自完整日志归档,不是尾部截断)

下载 run `30804783487` 的完整日志后,失败明细第一次完整可见:

```
FAIL src/automation/state-machine.test.ts  [#4658] EventSchema pin        × 5602ms
FAIL src/automation/sync-retirement.test.ts [#4738] sync/conflict pin     × 5379ms
FAIL src/cloud/tenant.test.ts               [#4739] TenantPlan pin        × 5022ms
Error: Test timed out in 5000ms.  (×3)
Tests  3 failed | 7359 passed (7362)
```

**全是超时,不是 OOM,与各 PR 的改动内容无关。** #4796 立案时只记了 `tenant.test.ts` 一条;实测这是一族 —— `packages/spec` 里 **13 个** compiler-API 导出面 pin(每个退役/双源 PR 各留一个),**零个**有显式超时,全部骑在 vitest 默认 5s 线上。

## 为什么 CI 中而本地不中(按 #4796 的要求「先测量再决定」)

这族 pin 每个都对全部 16 个公共入口建一次 `ts.createProgram` —— 天然秒级:

| 环境 | 实测耗时 |
|:--|:--|
| 空闲机器(13 GB 可用) | ~2-3s |
| CI 分片(turbo 把 `spec#build` 与 `spec#test` **并发**跑在同 4 vCPU 上) | **5.0 / 5.4 / 5.6s** |

争抢是概率性的 —— 这解释了「与改动内容无关、重跑可过、专挑真跑 spec 的 PR」的全部观测。今晨四次命中(#4831 ×2 含合并队列、#4841、#4846)加上 #4796 立案时的两次,共**六次**把 PR 或队列打红。

也顺带解释了 #4845 的误诊:`DTS Build start` 紧接 `ELIFECYCLE` 是**并发任务的交织输出**(turbo 多任务 stdout + GitHub 按 group 同戳 flush),真正失败的一直是 `spec#test`,而失败明细在 job log API 只回的 ~10KB 尾部之外。#4845 已更正。

## 修法与理由

`packages/spec/vitest.config.ts` 设 `testTimeout: 30_000` + 长注释(测量数据、争抢机理、为什么 30s、真挂死由谁兜底):

- **30s ≈ 实测争抢峰值的 5 倍** —— 不是「4.5s 放宽到 10s 把踩雷推后」那种贴线调参;
- **真挂死仍由 CI 的 10 分钟 stall guard 兜底**(`run-with-stall-guard.mjs` 才是挂死检测器)—— 这个数字只阻止「健康但受争抢」的运行被读成失败;
- 选 config 级而非逐 it 加参:13 个文件零显式超时,逐个补必漏(这族随每个退役 PR 增长,今天就新增了 3 个);
- **#4796 的方案 2(导出面做成构建期产物、pin 只比对不现场解析)仍是长期正解**,本 PR 不关闭那个方向,issue 保持追踪。

## 验证

原三条失败 pin + 今晨新增的 activation-events pin 在新配置下实跑:

```
Test Files  4 passed (4)
     Tests  17 passed (17)
Duration  7.27s
```

空 frontmatter changeset(发布面零变化)。`content/docs/releases/` 未触碰。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176qgxgCXTJCUv4YFLtusP9

---
_Generated by [Claude Code](https://claude.ai/code/session_0176qgxgCXTJCUv4YFLtusP9)_