### PR TITLE
fix(auth): 两个 membership 入口对词表外的 policy 给出同向的拒绝 (#5205)

### DIFF
--- a/.changeset/auth-invalid-membership-policy-outcome.md
+++ b/.changeset/auth-invalid-membership-policy-outcome.md
@@ -1,0 +1,38 @@
+---
+"@objectstack/plugin-auth": minor
+---
+
+fix(auth): an unrecognised membership policy is refused by both reconcilers, not auto-bound by one of them (#5205)
+
+**The sign-up path used to bind anyway.** `reconcileMembership` and
+`backfillMemberships` — both public exports of `@objectstack/plugin-auth` — read
+the same `policy` field and judged it with opposite predicates. Sign-up tested
+`policy === 'invite-only'`, so any *other* value fell through to the `auto`
+branch and auto-bound the new user; the backfill tested `policy !== 'auto'` and
+refused. One input, two opposite postures, and the fail-open half was the one
+that runs per sign-up. A caller who wrote `'inviteOnly'` — or any host passing
+the policy from JavaScript, past the `MembershipPolicy` type — got auto-binding
+while believing they had switched it off, with nothing in the logs to say so.
+
+Both entry points now check `isMembershipPolicy()` before any policy semantics
+and refuse: nothing is bound, and the refusal names the offending value at
+`error` level (and on the returned result, so it survives a caller that passed
+no logger). This is the posture #5152 took one layer up at the settings
+boundary — an unrecognised value is rejected loudly, never coerced to `auto`.
+
+**Contract change — `ReconcileOutcome` gains `'invalid-policy'`, and
+`BackfillMembershipsResult.reason` gains the same member.** Both are exported
+types, so a consumer that switches exhaustively over them (a `never`-checked
+`default`, or a `Record< ReconcileOutcome, … >`) must handle the new member.
+The new verdict is deliberately *not* a reuse of the existing `policy-skip` /
+`'policy'`: those mean "a valid policy said no", and reporting them for "this
+is not a policy" sends whoever is debugging a missing bind to inspect a
+deployment setting that is fine. `BackfillMembershipsResult` also gains an
+optional `error?: string`, and the `logger` shape on `ReconcileMembershipDeps`
+gains an optional `error?` method (it falls back to `warn`).
+
+**No behaviour change for the two real policies.** `auto` binds and
+`invite-only` skips exactly as before, on both paths — the framework's own
+callers resolve the policy through `AuthManager.getMembershipPolicy()`, whose
+return type is `MembershipPolicy`, so nothing on a supported path can reach the
+new branch. This closes the dormant divergence on the export surface.

--- a/packages/plugins/plugin-auth/src/reconcile-membership.test.ts
+++ b/packages/plugins/plugin-auth/src/reconcile-membership.test.ts
@@ -1,8 +1,22 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, vi } from 'vitest';
-import { reconcileMembership, backfillMemberships } from './reconcile-membership.js';
+import {
+  reconcileMembership,
+  backfillMemberships,
+  MEMBERSHIP_POLICIES,
+  type MembershipPolicy,
+} from './reconcile-membership.js';
 import { runAttributedToUser } from './auth-actor-attribution.js';
+
+/**
+ * Off-vocabulary policy values, as a JS caller or a host stack could pass them
+ * past the `MembershipPolicy` type. `reconcileMembership` and
+ * `backfillMemberships` are public exports of `@objectstack/plugin-auth`, so
+ * the cast is the test reproducing a real call, not defeating the type system
+ * for convenience.
+ */
+const asPolicy = (value: unknown) => value as MembershipPolicy;
 
 /**
  * In-memory engine over sys_member (+ optional sys_user) with the find/insert
@@ -157,6 +171,206 @@ describe('backfillMemberships', () => {
     expect(res.scanned).toBe(2);
     expect(res.bound).toBe(1); // u2 still bound
     expect(res.skipped).toBe(1);
+  });
+});
+
+/**
+ * [#5205] The two entry points read the SAME policy field and used to judge it
+ * with opposite predicates: `reconcileMembership` tested `=== 'invite-only'`
+ * (so anything else, including a typo, fell through to the `auto` branch and
+ * bound — fail-open), `backfillMemberships` tested `!== 'auto'` (refused —
+ * fail-safe). The dangerous half was the sign-up path: a caller who believed
+ * they had turned auto-binding off got it anyway, silently.
+ *
+ * These pin the fixed contract: one input, one direction (nothing bound), and
+ * a verdict that says *why* — `'invalid-policy'`, not a `policy-skip` /
+ * `'policy'` that would send a reader to inspect a setting that is fine.
+ */
+describe('reconcileMembership / backfillMemberships — off-vocabulary policy (#5205)', () => {
+  const INVALID: Array<[label: string, value: unknown]> = [
+    ['camelCase typo', 'inviteOnly'],
+    ['snake_case typo', 'invite_only'],
+    ['wrong case', 'Auto'],
+    ['empty string', ''],
+    ['undefined', undefined],
+    ['null', null],
+    ['boolean', false],
+    ['object', { policy: 'invite-only' }],
+  ];
+
+  describe.each(INVALID)('policy = %s', (_label, value) => {
+    it('reconcileMembership refuses — invalid-policy, nothing bound', async () => {
+      const engine = makeEngine();
+      const resolveTargetOrg = vi.fn(async () => 'org_default');
+      const res = await reconcileMembership(engine, 'user-1', {
+        policy: asPolicy(value),
+        resolveTargetOrg,
+      });
+      expect(res.outcome).toBe('invalid-policy');
+      // The whole bug: this used to be `bound`.
+      expect(engine.insert).not.toHaveBeenCalled();
+      expect(engine._members).toHaveLength(0);
+      // Refused at the entry — no org was even resolved.
+      expect(resolveTargetOrg).not.toHaveBeenCalled();
+    });
+
+    it('backfillMemberships refuses — invalid-policy, nothing bound', async () => {
+      const engine = makeEngine({ users: [{ id: 'u1' }, { id: 'u2' }] });
+      const resolveTargetOrg = vi.fn(async () => 'org_default');
+      const res = await backfillMemberships(engine, {
+        policy: asPolicy(value),
+        resolveTargetOrg,
+      });
+      expect(res.reason).toBe('invalid-policy');
+      expect(res.bound).toBe(0);
+      expect(engine.insert).not.toHaveBeenCalled();
+      expect(resolveTargetOrg).not.toHaveBeenCalled();
+    });
+
+    it('both paths agree: same input, same direction, neither binds', async () => {
+      const signupEngine = makeEngine();
+      const backfillEngine = makeEngine({ users: [{ id: 'u1' }] });
+      const deps = { policy: asPolicy(value), resolveTargetOrg: async () => 'org_default' };
+
+      const signup = await reconcileMembership(signupEngine, 'user-1', deps);
+      const backfill = await backfillMemberships(backfillEngine, deps);
+
+      expect(signupEngine._members).toHaveLength(0);
+      expect(backfillEngine._members).toHaveLength(0);
+      // …and both name the same cause, so a reader of either one lands on the
+      // caller's policy value rather than on the deployment's setting.
+      expect(signup.outcome).toBe('invalid-policy');
+      expect(backfill.reason).toBe('invalid-policy');
+      expect(signup.outcome).not.toBe('policy-skip');
+      expect(backfill.reason).not.toBe('policy');
+    });
+  });
+
+  it('names the offending value so it is not swallowed — logged and returned', async () => {
+    const error = vi.fn();
+    const res = await reconcileMembership(makeEngine(), 'user-1', {
+      policy: asPolicy('inviteOnly'),
+      resolveTargetOrg: async () => 'org_default',
+      logger: { error },
+    });
+    // Returned, so the diagnosis survives a caller that passed no logger.
+    expect(res.error).toContain(`'inviteOnly'`);
+    expect(res.error).toContain('invite-only'); // the expected vocabulary
+    expect(error).toHaveBeenCalledTimes(1);
+    const [msg, meta] = error.mock.calls[0];
+    expect(msg).toContain(`'inviteOnly'`);
+    expect(meta).toMatchObject({ userId: 'user-1', expected: MEMBERSHIP_POLICIES });
+  });
+
+  it('logs at error, not warn — nothing else looks broken afterwards', async () => {
+    const error = vi.fn();
+    const warn = vi.fn();
+    await backfillMemberships(makeEngine({ users: [{ id: 'u1' }] }), {
+      policy: asPolicy('inviteOnly'),
+      resolveTargetOrg: async () => 'org_default',
+      logger: { error, warn },
+    });
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('still reaches a logger that only has warn', async () => {
+    const warn = vi.fn();
+    await reconcileMembership(makeEngine(), 'user-1', {
+      policy: asPolicy('inviteOnly'),
+      resolveTargetOrg: async () => 'org_default',
+      logger: { warn },
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain(`'inviteOnly'`);
+  });
+
+  it('refuses without a logger at all (the refusal is not a logging side effect)', async () => {
+    const engine = makeEngine();
+    const res = await reconcileMembership(engine, 'user-1', {
+      policy: asPolicy('inviteOnly'),
+      resolveTargetOrg: async () => 'org_default',
+    });
+    expect(res.outcome).toBe('invalid-policy');
+    expect(engine.insert).not.toHaveBeenCalled();
+  });
+
+  it('does not echo a non-string value into the log — typeof only', async () => {
+    const error = vi.fn();
+    const res = await reconcileMembership(makeEngine(), 'user-1', {
+      // A caller that passed the whole config object by mistake; it may carry
+      // fields that have no business in a log line.
+      policy: asPolicy({ membershipPolicy: 'invite-only', adminEmail: 'ops@example.com' }),
+      resolveTargetOrg: async () => 'org_default',
+      logger: { error },
+    });
+    expect(res.outcome).toBe('invalid-policy');
+    expect(res.error).toContain('[object]');
+    expect(error.mock.calls[0][0]).not.toContain('ops@example.com');
+    expect(JSON.stringify(error.mock.calls[0][1])).not.toContain('ops@example.com');
+  });
+
+  it('bounds a long string value', async () => {
+    const error = vi.fn();
+    const res = await reconcileMembership(makeEngine(), 'user-1', {
+      policy: asPolicy('x'.repeat(500)),
+      resolveTargetOrg: async () => 'org_default',
+      logger: { error },
+    });
+    expect(res.error).toContain('(truncated)');
+    expect(res.error!.length).toBeLessThan(200);
+  });
+
+  it('preconditions still win — a missing engine reports skipped, not invalid-policy', async () => {
+    const res = await reconcileMembership(undefined, 'user-1', {
+      policy: asPolicy('inviteOnly'),
+      resolveTargetOrg: async () => 'org_default',
+    });
+    expect(res.outcome).toBe('skipped');
+    const bf = await backfillMemberships(undefined, {
+      policy: asPolicy('inviteOnly'),
+      resolveTargetOrg: async () => 'org_default',
+    });
+    expect(bf.reason).toBe('engine-unavailable');
+  });
+});
+
+/**
+ * [#5205] The guard must not move the ground under the two values that ARE
+ * policies. Asserted as a table over the declared vocabulary, so the behaviour
+ * of every legal value is stated here rather than inferred from a green suite.
+ */
+describe('legal policies are unaffected by the invalid-policy guard (#5205)', () => {
+  const EXPECTED: Record<MembershipPolicy, { signup: string; backfillReason?: string; binds: boolean }> = {
+    auto: { signup: 'bound', backfillReason: undefined, binds: true },
+    'invite-only': { signup: 'policy-skip', backfillReason: 'policy', binds: false },
+  };
+
+  it('covers the whole declared vocabulary', () => {
+    expect(Object.keys(EXPECTED).sort()).toEqual([...MEMBERSHIP_POLICIES].sort());
+  });
+
+  it.each([...MEMBERSHIP_POLICIES])('reconcileMembership(%s) is unchanged', async (policy) => {
+    const engine = makeEngine();
+    const res = await reconcileMembership(engine, 'user-1', {
+      policy,
+      resolveTargetOrg: async () => 'org_default',
+    });
+    expect(res.outcome).toBe(EXPECTED[policy].signup);
+    expect(res.error).toBeUndefined();
+    expect(engine._members).toHaveLength(EXPECTED[policy].binds ? 1 : 0);
+  });
+
+  it.each([...MEMBERSHIP_POLICIES])('backfillMemberships(%s) is unchanged', async (policy) => {
+    const engine = makeEngine({ users: [{ id: 'u1' }] });
+    const res = await backfillMemberships(engine, {
+      policy,
+      resolveTargetOrg: async () => 'org_default',
+    });
+    expect(res.reason).toBe(EXPECTED[policy].backfillReason);
+    expect(res.error).toBeUndefined();
+    expect(res.bound).toBe(EXPECTED[policy].binds ? 1 : 0);
+    expect(engine._members).toHaveLength(EXPECTED[policy].binds ? 1 : 0);
   });
 });
 

--- a/packages/plugins/plugin-auth/src/reconcile-membership.ts
+++ b/packages/plugins/plugin-auth/src/reconcile-membership.ts
@@ -18,12 +18,33 @@
  *     the user — e.g. the cloud's personal-org provisioning — wins, and there
  *     is never a double membership);
  *   - honors the deployment's `membershipPolicy` (`auto` binds; `invite-only`
- *     never auto-binds);
+ *     never auto-binds; anything else is REFUSED, see below);
  *   - binds only to an unambiguous target org (single-org's default org;
  *     `multi` mode returns none — invite / JIT own membership there);
  *   - is idempotent (keyed on the `(organization_id, user_id)` unique index)
  *     and never throws (a failed bind must not fail user creation — the
  *     kernel:ready backfill is the self-healing net).
+ *
+ * ## Both entry points refuse an off-vocabulary policy (#5205)
+ *
+ * `reconcileMembership` and `backfillMemberships` are public exports of
+ * `@objectstack/plugin-auth`, so a JavaScript caller or a host stack can hand
+ * either one a policy the `MembershipPolicy` type would have rejected. They
+ * used to disagree about what that means: the sign-up reconciler tested
+ * `policy === 'invite-only'`, so a typo'd `'inviteOnly'` fell through to the
+ * `auto` branch and **auto-bound anyway** (fail-open — a caller who believed
+ * they had switched auto-binding off got it silently), while the backfill
+ * tested `policy !== 'auto'` and refused (fail-safe). One input, two opposite
+ * postures, and the dangerous one was on the per-sign-up path.
+ *
+ * Both now check {@link isMembershipPolicy} at the entry and return a distinct
+ * `'invalid-policy'` outcome/reason naming the offending value. It is a
+ * separate verdict on purpose rather than a reuse of `policy-skip`: reporting
+ * "skipped by policy" for "your policy is not a policy" sends whoever is
+ * debugging the auto-bind to read the deployment's setting, which is fine, and
+ * find it looking exactly as they left it, which is not. This matches the
+ * posture #5152 took one layer up at the settings boundary — an unrecognised
+ * value is rejected loudly, never coerced to `auto`.
  */
 
 import { authSystemWriteContext } from './auth-actor-attribution.js';
@@ -55,6 +76,12 @@ export type ReconcileOutcome =
   | 'yielded'
   /** `membershipPolicy: 'invite-only'` — auto-bind is off by policy. */
   | 'policy-skip'
+  /**
+   * The policy was not one of {@link MEMBERSHIP_POLICIES} — refused, nothing
+   * bound (#5205). Distinct from `policy-skip`, which means a *valid* policy
+   * said no; this one means the caller's policy value is unusable.
+   */
+  | 'invalid-policy'
   /** No unambiguous target org (multi mode, or single mode not bootstrapped). */
   | 'no-target-org'
   /** An error occurred and was swallowed (never fails user creation). */
@@ -63,7 +90,13 @@ export type ReconcileOutcome =
   | 'skipped';
 
 export interface ReconcileMembershipDeps {
-  /** Deployment membership policy. Default `'auto'` at the call site. */
+  /**
+   * Deployment membership policy. Default `'auto'` at the call site.
+   *
+   * Checked at runtime as well as declared: these functions are exported, so a
+   * JS caller can pass anything. Anything outside {@link MEMBERSHIP_POLICIES}
+   * is refused (`'invalid-policy'`), never coerced to `auto`.
+   */
   policy: MembershipPolicy;
   /**
    * Resolve the organization to bind the user to. Single-org → the default org;
@@ -71,10 +104,56 @@ export interface ReconcileMembershipDeps {
    * `tenancy.defaultOrgId`.
    */
   resolveTargetOrg: () => Promise<string | null>;
-  logger?: { info?: (msg: string, meta?: any) => void; warn?: (msg: string, meta?: any) => void };
+  logger?: {
+    info?: (msg: string, meta?: any) => void;
+    warn?: (msg: string, meta?: any) => void;
+    error?: (msg: string, meta?: any) => void;
+  };
 }
 
 const SYSTEM_CTX = { isSystem: true };
+
+/**
+ * Describe a rejected policy value for whoever reads the log, without trusting
+ * it. The declared vocabulary is two short literals, so echoing a *string*
+ * back is the entire point of the message — it is how the reader sees
+ * `'inviteOnly'` where they expected `'invite-only'`. Anything else is a value
+ * that arrived off the type contract, i.e. arbitrary caller data, and a log
+ * line is the wrong place to find out it was an object carrying user fields:
+ * those report as their `typeof` only. Strings are bounded for the same
+ * reason — a policy is never 64 characters long, so anything longer is not a
+ * typo and does not need to be reproduced in full to be diagnosed.
+ */
+function describePolicy(value: unknown): string {
+  if (typeof value === 'string') {
+    return value.length > 64 ? `'${value.slice(0, 64)}…' (truncated)` : `'${value}'`;
+  }
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+  return `[${typeof value}]`;
+}
+
+/**
+ * Refuse an off-vocabulary policy the same way from both entry points (#5205):
+ * one message, one log level, one returned description.
+ *
+ * `error`, not `warn`, for the reason #5152 gives at the settings boundary —
+ * nothing looks broken afterwards. The bind simply does not happen, and if
+ * this passed quietly the deployment would either keep auto-binding while an
+ * operator believed it had stopped (the old sign-up behaviour) or stop binding
+ * with no stated cause. Falls back to `warn` only because `error` is optional
+ * on the logger shape and a caller passing a two-method logger should still
+ * hear about it; the message is identical either way.
+ */
+function refuseInvalidPolicy(deps: ReconcileMembershipDeps, meta: Record<string, unknown>): string {
+  const described = describePolicy(deps.policy as unknown);
+  const message =
+    `[membership] refusing to bind: membership policy ${described} is not a recognized value ` +
+    `— expected one of: ${MEMBERSHIP_POLICIES.join(', ')}`;
+  const log = deps.logger?.error ?? deps.logger?.warn;
+  log?.(message, { ...meta, policy: described, expected: MEMBERSHIP_POLICIES });
+  return message;
+}
 
 function genMemberId(): string {
   const rand = Math.random().toString(36).slice(2, 10);
@@ -121,9 +200,16 @@ export async function reconcileMembership(
   engine: any,
   userId: string | undefined,
   deps: ReconcileMembershipDeps,
-): Promise<{ outcome: ReconcileOutcome; organizationId?: string }> {
+): Promise<{ outcome: ReconcileOutcome; organizationId?: string; error?: string }> {
   if (!engine || typeof engine.find !== 'function' || typeof engine.insert !== 'function' || !userId) {
     return { outcome: 'skipped' };
+  }
+  // #5205 — before any policy semantics, is this a policy at all? Testing
+  // `=== 'invite-only'` alone let every other value fall through to the `auto`
+  // branch and bind. The check is not dead code: the type says
+  // `MembershipPolicy`, the export surface says a JS caller can say otherwise.
+  if (!isMembershipPolicy(deps.policy)) {
+    return { outcome: 'invalid-policy', error: refuseInvalidPolicy(deps, { userId }) };
   }
   if (deps.policy === 'invite-only') {
     return { outcome: 'policy-skip' };
@@ -170,7 +256,13 @@ export interface BackfillMembershipsResult {
   scanned: number;
   bound: number;
   skipped: number;
-  reason?: 'policy' | 'no-target-org' | 'engine-unavailable';
+  reason?: 'policy' | 'invalid-policy' | 'no-target-org' | 'engine-unavailable';
+  /**
+   * Present with `reason: 'invalid-policy'` — the refusal message, naming the
+   * offending value. Carried on the result, not only logged, so the diagnosis
+   * survives a caller that passed no logger (#5205).
+   */
+  error?: string;
 }
 
 /**
@@ -189,6 +281,12 @@ export async function backfillMemberships(
   const summary: BackfillMembershipsResult = { scanned: 0, bound: 0, skipped: 0 };
   if (!engine || typeof engine.find !== 'function' || typeof engine.insert !== 'function') {
     return { ...summary, reason: 'engine-unavailable' };
+  }
+  // #5205 — same order, same verdict as the sign-up path. This one already
+  // refused an off-vocabulary value, but reported it as `'policy'`, which
+  // reads as "the deployment's policy said no" and hides a caller bug.
+  if (!isMembershipPolicy(deps.policy)) {
+    return { ...summary, reason: 'invalid-policy', error: refuseInvalidPolicy(deps, { pass: 'backfill' }) };
   }
   if (deps.policy !== 'auto') {
     return { ...summary, reason: 'policy' };


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5205

## 问题

`packages/plugins/plugin-auth/src/reconcile-membership.ts` 里，同一个 `policy` 字段被两个函数用**相反的谓词**判断：

```
reconcileMembership:   if (deps.policy === 'invite-only') return { outcome: 'policy-skip' };
backfillMemberships:   if (deps.policy !== 'auto')        return { ...summary, reason: 'policy' };
```

传入词表外的值（拼错的 `'inviteOnly'`、`undefined`、一个对象……）时：

| 函数 | 旧行为 |
|---|---|
| `reconcileMembership`（注册路径，逐个绑定） | 落到 `auto` 分支，**照常自动绑定** —— fail-open |
| `backfillMemberships`（回填路径，批量） | 判为非 `auto`，不绑 —— fail-safe |

危险的是前者：调用方以为自己关掉了自动绑定，实际上没有，日志里也看不出来。

#5152 之后框架自身通路上不可能再出现非法值（两个调用点都走 `AuthManager.getMembershipPolicy()`，返回类型是 `MembershipPolicy`），但 `index.ts` 有 `export * from './reconcile-membership.js'` —— JS 侧调用方或 cloud 宿主可以绕过类型直接传。所以这是「休眠」而不是「不可达」。

## 为什么是形状 2，不是形状 1

维护者 2026-08-04 在 #5205 上裁定进 v17、取形状 2。

**形状 1**（把 `reconcileMembership` 一行收紧成 `!== 'auto'`）确实能消灭方向性错误，且改动最小。但 issue 自己写了它的代价：`policy-skip` 这个 outcome 名对「值非法」这个原因是**撒谎**。它的语义是「一个合法的策略说了不」，拿它报告「你传的这个值根本不是策略」，会把排障的人指向部署设置去看 —— 而那个设置好端端的。少写的那几行，日后要在一次线上排障里连本带利还回来。

**形状 2**（两处入口用 `isMembershipPolicy()` 显式判非法 + 独立的 `'invalid-policy'` + 记 `error`）与 #5152 在 settings 边界上的姿态同源：非法值**响亮拒绝，不静默强转**。#5152 的 `auth-plugin.ts` 对一个词表外的 `OS_AUTH_MEMBERSHIP_POLICY` 就是这么做的（`logger.error` + 忽略 + 报出允许值），本 PR 只是把同一条纪律推到它下游的两个函数里，让这一层不再有第二种姿态。

代价是它改导出的联合类型 —— 正因如此才搭 v17 这班主版本车。

## 契约变更的影响面

| 导出物 | 变更 |
|---|---|
| `ReconcileOutcome` | 新增成员 `'invalid-policy'` |
| `BackfillMembershipsResult['reason']` | 新增成员 `'invalid-policy'` |
| `BackfillMembershipsResult` | 新增可选字段 `error?: string` |
| `reconcileMembership()` 返回值 | 新增可选字段 `error?: string` |
| `ReconcileMembershipDeps['logger']` | 新增可选方法 `error?`（缺省回落到 `warn`） |

对下游是 **minor**（changeset 按 minor 记）。唯一会被顶到的形状，是对这两个联合类型做**穷尽** switch 的消费者（`never` 收尾的 `default`，或 `Record< ReconcileOutcome, T >` 之类的全映射）—— 那种消费者需要补上新成员。

仓内消费者已逐个查过，均不受影响：

- `auth-manager.ts:3728` 忽略返回值（best-effort hook）；
- `admin-user-endpoints.ts:308` 只读 `result.outcome === 'bound'` 与 `result.organizationId`；
- `auth-plugin.ts:887` 只读 `res.bound`；
- `packages/qa/dogfood/test/membership-reconciler.dogfood.test.ts` 只对合法值断言 `'policy-skip'` / `'policy'`，语义未动。

`error` 记的是**哪个值非法**，且不吞原值 —— 同时进日志和返回值（后者是为了让没传 logger 的调用方也拿得到，拒绝本身不是日志的副作用）。策略是封闭词表、值很短，所以**字符串**原样回显（`'inviteOnly'` 与 `'invite-only'` 的区别正是这条消息的全部意义），并在 64 字符处截断；**非字符串**只报 `typeof`（`[object]`），因为那是脱离类型契约到达的任意调用方数据，日志行不是发现它带着用户字段的地方。

## 对抗性验证

新测试对**未修复的源码**（`origin/main` 的 `reconcile-membership.ts`，测试文件为本 PR 版本）真实执行：

```
 FAIL  src/reconcile-membership.test.ts > … > policy = camelCase typo > reconcileMembership refuses — invalid-policy, nothing bound
 FAIL  src/reconcile-membership.test.ts > … > policy = snake_case typo > reconcileMembership refuses — invalid-policy, nothing bound
 FAIL  src/reconcile-membership.test.ts > … > policy = wrong case > reconcileMembership refuses — invalid-policy, nothing bound
 FAIL  src/reconcile-membership.test.ts > … > policy = empty string > reconcileMembership refuses — invalid-policy, nothing bound
 FAIL  src/reconcile-membership.test.ts > … > policy = undefined > reconcileMembership refuses — invalid-policy, nothing bound
 FAIL  src/reconcile-membership.test.ts > … > policy = null > reconcileMembership refuses — invalid-policy, nothing bound
 FAIL  src/reconcile-membership.test.ts > … > policy = boolean > reconcileMembership refuses — invalid-policy, nothing bound
 FAIL  src/reconcile-membership.test.ts > … > policy = object > reconcileMembership refuses — invalid-policy, nothing bound

AssertionError: expected 'bound' to be 'invalid-policy' // Object.is equality
AssertionError: expected 'policy' to be 'invalid-policy' // Object.is equality
AssertionError: expected [ { …(2) } ] to have a length of +0 but got 1

 Test Files  1 failed (1)
      Tests  30 failed | 19 passed (49)
```

`expected 'bound' to be 'invalid-policy'` 与 `to have a length of +0 but got 1` 是今天的 fail-open 被抓现行：一行 `sys_member` 真的写进去了。同一次运行里 **19 passed** —— 既有测试与新加的「合法值行为不变」表全绿，说明红的只有本 PR 要修的那条方向性错误。

修复后同一文件：

```
 Test Files  1 passed (1)
      Tests  49 passed (49)
```

## 测试

- 8 个词表外的值 × 3 条断言（`reconcileMembership` 拒绝 / `backfillMemberships` 拒绝 / 两者同向且都不绑），并显式断言 `outcome !== 'policy-skip'`、`reason !== 'policy'`；
- 拒绝发生在**入口** —— `resolveTargetOrg` 一次都没被调用；
- 非法值被记进日志与返回值；`error` 级而非 `warn`；只有 `warn` 的 logger 也收得到；完全不传 logger 时照样拒绝；
- 非字符串值不把内容打进日志（`[object]`，断言 `ops@example.com` 不出现在消息与 meta 里）；超长字符串截断；
- 前置条件仍然优先：缺 engine 时是 `skipped` / `engine-unavailable`，不是 `invalid-policy`（两个函数的检查顺序保持对称）；
- **合法值逐条不变**：对 `MEMBERSHIP_POLICIES` 表驱动，钉住 `auto` → `bound` / 绑 1 行、`invite-only` → `policy-skip` / `reason: 'policy'` / 绑 0 行，外加一条断言保证这张表覆盖了整个声明词表（以后往词表里加值，这条会先红）。

## 证据边界

- `pnpm --filter @objectstack/plugin-auth` 全量：`Test Files 34 passed (34)` / `Tests 780 passed (780)`；`tsc --noEmit` 退出 0。
- 门禁：`check:engine-double-contract`、`check:adr-anchors`、`check:doc-authoring`、`check:org-identifier`、`check:role-word`、`check:startup-registry-verdict` 全 PASS；改动两文件 eslint 退出 0。
- 下游 `@objectstack/dogfood` 的 `tsc --noEmit`：`membership-reconciler.dogfood.test.ts` 对 `@objectstack/plugin-auth` 的 import **无报错**（该文件唯一的错是第 25 行 `@objectstack/verify` 的 `TS2307`）。该包剩余 181 条错全部是 `TS2307 Cannot find module`，指向本会话未构建、且本任务禁止触碰的兄弟包（`@objectstack/verify`、`plugin-security`、`plugin-audit` …，#5261 正在改），属沙箱构建状态，与本改动无关。**未**跑 dogfood 的运行时测试（要真实 DB）。
- **未**跑仓库全量 test/build（资源纪律：按包 scope）。CI 由 PM 盯。

## 文件面

只碰了 `packages/plugins/plugin-auth/src/reconcile-membership.ts` 及其同名测试，加一个 changeset。`ReconcileOutcome` 的定义与导出都在这一个文件里（`index.ts` 经 `export * from './reconcile-membership.js'` 转出，未改）。未触碰 `auth-manager.ts`、`org-create-posture-gate.test.ts`、`packages/objectql`、`plugin-dev`、`runtime`、`driver-sql`、`cli`、`packages/types/src/env.ts`、`packages/qa/**`、`packages/verify/**`、`content/docs/releases/`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015W6nhsDrz6zWQc8je12a1t


---
_Generated by [Claude Code](https://claude.ai/code/session_015W6nhsDrz6zWQc8je12a1t)_