### PR TITLE
fix(objectql): 单记录 delete 绑定 `hookContext.previous` —— 让引擎符合契约已声明的「for update/delete」 (#5272)

### DIFF
--- a/.changeset/single-delete-binds-previous.md
+++ b/.changeset/single-delete-binds-previous.md
@@ -1,0 +1,51 @@
+---
+"@objectstack/objectql": patch
+---
+
+fix(objectql): a single-record `delete()` binds `hookContext.previous` — the pre-image the contract has always promised (#5272)
+
+`HookContext.previous` is documented in the spec as *"the state of the record
+BEFORE the operation (**for update/delete**)"*, and `update()` has bound it all
+along. `delete()` never did. `previous` was `undefined` in **both**
+`beforeDelete` and `afterDelete`, for every single-record delete, on every
+object.
+
+That is not a cosmetic gap. Since #4775 a condition that cannot be evaluated
+**fails the operation**, so a legal, contract-shaped delete-side hook:
+
+```ts
+{ events: ['afterDelete'], condition: "previous.status == 'done'" }
+```
+
+rejected *every* single-record delete of that object — and reported it through
+the generic branch (`Unknown variable: previous`), which reads like the author
+misspelled a key. The key was fine; the engine never bound it. Same shape as
+#5037: a platform gap surfacing as the author's mistake.
+
+**Why now.** #5038 made a predicate bulk delete dispatch `afterDelete` once per
+matched row, each carrying that row's own pre-image. The single-record path
+still bound nothing, so it became strictly *worse* than the bulk path — the
+exact inversion the #4800/#4862 ruling ("an author writes the hook once; single
+and bulk mean the same thing") exists to prevent.
+
+**What changed.** `delete()` now takes the doomed row's pre-image once, before
+`beforeDelete` fires, and binds it to `hookContext.previous` for both phases —
+so hook `condition`s, record-change flow triggers and delete-audit handlers all
+see the deleted row. The read is demand-driven, exactly like `update()`'s: it
+happens only when the object has a delete-side hook (either phase) or a roll-up
+summary aggregating it. An object with neither pays nothing, and an object with
+both phases pays **one** read, not two — the roll-up path's own separate
+pre-image fetch has been folded into this one, and is now the same raw driver
+read `update()` already feeds the summary recompute.
+
+Nothing is fabricated: if the row is not there, `previous` stays **unbound**
+rather than becoming `{}`/`null`, so a condition reading it still faults loudly
+instead of answering for a record nobody read (#4649/#4775). The batch dispatch
+of a predicate delete still carries no `previous` — it stands for N rows — and
+its per-row `afterDelete` contexts are unchanged.
+
+Upgrade impact: a delete-side hook whose `condition` reads `previous` starts
+evaluating instead of rejecting the write, and delete-side handlers start
+receiving `ctx.previous`. If you worked around the gap by testing
+`ctx.previous == null` to detect "this is a delete", that test now answers
+differently — read `ctx.event` instead.

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -5532,7 +5532,88 @@ export class ObjectQL implements IObjectQLEngine {
           transaction: opCtx.context?.transaction,
           ql: this
       };
+
+      // [#5272] The pre-image of the row this delete is about to remove.
+      //
+      // `HookContext.previous` is documented — in the spec, since it was
+      // written — as "the state of the record BEFORE the operation (for
+      // update/delete)", and `update()` has bound it all along. `delete()`
+      // never did: `previous` was `undefined` in `beforeDelete` AND in
+      // `afterDelete`, so a legal, contract-shaped delete-side transition
+      // condition (`previous.status == "done"`) was unevaluable — and since
+      // #4775 unevaluable REJECTS the operation. Worse, it was reported
+      // through the generic branch, which reads as "you misspelled a key"
+      // when the key was fine and the engine simply never bound it (#5037's
+      // shape, one path over).
+      //
+      // #5038 made the asymmetry visible from the other side: a predicate
+      // bulk delete already binds each doomed row's own pre-image on its
+      // per-row `afterDelete`, so the SINGLE-record path was strictly worse
+      // than the bulk one — the exact inversion #4800/#4862 ruled against.
+      //
+      // Demand-driven, like `update()`'s `priorRecord`: read only when
+      // something on this object actually consumes it —
+      //   * a delete-side hook, EITHER phase (its `condition` may read
+      //     `previous`; its handler — plugin-audit, the record-change
+      //     trigger — reads `ctx.previous` directly);
+      //   * a roll-up summary aggregating this object, which needs the
+      //     doomed row's FK value to find the parent to recompute.
+      // Those two used to be separate reads at separate times (the summary
+      // one fetched only after `beforeDelete` had run); they are ONE read
+      // now — and a RAW driver read, which is exactly what `update()`
+      // already hands `recomputeSummaries` as its `previous` argument, so
+      // the two write paths now agree on what a pre-image is.
+      //
+      // `needsPriorRecord(schema)` is deliberately NOT part of this gate
+      // even though `update()`'s twin carries it: object validation rules
+      // are evaluated on insert/update only — `delete()` evaluates none —
+      // so including it would buy a read with no reader.
+      //
+      // Read BEFORE `beforeDelete` fires. A delete's `before` phase is the
+      // one that has nothing else to look at (its `input` carries an id and
+      // no data), and the pre-image has to be taken before the row is gone
+      // either way, so a single read serves both phases.
+      const deleteSchema = this._registry.getObject(object);
+      const wantsPreImage =
+        this.hasHooksFor('beforeDelete', object) ||
+        this.hasHooksFor('afterDelete', object) ||
+        this.getSummaryDescriptors(object).length > 0;
+      // `buildDriverOptions` is what carries the open transaction and the
+      // tenant scope onto a raw driver read. Skipping it here would read
+      // outside this write's transaction and across the tenant boundary —
+      // `update()`'s prior read passes the same bag for the same reason.
+      const readPreImage = async (targetId: unknown): Promise<Record<string, unknown> | null> => {
+        const preAst: QueryAST = { object, where: { id: targetId }, limit: 1 };
+        const preOpts = this.buildDriverOptions(object, opCtx.context, hookContext.input.options as any);
+        return (await driver.findOne(object, preAst, preOpts)) as Record<string, unknown> | null;
+      };
+      const bindPreImage = (row: Record<string, unknown> | null): void => {
+        // Never fabricate: a row that is not there leaves `previous` UNBOUND
+        // rather than `{}`/`null`, so a condition reading it faults loudly
+        // instead of answering for a record nobody read (#4649/#4775).
+        hookContext.previous = row ? (coerceBooleanFields(deleteSchema as any, row as any) as any) : undefined;
+      };
+      let priorRecord: Record<string, unknown> | null = null;
+      if (id && wantsPreImage) {
+        priorRecord = await readPreImage(id);
+        bindPreImage(priorRecord);
+      }
+
       await this.triggerHooks('beforeDelete', hookContext);
+
+      // A `beforeDelete` hook may repoint the target id, or clear it (which
+      // #4550's re-asked dispatch verdict below already accounts for). The
+      // pre-image bound above describes the OLD id, so it must not ride into
+      // `afterDelete` — or into the summary recompute — as though it
+      // described the new target. A cleared id falls through to the predicate
+      // branch, whose batch-scoped dispatch must carry no single row's
+      // pre-image at all (`hook-wrappers` diagnoses that dispatch by the
+      // absence of both).
+      if (wantsPreImage && hookContext.input.id !== id) {
+        priorRecord = hookContext.input.id ? await readPreImage(hookContext.input.id) : null;
+        bindPreImage(priorRecord);
+      }
+
       hookContext.input.options = this.buildDriverOptions(object, opCtx.context, hookContext.input.options as any);
 
       try {
@@ -5545,15 +5626,6 @@ export class ObjectQL implements IObjectQLEngine {
           // `record-after-delete` flow must see each deleted row rather than
           // one context that names none of them.
           let bulkPerRowRows: Record<string, unknown>[] | null = null;
-          // Capture the row's FK values BEFORE deletion so roll-up summaries can
-          // recompute the (now-orphaned) parent. Only when a summary aggregates
-          // this object — avoids an extra read on every delete.
-          let summaryPrev: any = null;
-          if (hookContext.input.id && this.getSummaryDescriptors(object).length > 0) {
-            try {
-              summaryPrev = await this.findOne(object, { where: { id: hookContext.input.id }, context: opCtx.context } as any);
-            } catch { /* best-effort */ }
-          }
           if (hookContext.input.id) {
               // Honor referential delete behavior (cascade/set_null/restrict)
               // for relations pointing at this record before removing it.
@@ -5607,9 +5679,13 @@ export class ObjectQL implements IObjectQLEngine {
             await this.triggerHooks('afterDelete', hookContext);
           }
 
-          // Roll-up: recompute the parent summary now that the child is gone.
-          const summaryFailures = summaryPrev
-            ? await this.recomputeSummaries(object, null, summaryPrev, opCtx.context)
+          // Roll-up: recompute the parent summary now that the child is gone,
+          // from the row's FK values captured BEFORE deletion. [#5272] That
+          // capture is now the same single pre-image read `previous` rides on
+          // (it used to be its own later `findOne`), which is also what
+          // `update()` passes here.
+          const summaryFailures = priorRecord
+            ? await this.recomputeSummaries(object, null, priorRecord, opCtx.context)
             : [];
 
           // Same split as update(): per-record `data.record.deleted` (#4626),

--- a/packages/objectql/src/hook-condition-previous-scope.test.ts
+++ b/packages/objectql/src/hook-condition-previous-scope.test.ts
@@ -240,20 +240,16 @@ describe('[#4784] hook condition binds `previous` alongside `record`', () => {
     expect(conditionWarnings()).toEqual([]);
   });
 
-  it('a delete-shaped context evaluates `previous` against the pre-image', async () => {
-    const calls: string[] = [];
-    const { logger, conditionWarnings } = captureLogger();
-    const wrapped = wrapDeclarativeHook(
-      makeHook('previous.done != true', ['beforeDelete']),
-      (async () => { calls.push('ran'); }) as any,
-      { logger },
-    );
-
-    await wrapped(makeCtx({ event: 'beforeDelete', input: { id: 't1', options: {} } } as any));
-
-    expect(calls).toEqual(['ran']);
-    expect(conditionWarnings()).toEqual([]);
-  });
+  // [#5272] The delete-shaped case that used to live here hand-built
+  // `previous` on the context and asserted the wrapper read it. It passed
+  // against an engine that never produced one — `delete()` assigned
+  // `hookContext.previous` nowhere, so the pin was a green light for behaviour
+  // that did not exist, and the real failure (every single-record delete with
+  // a `previous.*` condition rejected under #4775) sat behind it. Its
+  // replacement drives a real `engine.delete()` end to end — see
+  // '[#5272] a single-record delete binds `previous` through the real engine'
+  // at the bottom of this file. Nothing about the wrapper needed fixing; the
+  // producer did, so that is where the test now looks.
 
   it('a context with no engine still binds `previous` (merge only, no materialisation)', async () => {
     const calls: string[] = [];
@@ -501,5 +497,192 @@ describe('[#4784] a condition that never mentions `previous` costs zero extra fe
     // rides along on it.
     expect(plainCost).toBe(1);
     expect(prevCost).toBe(plainCost);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * [#5272] The DELETE side of the same contract, through a real engine.
+ *
+ * `HookContext.previous` is documented "for update/delete", and #5038 made a
+ * predicate bulk delete bind each doomed row's pre-image on its per-row
+ * `afterDelete`. The single-record path bound nothing at all, so it was
+ * strictly worse than the bulk one and every delete-side `previous.*`
+ * condition was rejected by #4775's fail-loud — through the generic branch,
+ * which reads like an author typo.
+ *
+ * Every case below goes insert → real `engine.delete()` → assert what the hook
+ * was handed. A hand-built context cannot answer any of these questions: it
+ * asserts what the test author already wrote down.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+describe('[#5272] a single-record delete binds `previous` through the real engine', () => {
+  async function bootDelete(hooks: Hook[]) {
+    const engine = new ObjectQL();
+    const mem = makeMemoryDriver();
+    engine.registerDriver(mem.driver, true);
+    await engine.init();
+    engine.registry.registerObject(taskObject as any);
+    const warn = vi.fn();
+    bindHooksToEngine(engine, hooks, {
+      packageId: 'app:showcase',
+      logger: { debug: () => {}, info: () => {}, warn, error: () => {} },
+    });
+    return {
+      engine,
+      reads: mem.reads,
+      conditionWarnings: () =>
+        warn.mock.calls.filter(([msg]) => String(msg).includes('condition evaluation failed')),
+    };
+  }
+
+  const observer = (event: string, sink: Array<Record<string, unknown> | undefined>): Hook => ({
+    name: `observe_${event}`,
+    object: 'hook_task',
+    events: [event],
+    priority: 90,
+    handler: (ctx: any) => { sink.push(ctx.previous); },
+  } as unknown as Hook);
+
+  it('hands `beforeDelete` the stored pre-image', async () => {
+    const seen: Array<Record<string, unknown> | undefined> = [];
+    const { engine } = await bootDelete([observer('beforeDelete', seen)]);
+
+    const row: any = await engine.insert('hook_task', { title: 'Ship it', status: 'done', done: true });
+    await engine.delete('hook_task', { where: { id: row.id } } as any);
+
+    expect(seen).toHaveLength(1);
+    // The row as the database held it — not `undefined`, and not the bare
+    // `{ id }` the delete's `input` carries.
+    expect(seen[0]).toEqual({ id: row.id, title: 'Ship it', status: 'done', done: true });
+  });
+
+  it('hands `afterDelete` the same pre-image — by then the row is gone', async () => {
+    const seen: Array<Record<string, unknown> | undefined> = [];
+    const { engine } = await bootDelete([observer('afterDelete', seen)]);
+
+    const row: any = await engine.insert('hook_task', { title: 'Ship it', status: 'done', done: true });
+    await engine.delete('hook_task', { where: { id: row.id } } as any);
+
+    // The pre-image is taken BEFORE the delete precisely because this is the
+    // only moment it exists: the row is unreadable now.
+    expect(await engine.findOne('hook_task', { where: { id: row.id } })).toBeFalsy();
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toEqual({ id: row.id, title: 'Ship it', status: 'done', done: true });
+  });
+
+  it('evaluates a `previous.*` delete-side condition instead of rejecting the delete (#4775)', async () => {
+    // The issue's own example: a legal, contract-shaped transition hook. Before
+    // the fix `previous` was unbound on every single-record delete, so this
+    // condition was unevaluable and #4775 failed the whole operation — with the
+    // generic `Unknown variable: previous`, which reads as a misspelling.
+    const audited: string[] = [];
+    const { engine, conditionWarnings } = await bootDelete([{
+      name: 'audit_completed_task_deletion',
+      object: 'hook_task',
+      events: ['afterDelete'],
+      priority: 90,
+      condition: "previous.status == 'done'",
+      handler: (ctx: any) => { audited.push(String(ctx.input?.id ?? '?')); },
+    } as unknown as Hook]);
+
+    const done: any = await engine.insert('hook_task', { title: 'Shipped', status: 'done', done: true });
+    const open: any = await engine.insert('hook_task', { title: 'Draft', status: 'todo', done: false });
+
+    // Neither delete is rejected, and the condition SELECTS: it fires for the
+    // completed task and not for the open one.
+    await expect(engine.delete('hook_task', { where: { id: done.id } } as any)).resolves.toBeDefined();
+    await expect(engine.delete('hook_task', { where: { id: open.id } } as any)).resolves.toBeDefined();
+
+    expect(audited).toEqual([done.id]);
+    expect(conditionWarnings()).toEqual([]);
+  });
+
+  it('is TOTAL over declared fields on a delete too — an unwritten column reads as null', async () => {
+    // Same materialisation the update side gets: `done` was never written, so
+    // the driver's row has no such key. `previous.done` must read as the
+    // materialised null rather than aborting the condition.
+    const audited: string[] = [];
+    const { engine, conditionWarnings } = await bootDelete([{
+      name: 'audit_incomplete_deletion',
+      object: 'hook_task',
+      events: ['beforeDelete'],
+      priority: 90,
+      condition: 'previous.done != true',
+      handler: (ctx: any) => { audited.push(String(ctx.input?.id ?? '?')); },
+    } as unknown as Hook]);
+
+    const row: any = await engine.insert('hook_task', { title: 'Untouched', status: 'todo' });
+    await engine.delete('hook_task', { where: { id: row.id } } as any);
+
+    expect(audited).toEqual([row.id]);
+    expect(conditionWarnings()).toEqual([]);
+  });
+
+  it('does not leak materialised nulls into what the delete hook observes', async () => {
+    const seen: Array<Record<string, unknown> | undefined> = [];
+    const { engine } = await bootDelete([{
+      name: 'observe_previous_on_delete',
+      object: 'hook_task',
+      events: ['afterDelete'],
+      priority: 90,
+      condition: 'previous.archived == null',
+      handler: (ctx: any) => { seen.push(ctx.previous); },
+    } as unknown as Hook]);
+
+    const row: any = await engine.insert('hook_task', { title: 'Ship it', status: 'todo' });
+    await engine.delete('hook_task', { where: { id: row.id } } as any);
+
+    expect(seen).toHaveLength(1);
+    // `archived` is declared and was materialised for the condition; the
+    // engine's own pre-image must not have gained a column the row never had.
+    expect(Object.keys(seen[0] as object).sort()).toEqual(['id', 'status', 'title']);
+  });
+
+  it('reads the pre-image ONCE for both phases', async () => {
+    // The cost guardrail: `beforeDelete` and `afterDelete` share one read, and
+    // it is the SAME read the roll-up summary path used to make separately.
+    const before: Array<Record<string, unknown> | undefined> = [];
+    const after: Array<Record<string, unknown> | undefined> = [];
+    const { engine, reads } = await bootDelete([
+      observer('beforeDelete', before),
+      observer('afterDelete', after),
+    ]);
+
+    const row: any = await engine.insert('hook_task', { title: 'A', status: 'todo', done: false });
+    const baseline = reads.findOne;
+    await engine.delete('hook_task', { where: { id: row.id } } as any);
+
+    expect(reads.findOne - baseline).toBe(1);
+    expect(before[0]).toEqual(after[0]);
+  });
+
+  it('reads nothing at all when the object has no delete-side hook', async () => {
+    // Demand-driven, exactly like update()'s prior-row gate: an object nobody
+    // observes on delete pays for no pre-image.
+    const { engine, reads } = await bootDelete([{
+      name: 'update_only_guard',
+      object: 'hook_task',
+      events: ['afterUpdate'],
+      priority: 100,
+      condition: 'record.status == "todo"',
+      handler: () => {},
+    } as unknown as Hook]);
+
+    const row: any = await engine.insert('hook_task', { title: 'A', status: 'todo', done: false });
+    const baseline = reads.findOne;
+    await engine.delete('hook_task', { where: { id: row.id } } as any);
+
+    expect(reads.findOne - baseline).toBe(0);
+  });
+
+  it('leaves `previous` UNBOUND when the row is not there — nothing is fabricated', async () => {
+    const seen: Array<Record<string, unknown> | undefined> = [];
+    const { engine } = await bootDelete([observer('beforeDelete', seen)]);
+
+    await engine.delete('hook_task', { where: { id: 'never_existed' } } as any);
+
+    // `{}` or `null` here would let `previous.status == "done"` answer for a
+    // record nobody read. Absent stays absent (#4649/#4775).
+    expect(seen).toEqual([undefined]);
   });
 });


### PR DESCRIPTION
Fixes #5272

按 issue 的 **A 方向**实施(PM 已拍板):`delete()` 复用 `update()` 同款的 demand-driven 前置行门,在单 id 路径取一次前置行并赋给 `hookContext.previous`,覆盖 `beforeDelete` / `afterDelete` 两个阶段。⛔ 未触碰 `packages/spec/**`、`content/docs/releases/**`、`metadata-protocol/src/protocol.ts`、`core/src/kernel.ts`,也未改 plugin-audit 的 `__previous` 兜底。

---

## 一、STALE-PREMISE 事实核对(基于合并 #5270 之后的现场)

worktree 基于 `3905c0064`(即 PR #5270 的合入点),逐条核对 issue 正文引用的行为:

| issue 的说法 | 合并后现场 | 结论 |
|:--|:--|:--|
| `hookContext.previous` 的赋值**只有一处**,在 `update()` 单 id 分支 | 现在是**两处**:`update()` 单 id 分支(`engine.ts` 原 5300 行),**以及 #5270 新增的 `buildPerRowAfterContexts()`**(原 1225 行),后者为批量 update **和批量 delete** 的每行 after 上下文赋 `previous` | ⚠️ **已过时,但结论更强**:单记录 delete 是合并后**唯一**一条完全不绑 `previous` 的写入路径 |
| `delete()` 全程不给 `hookContext.previous` 赋值 | 成立(修复前 `grep previous` 在 `delete()` 体内零命中) | ✅ 成立 |
| `summaryPrev` 只喂 `recomputeSummaries`,不进上下文 | 成立(原 5551–5556 读,5611–5613 唯一消费点) | ✅ 成立 |
| 报错走通用分支、读起来像作者拼错 key | 已用真实引擎复现,原文如下 | ✅ 成立 |

复现原文(在 stash 掉本 PR 的 `engine.ts` 改动、只跑新测试时打印):

```
Hook 'audit_completed_task_deletion' could not evaluate its condition
(type: Unknown variable: previous) — operation aborted. The condition reads
'previous', which is not bound for this operation — the scope holds 'record',
plus 'previous' only when the record's prior state is in hand.
```

补充一条 issue 未提、实施中确认的事实:`summaryPrev` 走的是**引擎级 `this.findOne()`**(过中间件、RLS、formula 投影),而 `update()` 喂给 `recomputeSummaries` 的 `priorRecord` 是**裸 driver 读**。同一件事两条路两种语义 —— 合并成一次读时按 `update()` 的口径统一(见下)。

---

## 二、实现摘要(`packages/objectql/src/engine.ts`)

前置行读取放在 `triggerHooks('beforeDelete')` **之前**:delete 的 before 阶段是唯一「除了 id 什么都没有」的阶段(`input` 无 `data`),而前像本来就必须在删除动作前取,一份数据两个阶段共用。

**门(demand-driven)**:

```
hasHooksFor('beforeDelete', object) || hasHooksFor('afterDelete', object)
  || getSummaryDescriptors(object).length > 0
```

- 用 `hasHooksFor(event, object)`(按对象)而不是 `update()` 那条 `this.hooks.get('afterUpdate')?.length > 0`(全局),与 #5038 批量 delete 侧同款,更省。
- **刻意没有把 `needsPriorRecord(schema)` 放进门**,虽然 `update()` 的孪生门带着它:对象校验规则只在 insert/update 求值,`delete()` 一条都不跑 —— 带上它就是买一次没有读者的读。这是对 PM 指令中「同款条件」的一处有意收窄,理由记在代码注释里。

**合并为一次读**:原先 roll-up summary 的 `summaryPrev` 是**另一次、更晚**的读(在 `beforeDelete` 之后)。现已删除,`recomputeSummaries` 直接吃这一次前置行。口径按 `update()` 统一为**裸 `driver.findOne`** —— `recomputeSummaries` 只取 `p?.[desc.fkField]`(存储列),裸读足够,且不会因调用方读权限被 RLS 收窄而静默跳过父行重算。

**租户/事务安全**:裸 driver 读经 `buildDriverOptions(object, opCtx.context, hookContext.input.options)` 取得 options —— 这正是把开启中的事务和 `tenantId` 带到裸读上的那一层,`update()` 的前置读同理。少了它会读到事务外、甚至跨租户。

**不臆造**:行不存在 → `previous` 保持 **unbound**(而非 `{}` / `null`),条件读它仍按 #4649/#4775 大声失败,而不是替一条没人读过的记录作答。

**id 被改写/清空的收尾**:`beforeDelete` hook 可以改写甚至清空 `input.id`(#4550 的 reject 判定就是为此再问一次)。hook 跑完后若 `input.id !== id`,则重读(改写)或丢弃(清空)绑定 —— 陈旧前像绝不进入 `afterDelete` 或 summary 重算;清空后落到 predicate 分支,而批量派发按契约本就不该带任何单行前像(`hook-wrappers` 正是靠这个「两者皆无」来诊断批量派发)。

**未动**:#5038 的批量 predicate delete 按行绑定路径逐字未改。

---

## 三、测试

### 改造既有「开绿灯」的 pin(本单硬性要求)

`hook-condition-previous-scope.test.ts` 的 `a delete-shaped context evaluates 'previous' against the pre-image` **手工构造 `previous`**,断言的是 wrapper 读没读它 —— 而引擎从不产出这份数据,于是它替一个不存在的行为发了绿灯,真正的故障(每一次带 `previous.*` 条件的单记录 delete 都被 #4775 打回)就藏在它后面。**已删除**,原位留下说明注释,替换为走真实引擎的端到端用例。

### 新增 8 例(全部 insert → 真实 `engine.delete()` → 断言 hook 拿到什么)

| 用例 | 断言 |
|:--|:--|
| `hands 'beforeDelete' the stored pre-image` | `ctx.previous` 等于数据库前像,不是 `undefined`、也不是 delete `input` 的裸 `{id}` |
| `hands 'afterDelete' the same pre-image — by then the row is gone` | 同一份前像;并先断言此刻该行已读不到,坐实「必须提前取」 |
| `evaluates a 'previous.*' delete-side condition instead of rejecting the delete (#4775)` | issue 原样的 `previous.status == 'done'`:两次 delete 都不被拒,且条件**有选择性**(只对 done 的那条触发) |
| `is TOTAL over declared fields on a delete too` | 从未写过的列在 delete 侧同样物化为 null,不中断表达式 |
| `does not leak materialised nulls into what the delete hook observes` | 引擎自己的 `ctx.previous` 不会多出该行从未有过的列 |
| `reads the pre-image ONCE for both phases` | before+after 两个 hook 都在时,`findOne` 增量 **= 1**(合并读的成本护栏) |
| `reads nothing at all when the object has no delete-side hook` | 增量 **= 0**(demand-driven 门) |
| `leaves 'previous' UNBOUND when the row is not there` | 拿到 `undefined`,不臆造 |

**反向验证(证明这些是真 pin,不是重言式)**:把 `engine.ts` 的改动 stash 掉单跑该文件 —— **6 failed | 17 passed**,失败原因正是 issue 描述的两类(`expected undefined to deeply equal {...}`、`HookConditionError ... Unknown variable: previous`);另 2 例(无 hook 不读、行不存在不绑)修复前后都应成立,故不失败。恢复改动后 23 例全绿。

### 验证记录

| 命令 | 结果 |
|:--|:--|
| `pnpm --filter @objectstack/objectql test` | `Test Files 116 passed (116)` / `Tests 1875 passed (1875)` |
| `pnpm --filter @objectstack/objectql typecheck` | `tsc --noEmit`,无输出(通过) |
| `pnpm exec eslint packages/objectql/src/engine.ts packages/objectql/src/hook-condition-previous-scope.test.ts` | 无输出(通过) |
| `turbo run test --filter @objectstack/plugin-audit --filter @objectstack/trigger-record-change` | `plugin-audit` 108 passed;`trigger-record-change` 55 passed(两者都读 `ctx.previous`,是本改动的直接下游) |

`summary-rollup.test.ts`(含 `recomputes when a child is deleted`)与 `engine-summary-retry.test.ts` 覆盖了被合并掉的那次读,均绿。

重的构建/测试全程持 `flock /tmp/os-heavy-verify.lock` 并带 `NODE_OPTIONS=--max-old-space-size=4096`,`--maxWorkers=2` / `--concurrency=2`。

---

## 四、变更记录

`.changeset/single-delete-binds-previous.md`(`@objectstack/objectql: patch`),写明行为变化与升级影响:原本因 #4775 被打回的 delete 侧 `previous.*` 条件现在正常求值;delete 侧 handler 开始收到 `ctx.previous`;若有人靠 `ctx.previous == null` 来判别「这是一次 delete」,该判据失效,应改读 `ctx.event`。未改 `content/docs/releases/**`。

---

## 五、范围外(未在本 PR 修,留给 PM 分诊)

1. **plugin-audit 的 `(ctx as any).__previous` 兜底可退役**(PM 已记为后续 finding,本 PR 按指令不动)。`audit-writers.ts` 的 `captureBefore` 在 `beforeDelete` 里**自己再读一次**前像塞进 `__previous`;单记录 delete 的 `previous` 落地后,这次读在 delete 路径上已成重复(update 路径本来就重复)。退役它可省掉一次读,但属独立面。
2. **`update()` 的前置行门仍是全局的**(`this.hooks.get('afterUpdate')?.length > 0`),而 delete 侧用的是按对象的 `hasHooksFor`。全局门意味着任一对象注册了 `afterUpdate`,**所有**对象的单 id update 都多付一次读。属可收窄的性能面,非缺陷,未在本单扩面。

以上两条尚未开 issue —— 均为 PM 已知/已记项与纯优化面,按 #4949 的立项纪律先在此列明,若需要我可另开 `finding` 标签的观察类 issue。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pbu27iNUfQCHeuS551Rqo7)_