### PR TITLE
test(plugin-auth): 证明 ADR-0069 D4 真能撤销活动会话，并把「会话的记录之处」定为 sys_session (#4785)

### DIFF
--- a/.changeset/session-of-record-is-sys-session.md
+++ b/.changeset/session-of-record-is-sys-session.md
@@ -1,0 +1,53 @@
+---
+"@objectstack/plugin-auth": patch
+---
+
+docs(plugin-auth): the session of record is always `sys_session` — cache backs rate-limit counters only (#4785)
+
+Settles an architectural question that had been answered two different ways by
+the code and the docs. **Nothing about the runtime changes**: this records the
+decision, proves the behaviour that depends on it, and corrects the docs that
+described the road not taken.
+
+**The decision.** ObjectStack's session of record is always the `sys_session`
+table. The kernel `cache` service serves authentication as the ADR-0069 D2
+rate-limit counter store and nothing else. It is never bound as better-auth's
+`secondaryStorage`, because that option is not a counter store — handing
+better-auth one also relocates sessions into it (`createSession` skips the
+`sys_session` row; `findSession` answers from the cached snapshot without
+reading the database). ADR-0069 D4's three session controls — idle timeout,
+absolute lifetime, concurrent-session cap — all revoke by writing that row, so a
+cache-backed session store would silently disable every one of them. Dual-writing
+(`session.storeSessionInDatabase: true`) was considered and rejected as the worst
+of the options: the row exists, so the controls *appear* to work, while the read
+path still answers from the cache.
+
+**Why this needed settling rather than just fixing.** The conflict had never
+fired — the cache lookup that would have wired `secondaryStorage` ran before the
+cache service registered, so the binding never took in a standard composition.
+The declaration and the runtime disagreed for a month and no test could tell,
+because no test asserted that a D4 control ends a *live session*; they asserted
+at most that a row got stamped. A stamped row nobody reads is exactly the failure
+mode in question.
+
+**What is new.** `session-of-record.test.ts` drives the real better-auth pipeline
+end to end and proves each of the three D4 controls actually de-authenticates a
+live session cookie — not that a column was written. It also pins the
+counter-factual: with a `secondaryStorage` bound, `sys_session` stays empty and
+the idle timeout never fires. Two facts that make the guarantee hold for real
+deployments are pinned with it — `AuthManager` does not plumb
+`storeSessionInDatabase`, so the rejected dual-write shape is unreachable through
+configuration; and the default composition (OIDC provider on) makes better-auth
+*refuse to boot* with a `secondaryStorage` rather than degrade quietly.
+
+**For hosts.** `cacheSecondaryStorage()` remains exported for anyone who wants
+better-auth's cached session store deliberately. It now says plainly what it
+costs: opting in disables the ADR-0069 D4 session controls, and a revoked session
+stays usable until its cached copy expires. Moving sessions into the cache
+platform-wide would be a new decision requiring its own revocation-consistency
+requirements, not a configuration change.
+
+ADR-0069's D2 "shared store" is scoped to rate-limit counters, D4 records
+`sys_session` as a precondition rather than a deployment preference, and the
+`ICacheService` contract page no longer lists session storage among the cache's
+uses.

--- a/content/docs/kernel/contracts/cache-service.mdx
+++ b/content/docs/kernel/contracts/cache-service.mdx
@@ -5,7 +5,7 @@ description: Reference for the Cache Service contract — key-value caching with
 
 # ICacheService Contract
 
-The Cache Service provides a **key-value caching** layer used throughout ObjectStack for metadata caching, query result caching, session storage, and rate limiting. Implementations can range from in-memory Maps to Redis clusters.
+The Cache Service provides a **key-value caching** layer used throughout ObjectStack for metadata caching, query result caching, and rate limiting. Implementations can range from in-memory Maps to Redis clusters. It does **not** store sessions: the session of record is always the `sys_session` table, because ADR-0069 D4's session controls (idle timeout, absolute lifetime, concurrent-session cap) revoke a session by writing that row. A host may opt in explicitly with `cacheSecondaryStorage()` from `@objectstack/plugin-auth`, but should know what it buys: better-auth then answers session lookups from the cached snapshot without reading the database, so **opting in disables all three D4 session controls** — a revoked session stays usable until its cached copy expires.
 
 <Callout type="info">
 **Source:** `packages/spec/src/contracts/cache-service.ts`  

--- a/docs/adr/0069-enterprise-authentication-hardening.md
+++ b/docs/adr/0069-enterprise-authentication-hardening.md
@@ -1,6 +1,6 @@
 # ADR-0069: Enterprise authentication hardening — password policy, enforced MFA, SSO, session controls, network gating, and anti-brute-force, all enforcement-wired
 
-**Status**: Accepted — **P1 + P2 implemented** (2026-07-04); P3 partially landed (see Addendum). Original proposal 2026-06-24.
+**Status**: Accepted — **P1 + P2 implemented** (2026-07-04); P3 partially landed (see Addendum). Original proposal 2026-06-24. Session-of-record question settled 2026-08-04 (#4785): sessions live in `sys_session`; the kernel `cache` service backs D2's rate-limit counters only.
 **Deciders**: ObjectStack Protocol Architects
 **Builds on**: [ADR-0049](./0049-no-unenforced-security-properties.md) (**the governing constraint** — a security property that isn't enforced at runtime is forbidden; no toggle may be a "false surface"), [ADR-0007](./0007-settings-manifest-and-kv-store.md) (settings manifest + cascade KV store), [ADR-0057](./0057-erp-authorization-core-business-units-and-scope-depth.md) (`sys_role` is platform-native, decoupled from better-auth; org scoping), [ADR-0066](./0066-unified-authorization-model.md) (capability/assignment split), [ADR-0068](./0068-unified-user-context-and-built-in-identity-roles.md) (`current_user` contract, built-in roles)
 **Consumers**: `@objectstack/plugin-auth` (better-auth wiring, `bindAuthSettings`/`applyConfigPatch`, auth route middleware), `@objectstack/service-settings` (`auth.manifest.ts`), `@objectstack/platform-objects` (identity objects `sys_user`/`sys_session`/`sys_account`), `@objectstack/rest` (auth request middleware seam), `../objectui` (settings UI rendering)
@@ -58,7 +58,21 @@ Legend: **[native]** = a better-auth config/plugin does the enforcing; **[custom
 |---|---|---|---|
 | `lockout_threshold` (failed attempts, 0 = off) | 0 | `before`/`after` hook on `/sign-in/email` | **[custom]+[field]** `sys_user.failed_login_count`, `sys_user.locked_until`; increment on failure, set `locked_until = now + lockout_duration` past threshold, **reject even on correct password** while locked, reset on success |
 | `lockout_duration_minutes` | 15 | as above | **[custom]** |
-| `rate_limit_window_seconds` / `rate_limit_max` (per IP, auth endpoints) | 60 / 10 | better-auth core `rateLimit` | **[native]** enable + tune better-auth `rateLimit` (stricter `customRules` for `/sign-in/*`, `/sign-up/*`, `/reset-password`); use a **shared store** (not in-memory) for multi-node |
+| `rate_limit_window_seconds` / `rate_limit_max` (per IP, auth endpoints) | 60 / 10 | better-auth core `rateLimit` | **[native]** enable + tune better-auth `rateLimit` (stricter `customRules` for `/sign-in/*`, `/sign-up/*`, `/reset-password`); use a **shared store** (not in-memory) for multi-node — see the scoping note below |
+
+> **What "shared store" means here, exactly: rate-limit counters and nothing else (#4785).**
+> The store is wired as better-auth's `rateLimit.customStorage`, fed by the kernel `cache`
+> service (`createLazyCacheRateLimitStorage`), and it holds **counters only**. It is
+> deliberately **not** better-auth's `secondaryStorage`, because that option is not a
+> counter store — handing better-auth one also relocates the **session of record** into it
+> (`createSession` skips the `sys_session` row, `findSession` answers from the cached
+> snapshot without reading the database), which silently disables every D4 control below.
+> **The session of record is always `sys_session`, the database.** Moving it into the cache
+> would be a NEW decision, not an implementation detail of this row: it would have to
+> supersede D4's revocation mechanism and state its own revocation-consistency
+> requirements — how a revocation invalidates the cached snapshot on every node, and what
+> happens when that invalidation fails — in the same ADR that proposes it. Absent such a
+> decision, a cache-backed session store is out of scope for D2.
 
 > Distinction that matters: better-auth `rateLimit` throttles **requests per IP/path** (native); **account lockout** (per-identity, survives IP rotation) is **custom** and needs the two `sys_user` fields above + an admin "unlock" action.
 
@@ -81,6 +95,27 @@ Legend: **[native]** = a better-auth config/plugin does the enforcing; **[custom
 | `max_concurrent_sessions_per_user` (0 = off) | 0 | post-`/sign-in` | **[custom]** count live `sys_session` for the user; reject or evict-oldest past the cap |
 | "Sign out all other sessions" | — | — | **[native]** already wired (`/revoke-other-sessions`, action on `sys_session`) — keep |
 | `session_expiry_days` / `session_refresh_days` | 7 / 1 | `session.expiresIn`/`updateAge` | **[native]** existing — keep |
+
+> **The session of record is `sys_session` — the database (#4785).** All three controls
+> above revoke the same way: stamp the row (`expires_at` into the past, plus
+> `revoked_at`/`revoke_reason` for the audit trail). That mechanism is only sound while
+> better-auth reads sessions from the database, so this is a **precondition of D4, not a
+> deployment preference**: the kernel `cache` service serves auth as the D2 rate-limit
+> counter store only, and is never bound as `secondaryStorage`. `expires_at` is the field
+> that actually revokes — better-auth's session read checks it and nothing else, so
+> `revoked_at`/`revoke_reason` are diagnostics, and a revocation that stamped only those
+> would be inert.
+>
+> Two of these three controls are enforced in `customSession`, which runs **after** the
+> session for the current request has already been validated, so idle-timeout and
+> absolute-max take effect on the **next** request (the detecting request still succeeds).
+> The concurrent cap runs in the sign-in after-hook and is effective immediately.
+>
+> `packages/plugins/plugin-auth/src/session-of-record.test.ts` proves each control really
+> ends a live session end-to-end through the real better-auth pipeline, and pins the
+> counter-factual — that a cache-backed session store makes them inert. The absence of
+> exactly that test is why the conflict in #4785 stayed invisible from 2026-07-04 until it
+> was found by reading the code.
 
 ### D5 — Network gating / IP allowlist (P2)
 
@@ -139,7 +174,7 @@ Each row in D1-D6 names exactly one of these seams. No setting is introduced wit
 | Phase | Status | Notes |
 |---|---|---|
 | **P1** (D1/D2/D3 + D7 fields) | ✅ **implemented** | Password complexity/history/expiry (`assertPasswordComplexity`/`assertPasswordNotReused`/`stampPasswordChangedAt`), HIBP (`haveIBeenPwned` plugin), account lockout (`assertAccountNotLocked`/`recordSignInOutcome` + `unlock_user` action), enforced MFA + grace (`computeAuthGate` → `MFA_REQUIRED`, per-org `require_mfa`), rate-limit tuning (`customRules`). All settings in `auth.manifest.ts`, bound via `bindAuthSettings`. Login-audit fields `last_login_at`/`last_login_ip` stamped on sign-in (`stampLastLogin`). |
-| **P2** (D4/D5) | 🟡 **mostly implemented** | Session idle/absolute/concurrent (`enforceSessionControls`/`enforceConcurrentCap`), the **global** IP allow-list (`isClientIpAllowed`, `auth.allowed_ip_ranges`), and the **shared multi-node rate-limit counters** (better-auth `rateLimit.customStorage` fed by the kernel cache service through `createLazyCacheRateLimitStorage`; shared iff the cache is — Redis adapter in a cluster) are landed. **Correction (#4772):** this row previously claimed a shared **session** store via `secondaryStorage` as landed. It was not: the binding was taken in `AuthPlugin.init()`, which runs *before* `CacheServicePlugin` registers `cache`, so it never fired in the standard composition — and the counters it was supposed to share never reached the cache either. The counters now ride `rateLimit.customStorage`, resolved at counting time. The **session** half is deliberately NOT auto-wired: better-auth answers `findSession` from a `secondaryStorage` snapshot without reading the database, while D4 above revokes by writing the `sys_session` row, so a cache-backed session store silently disables idle-timeout / absolute-max / concurrent-cap enforcement. `cacheSecondaryStorage` remains exported for a host that opts into that trade knowingly. **Remaining:** per-org `sys_organization.allowed_ip_ranges` (+ optional `sys_user.allowed_ip_ranges` override) — tracked in #2571; the session-store question — tracked in #4785. |
+| **P2** (D4/D5) | 🟡 **mostly implemented** | Session idle/absolute/concurrent (`enforceSessionControls`/`enforceConcurrentCap`), the **global** IP allow-list (`isClientIpAllowed`, `auth.allowed_ip_ranges`), and the **shared multi-node rate-limit counters** (better-auth `rateLimit.customStorage` fed by the kernel cache service through `createLazyCacheRateLimitStorage`; shared iff the cache is — Redis adapter in a cluster) are landed. **Correction (#4772):** this row previously claimed a shared **session** store via `secondaryStorage` as landed. It was not: the binding was taken in `AuthPlugin.init()`, which runs *before* `CacheServicePlugin` registers `cache`, so it never fired in the standard composition — and the counters it was supposed to share never reached the cache either. The counters now ride `rateLimit.customStorage`, resolved at counting time. The **session** half is NOT wired, by decision: better-auth answers `findSession` from a `secondaryStorage` snapshot without reading the database, while D4 above revokes by writing the `sys_session` row, so a cache-backed session store silently disables idle-timeout / absolute-max / concurrent-cap enforcement. **Settled 2026-08-04 (#4785): the session of record is always `sys_session`; cache serves auth as the rate-limit counter store only.** `cacheSecondaryStorage` remains exported for a host that opts into that trade knowingly and accepts that it disables the D4 controls — the default composition cannot reach it silently, because the OIDC provider plugin is on by default and better-auth refuses `secondaryStorage` without `session.storeSessionInDatabase`, which `AuthManager` does not plumb. Dual-writing (`storeSessionInDatabase: true`) was considered and **rejected**: the row exists so the controls appear to work, while the read path still answers from the cache. All three controls are proven end-to-end in `session-of-record.test.ts`. **Remaining:** per-org `sys_organization.allowed_ip_ranges` (+ optional `sys_user.allowed_ip_ranges` override) — tracked in #2571. |
 | **P2/P3** (D6) | 🟡 partial | Generic OIDC RP wired (`genericOAuth`/`sso`); admin OIDC **trust-list settings UI** still env/`sys_sso_provider`-only. |
 | **P3** (SAML, broader social) | 🟡 partial | `@better-auth/sso` present (SAML now better-auth-native — see Addendum); broader settings-driven social providers pending. |
 

--- a/packages/plugins/plugin-auth/src/auth-plugin.test.ts
+++ b/packages/plugins/plugin-auth/src/auth-plugin.test.ts
@@ -1315,6 +1315,15 @@ describe('AuthPlugin', () => {
       // better-auth answers `findSession` from a secondaryStorage snapshot
       // without reading the database, so a cache-backed session store would
       // silently disable them. The cache reaches the COUNTERS only.
+      //
+      // #4785 settled this as a DECISION, not a workaround: the session of
+      // record is always `sys_session`. This assertion is the wiring half of
+      // that decision; `session-of-record.test.ts` is the other half — it
+      // drives the real better-auth pipeline to prove each of the three D4
+      // controls actually ends a live session, and pins the counter-factual
+      // (with a `secondaryStorage` bound, `sys_session` stays EMPTY and the
+      // idle timeout never fires). Read the two together before changing
+      // either: this line alone says what we do, not why it matters.
       const cache = makeCache();
       const { manager } = await bootWith(async () => cache);
       expect((manager as any).config.secondaryStorage).toBeUndefined();

--- a/packages/plugins/plugin-auth/src/session-of-record.test.ts
+++ b/packages/plugins/plugin-auth/src/session-of-record.test.ts
@@ -1,0 +1,499 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// #4785 — "where is the session of record?", settled: it is ALWAYS `sys_session`
+// (the database). The kernel `cache` service serves auth as the rate-limit
+// counter store and nothing else.
+//
+// These are the tests whose ABSENCE let the conflict stay invisible. ADR-0069 D4
+// declares three session controls — idle timeout, absolute lifetime, concurrent
+// cap — and all three revoke the same way: by writing the `sys_session` row
+// (`expires_at` into the past + `revoked_at`/`revoke_reason`). Nothing proved
+// that write actually stopped a live session, so when better-auth's
+// `secondaryStorage` was (nearly) wired to the cache, no test could tell that
+// D4 had silently stopped working.
+//
+// So every test here asserts the END of the chain, not the middle: a request
+// that carries a real session cookie stops being authenticated. Asserting only
+// that the row was stamped would re-create the exact blind spot — a stamped row
+// nobody reads is precisely the failure mode #4785 describes.
+//
+// Real better-auth pipeline throughout (the #3585 EdDSA tests set this
+// precedent: patch the real thing, never stub our own code). Requests go in as
+// `Request` objects through `AuthManager.handleRequest`; the session cookie is
+// the one better-auth minted; the revocation path is the one `customSession`
+// and the sign-in after-hook really run.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { assertEngineDeleteDispatch } from '@objectstack/objectql';
+import { AuthManager } from './auth-manager';
+import { cacheSecondaryStorage } from './secondary-storage';
+
+/**
+ * In-memory IDataEngine, same shape as the #3585 harness.
+ *
+ * Two deliberate fidelity choices, because this file's whole value is that the
+ * fake cannot be more forgiving than the real engine:
+ *
+ * - **`fields` really projects.** `enforceSessionControls` asks for
+ *   `['id','created_at','last_activity_at','revoked_at']` and `enforceConcurrentCap`
+ *   for `['id','created_at','expires_at','revoked_at']`; the ObjectQL adapter
+ *   forwards better-auth's `select` as `fields` too. A fake that returned whole
+ *   rows would let a control read a column it never requested and still pass.
+ * - **`delete` is pinned to ObjectQL's own dispatch predicate**
+ *   ({@link assertEngineDeleteDispatch}), unlike the rest of this fake. This one
+ *   fires for real here: expiring a session in place makes better-auth's
+ *   `getSession` clean the row up via `deleteSession(token)`, so the delete path
+ *   is genuinely exercised by every revocation test below.
+ */
+const createMemoryEngine = () => {
+  const tables = new Map<string, any[]>();
+  const rows = (name: string) => {
+    if (!tables.has(name)) tables.set(name, []);
+    return tables.get(name)!;
+  };
+  const eq = (a: any, b: any) =>
+    a instanceof Date || b instanceof Date
+      ? new Date(a as any).getTime() === new Date(b as any).getTime()
+      : a === b;
+  const matches = (row: any, where: Record<string, any> = {}) =>
+    Object.entries(where).every(([k, v]) => {
+      const actual = row[k];
+      if (v && typeof v === 'object' && !Array.isArray(v) && !(v instanceof Date)) {
+        if ('$ne' in v) return !eq(actual, v.$ne);
+        if ('$in' in v) return (v.$in as any[]).some((x) => eq(actual, x));
+        if ('$gt' in v) return actual > v.$gt;
+        if ('$gte' in v) return actual >= v.$gte;
+        if ('$lt' in v) return actual < v.$lt;
+        if ('$lte' in v) return actual <= v.$lte;
+        if ('$regex' in v) return new RegExp(String(v.$regex)).test(String(actual ?? ''));
+      }
+      return eq(actual, v);
+    });
+  /** `fields` projection — `id` always survives, as it does in ObjectQL. */
+  const project = (row: any, fields?: string[]) => {
+    if (!Array.isArray(fields) || fields.length === 0) return { ...row };
+    const out: any = {};
+    for (const f of ['id', ...fields]) if (f in row) out[f] = row[f];
+    return out;
+  };
+  let seq = 0;
+  return {
+    tables,
+    async insert(name: string, data: any) {
+      const row = { id: data.id ?? `row_${++seq}`, ...data };
+      rows(name).push(row);
+      return { ...row };
+    },
+    async findOne(name: string, q: any = {}) {
+      const row = rows(name).find((r) => matches(r, q.where));
+      return row ? project(row, q.fields) : null;
+    },
+    async find(name: string, q: any = {}) {
+      let out = rows(name).filter((r) => matches(r, q.where));
+      const order = q.orderBy?.[0];
+      if (order) {
+        out = [...out].sort(
+          (a, b) => (a[order.field] > b[order.field] ? 1 : -1) * (order.order === 'desc' ? -1 : 1),
+        );
+      }
+      if (q.offset) out = out.slice(q.offset);
+      if (q.limit) out = out.slice(0, q.limit);
+      return out.map((r) => project(r, q.fields));
+    },
+    async count(name: string, q: any = {}) {
+      return rows(name).filter((r) => matches(r, q.where)).length;
+    },
+    async update(name: string, patch: any) {
+      const row = rows(name).find((r) => r.id === patch.id);
+      if (!row) return null;
+      Object.assign(row, patch);
+      return { ...row };
+    },
+    async delete(name: string, q: any = {}) {
+      assertEngineDeleteDispatch(q);
+      const table = rows(name);
+      const keep = table.filter((r) => !matches(r, q.where));
+      tables.set(name, keep);
+      return table.length - keep.length;
+    },
+  };
+};
+
+const SECRET = 'test-secret-at-least-32-chars-long!!';
+const PASSWORD = 'S3cure!Passw0rd-4785';
+
+const makeManager = (engine: any, config: Record<string, unknown> = {}) =>
+  new AuthManager({
+    secret: SECRET,
+    baseUrl: 'http://localhost:3000',
+    dataEngine: engine,
+    ...config,
+  } as any);
+
+const signUp = (manager: AuthManager, email: string) =>
+  manager.handleRequest(
+    new Request('http://localhost:3000/api/v1/auth/sign-up/email', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password: PASSWORD, name: 'Session Of Record' }),
+    }),
+  );
+
+const signIn = (manager: AuthManager, email: string) =>
+  manager.handleRequest(
+    new Request('http://localhost:3000/api/v1/auth/sign-in/email', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password: PASSWORD }),
+    }),
+  );
+
+const getSession = (manager: AuthManager, cookie: string) =>
+  manager.handleRequest(
+    new Request('http://localhost:3000/api/v1/auth/get-session', { headers: { cookie } }),
+  );
+
+const cookieFrom = (response: Response): string =>
+  (response.headers.getSetCookie?.() ?? [response.headers.get('set-cookie') ?? ''])
+    .map((c) => c.split(';')[0])
+    .filter(Boolean)
+    .join('; ');
+
+/**
+ * Is this cookie still authenticated?
+ *
+ * better-auth answers `/get-session` with HTTP 200 and a JSON `null` body when
+ * the session is gone — NOT a 401 — so a status-only assertion would pass
+ * against a fully revoked session. Read the body.
+ */
+const isAuthenticated = async (manager: AuthManager, cookie: string): Promise<boolean> => {
+  const res = await getSession(manager, cookie);
+  if (res.status !== 200) return false;
+  const body = await res.json().catch(() => null);
+  return Boolean((body as any)?.user?.id);
+};
+
+/** The single `sys_session` row for a cookie's session, straight from the table. */
+const sessionRows = (engine: any) => (engine.tables.get('sys_session') ?? []) as any[];
+
+/** Backdate columns on a stored session row, simulating the passage of time. */
+const ageSession = (engine: any, id: string, patch: Record<string, Date>) => {
+  const row = sessionRows(engine).find((r) => r.id === id);
+  if (!row) throw new Error(`no sys_session row ${id}`);
+  Object.assign(row, patch);
+};
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => vi.restoreAllMocks());
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('#4785 — the session of record is `sys_session` (the database)', () => {
+  it('a sign-up writes a real sys_session row, and the cookie authenticates against it', async () => {
+    const engine = createMemoryEngine();
+    const manager = makeManager(engine);
+
+    const signed = await signUp(manager, 'record@example.com');
+    expect(signed.status).toBe(200);
+    const cookie = cookieFrom(signed);
+
+    // The premise every D4 control rests on: the row EXISTS in the database.
+    expect(sessionRows(engine)).toHaveLength(1);
+    expect(await isAuthenticated(manager, cookie)).toBe(true);
+  });
+
+  it('deleting the row de-authenticates the cookie — the database is what is read', async () => {
+    // The converse of the test above, and the one that actually proves "of
+    // record": if better-auth were answering from anywhere else, dropping the
+    // row would leave the cookie working.
+    const engine = createMemoryEngine();
+    const manager = makeManager(engine);
+    const cookie = cookieFrom(await signUp(manager, 'authority@example.com'));
+    expect(await isAuthenticated(manager, cookie)).toBe(true);
+
+    engine.tables.set('sys_session', []);
+
+    expect(await isAuthenticated(manager, cookie)).toBe(false);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('ADR-0069 D4 — idle timeout really revokes a live session', () => {
+  it('an idle session stops being authenticated, and says why in the row', async () => {
+    const engine = createMemoryEngine();
+    const manager = makeManager(engine, { sessionIdleTimeoutMinutes: 30 });
+
+    const cookie = cookieFrom(await signUp(manager, 'idle@example.com'));
+    const id = sessionRows(engine)[0]!.id;
+    expect(await isAuthenticated(manager, cookie)).toBe(true);
+
+    // 90 minutes of inactivity against a 30-minute timeout. `created_at` stays
+    // recent so ONLY the idle rule can fire — this test must not pass for the
+    // absolute-lifetime reason.
+    ageSession(engine, id, { last_activity_at: new Date(Date.now() - 90 * MINUTE) });
+
+    // `enforceSessionControls` runs inside `customSession`, i.e. AFTER
+    // better-auth has already validated this request's session. So the request
+    // that DETECTS the timeout is still authenticated, and the next one is not.
+    // That one-request lag is the documented design, and pinning it here is
+    // what stops someone "fixing" the lag by moving the check somewhere the
+    // revocation write no longer happens.
+    expect(await isAuthenticated(manager, cookie)).toBe(true);
+
+    const row = sessionRows(engine).find((r) => r.id === id)!;
+    expect(row.revoke_reason).toBe('idle_timeout');
+    expect(row.revoked_at).toBeInstanceOf(Date);
+    expect(new Date(row.expires_at).getTime()).toBeLessThan(Date.now());
+
+    // The assertion that matters: the cookie is dead.
+    expect(await isAuthenticated(manager, cookie)).toBe(false);
+  });
+
+  it('an ACTIVE session is not revoked, and its last_activity_at is touched', async () => {
+    // The other half of the control: a timeout that revokes everything would
+    // pass every assertion above and be useless.
+    const engine = createMemoryEngine();
+    const manager = makeManager(engine, { sessionIdleTimeoutMinutes: 30 });
+
+    const cookie = cookieFrom(await signUp(manager, 'active@example.com'));
+    const id = sessionRows(engine)[0]!.id;
+
+    // 5 minutes idle against a 30-minute timeout — inside the window. Backdated
+    // past the 60s touch throttle so the touch is observable.
+    ageSession(engine, id, { last_activity_at: new Date(Date.now() - 5 * MINUTE) });
+
+    expect(await isAuthenticated(manager, cookie)).toBe(true);
+    expect(await isAuthenticated(manager, cookie)).toBe(true);
+
+    const row = sessionRows(engine).find((r) => r.id === id)!;
+    expect(row.revoked_at).toBeUndefined();
+    expect(row.revoke_reason).toBeUndefined();
+    expect(Date.now() - new Date(row.last_activity_at).getTime()).toBeLessThan(MINUTE);
+  });
+
+  it('is off when the setting is 0 — an ancient session stays authenticated', async () => {
+    const engine = createMemoryEngine();
+    const manager = makeManager(engine, { sessionIdleTimeoutMinutes: 0 });
+
+    const cookie = cookieFrom(await signUp(manager, 'off@example.com'));
+    ageSession(engine, sessionRows(engine)[0]!.id, {
+      last_activity_at: new Date(Date.now() - 400 * HOUR),
+    });
+
+    expect(await isAuthenticated(manager, cookie)).toBe(true);
+    expect(await isAuthenticated(manager, cookie)).toBe(true);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('ADR-0069 D4 — absolute lifetime really revokes a live session', () => {
+  it('a session past its absolute cap stops being authenticated however active it is', async () => {
+    const engine = createMemoryEngine();
+    const manager = makeManager(engine, { sessionAbsoluteMaxHours: 8 });
+
+    const cookie = cookieFrom(await signUp(manager, 'absolute@example.com'));
+    const id = sessionRows(engine)[0]!.id;
+    expect(await isAuthenticated(manager, cookie)).toBe(true);
+
+    // Created 12h ago (cap 8h) but active RIGHT NOW. This is the case
+    // better-auth's own `updateAge` can never catch — a session that keeps
+    // sliding its window forever — which is why D4 calls the absolute cap
+    // custom. Idle is off, so only the absolute rule can fire.
+    ageSession(engine, id, {
+      created_at: new Date(Date.now() - 12 * HOUR),
+      last_activity_at: new Date(),
+    });
+
+    expect(await isAuthenticated(manager, cookie)).toBe(true); // detecting request
+
+    const row = sessionRows(engine).find((r) => r.id === id)!;
+    expect(row.revoke_reason).toBe('absolute_max');
+    expect(new Date(row.expires_at).getTime()).toBeLessThan(Date.now());
+
+    expect(await isAuthenticated(manager, cookie)).toBe(false);
+  });
+
+  it('a session inside its absolute cap survives', async () => {
+    const engine = createMemoryEngine();
+    const manager = makeManager(engine, { sessionAbsoluteMaxHours: 8 });
+
+    const cookie = cookieFrom(await signUp(manager, 'within@example.com'));
+    ageSession(engine, sessionRows(engine)[0]!.id, {
+      created_at: new Date(Date.now() - 2 * HOUR),
+      last_activity_at: new Date(),
+    });
+
+    expect(await isAuthenticated(manager, cookie)).toBe(true);
+    expect(await isAuthenticated(manager, cookie)).toBe(true);
+    expect(sessionRows(engine)[0]!.revoke_reason).toBeUndefined();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('ADR-0069 D4 — concurrent-session cap really revokes the oldest session', () => {
+  it('a third sign-in under cap=2 kills the oldest cookie and spares the newer two', async () => {
+    const engine = createMemoryEngine();
+    const manager = makeManager(engine, { maxConcurrentSessions: 2 });
+
+    // Three sign-ins for ONE user. `enforceConcurrentCap` runs from the
+    // `/sign-in/email` after-hook, so sign-up alone never triggers it.
+    const first = cookieFrom(await signUp(manager, 'cap@example.com'));
+    const firstId = sessionRows(engine)[0]!.id;
+    // The cap sorts by `created_at` desc. Rows minted inside the same
+    // millisecond would sort unstably and make this test flaky for a reason
+    // that has nothing to do with the control, so each session is given a
+    // distinct, explicitly ordered birth time.
+    ageSession(engine, firstId, { created_at: new Date(Date.now() - 3 * HOUR) });
+
+    const second = cookieFrom(await signIn(manager, 'cap@example.com'));
+    const secondId = sessionRows(engine).find((r) => r.id !== firstId)!.id;
+    ageSession(engine, secondId, { created_at: new Date(Date.now() - 2 * HOUR) });
+
+    // Both live so far — cap is 2.
+    expect(await isAuthenticated(manager, first)).toBe(true);
+    expect(await isAuthenticated(manager, second)).toBe(true);
+
+    const third = cookieFrom(await signIn(manager, 'cap@example.com'));
+
+    const firstRow = sessionRows(engine).find((r) => r.id === firstId)!;
+    expect(firstRow.revoke_reason).toBe('concurrent_cap');
+    expect(new Date(firstRow.expires_at).getTime()).toBeLessThan(Date.now());
+
+    // Evict-oldest, not reject-newest: the oldest cookie is dead immediately
+    // (no detecting-request lag — the revocation landed before this read), and
+    // the two newest still work.
+    expect(await isAuthenticated(manager, first)).toBe(false);
+    expect(await isAuthenticated(manager, second)).toBe(true);
+    expect(await isAuthenticated(manager, third)).toBe(true);
+  });
+
+  it('is off when the setting is 0 — a third session survives', async () => {
+    const engine = createMemoryEngine();
+    const manager = makeManager(engine, { maxConcurrentSessions: 0 });
+
+    const first = cookieFrom(await signUp(manager, 'nocap@example.com'));
+    await signIn(manager, 'nocap@example.com');
+    await signIn(manager, 'nocap@example.com');
+
+    expect(await isAuthenticated(manager, first)).toBe(true);
+    expect(sessionRows(engine).some((r) => r.revoke_reason)).toBe(false);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('#4785 — why cache is NOT the session store (the rejected architecture)', () => {
+  // The counter-factual, run against the REAL adapter rather than argued in a
+  // comment. `auth-plugin.test.ts` pins that the kernel cache is never bound as
+  // `secondaryStorage`; this pins WHAT THAT PIN IS PROTECTING, so the cost of
+  // undoing it is visible in a failing test rather than in a security incident
+  // six months later.
+  const makeCache = () => {
+    const store = new Map<string, unknown>();
+    return {
+      store,
+      get: async (k: string) => (store.has(k) ? store.get(k) : undefined),
+      set: async (k: string, v: unknown) => void store.set(k, v),
+      delete: async (k: string) => store.delete(k),
+      has: async (k: string) => store.has(k),
+      clear: async () => store.clear(),
+      stats: async () => ({ hits: 0, misses: 0, keyCount: store.size }),
+    };
+  };
+
+  it('opting into cacheSecondaryStorage empties sys_session and makes idle timeout inert', async () => {
+    const engine = createMemoryEngine();
+    const cache = makeCache();
+    const manager = makeManager(engine, {
+      sessionIdleTimeoutMinutes: 30,
+      secondaryStorage: cacheSecondaryStorage(cache as any),
+      // The OIDC provider is on by default and refuses this configuration
+      // outright — see the boot-refusal test below. Off here so the session
+      // relocation itself is what's under test.
+      plugins: { oidcProvider: false },
+    });
+
+    const cookie = cookieFrom(await signUp(manager, 'cached@example.com'));
+    expect(await isAuthenticated(manager, cookie)).toBe(true);
+
+    // 1. No row at all: `createSession` skips the insert when a
+    //    `secondaryStorage` is present and `storeSessionInDatabase` is not set.
+    //    The session lives in the cache instead.
+    expect(sessionRows(engine)).toHaveLength(0);
+    expect(cache.store.size).toBeGreaterThan(0);
+
+    // 2. Therefore `enforceSessionControls` has nothing to find, nothing to
+    //    stamp, and its `findOne` miss is indistinguishable from a healthy
+    //    session — it returns early. The declared idle timeout is inert, and
+    //    the cookie outlives it: the session survives for its full TTL.
+    //
+    //    Ageing happens in the cache, which IS the store of record under this
+    //    configuration — exactly where it would age in production.
+    for (const [k, v] of cache.store) {
+      if (typeof v !== 'string' || !v.includes('"session"')) continue;
+      const snap = JSON.parse(v);
+      snap.session.updatedAt = new Date(Date.now() - 90 * MINUTE).toISOString();
+      cache.store.set(k, JSON.stringify(snap));
+    }
+
+    expect(await isAuthenticated(manager, cookie)).toBe(true);
+    expect(await isAuthenticated(manager, cookie)).toBe(true);
+    expect(sessionRows(engine)).toHaveLength(0);
+  });
+
+  it('option C (dual-write) is not reachable through config — asking for it changes nothing', async () => {
+    // The maintainer rejected `session.storeSessionInDatabase: true` as the
+    // WORST option: the row exists, so `enforceSessionControls` finds it and
+    // stamps it and every database-side assertion looks healthy — while
+    // `findSession` still answers from the cache snapshot, so revocation
+    // appears to work and does not.
+    //
+    // `AuthManager` never plumbs the flag: it builds better-auth's `session`
+    // block from `AUTH_SESSION_CONFIG` plus `expiresIn`/`updateAge` only, so a
+    // host that passes it is silently building the cache-only shape instead.
+    // Pinned behaviourally rather than by reading private options — this is the
+    // property that matters, and it holds no matter how the block is assembled.
+    const engine = createMemoryEngine();
+    const cache = makeCache();
+    const manager = makeManager(engine, {
+      sessionIdleTimeoutMinutes: 30,
+      secondaryStorage: cacheSecondaryStorage(cache as any),
+      plugins: { oidcProvider: false },
+      session: { storeSessionInDatabase: true },
+    });
+
+    const cookie = cookieFrom(await signUp(manager, 'dualwrite@example.com'));
+    expect(await isAuthenticated(manager, cookie)).toBe(true);
+
+    // Requested dual-write; got cache-only. No row was ever written, so there
+    // is nothing for a D4 control to stamp.
+    expect(sessionRows(engine)).toHaveLength(0);
+  });
+
+  it('the DEFAULT composition refuses to boot with a secondaryStorage rather than degrading quietly', async () => {
+    // The safety net under all of the above, and the reason this hole could
+    // never have opened silently in a standard `serve`: the OIDC provider
+    // plugin is enabled by default, and better-auth 1.7 hard-refuses
+    // `secondaryStorage` without `storeSessionInDatabase`. Since AuthManager
+    // does not plumb that flag (test above), the default composition cannot
+    // reach the cache-backed session store at all — it throws at boot.
+    //
+    // Loud absence beats a quiet downgrade (AGENTS.md "Absence must be loud"),
+    // and this is what makes ADR-0069 D4's guarantee hold for real deployments
+    // rather than by convention.
+    const engine = createMemoryEngine();
+    const cache = makeCache();
+    const manager = makeManager(engine, {
+      sessionIdleTimeoutMinutes: 30,
+      secondaryStorage: cacheSecondaryStorage(cache as any),
+    });
+
+    await expect(signUp(manager, 'default@example.com')).rejects.toThrow(
+      /storeSessionInDatabase/,
+    );
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4785

按维护者 2026-08-04 的裁定落地**方案 A**：会话的记录之处永远是 `sys_session`（数据库）；cache 之于 auth 只是限流计数器。方案 C（双写）明确否决。

**运行时零改动** —— 本 PR 做的是：把决策记录下来，并**证明**依赖这条决策的行为真的成立。

## 核心交付：那条一直缺席的端到端测试

`packages/plugins/plugin-auth/src/session-of-record.test.ts`（新增，12 个用例）。

ADR-0069 D4 声明了三个会话管控（空闲超时 / 绝对时长 / 并发上限），三者都靠**写 `sys_session` 行**来撤销，而此前没有任何测试断言过「这次写真的让一个**活动会话**失效了」—— 顶多断言了某个列被盖上了戳。**盖了戳却没人读的行，正是 #4785 描述的失效形态**，所以每个用例断言的都是链路的终点：一个带真实会话 cookie 的请求**不再是已认证状态**，而不是某列被写了。

沿用 #3585 EdDSA 测试确立的范式：跑**真实的 better-auth 管线**（真实 `Request` → `AuthManager.handleRequest` → better-auth 签发的真实 cookie），不 stub 我们自己的代码。

覆盖：
- **记录之处**：注册真的写出 `sys_session` 行；把行删掉，cookie 立刻失认证 —— 这条反向断言才真正证明「读的是数据库」。
- **空闲超时 / 绝对时长 / 并发上限**：各自真的终结一个活动会话，并各自有「不该撤销时不撤销」和「设为 0 时关闭」的对照用例。
- 三个管控的 `revoke_reason` 各不相同，且 `expires_at` 确实被写到过去。

**变异测试验证过它不是空转**（都能变红）：
- 把 `enforceSessionControls` / `enforceConcurrentCap` 改成 no-op → 4 个用例失败；
- 只盖 `revoked_at` 而不把 `expires_at` 写到过去（即「盖戳但读路径不看」）→ 2 个用例失败。

## 顺带查实的两个事实（都已钉住）

排查中发现，这个洞比 issue 正文估计的**更难被误踩**，两点都写成了测试：

1. `AuthManager` 根本不透传 `session.storeSessionInDatabase` —— 它构造 better-auth 的 `session` 块时只取 `expiresIn`/`updateAge`。**被否决的方案 C 在配置层面就不可达**：宿主即使传了这个标志，拿到的仍是 cache-only 形态。
2. 默认组合下 OIDC provider 插件是开的，而 better-auth 1.7 在有 `secondaryStorage` 却没有 `storeSessionInDatabase` 时**直接拒绝启动**。加上第 1 点，**标准 `serve` 组合根本无法悄悄走到出问题的架构上** —— 是响亮的启动失败，不是静默降级（符合 AGENTS.md「Absence must be loud」）。

## D4 本身有没有真缺陷？没有

按任务要求核过了：在裁定的架构（DB 为记录之处）下三个管控都真的生效。读路径确实认写进去的过去 `expires_at`（better-auth `getSession` 第 190 行判 `expiresAt < now`），且 ObjectStack 没有开启 `session.cookieCache`，所以不存在「撤销了但 cookie 缓存还认」的窗口。`auth-manager.ts` 未作任何修改。

一个值得记录的语义（已写进 ADR 与测试注释）：空闲/绝对两项在 `customSession` 里执行，而它跑在本次请求的会话**已被校验之后**，所以**发现超时的那次请求仍然成功，下一次才失认证**；并发上限在登录 after-hook 里跑，立即生效。测试把这个一次请求的延迟钉住了 —— 免得有人为了「修掉延迟」把检查挪到撤销写不再发生的地方。

## 文档侧

**`docs/adr/0069-*.md`**
- D2 的「shared store」明确限定为**限流计数器**：它是 `rateLimit.customStorage`，**不是** `secondaryStorage`（后者会连带搬走会话记录之处）；并写明**若将来要把会话搬进缓存，那是一条新决策**，必须在同一条 ADR 里给出撤销一致性要求（撤销如何让每个节点的缓存快照失效，失效失败时怎么办）。
- D4 增加说明：`sys_session` 是 **D4 的前置条件，不是部署偏好**；点明真正起撤销作用的是 `expires_at`（`revoked_at`/`revoke_reason` 是诊断用），只盖后两者的撤销是无效的。
- 状态行改为事实描述，并记录 C 被否决及其理由。

**`content/docs/kernel/contracts/cache-service.mdx`**（按裁定只改开头那一段）：从 cache 的用途列表里去掉 "session storage"，改为写实 —— 会话记录之处是 `sys_session`；宿主可以用 `cacheSecondaryStorage()` **显式选用**，但**选用即停用 D4 三个会话管控**，被撤销的会话会一直可用到缓存副本过期。

**`auth-plugin.test.ts`** 那条「cache 不绑 secondaryStorage」的钉扎测试保留，加注指向新测试 —— 原注释说的是「我们怎么做」，新测试说的是「为什么这件事重要」。

## 验证

```
pnpm --filter @objectstack/plugin-auth test       # 32 files, 711 passed
pnpm --filter @objectstack/plugin-auth typecheck  # tsc --noEmit, 干净
pnpm check:adr-anchors / check:doc-authoring / check:role-word
pnpm check:release-notes / check:nul-bytes        # 全绿
eslint（改动的两个测试文件）                        # 干净
```

已合入 `origin/main`（合入内容只动 `packages/lint`，与本 PR 不相交），合后重跑上述用例仍全绿。

## 范围

`packages/plugins/plugin-auth/**`（纯测试）+ `docs/adr/0069-*.md` + `cache-service.mdx` 开头一段 + changeset。`packages/spec/**` 与 `content/docs/releases/` **零改动**。

一处可选的后续（未做，因超出认领的文件面）：可以给 `secondary-storage.ts` 在 `scripts/adr-anchors.json` 里加一条 ADR-0069 锚点。目前 ADR 正文点名了测试文件、测试文件通篇点名 ADR-0069 D4，双向可发现性已经成立，`check:adr-anchors` 也是绿的。

---
_Generated by [Claude Code](https://claude.ai/code/session_015W6nhsDrz6zWQc8je12a1t)_