### PR TITLE
收紧 AriaProps 的未知键,并按门测量把 widget 全文件 + i18n 五个形状判为 no door(#4001 批 16)

### DIFF
--- a/.changeset/unknown-key-strictness-ui-batch16.md
+++ b/.changeset/unknown-key-strictness-ui-batch16.md
@@ -1,0 +1,95 @@
+---
+'@objectstack/spec': major
+---
+
+Close `AriaProps` against unknown keys, and reclassify `widget` + five `i18n` shapes as no-door (#4001 batch 16, ADR-0078)
+
+zod's default is `.strip`: a key a schema does not declare is silently discarded
+and the parse still succeeds. On an authoring surface that is the worst failure
+mode — the author (increasingly, an AI) gets a success envelope and ships
+metadata that quietly ignores what they wrote.
+
+**BREAKING — one shape.** `AriaPropsSchema` (`ui/i18n.zod.ts`) now raises a
+named, fixable error instead of dropping the key. It is carried as `aria:` on
+roughly thirty live shapes under six metadata-type roots — `ListViewSchema`,
+`PageSchema`, `PageComponentSchema`, `DashboardWidgetSchema`, `ChartConfigSchema`,
+`ActionSchema`, and twenty SDUI component defs — so this is the highest-fan-out
+single site the `ui/` wave has closed.
+
+**What it was doing.** Through the `view` metadata root, this parsed **clean**:
+
+```ts
+getMetadataTypeSchema('view').parse({
+  listViews: { my_view: { type: 'grid', columns: ['name'],
+    aria: { label: 'Accounts', describedBy: 'accounts-help' } } },
+})
+// → aria: {}
+```
+
+Both keys gone, reported valid. The accessible name existed in the source file
+and nowhere else — a screen-reader user hears the DOM default, and nothing in the
+toolchain ever said so. Those two spellings are not hypothetical: they are what
+objectui's `ARIA_KEY_ALIASES` normalizer folds at the `ListView` boundary
+(objectui#2890), i.e. what stored view metadata actually carries.
+
+**The renames, each anchored to a named sibling contract.**
+
+| you wrote | write instead | where the wrong word comes from |
+|---|---|---|
+| `label` | `ariaLabel` | objectui's stored legacy spelling, folded by `normalizeListViewSchema` |
+| `describedBy` | `ariaDescribedBy` | same |
+| `ariaRole` | `role` | this shape's own inconsistency — two of its three keys carry the `aria` prefix and `role` does not |
+
+`arialabel`, `ariaLabell`, `ariadescribedby`, `aria-label` and `roles` are left to
+the edit-distance fallback, measured before anything was hand-written: an alias
+for a key the fallback already reaches is transcription, not judgement.
+
+**Two keys get a prescription instead of a rename**, because renaming them would
+be wrong (the ledger's finding 7 — this campaign's own fix once signposting the
+way into the failure it exists to kill):
+
+- `live` is real and rendered — by objectui's `ListView` alone, which reads
+  `schema.aria?.live` and emits `aria-live`. objectui declares it as
+  `AriaPropsSchema.extend({ live })`, so **that surface keeps accepting it** (and
+  now inherits this error map for everything else). On any other surface the
+  message says where `live` IS valid rather than pointing at a declared key that
+  means something else. Promoting it into the shared shape would advertise
+  `aria-live` on twenty-nine renderers that do not implement it; the promotion
+  question is **#5058**.
+- `ariaLabelledBy` / `labelledBy` — `aria-labelledby` references another
+  element's id, which is not the same thing as `ariaLabel` (a literal string), so
+  there is nothing to rename it to. The gap is named, and is also #5058.
+
+**A `.strip()` was added to four files this batch did not otherwise touch.**
+`animation.zod.ts`, `dnd.zod.ts` (×2), `keyboard.zod.ts` and `touch.zod.ts` build
+their config shapes as `z.object({…}).merge(AriaPropsSchema.partial())`, and
+`.merge()` adopts the incoming schema's unknown-key posture — so closing
+`AriaProps` would have silently closed all five of those shapes too, with zod's
+generic message and against #4988's measured verdict that nothing parses them.
+The explicit `.strip()` holds their posture; `i18n.test.ts` pins it.
+
+**Nothing in `ui/widget.zod.ts` changed, and five of `ui/i18n.zod.ts`'s six
+shapes were left open** — deliberately, on measurement. The ledger scheduled
+`widget` as `authorable (p)` / 9 sites and warned that `i18n`'s label shapes were
+"wide-open records by design"; resolving both found something more specific.
+`widget.zod.ts` has no authoring door at all: nothing under `packages/spec/src`
+imports it except the barrel, a BFS from all 24 metadata-type roots plus
+`defineStack` never reaches it, and no `.parse()` on any of its shapes exists in
+`objectstack`, `objectui` or `cloud` outside its own tests. The same holds for
+`I18nObjectSchema`, `PluralRuleSchema`, `NumberFormatSchema`, `DateFormatSchema`
+and `LocaleConfigSchema`. `.strict()` is a property of a parse; there is no parse.
+Retiring them or giving them a carrier is ADR-0049 enforce-or-remove, tracked in
+**#5055** — not a breaking change to spend here.
+
+The warning about the open record was aimed one level off, and both levels are
+now recorded: `I18nObject.params` is a `z.record` interpolation bag whose key
+space is whatever the message template names — openness there is the contract, and
+it was never a site this ratchet could close. The config block the map assumed was
+open alongside it (`AriaProps`) turned out to be the directory's most widely
+carried live shape.
+
+Zero-breakage evidence: full `@objectstack/spec` suite, `tsc --noEmit`, all ten
+spec `check:*` gates, `objectstack validate` on app-showcase / app-crm / app-todo,
+and an ADR-0087 direct-parse probe over the three apps' **built** artifacts —
+zero `aria` slots present, with the probe's negative control proven red on a
+legacy-spelled block.

--- a/docs/audits/2026-07-unknown-key-strictness-ledger.md
+++ b/docs/audits/2026-07-unknown-key-strictness-ledger.md
@@ -437,6 +437,52 @@ dropped at parse, and nothing failed.
     has 8, and `ui/` as 49 when it has 72. Both the map and the gate now carry the
     open-site count directly (see the remaining-strip map below).
 
+20. **The DOOR measurement was wrong in the one direction that costs a breaking
+    change** (批 16; filed as #5056). The counter in finding 19 answers "how many
+    sites"; this is its opposite number — the instrument that answers "is there
+    anybody on the other side of them", which is the question the whole
+    authorable / `no door` split turns on.
+
+    批 13 built the BFS and 批 15 added a **derived-clone bridge** to it, for a
+    real reason: `.extend()` / `.strip()` produce a clone that shares no identity
+    with its base but DOES share the base's per-property schema instances, and
+    `ChartConfigSchema` is reached exactly that way through `ReportChartSchema`.
+    The bridge fired when **any one** property matched under the same name.
+
+    Two facts turn that into a false door. Zod's `.describe()` returns a clone
+    that shares the original `_zod.def` **object** — so every described
+    `SnakeCaseIdentifierSchema` and `I18nLabelSchema` is def-identical across the
+    entire spec. And `name` / `label` are two keys almost every authorable shape
+    here declares. So `WidgetManifestSchema` — in a file **nothing imports** —
+    measured as REACHABLE on 2 shared keys out of 20, and 批 16 came within one
+    control of closing nine sites in a dead file: a breaking change spent to
+    produce *"a precisely validated dead slot — the more convincing lie"*
+    (#4583), which is the exact artifact the `no door` class was invented to stop
+    the campaign from manufacturing.
+
+    **The error is one-directional.** A too-eager bridge can only invent a door,
+    never hide one — so its entire failure budget is spent on making batches
+    tighten things nothing parses. That is what makes it worth a numbered finding
+    rather than a fix in passing.
+
+    Two method notes, both of which the campaign has now paid for twice:
+
+    - **The control that catches it is the one nobody writes.** 批 15's near-miss
+      (`typeof v !== 'object'` skipping every lazy Proxy, which halved the graph)
+      was caught by a POSITIVE control. This one is invisible to positive
+      controls — every root still resolved — and needed a NEGATIVE one plus the
+      synthetic-carrier flip. A door measurement owes all three, in the same run:
+      a known-live schema, a known-dead one, and an injected carrier that must
+      flip the verdict.
+    - **The fix is to ask how much of the shape is shared, not whether anything
+      is.** A real derived clone carries nearly all of its base's properties; a
+      coincidence carries one or two of twenty. `ui/door-reachability.testkit.ts`
+      is now the one implementation, with the threshold justified against both
+      ends of the measured range (批 15's real derivation far above it, 批 16's
+      false positive far below). The duplicate copy still living in
+      `chart.test.ts` is part of #5056 — the campaign's own recurring lesson
+      about a second copy of the truth, arriving this time in its instruments.
+
 ## Where this ended up
 
 **24 of 25 registered types closed** (from 9 when the line started), and the
@@ -500,9 +546,9 @@ not verdicts).
 | `theme.zod.ts` | 14 | authorable (p) | authored themes |
 | `app.zod.ts` | 18 | authorable | **strict as of #4001 PR B** — `AppSchema` + branding / area / context-selector / contribution, and the nav-item union converted to `z.discriminatedUnion('type', …)` (the union-error question, settled empirically: matched-branch-only errors, exact recursive paths, `toJSONSchema` clean). Per-target `params` stay open. PR A (#4142) tombstoned the seven audit-dead keys first |
 | `dashboard.zod.ts` | 11 | authorable | partially strict |
-| `widget.zod.ts` | 9 | authorable (p) | |
+| `widget.zod.ts` | 9 | ~~authorable (p)~~ **no door** | **no authoring door (measured, #4001 批 16)** — the `(p)` resolved NEGATIVE for the whole file, the second such run after 批 13's five. Three independent measurements on 2026-08-04: (1) nothing under `packages/spec/src` imports this module except the `ui/index.ts` barrel, so no schema anywhere declares a carrier key for a widget shape — `field.widget` is a `z.string()` naming a registered *component* and has never referenced `WidgetManifest`; (2) a BFS over the in-memory Zod graph from all 24 metadata-type roots plus `defineStack` (4 766 nodes) reaches none of the six shapes, while `PageSchema` / `ObjectListViewSchema` resolve in the same run, a fresh `z.object` and a deliberate look-alike both resolve unreachable, and a synthetic carrier flips all six to reachable; (3) zero `.parse()` / `.safeParse()` in `objectstack`, `objectui` or `cloud` outside this file's own tests — objectui re-exports the inferred TYPES only and under different names (`RuntimeWidgetManifest` / `FieldWidgetComponentProps`, #4115 / #3161), and a `cloud` code search returns 0 for every symbol against a working index (`"@objectstack/spec"` → 345). ADR-0049 enforce-or-remove is **#5055**. ⚠️ **The campaign's own BFS said REACHABLE on the first run** — a false positive in the derived-clone bridge, filed as **#5056**: zod's `.describe()` returns a clone that SHARES the original `_zod.def`, so `WidgetManifestSchema.name` / `.label` (a described `SnakeCaseIdentifierSchema` / `I18nLabelSchema`) are def-identical to the same leaves on live schemas, and a bridge firing on ANY one shared property links two unrelated shapes. 2 shared keys of 20. The error is one-directional — it can only manufacture a door, i.e. it can only make a batch tighten something dead. Corrected to whole-shape overlap in `ui/door-reachability.testkit.ts` and pinned in `widget.test.ts` |
 | `page.zod.ts` | 7 | authorable | partially strict (ADR-0089) |
-| `chart.zod.ts` / `i18n.zod.ts` | 7+6 | authorable (p) | i18n label shapes are wide-open records by design — verify. **`chart` 6 → 7 at the re-measurement** — again no schema changed: `ChartAggregateSchema` is written `z\n  .object({`, and the old counter's `z\.object\(` could not match across the line break |
+| `chart.zod.ts` / `i18n.zod.ts` | 7+6 | authorable / **split** | **`chart` 6 → 7 at the re-measurement** — again no schema changed: `ChartAggregateSchema` is written `z\n  .object({`, and the old counter's `z\.object\(` could not match across the line break. **`i18n` SPLITS across two classes (measured, #4001 批 16)** and is the file this table's standing warning was about. The warning said "label shapes are wide-open records by design"; measurement says something more useful. `AriaPropsSchema` is a **real door and is closed** — carried as `aria:` on ~30 live shapes under six metadata-type roots (`ListViewSchema`, `PageSchema`, `PageComponentSchema`, `DashboardWidgetSchema`, `ChartConfigSchema`, `ActionSchema`, 20 SDUI component defs) and directly BFS-reachable. It was stripping in the wild: through the `view` root, `aria: { label: 'Accounts', describedBy: 'x' }` parsed CLEAN and returned `aria: {}`, so the accessible name existed in the source file and nowhere else. The other five (`I18nObject`, `PluralRule`, `NumberFormat`, `DateFormat`, `LocaleConfig`) are **no door** — no carrier, unreachable, zero parse in all three repos; ADR-0049 is #5055. Note `NumberFormat` / `DateFormat` DO have a carrier (`LocaleConfig.numberFormat` / `.dateFormat`) but the carrier is itself doorless, so the subtree is `no door`, not `no gate`. And the warning's own subject — the wide-open **record** level — was never one of the six sites: `I18nObject.params` is a `z.record` interpolation bag whose key space is whatever the message template names, so openness there is the contract and there was nothing to close. Pinned in `i18n.zod.ts`'s header, in `i18n.test.ts`, and here |
 | `responsive.zod.ts` | 4 | authorable | **strict as of #4001 批 13** — all four sites (`ResponsiveConfig`, `ResponsiveStyles`, and the two per-breakpoint maps). This is the one file of batch 13's six whose `(p)` resolved POSITIVE, and it resolved on the graph rather than on the file's face: `page.components[].responsive` / `.responsiveStyles` put both shapes inside the `page` metadata-type root (`dashboard.widgets[].responsive` was the second carrier until #4876 retired it, same day). What the closure bought is the batch's whole argument in one parse — **`PageComponentSchema` has been `.strict()` since ADR-0089 D3a and that never reached these blocks**, so `{ type:'element:text', responsiveStyles: { lg: {…} }, responsive: { colums: {…}, hideOn: [] } }` parsed CLEAN and returned `responsiveStyles: {}, responsive: {}` — every styling and layout instruction the author wrote, gone, reported valid. A strict shell over strip-mode children is a closed surface's silhouette, not a closed surface. The curation is the file's real hazard rather than typos: it carries TWO breakpoint vocabularies sixteen lines apart on the same component (`responsiveStyles`' `large`/`medium`/`small`/`xsmall`, ADR-0065, against `responsive`'s Tailwind `xs`…`2xl`), so the aliases run BOTH ways between them and are anchored to the named sibling, not to edit distance — batch 12's method, and the only thing that can answer `lg` → `large`. Two entries had to be measured rather than reasoned: `{ columns: { large: 4, lg: 3 } }` used to keep HALF the map (the node laid out, at the wrong width, on breakpoints the author never named — worse than a total loss, which is at least visible); and `hideOn` → `hiddenOn` needed a hand-written alias because the distance fallback provably cannot reach it — it lowercases the input but not the candidates, so a capital in a declared key costs an extra edit against a budget of 2, and the all-lowercase `hiddenon` resolves while the correctly-cased `hideOn` does not. That asymmetry is general to camelCase keys, i.e. to most of the spec, and is filed as **#4990**. `StyleMapSchema` stays deliberately OPEN (its key space is every CSS property; objectui's `declarations()` emits whatever it is handed) — recorded in the schema JSDoc, in a test pin, and in this row |
 | `dataset.zod.ts` | 4 | authorable (p) | analytics dimension/measure config |
 | `animation.zod.ts` / `dnd.zod.ts` / `keyboard.zod.ts` / `touch.zod.ts` / `offline.zod.ts` | 4+4+4+7+3 | ~~authorable (p)~~ **no door** | **no authoring door (measured, #4001 批 13)** — the `(p)` resolved NEGATIVE and the row is kept only so the arithmetic stays complete. Three independent measurements on 2026-08-03: (1) nothing under `packages/spec/src` imports these modules except the `ui/index.ts` barrel, so no schema anywhere declares a carrier key for them; (2) a BFS over the in-memory Zod graph from all 24 metadata-type roots plus `defineStack`'s `ObjectStackSchema` — the closure `build-schemas.ts` uses for the #4650 deletion check — reaches none of the 22 sites, while its three positive controls (`PageSchema`, batch 11's `WebhookSchema`, batch 10's `StateMachineSchema`) all resolve `root-graph` in the same run; (3) no `.parse()` / `.safeParse()` on any of them exists in `objectstack`, `objectui` or the example apps outside their own unit tests — objectui re-exports the inferred TYPES only and says so (#2561). `.strict()` is a property of a PARSE and there is no parse, so closing them would enforce nothing and would spend a v17 breaking change to leave *"a precisely validated dead slot — the more convincing lie"* (the #4583 row below). The live question is ADR-0049 enforce-or-remove, filed as **#4988**; each file's header comment and its test file carry the same verdict (the batch 12 three-places standard). **Do not reschedule these as strictness work** — that is what the `(p)` was for, and it has been answered |
@@ -673,17 +719,17 @@ it the same way: the decision is also written beside the schema and pinned in a
 test (`flow.test.ts`, `etl.test.ts`), because a row in a table is not where the
 next person to open that file will look.
 
-#### `ui/` — 119 strip of 198
+#### `ui/` — 118 strip of 198
 
 | File | Strip | Sites | Class | Batch |
 |---|---|---|---|---|
 | `component.zod.ts` | 29 | 29 | authorable (p) | Largest single block left. SDUI component props — **verify the React-prop open slots first**; `check:react-declaration-parity` compares two DECLARATIONS and cannot tell you which props a renderer reads |
 | `view.zod.ts` | 20 | 50 | mixed | Top level and the form/page shapes are closed (ADR-0089 + the final batch). Remaining are sub-blocks; `UserFiltersSchema` is the one the last batch **named as deliberately left open** — it strips page-only keys with a test pinning that, so closing it needs its own verification |
 | `theme.zod.ts` | 14 | 14 | authorable (p) | Authored themes; `Typography` / `Animation` sub-blocks dominate |
-| `widget.zod.ts` | 9 | 9 | authorable (p) | Widget manifest + lifecycle/event/property/source |
+| `widget.zod.ts` | 9 | 9 | **no door** | ⛔ **not strictness work** — the whole file measured unreachable from every authoring root (#4001 批 16), with no carrier key and zero parse in all three repos. ADR-0049 triage is **#5055**. See the triage row above, including why the campaign's own BFS said otherwise first (**#5056**) |
 | `chart.zod.ts` | 7 | 7 | authorable (p) | Axis / series / annotation / interaction / config / groupBy / aggregate |
 | `touch.zod.ts` | 7 | 7 | **no door** | ⛔ **not strictness work** — measured unreachable from every authoring root (#4001 批 13); ADR-0049 triage is #4988. See the triage row above |
-| `i18n.zod.ts` | 6 | 6 | authorable (p) | ⚠️ the triage row warns label shapes are wide-open records **by design** — verify before closing |
+| `i18n.zod.ts` | 5 | 6 | **split** | **批 16 closed the one real door**: `AriaPropsSchema` (`strictObject`, carried as `aria:` on ~30 shapes under six metadata-type roots — it was returning `aria: {}` for a legacy-spelled block). The 5 left are `I18nObject` / `PluralRule` / `NumberFormat` / `DateFormat` / `LocaleConfig`, all **no door** (#5055) — ⛔ **do not close them**. This row shrinks without disappearing, the third such in the ledger after `flow` (批 11) and `etl` (批 12): the reverse pin fires on ZERO, so a row parked at a deliberate floor looks exactly like a row nobody finished, and only the `Class` column separates them |
 | `animation.zod.ts` | 4 | 4 | **no door** | ⛔ same as `touch` — #4988 |
 | `dnd.zod.ts` | 4 | 4 | **no door** | ⛔ same as `touch` — #4988 |
 | `keyboard.zod.ts` | 4 | 4 | **no door** | ⛔ same as `touch` — #4988 |
@@ -708,9 +754,31 @@ line, which conflicts with nothing, merged clean and wrong on both sides.
 merged alongside #4876, which edits this same section, so the conflict was
 expected and both sides' row edits were kept before recomputing.
 
-**Authorable strip in `ui/`: 97 of 119** (was 123 of 123). The subtotal moved by
-26 while only 4 sites were CLOSED, and the 22-site gap is the batch's actual
-finding rather than a rounding of it: `touch` (7), `animation` (4), `dnd` (4),
+**Authorable strip in `ui/`: 82 of 118** (批 16; was 97 of 119 at 批 13, 123 of
+123 before the campaign reached this directory). Both numbers are **recomputed
+from the surviving rows**, never decremented by a batch's own count — 批 16's
+header is 29+20+14+9+7+7+5+4+4+4+3+3+2+2+2+1+1+1 = 118, and its authorable
+subtotal is that minus the 36 sites now classified `no door` (`widget` 9,
+`touch` 7, `i18n`'s remaining 5, `animation` 4, `dnd` 4, `keyboard` 4,
+`offline` 3) = 82. See the `automation/` section's note on why this is
+mechanical rather than remembered: it has now been got wrong on both sides of a
+clean merge six times, and this section is three-way contended (批 14 #5042 and
+批 15 #5043 both edit it).
+
+批 16 moved the subtotal by 15 while CLOSING exactly one site, and the 14-site
+gap is again the batch's finding rather than a rounding of it: `widget.zod.ts`
+(9) and five of `i18n.zod.ts`'s six (`I18nObject`, `PluralRule`, `NumberFormat`,
+`DateFormat`, `LocaleConfig`) left `authorable` because their `(p)` resolved
+negative. The one closure is the file the map had flagged as most likely to be
+deliberately open — `AriaPropsSchema` — which is worth reading twice: **the
+standing warning and the measurement pointed in opposite directions**, and the
+warning was not wrong so much as aimed one level off. The wide-open record it
+described is real (`I18nObject.params`) and was never a site this ratchet could
+close; the config block the map assumed was open with it turned out to be the
+directory's most widely carried live shape.
+
+批 13's own subtotal note, kept for the arithmetic trail: it moved by
+26 while only 4 sites were CLOSED, and that 22-site gap was that batch's finding: `touch` (7), `animation` (4), `dnd` (4),
 `keyboard` (4) and `offline` (3) were reclassified out of `authorable` because
 their `(p)` resolved negative — **no metadata document is ever parsed against
 them**, so there is no author for strictness to protect. The evidence is in their

--- a/packages/spec/src/ui/animation.zod.ts
+++ b/packages/spec/src/ui/animation.zod.ts
@@ -121,7 +121,14 @@ export const ComponentAnimationSchema = lazySchema(() => z.object({
   trigger: AnimationTriggerSchema.optional().describe('When to trigger the animation'),
   reducedMotion: z.enum(['respect', 'disable', 'alternative']).default('respect')
     .describe('Accessibility: how to handle prefers-reduced-motion'),
-}).merge(AriaPropsSchema.partial()).describe('Component-level animation configuration'));
+}).merge(AriaPropsSchema.partial())
+  // `.strip()` is LOAD-BEARING (#4001 批 16): `AriaPropsSchema` became `strictObject` and
+  // `.merge()` adopts the incoming schema's unknown-key posture, so without this the shape
+  // would silently become `.strict()` — with zod's generic message, not the campaign's — and
+  // would contradict this file's measured `no door` verdict (#4988: nothing parses it, so a
+  // strict shell enforces nothing). Keep it until #4988 says what happens to this file.
+  .strip()
+  .describe('Component-level animation configuration'));
 
 export type ComponentAnimation = z.infer<typeof ComponentAnimationSchema>;
 

--- a/packages/spec/src/ui/dnd.zod.ts
+++ b/packages/spec/src/ui/dnd.zod.ts
@@ -92,7 +92,14 @@ export const DropZoneSchema = lazySchema(() => z.object({
   maxItems: z.number().optional().describe('Maximum items allowed in drop zone'),
   highlightOnDragOver: z.boolean().default(true).describe('Highlight drop zone when dragging over'),
   dropEffect: DropEffectSchema.default('move').describe('Visual effect on drop'),
-}).merge(AriaPropsSchema.partial()).describe('Drop zone configuration'));
+}).merge(AriaPropsSchema.partial())
+  // `.strip()` is LOAD-BEARING (#4001 批 16): `AriaPropsSchema` became `strictObject` and
+  // `.merge()` adopts the incoming schema's unknown-key posture, so without this the shape
+  // would silently become `.strict()` — with zod's generic message, not the campaign's — and
+  // would contradict this file's measured `no door` verdict (#4988: nothing parses it, so a
+  // strict shell enforces nothing). Keep it until #4988 says what happens to this file.
+  .strip()
+  .describe('Drop zone configuration'));
 
 export type DropZone = z.infer<typeof DropZoneSchema>;
 
@@ -107,7 +114,14 @@ export const DragItemSchema = lazySchema(() => z.object({
   constraint: DragConstraintSchema.optional().describe('Drag movement constraints'),
   preview: z.enum(['element', 'custom', 'none']).default('element').describe('Drag preview type'),
   disabled: z.boolean().default(false).describe('Disable dragging'),
-}).merge(AriaPropsSchema.partial()).describe('Draggable item configuration'));
+}).merge(AriaPropsSchema.partial())
+  // `.strip()` is LOAD-BEARING (#4001 批 16): `AriaPropsSchema` became `strictObject` and
+  // `.merge()` adopts the incoming schema's unknown-key posture, so without this the shape
+  // would silently become `.strict()` — with zod's generic message, not the campaign's — and
+  // would contradict this file's measured `no door` verdict (#4988: nothing parses it, so a
+  // strict shell enforces nothing). Keep it until #4988 says what happens to this file.
+  .strip()
+  .describe('Draggable item configuration'));
 
 export type DragItem = z.infer<typeof DragItemSchema>;
 

--- a/packages/spec/src/ui/door-reachability.testkit.ts
+++ b/packages/spec/src/ui/door-reachability.testkit.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The #4001 campaign's door measurement, as ONE implementation.
+ *
+ * "Is this schema reachable from an authoring root?" is the question that
+ * decides a batch's whole verdict — `strictObject` when the answer is yes,
+ * `no door` (reclassify, do not tighten) when it is no. Getting it wrong in the
+ * false-positive direction spends a breaking change to produce *"a precisely
+ * validated dead slot — the more convincing lie"* (#4583).
+ *
+ * Not exported from `ui/index.ts` and not a tsup entry, so it never reaches the
+ * package's public surface; `*.testkit.ts` is also outside the strictness
+ * ledger's `*.zod.ts` walk, so it adds no site to any count.
+ *
+ * ## Why the obvious walk is wrong twice
+ *
+ * Both corrections below were found by a control going red, not by reading:
+ *
+ * 1. **`typeof v !== 'object'` silently halves the graph.** `lazySchema`'s Proxy
+ *    target is `function lazyZod() {}`, so every lazy schema is
+ *    `typeof 'function'`. Skipping those makes the BFS stop at the first lazy
+ *    node and report whole families unreachable (批 15; `build-schemas.ts`'s
+ *    equivalent never hit it because it runs under `OS_EAGER_SCHEMAS=1`, where
+ *    there are no proxies).
+ * 2. **A single shared property is NOT evidence of a derived clone** — this is
+ *    #5056, found at 批 16. `.extend()` / `.strip()` produce a clone that shares
+ *    no identity with its base but DOES share the base's per-property schema
+ *    instances, so a bridge over shared property defs is genuinely needed. The
+ *    bridge as first written fired when **any one** property matched under the
+ *    same name — and zod's `.describe()` returns a clone that shares the
+ *    original `_zod.def` OBJECT, which makes every described
+ *    `SnakeCaseIdentifierSchema` / `I18nLabelSchema` def-identical across the
+ *    whole spec. Two unrelated shapes that both declare `name` and `label` (i.e.
+ *    almost every authorable shape here) therefore bridged, and
+ *    `WidgetManifestSchema` — a file nothing imports — measured as REACHABLE.
+ *    The error is one-directional: it can only produce a false door, i.e. it can
+ *    only cause a batch to tighten something dead.
+ *
+ *    The fix is to ask how much of the shape is shared rather than whether
+ *    anything is: a real derived clone carries nearly all of its base's
+ *    properties, while a coincidence carries one or two out of twenty.
+ */
+
+import { getMetadataTypeSchema, listMetadataTypeSchemaTypes } from '../kernel/metadata-type-schemas';
+import { ObjectStackSchema } from '../stack.zod';
+
+/**
+ * Identity of a schema NODE.
+ *
+ * Keyed on `_zod.def`, never on the schema binding: `lazySchema` hands out a
+ * Proxy unless `OS_EAGER_SCHEMAS=1` while the graph holds the real instances, so
+ * comparing bindings reports every root as unreachable. `def` survives the Proxy
+ * (the `_zod` facade delegates to the real internals), so it is the one stable
+ * key for both identities.
+ */
+const defOf = (s: unknown): unknown => (s as { _zod?: { def?: unknown } })?._zod?.def;
+
+const shapeOf = (node: unknown): Record<string, unknown> | null => {
+  const def = defOf(node) as { type?: string; shape?: Record<string, unknown> } | undefined;
+  return def?.type === 'object' && def.shape ? def.shape : null;
+};
+
+function childrenOf(node: unknown): unknown[] {
+  const out: unknown[] = [];
+  const seen = new Set<unknown>();
+  const walk = (v: unknown): void => {
+    // See correction 1 in the module doc: `typeof v !== 'object'` alone skips
+    // every lazy schema, because the Proxy's target is a function.
+    if (v === null || (typeof v !== 'object' && typeof v !== 'function') || seen.has(v)) return;
+    seen.add(v);
+    if (defOf(v)) { out.push(v); return; }
+    if (Array.isArray(v)) { for (const x of v) walk(x); return; }
+    if (v instanceof Map) { for (const x of v.values()) walk(x); return; }
+    for (const x of Object.values(v as Record<string, unknown>)) walk(x);
+  };
+  walk(defOf(node));
+  return out;
+}
+
+/** How a schema was (or was not) reached from the authoring roots. */
+export type DoorVerdict = 'direct' | 'derived-clone' | 'unreachable';
+
+export interface DoorMeasurement {
+  /** `direct` / `derived-clone` mean there IS a door; `unreachable` means there is not. */
+  verdict: (schema: unknown) => DoorVerdict;
+  /** Fraction of the candidate's own shape shared with the best-matching visited object. */
+  cloneOverlap: (schema: unknown) => number;
+  /** Nodes walked — a sanity floor for "the graph actually got built". */
+  nodeCount: number;
+  /** Roots walked from. */
+  rootCount: number;
+}
+
+/**
+ * A schema is treated as a derived clone when it shares at least this much of
+ * its own shape, by property def identity under the same name, with one visited
+ * object node.
+ *
+ * Chosen against both ends of the measured range rather than by taste: 批 15's
+ * real derivation (`ChartConfigSchema` reached through `ReportChartSchema`,
+ * which re-narrows two of its keys) sits far above it, and 批 16's false
+ * positive (`WidgetManifestSchema`, 2 shared keys of 20 — `name` and `label`,
+ * both shared LEAVES rather than shared structure) sits far below.
+ */
+const DERIVED_CLONE_MIN_OVERLAP = 0.5;
+
+/**
+ * BFS the in-memory Zod graph from every metadata-type root plus `defineStack`'s
+ * `ObjectStackSchema` — the closure `build-schemas.ts` uses for the #4650
+ * deletion check.
+ *
+ * `extraRoots` exists for the control every measurement owes: inject a synthetic
+ * carrier for the schema under test and the verdict MUST flip. Without it,
+ * "unreachable" and "the walker is broken" are the same output.
+ */
+export function measureDoors(extraRoots: readonly unknown[] = []): DoorMeasurement {
+  const roots: unknown[] = [];
+  for (const type of listMetadataTypeSchemaTypes()) {
+    const s = getMetadataTypeSchema(type);
+    if (s) roots.push(s);
+  }
+  roots.push(ObjectStackSchema, ...extraRoots);
+
+  const visitedDefs = new Set<unknown>();
+  const visitedShapes: Array<Record<string, unknown>> = [];
+  const queue = [...roots];
+  while (queue.length > 0) {
+    const node = queue.pop();
+    const def = defOf(node);
+    if (!def || visitedDefs.has(def)) continue;
+    visitedDefs.add(def);
+    const shape = shapeOf(node);
+    if (shape) visitedShapes.push(shape);
+    for (const child of childrenOf(node)) queue.push(child);
+  }
+
+  const cloneOverlap = (schema: unknown): number => {
+    const shape = shapeOf(schema);
+    if (!shape) return 0;
+    const entries = Object.entries(shape);
+    if (entries.length === 0) return 0;
+    let best = 0;
+    for (const visited of visitedShapes) {
+      let shared = 0;
+      for (const [name, prop] of entries) {
+        const d = defOf(prop);
+        if (d && defOf(visited[name]) === d) shared++;
+      }
+      if (shared > best) best = shared;
+    }
+    return best / entries.length;
+  };
+
+  const verdict = (schema: unknown): DoorVerdict => {
+    const def = defOf(schema);
+    if (!def) return 'unreachable';
+    if (visitedDefs.has(def)) return 'direct';
+    return cloneOverlap(schema) >= DERIVED_CLONE_MIN_OVERLAP ? 'derived-clone' : 'unreachable';
+  };
+
+  return { verdict, cloneOverlap, nodeCount: visitedDefs.size, rootCount: roots.length };
+}

--- a/packages/spec/src/ui/i18n.test.ts
+++ b/packages/spec/src/ui/i18n.test.ts
@@ -14,6 +14,13 @@ import {
   type PluralRule,
   type LocaleConfig,
 } from './i18n.zod';
+import { measureDoors } from './door-reachability.testkit';
+import { getMetadataTypeSchema } from '../kernel/metadata-type-schemas';
+import { PageSchema } from './page.zod';
+import { ComponentAnimationSchema } from './animation.zod';
+import { DropZoneSchema, DragItemSchema } from './dnd.zod';
+import { KeyboardNavigationConfigSchema } from './keyboard.zod';
+import { TouchInteractionSchema } from './touch.zod';
 
 describe('I18nObjectSchema', () => {
   it('should accept valid i18n object with key only', () => {
@@ -243,5 +250,186 @@ describe('LocaleConfigSchema', () => {
   });
   it('should reject locale without code', () => {
     expect(() => LocaleConfigSchema.parse({})).toThrow();
+  });
+});
+
+// ============================================================================
+// #4001 批 16 — the SPLIT verdict for this file, both halves pinned.
+//
+// `AriaPropsSchema` is closed on a measured door; the other five shapes are
+// `no door` and stay open. Both halves can regress, in OPPOSITE directions:
+// the closed half by someone reopening it, the open half by a later sweep
+// "finishing the file" with a `strictObject` that gates nothing (#4583). The
+// same split is recorded in `i18n.zod.ts`'s header and in the ui/ row of
+// `docs/audits/2026-07-unknown-key-strictness-ledger.md`.
+// ============================================================================
+
+/** Reject `value` and hand back the serialized issues, so a pin reads what an author would. */
+function reject(schema: { safeParse: (v: unknown) => { success: boolean; error?: { issues: unknown } } }, value: unknown): string {
+  const r = schema.safeParse(value);
+  expect(r.success, `expected ${JSON.stringify(value)} to be REJECTED`).toBe(false);
+  return JSON.stringify(r.error?.issues ?? []);
+}
+
+describe('#4001 批 16 — AriaPropsSchema is closed (the door is real)', () => {
+  it('the controls parse — this suite fails closed, not by rejecting everything', () => {
+    expect(AriaPropsSchema.safeParse({}).success).toBe(true);
+    expect(AriaPropsSchema.safeParse({ ariaLabel: 'Close dialog' }).success).toBe(true);
+    expect(AriaPropsSchema.safeParse({ ariaLabel: 'x', ariaDescribedBy: 'y', role: 'dialog' }).success).toBe(true);
+  });
+
+  it('rejects an undeclared key and names the surface', () => {
+    const msg = reject(AriaPropsSchema as never, { ariaLabel: 'x', notAnAriaKey: 1 });
+    expect(msg).toContain('notAnAriaKey');
+    expect(msg).toContain('these ARIA attributes');
+  });
+
+  // ---- the door: a strict schema nobody parses gates nothing --------------
+  it('binds through the `view` metadata root, at the real carrier slot path', () => {
+    const view = getMetadataTypeSchema('view');
+    expect(view, 'the view root must resolve — this is the parse door').toBeTruthy();
+    const doc = (aria: unknown) => ({ listViews: { my_view: { type: 'grid', columns: ['name'], aria } } });
+
+    const control = view!.safeParse(doc({ ariaLabel: 'Accounts' }));
+    expect(control.success, 'control: a declared key still parses through the root').toBe(true);
+
+    const r = view!.safeParse(doc({ ariaLabel: 'Accounts', describedBy: 'accounts-help' }));
+    expect(r.success).toBe(false);
+    expect(JSON.stringify(r.error?.issues)).toContain('listViews');
+  });
+
+  it('is what was silently stripping BEFORE this batch — the legacy pair vanished whole', () => {
+    // Regression narrative, asserted rather than told: this exact document used
+    // to parse clean and come back `aria: {}`. The accessible name the author
+    // wrote existed in the source file and nowhere else.
+    const msg = reject(AriaPropsSchema as never, { label: 'Accounts', describedBy: 'accounts-help' });
+    expect(msg).toContain('`label` → `ariaLabel`');
+    expect(msg).toContain('`describedBy` → `ariaDescribedBy`');
+  });
+
+  // ---- curation, each entry anchored to a NAMED sibling contract ----------
+  it('renames objectui\'s stored legacy spellings (its own ARIA_KEY_ALIASES)', () => {
+    expect(reject(AriaPropsSchema as never, { label: 'x' })).toContain('`label` → `ariaLabel`');
+    expect(reject(AriaPropsSchema as never, { describedBy: 'x' })).toContain('`describedBy` → `ariaDescribedBy`');
+  });
+
+  it('renames the shape\'s own over-generalised prefix (`ariaRole` → `role`)', () => {
+    expect(reject(AriaPropsSchema as never, { ariaRole: 'dialog' })).toContain('`ariaRole` → `role`');
+  });
+
+  it('leaves the reachable typos to edit distance rather than hand-writing them', () => {
+    // Measured before any alias was written: these four the fallback already
+    // reaches, so an alias entry for them would be transcription, not judgement.
+    expect(reject(AriaPropsSchema as never, { arialabel: 'x' })).toContain('`arialabel` → `ariaLabel`');
+    expect(reject(AriaPropsSchema as never, { ariaLabell: 'x' })).toContain('`ariaLabell` → `ariaLabel`');
+    expect(reject(AriaPropsSchema as never, { ariadescribedby: 'x' })).toContain('`ariadescribedby` → `ariaDescribedBy`');
+    expect(reject(AriaPropsSchema as never, { roles: 'x' })).toContain('`roles` → `role`');
+  });
+
+  // ---- the two protocol gaps, prescribed WITHOUT a wrong rename ----------
+  it('`live` gets a prescription, never a rename — it is a key this schema cannot accept', () => {
+    // The ledger's finding 7: this campaign's own fix once signposted the way
+    // into the failure mode it exists to kill. `live` is real and rendered — by
+    // objectui's ListView alone — so the message says where it IS valid instead
+    // of pointing at a declared key that means something else.
+    const msg = reject(AriaPropsSchema as never, { live: 'polite' });
+    expect(msg).toContain('objectui');
+    expect(msg).toContain('#5058');
+    expect(msg, 'must not suggest a rename for a key with no correct target').not.toContain('`live` →');
+  });
+
+  it('never offers `live` as a suggestion for a NEIGHBOURING typo either', () => {
+    // `extraKeys: ['live']` would have made the objectui-extended surface's
+    // suggestions richer and this surface's suggestions WRONG. It is deliberately
+    // not used: `live` is not a key this schema accepts.
+    for (const typo of ['liv', 'lives', 'Live']) {
+      expect(reject(AriaPropsSchema as never, { [typo]: 'polite' })).not.toContain('→ `live`');
+    }
+  });
+
+  it('`aria-labelledby` names the gap instead of renaming to a different concept', () => {
+    for (const key of ['ariaLabelledBy', 'labelledBy']) {
+      const msg = reject(AriaPropsSchema as never, { [key]: 'other-element' });
+      expect(msg).toContain('#5058');
+      expect(msg, 'labelledby references an id; ariaLabel is a literal string').not.toContain(`\`${key}\` → \`ariaLabel\``);
+    }
+  });
+
+  // ---- what the strictness RIDES onto, in both directions -----------------
+  it('rides `.extend()` onto objectui\'s list-view aria — which is why `live` still works there', () => {
+    // objectui declares `SpecAriaPropsSchema.extend({ live })`. `.extend()`
+    // inherits `.strict()` AND the error map, so that surface accepts exactly
+    // `ariaLabel | ariaDescribedBy | role | live` and rejects the rest with this
+    // batch's message. Asserted on a local reconstruction because objectui is a
+    // separate repo — the mechanic is what matters and it is the finding-16 one.
+    const objectuiAria = AriaPropsSchema.extend({ live: z.enum(['polite', 'assertive', 'off']).optional() });
+    expect(objectuiAria.safeParse({ ariaLabel: 'x', live: 'polite' }).success).toBe(true);
+    expect(reject(objectuiAria as never, { ariaLabel: 'x', bogus: 1 })).toContain('these ARIA attributes');
+  });
+
+  it('does NOT ride `.merge()` into the four no-door files — they stay open', () => {
+    // `X.merge(AriaPropsSchema.partial())` adopts the INCOMING posture, so
+    // closing this shape silently closed `animation` / `dnd` / `keyboard` /
+    // `touch` too — with zod's generic message, no changeset, and against
+    // #4988's measured verdict that nothing parses them. The explicit `.strip()`
+    // in those four files is what holds this line; this is its pin.
+    expect(ComponentAnimationSchema.safeParse({ name: 'a', notAnAnimationKey: 1 }).success).toBe(true);
+    expect(DropZoneSchema.safeParse({ accept: ['card'], notADropZoneKey: 1 }).success).toBe(true);
+    expect(DragItemSchema.safeParse({ type: 'card', notADraggableKey: 1 }).success).toBe(true);
+    expect(KeyboardNavigationConfigSchema.safeParse({ notAKeyboardKey: 1 }).success).toBe(true);
+    expect(TouchInteractionSchema.safeParse({ notATouchKey: 1 }).success).toBe(true);
+  });
+});
+
+describe('#4001 批 16 — the other five shapes have no authoring door', () => {
+  const NO_DOOR: Array<[string, unknown]> = [
+    ['I18nObjectSchema', I18nObjectSchema],
+    ['PluralRuleSchema', PluralRuleSchema],
+    ['NumberFormatSchema', NumberFormatSchema],
+    ['DateFormatSchema', DateFormatSchema],
+    ['LocaleConfigSchema', LocaleConfigSchema],
+  ];
+
+  it('measures: AriaProps reachable, the other five not — controls in the same run', () => {
+    const { verdict, nodeCount, rootCount } = measureDoors();
+    expect(rootCount).toBeGreaterThan(20);
+    expect(nodeCount).toBeGreaterThan(1000);
+    expect(verdict(PageSchema), 'positive control').toBe('direct');
+    expect(verdict(AriaPropsSchema), 'the half of this file that HAS a door').toBe('direct');
+    expect(verdict(z.object({ a: z.string() })), 'negative control').toBe('unreachable');
+    for (const [name, schema] of NO_DOOR) {
+      expect(verdict(schema), `${name} must have no door`).toBe('unreachable');
+    }
+  });
+
+  it('a synthetic carrier flips all five — the verdict is the graph, not the walker', () => {
+    const carrier = z.object({
+      i18nObject: I18nObjectSchema,
+      plural: PluralRuleSchema,
+      numberFormat: NumberFormatSchema,
+      dateFormat: DateFormatSchema,
+      locale: LocaleConfigSchema,
+    });
+    const { verdict } = measureDoors([carrier]);
+    for (const [name, schema] of NO_DOOR) {
+      expect(verdict(schema), `${name} must become reachable once something carries it`).toBe('direct');
+    }
+  });
+
+  it('they still accept undeclared keys — this pins "open", not "broken"', () => {
+    expect(I18nObjectSchema.safeParse({ key: 'k', notAnI18nKey: 1 }).success).toBe(true);
+    expect(PluralRuleSchema.safeParse({ key: 'k', other: 'x', notAPluralForm: 1 }).success).toBe(true);
+    expect(NumberFormatSchema.safeParse({ notANumberFormatKey: 1 }).success).toBe(true);
+    expect(DateFormatSchema.safeParse({ notADateFormatKey: 1 }).success).toBe(true);
+    expect(LocaleConfigSchema.safeParse({ code: 'en-US', notALocaleKey: 1 }).success).toBe(true);
+  });
+
+  it('`I18nObject.params` stays a record ON PURPOSE — openness there is the contract', () => {
+    // The remeasure's standing warning for this file. `params` is an
+    // interpolation bag whose key space is whatever the message template names;
+    // it is not a site this ratchet could close and must not become one.
+    const r = I18nObjectSchema.safeParse({ key: 'items.count', params: { count: 5, anything: 'at all', ok: true } });
+    expect(r.success).toBe(true);
+    expect((r.data as { params?: Record<string, unknown> }).params).toEqual({ count: 5, anything: 'at all', ok: true });
   });
 });

--- a/packages/spec/src/ui/i18n.zod.ts
+++ b/packages/spec/src/ui/i18n.zod.ts
@@ -2,6 +2,36 @@
 
 import { z } from 'zod';
 
+// ⚠️ #4001 批 16 — this file SPLITS across the ledger's classes. Read before editing.
+//
+// `AriaPropsSchema` is a REAL DOOR and is closed (`strictObject`). Every other
+// shape here is `no door` and must NOT be tightened — see the per-schema notes.
+//
+// The split was measured on 2026-08-04, three independent ways with positive AND
+// negative controls in the same run (`i18n.test.ts` pins both halves):
+//
+//  - `AriaPropsSchema` is carried as `aria:` on ~30 live shapes across six
+//    metadata-type roots — `ListViewSchema`, `PageSchema`, `PageComponentSchema`,
+//    `DashboardWidgetSchema`, `ChartConfigSchema`, `ActionSchema`, and 20 SDUI
+//    component defs — and a BFS from all 24 roots plus `defineStack` reaches it
+//    directly. It was silently stripping: through the `view` root,
+//    `aria: { label: 'Accounts', describedBy: 'x' }` parsed CLEAN and returned
+//    `aria: {}`, so the accessible name the author wrote simply did not exist.
+//  - `I18nObjectSchema` / `PluralRuleSchema` / `NumberFormatSchema` /
+//    `DateFormatSchema` / `LocaleConfigSchema` have no carrier key anywhere, are
+//    unreachable in that same BFS, and are never parsed in `objectstack`,
+//    `objectui` or `cloud` outside this file's own tests. `.strict()` is a
+//    property of a PARSE; with no parse it enforces nothing and only makes a dead
+//    slot look load-bearing (#4583). ADR-0049 enforce-or-remove is #5055.
+//
+// Note `NumberFormatSchema` / `DateFormatSchema` DO have a carrier
+// (`LocaleConfig.numberFormat` / `.dateFormat`) — but the carrier is itself
+// doorless, so the whole subtree is `no door`, not `no gate`.
+//
+// The `z.record` slots stay open ON PURPOSE and are not sites this ratchet can
+// close: `I18nObject.params` is an interpolation bag whose key space is whatever
+// the message template names. Openness there is the contract.
+
 /**
  * I18n Object Schema
  * Structured internationalization label with translation key and parameters.
@@ -16,6 +46,7 @@ import { z } from 'zod';
  * ```
  */
 import { lazySchema } from '../shared/lazy-schema';
+import { strictObject } from '../shared/strict-object';
 export const I18nObjectSchema = lazySchema(() => z.object({
   /** Translation key (e.g., "views.task_list.label", "apps.crm.description") */
   key: z.string().describe('Translation key (e.g., "views.task_list.label")'),
@@ -47,16 +78,28 @@ export const I18nLabelSchema = lazySchema(() => z.string().describe('Display lab
 
 export type I18nLabel = z.infer<typeof I18nLabelSchema>;
 
+// The one closed shape in this file (#4001 批 16). Everything below `AriaProps`
+// stays open on the `no door` verdict recorded at the top.
+//
+// Curation is anchored to NAMED SIBLING CONTRACTS, never to edit distance —
+// each entry below was measured against a real producer, and the distance
+// fallback was measured first so nothing is hand-written that it already reaches
+// (it reaches `arialabel`, `ariaLabell`, `ariadescribedby`, `aria-label`,
+// `roles`; it does NOT reach any of the four aliases here).
+const ARIA_HISTORY =
+  'Until #4001 closed this shape an unknown key was dropped silently — the component still '
+  + 'rendered, with no accessible name and nothing to say the one you wrote had been discarded.';
+
 /**
  * ARIA Accessibility Properties Schema
- * 
+ *
  * Common ARIA attributes for UI components to support screen readers
  * and assistive technologies.
- * 
+ *
  * Aligned with WAI-ARIA 1.2 specification.
- * 
+ *
  * @see https://www.w3.org/TR/wai-aria-1.2/
- * 
+ *
  * @example
  * ```typescript
  * const aria: AriaProps = {
@@ -66,7 +109,44 @@ export type I18nLabel = z.infer<typeof I18nLabelSchema>;
  * };
  * ```
  */
-export const AriaPropsSchema = lazySchema(() => z.object({
+export const AriaPropsSchema = lazySchema(() => strictObject({
+  surface: 'these ARIA attributes',
+  history: ARIA_HISTORY,
+  aliases: {
+    // objectui's `ARIA_KEY_ALIASES` (`packages/core/src/utils/normalize-list-view.ts`)
+    // is the measured source for these two: they are the spellings stored view
+    // metadata really carries, folded onto the canonical keys at the ListView
+    // boundary (objectui#2890). A view authored the legacy way reached this
+    // schema and lost BOTH keys — `aria: {}` — so the accessible name existed in
+    // the source file and nowhere else.
+    label: 'ariaLabel',
+    describedBy: 'ariaDescribedBy',
+    // Two of this shape's three keys carry the `aria` prefix and `role` does not.
+    // An author who has just written `ariaLabel` and `ariaDescribedBy` generalises
+    // to `ariaRole`; that is the shape's own inconsistency, not a typo, and the
+    // distance fallback provably cannot bridge it (measured).
+    ariaRole: 'role',
+  },
+  guidance: {
+    // NOT an alias — `live` is not a key this schema accepts, and suggesting one
+    // the schema cannot accept is the ledger's finding 7 (this campaign's own fix
+    // signposting the way into the failure it exists to kill).
+    live: '`live` is objectui\'s LIST-VIEW-ONLY extension, declared there as '
+      + '`AriaPropsSchema.extend({ live })` and read by `ListView` alone — this shared shape is '
+      + 'carried by ~30 renderers and only one of them applies `aria-live`, so declaring it here '
+      + 'would advertise a capability the other 29 do not deliver. On an objectui list view the key '
+      + 'is valid as-is; anywhere else, drop it. Promoting it into the protocol is #5058.',
+    // `aria-labelledby` REFERENCES another element's id; `ariaLabel` is a literal
+    // string. Renaming between them would be a wrong prescription, so this names
+    // the gap instead of pretending there is a target.
+    ariaLabelledBy: '`aria-labelledby` has no counterpart in this protocol — it references another '
+      + 'element\'s id, which is not the same thing as `ariaLabel` (a literal accessible name), so '
+      + 'there is nothing to rename it to. Use `ariaLabel` only if a literal string is what you meant. '
+      + 'Declaring the referencing form is #5058.',
+    labelledBy: '`aria-labelledby` has no counterpart in this protocol — see `ariaLabelledBy`. '
+      + 'Use `ariaLabel` only if a literal accessible name is what you meant; #5058 tracks the gap.',
+  },
+}, {
   /** Accessible label for screen readers */
   ariaLabel: I18nLabelSchema.optional().describe('Accessible label for screen readers (WAI-ARIA aria-label)'),
 

--- a/packages/spec/src/ui/keyboard.zod.ts
+++ b/packages/spec/src/ui/keyboard.zod.ts
@@ -97,6 +97,13 @@ export const KeyboardNavigationConfigSchema = lazySchema(() => z.object({
   focusManagement: FocusManagementSchema.optional().describe('Focus and tab order management'),
   rovingTabindex: z.boolean().default(false)
     .describe('Enable roving tabindex pattern for composite widgets'),
-}).merge(AriaPropsSchema.partial()).describe('Keyboard navigation and shortcut configuration'));
+}).merge(AriaPropsSchema.partial())
+  // `.strip()` is LOAD-BEARING (#4001 批 16): `AriaPropsSchema` became `strictObject` and
+  // `.merge()` adopts the incoming schema's unknown-key posture, so without this the shape
+  // would silently become `.strict()` — with zod's generic message, not the campaign's — and
+  // would contradict this file's measured `no door` verdict (#4988: nothing parses it, so a
+  // strict shell enforces nothing). Keep it until #4988 says what happens to this file.
+  .strip()
+  .describe('Keyboard navigation and shortcut configuration'));
 
 export type KeyboardNavigationConfig = z.infer<typeof KeyboardNavigationConfigSchema>;

--- a/packages/spec/src/ui/touch.zod.ts
+++ b/packages/spec/src/ui/touch.zod.ts
@@ -140,6 +140,13 @@ export const TouchInteractionSchema = lazySchema(() => z.object({
   gestures: z.array(GestureConfigSchema).optional().describe('Configured gesture recognizers'),
   touchTarget: TouchTargetConfigSchema.optional().describe('Touch target sizing and hit area'),
   hapticFeedback: z.boolean().optional().describe('Enable haptic feedback on touch interactions'),
-}).merge(AriaPropsSchema.partial()).describe('Touch and gesture interaction configuration'));
+}).merge(AriaPropsSchema.partial())
+  // `.strip()` is LOAD-BEARING (#4001 批 16): `AriaPropsSchema` became `strictObject` and
+  // `.merge()` adopts the incoming schema's unknown-key posture, so without this the shape
+  // would silently become `.strict()` — with zod's generic message, not the campaign's — and
+  // would contradict this file's measured `no door` verdict (#4988: nothing parses it, so a
+  // strict shell enforces nothing). Keep it until #4988 says what happens to this file.
+  .strip()
+  .describe('Touch and gesture interaction configuration'));
 
 export type TouchInteraction = z.infer<typeof TouchInteractionSchema>;

--- a/packages/spec/src/ui/widget.test.ts
+++ b/packages/spec/src/ui/widget.test.ts
@@ -1,8 +1,18 @@
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
 import { FieldWidgetPropsSchema, type FieldWidgetProps } from './widget.zod';
-import { WidgetManifestSchema, type WidgetManifest } from './widget.zod';
+import {
+  WidgetManifestSchema,
+  WidgetLifecycleSchema,
+  WidgetEventSchema,
+  WidgetPropertySchema,
+  WidgetSourceSchema,
+  type WidgetManifest,
+} from './widget.zod';
 import { Field } from '../data/field.zod';
+import { measureDoors } from './door-reachability.testkit';
+import { PageSchema } from './page.zod';
+import { ObjectListViewSchema } from './view.zod';
 
 describe('FieldWidgetPropsSchema', () => {
   describe('Valid Widget Props', () => {
@@ -364,5 +374,82 @@ describe('Widget — retired performance (#3896 close-out)', () => {
     } catch (e) { message = String((e as Error).message); }
     expect(message).toMatch(/virtualScroll/);
     expect(message).toMatch(/#3896/);
+  });
+});
+
+// ============================================================================
+// #4001 批 16 — the `no door` verdict for this WHOLE FILE, pinned.
+//
+// This file was scheduled as `authorable (p)` / 9 sites and resolved NEGATIVE.
+// The pin exists because the verdict regresses in one specific way: a later
+// sweep "finishing the ui/ directory" wraps these nine sites in `strictObject`,
+// spends a breaking change, and gates nothing (#4583). Same verdict is recorded
+// in this file's header comment and in the ui/ row of
+// `docs/audits/2026-07-unknown-key-strictness-ledger.md` — the three-places
+// standard, because a row in a table is not where the next person looks.
+//
+// ADR-0049 enforce-or-remove for these shapes is #5055.
+// ============================================================================
+describe('#4001 批 16 — widget.zod.ts has no authoring door', () => {
+  const SHAPES: Array<[string, unknown]> = [
+    ['WidgetManifestSchema', WidgetManifestSchema],
+    ['WidgetLifecycleSchema', WidgetLifecycleSchema],
+    ['WidgetEventSchema', WidgetEventSchema],
+    ['WidgetPropertySchema', WidgetPropertySchema],
+    ['WidgetSourceSchema', WidgetSourceSchema],
+    ['FieldWidgetPropsSchema', FieldWidgetPropsSchema],
+  ];
+
+  it('is unreachable from all 24 metadata-type roots and defineStack', () => {
+    const { verdict, nodeCount, rootCount } = measureDoors();
+
+    // Controls FIRST, in the same run. An empty result and a broken walker
+    // produce the same output, and only these tell them apart.
+    expect(rootCount, 'roots must include every metadata type plus ObjectStackSchema').toBeGreaterThan(20);
+    expect(nodeCount, 'the graph must actually have been walked').toBeGreaterThan(1000);
+    expect(verdict(PageSchema), 'positive control').toBe('direct');
+    expect(verdict(ObjectListViewSchema), 'positive control').toBe('direct');
+    expect(verdict(z.object({ a: z.string() })), 'negative control').toBe('unreachable');
+
+    for (const [name, schema] of SHAPES) {
+      expect(verdict(schema), `${name} must have no door`).toBe('unreachable');
+    }
+  });
+
+  it('a synthetic carrier flips every one of them — the verdict is the graph, not the walker', () => {
+    // Without this the assertion above is satisfiable by a walker that reaches
+    // nothing at all. 批 15 shipped exactly that shape of vacuous pin once.
+    const carrier = z.object({
+      manifest: WidgetManifestSchema,
+      lifecycle: WidgetLifecycleSchema,
+      event: WidgetEventSchema,
+      property: WidgetPropertySchema,
+      source: WidgetSourceSchema,
+      props: FieldWidgetPropsSchema,
+    });
+    const { verdict } = measureDoors([carrier]);
+    for (const [name, schema] of SHAPES) {
+      expect(verdict(schema), `${name} must become reachable once something carries it`).toBe('direct');
+    }
+  });
+
+  it('#5056 — the OLD any-one-shared-property bridge would have called this file reachable', () => {
+    // The regression pin for the instrument defect this batch found. zod's
+    // `.describe()` returns a clone sharing the original `_zod.def`, so
+    // `WidgetManifestSchema.name` (a described SnakeCaseIdentifierSchema) and
+    // `.label` (a described I18nLabelSchema) are def-identical to the same
+    // leaves on live schemas. Two keys out of twenty is a coincidence, not a
+    // derivation — assert the OVERLAP is low, so a future edit that reinstates
+    // the any-property bridge cannot pass this file off as live surface.
+    const { cloneOverlap } = measureDoors();
+    expect(cloneOverlap(WidgetManifestSchema)).toBeGreaterThan(0);  // it DOES share leaves…
+    expect(cloneOverlap(WidgetManifestSchema)).toBeLessThan(0.2);   // …but nothing structural
+  });
+
+  it('the shapes still accept their own vocabulary — this pins "open", not "broken"', () => {
+    expect(WidgetLifecycleSchema.safeParse({ onMount: 'x', notAHook: 1 }).success).toBe(true);
+    expect(WidgetEventSchema.safeParse({ name: 'e', notAnEventKey: 1 }).success).toBe(true);
+    expect(WidgetPropertySchema.safeParse({ name: 'p', type: 'string', notAPropKey: 1 }).success).toBe(true);
+    expect(WidgetManifestSchema.safeParse({ name: 'w_one', label: 'W', notAManifestKey: 1 }).success).toBe(true);
   });
 });

--- a/packages/spec/src/ui/widget.zod.ts
+++ b/packages/spec/src/ui/widget.zod.ts
@@ -6,6 +6,41 @@ import { SnakeCaseIdentifierSchema } from '../shared/identifiers.zod';
 import { I18nLabelSchema, AriaPropsSchema } from './i18n.zod';
 import { retiredKey } from '../shared/retired-key';
 
+// ⛔ #4001 批 16 — EVERY shape in this file is `no door`. Do NOT `.strict()` them.
+//
+// The ledger scheduled this file as `authorable (p)` / 9 sites. Resolving the
+// `(p)` found no authoring door at all, measured three independent ways on
+// 2026-08-04, with positive AND negative controls in the same run:
+//
+//  1. **No carrier key.** Nothing under `packages/spec/src` imports this module
+//     except the `ui/index.ts` barrel, so no schema anywhere declares a key
+//     whose value is a widget shape. `field.widget` is a `z.string()` naming a
+//     registered *component*; it has never referenced `WidgetManifest`.
+//  2. **Unreachable.** A BFS over this build's in-memory Zod graph from all 24
+//     metadata-type roots plus `defineStack`'s `ObjectStackSchema` (4 766 nodes)
+//     reaches none of them, while `PageSchema` / `ObjectListViewSchema` resolve
+//     in the same run and a synthetic carrier flips every one of them to
+//     reachable — so the verdict is a fact about the graph, not a broken walker.
+//  3. **Never parsed.** No `.parse()` / `.safeParse()` on any of these exists in
+//     `objectstack`, `objectui` or `cloud` outside this file's own unit tests.
+//     objectui re-exports the inferred TYPES only, under different names
+//     (`RuntimeWidgetManifest` / `FieldWidgetComponentProps`, #4115 / #3161).
+//
+// `.strict()` is a property of a PARSE. With no parse it enforces nothing and
+// only makes a dead slot look load-bearing — "a precisely validated dead slot,
+// the more convincing lie" (#4583). The live question here is ADR-0049
+// enforce-or-remove, filed as #5055 (same class as #4988), NOT this ratchet.
+//
+// ⚠️ The campaign's own BFS reported `WidgetManifestSchema` as REACHABLE on the
+// first run. That was a false positive in the walker's derived-clone bridge, not
+// a door: zod's `.describe()` returns a clone that SHARES the original `_zod.def`
+// object, so `WidgetManifestSchema.name` (a described `SnakeCaseIdentifierSchema`)
+// and `.label` (a described `I18nLabelSchema`) are def-identical to the same
+// leaves on live schemas, and a bridge that fires on ANY one shared property
+// under a shared name links two unrelated shapes. Filed as #5056; `widget.test.ts`
+// pins the corrected (whole-shape overlap) form. Same verdict recorded in the
+// ui/ row of `docs/audits/2026-07-unknown-key-strictness-ledger.md`.
+
 /**
  * Widget Lifecycle Hooks Schema
  * 


### PR DESCRIPTION
Part of objectstack-ai/objectstack#4001 —— ui/ 波次批 16(T1 必保清单序首位),`widget` + `i18n` 两文件。

账面 15 站点,AST 复测**分毫不差**(widget 9/9,i18n 6/6,用台账门禁自己的计数器)。逐 schema 门测量后一分为十四:**收紧 1 个,改判 14 个**。

---

## 收紧(1 站点)

`ui/i18n.zod.ts` · `AriaPropsSchema` → `strictObject`

这是 ui/ 波次目前收紧的**扇出最大的单个站点**:作为 `aria:` 挂在约 30 个活形状上,横跨六个 metadata-type 根 —— `ListViewSchema` / `PageSchema` / `PageComponentSchema` / `DashboardWidgetSchema` / `ChartConfigSchema` / `ActionSchema`,以及 20 个 SDUI component def。

它在真门上真的在剥。经 `view` 根:

```ts
getMetadataTypeSchema('view').parse({
  listViews: { my_view: { type: 'grid', columns: ['name'],
    aria: { label: 'Accounts', describedBy: 'accounts-help' } } },
})
// → aria: {}
```

两个键整个消失,报告合法。作者写的无障碍名**只存在于源文件里**,屏幕阅读器用户听到的是 DOM 默认值,而工具链从头到尾没有一句话提过。

而且这两个拼法不是假想的:它们**逐字**就是 objectui `normalize-list-view.ts` 里 `ARIA_KEY_ALIASES` 折叠的那两个(objectui#2890),也就是存量视图元数据实际携带的拼法。

### 处方(逐条锚定具名姊妹契约,不靠编辑距离)

| 你写了 | 应写 | 错词从哪来 |
|---|---|---|
| `label` | `ariaLabel` | objectui 的存量旧拼法,`normalizeListViewSchema` 在 ListView 边界折叠 |
| `describedBy` | `ariaDescribedBy` | 同上 |
| `ariaRole` | `role` | 本形状**自己的**不一致:三个键里两个带 `aria` 前缀,`role` 不带 |

`arialabel` / `ariaLabell` / `ariadescribedby` / `aria-label` / `roles` **留给编辑距离兜底** —— 先测了它够得着才不手写:一条距离已经能到的别名是誊抄,不是判断。

### 两个键给处方而不给重命名(finding 7 纪律)

- **`live`** —— 它是真的,而且真的在渲染:objectui 的 `ListView.tsx:1984` 读 `schema.aria?.live` 并落成 `aria-live`;objectui 用 `AriaPropsSchema.extend({ live })` 声明它,所以**那个面继续接受它**(并且现在继承本批的错误映射)。在别的面上,消息告诉作者 `live` 在哪里**有效**,而不是指向一个语义不同的已声明键。把它加进共享形状 = 对另外 29 个不实现 aria-live 的渲染器宣告一个不兑现的能力(Prime Directive #10)。收编问题另开 **#5058**。
- **`ariaLabelledBy` / `labelledBy`** —— `aria-labelledby` 引用的是另一个元素的 id,与 `ariaLabel`(字面串)不是一回事,**没有可以重命名过去的目标**。所以点名缺口,同样 #5058。

### 顺带在四个本批不改的文件里加了 `.strip()`

`animation.zod.ts` / `dnd.zod.ts`(×2)/ `keyboard.zod.ts` / `touch.zod.ts` 用 `z.object({…}).merge(AriaPropsSchema.partial())` 构形,而 **`.merge()` 采纳传入 schema 的未知键姿态** —— 收紧 `AriaProps` 会把这五个形状一并悄悄收紧:用 zod 的通用文案(不是本战役的)、没有 changeset、而且违背 #4988 实测出的「没有任何东西 parse 它们」。显式 `.strip()` 守住这条线,`i18n.test.ts` 钉住。

这是 finding 16 的 `.extend()` 陷阱换了个方法名出现。

---

## 改判为 no door(14 站点,⛔ 不收紧)

`ui/widget.zod.ts` 全文件 6 个 schema / 9 站点,`ui/i18n.zod.ts` 的 `I18nObject` / `PluralRule` / `NumberFormat` / `DateFormat` / `LocaleConfig` 5 站点。

三条独立测量,**正对照与负对照在同一轮跑**:

1. **无载体键** —— `packages/spec/src` 下除 `ui/index.ts` 桶文件外没有任何模块 import `widget.zod`;`field.widget` 是个 `z.string()`,命名的是已注册**组件**,从不指向 `WidgetManifest`。
2. **图上不可达** —— 从 24 个 metadata-type 根 + `defineStack` 出发的 BFS(4766 节点)全都够不到;`PageSchema` / `ObjectListViewSchema` 同轮解析为 direct,一个新建 `z.object` 和一个刻意长得像的负对照都判不可达,注入合成载体后全部翻转为 direct。
3. **零 parse** —— `objectstack` / `objectui` / `cloud` 三仓,除各自单测外零 `.parse()`。objectui 只 re-export 推导 TYPE 且改了名(`RuntimeWidgetManifest` / `FieldWidgetComponentProps`);cloud 用 code search 对全部符号 0 命中,正对照 `"@objectstack/spec"` 同仓 345 命中(索引可用)。

`.strict()` 是 **parse 的属性**;没有 parse 就什么都不闸,只会把死槽装扮成受校验的活槽(#4583)。ADR-0049 enforce-or-remove 另开 **#5055**(与 #4988 同类)。

`NumberFormat` / `DateFormat` **确有**载体(`LocaleConfig.numberFormat` / `.dateFormat`),但载体自己无门,所以整棵子树是 `no door` 而不是 `no gate`。

### 重测的那条标注警告,落点比警告本身更有用

台账原文警告「i18n 的 label 形状按设计是宽开 record —— 收紧前必验」。验完的结论是**警告没错,但瞄偏了一层**:

- 它描述的那个宽开 record 是真的 —— `I18nObject.params`,插值参数袋,键空间就是消息模板命名的任何东西。**但它从来不是那 6 个站点之一**(它是 `z.record`,不是 `z.object`),所以本棘轮压根没有东西可关。
- 而地图假定和它一起宽开的那个**配置块**(`AriaProps`),测出来是本目录**扇出最大的活形状**。

即:标准警告与实测指向相反方向,而两边都被记了下来(schema 头注释 + 测试钉 + 台账行,三处标准)。

---

## 台账 finding 20 —— 战役自己的门测量会误报「可达」(#5056)

第一轮 BFS 把 `WidgetManifestSchema` 报成 **REACHABLE**,而这个文件全仓没人 import。差点据此对一个死文件做 9 站点的 breaking 收紧。

机制:批 15 引入的 **derived-clone bridge** 在「任意**一个**同名属性 def 相同」时判可达 —— 它存在是有真实理由的(`.extend()` 克隆不共享身份但共享逐属性实例)。可是 **zod 的 `.describe()` 返回的克隆共享同一个 `_zod.def` 对象**(实测 `defOf(z.string().describe('x')) === defOf(z.string())` 为 true),于是 `SnakeCaseIdentifierSchema` / `I18nLabelSchema` 这类共享叶子在全仓 def-同一,而 `name` / `label` 几乎是每个可授权形状都有的两个键。20 个键里命中 2 个(重合度 11%),判可达。

**误差只朝一个方向**:只会**造门**,不会藏门 —— 它全部的失效预算都花在让批次去收紧没人 parse 的东西上。

修法与阈值都写进 `ui/door-reachability.testkit.ts`:问「共享了多少形状」而不是「有没有共享」,阈值对着实测区间两端定(批 15 的真派生远在其上,批 16 的假阳远在其下)。`widget.test.ts` 有回归钉。批 15 留在 `chart.test.ts` 的那份拷贝属 #5056 —— 战役自己反复在记的「真相的第二份拷贝」,这次出现在它的仪器里。

**方法论上值得记一句**:批 15 的擦肩(`typeof v !== 'object'` 跳过所有 lazy Proxy)是**正对照**抓到的;这一条对正对照完全隐形(每个根都照样解析),要**负对照 + 合成载体翻转**才抓得到。一次门测量欠三样,同一轮跑:一个已知活的、一个已知死的、一个注入后必须翻转的载体。

---

## 验证

先证仪器会红,再信绿 —— **六次破坏,每个断言类目一次**,逐次回退:

| 破坏 | 红的是 |
|---|---|
| 走图器重新引入 `typeof v !== 'object'` | 合成载体对照(`unreachable` ≠ `direct`)。注意 no-door 断言仍绿 —— 这正是为什么需要这条对照 |
| bridge 退回「任意单属性」 | widget 的 no-door 断言 + #5056 重合度钉(`expected 1 to be less than 0.2`) |
| `AriaProps` 退回 `z.object` | 10 条断言全红 |
| 删掉 objectui 实测别名 | 两条重命名断言 |
| `live` 的 guidance 改成错误 alias | 「给处方不给重命名」断言 |
| 删掉一个 `.strip()` | `.merge()` 不外溢钉 |

零破坏实证:

- `@objectstack/spec` **301 文件 / 7709 用例通过**,`tsc --noEmit` 干净
- **spec 十个 `check:*` 闸门全绿**(8 个生成物 + 8 个源审计,含 `check:docs` —— 本批的判决全部写成 `//` 行注释,不会顶替参考页正文,批 15 的教训)
- 下游消费包:lint 1064 / metadata-protocol / metadata-core 103 / platform-objects 266 / sdui-parser 6 全过
- `objectstack validate` **三个示例应用 exit=0**
- **ADR-0087 直解探针**(批 14 方法,`validate` 对页面内嵌形状是空转 —— #5000):遍历三个应用**构建产物** `dist/objectstack.json`,按载体槽路径追踪 —— `aria` 槽 **0 个**,即零破坏;探针的负对照(一个带旧拼法的块)证明会红。另 250 个同名槽命中经 provenance 核对全部属于别的 schema(翻译包 / 校验规则的 JSON-Schema `properties` / dashboard `widgets` / action `params` / 连接器 IO schema),没有一个是本批形状的载体

## 台账

ui/ 段三方竞争如预期冲突。**两边的行全留,表头与可授权小计从存活行重算**,不向任一方解决:

```
行:  29+20+9+2+7+5+4+4+4+3+1+1+1 = 90 strip of 198
可授权 = 90 − 40(38 no door + 2 no gate)= component 29 + view 20 + app 1 = 50
```

哪一方的数字都不是最终值 —— 批 16 在还有批 14/15 行的树上算出 118,main 上写着 91。这是该表自己记录的这个模式的**第八次**,已按例记进去。

os-regen 四步做完:merge → 从 origin/main checkout 七条 driver 托管路径 → 重建 spec → `check:generated --fix`(八个全部已是最新;收紧不改任何生成快照,与批 14/15 一致)→ 断言姊妹条目存活(批 13/14/15/16 changeset 齐全,theme/chart/dataset/sharing 的 `strictObject` 计数完好)。

## 范围外发现(已建 issue,本 PR 不改)

- **#5055** —— 本批改判的 14 站点的 ADR-0049 enforce-or-remove(与 #4988 同类)
- **#5056** —— 上文的门测量仪器缺陷,含把 BFS 抽成一份共享工具的建议
- **#5058** —— `AriaProps` 对 WAI-ARIA 1.2 的两处缺口(`aria.live` 只活在 objectui 扩展里 / `aria-labelledby` 全无对应),additive,建议进 v18 地图
- **#5059** —— `content/docs/references/{data/mapping,system/translation}.mdx` 两张**公开参考页**的正文被本战役的内部 history 注释顶替(#3746 陷阱 1 已实际发生两次,`check:docs` 结构上看不见),附一条可做的窄门禁建议

## 已知限制,诚实记录

- `chart.test.ts` 里批 15 那份 BFS 拷贝仍是旧的 any-property 版本。它对 chart 自己的断言无害(那些 schema 确实可达),但它是 #5056 的一部分,**没有在本 PR 里改** —— 那是别的批次的文件,且修法已在 `door-reachability.testkit.ts` 里给出。
- `packages/lint` 的 `runtime-lazy-deps.test.ts` 在本容器里会因 5000ms 超时而红(多 agent 共享容器);把 timeout 放宽到 60s 后 4/4 通过,**契约断言本身(typescript / sucrase 都没被加载)成立**,所以不是本批引起的。

---

⛔ 草稿,不合并、不置 ready。`content/docs/releases/` 零触碰。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ehu85kbvMcrNTUJjwxvLJ9)_