### PR TITLE
fix(metadata-protocol): 引用解析不了而整条丢弃的 seed 记录,现在会在 error 级别说出来 (#4997)

### DIFF
--- a/.changeset/seed-loader-unresolved-record-drop-loud.md
+++ b/.changeset/seed-loader-unresolved-record-drop-loud.md
@@ -1,0 +1,37 @@
+---
+"@objectstack/metadata-protocol": patch
+---
+
+fix(metadata-protocol): a seed record dropped for an unresolvable reference now says so at `error` (#4997)
+
+When a seed's `lookup` / `master_detail` / `user` reference could not be
+resolved and no pass 2 would run (`multiPass: false`), the loader dropped the
+**whole record** — the right call, since writing it would put the raw
+natural-key string into the FK column or, on an upsert UPDATE, corrupt the row
+already there. The drop was counted (`errored`) and reported
+(`result.errors` → `success: false`), and the code comment above it claimed
+"LOUD", but the branch made **no logger call at all**. On the console a seed
+that silently dropped N records was indistinguishable from a clean one, and the
+`packages/runtime` seed call sites that only `await` the load never look at
+`result.success` — so the loss surfaced later as "the app installed but the data
+isn't there".
+
+That branch now logs at `error`, per AGENTS.md → "Degradation log levels"
+(#4632): the line names the record (`<object>` record #i), the field, the target
+`<object>.<field>` it could not find, and the **consequence** (the whole record
+was not seeded — not merely the association), followed by all three **remedies**
+— seed the target object first, enable `multiPass` so pass 2 back-fills the
+reference, or fix the natural key in the seed data.
+
+The same objective criterion (does the outcome enter `errors`/`allErrors`?)
+found one more never-logged branch in the same file and aligned it: a **deferred
+reference still unresolved after pass 2** was counted exactly like its sibling
+whose back-fill *write* fails — which has logged at `error` since #4729 — and
+logged nowhere. It now reports that the row was seeded while the relationship is
+permanently missing, and how to complete it.
+
+The **dry-run** branch stays deliberately quiet and is pinned that way by test:
+a dry run writes nothing, its caller is by definition reading the result object,
+and an `error` line about a simulated outcome only trains readers to skim
+`error`. No counters, result shapes or messages in `result.errors` changed —
+this is console output that was missing, not a contract change.

--- a/packages/metadata-protocol/src/seed-loader-unresolved-drop.test.ts
+++ b/packages/metadata-protocol/src/seed-loader-unresolved-drop.test.ts
@@ -1,0 +1,352 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, vi } from 'vitest';
+// `.js` extension deliberately: under `moduleResolution: nodenext` an
+// extensionless relative import does not resolve, every symbol it names
+// degrades to `any`, and the callbacks below then report TS7006 — the trap
+// AGENTS.md → "Build & Test" describes. Both spellings exist in this package's
+// tests; this one is the one tsc can actually read.
+import { SeedLoaderService } from './seed-loader.js';
+import type { IDataEngine, IMetadataService } from '@objectstack/spec/contracts';
+
+/**
+ * framework#4997: a record DROPPED because its reference cannot be resolved —
+ * and no pass 2 will run — must be LOUD in the console too, not only in the
+ * result object.
+ *
+ * The branch's own comment claimed "LOUD: counted + reported" while it made no
+ * logger call at all, so a seed that silently dropped N records looked exactly
+ * like a clean one on the console. The only difference was whether the caller
+ * inspected `result.success` — and several `packages/runtime` seed call sites
+ * just `await` the load and carry on. This is the deeper notch of #4729's
+ * finding (count says "error", log level says *nothing*), which that PR could
+ * not see because its audit criterion was the file's `logger.warn` calls, and
+ * `pnpm check:durability-log-level` cannot see it either: this is not a
+ * `try`/`catch`.
+ *
+ * Pinned here, per AGENTS.md → "Degradation log levels" (#4632):
+ *  - the DROPPED-record branch logs at `error`, naming the consequence (the
+ *    WHOLE record was not seeded) and every remedy;
+ *  - the same objective criterion — does this outcome enter
+ *    `errors`/`allErrors`? — applied to the file's other never-logged branch,
+ *    "deferred reference unresolved after pass 2";
+ *  - the DRY-RUN branch stays deliberately QUIET (its caller reads the result
+ *    by definition; a loud line about a simulated outcome trains readers to
+ *    skim `error`), which is a decision and therefore pinned as one.
+ */
+
+function createLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+}
+
+function createFaithfulEngine(): { engine: IDataEngine; store: Record<string, any[]> } {
+  const store: Record<string, any[]> = {};
+  let idCounter = 0;
+
+  const engine = {
+    find: vi.fn(async (objectName: string, query?: any) => {
+      let records = store[objectName] || [];
+      if (query?.where) {
+        records = records.filter((r) =>
+          Object.entries(query.where).every(([k, v]) => r[k] === v),
+        );
+      }
+      if (typeof query?.limit === 'number') records = records.slice(0, query.limit);
+      return records;
+    }),
+    findOne: vi.fn(async (objectName: string, query?: any) => {
+      const rows = await (engine.find as any)(objectName, { ...query, limit: 1 });
+      return rows[0] ?? null;
+    }),
+    insert: vi.fn(async (objectName: string, data: any) => {
+      if (!store[objectName]) store[objectName] = [];
+      if (Array.isArray(data)) {
+        const records = data.map((d) => ({ id: `gen-${++idCounter}`, ...d }));
+        store[objectName].push(...records);
+        return records;
+      }
+      const record = { id: `gen-${++idCounter}`, ...data };
+      store[objectName].push(record);
+      return record;
+    }),
+    update: vi.fn(async (objectName: string, data: any) => {
+      const records = store[objectName] || [];
+      const idx = records.findIndex((r) => r.id === data.id);
+      if (idx >= 0) { records[idx] = { ...records[idx], ...data }; return records[idx]; }
+      return data;
+    }),
+    delete: vi.fn(async () => ({ deleted: 1 })),
+    count: vi.fn(async (objectName: string) => (store[objectName] || []).length),
+    aggregate: vi.fn(async () => []),
+  } as unknown as IDataEngine;
+
+  return { engine, store };
+}
+
+/** `drop_order.customer_id` → `drop_customer`; no cycle, so nothing defers. */
+function createMetadata(): IMetadataService {
+  const objects: Record<string, any> = {
+    drop_customer: {
+      name: 'drop_customer',
+      fields: { name: { type: 'text' } },
+    },
+    drop_order: {
+      name: 'drop_order',
+      fields: {
+        name: { type: 'text' },
+        customer_id: { type: 'lookup', reference: 'drop_customer' },
+      },
+    },
+  };
+  return {
+    getObject: vi.fn(async (name: string) => objects[name]),
+    listObjects: vi.fn(async () => Object.values(objects)),
+    register: vi.fn(async () => {}),
+    get: vi.fn(async (_t: string, name: string) => objects[name]),
+    list: vi.fn(async () => []),
+    unregister: vi.fn(async () => {}),
+    exists: vi.fn(async () => false),
+    listNames: vi.fn(async () => []),
+  } as unknown as IMetadataService;
+}
+
+const SINGLE_PASS = {
+  dryRun: false,
+  haltOnError: false,
+  multiPass: false,
+  defaultMode: 'insert',
+  batchSize: 1000,
+  transaction: false,
+} as any;
+
+/** Record #0 seeds cleanly; record #1 points at a customer that does not exist. */
+const ORDERS = [
+  {
+    object: 'drop_order',
+    externalId: 'name',
+    mode: 'insert',
+    env: ['prod', 'dev', 'test'],
+    records: [
+      { name: 'ORD-1' },
+      { name: 'ORD-2', customer_id: 'Ghost Inc' },
+    ],
+  },
+] as any[];
+
+describe('a record dropped for an unresolvable reference is logged, not only counted (framework#4997)', () => {
+  it('logs at ERROR naming the object, the record, the field, the target and every remedy', async () => {
+    const { engine, store } = createFaithfulEngine();
+    const logger = createLogger();
+
+    await new SeedLoaderService(engine, createMetadata(), logger).load({
+      seeds: ORDERS,
+      config: SINGLE_PASS,
+    });
+
+    // The loss is real: ORD-2 was not written at all (not "written without the
+    // link" — that is the referencesDropped shape, a different branch).
+    expect(store.drop_order.map((r) => r.name)).toEqual(['ORD-1']);
+
+    // Mutation pin: before #4997 this path made NO logger call whatsoever.
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    const [message, cause, meta] = (logger.error as any).mock.calls[0];
+
+    // WHAT was lost — object, record ordinal, field, target, attempted value.
+    expect(message).toContain('drop_order');
+    expect(message).toContain('record #1');
+    expect(message).toContain('customer_id');
+    expect(message).toContain('drop_customer.name');
+    expect(message).toContain('Ghost Inc');
+
+    // CONSEQUENCE (#4632): the WHOLE record is gone, not just the association.
+    expect(message).toContain('NOT seeded AT ALL');
+    expect(message).toContain('WHOLE');
+
+    // REMEDY (#4632) — all three routes the issue names.
+    expect(message).toContain('seed drop_customer BEFORE drop_order');
+    expect(message).toContain('multiPass');
+    expect(message).toContain('fix the natural key');
+    expect(message).toMatch(/re-run the seed/);
+
+    // Structured payload per the `Logger` contract's `(message, error, meta)`.
+    // There is no thrown Error behind this one — nothing failed, the target
+    // simply is not there — so the error slot is deliberately undefined.
+    expect(cause).toBeUndefined();
+    expect(meta).toMatchObject({
+      object: 'drop_order',
+      field: 'customer_id',
+      target: 'drop_customer.name',
+      recordIndex: 1,
+    });
+
+    // Mutation pin: not `warn` — the level #4729 aligned everywhere else here.
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('is still COUNTED and reported, which is what the log level now agrees with', async () => {
+    const { engine } = createFaithfulEngine();
+
+    const result = await new SeedLoaderService(engine, createMetadata(), createLogger()).load({
+      seeds: ORDERS,
+      config: SINGLE_PASS,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.summary.totalErrored).toBe(1);
+    expect(result.summary.totalInserted).toBe(1);
+    // A dropped RECORD, never a dropped FIELD — the two counters mean different
+    // losses and must not blur (framework#3932).
+    expect(result.summary.totalReferencesDropped).toBe(0);
+    expect(result.results[0].errored).toBe(1);
+    // Row counters still reconcile against the dataset total.
+    const r = result.results[0];
+    expect(r.inserted + r.updated + r.skipped + r.errored).toBe(r.total);
+
+    const error = result.errors.find((e) => e.field === 'customer_id')!;
+    expect(error.message).toContain('Cannot resolve reference: drop_order.customer_id');
+    expect(error.recordIndex).toBe(1);
+    expect(error.attemptedValue).toBe('Ghost Inc');
+  });
+
+  it('a load where every reference resolves logs nothing loud (do not train readers to skim `error`)', async () => {
+    const { engine } = createFaithfulEngine();
+    const logger = createLogger();
+
+    const result = await new SeedLoaderService(engine, createMetadata(), logger).load({
+      seeds: [
+        {
+          object: 'drop_customer',
+          externalId: 'name',
+          mode: 'insert',
+          env: ['prod', 'dev', 'test'],
+          records: [{ name: 'Ghost Inc' }],
+        },
+        ORDERS[0],
+      ] as any,
+      config: SINGLE_PASS,
+    });
+
+    expect(result.success).toBe(true);
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('a DRY RUN reports the same miss in the result and stays quiet (framework#4997)', () => {
+  it('carries the note in result.errors while the console says nothing', async () => {
+    const { engine, store } = createFaithfulEngine();
+    const logger = createLogger();
+
+    const result = await new SeedLoaderService(engine, createMetadata(), logger).load({
+      seeds: ORDERS,
+      config: { ...SINGLE_PASS, dryRun: true },
+    });
+
+    // A dry run writes nothing, so nothing was lost.
+    expect(store.drop_order).toBeUndefined();
+    expect(engine.insert).not.toHaveBeenCalled();
+
+    // The caller of a dry run is by definition reading the result — the note is
+    // there, in full.
+    expect(result.dryRun).toBe(true);
+    expect(result.success).toBe(false);
+    const note = result.errors.find((e) => e.field === 'customer_id')!;
+    expect(note.message).toContain('[dry-run] Reference may not resolve');
+    expect(note.message).toContain('drop_order.customer_id');
+    expect(note.message).toContain('Ghost Inc');
+    expect(note.recordIndex).toBe(1);
+
+    // …and the console stays QUIET. This is a DECISION, not an oversight: an
+    // `error` line about a SIMULATED outcome is the over-application AGENTS.md
+    // warns about. Deleting the `if (config.dryRun)` guard's quietness — i.e.
+    // logging here like the real-run branch does — must turn this red.
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The same objective criterion (#5001 style: does this outcome enter
+ * `errors`/`allErrors`?) applied to the file's OTHER never-logged branch. Its
+ * sibling — the pass-2 back-fill whose WRITE fails — has logged at `error`
+ * since #4729; "the target never materialized" was counted identically and
+ * logged nowhere.
+ */
+describe('a deferred reference still unresolved after pass 2 is logged too (framework#4997)', () => {
+  const CIRCULAR = {
+    ...SINGLE_PASS,
+    multiPass: true,
+  } as any;
+
+  function createCircularMetadata(): IMetadataService {
+    const objects: Record<string, any> = {
+      drop_team: {
+        name: 'drop_team',
+        fields: {
+          name: { type: 'text' },
+          lead_id: { type: 'lookup', reference: 'drop_person' },
+        },
+      },
+      drop_person: {
+        name: 'drop_person',
+        fields: {
+          name: { type: 'text' },
+          team_id: { type: 'lookup', reference: 'drop_team' },
+        },
+      },
+    };
+    return {
+      getObject: vi.fn(async (name: string) => objects[name]),
+      listObjects: vi.fn(async () => Object.values(objects)),
+      register: vi.fn(async () => {}),
+      get: vi.fn(async (_t: string, name: string) => objects[name]),
+      list: vi.fn(async () => []),
+      unregister: vi.fn(async () => {}),
+      exists: vi.fn(async () => false),
+      listNames: vi.fn(async () => []),
+    } as unknown as IMetadataService;
+  }
+
+  it('logs at ERROR naming the row, the NULL reference, the missing target and the remedy', async () => {
+    const { engine, store } = createFaithfulEngine();
+    const logger = createLogger();
+
+    const result = await new SeedLoaderService(engine, createCircularMetadata(), logger).load({
+      seeds: [
+        {
+          object: 'drop_team',
+          externalId: 'name',
+          mode: 'insert',
+          env: ['prod', 'dev', 'test'],
+          // 'Nobody' is never seeded and is not in the database — pass 2 cannot
+          // rescue it, so the deferred reference is permanently NULL.
+          records: [{ name: 'Platform', lead_id: 'Nobody' }],
+        },
+      ] as any,
+      config: CIRCULAR,
+    });
+
+    // The ROW landed (unlike the pass-1 drop above) — only the link is missing.
+    expect(store.drop_team.map((r) => r.name)).toEqual(['Platform']);
+    expect(store.drop_team[0].lead_id == null).toBe(true);
+
+    // Mutation pin: this branch made no logger call before #4997.
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    const [message, , meta] = (logger.error as any).mock.calls[0];
+    expect(message).toContain('drop_team.lead_id');
+    expect(message).toContain("record 'Platform'");
+    expect(message).toContain('drop_person.name');
+    expect(message).toContain('Nobody');
+    // CONSEQUENCE + REMEDY.
+    expect(message).toContain('stays NULL');
+    expect(message).toContain('counter looks healthy');
+    expect(message).toMatch(/re-run the seed/);
+    expect(meta).toMatchObject({ object: 'drop_team', field: 'lead_id', recordIndex: 0 });
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    // …and it was already counted — the half the log level now agrees with.
+    expect(result.success).toBe(false);
+    expect(result.summary.totalErrored).toBe(1);
+    expect(result.errors.some((e) => e.message.includes('unresolved after pass 2'))).toBe(true);
+  });
+});

--- a/packages/metadata-protocol/src/seed-loader.ts
+++ b/packages/metadata-protocol/src/seed-loader.ts
@@ -752,6 +752,15 @@ export class SeedLoaderService implements ISeedLoaderService {
         if (sawUnresolved) {
           if (config.dryRun) {
             // Dry-run: report the miss but leave the authored value untouched.
+            //
+            // Deliberately QUIET — no logger call, unlike the real-run branch
+            // below (#4997). A dry run writes nothing, so nothing was lost: its
+            // caller is by definition reading the result object (that is the
+            // whole point of `validate()`), and an `error` line about a
+            // SIMULATED outcome is the over-application AGENTS.md → "Degradation
+            // log levels" warns about — it trains readers to skim `error`, which
+            // is what made the #4420 log unreadable in the first place. Pinned by
+            // test so this stays a decision rather than an oversight.
             pushError(
               `[dry-run] Reference may not resolve: ${objectName}.${ref.field} = ` +
                 `'${String(unresolvedItem)}' → ${ref.targetObject}.${ref.targetField}`,
@@ -782,20 +791,40 @@ export class SeedLoaderService implements ISeedLoaderService {
             });
             referencesDeferred++;
           } else {
-            // Cannot resolve and no pass 2 will run — skip the whole record
-            // (LOUD: counted + reported). Writing it anyway would either
-            // carry the raw natural-key string into the FK column or, on
-            // update, corrupt the existing row.
+            // Cannot resolve and no pass 2 will run — skip the whole record.
+            // Writing it anyway would either carry the raw natural-key string
+            // into the FK column or, on update, corrupt the existing row.
             //
-            // "LOUD" here means counted + in `result.errors` ONLY — this path
-            // logs nothing at all, so a load that drops N records looks
-            // identical to a clean one in the console. Filed as #4997 rather
-            // than fixed under #4729, whose audit criterion was the file's
-            // `logger.warn` calls.
-            pushError(
+            // LOUD, and now in all three registers: COUNTED (`errored`, below),
+            // REPORTED (`result.errors` / `allErrors` → `success: false`) and
+            // LOGGED at `error`. Until #4997 the comment here claimed "LOUD:
+            // counted + reported" while this path logged nothing at all, so a
+            // load that dropped N records was indistinguishable from a clean one
+            // in the console — and `packages/runtime`'s seed call sites only
+            // `await` the result. `error` is the level AGENTS.md → "Degradation
+            // log levels" reserves for exactly this: the boot looks healthy while
+            // rows the seed declares are simply not there.
+            const error = pushError(
               `Cannot resolve reference: ${objectName}.${ref.field} = '${String(unresolvedItem)}' → ` +
                 `${ref.targetObject}.${ref.targetField} not found`,
               unresolvedItem,
+            );
+            this.logger.error(
+              `[SeedLoader] ${error.message}. ${objectName} record #${i} was NOT seeded AT ALL — the WHOLE ` +
+                `record is dropped, not just its \`${ref.field}\` link, because writing it would put the raw ` +
+                `natural key '${String(unresolvedItem)}' into the FK column (or, on an upsert UPDATE, corrupt ` +
+                `the row already there). Nothing retries this: pass 2 is off. Restore the record in one of ` +
+                `three ways, then re-run the seed — seed ${ref.targetObject} BEFORE ${objectName} so the ` +
+                `target row exists; or enable \`multiPass\` so pass 2 back-fills the reference once every ` +
+                `object is loaded; or fix the natural key in the ${objectName} seed data so it names a real ` +
+                `${ref.targetObject}.${ref.targetField}.`,
+              undefined,
+              {
+                object: objectName,
+                field: ref.field,
+                target: `${ref.targetObject}.${ref.targetField}`,
+                recordIndex: i,
+              },
             );
             unresolvedRefError = true;
           }
@@ -1146,8 +1175,33 @@ export class SeedLoaderService implements ISeedLoaderService {
         // Still unresolved after pass 2 — the target never materialized. Name
         // the element that missed: on a multi-value field only one of several
         // natural keys is usually at fault.
+        //
+        // Logged at `error` for the same reason the back-fill-write failure
+        // above is, and aligned with it under the same objective criterion
+        // (#4997, extending #4729/#5001): this outcome enters `allErrors` and
+        // bumps `errored`, and until now it was the file's other
+        // counted-but-never-logged branch. The row itself WAS seeded, so every
+        // row counter reads healthy while the association it declared is
+        // permanently absent.
+        const missedValue = this.formatAttempted(stillUnresolved ? missingItem : deferred.attemptedValue);
+        this.logger.error(
+          `[SeedLoader] Deferred reference UNRESOLVED after pass 2 — ${deferred.objectName}.${deferred.field} ` +
+            `stays NULL on record '${deferred.recordExternalId}'. The row itself was seeded, so every row ` +
+            `counter looks healthy while the relationship is MISSING: nothing links it to ` +
+            `${deferred.targetObject}.${deferred.targetField} = '${missedValue}', because no such ` +
+            `${deferred.targetObject} row exists — neither seeded in this load nor already in the database. ` +
+            `Nothing retries this: pass 2 is the last one. Add the missing ${deferred.targetObject} record to ` +
+            `the seed (or fix the natural key that names it) and re-run the seed to complete the link.`,
+          undefined,
+          {
+            object: deferred.objectName,
+            field: deferred.field,
+            target: `${deferred.targetObject}.${deferred.targetField}`,
+            recordIndex: deferred.recordIndex,
+          },
+        );
         this.recordDeferredError(deferred, allResults, allErrors,
-          `Deferred reference unresolved after pass 2: ${deferred.objectName}.${deferred.field} = '${this.formatAttempted(stillUnresolved ? missingItem : deferred.attemptedValue)}' → ${deferred.targetObject}.${deferred.targetField} not found`);
+          `Deferred reference unresolved after pass 2: ${deferred.objectName}.${deferred.field} = '${missedValue}' → ${deferred.targetObject}.${deferred.targetField} not found`);
       }
     }
   }


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4997

## 问题

`packages/metadata-protocol/src/seed-loader.ts` pass-1 的引用解析分支:引用解析不了、且 `multiPass` 关闭(没有 pass 2 来补救)时,**整条记录被丢弃** —— 这是正确的取舍(写下去要么把原始自然键塞进 FK 列,要么在 upsert UPDATE 路径上污染已有行)。丢弃被计数(`errored`)、被上报(`result.errors` → `success: false`),分支自己的注释还写着 "LOUD",但这里**没有任何 logger 调用**。

结果就是:一次丢了 N 条记录的 seed,与一次干净的 seed 在控制台上一模一样。唯一的区别是调用方有没有去看 `result.success` —— 而 `packages/runtime` 的若干 seed 调用点只是 `await` 之后继续。

#4729 盘的是本文件的 `this.logger.warn` 调用,所以看不到这一格;`check:durability-log-level` 只扫 `try`/`catch`,这里不是 catch,也扫不到。

## 改动

**1)pass-1 丢弃分支补 `error` 日志(按 AGENTS.md →「Degradation log levels」/ #4632 的两项义务)**

一行里同时给出**后果**与**修复动作**:

> `[SeedLoader] Cannot resolve reference: drop_order.customer_id = 'Ghost Inc' → drop_customer.name not found. drop_order record #1 was NOT seeded AT ALL — the WHOLE record is dropped, not just its \`customer_id\` link, because writing it would put the raw natural key 'Ghost Inc' into the FK column (or, on an upsert UPDATE, corrupt the row already there). Nothing retries this: pass 2 is off. Restore the record in one of three ways, then re-run the seed — seed drop_customer BEFORE drop_order so the target row exists; or enable \`multiPass\` so pass 2 back-fills the reference once every object is loaded; or fix the natural key in the drop_order seed data so it names a real drop_customer.name.`

三条补救路径就是 issue 列的三条:先种目标对象 / 打开 `multiPass` 让 pass 2 回填 / 修掉 seed 里的自然键。注释里那句名不副实的 "LOUD: counted + reported" 也改写成现在真实成立的说法(计数 + 上报 + 日志三者齐了)。

**2)dry-run 分支:维持安静,并把理由写进注释 + 用测试钉住**

dry-run 什么都不写,没有任何损失;它的调用方按定义就是来读结果对象的(`validate()` 的全部意义)。为一次**模拟**结果打 `error`,正是 AGENTS.md 警告的过度施加 —— 训练读者跳过 `error`,而这恰恰是 #4420 那条 `warn` 没人读的成因。所以它保持安静,但这是一个**决定**而不是疏忽,因此有测试钉住:往这个分支加日志会立刻变红。

**3)同一客观判据扫完本文件,顺手对齐了另一处**

判据是 #5001 那一条:*这个结局有没有进 `errors`/`allErrors`?* 全文件只剩一处「进了、却一行日志都没有」—— `resolveDeferredUpdates()` 里的 **"deferred reference unresolved after pass 2"**(目标始终没出现)。它的孪生分支(回填 **写**失败)从 #4729 起就在 `error` 上报,而它计数完全相同、日志为零。现在也补上:说清行本身已经种下、关系永久缺失、以及怎么补齐。

## 测试

新增 `packages/metadata-protocol/src/seed-loader-unresolved-drop.test.ts`(5 例):

- multiPass 关闭 + 引用解析不了 → `error` 日志点名 object / record #i / field / target 与三条补救;并且**仍然被计数**(`totalErrored: 1`、`success: false`、行计数仍与 `total` 对账、`referencesDropped` 保持 0 —— 丢的是记录不是字段);
- 全部解析得开的 load → 控制台一片安静(不训练读者跳过 `error`);
- dry-run → 结果对象里带着 `[dry-run] Reference may not resolve` 的完整说明,`engine.insert` 一次没调,控制台安静;
- pass 2 之后仍未解析 → `error` 日志 + 已有计数。

**变异钉(mutation pin)**,三处都验过:

| 变异 | 结果 |
|:---|:---|
| 删掉 pass-1 新增的 `logger.error` | `expected "vi.fn()" to be called 1 times, but got 0 times` → 红 |
| 删掉 pass-2 新增的 `logger.error` | 同上 → 红 |
| 给 dry-run 分支**加**一条 `logger.error` | `expected "vi.fn()" to not be called at all, but actually been called 1 times` → 红 |

跑过的命令(均在 `flock /tmp/os-heavy-verify.lock` 下,`NODE_OPTIONS=--max-old-space-size=4096`,`--maxWorkers=2`):

- `pnpm --filter @objectstack/metadata-protocol test` → **37 files / 324 tests passed**
- `pnpm --filter @objectstack/runtime exec vitest run src/seed-loader.test.ts`(下游消费方)→ **41 passed**
- `tsc --noEmit`(本包在 #4311 的 DEBT 账本里,无 `typecheck` 脚本):改动前后同为 62 条,**新增 0** —— 新测试文件按 nodenext 用 `./seed-loader.js` 导入,不给账本添噪
- 门禁:`check:durability-log-level`、`check:startup-registry-verdict`、`check:type-check-coverage`、`check:engine-double-contract`(13 pinned / 31 DEBT / 1 exempt,加文件前后一致)、`check:published-files`、`check:nul-bytes`、`check:doc-authoring`、`check:error-code-casing`、`check:role-word`、`check:adr-anchors`、`check:release-notes`、`check:merge-driver`、`check:docs-audit-scope`、`check:node-version`、`check:driver-conformance`、`check:wildcard-fallthrough`、`check:init-service-contract`、`check:route-envelope`、`check:service-providers`、`check:slot-lookup`、`check:authz-resolver`、`check:org-identifier`、`check:stall-guard`、`check:console-sha`、`check:objectui-changeset` 全绿;`eslint` 干净
- 本地环境**先天**失败、与本改动无关(在原始树上 `git stash -u` 后复跑同样失败):`check:objectui-pin-fresh`(objectui pin 过期)、`check:i18n` / `check:i18n-coverage`(本 worktree 未全量 build)

## 范围

只动 `seed-loader.ts` + 新测试 + 一个 changeset(`@objectstack/metadata-protocol` patch)。`packages/spec/**` 与生成物零改动;`protocol.ts`(#5088 在飞)零改动;`content/docs/releases/` 未触碰。计数、结果对象形状、`result.errors` 里的 message 一律未变 —— 补的是本该有却没有的控制台输出,不是契约变更。

## 顺带发现(已另开 issue,未在本 PR 修)

- **#5127** —— 同文件 pass 2 里还有一处:目标解析成功、但源记录的内部 id 在 `insertedRecords` 里找不到(`if (recordId)` 没有 `else`),这条 deferred 回填**既不计数也不打日志**,只在结果对象里留下一个永远挂账的 `referencesDeferred`。它连计数都没有,不在本 issue 的判据内,故单开。
- **门禁是否要扩**:`check:durability-log-level` 只扫 `try`/`catch`,看不到这一类「非 catch 的静默丢弃」。按 #5062 刚返修过该脚本、同文件避免连续改动的纪律,本 PR **不动它**。是否值得为这一形态单开一个扫描器,我的判断是**值得,但要单开 issue 单独讨论**:它需要的判据(「一个分支写了 `errors`/`allErrors` 却没有 logger 调用」)是可 AST 化的,而且这轮两条发现都出自人工盘点,说明这个形态会复发;但它的假阳性面比 catch 大得多(dry-run 这类「安静是正确答案」的分支必须先有基线/豁免机制),所以不适合作为本 PR 的搭车项。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrmBxj8rK2uGCnh9aipjwX)_