### PR TITLE
fix(core)!: kernel:ready 抛错在两个内核上一律失败 boot(#5170)

### DIFF
--- a/.changeset/kernel-ready-unified-failure.md
+++ b/.changeset/kernel-ready-unified-failure.md
@@ -1,0 +1,44 @@
+---
+"@objectstack/core": minor
+---
+
+fix(core)!: a throwing `kernel:ready` handler now fails the boot on **LiteKernel** too (#5170)
+
+**Behaviour change — read this if you run `LiteKernel` (vitest harnesses,
+serverless functions, edge workers).** A `kernel:ready` handler that throws now
+**rejects `bootstrap()`** on `LiteKernel`, exactly as it always has on
+`ObjectKernel`. Before this change the throw was caught inside the kernel,
+written out as one `Hook handler failed: kernel:ready` error log, and the boot
+continued to "✅ Bootstrap complete".
+
+**Why it mattered.** The two kernels ran the same hook through two different
+dispatchers: `ObjectKernel` used `context.trigger` (a bare awaited loop that
+never catches), `LiteKernel` used `triggerHook` (per-handler try/catch,
+"continue with other handlers even if one fails"). Same hook name, same plugin
+code, opposite failure semantics — which is `declared ≠ enforced` in the
+kernel's own lifecycle contract.
+
+`kernel:ready` is the only correct moment for a plugin to assert that a
+precondition it *declared* was actually delivered: the service registry is
+still filling during `init()`, so a boot gate has nowhere earlier to run. Every
+"declare it and we refuse to start if we cannot honour it" gate in this repo
+therefore lives there — and on `LiteKernel` those gates were being downgraded to
+a log line while the process came up and served traffic without the guarantee it
+had announced. `EmailServicePlugin`'s `queueDelivery: true` gate (#5160) is the
+worked example: on `ObjectKernel` the boot failed, on `LiteKernel` the server
+came up and quietly fell back to inline delivery. Serverless is exactly where
+"do not start misconfigured" matters most.
+
+**Who is affected.** Any `LiteKernel` host whose `kernel:ready` handler throws
+on a healthy boot. That boot previously "succeeded"; it now fails loudly with
+the original error, and the kernel is left `stopped` rather than `running`. The
+failure was never silent — it was already an `ERROR` line in your logs — so
+check for `Hook handler failed: kernel:ready` in existing logs to find hosts
+that will now refuse to start. If the handler's work is genuinely optional,
+catch inside the handler and log there; the kernel no longer decides that for
+you. The full test surface in this repo that boots `LiteKernel` (core, client,
+runtime, http-conformance, the connectors, service-automation) passes unchanged
+— nothing was relying on the swallow.
+
+Scope: **`kernel:ready` only.** `kernel:bootstrapped`, `kernel:listening` and
+`kernel:shutdown` keep `LiteKernel`'s isolating dispatch, pinned by a test.

--- a/content/docs/kernel/events.mdx
+++ b/content/docs/kernel/events.mdx
@@ -33,6 +33,8 @@ ctx.hook('kernel:ready', async () => {
 
 `ctx.hook(name, handler)` takes exactly two arguments — there is no options/priority parameter. Kernel hooks run in **registration order**, and `ctx.trigger()` awaits each handler sequentially.
 
+A `kernel:ready` handler that **throws fails the boot**, on `ObjectKernel` and `LiteKernel` alike: the remaining `kernel:ready` handlers are skipped, `kernel:bootstrapped` and `kernel:listening` never fire, and `bootstrap()` rejects with the original error. That is what makes `kernel:ready` the place to assert that a precondition your plugin *declared* was actually met — the service registry is still filling during `init()`, so nothing earlier can judge it, and a deployment that cannot honour what it announced must refuse to start rather than serve without the guarantee. The other lifecycle hooks do **not** share that contract: `ObjectKernel` propagates their failures too, while `LiteKernel` logs each one and runs the remaining handlers. Put boot assertions in `kernel:ready`.
+
 ### Emitting Custom Events
 
 Plugins can trigger their own namespaced events for inter-plugin communication. Use `ctx.trigger()` (it is async and returns a `Promise`); handlers receive the positional arguments you pass to `trigger()`:

--- a/packages/core/src/kernel-base.ts
+++ b/packages/core/src/kernel-base.ts
@@ -247,7 +247,15 @@ export abstract class ObjectKernelBase {
     }
 
     /**
-     * Trigger a hook with all registered handlers
+     * Trigger a hook with all registered handlers, ISOLATING failures: a
+     * handler that throws is logged and the remaining handlers still run.
+     *
+     * Use this for notification-style hooks, where one subscriber's failure
+     * must not deny the others their notification. It is the WRONG dispatcher
+     * for a hook that carries boot assertions — a swallowed throw there turns
+     * "this deployment refuses to start misconfigured" into a log line nobody
+     * reads. Those hooks use {@link triggerHookOrThrow} (#5170).
+     *
      * @param name - Hook name
      * @param args - Arguments to pass to handlers
      */
@@ -265,6 +273,43 @@ export abstract class ObjectKernelBase {
                 this.logger.error(`Hook handler failed: ${name}`, error as Error);
                 // Continue with other handlers even if one fails
             }
+        }
+    }
+
+    /**
+     * Trigger a hook with all registered handlers, PROPAGATING the first
+     * failure: the remaining handlers do not run and the original error
+     * reaches the caller unwrapped.
+     *
+     * This is the dispatch semantics `ObjectKernel` has always had for every
+     * lifecycle hook (its `context.trigger` is a bare awaited loop that never
+     * catches). `LiteKernel` used the isolating {@link triggerHook} for all of
+     * them, so one hook name meant two opposite things depending on which
+     * kernel booted the same plugin code (#5170). `kernel:ready` is the hook
+     * where that divergence bites: it is the only correct moment for a plugin
+     * to assert that the preconditions it declared were actually met (the
+     * registries are still filling during `init()`), so "declared but not
+     * deliverable ⇒ refuse to boot" gates live there — and on LiteKernel,
+     * which is what vitest/serverless/edge run, they were being downgraded to
+     * an error log while the process carried on serving traffic without the
+     * guarantee it claimed.
+     *
+     * Deliberately NOT applied to the other hook names: #5170 rules
+     * `kernel:ready` only, and a notification hook keeping fail-soft dispatch
+     * is a separate judgement per hook, not a side effect of this one.
+     *
+     * @param name - Hook name
+     * @param args - Arguments to pass to handlers
+     */
+    protected async triggerHookOrThrow(name: string, ...args: any[]): Promise<void> {
+        const handlers = this.hooks.get(name) || [];
+        this.logger.debug(`Triggering hook: ${name}`, {
+            hook: name,
+            handlerCount: handlers.length,
+        });
+
+        for (const handler of handlers) {
+            await handler(...args);
         }
     }
 

--- a/packages/core/src/kernel.test.ts
+++ b/packages/core/src/kernel.test.ts
@@ -605,6 +605,37 @@ describe('ObjectKernel', () => {
             expect(order).toEqual(['kernel:ready', 'kernel:bootstrapped', 'kernel:listening']);
         });
 
+        // #5170 — the ObjectKernel HALF of the cross-kernel pin. `kernel:ready`
+        // is where plugins assert that what they declared is actually
+        // deliverable, so a throw there must fail the boot. LiteKernel has the
+        // twin of this test (lite-kernel.test.ts); the pair is what keeps one
+        // hook name from meaning two opposite things again.
+        it('fails the boot when a kernel:ready handler throws (#5170)', async () => {
+            const reached: string[] = [];
+            const plugin: Plugin = {
+                name: 'ready-thrower-plugin',
+                version: '1.0.0',
+                init: async (ctx) => {
+                    ctx.hook('kernel:ready', async () => {
+                        throw new Error('declared a durable queue, got none');
+                    });
+                    ctx.hook('kernel:ready', async () => { reached.push('later-ready'); });
+                    ctx.hook('kernel:bootstrapped', async () => { reached.push('kernel:bootstrapped'); });
+                    ctx.hook('kernel:listening', async () => { reached.push('kernel:listening'); });
+                },
+            };
+
+            await kernel.use(plugin);
+
+            // The ORIGINAL error surfaces — not a wrapped "bootstrap failed".
+            await expect(kernel.bootstrap()).rejects.toThrow('declared a durable queue, got none');
+
+            // Boot stopped AT the failing handler: no later ready handler, and
+            // neither of the anchors that promise "every ready handler settled".
+            expect(reached).toEqual([]);
+            expect(kernel.getState()).toBe('stopped');
+        });
+
         it('should trigger shutdown hook', async () => {
             let hookCalled = false;
 

--- a/packages/core/src/lite-kernel.test.ts
+++ b/packages/core/src/lite-kernel.test.ts
@@ -270,5 +270,66 @@ describe('LiteKernel with Configurable Logger', () => {
 
             expect(order).toEqual(['kernel:ready', 'kernel:bootstrapped', 'kernel:listening']);
         });
+
+        // #5170 — the LiteKernel half of the cross-kernel pin. This is the
+        // behaviour the issue changed: the throw used to be caught inside
+        // `triggerHook`, logged as `Hook handler failed: kernel:ready`, and the
+        // boot carried on to report "✅ Bootstrap complete". A vitest /
+        // serverless / edge host therefore came up WITHOUT the guarantee its
+        // ready handler had just refused to give it. Same hook, same plugin
+        // code, same answer on both kernels now.
+        it('fails the boot when a kernel:ready handler throws (#5170)', async () => {
+            const reached: string[] = [];
+            const plugin: Plugin = {
+                name: 'ready-thrower-plugin',
+                init: async (ctx) => {
+                    ctx.hook('kernel:ready', async () => {
+                        throw new Error('declared a durable queue, got none');
+                    });
+                    ctx.hook('kernel:ready', async () => { reached.push('later-ready'); });
+                    ctx.hook('kernel:bootstrapped', async () => { reached.push('kernel:bootstrapped'); });
+                    ctx.hook('kernel:listening', async () => { reached.push('kernel:listening'); });
+                },
+            };
+
+            kernel.use(plugin);
+
+            // The ORIGINAL error surfaces — not a wrapped "bootstrap failed".
+            await expect(kernel.bootstrap()).rejects.toThrow('declared a durable queue, got none');
+
+            // Boot stopped AT the failing handler: no later ready handler, and
+            // neither of the anchors that promise "every ready handler settled".
+            expect(reached).toEqual([]);
+            expect(kernel.getState()).toBe('stopped');
+        });
+
+        // The other side of the same contract: #5170 rules `kernel:ready` ONLY.
+        // The notification-style hooks keep LiteKernel's isolating dispatch, so
+        // one failing subscriber does not deny the others their notification.
+        // Pinned so a future "unify everything" reading of #5170 has to be a
+        // deliberate change with its own issue, not a silent widening.
+        it('keeps fail-soft dispatch for hooks other than kernel:ready (#5170)', async () => {
+            const reached: string[] = [];
+            const plugin: Plugin = {
+                name: 'other-hook-thrower-plugin',
+                init: async (ctx) => {
+                    ctx.hook('kernel:bootstrapped', async () => { throw new Error('bootstrapped boom'); });
+                    ctx.hook('kernel:bootstrapped', async () => { reached.push('later-bootstrapped'); });
+                    ctx.hook('kernel:listening', async () => { throw new Error('listening boom'); });
+                    ctx.hook('kernel:listening', async () => { reached.push('later-listening'); });
+                    ctx.hook('kernel:shutdown', async () => { throw new Error('shutdown boom'); });
+                    ctx.hook('kernel:shutdown', async () => { reached.push('later-shutdown'); });
+                },
+            };
+
+            kernel.use(plugin);
+
+            await expect(kernel.bootstrap()).resolves.toBeUndefined();
+            expect(kernel.getState()).toBe('running');
+            expect(reached).toEqual(['later-bootstrapped', 'later-listening']);
+
+            await expect(kernel.shutdown()).resolves.toBeUndefined();
+            expect(reached).toContain('later-shutdown');
+        });
     });
 });

--- a/packages/core/src/lite-kernel.ts
+++ b/packages/core/src/lite-kernel.ts
@@ -80,8 +80,23 @@ export class LiteKernel extends ObjectKernelBase {
             await this.runPluginStart(plugin);
         }
 
-        // Trigger ready hook (route/middleware registration phase)
-        await this.triggerHook('kernel:ready');
+        // Trigger ready hook (route/middleware registration phase).
+        //
+        // PROPAGATING dispatch, identical to ObjectKernel's (#5170): a
+        // `kernel:ready` handler that throws FAILS THE BOOT on both kernels.
+        // This hook is where plugins assert that what they declared can
+        // actually be delivered — the registries are still filling during
+        // init(), so a boot gate has nowhere earlier to run — and a swallowed
+        // assertion means the process keeps serving without the guarantee it
+        // announced. The kernel is left 'stopped' rather than 'running',
+        // mirroring `ObjectKernel.bootstrap()`'s catch, so a failed boot never
+        // reads as a live kernel.
+        try {
+            await this.triggerHookOrThrow('kernel:ready');
+        } catch (error) {
+            this.state = 'stopped';
+            throw error;
+        }
         // Trigger bootstrapped hook — "all synchronous bootstrap has settled"
         // anchor, strictly after every kernel:ready handler has settled and
         // before any HTTP socket opens. NOTE: does not guarantee background app

--- a/packages/plugins/plugin-email/src/email-plugin.ts
+++ b/packages/plugins/plugin-email/src/email-plugin.ts
@@ -659,10 +659,13 @@ export class EmailServicePlugin implements Plugin {
       //
       // NOT awaited: a backlog of stranded mail must not hold the server off
       // its port, and in inline mode every row is a transport round trip. And
-      // self-catching rather than trusting the hook: a `kernel:ready` handler
-      // that throws is silently swallowed on LiteKernel (#5170), which for a
-      // durability sweep would mean losing the report of the very failure it
-      // exists to prevent.
+      // self-catching BECAUSE it is not awaited: a `kernel:ready` handler that
+      // throws now fails the boot on BOTH kernels (#5170 unified that), but
+      // this sweep is detached from the handler, so an escaping rejection
+      // would surface as an unhandled rejection instead — losing the report of
+      // the very failure it exists to prevent. A stranded-row report is also
+      // not grounds to refuse an otherwise healthy boot; the gate above is
+      // where this plugin refuses.
       if (persistence) {
         const svc = this.service;
         this.outboxSweepSettled = (async () => {


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5170

按单上记录的决策落 **方案 A(统一为传播)**:`kernel:ready` handler 抛错在 `ObjectKernel` 与 `LiteKernel` 上一律**失败 boot**。B/C 未实现。

## 证据闸(改行为之前先做的摸底)

派发词要求先摸清 blast radius,结论是 **小到零**,可以推进:

1. **LiteKernel 上可达的 `kernel:ready` handler**:全仓 56 处非测试注册点(`git grep -n "hook('kernel:ready'" origin/main`),其中能出现在 LiteKernel 组合里的是 `ObjectQLPlugin`、`HonoServerPlugin`、`AppPlugin`、`AutomationServicePlugin`、dispatcher/rest 系列。逐个读过:它们要么是 warn-and-skip,要么自带 try/catch(例如 automation 的 `syncFlowsFromProtocol` 在没有 objectql 时只 warn —— 实测日志里就有 `[Automation] flow pull from ObjectQL registry failed: [Kernel] Service 'objectql' not found`,并不抛)。**没有一个在健康 boot 上抛错**。
2. **LiteKernel 启动的测试面**:`git grep -ln "LiteKernel"` 命中的全部 booting 套件都跑过了(见下),**零失败**——即没有任何既有测试是"靠吞异常才跑得起来"的。
3. 因此不触发"停下回报 needs_decision"的条件。

## 改法

内核基类新增 `triggerHookOrThrow`(传播版分发器),`LiteKernel` **只在 `kernel:ready` 这一处**用它:

- 为什么不是直接改调 `context.trigger`:`triggerHook` 那句 `logger.debug('Triggering hook: ...')` 是 LiteKernel boot 日志的一部分,换成 `context.trigger` 会静默丢掉它;新增一个并列的具名分发器还能把"哪些钩子该 fail-loud、哪些该 fail-soft"这件事**写在类型/命名上**,而不是靠调用点的注释。
- 为什么不是给 `triggerHook` 加参数:两种语义是两种契约,不是同一函数的开关;两个分发器各自带上"何时用我"的 docblock,下一个人加钩子时要做的是**选一个**,而不是记住一个布尔。
- **失败后 `state = 'stopped'`**,对齐 `ObjectKernel.bootstrap()` 的 catch —— 失败的 boot 不该继续读作 `running`。原始错误原样抛出,不包装。
- 其余钩子(`kernel:bootstrapped` / `kernel:listening` / `kernel:shutdown`)在 LiteKernel 上**语义不变**,按派发词"本单只裁 `kernel:ready`"。

## 测试

两边对称的回归用例(补在既有 lifecycle ordering 用例旁),外加一条"其余钩子仍 fail-soft"的 pin,让将来任何扩大化都必须是显式改动:

- `kernel.test.ts` — 抛错的 ready handler ⇒ `bootstrap()` reject 原始错误、后续 ready handler 不跑、`bootstrapped`/`listening` 不触发、`getState() === 'stopped'`。
- `lite-kernel.test.ts` — 同上一条(**这条在改动前是失败的**:`AssertionError: promise resolved "undefined" instead of rejecting`,即原先 boot 照常成功);外加 `keeps fail-soft dispatch for hooks other than kernel:ready`。

## 顺带订正的措辞(仅此两处)

- `packages/plugins/plugin-email/src/email-plugin.ts` —— #5160/PR #5173 里写的"a `kernel:ready` handler that throws is silently swallowed on LiteKernel"现在不成立。改为说明该 sweep 自 catch 的**真实**理由(它是脱离 handler 的 detached 任务,逃逸的 rejection 会变成 unhandled rejection;且滞留行报告不该否决一个本来健康的 boot)。行为零变化。
- `content/docs/kernel/events.mdx` —— 补一段把统一后的语义写成真话,并诚实写明其余钩子仍有内核差异。⛔ `content/docs/releases/**` 未碰。

## 验证(全部在容器共享锁下跑)

    packages/core          Test Files 27 passed | Tests 422 passed
    packages/core          typecheck  Tasks: 2 successful
    packages/plugin-email  Test Files 15 passed | Tests 231 passed  + typecheck
    packages/runtime       Test Files  7 passed | Tests  51 passed   (app-plugin / dispatcher / route-parity / server-timing)
    packages/client        Test Files  4 passed | Tests  16 passed
    qa/http-conformance    Test Files  2 passed | Tests  46 passed
    connector-rest/mcp/slack  3+2+3 files, 16+8+23 tests passed
    service-automation     Test Files 55 passed | Tests 665 passed

## changeset

`.changeset/kernel-ready-unified-failure.md`,**按行为变更来写**:点名受影响的人(vitest / serverless / edge 上 ready handler 会抛的宿主),写明"以前也不是完全静默 —— 是一条 `Hook handler failed: kernel:ready` 的 ERROR 日志",并给出自查方法(在既有日志里搜这句)与出路(工作若真的可选,就在 handler 内部自己 catch)。

## 范围外发现

- **#5257** — `kernel:listening` / `kernel:bootstrapped` / `kernel:shutdown` 在 LiteKernel 上仍被吞;其中 `HonoServerPlugin` 的 `await this.server.listen(port)` 没有自己的 try/catch,失败时 LiteKernel 会打印「✅ Bootstrap complete」而实际没有监听端口。同源不同钩子,本单派发词明确只裁 `kernel:ready`,故另开、未在本 PR 修。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pbu27iNUfQCHeuS551Rqo7


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pbu27iNUfQCHeuS551Rqo7)_