### PR TITLE
fix(objectql,service-queue): lifecycle settings 覆盖不再能绕过消费者的保留窗下限 (#5195)

### DIFF
--- a/.changeset/lifecycle-retention-floor.md
+++ b/.changeset/lifecycle-retention-floor.md
@@ -1,0 +1,74 @@
+---
+"@objectstack/objectql": minor
+"@objectstack/service-queue": patch
+---
+
+fix(objectql,service-queue): a `lifecycle` settings override can no longer undercut a consumer's retention floor (#5195)
+
+ADR-0057 P4 lets an operator override any object's retention window per
+environment and per tenant through the `lifecycle` settings namespace. Until now
+the only validation on that override was **does it parse** — and a retention
+window is not only the operator's business: other code can depend on the rows
+still being there.
+
+`sys_job_queue` is the worked example. `DbQueueAdapter` deduplicates publishes by
+comparing a terminal row's `created_at` against its idempotency window, so the
+dedup check only means anything while that row still exists; #5179 made the
+ordering an invariant by refusing, at construction, an idempotency window longer
+than the object's **declared** retention. A settings override the constructor
+cannot see walks straight around it:
+
+```jsonc
+// lifecycle → retention_overrides
+{ "sys_job_queue": { "maxAge": "1h" } }
+```
+
+completed rows are reaped an hour after they are written, publish keeps
+deduplicating against 24h, and duplicate deliveries resume **with nothing in any
+log**.
+
+**New: retention floors.** A consumer may now declare, at runtime, the shortest
+window its own contract survives:
+
+```ts
+lifecycle.registerRetentionFloor('sys_job_queue', {
+  policy: 'retention',          // or 'ttl'
+  minWindowMs: 24 * 60 * 60 * 1000,
+  declaredBy: 'com.objectstack.service.queue',
+  consequence: '…what silently breaks below it',
+  remedy: '…the settings change that makes an override legal',
+});
+```
+
+- An override below the floor — **global or tenant-scoped** — is **rejected**,
+  and the declared window keeps running. Not clamped to the floor: clamping
+  would enforce a third number written in neither the declaration nor the
+  settings, and that number would move whenever an unrelated package changed
+  its floor. Rejection has exactly one fallback, the declaration, which is
+  already how an unparseable override resolves.
+- The rejection is `error`-level and carries both the consequence and the fix,
+  because what it prevents leaves the system looking entirely healthy. It is
+  also on the sweep report as `LifecycleSweepReport.floorViolations` — machine-
+  readable, every sweep.
+- A **declared** window below a registered floor is reported the same way and
+  still enforced: refusing to reap would trade a broken consumer contract for
+  the unbounded table #5179 just closed.
+- Objects with no registered floor are completely unaffected — P4 overrides
+  behave exactly as before.
+
+Floors are runtime wiring, not spec surface (the same call ADR-0057's reap-guard
+amendment makes), plus a reason of their own: the queue's floor **is**
+`DbQueueAdapterOptions.idempotencyWindowMs`, a per-kernel construction option, so
+a static key on the object's `lifecycle` block could only ever be a second copy
+of it that drifts. No `packages/spec` change.
+
+`QueueServicePlugin` registers `sys_job_queue`'s floor on `kernel:ready`,
+carrying the window the adapter was actually constructed with — so a non-default
+`db.idempotencyWindowMs` is covered too. The ordering is now enforced from both
+sides: the constructor rejects a too-long `idempotencyWindowMs`, the floor
+rejects a too-short `maxAge`.
+
+New exports from `@objectstack/objectql`: `LifecycleRetentionFloor`,
+`LifecycleFloorViolation`, plus `LifecycleService.registerRetentionFloor()`.
+`LifecycleLoggerLike` gained an optional `error()` (absent ⇒ falls back to
+`warn`), and `LifecycleSweepReport` gained `floorViolations`.

--- a/docs/adr/0057-system-data-lifecycle-and-retention.md
+++ b/docs/adr/0057-system-data-lifecycle-and-retention.md
@@ -197,6 +197,51 @@ retried next sweep). Rules:
   dir), skipping `completed` sessions and vetoing on abort failure so the
   session's already-uploaded parts don't leak.
 
+#### Amendment (#5195): retention floors — a consumer's lower bound on a P4 override
+
+P4 (§3.2, below) lets an operator override any object's window per environment
+and per tenant through the `lifecycle` settings namespace. Until #5195 the only
+validation on that override was *does it parse*, and a window is not only an
+operator's decision: other code can depend on rows still being there.
+
+`sys_job_queue` is the worked example. `DbQueueAdapter` dedups publishes by
+comparing a terminal row's `created_at` against its idempotency window, so the
+dedup check only means anything while that row exists; #5179 made the ordering
+an invariant by refusing, at construction, an idempotency window longer than
+the object's **declared** retention. A settings override the constructor cannot
+see (`retention_overrides.sys_job_queue.maxAge = '1h'`) walks straight around
+it: completed rows are reaped an hour after they are written, publish keeps
+dedupping against 24h, and duplicate deliveries resume with **nothing in any
+log** — a one-day-old enforced invariant with a side door.
+
+So a consumer may register a **retention floor** at runtime
+(`lifecycle.registerRetentionFloor(object, floor)`) declaring the shortest
+window its own contract survives, plus the consequence and the fix. Rules:
+
+- An override — global **or** tenant-scoped — below the floor is **rejected**,
+  not clamped: the declared window keeps running, exactly as an unparseable
+  override already resolves ("never fail open into no bound at all"). Clamping
+  would enforce a third number written in neither the declaration nor the
+  settings, and that number would move whenever an unrelated package changed
+  its floor.
+- The rejection is **`error`-level and says both halves** — what silently
+  breaks below the floor and which two settings make it legal — because the
+  failure it prevents leaves the system looking entirely healthy. It is also
+  on the sweep report (`floorViolations`), machine-readable, every sweep.
+- Floors are **runtime wiring, not spec surface**, for the same reason reap
+  guards are, plus one of their own: the queue's floor *is*
+  `DbQueueAdapterOptions.idempotencyWindowMs`, a per-kernel construction
+  option, so a static key on the object's `lifecycle` block could only ever be
+  a second copy of it that drifts. A declaration says how long rows are kept; a
+  floor says how short a *consumer* can survive them being kept — different
+  authors, different lifetimes.
+- The floor also covers the declaration itself: a declared window below a
+  registered floor is reported the same way, and still enforced — refusing to
+  reap would trade a broken consumer contract for the unbounded table #5179
+  just closed.
+- First consumer: `sys_job_queue` (service-queue), floored at the adapter's
+  configured idempotency window.
+
 ### 3.4 Reclaim — driver space hygiene
 
 SQLite driver defaults to `auto_vacuum=INCREMENTAL` (shipped P0); the Reaper

--- a/packages/objectql/src/index.ts
+++ b/packages/objectql/src/index.ts
@@ -148,6 +148,9 @@ export type {
   LifecycleSettingsLike,
   LifecycleGovernanceAlert,
   LifecycleReapGuard,
+  // [#5195] Consumer-declared floors on settings-driven window overrides.
+  LifecycleRetentionFloor,
+  LifecycleFloorViolation,
 } from './lifecycle/lifecycle-service.js';
 export { parseLifecycleDuration } from './lifecycle/duration.js';
 export { lifecycleSettingsManifest } from './lifecycle/lifecycle-settings.js';

--- a/packages/objectql/src/lifecycle/lifecycle-service.test.ts
+++ b/packages/objectql/src/lifecycle/lifecycle-service.test.ts
@@ -695,6 +695,301 @@ describe('LifecycleService.sweep — governance (P4)', () => {
   });
 });
 
+// #5195 — ADR-0057 P4 lets an operator override any object's window through the
+// `lifecycle` settings namespace, and until this the only validation on that
+// override was "does it parse". That is a side door around #5179's invariant:
+// `DbQueueAdapter` dedups `sys_job_queue` publishes against terminal rows by
+// `created_at`, checks at CONSTRUCTION that its idempotency window is ≤ the
+// object's DECLARED retention — and never sees a settings override. Set
+// `maxAge: '1h'` and the rows the dedup check reads are reaped an hour after
+// they are written, so duplicate deliveries resume with nothing in any log.
+//
+// A consumer now registers the shortest window its contract survives; an
+// override below it is rejected (not clamped) and the declared window runs.
+// Nothing here names sys_job_queue: the mechanism is the deliverable, the queue
+// is only its first caller (pinned end-to-end in @objectstack/service-queue).
+describe('LifecycleService — retention floors (#5195)', () => {
+  const FLOOR_MS = 24 * 3_600_000; // 24h, the queue's default dedup window
+
+  const floor = (over: Partial<Parameters<LifecycleService['registerRetentionFloor']>[1]> = {}) => ({
+    policy: 'retention' as const,
+    minWindowMs: FLOOR_MS,
+    declaredBy: 'com.example.consumer',
+    consequence: 'the consumer silently re-accepts work it already did.',
+    remedy: 'raise the override to ≥ 24h, or shorten the consumer window.',
+    ...over,
+  });
+
+  const QUEUE_LIKE: LifecycleObjectLike = {
+    name: 'app_work_queue',
+    lifecycle: { class: 'transient', retention: { maxAge: '7d', onlyWhen: { status: 'done' } } } as any,
+  };
+
+  function fakeSettings(values: Record<string, unknown>, tenantValues: Record<string, Record<string, unknown>> = {}) {
+    return {
+      async get(_ns: string, key: string, ctx?: Record<string, unknown>) {
+        const tenantId = ctx?.tenantId as string | undefined;
+        if (tenantId && tenantValues[tenantId] && key in tenantValues[tenantId]) {
+          return { value: tenantValues[tenantId][key], source: 'tenant' };
+        }
+        if (key in values) return { value: values[key], source: 'global' };
+        return { value: undefined, source: 'default' };
+      },
+    };
+  }
+
+  it('rejects a global override below the floor and keeps enforcing the declared window', async () => {
+    const error = vi.fn();
+    const { engine, deletes } = captureEngine([QUEUE_LIKE]);
+    const settings = fakeSettings({ retention_overrides: { app_work_queue: { maxAge: '1h' } } });
+    const svc = service(engine, {
+      getSettings: () => settings,
+      logger: { ...silentLogger(), error },
+    });
+    svc.registerRetentionFloor('app_work_queue', floor());
+
+    const report = await svc.sweep();
+
+    // The 1h override never reaches the delete: rows still live 7d, so the
+    // consumer's 24h dedup window still has rows to dedup against.
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0].where).toEqual({ created_at: { $lt: isoCutoff('7d') }, status: 'done' });
+    expect(report.swept[0].cutoff).toBe(isoCutoff('7d'));
+
+    // …and it is loud: machine-readable on the report, `error` in the log,
+    // carrying the consequence AND the fix (AGENTS.md degradation rule).
+    expect(report.floorViolations).toEqual([{
+      object: 'app_work_queue',
+      policy: 'retention',
+      scope: 'global',
+      override: '1h',
+      offendingMs: 3_600_000,
+      floorMs: FLOOR_MS,
+      declaredBy: 'com.example.consumer',
+      appliedMs: 7 * 86_400_000,
+    }]);
+    expect(error).toHaveBeenCalledTimes(1);
+    const line = error.mock.calls[0]![0] as string;
+    expect(line).toContain('REJECTED');
+    expect(line).toContain('com.example.consumer');
+    expect(line).toContain('Consequence:');
+    expect(line).toContain('Fix:');
+  });
+
+  it('a legal override (≥ the floor) still wins over the declared window', async () => {
+    const { engine, deletes } = captureEngine([QUEUE_LIKE]);
+    // 2d: shorter than the declared 7d, longer than the 24h floor — exactly the
+    // environment tuning P4 exists for. The floor bounds overrides, it does not
+    // abolish them.
+    const settings = fakeSettings({ retention_overrides: { app_work_queue: { maxAge: '2d' } } });
+    const svc = service(engine, { getSettings: () => settings });
+    svc.registerRetentionFloor('app_work_queue', floor());
+
+    const report = await svc.sweep();
+
+    expect(deletes[0].where).toEqual({ created_at: { $lt: isoCutoff('2d') }, status: 'done' });
+    expect(report.floorViolations).toEqual([]);
+  });
+
+  it('an override exactly AT the floor is legal (the bound is ≥, not >)', async () => {
+    const { engine, deletes } = captureEngine([QUEUE_LIKE]);
+    const settings = fakeSettings({ retention_overrides: { app_work_queue: { maxAge: '24h' } } });
+    const svc = service(engine, { getSettings: () => settings });
+    svc.registerRetentionFloor('app_work_queue', floor());
+
+    const report = await svc.sweep();
+
+    expect(deletes[0].where).toEqual({ created_at: { $lt: isoCutoff('24h') }, status: 'done' });
+    expect(report.floorViolations).toEqual([]);
+  });
+
+  it('an object with no registered floor is untouched — 1h still applies', async () => {
+    const { engine, deletes } = captureEngine([
+      QUEUE_LIKE,
+      { name: 'sys_job_run', lifecycle: { class: 'telemetry', retention: { maxAge: '30d' } } as any },
+    ]);
+    const settings = fakeSettings({
+      retention_overrides: { app_work_queue: { maxAge: '1h' }, sys_job_run: { maxAge: '1h' } },
+    });
+    const svc = service(engine, { getSettings: () => settings });
+    // Floor on ONE object only.
+    svc.registerRetentionFloor('app_work_queue', floor());
+
+    const report = await svc.sweep();
+
+    const forObject = (name: string) => deletes.find((d) => d.object === name)!;
+    expect(forObject('app_work_queue').where.created_at.$lt).toBe(isoCutoff('7d'));
+    // No floor ⇒ P4 is unchanged: an aggressive override is the operator's call.
+    expect(forObject('sys_job_run').where.created_at.$lt).toBe(isoCutoff('1h'));
+    expect(report.floorViolations.map((v) => v.object)).toEqual(['app_work_queue']);
+  });
+
+  it('floors a TENANT-scoped override too — the same door one scope down', async () => {
+    const { engine, deletes } = captureEngine([QUEUE_LIKE]);
+    (engine as any).find = async (object: string) =>
+      object === 'sys_organization' ? [{ id: 'org_fast' }] : [];
+    const settings = fakeSettings(
+      {},
+      { org_fast: { retention_overrides: { app_work_queue: { maxAge: '1h' } } } },
+    );
+    const svc = service(engine, { getSettings: () => settings });
+    svc.registerRetentionFloor('app_work_queue', floor());
+
+    const report = await svc.sweep();
+
+    // The tenant pass falls back to the window that DID pass the floor (7d),
+    // so no tenant can shorten its way past another package's contract.
+    expect(deletes[0].where).toEqual({
+      created_at: { $lt: isoCutoff('7d') },
+      organization_id: 'org_fast',
+      status: 'done',
+    });
+    expect(report.floorViolations).toHaveLength(1);
+    expect(report.floorViolations[0]!.scope).toBe('tenant:org_fast');
+  });
+
+  it('a retention floor does not reject a ttl override (policies are separate windows)', async () => {
+    const { engine, deletes } = captureEngine([
+      { name: 'app_session', lifecycle: { class: 'transient', ttl: { field: 'expires_at', expireAfter: '7d' } } as any },
+    ]);
+    const settings = fakeSettings({ retention_overrides: { app_session: { expireAfter: '1h' } } });
+    const svc = service(engine, { getSettings: () => settings });
+    svc.registerRetentionFloor('app_session', floor()); // policy: 'retention'
+
+    const report = await svc.sweep();
+
+    expect(deletes[0].where).toEqual({ expires_at: { $lt: isoCutoff('1h') } });
+    expect(report.floorViolations).toEqual([]);
+
+    // The same floor declared for `ttl` DOES bite.
+    const second = captureEngine([
+      { name: 'app_session', lifecycle: { class: 'transient', ttl: { field: 'expires_at', expireAfter: '7d' } } as any },
+    ]);
+    const ttlSvc = service(second.engine, { getSettings: () => settings });
+    ttlSvc.registerRetentionFloor('app_session', floor({ policy: 'ttl' }));
+    const ttlReport = await ttlSvc.sweep();
+    expect(second.deletes[0].where).toEqual({ expires_at: { $lt: isoCutoff('7d') } });
+    expect(ttlReport.floorViolations[0]!.policy).toBe('ttl');
+  });
+
+  it('the strictest of several registered floors governs', async () => {
+    const { engine, deletes } = captureEngine([QUEUE_LIKE]);
+    const settings = fakeSettings({ retention_overrides: { app_work_queue: { maxAge: '2d' } } });
+    const svc = service(engine, { getSettings: () => settings });
+    svc.registerRetentionFloor('app_work_queue', floor()); // 24h — 2d clears it
+    svc.registerRetentionFloor('app_work_queue', floor({
+      minWindowMs: 3 * 86_400_000,
+      declaredBy: 'com.example.slow-consumer',
+    })); // 3d — 2d does not
+
+    const report = await svc.sweep();
+
+    expect(deletes[0].where.created_at.$lt).toBe(isoCutoff('7d'));
+    expect(report.floorViolations[0]!.declaredBy).toBe('com.example.slow-consumer');
+  });
+
+  it('re-registering the same (object, policy, declaredBy) replaces rather than accumulates', async () => {
+    const { engine, deletes } = captureEngine([QUEUE_LIKE]);
+    const settings = fakeSettings({ retention_overrides: { app_work_queue: { maxAge: '2d' } } });
+    const svc = service(engine, { getSettings: () => settings });
+    svc.registerRetentionFloor('app_work_queue', floor({ minWindowMs: 3 * 86_400_000 }));
+    // A reconstructed adapter re-registers with a lowered window; the stale
+    // stricter floor must not linger and keep rejecting a now-legal override.
+    svc.registerRetentionFloor('app_work_queue', floor({ minWindowMs: 3_600_000 }));
+
+    const report = await svc.sweep();
+
+    expect(deletes[0].where.created_at.$lt).toBe(isoCutoff('2d'));
+    expect(report.floorViolations).toEqual([]);
+  });
+
+  it('reports a DECLARED window below the floor, and still enforces it', async () => {
+    const error = vi.fn();
+    const { engine, deletes } = captureEngine([
+      { name: 'app_work_queue', lifecycle: { class: 'transient', retention: { maxAge: '6h' } } as any },
+    ]);
+    const svc = service(engine, { logger: { ...silentLogger(), error } });
+    svc.registerRetentionFloor('app_work_queue', floor());
+
+    const report = await svc.sweep();
+
+    // Refusing to reap would trade a broken consumer contract for the
+    // unbounded table #5179 closed — so the declaration still runs, loudly.
+    expect(deletes[0].where.created_at.$lt).toBe(isoCutoff('6h'));
+    expect(report.floorViolations).toEqual([{
+      object: 'app_work_queue',
+      policy: 'retention',
+      scope: 'global',
+      offendingMs: 6 * 3_600_000,
+      floorMs: FLOOR_MS,
+      declaredBy: 'com.example.consumer',
+      appliedMs: 6 * 3_600_000,
+    }]);
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error.mock.calls[0]![0]).toContain('declared retention window');
+  });
+
+  it('logs a standing violation once, but reports it on every sweep', async () => {
+    const error = vi.fn();
+    const { engine } = captureEngine([QUEUE_LIKE]);
+    const settings = fakeSettings({ retention_overrides: { app_work_queue: { maxAge: '1h' } } });
+    const svc = service(engine, { getSettings: () => settings, logger: { ...silentLogger(), error } });
+    svc.registerRetentionFloor('app_work_queue', floor());
+
+    const first = await svc.sweep();
+    const second = await svc.sweep();
+
+    // Hourly repetition of an unchanged misconfiguration is what trains people
+    // to skim `error` — the report stays complete regardless.
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(first.floorViolations).toHaveLength(1);
+    expect(second.floorViolations).toHaveLength(1);
+  });
+
+  it('falls back to warn when the logger has no error method', async () => {
+    const warn = vi.fn();
+    const { engine } = captureEngine([QUEUE_LIKE]);
+    const settings = fakeSettings({ retention_overrides: { app_work_queue: { maxAge: '1h' } } });
+    const svc = service(engine, {
+      getSettings: () => settings,
+      logger: { info: () => {}, warn, debug: () => {} },
+    });
+    svc.registerRetentionFloor('app_work_queue', floor());
+
+    await svc.sweep();
+
+    expect(warn.mock.calls.some((c) => String(c[0]).includes('REJECTED'))).toBe(true);
+  });
+
+  it('refuses a malformed floor at registration — an unactionable rejection helps nobody', () => {
+    const { engine } = captureEngine([QUEUE_LIKE]);
+    const svc = service(engine);
+    expect(() => svc.registerRetentionFloor('app_work_queue', floor({ minWindowMs: 0 })))
+      .toThrow(/positive finite minWindowMs/);
+    expect(() => svc.registerRetentionFloor('app_work_queue', floor({ minWindowMs: Number.NaN })))
+      .toThrow(/positive finite minWindowMs/);
+    expect(() => svc.registerRetentionFloor('app_work_queue', floor({ policy: 'forever' as any })))
+      .toThrow(/policy 'retention' or 'ttl'/);
+    expect(() => svc.registerRetentionFloor('app_work_queue', floor({ consequence: '' })))
+      .toThrow(/declaredBy, consequence and remedy/);
+    expect(() => svc.registerRetentionFloor('app_work_queue', floor({ remedy: '' })))
+      .toThrow(/declaredBy, consequence and remedy/);
+    expect(() => svc.registerRetentionFloor('', floor())).toThrow(/requires an object name/);
+  });
+
+  it('an unparseable override still keeps the declared window and is not a floor violation', async () => {
+    const { engine, deletes } = captureEngine([QUEUE_LIKE]);
+    const settings = fakeSettings({ retention_overrides: { app_work_queue: { maxAge: 'forever' } } });
+    const svc = service(engine, { getSettings: () => settings });
+    svc.registerRetentionFloor('app_work_queue', floor());
+
+    const report = await svc.sweep();
+
+    expect(deletes[0].where.created_at.$lt).toBe(isoCutoff('7d'));
+    expect(report.floorViolations).toEqual([]);
+  });
+});
+
 describe('LifecycleService timers', () => {
   it('start() sweeps after the initial delay and then on the interval; stop() disarms', async () => {
     vi.useFakeTimers();

--- a/packages/objectql/src/lifecycle/lifecycle-service.ts
+++ b/packages/objectql/src/lifecycle/lifecycle-service.ts
@@ -91,6 +91,9 @@ export interface LifecycleObjectLike {
 export interface LifecycleLoggerLike {
   info(msg: string, meta?: unknown): void;
   warn(msg: string, meta?: unknown): void;
+  /** Optional so a test double stays a two-method object; a real kernel logger
+   * always has it. Absent ⇒ {@link LifecycleService} falls back to `warn`. */
+  error?(msg: string, meta?: unknown): void;
   debug?(msg: string, meta?: unknown): void;
 }
 
@@ -168,6 +171,67 @@ const DEFAULT_GOVERNANCE: GovernanceSnapshot = {
 /** Cap on tenants scanned for per-tenant overrides each sweep. */
 const TENANT_SCAN_LIMIT = 200;
 
+/**
+ * [#5195] A **retention floor**: the shortest window a consumer's own contract
+ * can survive on an object it does not own.
+ *
+ * ADR-0057 P4 lets an operator override any object's window through the
+ * `lifecycle` settings namespace, and until #5195 the only validation on that
+ * override was "does it parse". That is a side door around exactly the kind of
+ * invariant #5179 had just made construction-time: `DbQueueAdapter` dedups
+ * `sys_job_queue` publishes by comparing `created_at` against its idempotency
+ * window and checks — at construction — that the window is ≤ the **declared**
+ * retention. A settings override the constructor cannot see (`maxAge: '1h'`)
+ * reaps the very rows the dedup check reads, and duplicate deliveries resume
+ * with nothing in any log.
+ *
+ * The floor is registered at **runtime** (`registerRetentionFloor`), the same
+ * shape as {@link LifecycleReapGuard} and for the same reason (ADR-0057 §3.3
+ * amendment): the number is not a property of the declaration at all. The
+ * queue's floor IS `DbQueueAdapterOptions.idempotencyWindowMs` — a per-kernel
+ * construction option — so a static key on the object's `lifecycle` block could
+ * only ever be a second, drifting copy of it. Declaration says how long rows
+ * are kept; a floor says how short a *consumer* can survive them being kept.
+ */
+export interface LifecycleRetentionFloor {
+  /** Which window is floored: `retention` (`maxAge`, incl. the rotation
+   * fallback) or `ttl` (`expireAfter`). */
+  policy: 'retention' | 'ttl';
+  /** Shortest window, in ms, that keeps the registrar's contract true. */
+  minWindowMs: number;
+  /** Who depends on it — named in the rejection so an operator knows who to
+   * talk to (e.g. `'com.objectstack.service.queue'`). */
+  declaredBy: string;
+  /** What breaks below the floor, in operator terms. Required: an error line
+   * without a consequence is an error line nobody can act on. */
+  consequence: string;
+  /** The config change that makes the override legal. Also required. */
+  remedy: string;
+}
+
+/**
+ * [#5195] A window that would have been enforced below a registered floor.
+ * Always reported per sweep (machine-readable), and logged at `error` once per
+ * distinct violation — the failure it prevents is silent duplicate work, which
+ * is a durability-class degradation, not a functional one.
+ */
+export interface LifecycleFloorViolation {
+  object: string;
+  policy: 'retention' | 'ttl';
+  /** `'global'`, or `tenant:<id>` for a tenant-scoped override. */
+  scope: string;
+  /** The offending settings literal — absent when the **declaration itself**
+   * is what sits below the floor (there is no override to blame). */
+  override?: string;
+  /** The offending window in ms. */
+  offendingMs: number;
+  /** The floor that rejected it, and who registered it. */
+  floorMs: number;
+  declaredBy: string;
+  /** The window actually enforced this sweep after the violation was handled. */
+  appliedMs: number;
+}
+
 export interface LifecycleSweepEntry {
   object: string;
   class: string;
@@ -193,6 +257,13 @@ export interface LifecycleSweepReport {
   reclaimed: string[];
   /** Governance alerts raised this sweep (quota breaches, growth spikes). */
   alerts: LifecycleGovernanceAlert[];
+  /**
+   * [#5195] Windows rejected this sweep for sitting below a registered
+   * {@link LifecycleRetentionFloor}. Empty on every healthy sweep; non-empty
+   * means an override (or a declaration) is being overruled, and the entry
+   * says by whom.
+   */
+  floorViolations: LifecycleFloorViolation[];
   /**
    * [#4551] Read-only referential-integrity finding for this sweep, when the
    * engine offers the audit. Absent on an engine that does not (older engine,
@@ -262,6 +333,15 @@ export class LifecycleService {
   private governance: GovernanceSnapshot = DEFAULT_GOVERNANCE;
   /** Per-object reap guards ({@link LifecycleReapGuard}). */
   private readonly reapGuards = new Map<string, LifecycleReapGuard>();
+  /**
+   * [#5195] Registered retention floors, keyed `object::policy::declaredBy` so
+   * a re-registration replaces rather than accumulates, while two independent
+   * consumers of one object both keep their say (the strictest wins).
+   */
+  private readonly retentionFloors = new Map<string, LifecycleRetentionFloor & { object: string }>();
+  /** Violations already logged, so a standing misconfiguration says it once
+   * (AGENTS.md degradation rule) while a CHANGED one speaks up again. */
+  private readonly reportedFloorViolations = new Set<string>();
   /**
    * [#4747] The "the engine is going away" bit, handed to the work in flight.
    *
@@ -342,6 +422,62 @@ export class LifecycleService {
   }
 
   /**
+   * [#5195] Register a {@link LifecycleRetentionFloor} for one object.
+   *
+   * From then on a settings override (global **or** tenant-scoped) that would
+   * shorten that object's window below the floor is REJECTED — the declared
+   * window stands — and the rejection is reported at `error` naming the
+   * registrar, the consequence and the fix.
+   *
+   * Rejected rather than clamped to the floor, deliberately. Clamping would
+   * enforce a third number that appears in neither the object's declaration nor
+   * the operator's settings, so nobody reading either surface could predict when
+   * rows actually disappear — and it would move whenever an unrelated package
+   * changed its floor. Rejection has exactly one fallback, the declaration,
+   * which is already the contract everywhere else in this file (an unparseable
+   * override resolves the same way: "never fail open into no bound at all").
+   * The operator's intent is not silently half-honoured; it is refused, loudly,
+   * with the two settings that would make it legal.
+   *
+   * Registering a floor is a wiring act, so a malformed one throws here rather
+   * than degrading into an unactionable log line at 3am.
+   */
+  registerRetentionFloor(object: string, floor: LifecycleRetentionFloor): void {
+    if (!object) throw new Error('[lifecycle] registerRetentionFloor requires an object name');
+    if (floor?.policy !== 'retention' && floor?.policy !== 'ttl') {
+      throw new Error(
+        `[lifecycle] retention floor for ${object} must declare policy 'retention' or 'ttl' (got ${JSON.stringify(floor?.policy)})`,
+      );
+    }
+    if (!Number.isFinite(floor.minWindowMs) || floor.minWindowMs <= 0) {
+      throw new Error(
+        `[lifecycle] retention floor for ${object} needs a positive finite minWindowMs (got ${String(floor.minWindowMs)})`,
+      );
+    }
+    if (!floor.declaredBy || !floor.consequence || !floor.remedy) {
+      throw new Error(
+        `[lifecycle] retention floor for ${object} must name declaredBy, consequence and remedy — `
+        + 'the rejection it produces is read by an operator who knows none of the three.',
+      );
+    }
+    this.retentionFloors.set(`${object}::${floor.policy}::${floor.declaredBy}`, { ...floor, object });
+  }
+
+  /** The strictest floor registered for (object, policy) — every registrar's
+   * floor has to hold, so the largest one governs. */
+  private floorFor(
+    object: string,
+    policy: 'retention' | 'ttl',
+  ): (LifecycleRetentionFloor & { object: string }) | undefined {
+    let strictest: (LifecycleRetentionFloor & { object: string }) | undefined;
+    for (const floor of this.retentionFloors.values()) {
+      if (floor.object !== object || floor.policy !== policy) continue;
+      if (!strictest || floor.minWindowMs > strictest.minWindowMs) strictest = floor;
+    }
+    return strictest;
+  }
+
+  /**
    * Apply every declared lifecycle policy once. Safe to call directly (the
    * dogfood growth gate and `db:clean`-style tooling do); re-entrant calls
    * while a sweep is running resolve to an empty report.
@@ -354,6 +490,7 @@ export class LifecycleService {
       errors: [],
       reclaimed: [],
       alerts: [],
+      floorViolations: [],
     };
     if (this.sweeping || !this.enabled) return report;
     // [#4747] Torn down ⇒ there is no engine to sweep through, whatever the
@@ -437,7 +574,10 @@ export class LifecycleService {
         this.opts.logger.info(
           `[lifecycle] sweep: ${report.swept.length} policy(ies) applied, ~${total} rows reaped, ` +
             `${report.reclaimed.length} datasource(s) reclaimed, ${report.errors.length} error(s), ` +
-            `${report.alerts.length} alert(s)`,
+            `${report.alerts.length} alert(s)` +
+            (report.floorViolations.length > 0
+              ? `, ${report.floorViolations.length} window(s) overruled by a registered retention floor`
+              : ''),
         );
       }
       return report;
@@ -617,7 +757,14 @@ export class LifecycleService {
     const ov = this.governance.overrides[object] ?? {};
 
     if (lc.ttl) {
-      const windowMs = this.effectiveWindowMs(ov.expireAfter, parseLifecycleDuration(lc.ttl.expireAfter), object);
+      const windowMs = this.effectiveWindowMs(
+        ov.expireAfter,
+        parseLifecycleDuration(lc.ttl.expireAfter),
+        object,
+        'ttl',
+        'global',
+        report,
+      );
       outcomes.push(await this.reap(engine, object, lc, 'ttl', lc.ttl.field, windowMs, report));
     }
 
@@ -649,7 +796,14 @@ export class LifecycleService {
       // granularity, an explicit retention.maxAge trims to the day inside the
       // live shards — and immediately bounds a legacy table the Rotator just
       // adopted whole into its first shard.
-      const windowMs = this.effectiveWindowMs(ov.maxAge, parseLifecycleDuration(lc.retention.maxAge), object);
+      const windowMs = this.effectiveWindowMs(
+        ov.maxAge,
+        parseLifecycleDuration(lc.retention.maxAge),
+        object,
+        'retention',
+        'global',
+        report,
+      );
       outcomes.push(
         await this.reap(engine, object, lc, 'retention', 'created_at', windowMs, report, lc.retention.onlyWhen),
       );
@@ -657,24 +811,126 @@ export class LifecycleService {
       // Rotation declared but the driver can't shard physically: the shard
       // window IS the bound — enforce the same window with an age-based reap
       // so the declaration is never inert.
-      const windowMs = this.effectiveWindowMs(ov.maxAge, lc.storage.shards * SHARD_UNIT_MS[lc.storage.unit], object);
+      const windowMs = this.effectiveWindowMs(
+        ov.maxAge,
+        lc.storage.shards * SHARD_UNIT_MS[lc.storage.unit],
+        object,
+        'retention',
+        'global',
+        report,
+      );
       outcomes.push(await this.reap(engine, object, lc, 'rotation-fallback', 'created_at', windowMs, report));
     }
 
     return outcomes;
   }
 
-  /** A governance override window beats the declared one — unless it fails to
+  /**
+   * A governance override window beats the declared one — unless it fails to
    * parse, in which case the declared window stands (never fail open into
-   * "no bound at all"). */
-  private effectiveWindowMs(override: string | undefined, declaredMs: number, object: string): number {
-    if (!override) return declaredMs;
+   * "no bound at all") — or [#5195] unless it sits below a registered
+   * {@link LifecycleRetentionFloor}, in which case it is rejected the same way
+   * and for the same reason: an override that breaks a consumer's contract is
+   * not a shorter policy, it is an invalid one.
+   *
+   * `fallbackMs` is what an invalid override falls back to: the declared window
+   * at global scope, and the already-resolved global window for a tenant-scoped
+   * override (which has itself passed this check).
+   */
+  private effectiveWindowMs(
+    override: string | undefined,
+    fallbackMs: number,
+    object: string,
+    policy: 'retention' | 'ttl',
+    scope: string,
+    report: LifecycleSweepReport,
+  ): number {
+    const floor = this.floorFor(object, policy);
+
+    if (!override) {
+      // No override: the DECLARATION is what runs. A declaration below the
+      // floor is a different defect (the object and its consumer disagree at
+      // authoring time, which is where #5179's constructor guard catches the
+      // queue case) — reported here too, because a floor registered against an
+      // object nobody re-checked would otherwise be silently unmet. The sweep
+      // still runs it: refusing to reap would trade a broken consumer contract
+      // for an unbounded table, which is the defect #5179 just closed.
+      if (floor && fallbackMs < floor.minWindowMs) {
+        this.reportFloorViolation(report, {
+          object,
+          policy,
+          scope,
+          offendingMs: fallbackMs,
+          floorMs: floor.minWindowMs,
+          declaredBy: floor.declaredBy,
+          appliedMs: fallbackMs,
+        }, floor, 'declared');
+      }
+      return fallbackMs;
+    }
+
+    let overrideMs: number;
     try {
-      return parseLifecycleDuration(override);
+      overrideMs = parseLifecycleDuration(override);
     } catch {
       this.opts.logger.warn(`[lifecycle] invalid override window '${override}' for ${object}; keeping the declared window`);
-      return declaredMs;
+      return fallbackMs;
     }
+
+    if (floor && overrideMs < floor.minWindowMs) {
+      this.reportFloorViolation(report, {
+        object,
+        policy,
+        scope,
+        override,
+        offendingMs: overrideMs,
+        floorMs: floor.minWindowMs,
+        declaredBy: floor.declaredBy,
+        appliedMs: fallbackMs,
+      }, floor, 'override');
+      return fallbackMs;
+    }
+
+    return overrideMs;
+  }
+
+  /**
+   * Record a floor violation on the sweep report (always) and log it at
+   * `error` (once per distinct violation).
+   *
+   * `error`, not `warn`, by the AGENTS.md test: after this degradation the
+   * system looks entirely normal — the sweep reports success, the table shrinks
+   * on schedule — while the contract that override silently broke shows up
+   * later as duplicate work nobody can trace back to a settings edit. The line
+   * owes a consequence and a fix, and both come from the registrar rather than
+   * from guesswork here.
+   */
+  private reportFloorViolation(
+    report: LifecycleSweepReport,
+    violation: LifecycleFloorViolation,
+    floor: LifecycleRetentionFloor,
+    kind: 'override' | 'declared',
+  ): void {
+    report.floorViolations.push(violation);
+    const dedupKey = `${violation.object}|${violation.policy}|${violation.scope}|${kind}|${violation.offendingMs}|${violation.floorMs}`;
+    if (this.reportedFloorViolations.has(dedupKey)) return;
+    this.reportedFloorViolations.add(dedupKey);
+
+    const where = violation.scope === 'global' ? 'global scope' : violation.scope;
+    const head =
+      kind === 'override'
+        ? `[lifecycle] REJECTED the ${violation.policy} override '${violation.override}' (${violation.offendingMs}ms) on `
+          + `${violation.object} at ${where}: it is below the ${violation.floorMs}ms floor registered by `
+          + `'${floor.declaredBy}'. Enforcing the declared ${violation.appliedMs}ms window instead.`
+        : `[lifecycle] ${violation.object}'s declared ${violation.policy} window (${violation.offendingMs}ms) is below `
+          + `the ${violation.floorMs}ms floor registered by '${floor.declaredBy}'; it is still being enforced as declared.`;
+    this.logError(`${head} Consequence: ${floor.consequence} Fix: ${floor.remedy}`);
+  }
+
+  /** `error` where the logger has one; a duck-typed test double may not. */
+  private logError(msg: string): void {
+    if (typeof this.opts.logger.error === 'function') this.opts.logger.error(msg);
+    else this.opts.logger.warn(msg);
   }
 
   /**
@@ -785,7 +1041,16 @@ export class LifecycleService {
       // Tenant-level windows (P4): each overriding tenant gets its own
       // cutoff on its own rows…
       for (const t of tenantWindows) {
-        const tMs = this.effectiveWindowMs(t[overrideKey], windowMs, `${object} (tenant ${t.tenantId})`);
+        // [#5195] Tenant-scoped overrides go through the same floor: a
+        // per-tenant `maxAge: '1h'` is the identical side door, one scope down.
+        const tMs = this.effectiveWindowMs(
+          t[overrideKey],
+          windowMs,
+          object,
+          policy === 'ttl' ? 'ttl' : 'retention',
+          `tenant:${t.tenantId}`,
+          report,
+        );
         const tCutoff = new Date(this.now() - tMs).toISOString();
         accumulate(await reapWhere({ [field]: { $lt: tCutoff }, organization_id: t.tenantId, ...scope }));
       }

--- a/packages/objectql/src/lifecycle/lifecycle-settings.ts
+++ b/packages/objectql/src/lifecycle/lifecycle-settings.ts
@@ -44,7 +44,9 @@ export const lifecycleSettingsManifest = {
       default: {},
       description:
         'Per-object window overrides: { "<object>": { "maxAge": "1y", "expireAfter": "30d" } }. ' +
-        'Duration literals: h/d/w/y. Tenant-scoped — a regulated tenant sets years while dev keeps days (ADR-0057 §3.2).',
+        'Duration literals: h/d/w/y. Tenant-scoped — a regulated tenant sets years while dev keeps days (ADR-0057 §3.2). ' +
+        'An override BELOW a retention floor a consumer registered (e.g. the job queue\'s dedup window) is rejected at ' +
+        'sweep time and logged at error — the declared window keeps running (#5195).',
     },
     {
       type: 'json',

--- a/packages/services/service-queue/README.md
+++ b/packages/services/service-queue/README.md
@@ -90,8 +90,14 @@ Two consequences worth knowing:
   setting would start accepting duplicates the moment the row was swept. The
   `db` adapter throws at construction instead of degrading quietly.
 - **The window is overridable per environment** through the `lifecycle`
-  settings namespace (`maxAge` per object), like every other ADR-0057 policy.
-  Keep it ≥ your idempotency window.
+  settings namespace (`maxAge` per object), like every other ADR-0057 policy —
+  but **not below the idempotency window**. On startup this plugin registers a
+  *retention floor* with the `LifecycleService` carrying the window the adapter
+  was actually constructed with; a global or tenant-scoped override under it is
+  **rejected** at sweep time (the declared window keeps running) and logged at
+  `error` naming the consequence and the two settings that would make it legal.
+  So the ordering is enforced from both sides: the constructor rejects a
+  too-long `idempotencyWindowMs`, the floor rejects a too-short `maxAge`.
 
 ## Service API
 

--- a/packages/services/service-queue/src/db-queue-adapter.ts
+++ b/packages/services/service-queue/src/db-queue-adapter.ts
@@ -44,6 +44,22 @@ export function completedRetentionWindowMs(): number {
   return lifecycleDurationMs(maxAge);
 }
 
+/**
+ * [#5195] The shape `LifecycleService.registerRetentionFloor()` accepts.
+ *
+ * Restated here rather than imported: `@objectstack/objectql` is a
+ * devDependency of this package on purpose (the queue must not drag the engine
+ * into every install), and the registration is duck-typed at the call site the
+ * same way the storage service's reap guards are.
+ */
+export interface QueueRetentionFloor {
+  policy: 'retention';
+  minWindowMs: number;
+  declaredBy: string;
+  consequence: string;
+  remedy: string;
+}
+
 export interface DbQueueAdapterOptions {
   /** Polling interval for the worker loop (ms, default 1000) */
   pollIntervalMs?: number;
@@ -145,6 +161,48 @@ export class DbQueueAdapter implements IQueueService {
         + 'retention (both windows are measured from `created_at`).',
       );
     }
+  }
+
+  /** The configured dedup window (ms) — the number the floor below is made of. */
+  get idempotencyWindowMs(): number {
+    return this.opts.idempotencyWindowMs;
+  }
+
+  /**
+   * [#5195] The retention floor `sys_job_queue` must satisfy for this adapter's
+   * dedup contract to mean anything, handed to `LifecycleService`
+   * (`registerRetentionFloor`) by `QueueServicePlugin`.
+   *
+   * The constructor check above only reads the object's **declaration**. ADR-0057
+   * P4 lets an operator override that window per environment/tenant through the
+   * `lifecycle` settings namespace, which the constructor cannot see: set
+   * `lifecycle.retention_overrides.sys_job_queue.maxAge = '1h'` and completed
+   * rows vanish an hour after they are written while publish keeps dedupping
+   * against a 24h window — duplicate deliveries resume, with nothing in any log.
+   * Registering the floor is what closes that door, and it carries the number
+   * this adapter was actually CONSTRUCTED with rather than a static copy of the
+   * default (a per-kernel option cannot live in the object's declaration).
+   */
+  retentionFloor(): QueueRetentionFloor {
+    const ms = this.opts.idempotencyWindowMs;
+    // Settings are authored as ADR-0057 duration literals, not milliseconds, so
+    // the remedy quotes one the operator can paste — rounded UP, since a
+    // rounded-down literal would be rejected by the very floor it is meant to
+    // satisfy.
+    const literal = `${Math.ceil(ms / 3_600_000)}h`;
+    return {
+      policy: 'retention',
+      minWindowMs: ms,
+      declaredBy: 'com.objectstack.service.queue',
+      consequence:
+        `DbQueueAdapter dedups sys_job_queue publishes by comparing created_at against its ${ms}ms `
+        + 'idempotency window, so a shorter retention deletes the very rows that check reads — '
+        + 'duplicate deliveries resume silently, with nothing in any log.',
+      remedy:
+        `set lifecycle.retention_overrides.sys_job_queue.maxAge to '${literal}' or longer, or lower `
+        + "QueueServicePlugin's db.idempotencyWindowMs to the window you actually want (both are measured "
+        + 'from created_at).',
+    };
   }
 
   // ── IQueueService ────────────────────────────────────────────────

--- a/packages/services/service-queue/src/db-queue-adapter.ts
+++ b/packages/services/service-queue/src/db-queue-adapter.ts
@@ -49,8 +49,8 @@ export function completedRetentionWindowMs(): number {
  *
  * Restated here rather than imported: `@objectstack/objectql` is a
  * devDependency of this package on purpose (the queue must not drag the engine
- * into every install), and the registration is duck-typed at the call site the
- * same way the storage service's reap guards are.
+ * into every install), so its types are not available to this package's
+ * consumers at build time.
  */
 export interface QueueRetentionFloor {
   policy: 'retention';
@@ -58,6 +58,27 @@ export interface QueueRetentionFloor {
   declaredBy: string;
   consequence: string;
   remedy: string;
+}
+
+/**
+ * [#5195] The `lifecycle` slot's contract as THIS package consumes it — the one
+ * method `QueueServicePlugin` calls, and nothing else.
+ *
+ * Declared rather than erased to `any` at the lookup (#4127/#4251): `any` would
+ * switch off checking on the single call that carries the floor, so a rename or
+ * a changed argument order in `LifecycleService.registerRetentionFloor` would
+ * compile here and fail at runtime inside a `try` that logs and continues —
+ * i.e. the floor would silently not exist, which is precisely the silent
+ * bypass #5195 exists to close.
+ *
+ * `registerRetentionFloor` is **optional** on purpose, and that optionality is
+ * the honest part of the contract: a kernel may carry a lifecycle service that
+ * predates floors, so the runtime `typeof … === 'function'` probe below is a
+ * real check and the type says so, instead of an `any` that hides both the
+ * check and the call.
+ */
+export interface LifecycleFloorRegistrar {
+  registerRetentionFloor?(object: string, floor: QueueRetentionFloor): void;
 }
 
 export interface DbQueueAdapterOptions {

--- a/packages/services/service-queue/src/job-queue-retention.test.ts
+++ b/packages/services/service-queue/src/job-queue-retention.test.ts
@@ -26,9 +26,10 @@
 // the engine.
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { assertEngineDeleteDispatch } from '@objectstack/objectql';
+import { assertEngineDeleteDispatch, LifecycleService } from '@objectstack/objectql';
 import { SysJobQueue } from '@objectstack/platform-objects/audit';
 import { DbQueueAdapter, completedRetentionWindowMs } from './db-queue-adapter.js';
+import { QueueServicePlugin } from './queue-service-plugin.js';
 import { lifecycleDurationMs } from './common.js';
 
 const QUEUE_TABLE = 'sys_job_queue';
@@ -65,6 +66,12 @@ function makeFakeEngine() {
     rows(): Row[] {
       return tables.get(QUEUE_TABLE) ?? [];
     },
+    // [#5195] The two members `LifecycleService` needs to sweep through this
+    // fake for real, so the floor can be proven end-to-end rather than
+    // re-mirrored: the object set it iterates, and the driver hook it consults
+    // for space reclaim (none here).
+    registry: { getAllObjects: () => [SysJobQueue as any] },
+    getDriverForObject: () => undefined,
     async find(table: string, opts: any = {}) {
       const t = tables.get(table) ?? [];
       let out = opts.where ? t.filter((r) => matches(r, opts.where)) : [...t];
@@ -307,5 +314,217 @@ describe('declared retention bounds sys_job_queue (#5179)', () => {
 
     expect(seen).toEqual([{ v: 1 }]);
     expect(engine.rows()[0]!.status).toBe('completed');
+  });
+});
+
+// #5195 — the invariant above is enforced against the object's DECLARATION,
+// which the adapter's constructor can read. ADR-0057 P4 also lets an operator
+// override that window at runtime through the `lifecycle` settings namespace,
+// and the constructor cannot see that at all: set
+// `retention_overrides.sys_job_queue.maxAge = '1h'` and completed rows are
+// reaped an hour after they are written while publish keeps dedupping against
+// 24h — duplicate deliveries resume, silently.
+//
+// These run the REAL `LifecycleService` over the REAL `SysJobQueue`
+// declaration, so what is pinned is the two packages agreeing, not this file's
+// idea of either.
+describe('a lifecycle settings override cannot undercut the dedup window (#5195)', () => {
+  const OVERRIDE_1H = { retention_overrides: { [QUEUE_TABLE]: { maxAge: '1h' } } };
+
+  function fakeSettings(values: Record<string, unknown>) {
+    return {
+      async get(_ns: string, key: string) {
+        return key in values
+          ? { value: values[key], source: 'global' }
+          : { value: undefined, source: 'default' };
+      },
+    };
+  }
+
+  function lifecycle(
+    engine: ReturnType<typeof makeFakeEngine>,
+    clock: ReturnType<typeof makeClock>,
+    settings: unknown,
+    logger: { info(m: string): void; warn(m: string): void; error(m: string): void },
+  ) {
+    return new LifecycleService({
+      getEngine: () => engine as any,
+      logger,
+      now: () => clock.ms,
+      getSettings: () => settings as any,
+    });
+  }
+
+  function collectingLogger() {
+    const errors: string[] = [];
+    return {
+      errors,
+      info: () => {},
+      warn: () => {},
+      error: (m: string) => { errors.push(m); },
+    };
+  }
+
+  /** Publish → deliver → age past the override window, then sweep. */
+  async function ageACompletedMessage(
+    engine: ReturnType<typeof makeFakeEngine>,
+    clock: ReturnType<typeof makeClock>,
+  ): Promise<{ adapter: DbQueueAdapter; firstId: string }> {
+    const adapter = new DbQueueAdapter({
+      engine,
+      clock,
+      options: { autoStart: false, pollIntervalMs: 60_000 },
+    });
+    await adapter.subscribe('billing', async () => { /* delivered */ });
+    const firstId = await adapter.publish('billing', { invoice: 7 }, { idempotencyKey: 'inv-7' });
+    await adapter.pollOnce();
+    expect(engine.rows()[0]!.status).toBe('completed');
+    // Past the 1h override, far inside both the 7d declaration and the 24h
+    // dedup window: the exact gap #5195 is about.
+    clock.advance(2 * HOUR);
+    return { adapter, firstId };
+  }
+
+  it('REPRODUCES the bypass when no floor is registered: the row is reaped and the duplicate lands', async () => {
+    const engine = makeFakeEngine();
+    const clock = makeClock(Date.parse('2026-03-01T00:00:00.000Z'));
+    const { adapter, firstId } = await ageACompletedMessage(engine, clock);
+
+    await lifecycle(engine, clock, fakeSettings(OVERRIDE_1H), collectingLogger()).sweep();
+
+    // Nothing kept the reaper off the row the dedup check reads…
+    expect(engine.rows()).toHaveLength(0);
+    // …so the same key publishes again, 2 hours into a 24 hour window.
+    const again = await adapter.publish('billing', { invoice: 7 }, { idempotencyKey: 'inv-7' });
+    expect(again).not.toBe(firstId);
+    expect(engine.rows()).toHaveLength(1);
+  });
+
+  it('rejects the override once the adapter has registered its floor — dedup keeps holding', async () => {
+    const engine = makeFakeEngine();
+    const clock = makeClock(Date.parse('2026-03-01T00:00:00.000Z'));
+    const { adapter, firstId } = await ageACompletedMessage(engine, clock);
+    const logger = collectingLogger();
+
+    const svc = lifecycle(engine, clock, fakeSettings(OVERRIDE_1H), logger);
+    svc.registerRetentionFloor(QUEUE_TABLE, adapter.retentionFloor());
+    const report = await svc.sweep();
+
+    // The declared 7d window runs instead of the 1h override…
+    expect(engine.rows()).toHaveLength(1);
+    expect(report.swept[0]!.cutoff).toBe(new Date(clock.ms - 7 * DAY).toISOString());
+    // …and the re-publish is still deduplicated to the original message.
+    const again = await adapter.publish('billing', { invoice: 7 }, { idempotencyKey: 'inv-7' });
+    expect(again).toBe(firstId);
+    expect(engine.rows()).toHaveLength(1);
+
+    // Loud, with the consequence and both fixes an operator needs.
+    expect(report.floorViolations).toHaveLength(1);
+    expect(report.floorViolations[0]).toMatchObject({
+      object: QUEUE_TABLE,
+      policy: 'retention',
+      scope: 'global',
+      override: '1h',
+      floorMs: DEFAULT_IDEMPOTENCY_WINDOW_MS,
+      declaredBy: 'com.objectstack.service.queue',
+    });
+    expect(logger.errors).toHaveLength(1);
+    expect(logger.errors[0]).toContain('duplicate deliveries resume silently');
+    expect(logger.errors[0]).toContain('lifecycle.retention_overrides.sys_job_queue.maxAge');
+    expect(logger.errors[0]).toContain('idempotencyWindowMs');
+  });
+
+  it('a legal override (≥ the dedup window) still takes effect', async () => {
+    const engine = makeFakeEngine();
+    const clock = makeClock(Date.parse('2026-03-01T00:00:00.000Z'));
+    const adapter = new DbQueueAdapter({ engine, clock, options: { autoStart: false } });
+    // 2d: shorter than the declared 7d, longer than the 24h dedup window.
+    const svc = lifecycle(
+      engine,
+      clock,
+      fakeSettings({ retention_overrides: { [QUEUE_TABLE]: { maxAge: '2d' } } }),
+      collectingLogger(),
+    );
+    svc.registerRetentionFloor(QUEUE_TABLE, adapter.retentionFloor());
+
+    const report = await svc.sweep();
+
+    expect(report.floorViolations).toEqual([]);
+    expect(report.swept[0]!.cutoff).toBe(new Date(clock.ms - 2 * DAY).toISOString());
+  });
+
+  it('the floor carries the CONFIGURED idempotency window, not the default', () => {
+    const adapter = new DbQueueAdapter({
+      engine: makeFakeEngine(),
+      options: { autoStart: false, idempotencyWindowMs: 3 * DAY },
+    });
+    // A static key on the object declaration could never say this — the number
+    // is a per-kernel construction option.
+    expect(adapter.idempotencyWindowMs).toBe(3 * DAY);
+    expect(adapter.retentionFloor()).toMatchObject({
+      policy: 'retention',
+      minWindowMs: 3 * DAY,
+      declaredBy: 'com.objectstack.service.queue',
+    });
+
+    const engine = makeFakeEngine();
+    const clock = makeClock(Date.parse('2026-03-01T00:00:00.000Z'));
+    const svc = lifecycle(
+      engine,
+      clock,
+      fakeSettings({ retention_overrides: { [QUEUE_TABLE]: { maxAge: '2d' } } }),
+      collectingLogger(),
+    );
+    svc.registerRetentionFloor(QUEUE_TABLE, adapter.retentionFloor());
+    // 2d clears the 24h default but NOT this adapter's 3d window.
+    return svc.sweep().then((report) => {
+      expect(report.floorViolations).toHaveLength(1);
+      expect(report.floorViolations[0]!.floorMs).toBe(3 * DAY);
+    });
+  });
+
+  it('QueueServicePlugin registers the floor at kernel:ready (the wiring, not just the ability)', async () => {
+    const engine = makeFakeEngine();
+    const clock = makeClock(Date.parse('2026-03-01T00:00:00.000Z'));
+    const svc = lifecycle(engine, clock, fakeSettings(OVERRIDE_1H), collectingLogger());
+
+    const readyHooks: Array<() => Promise<void>> = [];
+    const services = new Map<string, unknown>([
+      ['manifest', { register: () => {} }],
+      ['objectql', engine],
+      ['lifecycle', svc],
+    ]);
+    const ctx: any = {
+      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+      getService: (name: string) => {
+        if (!services.has(name)) throw new Error(`no service '${name}'`);
+        return services.get(name);
+      },
+      registerService: (name: string, s: unknown) => { services.set(name, s); },
+      replaceService: (name: string, s: unknown) => { services.set(name, s); },
+      hook: (name: string, fn: () => Promise<void>) => {
+        if (name === 'kernel:ready') readyHooks.push(fn);
+      },
+    };
+
+    const plugin = new QueueServicePlugin({ adapter: 'db', db: { pollIntervalMs: 60_000 } });
+    await plugin.init(ctx);
+    for (const fn of readyHooks) await fn();
+    await plugin.destroy();
+
+    // An unswept-by-1h row is the observable proof the plugin did the wiring —
+    // the ability to register a floor is worth nothing if nobody calls it.
+    engine.tables.set(QUEUE_TABLE, [{
+      id: 'm_old', queue: 'q', status: 'completed', payload_json: '{}',
+      created_at: new Date(clock.ms - 3 * HOUR).toISOString(),
+    }]);
+    const report = await svc.sweep();
+
+    expect(engine.rows()).toHaveLength(1);
+    expect(report.floorViolations[0]).toMatchObject({
+      object: QUEUE_TABLE,
+      floorMs: DEFAULT_IDEMPOTENCY_WINDOW_MS,
+      declaredBy: 'com.objectstack.service.queue',
+    });
   });
 });

--- a/packages/services/service-queue/src/queue-service-plugin.ts
+++ b/packages/services/service-queue/src/queue-service-plugin.ts
@@ -5,7 +5,7 @@ import { SysJobQueue } from '@objectstack/platform-objects/audit';
 import { MemoryQueueAdapter } from './memory-queue-adapter.js';
 import type { MemoryQueueAdapterOptions } from './memory-queue-adapter.js';
 import { DbQueueAdapter } from './db-queue-adapter.js';
-import type { DbQueueAdapterOptions } from './db-queue-adapter.js';
+import type { DbQueueAdapterOptions, LifecycleFloorRegistrar } from './db-queue-adapter.js';
 
 /**
  * Configuration options for the QueueServicePlugin.
@@ -130,14 +130,19 @@ export class QueueServicePlugin implements Plugin {
 
   /**
    * [#5195] Register the adapter's retention floor with the platform
-   * LifecycleService. Duck-typed and best-effort, exactly like the storage
-   * service's reap guards: a kernel without a lifecycle service has no sweeper
-   * either, so there is no override for anything to bypass.
+   * LifecycleService. Best-effort: a kernel without a lifecycle service has no
+   * sweeper either, so there is no override for anything to bypass.
+   *
+   * The lookup is typed to {@link LifecycleFloorRegistrar} — the slot's
+   * contract as this package consumes it — rather than erased to `any`
+   * (#4127/#4251). The `typeof … === 'function'` probe stays because the method
+   * is genuinely optional (a lifecycle service predating floors), but it is now
+   * a check the compiler can see rather than one `any` was hiding.
    */
   private registerRetentionFloor(ctx: PluginContext, adapter: DbQueueAdapter): void {
-    let lifecycle: any;
+    let lifecycle: LifecycleFloorRegistrar | undefined;
     try {
-      lifecycle = ctx.getService<any>('lifecycle');
+      lifecycle = ctx.getService<LifecycleFloorRegistrar>('lifecycle');
     } catch {
       lifecycle = undefined;
     }

--- a/packages/services/service-queue/src/queue-service-plugin.ts
+++ b/packages/services/service-queue/src/queue-service-plugin.ts
@@ -107,6 +107,17 @@ export class QueueServicePlugin implements Plugin {
         options: this.options.db,
       });
 
+      // [#5195] Tell the LifecycleService how short sys_job_queue's retention
+      // may get. The adapter's constructor already refuses an idempotency
+      // window longer than the DECLARED retention (#5179), but ADR-0057 P4
+      // overrides live in the `lifecycle` settings namespace, which the
+      // constructor never sees — an operator setting `maxAge: '1h'` would reap
+      // the rows publish dedups against and duplicate deliveries would resume
+      // silently. The floor carries the window this adapter was actually
+      // constructed with, so a non-default `db.idempotencyWindowMs` is covered
+      // too.
+      this.registerRetentionFloor(ctx, this.dbAdapter);
+
       try {
         (ctx as any).replaceService?.('queue', this.dbAdapter);
         this.dbAdapter.start();
@@ -115,6 +126,39 @@ export class QueueServicePlugin implements Plugin {
         ctx.logger.warn('QueueServicePlugin: replaceService failed; staying on MemoryQueueAdapter', err as any);
       }
     });
+  }
+
+  /**
+   * [#5195] Register the adapter's retention floor with the platform
+   * LifecycleService. Duck-typed and best-effort, exactly like the storage
+   * service's reap guards: a kernel without a lifecycle service has no sweeper
+   * either, so there is no override for anything to bypass.
+   */
+  private registerRetentionFloor(ctx: PluginContext, adapter: DbQueueAdapter): void {
+    let lifecycle: any;
+    try {
+      lifecycle = ctx.getService<any>('lifecycle');
+    } catch {
+      lifecycle = undefined;
+    }
+    if (!lifecycle || typeof lifecycle.registerRetentionFloor !== 'function') return;
+    try {
+      lifecycle.registerRetentionFloor(SysJobQueue.name, adapter.retentionFloor());
+      ctx.logger.info(
+        `QueueServicePlugin: registered a ${adapter.idempotencyWindowMs}ms retention floor on ${SysJobQueue.name} `
+        + 'with the lifecycle service (settings overrides below it are rejected)',
+      );
+    } catch (err) {
+      // A floor the service refused is a wiring bug in THIS plugin, not a
+      // degraded deployment — but it must not stop the queue from coming up.
+      ctx.logger.error(
+        'QueueServicePlugin: the lifecycle service rejected the sys_job_queue retention floor. A `lifecycle` '
+        + 'settings override may now shorten sys_job_queue.retention below the idempotency window, in which case '
+        + 'publish would silently re-accept duplicates (#5195). Fix the floor registration, or keep '
+        + 'lifecycle.retention_overrides.sys_job_queue unset.',
+        err as any,
+      );
+    }
   }
 
   async destroy(): Promise<void> {

--- a/scripts/adr-anchors.json
+++ b/scripts/adr-anchors.json
@@ -2,6 +2,11 @@
   "//": "ADR anchors — see scripts/check-adr-anchors.mjs. Each entry pins the ADR ids that MUST stay referenced in a file whose behaviour an accepted ADR decided. Add an entry when an ADR's decision is realized in code that would look arbitrary (or wrong) to someone reading the file alone.",
   "anchors": [
     {
+      "file": "packages/objectql/src/lifecycle/lifecycle-service.ts",
+      "adrs": ["ADR-0057"],
+      "invariant": "ADR-0057 P4 settings overrides are bounded from below by consumer-registered retention floors (§3.3 amendment, #5195). An override under a floor — global or tenant-scoped — is REJECTED, never clamped to the floor: the declared window is the one fallback, the same resolution an unparseable override already gets, and a clamp would enforce a third number written in neither the declaration nor the settings. Floors are runtime wiring, not spec surface, for the reap-guard reason plus one of their own — the first floor IS `DbQueueAdapterOptions.idempotencyWindowMs`, a per-kernel construction option a static `lifecycle` key could only copy and drift from. The rejection is `error`-level with consequence and fix because what it prevents (duplicate delivery on a reaped dedup row) leaves the system looking healthy."
+    },
+    {
       "file": "packages/objectql/src/validation/rule-validator.ts",
       "adrs": ["ADR-0057", "ADR-0058"],
       "invariant": "A declared field lock is the SERVER's to enforce (ADR-0057 D10 — the client grid is courtesy). A `readonlyWhen` whose predicate names a scope root the write path could not bind resolves to LOCKED, not to \"not locked\": \"could not check\" must never read as \"allowed\" on a field the author declared frozen. This narrows ADR-0058 D5's fail-soft tier deliberately and only for that case — a merely BROKEN predicate (undeclared key, null overload, parse fault, throw) still fails open, and requiredWhen / option visibleWhen are untouched."


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5195

## 边门是什么

ADR-0057 P4 允许运维通过 `lifecycle` settings 命名空间按环境/租户覆盖任一对象的保留窗,而在此之前对覆盖值的**唯一**校验是「能不能解析」(`lifecycle-service.ts` 的 `effectiveWindowMs`:覆盖胜过声明,只在解析失败时回落)。可保留窗并不只是运维一个人的事——**别的代码可能依赖那些行还在**。

`sys_job_queue` 就是现成的例子。`DbQueueAdapter` 的 publish 去重靠「拿终态行的 `created_at` 比 idempotency 窗」,#5192 把这个顺序做成了构造期不变量:构造时拒绝「idempotencyWindowMs > 对象**声明**的 retention」。但构造期读不到 settings 覆盖:

```jsonc
// lifecycle → retention_overrides
{ "sys_job_queue": { "maxAge": "1h" } }
```

completed 行写下 1 小时就被清、publish 仍按 24h 去重 → 窗口内的重复投递被重新接受,**日志里一行都没有**。一个昨天刚立起来的强制不变量,今天就有一扇能绕开它的边门。

## 落点:消费者向 lifecycle 注册「下限」

不写死 `sys_job_queue`,也**没动 `packages/spec`**。消费方在运行期声明自己的契约能承受的最短窗:

```ts
lifecycle.registerRetentionFloor('sys_job_queue', {
  policy: 'retention',          // 或 'ttl'
  minWindowMs: 24 * 60 * 60 * 1000,
  declaredBy: 'com.objectstack.service.queue',
  consequence: '…低于下限时什么会静默坏掉',
  remedy: '…把覆盖改成什么才合法',
});
```

`QueueServicePlugin` 在 `kernel:ready` 注册,和 service-storage 注册 reap guard 是同一形状(duck-typed、best-effort、没有 lifecycle 服务时什么都不做——那种内核本来也没有 sweeper)。

**为什么是运行期注册而不是 spec 上加 `minRetention`**:队列的下限**就是** `DbQueueAdapterOptions.idempotencyWindowMs`,一个 per-kernel 的构造参数。对象声明里的静态键只能是它的第二份拷贝,而且注定漂移。声明说的是「行保留多久」,下限说的是「**消费方**能承受行只保留多短」——两个不同作者、不同生命周期的数字。所以这条不需要动 spec,也**不应该**动 spec。

## 拒绝,不 clamp

覆盖低于下限时**拒绝该覆盖**,声明窗继续跑;不是 clamp 到下限。理由:

- clamp 会强制执行一个**声明里没有、settings 里也没有**的第三个数字——运维看哪个面都预测不出行到底什么时候消失;而且这个数字会因为一个不相干的包改了自己的下限而移动。
- 拒绝只有一个回落值:声明。这恰好是本文件里既有的处理方式(解析失败的覆盖也是回落到声明,「never fail open into no bound at all」),一条规则而不是两条。
- 运维的意图不是被悄悄地打个折,而是被**明确拒绝**,并同时给出两个能让它合法的设置。

## 响亮程度

- `error` 级(不是 `warn`)。按 AGENTS.md 的判据:降级之后系统**从外面看完全正常**——sweep 报告成功、表照常缩小——而被悄悄破坏的契约要到几天后的重复投递才显形。日志一行同时给出**后果**与**修复**:

  ```
  [lifecycle] REJECTED the retention override '1h' (3600000ms) on sys_job_queue at global scope:
  it is below the 86400000ms floor registered by 'com.objectstack.service.queue'. Enforcing the
  declared 604800000ms window instead. Consequence: DbQueueAdapter dedups sys_job_queue publishes
  by comparing created_at against its 86400000ms idempotency window, so a shorter retention deletes
  the very rows that check reads — duplicate deliveries resume silently, with nothing in any log.
  Fix: set lifecycle.retention_overrides.sys_job_queue.maxAge to '24h' or longer, or lower
  QueueServicePlugin's db.idempotencyWindowMs to the window you actually want (both are measured
  from created_at).
  ```

- 同时进 sweep report:`LifecycleSweepReport.floorViolations`,机器可读,**每轮都报**;日志按「同一处违规只说一次」去重(AGENTS.md:say it once),避免每小时一条 error 把人训练成跳过 error。

## 覆盖面

- **全局**覆盖和**租户级**覆盖走同一道门(租户级的 `maxAge: '1h'` 是同一扇边门往下一层)。
- `retention`(`maxAge`,含 rotation fallback)与 `ttl`(`expireAfter`)是两个独立的下限,互不误伤。
- 同一对象多个消费方各自注册时,**最严的下限**生效;同一 `(object, policy, declaredBy)` 重复注册是替换而非累积。
- **声明本身**低于下限也照样报(同样 `error` + report),但**仍然执行**——拒绝清扫等于用「消费方契约坏了」换回 #5179 刚关掉的无界增长表,不划算。
- **没注册下限的表完全不受影响**:P4 覆盖行为一字未变。
- 注册畸形的下限(缺 `consequence`/`remedy`、`minWindowMs ≤ 0`、policy 非法)在**注册时就抛**——一条没人能照着做的 error 日志等于没有。

## 改动面

| 文件 | 内容 |
|---|---|
| `packages/objectql/src/lifecycle/lifecycle-service.ts` | `registerRetentionFloor()`、`LifecycleRetentionFloor` / `LifecycleFloorViolation`、floor-aware 的 `effectiveWindowMs`、`report.floorViolations`、`LifecycleLoggerLike.error?`(缺省回落 `warn`) |
| `packages/objectql/src/lifecycle/lifecycle-settings.ts` | `retention_overrides` 的运维说明补上「低于下限会被拒」 |
| `packages/services/service-queue/src/db-queue-adapter.ts` | `idempotencyWindowMs` getter + `retentionFloor()`(带构造时的真实窗口,`remedy` 里给的是运维能直接粘的时长字面量) |
| `packages/services/service-queue/src/queue-service-plugin.ts` | `kernel:ready` 注册下限 |
| `docs/adr/0057-…md` | §3.3 新增 Amendment (#5195);`scripts/adr-anchors.json` 给 `lifecycle-service.ts` 上锚 |
| `packages/services/service-queue/README.md` | 原来那句提醒式的「Keep it ≥ your idempotency window」换成实际强制的描述 |

## 测试

`packages/objectql`(14 条新用例)+ `packages/services/service-queue`(5 条新用例,跑**真的** `LifecycleService` × **真的** `SysJobQueue` 声明):

- 1h 覆盖被拒 / 合法覆盖(2d)仍生效 / 恰好等于下限合法(界是 `≥` 不是 `>`)/ 无下限的表不受影响;
- 租户级覆盖同样被拒;ttl 下限与 retention 下限互不干扰;最严下限生效;重复注册是替换;
- 日志说一次、report 每轮都有;没有 `error` 方法的 logger 回落 `warn`;畸形下限注册即抛;
- **端到端**:publish → 投递 → 过 2 小时 → sweep,带下限时行还在、同 key 重发仍被去重;
- 以及一条 `REPRODUCES the bypass`(不注册下限时行被清、重复真的落库)——证明这套 harness **有能力失败**,不是恒真。

新写的假引擎全部把 `delete()` 路由到 `assertEngineDeleteDispatch(options)`(#4550 门禁,本分支跑绿)。

```
$ pnpm --filter @objectstack/objectql test
 Test Files  115 passed (115)
      Tests  1833 passed (1833)

$ pnpm --filter @objectstack/service-queue test
 Test Files  3 passed (3)
      Tests  35 passed (35)

$ pnpm --filter @objectstack/objectql --filter @objectstack/service-queue typecheck
packages/objectql typecheck: Done
packages/services/service-queue typecheck: Done

$ node scripts/check-engine-double-contract.mjs
check-engine-double-contract: OK — 17 pinned, 31 in the DEBT ledger, 1 exempt.
$ node scripts/check-startup-registry-verdict.mjs
✓ 40 startup/open-registry seam(s), none recording a verdict the boot can contradict.
$ node scripts/check-durability-degradation-log-level.mjs
✓ 14 durability-critical catch seam(s), all loud or rethrowing.
$ node scripts/check-adr-anchors.mjs
check-adr-anchors: OK (21 anchored file(s))
```

新用例逐条(verbose):

```
✓ LifecycleService — retention floors (#5195) > rejects a global override below the floor and keeps enforcing the declared window
✓ … > a legal override (≥ the floor) still wins over the declared window
✓ … > an override exactly AT the floor is legal (the bound is ≥, not >)
✓ … > an object with no registered floor is untouched — 1h still applies
✓ … > floors a TENANT-scoped override too — the same door one scope down
✓ … > a retention floor does not reject a ttl override (policies are separate windows)
✓ … > the strictest of several registered floors governs
✓ … > re-registering the same (object, policy, declaredBy) replaces rather than accumulates
✓ … > reports a DECLARED window below the floor, and still enforces it
✓ … > logs a standing violation once, but reports it on every sweep
✓ … > falls back to warn when the logger has no error method
✓ … > refuses a malformed floor at registration — an unactionable rejection helps nobody
✓ … > an unparseable override still keeps the declared window and is not a floor violation
✓ a lifecycle settings override cannot undercut the dedup window (#5195) > REPRODUCES the bypass when no floor is registered: the row is reaped and the duplicate lands
✓ … > rejects the override once the adapter has registered its floor — dedup keeps holding
✓ … > a legal override (≥ the dedup window) still takes effect
✓ … > the floor carries the CONFIGURED idempotency window, not the default
✓ … > QueueServicePlugin registers the floor at kernel:ready (the wiring, not just the ability)
```

changeset:`.changeset/lifecycle-retention-floor.md`(`@objectstack/objectql` minor —— 新增公开导出与 report 字段;`@objectstack/service-queue` patch)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MCKJaEomEqg4tvz4SzdNd


---
_Generated by [Claude Code](https://claude.ai/code/session_017MCKJaEomEqg4tvz4SzdNd)_