### PR TITLE
fix(runtime,spec): 让 @objectstack/runtime 的 src 真正被 tsc 读 —— 修 25 条并接进 turbo typecheck (#4311)

### DIFF
--- a/.changeset/runtime-typecheck-wired.md
+++ b/.changeset/runtime-typecheck-wired.md
@@ -1,0 +1,18 @@
+---
+'@objectstack/spec': patch
+---
+
+fix(spec,runtime): `EngineSchemaRegistryView` now declares the six package-lifecycle members it always had (#4311).
+
+`getPackage` / `installPackage` / `uninstallPackage` / `enablePackage` / `disablePackage` /
+`updatePackageManifest` are additions to the exported `EngineSchemaRegistryView` type only —
+`SchemaRegistry` has implemented all six since long before the contract existed, and three
+packages outside the engine already call them (`runtime`'s `/packages` domain handler,
+`metadata-protocol`'s install/update primitives, `service-package`'s hydration). The contract
+landed in #4404 declaring eight members; these six were missed, and nothing caught it because
+`@objectstack/runtime` had no `typecheck` script to read the caller. Zero runtime behaviour
+change: no implementation, call site or response shape moves.
+
+`@objectstack/runtime` itself is not released by this change — it gains a `typecheck` script and
+loses its `check-type-check-coverage` DEBT entry, plus type-only annotations (unused parameters
+renamed to `_`-prefixed, one unused import dropped).

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "tsup --config tsup.config.ts",
     "dev": "tsc -w",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/runtime/src/action-execution.ts
+++ b/packages/runtime/src/action-execution.ts
@@ -286,7 +286,7 @@ export async function callData(deps: ActionExecutionDeps,
  * `requiredPermissions` is ungated. Single-sourced so the REST `/actions/...`
  * route and the MCP `run_action` bridge enforce the SAME declaration.
  */
-export function actionPermissionError(deps: ActionExecutionDeps, actionDef: any, ec: any, objectName?: string): string | null {
+export function actionPermissionError(_deps: ActionExecutionDeps, actionDef: any, ec: any, objectName?: string): string | null {
     const required: string[] = Array.isArray(actionDef?.requiredPermissions)
         ? actionDef.requiredPermissions
         : [];
@@ -315,7 +315,7 @@ export function actionPermissionError(deps: ActionExecutionDeps, actionDef: any,
  * data-layer backstop — therefore decides what AI may trigger. Fail-closed by
  * default.
  */
-export function actionAiExposureError(deps: ActionExecutionDeps, actionDef: any, objectName?: string): string | null {
+export function actionAiExposureError(_deps: ActionExecutionDeps, actionDef: any, objectName?: string): string | null {
     if (actionDef?.ai?.exposed === true) return null;
     const on = objectName ? ` on '${objectName}'` : '';
     return (
@@ -331,7 +331,7 @@ export function actionAiExposureError(deps: ActionExecutionDeps, actionDef: any,
  * `flow` needs a `target` and an automation service. UI-only types
  * (`url`, `modal`, `form`) and `api` have no server dispatch here.
  */
-export function isHeadlessInvokableAction(deps: ActionExecutionDeps, action: any, hasAutomation: boolean): boolean {
+export function isHeadlessInvokableAction(_deps: ActionExecutionDeps, action: any, hasAutomation: boolean): boolean {
     const type: string = action?.type ?? 'script';
     if (type === 'script') return Boolean(action?.target || action?.body);
     if (type === 'flow') return Boolean(action?.target) && hasAutomation;
@@ -359,7 +359,7 @@ const SERVER_DISPATCHED_ACTION_TYPES: ReadonlySet<string> = new Set(['script', '
  * `Action '' on object '*' not found`. Naming the type and the prescription
  * turns that dead end into an actionable 400.
  */
-export function headlessActionTypeError(deps: ActionExecutionDeps, action: any, objectName?: string): string | null {
+export function headlessActionTypeError(_deps: ActionExecutionDeps, action: any, objectName?: string): string | null {
     const type: string = action?.type ?? 'script';
     if (SERVER_DISPATCHED_ACTION_TYPES.has(type)) return null;
     const name: string = action?.name ?? 'unknown';
@@ -424,7 +424,7 @@ export function flowActionUnavailableError(action: any): string {
  * `recordIdParam` that nothing honours is the `declared ≠ enforced` shape in
  * miniature.
  */
-export function seedFlowActionParams(deps: ActionExecutionDeps,
+export function seedFlowActionParams(_deps: ActionExecutionDeps,
     action: any,
     input: {
         objectName: string;
@@ -522,7 +522,7 @@ export async function dispatchFlowAction(deps: ActionExecutionDeps,
     return result ?? null;
 }
 
-export function actionLooksDestructive(deps: ActionExecutionDeps, action: any): boolean {
+export function actionLooksDestructive(_deps: ActionExecutionDeps, action: any): boolean {
     if (action?.ai?.requiresConfirmation !== undefined) return Boolean(action.ai.requiresConfirmation);
     return Boolean(action?.confirmText || action?.mode === 'delete' || action?.variant === 'danger');
 }
@@ -550,7 +550,7 @@ export function summarizeAction(deps: ActionExecutionDeps, action: any, obj: any
     };
 }
 
-export function jsonTypeOf(deps: ActionExecutionDeps, t: string | undefined): 'string' | 'number' | 'boolean' | 'array' {
+export function jsonTypeOf(_deps: ActionExecutionDeps, t: string | undefined): 'string' | 'number' | 'boolean' | 'array' {
     switch (t) {
         case 'number': case 'currency': case 'percent': case 'rating': case 'slider': case 'autonumber':
             return 'number';
@@ -600,7 +600,7 @@ export function summarizeActionParams(deps: ActionExecutionDeps, action: any, ob
  * parent object schema (holds `.fields`); pass `undefined` for a global
  * action with only inline params.
  */
-export function resolveDeclaredActionParams(deps: ActionExecutionDeps, action: any, obj: any): ResolvedActionParam[] {
+export function resolveDeclaredActionParams(_deps: ActionExecutionDeps, action: any, obj: any): ResolvedActionParam[] {
     const fields: Record<string, any> = obj?.fields ?? {};
     const out: ResolvedActionParam[] = [];
     for (const p of (Array.isArray(action?.params) ? action.params : [])) {
@@ -673,7 +673,7 @@ export function enforceActionParams(deps: ActionExecutionDeps,
  * context-less / self-invoked call so a body can distinguish "no session" the
  * same way hooks do.
  */
-export function buildActionSession(deps: ActionExecutionDeps, ec: any): any | undefined {
+export function buildActionSession(_deps: ActionExecutionDeps, ec: any): any | undefined {
     if (!ec || (ec.userId == null && ec.tenantId == null)) return undefined;
     return {
         ...(ec.userId != null ? { userId: String(ec.userId) } : {}),
@@ -724,7 +724,7 @@ export function buildActionExecutionContext(ec: any): Record<string, unknown> {
  * facade proxied every call context-less. Returns `undefined` when the engine
  * predates `createContext`, leaving the sandbox's own fallback in charge.
  */
-export function buildActionApi(deps: ActionExecutionDeps, ql: any, ec: any): any | undefined {
+export function buildActionApi(_deps: ActionExecutionDeps, ql: any, ec: any): any | undefined {
     if (!ql || typeof ql.createContext !== 'function') return undefined;
     try {
         return ql.createContext(buildActionExecutionContext(ec));
@@ -745,7 +745,7 @@ export function buildActionApi(deps: ActionExecutionDeps, ql: any, ec: any): any
  * and `ctx.api` write under the SAME identity (#3914); passing `ec` is what
  * separates a trusted write from a context-less one.
  */
-export function buildActionEngineFacade(deps: ActionExecutionDeps, ql: any, ec?: any): any {
+export function buildActionEngineFacade(_deps: ActionExecutionDeps, ql: any, ec?: any): any {
     const context = buildActionExecutionContext(ec);
     return {
         async insert(object: string, data: Record<string, unknown>): Promise<{ id: string }> {
@@ -1007,7 +1007,7 @@ export async function collectActionDeclarations(deps: ActionExecutionDeps,
  * `executeAction` will find: spec `objectName`, bundle-collector `object`,
  * else the `'global'` wildcard.
  */
-export function standaloneActionObjectName(deps: ActionExecutionDeps, action: any): string {
+export function standaloneActionObjectName(_deps: ActionExecutionDeps, action: any): string {
     if (typeof action?.objectName === 'string' && action.objectName.length > 0) return action.objectName;
     if (typeof action?.object === 'string' && action.object.length > 0) return action.object;
     return GLOBAL_ACTION_OBJECT_KEY;
@@ -1050,7 +1050,7 @@ export function isActionNotRegisteredError(err: any): boolean {
  * failed" (a business outcome, which propagates). Each surface words its own
  * miss: REST 404s naming the routed object, MCP throws naming the action.
  */
-export async function executeRegisteredAction(deps: ActionExecutionDeps,
+export async function executeRegisteredAction(_deps: ActionExecutionDeps,
     ql: any,
     objectName: string,
     candidates: string[],

--- a/packages/runtime/src/domains/auth.ts
+++ b/packages/runtime/src/domains/auth.ts
@@ -21,8 +21,15 @@ export function createAuthDomain(deps: DomainHandlerDeps): DomainRoute {
 /**
  * Handles Auth requests
  * path: sub-path after /auth/
+ *
+ * `_path` / `_method` / `_body` are unread by design and kept only for
+ * positional symmetry with the other domain handlers: since #4113 removed the
+ * mock session, this domain does not route on the sub-path at all — it hands
+ * `context.request` to the auth service whole, and that service owns the
+ * routing. They stay in the signature (rather than being dropped) because
+ * every caller passes them positionally, `createAuthDomain` included.
  */
-export async function handleAuthRequest(deps: DomainHandlerDeps, path: string, method: string, body: any, context: HttpProtocolContext): Promise<HttpDispatcherResult> {
+export async function handleAuthRequest(deps: DomainHandlerDeps, _path: string, _method: string, _body: any, context: HttpProtocolContext): Promise<HttpDispatcherResult> {
     // 1. Try generic Auth Service.
     //
     // [#4127] This probed `authService.handler(request, response)` — a method

--- a/packages/runtime/src/domains/mcp.ts
+++ b/packages/runtime/src/domains/mcp.ts
@@ -262,7 +262,7 @@ async function getMcpResourceMetadataUrl(deps: DomainHandlerDeps, context: HttpP
  * shape is unusable. The body is carried separately via `parsedBody`, so a
  * GET/DELETE (no body) and a POST (JSON-RPC) both normalise cleanly.
  */
-function toMcpWebRequest(deps: DomainHandlerDeps, raw: any, parsedBody: any): Request | undefined {
+function toMcpWebRequest(_deps: DomainHandlerDeps, raw: any, parsedBody: any): Request | undefined {
     if (!raw) return undefined;
     // Already a Web Request.
     if (typeof raw.headers?.get === 'function' && typeof raw.url === 'string' && typeof raw.method === 'string') {

--- a/packages/runtime/src/domains/meta.ts
+++ b/packages/runtime/src/domains/meta.ts
@@ -13,7 +13,6 @@ import {
 } from '@objectstack/core';
 import { pluralToSingular } from '@objectstack/spec/shared';
 import { CoreServiceName } from '@objectstack/spec/system';
-import * as actionExec from '../action-execution.js';
 import type { HttpProtocolContext, HttpDispatcherResult } from '../http-dispatcher.js';
 import type { DomainHandlerDeps, DomainRoute } from '../domain-handler-registry.js';
 

--- a/packages/spec/src/contracts/objectql-engine.ts
+++ b/packages/spec/src/contracts/objectql-engine.ts
@@ -50,7 +50,7 @@ import type { IDataDriver } from './data-driver';
 import type { FlowFunctionEffect, FlowFunctionEntry } from '../automation/flow-function.zod';
 
 /**
- * The engine's schema-registry view — the eight members reached through the
+ * The engine's schema-registry view — the members reached through the
  * `objectql` slot from outside the engine package.
  *
  * ObjectQL exposes the registry as a public `registry` getter over a private
@@ -58,6 +58,15 @@ import type { FlowFunctionEffect, FlowFunctionEntry } from '../automation/flow-f
  * handler reaching `_registry` through `as any` while its sibling handler read
  * the public getter (B2), and plugin-security's declared-metadata readers doing
  * the same, are the reaches this view retires.
+ *
+ * The package-lifecycle block below was missing from the original eight (#4404)
+ * and added by #4311's runtime slice. `SchemaRegistry` has always implemented
+ * all six; three packages outside the engine have always called them — the
+ * `/packages` domain handler in `runtime` (the REST owner of the whole family),
+ * `metadata-protocol`'s install/update primitives, and `service-package`'s
+ * hydration. Nothing caught the omission because `runtime` had no `typecheck`
+ * script, which is #4311's thesis in one line: the narrowing compiled only
+ * because no `tsc` ever read the caller.
  */
 export interface EngineSchemaRegistryView {
     /** The registered object schema, or `undefined`. */
@@ -76,6 +85,26 @@ export interface EngineSchemaRegistryView {
     unregisterItem(type: string, name: string): void;
     /** Seed the persisted disabled-package set before artifact load (AppPlugin boot). */
     setInitialDisabledPackageIds(ids: Iterable<string>): void;
+
+    // ── Package lifecycle (the in-memory half of `/packages`) ────────────
+    // The durable half lives in `sys_packages` and is the protocol service's;
+    // these six are the registry side the REST handlers fall back to and the
+    // protocol service writes through.
+    /** One installed package by id, or `undefined` — the duplicate-install guard's reader. */
+    getPackage(id: string): unknown;
+    /** Register a package manifest in the in-memory registry. */
+    installPackage(manifest: unknown, settings?: Record<string, unknown>): unknown;
+    /** Drop a package from the registry; `false` when no package had that id. */
+    uninstallPackage(id: string): boolean;
+    /** Flip a package to enabled; `undefined` when no package had that id. */
+    enablePackage(id: string): unknown;
+    /** Flip a package to disabled; `undefined` when no package had that id. */
+    disablePackage(id: string): unknown;
+    /** Merge the human-editable manifest fields (name / description / version) — a metadata edit, not a reinstall. */
+    updatePackageManifest(
+        id: string,
+        patch: { name?: string; description?: string; version?: string },
+    ): unknown;
 }
 
 /**

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -153,10 +153,6 @@ const DEBT = {
     errors: 2,
     note: 'code-tier 2 (TS2345).',
   },
-  '@objectstack/runtime': {
-    errors: 18,
-    note: 'noise only (TS6133 unused); no code-tier finding in #4311.',
-  },
   '@objectstack/service-analytics': {
     errors: 3,
     note: 'code-tier 2 (TS7053) + 1 noise.',
@@ -214,7 +210,7 @@ const TEST_DEBT = {
     errors: 467,
     note: 'TS2339 x255, TS2345 x188. Larger than driver-sql; src is clean, so the whole pile is test-only and invisible to every gate today.',
   },
-  '@objectstack/runtime': { tests: 66, errors: 220, note: 'TS18048 x81 (possibly-undefined), TS2345 x26, TS6133 x25. Also in DEBT: its src does not check either.' },
+  '@objectstack/runtime': { tests: 66, errors: 220, note: 'TS18048 x81 (possibly-undefined), TS2345 x26, TS6133 x25. Src graduated in #4311 (declares `typecheck`); this is now purely the hidden test layer.' },
   '@objectstack/objectql': { tests: 87, errors: 219, note: 'TS2339 x88, TS2554 x28 (wrong arity), TS7006 x25.' },
   '@objectstack/plugin-auth': { tests: 26, errors: 124, note: 'TS2493 x40 (tuple index out of range), TS18048 x24, TS2740 x18.' },
   '@objectstack/rest': { tests: 35, errors: 105, note: 'TS2835 x43 (NodeNext extensions), TS7006 x42. Also in DEBT.' },


### PR DESCRIPTION
Part of #4311 — 第一片:`@objectstack/runtime` 的 **src 层**(维护者已裁决按包切片)。照 #4855 / PR #5002 的毕业模式:修完 → 接线 → 同 PR 删台账条目。

## 问题

`scripts/check-type-check-coverage.mjs` 的 DEBT 台账把 `@objectstack/runtime` 记作:

```
'@objectstack/runtime': {
  errors: 18,
  note: 'noise only (TS6133 unused); no code-tier finding in #4311.',
},
```

`COVERED` 不变式接受「声明了 `typecheck` script」**或**「有一条带实测数的 DEBT 条目」,runtime 走的是后一条 —— 闸门诚实地记录了这个包没被检查,但**记录不等于执行**。runtime 是 dispatcher / domain handlers / action 执行的所在地,是本仓最重的运行时包之一,它的 `src/` 至今没有任何 `tsc` 读过。

## 实测:18 → 25,而且「noise only」是错的

台账冻结于 `b07d829`(2026-07-31);我在最新 main 上实测 **25 条**。漂移方向与 #4855(12 → 14)一致,再次印证「用记录顶替执行,记录就会漂」。

但比数字更重要的是**分类被记错了**:

| 类别 | 实测 | 台账所记 |
| --- | ---: | --- |
| TS6133 未用形参 / 导入(noise) | 18 | 18(全部) |
| **TS2339 属性不存在(code-tier)** | **7** | **0(「no code-tier finding」)** |

7 条 TS2339 全部落在 `src/domains/packages.ts`,是一处**真实的契约缺陷**,不是噪音。

## 真缺陷:`EngineSchemaRegistryView` 少声明了六个成员

```
src/domains/packages.ts(99,40):  error TS2339: Property 'getPackage' does not exist on type 'EngineSchemaRegistryView'.
src/domains/packages.ts(111,32): error TS2339: Property 'installPackage' does not exist on type 'EngineSchemaRegistryView'.
src/domains/packages.ts(121,34): error TS2339: Property 'enablePackage' does not exist on type 'EngineSchemaRegistryView'.
src/domains/packages.ts(134,34): error TS2339: Property 'disablePackage' does not exist on type 'EngineSchemaRegistryView'.
src/domains/packages.ts(437,34): error TS2339: Property 'getPackage' does not exist on type 'EngineSchemaRegistryView'.
src/domains/packages.ts(475,34): error TS2339: Property 'updatePackageManifest' does not exist on type 'EngineSchemaRegistryView'.
src/domains/packages.ts(487,46): error TS2339: Property 'uninstallPackage' does not exist on type 'EngineSchemaRegistryView'.
```

#4404 (#4251 B3) 把 `objectql` 槽的契约落地为 `IObjectQLEngine` / `EngineSchemaRegistryView`,文档写的是「**the eight members reached through the `objectql` slot from outside the engine package**」。这句话在写下时就不成立:

- `SchemaRegistry`(`packages/objectql/src/registry.ts:1576-1712`)一直实现着这六个成员;
- **引擎包之外**一直有三个包在调它们:`runtime` 的 `/packages` domain handler(整个 `/packages` REST 家族的 owner)、`metadata-protocol` 的 `installPackage`/`updatePackageManifest` 原语(`protocol.ts:9706,9754`)、`service-package` 的 hydration(`index.ts:213,243`)。

**为什么没人发现**:这三个包当时(和现在)都没有 `typecheck` —— runtime 与 metadata-protocol 都在 DEBT 台账里。契约的收窄之所以能编译通过,**只是因为没有任何 tsc 读过调用方**。这正是 #4311 议题正文里那句话的字面重演:「这类收窄本应让传旧形状的调用编译失败 —— 而它们至今全绿,因为没有任何 tsc 读过这些文件」。

### 修在生产者,不在消费者

按契约优先(Prime Directive #12),修法是**给 spec 的契约补齐声明**,而不是在 runtime 侧写 `(registry as any).installPackage`:

```ts
// ── Package lifecycle (the in-memory half of `/packages`) ────────────
getPackage(id: string): unknown;
installPackage(manifest: unknown, settings?: Record< string, unknown >): unknown;
uninstallPackage(id: string): boolean;
enablePackage(id: string): unknown;
disablePackage(id: string): unknown;
updatePackageManifest(id: string, patch: { name?: string; description?: string; version?: string }): unknown;
```

参数/返回类型沿用该文件既有政策(engine-local 类型 `InstalledPackage` / `ObjectStackManifest` 一律写 `unknown`,spec 不依赖 engine 包),成员写成 **required** 而非 optional —— 与该文件已写明的立场一致:「this contract describes THAT engine — the slot's actual occupant — not a hypothetical minimal one」。`ObjectQL implements IObjectQLEngine` 的 `implements` 校验仍然通过(见下方 objectql 的 typecheck 绿)。

零运行时改动:没有任何实现、调用点或响应形状移动;只是让声明追上了一直存在的实现。

## 另外 18 条 TS6133 —— 逐条说明,没有一条是「加 `!` 闭嘴」

本片**一个 `!` 也没有加,一个 `?.` 也没有加**(`bang_justifications_count = 0`)。TS18048 possibly-undefined 那一类全部在 **test 层**(TEST_DEBT 的 220 条),本片不碰。src 层的 18 条全是未用符号,三种处理:

| 位置 | 数量 | 处理 | 为什么这么修 |
| --- | ---: | --- | --- |
| `action-execution.ts` 13 个导出纯函数的首参 `deps` | 13 | 改名 `_deps` | 该模块的约定是**每个导出 helper 一律 deps 优先**(23 个函数如此),13 个纯谓词/纯构造函数用不到它。同文件 `reconcileActionRegistrations`(:1172)**本来就写着 `_deps`** —— 这是文件内既有先例,不是我发明的写法。删参会改导出函数签名,而调用它们的测试是按位置传参且不受类型检查,静默错位风险远大于收益。 |
| `domains/auth.ts` 的 `path` / `method` / `body` | 3 | 改名 `_path` / `_method` / `_body` + 补注释 | #4113 删掉 mock session 之后,`/auth` 不再按子路径分流,而是把 `context.request` 整个交给 auth service(`authService.handleRequest(context.request)`),由它自己路由 —— 三个参数是那次删除的残留。保留形参是为了与其它 domain handler 的位置签名对齐(`createAuthDomain` 就是按位置传的)。 |
| `domains/meta.ts` 的 `import * as actionExec` | 1 | 删除该 import | 全文件零引用(`grep` 仅命中 import 行本身)。`action-execution.ts` 顶层无副作用(只有函数声明和一个模块级 `Set`),删除不改变任何加载行为。 |
| `domains/mcp.ts` 的 `toMcpWebRequest(deps, …)` | 1 | 改名 `_deps` | 模块私有函数,同样遵循该文件 deps 优先的调用约定。 |

## 接进强制执行

```json
"typecheck": "tsc --noEmit"
```

外加删掉 `check-type-check-coverage.mjs` 里 runtime 的 DEBT 条目(毕业动作;不删则 `RECONCILED` 不变式失败)。

```
✓ check:type-check-coverage --self-test — 18 semantic case(s) hold.
check-type-check-coverage: OK — 62/77 workspace packages type-checked (plus the root),
  15 in the DEBT ledger (358 frozen raw errors), 1 exempt.
  test layer: 21 package(s) still exclude their own tests (652 files, 2243 frozen raw errors in TEST_DEBT).
```

覆盖率 61/77 → **62/77**,DEBT 16 → **15** 个包。`turbo.json` 与 `lint.yml` 未改动(`RUNNABLE` 不变式已在管它们)。

### TEST_DEBT 未被本片激活 —— 已确认

runtime 的 `tsconfig.json` 仍然 `exclude: ["node_modules","dist","**/*.spec.ts","**/*.test.ts"]`,**本 PR 没有动它**。所以接上 `tsc --noEmit` 只让 `src/**/*` 进入检查,66 个测试文件的 220 条错误仍然被 `TEST_DEBT` 条目冻结着,`TESTS_COVERED` 不变式照常成立(上面的实跑输出里 test 层仍是 21 个包 / 652 文件 / 2243 条,与 main 逐字相同)。这正是台账机制既有约定所要求的:**DEBT 是「src 不检查」,TEST_DEBT 是「src 检查、测试被藏」,两者独立**,src 毕业不牵动 test 层。

只订正了 TEST_DEBT 条目里一句因本 PR 而失真的注释(「Also in DEBT: its src does not check either.」→ 记明 src 已在 #4311 毕业),**实测数字 `tests: 66, errors: 220` 原封未动** —— 台账的诚实性要求删掉已经变假的话,而不是让它留在那里烂掉。

## 反向验证

在 `src/domains/packages.ts` 里给 `registry.enablePackage(id)` 塞一个多余实参,走**真实 CI 入口**:

```
$ npx turbo run typecheck --filter=@objectstack/runtime
@objectstack/runtime:typecheck: src/domains/packages.ts(121,52): error TS2554: Expected 1 arguments, but got 2.
Failed:    @objectstack/runtime#typecheck
```

值得注意的是:**判红靠的正是本 PR 新加的那条声明** —— 说明补进契约的六个成员是承重的,不是装饰(与 #5002 里 `: Flow` 优于 `as const` 的论证同形)。

revert 后:

```
@objectstack/runtime:typecheck: cache hit, replaying logs decc78ab0624d82d
 Tasks:    28 successful, 28 total
```

`decc78ab0624d82d` 与注入前那次绿跑的 turbo hash **逐字相同** —— 状态被精确还原,绿不是陈旧缓存蒙对的(照搬 #5002 的证法)。

## 测试与门禁

```
$ pnpm --filter @objectstack/runtime test
 Test Files  82 passed (82)
      Tests  1131 passed (1131)

$ npx turbo run typecheck --filter={objectql,spec,service-package,plugin-security,runtime}
 Tasks:    32 successful, 32 total          # 契约改动的下游全绿,含 ObjectQL 的 implements 校验

$ pnpm --filter @objectstack/spec check:generated
 ✓ All 8 generated artifacts are up to date.  # 接口加成员不改 api-surface(它只记导出名)

$ eslint . --no-inline-config                 # 干净
```

零行为改动:所有修改要么是类型声明补齐,要么是未用符号改名/删除。1131 个测试逐个通过,数量与 main 一致。

## 改动范围

```
packages/runtime/package.json                  |  1 +
packages/runtime/src/action-execution.ts       | 26 +++++++-------
packages/runtime/src/domains/auth.ts           |  9 ++++-
packages/runtime/src/domains/mcp.ts            |  2 +-
packages/runtime/src/domains/meta.ts           |  1 -
packages/spec/src/contracts/objectql-engine.ts | 31 +++++++++++++++-
scripts/check-type-check-coverage.mjs          |  6 +---
```

- `scripts/check-type-check-coverage.mjs` —— **根目录共享文件**,只删 runtime 的 4 行 DEBT 条目 + 改 TEST_DEBT 的一句注释。闸门语义零改动。
- `packages/spec/src/contracts/objectql-engine.ts` —— 超出「只动 runtime」的落点,但按 Prime Directive #12 这条缺陷的**生产者就在 spec**;在消费者侧 `as any` 会把一个真实的契约漏声明永久藏进 runtime。
- `.changeset/runtime-typecheck-wired.md` —— `@objectstack/spec` patch(导出接口有新增成员,`.d.ts` 对消费者可见);runtime 侧纯类型标注 + dev script,不发版。

## 留给后续切片的

- **runtime 的 test 层 220 条**(TEST_DEBT):本片按分派只做 src,未动 `tsconfig` 的 exclude。
- 一条观察,不立单:`/packages` 的 enable/disable/get/uninstall 四条路由**直接写 in-memory registry**,而 install/update 已经优先走 protocol service(持久化到 `sys_packages`)、只在服务缺席时回落 registry。四条路由的持久化对称性看着像缺口,但修它要改运行时行为,超出「类型修复不得改变测试行为」的边界,本 PR 不碰。

---
_Generated by [Claude Code](https://claude.ai/code/session_018iARDqtrhQgz6fVHDeDkbQ)_