### PR TITLE
fix(cli): 启动 banner 的 `Tenancy:` 改读 resolveTenancyPosture(),不再打印被取代的布尔 (#4801)

### DIFF
--- a/.changeset/cli-banner-tenancy-posture.md
+++ b/.changeset/cli-banner-tenancy-posture.md
@@ -1,0 +1,53 @@
+---
+"@objectstack/cli": patch
+---
+
+fix(cli): the boot banner's `Tenancy:` row now reports the resolved posture, not the superseded boolean (#4801)
+
+`printServerReady` printed `Tenancy: multi-tenant | single-tenant` from a boolean
+`multiTenant` that `serve` filled with `resolveMultiOrgEnabled()` — i.e. from
+`OS_MULTI_ORG_ENABLED`. [ADR-0105 D1] replaced that knob with
+`OS_TENANCY_POSTURE`, keeping the boolean only as the fallback
+`resolveTenancyPosture()` consults when the posture is unset, and **the runtime
+wiring in `serve` already keys off the posture**. So the banner and the server it
+describes read two different sources for one fact, and they drifted exactly where
+it hurts: booting with `OS_TENANCY_POSTURE=isolated` and `OS_MULTI_ORG_ENABLED`
+unset printed
+
+```
+  Tenancy: single-tenant
+  Plugins: 40 loaded
+           …, Organizations, …
+```
+
+— the banner claiming single-org one line above the plugin table that proves the
+organization wall is up (observed on a real boot in cloud#1020, where the lie was
+only caught by hand-comparing the plugin list).
+
+This is not cosmetic. It is the "declared ≠ enforced" class (ADR-0049) landing on
+the **diagnostic** surface, which is the worst place for it: a banner that can be
+wrong costs every later investigation an extra lap proving whether it is.
+
+**What changes for users.** The row now prints the posture verbatim — `Tenancy:
+single`, `Tenancy: group`, `Tenancy: isolated` — sourced from the same
+`resolveTenancyPosture()` call the runtime wiring uses. The old `multi-tenant` /
+`single-tenant` vocabulary is gone. That vocabulary was itself part of the defect:
+tenancy has been a three-valued spectrum since ADR-0105, and a boolean has no
+spelling for `group` at all, so a `group` deployment could only ever be
+misreported.
+
+**The internal `multiTenant` option is removed, not deprecated.** With the posture
+authoritative, a retained boolean could only ever be a field the printer ignores —
+and a field that exists but cannot be believed is precisely how this bug was
+authored in the first place. `ServerReadyOptions.tenancyPosture` is typed as
+`TenancyPosture`, so re-wiring the banner to the legacy boolean now fails to
+compile (`resolveMultiOrgEnabled()` returns `boolean`) instead of producing a
+plausible-looking wrong line. The interface is package-internal — `format.ts` is
+not re-exported from `@objectstack/cli`'s entry point — so no consumer code needs
+a change.
+
+Regression-pinned in `packages/cli/src/utils/format.tenancy.test.ts`, which asserts
+the printed token **is** `resolveTenancyPosture()`'s answer across the cases that
+made the old code wrong: posture set with the boolean unset, posture unset with the
+boolean true, both set and contradicting (either direction), the legacy `multi`
+spelling, and `group`.

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -10,7 +10,11 @@ import { loadConfig, BUNDLE_REQUIRE_EXTERNALS } from '../utils/config.js';
 import { mergeBootConfig } from '../utils/merge-boot-config.js';
 import { isHostConfig, shouldBootWithLibrary } from '../utils/plugin-detection.js';
 import { resolveDriverType, resolveStorageDefinition, UnsupportedDriverError } from '../utils/storage-driver.js';
-import { readEnvWithDeprecation, resolveMultiOrgEnabled, resolveTenancyPosture, resolveAllowDegradedTenancy, isMcpServerEnabled, stampSearchPinyinEnabled, isModuleNotFoundError } from '@objectstack/types';
+// [ADR-0105 D1] `resolveMultiOrgEnabled` is deliberately NOT imported here: the
+// posture is the authoritative knob and `resolveTenancyPosture()` already folds
+// the legacy boolean in as its unset-fallback. serve's last direct reader of the
+// boolean was the banner, and that was exactly the drift #4801 fixed.
+import { readEnvWithDeprecation, resolveTenancyPosture, resolveAllowDegradedTenancy, isMcpServerEnabled, stampSearchPinyinEnabled, isModuleNotFoundError } from '@objectstack/types';
 import { PLATFORM_CAPABILITY_TOKENS, PLATFORM_ALWAYS_ON_CAPABILITIES } from '@objectstack/spec/kernel';
 import { missingProviderMessage } from '../utils/capability-preflight.js';
 import { resolveObjectStackHome } from '@objectstack/runtime';
@@ -2688,7 +2692,15 @@ export default class Serve extends Command {
         consolePath: loadedPlugins.includes('ConsoleUI') ? CONSOLE_PATH : undefined,
         driverLabel: resolvedDriverLabel,
         databaseUrl: resolvedDatabaseUrl ? redactConnectionUrl(resolvedDatabaseUrl) : undefined,
-        multiTenant: resolveMultiOrgEnabled(),
+        // [ADR-0105 D1] #4801 — the banner reads the SAME resolver the runtime
+        // wiring above keys off (`resolveTenancyPosture()`), not the legacy
+        // boolean `resolveMultiOrgEnabled()`. With `OS_TENANCY_POSTURE=isolated`
+        // and `OS_MULTI_ORG_ENABLED` unset, the boolean says `false` while the
+        // wall is up — the banner printed `single-tenant` on the same screen
+        // that listed `Organizations` in the plugin table (cloud#1020). A
+        // diagnostic surface that disagrees with the runtime costs every later
+        // investigation an extra lap.
+        tenancyPosture: resolveTenancyPosture(),
         seededAdmin,
         automation: automationSummary,
         seeds: seedSummary,

--- a/packages/cli/src/utils/format.tenancy.test.ts
+++ b/packages/cli/src/utils/format.tenancy.test.ts
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveTenancyPosture } from '@objectstack/types';
+import type { TenancyPosture } from '@objectstack/spec/security';
+import { printServerReady, type ServerReadyOptions } from './format.js';
+
+/**
+ * framework#4801 — the boot banner's `Tenancy:` row.
+ *
+ * [ADR-0105 D1] `OS_TENANCY_POSTURE` is the authoritative knob; the boolean
+ * `OS_MULTI_ORG_ENABLED` survives only as its unset-fallback, folded in by
+ * `resolveTenancyPosture()`. serve wires the runtime off that resolver, but the
+ * banner printed a boolean sourced from `resolveMultiOrgEnabled()` — a second
+ * source for one fact. Booting with `OS_TENANCY_POSTURE=isolated` alone printed
+ * `Tenancy: single-tenant` on the same screen where the plugin table listed
+ * `Organizations` (observed in cloud#1020): the banner said single-org while the
+ * organization wall was up.
+ *
+ * So the property under test is not "the line looks right", it is **the banner
+ * and the resolver cannot disagree**. Every case below computes
+ * `resolveTenancyPosture()` from the environment and asserts the printed token
+ * IS that value — including the cases that made the old code wrong: a posture
+ * set with the boolean unset, a posture that contradicts the boolean, and
+ * `group`, which a boolean cannot express at all.
+ */
+describe('printServerReady Tenancy row (#4801, ADR-0105 D1)', () => {
+  const base: ServerReadyOptions = {
+    port: 3000,
+    configFile: 'objectstack.config.ts',
+    isDev: true,
+    pluginCount: 1,
+  };
+
+  const originalPosture = process.env.OS_TENANCY_POSTURE;
+  const originalMultiOrg = process.env.OS_MULTI_ORG_ENABLED;
+
+  let lines: string[];
+  let spy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    lines = [];
+    spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      // Strip SGR escapes so assertions hold whether or not chalk colors.
+      lines.push(args.join(' ').replace(/\u001b\[[0-9;]*m/g, ''));
+    });
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+    if (originalPosture === undefined) delete process.env.OS_TENANCY_POSTURE;
+    else process.env.OS_TENANCY_POSTURE = originalPosture;
+    if (originalMultiOrg === undefined) delete process.env.OS_MULTI_ORG_ENABLED;
+    else process.env.OS_MULTI_ORG_ENABLED = originalMultiOrg;
+  });
+
+  /** The single `Tenancy:` row, ANSI-stripped and trimmed. */
+  const tenancyLine = (): string | undefined => {
+    const rows = lines.filter((l) => l.includes('Tenancy:'));
+    expect(rows.length).toBeLessThanOrEqual(1);
+    return rows[0]?.trim();
+  };
+
+  /** The token the banner printed after `Tenancy:`. */
+  const printedPosture = (): string | undefined => tenancyLine()?.replace(/^Tenancy:\s*/, '');
+
+  /** Set the two knobs, exactly (unset = absent, not empty). */
+  const env = (posture: string | undefined, multiOrg: string | undefined) => {
+    if (posture === undefined) delete process.env.OS_TENANCY_POSTURE;
+    else process.env.OS_TENANCY_POSTURE = posture;
+    if (multiOrg === undefined) delete process.env.OS_MULTI_ORG_ENABLED;
+    else process.env.OS_MULTI_ORG_ENABLED = multiOrg;
+  };
+
+  /**
+   * The invariant, applied to whatever the environment currently says: boot the
+   * banner the way serve does — `tenancyPosture: resolveTenancyPosture()` — and
+   * assert the row names precisely the resolver's answer.
+   */
+  const expectBannerAgreesWithResolver = (): TenancyPosture => {
+    const resolved = resolveTenancyPosture();
+    printServerReady({ ...base, tenancyPosture: resolved });
+    expect(printedPosture()).toBe(resolved);
+    return resolved;
+  };
+
+  describe('the banner never disagrees with resolveTenancyPosture()', () => {
+    it('posture explicitly isolated, boolean unset — the cloud#1020 lie', () => {
+      // The regression case. `resolveMultiOrgEnabled()` is false here, so the
+      // old banner printed `single-tenant` while serve mounted the wall.
+      env('isolated', undefined);
+      expect(expectBannerAgreesWithResolver()).toBe('isolated');
+      expect(tenancyLine()).toBe('Tenancy: isolated');
+      expect(tenancyLine()).not.toContain('single-tenant');
+    });
+
+    it('posture unset, boolean true — the legacy fallback still reads isolated', () => {
+      env(undefined, 'true');
+      expect(expectBannerAgreesWithResolver()).toBe('isolated');
+      expect(tenancyLine()).toBe('Tenancy: isolated');
+    });
+
+    it('posture single while the boolean says true — posture wins', () => {
+      // Contradiction, the direction the old code got right by accident: the
+      // boolean would have said `multi-tenant`, the runtime runs unwalled.
+      env('single', 'true');
+      expect(expectBannerAgreesWithResolver()).toBe('single');
+      expect(tenancyLine()).toBe('Tenancy: single');
+    });
+
+    it('posture isolated while the boolean says false — posture wins', () => {
+      // The same contradiction pointing the other way, which the old code got
+      // wrong: banner `single-tenant`, runtime walled.
+      env('isolated', 'false');
+      expect(expectBannerAgreesWithResolver()).toBe('isolated');
+      expect(tenancyLine()).toBe('Tenancy: isolated');
+    });
+
+    it('prints group — the posture a boolean can only misreport', () => {
+      // `group` is why the field is not a boolean: flattened, it must print
+      // either `multi-tenant` (wrong wall shape) or `single-tenant` (no wall).
+      env('group', undefined);
+      expect(expectBannerAgreesWithResolver()).toBe('group');
+      expect(tenancyLine()).toBe('Tenancy: group');
+    });
+
+    it('posture unset and boolean unset — single, the default', () => {
+      env(undefined, undefined);
+      expect(expectBannerAgreesWithResolver()).toBe('single');
+      expect(tenancyLine()).toBe('Tenancy: single');
+    });
+
+    it("accepts the legacy 'multi' spelling and prints its canonical name", () => {
+      env('multi', undefined);
+      expect(expectBannerAgreesWithResolver()).toBe('isolated');
+      expect(tenancyLine()).toBe('Tenancy: isolated');
+    });
+  });
+
+  it('prints the posture verbatim for every posture the spec defines', () => {
+    for (const posture of ['single', 'group', 'isolated'] as const) {
+      lines = [];
+      printServerReady({ ...base, tenancyPosture: posture });
+      expect(tenancyLine()).toBe(`Tenancy: ${posture}`);
+    }
+  });
+
+  it('omits the row entirely when the caller has no posture to report', () => {
+    printServerReady({ ...base });
+    expect(tenancyLine()).toBeUndefined();
+  });
+
+  it('never flattens the posture back into multi-/single-tenant wording', () => {
+    // The old vocabulary is the tell that a boolean crept back in: it has no
+    // spelling for `group`, so its return means the spectrum was squashed again.
+    for (const posture of ['single', 'group', 'isolated'] as const) {
+      lines = [];
+      printServerReady({ ...base, tenancyPosture: posture });
+      // Assert the row EXISTS before asserting what it does not say — a
+      // `not.toMatch` over a banner with no Tenancy row at all passes
+      // vacuously, which reads identical to the bug this file exists to catch.
+      expect(tenancyLine()).toBeDefined();
+      expect(lines.join('\n')).not.toMatch(/multi-tenant|single-tenant/);
+    }
+  });
+
+  it('rejects the boolean shape at COMPILE time, not at review time', () => {
+    // These two directives are the structural half of the fix and are checked
+    // by `pnpm typecheck` (tests are type-checked — AGENTS.md), not by the
+    // assertions in this file. `resolveMultiOrgEnabled()` returns `boolean`, so
+    // re-wiring the banner to the legacy knob can no longer compile, and the
+    // retired field name can no longer be passed in silently ignored.
+    // @ts-expect-error — tenancyPosture is a TenancyPosture, never a boolean.
+    printServerReady({ port: 1, configFile: 'c', isDev: true, pluginCount: 0, tenancyPosture: true });
+    // @ts-expect-error — `multiTenant` was removed with #4801; nothing reads it.
+    printServerReady({ port: 1, configFile: 'c', isDev: true, pluginCount: 0, multiTenant: true });
+    // @ts-expect-error — and an arbitrary string is not a posture.
+    printServerReady({ port: 1, configFile: 'c', isDev: true, pluginCount: 0, tenancyPosture: 'multi' });
+    expect(lines.filter((l) => l.includes('Tenancy:'))).toHaveLength(2);
+  });
+});

--- a/packages/cli/src/utils/format.ts
+++ b/packages/cli/src/utils/format.ts
@@ -2,6 +2,7 @@
 
 import chalk from 'chalk';
 import type { ZodError } from 'zod';
+import type { TenancyPosture } from '@objectstack/spec/security';
 
 // ─── Constants ──────────────────────────────────────────────────────
 export const CLI_NAME = 'objectstack';
@@ -285,8 +286,31 @@ export interface ServerReadyOptions {
   driverLabel?: string;
   /** Resolved DB URL with credentials redacted. */
   databaseUrl?: string;
-  /** Whether the SecurityPlugin was wired in multi-tenant mode (default true). */
-  multiTenant?: boolean;
+  /**
+   * [ADR-0105 D1] The deployment's resolved tenancy posture — printed verbatim.
+   *
+   * This is the SAME fact serve wires the runtime from: it must be
+   * `resolveTenancyPosture()` (`@objectstack/types`), never a re-derivation.
+   * The banner used to take a boolean `multiTenant` sourced from
+   * `resolveMultiOrgEnabled()`, i.e. from `OS_MULTI_ORG_ENABLED` — the knob
+   * `OS_TENANCY_POSTURE` superseded, and which `resolveTenancyPosture()` now
+   * consults only as a fallback when the posture is unset. So a deployment
+   * booted with `OS_TENANCY_POSTURE=isolated` alone printed
+   * `Tenancy: single-tenant` while the organization wall was actually up and
+   * `Organizations` was in the plugin table one line below (framework#4801,
+   * observed in cloud#1020). Two sources for one fact, drifting.
+   *
+   * The field is the posture, not a boolean, for the same reason: tenancy is a
+   * three-valued spectrum (`single` | `group` | `isolated`), and a boolean
+   * cannot say `group` at all — it would have to lie, and the flattening is
+   * where the drift hides. Typing it as {@link TenancyPosture} also makes the
+   * old wiring a COMPILE error rather than a wrong-but-plausible line of
+   * output: `resolveMultiOrgEnabled()` returns `boolean` and no longer fits.
+   *
+   * Omitted → no `Tenancy:` row (unchanged: a caller with nothing to say says
+   * nothing, rather than guessing a posture).
+   */
+  tenancyPosture?: TenancyPosture;
   /**
    * Credentials of the dev admin seeded on an empty DB this boot (dev only).
    * When present, the banner surfaces them so backend debugging never has to
@@ -409,8 +433,10 @@ export function printServerReady(opts: ServerReadyOptions) {
     const dbInfo = opts.databaseUrl ? `${opts.driverLabel}  ${chalk.dim('→')} ${opts.databaseUrl}` : opts.driverLabel;
     console.log(chalk.dim(`  Driver:  ${dbInfo}`));
   }
-  if (opts.multiTenant !== undefined) {
-    console.log(chalk.dim(`  Tenancy: ${opts.multiTenant ? 'multi-tenant' : 'single-tenant'}`));
+  // [ADR-0105 D1] Print the posture verbatim — see `tenancyPosture` above for
+  // why this is not a boolean and why it must be the resolver's answer.
+  if (opts.tenancyPosture !== undefined) {
+    console.log(chalk.dim(`  Tenancy: ${opts.tenancyPosture}`));
   }
   console.log(chalk.dim(`  Plugins: ${opts.pluginCount} loaded`));
   if (opts.pluginNames && opts.pluginNames.length > 0) {


### PR DESCRIPTION
Fixes #4801

## 为什么读 posture 而不是布尔

ADR-0105 D1 之后,`OS_TENANCY_POSTURE` 是权威 knob,布尔 `OS_MULTI_ORG_ENABLED` 只是 `resolveTenancyPosture()` 在 posture unset 时的回退。`serve` 的**运行时接线**(`serve.ts` 里挂 `@objectstack/organizations` 的那段)早就读 `resolveTenancyPosture()`,但 banner 的 `Tenancy:` 行读的是 `resolveMultiOrgEnabled()` 返回的布尔 —— 同一个事实两个来源,于是它们漂了:

```
  Tenancy: single-tenant          ← banner 读布尔(OS_MULTI_ORG_ENABLED 未设 ⇒ false)
  Plugins: 40 loaded
           …, Organizations, …    ← 运行时按 posture=isolated 真的挂上了组织墙
```

这不是显示美化。这是「声明与执行不一致」(ADR-0049 那一类)落在**诊断面**上 —— 最坏的落点:一个可能撒谎的 banner,会让此后每一次排障都多花一轮去确认它有没有撒谎。cloud#1020 里就是靠人工比对插件表才发现的。

`Tenancy:` 现在直接打印 posture 名(`single` / `group` / `isolated`),来源是运行时接线用的同一个 `resolveTenancyPosture()` 调用。

## 布尔字段的去留:**删除**,不保留兼容项

`ServerReadyOptions.multiTenant?: boolean` → `tenancyPosture?: TenancyPosture`。理由有三条,按重要性:

1. **说不清它还为谁存在。** posture 是权威源;若保留布尔,议题已经规定「不一致时以 posture 为准」—— 那它就是一个**永远只能被忽略**的字段。一个存在但不可信的字段,正是本 bug 当初被写出来的方式:调用方看到 `multiTenant` 就填了个布尔进去,完全合理,而结果是错的。
2. **删除把「错误接线」从运行期挪到编译期。** `tenancyPosture` 的类型是 `TenancyPosture`,`resolveMultiOrgEnabled()` 返回 `boolean` —— 现在把 banner 接回旧 knob **无法通过编译**,而不是产出一行看起来很合理的错话。这是本仓「在源头就不给出错的机会」的取向:结构上防止,而不是消费端兜底。
3. **布尔在语义上本来就不够用。** tenancy 自 ADR-0105 起是三值谱系,布尔**根本没有 `group` 的拼法** —— 一个 `group` 部署只可能被误报。压扁本身就是漂移藏身的地方。

影响面为零:`format.ts` 没有从 `@objectstack/cli` 的入口 re-export,`ServerReadyOptions` 是包内部接口;全仓 `printServerReady` 只有 `serve.ts` 一个调用点(已改齐,并顺手从 import 里去掉了因此不再使用的 `resolveMultiOrgEnabled`)。

## 测试:三种场景 + 反向验证

新增 `packages/cli/src/utils/format.tenancy.test.ts`。被断言的性质不是「这行看起来对」,而是 **banner 与 `resolveTenancyPosture()` 不可能不一致**:每个用例都从环境变量算出 `resolveTenancyPosture()`,再断言打印出的 token **就是**它。

覆盖(前三条即议题点名的三种):

| 场景 | `OS_TENANCY_POSTURE` | `OS_MULTI_ORG_ENABLED` | 期望 |
|---|---|---|---|
| posture 显式非 single(cloud#1020 那条) | `isolated` | unset | `Tenancy: isolated` |
| posture unset、布尔 true(回退路径) | unset | `true` | `Tenancy: isolated` |
| 两者矛盾 · posture 弱 | `single` | `true` | `Tenancy: single` |
| 两者矛盾 · posture 强 | `isolated` | `false` | `Tenancy: isolated` |
| 布尔表达不了的 posture | `group` | unset | `Tenancy: group` |
| 默认 | unset | unset | `Tenancy: single` |
| legacy 拼法 | `multi` | unset | `Tenancy: isolated` |

外加:省略 posture 时整行不打印;任何 posture 下输出都不再出现 `multi-tenant`/`single-tenant` 措辞(**先断言该行存在再断言它不含旧措辞** —— 一个没有 `Tenancy:` 行的 banner 会让 `not.toMatch` 空转通过,那和本文件要抓的 bug 从外部看一模一样);以及两条 `@ts-expect-error`,在 `pnpm typecheck` 而非 review 阶段钉住形状。

### 反向验证(把 `format.ts` stash 回改前,只留新测试与调用点)

```
$ git stash push -- packages/cli/src/utils/format.ts
$ pnpm --filter @objectstack/cli exec vitest run src/utils/format.tenancy.test.ts

  × posture explicitly isolated, boolean unset — the cloud#1020 lie 11ms
  × posture unset, boolean true — the legacy fallback still reads isolated 2ms
  × posture single while the boolean says true — posture wins 2ms
  × posture isolated while the boolean says false — posture wins 1ms
  × prints group — the posture a boolean can only misreport 1ms
  × posture unset and boolean unset — single, the default 1ms
  × accepts the legacy 'multi' spelling and prints its canonical name 1ms
  × prints the posture verbatim for every posture the spec defines 1ms
  × rejects the boolean shape at COMPILE time, not at review time 4ms

AssertionError: expected undefined to be 'Tenancy: single'
AssertionError: expected [ '  Tenancy: multi-tenant' ] to have a length of 2 but got 1

 Test Files  1 failed (1)
      Tests  9 failed | 2 passed (11)
```

(注:上面这轮跑的是加强前的版本,当时「never flattens」那条空转通过;已按上一段所述改成先断言行存在。)

改动在位后:

```
$ pnpm --filter @objectstack/cli exec vitest run src/utils/format.tenancy.test.ts
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

两条 `@ts-expect-error` 也做了同样的反向验证 —— 去掉其中一条,tsc 立刻报出被它挡住的那个错,证明指令是承重的而非装饰:

```
packages/cli/src/utils/format.tenancy.test.ts(174,79): error TS2322:
  Type 'true' is not assignable to type '"group" | "single" | "isolated" | undefined'.
```

## 其它验证

- ESLint:`npx eslint packages/cli/src/utils/format.ts packages/cli/src/utils/format.tenancy.test.ts packages/cli/src/commands/serve.ts` → 干净(无输出)。
- Typecheck:本 worktree 里 `pnpm --filter @objectstack/cli typecheck` 会报一批 `TS2307: Cannot find module '@objectstack/runtime' | '@objectstack/core' | …`,这是**工作区未构建 dist 的既有环境噪音**(在未改动的 `origin/main` 树上同样复现),与本改动无关。改动涉及的两个文件已用一份把 `@objectstack/spec` / `@objectstack/types` 映射到**源码**的 tsconfig 单独 `tsc --noEmit` 过,结果零错误;CI 会先构建再 typecheck,是权威一轮。
- 同理,`src/utils/` 里 7 个测试文件在本地因同样的未构建依赖而 collect 失败,`sqlite-occupancy.test.ts` 有 1 条环境相关失败 —— 均已通过 stash 全部改动、在等同 `origin/main` 的树上复跑确认为既有失败(`Tests 1 failed | 14 passed`,一字不差)。

## 边界

只做 banner 这半块。**未触碰** `serve.ts` 里的 tenancy 守卫逻辑(#4818 / PR #4858 刚改过),也未触碰 cloud#1020 那边仍在等维护者拍板的许可闸门决策 —— 正如议题开头所写,banner 无论那个决策怎么落都该修。已附 changeset(`@objectstack/cli` patch,CLI 输出为用户可见变化)。

---
_Generated by [Claude Code](https://claude.ai/code/session_018iARDqtrhQgz6fVHDeDkbQ)_