### PR TITLE
docs(os-dev): 自扫字符类补上 DEL,与 #5460 扩面后的门禁扫描面对齐 (#5484)

### DIFF
--- a/.claude/agents/os-dev.md
+++ b/.claude/agents/os-dev.md
@@ -271,7 +271,7 @@ binary: zero matches, no signal, and the rule you just wrote becomes
 invisible to every agent that greps for it. Run
 `node scripts/check-nul-bytes.mjs` before pushing, and when your change so
 much as *mentions* control characters, self-scan beyond the gate
-(`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' <files>`) — the gate's blind
+(`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]' <files>`) — the gate's blind
 spots are exactly where these bytes hide.
 
 The GitHub body sanitizer is the same discipline's other half: it strips `<`


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5484

## 问题

`.claude/agents/os-dev.md` 的 Byte discipline 段要求 dev agent 在改动「提及控制字符」时,除了跑门禁还要逐字节**自扫**,理由原话是 self-scan **beyond** the gate —— the gate's blind spots are exactly where these bytes hide。

但它给出的字符类停在 #5157 时代的扫描面(ASCII 控制字符减 tab/LF/CR,且只覆盖 C0 连续区间)。#5460(PR #5479)已把门禁 `scripts/check-nul-bytes.mjs` 的扫描面扩到含 DEL(U+007F,该字节不属于 C0,独自坐在 ASCII 表末端,正因如此被区间写法漏掉),这条指令没跟 —— 于是它成了门禁的**真子集**:

- agent 写下一枚 U+007F,按指令自扫 → **绿**;
- 推上去,CI 的 `check:nul-bytes` → **红**。

即这条指令在它唯一被设计来防的场景里给出假绿,把本可本地一秒发现的问题推迟整个 CI 轮次。

## 改动

一行:该字符类补上 `\x7f`,与门禁脚本头现行表述一致(`[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]`)。周边散文未陈述扫描面范围,无需同步;文件面仅 `.claude/agents/os-dev.md`,未触 `scripts/` 与 `packages/lint`。

「同一事实手抄三处(门禁脚本 / 历史 changeset / 本指令)、靠人肉同步」的单源化根治方向,按裁定留在 #5484 正文,**不在本单实施**。另两处均正确:门禁脚本 #5460 已更新;两份历史 changeset 凝固在各自当时的语义。

## 验证

本改动无可执行面、无单测面(纯 agent 指令文本),验证由覆盖 `.claude/` 的两道门禁 + 逐字节自扫构成。写这条修改本身就是 #4890 一族的事故源现场(该族多次事故全发生在「写关于该字节的内容」时),因此自扫用的是**扩面后**的字符类。

```
# 逐字节自扫(扩面后字符类,含 0x7f)—— 改动文件
$ grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]' .claude/agents/os-dev.md
exit=1(无匹配)
# 提交后的 blob 同样干净:git show HEAD:.claude/agents/os-dev.md | grep -caP ... -> 0

# 门禁 1
$ node scripts/check-nul-bytes.mjs --self-test && node scripts/check-nul-bytes.mjs
✓ check-nul-bytes --self-test: 48 assertions over a temp git repo (real scan() path)
check-nul-bytes: OK (scanned 5520 tracked text file(s); skipped 5 binary, 1 non-regular;
                     no raw ASCII control bytes).

# 门禁 2
$ node scripts/check-doc-authoring.mjs --self-test && node scripts/check-doc-authoring.mjs
✓ check-doc-authoring self-test: scope wiring (.claude and the live docs/ corpus in, ...)
✓ doc authoring guard: 362 files clean — no bare metadata literals.
```

字节级确认改动写入的是转义文本而非真字节(`od -c` 该行):`\ x 7 f` 四个字符,行内无 `177` 八进制字节。

### 反向验证(方向先判后跑)

预判三条腿:同一枚真 DEL 字节的样本上,**旧**字符类绿(即 issue 描述的假绿)、**新**字符类红、门禁红。实跑与预判一致:

- 样本:`od -c` 显示 `case ' 177 ':`(以 `printf '\177'` 生成,未粘贴裸字节);
- 旧字符类 `[\x00-\x08\x0b\x0c\x0e-\x1f]` → exit=1,**无匹配 = 假绿**;
- 新字符类(本 PR)→ exit=0,命中该行;
- 门禁一侧无须另造样本:其 `--self-test`(本 PR 已跑,48 断言全绿)自带 #5460 的 DEL 样本断言,包括 `'#5460: a raw 0x7f Backspace literal must be flagged'`。

三条腿合起来即「指令与门禁在该字节类上等价」——issue 描述的假绿窗口关闭。

## changeset

`.claude/` 内部 agent 指令文本,不释放任何包 → 按 pr-automation.yml 的 route 2 走 `skip-changeset` 标签(先例 PR #5501),不加空 frontmatter changeset(#4898)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE


---
_Generated by [Claude Code](https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE)_