### PR TITLE
fix(metadata,spec): publish 门兜底 —— publishPackage 接门 + 匹配器装载期拒绝(#5040 E7b)

### DIFF
--- a/.changeset/endpoint-publish-gate-backstop.md
+++ b/.changeset/endpoint-publish-gate-backstop.md
@@ -1,0 +1,53 @@
+---
+"@objectstack/spec": minor
+"@objectstack/metadata": minor
+---
+
+fix(metadata,spec): the endpoint publish gates now guard the metadata write path too (#5189, #5040 E7b)
+
+#5111 (E7) hung the five per-endpoint `apis:` gates on
+`ObjectStackDefinitionSchema`, which every path that parses a **stack** runs
+through — `defineStack`, `os validate`, the lint scorer, artifact ingest,
+`EnvironmentArtifactSchema.metadata`. #5189 proved a stored `api` item need
+never have been part of a stack: `MetadataManager.publishPackage`, a direct
+`metadata.register()` and a Studio metadata write each mint one item at a time
+and saw no gate at all.
+
+Three of the five gates degrade safely when bypassed — the executor answers a
+structured 501 naming the item, and a path outside the `apps/<namespace>/`
+carve-out simply matches nothing. **ADR-0121 D6 has no runtime counterpart**:
+the runtime honours `authRequired: false` faithfully and `deriveBucketConfig`
+returns `null` for a budget whose `enabled` is not `true`, so the bypass minted
+an anonymous, zero-quota execution entry point — the exact shape D6 exists to
+forbid.
+
+Two doors now, both running the SAME gate function rather than a second copy of
+the criteria:
+
+- **Publish** — `MetadataManager.publishPackage` runs
+  `validateApiEndpointDeclarations` over the package's `api` items and fails
+  the publish, naming each endpoint and the key to fix, on the same
+  `validationErrors` surface it already uses. This pass is **not** governed by
+  `options.validate`: an opt-out on a security gate is the bypass this fixed.
+- **Load** — the endpoint matcher's index build re-applies the *identity-free*
+  subset (supported subset, mapping, policy/D6) to every stored item. A
+  declaration that never passed publish is EXCLUDED from the index and named at
+  `error` level, so a bypassed endpoint answers 404 with a loud log instead of
+  answering anonymously and unmetered. The namespace and uniqueness gates are
+  deliberately not applied there — both need a stack identity a stored row does
+  not carry.
+
+**New in `@objectstack/spec/api`** (the module was package-internal in #5111,
+whose only consumer was one file away):
+`validateApiEndpointDeclarations`, `identityFreeEndpointGateFailure`,
+`EndpointGateIssue`, `EndpointGateIdentity`.
+
+**New option — `publishPackage(id, { namespace })`.** `MetadataManager` indexes
+items by `packageId` and carries no manifest, so it cannot prove a namespace on
+its own and will **not** infer one from the items it is judging (an
+author-supplied value would make the ADR-0121 D1/D2 carve-out gate vacuous).
+Callers that hold the package manifest pass its explicit `manifest.namespace`;
+without it the namespace gate fails and the package's `api` items do not
+publish — which is the rule, not a limitation: a publish that cannot prove a
+namespace must not mint a URL under one. Packages that declare no `api` items
+are untouched.

--- a/packages/metadata/src/endpoint-matcher.test.ts
+++ b/packages/metadata/src/endpoint-matcher.test.ts
@@ -41,7 +41,17 @@ function makeLogger(): Logger & { error: ReturnType<typeof vi.fn> } {
   } as unknown as Logger & { error: ReturnType<typeof vi.fn> };
 }
 
-/** A minimal, valid `ApiEndpointSchema` input. `authRequired` deliberately omitted. */
+/**
+ * A minimal `ApiEndpointSchema` input that also PASSES the identity-free
+ * publish gates (#5189). `authRequired` is deliberately omitted so the
+ * schema-default tests still have something to prove.
+ *
+ * `objectParams` is not decoration: E7's target gate rejects an
+ * `object_operation` that does not name both `object` and `operation`, and
+ * since #5189 the index applies that gate too — a fixture without it would be
+ * excluded rather than served, which is the correct behaviour and a useless
+ * fixture.
+ */
 function endpoint(over: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     name: 'list_tasks',
@@ -49,6 +59,7 @@ function endpoint(over: Record<string, unknown> = {}): Record<string, unknown> {
     method: 'GET',
     type: 'object_operation',
     target: 'showcase_task',
+    objectParams: { object: 'showcase_task', operation: 'find' },
     ...over,
   };
 }
@@ -109,7 +120,14 @@ describe('buildEndpointIndex', () => {
   });
 
   it('preserves an explicit authRequired: false', () => {
-    const index = buildEndpointIndex([endpoint({ authRequired: false })], makeLogger());
+    // The armed budget is not incidental: since #5189 an anonymous endpoint
+    // without one never reaches the index at all (ADR-0121 D6), so this is the
+    // only shape in which "authRequired: false survives the round trip" is
+    // still an observable fact.
+    const index = buildEndpointIndex(
+      [endpoint({ authRequired: false, rateLimit: { enabled: true, windowMs: 60000, maxRequests: 100 } })],
+      makeLogger(),
+    );
     expect(index.get('GET /api/v1/apps/showcase/tasks')!.authRequired).toBe(false);
   });
 
@@ -149,6 +167,100 @@ describe('parse failure — loud skip, no collateral damage', () => {
     expect(index.size).toBe(0);
     expect(logger.error).toHaveBeenCalledTimes(3);
     expect(logger.error.mock.calls[0][0]).toContain('<unnamed>');
+  });
+});
+
+describe('#5189 — publish gates re-applied at load (identity-free subset)', () => {
+  it('EXCLUDES an anonymous endpoint with no armed rate limit (ADR-0121 D6) and says so loudly', () => {
+    const logger = makeLogger();
+    const index = buildEndpointIndex([endpoint({ name: 'open_tasks', authRequired: false })], logger);
+
+    // The whole point: the route is gone, not served anonymously and unmetered.
+    expect(index.size).toBe(0);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    const [message, , meta] = logger.error.mock.calls[0];
+    expect(message).toContain('open_tasks');
+    expect(message).toContain('WITHOUT passing the');
+    expect(message).toContain('404');
+    expect(message).toContain('Republish');
+    // the gate's own prescription rides along
+    expect(message).toContain('authRequired: false');
+    expect(meta).toMatchObject({ name: 'open_tasks' });
+  });
+
+  it('EXCLUDES a rateLimit that is present but not armed — `enabled` defaults to false', () => {
+    const logger = makeLogger();
+    const index = buildEndpointIndex(
+      [endpoint({ name: 'open_tasks', authRequired: false, rateLimit: { windowMs: 60000, maxRequests: 100 } })],
+      logger,
+    );
+    expect(index.size).toBe(0);
+    expect(logger.error.mock.calls[0][0]).toContain('meters nothing');
+  });
+
+  it('SERVES an anonymous endpoint that carries an armed budget', () => {
+    const logger = makeLogger();
+    const index = buildEndpointIndex(
+      [
+        endpoint({
+          name: 'open_tasks',
+          authRequired: false,
+          rateLimit: { enabled: true, windowMs: 60000, maxRequests: 100 },
+        }),
+      ],
+      logger,
+    );
+    expect(index.get('GET /api/v1/apps/showcase/tasks')!.authRequired).toBe(false);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('EXCLUDES the other identity-free gate failures too — one judge, not a D6 special case', () => {
+    for (const bad of [
+      endpoint({ name: 'proxied', type: 'proxy', target: 'https://x.test' }),
+      endpoint({ name: 'no_params', objectParams: undefined }),
+      endpoint({ name: 'mapped', outputMapping: [{ source: 'a', target: 'b', transform: 'upper' }] }),
+      endpoint({ name: 'neg_cache', cacheTtl: -1 }),
+      endpoint({ name: 'post_cache', method: 'POST', cacheTtl: 30 }),
+    ]) {
+      const logger = makeLogger();
+      expect(buildEndpointIndex([bad], logger).size).toBe(0);
+      expect(logger.error).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('does NOT apply the namespace gate — the matcher has no stack identity to judge it with', () => {
+    // Outside any `apps/<ns>/` carve-out: publish rejects this (it knows the
+    // manifest), the index does not (it does not, and inferring one from the
+    // path being judged would be circular). It is simply unreachable in
+    // practice — the endpoint step only consults paths under that mount.
+    const logger = makeLogger();
+    const index = buildEndpointIndex([endpoint({ name: 'stray', path: '/api/v1/elsewhere' })], logger);
+    expect(index.has('GET /api/v1/elsewhere')).toBe(true);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('excludes a gate-failing item without disturbing the good ones', () => {
+    const logger = makeLogger();
+    const index = buildEndpointIndex(
+      [endpoint({ name: 'open_tasks', path: '/api/v1/apps/showcase/open', authRequired: false }), endpoint()],
+      logger,
+    );
+    expect([...index.keys()]).toEqual(['GET /api/v1/apps/showcase/tasks']);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('a gate-failing item does not take the route from a valid duplicate claimant', () => {
+    const logger = makeLogger();
+    // `a_tasks` would win the lexicographic tie-break — but it never claims,
+    // because it never passes the gates.
+    const index = buildEndpointIndex(
+      [endpoint({ name: 'a_tasks', authRequired: false }), endpoint({ name: 'z_tasks' })],
+      logger,
+    );
+    expect(index.get('GET /api/v1/apps/showcase/tasks')!.name).toBe('z_tasks');
+    // one gate error, and NO duplicate-claim error: there was never a duplicate
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error.mock.calls[0][0]).not.toContain('duplicate endpoint claim');
   });
 });
 

--- a/packages/metadata/src/endpoint-matcher.ts
+++ b/packages/metadata/src/endpoint-matcher.ts
@@ -49,6 +49,34 @@
  * "absence must be loud" (AGENTS.md, Route & surface ownership §3). Skipping
  * one bad item never disturbs the good ones.
  *
+ * ## The publish gates, applied a second time at load (#5189, #5040 E7b)
+ *
+ * Parsing is necessary and NOT sufficient. `ApiEndpointSchema` accepts shapes
+ * the runtime refuses and shapes ADR-0121 forbids — `type: 'proxy'`, a mapping
+ * `transform`, and above all `authRequired: false` with no armed `rateLimit`.
+ * E7 (#5111) hung the gates that reject those on `ObjectStackDefinitionSchema`,
+ * which covers every path that parses a STACK; #5189 proved that a stored `api`
+ * item need never have been part of one (`metadata.register()`, a Studio write,
+ * `publishPackage`). Most gates degrade safely when bypassed — the executor
+ * answers a structured 501, a mis-namespaced path simply matches nothing — but
+ * D6 has no runtime counterpart at all: the runtime honours `authRequired:
+ * false` faithfully and `deriveBucketConfig` returns `null` for a disarmed
+ * budget, so a bypassed D6 mints an anonymous, zero-quota execution entry
+ * point. That is the exact shape D6 exists to prevent.
+ *
+ * So every parsed item is re-judged here by
+ * {@link identityFreeEndpointGateFailure} — the SAME `firstFailure` the publish
+ * gate runs, minus the two gates that need an identity this module does not
+ * have. The asymmetry is deliberate and worth stating: the **namespace** gate
+ * needs `manifest.namespace` (a stored row carries no manifest, and deriving
+ * one from the very path being judged would be circular), and the
+ * **uniqueness** gate is a per-stack rule that the duplicate-claim resolution
+ * below already covers store-wide. An item failing an identity-free gate is
+ * EXCLUDED from the index and named at `error` level, exactly like a parse
+ * failure: a bypassed endpoint that answers 404 plus a loud log is the safe
+ * failure; one that answers anonymously and unmetered is not. Publish is the
+ * first door; this is the backstop, never the only door.
+ *
  * ## Duplicate claims
  *
  * Two stored items may claim the same METHOD+path (publish rejects that inside
@@ -72,7 +100,12 @@
  * have recovered.
  */
 
-import { ApiEndpointSchema, normalizeEndpointPath, type ApiEndpoint } from '@objectstack/spec/api';
+import {
+  ApiEndpointSchema,
+  identityFreeEndpointGateFailure,
+  normalizeEndpointPath,
+  type ApiEndpoint,
+} from '@objectstack/spec/api';
 import type { ApiEndpointMatch } from '@objectstack/spec/contracts';
 import type { Logger } from '@objectstack/spec/contracts';
 
@@ -145,6 +178,24 @@ export function buildEndpointIndex(items: readonly unknown[], logger: Logger): E
     }
 
     const endpoint = parsed.data;
+
+    // [#5189, #5040 E7b] Second door: the identity-free publish gates. A stored
+    // item that never passed publish is excluded rather than served — see the
+    // module header for why D6 in particular cannot be left to the runtime.
+    const gateFailure = identityFreeEndpointGateFailure(endpoint);
+    if (gateFailure) {
+      logger.error(
+        `[EndpointMatcher] stored api item '${endpoint.name}' was stored WITHOUT passing the ` +
+          `endpoint publish gates (#5040 E7 / ADR-0121) — it is EXCLUDED from endpoint matching and ` +
+          `its declared route will answer 404. Republish it through a gated path (a stack artifact, ` +
+          `or \`publishPackage\` with the package's \`manifest.namespace\`); a direct metadata write ` +
+          `is not a publish. Gate failure: ${gateFailure.message}`,
+        undefined,
+        { name: endpoint.name, issue: { path: gateFailure.path, message: gateFailure.message } },
+      );
+      continue;
+    }
+
     const key = endpointIndexKey(endpoint.method, endpoint.path);
     const incumbent = index.get(key);
 

--- a/packages/metadata/src/metadata-manager-match-endpoint.test.ts
+++ b/packages/metadata/src/metadata-manager-match-endpoint.test.ts
@@ -36,6 +36,12 @@ vi.mock('@objectstack/core', () => ({
   }),
 }));
 
+/**
+ * A stored `api` item that parses AND passes the identity-free publish gates
+ * the index applies since #5189 — `objectParams` is required for an
+ * `object_operation` (E7's target gate), so without it the item would be
+ * excluded from the index instead of matched.
+ */
 function endpoint(over: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     name: 'list_tasks',
@@ -43,6 +49,7 @@ function endpoint(over: Record<string, unknown> = {}): Record<string, unknown> {
     method: 'GET',
     type: 'object_operation',
     target: 'showcase_task',
+    objectParams: { object: 'showcase_task', operation: 'find' },
     ...over,
   };
 }
@@ -91,6 +98,34 @@ describe('#5089 — MetadataManager.matchEndpoint', () => {
   it('ignores items of other metadata types', async () => {
     await manager.register('action', 'list_tasks', endpoint());
     await expect(manager.matchEndpoint(TASKS)).resolves.toBeUndefined();
+  });
+
+  // ── #5189 (#5040 E7b) — the load-time backstop, end to end ─────────────
+  //
+  // `register()` is route 3 of #5189: a direct metadata write that no publish
+  // gate ever sees. Before the backstop it minted an anonymous, zero-quota
+  // execution entry point — the runtime honours `authRequired: false` and an
+  // unarmed budget meters nothing. It must now MISS.
+  describe('#5189 — a directly-registered item that never passed publish', () => {
+    it('does not match when it violates ADR-0121 D6 (anonymous + no armed budget)', async () => {
+      await manager.register('api', 'open_tasks', endpoint({ name: 'open_tasks', authRequired: false }));
+      await expect(manager.matchEndpoint(TASKS)).resolves.toBeUndefined();
+    });
+
+    it('matches once the same declaration arms its budget', async () => {
+      await manager.register(
+        'api',
+        'open_tasks',
+        endpoint({
+          name: 'open_tasks',
+          authRequired: false,
+          rateLimit: { enabled: true, windowMs: 60000, maxRequests: 100 },
+        }),
+      );
+      const match = await manager.matchEndpoint(TASKS);
+      expect(match?.endpoint.name).toBe('open_tasks');
+      expect(match?.endpoint.authRequired).toBe(false);
+    });
   });
 
   describe('invalidation', () => {

--- a/packages/metadata/src/metadata-manager.ts
+++ b/packages/metadata/src/metadata-manager.ts
@@ -49,6 +49,13 @@ import {
   MetadataEventSchema,
   type MetadataEvent as RealtimeMetadataEvent,
 } from '@objectstack/spec/api';
+// [#5189, #5040 E7b] The endpoint publish gates, reused verbatim — see
+// `gateApiItemsForPublish`.
+import {
+  ApiEndpointSchema,
+  validateApiEndpointDeclarations,
+  type ApiEndpoint,
+} from '@objectstack/spec/api';
 import { createLogger, type Logger } from '@objectstack/core';
 import { JSONSerializer } from './serializers/json-serializer.js';
 import { YAMLSerializer } from './serializers/yaml-serializer.js';
@@ -70,6 +77,19 @@ import type { ApiEndpointMatch } from '@objectstack/spec/contracts';
  * Watch callback function (legacy)
  */
 export type WatchCallback = (event: MetadataWatchEvent) => void | Promise<void>;
+
+/**
+ * [#5189] Appended to the namespace gate's message when `publishPackage` was
+ * called without one, because the gate's own text ("declare an explicit
+ * `manifest.namespace`") describes a stack file this caller may not have.
+ */
+const PUBLISH_NAMESPACE_REMEDY =
+  'From `MetadataManager.publishPackage` specifically: this method indexes items by `packageId` and '
+  + 'carries no manifest, so it cannot prove a namespace on its own and will not infer one from the '
+  + 'items being published (an author-supplied value would make the carve-out gate vacuous). Pass the '
+  + "package's explicit namespace as `publishPackage(id, { namespace })`, or publish the endpoints as "
+  + 'part of a stack artifact (`defineStack` → compile → artifact ingest), which carries the manifest '
+  + 'and runs these same gates at parse time.';
 
 /**
  * RFC-4122 v4 uuid for realtime `MetadataEvent.id` (#4602).
@@ -805,11 +825,32 @@ export class MetadataManager implements IMetadataService {
    * 2. Snapshot all items in the package (publishedDefinition = clone(metadata))
    * 3. Increment version
    * 4. Set all items state → active
+   *
+   * [#5189, #5040 E7b] Step 1 additionally runs the **endpoint publish gates**
+   * over every `api` item — see {@link gateApiItemsForPublish}. That pass is
+   * NOT governed by `options.validate`: the gates are a contract, not a
+   * lint (ADR-0121 D6 says publish REJECTS an unmetered anonymous endpoint),
+   * and an opt-out flag on a security gate is the bypass this issue closed.
    */
   async publishPackage(packageId: string, options?: {
     changeNote?: string;
     publishedBy?: string;
     validate?: boolean;
+    /**
+     * [#5189] The package manifest's EXPLICIT `manifest.namespace` (ADR-0121
+     * D2), supplied by a caller that holds the manifest.
+     *
+     * `MetadataManager` has no manifest concept — it indexes items by
+     * `packageId` and nothing else — so it cannot prove a namespace on its
+     * own, and an `api` item's own `namespace`-ish fields are author-supplied
+     * data, not identity (reading them would make the D1/D2 carve-out gate
+     * vacuous: an author would simply declare the namespace their path
+     * already uses). Absent this option the namespace gate fails and `api`
+     * items in the package cannot publish through this path — which is the
+     * correct outcome, not a limitation to route around: a publish that
+     * cannot prove a namespace must not mint a URL under one.
+     */
+    namespace?: string;
   }): Promise<PackagePublishResult> {
     const now = new Date().toISOString();
     const shouldValidate = options?.validate !== false;
@@ -837,10 +878,19 @@ export class MetadataManager implements IMetadataService {
       };
     }
 
+    const validationErrors: Array<{ type: string; name: string; message: string }> = [];
+
+    // [#5189, #5040 E7b] Endpoint publish gates — ALWAYS, `validate: false`
+    // included. Every other check in this method is a best-effort quality
+    // check whose opt-out is a convenience; these gates decide whether an
+    // externally reachable, possibly ANONYMOUS execution entry point comes
+    // into existence, and ADR-0121 D6 has no runtime counterpart to catch what
+    // slips through. A flag that turns them off would be exactly the bypass
+    // #5189 filed.
+    validationErrors.push(...this.gateApiItemsForPublish(packageItems, options?.namespace));
+
     // Validation pass
     if (shouldValidate) {
-      const validationErrors: Array<{ type: string; name: string; message: string }> = [];
-
       // Schema validation
       for (const item of packageItems) {
         const result = await this.validate(item.type, item.data);
@@ -883,17 +933,17 @@ export class MetadataManager implements IMetadataService {
           }
         }
       }
+    }
 
-      if (validationErrors.length > 0) {
-        return {
-          success: false,
-          packageId,
-          version: 0,
-          publishedAt: now,
-          itemsPublished: 0,
-          validationErrors,
-        };
-      }
+    if (validationErrors.length > 0) {
+      return {
+        success: false,
+        packageId,
+        version: 0,
+        publishedAt: now,
+        itemsPublished: 0,
+        validationErrors,
+      };
     }
 
     // Determine the next version by finding the max current version across items
@@ -924,6 +974,98 @@ export class MetadataManager implements IMetadataService {
       publishedAt: now,
       itemsPublished: packageItems.length,
     };
+  }
+
+  /**
+   * [#5189, #5040 E7b] Run the endpoint publish gates over a package's `api`
+   * items and report every failure as a publish-blocking validation error.
+   *
+   * ## Why this exists at all
+   *
+   * E7 (#5111) hung the five per-endpoint gates on
+   * `ObjectStackDefinitionSchema`, which covers every path that parses a
+   * STACK — `defineStack`, `os validate`, the lint scorer, artifact ingest,
+   * `EnvironmentArtifactSchema.metadata`. It does not cover this one: an `api`
+   * item can be minted item-by-item (`metadata.register()`, a Studio write)
+   * and published here without a stack ever being parsed. Three of the gates
+   * degrade safely when bypassed (the executor answers a structured 501; a
+   * mis-namespaced path matches nothing), but **ADR-0121 D6 has no runtime
+   * counterpart**: `authRequired: false` is honoured faithfully and an
+   * unarmed `rateLimit` meters nothing, so the bypass mints an anonymous,
+   * zero-quota execution entry point. Hence a gate here, on the same
+   * function, rather than a second set of criteria that would drift.
+   *
+   * ## What it judges, and on what
+   *
+   * The registry stores either a raw spec document or a publish envelope
+   * (`{ name, packageId, state, metadata: {…spec} }`); the endpoint is read
+   * out with the SAME rule this method's caller uses for
+   * `publishedDefinition` (`data.metadata ?? data`), so publish gates exactly
+   * the document publish is about to snapshot. An item that does not satisfy
+   * `ApiEndpointSchema` fails here too — not extra strictness but a
+   * precondition: an unparsed shape cannot be gated, and it could never be
+   * served either (the matcher's own loud skip refuses it at load).
+   *
+   * @param packageItems every item collected for this package (all types).
+   * @param namespace the caller-supplied `manifest.namespace`; `undefined`
+   *   fails the namespace gate, deliberately — see `publishPackage`'s option.
+   * @returns one entry per gate failure, `[]` when the package declares no
+   *   `api` items (a package without endpoints is untouched by this pass).
+   */
+  private gateApiItemsForPublish(
+    packageItems: Array<{ type: string; name: string; data: any }>,
+    namespace: string | undefined,
+  ): Array<{ type: string; name: string; message: string }> {
+    const apiItems = packageItems.filter(i => i.type === MetadataManager.ENDPOINT_METADATA_TYPE);
+    if (apiItems.length === 0) return [];
+
+    const errors: Array<{ type: string; name: string; message: string }> = [];
+    /** Parsed endpoints, index-aligned with the items that produced them. */
+    const endpoints: ApiEndpoint[] = [];
+    const gatedItems: Array<{ name: string }> = [];
+
+    for (const item of apiItems) {
+      const document = item.data?.metadata ?? item.data;
+      const parsed = ApiEndpointSchema.safeParse(document);
+      if (!parsed.success) {
+        for (const issue of parsed.error.issues) {
+          errors.push({
+            type: item.type,
+            name: item.name,
+            message:
+              `api item '${item.name}' does not satisfy ApiEndpointSchema and cannot be published: `
+              + `${issue.message} (at ${issue.path.join('.') || '<root>'}). An endpoint that does not `
+              + `parse cannot be gated and would be excluded from endpoint matching at load anyway.`,
+          });
+        }
+        continue;
+      }
+      endpoints.push(parsed.data);
+      gatedItems.push({ name: item.name });
+    }
+
+    for (const issue of validateApiEndpointDeclarations(endpoints, { namespace })) {
+      // The gate reports per-endpoint issues at `['apis', <index>, …]` and the
+      // namespace PRECONDITION once at `['apis']` — the latter is a property of
+      // the publish call, not of any one endpoint, so it is reported once with
+      // this path's own remedy appended.
+      const index = typeof issue.path[1] === 'number' ? issue.path[1] : undefined;
+      if (index === undefined) {
+        errors.push({
+          type: MetadataManager.ENDPOINT_METADATA_TYPE,
+          name: '',
+          message: `${issue.message} ${PUBLISH_NAMESPACE_REMEDY}`,
+        });
+        continue;
+      }
+      errors.push({
+        type: MetadataManager.ENDPOINT_METADATA_TYPE,
+        name: gatedItems[index]?.name ?? '',
+        message: issue.message,
+      });
+    }
+
+    return errors;
   }
 
   /**

--- a/packages/metadata/src/publish-endpoint-gate.test.ts
+++ b/packages/metadata/src/publish-endpoint-gate.test.ts
@@ -1,0 +1,241 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #5189 (#5040 E7b) — `publishPackage` runs the endpoint publish gates.
+ *
+ * E7 (#5111) hung the five per-endpoint gates on `ObjectStackDefinitionSchema`,
+ * covering every path that parses a STACK. This file pins the path that never
+ * does: an `api` item minted item-by-item (`metadata.register()`, a Studio
+ * write) and promoted by `publishPackage`, which before #5189 reached `state:
+ * 'active'` without any gate seeing it. The one that mattered is ADR-0121 D6 —
+ * `authRequired: false` with no armed `rateLimit` — because it is the only gate
+ * with NO runtime counterpart: the executor honours anonymous access faithfully
+ * and an unarmed budget meters nothing, so the bypass minted an anonymous,
+ * zero-quota execution entry point.
+ *
+ * The load-time half of the backstop lives in `endpoint-matcher.test.ts`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MetadataManager } from './metadata-manager.js';
+import { MemoryLoader } from './loaders/memory-loader.js';
+
+vi.mock('@objectstack/core', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const PKG = 'com.acme.endpoints';
+const NS = 'acme';
+
+/** A stored `api` item that passes every gate under `namespace: 'acme'`. */
+function apiItem(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: 'list_things',
+    path: `/api/v1/apps/${NS}/things`,
+    method: 'GET',
+    type: 'object_operation',
+    target: 'acme_thing',
+    objectParams: { object: 'acme_thing', operation: 'find' },
+    packageId: PKG,
+    state: 'draft',
+    ...over,
+  };
+}
+
+describe('#5189 — publishPackage gates `api` items', () => {
+  let manager: MetadataManager;
+
+  beforeEach(() => {
+    manager = new MetadataManager({ formats: ['json'], loaders: [new MemoryLoader()] });
+  });
+
+  // ── The security case: ADR-0121 D6 ─────────────────────────────────────
+  describe('ADR-0121 D6 — anonymous requires an ARMED budget', () => {
+    it('REJECTS an `authRequired: false` endpoint with no rateLimit, naming the endpoint and the key', async () => {
+      await manager.register('api', 'open_things', apiItem({ name: 'open_things', authRequired: false }));
+
+      const result = await manager.publishPackage(PKG, { namespace: NS });
+
+      expect(result.success).toBe(false);
+      expect(result.itemsPublished).toBe(0);
+      const errors = result.validationErrors ?? [];
+      expect(errors.length).toBeGreaterThan(0);
+      const d6 = errors.find(e => e.message.includes('authRequired: false'));
+      expect(d6).toBeDefined();
+      // names the endpoint …
+      expect(d6!.name).toBe('open_things');
+      expect(d6!.type).toBe('api');
+      expect(d6!.message).toContain('open_things');
+      // … and the key to fix, with the armed spelling.
+      expect(d6!.message).toContain('rateLimit');
+      expect(d6!.message).toContain('enabled: true');
+    });
+
+    it('REJECTS a rateLimit that is present but NOT armed (`enabled` defaults to false)', async () => {
+      await manager.register(
+        'api',
+        'open_things',
+        apiItem({
+          name: 'open_things',
+          authRequired: false,
+          rateLimit: { windowMs: 60000, maxRequests: 100 },
+        }),
+      );
+
+      const result = await manager.publishPackage(PKG, { namespace: NS });
+      expect(result.success).toBe(false);
+      expect(result.validationErrors!.some(e => e.message.includes('meters nothing'))).toBe(true);
+    });
+
+    it('PUBLISHES an anonymous endpoint that carries an armed budget', async () => {
+      await manager.register(
+        'api',
+        'open_things',
+        apiItem({
+          name: 'open_things',
+          authRequired: false,
+          rateLimit: { enabled: true, windowMs: 60000, maxRequests: 100 },
+        }),
+      );
+
+      const result = await manager.publishPackage(PKG, { namespace: NS });
+      expect(result.success).toBe(true);
+      expect(result.itemsPublished).toBe(1);
+      const stored = (await manager.get('api', 'open_things')) as Record<string, unknown>;
+      expect(stored.state).toBe('active');
+    });
+
+    it('is NOT opt-outable with `validate: false` — a gate is not a lint', async () => {
+      await manager.register('api', 'open_things', apiItem({ name: 'open_things', authRequired: false }));
+
+      const result = await manager.publishPackage(PKG, { namespace: NS, validate: false });
+      expect(result.success).toBe(false);
+      expect(result.validationErrors!.some(e => e.message.includes('authRequired: false'))).toBe(true);
+    });
+  });
+
+  // ── The rest of the gates come along, because it is ONE function ────────
+  describe('the other gates ride the same call', () => {
+    it('rejects an unsupported target type (`proxy`)', async () => {
+      await manager.register('api', 'proxied', apiItem({ name: 'proxied', type: 'proxy', target: 'https://x.test' }));
+      const result = await manager.publishPackage(PKG, { namespace: NS });
+      expect(result.success).toBe(false);
+      expect(result.validationErrors!.some(e => e.message.includes("type: 'proxy'"))).toBe(true);
+    });
+
+    it('rejects a path outside the stack carve-out (ADR-0121 D1)', async () => {
+      await manager.register('api', 'list_things', apiItem({ path: '/api/v1/things' }));
+      const result = await manager.publishPackage(PKG, { namespace: NS });
+      expect(result.success).toBe(false);
+      expect(result.validationErrors!.some(e => e.message.includes('carve-out'))).toBe(true);
+    });
+
+    it('rejects two items claiming the same METHOD + normalized path', async () => {
+      await manager.register('api', 'a_things', apiItem({ name: 'a_things' }));
+      await manager.register('api', 'b_things', apiItem({ name: 'b_things', path: `/api/v1/apps/${NS}/things/` }));
+
+      const result = await manager.publishPackage(PKG, { namespace: NS });
+      expect(result.success).toBe(false);
+      expect(result.validationErrors!.some(e => e.message.includes('already claimed by endpoint'))).toBe(true);
+    });
+
+    it('reports EVERY bad endpoint, not just the first', async () => {
+      await manager.register('api', 'bad_one', apiItem({ name: 'bad_one', type: 'proxy', target: 'https://x.test' }));
+      await manager.register('api', 'bad_two', apiItem({ name: 'bad_two', path: '/api/v1/elsewhere', method: 'POST' }));
+
+      const result = await manager.publishPackage(PKG, { namespace: NS });
+      expect(result.success).toBe(false);
+      const named = (result.validationErrors ?? []).map(e => e.name);
+      expect(named).toContain('bad_one');
+      expect(named).toContain('bad_two');
+    });
+  });
+
+  // ── Identity: this path cannot prove a namespace on its own ─────────────
+  describe('namespace identity (ADR-0121 D2 / #5040 Q1 = A)', () => {
+    it('refuses to publish `api` items when no namespace was supplied, and says why HERE', async () => {
+      await manager.register('api', 'list_things', apiItem());
+
+      const result = await manager.publishPackage(PKG);
+
+      expect(result.success).toBe(false);
+      const precondition = result.validationErrors!.find(e => e.message.includes('manifest.namespace'));
+      expect(precondition).toBeDefined();
+      // Reported ONCE, against the type rather than any one endpoint …
+      expect(precondition!.name).toBe('');
+      expect(precondition!.type).toBe('api');
+      // … and carries this call's own remedy, not only the stack-file one.
+      expect(precondition!.message).toContain('publishPackage(id, { namespace })');
+    });
+
+    it('does NOT infer the namespace from the item being judged', async () => {
+      // The item declares a `namespace` field and a matching path; believing it
+      // would make the carve-out gate vacuous.
+      await manager.register('api', 'list_things', apiItem({ namespace: NS }));
+
+      const result = await manager.publishPackage(PKG);
+      expect(result.success).toBe(false);
+      expect(result.validationErrors!.some(e => e.message.includes('manifest.namespace'))).toBe(true);
+    });
+  });
+
+  // ── Precondition + blast radius ────────────────────────────────────────
+  describe('shape and scope', () => {
+    it('rejects an `api` item that does not satisfy ApiEndpointSchema', async () => {
+      await manager.register('api', 'broken', { name: 'broken', path: '/api/v1/apps/acme/x', packageId: PKG });
+
+      const result = await manager.publishPackage(PKG, { namespace: NS });
+      expect(result.success).toBe(false);
+      expect(result.validationErrors!.some(e => e.message.includes('ApiEndpointSchema'))).toBe(true);
+    });
+
+    it('reads a publish ENVELOPE\'s `metadata` — the same document publish snapshots', async () => {
+      await manager.register('api', 'open_things', {
+        name: 'open_things',
+        packageId: PKG,
+        state: 'draft',
+        metadata: apiItem({ name: 'open_things', authRequired: false }),
+      });
+
+      const result = await manager.publishPackage(PKG, { namespace: NS });
+      expect(result.success).toBe(false);
+      expect(result.validationErrors!.some(e => e.message.includes('authRequired: false'))).toBe(true);
+    });
+
+    it('leaves a package with no `api` items completely untouched', async () => {
+      await manager.register('object', 'acme_thing', {
+        name: 'acme_thing', label: 'Thing', packageId: PKG, state: 'draft',
+        metadata: { fields: ['name'] },
+      });
+      await manager.register('view', 'thing_list', {
+        name: 'thing_list', label: 'Things', packageId: PKG, state: 'draft',
+        metadata: { columns: ['name'] },
+      });
+
+      // No namespace supplied, and none needed: the gate pass returns early.
+      const result = await manager.publishPackage(PKG);
+      expect(result.success).toBe(true);
+      expect(result.itemsPublished).toBe(2);
+    });
+
+    it('fails the WHOLE publish, leaving the good items unpublished (publish is atomic)', async () => {
+      await manager.register('api', 'good_things', apiItem({ name: 'good_things' }));
+      await manager.register('api', 'open_things', apiItem({
+        name: 'open_things',
+        path: `/api/v1/apps/${NS}/open`,
+        authRequired: false,
+      }));
+
+      const result = await manager.publishPackage(PKG, { namespace: NS });
+      expect(result.success).toBe(false);
+      const good = (await manager.get('api', 'good_things')) as Record<string, unknown>;
+      expect(good.state).toBe('draft');
+      expect(good.publishedDefinition).toBeUndefined();
+    });
+  });
+});

--- a/packages/spec/api-surface.json
+++ b/packages/spec/api-surface.json
@@ -2541,6 +2541,8 @@
     "EnablePackageRequestSchema (const)",
     "EnablePackageResponse (type)",
     "EnablePackageResponseSchema (const)",
+    "EndpointGateIdentity (interface)",
+    "EndpointGateIssue (interface)",
     "EndpointMapping (const)",
     "EndpointMappingKey (type)",
     "EndpointRegistry (type)",
@@ -3124,9 +3126,11 @@
     "envelopeViolations (function)",
     "getAuthEndpointUrl (function)",
     "getDefaultRouteRegistrations (function)",
+    "identityFreeEndpointGateFailure (function)",
     "normalizeEndpointPath (function)",
     "readServiceSelfInfo (function)",
-    "standardErrorCodeForHttpStatus (function)"
+    "standardErrorCodeForHttpStatus (function)",
+    "validateApiEndpointDeclarations (function)"
   ],
   "./ui": [
     "ACTION_LOCATIONS (const)",

--- a/packages/spec/src/api/apis-publish-gates.test.ts
+++ b/packages/spec/src/api/apis-publish-gates.test.ts
@@ -35,6 +35,7 @@ import { describe, it, expect } from 'vitest';
 
 import { ObjectStackDefinitionSchema, defineStack } from '../stack.zod';
 import { ApiEndpointSchema, normalizeEndpointPath } from './endpoint.zod';
+import { identityFreeEndpointGateFailure, validateApiEndpointDeclarations } from './endpoint-publish-gate';
 
 const manifest = {
   id: 'com.example.apis',
@@ -495,5 +496,72 @@ describe('[#5111] the `ApiEndpoint` vocabulary itself is untouched', () => {
     // Guards the guard: the vocabulary must still be a real schema, not an
     // `any` that would make the assertions above meaningless.
     expect(() => ApiEndpointSchema.parse({ name: 'Bad Name', path: 'no-slash' })).toThrow();
+  });
+});
+
+// ============================================================================
+// [#5189 / #5040 E7b] The identity-free subset, for consumers holding one
+// stored endpoint and no stack.
+// ============================================================================
+
+describe('identityFreeEndpointGateFailure — the same judge, minus stack identity', () => {
+  it('passes an endpoint that passes the full gates', () => {
+    expect(identityFreeEndpointGateFailure(ApiEndpointSchema.parse(validObjectEndpoint))).toBeUndefined();
+  });
+
+  it('still refuses D6 — the gate with no runtime counterpart, and the reason #5189 exists', () => {
+    const failure = identityFreeEndpointGateFailure(
+      ApiEndpointSchema.parse({ ...validObjectEndpoint, cacheTtl: undefined, authRequired: false }),
+    );
+    expect(failure).toBeDefined();
+    expect(failure!.path).toEqual(['rateLimit']);
+    expect(failure!.message).toContain('authRequired: false');
+    expect(failure!.message).toContain('enabled: true');
+  });
+
+  it('accepts an anonymous endpoint whose budget is ARMED', () => {
+    expect(
+      identityFreeEndpointGateFailure(
+        ApiEndpointSchema.parse({
+          ...validObjectEndpoint,
+          cacheTtl: undefined,
+          authRequired: false,
+          rateLimit: { enabled: true, windowMs: 60000, maxRequests: 100 },
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it('still refuses the target, mapping and policy gates', () => {
+    const cases: Array<[Record<string, unknown>, (string | number)[]]> = [
+      [{ type: 'proxy', target: 'https://x.test', objectParams: undefined }, ['type']],
+      [{ objectParams: { object: 'showcase_task' } }, ['objectParams']],
+      [{ outputMapping: [{ source: 'a', target: 'b', transform: 'upper' }] }, ['outputMapping', 0, 'transform']],
+      [{ cacheTtl: -1 }, ['cacheTtl']],
+    ];
+    for (const [over, path] of cases) {
+      const failure = identityFreeEndpointGateFailure(
+        ApiEndpointSchema.parse({ ...validObjectEndpoint, ...over }),
+      );
+      expect(failure).toBeDefined();
+      // Paths are relative to the ENDPOINT, not to a stack's `apis:` array.
+      expect(failure!.path).toEqual(path);
+    }
+  });
+
+  it('does NOT judge the namespace — that gate needs a manifest this caller does not have', () => {
+    // The full gate rejects this path under `namespace: 'showcase'`; the
+    // identity-free subset cannot, and must not pretend to.
+    const stray = ApiEndpointSchema.parse({ ...validObjectEndpoint, path: '/api/v1/elsewhere' });
+    expect(identityFreeEndpointGateFailure(stray)).toBeUndefined();
+    expect(validateApiEndpointDeclarations([stray], { namespace: 'showcase' })).toHaveLength(1);
+  });
+
+  it('does NOT judge uniqueness — a single endpoint has no siblings to collide with', () => {
+    const one = ApiEndpointSchema.parse(validObjectEndpoint);
+    expect(identityFreeEndpointGateFailure(one)).toBeUndefined();
+    expect(identityFreeEndpointGateFailure(one)).toBeUndefined();
+    // …while the full gate still catches the pair.
+    expect(validateApiEndpointDeclarations([one, one], { namespace: 'showcase' })).toHaveLength(1);
   });
 });

--- a/packages/spec/src/api/endpoint-publish-gate.ts
+++ b/packages/spec/src/api/endpoint-publish-gate.ts
@@ -208,6 +208,46 @@ export function validateApiEndpointDeclarations(
     return issues;
 }
 
+/**
+ * The IDENTITY-FREE gates for ONE already-parsed endpoint (#5189, #5040 E7b).
+ *
+ * Everything {@link validateApiEndpointDeclarations} judges EXCEPT the two
+ * gates that need a stack identity the caller may not have:
+ *
+ *  - the **namespace** gate (ADR-0121 D1/D2) needs `manifest.namespace`, and
+ *  - the **uniqueness** gate needs the sibling declarations of the same stack.
+ *
+ * Everything else — supported subset, mapping, policy (D6 included) — is
+ * judgeable from the endpoint alone, so a consumer holding a single stored
+ * declaration and no manifest can still refuse the shapes the runtime cannot
+ * serve. The load-time backstop in the endpoint matcher
+ * (`packages/metadata/src/endpoint-matcher.ts`) is exactly that consumer: a
+ * declaration reaches the store through paths that never saw a manifest
+ * (a direct `metadata.register()`, a Studio write), and D6 is the one gate
+ * with no runtime counterpart — an unmetered anonymous endpoint executes
+ * faithfully, which is precisely what D6 exists to prevent (#5189).
+ *
+ * Additive on purpose: it delegates to the SAME {@link firstFailure} the
+ * full gate runs, so publish-time and load-time can never grow two opinions
+ * of what is servable. The issue `path` it returns is relative to the
+ * endpoint itself (`['rateLimit']`), not to a stack's `apis:` array.
+ *
+ * @returns the first gate failure, or `undefined` when the endpoint passes
+ *          every identity-free gate.
+ */
+export function identityFreeEndpointGateFailure(endpoint: ApiEndpoint): EndpointGateIssue | undefined {
+    return firstFailure(
+        endpoint,
+        `Endpoint '${endpoint.name}'`,
+        (...rest) => rest,
+        // No mount → `namespaceGate` returns undefined (it is "already reported
+        // once, against `apis`" in the full run); no claims → `uniquenessGate`
+        // has nothing to collide with. Both asymmetries are the point.
+        undefined,
+        new Map(),
+    );
+}
+
 /** The normalized claim key — the matcher's own index key (`endpointIndexKey`). */
 function claimKey(endpoint: ApiEndpoint): string {
     return `${endpoint.method.toUpperCase()} ${normalizeEndpointPath(endpoint.path)}`;

--- a/packages/spec/src/api/index.ts
+++ b/packages/spec/src/api/index.ts
@@ -15,6 +15,21 @@
 
 export * from './contract.zod';
 export * from './endpoint.zod';
+// [#5189, #5040 E7b] The per-endpoint publish gates. #5111 kept this module
+// package-internal because its only consumer was `ObjectStackDefinitionSchema`,
+// one file away. #5189 proved the stack schema is NOT the only door: a
+// `MetadataManager.publishPackage` / `metadata.register()` / Studio write mints
+// an `api` item without ever parsing a stack, and ADR-0121 D6 (anonymous
+// endpoints must carry an armed budget) has no runtime counterpart to catch it.
+// The gate therefore becomes public so the metadata layer can reuse the SAME
+// criteria at publish and at index-build time — one judge, three doors, rather
+// than a second implementation that drifts.
+export {
+    validateApiEndpointDeclarations,
+    identityFreeEndpointGateFailure,
+    type EndpointGateIssue,
+    type EndpointGateIdentity,
+} from './endpoint-publish-gate';
 export * from './discovery.zod';
 export * from './events.zod';
 export * from './realtime-shared.zod';


### PR DESCRIPTION
Fixes #5189
Part-of #5040(E7b)。前置 PR #5188(`d21c001`)已落 main,门函数在。

## 事实

E7(#5111)把五道逐端点门挂在 `ObjectStackDefinitionSchema` 上,覆盖了所有**解析 stack** 的入径。#5189 证实:一条存量 `api` 条目根本不必属于任何 stack —— `MetadataManager.publishPackage`、直接 `metadata.register()`、Studio 元数据写接口,三条路各自逐条造条目,**一道门都没经过**。

绕过后的后果按门分化:

- 不支持子集 / 映射 / 命名空间三类门**有安全的降级**:执行链答结构化 501 并点名条目;落在 `apps/{namespace}/` carve-out 之外的路径干脆匹配不上;
- **ADR-0121 D6 没有任何运行时对偶**:运行时忠实执行 `authRequired: false`,而 `deriveBucketConfig` 对 `enabled` 非 `true` 的预算返回 `null`、不计量。于是绕过铸出一个**匿名可达、零配额的执行入口** —— 正是 D6 要防的形状。

## 处置:两道门,一个判据

采用 issue 建议的 **A + C**,关键在于两层跑的是**同一个门函数**,不产生第二套判据。

**1. Publish 层** —— `publishPackage` 对包内 `api` 条目跑 `validateApiEndpointDeclarations`,失败即在它**既有的** `validationErrors` 出口上让整次发布失败(发布本就是原子的),逐条点名端点与待修的 key。

这一遍**不受 `options.validate` 管辖**:其余检查都是尽力而为的质量检查,关掉是便利;这道门决定的是「一个对外可达、可能匿名的执行入口是否诞生」,而 D6 没有运行时对偶接得住漏网的。**给安全门加开关,就是本单要关掉的那个绕过。**

不满足 `ApiEndpointSchema` 的条目也在此失败 —— 这不是额外严格,而是前置条件:没解析出来的形状无从过门,而且它在装载期也会被匹配器的响亮跳过拒之门外。

**2. Load 层(纵深防御)** —— `buildEndpointIndex` 对每条已解析条目再跑一遍**免身份子集**(不支持子集 / 映射 / policy 含 D6),经新增的 `identityFreeEndpointGateFailure` 委托给全量门**同一个** `firstFailure`。未过门的条目被**排除出索引**,并以与解析失败跳过相同的 `error` 级别点名。绕过因此从「匿名零配额可执行」变成「404 + 一条响亮日志」—— 安全的失败姿态。

**刻意不对称,值得写明**:命名空间门与唯一性门**不在**装载期施加。前者需要 `manifest.namespace`,而一条存量行不携带 manifest —— 从「正被审判的那条 path」反推命名空间是循环论证;后者是 per-stack 规则,而下方既有的重复认领裁决已在全库范围覆盖同一问题。

## 身份:publishPackage 知道命名空间吗?

**不知道。** `MetadataManager` 只按 `packageId` 索引条目,不存在 manifest 概念(全文件无 `manifest` 一词)。

因此新增**加性**选项 `publishPackage(id, { namespace })`:持有 manifest 的调用方传入显式 `manifest.namespace`,即可跑全量门;不传则命名空间门失败,该包的 `api` 条目**发不出去** —— 这是规则本身,不是待绕开的限制(一次无法证明命名空间的发布,不该在某个命名空间下铸出 URL)。

它**不会**从被审判的条目里反推命名空间:条目上的 `namespace` 是作者填的数据,不是身份,采信它会让 D1/D2 的 carve-out 门**形同虚设**(作者只需把命名空间填成自己 path 已经用的那个)。不含 `api` 条目的包完全不受影响(该遍直接早返回)。

## 契约面

`packages/spec/src/api/index.ts` 导出门模块的四个公共名(#5111 时它是包内私有,因为唯一消费者就在隔壁文件;#5189 证明 stack schema 不是唯一的门)。`api-surface.json` 恰好只在 `./api` 上多这四项:

```
+ EndpointGateIdentity (interface)
+ EndpointGateIssue (interface)
+ identityFreeEndpointGateFailure (function)
+ validateApiEndpointDeclarations (function)
```

门模块自身的判定逻辑**一字未改**,只加了一个委托给同一 `firstFailure` 的加性导出。

## 测试夹具的一处修正

`endpoint-matcher.test.ts` / `metadata-manager-match-endpoint.test.ts` 的基础夹具补上了 E7 target 门要求的 `objectParams`。没有它,那个夹具描述的是一条运行时会答 501 的端点 —— 装载期门(正确地)把它排除,于是它作为夹具也就没了意义。同理,`preserves an explicit authRequired: false` 一例补上了已装配的预算:D6 之后,那是「`authRequired: false` 能原样往返」仍然可观测的唯一形状。

## 验证

```
pnpm --filter @objectstack/spec test        → Test Files 305 passed | Tests 7809 passed
pnpm --filter @objectstack/metadata test    → Test Files  18 passed | Tests  407 passed
pnpm --filter @objectstack/spec typecheck   → Done(0 error)
pnpm --filter @objectstack/spec check:generated → ✓ All 8 generated artifacts are up to date
pnpm --filter @objectstack/spec check:exported-any        → ✅ 1843 types + 1594 schemas,无 any
pnpm --filter @objectstack/spec check:dual-source-exports → ✅ 4248 names,0 dual-source
pnpm check:adr-anchors / check:durability-log-level / check:startup-registry-verdict → 全 OK
pnpm check:type-check-coverage → OK(62/77 covered;metadata 仍在 DEBT 账,新增文件 0 error)
eslint(全部改动文件)→ 无输出
```

`@objectstack/metadata` 的 `tsc --noEmit` 原始报错全部落在既有测试文件的 TS2835(无扩展名相对导入,既有债),本 PR 新增/改动的源文件与新测试文件 **0 error**。

新增测试:

- **publish 层**(`packages/metadata/src/publish-endpoint-gate.test.ts`,15 例)—— D6 无限流被拒并点名端点+key;`rateLimit` 存在但未装配(`enabled` 默认 `false`)被拒;装配后放行;`validate: false` 关不掉;其余四门同行;命名空间缺失时只报一次并带本路径自己的补救;不从条目反推命名空间;发布信封 `metadata` 与裸文档两种存储形状都读得对;无 `api` 条目的包零影响;一条坏端点让整包发布失败、好条目仍是 draft。
- **load 层**(`endpoint-matcher.test.ts` +8 例,`metadata-manager-match-endpoint.test.ts` +2 例)—— D6 违规条目被排除、日志响亮、匹配器 miss;装配预算后可服务;其余免身份门同样排除;命名空间门**不**施加(并写明为何);未过门条目**不**从合法的重复认领者手里抢走路由;既有的响亮跳过与重复认领测试全绿。
- **spec 层**(`apis-publish-gates.test.ts` +6 例)—— 免身份子集与全量门的一致性,以及两处不对称(命名空间、唯一性)的正反两面。

## 变更集

`.changeset/endpoint-publish-gate-backstop.md` —— `@objectstack/spec` minor(新导出)+ `@objectstack/metadata` minor(新 `namespace` 选项 + 发布/装载行为收紧)。未触碰 `content/docs/releases/`。

## 越范围发现(已另行归档,不在本 PR 内修)

**#5206** —— `api` 根本不在 `DEFAULT_METADATA_TYPE_REGISTRY` / `BUILTIN_METADATA_TYPE_SCHEMAS` 里,所以 `metadata-protocol` 的 `saveMetaItem` 对 `api` 条目**一道校验都不跑**(比 #5189 正文推断的「只按 `ApiEndpointSchema` 校验」还弱一层);同时 `publishPackageDrafts`(Studio「全部发布」的真实入径)也没有第一道门。本 PR 的第二层已经兜住了它的**安全**后果(未过门条目一律不进索引),因此 #5206 降级为「拒绝得晚、而非拒绝不了」+「活类型没有契约」,不再是安全洞。文件面在 `packages/metadata-protocol` + `packages/spec/src/kernel`,与本单互斥。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYGdmvWP1ieZSLqvAW6uyd