### PR TITLE
fix(ci): Check Changeset 实时读 skip-changeset 标签,首个 run 不再永久红 (#5580)

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -59,6 +59,27 @@ jobs:
     #     that was structurally unsatisfiable.
     # Pin the author as well as the branch name, so a hand-pushed branch of
     # that name cannot borrow the exemption as an escape hatch.
+    #
+    # The LABEL half of this expression is a fast path, NOT the authority (#5580).
+    # `github.event.pull_request.labels` is a snapshot frozen when the event
+    # fired, so a label applied seconds after `gh pr create` is invisible to the
+    # `opened` run -- and `rerun_failed_jobs` replays that SAME payload
+    # (pm-dispatch Operational notes 5), so the resulting red run can never be
+    # re-run green. It is permanently red by construction: three PRs in one day
+    # (#5467 -- this gate's own fix PR -- plus #5501 and #5577) each left a stale
+    # red that a human or agent had to stop and explain away.
+    # The authority is the live re-read in the first step below. This expression
+    # only short-circuits the case where the payload ALREADY shows the label, so
+    # the common path still costs no runner at all. The branch/author half needs
+    # no such treatment: head_ref and the PR author cannot change under a rerun.
+    #
+    # Keeping the fast path leaves ONE stale cell, in the opposite direction: a
+    # label REMOVED after the event fired still short-circuits this run, which is
+    # then permissive on the strength of a snapshot. That one is self-correcting
+    # and was left deliberately -- removing a label always fires an `unlabeled`
+    # event of its own, and the run it starts sees no label in either place and
+    # enforces. The direction #5580 is about has no such rescue: the `labeled`
+    # run's green verdict does not clear the `opened` run's red one.
     if: >-
       !contains(github.event.pull_request.labels.*.name, 'skip-changeset')
       && !(github.head_ref == 'changeset-release/main'
@@ -68,23 +89,80 @@ jobs:
       pull-requests: write
 
     steps:
+      # The label read the frozen payload could not do. It runs BEFORE checkout
+      # on purpose: when the label is there, every step below is skipped and the
+      # whole job costs one API call, so converging on the live state is cheaper
+      # than the stale red it replaces.
+      #
+      # The direction of the tolerance is deliberate: an unreadable label list
+      # (API error, no PR number) resolves to `skip=false`, i.e. ENFORCE. A gate
+      # that could not read its input has verified nothing, and handing out an
+      # exemption on that basis is the #4690 anti-pattern -- a check that skips
+      # silently, exits 0 and reads as "no violations". The failure is announced
+      # as a warning and the changeset count below decides.
+      - name: Re-read this PR's labels live (the event payload can predate them)
+        id: labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::warning::No PR number on this event, so the labels could not be re-read. Enforcing the changeset check."
+            echo 'skip=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # The pulls endpoint carries the PR's full label set inline, and a GET
+          # on it is covered by this job's own pull-requests permission -- no
+          # pagination, no wider scope than the job already declares.
+          if ! LABELS=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.labels[].name'); then
+            echo "::warning::Could not read the labels of PR #$PR_NUMBER, so this run cannot see a 'skip-changeset' applied after the event fired. Enforcing the changeset check."
+            echo 'skip=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Labels on PR #$PR_NUMBER right now: ${LABELS:-(none)}"
+          # Whole-line fixed match, fed by a here-string rather than a pipe.
+          # `-x -F` because the payload expression this replaces, `contains(<array>,
+          # 'skip-changeset')`, matches an array ELEMENT exactly -- a substring
+          # match would newly exempt a PR labelled e.g. `skip-changeset-audit`.
+          # The here-string (as in release.yml) keeps `grep -q` out of a pipeline:
+          # -q closes the pipe on the first hit, so a piped writer can take
+          # SIGPIPE and, under `set -o pipefail`, flip this test to false for a
+          # long enough label list.
+          if grep -qxF 'skip-changeset' <<<"$LABELS"; then
+            echo "::notice::'skip-changeset' is on PR #$PR_NUMBER (read live, not from the event payload), so this PR declares no release of its own and the changeset check is exempt."
+            echo 'skip=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'skip=false' >> "$GITHUB_OUTPUT"
+          fi
+
+      # Every step from here down carries the same guard rather than the job
+      # carrying one `if:`, because a job-level `if:` cannot read a step of its
+      # own job. Repeating it beats the alternatives: a separate gate job would
+      # add a check row and a brand-new way to go red to a repo already fighting
+      # check-list noise, and testing the label inside the counting step would
+      # pay for checkout + install before discovering the PR is exempt.
       - name: Checkout repository
+        if: steps.labels.outputs.skip != 'true'
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
+        if: steps.labels.outputs.skip != 'true'
         uses: actions/setup-node@v7
         with:
           node-version: '22'
 
       - name: Enable Corepack
+        if: steps.labels.outputs.skip != 'true'
         run: corepack enable
 
       - name: Install dependencies
+        if: steps.labels.outputs.skip != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Check for a changeset added by this PR
+        if: steps.labels.outputs.skip != 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
@@ -157,5 +235,21 @@ jobs:
         # so a single `major` bump promotes the ENTIRE monorepo to a new major
         # version. During the launch window we ship breaking changes as `minor`.
         # Add the `allow-major` PR label when a whole-stack major is intended.
-        if: "!contains(github.event.pull_request.labels.*.name, 'allow-major')"
+        #
+        # The first clause keeps this step exempt exactly when the changeset check
+        # above is: before #5580 the `skip-changeset` label skipped the whole job,
+        # this step included, and a live-read label must not quietly re-arm it.
+        #
+        # The second clause still reads the frozen payload, and so still carries
+        # the #5580 race in its own right: an `allow-major` applied after the event
+        # fired is invisible to this run and a rerun replays the same payload.
+        # It is DORMANT while Changesets is in pre-release mode, because
+        # check-changeset-no-major.mjs stands aside for the whole RC window (see
+        # its RC EXEMPTION note), so the label is currently never needed. Tracked
+        # as #5620 rather than fixed here: #5580 scoped this change to the
+        # `skip-changeset` read, and widening a green gate's exemption path under
+        # cover of another issue is how exemptions grow unnoticed.
+        if: >-
+          steps.labels.outputs.skip != 'true'
+          && !contains(github.event.pull_request.labels.*.name, 'allow-major')
         run: node scripts/check-changeset-no-major.mjs


### PR DESCRIPTION
Fixes #5580

## 症状

`.github/workflows/pr-automation.yml` 的 changeset-check job 从**事件载荷**读标签:

```yaml
if: >-
  !contains(github.event.pull_request.labels.*.name, 'skip-changeset')
```

`github.event.pull_request.labels` 是事件触发那一刻的快照。于是开 PR 后数秒内补
`skip-changeset` 标签时:

1. `opened` 事件的 run 看不见标签 → 走计数路径 → 无 changeset → **红**;
2. 标签落上后 `labeled` 事件的新 run → skipped(判定正确);
3. 但首个红 run **永久红**:`rerun_failed_jobs` 复用原事件载荷(pm-dispatch
   Operational notes 5),重跑多少次都看不见后来的标签。

一日三例:#5467(该门禁自己的修复 PR)、#5501、#5577。每例的直接成本是一个需要人或
agent 停下来「认签名解释掉」的红检查 —— merge-queue-triage、PM 复核、事件订阅三方
会各自撞一次。

## 修法

job 内新增**第一个**步骤,用 `gh api repos/$REPO/pulls/$PR` 实时读回标签集,产出
`steps.labels.outputs.skip`;其后每个步骤按它决定是否执行。载荷读法按 issue 建议
**保留为 fast-path**(载荷已有标签 → 整个 job 跳过,常规路径零 runner 成本)。

重跑因此收敛:载荷仍是旧的,但实时读每次都重新查询。

### 四个设计决定

- **容忍方向朝着执行。** 标签读不到(API 报错、无 PR 号)判为 `skip=false`,即照常
  执行守卫。读不到输入的门什么也没验证,据此发豁免正是 #4690 反模式(静默跳过、
  exit 0、看起来像「无违规」)。失败以 `::warning::` 明说,由计数步骤定论。
- **实时读放在 checkout 之前。** 标签在位时其后全部步骤跳过,整个 job 只花一次 API
  调用 —— 收敛到实时状态比它替掉的那个 stale 红更便宜。
- **精确整行匹配**(`grep -qxF`,here-string 而非管道)。被替换的 `contains(数组,
  'skip-changeset')` 是数组元素精确匹配,子串匹配会让 `skip-changeset-audit` 这类
  标签新获豁免。here-string(与 release.yml 一致)让 `grep -q` 不进管道:`-q` 首个
  命中即关闭管道,写入端可能吃 SIGPIPE,在 `set -o pipefail` 下会把判定翻成 false。
  该步骤未写 `shell:`,两种方言都已实测。
- **每步重复 guard,而非新增一个 gate job。** job 级 `if:` 读不到自己 job 的步骤;
  另起一个 gate job 会给本已在与检查列表噪音作战的仓库再添一行检查和一个全新的变红
  途径,而把标签判定塞进计数步骤里则要先付 checkout + install 才发现该 PR 豁免。

## 边界

- ⛔ 未动 `BASE_SHA` diff **计数逻辑**,也未动 #5292/PR #5467 的三段有序失败文案 ——
  heredoc 终结符仍在块基缩进(解析后确认 `MSG` 落在生成脚本第 0 列)。
- ⛔ 未动其他 job。
- `allow-major` 步骤的同款载荷读法**按边界留在原样**,只补上「changeset 豁免时同样
  跳过」这一句以保持 #5580 之前的语义(那时整个 job 连带此步骤一起跳过)。它自身的
  竞态在 RC pre-mode 期间休眠 —— `check-changeset-no-major.mjs` 整个 RC 窗口让位,
  标签目前根本用不上 —— 已记为 #5620,文件内注释指向它。

## 验证

| 项 | 结果 |
|:--|:--|
| `pnpm check:workflow-status-functions`(#5343/PR #5477 门禁) | OK,22 workflow / 39 job / 19 个 job 级 `if:`;self-test 34 断言通过 |
| `pnpm check:nul-bytes` | OK,5533 个文件无裸控制字节;self-test 48 断言通过 |
| `pnpm check:node-version` | OK,23 个 setup-node 步骤仍全在 Node 22 |
| YAML 结构解析 | 7 个步骤中 6 个带 guard(实时读步骤自身不带,它必须总是执行);`BASE_SHA` env 与计数命令逐字未变 |
| 步骤脚本分支矩阵 | **14/14 通过**(见下) |
| 前后决策真值表 | 7 格中仅 2 格改变,与事前预测一致(见下) |

### 分支矩阵(从 YAML 抽出真实 `run:` 脚本,stub `gh`,两种 shell 方言)

跑的是 workflow 里那段脚本本身,不是重敲的副本。

| 场景 | 期望 | `bash -e` | `bash -eo pipefail` |
|:--|:--|:--|:--|
| 载荷 stale、标签实时在位 —— **#5580 本体** | exempt | PASS | PASS |
| 实时无该标签 | enforce | PASS | PASS |
| 完全没有标签 | enforce | PASS | PASS |
| API 失败(HTTP 403) | enforce + warning | PASS | PASS |
| 无 PR 号(gh 一次都没调用) | enforce + warning | PASS | PASS |
| 近似标签名(`skip-changeset-audit` / `no-skip-changeset`) | enforce | PASS | PASS |
| 401 个标签含目标(pipefail 压力) | exempt | PASS | PASS |

### 反向验证

GitHub 表达式语言无法在本地执行,所以**前后决策函数是建模的**(shell 那一半是真跑
的)。方向先预测后运行:应当**只有一格**改变。

| 场景 | 载荷 | 实时 | BEFORE | AFTER | 变 |
|:--|:--|:--|:--|:--|:--|
| 开 PR 前就带标签,仍在 | has | has | skipped | skipped | . |
| 开 PR 后约 5s 补标签 —— **本 bug** | none | has | enforce | **exempt** | YES |
| 该红 run 的 `rerun_failed_jobs`(同一份冻结载荷) | none | has | enforce | **exempt** | YES |
| 全程无标签、无 changeset | none | none | enforce | enforce | . |
| 开 PR 后**移除**标签(载荷仍带) | has | none | skipped | skipped | . |
| 该移除触发的 `unlabeled` 事件 | none | none | enforce | enforce | . |
| 标签实时在位但 labels API 读不到 | none | n/a | enforce | enforce | . |

实际改变 2 格,而非 1 —— 因为「首 run」与「它的重跑」是同一个缺陷的两次,预测里写的
就是这两格;其余 5 格逐格不变。

**保留 fast-path 留下的唯一反向 stale 格已如实记在文件里**:标签在开 PR 后被移除时
本 run 仍短路,即凭快照放行。该格自愈 —— 移除标签必然触发 `unlabeled` 事件,它起的
run 两处都看不到标签而照常执行。#5580 那个方向没有这种救援:`labeled` run 的绿不会
清掉 `opened` run 的红。这是保留 fast-path 换来常规路径零成本的代价,值得,但下一个
读者应当看见它,所以写进了注释而不是只写在这里。

## 本 PR 自身

- **需要 `skip-changeset` 标签**:纯 workflow 改动,⛔ 未写空 frontmatter changeset
  (那正是 #5292/PR #5467 判定为最后手段的东西)。请 PM 落标签。
- `pull_request` 事件的 workflow 取自 merge ref,所以本 PR 的 Check Changeset 跑的
  已经是**新逻辑**。预测:标签若在首个 run 的第一步之后才落上,该 run 仍会红 —— 但
  这次 `rerun_failed_jobs` 就能变绿,而这恰是修好了的那半。
- **已知 base 侧红,非本 PR 引入**:ESLint job 全仓红于 #5604 ——
  `check:engine-double-contract` 在 `packages/runtime/src/action-execution-calldata-not-found.test.ts`
  第 69、102 行。在本分支 base(`cc5b048a0`)上直接跑该脚本复现,退出码 1,签名逐字
  一致;本 PR 只改一个 workflow 文件。ESLint 非必需检查。注意上面两个门禁**也在**
  ESLint job 里,且排在那个失败步骤**之前**,所以它们各自的绿在 job 日志里仍可见,
  只是 job 总结论为红。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE)_