### PR TITLE
fix(objectql): 区分「同一实例的幂等重入」与「真正的 driver 名字冲突」(#4773)

### DIFF
--- a/.changeset/driver-double-registration-log.md
+++ b/.changeset/driver-double-registration-log.md
@@ -1,0 +1,45 @@
+---
+"@objectstack/objectql": patch
+---
+
+fix(objectql): a re-registered driver stops crying wolf, and a real name collision starts saying what it cost (#4773)
+
+Every boot printed one line into `⚠ Boot diagnostics`:
+
+```
+WARN Driver already registered, skipping {"driverName":"com.objectstack.driver.sql"}
+```
+
+It was never an anomaly. The standalone `default` datasource is registered
+twice, on two legs of one round trip, and traced end to end it is the **same
+object instance** both times:
+
+1. `DatasourceConnectionService.attemptConnect()` builds the default driver and
+   registers it (`isDefault: true`), driven by `DefaultDatasourcePlugin.init()`;
+2. that plugin republishes the instance it just read back out of the engine as
+   the `driver.<name>` kernel service — the surface `os migrate` and serve's
+   storage detection resolve the primary DB through — and
+   `ObjectQLPlugin.start()`'s `driver.*` discovery loop bridges every such
+   service into the engine, handing back the driver it already holds.
+
+Nothing is decided and nothing is discarded, so `registerDriver` now reports
+that at `debug`. A no-anomaly line on every single boot does not belong at
+`warn`; it only teaches operators that `warn` means nothing.
+
+The reason this is not a blanket downgrade: the same `warn` also covered the
+case that genuinely matters — **two different driver instances claiming one
+name**, where "skipping" silently drops one of two configurations (connection
+string, pool, tenant scoping, capability set) while every query bound to that
+name keeps working against the winner. The two are now told apart by object
+identity:
+
+- **same instance** → `debug`, nothing happened;
+- **different instance under a held name** → still `warn`, now naming which
+  configuration was KEPT and which was DISCARDED (with both versions) so the
+  operator can tell what is actually in force;
+- **same instance re-registered with `isDefault` while another driver holds
+  that role** → `warn`, because the caller's intent is otherwise dropped in
+  silence.
+
+Registration behaviour is unchanged in all three cases — first registration
+still wins. Only which of them is worth an operator's attention changed.

--- a/packages/objectql/src/engine-driver-registration.test.ts
+++ b/packages/objectql/src/engine-driver-registration.test.ts
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// framework#4773: every showcase boot logged
+// `WARN Driver already registered, skipping {"driverName":"com.objectstack.driver.sql"}`.
+//
+// The diagnosis: the standalone `default` datasource is registered twice, on
+// two legs of ONE round trip, with the SAME object instance both times —
+// `DatasourceConnectionService.attemptConnect()` registers the driver it built
+// (isDefault: true), `DefaultDatasourcePlugin.init()` republishes that same
+// instance as the `driver.<name>` kernel service, and `ObjectQLPlugin.start()`'s
+// `driver.*` discovery loop bridges it back in (isDefault: false). Nothing is
+// decided and nothing is discarded, so a `warn` on every boot was pure noise —
+// and worse, it was indistinguishable from the case that DOES matter: two
+// DIFFERENT drivers claiming one name, where "skipping" silently drops one of
+// two configurations.
+//
+// These tests pin the split: identical re-entry is quiet, real divergence is
+// loud. Deleting the split would make both cases warn again (the #4773 noise)
+// or both cases quiet (a silently-adopted config, strictly worse).
+
+import { describe, it, expect } from 'vitest';
+import { ObjectQL } from './engine.js';
+
+type Record_ = { level: string; message: string; meta?: Record<string, unknown> };
+
+/** Captures every record the engine logs, at every level. */
+function makeCapturingLogger() {
+  const records: Record_[] = [];
+  const push = (level: string) => (message: string, meta?: Record<string, unknown>) => {
+    records.push({ level, message, meta });
+  };
+  const logger: any = {
+    debug: push('debug'),
+    info: push('info'),
+    warn: push('warn'),
+    error: push('error'),
+    fatal: push('fatal'),
+    child: () => logger,
+  };
+  return { logger, records };
+}
+
+/** Minimal IDataDriver stub — only identity/name/version matter here. */
+function makeDriver(name: string, version = '1.0.0') {
+  const driver: any = {
+    name,
+    version,
+    supports: {},
+    async connect() {}, async disconnect() {}, async checkHealth() { return true; },
+    async execute() { return null; },
+    async find() { return []; },
+    async findOne() { return null; },
+    async create(_o: string, data: Record<string, unknown>) { return { id: 'r_1', ...data }; },
+    async update(_o: string, id: string, data: Record<string, unknown>) { return { ...data, id }; },
+    async delete() { return true; },
+    async count() { return 0; },
+    async bulkCreate() { return []; },
+    async bulkUpdate() { return []; },
+    async bulkDelete() {},
+    async beginTransaction() { return { __trx: true, commit: async () => {}, rollback: async () => {} }; },
+    async commit() {}, async rollback() {},
+  };
+  return driver;
+}
+
+const warnsAbout = (records: Record_[], driverName: string) =>
+  records.filter((r) => r.level === 'warn' && r.meta?.driverName === driverName);
+
+describe('ObjectQL.registerDriver — identical re-entry vs. real name collision (#4773)', () => {
+  it('re-registering the SAME instance is quiet: debug, never warn', () => {
+    const { logger, records } = makeCapturingLogger();
+    const engine = new ObjectQL({ logger });
+    const driver = makeDriver('com.objectstack.driver.sql');
+
+    engine.registerDriver(driver, true);
+    // The `driver.*` discovery loop's leg: same object, no default claim.
+    engine.registerDriver(driver);
+
+    expect(warnsAbout(records, 'com.objectstack.driver.sql')).toEqual([]);
+    const debugs = records.filter((r) => r.level === 'debug' && r.meta?.driverName === 'com.objectstack.driver.sql');
+    expect(debugs).toHaveLength(1);
+    expect(debugs[0]!.message).toMatch(/same instance is a no-op/);
+  });
+
+  it('the quiet re-entry changes nothing: the first registration still stands', () => {
+    const { logger } = makeCapturingLogger();
+    const engine = new ObjectQL({ logger });
+    const driver = makeDriver('com.objectstack.driver.sql');
+
+    engine.registerDriver(driver, true);
+    engine.registerDriver(driver);
+
+    expect(engine.getDriverByName('com.objectstack.driver.sql')).toBe(driver);
+    expect(engine.getDefaultDriverName()).toBe('com.objectstack.driver.sql');
+  });
+
+  it('a DIFFERENT instance under a held name stays LOUD and names which config survived', () => {
+    const { logger, records } = makeCapturingLogger();
+    const engine = new ObjectQL({ logger });
+    const kept = makeDriver('com.objectstack.driver.sql', '1.0.0');
+    const discarded = makeDriver('com.objectstack.driver.sql', '2.0.0');
+
+    engine.registerDriver(kept, true);
+    engine.registerDriver(discarded);
+
+    const warns = warnsAbout(records, 'com.objectstack.driver.sql');
+    expect(warns).toHaveLength(1);
+    // The operator must be able to tell WHICH of the two configurations is in
+    // force without reading the source — that is the whole cost of a collision.
+    expect(warns[0]!.message).toMatch(/collision/i);
+    expect(warns[0]!.message).toMatch(/KEEPING/);
+    expect(warns[0]!.message).toMatch(/DISCARDING/);
+    expect(warns[0]!.meta).toMatchObject({ keptVersion: '1.0.0', discardedVersion: '2.0.0' });
+    // First-wins is unchanged behaviour — only the reporting got sharper.
+    expect(engine.getDriverByName('com.objectstack.driver.sql')).toBe(kept);
+  });
+
+  it('a dropped `isDefault` request stays LOUD — the intent is silently lost otherwise', () => {
+    const { logger, records } = makeCapturingLogger();
+    const engine = new ObjectQL({ logger });
+    const first = makeDriver('driver.a');
+    const second = makeDriver('driver.b');
+
+    engine.registerDriver(first, true);
+    engine.registerDriver(second);
+    // Same instance, but now asking for a role another driver already holds.
+    engine.registerDriver(second, true);
+
+    const warns = warnsAbout(records, 'driver.b');
+    expect(warns).toHaveLength(1);
+    expect(warns[0]!.message).toMatch(/IGNORED/);
+    expect(warns[0]!.meta).toMatchObject({ currentDefault: 'driver.a' });
+    expect(engine.getDefaultDriverName()).toBe('driver.a');
+  });
+
+  it('a same-instance re-entry that re-asserts an ALREADY-held default stays quiet', () => {
+    const { logger, records } = makeCapturingLogger();
+    const engine = new ObjectQL({ logger });
+    const driver = makeDriver('com.objectstack.driver.sql');
+
+    engine.registerDriver(driver, true);
+    engine.registerDriver(driver, true);
+
+    expect(warnsAbout(records, 'com.objectstack.driver.sql')).toEqual([]);
+    expect(engine.getDefaultDriverName()).toBe('com.objectstack.driver.sql');
+  });
+});

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -2020,11 +2020,69 @@ export class ObjectQL implements IObjectQLEngine {
   }
 
   /**
-   * Register a new storage driver
+   * Register a new storage driver.
+   *
+   * **Re-registering the SAME driver instance is by design, not an anomaly**
+   * (#4773). Every standalone boot does it exactly once, on two legs of one
+   * round trip:
+   *
+   *  1. `DatasourceConnectionService.attemptConnect()` builds the `default`
+   *     datasource's driver and registers it here with `isDefault: true`
+   *     (`service-datasource/src/datasource-connection-service.ts`), driven by
+   *     `DefaultDatasourcePlugin.init()`;
+   *  2. that plugin then republishes **the very object it just read back out of
+   *     this engine** as the `driver.<name>` kernel service — the surface
+   *     `os migrate` and serve's storage detection resolve the primary DB
+   *     through — and `ObjectQLPlugin.start()`'s `driver.*` discovery loop
+   *     bridges every such service into the engine, handing us back the
+   *     instance we already hold.
+   *
+   * So this guard has to answer two different questions, and the whole point of
+   * splitting it is that they deserve different voices:
+   *
+   *  - **Same instance** → leg 2 above. Nothing is decided and nothing is
+   *    discarded, and it happens on every boot: `debug`. Reporting a
+   *    no-anomaly, every-boot event at `warn` only teaches operators that
+   *    `warn` means nothing, which is what makes the next real one unreadable
+   *    (the degradation-log-level rule, #4632).
+   *  - **A DIFFERENT driver under a name we already hold** → two distinct
+   *    configurations claim one name and exactly one of them is silently
+   *    dropped. Whatever the loser carried — connection string, pool, tenant
+   *    scoping, capability set — is simply not in force, while every query
+   *    bound to that name keeps working against the winner. That is a real
+   *    caller-side defect and stays loud, now saying *which* config survived.
+   *  - **Same instance, but the caller asked for `isDefault` and something
+   *    else already is the default** → the caller's intent is being dropped,
+   *    so it is loud too rather than folded into the quiet path.
    */
   registerDriver(driver: IDataDriver, isDefault: boolean = false) {
-    if (this.drivers.has(driver.name)) {
-      this.logger.warn('Driver already registered, skipping', { driverName: driver.name });
+    const existing = this.drivers.get(driver.name);
+    if (existing) {
+      if (existing !== driver) {
+        this.logger.warn(
+          'Driver name collision — KEEPING the already-registered driver and DISCARDING the one just supplied. ' +
+            'Two different driver instances claim one name, so whatever configuration the discarded instance carried ' +
+            '(connection string, pool, capabilities) is NOT in force, while queries routed to this name keep working ' +
+            'against the one that was kept. Fix the caller: give the second datasource a name of its own.',
+          {
+            driverName: driver.name,
+            keptVersion: existing.version,
+            discardedVersion: driver.version,
+          },
+        );
+      } else if (isDefault && this.defaultDriver !== driver.name) {
+        this.logger.warn(
+          'Driver re-registered as DEFAULT but another driver already holds that role — the request is IGNORED and ' +
+            'the existing default stands. Unregister the current default first if the switch was intended.',
+          { driverName: driver.name, currentDefault: this.defaultDriver },
+        );
+      } else {
+        // The by-design round trip documented above — expected on every boot,
+        // so it must not reach the boot-diagnostics warning list.
+        this.logger.debug('Driver already registered — re-registering the same instance is a no-op', {
+          driverName: driver.name,
+        });
+      }
       return;
     }
 

--- a/packages/objectql/src/plugin.ts
+++ b/packages/objectql/src/plugin.ts
@@ -432,7 +432,17 @@ export class ObjectQLPlugin implements Plugin {
         const services = ctx.getServices();
         for (const [name, service] of services.entries()) {
             if (name.startsWith('driver.')) {
-                 // Register Driver
+                 // Register Driver.
+                 //
+                 // For the standalone `default` this is the SECOND leg of a
+                 // round trip, not a new registration (#4773):
+                 // `DefaultDatasourcePlugin.init()` already registered the
+                 // driver through `DatasourceConnectionService`, then
+                 // republished that same instance as this `driver.<name>`
+                 // service for `os migrate` / serve storage detection. Handing
+                 // it back is a deliberate no-op — see `registerDriver`, which
+                 // distinguishes this identical re-entry (quiet) from a real
+                 // name collision between two different instances (loud).
                  this.ql.registerDriver(service);
                  ctx.logger.debug('Discovered and registered driver service', { serviceName: name });
             }

--- a/packages/runtime/src/default-datasource-plugin.test.ts
+++ b/packages/runtime/src/default-datasource-plugin.test.ts
@@ -228,6 +228,66 @@ describe('DefaultDatasourcePlugin — the default datasource as a declaration (#
     expect(disconnects).toBe(0);
   }, BOOT_TIMEOUT);
 
+  it('registers the default driver TWICE with the same instance, and says nothing about it (#4773)', async () => {
+    // The round trip this pins: DefaultDatasourcePlugin.init() connects the
+    // driver through DatasourceConnectionService (registerDriver, isDefault:
+    // true), then republishes THAT instance as the `driver.<name>` kernel
+    // service, and ObjectQLPlugin.start()'s `driver.*` discovery loop bridges
+    // it straight back in (registerDriver, isDefault: false). Every boot logged
+    // `WARN Driver already registered, skipping` for it — a no-anomaly line in
+    // the boot diagnostics of every single `pnpm dev`.
+    //
+    // Both halves are asserted on purpose: the warning count alone would stay
+    // green if the second registration simply stopped happening, which is a
+    // different change with different consequences (the `driver.*` bridge is
+    // what a pre-built DriverPlugin relies on).
+    const { ObjectQL } = await import('@objectstack/objectql');
+    const registrations: Array<{ name: string; instance: unknown; isDefault: boolean }> = [];
+    const originalRegister = ObjectQL.prototype.registerDriver;
+    ObjectQL.prototype.registerDriver = function (driver: any, isDefault = false) {
+      registrations.push({ name: driver?.name, instance: driver, isDefault });
+      return originalRegister.call(this, driver, isDefault);
+    };
+    // ObjectLogger writes straight to `process.stdout` in Node (console is only
+    // its browser fallback), and `serve`'s boot-quiet window intercepts exactly
+    // this stream — so this is the same bytes the `⚠ Boot diagnostics` block
+    // replays. Capturing `console.warn` instead would see nothing and pass
+    // vacuously.
+    const stdoutLines: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    (process.stdout as any).write = (chunk: any, ...rest: any[]) => {
+      stdoutLines.push(String(chunk));
+      return (originalWrite as any)(chunk, ...rest);
+    };
+
+    const kernel = await assemble({});
+    try {
+      await kernel.bootstrap();
+      const engine = kernel.getService<IDataEngine>('data');
+      const defaultName = engine.getDefaultDriverName!()!;
+
+      // (a) it really is registered twice, with ONE object — object identity,
+      // not merely an equal configuration.
+      const forDefault = registrations.filter((r) => r.name === defaultName);
+      expect(forDefault).toHaveLength(2);
+      expect(forDefault[0]!.isDefault).toBe(true);
+      expect(forDefault[1]!.isDefault).toBe(false);
+      expect(forDefault[1]!.instance).toBe(forDefault[0]!.instance);
+      // …and the second leg is the `driver.*` service bridge, same instance again.
+      expect(kernel.getService(`driver.${defaultName}`)).toBe(engine.getDriverByName!(defaultName));
+
+      // (b) that round trip is silent — no boot-diagnostics warning.
+      const driverWarns = stdoutLines.filter(
+        (l) => /\bWARN\b/.test(l) && /already registered|Driver name collision/i.test(l),
+      );
+      expect(driverWarns).toEqual([]);
+    } finally {
+      (process.stdout as any).write = originalWrite;
+      ObjectQL.prototype.registerDriver = originalRegister;
+      try { await (kernel as any)?.stop?.(); } catch { /* noop */ }
+    }
+  }, BOOT_TIMEOUT);
+
   it("rejects an app bundle that declares a datasource named 'default' (host-reserved name)", async () => {
     const kernel = await assemble({
       bundle: {


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4773

## 逐条回答 issue 的三个问题

### 1. 谁注册了第一次、谁注册了第二次?

在真实 boot 上打桩 `ObjectQL.prototype.registerDriver` 抓调用栈,得到确定答案 —— **两次,不多不少**:

```
--- call #1  name=com.objectstack.driver.sqlite-wasm  isDefault=true
    at DatasourceConnectionService.attemptConnect (services/service-datasource/dist/index.js:605)
    at async DatasourceConnectionService.connect
    at async DefaultDatasourcePlugin.init (runtime/dist/index.js:142)
    at async ObjectKernel.initPluginWithTimeout

--- call #2  name=com.objectstack.driver.sqlite-wasm  isDefault=false
    at ObjectQLPlugin.start (objectql/dist/index.mjs:8527)
    at ObjectKernel.startPluginWithTimeout
    at ObjectKernel.bootstrap
```

对应源码位置:

| | 调用方 | 源码 | `isDefault` |
|---|---|---|---|
| 第一次(**赢**) | `DatasourceConnectionService.attemptConnect()`,由 `DefaultDatasourcePlugin.init()` 驱动 | `packages/services/service-datasource/src/datasource-connection-service.ts:542`(经 `packages/runtime/src/default-datasource-plugin.ts:142`) | `true` |
| 第二次(**被 skip**) | `ObjectQLPlugin.start()` 的 `driver.*` 服务发现循环 | `packages/objectql/src/plugin.ts:436` | `false` |

中间那一跳是关键:`DefaultDatasourcePlugin.init()` 在连上之后,把**它刚从 engine 里读回来的那个对象**(`packages/runtime/src/default-datasource-plugin.ts:163-172`,`engine.getDriverByName(engine.getDefaultDriverName())`)重新注册成 `driver.{name}` kernel service —— 那是 `os migrate`(`schema-migrate.ts` 的 `SQL_DRIVER_SERVICES`)和 serve 存储探测定位主库用的面。于是 Phase 2 里 `ObjectQLPlugin.start()` 的发现循环把它又交回给 engine。**这是一趟往返的两条腿,不是两次独立注册。**

`OS_DATABASE_URL` 推断和 `defineStack` 的 datasource 声明这两个候选都排除了:前者只产出**定义**(`standalone-stack.ts` 只做 URL→config 翻译,不建 driver),后者的非 default datasource 在 `attemptConnect` 里会被 `engineDriver.name = name` 打上自己的名字,天生不撞名。

### 2. ⭐ 两次注册的配置是否一致?—— 一致到**对象同一性**这一级

这是本单的承重问题,答案比「配置等价」更强:

```
SAME INSTANCE (call1.driver === call2.driver):  true
same name:  true
same version:  1.0.0 1.0.0
```

两次传进 `registerDriver` 的是**同一个 JS 对象引用**。没有第二份连接串、没有第二份能力集、没有任何一份配置被静默采纳或丢弃 —— 第二次调用在语义上是纯 no-op。(`supports` 两次读出来不是同一个对象,只因为它是 `get supports()` 每次现造一个,`sql-driver.ts:563`;实例本身同一。)

所以这**不**是 issue 第 2 点担心的「静默采用其中一份配置」,是第 3 点的「设计内的幂等重入」。

### 3. 那就该降级日志 —— 但**不是**一刀切降级

按 #4632 的降级日志级别约定,一条每次启动都出现、且不代表任何异常的 `warn` 只会训练人忽略 warn。但直接把这行降成 debug 会连带吞掉**真正要命的那一类**:同一个名字下来了**两个不同的实例**时,「skipping」确实就是静默丢掉了两份配置中的一份 —— 而在今天的代码里,这两种情况打的是同一行、同一级别的日志,**读日志的人无法分辨**。

所以按对象同一性把它劈成三支:

- **同一实例重入** → `debug`,并在日志点注明这趟往返为什么存在;
- **同名的不同实例** → 仍然 `warn`,而且现在说清楚**哪一份配置生效了、哪一份被丢了**(带双方 `version`),并给出修法(给第二个 datasource 起自己的名字);
- **同一实例但带 `isDefault`、而 default 已被别人占着** → 也 `warn`:调用方的意图正在被无声丢弃。

**注册行为零变化**,先到先得不变;变的只是哪一种值得运维看一眼。

## 复现前后对照(issue 里给的 repro)

`rm -rf examples/app-showcase/.objectstack && pnpm dev`(实跑在随机端口 `--fresh -p 38773/38774`,不占 3000):

**before**
```
  ⚠ Boot diagnostics — 2 warnings logged during startup:
    2026-08-03T19:53:14.434Z WARN Driver already registered, skipping {"driverName":"com.objectstack.driver.sql"}
    2026-08-03T19:53:20.099Z WARN StorageServicePlugin: storage adapter swapped (LocalStorageAdapter → LocalStorageAdapter). ...
```

**after**
```
  ⚠ Boot diagnostics — 1 warning logged during startup:
    2026-08-03T20:01:35.312Z WARN StorageServicePlugin: storage adapter swapped (LocalStorageAdapter → LocalStorageAdapter). ...
```

剩下那条是已在跟踪的 #4968,不在本单范围内。

## 文件面(申报)

- `packages/objectql/src/engine.ts` —— `registerDriver` 的守卫按对象同一性分三支 + 文档;
- `packages/objectql/src/plugin.ts` —— **仅注释**:在第二个调用方(`driver.*` 发现循环)处交叉引用这趟往返,让两端都能查到;
- `packages/objectql/src/engine-driver-registration.test.ts`(新)、`packages/runtime/src/default-datasource-plugin.test.ts` —— 回归测试;
- `.changeset/driver-double-registration-log.md`。

`packages/spec/**`、`protocol.ts`、`content/docs/releases/` 零改动;showcase 只读复现。

## 测试

新增 5 条 engine 单测(安静重入 / 重入不改变既有注册 / 同名不同实例仍然响且点名双方 / `isDefault` 意图被丢弃仍然响 / 重申已持有的 default 保持安静),外加 1 条**真 kernel boot** 的回归钉(`default-datasource-plugin.test.ts`)。

那条 boot 钉两半都断言,避免空转:(a) 这趟往返**确实发生了** —— `registerDriver` 对 default 名字恰好被调 2 次、`isDefault` 依次为 `true`/`false`、第二次的实例 `toBe` 第一次的实例,且 `driver.{name}` kernel service `toBe` engine 里那一个;(b) 整个 boot 的 stdout 里没有对应的 WARN(拦 `process.stdout.write` 而不是 `console.warn` —— Node 下 `ObjectLogger` 直写 stdout,`serve` 的 boot-quiet 窗口拦的也是这一路;第一版拦 `console.warn` 就是空转的,负向对照当场抓出来了)。

**负向对照**:把 `engine.ts` 换回 `origin/main` 重跑该钉 → `AssertionError: expected [ Array(1) ] to deeply equal []`,`Tests 1 failed`;换回本 PR → 通过。

```
pnpm --filter @objectstack/objectql test    → Test Files 113 passed (113) | Tests 1793 passed (1793)
pnpm --filter @objectstack/runtime  test    → Test Files  80 passed  (80) | Tests 1095 passed (1095)
pnpm --filter @objectstack/objectql typecheck → tsc --noEmit clean
```

门禁链(合并 `origin/main` 后重跑):`check:engine-double-contract` OK(9 pinned / 30 DEBT / 1 exempt)、`check:durability-log-level` OK(10 seams)、`check:startup-registry-verdict` OK(47 seams)、`check:driver-conformance` OK(20 cells)、`check:adr-anchors` OK、`check:init-service-contract` OK、`check:service-providers` OK、`check:type-check-coverage` OK、`check:nul-bytes` / `check:release-notes` / `check:doc-authoring` / `check:error-code-casing` / `check:role-word` OK,改动文件 eslint 无输出。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrmBxj8rK2uGCnh9aipjwX
