### PR TITLE
fix(lint): `translation-target-unknown` 读取视图容器的默认 `form.sections` (#5415)

### DIFF
--- a/.changeset/translation-refs-container-default-form-sections.md
+++ b/.changeset/translation-refs-container-default-form-sections.md
@@ -1,0 +1,36 @@
+---
+"@objectstack/lint": patch
+---
+
+fix(lint): `translation-target-unknown` reads a view container's DEFAULT `form.sections` (#5415)
+
+`validate-translation-references` derives the `_sections` names an object may
+legally be translated by from a list of anchors: `fieldGroups[].key`, the named
+sections on `listViews.*` / `formViews.*`, the named sections on a page's
+`record:details` component, and the view record's own `sections`. The list was
+missing one: the view CONTAINER's **default form** — the `form` that
+`defineView({ list, form, formViews })` declares and that `ObjectForm` renders
+when no named form view is asked for.
+
+`collectViewRecord` iterated `['listViews', 'formViews']`, and `view.form` is
+neither of those nor the record's own `sections`, so `view.form.sections[].name`
+contributed **nothing** to the fact set. The renderer resolves those headings
+through exactly the same `sectionLabel(object, section.name, …)` convention as
+any named form view, so a bundle that correctly translated one of them was
+reported as keyed to a section "which nothing on object X declares", with a hint
+advising the author to delete a translation that renders. On the in-repo
+showcase contact surface — whose object declares `field.group` and no
+`fieldGroups[]`, so the default form is its **only** section anchor — all four
+headings were in that state, and the hint went as far as "declares no named
+section at all".
+
+The default form now feeds the same section collector as `formViews.*`, bound
+by `bindingOf(view.form) ?? listBinding` — i.e. `form.data.object` first, then
+the record-level object, then the list beside it — which is the resolution the
+CLI i18n walker performs for the same surface, so the rule that DEMANDS a key
+and the rule that ACCEPTS one agree on which object a heading belongs to. Each
+anchor is now a call into one collector rather than its own copy of the loop.
+
+Nothing tightens: an unnamed section is still untranslatable (it has no stable
+key to look up), and a `_sections` key no anchor declares is still reported —
+now with the real anchors enumerated in the hint.

--- a/packages/lint/src/validate-translation-references.test.ts
+++ b/packages/lint/src/validate-translation-references.test.ts
@@ -6,6 +6,10 @@ import {
   TRANSLATION_TARGET_UNKNOWN,
   TRANSLATION_OPTION_KEY_UNKNOWN,
 } from './validate-translation-references.js';
+// Real shipped metadata — see the `#5415` describe block for why this is
+// imported rather than reduced by hand.
+import { Contact } from '../../../examples/app-showcase/src/data/objects/contact.object.js';
+import { ContactViews } from '../../../examples/app-showcase/src/ui/views/contact.view.js';
 
 /** A stack shaped like the HotCRM lead surface: fields, options, a view, an action. */
 const leadStack = (translations: unknown[]) => ({
@@ -532,4 +536,134 @@ describe('validateTranslationReferences — section anchors', () => {
     expect(findings).toHaveLength(1);
     expect(findings[0].hint).toContain('declares no named section at all');
   });
+
+  // #5415. `collectViewRecord` walked `['listViews', 'formViews']` and the
+  // record's own `sections`; the CONTAINER's default form — `defineView({ form:
+  // … })`, the one `ObjectForm` renders when no named form view is asked for —
+  // was in neither, so its named sections contributed nothing and a correct
+  // translation of a heading that DOES render was reported as an unknown
+  // target.
+  it('resolves a section named on the container default `form`', () => {
+    const stack = {
+      objects: [{ name: 'crm_lead', fields: { name: { type: 'text' } } }],
+      views: [
+        {
+          list: { type: 'grid', name: 'all_leads', data: { provider: 'object', object: 'crm_lead' } },
+          form: {
+            type: 'simple',
+            data: { provider: 'object', object: 'crm_lead' },
+            sections: [{ name: 'contact_info', label: 'Contact Info' }],
+          },
+        },
+      ],
+      translations: [
+        { en: { objects: { crm_lead: { label: 'Lead', _sections: { contact_info: { label: 'Contact' } } } } } },
+      ],
+    };
+    expect(validateTranslationReferences(stack)).toEqual([]);
+  });
+
+  it('binds the default `form` by its OWN data, not by the list beside it', () => {
+    // Two objects in one record: the list shows leads, the form edits contacts.
+    // The section belongs to whatever `form.data.object` says — the same
+    // resolution the CLI i18n walker's `viewObjectName` performs.
+    //
+    // Both directions are asserted in ONE stack on purpose. "crm_lead is still
+    // reported" alone would pass just as well if the default form contributed
+    // NOTHING (the pre-#5415 behaviour) — it is the `crm_contact` half, which
+    // resolves only once the form is collected under its own binding, that
+    // makes the pair falsifiable.
+    const stack = (objectName: string) => ({
+      objects: [
+        { name: 'crm_lead', fields: { name: { type: 'text' } } },
+        { name: 'crm_contact', fields: { name: { type: 'text' } } },
+      ],
+      views: [
+        {
+          list: { type: 'grid', name: 'all_leads', data: { provider: 'object', object: 'crm_lead' } },
+          form: {
+            type: 'simple',
+            data: { provider: 'object', object: 'crm_contact' },
+            sections: [{ name: 'contact_info', label: 'Contact Info' }],
+          },
+        },
+      ],
+      translations: [
+        { en: { objects: { [objectName]: { label: 'X', _sections: { contact_info: { label: 'Contact' } } } } } },
+      ],
+    });
+
+    expect(validateTranslationReferences(stack('crm_contact'))).toEqual([]);
+
+    const findings = validateTranslationReferences(stack('crm_lead'));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].path).toBe('translations[0].en.objects.crm_lead._sections.contact_info');
+  });
+});
+
+/**
+ * #5415, pinned against the metadata the repo actually ships.
+ *
+ * `examples/app-showcase` is imported here rather than reduced by hand on
+ * purpose: the defect was an anchor MISSING from a list, and a hand-written
+ * fixture can only pin the anchors whoever wrote it remembered. The showcase
+ * contact surface is the exact shape that exposed it —
+ *
+ *   - the object declares `field.group` and NO `fieldGroups[]`, so the object
+ *     side contributes no section anchor at all;
+ *   - the container's default `form` names all four sections;
+ *   - `formViews.create` names none of its own (a sparse create override with
+ *     one unnamed section) — which is what keeps the "still reports a real
+ *     unknown" control below honest.
+ *
+ * So every `_sections` key this surface legitimately carries comes from
+ * `view.form.sections[].name`, and nothing else.
+ */
+describe('validateTranslationReferences — the showcase contact surface (#5415)', () => {
+  const showcaseContactStack = (translations: unknown[]) => ({
+    objects: [Contact],
+    views: [ContactViews],
+    translations,
+  });
+
+  const sectionBundle = (sections: Record<string, unknown>) => [
+    { 'zh-CN': { objects: { showcase_contact: { _sections: sections } } } },
+  ];
+
+  it('accepts every section the default form names', () => {
+    // `ObjectForm` renders these four headings and resolves each through
+    // `sectionLabel(object, section.name, …)` — translating them is correct.
+    const findings = validateTranslationReferences(
+      showcaseContactStack(
+        sectionBundle({
+          contact: { label: '联系方式' },
+          work: { label: '工作' },
+          status: { label: '状态' },
+          notes: { label: '备注' },
+        }),
+      ),
+    );
+    expect(findings).toEqual([]);
+  }, 60_000);
+
+  it('still reports a section name nothing declares, and names the real ones', () => {
+    // The over-widening control: `contract` is a typo of `contact`, and
+    // `who_is_this` is the LABEL of `formViews.create`'s unnamed section — an
+    // unnamed section is not translatable, so neither key may resolve.
+    const findings = validateTranslationReferences(
+      showcaseContactStack(sectionBundle({ contract: { label: '合同' }, who_is_this: { label: '这是谁' } })),
+    );
+    expect(findings).toHaveLength(2);
+    expect(findings.map((f) => f.rule)).toEqual([TRANSLATION_TARGET_UNKNOWN, TRANSLATION_TARGET_UNKNOWN]);
+    expect(findings.map((f) => f.path)).toEqual([
+      'translations[0]["zh-CN"].objects.showcase_contact._sections.contract',
+      'translations[0]["zh-CN"].objects.showcase_contact._sections.who_is_this',
+    ]);
+    // The hint now enumerates the anchors the object really has, instead of
+    // claiming it "declares no named section at all".
+    for (const finding of findings) {
+      expect(finding.hint).toContain('Declared sections: contact, notes, status, work');
+      expect(finding.hint).not.toContain('declares no named section at all');
+    }
+  }, 60_000);
 });

--- a/packages/lint/src/validate-translation-references.ts
+++ b/packages/lint/src/validate-translation-references.ts
@@ -218,6 +218,18 @@ function emptyFacts(): ObjectFacts {
  *     at the record root. A record-level lookup alone resolves to nothing on
  *     the canonical shape, which silently drops the whole record — a rule that
  *     then reports every view key the app ships.
+ *
+ * A third thing was learned later, from the showcase (#5415): the container's
+ * DEFAULT form (`form`) is a section anchor too. It is not one of the
+ * `formViews.*` entries and it is not the record's own `sections` either, so
+ * for two protocol versions its named sections contributed NOTHING — and a
+ * bundle that correctly translated one of them was reported as keyed to a
+ * section "nothing declares", with a hint advising the author to delete a
+ * translation that renders. `ObjectForm` reads that form and resolves its
+ * headings through the same `sectionLabel(object, section.name, …)` convention
+ * as any named form view, so every anchor below feeds ONE collector: the list
+ * of anchors is now a list of call sites, not four copies of a loop that can
+ * drift apart one at a time.
  */
 function collectViewRecord(view: AnyRec, factsFor: (objectName: string) => ObjectFacts): void {
   const recordObject = viewObjectName(view);
@@ -226,6 +238,22 @@ function collectViewRecord(view: AnyRec, factsFor: (objectName: string) => Objec
 
   const addView = (objectName: string | undefined, name: string | undefined) => {
     if (objectName && name) factsFor(objectName).views.add(name);
+  };
+
+  /**
+   * Register the `_sections` names one form-ish container declares.
+   *
+   * Form sections carry an OPTIONAL `name` that exists purely for the
+   * `_sections` lookup (`ui/view.zod.ts`: "Stable section identifier for i18n
+   * lookup"). A section without one cannot be translated at all, so it
+   * contributes nothing here.
+   */
+  const addSections = (container: AnyRec, binding: string | undefined) => {
+    if (!binding) return;
+    for (const section of asArray(container.sections)) {
+      const sectionName = strName(section.name);
+      if (sectionName) factsFor(binding).sections.add(sectionName);
+    }
   };
 
   const listBinding = isRec(view.list) ? bindingOf(view.list) : undefined;
@@ -240,27 +268,19 @@ function collectViewRecord(view: AnyRec, factsFor: (objectName: string) => Objec
       const binding = bindingOf(sub) ?? listBinding;
       addView(binding, subKey);
       addView(binding, strName(sub.name));
-
-      // Form sections carry an OPTIONAL `name` that exists purely for the
-      // `_sections` lookup (`ui/view.zod.ts`: "Stable section identifier for
-      // i18n lookup"). A section without one cannot be translated at all, so
-      // it contributes nothing here.
-      if (binding) {
-        for (const section of asArray(sub.sections)) {
-          const sectionName = strName(section.name);
-          if (sectionName) factsFor(binding).sections.add(sectionName);
-        }
-      }
+      addSections(sub, binding);
     }
   }
 
-  const sectionBinding = recordObject ?? listBinding;
-  if (sectionBinding) {
-    for (const section of asArray(view.sections)) {
-      const sectionName = strName(section.name);
-      if (sectionName) factsFor(sectionBinding).sections.add(sectionName);
-    }
-  }
+  // The container's default form — the one `defineView({ form: … })` declares
+  // and `ObjectForm` renders when no named form view is asked for. Bound the
+  // way the CLI i18n walker's `viewObjectName` resolves `view.form.data.object`
+  // (#5415), so the two agree on which object the headings belong to.
+  // Deliberately sections only: the default form has no map key, and whether it
+  // contributes a `_views` name is the neighbouring question #5164 owns.
+  if (isRec(view.form)) addSections(view.form, bindingOf(view.form) ?? listBinding);
+
+  addSections(view, recordObject ?? listBinding);
 }
 
 /** The object a view (or one of its containers) binds to, across the shapes it is authored in. */

--- a/packages/lint/src/validate-translation-references.ts
+++ b/packages/lint/src/validate-translation-references.ts
@@ -222,7 +222,7 @@ function emptyFacts(): ObjectFacts {
  * A third thing was learned later, from the showcase (#5415): the container's
  * DEFAULT form (`form`) is a section anchor too. It is not one of the
  * `formViews.*` entries and it is not the record's own `sections` either, so
- * for two protocol versions its named sections contributed NOTHING — and a
+ * its named sections contributed NOTHING to the fact set — and a
  * bundle that correctly translated one of them was reported as keyed to a
  * section "nothing declares", with a hint advising the author to delete a
  * translation that renders. `ObjectForm` reads that form and resolves its


### PR DESCRIPTION
Fixes #5415

## 前提复核(改之前先证伪)

按正文在 `origin/main`(切 worktree 时 `9fad07f66`,issue 钉的是 `b4872a868`,两者之间未触 `packages/lint`)重跑了 showcase 复现:直接 import 真实的 `examples/app-showcase/src/ui/views/contact.view.ts`,把正确翻译 `showcase_contact._sections.contact` 的 bundle 喂给 `validateTranslationReferences`,输出与 issue 正文**逐字一致**:

```
rule:     translation-target-unknown
severity: warning
where:    locale "zh-CN" · object "showcase_contact" · section "contact"
message:  Translations are keyed to section "contact", which nothing on object
          "showcase_contact" declares — no `fieldGroups[].key`, no named form-view
          section, no named `record:details` section. ...
hint:     ... Object "showcase_contact" declares no named section at all.
```

前提成立。

## 改了什么

`collectViewRecord` 原本从四个锚点收集对象的合法 `_sections` 名:`fieldGroups[].key`、`listViews.*` / `formViews.*` 的具名段落、页面 `record:details` 的具名段落、以及视图记录自身的 `sections`。容器的**默认 `form`**(`defineView({ list, form, formViews })` 里那个、没有指定具名表单视图时 `ObjectForm` 渲染的那个)哪一条都不是 —— 循环写死 `['listViews', 'formViews']`,而它既不在其中、也不是记录自身的 `sections`,于是 `view.form.sections[].name` 对事实集**零贡献**。

现在默认 `form` 走与 `formViews.*` 完全相同的段落收集路径,绑定取 `bindingOf(view.form) ?? listBinding` —— 即先 `form.data.object`、再记录级对象、最后旁边那个 list 的绑定 —— 与 CLI i18n walker 的 `viewObjectName` 对 `view.form.data.object` 的解析对齐。这正是 #5405 要建立的集合关系(覆盖走查器**要求**的 key ⊆ 引用校验器**接受**的 key)在 lint 侧的那一半。

顺带把四处段落收集收敛成一个 `addSections` 收集器:锚点清单从此是「一串调用点」,而不是四份会各自漂移的循环副本。

**没有任何收紧**:无名段落依旧不可翻译(它没有可查的稳定 key),任何锚点都没声明的 `_sections` key 依旧上报 —— 只是 hint 现在会列出真实存在的锚点,而不再断言「declares no named section at all」。

未触 `_views` 族(#5164 领地),未触 `packages/lint/src/index.ts`(PR #5416 在队列中触该文件)。

## 测试

`packages/lint/src/validate-translation-references.test.ts` 新增 4 例:

1. **默认 `form` 的具名段落可解析**(合成最小形状)。
2. **默认 `form` 按自己的 `data` 绑定,而不是旁边的 list** —— 一个 stack 里同时断言两个方向。只断言「`crm_lead` 仍被上报」是**不可证伪**的:在修复前它同样通过,因为默认 form 什么都没贡献(空集合让断言"通过"的经典陷阱);是 `crm_contact` 那一半让这一对有了方向。
3. + 4. **真实 showcase 元数据**(`import { Contact }` + `import { ContactViews }`)。选真实 import 而不是手工缩写:缺陷本身就是「锚点清单漏了一项」,手写 fixture 只能钉住作者记得的锚点。而这个面恰好是暴露它的形状 —— 对象只声明 `field.group`、没有 `fieldGroups[]`,所以**默认 form 是它唯一的段落锚点**。一例钉四个具名段落全部被接受;一例是防过度放宽的反例:`contract`(`contact` 的错拼)与 `who_is_this`(`formViews.create` 那个**无名**段落的 label)两个 key 仍各上报一条,且 hint 改口列出 `Declared sections: contact, notes, status, work`。

按车道口径,两条真实元数据 import 的用例显式 `}, 60_000)`。

### 反向验证(方向先预判,再跑)

预判:删掉新加的这一条 limb,4 条新用例应**全红**(这是纯放宽,不存在 #5018 那种反转,也不存在 #5046 那种「计数从 1 变 0 反而多出诊断」)。实测一致:

```
× resolves a section named on the container default `form` 12ms
× binds the default `form` by its OWN data, not by the list beside it 2ms
× accepts every section the default form names 3ms
× still reports a section name nothing declares, and names the real ones 5ms
AssertionError: expected [ { severity: 'warning', …(5) } ] to deeply equal []
AssertionError: expected 'Sections are translatable only throug…' to contain 'Declared sections: contact, notes, st…'
Tests  4 failed | 24 passed (28)
```

恢复 limb 后:

```
pnpm --filter @objectstack/lint test        →  Test Files 57 passed | Tests 1202 passed (1202)
pnpm --filter @objectstack/lint typecheck   →  tsc --noEmit (clean)
pnpm --filter @objectstack/lint build       →  DTS Build success
npx eslint <两个改动文件> --no-inline-config  →  clean
node scripts/check-nul-bytes.mjs            →  OK (5429 files)
```

消费半径已按规则的调用点(而非改动包)扫过:`translation-target-unknown` / `validateTranslationReferences` 仅由 `packages/lint` 内的 `reference-integrity-suite` + `index.ts` 消费,全仓 `_sections` 的 fixture 只出现在本规则的测试与 `packages/spec` 的 translation schema 测试里 —— 没有 #5046 那种跨包 fixture 需要同步。

### 关于 #5416

切 worktree 时 PR #5416(#5405)尚未合入 `main`,故按分诊口径**跳过**「走查器要求 ⊆ 校验器接受」的集合断言,不为它引入跨分支依赖;本修复不依赖 #5416。#5416 落地后可在其上补该断言。

## 越界发现(已另开 issue,未在本 PR 修)

- #5420 — `ContactViews` 在 `examples/app-showcase/objectstack.config.ts` 的 `views` 里**从未注册**(barrel 导出了、config 第 23/196 行漏了),而 app 导航有 `nav_contacts`、文档 `content/docs/ui/create-vs-edit-form.mdx` 又把该文件列为活参考实现。本 PR 的 fixture 直接 import 该模块,不依赖 showcase 注册。
- #5421 — `packages/lint/src/runtime-lazy-deps.test.ts` 的 in-process 用例用默认 5s 超时(同文件的冷加载兄弟用例已带 `COLD_LOAD_TIMEOUT_MS`),负载下 4 跑 2 挂,与本改动无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FNvXhtSdnEGEfLEsMmvxh

---
_Generated by [Claude Code](https://claude.ai/code/session_016FNvXhtSdnEGEfLEsMmvxh)_