### PR TITLE
fix(plugin-audit): 让 provisioning 说出表建到了哪个 datasource (#4887)

### DIFF
--- a/.changeset/audit-provisioning-datasource-audible.md
+++ b/.changeset/audit-provisioning-datasource-audible.md
@@ -1,0 +1,50 @@
+---
+"@objectstack/plugin-audit": patch
+---
+
+fix(plugin-audit): say where the audit system tables were provisioned, and stop skipping provisioning silently (#4887)
+
+`AuditPlugin.provisionSystemTables()` created `sys_audit_log` / `sys_activity` /
+`sys_comment` at `kernel:ready` and then said **nothing** — not on success, and
+not when it skipped the work entirely (`typeof engine.syncObjectSchema !==
+'function'` returned silently). `syncObjectSchema()` itself returns `void` and
+has three silent exits of its own — the object is not in the registry, no driver
+resolves for it, or the resolved driver has no `syncSchema` — none of which
+throw. So "provisioned three tables" and "provisioned nothing at all" produced
+byte-identical logs, and the only way to tell them apart was to go looking in a
+database.
+
+#4887 is what that costs. `sys_audit_log` and `sys_activity` were reported as
+never provisioned because they were absent from the primary SQLite file, with
+the silent `typeof` bail named as the likely cause. Neither was true:
+`sys_audit_log` (`lifecycle.class: 'audit'`) and `sys_activity`
+(`lifecycle.class: 'telemetry'`) are routed by **ADR-0057 §3.6** to the
+dedicated `telemetry` datasource whenever one is registered, and `os dev`
+registers one by default as a *sibling file* (`dev.db` → `dev.telemetry.db`).
+Both tables had been created — in the other store. `sys_comment` carries no
+lifecycle class, stays on the primary, and was the one that "existed". Nothing
+in the log connected those three facts.
+
+Provisioning now reports itself:
+
+- **Wholesale skip is a `warn`, naming the consequence** — the tables stay
+  lazy-created on first WRITE, so an env that READS one first (the home page
+  activity feed queries `sys_activity` before any mutation) logs "no such
+  table" until something writes.
+- **One `info` line per boot listing where each table landed** —
+  `sys_audit_log→telemetry, sys_activity→telemetry, sys_comment→sqlite`,
+  resolved through the engine's own `getDriverForObject`, so the log states the
+  routing rather than leaving it to be inferred.
+- **A second `info` line when the ADR-0057 split is in effect**, saying
+  explicitly that those tables live in a different store — on SQLite, a
+  different *file* — and that anything reading them without naming the object
+  (raw SQL against the default datasource) will report "no such table" even
+  though provisioning succeeded.
+- **An object that resolves to no driver is a `warn`** — `syncObjectSchema()`
+  returns without issuing any DDL in that case and throws nothing, so the
+  per-object `catch` never fires; from outside the engine this is the only place
+  it can be observed.
+
+Behaviour is otherwise unchanged: the same three objects are synced, per-object
+failures stay isolated, and an engine without on-demand DDL still degrades
+instead of failing `start()`.

--- a/packages/plugins/plugin-audit/src/audit-plugin.test.ts
+++ b/packages/plugins/plugin-audit/src/audit-plugin.test.ts
@@ -39,8 +39,14 @@ function makeCtx(engine: unknown) {
     ['manifest', { register() {} }],
   ]);
   const readyHooks: Array<() => Promise<void> | void> = [];
+  // #4887 — the log IS the deliverable for the provisioning path: its silence
+  // is what made a working-but-elsewhere table read as a never-created one.
+  // Capture info/warn so the tests can assert on what an operator would see.
+  const logs = { info: [] as string[], warn: [] as string[] };
   const logger = {
-    info() {}, warn() {}, error() {}, debug() {},
+    info(msg: string) { logs.info.push(String(msg)); },
+    warn(msg: string) { logs.warn.push(String(msg)); },
+    error() {}, debug() {},
     child() { return logger; },
   };
   const ctx = {
@@ -51,7 +57,7 @@ function makeCtx(engine: unknown) {
       if (event === 'kernel:ready') readyHooks.push(fn);
     },
   } as any;
-  return { ctx, fireReady: async () => { for (const fn of readyHooks) await fn(); } };
+  return { ctx, logs, fireReady: async () => { for (const fn of readyHooks) await fn(); } };
 }
 
 describe('AuditPlugin — system table provisioning', () => {
@@ -86,6 +92,146 @@ describe('AuditPlugin — system table provisioning', () => {
     await plugin.init(ctx);
     await plugin.start(ctx);
     await expect(fireReady()).resolves.toBeUndefined();
+  });
+});
+
+/**
+ * #4887 — provisioning must SAY what it did.
+ *
+ * `syncObjectSchema` returns `void` and has three silent exits of its own
+ * (object not registered / no driver / driver without `syncSchema`), so a
+ * caller that only catches throws cannot distinguish "created the table" from
+ * "did nothing". Combined with a silent `typeof sync !== 'function'` bail on
+ * this side, a boot where provisioning was skipped WHOLESALE logged exactly
+ * the same thing as a boot where it worked: nothing.
+ *
+ * #4887 is what that costs. `sys_audit_log` / `sys_activity` were reported as
+ * "never provisioned" because they were absent from the primary SQLite file —
+ * but ADR-0057 §3.6 routes both (lifecycle classes `audit` / `telemetry`) to
+ * the `telemetry` datasource when one is registered, and `os dev` registers one
+ * by default as a sibling file. The tables existed; the log just never said
+ * where. These tests pin the three statements an operator now gets.
+ */
+describe('AuditPlugin — provisioning is audible (#4887)', () => {
+  /** Engine whose datasource routing mirrors ADR-0057 §3.6 in `os dev`. */
+  function makeRoutingEngine(routes: Record<string, string | undefined>, defaultName = 'sqlite') {
+    return {
+      async syncObjectSchema(_name: string) { /* DDL issued on the resolved driver */ },
+      getDriverForObject(name: string) {
+        const ds = routes[name];
+        return ds === undefined ? undefined : { name: ds };
+      },
+      getDefaultDriverName() { return defaultName; },
+    };
+  }
+
+  it('warns — instead of returning silently — when the engine has no syncObjectSchema', async () => {
+    const { ctx, logs, fireReady } = makeCtx({ async find() { return []; } });
+    const plugin = new AuditPlugin();
+    await plugin.init(ctx);
+    await plugin.start(ctx);
+    await fireReady();
+
+    const warned = logs.warn.find((m) => m.includes('no syncObjectSchema'));
+    expect(warned).toBeDefined();
+    // The warning must name the CONSEQUENCE, not just the missing method:
+    // nothing is provisioned and a read-first env logs "no such table".
+    expect(warned).toMatch(/sys_activity/);
+    expect(warned).toMatch(/no such table/);
+  });
+
+  it('reports the datasource each system table was provisioned into', async () => {
+    // The exact `os dev` shape: audit + activity split off to `telemetry`,
+    // comment stays on the primary.
+    const engine = makeRoutingEngine({
+      sys_audit_log: 'telemetry',
+      sys_activity: 'telemetry',
+      sys_comment: 'sqlite',
+    });
+    const { ctx, logs, fireReady } = makeCtx(engine);
+    const plugin = new AuditPlugin();
+    await plugin.init(ctx);
+    await plugin.start(ctx);
+    await fireReady();
+
+    const placement = logs.info.find((m) => m.includes('system tables provisioned'));
+    expect(placement).toBeDefined();
+    expect(placement).toContain('sys_audit_log→telemetry');
+    expect(placement).toContain('sys_activity→telemetry');
+    expect(placement).toContain('sys_comment→sqlite');
+
+    // …and the split itself is called out, because "absent from the database I
+    // am looking at" is not "never created".
+    const split = logs.info.find((m) => m.includes('NON-default datasource'));
+    expect(split).toBeDefined();
+    expect(split).toContain('ADR-0057');
+    expect(split).toContain('sys_audit_log→telemetry');
+    expect(split).toContain('sys_activity→telemetry');
+    // sys_comment is ON the default datasource — it must not be listed as split.
+    expect(split).not.toContain('sys_comment');
+  });
+
+  it('says nothing about a split when every table is on the default datasource', async () => {
+    const engine = makeRoutingEngine({
+      sys_audit_log: 'sqlite',
+      sys_activity: 'sqlite',
+      sys_comment: 'sqlite',
+    });
+    const { ctx, logs, fireReady } = makeCtx(engine);
+    const plugin = new AuditPlugin();
+    await plugin.init(ctx);
+    await plugin.start(ctx);
+    await fireReady();
+
+    expect(logs.info.find((m) => m.includes('system tables provisioned'))).toBeDefined();
+    expect(logs.info.some((m) => m.includes('NON-default datasource'))).toBe(false);
+    expect(logs.warn.some((m) => m.includes('NO datasource driver'))).toBe(false);
+  });
+
+  it("warns when an object resolves to no driver — syncObjectSchema's own silent exit", async () => {
+    // `syncObjectSchema` returns without issuing DDL when no driver backs the
+    // object. It throws nothing, so the per-object catch never fires: the only
+    // way this is ever visible is from the outside, here.
+    const engine = makeRoutingEngine({
+      sys_audit_log: undefined,
+      sys_activity: 'sqlite',
+      sys_comment: 'sqlite',
+    });
+    const { ctx, logs, fireReady } = makeCtx(engine);
+    const plugin = new AuditPlugin();
+    await plugin.init(ctx);
+    await plugin.start(ctx);
+    await fireReady();
+
+    const warned = logs.warn.find((m) => m.includes('NO datasource driver'));
+    expect(warned).toBeDefined();
+    expect(warned).toContain('sys_audit_log');
+    // The other two still provisioned — one unroutable object does not stop them.
+    const placement = logs.info.find((m) => m.includes('system tables provisioned'));
+    expect(placement).toContain('sys_activity→sqlite');
+    expect(placement).toContain('sys_comment→sqlite');
+    expect(placement).not.toContain('sys_audit_log');
+  });
+
+  it('keeps reporting placements when one object fails to sync', async () => {
+    const engine = {
+      async syncObjectSchema(name: string) {
+        if (name === 'sys_activity') throw new Error('disk I/O error');
+      },
+      getDriverForObject() { return { name: 'sqlite' }; },
+      getDefaultDriverName() { return 'sqlite'; },
+    };
+    const { ctx, logs, fireReady } = makeCtx(engine);
+    const plugin = new AuditPlugin();
+    await plugin.init(ctx);
+    await plugin.start(ctx);
+    await fireReady();
+
+    expect(logs.warn.some((m) => m.includes('could not provision sys_activity'))).toBe(true);
+    const placement = logs.info.find((m) => m.includes('system tables provisioned'));
+    expect(placement).toContain('sys_audit_log→sqlite');
+    expect(placement).toContain('sys_comment→sqlite');
+    expect(placement).not.toContain('sys_activity');
   });
 });
 

--- a/packages/plugins/plugin-audit/src/audit-plugin.ts
+++ b/packages/plugins/plugin-audit/src/audit-plugin.ts
@@ -181,19 +181,96 @@ export class AuditPlugin implements Plugin {
    * it is absent (and alters to add columns) — so this is safe on every boot,
    * and a no-op for objects whose table already exists. Per-object failures are
    * isolated so one bad object can't block the rest.
+   *
+   * ## Why this method reports where each table landed (#4887)
+   *
+   * `syncObjectSchema` returns `void` and exits SILENTLY on three conditions
+   * the plugin cannot see from the outside: the object is not in the registry,
+   * no driver resolves for it, or the resolved driver has no `syncSchema`. A
+   * caller that only catches throws therefore cannot tell "created" from "did
+   * nothing" — and neither could a reader of the log, because this method said
+   * nothing at all on success.
+   *
+   * That silence cost a whole misdiagnosis. #4887 reported these tables as
+   * "never provisioned" because they were absent from the primary SQLite file,
+   * and concluded the guard below had bailed out. It had not: `sys_audit_log`
+   * (`lifecycle.class: 'audit'`) and `sys_activity` (`lifecycle.class:
+   * 'telemetry'`) are routed by ADR-0057 §3.6 to the dedicated `telemetry`
+   * datasource whenever one is registered — which `os dev` provisions by
+   * default as a SIBLING FILE (`dev.db` → `dev.telemetry.db`). Their tables
+   * were created, in that other store. `sys_comment` carries no lifecycle
+   * class, stays on the primary, and was the one the reporter found. So the
+   * provisioning loop reports the resolved datasource per object, and calls out
+   * the split explicitly when it is in effect: a table that is "missing" from
+   * the database you are looking at, and a table that was never created, are
+   * different problems, and the log now distinguishes them.
    */
   private async provisionSystemTables(engine: IDataEngine, ctx: PluginContext): Promise<void> {
     // `syncObjectSchema` lives on the concrete ObjectQL engine, not the
     // IDataEngine contract; engines/drivers without on-demand DDL (e.g. an
     // in-memory test double) simply skip provisioning.
     const sync = (engine as unknown as { syncObjectSchema?: (name: string) => Promise<void> }).syncObjectSchema;
-    if (typeof sync !== 'function') return;
+    if (typeof sync !== 'function') {
+      // #4887 — this return used to be silent, so "provisioning was skipped
+      // wholesale" and "provisioning ran fine" produced identical logs. Name
+      // the consequence, not just the condition.
+      ctx.logger.warn(
+        'AuditPlugin: this engine exposes no syncObjectSchema() — sys_audit_log / sys_activity / sys_comment were NOT ' +
+          'provisioned up-front and stay lazy-created on first WRITE. An env that READS one first (the home page ' +
+          'activity feed queries sys_activity before any mutation) will log "no such table" until something writes to it.',
+      );
+      return;
+    }
+    // Same optional-probe posture as `syncObjectSchema` above: `getDriverForObject`
+    // is public on the concrete ObjectQL engine but not part of IDataEngine, so
+    // engines that lack it simply report no datasource — never an error.
+    const resolveDriver = (engine as unknown as {
+      getDriverForObject?: (name: string) => { name?: string } | undefined;
+    }).getDriverForObject;
+    // Declared on IDataEngine (optional — engines with no named-driver registry
+    // omit it), so no cast is needed here.
+    const defaultDatasource = engine.getDefaultDriverName?.();
+
+    const placements: string[] = [];
+    const offDefault: string[] = [];
     for (const obj of [SysAuditLog, SysActivity, SysComment]) {
       try {
         await sync.call(engine, obj.name);
       } catch (err) {
         ctx.logger.warn(`AuditPlugin: could not provision ${obj.name} storage — ${(err as Error)?.message ?? err}`);
+        continue;
       }
+      if (typeof resolveDriver !== 'function') continue;
+      let datasource: string | undefined;
+      try {
+        datasource = resolveDriver.call(engine, obj.name)?.name;
+      } catch {
+        datasource = undefined;
+      }
+      if (!datasource) {
+        // The second of the two silent exits #4887 asked to make audible: the
+        // call above resolved without throwing, but no driver backs this object,
+        // so `syncObjectSchema` returned having issued no DDL at all.
+        ctx.logger.warn(
+          `AuditPlugin: ${obj.name} resolves to NO datasource driver — syncObjectSchema() returned without creating its ` +
+            'storage. Reads and writes against it will fail with "no such table" until a driver backs its datasource.',
+        );
+        continue;
+      }
+      placements.push(`${obj.name}→${datasource}`);
+      if (defaultDatasource !== undefined && datasource !== defaultDatasource) offDefault.push(`${obj.name}→${datasource}`);
+    }
+
+    if (placements.length > 0) {
+      ctx.logger.info(`AuditPlugin: system tables provisioned — ${placements.join(', ')}`);
+    }
+    if (offDefault.length > 0) {
+      ctx.logger.info(
+        `AuditPlugin: ${offDefault.join(', ')} live on a NON-default datasource (ADR-0057 §3.6 lifecycle-class ` +
+          `separation), not on '${defaultDatasource}'. Their tables exist in that store — on SQLite, a different FILE. ` +
+          'Anything that reads them without naming the object (raw SQL on the default datasource) will report ' +
+          '"no such table" even though provisioning succeeded.',
+      );
     }
   }
 }


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4887

## TL;DR —— issue 的表象不成立,真因在别的车道

#4887 报告 "plugin-audit 从不 provision `sys_audit_log` / `sys_activity`",并猜测是 `provisionSystemTables()` 里那个静默的 `if (typeof sync !== 'function') return;` 提前返回了。

**实测下来两条都不成立。** provisioning 是好的,`syncObjectSchema` 被正常调用、表被正常创建 —— 只是创建在了**另一个物理库**里。真正的缺陷在 `service-analytics` 的原始 SQL 桥接,已另开 #5033(未认领,不在本车道)。

本 PR 只做本车道该做、且 issue 明确要求的那件事:**把 provisioning 的静默改成可听见**,让下一个人不必重走这条弯路。

## 诊断:两个 sqlite 文件

`examples/app-showcase`,`main` @ `e001a1f`,`SqlDriver(better-sqlite3)`,单租户:

```
pnpm dev -- --database file:/tmp/os4887/fresh.db -p 39117
```

启动横幅 `Plugins: 47 loaded` 里同时有 `TelemetryDatasource` 和 `Audit`。这是关键 —— 磁盘上有**两个**库:

```
=== /tmp/os4887/fresh.db ===            主库,88 个对象(与 issue 报的 88 完全吻合)
  sys_audit_log  : MISSING
  sys_activity   : MISSING
  sys_comment    : sys_comment

=== /tmp/os4887/fresh.telemetry.db ===  ADR-0057 §3.6 兄弟文件,9 个对象
  sys_audit_log  : sys_audit_log                              [table]
  sys_activity   : sys_activity, sys_activity__r20260804      [view + 轮转分片]
  sys_comment    : MISSING
```

原因是 **ADR-0057 §3.6**(P3 separation,#2791 已实现):`sys_audit_log` 的 `lifecycle.class` 是 `audit`,`sys_activity` 是 `telemetry`,引擎 `getDriver()` 第 3 步把这两类对象路由到名为 `telemetry` 的 datasource;而 `os dev` 在 file-backed sqlite 主库上**默认**provision 这个兄弟文件(`packages/cli/src/utils/telemetry-datasource.ts`:`dev.db` → `dev.telemetry.db`)。`sys_comment` 没有 `lifecycle.class`,留在主库 —— 所以报告人看到的正是"两个缺、一个在"。

同一个对象,两条读路径给出两个答案:

```
# 走对象路由(engine.find → getDriver → telemetry 驱动)
GET /api/v1/data/sys_audit_log?$top=200   → HTTP 200,49 条真实审计记录

# 走 dataset 原始 SQL(engine.execute,没带 { object } → 默认驱动)
POST /api/v1/analytics/dataset/query      → HTTP 200,{"rows":[],"fields":[],"totals":[]}
   服务端: WARN [Analytics] … no such table: sys_audit_log
```

**49 条记录真实存在,安全看板显示 0。** 这就是 issue 观察到的现象,但成因是 `service-analytics` 的 `executeRawSql` 自动桥接拿到了 `objectName` 却把它丢掉了(`packages/services/service-analytics/src/plugin.ts:267`),导致 dataset 的原始 SQL 永远打在默认 datasource 上。同一文件里的 `executeAggregate` 桥接调用 `engine.aggregate(objectName, …)`,路由是对的 —— 两条路径对"这个对象在哪个库"给出了不一致的答案。

详细复现与建议方向见 **#5033**。那是 `packages/services/service-analytics/**`,不是本车道,本 PR 不碰。

## 本 PR 改了什么

`syncObjectSchema()` 返回 `void`,并且自己有**三个静默出口**(对象不在 registry / 没有驱动 / 驱动没有 `syncSchema`),都不抛错 —— 所以调用方只 catch 异常是分辨不出"建好了"和"什么都没干"的。再叠加本侧那个静默的 `typeof` 提前返回,结果是:provisioning **全跳过**和 provisioning **正常工作**,打出来的日志一模一样(都是空)。这正是本 issue 被误诊的机制。

现在 provisioning 会自述:

- **整体跳过改成 `warn`,并说清后果** —— 表退回"首次 WRITE 时懒建",先 READ 的环境(首页活动流在任何写入之前就查 `sys_activity`)会一直打 `no such table`;
- **每次启动一行 `info`,列出每张表落到了哪个 datasource** —— 通过引擎自己的 `getDriverForObject` 解析,不靠推断;
- **ADR-0057 拆分生效时再补一行 `info`**,明确说这些表在另一个 store(SQLite 上就是另一个**文件**),以及"任何不指名对象去读它们的路径(默认 datasource 上的原始 SQL)会报 `no such table`,尽管 provisioning 是成功的";
- **对象解析不到驱动时是 `warn`** —— 这种情况 `syncObjectSchema()` 不发 DDL 也不抛错,per-object 的 `catch` 永远不会触发,从引擎外面只有这里能观测到。

真实运行时的输出(本分支,`pnpm dev` 全新库):

```
INFO AuditPlugin: system tables provisioned — sys_audit_log→telemetry, sys_activity→telemetry, sys_comment→com.objectstack.driver.sql
INFO AuditPlugin: sys_audit_log→telemetry, sys_activity→telemetry live on a NON-default datasource (ADR-0057 §3.6
     lifecycle-class separation), not on 'com.objectstack.driver.sql'. Their tables exist in that store — on SQLite,
     a different FILE. Anything that reads them without naming the object (raw SQL on the default datasource) will
     report "no such table" even though provisioning succeeded.
```

行为本身没变:同样 sync 这三个对象,per-object 失败依然互相隔离,没有 on-demand DDL 的引擎依然降级而不是让 `start()` 失败。

## 测试

新增 `AuditPlugin — provisioning is audible (#4887)` 5 个用例,覆盖:整体跳过要 warn 且点名后果、逐对象 datasource 落点上报、全在默认 datasource 时不误报拆分、解析不到驱动要 warn、单个对象 sync 失败不影响其余上报。

```
pnpm --filter @objectstack/plugin-audit exec vitest run --maxWorkers=2
 Test Files  7 passed (7)
      Tests  99 passed (99)

pnpm --filter @objectstack/plugin-audit typecheck   → tsc --noEmit,无输出(通过)
pnpm --filter @objectstack/plugin-audit build       → CJS/ESM/DTS Build success
eslint (改动的两个文件)                              → 无输出(通过)
```

反向验证(防空转):把 `audit-plugin.ts` 还原成 `main` 的版本后重跑,新增 5 个用例**全部失败**、旧用例全绿 —— 新测试确实在测新行为。

## 范围之外

- **#5033**(已开,未认领):`service-analytics` 的 `executeRawSql` 桥接丢弃 `objectName`。这是 #4887 现象的真因,影响面覆盖所有 `lifecycle.class ∈ {audit, telemetry, event}` 的对象以及任何显式外挂 datasource 的业务对象。
- #4887 后半段的 "0 vs not-available" widget 语义问题,涉及 analytics/UI 表面,一并记在 #5033 里,本 PR 不实现。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015W6nhsDrz6zWQc8je12a1t


---
_Generated by [Claude Code](https://claude.ai/code/session_015W6nhsDrz6zWQc8je12a1t)_