### PR TITLE
fix(spec): 两条 area 退役处方在 #4722 之后改口径 —— 项级闸门在两棵树都由服务端剥离 (#4749)

### DIFF
--- a/.changeset/area-prescription-both-trees.md
+++ b/.changeset/area-prescription-both-trees.md
@@ -25,8 +25,19 @@ schema 的 unknown-key 报错正文)。它此前写着:
 绑定上下文)。所以「必须永不到达浏览器」的东西写 `requiredPermissions`,不要写 `visible`
 —— 这一条在 #4722 之后反而更容易被误读,因此写进了正文并单独钉了 pin。
 
+同一次改口径也覆盖姊妹处方 `AREA_VISIBLE_RETIRED`(作者写错 `areas[].visible` 时读到的那
+份)。它此前把服务端强制的落点枚举成「on the app itself, or on items of the app's top-level
+`navigation` tree」—— 不是假话,但 #4722 之后这份**枚举**漏了 `areas[].navigation` 的项,
+效果与上面那句相同:一个已经站在 area 内部、本可以就地把闸门写在该 area 项上的作者,被劝去
+重构导航树。现在两处落点都列全。
+
+⚠️ 这条**没有**改变 `visible` 自身的口径:项级 `visible` 依然是 CEL、依然只在浏览器里求值,
+#4722 没有碰这一半。正文里把两者的分工写死 —— `visible` 隐藏的是**已经发出去**的条目,
+`requiredPermissions` 才让条目根本不被发出 —— 因为作者是攥着一个 CEL 表达式走到这条报错前
+的,「就近改写成项级 `visible`」正是此刻最顺手也最危险的那个落点。
+
 退役裁决本身不动:被强制的是 area **内部的项**,area **级**键(`areas[].visible` /
 `areas[].requiredPermissions`,#4651)保持退役,没有复活。
 
-行为零变化 —— 改的是报错正文与它的 pin 断言,以及 `app.zod.ts` 里同一段已随 #4722 过期的
-说明性注释。
+行为零变化 —— 改的是两条报错正文与它们的 pin 断言,以及 `app.zod.ts` 里同一段已随 #4722
+过期的说明性注释。

--- a/.changeset/area-prescription-both-trees.md
+++ b/.changeset/area-prescription-both-trees.md
@@ -1,0 +1,32 @@
+---
+'@objectstack/spec': patch
+---
+
+fix(spec): `areas[].requiredPermissions` 的退役处方改口径 —— 项级闸门在**两棵树**都由服务端剥离(#4749)
+
+`AREA_REQUIRED_PERMISSIONS_RETIRED` 是作者写错 area 级键时唯一能读到的文字(strict
+schema 的 unknown-key 报错正文)。它此前写着:
+
+> Items nested under `areas[]` are gated in the shell only — the server does not
+> walk `areas` — so anything that must never reach the browser belongs in the
+> top-level tree, or in its own app.
+
+这句话在 #4722 之后已经过时。`filterAppForUser` 现在对每一棵 `areas[].navigation`
+跑**同一个** `filterNav`,所以导航**项**上的 `requiredPermissions` / `requiresService`
+在顶层树和 area 内部被同等强制,被闸住的条目(连同它的 `objectName` / `pageName` /
+`componentRef` 目标)根本不会进入 `/meta` 响应体。
+
+方向上这是「过度保守」而非不安全 —— 它劝作者把敏感项挪到顶层树,那仍然可行 —— 但它错了,
+而且错在**说给作者听的**那一份上:一个本可以就地把 `requiredPermissions` 写在 area 内部项
+上的作者,会被这段话劝去重构导航树。
+
+处方正文改后陈述当前事实,并保住 #4722 **没有**改变的那一半非对称性:`visible`(CEL)与
+`requiresObject` 在任何层级**依然只在客户端求值**(服务端跑 CEL 需要读层没有的 `user`
+绑定上下文)。所以「必须永不到达浏览器」的东西写 `requiredPermissions`,不要写 `visible`
+—— 这一条在 #4722 之后反而更容易被误读,因此写进了正文并单独钉了 pin。
+
+退役裁决本身不动:被强制的是 area **内部的项**,area **级**键(`areas[].visible` /
+`areas[].requiredPermissions`,#4651)保持退役,没有复活。
+
+行为零变化 —— 改的是报错正文与它的 pin 断言,以及 `app.zod.ts` 里同一段已随 #4722 过期的
+说明性注释。

--- a/packages/spec/src/ui/app.test.ts
+++ b/packages/spec/src/ui/app.test.ts
@@ -1433,10 +1433,29 @@ describe('unknown keys are rejected, not stripped (#4001 PR B)', () => {
       // The two enforced layers, named.
       expect(msg).toMatch(/on the APP/s);
       expect(msg).toMatch(/navigation ITEM/s);
-      // The honest caveat: the server does not walk areas, so an item gate
-      // INSIDE an area is shell-side only. Without this the prescription would
-      // trade one false belief for a weaker one.
-      expect(msg).toMatch(/shell only|does not walk/is);
+      // #4722 closed the caveat this prescription used to carry ("the server
+      // does not walk `areas`", so an item gate inside an area was shell-side
+      // only). The pin moves to the CORRECTED fact rather than being deleted:
+      // an author who reads a prescription that has simply gone quiet about
+      // `areas[]` concludes the old boundary still holds, which is the same
+      // false belief one step further from the evidence.
+      expect(msg).toMatch(/BOTH trees/s);
+      expect(msg).toMatch(/areas\[\]\.navigation/s);
+      expect(msg).toMatch(/#4722/s);
+      // The asymmetry that SURVIVES #4722 — and the reason this is the layer
+      // an author must reach for: `requiredPermissions` is enforced before the
+      // body ships, `visible` is not evaluated until it is already in the
+      // browser. Dropping this half would trade the old false belief for the
+      // one #4722 makes newly tempting ("areas are gated now, `visible` is
+      // fine").
+      expect(msg).toMatch(/client-side ONLY/s);
+      expect(msg).toMatch(/`visible` \(CEL\)/s);
+      expect(msg).toMatch(/never in `visible`/s);
+      // The retirement itself is untouched: enforcing the items inside an area
+      // is not a revived area-LEVEL gate, and the message must not read as one.
+      expect(msg).toMatch(/not revived/s);
+      // Belt and braces on the specific claim this pin replaced.
+      expect(msg).not.toMatch(/does not walk/i);
     });
 
     it('rejects `areas[].visible` and points at the item-level CEL gate that is evaluated', () => {

--- a/packages/spec/src/ui/app.test.ts
+++ b/packages/spec/src/ui/app.test.ts
@@ -1463,6 +1463,25 @@ describe('unknown keys are rejected, not stripped (#4001 PR B)', () => {
       expect(msg).toMatch(/visible.*removed.*17\.0\.0/s);
       expect(msg).toMatch(/fails open|EVERYONE/s);
       expect(msg).toMatch(/navigation ITEM's `visible`/s);
+      // #4722 also moved where a SERVER-enforced gate may live, and this
+      // prescription's closing enumeration had not followed. It used to name
+      // the top-level tree as the only item-level destination, which sends an
+      // author already standing inside an area off to restructure their
+      // navigation for a gate they can now write in place. Pin the corrected
+      // enumeration rather than merely the absence of the old one.
+      expect(msg).toMatch(/either navigation tree/s);
+      expect(msg).toMatch(/areas\[\]\.navigation/s);
+      expect(msg).toMatch(/#4722/s);
+      // …and do NOT let that drag `visible`'s own verdict along: #4722 changed
+      // nothing about CEL, which is still evaluated in the browser at every
+      // level. That asymmetry is the entire reason this prescription can send a
+      // must-never-ship gate to `requiredPermissions` rather than to an item's
+      // `visible` — the destination it would otherwise be natural to reach for,
+      // since the author arrived here holding a CEL expression.
+      expect(msg).toMatch(/evaluated in the browser/s);
+      expect(msg).toMatch(/navigation ITEM's `visible` takes the same CEL expression/s);
+      // Negative pin on the enumeration this replaced.
+      expect(msg).not.toMatch(/on items of the app's top-level/s);
     });
 
     it('routes the retired gating aliases to the same prescriptions', () => {

--- a/packages/spec/src/ui/app.zod.ts
+++ b/packages/spec/src/ui/app.zod.ts
@@ -686,9 +686,12 @@ const AREA_VISIBLE_RETIRED =
   + 'gate that fails open, which is worse than no gate at all. Delete the key and gate the '
   + 'items INSIDE the area — a navigation ITEM\'s `visible` takes the same CEL expression and '
   + 'IS evaluated per item by the shell. For a gate the SERVER enforces, use '
-  + '`requiredPermissions`: on the app itself, or on items of the app\'s top-level '
-  + '`navigation` tree. Run `os migrate meta --from 16` to rewrite existing sources '
-  + 'automatically.';
+  + '`requiredPermissions` instead: on the app itself, or on the ITEMS of either navigation '
+  + 'tree — the app\'s top-level `navigation` AND every `areas[].navigation`, both stripped '
+  + 'server-side since #4722. The distinction survives at every level: `visible` is CEL '
+  + 'evaluated in the browser, so it hides an entry that has already been sent, while '
+  + '`requiredPermissions` stops that entry from being served at all. Run '
+  + '`os migrate meta --from 16` to rewrite existing sources automatically.';
 
 const AREA_REQUIRED_PERMISSIONS_RETIRED =
   '`areas[].requiredPermissions` was removed in @objectstack/spec 17.0.0 (#4651, ADR-0049) — '

--- a/packages/spec/src/ui/app.zod.ts
+++ b/packages/spec/src/ui/app.zod.ts
@@ -647,13 +647,13 @@ const AREA_ORDER_RETIRED =
  * 17.0.0 (#4651, ADR-0049).
  *
  * These were not ordinary dead keys. They were **fail-open capability gates**:
- * the authoritative server-side filter (`filterAppForUser`,
- * `packages/rest/src/rest-server.ts`) reads the app's `requiredPermissions` and
- * then walks ONLY `item.navigation` — it returns early when that tree is
- * absent and never touches `item.areas` at all — while the client renders every
- * area in the switcher. So an author who wrote `requiredPermissions:
- * ['sales.admin']` on an area got a clean parse, a stored value, and an area
- * visible to everyone.
+ * at the time of the retirement the authoritative server-side filter
+ * (`filterAppForUser`, `packages/rest/src/rest-server.ts`) read the app's
+ * `requiredPermissions` and then walked ONLY `item.navigation` — it returned
+ * early when that tree was absent and never touched `item.areas` at all — while
+ * the client rendered every area in the switcher. So an author who wrote
+ * `requiredPermissions: ['sales.admin']` on an area got a clean parse, a stored
+ * value, and an area visible to everyone.
  *
  * What made them read alive is that the SAME key names are genuinely enforced
  * one level up and one level down: app-level `requiredPermissions` drops the
@@ -668,6 +668,17 @@ const AREA_ORDER_RETIRED =
  * remove its items everywhere? does the server bind `user` for area CEL?), and
  * a retirement PR must not invent an authorization mechanism. Removing a gate
  * that never gated is strictly safer than shipping a major with it in place.
+ *
+ * SINCE #4722 the paragraph above is history on one point, and the prescription
+ * below states the current fact: `filterAppForUser` now runs the same
+ * `filterNav` over every `areas[].navigation`, so an ITEM's
+ * `requiredPermissions` / `requiresService` is enforced server-side in both
+ * trees and a gated entry never ships in the `/meta` body. That closed the
+ * shell-only boundary these prescriptions used to warn about; it did NOT revive
+ * the area-LEVEL keys, which stay retired. `visible` (CEL) and `requiresObject`
+ * remain client-side only at every level — server-side CEL needs a bound `user`
+ * context the read layer does not have. Mirrored in `liveness/app.json`
+ * (`areas.navigation`) and pinned in `packages/rest/src/rest.test.ts`.
  */
 const AREA_VISIBLE_RETIRED =
   '`areas[].visible` was removed in @objectstack/spec 17.0.0 (#4651, ADR-0049) — nothing ever '
@@ -686,10 +697,13 @@ const AREA_REQUIRED_PERMISSIONS_RETIRED =
   + 'gate to a layer that is actually enforced. `requiredPermissions` on the APP is checked '
   + 'server-side (the app is dropped from /meta entirely for a caller who lacks them), and '
   + '`requiredPermissions` / `requiresService` on a navigation ITEM are stripped server-side '
-  + 'from the app\'s top-level `navigation` tree and re-checked in the shell. Items nested '
-  + 'under `areas[]` are gated in the shell only — the server does not walk `areas` — so '
-  + 'anything that must never reach the browser belongs in the top-level tree, or in its own '
-  + 'app. Run `os migrate meta --from 16` to rewrite existing sources automatically.';
+  + 'in BOTH trees — the app\'s top-level `navigation` AND every `areas[].navigation`, through '
+  + 'the same filter since #4722 — then re-checked in the shell, so an item gated inside an '
+  + 'area never reaches the browser either. That enforces the items INSIDE an area; the '
+  + 'area-level key is not revived. Still evaluated client-side ONLY, at every level: '
+  + '`visible` (CEL) and `requiresObject` — so anything that must never reach the browser '
+  + 'goes in `requiredPermissions`, never in `visible`. Run `os migrate meta --from 16` to '
+  + 'rewrite existing sources automatically.';
 
 /**
  * Navigation Area Schema


### PR DESCRIPTION
Fixes #4749

## 前提复核(改之前先证实)

issue 是线索不是规格,两半都在 `origin/main`(`c7406b0`)上核过 —— 引用的行号确实因今日
churn 移位了:

| issue 的说法 | origin/main 实际 | 结论 |
|---|---|---|
| 处方正文 `app.zod.ts:662` 仍写 "the server does not walk `areas`" | 实际在 `app.zod.ts:690` | 成立(行号移位) |
| pin 断言 `app.test.ts:1374` | 实际在 `app.test.ts:1439` | 成立(行号移位) |
| #4722 已让服务端走 `areas[].navigation` | `rest-server.ts:1811` 的 `[#4722] Applies the SAME item gate to every areas[].navigation tree`,实现在 1890 行的 `filterAreas`(复用同一个 `filterNav`) | 成立 |

所以 `premise_still_valid: true`,处方正文把一个**已经关闭**的缺口描述成仍然存在。

## 改了什么(两条处方,一次改完)

### 1. `AREA_REQUIRED_PERMISSIONS_RETIRED` —— issue 点名的那条

原本说:

> Items nested under `areas[]` are gated in the shell only — the server does not walk
> `areas` — so anything that must never reach the browser belongs in the top-level tree,
> or in its own app.

改后陈述当前事实:项级 `requiredPermissions` / `requiresService` 在**两棵树**(顶层
`navigation` 与每一棵 `areas[].navigation`)都由服务端经同一个 filter 剥离(#4722),被闸住
的条目不会进入 `/meta` 响应体。

### 2. `AREA_VISIBLE_RETIRED` —— PM 复核时扩入本 PR 的姊妹条

issue 正文本就把「核对 `AREA_VISIBLE_RETIRED`」列进本单,预判是「大概率不用改」;核对结果
是**需要改**。它收尾句把服务端强制的落点枚举为:

> use `requiredPermissions`: on the app itself, or on items of the app's top-level
> `navigation` tree.

其中没有假话(列出的两层确实被强制),但 #4722 之后这是一份**漏了第三项的枚举**,危害与上面
那句同构:一个已经站在 area 内部、本可以就地把闸门写在该 area 项上的作者,被劝去重构导航树。
现在两处落点都列全。

PM 的裁定理由(记录在案):它与第 1 条同文件、同常量块、同一类缺陷;另开 PR 按同文件串行
规则要等本 PR 合入,为六个词付一整轮;而且留着它 = 本 PR 把一条处方改对、把紧邻的另一条留错
—— 正是下面 JSDoc 那步所依据的同一个自相矛盾。

### 三件刻意保住的事

1. **#4722 没有改变的那一半非对称性**:`visible`(CEL)与 `requiresObject` 在任何层级依然
   只在客户端求值(服务端跑 CEL 需要读层没有的 `user` 绑定上下文)。这在 area 被服务端闸住
   之后**反而更容易被误读**成「现在写 `visible` 也安全了」;在第 2 条里风险更高 —— 作者是攥着
   一个 CEL 表达式走到那条报错前的,「就近改写成项级 `visible`」是此刻最顺手也最危险的落点。
   故两条正文都把分工写死:`visible` 隐藏的是**已经发出去**的条目,`requiredPermissions` 才
   让条目根本不被发出。两条都单独钉了 pin。
2. **退役裁决不动**:被强制的是 area **内部的项**,area **级**键(#4651)保持退役、没有复活
   —— 第 1 条正文里明写 "the area-level key is not revived"。
3. **pin 是换钉不是删钉**(两条同样处理)。断言钉在**改正后的事实**上,并各加一条对旧措辞的
   负向断言。只删旧断言会让一份「对 `areas[]` 闭口不谈」的处方照样通过,而作者读到闭口不谈时
   的默认结论正是旧边界。

措辞蓝本取自 #4722 已改写的 `packages/spec/liveness/app.json` 的 `areas.navigation` note。

### 一处越出「仅处方字符串」的改动(PM 复核已批准)

`app.zod.ts` 里这两个常量正上方的 JSDoc,用**现在时**陈述了同一个已过期的事实
("reads … walks ONLY `item.navigation` … never touches `item.areas` at all")。只改字符串
会让同一段代码自相矛盾。故把该段改为**过去时的退役当时状态**,并补一段记录 #4722。没有动
schema 形状、没有动任何别的键。

## 验证

- `vitest run src/ui/app.test.ts` → 98 passed;全量 `pnpm --filter @objectstack/spec test`
  → **312 files / 8022 tests passed**(两轮改动后各跑一次,均全绿)
- `pnpm --filter @objectstack/spec typecheck` → clean;`eslint` 两个改动文件 → clean
- `check:generated` → **9/9 green**(build 之后一轮全过)。`check:api-surface` 在全新
  worktree 上首轮报红是 AGENTS.md §9 记的 stale-dist 幻影,`build` 后即
  "public API surface + factory signatures unchanged"。**没有生成物因本改动变 stale** ——
  这两段文字只活在 Zod 的 error 字符串里,不投影进任何生成物,所以本 PR 不含重生成的产物。
- **反向验证,两条各做一次,方向都是事前预测的「红」**:
  - 还原第 1 条旧文本 → `AssertionError: expected 'Unrecognized key(s) on this navigatio…' to match /BOTH trees/s`,`Tests 1 failed | 97 skipped`
  - 只还原第 2 条旧文本 → `AssertionError: expected 'Unrecognized key(s) on this navigatio…' to match /either navigation tree/s`,`Tests 1 failed | 97 skipped`
  - 两次还原后复跑均全绿。
- 消费半径扫过:`packages/cli` / `packages/lint` / `packages/rest` 及各 fixture 都没有钉这两段
  措辞的断言。
- `node scripts/check-nul-bytes.mjs` OK,并对三个改动文件做了越出该 gate 的控制字符自扫。

## 仍留在 #5337 的越界发现(**不**在本 PR 修)

`packages/spec/src/migrations/registry.ts` 的 protocol-17 rationale 仍写着 "since the server
does not walk `areas`",并投影进生成的 `docs/protocol-upgrade-guide.md`(升级中的作者正在读
的那份);同一句也留在待发布的 `.changeset/app-area-fail-open-gates-removed.md`。按 PM 复核
裁定留给后续单:它要跑 `gen:upgrade-guide`,且该文档走 os-regen 驱动,不该混进本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTszibd6C8sUCCZnM4VcrL