### PR TITLE
fix(core): 隔离 kernel:shutdown 分发,并让「超时」只报真超时 (#5274)

### DIFF
--- a/.changeset/kernel-shutdown-isolate-and-honest-timeout.md
+++ b/.changeset/kernel-shutdown-isolate-and-honest-timeout.md
@@ -1,0 +1,44 @@
+---
+"@objectstack/core": patch
+---
+
+fix(core): one throwing `kernel:shutdown` handler no longer skips every plugin `destroy()` and kills the process under a false "Shutdown timed out" (#5274)
+
+**On `ObjectKernel`, a single bad shutdown subscriber used to end the entire teardown
+and `process.exit(1)` the host — reporting a timeout that never happened.**
+
+`performShutdown()` dispatched `kernel:shutdown` through `context.trigger` (a bare
+awaited loop that never catches), so the first handler that threw propagated out to
+`shutdown()`'s `Promise.race` catch. That catch was written for the timeout race alone
+and treated every exception as one, producing three consequences at once:
+
+1. the remaining `kernel:shutdown` handlers never ran;
+2. **every** plugin's `destroy()` was skipped — the reverse-order destroy pass sits
+   after the trigger in `performShutdown()`, so it was never reached;
+3. the process was killed by `process.exit(1)` under the log line
+   `Shutdown timed out — forcing exit`, while nothing had timed out — sending whoever
+   read it to the `shutdownTimeout` config for a handler bug.
+
+Two changes, matching the reasoning #5257 recorded at `LiteKernel`'s shutdown dispatch
+site:
+
+- **`kernel:shutdown` now dispatches ISOLATING on `ObjectKernel` too.** A handler that
+  throws is logged as `Hook handler failed: kernel:shutdown` and the remaining handlers
+  still run, followed by the reverse-order `destroy()` pass and the `onShutdown()`
+  handlers — both of which already isolated per plugin and per handler. What is queued
+  behind a failing shutdown handler is the cleanup that flushes buffers, closes
+  connections and releases locks, so one bad handler must not amplify into leaks and
+  unflushed writes. The BOOT-path hooks are untouched: `kernel:ready`,
+  `kernel:bootstrapped` and `kernel:listening` still propagate and still fail the boot
+  (#5170, #5257).
+- **The timeout catch now handles only a genuine timeout**, discriminated by identity on
+  the timer's own rejection — not by message, not by type, so nothing a plugin throws
+  can impersonate it. A genuine `shutdownTimeout` overrun is **unchanged**: it still
+  logs `Shutdown timed out — forcing exit` and still calls `process.exit(1)`, because
+  teardown really is hung and the process would otherwise hold what it failed to
+  release. Any other exception is logged at `error` and follows the normal path —
+  `state = 'stopped'`, return — with no `process.exit`, leaving an embedding host
+  (cloud auth-proxy, CLI, a test runner) its own chance to finish cleanly.
+
+`shutdown()` still never rejects, so no existing caller changes. Telling the two paths
+apart is the point of the fix, and both are pinned by named tests.

--- a/content/docs/kernel/events.mdx
+++ b/content/docs/kernel/events.mdx
@@ -37,7 +37,7 @@ A handler on any of the three **boot-path** hooks — `kernel:ready`, `kernel:bo
 
 `kernel:ready` is still the right place for **boot assertions** specifically — the service registry is only finished filling by then, so nothing earlier can judge whether a precondition your plugin *declared* was actually met, and a deployment that cannot honour what it announced must refuse to start rather than serve without the guarantee.
 
-`kernel:shutdown` is the deliberate exception: on `LiteKernel` a failing shutdown handler is logged and the remaining cleanup still runs, because the handlers queued behind it — and the `destroy()` pass after them — are what flush buffers and release resources, so aborting teardown only leaks what they were about to release. `ObjectKernel`'s shutdown path does not yet match that (tracked in [#5274](https://github.com/objectstack-ai/objectstack/issues/5274)); write shutdown handlers that handle their own errors either way.
+`kernel:shutdown` is the deliberate exception, on **both** kernels: a failing shutdown handler is logged (`Hook handler failed: kernel:shutdown`) and the remaining cleanup still runs, because the handlers queued behind it — and the `destroy()` pass after them — are what flush buffers and release resources, so aborting teardown only leaks what they were about to release. On `ObjectKernel` this also means a throwing shutdown handler no longer kills the host process: `shutdown()` still never rejects, the kernel still ends `stopped`, and `process.exit(1)` is reserved for a genuine `shutdownTimeout` overrun — the one case where teardown really is hung ([#5274](https://github.com/objectstack-ai/objectstack/issues/5274)). Write shutdown handlers that handle their own errors either way.
 
 ### Emitting Custom Events
 

--- a/packages/core/src/kernel.test.ts
+++ b/packages/core/src/kernel.test.ts
@@ -728,6 +728,146 @@ describe('ObjectKernel', () => {
 
             expect(handlerCalled).toBe(true);
         });
+
+        // #5274. `process.exit` is intercepted in all three tests below — the
+        // behaviour under test is precisely whether the kernel kills the host
+        // process, and an unintercepted `exit(1)` takes the vitest worker with
+        // it (which is why this pin could not land in #5257).
+        const spyOnExit = () =>
+            vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+        const spyOnLog = (k: ObjectKernel, level: 'error' | 'info') =>
+            vi.spyOn(
+                (k as unknown as { logger: Record<'error' | 'info', (...a: unknown[]) => void> }).logger,
+                level,
+            );
+
+        // The issue's reproduction, inverted into a pin. Before this, the first
+        // throwing `kernel:shutdown` handler ended the entire teardown: the
+        // probe recorded `reached=["process.exit(1)"]` — neither the second
+        // handler nor the plugin's destroy() ever ran. What is queued behind a
+        // failing shutdown handler is the rest of the cleanup (flush buffers,
+        // close connections, release locks), so one bad handler must not
+        // amplify into leaks and unflushed writes.
+        it('runs the remaining kernel:shutdown handlers, every destroy() and every onShutdown handler when one handler throws (#5274)', async () => {
+            const reached: string[] = [];
+            const exitSpy = spyOnExit();
+
+            const plugin: Plugin = {
+                name: 'shutdown-thrower',
+                version: '1.0.0',
+                init: async (ctx) => {
+                    ctx.hook('kernel:shutdown', async () => {
+                        throw new Error('shutdown boom');
+                    });
+                    ctx.hook('kernel:shutdown', async () => { reached.push('later-shutdown'); });
+                },
+                destroy: async () => { reached.push('plugin-destroy'); },
+            };
+
+            try {
+                await kernel.use(plugin);
+                kernel.onShutdown(async () => { reached.push('shutdown-handler'); });
+                await kernel.bootstrap();
+                await kernel.shutdown();
+
+                // Every teardown step behind the failing handler still ran, in
+                // order: remaining subscribers → reverse-order destroy() →
+                // custom shutdown handlers.
+                expect(reached).toEqual(['later-shutdown', 'plugin-destroy', 'shutdown-handler']);
+                // …and the host process was left alone.
+                expect(exitSpy).not.toHaveBeenCalled();
+                expect(kernel.getState()).toBe('stopped');
+            } finally {
+                exitSpy.mockRestore();
+            }
+        });
+
+        // The second half of the same defect, pinned separately because it can
+        // regress on its own: the outer catch was written only for the timeout
+        // race, so a handler throw was reported as `Shutdown timed out —
+        // forcing exit` when nothing had timed out — sending whoever read that
+        // line straight to the `shutdownTimeout` config.
+        it('names the failing handler and never reports a timeout that did not happen (#5274)', async () => {
+            const exitSpy = spyOnExit();
+            const errorSpy = spyOnLog(kernel, 'error');
+            const infoSpy = spyOnLog(kernel, 'info');
+
+            const plugin: Plugin = {
+                name: 'shutdown-thrower-logs',
+                version: '1.0.0',
+                init: async (ctx) => {
+                    ctx.hook('kernel:shutdown', async () => {
+                        throw new Error('shutdown boom');
+                    });
+                },
+            };
+
+            try {
+                await kernel.use(plugin);
+                await kernel.bootstrap();
+                await kernel.shutdown();
+
+                const errors = errorSpy.mock.calls.map((c) => String(c[0]));
+                // The failure is reported where it happened, naming the hook —
+                // same line LiteKernel's isolating dispatcher logs.
+                expect(errors).toContain('Hook handler failed: kernel:shutdown');
+                // …and NOT as a timeout.
+                expect(errors.some((m) => m.includes('Shutdown timed out'))).toBe(false);
+                expect(exitSpy).not.toHaveBeenCalled();
+
+                // Teardown really did complete, so it says so.
+                const infos = infoSpy.mock.calls.map((c) => String(c[0]));
+                expect(infos.some((m) => m.includes('Graceful shutdown complete'))).toBe(true);
+            } finally {
+                exitSpy.mockRestore();
+                errorSpy.mockRestore();
+                infoSpy.mockRestore();
+            }
+        });
+
+        // The other side of the discrimination, and the reason it is drawn by
+        // identity on the timer's own rejection: a GENUINE timeout keeps the
+        // hard exit. `performShutdown()` is still running and has stopped
+        // making progress, so the process would hang holding whatever it failed
+        // to release. This behaviour is unchanged by #5274 — pinned so the
+        // narrowing of the catch cannot quietly take it along.
+        it('still logs the timeout and still forces exit(1) when shutdown genuinely times out (#5274)', async () => {
+            const slowKernel = new ObjectKernel({
+                logger: { level: 'error' },
+                gracefulShutdown: false,
+                skipSystemValidation: true,
+                shutdownTimeout: 20,
+            });
+
+            const exitSpy = spyOnExit();
+            const errorSpy = spyOnLog(slowKernel, 'error');
+
+            const plugin: Plugin = {
+                name: 'hanging-shutdown-plugin',
+                version: '1.0.0',
+                init: async (ctx) => {
+                    // Never settles — the actual shape of a hung teardown.
+                    // Deliberately left pending: resolving it later would let
+                    // the teardown resume after the test had finished.
+                    ctx.hook('kernel:shutdown', () => new Promise<void>(() => {}));
+                },
+            };
+
+            try {
+                await slowKernel.use(plugin);
+                await slowKernel.bootstrap();
+                await slowKernel.shutdown();
+
+                const errors = errorSpy.mock.calls.map((c) => String(c[0]));
+                expect(errors).toContain('Shutdown timed out — forcing exit');
+                expect(exitSpy).toHaveBeenCalledWith(1);
+                expect(slowKernel.getState()).toBe('stopped');
+            } finally {
+                exitSpy.mockRestore();
+                errorSpy.mockRestore();
+            }
+        }, 5000);
     });
 
     describe('Dependency Resolution', () => {

--- a/packages/core/src/kernel.ts
+++ b/packages/core/src/kernel.ts
@@ -425,11 +425,22 @@ export class ObjectKernel {
         this.state = 'stopping';
         this.logger.info('Graceful shutdown started');
 
+        // The ONE rejection that means "teardown hung". Created here so the
+        // catch below can discriminate by IDENTITY (#5274): only this
+        // `setTimeout` can produce this exact object, so no message match, no
+        // `instanceof`, and nothing a plugin throws can ever impersonate it —
+        // not even a handler throwing `new Error('Shutdown timeout exceeded')`.
+        // That discrimination is the whole point: the catch used to be reached
+        // by BOTH the timer and any exception escaping `performShutdown()`, and
+        // it treated them identically — `process.exit(1)` under a log line
+        // reading "Shutdown timed out" when nothing had timed out.
+        const shutdownTimeoutError = new Error('Shutdown timeout exceeded');
+
         try {
             const shutdownPromise = this.performShutdown();
             const timeoutPromise = new Promise<void>((_, reject) => {
                 const t = setTimeout(() => {
-                    reject(new Error('Shutdown timeout exceeded'));
+                    reject(shutdownTimeoutError);
                 }, this.config.shutdownTimeout);
                 // Don't let this timer keep the event loop alive
                 if (t.unref) t.unref();
@@ -440,11 +451,32 @@ export class ObjectKernel {
             this.state = 'stopped';
             this.logger.info('✅ Graceful shutdown complete');
         } catch (error) {
-            this.logger.error('Shutdown timed out — forcing exit', error as Error);
             this.state = 'stopped';
-            // Flush logger then hard-exit; the process would otherwise hang
-            await this.logger.destroy();
-            process.exit(1);
+
+            if (error === shutdownTimeoutError) {
+                // GENUINE timeout: `performShutdown()` is still running and has
+                // stopped making progress, so the process would otherwise hang
+                // holding whatever it failed to release. Hard-exit stays — it
+                // is the only branch it was ever right for.
+                this.logger.error('Shutdown timed out — forcing exit', error as Error);
+                // Flush logger then hard-exit; the process would otherwise hang
+                await this.logger.destroy();
+                process.exit(1);
+            } else {
+                // NOT a timeout. `performShutdown()` isolates every teardown
+                // step it owns (hook dispatch, each destroy(), each shutdown
+                // handler), so reaching here means something outside those
+                // loops failed — the teardown is over either way, and there is
+                // nothing hung to escape from. Killing the host process here
+                // would take away the embedding host's (cloud auth-proxy, CLI,
+                // a test runner) chance to do its own cleanup, over a fault
+                // that did not require it. Log and return down the normal
+                // path; `shutdown()` still never rejects.
+                this.logger.error(
+                    'Shutdown finished with an unexpected teardown error — the kernel is stopped and the process is NOT being exited; some cleanup may not have run',
+                    error as Error,
+                );
+            }
         } finally {
             await this.logger.destroy();
         }
@@ -673,9 +705,55 @@ export class ObjectKernel {
         this.startedPlugins.clear();
     }
 
+    /**
+     * Dispatch `kernel:shutdown`, ISOLATING failures: a handler that throws is
+     * logged and the remaining handlers still run (#5274).
+     *
+     * This is a per-hook judgement, deliberately NOT the bare awaited loop
+     * `context.trigger` runs for every other hook — the boot-path hooks
+     * (`kernel:ready`, `kernel:bootstrapped`, `kernel:listening`) keep
+     * propagating, because everything dispatched before "✅ Bootstrap complete"
+     * is a precondition of that claim and swallowing a throw there only hides
+     * the failure behind a process reporting success (#5170, #5257).
+     *
+     * On the teardown path there is no "refuse to proceed" left to buy. What is
+     * queued behind a failing shutdown handler is the rest of the cleanup —
+     * every other subscriber, then each plugin's `destroy()` in reverse order —
+     * which is what flushes buffers, closes connections and releases locks. So
+     * one bad handler must not amplify into leaked resources and unflushed
+     * writes. Same reasoning, same wording, same `Hook handler failed:
+     * kernel:shutdown` log line as `LiteKernel`'s dispatch site, which reaches
+     * the shared isolating dispatcher `ObjectKernelBase.triggerHook` (#5257).
+     *
+     * `ObjectKernel` cannot call that dispatcher: it does not extend
+     * `ObjectKernelBase` (only `LiteKernel` does) and owns its own `hooks` map,
+     * so the semantics are mirrored here rather than shared. One hook name
+     * meaning two opposite things across the two kernels is exactly the bug
+     * #5170/#5257 closed, so the pin for this one lives on both sides too.
+     */
+    private async triggerShutdownHookIsolating(): Promise<void> {
+        const handlers = this.hooks.get('kernel:shutdown') || [];
+        this.logger.debug('Triggering hook: kernel:shutdown', {
+            hook: 'kernel:shutdown',
+            handlerCount: handlers.length,
+        });
+
+        for (const handler of handlers) {
+            try {
+                await handler();
+            } catch (error) {
+                this.logger.error('Hook handler failed: kernel:shutdown', error as Error);
+                // Continue with other handlers even if one fails
+            }
+        }
+    }
+
     private async performShutdown(): Promise<void> {
-        // Trigger shutdown hook
-        await this.context.trigger('kernel:shutdown');
+        // Trigger shutdown hook — ISOLATING dispatch, see the method's own
+        // rationale. The two loops below already isolate per plugin and per
+        // handler; before #5274 this line was the one teardown step that did
+        // not, so a single throwing subscriber skipped BOTH of them.
+        await this.triggerShutdownHookIsolating();
 
         // Destroy plugins in reverse order
         const orderedPlugins = Array.from(this.plugins.values()).reverse();


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5274

按 issue 上的裁定取 **A**(隔离式分发 + 收紧超时 catch);B(向调用方 reject)未实现 —— `shutdown()` 今天从不 reject,改这一点对既有调用方是 breaking。

## 问题

`ObjectKernel.performShutdown()` 用 `this.context.trigger('kernel:shutdown')`(裸 await 循环、从不 catch),第一个抛错的 handler 一路冒到 `shutdown()` 的 `Promise.race` 外层 catch;而那个 catch 只为**超时**写的,把所有异常一视同仁。于是一个插件的坏 handler 同时造成三件事:

1. 其余 `kernel:shutdown` handler 不再执行;
2. **每一个**插件的 `destroy()` 被跳过 —— 逆序销毁循环排在 trigger 之后,根本没走到;
3. 宿主进程被 `process.exit(1)` 杀掉,日志却写 `Shutdown timed out — forcing exit`,而实际什么都没超时 —— 读到这行的人会直奔 `shutdownTimeout` 配置去查一个 handler 的 bug。

## 改动

与 #5257 刚在 LiteKernel 停机分发点写下的理由对齐:

**1. `kernel:shutdown` 在 ObjectKernel 上也改隔离式分发。** 抛错的 handler 记 `Hook handler failed: kernel:shutdown`,其余 handler 照常跑,随后是逆序 `destroy()` 与 `onShutdown()` handler —— 后两个循环本来就已经逐插件/逐 handler 隔离了,这行是停机路径上唯一没隔离的一步。排在失败 handler 后面的正是冲刷缓冲、关连接、放锁的清理,所以一个坏 handler 不该放大成泄漏和未落盘的写。

⚠️ **boot 路径分发未动**:`kernel:ready` / `kernel:bootstrapped` / `kernel:listening` 仍然传播、仍然让 boot 失败(#5170 / #5258、#5257 / #5275)。

**关于「复用 `triggerHook`」的取舍(裁定里让我说明选择)**:代码证据不支持直接复用。`ObjectKernel` **并不继承** `ObjectKernelBase`(只有 `LiteKernel` 继承),它有自己的私有 `hooks` map 和自己的 `context.trigger`,所以 `protected triggerHook` 从这里够不着。把共享实现抽成自由函数需要动 `kernel-base.ts` —— 超出本单声明的文件面,且与该文件今天的两次改动(#5258/#5275)有冲突风险。因此在 `kernel.ts` 内以私有方法**镜像**同一语义,日志行逐字相同(`Hook handler failed: kernel:shutdown`),并在方法注释里写明「为什么不能直接复用」。两侧各有具名回归测试,正是 #5170/#5257 关掉的「同一个钩子名在两个 kernel 上含义相反」那类 bug 的防线。

**2. 超时 catch 收紧到只处理真超时**,靠**对象身份**区分,而不是消息匹配或 `instanceof`:

```ts
const shutdownTimeoutError = new Error('Shutdown timeout exceeded');
// …setTimeout(() => reject(shutdownTimeoutError), …)
} catch (error) {
    this.state = 'stopped';
    if (error === shutdownTimeoutError) { /* 原样保留:日志 + process.exit(1) */ }
    else { /* 记 error,走正常路径返回,不 exit */ }
}
```

只有那个 `setTimeout` 能产生这个对象,所以插件抛什么都冒充不了它 —— 连 handler 自己 `throw new Error('Shutdown timeout exceeded')` 也不行。

- **真超时路径原样不动**:仍记 `Shutdown timed out — forcing exit`,仍 `process.exit(1)`。此时 `performShutdown()` 确实还在跑且不再推进,进程本来就会挂住并攥着没释放的东西。
- **非超时异常**:记 `error`(说明后果:内核已 stopped、进程**不会**被退出、可能有清理没跑完),按正常路径返回,**不** `process.exit`。嵌入式宿主(cloud auth-proxy、CLI、测试进程)因此保住了自己收尾的机会。`shutdown()` 依旧从不 reject,调用方无需改动。

区分这两条路径是本单的核心,所以两条都单独 pin 住了。

## 测试

三个具名的逐行为用例(`packages/core/src/kernel.test.ts`,`Graceful Shutdown` 块内),用 `vi.spyOn(process, 'exit')` 拦截退出 —— 这正是 #5257 的开发者当时无法把该用例落在那个 PR 里的原因。

| 用例 | 钉住的行为 |
|:---|:---|
| `runs the remaining kernel:shutdown handlers, every destroy() and every onShutdown handler when one handler throws` | issue 正文的复现:`reached` 必须是 `['later-shutdown', 'plugin-destroy', 'shutdown-handler']`,进程未被 exit,`state === 'stopped'` |
| `names the failing handler and never reports a timeout that did not happen` | 记 `Hook handler failed: kernel:shutdown`;**不**出现 `Shutdown timed out`;停机确实完成,所以 `✅ Graceful shutdown complete` 照常打 |
| `still logs the timeout and still forces exit(1) when shutdown genuinely times out` | 真超时(`shutdownTimeout: 20` + 永不 settle 的 handler)仍记超时文案、仍 `process.exit(1)` |

**反证(把 `kernel.ts` 暂时 stash 回改前状态跑同三个用例)**:

```
× runs the remaining kernel:shutdown handlers … (#5274)
  → expected [] to deeply equal [ 'later-shutdown', …(2) ]
× names the failing handler and never reports a timeout … (#5274)
  → expected [ 'Shutdown timed out — forcing exit' ] to include 'Hook handler failed: kernel:shutdown'
✓ still logs the timeout and still forces exit(1) … (#5274)   23ms
```

改前的日志与 issue 探针输出逐字一致:`ERROR Shutdown timed out — forcing exit {"error":{"message":"shutdown boom"…}}`。注意第三个用例在改前改后**都**通过 —— 这正是它作为「行为未变」之 pin 的意义。

## 影响面验证

分支已 merge 当时的 `origin/main`(含 #5270、#5277,均未触及 `packages/core`),在容器验证锁下跑:

```
@objectstack/core:               27 files / 429 tests   passed
@objectstack/runtime:            89 files / 1313 tests  passed
@objectstack/client:             17 files / 222 tests   passed
@objectstack/service-automation: 55 files / 665 tests   passed
@objectstack/http-conformance:    2 files / 46 tests    passed
connector-{mcp,rest,openapi,slack}: 11 files / 79 tests passed
Tasks: 40 successful, 40 total
```

`node scripts/check-durability-degradation-log-level.mjs` ✓、`check-startup-registry-verdict.mjs` ✓(本 PR 新增了 catch 块,故一并跑)。

**typecheck**:`@objectstack/core` 无 `typecheck` script(#4311 DEBT 台账)。在同一棵合并树上两侧实测 `tsc --noEmit -p packages/core/tsconfig.json`:**改前 95 → 改后 98(+3)**。三个新增全部是 `kernel.test.ts` 里新用例的 `init: async (ctx)` 报 TS7006 implicit-any,成因是该文件既有的 TS2835(`import … from './kernel'` 缺 `.js` 扩展名)—— 正是 AGENTS.md 记的那个陷阱:导入不解析 ⇒ 符号退化成 `any` ⇒ 其上的回调逐个报 TS7006。`kernel.ts`(源码)零新增错误,零 code-tier 新增。该 config-tier 债已由 #4311 台账中 core 条目明文记载(`code-tier 3; the rest is config-tier (TS2835/TS2347) and noise (TS7006)`),故未在本 PR 顺手修 —— 修它会重排整个文件的错误读数,属于另一件事。台账只要求条目存在、不比对数值(main 自身已从 91 漂到 95)。

## 文档

`content/docs/kernel/events.mdx` 里那句「`ObjectKernel` 的停机路径尚未与之一致(见 #5274)」被本改动证伪,改为如实描述两个 kernel 现在一致,并写明 `process.exit(1)` 只留给真正的 `shutdownTimeout` 超时。最小改动,只动这一句。

## 范围

严格限于认领时声明的文件面:`packages/core/src/kernel.ts`、`kernel.test.ts`、`content/docs/kernel/events.mdx`(一句)、一个 changeset。未动 `packages/spec/**`、`content/docs/releases/**`,也未碰在飞的 `metadata-protocol/src/protocol.ts`、`metadata/src/metadata-manager.ts`、`objectql/**`、`triggers/**`、showcase。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pbu27iNUfQCHeuS551Rqo7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pbu27iNUfQCHeuS551Rqo7)_