### PR TITLE
fix(lint): org-axis 红线读 spec 声明的 sharing-rule 键 —— ADR-0105 D6 两条门禁此前从不触发 (#4984)

### DIFF
--- a/.changeset/org-axis-red-lines-read-spec-keys.md
+++ b/.changeset/org-axis-red-lines-read-spec-keys.md
@@ -1,0 +1,43 @@
+---
+"@objectstack/lint": minor
+---
+
+fix(lint): `validateOrgAxisRedLines` reads the sharing-rule keys the spec declares — the ADR-0105 D6 red lines fired on nothing before (#4984)
+
+The two ADR-0105 D6 red lines are declared `error` and gate `os validate` /
+`os build` / `os lint`. On the sharing-rule path neither of them could fire.
+
+`validateOrgAxisRedLines` read `rule.criteria ?? rule.filter` and
+`rule.sharedTo ?? rule.recipient`. `SharingRuleSchema` is `.strict()` and its
+declared keys are `condition` and `sharedWith`; all four names it was reading
+exist only as **rejected aliases** in `sharingRuleUnknownKeyError`, the
+prescription attached to the refusal message. The rule runs on the post-parse
+stack (`input: 'parsed'`), so for every spec-valid stack those four properties
+were `undefined`, `JSON.stringify(undefined ?? '')` was `'""'`, and the
+`parent_organization_id` test was constantly false.
+
+**This is a behaviour change: the rule previously never triggered.** Both red
+lines are now live on the sharing-rule path:
+
+| Authored shape | Before | After |
+|:--|:--|:--|
+| `condition` reading `parent_organization_id` | passed | `error` `org-axis-permission-inheritance` at `sharingRules[i].condition` |
+| `sharedWith` reading `parent_organization_id` | passed | `error` `org-axis-permission-inheritance` at `sharingRules[i].sharedWith` |
+| `sharedWith: { type: 'business_unit' }` on a `tenancy.enabled: false` object | passed | `error` `org-axis-cross-org-bu-grant` at `sharingRules[i].sharedWith` |
+
+A stack that ships today keeps building unless it contains one of those three —
+the shapes D6 forbids and the gate was meant to have been refusing all along.
+The rejected aliases are deliberately **not** read: a rule spelling `criteria`
+or `sharedTo` is refused by the schema's own parse with the canonical key
+named, and a consumer must not tolerate what the producer's contract rejects.
+
+`condition` is an `ExpressionInput`, so all three of its shapes are scanned —
+the authored bare string, the parsed `{ dialect, source }` envelope, and the
+compiled `{ dialect, ast }` form.
+
+The rule's own tests were the reason this survived review: their fixtures used
+the same rejected aliases, so the suite was green while the gate was dead. Every
+sharing-rule fixture now goes through `SharingRuleSchema` before the lint sees
+it, and every object fixture through `ObjectSchema` — a fixture that drifts from
+the spec surface fails at the fixture instead of silently exercising a shape no
+author can write.

--- a/packages/lint/src/validate-org-axis-red-lines.test.ts
+++ b/packages/lint/src/validate-org-axis-red-lines.test.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
+import { ObjectSchema } from '@objectstack/spec/data';
+import { SharingRuleSchema, type SharingRuleInput } from '@objectstack/spec/security';
 
 import {
   validateOrgAxisRedLines,
@@ -9,6 +11,104 @@ import {
 } from './validate-org-axis-red-lines.js';
 
 const rules = (stack: unknown) => validateOrgAxisRedLines(stack).map((f) => f.rule);
+
+/**
+ * ── The fixture/schema drift guard (#4984) ──────────────────────────────────
+ *
+ * Every sharing-rule fixture below is built through `sharingRule()`, which
+ * PARSES it with the real `SharingRuleSchema` before the lint ever sees it. A
+ * fixture that drifts from the spec surface therefore fails here, loudly, at
+ * the fixture — not silently, by exercising a code path no author can reach.
+ *
+ * This guard exists because its absence cost a red line. The pre-#4984 fixtures
+ * spelled the rule's keys `criteria` and `sharedTo`; `SharingRuleSchema` is
+ * `.strict()` and knows those two only as REJECTED aliases of `condition` and
+ * `sharedWith`. The lint read the aliases too, so the tests passed against a
+ * shape no spec-valid stack can contain: green tests, dead gate. Renaming the
+ * keys alone would fix today's bug and leave tomorrow's drift undetectable —
+ * this helper is the structural half of the fix.
+ *
+ * It returns the PARSED rule, which is also what the registry feeds the lint
+ * (`input: 'parsed'`): `condition` arrives as the `{ dialect, source }`
+ * envelope, not the authored string.
+ */
+function sharingRule(input: SharingRuleInput): Record<string, unknown> {
+  const result = SharingRuleSchema.safeParse(input);
+  if (!result.success) {
+    const detail = result.error.issues
+      .map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`)
+      .join('; ');
+    throw new Error(
+      `sharing-rule fixture is not spec-valid — the lint would be tested against a shape ` +
+        `no author can write (#4984). Keys given: ${Object.keys(input as object).join(', ')}. ${detail}`,
+    );
+  }
+  return result.data as unknown as Record<string, unknown>;
+}
+
+/** Same guard for the object fixtures rule ② reads (`tenancy` / `systemFields`). */
+function objectFixture(input: Record<string, unknown>): Record<string, unknown> {
+  const result = ObjectSchema.safeParse({
+    label: 'Fixture',
+    fields: { name: { type: 'text', label: 'Name' } },
+    ...input,
+  });
+  if (!result.success) {
+    throw new Error(
+      `object fixture is not spec-valid (#4984): ` +
+        result.error.issues.map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`).join('; '),
+    );
+  }
+  return result.data as unknown as Record<string, unknown>;
+}
+
+/** A recipient that is beyond reproach, for fixtures whose subject is the predicate. */
+const HQ_TEAM = { type: 'team', value: 'hq' } as const;
+
+describe('sharing-rule fixtures track the spec surface (meta-test, #4984)', () => {
+  it('rejects a fixture spelled with the schema-rejected aliases', () => {
+    // The exact pre-#4984 fixture shapes. Each must now fail at the fixture.
+    expect(() =>
+      sharingRule({
+        name: 'hq_rollup',
+        object: 'work_order',
+        criteria: { parent_organization_id: 'org_hq' },
+      } as unknown as SharingRuleInput),
+    ).toThrow(/not spec-valid/);
+    expect(() =>
+      sharingRule({
+        name: 'plant_team',
+        object: 'work_order',
+        sharedTo: { type: 'business_unit', id: 'bu_plant_a' },
+      } as unknown as SharingRuleInput),
+    ).toThrow(/not spec-valid/);
+  });
+
+  it('rejects the rejected recipient alias `id` (the recipient shape is strict too)', () => {
+    expect(() =>
+      sharingRule({
+        name: 'r',
+        type: 'criteria',
+        object: 'work_order',
+        // `id` is an alias of `value`, rejected by `sharingRecipientUnknownKeyError`.
+        sharedWith: { type: 'business_unit', id: 'bu_plant_a' },
+        condition: 'true',
+      } as unknown as SharingRuleInput),
+    ).toThrow(/not spec-valid/);
+  });
+
+  it('accepts the canonical shape and hands the lint the PARSED envelope', () => {
+    const rule = sharingRule({
+      name: 'ok',
+      type: 'criteria',
+      object: 'work_order',
+      sharedWith: HQ_TEAM,
+      condition: "record.status == 'open'",
+    });
+    expect(rule.condition).toEqual({ dialect: 'cel', source: "record.status == 'open'" });
+    expect(rule.sharedWith).toEqual({ type: 'team', value: 'hq' });
+  });
+});
 
 describe('validateOrgAxisRedLines — ① no permission inheritance on the org axis', () => {
   it('flags an RLS `using` on a permission set that walks the org parent', () => {
@@ -62,14 +162,96 @@ describe('validateOrgAxisRedLines — ① no permission inheritance on the org a
     expect(findings[0].path).toBe('objects[0].rowLevelSecurity[0].using');
   });
 
-  it('flags a sharing rule whose criteria walk the org parent', () => {
+  it('flags a spec-valid sharing rule whose `condition` walks the org parent', () => {
+    // Exactly the stack #4984 showed passing `os validate` / `os build` / `os lint`.
+    const findings = validateOrgAxisRedLines({
+      sharingRules: [
+        sharingRule({
+          name: 'hq_sees_children',
+          type: 'criteria',
+          object: 'work_order',
+          sharedWith: HQ_TEAM,
+          condition: "record.parent_organization_id == 'org_hq'",
+        }),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      severity: 'error',
+      rule: ORG_AXIS_PERMISSION_INHERITANCE,
+      path: 'sharingRules[0].condition',
+    });
+    expect(findings[0].where).toBe('sharing rule "hq_sees_children"');
+    expect(findings[0].message).toMatch(/parent_organization_id/);
+  });
+
+  it('flags the pre-parse `condition` shape too (`os lint` runs on the normalized stack)', () => {
+    // Bare-string shorthand — what the author typed, before `ExpressionInputSchema`
+    // wraps it. The `parsed` tier falls back to `normalized` under `os lint`.
     expect(
       rules({
         sharingRules: [
-          { name: 'hq_rollup', object: 'work_order', criteria: { parent_organization_id: 'org_hq' } },
+          {
+            name: 'hq_sees_children',
+            type: 'criteria',
+            object: 'work_order',
+            sharedWith: { type: 'team', value: 'hq' },
+            condition: "record.parent_organization_id == 'org_hq'",
+          },
         ],
       }),
     ).toEqual([ORG_AXIS_PERMISSION_INHERITANCE]);
+  });
+
+  it('flags the compiled `{ dialect, ast }` condition shape', () => {
+    expect(
+      rules({
+        sharingRules: [
+          {
+            name: 'hq_sees_children',
+            object: 'work_order',
+            sharedWith: { type: 'team', value: 'hq' },
+            condition: {
+              dialect: 'cel',
+              ast: { type: 'binary', op: '==', left: { type: 'member', path: ['record', 'parent_organization_id'] } },
+            },
+          },
+        ],
+      }),
+    ).toEqual([ORG_AXIS_PERMISSION_INHERITANCE]);
+  });
+
+  it('flags a recipient that reaches for the org parent', () => {
+    const findings = validateOrgAxisRedLines({
+      sharingRules: [
+        sharingRule({
+          name: 'by_parent_org',
+          type: 'criteria',
+          object: 'work_order',
+          sharedWith: { type: 'team', value: 'parent_organization_id' },
+          condition: 'true',
+        }),
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].path).toBe('sharingRules[0].sharedWith');
+  });
+
+  it('does NOT resurrect the schema-rejected aliases — parse is that gate', () => {
+    // `criteria` / `filter` / `sharedTo` / `recipient` are rejected by
+    // `SharingRuleSchema` with a named fix-it. Reading them here as `??`
+    // fallbacks is what made this rule inert (#4984); a consumer must not
+    // tolerate what the producer's contract refuses (Prime Directive #12).
+    expect(
+      rules({
+        sharingRules: [
+          { name: 'a', object: 'work_order', criteria: { parent_organization_id: 'org_hq' } },
+          { name: 'b', object: 'work_order', filter: "record.parent_organization_id == 'x'" },
+          { name: 'c', object: 'work_order', sharedTo: { type: 'team', id: 'parent_organization_id' } },
+          { name: 'd', object: 'work_order', recipient: { type: 'team', id: 'parent_organization_id' } },
+        ],
+      }),
+    ).toEqual([]);
   });
 
   it('stays silent on membership-based and business-unit scoping (the sanctioned paths)', () => {
@@ -88,9 +270,15 @@ describe('validateOrgAxisRedLines — ① no permission inheritance on the org a
           },
         ],
         sharingRules: [
-          { name: 'plant_team', object: 'work_order', sharedTo: { type: 'business_unit', id: 'bu_plant_a' } },
+          sharingRule({
+            name: 'plant_team',
+            type: 'criteria',
+            object: 'work_order',
+            sharedWith: { type: 'business_unit', value: 'bu_plant_a' },
+            condition: "record.status == 'open'",
+          }),
         ],
-        objects: [{ name: 'work_order' }],
+        objects: [objectFixture({ name: 'work_order' })],
       }),
     ).toEqual([]);
   });
@@ -98,13 +286,21 @@ describe('validateOrgAxisRedLines — ① no permission inheritance on the org a
 
 describe('validateOrgAxisRedLines — ② business-unit trees stay org-internal', () => {
   const platformGlobalStack = (tenancy: unknown) => ({
-    objects: [{ name: 'material_catalog', tenancy }],
+    objects: [
+      objectFixture(
+        tenancy === undefined
+          ? { name: 'material_catalog' }
+          : { name: 'material_catalog', tenancy },
+      ),
+    ],
     sharingRules: [
-      {
+      sharingRule({
         name: 'catalog_to_plant',
+        type: 'criteria',
         object: 'material_catalog',
-        sharedTo: { type: 'business_unit', id: 'bu_plant_a' },
-      },
+        sharedWith: { type: 'business_unit', value: 'bu_plant_a' },
+        condition: 'true',
+      }),
     ],
   });
 
@@ -114,7 +310,7 @@ describe('validateOrgAxisRedLines — ② business-unit trees stay org-internal'
     expect(findings[0]).toMatchObject({
       severity: 'error',
       rule: ORG_AXIS_CROSS_ORG_BU_GRANT,
-      path: 'sharingRules[0].sharedTo',
+      path: 'sharingRules[0].sharedWith',
     });
     expect(findings[0].message).toMatch(/spans EVERY organization/);
   });
@@ -122,9 +318,15 @@ describe('validateOrgAxisRedLines — ② business-unit trees stay org-internal'
   it('flags the `systemFields.tenant: false` spelling of the same opt-out', () => {
     expect(
       rules({
-        objects: [{ name: 'material_catalog', systemFields: { tenant: false } }],
+        objects: [objectFixture({ name: 'material_catalog', systemFields: { tenant: false } })],
         sharingRules: [
-          { name: 'r', object: 'material_catalog', sharedTo: { type: 'business_unit', id: 'bu' } },
+          sharingRule({
+            name: 'r',
+            type: 'criteria',
+            object: 'material_catalog',
+            sharedWith: { type: 'business_unit', value: 'bu' },
+            condition: 'true',
+          }),
         ],
       }),
     ).toEqual([ORG_AXIS_CROSS_ORG_BU_GRANT]);
@@ -138,9 +340,15 @@ describe('validateOrgAxisRedLines — ② business-unit trees stay org-internal'
   it('allows a non-BU audience on a platform-global object', () => {
     expect(
       rules({
-        objects: [{ name: 'material_catalog', tenancy: { enabled: false } }],
+        objects: [objectFixture({ name: 'material_catalog', tenancy: { enabled: false } })],
         sharingRules: [
-          { name: 'r', object: 'material_catalog', sharedTo: { type: 'position', name: 'buyer' } },
+          sharingRule({
+            name: 'r',
+            type: 'criteria',
+            object: 'material_catalog',
+            sharedWith: { type: 'position', value: 'buyer' },
+            condition: 'true',
+          }),
         ],
       }),
     ).toEqual([]);

--- a/packages/lint/src/validate-org-axis-red-lines.ts
+++ b/packages/lint/src/validate-org-axis-red-lines.ts
@@ -75,6 +75,29 @@ function str(v: unknown): string {
   return typeof v === 'string' ? v : '';
 }
 
+/**
+ * The text behind an `ExpressionInput` slot — the CEL source, whichever shape
+ * it arrives in.
+ *
+ * `SharingRule.condition` is an `ExpressionInputSchema`: a bare string at
+ * authoring time, the `{ dialect, source }` envelope after parse, and
+ * `{ dialect, ast }` once `objectstack compile` lowers it. This rule sees all
+ * three (`input: 'parsed'`, falling back to the normalized stack under `os
+ * lint`), so each has to yield something to scan. The `ast` branch stringifies
+ * the node — a field reference survives as its identifier — while no branch
+ * ever reads `meta.rationale`, whose prose may legitimately name the very field
+ * it is explaining that the rule does NOT use.
+ */
+function expressionText(v: unknown): string {
+  if (typeof v === 'string') return v;
+  if (v && typeof v === 'object') {
+    const rec = v as AnyRec;
+    if (typeof rec.source === 'string') return rec.source;
+    if (rec.ast !== undefined) return JSON.stringify(rec.ast) ?? '';
+  }
+  return '';
+}
+
 /** True iff the object opted out of tenancy — platform-global, no org column. */
 function isTenancyDisabled(object: AnyRec): boolean {
   const tenancy = object.tenancy as AnyRec | undefined;
@@ -143,19 +166,32 @@ export function validateOrgAxisRedLines(stack: unknown): OrgAxisFinding[] {
     });
   });
 
-  // Sharing rules — criteria and recipient may both reach for the org parent.
+  // Sharing rules — the predicate and the recipient may both reach for the org
+  // parent, so both slots are scanned.
+  //
+  // The keys read here are the ones `SharingRuleSchema` DECLARES: `condition`
+  // (the CEL predicate) and `sharedWith` (the recipient). `criteria` / `filter`
+  // / `sharedTo` / `recipient` are NOT alternative spellings — the schema is
+  // `.strict()` and rejects them by name, with `sharingRuleUnknownKeyError`
+  // prescribing the canonical key. Reading them here as `??` fallbacks is what
+  // made this red line inert for every spec-valid stack (#4984): after parse
+  // they are always `undefined`, so the gate never fired. Alias tolerance
+  // belongs at the schema's refusal, not in a consumer (Prime Directive #12).
   asArray(cfg.sharingRules ?? cfg.sharing).forEach((rule, rIndex) => {
-    const criteria = JSON.stringify(rule.criteria ?? rule.filter ?? '');
-    const sharedTo = JSON.stringify(rule.sharedTo ?? rule.recipient ?? '');
-    if (criteria.includes(ORG_PARENT_FIELD) || sharedTo.includes(ORG_PARENT_FIELD)) {
+    const slots: Array<{ key: string; text: string }> = [
+      { key: 'condition', text: expressionText(rule.condition) },
+      { key: 'sharedWith', text: JSON.stringify(rule.sharedWith ?? '') ?? '' },
+    ];
+    for (const slot of slots) {
+      if (!slot.text.includes(ORG_PARENT_FIELD)) continue;
       findings.push({
         severity: 'error',
         rule: ORG_AXIS_PERMISSION_INHERITANCE,
         where: `sharing rule "${str(rule.name) || rIndex}"`,
-        path: `sharingRules[${rIndex}]`,
+        path: `sharingRules[${rIndex}].${slot.key}`,
         message:
-          `Sharing rule reads \`${ORG_PARENT_FIELD}\`, granting access by walking the organization ` +
-          `tree. ADR-0105 D6 forbids permission inheritance along the org axis.`,
+          `Sharing rule ${slot.key} reads \`${ORG_PARENT_FIELD}\`, granting access by walking the ` +
+          `organization tree. ADR-0105 D6 forbids permission inheritance along the org axis.`,
         hint: INHERITANCE_HINT,
       });
     }
@@ -171,14 +207,16 @@ export function validateOrgAxisRedLines(stack: unknown): OrgAxisFinding[] {
   asArray(cfg.sharingRules ?? cfg.sharing).forEach((rule, rIndex) => {
     const target = str(rule.object ?? rule.objectName);
     if (!target || !tenancyDisabledObjects.has(target)) return;
-    const sharedTo = (rule.sharedTo ?? rule.recipient) as AnyRec | undefined;
-    const recipientType = str(sharedTo?.type);
+    // `sharedWith` is the declared recipient key; `sharedTo` / `recipient` are
+    // spelt out only in the schema's rejection message (#4984).
+    const sharedWith = rule.sharedWith as AnyRec | undefined;
+    const recipientType = str(sharedWith?.type);
     if (recipientType !== 'business_unit') return;
     findings.push({
       severity: 'error',
       rule: ORG_AXIS_CROSS_ORG_BU_GRANT,
       where: `sharing rule "${str(rule.name) || rIndex}" on object "${target}"`,
-      path: `sharingRules[${rIndex}].sharedTo`,
+      path: `sharingRules[${rIndex}].sharedWith`,
       message:
         `A business-unit sharing rule targets "${target}", which opted out of tenancy ` +
         `(\`tenancy.enabled: false\`). Platform-global objects carry no organization column, so this ` +


### PR DESCRIPTION
Fixes #4984

## 死态复现(before 证据,最新 main)

`validateOrgAxisRedLines` 注册为 `input: 'parsed'`,即跑在 Zod parse 之后。它取 `rule.criteria ?? rule.filter` 与 `rule.sharedTo ?? rule.recipient`,而 `SharingRuleSchema` 是 `.strict()` 的、声明的键是 `condition` / `sharedWith` —— 那四个名字只作为**被拒别名**出现在 `sharingRuleUnknownKeyError` 里(那是给报错信息用的处方,不是被接受的键)。

在 `c87ef7034`(本分支的基点)上实测:

```
=== 1. spec-valid 且违反 D6 ① 的 sharing rule(真实键名) ===
safeParse ok: true
  {"name":"hq_sees_children","object":"work_order","active":true,"accessLevel":"read",
   "sharedWith":{"type":"team","value":"hq"},"type":"criteria",
   "condition":{"dialect":"cel","source":"record.parent_organization_id == 'org_hq'"}}
findings on PARSED stack: []          ← 判绿
findings on RAW (pre-parse) stack: [] ← 判绿

=== 2. 现有测试 fixture 用的死键,过不了 schema ===
name,object,criteria  => REJECTED: Unrecognized key(s) on this sharing rule: `criteria`.
name,object,sharedTo  => REJECTED: Unrecognized key(s) on this sharing rule: `sharedTo`.

=== 3. 平台级对象上的 BU 授权(真实键名,D6 ②) ===
safeParse ok: true
findings: []                          ← 判绿
```

即:一条声明为 `error`、以 ADR-0105 D6 红线为依据的门禁,在 sharing-rule 这条路径上**对任何 spec 合法的 stack 永不触发**;而**它自己的测试 fixture 用的正是那些被拒的死键,所以测试全绿、规则全死**。

## 改了什么

**1. 规则改读 canonical 键。** `rule.condition` / `rule.sharedWith`,不再有 `??` 别名兜底。别名已经在 `sharingRuleUnknownKeyError` 里有明确处方并被 parse 拒收 —— consumer 不该容忍 producer 契约拒绝的东西(Prime Directive #12)。新增一条测试把这个决定钉住:写 `criteria` / `filter` / `sharedTo` / `recipient` 的规则**不**判红,交给 spec 的拒收。

**2. 语义按 D6 原文逐条搬,不是只换名字。** 别名与真键的形状确实不同:

| | 死键 | 真键 | 形状差异 |
|:--|:--|:--|:--|
| 谓词 | `criteria` / `filter` | `condition` | `ExpressionInput` —— 裸串(作者态)/ `{ dialect, source }`(parse 后)/ `{ dialect, ast }`(compile 后),三种都要能取到文本,新增 `expressionText()` |
| 收件人 | `sharedTo` / `recipient` | `sharedWith` | `.strict()` 的 `{ type, value }`;`id` 也是被拒别名 |

`expressionText()` 刻意不读 `meta.rationale` —— 那段散文完全可能正当地提到它正在解释「本规则不使用」的那个字段,error 级门禁不能被注释误伤。

`path` 从笼统的 `sharingRules[i]` 细化到 `sharingRules[i].condition` / `sharingRules[i].sharedWith`,两个槽位各自点名。

**3. fixture/schema 漂移守卫(本单的结构性修复)。** 只改键名的话,同样的漂移下次还来。现在每个 sharing-rule fixture 都过 `sharingRule()`,它先用真的 `SharingRuleSchema` parse 再交给 lint;object fixture 同理走 `objectFixture()` → `ObjectSchema`。fixture 一旦与 spec 漂移就在 fixture 处判红,而不是去测一个作者写不出来的形状。元测试本身也自证不死:把 #4984 之前的两个 fixture 原样喂进去,断言它们**抛错**。

## 反向验证

| 场景 | 结果 |
|:--|:--|
| 真实键名的违规 stack(修复后) | 判红并点名 `sharingRules[0].condition` / `.sharedWith` |
| 合法 stack(membership / BU / 非 BU 收件人) | 判绿 |
| 把规则改回读死键,跑新测试 | **7 failed** —— 元测试与行为测试同时判红 |

改回死键时的失败清单:

```
× flags a spec-valid sharing rule whose `condition` walks the org parent
× flags the pre-parse `condition` shape too (`os lint` runs on the normalized stack)
× flags the compiled `{ dialect, ast }` condition shape
× flags a recipient that reaches for the org parent
× does NOT resurrect the schema-rejected aliases — parse is that gate
× flags a business-unit grant on a `tenancy.enabled: false` object
× flags the `systemFields.tenant: false` spelling of the same opt-out
 Tests  7 failed | 11 passed (18)
```

## 真实元数据上是否有新红

**没有。** D6 是 error 级,所以逐条核过:

- `examples/app-showcase` / `examples/app-crm` 的全部 sharing rule:没有任何 `condition` 或 `sharedWith` 提到 `parent_organization_id`;
- 全仓没有对象声明 `tenancy.enabled: false` 或 `systemFields.tenant: false`,所以 D6 ② 也无处触发;
- `default-permission-sets.ts` 与 `examples/app-showcase/src/security/permission-sets.ts` 的 RLS `using`/`check`:只有 `assignee == current_user.email` / `owner == current_user.email` 一类,无 org 轴引用。

## 验证

```
$ pnpm --filter @objectstack/lint test
 Test Files  54 passed (54)
      Tests  987 passed | 4 skipped (991)

$ pnpm --filter @objectstack/lint typecheck
(clean)

$ npx eslint packages/lint/src/validate-org-axis-red-lines{,.test}.ts --no-inline-config
(clean)
```

## 顺手发现,已单独建单(未随本 PR 修)

- **#4989** —— 同一文件的 `objects[].rowLevelSecurity` 分支也是死路径:`ObjectSchema` 根本不声明 `rowLevelSecurity`,`objects[0]` 带该键的 stack 被 parse 拒收。危害小于本单(permission-set 那段覆盖了 RLS 的唯一可授权落点,红线没有洞),但「删掉该段」还是「给 spec 加对象级 RLS 授权面」是 ADR 级取舍,不宜在本 PR 里替维护者决定。
- **#4991** —— D6 ② 只拦 `business_unit` 收件人,漏了 `unit_and_subordinates`,而 ADR-0105 D6 ② 原文点名的正是后者,且它的授权面更大(整棵 BU 子树)。这是 error 级门禁的**扩张**,不随本单做;已核查按此扩张现有真实元数据不会产生新红。


---
_Generated by [Claude Code](https://claude.ai/code/session_018iARDqtrhQgz6fVHDeDkbQ)_