### PR TITLE
test(driver-sql): LIKE-escape 守卫接入 live PG + MySQL 方言矩阵，补字面反斜杠用例 (#5589)

### DIFF
--- a/packages/drivers/driver-sql/src/sql-driver-like-escape.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-like-escape.test.ts
@@ -1,7 +1,84 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+/**
+ * LIKE-metacharacter escaping for the `$contains` family — the guard on
+ * `SqlDriver.applyLike`, whose own TSDoc calls an unescaped `%` a filter bypass
+ * and grades it P0.
+ *
+ * Two layers, and they are not the same assertion:
+ *
+ *  1. **The P0-3 regression** (below, hard-coded `better-sqlite3`) — the one
+ *     that must run on every `pnpm test`, on any machine, with no server to
+ *     provision. It is the default-path guard and is deliberately NOT replaced
+ *     by the matrix.
+ *  2. **The DRIVER axis** (#5589, ADR-0053 D-A3) — the same predicates re-run
+ *     once per cell of `DIALECT_CELLS`, plus the literal-backslash case, on
+ *     whatever live engines the runner provisioned.
+ *
+ * # Why the second layer exists (#5589)
+ *
+ * `applyLike` binds an explicit `ESCAPE ?` precisely BECAUSE the three shipped
+ * dialects disagree about what a backslash means inside a LIKE pattern:
+ * Postgres defaults to backslash, MySQL assumes `\` unless `NO_BACKSLASH_ESCAPES`
+ * is set, and SQLite honours NO default escape character at all. Layer 1 covered
+ * exactly one of those three — and it was the end of the range with the *least*
+ * to say, since on SQLite nothing is an escape character until the clause says
+ * so. A dialect-specific miscompile of a P0 filter bypass had nothing to fail.
+ *
+ * The infrastructure to fix that was already here and already wired into CI: the
+ * `Temporal Conformance (live PG + MySQL)` job runs this whole package against
+ * Postgres 16 and MySQL 8.0 with `OS_TEST_POSTGRES_URL` / `OS_TEST_MYSQL_URL`
+ * set, and `live-dialect-matrix.testkit.ts` is the shared cell list every other
+ * matrix consumer iterates. Layer 1 simply never joined — the LIKE family was
+ * 0 of the 8 files reading those URLs. No new CI job is needed here either.
+ *
+ * A cell nobody provisioned is a named skip, and a red under
+ * `OS_EXPECT_LIVE_DIALECT_MATRIX=1` (`declareUnprovisionedCell`): a matrix that
+ * silently found zero live cells must not report OK (#4646).
+ *
+ * # What the live cells prove that SQLite cannot
+ *
+ * Stated precisely, because the temptation is to overclaim — and #5589 assumed
+ * the opposite, that the backslash case could not go before-red/after-green on
+ * SQLite at all. Measured: it can. Deleting the `\\` limb of the escaped
+ * character class turns the case red on the SQLite cell alone (the pattern
+ * degenerates to `%\%`, whose trailing wildcard the backslash consumes, so the
+ * answer is `[]` rather than `['bsl']`), while the other three stay green. The
+ * bound `ESCAPE '\'` puts every dialect under one rule, which is the whole
+ * design, so the ARITHMETIC is decidable in-process. What only a live cell can
+ * decide is whether the *transport* preserves that rule:
+ *
+ *   - **MySQL, the `ESCAPE` argument.** The manual requires it to "evaluate as a
+ *     constant at execution time". `applyLike` binds a placeholder. Through
+ *     knex + mysql2's default `query()` path it is interpolated client-side into
+ *     a literal and the constraint holds — but that was an INFERENCE from the
+ *     driver's code path, never an execution. The mysql cell executes it.
+ *   - **MySQL, the backslash's second life.** MySQL applies C escape syntax
+ *     inside string literals, so the one backslash this code binds has to survive
+ *     mysql2's own escaping and the server's lexer before LIKE ever sees it.
+ *     Only a real server round-trip can show the count came out right.
+ *   - **Postgres.** `standard_conforming_strings`, and the fact that a bound
+ *     parameter is not a string literal at all, are likewise claims about a
+ *     wire protocol rather than about this file's arithmetic.
+ *
+ * So the literal-backslash case is the interesting cell of the four, and its
+ * value is concentrated on `live mysql` / `live postgres`. That is a statement
+ * about which cells carry the new information, NOT a claim that the SQLite cell
+ * is decorative — it pins the `\` limb of the escaped character class exactly as
+ * hard as the others do.
+ *
+ * (Nothing here is temporal, so the D-B3 server-timezone axis does not apply —
+ * requiring a non-UTC server would only manufacture reds that say nothing about
+ * LIKE. Same call as `sql-driver-or-filter.test.ts` and the pagination matrix.)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
 import { SqlDriver } from '../src/index.js';
+import {
+  DIALECT_CELLS,
+  declareUnprovisionedCell,
+  type DialectCell,
+} from './live-dialect-matrix.testkit.js';
 
 /**
  * P0-3 regression: the `contains` / `$contains` operator must escape LIKE
@@ -49,3 +126,128 @@ describe('SqlDriver — contains escapes LIKE metacharacters (P0-3)', () => {
     expect(r.map((x: any) => x.id)).toEqual(['1']);
   });
 });
+
+// ── The driver axis (#5589, ADR-0053 D-A3) ──────────────────────────────────
+
+/**
+ * Issue-prefixed table name: the live cells share one database with every other
+ * suite in this package (and with each other's runs), so the bare `docs` layer 1
+ * can afford on an in-memory SQLite would be a collision waiting to be read as a
+ * filter-bypass regression.
+ */
+const LIKE_TABLE = 'os5589_like_escape';
+
+/**
+ * The fixture rows, one per metacharacter under test plus one carrying none.
+ *
+ * Each row is the ONLY row that its case's expected answer names, so a widening
+ * miscompile (which is the failure mode: every LIKE defect here matches MORE
+ * rows, never fewer) cannot be mistaken for a pass.
+ */
+const LIKE_ROWS = [
+  { id: 'pct', title: '50% off sale' }, // literal %
+  { id: 'plain', title: 'plain title' }, // no metacharacter
+  { id: 'us', title: 'a_b underscore' }, // literal _
+  { id: 'bsl', title: 'C:\\logs' }, // literal backslash — one, not two
+] as const;
+
+interface LikeEscapeCase {
+  readonly name: string;
+  /** The comparand a user typed, as a LITERAL. */
+  readonly value: string;
+  readonly expected: readonly string[];
+  readonly note: string;
+}
+
+const LIKE_ESCAPE_CASES: readonly LikeEscapeCase[] = [
+  {
+    name: 'a "%" value matches only rows containing a literal %, not every row',
+    value: '%',
+    expected: ['pct'],
+    note: 'an unescaped % expands to %%% and matches every row — the P0 filter bypass',
+  },
+  {
+    name: 'a "_" value matches only rows containing a literal _, not any single char',
+    value: '_',
+    expected: ['us'],
+    note: 'an unescaped _ is LIKE\'s single-character wildcard, so %_% matches every non-empty row',
+  },
+  {
+    name: 'an ordinary substring still matches normally',
+    value: 'sale',
+    expected: ['pct'],
+    note: 'the escaping must not break the ordinary case it wraps',
+  },
+  {
+    name: 'a "\\" value matches only rows containing a literal backslash',
+    value: '\\',
+    expected: ['bsl'],
+    note:
+      'the escape character itself, escaped: the pattern reaching the server must carry TWO ' +
+      'backslashes and the bound ESCAPE argument exactly ONE. Drop the `\\\\` limb of the escaped ' +
+      'character class and the pattern degenerates to `%\\%` — whose trailing wildcard is eaten ' +
+      'by the backslash, leaving "anything, then a literal % at end of string", which answers ' +
+      'NO row here (measured on the sqlite cell: []). On MySQL this is also the case that ' +
+      'executes, rather than infers, that the bound ESCAPE placeholder satisfies "constant at ' +
+      'execution time" and that one backslash survives client-side interpolation plus the ' +
+      'server lexer',
+  },
+];
+
+for (const cell of DIALECT_CELLS) {
+  if (!cell.available) {
+    declareUnprovisionedCell(cell, 'LIKE-metacharacter escape');
+    continue;
+  }
+  declareLikeEscapeSweep(cell);
+}
+
+function declareLikeEscapeSweep(cell: DialectCell): void {
+  describe(`SqlDriver LIKE-metacharacter escape (${cell.label})`, () => {
+    let driver: SqlDriver;
+    let knexInstance: any;
+
+    beforeAll(async () => {
+      driver = new SqlDriver(cell.config());
+      knexInstance = (driver as any).knex;
+
+      // Live cells reuse one database, so the sweep starts from a dropped table.
+      await knexInstance.schema.dropTableIfExists(LIKE_TABLE);
+      await knexInstance.schema.createTable(LIKE_TABLE, (t: any) => {
+        t.string('id').primary();
+        t.string('title');
+      });
+      await knexInstance(LIKE_TABLE).insert([...LIKE_ROWS]);
+    });
+
+    afterAll(async () => {
+      await knexInstance?.schema.dropTableIfExists(LIKE_TABLE).catch(() => {});
+      await driver?.disconnect?.();
+    });
+
+    /**
+     * The fixture must have landed as typed before any verdict below means
+     * anything. A backslash that mysql2 or the server lexer ate on the way IN
+     * would make the `\` case fail for a reason that has nothing to do with
+     * `applyLike` — and, worse, a doubled one would make it PASS for the wrong
+     * reason on a build that had stopped escaping.
+     */
+    it('stored the fixture backslash as exactly one character', async () => {
+      const rows = await knexInstance(LIKE_TABLE).where({ id: 'bsl' }).select('title');
+      expect(String(rows[0]?.title)).toBe('C:\\logs');
+    });
+
+    for (const c of LIKE_ESCAPE_CASES) {
+      it(c.name, async () => {
+        const rows = await driver.find(LIKE_TABLE, {
+          object: LIKE_TABLE,
+          where: { title: { $contains: c.value } },
+        });
+        const got = rows
+          .map((r: any) => String(r.id))
+          .sort((x: string, y: string) => x.localeCompare(y));
+        expect(got, c.note).toEqual([...c.expected]);
+      });
+    }
+  });
+}


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5589

Test-only。无任何运行时改动，`sql-driver.ts` 一个字节都没动。

## 前提复核（issue 是线索不是规格）

issue 写于 #4645 Phase A 之前，引用的是旧路径。基于当前 `origin/main`（`7bf3d1ce2`）重核，结论：**前提全部成立，只有路径与行号偏移**。

| issue 的说法 | 复核结果 |
|---|---|
| `applyLike` 在 `packages/plugins/driver-sql/src/sql-driver.ts` ~:6276 | 现居 `packages/drivers/driver-sql/src/sql-driver.ts:6292`（Phase A 已 MERGED，`06ba03627`）；注释里的 "a filter-bypass, P0" 与绑定的 `ESCAPE ?` 与描述一致 |
| 守卫 `sql-driver-like-escape.test.ts` 硬编码单一方言 | 成立：`client: 'better-sqlite3'`, `connection: { filename: ':memory:' }` |
| 读两个 live URL 的测试文件共 8 个 | 成立，逐字符相同的 8 个文件（含 testkit 本身） |
| 其中提及 `$contains` / `LIKE` / `startsWith` / `endsWith` 的：0 个 | 成立（grep 覆盖这四个词，命中数 0） |
| CI 的 `Temporal Conformance (live PG + MySQL)` 已跑整个 driver-sql 套件并注入两个 URL + `OS_EXPECT_LIVE_DIALECT_MATRIX=1` | 成立（`.github/workflows/ci.yml:378` 起；测试步骤跑 `pnpm --filter @objectstack/driver-sql test`） |

所以缺的确实不是基础设施，只是没接线。**不新增 CI 作业。**

## 改了什么

单文件：`packages/drivers/driver-sql/src/sql-driver-like-escape.test.ts`。

1. **既有 SQLite 硬编码守卫原样保留**（一行未改）。它是「任何机器、任何 `pnpm test`、不需要 provision 任何东西」路径上唯一必跑的那份；矩阵是它的**扩展不是替代**。
2. **新增方言轴**：三个既有用例（字面 `%` / 字面 `_` / 普通子串）按 `DIALECT_CELLS` 逐 cell 重跑，表名带 issue 前缀 `os5589_like_escape`（live cell 与本包其它套件共库，裸表名会把撞名读成过滤器旁路回归）。
3. **补第四个用例：字面 `\`** —— 转义符自身。这是 MySQL 那两条约束从「推断」变成「实测」的地方：手册要求 `ESCAPE` 实参 "must evaluate as a constant at execution time"，以及 MySQL 在字符串字面量里应用 C 转义语法（那一个反斜杠要挺过 mysql2 的客户端转义 + 服务端 lexer 才轮得到 LIKE 看见）。
4. **fixture 完整性断言前置**：先断言 `C:\logs` 存进去是**一个**反斜杠。进库路上被吃掉的反斜杠会让 `\` 用例因为跟 `applyLike` 毫无关系的原因变红；更糟的是被加倍的那种，会让一个已经停止转义的构建**因为错误的理由变绿**。
5. 未 provision 的 cell 走 testkit 既有的 `declareUnprovisionedCell` —— 具名 skip，在 `OS_EXPECT_LIVE_DIALECT_MATRIX=1` 下转具名红。新用例自动落在这个语义里。

D-B3 服务器时区轴**不引入**：这里没有任何时间量，要求非 UTC 服务器只会制造与 LIKE 无关的红。与 `sql-driver-or-filter.test.ts` / 分页矩阵同一判断。

## 反向验证：预测方向 = 实测方向，但 issue 的那句话被证伪

**先定方向后跑**：预测「删掉转义字符类里的 `\\` 那一支 → 新的字面 `\` 用例在 SQLite cell 上变红，其余三个保持绿」。

实测**完全命中**（`applyLike` 的 `/[\\%_]/g` 临时改成 `/[%_]/g`）：

```
FAIL  SqlDriver LIKE-metacharacter escape (sqlite) > a "\" value matches only rows containing a literal backslash
AssertionError: ... expected [] to deeply equal [ 'bsl' ]
Tests  1 failed | 7 passed | 2 skipped (10)
```

两处需要如实纠正，都已写进代码注释而不是留给下一个读者去踩：

- **issue 说这一格「无法在 SQLite 上做前红后绿」—— 不成立。** 因为 `applyLike` 绑的是**显式** `ESCAPE`，三方言被放进同一条规则，所以这一格的**算术**在进程内就可判定，SQLite 能前红后绿。live cell 真正独占的不是算术，是**传输**：绑定参数经 mysql2 插值 / PG 协议之后，那一个反斜杠和 `ESCAPE` 实参是否还成立。注释里把这个区分写死了，免得把 SQLite cell 读成装饰品。
- **收到的值是 `[]`，不是我原先注释里写的 `['pct']`。** 因为 pattern 退化成 `%\%` 时，`contains` 形状**结尾的那个通配符被反斜杠吃掉了**，语义变成「任意内容 + 结尾一个字面 `%`」，本 fixture 无行命中。注释已按实测改写。

## 本地能证明什么、不能证明什么

⚠️ **本容器没有 live PG / MySQL。** 本地已证明的：

| 项 | 结果 |
|---|---|
| 默认模式（无 URL） | `Tests  8 passed \| 2 skipped (10)` —— sqlite cell 4 个用例 + fixture 断言全绿，两个 live cell 具名 skip |
| `OS_EXPECT_LIVE_DIALECT_MATRIX=1` 且缺 URL | `Tests  2 failed \| 8 passed` —— 两个 live cell 转具名红，消息点名 `OS_TEST_POSTGRES_URL` / `OS_TEST_MYSQL_URL` 与 ADR-0053 D-A3 |
| driver-sql 包全量 | `Test Files  63 passed \| 4 skipped (67)` / `Tests  860 passed \| 46 skipped (906)` |
| `pnpm --filter @objectstack/driver-sql typecheck` | 绿（`tsc --noEmit` 无输出） |
| `eslint --no-inline-config` 变更文件 | 绿 |
| `check:query-options-erasure` | `test surface: 267 site(s) ... at the ceiling`，未涨 |
| `check:nul-bytes`（含 `--self-test`）+ 变更文件控制字节自扫 | 绿 / 无命中 |
| `check:adr-anchors` | 绿 |

**两个 live 方言的真实执行只会发生在 CI 的 `Temporal Conformance (live PG + MySQL)` 作业里。该作业绿是本 PR 的合并前提。**

若该作业在这两个新 cell 上变红，那个失败输出就是本单最有价值的产出（很可能坐实 issue 第 2 点的 MySQL `ESCAPE` 约束问题）—— 届时按 Prime Directive #10 另立单，⛔ **不在本 PR 里改实现**。

## 未验证

- 未核实 knex + mysql2 在本仓配置下是否可能走服务端预处理 `execute()` 路径（issue 自己也把这条列为未验证）。本 PR 只让当前路径**被执行**，不对该路径的选择做任何断言。
- `$notContains` / `$startsWith` / `$endsWith` 三个 shape 未接入矩阵：它们与 `$contains` 共用同一个 `applyLike` 转义表达式，shape 只决定 `%` 的位置。按 issue + 分诊的范围面（三个既有用例 + 一个 `\`）收口，不扩。

## 标签

test-only，请挂 `skip-changeset`（本 agent 无标签写权限，PM 代挂）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01WyvqvKMG6asi9aXjKE6xtx)_