### PR TITLE
fix(metadata-protocol): updateMany classifies an id-less row as a caller error, matching batchData (#5100)

### DIFF
--- a/.changeset/updatemany-idless-row-guard.md
+++ b/.changeset/updatemany-idless-row-guard.md
@@ -1,0 +1,21 @@
+---
+"@objectstack/metadata-protocol": patch
+---
+
+fix(metadata-protocol): `updateMany` classifies an id-less row as a caller error, matching `batchData`'s update branch (#5100)
+
+`runUpdateManyLoop` lacked the `!record.id` guard #4793 gave `runBatchDataLoop`'s
+update branch, so the two by-id update faces classified the same malformed row
+differently: `VALIDATION_FAILED`/400 on batch, but on `updateMany` the row fell
+through to the #5088 existence probe as `{ id: undefined }` and came back
+`RECORD_NOT_FOUND`/404 with `undefined` interpolated into the message — a
+request-shape error reported as a data-state one, with the row's fate left to
+each driver's undefined-where-key handling.
+
+Not reachable over REST (`UpdateManyRecordSchema` requires `id`, #3939) — the
+change is observable only to in-process callers of the protocol method, whose
+id-less rows now answer `VALIDATION_FAILED`/400 (`Record id is required for
+update`) before any engine round-trip, identically on both faces (#4620: one
+classification per file, enforced by a cross-face parity test). `record.data`
+handling is aligned to the batch branch's `record.data || {}` in the same
+change.

--- a/packages/metadata-protocol/src/protocol.bulk-record-not-found.test.ts
+++ b/packages/metadata-protocol/src/protocol.bulk-record-not-found.test.ts
@@ -421,6 +421,52 @@ describe('[#5088] batchData delete — the driver`s return decides, as in delete
     });
 });
 
+describe('[#5100] an id-less row is a CALLER error on both by-id update faces', () => {
+    it('updateMany: VALIDATION_FAILED/400 before any engine read or write', async () => {
+        const t = makeStoreEngine();
+        const p = new ObjectStackProtocolImplementation(t.engine);
+
+        const res: any = await p.updateManyData({
+            object: 'showcase_task',
+            records: [{ data: { progress: 1 } }],
+            options: { continueOnError: true },
+        } as any);
+
+        expect(res.succeeded).toBe(0);
+        expect(res.failed).toBe(1);
+        expect(res.results[0].errors?.[0]?.code).toBe('VALIDATION_FAILED');
+        expect(res.results[0].errors?.[0]?.httpStatus).toBe(400);
+        expect(res.results[0].errors?.[0]?.message).toBe('Record id is required for update');
+        // A missing id is a request-shape error, not a data-state one — and it
+        // must fail BEFORE any engine round-trip: unguarded, the row reached
+        // the #5088 probe as `{ id: undefined }`, whose reading is up to the
+        // driver's undefined-where-key handling, and came back as a 404 with
+        // `undefined` interpolated into the message.
+        expect(res.results[0].errors?.[0]?.message).not.toContain('not found');
+        expect(t.findOne).not.toHaveBeenCalled();
+        expect(t.update).not.toHaveBeenCalled();
+    });
+
+    it('the two by-id update faces give ONE classification for the same malformed row (#4620)', async () => {
+        const t = makeStoreEngine();
+        const p = new ObjectStackProtocolImplementation(t.engine);
+
+        const many: any = await p.updateManyData({
+            object: 'showcase_task',
+            records: [{ data: { progress: 1 } }],
+        } as any);
+        const batch: any = await p.batchData({
+            object: 'showcase_task',
+            request: { operation: 'update', records: [{ data: { progress: 1 } }] },
+        } as any);
+
+        expect(many.results[0].errors[0].code).toBe(batch.results[0].errors[0].code);
+        expect(many.results[0].errors[0].message).toBe(batch.results[0].errors[0].message);
+        expect(many.results[0].errors[0].httpStatus).toBe(batch.results[0].errors[0].httpStatus);
+        expect(batch.results[0].errors[0].code).toBe('VALIDATION_FAILED');
+    });
+});
+
 describe('[#5088] the three by-id write faces answer the SAME thing', () => {
     it('single-record PATCH, updateMany and batchData produce one message for one missing id', async () => {
         const t = makeStoreEngine();

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -5935,6 +5935,17 @@ export class ObjectStackProtocolImplementation implements
                 //     (#2948) / `readonlyWhen` (#3042) strips that single-write now
                 //     surfaces (#3431) happened silently here. Collect per row.
                 //
+                // [#5100] Same guard as `runBatchDataLoop`'s update branch
+                // (#4793), same classification: an id-less row is a CALLER
+                // error — VALIDATION_FAILED/400 — not a data-state one. The
+                // REST entrance already rejects it (`UpdateManyRecordSchema`
+                // requires `id`, #3939), but that invariant lives two packages
+                // away; unguarded, an in-process caller's malformed row
+                // reached the probe and the write as `{ id: undefined }`,
+                // whose reading is up to each driver's undefined-where-key
+                // handling — at best a 404 with `undefined` interpolated into
+                // the message, at worst a where-clause with no id at all.
+                if (!record.id) throw rowRequiredIdError('update');
                 // [#5088] Third gap, the same shape: no existence gate. A row
                 // naming no record went straight into `engine.update`, so the
                 // hook pipeline ran over a payload-only record and the row came
@@ -5945,7 +5956,7 @@ export class ObjectStackProtocolImplementation implements
                 const dropped: DroppedFieldsEvent[] = [];
                 const opts: any = { where: { id: record.id }, onFieldsDropped: (e: DroppedFieldsEvent) => { dropped.push(e); } };
                 if (context !== undefined) opts.context = context;
-                const updated = await this.engine.update(object, record.data, opts);
+                const updated = await this.engine.update(object, record.data || {}, opts);
                 results.push({ id: record.id, success: true, data: updated, index, ...(dropped.length > 0 ? { droppedFields: dropped } : {}) });
                 succeeded++;
             } catch (err: any) {


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5100

维护者已拍板补齐守卫，裁定记录在 [#5100 的裁定评论](https://github.com/objectstack-ai/objectstack/issues/5100#issuecomment-5176490277)。protocol.ts 已知的最后一处 by-id 写面口径漂移（#4435→#5088、#5099 同族），关掉它即关掉整类。

## 问题

`runUpdateManyLoop` 缺 `runBatchDataLoop` update 分支那道 `!record.id` 守卫（#4793）。同一个没有 id 的行，两个 by-id update 写面给两种分类：

| 写面 | 分类 |
|:--|:--|
| `batchData` update 分支 | `VALIDATION_FAILED` / 400（`Record id is required for update`）|
| `updateMany`（修前）| 落进 #5088 存在性探针，`RECORD_NOT_FOUND` / 404，消息是插值出来的 `Record undefined not found in …` |

请求形状错误被报成数据状态错误，且未设防路径把 `{ id: undefined }` 递进探针和写两层——这个 where 形状怎么读取决于各 driver 对 undefined 键的处理，最好情况是那个 404，其余情况不受任何约束。

**当前 REST 打不到**（`UpdateManyRecordSchema` 强制 id 必填，#3939）——但这个 dormancy 依赖的不变量写在两个包之外，`protocol.ts` 本地无痕迹；任何新入口（进程内调用、新传输层）都会无声地把它变 live。守卫把分布式不变量收为本地不变量。

## 修法

- 循环头补同一句 `if (!record.id) throw rowRequiredIdError('update')`——与 batch 分支共用同一个 helper、同一分类，守卫先于任何引擎往返（探针也不再跑）。
- 顺带把 `record.data` 裸递对齐为 batch 分支的 `record.data || {}`（同族微漂移）。
- **可观察行为变化仅限进程内调用者**：id-less 行从 404（消息含 `undefined`）变为 400。changeset 如实记录。

## 先证红再信绿

在 #5088 的跨面一致性测试文件里新增 `[#5100]` describe（2 例：单面分类断言 + 双面同答案的 #4620 对称 pin，含"引擎从未被问到"断言）。守卫缺席时:

```
Tests  2 failed | 15 passed (17)
AssertionError: expected 'RECORD_NOT_FOUND' to be 'VALIDATION_FAILED'   // 单面分类
AssertionError: expected 'RECORD_NOT_FOUND' to be 'VALIDATION_FAILED'   // 双面对称 pin
```

修复后：`@objectstack/metadata-protocol` **40 文件 / 348 用例全绿**，`turbo typecheck --filter=...@objectstack/metadata-protocol` **82 任务全过**。

## 备注

- 与在飞的 #5038（`packages/objectql` + `service-automation`，predicate 批量写按行语义）无共享文件；本 PR 是 #5187（upsert 存在性分岔）落地后同分支的串行后续。
- 契约上没有新决定——这是把 #4793 已定的分类补齐到最后一个写面。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BotUP49pqhvqGY393n2HfU

---
_Generated by [Claude Code](https://claude.ai/code/session_01BotUP49pqhvqGY393n2HfU)_