### PR TITLE
docs(protocol): widget-contract 的 Theme 段停止教 #3494 已删除的 `density`,token 词表按 #5021 重写 (#5291)

### DIFF
--- a/.changeset/widget-contract-theme-token-vocabulary.md
+++ b/.changeset/widget-contract-theme-token-vocabulary.md
@@ -1,0 +1,36 @@
+---
+---
+
+docs(protocol): `protocol/objectui/widget-contract` 的 Theme 段停止教 #3494 已删除的 `density`,整段 token 词表按 #5021 的退役结果重写 (#5291)
+
+该页 Theme 段的散文与 YAML 示例都在教 `density`(「`density` is one of `compact`,
+`regular`, or `spacious`」+ 示例里的 `density: regular`)。这个键在 #3494 就被删了,
+而 `ThemeSchema` 自 #4001 批 15 起是 `.strict()` —— 两件事叠加的结果是**照抄本页示例
+必然 parse 失败**:`defineStack({ themes })` / `defineTheme()` 都会拒。拒绝本身是响亮
+且带处方的(`THEME_RETIRED_KEY_GUIDANCE` 里 `density` 的墓碑),问题在于平台自己的权威
+文档把作者送进了那次拒绝——对从这一页取样写主题的 AI 作者尤其贵。
+
+原示例其实有**两处**解析失败:除 `density` 外,`colors:` 下只有一行注释,YAML 解析成
+`null`,而 `colors` 是必填且 `primary` 必填。现在的示例是一份真能通过 `ThemeSchema`
+解析的完整主题。
+
+同时把整段的 token 词表口径刷新到 #5021 之后:
+
+- 逐一列出 `ThemeSchema` 的**十个**可写键(`name` / `label` / `description` / `mode` /
+  `extends` 五个身份与继承键,加 `colors` / `borderRadius` / `shadows` / `typography` /
+  `customVars` 五个 token 键),并给出每个键实际落到 document 上的 CSS 变量——包括
+  `colors` 出门时的改名(`surface` → `--card`、`text` → `--foreground`、
+  `error` → `--destructive` …)、`borderRadius.base` / `shadows.base` 发的是裸
+  `--radius` / `--shadow`、`typography` 自 #5021 起只剩 `fontFamily.base`(发
+  `--font-sans`)。
+- 新增一段 Callout 点名两批退役键:#3494 的 `spacing` / `breakpoints` / `logo` /
+  `density` / `wcagContrast` / `rtl` / `touchTarget` / `keyboardNavigation`,以及 #5021
+  (`@objectstack/spec` 17.0.0, ADR-0049)的 `animation` / `zIndex`、`typography` 四条
+  排版标尺、`fontFamily.heading` / `mono`;两批的处方都是 `customVars`,且是逐字节等价
+  的替代(`customVars` 里写 `font-size-lg` 发的就是同一个 `--font-size-lg`),并给出
+  `os migrate meta --from 16`。
+
+页面的每条断言都对着 `packages/spec/src/ui/theme.zod.ts` 与 objectui `ThemeEngine.ts`
+逐键核过:16 个退役键全部被拒、10 个活键全部被接受。
+
+Docs-only;releases nothing.

--- a/content/docs/protocol/objectui/widget-contract.mdx
+++ b/content/docs/protocol/objectui/widget-contract.mdx
@@ -316,21 +316,54 @@ The widget manifest carries **no** performance block. Virtualization for large d
 
 ## Theme
 
-ObjectUI theming is defined by `ThemeSchema` in `packages/spec/src/ui/theme.zod.ts`. A theme requires a `name`, `label`, and `colors` palette. The `mode` is one of `light`, `dark`, or `auto`, and `density` is one of `compact`, `regular`, or `spacious`. `borderRadius` is a scale object (`none`/`sm`/`base`/`md`/`lg`/...), not a single token:
+ObjectUI theming is defined by `ThemeSchema` in `packages/spec/src/ui/theme.zod.ts`, and it declares **ten** authorable keys — that list is the whole vocabulary. Five of them are identity and inheritance: `name` (a snake_case identifier) and `label` are required, `description` is optional, `mode` is one of `light`, `dark`, or `auto` (default `light`), and `extends` names another theme to inherit from. The other five are the token surface:
+
+| Key | Required | Shape | What it puts on the document |
+|-------|-------|-------|-------|
+| `colors` | ✅ | `ColorPalette`; only `primary` is mandatory inside it | The shadcn palette variables — **renamed on the way out**: `surface` emits `--card`, `text` emits `--foreground`, `textSecondary` emits `--muted-foreground`, `disabled` emits `--muted`, `error` emits `--destructive`. |
+| `borderRadius` | — | A scale object (`none`/`sm`/`base`/`md`/`lg`/`xl`/`2xl`/`full`), not a single token | `--radius-sm`, `--radius-md`, ... — and `base` emits the bare `--radius`. |
+| `shadows` | — | The same stops plus `inner` | `--shadow-sm`, `--shadow-md`, ... — and `base` emits the bare `--shadow`. |
+| `typography` | — | One live key since #5021: `fontFamily.base` | `--font-sans`. |
+| `customVars` | — | A flat string map | Every entry verbatim, `--` prefixed if you omit it: `z-modal: '1050'` emits `--z-modal: 1050`. This is the declared door for any other custom property. |
 
 ```yaml
 name: corporate
 label: Corporate
 mode: light
-density: regular
 colors:
-  # ColorPalette configuration
+  primary: '#2563eb'
+  surface: '#ffffff'
+  text: '#111827'
 borderRadius:
   base: 0.25rem
   md: 0.375rem
+shadows:
+  base: '0 1px 3px rgb(0 0 0 / 0.1)'
+typography:
+  fontFamily:
+    base: 'Inter, system-ui, sans-serif'
+customVars:
+  space-4: 1rem
 ```
 
-Widgets inherit the active theme automatically; they do not each carry a full set of color/typography props.
+`ThemeSchema` is `.strict()` (#4001), so a key outside that list is a **parse failure** at `defineStack({ themes })` / `defineTheme()`, carrying its own prescription — not a value silently dropped while the theme still reports valid.
+
+<Callout type="warn">
+  **Older theme samples no longer parse** — check yours before copying it forward.
+  **#3494** removed `spacing`, `breakpoints`, `logo`, `density`, `wcagContrast`,
+  `rtl`, `touchTarget` and `keyboardNavigation`: the theme engine never emitted a
+  variable for any of them, so authoring one was a silent no-op. **#5021**
+  (`@objectstack/spec` 17.0.0, ADR-0049) removed `animation`, `zIndex`, the
+  `typography.fontSize` / `fontWeight` / `lineHeight` / `letterSpacing` scales and
+  `typography.fontFamily.heading` / `mono`: those *were* emitted, faithfully and
+  for years, but no first-party component or stylesheet has ever read one.
+  The prescription in both waves is `customVars`, and it is a byte-for-byte
+  replacement — `customVars` carrying `font-size-lg: 1.125rem` puts exactly the
+  same `--font-size-lg` on the document the retired scale did. Run
+  `os migrate meta --from 16` to rewrite stored metadata automatically.
+</Callout>
+
+Widgets inherit the active theme automatically; they do not each carry their own copy of the palette or the font stack.
 
 ## What's Next?
 


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5291

## 前提已核(against `origin/main` @ `01c0baef9`)

issue 正文是线索不是规格,先证伪再动手。该页确实仍停在 #3494 之前:

- `content/docs/protocol/objectui/widget-contract.mdx:319` 散文:「… and `density` is one of `compact`, `regular`, or `spacious`」
- 同段 `:325` YAML 示例:`density: regular`
- `packages/spec/src/ui/theme.zod.ts` 的 `THEME_RETIRED_KEY_GUIDANCE` 里 `density` 是一条 #3494 墓碑,`ThemeSchema` 自 #4001 批 15 起 `.strict()`

派发口径的前置条件也已满足:PR #5289 已 MERGED,#5021 的退役面已在 `origin/main` 的 `theme.zod.ts` 上落定。

## 用可执行的方式钉住「照抄即失败」

把该页 `## Theme` 段的 YAML fence 抽出来喂给真正的 `ThemeSchema`(即 `defineTheme()` / `defineStack({ themes })` 跑的那一段)。**方向是在跑之前定的:改前红、改后绿**——这一单里被改的是示例本身,规则(`ThemeSchema`)没动,所以这是最普通的那个方向,没有反转。

改前(`origin/main` 的页面),**两处**失败而不是一处:

```
RESULT: ThemeSchema.safeParse -> FAILURE
  [invalid_type] path=["colors"] :: Invalid input: expected object, received null
  [unrecognized_keys] path=[] :: Unrecognized key(s) on this theme: `density`. …
  • `density` was removed in #3494 — no renderer read it. Express compact/comfortable spacing as your own tokens under `customVars`.
```

`colors:` 底下只有一行注释,YAML 解析成 `null`,而 `colors` 必填、其 `primary` 必填。issue 只点了 `density`,但「照抄本页 = 构建失败」这条主张实际由两个缺陷共同成立,所以两个一起修——只修 `density` 的话,照抄的人仍然拿到一次失败,缺陷的标题依旧成立。

改后(本分支):

```
RESULT: ThemeSchema.safeParse -> SUCCESS
parsed keys: borderRadius, colors, customVars, label, mode, name, shadows, typography
```

## 词表刷新:每条断言逐键核过,不是照抄 issue 正文

派发口径明确要求以 `origin/main` 的实际墓碑为准。退役面与活键都对着 `theme.zod.ts`、发出的 CSS 变量对着 objectui `packages/core/src/theme/ThemeEngine.ts` 核过:

- `COLOR_TO_CSS_MAP` 确认改名:`surface` → `--card`、`text` → `--foreground`、`textSecondary` → `--muted-foreground`、`disabled` → `--muted`、`error` → `--destructive`
- `generateBorderRadiusVars` / `generateShadowVars` 确认 `base` 发的是裸 `--radius` / `--shadow`
- `generateTypographyVars` 确认 `fontFamily.base` 发 `--font-sans`
- `customVars` 确认逐字发出(缺 `--` 前缀时补上)

并用第二个 harness 把页面的主张与 schema 对齐扫了一遍——16 个退役键必须被拒、10 个活键必须被接受:

```
## RETIRED at the theme level — each must be REJECTED
  spacing / breakpoints / logo / density / wcagContrast / rtl /
  touchTarget / keyboardNavigation / animation / zIndex        rejected
## RETIRED inside typography — each must be REJECTED
  fontSize / fontWeight / lineHeight / letterSpacing            rejected
  fontFamily.heading / fontFamily.mono                          rejected
## LIVE — the ten keys the doc enumerates, each must be ACCEPTED
  name / label / description / mode / colors / typography /
  borderRadius / shadows / customVars / extends                 accepted

OK — doc claims match the schema exactly.
```

两个 harness 都是一次性的,已在提交前删除,不进仓库。

## 改了什么

- 散文改为逐一列出 `ThemeSchema` 的**十个**可写键,并用一张表给出每个 token 键实际落到 document 上的 CSS 变量。
- YAML 示例换成一份真能解析通过的完整主题(含 `shadows` / `typography.fontFamily.base` / `customVars` 三个此前没露过面的活键)。
- 新增一段 `Callout type="warn"`(与本页 `widget.performance` 那段同一形状)点名两批退役键:#3494 的八个,#5021(`@objectstack/spec` 17.0.0, ADR-0049)的 `animation` / `zIndex`、`typography` 四条排版标尺、`fontFamily.heading` / `mono`。处方统一是 `customVars`,并说明它是**逐字节等价**的替代,附 `os migrate meta --from 16`。
- 末句由「they do not each carry a full set of color/typography props」改为不再暗示主题有一套 typography 词表可继承。

范围严格限定在该页 Theme 段。⛔ 未碰 `content/docs/references/**`(生成物)与 `content/docs/releases/`。同页其它段落不在本单范围。

## 门禁(真实输出)

```
✓ doc authoring guard: 362 files clean — no bare metadata literals.
check-role-word: OK (43 baselined file(s), no new occurrences).
✓ docs-accuracy-audit scope is in sync with content/docs/: 178 hand-written doc(s).
check-nul-bytes: OK (scanned 5443 tracked text file(s); … no raw NUL bytes).
✓ .changeset/config.json "fixed" group is in sync with 69 public workspace packages.
```

另外用 `@mdx-js/mdx` 单独编译了这一页(`MDX compile OK`),因为本次新增了表格与 Callout。`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 自查该页无控制字节。

Changeset:`.changeset/widget-contract-theme-token-vocabulary.md`(docs-only,空 frontmatter,releases nothing——沿用 `http-protocol-discovery-two-shapes.md` 的先例)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE

---
_Generated by [Claude Code](https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE)_