### PR TITLE
fix(tooling): objectui-range 改读 objectui 声明的 changeset,不再按 commit 类型猜 (#4843)

### DIFF
--- a/.changeset/objectui-range-from-declarations.md
+++ b/.changeset/objectui-range-from-declarations.md
@@ -1,0 +1,34 @@
+---
+---
+
+Tooling-only (#4843): `scripts/objectui-range.mjs` — the aggregation layer whose output is
+pasted into a release page's **Console** section — now reports the frontend changes objectui
+**declared** over the pinned range instead of guessing them from conventional-commit types.
+Releases nothing; no package changes.
+
+#4731 fixed this failure mode on the `bump-objectui.sh` side; the release page kept the old
+guess (`const KEEP = ALL_TYPES ? null : new Set(['feat', 'fix'])`, with `--all` as an
+explicit opt-in). Measured on the same real range (`7d9734d5e321..785b8a5d432c`, 53
+non-merge objectui commits), the default output **dropped 13 commits that actually
+released** — 6 of them breaking `refactor(...)!`, including `refactor(layout)!: delete
+PageNodeRenderer` and burn-ledger batches 2/4/5/6/7, plus `chore(deps): lockstep the
+@objectstack family onto 17.0.0-rc.1` — while **listing 5 commits that release nothing** in
+objectui (two `fix(ci)`: one with no changeset, one whose changeset has an empty
+frontmatter). Breaking changes were the single class structurally unable to appear, in the
+artifact that leads with breaking changes.
+
+The two scripts now share **one** criterion rather than each carrying a copy: the
+classification moved into an exported `classifyRange()` in
+`scripts/objectui-changeset-digest.mjs`, and both `bump-objectui.sh` (the platform release
+record) and `objectui-range.mjs` (the release page) go through it. A second copy would
+drift, and the first thing it would drift on is the class that already went missing once.
+
+Because the output *is* release-page body text — a reader cannot tell a filtered list from a
+complete one — the accounting is now **unconditional**: every run prints how many changesets
+released of how many were added across how many commits, plus the excluded counts
+(release-nothing changesets, commits carrying no changeset), including when those counts are
+zero. `--all` changes meaning from "include every commit type" (the filter is gone) to "also
+name the excluded entries, one per line". Headings group by the level objectui declared
+(breaking / features / fixes); grouping is presentation and never a filter. Guarded by
+`node scripts/objectui-range.mjs --self-test`, folded into the existing
+`pnpm check:objectui-changeset` gate.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -233,6 +233,9 @@ jobs:
       # throwaway git repos carrying those exact shapes, runs the real scripts
       # over them, and asserts the emitted changeset — including that a cap which
       # fires announces itself and that an unwalkable range degrades loudly.
+      # #4843 folded `scripts/objectui-range.mjs` — the release page's Console
+      # section — onto that same `classifyRange()` criterion, so both self-tests
+      # run here: one criterion, two consumers, no room to drift apart.
       - name: objectui pin-changeset digest guard
         run: pnpm check:objectui-changeset
 

--- a/docs/releases-maintenance.md
+++ b/docs/releases-maintenance.md
@@ -71,14 +71,31 @@ platform version maps to.
 Backend content comes from the spec/package changesets. Frontend content comes from
 objectui's history for the SHA range bundled in that release. Because `.objectui-sha`
 is version-controlled, `scripts/objectui-range.mjs` computes that range from any two
-framework revisions and prints the feat/fix commits grouped by type + the largest
-touched areas — ready to paste into a Console section:
+framework revisions and prints the frontend changes **objectui declared** over it —
+grouped by declared level (breaking / features / fixes), with the largest touched
+areas — ready to paste into a Console section:
 
 ```bash
 # frontend delta bundled between two framework revisions (needs ../objectui)
 node scripts/objectui-range.mjs <old-rev> <new-rev>   # e.g. the two release commits
 node scripts/objectui-range.mjs --from <sha> --to <sha> --json   # explicit SHAs / tooling
+node scripts/objectui-range.mjs <old-rev> <new-rev> --all         # also name what ships nothing
 ```
+
+**What "a frontend change" means here (#4843).** The list comes from the
+`.changeset/*.md` files objectui added over the range, via the same `classifyRange()`
+in `scripts/objectui-changeset-digest.mjs` that `bump-objectui.sh` uses to write the
+pin changeset (#4731) — one criterion, two consumers, so the platform release record
+and this page's Console section cannot disagree. A changeset with an empty frontmatter
+block is changesets' own "release-nothing" marker and is excluded; so is a commit that
+added no changeset. **Both exclusions are counted out loud in the printed markdown**,
+because the output *is* release-page body text and a reader cannot otherwise tell a
+filtered list from a complete one. Headings group by declared level; grouping is
+presentation and never a filter.
+
+This replaced a `feat|fix` guess on commit subjects. On the real range
+`7d9734d5e321..785b8a5d432c` that guess dropped 13 commits that actually released —
+6 of them breaking `refactor(...)!` — and listed 5 that release nothing.
 
 Without an objectui checkout it still prints the SHA range to inspect. The framework
 changesets also embed companion frontend notes inline ("Companion objectui PR

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "check:durability-log-level": "node scripts/check-durability-degradation-log-level.mjs --self-test && node scripts/check-durability-degradation-log-level.mjs",
     "check:startup-registry-verdict": "node scripts/check-startup-registry-verdict.mjs --self-test && node scripts/check-startup-registry-verdict.mjs",
     "check:console-sha": "node scripts/check-console-sha.mjs",
-    "check:objectui-changeset": "node scripts/objectui-changeset-digest.mjs --self-test",
+    "check:objectui-changeset": "node scripts/objectui-changeset-digest.mjs --self-test && node scripts/objectui-range.mjs --self-test",
     "check:release-notes": "node scripts/check-release-notes.mjs",
     "check:node-version": "node scripts/check-node-version.mjs",
     "check:published-files": "node scripts/check-published-files.mjs --self-test && node scripts/check-published-files.mjs",

--- a/scripts/objectui-changeset-digest.mjs
+++ b/scripts/objectui-changeset-digest.mjs
@@ -125,12 +125,21 @@ export function clampSummary(summary, limit = 180) {
  * it — the released frontend change would vanish from the release record, the
  * very failure this whole mechanism exists to prevent.
  *
- * @returns {{ entries: Array<{ path: string, sha: string, subject: string }>, totalCommits: number, commitsWithChangeset: number }}
+ * `commits` is every non-merge commit in the range (newest first) and
+ * `commitsWithChangesetShas` the subset that added one, so a caller can NAME
+ * the commits it is leaving out instead of only counting them (#4843).
+ *
+ * @returns {{ entries: Array<{ path: string, sha: string, subject: string }>, commits: Array<{ sha: string, subject: string }>, totalCommits: number, commitsWithChangeset: number, commitsWithChangesetShas: Set<string> }}
  */
 export function collectAddedChangesets(objectuiRoot, from, to) {
-  const totalCommits = git(objectuiRoot, ['log', '--no-merges', '--format=%H', `${from}..${to}`])
+  const commits = git(objectuiRoot, ['log', '--no-merges', '--format=%H%x09%s', `${from}..${to}`])
     .split('\n')
-    .filter(Boolean).length;
+    .filter(Boolean)
+    .map((line) => {
+      const tab = line.indexOf('\t');
+      return { sha: line.slice(0, tab), subject: line.slice(tab + 1) };
+    });
+  const totalCommits = commits.length;
 
   const raw = git(objectuiRoot, [
     'log',
@@ -164,7 +173,13 @@ export function collectAddedChangesets(objectuiRoot, from, to) {
     commitsWithChangeset.add(sha);
     entries.push({ path, sha, subject });
   }
-  return { entries, totalCommits, commitsWithChangeset: commitsWithChangeset.size };
+  return {
+    entries,
+    commits,
+    totalCommits,
+    commitsWithChangeset: commitsWithChangeset.size,
+    commitsWithChangesetShas: commitsWithChangeset,
+  };
 }
 
 /** Read a changeset's content at `to`, falling back to the commit that added it. */
@@ -196,31 +211,36 @@ export function inPreMode(frameworkRoot) {
 }
 
 /**
- * Build the digest for a range.
+ * THE criterion: which objectui changes over `from..to` actually ship in the
+ * frontend release, as objectui DECLARED it — plus a full account of what is
+ * being left out and why.
  *
- * @returns {{ bump: string, declaredLevel: string|null, breaking: number, releasing: Array<object>, releaseNothing: number, noChangeset: number, totalCommits: number, downgradedMajor: boolean, body: string }}
+ * This is the single shared implementation. `bump-objectui.sh` (via
+ * `buildDigest` below, #4731) and `scripts/objectui-range.mjs` (#4843) both go
+ * through it, so the platform release record and the release page's Console
+ * section can never disagree about what "a releasing frontend change" means.
+ * Two copies of this rule would drift, and the first thing they would drift on
+ * is the class that already went missing once: breaking `refactor(...)!`.
+ *
+ * Nothing here reads a commit type. Grouping output BY type is presentation and
+ * belongs to the caller; it must never become a filter again.
+ *
+ * @returns {{ releasing: Array<object>, releaseNothingEntries: Array<object>, noChangesetCommits: Array<object>, releaseNothing: number, noChangeset: number, changesetsAdded: number, totalCommits: number }}
  */
-export function buildDigest({
-  objectuiRoot,
-  frameworkRoot = REPO_ROOT,
-  from,
-  to,
-  max = DEFAULT_MAX_ENTRIES,
-  bumpOverride = '',
-}) {
-  const { entries, totalCommits, commitsWithChangeset } = collectAddedChangesets(
+export function classifyRange({ objectuiRoot, from, to }) {
+  const { entries, commits, totalCommits, commitsWithChangesetShas } = collectAddedChangesets(
     objectuiRoot,
     from,
     to,
   );
 
   const releasing = [];
-  let releaseNothing = 0;
+  const releaseNothingEntries = [];
   for (const entry of entries) {
     const { packages, summary } = parseChangeset(readAt(objectuiRoot, to, entry.sha, entry.path));
     const level = highestLevel(packages);
     if (!level) {
-      releaseNothing++;
+      releaseNothingEntries.push({ ...entry, summary: summary || entry.subject });
       continue;
     }
     releasing.push({
@@ -235,6 +255,38 @@ export function buildDigest({
   // order. The class the old filter could not represent at all now leads.
   const order = { major: 0, minor: 1, patch: 2 };
   releasing.sort((a, b) => order[a.level] - order[b.level]);
+
+  const noChangesetCommits = commits.filter((c) => !commitsWithChangesetShas.has(c.sha));
+
+  return {
+    releasing,
+    releaseNothingEntries,
+    noChangesetCommits,
+    releaseNothing: releaseNothingEntries.length,
+    noChangeset: noChangesetCommits.length,
+    changesetsAdded: entries.length,
+    totalCommits,
+  };
+}
+
+/**
+ * Build the digest for a range.
+ *
+ * @returns {{ bump: string, declaredLevel: string|null, breaking: number, releasing: Array<object>, releaseNothing: number, noChangeset: number, totalCommits: number, downgradedMajor: boolean, body: string }}
+ */
+export function buildDigest({
+  objectuiRoot,
+  frameworkRoot = REPO_ROOT,
+  from,
+  to,
+  max = DEFAULT_MAX_ENTRIES,
+  bumpOverride = '',
+}) {
+  const { releasing, releaseNothing, noChangeset, changesetsAdded, totalCommits } = classifyRange({
+    objectuiRoot,
+    from,
+    to,
+  });
 
   const declaredLevel = releasing.length
     ? releasing.reduce(
@@ -273,7 +325,6 @@ export function buildDigest({
     );
   }
 
-  const noChangeset = Math.max(0, totalCommits - commitsWithChangeset);
   const omitted = [];
   if (releaseNothing > 0) {
     omitted.push(
@@ -286,7 +337,7 @@ export function buildDigest({
 
   const accounting =
     `Derived from the changesets objectui declared over the range — ` +
-    `${releasing.length} releasing of ${entries.length} changeset${entries.length === 1 ? '' : 's'} added ` +
+    `${releasing.length} releasing of ${changesetsAdded} changeset${changesetsAdded === 1 ? '' : 's'} added ` +
     `across ${totalCommits} non-merge commit${totalCommits === 1 ? '' : 's'}` +
     (omitted.length ? `; omitted: ${omitted.join(', ')} (they ship no package code).` : '.');
 

--- a/scripts/objectui-range.mjs
+++ b/scripts/objectui-range.mjs
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+//
 // objectui-range — summarize the frontend (objectui) delta bundled between two
 // framework revisions, ready to paste into a release page's Console section.
 //
 // The platform is one version-locked train and the Console UI is frozen into
 // @objectstack/console at the objectui commit pinned in .objectui-sha. To learn
 // "what did the frontend change between platform version A and B", you diff the
-// pinned SHA at two framework revisions and read objectui's log for that range.
-// This script does exactly that — the aggregation layer described in
+// pinned SHA at two framework revisions and read what objectui DECLARED over
+// that range. This script does exactly that — the aggregation layer described in
 // docs/releases-maintenance.md.
 //
 // Usage:
@@ -16,18 +18,48 @@
 //   node scripts/objectui-range.mjs --from <objectui-sha> --to <objectui-sha>
 //       skip the framework lookup; use explicit objectui SHAs.
 //   … --json     emit structured JSON instead of markdown
-//   … --all      include every conventional-commit type (default: feat + fix)
+//   … --all      also itemize what ships nothing (release-nothing changesets and
+//                commits carrying no changeset), not just count them
+//   … --self-test  run the built-in assertions over throwaway git repos
 //
 // Env:
 //   OBJECTUI_ROOT=/path/to/objectui   (default: ../objectui, like bump-objectui.sh)
+//
+// WHAT COUNTS AS A FRONTEND CHANGE HERE (#4843)
+// ---------------------------------------------
+// The releasing entries come from `classifyRange()` in
+// scripts/objectui-changeset-digest.mjs — the SAME function `bump-objectui.sh`
+// uses to write the pin changeset (#4731). One criterion, two consumers: the
+// platform release record and this release-page section can no longer disagree
+// about which frontend changes shipped.
+//
+// This script used to guess instead, keeping only `feat` + `fix` subject lines
+// unless you passed `--all`. Measured on the real range
+// `7d9734d5e321..785b8a5d432c` (53 non-merge commits, objectui), that guess:
+//
+//   * DROPPED 13 commits that actually released, 6 of them BREAKING (`!`):
+//     `refactor(layout)!: delete PageNodeRenderer` and burn-ledger batches
+//     2/4/5/6/7 — plus `chore(deps): lockstep the @objectstack family onto
+//     17.0.0-rc.1`. Breaking changes were the single class structurally unable
+//     to appear, in the artifact that leads with breaking changes.
+//   * PULLED IN 5 commits that release nothing in objectui, two of them
+//     `fix(ci)` (one with no changeset at all, one whose changeset has an empty
+//     frontmatter — changesets' own spelling of "release-nothing").
+//
+// The output is a release page's body, so a reader cannot tell a filtered list
+// from a complete one. Hence: the accounting footer is UNCONDITIONAL — every
+// excluded item is counted out loud in the artifact itself, and `--all` names
+// them. Headings group by the level objectui declared; grouping is presentation
+// and must never become a filter again. Declaration over inference, per
+// AGENTS.md Prime Directive #12.
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
-import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { classifyRange, clampSummary } from './objectui-changeset-digest.mjs';
 
 const FRAMEWORK_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
-const OBJECTUI_ROOT =
-  process.env.OBJECTUI_ROOT || join(FRAMEWORK_ROOT, '..', 'objectui');
 
 const argv = process.argv.slice(2);
 const has = (f) => argv.includes(f);
@@ -40,11 +72,16 @@ const positional = argv.filter(
 );
 
 const JSON_OUT = has('--json');
-const ALL_TYPES = has('--all');
+const SHOW_EXCLUDED = has('--all');
 
 if (has('-h') || has('--help')) {
-  console.log(readFileSync(fileURLToPath(import.meta.url), 'utf8').split('\n')
-    .filter((l) => l.startsWith('//')).map((l) => l.slice(3)).join('\n'));
+  console.log(
+    readFileSync(fileURLToPath(import.meta.url), 'utf8')
+      .split('\n')
+      .filter((l) => l.startsWith('//'))
+      .map((l) => l.slice(3))
+      .join('\n'),
+  );
   process.exit(0);
 }
 
@@ -58,99 +95,383 @@ function git(cwd, args) {
 }
 
 // Resolve the objectui SHA pinned at a given framework rev (or the working tree).
-function pinAt(rev) {
+function pinAt(root, rev) {
   if (rev === undefined) {
-    const p = join(FRAMEWORK_ROOT, '.objectui-sha');
+    const p = join(root, '.objectui-sha');
     if (!existsSync(p)) die('.objectui-sha not found in the working tree');
     return readFileSync(p, 'utf8').trim();
   }
   try {
-    return git(FRAMEWORK_ROOT, ['show', `${rev}:.objectui-sha`]).trim();
+    return git(root, ['show', `${rev}:.objectui-sha`]).trim();
   } catch {
     return die(`cannot read .objectui-sha at framework rev '${rev}'`);
   }
 }
 
-let fromSha = val('--from');
-let toSha = val('--to');
-if (!fromSha || !toSha) {
-  if (positional.length < 1) {
-    die('need <old-rev> [new-rev], or --from <sha> --to <sha>. See --help/header.');
-  }
-  fromSha = pinAt(positional[0]);
-  toSha = pinAt(positional[1]); // undefined → working-tree pin
-}
-
-if (!existsSync(join(OBJECTUI_ROOT, '.git'))) {
-  die(
-    `no objectui checkout at ${OBJECTUI_ROOT}.\n` +
-      `  Clone it as a sibling, or set OBJECTUI_ROOT=/path/to/objectui.\n` +
-      `  Range to inspect once available: ${fromSha.slice(0, 12)}..${toSha.slice(0, 12)}`,
-  );
-}
-
-if (fromSha === toSha) {
-  console.log(`objectui unchanged (${fromSha.slice(0, 12)}) — no frontend delta in this range.`);
-  process.exit(0);
-}
-
-let rawLog;
-try {
-  rawLog = git(OBJECTUI_ROOT, [
-    'log', '--no-merges', '--format=%H%x09%s', `${fromSha}..${toSha}`,
-  ]);
-} catch {
-  die(
-    `cannot walk ${fromSha.slice(0, 12)}..${toSha.slice(0, 12)} in ${OBJECTUI_ROOT}.\n` +
-      `  Fetch it: git -C ${OBJECTUI_ROOT} fetch --all`,
-  );
-}
-
 const CC = /^(feat|fix|refactor|perf|docs|test|chore|build|ci|style|revert)(?:\(([^)]+)\))?(!)?:\s*(.+)$/;
-const KEEP = ALL_TYPES ? null : new Set(['feat', 'fix']);
 
-const commits = [];
-for (const line of rawLog.split('\n').filter(Boolean)) {
-  const tab = line.indexOf('\t');
-  const sha = line.slice(0, tab);
-  const subject = line.slice(tab + 1);
+/** Conventional-commit scope, when the subject has one. PRESENTATION ONLY. */
+function scopeOf(subject) {
   const m = subject.match(CC);
-  const type = m ? m[1] : 'other';
-  const scope = m ? m[2] || '' : '';
-  const desc = m ? m[4] : subject;
-  if (KEEP && !KEEP.has(type)) continue;
-  commits.push({ sha, type, scope, desc, subject });
+  return m ? m[2] || '' : '';
 }
 
-// Top touched areas (by scope) across the kept commits — the "big picture" line.
-const areaCounts = {};
-for (const c of commits) if (c.scope) areaCounts[c.scope] = (areaCounts[c.scope] || 0) + 1;
-const topAreas = Object.entries(areaCounts).sort((a, b) => b[1] - a[1]).slice(0, 10);
+/** Declared level → the release-page heading it belongs under. */
+const SECTIONS = [
+  ['major', 'Breaking changes'],
+  ['minor', 'Features'],
+  ['patch', 'Fixes'],
+];
 
-const byType = { feat: [], fix: [] };
-for (const c of commits) (byType[c.type] || (byType[c.type] = [])).push(c);
+/**
+ * Render the Console section for a classified range.
+ *
+ * Every count that could hide something is in the returned markdown, always —
+ * including the zeros. A footer that only appears when something was dropped
+ * still leaves the reader unable to tell "nothing dropped" from "footer not
+ * implemented".
+ */
+export function renderRange({ fromSha, toSha, classified, showExcluded = false }) {
+  const { releasing, releaseNothingEntries, noChangesetCommits, changesetsAdded, totalCommits } =
+    classified;
 
-if (JSON_OUT) {
-  console.log(JSON.stringify(
-    { from: fromSha, to: toSha, count: commits.length, topAreas, commits }, null, 2,
-  ));
-  process.exit(0);
+  const areaCounts = {};
+  for (const r of releasing) {
+    const scope = scopeOf(r.subject);
+    if (scope) areaCounts[scope] = (areaCounts[scope] || 0) + 1;
+  }
+  const topAreas = Object.entries(areaCounts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10);
+
+  const line = (r) => {
+    const scope = scopeOf(r.subject) || r.packages[0] || '';
+    return `- ${scope ? `**${scope}** — ` : ''}${clampSummary(r.summary)} (objectui \`${r.sha.slice(0, 9)}\`)`;
+  };
+
+  const out = [];
+  out.push(
+    `<!-- objectui ${fromSha.slice(0, 12)}..${toSha.slice(0, 12)} — ` +
+      `${releasing.length} releasing changeset(s) of ${changesetsAdded} added ` +
+      `across ${totalCommits} non-merge commit(s) -->`,
+  );
+  if (topAreas.length) {
+    out.push('', `_Largest areas: ${topAreas.map(([a, n]) => `${a} (${n})`).join(', ')}_`);
+  }
+
+  for (const [level, heading] of SECTIONS) {
+    const group = releasing.filter((r) => r.level === level);
+    if (group.length) out.push('', `### ${heading}`, ...group.map(line));
+  }
+
+  if (!releasing.length) {
+    out.push(
+      '',
+      '_No releasing changeset in this range — every objectui commit here ships nothing._',
+    );
+  }
+
+  // --- the accounting. UNCONDITIONAL: a release page reader cannot otherwise
+  // tell a filtered list from a complete one (#4843 / #3340). ---
+  const excluded = [
+    `${releaseNothingEntries.length} release-nothing changeset${releaseNothingEntries.length === 1 ? '' : 's'}`,
+    `${noChangesetCommits.length} commit${noChangesetCommits.length === 1 ? '' : 's'} carrying no changeset`,
+  ];
+  out.push(
+    '',
+    `_Derived from the changesets objectui declared over this range — ` +
+      `${releasing.length} releasing of ${changesetsAdded} added across ${totalCommits} non-merge commit(s). ` +
+      `Excluded as shipping no package code: ${excluded.join(', ')}` +
+      `${showExcluded ? '' : ' (run with `--all` to list them)'}._`,
+  );
+
+  if (showExcluded) {
+    const rows = [
+      ...releaseNothingEntries.map(
+        (e) => `- _(release-nothing)_ ${e.subject} (objectui \`${e.sha.slice(0, 9)}\`)`,
+      ),
+      ...noChangesetCommits.map(
+        (c) => `- _(no changeset)_ ${c.subject} (objectui \`${c.sha.slice(0, 9)}\`)`,
+      ),
+    ];
+    out.push('', '### Excluded — ships no package code');
+    out.push(...(rows.length ? rows : ['- _(nothing excluded in this range)_']));
+  }
+
+  return { markdown: out.join('\n'), topAreas };
 }
 
-const line = (c) => `- ${c.scope ? `**${c.scope}** — ` : ''}${c.desc}`;
-const out = [];
-out.push(`<!-- objectui ${fromSha.slice(0, 12)}..${toSha.slice(0, 12)} — ${commits.length} commit(s) -->`);
-if (topAreas.length) {
-  out.push('', `_Largest areas: ${topAreas.map(([a, n]) => `${a} (${n})`).join(', ')}_`);
-}
-if (byType.feat?.length) {
-  out.push('', '### Features', ...byType.feat.map(line));
-}
-if (byType.fix?.length) {
-  out.push('', '### Fixes', ...byType.fix.map(line));
-}
-const extra = Object.keys(byType).filter((t) => t !== 'feat' && t !== 'fix' && byType[t].length);
-for (const t of extra) out.push('', `### ${t}`, ...byType[t].map(line));
-if (commits.length === 0) out.push('', '_No feat/fix commits in range (try --all)._');
+function main() {
+  let fromSha = val('--from');
+  let toSha = val('--to');
+  if (!fromSha || !toSha) {
+    if (positional.length < 1) {
+      die('need <old-rev> [new-rev], or --from <sha> --to <sha>. See --help/header.');
+    }
+    fromSha = pinAt(FRAMEWORK_ROOT, positional[0]);
+    toSha = pinAt(FRAMEWORK_ROOT, positional[1]); // undefined → working-tree pin
+  }
 
-console.log(out.join('\n'));
+  const objectuiRoot = process.env.OBJECTUI_ROOT || join(FRAMEWORK_ROOT, '..', 'objectui');
+
+  if (!existsSync(join(objectuiRoot, '.git'))) {
+    die(
+      `no objectui checkout at ${objectuiRoot}.\n` +
+        `  Clone it as a sibling, or set OBJECTUI_ROOT=/path/to/objectui.\n` +
+        `  Range to inspect once available: ${fromSha.slice(0, 12)}..${toSha.slice(0, 12)}`,
+    );
+  }
+
+  if (fromSha === toSha) {
+    console.log(
+      `objectui unchanged (${fromSha.slice(0, 12)}) — no frontend delta in this range.`,
+    );
+    return 0;
+  }
+
+  let classified;
+  try {
+    classified = classifyRange({ objectuiRoot, from: fromSha, to: toSha });
+  } catch {
+    die(
+      `cannot walk ${fromSha.slice(0, 12)}..${toSha.slice(0, 12)} in ${objectuiRoot}.\n` +
+        `  Fetch it: git -C ${objectuiRoot} fetch --all`,
+    );
+  }
+
+  const { markdown, topAreas } = renderRange({
+    fromSha,
+    toSha,
+    classified,
+    showExcluded: SHOW_EXCLUDED,
+  });
+
+  if (JSON_OUT) {
+    console.log(
+      JSON.stringify(
+        {
+          from: fromSha,
+          to: toSha,
+          criterion: 'declared-changeset',
+          count: classified.releasing.length,
+          totalCommits: classified.totalCommits,
+          changesetsAdded: classified.changesetsAdded,
+          releaseNothing: classified.releaseNothing,
+          noChangeset: classified.noChangeset,
+          topAreas,
+          releasing: classified.releasing,
+          releaseNothingEntries: classified.releaseNothingEntries,
+          noChangesetCommits: classified.noChangesetCommits,
+        },
+        null,
+        2,
+      ),
+    );
+    return 0;
+  }
+
+  console.log(markdown);
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Self-test (#4843) — the repo idiom for a `scripts/` gate: build a throwaway
+// git repo carrying the exact shapes measured on the real range, run the real
+// code over it, assert the ARTIFACT (the markdown a maintainer pastes).
+// ---------------------------------------------------------------------------
+
+function selfTest() {
+  const failures = [];
+  const check = (name, cond, detail = '') => {
+    if (cond) {
+      console.log(`  ✓ ${name}`);
+    } else {
+      failures.push(`${name}${detail ? ` — ${detail}` : ''}`);
+      console.log(`  ✗ ${name}${detail ? ` — ${detail}` : ''}`);
+    }
+  };
+
+  const tmp = mkdtempSync(join(tmpdir(), 'objectui-range-selftest-'));
+  try {
+    const ui = join(tmp, 'objectui');
+    mkdirSync(join(ui, '.changeset'), { recursive: true });
+    const g = (...args) => git(ui, args);
+    g('init', '-q', '-b', 'main');
+    g('config', 'user.email', 'selftest@objectstack.ai');
+    g('config', 'user.name', 'self test');
+    g('config', 'commit.gpgsign', 'false');
+
+    const commit = (subject, files) => {
+      for (const [path, content] of Object.entries(files)) {
+        mkdirSync(dirname(join(ui, path)), { recursive: true });
+        writeFileSync(join(ui, path), content);
+      }
+      g('add', '-A');
+      g('commit', '-q', '-m', subject);
+      return g('rev-parse', 'HEAD').trim();
+    };
+
+    const base = commit('chore: base', { 'README.md': 'base\n' });
+
+    // The five shapes measured on 7d9734d5e321..785b8a5d432c.
+    // 1. an ordinary releasing `feat` — the only shape the old filter got right
+    commit('feat(grid): aggregate single-call mode for bulk actions (#3201)', {
+      '.changeset/bulk-action-aggregate.md':
+        '---\n"@object-ui/plugin-grid": minor\n---\n\nGrid bulk actions gain an aggregate single-call mode.\n',
+      'src/grid.ts': 'a\n',
+    });
+    // 2. a BREAKING `refactor(...)!` — structurally invisible to a feat|fix filter
+    const breakingSha = commit(
+      'refactor(layout)!: delete PageNodeRenderer, the unregistered page-node renderer (#3225)',
+      {
+        '.changeset/remove-dead-layout-page-node-renderer.md':
+          '---\n"@object-ui/layout": major\n---\n\nRemove `PageNodeRenderer`, the dead page-node renderer (objectui#3223).\n',
+        'src/layout.ts': 'b\n',
+      },
+    );
+    // 3. a releasing `chore(deps)` — also invisible to a feat|fix filter
+    commit('chore(deps): lockstep the @objectstack family onto 17.0.0-rc.1 (#3189)', {
+      '.changeset/objectstack-family-rc1-lockstep.md':
+        '---\n"@object-ui/app-shell": minor\n"@object-ui/core": minor\n---\n\nBring the whole `@objectstack` family to `17.0.0-rc.1`.\n',
+      'package.json': '{}\n',
+    });
+    // 4. matches `fix` on the subject, declares release-nothing (empty frontmatter)
+    commit('fix(ci): hand the cross-repo token to github-script (#3186)', {
+      '.changeset/fix-cross-repo-closer-require.md':
+        '---\n---\n\nfix(ci): hand the cross-repo token to github-script\n\nRelease-nothing: touches a workflow only.\n',
+      '.github/workflows/x.yml': 'on: push\n',
+    });
+    // 5. matches `fix` on the subject, carries no changeset at all
+    commit('fix(ci): never render a budget FAIL for a run that measured nothing (#3198)', {
+      '.github/workflows/y.yml': 'on: push\n',
+    });
+    const head = g('rev-parse', 'HEAD').trim();
+
+    console.log('objectui-range --self-test');
+
+    const classified = classifyRange({ objectuiRoot: ui, from: base, to: head });
+    const { markdown } = renderRange({ fromSha: base, toSha: head, classified });
+
+    // --- the class that went missing: it must be IN the artifact, and lead ---
+    check(
+      'a BREAKING `refactor(...)!` commit IS in the pasteable list',
+      markdown.includes('PageNodeRenderer') && markdown.includes(breakingSha.slice(0, 9)),
+      markdown,
+    );
+    check(
+      'breaking changes get their own leading section (declared major)',
+      markdown.indexOf('### Breaking changes') > -1 &&
+        markdown.indexOf('### Breaking changes') < markdown.indexOf('### Features'),
+      markdown,
+    );
+    check(
+      'a releasing non-feat/fix `chore(deps)` commit IS in the list',
+      markdown.includes('Bring the whole'),
+      markdown,
+    );
+    check(
+      'commit type never filters: all 3 releasing changesets are listed',
+      classified.releasing.length === 3,
+      `got ${classified.releasing.length}`,
+    );
+
+    // --- what ships nothing is excluded, and SAYS SO in the artifact ---
+    check(
+      'a `fix(ci)` with an EMPTY frontmatter changeset is NOT listed',
+      !markdown.includes('cross-repo token'),
+      markdown,
+    );
+    check(
+      'a `fix(ci)` with no changeset at all is NOT listed',
+      !markdown.includes('budget FAIL'),
+      markdown,
+    );
+    check(
+      'the release-nothing count is spoken IN THE MARKDOWN, not just in JSON',
+      classified.releaseNothing === 1 && markdown.includes('1 release-nothing changeset'),
+      markdown,
+    );
+    check(
+      'the no-changeset commit count is spoken IN THE MARKDOWN',
+      classified.noChangeset === 1 && markdown.includes('1 commit carrying no changeset'),
+      markdown,
+    );
+    check(
+      'the accounting footer is unconditional and states the totals',
+      markdown.includes('3 releasing of 4 added across 5 non-merge commit(s)'),
+      markdown,
+    );
+
+    // --- a range that excludes NOTHING still says so (zeros are load-bearing) ---
+    const clean = renderRange({
+      fromSha: base,
+      toSha: head,
+      classified: {
+        ...classified,
+        releaseNothingEntries: [],
+        noChangesetCommits: [],
+        releaseNothing: 0,
+        noChangeset: 0,
+      },
+    });
+    check(
+      'a range excluding nothing STILL prints the accounting (0, not silence)',
+      clean.markdown.includes('0 release-nothing changesets') &&
+        clean.markdown.includes('0 commits carrying no changeset'),
+      clean.markdown,
+    );
+
+    // --- `--all` names the excluded entries instead of only counting them ---
+    const all = renderRange({ fromSha: base, toSha: head, classified, showExcluded: true });
+    check(
+      '`--all` itemizes the excluded commits by subject',
+      all.markdown.includes('### Excluded — ships no package code') &&
+        all.markdown.includes('cross-repo token') &&
+        all.markdown.includes('budget FAIL'),
+      all.markdown,
+    );
+
+    // --- end-to-end through the real CLI ------------------------------------
+    const cli = fileURLToPath(import.meta.url);
+    const run = (args) =>
+      execFileSync('node', [cli, ...args], {
+        encoding: 'utf8',
+        env: { ...process.env, OBJECTUI_ROOT: ui },
+      });
+    const cliMd = run(['--from', base, '--to', head]);
+    check(
+      'the CLI markdown carries the breaking entry and not the ci noise',
+      cliMd.includes('PageNodeRenderer') && !cliMd.includes('cross-repo token'),
+      cliMd,
+    );
+    const cliJson = JSON.parse(run(['--from', base, '--to', head, '--json']));
+    check(
+      'the CLI JSON reports the declared criterion and the excluded counts',
+      cliJson.criterion === 'declared-changeset' &&
+        cliJson.count === 3 &&
+        cliJson.releaseNothing === 1 &&
+        cliJson.noChangeset === 1,
+      JSON.stringify(cliJson).slice(0, 200),
+    );
+    check(
+      'every listed entry carries the level objectui declared',
+      cliJson.releasing.every((r) => ['major', 'minor', 'patch'].includes(r.level)) &&
+        cliJson.releasing.filter((r) => r.level === 'major').length === 1,
+      JSON.stringify(cliJson.releasing.map((r) => r.level)),
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+
+  if (failures.length) {
+    console.error(`\n⛔ objectui-range --self-test: ${failures.length} failure(s)`);
+    for (const f of failures) console.error(`   - ${f}`);
+    return 1;
+  }
+  console.log('✓ objectui-range --self-test: all checks passed');
+  return 0;
+}
+
+if (resolve(process.argv[1] ?? '') === resolve(fileURLToPath(import.meta.url))) {
+  process.exit(has('--self-test') ? selfTest() : main());
+}


### PR DESCRIPTION
Fixes #4843

## 问题

`scripts/objectui-range.mjs` 的产物是**发布页 Console 段落的正文**。它一直沿用 #4731 已经从 `bump-objectui.sh` 里拆掉的那套猜测:

```js
const KEEP = ALL_TYPES ? null : new Set(['feat', 'fix']);
```

比 #4731 轻的地方:过滤在 `--help` 里写明了,也有 `--all`。重的地方:读者拿到的是一份**看不出被过滤过的 markdown** —— 尾部没有任何「另有 N 条被排除」的说明,而 `--all` 不是默认。

## 实测(真实 objectui 检出,非构造)

区间 `7d9734d5e321..785b8a5d432c`,53 个非 merge 提交。跑新旧两套逻辑做集合差:

| | 条数 |
|:---|---:|
| 真正发版、但被类型过滤**丢掉** | **13** |
| 其中带 `!` 的破坏性变更 | **6** |
| 在 objectui 侧 release-nothing、却被类型过滤**误收** | **5** |

丢掉的 13 条里包括 `refactor(layout)!: delete PageNodeRenderer`、burn ledger batch 2/4/5/6/7,以及 `chore(deps): lockstep the @objectstack family onto 17.0.0-rc.1`。误收的 5 条里有两条 `fix(ci)`(一条完全没有 changeset,一条 changeset 的 frontmatter 是空的)。

**这三个数字与议题正文完全一致 —— 我用真实检出复核过,没有偏差。**

破坏性变更是唯一被类型过滤**结构性**挡在门外的一类,而它出现在一份「以破坏性变更打头」的产物里。

## 改动

### 1. 两处收敛到同一个判据,而不是各写一份

判据抽成 `scripts/objectui-changeset-digest.mjs` 导出的 `classifyRange()`,`buildDigest()`(即 `bump-objectui.sh` 走的路径)和 `objectui-range.mjs` 都走它。复制一份平行实现两边必然漂,而第一个漂掉的就是已经掉过一次的那一类。

复用的既有导出:`collectAddedChangesets()` / `parseChangeset()` / `highestLevel()` / `clampSummary()`。对公开面只做了两处小幅扩展,没有新写平行逻辑:

- `collectAddedChangesets()` 多返回 `commits`(区间内全部非 merge 提交)和 `commitsWithChangesetShas`,这样调用方能**点名**被排除的提交,而不只是数出来;
- 新增 `classifyRange()`,把原先内嵌在 `buildDigest()` 里的分类循环提出来 —— `buildDigest()` 的返回字段和行为一字未改,它自己的 `--self-test` 20 条断言全绿即为证。

### 2. 排除必须出声

产物是发布页正文,所以**账目是无条件打印的**,零也打印:

```
_Derived from the changesets objectui declared over this range — 44 releasing of 48
added across 53 non-merge commit(s). Excluded as shipping no package code:
4 release-nothing changesets, 7 commits carrying no changeset (run with `--all` to list them)._
```

只在「有东西被丢掉时」才出现的脚注,仍然让读者分不清「没丢东西」和「脚注没实现」。

`--all` 语义随之改变:过滤已经不存在了,所以它从「包含所有 commit 类型」变成「**逐条点名**被排除的条目」(release-nothing 的 changeset + 无 changeset 的提交),`--help` 里写明。

### 3. 分组是呈现,不是筛选

标题按 objectui **声明的级别**分组(Breaking changes / Features / Fixes),正好对上发布页的结构(破坏性 → 迁移,minor → 新能力,patch → 修复)。没有任何一处再读 commit 类型来决定收不收 —— commit 的 scope 只用来生成 `_Largest areas_` 那一行和条目前缀,纯呈现。

## 验证

### `--self-test`(按 `scripts/` 既有惯例,折进已有的 `pnpm check:objectui-changeset`)

构造一次性 git 仓库复刻实测到的五种形态,跑真实代码,断言**产物**:

```
objectui-range --self-test
  ✓ a BREAKING `refactor(...)!` commit IS in the pasteable list
  ✓ breaking changes get their own leading section (declared major)
  ✓ a releasing non-feat/fix `chore(deps)` commit IS in the list
  ✓ commit type never filters: all 3 releasing changesets are listed
  ✓ a `fix(ci)` with an EMPTY frontmatter changeset is NOT listed
  ✓ a `fix(ci)` with no changeset at all is NOT listed
  ✓ the release-nothing count is spoken IN THE MARKDOWN, not just in JSON
  ✓ the no-changeset commit count is spoken IN THE MARKDOWN
  ✓ the accounting footer is unconditional and states the totals
  ✓ a range excluding nothing STILL prints the accounting (0, not silence)
  ✓ `--all` itemizes the excluded commits by subject
  ✓ the CLI markdown carries the breaking entry and not the ci noise
  ✓ the CLI JSON reports the declared criterion and the excluded counts
  ✓ every listed entry carries the level objectui declared
✓ objectui-range --self-test: all checks passed
```

`objectui-changeset-digest --self-test` 的 20 条断言同样全绿(重构未改行为)。

### 反向验证 —— 证明这些用例是有承重的

把**同一份**构造 fixture 喂给 `origin/main` 上改动前的 `objectui-range.mjs`,再用新用例的断言去评它。改动前的产物长这样:

```
（下面第一行本是一条 HTML 注释,GitHub 正文会把它整行吞掉,这里去掉尖括号写出)
!-- objectui 5b86f5727c8e..3d662d017506 — 3 commit(s) --

_Largest areas: ci (2), grid (1)_

### Features
- **grid** — aggregate single-call mode for bulk actions (#3201)

### Fixes
- **ci** — never render a budget FAIL for a run that measured nothing (#3198)
- **ci** — hand the cross-repo token to github-script (#3186)
```

失效模式在这几行里一览无余:破坏性的 `refactor(layout)!` 不见了,列出来的两条 `fix(ci)` 恰恰是 objectui 侧什么都不发版的两条,计数写的是「3 commit(s)」而真实区间有 5 条,而且没有任何一处提示这份清单被过滤过。

断言评估结果:

```
  ✗ FAILS (load-bearing) — a BREAKING `refactor(...)!` commit IS in the pasteable list
  ✗ FAILS (load-bearing) — breaking changes get their own leading section
  ✗ FAILS (load-bearing) — a releasing non-feat/fix `chore(deps)` commit IS in the list
  ✗ FAILS (load-bearing) — a `fix(ci)` with an EMPTY frontmatter changeset is NOT listed
  ✗ FAILS (load-bearing) — a `fix(ci)` with no changeset at all is NOT listed
  ✗ FAILS (load-bearing) — the release-nothing count is spoken IN THE MARKDOWN
  ✗ FAILS (load-bearing) — the no-changeset commit count is spoken IN THE MARKDOWN
  ✗ FAILS (load-bearing) — the accounting footer is unconditional and states the totals

=> 8 of 8 new assertions FAIL against the pre-change script (0 would mean the tests assert nothing).
```

8/8 全部失败 —— 用例确实压在改动上,不是一组什么都断言不到的绿灯。

### 其他

- `npx eslint scripts/objectui-range.mjs scripts/objectui-changeset-digest.mjs --no-inline-config` → exit 0
- `pnpm check:objectui-changeset` → exit 0(两个 self-test 串起来)
- 在真实检出上跑了 `--json` / `--all` / `--help` / 无 objectui 检出的降级路径

## ⚠️ 需要排队的共享文件

本 PR 动了两个本仓最热的合并冲突点,已尽量压到最小:

- `package.json` —— **改了 1 行既有的**(`check:objectui-changeset` 后面串上第二个 self-test),没有新增 script key;
- `.github/workflows/lint.yml` —— **只加了 3 行注释**,step 名和 `run:` 都没动。

请据此安排合并顺序。

## 与议题描述的出入

无。议题正文的三个数字(丢 13 / 其中 6 条带 `!` / 误收 5 条含两条 `fix(ci)`)我在真实 objectui 检出上逐条复核过,全部吻合。

一处议题没提、实测才看到的事实值得记一笔:被排除的 7 条「无 changeset」提交里,有两条**确实改了已发布包的源码** —— `fix(charts): name the slices`(动了 `packages/plugin-charts/src/`、`packages/plugin-dashboard/src/`)和 `fix(i18n): resolve qualified view ids`(动了 `packages/i18n/src/`)。旧口径碰巧收了它们,但那是因为 subject 以 `fix` 开头,和是否发版无关;真正的洞在 objectui 侧没有「改了包源码就必须带 changeset」的门禁,以致这两条在 objectui 自己的 CHANGELOG 里也查不到。本 PR 之后它们至少不再无声(计数 + `--all` 点名),但出声不等于修好 —— 已按 Prime Directive #10 另立 **#4904**(未认领),未在本 PR 内扩范围。

## 关联

- #4731 / PR #4842 —— 同一失效模式的 `bump-objectui.sh` 侧,本 PR 复用其导出
- #3340 —— 两者共同要防的洞
- #4904 —— 本 PR 实测中发现的上游缺口(另立,未认领)
