### PR TITLE
fix(ci): 下游 job 改用显式状态函数,`filter` 失败不再静默跳过七个核心闸门 (#4928)

### DIFF
--- a/.changeset/ci-filter-implicit-success-guard.md
+++ b/.changeset/ci-filter-implicit-success-guard.md
@@ -1,0 +1,24 @@
+---
+---
+
+CI-only: a failed `filter` job no longer skips all seven core gates while branch
+protection reports green. Releases nothing.
+
+`ci.yml`'s downstream jobs were guarded by `if: needs.filter.outputs.core ==
+'true'`, which names no status function — so GitHub wrapped it in an implicit
+`success()`. Any `filter` failure (checkout flake, a `dorny/paths-filter` fault,
+the 10-minute timeout) skipped `test` / `temporal-conformance` / `dogfood` /
+`dogfood-verify` / `build-core` / `build-docs` / `console-pin` at once, and a
+skipped required check counts as a pass: zero tests ran, nothing went red, the
+PR was mergeable. All seven now read `if: ${{ !cancelled() &&
+needs.filter.outputs.<name> != 'false' }}` — skip only when the filter
+EXPLICITLY said false — which is the same "when in doubt, run everything"
+trade-off the `|| 'true'` on the filter's own outputs already made.
+
+`test-gate` and `dogfood-gate` additionally take `filter` into `needs` and
+refuse to accept a `skipped` leg when `filter` did not succeed, so the invariant
+is asserted rather than merely arranged. `cancelled` keeps passing both gates
+(#3668's run-lifecycle reasoning) and no other state changes behavior.
+
+Third sighting of this GitHub semantic; the other two were `release.yml`'s
+publish-integrity guard and its `docker` job (#4900).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,37 @@ jobs:
       docs: ${{ steps.changes.outputs.docs || 'true' }}
       core: ${{ steps.changes.outputs.core || 'true' }}
       console: ${{ steps.changes.outputs.console || 'true' }}
+      # ── THE FILTER CONTRACT, both halves (#4928) ──────────────────────────
+      #
+      # Half 1 is the `|| 'true'` above: when in doubt, RUN EVERYTHING. It
+      # covers a missing output VALUE.
+      #
+      # Half 2 is every downstream `if:` in this file, and it used to be
+      # missing. GitHub wraps an `if:` that names no status function in an
+      # IMPLICIT success(), so the original `if: needs.filter.outputs.core ==
+      # 'true'` had TWO independent paths to "skip" when this job DIED
+      # (checkout flake, a dorny/paths-filter fault, the 10-minute timeout):
+      # the implicit success() is false, and the output is no longer a
+      # trustworthy 'true'. Both roads led to skipping test / dogfood /
+      # build-core — and skipped counts as SUCCESS in branch protection, so a
+      # single flake here produced a fully green, zero-test-run, mergeable PR
+      # with no red signal anywhere.
+      #
+      # So every downstream job now spells the contract as "skip only when the
+      # filter EXPLICITLY said false":
+      #
+      #     if: ${{ !cancelled() && needs.filter.outputs.<name> != 'false' }}
+      #
+      # `!cancelled()` displaces the implicit success() (a genuine run-level
+      # cancellation still skips — #3668's lifecycle reasoning); `!= 'false'`
+      # makes the empty string mean "run", exactly like `|| 'true'` does. This
+      # is deliberately robust to BOTH readings of what a failed job's outputs
+      # are — null/empty or the `|| 'true'` fallback — because `'' != 'false'`
+      # and `'true' != 'false'` are both true. The old form was broken under
+      # both, because the implicit success() dominates either way.
+      #
+      # Third occurrence of this GitHub semantic in one audit; the other two
+      # were release.yml's publish-integrity guard and its docker job (#4900).
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -94,7 +125,9 @@ jobs:
     # (the #3622 lesson; see dogfood-gate).
     name: Test Core (${{ matrix.shard }}/3)
     needs: filter
-    if: needs.filter.outputs.core == 'true'
+    # "Skip only when the filter EXPLICITLY said no core paths changed" — see
+    # THE FILTER CONTRACT on the filter job's outputs (#4928).
+    if: ${{ !cancelled() && needs.filter.outputs.core != 'false' }}
     runs-on: ubuntu-latest
     # Backstop only — the stall guard on the test steps is the primary
     # detector for a #4250-style hang and fires well before this. 30 min is
@@ -277,7 +310,7 @@ jobs:
     # dogfood-gate for why `cancelled` passes and why this must not be
     # `if: !cancelled()` on the job.
     name: Test Core
-    needs: test
+    needs: [test, filter]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -287,7 +320,29 @@ jobs:
       - name: Verify test shard results
         run: |
           result="${{ needs.test.result }}"
-          echo "test matrix aggregate result: $result"
+          filter_result="${{ needs.filter.result }}"
+          echo "test matrix aggregate result: $result (filter job: $filter_result)"
+          # `skipped` passes this gate, but only when `filter` is the thing that
+          # decided it. `skipped` alone cannot tell "the path filter said no
+          # core paths changed" apart from "the path filter itself exploded and
+          # took every downstream job with it" — #4928, where the second case
+          # published a green Test Core over zero test runs. The `if:` on the
+          # `test` job above now makes a filter failure RUN the suite rather
+          # than skip it, so this branch should be unreachable; it is kept as
+          # the standing assertion of that invariant, because the failure mode
+          # it guards is silent and the `if:` is one careless edit from coming
+          # back. `filter` is in `needs` for exactly this read.
+          #
+          # `cancelled` on either side stays a pass, for #3668's reason spelled
+          # out in dogfood-gate below: cancellation is a run-lifecycle state
+          # (cancel-in-progress supersession), not a verdict, and failing here
+          # would paint a false red on the superseded SHA.
+          if [ "$result" = "skipped" ] \
+             && [ "$filter_result" != "success" ] \
+             && [ "$filter_result" != "cancelled" ]; then
+            echo "::error::Test Core shards were skipped while the filter job did not succeed (filter result: $filter_result). Refusing to report a pass over zero test runs — see #4928."
+            exit 1
+          fi
           case "$result" in
             success|skipped|cancelled) echo "Test Core gate satisfied ($result)." ;;
             *) echo "::error::Test Core shards did not pass (aggregate result: $result)"; exit 1 ;;
@@ -322,7 +377,8 @@ jobs:
   temporal-conformance:
     name: Temporal Conformance (live PG + MySQL)
     needs: filter
-    if: needs.filter.outputs.core == 'true'
+    # See THE FILTER CONTRACT on the filter job's outputs (#4928).
+    if: ${{ !cancelled() && needs.filter.outputs.core != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -510,7 +566,8 @@ jobs:
     # dogfood-gate job below — the shard count can change without touching it.
     name: Dogfood Regression Gate (${{ matrix.shard }}/3)
     needs: filter
-    if: needs.filter.outputs.core == 'true'
+    # See THE FILTER CONTRACT on the filter job's outputs (#4928).
+    if: ${{ !cancelled() && needs.filter.outputs.core != 'false' }}
     runs-on: ubuntu-latest
     # Backstop only — the stall guard on the test step is the primary detector
     # for a #4250-style hang (see Test Core). 30 min is ~6× a shard (~5 min;
@@ -639,7 +696,8 @@ jobs:
   dogfood-verify:
     name: Dogfood Verify CLI
     needs: filter
-    if: needs.filter.outputs.core == 'true'
+    # See THE FILTER CONTRACT on the filter job's outputs (#4928).
+    if: ${{ !cancelled() && needs.filter.outputs.core != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -727,9 +785,11 @@ jobs:
     # the split.
     #
     # `if: always()` + result inspection so a legitimately skipped matrix (the
-    # `filter` job says no core paths changed) still satisfies the gate.
+    # `filter` job says no core paths changed) still satisfies the gate —
+    # LEGITIMATELY being the operative word since #4928: `filter` must have
+    # concluded success (or the run been cancelled) for a skip to count.
     name: Dogfood Regression Gate
-    needs: [dogfood, dogfood-verify]
+    needs: [dogfood, dogfood-verify, filter]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -755,10 +815,27 @@ jobs:
           # #3622 merge-deadlock all over again.
           verify_result="${{ needs['dogfood-verify'].result }}"
           echo "dogfood-verify result: $verify_result"
+          # `skipped` is only a legitimate pass when the `filter` job is what
+          # decided it — the same #4928 hole test-gate documents above. A leg
+          # that is skipped while `filter` FAILED means the regression suite
+          # never ran and nothing anywhere is red. The `if:` conditions on
+          # dogfood / dogfood-verify make that unreachable today; this is the
+          # standing assertion that keeps it so. `cancelled` on `filter` still
+          # passes, same lifecycle reasoning as the paragraph above.
+          filter_result="${{ needs.filter.result }}"
+          echo "filter job result: $filter_result"
           fail=0
           for r in "dogfood:$result" "dogfood-verify:$verify_result"; do
             case "${r#*:}" in
-              success|skipped|cancelled) echo "Gate leg ${r%%:*} satisfied (${r#*:})." ;;
+              skipped)
+                if [ "$filter_result" != "success" ] && [ "$filter_result" != "cancelled" ]; then
+                  echo "::error::Gate leg ${r%%:*} was skipped while the filter job did not succeed (filter result: $filter_result). Refusing to report a pass over zero runs — see #4928."
+                  fail=1
+                else
+                  echo "Gate leg ${r%%:*} satisfied (skipped by filter)."
+                fi
+                ;;
+              success|cancelled) echo "Gate leg ${r%%:*} satisfied (${r#*:})." ;;
               *) echo "::error::Gate leg ${r%%:*} did not pass (result: ${r#*:})"; fail=1 ;;
             esac
           done
@@ -767,7 +844,11 @@ jobs:
   build-core:
     name: Build Core
     needs: filter
-    if: needs.filter.outputs.core == 'true'
+    # See THE FILTER CONTRACT on the filter job's outputs (#4928). No
+    # aggregation gate stands behind this job — its own name IS the required
+    # context — so this `if:` is the only thing between a filter flake and a
+    # green "Build Core" that built nothing.
+    if: ${{ !cancelled() && needs.filter.outputs.core != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -914,7 +995,9 @@ jobs:
   build-docs:
     name: Build Docs
     needs: filter
-    if: needs.filter.outputs.docs == 'true'
+    # See THE FILTER CONTRACT on the filter job's outputs (#4928). `docs`, not
+    # `core` — each job keeps its own filter output.
+    if: ${{ !cancelled() && needs.filter.outputs.docs != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -1000,7 +1083,9 @@ jobs:
   console-pin:
     name: Console Pin Gate
     needs: filter
-    if: needs.filter.outputs.console == 'true'
+    # See THE FILTER CONTRACT on the filter job's outputs (#4928). `console`,
+    # not `core` — each job keeps its own filter output.
+    if: ${{ !cancelled() && needs.filter.outputs.console != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:


### PR DESCRIPTION
Fixes #4928

## 改了什么

`ci.yml` 的 7 个下游 job 原本都是 `if: needs.filter.outputs.core == 'true'` 这个形状。`if:` 里不出现状态函数时,GitHub 会隐式包一层 `success()`,于是 `filter` 一旦失败(checkout 抖动、`dorny/paths-filter` 故障、10 分钟超时),七个 job 会被一起跳过 —— 而 skipped 在分支保护里算通过。结果是零测试运行、全绿可合、没有任何红色信号。

七处统一改成「只有过滤器**明确说 false** 才跳」,每个 job 保留自己的输出名:

| job | 输出名 | 新条件 |
|:--|:--|:--|
| `test` | `core` | `!cancelled() && needs.filter.outputs.core != 'false'` |
| `temporal-conformance` | `core` | 同上 |
| `dogfood` | `core` | 同上 |
| `dogfood-verify` | `core` | 同上 |
| `build-core` | `core` | 同上 |
| `build-docs` | `docs` | `... needs.filter.outputs.docs != 'false'` |
| `console-pin` | `console` | `... needs.filter.outputs.console != 'false'` |

这与 `filter` 自身 outputs 上 `|| 'true'` 的取舍完全一致 —— 存疑就全跑。作者意图本来就写在代码里了,只是那半只覆盖「输出值缺失」,没覆盖「job 整体失败」。

## 真值表:只有一个状态改变了行为

`filter` 的每种结局,旧条件 vs 新条件(模拟脚本按 GitHub 文档语义实现,两种「失败 job 的 outputs 是什么」的读法都跑了):

| 状态 | `outputs.core` | 旧 | 新 |
|:--|:--|:--|:--|
| S1 `filter` 成功,核心路径有改动 | `'true'` | RUN | RUN |
| S2 `filter` 成功,核心路径没改动 | `'false'` | SKIP | SKIP |
| **S3 `filter` 失败(本 issue)** | `''` 或 `'true'` | **SKIP** | **RUN** |
| S4 run 被取消(supersession) | `''` | SKIP | SKIP |
| S5 merge_group(过滤步骤被跳过) | `'true'` | RUN | RUN |

**只有 S3 变了**,其余四个状态逐字节同行为 —— 这是共享基础设施改动该有的爆炸半径。

S3 那一行同时说明了为什么这个写法是稳的:「失败 job 的 outputs」有两种读法(null/空串,或者 `|| 'true'` 照常渲染),新条件在**两种读法下都跑**(`'' != 'false'` 与 `'true' != 'false'` 都为真);而旧条件在**两种读法下都跳**,因为隐式 `success()` 压过一切。修法不依赖于这个语义细节的判定结果。

`!cancelled()` 只排挤隐式 `success()`,不改变取消语义:真正的 run 级取消(`cancel-in-progress`)仍然跳过,即 #3668 的 run-lifecycle 论证原样保留。超时的 job 结论是 `failure` 而非 `cancelled`,所以 issue 点名的第三种失败模式也被 S3 覆盖。

repo 内已有同形状的生产先例:`release.yml:342` 的 `docker` job 正是靠 `!cancelled() && needs.release.outputs.published == 'true'` 在上游 job 失败后仍然执行(#4900)。

## 另一半:聚合闸门

issue 自己的分析指出,`case "$result" in success|skipped|cancelled)` 分不清「路径过滤器说没碰核心代码」和「过滤器自己炸了」。只修 `if:` 会把这半个洞留着。

`test-gate` 与 `dogfood-gate` 因此把 `filter` 纳入 `needs`,并在某条腿是 `skipped` 而 `filter` **未成功**时判红。这条分支在新 `if:` 下不可达 —— 留作**不变量的常驻断言**,因为它守的失败模式是静默的,而那七行 `if:` 距离被人手滑改回去只有一次编辑。`cancelled` 两侧仍然放行,理由与 `dogfood-gate` 里已有的那段一致。

`build-core` / `build-docs` / `console-pin` / `temporal-conformance` 背后没有聚合闸门(它们自己的 name 就是必需检查),所以对这四个来说 `if:` 就是全部的修复。

## 验证

CI 配置没法靠跑本地测试套件证明,所以做了三件能真做的:

**1. `actionlint` 1.7.7,改前改后都零发现**

```
### BASELINE (origin/main ci.yml) ###   baseline exit=0
### CHANGED (this branch)      ###   changed  exit=0
```

绿色不是空转 —— 反向对照:故意把 `docs` 拼成 `doc`、把 `test-gate` 的 `needs` 去掉 `filter`,actionlint 立刻两条都点名:

```
ci.yml:321:67: property "filter" is not defined in object type {test: {outputs: {}; result: string}} [expression]
ci.yml:998:29: property "doc" is not defined in object type {console: string; core: string; docs: string} [expression]
negative-control exit=1
```

也就是说它确实在逐条类型检查这些表达式:七处 `if:` 引用的输出名真的存在于 `filter` 的 outputs 上,两个闸门的 `needs.filter.result` 真的有 `needs:` 撑着。

**2. YAML 解析 + job 图**

`python3 yaml.safe_load` 通过,10 个 job 全部还在,`needs` / `if` 逐条 dump 核对,无环。

**3. 两个闸门的 shell 脚本按真实结果状态跑遍**

从 YAML 里抽出 `run:` 原文,替换表达式后交给真 bash 执行(不是重写一份等价逻辑)。`test-gate` 跑了 4×4 全交叉:

```
test.result  filter.result  exit
skipped      success        0      Test Core gate satisfied (skipped).
skipped      failure        1      ::error::Test Core shards were skipped while the filter job did not succeed …
skipped      cancelled      0      Test Core gate satisfied (skipped).
cancelled    failure        0      Test Core gate satisfied (cancelled).
failure      success        1      ::error::Test Core shards did not pass (aggregate result: failure)
```

`dogfood-gate` 同样,并确认它不会短路 —— 一腿 pass 一腿 error 时两行都打出来且整体 exit 1。

其余门禁:`check-nul-bytes` OK(5379 个文件),`check-changeset-fixed` OK,`check-changeset-no-major` exit 0,控制字符自查 `grep -naP` 零命中。

## changeset

CI-only,不发布任何包,所以用了仓库既有的**空 frontmatter** 写法(与 `ci-cache-tier1-optimizations.md` / `agents-releases-freeze-merge-queue.md` 同款)—— 这是 `Check Changeset` 明确认可的「本 PR 不发布任何东西」声明,门禁照常绿。

## 并发核查

Operational note 8:重跑 `git log --oneline origin/main -- .github/workflows/ci.yml`,最新仍是认领时那个 `b8503183c`(与本单无关),期间无人改动 `ci.yml`,不存在静默 revert 的风险。

## 派生

`#4928` 正文提到的「静态扫出来」那条规则拆成了 #5343 单独立单,没有塞进本 PR:落地它需要处理 `publish-smoke.yml:98` 这个唯一存量违规,而那里的 `resolve` job 没有 `|| 'true'` 兜底、`ref` 也由它算出,「存疑就全跑」会导致 checkout 落到错的 ref 跑一趟 45 分钟的 job —— 属于那个 workflow 自己的取舍,不该由本 PR 顺手拍板。#5343 里写了完整审计表和验收条件(含「输入缺失必须大声失败」的 #4690 约束)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTszibd6C8sUCCZnM4VcrL

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTszibd6C8sUCCZnM4VcrL)_