### PR TITLE
fix(driver-sql): `$field` 跨字段比较按 ADR-0112 响亮拒绝,不再抛裸 TypeError (#5041)

### DIFF
--- a/.changeset/gentle-pumas-repeat.md
+++ b/.changeset/gentle-pumas-repeat.md
@@ -1,0 +1,14 @@
+---
+'@objectstack/driver-sql': patch
+'@objectstack/spec': patch
+---
+
+fix(driver-sql): `$field` 跨字段比较改为按 ADR-0112 响亮拒绝,不再抛裸 TypeError
+
+`{ amount: { $gt: { $field: 'budget' } } }`(spec `FieldReferenceSchema`,由 `compileCelToFilter` 在转译含字段间比较的 CEL 权限/RLS 规则时产出)此前被 SqlDriver 当作**绑定值**交给驱动,sqlite 抛出无 `code`、无 `status` 的裸 `TypeError` —— 落在 `INVALID_FILTER` 信封之外,到客户端表现为不透明的服务端错误。更隐蔽的是列表位置:`$in` / `$between` 里的 `$field` 成员连报错都没有,直接静默返回零行。
+
+现在两者都以完整信封拒绝(`error.code = INVALID_FILTER`、HTTP 400、无 `[sql-driver]` 前缀),报错点名字段、运算符与被引用字段,并说明跨字段比较**当前仅内存求值路径(`matchesFilter`)支持**。三个比较发射点统一处理,Filter Protocol 与数组三元组两种写法得到同一答案。
+
+同一处闸门补上了 issue 指出的通用臂:**已知运算符 + 无法绑定的值形态**(标量比较位上的普通对象 / 数组)此前同样是裸 `TypeError`,现在也返回 `INVALID_FILTER`。`$in` / `$nin` / `$between` 的正常数组绑定不受影响。
+
+`FieldReferenceSchema` 声明保留,JSDoc 补注执行支持面(内存求值 ✅ / SQL 下推 ❌ 响亮拒绝);SQL 列对列编译实现见 #5222。

--- a/packages/plugins/driver-sql/src/sql-driver-cross-field-reference.test.ts
+++ b/packages/plugins/driver-sql/src/sql-driver-cross-field-reference.test.ts
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#5041] A `{ $field }` cross-field comparison is REFUSED by this driver, in
+ * the ADR-0112 envelope — never as a bare `TypeError`, never as zero rows.
+ *
+ * `FieldReferenceSchema` (`packages/spec/src/data/filter.zod.ts`) is declared,
+ * and it is genuinely PRODUCED: `compileCelToFilter` emits `{ $field: path }`
+ * whenever a CEL permission/RLS rule compares one field to another. The only
+ * implementation in the repo is the in-memory evaluator
+ * (`packages/formula/src/matches-filter.ts` — `resolveValue`). Pushed down to
+ * SQL, the reference object was handed to Knex as a BIND VALUE:
+ *
+ * ```
+ * { amount: { $gt: { $field: 'budget' } } }
+ * → select `id` from `deal` where `amount` > {"$field":"budget"}
+ * → TypeError: SQLite3 can only bind numbers, strings, bigints, buffers, and null
+ * ```
+ *
+ * That error carried no `code` and no `status`, so it landed outside the
+ * envelope every sibling filter refusal in this driver already speaks (#4436 /
+ * ADR-0112) and reached the client as an opaque server error. The maintainer's
+ * adjudication on #5041 is the minimum path: refuse loudly here, keep the spec
+ * declaration, and track column-to-column compilation as its own capability.
+ *
+ * These tests assert the FULL envelope — `code`, `status`, and the message
+ * content a caller needs to act — not merely that something was thrown.
+ *
+ * **Negative control** for the other half of the contract (the memory path
+ * still RESOLVES `$field` and matches correctly) lives with that implementation
+ * and is unchanged by this fix: `packages/formula/src/matches-filter.test.ts`
+ * ("$field reference (field-to-field)"). Nothing in this change touches the
+ * evaluator or the `cel-to-filter` producer.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SqlDriver } from '../src/index.js';
+import type { FilterCondition } from '@objectstack/spec/data';
+
+/** The shape `mapDataError` / `sendError` read off a thrown driver error. */
+interface WireBearingError extends Error {
+  code?: string;
+  status?: number;
+}
+
+async function refusalOf(run: () => Promise<unknown>): Promise<WireBearingError> {
+  try {
+    await run();
+  } catch (e) {
+    return e as WireBearingError;
+  }
+  throw new Error('expected the driver to refuse this filter, but it resolved');
+}
+
+describe('[#5041] SqlDriver refuses `$field` cross-field comparison in the ADR-0112 envelope', () => {
+  let driver: SqlDriver;
+
+  beforeEach(async () => {
+    driver = new SqlDriver({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    await driver.initObjects([
+      {
+        name: 'deal',
+        fields: {
+          id: { type: 'text', name: 'id' },
+          stage: { type: 'text', name: 'stage' },
+          amount: { type: 'number', name: 'amount' },
+          budget: { type: 'number', name: 'budget' },
+        },
+      } as any,
+    ]);
+    // `amount > budget` is TRUE for this row, so a driver that silently dropped
+    // the predicate would return it — the failure mode is visible, not implied.
+    await driver.create('deal', { id: '1', stage: 'won', amount: 10, budget: 5 });
+  });
+
+  const find = (where: unknown) =>
+    driver.find('deal', { object: 'deal', fields: ['id'], where: where as FilterCondition });
+
+  it('the issue repro — `{ amount: { $gt: { $field: "budget" } } }` — carries the full envelope', async () => {
+    const err = await refusalOf(() => find({ amount: { $gt: { $field: 'budget' } } }));
+
+    // ADR-0112 wire identity: the catalogued code and a client-error status.
+    expect(err.code).toBe('INVALID_FILTER');
+    expect(err.status).toBe(400);
+
+    // NOT the pre-fix failure: a bare TypeError with neither.
+    expect(err).not.toBeInstanceOf(TypeError);
+    expect(err.message).not.toContain('can only bind');
+
+    // #3867 — driver-internal wording never ships to a client.
+    expect(err.message).not.toContain('[sql-driver]');
+
+    // The actionable half: which field, which operator, which reference, and
+    // the reason — cross-field comparison is memory-path-only today.
+    expect(err.message).toContain('amount');
+    expect(err.message).toContain('$gt');
+    expect(err.message).toContain('budget');
+    expect(err.message).toContain('$field');
+    expect(err.message).toContain('in-memory');
+    expect(err.message).toContain('matchesFilter');
+  });
+
+  // One condition — "this comparison references another field" — gets one
+  // answer however the caller spelled it. Each of these bound the reference
+  // object as a VALUE before the fix.
+  const spellings: Array<[string, unknown]> = [
+    ['$eq', { amount: { $eq: { $field: 'budget' } } }],
+    ['$ne', { amount: { $ne: { $field: 'budget' } } }],
+    ['$gte', { amount: { $gte: { $field: 'budget' } } }],
+    ['$lt', { amount: { $lt: { $field: 'budget' } } }],
+    ['$lte', { amount: { $lte: { $field: 'budget' } } }],
+    ['nested under $and', { $and: [{ amount: { $gt: { $field: 'budget' } } }] }],
+    ['nested under $or', { $or: [{ amount: { $gt: { $field: 'budget' } } }] }],
+    ['nested under $not', { $not: { amount: { $gt: { $field: 'budget' } } } }],
+    ['array triple, symbolic op', [['amount', '>', { $field: 'budget' }]]],
+    ['array triple, word op', [['amount', 'gt', { $field: 'budget' }]]],
+    ['LIKE family (would have stringified to `[object Object]`)',
+      { stage: { $startsWith: { $field: 'budget' } } }],
+  ];
+
+  for (const [name, where] of spellings) {
+    it(`${name} → 400 INVALID_FILTER naming the reference`, async () => {
+      const err = await refusalOf(() => find(where));
+      expect(err.code).toBe('INVALID_FILTER');
+      expect(err.status).toBe(400);
+      expect(err).not.toBeInstanceOf(TypeError);
+      expect(err.message).toContain('$field');
+      expect(err.message).toContain('budget');
+    });
+  }
+
+  // A `$field` inside a LIST did not even crash before the fix: it compiled and
+  // returned ZERO ROWS. A silent wrong answer on a permission-scoped read is
+  // the failure #3948 / #4209 exist to prevent, so it gets the same refusal.
+  const listCases: Array<[string, unknown]> = [
+    ['$in', { amount: { $in: [{ $field: 'budget' }, 1] } }],
+    ['$nin', { amount: { $nin: [{ $field: 'budget' }] } }],
+    ['$between lower bound', { amount: { $between: [{ $field: 'budget' }, 100] } }],
+    ['$between upper bound', { amount: { $between: [0, { $field: 'budget' }] } }],
+  ];
+
+  for (const [name, where] of listCases) {
+    it(`${name} with a $field member → refused, not silently zero rows`, async () => {
+      const err = await refusalOf(() => find(where));
+      expect(err.code).toBe('INVALID_FILTER');
+      expect(err.status).toBe(400);
+      expect(err.message).toContain('$field');
+      // The member's position is named, so a long list is still actionable.
+      expect(err.message).toMatch(/index \d+/);
+    });
+  }
+
+  // The general arm the issue reported as missing: a KNOWN operator whose value
+  // shape cannot be bound. Measured pre-fix, every one of these was the same
+  // bare `TypeError` as the `$field` case.
+  const uncompilable: Array<[string, unknown]> = [
+    ['$gt with a plain object', { amount: { $gt: { foo: 1 } } }],
+    ['$eq with a plain object', { amount: { $eq: { foo: 1 } } }],
+    ['$ne with a plain object', { amount: { $ne: { foo: 1 } } }],
+    ['$gt with an array', { amount: { $gt: [1, 2] } }],
+    ['$eq with an array', { amount: { $eq: [1, 2] } }],
+    ['implicit `=` with a plain object', { amount: { } }],
+  ];
+
+  for (const [name, where] of uncompilable) {
+    it(`${name} → 400 INVALID_FILTER instead of a bare TypeError`, async () => {
+      const err = await refusalOf(() => find(where));
+      expect(err.code).toBe('INVALID_FILTER');
+      expect(err.status).toBe(400);
+      expect(err).not.toBeInstanceOf(TypeError);
+      expect(err.message).not.toContain('can only bind');
+      expect(err.message).not.toContain('[sql-driver]');
+      expect(err.message).toContain('amount');
+    });
+  }
+
+  // The guard must not narrow what already compiled. These are the shapes it
+  // sits directly in front of.
+  describe('comparands that legitimately compile are untouched', () => {
+    it('a scalar equality still matches', async () => {
+      const rows = await find({ stage: 'won' });
+      expect(rows.map((r: any) => r.id)).toEqual(['1']);
+    });
+
+    it('$in with a real value list still matches', async () => {
+      const rows = await find({ amount: { $in: [10, 20] } });
+      expect(rows.map((r: any) => r.id)).toEqual(['1']);
+    });
+
+    it('$nin with a real value list still matches', async () => {
+      const rows = await find({ amount: { $nin: [99] } });
+      expect(rows.map((r: any) => r.id)).toEqual(['1']);
+    });
+
+    it('$between with a real range still matches', async () => {
+      const rows = await find({ amount: { $between: [0, 100] } });
+      expect(rows.map((r: any) => r.id)).toEqual(['1']);
+    });
+
+    it('a Date comparand still binds', async () => {
+      await expect(find({ amount: { $gt: new Date(0) } })).resolves.toBeDefined();
+    });
+
+    it('a null comparand is still a null predicate, not a refusal', async () => {
+      const rows = await find({ budget: { $ne: null } });
+      expect(rows.map((r: any) => r.id)).toEqual(['1']);
+    });
+
+    it('an array triple with a scalar still matches', async () => {
+      const rows = await find([['amount', '>', 1]]);
+      expect(rows.map((r: any) => r.id)).toEqual(['1']);
+    });
+
+    it('the malformed-$between refusal keeps its own descriptive message', async () => {
+      const err = await refusalOf(() => find({ amount: { $between: 5 } }));
+      expect(err.code).toBe('INVALID_FILTER');
+      expect(err.message).toContain('[min, max]');
+    });
+  });
+});

--- a/packages/plugins/driver-sql/src/sql-driver.ts
+++ b/packages/plugins/driver-sql/src/sql-driver.ts
@@ -547,9 +547,9 @@ function isBindableComparand(value: unknown): boolean {
  * 1. **`{ $field }`** — declared, produced, and implemented only in memory.
  *    Refused wherever it appears, including inside an `$in` / `$nin` / `$between`
  *    list. The list case matters more than it looks: a `$field` member did not
- *    even crash, it compiled to `where amount in ('[object Object]')`-shaped
- *    nonsense and returned ZERO ROWS — a silent wrong answer, which #3948 /
- *    #4209 settled is strictly worse than an error on a scoped read.
+ *    even crash — the query compiled, ran, and returned ZERO ROWS. A silent
+ *    wrong answer is what #3948 / #4209 settled is strictly worse than an error
+ *    on a permission-scoped read.
  *
  * 2. **The general arm** — a known operator whose comparand is a shape no
  *    dialect can bind (a plain object, an array where one value belongs). The
@@ -558,12 +558,15 @@ function isBindableComparand(value: unknown): boolean {
  *    {@link SCALAR_COMPARAND_OPERATORS} so the legitimate array binds keep
  *    working untouched.
  *
- * Deliberately NOT extended to the `LIKE` family: `$contains`/`$startsWith`/…
- * stringify their comparand, so an object there compiles and runs (matching
- * nothing) rather than failing to bind. That is a separate defect class —
- * a filter that is applied nonsensically, not one that cannot be applied — and
- * widening this guard to cover it would change behaviour beyond what #5041
- * measured. Filed separately.
+ * Deliberately NOT extended to two neighbouring shapes, both of which return
+ * zero rows today rather than failing to bind: a non-`$field` object MEMBER of
+ * an `$in`/`$nin` list, and the `LIKE` family (`$contains`/`$startsWith`/…),
+ * which stringifies its comparand to `[object Object]`. Those are a different
+ * defect class — a filter applied nonsensically, not one that cannot be applied
+ * — and their direction is fail-closed (they narrow the result set, so they are
+ * not a filter bypass). Widening this guard to cover them would change the
+ * behaviour of paths that do not throw today, beyond what #5041 measured; see
+ * the #5041 PR discussion for the measurement.
  */
 function assertCompilableComparand(field: string, op: string, value: unknown): void {
   const ref = fieldReferenceOf(value);

--- a/packages/plugins/driver-sql/src/sql-driver.ts
+++ b/packages/plugins/driver-sql/src/sql-driver.ts
@@ -461,6 +461,144 @@ function unsupportedFilterError(message: string): Error {
   return err;
 }
 
+/**
+ * [#5041] The referenced field name when `value` is a Filter Protocol FIELD
+ * REFERENCE (`{ $field: 'other_column' }` — spec `FieldReferenceSchema` in
+ * `data/filter.zod.ts`), else `null`.
+ *
+ * The predicate deliberately mirrors `@objectstack/formula`'s `resolveValue`
+ * (`matches-filter.ts`): an object, not an array, carrying a `$field` key. The
+ * two execution paths must agree on **what a field reference is**; they differ
+ * only in what they DO with one — the in-memory evaluator resolves it against
+ * the record, this driver refuses it (below). A driver that recognised a
+ * narrower shape than the evaluator would silently bind the remainder as
+ * literal values again, which is precisely the defect being closed.
+ */
+function fieldReferenceOf(value: unknown): string | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const ref = (value as Record<string, unknown>).$field;
+  return typeof ref === 'string' ? ref : null;
+}
+
+/**
+ * [#5041] `{ $field }` reached a comparison this driver compiles to SQL.
+ *
+ * `FieldReferenceSchema` is declared in the spec and really is PRODUCED —
+ * `compileCelToFilter` emits `{ $field: path }` for a field-to-field comparison
+ * in a CEL permission/RLS rule — but the only implementation in the repo is the
+ * in-memory evaluator. Pushed down to SQL, the reference object was handed to
+ * Knex as a BIND VALUE, so sqlite answered with a bare `TypeError` ("can only
+ * bind numbers, strings, bigints, buffers, and null") carrying no `code` and no
+ * `status` — outside the ADR-0112 envelope every sibling filter refusal in this
+ * driver speaks, and therefore served as an opaque 500-shaped body.
+ *
+ * Refusing loudly is the whole fix here (maintainer adjudication on #5041):
+ * column-to-column compilation is a capability tracked separately, and until it
+ * lands the honest answer to "this filter cannot run on this backend" is the
+ * catalogued `INVALID_FILTER`, not a crash and not a silent wrong answer.
+ */
+function crossFieldComparisonError(field: string, op: string, ref: string, index?: number): Error {
+  const position = index === undefined ? '' : ` at index ${index} of its value list`;
+  return unsupportedFilterError(
+    `Operator "${op}" on field "${field}" compares against another field ` +
+      `({ "$field": "${ref}" })${position}. Cross-field comparison is currently supported ` +
+      `only on the in-memory evaluation path (matchesFilter); it cannot be compiled to SQL, ` +
+      `so this filter cannot be pushed down to the database. Compare against a literal value ` +
+      `instead, or evaluate the rule in memory.`,
+  );
+}
+
+/**
+ * [#5041] Operators whose comparand is a single bound VALUE, in both spellings
+ * this driver accepts — the Filter Protocol `$`-form read by
+ * {@link SqlDriver.applyFilterCondition} and the canonicalised infix form read
+ * by {@link SqlDriver.applyAstComparison}.
+ *
+ * The list-shaped operators (`$in` / `$nin` / `$between`) are deliberately
+ * ABSENT: an array is their legitimate comparand, and they compile through
+ * their own `whereIn` / `whereBetween` arms. Only their MEMBERS are inspected
+ * (for `$field`), never their arity — the existing descriptive `$between`
+ * refusal stays the one that answers a malformed range.
+ */
+const SCALAR_COMPARAND_OPERATORS: ReadonlySet<string> = new Set([
+  '$eq', '$ne', '$gt', '$gte', '$lt', '$lte',
+  '=', '==', '!=', '<>', '>', '>=', '<', '<=', 'like', 'ilike',
+]);
+
+/**
+ * Can this value be handed to a driver as a bound parameter at all?
+ *
+ * Same classification the write path applies in `formatInput` — anything that
+ * is not a primitive, a `Date` or a binary buffer is a shape better-sqlite3
+ * refuses outright and the other dialects mangle. (`ArrayBuffer.isView` covers
+ * `Buffer`, which is a `Uint8Array`.)
+ */
+function isBindableComparand(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  const kind = typeof value;
+  if (kind === 'string' || kind === 'number' || kind === 'bigint' || kind === 'boolean') return true;
+  return value instanceof Date || ArrayBuffer.isView(value);
+}
+
+/**
+ * [#5041] The one gate every comparison comparand passes before it becomes a
+ * bind parameter, covering both halves of the gap the issue measured:
+ *
+ * 1. **`{ $field }`** — declared, produced, and implemented only in memory.
+ *    Refused wherever it appears, including inside an `$in` / `$nin` / `$between`
+ *    list. The list case matters more than it looks: a `$field` member did not
+ *    even crash, it compiled to `where amount in ('[object Object]')`-shaped
+ *    nonsense and returned ZERO ROWS — a silent wrong answer, which #3948 /
+ *    #4209 settled is strictly worse than an error on a scoped read.
+ *
+ * 2. **The general arm** — a known operator whose comparand is a shape no
+ *    dialect can bind (a plain object, an array where one value belongs). The
+ *    issue noted this branch had no rejection arm at all; measured, every such
+ *    shape produced the same bare `TypeError`. Scoped to
+ *    {@link SCALAR_COMPARAND_OPERATORS} so the legitimate array binds keep
+ *    working untouched.
+ *
+ * Deliberately NOT extended to the `LIKE` family: `$contains`/`$startsWith`/…
+ * stringify their comparand, so an object there compiles and runs (matching
+ * nothing) rather than failing to bind. That is a separate defect class —
+ * a filter that is applied nonsensically, not one that cannot be applied — and
+ * widening this guard to cover it would change behaviour beyond what #5041
+ * measured. Filed separately.
+ */
+function assertCompilableComparand(field: string, op: string, value: unknown): void {
+  const ref = fieldReferenceOf(value);
+  if (ref !== null) throw crossFieldComparisonError(field, op, ref);
+
+  if (Array.isArray(value)) {
+    for (const [index, member] of value.entries()) {
+      const memberRef = fieldReferenceOf(member);
+      if (memberRef !== null) throw crossFieldComparisonError(field, op, memberRef, index);
+    }
+    // An array IS the comparand for the list operators; only a scalar operator
+    // is wrong to receive one, and that falls through to the check below.
+  }
+
+  if (!SCALAR_COMPARAND_OPERATORS.has(op) || isBindableComparand(value)) return;
+
+  throw unsupportedFilterError(
+    `Operator "${op}" on field "${field}" requires a single comparable value, but received ` +
+      `${Array.isArray(value) ? 'an array' : `an object (${safeShapePreview(value)})`}, which cannot be ` +
+      `bound as a SQL parameter. Use a string, number, boolean, null, Date or binary value; ` +
+      `for a list use $in/$nin, and for a range use $between.`,
+  );
+}
+
+/** A short, non-throwing rendering of an offending comparand for the message. */
+function safeShapePreview(value: unknown): string {
+  try {
+    const json = JSON.stringify(value);
+    if (typeof json !== 'string') return typeof value;
+    return json.length > 80 ? `${json.slice(0, 77)}...` : json;
+  } catch {
+    return typeof value;
+  }
+}
+
 // ── Introspection Types ──────────────────────────────────────────────────────
 
 export interface IntrospectedColumn {
@@ -5216,6 +5354,9 @@ export class SqlDriver implements IDataDriver {
       for (const [key, value] of Object.entries(filters)) {
         if (['limit', 'offset', 'fields', 'orderBy'].includes(key)) continue;
         const column = this.remoteColumn(table, key, key);
+        // #5041 — the plain `{ field: value }` map compiles to an implicit `=`,
+        // so it is a comparison emitter too and gets the same gate.
+        assertCompilableComparand(column, '=', value);
         const coerced = this.coerceFilterValue(table, key, value);
         const expr = this.filterColumnExpr(table, key, column);
         if (expr && this.applyNormalizedComparison(builder, 'and', expr, '=', coerced)) continue;
@@ -5381,6 +5522,13 @@ export class SqlDriver implements IDataDriver {
     // driver and driver-memory drifted apart. #3948.
     const opLower = canonicalAstOperator(String(op));
 
+    // #5041 — the array (`[field, op, value]`) spelling reaches Knex through a
+    // different emitter than the Filter Protocol one, and measured identically:
+    // `[['amount', 'gt', { $field: 'budget' }]]` also threw a bare TypeError.
+    // One filter condition gets one answer however it was spelled, so the same
+    // gate runs here, on the RAW value (pre-coercion).
+    assertCompilableComparand(field, opLower, rawValue);
+
     // Value comparisons on a mixed-storage column read it through the CASE; every
     // other operator (null predicates, the LIKE family, a malformed `between`)
     // declines and falls through to the ordinary handling below.
@@ -5535,6 +5683,10 @@ export class SqlDriver implements IDataDriver {
         const columnExpr = this.filterColumnExpr(table, localField, field);
         for (const [rawOp, opValue] of Object.entries(value as Record<string, any>)) {
           const method = logicalOp === 'or' ? 'orWhere' : 'where';
+          // #5041 — reject a comparand that cannot become a bind parameter
+          // BEFORE any rewrite or coercion touches it, so the message names the
+          // shape the caller actually sent.
+          assertCompilableComparand(field, rawOp, opValue);
           // Calendar-day upper bounds first (#3777): `$lte` on a bare
           // `YYYY-MM-DD` against a datetime column compiles half-open, and a
           // `$between` whose max is a bare day decomposes into the same pair —

--- a/packages/spec/src/data/filter.zod.ts
+++ b/packages/spec/src/data/filter.zod.ts
@@ -28,10 +28,39 @@ import { z } from 'zod';
  * Field Reference
  * Represents a reference to another field/column instead of a literal value.
  * Used for joins (ON clause) and cross-field comparisons.
- * 
+ *
  * @example
  * // user.id = order.owner_id
  * { "$eq": { "$field": "order.owner_id" } }
+ *
+ * ## Execution support (#5041)
+ *
+ * This shape is declared here and really is produced — `compileCelToFilter`
+ * (`@objectstack/formula`) emits `{ $field: path }` for a field-to-field
+ * comparison in a CEL permission/RLS rule. Its execution support is NOT
+ * uniform across evaluation paths, and a producer must know which path its
+ * filter will run on:
+ *
+ * - **In-memory evaluation — supported.** `matchesFilter`
+ *   (`@objectstack/formula`, `matches-filter.ts`) resolves the reference
+ *   against the record, dot-paths included.
+ * - **SQL push-down — refused, loudly.** `@objectstack/driver-sql` (and
+ *   `driver-sqlite-wasm`, which inherits its filter compiler) does not compile
+ *   a field reference to a column-to-column comparison. Rather than bind the
+ *   reference object as a literal value — which produced a bare driver
+ *   `TypeError` outside the ADR-0112 envelope, and, inside an `$in`/`$between`
+ *   list, a silent zero-row answer — the driver rejects the filter with
+ *   `INVALID_FILTER` (HTTP 400) naming the field, the operator and the
+ *   reference.
+ *
+ * The declaration is deliberately retained: the shape has a real producer and
+ * a real implementation, so it is not a dead key. Compiling it to SQL
+ * column-to-column comparison is tracked as its own capability in #5222, where
+ * the two open semantic questions ride with it — dot-path relation references,
+ * and the validation boundary for the referenced column name.
+ *
+ * @see https://github.com/objectstack-ai/objectstack/issues/5041 (refusal)
+ * @see https://github.com/objectstack-ai/objectstack/issues/5222 (SQL support)
  */
 import { lazySchema } from '../shared/lazy-schema';
 export const FieldReferenceSchema = lazySchema(() => z.object({


### PR DESCRIPTION
Fixes #5041

按维护者 2026-08-04 的裁决 **C(最低限度,响亮拒绝)** 实施:消除静默半态,保留声明,真正的 SQL 列对列实现另立能力单。

## 问题

`FieldReferenceSchema`(`{ $field: '...' }`)在 spec 里声明了,并且**真的有生产者**——`compileCelToFilter` 在转译含字段间比较的 CEL 权限 / RLS 规则时会产出它。但全仓唯一实现是内存求值器。下推到 SQL 时,这个引用对象被当作**绑定值**交给 Knex:

```
{ amount: { $gt: { $field: 'budget' } } }
→ select `id` from `deal` where `amount` > {"$field":"budget"}
→ TypeError: SQLite3 can only bind numbers, strings, bigints, buffers, and null
```

该错误既无 `code` 也无 `status`,落在本驱动其它 filter 拒绝一致遵守的 ADR-0112 信封(#4436)之外,到客户端表现为不透明的服务端错误。

## 实测发现两件 issue 未记录的事

落地前先做了探针测量,结果改变了改动范围:

1. **数组三元组写法有同样的缺陷**。`[['amount', 'gt', { $field: 'budget' }]]` 走的是另一个发射点(`applyAstComparison`),同样抛裸 `TypeError`。一个 filter 条件不该因为写法不同得到两种答案,所以闸门装在全部三个比较发射点上。

2. **列表位置比崩溃更糟:静默零行**。`$in` / `$nin` / `$between` 里的 `$field` 成员**连报错都没有**,查询正常返回、结果为空。权限域读取上的静默错误答案,正是 #3948 / #4209 要根除的那一类,因此一并纳入拒绝(报错点名成员下标)。

## 改动

**1. 响亮拒绝(裁决 C 第 1 条)**

`{ $field }` 出现在任何比较操作数位置(含列表成员)时,以完整信封拒绝:`error.code = INVALID_FILTER`、HTTP 400、无 `[sql-driver]` 前缀,消息点名字段、运算符、被引用字段,并说明**跨字段比较当前仅内存求值路径(`matchesFilter`)支持**。

识别 `$field` 的谓词刻意与 `@objectstack/formula` 的 `resolveValue` 保持逐字一致——两条执行路径必须对「什么是字段引用」有同一个认识,只在「拿它怎么办」上分岔(内存求值 / SQL 拒绝)。驱动若认得比求值器更窄的形状,剩下的又会被当字面值绑定,正是本单要关掉的那个洞。

**2. 通用臂(裁决要求先测量再决定)**

issue 指出「已知运算符 + 值形态编译不了」这条路径完全没有拒绝臂。实测:标量比较位上的普通对象、数组、`{}` 全部是同一个裸 `TypeError`。**已纳入**,同一闸门、同一信封。

作用域刻意收窄到**标量比较运算符**(`$eq/$ne/$gt/$gte/$lt/$lte` 及其中缀拼写),因此 `$in` / `$nin` / `$between` 的合法数组绑定完全不受影响——它们走各自的 `whereIn` / `whereBetween` 臂,只有成员被检查(且只查 `$field`),元数不管,原有的 `$between` 描述性报错保持原样。

**未纳入**(避免超出实测范围的行为变更,见下方遗留发现):`LIKE` 家族的对象操作数。

**3. 保留声明(裁决第 2 条)**

`FieldReferenceSchema` 不动,仅补 JSDoc 记录执行支持面(内存求值 ✅ / SQL 下推 ❌ 响亮拒绝)并链接 #5222。纯注释改动,形态与姿态均未变,`check:generated` 8 项产物全部无漂移,**未触碰任何台账文件**。

**4. v18 能力单(裁决第 3 条)**

#5222 —— SqlDriver 编译 `$field` 为列对列比较,两个待决语义点(点号关联路径语义、被引用列名校验边界)一并在那单议。

## 遗留发现(未在本 PR 修,供后续判断)

`$in` 成员为**非 `$field` 的普通对象**、以及 `$startsWith` 等 `LIKE` 家族的对象操作数,目前仍静默返回零行(`LIKE` 家族会把操作数 `String()` 成 `[object Object]`)。这是**另一类缺陷**——filter 被无意义地应用了,而不是无法应用——且方向是 fail-closed(收窄结果,非放宽),不构成 filter 绕过。把闸门扩到这里会改变当前不抛错路径的行为,超出 #5041 的实测范围,故留待单独判断。

## 验证

| 命令 | 结果 |
|:---|:---|
| `pnpm --filter @objectstack/driver-sql test` | **683 passed**, 44 skipped |
| `pnpm --filter @objectstack/driver-sqlite-wasm test`(继承本 filter 编译器) | **232 passed** |
| `pnpm --filter @objectstack/spec test` | **7809 passed** |
| `pnpm --filter @objectstack/formula test`(负对照) | **323 passed** |
| `pnpm --filter @objectstack/driver-sql --filter @objectstack/spec typecheck` | Done, 无错误 |
| `pnpm --filter @objectstack/spec check:generated` | 8/8 up to date |

新增 `sql-driver-cross-field-reference.test.ts`(30 例):断言**完整信封**(`code` + `status` + 消息内容),而非只断言抛了什么类型;覆盖 issue 原始形态、各运算符拼写、`$and`/`$or`/`$not` 嵌套、数组三元组、列表成员、通用臂;并有一组「合法操作数不受影响」的守护(标量等值、真实 `$in`/`$nin`/`$between`、`Date`、`null` 谓词、数组三元组)。

**负对照**:内存求值器对同一条 filter 仍正确匹配 —— `packages/formula/src/matches-filter.test.ts` 的 `$field reference (field-to-field)` 单独跑通过,本 PR 未触碰求值器与 `cel-to-filter` 生产者。

## Refs

- https://github.com/objectstack-ai/objectstack/issues/5041(裁决 + 探针证据)
- https://github.com/objectstack-ai/objectstack/issues/5222(v18 列对列实现)
- https://github.com/objectstack-ai/cloud/issues/1051(列名校验边界讨论)
- https://github.com/objectstack-ai/cloud/issues/1058(Turso transport 静默零行,不在本单)
- https://github.com/objectstack-ai/cloud/pull/1059(探针输出)
- ADR-0112 / #4436(`INVALID_FILTER` 信封)

https://claude.ai/code/session_01Ehu85kbvMcrNTUJjwxvLJ9


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ehu85kbvMcrNTUJjwxvLJ9)_