### PR TITLE
test(dogfood): cover /actions and /automation in the anonymous-deny proof artifact (#5570)

### DIFF
--- a/packages/qa/dogfood/test/authz-conformance.matrix.ts
+++ b/packages/qa/dogfood/test/authz-conformance.matrix.ts
@@ -89,6 +89,23 @@ export const AUTHZ_CONFORMANCE: AuthzPrimitive[] = [
     enforcement: 'rest/rest-server.ts registerMetadataEndpoints guarded registrar (enforceAuth → shouldDenyAnonymous) — every /meta route inherits the gate; runtime/http-dispatcher.ts handleMetadata mirrors it for the dispatcher metadata catch-all',
     proof: 'showcase-anonymous-deny-surfaces.dogfood.test.ts',
     covers: ['meta:rest-server.ts:registerMetadataEndpoints', 'meta:http-dispatcher.ts:handleMetadata'] },
+  // #5519 — the two DISPATCHER-mounted execution surfaces. `@objectstack/rest`
+  // gated `/data` and `/meta`; these routes are mounted by a SECOND
+  // registration path (dispatcher-plugin.ts, straight onto the host
+  // IHttpServer) and inherited none of it, so the "#2567 uniform posture"
+  // claim above was false on them until PR #5569. The proof artifact was
+  // silent too — #5570 is the evidence half, and these two rows are what make
+  // the gate's removal fail CI instead of review.
+  { id: 'anonymous-deny-actions', summary: 'anonymous-deny on the business-action dispatch surface (#2567 surface 2 / #5519)', state: 'enforced',
+    enforcement: 'runtime/domains/actions.ts handleActionsRequest — shouldDenyAnonymous as the handler\'s FIRST statement, ahead of the ADR-0066 D4 requiredPermissions gate and the ADR-0104 param contract; those keep their semantics and simply run after the auth baseline, so an anonymous caller never reaches action dispatch and never learns the route\'s shape',
+    proof: 'showcase-anonymous-deny-surfaces.dogfood.test.ts',
+    covers: ['actions:domains/actions.ts:anonymous-gate'],
+    note: 'A `type: \'script\'` action body runs `isSystem: true` (elevated), so an ungated POST was an anonymous privilege-escalating WRITE, not merely an information leak — #5519 measured `POST /actions/showcase_task/showcase_mark_done/:id` answering 200 with the update applied. Internal dispatch is unaffected: this handler is a pure HTTP seam (the MCP `run_action` bridge enters through action-execution.invokeBusinessAction, declarative endpoints through the transport fallback seam with their own `authRequired` gate), so `authRequired: false` public endpoints stay public.' },
+  { id: 'anonymous-deny-automation', summary: 'anonymous-deny on the automation/flow surface (#2567 surface 3 / #5519)', state: 'enforced',
+    enforcement: 'runtime/domains/automation.ts handleAutomationRequest — shouldDenyAnonymous DOMAIN-WIDE at the top, and deliberately BEFORE the isServiceServeable probe so the 401/501 difference cannot be used to fingerprint whether a deployment mounts automation',
+    proof: 'showcase-anonymous-deny-surfaces.dogfood.test.ts',
+    covers: ['automation:domains/automation.ts:anonymous-gate'],
+    note: 'Ungated, an anonymous caller could start real flow runs (`POST /:name/trigger`), read the full flow inventory (`GET /automation`), and DEREGISTER a registered flow (`DELETE /:name` → `{deleted:true}`) — the destructive one, which #5519 did not originally record. Gating the DOMAIN rather than each route is what keeps a newly added automation route from arriving ungated. Engine-internal triggers (record-change, schedule) never speak HTTP and are untouched.' },
 
   // ── #2992 / ADR-0096 D4 — latent execution surfaces (pre-wiring identity
   // admission). Neither surface is reachable by a client today; these rows

--- a/packages/qa/dogfood/test/authz-conformance.test.ts
+++ b/packages/qa/dogfood/test/authz-conformance.test.ts
@@ -46,6 +46,25 @@ const PROBES: ReadonlyArray<{ file: string; re: RegExp; key: (m: RegExpExecArray
     re: /async\s+(handleMetadata)\s*\(/g,
     key: (m) => `meta:http-dispatcher.ts:${m[1]}`,
   },
+  // ── #5519 — the two dispatcher-mounted execution surfaces ──────────────
+  // These are GATE pins, in the shape the MCP rows below already use: the key
+  // exists only while the domain handler still consults `shouldDenyAnonymous`.
+  // Delete the gate (the #5519 regression, in either domain) and the key
+  // vanishes → the covering row goes STALE → red CI. `/actions` and
+  // `/automation` are mounted by dispatcher-plugin.ts, a separate registration
+  // path from the `@objectstack/rest` one that gates `/data` and `/meta`, which
+  // is exactly why they diverged unnoticed.
+  {
+    file: 'packages/runtime/src/domains/actions.ts',
+    re: /shouldDenyAnonymous\s*\(/g,
+    key: () => 'actions:domains/actions.ts:anonymous-gate',
+  },
+  {
+    file: 'packages/runtime/src/domains/automation.ts',
+    re: /shouldDenyAnonymous\s*\(/g,
+    key: () => 'automation:domains/automation.ts:anonymous-gate',
+  },
+
   // Raw-hono standard /data routes — genuinely pattern-based: ANY new
   // `rawApp.<verb>(`${prefix}/data...`)` → a new key → CI fails until a row covers it.
   {
@@ -149,6 +168,13 @@ const HIGH_RISK = [
   // entry point rather than gating it, so there is nothing left to mark
   // high-risk there)
   'anonymous-deny-meta',
+  // #5519 — the dispatcher-mounted execution surfaces. `/actions` reaches a
+  // `script` body that runs `isSystem: true` elevated and `/automation` starts,
+  // lists and deregisters flows, so both guard the same object data as REST
+  // `/data` through sibling entry points. Proven end-to-end by the same
+  // surfaces proof (#5570).
+  'anonymous-deny-actions',
+  'anonymous-deny-automation',
   // #2948/#3003 — write-integrity face: without the strip, `readonly: true`
   // is false compliance (declared ≠ enforced) and approval/status columns are
   // one direct PATCH away from self-approval.
@@ -244,5 +270,23 @@ describe('#2567 — anonymous-deny surface ratchet bites', () => {
       opts(() => new Set([...discoverAnonymousDenySurfaces()].filter((k) => k !== stdio))),
     );
     expect(problems.some((p) => /STALE covers/.test(p) && p.includes(stdio))).toBe(true);
+  });
+
+  // ── #5519 — the dispatcher execution-surface gates bite too ────────────
+  it('(h) deleting either /actions or /automation anonymous gate → STALE covers failure (#5519)', () => {
+    for (const gate of [
+      'actions:domains/actions.ts:anonymous-gate',
+      'automation:domains/automation.ts:anonymous-gate',
+    ]) {
+      // Baseline sanity: the gate is in source TODAY. If this ever goes false
+      // the surface has regressed to its pre-#5569 state, which is the whole
+      // point of the pin.
+      expect(discoverAnonymousDenySurfaces().has(gate), `${gate} must be in source`).toBe(true);
+      const problems = checkLedger(
+        AUTHZ_CONFORMANCE,
+        opts(() => new Set([...discoverAnonymousDenySurfaces()].filter((k) => k !== gate))),
+      );
+      expect(problems.some((p) => /STALE covers/.test(p) && p.includes(gate))).toBe(true);
+    }
   });
 });

--- a/packages/qa/dogfood/test/showcase-anonymous-deny-surfaces.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-anonymous-deny-surfaces.dogfood.test.ts
@@ -8,17 +8,52 @@
 //   - the raw-hono standard `/data` routes (order-dependent shadowing) — that
 //     surface has since been deleted outright (#4073), which removes the entry
 //     point rather than gating it
+//   - the DISPATCHER-mounted execution surfaces `/actions/*` and `/automation/*`
+//     (#5519, gated by PR #5569 — see the block below)
 //
 // This proof boots the real showcase HTTP stack ON THE PLATFORM DEFAULT (the
 // verify harness passes no `requireAuth` override, so the flipped secure default
 // is what a fresh production deployment gets) and asserts every surface denies
 // an anonymous caller with 401 while an authenticated member is unaffected.
+//
+// ── Why `/actions` and `/automation` are here (#5570) ────────────────────────
+//
+// `authz-conformance.matrix.ts` names THIS FILE as the proof artifact for the
+// "#2567 anonymous posture is uniform across surfaces" claim. #5519 then found
+// the claim false on exactly two surfaces this file did not drive: anonymous
+// callers could POST a `script` action (whose body runs `isSystem: true`
+// elevated) and could trigger, list, or DEREGISTER automation flows. The
+// artifact was silent throughout — a declared ≠ proven gap living in the test
+// layer. PR #5569 built the gate in `packages/runtime`; #5570 is the evidence
+// half, so the proof file once again covers everything the matrix row claims
+// it covers.
+//
+// The value this boot adds OVER #5569's own runtime integration test
+// (`dispatcher-plugin.anonymous-gate.integration.test.ts`) is precisely the
+// comparison that test documented it could NOT make: it boots a LiteKernel that
+// mounts no `/data` and no `/meta`, so it had no second surface to contrast
+// against. Here all four surfaces are served by ONE process — and by TWO
+// different registration paths (`@objectstack/rest` owns `/data` + `/meta`;
+// `dispatcher-plugin.ts` mounts `/actions` + `/automation` straight onto the
+// host server) — which is the divergence #5519 was about in the first place.
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import { type VerifyStack } from '@objectstack/verify';
 import { getSharedShowcase } from './shared-showcase.js';
 
 const OBJ = '/data/showcase_private_note';
+
+// `showcase_mark_done` is a `type: 'script'` action declared on `showcase_task`
+// whose body performs an `api.write` update — the exact action #5519 measured
+// answering 200 to an anonymous caller. The record id is deliberately a
+// non-existent one: the gate is the FIRST statement of `handleActionsRequest`,
+// so an anonymous request is refused before any object, action or record is
+// resolved. Needing a real record to get a 401 would mean the gate had moved
+// behind the lookups.
+const ACTION = '/actions/showcase_task/showcase_mark_done/anon-probe-id';
+// A real showcase flow declaration, so the deregister case names something that
+// genuinely exists in the app's metadata.
+const FLOW = 'showcase_reassign_wizard';
 
 describe('showcase: anonymous posture is uniform across surfaces (#2567)', () => {
   let stack: VerifyStack;
@@ -29,6 +64,15 @@ describe('showcase: anonymous posture is uniform across surfaces (#2567)', () =>
     await stack.signIn();
     memberToken = await stack.signUp('surfaces-member@verify.test');
   }, 60_000);
+
+  /** An HTTP call carrying no credential of any kind. */
+  const anon = (method: string, path: string, body?: unknown) =>
+    stack.api(path, {
+      method,
+      ...(body === undefined
+        ? {}
+        : { headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }),
+    });
 
   // ── /meta ──────────────────────────────────────────────────────────────
   it('anonymous GET /meta is denied (401)', async () => {
@@ -50,5 +94,110 @@ describe('showcase: anonymous posture is uniform across surfaces (#2567)', () =>
   it('an authenticated member is allowed on the data surface', async () => {
     const r = await stack.apiAs(memberToken, 'GET', OBJ);
     expect(r.status).toBe(200);
+  });
+
+  // ── /actions (dispatcher-mounted; runtime domains/actions.ts) — #5519 ───
+  it('anonymous POST of a script action is denied (401)', async () => {
+    const r = await anon('POST', ACTION, { params: {} });
+    expect(r.status, 'anonymous action dispatch must be 401').toBe(401);
+  });
+
+  it('an authenticated member is NOT denied on the action surface', async () => {
+    // Whatever the action surface answers a MEMBER — 200, a 400 from the param
+    // contract, a 403 from `requiredPermissions` — it is an answer about
+    // authorization, not about anonymity. The assertion is deliberately the
+    // same `.not.toBe(401)` the /meta contrast uses: this file's subject is the
+    // anonymous posture, and pinning the member's exact status here would make
+    // it fail for reasons that belong to other proofs.
+    const r = await stack.apiAs(memberToken, 'POST', ACTION, { params: {} });
+    expect(r.status, 'an authenticated caller must clear the auth gate').not.toBe(401);
+  });
+
+  // ── /automation (dispatcher-mounted; runtime domains/automation.ts) ─────
+  //
+  // The gate is DOMAIN-WIDE and sits ahead of the `isServiceServeable` probe on
+  // purpose: this stack installs no `@objectstack/service-automation`, so the
+  // domain's own answer here is 501. If the gate ran after the probe, anonymous
+  // and authenticated callers would both get 501 and the 401/501 difference
+  // would fingerprint whether a deployment mounts automation at all. The
+  // authenticated 501 case below is what gives these three cases their teeth:
+  // in this one process, the same route answers 401 to anonymous and 501 to a
+  // member, so the 401 can only be the gate's answer.
+  it('anonymous POST /automation/:name/trigger is denied (401)', async () => {
+    const r = await anon('POST', `/automation/${FLOW}/trigger`, { recordId: 'anon-probe-id' });
+    expect(r.status, 'anonymous flow trigger must be 401').toBe(401);
+  });
+
+  it('anonymous GET /automation is denied (401) — the flow inventory stays private', async () => {
+    const r = await anon('GET', '/automation');
+    expect(r.status, 'anonymous flow listing must be 401').toBe(401);
+  });
+
+  it('anonymous DELETE /automation/:name is denied (401) — the destructive one', async () => {
+    const r = await anon('DELETE', `/automation/${FLOW}`);
+    expect(r.status, 'anonymous flow deregistration must be 401').toBe(401);
+  });
+
+  it('an authenticated caller reaches the domain, which answers 501 — not 401', async () => {
+    const r = await stack.apiAs(memberToken, 'GET', '/automation');
+    expect(r.status, 'authenticated flow listing must clear the auth gate').not.toBe(401);
+    // The domain's OWN answer on a stack with no automation service. Asserting
+    // it (rather than only `.not.toBe(401)`) is what proves the anonymous 401
+    // above is produced by the gate and not by the domain: drop the gate and
+    // the anonymous cases collapse onto THIS status.
+    expect(r.status, 'no @objectstack/service-automation is installed on this boot').toBe(501);
+  });
+
+  // ── one code, one message — two wrappers ───────────────────────────────
+  it('every denied surface answers the SAME code and message (the wrappers differ)', async () => {
+    const rest = await Promise.all([
+      anon('GET', '/meta').then((r) => r.json()),
+      anon('GET', OBJ).then((r) => r.json()),
+    ]);
+    const dispatcher = await Promise.all([
+      anon('POST', ACTION, { params: {} }).then((r) => r.json()),
+      anon('POST', `/automation/${FLOW}/trigger`, {}).then((r) => r.json()),
+      anon('GET', '/automation').then((r) => r.json()),
+      anon('DELETE', `/automation/${FLOW}`).then((r) => r.json()),
+    ]);
+
+    // Each family is read in ITS OWN declared shape — no `??` chain across the
+    // two, because a tolerant reader here would hide the day one of them
+    // changes. `@objectstack/rest` returns the flat `ANONYMOUS_DENY_BODY`
+    // (`{ error: <CODE>, message }`); the dispatcher returns its standard
+    // wrapper (`{ success: false, error: { code, message, httpStatus } }`).
+    for (const body of rest) {
+      expect(body).toEqual({
+        error: 'UNAUTHENTICATED',
+        message: 'Authentication is required to access this endpoint.',
+      });
+    }
+    for (const body of dispatcher) {
+      expect(body).toMatchObject({
+        success: false,
+        error: {
+          code: 'UNAUTHENTICATED',
+          message: 'Authentication is required to access this endpoint.',
+          httpStatus: 401,
+        },
+      });
+    }
+
+    // What is genuinely uniform — and what #2567 claims — is the SEMANTICS: one
+    // status, one code, one message, whichever surface you knock on. The two
+    // wrappers are a known, pre-existing platform-wide split (ADR-0112's
+    // amendment records `@objectstack/rest`'s flat envelope and the dispatcher's
+    // wrapped one as the two live shapes). Pinned here so that split cannot
+    // quietly widen into two different DENIALS.
+    const codes = new Set([
+      ...rest.map((b: any) => b.error),
+      ...dispatcher.map((b: any) => b.error.code),
+    ]);
+    const messages = new Set([
+      ...rest.map((b: any) => b.message),
+      ...dispatcher.map((b: any) => b.error.message),
+    ]);
+    expect([...codes]).toEqual(['UNAUTHENTICATED']);
+    expect([...messages]).toEqual(['Authentication is required to access this endpoint.']);
   });
 });


### PR DESCRIPTION
Fixes #5570

test-only。**请 PM 打 `skip-changeset` 标签** —— `.github/workflows/pr-automation.yml` 的 changeset 门把 "tests-only" 明写为 route 2 且标注 PREFERRED;`packages/qa/dogfood` 是 `private: true`,不发版,不产生 changeset 输入。(我已自行贴上该标签以免 CI 无谓变红,如与 PM 流程冲突请摘掉。)

## 前提复核(先证后改,rule 6)

分诊席 19:59Z 核过一次;我在**动手时刻的 `origin/main`(7e58212d1)** 上重核:**前提成立**。`showcase-anonymous-deny-surfaces.dogfood.test.ts` 改动前共 4 条用例,覆盖面只有 `/meta` ×2 与 `/data/showcase_private_note` ×2,`grep` 全文无 `/actions`、无 `/automation`。而 `authz-conformance.matrix.ts:90` 把该文件列为 `anonymous-deny-meta` 行的 proof 工件,该行所在的注释块声明的是 #2567「anonymous-deny posture is UNIFORM across HTTP surfaces」。

## 这次补的证据比 #5569 自己的集成用例多出什么

#5569 的 `dispatcher-plugin.anonymous-gate.integration.test.ts` 最后一条用例自己写明了它做不到的那半:

> The cross-surface contrast that made this a p0 — `/data` answering 401 while `/actions` answered 200 in the SAME process — is not provable on this boot: `@objectstack/rest` owns `/data` and `/meta` and the dispatcher plugin mounts neither, so there is no second surface here to compare against.

本 PR 补的正是这半:showcase 真启动里,**一个进程、两条注册路径**(`@objectstack/rest` 供 `/data` + `/meta`;`dispatcher-plugin.ts` 把 `/actions` + `/automation` 直接挂到 host server)四个面并排断言。那条注册路径的分叉就是 #5519 之所以发生的原因。

## 落点

三个文件,**全部在 `packages/qa/dogfood/test/`**,`packages/runtime/**` 一行未动(`git diff --stat -- packages/runtime` 为空)。

### 1. `showcase-anonymous-deny-surfaces.dogfood.test.ts`(+7 例,4 → 11)

| 匿名请求 | 断言 |
|---|---|
| `POST /actions/showcase_task/showcase_mark_done/anon-probe-id` | 401 |
| `POST /automation/showcase_reassign_wizard/trigger` | 401 |
| `GET /automation` | 401 |
| `DELETE /automation/showcase_reassign_wizard` | 401 |

对象 / action / flow 名全取自 showcase 现有声明:`showcase_mark_done` 是 `showcase_task` 上的 `type: 'script'` action(body 走 `api.write`,即 #5519 实测匿名拿到 200 并真的落了写的那一条);`showcase_reassign_wizard` 是 showcase 已声明的 flow。

recordId 刻意用不存在的 id:门是 `handleActionsRequest` 的**第一条语句**,匿名请求在任何对象 / action / 记录被解析之前就被拒。若非得先造一条真记录才能拿到 401,那说明门已经挪到了 lookup 后面。

再加两条**已认证对照**,它们是这批用例牙齿的来源(见下)。

### 2. 信封:同一个 code 与 message,两种 wrapper —— 如实钉住

这里有一条**与派发单预设不符、必须申报的事实**。派发单要求「信封断言与套件内 `/data`、`/meta` 现有条目逐字同形(同一 error/code 键)」。实测**两族的 body 形状并不同**:

```
GET  /meta          -> {"error":"UNAUTHENTICATED","message":"Authentication is required to access this endpoint."}
GET  /data/...      -> {"error":"UNAUTHENTICATED","message":"Authentication is required to access this endpoint."}
POST /actions/...   -> {"success":false,"error":{"code":"UNAUTHENTICATED","message":"Authentication is required to access this endpoint.","httpStatus":401}}
GET  /automation    -> {"success":false,"error":{"code":"UNAUTHENTICATED","message":"Authentication is required to access this endpoint.","httpStatus":401}}
```

`@objectstack/rest` 走 `ANONYMOUS_DENY_BODY` 的扁平信封,dispatcher 走它自己的 wrapper。这是 ADR-0112 修正案记录在案的**两个 live 信封**,不是本单引入的。

所以我没有硬凑「逐字同形」,也**没有写 `??` 容忍链**去把两种形状读成一种 —— 那正是 rule 5 要避免的宽容消费者。做法是:**每族按各自声明的形状显式断言**,再单独钉住真正统一的那层语义(同一 status / 同一 code / 同一 message),并注明 wrapper 分叉是已知平台事实。这样任何一族哪天变形都会红,而不是被容忍读悄悄吃掉。

顺带发现 `@objectstack/core` 的 `ANONYMOUS_DENY_BODY` 注释自称 "The single 401 body shape **every seam** returns",与上表不符 —— 已另行立单(见文末),未在本 PR 修。

### 3. `authz-conformance.matrix.ts` + `.test.ts` —— 登记惯例随行

按 #2567 Phase 2 现有惯例(surface 行 = `enforcement` + `proof` + `covers`,并进 `HIGH_RISK`)补两行:

- `anonymous-deny-actions` → `covers: ['actions:domains/actions.ts:anonymous-gate']`
- `anonymous-deny-automation` → `covers: ['automation:domains/automation.ts:anonymous-gate']`

并补两条 `PROBES`(形状与既有 `buildMcpBridge(context-threaded)` / `stdio-principal-bound` 这两条 **gate pin** 一致,而非 surface 探针)、一条 `(h)` bites 用例。删掉任一侧的门 → key 消失 → 覆盖它的行 STALE → CI 红。

> 这一步比 issue 的「约 20 行」建议做得多,理由:只加没有 `covers` 的行会与紧邻的 #2567 surface 行形成半登记,而 ratchet 才是让 #5519 那类回归**在 CI 而非 review 里**被抓住的机制。全部限于 `packages/qa/dogfood`。若 PM 认为超出本单,这三处可单独摘掉,不影响 1 的用例。

## 反向验证(方向先判后跑)—— 分两阶段,方向不同

**预判先写**,并且**故意不是「一律转红」**:

| 用例 | 预判 |
|---|---|
| 匿名 `POST /actions/...` | 401 → **400**(动作真派发,body 撞上 `showcase_audit_task_completion` 的 hook condition 报错)。红 |
| 匿名 `/automation` ×3 | 401 → **501**(本 boot 未装 `@objectstack/service-automation`)。红 |
| 信封一致性用例 | 红 |
| `/data`、`/meta` ×4 | **照常绿**(归 `@objectstack/rest`,未触碰) |
| 两条已认证对照 | **照常绿**(`.not.toBe(401)` 与 501 钉子都不受门影响) |
| conformance ratchet | 阶段 A **绿**(见下) |

### 阶段 A —— `if (false && shouldDenyAnonymous({...`,重建 runtime

```
Test Files  1 failed | 1 passed (2)
     Tests  5 failed | 15 passed (20)

× anonymous POST of a script action is denied (401)
  AssertionError: anonymous action dispatch must be 401: expected 400 to be 401
× anonymous POST /automation/:name/trigger is denied (401)
  AssertionError: anonymous flow trigger must be 401: expected 501 to be 401
× anonymous GET /automation is denied (401) — the flow inventory stays private
  AssertionError: anonymous flow listing must be 401: expected 501 to be 401
× anonymous DELETE /automation/:name is denied (401) — the destructive one
  AssertionError: anonymous flow deregistration must be 401: expected 501 to be 401
× every denied surface answers the SAME code and message (the wrappers differ)
```

**逐条命中预判**,`/data`、`/meta`、两条已认证对照全绿。

这里有一条值得单独说的:`/automation` 的「无门答案」是 **501 而不是 200**,因为本 boot 没装 automation 服务。这恰恰是那条**已认证 501 对照用例**存在的理由 —— 同一个进程、同一条路由,匿名 401 / 成员 501,两者并排,401 就只可能是门给的。这也是 #5569 刻意把门放在 `isServiceServeable` 探测**之前**的原因(否则 401 与 501 的差异会泄露该部署是否挂了 automation)。用例注释里写明了。

conformance ratchet 在阶段 A **保持绿**,这是**预判之内**:`if (false &&` 保留了 `shouldDenyAnonymous(` 这个 token,而 ratchet 钉的是调用的**存在**,不是它的**活性** —— 与文件里既有的每一条 gate pin 同一性质。两层是互补的,这本身就是 #5570「光有 ratchet 不够、proof 工件必须真跑」的论据。

### 阶段 B —— 真正删掉调用(`shouldDenyAnonymous` → 改名)

```
Tests  3 failed | 6 passed (9)

× is a sound conformance ledger ... + the #2567 surface ratchet holds
    STALE covers — surface no longer in source: actions:domains/actions.ts:anonymous-gate
    STALE covers — surface no longer in source: automation:domains/automation.ts:anonymous-gate
× the real matrix + real discover is sound (baseline lock)
× (h) deleting either /actions or /automation anonymous gate → STALE covers failure (#5519)
```

还原后 `git diff --stat -- packages/runtime` 为空。

## 消费半径扫描

不按被改的包扫,按被改工件的 caller 扫:`grep -rn "authz-conformance"` 全仓(排除 node_modules)只命中 `packages/qa/dogfood` 内部,外加 `packages/spec/src/contracts/realtime-service.ts` 与 `plugin-security/src/authz-matrix-gate.test.ts` 两处**纯注释引用**,无代码依赖。proof 工件本身只被 `checkLedger` 按文件名存在性校验。

## 实跑记录

```
pnpm --filter @objectstack/dogfood test       ->  Test Files 85 passed | 1 skipped (86)
                                                  Tests 514 passed | 3 skipped (517)      (main 基线 506 passed,+8 = 本 PR 新增)
pnpm --filter @objectstack/dogfood typecheck  ->  tsc --noEmit,无输出(绿)
node scripts/check-nul-bytes.mjs              ->  OK (scanned 5531 tracked text files; no raw ASCII control bytes)
grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' <本 PR 三个文件>  ->  clean
```

## 自限

- 文件面**只在 `packages/qa/dogfood/test/`**,三个文件,+210 行 / -0 行。未触碰 `packages/runtime/**`(防线本体)、未触碰其他 dogfood 套件、未触碰 `content/docs/releases/`。
- 该套件留在 `shared-showcase` project(plain `bootStack(showcaseStack)`),未改 `vitest.config.ts`、未改 `shared-showcase.ts`,不增加 boot 开销。用 `automation: true` 启动 showcase 需要 `process.chdir` + 三个 connector 插件 + 临时 MetadataPlugin(见 `showcase-declarative-endpoints.dogfood.test.ts`),那是另一类测试;且在共享 stack 上做真能生效的 `DELETE /automation/:name` 断言,一旦门回归就会连带污染同 worker 的其他文件。
- 未新增 changeset(test-only,见文首)。

## 顺带发现(未在本 PR 修)

`@objectstack/core` 的 `ANONYMOUS_DENY_BODY` 注释写着 "The single 401 body shape every seam returns: `{ error, message }`",但 dispatcher 侧五个 seam(ai / meta / security / actions / automation)返回的是 wrapper 形状。已按 Prime Directive #10 单独立单,不在本 PR 修。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FNvXhtSdnEGEfLEsMmvxh

---
_Generated by [Claude Code](https://claude.ai/code/session_016FNvXhtSdnEGEfLEsMmvxh)_