### PR TITLE
fix(approvals): 无自动化引擎时审批决策不再静默搁浅流程 run (#4420)

### DIFF
--- a/.changeset/approvals-engineless-resume-gap.md
+++ b/.changeset/approvals-engineless-resume-gap.md
@@ -1,0 +1,48 @@
+---
+"@objectstack/plugin-approvals": patch
+---
+
+fix(approvals): an approval decision can no longer strand a flow run silently when no automation engine is attached (#4420)
+
+#4420's fix closed every path by which a decision could be recorded while its
+flow stayed parked — except one, and it is the one where none of the new guards
+could run. Every guard it added (`assertRunResumable`'s pre-flight, the
+`RESUME_TARGET_LOST` refusal, the `RESUME_FAILED` throw) hangs off the
+automation engine. In a process where **no engine is attached**, all of them
+were skipped by the same `typeof this.automation?.resume === 'function'`
+condition that wrapped the resume itself — so the decision was written, the
+mirrored status field advanced, and the call answered HTTP 200 with
+`resumed: false` and **nothing logged at all**. That is #4420's reported
+symptom exactly, reproduced in the one composition its fix could not see.
+
+The composition is reachable the same way the original bug was: a flow parks at
+an `approval` node in a process that has the automation service, and the
+decision arrives in one that does not (the plugin failed to init, or the host
+was recomposed between releases). The request row still carries a
+`flow_run_id` — which is the row's own declaration that a run is parked on this
+decision.
+
+**What changes.** The decision still stands. Rolling it back is not on the
+table (a human really decided, and the row is durable by then), and refusing
+every such call would break the standalone approvals compositions the
+pre-flight deliberately protects — so `finalized` and `resumed` are unchanged
+for every existing caller. What changes is that the gap is no longer silent:
+
+- it is logged at **`error`**, per the durability rule in `AGENTS.md` —
+  persisted state and runtime state disagree while nothing looks broken from
+  the outside, which is the class that rule exists for;
+- the response carries **`resumeError`**, so `resumed: false` arrives with its
+  reason and the stranded run's id instead of leaving the caller to guess
+  whether a resume was even attempted.
+
+It reuses the already-registered `RESUME_FAILED` code and the existing resume
+message shape rather than introducing a new vocabulary — the fact being
+reported (an outcome recorded whose run did not advance) is the same one.
+
+Applied at all five sites that resume a recorded outcome: `decide`, the
+revision-limit auto-rejection, `sendBack`, `resubmit`, and both branches of
+`recall` (whose revise-window path needs `cancelRun` rather than `resume`).
+
+A request that names **no** run is unaffected and stays quiet — there is
+nothing parked on it, and reporting one there would be the mirror-image
+failure that trains operators to skim `error`.

--- a/packages/plugins/plugin-approvals/src/approval-restart-resume.test.ts
+++ b/packages/plugins/plugin-approvals/src/approval-restart-resume.test.ts
@@ -237,11 +237,25 @@ describe('approval decisions across a process restart (#4420)', () => {
     expect(marks).toEqual(['on_approved']);
   });
 
-  it('leaves a composition with no automation engine exactly as it was', async () => {
-    // Approvals also runs with no engine attached — the request row still
-    // names a run, but there is nothing here that could resume it. The
-    // pre-flight must stay out of the way rather than invent a failure.
-    const standalone = new ApprovalService({ engine: data as any, logger: noopLogger });
+  it('still records the decision with no automation engine attached — but never silently', async () => {
+    // Approvals runs with no engine attached, and the decision must still
+    // stand: a human really decided, the row is durable, and refusing every
+    // such call would break the standalone compositions the pre-flight
+    // deliberately protects. So `finalized` / `resumed` are unchanged.
+    //
+    // What changed is the silence. The request row NAMES a run, which is its
+    // own declaration that a flow is parked on this decision — and every guard
+    // the #4420 fix added hangs off an engine that is not there, so this was
+    // the one path left answering 200 / `resumed: false` with nothing logged:
+    // #4420's exact reported symptom, in the one composition its fix could not
+    // see. The gap is now reported at `error` (persisted state and runtime
+    // state disagree, and nothing looks broken) and carried on `resumeError`.
+    const logs: Array<{ level: string; msg: string }> = [];
+    const capturing = {
+      info() {}, warn() {}, debug() {},
+      error(msg: any) { logs.push({ level: 'error', msg: String(msg) }); },
+    };
+    const standalone = new ApprovalService({ engine: data as any, logger: capturing as any });
     const opened = await standalone.openNodeRequest({
       object: 'crm_deal', recordId: 'd1', runId: 'run_from_another_process',
       nodeId: 'approve_step', config: { approvers: [{ type: 'user', value: 'u1' }] } as any,
@@ -250,5 +264,43 @@ describe('approval decisions across a process restart (#4420)', () => {
     const out = await standalone.decide((opened as any).id, { decision: 'approve', actorId: 'u1' }, SYSTEM_CTX);
     expect(out.finalized).toBe(true);
     expect(out.resumed).toBe(false);
+
+    // The divergence is machine-visible, not a bare `resumed: false` the
+    // caller has to guess about, and it names the run that stayed parked.
+    expect(out.resumeError, 'the composition gap must reach the caller').toBeTruthy();
+    expect(out.resumeError).toMatch(/RESUME_FAILED/);
+    expect(out.resumeError).toMatch(/run_from_another_process/);
+
+    // …and it is loud in the log at `error`, per AGENTS.md's durability rule.
+    expect(logs.some(l => /no automation engine to advance/.test(l.msg)),
+      `expected a loud error log, got: ${JSON.stringify(logs)}`).toBe(true);
+  });
+
+  it('reports the same gap on a request that names no run — by staying quiet', async () => {
+    // The counterpart that keeps the rule honest: a standalone approvals
+    // request with NO `flow_run_id` has nothing parked on it, so there is no
+    // divergence to report. Reporting one here would be the mirror-image
+    // failure — training operators to skim `error`, which is what made #4420's
+    // original `warn` unreadable in the first place.
+    const logs: string[] = [];
+    const capturing = {
+      info() {}, warn() {}, debug() {}, error(msg: any) { logs.push(String(msg)); },
+    };
+    const standalone = new ApprovalService({ engine: data as any, logger: capturing as any });
+    const opened = await standalone.openNodeRequest({
+      object: 'crm_deal', recordId: 'd1', runId: 'run_x',
+      nodeId: 'approve_step', config: { approvers: [{ type: 'user', value: 'u1' }] } as any,
+    }, SYSTEM_CTX);
+    // `openNodeRequest` requires a run, so the only way a stored row names none
+    // is the one the `if (!runId)` guards are written for: a legacy or
+    // externally-created request that no flow node ever owned. Model it here.
+    data.tables.get('sys_approval_request')!
+      .find((r: any) => r.id === (opened as any).id).flow_run_id = null;
+
+    const out = await standalone.decide((opened as any).id, { decision: 'approve', actorId: 'u1' }, SYSTEM_CTX);
+    expect(out.finalized).toBe(true);
+    expect(out.resumed).toBe(false);
+    expect(out.resumeError, 'nothing was parked — nothing to report').toBeUndefined();
+    expect(logs, `no run named, so no degradation: ${JSON.stringify(logs)}`).toEqual([]);
   });
 });

--- a/packages/plugins/plugin-approvals/src/approval-service.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.ts
@@ -1967,6 +1967,58 @@ export class ApprovalService implements IApprovalService {
   }
 
   /**
+   * The run named by a recorded outcome cannot be advanced at all, because no
+   * automation engine in THIS process implements the capability it needs
+   * (#4420). Returns the reason, or `undefined` when the capability is there
+   * and the caller should proceed.
+   *
+   * **Why this is not simply "not our problem".** Approvals is legitimately
+   * usable with no engine attached, and {@link assertRunResumable} deliberately
+   * stays out of the way for that reason. But "no engine is attached" and "no
+   * run is waiting" are different facts, and only the second is benign: a
+   * `flow_run_id` on the row is the request's OWN declaration that a run is
+   * parked on this decision. Deciding it in a process that cannot resume it
+   * reproduces #4420's reported half-state exactly — a durable decision, a
+   * mirrored status field frozen mid-workflow, a flow parked forever — while
+   * the caller is answered HTTP 200. The engine-less composition is the one
+   * path the #4420 fix left silent, because every guard it added hangs off an
+   * engine that is not there.
+   *
+   * **So the outcome stands, but it is never silent.** Rolling the decision
+   * back is not on the table (a human really did decide, and the row is
+   * already durable), and refusing every such call would break the standalone
+   * compositions the pre-flight protects. What is owed is the report: `error`
+   * level per AGENTS.md's durability rule — persisted state and runtime state
+   * disagree and nothing looks broken from the outside — plus a `resumeError`
+   * on the response, so `resumed: false` carries its reason instead of leaving
+   * the caller to guess whether a resume was even attempted.
+   *
+   * Reuses the registered `RESUME_FAILED` code (ADR-0112 ledger) and
+   * {@link serviceResume}'s message shape: the fact being reported — an
+   * outcome recorded whose run did not advance — is the same one, and this
+   * needs no new vocabulary of its own.
+   */
+  private missingRunCapability(
+    runId: string,
+    requestId: string,
+    what: string,
+    capability: 'resume' | 'cancelRun',
+  ): string | undefined {
+    const fn = capability === 'resume' ? this.automation?.resume : this.automation?.cancelRun;
+    if (typeof fn === 'function') return undefined;
+    this.logger?.error?.(
+      '[approvals] no automation engine to advance the recorded outcome — the run is stranded',
+      { request: requestId, run: runId, outcome: what, capability },
+    );
+    return (
+      `${capability} of run '${runId}' failed [RESUME_FAILED]: ${what} was recorded on request ${requestId}, ` +
+      `but no automation engine in this process can ${capability} its flow run — the run stays parked and the ` +
+      `record's mirrored status will not advance. Compose the automation service in this host, or recall the ` +
+      `request to release the record.`
+    );
+  }
+
+  /**
    * Resume the run behind an outcome that has ALREADY been written down, and
    * fail loudly when it cannot be (#4420).
    *
@@ -1977,7 +2029,10 @@ export class ApprovalService implements IApprovalService {
    * everything it catches never reaches a write.
    *
    * `RESUME_IN_PROGRESS` is the exception — a concurrent resume is already
-   * advancing the run, so the outcome stands and only `resumed` is false.
+   * advancing the run, so the outcome stands and only `resumed` is false. So
+   * is a composition with no engine at all ({@link missingRunCapability}),
+   * which cannot throw without breaking every standalone deployment — it
+   * reports through `resumeError` instead.
    *
    * @param what - how the recorded outcome reads in the error, e.g.
    *   `"the approve decision"`.
@@ -1988,6 +2043,8 @@ export class ApprovalService implements IApprovalService {
     what: string,
     signal: { output?: Record<string, unknown>; branchLabel?: string },
   ): Promise<{ resumed: boolean; resumeError?: string }> {
+    const missing = this.missingRunCapability(runId, requestId, what, 'resume');
+    if (missing) return { resumed: false, resumeError: missing };
     try {
       await this.serviceResume(runId, signal);
       return { resumed: true };
@@ -2032,7 +2089,11 @@ export class ApprovalService implements IApprovalService {
 
     let resumed = false;
     let resumeError: string | undefined;
-    if (result.finalized && result.runId && typeof this.automation?.resume === 'function') {
+    // No `typeof this.automation?.resume === 'function'` guard here (#4420):
+    // skipping the call when no engine is attached is precisely how a decision
+    // against a parked run returned 200 / `resumed: false` with nothing logged.
+    // `resumeRecordedOutcome` reports that composition gap instead of hiding it.
+    if (result.finalized && result.runId) {
       const branchLabel = result.decision === 'approve'
         ? APPROVAL_BRANCH_LABELS.approve
         : APPROVAL_BRANCH_LABELS.reject;
@@ -2134,28 +2195,34 @@ export class ApprovalService implements IApprovalService {
     if (inReviseWindow) {
       // ADR-0044: the run is paused at the revise wait node, which has no
       // reject out-edge to resume down — terminally cancel it instead.
-      if (runId && typeof this.automation?.cancelRun === 'function') {
+      if (runId) {
+        resumeError = this.missingRunCapability(runId, requestId, 'the recall', 'cancelRun');
+        if (!resumeError) {
+          try {
+            await this.automation!.cancelRun!(runId, `approval request ${requestId} recalled during revision`);
+          } catch (err: any) {
+            resumeError = err?.message ?? String(err);
+            this.logger?.error?.('[approvals] cancelRun after revise-window recall failed — the run may be stranded', {
+              request: requestId, run: runId, error: resumeError,
+            });
+          }
+        }
+      }
+    } else if (runId) {
+      resumeError = this.missingRunCapability(runId, requestId, 'the recall', 'resume');
+      if (!resumeError) {
         try {
-          await this.automation.cancelRun(runId, `approval request ${requestId} recalled during revision`);
+          await this.serviceResume(runId, {
+            branchLabel: APPROVAL_BRANCH_LABELS.reject,
+            output: { decision: 'recall', requestId },
+          });
+          resumed = true;
         } catch (err: any) {
           resumeError = err?.message ?? String(err);
-          this.logger?.error?.('[approvals] cancelRun after revise-window recall failed — the run may be stranded', {
+          this.logger?.error?.('[approvals] resume after recall failed — the run may be stranded', {
             request: requestId, run: runId, error: resumeError,
           });
         }
-      }
-    } else if (runId && typeof this.automation?.resume === 'function') {
-      try {
-        await this.serviceResume(runId, {
-          branchLabel: APPROVAL_BRANCH_LABELS.reject,
-          output: { decision: 'recall', requestId },
-        });
-        resumed = true;
-      } catch (err: any) {
-        resumeError = err?.message ?? String(err);
-        this.logger?.error?.('[approvals] resume after recall failed — the run may be stranded', {
-          request: requestId, run: runId, error: resumeError,
-        });
       }
     }
 
@@ -2240,7 +2307,7 @@ export class ApprovalService implements IApprovalService {
       }
       let resumed = false;
       let resumeError: string | undefined;
-      if (runId && typeof this.automation?.resume === 'function') {
+      if (runId) {
         const outcome = await this.resumeRecordedOutcome(
           runId, requestId, 'the auto-rejection',
           {
@@ -2281,7 +2348,7 @@ export class ApprovalService implements IApprovalService {
 
     let resumed = false;
     let resumeError: string | undefined;
-    if (runId && typeof this.automation?.resume === 'function') {
+    if (runId) {
       const outcome = await this.resumeRecordedOutcome(
         runId, requestId, 'the send-back',
         {
@@ -2370,7 +2437,7 @@ export class ApprovalService implements IApprovalService {
 
     let resumed = false;
     let resumeError: string | undefined;
-    if (runId && typeof this.automation?.resume === 'function') {
+    if (runId) {
       const outcome = await this.resumeRecordedOutcome(
         runId, requestId, 'the resubmit',
         {


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4420

## ⚠️ 先说结论:issue 的前提已过期,#4420 的两条「期望」在当前 `origin/main` 上**都已交付**

派发词要求先诊断再动手。诊断结果是:issue 描述的 rc.1 现场**已经被修好了**,修复随 `17.0.0-rc.2` 出货(changeset `2826d1e`),并非「#1518 未落地」。实测证据(全部跑在 `origin/main` = `6bc93dc`,未含本 PR 改动):

| 派发词的诊断问题 | 实际答案 |
|:---|:---|
| 谁给引擎接 durable store?默认宿主路径接了吗? | `AutomationServicePlugin.start()`(`plugin.ts:596`)。默认 `suspendedRunStore: 'auto'` 即启用,**默认路径已接线** |
| 谁注册 `sys_automation_run` 让 schema sync 建表? | 同插件 `init()` 向 `manifest` 注册(`registerRunObject`),`start()` 补注册一次;并声明了 `optionalDependencies: ['com.objectstack.engine.objectql']` 保证顺序 |
| 复现「新引擎实例 B 收不到决策」 | **已有回归测试**且通过:`approval-restart-resume.test.ts` |

`resume(runId)` 找不到 run 也**早已响亮**:引擎返回 `RUN_NOT_FOUND` / `STORE_UNAVAILABLE`,`serviceResume` 把 `success:false` 抛成异常,`assertRunResumable` 在**任何写入之前**预检,REST 映射 409 / 503 / 500。

```
✓ approves a run that paused in a previous process, and the flow advances
✓ refuses the decision, writing nothing, when the run did not survive the restart
✓ names the stranded run when the resume fails after the decision was written
✓ treats a concurrent duplicate resume as benign, not as a failure
✓ does not block a decision when the suspended-run store is merely unreachable
Tests  48 passed (service-automation 持久化四套件) / 403 passed (plugin-approvals 全量)
```

**所以 #4420 主体无需重做。** 维护者可据此确认是否直接关单。

---

## 本 PR 修的是:那次修复唯一没能覆盖到的一条静默路径

#4420 的修复加的每一道闸门 —— `assertRunResumable` 预检、`RESUME_TARGET_LOST` 拒绝、`RESUME_FAILED` 抛错 —— **全都挂在 automation 引擎上**。而在一个**没有挂引擎**的进程里,它们被包在同一个条件里一起跳过了:

```ts
if (result.finalized && result.runId && typeof this.automation?.resume === 'function') {
```

于是:决策落库、镜像状态字段推进、接口返回 **HTTP 200 + `resumed: false`,且零日志**。这正是 #4420 报告的症状本身 —— 只是发生在它的修复看不见的那个 composition 里。

**可达路径与原 bug 同源**:流程在有 automation 的进程里停在 `approval` 节点,决策却到达一个没有 automation 的进程(插件 init 失败,或跨版本重新 composition)。此时请求行仍带着 `flow_run_id` —— 那是这行数据**自己声明**有一个 run 正停在这个决策上。

原有测试其实把这个行为**钉住**了(`leaves a composition with no automation engine exactly as it was`),理由是「这里没有任何东西能 resume 它,预检不该无中生有地造一个失败」。该理由混淆了两件事:**「没挂引擎」和「没有 run 在等」是不同的事实,只有后者是良性的**。

### 改动

决策**依然成立**,`finalized` / `resumed` 对所有既有调用方**保持不变** —— 决策落库时人确实已经批了,回滚不在选项内;而对每个这类调用都报错会打断预检刻意保护的 standalone composition。变的只是「不再静默」:

- **`error` 级日志** —— 依 AGENTS.md 的 durability 规则:持久化状态与运行时状态不一致,而系统从外面看毫无异样,正是该规则针对的那一类;
- **响应带 `resumeError`** —— 让 `resumed: false` 带着原因和被搁浅的 run id 到达调用方,而不是让对方猜「到底试没试过 resume」。

复用**已注册**的 `RESUME_FAILED` 码(ADR-0112 ledger)与既有 resume 消息形状,不新造词汇 —— 因为要报告的事实是同一个:一个已记录的结果,其 run 没有推进。

覆盖全部 5 个 recorded-outcome resume 点:`decide`、改版次数超限的自动拒绝、`sendBack`、`resubmit`,以及 `recall` 的两个分支(revise 窗口那支用的是 `cancelRun` 而非 `resume`)。

**没有过度报告**:不带 run 的请求保持安静 —— 它上面没有东西被搁浅,在那里报 `error` 正是会训练运维忽略 `error` 的镜像错误,而那恰恰是 #4420 当初那条 `warn` 没人读的原因。

## 测试

```
pnpm --filter @objectstack/plugin-approvals test        → 18 files, 403 passed
pnpm --filter @objectstack/plugin-approvals typecheck   → tsc --noEmit, 0 error
pnpm --filter @objectstack/service-automation test      → 55 files, 662 passed
pnpm check:durability-log-level      → 8 seam(s), all loud or rethrowing ✓
pnpm check:startup-registry-verdict  → 47 seam(s), none recording a verdict ✓
pnpm check:error-code-casing         → 2722 files, no lowercase codes ✓
```

新增 2 条回归测试(替换那条把静默钉住的旧测试):
- `still records the decision with no automation engine attached — but never silently`
- `reports the same gap on a request that names no run — by staying quiet`

## 约束遵守

`packages/spec/**` 零改动(故复用已注册的 `RESUME_FAILED`,不新增 ledger 码)、`metadata-protocol/src/protocol.ts` 零改动、`content/docs/releases/` 零改动。改动面仅 `packages/plugins/plugin-approvals/src/**` + 一个 changeset。

## 待维护者定夺(见下)

本 PR 取的是「决策保留 + 响亮报告」。另一种读法是「**拒绝**这个决策」(视为坏 composition,返回 409)。后者语义更强,但会翻转上述被刻意钉住的设计决定,且可能打断合法的 standalone 部署 —— 故未擅自采用,列为 open question。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrmBxj8rK2uGCnh9aipjwX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrmBxj8rK2uGCnh9aipjwX)_