### PR TITLE
test(lint): give the in-process cold-load case the same COLD_LOAD_TIMEOUT_MS its siblings carry (#5421)

### DIFF
--- a/packages/lint/src/runtime-lazy-deps.test.ts
+++ b/packages/lint/src/runtime-lazy-deps.test.ts
@@ -121,6 +121,11 @@ describe('@objectstack/lint/runtime (kernel boot-path contract, #4463)', () => {
     COLD_LOAD_TIMEOUT_MS,
   );
 
+  // Same cold load as the two above, just in-process: the first `import()` of
+  // `./runtime.js` in this file pulls the whole gate graph through the transform.
+  // So it gets the same budget — the claim being pinned (the boot path loads no
+  // source parser) is proved by the assertions below, never by the wall clock,
+  // and a 5 s default only turns a busy runner into a false red on the gate.
   it('gating a flow in-process loads neither dep, and still finds the defect', async () => {
     const req = createRequire(import.meta.url);
     const { runRuntimeAuthoringRules } = await import('./runtime.js');
@@ -140,7 +145,7 @@ describe('@objectstack/lint/runtime (kernel boot-path contract, #4463)', () => {
           `may not pay for a source parser to publish a flow`,
       ).toBe(false);
     }
-  });
+  }, COLD_LOAD_TIMEOUT_MS);
 
   it('the runtime entry re-exports the gate and nothing that carries a parser', async () => {
     const mod = await import('./runtime.js');


### PR DESCRIPTION
Fixes #5421

## 问题

`packages/lint/src/runtime-lazy-deps.test.ts` 里有三处用例都要付一次「冷加载整张 gate 模块图」的代价:

- 两处 spawn 子进程的(built CJS / built ESM entry)已经以 `}, COLD_LOAD_TIMEOUT_MS)` 收尾;
- `gating a flow in-process loads neither dep, and still finds the defect` 以 `})` 收尾,吃 vitest 默认的 5000 ms —— 尽管它的第一个动作就是 `await import('./runtime.js')`,即同一张冷图,只是在进程内加载。

结果是:机器一忙(多个 agent 的测试套件共用一个容器),这一处就超时,变成任何一条并行车道上的 false red,而且失败文案指向 runtime gate,而不是指向超时预算。

## 改法

只给该 in-process 用例补上兄弟用例已有的 `}, COLD_LOAD_TIMEOUT_MS)`,让三处冷加载用例声明同一个预算;另加一段注释说明为什么超时不是这里的断言工具。

⛔ 断言逻辑、其它用例、`LAZY_DEPS`、`COLD_LOAD_TIMEOUT_MS` 常量本身一律未动。该用例真正要钉的事实(boot path 不加载任何源码解析器)由它下面那圈 require-cache 断言证明,和挂钟无关 —— 超时只该宽到不会误伤。

## 同文件第三处冷加载用例:核对过,不存在

本文件第四个用例 `the runtime entry re-exports the gate and nothing that carries a parser` 同样写了 `await import('./runtime.js')`,但它在声明顺序上排在 in-process 用例之后,而本包没有本地 vitest 配置、全文件也没有任何 `concurrent`,所以它命中的是已经热起来的模块缓存,并不付冷加载。verbose 输出直接量到了这个差:同一次运行里冷的那次 **5383 ms**,热的这次 **1 ms**。因此按「付冷加载却吃默认超时」的口径,同文件没有第三处需要同样修法的用例。

## 验证

反向验证方向在跑之前就定好了,预期 **红**(本机冷加载耗时已经越过 5000 ms),实际也确实是红:

改前(`git stash` 掉本改动后跑同一文件):

```
FAIL  src/runtime-lazy-deps.test.ts > ... > gating a flow in-process loads neither dep, and still finds the defect
Error: Test timed out in 5000ms.
 ❯ src/runtime-lazy-deps.test.ts:124:3
 Tests  1 failed | 3 passed (4)
```

值得记一笔:在这个容器上它不是「间歇」复现,而是**确定性**复现——比 issue 里报的 4 跑 2 挂更强的证据。

改后(同一文件,verbose):

```
 ✓ ... > built CJS runtime entry loads no heavy dep, at import OR while gating 834ms
 ✓ ... > built ESM runtime entry loads no heavy dep, at import OR while gating 785ms
 ✓ ... > gating a flow in-process loads neither dep, and still finds the defect 5383ms
 ✓ ... > the runtime entry re-exports the gate and nothing that carries a parser 1ms
 Test Files  1 passed (1)   Tests  4 passed (4)
```

全包套件与类型检查:

```
pnpm --filter @objectstack/lint test   ->  Test Files 57 passed (57) / Tests 1198 passed (1198)
pnpm --filter @objectstack/lint typecheck  ->  tsc --noEmit,无输出(通过)
```

`node scripts/check-nul-bytes.mjs` OK;另对改动文件做了控制字符自查(`grep -naP` 覆盖 gate 扫不到的那段范围),干净。

## changeset

test-only,不面向用户,按 #5411 先例走 `skip-changeset` 豁免路径,未添加 changeset。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FNvXhtSdnEGEfLEsMmvxh

---
_Generated by [Claude Code](https://claude.ai/code/session_016FNvXhtSdnEGEfLEsMmvxh)_