### PR TITLE
test(driver-turso): 双传输各跑一遍 FILTER_LOGIC / PAGINATION 共享 case-set，清掉三条 DEBT (#5590)

### DIFF
--- a/packages/drivers/driver-turso/src/turso-filter-logic-conformance.test.ts
+++ b/packages/drivers/driver-turso/src/turso-filter-logic-conformance.test.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Filter logical-combinator conformance for TursoDriver in LOCAL mode (#3774,
+ * #5590) — the shared `@objectstack/spec/data` cases, run through this
+ * driver's own pipeline.
+ *
+ * `TursoDriver extends SqlDriver`, so in local (and replica — same local
+ * engine) mode the `$and` / `$or` / `$not` compilation is inherited and
+ * nothing here re-implements it. Two things this file pins are nonetheless
+ * this package's own, and would fail in no other suite in the repo:
+ *
+ * 1. **The transport router.** Every read method on this driver is an
+ *    `override` that branches on `this.isRemote` before it reaches
+ *    `super.find`. A branch that sent a local read down the remote path — or
+ *    a `toRemoteQuery` that ran on a query it was never meant to touch —
+ *    changes which compiler answers a filter, and only a row-result assertion
+ *    can see that.
+ * 2. **The temporal seam the constructor installs.** `filterColumnSql`
+ *    rewrites the SQL on the LEFT of a comparison for temporal columns
+ *    (ADR-0053 D-A1, #937). Every column in {@link FILTER_LOGIC_ROWS} is a
+ *    plain string, so the seam must leave all of them alone; a rewrite that
+ *    over-reached would corrupt exactly the boring predicates this table is
+ *    built from.
+ *
+ * "It inherits the compiler, therefore it is fine" is the assumption the
+ * shared case-sets exist to disprove — `driver-sqlite-wasm` recorded this same
+ * cell as DEBT for that reason and cleared it with a suite, not with the
+ * sentence. The REMOTE half of this driver inherits nothing at all and gets
+ * its own file (`turso-remote-filter-logic-conformance.test.ts`), the same
+ * two-transport shape the temporal suites next door already use.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { FILTER_LOGIC_CASES, FILTER_LOGIC_ROWS } from '@objectstack/spec/data';
+import { TursoDriver } from './turso-driver.js';
+
+const CONFORMANCE_OBJECT = {
+  name: 'conformance',
+  fields: {
+    a: { type: 'string' },
+    b: { type: 'string' },
+    c: { type: 'string' },
+    owner: { type: 'string' },
+    status: { type: 'string' },
+    parent_object: { type: 'string' },
+    parent_id: { type: 'string' },
+  },
+};
+
+const ids = (rows: Array<Record<string, unknown>>): string[] =>
+  rows.map((r) => String(r.id)).sort((x, y) => x.localeCompare(y));
+
+describe('TursoDriver — filter logic conformance (local mode)', () => {
+  let driver: TursoDriver;
+
+  beforeAll(async () => {
+    driver = new TursoDriver({ url: ':memory:' });
+    // The mode this suite is about — the SqlDriver-inherited engine. Replica
+    // shares it; remote does not (see module doc).
+    expect(driver.transportMode).toBe('local');
+    await driver.initObjects([CONFORMANCE_OBJECT]);
+    for (const row of FILTER_LOGIC_ROWS) {
+      await driver.create('conformance', { ...row }, { bypassTenantAudit: true });
+    }
+  });
+
+  afterAll(async () => {
+    await driver.disconnect();
+  });
+
+  /**
+   * The fixture as a whole, first: a case that returns nothing because the
+   * seed failed must not read as a case that correctly excluded everything.
+   */
+  it('the fixture really is all four rows', async () => {
+    const rows = await driver.find('conformance', { object: 'conformance' });
+    expect(ids(rows)).toEqual(['1', '2', '3', '4']);
+  });
+
+  for (const c of FILTER_LOGIC_CASES) {
+    it(c.name, async () => {
+      const rows = await driver.find(
+        'conformance',
+        { object: 'conformance', where: c.filter },
+        { bypassTenantAudit: true },
+      );
+      expect(ids(rows), c.note).toEqual([...c.expected]);
+    });
+  }
+});

--- a/packages/drivers/driver-turso/src/turso-pagination-conformance.test.ts
+++ b/packages/drivers/driver-turso/src/turso-pagination-conformance.test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Deterministic paged reads for TursoDriver in LOCAL mode (objectui#3106,
+ * #4363, #5590) — the contract on `IDataDriver.find`, run against the shared
+ * `@objectstack/spec/data` cases like every other driver.
+ *
+ * `TursoDriver extends SqlDriver`, so the tie-breaking ORDER BY is *built* by
+ * inherited code and nothing here re-implements it. What this pins is that it
+ * still reaches the engine on this driver: every read method is an `override`
+ * that branches on `this.isRemote` before delegating to `super.find`, so the
+ * inherited clause travels through one more layer here than it does in the
+ * base package. A router that mangled or bypassed the query — or a future
+ * override that rebuilt the paged read itself — would produce exactly the
+ * failure the contract rules out (full pages, real rows, one served twice and
+ * one never served), and it would fail in no other suite in the repo.
+ *
+ * The REMOTE transport keeps its own file
+ * (`turso-remote-pagination-conformance.test.ts`): it does not go through knex
+ * at all and assembles its own ORDER BY / LIMIT / OFFSET, which is a second
+ * implementation of this contract rather than a second engine under the same
+ * one.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  PAGINATION_ALL_IDS,
+  PAGINATION_CASES,
+  PAGINATION_ROWS,
+  PAGINATION_UNORDERED_CASES,
+} from '@objectstack/spec/data';
+import { TursoDriver } from './turso-driver.js';
+
+const TICKET_OBJECT = {
+  name: 'ticket',
+  fields: {
+    status: { type: 'string' },
+    rank: { type: 'integer' },
+    name: { type: 'string' },
+  },
+};
+
+describe('TursoDriver — paged reads are a partition of the result set (local mode)', () => {
+  let driver: TursoDriver;
+
+  beforeAll(async () => {
+    driver = new TursoDriver({ url: ':memory:' });
+    expect(driver.transportMode).toBe('local');
+    await driver.initObjects([TICKET_OBJECT]);
+    for (const row of PAGINATION_ROWS) {
+      await driver.create('ticket', { ...row }, { bypassTenantAudit: true });
+    }
+  });
+
+  afterAll(async () => {
+    await driver.disconnect();
+  });
+
+  /** Walk the whole table page by page, collecting the ids in visit order. */
+  const walk = async (
+    pageSize: number,
+    orderBy?: ReadonlyArray<{ field: string; order: 'asc' | 'desc' }>,
+  ): Promise<string[]> => {
+    const seen: string[] = [];
+    for (let offset = 0; offset < PAGINATION_ROWS.length; offset += pageSize) {
+      const page: Array<Record<string, unknown>> = await driver.find(
+        'ticket',
+        { ...(orderBy ? { orderBy: [...orderBy] } : {}), limit: pageSize, offset },
+        { bypassTenantAudit: true },
+      );
+      seen.push(...page.map((r) => String(r.id)));
+    }
+    return seen;
+  };
+
+  it('the fixture really is all twelve rows', async () => {
+    const rows: Array<Record<string, unknown>> = await driver.find(
+      'ticket',
+      { object: 'ticket' },
+      { bypassTenantAudit: true },
+    );
+    expect(rows.map((r) => String(r.id)).sort()).toEqual([...PAGINATION_ALL_IDS].sort());
+  });
+
+  for (const testCase of PAGINATION_CASES) {
+    it(`visits every row exactly once — ${testCase.name}`, async () => {
+      const seen = await walk(testCase.pageSize, testCase.orderBy);
+      expect(seen).toHaveLength(PAGINATION_ALL_IDS.length);
+      expect(new Set(seen).size).toBe(PAGINATION_ALL_IDS.length);
+      expect([...seen].sort()).toEqual([...PAGINATION_ALL_IDS].sort());
+    });
+
+    it(`page boundaries are invisible — ${testCase.name}`, async () => {
+      const paged = await walk(testCase.pageSize, testCase.orderBy);
+      const whole: Array<Record<string, unknown>> = await driver.find(
+        'ticket',
+        { orderBy: [...testCase.orderBy] },
+        { bypassTenantAudit: true },
+      );
+      expect(paged).toEqual(whole.map((r) => String(r.id)));
+    });
+  }
+
+  for (const testCase of PAGINATION_UNORDERED_CASES) {
+    it(`visits every row exactly once with NO orderBy at all — ${testCase.name}`, async () => {
+      const seen = await walk(testCase.pageSize);
+      expect(seen).toHaveLength(PAGINATION_ALL_IDS.length);
+      expect(new Set(seen).size).toBe(PAGINATION_ALL_IDS.length);
+      expect([...seen].sort()).toEqual([...PAGINATION_ALL_IDS].sort());
+    });
+
+    it(`walks an unsorted read in id order — ${testCase.name}`, async () => {
+      // The fixture's ids are shuffled relative to insertion order, so this
+      // distinguishes "the inherited tie-breaking ORDER BY reached the engine"
+      // from "SQLite happened to hand back rowid order".
+      expect(await walk(testCase.pageSize)).toEqual([...PAGINATION_ALL_IDS].sort());
+    });
+  }
+
+  it('leaves an UNPAGED unordered read alone — no sort is imposed on a caller who asked for none', async () => {
+    const rows: Array<Record<string, unknown>> = await driver.find(
+      'ticket',
+      {},
+      { bypassTenantAudit: true },
+    );
+    expect(rows.map((r) => String(r.id))).toEqual(PAGINATION_ROWS.map((r) => r.id));
+  });
+});

--- a/packages/drivers/driver-turso/src/turso-remote-filter-logic-conformance.test.ts
+++ b/packages/drivers/driver-turso/src/turso-remote-filter-logic-conformance.test.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Filter logical-combinator conformance for TursoDriver's REMOTE transport
+ * (#3774, #5590) — the shared `@objectstack/spec/data` cases, on rows.
+ *
+ * The local twin of this suite passes largely by INHERITANCE: `TursoDriver
+ * extends SqlDriver`, so `applyFilterCondition` compiles the combinators.
+ * Remote mode inherits none of it. `RemoteTransport.buildWhereSQL`
+ * (`src/remote-transport.ts`) is an independent filter compiler — its own
+ * `$and` / `$or` / `$not` nesting, its own operator vocabulary, its own
+ * comparand refusal, its own identity elements for the empty combinators. It
+ * is the "independent Nth backend" #3774 wrote this table for, and the seam
+ * has demonstrably diverged before: six semantic fixes landed in this one
+ * function while the package lived in `objectstack-ai/cloud` (#1071, #1074,
+ * #1078, #1080, #1116, #1117), every one of them a case where remote answered
+ * a filter differently from local.
+ *
+ * That history is also why the boolean-identity rows matter here more than
+ * anywhere else. `$and: []` is TRUE, `$or: []` is FALSE, a `{}` disjunct
+ * absorbs its `$or`, and `$not: {}` is FALSE (the #5322 ruling) — this
+ * transport reaches each of those through a *hand-written* branch rather than
+ * through knex, and "compiled to no clause" is the same string for TRUE and
+ * for "something was silently dropped". A dropped predicate leaves valid SQL,
+ * just wider, so it is invisible to a SQL-string assertion; only the row set
+ * tells them apart, which is what this file compares.
+ *
+ * ## Why a SQLite-backed client stub
+ *
+ * Same reason as the remote temporal suite next door: libsql IS SQLite, so
+ * `makeLibsqlSqliteStub` gives the transport real value and ordering semantics
+ * with no network and no credentials. The network itself stays the concern of
+ * the suites that mock `execute` and assert on the SQL string.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { FILTER_LOGIC_CASES, FILTER_LOGIC_ROWS } from '@objectstack/spec/data';
+import { TursoDriver } from './turso-driver.js';
+import { makeLibsqlSqliteStub, type LibsqlSqliteStub } from './libsql-sqlite-stub.testkit.js';
+
+const CONFORMANCE_OBJECT = {
+  name: 'conformance',
+  fields: {
+    a: { type: 'string' },
+    b: { type: 'string' },
+    c: { type: 'string' },
+    owner: { type: 'string' },
+    status: { type: 'string' },
+    parent_object: { type: 'string' },
+    parent_id: { type: 'string' },
+  },
+};
+
+const ids = (rows: Array<Record<string, unknown>>): string[] =>
+  rows.map((r) => String(r.id)).sort((x, y) => x.localeCompare(y));
+
+describe('TursoDriver remote — filter logic conformance', () => {
+  let driver: TursoDriver;
+  let stub: LibsqlSqliteStub;
+
+  beforeAll(async () => {
+    stub = makeLibsqlSqliteStub();
+    driver = new TursoDriver({ url: 'libsql://conformance.turso.io', client: stub as never });
+    await driver.connect();
+    // The mode this suite is about — the one that inherits nothing.
+    expect(driver.transportMode).toBe('remote');
+    // `syncSchema` is what creates the table and registers the field metadata
+    // in remote mode (`registerRemoteFieldMetadata`); there is no `initObjects`
+    // DDL path here.
+    await driver.syncSchema(CONFORMANCE_OBJECT.name, CONFORMANCE_OBJECT);
+    for (const row of FILTER_LOGIC_ROWS) {
+      await driver.create('conformance', { ...row });
+    }
+  });
+
+  afterAll(async () => {
+    await driver.disconnect();
+    stub.close();
+  });
+
+  /**
+   * The fixture as a whole, first — and read below the transport, so a case
+   * that returns nothing because the seed never landed cannot read as a case
+   * that correctly excluded everything.
+   */
+  it('the fixture really is all four rows, as stored', () => {
+    const rows = stub.raw.prepare('select id, a, b, c from conformance order by id').all() as Array<{
+      id: string;
+      a: string;
+      b: string;
+      c: string;
+    }>;
+    expect(rows.map((r) => r.id)).toEqual(['1', '2', '3', '4']);
+    for (const row of rows) {
+      const seeded = FILTER_LOGIC_ROWS.find((r) => r.id === row.id)!;
+      expect([row.a, row.b, row.c], row.id).toEqual([seeded.a, seeded.b, seeded.c]);
+    }
+  });
+
+  for (const c of FILTER_LOGIC_CASES) {
+    it(c.name, async () => {
+      const rows = await driver.find('conformance', { where: c.filter });
+      expect(ids(rows), c.note).toEqual([...c.expected]);
+    });
+  }
+
+  /**
+   * `count()` compiles its WHERE through the same `buildWhereSQL` but a
+   * different statement builder, so a combinator that is right for `find` can
+   * still be wrong for `count` — which is how a list view shows a page of rows
+   * under a total that disagrees with it. One assertion over the whole table
+   * rather than a second copy of it.
+   */
+  it('count() answers the same row set find() does, case for case', async () => {
+    for (const c of FILTER_LOGIC_CASES) {
+      expect(await driver.count('conformance', { where: c.filter }), c.name).toBe(c.expected.length);
+    }
+  });
+});

--- a/packages/drivers/driver-turso/src/turso-remote-pagination-conformance.test.ts
+++ b/packages/drivers/driver-turso/src/turso-remote-pagination-conformance.test.ts
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Deterministic paged reads for TursoDriver's REMOTE transport (objectui#3106,
+ * #4363, #5590) — the shared `@objectstack/spec/data` cases, on rows.
+ *
+ * The local twin of this suite passes by INHERITANCE: `TursoDriver extends
+ * SqlDriver`, so `orderKeysFor()` appends the `id` tie-breaker to every paged
+ * read. Remote mode inherits nothing — `RemoteTransport.buildSelectSQL`
+ * assembles its own ORDER BY / LIMIT / OFFSET — which makes it a second
+ * implementation of this contract inside ONE driver, selected by URL alone.
+ * That is exactly the shape #4363 wrote these cases for.
+ *
+ * ## What this suite measured, stated plainly
+ *
+ * Both case-sets pass here, and they do NOT pass for the reason the local
+ * twin's do. `buildSelectSQL` maps the caller's `orderBy` entries verbatim and
+ * appends no unique column, so:
+ *
+ * - a sorted paged read goes out as `ORDER BY status LIMIT ? OFFSET ?`, and
+ *   the ties come back in storage order rather than id order;
+ * - an unsorted paged read goes out with no ORDER BY at all.
+ *
+ * The property holds on this fixture because the stub is `better-sqlite3` over
+ * a twelve-row in-memory table: one plan, one arrangement, every time. On a
+ * real endpoint the arrangement of equal keys across two statements is not
+ * promised — the case-set's own module doc says so, and names the unsorted
+ * read as the same defect at full strength rather than as an exemption. The
+ * `driver-memory` carve-out ("storage order steady between reads") is about a
+ * JS array, not a SQL plan.
+ *
+ * So the honest reading of a green run here is: **the transport currently
+ * satisfies the cases without implementing the mechanism the contract asks
+ * for.** That gap is filed as #5653, and the two `records the measured
+ * mechanism` tests below pin it — they assert the tie arrangement IS storage
+ * order, so the day #5653 lands they go red and get updated with it, instead
+ * of the divergence sitting here undocumented under a green suite. Fixing the
+ * transport is deliberately not this file's job (#5590's boundary: write the
+ * suite, do not grade your own paper).
+ *
+ * ## Why a SQLite-backed client stub
+ *
+ * Same instrument, same reason as the remote temporal and filter-logic suites:
+ * these are row-order assertions, and a lost ORDER BY leaves the SQL perfectly
+ * valid — so a SQL-string assertion sails past it. libsql IS SQLite, so the
+ * stub gives the transport real ordering semantics with no network and no
+ * credentials.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  PAGINATION_ALL_IDS,
+  PAGINATION_CASES,
+  PAGINATION_ROWS,
+  PAGINATION_UNORDERED_CASES,
+} from '@objectstack/spec/data';
+import { TursoDriver } from './turso-driver.js';
+import { makeLibsqlSqliteStub, type LibsqlSqliteStub } from './libsql-sqlite-stub.testkit.js';
+
+const TICKET_OBJECT = {
+  name: 'ticket',
+  fields: {
+    status: { type: 'string' },
+    rank: { type: 'integer' },
+    name: { type: 'string' },
+  },
+};
+
+describe('TursoDriver remote — paged reads are a partition of the result set', () => {
+  let driver: TursoDriver;
+  let stub: LibsqlSqliteStub;
+
+  beforeAll(async () => {
+    stub = makeLibsqlSqliteStub();
+    driver = new TursoDriver({ url: 'libsql://conformance.turso.io', client: stub as never });
+    await driver.connect();
+    // The mode this suite is about — the one that assembles its own paging.
+    expect(driver.transportMode).toBe('remote');
+    await driver.syncSchema(TICKET_OBJECT.name, TICKET_OBJECT);
+    for (const row of PAGINATION_ROWS) {
+      await driver.create('ticket', { ...row });
+    }
+  });
+
+  afterAll(async () => {
+    await driver.disconnect();
+    stub.close();
+  });
+
+  /** Walk the whole table page by page, collecting the ids in visit order. */
+  const walk = async (
+    pageSize: number,
+    orderBy?: ReadonlyArray<{ field: string; order: 'asc' | 'desc' }>,
+  ): Promise<string[]> => {
+    const seen: string[] = [];
+    for (let offset = 0; offset < PAGINATION_ROWS.length; offset += pageSize) {
+      const page: Array<Record<string, unknown>> = await driver.find('ticket', {
+        ...(orderBy ? { orderBy: [...orderBy] } : {}),
+        limit: pageSize,
+        offset,
+      });
+      seen.push(...page.map((r) => String(r.id)));
+    }
+    return seen;
+  };
+
+  /**
+   * Read below the transport first: a walk that visits nothing because the
+   * seed never landed would satisfy every set comparison in this file for the
+   * wrong reason.
+   */
+  it('the fixture really is all twelve rows, as stored', () => {
+    const rows = stub.raw.prepare('select id from ticket').all() as Array<{ id: string }>;
+    expect(rows.map((r) => r.id).sort()).toEqual([...PAGINATION_ALL_IDS].sort());
+  });
+
+  for (const testCase of PAGINATION_CASES) {
+    it(`visits every row exactly once — ${testCase.name}`, async () => {
+      const seen = await walk(testCase.pageSize, testCase.orderBy);
+      expect(seen).toHaveLength(PAGINATION_ALL_IDS.length);
+      expect(new Set(seen).size).toBe(PAGINATION_ALL_IDS.length);
+      expect([...seen].sort()).toEqual([...PAGINATION_ALL_IDS].sort());
+    });
+
+    it(`page boundaries are invisible — ${testCase.name}`, async () => {
+      const paged = await walk(testCase.pageSize, testCase.orderBy);
+      const whole: Array<Record<string, unknown>> = await driver.find('ticket', {
+        orderBy: [...testCase.orderBy],
+      });
+      expect(paged).toEqual(whole.map((r) => String(r.id)));
+    });
+  }
+
+  for (const testCase of PAGINATION_UNORDERED_CASES) {
+    it(`visits every row exactly once with NO orderBy at all — ${testCase.name}`, async () => {
+      const seen = await walk(testCase.pageSize);
+      expect(seen).toHaveLength(PAGINATION_ALL_IDS.length);
+      expect(new Set(seen).size).toBe(PAGINATION_ALL_IDS.length);
+      expect([...seen].sort()).toEqual([...PAGINATION_ALL_IDS].sort());
+    });
+
+    it(`page boundaries are invisible with NO orderBy — ${testCase.name}`, async () => {
+      const paged = await walk(testCase.pageSize);
+      const whole: Array<Record<string, unknown>> = await driver.find('ticket', {});
+      expect(paged).toEqual(whole.map((r) => String(r.id)));
+    });
+  }
+
+  it('leaves an UNPAGED unordered read alone — no sort is imposed on a caller who asked for none', async () => {
+    const rows: Array<Record<string, unknown>> = await driver.find('ticket', {});
+    expect(rows.map((r) => String(r.id))).toEqual(PAGINATION_ROWS.map((r) => r.id));
+  });
+
+  /**
+   * The two pins. See the module doc: the cases above pass, but not by the
+   * mechanism the contract names, and a green suite that leaves that unsaid is
+   * how "covered" quietly stops meaning anything. Both assert the CURRENT
+   * behaviour and are expected to go red — and be rewritten — the day #5653
+   * gives this transport the tie-breaker local mode already has.
+   */
+  it('records the measured mechanism: a sorted paged read appends NO tie-breaker (#5653)', async () => {
+    const seen = await walk(5, [{ field: 'status', order: 'asc' }]);
+    // What the caller's key alone produces: the `status` groups in order, and
+    // INSIDE each group the rows in storage (insertion) order. With the `id`
+    // tie-breaker local mode appends, the `done` group would instead read
+    // r02,r03,r09,r10 — id order.
+    const groupedByStatusThenInsertion = PAGINATION_ROWS.map((row, index) => ({ row, index }))
+      .sort((x, y) => x.row.status.localeCompare(y.row.status) || x.index - y.index)
+      .map(({ row }) => row.id);
+    expect(seen).toEqual(groupedByStatusThenInsertion);
+  });
+
+  it('records the measured mechanism: an unsorted paged read is served in storage order, not id order (#5653)', async () => {
+    const seen = await walk(5);
+    expect(seen).toEqual(PAGINATION_ROWS.map((r) => r.id));
+    expect(seen).not.toEqual([...PAGINATION_ALL_IDS].sort());
+  });
+});

--- a/scripts/check-driver-conformance.mjs
+++ b/scripts/check-driver-conformance.mjs
@@ -137,8 +137,12 @@ const CASE_SETS = [
 // covered, is not yet) or EXEMPT (cannot meaningfully apply). Both are measured
 // claims; neither is a default.
 //
-// EMPTY, as of #4405 — every cell of the matrix is covered by a suite. The two
-// FILTER_LOGIC_CASES rows this ledger opened with are both cleared:
+// EMPTY, as of #5590 — every cell of the matrix is covered by a suite. Five
+// entries have passed through here across two generations, and every one of
+// them was cleared the same way: by writing the suite, never by the argument
+// that predicted the suite was unnecessary.
+//
+// The two FILTER_LOGIC_CASES rows this ledger opened with (#4405):
 //
 //   driver-mongodb      `translateFilter` was the independent fifth backend
 //                       #3774 never enrolled when it named "the four". It now
@@ -153,6 +157,45 @@ const CASE_SETS = [
 //                       rather than EXEMPT because "inherits, therefore fine" is
 //                       the assumption those suites exist to disprove; the suite
 //                       is what disproves it, not the entry.
+//
+// The three driver-turso rows Phase A of #4645 measured on arrival, cleared by
+// #5590. All three were DEBT for one reason — the driver is DUAL-TRANSPORT.
+// Local/replica inherits SqlDriver's filter compiler and its paging; remote
+// does not go through knex at all, and `src/remote-transport.ts` carries its
+// own `buildWhereSQL` (combinator nesting, operator vocabulary, comparand
+// refusal) and its own ORDER BY / LIMIT / OFFSET assembly. That is an
+// independent Nth backend, which is what #3774 and #4363 wrote the case-sets
+// for. So each cell took TWO suites, one per transport, in the shape the
+// temporal cells already had:
+//
+//   FILTER_LOGIC_CASES         driven by `turso-filter-logic-conformance` for
+//                              the local transport and by `turso-remote-filter-
+//                              logic-conformance` for the remote one. Both green
+//                              on arrival.
+//   PAGINATION_CASES,          driven by `turso-pagination-conformance` and
+//   PAGINATION_UNORDERED_CASES `turso-remote-pagination-conformance`, same two
+//                              transports. Also green — but read the note below
+//                              before trusting the remote half of these two the
+//                              way you can trust the local half.
+//
+// Both remote suites run over the `libsql-sqlite-stub.testkit` SQLite stub, so
+// the whole set is hermetic: no network, no credentials, on by default in CI —
+// which is what the temporal pair next door already established for this
+// package.
+//
+// ## What driver-turso's PAGINATION cells mean — read this before trusting them
+//
+// The local suite passes because `SqlDriver.orderKeysFor()` appends the `id`
+// tie-breaker the contract asks for. The remote suite passes WITHOUT that
+// mechanism: `buildSelectSQL` maps the caller's `orderBy` verbatim and appends
+// no unique column, so the cases hold on the stub's twelve-row `better-sqlite3`
+// table — one plan, one arrangement, every time — rather than by a promise the
+// transport makes. On a real endpoint that arrangement is not promised across
+// two statements, which is the defect `pagination-conformance.ts` is about.
+// Filed as #5653; the remote suite carries two `records the measured mechanism`
+// tests that pin the current no-tie-breaker behaviour so it cannot go quiet
+// under a green cell. Not a ledger entry, because the cells ARE covered — an
+// entry for a covered cell fails RECONCILED, and this is where the fact fits.
 //
 // An empty ledger is the intended steady state, not a reason to delete the
 // mechanism: the next driver that arrives uncovered fails CONSUMED and lands
@@ -191,54 +234,7 @@ const CASE_SETS = [
 // investment is frozen (#5499). Un-freezing it is what should re-run these cells
 // in CI; until then, this note is the honest state of the mongo column.
 
-// ## driver-turso arrived from `objectstack-ai/cloud` with three cells open (#4645)
-//
-// The package migrated into `packages/drivers/driver-turso` in Phase A of #4645
-// and entered this matrix the moment it landed on disk -- which is the gate
-// working as documented ("a new driver package is in scope the moment it
-// exists"), not a surprise. Measured on arrival: TEMPORAL_CASES and
-// TEMPORAL_TIME_CASES are genuinely covered, twice over
-// (`turso-temporal-conformance.test.ts` for the local transport,
-// `turso-remote-temporal-conformance.test.ts` for the remote one). The other
-// three had no suite in cloud either.
-//
-// They are DEBT rather than EXEMPT, and the reason is the driver's dual
-// transport. Local/replica mode does inherit SqlDriver's filter compiler and
-// paging -- but remote mode does not go through Knex at all:
-// `src/remote-transport.ts` carries its own `buildWhereSQL` (combinator
-// nesting, operator vocabulary, comparand refusal) and its own ORDER BY /
-// LIMIT / OFFSET assembly. That is an independent Nth backend, which is
-// precisely what #3774 and #4363 wrote the shared case-sets for. "Inherits,
-// therefore fine" is the assumption those suites exist to disprove -- the same
-// sentence driver-sqlite-wasm's cleared entry carried, and it was cleared by a
-// suite, not by the sentence.
-//
-// Clearing these: write the suites (both transports, hermetic -- the remote
-// half over `libsql-sqlite-stub.testkit.ts`), then delete these entries in the
-// same PR. Tracked as #5590.
-const LEDGER = [
-  {
-    driver: 'driver-turso',
-    marker: 'FILTER_LOGIC_CASES',
-    kind: 'DEBT',
-    why: "remote transport compiles its own WHERE (`src/remote-transport.ts` buildWhereSQL) instead of inheriting SqlDriver's, so combinator nesting is an independent implementation with no suite; local/replica inherits but is untested against the shared cases too.",
-    issue: '#5590',
-  },
-  {
-    driver: 'driver-turso',
-    marker: 'PAGINATION_CASES',
-    kind: 'DEBT',
-    why: 'remote transport assembles its own ORDER BY / LIMIT / OFFSET; no suite drives the sorted-partition property against either transport.',
-    issue: '#5590',
-  },
-  {
-    driver: 'driver-turso',
-    marker: 'PAGINATION_UNORDERED_CASES',
-    kind: 'DEBT',
-    why: 'same seam as PAGINATION_CASES, unsorted arm: the remote LIMIT/OFFSET path has no suite pinning that an unsorted paged read is still a partition.',
-    issue: '#5590',
-  },
-];
+const LEDGER = [];
 
 // ── Discovery ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5590

## 做了什么

给 `packages/drivers/driver-turso` 补四个套件，从 `@objectstack/spec/data` 导入并驱动 `FILTER_LOGIC_CASES` / `PAGINATION_CASES` / `PAGINATION_UNORDERED_CASES`，**每格两面**——照同包 temporal 那对套件的形状：

| 文件 | 传输面 | 引擎 |
|---|---|---|
| `turso-filter-logic-conformance.test.ts` | local | `:memory:`（better-sqlite3 + knex） |
| `turso-remote-filter-logic-conformance.test.ts` | remote | `libsql-sqlite-stub.testkit.ts` |
| `turso-pagination-conformance.test.ts` | local | `:memory:` |
| `turso-remote-pagination-conformance.test.ts` | remote | `libsql-sqlite-stub.testkit.ts` |

四个都 hermetic：不要网络、不要凭据、CI 默认跑。四个全绿，所以同一个 commit 里把 `scripts/check-driver-conformance.mjs` 的三条 DEBT 条目删干净（⛔ 判定函数一行未动，只动 `LEDGER` 数组与它的说明注释）。

## 为什么"继承所以没问题"不成立——这也是套件的内容主张

`TursoDriver` 是双传输的。local/replica 继承 `SqlDriver`；remote 完全不走 knex，`src/remote-transport.ts` 自带 `buildWhereSQL`（组合子嵌套、算子词表、比较值拒收、空组合子的布尔单位元）和自己的 ORDER BY / LIMIT / OFFSET 拼装。这就是 #3774 / #4363 设共享 case-set 要压的"独立实现的第 N 个后端"。

**反向验证（先定方向再跑，三个都按预测走）**：

1. 把 remote `buildWhereSQL` 的顶层 `clauses.join(' AND ')` 改成 `' OR '`（#3774 那个缺陷的形状）→ 预测 remote 套件红、local 套件绿。实测 **remote 16 红、local 全绿**，例如
   `multi-key $or branch ANDs its own keys: expected [ '1', '2', '3' ] to deeply equal [ '1' ]`。
2. 让 remote `buildSelectSQL` 只在**非分页**读上拼 ORDER BY → 预测 remote 分页套件红、local 绿。实测 **remote 6 红**（5 条 `page boundaries are invisible` + 机制 pin），local 全绿。
3. 在 `TursoDriver.find` 的 local 分支里把调用方 `orderBy` 丢掉（打的是本包自己的传输路由层，正是 local 套件模块注释声称在钉的东西）→ 预测 local 分页套件红、remote 绿。实测 **local 5 红**，remote 全绿。

三次都是"一面红另一面绿"，正好把 issue 的前提——两条传输是两套实现，一面的套件看不见另一面的回归——直接测了出来。

（顺带记一个诚实的强度边界：第 2 个 mutation 下 `visits every row exactly once` 仍然绿，因为丢掉 ORDER BY 后 rowid 序仍是一个 partition。这正是 case-set 自己说的"性质"和"那条子句"是两回事，所以 `page boundaries are invisible` 与机制 pin 才是这两个套件里带牙的断言。）

## remote 分页这两格是绿的，但请连着这段一起读

`buildSelectSQL` 把调用方的 `orderBy` **原样**透传、不追加唯一列；local 面走的是 `SqlDriver.orderKeysFor()`，按 #4363 的三态表补 `id` tie-breaker。实测 remote 面 `ORDER BY status ASC` 的并列组内是**插入序**而非 id 序，无序分页读则是 rowid 序：

```
remote sorted:    r03,r09,r02,r10 | r01,r12,r08,r06 | r07,r11,r05,r04
remote unordered: r07,r03,r11,r01,r09,r05,r12,r02,r08,r04,r10,r06
```

也就是说：**remote 面满足了这些 case，但不是靠契约点名的那个机制**——是靠 stub 那张 12 行内存表计划固定。真实 endpoint 上并列行的排布不被 SQLite 承诺在两条语句之间一致，而 `pagination-conformance.ts` 自己的模块注释就写明无序读是同一缺陷的满强度形态、`driver-memory` 那条"存储顺序稳定"的豁免针对的是 JS 数组不是 SQL 计划。

按本单边界（套件里不修实现、不给自己发准考证），这条缺陷**另开单**：#5653。remote 套件里留了两条 `records the measured mechanism` 测试把当前"没有 tie-breaker"的事实钉住——#5653 落地那天它们会红并随之改写，而不是让这条分叉在一个绿格子底下悄悄躺着。gate 注释里也记了同一件事（放注释而不是 LEDGER 条目：格子确实已覆盖，给已覆盖的格子留条目会判 RECONCILED 红）。

## 验证

```
$ npx vitest run --maxWorkers=2         # packages/drivers/driver-turso 全量
  Test Files  19 passed (19)
       Tests  621 passed (621)          # 迁入时是 15 files / 逐步增至 19

$ pnpm check:driver-conformance         # 含 --self-test
  driver-turso        ok  ok  ok  ok  ok
  check-driver-conformance: OK — 25 covered cell(s), 0 in the DEBT ledger, 0 exempt.
  OK  self-test: detects driven / unused / re-declared fixtures, discovers both axes, …

$ pnpm --filter @objectstack/driver-turso typecheck     # tsc --noEmit，无输出
$ npx eslint <5 个变更文件> --no-inline-config           # exit 0
$ node scripts/check-query-options-erasure-ratchet.mjs
  ✓ query-options-erasure ratchet holds: 84 unswept non-test site(s) in 19 file(s), none new.
    test surface: 267 site(s) in 51 file(s) — at the ceiling.     # 新套件零新增擦除站点
$ node scripts/check-nul-bytes.mjs
  check-nul-bytes: OK (scanned 5573 tracked text file(s); …)
```

query-options 类型：四个新套件的 query 从第一行就是正确类型，**没有一处 `as any`**（`find`/`count` 的签名本就 `any`，直接传字面量即可），所以 267 天花板纹丝不动。

## 边界

- ⛔ 没动 gate 的判定逻辑，只删 `LEDGER` 的三条 + 改它的说明注释。
- ⛔ 没修 remote transport 的任何语义，包括上面那条 tie-breaker 缺失（→ #5653）。
- 文件面只有 `packages/drivers/driver-turso/src/`（4 个新文件）+ `scripts/check-driver-conformance.mjs`。

## Changeset

测试 + gate ledger，不发布任何包 → 按 `pr-automation.yml` 的路线 2，请挂 `skip-changeset` 标签。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyvqvKMG6asi9aXjKE6xtx


---
_Generated by [Claude Code](https://claude.ai/code/session_01WyvqvKMG6asi9aXjKE6xtx)_