### PR TITLE
fix(ci): 两个标签写入 job 不再并发、也不再被标签事件重复触发 (#5649)

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -5,8 +5,59 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
+  # ===========================================================================
+  # Both label-writing jobs below write this PR's label set with a WHOLE-SET PUT
+  # (`PUT /issues/{n}/labels`), never an additive POST. Read out of the pinned
+  # sources rather than inferred from the docs (#5649):
+  #
+  #   * codelytv/pr-size-labeler@v1.10.4 -- src/github.sh:68-91
+  #     (`github::add_label_to_pr`): GETs the PR, greps its OWN size family out
+  #     of the result, appends the new size label, then
+  #     `curl -X PUT .../issues/$pr_number/labels` with the whole set.
+  #   * actions/labeler@v7.0.0 -- src/labeler.ts:56,111-133 plus
+  #     src/api/set-labels.ts: snapshots `preexistingLabels` at run start,
+  #     unions in the config matches, re-reads the live label list once, then
+  #     calls `client.rest.issues.setLabels` -- which IS the PUT.
+  #
+  # Neither action exposes an input that makes its write additive, and
+  # `sync-labels` is NOT that input: it only decides whether a label the CONFIG
+  # owns is dropped once its globs stop matching (labeler.ts:81-83). It is
+  # pinned explicitly below for upgrade-drift protection only. It does not, and
+  # cannot, stop the clobbering described here.
+  #
+  # A whole-set PUT only destroys someone else's label when that label lands
+  # inside the window between the writer's read and its PUT. What this file can
+  # therefore fix is the OVERLAP, and two changes below do exactly that:
+  #
+  #   1. The two writers no longer run concurrently -- `auto-label` needs
+  #      `pr-size`. They used to be started by the same event and overlapped
+  #      exactly. Live specimen, PR #5650 run 31051251795 (the `opened` run):
+  #      `Add size label` ran 22:03:47->22:03:49 and
+  #      `Label based on changed files` ran 22:03:47->22:03:49, and the
+  #      labeler's PUT emitted `unlabeled size/s` at 22:03:49 -- one second
+  #      after the size job added it, for a label the labeler does not manage.
+  #   2. Neither writer runs on `labeled`/`unlabeled` any more. Their only input
+  #      is the diff, which a label event cannot change, so such a run could
+  #      only ever re-PUT the same set -- one more chance to erase a concurrent
+  #      writer in exchange for no new information. Same PR, run 31051273625
+  #      (started by a label event): `Auto Label` recomputed and wrote nothing,
+  #      `Check PR Size` re-PUT at 22:04:22. The two event types stay in `on:`
+  #      because `changeset-check` genuinely needs them (#5580).
+  #
+  # NOT closed by either change, and deliberately recorded rather than implied:
+  # a writer OUTSIDE this workflow -- an agent or a human labelling the PR
+  # seconds after `gh pr create`, i.e. exactly while these jobs run -- can still
+  # land inside a PUT window and be erased. That is how #5533 lost its
+  # `skip-changeset` exemption for one second (15:46:44 applied, 15:46:45 erased
+  # by the labeler's PUT of `{size/m, tests}`). Closing that half needs the
+  # writes themselves to become additive, not merely better ordered; it is the
+  # open half of #5649 and no configuration here can stand in for it.
+  # ===========================================================================
   pr-size:
     name: Check PR Size
+    # A `labeled`/`unlabeled` event cannot change this job's input (the diff),
+    # so running it there buys nothing and costs one whole-set PUT. See above.
+    if: github.event.action != 'labeled' && github.event.action != 'unlabeled'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -31,6 +82,19 @@ jobs:
 
   auto-label:
     name: Auto Label
+    # ORDERING ONLY, not a dependency: this job wants `pr-size`'s PUT to be
+    # already done, so that the label set this one reads includes the size
+    # label and its own PUT carries it forward. `!cancelled()` is written out
+    # because GitHub would otherwise wrap this `if:` in an implicit `success()`
+    # -- a failed or skipped size job must not silently stop path labelling.
+    # (Same reasoning the check-workflow-status-functions gate exists to make
+    # explicit; that gate scans only `needs.*.outputs.*` reads, so this one is
+    # out of its scope and has to state its intent by hand.)
+    needs: pr-size
+    if: >-
+      !cancelled()
+      && github.event.action != 'labeled'
+      && github.event.action != 'unlabeled'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -45,6 +109,14 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml
+          # Pinned at the value it already defaults to (action.yml), because a
+          # default is not a decision: an upgrade may move it, and `true` would
+          # make this step REMOVE a label of its own config whenever the globs
+          # stop matching -- on a `synchronize` that reverts a docs file, for
+          # instance. Pinning it is upgrade-drift protection and nothing more:
+          # `sync-labels` never governed foreign labels, so it is NOT the fix
+          # for the clobbering documented at the top of this file (#5649).
+          sync-labels: false
 
   changeset-check:
     name: Check Changeset


### PR DESCRIPTION
Fixes #5649

本 PR 只做 issue 的**落点 2(CI 侧)**。落点 1(客户端写入语义)不改代码,实测结论见下方「工具面备案」。

## 一、归因:两个 job 都在整集 PUT,`sync-labels` 不是那个开关

按派发要求逐个读 pinned 版本的源码,不接受配置文档推断:

| action | 写入位置 | 语义 |
| --- | --- | --- |
| `codelytv/pr-size-labeler@v1.10.4` | `src/github.sh:68-91`(`github::add_label_to_pr`) | GET 读 PR 标签 → `grep -w -v` 掉自己那套 size 家族 → 追加新 size 标签 → `curl -X PUT .../issues/$pr_number/labels` |
| `actions/labeler@v7.0.0` | `src/labeler.ts:56,111-133` + `src/api/set-labels.ts` | run 开始时快照 `preexistingLabels` → 并入 config 命中项 → 回读一次实时标签(`pulls.get`,补 `manualAddedDuringRun`)→ `client.rest.issues.setLabels`,即 PUT |

**两者都是整集 PUT,都没有把写入改成新增的输入项。** `sync-labels` 不是那个开关:它只决定「**config 自己拥有的**标签在 glob 不再命中时是否删掉」(`labeler.ts:81-83`),对外来标签毫无作用,而且 `action.yml` 里缺省已经是 `false`。本 PR 仍然把它显式写出来,理由只有一条 —— 防升级漂移;注释里已经写明它**不是**本缺陷的修复,免得下一个读者把它当成已修。

### 谁抹的:run/job 级对号(PR #5650)

`opened` run `31051251795`:

```
Check PR Size / Add size label                22:03:47 -> 22:03:49   → labeled   size/s        22:03:48
Auto Label    / Label based on changed files  22:03:47 -> 22:03:49   → unlabeled size/s        22:03:49
                                                                       labeled   documentation 22:03:49
```

两个写入步骤的执行窗口**完全重合**;22:03:49 这条 `unlabeled size/s` 与 `labeled documentation` 同秒同 actor,只有 labeler 的一次 PUT `{documentation}` 能同时解释两者 —— 它的快照与回读都早于 22:03:48。**方向二的抹除者是 `Auto Label`(actions/labeler)。**

同一判据套回 #5533 的 15:46:45:`unlabeled skip-changeset` + `labeled size/m` + `labeled tests` 三条同秒,只有 labeler 的一次 PUT `{size/m, tests}` 能同时解释(size-labeler 的写入会保留 `skip-changeset`、也不会加 `tests`)。同一个抹除者。

## 二、改了什么(只动这两个 job 的配置)

整集 PUT 只在「别人的写入落在读→PUT 窗口内」时才有破坏性。本文件能修的是**重叠**:

1. **两个写入方不再并发** —— `auto-label` 加 `needs: pr-size`。原先由同一事件同时拉起、窗口重合(上表)。串行后 labeler 的快照里已经有 size 标签,PUT 会把它带上。`!cancelled()` 显式写出:`needs` 只用于排序,size job 失败/跳过不该顺手关掉路径打标。
2. **两个写入方不再被 `labeled`/`unlabeled` 触发** —— 它们唯一的输入是 diff,标签事件改不了 diff,这种 run 只能把同一集合再 PUT 一遍:零新信息,多一次互抹机会。现场标本:同 PR 的 run `31051273625` 由标签事件拉起,`Auto Label` 重算后无写入(`labeler.ts:111` 的 `isEqual` 短路),`Check PR Size` 在 22:04:22 又 PUT 了一次。两个事件类型**保留在 `on:` 里**,因为 `changeset-check` 确实需要(#5580)。
   全仓 grep 确认 `size/*`、`documentation`、`tests` 没有任何门禁/脚本消费,只有 `.github/labeler.yml` 与本文件提到它们 —— 所以取消「标签事件驱动的自动补挂」不会让任何判据失去输入。

⛔ 未触碰:`changeset-check` 的实时读与计数逻辑(#5580/#5625)、`allow-major`(#5620)、`.github/labeler.yml`、MCP 服务端。

## 三、验证

- `node scripts/check-workflow-status-functions.mjs` → `OK (scanned 22 workflow file(s), 39 job(s), 21 job-level if: expression(s); 9 read needs.*.outputs.*, all naming a status function)`;`--self-test` → 34 assertions 全过。
- YAML 结构验证(真 YAML parse,非 grep):`pr-size` 无 `needs`、`if` 为两个事件排除;`auto-label` `needs=pr-size`、`if` 含 `!cancelled()`;`changeset-check` 的 `if` 与 main 逐字一致;labeler step `with` = `{repo-token, configuration-path, sync-labels: false}`。
- `node scripts/check-nul-bytes.mjs` → `OK (scanned 5600 tracked text file(s) ...)`;另按控制字符条款做了闸门盲区自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`,零命中。
- **生效 ref**:`pull_request` 事件的 workflow 定义取自 merge ref,所以本 PR 的改动**在本 PR 自己的 run 上就生效**,A/B 可直接看本 PR 的 timeline。labeler 的配置文件同样取自 merge ref —— `src/api/get-content.ts` 用 `ref: github.context.sha`,`pull_request` 下即 merge commit(本 PR 没改 `labeler.yml`,但派发问到了,一并记为源码结论)。
- **可核验判据**(改动前后对照):本 PR 的 timeline 中,`github-actions[bot]` 不应再出现「针对本 job 不管的标签的 `unlabeled`」;`Check PR Size` 与 `Auto Label` 的执行窗口不再重合(后者 `started_at` 晚于前者 `completed_at`);标签事件不再拉起这两个 job(对应 run 里它们为 `skipped`)。

## 四、未关闭的一半(留给维护者决策,本 PR 不擅自动依赖)

**工作流之外**的写入方 —— 例如 `gh pr create` 之后几秒挂 `skip-changeset` 的 agent 或人,正好落在这两个 job 运行期间 —— 仍可能落进 PUT 窗口被抹。#5533 的豁免标签只活一秒就是这样丢的(15:46:44 挂上,15:46:45 被 labeler 的 PUT 抹掉),而这正是本 issue 里**有实际代价**的那一半。它需要写入本身变成新增语义,不是排序问题;两个 action 都没有对应的配置开关,只剩「自己拥有写入路径 / 换 action」这类决策。已按报告契约上报给 PM,注释里也写明了边界,没有伪装成已修。

## 五、工具面备案(落点 1,不改代码)

MCP `issue_write` 的 `labels` 字段语义会在本 PR 上做一次可控实验(挂标签前后回读),结论写进 #5649 的评论。agent 指令面「只加一个标签、不要整集写入」的条款已由 #5559 / PR #5650 落地,本单只补工具面事实。

## Changeset

workflow-only、无用户可见变更 → 走 `skip-changeset` 标签路线,不写空 frontmatter changeset(#4898 / #5292)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE)_