### PR TITLE
docs(os-dev): 「Byte discipline」段的 binary-file 危害点名 NUL,其余字节改引门禁脚本头的三条 (#5579)

### DIFF
--- a/.claude/agents/os-dev.md
+++ b/.claude/agents/os-dev.md
@@ -270,13 +270,23 @@ backslash-u forms like `\u0000` / `\u0001` — never as raw bytes, in **any**
 file (source, markdown, fixtures) and in any prompt or tool payload you
 compose: describe the escape, do not paste the byte. Editing tools
 materialize escapes into real control bytes precisely when you are writing
-*about* them — this repo has paid four times: #4763 (raw NUL in a dispatch
-prompt), #4890 (a raw NUL landed in `SKILL.md` **while writing the
-no-raw-NUL rule**, outside every gate's scan surface), and PR #5140's two
-bytes — a NUL plus, 14 bytes away, a `0x01` that `check:nul-bytes` does not
-scan for (#5157). One raw control byte makes grep treat the whole file as
-binary: zero matches, no signal, and the rule you just wrote becomes
-invisible to every agent that greps for it. Run
+*about* them, and this repo has paid for it repeatedly — including #4763
+(raw NUL in a dispatch prompt), #4890 (a raw NUL landed in `SKILL.md`
+**while writing the no-raw-NUL rule**, outside every gate's scan surface),
+and PR #5140's two bytes: a NUL plus, 14 bytes away, a `0x01` that the
+then-NUL-only scan walked straight past — the gap #5157 closed by widening
+the scan surface beyond NUL. The harms are argued in the gate script's
+header (`scripts/check-nul-bytes.mjs`) — cite it, don't re-derive it.
+Measured, only a raw **NUL** makes grep and ripgrep treat the whole file as
+binary and report zero matches with no signal, so the rule you just wrote
+becomes invisible to every agent that greps for it. Every other scanned byte
+(`0x01`, `0x7f`, …) keeps matching line by line, and is rejected for the
+three harms that land on the whole set: it **renders as nothing**, so the
+code lies to every reader; it is unfindable in **both** spellings, since the
+file holds a byte and not the escape text you would search for; and the
+accident source **does not pick byte values**. "Mine is not a NUL and grep
+still finds my file" is therefore never a reason to read a gate failure or a
+self-scan hit as a false positive. Run
 `node scripts/check-nul-bytes.mjs` before pushing, and when your change so
 much as *mentions* control characters, self-scan beyond the gate
 (`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]' <files>`) — the gate's blind


### PR DESCRIPTION
Fixes #5579

正文用 `U+00XX` 这种不含反斜杠转义的写法指代字节(#5460 口径)。文件里的散文沿用该文件与门禁脚本头既有的 `0x01`/`0x7f` 十六进制写法 —— 同样不含反斜杠转义,不会被编辑工具 materialise 成真字节,且与本 PR 要对齐的那个脚本头一致。

## 前提复核:仍成立

`origin/main`(4658e57c7)的 `.claude/agents/os-dev.md`「Byte discipline」段仍是 issue 记录的那个表述 —— 该段给出的**唯一**危害理由是:

> One raw control byte makes grep treat the whole file as binary: zero matches, no signal, and the rule you just wrote becomes invisible to every agent that greps for it.

## 实测:该危害只对 NUL 成立

不引用 issue 的表格,在本分支容器内重测。三个样本各为「一枚控制字节 + 一行可搜索文本」,用 `printf` 生成(未粘贴任何裸字节),`od -tx1` 确认字节确实落在文件里;GNU grep 3.11 + ripgrep 14.1.0,均不加 `-a`:

| 样本字节 | `grep -n searchable` | `rg -n searchable` |
|:--|:--|:--|
| U+0000 | `binary file matches`(不打印行内容) | `binary file matches (found "\0" byte around offset 4)` |
| U+0001 | `2:searchable line` | `2:searchable line` |
| U+007F | `2:searchable line` | `2:searchable line` |

与门禁脚本头 #5157 段的实测结论一致。即:门禁扫描面里除 NUL 之外的每个字节(含 #5460 纳入门禁、PR #5577 刚补进自扫字符类的 DEL)都**不会**让文件被当成二进制。

这不只是文字不精确 —— 它给 agent 留了一条自洽的错误推理:写出一枚 U+0001 或 U+007F、按 #5484 修好的字符类自扫命中,再去核对指令给出的唯一判据(「本文件被 grep 当成二进制」),发现不成立,于是把门禁的红读成误报。

## 改法:搬门禁脚本头已经写好的口径

`scripts/check-nul-bytes.mjs` 脚本头早就把两侧分开论证好了,`os-dev.md` 一条都没搬 —— 它搬的恰好是唯一不适用的那条。逐条对齐:

| 脚本头 | 改后的 os-dev.md |
|:--|:--|
| 「Measured, that harm really is NUL-specific: GNU grep 3.11 and ripgrep 14.1 report 'binary file matches' for a file carrying 0x00, and keep matching normally for one carrying 0x01 or 0x03」 | 「Measured, only a raw **NUL** makes grep and ripgrep treat the whole file as binary and report zero matches with no signal」+「Every other scanned byte keeps matching line by line」 |
| 危害 1「The byte RENDERS AS NOTHING … Code that lies to every reader」 | 「it **renders as nothing**, so the code lies to every reader」 |
| 危害 2「Nobody can search for it … unfindable in BOTH spellings」 | 「it is unfindable in **both** spellings, since the file holds a byte and not the escape text you would search for」 |
| 危害 3「The accident source does not pick bytes」 | 「the accident source **does not pick byte values**」 |

另补一句直接堵上那条错误推理:「不是 NUL、grep 还能搜到」永远不构成把门禁红或自扫命中读成误报的理由。危害论证指向脚本头「cite it, don't re-derive it」,不在 prompt 里再抄一遍论证细节 —— 该文件每个词都进每次派单的 token 预算。

## 顺带两处陈旧(issue 正文点名)

- **计数句**:「this repo has paid **four** times」→ 免计数措辞(`paid for it repeatedly — including …`)。该族现已多于四例;#5624 今天刚因同一种漂移把台账里的「four/five sibling」改成不含数字的表达。
- **时态**:「a `0x01` that `check:nul-bytes` **does not scan for** (#5157)」→ 「a `0x01` that the then-NUL-only scan walked straight past — the gap #5157 closed by widening the scan surface beyond NUL」。#5157 正是把该字节纳入扫描面的那一单,现在时读法已错。

## 边界:未做也未声称做的事

- **单源化**(字符类 / 危害论证不再手抄多处)是 #5484 正文留下的方向,**不在本 PR** —— 本 PR 只修散文口径。这次改动把危害论证指向脚本头而不是复制它,算是往那个方向少了一层重复,但真正的单源化(指令与脚本头共用单一来源)仍未做。
- 不动 `scripts/check-nul-bytes.mjs`(它是对的一侧)、不动 PR #5577 刚补的自扫字符类、不动 PR #5630 刚加的 Toolchain traps 条目。diff 逐行自查:只动该段内的目标句,前一句(backslash-u 处方行)与后面的自扫命令行在 diff 里都是上下文行、逐字节未变。
- 全仓扫了一遍是否还有同样过宽的表述:`.claude/skills/pm-dispatch/SKILL.md:1112` 与 `scripts/check-org-identifier.mjs:65` 的两处 binary/invisible 陈述都已正确限定在 NUL(git 的 binary 判定本就看 NUL),属实,**未开新单**。

## 验证

- `node scripts/check-nul-bytes.mjs` → `OK (scanned 5537 tracked text file(s); … no raw ASCII control bytes)`
- 改动文件自扫 `grep -naP` 完整控制字节类(含 DEL)→ 零命中(exit 1)
- 新增行 `cat -A` 与 `od -c` 复核 → 除 LF 外无任何控制字节
- 全程未向任何文件写入裸控制字节;验证样本在 scratchpad 用 `printf` 生成,与仓库文件面隔离

`.claude/` 文档-only、无用户可见变更,故**不加 changeset**,走 `skip-changeset` 标签路线(⛔ 不写空 frontmatter changeset)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE)_