### PR TITLE
fix(qa,dx): 让 dogfood 的 strict tsconfig 真正被执行 —— 修 14 条积压并接进 turbo typecheck (#4855)

### DIFF
--- a/.changeset/dogfood-typecheck-wired.md
+++ b/.changeset/dogfood-typecheck-wired.md
@@ -1,0 +1,15 @@
+---
+---
+
+ci(dx): `packages/qa/dogfood` 的 strict tsconfig 现在真的被执行 —— 加上 `typecheck` script 并从 `scripts/check-type-check-coverage.mjs` 的 DEBT 账本毕业(#4855)。Dev scripts / CI only;releases nothing。
+
+dogfood 有一份认真的 tsconfig(`strict`、`NodeNext`、`include: ["src/**/*", "test/**/*"]`),但 package.json 的 scripts 里只有 `test`。根 `pnpm typecheck` 是 `turbo run typecheck`,只跑声明了该 script 的包 —— 三个 qa 包里,这是唯一没声明的一个,所以这份配置**从未被执行过**。#4311 的覆盖率闸门确实看见了这个洞,但把它记成 DEBT(`errors: 12`)冻结了下来,而 DEBT 是「暂缓」不是「豁免」:门后的错误只会继续涨。在最新 main 上实测是 **14** 条,比账本冻结时多了 2 条 —— 正是这种漂移说明冻结不能长期替代执行。
+
+14 条全部修掉,分四类:
+
+- **NodeNext 缺扩展名(2 条,TS2307)** —— `field-zoo-roundtrip.dogfood.test.ts` 与 `field-zoo-value-shape.test.ts` 写 `from './field-zoo.matrix'`。包内另外 33 处相对 import 全都带 `.js`,这两处是仅有的例外。vitest 能解析,tsc 不能。附带消掉 1 条级联的 TS7006(未解析的 import 让符号退化成 `any`,回调参数随即报 implicit-any)。
+- **flow fixture 的 `type` 没有收窄(8 条,TS2322)** —— 四个 fixture 的 flow 是裸对象字面量,`type: 'autolaunched'` 推成 `string`,喂给 `defineStack` 时对不上字面量联合。修法不是 `as const`,而是按 `examples/app-todo/src/flows/task.flow.ts` 的既有写法标注 `: Flow`(`import type { Flow } from '@objectstack/spec/automation'`)—— 这样整份 fixture 都被 spec 的真实契约检查,而不只是让报错闭嘴。
+- **条件展开出的 headers(2 条,TS2322)** —— `attachments-permission-matrix.dogfood.test.ts` 的 `token ? { Authorization } : {}` 在匿名分支上推出 `Authorization?: undefined`,展开进 `headers` 后 `HeadersInit`(`Record< string, string >`)拒收。给该常量标注 `Record< string, string >`。
+- **连接器 handler 少传一个参数(1 条,TS2554)** —— `showcase-mcp-self-connection.dogfood.test.ts` 调 `handler!({})`,而 `McpConnectorBundle.handlers` 声明的是 `(input, ctx)`,引擎侧 `connector-nodes.ts` 也始终按两参数派发。这条一直「能跑」,只是因为 MCP 这个 handler 恰好忽略 `ctx` —— 契约上它是错的。改为按声明传两参数,与 connector-mcp 自己的测试一致;**没有放松任何契约**(把 `ctx` 改成可选才是错误方向)。
+
+修完接进执行:package.json 加 `"typecheck": "tsc --noEmit"`,并按闸门的 RECONCILED 不变式在同一个 PR 里删掉 DEBT 条目(graduated)。覆盖率从 60/77 走到 61/77,DEBT 从 17 个包降到 16 个。反向验证:在 fixture 里塞一个非法的 flow `type`,`turbo run typecheck` 判红并精确指出该行;移回后判绿(命中修复前那一次绿跑的同一个 turbo hash)。`pnpm --filter @objectstack/dogfood test` 481 passed / 3 skipped,行为未变。

--- a/packages/qa/dogfood/package.json
+++ b/packages/qa/dogfood/package.json
@@ -6,6 +6,7 @@
   "description": "Dogfood regression gate — hand-written golden tests that boot real example apps through @objectstack/verify's in-process HTTP stack, pinning historical runtime regressions (#2018 timezone bucketing, #1994 cross-owner RLS, #2004 field fidelity) that static checks miss.",
   "type": "module",
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/qa/dogfood/test/attachments-permission-matrix.dogfood.test.ts
+++ b/packages/qa/dogfood/test/attachments-permission-matrix.dogfood.test.ts
@@ -61,7 +61,11 @@ function bootFixture(extra: { multiTenant?: boolean } = {}) {
 
 /** Drive the REAL presigned three-step upload; returns the fileId. */
 async function uploadFile(stack: VerifyStack, token: string | null, name = 'hello.txt'): Promise<string> {
-  const auth = token ? { Authorization: `Bearer ${token}` } : {};
+  // Typed as a header record rather than inferred: the ternary would otherwise
+  // widen to `{ Authorization?: undefined }` on the anonymous branch, which the
+  // spread carries into `headers` and `HeadersInit` (Record< string, string >)
+  // rightly refuses.
+  const auth: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
   const presignRes = await stack.api('/storage/upload/presigned', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...auth },

--- a/packages/qa/dogfood/test/field-zoo-roundtrip.dogfood.test.ts
+++ b/packages/qa/dogfood/test/field-zoo-roundtrip.dogfood.test.ts
@@ -21,7 +21,7 @@ import showcaseStack from '@objectstack/example-showcase';
 import { SECRET_MASK } from '@objectstack/objectql';
 import { bootStack, type VerifyStack } from '@objectstack/verify';
 
-import { MATRIX, REFERENCE_TARGETS } from './field-zoo.matrix';
+import { MATRIX, REFERENCE_TARGETS } from './field-zoo.matrix.js';
 describe('dogfood: field-type capability matrix round-trips over HTTP (#2004)', () => {
   let stack: VerifyStack;
   let record: Record<string, unknown>;

--- a/packages/qa/dogfood/test/field-zoo-value-shape.test.ts
+++ b/packages/qa/dogfood/test/field-zoo-value-shape.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { valueSchemaFor } from '@objectstack/spec/data';
-import { MATRIX } from './field-zoo.matrix';
+import { MATRIX } from './field-zoo.matrix.js';
 
 describe('ADR-0104: field-zoo MATRIX write vectors parse under valueSchemaFor(stored)', () => {
   const writable = MATRIX.filter(

--- a/packages/qa/dogfood/test/fixtures/flow-durable-suspend-fixture.ts
+++ b/packages/qa/dogfood/test/fixtures/flow-durable-suspend-fixture.ts
@@ -22,6 +22,7 @@
 
 import { defineStack } from '@objectstack/spec';
 import { ObjectSchema, Field } from '@objectstack/spec/data';
+import type { Flow } from '@objectstack/spec/automation';
 
 /** The record the resumed half of the run stamps, so "it continued" is observable. */
 export const SuspendNote = ObjectSchema.create({
@@ -51,7 +52,7 @@ export const SuspendNote = ObjectSchema.create({
  * snapshot across the restart) cannot accidentally pass: the variables have to
  * survive the round-trip through `sys_automation_run` for the right row to move.
  */
-export const flowDurableSuspend = {
+export const flowDurableSuspend: Flow = {
   name: 'flow_durable_suspend',
   label: 'Flow Durable Suspend',
   type: 'screen',

--- a/packages/qa/dogfood/test/fixtures/flow-function-effect-fixture.ts
+++ b/packages/qa/dogfood/test/fixtures/flow-function-effect-fixture.ts
@@ -20,6 +20,7 @@
 
 import { defineStack } from '@objectstack/spec';
 import { ObjectSchema, Field } from '@objectstack/spec/data';
+import type { Flow } from '@objectstack/spec/automation';
 
 /** One object, so the sweep flow has something real to select. */
 export const FxInvoice = ObjectSchema.create({
@@ -36,7 +37,7 @@ export const FxInvoice = ObjectSchema.create({
 });
 
 /** start → get_record → script → end. `fn` is the only thing that varies. */
-const sweepFlow = (name: string, fn: string) => ({
+const sweepFlow = (name: string, fn: string): Flow => ({
   name,
   label: name,
   type: 'autolaunched',

--- a/packages/qa/dogfood/test/fixtures/flow-runas-fixture.ts
+++ b/packages/qa/dogfood/test/fixtures/flow-runas-fixture.ts
@@ -30,6 +30,7 @@
 import { defineStack } from '@objectstack/spec';
 import { ObjectSchema, Field } from '@objectstack/spec/data';
 import { PermissionSetSchema, RLS, type PermissionSet } from '@objectstack/spec/security';
+import type { Flow } from '@objectstack/spec/automation';
 import { SecurityPlugin, securityDefaultPermissionSets } from '@objectstack/plugin-security';
 
 /** The one object under test: an owner-scoped note (isolated via `created_by`). */
@@ -51,7 +52,7 @@ export const RunAsNote = ObjectSchema.create({
  * whose id is passed as the `noteId` input variable. The two variants differ
  * ONLY in `runAs`, isolating the identity switch as the single variable.
  */
-function touchFlow(name: string, runAs: 'system' | 'user', stamp: string) {
+function touchFlow(name: string, runAs: 'system' | 'user', stamp: string): Flow {
   return {
     name,
     label: `RunAs ${runAs} touch`,
@@ -81,7 +82,7 @@ function touchFlow(name: string, runAs: 'system' | 'user', stamp: string) {
  * `data.output.found`. Under `system` the elevated read returns the record;
  * under `user` the RLS-scoped read returns null.
  */
-function readFlow(name: string, runAs: 'system' | 'user') {
+function readFlow(name: string, runAs: 'system' | 'user'): Flow {
   return {
     name,
     label: `RunAs ${runAs} read`,

--- a/packages/qa/dogfood/test/fixtures/flow-touch-fixture.ts
+++ b/packages/qa/dogfood/test/fixtures/flow-touch-fixture.ts
@@ -21,6 +21,7 @@
 
 import { defineStack } from '@objectstack/spec';
 import { ObjectSchema, Field } from '@objectstack/spec/data';
+import type { Flow } from '@objectstack/spec/automation';
 
 /** The one object under test: a note the flow stamps as processed. */
 export const FlowNote = ObjectSchema.create({
@@ -42,7 +43,7 @@ export const FlowNote = ObjectSchema.create({
  * `status` to `processed`. Triggered via `POST /automation/flow_touch/trigger`
  * with `{ params: { noteId } }`.
  */
-export const flowTouch = {
+export const flowTouch: Flow = {
   name: 'flow_touch',
   label: 'Flow Touch',
   type: 'autolaunched',

--- a/packages/qa/dogfood/test/showcase-mcp-self-connection.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-mcp-self-connection.dogfood.test.ts
@@ -81,7 +81,11 @@ describe('showcase: the platform connects to its OWN MCP endpoint (#3167 self-co
     try {
       const handler = bundle.handlers['list_objects'];
       expect(handler, 'list_objects handler present').toBeDefined();
-      const result = await handler!({});
+      // Two args, as the engine itself dispatches them (connector-nodes.ts calls
+      // `handler(input, handlerCtx)`); the connector's own tests call it the same
+      // way. The one-arg call here only ever worked because this MCP handler
+      // happens to ignore `ctx` — it was not the declared contract.
+      const result = await handler!({}, {});
       // The app's own object list, round-tripped back through its own MCP surface.
       expect(JSON.stringify(result), `self list_objects result: ${JSON.stringify(result)}`).toContain('showcase_');
     } finally {

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -129,10 +129,6 @@ const DEBT = {
     errors: 91,
     note: 'code-tier 3; the rest is config-tier (TS2835/TS2347 module resolution) and noise (TS7006).',
   },
-  '@objectstack/dogfood': {
-    errors: 12,
-    note: 'code-tier 8 (TS2322/TS2554) + 3 config-tier + 1 noise.',
-  },
   '@objectstack/hono': {
     errors: 3,
     note: 'all code-tier (TS2769/TS18046).',


### PR DESCRIPTION
Fixes #4855

## 问题

`packages/qa/dogfood/tsconfig.json` 是一份认真的配置 —— `strict: true`、`module/moduleResolution: NodeNext`、`include` 覆盖 `test/**/*`。但 `packages/qa/dogfood/package.json` 的 scripts 里**只有 `test`**。根 `pnpm typecheck` 是 `turbo run typecheck`,只跑声明了该 script 的包;三个 qa 包里(`downstream-contract`、`http-conformance`、`dogfood`),这是唯一没声明的一个 —— 于是这份 strict 配置**从未被执行过**。

这就是「declared ≠ enforced」在构建配置层的形状:读代码的人(和写代码的 agent)会合理假设它在 CI 里把关,照着它的严格度写;实际没有任何一步跑它。而 dogfood 是本仓最重的行为门,它的 fixture 类型漂移此前没有任何东西会挡。

## 覆盖率闸门为什么没抓到

抓到了,但记成了**冻结债务**而不是缺口。`scripts/check-type-check-coverage.mjs` 的 `DEBT` 账本里有:

```
'@objectstack/dogfood': {
  errors: 12,
  note: 'code-tier 8 (TS2322/TS2554) + 3 config-tier + 1 noise.',
},
```

该闸门的 `COVERED` 不变式接受「声明了 `typecheck` script」**或**「有一条带实测错误数的 DEBT 条目」。dogfood 走的是后一条,所以闸门一路绿灯 —— 它诚实地记录了这个包没被检查,但记录不等于执行。

**DEBT 是暂缓,不是豁免**,而且会漂移:账本冻结于 `b07d829`(2026-07-31)时是 12 条,我在最新 main(`7d0e7b5`)上实测是 **14 条**。多出来的 2 条正是「冻结不能长期替代执行」的直接证据 —— 门后的东西只会继续涨。所以本 PR 走的是账本注释里写明的毕业路径:修完错误 → 加 script → 同一个 PR 里删掉 DEBT 条目(否则 `RECONCILED` 不变式会失败)。

## 实测的 14 条与修法

| 类别 | 数量 | 修法 |
| --- | --- | --- |
| NodeNext 缺扩展名 TS2307(+1 条级联 TS7006) | 3 | 两处 `./field-zoo.matrix` 补 `.js` |
| flow fixture 的 `type` 没收窄 TS2322 | 8 | 标注 `: Flow` |
| 条件展开出的 headers TS2322 | 2 | 标注 `Record< string, string >` |
| 连接器 handler 少传参 TS2554 | 1 | 按声明传两个参数 |

**1. NodeNext 缺扩展名。** `field-zoo-roundtrip.dogfood.test.ts` 与 `field-zoo-value-shape.test.ts` 写 `from './field-zoo.matrix'`。文件确实在,但 `moduleResolution: NodeNext` 要求 `.js`。这不是风格问题:包内另外 **33 处**相对 import 全部带 `.js`,这两处是仅有的例外。未解析的 import 让符号退化成 `any`,回调参数随即报 implicit-any —— 补上扩展名同时消掉那条级联的 TS7006。

**2. flow fixture 的 `type`。** 四个 fixture 里的 flow 是**裸对象字面量**,`type: 'autolaunched'` 推成 `string`,喂给 `defineStack` 时对不上字面量联合。修法不是 `as const`,而是按仓内既有写法(`examples/app-todo/src/flows/task.flow.ts`)标注:

```ts
import type { Flow } from '@objectstack/spec/automation';
export const flowTouch: Flow = { ... };
```

差别是实质性的:`as const` 只让报错闭嘴,`: Flow` 让**整份 fixture** 被 spec 的真实契约检查。反向验证那一步(见下)正是靠这个标注才判红的。

**3. headers。** `token ? { Authorization } : {}` 在匿名分支上推出 `Authorization?: undefined`,展开进 `headers` 后 `HeadersInit`(`Record< string, string >`)拒收。给该常量显式标注即可。

**4. 连接器 handler —— 这条值得单独说。** `showcase-mcp-self-connection.dogfood.test.ts` 调 `handler!({})`,但契约声明的是两个参数:

```ts
handlers: Record<
    string,
    (input: Record< string, unknown >, ctx: unknown) => Promise< Record< string, unknown > >
>;
```

引擎侧也**始终**按两参数派发(`service-automation/src/builtin/connector-nodes.ts:90`:`await handler((cfg.input ?? {}) as Record< string, unknown >, handlerCtx)`),connector-mcp 自己的测试同样写 `handlers.create_issue({...}, {})`。这条调用一直「能跑」,**只是因为 MCP 这个 handler 的实现恰好忽略 `ctx`** —— 契约上它是错的,是一处被这道没人跑的门盖住的真实契约违反(运行时不炸,但它在冒充引擎的调用而少传了引擎必给的东西)。

按契约优先修的是**调用方**:改成 `handler!({}, {})`。反方向(把 `ctx` 改成可选)会为了迁就一个测试而放松 connector-mcp 的公开契约,是错误方向,没有采纳。

## 接进强制执行

```json
"scripts": {
  "typecheck": "tsc --noEmit",
  "test": "vitest run"
}
```

外加删除 `check-type-check-coverage.mjs` 里的 DEBT 条目。闸门自测与实跑:

```
✓ check:type-check-coverage --self-test — 18 semantic case(s) hold.
check-type-check-coverage: OK — 61/77 workspace packages type-checked (plus the root),
  16 in the DEBT ledger (376 frozen raw errors), 1 exempt.
```

覆盖率 60/77 → **61/77**,DEBT 17 → **16** 个包。`turbo.json` 的 `typecheck` 任务与 lint.yml 的调用都已存在(闸门的 `RUNNABLE` 不变式在管),无需改动 —— 缺的只是这个包的 script。

## 反向验证

在 `flow-touch-fixture.ts` 里把 `type` 改成 `'not_a_real_flow_type'`,走**真实 CI 入口**:

```
$ npx turbo run typecheck --filter=@objectstack/dogfood
@objectstack/dogfood:typecheck: test/fixtures/flow-touch-fixture.ts(49,3): error TS2322:
  Type '"not_a_real_flow_type"' is not assignable to type
  '"api" | "schedule" | "autolaunched" | "screen" | "record_change"'.
 Tasks:    60 successful, 61 total
Failed:    @objectstack/dogfood#typecheck
```

改回后:

```
@objectstack/dogfood:typecheck: cache hit, replaying logs 238d29ba02f83710
 Tasks:    61 successful, 61 total
```

`238d29ba02f83710` 与注入前那次绿跑是同一个 turbo hash —— 证明状态被精确还原,绿不是残留缓存蒙对的。

## 测试

```
$ pnpm --filter @objectstack/dogfood test
 Test Files  83 passed | 1 skipped (84)
      Tests  481 passed | 3 skipped (484)
```

零行为改动:所有修改要么是类型标注,要么是补模块扩展名,要么是把调用补齐到既有契约(`ctx` 在这个 handler 的实现里本就未被读取)。ESLint 干净。

## 改动范围

限于 `packages/qa/dogfood`,加两个接线文件:

- `scripts/check-type-check-coverage.mjs` —— **根目录共享文件**,只删掉 dogfood 那一条 DEBT 条目(账本注释里写明的毕业动作;不删则 `RECONCILED` 不变式失败)。未改动闸门的任何语义。
- `.changeset/dogfood-typecheck-wired.md` —— 内部 qa 包 + dev script,按 `per-package-typecheck-coverage.md` / `ci-performance-optimization.md` 的先例用空 frontmatter,不发版。

`turbo.json` 与 `.github/workflows/lint.yml` **未改动**。


---
_Generated by [Claude Code](https://claude.ai/code/session_018iARDqtrhQgz6fVHDeDkbQ)_