### PR TITLE
ci(deps): pin brace-expansion to 5.0.9 for GHSA-rgw5-rvv9-x895 (#4945)

### DIFF
--- a/.changeset/brace-expansion-advisory-5-0-9.md
+++ b/.changeset/brace-expansion-advisory-5-0-9.md
@@ -1,0 +1,26 @@
+---
+---
+
+ci(deps): lift the `brace-expansion` pin to 5.0.9 so `Validate Package Dependencies` stops failing on every PR (#4945)
+
+`GHSA-rgw5-rvv9-x895` (7.5 high) affects `brace-expansion` 5.0.8 — which is
+exactly the version the previous pin (`brace-expansion@>=5.0.0 <5.0.8: ^5.0.8`,
+added for `GHSA-mh99-v99m-4gvg`) had settled on. The OSV-Scanner step in
+`.github/workflows/validate-deps.yml` reads `pnpm-lock.yaml` directly and exits
+non-zero on any match, so the job was red on `main` itself and attached that red
+to every PR that touched a manifest or the lockfile, whatever the PR contained
+(observed on #4944, which never touched `pnpm-lock.yaml`).
+
+The `pnpm-workspace.yaml` override bound moves to `<5.0.9` / `^5.0.9`. It stays a
+transitive-only pin — nothing declares `brace-expansion` directly; it arrives via
+`minimatch` (ts-morph, eslint, `@typescript-eslint`, glob, `@vscode/vsce`,
+archiver), so no published manifest changes and `check-override-consistency`
+still has nothing to reconcile. 5.0.8 disappears from the lockfile entirely; the
+three `minimatch` snapshots that referenced it now resolve 5.0.9.
+
+The reason to fix this on its own rather than let it ride along with the next
+dependency PR is the one the issue names: a permanently red required check
+trains everyone to scroll past it, and the next real advisory will look exactly
+like this one in the PR list.
+
+Lockfile and override metadata only; releases nothing.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ overrides:
   cookie@<0.7.0: 0.7.0
   svelte: ^5.55.7
   '@tootallnate/once@<2.0.1': 2.0.1
-  brace-expansion@>=5.0.0 <5.0.8: ^5.0.8
+  brace-expansion@>=5.0.0 <5.0.9: ^5.0.9
   sharp@>=0.34.0 <0.35.0: ^0.35.0
   react-router@<8.3.0: ^8.3.0
   '@sveltejs/kit@<2.69.1': ^2.69.1
@@ -5218,10 +5218,6 @@ packages:
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
-
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
-    engines: {node: 20 || >=22}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -12067,10 +12063,6 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@5.0.8:
-    dependencies:
-      balanced-match: 4.0.4
-
   brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
@@ -14563,11 +14555,11 @@ snapshots:
 
   minimatch@10.2.3:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@10.2.6:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -105,13 +105,16 @@ overrides:
   svelte: '^5.55.7'
   '@tootallnate/once@<2.0.1': '2.0.1'
   # OSV batch 2026-07 — transitive-only fixes (no publishable package declares these):
-  # brace-expansion GHSA-mh99-v99m-4gvg (via minimatch@10.x); sharp GHSA-f88m-g3jw-g9cj
+  # brace-expansion GHSA-mh99-v99m-4gvg (via minimatch@10.x), then GHSA-rgw5-rvv9-x895
+  # (7.5 high) which affects 5.0.8 itself — the version the first pin landed on — so the
+  # bound moves to <5.0.9. Still transitive-only through minimatch (ts-morph, eslint,
+  # @typescript-eslint, glob, @vscode/vsce, archiver); sharp GHSA-f88m-g3jw-g9cj
   # (next optionalDep ^0.34.5 excludes the fix); react-router GHSA-qwww-vcr4-c8h2 has no
   # 7.x fix — fumadocs-core peer allows 8.x and docs uses the next adapter, so jump to 8;
   # @sveltejs/kit GHSA-866w-xmhq-wj7x/GHSA-wqjv-9729-c5q2 (better-auth optional peer);
   # @hono/node-server GHSA-frvp-7c67-39w9 has no 1.x fix — @modelcontextprotocol/sdk
   # declares ^1.19.9 and only imports getRequestListener, which 2.x still exports.
-  'brace-expansion@>=5.0.0 <5.0.8': '^5.0.8'
+  'brace-expansion@>=5.0.0 <5.0.9': '^5.0.9'
   'sharp@>=0.34.0 <0.35.0': '^0.35.0'
   'react-router@<8.3.0': '^8.3.0'
   '@sveltejs/kit@<2.69.1': '^2.69.1'


### PR DESCRIPTION
Fixes #4945

## 问题

`Validate Package Dependencies` 的 OSV-Scanner step 直接扫 `pnpm-lock.yaml`,命中任一 advisory 就 exit 1。**`main` 上它本身就是红的**,于是每个触发该 workflow(改动任意 `package.json` / `pnpm-lock.yaml` / 相关 script)的 PR 都白白背一条红 —— 在 #4944 上实测复现,而那个 PR 根本没碰 lockfile。

Advisory:[GHSA-rgw5-rvv9-x895](https://osv.dev/GHSA-rgw5-rvv9-x895)(CVSS 7.5,high),影响 `brace-expansion` 5.0.8,修复版本 5.0.9。

讽刺之处在于 5.0.8 正是**上一条** advisory(`GHSA-mh99-v99m-4gvg`)的 pin 停靠的位置:`pnpm-workspace.yaml` 里原有那条 override 的区间上界恰好就是 5.0.8(开区间),把新受影响的版本排除在 override 之外,所以 5.0.8 岿然不动地留在 lockfile 里。

## 传递路径

纯传递依赖,没有任何 workspace 包直接声明它,全部经 `minimatch` 进来。`pnpm why brace-expansion --recursive`(修复前)节选:

```
brace-expansion@5.0.8
├─┬ minimatch@10.2.3
│ ├─┬ @ts-morph/common@0.29.0
│ │ └─┬ ts-morph@28.0.0
│ │   └── @objectstack/cli@17.0.0-rc.2 (dependencies)
│ ├─┬ @typescript-eslint/typescript-estree@8.65.0
│ │ └─┬ @typescript-eslint/parser@8.65.0
│ │   └── @objectstack/spec-monorepo@4.0.1 (devDependencies)
│ ├─┬ @vscode/vsce@3.9.2
│ │ └── objectstack-vscode@17.0.0-rc.2 (devDependencies)
│ ├─┬ glob@13.0.6
│ │ ├── @objectstack/metadata@17.0.0-rc.2 (dependencies)
│ │ └── @vscode/vsce@3.9.2 [deduped]
│ ├─┬ glob@7.2.3
│ │ └─┬ archiver-utils@2.1.0 → archiver@5.3.2 → exceljs@4.4.0
│ │     └── @objectstack/rest@17.0.0-rc.2 (dependencies)
│ └─┬ readdir-glob@1.1.3 → archiver@5.3.2 [deduped]
└─┬ minimatch@10.2.5
  └─┬ eslint@10.8.0
    └── @objectstack/spec-monorepo@4.0.1 (devDependencies)

brace-expansion@5.0.9
└─┬ minimatch@10.2.6   (@eslint/config-array, @oclif/core — 已经在修好的版本上)
```

## 改法

改动就是 `pnpm-workspace.yaml` 里**既有那一条** brace-expansion override 的一行:区间上界与 value 一起从 5.0.8 抬到 5.0.9(下界 5.0.0 与写法风格都不变)。精确文本见 Files changed —— 这里不重贴,因为 GitHub 的 body sanitizer 会把引号和尖括号转义成 HTML 实体,放进代码块反而显示成乱码。

pnpm v10 只从 `pnpm-workspace.yaml` 读 `overrides`,`package.json` 的 `pnpm.overrides` 会被静默忽略(该文件顶部注释已写明),所以 **没有新增 override 条目,也没有动根 `package.json`** —— 只是把既有条目的边界移动到新 advisory 之后。

`pnpm install` 重新解析后,lockfile 的改动面就是这一个包:5.0.8 在 `packages` / `snapshots` 两处的条目整体消失,`minimatch@10.2.3` 与 `minimatch@10.2.5` 改指 5.0.9。其余依赖一行未动。

由于是传递依赖,没有 published manifest 需要同步,`check-override-consistency.mjs` 无新增负担(仍然只有 1 条 published-manifest 声明需要核对,绿)。

## 验证(双向)

本地用 workflow 钉住的**同一个** scanner 版本(`google/osv-scanner-action` v2.3.8 → `osv-scanner_linux_amd64` v2.3.8)跑同一条命令。因本容器 egress 策略拦截 `api.osv.dev`(403),改用 `--offline --download-offline-databases` 走离线库,数据源等价、结论一致。

**修复前(红,exit 1)** —— 与 issue 里贴的 CI 输出逐字一致:

```
Scanned /home/user/objectstack-4945/pnpm-lock.yaml file and found 1503 packages
Total 1 package affected by 1 known vulnerability (0 Critical, 1 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
1 vulnerability can be fixed.

+-------------------------------------+------+-----------+-----------------+---------+---------------+----------------+
| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE         | VERSION | FIXED VERSION | SOURCE         |
+-------------------------------------+------+-----------+-----------------+---------+---------------+----------------+
| https://osv.dev/GHSA-rgw5-rvv9-x895 | 7.5  | npm       | brace-expansion | 5.0.8   | 5.0.9         | pnpm-lock.yaml |
+-------------------------------------+------+-----------+-----------------+---------+---------------+----------------+
EXIT=1
```

**修复后(绿,exit 0)**:

```
Scanned /home/user/objectstack-4945/pnpm-lock.yaml file and found 1502 packages
Loaded npm local db from /root/.cache/osv-scanner/npm/all.zip

No issues found
EXIT=0
```

该 job 的其余 step 也照原样跑过:

```
$ pnpm install --frozen-lockfile --prefer-offline      → Done in 4.5s  (lockfile 自洽)
$ node scripts/check-changeset-fixed.mjs               → ✓ fixed group in sync with 69 public workspace packages
$ node scripts/check-override-consistency.mjs          → ✓ 1 published-manifest declaration(s) … resolve to their override targets
```

功能抽查(`brace-expansion` 是 `minimatch`/`glob` 系的传递依赖,挑两个重度依赖 glob 匹配的 check):

```
$ pnpm check:doc-authoring     → ✓ 219 files clean — no bare metadata literals.
$ pnpm check:published-files   → ✓ 69 publishable package(s) … declare a files whitelist …
```

## 附带记录

issue 的建议 2(「advisory 无可用修复版本时 `validate-deps.yml` 该怎么表达」)本 PR **不处理** —— 这条 advisory 有修复版本,属于另一个议题(现有机制是 `osv-scanner.toml` 的 `[[IgnoredVulns]]`,workflow 注释里已指明)。留给维护者决定是否单开。

已附 changeset(空 frontmatter,不发版)。
