### PR TITLE
fix(plugin-email): send() 释放 insert 分配的行 id,不再泄漏进 managedRowIds (#5169)

### DIFF
--- a/.changeset/email-managed-row-ids-release-persisted-id.md
+++ b/.changeset/email-managed-row-ids-release-persisted-id.md
@@ -1,0 +1,29 @@
+---
+"@objectstack/plugin-email": patch
+---
+
+fix(plugin-email): `send()` releases an insert-assigned row id from `managedRowIds` instead of leaking it (#5169)
+
+`EmailPersistence.insert` is a **public** interface and may answer with an id of
+its own — a database-assigned primary key, an external delivery system's receipt
+id. `send()` reserves that id as service-managed too (so the `sys_email`
+`afterInsert` outbox drain skips a row `send()` is already delivering), but its
+`finally` only released the id `send()` had minted. The insert-assigned one was
+reserved and never released.
+
+Two consequences, both now fixed:
+
+- **memory** — one leaked string per message in a `Set` that lives as long as the
+  process;
+- **semantics** — `isServiceManaged(persistedId)` stayed true forever. Ids are
+  unique, so no other row was mistaken for a managed one, but that entry is a
+  standing "this row belongs to a live `send()`" assertion which the drain hook
+  and the boot outbox sweep (#5161) both trust and nothing ever re-checks: a row
+  stranded at `queued` under such an id would be skipped by every future sweep.
+
+The reservation window is unchanged — the release still happens in the same
+`finally`, after inline delivery has finalized the row and after queue mode has
+published the job, so nothing that relied on the row reading managed *during*
+`send()` is affected. The in-repo persistence returns the id it was given
+(ObjectQL echoes `row.id`), so no in-repo path ever reached the leaking branch;
+this was reachable only by a custom `EmailPersistence` implementation.

--- a/packages/plugins/plugin-email/src/email-service.queue-delivery.test.ts
+++ b/packages/plugins/plugin-email/src/email-service.queue-delivery.test.ts
@@ -189,6 +189,30 @@ describe('EmailService — queue delivery on', () => {
     expect(svc.isServiceManaged(res.id)).toBe(false);
   });
 
+  it('releases an insert-assigned id once the job is published (#5169)', async () => {
+    // Queue mode returns EARLY (right after the publish), so the release of an
+    // insert-assigned id happens on that path too — and it must, because the
+    // row is now the worker's: the boot outbox sweep decides whether to requeue
+    // it by asking `isServiceManaged`, and a permanently-true answer would make
+    // a stranded row unsweepable forever.
+    const queue = makeQueue();
+    const transport = { send: vi.fn(async () => ({ messageId: '<x>' })) };
+    const persistence: EmailPersistence = {
+      async insert() { return { id: 'db-pk-9' }; },
+      async update() { /* noop */ },
+    };
+    const svc = new EmailService({
+      transport, defaultFrom: 'no@reply.com', persistence, queueDelivery: wiring(queue),
+    });
+
+    const res = await svc.send(MSG);
+
+    // The job references the PERSISTED id, and that id is no longer managed.
+    expect(res).toMatchObject({ id: 'db-pk-9', status: 'queued' });
+    expect(queue.published[0].data).toEqual({ rowId: 'db-pk-9' });
+    expect(svc.isServiceManaged('db-pk-9')).toBe(false);
+  });
+
   it('sendInline() bypasses the queue — the mail/test path', async () => {
     const transport = { send: vi.fn(async () => ({ messageId: '<live@x>' })) };
     const queue = makeQueue();

--- a/packages/plugins/plugin-email/src/email-service.test.ts
+++ b/packages/plugins/plugin-email/src/email-service.test.ts
@@ -165,6 +165,35 @@ describe('EmailService', () => {
     expect(svc.isServiceManaged(insertedId!)).toBe(false); // cleared after send
   });
 
+  it('releases an insert-ASSIGNED row id from the managed set too (#5169)', async () => {
+    // `EmailPersistence` is public and its `insert` may answer with an id of
+    // its own — a database-assigned primary key, an external delivery system's
+    // receipt id. `send()` reserves that id as managed as well; the bug was
+    // that it never released it, so `isServiceManaged(persistedId)` stayed true
+    // forever: one leaked entry per message, and a "belongs to a live send()"
+    // assertion the drain hook and the boot sweep trust but nobody re-checks.
+    let managedDuringDelivery: boolean | undefined;
+    const transport = { send: vi.fn(async () => ({ messageId: '<m@x>' })) };
+    let svc!: EmailService;
+    const persistence: EmailPersistence = {
+      // Ignores the minted id and hands back the row's real (DB) key.
+      async insert() { return { id: 'db-pk-7' }; },
+      async update(id) {
+        // The `sent` finalize runs INSIDE send(), i.e. while this row is still
+        // send()'s to deliver — the window the managed flag exists to protect
+        // must NOT shrink to make the release possible.
+        managedDuringDelivery = svc.isServiceManaged(String(id));
+      },
+    };
+    svc = new EmailService({ transport, defaultFrom: 'no@reply.com', persistence });
+
+    const res = await svc.send({ to: 'a@b.com', subject: 'Hi', text: 'x' });
+
+    expect(res).toMatchObject({ id: 'db-pk-7', status: 'sent' });
+    expect(managedDuringDelivery).toBe(true);              // window kept
+    expect(svc.isServiceManaged('db-pk-7')).toBe(false);   // released, not leaked
+  });
+
   it('deliverPersistedRow delivers an existing row WITHOUT inserting a new one', async () => {
     const transport = { send: vi.fn(async () => ({ messageId: '<drained@x>' })) };
     const { p, rows } = makePersistence();

--- a/packages/plugins/plugin-email/src/email-service.ts
+++ b/packages/plugins/plugin-email/src/email-service.ts
@@ -583,6 +583,18 @@ export class EmailService implements IEmailService {
     // Reserve the row id BEFORE persistence.insert so the drain hook
     // (which fires synchronously inside that insert) sees it as managed
     // and skips it — `send()` owns this row's delivery.
+    //
+    // `EmailPersistence` is a PUBLIC interface and its `insert` may answer with
+    // an id of its own (a database-assigned primary key, an external delivery
+    // system's receipt id). That id is reserved too — and it has to be released
+    // by the same `finally`, which is why it is held in a variable declared
+    // OUT here rather than recomputed from `persistedId` inside the try (#5169).
+    // Reserving without releasing would leave `isServiceManaged(persistedId)`
+    // permanently true: one leaked string per message for the life of the
+    // process, and — worse than the memory — a standing "this row belongs to a
+    // live send()" assertion that the drain hook and the boot outbox sweep both
+    // trust and nothing ever re-checks.
+    let extraManagedId: string | undefined;
     this.managedRowIds.add(id);
     try {
       let persistedId: string | undefined;
@@ -590,7 +602,10 @@ export class EmailService implements IEmailService {
         try {
           const res = await this.options.persistence.insert(baseRow);
           persistedId = typeof res === 'string' ? res : res?.id ?? id;
-          if (persistedId !== id) this.managedRowIds.add(persistedId);
+          if (persistedId !== id) {
+            this.managedRowIds.add(persistedId);
+            extraManagedId = persistedId;
+          }
         } catch (err: any) {
           this.options.logger?.warn('EmailService: sys_email persist failed (non-fatal)', { error: err?.message });
         }
@@ -625,7 +640,16 @@ export class EmailService implements IEmailService {
       // reclaimed afterwards, which is why the keys travel with the delivery.
       return await this.deliverNormalized(rowId, normalized, undefined, storageKeys);
     } finally {
+      // Release EXACTLY what was reserved above — both ids, and only here.
+      // Here and not earlier: the reservation has to outlive the whole body,
+      // because in inline mode the delivery (and the `sent`/`failed` update of
+      // this very row) happens inside the try, and a sweep that ran mid-flight
+      // must still see the row as `send()`'s. Once this returns, ownership is
+      // over in both modes: inline delivery is finished, and a queued row is
+      // the worker's — with the row committed at `queued`, re-checkable, which
+      // is what makes the boot sweep a backstop rather than a double-send.
       this.managedRowIds.delete(id);
+      if (extraManagedId !== undefined) this.managedRowIds.delete(extraManagedId);
     }
   }
 


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5169

## 前提核验(对 `origin/main` @ `308c7095143c5001ed3a061236bed523df910c4b`)

issue 的前提**成立且未被 #5160/#5161 系列顺手改掉**。当前 main 上:

- `packages/plugins/plugin-email/src/email-service.ts:588` — `let persistedId` 声明在 `try` **内**;
- 同文件 `:593` — `if (persistedId !== id) this.managedRowIds.add(persistedId);`(加了);
- 同文件 `:628` — `finally { this.managedRowIds.delete(id); }`(只删自己铸的 `id`)。

#5161 的清扫器已落地(`outbox-sweep.ts:185` 正是 `if (service.isServiceManaged(rowId)) { result.skipped++; continue; }`),所以 issue 里"一条永远不会被复核的断言"这半在今天的 main 上是**真的有第二个消费者**了:一个永久 true 的条目会让那行在此后每一次 boot sweep 里都被跳过。

## 改了什么

`sendInternal()` 里 insert 回传的 id 现在用一个声明在 `try` 之外的变量 `extraManagedId` 携带,`finally` 释放**恰好**是上面预留的那两个 id:

```ts
let extraManagedId: string | undefined;
this.managedRowIds.add(id);
try {
  …
  if (persistedId !== id) {
    this.managedRowIds.add(persistedId);
    extraManagedId = persistedId;      // 预留与释放读同一个变量
  }
  …
} finally {
  this.managedRowIds.delete(id);
  if (extraManagedId !== undefined) this.managedRowIds.delete(extraManagedId);
}
```

没有采用 issue 建议的 `if (persistedId && persistedId !== id)`,理由有两条:`persistedId` 要为此提到 `try` 外(它在 `try` 里还有别的用途),而且 `persistedId` 为空串时 `if (persistedId)` 会漏删 —— 空串照样进得了 `add`(`'' !== id`)。让释放条件读预留时写下的那个变量,而不是重新推导一遍预留条件,是这两条的共同解。

**语义面(PM 提的那点)已核对:窗口没有变短。** `isServiceManaged` 的两个读者都在 insert 期间/`send()` 期间读:

- afterInsert drain 钩子(`email-plugin.ts:560`)在 `persistence.insert` **内部**同步判定,早于 `finally`;
- boot sweep 在别的时刻跑,靠的是"`send()` 正在管的行不要动"。

inline 模式下这一行的 `sent`/`failed` 终态更新发生在 `try` 内,queue 模式下 job 的 publish 也在 `try` 内 —— 释放仍在这两件事之后。`send()` 返回之后:inline 已投完,queued 行归 worker,且行已落库在 `queued`(可被重读复核),这正是 boot sweep 作为兜底而不是二次投递的前提。

## 反向验证(方向:预期红 → 实测红)

先只加两条用例、源码退回 main 的形状:

```
FAIL src/email-service.queue-delivery.test.ts > … releases an insert-assigned id once the job is published (#5169)
FAIL src/email-service.test.ts > … releases an insert-ASSIGNED row id from the managed set too (#5169)
AssertionError: expected true to be false // Object.is equality
 Test Files  2 failed (2)
      Tests  2 failed | 41 passed (43)
```

两条都恰好红在 `isServiceManaged(…) === false` 这一句(收到 `true` —— 泄漏本身)。inline 用例里那条 `managedDuringDelivery === true`(投递期间仍 managed)**改前改后都是绿的**,这是故意的:它守的是"窗口不许变短",不是缺陷本身;它若因本 PR 变红,说明释放提早了。

## 测试

```
pnpm --workspace-concurrency=2 --filter @objectstack/plugin-email test
 Test Files  20 passed (20)
      Tests  297 passed (297)

pnpm --workspace-concurrency=2 --filter @objectstack/plugin-email typecheck  → EXIT=0
node scripts/check-nul-bytes.mjs → OK (scanned 5477 tracked text file(s))
```

changeset:`.changeset/email-managed-row-ids-release-persisted-id.md`(patch)。仓内无任何路径进得了这条分支(plugin 自己的 persistence 原样回传 `row.id`,因为 ObjectQL insert 回传入参 id),所以对现有部署行为零变化。

## 顺带发现(未在本 PR 修)

已归档 #5523(`finding`,未指派、不带 `pm:queue`):同一段代码里,`persistedId !== id` 时 `add` 发生在 insert **返回后**,而 drain 钩子在 insert **内部**读 `hookCtx.result.id`,于是自建 persistence 分配新 id 时钩子读到 false、与 `send()` 自己的投递构成双发竞态。修法要么收紧 `EmailPersistence.insert` 契约、要么改钩子的判定口径,是一个动公开接口语义的独立决定,与本单的 diff 不在同一侧,故只归档。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BWS4heBoAitLmzCLhcYdbK)_