### PR TITLE
docs(adr-0053): 把 #5517 之后失真的两处 mongo 覆盖陈述改成实话 (#5539)

### DIFF
--- a/docs/adr/0053-date-and-datetime-semantics.md
+++ b/docs/adr/0053-date-and-datetime-semantics.md
@@ -837,6 +837,36 @@ sets** — the ADR's original requirement — through their own real entry point
 MySQL under a skewed process zone), `driver-memory`, `driver-mongodb` (real
 MongoDB), the analytics preview evaluator, and `formula`'s write-side `check`.
 
+> **Coverage correction, 2026-08-05 (#5517 / PR #5538) — the `driver-mongodb`
+> cell no longer runs by default.** This corrects a statement of *coverage*,
+> not any decision recorded here: the consumer still exists, still drives the
+> shared table through the driver's own entry point, and nothing in D-A3 or
+> D-A3.1 is reversed.
+>
+> `driver-mongodb` is the one cell above that needs a real server process, and
+> the seven suites in that package which need one became **opt-in** behind
+> `OS_TEST_MONGODB_MEMORY_SERVER_ENABLED=1` — among them
+> `mongodb-temporal-conformance.test.ts` (both `TEMPORAL_CASES` and
+> `TEMPORAL_TIME_CASES`, with no server-free half) and
+> `mongodb-datetime-storage.test.ts` (D-E4's row-result cover). Without the
+> switch they skip with a named notice and start no download. The reason was
+> not the matrix: `mongodb-memory-server` fetches a ~123 MB binary on first
+> use, two vitest workers raced that fetch, and the loser's abandoned download
+> surfaced as an unhandled rejection that turned all-green runs into `exit 1`
+> and ejected unrelated PRs from the merge queue. The maintainer retired the
+> download rather than fund single-flight or prewarm infrastructure for a
+> driver family whose investment is frozen (#5499); `test-mongod.ts` in that
+> package documents the mechanism.
+>
+> `scripts/check-driver-conformance.mjs` still reports these cells CONSUMED,
+> because that gate judges coverage by *import* and the files still import the
+> markers. Its ledger comment carries the per-marker state as measured on the
+> day of the change — read it before treating the mongo column as executed
+> coverage.
+>
+> Restoring these cells to CI hangs on #5499: whatever decision un-freezes that
+> family and provisions a mongod binary again also retires this note.
+
 It is modelled on `filter-logic-conformance.ts`, which exists for the same
 reason one layer down (#3774), and lives in `spec` for the D-D2 reason: every
 backend already depends on it.
@@ -975,6 +1005,15 @@ exactly what mingo performs and what a mongo text range uses — stays
 chronological across both widths.
 
 Coverage note: the mongo end-to-end sweep needs a real server
-(`mongodb-memory-server`), so it runs in CI and skips where no binary is
-available. The conversion itself is pinned by `mongodb-time-storage.test.ts`,
-which is pure and runs everywhere.
+(`mongodb-memory-server`), ~~so it runs in CI and skips where no binary is
+available~~ — **corrected 2026-08-05 (#5517 / PR #5538): it does not run in CI
+at all any more, and binary reachability stopped being the condition.** The
+mongod-backed suites are opt-in behind `OS_TEST_MONGODB_MEMORY_SERVER_ENABLED=1`
+(see the coverage correction under D-A3.1 for why), so
+`mongodb-temporal-conformance.test.ts` — which carries this axis's
+`TEMPORAL_TIME_CASES` and has no server-free half — skips with a named notice
+on every default run, whether or not a binary is reachable. It runs when a
+human asks for it, and returns to CI only if #5499 is un-frozen and something
+provisions a binary again. The conversion itself is pinned by
+`mongodb-time-storage.test.ts`, which is unaffected: it is pure, needs no
+server, and still runs everywhere.


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5539

Docs-only。只动 `docs/adr/0053-date-and-datetime-semantics.md` 一个文件,`scripts/`、`packages/`、`content/docs/releases/` 一律未碰。

## 前提复核(对 origin/main,不信 issue 快照)

- PR #5538 = commit `4fdf480`,已在 `main` 上(`test(driver-mongodb): gate the mongod-backed suites behind an opt-in env var (#5517) (#5538)`)。
- `packages/plugins/driver-mongodb/src/` 下 8 个文件 import `createTestMongod`,其中 7 个是真正需要 mongod 的套件,第 8 个 `mongodb-memory-server-gate.test.ts` 是钉住「闸门关闭时连库都不 import」的 pin test(默认跑)。
- ADR 的两处陈述在合并后的 `main` 上仍是原文,行号与 issue 快照有偏移:coverage note 在 977-980(不是 977-979),backend 列表在 834-838。
- issue 说「#5538 已把逐 marker 的真实状态记进 `scripts/check-driver-conformance.mjs` 的 ledger 注释」 —— **属实**,该注释按 marker 逐条写明 `FILTER_LOGIC_CASES` 仍默认跑、`PAGINATION_*` 与 `TEMPORAL_*` 仅 opt-in。本 PR 不动它。

前提成立,按分诊建议 1 执行。

## 改了什么

两处都是**覆盖陈述**的事实修正,不是新裁决 —— ADR 的 Status 行、D-A3 / D-A3.1 / D-A3.2 的任何决定都没有增删改。

**1. D-A3.1 的 backend 列表(834-838 行)之后,新增一段带日期的 correction note。**
原句「Five backends consume it and assert row-id sets through their own real entry points」本身没错(consumer 确实还在、还在跑同一张表),失真的是那一格**何时**执行。所以原文保留,后面补一段说明:`driver-mongodb` 是唯一需要真实 server 进程的一格,该包 7 个套件已改 opt-in;点名受影响的 `mongodb-temporal-conformance.test.ts`(`TEMPORAL_CASES` + `TEMPORAL_TIME_CASES`,无 server-free 半边)与 `mongodb-datetime-storage.test.ts`(D-E4 的 row-result cover);写清闸门的由来(~123 MB 二进制下载竞态 → unhandled rejection → 绿跑变 `exit 1` → 踢掉无关 PR;维护者选择退役下载而非为 #5499 冻结的家族投单飞/预热);并说明 `check-driver-conformance` 为何仍报 CONSUMED(它按 import 判定),把读者指向该脚本的 ledger 注释;最后写明恢复条件挂在 #5499 解冻,解冻后本注记随之退役。

**2. D-A3.2 结尾的 Coverage note(977-980 行)。**
用本 ADR 已有的删除线惯例(文中多处 `~~...~~` + 结论)处理:把 「so it runs in CI and skips where no binary is available」 **划掉而非删掉**(保留记录),补上实话 —— 默认根本不在 CI 跑,binary 是否可达已不再是条件;开关是 `OS_TEST_MONGODB_MEMORY_SERVER_ENABLED=1`。原句最后一半(「The conversion itself is pinned by `mongodb-time-storage.test.ts`, which is pure and runs everywhere」)**仍然成立并保留** —— 已核实该文件不 import `createTestMongod`,不受闸门影响。

## 验证

Docs-only 无行为变化,跑的是相关的仓内闸门(全部前台阻塞执行):

- `node scripts/check-nul-bytes.mjs --self-test && node scripts/check-nul-bytes.mjs` → `OK (scanned 5507 tracked text file(s); ... no raw ASCII control bytes)`
- `node scripts/check-doc-authoring.mjs` → `✓ doc authoring guard: 362 files clean`
- `node scripts/check-adr-anchors.mjs` → `OK (29 anchored file(s), every governing ADR still referenced)`
- `node scripts/docs-audit/check-audit-scope.mjs` → `✓ docs-accuracy-audit scope is in sync`
- `node scripts/check-driver-conformance.mjs` → `OK — 20 covered cell(s)`(确认本 PR 不改变该 gate 的判定,与注释所述一致)
- 额外自扫控制字节:`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' docs/adr/0053-date-and-datetime-semantics.md` → 无命中

`pnpm test` / `pnpm typecheck` 对本 PR 无意义:改动是一个 markdown 文件里的散文,没有任何 TS 程序或测试读取它 —— 与其编造一段与本改动无关的绿输出,不如把这一点写明。

## 一处刻意没改

D-E4(785 行)那句 「Row-result cover lives in `mongodb-datetime-storage.test.ts` (against a real MongoDB via `mongodb-memory-server`)」 —— 该套件确实也已 opt-in,但这句话只陈述 cover **在哪里**、用什么跑,没有声称「在 CI 跑」,严格讲不算失真。没有单独改它(避免扩面),改用上面第 1 处的 correction note 点名该文件,让同一份文档自洽。

## 无 changeset

Docs-only、不发布任何包,按 `pr-automation.yml` 的首选路线走 `skip-changeset` 标签(工作流注释里 PREFERRED 的那条)。标签已挂(`skip-changeset` + `documentation`)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyvqvKMG6asi9aXjKE6xtx
