### PR TITLE
docs(os-dev): PR 收尾清单增补 `skip-changeset` 硬步骤,以回读 PR labels 为闭环

### DIFF
--- a/.claude/agents/os-dev.md
+++ b/.claude/agents/os-dev.md
@@ -143,10 +143,13 @@ Definition of done, in order:
   applied, and CI's own write can wipe yours back (#5533's lasted one second).
   Then read the labels back once the bots have settled and quote that list in
   the report; the read, not the POST, is what closes this step. Check Changeset
-  re-reads labels live seconds after the PR opens (#5580), so expect its
-  `opened` run to have started before your label lands — #5542 did this right
-  and still logged one red `opened` run, which the label then exempted on every
-  later run. Declaring the label in the PR body is not applying it: #5533 and
+  re-reads the labels live in its first step (#5580), so the first run is a race
+  between that step and your POST, decided by runner start-up — and it is
+  attested both ways: #5542 labelled correctly and still logged a red `opened`
+  run, while #5650's label landed 41 s ahead of the re-read and that same
+  `opened` run went green. So land the label fast, and read the first run's
+  colour as information rather than as your verdict — every run after the label
+  is exempt. Declaring the label in the PR body is not applying it: #5533 and
   #5538 each said so in prose and each still cost a PM hand-fix.
 - Tear down anything you started (dev servers on random ports).
 

--- a/.claude/agents/os-dev.md
+++ b/.claude/agents/os-dev.md
@@ -132,6 +132,22 @@ Definition of done, in order:
   failure with backoff).
 - **Draft** PR to `main`, body starting `Fixes #<n>`, explanatory prose in
   Chinese per repo convention.
+- **`skip-changeset` label — your step, not CI's; the read-back is the proof.**
+  A test-only / workflow-only / `.claude/`-only PR releases nothing and writes
+  no changeset, so it needs the `skip-changeset` label — apply it yourself the
+  moment the PR exists. Nothing applies it for you: `.github/labeler.yml` has no
+  rule for it, and in every 2026-08-05 case
+  (#5533/#5538/#5542/#5624/#5642/#5645) the label came from an agent, never from
+  `github-actions[bot]`. **Add** the one label instead of writing the label set
+  — a set-write wipes the `size/*` / `documentation` / `tests` the bots just
+  applied, and CI's own write can wipe yours back (#5533's lasted one second).
+  Then read the labels back once the bots have settled and quote that list in
+  the report; the read, not the POST, is what closes this step. Check Changeset
+  re-reads labels live seconds after the PR opens (#5580), so expect its
+  `opened` run to have started before your label lands — #5542 did this right
+  and still logged one red `opened` run, which the label then exempted on every
+  later run. Declaring the label in the PR body is not applying it: #5533 and
+  #5538 each said so in prose and each still cost a PM hand-fix.
 - Tear down anything you started (dev servers on random ports).
 
 **Reverse verification — decide the expected direction BEFORE you run it.**


### PR DESCRIPTION
Fixes #5559

## 背景

测试-only / 工作流-only / `.claude/`-only 的 PR 不写 changeset,靠 `skip-changeset` 标签豁免 Check Changeset —— 门禁自己的失败文案就把标签列为 PREFERRED 路径。但 os-dev 的「Definition of done」收尾清单对这一步**一字未提**:当前 main 的 `.claude/agents/os-dev.md` 全文搜 label 零命中。于是 dev 在 PR 正文里「声明」标签而没有真正挂上,#5533、#5538 各烧一轮门禁红并由 PM 手工兜底 —— 「声明了 ≠ 执行了」正是 declared ≠ enforced 的 agent 版。

## 改动

`.claude/agents/os-dev.md` 收尾清单新增一条硬步骤,与「PR 正文以 Fixes 开头」同级。**19 行新增、0 行删除**,单文件;其余段落一字未动(含 #5630 新加的 toolchain trap 5、#5642 今日重写的 Byte discipline)。

## 实测校正了派发词的三处认知

派发词给的新数据点是「CI Auto Label 已会自动挂 skip-changeset,文案 PR has no user-facing published change,所以硬步骤应写成回读验证为准而非无条件 POST」。**逐 PR 核对 timeline 后,前半句证伪**,因此条款按实测事实落笔(「回读为准」这个结论保留 —— 但理由完全不同):

| 核对项 | 派发认知 | 实测 |
| --- | --- | --- |
| 谁挂的标签 | CI Auto Label | 六例 #5533/#5538/#5542/#5624/#5642/#5645 **全部**来自 agent(`os-zhuang` 五次、`claude[bot]` 一次);`github-actions[bot]` 一次都没挂过,它只挂 `size/*`、`documentation`、`tests`、`ci/cd` |
| 配置依据 | 有对应 labeler 规则 | `.github/labeler.yml` 九条规则里**没有** `skip-changeset`;仓内唯一匹配「PR has no user-facing published change」的字符串,是本 PR 初稿里我自己写下的那一行 |
| 「标签未落」的成因 | dev 漏做这一步 | #5533 的标签 `15:46:44` 已落地,`15:46:45` 被 `github-actions[bot]` 的整集写入抹掉 —— 只活了一秒,dev 侧与「没挂」无法区分 |

**整集写入会互相抹**:agent 每次挂标签都伴随一条自己发出的 `unlabeled`,把 bot 刚挂的 `size/*` / `documentation` / `tests` 抹掉(#5533/#5538/#5642/#5645 均可见);反向就是上表第三行。本 PR 自证时更抓到纯 CI 侧的一次:`22:03:48` bot 挂 `size/s`,`22:03:49` **bot 自己**把它 `unlabeled` 又挂上 `documentation` —— 与任何 agent 动作无关。条款因此写明**只加一个标签**。落点在 pr-automation.yml 与写入客户端,超出本单文件面,已另开 #5649,本 PR 不修。

## 实践自证:本 PR 自己是新条款的第一次实测

| 步骤 | 结果 |
| --- | --- |
| 开 PR 后立刻回读(`22:03:52`,PR 创建后 20 秒) | `["documentation"]` —— CI **没有**代挂 `skip-changeset`,证实上表第一、二行 |
| 以新增语义自挂(`POST /issues/5650/labels`) | 返回 `["documentation","skip-changeset"]`,`documentation` 未被抹;timeline 里我这次写入**没有**产生任何 `unlabeled` 事件 —— 与六例 agent 整集写入形成对照 |
| bot 平息后回读(`22:04:52`) | `["documentation","size/s","skip-changeset"]` —— 三个标签齐全,`size/s` 由 bot 自行补回 |

**预设方向被证伪的一处,如实改掉了条款措辞。** 初稿按 #5542 的历史预设「首 run 必然红」,并在本 PR 正文里写过「立刻落标签让首 run 直接豁免不可达」。实测相反:标签 `22:03:54` 落地,而 `opened` run(workflow run `31051251795`,创建于 `22:03:38`)的 Check Changeset job 直到 `22:04:35` 才启动并做实时回读 —— 读到了早它 41 秒的标签,该 run 直接 **success**。所以首 run 的颜色是一场由 runner 启动耗时决定的竞态,两个方向都有实例(#5542 红、#5650 绿),第二次 commit 把措辞改成如实描述竞态,并把指导语从「预期会红」改为「尽快落标签,把首 run 的颜色当信息而不是自己的判决」。

## 验证

- diff 逐行自查:单文件 19+/0−,只在目标清单区域;`- Tear down …` 之后一行未动。
- `node scripts/check-nul-bytes.mjs --self-test` 48 assertions 绿 + 全仓扫描 `OK (5573 tracked text file(s))`;改动文件自扫 `grep -naP` 控制字节零命中。
- `check-doc-authoring`(362 files clean)、`check-role-word`(43 baselined, no new)绿。
- markdown 结构:单个顶层列表项、18 行续行全为 2 空格缩进、`**` 四个成对、反引号 20 个成对、最大 80 列与既有条目一致。
- 必需检查:TypeScript Type Check / Build Core / Test Core / Dogfood Regression Gate 均按 path filter 处理(纯 `.claude/` diff),Check Changeset 经标签豁免。

## 边界

⛔ 未动 `.github/workflows/pr-automation.yml`(#5580/#5625 已改,#5620 在排队);⛔ 未动 pm-dispatch SKILL.md 的 PM 兜底逻辑;⛔ 未写 changeset(`.claude/` 文档-only,走标签路线)。