### PR TITLE
docs(ui): apps 页停止教 17.0.0 已退役的 `version` / `mobileNavigation`,两个 os:check 块改用 `defineApp()` (#5313)

### DIFF
--- a/.changeset/apps-mdx-retired-version-mobile-navigation.md
+++ b/.changeset/apps-mdx-retired-version-mobile-navigation.md
@@ -1,0 +1,41 @@
+---
+---
+
+docs(ui): `ui/apps` 停止教 17.0.0 已退役的 `App.version` 与 `App.mobileNavigation`,两个 `os:check` 示例改用 `defineApp()` 以便退役键在 tsc 就红 (#5313)
+
+`content/docs/ui/apps.mdx` 有四处仍把 17.0.0(2026-06 liveness audit / ADR-0049
+enforce-or-remove)已退役的键当作可作者化面在教:「Basic Structure」示例里的
+`version: '1.0.0'`、App Properties 表里的 `version` 行、整节 `## Mobile Navigation`
+(含 `mobileNavigation: { mode, bottomNavItems }` 示例与 `mode` 取值说明),以及
+「Complete Example」里的 `version: '2.0.0'`。
+
+墓碑是 `retiredKey()`(`z.never().optional()`),所以照抄这两个示例不是「多写一个没用
+的键」,而是**整条 save 硬失败**。实测把「Basic Structure」块原样喂给
+`getMetadataTypeSchema('app')`:
+
+    version :: `App.version` was removed in @objectstack/spec 17.0.0 (2026-06 liveness
+    audit — no consumer in framework or objectui). An app is versioned by its owning
+    package: use `manifest.version`. Delete the key.
+
+处置按墓碑自己的处方:`version` 删键(应用的版本是其所属包的 `manifest.version`);
+`mobileNavigation` 没有替代能力——它是完全未实现的键,连 `packages/mobile` 都没读过,
+`mode` 选择器不改变任何东西——故整节删除,并在 App Properties 表后新增 Callout 点名这
+两个键、给出各自处方,顺带指回已在正文交代过的 `homePageId`(#4667 / #4709)。
+
+同时给该页两个 `{/* os:check */}` 块加上 `defineApp()` 标注。此前两块都是无类型标注的
+对象字面量(`const crmApp = { … }`),没有任何东西把它们和 `AppSchema` 关联起来,
+`retiredKey()` 赖以在编译期开火的 `never` 入参类型永远不参与推断——`check:skill-examples`
+只做 tsc,于是对退役键这一类恒绿。加标注后同一个门在旧示例上会红:
+
+    ✗ Prose TypeScript examples do not compile against @objectstack/spec:
+      content/docs/ui/apps.mdx:19:3  error TS2322: Type 'string' is not assignable to type 'undefined'.
+      content/docs/ui/apps.mdx:239:3 error TS2322: Type 'string' is not assignable to type 'undefined'.
+
+改后 `✅ 204 prose examples type-check against @objectstack/spec`,两个块喂 schema 也都
+`parses: true`。这条标注是本次修复的护栏:此后该页示例里任何退役键都在门里当场红,而不是
+等作者照抄后在 save 时才发现。
+
+门本体(`packages/spec/scripts/check-skill-examples.ts`)不动——issue 里的 B 方案(对能
+推断出 schema 的块追加一次 `safeParse`)覆盖更广,但需要先解决「哪个块对应哪个 schema」
+的归属推断,是独立的一次设计。不碰 `packages/spec/**`、`content/docs/references/**`
+与 `content/docs/releases/`。Docs-only。

--- a/content/docs/ui/apps.mdx
+++ b/content/docs/ui/apps.mdx
@@ -11,10 +11,11 @@ An **App** is a logical container that bundles objects, views, pages, and dashbo
 
 {/* os:check */}
 ```typescript
-const crmApp = {
+import { defineApp } from '@objectstack/spec';
+
+const crmApp = defineApp({
   name: 'crm',
   label: 'CRM',
-  version: '1.0.0',
   description: 'Customer Relationship Management',
   icon: 'briefcase',
   active: true,
@@ -33,7 +34,7 @@ const crmApp = {
   ],
 
   requiredPermissions: ['crm_access'],
-};
+});
 ```
 
 ## App Properties
@@ -42,7 +43,6 @@ const crmApp = {
 | :--- | :--- | :--- | :--- |
 | `name` | `string` | ✅ | Machine name (`snake_case`) |
 | `label` | `string` | ✅ | Display name |
-| `version` | `string` | optional | App version |
 | `description` | `string` | optional | App description |
 | `icon` | `string` | optional | App icon (Lucide) |
 | `active` | `boolean` | optional | Is app active (default: `true`) |
@@ -50,6 +50,25 @@ const crmApp = {
 | `navigation` | `NavigationItem[]` | optional | Navigation tree |
 | `branding` | `AppBranding` | optional | Visual customization |
 | `requiredPermissions` | `string[]` | optional | Required permissions to access |
+
+<Callout type="warn">
+  **Older app samples no longer parse** — check yours before copying it forward.
+  `@objectstack/spec` 17.0.0 (2026-06 liveness audit, ADR-0049 enforce-or-remove)
+  removed `version` and `mobileNavigation`, and both are now refused at parse
+  time rather than ignored, so one leftover key fails the whole save.
+
+  - `version` — an app is versioned by its owning package. Use
+    `manifest.version` and delete the key; nothing in framework or objectui ever
+    read the per-app number, which could silently disagree with the package's.
+  - `mobileNavigation` — fully unimplemented: no renderer, `packages/mobile`
+    included, ever read it, so the `mode` picker changed nothing. Delete the
+    key; the block returns if and when a real mobile navigation ships.
+
+  `homePageId` (removed in the same major, #4667/#4709) is covered under
+  [Common Navigation Properties](#common-navigation-properties). Every rejection
+  carries its own replacement instruction, so paste the old app and read what
+  the error tells you.
+</Callout>
 
 ## Navigation Items
 
@@ -212,27 +231,15 @@ branding: {
 | `logo` | `string` | Logo image URL |
 | `favicon` | `string` | Favicon URL |
 
-## Mobile Navigation
-
-Configure mobile-specific navigation behavior:
-
-```typescript
-mobileNavigation: {
-  mode: 'bottom_nav',
-  bottomNavItems: ['nav_home', 'nav_accounts', 'nav_contacts', 'nav_settings'],
-}
-```
-
-`mode` accepts `'drawer'` (default), `'bottom_nav'`, or `'hamburger'`. `bottomNavItems` lists the navigation item `id`s to surface in the bottom bar (max 5).
-
 ## Complete Example
 
 {/* os:check */}
 ```typescript
-const projectApp = {
+import { defineApp } from '@objectstack/spec';
+
+const projectApp = defineApp({
   name: 'project_management',
   label: 'Project Management',
-  version: '2.0.0',
   description: 'Track projects, tasks, and team workload',
   icon: 'folder-kanban',
   active: true,
@@ -287,7 +294,7 @@ const projectApp = {
   // and the ROOT landing follows `isDefault`. The key was removed in 17.0.0
   // (#4667, #4709) — it did have a consumer, but it pointed at a navigation item
   // by id and fell back silently when that id dangled.
-};
+});
 ```
 
 ## Related


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5313

## 前提复核(origin/main @ 61fde5e44)

单子的四处现场逐一核过,全部仍然成立:

| 位置 | 内容 | 墓碑 |
|---|---|---|
| `apps.mdx:17`(第 12 行 os:check 块内) | `version: '1.0.0'` | `app.zod.ts:1116` |
| `apps.mdx:45`(App Properties 表) | `version` / `string` / optional | 同上 |
| `apps.mdx:217-227`(整节 Mobile Navigation) | `mobileNavigation: { mode, bottomNavItems }` + `mode` 取值说明 | `app.zod.ts:1262` |
| `apps.mdx:235`(第 230 行 os:check 块内) | `version: '2.0.0'` | 同 `version` |

把两个 os:check 块原样喂 `getMetadataTypeSchema('app')`(一次性 harness,已删):

```
--- apps.mdx:14 (crmApp) parses: false
    version :: `App.version` was removed in @objectstack/spec 17.0.0 (2026-06 liveness audit — no consumer in framework or objectui). An app is versioned by its owning package: use `manifest.version`. Delete the key.
--- apps.mdx:232 (projectApp) parses: false
    version :: `App.version` was removed in @objectstack/spec 17.0.0 ...
```

墓碑是 `retiredKey()`(`z.never().optional()`),所以照抄本页示例不是「多写一个没用的键」,是**整条 save 硬失败**。

## 改法(PM 已裁定走 A:修示例 + 加类型标注,不动门本体)

处置一律以 origin/main 上墓碑自己的处方为准:

- **`version`** —— 墓碑写「An app is versioned by its owning package: use `manifest.version`. Delete the key.」→ 两个示例里的 `version` 行删除,App Properties 表的 `version` 行删除。
- **`mobileNavigation`** —— 墓碑写「fully unimplemented; no renderer, including packages/mobile, ever read it. Delete the key; the block returns if/when a real mobile navigation ships.」→ **无替代能力可指向**,故整节 `## Mobile Navigation` 删除(而不是改写成指路)。
- App Properties 表后新增一个 warn Callout,点名这两个键 + 各自处方,并指回本页正文已经交代过的 `homePageId`(#4667 / #4709)。形制照刚合并的 #5454(widget-contract)那一版。

**类型标注**用 `defineApp({ … })`:它是 `app.zod.ts:482` 自称的「documented authoring entry point」,签名 `defineApp(config: z.input< typeof AppSchema >)`,且该页变量名(`const crmApp = …`)与 `defineApp` 的 JSDoc 示例完全同形;邻近页的惯例也是这一类(`views.mdx` 用 `defineView`,`ui/index.mdx` 用 `App.create`)。`AppInput` 确实是真类型而不是 `unknown` —— `app.nav-type-assertions.ts` 的探针把这件事钉住了(#4171/#4221/#4227),所以 `never` 入参这次真的会参与推断。

## 双向证明

**改前方向(先只加标注、不删 `version`)** —— 同一个门当场红:

```
✗ Prose TypeScript examples do not compile against @objectstack/spec:

  content/docs/ui/apps.mdx:19:3
      error TS2322: Type 'string' is not assignable to type 'undefined'.
  content/docs/ui/apps.mdx:239:3
      error TS2322: Type 'string' is not assignable to type 'undefined'.
```

这一步正是本单要害的证据:**加标注之前**,同样两个块喂给同一个门是 `✅` 绿的 —— 门只做 tsc,而无标注的对象字面量与 `AppSchema` 之间没有任何关联,`retiredKey()` 的 `never` 永不参与推断,所以「os:check 覆盖的是示例能否编译,不是示例是否合规」。标注本身就是本次修复的护栏。

**改后**:

```
✅ 204 prose examples type-check against @objectstack/spec
--- apps.mdx:14 (crmApp) parses: true
--- apps.mdx:238 (projectApp) parses: true
```

其余门:`check:doc-authoring` ✓ 362 files clean;`check:nul-bytes` OK(5447 files);MDX 用 `@mdx-js/mdx` 实编过一遍(Callout 与其中的 markdown 列表都正常渲染,没有被当成缩进代码块)。

## 范围

- 只动 `content/docs/ui/apps.mdx` + 一个 docs-only changeset(空 frontmatter)。
- 不动 `packages/spec/scripts/check-skill-examples.ts`(单子里的 B 方案:块级 `safeParse`。覆盖更广,但要先解决「哪个块对应哪个 schema」的归属推断,是独立的一次设计,留给维护者决定是否另立项)。
- 不碰 `packages/spec/**`、`content/docs/references/**`、`content/docs/releases/`。
- 已核:全仓(除 `references/` 生成物与 `releases/`)再无第二处教 `mobileNavigation`;本页也没有指向被删章节的锚点链接。本页 App Properties 表其余各行与 `AppSchema` 的活键逐一对过,无第二个退役键。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE


---
_Generated by [Claude Code](https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE)_