### PR TITLE
fix(objectql): readonly 剥离改为「说清后果 + 给出出路」,并把写路径语义写进文档 (#4903)

### DIFF
--- a/.changeset/readonly-strip-actionable-warning.md
+++ b/.changeset/readonly-strip-actionable-warning.md
@@ -1,0 +1,36 @@
+---
+'@objectstack/objectql': patch
+---
+
+fix(objectql): the static-`readonly` write strip now logs its consequence and its remedy
+
+Writing a `readonly: true` column from server-side code — a cron job or background
+task reaching the engine through `ctx.getService('data')` — dropped the value and
+reported success. The only trace was:
+
+```
+WARN Field 'work_duration' is read-only — ignoring incoming change (#2948)
+```
+
+which says what the engine did, not what it cost the caller or how to fix it. The
+downstream symptom is a field that persists fine through every REST path and never
+persists from cron (os-project-titanwind-ehr#750), which reads as "cron is broken"
+rather than "the value was stripped". The strip now names the object, states that
+the update was **committed without the field**, and carries both remedies: trusted
+server code declares itself with `{ context: { isSystem: true } }`, and any caller
+can detect drops programmatically with `options.onFieldsDropped` (the machine-readable
+strip signal that has existed since #3407 — one event per strip pass, with `fields`
+and `reason`).
+
+The level stays `warn`, deliberately: this seam cannot distinguish a hostile REST
+body forging `created_by` from trusted server code, because `ExecutionContext`
+carries no origin marker and `isSystem` — the only trust bit — is precisely the
+exemption. `error` would make the error log client-triggerable; `debug` would restore
+the silent drop.
+
+Behaviour is unchanged: what is stripped, what survives, and what `onFieldsDropped`
+reports are all identical. Documented in the [security protocol
+page](/docs/protocol/objectql/security) — strip condition, the caller-supplied-keys
+scope, why a `beforeUpdate` hook's backfill is exempt (the key snapshot is taken at
+engine entry, before hooks run), and the `isSystem` convention for plugin writes —
+and pinned in `engine-readonly-strip-signal.test.ts`.

--- a/content/docs/protocol/objectql/security.mdx
+++ b/content/docs/protocol/objectql/security.mdx
@@ -246,6 +246,64 @@ fields:
 
 > There is no separate `create` flag for fields. `editable` governs both create-time and update-time writes; read stripping is governed by `readable`.
 
+### Static `readonly` fields on the write path
+
+`readonly: true` on a field definition is a *schema-level* lock, independent of permission
+sets: no permission set can grant a write to it. It is enforced by **stripping**, not by
+rejecting — the offending key is removed from the payload and the rest of the write is
+committed. The write therefore **succeeds** (REST answers `200`), and the read-only column
+simply keeps its stored value.
+
+Four rules decide whether a given value survives:
+
+| # | Rule | Effect |
+|:--|:---|:---|
+| 1 | **Trusted context is exempt** | A write carrying `context.isSystem === true` skips the strip entirely and may set read-only columns. |
+| 2 | **Only *caller-supplied* keys are candidates** | The engine snapshots the payload's keys at entry (`suppliedKeys`), *before* middleware and `beforeUpdate` hooks run. Only keys in that snapshot can be stripped. |
+| 3 | **Hook / middleware backfill survives** | A key a `beforeUpdate` hook *adds* to `data` is absent from the entry snapshot, so it is not a candidate — this is why the built-in `updated_by` / `updated_at` stamps land even though those columns are `readonly`. |
+| 4 | **`context.preserveAudit` admits a whitelist** | An opt-in historical import reinstates the audit/timestamp family and author-declared business `readonly` fields; platform-managed `system` columns (tenancy, generated) stay stripped. |
+
+Rule 2 is scoped to keys, not values: a key the caller sent stays a strip candidate even if
+a hook later overwrites its value. So a `beforeUpdate` hook can *backfill* a read-only
+field, but cannot *rescue* one the caller supplied.
+
+<Callout type="warn">
+**Server-side plugins are not trusted by default.** `ctx.getService('data')` hands back the
+same engine the REST layer uses, with an **empty execution context** — so a cron job or
+background task writing a system-computed read-only column travels the same strip as
+untrusted client input, and its value is dropped while the call reports success. Trusted
+server code must say so:
+
+```ts
+const data = ctx.getService('data');
+await data.update('attendance', { id, status: 'closed', work_duration: 480 },
+  { context: { isSystem: true } });   // ← required to write a `readonly` column
+```
+
+`isSystem` is the documented convention for this, and it is deliberately explicit: it
+bypasses permission checks too, so it declares "this write is platform code acting as the
+platform", not "this write came from a plugin".
+</Callout>
+
+**Detecting a drop programmatically.** Every strip pass reports itself to the caller
+through `options.onFieldsDropped`, so a caller that reports per-field success (a flow's
+`update_record` step, an import runner) can surface a warning instead of a clean success:
+
+```ts
+await data.update('attendance', { id, work_duration: 480 }, {
+  onFieldsDropped: ({ object, fields, reason }) => {
+    // { object: 'attendance', fields: ['work_duration'], reason: 'readonly' }
+    logger.warn(`dropped ${fields.join(', ')} on ${object} (${reason})`);
+  },
+});
+```
+
+`reason` is `'readonly'` for this static lock and `'readonly_when'` for a conditional
+[`readonlyWhen`](/docs/references/data/field) predicate. The listener is an in-process
+callback: it is delivered by the local engine, and does **not** cross the RPC / Virtual
+Data Engine boundary, so a remote caller never receives these events. Without a listener,
+the only trace is a server-side `WARN` naming the object, the field, and both remedies.
+
 ---
 
 ## 4. Data Masking

--- a/packages/objectql/src/engine-readonly-strip-signal.test.ts
+++ b/packages/objectql/src/engine-readonly-strip-signal.test.ts
@@ -1,0 +1,268 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// #4903 — the static `readonly: true` write strip, from the CALLER's side.
+//
+// A server-side plugin (cron / background job) that writes a `readonly` column
+// through `ctx.getService('data').update(...)` gets a SUCCESSFUL call whose
+// value never lands: `getService('data')` hands back the plain engine, whose
+// execution context is empty, so `!context.isSystem` sends trusted server code
+// down the same strip as untrusted client input. Downstream report:
+// os-project-titanwind-ehr#750 — a settled `work_duration` stayed `null` when
+// (and only when) the auto-clock-out cron wrote it, while every REST path for
+// the same field worked, which reads as "cron is broken" rather than "the field
+// was stripped".
+//
+// This suite pins the three things that decide how expensive that is to
+// diagnose:
+//
+//  1. WHY the hook path differs (`suppliedKeys` is snapshotted at engine entry,
+//     BEFORE middleware and beforeUpdate hooks run) — the asymmetry the issue
+//     reports is pinned as EXISTING behaviour so the next change to it is
+//     deliberate. Nothing here endorses it.
+//  2. The strip's log states the CONSEQUENCE and both REMEDIES, so the log is
+//     actionable on its own (#4632's second-class shape: caller believes
+//     persisted, database disagrees, log is the only trace).
+//  3. The machine-readable signal that ALREADY exists — `onFieldsDropped`
+//     (#3407) — is reachable from exactly the caller shape the issue describes
+//     (in-process engine, no context), and `{ context: { isSystem: true } }`
+//     makes the same write land.
+//
+// What is NOT here: a strict/reject mode. That needs a new write-option key,
+// and both homes for it (`EngineUpdateOptionsSchema`, `WriteObservabilityOptions`)
+// live in `packages/spec` — see the issue thread.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ObjectQL } from './engine.js';
+import { readonlyStripWarning, stripReadonlyFields } from './validation/rule-validator.js';
+
+function makeDriver() {
+  const stores = new Map<string, Map<string, any>>();
+  const storeFor = (o: string) => {
+    let s = stores.get(o);
+    if (!s) { s = new Map(); stores.set(o, s); }
+    return s;
+  };
+  const matches = (row: any, where: any): boolean => {
+    if (!where || typeof where !== 'object') return true;
+    return Object.entries(where).every(([k, v]: [string, any]) => row?.[k] === v);
+  };
+  let n = 0;
+  const driver: any = {
+    name: 'memory', version: '0.0.0', supports: {},
+    async connect() {}, async disconnect() {}, async checkHealth() { return true; }, async execute() { return null; },
+    async find(object: string, ast: any) {
+      return Array.from(storeFor(object).values()).filter((r) => matches(r, ast?.where));
+    },
+    async findOne(object: string, ast: any) {
+      for (const r of storeFor(object).values()) if (matches(r, ast?.where)) return r;
+      return null;
+    },
+    async create(object: string, data: Record<string, unknown>) {
+      n += 1;
+      const id = (data.id as string) ?? `r_${n}`;
+      const row = { ...data, id };
+      storeFor(object).set(id, row);
+      return row;
+    },
+    async update(object: string, id: string, data: Record<string, unknown>) {
+      const s = storeFor(object);
+      const row = { ...s.get(id), ...data, id };
+      s.set(id, row);
+      return row;
+    },
+    async updateMany(object: string, ast: any, data: Record<string, unknown>) {
+      const s = storeFor(object);
+      let count = 0;
+      for (const row of [...s.values()]) {
+        if (!matches(row, ast?.where)) continue;
+        s.set(row.id, { ...row, ...data, id: row.id });
+        count += 1;
+      }
+      return count;
+    },
+    async delete(object: string, id: string) { return storeFor(object).delete(id); },
+    async count() { return 0; },
+    async bulkCreate(object: string, rows: Record<string, unknown>[]) {
+      return Promise.all(rows.map((r) => this.create(object, r, undefined)));
+    },
+    async bulkUpdate() { return []; }, async bulkDelete() {},
+    async beginTransaction() { return { __trx: true, commit: async () => {}, rollback: async () => {} }; },
+    async commit() {}, async rollback() {},
+  };
+  return { driver, storeFor };
+}
+
+/** A logger that records the lines the engine writes, for the log-contract pin. */
+function makeCapturingLogger() {
+  const warns: string[] = [];
+  const logger: any = {
+    warns,
+    debug() {}, info() {}, error() {}, trace() {}, fatal() {},
+    warn(msg: string) { warns.push(String(msg)); },
+    child() { return logger; },
+  };
+  return logger;
+}
+
+describe('static `readonly` write strip — caller-facing signal (#4903)', () => {
+  let engine: ObjectQL;
+  let logger: ReturnType<typeof makeCapturingLogger>;
+  let storeFor: ReturnType<typeof makeDriver>['storeFor'];
+
+  beforeEach(async () => {
+    logger = makeCapturingLogger();
+    engine = new ObjectQL({ logger });
+    const d = makeDriver();
+    storeFor = d.storeFor;
+    engine.registerDriver(d.driver, true);
+    await engine.init();
+    // The downstream shape, trimmed: an attendance record whose worked-hours
+    // column is settled by the platform, never typed by a user.
+    engine.registry.registerObject({
+      name: 'attendance',
+      fields: {
+        status: { type: 'text' },
+        check_out_time: { type: 'datetime' },
+        work_duration: { type: 'number', readonly: true },
+      },
+    } as any);
+    storeFor('attendance').set('att_1', { id: 'att_1', status: 'open', work_duration: null });
+  });
+
+  const att = () => storeFor('attendance').get('att_1');
+
+  // ── 1. the reported behaviour, and the documented way out ───────────────
+
+  it('THE REPORT: a contextless plugin write lands every field EXCEPT the readonly one', async () => {
+    await engine.update('attendance', {
+      id: 'att_1', status: 'closed', check_out_time: '2026-08-04T09:00:00Z', work_duration: 480,
+    });
+    // The call resolved without throwing — that is the whole complaint.
+    expect(att()).toMatchObject({ status: 'closed', check_out_time: '2026-08-04T09:00:00Z' });
+    expect(att().work_duration).toBeNull();
+  });
+
+  it('the SAME write lands in full once the caller declares itself trusted', async () => {
+    await engine.update(
+      'attendance',
+      { id: 'att_1', status: 'closed', work_duration: 480 },
+      { context: { isSystem: true } } as any,
+    );
+    expect(att()).toMatchObject({ status: 'closed', work_duration: 480 });
+  });
+
+  // ── 2. the machine-readable signal that already exists (#3407) ───────────
+
+  it('reports the drop to a contextless caller via onFieldsDropped', async () => {
+    // The listener is reachable from exactly the shape the issue describes:
+    // `ctx.getService('data')` registers the in-process engine (plugin.ts), so
+    // no RPC boundary swallows the event.
+    const events: any[] = [];
+    await engine.update(
+      'attendance',
+      { id: 'att_1', status: 'closed', work_duration: 480 },
+      { onFieldsDropped: (e: any) => events.push(e) } as any,
+    );
+    expect(events).toEqual([{ object: 'attendance', fields: ['work_duration'], reason: 'readonly' }]);
+  });
+
+  it('reports the drop on the BULK path too', async () => {
+    const events: any[] = [];
+    await engine.update(
+      'attendance',
+      { work_duration: 480 },
+      { where: { status: 'open' }, multi: true, onFieldsDropped: (e: any) => events.push(e) } as any,
+    );
+    expect(events).toEqual([{ object: 'attendance', fields: ['work_duration'], reason: 'readonly' }]);
+    expect(att().work_duration).toBeNull();
+  });
+
+  // ── 3. the log is actionable on its own ─────────────────────────────────
+
+  it('the strip WARNs the consequence and BOTH remedies, naming the object and field', async () => {
+    await engine.update('attendance', { id: 'att_1', work_duration: 480 });
+    const line = logger.warns.find((w: string) => w.includes('work_duration'));
+    expect(line, 'the strip must log').toBeDefined();
+    // Consequence — not just "ignoring incoming change".
+    expect(line).toContain("Field 'work_duration' on 'attendance'");
+    expect(line).toContain('COMMITTED WITHOUT IT');
+    // Remedy A: the documented convention for genuinely trusted server code.
+    expect(line).toContain('{ context: { isSystem: true } }');
+    // Remedy B: the machine-readable signal, so the log is not the only way out.
+    expect(line).toContain('onFieldsDropped');
+  });
+
+  it('stays at WARN — the seam cannot tell a forged client body from trusted server code', () => {
+    // Pinned deliberately: `ExecutionContext` carries no origin/channel marker,
+    // so an `error` level here would be client-triggerable log spam and a
+    // `debug` level would restore the silent drop. One level, chosen.
+    const calls: Array<[string, string]> = [];
+    const probe: any = {
+      warn: (m: string) => calls.push(['warn', m]),
+      error: (m: string) => calls.push(['error', m]),
+      info: (m: string) => calls.push(['info', m]),
+      debug: (m: string) => calls.push(['debug', m]),
+    };
+    stripReadonlyFields(
+      { name: 'attendance', fields: { work_duration: { type: 'number', readonly: true } } } as any,
+      { work_duration: 480 },
+      new Set(['work_duration']),
+      probe,
+    );
+    expect(calls.map(([level]) => level)).toEqual(['warn']);
+    expect(calls[0][1]).toBe(readonlyStripWarning('work_duration', 'attendance'));
+  });
+
+  it('omits the object clause when the schema carries no name', () => {
+    expect(readonlyStripWarning('work_duration')).toContain("Field 'work_duration' is read-only");
+  });
+
+  // ── 4. the hook/plugin asymmetry, PINNED as-is ──────────────────────────
+  //
+  // NOT an endorsement. The issue asks whether a beforeUpdate hook SHOULD be
+  // able to write a column a plugin cannot; that question is open. This pins
+  // the current answer and — more usefully — the MECHANISM, so a future change
+  // is made on purpose instead of by accident.
+
+  describe('beforeUpdate backfill vs. caller supply (pinned mechanism)', () => {
+    it('a hook-written readonly field LANDS while the same field supplied by the caller is stripped', async () => {
+      engine.registerHook('beforeUpdate', async (ctx: any) => {
+        ctx.input.data.work_duration = 480;
+      }, { object: 'attendance' });
+
+      // Caller supplies nothing read-only; the hook backfills it → persisted.
+      await engine.update('attendance', { id: 'att_1', status: 'closed' });
+      expect(att().work_duration).toBe(480);
+    });
+
+    it('a hook cannot rescue a key the CALLER supplied — the snapshot is taken first', async () => {
+      // The mechanism, stated: `suppliedKeys` is `new Set(Object.keys(data))`
+      // captured at engine entry, BEFORE middleware and beforeUpdate hooks run.
+      // A key the hook ADDS is absent from that snapshot and survives; a key the
+      // caller sent is in it and is stripped no matter what the hook does to the
+      // value afterwards.
+      storeFor('attendance').set('att_2', { id: 'att_2', status: 'open', work_duration: null });
+      engine.registerHook('beforeUpdate', async (ctx: any) => {
+        if (ctx.input.data.work_duration !== undefined) ctx.input.data.work_duration = 999;
+      }, { object: 'attendance' });
+
+      await engine.update('attendance', { id: 'att_2', status: 'closed', work_duration: 480 });
+      expect(storeFor('attendance').get('att_2')).toMatchObject({ status: 'closed' });
+      expect(storeFor('attendance').get('att_2').work_duration).toBeNull();
+    });
+
+    it('the engine-stamped audit column is the same exemption, not a special case', () => {
+      // `updated_by` survives a user write for exactly one reason: the audit
+      // hook writes it, so it is not in `suppliedKeys`. Supplied explicitly, it
+      // is dropped like any other readonly field.
+      const schema = {
+        name: 'attendance',
+        fields: { updated_by: { type: 'text', readonly: true, system: true } },
+      } as any;
+      const stamped = stripReadonlyFields(schema, { updated_by: 'hook-stamp' }, new Set());
+      expect(stamped).toEqual({ updated_by: 'hook-stamp' });
+      const forged = stripReadonlyFields(schema, { updated_by: 'attacker' }, new Set(['updated_by']));
+      expect(forged).toEqual({});
+    });
+  });
+});

--- a/packages/objectql/src/validation/rule-validator.ts
+++ b/packages/objectql/src/validation/rule-validator.ts
@@ -542,9 +542,30 @@ export function stripReadonlyWhenFieldsMulti(
  *
  * Returns the same object when nothing is stripped, else a shallow copy with the
  * offending keys removed.
+ *
+ * ### What the strip LOGS, and why it stays at `warn` (#4903)
+ *
+ * A dropped field is the #4632 second-class shape: the caller is told the write
+ * succeeded, the database disagrees about one column, and the server log is the
+ * only trace. So the message must carry the CONSEQUENCE (committed without the
+ * field) and the REMEDY, not just the fact — a bare "ignoring incoming change"
+ * is what made os-project-titanwind-ehr#750 read as "only cron can't write".
+ *
+ * It stays at `warn`, one level for every caller, because THIS SEAM CANNOT TELL
+ * THE TWO CALLERS APART. The strip runs on `!context.isSystem`, and
+ * `ExecutionContext` carries no origin / channel / transport marker — `isSystem`
+ * is the only trust bit, and it is precisely the exemption. A hostile REST body
+ * forging `created_by` and a trusted cron plugin writing a computed column
+ * arrive here indistinguishable (an absent context is not proof of server code
+ * either: a plugin may legitimately act as a user, and an unauthenticated REST
+ * write also has no principal). Escalating to `error` would therefore let any
+ * client fill the error log on demand; demoting to `debug` would re-hide the
+ * silent-drop. `warn` + a message that names both remedies is the honest single
+ * level. Changing this means giving `ExecutionContext` a real origin marker
+ * first — not guessing from the absence of a principal.
  */
 export function stripReadonlyFields(
-  objectSchema: { fields?: Record<string, ConditionalFieldDef> } | undefined | null,
+  objectSchema: { name?: string; fields?: Record<string, ConditionalFieldDef> } | undefined | null,
   data: Record<string, unknown> | undefined | null,
   suppliedKeys: ReadonlySet<string>,
   logger?: EvaluateRulesOptions['logger'],
@@ -561,9 +582,28 @@ export function stripReadonlyFields(
     if (preserveAudit && isPreservableUnderAudit(name, def)) continue; // historical import reinstates it
     if (result === data) result = { ...data };
     delete (result as Record<string, unknown>)[name];
-    logger?.warn?.(`Field '${name}' is read-only — ignoring incoming change (#2948)`);
+    logger?.warn?.(readonlyStripWarning(name, objectSchema?.name));
   }
   return result;
+}
+
+/**
+ * The message {@link stripReadonlyFields} logs per dropped field (#4903).
+ * Exported so the pin test asserts the CONTRACT of this text — consequence,
+ * `isSystem` remedy, `onFieldsDropped` remedy — rather than its wording.
+ */
+export function readonlyStripWarning(field: string, object?: string): string {
+  const on = object ? ` on '${object}'` : '';
+  return (
+    `Field '${field}'${on} is read-only: the caller-supplied value was DROPPED and the update ` +
+    `is being COMMITTED WITHOUT IT — the call returns success while this column keeps its stored ` +
+    `value (#2948). Server-side code that legitimately writes read-only columns (a plugin, a cron / ` +
+    `background job persisting a system-computed value) must declare itself trusted by passing ` +
+    `{ context: { isSystem: true } } on the write; a beforeUpdate hook does NOT need this because ` +
+    `hook-written keys are not caller-supplied. To detect drops programmatically instead of reading ` +
+    `this log, pass options.onFieldsDropped (#3407). Forged read-only keys from untrusted client ` +
+    `input are expected here and need no action.`
+  );
 }
 
 /**


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4903

## 先说结论:这一轮落了什么、什么必须留给维护者

| 方向(issue 三选一) | 本轮 | 说明 |
|:---|:---|:---|
| ① 失败可见 —— **dropped-fields 清单** | ✅ **早已存在**(#3407) | `options.onFieldsDropped` 每次剥离回调一次 `{ object, fields, reason }`,`readonly` / `readonly_when` 两种 reason 都发,单条 / 多行两条路径都发。issue 里「拿不到任何机器可读信号」这半句是**陈述过期**:信号在,只是**没写进文档、没人指得到**。本 PR 补了指路(日志 + 文档 + pin 测试)。 |
| ① 失败可见 —— **strict 开关(写入直接报错)** | ⛔ **未落,需维护者决策** | 需要新增一个写选项键,而**两个可能的落点都在 `packages/spec/**`**(本轮硬约束零改动)。见下方「需要维护者拍板」。 |
| ② 插件默认可信 | ⛔ 不做 | PM 已裁定:安全姿态放宽,只有维护者能授权。本 PR 不动任何默认值。 |
| ③ 文档写清楚 | ✅ 已落 | `content/docs/protocol/objectql/security.mdx` §3。 |
| (追加)剥离日志的级别与措辞 | ✅ 已落 | 见下。 |
| (追加)Hook / 插件不对称 | ✅ **只加 pin 测试,不改行为** | 该不该对称是 open question,本 PR 把**现状和机制**钉住,让下一个人是「有意改」而不是「顺手改坏」。 |

## 改了什么

### 1. 剥离日志:从「我做了什么」改成「你付出了什么 + 怎么解决」

原来只有:

```
WARN Field 'work_duration' is read-only — ignoring incoming change (#2948)
```

这句话说的是引擎的动作,没说调用方的代价,也没说出路 —— 于是下游看到的现象是「同一个字段 REST 写得进、cron 写不进」,读起来像 cron 坏了,而不是值被剥离了(os-project-titanwind-ehr#750)。现在这条 WARN 会指名对象与字段、明说 **update 已经在没有这个字段的情况下提交了**,并同时给出两条出路:可信服务端代码传 `{ context: { isSystem: true } }`;想要程序可读的信号就传 `options.onFieldsDropped`。

**级别保持 `warn`,这是刻意的**,理由写进了代码注释:这个接缝**分不出**「恶意客户端伪造 `created_by`」和「可信 cron 写系统结算值」。`ExecutionContext` 里没有任何 origin / channel / transport 标记,`isSystem` 是唯一的信任位,而它恰恰就是豁免条件;「没有 context」也不能当作服务端代码的证据(插件完全可以代表某个用户写,匿名 REST 写同样没有 principal)。所以升到 `error` 等于把错误日志变成任何客户端都能按需灌满的通道,降到 `debug` 等于把静默丢弃再藏回去。**一个级别,选定并写明理由**;要改这一点,得先给 `ExecutionContext` 一个真正的来源标记,而不是从「没有 principal」去猜。

行为零变化:剥什么、留什么、`onFieldsDropped` 报什么,全部同前。

### 2. 文档(`content/docs/protocol/objectql/security.mdx` §3 新增小节)

写清了 issue 要的四件事:

- **剥离条件**:`readonly: true` 是 schema 级锁,权限集授不动;执行方式是**剥离而非拒绝**,所以写入成功(REST 200),该列保持原值;
- **suppliedKeys 口径**:候选键在**引擎入口**快照,只有调用方送来的键才是候选;
- **Hook 豁免及其原因**(已核实机制,不是照抄 issue 措辞):快照发生在中间件与 `beforeUpdate` hook **之前**,所以 hook **新增**的键根本不在快照里 —— 这正是 `updated_by` / `updated_at` 明明是 `readonly` 却能落库的原因。并写明这条是**按键不按值**:hook 能**补写**一个只读字段,但**救不回**调用方自己送来的那个键;
- **插件写入的 `isSystem` 约定**:`ctx.getService('data')` 拿到的就是 REST 用的同一个引擎、执行上下文为空,所以服务端插件默认**不可信**,可信代码必须显式声明 —— 附带说明 `isSystem` 同时绕过权限检查,所以它的语义是「平台代码以平台身份写」,不是「这是插件写的」;
- 以及 `onFieldsDropped` 的用法、`reason` 取值,和它**不跨 RPC / Virtual Data Engine 边界**这一限制。

### 3. Pin 测试 `packages/objectql/src/engine-readonly-strip-signal.test.ts`(10 例)

- 复现现场:无 context 的插件式写入,其余字段落库、`work_duration` 恒为 null,且调用不抛;传 `{ context: { isSystem: true } }` 后同一次写入完整落库;
- `onFieldsDropped` 在**正是 issue 描述的调用形态**(进程内引擎、无 context)下确实回调,单条与 bulk 两条路径都钉;
- 日志契约:断言「后果 + 两条出路 + 对象名字段名」都在,以及**只发一条 `warn`、不发 `error`**;
- **不对称 pin**(PM 裁定 ⑤):hook 补写的只读字段落库、同名字段由调用方送来则被剥离 —— 并附一例把**机制**钉死(hook 改值救不回快照里的键)。注释里明说这是**钉住现状、不是背书**。

## 需要维护者拍板:strict(写入直接拒绝)模式该落在哪里

这是本轮唯一没做的实质项 —— 不是漏掉,是**做不了而不该猜**。strict 需要一个新的写选项键,而它的两个候选落点都在 `packages/spec/**`(本轮零改动约束):

- `EngineUpdateOptionsSchema`(`packages/spec/src/data/data-engine.zod.ts`)—— 可序列化选项;
- `WriteObservabilityOptions`(`packages/spec/src/contracts/data-engine.ts`)—— `onFieldsDropped` 就住在这里,因为函数无法进 JSON Schema。

三个选项、两条固定轴(项目长期健壮性 / 让 AI 写的元数据应用难以出错)的分析写在 issue #4903 的报告里,推荐 **B(在 `WriteObservabilityOptions` 旁加 `strictReadonlyWrites?: boolean`,默认 false,per-call 显式选择,违例抛带 `code` 的错)**。请维护者确认后再开一轮。

## 验证

```
pnpm --filter @objectstack/objectql typecheck   # tsc --noEmit,干净
pnpm --filter @objectstack/objectql test        # Test Files 115 passed | Tests 1820 passed
pnpm lint                                        # eslint . --no-inline-config,干净
pnpm check:doc-authoring / check:docs-audit-scope / check:nul-bytes /
  check:role-word / check:release-notes / check:durability-log-level /
  check:engine-double-contract                   # 全绿
```

已合入当日 `origin/main` 并重跑上述 objectql 闸门(合入的提交不触及 `packages/objectql` / `packages/spec`)。

## 约束遵守

- `packages/spec/**`、生成物:**零改动**;
- `packages/metadata-protocol/src/protocol.ts`(#5088 借道占用):**零改动**;
- `packages/services/service-analytics/**`(#5033):**零改动**;
- `content/docs/releases/`:**未触碰**;
- 变更面:`packages/objectql/src/validation/rule-validator.ts` + 一个新测试文件 + 一页文档 + 一个 changeset。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrmBxj8rK2uGCnh9aipjwX


---
_Generated by [Claude Code](https://claude.ai/code/session_01NrmBxj8rK2uGCnh9aipjwX)_