### PR TITLE
fix(plugin-audit): exclude sys_upload_session from audit/activity writes (#5202)

### DIFF
--- a/.changeset/audit-skip-sys-upload-session.md
+++ b/.changeset/audit-skip-sys-upload-session.md
@@ -1,0 +1,35 @@
+---
+"@objectstack/plugin-audit": patch
+---
+
+fix(plugin-audit): stop mirroring chunked-upload progress into the audit ledger (#5202)
+
+`SKIP_OBJECTS` in `audit-writers.ts` excludes operational telemetry / plumbing
+from `sys_audit_log` and `sys_activity` — ADR-0057 decision 5, *"stop the
+amplifier"*. `sys_upload_session` was the second table missing from group (2)
+for the same reason `sys_job_queue` was (#5193): it declares
+`lifecycle.class: 'transient'` and its own object comment says what the rows are
+worth — *"an upload session is ephemeral state, never business truth"*
+(ADR-0057 / #2970 item 4) — but nothing connected that declaration to the
+exemption list, which is hand-written.
+
+The audit hooks register for **all** objects and there is no "writes made under
+a system context are not audited" exemption, so `StorageMetadataStore`'s own
+writes were recorded like user edits. A chunked upload of N parts costs 1 + N
+writes — the `createSession()` insert plus one `updateSession()` per chunk — and
+then a terminal status update and the row's removal, each producing an
+`sys_audit_log` **and** an `sys_activity` row: 2 × (1 + N) rows for one file,
+with a `beforeUpdate` snapshot read apiece. Each of those rows was also unusually
+fat, because `updateSession()` writes the merged **full** record, so the `parts`
+JSON blob that grows with every chunk rode along in each diff's `old_value` /
+`new_value`.
+
+Nothing else changes: the exemption is one name in one list, and ordinary
+business objects are audited exactly as before. In particular `sys_file` stays
+audited — it declares `transient` too, but only to reap tombstones and
+unfinished uploads; its rows are mostly permanent business truth and keep their
+compliance value.
+
+Operators who tracked upload activity through `sys_activity` should read
+`sys_upload_session` (in-progress state) and `sys_file` (the durable record of
+what was actually stored) instead.

--- a/packages/plugins/plugin-audit/src/audit-writers.test.ts
+++ b/packages/plugins/plugin-audit/src/audit-writers.test.ts
@@ -353,6 +353,165 @@ describe('audit writers — operational plumbing is excluded (#5193, ADR-0057 D5
   });
 });
 
+describe('audit writers — chunked upload sessions are excluded (#5202, ADR-0057 D5)', () => {
+  // The upload-session table as `StorageMetadataStore` writes it, plus
+  // `sys_file` (its sibling, deliberately NOT exempted) and a business object.
+  // Same wildcard hooks a business object goes through — `SKIP_OBJECTS` is the
+  // only thing between an upload and the ledger.
+  const SCHEMA = {
+    sys_audit_log: SINGLE_TENANT.sys_audit_log,
+    sys_activity: SINGLE_TENANT.sys_activity,
+    sys_upload_session: ['id', 'file_id', 'status', 'uploaded_chunks', 'uploaded_size', 'parts', 'started_at', 'expires_at', 'updated_at'],
+    sys_file: ['id', 'name', 'size', 'status'],
+    crm_lead: ['id', 'name'],
+  };
+
+  /**
+   * Every write `StorageMetadataStore` performs for ONE chunked upload of
+   * `chunks` parts, in order: `createSession()` insert, one `updateSession()`
+   * per chunk, the terminal `updateSession()`, and the row's removal.
+   *
+   * `updateSession()` writes the MERGED FULL record, so `parts` — the JSON blob
+   * that grows by one entry per chunk — is in every single diff. The fixture
+   * grows it for real rather than sending a placeholder, because the size of
+   * those `old_value`/`new_value` payloads is half of what #5202 is about.
+   */
+  function uploadLifecycle(
+    chunks: number,
+    terminal: { status: string; via: 'afterUpdate' | 'afterDelete' },
+  ): Array<[string, Record<string, any>]> {
+    const partsAfter = (n: number) =>
+      JSON.stringify(Array.from({ length: n }, (_, i) => ({ part: i + 1, etag: `etag-${i + 1}` })));
+    const snapshot = (n: number, status: string) => ({
+      id: 'ups-1',
+      file_id: 'file-1',
+      status,
+      uploaded_chunks: n,
+      uploaded_size: n * 5_242_880,
+      parts: partsAfter(n),
+      updated_at: `2026-08-04T00:00:${String(n).padStart(2, '0')}.000Z`,
+    });
+
+    const writes: Array<[string, Record<string, any>]> = [
+      // createSession() — engine.insert with the full seeded record.
+      ['afterInsert', { input: { id: 'ups-1' }, result: snapshot(0, 'in_progress') }],
+    ];
+    // updateSession() — ONE per chunk, each carrying the whole grown record.
+    for (let n = 1; n <= chunks; n += 1) {
+      writes.push([
+        'afterUpdate',
+        {
+          input: snapshot(n, 'in_progress'),
+          __previous: snapshot(n - 1, 'in_progress'),
+          result: snapshot(n, 'in_progress'),
+        },
+      ]);
+    }
+    // complete() / abort() — a final updateSession() flipping status…
+    writes.push([
+      'afterUpdate',
+      {
+        input: { id: 'ups-1', status: terminal.status },
+        __previous: snapshot(chunks, 'in_progress'),
+        result: snapshot(chunks, terminal.status),
+      },
+    ]);
+    // …then deleteSession(), or the ADR-0057 TTL/retention reaper.
+    if (terminal.via === 'afterDelete') {
+      writes.push([
+        'afterDelete',
+        { input: { id: 'ups-1' }, __previous: snapshot(chunks, terminal.status), result: { id: 'ups-1' } },
+      ]);
+    }
+    return writes;
+  }
+
+  it('writes NO audit/activity row for a completed 8-chunk upload (create → 8 × update → complete → delete)', async () => {
+    const { engine, fire, created } = makeEngine(SCHEMA);
+    installAuditWriters(engine as any, 'test.audit');
+
+    const writes = uploadLifecycle(8, { status: 'completed', via: 'afterDelete' });
+    // Sanity-check the fixture itself: 1 insert + 8 chunk updates + 1 terminal
+    // update + 1 delete. Without the exemption that is 2 × 11 = 22 ledger rows
+    // for one file — the 2 × (1 + N) amplifier #5202 names.
+    expect(writes).toHaveLength(11);
+
+    for (const [event, ctx] of writes) {
+      await fire(event, { object: 'sys_upload_session', session: { isSystem: true }, ...ctx });
+    }
+
+    // Not "fewer rows" — zero.
+    expect(created).toEqual([]);
+  });
+
+  it('writes NO audit/activity row when the session is aborted and reaped instead', async () => {
+    const { engine, fire, created } = makeEngine(SCHEMA);
+    installAuditWriters(engine as any, 'test.audit');
+
+    // Abandoned mid-upload: the terminal write is the TTL reaper's DELETE of a
+    // row 1d past `expires_at`, not a user action.
+    for (const [event, ctx] of uploadLifecycle(3, { status: 'expired', via: 'afterDelete' })) {
+      await fire(event, { object: 'sys_upload_session', session: { isSystem: true }, ...ctx });
+    }
+    expect(created).toEqual([]);
+  });
+
+  it('does not re-read the growing session row before every chunk update', async () => {
+    const { engine, fire } = makeEngine(SCHEMA);
+    installAuditWriters(engine as any, 'test.audit');
+    const reads: string[] = [];
+    const ql = {
+      async findOne(object: string) {
+        reads.push(object);
+        return { id: 'ups-1' };
+      },
+    };
+
+    // `captureBefore` would otherwise snapshot the row — `parts` blob and all —
+    // once per chunk, on top of the write the store is already doing.
+    for (let n = 1; n <= 4; n += 1) {
+      await fire('beforeUpdate', { object: 'sys_upload_session', input: { id: 'ups-1', uploaded_chunks: n }, ql });
+    }
+    await fire('beforeDelete', { object: 'sys_upload_session', input: { id: 'ups-1' }, ql });
+    expect(reads).toEqual([]);
+
+    // Control — the assertion above can fail: a business object on the same
+    // harness DOES get snapshotted.
+    await fire('beforeUpdate', { object: 'crm_lead', input: { id: 'lead-1', name: 'Acme' }, ql });
+    expect(reads).toEqual(['crm_lead']);
+  });
+
+  it('still audits sys_file — mostly permanent business truth, deliberately NOT exempted', async () => {
+    const { engine, fire, created } = makeEngine(SCHEMA);
+    installAuditWriters(engine as any, 'test.audit');
+
+    // `sys_file` also declares `lifecycle.class: 'transient'`, but only to reap
+    // tombstones and unfinished uploads; the rows themselves are business truth
+    // with compliance value. #5202 exempts the SESSION, never the FILE — if a
+    // later "finish the sweep" change adds `sys_file` to `SKIP_OBJECTS`, this
+    // is the test that says no.
+    await fire('afterInsert', {
+      object: 'sys_file',
+      input: { id: 'file-1' },
+      result: { id: 'file-1', name: 'contract.pdf', size: 41_943_040, status: 'ready' },
+      session: { userId: 'user-1' },
+    });
+    expect(created.map((c) => c.object)).toEqual(['sys_audit_log', 'sys_activity']);
+  });
+
+  it('still audits ordinary business writes (the skip stays narrow)', async () => {
+    const { engine, fire, created } = makeEngine(SCHEMA);
+    installAuditWriters(engine as any, 'test.audit');
+    await fire('afterInsert', {
+      object: 'crm_lead',
+      input: { id: 'lead-1' },
+      result: { id: 'lead-1', name: 'Acme' },
+      session: { userId: 'user-1' },
+    });
+    expect(created.map((c) => c.object)).toEqual(['sys_audit_log', 'sys_activity']);
+  });
+});
+
 describe('audit writers — declarative trackHistory activity (ADR-0052 §5b)', () => {
   // crm_opportunity with a tracked select field (Stage) carrying option labels.
   const SCHEMA = {

--- a/packages/plugins/plugin-audit/src/audit-writers.ts
+++ b/packages/plugins/plugin-audit/src/audit-writers.ts
@@ -125,6 +125,19 @@ const SKIP_OBJECTS = new Set<string>([
   'sys_notification_receipt',
   'sys_inbox_message',           // per-user fan-out of every notification
   'sys_http_delivery',           // webhook/outbound transport log
+  // [#5202, ADR-0057 D5 — the same gap as #5193, one table over] Also
+  // `lifecycle.class: 'transient'`, and its own object comment settles what the
+  // rows are worth: "an upload session is ephemeral state, **never business
+  // truth**" (ADR-0057 / #2970 item 4). `StorageMetadataStore` is its only
+  // writer — `createSession()` inserts, `updateSession()` runs ONCE PER CHUNK,
+  // and `deleteSession()` (plus the TTL/retention reaper) removes the row — so
+  // an N-chunk upload cost 2 × (1 + N) `sys_audit_log` + `sys_activity` rows,
+  // each with its own `beforeUpdate` snapshot read. Worse per row than the
+  // count suggests: `updateSession()` writes the MERGED FULL record, so every
+  // chunk's diff drags along the `parts` JSON blob that grows with each part.
+  // Deliberately NOT `sys_file`: those rows are mostly permanent business truth
+  // and keep their compliance value, so they stay audited (see #5202).
+  'sys_upload_session',          // chunked-upload progress (1 write per chunk)
   'ai_traces',                   // LLM trace telemetry
 ]);
 


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5202

与 #5193 / PR #5201 **完全同形**:一行清单 + 注释,不做任何横切改造。

## 改了什么

`packages/plugins/plugin-audit/src/audit-writers.ts` 的 `SKIP_OBJECTS` 第 (2) 组
(ADR-0057 决策 5 “stop the amplifier”)加入 `sys_upload_session`,注释写明理由:

- 它同样声明 `lifecycle.class: 'transient'`;
- 它自己的对象注释已经把这些行的价值说死了 ——「an upload session is ephemeral state,
  **never business truth**」(ADR-0057 / #2970 item 4);
- 但这张豁免清单是**手写**的,与对象上的 `lifecycle.class` 没有任何机械关联,所以声明归声明,
  豁免归豁免 —— 这是同一个耦合缺失的第二个实例(第一个是 #5193)。

## 为什么是放大器

审计钩子对**全部对象**注册,且没有「系统上下文写入不审计」的豁免,所以
`StorageMetadataStore` 自己的写入被当成用户编辑记了下来。一次 N 块的分块上传:

| 写入 | 次数 |
|:--|:--|
| `createSession()` → `engine.insert` | 1 |
| `updateSession()` → `engine.update`(**每块一次**) | N |
| 终态 `updateSession()`(completed / failed / expired) | 1 |
| `deleteSession()` 或 ADR-0057 的 TTL / retention reaper | 1 |

每次写入同时落一行 `sys_audit_log` **和**一行 `sys_activity`,即 2 × (1 + N) 行,
外加每次 `beforeUpdate` 的 `captureBefore` 快照读。而且每行还特别肥:`updateSession()`
写的是 merged **全量**记录,所以那个随块数增长的 `parts` JSON blob 会挤进每一次 diff 的
`old_value` / `new_value`。

## ⛔ 没有动 `sys_file`

`sys_file` 也声明了 `transient`,但那只为收墓碑行与未完成上传;其行是 mostly permanent
business truth,审计有合规价值 —— #5201 的 dev 已查过并刻意不豁免,本 PR 沿用该判断,
并**加了一个测试把这个刻意的不豁免钉住**,防止后来者“顺手补全”把 `sys_file` 也塞进去。

同样按 issue 要求**未做**「`SKIP_OBJECTS` 与 `lifecycle.class` 机械关联」的横切改造
(独立决策),也未碰 `packages/spec` / `content/docs/releases/`。

## 测试

新增 describe 块 `audit writers — chunked upload sessions are excluded (#5202, ADR-0057 D5)`,
5 个用例:

1. **完整生命周期归零** —— create → 8 × chunk update → complete → delete,共 11 次写入,
   断言 `created` 为 `[]`(不是“少一点”,是零);fixture 里 `parts` 是**真的**按块增长的,
   因为那些 diff 载荷的体积正是本单的一半问题。
2. **中途放弃 + reaper 收行** —— 3 块后 `expired`,再由 TTL reaper DELETE,同样归零。
3. **不再为每块重读增长中的行** —— 4 次 `beforeUpdate` + 1 次 `beforeDelete` 零快照读,
   同一 harness 上的业务对象对照组证明该断言**能**失败。
4. **`sys_file` 仍然被审计**(刻意不豁免的钉子)。
5. **普通业务写入仍然被审计**(豁免面保持窄)。

假引擎沿用文件里既有的 `makeEngine`,**未定义 `delete()`**,所以不涉及 #5197 的
`assertEngineDeleteDispatch` 路由要求。

### 突变检查(删掉清单那一行 → 测试红)

```
× writes NO audit/activity row for a completed 8-chunk upload (create → 8 × update → complete → delete)
× writes NO audit/activity row when the session is aborted and reaped instead
× does not re-read the growing session row before every chunk update

AssertionError: expected [ …(22) ] to deeply equal []
AssertionError: expected [ …(12) ] to deeply equal []
AssertionError: expected [ 'sys_upload_session', …(4) ] to deeply equal []

Tests  3 failed | 105 passed (108)
```

22 = 2 × (1 + 8 + 1 + 1),12 = 2 × (1 + 3 + 1 + 1),5 = 4 次 chunk 快照读 + 1 次删除前快照读
—— 与 issue 正文推算的放大倍数逐位吻合。第 4、5 两个对照用例在突变下仍绿(它们本就该绿)。

### 恢复后

```
pnpm --filter @objectstack/plugin-audit typecheck   → tsc --noEmit, exit 0
pnpm --filter @objectstack/plugin-audit test        → Test Files 7 passed (7)
                                                       Tests 108 passed (108)
```

## Changeset

`.changeset/audit-skip-sys-upload-session.md`,`patch`(审计台账内容对运维可见),
照 #5201 的写法,含运维迁移提示:原先靠 `sys_activity` 看上传活动的,应改读
`sys_upload_session`(进行中状态)与 `sys_file`(实际存下什么的持久记录)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MCKJaEomEqg4tvz4SzdNd


---
_Generated by [Claude Code](https://claude.ai/code/session_017MCKJaEomEqg4tvz4SzdNd)_