### PR TITLE
feat(lint): 判红「声明了但运行期只会跳过」的 sharing-rule condition (#4698)

### DIFF
--- a/.changeset/sharing-rule-unlowerable-condition-gate.md
+++ b/.changeset/sharing-rule-unlowerable-condition-gate.md
@@ -1,0 +1,58 @@
+---
+"@objectstack/lint": minor
+---
+
+feat(lint): reject a sharing-rule condition the runtime can only skip (#4698)
+
+#4698 reported the same failure shape three times in one app in one day: a key
+that is authored, is schema-valid, reads as meaningful — and is never consumed
+by the runtime. Every check verifies that what is declared is *well-formed*,
+never that it is *read*. The issue's third measured instance is a sharing rule
+whose CEL `condition` uses `has(...)`: the seeder cannot lower it, skips the
+rule, and the only signal is one WARN line at boot. The rule exists in
+metadata, is absent from `sys_sharing_rule`, and grants nothing.
+
+**New rules, both `error`, on all three authoring commands:**
+
+- **`sharing-rule-unlowerable-condition`** — the condition is outside the
+  pushdown subset: a function call (`has(...)`, `size(...)`), arithmetic, a
+  ternary, or a cross-object path (`record.account.region`).
+- **`sharing-rule-runtime-variable-condition`** — the condition reads
+  `current_user.*`. Criteria sharing rules are materialised (one static
+  `criteria_json` per rule, from which grants are written), so there is no
+  "current user" at compile time. The fix is a different mechanism, not a
+  different spelling, which is why it has its own id.
+
+Fix each by rewriting the predicate inside the lowerable subset — `==` `!=`
+`>` `<` `>=` `<=`, `in`, `&&` `||` `!`, `== null` / `!= null`, and
+`startsWith` / `endsWith` / `contains` over single-column `record.<field>`
+paths (ADR-0058 D2). Two specific migrations: `has(record.x)` → `record.x !=
+null` (`has()` is correct in an object *validation* rule, which is
+interpreted, and wrong here, where the condition is compiled); and a related
+record's field → denormalise it onto this object (formula/rollup) and test
+that column, or share the related object instead. For per-user access, use an
+RLS policy (`rowLevelSecurity[].using`), where `current_user.*` *is* resolved.
+
+**Why this one surface and not "unread keys" in general.** "Is this key read?"
+is only a lint question when the answer is computable from the authored
+metadata alone, and usually it is not — a repo-wide grep for a reader is not
+evidence of absence, and a consumer may live in another package, another repo,
+or an uninstalled plugin. A sharing rule's `condition` is the case where the
+predicate is exact: its one runtime consumer
+(`bootstrapDeclaredSharingRules`) does exactly one thing with the key —
+`compileCelToFilter(condition, { variables: {} })` — and a condition that does
+not lower means the rule is skipped outright. So the lint calls that same
+compiler, from the same package, with the same options, instead of modelling
+the consumer; the verdict is identical to the seeder's by construction and is
+pinned in both directions by a test over a shared corpus.
+
+`error` rather than advisory, per the ADR-0078 claim `SharingRuleSchema`'s own
+docblock makes ("the whole authorable surface is enforced — nothing here
+validates and then silently does nothing"): there is no reading under which an
+unlowerable condition does what it says. It fails closed, which is why it was
+survivable, not why it was acceptable. Measured before shipping: every
+sharing-rule condition declared anywhere in this repo lowers cleanly, so the
+gate turns nothing red that works today.
+
+CEL *syntax* errors are deliberately left to `expression-invalid`, which
+already gates this same field with a message written about syntax.

--- a/packages/lint/src/authoring-rules.ts
+++ b/packages/lint/src/authoring-rules.ts
@@ -120,6 +120,7 @@ import { validateSeedStateMachine } from './validate-seed-state-machine.js';
 import { validateVisibilityPredicates } from './validate-visibility-predicates.js';
 import { validateSecurityPosture } from './validate-security-posture.js';
 import { validateOrgAxisRedLines } from './validate-org-axis-red-lines.js';
+import { validateSharingRuleEnforceability } from './validate-sharing-rule-enforceability.js';
 import { validateActionLocations } from './validate-action-locations.js';
 import { lintFlowPatterns } from './lint-flow-patterns.js';
 import { lintLivenessProperties } from './lint-liveness-properties.js';
@@ -794,6 +795,31 @@ export const AUTHORING_RULES: readonly AuthoringRule[] = [
     surfaces: CLI_ONLY,
     surfaceReason: RUNTIME_NEEDS_FULL_SNAPSHOT,
     run: (stack) => validateOrgAxisRedLines(stack),
+  },
+  // #4698 — the "declared but never read" gate, for the one surface where the
+  // predicate is EXACT rather than inferred. A sharing rule's `condition` has a
+  // single runtime consumer (`bootstrapDeclaredSharingRules`) whose only use of
+  // the key is `compileCelToFilter(condition, { variables: {} })`; a condition
+  // that does not lower means the rule is SKIPPED at boot, so the grant is
+  // declared and does not exist. The lint calls that same compiler, from the
+  // same package, with the same options — the verdict cannot drift from the
+  // consumer's. Gating for the ADR-0078 reason `SharingRuleSchema`'s own
+  // docblock states: the whole authorable surface is enforced, and this was the
+  // one field where that sentence was not yet true.
+  {
+    name: 'validateSharingRuleEnforceability',
+    tier: 'gating',
+    input: 'parsed',
+    commands: ALL,
+    source: 'packages/lint/src/validate-sharing-rule-enforceability.ts',
+    surfaces: CLI_ONLY,
+    surfaceReason:
+      'P2 (#4463): a sharing rule is not a `flow`, and P1 gates `flow` alone. The rule itself is '
+      + 'snapshot-safe — it reads ONLY `stack.sharingRules[].condition` and needs no other collection — '
+      + 'so widening it here is a `runtimeTypes: [\'sharing_rule\']` edit once the gate accepts that type, '
+      + 'not new wiring. Recorded as pending rather than done, because a rule that has never run at a '
+      + 'door should not claim it.',
+    run: (stack) => validateSharingRuleEnforceability(stack),
   },
 ];
 

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -195,6 +195,20 @@ export {
 } from './validate-org-axis-red-lines.js';
 export type { OrgAxisFinding, OrgAxisSeverity } from './validate-org-axis-red-lines.js';
 
+// #4698 — "a key that nothing reads should not validate clean", for the one
+// surface where "is it read?" is decidable: a sharing rule's `condition` is
+// read ONLY through `compileCelToFilter`, so the lint calls that same compiler
+// rather than modelling the consumer.
+export {
+  validateSharingRuleEnforceability,
+  SHARING_RULE_UNLOWERABLE_CONDITION,
+  SHARING_RULE_RUNTIME_VARIABLE_CONDITION,
+} from './validate-sharing-rule-enforceability.js';
+export type {
+  SharingRuleEnforceabilityFinding,
+  SharingRuleEnforceabilitySeverity,
+} from './validate-sharing-rule-enforceability.js';
+
 export {
   validateDashboardActionRefs,
   DASHBOARD_ACTION_TARGET_UNDEFINED,

--- a/packages/lint/src/validate-sharing-rule-enforceability.test.ts
+++ b/packages/lint/src/validate-sharing-rule-enforceability.test.ts
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { compileCelToFilter } from '@objectstack/formula';
+
+import {
+  validateSharingRuleEnforceability,
+  SHARING_RULE_UNLOWERABLE_CONDITION,
+  SHARING_RULE_RUNTIME_VARIABLE_CONDITION,
+} from './validate-sharing-rule-enforceability.js';
+import { AUTHORING_RULES, runAuthoringRules } from './authoring-rules.js';
+
+const ids = (stack: unknown) => validateSharingRuleEnforceability(stack).map((f) => f.rule);
+
+/** A complete, spec-shaped sharing rule with the condition swapped in. */
+const ruleWith = (condition: unknown) => ({
+  sharingRules: [
+    {
+      name: 'high_value_opps',
+      type: 'criteria',
+      object: 'opportunity',
+      accessLevel: 'read',
+      sharedWith: { type: 'team', value: 'deal_desk' },
+      condition,
+    },
+  ],
+});
+
+// ── Red: declared, schema-valid, and never read ──────────────────────
+//
+// Every source below parses as CEL and passes `SharingRuleSchema`. The seeder
+// still drops the rule on the floor, which is the whole defect (#4698).
+
+describe('validateSharingRuleEnforceability — the declared-but-never-read cases go RED', () => {
+  it('flags `has(...)` — the measured instance from the issue (hotcrm#621/#633)', () => {
+    const findings = validateSharingRuleEnforceability(
+      ruleWith("has(record.owner_id) && record.stage == 'closed_won'"),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      severity: 'error',
+      rule: SHARING_RULE_UNLOWERABLE_CONDITION,
+      // The declaration site is named, not just the rule.
+      path: 'sharingRules[0].condition',
+      where: 'sharing rule "high_value_opps" on object "opportunity"',
+    });
+    // It must say what actually happens at boot, not merely "unsupported".
+    expect(findings[0].message).toMatch(/SKIPS the rule at boot/);
+    expect(findings[0].message).toMatch(/never written to `sys_sharing_rule`/);
+    // …and prescribe the fix that works on THIS surface.
+    expect(findings[0].hint).toMatch(/record\.x != null/);
+    expect(findings[0].hint).toMatch(/INTERPRETED/);
+  });
+
+  it.each([
+    ['a bare function call', 'size(record.tags) > 0'],
+    ['arithmetic', 'record.amount * 2 > 100'],
+    ['a cross-object path', "record.account.region == 'EU'"],
+    ['a ternary', "record.stage == 'won' ? true : false"],
+  ])('flags %s', (_label, source) => {
+    expect(ids(ruleWith(source))).toEqual([SHARING_RULE_UNLOWERABLE_CONDITION]);
+  });
+
+  it('gives `current_user.*` its own id — the fix is a different mechanism, not a respelling', () => {
+    const findings = validateSharingRuleEnforceability(ruleWith('record.owner_id == current_user.id'));
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      severity: 'error',
+      rule: SHARING_RULE_RUNTIME_VARIABLE_CONDITION,
+      path: 'sharingRules[0].condition',
+    });
+    expect(findings[0].message).toMatch(/current_user\.id/);
+    // Points at the surface where `current_user.*` IS resolved.
+    expect(findings[0].hint).toMatch(/rowLevelSecurity\[\]\.using/);
+  });
+
+  it('reports the parsed tier identically — the envelope `ExpressionInputSchema` produces', () => {
+    expect(ids(ruleWith({ dialect: 'cel', source: 'size(record.tags) > 0' })))
+      .toEqual([SHARING_RULE_UNLOWERABLE_CONDITION]);
+  });
+
+  it('names each offending rule separately, with its own index', () => {
+    const findings = validateSharingRuleEnforceability({
+      sharingRules: [
+        { name: 'ok', object: 'a', condition: "record.stage == 'won'" },
+        { name: 'fn', object: 'b', condition: 'has(record.x)' },
+        { name: 'var', object: 'c', condition: 'record.owner == current_user.id' },
+      ],
+    });
+    expect(findings.map((f) => [f.rule, f.path])).toEqual([
+      [SHARING_RULE_UNLOWERABLE_CONDITION, 'sharingRules[1].condition'],
+      [SHARING_RULE_RUNTIME_VARIABLE_CONDITION, 'sharingRules[2].condition'],
+    ]);
+  });
+});
+
+// ── Green: conditions that really are read ───────────────────────────
+//
+// A false positive here is worse than the gap the rule closes: it rejects
+// security metadata that enforces correctly today and hands the author a
+// "correction" that would break it.
+
+describe('validateSharingRuleEnforceability — conditions the runtime DOES read stay green', () => {
+  it.each([
+    ["record.health == 'red'"],
+    ["record.health == 'red' && record.budget > 100000"],
+    ['record.done == false'],
+    ["record.stage in ['closed_won', 'closed_lost']"],
+    ['record.closed_at == null'],
+    ["record.name.startsWith('ACME')"],
+    ["!(record.stage in ['draft']) || record.amount >= 1000"],
+  ])('accepts %s', (source) => {
+    expect(validateSharingRuleEnforceability(ruleWith(source))).toEqual([]);
+  });
+
+  it('accepts every sharing-rule condition the bundled examples declare', () => {
+    // Lifted verbatim from examples/app-showcase/src/security/sharing-rules.ts
+    // and examples/app-crm. The gate must not turn shipped apps red.
+    const shipped = [
+      "record.health == 'red'",
+      "record.health == 'red' && record.budget > 100000",
+      "record.status == 'new'",
+      'record.done == false',
+    ];
+    for (const source of shipped) {
+      expect(validateSharingRuleEnforceability(ruleWith(source))).toEqual([]);
+    }
+  });
+
+  it('leaves CEL SYNTAX errors to validateStackExpressions — no double report', () => {
+    // Parses nowhere, but this rule stays silent: `expression-invalid` already
+    // gates the same field with a message written about syntax.
+    expect(compileCelToFilter('record.stage ==', { variables: {} })).toMatchObject({ reason: 'parse-error' });
+    expect(validateSharingRuleEnforceability(ruleWith('record.stage =='))).toEqual([]);
+  });
+
+  it('ignores shapes Zod owns rather than inventing a second complaint', () => {
+    expect(ids(ruleWith(undefined))).toEqual([]);
+    expect(ids(ruleWith(''))).toEqual([]);
+    expect(ids(ruleWith('   '))).toEqual([]);
+    expect(ids(ruleWith(42))).toEqual([]);
+    expect(ids(ruleWith({ dialect: 'cel' }))).toEqual([]);
+  });
+
+  it('is a no-op on a stack that declares no sharing rules', () => {
+    expect(validateSharingRuleEnforceability({})).toEqual([]);
+    expect(validateSharingRuleEnforceability(undefined)).toEqual([]);
+    expect(validateSharingRuleEnforceability({ sharingRules: [] })).toEqual([]);
+  });
+
+  it('checks inactive rules too — the seeder compiles the condition regardless of `active`', () => {
+    // `bootstrapDeclaredSharingRules` carries `active` through to `defineRule`;
+    // it does not skip the compile. A rule that is off today and unlowerable is
+    // still a rule that will grant nothing the day someone switches it on.
+    expect(ids({ sharingRules: [{ name: 'r', object: 'o', active: false, condition: 'has(record.x)' }] }))
+      .toEqual([SHARING_RULE_UNLOWERABLE_CONDITION]);
+  });
+});
+
+// ── The predicate is the consumer's, not a model of it ───────────────
+
+describe('validateSharingRuleEnforceability — the verdict IS the seeder\'s verdict', () => {
+  const corpus = [
+    "record.health == 'red'",
+    "record.health == 'red' && record.budget > 100000",
+    'record.done == false',
+    "record.stage in ['a', 'b']",
+    'record.closed_at != null',
+    'has(record.owner_id)',
+    'size(record.tags) > 0',
+    'record.amount * 2 > 100',
+    "record.account.region == 'EU'",
+    'record.owner_id == current_user.id',
+  ];
+
+  it('agrees with `compileCelToFilter({ variables: {} })` on every source, in both directions', () => {
+    for (const source of corpus) {
+      // This is exactly the call `bootstrap-declared-sharing-rules.ts` makes.
+      const seederWouldSeed = compileCelToFilter(source, { variables: {} }).ok;
+      const lintIsClean = validateSharingRuleEnforceability(ruleWith(source)).length === 0;
+      expect({ source, lintIsClean }).toEqual({ source, lintIsClean: seederWouldSeed });
+    }
+  });
+
+  /**
+   * The "before" half of the proof, kept mechanical rather than asserted in
+   * prose. #4698's complaint is that the offending stack passes the WHOLE
+   * toolchain, so it is not enough to show the new rule goes red — it must also
+   * be shown that nothing else ever did. Running the full author-time registry
+   * over the fixture and demanding that every OTHER rule stays silent is that
+   * statement, and unlike a comment it keeps holding: if some future rule grows
+   * to cover this shape, this test fails and someone has to decide which of the
+   * two owns it, instead of the stack quietly acquiring a duplicate diagnostic.
+   */
+  it('no OTHER author-time rule sees this — which is exactly why the gate was missing', () => {
+    const offending = {
+      objects: [
+        {
+          name: 'opportunity',
+          label: 'Opportunity',
+          sharingModel: 'private',
+          fields: {
+            name: { type: 'text', label: 'Name' },
+            owner_id: { type: 'text', label: 'Owner' },
+            stage: { type: 'text', label: 'Stage' },
+          },
+        },
+      ],
+      sharingRules: [
+        {
+          name: 'closed_won_to_deal_desk',
+          type: 'criteria',
+          object: 'opportunity',
+          accessLevel: 'read',
+          sharedWith: { type: 'team', value: 'deal_desk' },
+          condition: "has(record.owner_id) && record.stage == 'closed_won'",
+        },
+      ],
+    };
+
+    const findings = runAuthoringRules('validate', { normalized: offending, parsed: offending });
+    expect(findings.map((f) => f.rule)).toEqual([SHARING_RULE_UNLOWERABLE_CONDITION]);
+
+    // And the fixture really did travel through every rule — a registry that
+    // silently stopped running would satisfy the assertion above vacuously.
+    expect(AUTHORING_RULES.filter((r) => r.commands.includes('validate')).length).toBeGreaterThan(20);
+  });
+
+  it('a match-all filter is unreachable from a lowering condition (so lint need not re-check it)', () => {
+    // The seeder's SECOND guard is `isMatchAllCriteria(f)`, which lives in
+    // plugin-sharing — a runtime `@objectstack/lint` must not import. This
+    // pins the claim in the module docblock that duplicating it would be dead
+    // code: every condition the compiler lowers yields a concrete predicate.
+    for (const source of corpus) {
+      const result = compileCelToFilter(source, { variables: {} });
+      if (!result.ok) continue;
+      expect(Object.keys(result.filter as Record<string, unknown>).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/lint/src/validate-sharing-rule-enforceability.ts
+++ b/packages/lint/src/validate-sharing-rule-enforceability.ts
@@ -1,0 +1,248 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #4698 — "declared but never read", made decidable for ONE surface.
+ *
+ * The issue behind this file reported three shapes that pass `os validate`,
+ * `os lint`, `tsc` and a full test suite while the runtime never reads them.
+ * The useful invariant it names is the ledger discipline's: **a key that
+ * nothing reads should not validate clean.** The hard part is not the
+ * sentiment, it is the PREDICATE — "is this key read?" is only a lint question
+ * when the answer is computable from the authored metadata alone. Most of the
+ * time it is not: a repo-wide grep for a reader is famously not evidence of
+ * absence (#4604), and a consumer can live in another package, another repo, or
+ * a plugin nobody has installed yet (#4914).
+ *
+ * A sharing rule's `condition` is the case where the predicate is EXACT, and
+ * that is the whole reason this rule exists and its neighbours are deferred:
+ *
+ *   The one runtime consumer of a stack-declared `sharingRules[].condition` is
+ *   `bootstrapDeclaredSharingRules` (plugin-sharing), and the ONLY thing it
+ *   does with the key is hand it to `compileCelToFilter(condition, { variables:
+ *   {} })`. A condition that does not lower is not degraded, not partially
+ *   applied and not deferred — the rule is SKIPPED (ADR-0049: never seeded as a
+ *   permissive match-all), so it never reaches `sys_sharing_rule` and grants
+ *   nothing at all. The only trace is one WARN line at boot.
+ *
+ * So this rule does not model the consumer, guess at it, or grep for it. It
+ * calls the consumer's own decision procedure, from the same package
+ * (`@objectstack/formula`), on the same input, with the same options. The
+ * verdict is bit-identical to the seeder's by construction — there is no
+ * heuristic to drift and no false positive that is not also a real skip.
+ *
+ * ## Why `error`
+ *
+ * `SharingRuleSchema`'s own docblock makes the claim this rule enforces: "The
+ * whole authorable surface is enforced — nothing here validates and then
+ * silently does nothing (ADR-0078)." Until now that sentence held for every
+ * part of the shape EXCEPT the one field carrying the author's intent. There is
+ * no reading under which an unlowerable condition does what it says: the grant
+ * does not exist. Per the severity bar `lint-flow-patterns.ts` states — gate
+ * when no reading of the metadata behaves as written — that is an `error`, not
+ * a warning. It fails closed (the recipient under-sees rather than over-sees),
+ * which is why it was survivable, not why it is acceptable.
+ *
+ * Measured before shipping: every sharing-rule condition and RLS predicate
+ * declared anywhere in this repo (examples, platform permission sets) lowers
+ * cleanly, so the gate turns nothing red that works today.
+ *
+ * ## The two ids, and why not one
+ *
+ * `compileCelToFilter` fails for three reasons; two of them are authoring
+ * mistakes with DIFFERENT fixes, so they get different ids rather than one id
+ * with a branchy message (allowlists and `--json` consumers key on the id):
+ *
+ *  - `unsupported` → {@link SHARING_RULE_UNLOWERABLE_CONDITION}. The shape is
+ *    outside the pushdown subset: a function call (`has(...)`, `size(...)`),
+ *    arithmetic, a ternary, or a cross-object path (`record.account.region`).
+ *    This is the issue's measured instance — an author following the guidance
+ *    that is correct for object VALIDATIONS (where `has()` is interpreted, not
+ *    lowered) writes silently inert security metadata.
+ *  - `unresolved-variable` → {@link SHARING_RULE_RUNTIME_VARIABLE_CONDITION}.
+ *    The condition reads `current_user.*`. Criteria sharing rules are
+ *    MATERIALIZED — the seeder compiles one static `criteria_json` per rule and
+ *    the evaluator writes `sys_record_share` grants from it — so there is no
+ *    "current user" at compile time and the compiler correctly refuses. The fix
+ *    is a different mechanism (RLS / an ownership-shaped grant), not a
+ *    different spelling, which is exactly why it earns its own id.
+ *  - `parse-error` → deliberately NOT reported here. CEL syntax is
+ *    `validateStackExpressions`' surface and it already gates this same field
+ *    (`stack.sharingRules[].condition`). Reporting it twice, in two
+ *    vocabularies, would make the second report noise — and the first one is
+ *    the better message, because it is written about syntax.
+ *
+ * ## What this rule deliberately does NOT do
+ *
+ *  - **It does not re-implement `isMatchAllCriteria`.** The seeder's second
+ *    guard (skip a condition that lowers to a filter constraining nothing)
+ *    lives in `plugin-sharing`, and `@objectstack/lint` never depends on a
+ *    runtime. Copying it here would fork the one definition of "this predicate
+ *    constrains nothing" that `rule-criteria.ts` exists to be. It is also
+ *    unreachable from this door: every AST the compiler lowers yields a
+ *    concrete field predicate, so a lowering CEL condition cannot produce a
+ *    match-all filter. `matchAllIsUnreachable` in the tests pins that claim
+ *    against the compiler rather than asserting it in prose.
+ *  - **It does not judge RLS `using` / `check`.** Same class, same compiler,
+ *    and ADR-0056 D4 explicitly asks for this gate — but the RLS decision
+ *    procedure is `isSupportedRlsExpression`, which first bridges the legacy
+ *    SQL-ish subset through `sqlPredicateToCel`, and BOTH live in
+ *    `plugin-security`. Judging RLS here means either importing a runtime
+ *    (forbidden) or copying the bridge (forking the predicate — the thing this
+ *    file's opening paragraph refuses to do). Hoisting `sqlPredicateToCel` into
+ *    `@objectstack/formula` first would make it exact; that is a spec/runtime
+ *    move, not a lint change, and is filed separately.
+ *  - **It does not look at flow / hook `condition`s.** Those are INTERPRETED by
+ *    the CEL engine, not lowered to a filter, so the whole language is in scope
+ *    there and non-pushdownability means nothing. Reusing this predicate on
+ *    them would reject working metadata — the false-positive direction that is
+ *    worse than the gap.
+ */
+
+import { compileCelToFilter } from '@objectstack/formula';
+
+/** A `condition` outside the pushdown subset — the rule is never seeded. */
+export const SHARING_RULE_UNLOWERABLE_CONDITION = 'sharing-rule-unlowerable-condition';
+/** A `condition` reading `current_user.*` — unresolvable when grants are materialized. */
+export const SHARING_RULE_RUNTIME_VARIABLE_CONDITION = 'sharing-rule-runtime-variable-condition';
+
+export type SharingRuleEnforceabilitySeverity = 'error' | 'warning';
+
+export interface SharingRuleEnforceabilityFinding {
+  severity: SharingRuleEnforceabilitySeverity;
+  /** Diagnostic rule id (`sharing-rule-*`). */
+  rule: string;
+  /** Human-readable location, e.g. `sharing rule "high_value_opps" on object "opportunity"`. */
+  where: string;
+  /** Config path, e.g. `sharingRules[2].condition`. */
+  path: string;
+  /** What is wrong. */
+  message: string;
+  /** How to fix it. */
+  hint: string;
+}
+
+type AnyRec = Record<string, unknown>;
+
+/** Coerce a collection (array or name-keyed map) to an array of records. */
+function asArray(v: unknown): AnyRec[] {
+  if (Array.isArray(v)) return v as AnyRec[];
+  if (v && typeof v === 'object') {
+    return Object.entries(v as AnyRec).map(([name, def]) => ({ name, ...(def as AnyRec) }));
+  }
+  return [];
+}
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+/**
+ * The `condition` value in the shape the compiler takes.
+ *
+ * Both authoring tiers reach this rule: `os lint` runs it on the NORMALIZED
+ * stack, where a bare string is still a bare string, while `os validate` /
+ * `os build` run it after `ExpressionInputSchema` has wrapped that string into
+ * `{ dialect: 'cel', source }`. `compileCelToFilter` accepts either, so the
+ * verdict does not depend on which tier asked — the property the wiring guard's
+ * `input: 'parsed'` entries all have to satisfy.
+ *
+ * Anything else (a number, an envelope with no `source`) is returned as `null`:
+ * the shape is Zod's to reject, and inventing a second complaint about it here
+ * would just be the double-report this file avoids for syntax.
+ */
+function toCompilerInput(condition: unknown): string | { source?: string } | null {
+  if (typeof condition === 'string') return condition.trim() ? condition : null;
+  if (condition && typeof condition === 'object') {
+    const source = (condition as AnyRec).source;
+    if (typeof source === 'string' && source.trim()) return { source };
+  }
+  return null;
+}
+
+/** What the author sees quoted back at them. */
+function sourceOf(condition: unknown): string {
+  const input = toCompilerInput(condition);
+  if (typeof input === 'string') return input;
+  return str(input?.source);
+}
+
+const PUSHDOWN_SUBSET =
+  'The lowerable subset is: `==` `!=` `>` `<` `>=` `<=`, `in`, `&&` `||` `!`, `== null` / `!= null`, ' +
+  'and the string methods `startsWith` / `endsWith` / `contains` — over SINGLE-column `record.<field>` ' +
+  'paths (ADR-0058 D2).';
+
+/**
+ * Gate stack-declared sharing rules on the ONE thing their runtime consumer
+ * does with `condition`: lower it to a `criteria_json` filter.
+ *
+ * Pure `(stack) => Finding[]`; tolerates the normalized and the parsed tier.
+ */
+export function validateSharingRuleEnforceability(stack: unknown): SharingRuleEnforceabilityFinding[] {
+  const findings: SharingRuleEnforceabilityFinding[] = [];
+  const cfg = (stack ?? {}) as AnyRec;
+
+  asArray(cfg.sharingRules).forEach((rule, index) => {
+    const input = toCompilerInput(rule.condition);
+    if (input === null) return;
+
+    // The seeder's exact call: `compileCelToFilter(r.condition, { variables: {} })`
+    // in `bootstrap-declared-sharing-rules.ts`. Same function, same options —
+    // so `ok === false` here means "this rule will be skipped at boot", not
+    // "this rule looks suspicious".
+    const result = compileCelToFilter(input, { variables: {} });
+    if (result.ok) return;
+    // Syntax belongs to `validateStackExpressions`, which already gates this
+    // same field with a message written about syntax.
+    if (result.reason === 'parse-error') return;
+
+    const name = str(rule.name) || String(index);
+    const object = str(rule.object);
+    const where = `sharing rule "${name}"${object ? ` on object "${object}"` : ''}`;
+    const path = `sharingRules[${index}].condition`;
+    const source = sourceOf(rule.condition);
+    const skipped =
+      'so `bootstrapDeclaredSharingRules` SKIPS the rule at boot: it is never written to ' +
+      '`sys_sharing_rule`, no `sys_record_share` grant is ever materialised, and the only signal is one ' +
+      'WARN line in the boot log. The rule is declared and grants nothing (ADR-0049: an unlowerable ' +
+      'condition is never seeded as a permissive match-all).';
+
+    if (result.reason === 'unresolved-variable') {
+      findings.push({
+        severity: 'error',
+        rule: SHARING_RULE_RUNTIME_VARIABLE_CONDITION,
+        where,
+        path,
+        message:
+          `Sharing-rule condition \`${source}\` reads a runtime variable (${result.detail}), ` + skipped,
+        hint:
+          'A criteria sharing rule is MATERIALISED: the seeder compiles ONE static `criteria_json` per ' +
+          'rule and the evaluator writes `sys_record_share` rows from it, so there is no "current user" ' +
+          'for the condition to read. Express per-user access with the mechanism that runs per request ' +
+          'instead — an RLS policy on a permission set (`rowLevelSecurity[].using`, where ' +
+          '`current_user.*` IS resolved), or the record-ownership path. Keep this rule for the part of ' +
+          'the predicate that is a property of the RECORD (e.g. `record.stage == \'closed_won\'`) and ' +
+          'name the audience through `sharedWith`.',
+      });
+      return;
+    }
+
+    findings.push({
+      severity: 'error',
+      rule: SHARING_RULE_UNLOWERABLE_CONDITION,
+      where,
+      path,
+      message:
+        `Sharing-rule condition \`${source}\` is outside the pushdown subset the runtime can compile ` +
+        `(${result.detail}), ` + skipped,
+      hint:
+        'Rewrite the predicate inside the lowerable subset. ' + PUSHDOWN_SUBSET + ' Two traps in ' +
+        'particular: (1) `has(record.x)` is correct in an object VALIDATION rule, which is INTERPRETED, ' +
+        'and wrong here, where the condition is COMPILED — write the null test as `record.x != null`; ' +
+        '(2) a related-record path (`record.account.region`) is a join, which the compiler refuses by ' +
+        'design (ADR-0055) — denormalise the value onto this object (a formula/rollup field) and test ' +
+        'that column, or share the related object instead.',
+    });
+  });
+
+  return findings;
+}


### PR DESCRIPTION
Fixes #4698

范围已由 PM 收窄:**只做 `packages/lint` 内可判定的部分**。tenant-scoped unique-index 那条落在 objectql/driver-sql,不在本 PR(核实结论见下)。

## 判据:为什么是这一面,而不是「未读键」通用检查

议题给的不变式很好 —— *a key that nothing reads should not validate clean* —— 难的不是这句话,是**谓词**。「这个键被读了吗」只有在**消费面的决策过程拿得到手**时才是 lint 能回答的问题;多数时候拿不到:仓内 grep 找不到 reader 不构成没有消费者的证据(#4604 登记里那条方法学),消费者还可能住在另一个包、另一个仓,或者一个还没人装的插件里(#4914 的 hot-reload 案例)。

sharing rule 的 `condition` 是**判据精确**的那一例,这也是它入选、邻居被推迟的全部理由:

> stack 声明的 `sharingRules[].condition` 的唯一运行期消费者是 `bootstrapDeclaredSharingRules`(plugin-sharing),而它对这个键做的**唯一一件事**是 `compileCelToFilter(condition, { variables: {} })`。降不下来的 condition 不是被降级、不是被部分应用、也不是被延后 —— 整条规则被 **SKIP**(ADR-0049:绝不当作 match-all 种下去),永远进不了 `sys_sharing_rule`,一条 `sys_record_share` 都不会物化,现场只有启动日志里一行 WARN。

所以这条规则不建模消费者、不猜、不 grep。它**调用消费者自己的决策过程**,同一个包(`@objectstack/formula`)、同一个输入、同一组 options。判定与 seeder 逐位一致 —— 没有会漂移的启发式,也没有「误报但不是真跳过」的可能。

## 两条 rule id

| id | reason | 形状 | 修法 |
|---|---|---|---|
| `sharing-rule-unlowerable-condition` | `unsupported` | 函数调用(`has(...)` / `size(...)`)、算术、三元、跨对象路径 | 改写进可下推子集 |
| `sharing-rule-runtime-variable-condition` | `unresolved-variable` | 读了 `current_user.*` | 换机制(RLS),不是换拼法 |

分成两个 id 而不是一个 id 两条文案:两者**成因不同、修法不同**,而 allowlist 和 `--json` 消费者是按 id 认的。

第一条是议题实测的那一例:作者照着**对象校验规则**(那里是解释执行)正确的写法写 `has(record.x)`,到了这里(编译执行)就成了静默失效的安全元数据。第二条是 criteria sharing rule 被**物化**的必然结果 —— seeder 编译出一份静态 `criteria_json`,evaluator 据此写 `sys_record_share`,编译时根本不存在「当前用户」。

`parse-error` 刻意**不报**:CEL 语法是 `validateStackExpressions` 的地盘,它已经在 gate 同一个字段,而且它的报错是专门写语法的,更好。一个字段,一句抱怨。

## 为什么是 `error`

`SharingRuleSchema` 自己的 docblock 立了这个 flag:

> The whole authorable surface is enforced — nothing here validates and then silently does nothing (ADR-0078).

在这条 PR 之前,这句话对这个 shape 的**每一部分都成立,唯独对承载作者意图的那一个字段不成立**。按 `lint-flow-patterns.ts` 顶部写明的严重度标准 —— 没有任何一种读法下元数据按它写的那样行为,就 gate —— 这是 `error`。它 fail closed(收件人少看见,而不是多看见),那是它能一直活着的原因,不是它可以接受的原因。

## 双向证明

**改后判红**,并点名声明位置(`path: sharingRules[0].condition`、`where: sharing rule "x" on object "y"`),报文说清楚启动时会发生什么(`SKIPS the rule at boot` / `never written to sys_sharing_rule`),而不只是「unsupported」。

**真实被读的必须保持绿**(误伤比漏报更糟)—— 覆盖比较运算、`in`、`&&`/`||`/`!`、`== null`、字符串方法,以及**从 `examples/app-showcase` 与 `app-crm` 原样抄来的每一条 shipped condition**。

**判据即消费者的判据**,不是它的模型 —— 一个共享语料上双向断言 lint 干净 ⟺ `compileCelToFilter({ variables: {} })` 成功:

```ts
const seederWouldSeed = compileCelToFilter(source, { variables: {} }).ok;
const lintIsClean = validateSharingRuleEnforceability(ruleWith(source)).length === 0;
expect({ source, lintIsClean }).toEqual({ source, lintIsClean: seederWouldSeed });
```

**「改前判绿」这一半做成机械的,不是散文**。议题的抱怨正是这个 stack 能过**整条**工具链,所以只证明新规则判红不够,还得证明**此前没有任何东西判过它**。测试里跑一遍完整的 authoring registry,要求除本规则外**每一条**都保持沉默:

```
✓ no OTHER author-time rule sees this — which is exactly why the gate was missing
```

这句断言会一直成立下去:哪天有别的规则长到覆盖这个 shape,这条测试就会红,逼人决定归谁管,而不是让 stack 悄悄多出一条重复诊断。

## 上线前实测:现存代码有没有被判红

**没有。** 用 `isPushdownableCel` / `compileCelToFilter` 扫过 `examples/` 与 `packages/` 里每一条 sharing-rule `condition` 和每一条 RLS `using` / `check` 字面量(85 条),**全部可下推**。新 gate 不会让任何今天能工作的东西变红。

## 三个实例在当前 main 上的复核

| # | 实例 | 现状 | 归属 |
|---|---|---|---|
| 1 | `decision` 节点 `config.condition`(单数) | **已被修掉** —— #4414 的 `flow-inert-node-condition` 已经在判它,`schemaless-node-config.zod.ts` 的 strict 拒收也带了逐键处方 | 无需动作 |
| 2 | tenant-scoped 对象上的表级 `{ fields: ['name'], unique: true }` | **仍然活着** —— `lintUniqueDeclarations` 只在**两种**声明同时出现时触发,只写表级形式的对象拿不到任何诊断 | 不在本 PR。落点在 `driver-sql` 的 `normalizeDeclaredIndex`;而且租户性是 kernel 在注册时注入的、不是作者写的,该规则自己的注释就说明了 lint 判不了 —— 归 engine 车道,请 PM 移交立单 |
| 3 | sharing-rule condition 里的 `has(...)` | **仍然活着** | **本 PR** |

## 刻意不做的三件事(已立单,没有猜)

- **不重实现 `isMatchAllCriteria`。** seeder 的第二道闸(降下来但什么都不约束的 filter)住在 `plugin-sharing`,而 `@objectstack/lint` 不依赖 runtime。抄一份就是把 `rule-criteria.ts` 存在的意义 —— 「什么都不约束」的**唯一**定义 —— fork 掉。而且这道门根本到不了:编译器能降的每一个 AST 都产出具体字段谓词。这个论断在测试里**对着编译器 pin**,不是写在注释里。
- **不判 RLS `using` / `check` → #4983。** 同一类、同一个编译器,ADR-0056 D4 还明确要求这道 gate —— 但 RLS 的决策过程 `isSupportedRlsExpression` 要先经 `sqlPredicateToCel` 桥接遗留 SQL-ish 子集,**两个都住在 `plugin-security`**。在 lint 里判它只有两条路:import 一个 runtime(禁止),或者抄一份桥接(fork 判据 —— 正是本文件开篇拒绝做的事)。顺带一提:`isSupportedRlsExpression` 除了自己的单测和一行一致性矩阵描述之外**没有任何消费者** —— 它自己就是一个 declared-but-never-read 实例,而它恰恰是为了修这个缺陷类写的。
- **不碰 flow / hook 的 `condition`。** 那些是被 CEL 引擎**解释执行**的,不降成 filter,整个语言都在范围内,「不可下推」在那里什么都不意味着。把这条谓词复用过去会否掉能正常工作的元数据 —— 误伤方向,比缺口更糟。

## 顺手发现,已立单不修(Prime Directive #10)

- **#4983** —— ADR-0056 D4 的 RLS authoring gate 从未接线(见上)。
- **#4984** —— `validateOrgAxisRedLines` 读的 sharing-rule 键是 spec 拒收的:它取 `rule.criteria ?? rule.filter` 和 `rule.sharedTo ?? rule.recipient`,而 `SharingRuleSchema` 是 `.strict()`、声明的是 `condition` / `sharedWith`,那四个只作为**被拒别名**存在。实测 `criteria` / `sharedTo` 都 `REJECTED: Invalid input`。所以 ADR-0105 D6 ① 在 sharing-rule criteria 这条路径上**对任何 spec-valid 的 stack 都不会触发**,② 同理。同一缺陷类,方向反过来:consumer 读了没人写的键。现有测试 fixture 用的正是这些废键,所以**测试绿而规则死** —— 立单里建议加一条 fixture 先过 `SharingRuleSchema.safeParse` 的元测试,免得再来一次。

## 验证

```
pnpm --filter @objectstack/lint test   → Test Files 55 passed · Tests 1007 passed
pnpm --filter @objectstack/lint typecheck → tsc --noEmit,干净
eslint(4 个改动文件)                  → 干净
pnpm --filter @objectstack/cli test    → Test Files 67 passed · Tests 588 passed
```

（CLI 那轮第一次跑出 31 个 collection 失败,是新 worktree 里工作区依赖没构建导致的假红 —— `Failed to resolve entry for package "@objectstack/types"`;`pnpm --filter '@objectstack/cli^...' build` 之后全绿。）

改动限于 `packages/lint`(+ 对 `@objectstack/formula` / `@objectstack/spec` 的只读消费),外加一个 changeset。已从合入 #4951、#4973 之后的最新 main 开分支,并在推送前 merge 了一次 `origin/main`(带进了 #4972 对 `validate-expressions` 的改动,同包重叠,故重跑了整套 lint 测试)。

---
_Generated by [Claude Code](https://claude.ai/code/session_018iARDqtrhQgz6fVHDeDkbQ)_