### PR TITLE
fix(cli): `os doctor` tells a broken cloud-connection install from an absent one (#5644)

### DIFF
--- a/.changeset/doctor-optional-package-load-boundary.md
+++ b/.changeset/doctor-optional-package-load-boundary.md
@@ -1,0 +1,59 @@
+---
+"@objectstack/cli": patch
+---
+
+fix(cli): `os doctor` no longer treats a broken `@objectstack/cloud-connection` install as "not installed" (#5644)
+
+`readInstalledPackageEntries()` reached the installed-package ledger through a
+dynamic `import('@objectstack/cloud-connection')` whose `catch` meant "the
+optional package is not installed". That is right for one of the two things it
+caught:
+
+- **The specifier does not resolve** — the optional package really is not
+  there. Silence is correct and unchanged: `os doctor` must run to completion in
+  a checkout that never had it.
+- **The package is installed and will not load** — a pruned or unbuilt `dist/`,
+  an interrupted install, an artefact that throws while it evaluates, a
+  transitive dependency missing under it. It threw too, so it was answered with
+  the same silence.
+
+The ADR-0120 D5e unique-scope advisory then saw "no installed packages", found
+nothing to report, and the run printed:
+
+```
+  ✓ Unique scope          No unconfirmed installation-wide uniques for this 'isolated' environment
+```
+
+Measured: with the package present-but-unloadable and a ledger declaring an
+installation-wide `unique`, that line was printed and the finding appeared
+nowhere, `--verbose` included. It is the same false PASS #5412 removed at the
+`readdir` boundary and #5413 at the entry boundary, one boundary further up —
+and `os serve`, loading the same package in the same directory, has always named
+the failure out loud.
+
+The two states are now separated by **resolution**, not by the `import()` having
+thrown (`isModuleNotFoundError()` first — an error that is not a module-not-found
+error came from the package itself, so it is present by definition; then
+`import.meta.resolve()`, which answers "is the package there" without stating its
+entry file, unlike `createRequire().resolve()`). Only the genuinely-absent half
+is silent. The other prints an ordinary `HealthCheckResult` through the same
+renderer every other check uses:
+
+```
+  ⚠ Unique scope          Could not load the installed-package ledger reader (installed packages
+                          NOT checked for installation-wide uniques) — Cannot find module …
+```
+
+**Warning, not error**, and the exit code is unchanged, matching its two
+siblings: the environment still runs; what broke is doctor's ability to see part
+of it. The cause is quoted from the thrower, and `--verbose` expands it together
+with the remedy — reinstall, or build the package in a monorepo checkout.
+
+The row is **not** conditional on `.objectstack/installed-packages/` existing.
+Doctor cannot honestly say a ledger is absent when the constant naming the
+ledger's location is an export of the package that would not load.
+
+One consequence worth stating: in a monorepo checkout where
+`packages/cloud-connection` has not been built, `os doctor` under the `isolated`
+posture now prints this warning instead of a clean bill. That state is exactly
+what sent #5612 chasing a report face that had never regressed.

--- a/packages/cli/src/commands/doctor-ledger-read-failure.test.ts
+++ b/packages/cli/src/commands/doctor-ledger-read-failure.test.ts
@@ -44,6 +44,28 @@
  * positive assertion below. The two facts stay separately reported: the
  * directory could not be enumerated at all (#5412) versus it enumerated fine
  * and some files in it would not parse (#5413).
+ *
+ * ── The third half, one boundary UP (#5644) ──────────────────────────────
+ *
+ * The `import('@objectstack/cloud-connection')` that reaches all of the above
+ * had its own un-bound `catch`, and it merged the same two kinds of thing one
+ * level higher: a specifier that does not resolve (the optional package is not
+ * installed — silence is correct and stays) and a package that IS installed and
+ * will not load (unbuilt or pruned `dist/`, interrupted install, an artefact
+ * that throws). The second was answered with the first one's silence, so a
+ * ledger declaring an installation-wide `unique` produced `✓ Unique scope` and
+ * the finding appeared nowhere — measured, under `--verbose` included.
+ *
+ * The two are now separated by resolution rather than by the `import()` having
+ * thrown (`utils/optional-package.ts`, pinned against the real runtime in
+ * `utils/optional-package.test.ts`), and only the absent half is silent.
+ *
+ * That changes what the last describe of this file can simulate. Absence used
+ * to be simulated by making the module's evaluation throw; under the new
+ * contract that is precisely the OTHER state, so the case now pins the report
+ * it produces, and the absent contract is pinned separately through the loader
+ * seam. Both facts are still here — one of them changed how it is spelled,
+ * because the fact it used to spell was the defect.
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
@@ -52,7 +74,10 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import Doctor, { installedPackageLedgerFailureCheck } from './doctor.js';
+import Doctor, {
+  installedPackageLedgerFailureCheck,
+  installedPackageLedgerReaderFailureCheck,
+} from './doctor.js';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 /** `packages/cli` — the oclif root the real command is loaded against below. */
@@ -74,6 +99,15 @@ const LEDGER_HEADLINE = 'Could not read the installed-package ledger';
 
 /** The head of its ENTRY-level sibling (#5413). Deliberately distinct text. */
 const SKIPPED_HEADLINE = 'installed-package ledger entr';
+
+/**
+ * The head of the READER-level row (#5644) — the boundary above both.
+ *
+ * Deliberately not a superstring of `LEDGER_HEADLINE` ("read" vs "load"), so
+ * the `not.toContain(LEDGER_HEADLINE)` assertions below keep meaning what they
+ * say when this row is the one on screen.
+ */
+const READER_HEADLINE = 'Could not load the installed-package ledger reader';
 
 /**
  * ── Why this file needs a preflight (#5612) ──────────────────────────────
@@ -206,6 +240,58 @@ describe('installedPackageLedgerFailureCheck — the finding the shared catch us
   it('reports a thrown non-Error rather than swallowing it', () => {
     expect(installedPackageLedgerFailureCheck('boom').message).toContain('boom');
     expect(installedPackageLedgerFailureCheck(42).message).toContain('42');
+  });
+});
+
+describe('installedPackageLedgerReaderFailureCheck — the finding one boundary up (#5644)', () => {
+  it('quotes what was thrown, in the row AND in the verbose detail', () => {
+    const check = installedPackageLedgerReaderFailureCheck(
+      new Error("Cannot find module '/app/node_modules/@objectstack/cloud-connection/dist/index.js'"),
+    );
+
+    expect(check.message).toContain('dist/index.js');
+    expect(check.fix).toContain('dist/index.js');
+  });
+
+  it('takes the `Unique scope` name column and stays a warning, like its two siblings', () => {
+    const check = installedPackageLedgerReaderFailureCheck(new Error('boom'));
+
+    // Same reasoning as #5412: an operator scans the report by its name column,
+    // and a row under a different name leaves `Unique scope` simply missing —
+    // the silence this family of issues is about, wearing a different hat.
+    expect(check.name).toBe('Unique scope');
+    // The environment still runs; what broke is doctor's sight of part of it.
+    expect(check.status).toBe('warning');
+  });
+
+  it('says the package is PRESENT — the one thing that separates it from silence', () => {
+    const check = installedPackageLedgerReaderFailureCheck(new Error('boom'));
+    const fix = check.fix ?? '';
+
+    // A checkout that never installed the package prints nothing at all, so
+    // the row's whole meaning is "it is here and it is broken". If the text did
+    // not say so, the reader's first move would be to install what is already
+    // installed.
+    expect(fix).toContain('IS installed here');
+    expect(check.message).toContain('installed packages NOT checked');
+    // And it names the remedy for the state repo developers hit daily.
+    expect(fix).toContain('@objectstack/cloud-connection build');
+  });
+
+  it('does not claim to know whether a ledger exists', () => {
+    // It cannot: `DEFAULT_INSTALLED_PACKAGES_DIR` is an export of the package
+    // that would not load. Saying "the ledger is there" (the #5412 row's
+    // wording, correct for #5412) would be doctor asserting what it just lost
+    // the ability to check.
+    const fix = installedPackageLedgerReaderFailureCheck(new Error('boom')).fix ?? '';
+
+    expect(fix).not.toContain('it exists here');
+    expect(fix).toContain('cannot even tell you');
+  });
+
+  it('never trails off into nothing, and reports a thrown non-Error', () => {
+    expect(installedPackageLedgerReaderFailureCheck(new TypeError()).message).toContain('TypeError');
+    expect(installedPackageLedgerReaderFailureCheck('boom').message).toContain('boom');
   });
 });
 
@@ -494,23 +580,29 @@ describe('os doctor, end to end, against an unreadable installed-package ledger'
   }, 60_000);
 });
 
-describe('the optional package being absent stays completely silent (#5412 does not regress it)', () => {
+/**
+ * ── The two states the `import()` boundary used to merge (#5644) ─────────
+ *
+ * These two describes were ONE before #5644, and it asserted silence for a
+ * simulation that produced the wrong state. It made the module's evaluation
+ * throw — "the way an unresolvable specifier does", its comment said — and
+ * pinned that doctor said nothing. That is exactly the false PASS #5644 is
+ * about: an evaluation that throws means the package is HERE and unusable, and
+ * silence over it is a clean bill of health for a ledger nobody read.
+ *
+ * So the simulation keeps its mechanism and swaps its verdict (the "replace the
+ * assertion, not the repro" disposition #5413 used one layer down), and the
+ * contract it used to stand for — a package that is genuinely NOT INSTALLED is
+ * silent — moves to its own describe, spelled the only way that is now honest.
+ */
+describe('the optional package INSTALLED BUT UNLOADABLE is reported (#5644)', () => {
   /**
-   * ③, second half — the one branch that is SUPPOSED to swallow.
-   *
-   * `@objectstack/cloud-connection` resolves inside this monorepo, so absence
-   * is simulated by making its module evaluation throw the way an unresolvable
-   * specifier does. `vi.doMock` (not the hoisted `vi.mock`) plus a fresh
-   * module registry is what keeps this scoped to this one test — every case
-   * above needs the real module.
-   */
-  /**
-   * #5612 — this case needs the guard MORE than the e2e block does, not less.
-   * It simulates the package being unloadable and asserts doctor stays silent;
-   * in a worktree where the package really is unloadable it passes for that
-   * reason instead of for the mock's, i.e. green because nothing was proven
-   * (the empty-verdict trap PR #5046 wrote down). The preflight is what keeps
-   * the simulation distinguishable from the accident it simulates.
+   * #5612's preflight still earns its place here, and for its original reason.
+   * This case makes the real module's evaluation throw and asserts the row that
+   * follows; in a worktree where `cloud-connection` is genuinely unbuilt, the
+   * SAME row appears without the mock having done anything — green because the
+   * accident reproduced the simulation (PR #5046's empty-verdict trap in
+   * reverse). The guard is what keeps the two distinguishable.
    */
   beforeAll(assertLedgerReaderIsBuilt);
 
@@ -519,31 +611,50 @@ describe('the optional package being absent stays completely silent (#5412 does 
     vi.resetModules();
   });
 
-  it('prints no ledger row when the optional package cannot be loaded', async () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'os-doctor-5412-nopkg-'));
+  it('withholds the clean bill and names the reader, with a ledger it never read', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'os-doctor-5644-broken-'));
     fs.mkdirSync(path.join(tmp, 'node_modules'));
     fs.writeFileSync(
       path.join(tmp, 'objectstack.config.ts'),
       [
         'export default {',
-        "  manifest: { name: 'os5412np', label: 'No Package', version: '1.0.0' },",
+        "  manifest: { name: 'os5644', label: 'Broken Reader', version: '1.0.0' },",
         "  objects: [{ name: 'account', label: 'Account', fields: [{ name: 'name', type: 'text', label: 'Name' }] }],",
         '};',
         '',
       ].join('\n'),
     );
-    // A ledger directory EXISTS — so if the `import()` failure were still
-    // sharing a `catch` with the read failure, this is where the two would be
-    // confused in the other direction and produce a spurious warning.
-    fs.mkdirSync(path.join(tmp, '.objectstack/installed-packages'), { recursive: true });
+    // A ledger that DOES declare an installation-wide unique. Before #5644 this
+    // exact tree printed `✓ Unique scope` and `invoice.code` appeared nowhere,
+    // under `--verbose` included — the false PASS, measured.
+    const ledger = path.join(tmp, '.objectstack/installed-packages');
+    fs.mkdirSync(ledger, { recursive: true });
+    fs.writeFileSync(
+      path.join(ledger, 'billing.json'),
+      JSON.stringify({
+        manifestId: 'billing',
+        manifest: {
+          objects: [
+            {
+              name: 'invoice',
+              label: 'Invoice',
+              fields: [{ name: 'code', type: 'text', label: 'Code', unique: 'global' }],
+            },
+          ],
+        },
+      }),
+    );
 
     const savedPosture = process.env.OS_TENANCY_POSTURE;
     process.env.OS_TENANCY_POSTURE = 'isolated';
     const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tmp);
 
     vi.resetModules();
+    // The package RESOLVES — it is a workspace dependency of this very package
+    // — and its evaluation throws. That is the "installed and broken" state,
+    // and the classifier's real `import.meta.resolve()` is what recognises it.
     vi.doMock('@objectstack/cloud-connection', () => {
-      throw new Error("Cannot find package '@objectstack/cloud-connection'");
+      throw new Error('simulated corrupt build artefact');
     });
     const { default: FreshDoctor } = await import('./doctor.js');
 
@@ -556,7 +667,7 @@ describe('the optional package being absent stays completely silent (#5412 does 
     }) as never);
 
     try {
-      await FreshDoctor.run([], { root: CLI_ROOT });
+      await FreshDoctor.run(['--verbose'], { root: CLI_ROOT });
     } catch (err) {
       if (!(err instanceof Error) || !err.message.startsWith('__PROCESS_EXIT__')) throw err;
     } finally {
@@ -569,9 +680,179 @@ describe('the optional package being absent stays completely silent (#5412 does 
     }
 
     const out = plain(logs.join('\n'));
-    // Silence about the ledger, and the advisory's own half still reports.
+
+    // ① THE assertion of #5644: no clean bill over a ledger nobody read.
+    expect(out).not.toContain(CLEAN_BILL);
+    // ② …replaced by a row that names what could not be loaded.
+    expect(out).toContain(READER_HEADLINE);
+    expect(out).toContain('Unique scope');
+    // ③ NOT the directory-level row: the directory was never reached, and its
+    //    text asserts a ledger exists — which doctor cannot know from here.
     expect(out).not.toContain(LEDGER_HEADLINE);
+    expect(out).not.toContain(SKIPPED_HEADLINE);
+    // ④ The verbose channel carries the cause, like every other warning row.
+    expect(out).toContain('cause:');
+    // Gauge: warning, the report finishes, exit stays 0.
+    expect(out).toContain('Environment is functional but has some warnings');
+  }, 60_000);
+
+  it('quotes the load failure verbatim and keeps the row to one line', async () => {
+    // Driven through the loader seam so the cause is a fixed string rather than
+    // whatever the mocking machinery wraps a thrown error in. What the previous
+    // case proves is that the REAL mechanism reaches this row; what this one
+    // proves is what the row says once it does.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'os-doctor-5644-cause-'));
+    fs.mkdirSync(path.join(tmp, 'node_modules'));
+    fs.writeFileSync(
+      path.join(tmp, 'objectstack.config.ts'),
+      [
+        'export default {',
+        "  manifest: { name: 'os5644c', label: 'Cause', version: '1.0.0' },",
+        "  objects: [{ name: 'account', label: 'Account', fields: [{ name: 'name', type: 'text', label: 'Name' }] }],",
+        '};',
+        '',
+      ].join('\n'),
+    );
+
+    const savedPosture = process.env.OS_TENANCY_POSTURE;
+    process.env.OS_TENANCY_POSTURE = 'isolated';
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tmp);
+
+    vi.resetModules();
+    vi.doMock('../utils/optional-package.js', () => ({
+      loadOptionalPackage: async () => ({
+        state: 'broken',
+        cause: new Error(
+          "Cannot find module '/app/node_modules/@objectstack/cloud-connection/dist/index.js'",
+        ),
+      }),
+    }));
+    const { default: FreshDoctor } = await import('./doctor.js');
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+      logs.push(a.join(' '));
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__PROCESS_EXIT__:${code}`);
+    }) as never);
+
+    let exitCode: number | undefined;
+    try {
+      await FreshDoctor.run(['--verbose'], { root: CLI_ROOT });
+    } catch (err) {
+      if (!(err instanceof Error) || !err.message.startsWith('__PROCESS_EXIT__')) throw err;
+      exitCode = Number(err.message.split(':')[1]);
+    } finally {
+      logSpy.mockRestore();
+      exitSpy.mockRestore();
+      cwdSpy.mockRestore();
+      vi.doUnmock('../utils/optional-package.js');
+      vi.resetModules();
+      if (savedPosture === undefined) delete process.env.OS_TENANCY_POSTURE;
+      else process.env.OS_TENANCY_POSTURE = savedPosture;
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+
+    const out = plain(logs.join('\n'));
+    const row = out.split('\n').find((l) => l.includes(READER_HEADLINE)) ?? '';
+
+    // The producer's own words, on the row and in the detail.
+    expect(row).toContain('dist/index.js');
+    expect(out).toContain('IS installed here');
+    // One row is one line — the cause is folded, never wrapped into the report.
+    expect(row.includes('\n')).toBe(false);
+    expect(out).not.toContain(CLEAN_BILL);
+    expect(exitCode).toBeUndefined();
+  }, 60_000);
+});
+
+describe('the optional package being genuinely ABSENT stays completely silent (#5412, unchanged)', () => {
+  /**
+   * ③, second half — the one branch that is SUPPOSED to swallow, and the
+   * constraint #5644 was not allowed to break: `os doctor` must run to
+   * completion, and print its clean bill, in a checkout that never had the
+   * optional package.
+   *
+   * Simulated through the loader seam, and it has to be. Absence is now defined
+   * by RESOLUTION — `@objectstack/cloud-connection` is a declared dependency of
+   * this package, so it resolves here no matter what a module mock does to its
+   * evaluation, and a mock that throws now means "installed and broken" (the
+   * describe above). The seam is where the two states are decided, so it is the
+   * seam this case has to speak through.
+   *
+   * Which layer proves what, deliberately split:
+   *   - that a real unresolvable specifier IS classified absent, against the
+   *     real runtime: `utils/optional-package.test.ts`.
+   *   - that doctor stays silent when told so: here.
+   *
+   * No `assertLedgerReaderIsBuilt` preflight, and that is not a rollback of
+   * #5612: the preflight exists to stop a case passing because the real package
+   * happened to be unloadable. Nothing here reads the real package at all — the
+   * seam is mocked — so there is no accident left for it to catch.
+   */
+  afterEach(() => {
+    vi.doUnmock('../utils/optional-package.js');
+    vi.resetModules();
+  });
+
+  it('prints no ledger row, and still prints the clean bill', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'os-doctor-5412-nopkg-'));
+    fs.mkdirSync(path.join(tmp, 'node_modules'));
+    fs.writeFileSync(
+      path.join(tmp, 'objectstack.config.ts'),
+      [
+        'export default {',
+        "  manifest: { name: 'os5412np', label: 'No Package', version: '1.0.0' },",
+        "  objects: [{ name: 'account', label: 'Account', fields: [{ name: 'name', type: 'text', label: 'Name' }] }],",
+        '};',
+        '',
+      ].join('\n'),
+    );
+    // A ledger directory EXISTS — so if "not installed" were confused with
+    // "installed and broken" in the other direction, this is where the
+    // confusion would surface as a spurious warning.
+    fs.mkdirSync(path.join(tmp, '.objectstack/installed-packages'), { recursive: true });
+
+    const savedPosture = process.env.OS_TENANCY_POSTURE;
+    process.env.OS_TENANCY_POSTURE = 'isolated';
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tmp);
+
+    vi.resetModules();
+    vi.doMock('../utils/optional-package.js', () => ({
+      loadOptionalPackage: async () => ({ state: 'absent' }),
+    }));
+    const { default: FreshDoctor } = await import('./doctor.js');
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+      logs.push(a.join(' '));
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__PROCESS_EXIT__:${code}`);
+    }) as never);
+
+    try {
+      await FreshDoctor.run(['--verbose'], { root: CLI_ROOT });
+    } catch (err) {
+      if (!(err instanceof Error) || !err.message.startsWith('__PROCESS_EXIT__')) throw err;
+    } finally {
+      logSpy.mockRestore();
+      exitSpy.mockRestore();
+      cwdSpy.mockRestore();
+      if (savedPosture === undefined) delete process.env.OS_TENANCY_POSTURE;
+      else process.env.OS_TENANCY_POSTURE = savedPosture;
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+
+    const out = plain(logs.join('\n'));
+    // Silence about the ledger, in all three of its shapes…
+    expect(out).not.toContain(LEDGER_HEADLINE);
+    expect(out).not.toContain(SKIPPED_HEADLINE);
+    expect(out).not.toContain(READER_HEADLINE);
+    // …not even the package's name, under `--verbose`.
     expect(out).not.toContain('cloud-connection');
+    // …and the advisory's own half still reports.
     expect(out).toContain(CLEAN_BILL);
   }, 60_000);
 });

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -10,6 +10,11 @@ import { normalizeStackInput } from '@objectstack/spec';
 import { printHeader, printSuccess, printWarning, printError, printStep, printInfo } from '../utils/format.js';
 import { loadConfig, configExists } from '../utils/config.js';
 import { checkSpecVersionGap } from '../utils/spec-version.js';
+// #5644 — "the optional package is not installed" and "it is installed and
+// will not load" are two facts, and one `catch` around `import()` cannot tell
+// them apart. That classification lives in one place, with the measurements
+// behind it written down there.
+import { loadOptionalPackage } from '../utils/optional-package.js';
 import { validateWidgetBindings } from '@objectstack/lint';
 import {
   resolveTenancyPosture,
@@ -819,6 +824,17 @@ interface InstalledPackageLedgerReading {
   skipped: SkippedLedgerEntry[];
   /** Present ONLY when the ledger EXISTS and could not be read. */
   failure?: { cause: unknown };
+  /**
+   * Present ONLY when the package that READS the ledger is installed and could
+   * not be loaded (#5644).
+   *
+   * A THIRD fact, one boundary above `failure`: that one is "the ledger is
+   * there and I could not read it", this one is "the thing I read ledgers with
+   * is there and I could not load it". Both leave the ledger unexamined; only
+   * this one leaves doctor unable to say where the ledger even is, because the
+   * directory name is the missing package's own constant.
+   */
+  readerFailure?: { cause: unknown };
 }
 
 /**
@@ -865,17 +881,34 @@ interface SkippedLedgerEntry {
  * the producer's parsing rules in the consumer — the lenient-consumer
  * workaround this repo forbids — so `list()` was changed to REPORT what it
  * skipped, and this function passes that through as `skipped`.
+ *
+ * And a FOURTH, one boundary ABOVE case 1 (#5644). Case 1 says "the specifier
+ * does not resolve"; the `catch` that implemented it said "the `import()`
+ * threw", which is not the same sentence. A package that IS installed and will
+ * not load — a pruned or unbuilt `dist/`, an interrupted install, an artefact
+ * that throws while it evaluates — threw too, and was answered with the silence
+ * meant for a package that was never there. The ledger went unread with no
+ * trace, and the report printed `✓ Unique scope` for the third time in this
+ * function's history: now over a reader it could not even start. The two are
+ * separated by `loadOptionalPackage()` (`utils/optional-package.ts` carries how,
+ * and the measurements behind it); only the genuinely-absent half stays silent.
  */
 async function readInstalledPackageEntries(cwd: string): Promise<InstalledPackageLedgerReading> {
-  let mod: any;
-  try {
-    // Dynamic, like serve.ts's cloud-connection load: `os doctor` must still
-    // run in a checkout where the optional package is not resolvable. THIS
-    // catch, and only this one, is allowed to be silent.
-    mod = await import('@objectstack/cloud-connection');
-  } catch {
-    return { entries: [], skipped: [] };
+  // Dynamic, like serve.ts's cloud-connection load: `os doctor` must still run
+  // in a checkout where the optional package is not resolvable.
+  const load = await loadOptionalPackage('@objectstack/cloud-connection');
+  // Case 1, and ONLY case 1, is allowed to be silent: no package is here, so
+  // nothing was installed through it and nothing went unchecked.
+  if (load.state === 'absent') return { entries: [], skipped: [] };
+  // Case 4. Reported whether or not a ledger directory exists: doctor cannot
+  // honestly claim there is no ledger when the constant naming the ledger's
+  // location is an export of the package that would not load. Gating this row
+  // on `fs.existsSync()` is the rejected option B of #5644 — it reads "has
+  // anything ever been installed" as a proxy for "should this package be here".
+  if (load.state === 'broken') {
+    return { entries: [], skipped: [], readerFailure: { cause: load.cause } };
   }
+  const mod: any = load.module;
 
   const dir = path.join(cwd, mod.DEFAULT_INSTALLED_PACKAGES_DIR ?? '.objectstack/installed-packages');
   try {
@@ -908,6 +941,14 @@ interface UniqueScopeReading {
    * say it does not.
    */
   skippedLedgerEntries: SkippedLedgerEntry[];
+  /**
+   * Present when the ledger half could not even START — the package doctor
+   * reads ledgers through is installed and would not load (#5644). Suppresses
+   * the success line for the same reason `ledgerFailure` does, and is reported
+   * separately because it is a different fact with a different remedy: repair
+   * the INSTALL of `@objectstack/cloud-connection`, not the ledger.
+   */
+  ledgerReaderFailure?: { cause: unknown };
 }
 
 /**
@@ -952,6 +993,7 @@ async function findUnscopedGlobalUniques(
     advisories: out,
     skippedLedgerEntries: ledger.skipped,
     ...(ledger.failure ? { ledgerFailure: ledger.failure } : {}),
+    ...(ledger.readerFailure ? { ledgerReaderFailure: ledger.readerFailure } : {}),
   };
 }
 
@@ -1301,6 +1343,56 @@ export function installedPackageLedgerSkippedEntriesCheck(
   };
 }
 
+/**
+ * What doctor reports when the package it reads ledgers THROUGH is installed
+ * and will not load (#5644).
+ *
+ * The third sibling of `installedPackageLedgerFailureCheck`, one boundary
+ * above it. That one fires when the ledger directory could not be enumerated;
+ * `installedPackageLedgerSkippedEntriesCheck` fires when individual files in it
+ * would not parse; this one fires when the reader itself never started. All
+ * three produce the identical false PASS if unreported — `✓ Unique scope` over
+ * installed packages nobody looked at — so all three take the `Unique scope`
+ * name column, hold back the success line, and stay warnings.
+ *
+ * What is deliberately NOT a condition here: whether
+ * `.objectstack/installed-packages/` exists. Doctor does not know that it does
+ * not — the directory's name is `DEFAULT_INSTALLED_PACKAGES_DIR`, an export of
+ * the very package that would not load, and answering from the hard-coded
+ * fallback would be doctor claiming knowledge it just lost. Making the row
+ * conditional on the directory was option B of #5644 and was rejected on
+ * exactly that ground: "has anything ever been installed" is not a proxy for
+ * "should this package be here".
+ *
+ * The row exists because the ALTERNATIVE is provably worse, and was measured:
+ * with the package present-but-unloadable, a ledger declaring an
+ * installation-wide `unique` produced `✓ Unique scope` and the finding
+ * appeared nowhere, under `--verbose` included. In-repo this state is reached
+ * daily — any worktree where `packages/cloud-connection` is unbuilt — and its
+ * silence is what sent #5612 chasing a report face that had never regressed.
+ */
+export function installedPackageLedgerReaderFailureCheck(err: unknown): HealthCheckResult {
+  const cause = describeThrown(err);
+  return {
+    name: 'Unique scope',
+    status: 'warning',
+    message:
+      'Could not load the installed-package ledger reader (installed packages NOT checked '
+      + `for installation-wide uniques) — ${reportRowHeadline(cause)}`,
+    fix:
+      '`@objectstack/cloud-connection` IS installed here — its specifier resolves — and loading\n'
+      + '      it threw. That package is how `os doctor` reads `.objectstack/installed-packages/`,\n'
+      + '      so this half of the check never started: an installed app declaring an\n'
+      + '      installation-wide `unique` would not have appeared. Doctor cannot even tell you\n'
+      + '      whether a ledger is present — the directory’s name is one of that package’s\n'
+      + '      exports.\n'
+      + '      A checkout that never installed the package says nothing at all, so this row means\n'
+      + '      the install itself is broken: reinstall it, or — in a monorepo checkout — build it\n'
+      + '      (`pnpm --filter @objectstack/cloud-connection build`).\n'
+      + `      cause: ${indentUnderGutter(cause)}`,
+  };
+}
+
 // ─── Command ────────────────────────────────────────────────────────
 
 export default class Doctor extends Command {
@@ -1599,11 +1691,12 @@ export default class Doctor extends Command {
         // so nothing is silently lost.
         if (postureReading.ok && postureGatesGlobalUniques(postureReading.posture)) {
           printStep("Checking unique scopes against the 'isolated' tenancy posture...");
-          const { advisories, ledgerFailure, skippedLedgerEntries } = await findUnscopedGlobalUniques(
-            cwd,
-            config,
-            postureReading.posture,
-          );
+          const {
+            advisories,
+            ledgerFailure,
+            ledgerReaderFailure,
+            skippedLedgerEntries,
+          } = await findUnscopedGlobalUniques(cwd, config, postureReading.posture);
           if (advisories.length > 0) {
             hasWarnings = true;
             for (const { source, finding } of advisories) {
@@ -1629,7 +1722,18 @@ export default class Doctor extends Command {
               flags.verbose,
             );
           }
-          if (ledgerFailure) {
+          // #5644 — the same claim failing one boundary UP: the reader
+          // package is installed and would not load, so neither the directory
+          // nor the entries were ever reached. Mutually exclusive with the two
+          // above (nothing downstream of a reader that never loaded can also
+          // fail), so it is an `else if` rather than a fourth independent row.
+          if (ledgerReaderFailure) {
+            hasWarnings = true;
+            renderHealthCheckResult(
+              installedPackageLedgerReaderFailureCheck(ledgerReaderFailure.cause),
+              flags.verbose,
+            );
+          } else if (ledgerFailure) {
             hasWarnings = true;
             renderHealthCheckResult(installedPackageLedgerFailureCheck(ledgerFailure.cause), flags.verbose);
           } else if (advisories.length === 0 && skippedLedgerEntries.length === 0) {

--- a/packages/cli/src/utils/optional-package.test.ts
+++ b/packages/cli/src/utils/optional-package.test.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `loadOptionalPackage()` tells "not installed" from "installed and broken"
+ * (#5644).
+ *
+ * Every case below drives the REAL mechanism — a real `import()` and a real
+ * `import.meta.resolve()` against real files on disk. Nothing is mocked,
+ * because the whole subject of this module is what the runtime actually
+ * answers, and a mocked resolver would pin the assumption rather than the
+ * behaviour. `os doctor`'s three-state report is built on top of this, and its
+ * own file mocks THIS module in turn; the split is deliberate — the
+ * classification is proven here against the runtime, the rendering is proven
+ * there against doctor.
+ *
+ * The state each case stands for, in the world the caller cares about:
+ *
+ *   - absent                → the optional package was never installed.
+ *   - broken / throwing     → an artefact that blows up while it evaluates.
+ *   - broken / entry gone   → an unbuilt or pruned `dist/`. THE case a
+ *                             `catch`-only classifier gets wrong: it fails with
+ *                             `ERR_MODULE_NOT_FOUND`, exactly like a package
+ *                             that is not installed at all.
+ *   - broken / dep missing  → the package is fine, something under it is not.
+ *   - loaded                → nothing to report.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { loadOptionalPackage } from './optional-package.js';
+
+/** A specifier nothing in this workspace resolves — genuinely not installed. */
+const NEVER_INSTALLED = '@objectstack/not-a-real-package-5644';
+
+let tmp: string;
+/** Absolute `file:` URL, so resolution is anchored on the file, not on a base. */
+const fixtureUrl = (name: string) => pathToFileURL(path.join(tmp, name)).href;
+
+beforeAll(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'os-5644-optional-pkg-'));
+  fs.writeFileSync(path.join(tmp, 'healthy.mjs'), 'export const marker = "loaded";\n');
+  fs.writeFileSync(path.join(tmp, 'throws.mjs'), 'throw new Error("boom while evaluating");\n');
+  fs.writeFileSync(
+    path.join(tmp, 'missing-dep.mjs'),
+    'import "@objectstack/not-a-real-dependency-5644";\nexport const marker = "unreachable";\n',
+  );
+});
+
+afterAll(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('loadOptionalPackage — the two facts one `catch` used to merge', () => {
+  it('reports a specifier that does not resolve as absent, and carries no cause', async () => {
+    const load = await loadOptionalPackage(NEVER_INSTALLED);
+
+    // Silence downstream depends on this: `os doctor` must run to completion
+    // in a checkout that never had the optional package.
+    expect(load.state).toBe('absent');
+    // An absent package has nothing to say, so there is nothing to report.
+    expect(load).not.toHaveProperty('cause');
+  });
+
+  it('reports a module that throws while evaluating as broken, with what it threw', async () => {
+    const load = await loadOptionalPackage(fixtureUrl('throws.mjs'));
+
+    expect(load.state).toBe('broken');
+    expect((load as { cause: Error }).cause).toBeInstanceOf(Error);
+    // Quoted, not paraphrased — the row doctor prints repeats this verbatim.
+    expect((load as { cause: Error }).cause.message).toContain('boom while evaluating');
+  });
+
+  it('reports a RESOLVABLE module whose file is not there as broken, not absent', async () => {
+    // The unbuilt / pruned `dist/` state, and the reason this module exists.
+    // Node answers it with `ERR_MODULE_NOT_FOUND` — the same code a package
+    // that was never installed produces — so classifying by the error alone
+    // returns "absent" here and the caller goes silent over a package that IS
+    // installed. Resolution is what separates them: it succeeds, because the
+    // specifier is resolvable even though the file it names is missing.
+    const load = await loadOptionalPackage(fixtureUrl('not-built-yet.mjs'));
+
+    expect(load.state).toBe('broken');
+    expect(String((load as { cause: Error }).cause.message)).toContain('not-built-yet.mjs');
+  });
+
+  it('reports a package whose own dependency is missing as broken, not absent', async () => {
+    // The same trap one level down: the failure is `ERR_MODULE_NOT_FOUND` and
+    // it is NOT about this package, which is present and resolvable.
+    const load = await loadOptionalPackage(fixtureUrl('missing-dep.mjs'));
+
+    expect(load.state).toBe('broken');
+    expect(String((load as { cause: Error }).cause.message)).toContain(
+      '@objectstack/not-a-real-dependency-5644',
+    );
+  });
+
+  it('hands back the namespace when the package loads', async () => {
+    const load = await loadOptionalPackage(fixtureUrl('healthy.mjs'));
+
+    expect(load.state).toBe('loaded');
+    expect((load as { module: { marker: string } }).module.marker).toBe('loaded');
+  });
+
+  it('resolves a real workspace package rather than mistaking it for absent', async () => {
+    // The end-to-end control: the package `os doctor` actually loads. If this
+    // ever came back `absent` in a built worktree, every ledger check in this
+    // repo would be silently skipped and nothing else would notice.
+    const load = await loadOptionalPackage('@objectstack/cloud-connection');
+
+    expect(load.state).toBe('loaded');
+  });
+});

--- a/packages/cli/src/utils/optional-package.ts
+++ b/packages/cli/src/utils/optional-package.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Loading a package the caller can live without — with "it is not here" and
+ * "it is here and broken" kept apart (#5644).
+ *
+ * ── Why this exists ──────────────────────────────────────────────────────
+ *
+ * The shape it replaces is one `try` around a dynamic `import()` whose `catch`
+ * means "not installed":
+ *
+ *     try { mod = await import('@objectstack/cloud-connection'); }
+ *     catch { return nothing; }
+ *
+ * That is right for exactly one of the two things it catches. A specifier that
+ * does not resolve IS the optional package being absent, and silence is the
+ * correct, deliberate answer — `os doctor` must run to completion in a checkout
+ * that never had it. But a package that IS there and fails to load — an
+ * interrupted install, a pruned or unbuilt `dist/`, an artefact that throws
+ * while it evaluates, a transitive dependency missing under it — arrives in the
+ * same `catch` and is answered with the same silence. The caller then reports
+ * on a world it never looked at. In `os doctor` that produced a clean bill of
+ * health over an installed-package ledger it had not read (#5644, the `import`
+ * boundary of the same false PASS #5412 fixed at the `readdir` boundary).
+ *
+ * ── How the two are told apart ───────────────────────────────────────────
+ *
+ * Two mechanisms, in this order, both owned elsewhere in this repo:
+ *
+ *   1. **The error is not a module-not-found error at all** — the module was
+ *      found and threw while evaluating. Nothing more needs asking: that is a
+ *      broken package under every resolver. `isModuleNotFoundError()` is the
+ *      repo's single shared owner of this classification (`@objectstack/types`,
+ *      framework#3265); `serve.ts` reads it for the same purpose.
+ *   2. **It IS a module-not-found error** — which still covers two worlds, and
+ *      the error alone cannot separate them. `import.meta.resolve()` can, and
+ *      is the documented, stable API for asking it (Node >= 20.6; this package
+ *      requires >= 22). Measured on Node 22.22 against the real package:
+ *
+ *        | state                                   | resolve()   | import()    |
+ *        |-----------------------------------------|-------------|-------------|
+ *        | package absent                          | throws      | throws      |
+ *        | present, `dist/` missing (unbuilt/prun.) | RESOLVES    | throws      |
+ *        | present, entry throws while evaluating  | resolves    | throws      |
+ *        | healthy                                 | resolves    | loads       |
+ *
+ *      The second row is the one that matters and the reason `resolve()` is
+ *      used rather than `createRequire().resolve()`: CJS resolution stats the
+ *      entry file, so it fails there too and collapses the row back into
+ *      "absent" — and it answers for the `require` condition, i.e. a DIFFERENT
+ *      artefact than the one `import()` loads. `import.meta.resolve()` answers
+ *      for the same artefact and does not stat it, so "the package is there"
+ *      and "its entry is loadable" stay two questions.
+ *
+ * The resolve call is made only after `import()` has already failed: it costs
+ * nothing on the happy path, and the loaded module — never the resolver — stays
+ * the thing that decides whether loading worked.
+ *
+ * ── The one thing this must never do ─────────────────────────────────────
+ *
+ * Report a package that is genuinely absent. Every `absent` answer here is a
+ * caller's silence; every `broken` answer is a caller's finding. When the
+ * classification cannot be made — a runtime with no `import.meta.resolve` —
+ * only step 1's certainty is kept and the ambiguous case stays `absent`, i.e.
+ * the pre-#5644 behaviour, never a false alarm in a checkout that never
+ * installed anything.
+ */
+
+import { isModuleNotFoundError } from '@objectstack/types';
+
+/**
+ * What became of an optional package's load. Three states, because there are
+ * three facts — the two-state version of this type is the defect.
+ */
+export type OptionalPackageLoad =
+  /** The specifier does not resolve. The package is not installed. */
+  | { state: 'absent' }
+  /**
+   * It loaded. `module` is its namespace — `any`, like every other read of an
+   * optional package in this package: nothing here compiles against it.
+   */
+  | { state: 'loaded'; module: any }
+  /** It is installed and could not be loaded. `cause` is what was thrown. */
+  | { state: 'broken'; cause: unknown };
+
+/**
+ * True when `specifier` resolves from THIS module — the same base the
+ * `import()` below uses, so the two answer about the same package.
+ *
+ * A runtime without `import.meta.resolve` cannot answer, and says so by
+ * returning `false`: the caller then keeps the ambiguous case silent (see the
+ * header). Node 22+, this package's floor, always has it; so does vitest.
+ */
+function specifierResolves(specifier: string): boolean {
+  const resolve = (import.meta as ImportMeta & { resolve?: (s: string) => string }).resolve;
+  if (typeof resolve !== 'function') return false;
+  try {
+    resolve(specifier);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Load an optional package, saying which of the three things happened.
+ *
+ * @param specifier Bare package name, resolved from this file exactly as a
+ * static import in it would be.
+ */
+export async function loadOptionalPackage(specifier: string): Promise<OptionalPackageLoad> {
+  try {
+    const module = await import(specifier);
+    return { state: 'loaded', module };
+  } catch (cause) {
+    // Anything that is not a module-not-found error was thrown BY the package:
+    // it is present by definition, whatever any resolver would say.
+    if (!isModuleNotFoundError(cause)) return { state: 'broken', cause };
+    // A module-not-found error is either the package being absent or something
+    // missing UNDER a package that is present. Only the resolver knows.
+    return specifierResolves(specifier) ? { state: 'broken', cause } : { state: 'absent' };
+  }
+}

--- a/packages/cli/src/utils/optional-package.ts
+++ b/packages/cli/src/utils/optional-package.ts
@@ -105,8 +105,10 @@ function specifierResolves(specifier: string): boolean {
 /**
  * Load an optional package, saying which of the three things happened.
  *
- * @param specifier Bare package name, resolved from this file exactly as a
- * static import in it would be.
+ * @param specifier What a static import in THIS file would be given — normally
+ * a bare package name, resolved against this file's own `node_modules` chain.
+ * An absolute `file:` URL resolves as itself and is what the tests use to stand
+ * a real broken artefact up on disk.
  */
 export async function loadOptionalPackage(specifier: string): Promise<OptionalPackageLoad> {
   try {


### PR DESCRIPTION
Fixes #5644

按分诊 21:56Z 裁定的**方案 A**(先解析再加载)实现。B(用 ledger 目录在场做代理)、C(维持现状写成已知取舍)均未采用。

## 前提复核:成立(先证后改)

在已构建的工作树里,把 `@objectstack/cloud-connection` 置为「在场但求值抛错」,并放一份**声明了 installation-wide `unique`** 的 ledger 条目,`OS_TENANCY_POSTURE=isolated` 跑 `os doctor --verbose`:

```
  → Checking unique scopes against the 'isolated' tenancy posture...
  ✓ Unique scope          No unconfirmed installation-wide uniques for this 'isolated' environment
```

`invoice.code` 这条本该出现的 finding 一行都没有,连 `--verbose` 也没有。issue 正文描述的假 PASS 在 `origin/main` 上逐字复现。

## 判别机制:为什么是 `import.meta.resolve`,不是 `createRequire().resolve()`

Node 22.22 上对**真包**实测的四态(见 `packages/cli/src/utils/optional-package.ts` 头注释):

| 状态 | `import.meta.resolve()` | `createRequire().resolve()` | `import()` |
|---|---|---|---|
| 包不在 | 抛 | 抛 | 抛 |
| 包在、`dist/` 缺失(未构建/被裁剪) | **返回 URL** | **抛** | 抛 |
| 包在、入口求值抛错 | 返回 URL | 返回路径 | 抛 |
| 健康 | 返回 URL | 返回路径 | 加载 |

第二行是关键,也是不能用 CJS 解析的两个理由:它会 stat 入口文件,于是这一行塌回「没装」——而这恰是 issue 正文那条复现路径(`mv packages/cloud-connection/dist /tmp/x`)所在的态;它还按 `require` 条件解析,回答的是**另一个产物**(`index.cjs`),而 `import()` 加载的是 `index.js`。`import.meta.resolve` 回答同一个产物,且不 stat,所以「包在不在」与「入口能不能加载」保持两个问题。

判别分两步,两步都复用仓内既有的所有者:

1. 抛出的**不是** module-not-found 错误 → 一定是包自己抛的,不必再问解析器。`isModuleNotFoundError()`(`@objectstack/types`,framework#3265 指定的单一所有者,`serve.ts` 同样读它)。
2. 是 module-not-found 错误 → 仍然覆盖两个世界,只有解析器能分开(上表第一、二行)。

解析只在 `import()` 已经失败之后才调用:happy path 零成本,且判定「加载是否成功」的始终是加载本身,不是解析器。无 `import.meta.resolve` 的运行时(本包 engines 是 Node 22+,不会发生)只保留第 1 步的确定性,含混态一律归 `absent`——宁可退回改动前的沉默,也绝不在从未装过该包的 checkout 里误报。这条硬约束原样保留。

## 报法

新增第三个同族行,与 #5412 目录级行、#5413 条目级行同档:`Unique scope` 名列、`warning`、退出码不变、错误原文入 `--verbose` 详情,走 `renderHealthCheckResult`(#5410)。

```
  ⚠ Unique scope          Could not load the installed-package ledger reader (installed packages
                          NOT checked for installation-wide uniques) — Cannot find module …
```

措辞与 #5412 那行刻意区分(`load` 对 `read`,且不是其超串),因为**事实与药方都不同**:修的是 `@objectstack/cloud-connection` 的安装,不是 ledger。这一行也刻意**不**以 `.objectstack/installed-packages/` 是否存在为条件——ledger 目录名是那个加载不了的包自己的导出常量,doctor 无从断言「没有 ledger」;拿目录在场当条件正是被否决的方案 B。

代价说清楚:未构建 `packages/cloud-connection` 的仓内工作树,`isolated` 下跑 doctor 会多这一条 warning。而这个态的沉默,正是 #5612 追查一个从未回退的报告面的起点。

## 测试(三态各就各位)

- 新增 `packages/cli/src/utils/optional-package.test.ts`(6 例,**全真机制、零 mock**):真不可解析的 specifier → `absent`;求值抛错 → `broken`;**可解析但文件不在** → `broken`(未构建 `dist/` 的形态,单看错误码会误判成 `absent` 的那一例);包自身依赖缺失 → `broken`;健康 → `loaded`;外加真 workspace 包的对照例。
- `doctor-ledger-read-failure.test.ts`:17 → 24 例。新增 5 例渲染单测 + 2 例 e2e。
- **原最后一个 describe 是整批改动的重点**:它此前用「让模块求值抛错」来**模拟包不在**并断言沉默——在新契约下那恰恰是**另一个**态。于是重排为两个 describe:同一份复现留在原地、改钉它现在该产出的行(#5413 用过的「换断言不换复现」处置);而「真没装 → 沉默 + 照打 clean bill」这条契约移到自己的 describe,通过 loader 接缝表达(该包是本包的声明依赖,module mock 改不了它的**可解析性**,再用旧写法就是钉一个不存在的态)。分层是刻意的:分类本身对着真运行时钉在 `optional-package.test.ts`,渲染对着 doctor 钉在这里。
- **#5643 的 `beforeAll` 前置断言未回退**,并保留在它仍有判别力的位置:「在场且坏」那个 describe 里,未构建的工作树会**因为同一个原因**产出同一行,前置断言正是把模拟与巧合分开的那层。新增的 absent describe 不加它,并写明理由——那里根本不读真包(接缝已 mock),没有「因巧合而绿」可防;这是 #5612 同一条推理的应用,不是放宽。

## 反向验证(方向先判后跑,两处都是 before-green/after-red)

1. 把 `optional-package.ts` 的解析限支删掉(所有 module-not-found 一律判 `absent`)。预测:两条判别用例红,其余绿。实测:

```
× reports a RESOLVABLE module whose file is not there as broken, not absent
× reports a package whose own dependency is missing as broken, not absent
Tests  2 failed | 4 passed (6)
```

2. 把 doctor 的 `broken` 分支还原成改动前的合并(broken 也当 absent)。预测:两条 e2e 红,absent 那条仍绿(它走接缝)。实测:

```
× withholds the clean bill and names the reader, with a ledger it never read
× quotes the load failure verbatim and keeps the row to one line
Tests  2 failed | 22 passed (24)
```

## 验收

- `pnpm --filter @objectstack/cli test`:`83 passed (83)` / `825 passed (825)`(改动前为 82 文件 / 812 例)
- 两个改动文件单跑:`30 passed (30)`
- `pnpm --filter @objectstack/cli typecheck` 绿;改动文件 eslint 零告警
- `node scripts/check-nul-bytes.mjs` OK;改动文件另做控制字节自扫,无命中
- changeset:`@objectstack/cli` patch(行为变化:doctor 对坏包新增 warning 行)

## 边界

未动 `packages/cloud-connection` 本体、未动 `serve.ts`(它对同一个包的点名告警只是仓内对照读法)、未动 `packages/client/**`(#5638 在飞)。#5429(posture 门禁触发条件)现象不同,未收敛、未触碰。

一处界外观察,**未新立单**:在干净工作树里跑一次构建会重写 `packages/spec/authorable-surface.base.json`(baseRev + 三个 `EmailServiceConfig` 键)。已按关键词查重,命中既有 open 单 #5358 / #5370,同一现象,不另开;本 PR 已把该文件还原,不含在改动里。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FNvXhtSdnEGEfLEsMmvxh

---
_Generated by [Claude Code](https://claude.ai/code/session_016FNvXhtSdnEGEfLEsMmvxh)_