### PR TITLE
fix(metadata): `unregister()` 先删存储再失效 listCache —— 删除落库前的并发 list() 不再把已删项缓存满 30s (#5259)

### DIFF
--- a/.changeset/unregister-invalidate-after-delete.md
+++ b/.changeset/unregister-invalidate-after-delete.md
@@ -1,0 +1,56 @@
+---
+"@objectstack/metadata": patch
+---
+
+fix(metadata): `unregister()` invalidates the list cache AFTER the storage delete lands (#5259)
+
+`MetadataManager.unregister()` dropped the registry entry and called
+`invalidateListCache(type)` **before** awaiting `loader.delete()`. Those two steps
+are separated by a real await window — one DB round-trip per writable loader — and
+inside it the manager held a state that exists nowhere else: **registry already
+empty, loader not yet empty**. `list()` merges the two, so a read arriving in that
+window missed the just-cleared cache, assembled the still-stored row into its
+answer, and memoized it as a *complete* read — the full 30s healthy TTL, because no
+loader threw and #5184's 2s degraded TTL therefore never applied.
+
+Nothing invalidated again once the delete landed (`notifyWatchers()` does not touch
+`listCache`), so an item that was gone from storage kept being enumerated for up to
+half a minute. `list()` is the enumeration seam behind `GET /api/v1/metadata/:type`,
+the Studio left rail, sync/export and every consumer that decides existence from a
+declared set — and `get()`, which never reads that cache, said the item was gone the
+whole time. For a gating type (`permission`, `api`) the two faces of one manager
+answered opposite questions about whether a declaration exists.
+
+**Fixed by ordering, not by an extra invalidation.** `register()` never had this
+defect because it writes the registry *first* and the registry outranks every loader
+in the merge, so its own save window already shows the post-write state. The
+invariant is therefore not "invalidate early" but *invalidate last, once every store
+already holds the announced state*. `unregister()` now deletes from storage first,
+then drops the registry entry and invalidates with **nothing awaited between them**,
+then publishes and announces — #5219's invalidate-before-notify discipline unchanged.
+A `list()` racing the delete now either sees a coherent pre-delete state (the delete
+has not landed and has not been announced — that answer is the truth) or the
+post-delete state; it can no longer cache the pre-delete answer past the delete.
+
+This composes with #5253's single-flight rather than duplicating it: a read still
+*in flight* when the delete lands cannot be reached by dropping `listCache` — it has
+not written its entry yet and would write the pre-delete answer afterwards.
+`invalidateListCache()` also retracts that read's `inflightListReads` registration,
+so it resolves for the callers already waiting on it but loses the right to memoize,
+while a caller arriving later starts a fresh read.
+
+**A storage delete that fails is now loud.** It used to `logger.warn('Failed to
+delete …')` and continue. Per AGENTS.md "Degradation log levels" this is
+durability/consistency degradation, not functional: `unregister()` resolves
+normally, the caller is told the delete succeeded, and the surviving row is read
+straight back out of storage by the very next `list()`/`get()` — permanently, since
+nothing retries it. It now logs at `error`, once per un-deleted item, naming the
+consequence and the fix. The registry entry is still dropped in that case,
+deliberately: the loader still holds the row so the item is served either way, and
+keeping the entry would only pin an in-memory copy on top of a stored row nobody
+maintains — dropping it makes the next read fall through to storage, which is the
+actual truth after a failed delete, and makes it visible immediately instead of at
+the next restart.
+
+No API change. `unregister()` still resolves rather than throwing when a loader
+refuses the delete.

--- a/packages/metadata/src/metadata-manager-unregister-invalidate-order.test.ts
+++ b/packages/metadata/src/metadata-manager-unregister-invalidate-order.test.ts
@@ -1,0 +1,515 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #5259 — `unregister()` invalidates the list cache AFTER the storage delete
+ * lands, not before it.
+ *
+ * `unregister()` used to drop the registry entry and call
+ * `invalidateListCache(type)` and only THEN `await loader.delete(...)`. Between
+ * those two steps the manager sat in a state that exists nowhere else —
+ * **registry already empty, loader not yet empty** — and `list()` merges the
+ * two. So a read arriving in that window missed the just-cleared cache,
+ * assembled the still-stored row into its answer, and memoized it as a
+ * COMPLETE read: the full 30s healthy TTL, because no loader threw and #5184's
+ * 2s degraded TTL therefore never applied. Nothing invalidated again after the
+ * delete landed (`notifyWatchers()` does not touch `listCache`), so a row that
+ * was gone from storage kept being enumerated for up to half a minute — while
+ * `get()`, which never reads that cache, said it was gone.
+ *
+ * `register()` never had the defect, and the reason is the fix: it writes the
+ * registry first, and the registry outranks every loader in the merge, so its
+ * own save window already shows the post-write state. The invariant is
+ * therefore not "invalidate early" but **invalidate last, once every store
+ * already holds the announced state** — which for a delete means storage first,
+ * then registry + invalidate with nothing awaited between them, then announce
+ * (#5219's invalidate-before-notify bar, unchanged).
+ *
+ * What these tests pin:
+ *   1. the issue's probe, verbatim — a `list()` racing the delete must not
+ *      leave the deleted item cached once the delete has landed;
+ *   2. the composition with #5253's single-flight: a read still IN FLIGHT when
+ *      the delete lands is covered by `invalidateListCache()` retracting its
+ *      `inflightListReads` registration — dropping `listCache` alone cannot
+ *      reach it, because it has not written its entry yet;
+ *   3. the invalidation is after ALL loaders, not per loader;
+ *   4. a watcher woken by the `deleted` event that re-reads sees the delete;
+ *   5. the `loader.delete()` failure path is now loud at `error` with its
+ *      consequence and its fix, once per un-deleted item;
+ *   6. the deliberate decision that the registry entry is STILL dropped when
+ *      the storage delete failed — the runtime converges on storage truth
+ *      instead of pinning a second in-memory copy;
+ *   7. `register()`'s own ordering is unchanged.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type {
+    MetadataLoadOptions,
+    MetadataLoadResult,
+    MetadataLoaderContract,
+    MetadataSaveResult,
+    MetadataStats,
+} from '@objectstack/spec/system';
+import { MetadataManager } from './metadata-manager.js';
+import type { MetadataLoader } from './loaders/loader-interface.js';
+import type { MetadataWatchEvent } from '@objectstack/spec/system';
+
+// Stable logger mock — the failure-path assertions read what was logged.
+const logger = vi.hoisted(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+}));
+
+vi.mock('@objectstack/core', () => ({
+    createLogger: () => logger,
+}));
+
+/** Mirror of the manager's private `ListCacheEntry` (deliberately not exported). */
+type ListCacheEntry = { ts: number; items: unknown[]; degraded: boolean };
+
+const peekEntry = (mgr: MetadataManager, type: string): ListCacheEntry | undefined =>
+    (mgr as unknown as { listCache: Map<string, ListCacheEntry> }).listCache.get(type);
+
+/** Peek at #5253's in-flight map — internal by design, load-bearing here. */
+const inflight = (mgr: MetadataManager): Map<string, Promise<unknown[]>> =>
+    (mgr as unknown as { inflightListReads: Map<string, Promise<unknown[]>> }).inflightListReads;
+
+/** Peek at the in-memory registry — the half `list()` cannot tell apart from a loader hit. */
+const registryHas = (mgr: MetadataManager, type: string, name: string): boolean =>
+    (mgr as unknown as { registry: Map<string, Map<string, unknown>> }).registry.get(type)?.has(name) ??
+    false;
+
+const names = (items: unknown[]): string[] =>
+    (items as { name: string }[]).map((i) => i.name).sort();
+
+/** A gate a test opens by hand, so nothing depends on timer ordering. */
+class Gate {
+    private parked: Array<() => void> = [];
+    closed = false;
+    async pass(): Promise<void> {
+        if (!this.closed) return;
+        await new Promise<void>((resolve) => this.parked.push(resolve));
+    }
+    get parkedCount(): number {
+        return this.parked.length;
+    }
+    releaseAll(): void {
+        const parked = this.parked;
+        this.parked = [];
+        for (const resolve of parked) resolve();
+    }
+}
+
+/**
+ * A writable `datasource:` loader backed by a real store — the shape
+ * `unregister()` actually persists to.
+ *
+ * `loadMany` SNAPSHOTS the store before parking, modelling a real read that
+ * began before a concurrent delete committed: it answers with the rows it saw,
+ * not with whatever the store holds when it finally returns. That is precisely
+ * the read whose answer must not outlive the delete.
+ */
+class StoreLoader implements MetadataLoader {
+    readonly contract: MetadataLoaderContract;
+    /** type → name → data. */
+    readonly store = new Map<string, Map<string, unknown>>();
+
+    readonly readGate = new Gate();
+    readonly writeGate = new Gate();
+    readonly deleteGate = new Gate();
+
+    /** When true, `delete()` throws instead of removing the row (storage outage). */
+    failDeletes = false;
+    /** When true the loader has no `delete` at all — see `hasDelete`. */
+    loadManyCalls = 0;
+    deleteCalls: Array<{ type: string; name: string }> = [];
+
+    constructor(name = 'db') {
+        this.contract = {
+            name,
+            protocol: 'datasource:',
+            capabilities: { read: true, write: true, watch: false, list: true },
+        };
+    }
+
+    seed(type: string, name: string, data: unknown): void {
+        if (!this.store.has(type)) this.store.set(type, new Map());
+        this.store.get(type)!.set(name, data);
+    }
+
+    has(type: string, name: string): boolean {
+        return this.store.get(type)?.has(name) ?? false;
+    }
+
+    async loadMany<T = unknown>(type: string, _options?: MetadataLoadOptions): Promise<T[]> {
+        this.loadManyCalls += 1;
+        const snapshot = Array.from(this.store.get(type)?.values() ?? []);
+        await this.readGate.pass();
+        return snapshot as T[];
+    }
+
+    async save(type: string, name: string, data: unknown): Promise<MetadataSaveResult> {
+        await this.writeGate.pass();
+        this.seed(type, name, data);
+        return { success: true };
+    }
+
+    async delete(type: string, name: string): Promise<void> {
+        this.deleteCalls.push({ type, name });
+        await this.deleteGate.pass();
+        if (this.failDeletes) {
+            throw Object.assign(new Error('delete failed: ECONNRESET'), { code: 'ECONNRESET' });
+        }
+        this.store.get(type)?.delete(name);
+    }
+
+    async load(type: string, name: string): Promise<MetadataLoadResult> {
+        const data = this.store.get(type)?.get(name);
+        return { data: data ?? null };
+    }
+    async exists(type: string, name: string): Promise<boolean> {
+        return this.has(type, name);
+    }
+    async stat(): Promise<MetadataStats | null> {
+        return null;
+    }
+    async list(type: string): Promise<string[]> {
+        return Array.from(this.store.get(type)?.keys() ?? []);
+    }
+}
+
+/** Give queued microtasks a chance to run. */
+const flush = async (): Promise<void> => {
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+};
+
+const newManager = (...loaders: MetadataLoader[]): MetadataManager => {
+    const manager = new MetadataManager({ formats: ['json'], loaders: [] });
+    for (const loader of loaders) manager.registerLoader(loader);
+    return manager;
+};
+
+beforeEach(() => {
+    logger.error.mockClear();
+    logger.info.mockClear();
+    logger.warn.mockClear();
+    logger.debug.mockClear();
+});
+
+describe('#5259 — a list() racing unregister() cannot outlive the delete', () => {
+    it("the issue's probe: after the delete lands, list() is empty — not the deleted item for 30s", async () => {
+        const loader = new StoreLoader();
+        const manager = newManager(loader);
+        await manager.register('view', 'doomed', { name: 'doomed' });
+        expect(loader.has('view', 'doomed')).toBe(true);
+
+        // Park the storage delete so the probe can read inside the window.
+        loader.deleteGate.closed = true;
+        const removal = manager.unregister('view', 'doomed');
+        await flush();
+        expect(loader.deleteGate.parkedCount).toBe(1);
+
+        // The concurrent read. Inside the window the delete has neither landed
+        // nor been announced, so seeing the item is the TRUTH, not the bug —
+        // and, unlike before the fix, it is a coherent truth: registry and
+        // loader agree, rather than the registry being empty already.
+        const during = await manager.list('view');
+        expect(names(during)).toEqual(['doomed']);
+        expect(peekEntry(manager, 'view')).toBeDefined();
+
+        // Let the delete land.
+        loader.deleteGate.releaseAll();
+        await removal;
+        expect(loader.has('view', 'doomed')).toBe(false);
+
+        // The pin. Before the fix this read was served from a 30s-TTL entry
+        // written inside the window: `AFTER DELETE, list("view") =
+        // [{"name":"doomed"}]` with the loader store already empty.
+        expect(peekEntry(manager, 'view')).toBeUndefined();
+        expect(await manager.list('view')).toEqual([]);
+    });
+
+    it('the deleted item does not come back on any read within the healthy TTL', async () => {
+        const loader = new StoreLoader();
+        const manager = newManager(loader);
+        await manager.register('view', 'doomed', { name: 'doomed' });
+        await manager.register('view', 'keeper', { name: 'keeper' });
+
+        loader.deleteGate.closed = true;
+        const removal = manager.unregister('view', 'doomed');
+        await flush();
+        await manager.list('view'); // caches the pre-delete pair
+        loader.deleteGate.releaseAll();
+        await removal;
+
+        // Nothing advances the clock: if the window's entry had survived, these
+        // reads would serve it for the next 30s.
+        for (let i = 0; i < 3; i++) {
+            expect(names(await manager.list('view'))).toEqual(['keeper']);
+        }
+    });
+
+    it('#5253 composition: a read still IN FLIGHT when the delete lands loses the right to cache', async () => {
+        const loader = new StoreLoader();
+        const manager = newManager(loader);
+        await manager.register('view', 'doomed', { name: 'doomed' });
+
+        // A read that parks inside `loadMany`, having already snapshotted the
+        // pre-delete rows. `listCache` cannot cover this one — it has not
+        // written an entry yet, and would write the pre-delete answer AFTER any
+        // invalidation. Only retracting its `inflightListReads` registration
+        // reaches it, which is the mechanism #5253 added and this ordering fix
+        // depends on.
+        loader.readGate.closed = true;
+        const inFlight = manager.list('view');
+        await flush();
+        expect(loader.readGate.parkedCount).toBe(1);
+        expect(inflight(manager).has('view')).toBe(true);
+
+        // The delete lands (and is announced) while that read is still parked.
+        await manager.unregister('view', 'doomed');
+        expect(loader.has('view', 'doomed')).toBe(false);
+        expect(inflight(manager).has('view')).toBe(false); // registration retracted
+
+        // The caller already waiting keeps its answer — it asked before the
+        // delete, and restarting the read under it is what #5253 rejected.
+        loader.readGate.releaseAll();
+        expect(names(await inFlight)).toEqual(['doomed']);
+
+        // But that answer was NOT memoized, so nobody else inherits it.
+        expect(peekEntry(manager, 'view')).toBeUndefined();
+        loader.readGate.closed = false;
+        expect(await manager.list('view')).toEqual([]);
+    });
+
+    it('the invalidation happens after ALL writable loaders, not after each one', async () => {
+        const fast = new StoreLoader('fast');
+        const slow = new StoreLoader('slow');
+        const manager = newManager(fast, slow);
+        await manager.register('view', 'doomed', { name: 'doomed' });
+        expect(fast.has('view', 'doomed')).toBe(true);
+        expect(slow.has('view', 'doomed')).toBe(true);
+
+        // `fast` deletes immediately, `slow` parks: the window where one store
+        // is already empty and the other is not.
+        slow.deleteGate.closed = true;
+        const removal = manager.unregister('view', 'doomed');
+        await flush();
+        expect(fast.has('view', 'doomed')).toBe(false);
+        expect(slow.deleteGate.parkedCount).toBe(1);
+
+        // A read completing in that partial window still memoizes the item…
+        expect(names(await manager.list('view'))).toEqual(['doomed']);
+        expect(peekEntry(manager, 'view')).toBeDefined();
+
+        // …and the single invalidation after the LAST delete clears it.
+        slow.deleteGate.releaseAll();
+        await removal;
+        expect(peekEntry(manager, 'view')).toBeUndefined();
+        expect(await manager.list('view')).toEqual([]);
+    });
+
+    it('#5219 bar: a watcher woken by the `deleted` event re-reads the post-delete state', async () => {
+        const loader = new StoreLoader();
+        const manager = newManager(loader);
+        await manager.register('view', 'doomed', { name: 'doomed' });
+        await manager.list('view'); // warm the cache with the pre-delete answer
+
+        let seen: unknown[] | undefined;
+        const observed = new Promise<void>((resolve) => {
+            manager.subscribe('view', async (event: MetadataWatchEvent) => {
+                if (event.type !== 'deleted') return;
+                seen = await manager.list('view');
+                resolve();
+            });
+        });
+
+        await manager.unregister('view', 'doomed');
+        await observed;
+        expect(seen).toEqual([]);
+    });
+
+    it('{ notify: false } still suppresses the announcement — and still invalidates', async () => {
+        const loader = new StoreLoader();
+        const manager = newManager(loader);
+        await manager.register('view', 'doomed', { name: 'doomed' });
+        await manager.list('view');
+
+        const events: MetadataWatchEvent[] = [];
+        manager.subscribe('view', (event) => {
+            events.push(event);
+        });
+
+        await manager.unregister('view', 'doomed', { notify: false });
+        expect(events).toEqual([]);
+        expect(await manager.list('view')).toEqual([]);
+    });
+});
+
+describe('#5259 — a storage delete that fails is loud', () => {
+    it('logs at `error` (not `warn`) and names both the consequence and the fix', async () => {
+        const loader = new StoreLoader();
+        const manager = newManager(loader);
+        await manager.register('view', 'doomed', { name: 'doomed' });
+        logger.error.mockClear();
+        logger.warn.mockClear();
+
+        loader.failDeletes = true;
+        // Still resolves: the seam is best-effort by contract, which is exactly
+        // why the log has to carry the whole signal.
+        await expect(manager.unregister('view', 'doomed')).resolves.toBeUndefined();
+
+        expect(logger.error).toHaveBeenCalledTimes(1);
+        const [message, cause, context] = logger.error.mock.calls[0] as [string, unknown, unknown];
+        // Consequence — the row survived, and the system still looks healthy.
+        expect(message).toContain('view/doomed');
+        expect(message).toContain('db');
+        expect(message).toMatch(/STILL in its store/);
+        expect(message).toMatch(/reappears/);
+        // Fix — what to do about it.
+        expect(message).toMatch(/Fix:/);
+        expect(cause).toBeInstanceOf(Error);
+        expect(context).toMatchObject({ loader: 'db', type: 'view', name: 'doomed' });
+
+        // The old `warn` is gone, not merely joined by an error.
+        const warnedAboutDelete = logger.warn.mock.calls.some((call) =>
+            String(call[0]).toLowerCase().includes('delete'),
+        );
+        expect(warnedAboutDelete).toBe(false);
+    });
+
+    it('reports once per un-deleted ITEM — a batch teardown does not lose the casualty list', async () => {
+        const loader = new StoreLoader();
+        const manager = newManager(loader);
+        await manager.register('view', 'alpha', { name: 'alpha' });
+        await manager.register('view', 'beta', { name: 'beta' });
+        logger.error.mockClear();
+
+        loader.failDeletes = true;
+        await manager.bulkUnregister([
+            { type: 'view', name: 'alpha' },
+            { type: 'view', name: 'beta' },
+        ]);
+
+        expect(logger.error).toHaveBeenCalledTimes(2);
+        const messages = logger.error.mock.calls.map((call) => String(call[0]));
+        expect(messages.some((m) => m.includes('view/alpha'))).toBe(true);
+        expect(messages.some((m) => m.includes('view/beta'))).toBe(true);
+    });
+
+    it('reports once per loader that failed, naming each store that kept the row', async () => {
+        const a = new StoreLoader('db_a');
+        const b = new StoreLoader('db_b');
+        const manager = newManager(a, b);
+        await manager.register('view', 'doomed', { name: 'doomed' });
+        logger.error.mockClear();
+
+        a.failDeletes = true;
+        b.failDeletes = true;
+        await manager.unregister('view', 'doomed');
+
+        expect(logger.error).toHaveBeenCalledTimes(2);
+        const messages = logger.error.mock.calls.map((call) => String(call[0]));
+        expect(messages.some((m) => m.includes('db_a'))).toBe(true);
+        expect(messages.some((m) => m.includes('db_b'))).toBe(true);
+    });
+
+    it('one loader failing does not stop the delete reaching the others', async () => {
+        const broken = new StoreLoader('broken');
+        const healthy = new StoreLoader('healthy');
+        const manager = newManager(broken, healthy);
+        await manager.register('view', 'doomed', { name: 'doomed' });
+
+        broken.failDeletes = true;
+        await manager.unregister('view', 'doomed');
+
+        expect(broken.has('view', 'doomed')).toBe(true);
+        expect(healthy.has('view', 'doomed')).toBe(false);
+        expect(healthy.deleteCalls).toEqual([{ type: 'view', name: 'doomed' }]);
+    });
+
+    /**
+     * The decision the issue asked for, pinned so it cannot be reversed by
+     * accident: the registry entry is dropped even though the storage delete
+     * failed.
+     *
+     * Keeping it would look safer and is not. The loader still holds the row
+     * and `list()`/`get()` merge registry ∪ loaders, so the item is served
+     * either way — the surviving registry entry would only decide WHICH copy
+     * wins, pinning an in-memory definition on top of a stored row nobody
+     * maintains anymore. Dropping it makes the next read fall through to
+     * storage, which after a failed delete is the actual truth (the item still
+     * exists), and makes that visible immediately instead of at the next
+     * restart. The divergence is reported by the `error` above, not papered
+     * over with a second in-memory copy.
+     */
+    it('drops the registry entry anyway, so the next read converges on storage truth', async () => {
+        const loader = new StoreLoader();
+        const manager = newManager(loader);
+        await manager.register('view', 'doomed', { name: 'doomed' });
+
+        loader.failDeletes = true;
+        await manager.unregister('view', 'doomed');
+
+        expect(registryHas(manager, 'view', 'doomed')).toBe(false);
+        // Storage kept the row, so the item is visibly back — immediately, and
+        // in every face at once rather than `list()` and `get()` disagreeing.
+        expect(loader.has('view', 'doomed')).toBe(true);
+        expect(names(await manager.list('view'))).toEqual(['doomed']);
+        expect(await manager.get('view', 'doomed')).toEqual({ name: 'doomed' });
+    });
+});
+
+describe('#5259 — register() is unchanged', () => {
+    it('still writes the registry BEFORE its save window, so a read inside it sees the new value', async () => {
+        const loader = new StoreLoader();
+        const manager = newManager(loader);
+        await manager.register('view', 'existing', { name: 'existing', v: 1 });
+        await manager.list('view'); // warm the cache
+
+        // Park the storage write: the mirror image of the delete window.
+        loader.writeGate.closed = true;
+        const write = manager.register('view', 'existing', { name: 'existing', v: 2 });
+        await flush();
+        expect(loader.writeGate.parkedCount).toBe(1);
+
+        // Registry-first + invalidate-first is what makes this the NEW value:
+        // the registry outranks the loader's still-old row in the merge. This
+        // is the ordering #5259 deliberately did NOT change.
+        const during = (await manager.list('view')) as Array<{ name: string; v: number }>;
+        expect(during).toEqual([{ name: 'existing', v: 2 }]);
+
+        loader.writeGate.releaseAll();
+        await write;
+        expect(await manager.list('view')).toEqual([{ name: 'existing', v: 2 }]);
+        expect(loader.store.get('view')?.get('existing')).toEqual({ name: 'existing', v: 2 });
+    });
+
+    it('still announces added/changed, and the announcement still follows the invalidation', async () => {
+        const loader = new StoreLoader();
+        const manager = newManager(loader);
+
+        const seen: Array<{ type: string; listedAtEvent: string[] }> = [];
+        const settled: Array<Promise<void>> = [];
+        manager.subscribe('view', (event: MetadataWatchEvent) => {
+            settled.push(
+                (async () => {
+                    seen.push({
+                        type: event.type,
+                        listedAtEvent: names(await manager.list('view')),
+                    });
+                })(),
+            );
+        });
+
+        await manager.register('view', 'a', { name: 'a' });
+        await manager.register('view', 'a', { name: 'a', v: 2 });
+        await manager.unregister('view', 'a');
+        await Promise.all(settled);
+
+        expect(seen.map((s) => s.type)).toEqual(['added', 'changed', 'deleted']);
+        // Every watcher that re-read on the event saw the post-write state.
+        expect(seen.map((s) => s.listedAtEvent)).toEqual([['a'], ['a'], []]);
+    });
+});

--- a/packages/metadata/src/metadata-manager.ts
+++ b/packages/metadata/src/metadata-manager.ts
@@ -79,6 +79,23 @@ import type { ApiEndpointMatch } from '@objectstack/spec/contracts';
 export type WatchCallback = (event: MetadataWatchEvent) => void | Promise<void>;
 
 /**
+ * [#5259] A {@link MetadataLoader} that also implements deletion.
+ *
+ * `MetadataLoader` declares `save?` but no `delete?`, so `unregister()` has
+ * always duck-typed the method at the call site. Naming the shape here replaces
+ * the two `as any` casts that did it before — the cast is still a cast, but it
+ * is now one declared shape rather than an untyped hole, and the `typeof
+ * … === 'function'` guard in front of it is what actually decides.
+ *
+ * Whether the loader contract itself should declare `delete?` (and what a
+ * `capabilities.write` loader *without* one means) is a separate question,
+ * deliberately not answered here.
+ */
+type DeletableMetadataLoader = MetadataLoader & {
+  delete?: (type: string, name: string) => Promise<unknown>;
+};
+
+/**
  * [#5189] Appended to the namespace gate's message when `publishPackage` was
  * called without one, because the gate's own text ("declare an explicit
  * `manifest.namespace`") describes a stack file this caller may not have.
@@ -228,6 +245,17 @@ export class MetadataManager implements IMetadataService {
   //
   // Invalidated on every `register()` / `unregister()` to keep CRUD writes
   // visible to subsequent reads.
+  //
+  // [#5259] WHERE in a write the invalidation sits is part of that promise, not
+  // an implementation detail. `list()` merges registry ∪ loaders, so an
+  // invalidation issued while only ONE of the two has been updated lets the
+  // next read memoize the half-applied view for a full TTL. The rule both
+  // writers follow: **invalidate last, once every store already holds the state
+  // being announced** — `register()` satisfies it by writing the registry
+  // first (the registry outranks loaders in the merge, so its save window
+  // already shows the post-write value); `unregister()` satisfies it by
+  // deleting from storage first and invalidating after, with nothing awaited
+  // between the registry drop and the invalidation. See `unregister()`.
   private listCache = new Map<string, ListCacheEntry>();
   private static readonly LIST_CACHE_TTL_MS = 30_000;
   /**
@@ -863,6 +891,14 @@ export class MetadataManager implements IMetadataService {
    * pre-write answer, and a caller arriving after this point gets a fresh read
    * instead of joining a pre-write one. The reasoning — including why waiting
    * callers are NOT restarted — is on the `inflightListReads` field.
+   *
+   * [#5259] Both halves are only as good as WHEN the caller invokes this. This
+   * clears what is stale *as of now*; it cannot pre-empt a store the caller has
+   * not finished updating yet. Callers must therefore invalidate only once
+   * every store already holds the state they are about to announce — see the
+   * `listCache` field comment and {@link unregister}, whose pre-#5259 ordering
+   * invalidated one await too early and let the next read cache a view in which
+   * the registry was empty and the loader was not.
    */
   private invalidateListCache(type: string): void {
     this.listCache.delete(type);
@@ -933,9 +969,78 @@ export class MetadataManager implements IMetadataService {
    * {@link MetadataWatchEvent} — the delete half of the {@link register}
    * contract. Pass `{ notify: false }` only for teardown that announces by
    * other means.
+   *
+   * ## [#5259] Storage FIRST, in-memory second — the order is the fix
+   *
+   * This method used to drop the registry entry and call
+   * {@link invalidateListCache} *before* awaiting `loader.delete()`. Those two
+   * steps are separated by a real await window (one DB round-trip per writable
+   * loader), and inside it the manager was in a state that exists nowhere else:
+   * **registry already empty, loader not yet empty**. `list()` merges the two,
+   * so a read arriving in that window
+   *
+   *   • missed the cache (it had just been invalidated),
+   *   • assembled the still-stored row into its answer, and
+   *   • memoized that answer as a COMPLETE read — the full 30s healthy TTL,
+   *     because no loader threw, so #5184's 2s degraded TTL never applied.
+   *
+   * Nothing invalidated again afterwards ({@link notifyWatchers} does not touch
+   * `listCache`), so a row that was gone from storage kept being enumerated for
+   * up to 30s — and `get()`, which never consulted that cache, disagreed with
+   * `list()` the whole time. For a gating type (`permission`, `api`) the two
+   * faces of the same manager answered opposite questions about whether a
+   * declaration exists.
+   *
+   * {@link register} never had this defect, and the reason is instructive: it
+   * writes the registry *first*, and the registry outranks every loader in the
+   * merge, so throughout its own save window the merged view already equals the
+   * post-write state. The invariant that makes register correct is not "where
+   * the invalidate sits" but **the invalidate must be the last thing after
+   * every store already holds the announced state**. Restated for delete, that
+   * means storage first:
+   *
+   *   1. `await loader.delete()` on every writable loader. Throughout this
+   *      window registry AND loaders still hold the item, so a concurrent
+   *      `list()` observes a coherent pre-delete state — which is the truth,
+   *      because the delete has not landed and has not been announced.
+   *   2. Drop the registry entry and `invalidateListCache(type)` — with **no
+   *      await between them**, so no read can interleave and observe the
+   *      half-applied state that produced the bug. Everything cached or
+   *      in-flight from step 1 is dropped here, at the moment the final state
+   *      becomes true.
+   *   3. Publish + announce. #5219's invalidate-before-notify bar, unchanged:
+   *      a watcher woken by the `deleted` event and re-reading through `list()`
+   *      gets a fresh read of the post-delete state.
+   *
+   * **Composition with #5253's single-flight (this is the load-bearing half).**
+   * A `list()` that is still walking the loaders when step 2 runs cannot be
+   * fixed by dropping `listCache` alone — it has not written its entry yet, and
+   * it would write the pre-delete answer *after* the invalidation. The
+   * mechanism that covers it is `invalidateListCache()` also retracting the
+   * read's registration in `inflightListReads`: a retracted read still resolves
+   * for the callers already waiting on it (they asked before the delete) but
+   * loses the right to memoize, and any caller arriving after step 2 starts a
+   * fresh read rather than joining the pre-delete one. So every read is
+   * covered: one that FINISHED in the window has its entry deleted, one still
+   * IN FLIGHT loses its permission to cache, and one starting later reads the
+   * post-delete state. That is why the invalidate must come after the deletes
+   * rather than being duplicated on both sides of them — a second invalidate
+   * before the await would buy nothing and would re-open step 1's window.
    */
   async unregister(type: string, name: string, options?: MetadataWriteOptions): Promise<void> {
-    // Remove from in-memory registry
+    // ── 1. Storage first ────────────────────────────────────────────────
+    // Delete only from database-backed loaders that declare write capability.
+    for (const loader of this.loaders.values()) {
+      if (loader.contract.protocol !== 'datasource:' || !loader.contract.capabilities.write) continue;
+      if (typeof (loader as DeletableMetadataLoader).delete !== 'function') continue;
+      try {
+        await this.deleteMetaItemFromLoader(loader, type, name);
+      } catch (error) {
+        this.reportMetaItemDeleteFailure(loader.contract.name, type, name, error);
+      }
+    }
+
+    // ── 2. In-memory state, then invalidation — nothing awaited between ──
     const typeStore = this.registry.get(type);
     if (typeStore) {
       typeStore.delete(name);
@@ -945,18 +1050,7 @@ export class MetadataManager implements IMetadataService {
     }
     this.invalidateListCache(type);
 
-    // Delete only from database-backed loaders that declare write capability
-    for (const loader of this.loaders.values()) {
-      if (loader.contract.protocol !== 'datasource:' || !loader.contract.capabilities.write) continue;
-      if (typeof (loader as any).delete === 'function') {
-        try {
-          await (loader as any).delete(type, name);
-        } catch (error) {
-          this.logger.warn(`Failed to delete ${type}/${name} from loader ${loader.contract.name}`, { error });
-        }
-      }
-    }
-
+    // ── 3. Announce ─────────────────────────────────────────────────────
     // Publish metadata.{type}.deleted event to realtime service
     await this.publishRealtimeMetadataEvent('deleted', type, name, {
       userId: options?.userId,
@@ -973,6 +1067,86 @@ export class MetadataManager implements IMetadataService {
         timestamp: new Date().toISOString(),
       });
     }
+  }
+
+  /**
+   * Delete one metadata item from one writable loader — the storage half of
+   * {@link unregister}.
+   *
+   * A one-line wrapper on purpose: it gives this durability seam a **name**.
+   * `check:durability-log-level` matches by callee name against an explicit
+   * vocabulary, and the raw call is `loader.delete(...)` — putting `delete` in
+   * that vocabulary would claim every `.delete()` in the monorepo (`Map`,
+   * `Set`, cache handles, `URLSearchParams`) and the gate would drown in false
+   * positives, which is exactly the failure mode its own header warns about.
+   * Named here, `deleteMetaItemFromLoader` is in `DURABILITY_CRITICAL_CALLEES`
+   * with a blast radius of precisely this call site, mirroring `saveMetaItem`
+   * on the write side (#4754).
+   *
+   * `MetadataLoader` declares `save?` but no `delete?`, which is why the caller
+   * duck-types before getting here; widening the loader contract is a separate
+   * question and deliberately not answered by this issue.
+   */
+  private async deleteMetaItemFromLoader(
+    loader: MetadataLoader,
+    type: string,
+    name: string,
+  ): Promise<void> {
+    const del = (loader as DeletableMetadataLoader).delete;
+    if (typeof del !== 'function') return;
+    await del.call(loader, type, name);
+  }
+
+  /**
+   * Report — at `error` — that a loader refused to delete an item the runtime
+   * has already dropped and announced as deleted.
+   *
+   * [#5259] This used to be a `logger.warn('Failed to delete …')` and continue.
+   * AGENTS.md → "Degradation log levels" decides the level with one question:
+   * *after the degradation, does the system still look normal from the outside
+   * while something it claims is persisted has not actually landed?* Here it is
+   * the deletion that did not land, which is the same class and the same
+   * silence: `unregister()` resolves normally, the caller is told the delete
+   * succeeded, and the surviving row is read straight back out of storage —
+   * permanently, since nothing ever retries this. Durability/consistency
+   * degradation ⇒ `error`, naming the **consequence** and the **fix**.
+   *
+   * **Why the registry entry is still dropped when this fires.** The
+   * alternative — keep the item registered so runtime state matches storage —
+   * looks safer and is not. The loader still holds the row, and `list()`/`get()`
+   * merge registry ∪ loaders, so the item is served either way; the only thing
+   * the surviving registry entry would change is *which copy wins*, pinning an
+   * in-memory definition that outranks the stored row nobody is maintaining
+   * anymore. Dropping it makes the very next read fall through to storage,
+   * which is the actual truth after a failed delete — the item still exists —
+   * and it surfaces that immediately (the item visibly reappears) instead of at
+   * the next restart. One truth, read from where it lives; the divergence is
+   * reported here rather than papered over with a second in-memory copy.
+   *
+   * **Said once per un-deleted item, not once per loader.** The once-per-outage
+   * discipline of {@link reportLoaderReadFailure} exists because `list()` is hot
+   * and its repeats are *identical*; these are not. Each line names a different
+   * item that is still in storage and that nothing will ever retry, so
+   * collapsing them would hand an operator the first casualty and silently drop
+   * the rest of the list — the failure this level was raised to prevent.
+   */
+  private reportMetaItemDeleteFailure(
+    loaderName: string,
+    type: string,
+    name: string,
+    error: unknown,
+  ): void {
+    this.logger.error(
+      `[MetadataManager] Loader \`${loaderName}\` could NOT delete \`${type}/${name}\` — the row is STILL in its store, ` +
+        `while the runtime has already dropped the item from its registry and announced it as deleted. ` +
+        `Nothing looks broken: \`unregister()\` resolves normally and the caller (Studio/Setup, REST DELETE, the CLI, a package teardown) ` +
+        `is told the delete succeeded — but the surviving row is read straight back out of storage by the very next \`list()\`/\`get()\`, ` +
+        `so the "deleted" item reappears and keeps reappearing across restarts. Nothing retries this delete. ` +
+        `Fix: check the datasource behind \`${loaderName}\` — connection, credentials, and that its metadata table exists and is writable — ` +
+        `then re-issue the delete for \`${type}/${name}\`. Until that succeeds the item is NOT deleted, whatever the delete call reported.`,
+      error instanceof Error ? error : undefined,
+      { loader: loaderName, type, name, error },
+    );
   }
 
   /**

--- a/scripts/check-durability-degradation-log-level.mjs
+++ b/scripts/check-durability-degradation-log-level.mjs
@@ -144,6 +144,10 @@ const DURABILITY_CRITICAL_CALLEES = new Map([
         'saveMetaItem',
         'The metadata definition was never written to the authoritative store — the runtime looks completely normal because the in-memory registry already has it, and the definition simply vanishes on the next provision/restart (#4754, from #4669).',
     ],
+    [
+        'deleteMetaItemFromLoader',
+        'The metadata definition was never deleted from the authoritative store — `unregister()` still resolves and still announces `deleted`, the in-memory registry entry is gone, and the surviving row is read straight back out of storage by the very next `list()`/`get()`, so the "deleted" item reappears and survives every restart. Nothing retries it (#5259).',
+    ],
 ]);
 
 /** Log levels that are ACCEPTABLE inside a durability-guarding catch. */


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5259

## 病灶:失效发生在「只更新了两个存储之一」的时刻

`MetadataManager.unregister()` 原来的顺序是「删 registry → `invalidateListCache(type)` → `await loader.delete()` → 宣告」。第 2 步与第 3 步之间是一个真实的 await 窗口(每个可写 loader 一次 DB 往返),窗口内管理器处于一个**别处不存在**的状态:**registry 已空,loader 未空**。而 `list()` 是 registry ∪ loaders 的合并,于是窗口内到达的读:

- 缓存刚被清掉 ⇒ miss;
- 把仍在存储里的行装进答案;
- 并把它按**完整读**记入 `listCache` —— 拿满 30s 健康 TTL,因为没有任何 loader 抛错,#5184 的 2s 降级 TTL 根本不适用。

删除落库后**没有任何东西再失效一次**(`notifyWatchers()` 不碰 `listCache`),所以一个存储里已经没有的项继续被枚举最多半分钟;同一时刻 `get()`(从不读该缓存)说它已经没了。`list()` 是枚举面的入口(`GET /api/v1/metadata/:type`、Studio 左栏、同步/导出、以及所有「按已声明集合判存在性」的消费者),对 `permission` / `api` 这类门控类型,同一个管理器的两张脸会对「这条声明还在不在」给出相反答案。

## 修法:靠顺序,不靠多加一次失效

`register()` 从来没有这个毛病,原因很说明问题:它**先写 registry**,而合并时 registry 压过所有 loader,所以它自己的 save 窗口里合并视图**已经**等于写后状态。于是真正的不变量不是「早点失效」,而是:

> **失效必须是最后一步 —— 在每个存储都已经持有「即将被宣告的那个状态」之后。**

把这句话翻译到删除方向,就是存储优先:

1. 对每个可写 loader `await loader.delete()`。整个窗口里 registry 和 loader **都**还持有该项,所以并发 `list()` 观察到的是一个自洽的删除前状态 —— 而那就是当时的事实:删除既没落库,也没被宣告。
2. 删 registry 条目 + `invalidateListCache(type)`,**两者之间不 await**,所以没有任何读能插进来观察到那个半应用状态。第 1 步窗口里被缓存的、以及仍在飞的,都在这一刻——终态成立的那一刻——被一并丢弃。
3. 再 publish + 宣告。#5219 的 invalidate-before-notify 纪律原样保留:被 `deleted` 事件叫醒、回头走 `list()` 的 watcher 拿到的是删除后状态的新鲜读。

### 与 #5260 single-flight 的协同(这一半是承重的)

PM 要求写清「哪个机制交付了『racing 的 list() 要么看到删除后状态,要么失去缓存删除前答案的权利』」,并钉住它。答案是**两个机制各管一半,缺一不可**:

| racing 的 `list()` 处于 | 谁兜住它 |
|:---|:---|
| 窗口内**已完成**(条目已写进 `listCache`) | 第 2 步的 `listCache.delete(type)` |
| 窗口内**仍在飞**(还在 walk loaders) | 第 2 步的 `inflightListReads.delete(type)` —— #5260 加的撤销 |
| 第 2 步**之后**才发起 | 读到 registry 空 + loader 空的终态 |

中间那一行是关键:**光丢 `listCache` 够不着它**。在飞的读还没写条目,它会在失效**之后**才把删除前答案写进去。只有撤销它在 `inflightListReads` 里的登记才能拦下 —— 被撤销的读仍然为「已经在等它的调用方」返回结果(他们是在删除之前问的,#5260 明确拒绝在他们脚下重启读),但**失去 memoize 的权利**;而失效之后到达的调用方会发起一次全新的读,而不是加入一个删除前的读。

这也解释了为什么**不**采用「await 前后各失效一次」:前置的那次买不到任何东西,还会重新打开第 1 步的窗口(registry 空 / loader 未空)——正是本卡的病灶本身。

## `loader.delete()` 失败路径:从 `warn` 抬到 `error`,并说明为什么 registry 条目照删

原来失败只 `logger.warn('Failed to delete …')` 然后继续。按 AGENTS.md「Degradation log levels」的那一个问题 —— *降级之后系统从外面看是否依然正常,而它声称已持久化的东西其实没落地?* —— 这里没落地的是**删除**,答案是「是」,而且同样安静:`unregister()` 正常 resolve,调用方(Studio/Setup、REST DELETE、CLI、package teardown)被告知删除成功,幸存的行被下一次 `list()`/`get()` 直接读回来,而且**永远**如此,因为没有任何东西会重试。属于耐久性/一致性降级 ⇒ `error`,并且这条 `error` 同时交付**后果**与**修复**。

**报一次 per 未删项,而不是 per loader 只报一次。** `reportLoaderReadFailure` 的「只说一次」是因为 `list()` 是热路径且重复内容**完全相同**;这里不同 —— 每一行点名一个不同的、仍在存储里且不会被重试的项。合并它们等于把第一个受害者交给运维、把其余的名单悄悄丢掉,正是抬高日志级别要防的那件事。

**为什么删除失败时仍然丢掉 registry 条目(本 PR 的选择,已在代码与测试里写明理由)。** 直觉上「保留条目让运行时状态与存储一致」更安全,其实不然:loader 里那一行还在,而 `list()`/`get()` 是 registry ∪ loaders,所以**无论保不保留,这个项都照样被端出来**;保留下来唯一改变的是**哪份副本赢** —— 把一份内存定义钉在一行没人再维护的存储行之上。丢掉它,下一次读就穿透到存储,而存储在删除失败之后正是**事实**(这个项还在),并且这个事实**立刻**可见(项肉眼可见地回来了),而不是等到下次重启;`list()` 与 `get()` 也在同一时刻给同一个答案。分歧由上面那条 `error` 上报,而不是用第二份内存副本糊过去。

**没有改契约**:`unregister()` 在 loader 拒绝删除时依然 resolve 而不 throw。(顺带记录一个非对称:`register()` 的 `loader.save()` 没有 try/catch,失败会向调用方抛出;`unregister()` 则吞掉。要不要把删除方向也改成抛出,是一个独立的公共契约问题,本卡没有要求,故明确不在此擅自决定 —— 见「留给分诊」。)

## 让新级别被**执行**,而不只是被写下来

AGENTS.md 要求:发现新的耐久性缝就在同一个 PR 里把它加进 `DURABILITY_CRITICAL_CALLEES`。原始调用是 `loader.delete(...)`,而该 gate 按 callee 名匹配 —— 把 `delete` 放进词表会认领全仓每一个 `.delete()`(`Map`、`Set`、缓存句柄),正是那个脚本自己头注释里警告的「假阳性多到让人把 gate 关掉」。所以这条缝被起了名字:`deleteMetaItemFromLoader`(与写方向的 `saveMetaItem` 对称,#4754),词表条目的爆炸半径正好是这一个调用点。

```
✓ durability-degradation log levels: 23 durability-critical catch seam(s), all loud or rethrowing (2 baselined).
```

(改动前是 22;新增的那一条被识别为 loud,全仓其余站点零变化。)

## 测试

新增 `packages/metadata/src/metadata-manager-unregister-invalidate-order.test.ts`,13 例。其中 **6 例在 `origin/main` 的代码上失败**(下面有实测输出),包括 issue 正文的探针原样搬过来那一例。

```
✓ the issue's probe: after the delete lands, list() is empty — not the deleted item for 30s
✓ the deleted item does not come back on any read within the healthy TTL
✓ #5253 composition: a read still IN FLIGHT when the delete lands loses the right to cache
✓ the invalidation happens after ALL writable loaders, not after each one
✓ #5219 bar: a watcher woken by the `deleted` event re-reads the post-delete state
✓ { notify: false } still suppresses the announcement — and still invalidates
✓ logs at `error` (not `warn`) and names both the consequence and the fix
✓ reports once per un-deleted ITEM — a batch teardown does not lose the casualty list
✓ reports once per loader that failed, naming each store that kept the row
✓ one loader failing does not stop the delete reaching the others
✓ drops the registry entry anyway, so the next read converges on storage truth
✓ register(): still writes the registry BEFORE its save window, so a read inside it sees the new value
✓ register(): still announces added/changed, and the announcement still follows the invalidation
```

测试里的 loader 有一处刻意设计:`loadMany` 在挂闸**之前**先给 store 拍快照,模拟一次「在并发删除提交之前就开始」的真实读 —— 它回答的是它看见的行,而不是它最终返回时 store 里剩下的东西。那正是「答案不许活过删除」的那一次读。

### 反向验证(把 `metadata-manager.ts` 换回 `origin/main` 的版本再跑同一批测试)

```
× the issue's probe: after the delete lands, list() is empty — not the deleted item for 30s
× the deleted item does not come back on any read within the healthy TTL
× the invalidation happens after ALL writable loaders, not after each one
× logs at `error` (not `warn`) and names both the consequence and the fix
× reports once per un-deleted ITEM — a batch teardown does not lose the casualty list
× reports once per loader that failed, naming each store that kept the row
AssertionError: expected { ts: 1785851986938, …(2) } to be undefined
AssertionError: expected [ 'doomed', 'keeper' ] to deeply equal [ 'keeper' ]
Tests  6 failed | 7 passed (13)
```

### 包级全量 + 门

```
$ pnpm --filter @objectstack/metadata exec vitest run --maxWorkers=2
 Test Files  22 passed (22)
      Tests  478 passed (478)

$ node scripts/check-durability-degradation-log-level.mjs
✓ durability-degradation log levels: 23 durability-critical catch seam(s), all loud or rethrowing (2 baselined).
$ node scripts/check-durability-degradation-log-level.mjs --self-test
✓ self-test: 19 case(s) passed
$ node scripts/check-startup-registry-verdict.mjs
✓ startup registry verdicts: 40 startup/open-registry seam(s) across 1427 file(s), 34 read-only (legal), none recording a verdict the boot can contradict.
$ npx eslint packages/metadata/src/metadata-manager.ts packages/metadata/src/metadata-manager-unregister-invalidate-order.test.ts
(clean)
```

类型:`@objectstack/metadata` 在 `check-type-check-coverage.mjs` 里是 DEBT(无 `typecheck` 脚本)。用 `tsc --noEmit -p packages/metadata/tsconfig.json` 实测,`origin/main` 基线 **92** 个错误,本分支 **92** 个 —— 本次改动**新增 0 个**,且我改的两个文件里一个都没有。

已合并 `origin/main`(合到 `08f93bc1a`),干净;`packages/metadata/src/`、`pnpm-lock.yaml`、`packages/spec/` 在这期间都没有动过,合并后又完整跑了一遍上面的包级全量与各门。

## 范围

严格按认领时声明的文件面:

- `packages/metadata/src/metadata-manager.ts` —— 仅 `unregister()` 的失效/删除顺序与失败上报(外加两处同一策略块的注释:`listCache` 字段注释与 `invalidateListCache()` 的文档,把「失效必须最后」这条不变量写在下一位作者会读到的地方);
- 新增 `packages/metadata/src/metadata-manager-unregister-invalidate-order.test.ts`;
- `scripts/check-durability-degradation-log-level.mjs` —— 只加一条词表条目(AGENTS.md 明文要求「在修复它的同一个 PR 里加」);
- `.changeset/unregister-invalidate-after-delete.md`。

⛔ 未回改 #5260 的 single-flight、#5251 的 degraded/TTL、#5183 的 loader seams、#5219 的集群订阅、#5229 的 FS 失效 —— 全部是在其之上协同。`packages/spec/**` 零改动;`content/docs/releases/**` 未碰;`packages/core/src/**`(#5257)、objectql/automation(#5038)、`packages/metadata-protocol/src/protocol.ts`(#5263)均未触及。

## 越界发现(已另立卡,未在本 PR 修)

- **#5276**(`finding`,未认领):`MetadataLoader` 接口声明了 `save?` 却完全没有 `delete`,所以 `unregister()` 只能鸭子类型地探它 —— 一个声明了 `protocol: 'datasource:'` + `capabilities.write: true` 却**没有 `delete` 方法**的 loader 会被**一声不吭地跳过**(既不是 `warn`,也不是本 PR 新加的 `error`),而 registry 照删、`deleted` 照宣告。后果与本卡处理的「delete 抛错」同类却更安静。归为 observation-class:全仓唯一的 `datasource:` loader 是 `DatabaseLoader`,它有 `delete`,所以今天没有用户路径会踩到;修它要动 `MetadataLoader` 这个公共接口(第三方 loader 的实现面),故明确不在本卡内擅自决定。本 PR 只把原来的两处 `as any` 收敛成一个具名的 `DeletableMetadataLoader` 形状 —— cast 还是 cast,但至少是一个被声明的形状而不是无类型的洞;契约缺口原样留给 #5276。

## 留给分诊的一个契约问题(不阻塞本卡)

`register()` 的 `loader.save()` 失败会**抛给调用方**(无 try/catch),`unregister()` 的 `loader.delete()` 失败则**吞掉**。本 PR 把后者从「静默」修成「响」,但没有改 throw / 不 throw 的契约,因为那会改变 `bulkUnregister` / `unregisterPackage` / REST DELETE 的既有行为,而 issue 没有要求。如果维护者认为两侧应当对称(删除失败也抛),那是一张独立的卡,我可以按吩咐去立。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pbu27iNUfQCHeuS551Rqo7


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pbu27iNUfQCHeuS551Rqo7)_