### PR TITLE
fix(service-settings): 保存期强制 select 声明的 options —— 声明即强制 (#5131)

### DIFF
--- a/.changeset/settings-select-options-enforced.md
+++ b/.changeset/settings-select-options-enforced.md
@@ -1,0 +1,53 @@
+---
+"@objectstack/service-settings": patch
+---
+
+fix(service-settings): a settings `select` now rejects values outside its declared `options` (#5131)
+
+`SettingsService.validatePatch` enforced two of the constraints a settings
+manifest declares — `required` and `pattern` — and skipped the third. A
+specifier's `options` table never took part in save-time validation, so any
+string at all could be written into a dropdown field:
+
+```ts
+await svc.setMany('mail', { provider: 'sendgrid', from_email: 'a@b.com' }); // stored
+```
+
+Going through the console this was unreachable: the dropdown only ever emits a
+value from the table. But `PUT /api/settings/:ns` is an authorizable public
+surface, and scripts, migration tools and AI-authored bootstrap code write it
+directly — where the bad value was accepted, persisted and read back **in
+silence**, leaving every consumer to improvise its own answer for an
+enumeration member that does not exist. It was not `mail`-specific:
+`storage.adapter`, `sms.provider`, `ai.provider`, `localization.date_format` and
+every other `select` behaved the same way.
+
+This is the API-side gate that #5094 was missing. That change retired
+`sendgrid` / `ses` from the `mail` provider table because this server cannot
+deliver through them — with no write-side enforcement, the values it had just
+retired could be written straight back in the same afternoon.
+
+**Now:** a `select` / `radio` / `multiselect` value that is not a member of the
+declared table is rejected with a `FieldError` whose `code` is `invalid_option`
+and whose `constraint` carries the allowed set (`{ allowed: 'smtp, resend,
+postmark, log' }`), so a client composes its own message instead of parsing
+ours. The enforced set is the spec's own: `SpecifierSchema` already *requires* a
+non-empty `options` on exactly those three types, so declared and enforced name
+one list rather than two that can drift.
+
+Two deliberate limits keep this from breaking workspaces that already carry
+drift:
+
+- **The check is gated on TOUCH**, like `required` and `pattern` before it. A
+  value that pre-dates the current option table only fails the patch that
+  writes that key — editing `from_name` is not rejected because a stale
+  `provider` sits in the store. The opposite rule would lock every workspace
+  with historical drift out of its own settings page entirely, which is worse
+  than the gap being closed. Resets (all-null patches) are never blocked.
+- **A specifier that declares no option table is left alone.** It cannot say
+  what is legal, so it stays lenient rather than rejecting every write.
+
+Values are compared in string form, so an option declared `value: 30` still
+matches after a round trip through JSON or a form post. There is no opt-out: a
+manifest that needs to accept custom values would declare that explicitly in
+the spec, not rely on a tolerant consumer.

--- a/packages/services/service-settings/src/envelope.conformance.test.ts
+++ b/packages/services/service-settings/src/envelope.conformance.test.ts
@@ -430,6 +430,33 @@ describe('settings envelope (#4224) — SETTINGS_VALIDATION speaks the field-lev
     expect(fields.map((f: any) => f.code).sort()).toEqual(['invalid_format', 'required']);
   });
 
+  it('an out-of-table select reaches the client as a parseable invalid_option (#5131)', async () => {
+    const { http, service } = mount();
+    service.registerManifest({
+      namespace: 'enumerated',
+      label: 'Enumerated',
+      writePermission: 'setup.write',
+      readPermission: 'setup.access',
+      specifiers: [
+        { key: 'provider', type: 'select', label: 'Provider',
+          options: [{ value: 'smtp', label: 'SMTP' }, { value: 'log', label: 'Log' }] },
+      ],
+    } as any);
+    const { status, body } = await drive(http, 'PUT /api/settings/:namespace', {
+      params: { namespace: 'enumerated' },
+      body: { provider: 'sendgrid' },
+    });
+    expect(status).toBe(400);
+    expect(body.error.code).toBe('SETTINGS_VALIDATION');
+
+    const [field] = body.error.details.fields;
+    expect(FieldErrorSchema.safeParse(field).success).toBe(true);
+    // The constraint kind is stamped where the check failed, so the route
+    // never has to infer it back out of the prose (ADR-0114).
+    expect(field.code).toBe('invalid_option');
+    expect(field.constraint).toEqual({ allowed: 'smtp, log' });
+  });
+
   it('the pre-#4224 map is gone from both of its old spellings', async () => {
     const http = lockedPattern();
     const { body } = await drive(http, 'PUT /api/settings/:namespace', {

--- a/packages/services/service-settings/src/settings-service.test.ts
+++ b/packages/services/service-settings/src/settings-service.test.ts
@@ -413,6 +413,188 @@ describe('SettingsService — save-time validation (required/visible/pattern)', 
   });
 });
 
+/**
+ * #5131 — a manifest's `options` table is enforced at SAVE time.
+ *
+ * Until this suite existed the enumeration was a front-end convention: the
+ * console dropdown only ever emitted legal values, so an admin going through
+ * the UI could not produce a bad one — but `PUT /api/settings/:ns` is an
+ * authorizable public surface, and a script, a migration or AI-authored
+ * bootstrap code could write any string at all into a `select` and have it
+ * stored, read back, and improvised over by each consumer in turn.
+ *
+ * The load-bearing case is `mail.provider`: #5094/#5133 retired `sendgrid`
+ * and `ses` from the option table because this server cannot deliver through
+ * them, and that manifest-side tightening had no matching gate on the API
+ * side — the very values just retired could be written straight back in.
+ */
+describe('SettingsService — save-time validation (declared options are enforced)', () => {
+  const mailService = () => {
+    const svc = new SettingsService({ env: {} });
+    svc.registerManifest(mailSettingsManifest);
+    return svc;
+  };
+
+  it('refuses a provider outside the declared table, naming the allowed set', async () => {
+    const svc = mailService();
+    // `sendgrid` left the table in #5094; before this gate it could be written
+    // back the same afternoon it was retired.
+    await expect(
+      svc.setMany('mail', { provider: 'sendgrid', from_email: 'a@b.com' }),
+    ).rejects.toMatchObject({
+      code: 'SETTINGS_VALIDATION',
+      fields: [
+        {
+          field: 'provider',
+          code: 'invalid_option',
+          label: 'Provider',
+          // The allowed set travels as a discrete constraint (ADR-0114), so a
+          // client branches on the machine value instead of parsing our prose.
+          constraint: { allowed: 'smtp, resend, postmark, log' },
+          value: 'sendgrid',
+        },
+      ],
+    });
+    // Atomic: the rejected batch persisted nothing, not even the legal key.
+    expect((await svc.get('mail', 'provider')).source).toBe('default');
+    expect((await svc.get('mail', 'from_email')).value).toBeNull();
+  });
+
+  it('accepts every value the table does declare', async () => {
+    for (const [provider, extra] of [
+      ['smtp', { smtp_host: 'smtp.example.com' }],
+      ['resend', { api_key: 're-key' }],
+      ['postmark', { api_key: 'pm-key' }],
+      ['log', {}],
+    ] as const) {
+      const svc = mailService();
+      await expect(
+        svc.setMany('mail', { provider, ...extra, from_email: 'a@b.com' }),
+      ).resolves.toBeDefined();
+      expect((await svc.get('mail', 'provider')).value).toBe(provider);
+    }
+  });
+
+  it('checks the option table only when the patch TOUCHES the key', async () => {
+    // A workspace that saved `sendgrid` while the option existed still carries
+    // it. Simulated exactly as it happened: write under the OLD table, then
+    // re-register the narrowed manifest (#5094) over the same namespace.
+    const svc = new SettingsService({ env: {} });
+    svc.registerManifest({
+      ...mailSettingsManifest,
+      specifiers: mailSettingsManifest.specifiers.map((s: any) =>
+        s.key === 'provider'
+          ? { ...s, options: [...s.options, { value: 'sendgrid', label: 'SendGrid' }] }
+          : s,
+      ),
+    } as any);
+    await svc.setMany('mail', { provider: 'sendgrid', api_key: 'sg-key', from_email: 'a@b.com' });
+    svc.registerManifest(mailSettingsManifest);
+
+    // The stale value is still there …
+    expect((await svc.get('mail', 'provider')).value).toBe('sendgrid');
+    // … and it does NOT lock the workspace out of editing anything else. A
+    // patch that never mentions `provider` is not rejected on its account —
+    // the opposite rule would make the settings page unusable for every
+    // workspace carrying historical drift, which is worse than the gap.
+    await expect(svc.setMany('mail', { from_name: 'Acme Ops' })).resolves.toBeDefined();
+    expect((await svc.get('mail', 'from_name')).value).toBe('Acme Ops');
+    // Only re-writing the key itself is refused.
+    await expect(svc.setMany('mail', { provider: 'sendgrid' })).rejects.toMatchObject({
+      code: 'SETTINGS_VALIDATION',
+      fields: [{ field: 'provider', code: 'invalid_option' }],
+    });
+    // And a reset still clears it — an all-null patch is never blocked.
+    await expect(svc.resetNamespace('mail')).resolves.toBeGreaterThan(0);
+  });
+
+  it('leaves the value alone when the specifier declares no option table', async () => {
+    // `registerManifest` takes manifests as given (no Zod pass), so a
+    // hand-built select without `options` reaches the validator. It cannot say
+    // what is legal, so it stays lenient rather than rejecting every write.
+    const svc = new SettingsService({ env: {} });
+    svc.registerManifest({
+      namespace: 'freeform',
+      label: 'Freeform',
+      specifiers: [{ type: 'select', key: 'mode', label: 'Mode' }],
+    } as any);
+    await expect(svc.setMany('freeform', { mode: 'whatever' })).resolves.toBeDefined();
+  });
+
+  it('enforces radio and multiselect from the same table, element-wise', async () => {
+    // All three types are covered because the SPEC requires an `options` table
+    // on all three; `radio`/`multiselect` have no producer manifest today and
+    // would otherwise be a hole the first one to author them falls into.
+    const svc = new SettingsService({ env: {} });
+    svc.registerManifest({
+      namespace: 'shapes',
+      label: 'Shapes',
+      specifiers: [
+        { type: 'radio', key: 'tier', label: 'Tier',
+          options: [{ value: 'free', label: 'Free' }, { value: 'pro', label: 'Pro' }] },
+        { type: 'multiselect', key: 'channels', label: 'Channels',
+          options: [{ value: 'email', label: 'Email' }, { value: 'sms', label: 'SMS' }] },
+      ],
+    } as any);
+
+    await expect(svc.setMany('shapes', { tier: 'enterprise' })).rejects.toMatchObject({
+      fields: [{ field: 'tier', code: 'invalid_option', constraint: { allowed: 'free, pro' } }],
+    });
+    await expect(svc.setMany('shapes', { tier: 'pro' })).resolves.toBeDefined();
+
+    // Every element is checked, and the rejected one is the one reported.
+    await expect(
+      svc.setMany('shapes', { channels: ['email', 'carrier-pigeon'] }),
+    ).rejects.toMatchObject({
+      fields: [{ field: 'channels', code: 'invalid_option', value: 'carrier-pigeon' }],
+    });
+    await expect(svc.setMany('shapes', { channels: ['email', 'sms'] })).resolves.toBeDefined();
+    await expect(svc.setMany('shapes', { channels: [] })).resolves.toBeDefined();
+  });
+
+  it('matches option values by string form, so a number option survives JSON', async () => {
+    // A stored value has been through JSON and, over REST, a form post: an
+    // option declared `value: 30` legitimately reads back as '30'. Rejecting
+    // that would enforce the transport rather than the enumeration.
+    const svc = new SettingsService({ env: {} });
+    svc.registerManifest({
+      namespace: 'retention',
+      label: 'Retention',
+      specifiers: [
+        { type: 'select', key: 'days', label: 'Days',
+          options: [{ value: 7, label: '7' }, { value: 30, label: '30' }] },
+        { type: 'select', key: 'archive', label: 'Archive',
+          options: [{ value: true, label: 'On' }, { value: false, label: 'Off' }] },
+      ],
+    } as any);
+    await expect(svc.setMany('retention', { days: 30 })).resolves.toBeDefined();
+    await expect(svc.setMany('retention', { days: '30' })).resolves.toBeDefined();
+    await expect(svc.setMany('retention', { archive: false })).resolves.toBeDefined();
+    await expect(svc.setMany('retention', { days: 45 })).rejects.toMatchObject({
+      fields: [{ field: 'days', code: 'invalid_option', constraint: { allowed: '7, 30' } }],
+    });
+  });
+
+  it('never echoes the rejected value for an encrypted specifier', async () => {
+    // `encrypted` is authorable on any specifier, and this message lands in
+    // logs — so the offending value is named only where it is safe to name.
+    const svc = new SettingsService({ env: {} });
+    svc.registerManifest({
+      namespace: 'vault',
+      label: 'Vault',
+      specifiers: [
+        { type: 'select', key: 'key_ref', label: 'Key', encrypted: true,
+          options: [{ value: 'primary', label: 'Primary' }] },
+      ],
+    } as any);
+    const err = await svc.setMany('vault', { key_ref: 's3cr3t-handle' }).catch((e) => e);
+    expect(err.code).toBe('SETTINGS_VALIDATION');
+    expect(err.fields[0]).toMatchObject({ field: 'key_ref', code: 'invalid_option' });
+    expect(err.fields[0].value).toBeUndefined();
+    expect(err.message).not.toContain('s3cr3t-handle');
+  });
+});
+
 describe('SettingsService — user-scoped values', () => {
   it('isolates writes by ctx.userId', async () => {
     const svc = new SettingsService({ env: {} });

--- a/packages/services/service-settings/src/settings-service.ts
+++ b/packages/services/service-settings/src/settings-service.ts
@@ -46,6 +46,43 @@ const LAYOUT_ONLY_TYPES = new Set([
   'action_button',
 ]);
 
+/**
+ * Specifier types whose stored value must be a member of the declared
+ * `options` table.
+ *
+ * THE list is the spec's, not a judgement call made here: `SpecifierSchema`'s
+ * superRefine (`settings-manifest.zod.ts`) rejects a manifest that authors one
+ * of exactly these three types without a non-empty `options`. So "the types
+ * that must declare an option table" and "the types whose value is checked
+ * against it" name the same set — declared IS enforced, with no third list to
+ * drift. `radio` and `multiselect` have no producer manifest today; they are
+ * covered anyway because the alternative is that the first manifest to author
+ * one silently re-opens this exact hole.
+ */
+const OPTION_BEARING_TYPES = new Set(['select', 'radio', 'multiselect']);
+
+/**
+ * The declared option values, in string form.
+ *
+ * String form because a stored value has been through JSON (and, over the REST
+ * boundary, a form post): an option declared `value: 30` is legitimately read
+ * back as `'30'`, and rejecting that would be enforcing the transport rather
+ * than the enumeration. Same rule the record validator applies to
+ * `select`/`multiselect` field options (objectui#2729).
+ */
+function declaredOptionValues(options: unknown): string[] {
+  if (!Array.isArray(options)) return [];
+  const out: string[] = [];
+  for (const opt of options) {
+    if (!opt || typeof opt !== 'object') continue;
+    const v = (opt as Record<string, unknown>).value;
+    if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
+      out.push(String(v));
+    }
+  }
+  return out;
+}
+
 interface RegisteredManifest {
   manifest: SettingsManifest;
   /** Resolved specifier scopes for fast lookup. */
@@ -613,8 +650,19 @@ export class SettingsService {
    *   is (switching provider must validate that provider's fields).
    * - `required` + visible + empty → rejected.
    * - `pattern` (text fields) + non-empty value that mismatches → rejected.
+   * - `options` (`select`/`radio`/`multiselect`) + non-empty value outside
+   *   the declared table → rejected (`invalid_option`).
    * - All-null patches (namespace reset) and unparseable visibility
    *   expressions skip validation rather than block the write.
+   *
+   * The TOUCH gate is what keeps the options check from being a regression
+   * for existing workspaces: a value that pre-dates a manifest's current
+   * option table (a `mail.provider` of `sendgrid`, retired in #5094) only
+   * fails the patch that writes that key. A patch changing `from_name`
+   * alone is not rejected because a stale `provider` sits in the store —
+   * otherwise every workspace carrying historical drift would be locked out
+   * of its own settings page, unable to edit anything, which is worse than
+   * the gap this closes.
    */
   private async validatePatch(
     namespace: string,
@@ -679,6 +727,58 @@ export class SettingsService {
         });
         continue;
       }
+
+      // A `select`/`radio`/`multiselect` value must be a member of the option
+      // table the manifest declares. Until this check existed the `options`
+      // list was a front-end convention only — the console dropdown emitted
+      // legal values, but `PUT /api/settings/:ns` accepted any string at all,
+      // so a script, a migration or AI-authored bootstrap code could write
+      // `provider: 'sendgrid'` into a namespace that has no such provider and
+      // the write would succeed silently, leaving each consumer to improvise.
+      if (!empty && OPTION_BEARING_TYPES.has(type)) {
+        const allowed = declaredOptionValues(spec.options);
+        // A manifest with no option table cannot say what is legal. The spec
+        // refuses that shape at parse time, but `registerManifest` takes
+        // manifests as given (no Zod pass), so skip rather than reject every
+        // write to a hand-built manifest — same leniency the unparseable
+        // `visible` and invalid `pattern` branches already take.
+        if (allowed.length > 0) {
+          // `multiselect` stores an array, `select`/`radio` a scalar; both are
+          // checked element-wise against the one table. A scalar arriving at a
+          // multiselect is wrapped rather than rejected — policing the value's
+          // SHAPE is a different constraint (`invalid_type`) with a different
+          // owner, and inventing it here would reject writes this change was
+          // never asked to touch.
+          const picked = Array.isArray(value) ? value : [value];
+          // `findIndex`, not `find`: a `find` returning `undefined` cannot say
+          // whether nothing was rejected or whether the rejected element WAS
+          // `undefined` — and the latter would slip through the check.
+          const at = picked.findIndex((v) => !allowed.includes(String(v)));
+          if (at !== -1) {
+            const offending = picked[at];
+            // An option value is not a secret, but `encrypted` is authorable on
+            // any specifier — so never echo the rejected value for a key whose
+            // contents are held encrypted, in a message that lands in logs.
+            const secret = reg.encryptedKeys.has(key);
+            const got = secret ? '' : ` Received '${String(offending)}'.`;
+            errors.push({
+              field: key,
+              code: 'invalid_option',
+              message: `${label} must be one of: ${allowed.join(', ')}.${got}`,
+              label,
+              // The allowed set as a discrete constraint, so a client composes
+              // its own sentence instead of parsing ours (`FieldError.
+              // constraint`, ADR-0114). Key and comma-joined form are the ones
+              // the spec's own `{ allowed: 'draft, sent' }` example documents
+              // and the record validator already emits for this same code.
+              constraint: { allowed: allowed.join(', ') },
+              ...(secret ? {} : { value: String(offending) }),
+            });
+            continue;
+          }
+        }
+      }
+
       if (!empty && typeof spec.pattern === 'string' && typeof value === 'string') {
         let re: RegExp | undefined;
         try {

--- a/packages/services/service-settings/src/settings-service.types.ts
+++ b/packages/services/service-settings/src/settings-service.types.ts
@@ -268,8 +268,11 @@ export class SettingsForbiddenError extends Error {
 /**
  * Thrown when a write would leave the namespace in an invalid state —
  * a `required` field that is visible under the post-write values is
- * empty (e.g. provider=cloudflare saved without an API key), or a value
- * that does not match its specifier's declared `pattern`. The whole
+ * empty (e.g. provider=cloudflare saved without an API key), a value
+ * that does not match its specifier's declared `pattern`, or a value a
+ * `select`/`radio`/`multiselect` specifier does not list in its declared
+ * `options` (#5131 — those enumerations used to be a front-end
+ * convention that the write path never checked). The whole
  * batch is rejected; `fields` carries one entry per offending key, which
  * the UI can render inline against the input it addresses.
  *
@@ -277,8 +280,8 @@ export class SettingsForbiddenError extends Error {
  * (#3977) — rather than the `Record<key, message>` map it was until #4224.
  * The map predated that catalog and named the constraint only in prose, so
  * a consumer could render the sentence but not branch on *which* constraint
- * failed; `code` (`required` / `invalid_format`) now says it in the one
- * spelling every other validator in the platform uses. `label` and
+ * failed; `code` (`required` / `invalid_format` / `invalid_option`) now
+ * says it in the one spelling every other validator in the platform uses. `label` and
  * `constraint` carry what the message interpolates, so a form can compose
  * its own text instead of parsing ours.
  */


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5131

## 问题

`SettingsService.validatePatch` 的 docstring 写明它「fulfilling the spec promise that `required` is enforced server-side」,实际只做两项校验:`required` + visible + 空,以及 `pattern` 不匹配。**manifest 声明的 `options` 表从头到尾不参与校验。**

走控制台碰不到——下拉框只会发出合法值;但 `PUT /api/settings/:ns` 是公开的可授权面,脚本、迁移工具、AI 写的初始化代码可以直接写入枚举外的值,而且一路静默:值存下来了,读回来了,消费端各自随机应对。这不是 `mail` 专有的,`storage.adapter`、`sms.provider`、`ai.provider`、`localization.date_format` 等所有 `type: 'select'` 的键都一样。

这正是 #5094 缺失的另一半。那一单把 `sendgrid` / `ses` 从 `mail` 的选项表里退役(本服务器无法通过它们投递),而没有写入期强制,**刚退役的值当天就能被重新写回去**——manifest 侧收紧的契约在 API 侧没有对应的闸门。

## 改动

`validatePatch` 增加第三条:`select` / `radio` / `multiselect` 的非空值不在声明的 `options` 表内 → `FieldError`,`code` 为 `invalid_option`,`constraint` 带上允许值集合。

```
Provider must be one of: smtp, resend, postmark, log. Received 'sendgrid'.
  → { field: 'provider', code: 'invalid_option',
      constraint: { allowed: 'smtp, resend, postmark, log' }, value: 'sendgrid' }
```

按 ADR-0114,constraint kind 在失败点打戳,不让路由层从文案反推;`constraint` 的键名与逗号连接形态取自 spec 自己文档化的例子(`errors.zod.ts` 里 `{ allowed: 'draft, sent' }`),也是 record validator 对同一个 code 已经发出的形态——同一个 code 不应该有两种线上形状。

## 三个判断,请复核

**1. `invalid_option` 不是新 code,不动 `packages/spec`。** issue 与裁定都说「用新的 `invalid_option`」,实际它**已经在** `FieldErrorCode` 这个闭合枚举里(`packages/spec/src/api/errors.zod.ts:257`,注释 `// not a member of the field's declared options`)。所以本单完全不需要碰 spec——四单在飞的车道没有被占用,这是好消息。

**2. `multiselect` 存在,`radio` 也一并覆盖。** 裁定要求先确认 `multiselect` 是否真实存在:它在 `SpecifierType` 闭合枚举里(`settings-manifest.zod.ts:34`),`radio` 同理。更关键的是 `SpecifierSchema` 的 superRefine **恰好要求这三类**声明非空 `options`:

```
// select/radio/multiselect require options.
if (['select', 'radio', 'multiselect'].includes(spec.type)) { ... }
```

所以强制的类型集合不是我在这里做的判断,而是抄 spec 自己的那一份——「必须声明选项表的类型」与「值要被拿去比对选项表的类型」指同一份清单,不存在第三份会漂移的列表。

`radio` / `multiselect` 今天确实没有生产者 manifest(15 处 `select`,0 处另两种)。我仍然覆盖了它们,理由是这里不是**声明**一个没人生产的属性(那才是本仓反复在修的形态),而是让校验器的类型覆盖面等于 spec 已经闭合的枚举;只做 `select` 的话,第一个写 `radio` 的 manifest 会无声地重新打开这个洞。如果认为这仍算越界,删掉常量里的两个成员即可,测试会指出对应用例。

**3. 不留逃生舱,按裁定执行。** 没有 `allowCustom` 之类的预留。

## 兼容性:两条刻意的边界

- **按 touch 语义校验**(裁定第 1 点),与既有 `required` / `pattern` 完全一致。存量越界值只让**写该键的那次 patch** 失败;只改 `from_name` 的 patch 不会因为库里躺着一个老的 `provider` 被整体拒绝。相反做法会把带历史脏值的工作区锁死在设置页里改不动任何东西,比现状更糟。全 null 的重置(`resetNamespace`)永不阻塞——脏值始终清得掉。
- **没有声明 `options` 的 specifier 放行。** spec 在 parse 期就拒绝这种形状,但 `registerManifest` 是照单全收的(不走 Zod),所以手搓 manifest 会到达校验器。它说不出什么是合法的,于是保持宽容——与既有「`visible` 解析不了」「`pattern` 非法」两个分支同样的退让。

另有两处细节:值按**字符串形态**比较,声明为 `value: 30` 的选项经 JSON 或表单往返读回 `'30'` 仍然匹配(否则强制的是传输层而不是枚举,与 record validator 对 objectui#2729 的处理一致);`encrypted` specifier 的越界值**不回显**(`encrypted` 在任何 specifier 上都可声明,而这条 message 会进日志)。

## 测试

`packages/services/service-settings` 新增 7 个用例 + envelope conformance 1 个:

- `sendgrid` 今天仍能写进去 → 修复后以 `invalid_option` 被拒,且批次原子(合法的 `from_email` 也没落库);
- 表内四个值(`smtp` / `resend` / `postmark` / `log`)逐个仍可保存;
- **touch 语义**:先用加宽的 manifest 写入 `sendgrid`,再把收紧后的真 manifest 覆盖注册上去(#5094 的真实过程),此时只改 `from_name` 仍然成功、重写 `provider` 被拒、`resetNamespace` 仍能清掉;
- 无 `options` 的 select 放行;`radio` / `multiselect` 逐元素校验;数字/布尔选项的字符串形态匹配;encrypted 不回显;
- 路由层:400 的 `details.fields[0]` 能通过 `FieldErrorSchema.safeParse`,`code === 'invalid_option'`,`constraint` 如实到达客户端。

反向验证过用例不是摆设:把强制类型集合临时置空后,恰好这 6 个断言拒绝的用例失败,两个断言放行的用例仍然通过。

现有测试没有一条在钉「越界值可以保存」的现状,因此没有需要翻面的用例。`ai` manifest 那批写 `provider: 'cloudflare'` 的用例一度看着可疑,核对后 `cloudflare` 确实在选项表内(`ai.manifest.ts:50`),不受影响。

```
pnpm --filter @objectstack/service-settings test   →  15 files, 222 passed
pnpm --filter @objectstack/plugin-email     test   →   8 files, 127 passed   (下游消费者)
pnpm --filter @objectstack/service-settings build  →  DTS build success
npx eslint packages/services/service-settings/src  →  clean
```

类型检查:该包没有 `typecheck` script,`npx tsc --noEmit -p tsconfig.json` 报 13 处错误——改动前后**逐字相同**,且没有一处落在本 PR 触碰的文件里(已用 stash 对比基线确认)。这 13 处是 #4311 那个缺口的实例,已作为数据点评论在该 issue 下,未在本 PR 内修。

## 影响面

写入路径的行为收紧,可能影响绕过控制台直接调 API 的脚本——但它们写入的正是本单要拦的越界值。读取路径、控制台交互、既有合法写入均不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MCKJaEomEqg4tvz4SzdNd

---
_Generated by [Claude Code](https://claude.ai/code/session_017MCKJaEomEqg4tvz4SzdNd)_