### PR TITLE
fix(metadata): 历史序号 event_seq 不再从一次失败的读里凭空发号 —— 只有「表还没建」可以从 1 开始 (#4825)

### DIFF
--- a/.changeset/next-event-seq-read-failure-loud.md
+++ b/.changeset/next-event-seq-read-failure-loud.md
@@ -1,0 +1,43 @@
+---
+"@objectstack/metadata": patch
+---
+
+fix(metadata): 历史序号 `event_seq` 不再从一次失败的读里凭空发号 —— 只有「表还没建」可以从 1 开始 (#4825)
+
+`DatabaseLoader.nextEventSeq()` 过去把读 `sys_metadata_history` 的**全部**失败折成同一个答案:
+
+```ts
+} catch {
+  // Table not provisioned yet or driver error — start at 1.
+  return 1;
+}
+```
+
+注释同时点名了两种原因,然后用同一个 `return 1` 对待。这是 #4728 刚修掉的同一种形状,但危害是
+**更贵的那一半**:#4728 是「字节没落盘」,本条是「**落盘的字节是错的**」。历史表里已经有 N 行时,
+一次瞬时读失败(连接抖动、超时、权限)会让下一条历史拿到 `event_seq = 1`,与既有行**直接撞号**,
+而 insert **成功**、日志**一行没有**。`event_seq` 正是历史列表排序与 rollback 定位的依据,撞号之后
+版本顺序就永久不可信 —— 重试不修、重启也不修。
+
+现在按**错误类型**判别,复用 #4728 落地的那套判别机制(`packages/metadata/src/utils/schema-sync-errors.ts`
+里新增的 `isMissingTableError()` 与既有 `isSchemaAlreadyExistsError()` 共用同一个 code / errno /
+message + `cause` 链匹配器,而不是在同一个包里另起一套错误判别):
+
+- **良性的「表还没建」**(SQLite `no such table: …`、Postgres SQLSTATE `42P01` /
+  `relation "…" does not exist`、MySQL `ER_NO_SUCH_TABLE` / errno `1146`,并跟随 `cause` 链)——
+  没有行,就没有可撞的号,`1` 确实是下一个号,静默返回。
+- **其余一切读失败** —— `nextEventSeq()` 原样抛出。调用方 `createHistoryRecord()` 以
+  `console.error` 上报**后果**(该条历史记录未写入;元数据写入本身已成功,所以服务器仍报告健康,
+  而变更历史正在悄悄出现空洞,版本时间线与 rollback 目标将不完整)、**为什么是空洞而不是错号**
+  (从 1 发号会与既有行撞号,把「不完整」变成「顺序错误」,后者无人能发现)与**修复动作**,
+  然后**跳过这条历史记录**。
+- 判别的方向刻意保守:凡是没有被正面识别为「表不存在」的,一律当作真实失败。`does not exist`
+  本身不够 —— `role "…" does not exist`、`database "…" does not exist`、`column "…" does not exist`
+  都是真实失败,对着一张可能满是行的表返回 1 正是要避免的事,所以消息匹配要求 table/relation 与
+  该短语同现。
+
+两条边界保持不变:元数据写入本身**不**因此失败(记录已经落盘,把它报成失败是比原缺陷更糟的谎),
+以及本路径已知的并发撞号限制(非事务,canonical producer 仍是 `SysMetadataRepository`)——那是被
+记录过的限制,与「读失败静默重置到 1」是两回事。报告只说**一次**,恢复时补一条 `info`。
+
+无 API / schema 变更;新增内部工具 `isMissingTableError()`(未从包入口导出)。

--- a/packages/metadata/src/loaders/database-loader.test.ts
+++ b/packages/metadata/src/loaders/database-loader.test.ts
@@ -641,6 +641,201 @@ describe('DatabaseLoader schema-sync failure reporting (#4728)', () => {
   });
 });
 
+// ---------- event_seq is never invented from a read that failed ----------
+
+/**
+ * #4825 (same family as #4728, rule: #4632).
+ *
+ * `nextEventSeq()` used to `catch { return 1 }`, with a comment naming BOTH
+ * "table not provisioned yet" (benign) and "driver error" (not benign). With N
+ * rows already in `sys_metadata_history`, one flaky read therefore handed the
+ * next row `event_seq = 1` — colliding with an existing row while the insert
+ * SUCCEEDED and nothing was logged.
+ *
+ * That is why these tests assert on the VALUE that lands, not merely on whether
+ * a write happened: the damage here is not a missing row, it is a written row
+ * carrying a wrong number, which no retry and no restart repairs.
+ *
+ * Both directions are pinned, plus a same-call-site/opposite-verdict case — a
+ * suite proving only the loud half would pass on a `() => true` classifier,
+ * which is the bug, and one proving only the benign half would pass on the
+ * `catch { return 1 }` being replaced.
+ */
+describe('DatabaseLoader event_seq on a failed history read (#4825)', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+
+  /** Benign: nothing has been provisioned, so there is no row to collide with. */
+  const noSuchTable = () =>
+    Object.assign(new Error('no such table: sys_metadata_history'), { code: 'SQLITE_ERROR' });
+
+  /** NOT benign: the rows are still there, this read just did not see them. */
+  const connectionReset = () =>
+    Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' });
+
+  /** Every `event_seq` this driver was asked to persist, in order. */
+  function historySeqsWritten(driver: IDataDriver): unknown[] {
+    const calls = (driver.create as ReturnType<typeof vi.fn>).mock.calls as unknown[][];
+    return calls
+      .filter((call: unknown[]) => call[0] === 'sys_metadata_history')
+      .map((call: unknown[]) => (call[1] as Record<string, unknown>).event_seq);
+  }
+
+  /** The mock driver's own `find`, still callable after we wrap it. */
+  type DriverFind = (table: string, query: unknown) => Promise<Record<string, unknown>[]>;
+
+  /**
+   * A driver whose reads of the HISTORY table fail while `broken` — writes and
+   * the `sys_metadata` table keep working throughout, which is exactly what
+   * makes the defect invisible in production.
+   */
+  function driverWithBreakableHistoryReads(makeError: () => unknown, startBroken = false) {
+    const driver = createMockDriver();
+    const realFind = driver.find as DriverFind;
+    let broken = startBroken;
+    driver.find = vi.fn().mockImplementation((table: string, query: unknown) => {
+      if (broken && table === 'sys_metadata_history') return Promise.reject(makeError());
+      return realFind(table, query);
+    });
+    return {
+      driver,
+      breakReads: () => {
+        broken = true;
+      },
+      healReads: () => {
+        broken = false;
+      },
+    };
+  }
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    infoSpy.mockRestore();
+  });
+
+  describe('the benign case — the history table is not provisioned yet', () => {
+    it('numbers from 1 and stays silent', async () => {
+      const { driver } = driverWithBreakableHistoryReads(noSuchTable, true);
+      const loader = new DatabaseLoader({ driver });
+
+      await loader.save('object', 'account', { name: 'account' });
+
+      expect(historySeqsWritten(driver)).toEqual([1]);
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(infoSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('a REAL read failure against a table that already has rows', () => {
+    it('does NOT restart at 1 — no colliding row is written at all', async () => {
+      const { driver, breakReads } = driverWithBreakableHistoryReads(connectionReset);
+      const loader = new DatabaseLoader({ driver });
+
+      // Build real history first: two rows, event_seq 1 and 2.
+      await loader.save('object', 'account', { name: 'account' });
+      await loader.save('object', 'contact', { name: 'contact' });
+      expect(historySeqsWritten(driver)).toEqual([1, 2]);
+
+      breakReads();
+      await loader.save('object', 'lead', { name: 'lead' });
+
+      // Before #4825 this was [1, 2, 1] — a duplicate `event_seq` written
+      // successfully, silently, over the top of an existing row's number.
+      expect(historySeqsWritten(driver)).toEqual([1, 2]);
+    });
+
+    it('reports at error, naming the consequence, the deliberate skip, and the fix', async () => {
+      const { driver, breakReads } = driverWithBreakableHistoryReads(connectionReset);
+      const loader = new DatabaseLoader({ driver });
+
+      await loader.save('object', 'account', { name: 'account' });
+      breakReads();
+      await loader.save('object', 'lead', { name: 'lead' });
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const [message, cause] = errorSpy.mock.calls[0] as [string, unknown];
+      expect(message).toContain('sys_metadata_history');
+      expect(message).toContain('event_seq');
+      // consequence: the row is gone AND the system keeps looking fine
+      expect(message).toMatch(/NOT written/);
+      expect(message).toMatch(/SUCCEEDED/);
+      expect(message).toMatch(/looking healthy/i);
+      // why a hole is preferable to a wrong number
+      expect(message).toMatch(/collide/i);
+      // fix
+      expect(message).toMatch(/fix the datasource\/driver error/i);
+      // and the driver error is carried, not discarded
+      expect((cause as Error).message).toBe('read ECONNRESET');
+    });
+
+    it('does not fail the metadata write it accompanies', async () => {
+      const { driver, breakReads } = driverWithBreakableHistoryReads(connectionReset);
+      const loader = new DatabaseLoader({ driver });
+
+      breakReads();
+      const result = await loader.save('object', 'account', { name: 'account' });
+
+      // The record write already happened; reporting it as failed would be a
+      // worse lie than the one being fixed. The history hole is what is loud.
+      expect(result.success).toBe(true);
+      expect((await loader.load('object', 'account')).data).toEqual({ name: 'account' });
+    });
+
+    it('says it once, not once per skipped entry, and reports recovery', async () => {
+      const { driver, breakReads, healReads } = driverWithBreakableHistoryReads(connectionReset);
+      const loader = new DatabaseLoader({ driver });
+
+      await loader.save('object', 'account', { name: 'account' });
+      breakReads();
+      await loader.save('object', 'contact', { name: 'contact' });
+      await loader.save('object', 'lead', { name: 'lead' });
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+
+      healReads();
+      await loader.save('object', 'deal', { name: 'deal' });
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      expect((infoSpy.mock.calls[0] as [string])[0]).toMatch(/readable again/i);
+      // Numbering resumes after the surviving max (1), never from 1 again.
+      expect(historySeqsWritten(driver)).toEqual([1, 2]);
+    });
+  });
+
+  it('DISTINGUISHES the two: same call site, opposite verdicts', async () => {
+    const { driver: benignDriver } = driverWithBreakableHistoryReads(noSuchTable, true);
+    const { driver: realDriver } = driverWithBreakableHistoryReads(connectionReset, true);
+
+    await new DatabaseLoader({ driver: benignDriver }).save('object', 'account', { name: 'a' });
+    await new DatabaseLoader({ driver: realDriver }).save('object', 'account', { name: 'a' });
+
+    // Benign: numbered, written, silent. Real: not numbered, not written, loud.
+    expect(historySeqsWritten(benignDriver)).toEqual([1]);
+    expect(historySeqsWritten(realDriver)).toEqual([]);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies to the rollback history path too, not just save()', async () => {
+    const { driver, breakReads } = driverWithBreakableHistoryReads(connectionReset);
+    const loader = new DatabaseLoader({ driver });
+
+    await loader.save('object', 'account', { name: 'account' });
+    await loader.save('object', 'account', { name: 'account', label: 'Account' });
+    expect(historySeqsWritten(driver)).toEqual([1, 2]);
+
+    breakReads();
+    await loader.registerRollback('object', 'account', { name: 'account' }, 1);
+
+    expect(historySeqsWritten(driver)).toEqual([1, 2]);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
 // ---------- DatabaseLoader read-through cache ----------
 
 describe('DatabaseLoader read-through cache', () => {

--- a/packages/metadata/src/loaders/database-loader.ts
+++ b/packages/metadata/src/loaders/database-loader.ts
@@ -26,7 +26,7 @@ import type { IDataDriver, IDataEngine } from '@objectstack/spec/contracts';
 import type { MetadataLoader } from './loader-interface.js';
 import { calculateChecksum } from '../utils/metadata-history-utils.js';
 import { LRUCache } from '../utils/lru-cache.js';
-import { isSchemaAlreadyExistsError } from '../utils/schema-sync-errors.js';
+import { isMissingTableError, isSchemaAlreadyExistsError } from '../utils/schema-sync-errors.js';
 import { addSysMetadataOverlayIndex } from '../migrations/add-sys-metadata-overlay-index.js';
 import { migrateProjectIdToEnvironmentId } from '../migrations/migrate-project-id-to-environment-id.js';
 
@@ -131,6 +131,12 @@ export class DatabaseLoader implements MetadataLoader {
    */
   private schemaFailureReported = false;
   private historySchemaFailureReported = false;
+  /**
+   * Same once-only discipline for the #4825 seam: the history table is readable
+   * or it is not, and repeating the report per skipped write turns a real
+   * degradation into noise people learn to skim.
+   */
+  private historySeqFailureReported = false;
 
   /** (type, name) → metadata payload — primes `load()` */
   private readonly loadCache?: LRUCache<string, Record<string, unknown> | null>;
@@ -267,6 +273,24 @@ export class DatabaseLoader implements MetadataLoader {
    * Reads `MAX(event_seq) + 1` for the configured `organization_id`.
    * Legacy path — not transactional, so concurrent writes can collide.
    * The canonical (transactional) producer is `SysMetadataRepository`.
+   *
+   * #4825 (same shape as #4728, rule from #4632) — discriminate by error TYPE.
+   * This used to `catch { return 1 }`, with a comment that named BOTH reasons a
+   * read can fail and then answered both the same way. Exactly one of them is
+   * benign: the history table has not been provisioned, so there is no row to
+   * be inconsistent with and 1 genuinely IS the next number. Every other reason
+   * — connection drop, timeout, insufficient privileges — means the rows are
+   * still there and simply were not seen, and answering 1 against a table with
+   * N rows **collides with existing rows**: the insert succeeds, the log stays
+   * empty, and `event_seq` (the ordering key that history listing and rollback
+   * targeting both stand on) is silently wrong from then on. Note this is the
+   * costlier half of the #4728 family — not bytes that never landed, but bytes
+   * that landed *wrong*, which no retry and no restart repairs.
+   *
+   * @throws The underlying driver error, unchanged, for every non-benign read
+   *         failure. Deliberate: a sequence number this method cannot derive
+   *         from data it actually read is not a number it may invent. The
+   *         caller ({@link createHistoryRecord}) owns the consequence.
    */
   private async nextEventSeq(): Promise<number> {
     const where: Record<string, unknown> = this.organizationId
@@ -280,9 +304,11 @@ export class DatabaseLoader implements MetadataLoader {
         if (v > max) max = v;
       }
       return max + 1;
-    } catch {
-      // Table not provisioned yet or driver error — start at 1.
-      return 1;
+    } catch (error) {
+      // Benign — and ONLY benign: there is no table, therefore no row, so
+      // numbering from 1 cannot collide with anything.
+      if (isMissingTableError(error)) return 1;
+      throw error;
     }
   }
 
@@ -493,7 +519,41 @@ export class DatabaseLoader implements MetadataLoader {
     // transaction, so concurrent writers can collide. The SysMetadataRepository
     // path serializes this under engine.transaction(); DatabaseLoader is
     // deprecated for new writes and tolerates the race.
-    const eventSeq = await this.nextEventSeq();
+    //
+    // #4825: the concurrency race above is a KNOWN, recorded limitation of this
+    // path. A read failure is not the same thing and is not tolerated — if the
+    // sequence cannot be derived from rows we actually read, we write NO history
+    // row rather than one carrying a number we made up. A missing row is loud
+    // here and visibly absent later; a colliding row is silent now and corrupts
+    // the ordering that `queryHistory` and `rollback` both depend on, forever.
+    let eventSeq: number;
+    try {
+      eventSeq = await this.nextEventSeq();
+    } catch (error) {
+      if (!this.historySeqFailureReported) {
+        this.historySeqFailureReported = true;
+        console.error(
+          `[Metadata] Could not read \`${this.historyTableName}\` to determine the next \`event_seq\` — the history ` +
+            `entry for ${type}/${name} was NOT written, and further entries are being skipped while this persists. ` +
+            `The metadata write itself SUCCEEDED, so the server keeps looking healthy while its change history ` +
+            `silently develops holes: version timelines and rollback targets will be incomplete. The entry is skipped ` +
+            `deliberately — numbering it from 1 (what this code did before #4825) would collide with existing rows and ` +
+            `make \`event_seq\` ordering wrong rather than merely incomplete, which nothing detects and no restart ` +
+            `repairs. Fix the datasource/driver error below (connection, timeout, privileges); the next metadata write ` +
+            `retries and reports recovery.`,
+          error,
+        );
+      }
+      return;
+    }
+
+    if (this.historySeqFailureReported) {
+      this.historySeqFailureReported = false;
+      console.info(
+        `[Metadata] \`${this.historyTableName}\` is readable again — \`event_seq\` numbering recovered and change ` +
+          `history is being recorded again. Entries skipped during the outage are not backfilled.`,
+      );
+    }
 
     const historyRecord: Partial<MetadataHistoryRecord> = {
       id: historyId,

--- a/packages/metadata/src/utils/schema-sync-errors.test.ts
+++ b/packages/metadata/src/utils/schema-sync-errors.test.ts
@@ -1,15 +1,17 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * #4728 — the classification that decides whether a DDL failure may be silenced.
+ * #4728 / #4825 — the classifications that decide whether a driver failure may
+ * be silenced.
  *
- * Both directions are pinned deliberately. A test suite that only proves the
- * benign case is recognised would pass just as happily on `() => true`, which is
- * exactly the bug being fixed (one benign reason excusing every reason).
+ * Both directions are pinned deliberately, for both predicates. A test suite
+ * that only proves the benign case is recognised would pass just as happily on
+ * `() => true`, which is exactly the bug being fixed (one benign reason excusing
+ * every reason).
  */
 
 import { describe, it, expect } from 'vitest';
-import { isSchemaAlreadyExistsError } from './schema-sync-errors.js';
+import { isMissingTableError, isSchemaAlreadyExistsError } from './schema-sync-errors.js';
 
 describe('isSchemaAlreadyExistsError', () => {
     describe('benign — the table/column is already provisioned', () => {
@@ -113,5 +115,156 @@ describe('isSchemaAlreadyExistsError', () => {
             }
             expect(isSchemaAlreadyExistsError(err)).toBe(false);
         });
+    });
+});
+
+/**
+ * #4825 — the READ-side counterpart. `nextEventSeq()` may only answer "1" when
+ * the table genuinely has no rows to collide with; every other read failure has
+ * to stay loud, because the rows are still there and were merely not seen.
+ */
+describe('isMissingTableError', () => {
+    describe('benign — the table has not been provisioned yet', () => {
+        it('recognises the SQLite message (code is the undifferentiated SQLITE_ERROR)', () => {
+            const err = Object.assign(new Error('no such table: sys_metadata_history'), {
+                code: 'SQLITE_ERROR',
+            });
+            expect(isMissingTableError(err)).toBe(true);
+        });
+
+        it('recognises PostgreSQL undefined_table by SQLSTATE, even with an opaque message', () => {
+            expect(isMissingTableError(Object.assign(new Error('db error'), { code: '42P01' }))).toBe(
+                true,
+            );
+        });
+
+        it('recognises the PostgreSQL undefined_table message', () => {
+            const err = new Error('relation "sys_metadata_history" does not exist');
+            expect(isMissingTableError(err)).toBe(true);
+        });
+
+        it('recognises MySQL ER_NO_SUCH_TABLE by code, by errno and by message', () => {
+            expect(
+                isMissingTableError(
+                    Object.assign(new Error('opaque'), { code: 'ER_NO_SUCH_TABLE' }),
+                ),
+            ).toBe(true);
+            expect(isMissingTableError(Object.assign(new Error('opaque'), { errno: 1146 }))).toBe(
+                true,
+            );
+            expect(
+                isMissingTableError(new Error("Table 'app.sys_metadata_history' doesn't exist")),
+            ).toBe(true);
+        });
+
+        it('follows an error wrapped as `cause`', () => {
+            const inner = Object.assign(new Error('no such table: sys_metadata_history'), {
+                code: 'SQLITE_ERROR',
+            });
+            const outer = Object.assign(new Error('find failed'), { cause: inner });
+            expect(isMissingTableError(outer)).toBe(true);
+        });
+
+        it('accepts a bare thrown string', () => {
+            expect(isMissingTableError('no such table: sys_metadata_history')).toBe(true);
+        });
+    });
+
+    describe('NOT benign — the rows may exist and simply were not read', () => {
+        it('rejects a dropped connection', () => {
+            const err = Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' });
+            expect(isMissingTableError(err)).toBe(false);
+        });
+
+        it('rejects a statement timeout', () => {
+            const err = Object.assign(new Error('canceling statement due to statement timeout'), {
+                code: '57014',
+            });
+            expect(isMissingTableError(err)).toBe(false);
+        });
+
+        it('rejects insufficient privileges on an EXISTING table', () => {
+            const err = Object.assign(
+                new Error('permission denied for table sys_metadata_history'),
+                { code: '42501' },
+            );
+            expect(isMissingTableError(err)).toBe(false);
+        });
+
+        it('rejects a locked/busy database', () => {
+            const err = Object.assign(new Error('database is locked'), { code: 'SQLITE_BUSY' });
+            expect(isMissingTableError(err)).toBe(false);
+        });
+
+        /**
+         * The reason the message test demands the word table/relation instead of
+         * a bare "does not exist". Each of these is a REAL failure against a
+         * table that may be full of rows — classifying any of them benign would
+         * restart numbering at 1 and collide.
+         */
+        it('rejects other "does not exist" objects — role, database, column', () => {
+            expect(
+                isMissingTableError(
+                    Object.assign(new Error('role "app_rw" does not exist'), { code: '42704' }),
+                ),
+            ).toBe(false);
+            expect(
+                isMissingTableError(
+                    Object.assign(new Error('database "objectstack" does not exist'), {
+                        code: '3D000',
+                    }),
+                ),
+            ).toBe(false);
+            expect(
+                isMissingTableError(
+                    Object.assign(new Error('column "event_seq" does not exist'), { code: '42703' }),
+                ),
+            ).toBe(false);
+        });
+
+        it('rejects values that carry no signal at all', () => {
+            expect(isMissingTableError(undefined)).toBe(false);
+            expect(isMissingTableError(null)).toBe(false);
+            expect(isMissingTableError(new Error(''))).toBe(false);
+            expect(isMissingTableError({})).toBe(false);
+            expect(isMissingTableError(42)).toBe(false);
+        });
+
+        it('does not follow a cause chain forever', () => {
+            let err: Error = new Error('no such table: sys_metadata_history');
+            for (let i = 0; i < 8; i++) {
+                err = Object.assign(new Error(`wrap ${i}`), { cause: err });
+            }
+            expect(isMissingTableError(err)).toBe(false);
+        });
+    });
+});
+
+/**
+ * The two predicates share one matcher but must never collapse into each
+ * other's negation: both ask "is this THE one benign reason?", and an error
+ * neither recognises has to be loud under both.
+ */
+describe('the two classifications are independent, not complementary', () => {
+    it('an "already exists" DDL error is not a missing-table read error', () => {
+        const err = Object.assign(new Error('table sys_metadata_history already exists'), {
+            code: '42P07',
+        });
+        expect(isSchemaAlreadyExistsError(err)).toBe(true);
+        expect(isMissingTableError(err)).toBe(false);
+    });
+
+    it('a missing-table read error is not a benign DDL error', () => {
+        const err = Object.assign(new Error('no such table: sys_metadata_history'), {
+            code: '42P01',
+        });
+        expect(isMissingTableError(err)).toBe(true);
+        expect(isSchemaAlreadyExistsError(err)).toBe(false);
+    });
+
+    it('an unrecognised failure is benign under NEITHER — the default is loud', () => {
+        const err = Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' });
+        expect(isSchemaAlreadyExistsError(err)).toBe(false);
+        expect(isMissingTableError(err)).toBe(false);
     });
 });

--- a/packages/metadata/src/utils/schema-sync-errors.ts
+++ b/packages/metadata/src/utils/schema-sync-errors.ts
@@ -1,7 +1,27 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * DDL failure classification for metadata schema sync (#4728, rule from #4632).
+ * Driver-error classification for the metadata storage seams (#4728, #4825;
+ * rule from #4632).
+ *
+ * Two questions live here, and they share one mechanism on purpose. A second
+ * hand-rolled `catch`-and-guess elsewhere in this package would be a second
+ * de-facto vocabulary of "which driver errors are benign" — the exact debt this
+ * module exists to retire. Both predicates below are thin wrappers over one
+ * signature matcher, so a driver quirk is taught to the package once.
+ *
+ * 1. {@link isSchemaAlreadyExistsError} — "was this DDL failure just the table
+ *    already being there?" (#4728, `ensureSchema` / `ensureHistorySchema`).
+ * 2. {@link isMissingTableError} — "did this READ fail because the table has
+ *    not been provisioned yet?" (#4825, `nextEventSeq`).
+ *
+ * They are deliberately **not** each other's negation. Each answers "is this
+ * the one benign reason?" and defaults to *not benign*, so an error neither
+ * recognises is loud under both.
+ *
+ * ---
+ *
+ * ## 1. DDL failure classification (#4728)
  *
  * `IDataDriver.syncSchema()` is contractually **idempotent** ("creates tables if
  * missing, adds columns, updates indexes"), so in principle a re-sync of an
@@ -36,54 +56,117 @@
  * recognised as "already exists" is treated as a real failure, because the cost
  * of a false "benign" (silent data loss) is far higher than the cost of a false
  * "real" (one extra error line).
+ *
+ * ---
+ *
+ * ## 2. Missing-table classification for reads (#4825)
+ *
+ * `DatabaseLoader.nextEventSeq()` reads `sys_metadata_history` to decide what
+ * `event_seq` the NEXT history row gets. Its `catch` named both reasons a read
+ * can fail — "table not provisioned yet" (benign: 1 really is the next number)
+ * and "driver error" (**not** benign) — and answered both with `return 1`.
+ *
+ * That is the #4728 shape one layer down, but the damage is the opposite kind
+ * and worse. #4728 was *bytes that never landed*; this is **bytes that land
+ * wrong**: with N rows already in the table, one flaky read hands the next row
+ * `event_seq = 1`, colliding with an existing row. The insert **succeeds**, no
+ * line is logged, and `event_seq` — the ordering key that history listing and
+ * rollback targeting both stand on — is now silently untrustworthy.
+ *
+ * So the read seam gets the same treatment, with the same conservative default:
+ *
+ * ```ts
+ * catch (error) {
+ *   if (isMissingTableError(error)) return 1;   // benign: nothing to collide with
+ *   throw error;                                // caller reports the consequence
+ * }
+ * ```
  */
+
+/** One "which errors mean X?" vocabulary, in the three forms drivers use. */
+interface DriverErrorSignature {
+    /** `error.code` — Postgres SQLSTATE, or mysql2's symbolic name. */
+    readonly codes: ReadonlySet<string>;
+    /** `error.errno` — MySQL/MariaDB numeric equivalents. */
+    readonly errnos: ReadonlySet<number>;
+    /** `error.message` — the only signal SQLite-family drivers give. */
+    readonly message: RegExp;
+}
 
 /**
  * Driver/SQLSTATE codes that mean "the thing you asked me to create is already
  * there". Postgres reports SQLSTATE on `code`; mysql2 reports its symbolic name.
  */
-const ALREADY_EXISTS_CODES: ReadonlySet<string> = new Set([
-    // PostgreSQL SQLSTATE (class 42 — syntax error or access rule violation)
-    '42P07', // duplicate_table
-    '42701', // duplicate_column
-    '42710', // duplicate_object — index / constraint already exists
-    // MySQL / MariaDB (mysql2 puts the symbolic name on `code`)
-    'ER_TABLE_EXISTS_ERROR', // 1050
-    'ER_DUP_FIELDNAME', // 1060
-    'ER_DUP_KEYNAME', // 1061
-]);
-
-/** MySQL/MariaDB numeric equivalents of the codes above (`errno`). */
-const ALREADY_EXISTS_ERRNOS: ReadonlySet<number> = new Set([1050, 1060, 1061]);
+const ALREADY_EXISTS: DriverErrorSignature = {
+    codes: new Set([
+        // PostgreSQL SQLSTATE (class 42 — syntax error or access rule violation)
+        '42P07', // duplicate_table
+        '42701', // duplicate_column
+        '42710', // duplicate_object — index / constraint already exists
+        // MySQL / MariaDB (mysql2 puts the symbolic name on `code`)
+        'ER_TABLE_EXISTS_ERROR', // 1050
+        'ER_DUP_FIELDNAME', // 1060
+        'ER_DUP_KEYNAME', // 1061
+    ]),
+    errnos: new Set([1050, 1060, 1061]),
+    /**
+     * Message fallback for drivers that carry no machine-readable code —
+     * notably SQLite, whose `code` is the undifferentiated `SQLITE_ERROR` for
+     * every DDL failure, so the message is the only signal available:
+     *   - `table sys_metadata already exists`
+     *   - `duplicate column name: environment_id`
+     *   - `index idx_x already exists`
+     * Postgres phrases its own as `relation "x" already exists` /
+     * `column "x" of relation "y" already exists`, which matches the same test.
+     */
+    message: /already exists|duplicate column name|duplicate key name/i,
+};
 
 /**
- * Message fallback for drivers that carry no machine-readable code — notably
- * SQLite, whose `code` is the undifferentiated `SQLITE_ERROR` for every DDL
- * failure, so the message is the only signal available:
- *   - `table sys_metadata already exists`
- *   - `duplicate column name: environment_id`
- *   - `index idx_x already exists`
- * Postgres phrases its own as `relation "x" already exists` /
- * `column "x" of relation "y" already exists`, which matches the same test.
+ * Codes/messages that mean "the table you tried to READ has not been created".
+ *
+ * Narrower than it looks, on purpose. `does not exist` on its own also covers
+ * `role "x" does not exist` (42704), `database "x" does not exist` (3D000) and
+ * `column "x" does not exist` (42703) — every one of them a **real** failure
+ * that must stay loud, and every one of them a case where "start numbering at
+ * 1" would be the wrong answer against a table that may be full of rows. So the
+ * message test demands the word table/relation next to the phrase rather than
+ * the phrase alone, and the code set carries only the table-scoped SQLSTATEs.
  */
-const ALREADY_EXISTS_MESSAGE = /already exists|duplicate column name|duplicate key name/i;
+const MISSING_TABLE: DriverErrorSignature = {
+    codes: new Set([
+        '42P01', // PostgreSQL undefined_table
+        'ER_NO_SUCH_TABLE', // MySQL / MariaDB 1146
+    ]),
+    errnos: new Set([1146]),
+    /**
+     *   - SQLite / libsql: `no such table: sys_metadata_history`
+     *   - PostgreSQL:      `relation "sys_metadata_history" does not exist`
+     *   - MySQL/MariaDB:   `Table 'app.sys_metadata_history' doesn't exist`
+     */
+    message:
+        /no such table|relation ["'`][^"'`]+["'`] does not exist|table ["'`][^"'`]+["'`] doesn'?t exist|unknown table/i,
+};
 
 /** How far to follow an `error.cause` chain — drivers wrap, but not deeply. */
 const MAX_CAUSE_DEPTH = 4;
 
 /**
- * Is this DDL error the benign "already provisioned" case?
+ * The single matcher both predicates run on: code, then errno, then message,
+ * then one step down the `cause` chain.
  *
- * @param error - The value thrown by `syncSchema()` (or any DDL call).
- * @returns `true` only when the error positively identifies as
- *          table/column/index-already-exists. Anything else — including an
- *          unrecognised error, `undefined`, or a permission/connection failure —
- *          returns `false` and MUST be reported loudly by the caller.
+ * Unrecognised is always `false` — a benign verdict must be *earned*, never
+ * defaulted to, because a false "benign" corrupts data while a false "real"
+ * costs one error line.
  */
-export function isSchemaAlreadyExistsError(error: unknown, depth = 0): boolean {
+function matchesDriverError(
+    error: unknown,
+    signature: DriverErrorSignature,
+    depth: number,
+): boolean {
     if (error === null || error === undefined || depth > MAX_CAUSE_DEPTH) return false;
 
-    if (typeof error === 'string') return ALREADY_EXISTS_MESSAGE.test(error);
+    if (typeof error === 'string') return signature.message.test(error);
     if (typeof error !== 'object') return false;
 
     const err = error as {
@@ -93,10 +176,43 @@ export function isSchemaAlreadyExistsError(error: unknown, depth = 0): boolean {
         cause?: unknown;
     };
 
-    if (typeof err.code === 'string' && ALREADY_EXISTS_CODES.has(err.code)) return true;
-    if (typeof err.errno === 'number' && ALREADY_EXISTS_ERRNOS.has(err.errno)) return true;
-    if (typeof err.message === 'string' && ALREADY_EXISTS_MESSAGE.test(err.message)) return true;
+    if (typeof err.code === 'string' && signature.codes.has(err.code)) return true;
+    if (typeof err.errno === 'number' && signature.errnos.has(err.errno)) return true;
+    if (typeof err.message === 'string' && signature.message.test(err.message)) return true;
 
     // Drivers commonly re-throw with the original attached as `cause`.
-    return isSchemaAlreadyExistsError(err.cause, depth + 1);
+    return matchesDriverError(err.cause, signature, depth + 1);
+}
+
+/**
+ * Is this DDL error the benign "already provisioned" case?
+ *
+ * @param error - The value thrown by `syncSchema()` (or any DDL call).
+ * @param depth - Internal `cause`-chain recursion counter; callers pass nothing.
+ * @returns `true` only when the error positively identifies as
+ *          table/column/index-already-exists. Anything else — including an
+ *          unrecognised error, `undefined`, or a permission/connection failure —
+ *          returns `false` and MUST be reported loudly by the caller.
+ */
+export function isSchemaAlreadyExistsError(error: unknown, depth = 0): boolean {
+    return matchesDriverError(error, ALREADY_EXISTS, depth);
+}
+
+/**
+ * Is this READ error the benign "table has not been provisioned yet" case?
+ *
+ * The only failure that licenses a caller to treat an empty table as the truth
+ * — there are no rows, so there is nothing to be inconsistent with. A
+ * connection drop, a timeout, a permission denial or a query error all mean the
+ * rows may well exist and simply were not seen; those return `false` and the
+ * caller must report the consequence and give up rather than compute an answer
+ * from data it never read (#4825).
+ *
+ * @param error - The value thrown by a driver/engine read (`find`, `findOne`, …).
+ * @param depth - Internal `cause`-chain recursion counter; callers pass nothing.
+ * @returns `true` only when the error positively identifies as
+ *          table/relation-does-not-exist.
+ */
+export function isMissingTableError(error: unknown, depth = 0): boolean {
+    return matchesDriverError(error, MISSING_TABLE, depth);
 }


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4825

## 问题:不是「字节没落盘」,是「落盘的字节是错的」

`DatabaseLoader.nextEventSeq()` 把读 `sys_metadata_history` 的**全部**失败折成同一个答案:

```ts
} catch {
  // Table not provisioned yet or driver error — start at 1.
  return 1;
}
```

注释同时点名了两种原因,然后用同一个 `return 1` 对待两者。这是 #4728 刚修掉的同一种形状,
但危害是**更贵的那一半**:

- #4728 是「声称持久化、实际没落盘」——坏在**缺失**,重试/重启可以修;
- 本条是「**落盘了,但落的字节是错的**」。历史表已有 N 行时,一次瞬时读失败(连接抖动、
  超时、权限)让下一条历史拿到 `event_seq = 1`,与既有行**直接撞号**,而 insert **成功**、
  日志**一行没有**。`event_seq` 正是历史列表排序与 rollback 定位的依据 —— 撞号之后版本顺序
  永久不可信,重试不修、重启也不修。

#4632 的机械检查看不到它:`DURABILITY_CRITICAL_CALLEES` 建在「持久化调用」上,而这一类的
危害发生在**读**上,读的结果决定了写什么(见下「关于词表」)。

## 为什么走方向 1 而不是方向 2(删掉这条 legacy 路径)

issue 给了两条方向,方向 2(确认无生产调用方后直接删除、收敛到 `SysMetadataRepository`)
更彻底 —— 但**核实下来它不成立**。TSDoc 里的 "legacy" 指的是「不是 canonical 的事务型
producer」,不是「没有生产调用方」。全仓查证:

- `MetadataManager.setDatabaseDriver()` / `setDataEngine()` 在 platform kernel 上把
  `DatabaseLoader` 注册为生产 loader;
- `MetadataManager.save()`(`metadata-manager.ts:1591`,以及 `:408` 的
  `protocol === 'datasource:' && capabilities.write` 分发)→ `DatabaseLoader.save()` →
  `createHistoryRecord()` → `nextEventSeq()`;
- `MetadataManager.rollback()` → `DatabaseLoader.registerRollback()` → 同一条路径;
- 且两者都有对外 REST 路由:`rest-route-ledger.ts` 里的
  `POST /api/v1/meta/:type/:name/rollback` 与 `GET /api/v1/meta/:type/:name/history`。

所以这段代码在跑,而且跑在正是会撞号的那条路上。走方向 1。

## 改法:按错误类型判别,复用 #4728 的那套机制

⚠️ 刻意**没有**另起一套错误判别 —— 同一个包里两套判别就是新的债。
`packages/metadata/src/utils/schema-sync-errors.ts`(#4728 / PR #4823 落地)重构成
**一个匹配器 + 两个词表**:`code` → `errno` → `message` → 跟随 `cause` 链(上限 4 层),
`isSchemaAlreadyExistsError()` 与新增的 `isMissingTableError()` 都是它的薄封装。既有
predicate 的签名与行为逐字节不变(其原有测试原样通过)。

两个 predicate **不是彼此的取反**:各自只回答「这是那唯一一种良性原因吗?」,默认都是
「不良性」,所以两边都不认识的错误在两边都响亮。

- **良性的「表还没建」** —— SQLite `no such table: …`、Postgres SQLSTATE `42P01` /
  `relation "…" does not exist`、MySQL `ER_NO_SUCH_TABLE` / errno `1146`。没有行,就没有
  可撞的号,`1` 确实是下一个号 → 静默返回 1。
- **其余一切读失败** —— `nextEventSeq()` **原样抛出**。调用方 `createHistoryRecord()`
  以 `console.error` 上报后**跳过这条历史记录**。

判别方向刻意保守。`does not exist` 本身**不够**:`role "…" does not exist`(42704)、
`database "…" does not exist`(3D000)、`column "…" does not exist`(42703)全是真实失败,
而且每一条都对应「表里可能满是行」的场景 —— 判成良性正是撞号的来源。所以消息匹配要求
table/relation 与该短语同现,code 集合只收表级 SQLSTATE。

## 上报的文案与两条边界

`error` 一行同时给出 AGENTS.md「Degradation log levels」要求的两样东西,外加一个这条特有的:

1. **后果**:该条历史未写入;**元数据写入本身已成功**,所以服务器仍报告健康,而变更历史
   正在悄悄出现空洞,版本时间线与 rollback 目标将不完整;
2. **为什么是空洞而不是错号**:从 1 发号会与既有行撞号,把「不完整」变成「顺序错误」——
   前者可见、后者无人能发现;
3. **修复动作**:修掉下面那条驱动/数据源错误;下一次元数据写入会重试并补报恢复。

两条边界刻意保持不变:

- **元数据写入本身不因此失败**。记录已经落盘,把它报成失败会是比原缺陷更糟的谎;这也与
  同一函数里既有的「history 失败不拖垮主操作」策略、以及 #4728 对 `ensureHistorySchema()`
  的处理一致。
- **本路径已知的并发撞号限制不变**(非事务,canonical producer 仍是
  `SysMetadataRepository`)。那是被记录过的限制,与「读失败静默重置到 1」是两回事。

按「说一次」的纪律:`historySeqFailureReported` 一次性开关 + 恢复时补一条 `info`。

## 测试

钉住的是**落盘的值**,不只是「有没有写」——因为危害就在值上:

- 良性(表不存在)→ `event_seq` 落 `1`,`console.error`/`info` 一行没有;
- 真实读失败、且历史表**已有 N 行** → 落盘序列停在 `[1, 2]` 而**不是** `[1, 2, 1]`
  (改前就是后者:一条撞号的行成功写入、悄无声息),同时 `error` 响亮上报;
- **同一调用点、相反结论**的对照用例(仿 #4823 的写法),否则一个 `() => true` 的分类器
  也能过;
- 主写入不受影响(`save()` 仍 `success: true`,记录可读回);
- 只说一次 + 恢复补 `info`,恢复后从 `2` 续号而非再从 1;
- `registerRollback()` 这条 rollback 历史路径同样覆盖;
- classifier 层:两个方向 + 「两者互不为取反」+ `role/database/column does not exist`
  必须判为**非**良性 + `cause` 链深度上限。

`pnpm check:durability-log-level` 仍绿(8 个 seam,全部响亮或 rethrow),
`scripts/durability-degradation.baseline.json` 无需改动(仍为空)。

## 关于词表(`_find` 是否该进 `DURABILITY_CRITICAL_CALLEES`)—— 只给看法,未动手

issue 末尾那个问题是独立决定,本 PR **没有**改词表,看法记在这里供维护者判断:

**不建议把 `_find` 加进现有词表。** 词表里现有的五个条目全是**写 / provisioning** 调用,
失败本身就等于持久化损失,「记 error 或 rethrow」是完整的补救。读不是:绝大多数包着读的
`catch` 合理地停在 `warn`/`debug`。而且 AST 是按 callee **名字**匹配的,加 `_find`
(以及必然连坐的 `find`/`findOne`/`count`)会在几百个良性读 seam 上炸开 —— 一个塞满
两百条例外的 shrink-only baseline,正是它自己的 `$comment` 警告过的「门禁失去意义」。

有害的形状比「catch 里有个读」窄得多,是**三部分同时成立**:
读失败 → `catch` 用一个**编造的值**顶替没读到的数据 → 那个值被**写下去 / 记录下来**。
`nextEventSeq` 三条全中(`_find` → `return 1` → `event_seq: 1` 落库);
`catch { return [] }` 只让列表渲染成空,前两条中、第三条不中,是完全合法的。

所以它需要的是**词表之外的第二条规则**,形状与 AGENTS.md 里紧跟在降级规则之后的
「Startup registry reads」那条一样(那条也是写侧规则的读侧对应物,靠「三部分同时成立」
而不是靠 callee 词表立住)。问句大致是:

> 这个 `catch` 是否用一个编造的值顶替了它没能读到的数据?那个值是否随后被写入或记录?
> 两个都是 → 这个 fallback 值必须由错误分类**挣来**,否则就不该产生。

**能不能机械化是开放问题,我不会替它打包票。** 写侧门禁成立是因为「callee 名在词表里」
是个便宜的 AST 判断;读侧要的是数据流(catch 的返回值最终进了某个被持久化的字段),
通用版本是 taint analysis,而一个 60% 精度的门禁配 shrink-only baseline 比没有更糟。
建议:先把规则写进 AGENTS.md(#4632 的价值本来也主要来自规则本身),机械检查作为独立的、
刻意收窄到「`catch` 里 `return` 一个字面量」的后续单,先量命中率再决定是否上门禁。

顺带:#4777(把词表扩到启动期注册表判断)是同一观察的另一侧 —— 两条都说明 #4632 的词表
应当**保持原样**(只收持久化写调用),新形状各立新规则,而不是往老列表里塞新词。

## 顺带发现,已单开不在本 PR 修

**#4867** —— `packages/metadata-protocol/src/sys-metadata-repository.ts` 的
`nextEventSeq()` 与 `nextItemVersion()` 有**逐字同形**的 `catch { return 1 }`。而那是
**canonical 路径**(本单正文与分诊都把它称作「历史写入应当收敛过去的地方」),并且那里有
**两个**数字:`event_seq`,以及 `version` —— 后者的 TSDoc 明说它刻意从 history 取 MAX
「so delete + recreate continues incrementing instead of restarting at 1」,一次读失败正好
把它恢复成它明确要避免的行为,而 `rollback(type, name, version)` 正是按 `version` 定位快照。
跨包复用本 PR 新增的判别器需要先定它的落点(内部工具 vs 下沉到共同依赖),已在 #4867 里
列出三个选项,留给维护者定。

## 验证

```
pnpm --filter @objectstack/metadata exec vitest run --maxWorkers=2
  Test Files  15 passed (15)
       Tests  336 passed (336)
```

`packages/metadata` 无 `typecheck` script(在 `check-type-check-coverage.mjs` 的 DEBT 账本里)。
手动量了两次 `tsc --noEmit`:改动前 **92**,改动后 **92** —— 本 PR 新增 0 个类型错误
(过程中一版测试写法引入过 5 个 `TS2348`,已用一个带类型的 `DriverFind` 别名 + 单一
`driverWithBreakableHistoryReads()` helper 消掉,顺带去掉了四处重复的 driver 包装)。


---
_Generated by [Claude Code](https://claude.ai/code/session_015Br2xsJsczFsTR9bvbh2Ny)_