### PR TITLE
fix(tooling): merge 驱动不再绑定到「上一个装过依赖的 worktree」,并补上悬空判红的断言 (#4868)

### DIFF
--- a/.changeset/merge-driver-worktree-independent.md
+++ b/.changeset/merge-driver-worktree-independent.md
@@ -1,0 +1,28 @@
+---
+---
+
+Tooling-only: `merge.os-regen.driver` is registered as a worktree-independent
+command, and `check:merge-driver` now asserts the registered driver actually
+resolves (#4868). Releases nothing.
+
+`setup-git-hooks.mjs` baked an absolute `${REPO_ROOT}/scripts/git-merge-regen.mjs`
+into `.git/config`. Linked worktrees SHARE one `.git/config`, so every
+`pnpm install` re-pointed the container-wide driver at whichever worktree had just
+installed — and the moment that worktree was removed, which AGENTS.md *requires*
+on task cleanup, every merge touching a `merge=os-regen` path in every other
+worktree died with `MODULE_NOT_FOUND`. Following the cleanup rule is what
+triggered the breakage, which is why it recurred across four worktrees.
+
+The value is now `node "$(git rev-parse --show-toplevel)/scripts/git-merge-regen.mjs" %O %A %B %P`.
+Git hands a merge driver to a shell, so the substitution runs per invocation
+inside the worktree being merged: it binds to no worktree yet still resolves to
+the right root — the property the absolute path was there to guarantee. Existing
+clones self-heal on the next `pnpm install`.
+
+The gate could not see any of this, because it never looked: every existing
+`--self-test` check builds its own temp repo and registers its own driver, so all
+of them stayed green while the live config dangled. A new `registeredDriverResolves()`
+check reads the *live* config and fails when the script does not exist, when it
+points outside the current worktree (the same bug one step before it bites), or
+when the value has drifted from what the registrar writes. The registrar and the
+gate now read one declaration, `GIT_SETTINGS` in `regen-artifacts.mjs`.

--- a/scripts/git-merge-regen.mjs
+++ b/scripts/git-merge-regen.mjs
@@ -55,12 +55,19 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { NOT_DRIVER_MANAGED, PENDING_MARKER, REGEN_ARTIFACTS, entryForPath } from './regen-artifacts.mjs';
+import {
+  DRIVER_NAME,
+  GIT_SETTINGS,
+  NOT_DRIVER_MANAGED,
+  PENDING_MARKER,
+  REGEN_ARTIFACTS,
+  entryForPath,
+} from './regen-artifacts.mjs';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -194,6 +201,117 @@ function hookIsExecutable() {
 }
 
 /**
+ * The driver registered in THIS clone must resolve — here, now (#4868).
+ *
+ * Every other check in this self-test builds a throwaway repo and registers its own
+ * driver into it, so all of them stayed green for weeks while the real
+ * `merge.os-regen.driver` in the shared `.git/config` pointed at a DELETED worktree
+ * and every real merge of a `merge=os-regen` path died with MODULE_NOT_FOUND. The
+ * self-test and the live merge path were simply not the same path. This check reads
+ * the live one, which is the only reason it can catch that class of failure.
+ *
+ * It fails in three distinguishable ways, all of which have happened or are one
+ * `pnpm install` away:
+ *   - the script the value names does not exist (the dangling-worktree bug);
+ *   - it exists but lives outside this worktree (bound to someone else's worktree —
+ *     green for whoever installed last, broken for everyone else, so this is the
+ *     check that catches the bug *before* the other worktree is removed);
+ *   - the value has drifted from what `setup-git-hooks.mjs` registers.
+ */
+function registeredDriverResolves() {
+  const { key, value: expected } = GIT_SETTINGS.find((s) => s.key === `merge.${DRIVER_NAME}.driver`);
+
+  let actual = '';
+  try {
+    actual = execFileSync('git', ['config', '--get', key], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    actual = ''; // unset — `git config --get` exits 1
+  }
+
+  if (!actual) {
+    // A supported state, not a failure: git falls back to a text merge, which is
+    // exactly the pre-#4675 behaviour. `pnpm install` registers it.
+    console.log(`✓ ${key} is unregistered — merges text-merge as they did before #4675`);
+    return true;
+  }
+
+  const expansion = expandDriverScript(actual);
+  if (expansion.skip) {
+    console.log(`✓ ${key} not checked for resolution (${expansion.skip})`);
+    return true;
+  }
+  if (expansion.error) return fail(`could not expand ${key} ("${actual}"): ${expansion.error}`);
+
+  const script = expansion.path;
+  if (!existsSync(script)) {
+    return fail(`${key} names a script that does not exist:\n`
+      + `    ${script}\n`
+      + `  Registered value: ${actual}\n`
+      + '  Every merge touching a merge=os-regen path in this clone dies with MODULE_NOT_FOUND,\n'
+      + '  and git leaves the path CONFLICTED with ours in it and no conflict markers.\n'
+      + '  Fix: pnpm install  (re-registers the driver for this worktree)');
+  }
+
+  const root = realpath(REPO_ROOT);
+  if (relative(root, realpath(script)).startsWith('..')) {
+    return fail(`${key} points OUTSIDE this worktree:\n`
+      + `    ${script}\n`
+      + `  Linked worktrees share one .git/config, so this is bound to another worktree and\n`
+      + '  breaks for everyone the moment that one is removed.\n'
+      + '  Fix: pnpm install  (re-registers the driver for this worktree)');
+  }
+
+  if (actual !== expected) {
+    return fail(`${key} has drifted from what setup-git-hooks.mjs registers.\n`
+      + `    registered: ${actual}\n`
+      + `    expected:   ${expected}\n`
+      + '  Fix: pnpm install');
+  }
+
+  console.log(`✓ merge.${DRIVER_NAME}.driver resolves in THIS worktree (${relative(root, realpath(script))})`);
+  return true;
+}
+
+/**
+ * Expand the driver value's script path the way git will: git hands a merge driver
+ * command to a shell, so `$(git rev-parse --show-toplevel)` is only meaningful once
+ * a shell has run it, from inside the worktree being merged.
+ */
+function expandDriverScript(value) {
+  // Drop the trailing %O %A %B %P placeholders; what remains is `node <script>`.
+  const command = value.replace(/(\s+%[A-Za-z])+\s*$/, '');
+  const expr = /^\s*node\s+(\S.*)$/.exec(command)?.[1];
+  if (!expr) return { skip: `not a \`node <script>\` command: "${value}"` };
+  try {
+    return {
+      path: execFileSync('sh', ['-c', `printf '%s' ${expr}`], {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).trim(),
+    };
+  } catch (err) {
+    // No POSIX shell (some Windows setups). Git could not run the driver either,
+    // so there is nothing this check could assert that would still be true.
+    if (err?.code === 'ENOENT') return { skip: 'no POSIX shell available to expand it' };
+    return { error: err?.stderr?.toString().trim() || err?.message || String(err) };
+  }
+}
+
+/** Best-effort realpath: symlinked checkouts otherwise read as "outside the worktree". */
+function realpath(p) {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
+/**
  * Prove the driver end to end against real git: a conflicting change on both
  * sides of a mapped path must come out resolved, marker-free, and recorded.
  * Asserting the behaviour rather than the wiring is the point — the wiring
@@ -207,7 +325,12 @@ function endToEnd() {
     git('config', 'user.email', 'selftest@objectstack.ai');
     git('config', 'user.name', 'self-test');
     git('config', 'merge.os-regen.name', 'regenerate instead of text-merging');
-    git('config', 'merge.os-regen.driver', `node ${join(REPO_ROOT, 'scripts/git-merge-regen.mjs')} %O %A %B %P`);
+    // Absolute on purpose, and NOT the value we register in a real clone: this temp
+    // repo is not the ObjectStack worktree, so the registered
+    // `$(git rev-parse --show-toplevel)` would resolve to `dir` — which has no
+    // scripts/. Here we want the driver under test, i.e. this clone's copy.
+    // Checking the value real clones get is `registeredDriverResolves()`'s job (#4868).
+    git('config', 'merge.os-regen.driver', `node "${join(REPO_ROOT, 'scripts/git-merge-regen.mjs')}" %O %A %B %P`);
 
     const target = REGEN_ARTIFACTS[0].path;
     mkdirSync(join(dir, dirname(target)), { recursive: true });
@@ -245,7 +368,13 @@ function endToEnd() {
 
 if (process.argv.includes('--self-test')) {
   console.log('git-merge-regen --self-test\n');
-  const results = [reconcileAttributes(), reconcileScripts(), hookIsExecutable(), endToEnd()];
+  const results = [
+    reconcileAttributes(),
+    reconcileScripts(),
+    hookIsExecutable(),
+    registeredDriverResolves(),
+    endToEnd(),
+  ];
   console.log(
     results.every(Boolean)
       ? `\n✓ merge driver wiring is consistent (${NOT_DRIVER_MANAGED.length} path(s) deliberately excluded).`

--- a/scripts/regen-artifacts.mjs
+++ b/scripts/regen-artifacts.mjs
@@ -89,6 +89,33 @@ export const PENDING_MARKER = 'os-regen-pending';
 /** The git config key pair that registers the driver in a clone. */
 export const DRIVER_NAME = 'os-regen';
 
+/**
+ * The script git runs as the merge driver, as a shell word (#4868).
+ *
+ * Resolved at MERGE time against the worktree being merged, never at install time
+ * against the worktree that happened to run `pnpm install`. Linked worktrees share
+ * one `.git/config`, so an absolute path here is a container-wide setting written
+ * by whoever installed last — and it dangles the moment that worktree is removed,
+ * which AGENTS.md requires on task cleanup. See `setup-git-hooks.mjs` for the two
+ * constraints this spelling satisfies and the two traps it avoids.
+ */
+export const DRIVER_SCRIPT_EXPR = '"$(git rev-parse --show-toplevel)/scripts/git-merge-regen.mjs"';
+
+/**
+ * Every git config setting that `pnpm install` registers, declared once.
+ *
+ * `setup-git-hooks.mjs` writes these; `git-merge-regen.mjs --self-test` asserts the
+ * live config still matches them and that the driver script actually resolves. One
+ * declaration, so the registrar and the gate cannot drift apart.
+ */
+export const GIT_SETTINGS = Object.freeze([
+  { key: `merge.${DRIVER_NAME}.name`, value: 'regenerate generator-owned artifacts instead of text-merging' },
+  // %O %A %B %P — ancestor, ours (the output file), theirs, pathname. Unquoted on
+  // purpose: git generates %O %A %B as temp names and shell-quotes %P itself.
+  { key: `merge.${DRIVER_NAME}.driver`, value: `node ${DRIVER_SCRIPT_EXPR} %O %A %B %P` },
+  { key: 'core.hooksPath', value: '.githooks' },
+]);
+
 /** Resolve the entry that owns a path, or undefined. Handles the one `**` entry. */
 export function entryForPath(p) {
   return REGEN_ARTIFACTS.find((e) =>

--- a/scripts/setup-git-hooks.mjs
+++ b/scripts/setup-git-hooks.mjs
@@ -26,21 +26,43 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { DRIVER_NAME } from './regen-artifacts.mjs';
+import { GIT_SETTINGS } from './regen-artifacts.mjs';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
-const SETTINGS = [
-  { key: `merge.${DRIVER_NAME}.name`, value: 'regenerate generator-owned artifacts instead of text-merging' },
-  // %O %A %B %P — ancestor, ours (the output file), theirs, pathname. `node` and
-  // a repo-relative path keep this working on Windows and in linked worktrees,
-  // where a bare `./scripts/...` would resolve against the wrong root.
-  { key: `merge.${DRIVER_NAME}.driver`, value: `node "${join(REPO_ROOT, 'scripts/git-merge-regen.mjs')}" %O %A %B %P` },
-  { key: 'core.hooksPath', value: '.githooks' },
-];
+// What gets registered lives in `regen-artifacts.mjs` — one declaration, read both
+// by this registrar and by the `--self-test` gate that verifies it (#4868).
+//
+// The driver value is deliberately NOT an absolute path any more. It must satisfy
+// two constraints at once, and the obvious spellings each satisfy only one:
+//
+//   - It must not bind to one specific worktree. Baking an absolute
+//     `${REPO_ROOT}/scripts/...` in here did exactly that: linked worktrees SHARE
+//     one `.git/config`, so every `pnpm install` re-pointed the container-wide
+//     driver at the installing worktree, and the moment that worktree was removed
+//     — which AGENTS.md *requires* on task cleanup — every merge of a
+//     `merge=os-regen` path in every other worktree died with MODULE_NOT_FOUND.
+//     Observed drifting across four worktrees before anyone noticed.
+//   - It must still resolve to the right root. A bare `./scripts/...` relies on
+//     git's (undocumented) choice of cwd for merge drivers, which is what the
+//     absolute path was originally there to avoid.
+//
+// `$(git rev-parse --show-toplevel)` satisfies both: git runs merge drivers
+// through a shell, so the substitution happens per invocation, inside the worktree
+// being merged. Verified in git 2.43 from a linked worktree, invoked from both the
+// worktree root and a subdirectory.
+//
+// Two traps, both verified empirically rather than assumed:
+//   - NO leading `!`. That prefix is alias/credential-helper syntax; a merge driver
+//     value is already handed to the shell verbatim, so `!node ...` runs a program
+//     literally named `!node` — "not found", and git falls back to a text merge.
+//   - The placeholders stay UNQUOTED. git substitutes %O %A %B as generated temp
+//     names and already shell-quotes %P itself; wrapping them in quotes of our own
+//     hands the driver a pathname with literal quote characters in it.
+const SETTINGS = GIT_SETTINGS;
 
 function git(args, opts = {}) {
   return execFileSync('git', args, { cwd: REPO_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], ...opts });


### PR DESCRIPTION
Fixes #4868

## 缺陷:遵守收尾纪律,就是触发缺陷的动作

`scripts/setup-git-hooks.mjs` 把**绝对路径**写进 `merge.os-regen.driver`。linked worktree 共用同一份 `/home/user/objectstack/.git/config`,于是每次有人 `pnpm install`,**全容器**的驱动就被改指向那个人的 worktree。

关键的一环不是花絮:AGENTS.md **要求**任务收尾时 `git worktree remove`。所以「按规矩收尾」正是让驱动悬空的那个动作 —— 这就是它为什么必然反复发生,而不是偶发。本单实施期间实测路径漂过四轮(`-4796` → `-4793` → `-4843` → `-4890`),其中 `-4843` → `-4890` 是我开工到建 worktree 这几分钟内、被另一个并行 agent 的 install 改掉的。

驱动一坏,所有 agent 凡碰到 `.gitattributes` 里 `merge=os-regen` 映射的文件(`spec-changes.json`、`authorable-surface.json`、`content/docs/references/**` 等)的 merge 全部 MODULE_NOT_FOUND。

**比议题描述的更糟一点**:实测驱动崩溃后,git 把该路径留成 `UU`,里面是 **ours、且零冲突标记**:

```
OURS_MARKER present: 1
THEIRS_MARKER present: 0
conflict markers: 0
```

也就是说一次条件反射式的 `git add -A` 就会静默吞掉 incoming 那一侧 —— 正是 #4616 那类「无冲突标记地静默吞掉别人的删除」。

## 为什么不能简单改回相对路径

原第 40 行的注释说明绝对路径是**刻意**的:躲开「相对路径解析到错的根」。所以解法必须**同时**满足两个约束:

1. 不绑定到任何具体 worktree;
2. git 调用驱动时能解析到**当前工作树**的根。

新值:

```
node "$(git rev-parse --show-toplevel)/scripts/git-merge-regen.mjs" %O %A %B %P
```

git 把 merge 驱动命令整条交给 shell,所以命令替换在**每次调用时、在正在被合并的那个工作树里**求值 —— 两个约束同时满足。既有 clone 下次 `pnpm install` 自愈。

### 议题建议的 `!` 形式是错的 —— 实测,没有照抄

议题建议 `!node "$(git rev-parse --show-toplevel)"/scripts/...`。在 linked worktree 里实测(git 2.43):

```
    !node "$(git rev-parse --show-toplevel)/scripts/x.mjs" .merge_file_9Sb2gX ... 'art.json': 1: !node: not found
    Auto-merging art.json
    CONFLICT (content): Merge conflict in art.json
```

`!` 前缀是 alias / credential-helper 的语法;merge 驱动的值本来就直接交给 shell,所以 `!node` 是在找一个真名叫 `!node` 的程序。**失败方式还是静默降级成文本合并** —— 比现状更隐蔽。已去掉 `!`。

### 占位符必须保持不加引号 —— 也是实测

顺手「改进」引用会引入新缺陷。git 自己已经对 `%P` 做了 shell 引用:

```
不加引号: ARGV=[".merge_file_mNVhOu",".merge_file_HqfCyx",".merge_file_Zupv9J","art.json"]
自己加引号: ARGV=[".merge_file_mok9gZ",".merge_file_sKzy0x",".merge_file_wRJoN3","'art.json'"]
```

即自己加引号会把**字面引号**塞进 pathname。已在代码注释里记下这个坑。

其余验证:`$(git rev-parse --show-toplevel)` 形式在 linked worktree 里、从工作树根和子目录发起的 merge 都正确解析到该 worktree 根。

## 自检本身是反面教材,所以新增断言读**实时** config

`pnpm check:merge-driver` 的每一条既有检查都**自建临时仓库、注册自己的驱动**,所以它和真实调用路径不是同一条。开工时的实测 —— 此时真实 config 指向已删除的 `-4843`:

```
$ git config --show-origin --get merge.os-regen.driver
file:.git/config  node "/home/user/objectstack-4843/scripts/git-merge-regen.mjs" %O %A %B %P
$ ls /home/user/objectstack-4843/scripts/git-merge-regen.mjs
ls: cannot access ...: No such file or directory

$ pnpm check:merge-driver
✓ merge driver wiring is consistent (6 path(s) deliberately excluded).
✓ check-regen-pending self-test passed.
=== EXIT: 0 ===
```

**全绿。** 这就是它能漂四轮没人发现的原因。

新增 `registeredDriverResolves()` 读**实时** config,三种判红方式:

### 判红 1 —— 脚本不存在(悬空,即本单的现场)

```
✓ .githooks/pre-commit is executable in the index (100755)
✗ merge.os-regen.driver names a script that does not exist:
    /home/user/objectstack-4843/scripts/git-merge-regen.mjs
  Registered value: node "/home/user/objectstack-4843/scripts/git-merge-regen.mjs" %O %A %B %P
  Every merge touching a merge=os-regen path in this clone dies with MODULE_NOT_FOUND,
  and git leaves the path CONFLICTED with ours in it and no conflict markers.
  Fix: pnpm install  (re-registers the driver for this worktree)

✗ merge driver wiring is inconsistent — see above.
EXIT=1
```

### 判红 2 —— 指向本工作树以外(缺陷咬人**前**一步)

这条是我加的、议题没提的:worktree 还在、脚本还能解析,但驱动已经绑在别人的 worktree 上 —— 对刚 install 的那个人是绿的,对其他所有人已经是坏的。等到它被删才报,已经晚了。

```
✗ merge.os-regen.driver points OUTSIDE this worktree:
    /home/user/objectstack-4719/scripts/git-merge-regen.mjs
  Linked worktrees share one .git/config, so this is bound to another worktree and
  breaks for everyone the moment that one is removed.
  Fix: pnpm install  (re-registers the driver for this worktree)
EXIT=1
```

### 判红 3 —— 与注册值漂移

实拍(我的 `pnpm install` 用旧代码写进 config 之后):

```
✗ merge.os-regen.driver has drifted from what setup-git-hooks.mjs registers.
    registered: node "/home/user/objectstack-4868/scripts/git-merge-regen.mjs" %O %A %B %P
    expected:   node "$(git rev-parse --show-toplevel)/scripts/git-merge-regen.mjs" %O %A %B %P
  Fix: pnpm install
EXIT=1
```

制造悬空态用的是进程级的 `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0` 注入,**没有改共享的 `.git/config`** —— 并行 agent 的 merge 不受影响。(判红 1 里既有的 `endToEnd` 也跟着红了,那是该注入方式会漏进它自建的临时仓库所致,不是真实场景的行为;判红 2 干净地只有新断言红。)

修好后:

```
✓ .gitattributes ↔ regen-artifacts.mjs agree on 7 path(s)
✓ all 14 gen:/check: names resolve in @objectstack/spec
✓ .githooks/pre-commit is executable in the index (100755)
✓ merge.os-regen.driver resolves in THIS worktree (scripts/git-merge-regen.mjs)
✓ end-to-end: conflicting packages/spec/spec-changes.json merged without markers and recorded as pending

✓ merge driver wiring is consistent (6 path(s) deliberately excluded).
✓ check-regen-pending self-test passed.
EXIT=0
```

## 真实合并路径验证(比 self-test 更重要 —— self-test 已经证明过它会骗人)

在本 worktree 里构造两侧都改 `packages/spec/spec-changes.json` 的真实合并,**不带任何 `-c` 覆盖**,驱动完全由共享 `.git/config` 解析:

```
$ git config --get merge.os-regen.driver
node "$(git rev-parse --show-toplevel)/scripts/git-merge-regen.mjs" %O %A %B %P

$ git merge lab3-theirs -m lab
  ⟳ packages/spec/spec-changes.json
     not text-merged — it is generated. Regenerate from the merged tree:
       pnpm --filter @objectstack/spec gen:spec-changes
     The pre-commit hook will not let this commit through until you do.
Auto-merging packages/spec/spec-changes.json
Merge made by the 'ort' strategy.

=== pending marker contents ===
packages/spec/spec-changes.json
=== conflicted paths: 0 ===
```

驱动被正确调用、pending marker 落盘、零冲突。同一场景在悬空值下则是本 PR 开头那段 MODULE_NOT_FOUND。

## declared = enforced

注册方(`setup-git-hooks.mjs`)与校验方(`git-merge-regen.mjs --self-test`)此前各写各的;现在共读 `regen-artifacts.mjs` 里同一份 `GIT_SETTINGS` 声明,少一处可漂移的副本。

## 改动范围

`scripts/setup-git-hooks.mjs`、`scripts/regen-artifacts.mjs`、`scripts/git-merge-regen.mjs`,加一个空 frontmatter changeset(tooling 改动,不发版)。**未改**根 `package.json`,**未改** `.github/workflows/`,**未碰** `content/docs/releases/`。

`pnpm check:merge-driver` 绿;三个改动脚本 ESLint 干净(exit 0);`setup-git-hooks.mjs` 重复运行仍然静默(幂等)。


---
_Generated by [Claude Code](https://claude.ai/code/session_018iARDqtrhQgz6fVHDeDkbQ)_