### PR TITLE
docs(pm-dispatch,os-dev): 假引擎的 delete() 一律路由 assertEngineDeleteDispatch,并收编 run-summary 的盲区实例 (#5197)

### DIFF
--- a/.claude/agents/os-dev.md
+++ b/.claude/agents/os-dev.md
@@ -113,6 +113,14 @@ build/test runs OOM it.** Binding rules:
    exactly when 7.28.0's own advisories landed (#5032, the live specimen of
    #4961's warning; brace-expansion did the same at 5.0.8). Put the upper
    bound at the major boundary and move only the replacement target.
+5. **A new fake engine's `delete()` opens with
+   `assertEngineDeleteDispatch(options)`** from `@objectstack/objectql` — never a
+   hand-mirrored `if (!where?.id && !multi)`, which has exactly the hole
+   `check:engine-double-contract` names (#5173's copy passed
+   `where: { id: { $in: […] } }`). That gate went red on four dev agents' new
+   tests in two days (#5173 / #5191 / #5192 / #5584), one CI lap each — copy one
+   of the pinned fakes the gate lists on a green run instead
+   (`service-automation/src/builtin/crud-bulk-intent.test.ts` is the fullest).
 
 Definition of done, in order:
 

--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -837,6 +837,11 @@ Follow your operating procedure (you are the os-dev agent). Non-negotiables:
 - If the issue underspecifies a decision that changes the public contract
   (spec schema, API shape, naming), STOP and return status "needs_decision"
   with your open questions — do not guess.
+- Any NEW fake engine your tests introduce must open its `delete()` with
+  `assertEngineDeleteDispatch(options)` from `@objectstack/objectql`, never a
+  hand-mirrored `if (!where?.id && !multi)` — `check:engine-double-contract`
+  went red on four dev agents' new tests in two days (#5173 / #5191 / #5192 /
+  #5584), one CI lap each. Copy a pinned fake, don't write the guard.
 Return ONLY the JSON report defined in your agent definition.
 ```
 

--- a/packages/services/service-automation/src/run-summary.test.ts
+++ b/packages/services/service-automation/src/run-summary.test.ts
@@ -8,6 +8,7 @@
 // all read.
 
 import { describe, it, expect } from 'vitest';
+import { assertEngineDeleteDispatch } from '@objectstack/objectql';
 import { AutomationEngine } from './engine.js';
 import type { StepLogEntry, NodeExecutor, RunRecord } from './engine.js';
 import { summarizeRun, formatRunSummaryLine } from './run-summary.js';
@@ -407,21 +408,43 @@ describe('node executors report what they touched', () => {
         const data: any = {
             async find() { return []; },
             async findOne() { return null; },
-            async delete() { return false; },
+            // #5197 — the double's delete opens with the PRODUCER's own dispatch
+            // decision, so a sweep this fixture accepts is one `ObjectQL.delete`
+            // accepts. It used to answer `false` to anything, which is how the
+            // shape below stayed green here while #5225's real purge flow died
+            // on it every run.
+            async delete(_object: string, options: any) {
+                assertEngineDeleteDispatch(options);
+                return 0; // driver.deleteMany contract: Promise<number> — nothing matched
+            },
         };
         const engine = new AutomationEngine(logger);
         registerCrudNodes(engine, { logger, getService: (n: string) => (n === 'data' ? data : undefined) } as never);
         engine.registerFlow('f', flowOf(
             [
                 { id: 'start', type: 'start', label: 'S' },
-                { id: 'd', type: 'delete_record', label: 'D', config: { objectName: 'deal', filter: { stale: true } } },
+                // `multi: true` is what makes a PREDICATE delete reach the driver
+                // at all (#5393); without it the engine refuses the call, which
+                // `builtin/crud-bulk-intent.test.ts` pins on the executor side.
+                // Here the subject is the counter, so the sweep declares intent
+                // and the driver reports that it matched nothing.
+                { id: 'd', type: 'delete_record', label: 'D', config: { objectName: 'deal', filter: { stale: true }, multi: true } },
                 { id: 'end', type: 'end', label: 'E' },
             ],
             [{ id: 'e1', source: 'start', target: 'd' }, { id: 'e2', source: 'd', target: 'end' }],
         ) as never);
 
         const res = await engine.execute('f', { event: 'schedule' } as AutomationContext);
+        // `acted: 0` alone does NOT say the sweep deleted nothing — it is equally
+        // what a REFUSED delete leaves behind, so the counter has to be read
+        // together with the outcome or the case passes for the empty reason
+        // (measured: with the fake pinned and `multi` dropped, the run fails and
+        // this assertion alone still went green).
+        expect(res.success).toBe(true);
         expect(res.summary!.acted).toBe(0);
+        expect(res.summary!.nodes.find((n) => n.nodeId === 'd')).toMatchObject({
+            nodeType: 'delete_record', runs: 1, failures: 0, acted: 0,
+        });
     });
 
     it('notify counts DELIVERED notifications as acted — a nudge sweep acts by notifying', async () => {


### PR DESCRIPTION
Fixes #5197

三个落点,前两个是同措辞的一行纪律,第三个是评论里已定位的盲区实例收编。

## 为什么值得动 agent 定义文件

同一天三个互不相同任务、互不相同包的 dev agent(3/3)新写假引擎全部踩 `check:engine-double-contract` 判红,错误一模一样 —— 手抄守卫、未路由 `assertEngineDeleteDispatch`(#5173、#5191、#5192),各花一轮 CI 往返 ≈15 分钟;#5584 的新测试是第四次同款命中(即当前 main 上的 #5604)。门禁没漏,防线是好的;代价纯粹是「新增测试 + 需要假引擎 + delete 路径」这个高频组合缺一行提交前的提示。

两处措辞相互一致,都点名手抄守卫**真有洞**这一实测事实(而不是「风格不推荐」):#5173 的手抄副本放行了 `where: { id: { $in: [...] } }` —— 看着像 id,实为多行谓词,真引擎无 `multi` 时拒收。样板引用的是「门禁绿跑时自己列出的 pinned 假引擎」,不是一个会过期的计数。

- `.claude/agents/os-dev.md` —— 进「Toolchain traps」第 5 条(该列表的定义就是「每条都让至少一个 agent 白跑一轮红」,正好是这件事)。
- `.claude/skills/pm-dispatch/SKILL.md` —— 派发词模板的 Non-negotiables 末条。⛔ 模板其余部分未动,#5513(同文件六条新规程)是另单。

## 第三处:run-summary.test.ts 的盲区实例

`packages/services/service-automation/src/run-summary.test.ts` 的内联假引擎 `async delete() { return false; }` 对谓词删除照单全收。而 `delete_record` 自 #5393 起转发 `multi: cfg.multi === true`,所以 `{ objectName: 'deal', filter: { stale: true } }` 这一形状真引擎是 **reject**。

该文件既不在 pinned 也不在 DEBT 台账:门禁的形参个数判据(`isEngineDeleteShape` 要求 `delete` 至少两个形参)够不到零形参的 `delete`,所以这是**检测器盲区,不是已登记的债**。这个扫描面缺口连同实测口径另立 #5629(实测:只放开该判据,发现面从 59 个 double/58 文件涨到 150 个/107 文件),⛔ 本 PR 不修它。后果不是假设 —— #5225 里 showcase 的 `showcase_inquiry_purge` 从上线起每次 `acted: 0`,单测却一路绿。

收编按**补声明**处置,不是重写断言:该 fixture 从来就不是契约内合法的,补 `multi: true` 声明其批量意图,于是 sweep 真的到达驱动、驱动报告匹配 0 行,用例原本的主题(计数器读 0)完整保留。执行器侧的 reject 传播已由 `builtin/crud-bulk-intent.test.ts:153` 钉住,此处不重复。`@objectstack/objectql` 早已是本包 devDependency(#5393 加的),无需动 package.json,无 turbo 环。

## 反向验证:预期红,实测**仍然绿** —— 所以断言也得加强

先说方向,再说结果。预期是「假引擎收编 + 撤掉 `multi:true` → 判红」。实测**绿**:

```
Test Files  1 passed (1)
     Tests  1 passed | 33 skipped (34)
```

原因是 `acted: 0` 既是「删了 0 行」也是「删除被拒」留下的痕迹 —— 运行失败了,summary 照样记 `acted: 0`,原用例唯一的断言两种情形都满足,是**为空而绿**(os-dev.md 里 fixture triage 那条「assertion keeps passing because nothing is produced」的活体标本)。

所以只收编假引擎对这个用例买不到任何东西,断言必须同时加强。补 `res.success` 与该节点 `runs: 1 / failures: 0 / acted: 0` 之后,同一撤销才真的判红:

```
FAIL  src/run-summary.test.ts > delete_record reports 0 when the driver reports nothing deleted
AssertionError: expected false to be true
 ❯ src/run-summary.test.ts:443:29  expect(res.success).toBe(true);
```

恢复 `multi: true` 后全绿。这一步是实测逼出来的,不是顺手加固。

## 验证

- `pnpm --filter @objectstack/service-automation test` → `Test Files 59 passed (59) / Tests 713 passed (713)`。
- `pnpm check:engine-double-contract` —— 改动前:`58 in 57 test file(s) — 24 pinned, 34 in the shrink-only baseline`,1 problem;改动后:`59 in 58 test file(s) — 25 pinned, 34 in the shrink-only baseline`,仍是 1 problem,且仍是**同一个** #5604 的 `action-execution-calldata-not-found.test.ts`。即本 PR 只让 run-summary.test.ts 进入 pinned 计数(24→25),台账 34 未动 —— 收编是钉接,没有记债。`--self-test` 绿。
- `node scripts/check-nul-bytes.mjs` 绿;三个改动文件另做了越过门禁扫描面的自扫(含 DEL 与 `0x01` 那一类),无控制字节。
- 类型:本包在仓库的 `turbo run typecheck` 里没有 typecheck 任务(#4311 的面),直跑 `tsc --noEmit -p` 有 5 处**先存**报错,全部落在本 PR 未触碰的 `engine.test.ts` 与 `nested-region-parity.test.ts`,`run-summary.test.ts` 零报错。
- ESLint job 全仓红 = #5604 签名(main 既有),非本 PR 引入,不追。

## 变更集

`.claude/` 文档 + 测试-only,无用户可见面 → 走 `skip-changeset` 标签路线,未写空 frontmatter changeset。请 PM 落标签。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE)_