### PR TITLE
fix(lint): ADR-0105 D6 ② 的收件人词表扩至 ADR 原文范围 —— `unit_and_subordinates` 也判红 (#4991)

### DIFF
--- a/.changeset/adr-0105-d6-unit-and-subordinates.md
+++ b/.changeset/adr-0105-d6-unit-and-subordinates.md
@@ -1,0 +1,34 @@
+---
+"@objectstack/lint": patch
+---
+
+fix(lint): 扩 ADR-0105 D6 ② 的收件人词表至 ADR 原文范围 —— `unit_and_subordinates`
+也判红
+
+`org-axis-cross-org-bu-grant`(D6 ②)此前只对 `sharedWith.type ===
+'business_unit'` 判红,而授权面**更大**的另一个业务单元收件人
+`unit_and_subordinates`(一个 BU **加上其全部后代单元**,ADR-0057 D5 子树扩张)
+直接放行。两者的缺陷完全相同:平台级对象(`tenancy.enabled: false` /
+`systemFields.tenant: false`)没有 organization 列可供 Layer 0 收口,BU 子树没有
+任何 organization 可供解析,授权因而跨到库里每一个 organization —— 正是 ADR 拒绝
+的"跨 org BU 巨树",从后门到达。
+
+漏掉的恰恰是 ADR-0105 D6 ② 自己点名的那一个:
+
+> Every BU mechanism — `unit_and_subordinates` sharing, `adminScope`
+> delegation, depth scopes — operates within one organization. There is no
+> cross-org tree.
+
+判定改为收件人类型 ∈ `{ business_unit, unit_and_subordinates }`,诊断信息里点名
+**实际写下的**类型并说明其触及范围(子树那一个额外写明 "AND every descendant
+unit"),修复建议改为指向三个扁平收件人。
+
+词表与 spec 枚举 `ShareRecipientType` 的差集不再是隐式的:规则里以表格逐条写明
+拦截二者、放行 `user` / `team` / `position` 的理由(它们的运行时展开都不经
+`BusinessUnitGraphService`,是 `tenancy.enabled: false` 平台级目录**被设计用来**
+共享的方式),并附一条测试断言两半恰好划分 `ShareRecipientType` —— 将来枚举加成员
+会在词表处失败,而不是无声地落进没人选过的那一桶。#4991 正是这条断言缺席的产物。
+
+这是 error 级门禁的扩张,因此复核了真实元数据:`examples/app-showcase` /
+`app-crm` 是仓库里仅有的已声明 sharing rule(共 11 条),全仓无任何对象关掉
+tenancy,扩张后 org-axis 红线数为 **0** —— 不产生新红。

--- a/packages/lint/src/validate-org-axis-red-lines.test.ts
+++ b/packages/lint/src/validate-org-axis-red-lines.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { ObjectSchema } from '@objectstack/spec/data';
-import { SharingRuleSchema, type SharingRuleInput } from '@objectstack/spec/security';
+import { ShareRecipientType, SharingRuleSchema, type SharingRuleInput } from '@objectstack/spec/security';
 
 import {
   validateOrgAxisRedLines,
@@ -284,8 +284,21 @@ describe('validateOrgAxisRedLines — ① no permission inheritance on the org a
   });
 });
 
+/**
+ * ── Rule ②'s recipient word list ────────────────────────────────────────────
+ *
+ * The two BU-tree recipients ② intercepts, and the three it deliberately lets
+ * past. Split out here because the drift guard below asserts the two halves
+ * partition `ShareRecipientType` exactly — the check whose absence is #4991.
+ */
+const BU_TREE_RECIPIENTS = ['business_unit', 'unit_and_subordinates'] as const;
+const FLAT_RECIPIENTS = ['user', 'team', 'position'] as const;
+
 describe('validateOrgAxisRedLines — ② business-unit trees stay org-internal', () => {
-  const platformGlobalStack = (tenancy: unknown) => ({
+  const platformGlobalStack = (
+    tenancy: unknown,
+    recipientType: string = 'business_unit',
+  ) => ({
     objects: [
       objectFixture(
         tenancy === undefined
@@ -298,21 +311,82 @@ describe('validateOrgAxisRedLines — ② business-unit trees stay org-internal'
         name: 'catalog_to_plant',
         type: 'criteria',
         object: 'material_catalog',
-        sharedWith: { type: 'business_unit', value: 'bu_plant_a' },
+        sharedWith: { type: recipientType, value: 'bu_plant_a' },
         condition: 'true',
-      }),
+      } as unknown as SharingRuleInput),
     ],
   });
 
-  it('flags a business-unit grant on a `tenancy.enabled: false` object', () => {
-    const findings = validateOrgAxisRedLines(platformGlobalStack({ enabled: false }));
-    expect(findings).toHaveLength(1);
-    expect(findings[0]).toMatchObject({
-      severity: 'error',
-      rule: ORG_AXIS_CROSS_ORG_BU_GRANT,
-      path: 'sharingRules[0].sharedWith',
-    });
-    expect(findings[0].message).toMatch(/spans EVERY organization/);
+  /**
+   * The word list ② enforces must PARTITION the authoring enum: every member of
+   * `ShareRecipientType` is either intercepted as a BU-tree recipient or named
+   * in the allowed half with a reason in the rule's own comment. No third
+   * bucket, no silent remainder.
+   *
+   * This is the guard #4991 is the absence of. ② shipped naming a single
+   * recipient, `business_unit`, while ADR-0105 D6 ②'s own sentence names
+   * `unit_and_subordinates` — the strictly WIDER grant (a BU plus every
+   * descendant unit) sailed past the gate that stopped the narrower one. A
+   * sixth enum member added tomorrow fails HERE, at the vocabulary, instead of
+   * quietly inheriting whichever bucket nobody chose for it.
+   */
+  it('partitions `ShareRecipientType` — no recipient is unaccounted for (#4991)', () => {
+    const declared = [...ShareRecipientType.options].sort();
+    const accounted = [...BU_TREE_RECIPIENTS, ...FLAT_RECIPIENTS].sort();
+    expect(accounted).toEqual(declared);
+  });
+
+  it.each(BU_TREE_RECIPIENTS)(
+    'flags a `%s` grant on a `tenancy.enabled: false` object',
+    (recipientType) => {
+      const findings = validateOrgAxisRedLines(platformGlobalStack({ enabled: false }, recipientType));
+      expect(findings).toHaveLength(1);
+      expect(findings[0]).toMatchObject({
+        severity: 'error',
+        rule: ORG_AXIS_CROSS_ORG_BU_GRANT,
+        path: 'sharingRules[0].sharedWith',
+      });
+      expect(findings[0].message).toMatch(/spans EVERY organization/);
+      // The diagnostic names the recipient actually written, not a generic
+      // "business-unit rule" the author then has to go match up themselves.
+      expect(findings[0].message).toContain(`\`${recipientType}\``);
+    },
+  );
+
+  it('spells out that `unit_and_subordinates` reaches the whole subtree', () => {
+    // The two recipients share a defect but not a blast radius: this one is the
+    // BU plus every descendant unit (ADR-0057 D5), so the message says so.
+    const [finding] = validateOrgAxisRedLines(
+      platformGlobalStack({ enabled: false }, 'unit_and_subordinates'),
+    );
+    expect(finding.message).toMatch(/AND every descendant unit/);
+    const [narrow] = validateOrgAxisRedLines(platformGlobalStack({ enabled: false }, 'business_unit'));
+    expect(narrow.message).not.toMatch(/descendant/);
+  });
+
+  it('flags `unit_and_subordinates` under the `systemFields.tenant: false` spelling too', () => {
+    expect(
+      rules({
+        objects: [objectFixture({ name: 'material_catalog', systemFields: { tenant: false } })],
+        sharingRules: [
+          sharingRule({
+            name: 'r',
+            type: 'criteria',
+            object: 'material_catalog',
+            sharedWith: { type: 'unit_and_subordinates', value: 'bu_field_ops' },
+            condition: 'true',
+          }),
+        ],
+      }),
+    ).toEqual([ORG_AXIS_CROSS_ORG_BU_GRANT]);
+  });
+
+  it('allows `unit_and_subordinates` on an ORG-SCOPED object (the showcase shape)', () => {
+    // `share_new_inquiries_with_field_ops` → `showcase_inquiry` in
+    // examples/app-showcase: a real, correct subtree grant. The widened word
+    // list must not turn the sanctioned intra-org case red.
+    expect(rules(platformGlobalStack({ enabled: true }, 'unit_and_subordinates'))).toEqual([]);
+    expect(rules(platformGlobalStack(undefined, 'unit_and_subordinates'))).toEqual([]);
   });
 
   it('flags the `systemFields.tenant: false` spelling of the same opt-out', () => {
@@ -337,22 +411,30 @@ describe('validateOrgAxisRedLines — ② business-unit trees stay org-internal'
     expect(rules(platformGlobalStack(undefined))).toEqual([]);
   });
 
-  it('allows a non-BU audience on a platform-global object', () => {
-    expect(
-      rules({
-        objects: [objectFixture({ name: 'material_catalog', tenancy: { enabled: false } })],
-        sharingRules: [
-          sharingRule({
-            name: 'r',
-            type: 'criteria',
-            object: 'material_catalog',
-            sharedWith: { type: 'position', value: 'buyer' },
-            condition: 'true',
-          }),
-        ],
-      }),
-    ).toEqual([]);
-  });
+  it.each(FLAT_RECIPIENTS)(
+    'allows the flat `%s` audience on a platform-global object (the sanctioned path)',
+    (recipientType) => {
+      // These three expand with no business-unit tree involved — `user` not at
+      // all, `team` via `TeamGraphService`, `position` flat over holders
+      // (ADR-0090 D3). Sharing a platform-global catalog to them is what
+      // `tenancy.enabled: false` is FOR; ② forbids resolving a BU subtree with
+      // no organization to resolve it within, not sharing a global object.
+      expect(
+        rules({
+          objects: [objectFixture({ name: 'material_catalog', tenancy: { enabled: false } })],
+          sharingRules: [
+            sharingRule({
+              name: 'r',
+              type: 'criteria',
+              object: 'material_catalog',
+              sharedWith: { type: recipientType, value: 'buyer' },
+              condition: 'true',
+            } as unknown as SharingRuleInput),
+          ],
+        }),
+      ).toEqual([]);
+    },
+  );
 });
 
 describe('validateOrgAxisRedLines — input tolerance', () => {

--- a/packages/lint/src/validate-org-axis-red-lines.ts
+++ b/packages/lint/src/validate-org-axis-red-lines.ts
@@ -29,7 +29,10 @@
  * business-unit sharing rule on a PLATFORM-GLOBAL object (`tenancy.enabled:
  * false`) has no organization column to scope against, so the grant spans every
  * organization in the database — a cross-org BU grant by construction, and the
- * "cross-org BU mega-tree" the ADR rejected, arrived at by accident.
+ * "cross-org BU mega-tree" the ADR rejected, arrived at by accident. It covers
+ * BOTH business-unit recipients, `business_unit` and `unit_and_subordinates`
+ * — see {@link BU_TREE_RECIPIENT_TYPES} for the word list and its deliberate
+ * complement.
  *
  * Both are `error`, per ADR-0049 discipline: each mirrors a real enforcement
  * property (the Layer 0 wall's independence; the org-predicated BU resolver),
@@ -61,6 +64,41 @@ type AnyRec = Record<string, unknown>;
 
 /** The org-axis grouping reference. Reporting only — never an authorization input. */
 const ORG_PARENT_FIELD = 'parent_organization_id';
+
+/**
+ * The sharing-rule recipients rule ② intercepts: the ones whose runtime
+ * expansion IS the business-unit tree.
+ *
+ * Cross-checked word-for-word against the authoring enum `ShareRecipientType`
+ * (`@objectstack/spec/security`, `sharing.zod.ts`) — the only vocabulary an
+ * author can write, since `sharedWith` is `.strict()` and rejects everything
+ * else by name. That enum has FIVE members; this list intercepts two, and the
+ * difference is deliberate, not an oversight (it is exactly the oversight
+ * #4991 was filed for — ② shipped naming only `business_unit` while ADR-0105
+ * D6 ②'s own text names `unit_and_subordinates`):
+ *
+ * | `ShareRecipientType`    | ② | Why                                        |
+ * |-------------------------|---|--------------------------------------------|
+ * | `business_unit`         | ✅ | Members of exactly one BU — `BusinessUnitGraphService`, org-predicated. |
+ * | `unit_and_subordinates` | ✅ | That BU **plus every descendant unit** (ADR-0057 D5 subtree widening) — same resolver, strictly WIDER grant. |
+ * | `user`                  | — | A literal user id, no expansion at all. No tree to resolve, so no org to resolve it in. |
+ * | `team`                  | — | `sys_team` is a FLAT collaboration grouping (ADR-0090 D3 renamed `group` → `team`); `TeamGraphService`, not the BU graph. |
+ * | `position`              | — | Flat holder expansion (ADR-0090 D3 finalized the retirement of the position hierarchy); `PositionGraphService`, not the BU graph. The BU *depth scopes* D6 ② also names are a SCOPE mechanism, not a sharing-rule recipient. |
+ *
+ * The three allowed recipients are the sanctioned way to share a
+ * platform-global object (ADR-0066): naming a user, a flat team, or a flat
+ * position audience grants those people the catalog, which is the entire point
+ * of `tenancy.enabled: false`. What ② forbids is not "sharing a global object"
+ * but "resolving a BU SUBTREE with no organization to resolve it within".
+ *
+ * The runtime contract `SharingRuleRecipientType`
+ * (`spec/contracts/sharing-service.ts`) additionally carries `queue`; it is
+ * deliberately NOT authorable ("no `sys_queue` yet") and `expandRecipient`
+ * returns `[]` for it, so no author can reach it and it grants nothing. If it
+ * ever becomes authorable it is a work-distribution list, not a BU node — but
+ * this table is the place to re-decide that, in `ShareRecipientType` order.
+ */
+const BU_TREE_RECIPIENT_TYPES = new Set(['business_unit', 'unit_and_subordinates']);
 
 /** Coerce a collection (array or name-keyed map) to an array of records. */
 function asArray(v: unknown): AnyRec[] {
@@ -199,8 +237,10 @@ export function validateOrgAxisRedLines(stack: unknown): OrgAxisFinding[] {
 
   // ── ② Business-unit trees remain org-internal ─────────────────────────────
   //
-  // A `business_unit` recipient on a platform-global object has no organization
+  // A business-unit recipient on a platform-global object has no organization
   // column to scope against, so the grant reaches every organization's rows.
+  // Both BU recipients count — see `BU_TREE_RECIPIENT_TYPES` for why that word
+  // list is two long and which three of `ShareRecipientType` it lets past.
   const tenancyDisabledObjects = new Set(
     objects.filter((o) => isTenancyDisabled(o)).map((o) => str(o.name)).filter(Boolean),
   );
@@ -211,21 +251,29 @@ export function validateOrgAxisRedLines(stack: unknown): OrgAxisFinding[] {
     // spelt out only in the schema's rejection message (#4984).
     const sharedWith = rule.sharedWith as AnyRec | undefined;
     const recipientType = str(sharedWith?.type);
-    if (recipientType !== 'business_unit') return;
+    if (!BU_TREE_RECIPIENT_TYPES.has(recipientType)) return;
+    // `unit_and_subordinates` is the strictly wider of the two — it is the BU
+    // named plus every descendant unit — so say which one was written rather
+    // than a generic "business-unit rule" the author has to go look up.
+    const reach =
+      recipientType === 'unit_and_subordinates'
+        ? 'a business unit AND every descendant unit'
+        : 'a business unit';
     findings.push({
       severity: 'error',
       rule: ORG_AXIS_CROSS_ORG_BU_GRANT,
       where: `sharing rule "${str(rule.name) || rIndex}" on object "${target}"`,
       path: `sharingRules[${rIndex}].sharedWith`,
       message:
-        `A business-unit sharing rule targets "${target}", which opted out of tenancy ` +
-        `(\`tenancy.enabled: false\`). Platform-global objects carry no organization column, so this ` +
-        `grant spans EVERY organization — a cross-organization business-unit grant, which ADR-0105 D6 ` +
-        `forbids (BU trees are org-internal).`,
+        `Sharing rule recipient \`${recipientType}\` (${reach}) targets "${target}", which opted out of ` +
+        `tenancy (\`tenancy.enabled: false\`). Platform-global objects carry no organization column, so ` +
+        `this grant spans EVERY organization — a cross-organization business-unit grant, which ADR-0105 ` +
+        `D6 forbids (BU trees are org-internal).`,
       hint:
         `Either scope the object to organizations (drop \`tenancy.enabled: false\` so Layer 0 walls it), ` +
-        `or share it to a position / permission-set audience instead of a business unit. A ` +
-        `platform-global catalog that everyone should read wants an OWD of \`public_read\`, not a BU grant.`,
+        `or share it to a \`user\` / \`team\` / \`position\` audience instead — those expand flat, with no ` +
+        `business-unit tree to resolve. A platform-global catalog that everyone should read wants an OWD ` +
+        `of \`public_read\`, not a BU grant.`,
     });
   });
 


### PR DESCRIPTION
Fixes #4991

## 问题

`org-axis-cross-org-bu-grant`(ADR-0105 D6 ②)此前只对一种收件人判红:

```ts
if (recipientType !== 'business_unit') return;
```

而 `ShareRecipientType` 里有**两个**业务单元收件人,漏掉的那个授权面更大:

| `sharedWith.type` | 展开 | 改前 | 改后 |
|:--|:--|:--|:--|
| `business_unit` | 正好一个 BU 的成员 | 判红 ✅ | 判红 ✅ |
| `unit_and_subordinates` | 该 BU **加上其全部后代单元**(ADR-0057 D5) | **放行** ❌ | 判红 ✅ |

两者的缺陷完全相同 —— 平台级对象(`tenancy.enabled: false` / `systemFields.tenant: false`)没有 organization 列可供 Layer 0 收口,BU 子树没有任何 organization 可供解析,授权因而跨到库里每一个 organization。而漏掉的恰恰是 ADR-0105 D6 ② **自己点名**的那一个:

> Every BU mechanism — `unit_and_subordinates` sharing, `adminScope` delegation, depth scopes — operates within one organization. There is no cross-org tree.

## 词表核对(本单的核心要求)

以 spec 的 **`ShareRecipientType`**(`packages/spec/src/security/sharing.zod.ts`,`sharedWith.type` 的唯一可写词表,`.strict()` 逐名拒绝其余)为准逐词交叉核对。五个成员,拦二放三,差集**在规则注释里以表格逐条写明**:

| `ShareRecipientType` | ② | 理由 |
|:--|:-:|:--|
| `business_unit` | ✅ | 走 `BusinessUnitGraphService`,org-predicated |
| `unit_and_subordinates` | ✅ | 同一解析器,**严格更宽**的授权 |
| `user` | — | 字面 user id,完全不展开,没有树可解析 |
| `team` | — | `sys_team` 是扁平协作分组(ADR-0090 D3),走 `TeamGraphService` |
| `position` | — | 扁平 holder 展开(ADR-0090 D3 已终结职位层级),走 `PositionGraphService`;D6 ② 同时点名的 BU **depth scope** 是 scope 机制,不是 sharing-rule 收件人 |

差集是**故意**的,不是遗漏:放行的三个正是共享平台级目录的既定方式(ADR-0066)。② 禁止的不是"共享全局对象",而是"在没有 organization 可供解析的地方解析 BU 子树"。逐一按 `plugin-sharing` 的 `expandRecipient` 复核过运行时展开路径 —— 恰好只有两个走 `BusinessUnitGraphService`。

运行时契约 `SharingRuleRecipientType` 另有 `queue`,**刻意不可授权**(没有 `sys_queue`),`expandRecipient` 对其返回 `[]`,注释里一并记账。

## 结构性防复发

新增断言:**拦截半 ∪ 放行半 == `ShareRecipientType.options`**。#4991 正是这条断言缺席的产物 —— ② 照着一个收件人写完就没回头看枚举。将来枚举加第六个成员会在词表处失败,而不是无声地落进没人选过的那一桶。

## 双向证明

全部 fixture 走 #4992 引入的 `sharingRule()` meta-guard(先经真 `SharingRuleSchema` 解析,spec 合法才算数):

- **判红且点名**:`unit_and_subordinates` + `tenancy.enabled: false` / `systemFields.tenant: false` 两种拼法均判红,message 含 `` `unit_and_subordinates` `` 与 "AND every descendant unit"
- **不回归**:`business_unit` 既有拦截保持,message 不含 "descendant"
- **判绿**:`user` / `team` / `position` 在平台级对象上放行;`unit_and_subordinates` 在 org-scoped 对象上放行(showcase 的真实形状)

## 真实元数据复核(未沿用 #4984 的预核,独立重跑)

把改后的规则真跑在仓库的真实元数据上,而非只 grep:

```
=== app-showcase ===
objects scanned: 21
tenancy-disabled objects: (NONE)
sharing rules: 8
  - share_new_inquiries_with_field_ops: sharedWith.type=unit_and_subordinates object=showcase_inquiry
  - (其余 7 条均为 position)
org-axis findings: 0

=== app-crm ===
objects scanned: 6
tenancy-disabled objects: (NONE)
sharing rules: 3   (均为 position)
org-axis findings: 0

TOTAL org-axis reds on real metadata (widened rule): 0
```

并复核了 examples 之外:全仓 `sharedWith` 的非测试出现点只有这两个 examples;`default-permission-sets.ts` / `app-default-permission-set.ts` 不含任何 sharing rule;`tenancy.enabled: false` 的非测试声明为零。**扩张后零新红**,结论与 #4984 的预核一致但为独立重跑所得。

## 验证

- `pnpm --filter @objectstack/lint test` → `Test Files 55 passed (55)` / `Tests 1017 passed | 4 skipped (1021)`
- 目标文件 25 passed(改前 20)
- `pnpm --filter @objectstack/lint typecheck` → 干净
- `npx eslint` 两个改动文件 → 干净
- changeset:`@objectstack/lint` patch

改动限于 `packages/lint`(2 个文件)+ 1 个 changeset。未触碰 `content/docs/releases/`。


---
_Generated by [Claude Code](https://claude.ai/code/session_018iARDqtrhQgz6fVHDeDkbQ)_