### PR TITLE
docs(spec): HookContext.input 契约表改成引擎真正构造的形状 (#5273)

### DIFF
--- a/packages/objectql/src/hook-input-shape-contract.test.ts
+++ b/packages/objectql/src/hook-input-shape-contract.test.ts
@@ -77,7 +77,11 @@ describe('[#5273] a bulk write carries no `ast` on `input`', () => {
     const { engine } = await boot();
     engine.registerHook('beforeFind', async (ctx: any) => { seen.push(ctx.input); }, { object: 'task' });
 
-    await engine.find('task', {} as any);
+    // No `as any` on the options: `find(object, query?: EngineQueryOptions)`
+    // already infers an empty query, and erasing it would add a site to the
+    // #4918 query-options ratchet (`check:query-options-erasure`) for no gain —
+    // this call is in-contract, not a deliberate off-contract probe.
+    await engine.find('task', {});
 
     expect(seen).toHaveLength(1);
     expect('ast' in seen[0]!).toBe(true);

--- a/packages/objectql/src/hook-input-shape-contract.test.ts
+++ b/packages/objectql/src/hook-input-shape-contract.test.ts
@@ -1,0 +1,320 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#5273] The `HookContext.input` shape table in `packages/spec` is TRUE of
+ * this engine.
+ *
+ * `packages/spec/src/data/hook.zod.ts` documents, per operation, the exact
+ * `input` a handler receives. That table is the whole contract: `input` itself
+ * is `z.record(z.string(), z.unknown())` — an open shape by design, so Zod
+ * validates NOTHING about which keys are present, and the prose is the only
+ * thing an author (human or AI) can read to learn what to reach for. Which is
+ * why it drifted silently: three keys it named had no producer left.
+ *
+ *   - `update (bulk)` / `delete (bulk)` were documented as carrying
+ *     `{ ast: QueryAST, ... }`, with the table repeating below it that "the
+ *     row-scoping predicate is carried in `input.ast`". The engine has never
+ *     put an AST on a WRITE context: the bulk predicate lives on the internal
+ *     `OperationContext.ast` (#2982) precisely so middleware-composed row
+ *     filters bind the driver call where no handler can widen them. So the one
+ *     field the docs pointed at resolved `undefined`.
+ *   - `insert` was documented as `{ doc: Record, ... }`; the engine builds
+ *     `{ data: row, ... }`. (`trigger-record-change` still carries a defensive
+ *     `input.doc` alias read for that reason — filed separately, not fixed
+ *     here.)
+ *
+ * The table was also silent about #5038: since ADR-0058's bulk-write addendum
+ * the `after*` events on a bulk write fire PER MATCHED ROW on a
+ * single-record-shaped context, so `input.id` — documented as absent on bulk
+ * writes — is in fact bound on every after-event a bulk write dispatches.
+ *
+ * ## Why this file lives in objectql
+ *
+ * The defect is in spec's prose, but prose is unassertable and `packages/spec`
+ * cannot execute a hook dispatch: objectql depends on spec, so a spec-side
+ * test importing the engine would invert the dependency. The FACTS the prose
+ * claims are pinned here instead, next to the engine that produces them and
+ * next to #5038's own `bulk-write-per-row-hooks.test.ts`.
+ *
+ * ## Reading the assertions
+ *
+ * Hooks are registered with `engine.registerHook` — the RAW context, so what
+ * is asserted is what the engine constructs, not a view of it. The declarative
+ * (metadata `Hook`) path additionally wraps `ctx.input` in the flat-input
+ * proxy of `hook-wrappers.ts`; the last describe pins that an author on THAT
+ * path sees the same answer, since the false `input.ast` sentence was aimed at
+ * exactly those authors.
+ *
+ * `beforeFind` is the POSITIVE CONTROL (#4865): it really does carry
+ * `input.ast`, so "no `ast` on the write paths" is a measurement, not an
+ * assertion that would pass against an engine that had stopped setting `ast`
+ * anywhere at all.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ObjectQL } from './engine.js';
+import { bindHooksToEngine } from './hook-binder.js';
+import type { Hook, HookContext } from '@objectstack/spec/data';
+
+const TASK_FIELDS = {
+  id: { name: 'id', label: 'ID', type: 'text' as const, primaryKey: true },
+  title: { name: 'title', label: 'Title', type: 'text' as const },
+  status: { name: 'status', label: 'Status', type: 'text' as const },
+};
+const taskObject = { name: 'task', label: 'Task', fields: TASK_FIELDS };
+
+const silentLogger = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * 1. The row-scoping predicate is NOT on `input` (the deleted claim)
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+describe('[#5273] a bulk write carries no `ast` on `input`', () => {
+  it('POSITIVE CONTROL — a read DOES carry `input.ast`', async () => {
+    // Without this, every "no ast" assertion below would also pass against an
+    // engine that had stopped building read contexts correctly.
+    const seen: Array<Record<string, unknown>> = [];
+    const { engine } = await boot();
+    engine.registerHook('beforeFind', async (ctx: any) => { seen.push(ctx.input); }, { object: 'task' });
+
+    await engine.find('task', {} as any);
+
+    expect(seen).toHaveLength(1);
+    expect('ast' in seen[0]!).toBe(true);
+    expect(seen[0]!.ast).toBeDefined();
+  });
+
+  it('`beforeUpdate` on a bulk write has no `ast` key', async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const { engine } = await boot();
+    engine.registerHook('beforeUpdate', async (ctx: any) => { seen.push(ctx.input); }, { object: 'task' });
+
+    await seedTasks(engine, [{ title: 'a', status: 'todo' }, { title: 'b', status: 'todo' }]);
+    await engine.update('task', { status: 'done' }, { multi: true, where: { status: 'todo' } } as any);
+
+    expect(seen).toHaveLength(1); // before* fires ONCE for the whole batch
+    expect('ast' in seen[0]!).toBe(false);
+    expect(seen[0]!.ast).toBeUndefined();
+  });
+
+  it('`beforeDelete` on a bulk write has no `ast` key', async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const { engine } = await boot();
+    engine.registerHook('beforeDelete', async (ctx: any) => { seen.push(ctx.input); }, { object: 'task' });
+
+    await seedTasks(engine, [{ title: 'a', status: 'todo' }, { title: 'b', status: 'todo' }]);
+    await engine.delete('task', { multi: true, where: { status: 'todo' } } as any);
+
+    expect(seen).toHaveLength(1);
+    expect('ast' in seen[0]!).toBe(false);
+    expect(seen[0]!.ast).toBeUndefined();
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * 2. `input.id` — present-but-undefined on the batch, bound per row after
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+describe('[#5273] `input.id` on a bulk write', () => {
+  it('`beforeUpdate` leaves `id` undefined (the key exists; nothing binds it)', async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const { engine } = await boot();
+    engine.registerHook('beforeUpdate', async (ctx: any) => { seen.push(ctx.input); }, { object: 'task' });
+
+    await seedTasks(engine, [{ title: 'a', status: 'todo' }, { title: 'b', status: 'todo' }]);
+    await engine.update('task', { status: 'done' }, { multi: true, where: { status: 'todo' } } as any);
+
+    // The engine builds `{ id, data, options }` with the shorthand `id`, so the
+    // KEY is there while the value is not. Documented as `{ id: undefined, … }`
+    // rather than "no id" because `'id' in input` answers true.
+    expect('id' in seen[0]!).toBe(true);
+    expect(seen[0]!.id).toBeUndefined();
+    expect(seen[0]!.data).toEqual({ status: 'done' });
+    expect(seen[0]!.options).toBeDefined();
+  });
+
+  it('`afterUpdate` fires per matched row, each naming its own `id`', async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const { engine } = await boot();
+    engine.registerHook('afterUpdate', async (ctx: any) => { seen.push(ctx.input); }, { object: 'task' });
+
+    const rows = await seedTasks(engine, [{ title: 'a', status: 'todo' }, { title: 'b', status: 'todo' }]);
+    await engine.update('task', { status: 'done' }, { multi: true, where: { status: 'todo' } } as any);
+
+    expect(seen).toHaveLength(2);
+    expect(seen.map((i) => i.id).sort()).toEqual(rows.map((r) => r.id).sort());
+    // Single-record shape: the payload rides along, exactly as on a single-id
+    // write, so a handler needs no bulk-aware branch.
+    for (const input of seen) expect(input.data).toEqual({ status: 'done' });
+  });
+
+  it('`afterDelete` fires per matched row, each naming its own `id`', async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const { engine } = await boot();
+    engine.registerHook('afterDelete', async (ctx: any) => { seen.push(ctx.input); }, { object: 'task' });
+
+    const rows = await seedTasks(engine, [{ title: 'a', status: 'todo' }, { title: 'b', status: 'todo' }]);
+    await engine.delete('task', { multi: true, where: { status: 'todo' } } as any);
+
+    expect(seen).toHaveLength(2);
+    expect(seen.map((i) => i.id).sort()).toEqual(rows.map((r) => r.id).sort());
+    // A delete has no post-state, so no payload rides along.
+    for (const input of seen) expect('data' in input).toBe(false);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * 3. The rest of the table, so the whole thing is measured and not just the
+ *    two rows #5273 named
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+describe('[#5273] the single-record rows of the table', () => {
+  it('insert carries `data` — never `doc`', async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const { engine } = await boot();
+    engine.registerHook('beforeInsert', async (ctx: any) => { seen.push(ctx.input); }, { object: 'task' });
+
+    await engine.insert('task', { title: 'a', status: 'todo' } as any);
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.data).toMatchObject({ title: 'a', status: 'todo' });
+    expect('doc' in seen[0]!).toBe(false);
+  });
+
+  it('a batch insert builds ONE context per row (#2922)', async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const { engine } = await boot();
+    engine.registerHook('beforeInsert', async (ctx: any) => { seen.push(ctx.input); }, { object: 'task' });
+
+    await engine.insert('task', [{ title: 'a' }, { title: 'b' }] as any);
+
+    expect(seen).toHaveLength(2);
+    expect(seen.map((i) => (i.data as any).title)).toEqual(['a', 'b']);
+  });
+
+  it('a single-id update binds `id` and `data`', async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const { engine } = await boot();
+    engine.registerHook('beforeUpdate', async (ctx: any) => { seen.push(ctx.input); }, { object: 'task' });
+
+    const [row] = await seedTasks(engine, [{ title: 'a', status: 'todo' }]);
+    await engine.update('task', { status: 'done' }, { where: { id: row.id } } as any);
+
+    expect(seen[0]!.id).toBe(row.id);
+    expect(seen[0]!.data).toEqual({ status: 'done' });
+    expect('ast' in seen[0]!).toBe(false);
+  });
+
+  it('a single-id delete binds `id` and carries no `data`', async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const { engine } = await boot();
+    engine.registerHook('beforeDelete', async (ctx: any) => { seen.push(ctx.input); }, { object: 'task' });
+
+    const [row] = await seedTasks(engine, [{ title: 'a', status: 'todo' }]);
+    await engine.delete('task', { where: { id: row.id } } as any);
+
+    expect(seen[0]!.id).toBe(row.id);
+    expect('data' in seen[0]!).toBe(false);
+    expect('ast' in seen[0]!).toBe(false);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * 4. The declarative path sees the same answer
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+describe('[#5273] a metadata-declared hook reads the same shape', () => {
+  it('`ctx.input.ast` is undefined on a bulk update through the flat-input proxy', async () => {
+    // The deleted sentence told THIS author to read `input.ast`. The proxy
+    // passes `ast` through to the wrapper rather than folding it into `data`,
+    // so the read is faithful — there is simply nothing behind it on a write.
+    const seen: unknown[] = [];
+    const { engine } = await boot();
+    bindHooksToEngine(
+      engine,
+      [{
+        name: 'reads_ast', object: 'task', events: ['beforeUpdate'], priority: 100,
+        handler: (ctx: HookContext) => { seen.push((ctx.input as any).ast); },
+      } as unknown as Hook],
+      { packageId: 'app:test', logger: silentLogger },
+    );
+
+    await seedTasks(engine, [{ title: 'a', status: 'todo' }]);
+    await engine.update('task', { status: 'done' }, { multi: true, where: { status: 'todo' } } as any);
+
+    expect(seen).toEqual([undefined]);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Harness — a memory driver just wide enough for the dispatch paths above.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+async function seedTasks(engine: ObjectQL, rows: Record<string, unknown>[]): Promise<any[]> {
+  const written = await engine.insert('task', rows as any);
+  return Array.isArray(written) ? written : [written];
+}
+
+function makeMemoryDriver(): any {
+  const stores = new Map<string, Map<string, Record<string, unknown>>>();
+  const storeFor = (o: string) => {
+    let s = stores.get(o);
+    if (!s) { s = new Map(); stores.set(o, s); }
+    return s;
+  };
+  let nextId = 0;
+  const matches = (row: Record<string, unknown>, where: any): boolean => {
+    if (!where || typeof where !== 'object') return true;
+    for (const [k, v] of Object.entries(where)) {
+      if (k.startsWith('$')) continue;
+      const expected = v && typeof v === 'object' && '$eq' in (v as any) ? (v as any).$eq : v;
+      if ((row[k] ?? null) !== (expected ?? null)) return false;
+    }
+    return true;
+  };
+  const d: any = {
+    name: 'memory', version: '0.0.0', supports: {},
+    async connect() {}, async disconnect() {}, async checkHealth() { return true; },
+    async execute() { return null; }, async syncSchema() {},
+    async find(o: string, ast: any) {
+      return Array.from(storeFor(o).values()).filter((r) => matches(r, ast?.where));
+    },
+    async findOne(o: string, ast: any) { for (const r of storeFor(o).values()) if (matches(r, ast?.where)) return r; return null; },
+    async create(o: string, data: Record<string, unknown>) {
+      nextId += 1;
+      const id = (data.id as string) ?? `r_${nextId}`;
+      const row = { ...data, id }; storeFor(o).set(id, row); return row;
+    },
+    async update(o: string, id: string, data: Record<string, unknown>) {
+      const s = storeFor(o); const cur = s.get(id); if (!cur) return null;
+      const u = { ...cur, ...data, id }; s.set(id, u); return u;
+    },
+    async upsert(o: string, data: any) { const id = data.id; return id && storeFor(o).has(id) ? this.update(o, id, data) : this.create(o, data); },
+    async delete(o: string, id: string) { return storeFor(o).delete(id); },
+    async count(o: string, ast: any) { return Array.from(storeFor(o).values()).filter((r) => matches(r, ast?.where)).length; },
+    async bulkCreate(o: string, rows: any[]) { return Promise.all(rows.map((r) => this.create(o, r))); },
+    async bulkUpdate() { return []; }, async bulkDelete() {},
+    async updateMany(o: string, ast: any, data: Record<string, unknown>) {
+      const rows = Array.from(storeFor(o).values()).filter((r) => matches(r, ast?.where));
+      for (const r of rows) storeFor(o).set(r.id as string, { ...r, ...data, id: r.id });
+      return rows.length;
+    },
+    async deleteMany(o: string, ast: any) {
+      const rows = Array.from(storeFor(o).values()).filter((r) => matches(r, ast?.where));
+      for (const r of rows) storeFor(o).delete(r.id as string);
+      return rows.length;
+    },
+    async beginTransaction() { return { commit: async () => {}, rollback: async () => {} }; },
+    async commit() {}, async rollback() {},
+  };
+  return d;
+}
+
+async function boot(): Promise<{ engine: ObjectQL; driver: any }> {
+  const engine = new ObjectQL();
+  const driver = makeMemoryDriver();
+  engine.registerDriver(driver, true);
+  await engine.init();
+  engine.registry.registerObject(taskObject as any);
+  return { engine, driver };
+}

--- a/packages/spec/src/data/hook.zod.ts
+++ b/packages/spec/src/data/hook.zod.ts
@@ -311,17 +311,46 @@ export const HookContextSchema = lazySchema(() => z.object({
    * Input Parameters (Mutable)
    * Modify this to change the behavior of the operation.
    *
+   * These shapes are exactly what the engine BUILDS — `packages/objectql`'s
+   * `engine.ts` is the only producer of a `HookContext`. A key this table
+   * lists but no producer sets reads back `undefined` at every call site, and
+   * a contract statement is the one place that cannot be discovered as false:
+   * #5273 was three such keys (`ast` on both bulk writes, `doc` on insert)
+   * standing in the table long after the engine had stopped agreeing. Pinned
+   * against the real engine in
+   * `packages/objectql/src/hook-input-shape-contract.test.ts` — the assertions
+   * live there because only objectql can execute a dispatch, and spec must not
+   * depend on it.
+   *
    * - find (also fires for findOne): { ast: QueryAST, options: DriverOptions }
-   * - insert: { doc: Record, options: DriverOptions }
+   * - insert (one context per row, batch inserts included): { data: Record, options: DriverOptions }
    * - update (single id): { id: ID, data: Record, options: DriverOptions }
-   * - update (bulk, multi:true): { ast: QueryAST, data: Record, options: DriverOptions }
+   * - update (bulk, multi:true) — before: { id: undefined, data: Record, options: DriverOptions }
+   * - update (bulk, multi:true) — after, PER MATCHED ROW: { id: ID, data: Record, options: DriverOptions }
    * - delete (single id): { id: ID, options: DriverOptions }
-   * - delete (bulk, multi:true): { ast: QueryAST, options: DriverOptions }
+   * - delete (bulk, multi:true) — before: { id: undefined, options: DriverOptions }
+   * - delete (bulk, multi:true) — after, PER MATCHED ROW: { id: ID, options: DriverOptions }
    *
    * A bulk (`multi: true`) update/delete fires the SAME `beforeUpdate`/
-   * `beforeDelete` events as a single-id write — the row-scoping predicate is
-   * carried in `input.ast` (no per-row `id`). There is no separate `*Many`
-   * event.
+   * `beforeDelete` events as a single-id write, ONCE for the whole batch;
+   * there is no separate `*Many` event. `input.id` is present but `undefined`
+   * there — binding it is precisely the test the engine dispatches on, so a
+   * `before*` handler that sets it REROUTES the write onto the single-id path.
+   *
+   * The row-scoping predicate is NOT reachable from `input` at all. It lives
+   * on the engine-internal `OperationContext.ast` (#2982) so that the filters
+   * middleware composes onto it — RLS write policies, the sharing plugin's
+   * editable-rows filter — bind the driver call itself, where no handler can
+   * widen them. A bulk write therefore hands hooks no queryable predicate:
+   * scope the batch through `options.where` at the CALLER, or work per row on
+   * the `after*` events below.
+   *
+   * Since #5038 (ADR-0058's bulk-write addendum) the `after*` events on a bulk
+   * write dispatch ONCE PER MATCHED ROW, each on a single-record-shaped
+   * context — `input.id` names that row, `previous` is its pre-image and
+   * `result` its post-state — so a handler written for a single-id write needs
+   * no bulk-aware branch of its own. The batch-level context keeps the
+   * affected COUNT as `result` and is what the call itself resolves (#4639).
    */
   input: z.record(z.string(), z.unknown()).describe('Mutable input parameters'),
 


### PR DESCRIPTION
Fixes #5273

按 issue 正文与分诊结论采「**改注释,不改引擎**」方向。把安全过滤后的 mutable AST 交给 hook 改写需要单独裁,本单不做。

## 前提核实(对合并 #5621 后的 `origin/main`)

| 断言 | 结果 |
|:---|:---|
| 契约表仍宣称批量写带 `ast` | ✅ 成立(`hook.zod.ts:314-325`) |
| `input: { ast }` 只出现在读路径 | ✅ 仅 `engine.ts:4640` / `4773`,都喂 `driver.find`/`findOne` |
| 写路径构造 `{ id, data?, options }` | ✅ `5243`(update)/ `5705`(delete) |
| 批量谓词走 `opCtx.ast`(#2982) | ✅ 从不进 `hookContext.input` |
| 零写路径 `ctx.input.ast` 消费者 | ✅ grep 确认;读路径的两处消费者充当 #4865 正控 |

全仓 `HookContext` 生产点恰好 5 处,全在 `engine.ts`,外加 #5038 的 `buildPerRowAfterContexts`。

## 改了什么

1. **删掉**「the row-scoping predicate is carried in `input.ast`」整句;批量写 before 事件的表行不再写 `ast`。
2. **补上 #5038 后的按行形状**:批量写的 `after*` 按匹配行派发,每行是单记录形状,`input.id` 在那里**是**绑定的。
3. **`input.id` 的精确措辞**:批量 before 事件上 `id` 这个**键存在、值为 `undefined`**(引擎用 shorthand 建 `{ id, … }`),不是「没有 id」——因为 `'id' in input` 答 true。顺带说明:在 `before*` 里绑定它会把这次写**改道**到单条路径,那正是引擎的分发判据。
4. **保留**仍然成立的两句:before 事件整批只触发一次;没有 `*Many` 事件。

### ⚠️ 超出 issue 正文的一处(请复核)

同一张表里 `insert: { doc: Record }` **也是假的** —— 引擎建的是 `{ data: row, options }`。issue 没点它,但它就在我正在改写的这张表里,留着等于明知故留一条假行。已一并改正并加了 pin。

`packages/triggers/trigger-record-change` 里那条读 `input.doc` 的防御性兜底(其自身注释已写明 `doc` 只是 alias)是**消费端 fallback**,属 PD #12 债,另行立项,本 PR 不动。

## 未做的事

- **不动引擎**。
- **`hook-wrappers.ts` 的 `ast` 特判故意保留**:派单说「实测安全才清」,实测结论是**不安全**——它在**读路径上是活的**。`installFlatInput` 对所有事件生效,beforeFind 的 `input` 确实带 `ast`;去掉特判后 `input.ast = X` 这种改写会被折进 `data`,反而弄坏一条真实能力。

## pin 策略

走派单的第一选项,但落点必须在 objectql:**spec 不能反向依赖 objectql**(objectql 依赖 spec,spec 侧测试导入引擎会倒转依赖),所以事实 pin 在
`packages/objectql/src/hook-input-shape-contract.test.ts`,紧邻 #5038 自己的 `bulk-write-per-row-hooks.test.ts`。用 `engine.registerHook` 取**原始**上下文(不经 flat-input 代理),另有一组用 `bindHooksToEngine` 验声明式作者看到的答案一致——那句假话正是写给声明式作者的。

### 先证红(方向:预测为红,实测为红)

先按**旧断言**写(bulk before 有 `ast`、insert 有 `doc`)并运行:

```
FAIL  > `beforeUpdate` on a bulk write has no `ast` key
AssertionError: expected false to be true
 ❯ src/hook-input-shape-contract.test.ts:96:31
FAIL  > `beforeDelete` on a bulk write has no `ast` key
FAIL  > insert carries `data` — never `doc`

Test Files  1 failed | 119 passed (120)
     Tests  3 failed | 1931 passed (1934)
```

恰好三条红,全是旧契约声称、引擎从不兑现的键。**正控同批为绿**(`beforeFind` 确实带 `ast`),所以「写路径没有 ast」是一次测量,不是空过。翻转后全绿。

## 验证

| 命令 | 结果 |
|:---|:---|
| `--filter @objectstack/objectql test` | **1934 passed (120 files)** |
| `--filter @objectstack/spec test` | **8060 passed (316 files)** |
| 两包 `typecheck` | 绿 |
| `--filter @objectstack/spec check:generated` | **10/10 up to date** |
| `node scripts/check-nul-bytes.mjs` | OK(另做控制字节自扫,干净) |
| `eslint` 改动文件 | 0 |

## changeset:无

`check:generated` 的 `check:docs content/docs/references/**` 在**含本次改动的 dist 上**跑绿,说明这段 TSDoc **不流入**生成参考页(`content/docs/references/data/hook.mdx` 的 input 行取自 `.describe('Mutable input parameters')`,本次未动)。故不触发 #5550 那条「生成文档移动就取 patch changeset」的前置条件;纯注释订正 + 测试,按 AGENTS.md「纯 bug 修复不需要 changeset」。如维护者认为「契约散文订正」应进发布说明,我补一个 patch changeset。

---
_Generated by [Claude Code](https://claude.ai/code/session_018fxLGQdatPbBUvCgiVxg6D)_