### PR TITLE
fix(metadata): 集群对端的元数据写入现在会失效本节点的 listCache / registry (#5109)

### DIFF
--- a/.changeset/cluster-peer-write-invalidates-caches.md
+++ b/.changeset/cluster-peer-write-invalidates-caches.md
@@ -1,0 +1,39 @@
+---
+"@objectstack/metadata": patch
+---
+
+fix(metadata): 集群对端的元数据写入现在会失效本节点的 `listCache` / registry (#5109)
+
+多节点部署下,节点 A 改一条 `view` / `permission` / `flow`,节点 B 收到
+`metadata.changed` 广播后**只叫醒了 watcher,却没有失效自己的缓存**。
+`attachClusterPubSub()` 的订阅回调此前只做一件事 —— `notifyWatchersLocal()`,
+既不碰 `this.registry` 也不碰 `this.listCache`。后果是 B 上任何走 `list(type)`
+的读在 `LIST_CACHE_TTL_MS`(30 秒)窗口内继续返回改动前的清单;更糟的是,被叫醒的
+watcher(ObjectQL SchemaRegistry 桥、Studio HMR SSE)如果回头调 `list()` 重新拉取,
+拉到的还是旧的 —— 一份「失效通知」附带着失效数据。单机部署完全无感,只有多节点才暴露。
+
+这与该通道自己声明的用途相反(`ClusterMetadataChangedPayload`:"consumed by peers
+to **invalidate their local caches**",另见 `content/docs/kernel/cluster.mdx` §6.2
+与 `metadata-lifecycle.mdx`);现在实现与声明一致。
+
+修法沿用同文件里 `applyRepoEvent()` 自 ADR-0008 PR-6 起就用对的那条路径,并把两条
+「外部写入」缝(仓库 watch 循环、集群对端回放)收敛到同一个私有方法
+`invalidateForForeignWrite(type, name)`:
+
+- **删除而不预填。** 即便事件带着 body,也只删除 registry 条目而不写入 ——
+  那份 body 是别人那次写入的快照,可能已被后续写入取代,预填会与真实 head 竞态,
+  并要求我们去规范化一份自己没有加载过的定义。删除后 `get()` 自然穿透到 loader /
+  repository,也就是真相所在。
+- **同步失效,先失效再通知。** 失效发生在收到消息的当拍(不在 `setImmediate` 内),
+  通知仍然延迟派发。`setImmediate` 的存在理由是不让**消费方的 watcher 回调**背压
+  pubsub 派发循环;而失效只是两次 `Map.delete`,不执行任何消费方代码,没有需要延迟的
+  东西——把它一起延迟只会留下「已收到广播、尚未失效」的读窗口,请求处理器里任何一个
+  `await` 都足以撞进去。先失效后通知也与本文件其他写入路径
+  (`register` / `unregister` / `applyRepoEvent`)一致,于是回头 `list()` 的 watcher
+  拿到的是写后清单。
+- **无名事件只失效清单缓存。** `MetadataWatchEvent.name` 在 spec 里是可选的,无名事件
+  无法定位 registry 条目;此时不会把整个 type 的 registry 一并清掉 —— 那会驱逐
+  `registerInMemory()` 注册的、任何 loader 都无法恢复的代码态构件(如 `origin:'code'`
+  的 datasource)。
+
+回环抑制(`originNode`)仍然先于失效判断,本节点自己的广播不会让自己白白重建缓存。

--- a/content/docs/kernel/cluster.mdx
+++ b/content/docs/kernel/cluster.mdx
@@ -346,9 +346,20 @@ The transport is handed to the manager by `MetadataClusterBridgePlugin`
 `kernel:ready`. `Runtime` registers that bridge automatically alongside the
 cluster service.
 
-Peers suppress their own messages by `originNode` and replay the watch
-event locally — there is currently **no** `version` / `name` / `tenantId` /
-`operation` field and **no** version comparison.
+On receipt a peer suppresses its own messages by `originNode`, then — **first,
+synchronously** — invalidates its local caches for that type: it drops the
+`registry` entry named by the nested watch event and the `list(type)` cache
+(`invalidateForForeignWrite`). Only then does it replay the watch event into
+its local watch hub, deferred by one tick so a slow consumer callback cannot
+back-pressure the pubsub dispatch loop. That order is what lets a woken
+consumer answer by re-reading through `list()` and see the write rather than
+the pre-write set (#5109). The registry entry is **deleted, never pre-filled**
+from the payload — the peer re-reads the shared store, which is the source of
+truth.
+
+At the payload's top level there is still **no** `version` / `name` /
+`tenantId` / `operation` field and **no** version comparison; the item's name
+is carried only inside the replayed `event`.
 
 **Target spec (planned).** The richer, version-stamped payload below is
 defined as `MetadataChangedEventPayloadSchema` in `kernel/cluster.zod.ts`

--- a/packages/metadata/src/metadata-manager-cluster.test.ts
+++ b/packages/metadata/src/metadata-manager-cluster.test.ts
@@ -3,6 +3,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { MetadataManager } from './metadata-manager';
 import { MemoryLoader } from './loaders/memory-loader';
+import type { MetadataLoader } from './loaders/loader-interface.js';
+import type { MetadataLoaderContract, MetadataLoadResult, MetadataSaveResult, MetadataStats } from '@objectstack/spec/system';
 import type { IPubSub, PubSubMessage } from '@objectstack/spec/contracts';
 
 vi.mock('@objectstack/core', () => ({
@@ -39,7 +41,78 @@ class TestPubSub implements IPubSub {
     async close(): Promise<void> { this.subs.clear(); }
 }
 
+/**
+ * A writable, `datasource:`-protocol loader whose storage can be SHARED by two
+ * managers — the in-test stand-in for the one `sys_metadata` table two cluster
+ * replicas both read and write.
+ *
+ * `MemoryLoader` cannot play this role: its protocol is `memory:`, and
+ * `MetadataManager.register()` persists only to `datasource:` loaders that
+ * declare `capabilities.write`. Without a shared writable store, node A's
+ * write is invisible to node B no matter how node B's caches behave, and the
+ * #5109 regression cannot be observed at all.
+ */
+class SharedStoreLoader implements MetadataLoader {
+    readonly contract: MetadataLoaderContract = {
+        name: 'shared-store',
+        protocol: 'datasource:',
+        capabilities: { read: true, write: true, watch: false, list: true },
+    };
+
+    // type -> name -> data. Deliberately public: tests assert on it.
+    readonly storage = new Map<string, Map<string, unknown>>();
+
+    async load(type: string, name: string): Promise<MetadataLoadResult> {
+        const data = this.storage.get(type)?.get(name);
+        return data ? { data, source: 'shared-store', format: 'json', loadTime: 0 } : { data: null };
+    }
+    async loadMany<T = unknown>(type: string): Promise<T[]> {
+        return Array.from((this.storage.get(type) ?? new Map()).values()) as T[];
+    }
+    async exists(type: string, name: string): Promise<boolean> {
+        return this.storage.get(type)?.has(name) ?? false;
+    }
+    async stat(type: string, name: string): Promise<MetadataStats | null> {
+        return (await this.exists(type, name))
+            ? { size: 0, mtime: new Date().toISOString(), format: 'json' }
+            : null;
+    }
+    async list(type: string): Promise<string[]> {
+        return Array.from((this.storage.get(type) ?? new Map()).keys());
+    }
+    async save(type: string, name: string, data: unknown): Promise<MetadataSaveResult> {
+        let typeStore = this.storage.get(type);
+        if (!typeStore) { typeStore = new Map(); this.storage.set(type, typeStore); }
+        typeStore.set(name, data);
+        return { success: true, path: `${type}/${name}` };
+    }
+    async delete(type: string, name: string): Promise<void> {
+        this.storage.get(type)?.delete(name);
+    }
+}
+
 const flush = () => new Promise<void>((r) => setImmediate(r));
+
+/** Read a manager's private list cache without waiting on any async seam. */
+const cachedTypes = (mgr: MetadataManager): string[] =>
+    Array.from((mgr as unknown as { listCache: Map<string, unknown> }).listCache.keys());
+
+/**
+ * Two managers wired to one bus and one shared store — the cluster shape:
+ * two replicas of the same app in front of the same `sys_metadata`.
+ */
+function makeCluster() {
+    const bus = new TestPubSub();
+    const store = new SharedStoreLoader();
+    const a = new MetadataManager({ formats: ['json'], loaders: [store] });
+    const b = new MetadataManager({ formats: ['json'], loaders: [store] });
+    a.attachClusterPubSub(bus, 'node-A');
+    b.attachClusterPubSub(bus, 'node-B');
+    return { bus, store, a, b };
+}
+
+const viewNames = (items: unknown[]): string[] =>
+    (items as { name: string }[]).map((v) => v.name).sort();
 
 function makeManager(): MetadataManager {
     return new MetadataManager({
@@ -169,5 +242,156 @@ describe('MetadataManager — cluster pub/sub bridge', () => {
         await flush();
 
         expect(received).toHaveLength(0);
+    });
+});
+
+/**
+ * #5109 — a peer's write must invalidate THIS node's caches, not just wake its
+ * watchers.
+ *
+ * Before this, `attachClusterPubSub`'s subscriber did exactly one thing on an
+ * incoming `metadata.changed`: `notifyWatchersLocal()`. It never touched
+ * `registry` or `listCache`. So node B's watchers were woken while every
+ * `list(type)` on B kept answering the pre-write set for up to
+ * `LIST_CACHE_TTL_MS` (30s) — and a watcher that responded to the wake-up by
+ * re-reading through `list()` was handed the stale set back. An invalidation
+ * notice carrying invalidated data.
+ *
+ * The fix reuses `applyRepoEvent`'s long-standing shape (delete the registry
+ * entry, drop the list cache, THEN announce) via `invalidateForForeignWrite`.
+ */
+describe('MetadataManager — a cluster peer write invalidates local caches (#5109)', () => {
+    const view = (name: string, title: string) => ({ name, title, object: 'account' });
+
+    it('B\'s pre-warmed list() sees A\'s register() without waiting out the 30s TTL', async () => {
+        const { store, a, b } = makeCluster();
+        await store.save('view', 'v_existing', view('v_existing', 'existing'));
+
+        // B pre-warms its list cache — the issue's repro, verbatim.
+        expect(viewNames(await b.list('view'))).toEqual(['v_existing']);
+
+        // A writes. Same tick, no timers: the 30s TTL has not lapsed.
+        await a.register('view', 'v_new', view('v_new', 'new'));
+
+        expect(viewNames(await b.list('view'))).toEqual(['v_existing', 'v_new']);
+    });
+
+    it('propagates A\'s unregister() to B\'s list()', async () => {
+        const { store, a, b } = makeCluster();
+        await store.save('view', 'v_doomed', view('v_doomed', 'doomed'));
+        expect(viewNames(await b.list('view'))).toEqual(['v_doomed']);
+
+        await a.unregister('view', 'v_doomed');
+
+        expect(await b.list('view')).toEqual([]);
+    });
+
+    it('invalidates SYNCHRONOUSLY on receipt — not inside the deferred replay', async () => {
+        const { store, a, b } = makeCluster();
+        await store.save('view', 'v_existing', view('v_existing', 'existing'));
+        await b.list('view');
+        expect(cachedTypes(b)).toEqual(['view']);
+
+        const woken: unknown[] = [];
+        b.subscribe('view', (e: unknown) => { woken.push(e); });
+
+        await a.register('view', 'v_new', view('v_new', 'new'));
+
+        // Resuming from `await` is a microtask, so no `setImmediate` callback
+        // can have run yet: the watcher replay is still pending...
+        expect(woken).toHaveLength(0);
+        // ...and the cache is ALREADY gone. This is the seam the fix pins: a
+        // read landing between receipt and the deferred tick — every `await`
+        // inside a request handler is such a window — must not be served
+        // stale. Deferring the invalidation alongside the notify would leave
+        // this expectation red.
+        expect(cachedTypes(b)).toEqual([]);
+
+        await flush();
+        expect(woken).toHaveLength(1);
+    });
+
+    it('a watcher that re-reads via list() on the wake-up gets the post-write set', async () => {
+        const { store, a, b } = makeCluster();
+        await store.save('view', 'v_existing', view('v_existing', 'existing'));
+        await b.list('view');
+
+        // The ObjectQL SchemaRegistry bridge and the HMR SSE stream both react
+        // to the event by re-reading. That re-read is what used to contradict
+        // the notification it was answering.
+        let seenByWatcher: string[] = [];
+        const observed = new Promise<void>((resolve) => {
+            b.subscribe('view', () => {
+                void b.list('view').then((items: unknown[]) => {
+                    seenByWatcher = viewNames(items);
+                    resolve();
+                });
+            });
+        });
+
+        await a.register('view', 'v_new', view('v_new', 'new'));
+        await observed;
+
+        expect(seenByWatcher).toEqual(['v_existing', 'v_new']);
+    });
+
+    it('drops B\'s stale registry entry so get() falls through to the shared store', async () => {
+        const { store, a, b } = makeCluster();
+        // B holds its own copy in the in-memory registry, which shadows the
+        // store in both get() and list(). Dropping the list cache alone would
+        // leave B serving this copy forever.
+        await b.register('view', 'v_shared', view('v_shared', 'old'));
+        expect((await b.get('view', 'v_shared') as { title: string }).title).toBe('old');
+
+        await a.register('view', 'v_shared', view('v_shared', 'new'));
+
+        expect((await b.get('view', 'v_shared') as { title: string }).title).toBe('new');
+        expect((await b.list('view') as { title: string }[])[0].title).toBe('new');
+        // Deleted, never pre-filled from the payload — the answer came from
+        // the store, which is the source of truth (see
+        // `invalidateForForeignWrite`).
+        expect(store.storage.get('view')?.get('v_shared')).toMatchObject({ title: 'new' });
+    });
+
+    it('a nameless remote event invalidates the list cache but keeps in-memory-only entries', async () => {
+        const bus = new TestPubSub();
+        const mgr = makeManager();
+        mgr.attachClusterPubSub(bus, 'node-B');
+
+        // `registerInMemory` artefacts (code-owned datasources, ADR-0015
+        // Addendum) exist in NO loader — evicting one on a nameless event
+        // would be an unrecoverable loss in exchange for a guess.
+        mgr.registerInMemory('datasource', 'crm_db', { name: 'crm_db', origin: 'code' });
+        await mgr.list('datasource');
+        expect(cachedTypes(mgr)).toEqual(['datasource']);
+
+        // `MetadataWatchEvent.name` is optional in the spec, so this payload
+        // is legal on the wire.
+        await bus.publish('metadata.changed', {
+            originNode: 'node-A',
+            type: 'datasource',
+            event: { type: 'changed', path: '/some/file.json', timestamp: Date.now() },
+        });
+        await flush();
+
+        expect(cachedTypes(mgr)).toEqual([]);
+        expect(await mgr.get('datasource', 'crm_db')).toMatchObject({ name: 'crm_db' });
+    });
+
+    it('leaves the local node\'s own caches alone on a loopback event', async () => {
+        const { store, a } = makeCluster();
+        await store.save('view', 'v_existing', view('v_existing', 'existing'));
+        await a.list('view');
+        expect(cachedTypes(a)).toEqual(['view']);
+
+        // A hears its own broadcast back on a driver without dedup — the
+        // loopback guard must still short-circuit before any invalidation, or
+        // every local write would pay a needless cache rebuild.
+        await (a as unknown as { clusterPubSub: IPubSub }).clusterPubSub.publish(
+            'metadata.changed',
+            { originNode: 'node-A', type: 'view', event: { type: 'changed', name: 'v_existing', path: '' } },
+        );
+
+        expect(cachedTypes(a)).toEqual(['view']);
     });
 });

--- a/packages/metadata/src/metadata-manager.ts
+++ b/packages/metadata/src/metadata-manager.ts
@@ -185,9 +185,12 @@ export class MetadataManager implements IMetadataService {
   // become cluster-wide:
   //   • Local notifyWatchers() publishes on `metadata.changed` so peers
   //     can invalidate their caches.
-  //   • Subscribed remote events are replayed into the local watch hub
-  //     so existing consumers (ObjectQLPlugin, Studio HMR, …) see
-  //     uniform behavior regardless of which node initiated the change.
+  //   • A subscribed remote event first invalidates THIS node's caches
+  //     (registry entry + listCache, via `invalidateForForeignWrite` —
+  //     #5109) and is then replayed into the local watch hub, so existing
+  //     consumers (ObjectQLPlugin, Studio HMR, …) see uniform behavior
+  //     regardless of which node initiated the change — including when
+  //     they answer the event by re-reading through `list()`.
   // `originNode` on the payload prevents loopback; `partitionKey` keeps
   // per-object ordering on partitioned drivers.
   private clusterPubSub?: IPubSub;
@@ -207,9 +210,9 @@ export class MetadataManager implements IMetadataService {
   // ── #5089 (#5040 E2): declared-endpoint index ────────────────────────
   // Backs `matchEndpoint`. Lazily built from `api` items on the first call
   // and invalidated by every path that can change them — see
-  // `invalidateListCache` (local writes, repo events, HMR/artifact ingest,
-  // which registers with `notify:false`) and the `subscribe('api', …)`
-  // registration below (cluster peer replay, which reaches watchers only).
+  // `invalidateListCache` (local writes, repo events, HMR/artifact ingest
+  // which registers with `notify:false`, and — since #5109 — cluster peer
+  // replay) and the `subscribe('api', …)` registration below.
   private static readonly ENDPOINT_METADATA_TYPE = 'api';
   private readonly endpointMatcher: EndpointMatcher;
 
@@ -218,17 +221,18 @@ export class MetadataManager implements IMetadataService {
     this.logger = createLogger({ level: 'info', format: 'pretty' });
 
     // [#5089] Endpoint index (see `matchEndpoint`). Two invalidation seams,
-    // covering disjoint event sets — both are needed, neither is redundant:
-    //   1. `invalidateListCache('api')` — every LOCAL mutation of the stored
-    //      set, including the `{ notify: false }` writes the artifact ingest
-    //      and the HMR reload use, which by construction never reach a
-    //      watcher. It is the same invariant the list cache carries: if the
-    //      cached list of a type is stale, so is the index built from it.
-    //   2. `subscribe('api', …)` — a CLUSTER peer's write, which
-    //      `attachClusterPubSub` replays through `notifyWatchersLocal` only
-    //      and therefore does not pass through (1). (That the peer replay
-    //      leaves the manager's OWN caches stale is #5109; the index does not
-    //      inherit the bug because it listens on the watcher too.)
+    // covering overlapping but non-identical event sets — both are kept:
+    //   1. `invalidateListCache('api')` — every mutation of the stored set
+    //      this manager learns about, including the `{ notify: false }`
+    //      writes the artifact ingest and the HMR reload use, which by
+    //      construction never reach a watcher. It is the same invariant the
+    //      list cache carries: if the cached list of a type is stale, so is
+    //      the index built from it. Since #5109 a CLUSTER peer's write also
+    //      passes through here, via `invalidateForForeignWrite`.
+    //   2. `subscribe('api', …)` — the watcher seam, which additionally
+    //      covers events raised by subclasses / test doubles that call
+    //      `notifyWatchers` without a cache mutation of their own.
+    //      Double invalidation is idempotent, so the overlap is free.
     this.endpointMatcher = new EndpointMatcher({
       listApiItems: () => this.listForIndex(MetadataManager.ENDPOINT_METADATA_TYPE),
       logger: this.logger,
@@ -2027,22 +2031,57 @@ export class MetadataManager implements IMetadataService {
     }
   }
 
+  /**
+   * Drop every local cache of `type` (and of `name` within it) that a change
+   * we did not perform ourselves has just invalidated, so the next read falls
+   * through to the source of truth.
+   *
+   * The two callers are the manager's two *foreign-write* seams — the
+   * repository watch loop ({@link applyRepoEvent}) and the cluster peer replay
+   * in {@link attachClusterPubSub}. Both learn about a write that landed
+   * somewhere else (the repo head; another node's `sys_metadata`) and hold
+   * caches that the write silently aged out. Local writes do not come through
+   * here: `register()` / `unregister()` / `registerInMemory()` update the
+   * registry to the value they just wrote and call `invalidateListCache()`
+   * themselves.
+   *
+   * **Delete, do not pre-fill.** Even when the event carries a body we drop the
+   * registry entry rather than writing the body into it: the body reaching us
+   * is a snapshot of *someone else's* write, already possibly superseded, and
+   * pre-filling would race with the true head and require us to re-canonicalise
+   * a definition we did not load. Lazy invalidation is the safer default —
+   * `get()` then falls through to the loaders / repository, which is where the
+   * truth is. (This paragraph is the rationale `applyRepoEvent` carried since
+   * ADR-0008 PR-6; #5109 extended the same choice to the cluster path.)
+   *
+   * `name` is optional because `MetadataWatchEvent.name` is: a nameless event
+   * cannot address a registry entry, so it invalidates the list cache only.
+   * Dropping the whole type store instead would evict `registerInMemory()`
+   * artefacts (code-owned datasources, ADR-0015 Addendum) that no loader can
+   * restore — an unrecoverable loss in exchange for a guess.
+   */
+  private invalidateForForeignWrite(type: string, name?: string): void {
+    if (name) {
+      const typeStore = this.registry.get(type);
+      if (typeStore) {
+        typeStore.delete(name);
+        if (typeStore.size === 0) this.registry.delete(type);
+      }
+    }
+    this.invalidateListCache(type);
+  }
+
   /** Translate a repo event to the legacy MetadataWatchEvent + invalidate caches. */
   private applyRepoEvent(evt: MetadataEvent): void {
     const ref: MetaRef = evt.ref;
     const type = ref.type;
     const name = ref.name;
 
-    // Invalidate in-memory registry so manager.get() falls through to
-    // loaders / repository on next read. We do NOT pre-fill the registry
-    // here — that would race with the repo head and require us to
-    // re-canonicalise. Lazy invalidation is the safer default.
-    const typeStore = this.registry.get(type);
-    if (typeStore) {
-      typeStore.delete(name);
-      if (typeStore.size === 0) this.registry.delete(type);
-    }
-    this.listCache.delete(type);
+    // Invalidate before announcing, so a watcher that re-reads on the event
+    // observes the write rather than the pre-write cache. See
+    // {@link invalidateForForeignWrite} for why the registry entry is deleted
+    // rather than pre-filled.
+    this.invalidateForForeignWrite(type, name);
 
     const legacyType: 'added' | 'changed' | 'deleted' =
       evt.op === 'create' ? 'added'
@@ -2137,6 +2176,40 @@ export class MetadataManager implements IMetadataService {
         // Loopback guard — never replay events we just emitted.
         if (p?.originNode && p.originNode === this.clusterNodeId) return;
         if (!p?.type || !p.event) return;
+
+        // [#5109] Invalidate FIRST, and SYNCHRONOUSLY on receipt — this is
+        // what the channel is for ("consumed by peers to invalidate their
+        // local caches", see ClusterMetadataChangedPayload). Until this
+        // landed, a peer's write only woke this node's watchers: the registry
+        // entry and the `listCache` were left untouched, so every `list(type)`
+        // kept serving the pre-write set for up to LIST_CACHE_TTL_MS (30s) —
+        // and a watcher that re-read via `list()` in response to the wake-up
+        // got the stale set back, an invalidation notice carrying invalidated
+        // data.
+        //
+        // Two deliberate choices, both pinned by tests in
+        // `metadata-manager-cluster.test.ts`:
+        //
+        //   • BEFORE the notify, matching every other write path in this file
+        //     (`register` / `unregister` / `applyRepoEvent` all invalidate,
+        //     then announce): a watcher must never be able to observe the
+        //     event and the pre-event cache at the same time.
+        //   • OUTSIDE the `setImmediate`, unlike the notify. The deferral
+        //     exists so a slow *watcher callback* — arbitrary consumer code —
+        //     cannot back-pressure the pubsub dispatch loop. Invalidation is
+        //     two `Map.delete`s and runs no consumer code, so it has nothing
+        //     to defer for, while deferring it would leave a window between
+        //     receipt and the next tick in which reads still answer stale.
+        //     Any `await` in a request handler is enough to lose that race.
+        try {
+          this.invalidateForForeignWrite(p.type, p.event.name);
+        } catch (err) {
+          this.logger.error('Cluster remote invalidation failed', undefined, {
+            type: p.type,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+
         // Defer to setImmediate so a slow local handler can't back-pressure
         // the pubsub dispatch loop on memory drivers.
         setImmediate(() => {


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5109

## 问题

`attachClusterPubSub()` 的订阅回调在收到对端 `metadata.changed` 广播时,只做一件事 —— `notifyWatchersLocal()`。它既不碰 `this.registry`,也不碰 `this.listCache`。

于是:节点 A 改一条 view/permission/flow,节点 B 的 watcher(ObjectQL SchemaRegistry 桥、HMR SSE)确实被叫醒了,但 B 上任何走 `list(type)` 的读在 `LIST_CACHE_TTL_MS = 30_000` 窗口内继续返回改动前的清单;被叫醒的 watcher 如果回头调 `list()` 重新拉取,拉到的还是旧的 —— 一份「失效通知」附带着失效数据。单机部署完全无感,只有多节点才暴露。

这与该通道自己声明的用途相反(`ClusterMetadataChangedPayload` 的注释原文:"consumed by peers to **invalidate their local caches**",另见 `content/docs/kernel/cluster.mdx` §6.2、`metadata-lifecycle.mdx`)。

## 修法:收敛到 `applyRepoEvent` 的既有形状

issue 把 `applyRepoEvent()` 点名为「同文件内已做对的那条路径,可作修法样板」,本 PR 就照办 —— 并把两条「**外部写入**」缝(仓库 watch 循环、集群对端回放)提取到同一个私有方法 `invalidateForForeignWrite(type, name)`。两者的共同点正是这个方法的定义域:它们都是在得知一次**落在别处的写入**(repo head;另一个节点的 `sys_metadata`),而本节点手里的缓存已被那次写入悄悄作废。本地写入不走这里 —— `register()` / `unregister()` / `registerInMemory()` 把 registry 更新成自己刚写的值,并各自调 `invalidateListCache()`。

`applyRepoEvent` 的行为不变(它原先直接 `listCache.delete(type)`,现在经 `invalidateListCache(type)`,顺带同步失效 `EndpointMatcher` 索引 —— 纯增量,原先靠 watcher 那条缝也会失效)。

### 三个刻意的选择

**1. 删除 registry 条目,而不预填。** 这正是 issue 里那句「要不要连 `registry` 一起删」的裁决点,答案沿用 `applyRepoEvent` 自 ADR-0008 PR-6 起的理由,并对集群路径再补一条:到手的 body 是**别人那次写入的快照**,可能已被后续写入取代;预填会与真实 head 竞态,并要求我们去规范化一份自己没有加载过的定义。删掉之后 `get()` 自然穿透到 loader / repository —— 真相所在。这条也是本 PR 能修复 `list()` 的必要条件:registry 条目在 `list()` 里**盖过** loader 的同名项,只清 `listCache` 会让 B 永远端着自己那份旧副本(测试 `drops B's stale registry entry…` 就是钉这一点的)。

**2. 同步失效,且先失效再通知**(PR 描述里点名说明,对应 PM 指出的 async 接缝)。失效发生在收到消息的**当拍**,不在 `setImmediate` 内;通知仍然延迟一拍。理由:

- `setImmediate` 的存在理由写在原注释里 —— 不让**消费方的 watcher 回调**(任意用户代码)背压 pubsub 派发循环。失效只是两次 `Map.delete`,不执行任何消费方代码,没有需要延迟的东西;
- 把失效一起延迟,只会留下「已收到广播、尚未失效」的读窗口。请求处理器里任何一个 `await` 都足以撞进去 —— 那只是把 30 秒的 bug 缩短成一拍的 bug,不是修好它;
- 先失效后通知,与本文件其他所有写入路径(`register` / `unregister` / `applyRepoEvent`)一致,于是回头 `list()` 的 watcher 拿到的是写后清单,issue 说的「失效通知与失效数据自相矛盾」才真正消解。

测试 `invalidates SYNCHRONOUSLY on receipt — not inside the deferred replay` 把这个选择钉死:`await` 的恢复是 microtask,`setImmediate` 回调此刻还没跑(断言 watcher 尚未被调用),而缓存**已经**没了。把失效挪进 `setImmediate` 会让这条断言变红。

**3. 无名事件只失效清单缓存。** `MetadataWatchEvent.name` 在 spec 里是 `optional`,所以无名事件是合法上线的。无名就无法定位 registry 条目;此时**不**把整个 type 的 registry 一并清掉 —— 那会驱逐 `registerInMemory()` 注册的、任何 loader 都无法恢复的代码态构件(`origin: 'code'` 的 datasource、stack 声明的 roles/permissions,ADR-0015 Addendum),拿一次不可恢复的丢失去换一个猜测。

回环抑制(`originNode`)仍然在最前面短路,本节点自己的广播不会让自己白白重建缓存(有测试)。

## 测试

`packages/metadata/src/metadata-manager-cluster.test.ts` 新增 7 例,骨架就是 issue 的复现思路:两个 `MetadataManager` 接同一个 `IPubSub`,并共享**同一个 `datasource:` 协议的可写 loader** —— 两个副本共用一张 `sys_metadata` 的在测替身。

> 为什么不能用 `MemoryLoader`:它的 protocol 是 `memory:`,而 `register()` 只持久化到 `datasource:` 且声明 `capabilities.write` 的 loader。没有共享的可写存储,A 的写入对 B 根本不可见,#5109 的回归也就无从观察。

| 用例 | 钉住的行为 |
|:---|:---|
| B 预热 `list('view')` → A `register()` → B `list('view')` | issue 的原始复现,不等 30s TTL |
| A `unregister()` → B `list('view')` | 删除方向同样传播 |
| 同步失效、先于延迟回放 | 上文选择 2 |
| watcher 在被叫醒后回头 `list()` | 拿到写后清单(矛盾消解) |
| B 的 registry 旧副本被删,`get()` 穿透到共享存储 | 上文选择 1 |
| 无名事件 | 只失效清单缓存,保留 `registerInMemory` 条目 |
| 回环事件 | 本节点自己的广播不触发失效 |

其中 6 例在 main 上是红的(第 7 例是回环守卫,两边都绿)。

```
# 有修复
 Test Files  1 passed (1)
      Tests  13 passed (13)

# git stash 掉 metadata-manager.ts 后
     × B's pre-warmed list() sees A's register() without waiting out the 30s TTL
     × propagates A's unregister() to B's list()
     × invalidates SYNCHRONOUSLY on receipt — not inside the deferred replay
     × a watcher that re-reads via list() on the wake-up gets the post-write set
     × drops B's stale registry entry so get() falls through to the shared store
     × a nameless remote event invalidates the list cache but keeps in-memory-only entries
 Test Files  1 failed (1)
      Tests  6 failed | 7 passed (13)
```

全包与下游:

```
pnpm --filter @objectstack/metadata test        → 18 files / 433 tests passed
pnpm --filter @objectstack/service-cluster test →  3 files /  45 tests passed
```

类型:`@objectstack/metadata` 无 `typecheck` 脚本(`scripts/check-type-check-coverage.mjs` 里的 DEBT 条目,87)。直接跑 `tsc --noEmit -p packages/metadata/tsconfig.json` 对比:**改动前 92 → 改动后 92**,净增 0(新测试的 import 带上了 `.js` 扩展名,回调参数显式标注,避免 AGENTS.md 记的那个「缺扩展名 → 全变 any → 一堆 TS7006」陷阱)。

`eslint` 对两个改动的 TS 文件零输出。

## 文档

`content/docs/kernel/cluster.mdx` §6.2 只改了描述**对端收到广播后做什么**的那一段:原文「replay the watch event locally — there is currently no `version` / `name` / … field」会让人以为事件里根本没有名字信息(其实 `name` 在**内嵌的 watch event** 里,正是本修复用来定位 registry 条目的东西)。现在把「先同步失效、再延迟回放」写清楚,并把「没有 name 字段」限定回 payload 顶层。没有重写整节,`§6.2` 开头那句 "Cross-node metadata invalidation already works" 现在才真的成立。

## 范围与不做的事

- 只动 `packages/metadata/src/metadata-manager.ts` 的集群 pubsub / watcher 通知 / listCache 失效一段 + 本包测试 + 一个 changeset + 上面那段文档;
- ⛔ 没有回改 #5183(#5108)今天落地的 loader 降级面(`loaders/**`、`reportLoaderReadFailure` / `reportLoaderReadRecovered`)—— 建立在它们之上,一个字没改;
- ⛔ `packages/spec/**` 零改动;
- **与 #5184 不冲突**:那单裁的是 `cacheListResult()` 要不要区分降级结果(写入路径的判据),本 PR 一行没碰 `cacheListResult`;本 PR 补的是失效路径的一个触发源。#5184 自己也写明两者「不是重复,也不是子集,建议串行」。

## 顺带发现(未在本 PR 修)

- **#5218** —— FS 监听改动同样不失效本节点的 `listCache`:`NodeMetadataManager.handleFileEvent()` 也是只 `notifyWatchers`、不失效,是 #5109 的**本地同形缺陷**(触发面是开发期 `watch: true`,不是生产多节点)。已按 Prime Directive #10 单独立卡、未认领,并在卡里注明可复用本 PR 落地的 `invalidateForForeignWrite` 作样板。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pbu27iNUfQCHeuS551Rqo7


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pbu27iNUfQCHeuS551Rqo7)_