### PR TITLE
docs(skills): an unevaluable hook condition aborts the write (#4775)

### DIFF
--- a/.changeset/skill-hook-condition-aborts.md
+++ b/.changeset/skill-hook-condition-aborts.md
@@ -1,0 +1,31 @@
+---
+---
+
+Docs-only: the `objectstack-data` skill's hook reference taught the pre-17
+failure mode for an unevaluable `condition`.
+
+`skills/objectstack-data/references/data-hooks.md` had been updated for #4770
+(the condition reads the record, not the payload) and #4784 (`previous` is
+bound), but its closing bullet still said an undeclared key leaves the condition
+"logged at WARN and treated as false" — the behaviour #4775 replaced. An
+unevaluable condition now **aborts the operation**.
+
+This is the AI-authoring reference for hooks, so the stale sentence pointed the
+wrong way on the one axis that matters: it told an author a typo is a soft
+failure. It also silently downgraded the two bullets above it — `previous` is
+unbound on inserts and on `multi: true` writes, and `has()` is not a null guard —
+from "this breaks your write" to "this quietly disables your hook".
+
+Replaced with a callout carrying the #4775 rule and the reason the two outcomes
+had to split (a `before*` guard swallowed into `false` lets writes through; an
+audit hook swallowed into `false` drops records — opposite failures), plus the
+practical authoring consequence.
+
+Swept the rest of `skills/` and `.claude/skills/` against the same rc.2 window;
+nothing else was stale. `objectstack-automation` already documents #4343's
+`script`-node retirements, `objectstack-query` already carries the #4286
+`cursor` / `joins` / `windowFunctions` prescriptions, and
+`objectstack-formula` already documents #4649 fail-closed predicates and #4763's
+build-time `has()` rejection.
+
+Releases nothing.

--- a/skills/objectstack-data/references/data-hooks.md
+++ b/skills/objectstack-data/references/data-hooks.md
@@ -260,8 +260,21 @@ in neither). So:
   `has(record.spent) && record.spent > record.budget` still faults on
   `null > null`. `has()` answers "is this key declared at all", which is a
   question about your spelling, not about your data.
-- An **undeclared** key (a typo) stays unevaluable: the condition is logged at
-  WARN and treated as false.
+
+⚠️ **An unevaluable condition ABORTS the operation (#4775).** A typo'd key
+(`record.stauts`), a `previous` reference on an insert, or a comparison CEL has
+no overload for does **not** degrade to "the hook did not fire" — it **fails the
+write**. Until protocol 17 the gate emitted a `logger.warn` and returned `false`,
+which is why the two bullets above are load-bearing rather than stylistic: a
+`before*` guard swallowed into `false` silently let writes through, and an audit
+hook swallowed into `false` silently dropped records. Those are opposite
+failures, so "the condition said no" and "the platform could not work out what
+the condition says" are now different outcomes and the second one is loud.
+
+Practical consequence when authoring: spell keys against the object's **declared**
+fields, and never reach for `previous` in a hook that can fire on insert or on a
+`multi: true` write — that mistake used to cost you a hook that quietly never
+ran, and now costs you every write the hook is attached to.
 
 #### `onError` — Error Handling
 


### PR DESCRIPTION
Third pass of the rc.2 catch-up, after #4877 (release page) and #4881 (docs sweep run 5): the same window applied to `skills/` and `.claude/skills/`.

Skills matter more than prose here — they are what an AI author reads before emitting metadata, and #4001 closed the whole authorable surface in this window, so a stale skill now produces metadata that hard-fails at parse.

## The sweep came back almost clean

Checked all 10 published skills and the 3 internal ones against the window's retirements and behaviour changes. Already correct, updated by the PRs that changed them:

- `objectstack-automation` documents #4343's `script`-node retirements (`actionType: 'email' | 'slack'` as logger-backed stubs, inline `config.script` never executed).
- `objectstack-query` carries the #4286 prescriptions for `cursor`, `joins` and `windowFunctions`.
- `objectstack-formula` documents #4649 fail-closed predicates and #4763's build/publish rejection of `has()` as a null guard, with the `null < null` worked example.
- `objectstack-data/references/data-hooks.md` was updated for #4770 (the condition reads the record, not the payload) and #4784 (`previous` is bound), including the transition idiom.

The `has(vars.picked)` in `objectstack-automation` is over a **flow variable**, not a declared record field — that is the "was this written at all" use #4763 explicitly leaves untouched. Not a finding.

## One finding

`skills/objectstack-data/references/data-hooks.md` had been updated for #4770 and #4784 but never for **#4775**, and closed the `condition` section with:

> An **undeclared** key (a typo) stays unevaluable: the condition is logged at WARN and treated as false.

That is exactly the behaviour #4775 replaced. An unevaluable condition now **aborts the operation**.

Wrong in the dangerous direction for an AI-authoring reference: it tells an author a typo is a soft failure. It also silently downgraded the two bullets immediately above it — `previous` is unbound on inserts and on `multi: true` writes, and `has()` is not a null guard — from *"this breaks your write"* to *"this quietly disables your hook"*. Both are now write-failing mistakes, which is what makes those bullets load-bearing rather than stylistic.

Replaced with a callout carrying the #4775 rule, the reason the two outcomes had to split (a `before*` guard swallowed into `false` lets writes through; an audit hook swallowed into `false` drops records — opposite failures from one collapsed outcome), and the practical authoring consequence.

## Verification

- `node scripts/check-doc-authoring.mjs` — 215 files clean

Docs-only; releases nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaegKY1Y7GqTb8CKMm5GLC)_