### PR TITLE
fix(core): 插件 init/start 超时守卫在 race 落定时被清除 —— 进程不再空转 `startupTimeout` (#4813)

### DIFF
--- a/.changeset/kernel-startup-timeout-guard-cleared.md
+++ b/.changeset/kernel-startup-timeout-guard-cleared.md
@@ -1,0 +1,33 @@
+---
+'@objectstack/core': patch
+---
+
+fix(core): 插件 init/start 的超时守卫定时器在 race 结束时被清除,进程不再空转 `startupTimeout` (#4813)
+
+`ObjectKernel.initPluginWithTimeout()` / `startPluginWithTimeout()` 各自 `setTimeout` armed
+一根超时守卫,然后**把它扔了**:插件赢下 race 之后,那根定时器既没 `clearTimeout` 也没
+`unref()`,带着 ref 一直挂到 `startupTimeout` 走完。于是每个进程在活干完之后还要空转整整
+一个 `startupTimeout` —— `ObjectQLPlugin` 是 120 秒。
+
+实测(`examples/app-crm`,同一条 `migrate recorded-by --json`,同一个构建链,唯一差别是本
+改动):
+
+| | 墙钟 |
+|:--|:--|
+| 修复前 | 122.4s |
+| 修复后 | 3.1s |
+
+JSON 与 `✅ Graceful shutdown complete` 两次都在 ~3 秒出现 —— 后面那 119 秒纯粹是 8 根
+孤儿定时器(4 个 init + 4 个 start)钉着事件循环。`os serve` 里同样漏,只是那里进程本来
+就长命,看不出来。
+
+**为什么是 `clearTimeout` 而不是 `unref()`。** 隔壁 `shutdown()` 的守卫用的是 `unref()`,
+但那个写法在这里是错的,而且不是风格问题:`unref()` 让定时器不再钉住事件循环,**同时也
+让它不再是一个守卫** —— 若 hook 永不 settle 且没有别的东西撑着事件循环,Node 会在定时器
+触发之前直接退出,超时被**静默吞掉**,谁也不会收到那个 error。守卫必须在 race 未决期间
+保持 ref'd,在 race 落定的那一刻被回收,这正是 `finally { clearTimeout(guard) }` 表达的
+语义。两个守卫合并为一个私有 helper `raceStartupTimeout()`,措辞与理由写在它的 doc
+comment 里。
+
+`startupTimeout` 的取值一个都没动 —— 慢启动的插件需要那个上限,问题从来不在时长,而在
+没人回收。

--- a/packages/core/src/kernel.test.ts
+++ b/packages/core/src/kernel.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { ObjectKernel } from './kernel';
 import { ServiceLifecycle, PluginMetadata } from './plugin-loader';
 import type { Plugin } from './types';
@@ -228,6 +228,133 @@ describe('ObjectKernel', () => {
             expect(kernel.isRunning()).toBe(true);
 
             await kernel.shutdown();
+        });
+    });
+
+    // #4813 — the guard timer must not outlive the race it guards.
+    //
+    // These tests are about the *process*, not about the source: asserting
+    // "kernel.ts calls clearTimeout" would be a tautology that any refactor
+    // could satisfy while still pinning the event loop. What is asserted here
+    // is the observable consequence — after the work is done, nothing the
+    // guards armed is still holding the loop open.
+    describe('Startup timeout guards do not outlive the race (#4813)', () => {
+        /**
+         * Ref'd `Timeout` handles — `getActiveResourcesInfo()` reports only
+         * resources that are *currently keeping the event loop alive*, which
+         * is precisely the property that made `os migrate` hang ~120s after
+         * printing `✅ Graceful shutdown complete`.
+         */
+        const refdTimers = () =>
+            process.getActiveResourcesInfo().filter((r) => r === 'Timeout').length;
+
+        it('leaves no ref\'d timer behind after the plugin wins the race', async () => {
+            const plugin: PluginMetadata = {
+                name: 'fast-plugin-long-guard',
+                version: '1.0.0',
+                init: async () => {},
+                start: async () => {},
+                // The real value that hung one-shot CLI processes: ObjectQLPlugin.
+                startupTimeout: 120_000,
+            };
+
+            await kernel.use(plugin);
+
+            const before = refdTimers();
+            await kernel.bootstrap();
+            const after = refdTimers();
+
+            // Two guards were armed (init + start) and both lost their race.
+            // While either is still ref'd the process cannot exit for up to
+            // `startupTimeout` — 120s of idling after a 3s job.
+            expect(after).toBe(before);
+
+            await kernel.shutdown();
+        });
+
+        it('reclaims one guard per lifecycle hook, for every plugin', async () => {
+            const makePlugin = (n: number): PluginMetadata => ({
+                name: `guarded-plugin-${n}`,
+                version: '1.0.0',
+                init: async () => {},
+                start: async () => {},
+                startupTimeout: 120_000,
+            });
+
+            for (let n = 0; n < 4; n++) {
+                await kernel.use(makePlugin(n));
+            }
+
+            const before = refdTimers();
+            await kernel.bootstrap();
+
+            // The issue's probe caught exactly this shape: 8 ref'd Timeouts
+            // for 4 plugins (4 init + 4 start). The count must not scale with
+            // the plugin list — it must not grow at all.
+            expect(refdTimers()).toBe(before);
+
+            await kernel.shutdown();
+        });
+
+        it('still fires the guard when the plugin loses the race', async () => {
+            // The companion assertion to the two above: reclaiming the guard
+            // must not disarm it. `unref()` would satisfy "no ref'd timer" by
+            // detaching the guard from the loop — and a process with nothing
+            // else to run then exits *silently* instead of reporting the
+            // timeout. Clearing on settle keeps the guard armed exactly while
+            // the race is undecided.
+            const plugin: PluginMetadata = {
+                name: 'hanging-plugin',
+                version: '1.0.0',
+                init: async () => {
+                    await new Promise((resolve) => setTimeout(resolve, 5000));
+                },
+                startupTimeout: 50,
+            };
+
+            await kernel.use(plugin);
+
+            await expect(kernel.bootstrap()).rejects.toThrow(
+                'Plugin hanging-plugin init timeout after 50ms'
+            );
+        }, 1000);
+    });
+
+    describe('Startup timeout guards under fake timers (#4813)', () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('schedules no pending timer once bootstrap has settled', async () => {
+            const kernelWithFakeTimers = new ObjectKernel({
+                logger: { level: 'error' },
+                gracefulShutdown: false,
+                skipSystemValidation: true,
+            });
+
+            const plugin: PluginMetadata = {
+                name: 'fake-timer-plugin',
+                version: '1.0.0',
+                init: async () => {},
+                start: async () => {},
+                startupTimeout: 120_000,
+            };
+
+            await kernelWithFakeTimers.use(plugin);
+
+            const before = vi.getTimerCount();
+            await kernelWithFakeTimers.bootstrap();
+
+            // Unlike `getActiveResourcesInfo()`, the fake-timer count includes
+            // unref'd timers — so this one distinguishes "the guard was
+            // reclaimed" from "the guard was merely detached from the loop".
+            expect(vi.getTimerCount()).toBe(before);
+
+            await kernelWithFakeTimers.shutdown();
         });
     });
 

--- a/packages/core/src/kernel.ts
+++ b/packages/core/src/kernel.ts
@@ -541,16 +541,56 @@ export class ObjectKernel {
 
         this.currentlyInitializing = plugin.name;
         try {
-            const initPromise = plugin.init(this.context);
-            const timeoutPromise = new Promise<void>((_, reject) => {
-                setTimeout(() => {
-                    reject(new Error(`Plugin ${plugin.name} init timeout after ${timeout}ms`));
-                }, timeout);
-            });
-
-            await Promise.race([initPromise, timeoutPromise]);
+            await this.raceStartupTimeout(
+                plugin.init(this.context),
+                timeout,
+                `Plugin ${plugin.name} init timeout after ${timeout}ms`
+            );
         } finally {
             this.currentlyInitializing = undefined;
+        }
+    }
+
+    /**
+     * Race a plugin lifecycle hook against its startup-timeout guard, and
+     * reclaim the guard the moment the race settles (#4813).
+     *
+     * The guard used to be armed and then abandoned: when the plugin won the
+     * race, its `setTimeout` stayed ref'd in the event loop for the full
+     * `startupTimeout`, so every process idled that long after its work was
+     * done. One `os migrate` finished in 3s and then sat for 120s
+     * (`ObjectQLPlugin.startupTimeout`), held open by 8 orphaned guards — one
+     * per init plus one per start.
+     *
+     * Clearing on settle rather than `unref()`-ing at arm time is deliberate.
+     * An unref'd guard also stops pinning the loop, but it stops being a guard
+     * as well: if the hook never settles and nothing else keeps the loop alive,
+     * Node exits before the timer can fire and the timeout is never reported.
+     * The guard has to stay ref'd exactly as long as the race is undecided,
+     * which is what `clearTimeout` in a `finally` expresses.
+     *
+     * `operation` is widened to `T | PromiseLike<T>` because the Plugin
+     * contract permits a synchronous hook (`init`/`start` return
+     * `void | Promise<void>`); such a hook wins the race immediately and the
+     * guard is reclaimed on the same turn.
+     */
+    private async raceStartupTimeout<T>(
+        operation: T | PromiseLike<T>,
+        timeout: number,
+        message: string
+    ): Promise<T> {
+        let guard: ReturnType<typeof setTimeout> | undefined;
+
+        const timeoutPromise = new Promise<never>((_, reject) => {
+            guard = setTimeout(() => {
+                reject(new Error(message));
+            }, timeout);
+        });
+
+        try {
+            return await Promise.race([operation, timeoutPromise]);
+        } finally {
+            clearTimeout(guard);
         }
     }
 
@@ -584,15 +624,12 @@ export class ObjectKernel {
         this.logger.debug(`Start: ${plugin.name}`, { plugin: plugin.name });
         
         try {
-            const startPromise = plugin.start(this.context);
-            const timeoutPromise = new Promise<void>((_, reject) => {
-                setTimeout(() => {
-                    reject(new Error(`Plugin ${plugin.name} start timeout after ${timeout}ms`));
-                }, timeout);
-            });
+            await this.raceStartupTimeout(
+                plugin.start(this.context),
+                timeout,
+                `Plugin ${plugin.name} start timeout after ${timeout}ms`
+            );
 
-            await Promise.race([startPromise, timeoutPromise]);
-            
             const duration = Date.now() - startTime;
             this.startedPlugins.add(plugin.name);
             this.pluginStartTimes.set(plugin.name, duration);


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4813

`initPluginWithTimeout()` / `startPluginWithTimeout()` 各自 `setTimeout` armed 一根超时守卫,然后**把它扔了**。插件赢下 race 之后那根定时器既没 `clearTimeout` 也没 `unref()`,带着 ref 一直挂到 `startupTimeout` 走完 —— 每个进程在活干完之后还要空转整整一个 `startupTimeout`。

两处守卫合并成一个私有 helper `raceStartupTimeout()`,在 `finally` 里 `clearTimeout`。`startupTimeout` 的取值一个都没动。

## 为什么是 `clearTimeout` 而不是 `unref()` —— 我验证过再决定的

issue 提到「`finally { clearTimeout(t) }` 比 `unref()` 更彻底」,并猜测理由是 unref 的定时器仍会触发那个 reject,产生一个无人处理的 rejection。**这个猜测是错的,我实测否定了它** —— `Promise.race` 会给每个 arm 都挂上 handler,所以输掉的 timeout promise 后来 reject 时是**被处理过的**,不会有 unhandledRejection:

```js
process.on('unhandledRejection', r => console.log('UNHANDLED:', String(r)));
const work = Promise.resolve('done');
const guard = new Promise((_, reject) => {
  setTimeout(() => reject(new Error('guard fired')), 300).unref();
});
await Promise.race([work, guard]);
setTimeout(() => console.log('still alive at 600ms'), 600);
// → race settled: done
// → still alive at 600ms          ← 没有 UNHANDLED
```

真正的理由是另一条,而且更硬:**`unref()` 让定时器不再钉住事件循环,同时也让它不再是一个守卫。**

```js
// 一个永不 settle 的 hook,守卫用 unref():
const never = new Promise(() => {});
const guard = new Promise((_, reject) => {
  const t = setTimeout(() => reject(new Error('start timeout after 500ms')), 500);
  if (t.unref) t.unref();                       // shutdown() 的写法
});
try { await Promise.race([never, guard]); }
catch (e) { console.log('GUARD FIRED:', e.message); }
console.log('after await');
```

实际输出:**什么都没打印**,Node 直接退出(exit 13,`unsettled top-level await`)。守卫从来没有触发,超时被**静默吞掉**。若 hook 永不 settle 且没有别的东西撑着事件循环,`unref()` 的守卫就是个摆设 —— 这正是它要防的那种故障。

所以正确语义是:守卫在 race **未决期间保持 ref'd**(它必须能触发),在 race **落定的那一刻被回收**。`finally { clearTimeout(guard) }` 恰好表达这个,`unref()` 表达不了。

关于「保持同一种写法」:`shutdown()` 自己那处 `if (t.unref) t.unref();` **本 PR 没有动** —— issue 的边界写明只碰这两个守卫,而且改它会在一个边缘情形上改变行为(shutdown 卡死且事件循环空转时,现在静默退出 0,改成 clear 后会触发 `Shutdown timeout exceeded` → `process.exit(1)`)。那是一个独立的判断,不该搭本 PR 的车。理由与取舍写在 `raceStartupTimeout()` 的 doc comment 里,下一个读到 `shutdown()` 的人能看到两种写法各自的适用面。

## 验收:真实 CLI,同一个构建链,唯一差别是本改动

```bash
cd examples/app-crm
OS_DATABASE_URL="file:/tmp/t.db" node ../../packages/cli/bin/run.js migrate recorded-by --json
```

| | 墙钟 |
|:--|:--|
| 修复前 | **122.4s** |
| 修复后 | **3.1s** |

两次 JSON 与 `✅ Graceful shutdown complete` 都在 ~3 秒出现;后面那 119 秒纯粹是 8 根孤儿定时器钉着事件循环。(为了拿到干净的 before,我把 `kernel.ts` stash 掉、只重建 `@objectstack/core`、跑同一条命令,再还原 —— 所以这一对数字之间没有别的变量。)

## 测试:钉的是「定时器不再把进程钉住」,不是「代码里调了 clearTimeout」

后者是同义反复,任何重构都能满足它而照旧漏定时器。新增 4 条,前 3 条**修复前全红**:

```
AssertionError: expected 3 to be 1     ← leaves no ref'd timer behind after the plugin wins the race
AssertionError: expected 11 to be 3    ← reclaims one guard per lifecycle hook, for every plugin
AssertionError: expected 2 to be +0    ← schedules no pending timer once bootstrap has settled
Test Files  1 failed (1)
     Tests  3 failed | 1 passed | 31 skipped (35)
```

- **`getActiveResourcesInfo()` 探针**(issue 自己的思路)。它只报告**当前正在维持事件循环存活**的资源,正是「进程为什么不退出」这个问题的直接答案。1 个插件 ⇒ 修前多出 2 根(init + start);**4 个插件 ⇒ 修前多出 8 根**,与 issue 里 probe 抓到的 `8 ref'd timers still alive` 一模一样。断言的是 delta 为 0,不是绝对值。
- **假定时器那条是用来区分半修的**:`getActiveResourcesInfo()` 不计 unref'd 定时器,所以只有它无法分辨「守卫被回收了」和「守卫只是被摘下了循环」;`vi.getTimerCount()` 两者都计,`unref()` 方案过不了这一条。
- **第 4 条是反向配对**:插件输掉 race 时守卫**照旧触发**(`Plugin hanging-plugin init timeout after 50ms`)。回收守卫不等于解除守卫 —— 没有这条,「把两个 `setTimeout` 删掉」也能让前 3 条变绿。

```
@objectstack/core     28 files /  462 tests passed
@objectstack/runtime  80 files / 1092 tests passed
@objectstack/cli      67 files /  585 tests passed
tsc --noEmit (core)   120 errors — 与改动前 baseline 完全相同,本 PR 新增 0
```

`@objectstack/core` 没有 `typecheck` script,走 `check-type-check-coverage.mjs` 的 DEBT 棘轮,所以我按「改动前/改动后同一条命令」测了两次而不是只看绝对数。中途 helper 的形参一度写成 `Promise< T >` 而多出 2 个 TS2345 —— Plugin 契约允许**同步** hook(`init`/`start` 返回 `void | Promise< void >`),已改为 `T | PromiseLike< T >`,回到 baseline。

## ⚠️ 本 PR 改变了 #4747 那条路径的时序 —— 请连带读这一段

**#4747 已经独立修好了**(PR #4815,`127f09125`,已在 main 上),修的是生命周期契约那一侧:`ObjectQLPlugin` 的关停逻辑从内核根本不调用的 `stop()` 挪到 `destroy()`,`bootSchemaStack().shutdown()` 从 `(runtime as any).stop?.()` 改走 `kernel.shutdown()`。所以**本 PR 不会掩盖 #4747** —— 它已经不是靠时序活着的了。

但这件事仍然值得写下来,因为**本 PR 确实会让 #4747 的现象即使在未修状态下也不再复现**:#4551 的巡检首次 sweep 排在启动后 60 秒,而正是这 120 秒空转把一次性 CLI 进程留到了 60 秒定时器触发。修好之后进程 3 秒就退出,**那条巡检路径不再被触发**。假如 #4815 没有先落地,本 PR 会让一个真实缺陷「看起来消失了」而根因原封不动。#4813 与 #4747 必须各自被各自的修复关闭,这是其中一半。

推而广之:只要这些守卫还在漏,任何「启动后 N 秒才做的事」都会在一个自以为已经结束的进程里醒来 —— 反过来,修好之后,任何依赖「进程反正还活着」的周期性工作都会失去那个隐式的宽限期。目前仓里只有 ADR-0057 巡检这一处踩到,已由 #4815 从正确的一侧解决。

## 超范围产出(未在本 PR 修)

- **#4873(新开,未认领)**:`os migrate` **成功**时退出码是随机非零值。这是我为了拿 before/after 数字才看清的:issue #4813 把不稳定退出码(214/238)归因于「挂太久被外部杀掉」,**这个归因是错的** —— 修复后没有任何东西杀它,它 3 秒自行退出,退出码依旧随机(实测 62 / 169 / 208 / 171 / 176;修复前是 163)。同一个 `bin/run.js` 的 `--version` / `--help` 干净退出 0,所以问题在 `bootSchemaStack` 系子命令的退出路径上。对按退出码判断成败的 CI 是直接的假失败,且因为随机而无法特判兜底。
- **`packages/core/src/health-monitor.ts:315` 的 `timeout()` 是同一个漏法**:`setTimeout(() => reject(...), ms)` 进 `Promise.race`(`:112` 的健康检查),赢下 race 之后同样不清除。它今天没造成 #4813 的现象,因为健康监控不在 bootstrap 路径上启动;但它是同一个形状,应当用同一个 helper 收编。issue 的边界写明只碰 kernel.ts 的两个守卫,故本 PR 未动 —— 如果维护者希望一并收,我可以在同一条分支上补。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Br2xsJsczFsTR9bvbh2Ny


---
_Generated by [Claude Code](https://claude.ai/code/session_015Br2xsJsczFsTR9bvbh2Ny)_