### PR TITLE
fix(cli): i18n 覆盖走查收集 `objects.*._sections` —— 段落标题不再是「声明了、渲染了、却零告警」的面 (#5405)

### DIFF
--- a/.changeset/i18n-walker-object-sections.md
+++ b/.changeset/i18n-walker-object-sections.md
@@ -1,0 +1,64 @@
+---
+"@objectstack/cli": minor
+"@objectstack/lint": minor
+---
+
+fix(cli): the i18n walker collects `objects.<o>._sections` — section headings are gated and scaffolded like every other label (#5405)
+
+An object's SECTION headings were the one declared, resolved, rendered
+translation surface the shared i18n walker had no kind for.
+`ExpectedEntry['source']` listed `object | field | option | view | action |
+globalAction | app | navigation | dashboard | widget | page` plus two
+`metadataForm*` kinds — and those two cover **Studio metadata forms**
+(`metadataForms.<type>.sections.*`, hidden behind `--include-platform`), not app
+objects. So `objects.<o>._sections.<s>.label` was structurally unreachable in
+both directions: `os i18n extract` never scaffolded a heading, and
+`os lint` could not report one missing.
+
+The surface itself was never in doubt. `ObjectTranslationDataSchema` declares
+`_sections` (with `sections` as an authoring alias), and `@object-ui/i18n`'s
+`sectionLabel` resolves it for `record:details`, for `ObjectForm`/`ModalForm`
+and for the field-group designer. Only the walker disagreed — which is exactly
+the drift `collectExpectedEntries` was consolidated to prevent (#3370).
+
+Measured downstream before this landed: 85 sections across 15 objects, **2 of
+85** translated in `ja-JP` and in `es-ES` — English headings on essentially
+every record page and form — with `objectstack lint` reporting **zero** i18n
+warnings for both locales.
+
+**What is collected.** A `section` kind, from the two independent surfaces that
+both resolve to the same key — a heading is expected if *either* declares it,
+and one heading is one expected key however many declare it:
+
+- **`fieldGroups` × field `group`** — the fields decide which sections exist and
+  `fieldGroups[].label` supplies the source text. Membership is read through
+  `deriveFieldGroupLayout` (ADR-0085 §5), the same shared derivation the
+  renderers consume, so a group nothing visible references — or a `group:` no
+  `fieldGroups` entry declares — produces no heading and therefore no expected
+  key. The trailing ungrouped bucket renders without chrome and is skipped.
+- **A named `sections[]`** on a form view (including a view container's default
+  `form`) or inside a record page's component tree.
+
+A section with no `name` is skipped: every renderer guards the lookup on it
+(`s?.name ? sectionLabel(…) : s?.label`), so it is untranslatable by
+construction and demanding a bundle entry for it would be noise. A group that
+declares no `label` still yields a scaffold key seeded from its own name, but no
+coverage finding — nobody authored that text.
+
+**What you get.** `os lint` gains an `i18n/missing-section` category — user
+metadata, so it is reported without `--include-platform` — and `os i18n
+extract` scaffolds the headings for free, because the gate and the extractor
+read the one walker. A project that declares no locales still reports nothing;
+the gate stays opt-in.
+
+**`@objectstack/lint`** now exports its shared page traversal
+(`walkPageComponents`, `isSourceAuthoredPage`, `WalkedComponent`) so the CLI
+consumes it instead of growing a private copy — that walk exists precisely
+because duplicating it produced a dead rule once already (#3583). Reusing it is
+also what makes the page half correct rather than merely present: it reaches
+`slots.<slot>` and the untyped nesting a record page really uses
+(`page:tabs` → `properties.items[].children[]` → `record:details`), skips
+source-authored pages whose `regions` are a derived cache, and resolves each
+component's OWN binding (`dataSource.object` → `properties.object` → the page's
+`object`) — so a re-bound `record:details` keys its headings under the object it
+actually shows.

--- a/examples/app-showcase/src/system/translations/index.ts
+++ b/examples/app-showcase/src/system/translations/index.ts
@@ -251,6 +251,27 @@ export const ShowcaseTranslationBundle = {
             successMessage: '已为整个选中集重算工时。',
           },
         },
+        // Section headings of the four form-view projections in
+        // `ui/views/task.view.ts` (tabbed / wizard / split). Each section
+        // there declares a stable `name`, which is the only thing that makes
+        // the heading translatable — `ObjectForm` looks it up as
+        // `objects.showcase_task._sections.<name>.label` and otherwise renders
+        // the English `label` verbatim. Wording follows the vocabulary the
+        // rest of this bundle already uses (任务 / 负责人 / 进度), rather than
+        // introducing a second word per idea.
+        _sections: {
+          // tabbed
+          overview: { label: '概览' },
+          schedule: { label: '排期' },
+          details: { label: '详细信息' },
+          // wizard steps
+          step_basics: { label: '基本信息' },
+          step_assign: { label: '指派' },
+          step_schedule: { label: '排期' },
+          // split panes
+          split_task: { label: '任务' },
+          split_schedule: { label: '排期' },
+        },
       },
       showcase_account: {
         label: '客户',
@@ -341,6 +362,19 @@ export const ShowcaseTranslationBundle = {
         _views: {
           list: { label: '全部单元' },
           org_chart: { label: '组织架构图' },
+        },
+      },
+      // `_sections` only, on the same footing as the two `_views`-only blocks
+      // above: this ADR-0085 fixture has no zh-CN block of its own and its
+      // object/field debt sits inside the ratchet's baseline. Its two
+      // `fieldGroups` headings are what the coverage walker newly surfaces
+      // (#5405), and translating exactly those is what keeps the gate from
+      // widening; the rest is left exactly as it was. `财务信息` follows the
+      // group's own description ("Financial fields"), not the bare word Money.
+      showcase_semantic_zoo: {
+        _sections: {
+          basics: { label: '基本信息' },
+          money: { label: '财务信息' },
         },
       },
       showcase_field_zoo: {

--- a/packages/cli/src/utils/i18n-coverage.ts
+++ b/packages/cli/src/utils/i18n-coverage.ts
@@ -47,6 +47,7 @@ export interface CoverageIssue {
     | 'object'
     | 'field'
     | 'option'
+    | 'section'
     | 'view'
     | 'action'
     | 'globalAction'
@@ -191,6 +192,11 @@ const COVERAGE_SOURCE: Record<ExpectedEntry['source'], CoverageIssue['source']> 
   object: 'object',
   field: 'field',
   option: 'option',
+  // An object section heading (`objects.<o>._sections.<s>.label`) is the
+  // user's own metadata, not the Studio-form baseline — it keeps its own
+  // bucket so `os lint` reports it as `i18n/missing-section` rather than
+  // folding it away with `--include-platform`.
+  section: 'section',
   view: 'view',
   action: 'action',
   globalAction: 'globalAction',
@@ -208,6 +214,7 @@ const SOURCE_NOUN: Record<CoverageIssue['source'], string> = {
   object: 'Object',
   field: 'Field',
   option: 'Option',
+  section: 'Section',
   view: 'View',
   action: 'Action',
   globalAction: 'Global action',

--- a/packages/cli/src/utils/i18n-extract.ts
+++ b/packages/cli/src/utils/i18n-extract.ts
@@ -30,6 +30,7 @@
  *   objects.<name>.fields.<field>.help
  *   objects.<name>.fields.<field>.placeholder
  *   objects.<name>.fields.<field>.options.<value>
+ *   objects.<name>._sections.<section>.label
  *   objects.<name>._views.<view>.label
  *   objects.<name>._views.<view>.description
  *   objects.<name>._views.<view>.emptyState.title / .message
@@ -64,6 +65,8 @@
 import type { TranslationBundle, TranslationData } from '@objectstack/spec/system';
 import { METADATA_FORM_REGISTRY } from '@objectstack/spec/system';
 import { DEFAULT_METADATA_TYPE_REGISTRY } from '@objectstack/spec/kernel';
+import { deriveFieldGroupLayout } from '@objectstack/spec/data';
+import { walkPageComponents } from '@objectstack/lint';
 
 // ─── Public types ──────────────────────────────────────────────────────
 
@@ -95,6 +98,7 @@ export interface ExpectedEntry {
     | 'object'
     | 'field'
     | 'option'
+    | 'section'
     | 'view'
     | 'action'
     | 'globalAction'
@@ -332,6 +336,165 @@ function pushActionResultDialog(
   }
 }
 
+// ─── Object sections (`objects.<o>._sections.<section>.label`) ─────────
+//
+// A section heading is authored in TWO independent places and rendered from
+// both, so a walk that reads only one of them under-reports (#5405):
+//
+//   (a) the object's `fieldGroups` semantic role (ADR-0085 §5) — the fields
+//       are the authority for which sections exist (a declared group nothing
+//       references never renders), `fieldGroups[].label` supplies the source
+//       text. Rendered by `RecordDetailView` via
+//       `deriveFieldGroupDetailSections` and by `ObjectFormDesigner`, both of
+//       which look the heading up as `sectionLabel(object, group.key, …)`.
+//
+//   (b) authored `sections[]` on a form view or inside a record page's
+//       component tree, keyed by the section's own `name`. Rendered by
+//       `plugin-form`'s `ObjectForm`/`ModalForm` and `plugin-detail`'s
+//       `record:details`.
+//
+// Both resolve through the SAME convention —
+// `objects.<object>._sections.<name>.label`, `useObjectLabel.sectionLabel` in
+// `@object-ui/i18n` — against the `_sections` slot `ObjectTranslationDataSchema`
+// declares. So one expected key per (object, section), whichever source found
+// it first.
+//
+// A section with no `name` is deliberately skipped: every renderer guards the
+// lookup on it (`s?.name ? sectionLabel(...) : s?.label`), so a nameless
+// section is untranslatable by construction and demanding a bundle entry for
+// it would be noise. The `_sections` schema says the same ("Each section in
+// the page schema must declare a stable `name` for the lookup to fire").
+
+/** object name → section name → source label (undefined = none authored). */
+type SectionIndex = Map<string, Map<string, string | undefined>>;
+
+/**
+ * Record one (object, section) pair.
+ *
+ * One heading, one key — however many surfaces declare it. The first AUTHORED
+ * label wins, and a later authored one upgrades an entry recorded without any
+ * (a group that declares no `label` of its own, whose heading text the page
+ * section carries): `inline` must report the text the reader actually sees,
+ * whichever surface happens to be walked first.
+ */
+function addSection(index: SectionIndex, objectName: unknown, sectionName: unknown, label: unknown): void {
+  if (typeof objectName !== 'string' || objectName.length === 0) return;
+  if (typeof sectionName !== 'string' || sectionName.length === 0) return;
+  let sections = index.get(objectName);
+  if (!sections) index.set(objectName, (sections = new Map()));
+  const authored = inlineText(label);
+  if (!sections.has(sectionName)) sections.set(sectionName, authored);
+  else if (sections.get(sectionName) === undefined && authored !== undefined) {
+    sections.set(sectionName, authored);
+  }
+}
+
+/** Read a `sections[]` array (form view / component props) into the index. */
+function addSectionList(index: SectionIndex, sections: unknown, objectName: unknown): void {
+  if (!Array.isArray(sections)) return;
+  for (const section of sections) {
+    if (!section || typeof section !== 'object') continue;
+    const s = section as Record<string, unknown>;
+    // `record:details` reads `title ?? label`, form views author `label`; a
+    // localized-map label (`{ en, 'zh-CN' }`) is already multilingual and
+    // `inlineText` drops it to "nothing authored in plain text".
+    addSection(index, objectName, s.name, s.label ?? s.title);
+  }
+}
+
+/**
+ * Emit `objects.<object>._sections.<section>.label` for every section the
+ * stack renders, from both authoring surfaces.
+ */
+function walkObjectSections(config: any, out: ExpectedEntry[]): void {
+  const index: SectionIndex = new Map();
+
+  // (a) `fieldGroups` × field `group` membership. `deriveFieldGroupLayout` is
+  //     the shared derivation the renderers themselves consume, so "which
+  //     groups become sections" is decided in exactly one place: a group no
+  //     visible field references, or one that is referenced but never
+  //     declared, produces no heading and therefore no expected key.
+  const objects: any[] = Array.isArray(config?.objects) ? config.objects : [];
+  for (const obj of objects) {
+    if (!obj?.name) continue;
+    const derived = deriveFieldGroupLayout(obj);
+    if (!derived) continue;
+    // The derivation substitutes the key for a missing label; read the
+    // declared label back so `inline` stays honest about what was authored.
+    const declaredLabels = new Map<string, unknown>();
+    for (const group of Array.isArray(obj.fieldGroups) ? obj.fieldGroups : []) {
+      if (group && typeof group === 'object' && typeof group.key === 'string') {
+        declaredLabels.set(group.key, group.label);
+      }
+    }
+    for (const section of derived) {
+      // The trailing ungrouped bucket carries no key — it renders without
+      // chrome, so there is no heading to translate.
+      if (section.key === undefined) continue;
+      addSection(index, obj.name, section.key, declaredLabels.get(section.key));
+    }
+  }
+
+  // (b) authored form-view sections.
+  const views: any[] = Array.isArray(config?.views) ? config.views : [];
+  for (const view of views) {
+    const containerObject = viewObjectName(view);
+    addSectionList(index, view?.sections, containerObject);
+    if (view?.form && typeof view.form === 'object') {
+      addSectionList(index, view.form.sections, viewObjectName(view.form) ?? containerObject);
+    }
+    if (view?.formViews && typeof view.formViews === 'object') {
+      for (const form of Object.values<any>(view.formViews)) {
+        if (!form || typeof form !== 'object') continue;
+        addSectionList(index, form.sections, viewObjectName(form) ?? containerObject);
+      }
+    }
+  }
+
+  // (b) authored page sections — a record page's `record:details`.
+  //
+  // Reuses `@objectstack/lint`'s shared page traversal rather than growing a
+  // private copy. That walk exists precisely because duplicating it produced a
+  // dead rule once already (#3583): components hang off `regions[].components`
+  // AND `slots.<slot>` (which may be a bare component, not an array), sub-trees
+  // live inside the untyped `properties` bag (`page:tabs` →
+  // `properties.items[].children`, `page:card` → `properties.body`/`.footer`),
+  // and source-authored pages (`kind: 'html' | 'react' | 'jsx'`) hold only a
+  // DERIVED region cache that the author never wrote — scaffolding translation
+  // keys off that cache would invent an authoring surface.
+  //
+  // It also resolves each component's OWN binding
+  // (`dataSource.object` → `properties.object` → the page's `object`), which a
+  // page-level-only binding would get wrong rather than merely miss: a
+  // `record:details` retargeted at another object would key its headings under
+  // the page's object, and no bundle entry there would ever resolve.
+  const pages: any[] = Array.isArray(config?.pages) ? config.pages : [];
+  for (let pi = 0; pi < pages.length; pi++) {
+    const page = pages[pi];
+    if (!page || typeof page !== 'object') continue;
+    for (const walked of walkPageComponents(page, `pages[${pi}]`)) {
+      if (!walked.objectName) continue;
+      const props = walked.component.properties;
+      if (!props || typeof props !== 'object' || Array.isArray(props)) continue;
+      addSectionList(index, (props as Record<string, unknown>).sections, walked.objectName);
+    }
+  }
+
+  for (const [objectName, sections] of index) {
+    for (const [sectionName, label] of sections) {
+      pushDerived(
+        out,
+        ['objects', objectName, '_sections', sectionName, 'label'],
+        // Seed mirrors the renderer's own fallback (`s.label || s.name`).
+        label ?? sectionName,
+        label,
+        'section',
+        { objectName },
+      );
+    }
+  }
+}
+
 /** Collect every translatable entry from a normalized stack config. */
 export function collectExpectedEntries(config: any): ExpectedEntry[] {
   const out: ExpectedEntry[] = [];
@@ -538,6 +701,13 @@ export function collectExpectedEntries(config: any): ExpectedEntry[] {
       }
     }
   }
+
+  // ── Object sections (fieldGroups + authored form/page sections) ───
+  // Deliberately a pass of its own: the two authoring surfaces live in
+  // `objects`, `views` and `pages`, and one section may be declared by more
+  // than one of them — collecting first and emitting once keeps a heading
+  // from being counted twice against coverage.
+  walkObjectSections(config, out);
 
   // ── Metadata configuration forms (Studio admin UI) ────────────────
   // Registry-driven: always included, independent of stack config. These

--- a/packages/cli/test/i18n-section-coverage.test.ts
+++ b/packages/cli/test/i18n-section-coverage.test.ts
@@ -1,0 +1,526 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+//
+// objectstack#5405 — an object's SECTION headings were the one declared,
+// resolved, rendered translation surface the shared walker had no kind for.
+// `ExpectedEntry['source']` listed object/field/option/view/action/... and two
+// `metadataForm*` kinds (Studio metadata forms, a different namespace), so
+// `objects.<o>._sections.<s>.label` was structurally unreachable: `os i18n
+// extract` never scaffolded a heading and `os lint` could not report one
+// missing. Measured downstream (hotcrm#697): 85 sections across 15 objects,
+// 2 of 85 translated in ja-JP and es-ES, and `objectstack lint` reported
+// ZERO i18n warnings for both.
+//
+// The surface itself was never in doubt — `ObjectTranslationDataSchema`
+// declares `_sections` (with `sections` as an authoring alias), and
+// `@object-ui/i18n`'s `sectionLabel` resolves it for `record:details`, for
+// `ObjectForm`/`ModalForm` and for the field-group designer. Only the walker
+// disagreed.
+//
+// Two authoring surfaces feed one key, and BOTH are load-bearing:
+//   (a) `fieldGroups` × field `group` — the fields decide which sections
+//       exist, `fieldGroups[].label` supplies the source text;
+//   (b) a named `sections[]` on a form view or inside a record page's
+//       component tree — where the nesting is deep enough
+//       (`page:tabs` → `properties.items[].children[]` → `record:details`)
+//       that a shallow walk sees nothing.
+
+import { describe, it, expect } from 'vitest';
+import { collectExpectedEntries, extractTranslations } from '../src/utils/i18n-extract';
+import { computeI18nCoverage } from '../src/utils/i18n-coverage';
+import { foldCoverageIssues } from '../src/commands/lint';
+import { ObjectTranslationDataSchema } from '@objectstack/spec/system';
+import { deriveFieldGroupLayout } from '@objectstack/spec/data';
+
+/** Every `objects.<o>._sections.*` path the walker emits, as dot-paths. */
+const sectionKeys = (config: any) =>
+  collectExpectedEntries(config)
+    .filter((e) => e.source === 'section')
+    .map((e) => e.path.join('.'));
+
+const sectionEntries = (config: any) =>
+  collectExpectedEntries(config).filter((e) => e.source === 'section');
+
+// ── (a) fieldGroups × field `group` ────────────────────────────────────
+
+/**
+ * `showcase_semantic_zoo`'s posture: two declared groups, both referenced.
+ * `money` also carries icon/description, so the group is the full ADR-0085
+ * shape rather than a bare key.
+ */
+const groupedObject = {
+  name: 'crm_opportunity',
+  label: 'Opportunity',
+  fields: {
+    name: { label: 'Name', group: 'basics' },
+    amount: { label: 'Amount', group: 'money' },
+    notes: { label: 'Notes' },
+  },
+  fieldGroups: [
+    { key: 'basics', label: 'Basic Information' },
+    { key: 'money', label: 'Financials', collapse: 'collapsed' },
+  ],
+};
+
+describe('field-group sections', () => {
+  it('emits one label key per rendered group, seeded from `fieldGroups[].label`', () => {
+    const entries = sectionEntries({ objects: [groupedObject] });
+
+    expect(entries.map((e) => ({ path: e.path.join('.'), inline: e.inline, objectName: e.objectName }))).toEqual([
+      {
+        path: 'objects.crm_opportunity._sections.basics.label',
+        inline: 'Basic Information',
+        objectName: 'crm_opportunity',
+      },
+      {
+        path: 'objects.crm_opportunity._sections.money.label',
+        inline: 'Financials',
+        objectName: 'crm_opportunity',
+      },
+    ]);
+  });
+
+  it('leaves the ungrouped bucket alone — it renders without a heading', () => {
+    // `notes` declares no group and lands in the trailing untitled bucket,
+    // which `deriveFieldGroupLayout` returns with NO `key`. Renderers show no
+    // card chrome for it, so there is no heading to translate.
+    expect(sectionKeys({ objects: [groupedObject] })).not.toContain(
+      'objects.crm_opportunity._sections.undefined.label',
+    );
+    expect(sectionKeys({ objects: [groupedObject] })).toHaveLength(2);
+  });
+
+  it('drops a declared group no visible field references', () => {
+    // The fields are the authority for which sections EXIST — a group nothing
+    // references never becomes a heading, so demanding a translation for it
+    // would be a gap that cannot be seen on any screen.
+    const config = {
+      objects: [
+        {
+          name: 'crm_lead',
+          fields: { name: { label: 'Name', group: 'basics' }, hidden_note: { label: 'Note', group: 'ghost', hidden: true } },
+          fieldGroups: [{ key: 'basics', label: 'Basics' }, { key: 'ghost', label: 'Ghost' }],
+        },
+      ],
+    };
+    expect(sectionKeys(config)).toEqual(['objects.crm_lead._sections.basics.label']);
+  });
+
+  it('drops a field `group` that no `fieldGroups` entry declares', () => {
+    // `deriveFieldGroupLayout` treats an undeclared group as ungrouped, so
+    // nothing renders a heading for it. Same reasoning, other direction.
+    const config = {
+      objects: [
+        {
+          name: 'crm_lead',
+          fields: { name: { label: 'Name', group: 'basics' }, phone: { label: 'Phone', group: 'nowhere' } },
+          fieldGroups: [{ key: 'basics', label: 'Basics' }],
+        },
+      ],
+    };
+    expect(sectionKeys(config)).toEqual(['objects.crm_lead._sections.basics.label']);
+  });
+
+  it('keeps `inline` unset when the group declares no label of its own', () => {
+    // The key still renders (the derivation falls back to the group key), so
+    // the skeleton is seeded — but nobody AUTHORED that text, and the coverage
+    // gate must not report an untranslated string that does not exist.
+    const entries = sectionEntries({
+      objects: [
+        {
+          name: 'crm_lead',
+          fields: { name: { label: 'Name', group: 'basics' } },
+          fieldGroups: [{ key: 'basics' }],
+        },
+      ],
+    });
+    expect(entries).toEqual([
+      {
+        path: ['objects', 'crm_lead', '_sections', 'basics', 'label'],
+        sourceValue: 'basics',
+        inline: undefined,
+        source: 'section',
+        objectName: 'crm_lead',
+      },
+    ]);
+  });
+});
+
+// ── (b) authored sections on form views and record pages ───────────────
+
+describe('authored form-view sections', () => {
+  const config = {
+    views: [
+      {
+        list: { type: 'grid', data: { object: 'crm_contact' } },
+        form: {
+          type: 'simple',
+          data: { object: 'crm_contact' },
+          sections: [
+            { name: 'contact', label: 'Contact', fields: ['name'] },
+            { name: 'work', label: 'Work', fields: ['company'] },
+          ],
+        },
+        formViews: {
+          create: {
+            type: 'simple',
+            data: { object: 'crm_contact' },
+            sections: [
+              { name: 'who', label: 'Who is this?', fields: ['name'] },
+              // No `name` → `ObjectForm`'s `tSec` falls straight through to
+              // `s.label`; the lookup can never fire, so no expected key.
+              { label: 'Anything else?', fields: ['notes'] },
+            ],
+          },
+        },
+      },
+    ],
+  };
+
+  it('covers the container default form AND its named overrides', () => {
+    expect(sectionKeys(config).sort()).toEqual([
+      'objects.crm_contact._sections.contact.label',
+      'objects.crm_contact._sections.who.label',
+      'objects.crm_contact._sections.work.label',
+    ]);
+  });
+
+  it('skips a section with no `name` — every renderer guards the lookup on it', () => {
+    expect(sectionKeys(config)).not.toContain('objects.crm_contact._sections.anything_else.label');
+  });
+});
+
+describe('authored record-page sections', () => {
+  /**
+   * The showcase `showcase_project_detail` shape: a slotted record page whose
+   * `record:details` lives two levels down inside `page:tabs`
+   * (`properties.items[].children[]`). This is the nesting the issue calls
+   * out — a walk that only looked at `regions[].components[].properties`
+   * would report nothing here.
+   */
+  const slottedPage = {
+    name: 'crm_opportunity_detail',
+    type: 'record',
+    object: 'crm_opportunity',
+    kind: 'slotted',
+    regions: [],
+    slots: {
+      tabs: {
+        type: 'page:tabs',
+        properties: {
+          items: [
+            {
+              key: 'details',
+              label: 'Details',
+              children: [
+                {
+                  type: 'record:details',
+                  properties: {
+                    sections: [
+                      { name: 'overview', label: 'Overview', fields: ['name'] },
+                      { name: 'timeline', title: 'Timeline', fields: ['close_date'] },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  it('reaches sections nested under `page:tabs → children → record:details`', () => {
+    expect(sectionKeys({ pages: [slottedPage] }).sort()).toEqual([
+      'objects.crm_opportunity._sections.overview.label',
+      'objects.crm_opportunity._sections.timeline.label',
+    ]);
+  });
+
+  it('reads `title` as the source text too — that is what `record:details` renders', () => {
+    const timeline = sectionEntries({ pages: [slottedPage] }).find((e) => e.path[3] === 'timeline');
+    expect(timeline?.inline).toBe('Timeline');
+  });
+
+  it('reaches the plain `regions[].components[]` shape, and never mines a page REGION name', () => {
+    // `PageSchema.aliases` maps `sections` → `regions`, and a region carries a
+    // `name` exactly like a section does. The shared walk enters at
+    // `regions[].components[]` / `slots.<slot>` and reads `sections` only from
+    // a COMPONENT's `properties`, so the region name `main` can never become a
+    // heading key.
+    //
+    // Paired with a real section in that same region, so the assertion cannot
+    // pass merely because nothing was produced.
+    const config = {
+      pages: [
+        {
+          name: 'crm_lead_detail',
+          object: 'crm_lead',
+          regions: [
+            {
+              name: 'main',
+              components: [
+                { type: 'record:details', properties: { sections: [{ name: 'summary', label: 'Summary' }] } },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const keys = sectionKeys(config);
+    expect(keys).toEqual(['objects.crm_lead._sections.summary.label']);
+    expect(keys).not.toContain('objects.crm_lead._sections.main.label');
+  });
+
+  it('ignores a page with no object binding — the key has nothing to hang on', () => {
+    const detailsComponent = {
+      type: 'record:details',
+      properties: { sections: [{ name: 'summary', label: 'Summary' }] },
+    };
+    const config = {
+      pages: [
+        // No `object`: the section is real but there is no object to key it
+        // under, so no expected key can be formed.
+        { name: 'marketing_home', regions: [{ name: 'main', components: [detailsComponent] }] },
+        // Same component, bound — proves the exclusion is the binding and not
+        // a dead walk.
+        { name: 'crm_lead_detail', object: 'crm_lead', regions: [{ name: 'main', components: [detailsComponent] }] },
+      ],
+    };
+    expect(sectionKeys(config)).toEqual(['objects.crm_lead._sections.summary.label']);
+  });
+
+  it('keys a re-bound component under ITS object, not the page’s', () => {
+    // `dataSource.object` / `properties.object` retarget a component, so one
+    // page can show two objects. Keying such a section under the PAGE's object
+    // is worse than missing it — the bundle entry would sit at a path the
+    // resolver never reads. The shared lint traversal resolves the binding per
+    // component, which is the reason to reuse it rather than re-walk here.
+    const config = {
+      pages: [
+        {
+          name: 'crm_lead_detail',
+          object: 'crm_lead',
+          regions: [
+            {
+              name: 'main',
+              components: [
+                {
+                  type: 'record:details',
+                  dataSource: { object: 'crm_account' },
+                  properties: { sections: [{ name: 'company', label: 'Company' }] },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(sectionKeys(config)).toEqual(['objects.crm_account._sections.company.label']);
+  });
+
+  it('skips a source-authored page — its `regions` are a derived cache, not authoring', () => {
+    // `kind: 'html' | 'react' | 'jsx'` pages are authored as `source`; the
+    // region tree is at most a compiled cache the source wins over. Scaffolding
+    // translation keys off it would invent an authoring surface, so the shared
+    // walk yields nothing for those pages. Paired with the same component on a
+    // normally-authored page.
+    const detailsComponent = {
+      type: 'record:details',
+      properties: { sections: [{ name: 'summary', label: 'Summary' }] },
+    };
+    const config = {
+      pages: [
+        { name: 'crm_lead_html', object: 'crm_lead', kind: 'html', source: '<div/>', regions: [{ name: 'main', components: [detailsComponent] }] },
+        { name: 'crm_account_detail', object: 'crm_account', regions: [{ name: 'main', components: [detailsComponent] }] },
+      ],
+    };
+    expect(sectionKeys(config)).toEqual(['objects.crm_account._sections.summary.label']);
+  });
+});
+
+describe('one key per (object, section) however many surfaces declare it', () => {
+  it('does not double-count a heading authored as a field group AND a page section', () => {
+    const config = {
+      objects: [groupedObject],
+      pages: [
+        {
+          name: 'crm_opportunity_detail',
+          object: 'crm_opportunity',
+          regions: [
+            {
+              name: 'main',
+              components: [
+                { type: 'record:details', properties: { sections: [{ name: 'basics', label: 'Basic Information' }] } },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(sectionKeys(config)).toEqual([
+      'objects.crm_opportunity._sections.basics.label',
+      'objects.crm_opportunity._sections.money.label',
+    ]);
+  });
+
+  it('takes the authored heading from whichever surface has one', () => {
+    // The field group declares no `label`, the page section does. Whichever
+    // surface is walked first, `inline` has to report the text the reader
+    // actually sees — otherwise the gate stays quiet about a heading that is
+    // sitting on screen in the source locale.
+    const config = {
+      objects: [
+        {
+          name: 'crm_lead',
+          fields: { name: { label: 'Name', group: 'basics' } },
+          fieldGroups: [{ key: 'basics' }],
+        },
+      ],
+      pages: [
+        {
+          name: 'crm_lead_detail',
+          object: 'crm_lead',
+          regions: [
+            {
+              name: 'main',
+              components: [
+                { type: 'record:details', properties: { sections: [{ name: 'basics', label: 'Basic Information' }] } },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const entries = sectionEntries(config);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].inline).toBe('Basic Information');
+  });
+});
+
+// ── The gate: lint reports it, extract scaffolds it ────────────────────
+
+describe('coverage + lint', () => {
+  const config = {
+    objects: [groupedObject],
+    i18n: { defaultLocale: 'en', supportedLocales: ['ja-JP'] },
+    translations: [
+      {
+        'ja-JP': {
+          objects: {
+            crm_opportunity: {
+              label: '商談',
+              fields: { name: { label: '名前' }, amount: { label: '金額' }, notes: { label: 'メモ' } },
+              // `basics` is translated; `money` is not — exactly the hotcrm
+              // shape where a bundle looks complete and the headings are not.
+              _sections: { basics: { label: '基本情報' } },
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  it('reports the untranslated heading that used to be invisible', () => {
+    const report = computeI18nCoverage(config);
+    const sections = report.issues.filter((i) => i.source === 'section');
+
+    expect(sections.map((i) => ({ locale: i.locale, key: i.key, severity: i.severity }))).toEqual([
+      {
+        locale: 'ja-JP',
+        key: 'objects.crm_opportunity._sections.money.label',
+        severity: 'warning',
+      },
+    ]);
+    expect(sections[0].message).toContain('Section "crm_opportunity" _sections.money.label');
+  });
+
+  it('surfaces it through `os lint` as `i18n/missing-section`, not as platform noise', () => {
+    const { folded, hiddenPlatform } = foldCoverageIssues(
+      computeI18nCoverage(config).issues,
+      /* includePlatform */ false,
+    );
+    const rules = folded.filter((i) => i.rule.startsWith('i18n/')).map((i) => i.rule);
+
+    expect(rules).toContain('i18n/missing-section');
+    // The heading belongs to the user's own metadata: `--include-platform`
+    // must not be what makes it visible.
+    expect(hiddenPlatform).toBeGreaterThan(0);
+    expect(
+      foldCoverageIssues(computeI18nCoverage(config).issues, false).folded.some(
+        (i) => i.path === 'translations.ja-JP.objects.crm_opportunity._sections.money.label',
+      ),
+    ).toBe(true);
+  });
+
+  it('scaffolds the heading in `os i18n extract` — the same walker, for free', () => {
+    const result = extractTranslations({ objects: [groupedObject] }, { locales: ['ja-JP'], fill: 'default' });
+    expect((result.bundles['ja-JP'] as any).objects.crm_opportunity._sections).toEqual({
+      basics: { label: 'Basic Information' },
+      money: { label: 'Financials' },
+    });
+  });
+
+  it('a monolingual project still reports nothing', () => {
+    // The gate is opt-in by construction and sections must not break that.
+    const report = computeI18nCoverage({ objects: [groupedObject] });
+    expect(report.issues.filter((i) => i.source === 'section')).toEqual([]);
+  });
+});
+
+// ── Reconciliation: declared = enforced ────────────────────────────────
+
+describe('the emitted key is the key the platform declares and consumes', () => {
+  it('every emitted path parses against `ObjectTranslationDataSchema._sections`', () => {
+    // The DECLARATION face. `packages/spec/src/system/translation.zod.ts`
+    // declares `_sections: z.record(..., { label, description })` on a
+    // strictObject — so a walker that invented a spelling (`sections`,
+    // `_section`, `.title`) would be rejected here rather than silently
+    // scaffolding keys no bundle may legally carry.
+    const bundle = extractTranslations({ objects: [groupedObject] }, { locales: ['en'] })
+      .bundles.en as any;
+
+    const parsed = ObjectTranslationDataSchema.safeParse(bundle.objects.crm_opportunity);
+    expect(parsed.success ? null : parsed.error.issues).toBeNull();
+    expect(Object.keys((parsed as any).data._sections)).toEqual(['basics', 'money']);
+  });
+
+  it('field-group keys are read through the shared ADR-0085 derivation, not a second copy', () => {
+    // The CONSUMPTION face. `deriveFieldGroupLayout` is the one derivation the
+    // renderers consume — `@object-ui/plugin-detail`'s
+    // `deriveFieldGroupDetailSections` maps its `key` straight onto the
+    // section `name` that `sectionLabel(object, name, …)` looks up. Deriving
+    // the expected set the same way is what makes "declared" and "gated" the
+    // same set instead of two lists that drift.
+    const rendered = (deriveFieldGroupLayout(groupedObject) ?? [])
+      .filter((s) => s.key !== undefined)
+      .map((s) => `objects.crm_opportunity._sections.${s.key}.label`);
+
+    expect(sectionKeys({ objects: [groupedObject] })).toEqual(rendered);
+  });
+});
+
+// ── Real metadata from the in-repo example app ─────────────────────────
+
+describe('the showcase app, walked for real', () => {
+  it('picks up `showcase_contact`’s default-form sections and `showcase_semantic_zoo`’s field groups', async () => {
+    const [{ ContactViews }, { SemanticZoo }] = await Promise.all([
+      import('../../../examples/app-showcase/src/ui/views/contact.view'),
+      import('../../../examples/app-showcase/src/data/objects/semantic-zoo.object'),
+    ]);
+
+    const keys = sectionKeys({ objects: [SemanticZoo], views: [ContactViews] });
+
+    expect(keys.sort()).toEqual([
+      // `fieldGroups: [{ key: 'basics' }, { key: 'money' }]`, both referenced
+      // by `group:` on real fields.
+      'objects.showcase_semantic_zoo._sections.basics.label',
+      'objects.showcase_semantic_zoo._sections.money.label',
+      // `ContactViews.form.sections[].name` — the container's DEFAULT form,
+      // which `ObjectForm` renders and translates like any other.
+      'objects.showcase_contact._sections.contact.label',
+      'objects.showcase_contact._sections.notes.label',
+      'objects.showcase_contact._sections.status.label',
+      'objects.showcase_contact._sections.work.label',
+    ].sort());
+  }, 60_000);
+});

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -507,3 +507,11 @@ export {
   stackKeyForType,
 } from './runtime-gate.js';
 export type { RuntimeGateResult, RuntimeStackContext } from './runtime-gate.js';
+
+// The shared page-component traversal every `properties`-inspecting rule is
+// built on (#3583). Exported because the CLI's i18n walker needs the same
+// traversal to find `record:details` sections — and this walk is the one whose
+// duplication has already produced a dead rule, so a second copy in another
+// package is exactly what the module exists to prevent (#5405).
+export { walkPageComponents, isSourceAuthoredPage } from './page-walk.js';
+export type { WalkedComponent } from './page-walk.js';


### PR DESCRIPTION
Fixes #5405

> 正文刻意不写 `&lt;` 紧跟字母的写法(GitHub 正文清洗器会把它当 HTML 标签吞掉)。占位符一律写成 `{type}` / `{slot}` 形式。

## 前提核验(先证伪,再动手)

按 rule 6 对 `origin/main`(`b4872a868`)逐条验证 issue 正文,三条全部成立:

- `grep -c "_sections" packages/cli/src/utils/i18n-extract.ts` → `0`;反查对照组 `_views` → `9`、`fieldGroups` → `0`。零命中不是 grep 失灵。
- `ExpectedEntry['source']` 联合类型(`i18n-extract.ts:96-111`)确无 `section`;两个 `metadataForm*` 项走的是 `metadataForms.{type}.sections.*` 这条 Studio 元数据表单命名空间,与 app object 无关。
- `COVERAGE_SOURCE`(`i18n-coverage.ts`)照抄同一联合,`computeI18nCoverage` 结构上不可能报出缺失的段落标题。

反向面同样核实过:声明面 `ObjectTranslationDataSchema._sections`(`packages/spec/src/system/translation.zod.ts:216`,并把 `sections` 列为 authoring alias);消费面 `@object-ui/i18n` 的 `sectionLabel`(`useObjectLabel.ts:397-400`)被 `plugin-detail` 的 `record:details`、`plugin-form` 的 `ObjectForm`/`ModalForm`、以及 `ObjectFormDesigner` 三处读取。**只有走查器不知道这个面存在。**

## 改法

新增 `section` kind,双源取齐,同一 (object, section) 只产一个 key:

**(a) `fieldGroups` × 字段 `group`。** 经 `deriveFieldGroupLayout`(ADR-0085 §5)判定 —— 这正是渲染端自己消费的那份共享推导(`plugin-detail` 的 `deriveFieldGroupDetailSections` 把它的 `key` 直接映射成 `sectionLabel(object, name, …)` 查的那个 `name`)。因此:没有可见字段引用的已声明分组不出 key,`fieldGroups` 未声明的 `group:` 也不出 key,尾部无 key 的 ungrouped 桶不出 key —— 屏幕上不存在的标题,不该记一笔翻译债。`fieldGroups[].label` 供默认语言文本;分组自身没写 `label` 时仍产出脚手架 key(种子退回分组名),但 `inline` 留空,覆盖门不去追一句没人写过的话。

**(b) 具名 `sections[]`。** 表单视图(含容器的默认 `form`)与记录页组件树。无 `name` 的段落一律跳过 —— 每个渲染端都把查表挂在它上面(`s?.name ? sectionLabel(…) : s?.label`),没有 `name` 就是构造性不可翻译。

`COVERAGE_SOURCE` 映射之,`os lint` 得到 `i18n/missing-section` 类别,落在用户桶而非平台桶(不需要 `--include-platform` 才看得见);`os i18n extract` 的骨架经共享走查器免费获得。

### 页面这半边:复用,而不是再抄一份

页面段落走 `@objectstack/lint` 的 `walkPageComponents`(本 PR 顺带把它连同 `isSourceAuthoredPage` / `WalkedComponent` 从 lint 的 index 导出)。`page-walk.ts` 的模块头就写着它为何独此一份:重复实现已经造出过一条死规则(#3583)。复用不只是 DRY,它是这半边**正确**与**仅仅存在**的分界:

- 组件挂在 `regions[].components` **和** `slots.{slot}`(后者可以是裸组件而非数组);
- 子树藏在无类型的 `properties` 袋里(`page:tabs` → `properties.items[].children[]`,`page:card` → `properties.body`/`.footer`)—— 也就是 issue 点名的那层深嵌套;
- `kind: 'html' | 'react' | 'jsx'` 的页面,`regions` 只是 `source` 的派生缓存,拿它刮 key 等于凭空发明一个作者面;
- 每个组件解析**自己**的绑定(`dataSource.object` → `properties.object` → 页面 `object`)。这条比「漏」更要紧:被 `dataSource` 改绑到别的对象的 `record:details`,若按页面对象记 key,产出的是一个解析器永远不读的**错**路径。

## 验证

```
pnpm --filter @objectstack/cli exec vitest run --maxWorkers=2
  Test Files  78 passed (78)      Tests  749 passed (749)

pnpm --filter @objectstack/lint test
  Test Files  57 passed (57)      Tests  1198 passed (1198)

pnpm --filter @objectstack/cli --filter @objectstack/lint typecheck
  packages/lint typecheck: Done
  packages/cli typecheck: Done
```

新增 `packages/cli/test/i18n-section-coverage.test.ts`(22 例)。

**反向核验 —— 方向是先判后跑,结果是常规的「红」:** 这是补一个从未存在的面,不是收窄既有规则,所以预判为「注释掉 `walkObjectSections(config, out)` 调用 → 新用例转红」。实测 `16 failed | 4 passed`,方向吻合。那 4 例正是断言「不该产出」的负向用例 —— 它们在删除态下**因为什么都没产出而绿**,即 PR #5046 记录的空集假绿。据此逐条整改,而不是留给下一个读者踩:

- 「区域名不当作段落名」与「未绑定对象的页面跳过」两例,各自补上同配置下的正向断言(同一个 region 里放一个真段落 / 同一个组件挂到一个绑定了对象的页面上),现在它们无法靠「什么都没有」通过;
- 「无 `name` 的段落跳过」由同 describe 首例的精确 `toEqual([三个 key])` 兜住,负向断言只是把意图写明;
- 「单语项目零告警」是刻意的 opt-in 不变量,同一对象的正向覆盖用例就在上面。

**对账锚(声明即强制),两面各一处:**

- **声明面** —— 把 `extractTranslations` 产出的 bundle 直接喂给 `ObjectTranslationDataSchema.safeParse`,要求全绿且 `_sections` 键集合精确匹配。走查器若发明了拼写(`sections` / `_section` / `.title`),在这里被严格 schema 当场拒绝,而不是安静地刮出一堆 bundle 合法性存疑的 key。
- **消费面** —— 断言字段分组产出的 key 集合 **等于** `deriveFieldGroupLayout` 自己返回的有 key 段落集合。渲染端消费的就是这份推导,于是「声明的」与「被门禁的」是同一个集合,而不是两张会漂移的清单。

**真实取数** —— 直接 import 仓内示例 app 的两个模块,不造假数据:`examples/app-showcase/src/ui/views/contact.view.ts`(容器默认 `form` 的四个具名段落 `contact`/`work`/`status`/`notes`,绑 `showcase_contact`)与 `examples/app-showcase/src/data/objects/semantic-zoo.object.ts`(`fieldGroups: basics/money`,两者都被真实字段的 `group:` 引用),断言六个 key 一个不多一个不少。按车道纪律该用例显式 `}, 60_000)`。

## 越界与顺带发现

- ⛔ 未触碰 `_views` 族的任何拼写/键逻辑(#5164 领地),未触碰 `commands/doctor.ts`(在飞 #5412)。
- **唯一一处越出 PM 声明文件面**:`packages/lint/src/index.ts` 增加一行导出。理由如上 —— 另一个选择是在 cli 里再抄一份页面走查,而那正是 `page-walk.ts` 存在的目的所反对的,且会丢掉按组件解析绑定这条正确性。`packages/lint` 无 API 基线门禁,全量 1198 例通过。
- **顺带发现,已单独立 issue #5415(未在本 PR 修)**:`packages/lint` 的 `validate-translation-references` 在收集 `_sections` 事实时,`collectViewRecord` 只遍历 `['listViews', 'formViews']`,**漏掉视图容器的默认 `form.sections`**。实测:给 `showcase_contact` 正确翻译一个真实渲染的段落标题,会被报 `translation-target-unknown`,措辞还是「该对象根本没有具名段落」—— 建议作者删掉一个能用的翻译。本 PR 落地后二者会在真实 showcase 元数据上互相打架(extract 刮出的 key 立刻被 lint 判为未知目标),所以现在就记了下来。应有的集合关系是:覆盖走查器**要求**的每个 key,都必须是引用校验器**接受**的 key。