### PR TITLE
fix(spec): docs-gen 把嵌套花括号整对包进行内代码,不再切成半对 (#5452)

### DIFF
--- a/.changeset/docs-gen-nested-brace-escape.md
+++ b/.changeset/docs-gen-nested-brace-escape.md
@@ -1,0 +1,41 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): docs-gen no longer cuts a nested `{…}` / `<…>` in half (#5452)
+
+The reference-docs generator wraps a delimited fragment of `.describe()` prose
+in an inline-code span so MDX renders it literally instead of parsing it as a
+JS expression or a JSX tag. It located the fragment's closing delimiter with
+`indexOf` — the **first** closer, not the **matching** one — so any nested pair
+was wrapped only up to its inner closer and the outer one fell outside the
+span.
+
+The published symptom: `{{var}}` in a description was emitted as
+`` `{{var}` `` followed by a stray `}`. Readers saw `{{var}` plus an orphan
+brace on precisely the rows that teach template-variable syntax, where the
+paired double brace *is* the thing being documented. Nesting is not an exotic
+input in this corpus — template interpolation and filter-map examples both
+produce it.
+
+The matcher now counts nesting depth, so the whole pair lands inside one code
+span. Five rows across four regenerated reference pages change:
+
+- `references/ai/model-registry.mdx` — `PromptTemplate.system` / `.user`,
+  both `{{var}}`
+- `references/automation/flow.mdx` — `flow.nodes[].outputSchema`,
+  `{{nodeId.field}}`
+- `references/ai/solution-blueprint.mdx` — the roll-up `filter` example,
+  `{ status: { $in: [...] } }`
+- `references/api/analytics.mdx` — the retired `query` envelope,
+  `{ cube, query: {...} }`
+
+The issue reported three; the last two were cut in the same place but start
+with a single brace, so the `` `{{ `` grep that found the others could never
+have seen them.
+
+Unchanged: a single `{…}` pair, a `{<id>}` nest, and a lone unmatched `<` / `{`
+(entity-escaped, e.g. a SemVer range `>=4.0 <5`) all escape exactly as before.
+No package export or runtime behaviour changes — the fix is in
+`scripts/build-docs.ts`, whose escaping moved to `scripts/lib/escape-mdx.ts` so
+it can be pinned directly rather than by grepping emitted `.mdx`.

--- a/content/docs/references/ai/model-registry.mdx
+++ b/content/docs/references/ai/model-registry.mdx
@@ -168,8 +168,8 @@ const result = ModelCapabilitySchema.parse(data);
 | **id** | `string` | ✅ | Unique template identifier |
 | **name** | `string` | ✅ | Template name (snake_case) |
 | **label** | `string` | ✅ | Display name |
-| **system** | `string \| { dialect: Enum<'cel' \| 'cron' \| 'template'>; source?: string; ast?: any; meta?: object }` | optional | System prompt — supports `{{var}`} interpolation |
-| **user** | `string \| { dialect: Enum<'cel' \| 'cron' \| 'template'>; source?: string; ast?: any; meta?: object }` | ✅ | User prompt template — supports `{{var}`} interpolation |
+| **system** | `string \| { dialect: Enum<'cel' \| 'cron' \| 'template'>; source?: string; ast?: any; meta?: object }` | optional | System prompt — supports `{{var}}` interpolation |
+| **user** | `string \| { dialect: Enum<'cel' \| 'cron' \| 'template'>; source?: string; ast?: any; meta?: object }` | ✅ | User prompt template — supports `{{var}}` interpolation |
 | **assistant** | `string` | optional | Assistant message prefix |
 | **variables** | `{ name: string; type?: Enum<'string' \| 'number' \| 'boolean' \| 'object' \| 'array'>; required?: boolean; defaultValue?: any; … }[]` | optional | Template variables |
 | **modelId** | `string` | optional | Recommended model ID |

--- a/content/docs/references/ai/solution-blueprint.mdx
+++ b/content/docs/references/ai/solution-blueprint.mdx
@@ -153,7 +153,7 @@ const result = BlueprintAppSchema.parse(data);
 | **field** | `string` | optional | Numeric field on the CHILD object to aggregate. Ignored for "count" (pass "id" or omit it). |
 | **relationshipField** | `string` | optional | The child FK field pointing back at this parent. Auto-detected from the child's lookup / master_detail; set it only when the child has more than one reference to this parent. |
 | **conditions** | `{ field: string; op: Enum<'lt' \| 'lte' \| 'gt' \| 'gte' \| 'eq' \| 'ne'>; value: number \| string \| boolean }[]` | optional | CONDITIONAL roll-up: aggregate only the child rows matching these comparisons (ANDed). REQUIRED whenever the field name carries a qualifier — "已完成任务数 / 已收货金额 / 待处理工单数", any 已X / 未X / `<某状态>`的 count-or-sum → e.g. [`{ field: "status", op: "eq", value: "completed" }`]. WITHOUT it the roll-up silently counts EVERY child and reports a plausible-looking WRONG number, which is worse than a visible 0. |
-| **filter** | `any` | optional | The same predicate as a canonical query filter map (e.g. `{ status: "completed" }`, `{ status: { $in: ["received", "partial"] }` }). Use it when hand-authoring a blueprint; the structured design path uses `conditions` instead. Wins over `conditions` when both are given. |
+| **filter** | `any` | optional | The same predicate as a canonical query filter map (e.g. `{ status: "completed" }`, `{ status: { $in: ["received", "partial"] } }`). Use it when hand-authoring a blueprint; the structured design path uses `conditions` instead. Wins over `conditions` when both are given. |
 
 
 ---

--- a/content/docs/references/api/analytics.mdx
+++ b/content/docs/references/api/analytics.mdx
@@ -67,7 +67,7 @@ const result = AnalyticsEndpoint.parse(data);
 | **limit** | `number` | optional |  |
 | **offset** | `number` | optional |  |
 | **timezone** | `string` | optional |  |
-| **query** | `any` | optional | [REMOVED] `query` was removed from AnalyticsQueryRequest in @objectstack/spec 17.0.0 (#3878). The `{ cube, query: {...}` } envelope was the dialect of the retired degraded analytics shim (#3891) — the real engine never understood it. Move the query.* fields to the body top level: `{ cube, measures, dimensions?, where?, timeDimensions?, order?, limit?, offset?, timezone? }`. |
+| **query** | `any` | optional | [REMOVED] `query` was removed from AnalyticsQueryRequest in @objectstack/spec 17.0.0 (#3878). The `{ cube, query: {...} }` envelope was the dialect of the retired degraded analytics shim (#3891) — the real engine never understood it. Move the query.* fields to the body top level: `{ cube, measures, dimensions?, where?, timeDimensions?, order?, limit?, offset?, timezone? }`. |
 | **format** | `any` | optional | [REMOVED] `format` was removed from AnalyticsQueryRequest in @objectstack/spec 17.0.0 (#3878). It was never implemented — every response is the JSON envelope. Delete the key; for CSV/XLSX use the export surface instead. |
 
 

--- a/content/docs/references/automation/flow.mdx
+++ b/content/docs/references/automation/flow.mdx
@@ -103,7 +103,7 @@ const result = FlowSchema.parse(data);
 | **position** | `{ x: number; y: number }` | optional |  |
 | **timeoutMs** | `integer` | optional | Maximum execution time for this node in milliseconds |
 | **inputSchema** | `Record<string, { type: Enum<'string' \| 'number' \| 'boolean' \| 'object' \| 'array'>; required: boolean; description?: string }>` | optional | Input parameter schema for this node |
-| **outputSchema** | `any` | optional | [REMOVED] `flow.nodes[].outputSchema` was removed in @objectstack/spec 17.0.0 (#3896 audit close-out) — it was never validated: the engine does not check node outputs against it, so it documented a contract nothing enforced. Delete the key. Downstream nodes read prior outputs via expressions (`{{nodeId.field}`}) regardless of any declaration. |
+| **outputSchema** | `any` | optional | [REMOVED] `flow.nodes[].outputSchema` was removed in @objectstack/spec 17.0.0 (#3896 audit close-out) — it was never validated: the engine does not check node outputs against it, so it documented a contract nothing enforced. Delete the key. Downstream nodes read prior outputs via expressions (`{{nodeId.field}}`) regardless of any declaration. |
 | **waitEventConfig** | `{ eventType: Enum<'timer' \| 'signal' \| 'webhook' \| 'manual' \| 'condition'>; timerDuration?: string; signalName?: string; timeoutMs?: any; … }` | optional | Configuration for wait node event resumption |
 | **boundaryConfig** | `{ attachedToNodeId: string; eventType: Enum<'error' \| 'timer' \| 'signal' \| 'cancel'>; interrupting: boolean; errorCode?: string; … }` | optional | Configuration for boundary events attached to host nodes |
 

--- a/packages/spec/scripts/build-docs.ts
+++ b/packages/spec/scripts/build-docs.ts
@@ -26,6 +26,7 @@ import {
   resolveImports,
   type CategorySurface,
 } from './lib/docs-import-surface';
+import { escapeMdxDescription } from './lib/escape-mdx';
 import { anchorFor, formatType, type TypeContext } from './lib/format-type';
 import { createSink } from './lib/generated-output';
 import { schemaNameFromExportKey } from './lib/schema-name';
@@ -257,47 +258,8 @@ function generateMarkdown(schemaName: string, schema: any, category: string, zod
   // Add schema heading
   md += `## ${schemaName}\n\n`;
   
-  // Escape MDX-unsafe characters in description text. MDX parses `{` as a JS
-  // expression and `<` as JSX, so any raw `{token}` / `<title>` inside a Zod
-  // `.describe()` string breaks the docs build. Wrap such fragments in inline
-  // code so they render literally.
-  //
-  // Single pass with backtick tracking: fragments already inside an inline-code
-  // span are left untouched. A naive two-pass replace double-wraps nested cases
-  // like `{<id>}` into `` `{`<id>`}` `` — the inner backticks close the span
-  // early and leak `<id>` as raw JSX (MDX: "Expected a closing tag for `<id>`").
-  //
-  // A matched `{…}` / `<…>` pair is wrapped in an inline-code span so it renders
-  // literally. A *lone* `<` or `{` with no closing partner (e.g. a SemVer range
-  // `">=4.0 <5"`, or prose like `count < 5`) can't be wrapped, so it is replaced
-  // with its HTML entity — otherwise MDX reads the `<` as the start of a JSX tag
-  // and the build dies ("Unexpected character `5` before name").
-  const escapeMdxDescription = (raw: string): string => {
-    let out = '';
-    let inCode = false;
-    for (let i = 0; i < raw.length; i++) {
-      const ch = raw[i];
-      if (ch === '`') {
-        inCode = !inCode;
-        out += ch;
-        continue;
-      }
-      if (!inCode && (ch === '{' || ch === '<')) {
-        const close = ch === '{' ? '}' : '>';
-        const end = raw.indexOf(close, i + 1);
-        if (end !== -1) {
-          out += '`' + raw.slice(i, end + 1) + '`';
-          i = end;
-          continue;
-        }
-        // Unmatched: escape so MDX doesn't treat it as a JSX/expression opener.
-        out += ch === '<' ? '&lt;' : '&#123;';
-        continue;
-      }
-      out += ch;
-    }
-    return out;
-  };
+  // Description text is made MDX-safe by `lib/escape-mdx.ts` — extracted so the
+  // escaping can be pinned directly instead of by grepping emitted `.mdx`.
 
   // Add description with better formatting
   if (mainDef.description) {

--- a/packages/spec/scripts/escape-mdx.test.ts
+++ b/packages/spec/scripts/escape-mdx.test.ts
@@ -1,0 +1,157 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Pin for how the reference-docs generator escapes `{…}` / `<…>` inside
+ * `.describe()` prose — #5452.
+ *
+ * The escaper wrapped a delimited fragment in an inline-code span, but found
+ * its closing partner with `indexOf`, i.e. the FIRST closer rather than the
+ * MATCHING one. Nested delimiters are not an exotic input here — `{{var}}` is
+ * the template-interpolation syntax the spec's own prose *teaches*, and a
+ * filter map (`{ status: { $in: [...] } }`) is an ordinary example — so the
+ * wrap ended at the inner `}` and the outer one fell outside the span:
+ * `{{var}}` was published as `` `{{var}` `` plus a stray `}`.
+ *
+ * The issue counted three sites (`grep -rn '`{{' content/docs/references/`).
+ * The corpus gate below counts FIVE, because that grep only sees the fragments
+ * whose nesting starts at character one; `ai/solution-blueprint.mdx` and
+ * `api/analytics.mdx` were cut in exactly the same place with a single leading
+ * brace, and no grep for `` `{{ `` could have found them.
+ *
+ * MEASURED (reverse verification), both directions run:
+ *   - restoring the old matcher (`raw.indexOf(close, i + 1)` in place of
+ *     `findMatchingClose`) turns the four nested-delimiter unit cases red,
+ *     each reporting the split shape;
+ *   - and, after re-running `gen:docs` over the restored escaper, the corpus
+ *     gate goes red with 5 offenders — the same 5 that were on `main`.
+ * The direction is the ordinary one (restore the defect → the new pins go red)
+ * because these assert a POSITIVE output shape the fix produces, not the
+ * absence of a finding. The single-delimiter and unmatched cases stay green
+ * either way, which is exactly why the bug survived: the escaper was correct
+ * on every shape anyone had thought to look at.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import url from 'url';
+
+import { describe, expect, it } from 'vitest';
+
+import { escapeMdxDescription } from './lib/escape-mdx';
+
+const HERE = path.dirname(url.fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, '../../..');
+const REFERENCES = path.join(REPO, 'content/docs/references');
+
+describe('escapeMdxDescription — nested delimiters (#5452)', () => {
+  it('wraps `{{var}}` whole, leaving no stray closer outside the span', () => {
+    expect(escapeMdxDescription('System prompt — supports {{var}} interpolation')).toBe(
+      'System prompt — supports `{{var}}` interpolation',
+    );
+  });
+
+  it('wraps a doubled brace inside parentheses (the automation/flow.mdx specimen)', () => {
+    expect(
+      escapeMdxDescription(
+        'Downstream nodes read prior outputs via expressions ({{nodeId.field}}) regardless.',
+      ),
+    ).toBe('Downstream nodes read prior outputs via expressions (`{{nodeId.field}}`) regardless.');
+  });
+
+  it('wraps a singly-nested filter map whole (the ai/solution-blueprint.mdx specimen)', () => {
+    // The variant `grep '`{{'` could not see: nesting that starts one char in.
+    expect(escapeMdxDescription('e.g. { status: { $in: ["received"] } }.')).toBe(
+      'e.g. `{ status: { $in: ["received"] } }`.',
+    );
+  });
+
+  it('wraps nested angle delimiters whole', () => {
+    // The span opens at the delimiter, not at the identifier in front of it —
+    // pre-existing behaviour, and MDX-safe either way. What #5452 changes is
+    // that BOTH closing `>` land inside the span instead of one leaking out.
+    expect(escapeMdxDescription('Shaped as Array<Record<string, any>> at rest')).toBe(
+      'Shaped as Array`<Record<string, any>>` at rest',
+    );
+  });
+
+  it('wraps each of two independent doubled pairs on one line', () => {
+    expect(escapeMdxDescription('render {{a.b}} then {{c}} here')).toBe(
+      'render `{{a.b}}` then `{{c}}` here',
+    );
+  });
+});
+
+describe('escapeMdxDescription — shapes the fix must not disturb', () => {
+  it('still wraps a single `{…}` pair', () => {
+    expect(escapeMdxDescription('a {token} b')).toBe('a `{token}` b');
+  });
+
+  it('still wraps a `{<id>}` nest in ONE span (no inner backticks)', () => {
+    expect(escapeMdxDescription('path {<id>} here')).toBe('path `{<id>}` here');
+  });
+
+  it('still entity-escapes a lone `<` with no partner (SemVer range)', () => {
+    expect(escapeMdxDescription('supports >=4.0 <5 only')).toBe('supports >=4.0 &lt;5 only');
+  });
+
+  it('still entity-escapes a lone `{` with no partner', () => {
+    expect(escapeMdxDescription('an unclosed { here')).toBe('an unclosed &#123; here');
+  });
+
+  it('still leaves fragments already inside an inline-code span untouched', () => {
+    expect(escapeMdxDescription('see `{{var}}` above')).toBe('see `{{var}}` above');
+  });
+});
+
+/**
+ * Corpus gate over the generator's committed OUTPUT.
+ *
+ * The invariant is brace BALANCE inside an inline-code span, not the literal
+ * `` `{{ ``-plus-stray-`}` string the issue grepped for. Balance is what the
+ * defect actually violates — the wrap cut a pair in half — so it catches the
+ * two sites whose nesting did not start at character one, and it keeps
+ * catching them when the offending prose is reworded.
+ *
+ * Angle delimiters deliberately get NO corpus gate: `<`/`>` are also the
+ * comparison operators, and validation-rule / SemVer examples legitimately
+ * carry an unbalanced one inside a code span (`record.amount < 0`,
+ * `>=1.2.3`) — 11 such spans, all correct. Nesting for angles is pinned by
+ * the positive unit case above instead. Backslash-escaped delimiters are not
+ * delimiters: the module-JSDoc path escapes braces as `\{`, so they are
+ * dropped before counting.
+ */
+describe('published reference pages keep inline-code braces balanced (#5452)', () => {
+  const pages: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.mdx')) pages.push(full);
+    }
+  };
+  walk(REFERENCES);
+
+  it('finds the generated reference corpus', () => {
+    expect(pages.length).toBeGreaterThan(50);
+  });
+
+  it('has no inline-code span with an unbalanced brace', () => {
+    const offenders: string[] = [];
+    for (const file of pages) {
+      const rel = path.relative(REPO, file);
+      fs.readFileSync(file, 'utf-8')
+        .split('\n')
+        .forEach((line, index) => {
+          // Odd segments of a backtick split are the inline-code spans.
+          const segments = line.split('`');
+          for (let i = 1; i < segments.length; i += 2) {
+            const span = segments[i].replace(/\\[{}]/g, '');
+            const opens = span.split('{').length - 1;
+            const closes = span.split('}').length - 1;
+            if (opens !== closes) offenders.push(`${rel}:${index + 1}  \`${segments[i]}\``);
+          }
+        });
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/spec/scripts/escape-mdx.test.ts
+++ b/packages/spec/scripts/escape-mdx.test.ts
@@ -20,8 +20,8 @@
  *
  * MEASURED (reverse verification), both directions run:
  *   - restoring the old matcher (`raw.indexOf(close, i + 1)` in place of
- *     `findMatchingClose`) turns the four nested-delimiter unit cases red,
- *     each reporting the split shape;
+ *     `findMatchingClose`) turns all five nested-delimiter unit cases red
+ *     (`5 failed | 7 passed`), each reporting the split shape;
  *   - and, after re-running `gen:docs` over the restored escaper, the corpus
  *     gate goes red with 5 offenders — the same 5 that were on `main`.
  * The direction is the ordinary one (restore the defect → the new pins go red)

--- a/packages/spec/scripts/lib/escape-mdx.ts
+++ b/packages/spec/scripts/lib/escape-mdx.ts
@@ -6,8 +6,8 @@
  * Extracted from `build-docs.ts` (#5452) for the same reason `format-type.ts`
  * was (#4912): the generator is a top-level script with side effects, so the
  * only way to assert on its escaping used to be to run the whole thing and grep
- * the emitted `.mdx` — which is how the doubled-brace defect below survived on
- * `main` across three reference pages.
+ * the emitted `.mdx` — which is how the nested-delimiter defect below survived
+ * on `main` across five rows of four reference pages.
  */
 
 /** Opening delimiter → its closing partner. */

--- a/packages/spec/scripts/lib/escape-mdx.ts
+++ b/packages/spec/scripts/lib/escape-mdx.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `.describe()` / JSDoc prose → a fragment that is safe to paste into MDX.
+ *
+ * Extracted from `build-docs.ts` (#5452) for the same reason `format-type.ts`
+ * was (#4912): the generator is a top-level script with side effects, so the
+ * only way to assert on its escaping used to be to run the whole thing and grep
+ * the emitted `.mdx` — which is how the doubled-brace defect below survived on
+ * `main` across three reference pages.
+ */
+
+/** Opening delimiter → its closing partner. */
+const DELIMITERS: Record<string, string> = { '{': '}', '<': '>' };
+
+/**
+ * Index of the delimiter that closes the pair opened at `start`, or `-1` when
+ * the opener has no partner.
+ *
+ * Counts NESTING rather than taking the first closer (`indexOf`), because the
+ * delimiters this escaper cares about arrive doubled far more often than
+ * singly: `{{var}}` is the template-interpolation syntax the spec's own
+ * `.describe()` text teaches, and `Array< Record< string, x > >` is an ordinary
+ * type string. Matching the FIRST closer cuts such a fragment in half — the
+ * wrap ends at the inner `}` and the outer one is left outside the code span,
+ * so `{{var}}` rendered as `{{var}` followed by a stray `}` (#5452).
+ */
+function findMatchingClose(raw: string, start: number): number {
+  const open = raw[start];
+  const close = DELIMITERS[open];
+  if (!close) return -1;
+  let depth = 0;
+  for (let i = start; i < raw.length; i++) {
+    if (raw[i] === open) {
+      depth++;
+    } else if (raw[i] === close) {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Escape MDX-unsafe characters in description text.
+ *
+ * MDX parses `{` as a JS expression and `<` as JSX, so any raw `{token}` /
+ * `<title>` inside a Zod `.describe()` string breaks the docs build. Such
+ * fragments are wrapped in inline code so they render literally.
+ *
+ * Single pass with backtick tracking: fragments already inside an inline-code
+ * span are left untouched. A naive two-pass replace double-wraps nested cases
+ * like `{<id>}` into `` `{`<id>`}` `` — the inner backticks close the span
+ * early and leak `<id>` as raw JSX (MDX: "Expected a closing tag for `<id>`").
+ *
+ * A matched `{…}` / `<…>` pair — matched by NESTING DEPTH, see
+ * `findMatchingClose` — is wrapped in an inline-code span so it renders
+ * literally. A *lone* `<` or `{` with no closing partner (e.g. a SemVer range
+ * `">=4.0 <5"`, or prose like `count < 5`) can't be wrapped, so it is replaced
+ * with its HTML entity — otherwise MDX reads the `<` as the start of a JSX tag
+ * and the build dies ("Unexpected character `5` before name").
+ */
+export function escapeMdxDescription(raw: string): string {
+  let out = '';
+  let inCode = false;
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    if (ch === '`') {
+      inCode = !inCode;
+      out += ch;
+      continue;
+    }
+    if (!inCode && (ch === '{' || ch === '<')) {
+      const end = findMatchingClose(raw, i);
+      if (end !== -1) {
+        out += '`' + raw.slice(i, end + 1) + '`';
+        i = end;
+        continue;
+      }
+      // Unmatched: escape so MDX doesn't treat it as a JSX/expression opener.
+      out += ch === '<' ? '&lt;' : '&#123;';
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}


### PR DESCRIPTION
Fixes #5452

**排版说明**:GitHub 会把 body 里的引号和尖括号在**存储时**转义,所以本文刻意不写裸引号/尖括号,证据改用表格与列表呈现(#5452 实施中踩到,已回读存储后的 body 校验过)。

## 前提复核(先于实现)

issue 的基线是 `ed0d2aac0`,已前移大半天。在 `origin/main` @ `5acb93add` 上重新核对,3 处存量**仍在**,前提成立:

```
content/docs/references/ai/model-registry.mdx:171
content/docs/references/ai/model-registry.mdx:172
content/docs/references/automation/flow.mdx:106
```

## 根因

`packages/spec/scripts/build-docs.ts` 的 `escapeMdxDescription` 把带定界符的片段包进行内代码,让 MDX 按字面渲染而不是当成 JS 表达式 / JSX 标签。它用 `indexOf` 找收尾定界符 —— 取的是**第一个**闭合符,不是**配对**的那个:

```ts
const end = raw.indexOf(close, i + 1);   // 旧:第一个闭合符
```

所以任何嵌套对都只被包到内层闭合符为止,外层那个漏在代码跨度之外。`{{var}}` 于是输出成反引号只吃掉前半截、后面跟一个游离的 `}` —— 恰恰落在「教读者怎么写模板变量」的那几行上,而成对双花括号本身就是被文档的东西。

## 修法

改成**按嵌套深度**配对(新增 `packages/spec/scripts/lib/escape-mdx.ts` 的 `findMatchingClose`),整对落进同一个代码跨度。

转义逻辑同时从 `build-docs.ts` 抽到 `scripts/lib/escape-mdx.ts` —— 和 #4912 抽 `format-type.ts` 是同一个理由:生成器是带副作用的顶层脚本,在此之前想断言它的输出只能整跑一遍再 grep 产物,这正是本 bug 能在 main 上活下来的原因。

## 实测:是 5 处,不是 3 处

重新 `gen:docs` 后改动 4 个页面共 5 行。除 issue 点名的 3 处外,另有两处**同一根因**但起手只有单个花括号,因此 issue 用的 `` `{{ `` grep 天然看不见它们:

| 页面 | 行 | 修前 | 修后 |
|:---|:---|:---|:---|
| `ai/model-registry.mdx` | 171 / 172 | `` `{{var}` `` + 游离 `}` | `` `{{var}}` `` |
| `automation/flow.mdx` | 106 | `` `{{nodeId.field}` `` + 游离 `}` | `` `{{nodeId.field}}` `` |
| `ai/solution-blueprint.mdx` | 156 | `` `{ status: { $in: [...] }` `` + 游离 `}` | 整对包住 |
| `api/analytics.mdx` | 70 | `` `{ cube, query: {...}` `` + 游离 `}` | 整对包住 |

## ⚠️ 验收判据需要更正:issue 那条 grep 不会归零,也**不应该**归零

issue(及派单)把验收写成「`grep -rn` 反引号加两个左花括号,应归零」。**实测这条判据是错的**:该 pattern 匹配「反引号后面跟两个左花括号」,而**修好之后的正确输出 `` `{{var}}` `` 同样以反引号加两个左花括号开头**。所以它修前修后都是 3 命中,内容变了、计数不动。归零只有在「参考文档里根本不许出现模板变量语法」时才成立,而那恰恰与本单目的相反。

两条判据在同一语料(main 的 224 页 vs 本 PR 重生成后)上的实测:

| 扫描判据 | main | 本 PR |
|:---|:---:|:---:|
| issue 那条字面 pattern(反引号 + 两个左花括号) | 3 | **3** |
| 缺陷形状(以左花括号开头的行内代码跨度,闭合反引号后紧跟游离右花括号) | 5 | **0** |

下面的门禁测试用的是第二条判据的等价不变量,不是 issue 那条字面 grep。

## 门禁测试 + 反向验证

`packages/spec/scripts/escape-mdx.test.ts`(12 例)= 单元 pin + 全语料门禁。

门禁判据是**行内代码跨度里的花括号必须配平** —— 配平才是缺陷真正破坏的不变量(包裹把一对切成了两半),所以它能抓住上表那两处非双花括号开头的,并且在措辞改写后依然抓得住。实测语料信噪比:main 的 224 页 **5 处**违例(即上表 5 行),本 PR 重生成后 **0 处**,零噪声。

尖括号**故意不设语料门禁**:尖括号同时是比较运算符,校验规则里的比较式与 SemVer 区间前缀合法地带着不配平的一只,实测 11 处全部正确,设门禁纯属噪声。尖括号的嵌套改由正向单元用例 pin。反斜杠转义过的花括号(模块 JSDoc 那条路径写成反斜杠加花括号)在计数前先剔除。

**反向验证 —— 两个方向都实跑了,方向为常规「还原缺陷 → 转红」。** 把 `findMatchingClose` 换回 `raw.indexOf(close, i + 1)`:

**方向 1:5 条嵌套定界符单元用例立刻转红**,各自报出被切开的形状:

- `PromptTemplate` 的 `` `{{var}}` `` —— 跨度只吃到内层右花括号,外层漏出
- `flow` 的 `` `{{nodeId.field}}` `` —— 同上
- roll-up 的 `` `{ status: { $in: [...] } }` `` —— 单层起手的嵌套,同样被切
- 嵌套泛型类型串(Array 套 Record)—— 尾部第二个闭合尖括号漏出跨度
- 一行里两个独立的双花括号对 —— 两处各切一次

```
Tests  5 failed | 7 passed (12)
```

**方向 2:再跑 `gen:docs` 让语料回到旧转义之下,语料门禁转红**,报出的 5 行与 main 上那 5 行逐行一致:

```
× has no inline-code span with an unbalanced brace
+   content/docs/references/ai/model-registry.mdx:171
+   content/docs/references/ai/model-registry.mdx:172
+   content/docs/references/ai/solution-blueprint.mdx:156
+   content/docs/references/api/analytics.mdx:70
+   content/docs/references/automation/flow.mdx:106
```

之所以是常规方向而非反转方向:这些用例断言的是修复**产生**的正向输出形状,不是某个 finding 的消失。单定界符与不配对的用例两个方向都是绿的 —— 这正是 bug 活下来的原因:凡是有人想到去看的形状,转义器都是对的。

还原修复后重跑 `gen:docs`,工作树与本 PR 提交**逐字节一致**(`git status` 干净),生成物可复现。

## 验证

```console
$ pnpm --filter @objectstack/spec exec vitest run --maxWorkers=2
Test Files  315 passed (315)
     Tests  8022 passed (8022)

$ pnpm --filter @objectstack/spec typecheck
check:test-typecheck: OK

$ pnpm --filter @objectstack/spec check:docs
✅ 239 generated files in sync with packages/spec

$ node scripts/check-nul-bytes.mjs
check-nul-bytes: OK (scanned 5501 tracked text file(s))
```

## 刻意不做的三件事

- **#5307 在 `email-config.zod.ts` `appName` describe 里的绕写保持原样**。那段注释引用本单、历史成立,且措辞是作者面的选择,不是本单验收项。
- **`packages/spec/authorable-surface.base.json` 未纳入**。跑 `gen:schema` 会顺手把 `baseRev` 推到当前 main 并吸收 #5307 / #5498 新增的键 —— 那是 `gen:schema` 的副作用,与本单无关,且是并行 agent 的冲突热点,已还原。
- **配平扫描顺带发现的另一条缺陷未在此修**,已单独立单 **#5553**:模块 JSDoc 走的是另一条路径(`getFileDescription` 按源码行 `join` 成段落),跨行的行内代码跨度被段落边界切断,5 张参考页正文露出裸反引号;根因与本单无关。

## 变更集

`@objectstack/spec` patch。包导出与运行时行为零变化(改的是 `scripts/`,不进 `dist`),但参考文档是该包生成器的读者可见产物,被切坏的又正是教语法的那一列,所以走 changeset 而非 skip 标签。
