### PR TITLE
fix(lint): report a `config.timeRelative` descriptor the sweep will refuse, at authoring time (#5496)

### DIFF
--- a/.changeset/flow-time-relative-descriptor-lint.md
+++ b/.changeset/flow-time-relative-descriptor-lint.md
@@ -1,0 +1,47 @@
+---
+"@objectstack/lint": patch
+---
+
+fix(lint): report a `config.timeRelative` descriptor the sweep will refuse, at authoring time (#5496)
+
+A flow start node declaring `config.timeRelative` got **zero** authoring-time
+diagnostics when its descriptor could not parse. The two rules that look at the
+slot each looked at something else: `lint-flow-patterns` decides "this is a
+time-relative flow" from `timeRelative != null` alone (never the shape), and
+`validate-flow-trigger-readiness`'s existing check reads only
+`timeRelative.object`, to compare it against the stack's objects. So
+
+```ts
+config: { timeRelative: { object: 'task', field: 'due_at', offsetDays: -1 } }
+```
+
+— three separate schema violations: `dateField` missing, `offsetDays` declared
+as an int **array** and written as a scalar, and `field` an unrecognized key —
+passed `os validate` silently. `TimeRelativeTriggerSchema` does reject it, but
+the only place that schema ran was **bind time**, inside
+`TimeRelativeTriggerPlugin.start()`, which warns and returns: the sweep is never
+installed, the flow reports itself armed, and the author's sole feedback is one
+line in a server log. For an AI author that line is outside the feedback loop
+entirely; `os validate` is what it reads.
+
+**New rule — `flow-time-relative-descriptor-invalid` (warning).** A start node
+whose `config.timeRelative` is present runs that same schema at authoring time,
+and a failure is reported naming `config.timeRelative` with the schema's own
+issue list forwarded — so the diagnostic carries the missing key, the wrong type,
+and, for an unrecognized key, the "did you mean" the schema already computes
+(`field` → `dateField`) plus its wrong-layer guidance (a `schedule` written
+*inside* the descriptor is told it belongs beside it). The list is rendered
+exactly as the bind-time warning renders it, so the two channels tell one story.
+
+Nothing is shifted except **when** the schema runs. No shape knowledge is
+re-implemented in the rule and no consumer-side tolerance is added: the verdict
+and every word of its wording remain `TimeRelativeTriggerSchema`'s, so the rule
+tracks the descriptor's contract as it evolves instead of drifting from a second
+copy of it.
+
+The rule and the existing object-name check decide different facts and cannot
+report the same one twice — only the stack knows whether an object name exists,
+and only the schema knows the descriptor's shape. A descriptor wrong in both ways
+gets both findings, at their own paths. Canonical descriptors are unaffected:
+every one shipped in the repo (the showcase `Task Due Reminder`, the
+`content/docs` examples) parses, so this adds no diagnostic to existing apps.

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -53,6 +53,7 @@ export {
   validateFlowTriggerReadiness,
   FLOW_TRIGGER_UNKNOWN_OBJECT,
   FLOW_DRAFT_STATUS_AMBIGUOUS,
+  FLOW_TIME_RELATIVE_DESCRIPTOR_INVALID,
 } from './validate-flow-trigger-readiness.js';
 export type {
   FlowTriggerReadinessFinding,

--- a/packages/lint/src/validate-flow-trigger-readiness.test.ts
+++ b/packages/lint/src/validate-flow-trigger-readiness.test.ts
@@ -1,11 +1,13 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
+import { TimeRelativeTriggerSchema } from '@objectstack/spec/automation';
 import {
   validateFlowTriggerReadiness,
   FLOW_TRIGGER_UNKNOWN_OBJECT,
   FLOW_DRAFT_STATUS_AMBIGUOUS,
   FLOW_TRIGGER_UNKNOWN_EVENT,
+  FLOW_TIME_RELATIVE_DESCRIPTOR_INVALID,
 } from './validate-flow-trigger-readiness.js';
 
 function recordFlow(overrides: Record<string, unknown> = {}) {
@@ -174,6 +176,207 @@ describe('validateFlowTriggerReadiness', () => {
     expect(findings[0].rule).toBe(FLOW_TRIGGER_UNKNOWN_OBJECT);
     expect(findings[0].message).toContain("'contract'");
     expect(findings[0].path).toBe('flows[0].nodes[0].config.timeRelative.object');
+    // The SHAPE is canonical, so the descriptor rule stays out of it — the two
+    // halves of 1b decide different facts and must not both fire on one.
+    expect(TimeRelativeTriggerSchema.safeParse({
+      object: 'contract', dateField: 'end_date', withinDays: 60,
+    }).success).toBe(true);
+    expect(findings.some((f) => f.rule === FLOW_TIME_RELATIVE_DESCRIPTOR_INVALID)).toBe(false);
+  });
+
+  // ── #5496 — the descriptor's SHAPE ────────────────────────────────────────
+  //
+  // `TimeRelativeTriggerSchema` is the only thing that can judge a
+  // `config.timeRelative` descriptor (the node `config` slot is open by design,
+  // ADR-0018, so no outer flow gate sees inside it), and until this rule the only
+  // place it ran was BIND time — one warn in a server log, nothing in
+  // `os validate`. These tests pin the forwarding, not a second copy of the
+  // shape: where a message is asserted it is asserted against what the schema
+  // itself produces, so the rule cannot drift from the contract it speaks for.
+  describe('config.timeRelative descriptor shape (#5496)', () => {
+    /** The stack from the issue: `task` EXISTS, flow is active and runs as system. */
+    function timeRelativeStack(timeRelative: unknown, objectName = 'task') {
+      return {
+        objects: [{ name: objectName, label: 'Task', fields: {} }],
+        flows: [
+          {
+            name: 'task_due_reminder',
+            type: 'schedule',
+            status: 'active',
+            runAs: 'system',
+            nodes: [
+              { id: 'start', type: 'start', config: { timeRelative } },
+              { id: 'end', type: 'end' },
+            ],
+            edges: [{ id: 'e1', source: 'start', target: 'end' }],
+          },
+        ],
+      };
+    }
+
+    /** The exact descriptor #5496 was filed for — three separate zod issues. */
+    const badDescriptor = { object: 'task', field: 'due_at', offsetDays: -1 };
+
+    it('flags the descriptor from #5496 and names every key zod named', () => {
+      const findings = validateFlowTriggerReadiness(timeRelativeStack(badDescriptor));
+      expect(findings).toHaveLength(1);
+      const [f] = findings;
+      expect(f.rule).toBe(FLOW_TIME_RELATIVE_DESCRIPTOR_INVALID);
+      expect(f.severity).toBe('warning');
+      // Criterion 1: the finding NAMES config.timeRelative, in both channels the
+      // CLI prints (`• where: message` then `at path`).
+      expect(f.path).toBe('flows[0].nodes[0].config.timeRelative');
+      expect(f.message).toContain('config.timeRelative');
+      expect(f.where).toBe('flow "task_due_reminder" › start node');
+      // …and carries zod's own key names: the missing `dateField`, the scalar
+      // `offsetDays`, and the unrecognized `field` with the schema's suggestion.
+      expect(f.message).toContain('dateField: Invalid input: expected string, received undefined');
+      expect(f.message).toContain('offsetDays: Invalid input: expected array, received number');
+      expect(f.message).toContain('Unrecognized key(s)');
+      expect(f.message).toContain('`field`');
+      expect(f.message).toContain('Did you mean `field` → `dateField`?');
+      // The consequence, which is the whole reason this is not just a log line.
+      expect(f.message).toMatch(/never runs/);
+      expect(f.hint).toContain('TimeRelativeTriggerSchema');
+    });
+
+    it('forwards the schema verbatim rather than restating it (anti-drift pin)', () => {
+      // Every problem segment is `TimeRelativeTriggerSchema`'s own text, rendered
+      // the way `TimeRelativeTrigger.start()` renders the identical issue list at
+      // bind time. Derived from the schema HERE too, so this assertion tracks the
+      // contract instead of freezing today's wording: if the schema's message for
+      // a rejected descriptor changes, the rule's output changes with it and this
+      // test keeps passing — but a hand-written copy in the rule would not.
+      const parsed = TimeRelativeTriggerSchema.safeParse(badDescriptor);
+      expect(parsed.success).toBe(false);
+      const expected = parsed.error!.issues
+        .map((i) => `${i.path.join('.') || '(root)'}: ${i.message.replace(/\s+/g, ' ').trim()}`)
+        .join('; ');
+      const [f] = validateFlowTriggerReadiness(timeRelativeStack(badDescriptor));
+      expect(f.message).toContain(expected);
+      // Single-line, so the CLI's bulleted list stays aligned (the schema's
+      // guidance bullets arrive with newlines in them).
+      expect(f.message).not.toContain('\n');
+      expect(f.hint).not.toContain('\n');
+    });
+
+    it('stays silent on the canonical descriptors — including the ones shipped in the repo', () => {
+      // Criterion 2. Each is pinned against the schema as well as against the
+      // rule, so a fixture cannot rot into an unbindable descriptor and keep this
+      // test green for the wrong reason (#4966's lesson, one layer down).
+      const canonical: Array<[string, Record<string, unknown>]> = [
+        ['#5496 acceptance shape', { object: 'task', dateField: 'due_at', offsetDays: [-1] }],
+        // examples/app-showcase `Task Due Reminder` (#1874) — the showcase flow
+        // criterion 2 names by hand.
+        ['showcase Task Due Reminder', {
+          object: 'task',
+          dateField: 'due_date',
+          offsetDays: [3, 1],
+          filter: { status: { $ne: 'done' } },
+        }],
+        // content/docs/references/automation/time-relative-trigger.mdx, all three
+        // examples, and content/docs/automation/flows.mdx's `renewalReminder`.
+        ['docs T-minus example', {
+          object: 'task', dateField: 'end_date', offsetDays: [60, 30, 7], filter: { status: 'active' },
+        }],
+        ['docs expiring-soon example', { object: 'task', dateField: 'expires_on', withinDays: 30 }],
+        ['docs overdue example', {
+          object: 'task', dateField: 'due_date', withinDays: -14, filter: { status: 'open' },
+        }],
+        ['with maxRecords', { object: 'task', dateField: 'due_at', withinDays: 7, maxRecords: 50 }],
+      ];
+      for (const [label, descriptor] of canonical) {
+        expect(TimeRelativeTriggerSchema.safeParse(descriptor).success, `${label} must be spec-valid`).toBe(true);
+        expect(validateFlowTriggerReadiness(timeRelativeStack(descriptor)), label).toEqual([]);
+      }
+    });
+
+    it('reports a wrong object name and a wrong shape as two facts, not one twice', () => {
+      // Criterion 3. `contract` is not in the stack AND the descriptor does not
+      // parse. The two findings are distinguishable by rule id and by path, and
+      // neither restates the other's fact: the unknown-object warning says nothing
+      // about the shape, and the schema — which has no stack knowledge — cannot
+      // say anything about the name.
+      const findings = validateFlowTriggerReadiness(
+        timeRelativeStack({ object: 'contract', field: 'end_date', withinDays: 60 }),
+      );
+      expect(findings).toHaveLength(2);
+      expect(findings.map((f) => f.rule)).toEqual([
+        FLOW_TRIGGER_UNKNOWN_OBJECT,
+        FLOW_TIME_RELATIVE_DESCRIPTOR_INVALID,
+      ]);
+      expect(findings.map((f) => f.path)).toEqual([
+        'flows[0].nodes[0].config.timeRelative.object',
+        'flows[0].nodes[0].config.timeRelative',
+      ]);
+      // The name warning talks only about the name…
+      expect(findings[0].message).toContain("'contract'");
+      expect(findings[0].message).not.toContain('dateField');
+      // …and the shape warning only about the shape (it never echoes the name).
+      expect(findings[1].message).toContain('dateField');
+      expect(findings[1].message).not.toContain("'contract'");
+    });
+
+    it('forwards the exactly-one-window rule (both modes, and neither)', () => {
+      for (const descriptor of [
+        { object: 'task', dateField: 'due_at', withinDays: 3, offsetDays: [1] },
+        { object: 'task', dateField: 'due_at' },
+      ]) {
+        const findings = validateFlowTriggerReadiness(timeRelativeStack(descriptor));
+        expect(findings.map((f) => f.rule)).toEqual([FLOW_TIME_RELATIVE_DESCRIPTOR_INVALID]);
+        expect(findings[0].message).toContain('exactly one of `withinDays`');
+      }
+    });
+
+    it("forwards the schema's wrong-layer guidance for a `schedule` written INSIDE the descriptor", () => {
+      // The cadence knob is a SIBLING of `timeRelative` on the same config. The
+      // schema carries that prescription; the value of forwarding is that the
+      // author reads it from `os validate` instead of from a server log.
+      const findings = validateFlowTriggerReadiness(
+        timeRelativeStack({
+          object: 'task',
+          dateField: 'due_at',
+          withinDays: 3,
+          schedule: { type: 'cron', expression: '0 8 * * *' },
+        }),
+      );
+      expect(findings.map((f) => f.rule)).toEqual([FLOW_TIME_RELATIVE_DESCRIPTOR_INVALID]);
+      expect(findings[0].message).toContain('`schedule` is a sibling of `timeRelative`');
+    });
+
+    it('flags an array descriptor — the engine routes it, so the trigger refuses it', () => {
+      const findings = validateFlowTriggerReadiness(timeRelativeStack([{ object: 'task' }]));
+      expect(findings.map((f) => f.rule)).toEqual([FLOW_TIME_RELATIVE_DESCRIPTOR_INVALID]);
+      expect(findings[0].message).toContain('expected object, received array');
+    });
+
+    it('says nothing about a non-object timeRelative — the engine does not route it here', () => {
+      // `AutomationEngine`'s trigger resolution requires `typeof … === 'object'`,
+      // so `timeRelative: 'daily'` never reaches the time-relative trigger and no
+      // descriptor verdict applies to it. Whatever that flow's defect is, it is
+      // not this rule's, and guessing here would make the rule speak for flows
+      // the engine hands somewhere else.
+      const findings = validateFlowTriggerReadiness(timeRelativeStack('daily'));
+      expect(findings.some((f) => f.rule === FLOW_TIME_RELATIVE_DESCRIPTOR_INVALID)).toBe(false);
+    });
+
+    it('is inert on flows that declare no timeRelative at all', () => {
+      const findings = validateFlowTriggerReadiness({
+        objects: [candidateObject],
+        flows: [recordFlow({ status: 'active' })],
+      });
+      expect(findings).toEqual([]);
+    });
+
+    it('still flags the draft-status ambiguity alongside a bad descriptor', () => {
+      const stack = timeRelativeStack(badDescriptor);
+      delete (stack.flows[0] as Record<string, unknown>).status;
+      const findings = validateFlowTriggerReadiness(stack);
+      expect(findings.map((f) => f.rule)).toEqual([
+        FLOW_TIME_RELATIVE_DESCRIPTOR_INVALID,
+        FLOW_DRAFT_STATUS_AMBIGUOUS,
+      ]);
+    });
   });
 
   it('passes the record-after-write (create-OR-update) token (#3427)', () => {

--- a/packages/lint/src/validate-flow-trigger-readiness.ts
+++ b/packages/lint/src/validate-flow-trigger-readiness.ts
@@ -4,8 +4,8 @@
 // third-party eval: a record-change flow that silently never fires).
 //
 // A pure `(stack) => Finding[]` rule (ADR-0019), run from `os validate` and
-// reusable by AI authoring. It catches the two authoring mistakes that produce
-// a flow which LOOKS armed but never launches — with zero runtime output:
+// reusable by AI authoring. It catches the authoring mistakes that produce a
+// flow which LOOKS armed but never launches — with zero runtime output:
 //
 //   1. `objectName` mismatch — the start node targets an object name that is
 //      not defined in this stack. The runtime binds an ObjectQL hook filtered
@@ -23,6 +23,20 @@
 //      deliberately or `'obsolete'` to disable. Only auto-triggered flows are
 //      flagged (manual/screen flows have no arming semantics to be unclear
 //      about).
+//
+//   3. A `config.timeRelative` descriptor that does not PARSE — the shape half
+//      of the time-relative sweep (#5496). Only `TimeRelativeTriggerSchema` can
+//      judge it, and until this rule the only place it ran was BIND time, so an
+//      unparseable descriptor produced one warn in a server log and nothing at
+//      all in `os validate`. The judgement is not re-implemented here: the rule
+//      runs that schema and forwards its issue list verbatim.
+//
+// The spec import is deliberate and is what makes rule 3 possible without a
+// second copy of the descriptor's shape living in this file. It stays inside the
+// package's stated dependency direction — lint → `@objectstack/spec`, never onto
+// a runtime.
+
+import { TimeRelativeTriggerSchema } from '@objectstack/spec/automation';
 
 export type FlowTriggerReadinessSeverity = 'error' | 'warning';
 
@@ -41,6 +55,16 @@ export interface FlowTriggerReadinessFinding {
 export const FLOW_TRIGGER_UNKNOWN_OBJECT = 'flow-trigger-unknown-object';
 export const FLOW_DRAFT_STATUS_AMBIGUOUS = 'flow-draft-status-ambiguous';
 export const FLOW_TRIGGER_UNKNOWN_EVENT = 'flow-trigger-unknown-event';
+/**
+ * #5496 — `config.timeRelative` is present but `TimeRelativeTriggerSchema`
+ * rejects it, so the sweep is never installed.
+ *
+ * Named for the DESCRIPTOR rather than for the rule that reads it, because this
+ * is the first of a family: every flow-node `config` slot whose contract a
+ * schema (or the engine) can already decide, yet which nothing checks at
+ * authoring time. `flow-<descriptor>-<verdict>` is the shape the next one takes.
+ */
+export const FLOW_TIME_RELATIVE_DESCRIPTOR_INVALID = 'flow-time-relative-descriptor-invalid';
 
 type AnyRec = Record<string, unknown>;
 
@@ -76,7 +100,11 @@ function startNodeOf(flow: AnyRec): { node: AnyRec; index: number } | undefined 
 
 /**
  * Validate auto-launched flow trigger wiring against the stack definition.
- * Pure and dependency-free; safe on pre- or post-parse stacks.
+ *
+ * Pure — no I/O, no runtime, no mutation of `stack` — and safe on pre- or
+ * post-parse stacks. Its one dependency is the `@objectstack/spec` schema that
+ * owns the `timeRelative` descriptor's contract, which is the point: the rule
+ * ASKS that schema rather than restating it.
  */
 export function validateFlowTriggerReadiness(stack: AnyRec): FlowTriggerReadinessFinding[] {
   const findings: FlowTriggerReadinessFinding[] = [];
@@ -128,11 +156,32 @@ export function validateFlowTriggerReadiness(stack: AnyRec): FlowTriggerReadines
       }
     }
 
-    // 1b. Time-relative flow sweeping an object this stack does not define. Like
-    //     the record-change case, a wrong object name makes the sweep match
-    //     nothing forever with no runtime output.
+    // 1b. Two facts about the same `config.timeRelative` descriptor, from the two
+    //     places that can decide them. The split is what keeps them from
+    //     reporting the same thing twice:
+    //
+    //       - the NAME in `object` is checked against this stack (1b-i). Only the
+    //         stack knows it; `TimeRelativeTriggerSchema` has no stack knowledge
+    //         and can never raise it.
+    //       - the SHAPE of everything else is checked by that schema (1b-ii).
+    //         Only it knows the descriptor's contract; this rule reads no other
+    //         key of `tr`.
+    //
+    //     So a descriptor that is wrong in both ways reports both, at two
+    //     different paths (`…timeRelative.object` and `…timeRelative`) — two
+    //     facts, not one fact twice.
+    //
+    //     The `isTimeRelative` guard is deliberately the ENGINE's routing
+    //     predicate, character for character (`AutomationEngine`'s trigger
+    //     resolution: `config.timeRelative != null && typeof … === 'object'`).
+    //     This rule therefore speaks for exactly the flows the engine hands to
+    //     the time-relative trigger, and stays silent about the ones it does not.
     if (isTimeRelative && start) {
       const tr = config.timeRelative as AnyRec;
+
+      // 1b-i. Sweeping an object this stack does not define. Like the
+      //     record-change case, a wrong object name makes the sweep match
+      //     nothing forever with no runtime output.
       const objectName = typeof tr.object === 'string' ? tr.object : undefined;
       if (objectName && !objectNames.has(objectName) && !objectName.startsWith('sys_')) {
         findings.push({
@@ -146,6 +195,45 @@ export function validateFlowTriggerReadiness(stack: AnyRec): FlowTriggerReadines
           hint:
             `Object names match exactly. Check config.timeRelative.object against the object's registered name. ` +
             `If the object comes from another installed package, this warning can be ignored.`,
+        });
+      }
+
+      // 1b-ii. #5496 — the descriptor does not parse, so `TimeRelativeTrigger`
+      //     refuses it at bind time and the sweep is never installed. The flow
+      //     declares a time-relative trigger, passes every gate, and never runs.
+      //
+      //     Before this rule the author's ONLY feedback was one warn in the
+      //     server log at bind time — a channel an AI author's loop never reads,
+      //     unlike `os validate`. Nothing is shifted except WHEN the schema runs:
+      //     the verdict, and every word of its wording, is still
+      //     `TimeRelativeTriggerSchema`'s. Re-deriving any of it here would put a
+      //     second copy of the descriptor's contract in a consumer, which is the
+      //     drift this forwards precisely to avoid — `field` is rejected here
+      //     because the SCHEMA rejects it, and it will keep tracking the schema
+      //     when the descriptor gains a key.
+      const parsed = TimeRelativeTriggerSchema.safeParse(tr);
+      if (!parsed.success) {
+        // Rendered exactly as the bind-time warn renders the same issue list
+        // (`TimeRelativeTrigger.start`), so an author who sees both channels sees
+        // one story told twice, not two dialects. Whitespace is collapsed because
+        // a finding is one line here (the CLI prints `• where: message`) while a
+        // log line is free to wrap — the schema's guidance bullets carry newlines.
+        const problems = parsed.error.issues
+          .map((i) => `${i.path.join('.') || '(root)'}: ${i.message.replace(/\s+/g, ' ').trim()}`)
+          .join('; ');
+        findings.push({
+          severity: 'warning',
+          rule: FLOW_TIME_RELATIVE_DESCRIPTOR_INVALID,
+          where: `flow "${flowName}" › start node`,
+          path: `flows[${flowIndex}].nodes[${start.index}].config.timeRelative`,
+          message:
+            `has a config.timeRelative descriptor the time-relative trigger REFUSES at bind time, so the ` +
+            `sweep is never installed — the flow declares a time-relative trigger and then never runs ` +
+            `(the only trace is one warn in the server log). ${problems}`,
+          hint:
+            `Those messages are TimeRelativeTriggerSchema's own — the same schema the trigger safeParses at ` +
+            `bind time, so a descriptor that satisfies them binds. An unrecognized key names the declared key ` +
+            `it was probably meant to be; see content/docs/references/automation/time-relative-trigger.mdx.`,
         });
       }
     }


### PR DESCRIPTION
Fixes #5496

按分诊裁决执行**方案 1**:在 `packages/lint/src/validate-flow-trigger-readiness.ts` 的 §1b 区域新增规则,对非空 `config.timeRelative` 跑 `TimeRelativeTriggerSchema.safeParse`,失败时**逐字转发 zod 的 issue 列表**。判定权唯一留在 schema —— lint 里没有任何一行复写描述符的形状知识。

## 前提复核(先证实,再动手)

issue 正文的前提在当前 `main`(e6b1bb013,#5635 今日改过 `lint-flow-patterns.ts` 之后)**仍然成立**。实测:`task` 对象存在、`status: 'active'`、`runAs: 'system'`,即除描述符外一切合规:

```
validateFlowTriggerReadiness = []
lintFlowPatterns             = []
```

两条 lint 全沉默,原因与正文一致:`lint-flow-patterns.ts:254` 的 `startCfg.timeRelative != null` 只看非空;§1b 只读 `timeRelative.object` 拿去比对 stack 里的对象名。`TimeRelativeTriggerSchema` 确实拒绝这个描述符,但它唯一运行的地方是 **bind 期**(`TimeRelativeTriggerPlugin.start()`:warn 后 `return`)—— sweep 永不装,flow 自称已武装,作者唯一的反馈是服务器日志里的一行。对 AI 作者来说那行完全在反馈回路之外,它读的是 `os validate`。

## 改法

新规则 `flow-time-relative-descriptor-invalid`(severity **warning**,与该文件现行一致):

- 判据刻意与**引擎的路由判据逐字一致**(`AutomationEngine` 的 trigger 解析:`config.timeRelative != null && typeof … === 'object'`),所以规则只为「引擎真正交给 time-relative trigger 的那些 flow」发言,不多说也不少说。
- 诊断把 zod 的 issue 列表按 `path: message` 拼接,**与 bind 期 warn 的渲染方式完全一致**(`TimeRelativeTrigger.start()` 用的就是这个格式),两条通道讲同一个故事、同一种方言。仅做空白折叠:finding 在 CLI 里是一行(`• where: message`),而 schema 的 guidance 分条带换行。
- 因此诊断自带 schema 已经算好的东西:缺失的键名、错误的类型、未知键的「Did you mean」(`field` → `dateField`),以及 wrong-layer 提示(`schedule` 写在描述符**里面**时,告诉作者它是同级兄弟)。
- 唯一被前移的是 schema 运行的**时机**;判定与措辞仍然全部属于 `TimeRelativeTriggerSchema`,所以描述符将来加键时规则自动跟上,不会和第二份副本漂移。没有引入任何消费端宽容(PD #12):不加 `??` 别名、不做 coercion。

`packages/lint/src/index.ts` 补了新规则 id 常量的 barrel 导出(该包只开 `"."` / `"./runtime"` 两个入口,不进 barrel 消费者就拿不到)。

## 三条完成判据(逐条实测,非推断)

**① 坏描述符点名 `config.timeRelative` 且含 zod 键名** —— 把 showcase 的 `Task Due Reminder` 临时改成 issue 正文那个描述符,跑**真的 `os validate`**(已还原):

```
⚠ flow "showcase_task_due_reminder" › start node: has a config.timeRelative descriptor the
time-relative trigger REFUSES at bind time, so the sweep is never installed — the flow declares a
time-relative trigger and then never runs (the only trace is one warn in the server log).
dateField: Invalid input: expected string, received undefined; offsetDays: Invalid input: expected
array, received number; (root): Unrecognized key(s) on this flow start node's `config.timeRelative`
descriptor: `field`. … Did you mean `field` → `dateField`?
      rule: flow-time-relative-descriptor-invalid  at flows[0].nodes[0].config.timeRelative
```

三条 zod issue(`dateField` 缺失、`offsetDays` 需数组、`field` 未知键)全部到位。

**② canonical 描述符零诊断(A/B 实测)** —— 仓库里 **10 个**真实 time-relative 描述符逐个 `safeParse`,全部 spec-valid(showcase `Task Due Reminder`、`content/docs/automation/flows.mdx`、`content/docs/references/automation/time-relative-trigger.mdx` 三个例子、各包测试 fixture)。三个 example app 的 `os validate` 输出改动前后**逐行一致**:

```
##### DIFF app-showcase (before vs after) → IDENTICAL — zero new diagnostics
##### DIFF app-crm      (before vs after) → IDENTICAL — zero new diagnostics
##### DIFF app-todo     (before vs after) → IDENTICAL — zero new diagnostics
```

「before」是真的 before:stash 掉规则、重建 `@objectstack/lint` dist、重跑同一条命令。三个 app 都 exit=0,showcase 输出里 `task_due_reminder` 一次都没出现。

**③ 与 §1b unknown-object 不重复报同一件事** —— 对象名错 + 形状同时错时的实测输出:

```
⚠ … sweeps object 'contract', which this stack does not define — …
      rule: flow-trigger-unknown-object  at flows[0].nodes[0].config.timeRelative.object
⚠ … has a config.timeRelative descriptor the time-relative trigger REFUSES at bind time, …
      dateField: …; (root): Unrecognized key(s) … Did you mean `field` → `dateField`?
      rule: flow-time-relative-descriptor-invalid  at flows[0].nodes[0].config.timeRelative
```

两条 finding、两个 path、两件不同的事:**只有 stack 知道对象名存不存在,只有 schema 知道形状**。schema 没有 stack 知识,永远报不出对象名;这条规则不读 `tr` 的任何其他键,也永远不报形状之外的事。测试里对此双向设了断言(名字那条不提 `dateField`,形状那条不提 `'contract'`)。

## 反向验证(方向是**先预测再跑**的)

预测:把新规则的 `safeParse` 分支停掉,新增的坏描述符用例应该报**零诊断**(而不是报错的诊断)—— 因为这正是 issue 的前提。实测方向一致:

```
× flags the descriptor from #5496 and names every key zod named
  AssertionError: expected [] to have a length of 1 but got +0
× reports a wrong object name and a wrong shape as two facts, not one twice
  expected [ { severity: 'warning', …(5) } ] to have a length of 2 but got 1
(7 failed)
```

值得记一笔:断言「沉默」的那几个用例(canonical 全绿、非对象标量不报)在**没有规则时也通过** —— 它们本来就该那样,所以它们不是这条规则的红证据,真正的红证据是上面那 7 条。恢复后 31/31 全绿。

另设了一条**防漂移 pin**:测试从 schema 现场算出期望的 issue 文本再比对,所以 schema 措辞变了规则输出跟着变、测试照样绿,而手抄一份副本在规则里就不会。

## 验证

| 项 | 结果 |
| --- | --- |
| `pnpm --filter @objectstack/lint test` | 59 files / **1358 passed**(新增 10) |
| `pnpm --filter @objectstack/lint typecheck` | 绿 |
| `pnpm --filter @objectstack/lint build` | 绿 |
| 消费半径 `pnpm --filter @objectstack/cli test` | 82 files / **812 passed** |
| example app A/B ×3 | 逐行一致,零新增诊断 |
| `node scripts/check-nul-bytes.mjs` | OK(5539 files) |
| 控制字节自扫(超出闸门盲区) | 改动文件全清 |
| `eslint` 改动文件 | exit=0 |

## severity 建议

**维持 warning**。跑完真实输出后的实感:后果确实接近 error(声明了 time-relative 触发、运行时永远不绑),但转发的 zod 文案里 `strictObject` 会带上 history 那句(「Until #4001 these were dropped silently — …」),在 error 的显示位上噪音偏大;而且该文件现行规则全是 warning,单独升一条会让 flow 家族的 severity 不成体系。若要升,建议与该文件其他 never-fire 类规则(`flow-trigger-unknown-event`)**同批**升,并单独一个 PR —— 已发布规则 id 的 severity 变更本身就该独立成 PR。

## 边界(都没碰)

- ⛔ 未动 `packages/spec` 的 schema;⛔ 未动 trigger-schedule 的 bind 期行为;⛔ 未动 `lint-flow-patterns.ts` 的 `userLessTriggerKind`(反模式层,分诊已否决方案 2);⛔ 未动 `content/docs/releases/`。
- **#5482 的接缝**:规则 id 取 `flow-{descriptor}-{verdict}` 风格(常量 JSDoc 里写明了这是同族第一条、下一条照此取名),落位留在 §1b 之后、§1c 之前的相邻空间。⛔ 未实现、未预埋它的任何逻辑。
- 一个建后即弃的副作用需要 reviewer 知道:构建 `@objectstack/spec` 会让 `gen:schema` 重写 `packages/spec/authorable-surface.base.json`(重锚 baseRev)。那不是本 PR 的改动,已 revert,不在 diff 里。

## changeset

`.changeset/flow-time-relative-descriptor-lint.md` —— `"@objectstack/lint": patch`。

## 范围外发现(已另开,均未指派)

- **#5647** —— 标量 `config.timeRelative`(如 `timeRelative: 'daily'`)时引擎解析不出任何 trigger,flow 永不触发且**全层零输出**(连 bind 期 warn 都没有,比本单修的缺口还差一档)。与 #3481 同构。不在本 PR 修:覆盖它需要放宽 `isTimeRelative`,而该变量同时喂 §1b 的 unknown-object 规则和 `isAutoTriggered`(draft-status 规则),会改变另外两条已发布规则的覆盖面。已实测证实沉默,非推断。
- **#5648**(`finding` 标签,观察类)—— `FLOW_TRIGGER_UNKNOWN_EVENT` 规则 id 常量没进 barrel,消费者拿不到,只能对字面量。本 PR 只补了自己新增的那一行,补别人的漏项属范围外。