### PR TITLE
test(devx): check-nul-bytes 的 --self-test 断言字符类引用面逐字节相等,终结该族漂移 (#5646)

### DIFF
--- a/scripts/check-nul-bytes.mjs
+++ b/scripts/check-nul-bytes.mjs
@@ -183,11 +183,41 @@
 // There is intentionally NO per-file exemption hatch. No tracked file in this
 // repo carries a legitimate raw control byte; if one ever genuinely needs to,
 // that is a decision to take in the open, not a line to add to a skip-list.
+//
+// ## The character class is written down once (#5646)
+//
+// The scanned set exists for two audiences: as the IS_SCANNED table below, which
+// is what the gate actually scans, and as a PCRE character class in the agent
+// instructions that tell an author to self-scan beyond the gate. The second was
+// a hand transcription of the first, and that transcription drifted twice in one
+// day: #5577 found the self-scan class missing `\x7f` months after #5460 put DEL
+// in the table, and #5579 found the harm argument next to it carrying only the
+// part that is true of NUL.
+//
+// #5579 fixed the prose side by making it CITE this header instead of restating
+// it. The class itself cannot be handled that way -- an author needs a command
+// line they can paste -- so it is handled the other way round: `scannedCharClass()`
+// DERIVES the class from the table, and `--self-test` asserts that every
+// registered reference spells it byte-for-byte identically. Drift is red at the
+// same gate that scans the tree.
+//
+// Deliberately an assertion and not codegen. The files that carry the class are
+// hand-written prompts; generating them would buy the same guarantee at the cost
+// of turning agent instructions into build output. An assertion leaves them
+// hand-written and merely refuses to let them be WRONG, and it names the exact
+// string to paste when they are.
+//
+// The registered set is an explicit ledger (see CHAR_CLASS_REFERENCES), like the
+// repo's other shrink-only gates: a new file spelling the class out has to be
+// added to it, and a file that stops spelling it out has to be removed from it
+// on purpose. Extraction failure is RED, never a silent skip -- the class
+// vanishing from a self-scan command is the same defect as it drifting.
 
 import { execFileSync } from 'node:child_process';
 import { lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 /**
  * The scanned set as a 256-entry lookup: every ASCII control character except
@@ -211,6 +241,83 @@ IS_SCANNED[0x0d] = 0; // CR
 // "control character" agree -- C's `iscntrl` and the regex class \p{Cc} both
 // include it.
 IS_SCANNED[0x7f] = 1;
+
+/**
+ * The scanned set as a PCRE character class, e.g. the argument of
+ * `grep -naP '<class>'`, derived from the table above rather than written out.
+ *
+ * This is the spelling for HUMANS and for grep, as opposed to `escapeFor()`,
+ * which is the JS `\uNNNN` spelling an author should write in source. Both are
+ * built from byte values, never from a literal: this file is in its own scan
+ * surface (#5646, #4890).
+ *
+ * Runs of three or more bytes collapse to a range; a run of one or two is
+ * spelled out, because `\x0b-\x0c` is no shorter than `\x0b\x0c` and reads
+ * worse. That rule is a CONVENTION, not a semantic property -- both spellings
+ * match the same bytes -- and it is fixed here precisely because the reference
+ * check below demands byte equality: something has to be canonical, and it is
+ * this function. When a byte is added or removed, the emitted string changes and
+ * the self-test prints the new one to paste into every registered reference.
+ */
+export function scannedCharClass() {
+  const esc = (byteValue) => `\\x${byteValue.toString(16).padStart(2, '0')}`;
+  let out = '';
+  for (let b = 0; b < 256; b++) {
+    if (IS_SCANNED[b] !== 1) continue;
+    let end = b;
+    while (end + 1 < 256 && IS_SCANNED[end + 1] === 1) end++;
+    const run = end - b + 1;
+    out += run >= 3 ? `${esc(b)}-${esc(end)}` : Array.from({ length: run }, (_, i) => esc(b + i)).join('');
+    b = end;
+  }
+  return `[${out}]`;
+}
+
+/**
+ * Every file that spells the scanned set out as a character class, and how to
+ * find it there. `--self-test` asserts each extracted spelling equals
+ * `scannedCharClass()` byte for byte (#5646).
+ *
+ * `anchor` matches the SURROUNDINGS of the class and captures the class itself.
+ * It deliberately contains no part of the class: an anchor that did would stop
+ * matching on exactly the drift it exists to catch, turning a mismatch (which
+ * reports both spellings) into an extraction failure (which cannot).
+ *
+ * Registering a file makes its copy of the class immutable-except-in-step. Not
+ * registered, on purpose:
+ *
+ *   - `.changeset/control-byte-gate-scans-*.md` and the published CHANGELOGs.
+ *     Those are HISTORICAL RECORDS of one widening each, and one of them states
+ *     the pre-DEL set correctly for the change it describes. Forcing them to
+ *     equal today's set would falsify the record.
+ *   - The prose ENUMERATIONS of the same bytes -- this header's opening line and
+ *     the `.github/workflows/lint.yml` step comment. Those are sentences, not
+ *     pasteable classes; prose stays on the #5579 footing -- cite this header,
+ *     do not restate it. (Which is why this list names them rather than quoting
+ *     them: a ledger entry that spelled the bytes out would be one more copy.)
+ *   - The non-ASCII guard `[^\x00-\x7f]` quoted in the isLikelyEmail changeset
+ *     and the plugin-auth CHANGELOG: a different regex about input validation,
+ *     unrelated to this set.
+ */
+const CHAR_CLASS_REFERENCES = [
+  {
+    file: '.claude/agents/os-dev.md',
+    site: 'the byte-discipline self-scan command line',
+    // The single-quoted PCRE argument of `grep -naP`.
+    anchor: /grep -naP '([^']*)'/g,
+  },
+  {
+    file: 'scripts/check-nul-bytes.mjs',
+    site: "this header's own pasteable rendering of the scanned set",
+    // The backticked class on the line after the word "Equivalently".
+    anchor: /Equivalently\r?\n\/\/ `([^`]*)`/g,
+  },
+];
+
+/** The repo this script lives in -- resolved from the script, so cwd cannot lie. */
+function scriptRepoRoot() {
+  return join(dirname(fileURLToPath(import.meta.url)), '..');
+}
 
 /**
  * The escape an author should have written for a byte, as TEXT.
@@ -427,6 +534,57 @@ byte's name or the escape TEXT -- never the byte itself.`);
 // function main() calls -- over it. Every control byte below is produced at
 // runtime from a byte value; none is written as a literal, because this file is
 // in its own scan surface and a literal would make the guard fail on itself.
+
+/**
+ * Every registered reference spells the scanned set exactly as this script emits
+ * it (#5646). Reads the real files in the repo the script lives in -- the point
+ * is the checked-in text, so there is nothing to fixture.
+ *
+ * Three ways this goes red, all of them drift:
+ *   1. a registered file is unreadable -- de-registering is a decision, not a
+ *      side effect of deleting or renaming;
+ *   2. the anchor finds nothing -- the class disappearing from a self-scan
+ *      command line leaves the instruction useless, so a silent skip here would
+ *      be the #4690 anti-pattern applied to the gate that exists to stop it;
+ *   3. an extracted spelling differs from the emitted one, in any byte.
+ */
+function checkCharClassReferences(root, assert) {
+  const canonical = scannedCharClass();
+  assert(
+    CHAR_CLASS_REFERENCES.length > 0,
+    'the character-class reference ledger is empty -- with no registered file this check asserts nothing',
+  );
+
+  for (const ref of CHAR_CLASS_REFERENCES) {
+    let text = null;
+    try {
+      text = readFileSync(join(root, ref.file), 'utf8');
+    } catch {
+      // fall through to the assertion below, which reports it as drift
+    }
+    assert(
+      text !== null,
+      `${ref.file} is a registered character-class reference but could not be read -- restore it, or remove it from CHAR_CLASS_REFERENCES on purpose`,
+    );
+    if (text === null) continue;
+
+    const found = [...text.matchAll(ref.anchor)].map((m) => m[1]);
+    assert(
+      found.length > 0,
+      `${ref.file}: found no character class at the registered anchor (${ref.site}). Either the class was removed -- ` +
+        `then de-register it, since an instruction to self-scan without a class to scan for is worse than none -- or the ` +
+        `surrounding text moved, in which case update the anchor. Expected to find: ${canonical}`,
+    );
+    for (const spelling of found) {
+      assert(
+        spelling === canonical,
+        `${ref.file} (${ref.site}) spells the scanned set as ${spelling}, but this gate scans ${canonical}. ` +
+          `The IS_SCANNED table is authoritative: paste the gate's spelling into the reference (#5577 was this drift, ` +
+          `a self-scan class missing \\x7f for months after #5460 added DEL to the table).`,
+      );
+    }
+  }
+}
 
 function selfTest() {
   const failures = [];
@@ -685,9 +843,27 @@ function selfTest() {
     const expectedSet = [...Array(0x20).keys()].filter((b) => b !== 0x09 && b !== 0x0a && b !== 0x0d).concat(0x7f);
     assert(scannedSet.join() === expectedSet.join(), `the scanned set is C0-minus-tab/LF/CR plus DEL, got ${scannedSet.length} bytes`);
     assert(IS_SCANNED[0x20] === 0 && IS_SCANNED[0x7e] === 0, 'printable ASCII is never scanned');
+
+    // The emitted character class is what the reference check below compares
+    // against, so it has to be right as a REGEX and not merely stable as a
+    // string: compiled and run over all 256 byte values, it must select exactly
+    // the table's set. Without this, a broken emitter would happily hold every
+    // reference file byte-equal to a class that scans the wrong bytes.
+    const emittedClass = new RegExp(scannedCharClass());
+    const emittedSet = [...Array(256).keys()].filter((b) => emittedClass.test(String.fromCharCode(b)));
+    assert(
+      emittedSet.join() === scannedSet.join(),
+      `the emitted class ${scannedCharClass()} matches exactly the scanned set, got ${emittedSet.length} of ${scannedSet.length} bytes`,
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+
+  // ── #5646: the class is transcribed nowhere ────────────────────────────────
+  //
+  // Not a temp-repo fixture: the subject is the checked-in text of this repo's
+  // own instruction files, which is exactly what drifted in #5577.
+  checkCharClassReferences(scriptRepoRoot(), assert);
 
   if (failures.length) {
     console.error(`✗ check-nul-bytes --self-test -- ${failures.length} failure(s)\n`);


### PR DESCRIPTION
Fixes #5646

字符类此前是**手抄**关系:`IS_SCANNED` 表是门禁真正扫的东西,而 `.claude/agents/os-dev.md`「Byte discipline」段的自扫命令行里躺着一份手写副本。该族漂移当日已付两次 —— #5577(自扫类缺 `\x7f`,门禁侧从 #5460 起早已纳入)与 #5579(危害论证只搬了对 NUL 成立的那条)。#5579 把**散文**侧改成「cite the header」(少一层重复),但字符类不能这么办:作者需要一条能直接粘的命令行。所以反向处理 —— 派生 + 断言。

## 修法

- `scannedCharClass()` 从 `IS_SCANNED` 表**派生**出 PCRE 字符类(逐字节由字节值拼出,不写字面量 —— 本文件在自己的扫描面内)。
- `--self-test` 新增一条检查:`CHAR_CLASS_REFERENCES` 里登记的每处引用,提取出的字符类与派生结果**逐字节相等**;不等即红,失败信息同时打印两种拼写与「该粘贴哪一个」。
- **不做 codegen**(#5646 边界):引用文件是手写 prompt,生成它们会把 agent 指令变成构建产物。断言只拒绝它们「错」。散文继续走 #5579/#5642 的 cite-the-header 口径,本单只锁字符类字符串。

比较是**逐字节**而非语义:`\x0b-\x0c` 与 `\x0b\x0c` 匹配同一批字节,但前者会判红。所以 `scannedCharClass()` 里的折叠约定(连续 3 字节以上收成区间,1–2 字节逐个写)是承重的 —— 必须有一个规范拼写,而它就是这个函数。为防「emitter 稳定但错」,另加一条:把派生出的类编译成真 RegExp、跑遍 0–255,选中的集合必须与表完全一致。

## 引用面台账(全仓实测)

`git grep 'x00-'` 与 `git grep 'grep -naP'` 全仓共 9 处命中,登记 2 处:

| 位置 | 形态 | 处置 |
| --- | --- | --- |
| `.claude/agents/os-dev.md:311` | 自扫命令行里单引号包裹的 PCRE 类 | **登记**(锚点:`grep -naP` 之后的引号串) |
| `scripts/check-nul-bytes.mjs:9` | 脚本头「Equivalently」后的反引号类 | **登记** —— 实测这是第三份手抄:#5460 加 DEL 时曾需同步改它 |
| `.changeset/control-byte-gate-scans-all-c0.md` | 扩面前的集合(无 `\x7f`) | **不登记** —— 历史记录,对它所描述的那次变更是**正确的**;强制等于今天的集合会伪造记录 |
| `.changeset/control-byte-gate-scans-del.md` | 当时的集合 | **不登记**,同上(历史记录类文本) |
| `packages/plugins/plugin-auth/CHANGELOG.md`、`.changeset/isLikelyEmail-no-control-char.md` | `[^\x00-\x7f]` | **不登记** —— 另一条关于非 ASCII 输入校验的正则,与本集合无关 |
| `scripts/check-nul-bytes.mjs:6`、`.github/workflows/lint.yml:98` | 同一批字节的**散文枚举** | **不登记** —— 是句子而不是可粘贴的类,归 cite-the-header 口径 |
| `.claude/skills/pm-dispatch/SKILL.md`、`scripts/check-workflow-status-functions.mjs:291` | 只提门禁名/惯例,无字符类 | 非引用处 |

取舍口径:只锁**受众是 agent 指令、可直接粘贴**的活引用;历史记录类文本反而必须允许「过时」。台账写死在脚本里,新增引用处需登记 —— 与仓内 shrink-only 门禁的「显式列表」惯例同构。

提取锚点刻意**不含字符类本身**:含了的话,它会在正要抓的那次漂移上停止匹配,把「不相等」(能报出两种拼写)降级成「提取不到」(报不出)。

## 先红后绿(四个方向,均前台实测)

预期方向:引用面被改动即红。四种都是漂移,四种都必须红。

1. **改错一位**(os-dev.md 的 `\x7f` 改成 `\x7e`):
   `✗ … .claude/agents/os-dev.md (the byte-discipline self-scan command line) spells the scanned set as [\x00-\x08\x0b\x0c\x0e-\x1f\x7e], but this gate scans [\x00-\x08\x0b\x0c\x0e-\x1f\x7f].` exit=1 → 还原后 56 断言绿。
2. **复现 #5577 原形**(整段去掉 `\x7f`):同一条断言判红,报出 `[\x00-\x08\x0b\x0c\x0e-\x1f]` —— 正是当初漂了数月的那一版。
3. **提取不到即红**(把整条 `grep -naP` 命令行删掉):
   `✗ … found no character class at the registered anchor (the byte-discipline self-scan command line). Either the class was removed -- then de-register it … Expected to find: [\x00-\x08\x0b\x0c\x0e-\x1f\x7f]` exit=1。⛔ 不静默跳过(#4690 反模式)。
4. **登记文件消失**(重命名 os-dev.md 而未去登记):`… is a registered character-class reference but could not be read -- restore it, or remove it from CHAR_CLASS_REFERENCES on purpose` exit=1。

另两条旁证:**未来扩面**场景(往表里加一枚字节、两处引用都忘改)一次报出 4 条失败,其中两条分别点名 os-dev.md 与脚本头并给出新的规范拼写;**语义相同、字节不同**(`\x0b-\x0c`)照样判红,坐实逐字节口径。

## 权威方向与 os-dev.md 零改动

脚本 `IS_SCANNED` 表是权威。实测两处当前**已经一致**(#5577 修完至今未再漂),所以本 PR 的 `os-dev.md` 改动为零 —— 文件面只有 `scripts/check-nul-bytes.mjs`(+175/-0)。若实测到漂移,跟改会朝脚本对齐。

## 边界

- self-test 现有断言结构与退出码语义不变,断言数 **48 到 56**(只增不减)。
- CI 的 `pnpm check:nul-bytes` 是 `--self-test` 再接全仓扫描,所以这条新断言天然进 CI 门禁。
- 新检查读的是**真实的仓内文本**(不是临时仓 fixture):标的正是 checked-in 的指令文件本身。仓根由 `import.meta.url` 解析,cwd 骗不了它。
- 字节纪律:改动文件自扫零命中;未向任何文件写入裸控制字节,样本一律由字节值在运行时生成。
- 纯 `scripts/` 门禁改动,不发布任何包 → 走 `skip-changeset` 标签路线(⛔ 不写空 frontmatter changeset,#4898)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE)_