### PR TITLE
fix(service-analytics): `where` 为 FilterArray 时下沉而不是静默丢弃(第五道门,#5334)

### DIFF
--- a/.changeset/analytics-where-filter-array-lowered.md
+++ b/.changeset/analytics-where-filter-array-lowered.md
@@ -1,0 +1,39 @@
+---
+"@objectstack/service-analytics": patch
+---
+
+fix(service-analytics): a `where` written as a `FilterArray` is lowered instead of silently dropped (#5334)
+
+**Observable behaviour change.** An analytics query whose `where` arrived as an
+ARRAY had its filter **deleted**: `normalizeAnalyticsFilterTree` answered every
+array with `return null`, so no predicate was compiled, no error was raised, and
+the widget charted the **entire dataset**. The compiled SQL stayed perfectly
+valid — just broader than the author asked for — which is why it was invisible
+to every test that asserts a SQL string. The issue's own measurement:
+`generateSql({cube:'deals', measures:['total'], dimensions:['id'], where:
+[['stage','=','won']]})` emitted `SELECT id AS "id", COUNT(*) AS "total" FROM
+"deal" GROUP BY id` with an empty `params`. It now emits the bound `WHERE` and
+returns the two won deals.
+
+`FilterArray` (`['stage','=','won']`, `['and', […], […]]`, `[[…], […]]`) is
+INPUT-ONLY authoring sugar (#5285), and #5158's ruling C says every door into
+the runtime lowers it through the single `parseFilterAST` sink before anything
+downstream sees a filter. #5329 closed ObjectQL's six entry points that way and
+deleted the four drivers' private array dialects. Analytics is the **fifth
+door**: it compiles `where` itself — to SQL (`NativeSQLStrategy`) or to a
+`FilterCondition` for the engine (`ObjectQLStrategy`) — so nothing upstream
+lowers for it. It now gives the same three answers the engine door gives:
+
+- `[]` — "no filter", not a failed filter: no predicate, no error (unchanged).
+- A well-formed `FilterArray` — **lowered** through `parseFilterAST`, so both
+  spellings of one filter select the same rows on both strategies.
+- Any other non-empty array — **refused** with `INVALID_FILTER` / 400
+  (ADR-0112), the envelope the drivers' `filterArrayReachedDriverError` uses.
+  This is where the undeclared INFIX form (`[condA, 'or', condB]`) lands, and
+  where a list of `FilterCondition` objects (`[{stage:'won'}]`) lands — neither
+  is a `FilterArray`, `parseFilterAST` has no lowering for either, and dropping
+  them is what returned the unfiltered dataset.
+
+Lowering rather than refusing keeps one dashboard's metadata meaning one thing:
+the same `where` on a plain `find()` already lowers at the engine door, so
+refusing it here would have forked the product by which face read the metadata.

--- a/packages/services/service-analytics/src/__tests__/filter-array-lowering.test.ts
+++ b/packages/services/service-analytics/src/__tests__/filter-array-lowering.test.ts
@@ -1,0 +1,555 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#5334] The analytics door for a `where` written as a `FilterArray`.
+ *
+ * `FilterArray` (`['stage', '=', 'won']`, `['and', […], […]]`, `[[…], […]]`) is
+ * INPUT-ONLY authoring sugar (#5285); `where` is a `FilterCondition`. #5158's
+ * ruling C says every door LOWERS the sugar through the one `parseFilterAST`
+ * sink, and #5329 did that for ObjectQL's six entry points while deleting the
+ * four drivers' private array dialects.
+ *
+ * Analytics compiles `where` ITSELF — to SQL (`NativeSQLStrategy`) or to a
+ * `FilterCondition` for the engine (`ObjectQLStrategy`) — so no upstream door
+ * lowers for it, and `normalizeAnalyticsFilterTree` answered an array with
+ * `return null`: the whole `where` vanished and the chart was drawn over the
+ * ENTIRE dataset. This file pins the three arrivals the engine door gives,
+ * as ROW RESULTS on a real SQLite (`sql.js`) rather than as SQL strings — a
+ * dropped predicate leaves the SQL perfectly valid, which is exactly why the
+ * defect survived every string assertion in this package.
+ *
+ * ## The issue's own repro, and why it lands in the refusal arm
+ *
+ * #5334's body reproduces the drop with `where: [{ stage: 'won' }]`. That
+ * literal is NOT a `FilterArray`: `FilterArraySchema`'s list arm is
+ * `z.array(FilterArraySchema).min(1)`, so a list's elements must themselves be
+ * filter ARRAYS — `isFilterAST([{stage:'won'}])` is `false` and
+ * `parseFilterAST` returns `undefined` for it. It is therefore "some other
+ * non-empty array" and takes the third answer (loud refusal), the same answer
+ * `engine.find('deal', {where: [{stage:'won'}]})` has given since #5329. The
+ * lowerable spelling of the same intent is `[['stage','=','won']]`, pinned
+ * below with the WHERE clause and the bound value the issue asked for.
+ *
+ * ## Why `sql.js` and not `better-sqlite3`
+ *
+ * Same reason as its neighbours (`native-sql-filter-logic-conformance`): the
+ * native binding is loadable only by the exact Node ABI it was built for and
+ * aborts the vitest worker on CI's Node, taking the file's cases silently with
+ * it. `sql.js` is the pure-WASM engine `driver-sql` itself falls back to.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Cube, FilterCondition } from '@objectstack/spec/data';
+import type { AnalyticsQuery, StrategyContext } from '@objectstack/spec/contracts';
+
+import { NativeSQLStrategy } from '../strategies/native-sql-strategy.js';
+import { ObjectQLStrategy } from '../strategies/objectql-strategy.js';
+
+/** The fixture, shared by the SQL path (as a table) and the engine path (as rows). */
+interface DealRow {
+  id: string;
+  stage: string;
+  owner: string;
+  amount: number;
+  closed_at: string | null;
+}
+
+const DEALS: DealRow[] = [
+  { id: 'd1', stage: 'won', owner: 'u1', amount: 10, closed_at: '2026-01-01' },
+  { id: 'd2', stage: 'won', owner: 'u2', amount: 20, closed_at: null },
+  { id: 'd3', stage: 'lost', owner: 'u1', amount: 30, closed_at: '2026-02-01' },
+  { id: 'd4', stage: 'open', owner: 'u1', amount: 40, closed_at: null },
+];
+
+const CUBE: Cube = {
+  name: 'deals',
+  title: 'Deals',
+  sql: 'deal',
+  measures: { total: { name: 'total', label: 'Total', type: 'count', sql: '*' } },
+  dimensions: Object.fromEntries(
+    ['id', 'stage', 'owner', 'amount', 'closed_at'].map((n) => [
+      n,
+      { name: n, label: n, type: n === 'amount' ? 'number' : 'string', sql: n },
+    ]),
+  ),
+  public: false,
+} as unknown as Cube;
+
+/** Point sql.js at the `.wasm` shipped inside its own package (Node-safe). */
+async function locateWasm(): Promise<((file: string) => string) | undefined> {
+  try {
+    const { createRequire } = await import('node:module');
+    const require = createRequire(import.meta.url);
+    const pkgJsonPath = require.resolve('sql.js/package.json');
+    const { dirname, join } = await import('node:path');
+    const dir = dirname(pkgJsonPath);
+    return (file: string) => join(dir, 'dist', file);
+  } catch {
+    return undefined;
+  }
+}
+
+/** The refused-filter envelope every sibling filter refusal speaks (ADR-0112). */
+interface FilterRefusal extends Error {
+  code?: string;
+  status?: number;
+}
+
+/** Run `fn`, requiring it to REFUSE — returns the error so its envelope can be read. */
+async function refusalOf(fn: () => Promise<unknown>): Promise<FilterRefusal> {
+  try {
+    await fn();
+  } catch (e) {
+    return e as FilterRefusal;
+  }
+  throw new Error('expected the filter to be refused, but the query ran');
+}
+
+/**
+ * The equivalence table: one intent, spelled as the canonical `FilterCondition`
+ * object and as the `FilterArray` sugar, with the rows it must select.
+ *
+ * "FilterArray is authoring sugar" is a claim about ROWS — the two spellings
+ * must select the same records, not merely both run — so every case carries an
+ * explicit expectation as well. A table that only compared the two spellings
+ * would pass just as happily if both returned the whole fixture, which is the
+ * defect itself.
+ */
+const EQUIVALENT_SPELLINGS: Array<{
+  name: string;
+  object: FilterCondition;
+  array: unknown[];
+  expected: string[];
+  /** Ids expected once the `owner = 'u1'` read scope is ANDed in. */
+  scoped: string[];
+}> = [
+  {
+    name: 'equality — the issue\'s own filter, in its lowerable spelling',
+    object: { stage: 'won' },
+    array: [['stage', '=', 'won']],
+    expected: ['d1', 'd2'],
+    scoped: ['d1'],
+  },
+  {
+    name: 'a bare comparison node, not wrapped in a list',
+    object: { stage: 'won' },
+    array: ['stage', '=', 'won'],
+    expected: ['d1', 'd2'],
+    scoped: ['d1'],
+  },
+  {
+    name: 'inequality',
+    object: { stage: { $ne: 'won' } },
+    array: ['stage', '!=', 'won'],
+    expected: ['d3', 'd4'],
+    scoped: ['d3', 'd4'],
+  },
+  {
+    name: 'ordered comparison',
+    object: { amount: { $gt: 15 } },
+    array: ['amount', '>', 15],
+    expected: ['d2', 'd3', 'd4'],
+    scoped: ['d3', 'd4'],
+  },
+  {
+    name: 'prefix AND group',
+    object: { $and: [{ stage: 'won' }, { owner: 'u1' }] },
+    array: ['and', ['stage', '=', 'won'], ['owner', '=', 'u1']],
+    expected: ['d1'],
+    scoped: ['d1'],
+  },
+  {
+    name: 'prefix OR group — the disjunction a flat array could never carry',
+    object: { $or: [{ stage: 'won' }, { stage: 'lost' }] },
+    array: ['or', ['stage', '=', 'won'], ['stage', '=', 'lost']],
+    expected: ['d1', 'd2', 'd3'],
+    scoped: ['d1', 'd3'],
+  },
+  {
+    name: 'legacy flat list — implicit AND',
+    object: { $and: [{ stage: 'won' }, { owner: 'u2' }] },
+    array: [['stage', '=', 'won'], ['owner', '=', 'u2']],
+    expected: ['d2'],
+    scoped: [],
+  },
+  {
+    name: 'set membership',
+    object: { stage: { $in: ['won', 'lost'] } },
+    array: ['stage', 'in', ['won', 'lost']],
+    expected: ['d1', 'd2', 'd3'],
+    scoped: ['d1', 'd3'],
+  },
+  {
+    name: 'null predicate — two-element node, direction from the operator name',
+    object: { closed_at: { $null: true } },
+    array: ['closed_at', 'is_null'],
+    expected: ['d2', 'd4'],
+    scoped: ['d4'],
+  },
+  {
+    name: 'not-null predicate',
+    object: { closed_at: { $null: false } },
+    array: ['closed_at', 'is_not_null'],
+    expected: ['d1', 'd3'],
+    scoped: ['d1', 'd3'],
+  },
+  {
+    // #5325 crossing: the lowered `{$in: []}` is the boolean CONSTANT FALSE,
+    // not an absent predicate. Were the lowering to land in the pre-#5325 tree
+    // it would have emitted no clause at all and charted every row.
+    name: 'empty set membership — the boolean constant FALSE, not "no filter"',
+    object: { stage: { $in: [] } },
+    array: ['stage', 'in', []],
+    expected: [],
+    scoped: [],
+  },
+  {
+    name: 'range — `between` lowers to its two bounds on both spellings',
+    object: { amount: { $between: [15, 35] } },
+    array: ['amount', 'between', [15, 35]],
+    expected: ['d2', 'd3'],
+    scoped: ['d3'],
+  },
+  {
+    name: 'nested group — OR of an AND',
+    object: {
+      $or: [{ $and: [{ stage: 'won' }, { owner: 'u1' }] }, { stage: 'lost' }],
+    },
+    array: ['or', ['and', ['stage', '=', 'won'], ['owner', '=', 'u1']], ['stage', '=', 'lost']],
+    expected: ['d1', 'd3'],
+    scoped: ['d1', 'd3'],
+  },
+];
+
+/** The arrays that CANNOT be lowered — every one of them silently vanished before. */
+const UNLOWERABLE: Array<{ name: string; where: unknown[]; matches: RegExp }> = [
+  {
+    // #5334's own repro literal. A list's elements must be filter ARRAYS.
+    name: 'a list of FilterCondition OBJECTS — the shape #5334 reproduced with',
+    where: [{ stage: 'won' }],
+    matches: /is not a filter/,
+  },
+  {
+    // The dialect four drivers used to compile and no schema ever declared.
+    name: 'the INFIX join form',
+    where: [['stage', '=', 'won'], 'or', ['stage', '=', 'lost']],
+    matches: /Infix joins .* NOT one of the shapes/s,
+  },
+  {
+    name: 'a comparison whose operator is outside the AST vocabulary',
+    where: ['stage', 'sounds_like', 'won'],
+    matches: /is not a filter/,
+  },
+  {
+    name: 'a logical node with nothing to join',
+    where: ['and'],
+    matches: /is not a filter/,
+  },
+  {
+    name: 'elements that are neither keyword nor condition',
+    where: [42],
+    matches: /is not a filter/,
+  },
+];
+
+// ── The raw-SQL door ─────────────────────────────────────────────────────────
+
+describe('[#5334] NativeSQLStrategy — a `where` FilterArray is lowered, not dropped', () => {
+  let db: any;
+  let ctx: StrategyContext;
+  let scopedCtx: StrategyContext;
+
+  beforeAll(async () => {
+    const mod: any = await import('sql.js');
+    const initSqlJs = mod.default ?? mod;
+    const locateFile = await locateWasm();
+    const SQL = await initSqlJs(locateFile ? { locateFile } : undefined);
+
+    db = new SQL.Database();
+    db.run(`
+      CREATE TABLE "deal" (
+        "id" TEXT PRIMARY KEY,
+        "stage" TEXT,
+        "owner" TEXT,
+        "amount" INTEGER,
+        "closed_at" TEXT
+      );
+    `);
+    const insert = db.prepare(
+      `INSERT INTO "deal" ("id","stage","owner","amount","closed_at") VALUES (?,?,?,?,?)`,
+    );
+    for (const r of DEALS) insert.run([r.id, r.stage, r.owner, r.amount, r.closed_at]);
+    insert.free();
+
+    const base = {
+      getCube: (name: string) => (name === 'deals' ? CUBE : undefined),
+      queryCapabilities: () => ({ nativeSql: true, objectqlAggregate: false, inMemory: false }),
+      // The strategy binds `$1`-style placeholders in ascending order, each
+      // pushed immediately before it is referenced, so a positional rewrite to
+      // SQLite's `?` preserves the pairing.
+      executeRawSql: async (_object: string, sql: string, params: unknown[]) => {
+        const stmt = db.prepare(sql.replace(/\$\d+/g, '?'));
+        stmt.bind(params as any[]);
+        const out: Record<string, unknown>[] = [];
+        while (stmt.step()) out.push(stmt.getAsObject());
+        stmt.free();
+        return out;
+      },
+    };
+    ctx = base as StrategyContext;
+    // ADR-0021 D-C read scope — the authorisation surface. Lowering happens
+    // BEFORE the scope is ANDed in, so the scope must apply identically to both
+    // spellings; a door that lowered after (or instead of) scoping would show up
+    // here as a row the scope excludes.
+    scopedCtx = { ...base, getReadScope: () => ({ owner: 'u1' }) } as StrategyContext;
+  });
+
+  afterAll(() => {
+    db?.close();
+  });
+
+  const idsOf = (rows: Record<string, unknown>[]): string[] =>
+    rows.map((r) => String(r.id)).sort((a, b) => a.localeCompare(b));
+
+  const run = async (where: unknown, c: StrategyContext = ctx): Promise<string[]> =>
+    idsOf(
+      (
+        await new NativeSQLStrategy().execute(
+          { cube: 'deals', measures: ['total'], dimensions: ['id'], where } as AnalyticsQuery,
+          c,
+        )
+      ).rows,
+    );
+
+  // ── the issue's acceptance criterion, at the `generateSql` layer ──────────
+
+  it('emits a bound WHERE for the lowerable spelling of #5334\'s filter', async () => {
+    const { sql, params } = await new NativeSQLStrategy().generateSql(
+      {
+        cube: 'deals',
+        measures: ['total'],
+        dimensions: ['id'],
+        where: [['stage', '=', 'won']],
+      } as AnalyticsQuery,
+      ctx,
+    );
+    // Before #5334 this statement had NO `WHERE` at all and `params` was empty —
+    // the filter was gone and the chart covered the whole table.
+    expect(sql).toMatch(/WHERE/);
+    expect(sql).toMatch(/stage/);
+    expect(params).toEqual(['won']);
+    expect(await run([['stage', '=', 'won']])).toEqual(['d1', 'd2']);
+  });
+
+  // ── arrival 1: `[]` is "no filter", not a failed filter ───────────────────
+
+  it('`[]` charts every row, with no WHERE and no error', async () => {
+    const { sql, params } = await new NativeSQLStrategy().generateSql(
+      { cube: 'deals', measures: ['total'], dimensions: ['id'], where: [] } as AnalyticsQuery,
+      ctx,
+    );
+    expect(sql).not.toMatch(/WHERE/);
+    expect(params).toEqual([]);
+    expect(await run([])).toEqual(['d1', 'd2', 'd3', 'd4']);
+  });
+
+  // ── arrival 2: lowered — the two spellings select the SAME rows ───────────
+
+  for (const c of EQUIVALENT_SPELLINGS) {
+    it(`lowers: ${c.name}`, async () => {
+      const fromObject = await run(c.object);
+      const fromArray = await run(c.array);
+      expect(fromObject, 'the canonical object spelling').toEqual(c.expected);
+      expect(fromArray, 'the FilterArray spelling').toEqual(c.expected);
+      expect(fromArray, 'sugar means the same rows').toEqual(fromObject);
+    });
+
+    it(`lowers under the read scope: ${c.name}`, async () => {
+      const fromObject = await run(c.object, scopedCtx);
+      const fromArray = await run(c.array, scopedCtx);
+      expect(fromObject, 'object spelling, scoped').toEqual(c.scoped);
+      expect(fromArray, 'array spelling, scoped').toEqual(c.scoped);
+      expect(fromArray, 'the scope applies to both spellings alike').toEqual(fromObject);
+    });
+  }
+
+  // ── arrival 3: refused, loudly, in the ADR-0112 envelope ──────────────────
+
+  for (const c of UNLOWERABLE) {
+    it(`refuses: ${c.name}`, async () => {
+      const err = await refusalOf(() => run(c.where));
+      expect(err.code).toBe('INVALID_FILTER');
+      expect(err.status).toBe(400);
+      expect(err.message).toMatch(c.matches);
+      // The refusal must name what the alternative would have been — a filter
+      // that does not run must not read as a filter that matched everything.
+      expect(err.message).toMatch(/UNFILTERED/);
+    });
+  }
+
+  it('a refused filter runs NOTHING — no SQL reaches the driver', async () => {
+    const seen: string[] = [];
+    const spy = {
+      ...ctx,
+      executeRawSql: async (o: string, sql: string, p: unknown[]) => {
+        seen.push(sql);
+        return ctx.executeRawSql!(o, sql, p);
+      },
+    } as StrategyContext;
+    await refusalOf(() => run([{ stage: 'won' }], spy));
+    expect(seen).toEqual([]);
+  });
+
+  it('the caller\'s own array is never mutated', async () => {
+    const where = [['stage', '=', 'won']];
+    await run(where);
+    expect(where).toEqual([['stage', '=', 'won']]);
+  });
+});
+
+// ── The engine door ──────────────────────────────────────────────────────────
+
+/**
+ * A small stand-in for `engine.aggregate` over {@link DEALS}.
+ *
+ * It implements only the `FilterCondition` vocabulary these cases produce, and
+ * it exists to answer "does the LOWERED condition select the right records",
+ * not to be a second engine. The stronger assertion in each case is the
+ * structural one — the condition handed to the engine for the array spelling is
+ * the SAME condition the object spelling produces.
+ */
+function matches(row: DealRow, cond: unknown): boolean {
+  if (cond === null || typeof cond !== 'object') return false;
+  return Object.entries(cond as Record<string, unknown>).every(([key, val]) => {
+    if (key === '$and') return (val as unknown[]).every((c) => matches(row, c));
+    if (key === '$or') return (val as unknown[]).some((c) => matches(row, c));
+    if (key === '$not') return !matches(row, val);
+    const actual = (row as unknown as Record<string, unknown>)[key];
+    if (val === null) return actual === null || actual === undefined;
+    if (val === undefined) return true;
+    if (typeof val !== 'object') return actual === val;
+    return Object.entries(val as Record<string, unknown>).every(([op, operand]) => {
+      switch (op) {
+        case '$eq': return actual === operand;
+        case '$ne': return actual !== operand;
+        case '$gt': return (actual as number) > (operand as number);
+        case '$gte': return (actual as number) >= (operand as number);
+        case '$lt': return (actual as number) < (operand as number);
+        case '$lte': return (actual as number) <= (operand as number);
+        case '$in': return (operand as unknown[]).includes(actual);
+        case '$nin': return !(operand as unknown[]).includes(actual);
+        case '$null':
+          return operand === true
+            ? actual === null || actual === undefined
+            : actual !== null && actual !== undefined;
+        default:
+          throw new Error(`fixture engine cannot evaluate operator ${op}`);
+      }
+    });
+  });
+}
+
+describe('[#5334] ObjectQLStrategy — the lowered FilterCondition reaches the engine', () => {
+  const captured: Array<Record<string, unknown> | undefined> = [];
+
+  const ctx = {
+    getCube: (name: string) => (name === 'deals' ? CUBE : undefined),
+    queryCapabilities: () => ({ nativeSql: false, objectqlAggregate: true, inMemory: false }),
+    executeAggregate: async (
+      _object: string,
+      options: { groupBy?: string[]; filter?: Record<string, unknown> },
+    ) => {
+      captured.push(options.filter);
+      return DEALS.filter((r) => matches(r, options.filter ?? {})).map((r) => ({
+        id: r.id,
+        total: 1,
+      }));
+    },
+  } as unknown as StrategyContext;
+
+  const run = async (where: unknown): Promise<{ ids: string[]; filter: unknown }> => {
+    captured.length = 0;
+    const result = await new ObjectQLStrategy().execute(
+      { cube: 'deals', measures: ['total'], dimensions: ['id'], where } as AnalyticsQuery,
+      ctx,
+    );
+    return {
+      ids: result.rows.map((r) => String(r.id)).sort((a, b) => a.localeCompare(b)),
+      filter: captured[0],
+    };
+  };
+
+  it('`[]` reaches the engine as no filter at all', async () => {
+    const { ids, filter } = await run([]);
+    // ABSENT, not `{}` — the same reading the engine door gives it, where the
+    // `where` key is DELETED rather than lowered to an empty condition.
+    expect(filter).toBeUndefined();
+    expect(ids).toEqual(['d1', 'd2', 'd3', 'd4']);
+  });
+
+  for (const c of EQUIVALENT_SPELLINGS) {
+    it(`lowers for the engine: ${c.name}`, async () => {
+      const fromObject = await run(c.object);
+      const fromArray = await run(c.array);
+      // The condition itself, not just the rows: the engine must receive the
+      // SAME `FilterCondition` either spelling was written as.
+      expect(fromArray.filter, 'the lowered condition').toEqual(fromObject.filter);
+      expect(fromObject.ids).toEqual(c.expected);
+      expect(fromArray.ids).toEqual(c.expected);
+    });
+  }
+
+  for (const c of UNLOWERABLE) {
+    it(`refuses before the engine is called: ${c.name}`, async () => {
+      captured.length = 0;
+      const err = await refusalOf(() =>
+        new ObjectQLStrategy().execute(
+          {
+            cube: 'deals',
+            measures: ['total'],
+            dimensions: ['id'],
+            where: c.where,
+          } as AnalyticsQuery,
+          ctx,
+        ),
+      );
+      expect(err.code).toBe('INVALID_FILTER');
+      expect(err.status).toBe(400);
+      expect(captured).toEqual([]);
+    });
+  }
+
+  it('the echoed display SQL carries the lowered predicate too', async () => {
+    // `generateSql` renders the statement a debugger reads. It compiles the
+    // same tree, so an array `where` that vanished from execution vanished from
+    // the echo as well — SQL that cannot reproduce the result it explains.
+    const { sql, params } = await new ObjectQLStrategy().generateSql(
+      {
+        cube: 'deals',
+        measures: ['total'],
+        dimensions: ['id'],
+        where: ['stage', '=', 'won'],
+      } as AnalyticsQuery,
+      ctx,
+    );
+    expect(sql).toMatch(/WHERE/);
+    expect(sql).toMatch(/stage/);
+    expect(params).toEqual(['won']);
+  });
+
+  it('the display SQL refuses the same arrays execution refuses', async () => {
+    const err = await refusalOf(() =>
+      new ObjectQLStrategy().generateSql(
+        {
+          cube: 'deals',
+          measures: ['total'],
+          dimensions: ['id'],
+          where: [{ stage: 'won' }],
+        } as AnalyticsQuery,
+        ctx,
+      ),
+    );
+    expect(err.code).toBe('INVALID_FILTER');
+    expect(err.status).toBe(400);
+  });
+});

--- a/packages/services/service-analytics/src/strategies/filter-normalizer.ts
+++ b/packages/services/service-analytics/src/strategies/filter-normalizer.ts
@@ -88,13 +88,34 @@
  * `NOT (c IS NOT NULL AND (c IS NOT NULL AND c = v))` is the same predicate —
  * so it buys portability for one redundant conjunct.
  *
+ * # A `where` ARRAY is lowered here, not dropped (#5334)
+ *
+ * `FilterArray` — `['stage', '=', 'won']`, `['and', […], […]]`, `[[…], […]]` —
+ * is INPUT-ONLY authoring sugar (`spec/data/filter.zod.ts`, #5285), and #5158's
+ * ruling C says every door into the runtime LOWERS it through the one
+ * `parseFilterAST` sink before anything downstream sees a filter. #5329 closed
+ * the engine's six entry points that way and deleted the four drivers' array
+ * dialects. Analytics is the FIFTH door: it compiles `where` itself — to SQL
+ * (`NativeSQLStrategy`) or to a `FilterCondition` for the engine
+ * (`ObjectQLStrategy`) — so nothing upstream lowers for it.
+ *
+ * Until #5334 this function answered an array with `return null`: the WHOLE
+ * `where` disappeared, no error, no trace, and the widget charted the entire
+ * dataset — the #3650 / #4128 silent-widening class again, reached through the
+ * array spelling. {@link normalizeAnalyticsFilterTree} now gives the same three
+ * answers the engine door gives, so one query means one thing on every path.
+ *
  * Row-result cover: `filter-operator-coverage.test.ts` for the operator
  * vocabulary, `native-sql-filter-logic-conformance.test.ts`, which runs the
  * SHARED combinator table (`FILTER_LOGIC_CASES`, #3774) that the SQL compiler,
- * the in-memory matcher, `formula` and `read-scope-sql` are already held to, and
+ * the in-memory matcher, `formula` and `read-scope-sql` are already held to,
  * `filter-normalizer-not-null-safe.test.ts` for the two squares that table
- * deliberately does not carry (NULL handling, boolean identities).
+ * deliberately does not carry (NULL handling, boolean identities), and
+ * `filter-array-lowering.test.ts` for the array door (#5334).
  */
+
+import { isFilterAST, parseFilterAST, VALID_AST_OPERATORS } from '@objectstack/spec/data';
+import { StandardErrorCode } from '@objectstack/spec/api';
 
 export interface NormalizedAnalyticsFilter {
   member: string;
@@ -639,16 +660,105 @@ function nullSafeNegationOperand(node: Record<string, unknown>): Record<string, 
   return out;
 }
 
+// ── [#5334] The FilterArray door ─────────────────────────────────────────────
+
 /**
- * Normalize an analytics query's `where` (FilterCondition) into the tree the
- * strategies compile. `null` when the query carries no `where`.
+ * [#5334] A filter refusal in the ADR-0112 envelope every sibling filter
+ * refusal in the repo speaks — `INVALID_FILTER` / 400.
+ *
+ * The twin of `driver-sql`'s and `driver-memory`'s `unsupportedFilterError`.
+ * A caller that writes an unlowerable filter has made a 400-class mistake, and
+ * a coded refusal is what lets the `/analytics` face answer it as one instead
+ * of as an opaque 500.
+ */
+function invalidFilterError(message: string): Error {
+  const err = new Error(message) as Error & { code?: string; status?: number };
+  err.code = StandardErrorCode.enum.INVALID_FILTER;
+  err.status = 400;
+  return err;
+}
+
+/**
+ * [#5334] A `where` array this door cannot lower.
+ *
+ * Deliberately the same refusal the other doors give, in the same envelope:
+ * `driver-sql` / `driver-memory` / `driver-mongodb`'s
+ * `filterArrayReachedDriverError` (#5158/#5329) and the engine's own
+ * `lowerWhereFilterArray`. The INFIX join form (`[condA, 'or', condB]`) is the
+ * shape that makes this branch load-bearing — no schema declares it,
+ * `FilterArraySchema` excludes it and `parseFilterAST` has no lowering for it,
+ * so it can only be refused; silently dropping it returns the UNFILTERED
+ * dataset, which is what this whole module exists to prevent.
+ */
+function filterArrayNotLowerableError(where: unknown[]): Error {
+  return invalidFilterError(
+    `[analytics] received a 'where' array that is not a filter: ${JSON.stringify(where)}. ` +
+    `A filter array is a comparison [field, operator, value], a logical node ` +
+    `["and"|"or", ...conditions], or a list of those — it is INPUT-ONLY sugar (spec ` +
+    `'FilterArray'), lowered to a FilterCondition by @objectstack/spec parseFilterAST() at ` +
+    `every door, this one included (#5158/#5334). This value cannot be lowered, and an ` +
+    `unapplied filter would have charted the UNFILTERED dataset. Recognised operators: ` +
+    `${[...VALID_AST_OPERATORS].sort().join(', ')}. Infix joins ([condA, "or", condB]) are ` +
+    `NOT one of the shapes — write the prefix form ["or", condA, condB].`,
+  );
+}
+
+/**
+ * Normalize an analytics query's `where` into the tree the strategies compile.
+ * `null` when the query carries no `where` — i.e. no constraint.
+ *
+ * `where` is declared a `FilterCondition` (`AnalyticsQuerySchema`), and the
+ * object form is the whole of the contract downstream. An ARRAY nevertheless
+ * arrives — it is the `FilterArray` authoring sugar four published contracts
+ * teach, and analytics is a door into the runtime like any other — so it is
+ * LOWERED here (#5334, on #5158's ruling C), giving the same three answers
+ * `ObjectQL`'s six entry points give since #5329:
+ *
+ * 1. `[]` — "no filter", not a failed filter: `null`, the same reading every
+ *    layer gives it (the engine door DELETES the key; `parseFilterAST([])` is
+ *    `undefined`). No predicate is emitted and no error is raised.
+ * 2. A well-formed `FilterArray` — lowered through `parseFilterAST` and
+ *    compiled by {@link buildNode}, so the author gets the SAME rows either
+ *    spelling produces. `isFilterAST` gates first so the operator vocabulary is
+ *    checked before `parseFilterAST`'s lenient `$${op}` fallback can turn a
+ *    misspelling into a `$sounds_like` condition nothing executes.
+ * 3. Anything else array-shaped — REFUSED, loudly. Before #5334 all three of
+ *    these arrivals answered the same way: `return null`, which for (2) and (3)
+ *    means the predicate VANISHED and the chart was drawn over every row.
+ *
+ * Lowering rather than refusing outright is what keeps ONE dashboard's
+ * metadata meaning one thing: the same `where` on a plain `find()` already
+ * lowers at the engine door (#5329), so refusing it here would have forked the
+ * product by which face read the metadata.
  */
 export function normalizeAnalyticsFilterTree(
   query: { where?: unknown } | unknown,
 ): NormalizedFilterNode | null {
   if (!query || typeof query !== 'object') return null;
   const where = (query as { where?: unknown }).where;
-  if (!where || typeof where !== 'object' || Array.isArray(where)) return null;
+  if (!where || typeof where !== 'object') return null;
+
+  if (Array.isArray(where)) {
+    // (1) `[]` is "no filter", not a failed filter.
+    if (where.length === 0) return null;
+    // (3) Not a shape `parseFilterAST` can express.
+    if (!isFilterAST(where)) throw filterArrayNotLowerableError(where);
+    // (2) The declared path.
+    const condition = parseFilterAST(where);
+    if (!condition || typeof condition !== 'object' || Array.isArray(condition)) {
+      // Unreachable by construction — `isFilterAST` accepted the shape, so
+      // `parseFilterAST` has a lowering for it. Loud rather than silent for the
+      // same reason the engine door is: the failure mode of the two spec
+      // functions disagreeing is a dropped predicate, i.e. every row.
+      throw invalidFilterError(
+        `[analytics] filter array ${JSON.stringify(where)} passed isFilterAST() but ` +
+        `parseFilterAST() lowered it to ${JSON.stringify(condition)}. Refusing rather than ` +
+        `charting the dataset unfiltered (#5158/#5334).`,
+      );
+    }
+    return buildNode(condition as Record<string, unknown>);
+  }
+
   return buildNode(where as Record<string, unknown>);
 }
 


### PR DESCRIPTION
Fixes #5334

按维护者裁定取 **lower(下沉)**,与 #5329 的 engine 六入口逐条同构。改动只在 `packages/services/service-analytics/src/strategies/filter-normalizer.ts` 的 `normalizeAnalyticsFilterTree` 一处 + 新测试 + changeset。

## 现场核对(worktree 基于 `c89d18c16`,晚于要求的 `1792384e8`)

issue 正文引用的两行**仍然逐字成立**:

```
const where = (query as { where?: unknown }).where;
if (!where || typeof where !== 'object' || Array.isArray(where)) return null;
```

`Array.isArray(where)` → `return null`,整条 `where` 消失。#5325 / PR #5335 的大改(守卫下推、`{kind:'const'}`、三个编译器的 `paramBase`/`joinBase` 截断、`{$in:[]}` 与 `{a:{}}` 的新答案)都落在这一行**之下**的 `buildNode` 一侧,没有动这个入口,所以两条引用与现场无出入。

其余核过的事实(用 built spec 实测,不是读代码推断):

| 事实 | 实测 |
|:---|:---|
| `parseFilterAST` 住在 `packages/spec/src/data/filter.zod.ts`,`service-analytics` 已依赖 `@objectstack/spec` | 是,**零新依赖**(裁定第 1 条成立) |
| `isFilterAST([['stage','=','won']])` | `true` → `{stage:'won'}` |
| `isFilterAST([{stage:'won'}])` | **`false`**,`parseFilterAST` 返回 `undefined` |
| `isFilterAST([['stage','=','won'],'or',['stage','=','lost']])`(中缀) | `false`,`parseFilterAST` 返回 `undefined` |
| `isFilterAST(['stage','sounds_like','won'])` | `false`,但 `parseFilterAST` 会给出 `{stage:{$sounds_like:'won'}}` —— **所以必须先 `isFilterAST` 把门**,否则拼错的算子会被兜底成一个没人执行的条件 |

### ⚠️ 一处与派发说明的出入,请复核

派发说明把 issue 正文那条实测(`where: [{ stage: 'won' }]`)列为验收:「改后必须产出正确的 WHERE 并绑值」。**这条字面用例落在拒收分支,不是下沉分支**,原因如上表:`[{stage:'won'}]` 不是 `FilterArray` —— `FilterArraySchema` 的列表分支是 `z.array(FilterArraySchema).min(1)`,元素必须**还是数组**;`isFilterAST` 为 `false`,`parseFilterAST` 无从下沉。`engine.find('deal', {where: [{stage:'won'}]})` 自 #5329 起给的也正是拒收。

按裁定的三种到达(`[]` / `isFilterAST` 真 / 其余非空数组 → 响亮拒收),它只能落在第三格。要让它「产出正确的 WHERE」,就得为「FilterCondition 对象的数组 = 隐式 AND」新造一种谱系里没有的方言 —— 那正是 #5158 拍板 C 在消灭的东西,也会立刻与 engine 门分叉。

所以本 PR:**同一个意图的可下沉写法 `[['stage','=','won']]` 钉住了 issue 要的 WHERE + 绑值**,而 issue 正文那条字面量钉成拒收(`INVALID_FILTER` / 400)。两者都有用例。若维护者要的是另一种读法,说一声,我改。

## 三种到达,与 #5329 engine 门逐条对照

| 到达 | engine 门(`lowerWhereFilterArray`) | 本 PR(`normalizeAnalyticsFilterTree`) |
|:---|:---|:---|
| `[]` | 删掉 `where` 键 | 返回 `null`(= 无约束)。同义:两边都不发谓词、不报错 |
| `isFilterAST` 为真 | `parseFilterAST` → 交给驱动 | `parseFilterAST` → 交给 `buildNode` |
| 其余非空数组(含中缀、含 `[{...}]`、含词表外算子、含 `['and']`、含 `[42]`) | 抛错,措辞含 “is not a filter” / “Infix joins … NOT one of the shapes” | 同措辞,**外加 ADR-0112 信封**:`code === 'INVALID_FILTER'`、`status === 400` |
| `isFilterAST` 真但 `parseFilterAST` 落空 | 「构造上不可达」的响亮兜底 | 同,不静默 |

信封取的是四驱动 `filterArrayReachedDriverError` 的那一套(`INVALID_FILTER` / 400),没有另造第三套。engine 门本身抛的是裸 `Error`(无 code/status)—— 派发说明要求对齐的是驱动侧信封,这里按驱动侧落。

## 下沉产物 × #5335 新逻辑的交互(逐条核过)

`parseFilterAST` 的值域是封闭的,核完的结论是**没有意外交互**,理由不是「跑了没炸」而是值域本身:

- **`$not` 不会出现**。AST 词表(`AST_OPERATOR_MAP`)没有取反算子,组只有 `and`/`or`,所以下沉产物里永远没有 `$not` —— #5335 的 `nullSafeNegationOperand` / `notOf` / 「NOT TRUE ≡ FALSE」这条路**不会被数组写法触发**。对象写法的 `$not` 一行未动。
- **`{}` 与 `{field:{}}` 不会出现**。`convertComparison` 必产出恰好一个键;组要么返回子条件、要么 `undefined`。所以 #5325 的「TRUE 吸收 `$or`」与 #5240 的空字段约束拒收都不会被下沉产物撞到。
- **空 `$and` / `$or` 数组不会出现**。`parseFilterAST` 对 0 个子条件返回 `undefined`,1 个直接返回该子条件,所以组至少两支且全是对象 —— `buildNode` 的空组合器拒收不会被误触。
- **`{$in: []}` 会出现**(`['stage','in',[]]`),正好落在 #5335 新加的布尔常量 `{kind:'const', value:false}` 上:编译成 `1 = 0`,取 0 行。已单独钉住(见测试表)。若这次下沉落在 #5325 之前的树上,它会一条子句都不发、画全表。
- **算子词表是子集**:AST 能产出的 `$` 算子只有 `$eq $ne $gt $gte $lt $lte $in $nin $contains $notContains $startsWith $endsWith $between $null`,全部在 analytics 的词表内(`MONGO_TO_CUBE_OP` + `$between` + `$null`)。下沉不会造出 analytics 编译不了的算子。
- `$between`(`['amount','between',[15,35]]`)照旧下沉成两个界,继承 `$lte` 的整日规则。

## 两个 strategy 都覆盖

下沉发生在 `normalizeAnalyticsFilterTree`,两条路都受益,但各自有用例钉住:

- `NativeSQLStrategy` —— 断言打在 `generateSql`(SQL + `params`)和 `.execute`(**在 sql.js 上真取行**)。
- `ObjectQLStrategy` —— 断言打在交给引擎的 `FilterCondition` 上(数组写法产出的条件与对象写法**深相等**),以及经一个 stand-in 引擎取到的行;外加 `generateSql` 回显 SQL 这条路(它也编译同一棵树,原先数组 `where` 从执行里消失时,回显里也一起消失了)。

## 测试

新文件 `packages/services/service-analytics/src/__tests__/filter-array-lowering.test.ts`,56 个用例。

| 组 | 覆盖 | 结果 |
|:---|:---|:---|
| issue 验收 | `generateSql` 产出 `WHERE` + `params === ['won']`,`.execute` 取到 `d1,d2` | pass |
| 到达 1 | `[]` → 无 `WHERE`、`params` 为空、取全表;engine 路 `filter` 为 `undefined` | pass |
| 到达 2 | 13 组「对象写法 ⇄ 数组写法」等价表,每组**都带显式期望行**(只比两种写法会让「双双画全表」也通过) | pass |
| 到达 3 | 5 种不可下沉数组:`[{stage:'won'}]`、中缀、词表外算子、`['and']`、`[42]` —— `code === 'INVALID_FILTER'`、`status === 400`、措辞含 “UNFILTERED” | pass |
| 授权面等价性 | 同一批等价表在 `getReadScope: () => ({owner:'u1'})` 下重跑,两种写法取到的行**逐条相同**且等于 scope 后的期望 —— 证明下沉发生在 scope 注入之前、没有绕过它 | pass |
| 拒收不执行 | 被拒的筛选一条 SQL 都没到驱动;engine 路一次 `executeAggregate` 都没发 | pass |
| 入参不被改写 | 调用方自己的数组原样保留 | pass |
| #5335 交叉 | `['stage','in',[]]` → 布尔常量 FALSE → 0 行 | pass |

命令与输出:

```
pnpm --filter @objectstack/service-analytics exec vitest run --maxWorkers=2 src/__tests__/filter-array-lowering.test.ts
 Test Files  1 passed (1)
      Tests  56 passed (56)

pnpm --filter @objectstack/service-analytics exec vitest run --maxWorkers=2      # 连带面全量
 Test Files  45 passed (45)
      Tests  695 passed (695)

tsc --noEmit -p packages/services/service-analytics/tsconfig.json
 # 改前 / 改后逐字节相同的 13 行既存报错(analytics-service.test.ts、
 # measure-source-field-gate.test.ts、objectql-timedimension-projection.test.ts),
 # 本次改动新增 0 条。该包没有 typecheck script,故直接 tsc 并与 stash 基线对比。

eslint --no-inline-config <两个改动文件>
 # 干净退出;实现侧无 `as any`。
```

### 反向验证(把实现 stash 掉,新用例必须失败)

`git stash push -- .../filter-normalizer.ts` 后跑同一个测试文件:**53 failed | 3 passed (56)**。原文节选:

```
FAIL  ... > emits a bound WHERE for the lowerable spelling of #5334's filter
AssertionError: expected 'SELECT id AS "id", COUNT(*) AS "total…' to match /WHERE/
- Expected:  /WHERE/
+ Received:  "SELECT id AS \"id\", COUNT(*) AS \"total\" FROM \"deal\" GROUP BY id"

FAIL  ... > lowers: equality — the issue's own filter, in its lowerable spelling
AssertionError: the FilterArray spelling: expected [ 'd1', 'd2', 'd3', 'd4' ] to deeply equal [ 'd1', 'd2' ]

FAIL  ... > lowers under the read scope: prefix AND group
AssertionError: array spelling, scoped: expected [ 'd1', 'd3', 'd4' ] to deeply equal [ 'd1' ]

FAIL  ... > refuses: the INFIX join form
Error: expected the filter to be refused, but the query ran
```

第一条正是 issue 正文那句「生成无 WHERE 的 SQL、`params` 为空」的机器复现。仍然通过的 3 条是 `[]` 的两条(它本来就该无过滤)和「入参不被改写」—— 语义未变,符合预期。

### 本地跳过 / CI-only 盲区

`grep -rn "skipIf|describe.skip|it.skip|test.skip|todo(|.only("` 扫 `service-analytics/src` 全包:**0 命中**。本包没有条件跳过的用例,上面的 695 就是本地实际执行数,没有「本地跳过、CI 才跑」的盲区。新用例用 `sql.js`(纯 WASM),与邻居 `native-sql-filter-logic-conformance` 同一理由,不依赖 native ABI。

## 变更记录

`.changeset/analytics-where-filter-array-lowered.md`(`@objectstack/service-analytics`: patch),写明这是**可观察的行为变更**:此前数组 `where` 被静默丢弃、图表画全表;现在正确筛选,或以 `INVALID_FILTER` / 400 响亮拒收。未碰 `content/docs/releases/`。

## 范围外(已单独立单,本 PR 一行未改)

- **#5352** —— analytics 的 filter 拒收到不了调用方:`filter-normalizer.ts` 既存的四处拒收是裸 `Error`(无 ADR-0112 信封),而 `/analytics/dataset/query` 的 REST 面用 message 正则嗅探、丢弃 `code`/`status`,一律答 `500 ANALYTICS_QUERY_FAILED`。本 PR 新落的 `INVALID_FILTER` / 400 在 service 侧是对的,过了那道面同样会被降级成 500。一个缺陷的两半,未打标,待分诊。
- **#5353**(`finding`)—— `inferCube` 仍用 `!Array.isArray(query.where)` 把数组当非筛选跳过;#5334 之后已过时。今天无可观察后果(`resolveFieldSql` 回落裸列名,取到的行一致),记为观察类。
- **#5332**(`{$eq: null}` 编译成 `col = ''`)、**#5333**(回显丢 `$startsWith`/`$endsWith`)—— 同文件的独立单,本 PR 未碰;`nullValueSatisfiesOperator` 的注释里已有指向 #5332 的既存说明,保持原样。
- `packages/spec/**`、`packages/objectql/**`、`packages/plugins/**` —— 只读作参照,一行未改。构建曾顺带重写 `packages/spec/authorable-surface.base.json`(生成物,`baseRev` 跟到当前 HEAD),已 `git checkout` 还原,不在本 PR 的 diff 里。

## 风险

- 行为收紧:此前静默通过(丢筛选、画全表)的不可下沉数组现在 400。按裁定这是本单的目的,但若现网真有 producer 在发这类数组,它会从「悄悄画全表」变成「报错」—— 这正是想要的方向,只是变更本身可观察。issue 正文写明未找到今天真的会给 analytics 传数组 `where` 的 producer。
- 拒收在 REST 面上目前仍以 500 呈现(#5352),状态码要等那单落地才对。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pbu27iNUfQCHeuS551Rqo7)_