### PR TITLE
fix(showcase): 注册 `ContactViews` —— 文档引用的「create form ≠ edit form」参考实现终于真的进栈 (#5420)

### DIFF
--- a/.changeset/showcase-register-contact-views.md
+++ b/.changeset/showcase-register-contact-views.md
@@ -1,0 +1,19 @@
+---
+---
+
+fix(showcase): 把 `ContactViews` 注册进 `objectstack.config.ts` 的 `views:`（#5420）
+
+`examples/app-showcase/src/ui/views/contact.view.ts` 声明了「create form ≠ edit
+form」的整套元数据（四个具名段落的默认 `form` + 稀疏的 `formViews.create` +
+列表上的 `addRecord.formView: 'create'` 绑定），barrel 也导出了它 —— 但 config
+第 23 行的具名 import 与第 196 行的 `views:` 数组都漏了它。`views:` 背后没有目录
+扫描，CLI 读的就是这个数组，所以这份元数据编译通过、类型通过、lint 干净，却既进
+不了运行栈，也进不了任何静态门。后果是 `nav_contacts` 渲染的是派生默认表单而不是
+作者写的那份，而 `content/docs/ui/create-vs-edit-form.mdx` 正把这个文件当作活的
+参考实现引用。
+
+注册之后随之可见的 5 个 zh-CN 覆盖键（`_views.list.label` 与
+`_sections.{contact,work,status,notes}.label`）在同一提交内补齐译文，棘轮基线
+`scripts/i18n-coverage-baseline.json` 与 `supportedLocales` 均未改动。
+
+仅改示例应用（`examples/app-showcase` 为 private 包），不发布任何包。

--- a/examples/app-showcase/objectstack.config.ts
+++ b/examples/app-showcase/objectstack.config.ts
@@ -20,7 +20,7 @@ import { setupShowcaseExternalDatasource } from './src/system/datasources/extern
 import { registerRecalcEndpoint } from './src/system/server/recalc-endpoint.js';
 import { registerShowcasePositionBindings } from './src/security/bind-position-sets.js';
 import { registerShowcaseApprovalDemo } from './src/security/seed-approval-demo.js';
-import { TaskViews, ProjectViews, InquiryViews, BusinessUnitViews } from './src/ui/views/index.js';
+import { TaskViews, ProjectViews, InquiryViews, BusinessUnitViews, ContactViews } from './src/ui/views/index.js';
 import { ShowcaseApp } from './src/ui/apps/index.js';
 import { ChartGalleryDashboard, OpsDashboard, RevenuePulseDashboard } from './src/ui/dashboards/index.js';
 import { ShowcaseTaskDataset, ShowcaseProjectDataset, ShowcaseInvoiceDataset, ShowcaseAccountDataset } from './src/ui/datasets/index.js';
@@ -193,7 +193,7 @@ export default defineStack({
 
   // UI
   apps: [ShowcaseApp],
-  views: [TaskViews, ProjectViews, InquiryViews, BusinessUnitViews],
+  views: [TaskViews, ProjectViews, InquiryViews, BusinessUnitViews, ContactViews],
   pages: [CapabilityMapPage, StartHerePage, ComponentGalleryPage, ProjectWorkspacePage, ProjectDetailPage, TaskWorkbenchPage, TaskTriagePage, TaskBoardPage, TaskCalendarPage, TaskGalleryPage, TaskSchedulePage, TaskTimelinePage, TaskMapPage, TaskAllViewsPage, ActiveProjectsPage, TaskDetailPage, ReviewQueuePage, NewProjectWizardPage, MyWorkPage, SettingsPage, StylingGalleryPage, CommandCenterPage, CommandCenterJsxPage, CrmWorkbenchPage, TaskDeskPage, PageVariablesPage, ContactFormPage, RenewalsPipelinePage],
   dashboards: [ChartGalleryDashboard, OpsDashboard, RevenuePulseDashboard],
   books: allBooks,

--- a/examples/app-showcase/src/system/translations/index.ts
+++ b/examples/app-showcase/src/system/translations/index.ts
@@ -303,6 +303,35 @@ export const ShowcaseTranslationBundle = {
           lead_score: { label: '线索评分' },
           notes: { label: '备注' },
         },
+        // #5420 — `ContactViews` had never been listed in the config's `views:`
+        // array, so nothing (runtime or gate) could reach these two surfaces.
+        // Registering the container is what makes them translatable at all.
+        //
+        // `_views.list` — the container's DEFAULT list, which the resolver ids
+        // as `list` (`primary.name || 'list'`). Its source label is the bare
+        // plural "Contacts", so the object's own `pluralLabel` above is the
+        // right word; the `全部…` spelling the task/project lists use belongs to
+        // labels that actually say "All …".
+        _views: {
+          list: { label: '联系人' },
+        },
+        // `_sections` — the four groups of the default edit form in
+        // `ui/views/contact.view.ts`. Each declares a stable `name`, which is
+        // the only reason the heading is translatable (`ObjectForm` looks it up
+        // as `objects.showcase_contact._sections.<name>.label` and otherwise
+        // renders the English `label` verbatim). Wording reuses the vocabulary
+        // this bundle already established — 状态 and 备注 are exactly the words
+        // its `stage`-family and `notes` entries use — rather than minting a
+        // second term per idea. `contact` reads 联系方式 (contact DETAILS, its
+        // fields being 姓名/邮箱/电话) instead of a circular 联系人 heading
+        // inside a contact record; `work` follows the `…信息` shape the
+        // showcase_semantic_zoo headings set.
+        _sections: {
+          contact: { label: '联系方式' },
+          work: { label: '工作信息' },
+          status: { label: '状态' },
+          notes: { label: '备注' },
+        },
       },
       showcase_invoice: {
         label: '发票',

--- a/examples/app-showcase/test/seed.test.ts
+++ b/examples/app-showcase/test/seed.test.ts
@@ -3,6 +3,29 @@
 import { describe, it, expect } from 'vitest';
 import stack from '../objectstack.config.js';
 import { ShowcaseSeedData } from '../src/data/seed/index.js';
+import * as viewBarrel from '../src/ui/views/index.js';
+import { ShowcaseTranslationBundle } from '../src/system/translations/index.js';
+
+/**
+ * The object a view CONTAINER targets (#5420).
+ *
+ * A container (`defineView({ list, form, formViews })`) carries no top-level
+ * `name` — per `view.zod.ts` it is keyed implicitly by the object its default
+ * list or form binds to, the same key objectql's `resolveMetadataItemName` and
+ * the i18n walker derive. Read structurally rather than through the spec types:
+ * `data` is a union (an `api`-provider view has no `object` at all), and a guard
+ * that only compiles for the `object` arm would stop compiling the day a
+ * showcase view switches provider — noise in a test about registration.
+ */
+function targetObject(container: unknown): string | undefined {
+  const objectOf = (node: unknown): string | undefined => {
+    const data = (node as { data?: unknown } | undefined)?.data;
+    const object = (data as { object?: unknown } | undefined)?.object;
+    return typeof object === 'string' ? object : undefined;
+  };
+  const c = container as { list?: unknown; form?: unknown } | undefined;
+  return objectOf(c?.list) ?? objectOf(c?.form);
+}
 
 /**
  * Smoke test — the stack loads and registers the expected breadth of
@@ -16,6 +39,87 @@ describe('showcase stack', () => {
     expect(names).toContain('showcase_field_zoo');
     // 6 objects: account, project, task, category, team, membership, field_zoo
     expect((stack.objects ?? []).length).toBeGreaterThanOrEqual(6);
+  });
+
+  /**
+   * #5420 — every view container the barrel exports must reach the stack.
+   *
+   * `src/ui/views/index.ts` is a barrel, and `objectstack.config.ts` names its
+   * members one by one in a hand-written import list. There is no directory
+   * scan behind `views:` — the CLI reads exactly that array — so an export the
+   * import list forgets is metadata that compiles, type-checks, lints clean and
+   * is never loaded by anything: no runtime container, and no static pass
+   * (`os validate` / `os lint` / `os i18n extract` / the coverage ratchet) can
+   * see it either. `ContactViews` sat that way while
+   * `content/docs/ui/create-vs-edit-form.mdx` cited it as the live reference
+   * implementation of "create form ≠ edit form", and the app's `nav_contacts`
+   * entry rendered the derived default form instead of the authored one.
+   *
+   * Matched by TARGET OBJECT, not by object identity: `defineStack` parses the
+   * config, so `stack.views[i]` is a structural copy and never `===` the
+   * exported container. A view container carries no top-level `name` (spec:
+   * `view.zod.ts`) — it is keyed implicitly by the object its default list or
+   * form binds to, which is the same key objectql's `resolveMetadataItemName`
+   * and the i18n walker use.
+   */
+  it('registers every view container the barrel exports', () => {
+    const registered = new Set(
+      (stack.views ?? []).map((v) => targetObject(v)).filter((o) => o !== undefined),
+    );
+    const missing = Object.entries(viewBarrel)
+      .filter(([, container]) => {
+        const object = targetObject(container);
+        // A container the guard cannot key is reported, never skipped —
+        // silently passing on an unresolvable one is how this guard would
+        // rot into the very "looks covered, covers nothing" shape #5420 is.
+        return object === undefined || !registered.has(object);
+      })
+      .map(([name]) => name);
+    expect(missing, `exported but absent from \`views:\` → ${missing.join(', ')}`).toEqual([]);
+    // The barrel is the authority for how many there are; assert it is not
+    // empty so a barrel that stops exporting cannot make this vacuously green.
+    expect(Object.keys(viewBarrel).length).toBeGreaterThanOrEqual(5);
+    expect(registered.has('showcase_contact')).toBe(true);
+  });
+
+  /**
+   * #5420 — the section headings the registration makes translatable, pinned
+   * from BOTH sides on the real stack.
+   *
+   * Registering `ContactViews` is what puts its four named `form.sections` in
+   * front of the i18n gates, and the two gates read the same set in opposite
+   * directions: `i18n/missing-section` (#5405) fails on a declared section
+   * with no bundle entry, `translation-target-unknown` (#5415/#5422) fails on
+   * a bundle entry no section declares. A test that checked one direction
+   * would stay green while the other broke, so this asserts set EQUALITY.
+   *
+   * Read on the composed stack, not on the imported container: what the gates
+   * see is `stack.views`, and that is exactly the reachability this issue was
+   * about. A section with no `name` (the sparse `formViews.create` section) is
+   * untranslatable by construction — every renderer guards the lookup on
+   * `name` — so it is deliberately outside the set.
+   */
+  it('keys the contact form sections to exactly what the container declares', () => {
+    const contact = (stack.views ?? []).find((v) => targetObject(v) === 'showcase_contact');
+    const form = (contact as { form?: unknown } | undefined)?.form;
+    const sections = (form as { sections?: unknown } | undefined)?.sections;
+    const declared = (Array.isArray(sections) ? sections : [])
+      .map((s) => (s as { name?: unknown } | undefined)?.name)
+      .filter((n): n is string => typeof n === 'string')
+      .sort();
+    expect(declared).toEqual(['contact', 'notes', 'status', 'work']);
+
+    const zh = ShowcaseTranslationBundle['zh-CN']?.objects?.showcase_contact as
+      | { _sections?: Record<string, { label?: string }> }
+      | undefined;
+    expect(Object.keys(zh?._sections ?? {}).sort()).toEqual(declared);
+    // Every entry carries an actual translation — an empty or echoed English
+    // label would satisfy the key set while faking the coverage.
+    for (const name of declared) {
+      const label = zh?._sections?.[name]?.label;
+      expect(label, `zh-CN _sections.${name}.label`).toBeTruthy();
+      expect(label).not.toMatch(/^[\x20-\x7e]+$/);
+    }
   });
 
   it('registers UI, automation, security, and AI metadata', () => {


### PR DESCRIPTION
Fixes #5420

## 前提复核（先证伪,再实现）

在 `origin/main` `123067ce7`(即 #5416 / #5422 合并之后)上实证,issue 的前提**仍然成立** —— #5416 与 #5422 都没有做注册:

```
git show origin/main:examples/app-showcase/objectstack.config.ts | grep -n Views
23:  import { TaskViews, ProjectViews, InquiryViews, BusinessUnitViews } from './src/ui/views/index.js';
196: views: [TaskViews, ProjectViews, InquiryViews, BusinessUnitViews],
```

barrel `src/ui/views/index.ts` 导出 5 个容器,config 的具名 import 只取了 4 个。`views:` 背后没有目录扫描,CLI 读的就是这个数组,所以这份元数据编译通过、类型通过、lint 干净,却**既进不了运行栈,也进不了任何静态门**:`nav_contacts` 渲染的是派生默认表单而不是作者写的那份,`addRecord.formView: 'create'` 从未绑定,而 `content/docs/ui/create-vs-edit-form.mdx` 一直把这个文件当作活的参考实现引用。这也解释了 #5405 的 `i18n/missing-section` 为什么在 showcase 上采到 10 条却没有一条属于 `showcase_contact`。

## 改了什么

1. `examples/app-showcase/objectstack.config.ts` —— 第 23 行 import + 第 196 行 `views:` 各补一个 `ContactViews`。
2. `examples/app-showcase/src/system/translations/index.ts` —— 为注册后新可见的 5 个 zh-CN 覆盖键补译文。
3. `examples/app-showcase/test/seed.test.ts` —— 两条 pin(见下)。
4. 空 frontmatter changeset —— 示例应用为 private 包,不发布任何包(仓规里「本 PR 不发布任何东西」的正规声明方式)。

⛔ 未动 `packages/**`,未动棘轮基线 `scripts/i18n-coverage-baseline.json`,未缩 `supportedLocales`。

## 新增键是实测的,不是预测的

```
node packages/cli/bin/run.js lint examples/app-showcase/objectstack.config.ts

  483 warning(s)   ← 注册前(= origin/main)
  488 warning(s)   ← 只注册、未补译文
  484 warning(s)   ← 本 PR 最终态
```

注册引入的 5 条,逐条 diff 出来的:

```
+ i18n/missing-view     translations.zh-CN.objects.showcase_contact._views.list.label
+ i18n/missing-section  translations.zh-CN.objects.showcase_contact._sections.contact.label
+ i18n/missing-section  translations.zh-CN.objects.showcase_contact._sections.work.label
+ i18n/missing-section  translations.zh-CN.objects.showcase_contact._sections.status.label
+ i18n/missing-section  translations.zh-CN.objects.showcase_contact._sections.notes.label
```

`formViews.create` 的那个段落没有 `name`,按渲染器的约定天生不可翻译,所以不在集合内 —— 这不是遗漏。

译文体例对齐 PR #5416 的返工 commit `e3d1e855c`:zh-CN 从本 bundle 既有词汇表取词(`状态`/`备注` 就是它自己 `stage` 族与 `notes` 的用词),`en` 不加条目(默认语言由内联 label 满足,复述源串只会伪造覆盖率)。两处需要解释的取词写在代码注释里:`contact` 取「联系方式」而不是在联系人记录里再套一个循环的「联系人」;`_views.list` 的源串是光秃秃的 "Contacts",所以用对象自己的 `pluralLabel`,而 task/project 列表的「全部…」属于那些真的写了 "All …" 的 label。

## 两条 pin

`test/seed.test.ts`:

- **`registers every view container the barrel exports`** —— 按**目标对象**比对,不是按对象标识:`defineStack` 会 parse config,`stack.views[i]` 是结构副本,永远不 `===` 导出的容器(第一版按标识写的,五个全红,已改)。容器本身按 spec 无顶层 `name`,隐式以 `list`/`form` 绑定的对象为键,与 objectql 的 `resolveMetadataItemName` 和 i18n walker 同一套推导。
- **`keys the contact form sections to exactly what the container declares`** —— 断言**集合相等**,因为两个 i18n 门是反向读同一个集合的:`i18n/missing-section`(#5405)红在「声明了没译文」,`translation-target-unknown`(#5415/#5422)红在「有译文没声明」。只查一个方向的测试会在另一个方向坏掉时保持绿。#5422 落地后这个集合关系**第一次在真实 config 上可测**,实测结论:四个正确翻译的段落**没有**被 `translation-target-unknown` 误报。

### 反向验证(方向是事先预判的:红)

把 config 那一处 hunk stash 掉重跑,两条 pin 按预期变红,且第一条精确点名:

```
AssertionError: exported but absent from `views:` → ContactViews:
  expected [ 'ContactViews' ] to deeply equal []
 Tests  2 failed | 4 passed (6)
```

只点名 `ContactViews`、不误伤其余四个,说明按目标对象比对的那版 helper 是对的。

## 验证

```
pnpm build (turbo, --concurrency=2)      Tasks: 71 successful, 71 total
npx tsc --noEmit (examples/app-showcase) 通过
npx vitest run  (examples/app-showcase)  Test Files 12 passed / Tests 126 passed
npx objectstack validate                 ✓ Validation passed (1367ms)，exit 0
pnpm check:i18n-coverage                 OK (12 config(s), 660 baselined
                                         untranslated string(s), none new)
node scripts/check-nul-bytes.mjs         OK (5436 files, no raw NUL bytes)
```

仓库级 `check:i18n-coverage` 是先 `turbo run build` 再跑的(门 shell 到构建产物)—— #5416 用一次 CI 红换来的教训,这次没有重付。

## 已知遗留:`_views.list` 上那条 `translation-target-unknown`

补 `_views.list` 译文之后,`translation-target-unknown` 多出一条 —— 但这**不是本 PR 引入的新类**:`showcase_project` / `showcase_task` / `showcase_inquiry` / `showcase_business_unit` 在 main 上已经各有一条一模一样的。根因是 #5164 记录的那件事:i18n 覆盖 walker 把容器默认列表按 `primary.name || 'list'` 推导出 `_views.list.label` 并**要求**它,而引用校验器认为没有任何视图叫 `list` —— 同一次 `os lint` 里两条规则互相打架。`validate-translation-references.ts` 的注释也明写了这归 #5164。本 PR 只能二选一,选了不让覆盖率棘轮变红的那一边,并把第 5 个实例作为数据点评论回 #5164。


---
_Generated by [Claude Code](https://claude.ai/code/session_016FNvXhtSdnEGEfLEsMmvxh)_