### PR TITLE
docs(cli): narrow the `dev --fresh` isolation claim to what it actually covers (#5594)

### DIFF
--- a/.changeset/dev-fresh-claim-scope.md
+++ b/.changeset/dev-fresh-claim-scope.md
@@ -1,0 +1,31 @@
+---
+'@objectstack/cli': patch
+---
+
+`os dev --fresh` states the isolation it actually delivers (#5594)
+
+The `--fresh` block promised its tempdir "owns ALL persistent state for this
+run". After #4968 that is true of everything the CLI itself places — the dev
+SQLite DB (`OS_HOME` → `<home>/data/dev.db`, published as `OS_DATABASE_URL`),
+the uploads root (published on the settings service's own name
+`OS_STORAGE_LOCAL_ROOT`), and any plugin state keyed off `OS_HOME` — but it was
+never true of state an **app** reaches by a relative path it declares itself.
+Such a path is resolved by its own consumer against the process working
+directory, which `--fresh` does not move, so the file lands in the project tree
+and is still there after the run exits.
+
+The live specimen is deliberate authoring, not a bug: the showcase's
+`showcase-external` datasource declares
+`filename: '.objectstack/data/showcase_external.db'` and documents that the path
+resolves against the project cwd — so a `--fresh` showcase run leaves that file
+(plus `-wal`/`-shm`) behind.
+
+No behaviour changed. The `--fresh` flag help, the source comments, and the
+`os dev` flag table in the CLI docs now name the covered surface
+(`OS_HOME`-keyed state plus the env channels the CLI publishes) and state
+plainly what falls outside it, with a docs note on declaring an absolute path
+when a datasource should follow `--fresh`.
+
+Re-anchoring app-declared relative paths on `OS_HOME` is a behaviour change
+resting on an open contract question ("relative to cwd" vs "relative to this
+run's home") and is deliberately not taken here.

--- a/content/docs/deployment/cli.mdx
+++ b/content/docs/deployment/cli.mdx
@@ -138,13 +138,28 @@ os dev --database file:./data/test.db --auth-secret $(openssl rand -hex 32)
 | `-p, --port <n>` | `OS_PORT` / `PORT` | Listen port (default `3000`). In dev a busy port auto-hops to the next free one; the banner shows the actual port. |
 | `--ui` | — | Force Console UI on (already on by default in dev) |
 | `--compile` | — | Force compiling `objectstack.config.ts` → `dist/objectstack.json` before starting (auto when the artifact is missing; ignored with `--artifact`) |
-| `--fresh` | — | Ephemeral `OS_HOME` in the OS tempdir (clean DB, uploads, storage), auto-deleted on exit; implies `--seed-admin` |
+| `--fresh` | — | Ephemeral `OS_HOME` in the OS tempdir (clean DB, uploads root, and other `OS_HOME`-keyed state), auto-deleted on exit; implies `--seed-admin`. See the scope note below |
 | `--seed-admin` / `--no-seed-admin` | — | Seed a dev admin (`admin@objectos.ai` / `admin123`) on an empty DB — default on; override with `--admin-email` / `--admin-password` |
 | `-v, --verbose` | — | Verbose output |
 
 By default `os dev` keeps your data between restarts in a project-local SQLite
 file at `.objectstack/data/dev.db` (created on first run). Pass `--database`,
 set `OS_DATABASE_URL`, or use `--fresh` for a throwaway run.
+
+<Callout type="info" title="What `--fresh` covers">
+`--fresh` isolates the state **the CLI places for the run**: everything keyed
+off the ephemeral `OS_HOME` (the dev SQLite DB, the uploads root, plugin state
+under `OS_HOME`) plus the env channels `os dev` publishes for it —
+`OS_DATABASE_URL` and `OS_STORAGE_LOCAL_ROOT`. That tempdir is deleted on exit.
+
+It does **not** relocate state your app reaches by a **relative path it
+declares itself** — for example a datasource with
+`config: { filename: '.objectstack/data/my.db' }`. Such a path is resolved by
+its own consumer against the process working directory, which `--fresh` does
+not change, so the file is written into your project tree and is still there
+after the run ends. Declare an absolute path (or one derived from `OS_HOME`)
+when you want a datasource to follow `--fresh`.
+</Callout>
 
 With a file-backed SQLite database, dev also provisions a sibling
 `<db>.telemetry.<ext>` file registered as the `telemetry` datasource —

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -97,15 +97,18 @@ export default class Dev extends Command {
     }),
 
     // ── Ephemeral / fresh-environment helpers ────────────────────────
-    // `--fresh` creates an isolated tempdir for OS_HOME / DB / uploads
-    // so every run starts from a clean slate. Combine with `--seed-admin`
+    // `--fresh` creates an isolated tempdir for OS_HOME / DB / uploads, so
+    // every run starts from a clean slate for the OS_HOME-keyed state the
+    // CLI itself places (see the block in `run()` for the exact covered
+    // surface, and for what an app-declared relative path escapes — #5594).
+    // Combine with `--seed-admin`
     // (default-on when --fresh) to also provision a logged-in admin
     // account, so backend debugging never blocks on first-run wizards.
     // The seeded admin uses FIXED, well-known credentials by default
     // (admin@objectos.ai / admin123) so tooling never has to guess them —
     // override with --admin-email / --admin-password when needed.
     fresh: Flags.boolean({
-      description: 'Start with an ephemeral OS_HOME under the OS tempdir (clean DB, uploads, storage); auto-deletes on exit. Implies --seed-admin (admin@objectos.ai / admin123) unless --no-seed-admin is given.',
+      description: 'Start with an ephemeral OS_HOME under the OS tempdir — clean DB, uploads root and other OS_HOME-keyed state for this run, auto-deleted on exit. State an app reaches by its own cwd-relative path (e.g. a datasource `filename: .objectstack/...`) is NOT covered and survives exit. Implies --seed-admin (admin@objectos.ai / admin123) unless --no-seed-admin is given.',
       default: false,
     }),
     'seed-admin': Flags.boolean({
@@ -180,10 +183,29 @@ export default class Dev extends Command {
       const environmentId = flags['environment-id'] ?? process.env.OS_ENVIRONMENT_ID ?? 'env_local';
 
       // ── --fresh: ephemeral OS_HOME under the OS tempdir ─────────────
-      // Creates a unique scratch dir that owns ALL persistent state for
-      // this run: the SQLite DB (via OS_HOME → <home>/data/...), the
-      // storage-service uploads root (OS_STORAGE_LOCAL_ROOT), and any other
-      // state plugins keyed off OS_HOME. Auto-deleted on exit.
+      // Creates a unique scratch dir that owns the state this command can
+      // actually place, and nothing more. What it covers, exactly:
+      //   - the dev SQLite DB the CLI resolves for the run
+      //     (OS_HOME → <home>/data/dev.db, published as OS_DATABASE_URL),
+      //   - the storage-service uploads root, published on the settings
+      //     service's own env name OS_STORAGE_LOCAL_ROOT (#4968),
+      //   - any other state a plugin keys off OS_HOME.
+      // In one sentence: framework-owned, OS_HOME-keyed state plus the env
+      // channels this block publishes below. Auto-deleted on exit.
+      //
+      // NOT covered — state reached by an app-declared RELATIVE path (#5594).
+      // Such a path is resolved by its own consumer against the process cwd,
+      // which `--fresh` does not move, so it is written into the project tree
+      // and survives exit. The live specimen is deliberate authoring, not a
+      // bug: examples/app-showcase's `showcase-external` datasource declares
+      // `filename: '.objectstack/data/showcase_external.db'` and says in its
+      // own comment that the path resolves against the project cwd — so a
+      // `--fresh` run of the showcase leaves that file (+ -wal/-shm) behind.
+      // Re-anchoring app-declared relative paths on OS_HOME would be a
+      // behaviour change resting on an open contract question ("relative to
+      // cwd" vs "relative to this run's home"); it is deliberately NOT taken
+      // here, and this comment states the covered surface instead of an
+      // unqualified promise a reader would rely on for isolation.
       //
       // The uploads root MUST be published under the name the settings
       // service derives for it — `envKeyOf('storage','local_root')` (#4968).


### PR DESCRIPTION
Fixes #5594

按 PM 裁定走 issue 的**处置 1**:把 `--fresh` 的声明口径收窄到真实覆盖面。⛔ **不做处置 2**(app 声明的相对路径改锚 `OS_HOME`)—— 那是行为变更 + 契约题("relative to cwd" 还是 "relative to this run's home"),issue 正文自己也声明不预设,要做须另立单拍板。

## 前提复核(先证后改)

基于 `origin/main` @ `2614aefb3`(≥ `a287d1ce1`,#5601 之后)核对,注释措辞仍在:

```
packages/cli/src/commands/dev.ts:183
// Creates a unique scratch dir that owns ALL persistent state for
// this run: the SQLite DB (via OS_HOME → ...
```

前提成立。

## 真实覆盖面

`--fresh` 覆盖的是**这条命令自己放置**的状态:

- dev SQLite DB —— `OS_HOME` 下的 `data/dev.db`,以 `OS_DATABASE_URL` 发布;
- storage 上传根 —— 以 settings 服务自有的 env 名 `OS_STORAGE_LOCAL_ROOT` 发布(#4968 之后);
- 其他以 `OS_HOME` 为键的插件态。

一句话:`OS_HOME` 键控的框架态 + 本块向 serve 子进程发布的 env 通道。

**不覆盖**:app 自己声明的**相对路径**所指向的状态。这类路径由各自的消费者按进程 cwd 解析,而 `--fresh` 并不移动 cwd,于是文件落在项目树里、退出后仍在。活体样本是刻意设计而非 bug —— showcase 的 `showcase-external` datasource 声明 `filename: '.objectstack/data/showcase_external.db'`,其自身注释就写明按项目 cwd 解析;因此 `--fresh` 跑 showcase 会留下该文件(含 `-wal`/`-shm`)。**本 PR 未改动该 datasource 声明。**

## 改动面

- `packages/cli/src/commands/dev.ts`
  - `run()` 里的 `--fresh` 注释块:逐条列出覆盖面,并显式点出相对路径不在承诺内 + 为什么不在这里改锚;#4968 那段关于 `OS_STORAGE_LOCAL_ROOT` 名字来源的准确叙述**原样保留**。
  - flag 声明处的注释 + `--fresh` 的 **flag help 文本**(`os dev --help` 的用户可见面)同步收窄。
- `content/docs/deployment/cli.mdx`
  - `os dev` 选项表里 `--fresh` 一行改写;
  - 表下新增一段 "What `--fresh` covers" Callout,写明覆盖面、不覆盖什么、以及想让 datasource 跟随 `--fresh` 时应声明绝对路径。
- ⛔ 未触碰 `content/docs/releases/`;未触碰 doctor 文件族(#5612 在飞)与 `packages/runtime`(#5581 在飞)。

**未改 `serve.ts:2987`**:那里是 #4968 的历史叙述,原文以过去时引用旧承诺("`dev --fresh` promised … uploads actually landed under the project cwd"),作为 bug 史实**仍然准确**,且 `serve.ts` 是 CLI 里最热的文件,不必为一句历史引用制造冲突面。

## 验证

零行为变更(只改注释、help 字符串与文档),故无新增测试;既有测试无一断言 "ALL state" 措辞(`packages/cli/test/commands.test.ts` 只断言 command 级 description,flag description 无 pin)。

- `pnpm --filter @objectstack/cli test` → `Test Files 82 passed (82) / Tests 812 passed (812)`
- `pnpm --filter @objectstack/cli typecheck` → `tsc --noEmit`,无输出
- `node scripts/check-role-word.mjs` → OK(43 baselined,无新增)
- `node scripts/check-doc-authoring.mjs` → 362 files clean
- `node scripts/docs-audit/check-audit-scope.mjs` → in sync
- `node scripts/check-nul-bytes.mjs` → OK(5537 files,无裸控制字节)

## Changeset

带了 `.changeset/dev-fresh-claim-scope.md`(`@objectstack/cli: patch`)。虽是口径修正,但 `--fresh` 的 **flag help 文本随包发布、用户 `--help` 直接可见**,属用户可见变更,按 AGENTS.md 走真实 changeset 而非 `skip-changeset` 标签;若 PM 判定不该发版,改挂 `skip-changeset` 并删除该 changeset 即可。

---
_Generated by [Claude Code](https://claude.ai/code/session_016FNvXhtSdnEGEfLEsMmvxh)_