### PR TITLE
fix(runtime,tooling): `saveMetaItem` 进入持久性词表 + 包发布可见性翻转不再静默丢写 (#4754)

### DIFF
--- a/.changeset/durability-gate-savemetaitem.md
+++ b/.changeset/durability-gate-savemetaitem.md
@@ -1,0 +1,35 @@
+---
+"@objectstack/runtime": patch
+---
+
+fix(runtime,tooling): `saveMetaItem` 进入持久性词表,包发布的可见性翻转不再静默丢写 (#4754)
+
+#4632 立的「Degradation log levels」规则由 `pnpm check:durability-log-level` 机械执行,
+但它只认 `DURABILITY_CRITICAL_CALLEES` 这张显式词表 —— 词表以外的持久性接缝它发现不了。
+#4669 的事故正是这一类:`protocol.saveMetaItem()` 失败被吞掉,整条投影路径停摆却一个红灯
+都没有,跨了一个发布周期才被偶然看见。本次把 `saveMetaItem` 加进词表,并把它照出来的
+每一处逐个判过。
+
+**真丢失的那一处已修好。** `POST /packages/:id/publish-drafts` 的 ADR-0045 可见性翻转
+(`packages/runtime/src/domains/packages.ts`)是一次搭别人便车的元数据**写入**:草稿已经
+发布,所以这个路由无论如何都答 200,而写失败只会在响应体里留下一个没人读的 `unhideError`。
+症状因此是「我明明发布了,应用却没出现」,而且要很久以后才有人把它和这里联系起来 ——
+正是 #4669 的形状。现在它按范本在 `error` 级别报告:点名是哪个包、其 app 仍然以
+`hidden: true` 存着因而在启动器里不可见、发布却报告了成功,并给出修复动作(重跑
+publish-drafts,幂等;或直接 `PUT /meta/app/<name>` 置 `hidden: false`),同时带上原始
+错因。响应契约不变 —— 仍然是 200,仍然带 `unhideError`。
+
+**闸门自身的两个精度缺陷一并修掉**(词表加一个条目就让它们暴露了,8 处命中里 4 处是误报):
+
+- **同文件 concise-arrow 报告器看不见。** 闸门文档明说 `catch` 一侧会追同文件的 helper,
+  但遍历只访问子节点,而 `const logError = (...a) => console.error(...a)` 的函数体**就是**
+  那个调用表达式本身,于是 `rest-server.ts` 里最响的两处 `/meta` PUT 反被判成「完全静默」。
+- **一处接缝被按嵌套层数重复指认。** 一个已被内层 `catch` 消化掉的调用,仍然算在每一层
+  外层 `catch` 头上 —— 而那些外层多半是正确的路由级错误处理器。`packages.ts` 里同一个
+  `saveMetaItem` 因此被报了三次。现在只有当内层 `catch` 每条路径都向外传播时,外层才被
+  判定为真正的守卫。
+
+两个修复都在 `--self-test` 里双向钉住(改前必失败,改后才通过),自测用例由 CI 执行。
+
+判定为「故障已答给调用方」的三处(`meta.ts` 的 4xx/422、`protocol.ts` 两处结构化逐项
+失败报告)不是降级,记入 shrink-only 基线并附理由与关闭条件(#5241)。

--- a/packages/runtime/src/domains/packages.ts
+++ b/packages/runtime/src/domains/packages.ts
@@ -230,6 +230,24 @@ export async function handlePackagesRequest(deps: DomainHandlerDeps, path: strin
                             if (unhidden.length > 0) (result as any).unhiddenApps = unhidden;
                         }
                     } catch (e: any) {
+                        // #4754 — ADR-0045's visibility flip is a metadata WRITE
+                        // riding on someone else's success. The drafts are already
+                        // promoted, so this route answers 200 either way, and
+                        // `unhideError` lands in a response body no operator reads.
+                        // That is the #4669 shape exactly: the write did not land,
+                        // the runtime looks completely healthy, and the loss only
+                        // surfaces later as "I published it but the app isn't
+                        // there". So it is reported at `error` (AGENTS.md →
+                        // "Degradation log levels"), not swallowed.
+                        const logger = deps.logger ?? console;
+                        logger.error(
+                            `[Packages] publish-drafts: the ADR-0045 visibility flip FAILED for package '${id}' — its drafts ARE ` +
+                            `published and live, but every hidden app bound to it is still STORED with \`hidden: true\`, so those ` +
+                            `apps stay invisible in the launcher while the publish reports success. Nothing retries this flip. ` +
+                            `Re-run POST /packages/${id}/publish-drafts once the cause below is resolved (it is idempotent), or ` +
+                            `unhide one app directly via PUT /meta/app/<name> with \`{"hidden": false}\`. Cause: ` +
+                            `${e?.message ?? String(e)}`,
+                        );
                         (result as any).unhideError = e?.message ?? 'visibility flip failed';
                     }
                     // A publish promoted drafts to active (or unhid an additive

--- a/packages/runtime/src/http-dispatcher.test.ts
+++ b/packages/runtime/src/http-dispatcher.test.ts
@@ -1874,6 +1874,53 @@ describe('HttpDispatcher', () => {
             expect((result.response as any)?.body?.data?.unhideError).toBe('meta backend down');
             expect(saveMetaItem).not.toHaveBeenCalled();
         });
+
+        // #4754 — the flip is a metadata WRITE riding on someone else's success.
+        // `unhideError` in a 200 body is not a signal anyone reads: the route
+        // still answers success, so the loss ("I published it but the app never
+        // appeared") surfaces much later to someone who cannot connect it back
+        // here. That is the #4669 shape, so AGENTS.md → "Degradation log levels"
+        // requires `error`, naming the CONSEQUENCE and the FIX.
+        it('POST /packages/:id/publish-drafts logs at ERROR (consequence + fix) when the saveMetaItem write fails', async () => {
+            const publishPackageDrafts = vi.fn().mockResolvedValue({
+                success: true, publishedCount: 1, failedCount: 0, published: [], failed: [], seedApplied: { success: true },
+            });
+            const getMetaItems = vi.fn().mockResolvedValue([
+                { name: 'edu_admin', hidden: true, navigation: [] },
+            ]);
+            const saveMetaItem = vi.fn().mockRejectedValue(new Error('sys_metadata write rejected'));
+            (kernel as any).getService = vi.fn().mockImplementation((name: string) => {
+                if (name === 'protocol') return Promise.resolve({ publishPackageDrafts, getMetaItems, saveMetaItem });
+                if (name === 'objectql') return Promise.resolve({ registry: { getAllPackages: vi.fn().mockReturnValue([]) } });
+                return null;
+            });
+            // No host logger is attached to the dispatcher in this harness, so
+            // the domain falls back to `console` (`deps.logger ?? console`).
+            const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            try {
+                const result = await dispatcher.handlePackages('/app.edu/publish-drafts', 'POST', {}, {}, { request: {} });
+
+                // Unchanged contract: the drafts ARE published, so this still 200s
+                // and still carries the machine-readable `unhideError`.
+                expect(result.response?.status).toBe(200);
+                expect((result.response as any)?.body?.data?.unhideError).toBe('sys_metadata write rejected');
+
+                expect(errorSpy).toHaveBeenCalledTimes(1);
+                const line = String(errorSpy.mock.calls[0]?.[0] ?? '');
+                // The consequence, concretely — what is not durable, and that the
+                // system keeps looking healthy anyway.
+                expect(line).toContain('app.edu');
+                expect(line).toMatch(/hidden/i);
+                expect(line).toMatch(/publish reports success|reports success/i);
+                // The fix — the concrete action that restores the intended state.
+                expect(line).toContain('publish-drafts');
+                // And the cause is not swallowed.
+                expect(line).toContain('sys_metadata write rejected');
+            } finally {
+                errorSpy.mockRestore();
+            }
+        });
     });
 
     // ═══════════════════════════════════════════════════════════════

--- a/scripts/check-durability-degradation-log-level.mjs
+++ b/scripts/check-durability-degradation-log-level.mjs
@@ -140,6 +140,10 @@ const DURABILITY_CRITICAL_CALLEES = new Map([
         'dropPromotedDraftRow',
         "A published draft was never drained — the active row is correct, but the `state='draft'` row is still in `sys_metadata`, so Studio/Setup keeps showing unpublished changes that do not exist and the next publish promotes the same stale body again (#4981).",
     ],
+    [
+        'saveMetaItem',
+        'The metadata definition was never written to the authoritative store — the runtime looks completely normal because the in-memory registry already has it, and the definition simply vanishes on the next provision/restart (#4754, from #4669).',
+    ],
 ]);
 
 /** Log levels that are ACCEPTABLE inside a durability-guarding catch. */
@@ -179,22 +183,40 @@ function collectSourceFiles(dir, out = []) {
     return out;
 }
 
+/** Does this node's body run LATER (a callback), rather than on this tick? */
+function runsLater(node) {
+    return (
+        ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isArrowFunction(node) ||
+        ts.isMethodDeclaration(node) ||
+        ts.isClassDeclaration(node) ||
+        ts.isClassExpression(node)
+    );
+}
+
 /** Walk `node`'s subtree without descending into bodies that run LATER. */
 function walkSameTick(node, visit) {
     node.forEachChild((child) => {
-        if (
-            ts.isFunctionDeclaration(child) ||
-            ts.isFunctionExpression(child) ||
-            ts.isArrowFunction(child) ||
-            ts.isMethodDeclaration(child) ||
-            ts.isClassDeclaration(child) ||
-            ts.isClassExpression(child)
-        ) {
-            return;
-        }
+        if (runsLater(child)) return;
         visit(child);
         walkSameTick(child, visit);
     });
+}
+
+/**
+ * `walkSameTick`, plus the node itself.
+ *
+ * A concise-arrow helper body (`const logError = (...a) => console.error(...a)`)
+ * IS the call expression, not a block containing one, so a plain `walkSameTick`
+ * — which only ever visits CHILDREN — never inspects it and the helper reads as
+ * silent. That shape is exactly the same-file reporter the `catch` side is
+ * documented to follow, so missing it made a genuinely loud catch report as
+ * `silent-swallow` (`rest-server.ts`'s two `/meta` PUT handlers, #4754).
+ */
+function walkSameTickInclusive(node, visit) {
+    visit(node);
+    walkSameTick(node, visit);
 }
 
 /** Walk everything, including nested function bodies. */
@@ -280,7 +302,7 @@ function analyzeSourceFile(sf, relPath, findings, seams) {
     const collectResponse = (block, seen = new Set(), depth = 0) => {
         const levels = [];
         let rethrows = false;
-        walkSameTick(block, (child) => {
+        walkSameTickInclusive(block, (child) => {
             if (ts.isThrowStatement(child)) rethrows = true;
             const level = loggerLevel(child);
             if (level) {
@@ -349,20 +371,65 @@ function analyzeSourceFile(sf, relPath, findings, seams) {
         return sawReturn || !block.statements.some(alwaysThrows);
     };
 
-    walkAll(sf, (node) => {
-        if (!ts.isTryStatement(node) || !node.catchClause) return;
-
-        // 1. Does the guarded block call a durability-critical operation?
+    /**
+     * Collect the durability-critical calls a `catch` ACTUALLY guards.
+     *
+     * A call wrapped in a NESTED try whose own catch RECOVERS can never reach
+     * the outer catch — the inner catch consumed it, and that inner catch is
+     * judged on its own as a seam in its own right. Attributing the call to
+     * every enclosing catch as well reported ONE seam once per level of
+     * nesting, and the enclosing handlers it accused are usually generic
+     * request-level error handlers that are correct as written. That pressures
+     * an author to baseline correct code, which is how a shrink-only ledger
+     * stops meaning anything (#4754: one `saveMetaItem` in `packages.ts`
+     * surfaced three times — at its real seam and at the two route/function
+     * level `catch`es enclosing it).
+     *
+     * Only an inner catch that propagates on EVERY path (see `catchRecovers`)
+     * actually delivers the failure outward, and then the outer catch is a real
+     * guard and is judged as one. Coverage is never lost either way: the
+     * shadowing catch is itself checked.
+     */
+    const collectGuardedCalls = (tryBlock) => {
         const guarded = [];
-        const inspectForCritical = (child) => {
+        const inspect = (child) => {
             const name = calleeName(child);
             if (name && DURABILITY_CRITICAL_CALLEES.has(name)) {
                 guarded.push({ callee: name, line: lineOf(child) });
             }
         };
+        const walk = (n) => {
+            n.forEachChild((child) => {
+                if (runsLater(child)) return;
+                if (
+                    ts.isTryStatement(child) &&
+                    child.catchClause &&
+                    catchRecovers(child.catchClause.block)
+                ) {
+                    // The inner TRY block is shadowed. Its `catch`/`finally`
+                    // bodies are not — a critical call there does propagate out.
+                    for (const b of [child.catchClause.block, child.finallyBlock]) {
+                        if (!b) continue;
+                        inspect(b);
+                        walk(b);
+                    }
+                    return;
+                }
+                inspect(child);
+                walk(child);
+            });
+        };
         // The try block itself may BE a call at top level, so check it too.
-        inspectForCritical(node.tryBlock);
-        walkSameTick(node.tryBlock, inspectForCritical);
+        inspect(tryBlock);
+        walk(tryBlock);
+        return guarded;
+    };
+
+    walkAll(sf, (node) => {
+        if (!ts.isTryStatement(node) || !node.catchClause) return;
+
+        // 1. Does the guarded block call a durability-critical operation?
+        const guarded = collectGuardedCalls(node.tryBlock);
         if (guarded.length === 0) return;
 
         // 2. How does the catch respond?
@@ -636,6 +703,91 @@ function selfTest() {
                 } }`,
             expectViolation: true,
         },
+        {
+            // #4754: `rest-server.ts` reports through
+            // `const logError = (...a) => console.error(...a)` — a same-file
+            // helper the catch side is DOCUMENTED to follow. Its body is the
+            // call expression itself, not a block containing one, and the
+            // walker only ever visited CHILDREN, so the loudest site in the
+            // file read as `silent-swallow`. A false positive here is not
+            // cosmetic: the only ways to satisfy it are to baseline correct
+            // code or to bolt on a redundant log.
+            name: 'passes: catch delegating to a loud CONCISE-ARROW helper (expression body)',
+            code: `
+                const logError = (...args: unknown[]) => (globalThis as any).console?.error(...args);
+                class P { async f(driver: any, obj: any) {
+                    try { await driver.syncSchema('t', obj); } catch (e) { logError('DDL never ran', e); }
+                } }`,
+            expectViolation: false,
+        },
+        {
+            name: 'flags: catch delegating to a QUIET concise-arrow helper (expression body)',
+            code: `
+                const note = (...args: unknown[]) => (globalThis as any).console?.warn(...args);
+                class P { async f(driver: any, obj: any) {
+                    try { await driver.syncSchema('t', obj); } catch (e) { note('failed', e); }
+                } }`,
+            expectViolation: true,
+        },
+        {
+            // #4754: one `saveMetaItem` in `packages.ts` was reported THREE
+            // times — at its real seam and again at each enclosing route- and
+            // function-level catch, neither of which can ever observe it. The
+            // enclosing handlers are correct as written, so every extra report
+            // is pressure to baseline correct code.
+            name: 'passes: enclosing catch is not accused when an inner RECOVERING catch already consumed the call',
+            code: `
+                class P { async f(ctx: any, driver: any, obj: any) {
+                    try {
+                        try { await driver.syncSchema('t', obj); }
+                        catch (e) { ctx.logger.error('DDL never ran — not durable; fix X', e); }
+                        return 'ok';
+                    } catch (outer) { return 'failed'; }
+                } }`,
+            expectViolation: false,
+            expectCount: 0,
+        },
+        {
+            name: 'flags: the inner catch itself is still judged (no coverage lost to shadowing)',
+            code: `
+                class P { async f(ctx: any, driver: any, obj: any) {
+                    try {
+                        try { await driver.syncSchema('t', obj); }
+                        catch (e) { ctx.logger.warn('oh well', e); }
+                        return 'ok';
+                    } catch (outer) { return 'failed'; }
+                } }`,
+            expectViolation: true,
+            // Exactly one: the inner seam. The outer catch never sees it.
+            expectCount: 1,
+        },
+        {
+            name: 'flags: enclosing catch IS accused when the inner catch rethrows on every path',
+            code: `
+                class P { async f(ctx: any, driver: any, obj: any) {
+                    try {
+                        try { await driver.syncSchema('t', obj); }
+                        catch (e) { throw e; }
+                        return 'ok';
+                    } catch (outer) { return 'failed'; }
+                } }`,
+            expectViolation: true,
+            // Only the outer one: the inner catch propagates, so it is excused
+            // and the failure genuinely arrives at the outer catch.
+            expectCount: 1,
+        },
+        {
+            name: 'flags: a critical call in an inner CATCH body still reaches the enclosing catch',
+            code: `
+                class P { async f(ctx: any, driver: any, obj: any, fallback: any) {
+                    try {
+                        try { await driver.initObjects(obj); }
+                        catch (e) { ctx.logger.error('primary failed; retrying', e); await driver.syncSchema('t', fallback); }
+                        return 'ok';
+                    } catch (outer) { return 'failed'; }
+                } }`,
+            expectViolation: true,
+        },
     ];
 
     let failures = 0;
@@ -645,9 +797,18 @@ function selfTest() {
         const seams = [];
         analyzeSourceFile(sf, 't.ts', findings, seams);
         const got = findings.length > 0;
-        if (got !== c.expectViolation) {
+        // `expectCount` pins HOW MANY seams a case reports, not just whether it
+        // reports one. Nesting cases need it: "still flags" is satisfied both by
+        // the correct single finding and by the duplicate-per-nesting-level bug
+        // it replaced, so a boolean cannot tell those two apart (#4754).
+        const countMismatch = c.expectCount !== undefined && findings.length !== c.expectCount;
+        if (got !== c.expectViolation || countMismatch) {
             failures++;
-            console.error(`  ✗ ${c.name}: expected violation=${c.expectViolation}, got ${got}`);
+            console.error(
+                `  ✗ ${c.name}: expected violation=${c.expectViolation}` +
+                    (c.expectCount !== undefined ? ` count=${c.expectCount}` : '') +
+                    `, got violation=${got} count=${findings.length}`,
+            );
         } else {
             console.log(`  ✓ ${c.name}`);
         }

--- a/scripts/durability-degradation.baseline.json
+++ b/scripts/durability-degradation.baseline.json
@@ -5,7 +5,54 @@
     "site that gets fixed must have its entry deleted in the same PR. There is deliberately",
     "no `--fix`/`--update` flag — a generator would let a new violation be admitted by",
     "'just run the update command', which is precisely how a gate stops meaning anything.",
-    "Every entry names WHY it is still here and WHAT closes it."
+    "Every entry names WHY it is still here and WHAT closes it.",
+    "",
+    "Key granularity is `<file>::<callee>`, NOT a line — line numbers churn on every",
+    "unrelated edit and a line-keyed ledger would go stale constantly. The cost is that an",
+    "entry licenses the WHOLE file for that callee: a genuinely new silent swallow of the",
+    "same callee in an already-listed file would be excused. Read the entry's `sites` list",
+    "as the set it was reviewed against, and re-review when that file grows a new one."
   ],
-  "entries": []
+  "entries": [
+    {
+      "file": "packages/runtime/src/domains/meta.ts",
+      "callee": "saveMetaItem",
+      "sites": ["PUT /metadata/:type/:name — catch → deps.errorFromThrown(e, 400)"],
+      "reason": [
+        "Not a degradation: `saveMetaItem` IS this request's primary operation, and the catch",
+        "hands the failure straight back to the caller as a real 4xx/422 error envelope",
+        "(errorFromThrown preserves the protocol's own `.status` plus the structured",
+        "spec-validation `issues`). Nothing continues on a reduced path and nothing looks",
+        "normal afterwards — the Studio that asked for the save is told, field-anchored, that",
+        "it did not happen. AGENTS.md's judgment question ('does the system still look normal",
+        "while something it claims is persisted has not landed?') answers NO here.",
+        "Raising it to `error` would be the mirror-image failure AGENTS.md warns about: the",
+        "common case on this path is an author submitting an off-spec body, so it would emit a",
+        "durability `error` per bad keystroke and train everyone to skim `error` — which is",
+        "what made the #4420 `warn` unreadable in the first place."
+      ],
+      "closes": "#5241 — teach the checker a DECLARED failure-propagation vocabulary (a catch whose every path returns an error envelope propagates the failure and is not a degradation), then delete this entry. Until then the gate cannot tell 'reported to the caller' from 'swallowed'.",
+      "added": "2026-08-04 (#4754, the PR that added `saveMetaItem` to DURABILITY_CRITICAL_CALLEES)"
+    },
+    {
+      "file": "packages/metadata-protocol/src/protocol.ts",
+      "callee": "saveMetaItem",
+      "sites": [
+        "migrateStoredItems() apply pass — catch → record({ outcome: 'failed', reason }), which increments report.failed and itemises the row",
+        "duplicate/copy into target package — catch → failed.push({ type, name, error }), which flips the returned `success` to false and populates failedCount/failed[]"
+      ],
+      "reason": [
+        "Not a degradation: both are batch operations whose CONTRACT is a per-item outcome",
+        "report, and both catches write the failure into that report rather than dropping it.",
+        "The first increments a `failed` counter and itemises the row with its reason; the",
+        "second flips the aggregate `success` to false and returns the failed item in",
+        "`failed[]`. This is strictly louder than a log line — it is the `error` + counter",
+        "shape #4669 itself adopted, delivered as structured data the caller cannot miss.",
+        "The system does not look normal afterwards: the response says, per item, that the",
+        "write did not land."
+      ],
+      "closes": "#5241 — same declared failure-propagation vocabulary (structured per-item outcome reports are the second shape it must cover), then delete this entry.",
+      "added": "2026-08-04 (#4754, the PR that added `saveMetaItem` to DURABILITY_CRITICAL_CALLEES)"
+    }
+  ]
 }


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4754

## 先说重测结果:issue 的清单要按当前 main 重读

issue 的「8 处 / 3 包 4 文件」表是 08-03 测的。在 `origin/main`(基线 `718b229fa`,已合并至 `4addd9dd`)重跑探针,**总数与文件分布完全一致**,只有行号漂移 —— E6(#5093)对 rest-server enrichment 管线的改动没有增删这一族接缝:

| 文件 | issue 的数 | 重测的数 | 说明 |
|---|---|---|---|
| `packages/runtime/src/domains/packages.ts` | 3 | 3 | 三处**指向同一个** `saveMetaItem()`(行 219),由三层嵌套 catch 各报一次 |
| `packages/rest/src/rest-server.ts` | 2 | 2 | 行号 3671 / 4025 |
| `packages/metadata-protocol/src/protocol.ts` | 2 | 2 | 行号 7631 / 8769 |
| `packages/runtime/src/domains/meta.ts` | 1 | 1 | 行号 161 |

但**逐处读完之后,结论和 issue 的预判差别很大**:issue 把「catch 里连日志都没有」这个**形态**当成了「真丢数据」这个**实质**,而 8 处里只有 1 处真的丢。下面是逐处判定。

## 逐处判定

### 真丢失(1 处)—— 已按范本改成 `error`

**`packages/runtime/src/domains/packages.ts`,ADR-0045 可见性翻转。** 这是一次**搭别人便车的元数据写入**:草稿此时已经发布成功,所以 `POST /packages/:id/publish-drafts` 无论翻转成不成都答 200,写失败只在响应体里留下一个 `unhideError` —— 没有运维会读它。于是症状变成「我明明发布了,应用却没出现」,而且要过很久才有人把它和这里联系起来。这正是 #4669 的形状,AGENTS.md 的判据原问答案是**是**(系统看起来完全正常,而它声称写进去的东西没落盘)。

现在按 `service-automation` `start()` 的范本在 `error` 级报告,一行里交清两件事:

- **后果**:点名是哪个包;它的 app 仍以 `hidden: true` 存着,因而在启动器里不可见;而发布报告的是成功;没有任何东西会重试这次翻转;
- **修复动作**:重跑 `POST /packages/:id/publish-drafts`(幂等),或直接对该 app 走 `PUT /meta/app/:name` 置 `hidden: false`;并带上原始错因。

响应契约**不变** —— 仍然 200,仍然带 `unhideError`。

### 不是降级、故障已答给调用方(3 处)—— 进 shrink-only 基线

- **`packages/runtime/src/domains/meta.ts`** — `catch` → `deps.errorFromThrown(e, 400)`。`saveMetaItem` **就是这个请求的主操作**,失败原样回给调用方(保留协议自己的 `.status` 和结构化 `issues`)。没有任何路径在降级后继续,Studio 拿到的是字段级锚定的 4xx/422。
- **`packages/metadata-protocol/src/protocol.ts` ×2** — 两处都是**契约就是逐项结果报告**的批量操作:`migrateStoredItems` 做 `report.failed++` 并把该行连原因一起 itemise;复制入包那处 `failed.push()` 并把聚合 `success` 翻成 `false`、填 `failedCount` / `failed[]`。这比一行日志**更响**,而且正是 #4669 自己采用的「`error` + 计数」形状,只不过以结构化数据交付。

这三处**不能**升成 `error`:`meta.ts` 那条路径最常见的情况是作者提交了不合 spec 的 body,升级后每一次校验拒绝都会打一条持久性 `error` —— 正是 AGENTS.md 点名的镜像错误(「trains everyone to skim `error`」),也正是 #4420 那条 `warn` 当初没人读的成因。基线条目写清了理由与关闭条件,指向 #5241。

> 基线键是 `file::callee`(**不含行号** —— 行号会因无关改动天天漂),所以 3 处站点合成 **2 个键**。条目里新增了 `sites` 字段列出复核过的站点集合,并在表头说明这个粒度的代价。

### 闸门自身的误报(4 处)—— 修闸门,不写基线

剩下 4 处根本不是代码的问题,是闸门看错了。**给正确代码写基线是有害的**:基线表头自己写着每条都要有「WHAT closes it」,而正确代码永远关不掉;更糟的是它给下一个作者立了「这闸门会误报,遇红先加基线」的范例 —— 而脚本自己的注释恰恰说,误报到让人绕过的闸门 *worth less than no gate, because it also reports success*。所以这两个缺陷是修掉的:

**① 同文件 concise-arrow 报告器看不见。** 闸门文档明说 `catch` 一侧会追同文件 helper(不然「把失败藏到一层间接后面」就成了最省事的变哑办法),但遍历只访问**子节点**,而

```ts
const logError = (...args: unknown[]) => (globalThis as any).console?.error(...args);
```

的函数体**就是**那个调用表达式本身。于是 `rest-server.ts` 里最响的两处 `/meta` PUT(`logError` + `sendError`)被判成「完全静默」。修完后它们如实显示 `loud (error@49 via logError())`。

**② 一处接缝被按嵌套层数重复指认。** 一个已被内层 `catch` 消化掉的调用,仍然算在**每一层**外层 `catch` 头上。`packages.ts` 那一个 `saveMetaItem` 因此被报了三次 —— 真接缝一次,加上路由级和函数级两个**永远看不到它**的通用错误处理器。现在只有当内层 `catch` **每条路径都向外传播**时(复用已有的 `catchRecovers`),外层才算真正的守卫;内层 `catch`/`finally` 体里的调用仍然算外层的。**覆盖面一点没丢** —— 那个消化掉故障的内层 catch 本身照样被判。

## 效果

```
词表加 saveMetaItem,闸门未修:  8 处命中
仅修闸门两个精度缺陷:          4 处命中   ← 4 处误报消失,一行产品代码没动
修掉真丢失那 1 处 + 3 处进基线: 绿
```

```
$ pnpm check:durability-log-level
✓ self-test: 19 case(s) passed
✓ durability-degradation log levels: 22 durability-critical catch seam(s), all loud or rethrowing (2 baselined).
```

## 测试

自测用例**双向钉住**(#4690:只绿过的闸门和什么都不匹配的闸门无法区分)。把两个修复分别单独回退,新用例确实失败:

```
=== 回退修复 ①(concise-arrow)===
  ✗ passes: catch delegating to a loud CONCISE-ARROW helper (expression body):
      expected violation=false, got violation=true count=1
=== 回退修复 ②(嵌套遮蔽)===
  ✗ passes: enclosing catch is not accused when an inner RECOVERING catch already consumed the call:
      expected violation=false count=0, got violation=true count=1
  ✗ flags: the inner catch itself is still judged (no coverage lost to shadowing):
      expected violation=true count=1, got violation=true count=2
```

最后一条说明了为什么给自测加了 `expectCount`:**布尔断言区分不出「正确地报 1 次」和「按嵌套层数重复报 2 次」** —— 光看「还是红的」这个 bug 能完美蒙混过去。

产品侧新增用例同样做了反向验证(去掉日志即失败:`expected "error" to be called 1 times, but got 0 times`):

```
$ pnpm --filter @objectstack/runtime test
 Test Files  89 passed (89)
      Tests  1313 passed (1313)

$ pnpm --filter @objectstack/runtime typecheck
> tsc --noEmit          # 干净
```

以上均为合并 `origin/main`(`4addd9dd`)、`pnpm install --frozen-lockfile` + 重建依赖图之后重跑的结果;闸门在合并后仍是 22 seams,新入的 driver-sql schema-drift 改动没有新增这一族接缝。

## 顺带发现(未在本 PR 修,已另立)

- **#5241** — 闸门分不清「故障已答给调用方」和「故障被吞掉」,这正是本 PR 那 2 条基线的来由。根因是 `saveMetaItem` 和词表里其他条目**不是一类**:现有条目清一色是**背景副作用**(调用方不等结果),而 `saveMetaItem` 8 处里 7 处是**调用方直面的主操作**。观察类,`finding`。
- **#5242** — 同一段代码的另一个缺陷:可见性翻转中途失败时,已经翻转成功的 app 从响应里整批消失(`unhiddenApps` 的赋值在循环之后、try 之内),连带 `metadata:reloaded` 对这几个 app 漏播。与日志级别无关,改它要动作用域和响应语义,故未夹带。观察类,`finding`。

未触碰:`packages/metadata-protocol/src/seed-loader.ts`(#5127 同批)、`packages/spec/**`、`content/docs/releases/**`,以及派单列出的其余在飞面。`rest-server.ts` 与 `protocol.ts` 虽在声明文件面内,最终**没有改动**(①/基线已解决)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pbu27iNUfQCHeuS551Rqo7
