### PR TITLE
test(service-queue): pin db-queue-adapter's engine double to ObjectQL.delete's dispatch predicate (#5198)

### DIFF
--- a/packages/services/service-queue/src/db-queue-adapter.test.ts
+++ b/packages/services/service-queue/src/db-queue-adapter.test.ts
@@ -1,6 +1,11 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ENGINE_DELETE_DISPATCH_CASES,
+  ENGINE_DELETE_REJECT_MESSAGE,
+  assertEngineDeleteDispatch,
+} from '@objectstack/objectql';
 import { DbQueueAdapter } from './db-queue-adapter.js';
 
 /**
@@ -54,15 +59,26 @@ function makeFakeEngine() {
       return r;
     },
     async delete(table: string, opts: any) {
-      // Real-engine contract: the target id lives at `where.id` — there is no
-      // top-level `id` option. The mock used to accept `opts.id`, a signature
-      // the real engine rejects, which is exactly how the adapter's broken
-      // `{ id }` bags stayed green (#4371 option-2 survey).
-      const id = opts?.where?.id;
-      if (id == null) throw new Error('Delete requires an ID or options.multi=true');
+      // [#4550/#5198] Opened with ObjectQL.delete's OWN dispatch predicate.
+      // What stood here was a hand-mirrored `if (opts?.where?.id == null)` —
+      // written for #4371 to stop the mock accepting the top-level `{ id }`
+      // bags the real engine rejects, and correct about that. But a mirror is a
+      // second copy of the contract, and it was looser than the producer in
+      // both directions: `where: { id: { $in: [...] } }` only LOOKS like an id
+      // (a multi-row predicate the engine refuses without `multi`) and the
+      // mirror waved it through, while `{ multi: true }` with no `where` is a
+      // shape the engine ACCEPTS and the mirror threw on. A double that imports
+      // the decision cannot drift from it; the same predicate already opens the
+      // sibling `job-queue-retention.test.ts` fake in this package.
+      const dispatch = assertEngineDeleteDispatch(opts);
       const t = tables.get(table) ?? [];
-      tables.set(table, t.filter((r) => r.id !== id));
-      return { id };
+      if (dispatch.kind === 'multi') {
+        const keep = t.filter((r) => !matches(r, opts?.where ?? {}));
+        tables.set(table, keep);
+        return t.length - keep.length; // drivers report a deleted count
+      }
+      tables.set(table, t.filter((r) => r.id !== dispatch.id));
+      return { id: dispatch.id };
     },
   };
 }
@@ -230,5 +246,75 @@ describe('DbQueueAdapter', () => {
     expect(await adapter.getQueueSize('mix')).toBe(3);
     await adapter.pollOnce();
     expect(await adapter.getQueueSize('mix')).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The double itself, measured against the producer (#4550 / #5198)
+// ---------------------------------------------------------------------------
+//
+// Every assertion above is only worth what this fake's fidelity is worth: a
+// double that accepts a call the real engine refuses turns a green suite into
+// no suite at all, on exactly the path the double was introduced for (#4434).
+// So the fake is driven against ObjectQL.delete's OWN published case-set here,
+// rather than trusted because its `delete` now names the right function.
+//
+// This is what the deleted `scripts/engine-double-contract.baseline.json` DEBT
+// entry bought, and why the entry could go: the gate proves the predicate is
+// CALLED, and these two tests prove the call is answered — the by-id and multi
+// branches route by verdict, and every shape the engine rejects the fake
+// rejects, with the producer's own message.
+
+describe('makeFakeEngine().delete conforms to ObjectQL.delete (#4550)', () => {
+  it.each(ENGINE_DELETE_DISPATCH_CASES.map((c) => [c.what, c] as const))(
+    'agrees with the engine on %s',
+    async (_what, c) => {
+      const engine = makeFakeEngine();
+      engine.tables.set('sys_job_queue', [{ id: 'rec_1', rule_id: 'r1' }]);
+      const call = engine.delete('sys_job_queue', c.options as any);
+      if (c.expect === 'reject') {
+        // Not merely "throws": the same message a real server answers with, so
+        // the fake's rejection surface cannot drift from the producer's.
+        await expect(call).rejects.toThrow(ENGINE_DELETE_REJECT_MESSAGE);
+        // …and a refused call must not have deleted anything on its way out.
+        expect(engine.tables.get('sys_job_queue')).toHaveLength(1);
+        return;
+      }
+      await expect(call).resolves.toBeDefined();
+    },
+  );
+
+  it('routes by the verdict, not by guessing at `where`', async () => {
+    const engine = makeFakeEngine();
+    const rows = () => engine.tables.get('sys_job_queue') ?? [];
+
+    // by-id: the scalar id is the ONLY row removed, siblings survive.
+    engine.tables.set('sys_job_queue', [{ id: 'a' }, { id: 'b' }]);
+    expect(await engine.delete('sys_job_queue', { where: { id: 'a' } })).toEqual({ id: 'a' });
+    expect(rows().map((r: any) => r.id)).toEqual(['b']);
+
+    // multi: the predicate matches many, and the fake reports the count a
+    // driver's `deleteMany` reports.
+    engine.tables.set('sys_job_queue', [
+      { id: 'a', status: 'completed' },
+      { id: 'b', status: 'completed' },
+      { id: 'c', status: 'pending' },
+    ]);
+    expect(
+      await engine.delete('sys_job_queue', { where: { status: 'completed' }, multi: true }),
+    ).toBe(2);
+    expect(rows().map((r: any) => r.id)).toEqual(['c']);
+
+    // `where: { id: { $in: […] } }` only LOOKS like an id: it is a multi-row
+    // predicate, so without `multi` the engine rejects it — the exact case a
+    // hand-mirrored `if (opts?.where?.id == null)` waves through, and the reason
+    // the mirror had to go rather than be corrected in place. (This fake's
+    // `matches` is equality-only by design — no fixture here sends an operator
+    // predicate — so what is pinned is the dispatch verdict, not `$in` matching.)
+    engine.tables.set('sys_job_queue', [{ id: 'a' }, { id: 'b' }, { id: 'c' }]);
+    await expect(
+      engine.delete('sys_job_queue', { where: { id: { $in: ['a', 'b'] } } }),
+    ).rejects.toThrow(ENGINE_DELETE_REJECT_MESSAGE);
+    expect(rows()).toHaveLength(3);
   });
 });

--- a/packages/services/service-queue/src/db-queue-adapter.test.ts
+++ b/packages/services/service-queue/src/db-queue-adapter.test.ts
@@ -316,5 +316,14 @@ describe('makeFakeEngine().delete conforms to ObjectQL.delete (#4550)', () => {
       engine.delete('sys_job_queue', { where: { id: { $in: ['a', 'b'] } } }),
     ).rejects.toThrow(ENGINE_DELETE_REJECT_MESSAGE);
     expect(rows()).toHaveLength(3);
+
+    // The property the removed mirror was ORIGINALLY written for (#4371): a
+    // top-level `{ id }` bag is not an address — the id lives at `where.id`.
+    // It is not one of ENGINE_DELETE_DISPATCH_CASES, so it is asserted here
+    // rather than left to lapse with the code that used to carry it.
+    await expect(
+      engine.delete('sys_job_queue', { id: 'a' } as any),
+    ).rejects.toThrow(ENGINE_DELETE_REJECT_MESSAGE);
+    expect(rows()).toHaveLength(3);
   });
 });

--- a/scripts/engine-double-contract.baseline.json
+++ b/scripts/engine-double-contract.baseline.json
@@ -242,13 +242,6 @@
       "closes": "add @objectstack/objectql to devDependencies, then open the fake's delete with assertEngineDeleteDispatch(opts)"
     },
     {
-      "file": "packages/services/service-queue/src/db-queue-adapter.test.ts",
-      "unguarded": 1,
-      "kind": "DEBT",
-      "why": "HAND-MIRRORS the guard already, which is the second copy of the contract this gate exists to remove — but @objectstack/service-queue does not depend on @objectstack/objectql, so replacing the copy with the producer's predicate needs a devDependency change.",
-      "closes": "add @objectstack/objectql to devDependencies, then replace the mirrored `if` with assertEngineDeleteDispatch(options)"
-    },
-    {
       "file": "packages/spec/src/contracts/data-engine.test.ts",
       "unguarded": 1,
       "kind": "EXEMPT",


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5198

## 做了什么

`scripts/engine-double-contract.baseline.json` 里 `db-queue-adapter.test.ts` 的 DEBT 条目自述的阻塞是"`@objectstack/service-queue` 不依赖 `@objectstack/objectql`,要先加 devDependency"。PR #5192 为了把新增的 `job-queue-retention.test.ts` 钉到 producer 谓词上,已经把这条 devDependency 加进去了 —— 阻塞理由过期,`closes` 只剩第二步。

本 PR 结清这笔账:

1. `db-queue-adapter.test.ts` 里假 engine 的 `delete` 开头,把手抄的 `if (opts?.where?.id == null) throw` 换成 producer 自己的 `assertEngineDeleteDispatch(opts)`,并按返回的 verdict 分 by-id / multi 两支删除(与同包 `job-queue-retention.test.ts` 的写法一致);
2. 删掉台账里这一条 DEBT 条目 —— 门禁是双向 ratchet,pin 掉之后条目必须在同一个 PR 里消失,否则 `RECONCILED` 会红。

## 为什么是"换掉"而不是"就地修正"

那个手抄的 `if` 是 #4371 加的,当时的目的(不再接受顶层 `{ id }` 口袋)是对的。但它作为契约的第二份拷贝,**两个方向都和 producer 不一致**:

- 它**接受**了 `where: { id: { $in: [...] } }` 和 `where: { id: ['a','b'] }`(没有 `multi`)—— 这两个只是"看起来像 id",真 engine 按多行谓词拒绝。这正是 #4550 说手抄守卫必然漏掉的那一半;
- 它对 `{ multi: true }`(无 `where`)**抛错** —— 而真 engine 接受。

一个 import 了决策的 double 不可能比决策更松,这是 pin 而不是抄的全部意义。

## 测试

除了替换谓词,还把这个 double 本身钉到 producer 发布的用例集 `ENGINE_DELETE_DISPATCH_CASES` 上(13 个 case)+ 一个 verdict 路由测试:门禁只能证明谓词**被调用**,这些测试证明调用**被正确回答**(拒绝时消息也用 producer 的 `ENGINE_DELETE_REJECT_MESSAGE`,且拒绝路径上没有顺手删掉行)。

```
pnpm --filter @objectstack/service-queue test
  Test Files  3 passed (3)
       Tests  49 passed (49)          # db-queue-adapter.test.ts: 12 旧 + 14 新 = 26

pnpm --filter @objectstack/service-queue typecheck    # tsc --noEmit,无输出
pnpm check:engine-double-contract
  OK  self-test: ...
  engine doubles: 56 in 56 test file(s) — 24 pinned ..., 32 in the shrink-only baseline
  pinned  packages/services/service-queue/src/db-queue-adapter.test.ts
  pinned  packages/services/service-queue/src/job-queue-retention.test.ts
  check-engine-double-contract: OK — 24 pinned, 31 in the DEBT ledger, 1 exempt
```
（pinned 23 → 24,DEBT 32 → 31。）

## 反向验证(方向先预测、后运行)

预测:把手抄的 `if` 放回去 → 新测试转红,且门禁因条目已删而报 `PINNED`。两者都成立:

```
× agrees with the engine on multi with a predicate                 # 真 engine 接受,mirror 抛错
× agrees with the engine on multi with no predicate at all         # 同上
× agrees with the engine on $in over ids, no multi                 # 真 engine 拒绝,mirror 放过
× agrees with the engine on array id, no multi                     # 同上
× routes by the verdict, not by guessing at `where`
  Tests  5 failed | 21 passed (26)

x PINNED: packages/services/service-queue/src/db-queue-adapter.test.ts declares 1 engine
  double(s) whose delete() does not route through assertEngineDeleteDispatch (line 27).
check-engine-double-contract: 1 problem(s).    # exit 1
```

诚实记一笔:`multi alongside an $in id set` 这一个 case 在 mirror 下**也是绿的** —— 它期望"接受",而 mirror 因为 `where.id` 非空而恰好接受了。它绿不是因为 mirror 对,方向判断要看上面那 5 条。

## Changeset

测试 + 门禁台账,不发布任何东西,按 Check Changeset 门自己的说明走**首选**路径:打 `skip-changeset` 标签,不加 `.changeset/*.md`(空 changeset 是 last resort,因为它是 changesets/action 的真实输入)。

Found-during: #5179 / PR #5192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWS4heBoAitLmzCLhcYdbK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWS4heBoAitLmzCLhcYdbK)_