### PR TITLE
fix(metadata): DatabaseLoader 的读故障不再被吞成「什么都没声明」 (#5108)

### DIFF
--- a/.changeset/database-loader-read-outage-is-not-a-miss.md
+++ b/.changeset/database-loader-read-outage-is-not-a-miss.md
@@ -1,0 +1,37 @@
+---
+"@objectstack/metadata": patch
+---
+
+fix(metadata): `DatabaseLoader` 的读故障不再被吞成「什么都没声明」(#5108)
+
+`DatabaseLoader` 的五个读方法此前都把**任何**存储异常 `catch {}` 成各自的空值 ——
+`load` → `null`、`loadMany` → `[]`、`exists` → `false`、`stat` → `null`、
+`list` → `[]`。于是 `sys_metadata` 所在库不可达时,`loadMany('permission')` 与
+「这个环境一条 permission 都没声明」返回**完全一样的值**,而且异常是在 loader 内部
+就被抹掉的:`MetadataManager` 那几个 `try/catch` 降级分支拿到的是一次「成功的空读」,
+根本不会触发,整条链上没有任何一处会说出「读失败了」。
+
+现在按**错误类型**判决(#4632 立的规矩,#4728 / #4825 已经在同一个文件里用过两次的
+形状,判据复用现成的 `isMissingTableError`):
+
+- 唯一良性的失败原因是 `sys_metadata` 尚未 provisioned —— 那时确实没有行,
+  「什么都没声明」就是事实,首次启动照旧返回空值、不报错、不缓存;
+- 其余全部原因(连接断开、超时、权限不足、查询出错)意味着行还在、只是这次没读到,
+  一律把驱动原始异常**原样抛出**,由调用方决定降级姿态。判据保守:无法正面识别为
+  「表不存在」的错误一律当作真故障。
+
+由此上层三个已有的机制第一次真的生效:
+
+- `MetadataManager.list()` 的降级分支会真的进,并且**升级到 `error`**
+  (AGENTS.md「Degradation log levels」:系统看着正常、它声称掌握的清单其实是残缺的),
+  日志写明后果与修法,每次故障只说一次、恢复时再说一次;`list()` 仍然尽力返回可读
+  loader 的内容 —— 这个 best-effort 姿态是刻意保留的;
+- `MetadataManager.loadDiagnosed()`(ADR-0110 D3)对 `DatabaseLoader` 终于能报出
+  `degraded` / `errors`,而不是把 outage 报成 miss;
+- `listForIndex()` / `matchEndpoint`(#5089)契约要求「读不到存储必须抛出,不得伪装成
+  miss(miss 会变成 404)」—— 这条此前对 `MemoryLoader` / `RemoteLoader` 有效、对
+  `DatabaseLoader` 无效,现在对真实的 datasource loader 也成立了。
+
+**行为变化**:`MetadataManager.exists()` 与 `listNames()` 本来就没有 `try/catch`,
+所以存储故障现在会从它们抛出,而不再静默答「不存在」/「空清单」。这正是本次修复要的
+姿态 —— 可用性故障不是一次「没有」。

--- a/.changeset/database-loader-read-outage-is-not-a-miss.md
+++ b/.changeset/database-loader-read-outage-is-not-a-miss.md
@@ -25,7 +25,9 @@ fix(metadata): `DatabaseLoader` 的读故障不再被吞成「什么都没声明
 - `MetadataManager.list()` 的降级分支会真的进,并且**升级到 `error`**
   (AGENTS.md「Degradation log levels」:系统看着正常、它声称掌握的清单其实是残缺的),
   日志写明后果与修法,每次故障只说一次、恢复时再说一次;`list()` 仍然尽力返回可读
-  loader 的内容 —— 这个 best-effort 姿态是刻意保留的;
+  loader 的内容 —— 这个 best-effort 姿态是刻意保留的。兄弟方法
+  `MetadataManager.loadMany()` 的同一条缝走同一个判决,不让同一次故障在同一个文件里
+  报出两个级别;
 - `MetadataManager.loadDiagnosed()`(ADR-0110 D3)对 `DatabaseLoader` 终于能报出
   `degraded` / `errors`,而不是把 outage 报成 miss;
 - `listForIndex()` / `matchEndpoint`(#5089)契约要求「读不到存储必须抛出,不得伪装成

--- a/packages/metadata/src/loaders/database-loader.test.ts
+++ b/packages/metadata/src/loaders/database-loader.test.ts
@@ -1008,6 +1008,34 @@ describe('DatabaseLoader read failures are outages, not misses (#5108)', () => {
       expect(logger.error).toHaveBeenCalledTimes(1);
     });
 
+    it('the sibling plural read, loadMany(), reports at the same level', async () => {
+      const manager = managerOverBrokenDb();
+
+      await expect(manager.loadMany('permission')).resolves.toEqual([]);
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('un-says it when the loader becomes readable again', async () => {
+      const driver = createMockDriver();
+      let broken = true;
+      const realFind = driver.find as unknown as (t: string, q: unknown) => Promise<Record<string, unknown>[]>;
+      driver.find = vi.fn().mockImplementation((table: string, query: unknown) => {
+        if (broken) return Promise.reject(connectionReset());
+        return realFind(table, query);
+      });
+      const manager = new MetadataManager({ formats: ['json'], loaders: [] });
+      manager.registerLoader(new DatabaseLoader({ driver, cache: { enabled: false } }));
+
+      await manager.loadMany('permission');
+      expect(logger.error).toHaveBeenCalledTimes(1);
+
+      broken = false;
+      await manager.loadMany('permission');
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.info.mock.calls.map(c => c[0]).join()).toMatch(/readable again/i);
+    });
+
     it('loadDiagnosed reports `degraded` — ADR-0110 D3 now holds for the DB loader', async () => {
       const manager = managerOverBrokenDb();
 

--- a/packages/metadata/src/loaders/database-loader.test.ts
+++ b/packages/metadata/src/loaders/database-loader.test.ts
@@ -6,14 +6,18 @@ import type { IDataDriver } from '@objectstack/spec/contracts';
 import { MetadataManager } from '../metadata-manager';
 import { MemoryLoader } from './memory-loader';
 
-// Suppress logger output during tests
+// Suppress logger output during tests. Stable object (not a fresh one per
+// `createLogger()` call) so the #5108 block can assert on what `list()` says
+// when a loader cannot be read — the whole point of that fix is the log line.
+const logger = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
 vi.mock('@objectstack/core', () => ({
-  createLogger: () => ({
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-  }),
+  createLogger: () => logger,
 }));
 
 /**
@@ -378,46 +382,49 @@ describe('DatabaseLoader', () => {
   });
 
   describe('error handling', () => {
-    it('should return null data on load failure', async () => {
+    // [#5108] These five used to assert the opposite — that a read failure is
+    // answered with the method's empty value. That behaviour WAS the defect:
+    // it made an unreachable `sys_metadata` byte-identical to "nothing of this
+    // type was ever declared". The read seam now discriminates by error type
+    // (see the dedicated #5108 block below for the benign half).
+    it('should rethrow a read failure from load — an outage is not a miss', async () => {
       const failingDriver = createMockDriver();
       failingDriver.findOne = vi.fn().mockRejectedValue(new Error('DB error'));
       const failLoader = new DatabaseLoader({ driver: failingDriver });
 
-      const result = await failLoader.load('object', 'account');
-      expect(result.data).toBeNull();
+      await expect(failLoader.load('object', 'account')).rejects.toThrow('DB error');
     });
 
-    it('should return empty array on loadMany failure', async () => {
+    it('should rethrow a read failure from loadMany', async () => {
       const failingDriver = createMockDriver();
       failingDriver.find = vi.fn().mockRejectedValue(new Error('DB error'));
       const failLoader = new DatabaseLoader({ driver: failingDriver });
 
-      const result = await failLoader.loadMany('object');
-      expect(result).toEqual([]);
+      await expect(failLoader.loadMany('object')).rejects.toThrow('DB error');
     });
 
-    it('should return false on exists failure', async () => {
+    it('should rethrow a read failure from exists', async () => {
       const failingDriver = createMockDriver();
       failingDriver.count = vi.fn().mockRejectedValue(new Error('DB error'));
       const failLoader = new DatabaseLoader({ driver: failingDriver });
 
-      expect(await failLoader.exists('object', 'account')).toBe(false);
+      await expect(failLoader.exists('object', 'account')).rejects.toThrow('DB error');
     });
 
-    it('should return null on stat failure', async () => {
+    it('should rethrow a read failure from stat', async () => {
       const failingDriver = createMockDriver();
       failingDriver.findOne = vi.fn().mockRejectedValue(new Error('DB error'));
       const failLoader = new DatabaseLoader({ driver: failingDriver });
 
-      expect(await failLoader.stat('object', 'account')).toBeNull();
+      await expect(failLoader.stat('object', 'account')).rejects.toThrow('DB error');
     });
 
-    it('should return empty array on list failure', async () => {
+    it('should rethrow a read failure from list', async () => {
       const failingDriver = createMockDriver();
       failingDriver.find = vi.fn().mockRejectedValue(new Error('DB error'));
       const failLoader = new DatabaseLoader({ driver: failingDriver });
 
-      expect(await failLoader.list('object')).toEqual([]);
+      await expect(failLoader.list('object')).rejects.toThrow('DB error');
     });
 
     it('should throw descriptive error on save failure', async () => {
@@ -833,6 +840,235 @@ describe('DatabaseLoader event_seq on a failed history read (#4825)', () => {
 
     expect(historySeqsWritten(driver)).toEqual([1, 2]);
     expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------- A storage read failure is never answered as "nothing declared" ----------
+
+/**
+ * #5108 (rule: #4632; same shape one layer up from #4825, ADR-0110 D3).
+ *
+ * Every read method used to `catch {}` into its own empty value, so a
+ * `sys_metadata` the metadata plane could not reach returned EXACTLY what "this
+ * environment declares nothing of that type" returns — `[]`, `false`, `null` —
+ * with not one line logged anywhere on the chain. `MetadataManager`'s own
+ * degradation branches could not fire either, because the loader handed them a
+ * *successful* empty read rather than an exception.
+ *
+ * Both directions are pinned, deliberately, exactly as #4728/#4825 pin theirs:
+ * proving the outage is loud is not enough, because "always throw" would pass
+ * that alone while making a first boot against an unprovisioned table explode.
+ * The point is that the two are DISTINGUISHED.
+ */
+describe('DatabaseLoader read failures are outages, not misses (#5108)', () => {
+  /** Benign: nothing provisioned yet, so "nothing declared" really is true. */
+  const noSuchTable = () =>
+    Object.assign(new Error('no such table: sys_metadata'), { code: 'SQLITE_ERROR' });
+
+  /** NOT benign: the rows are there, this read simply did not see them. */
+  const connectionReset = () =>
+    Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' });
+
+  /**
+   * A driver whose reads of `sys_metadata` fail the way a real outage does.
+   * `syncSchema` still succeeds — the table was provisioned at boot and the
+   * datasource fell over afterwards, which is what makes the defect invisible.
+   */
+  function driverWithFailingReads(makeError: () => unknown): IDataDriver {
+    const driver = createMockDriver();
+    driver.find = vi.fn().mockImplementation(() => Promise.reject(makeError()));
+    driver.findOne = vi.fn().mockImplementation(() => Promise.reject(makeError()));
+    driver.count = vi.fn().mockImplementation(() => Promise.reject(makeError()));
+    return driver;
+  }
+
+  describe('a REAL outage — the driver is reachable but the read failed', () => {
+    let loader: DatabaseLoader;
+
+    beforeEach(() => {
+      loader = new DatabaseLoader({ driver: driverWithFailingReads(connectionReset) });
+    });
+
+    it('loadMany rethrows instead of answering []', async () => {
+      await expect(loader.loadMany('permission')).rejects.toThrow('read ECONNRESET');
+    });
+
+    it('exists rethrows instead of answering false', async () => {
+      await expect(loader.exists('permission', 'admin_all')).rejects.toThrow('read ECONNRESET');
+    });
+
+    it('stat rethrows instead of answering null', async () => {
+      await expect(loader.stat('permission', 'admin_all')).rejects.toThrow('read ECONNRESET');
+    });
+
+    it('list rethrows instead of answering []', async () => {
+      await expect(loader.list('permission')).rejects.toThrow('read ECONNRESET');
+    });
+
+    it('load rethrows too — ADR-0110 D3 needs the singular read to fail loudly', async () => {
+      await expect(loader.load('permission', 'admin_all')).rejects.toThrow('read ECONNRESET');
+    });
+
+    it('carries the driver error unchanged, so the cause is diagnosable', async () => {
+      const thrown = await loader.loadMany('permission').catch((e: unknown) => e);
+      expect((thrown as { code?: string }).code).toBe('ECONNRESET');
+    });
+
+    it('does not poison the cache with the failed read', async () => {
+      await expect(loader.loadMany('permission')).rejects.toThrow();
+      // A retry must hit the driver again rather than serve a memoized [].
+      await expect(loader.loadMany('permission')).rejects.toThrow();
+    });
+  });
+
+  describe('the benign case — `sys_metadata` has not been provisioned yet', () => {
+    let loader: DatabaseLoader;
+
+    beforeEach(() => {
+      loader = new DatabaseLoader({ driver: driverWithFailingReads(noSuchTable) });
+    });
+
+    it('answers empty rather than exploding on a first boot', async () => {
+      await expect(loader.loadMany('permission')).resolves.toEqual([]);
+      await expect(loader.list('permission')).resolves.toEqual([]);
+      await expect(loader.exists('permission', 'admin_all')).resolves.toBe(false);
+      await expect(loader.stat('permission', 'admin_all')).resolves.toBeNull();
+      await expect(loader.load('permission', 'admin_all')).resolves.toMatchObject({ data: null });
+    });
+
+    it('does not memoize the empty answer — the table may appear next call', async () => {
+      const driver = createMockDriver();
+      let provisioned = false;
+      const realFind = driver.find as unknown as (t: string, q: unknown) => Promise<Record<string, unknown>[]>;
+      driver.find = vi.fn().mockImplementation((table: string, query: unknown) => {
+        if (!provisioned) return Promise.reject(noSuchTable());
+        return realFind(table, query);
+      });
+      const healing = new DatabaseLoader({ driver });
+
+      expect(await healing.list('permission')).toEqual([]);
+
+      provisioned = true;
+      await healing.save('permission', 'admin_all', { name: 'admin_all' });
+      expect(await healing.list('permission')).toEqual(['admin_all']);
+    });
+  });
+
+  it('DISTINGUISHES the two: same call site, opposite verdicts', async () => {
+    const benign = new DatabaseLoader({ driver: driverWithFailingReads(noSuchTable) });
+    const real = new DatabaseLoader({ driver: driverWithFailingReads(connectionReset) });
+
+    expect(await benign.loadMany('permission')).toEqual([]);
+    await expect(real.loadMany('permission')).rejects.toThrow('read ECONNRESET');
+  });
+
+  describe('what the manager on top of it can finally say', () => {
+    beforeEach(() => {
+      logger.error.mockClear();
+      logger.info.mockClear();
+      logger.warn.mockClear();
+    });
+
+    function managerOverBrokenDb(): MetadataManager {
+      const manager = new MetadataManager({ formats: ['json'], loaders: [new MemoryLoader()] });
+      manager.registerLoader(
+        new DatabaseLoader({ driver: driverWithFailingReads(connectionReset) }),
+      );
+      return manager;
+    }
+
+    it('list() keeps serving what it can, and reports the outage at `error`', async () => {
+      const manager = managerOverBrokenDb();
+      manager.registerInMemory('permission', 'from_code', { name: 'from_code' });
+
+      const items = await manager.list('permission');
+      // Best-effort listing survives — that posture is deliberate.
+      expect(items).toEqual([{ name: 'from_code' }]);
+
+      // …but it is no longer silent. AGENTS.md → "Degradation log levels":
+      // the system looks normal while the set it gates on is short → `error`.
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.warn).not.toHaveBeenCalled();
+      const [message] = logger.error.mock.calls[0] as [string];
+      expect(message).toContain('database');
+      expect(message).toContain('permission');
+      expect(message).toMatch(/PARTIAL/);
+      expect(message).toMatch(/never declared/i);
+      expect(message).toMatch(/reporting healthy/i);
+      expect(message).toMatch(/Fix:/);
+    });
+
+    it('says it once per outage, not once per read', async () => {
+      const manager = managerOverBrokenDb();
+
+      await manager.list('permission');
+      await manager.list('view');
+      await manager.list('flow');
+
+      expect(logger.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('loadDiagnosed reports `degraded` — ADR-0110 D3 now holds for the DB loader', async () => {
+      const manager = managerOverBrokenDb();
+
+      const diagnosed = await manager.loadDiagnosed('permission', 'admin_all');
+      expect(diagnosed.data).toBeNull();
+      expect(diagnosed.degraded).toBe(true);
+      expect(diagnosed.errors.join()).toContain('read ECONNRESET');
+    });
+
+    it('a clean miss is still NOT degraded — the distinction is the point', async () => {
+      const manager = new MetadataManager({ formats: ['json'], loaders: [new MemoryLoader()] });
+      manager.registerLoader(new DatabaseLoader({ driver: createMockDriver() }));
+
+      const diagnosed = await manager.loadDiagnosed('permission', 'never_declared');
+      expect(diagnosed.data).toBeNull();
+      expect(diagnosed.degraded).toBe(false);
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The reason #5108 was split out of #5089. `listForIndex()` was written
+     * without a `try/catch` precisely so an unreadable store could not be
+     * served as "no endpoint declares this route" — but that only worked for
+     * loaders that actually report their failures. Against a real
+     * `DatabaseLoader` the seam was inert: the loader swallowed first, so
+     * `matchEndpoint` answered `undefined`, which the REST layer turns into a
+     * 404 — an availability failure rendered as a semantic "not declared".
+     */
+    it('matchEndpoint REJECTS on a broken DatabaseLoader instead of 404-shaped undefined', async () => {
+      const manager = managerOverBrokenDb();
+
+      await expect(
+        manager.matchEndpoint({ method: 'GET', path: '/api/v1/apps/showcase/tasks' }),
+      ).rejects.toThrow('read ECONNRESET');
+    });
+
+    it('…even when the endpoint IS declared in another, healthy loader', async () => {
+      const manager = managerOverBrokenDb();
+      manager.registerInMemory('api', 'list_tasks', {
+        name: 'list_tasks',
+        path: '/api/v1/apps/showcase/tasks',
+        method: 'GET',
+        type: 'object_operation',
+        target: 'showcase_task',
+      });
+
+      // A partial read cannot prove the match it found is the right one.
+      await expect(
+        manager.matchEndpoint({ method: 'GET', path: '/api/v1/apps/showcase/tasks' }),
+      ).rejects.toThrow('read ECONNRESET');
+    });
+
+    it('an unprovisioned table is NOT an outage — matchEndpoint still answers a clean miss', async () => {
+      const manager = new MetadataManager({ formats: ['json'], loaders: [new MemoryLoader()] });
+      manager.registerLoader(new DatabaseLoader({ driver: driverWithFailingReads(noSuchTable) }));
+
+      await expect(
+        manager.matchEndpoint({ method: 'GET', path: '/api/v1/apps/showcase/tasks' }),
+      ).resolves.toBeUndefined();
+      expect(logger.error).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/packages/metadata/src/loaders/database-loader.ts
+++ b/packages/metadata/src/loaders/database-loader.ts
@@ -665,6 +665,59 @@ export class DatabaseLoader implements MetadataLoader {
   }
 
   // ==========================================
+  // Read-failure classification (#5108)
+  // ==========================================
+
+  /**
+   * Decide what a failed READ against {@link tableName} means, and rethrow
+   * unless it is the ONE benign reason.
+   *
+   * #5108 (rule from #4632; same shape as #4728 and #4825) — discriminate by
+   * error TYPE. Every read method below used to `catch {}` into its own empty
+   * value: `load` → `null`, `loadMany` → `[]`, `exists` → `false`, `stat` →
+   * `null`, `list` → `[]`. That made a database the metadata plane cannot
+   * reach **indistinguishable** from an environment where nothing of that type
+   * was ever declared — and it erased the failure *inside the loader*, so
+   * neither `MetadataManager`'s own `try/catch` degradation branches nor
+   * {@link import('../metadata-manager.js').MetadataManager.loadDiagnosed}
+   * (ADR-0110 D3, whose whole purpose is to tell a miss from an outage) could
+   * report anything. Nowhere on the chain was there a line saying the read
+   * failed.
+   *
+   * Why that is worse than a noisy error: every consumer that gates on a
+   * *declared set* — permissions, sharing rules, policies, endpoint
+   * declarations — reads the empty answer as "the author declared none". Some
+   * then fail open (grant), some fail closed (lock out); both look healthy
+   * from outside. This is the AGENTS.md → "Degradation log levels" shape the
+   * repo has already paid for twice, one layer up from #4825.
+   *
+   * Exactly one failure reason is benign: `sys_metadata` has not been
+   * provisioned yet. There are then genuinely no rows, so "nothing declared"
+   * IS the truth, and a first boot must not explode. Every other reason —
+   * connection drop, timeout, insufficient privileges, malformed query — means
+   * the rows may well be there and simply were not seen.
+   *
+   * Classification is conservative in the same direction as
+   * {@link isMissingTableError} itself: an unrecognised error is NOT benign.
+   * A false "benign" silently mis-answers a security question; a false "real"
+   * costs one loud error.
+   *
+   * @param error The value thrown by `_find` / `_findOne` / `_count`.
+   * @throws The underlying driver error, unchanged — deliberately, matching
+   *         {@link nextEventSeq}. The loader does not log it: the caller owns
+   *         the consequence and is the only layer that knows what an
+   *         incomplete answer costs it (`MetadataManager.list()` reports it at
+   *         `error`; `listForIndex()`/`matchEndpoint` let it propagate so an
+   *         outage can never be served as a 404).
+   * @returns normally ONLY for the benign case, licensing the caller to answer
+   *          with its empty value.
+   */
+  private rethrowUnlessTableUnprovisioned(error: unknown): void {
+    if (isMissingTableError(error)) return;
+    throw error;
+  }
+
+  // ==========================================
   // MetadataLoader Interface Implementation
   // ==========================================
 
@@ -718,7 +771,11 @@ export class DatabaseLoader implements MetadataLoader {
         etag: record.checksum,
         loadTime: Date.now() - startTime,
       };
-    } catch {
+    } catch (error) {
+      this.rethrowUnlessTableUnprovisioned(error);
+      // Benign only: the table is not provisioned, so there is no row. Not
+      // cached — `ensureSchema()` retries, and a `null` memoized here would
+      // outlive the provisioning that fixes it.
       return {
         data: null,
         loadTime: Date.now() - startTime,
@@ -748,7 +805,9 @@ export class DatabaseLoader implements MetadataLoader {
 
       this.loadManyCache?.set(type, result);
       return result;
-    } catch {
+    } catch (error) {
+      this.rethrowUnlessTableUnprovisioned(error);
+      // Benign only: no table, therefore no items of this type. Not cached.
       return [];
     }
   }
@@ -768,7 +827,9 @@ export class DatabaseLoader implements MetadataLoader {
       });
 
       return count > 0;
-    } catch {
+    } catch (error) {
+      this.rethrowUnlessTableUnprovisioned(error);
+      // Benign only: no table, therefore the item genuinely does not exist.
       return false;
     }
   }
@@ -805,7 +866,9 @@ export class DatabaseLoader implements MetadataLoader {
       };
       this.statCache?.set(key, stats);
       return stats;
-    } catch {
+    } catch (error) {
+      this.rethrowUnlessTableUnprovisioned(error);
+      // Benign only: no table, therefore nothing to stat. Not cached.
       return null;
     }
   }
@@ -830,7 +893,9 @@ export class DatabaseLoader implements MetadataLoader {
 
       this.listCache?.set(type, names);
       return names;
-    } catch {
+    } catch (error) {
+      this.rethrowUnlessTableUnprovisioned(error);
+      // Benign only: no table, therefore no names. Not cached.
       return [];
     }
   }

--- a/packages/metadata/src/metadata-manager.ts
+++ b/packages/metadata/src/metadata-manager.ts
@@ -1701,8 +1701,13 @@ export class MetadataManager implements IMetadataService {
                 }
                 results.push(item);
             }
+            this.reportLoaderReadRecovered(loader.contract.name);
         } catch (e) {
-           this.logger.warn(`Loader ${loader.contract.name} failed to loadMany ${type}`, { error: e });
+            // [#5108] Same seam, same verdict as `list()` — see
+            // {@link reportLoaderReadFailure}. Two adjacent plural reads
+            // reporting one storage outage at two different levels is how the
+            // wrong one gets copied.
+            this.reportLoaderReadFailure(loader.contract.name, type, e);
         }
     }
     return results;

--- a/packages/metadata/src/metadata-manager.ts
+++ b/packages/metadata/src/metadata-manager.ts
@@ -149,6 +149,14 @@ export class MetadataManager implements IMetadataService {
   private listCache = new Map<string, { ts: number; items: unknown[] }>();
   private static readonly LIST_CACHE_TTL_MS = 30_000;
 
+  // [#5108] Loader names whose read failure has already been reported at
+  // `error` by `list()`. AGENTS.md → "Degradation log levels": say it once, at
+  // the first degradation — `list()` is hot enough that one line per failed
+  // read would bury the one line that matters. Cleared when the loader answers
+  // again, so a second outage is reported again. Same once-only discipline as
+  // `DatabaseLoader.schemaFailureReported`.
+  private readonly loaderReadFailureReported = new Set<string>();
+
   // Realtime service for event publishing
   private realtimeService?: IRealtimeService;
 
@@ -536,8 +544,9 @@ export class MetadataManager implements IMetadataService {
             items.set(itemAny.name, item);
           }
         }
+        this.reportLoaderReadRecovered(loader.contract.name);
       } catch (e) {
-        this.logger.warn(`Loader ${loader.contract.name} failed to loadMany ${type}`, { error: e });
+        this.reportLoaderReadFailure(loader.contract.name, type, e);
       }
     }
 
@@ -545,6 +554,60 @@ export class MetadataManager implements IMetadataService {
     this.cacheListResult(type, result);
     return result;
   }
+
+  /**
+   * Report — at `error`, once per outage episode — that a loader could not be
+   * read while serving {@link list}.
+   *
+   * [#5108] This branch used to be dead for the loader that matters. Before
+   * #5108 `DatabaseLoader` caught its own read failures and answered `[]`, so
+   * `list()` received a *successful empty read* and never entered this `catch`
+   * at all: an unreachable `sys_metadata` and "this environment declares no
+   * `permission`" produced byte-identical results with not one line logged.
+   * With the loader rethrowing everything but the benign not-provisioned case,
+   * this is where the outage finally becomes speakable.
+   *
+   * `error`, not `warn`, per AGENTS.md → "Degradation log levels". Apply its
+   * one question — *does the system still look normal from outside while
+   * something it claims to know has not actually landed?* — and the answer is
+   * yes: `list()` still returns, callers still get an array, nothing 500s, and
+   * the set they gate on is quietly short. Which way that cuts depends on the
+   * consumer, and both ways are silent (#3935 is the fail-open precedent).
+   *
+   * Said **once** per loader, and un-said on recovery, because `list()` is a
+   * hot path — one line per outage, not one per read.
+   *
+   * Deliberately does NOT rethrow: `list()` is the best-effort listing seam and
+   * must keep serving what the reachable loaders hold. The strict counterpart
+   * for callers whose answer is a security decision is `listForIndex()` (no
+   * `catch`, feeding `matchEndpoint`) and {@link loadDiagnosed} (ADR-0110 D3)
+   * for the singular read — both of which only became honest for
+   * `DatabaseLoader` with the same #5108 change.
+   */
+  private reportLoaderReadFailure(loaderName: string, type: string, error: unknown): void {
+    if (this.loaderReadFailureReported.has(loaderName)) return;
+    this.loaderReadFailureReported.add(loaderName);
+    this.logger.error(
+      `[MetadataManager] Loader \`${loaderName}\` could NOT be read (first failure seen while listing \`${type}\`) — ` +
+        `every list served from now on is a PARTIAL set presented as a complete one, and the server keeps reporting healthy. ` +
+        `Consumers that gate on a declared set (permissions, sharing rules, policies, api endpoints) will read the ` +
+        `declarations this loader holds as "never declared" — which grants or locks out depending on the consumer, silently either way. ` +
+        `Fix: check the datasource behind \`${loaderName}\` — connection, credentials, and that its metadata table exists. ` +
+        `The read is retried on the next list once the ${MetadataManager.LIST_CACHE_TTL_MS}ms list cache lapses, so a transient ` +
+        `cause recovers on its own and the recovery is logged.`,
+      error instanceof Error ? error : undefined,
+      { loader: loaderName, type, error },
+    );
+  }
+
+  /** Un-say {@link reportLoaderReadFailure} once the loader answers again. */
+  private reportLoaderReadRecovered(loaderName: string): void {
+    if (!this.loaderReadFailureReported.delete(loaderName)) return;
+    this.logger.info(
+      `[MetadataManager] Loader \`${loaderName}\` is readable again — listings are complete once more.`,
+    );
+  }
+
   private cacheListResult(type: string, items: unknown[]): void {
     this.listCache.set(type, { ts: Date.now(), items });
   }
@@ -565,7 +628,7 @@ export class MetadataManager implements IMetadataService {
    * Enumerate stored items of `type` for an index build — like {@link list},
    * but a store that cannot be read THROWS instead of contributing nothing.
    *
-   * [#5089] `list()` deliberately warn-logs and skips a failing loader so a
+   * [#5089] `list()` deliberately logs a failing loader and skips it so a
    * partially-available metadata plane still serves what it can. That posture
    * is wrong for `matchEndpoint`: its `undefined` becomes an HTTP 404, and a
    * store outage that silently yields "zero declarations" would turn every
@@ -577,10 +640,14 @@ export class MetadataManager implements IMetadataService {
    * is `list()`'s failure posture inverted for the one caller whose answer is
    * a security/availability decision rather than a best-effort listing.
    *
-   * ⚠️ This surfaces only failures a loader actually reports. `DatabaseLoader`
-   * currently swallows its own read errors into `[]` (#5108), so a DB outage is
-   * invisible even here — that is a defect in the loader, not a reason to
-   * soften this seam.
+   * This surfaces only failures a loader actually reports — which, since
+   * #5108, includes `DatabaseLoader`: it used to swallow its own read errors
+   * into `[]`, making a DB outage invisible even here. It now rethrows every
+   * read failure except the benign "table not provisioned yet", so this seam
+   * holds against the real datasource-backed loader and not just the memory /
+   * remote ones. (`database-loader.test.ts` pins that end to end: a broken
+   * driver behind a real `DatabaseLoader` makes `matchEndpoint` reject rather
+   * than answer a 404-shaped `undefined`.)
    */
   private async listForIndex(type: string): Promise<unknown[]> {
     const items = new Map<string, unknown>();


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5108

## 结论:走方向 2(loader 照实抛出),不新增 `loadManyDiagnosed`

issue 给了两条路,PM 的初读偏向方向 1(给 loader 接口补 `loadManyDiagnosed`)。读完代码后我选了方向 2,理由是**代码证据在这一侧压倒性地一致**:

1. **本包已经把这条规矩立过两次,判据是现成的。** `packages/metadata/src/utils/schema-sync-errors.ts` 就是为「哪些驱动错误可以被静默」这一个问题存在的模块,它的文档里写着 READ 路径的标准写法:

   ```ts
   catch (error) {
     if (isMissingTableError(error)) return BENIGN_EMPTY_VALUE;
     throw error;                     // caller reports the consequence
   }
   ```

   `nextEventSeq()`(#4825)就在**同一个文件里**照这个形状写着,`@throws` 那行明说「the underlying driver error, unchanged」。本次修复只是把同一条规矩用到它旁边的五个读方法上,没有引入任何新词汇。更强的信号:`packages/metadata/src/errors.ts` 这个子路径**专门为导出 `isMissingTableError` 而存在**,文档里逐条论证了为什么不能有第二套「哪些驱动错误算良性」的判据。方向 1 不需要这个判据,方向 2 正好是它的第二个消费方。

2. **#5089 落地的代码已经把裁决写死在注释里。** `listForIndex()` 的注释原文:「`DatabaseLoader` currently swallows its own read errors into `[]` (#5108), so a DB outage is invisible even here —— **that is a defect in the loader**, not a reason to soften this seam.」修法的落点已经被上一单指到 loader 了。

3. **方向 1 并不能独立满足验收条件。** `listForIndex()` 调的是 `loadMany`,契约要求读不到存储必须**抛出**。哪怕补了 `loadManyDiagnosed`,只要 `loadMany` 还返回 `[]`,`matchEndpoint` 在 outage 下照样答 `undefined` → 404。也就是说方向 1 要成立,**必须先做方向 2**;做完方向 2 之后,`loadManyDiagnosed` 就只剩「manager 层已经有的 `try/catch` 的另一种写法」这一点价值了。

4. **方向 1 的成本落在公共契约上。** 给 `MetadataLoader` 加必选方法会打断所有实现方(含外部);加可选方法则逼消费方在调用点写一个 `?.` + `??` 的宽容回退(先试 diagnosed 版本,没有就退回 `loadMany` 并假定 `degraded: false`)—— 正是 Prime Directive #12 禁止的 consumer-side 容忍。而且 `exists` / `stat` 没有自然的 diagnosed 对位物,只会变成接口膨胀。方向 2 **零接口改动、零 spec 改动**(`packages/spec/**` 未改一个字节)。

「不能不动 spec 契约就修」这条没有发生,所以没有走 `needs_decision`。

## 改了什么

### `packages/metadata/src/loaders/database-loader.ts`

五个读方法 —— `load` / `loadMany` / `exists` / `stat` / `list` —— 此前都是 `catch {}` 成各自的空值。issue 点名了其中三个(以及 `loadMany` 连 warn 都没有);实际上**五个全是同一形状**,多出来的两处是 issue 前提的修正,见下。

新增一个私有判决方法 `rethrowUnlessTableUnprovisioned(error)`,五处 `catch` 统一走它:

- **唯一良性**:`sys_metadata` 尚未 provisioned。那时确实没有行,「什么都没声明」就是事实,首次启动照旧返回空值、不报错、**不写缓存**(表随时可能出现,memoize 一个空值会活得比 provisioning 还久);
- **其余全部**:连接断开、超时、权限不足、查询出错 —— 行还在、只是这次没读到,把驱动**原始异常原样抛出**。判据保守:无法正面识别为「表不存在」的错误一律当真故障(假的「良性」会静默答错一个安全问题,假的「真故障」只值一行 error)。

### `packages/metadata/src/metadata-manager.ts`(最小触碰)

- `list()` 的降级分支改走新的 `reportLoaderReadFailure()`,**级别从 `warn` 升到 `error`**。按 AGENTS.md「Degradation log levels」那一问:降级之后系统从外面看仍然正常,而它声称掌握的清单其实是残缺的 → `error`。日志同时给出**后果**(此后每次 list 都是把残缺集合当完整集合发出去;按消费方姿态不同,要么放行要么锁死,两种都静默)和**修法**(查该 loader 背后的 datasource:连接、凭证、表是否存在)。每次故障**只说一次**,loader 恢复时说一次 recovery;
- `list()` 仍然尽力返回可读 loader 的内容 —— 这个 best-effort 姿态是刻意保留的,严格对位物是 `listForIndex()` 和 `loadDiagnosed()`;
- 兄弟方法 `loadMany()` 的同一条缝复用同一个判决(**这一处超出了派单里写的「仅 list()」**,明说在这里:同一次存储故障在同一个文件里报出两个级别,是错的那个被抄走的方式。若认为该收回,单独 revert 第二个 commit 即可,不影响主修复);
- `listForIndex()` 的注释里那段指向本 issue 的 ⚠️ 已经过期,改写成现状。

⛔ `attachClusterPubSub` / `notifyWatchersLocal` / `listCache` 失效逻辑**一行未动**(#5109 的面)。

## 上层三个机制第一次真的生效

| 机制 | 修复前 | 修复后 |
|:--|:--|:--|
| `MetadataManager.list()` 的降级分支 | 形同虚设 —— loader 递上来的是一次「成功的空读」,`catch` 根本不进 | 进,且在 `error` |
| `loadDiagnosed()`(ADR-0110 D3) | 对 `DatabaseLoader` 永远 `degraded: false` —— **单数读也一样被吞了** | 报出 `degraded` + `errors` |
| `listForIndex()` / `matchEndpoint`(#5089) | 对 `MemoryLoader` / `RemoteLoader` 有效,对 `DatabaseLoader` 无效 | 对真实 datasource loader 也成立 |

## issue 前提的两处修正(已按 origin/main 逐条核对)

1. **行号漂移**(#5089 的 ecc61ab 今天落地所致):`loadMany` 是 `:729-753`(issue 写 740-753),`exists` `:756-773`,`stat` `:776-808`。缺陷本身逐字属实。
2. **「`load` 至少让异常冒到 manager 那层被 warn 记下」这句不成立。** `DatabaseLoader.load()` 在 `:721` 同样把异常吞成 `{ data: null }`。也就是说 issue 引用为「单数读已经立过规矩」的那条 —— ADR-0110 D3 的 `loadDiagnosed` —— 对 `DatabaseLoader` **同样是失效的**:它拿到的也是一次成功的空读,`degraded` 永远是 `false`。本 PR 把 `load()` 一并修了(同一个文件、同一形状、同一条要求),否则 issue 举来当标准的那条先例自己还是坏的。loader 自己的 `list()`(`:833`)是第五处同形,`MetadataManager.listNames()` 走的正是它。

## 行为变化(明说)

`MetadataManager.exists()` 与 `listNames()` 本来就没有 `try/catch`,所以存储故障现在会从它们**抛出**,而不再静默答「不存在」/「空清单」。这正是本次修复要的姿态 —— 可用性故障不是一次「没有」。已核对:这两个方法在 `packages/**` / `apps/**` 里除测试外**没有生产调用方**。

`list()` 那条 30s `listCache` 的注释记着一个真实场景:权限中间件在事务里调 `list('permission')`,knex 等满 `acquireConnectionTimeout` 才返回。那条路径现在会 throw → 被 `list()` 的 `catch` 接住 → **返回值与之前完全一致**(registry 部分),只是多了一行 error。没有新增任何会冒到中间件的异常。

## 验证

```
pnpm --filter @objectstack/metadata test          → 17 files, 403 tests passed
pnpm --filter @objectstack/metadata-protocol test → 38 files, 339 tests passed
pnpm --filter @objectstack/runtime test           → 88 files, 1270 tests passed
pnpm --filter @objectstack/cli test               → 69 files, 612 tests passed

packages/metadata: npx tsc --noEmit → 92 errors
  origin/main 同一套已构建依赖下同样 92 —— 零新增
  (该包无 typecheck 脚本,在 #4311 的 DEBT ledger 里)

pnpm check:durability-log-level → 12 seam(s), all loud or rethrowing ✓
pnpm check:adr-anchors          → 20 anchored file(s) ✓
pnpm check:type-check-coverage  → OK ✓
pnpm check:error-code-casing    → OK ✓
pnpm check:nul-bytes            → OK ✓
npx eslint 三个改动文件          → clean
```

新增测试沿用 #4728 / #4825 「**两个方向都钉**」的姿态 —— 只证明故障够响是不够的,因为「一律抛出」也能单独通过,同时会让首次启动炸掉。要钉的是两者**被区分开**:

- 真 outage(`ECONNRESET`):五个读方法逐个 rejects,驱动错误 `code` 原样带出,重试不吃毒化缓存;
- 良性(`no such table: sys_metadata`):五个读方法逐个答空,不报错,**且不 memoize** —— 表后来被建出来时下一次读就能看见;
- 同一调用点、相反裁决的对照;
- manager 层:`list()` 照常返回可读内容 + `error` 一次(断言 `PARTIAL` / `never declared` / `reporting healthy` / `Fix:` 都在)、`warn` 零次;每次故障只说一次;恢复时 un-say;`loadDiagnosed` 报 `degraded`;干净的 miss **仍然** `degraded: false`;
- **验收项**:破损驱动 + 真实 `DatabaseLoader` → `matchEndpoint` **rejects**,不再答那个会变成 404 的 `undefined`;即使别的健康 loader 里声明了该端点也照样 rejects(残缺的读证明不了它找到的就是对的);而**未 provisioned 的表不是 outage** —— `matchEndpoint` 照常答一次干净的 miss。

原先 `error handling` 里那五条断言「读失败要答空值」的测试被改写了 —— 它们钉的正是本 issue 的缺陷本身。
