### PR TITLE
fix(client): 让 client 测试层真的进 tsc,那处 `@ts-expect-error` 不再是幽灵检查

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,11 +46,15 @@ never its own *strictness*: `strict` and friends are inherited, untouched.
 "tsc is the best sweeper" channel the spec-property-retirement playbook leans on: the
 directive is meant to go red the day a removed key comes back. Outside a program it
 evaluates never, and *deleting the directive leaves every gate just as green* — which is
-how spec's 17 retirement pins across 5 files were found (#5286). Before writing one,
-check the file is compiled. `packages/spec` additionally holds its test-layer residue in
-a per-file, exactly-measured, shrink-only ledger (`packages/spec/test-typecheck-debt.json`,
-`pnpm --filter @objectstack/spec gen:test-typecheck-debt`): a file not listed there may
-have no type errors at all.
+how spec's 17 retirement pins across 5 files were found (#5286), and the repo-wide sweep
+that followed found the eighteenth in `packages/client` (#5449). Before writing one,
+check the file is compiled. A package whose test layer still carries residue holds it in
+a per-file, exactly-measured, shrink-only ledger next to its `tsconfig.test.json`
+(`<package>/test-typecheck-debt.json`, regenerated with
+`pnpm --filter <package> gen:test-typecheck-debt`): a file not listed there may have no
+type errors at all. The gate behind both is one shared script,
+`scripts/check-test-typecheck.mts --package <dir>` — onboard a package by wiring its
+`typecheck` script to it, never by copying it.
 
 One trap worth knowing before you read any of these counts: under `moduleResolution:
 NodeNext` a relative import missing its `.js` extension does not resolve, every symbol it

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,7 +16,9 @@
     "build": "tsup --config ../../tsup.config.ts",
     "test": "vitest run",
     "test:integration": "vitest run --config vitest.integration.config.ts",
-    "typecheck": "tsc --noEmit"
+    "check:test-typecheck": "tsx ../../scripts/check-test-typecheck.mts --self-test && tsx ../../scripts/check-test-typecheck.mts --package packages/client --project tsconfig.test.json",
+    "gen:test-typecheck-debt": "tsx ../../scripts/check-test-typecheck.mts --update --package packages/client --project tsconfig.test.json",
+    "typecheck": "tsc --noEmit && pnpm check:test-typecheck"
   },
   "dependencies": {
     "@objectstack/core": "workspace:*",
@@ -29,6 +31,7 @@
     "@objectstack/objectql": "workspace:*",
     "@objectstack/plugin-hono-server": "workspace:*",
     "@objectstack/runtime": "workspace:*",
+    "tsx": "^4.23.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   },

--- a/packages/client/src/client.batch-transaction.test.ts
+++ b/packages/client/src/client.batch-transaction.test.ts
@@ -94,7 +94,10 @@ describe('data.batchTransaction (live Hono, #1604)', () => {
             label: 'Task',
             fields: {
                 title: { type: 'text', label: 'Title' },
-                project: { type: 'lookup', reference_to: 'project', label: 'Project' },
+                // `reference`, not `reference_to`: the latter is no key the field
+                // schema knows, so this lookup declared no target at all until a
+                // tsc program finally read the file (TS2561, #5449).
+                project: { type: 'lookup', reference: 'project', label: 'Project' },
             },
         });
         // Objects registered AFTER bootstrap miss the boot-time schema sync, so

--- a/packages/client/src/client.hono.test.ts
+++ b/packages/client/src/client.hono.test.ts
@@ -47,7 +47,7 @@ describe('ObjectStackClient (with Hono Server)', () => {
         // --- BROKER SHIM START ---
         // HttpDispatcher requires a broker to function. We inject a simple shim.
         (kernel as any).broker = {
-            call: async (action: string, params: any, opts: any) => {
+            call: async (action: string, params: any, _opts: any) => {
                 const parts = action.split('.');
                 const service = parts[0];
                 const method = parts[1];
@@ -159,9 +159,12 @@ describe('ObjectStackClient (with Hono Server)', () => {
 
         // Discovery is REST's, computed from its registry (#4018 D12: declared
         // === enforced). Every route it advertises must actually answer.
+        // `routes` is optional on the discovery payload, so it is reached
+        // optionally and asserted — a missing map fails `toContain` rather than
+        // being waved through by a `!` or a `?? {}` default (#5449).
         const endpoints = client['discoveryInfo']!.routes;
-        expect(endpoints.data).toContain('/api/v1/data');
-        expect(endpoints.metadata).toContain('/api/v1/meta');
+        expect(endpoints?.data).toContain('/api/v1/data');
+        expect(endpoints?.metadata).toContain('/api/v1/meta');
 
         // Enforced, not just declared — the pairing #4018 exists to hold.
         expect((await fetch(`${baseUrl}/api/v1/meta/objects`)).status).not.toBe(404);

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import { ObjectStackClient, QueryBuilder, FilterBuilder, createQuery, createFilter } from './index';
+// `QueryBuilder` / `FilterBuilder` are named only by the `describe` blocks below;
+// the suites build them through `createQuery` / `createFilter`, so importing the
+// classes themselves left two unused bindings (TS6133) the moment this file
+// entered a tsc program (#5449).
+import { ObjectStackClient, createQuery, createFilter } from './index';
 
 /** Helper: create a client with mocked fetch that returns the given response body */
 function createMockClient(body: any, status = 200) {
@@ -103,7 +107,11 @@ describe('ObjectStackClient', () => {
 
         const result = await client.meta.getItem('object', 'customer');
         expect(fetchMock).toHaveBeenCalledWith('http://localhost:3000/api/v1/meta/object/customer', expect.any(Object));
-        expect(result.name).toBe('customer');
+        // `meta.getItem` has no declared return type (unlike the `getItems`
+        // beside it — #5545), so its unwrapped payload is `unknown`. Asserted
+        // structurally rather than cast: same assertion strength, without
+        // pretending this surface is typed (#5449).
+        expect(result).toMatchObject({ name: 'customer' });
     });
 
     it('meta.getView speaks the path-param dialect both surfaces accept (#3611)', async () => {
@@ -1280,7 +1288,12 @@ describe('ScopedProjectClient', () => {
 
     it('throws when environmentId is missing', () => {
         const client = new ObjectStackClient({ baseUrl: 'http://localhost:3000' });
-        // @ts-expect-error — empty string rejected at runtime
+        // No `@ts-expect-error` here, and that is the finding of #5449 rather than
+        // an omission. `project(environmentId: string)` accepts `''` — it is a
+        // perfectly good `string` — so the directive that sat on this line
+        // suppressed nothing and reported TS2578 ("unused") the first time a tsc
+        // program read the file. Its own comment said what the test actually
+        // proves: the empty id is rejected at RUNTIME, by the guard below.
         expect(() => client.project('')).toThrow(/environmentId is required/);
     });
 

--- a/packages/client/test-typecheck-debt.json
+++ b/packages/client/test-typecheck-debt.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Per-file tsc error debt of the @objectstack/client TEST layer (#5286). `tsconfig.test.json` compiles `src/**/*.test.ts` — which `tsconfig.json` excludes and therefore no gate ever read — and every file below still carries errors from before that gate existed, almost all of them fixture literals annotated with a schema OUTPUT type (`z.infer`) while holding an authored INPUT literal. EXACT ratchet, judged by re-running tsc: a file that gains errors is red, a file that loses them is red until its number is re-recorded, a file that reaches zero is red until its entry is deleted, and a file NOT listed here may have no errors at all. Regenerate with: pnpm --filter @objectstack/client gen:test-typecheck-debt",
+  "entries": {
+    "src/client.batch-transaction.test.ts": 3,
+    "src/client.environment-scoping.test.ts": 1,
+    "src/client.hono.test.ts": 2
+  }
+}

--- a/packages/client/tsconfig.test.json
+++ b/packages/client/tsconfig.test.json
@@ -1,0 +1,62 @@
+// The TEST-layer type-check program (#5449, the mechanism #5286/PR #5478 set
+// for `packages/spec`). `tsconfig.json` above stays as it is: it is the BUILD
+// config, and its `**/*.test.ts` exclusion has a reason — ci.yml gates that no
+// test file reaches the published artifact. This sibling puts the excluded
+// layer back in front of tsc, and `package.json`'s `typecheck` script NAMES it
+// (`-p tsconfig.test.json`), because a config no script invokes is exactly the
+// phantom this whole change is about.
+//
+// What differs from the build config, and what deliberately does NOT:
+//   - module semantics ONLY. The tests are written and executed as ESM by
+//     vitest (esbuild/vite), while `client` has no `"type": "module"`, so the
+//     build config's NodeNext compiles them as CJS and reports errors about the
+//     CHECK rather than the code (TS2835 extensionless relative imports, TS1470
+//     `import.meta`, TS2550 lib). Matching vitest is fidelity.
+//   - `rootDir` widens to the workspace root. It steers emit layout only, and
+//     this program emits nothing; inherited as `./src` it reported TS6059 for
+//     the four route-ledger modules `client-url-conformance.test.ts` and the
+//     three `*-route-ledger-coverage.test.ts` files deep-import from sibling
+//     packages (`../../runtime/src/route-ledger`, …). Those five TS6059 are the
+//     bulk of this package's stale TEST_DEBT entry — a measurement of the
+//     misconfigured check, not of the tests.
+//   - STRICTNESS IS UNTOUCHED. `strict`, `noUnusedLocals`, `noUnusedParameters`,
+//     `noImplicitReturns` and the rest are inherited from the root config.
+//     Nothing here may loosen a type rule; if a test does not compile, that is
+//     the finding.
+//
+// `include` deliberately stops at `src`, matching the build config's root, and
+// none of the files it leaves out carries a `@ts-expect-error`, so no pin is
+// hiding there. `tests/integration/` — the suite `vitest.integration.config.ts`
+// runs against a live server — is in no tsconfig at all: a second,
+// differently-shaped hole (1 file / 3 errors, one of them a real API drift, the
+// suite reading a `client.discovery` property `ObjectStackClient` does not
+// have) that wants its own change rather than a rider on this one. Filed as
+// #5544.
+//
+// The per-file ledger beside this config (`test-typecheck-debt.json`) is small
+// on purpose. Under the repaired config the whole test layer came to 13 errors;
+// eight were the tests' own and are fixed in this same change (two unused
+// imports, an unused parameter, two possibly-undefined reads, an `unknown`
+// payload asserted structurally, a `reference_to` key the field schema never
+// had, and the phantom pin itself). Re-spelling that key uncovered one more of
+// the remaining kind, and all six that stay are ONE producer-side defect
+// wearing three files' clothes: objectql's `registerObject` takes the schema's
+// OUTPUT type (`z.infer`) where it should take the INPUT one, so a perfectly
+// good authored literal reads as missing nine defaulted keys (#5543). Holding
+// them EXACT and shrink-only means fixing #5543 turns the ledger red until the
+// entries are deleted, instead of letting it rot. Every file NOT listed there —
+// `client.test.ts`, the pin file, first among them — must have no errors at
+// all.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "../..",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -217,8 +217,8 @@
     "check:react-blocks": "tsx scripts/build-react-blocks-contract.ts --check",
     "check:react-declaration-parity": "tsx scripts/check-react-blocks-declaration-parity.ts",
     "check:skill-examples": "tsx scripts/check-skill-examples.ts",
-    "check:test-typecheck": "tsx scripts/check-test-typecheck.mts --self-test && tsx scripts/check-test-typecheck.mts --project tsconfig.test.json",
-    "gen:test-typecheck-debt": "tsx scripts/check-test-typecheck.mts --update --project tsconfig.test.json",
+    "check:test-typecheck": "tsx ../../scripts/check-test-typecheck.mts --self-test && tsx ../../scripts/check-test-typecheck.mts --package packages/spec --project tsconfig.test.json",
+    "gen:test-typecheck-debt": "tsx ../../scripts/check-test-typecheck.mts --update --package packages/spec --project tsconfig.test.json",
     "typecheck": "tsc --noEmit && pnpm check:test-typecheck"
   },
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -599,6 +599,9 @@ importers:
       '@objectstack/runtime':
         specifier: workspace:*
         version: link:../runtime
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/scripts/check-test-typecheck.mts
+++ b/scripts/check-test-typecheck.mts
@@ -1,6 +1,6 @@
 #!/usr/bin/env tsx
-// check-test-typecheck — the spec test layer is compiled by tsc, and every
-// error it still carries is a named, measured, shrink-only entry (#5286).
+// check-test-typecheck — a package's TEST layer is compiled by tsc, and every
+// error it still carries is a named, measured, shrink-only entry (#5286, #5449).
 //
 // WHY THIS EXISTS. `packages/spec/tsconfig.json` excluded `**/*.test.ts`, and
 // the package's `typecheck` script is `tsc --noEmit` against that very config.
@@ -9,44 +9,52 @@
 // second compile step. Seventeen `@ts-expect-error` retirement pins across five
 // files — the "tsc is the best sweeper" channel the spec-property-retirement
 // playbook leans on — were PHANTOM checks. Deleting a directive line left the
-// suite green, which is the definition of a check that never ran.
+// suite green, which is the definition of a check that never ran. The repo-wide
+// sweep that finding triggered turned up an eighteenth pin in
+// `packages/client` (#5449), which is why this gate is now shared rather than
+// spec-local: the mechanism is one mechanism, named per package with
+// `--package`, and every package that follows onboards by wiring its
+// `typecheck` script instead of copying 300 lines.
 //
 // The repair is `tsconfig.test.json`: the same strictness flags (they are
 // inherited, untouched — this is fidelity, not loosening) with module semantics
 // that match how vitest actually executes the files (`module: esnext`,
 // `moduleResolution: bundler`, `lib` including ES2022). Under the build config's
-// NodeNext, 108 of the 842 raw errors were the CHECK being misconfigured rather
-// than the code being wrong (TS2835 x58 "dynamic import needs .js", TS1470 x24
-// `import.meta` in a CJS program, TS2307 x18, TS2550 x7 lib) — a config-tier
-// pile that says nothing about the tests. Fixing the config first, then reading
-// the residue, is the #4311 discipline this repo already writes down.
+// NodeNext, 108 of spec's 842 raw errors were the CHECK being misconfigured
+// rather than the code being wrong (TS2835 x58 "dynamic import needs .js",
+// TS1470 x24 `import.meta` in a CJS program, TS2307 x18, TS2550 x7 lib) — a
+// config-tier pile that says nothing about the tests. Client's five TS6059 were
+// the same shape, from an inherited `rootDir`. Fixing the config first, then
+// reading the residue, is the #4311 discipline this repo already writes down.
 //
-// The residue is real and large (691 errors over 79 files at the baseline),
-// overwhelmingly fixture object literals annotated with a schema's OUTPUT type
-// (`z.infer`) while holding an authored INPUT literal — so every defaulted key
-// reads as "missing". Hand-fixing 691 of those in the PR that opens the gate
-// would bury the gate. They are ledgered per file instead, in
-// `test-typecheck-debt.json`, and the ledger is EXACT: recorded must equal
-// measured. That is what makes it shrink-only in practice —
+// The residue is real (691 errors over 79 files for spec; 6 over 3 files for
+// client), overwhelmingly fixture object literals annotated with a schema's
+// OUTPUT type (`z.infer`) while holding an authored INPUT literal — so every
+// defaulted key reads as "missing". Hand-fixing 691 of those in the PR that
+// opens the gate would bury the gate. They are ledgered per file instead, in
+// the package's own `test-typecheck-debt.json`, and the ledger is EXACT:
+// recorded must equal measured. That is what makes it shrink-only in practice —
 //
 //   • a file gains errors      → red ("grew")
 //   • a file loses errors      → red ("shrank; re-record") — so the number
 //                                tracks reality downward instead of rotting
 //   • a file reaches zero      → red ("graduated; delete the entry")
 //   • an unledgered file errors→ red — this is the everyday case, and it is
-//                                why the five pin files carry NO entry: any
-//                                error in them, including the TS2578 that a
-//                                deleted `@ts-expect-error` produces, is red.
+//                                why the pin files carry NO entry: any error in
+//                                them, including the TS2578 that a deleted (or
+//                                a never-applicable) `@ts-expect-error`
+//                                produces, is red.
 //
 // Growing the ledger is possible (add the file and its count) but it is a
 // visible line in this repo's diff and needs the same justification any DEBT
 // entry needs — the idiom of `scripts/check-type-check-coverage.mjs`, applied
 // per file rather than per package.
 //
-// Usage:
-//   tsx scripts/check-test-typecheck.mts             # compile + judge
-//   tsx scripts/check-test-typecheck.mts --update    # re-record the ledger
-//   tsx scripts/check-test-typecheck.mts --self-test # ledger semantics only
+// Usage (`--package` is repo-relative and required for everything but
+// `--self-test`, which judges the ledger semantics alone):
+//   tsx scripts/check-test-typecheck.mts --package packages/spec
+//   tsx scripts/check-test-typecheck.mts --package packages/spec --update
+//   tsx scripts/check-test-typecheck.mts --self-test
 
 import { spawnSync } from 'node:child_process';
 import { createRequire } from 'node:module';
@@ -55,22 +63,46 @@ import path from 'node:path';
 import url from 'node:url';
 
 const HERE = path.dirname(url.fileURLToPath(import.meta.url));
-const SPEC = path.resolve(HERE, '..');
+const ROOT = path.resolve(HERE, '..');
+const SELF_TEST = process.argv.includes('--self-test');
+
+/** A flag's value, or `undefined` when the flag is absent or trailing. */
+function flag(name: string): string | undefined {
+  const i = process.argv.indexOf(name);
+  return i !== -1 && process.argv[i + 1] && !process.argv[i + 1].startsWith('--') ? process.argv[i + 1] : undefined;
+}
+
+// Repo-relative, and REQUIRED: a gate that guessed which package it was judging
+// would report a clean run over whichever one it happened to find.
+const PKG_DIR = ((): string => {
+  const value = flag('--package');
+  if (!value) {
+    if (SELF_TEST) return 'packages/spec'; // only the ledger semantics run; nothing is read
+    throw new Error('check-test-typecheck: --package <repo-relative dir> is required (e.g. --package packages/client).');
+  }
+  return value.replace(/\/+$/, '');
+})();
+const PKG = path.resolve(ROOT, PKG_DIR);
+const PKG_NAME = ((): string => {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(PKG, 'package.json'), 'utf8')).name ?? PKG_DIR;
+  } catch {
+    if (SELF_TEST) return '@objectstack/spec';
+    throw new Error(`check-test-typecheck: no readable package.json at ${PKG_DIR}.`);
+  }
+})();
 // Named on the command line rather than hardcoded, so the wiring is visible in
 // package.json: `check:type-check-coverage` reads the typecheck script chain to
 // decide whether a sibling test tsconfig is actually invoked, and a config no
 // script names is exactly the phantom this gate is about.
-const PROJECT = ((): string => {
-  const i = process.argv.indexOf('--project');
-  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : 'tsconfig.test.json';
-})();
-const LEDGER_PATH = path.join(SPEC, 'test-typecheck-debt.json');
+const PROJECT = flag('--project') ?? 'tsconfig.test.json';
+const LEDGER_PATH = path.join(PKG, 'test-typecheck-debt.json');
 const LEDGER_NAME = 'test-typecheck-debt.json';
 const ISSUE = 'https://github.com/objectstack-ai/objectstack/issues/5286';
-const UPDATE_COMMAND = 'pnpm --filter @objectstack/spec gen:test-typecheck-debt';
+const UPDATE_COMMAND = `pnpm --filter ${PKG_NAME} gen:test-typecheck-debt`;
 
 const LEDGER_COMMENT =
-  'Per-file tsc error debt of the @objectstack/spec TEST layer (#5286). ' +
+  `Per-file tsc error debt of the ${PKG_NAME} TEST layer (#5286). ` +
   '`tsconfig.test.json` compiles `src/**/*.test.ts` — which `tsconfig.json` excludes and therefore ' +
   'no gate ever read — and every file below still carries errors from before that gate existed, ' +
   'almost all of them fixture literals annotated with a schema OUTPUT type (`z.infer`) while holding ' +
@@ -86,8 +118,8 @@ const DIAGNOSTIC = /^(\S[^(]*)\((\d+),(\d+)\): error (TS\d+): /;
 
 /**
  * Per-file error counts from a raw `tsc --noEmit --pretty false` transcript.
- * Paths are normalised to posix and relative to the spec package, so the ledger
- * reads the same on every platform.
+ * Paths are normalised to posix and relative to the package being judged, so
+ * the ledger reads the same on every platform.
  */
 export function parseDiagnostics(output: string): Map<string, number> {
   const counts = new Map<string, number>();
@@ -170,7 +202,7 @@ function runTsc(): string {
   const require = createRequire(import.meta.url);
   const tsc = require.resolve('typescript/bin/tsc');
   const result = spawnSync(process.execPath, [tsc, '--noEmit', '--pretty', 'false', '-p', PROJECT], {
-    cwd: SPEC,
+    cwd: PKG,
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,
     env: { ...process.env, NODE_OPTIONS: process.env.NODE_OPTIONS ?? '--max-old-space-size=4096' },
@@ -300,6 +332,6 @@ if (problems.length) {
 
 const total = [...counts.values()].reduce((a, b) => a + b, 0);
 console.log(
-  `check:test-typecheck: OK — spec's test layer compiles under ${PROJECT}; ` +
+  `check:test-typecheck: OK — ${PKG_NAME}'s test layer compiles under ${PKG_DIR}/${PROJECT}; ` +
     `${counts.size} file(s) / ${total} error(s) held in ${LEDGER_NAME} (shrink-only, ${ISSUE}).`,
 );

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -251,7 +251,6 @@ const TEST_DEBT = {
   '@objectstack/driver-mongodb': { tests: 7, errors: 44, note: 'TS2345 x22, TS2591 x15 (`process` -- the test files need types:["node"] once included).' },
   '@objectstack/lint': { tests: 39, errors: 26, note: 'TS7006 x20, TS2835 x6.' },
   '@objectstack/plugin-security': { tests: 32, errors: 20, note: 'TS2739 x8, TS2740 x5 -- incomplete literals.' },
-  '@objectstack/client': { tests: 15, errors: 19, note: 'TS6059 x5 (rootDir), TS2740 x5, TS6133 x3.' },
   '@objectstack/formula': { tests: 13, errors: 12, note: 'TS2345 x3, TS2352 x3, TS2591 x3.' },
   '@objectstack/trigger-record-change': { tests: 4, errors: 8, note: 'TS2353 x8 -- one unknown-property shape repeated.' },
   '@objectstack/verify': { tests: 2, errors: 6, note: 'TS7006 x4, TS2835 x2.' },
@@ -277,8 +276,6 @@ const TEST_DEBT = {
 // `include`, or add a sibling `tsconfig.test.json` the typecheck script names)
 // -- and then delete the entry, which RECONCILED forces anyway.
 const PHANTOM_PIN_DEBT = {
-  'packages/client/src/client.test.ts':
-    'tsconfig.json excludes `**/*.test.ts` and the package has no sibling test config; also in TEST_DEBT (15 files / 19 errors). Onboarding it is #5449, not #5286 -- the two directives here pin retired client options.',
   'packages/metadata-core/test/types.test.ts':
     'Outside the program for a different reason, and one no exclusion names: `include` is `["src/**/*"]` while this file lives in a sibling `test/` tree, so TESTS_COVERED never saw it either (its testFiles count is 0). Repair is to widen `include` or add a test config; tracked by #5476, not by #5286 (which scoped itself to packages/spec).',
 };


### PR DESCRIPTION
Fixes #5449

照 #5286 / PR #5478 定下的机制跟进,不发明第二套。

## 前提复核(先证后改)

在最新 `origin/main`(`9894a723e`)上两态实测:

- 保留 `packages/client/src/client.test.ts:1283` 的 `// @ts-expect-error — empty string rejected at runtime` → `pnpm --filter @objectstack/client typecheck` 退出码 0
- 删掉该指令行 → 同一条命令仍退出码 0

两态皆绿 = 该指令从未被求值。前提成立。

## 反向验证方向:与派发模板相反,如实申报

派发单预判「修好后删掉指令行应红 TS2578」。**这个方向在本单不成立,而且是本单的核心发现**:`project(environmentId: string)` 接受 `''` —— 那就是一个合法的 `string` —— 所以该指令从来没有东西可压制。它第一次被编译时报的就是

```
src/client.test.ts(1283,9): error TS2578: Unused '@ts-expect-error' directive.
```

也就是说,**正确的修法就是删掉这行指令**(它自己的注释已经说明了这个测试真正证明的事:空 id 是在**运行时**被下面那道 guard 拒绝的)。因此反向验证是镜像的:**把指令行加回去应该红**。先判后跑,实跑结果:

```
✓ check:test-typecheck --self-test — 8 semantic case(s) + the parser hold.
check:test-typecheck: 1 problem(s)

  • src/client.test.ts: 1 type error(s) in a file the ledger does not cover. Fix them — this file is
    inside the checked zone, which is the point of tsconfig.test.json. (A deleted `@ts-expect-error`
    shows up exactly here, as TS2578/TS2694.)
ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL @objectstack/client typecheck: Exit status 1
```

修改前同样的「加回去」是绿的,修改后是红的 —— 这正是「该文件现在真的在一个 tsc program 里」的证据。

## 做了什么

- **`packages/client/tsconfig.test.json`(新增)**:build config 的 sibling。build 的 `exclude` **保留不动**(ci.yml 有「编译产物不得含测试文件」的闸门,已实跑 `pnpm --filter @objectstack/client build` 确认 `dist/` 无测试文件)。差异只在**模块语义**:`module: esnext`、`moduleResolution: bundler`、ES2022 lib,匹配 vitest 的真实执行方式;外加把 `rootDir` 放宽到工作区根 —— 有四个测试文件深引用兄弟包的 route ledger(`../../runtime/src/route-ledger` 等),继承来的 `rootDir: ./src` 会为此报 5 条 TS6059,那是**检查本身配错**,不是测试的问题(它们正是该包 TEST_DEBT 陈旧条目的大头)。**严格性 flags 一律继承,一条都没放宽。**

- **13 条错误,修掉 8 条真实缺陷**:两个未使用的 import、一个未使用的形参、两处对可选 `routes` 的可能为 undefined 的读取(改成可选读 + 断言,没有用 `!` 或 `?? {}` 兜底,map 缺失照样测试失败)、一处 `unknown` 载荷改用 `toMatchObject` 结构断言(不加 cast)、一个字段 schema 根本没有的 `reference_to` key(那个 lookup 此前**没有声明任何目标**),以及那处幽灵 pin。重新拼对 `reference` 之后又暴露出 1 条同族错误。

- **剩下 6 条进 EXACT ratchet 台账**:三个文件、一个根因 —— objectql 的 `registerObject` 参数标成了 schema 的 OUTPUT 类型(`z.infer`)而非 INPUT(已另立 #5543)。`packages/client/test-typecheck-debt.json` 逐文件精确记账、只减不增;#5543 修好那天台账会自动变红要求毕业,而不是烂在那里。**pin 所在文件 `client.test.ts` 不在台账里,必须零错误** —— 上面的反向验证就是靠这一点成立的。

- **`scripts/check-test-typecheck.mts`:从 `packages/spec/scripts/` 提升为共享脚本**,用 `--package` 指定包。派发单明确要求「不要发明第二套」,而把 300 行脚本复制一份进 client 恰恰就是第二套。spec 侧只改 `package.json` 的两行脚本;其台账文件一字未动,生成的 `_comment` 模板与已存字节完全一致(未来 `--update` 不会产生伪 diff),实跑 `pnpm --filter @objectstack/spec check:test-typecheck` 仍为 79 文件 / 691 错误。

- **两处台账毕业**(闸门本身会强制):`@objectstack/client` 从 `TEST_DEBT` 删除(陈旧条目记 15 文件 / 19 错误,其中 5 条是上面说的 rootDir 误配),`PHANTOM_PIN_DEBT` 里 #5478 写明「留给 #5449」的 seed 条目删除。

- `AGENTS.md` 里那一段随之更新:台账不再是 spec 专有,闸门是一个共享脚本,接入方式是接线而不是复制。

## 验证

```
pnpm --filter @objectstack/client typecheck
  ✓ check:test-typecheck --self-test — 8 semantic case(s) + the parser hold.
  check:test-typecheck: OK — @objectstack/client's test layer compiles under
  packages/client/tsconfig.test.json; 3 file(s) / 6 error(s) held in
  test-typecheck-debt.json (shrink-only, #5286).

pnpm --filter @objectstack/client test
  Test Files  17 passed (17)
       Tests  222 passed (222)

pnpm --filter @objectstack/spec check:test-typecheck
  check:test-typecheck: OK — @objectstack/spec's test layer compiles under
  packages/spec/tsconfig.test.json; 79 file(s) / 691 error(s) held in
  test-typecheck-debt.json

node scripts/check-type-check-coverage.mjs
  check-type-check-coverage: OK — 62/77 workspace packages type-checked (plus the root),
  15 in the DEBT ledger, 1 exempt.
    test layer: 19 package(s) still exclude their own tests   ← 修改前为 20

node scripts/check-nul-bytes.mjs
  check-nul-bytes: OK (scanned 5496 tracked text file(s); no raw ASCII control bytes).

pnpm --filter @objectstack/client build   → dist/ 无测试文件
eslint --no-inline-config <改动文件>       → 无输出
```

## 未做 / 界外

- **不做** issue 处置段建议的「跨包不变式」(任何带 pin 的测试文件不得落在排除区内)—— 那是 #5286 留下的独立提案,越界另立单。顺带一提,`check-type-check-coverage.mjs` 的 `PINS_CHECKED` 已经在做等价的事,且 `PHANTOM_PIN_DEBT` 对新增条目是关闭的。
- 文件面未触碰 `packages/runtime/**`(#5519 在飞)与 `packages/rest/**`(#5530 在飞)。
- 界外发现(查重后新立,无标签无指派):#5543(objectql `registerObject` 参数类型 —— 6 条残留欠账的唯一根因)、#5544(`packages/client/tests/integration/` 不在任何 tsconfig 里,且断言了一个不存在的 `client.discovery`)、#5545(`meta.getItem` 缺返回类型声明,而并排的 `getItems` 有)。

## Changeset

纯测试层 + 工装,不发布任何行为变更,按仓里同类先例(PR #5478 同样未加 changeset)走 `pr-automation.yml` 首选的**第 2 条路径**:请打 `skip-changeset` 标签,而不是塞一个空 changeset(空 changeset 是 changesets/action 的真实输入,全空会静默绿着停掉发布 —— #4898)。

---
_Generated by [Claude Code](https://claude.ai/code/session_016FNvXhtSdnEGEfLEsMmvxh)_