### PR TITLE
docs(skills): formula §5 绑定作用域表补上「condition 求不出值 = 该次写入失败」(#4814)

### DIFF
--- a/.changeset/skill-formula-condition-abort-scope.md
+++ b/.changeset/skill-formula-condition-abort-scope.md
@@ -1,0 +1,41 @@
+---
+---
+
+Docs-only: the `objectstack-formula` skill's `previous` binding-scope table
+never said what an unevaluable hook `condition` now costs (#4814).
+
+§5 ("Update hook condition — `previous` vs `record`") is where an AI author is
+taught to write `previous.x != record.x`, and the mechanical translation table
+sends `OLD.x` / `ISCHANGED(x)` to the same place. The table listed exactly where
+`previous` is **unbound** — insert events, and `multi: true` predicate bulk
+updates — and then closed with "referencing `previous` where it is unbound makes
+the whole expression unevaluable", which was the pre-17 outcome: a `logger.warn`
+and a hook that did not fire.
+
+#4775 changed that outcome: an unevaluable condition **aborts the operation**,
+`before*` and `after*` in the same direction, with an error naming the hook and
+the key. So the table's own rows changed meaning — "this quietly disables your
+hook" became "this fails your write" — without a word of the table changing.
+That is the drift this fixes: the surface teaching the idiom was the one surface
+still describing the old consequence.
+
+Adds, in §5:
+
+- the #4775 rule, with the reason the two outcomes had to split (a `before*`
+  guard swallowed into `false` let writes through; an audit hook swallowed into
+  `false` dropped records — opposite failures out of one collapsed result), and
+  the note that `onError` is not an escape from it (it governs a handler that
+  throws; the condition is evaluated before any handler runs);
+- the `multi: true` cell in full (#4800/B1): one hook condition reading
+  `previous.*` fails *every* predicate bulk update of that object, fail-loud
+  takes no exception, and the error is a diagnosis — it names the batch, says
+  the N matched rows have no single prior record, and gives the two real ways
+  out (drop `previous`, or write by id). A record-change flow trigger is
+  explicitly **not** one of them: it binds the same lifecycle hook and gets the
+  same unbound `previous`. `record` is the bare payload on that path too, so a
+  declared field this write does not set is unevaluable as well.
+
+Plus a pointer under the legacy → CEL table, since `OLD.x` / `ISCHANGED(x)` are
+how a migrating author arrives at `previous.x` in the first place.
+
+Releases nothing.

--- a/skills/objectstack-formula/SKILL.md
+++ b/skills/objectstack-formula/SKILL.md
@@ -308,11 +308,36 @@ roots (#4784) — one scope, one meaning, whichever surface reads it.
 |:---|:---|
 | Update hook `condition` (single-record write), validation rule on update | the stored pre-write row |
 | Insert events (`beforeInsert` / `afterInsert`), validation rule on insert | **unbound** — there is no prior state |
-| Predicate bulk update (`multi: true`) hook `condition` | **unbound** — one write matches N rows and the hook fires once, so there is no single prior record |
+| Predicate bulk update (`multi: true`) hook `condition` | **unbound** — one write matches N rows and the hook fires once, so there is no single prior record. `record` is the bare payload here too, so a *declared* field this write does not set is unevaluable as well |
 
-Referencing `previous` where it is unbound makes the whole expression
-unevaluable — so write insert-event conditions over `record` alone, and keep
-transition conditions to single-record writes.
+⚠️ **An unevaluable condition ABORTS the operation (#4775).** Referencing
+`previous` where it is unbound — like a typo'd key (`record.stauts`), a retired
+field, or a comparison CEL has no overload for — does **not** degrade to "the
+hook did not fire": it **fails the write**, with an error naming the hook and
+the key. Until protocol 17 the gate emitted a `logger.warn` and returned
+`false`, which is what makes this table load-bearing rather than stylistic: a
+`before*` guard swallowed into `false` silently let writes through, and an audit
+hook swallowed into `false` silently dropped records. Those are opposite
+failures, so "the condition said no" and "the platform could not work out what
+the condition says" are now different outcomes and the second one is loud —
+`before*` and `after*` in the same direction, with no `onError` escape
+(`onError` governs a handler that throws, and the condition is evaluated before
+any handler runs). A condition that does not even **compile** aborts the same
+way.
+
+So write insert-event conditions over `record` alone, and keep transition
+conditions to single-record writes — that mistake used to cost you a hook that
+quietly never ran, and now costs you every write the hook is attached to.
+
+**On a `multi: true` bulk update the cost lands on every batch (#4800/B1).**
+One hook condition reading `previous.*` makes *every* predicate bulk update of
+that object fail, and the failure names a hook that has nothing to do with the
+write. Fail-loud takes no exception here, but the error is a diagnosis rather
+than a raw `No such key: previous`: it says this is a predicate bulk write, that
+the N matched rows have no single prior record to bind, and gives the two ways
+out — rewrite the condition without `previous`, or target the write at one
+record (update by id). A record-change flow trigger is **not** a way around it:
+it binds the same lifecycle hook and receives the same unbound `previous`.
 
 **`previous` is total over the object's declared fields.** A declared column the
 driver never returned reads as `null`, not as a fault. Guard with `!= null`,
@@ -348,6 +373,11 @@ When migrating Salesforce-flavor metadata, apply these rules in order:
 | `IN (a, b, c)` | `in [a, b, c]` |
 | `ISCHANGED(x)` | `previous.x != record.x` |
 | `MONTH_DIFF`, `MID`, `LEFT`, `RIGHT`, `SUBSTITUTE` | _not in stdlib — propose addition_ |
+
+> ⚠️ `OLD.x` and `ISCHANGED(x)` both land on `previous.x`, which exists only
+> where `previous` is **bound** — see §5. On an insert event, or on a
+> `multi: true` predicate bulk update, it is not; since #4775 that does not
+> quietly skip the hook, it **fails the write**.
 
 ---
 


### PR DESCRIPTION
Fixes #4814

`skills/objectstack-formula/SKILL.md` §5 的 `previous` 绑定作用域表,把「在哪儿不绑定」列得很齐,然后用一句 **pre-17 的后果**收尾:

> Referencing `previous` where it is unbound makes the whole expression unevaluable — so write insert-event conditions over `record` alone …

#4775 合入之后这句话所描述的世界已经不存在了:求不出值不再是 warn + hook 不触发,而是**抛错并中断该次写入**。也就是说,**表里每一行的含义都变了,而表一个字没动** —— 正是本单要修的漂移。

## 补了哪两格

**1. fail loud 的后果(#4775)** —— 紧跟表格加了一条 ⚠️ 说明:求不出值(拼错的 key、已退役字段、CEL 没有重载的比较、以及在不绑定处引用 `previous`)**不会**降级成「这条 hook 没触发」,而是**让这次写入失败**,错误点名 hook 与 key;`before*` 与 `after*` **同一方向**;`onError` 不是逃生口(它管的是 handler 抛错,而 condition 求值发生在任何 handler 之前);编译不过的 condition 同样中断。并保留了「为什么两种结果必须分开」的理由 —— guard 被吞成 `false` 会放行本该被拦的写入,审计 hook 被吞成 `false` 会漏记,这是一个结果压住的两种**相反**失败。

**2. #4800/B1 那一格** —— 表里 `multi: true` 那一行补全:批量路径上 `record` 也只是**裸 payload**,所以这次写入没设置的**已声明**字段同样求不出值。表下另起一段写清代价:某对象上只要有一条引用 `previous.*` 的 hook 条件,该对象的**每一次**批量更新都会失败,且失败点名一个与这次写入无关的 hook;fail loud 在这里**不开例外**,但错误是**专门诊断**而不是裸 `No such key: previous`(点名这是 predicate 批量写、说明 N 行没有单一前置记录、给出两条出路:去掉 `previous`,或按 id 单记录写入);并明确写出 **record-change flow trigger 不是出路** —— 它绑的是同一批生命周期 hook,拿到的是同样未绑定的 `previous`。

**3. 顺带一处指路** —— legacy → CEL 机械翻译表下加了一条 blockquote:`OLD.x` / `ISCHANGED(x)` 都落到 `previous.x`,而 `previous` 只在绑定处存在(见 §5),insert 事件与 `multi: true` 批量上不绑定、#4775 之后是**写入失败**。理由见下。

## 表的实际结构与议题描述不一致(如实报告)

议题正文把它写成「§5 的 `ISCHANGED(x)` → `previous.x != record.x` 迁移表」,像是一张表。实际文件里是**两张表、两个不同章节**:

| 位置 | 内容 |
|:--|:--|
| `## Mandatory patterns for AI emission` → `### 5. Update hook condition — previous vs record`(约 288–330 行) | **绑定作用域表**(`previous` 在哪儿绑定/不绑定,三行),以及紧随其后的那句后果说明 |
| `## Mechanical translation table (legacy → CEL)`(约 355 行起,独立顶层章节) | `OLD.x` → `previous.x`、`ISCHANGED(x)` → `previous.x != record.x` 的**迁移表** |

所以两格补在 §5 的绑定作用域表(那才是讲后果的地方),而迁移表那边只加一条指向 §5 的 blockquote —— 迁移表恰恰是读者**到达** `previous.x` 的入口,只改 §5 会漏掉从迁移表照抄下来的那条路径。#4861 的复核评论也明确要求「表格那一行**与紧随其后那句话**的口径都要改」,已照此办理。

## 措辞来源

⚠️ **#4775 的已合并 PR(#4861)描述里没有现成的那段 SKILL.md 文字。** 它写的是「`skills/objectstack-formula/SKILL.md` §5 该补的那一行已写进给 PM 的报告,由 #4814 在对侧车道补上」—— 那份报告不在任何 PR/issue 正文或评论里,#4775 的九条评论与 #4861 的评论都没有它。**没有编造一段冒充原文**,措辞取自三个可核对的来源:

1. **已合入的同族 skill 文本(主要来源)** —— `skills/objectstack-data/references/data-hooks.md` 的 #4775 callout(由 PR #4883 落地),本次直接沿用它的句式与论证("does not degrade to…it fails the write"、两种相反失败的解释、"opposite failures"、practical consequence 一段)。这是仓内已发布的 skill 面对同一条规则的既有口径,两处 skill 用同一套话正是本单要保的东西。
2. **实现本身(诊断文案与语义)** —— `packages/objectql/src/hook-wrappers.ts` 的 `unevaluableConditionError` / `uncompilableConditionError`(B1 分支的原话:predicate bulk write / 无单一前置记录 / 两条出路 / flow trigger 不是出路),以及 `cel-fault.ts` 与 validation 谓词共用错误形状这一事实。
3. **PR #4861 正文**(方案 B 的裁定口径:`before*`/`after*` 同一方向、不接 `onError`、编译不过同样阻断)与 #4800/B1 的拍板评论。

即:文档措辞与实现文案同源,而不是我自己重述一遍。

## 验证

| 命令 | 结果 |
|:--|:--|
| `node scripts/check-doc-authoring.mjs` | `✓ doc authoring guard: 215 files clean` |
| `node scripts/check-role-word.mjs` | `OK (43 baselined file(s), no new occurrences)` |
| `node scripts/check-nul-bytes.mjs` | `OK (2985 tracked source file(s), no raw NUL bytes)` |
| `pnpm --filter @objectstack/spec check:skill-docs` | `✅ Skill docs in sync` |
| `pnpm --filter @objectstack/spec check:skill-refs` | `✅ 9 generated files in sync with packages/spec` |
| `pnpm --filter @objectstack/spec check:skill-examples` | `✅ 201 prose examples type-check against @objectstack/spec` |
| `pnpm --filter @objectstack/spec check:generated` | `✓ All 8 generated artifacts are up to date.` |

无需重新生成任何产物(本次只改 SKILL.md 正文,未动 frontmatter,`gen:skill-docs` / `gen:skill-refs` 均已在同步状态)。

## 范围

改动仅 `skills/objectstack-formula/SKILL.md` + 一个 changeset,共 35 行新增 / 5 行删除。**`content/docs/releases/` 一个字未碰**;未动 `packages/**`、`content/docs/**`、其他 skill。changeset 用**空 frontmatter**(先例:`.changeset/skill-hook-condition-aborts.md`、`.changeset/skills-definehook-examples.md` —— 同为 skills-only 文档改动),不发布任何包。

草稿状态,未 enable auto-merge、未 undraft,由 PM 复核后决定。

---
_Generated by [Claude Code](https://claude.ai/code/session_018iARDqtrhQgz6fVHDeDkbQ)_