### PR TITLE
fix(runtime): callData 的 ObjectQL 兜底对「记录不存在」统一答 404 RECORD_NOT_FOUND (#5138)

### DIFF
--- a/.changeset/calldata-record-not-found-unify.md
+++ b/.changeset/calldata-record-not-found-unify.md
@@ -1,0 +1,51 @@
+---
+"@objectstack/runtime": patch
+"@objectstack/metadata-protocol": patch
+---
+
+fix(runtime): `callData`'s ObjectQL fallback answers a missing record id with 404 `RECORD_NOT_FOUND` (#5138)
+
+`callData` (the data bridge behind `/data`, the MCP bridge and the declarative
+endpoint executor) is protocol-first with an ObjectQL fallback. The fallback
+gave **three different answers to one fact** — that `id` names no row:
+
+| verb | before | on the wire |
+|---|---|---|
+| `get` | `return … : null` | `200 { data: null }` |
+| `update` | `throw new Error('[ObjectStack] Not Found')` — no `.status` | **500** |
+| `delete` | no existence check at all | `200 { deleted: true }` |
+
+The protocol path has answered `404 RECORD_NOT_FOUND` on all three verbs since
+#4435 (re-asserted for the batch path by #5088), so the answer to the same
+request depended on something no caller can see: whether the deployment
+registered the `protocol` slot (`MetadataPlugin` / `@objectstack/metadata-protocol`).
+All three fallback branches now throw the SAME envelope the protocol throws.
+
+Two of these were actively harmful. `update` reported a caller mistake as an
+internal fault — every dispatcher exit reads `.status` → `.statusCode` → 500, so
+a 4xx fact entered error reporting and alerting as a 5xx. `delete` reported
+success for a row that never existed, which is the hardest class to notice: an
+integrator reading `200` records the cleanup as done.
+
+The envelope is not re-spelled. `recordNotFoundError` is now exported from
+`@objectstack/metadata-protocol` and imported by the fallback, so there is one
+construction point and the two paths behind one `callData` cannot drift apart
+again.
+
+**Upgrade note.** If you run an assembly WITHOUT the metadata-protocol plugin
+(lean hosts, and the MCP multi-env path that threads a raw driver), these three
+calls change their answer for a missing id — from `200`/`200`/`500` to `404
+{ code: 'RECORD_NOT_FOUND', message: 'Record <id> not found in <object>' }`.
+Deployments that DO register the protocol slot are unaffected: they already
+answered `404` and this release does not touch that path. A client that
+branched on `data === null` from `GET /data/:object/:id` should branch on the
+`404` instead; a client that treated `DELETE` as idempotent should treat `404`
+as "already gone". Declarative endpoints (`object_operation`) inherit the same
+answer, since they reuse `/data`'s delegation.
+
+`delete`'s existence check is a `find` probe, not a read of what `ql.delete`
+returned: `IDataDriver.delete` declares `Promise< boolean >` and the protocol
+can read it, but `IDataEngine.delete` declares `Promise< any >` and the engine
+returns its driver's result through the hook chain — testing that for `false`
+would be reading a signal the contract does not promise, and it fails in the
+direction this fixes.

--- a/packages/metadata-protocol/src/index.ts
+++ b/packages/metadata-protocol/src/index.ts
@@ -1,6 +1,10 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 export { ObjectStackProtocolImplementation, ConcurrentUpdateError, normalizeViewMetadata, graftNormalizedOperators, stripReadDecorations } from './protocol.js';
+// [#5138] The 404 envelope every single-record path answers, exported so the
+// ObjectQL FALLBACK in `@objectstack/runtime`'s `callData` builds the SAME one
+// instead of minting a second not-found shape. See `recordNotFoundError`.
+export { recordNotFoundError } from './protocol.js';
 export { createMetadataProtocolPlugin, assembleMetadataProtocol } from './plugin.js';
 export type { MetadataProtocolPluginOptions } from './plugin.js';
 export type { UninstallCleanup, UninstallCleanupOutcome } from './protocol.js';

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -340,8 +340,19 @@ function resolveOverlaySchema(type: string, _item: unknown): z.ZodTypeAny | null
  * params, #4190 stopped dropping filters) — a write that touched zero rows
  * reporting 200 is that shape one level up, on the verb where it costs the
  * most.
+ *
+ * [#5138] EXPORTED, for the same "cannot disagree about it" reason one layer
+ * out. `@objectstack/runtime`'s `callData` is protocol-first with an ObjectQL
+ * FALLBACK, and the fallback had reinvented this fact three incompatible ways
+ * (`get` → `null`, `update` → a bare `Error` with no status ⇒ 500, `delete` →
+ * no check at all ⇒ `200 { deleted: true }` for a row that never existed). It
+ * now calls THIS function, so the two paths behind one `callData` answer a
+ * missing id identically — which is the only reason a caller may stop caring
+ * which of them served it. Re-spelling the envelope there would have been a
+ * second not-found envelope; `RECORD_NOT_FOUND` (#5088) is the one this repo
+ * has.
  */
-function recordNotFoundError(object: string, id: string | number): Error {
+export function recordNotFoundError(object: string, id: string | number): Error {
     const err = new Error(`Record ${id} not found in ${object}`) as Error & {
         code?: string;
         status?: number;

--- a/packages/runtime/src/action-execution-calldata-not-found.test.ts
+++ b/packages/runtime/src/action-execution-calldata-not-found.test.ts
@@ -1,0 +1,362 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #5138 — `callData` answers "this id names no row" with ONE fact.
+ *
+ * `callData` is protocol-first with an ObjectQL fallback, and the fallback gave
+ * three different answers to the single fact that `params.id` matches nothing.
+ * Measured on `main` @ `c11369013` before the fix, same harnesses as below:
+ *
+ * ```
+ * FALLBACK get   : resolved  null                                   → /data 200 {data:null}
+ * FALLBACK update: rejected  Error('[ObjectStack] Not Found')       → no .status ⇒ 500
+ *                            (code: undefined, status: undefined)
+ * FALLBACK delete: resolved  { object, id, deleted: true }          → 200, row never existed
+ * PROTOCOL get   : rejected  RECORD_NOT_FOUND / 404
+ * PROTOCOL update: rejected  RECORD_NOT_FOUND / 404
+ * PROTOCOL delete: rejected  RECORD_NOT_FOUND / 404
+ * ```
+ *
+ * So the protocol path was ALREADY the canonical answer on all three verbs
+ * (#4435, re-asserted for the batch path by #5088) and needed no change — only
+ * pinning. The whole defect was the fallback, where the same GET answered 200
+ * or 404 depending on nothing the caller can see: whether the deployment
+ * registered the `protocol` slot.
+ *
+ * The fix imports `recordNotFoundError` from `@objectstack/metadata-protocol`
+ * rather than re-spelling it, so there is one construction point for the
+ * envelope and the two paths behind one `callData` cannot drift apart again.
+ *
+ * The suite is organised around that: the fallback's three verbs (was-red
+ * cases), the protocol's three (pins), and a field-for-field identity assertion
+ * across the two — which is the claim a caller actually depends on. Then the
+ * two consuming faces the issue names: `/data` through the REAL `HttpDispatcher`,
+ * and the declarative endpoint executor (#5092 / PR #5136) driven with the REAL
+ * `callData` bound, which is where the status a client receives is decided.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ObjectStackProtocolImplementation } from '@objectstack/metadata-protocol';
+import { ApiEndpointSchema } from '@objectstack/spec/api';
+import type { ApiEndpoint } from '@objectstack/spec/api';
+
+import { callData, type ActionExecutionDeps } from './action-execution.js';
+import { HttpDispatcher, type HttpProtocolContext } from './http-dispatcher.js';
+import { buildEndpointExecutionContext, executeEndpointTarget } from './endpoint-executor.js';
+
+const EC = { userId: 'u1', isSystem: false, positions: [], permissions: [] } as any;
+/** [#5155] Every service lookup resolves off the REQUEST's kernel. */
+const REQ = { request: {} } as HttpProtocolContext;
+const SCHEMA = { name: 'task', fields: { title: { name: 'title', type: 'text' } } };
+const GHOST = 'definitely_not_a_row';
+
+// ---------------------------------------------------------------------------
+// Harnesses — the SAME row set behind both paths, so "exists" means one thing
+// ---------------------------------------------------------------------------
+
+function rows() {
+    return new Map<string, any>([['r1', { id: 'r1', title: 'one' }]]);
+}
+
+/**
+ * ObjectQL-only: no `protocol` slot, so every verb takes the fallback. This is
+ * the combination the issue names — a deployment WITHOUT `MetadataPlugin`
+ * (`@objectstack/metadata-protocol`, which is what registers the slot). With it
+ * installed the fallback is unreachable, which is why nothing caught this.
+ */
+function fallbackHarness(store = rows()) {
+    const deleted: string[] = [];
+    const ql: any = {
+        // `registry` is what `HttpDispatcher.getObjectQLService` requires before
+        // it will hand the service to `callData` — not decoration.
+        registry: { getObject: (n: string) => (n === 'task' ? SCHEMA : undefined) },
+        find: async (_o: string, bag: any) => {
+            const hit = store.get(String(bag?.where?.id));
+            return hit ? [hit] : [];
+        },
+        update: async (_o: string, data: any, opts: any) => {
+            const id = String(opts?.where?.id);
+            if (!store.has(id)) return null;
+            store.set(id, { ...store.get(id), ...data });
+            return store.get(id);
+        },
+        delete: async (_o: string, opts: any) => {
+            const id = String(opts?.where?.id);
+            deleted.push(id);
+            return store.delete(id);
+        },
+    };
+    const services: Record<string, any> = {
+        metadata: { getObject: async () => ({ name: 'task', fields: {} }) },
+        objectql: ql,
+    };
+    const deps: ActionExecutionDeps = {
+        resolveService: (async (_c: HttpProtocolContext, name: string) => services[name]) as any,
+        getObjectQL: async () => ql,
+    };
+    return { deps, store, deleted, ql, services };
+}
+
+/** Protocol-first, with the REAL `@objectstack/metadata-protocol` occupant. */
+function protocolHarness(store = rows()) {
+    const engine: any = {
+        registry: { getObject: (n: string) => (n === 'task' ? SCHEMA : undefined) },
+        findOne: async (_o: string, opts: any) => store.get(String(opts?.where?.id)) ?? null,
+        find: async () => [...store.values()],
+        update: async (_o: string, data: any, opts: any) => {
+            const id = String(opts?.where?.id);
+            if (!store.has(id)) return null;
+            store.set(id, { ...store.get(id), ...data });
+            return store.get(id);
+        },
+        delete: async (_o: string, opts: any) => store.delete(String(opts?.where?.id)),
+    };
+    const services: Record<string, any> = {
+        metadata: { getObject: async () => ({ name: 'task', fields: {} }) },
+        protocol: new ObjectStackProtocolImplementation(engine),
+        objectql: engine,
+    };
+    const deps: ActionExecutionDeps = {
+        resolveService: (async (_c: HttpProtocolContext, name: string) => services[name]) as any,
+        getObjectQL: async () => engine,
+    };
+    return { deps, store, services };
+}
+
+const verb = {
+    get: (id: string) => ['get', { object: 'task', id }] as const,
+    update: (id: string) => ['update', { object: 'task', id, data: { title: 'x' } }] as const,
+    delete: (id: string) => ['delete', { object: 'task', id }] as const,
+};
+type Verb = keyof typeof verb;
+const VERBS: Verb[] = ['get', 'update', 'delete'];
+
+const run = (deps: ActionExecutionDeps, v: Verb, id: string) => {
+    const [action, params] = verb[v](id);
+    return callData(deps, REQ, action, params, undefined, undefined, EC);
+};
+
+/** Capture the rejection as plain data so the two paths can be compared. */
+async function rejection(p: Promise<unknown>) {
+    let caught: any;
+    let resolved: unknown;
+    let didResolve = false;
+    try {
+        resolved = await p;
+        didResolve = true;
+    } catch (e) {
+        caught = e;
+    }
+    expect(
+        didResolve,
+        `expected a RECORD_NOT_FOUND rejection, but the call RESOLVED with ${JSON.stringify(resolved)}`,
+    ).toBe(false);
+    return { code: caught?.code, status: caught?.status, message: caught?.message, object: caught?.object };
+}
+
+/** The #5088/#4435 envelope, spelled once. */
+const notFoundEnvelope = (id: string) => ({
+    code: 'RECORD_NOT_FOUND',
+    status: 404,
+    message: `Record ${id} not found in task`,
+    object: 'task',
+});
+
+// ---------------------------------------------------------------------------
+// The fallback — the three answers that were three different facts
+// ---------------------------------------------------------------------------
+
+describe('the ObjectQL fallback answers a missing id with RECORD_NOT_FOUND (#5138)', () => {
+    it.each(VERBS)('%s rejects with the #5088 envelope — code, status, message, object', async (v) => {
+        const h = fallbackHarness();
+        expect(await rejection(run(h.deps, v, GHOST))).toEqual(notFoundEnvelope(GHOST));
+    }, 60_000);
+
+    it('the 404 carries a `status`, not a `statusCode` — the property every exit reads FIRST', async () => {
+        // `update` used to throw a bare `Error`, so all three dispatcher exits
+        // (`HttpDispatcher.errorFromThrown`, `dispatcher-plugin`'s
+        // `errorResponseBase`, `endpoint-executor`'s `errorAnswer`) fell to
+        // their 500 default and a caller mistake entered error reporting as an
+        // internal fault. They read `.status` → `.statusCode` → 500.
+        const h = fallbackHarness();
+        let caught: any;
+        try { await run(h.deps, 'update', GHOST); } catch (e) { caught = e; }
+        expect(caught.status).toBe(404);
+        expect(caught).toBeInstanceOf(Error);
+        // Nothing here should look like the old bare throw.
+        expect(caught.message).not.toBe('[ObjectStack] Not Found');
+    }, 60_000);
+
+    it('delete refuses BEFORE touching the store — no delete is issued for a row that is not there', async () => {
+        // The old branch called `ql.delete` unconditionally and answered
+        // `{ deleted: true }`. A 404 that still issued the write would be the
+        // same lie with a different status code.
+        const h = fallbackHarness();
+        await rejection(run(h.deps, 'delete', GHOST));
+        expect(h.deleted).toEqual([]);
+    }, 60_000);
+
+    it.each(VERBS)('%s is unchanged for an id that DOES exist', async (v) => {
+        const h = fallbackHarness();
+        await expect(run(h.deps, v, 'r1')).resolves.toBeTruthy();
+    }, 60_000);
+
+    it('a real delete still deletes, and still answers `deleted: true`', async () => {
+        const h = fallbackHarness();
+        const out: any = await run(h.deps, 'delete', 'r1');
+        expect(out).toEqual({ object: 'task', id: 'r1', deleted: true });
+        expect(h.deleted).toEqual(['r1']);
+        expect(h.store.has('r1')).toBe(false);
+    }, 60_000);
+
+    it('a real update still returns the merged record', async () => {
+        const h = fallbackHarness();
+        const out: any = await run(h.deps, 'update', 'r1');
+        expect(out).toEqual({ object: 'task', id: 'r1', record: { id: 'r1', title: 'x' } });
+    }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// The protocol path — already canonical, pinned so it stays that way
+// ---------------------------------------------------------------------------
+
+describe('the protocol path answers the same missing id the same way (#4435/#5088)', () => {
+    it.each(VERBS)('%s rejects with the #5088 envelope', async (v) => {
+        const h = protocolHarness();
+        expect(await rejection(run(h.deps, v, GHOST))).toEqual(notFoundEnvelope(GHOST));
+    }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// The claim a caller depends on
+// ---------------------------------------------------------------------------
+
+describe('one `callData`, one answer — the two paths are field-for-field identical', () => {
+    it.each(VERBS)('%s: fallback envelope === protocol envelope', async (v) => {
+        const withoutProtocol = await rejection(run(fallbackHarness().deps, v, GHOST));
+        const withProtocol = await rejection(run(protocolHarness().deps, v, GHOST));
+        expect(withoutProtocol).toEqual(withProtocol);
+    }, 60_000);
+
+    it('and the envelope is built ONCE — the fallback imports the protocol’s factory', async () => {
+        // If either side ever re-spells the shape, the three assertions above
+        // can be kept green by editing a literal in this file. This one cannot:
+        // it compares the fallback's throw against the exported factory itself.
+        const { recordNotFoundError } = await import('@objectstack/metadata-protocol');
+        const reference = recordNotFoundError('task', GHOST) as any;
+        const actual = await rejection(run(fallbackHarness().deps, 'get', GHOST));
+        expect(actual).toEqual({
+            code: reference.code,
+            status: reference.status,
+            message: reference.message,
+            object: reference.object,
+        });
+    }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// Consuming face 1 — `/data` through the REAL dispatcher
+// ---------------------------------------------------------------------------
+
+/**
+ * A kernel with an `objectql` occupant and NO `protocol` one — the combination
+ * that reaches the fallback. `auth` answers a session so the request gets past
+ * the anonymous-deny gate and reaches the branch under test.
+ */
+function dispatcherOverFallback() {
+    const h = fallbackHarness();
+    const resolve = (name: string) =>
+        name === 'objectql' ? h.ql
+        : name === 'metadata' ? h.services.metadata
+        : name === 'auth' ? { api: { getSession: async () => ({ user: { id: 'u1' } }) } }
+        : undefined;
+    const kernel: any = { getService: resolve, getServiceAsync: async (n: string) => resolve(n) };
+    return { dispatcher: new HttpDispatcher(kernel), deleted: h.deleted };
+}
+
+describe('/data through the real HttpDispatcher inherits the one answer (#5138)', () => {
+    const cases: Array<[string, string, any]> = [
+        ['GET', `/data/task/${GHOST}`, undefined],
+        ['PATCH', `/data/task/${GHOST}`, { title: 'x' }],
+        ['DELETE', `/data/task/${GHOST}`, undefined],
+    ];
+
+    it.each(cases)('%s %s rejects with 404 RECORD_NOT_FOUND', async (method, path, body) => {
+        const { dispatcher } = dispatcherOverFallback();
+        // `dispatch()` re-throws everything but a permission denial; the two
+        // mounts that serve this domain (`dispatcher-plugin`'s catch →
+        // `errorResponseBase`, and `HttpDispatcher.errorFromThrown`) both read
+        // `.status` first, which is what turns this into a 404 on the wire —
+        // pinned for those exits by `domains/error-passthrough.test.ts`.
+        await expect(
+            dispatcher.dispatch(method, path, body, {}, { request: {} } as HttpProtocolContext),
+        ).rejects.toMatchObject({ status: 404, code: 'RECORD_NOT_FOUND' });
+    }, 60_000);
+
+    it('DELETE no longer answers a 200 success for a row that never existed', async () => {
+        // The was-red case in its most consequential form: this used to RESOLVE
+        // `{ handled: true, response: { status: 200, ... deleted: true } }`.
+        const { dispatcher, deleted } = dispatcherOverFallback();
+        const result = dispatcher.dispatch('DELETE', `/data/task/${GHOST}`, undefined, {}, { request: {} } as HttpProtocolContext);
+        await expect(result).rejects.toBeTruthy();
+        expect(deleted).toEqual([]);
+    }, 60_000);
+
+    it('GET on a row that exists still answers 200 with the record', async () => {
+        const { dispatcher } = dispatcherOverFallback();
+        const res: any = await dispatcher.dispatch('GET', '/data/task/r1', undefined, {}, { request: {} } as HttpProtocolContext);
+        expect(res.handled).toBe(true);
+        expect(res.response.status).toBe(200);
+    }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// Consuming face 2 — the declarative endpoint executor (#5092 / PR #5136)
+// ---------------------------------------------------------------------------
+
+/**
+ * The executor reuses `/data`'s delegation byte for byte, so it inherits this
+ * unification for free — and unlike `dispatch()` it BUILDS the HTTP answer, so
+ * this is where the status a client receives is asserted directly.
+ */
+function declaredEndpoint(operation: 'get' | 'update' | 'delete'): ApiEndpoint {
+    return ApiEndpointSchema.parse({
+        name: 'task_by_id',
+        path: '/api/v1/apps/showcase/task',
+        method: operation === 'get' ? 'GET' : operation === 'update' ? 'PATCH' : 'DELETE',
+        type: 'object_operation',
+        target: 'task',
+        objectParams: { object: 'task', operation },
+    });
+}
+
+describe('a declared endpoint answers 404 RECORD_NOT_FOUND on the wire (#5092/#5136)', () => {
+    it.each(['get', 'update', 'delete'] as const)('%s → status 404, code RECORD_NOT_FOUND', async (operation) => {
+        const h = fallbackHarness();
+        const ctx = buildEndpointExecutionContext({
+            request: {
+                method: 'GET',
+                path: '/api/v1/apps/showcase/task',
+                query: { id: GHOST },
+                headers: {},
+                ...(operation === 'update' ? { body: { title: 'x' } } : {}),
+            },
+            match: { endpoint: declaredEndpoint(operation), params: {} },
+            executionContext: EC,
+        });
+        const answer = await executeEndpointTarget(ctx, {
+            // The REAL `callData`, bound the way `dispatcher-plugin` binds it.
+            callData: (action, params, driver, scope, ec) =>
+                callData(h.deps, REQ, action, params, driver, scope, ec),
+        });
+
+        expect(answer.status).toBe(404);
+        const error = (answer.body as any).error;
+        expect(error.code).toBe('RECORD_NOT_FOUND');
+        expect(error.httpStatus).toBe(404);
+        // A 4xx message is a deliberate business answer and reaches the caller
+        // intact — the 5xx leak sanitiser must not have touched it.
+        expect(error.message).toBe(`Record ${GHOST} not found in task`);
+        expect(h.deleted).toEqual([]);
+    }, 60_000);
+});

--- a/packages/runtime/src/action-execution.ts
+++ b/packages/runtime/src/action-execution.ts
@@ -19,6 +19,13 @@ import { validateActionParams, type ResolvedActionParam } from '@objectstack/spe
 import type { ExecutionContext } from '@objectstack/spec/kernel';
 import type { IObjectQLEngine, ServiceSlotContract, ServiceSlotContracts } from '@objectstack/spec/contracts';
 import { checkApiExposure } from './api-exposure.js';
+// [#5138] The ONE 404 envelope a single-record path answers. Imported rather
+// than re-spelled so `callData`'s ObjectQL fallback and the protocol service it
+// falls back FROM cannot disagree about what "this id names no row" looks like.
+// A pure factory — no service resolution — so importing it costs the fallback
+// nothing on an assembly where the protocol plugin is absent, which is exactly
+// when the fallback runs.
+import { recordNotFoundError } from '@objectstack/metadata-protocol';
 import { actorUserFromExecutionContext, resolveActorDisplayName } from './security/actor-user.js';
 import type { HttpProtocolContext } from './http-dispatcher.js';
 import {
@@ -165,7 +172,14 @@ export async function callData(deps: ActionExecutionDeps,
             if (all && (all as any).value) all = (all as any).value;
             if (!all) all = [];
             const match = (all as any[]).find((i: any) => i.id === params.id);
-            return match ? { object: params.object, id: params.id, record: match } : null;
+            // [#5138] Was `: null` — a miss resolved, and `/data` wrapped it as
+            // `200 { data: null }`. The protocol path this falls back from has
+            // answered `404 RECORD_NOT_FOUND` since #4435, so the same GET
+            // answered 200 or 404 depending only on whether the deployment
+            // registered the protocol slot — a difference the caller cannot see
+            // and never asked for.
+            if (!match) throw recordNotFoundError(params.object, params.id);
+            return { object: params.object, id: params.id, record: match };
         }
         throw { statusCode: 503, message: 'Data service not available' };
     }
@@ -179,7 +193,15 @@ export async function callData(deps: ActionExecutionDeps,
             if (all && (all as any).value) all = (all as any).value;
             if (!all) all = [];
             const existing = (all as any[]).find((i: any) => i.id === params.id);
-            if (!existing) throw new Error('[ObjectStack] Not Found');
+            // [#5138] Was `throw new Error('[ObjectStack] Not Found')`. That
+            // error carried neither `.status` nor `.statusCode`, so BOTH
+            // dispatcher exits fell through to their 500 fallback
+            // (`HttpDispatcher.errorFromThrown`, `dispatcher-plugin`'s
+            // `errorResponseBase`, and the endpoint executor's `errorAnswer`
+            // all read `.status` → `.statusCode` → 500). A caller mistake was
+            // reported as an internal fault and taken to the error reporter
+            // with it.
+            if (!existing) throw recordNotFoundError(params.object, params.id);
             await ql.update(params.object, params.data, findOpts({ where: { id: params.id } }));
             return { object: params.object, id: params.id, record: { ...existing, ...params.data } };
         }
@@ -191,6 +213,31 @@ export async function callData(deps: ActionExecutionDeps,
             return await protocol.deleteData({ object: params.object, id: params.id, ...(scopeId ? { environmentId: scopeId } : {}), context: executionContext });
         }
         if (ql && typeof ql.delete === 'function') {
+            // [#5138] There was NO existence check here: the delete ran and the
+            // answer was `200 { deleted: true }` for any string in the path, so
+            // a typo'd id, an already-deleted row and a real deletion were
+            // indistinguishable — the exact shape #4435 removed from the
+            // protocol's `deleteData`, still live on the path that stands in
+            // for it. The "assume it worked" answer is the worst of the three
+            // this fallback gave, because an integrator reading 200 records the
+            // cleanup as done.
+            //
+            // The existence PROBE is a `find`, not a read of what `ql.delete`
+            // returned. `deleteData` can read its result because `IDataDriver.
+            // delete` declares `Promise<boolean>` ("true if deleted, false if
+            // not found"); `ql` here is the ObjectQL ENGINE (or, on the MCP
+            // multi-env path, a raw driver), and `IDataEngine.delete` declares
+            // `Promise<any>` — the engine passes its driver's result through
+            // the hook chain and returns `opCtx.result`. Testing that for
+            // `=== false` would be reading a signal the contract does not
+            // promise, which fails silently in the direction this issue is
+            // about: back to reporting a delete that removed nothing. The probe
+            // is the same one the sibling `get`/`update` fallbacks already run.
+            let all = await ql.find(params.object, findOpts({ where: { id: params.id }, limit: 1 }));
+            if (all && (all as any).value) all = (all as any).value;
+            if (!all) all = [];
+            const existing = (all as any[]).find((i: any) => i.id === params.id);
+            if (!existing) throw recordNotFoundError(params.object, params.id);
             await ql.delete(params.object, findOpts({ where: { id: params.id } }));
             return { object: params.object, id: params.id, deleted: true };
         }


### PR DESCRIPTION
Fixes #5138

基于 `origin/main` @ `c11369013`(含 #5569 `5aaa6fca8`)。

## 前提复核:成立,且 protocol 路径「先测后判」的结论是**不需要改**

开工先在最新 main 上实测,复现 harness 用一个不注册 `protocol` 槽的服务组合(这正是 issue 自述「装了 MetadataPlugin 的部署走不到兜底」所要求的),同一行数据同时喂给两条路径:

```
FALLBACK get   : resolved  null                              -> /data 200 {data:null}
FALLBACK update: rejected  Error('[ObjectStack] Not Found')  -> code undefined, status undefined => 500
FALLBACK delete: resolved  {object,id,deleted:true}          -> 200,行从未存在
PROTOCOL get   : rejected  RECORD_NOT_FOUND / 404 / "Record ghost not found in task"
PROTOCOL update: rejected  RECORD_NOT_FOUND / 404 / "Record ghost not found in task"
PROTOCOL delete: rejected  RECORD_NOT_FOUND / 404 / "Record ghost not found in task"
```

三分支的分歧与 issue 描述逐条吻合。**protocol 路径三个动词已经都是规范答案**(#4435 落下、#5088 在批量面重申),所以按分诊锚定第 2 条,这次**没有动 protocol 路径一行**,只把它钉进测试;真正的缺陷全部在兜底侧。

## 改了什么

三个兜底分支抛同一个信封。信封**不重新拼写**:`recordNotFoundError` 从 `@objectstack/metadata-protocol` 导出、由 `callData` 导入 —— 一个构造点,两条路径无法再漂移,也没有新造第二种 not-found 信封。它是纯工厂函数(不做任何服务解析),所以在「protocol 插件缺席」的装配上导入它零代价,而那正是兜底会跑的场合。

| 动词 | 之前 | 现在 |
|---|---|---|
| `get` | `: null` | `throw recordNotFoundError(object, id)` |
| `update` | `throw new Error('[ObjectStack] Not Found')`(无 `.status`) | 同上 |
| `delete` | 无存在性检查 | 先探测,不存在则同上,**且不下发删除** |

其中 `update` 的裸 Error 是把 4xx 事实报成 5xx 的直接原因:三个错误出口(`HttpDispatcher.errorFromThrown`、`dispatcher-plugin` 的 `errorResponseBase`、endpoint executor 的 `errorAnswer`)都是读 `.status` 再读 `.statusCode` 再兜底 500。

### delete 为什么用 find 探测,而不是读 `ql.delete` 的返回值

`deleteData` 能读返回值,是因为 `IDataDriver.delete` 声明了 `Promise< boolean >`(契约原文:true if deleted, false if not found)。但兜底里的 `ql` 是 ObjectQL **引擎**(或 MCP 多环境路径上的裸驱动),而 `IDataEngine.delete` 声明的是 `Promise< any >` —— `engine.ts:5589` 把驱动结果穿过 hook 链后返回 `opCtx.result`。对它测 `=== false` 是读一个契约没有承诺的信号,而且失败方向恰好是本单要修的方向(退回「删了零行却报成功」)。探测用的正是同函数里 `get`/`update` 兜底已经在跑的那一个 `find`。

## 反向验证(方向先判后跑)

预判写在跑之前:还原三分支后,兜底与两个消费面的用例应变红,而 **protocol 路径的 3 条与全部 happy-path 用例应保持绿**(因为 protocol 本来就是对的,这次没改它)。

实跑结果 **16 red / 9 green,与预判逐条一致**。旧答案在 assertion 里原样浮出:

```
expected a RECORD_NOT_FOUND rejection, but the call RESOLVED with null
expected { code: undefined, status: undefined, ... } to deeply equal { code: 'RECORD_NOT_FOUND', ... }
expected a RECORD_NOT_FOUND rejection, but the call RESOLVED with {"object":"task","id":"definitely_not_a_row","deleted":true}
expected Error: [ObjectStack] Not Found to match object { status: 404, code: 'RECORD_NOT_FOUND' }
```

保持绿的 9 条正是应该绿的:protocol 三动词 3 条 + happy-path 6 条。

**一处过程更正,记在这里而不是抹掉**:第一次还原是**不完整**的 —— 脚本用的字符串替换同时命中了 `update` 和 `delete` 两个分支的同一行,导致 delete 的探测其实没被删掉,只有信封退回了裸 Error。结果是 14 red / 9 green + 2 条「本该红却绿」("delete refuses BEFORE touching the store"、"DELETE no longer answers a 200 success")。那 2 条绿是**还原不彻底的证据,不是用例无效** —— 探测还在,所以它们当然仍然通过。重做彻底还原后两条如期转红,才得到上面的 16/9。这也顺带说明这两条用例确实钉的是探测本身,而不是信封。

## 消费面

- **`/data` 经真实 `HttpDispatcher.dispatch()`**:GET/PATCH/DELETE `/data/task/:missing` 三条,断言抛出体带 `status: 404` + `code: 'RECORD_NOT_FOUND'`。`dispatch()` 对非权限错误是原样再抛,落到 HTTP 状态码由两个挂载点的出口完成,而「`.status` 优先」这一步已由 `domains/error-passthrough.test.ts` 钉住。另有一条专门断言 DELETE 不再 resolve 出 200,且底层 `ql.delete` 一次都没被调用。
- **声明式端点执行器(#5092 / PR #5136)**:用**真实 `callData`** 绑定驱动 `executeEndpointTarget`,它自己构造 HTTP 应答,所以这里能直接断言客户端拿到的状态码。还原后的实测把三个旧答案完整暴露出来:`get -> 200`、`update -> 500`、`delete -> 200`;修复后三者均为 `404` + `RECORD_NOT_FOUND` + 原文消息(4xx 不经 5xx 泄漏消毒)。

### 半径扫描(按规则的消费者枚举,不按改动包)

`callData` 的 get/update/delete 调用方逐个看过:

- `domains/actions.ts:300` 与 `action-execution.ts:915`(动作体加载 `ctx.record`):两处本来就是 `try { ... if (got?.record) ... } catch { /* pass empty */ }`。之前 `null` 走 `got?.record` 落空,现在抛出走既有 `catch`,**结果都是 `record = {}`,行为不变**。
- `domains/mcp.ts` 的 `bridge.get`:`packages/mcp/src/mcp-http-tools.ts:475` 的 `get_record` 工具同时处理 `record == null` 和 `catch`,两条都产出 errorResult;而装了 protocol 的正常部署本来走的就是抛出那条,所以这次是让精简装配向生产行为**收敛**。
- 全仓 grep `[ObjectStack] Not Found` 无任何消费者依赖旧消息。
- `packages/rest/**`、`packages/cli/src/commands/**`、`domains/actions.ts` 匿名门:未触碰。
- qa/dogfood 两处提及 `callData` 的用例:一处是 RLS 拒绝断言 `isError === true`(两种形状都成立,且走 protocol 路径),一处的 404 是路由未匹配的 404,均不受影响。

## 测试

新增 `packages/runtime/src/action-execution-calldata-not-found.test.ts`(25 条,in-process 用例均显式 `}, 60_000)`),分四组:兜底三动词的信封、protocol 三动词的钉子、**两条路径 field-for-field 相等**(调用方真正依赖的那个断言),以及上面两个消费面。其中一条刻意不比字面量而是拿导出的工厂函数本身对照 —— 那样任何一侧重新拼写形状都无法靠改本文件里的字面量把它糊绿。

```
pnpm --filter @objectstack/runtime test
  Test Files  97 passed (97)
       Tests  1422 passed (1422)

pnpm --filter @objectstack/metadata-protocol test
  Test Files  42 passed (42)
       Tests  388 passed (388)

pnpm --filter @objectstack/runtime typecheck   -> tsc --noEmit, Done

node scripts/check-nul-bytes.mjs
  OK (scanned 5518 tracked text file(s); no raw ASCII control bytes)
```

changeset:`@objectstack/runtime` + `@objectstack/metadata-protocol` 均 patch,升级须知写明了「精简装配上这三个调用对不存在 id 的答案会变」以及装了 protocol 的部署不受影响。未触碰 `content/docs/releases/`。

## 界外发现

- **#5581**(已立,`finding` 标签,未派单):同一函数里 `delete` 的**成功体**两条路径形状也不同 —— protocol 回 `{object, id, success: true}`(合 `DeleteDataResponseSchema`),兜底回 `{object, id, deleted: true}`(`success` 缺失、`deleted` 未声明);且 `domains/data.ts:102` 的注释把兜底形状写成了规范。本 PR **刻意保持 `deleted: true` 原样**并有测试钉住成功路径未变,因为「删除成功的规范键是哪个」是一次独立取舍,会动到 spec 或所有 `deleted` 读取方。
- **#5571**(毗邻观察单,未触碰):复现路上没有撞到该 400。本 PR 对它的可达性也**不构成改变** —— 动作体加载记录那两处本来就 `try/catch` 吞掉查不到的情况并以 `record = {}` 继续(见上方半径扫描),这次抛出走的是同一个既有 catch,后续时序与之前一致。没有因果可写,不算修复它。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FNvXhtSdnEGEfLEsMmvxh

---
_Generated by [Claude Code](https://claude.ai/code/session_016FNvXhtSdnEGEfLEsMmvxh)_