### PR TITLE
fix(service-automation): connector 降级路径的两条日志改用结构化 meta (#5636)

### DIFF
--- a/.changeset/connector-degrade-cause.md
+++ b/.changeset/connector-degrade-cause.md
@@ -1,0 +1,52 @@
+---
+"@objectstack/service-automation": patch
+---
+
+fix(service-automation): connector 降级路径的两条日志改用结构化 `meta`,message 保持单行 (#5636)
+
+## 接缝
+
+`degradeConnectorInstance`(#3017 的降级/重试路径)有两条记录报告的是**外来**失败,却把
+它插进了日志 message —— 与 #5048(flow 绑定)、#5575(`reconcileDeclaredConnectors` 的
+`fail()`)同一类,是那两单范围之外的第三个接缝:
+
+- **husk 注册失败**(`warn`):`err` 来自 `engine.registerDegradedConnector` →
+  `ConnectorSchema.parse`,catch 自己的注释就写着「the entry's def no longer parses」,
+  也就是说这里预期接到的正是 `ZodError` —— 它的 `.message` 是 issue 数组的多行 JSON
+  dump,第一行只有一个 `[`。
+- **降级公告**(`error`):文本是 `ConnectorUpstreamUnavailableError.message`,由第三方
+  provider factory 构造(ADR-0097 明确鼓励第三方去写)。spec 只定义错误类、不约束文本,
+  所以上游 SDK 的多行失败会原样落在这里。
+
+## 危害:这条 `warn` 的下游与 #5575 的 `error` 不同(实测)
+
+`ObjectLogger` 把 `warn` 送 stdout、`error`/`fatal` 送 stderr,而 `serve` 的启动静默窗口
+只包了 `process.stdout.write`。#5575 的接缝全是 `error`,所以那一单的结论是「启动缓冲根本
+看不到」;这一条不同,而且差别是**测出来**的,不是推的:
+
+- 它是 `warn` → stdout,缓冲**确实**看得到;
+- 它在**冷启动**就会跑 —— `materializeDeclaredConnectors(ctx, { fatal: true })` 遇到上游
+  不可达是降级、不是抛错 —— 而窗口此时正开着(`serve` 在 config 加载前接管 stdout,直到
+  banner 打印才恢复);
+- `BootLogCapture.offer()` 只在 `classifyBootLogLine` 能在该物理行上找到 `<ts> <LEVEL>`
+  头时才保留它,所以插值 dump 的每一条续行是被**直接丢弃**,不只是难解析。
+
+对一份 13 行的插值 ZodError 实测:写出 13 行物理行,缓冲保留 **1** 行(那条止于 Zod `[`
+的头行)、丢弃 **12** 行 —— 唯一被留下的那行不含任何事实。这正是 cloud#971 的原始形态。
+`error` 那一条走 stderr,不经缓冲,危害是 #5575 那一串按行消费者(文件 sink、
+`docker logs`/journald 送采集、`grep ERROR`):一条诊断散成 N 个无法归属的碎片。
+
+## 改法
+
+两条都复用同包 `thrown-cause-diagnostics.ts` 的 `describeThrownForLog`(#5572/#5575 落地):
+message 是不含换行的自足句子,cause 走 logger 的结构化 meta。位置按 `Logger` 契约区分,
+并且是核对源码后确认的而非照抄:`warn(message, meta?)` 没有 `Error` 位,cause 就在**第二**
+参;`error(message, error?, meta?)` 的 cause 在**第三**参(第二参塞原始 error 会让每次重试
+的记录都附带完整堆栈)。
+
+## 刻意没有改的一件事
+
+`degradedReason` —— `GET /connectors` 展示的、以及 `connector_action` 被拒时引用的那段文本
+—— 仍然逐字保留 provider 自己的 message,包含换行。它是人透过 JSON 读的字段,不经按行切分
+的消费者;重塑它属于另一次契约变更。因此调用点同时传 `reason`(那段文本)与 `cause`(抛出值
+本身):前者喂 husk 与重试簿记,后者只喂日志记录。测试双向钉住了这个分离。

--- a/packages/services/service-automation/src/connector-degrade-cause.test.ts
+++ b/packages/services/service-automation/src/connector-degrade-cause.test.ts
@@ -1,0 +1,416 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// Regression: #5636 — the #3017 connector DEGRADE path must report why an
+// instance degraded in a form a line-oriented log consumer can read.
+//
+// `degradeConnectorInstance` is the third seam of the family #5048 (flow binding)
+// and #5575 (`reconcileDeclaredConnectors`'s `fail()`) already closed, and it was
+// out of both of their scopes. Two of its records interpolated a FOREIGN message
+// into the log MESSAGE:
+//
+//     ctx.logger.warn(`… could not register degraded husk for '${name}': ${(err as Error).message}`);
+//     ctx.logger.error(`… retrying with backoff, attempt ${n} (#3017): ${info.reason}`);
+//
+// Neither text is ours. The first `err` comes out of
+// `engine.registerDegradedConnector` → `ConnectorSchema.parse`, so the catch's
+// own comment ("the entry's def no longer parses") names a `ZodError` — whose
+// `.message` is a multi-line JSON dump opening on the single character `[`. The
+// second is `ConnectorUpstreamUnavailableError.message`, constructed by a
+// third-party provider factory that ADR-0097 explicitly invites people to write;
+// the spec defines the error class and says nothing about its text, so an SDK's
+// multi-line failure lands there verbatim.
+//
+// ## Why the `warn` seam is worse than #5575's, and not by the same mechanism
+//
+// `ObjectLogger` routes `warn` to **stdout** and `error`/`fatal` to **stderr**,
+// and `serve`'s boot-quiet window wraps `process.stdout.write` only. #5575's
+// seams are all `error`, so its issue text was corrected: the boot buffer never
+// sees them. This seam is different and the difference is measured, not assumed:
+//
+//   • it is `warn` → stdout, so the buffer DOES see it;
+//   • it runs at **cold boot** — `materializeDeclaredConnectors(ctx, { fatal:
+//     true })` degrades instead of throwing when the upstream is unreachable —
+//     which is exactly when the window is open;
+//   • `BootLogCapture.offer()` retains a physical line only when
+//     `classifyBootLogLine` finds a `<ts> <LEVEL>` head on it, so every
+//     continuation line of an interpolated dump is DROPPED, not merely mangled.
+//
+// That is cloud#971's original shape. The local reproduction at the bottom of
+// this file measures it (13 physical lines in, 1 retained, 12 dropped) using the
+// CLI's own predicate, re-stated here rather than imported — this package must
+// not depend on `@objectstack/cli`, and the predicate is the general one every
+// line-based consumer keys off, the CLI's buffer being the strictest example.
+//
+// The `error` seam has the #5575 harm instead (file sink, `docker logs` into a
+// shipper, `grep ERROR` — one record read as N unattributable fragments).
+//
+// ## The fix, and the one thing it deliberately does NOT change
+//
+// Both records keep a newline-free message and hand the cause to the logger's
+// `meta` (`warn`'s second argument; `error`'s THIRD, per the `Logger` contract's
+// `error(message, error?, meta?)`), rendered by `describeThrownForLog`.
+//
+// `degradedReason` — what `GET /connectors` shows and what a `connector_action`
+// refusal quotes — still carries the provider's message VERBATIM, newlines
+// included. It is read by a human through JSON, not by a line splitter, and
+// reshaping it would be a separate contract change. So the call site passes both
+// `reason` (that text) and `cause` (the thrown value); the tests below pin the
+// separation in both directions.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { LiteKernel, ObjectLogger } from '@objectstack/core';
+import type { ConnectorProviderFactory } from '@objectstack/spec/integration';
+import { ConnectorUpstreamUnavailableError } from '@objectstack/spec/integration';
+import { AutomationServicePlugin } from './plugin.js';
+import type { AutomationEngine } from './engine.js';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+// ── fixtures ───────────────────────────────────────────────────────────────
+
+/**
+ * What an SDK-wrapping provider factory throws when its upstream is down and it
+ * forwards the driver's own multi-line text. `connector-mcp` writes a single
+ * line today (which is why #5636 is a `finding`), but nothing in the spec makes
+ * that a rule — `ConnectorUpstreamUnavailableError`'s constructor takes whatever
+ * message the factory hands it.
+ */
+const MULTILINE_UPSTREAM = [
+    "connector 'gh_mcp' could not reach its MCP server",
+    '  cause: connect ECONNREFUSED 127.0.0.1:8931',
+    '  hint: is the MCP server running?',
+].join('\n');
+
+/** A provider-bound declarative entry, as `registerApp` stores it. */
+function providerConnector(name: string, opts: { type?: string } = {}) {
+    return {
+        name,
+        label: name,
+        type: opts.type ?? 'api',
+        provider: 'fake',
+        providerConfig: {},
+    };
+}
+
+/** A factory that is always down, throwing `message` with the #3017 marker. */
+function downFactory(message: string): ConnectorProviderFactory {
+    return () => {
+        throw new ConnectorUpstreamUnavailableError(message);
+    };
+}
+
+/**
+ * Boot a kernel with a declared connector set and a provider factory. Boot must
+ * NOT throw on an unreachable upstream — `{ fatal: true }` degrades (#3017) —
+ * which is what puts this seam inside `serve`'s boot-quiet window.
+ */
+async function bootDegraded(declared: unknown[], factory: ConnectorProviderFactory, logger?: unknown) {
+    const kernel = new LiteKernel({ logger: logger ?? { level: 'silent' } } as never);
+    kernel.use(new AutomationServicePlugin());
+    kernel.use({
+        name: 'test.harness',
+        type: 'standard' as const,
+        version: '1.0.0',
+        dependencies: ['com.objectstack.service-automation'],
+        async init(ctx: any) {
+            ctx.registerService('objectql', {
+                registry: { listItems: (t: string) => (t === 'connector' ? declared : []) },
+            });
+            ctx.getService('automation').registerConnectorProvider('fake', factory);
+        },
+        async start() {},
+    } as never);
+    await kernel.bootstrap();
+    return { kernel, engine: kernel.getService('automation') as AutomationEngine };
+}
+
+/** Capture everything written to one std stream while `fn` runs, split to lines. */
+async function captureStream(
+    which: 'stdout' | 'stderr',
+    fn: () => Promise<void>,
+): Promise<string[]> {
+    const chunks: string[] = [];
+    const spy = vi.spyOn(process[which], 'write').mockImplementation(((c: string | Uint8Array) => {
+        chunks.push(String(c));
+        return true;
+    }) as never);
+    try {
+        await fn();
+    } finally {
+        spy.mockRestore();
+    }
+    return chunks.join('').split('\n').filter((l) => l.length > 0);
+}
+
+/**
+ * `ObjectLogger`'s `pretty`/`text` record head — the same predicate
+ * `classifyBootLogLine` applies in `packages/cli/src/utils/boot-log-capture.ts`.
+ * Re-stated, not imported: see the file docblock.
+ */
+const RECORD_HEAD = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z(?: \|)? (DEBUG|INFO|WARN|ERROR|FATAL)\b/;
+
+const DEGRADE_PREFIX = '[Automation] connector instance';
+const HUSK_PREFIX = '[Automation] could not register degraded husk';
+
+// ── the `error` seam: the degrade announcement ─────────────────────────────
+
+describe('#5636 — the degrade announcement is ONE record, cause in meta', () => {
+    it('a multi-line upstream message never reaches the log message', async () => {
+        const lines = await captureStream('stderr', async () => {
+            const { kernel } = await bootDegraded(
+                [providerConnector('gh_mcp')],
+                downFactory(MULTILINE_UPSTREAM),
+                { level: 'error', format: 'json' },
+            );
+            await kernel.shutdown();
+        });
+
+        const mine = lines.filter((l) => l.includes(DEGRADE_PREFIX));
+        expect(mine, 'the seam announced exactly once').toHaveLength(1);
+        // Pre-fix this was 3 physical lines, of which 2 carried no level head.
+        expect(lines, 'one call, one physical line').toHaveLength(1);
+        const record = JSON.parse(lines[0]) as {
+            level: string;
+            msg: string;
+            error?: string;
+            issues?: unknown;
+        };
+        expect(record.level).toBe('error');
+        expect(record.msg).not.toContain('\n');
+        expect(record.msg).toContain("'gh_mcp'");
+        expect(record.msg).toContain("provider 'fake'");
+        expect(record.msg).toContain('instance registered degraded (no actions)');
+        expect(record.msg).toContain('attempt 1 (#3017)');
+        // Not a validation rejection → `error`, not `issues`; and the full text
+        // survives, newlines escaped by the logger's JSON.stringify.
+        expect(record.issues).toBeUndefined();
+        expect(record.error).toBe(MULTILINE_UPSTREAM);
+    });
+
+    it('renders as a single head-bearing line in `pretty` too', async () => {
+        const lines = await captureStream('stderr', async () => {
+            const { kernel } = await bootDegraded(
+                [providerConnector('gh_mcp')],
+                downFactory(MULTILINE_UPSTREAM),
+                { level: 'error', format: 'pretty' },
+            );
+            await kernel.shutdown();
+        });
+
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toMatch(RECORD_HEAD);
+        expect(lines[0]).toContain('ERROR');
+        expect(lines[0]).toContain('ECONNREFUSED 127.0.0.1:8931');
+        expect(lines[0]).toContain('is the MCP server running?');
+    });
+
+    it("calls error(message, undefined, meta) — the contract's third slot", async () => {
+        const error = vi.spyOn(ObjectLogger.prototype, 'error');
+        const { kernel } = await bootDegraded(
+            [providerConnector('gh_mcp')],
+            downFactory(MULTILINE_UPSTREAM),
+        );
+
+        const call = error.mock.calls.find((c) => String(c[0]).includes(DEGRADE_PREFIX));
+        expect(call, 'the seam logged at error level').toBeDefined();
+        const [message, errorSlot, meta] = call as [string, unknown, Record<string, unknown>];
+        expect(message).not.toContain('\n');
+        // The second slot stays empty on purpose: the raw error there ships its
+        // stack on every retry record (#5575).
+        expect(errorSlot).toBeUndefined();
+        expect(meta.error).toBe(MULTILINE_UPSTREAM);
+        expect(meta.issues).toBeUndefined();
+
+        await kernel.shutdown();
+    });
+
+    it('leaves `degradedReason` verbatim — the husk field is not the log message', async () => {
+        // The API-facing field keeps the provider's own text, newlines included:
+        // `GET /connectors` and the `connector_action` refusal are read as JSON
+        // by a human, not split by a line-oriented consumer. Moving the cause out
+        // of the log MESSAGE must not reshape it.
+        const { kernel, engine } = await bootDegraded(
+            [providerConnector('gh_mcp')],
+            downFactory(MULTILINE_UPSTREAM),
+        );
+
+        const desc = engine.getConnectorDescriptors().find((d) => d.name === 'gh_mcp');
+        expect(desc?.state).toBe('degraded');
+        expect(desc?.degradedReason).toBe(MULTILINE_UPSTREAM);
+        expect(engine.getConnectorDegradedReason('gh_mcp')).toBe(MULTILINE_UPSTREAM);
+
+        await kernel.shutdown();
+    });
+});
+
+// ── the `warn` seam: the husk could not even be registered ─────────────────
+
+describe('#5636 — a husk-registration rejection reports its issues, on one line', () => {
+    // `buildDegradedHuskDef` copies `entry.type` through a cast, so a declared
+    // `type` outside `ConnectorTypeSchema`'s enum makes `registerDegradedConnector`'s
+    // `ConnectorSchema.parse` throw — the "entry's def no longer parses" case the
+    // catch was written for, reached without stubbing the engine.
+    const badTypeEntry = () => providerConnector('gh_mcp', { type: 'mcp_server' });
+
+    it('the ZodError becomes structured meta, not a 13-line stdout spill', async () => {
+        const lines = await captureStream('stdout', async () => {
+            const { kernel } = await bootDegraded([badTypeEntry()], downFactory('upstream down'), {
+                level: 'warn',
+                format: 'json',
+            });
+            await kernel.shutdown();
+        });
+
+        const mine = lines.filter((l) => l.includes(HUSK_PREFIX));
+        expect(mine, 'the husk failure was reported exactly once').toHaveLength(1);
+        const record = JSON.parse(mine[0]) as {
+            msg: string;
+            issues?: Array<Record<string, unknown>>;
+        };
+        expect(record.msg).not.toContain('\n');
+        expect(record.msg).toContain("'gh_mcp'");
+        expect(record.msg).toContain('#3017');
+        // The facts a reader came for.
+        const issues = record.issues;
+        expect(Array.isArray(issues)).toBe(true);
+        expect(issues!.some((i) => i.path === 'type')).toBe(true);
+        expect(JSON.stringify(issues)).not.toContain('REDACTED');
+        // Every line on stdout still carries a level head — nothing for the boot
+        // buffer to drop.
+        for (const line of lines) {
+            expect(classifyLine(line), line).not.toBeNull();
+        }
+    });
+
+    it('calls warn(message, meta) — `warn` has no Error slot', async () => {
+        // Verified against the contract rather than assumed: `Logger.warn` is
+        // `warn(message, meta?)`, so the cause belongs in argument TWO here even
+        // though the `error` seam above must use argument THREE.
+        const warn = vi.spyOn(ObjectLogger.prototype, 'warn');
+        const { kernel } = await bootDegraded([badTypeEntry()], downFactory('upstream down'));
+
+        const call = warn.mock.calls.find((c) => String(c[0]).includes(HUSK_PREFIX));
+        expect(call, 'the seam logged at warn level').toBeDefined();
+        const [message, meta] = call as [string, Record<string, unknown>];
+        expect(message).not.toContain('\n');
+        expect(call).toHaveLength(2);
+        const issues = meta.issues as Array<Record<string, unknown>>;
+        expect(Array.isArray(issues)).toBe(true);
+        expect(issues.some((i) => i.path === 'type')).toBe(true);
+
+        await kernel.shutdown();
+    });
+
+    it('the retry bookkeeping survives a husk that could not register', async () => {
+        // The whole reason the catch only logs: recovery is driven by
+        // `degradedInstances`, which was written before the husk attempt.
+        const { kernel, engine } = await bootDegraded([badTypeEntry()], downFactory('upstream down'));
+        expect(engine.getRegisteredConnectors()).not.toContain('gh_mcp');
+        await kernel.shutdown();
+    });
+});
+
+// ── reverse verification, direction predicted before running ───────────────
+
+/**
+ * `classifyBootLogLine`'s verdict, reduced to what matters here: a line either
+ * carries an `ObjectLogger` level head (retained by `BootLogCapture`) or it does
+ * not (dropped by `offer()`).
+ */
+function classifyLine(raw: string): string | null {
+    const line = raw.replace(/\u001B\[[0-9;]*m/g, '').trim();
+    if (!line) return null;
+    if (line.startsWith('{')) {
+        try {
+            const rec = JSON.parse(line) as { level?: unknown; time?: unknown };
+            return typeof rec.time === 'string' && typeof rec.level === 'string' ? String(rec.level) : null;
+        } catch {
+            return null;
+        }
+    }
+    const m = RECORD_HEAD.exec(line);
+    return m ? m[1].toLowerCase() : null;
+}
+
+describe('#5636 — what the interpolated rendering cost, measured', () => {
+    it('the pre-fix `warn` shape loses its every fact to the boot buffer', async () => {
+        // Predicted BEFORE running, and it is the plain red direction: rendering
+        // the OLD shape — a multi-line cause inside the message — must produce
+        // MANY physical lines of which exactly ONE classifies (the head line,
+        // truncated at Zod's `[`), so a boot-quiet window retains that one and
+        // drops the rest. The fixed shape must produce exactly one line that
+        // classifies AND carries the facts. (A local reproduction: the seam's own
+        // one-line guarantee is asserted end-to-end above.)
+        const zodDump = JSON.stringify(
+            [
+                {
+                    code: 'invalid_value',
+                    values: ['saas', 'database', 'file_storage', 'message_queue', 'api', 'custom'],
+                    path: ['type'],
+                    message: 'Invalid option',
+                },
+            ],
+            null,
+            2,
+        );
+        expect(zodDump.split('\n').length, 'fixture must be multi-line').toBeGreaterThan(1);
+        expect(zodDump.split('\n')[0].trim(), "…and open with Zod's `[`").toBe('[');
+
+        const log = new ObjectLogger({ level: 'warn', format: 'pretty' });
+
+        const before = await captureStream('stdout', async () => {
+            log.warn(`[Automation] could not register degraded husk for 'gh_mcp': ${zodDump}`);
+        });
+        expect(before.length, 'one call, many physical lines').toBeGreaterThan(1);
+        const beforeKept = before.filter((l) => classifyLine(l) !== null);
+        expect(beforeKept).toHaveLength(1);
+        // What the boot buffer would keep: a warning that names the instance and
+        // then stops at a bracket. Every fact is on a dropped line.
+        expect(beforeKept[0].trimEnd().endsWith('[')).toBe(true);
+        expect(beforeKept[0]).not.toContain('Invalid option');
+        expect(before.length - beforeKept.length, 'lines the buffer drops').toBeGreaterThan(1);
+
+        const after = await captureStream('stdout', async () => {
+            log.warn(`[Automation] could not register degraded husk for 'gh_mcp' (#3017).`, {
+                issues: [{ code: 'invalid_value', path: 'type', message: 'Invalid option' }],
+            });
+        });
+        expect(after).toHaveLength(1);
+        expect(classifyLine(after[0])).toBe('warn');
+        expect(after[0]).toContain('Invalid option');
+        expect(after[0]).toContain('type');
+    });
+
+    it('the pre-fix `error` shape splits one degrade into unattributable fragments', async () => {
+        // Same prediction on the stderr side, where nothing buffers: the record
+        // is not dropped, it is mis-read — the continuation lines carry no level
+        // and no timestamp, so a file sink stores them as their own records and a
+        // `grep ERROR` returns the one line that holds no facts.
+        const log = new ObjectLogger({ level: 'error', format: 'pretty' });
+
+        const before = await captureStream('stderr', async () => {
+            log.error(
+                `[Automation] connector instance 'gh_mcp' (provider 'fake') upstream unavailable — ` +
+                    `instance registered degraded (no actions); retrying with backoff, attempt 1 (#3017): ${MULTILINE_UPSTREAM}`,
+            );
+        });
+        expect(before).toHaveLength(3);
+        expect(before.filter((l) => classifyLine(l) !== null)).toHaveLength(1);
+        expect(before[1]).not.toMatch(RECORD_HEAD);
+        expect(before[1]).toContain('ECONNREFUSED');
+
+        const after = await captureStream('stderr', async () => {
+            log.error(
+                `[Automation] connector instance 'gh_mcp' (provider 'fake') upstream unavailable — ` +
+                    `instance registered degraded (no actions); retrying with backoff, attempt 1 (#3017).`,
+                undefined,
+                { error: MULTILINE_UPSTREAM },
+            );
+        });
+        expect(after).toHaveLength(1);
+        expect(after[0]).toMatch(RECORD_HEAD);
+        expect(after[0]).toContain('ECONNREFUSED');
+    });
+});

--- a/packages/services/service-automation/src/plugin.ts
+++ b/packages/services/service-automation/src/plugin.ts
@@ -1184,7 +1184,18 @@ export class AutomationServicePlugin implements Plugin {
                         provider,
                         signature,
                         hasLive: existing !== undefined,
+                        // #5636 — `reason` and `cause` are the SAME failure rendered
+                        // for two audiences, and both are needed. `reason` is the
+                        // husk's operator-facing text: it becomes `degradedReason`
+                        // in `GET /connectors` and the `connector_action` refusal,
+                        // where the provider's own wording (newlines included) is
+                        // read by a human, not a line-oriented parser. `cause` is
+                        // the thrown value itself, so the LOG record can render it
+                        // as structured `meta` instead of interpolating it into a
+                        // message. Passing only the flattened string here is what
+                        // forced the interpolation this issue removes.
                         reason: (err as Error).message,
+                        cause: err,
                     });
                     continue;
                 }
@@ -1242,6 +1253,19 @@ export class AutomationServicePlugin implements Plugin {
      * and a `connector_action` dispatch fails with the reason, rather than the
      * instance silently missing. A config edit (signature change) resets the
      * backoff — it is a different upstream/config now.
+     *
+     * #5636 — both log records here report a FOREIGN failure, so neither may
+     * interpolate it into its message; the cause travels in the logger's `meta`
+     * instead. See ./thrown-cause-diagnostics.ts for the mechanism, and note
+     * that this path's `warn` reaches a downstream #5575's `error` seams do not:
+     * a cold-boot degrade (`materializeDeclaredConnectors(ctx, { fatal: true })`
+     * degrades rather than throwing when the upstream is unreachable) happens
+     * inside `serve`'s boot-quiet window, which wraps `process.stdout.write`
+     * only — so a `warn` there is buffered by `BootLogCapture`, which keeps a
+     * physical line ONLY when `classifyBootLogLine` finds a level head on it.
+     * Measured on a 13-line interpolated ZodError dump: 1 line retained (the
+     * head line, ending at Zod's `[`) and 12 dropped outright. That is cloud#971
+     * in its original form, not merely a hard-to-parse record.
      */
     private degradeConnectorInstance(
         engine: AutomationEngine,
@@ -1252,7 +1276,13 @@ export class AutomationServicePlugin implements Plugin {
             provider: string;
             signature: string;
             hasLive: boolean;
+            /**
+             * Operator-facing text for the husk (`degradedReason`) — the
+             * provider's own message, kept verbatim for human readers.
+             */
             reason: string;
+            /** The thrown value, for the log record's structured `meta` (#5636). */
+            cause: unknown;
         },
     ): void {
         const prior = this.degradedInstances.get(info.name);
@@ -1269,17 +1299,29 @@ export class AutomationServicePlugin implements Plugin {
             } catch (err) {
                 // Can't even register the husk (e.g. the entry's def no longer
                 // parses) — the retry bookkeeping above still drives recovery.
+                //
+                // #5636 — the catch comment names the expected failure as a parse
+                // rejection, i.e. exactly the multi-line `ZodError.message` this
+                // must not interpolate. `warn`'s SECOND argument is `meta` (the
+                // `Logger` contract has no `Error` slot below `error`), so the
+                // cause goes there.
                 ctx.logger.warn(
-                    `[Automation] could not register degraded husk for '${info.name}': ${(err as Error).message}`,
+                    `[Automation] could not register degraded husk for '${info.name}' — the instance stays absent from the ` +
+                        `connector registry until a retry succeeds (#3017).`,
+                    describeThrownForLog(err),
                 );
             }
         }
+        // Third argument, per `error(message, error?, meta?)` — NOT the second,
+        // which would ship the thrown value's stack on every retry (#5575).
         ctx.logger.error(
             `[Automation] connector instance '${info.name}' (provider '${info.provider}') upstream unavailable — ` +
                 (info.hasLive
                     ? 'the previously-materialized connector keeps serving'
                     : 'instance registered degraded (no actions)') +
-                `; retrying with backoff, attempt ${attempts} (#3017): ${info.reason}`,
+                `; retrying with backoff, attempt ${attempts} (#3017).`,
+            undefined,
+            describeThrownForLog(info.cause),
         );
     }
 


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5636

## 前提重验:两处接缝原样成立

立单时基于 `cc5b048a0`,其后 PR #5639(#5575)已合入同文件,行号确实漂移了。对
`origin/main` `5b60b3669` 逐条核对后,**两处接缝的代码形态一字未变**,只是位置移到
`plugin.ts:1273-1275`(husk 注册失败的 `warn`)与 `plugin.ts:1288-1294`(降级公告的
`error`)。issue 描述的 `reason` 来源链也成立:`plugin.ts:1187` 的
`reason: (err as Error).message` 把 `ConnectorUpstreamUnavailableError.message` 原样
传进 `degradeConnectorInstance`,而该 message 由第三方 provider factory 构造 ——
`packages/spec/src/integration/connector-provider-errors.ts` 只定义错误类,构造函数收
什么文本就是什么文本,不约束行数。

issue 提醒要实测而非照抄的两件事,都实测了:

- **`warn` 的第二参就是 `meta`** —— `packages/spec/src/contracts/logger.ts` 声明
  `warn(message, meta?)`,`error(message, error?: Error, meta?)`。只有 `error`/`fatal`
  有 `Error` 位。所以两条记录的 cause 落在**不同参数位**,代码里各自注释了原因。
- **`warn` 侧的 BootLogCapture 危害论证成立**(与 #5575 相反,那一单被证伪) —— 见下。

## 危害:这条 `warn` 的下游与 #5575 的 `error` 不同,而且是量出来的

`ObjectLogger` 把 `warn` 送 stdout、`error`/`fatal` 送 stderr,`serve` 的启动静默窗口
只包了 `process.stdout.write`。#5575 的接缝全是 `error`,所以那一单的结论是「启动缓冲
根本看不到」。这一条不同,四个条件都核实过:

1. 它是 `warn` → stdout,缓冲**确实**看得到;
2. 它在**冷启动**就会跑 —— `materializeDeclaredConnectors(ctx, { fatal: true })` 遇到
   上游不可达是降级、不抛错(`plugin.ts:1180`);
3. 窗口此时正开着 —— `serve.ts:710` 在 config 加载前接管 stdout,直到 banner 打印才
   恢复;
4. `BootLogCapture.offer()` 只在 `classifyBootLogLine` 能在该物理行上找到时间戳 + 等级
   头时才保留它,续行**直接丢弃**。

拿真 `ObjectLogger` + 真 `BootLogCapture` 对一份 13 行的插值 ZodError dump 跑了一遍:

```
### PRE-FIX  warn(`… : ${err.message}`)
physical stdout lines written : 13
BootLogCapture retained lines : 1
  | "2026-08-05T22:48:09.508Z WARN [Automation] could not register degraded husk for 'gh_mcp': ["
DROPPED (written but not retained): 12

### POST-FIX warn(msg, describeThrownForLog(err))
physical stdout lines written : 1
BootLogCapture retained lines : 1
  | "…WARN [Automation] could not register degraded husk for 'gh_mcp' (#3017). {"issues":[{…}]}"
DROPPED: 0
```

唯一被留下的那一行不含任何事实 —— 它止于 Zod 的 `[`。这是 cloud#971 的原始形态,不只是
「不好解析」。`error` 那一条走 stderr、不经缓冲,危害是 #5575 那一串按行消费者(文件
sink、`docker logs`/journald 送采集、`grep ERROR`):一条诊断散成 N 个无法归属的碎片。

## 改法

两条都复用同包 `thrown-cause-diagnostics.ts` 的 `describeThrownForLog`(#5572/#5639
落地):message 是不含换行的自足句子,cause 走结构化 meta,位置按上面核实过的契约区分。
没有新增 meta 字段名,因此不涉及 #5573 的子串脱敏(`issues` / `error` 是既有字段,被拒
键名仍在 `unrecognized` 里)。

## 刻意没有改的一件事(取舍,附代码证据)

`degradedReason` —— `engine.ts:1659` 存进 registry、经 `getConnectorDescriptors()` 出
`GET /connectors`、并被 `getConnectorDegradedReason()` 用于 `connector_action` 被拒时
的文本 —— 仍然逐字保留 provider 自己的 message,包含换行。它是人透过 JSON 读的字段,
不经按行切分的消费者;重塑它属于另一次契约变更,不该搭在这一单里。

因此调用点同时传两个值,而不是把 `reason` 换成 `cause`:

```ts
// plugin.ts:1187 附近
reason: (err as Error).message,   // 喂 husk 与重试簿记,逐字不变
cause: err,                        // 只喂日志记录的结构化 meta
```

`connector-degrade-cause.test.ts` 双向钉住了这个分离:一条断言 `degradedReason` 与
`getConnectorDegradedReason()` 都等于那段多行原文,另一条断言日志 message 不含换行。

## 测试

新增 `packages/services/service-automation/src/connector-degrade-cause.test.ts`(9 例),
结构与 #5639 的 `connector-fail-cause.test.ts` 对齐:端到端跑**真** logger、读**真**字节,
不信 spy 单独作证。

```
pnpm --filter @objectstack/service-automation test
  Test Files  61 passed (61)
        Tests  730 passed (730)      # 新增前 60 / 721
```

`connector-degrade-cause` + `connector-fail-cause` + `connector-materialization` 三件套:
`Tests 53 passed (53)`。

### 反向验证:方向先预测,再跑

预测(跑之前写下):把两处插值还原成修前形状,新增用例里**读日志形状**的那些必须变红
(插值多行 cause 会让 `pretty` 下不止一条物理行、`msg` 含换行、meta 里没有 cause),而
**不读**日志形状的那些必须保持绿。这是最常见的「红」方向,不是 #5018 那种反转。

实测:`Tests 5 failed | 4 passed (9)`。

```
× a multi-line upstream message never reaches the log message
× renders as a single head-bearing line in `pretty` too
× calls error(message, undefined, meta) — the contract's third slot
✓ leaves `degradedReason` verbatim — the husk field is not the log message
× the ZodError becomes structured meta, not a 13-line stdout spill
× calls warn(message, meta) — `warn` has no Error slot
✓ the retry bookkeeping survives a husk that could not register
✓ the pre-fix `warn` shape loses its every fact to the boot buffer
✓ the pre-fix `error` shape splits one degrade into unattributable fragments

AssertionError: expected '[Automation] connector instance 'gh_…' not to contain a newline
AssertionError: expected [ …(3) ] to have a length of 1 but got 3
```

**一处如实订正**:我预测的是「6 红 / 3 绿」,实测「5 红 / 4 绿」。每一条用例的**方向**
都与预测一致(读日志形状的全红、不读的全绿),差的是我数错了有几条读日志形状 —— 9 例里
只有 5 例读,另外 4 例分别是 `degradedReason` 逐字保留、重试簿记存活、以及两条本地
「代价度量」复现(它们不经接缝,还原与否都绿)。记在这里而不是改成 5/4 假装当初就这么
预测。

### 用例怎么触到 `warn` 那一条

不 stub engine:`buildDegradedHuskDef` 把 `entry.type` 经一次 cast 抄进 husk def,所以
声明一个 `ConnectorTypeSchema` 枚举外的 `type`(如 `mcp_server`)就让
`registerDegradedConnector` 里的 `ConnectorSchema.parse` 真抛 ZodError —— 正是那个 catch
注释写的「the entry's def no longer parses」。

### 门检查

```
check:nul-bytes            OK (5593 tracked text files, no raw ASCII control bytes)
check:type-check-coverage  OK — service-automation 的 DEBT 帐未变(raw tsc: 5 处既有,新增 0)
check:durability-log-level OK (24 个耐久性 catch 接缝)
check:startup-registry-verdict OK
check:adr-anchors / check:error-code-casing / check:doc-authoring  OK
eslint(改动的两个文件)      clean
```

**字节纪律,两次命中,都如实记下**:

1. 用例里那个 ANSI strip 正则需要一个 ESC 转义(反斜杠 u 0 0 1 B 六个 ASCII 字符)。
   写文件时它被落成了**真** ESC 字节;`grep -naP` 自查抓到后用脚本按字节替换回转义序列,
   源码现在干净(`check:nul-bytes` 与自查都绿)。
2. **同一条纪律也适用于工具载荷**:本 PR 正文的初版里也带了一个真 ESC 字节 —— 恰恰是
   在写上面第 1 条、描述这个字节的那句话里落进去的。回读存档正文时发现,已改成纯文字
   描述。这正是 #4890 的原样重演(在写「禁止真 NUL」这条规则的同时把真 NUL 写进了
   `SKILL.md`),也是 #5157 的教训:写*关于*控制字符的东西时最容易把它写成真字节,
   所以正文必须回读校验,不能只信写出去的那一份。

### 消费半径扫过

`retrying with backoff, attempt` / `register degraded husk` / `degradedReason` 在
framework 全仓、`../cloud`、`../objectui` 里都没有其他消费者(唯一命中就是本文件与新用例),
所以改 message 文本不牵动任何 fixture 或断言。

## 范围外发现(已按 Prime Directive #10 立单,未在本 PR 修)

搜重后确认无同题 issue,两单都 unassigned、`finding` 标签、无 `pm:queue`:

- **#5660** —— `engine.ts:1659` 的 `registerDegradedConnector` 自己那条 `warn` 仍把同一个
  `reason` 插进 message。它在调用顺序上**先**发生,而且在 husk 注册成功的**常见**分支上就
  会打,所以本 PR 修完之后,首次降级的默认路径上还留着一条会溢出的 warn。没有一起修,
  是因为它在另一个文件、另一个契约上:`registerDegradedConnector` 的签名只收
  `reason: string`(没有抛出值可用),而那个字符串同时是 API 可见的 `degradedReason` ——
  修法要先在「加 `cause?` 参数」和「reason 降为 meta 字段」之间定一个,不是零决策,
  issue 里把两条路和倾向写清了。
- **#5661** —— 同文件另外三处外来 `${err.message}` 插值(`plugin.ts:454` / `592-594` /
  `931-936`),三单(#5048/#5575/#5636)都没覆盖。其中两条是**耐久性**诊断,注释自己写明
  「suspended runs will NOT survive a restart」「will hang indefinitely」并特意选了
  `error` 级 —— 最不该被切碎的记录。issue 里也说明了为什么 `plugin.ts:191`(是 `throw`,
  按 #5575 的界线应保持现状)和 `:729`(`debug`,且文本是我们自己的)不含在内。
