### PR TITLE
fix(client)!: `DeleteDataResult` 声明它自称的 schema —— `success`,不是 `deleted` (#5638)

### DIFF
--- a/.changeset/client-delete-result-success.md
+++ b/.changeset/client-delete-result-success.md
@@ -1,0 +1,80 @@
+---
+"@objectstack/client": major
+---
+
+fix(client)!: `DeleteDataResult` declares the schema it names — `success`, not `deleted` (#5638)
+
+`DeleteDataResult` — the return type of `client.data.delete()` and of the
+project-scoped `client.project(id).data.delete()` — carried the comment
+`Spec: DeleteDataResponseSchema` above a declaration that contradicted it:
+
+```ts
+/** Spec: DeleteDataResponseSchema */
+export interface DeleteDataResult {
+  object: string;
+  id: string;
+  deleted: boolean;   // ← the schema declares `success`
+}
+```
+
+`DeleteDataResponseSchema` (`packages/spec/src/api/protocol.zod.ts`) declares
+`{ object, id, success }`. `deleted` has never been declared by any schema, and
+no server path has ever returned it on `/data/:object/:id`.
+
+**The old key was never readable at runtime — this rename reveals a defect, it
+does not break working code.** Both `delete` surfaces are pure `unwrapResponse`
+/ `_unwrap` passthroughs: the SDK returns the server's body untouched, so this
+interface is a *claim* about the wire, never a rewrite of it. The claim was
+false in the one direction that matters — the compiler endorsed the wrong
+spelling:
+
+```ts
+const r = await client.data.delete('task', id);
+if (r.deleted) { … }   // compiled; `undefined` at runtime; branch never taken
+if (r.success) { … }   // rejected by the compiler; correct on the wire
+```
+
+## What to change
+
+`r.deleted` → `r.success`. That is the whole migration. Nothing about the
+request, the route, the status codes or the error shapes changes, and no server
+needs upgrading: the value you are now allowed to read is the one that was
+already arriving.
+
+⛔ **Do not write `r.success ?? r.deleted`.** There is one producer shape, and a
+consumer that accepts two spellings is the shape contract-first exists to
+prevent — the same ruling #5581 applied on the producer side. No deprecated
+`deleted?: boolean` transition key ships for the same reason; a transition
+period is for keys that *worked*, and this one never did.
+
+## Why the type was wrong on every deployment, not just some
+
+The protocol path (`deleteData`) has always answered `success`. #5581 / PR
+#5641 brought the ObjectQL fallback — the path a slim assembly without
+`MetadataPlugin` takes — to the same shape. So before that fix the declaration
+was wrong on ordinary deployments and accidentally right on slim ones; after
+it, both paths answer `{ object, id, success }` and the declaration was simply
+wrong everywhere. The consumer-side correction had to follow the producer, not
+lead it.
+
+## Downstream
+
+`objectui`'s `ObjectStackDataSource.delete()` is a live victim of the old
+declaration — it guards `emitMutation` on `result.deleted`, so the delete
+mutation event has never fired against a real server and the method returns
+`undefined` where it declares `boolean`. Its own suite stayed green because the
+fixture mocks `{ deleted: true }`, a body no server produces. Filed as
+objectstack-ai/objectui#3412, which is blocked on this package publishing —
+its fix is a type unblock, not a behaviour change, since `success` is already
+what arrives.
+
+## Pins
+
+`packages/client/src/data-delete-result-shape.test.ts` asserts mutual
+assignability between `DeleteDataResult` and the spec's `DeleteDataResponse`,
+so a rename on either side (or a re-added optional `deleted`) fails
+`check:test-typecheck`. `client.hono.test.ts` gains the delete case this live
+server suite never had: a real DELETE over HTTP whose body is read as
+`deleted.success` and whose key set is asserted literally — `z.object` strips
+unknown keys, so a passing parse alone cannot prove no stray `deleted` rode
+along.

--- a/.changeset/client-delete-result-success.md
+++ b/.changeset/client-delete-result-success.md
@@ -1,5 +1,6 @@
 ---
 "@objectstack/client": major
+"@objectstack/cli": patch
 ---
 
 fix(client)!: `DeleteDataResult` declares the schema it names — `success`, not `deleted` (#5638)
@@ -56,6 +57,23 @@ was wrong on ordinary deployments and accidentally right on slim ones; after
 it, both paths answer `{ object, id, success }` and the declaration was simply
 wrong everywhere. The consumer-side correction had to follow the producer, not
 lead it.
+
+## `os data delete` was reading the phantom key too
+
+`packages/cli/src/commands/data/delete.ts` built its `--format json` / `--format
+yaml` payload with `deleted: result.deleted`. That evaluated to `undefined`, and
+`JSON.stringify` drops undefined values — so the `deleted` key the command has
+always declared **never appeared in a single run**. It now carries
+`result.success`, the server's own verdict.
+
+Observable change: `os data delete --format json` gains `deleted: true` (YAML
+likewise) on a successful delete. The key name stays `deleted` deliberately —
+it is the CLI's output key, not the protocol's, and the payload's top-level
+`success` already means something different (the CLI envelope's "the command
+completed"). Conflating the two is the hazard #5641 called out when it noted
+that `body.success` and `body.data.success` are different facts. Scripts
+reading `.deleted` from this command were reading `undefined` before and get a
+boolean now; nothing that worked stops working.
 
 ## Downstream
 

--- a/content/docs/kernel/runtime-services/data-service.mdx
+++ b/content/docs/kernel/runtime-services/data-service.mdx
@@ -30,7 +30,8 @@ services.data.delete(object: string, id: string): Promise<DeleteDataResult>
 - `get`: single record payload
 - `find`: list payload + pagination metadata
 - `create`/`update`: mutated record payload
-- `delete`: success marker / deleted ID payload
+- `delete`: `{ object, id, success }` — the spec's `DeleteDataResponse`. The
+  flag is `success`, not `deleted` (#5638)
 
 ## Typical Errors
 

--- a/packages/cli/src/commands/data/delete.ts
+++ b/packages/cli/src/commands/data/delete.ts
@@ -57,15 +57,24 @@ export default class DataDelete extends Command {
       // Delete the record
       const result = await client.data.delete(args.object, args.id);
 
+      // [#5638] `deleted` is THIS COMMAND's output key; its value is the
+      // protocol's `DeleteDataResponse.success`. Two different booleans live
+      // in this payload and must not be conflated: the top-level `success` is
+      // the CLI envelope's "the command completed" flag (this branch is only
+      // reached when it did), while the server's flag is its statement that
+      // the deletion happened. Until now this read was `result.deleted` — a
+      // key no server has ever returned — so it evaluated to `undefined` and
+      // `JSON.stringify` dropped it: the documented key was simply absent
+      // from every `os data delete --format json` run.
       if (flags.format === 'json') {
         await emitJson({
           success: true,
           object: result.object,
           id: result.id,
-          deleted: result.deleted,
+          deleted: result.success,
         });
       } else if (flags.format === 'yaml') {
-        await formatOutput({ success: true, object: result.object, id: result.id, deleted: result.deleted }, 'yaml');
+        await formatOutput({ success: true, object: result.object, id: result.id, deleted: result.success }, 'yaml');
       } else {
         printSuccess(`Record deleted: ${result.id}`);
       }

--- a/packages/client/src/client.hono.test.ts
+++ b/packages/client/src/client.hono.test.ts
@@ -200,4 +200,37 @@ describe('ObjectStackClient (with Hono Server)', () => {
         expect(resultsResponse.records.length).toBeGreaterThan(0);
         expect(resultsResponse.records[0].name).toBe('Hono User');
     });
+
+    // [#5638] The one method whose declared return shape this suite never
+    // exercised — and the one that was wrong. `DeleteDataResult` claimed
+    // `deleted: boolean`; the schema it names declares `success`. This is the
+    // runtime half of the pin: a REAL delete, over HTTP, against the server
+    // this package's consumers talk to, read through the declared type.
+    //
+    // Nothing in this test is mocked into the answer: the DELETE route calls
+    // `protocol.deleteData` (rest-server.ts), NOT the broker shim above, so the
+    // body asserted here is the server's own.
+    it('should delete data via hono, answering the SPEC\'s `success` body', async () => {
+        const client = new ObjectStackClient({ baseUrl });
+        await client.connect();
+
+        const created = await client.data.create('customer', {
+            name: 'Doomed User',
+            email: 'doomed@example.com',
+        });
+
+        // Spec: DeleteDataResponse = { object, id, success }
+        const deleted = await client.data.delete('customer', created.id);
+        expect(deleted.success).toBe(true);
+        expect(deleted.object).toBe('customer');
+        expect(deleted.id).toBe(created.id);
+        // The undeclared key must not ride along (a passing schema parse would
+        // strip it silently, so assert the key set itself).
+        expect(Object.keys(deleted).sort()).toEqual(['id', 'object', 'success']);
+
+        // And the delete actually happened — a success flag nobody cross-checks
+        // is the cheapest thing in the world to keep green.
+        const remaining = await client.data.find('customer', { where: { id: created.id } });
+        expect(remaining.records.length).toBe(0);
+    });
 });

--- a/packages/client/src/data-delete-result-shape.test.ts
+++ b/packages/client/src/data-delete-result-shape.test.ts
@@ -1,0 +1,112 @@
+/**
+ * [#5638] `DeleteDataResult` is a CLAIM about the server's delete body, and it
+ * has to be the claim its own comment makes: `Spec: DeleteDataResponseSchema`.
+ *
+ * It declared `{ object, id, deleted: boolean }` while
+ * `DeleteDataResponseSchema` declares `{ object, id, success: boolean }`. Both
+ * `delete` surfaces (`client.data.delete` and the project-scoped
+ * `client.project(id).data.delete`) are pure `unwrapResponse` / `_unwrap`
+ * passthroughs — no runtime rewriting anywhere — so a consumer writing
+ * `r.deleted` compiled fine and read `undefined` against every server path
+ * that exists (#5581 / PR #5641 brought the ObjectQL fallback to `success`
+ * too, so both producer paths now answer the same shape).
+ *
+ * WHICH LAYER ACTUALLY MOVES, and why that is not the usual one: the fix is a
+ * type declaration, and types are erased before vitest ever runs. Reverting
+ * `success` back to `deleted` therefore leaves every runtime assertion below
+ * GREEN — they assert on a body the mock/server produced, which the client
+ * never touched either way. The assertion that goes red on revert is the
+ * type-level one (`SpecAndSdkAgree`), plus the `r.success` reads, and both are
+ * enforced by `pnpm --filter @objectstack/client typecheck` → `check:test-typecheck`
+ * (#5449/#5546), which compiles this file with the package's full strictness
+ * and no debt-ledger entry. The runtime assertions below are shape pins: they
+ * pin that the passthrough stays a passthrough, which is what makes the type
+ * the only thing standing between a consumer and the wire.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { DeleteDataResponseSchema, type DeleteDataResponse } from '@objectstack/spec/api';
+import { ObjectStackClient, type DeleteDataResult } from './index';
+
+/** Mutual assignability — `A extends B` alone would pass on a strict subset. */
+type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+/**
+ * The pin. `DeleteDataResult` must be structurally the spec type, field for
+ * field: rename either side, add a key to one, or make one optional, and this
+ * stops being `true` — a type error at `check:test-typecheck`, not a runtime
+ * failure. (This is deliberately an equality, not `extends`: the old `deleted`
+ * declaration was neither a subset nor a superset of the schema, and a
+ * one-directional check would still have caught it — but a future
+ * `success: boolean; deleted?: boolean` "transition" shape would slip past
+ * one, and that shape is exactly what #5638's triage ruled out.)
+ */
+const SpecAndSdkAgree: Exact<DeleteDataResult, DeleteDataResponse> = true;
+
+/** Helper: a client whose fetch answers `body` with `status`. */
+function createMockClient(body: any, status = 200) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: async () => body,
+    headers: new Headers(),
+  });
+  const client = new ObjectStackClient({ baseUrl: 'http://localhost:3000', fetch: fetchMock });
+  return { client, fetchMock };
+}
+
+/** The body every server path answers a successful delete with (#5581). */
+const SPEC_BODY = { object: 'task', id: 't1', success: true };
+
+describe('[#5638] DeleteDataResult === DeleteDataResponseSchema', () => {
+  it('declares the schema\'s shape, field for field (type-level)', () => {
+    // Reading the binding is what keeps `noUnusedLocals` satisfied; the
+    // assertion that matters already happened in tsc, above.
+    expect(SpecAndSdkAgree).toBe(true);
+  });
+
+  it('the schema still declares `success` and has never declared `deleted`', () => {
+    const parsed = DeleteDataResponseSchema.safeParse(SPEC_BODY);
+    expect(parsed.success).toBe(true);
+    expect(DeleteDataResponseSchema.safeParse({ object: 'task', id: 't1', deleted: true }).success)
+      .toBe(false);
+  });
+
+  for (const [surface, del] of [
+    ['client.data.delete', (c: ObjectStackClient) => c.data.delete('task', 't1')],
+    ['client.project(id).data.delete', (c: ObjectStackClient) => c.project('proj-xyz').data.delete('task', 't1')],
+  ] as const) {
+    describe(surface, () => {
+      it('hands back the spec body, and `success` is reachable through the declared type', async () => {
+        const { client } = createMockClient(SPEC_BODY);
+        const r: DeleteDataResult = await del(client);
+
+        // The typed read. Under the pre-#5638 declaration this line is
+        // TS2339 (`success` does not exist) — and the line a consumer WOULD
+        // have written, `r.deleted`, compiled and evaluated to `undefined`.
+        expect(r.success).toBe(true);
+        expect(r.object).toBe('task');
+        expect(r.id).toBe('t1');
+
+        // `z.object` strips unknown keys, so a passing `safeParse` cannot by
+        // itself prove no stray `deleted` came along (the #5641 caveat).
+        // Assert the key set literally as well.
+        expect(DeleteDataResponseSchema.safeParse(r).success).toBe(true);
+        expect(Object.keys(r).sort()).toEqual(['id', 'object', 'success']);
+        expect('deleted' in (r as object)).toBe(false);
+      });
+
+      it('does not manufacture `success` — an off-spec body passes through verbatim', async () => {
+        // Contract-first: the fix belongs in the type (and, for the server,
+        // in #5581), NOT in a tolerant consumer that reads
+        // `body.success ?? body.deleted`. If someone ever adds that alias,
+        // this test is where it shows up.
+        const { client } = createMockClient({ object: 'task', id: 't1', deleted: true });
+        const r = await del(client) as unknown as Record<string, unknown>;
+
+        expect(r.success).toBeUndefined();
+        expect(r.deleted).toBe(true);
+      });
+    });
+  }
+});

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -232,11 +232,21 @@ export interface UpdateDataResult<T = any> {
   droppedFields?: DroppedFieldsEvent[];
 }
 
-/** Spec: DeleteDataResponseSchema */
+/**
+ * Spec: DeleteDataResponseSchema
+ *
+ * [#5638] The success flag is `success`, matching the schema this comment
+ * names (`packages/spec/src/api/protocol.zod.ts`). It was declared `deleted`
+ * — a key no schema has ever declared and no server path has ever returned on
+ * `/data/:object/:id`, so `r.deleted` compiled and read `undefined` at
+ * runtime. Both `delete` surfaces below are pure `unwrapResponse` / `_unwrap`
+ * passthroughs: this interface is a claim about the server's body, never a
+ * rewrite of it, so the claim has to be the schema's.
+ */
 export interface DeleteDataResult {
   object: string;
   id: string;
-  deleted: boolean;
+  success: boolean;
 }
 
 export interface StandardError {


### PR DESCRIPTION
Fixes #5638

> **首轮 CI 红过一次,根因是我漏扫了 `packages/cli` 这个消费方。** 复盘、修法与「为什么 CLI 输出键名不改」写在 [这条评论](https://github.com/objectstack-ai/objectstack/pull/5657#issuecomment-5198294034) 里,下文的「改动」「测绘」「验证」三节已按第二轮更新。

## 前提复核:两半都成立

基线 `origin/main` = `30b784363`,`git merge-base --is-ancestor 7bf3d1ce2 origin/main` 确认已含 PR #5641。

| 复核项 | 实测 |
|---|---|
| 类型仍声明 `deleted`? | 是。`packages/client/src/index.ts:235-239`,注释 `Spec: DeleteDataResponseSchema` 之下第三个键是 `deleted: boolean` |
| schema 声明的是 `success`? | 是。`packages/spec/src/api/protocol.zod.ts:472` 的 `DeleteDataResponseSchema` = `{ object, id, success }` |
| 生产方两条路径已同形? | 是。protocol 侧 `deleteData` 一直如此;ObjectQL 兜底 `packages/runtime/src/action-execution.ts:260` 现为 `return { object: params.object, id: params.id, success: true }`(#5641 落的那一行) |
| 有没有第三条真在运行时给出 `deleted` 的路径? | 没有。REST 的 `DELETE /data/:object/:id`(`packages/rest/src/rest-server.ts:5046`)直接 `res.json(await p.deleteData(...))`,不经过任何改写 |

第四行是本单的停手条件(「若某处真的在运行时拿到过 `deleted`,前提可能有变」)。它没有触发 —— 相反,测绘找到的**两个**下游读取方拿到的正是 `undefined`,反过来加固了前提。

## 改动

1. **`packages/client/src/index.ts`** —— `DeleteDataResult.deleted` → `success`,注释保持指向 schema 并写清「这是对响应体的一句声明、不是改写」。⛔ 不留 deprecated 双键、不加 `deleted?: boolean` 过渡:消费端同时认两种拼写正是 contract-first 禁止的形状,而且旧键在任何部署上运行时都恒 `undefined`,改名是揭错而非破坏在用行为。
2. **`packages/client/src/data-delete-result-shape.test.ts`(新)** —— 见下。
3. **`packages/client/src/client.hono.test.ts`** —— 这套 live server 套件此前有 create / get / find,唯独没有 delete;补上真实 HTTP DELETE 用例。
4. **`packages/cli/src/commands/data/delete.ts`** —— `deleted: result.deleted` → `result.success`。该处恒 `undefined`,而 `JSON.stringify` 丢弃 undefined,所以这个命令声明已久的 `deleted` 键**在任何一次 `os data delete --format json` 里都没出现过**。**输出键名保持 `deleted` 不变**(理由见上方评论:同 payload 顶层的 `success` 是 CLI 信封的另一件事,撞名会把两个不同事实揉成一个;改键名属输出契约决定,留给维护者)。与 #5644 无交集 —— 那单整单落在 `commands/doctor.ts`。
5. **`content/docs/kernel/runtime-services/data-service.mdx`** —— `delete` 的返回值由含糊的「success marker / deleted ID payload」写实为 `{ object, id, success }`。这一句正是 AI 作者会照着猜键名的地方。未触碰 `content/docs/releases/`。

changeset:`@objectstack/client` **major**(公开导出接口的破坏性重命名)+ `@objectstack/cli` **patch**,升级须知点明「旧键从未在运行时有值,迁移就是把 `r.deleted` 改成 `r.success`,服务端无需升级」,并写清 CLI 输出的可观察变化。

## 测试怎么钉的:三层,且必须说清哪一层会动

照 #5641 的三层先例,但**本单的层次分工与它相反,这一点不能含糊**:#5641 改的是运行时构造的字面量,vitest 抓得住;本单改的是**类型声明**,而类型在 vitest 跑起来之前就被擦掉了。所以:

- **类型层(唯一会动的一层)** —— `Exact< DeleteDataResult, DeleteDataResponse >` 双向可赋值断言。任一侧改名、多一个键、把某个键改成可选(包括未来有人想加回 `success: boolean; deleted?: boolean` 这种「过渡形状」),它就不再是 `true`,`check:test-typecheck`(#5449/#5546)报错。新文件不在 `test-typecheck-debt.json` 里,按该配置的口径必须零错误。
- **运行时形状层** —— 两个 delete 面各自:mock 出 spec 响应体 → 经 typed 字段读 `r.success`、`safeParse` 绿、**逐字断言键集 `['id','object','success']`**(`z.object` 会剥未知键,单靠 parse 证不了没有残留的 `deleted` —— #5641 记过的那条注意事项)。
- **反 fallback 钉** —— 「不合成 `success`」:喂一个 off-spec 的 `{object, id, deleted: true}`,断言 `r.success` 仍是 `undefined`、`r.deleted` 原样透出。这条钉的是**我们没有**在消费端加 `body.success ?? body.deleted`。将来谁加了容错读,红在这里。
- **真实服务端层** —— `client.hono.test.ts` 里 create 一条再 `client.data.delete`,读 `deleted.success`、断言键集、并回查 `find` 确认记录真的没了(一个没人交叉验证的 success 标志是世上最容易保持绿的东西)。这条不是自证:该路由走的是 `protocol.deleteData`,**不是**该套件顶部那个 broker shim,所以断言的是服务端自己的响应体。

CLI 侧未新增用例:改名之后,`data/delete.ts` 已经不可能再拼错这个键 —— 拼错就是 `@objectstack/cli#build` 编译错误(首轮 CI 演示的正是这一点)。结构性阻断比再加一条断言更强。

## 反向验证:方向先判后跑,而预判的方向不是模板里的那一种

**预判**:把 `success` 改回 `deleted` 后 ——

- `pnpm --filter @objectstack/client typecheck` → **红**(新 pin 文件 2 处 + hono 用例 1 处);
- `vitest run` → **仍然全绿**。因为类型被擦除,而 client 对响应体不做任何改写:mock 与真实服务端给什么,断言就读到什么,与声明成哪个键无关。

**实测,与预判一致:**

```
check:test-typecheck: 2 problem(s)
  • src/client.hono.test.ts: 3 type error(s), ledger records 2 — the debt GREW. Fix the 1 new one(s) …
  • src/data-delete-result-shape.test.ts: 2 type error(s) in a file the ledger does not cover …
 ELIFECYCLE  Command failed with exit code 1.
```

```
（同一次回退下的 vitest）
 Test Files  2 passed (2)
      Tests  10 passed (10)
```

**这一层要如实说**:本单没有「回退后测试变红」这种常见方向可写 —— 单元测试**在原理上**看不见这个缺陷,这恰恰是它能在三个面上活到今天的原因(client 自己没有 delete 响应体的用例;CLI 那两行没有任何用例;objectui 的用例喂的是自己编的键)。会动的只有类型门。把 vitest 的绿写成「验证通过」会是一份形状对、内容假的证据,所以这里写明它不动、以及为什么不动。

## `.deleted` 读取方测绘(跨仓;首轮漏过一处,已补全)

`DeleteDataResult` 全仓 5 处引用(类型定义 + 两个面各 2 处)+ 文档一处引用其名。**具名字段读取方仓内只有一个:`packages/cli/src/commands/data/delete.ts`** —— 首轮被我漏掉,CI 抓出,已修(见上)。补扫全仓确认再无第三处(`meta/delete.ts:61/63` 的 `result.deleted` 属 `meta.deleteItem`,另一个类型、不受影响)。

`client` 内另有五处 `if (res.status === 204) return { deleted: true }`(`index.ts` 3416 / 3467 / 3536 / 3590 / 3799)—— 正文与分诊都核过分别是 shares revoke、sharing rules delete、reports delete、report schedules unschedule、ai conversations delete,没有一条走 `/data/:object/:id`,**未动**。`client-react` 的 `data-hooks.tsx:291` 以 `as any` 直通、不读键。`cloud` 仓零命中。

**objectui 命中一个真实受害者**,已另立单(见下),本 PR 不跨仓改:它的修复依赖本包发版后类型才对得上,今天改会因已发布的 client 类型仍声明 `deleted` 而 TS 红,而绕过它只剩 `as any` —— 正是本单禁止的形状。

## 界外发现

- **objectstack-ai/objectui#3412(新立,未标签、未指派)** —— `ObjectStackDataSource.delete()`(`packages/data-objectstack/src/index.ts:1438/1441`)拿 `result.deleted` 当守卫发 `MutationEvent`、并把它作为 `Promise< boolean >` 的返回值。对真实服务端它恒 `undefined`,所以**单条删除的 mutation 事件从未发出过**(订阅方的列表/计数删除后不刷新),方法也恒返回 `undefined`。它的套件之所以绿,是因为 `onMutation.test.ts:83-84` 的 fixture 自己 mock 了 `{ deleted: true }` / `{ deleted: false }` —— 一个没有服务端会产生的响应体;#4984 那一族(fixture 拼写了不存在的键,于是守卫已死而断言照绿)的又一个标本。已在单里写明该 fixture 属「整条替换」而非「改拼写」,并挂 `Blocked-by: #5638`。立单前按关键词 + 文件路径搜过 objectui 开/闭 issue,零重复(#2582 同族不同因,已在正文区分)。
- **`pnpm --filter ... build` 会改写受版本控制的 `packages/spec/authorable-surface.base.json`**(重锚 `baseRev` + 3 个键)。已确认是既有已知问题 **#5358 / #5370** 的同一现象,故**未重复立单**;两轮都已 `git checkout --` 丢弃该副作用,提交里不含它。

## 验证(第二轮,CI 24 项 0 失败)

- `pnpm --filter @objectstack/client test`:**18 files / 229 tests 全绿**,exit 0(新文件 6 条 + hono delete 1 条)
- `pnpm --filter @objectstack/client typecheck`:绿 —— `tsc --noEmit` 无输出,`check:test-typecheck: OK`(债务台账仍是既有的 3 files / 6 errors,未增)
- `pnpm --filter @objectstack/cli test`:**82 files / 812 tests 全绿**,exit 0;`typecheck` 绿
- `pnpm --filter '...@objectstack/client' build`:client + 全部 6 个下游(cli、client-react、app-todo、app-crm、app-showcase、qa/dogfood)全绿 —— 这次是按**类型的消费半径**扫的,不是按被改的包
- `node scripts/check-nul-bytes.mjs`:OK;另对全部改动文件做 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 自扫,全净
- 未触碰 `packages/runtime`、`packages/spec`、`packages/cli/src/commands/doctor.ts`(#5644 在飞)、`content/docs/releases/`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FNvXhtSdnEGEfLEsMmvxh