### PR TITLE
fix(cli): `config.email.persist` 接线到 EmailServicePlugin，补上 `OS_EMAIL_PERSIST_ENABLED` (#5447)

### DIFF
--- a/.changeset/email-persist-config-carrier.md
+++ b/.changeset/email-persist-config-carrier.md
@@ -1,0 +1,32 @@
+---
+'@objectstack/cli': patch
+---
+
+`config.email.persist` now actually reaches the email plugin (#5447)
+
+`EmailServiceConfigSchema` has always declared `persist` — the generated
+reference documents it as "Persist to sys_email (default true)" — and
+`EmailServicePlugin` has always honoured the constructor option, building no
+`EmailPersistence` when `persist === false`. What did not exist was the segment
+between them: `resolveEmailCapabilityArg` in `os serve` is the only reader
+`config.email` has, and it read every declared key except this one.
+
+So a deployment that wrote `email: { persist: false }` to keep message bodies
+out of the database type-checked, parsed, and read as configured — and went on
+writing every subject, body and recipient to `sys_email`. Operators who
+switched persistence off for PII reasons were not getting what the contract
+promised. **If you rely on that row being written, no action is needed; if you
+had declared `persist: false` and audited on the assumption it took effect,
+those rows exist and are worth reviewing.**
+
+Resolution order, per setting, matching the rest of this resolver:
+
+    OS_EMAIL_PERSIST_ENABLED  >  config.email.persist  >  default (persist ON)
+
+`OS_EMAIL_PERSIST_ENABLED` is new, and reads the same truth table as
+`OS_EMAIL_QUEUE_ENABLED` (`1`/`true`/`yes`/`on`, case- and space-insensitive);
+that table is now one shared helper instead of two copies. Unlike the queue
+flag it is default-ON, because it does not enable a capability — it is the off
+switch for one that has always been on. A deployment that declares neither
+source is byte-for-byte unchanged: the key is left out of the plugin's
+constructor options entirely and the plugin's own default decides.

--- a/packages/cli/src/commands/serve-email-persist.test.ts
+++ b/packages/cli/src/commands/serve-email-persist.test.ts
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// framework#5447 — `config.email.persist` reaches `EmailServicePlugin`.
+//
+// `EmailServiceConfigSchema` has declared `persist` ("Persist to sys_email
+// (default true)") for as long as the plugin has honoured it, and the plugin
+// half was never in doubt: it builds no `EmailPersistence` when
+// `persist === false`, and says so in its own queue-delivery diagnostics. What
+// did not exist was the segment between them. `config.email` has exactly one
+// reader in the repo — `resolveEmailCapabilityArg`, whose return value IS the
+// plugin's constructor argument (see the `cap === 'email'` arm of the
+// capability loop) — and it read every declared key except this one.
+//
+// So the key was declared, typed, parsed, and documented, and a PII-sensitive
+// deployment that wrote `persist: false` to keep message bodies out of the
+// database kept writing every body to `sys_email`. That is Prime Directive
+// #10's declared != enforced with a privacy blast radius, and ADR-0049's
+// enforce-or-remove was answered "enforce".
+//
+// The end-to-end block below is the point of this file. Asserting only that
+// the resolver emits `persist: false` would re-pin the same declaration twice
+// (a resolver key name against a test's expectation of that key name) and
+// could not tell whether the plugin reads `persist` at all — which is exactly
+// the class of gap being closed. So it boots the REAL `EmailServicePlugin`
+// over the resolver's REAL output and asks the plugin what it built.
+
+import { describe, it, expect, vi } from 'vitest';
+import { EmailServicePlugin } from '@objectstack/plugin-email';
+import { resolveEmailCapabilityArg } from './serve.js';
+
+// ── resolver ───────────────────────────────────────────────────────────────
+
+describe('resolveEmailCapabilityArg — sys_email persistence (#5447)', () => {
+  it('leaves persist unset when neither config nor env declares it', () => {
+    // The no-regression case: absent, not `false`. An option nobody wrote must
+    // not appear in what the plugin is constructed with, because the plugin's
+    // default (persist ON) is what every existing deployment is running and
+    // emitting `persist: true` here would only look equivalent.
+    expect(resolveEmailCapabilityArg({}, {})).not.toHaveProperty('options.persist');
+  });
+
+  it('carries config.email.persist:false through to the constructor options', () => {
+    const { options } = resolveEmailCapabilityArg({ persist: false }, {});
+    expect(options.persist).toBe(false);
+  });
+
+  it('carries an explicit config.email.persist:true too', () => {
+    const { options } = resolveEmailCapabilityArg({ persist: true }, {});
+    expect(options.persist).toBe(true);
+  });
+
+  it('reads OS_EMAIL_PERSIST_ENABLED on the same truth table as OS_EMAIL_QUEUE_ENABLED', () => {
+    // One truth table for both flags, which is why `envBooleanFlag` was
+    // extracted instead of the list being written a second time: an operator
+    // who learned `on` works for the queue flag must not find it silently
+    // means "off" here.
+    for (const on of ['1', 'true', 'TRUE', 'yes', 'on', ' On ']) {
+      expect(resolveEmailCapabilityArg({}, { OS_EMAIL_PERSIST_ENABLED: on }).options.persist, on)
+        .toBe(true);
+    }
+    for (const off of ['0', 'false', 'no', 'off', '']) {
+      expect(resolveEmailCapabilityArg({}, { OS_EMAIL_PERSIST_ENABLED: off }).options.persist, off)
+        .toBe(false);
+    }
+  });
+
+  it('lets env override config in BOTH directions', () => {
+    // Both directions, because a one-way test passes just as well against a
+    // resolver that ignores config entirely.
+    expect(
+      resolveEmailCapabilityArg({ persist: true }, { OS_EMAIL_PERSIST_ENABLED: 'false' })
+        .options.persist,
+    ).toBe(false);
+    expect(
+      resolveEmailCapabilityArg({ persist: false }, { OS_EMAIL_PERSIST_ENABLED: 'true' })
+        .options.persist,
+    ).toBe(true);
+  });
+
+  it('does not let an UNSET env var read as false over a config that said true', () => {
+    // The tri-state `envBooleanFlag` exists for this case: `undefined` must
+    // fall through to config, not resolve to `false`.
+    expect(
+      resolveEmailCapabilityArg({ persist: true }, { OS_EMAIL_QUEUE_ENABLED: 'true' })
+        .options.persist,
+    ).toBe(true);
+  });
+
+  it('keeps the queue flag resolving exactly as it did before the extraction', () => {
+    // `envBooleanFlag` replaced OS_EMAIL_QUEUE_ENABLED's inline list; these
+    // pin that the refactor was behaviour-preserving, empty string included.
+    expect(resolveEmailCapabilityArg({}, { OS_EMAIL_QUEUE_ENABLED: 'on' }).options.queueDelivery)
+      .toBe(true);
+    expect(resolveEmailCapabilityArg({ queueDelivery: true }, { OS_EMAIL_QUEUE_ENABLED: '' })
+      .options.queueDelivery).toBe(false);
+    expect(resolveEmailCapabilityArg({ queueDelivery: true }, {}).options.queueDelivery).toBe(true);
+    expect(resolveEmailCapabilityArg({}, {})).not.toHaveProperty('options.queueDelivery');
+  });
+
+  it('does not disturb the rest of the resolved options', () => {
+    const { options } = resolveEmailCapabilityArg(
+      { provider: 'smtp', persist: false, options: { host: 'smtp.acme.test' } },
+      {},
+    );
+    expect(options).toMatchObject({
+      provider: 'smtp',
+      persist: false,
+      providerOptions: { host: 'smtp.acme.test' },
+    });
+  });
+});
+
+// ── end to end: resolver output -> real plugin ─────────────────────────────
+
+/**
+ * Minimal ObjectQL stand-in. `start()`'s `kernel:ready` handler needs an
+ * engine to exist before it decides anything about persistence, and the
+ * stranded-outbox sweep reads `sys_email` on the persisting path.
+ */
+function fakeEngine() {
+  return {
+    async find() { return []; },
+    async insert(_table: string, data: any) { return { id: data?.id }; },
+    async update() { return {}; },
+    async delete() { return { deleted: 0 }; },
+  };
+}
+
+/**
+ * Boot the real plugin the way `os serve` does — through the resolver — and
+ * report whether an `EmailPersistence` was built.
+ *
+ * `EmailService.setPersistence` is called only on the persisting branch, and
+ * it is what puts `persistence` into the live service's options, so reading
+ * that back is a direct observation of the branch the plugin took rather than
+ * a restatement of the flag it was handed.
+ */
+async function bootThroughResolver(
+  cfgEmail: Record<string, any>,
+  env: NodeJS.ProcessEnv = {},
+): Promise<{ persistenceBuilt: boolean; constructedWith: Record<string, unknown> }> {
+  const constructedWith = resolveEmailCapabilityArg(cfgEmail, env).options;
+
+  const services: Record<string, unknown> = { manifest: { register: () => {} }, objectql: fakeEngine() };
+  const hooks: Record<string, Array<() => Promise<void> | void>> = {};
+  const ctx: any = {
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    getService: (name: string) => {
+      if (!(name in services)) throw new Error(`service '${name}' not registered`);
+      return services[name];
+    },
+    registerService: (name: string, svc: unknown) => { services[name] = svc; },
+    hook: (name: string, fn: () => Promise<void> | void) => { (hooks[name] ??= []).push(fn); },
+  };
+
+  const plugin = new EmailServicePlugin(constructedWith as any);
+  await plugin.init(ctx);
+  await plugin.start(ctx);
+  for (const fn of hooks['kernel:ready'] ?? []) await fn();
+
+  const service = services.email as { options: { persistence?: unknown } };
+  return { persistenceBuilt: service.options.persistence != null, constructedWith };
+}
+
+describe('config.email.persist reaches EmailServicePlugin (#5447)', () => {
+  it('builds NO EmailPersistence when the config says persist:false', async () => {
+    const { persistenceBuilt, constructedWith } = await bootThroughResolver({ persist: false });
+    expect(constructedWith.persist).toBe(false);
+    expect(persistenceBuilt).toBe(false);
+  }, 60_000);
+
+  it('still persists when the config says nothing — behaviour before #5447, unchanged', async () => {
+    // The compatibility anchor. Every deployment that never wrote the key is
+    // this case, and it must be indistinguishable from the pre-#5447 build.
+    const { persistenceBuilt, constructedWith } = await bootThroughResolver({});
+    expect(constructedWith).not.toHaveProperty('persist');
+    expect(persistenceBuilt).toBe(true);
+  }, 60_000);
+
+  // The two cases below are completeness pins, NOT discriminating ones, and
+  // saying so is the point of this comment. Their expected outcome —
+  // persistence built — is also what an unwired resolver produces, because the
+  // plugin default is ON. Deleting the wiring leaves both GREEN (measured: 8
+  // of these 13 go red, these two and the three default-behaviour pins do
+  // not). They are worth keeping as the positive half of the matrix; they are
+  // not evidence the carrier exists. The assertions that prove that are the
+  // `persist:false` one above and the `OS_EMAIL_PERSIST_ENABLED=false` one
+  // below — the two whose expectation DIFFERS from the default.
+  it('persists on an explicit persist:true', async () => {
+    const { persistenceBuilt } = await bootThroughResolver({ persist: true });
+    expect(persistenceBuilt).toBe(true);
+  }, 60_000);
+
+  it('lets OS_EMAIL_PERSIST_ENABLED=false switch persistence off over a config that said true',
+    async () => {
+      const { persistenceBuilt } = await bootThroughResolver(
+        { persist: true },
+        { OS_EMAIL_PERSIST_ENABLED: 'false' },
+      );
+      expect(persistenceBuilt).toBe(false);
+    }, 60_000);
+
+  it('lets OS_EMAIL_PERSIST_ENABLED=true switch it back on over a config that said false',
+    async () => {
+      const { persistenceBuilt } = await bootThroughResolver(
+        { persist: false },
+        { OS_EMAIL_PERSIST_ENABLED: 'true' },
+      );
+      expect(persistenceBuilt).toBe(true);
+    }, 60_000);
+});

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -2974,6 +2974,27 @@ export interface EmailCapabilityArg {
 }
 
 /**
+ * The ONE truth table this file reads its `OS_EMAIL_*_ENABLED` booleans with
+ * (#5447).
+ *
+ * Extracted rather than restated: `OS_EMAIL_QUEUE_ENABLED` carried this list
+ * inline, and a second boolean flag written a second way is how one env var
+ * ends up accepting `on` while its neighbour does not — the operator-visible
+ * half of the "two literals describing one vocabulary" trap that split the
+ * settings dropdown from the transports (#5094).
+ *
+ * Tri-state on purpose: `undefined` means the variable is unset and the caller
+ * must fall through to config, which is what keeps an absent flag from
+ * silently reading as `false` and overriding a config that said `true`.
+ * An empty string is a SET variable and resolves to `false`, matching the
+ * behaviour `OS_EMAIL_QUEUE_ENABLED` already had.
+ */
+function envBooleanFlag(raw: string | undefined): boolean | undefined {
+  if (raw == null) return undefined;
+  return ['1', 'true', 'yes', 'on'].includes(String(raw).trim().toLowerCase());
+}
+
+/**
  * Resolve what `EmailServicePlugin` is constructed with, from `config.email`
  * plus `OS_EMAIL_*` env (env wins, so an operator can override per environment).
  *
@@ -3007,6 +3028,18 @@ export interface EmailCapabilityArg {
  * delivery from inline to the durable `sys_job_queue` path (#5160). It reuses
  * `OS_EMAIL_RETRIES` as its attempt budget rather than adding a second retry
  * knob — see `EmailServicePlugin.makeQueueDelivery`.
+ *
+ * `OS_EMAIL_PERSIST_ENABLED=false` (or `config.email.persist: false`) stops
+ * every delivery attempt being written to `sys_email` (#5447). The plugin
+ * option has been live since the plugin had one — it builds no
+ * `EmailPersistence` when `persist === false` — but nothing carried the
+ * declared `config.email.persist` here, so a PII-sensitive deployment that
+ * switched persistence off in `objectstack.config.ts` type-checked, parsed,
+ * read "Persist to sys_email (default true)" in the generated reference, and
+ * went on writing every message body to the database. Resolution order is this
+ * function's own, per setting: env > `config.email.persist` > the plugin
+ * default (persist ON) — so a config and an env that say nothing leave the
+ * option absent and the plugin's default untouched.
  */
 export function resolveEmailCapabilityArg(
   cfgEmail: Record<string, any> = {},
@@ -3033,9 +3066,15 @@ export function resolveEmailCapabilityArg(
   // is not knowable here — no kernel exists yet — so the plugin asserts it on
   // `kernel:ready`, where the service registry has settled, and fails the boot
   // there if no durable queue showed up.
-  const queueDelivery = env.OS_EMAIL_QUEUE_ENABLED != null
-    ? ['1', 'true', 'yes', 'on'].includes(String(env.OS_EMAIL_QUEUE_ENABLED).trim().toLowerCase())
-    : cfgEmail.queueDelivery;
+  const queueDelivery = envBooleanFlag(env.OS_EMAIL_QUEUE_ENABLED) ?? cfgEmail.queueDelivery;
+  // `OS_EMAIL_PERSIST_ENABLED` — the carrier `config.email.persist` never had
+  // (#5447). `_ENABLED` is Prime Directive #9's boolean-flag shape; unlike the
+  // queue flag it is default-ON rather than default-off, because it does not
+  // enable a new capability — it is the off switch for one that has always
+  // been on, and a deployment that says nothing must keep its `sys_email`
+  // audit trail. Absent from BOTH sources means the key is left out of the
+  // constructor options entirely, so the plugin's own default decides.
+  const persist = envBooleanFlag(env.OS_EMAIL_PERSIST_ENABLED) ?? cfgEmail.persist;
   const defaultTemplateContext = {
     appName: env.OS_APP_NAME || cfgEmail.appName || configAppName || 'ObjectStack',
     ...(cfgEmail.defaultTemplateContext || {}),
@@ -3070,6 +3109,7 @@ export function resolveEmailCapabilityArg(
     defaultFrom,
     ...(retries != null && !Number.isNaN(retries) ? { retries } : {}),
     ...(queueDelivery != null ? { queueDelivery: !!queueDelivery } : {}),
+    ...(persist != null ? { persist: !!persist } : {}),
     defaultTemplateContext,
   };
 


### PR DESCRIPTION
Fixes #5447

## 问题

`EmailServiceConfigSchema` 一直声明着 `persist`，生成的参考文档正面写着 “Persist to sys_email (default true)”；插件侧也一直是活的 —— `EmailServicePlugin` 在 `persist === false` 时不构造 `EmailPersistence`，并且在队列投递诊断里引用这个键。**缺的只是两者之间那一段路**：`config.email` 在全仓唯一的读者是 `resolveEmailCapabilityArg`，而它读遍了每一个声明键，独独没读这一个。

后果是 Prime Directive #10 的 declared ≠ enforced，且带 PII 半径：作者在 `objectstack.config.ts` 写 `email: { persist: false }` 想把邮件正文挡在库外 —— 类型通过、schema 通过、文档确认，运行时照旧把每一封邮件的收件人 / 主题 / 正文写进 `sys_email`。按 ADR-0049 enforce-or-remove 取 enforce（分诊裁定）。

## 改动

`packages/cli/src/commands/serve.ts` 一处接线 + 一处提取：

- `resolveEmailCapabilityArg` 读 `cfgEmail.persist`，并作为插件构造参数传出。
- 新增 `OS_EMAIL_PERSIST_ENABLED`。优先级按本函数自述的「env 逐项覆盖」：`OS_EMAIL_PERSIST_ENABLED` 优先于 `config.email.persist`，再退到默认（persist 开）。
- 真值表**不新造第二套**：`OS_EMAIL_QUEUE_ENABLED` 原本内联了 `1/true/yes/on` 这张表，现提取为共用的 `envBooleanFlag`，两个 flag 同一张表。它是三态的 —— 未设置返回 `undefined` 从而落到 config，而不是被读成 `false` 去压掉一个写了 `true` 的 config。

命名说明：`_ENABLED` 是 PD #9 的布尔开关形状，但与队列 flag 不同，**它默认开**。因为它并非启用一个新能力，而是一个一直开着的能力的关闭开关；两侧都不声明时，该键**根本不出现在构造参数里**，由插件自身默认决定 —— 存量部署逐字不变。

## 测试

`packages/cli/src/commands/serve-email-persist.test.ts`，13 例全绿（`pnpm --filter @objectstack/cli test` 全量 80 文件 / 780 例全绿，`typecheck` 干净）。

端到端那一组是本文件的重点：只断言 resolver 吐出 `persist: false` 等于拿键名去钉键名，且完全无法回答「插件到底读不读它」—— 而这正是本单要关的那类缺口。所以它用 resolver 的**真实输出**去构造**真实的** `EmailServicePlugin`，跑到 `kernel:ready`，再回读 `EmailPersistence` 究竟有没有被构造。

**反向验证（方向先判后跑，结论与预判一致）**：删掉接线那一行，13 例中恰好 8 例转红。留绿的 5 例里，3 例是「两侧都不声明 → 行为与现状逐字一致」的兼容锚点（本就该绿），另 2 例（显式 `persist: true`、`OS_EMAIL_PERSIST_ENABLED=true` 压 config `false`）**是因为期望值恰好等于插件默认值而绿的，并不具备判别力**。这一点已写进测试文件的注释，避免后来者把它们误读成接线存在的证据；真正判别接线的是 `persist:false` 与 `OS_EMAIL_PERSIST_ENABLED=false` 那两例。

## ⚠️ 与 #5307 的落地顺序（需要 reviewer 决定合并次序）

issue 与派单都要求「把 `serve-email-config-parity.contract.test.ts` 的 `DECLARED_BUT_UNREAD` 豁免数组清空、断言收紧为集合相等」。**该文件当前不在 `main` 上** —— #5307 仍是 open，其 PR 未合并，文件只存在于在飞分支 `claude/issue-5307-email-config-keys`。因此本 PR 无法完成这一项，它是一个跨 PR 的合并次序问题：

- 若**本 PR 先合**：#5307 分支合并前需把 `DECLARED_BUT_UNREAD` 由 `['persist']` 改为 `[]`，并把该断言收紧为集合相等 —— 否则它的 `reads every key it declares` 一例会红（`unread` 实际为 `[]`，期望 `['persist']`）。
- 若 **#5307 先合**：本 PR 需在合并前补一次提交做同样的清空。

两个分支的文件面不相交（本 PR 只动 `serve.ts` + 新增测试 + changeset；#5307 动 `packages/spec` + 新增该 parity 测试），不会产生文本冲突，只有这一处语义耦合。

## 范围

严格按派单收口：未动 `packages/spec` 的 schema 本体（键已声明，无需改），未动 `packages/plugins/plugin-email`（插件侧本就完整），未碰 `defaultTemplateContext` / `appName` 相关行（#5448 同函数待派）。changeset 为 `@objectstack/cli` patch，正文写明 PII 动机并提示：曾声明 `persist: false` 并据此做过审计的部署，那些行其实存在，值得复查。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FNvXhtSdnEGEfLEsMmvxh

---
_Generated by [Claude Code](https://claude.ai/code/session_016FNvXhtSdnEGEfLEsMmvxh)_