### PR TITLE
ci(deps): OSV 批次 2026-08 —— undici 7.29.0 / hono 4.12.34 / fast-uri 3.1.5,把 main 上永远红的共享门禁修绿 (#5032)

### DIFF
--- a/.changeset/osv-batch-2026-08-fixable-bumps.md
+++ b/.changeset/osv-batch-2026-08-fixable-bumps.md
@@ -1,0 +1,59 @@
+---
+"@objectstack/plugin-hono-server": patch
+---
+
+ci(deps): OSV security batch 2026-08 — undici to 7.29.0, hono to 4.12.34,
+fast-uri to 3.1.5, so `Validate Package Dependencies` stops failing on every PR (#5032)
+
+Eight advisories (2 high, 6 medium) matched packages resolved in `main`'s
+`pnpm-lock.yaml`, and all eight name a fixed version:
+
+| advisory | CVSS | package | resolved | fixed |
+| --- | --- | --- | --- | --- |
+| `GHSA-7p8r-x3mc-p8w7` | 7.5 | `fast-uri` | 3.1.4 | 3.1.5 |
+| `GHSA-8j4g-w8fx-2239` | 5.3 | `hono` | 4.12.32, 4.12.33 | 4.12.34 |
+| `GHSA-4cwx-7wf7-3272` | 7.4 | `undici` | 7.28.0 | 7.29.0 |
+| `GHSA-jr45-8vmc-qm54` | 5.9 | `undici` | 7.28.0 | 7.29.0 |
+| `GHSA-8xcm-r25x-g524` | 4.8 | `undici` | 7.28.0 | 7.29.0 |
+| `GHSA-v3r7-h72x-cjcm` | 4.8 | `undici` | 7.28.0 | 7.29.0 |
+| `GHSA-m8rv-5g2x-5cg5` | 4.2 | `undici` | 7.28.0 | 7.29.0 |
+
+The OSV-Scanner step in `.github/workflows/validate-deps.yml` reads
+`pnpm-lock.yaml` directly and exits non-zero on any match, so the job was red on
+`main` itself and attached that red to every PR touching a manifest or the
+lockfile, whatever the PR contained (observed on #5027, whose own lockfile delta
+is three lines and resolves no new package). A permanently red gate is worse
+than no gate: the next PR that really does introduce a vulnerable dependency
+looks exactly like all the others.
+
+`undici` repeats the trap #4945 taught. The existing pin
+(`undici@>=7.23.0 <7.28.0: ^7.28.0`, added for `GHSA-vmh5-mc38-953g`) had
+settled on 7.28.0 — the version these five advisories affect — and its exclusive
+upper bound no longer covered it, so the override sat there doing nothing.
+Selector and target move together, to `<7.29.0` / `^7.29.0`. Transitive-only via
+`@vscode/vsce` > `cheerio`; `@ai-sdk/provider-utils` already resolved 7.29.0, so
+the two dedupe onto one copy. `jsdom`'s `undici` 8.9.0 is outside the selector
+and untouched.
+
+`fast-uri` is transitive-only through `ajv@8.20.0` (declares `^3.0.1`), reaching
+`@modelcontextprotocol/sdk`, `@objectstack/objectql`, `secretlint` and `table`;
+a `fast-uri@<3.1.5: ^3.1.5` override covers all of them.
+
+`hono` is the one that is not transitive-only, which is why this changeset
+releases something. Two versions were resolved: 4.12.32 from our own packages
+and 4.12.33 pulled by `@modelcontextprotocol/sdk`. The override moves the
+transitive copy and the declared ranges move with it — `@objectstack/plugin-hono-server`
+`dependencies.hono` to `^4.12.34` (the published-manifest change this patch
+covers), plus the `@objectstack/hono` and `@objectstack/plugin-auth`
+devDependencies. Overrides do not ship with published packages, so a declared
+range left behind would mean downstream resolves a version CI never ran —
+exactly what `scripts/check-override-consistency.mjs` exists to catch. The
+`@objectstack/hono` **peer** range stays the permissive `^4.12.8` on purpose: a
+peer states which host `hono` the adapter works against, and a host that pins an
+old one owns that copy. After the bump the workspace resolves a single
+`hono@4.12.34`.
+
+Scope is the eight advisories #5032 lists and nothing else. #4965 (advisories
+with no fix available, and the `osv-scanner.toml` exemption conventions that
+answer them) is a separate question — every advisory here has a fix, so this is
+an upgrade, not an exemption.

--- a/packages/adapters/hono/package.json
+++ b/packages/adapters/hono/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@objectstack/runtime": "workspace:*",
-    "hono": "^4.12.32",
+    "hono": "^4.12.34",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   },

--- a/packages/plugins/plugin-auth/package.json
+++ b/packages/plugins/plugin-auth/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
-    "hono": "^4.12.32",
+    "hono": "^4.12.34",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   },

--- a/packages/plugins/plugin-hono-server/package.json
+++ b/packages/plugins/plugin-hono-server/package.json
@@ -16,7 +16,7 @@
     "@objectstack/observability": "workspace:*",
     "@objectstack/spec": "workspace:*",
     "@objectstack/types": "workspace:*",
-    "hono": "^4.12.32"
+    "hono": "^4.12.34"
   },
   "devDependencies": {
     "@types/node": "^26.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   minimatch@<10.2.3: 10.2.3
   tar@>=2.0.0 <7.5.11: ^7.5.11
   form-data@<4.0.6: '>=4.0.6'
-  undici@>=7.23.0 <7.28.0: ^7.28.0
+  undici@>=7.23.0 <7.29.0: ^7.29.0
   better-auth@<1.7.0-rc.2: 1.7.0-rc.2
   '@better-auth/core@<1.7.0-rc.2': 1.7.0-rc.2
   '@better-auth/scim@<1.7.0-rc.1': 1.7.0-rc.1
@@ -31,6 +31,8 @@ overrides:
   react-router@<8.3.0: ^8.3.0
   '@sveltejs/kit@<2.69.1': ^2.69.1
   '@hono/node-server@<2.0.5': ^2.0.10
+  fast-uri@<3.1.5: ^3.1.5
+  hono@<4.12.34: ^4.12.34
 
 importers:
 
@@ -286,8 +288,8 @@ importers:
         version: link:../../types
     devDependencies:
       hono:
-        specifier: ^4.12.32
-        version: 4.12.32
+        specifier: ^4.12.34
+        version: 4.12.34
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -575,7 +577,7 @@ importers:
     devDependencies:
       '@hono/node-server':
         specifier: ^2.0.12
-        version: 2.0.12(hono@4.12.33)
+        version: 2.0.12(hono@4.12.34)
       '@objectstack/driver-sqlite-wasm':
         specifier: workspace:*
         version: link:../plugins/driver-sqlite-wasm
@@ -1379,8 +1381,8 @@ importers:
         specifier: ^26.1.2
         version: 26.1.2
       hono:
-        specifier: ^4.12.32
-        version: 4.12.32
+        specifier: ^4.12.34
+        version: 4.12.34
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1475,7 +1477,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: ^2.0.12
-        version: 2.0.12(hono@4.12.32)
+        version: 2.0.12(hono@4.12.34)
       '@objectstack/core':
         specifier: workspace:*
         version: link:../../core
@@ -1489,8 +1491,8 @@ importers:
         specifier: workspace:*
         version: link:../../types
       hono:
-        specifier: ^4.12.32
-        version: 4.12.32
+        specifier: ^4.12.34
+        version: 4.12.34
     devDependencies:
       '@types/node':
         specifier: ^26.1.2
@@ -3136,7 +3138,7 @@ packages:
     resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4
+      hono: ^4.12.34
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -6093,8 +6095,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -6473,12 +6475,8 @@ packages:
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
-  hono@4.12.32:
-    resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
-    engines: {node: '>=16.9.0'}
-
-  hono@4.12.33:
-    resolution: {integrity: sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@4.1.0:
@@ -8802,10 +8800,6 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
@@ -10049,13 +10043,9 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.3.3
 
-  '@hono/node-server@2.0.12(hono@4.12.32)':
+  '@hono/node-server@2.0.12(hono@4.12.34)':
     dependencies:
-      hono: 4.12.32
-
-  '@hono/node-server@2.0.12(hono@4.12.33)':
-    dependencies:
-      hono: 4.12.33
+      hono: 4.12.34
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -10330,7 +10320,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.12(hono@4.12.33)
+      '@hono/node-server': 2.0.12(hono@4.12.34)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -10340,7 +10330,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.6.1(express@5.2.1)
-      hono: 4.12.33
+      hono: 4.12.34
       jose: 6.2.7
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -11807,7 +11797,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -12182,7 +12172,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.28.0
+      undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
   chokidar@4.0.3:
@@ -12981,7 +12971,7 @@ snapshots:
       fast-string-truncated-width: 3.0.3
     optional: true
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -13467,9 +13457,7 @@ snapshots:
       set-cookie-parser: 3.1.2
     optional: true
 
-  hono@4.12.32: {}
-
-  hono@4.12.33: {}
+  hono@4.12.34: {}
 
   hosted-git-info@4.1.0:
     dependencies:
@@ -16106,8 +16094,6 @@ snapshots:
   underscore@1.13.8: {}
 
   undici-types@8.3.0: {}
-
-  undici@7.28.0: {}
 
   undici@7.29.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,6 +29,16 @@ onlyBuiltDependencies:
 #     dropped requestTls in SOCKS5 ProxyAgent. Pulled 7.27.2 through
 #     @vscode/vsce > cheerio (declares undici ^7.19.0); force the patched
 #     7.28.0 line (stays in the 7.x major cheerio supports). CI audit gate.
+#     Then five more advisories landed on 7.28.0 itself — the version this pin
+#     had settled on (GHSA-4cwx-7wf7-3272 7.4 high, GHSA-jr45-8vmc-qm54 5.9,
+#     GHSA-8xcm-r25x-g524 / GHSA-v3r7-h72x-cjcm 4.8, GHSA-m8rv-5g2x-5cg5 4.2) —
+#     so the bound moves to <7.29.0 / ^7.29.0 (#5032). NOTE the recurring trap:
+#     an exclusive upper bound stops covering the very version it pinned once
+#     that version is itself flagged, so the selector AND the target must move
+#     together — same shape as the brace-expansion 5.0.8 → 5.0.9 lift (#4945).
+#     Still transitive-only via cheerio; @ai-sdk/provider-utils already resolves
+#     7.29.0, so the two dedupe. jsdom's undici 8.9.0 is outside the selector
+#     and unaffected.
 #   - @better-auth/scim: GHSA-j8v8-g9cx-5qf4 (high) — account/provider
 #     takeover. The advisory is patched only in >=1.7.0-beta.4 — there is NO
 #     stable patched release yet (npm `latest` is still on the 1.6.x line), so
@@ -83,7 +93,7 @@ overrides:
   'minimatch@<10.2.3': '10.2.3'
   'tar@>=2.0.0 <7.5.11': '^7.5.11'
   'form-data@<4.0.6': '>=4.0.6'
-  'undici@>=7.23.0 <7.28.0': '^7.28.0'
+  'undici@>=7.23.0 <7.29.0': '^7.29.0'
   # better-auth family — kept on one line (see @better-auth/oauth-provider note).
   'better-auth@<1.7.0-rc.2': '1.7.0-rc.2'
   '@better-auth/core@<1.7.0-rc.2': '1.7.0-rc.2'
@@ -119,3 +129,22 @@ overrides:
   'react-router@<8.3.0': '^8.3.0'
   '@sveltejs/kit@<2.69.1': '^2.69.1'
   '@hono/node-server@<2.0.5': '^2.0.10'
+  # OSV batch 2026-08 (#5032) — all three name a fixed version, so they are
+  # upgrades, not exemptions (the osv-scanner.toml route #4965 defines is for
+  # advisories with NO fix and does not apply here):
+  #   fast-uri GHSA-7p8r-x3mc-p8w7 (7.5 high) — transitive-only via ajv@8.20.0
+  #     (declares ^3.0.1), which reaches @modelcontextprotocol/sdk, objectql,
+  #     secretlint and table. Nothing declares fast-uri directly.
+  #   hono GHSA-8j4g-w8fx-2239 (5.3) — the one entry here that is NOT
+  #     transitive-only: two versions resolved, 4.12.32 from our own packages
+  #     and 4.12.33 pulled by @modelcontextprotocol/sdk. The override moves the
+  #     transitive copy; the declared ranges are bumped to ^4.12.34 in lockstep
+  #     (plugin-hono-server dependency, plugin-auth + @objectstack/hono
+  #     devDependencies) so a downstream install — which never sees these
+  #     overrides — resolves the same patched line that CI tested. The
+  #     @objectstack/hono PEER range stays the permissive ^4.12.8 on purpose: a
+  #     peer states what host hono we work against, and a host that pins an old
+  #     hono owns that copy; narrowing it fixes nothing here and only breaks
+  #     compatibility. check-override-consistency.mjs covers both forms.
+  'fast-uri@<3.1.5': '^3.1.5'
+  'hono@<4.12.34': '^4.12.34'


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5032

## 这批公告是什么

8 条公告(2 High、6 Medium)命中 `origin/main` lockfile 里已解析的 4 个 package@version,**每一条都给出了修复版本**,所以走升级、不走豁免:

| 公告 | CVSS | package | 原解析版本 | 修复版本 |
|:---|---:|:---|:---|:---|
| [GHSA-7p8r-x3mc-p8w7](https://osv.dev/GHSA-7p8r-x3mc-p8w7) | 7.5 | `fast-uri` | 3.1.4 | **3.1.5** |
| [GHSA-8j4g-w8fx-2239](https://osv.dev/GHSA-8j4g-w8fx-2239) | 5.3 | `hono` | 4.12.32 | **4.12.34** |
| [GHSA-8j4g-w8fx-2239](https://osv.dev/GHSA-8j4g-w8fx-2239) | 5.3 | `hono` | 4.12.33 | **4.12.34** |
| [GHSA-4cwx-7wf7-3272](https://osv.dev/GHSA-4cwx-7wf7-3272) | 7.4 | `undici` | 7.28.0 | **7.29.0** |
| [GHSA-8xcm-r25x-g524](https://osv.dev/GHSA-8xcm-r25x-g524) | 4.8 | `undici` | 7.28.0 | **7.29.0** |
| [GHSA-jr45-8vmc-qm54](https://osv.dev/GHSA-jr45-8vmc-qm54) | 5.9 | `undici` | 7.28.0 | **7.29.0** |
| [GHSA-m8rv-5g2x-5cg5](https://osv.dev/GHSA-m8rv-5g2x-5cg5) | 4.2 | `undici` | 7.28.0 | **7.29.0** |
| [GHSA-v3r7-h72x-cjcm](https://osv.dev/GHSA-v3r7-h72x-cjcm) | 4.8 | `undici` | 7.28.0 | **7.29.0** |

`Validate Package Dependencies` 的 OSV-Scanner step 直接扫 `pnpm-lock.yaml`,命中即 exit 1。**红在 main 自己身上**,于是每个碰 manifest / lockfile 的 PR 都白背一条红(#5027 上实测,那个 PR 的 lockfile 增量只有三行、没解析出任何新包)。永远红的门禁比没有门禁更糟:下一个真的引入了脆弱依赖的 PR,在列表里长得和其它 PR 一模一样。

## 三个包各自的改法

**`undici` —— 又一次踩中 #4945 那个坑。** 原有的 pin(`undici@>=7.23.0 <7.28.0` → `^7.28.0`,当初为 GHSA-vmh5-mc38-953g 加的)恰好停在 7.28.0,而这 5 条新公告影响的正是 7.28.0;开区间上界不再覆盖它自己钉出来的版本,override 就在那儿空转。所以**区间上界与 target 必须一起移动**,抬到 `<7.29.0` / `^7.29.0` —— 和 brace-expansion 5.0.8 → 5.0.9(#4961)是同一形状,我在 `pnpm-workspace.yaml` 的注释里把这个复发陷阱写明了。纯传递依赖(`@vscode/vsce` → `cheerio`),而 `@ai-sdk/provider-utils` 本来就解析 7.29.0,所以两份 dedupe 成一份;`jsdom` 的 undici 8.9.0 在 selector 之外,未受影响。

**`fast-uri` —— 纯传递依赖**,经 `ajv@8.20.0`(声明 `^3.0.1`)进来,下游是 `@modelcontextprotocol/sdk` / `@objectstack/objectql` / `secretlint` / `table`。一条 `fast-uri@<3.1.5` → `^3.1.5` 覆盖全部。

**`hono` —— 本批唯一不是纯传递的一个**,也是这个 changeset 会发版的原因。两个版本同时在树上:4.12.32 来自我们自己的包,4.12.33 由 `@modelcontextprotocol/sdk` 拉入。override 负责搬动传递的那份,**声明范围同步抬到 `^4.12.34`**(`plugin-hono-server` 的 dependency,加上 `@objectstack/hono` 与 `plugin-auth` 的 devDependency)—— overrides 不随已发布包出厂,声明范围如果留在旧值,下游装到的就是 CI 从未跑过的版本,这正是 `check-override-consistency.mjs` 存在的理由(它现在覆盖 2 条声明,绿)。

`@objectstack/hono` 的 **peer 范围刻意保持宽松的 `^4.12.8`**:peer 说的是"这个 adapter 能配合哪个宿主 hono 工作",宿主自己钉了旧版就由宿主拥有那份副本;收窄它在本单里修不好任何东西,只会砍掉兼容性。

## 验证 —— 用 workflow 钉住的同一个 scanner

本容器 egress 拦 `api.osv.dev`,故按 #4961 的做法用真实二进制 + 离线库(`osv-scanner_linux_amd64` v2.3.8,与 workflow 的 action v2.3.8 同版本):

修复前(与 issue 里贴的 CI 输出逐字一致):

```
Scanned .../pnpm-lock.yaml file and found 1502 packages
Total 4 packages affected by 8 known vulnerabilities (0 Critical, 2 High, 6 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
8 vulnerabilities can be fixed.
EXIT=1
```

修复后(已含 #5036 落地的 `osv-scanner.toml`,且该文件**零豁免** —— 绿是真升级换来的,不是被过滤掉的):

```
Scanned .../pnpm-lock.yaml file and found 1500 packages
Loaded filter from: /home/user/objectstack-issue-5032/osv-scanner.toml
Loaded npm local db from /root/.cache/osv-scanner/npm/all.zip

No issues found
EXIT=0
```

该 job 的其余 step 全部照原样本地跑过(含 #5036 新增的那条):

```
pnpm install --frozen-lockfile --prefer-offline   → Done in 3s
node scripts/check-changeset-fixed.mjs            → ✓ fixed group 与 69 个 public 包同步
node scripts/check-override-consistency.mjs       → ✓ 2 published-manifest declaration(s) … 全部解析到 override target
node scripts/check-osv-exemptions.mjs --self-test → ✓ self-test passed
node scripts/check-osv-exemptions.mjs             → ✓ osv-scanner.toml holds zero OSV exemptions
```

`pnpm why` 前后对照:

| package | before | after |
|:---|:---|:---|
| `hono` | `Found 2 versions`(4.12.32 我们的包 / 4.12.33 经 MCP SDK) | `Found 1 version` → 4.12.34 |
| `fast-uri` | `Found 1 version` → 3.1.4 | `Found 1 version` → 3.1.5 |
| `undici` | 7.28.0(cheerio)、7.29.0(ai-sdk)、8.9.0(jsdom) | **7.28.0 消失**,cheerio 与 ai-sdk 并到 7.29.0;jsdom 8.9.0 不动 |

构建与受影响包的测试(全部在共享 verify 锁内、限堆跑,已 merge 当前 main 后重跑一遍):

```
pnpm build --concurrency=2   → Tasks: 71 successful, 71 total   (exit 0)
pnpm --filter {plugin-hono-server,hono,plugin-auth,client,mcp,connector-mcp,objectql} test → exit 0
    plugin-hono-server  13 files / 150 tests passed
    plugin-auth         29 files / 658 tests passed
    hono(adapter)        2 files /  73 tests passed
    client              17 files / 222 tests passed
    mcp                  8 files /  83 tests passed
    connector-mcp        3 files /  23 tests passed
    objectql           113 files / 1793 tests passed
pnpm --filter <同上> typecheck → exit 0
```

## 范围

严格限于 #5032 列的这 8 条。#4965(**无修复版本**的公告该怎么表达)是另一个议题,刚由 #5036 落地了 `osv-scanner.toml` 的三条约定 —— 本批每条都有修复版,按那份约定的原话就该"take the fix",所以本 PR 不新增任何 `[[IgnoredVulns]]`。改动面:`pnpm-workspace.yaml` + 3 个 manifest 的 hono 范围 + `pnpm-lock.yaml` + 1 个 changeset。`packages/spec/**`、`metadata-protocol/src/protocol.ts`、`content/docs/releases/` 零改动。

## 一处需要维护者知情的撞车

本单有两条认领评论(00:39:44 本 session `session_01NrmBxj8rK2uGCnh9aipjwX`,00:40:04 另一 session `session_018iARDqtrhQgz6fVHDeDkbQ` 的分支 `claude/issue-osv-fast-uri-hono-undici`)。按 AGENTS.md「认领评论时间戳先者优先」的判据由本 session 实施;推送前再查一次,`origin` 上不存在该分支、也没有针对这批公告的其它 PR。若那边已有更完整的在飞改动,请直接关掉本 PR —— lockfile 是全仓最易冲突的单文件,两份并行改动比任何一份都糟。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrmBxj8rK2uGCnh9aipjwX)_