### PR TITLE
fix(client): 把 `tests/integration/` 纳入 tsc,并把 discovery 断言改到真实存在的表面 (#5544)

### DIFF
--- a/packages/client/tests/integration/01-discovery.test.ts
+++ b/packages/client/tests/integration/01-discovery.test.ts
@@ -36,9 +36,13 @@ describe('Discovery & Connection', () => {
       
       // Version should be a semantic version or API version string
       expect(discovery.version).toMatch(/^v?\d+/);
-      
-      // API name should be non-empty
-      expect(discovery.apiName.length).toBeGreaterThan(0);
+
+      // API name should be non-empty. `apiName` is optional on the discovery
+      // payload (spec `protocol.zod.ts` keeps it as the deprecated alias for
+      // `name`), so it is reached optionally and asserted — a missing value
+      // fails `toBeGreaterThan` rather than being waved through by a `!` or a
+      // `?? ''` default (#5449).
+      expect(discovery.apiName?.length).toBeGreaterThan(0);
     });
   });
 
@@ -56,13 +60,23 @@ describe('Discovery & Connection', () => {
     test('should resolve API routes from discovery info', async () => {
       const client = new ObjectStackClient({ baseUrl: TEST_SERVER_URL });
       await client.connect();
-      
-      // After connection, client should have discovery info
-      expect(client.discovery).toBeDefined();
-      expect(client.discovery?.version).toBeDefined();
-      
-      // Verify that subsequent API calls can be made (routes are resolved)
-      // This implicitly tests route resolution
+
+      // After connection, the client should have retained the discovery info.
+      // `ObjectStackClient` has no public `discovery` property — the one this
+      // case asserted until #5544 never existed on the class; the payload is
+      // held on the private `discoveryInfo` field (`src/index.ts`), which is
+      // what `getRoute()` steers every subsequent call with. It is read here
+      // through the bracket-notation escape hatch, exactly as this package's
+      // `src/client.hono.test.ts` already reads the same field — no public API
+      // is invented on behalf of a suite no type checker had ever compiled.
+      const discoveryInfo = client['discoveryInfo'];
+      expect(discoveryInfo).toBeDefined();
+      expect(discoveryInfo?.version).toBeDefined();
+
+      // Route resolution is what this case is named for: the routes map
+      // `getRoute()` reads has to be populated for subsequent API calls to be
+      // steered at all.
+      expect(discoveryInfo?.routes).toBeDefined();
     });
   });
 });

--- a/packages/client/tsconfig.test.json
+++ b/packages/client/tsconfig.test.json
@@ -24,14 +24,16 @@
 //     Nothing here may loosen a type rule; if a test does not compile, that is
 //     the finding.
 //
-// `include` deliberately stops at `src`, matching the build config's root, and
-// none of the files it leaves out carries a `@ts-expect-error`, so no pin is
-// hiding there. `tests/integration/` — the suite `vitest.integration.config.ts`
-// runs against a live server — is in no tsconfig at all: a second,
-// differently-shaped hole (1 file / 3 errors, one of them a real API drift, the
-// suite reading a `client.discovery` property `ObjectStackClient` does not
-// have) that wants its own change rather than a rider on this one. Filed as
-// #5544.
+// `include` covers BOTH test roots this package has. `src/**/*` is the layer
+// the build config excludes; `tests/**/*` is `tests/integration/`, the suite
+// `vitest.integration.config.ts` runs against a live server and the regular
+// `vitest.config.ts` excludes. Until #5544 it was named by no `include` and no
+// `exclude` anywhere — the #5476 shape, outside every program rather than
+// inside an excluded region — so neither vitest's regular run nor tsc ever read
+// it, and it had drifted onto a `client.discovery` property `ObjectStackClient`
+// does not have. Compiling it does NOT run it: the vitest split is unchanged,
+// the suite still needs a server. tsc reading a file is the cheaper of the two
+// gates and the only one that works without one.
 //
 // The per-file ledger beside this config (`test-typecheck-debt.json`) is small
 // on purpose. Under the repaired config the whole test layer came to 13 errors;
@@ -57,6 +59,6 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["node"]
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "tests/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Fixes #5544

## 前提复核(先证后改)

在合入 #5546 之后的 `origin/main` @ `229d29ea4` 上逐条复核,issue 的前提**完全成立**:

- `packages/client/tsconfig.test.json` 的 `include` 停在 `["src/**/*"]`,全仓没有任何 `exclude` 指名 `tests/integration/` —— 是 #5476 那种「在所有 program 之外」的形状,不是 #5286 那种「落在排除区里」。
- 临时把 `tests/**/*` 纳入编译,量到的就是 issue 列的那 1 文件 / 3 条:

```
tests/integration/01-discovery.test.ts(41,14): error TS18048: 'discovery.apiName' is possibly 'undefined'.
tests/integration/01-discovery.test.ts(61,21): error TS2339: Property 'discovery' does not exist on type 'ObjectStackClient'.
tests/integration/01-discovery.test.ts(62,21): error TS2339: Property 'discovery' does not exist on type 'ObjectStackClient'.
```

- 该文件不含任何 `@ts-expect-error`(`grep` 为空),PINS_CHECKED / PHANTOM_PIN_DEBT 不受影响。

## 改了什么

**1. `tsconfig.test.json` 的 `include` 纳入 `tests/**/*`**,并把配置头部那段「`tests/integration/` 不在任何 tsconfig 里,留给 #5544」的注释改写成现在的事实。

**运行通道一个字没动**:`vitest.config.ts` 仍然排除 `tests/integration/**`,`test:integration` 仍然走 `vitest.integration.config.ts`、仍然需要 README 里那台外部服务器。让 tsc 读它,不等于让 CI 跑它 —— 两条通道里,只有 tsc 这条在没有服务器时也能工作。

**2. 3 条错误全修,该文件不进 debt 台账。**

- **TC-DISC-004(2 条 TS2339,真实 API 漂移)**:`client.discovery` 在 `ObjectStackClient` 上从来没存在过(`git log -S` 查不到任何时期的公开 `discovery` getter)。发现结果存在私有的 `discoveryInfo` 字段上,本 PR 用**同包 `src/client.hono.test.ts:158/165` 已经在用的**方括号读法读它 —— 那两行今天就在编译且是干净的(该文件在台账里的 2 条是 #5543 的 `z.infer` 家族,与此无关)。**没有为这个死套件新增任何公开 API**,遵守裁定。
- 顺带把断言强度**提上去**:该用例名叫 "Route Resolution",而原来只断言了 version;现在补断言 `routes` 已填充 —— 那正是 `getRoute()` 用来路由后续每一次调用的东西,也是这个用例名字的含义。
- **TC-DISC-002(1 条 TS18048)**:按本包 #5449 定下的约定改成可选链断言 —— 值缺失时由 `toBeGreaterThan` 判红,而不是用 `!` 或 `?? ''` 兜过去。

## 一个刻意**没做**的改动(附证据)

`apiName` 在 spec 里被标注为 deprecated(`protocol.zod.ts:118-127`,canonical 是 `name`)。看上去应该顺手把断言改写成 `name`,但两个 discovery 生产者的拼法是**相反**的:

- `packages/metadata-protocol/src/protocol.ts:2509` 的 `getDiscovery()` 只发 `apiName`,不发 `name`;
- `packages/runtime` 的 `getDiscoveryInfo()` 只发 `name` —— 同仓 `packages/runtime/src/http-dispatcher.root.test.ts:38` 的注释原话就是 "getDiscoveryInfo returns 'name' not 'apiName'"。

该套件跑在一台外部服务器上,本单无法证伪它背后是哪个生产者;而在消费者侧写 `discovery.name ?? discovery.apiName` 正是契约优先原则禁止的宽松兜底。所以**断言的键原样保留**,只修类型错误,并把这份证据补到已有的 #4828(它的决策点 4 正是 `name` 必填 vs 生产者不产出),没有另开重复单。

## 反向验证(方向先判后跑,两个方向都对上了)

| 状态 | 预判 | 实测 |
|:---|:---|:---|
| 旧断言 + **新** include | 红,且恰好是原来那 3 条 | 3 条一字不差复现 |
| 旧断言 + **旧** include | **绿** —— 因为 tsc 根本看不见这个文件 | `tests/` 前缀错误数 = 0 |

值得写明:这条改动**回滚不会变红,而是变瞎**。第二行才是这个 issue 的本体 —— 一个既不被 vitest 跑、也不被 tsc 读的文件,可以对着一个不存在的属性断言好几个月而全绿。

## 验证

```
$ pnpm --filter @objectstack/client typecheck
✓ check:test-typecheck --self-test — 8 semantic case(s) + the parser hold.
check:test-typecheck: OK — @objectstack/client's test layer compiles under
packages/client/tsconfig.test.json; 3 file(s) / 6 error(s) held in
test-typecheck-debt.json (shrink-only, ... issues/5286).

$ pnpm --filter @objectstack/client test
 Test Files  17 passed (17)
      Tests  222 passed (222)

$ pnpm check:type-check-coverage
check-type-check-coverage: OK — 62/77 workspace packages type-checked ...

$ node scripts/check-nul-bytes.mjs
check-nul-bytes: OK (scanned 5507 tracked text file(s) ...)
```

`test-typecheck-debt.json` 未改动(仍是 3 文件 / 6 条 #5543 家族),该集成文件零错误、**不入台账**。集成套件本身仍能被 `vitest list --config vitest.integration.config.ts` 正常收集到 4 个用例;常规 `vitest list` 里它依然是 0 命中(排除关系未变)。

## changeset

**无 changeset,请打 `skip-changeset` 标签。** 本 PR 只改一个 tsconfig 的 `include` 与一个从未被任何通道执行过的测试文件,不发布任何包、不改变任何运行时行为 —— 与同包 #5546(PR 走的正是 skip-changeset 路径)同型。

## 界外发现

- **新立 #5564**(观察类,`finding`,未认领):`packages/client/vitest.integration.config.ts` 的 `test.poolOptions` 在 Vitest 4 已被移除,vitest 只打一条 DEPRECATED 警告 —— 注释声明的「集成测试串行执行以避免竞态」实际没有生效。全仓孤例。因该套件无自动通道执行,今天无人可踩,故未修入本 PR。
- **评论补到 #4828**(未新开重复单):上面那段 `apiName` / `name` 生产者分裂的证据。
- `packages/spec/authorable-surface.base.json` 在构建依赖时被 `gen:schema` 重写(baseRev 推进)—— 已 revert,未混入本 PR;该现象已由 #5358 / #5370 覆盖,不另开单。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FNvXhtSdnEGEfLEsMmvxh

---
_Generated by [Claude Code](https://claude.ai/code/session_016FNvXhtSdnEGEfLEsMmvxh)_