### PR TITLE
test(spec): 让 flow.test.ts 剩下的跑不通 fixture 形状真的能跑,并逐条钉住 (#5500)

### DIFF
--- a/packages/spec/src/automation/flow.test.ts
+++ b/packages/spec/src/automation/flow.test.ts
@@ -18,9 +18,16 @@ import {
 // builtin's config could run. These are the contracts that do.
 import {
   GetRecordConfigSchema,
+  CreateRecordConfigSchema,
   UpdateRecordConfigSchema,
   DeleteRecordConfigSchema,
 } from './builtin-node-config.zod';
+// #5500 — the `loop` container contract (ADR-0031). A `loop` with no
+// `config.body` is the LEGACY flat-graph shape: `loop-node.ts` reads
+// `config.collection` as a bare VARIABLE NAME, binds `$loopItems`/`$loopIndex`
+// and falls through without iterating — so no `iteratorVariable` is ever set
+// and a `{item.…}` token downstream references nothing.
+import { LoopConfigSchema } from './control-flow.zod';
 
 describe('FlowNodeAction', () => {
   it('should accept all node action types', () => {
@@ -114,8 +121,12 @@ describe('FlowNodeSchema', () => {
       id: 'node_3',
       type: 'create_record',
       label: 'Create Account',
+      // #5500 — was `object:`, the retired spelling the ADR-0087 D2 conversion
+      // `flow-node-crud-object-alias` rewrites at load (live through this major,
+      // retires at 18). A fixture is a teaching surface, so it spells the
+      // canonical key the executor actually reads.
       config: {
-        object: 'account',
+        objectName: 'account',
         fields: {
           name: '{input.companyName}',
           status: 'active',
@@ -124,6 +135,13 @@ describe('FlowNodeSchema', () => {
     };
 
     expect(() => FlowNodeSchema.parse(node)).not.toThrow();
+
+    // #5500 — `FlowNodeSchema.config` is deliberately open (ADR-0018), so the
+    // parse above stays green on a config no executor could run. Pin the config
+    // against the contract `create_record` actually parses: this is a VALUE
+    // verdict (the executor refuses the node without `objectName`), so full
+    // safeParse green is the right bar, and the alias spelling turns it red.
+    expect(CreateRecordConfigSchema.safeParse(node.config).success).toBe(true);
   });
 
   it('should accept all node types', () => {
@@ -481,8 +499,11 @@ describe('FlowSchema', () => {
             id: 'create_contact',
             type: 'create_record',
             label: 'Create Contact',
+            // #5500 — `object:` → `objectName:` (see `should accept node with
+            // config`). The `{firstName}` &c. tokens are declared INPUT
+            // variables, which the engine binds by name, so they resolve.
             config: {
-              object: 'contact',
+              objectName: 'contact',
               fields: {
                 first_name: '{firstName}',
                 last_name: '{lastName}',
@@ -494,9 +515,21 @@ describe('FlowSchema', () => {
             id: 'assign_output',
             type: 'assignment',
             label: 'Set Output',
+            // #5500 — was `{ variable: 'contactId', value: '{create_contact.id}' }`,
+            // which set NEITHER. `logic-nodes.ts` normalizes three assignment
+            // shapes and its last branch is "no `assignments` wrapper → the
+            // top-level config keys ARE the variable names", so that config
+            // declared two variables literally named `variable` and `value`,
+            // and `contactId` — declared `isOutput: true` right above — was
+            // never written. Measured: with the old shape the run ends with
+            // `variable='contactId'`, `value='<the new id>'`, `contactId=undefined`.
+            //
+            // The VALUE token was fine and is kept verbatim: the engine binds
+            // every node's `result.output` under `<nodeId>.<key>` and the
+            // template resolver reads that flat key, so `{create_contact.id}`
+            // resolves to the created row's id (`create_record` outputs `id`).
             config: {
-              variable: 'contactId',
-              value: '{create_contact.id}',
+              assignments: { contactId: '{create_contact.id}' },
             },
           },
           { id: 'end', type: 'end', label: 'End' },
@@ -509,6 +542,23 @@ describe('FlowSchema', () => {
       };
 
       expect(() => FlowSchema.parse(screenFlow)).not.toThrow();
+
+      // #5500 — pin the create node against the contract its executor parses.
+      const cfgOf = (id: string) => screenFlow.nodes.find(n => n.id === id)?.config;
+      expect(CreateRecordConfigSchema.safeParse(cfgOf('create_contact')).success).toBe(true);
+
+      // #5500 — pin the assignment's SHAPE, which no spec schema governs (the
+      // executor reads `config` directly, so `FlowSchema.parse` can never catch
+      // this). The writes must live under `assignments`, and every name written
+      // must be a variable this flow declares — reverting to the bare
+      // `{ variable, value }` shape leaves `assignments` undefined and turns
+      // both assertions red.
+      const assignCfg = cfgOf('assign_output') as { assignments?: Record<string, unknown> };
+      expect(Object.keys(assignCfg?.assignments ?? {})).toEqual(['contactId']);
+      const declared = new Set((screenFlow.variables ?? []).map(v => v.name));
+      for (const written of Object.keys(assignCfg?.assignments ?? {})) {
+        expect(declared.has(written)).toBe(true);
+      }
     });
 
     it('should accept scheduled flow', () => {
@@ -523,33 +573,72 @@ describe('FlowSchema', () => {
             id: 'get_old_records',
             type: 'get_record',
             label: 'Find Old Records',
+            // #5500 — three defects in two keys:
+            //  • `object:` → `objectName:` (the ADR-0087 D2 alias, as above).
+            //  • `filter` was the STRING `'created_at < DAYS_AGO(90)'`. The
+            //    contract declares `z.record(z.string(), z.unknown())`, so a
+            //    string fails safeParse outright ("expected record, received
+            //    string"), and `DAYS_AGO()` is a function no layer implements.
+            //    The date window is spelled in the dialect that OWNS a filter
+            //    value position: `{90_days_ago}` is a spec date macro
+            //    (`DATE_MACRO_PARAM_RE`), and `interpolateFilter` hands a known
+            //    filter token through VERBATIM for the query engine's
+            //    `resolveFilterTokens` to expand (#3810 ownership transfer) —
+            //    `date-macros.zod.ts` names "flow node filters" as a consumer.
+            //  • `limit` was absent. The executor branches on it: `limit > 1`
+            //    runs `find` and outputs a `records` LIST; otherwise `findOne`
+            //    and a single `record`. A cleanup sweep wants the list, and the
+            //    loop below needs an array, so the limit is what makes the
+            //    downstream `collection` an array at all.
             config: {
-              object: 'log_entry',
-              filter: 'created_at < DAYS_AGO(90)',
+              objectName: 'log_entry',
+              filter: { created_at: { $lt: '{90_days_ago}' } },
+              limit: 200,
+              outputVariable: 'oldRecords',
             },
           },
           {
             id: 'loop_records',
             type: 'loop',
             label: 'For Each Record',
+            // #5500 — was a LEGACY flat-graph loop: no `config.body`, so
+            // `loop-node.ts` took its back-compat branch, which reads
+            // `config.collection` as a bare VARIABLE NAME (not a template),
+            // found no variable literally named `{get_old_records.records}`,
+            // bound nothing and returned success. The `loop → delete → loop`
+            // back-edge was ordinary graph traversal, and `{item.id}` in the
+            // delete node below referenced a variable no one ever set.
+            // Measured on the old shape: `$loopItems` unset, `item` undefined.
+            //
+            // This is now the ADR-0031 structured container: the per-item steps
+            // live in `config.body` (a single-entry/single-exit region run in
+            // the enclosing scope) and `iteratorVariable` is what binds `item`.
             config: {
-              collection: '{get_old_records.records}',
-            },
-          },
-          {
-            id: 'delete_record',
-            type: 'delete_record',
-            label: 'Delete Record',
-            // #4924 — this was the worst of the three shapes: `recordId` was the
-            // node's ONLY key, no executor reads it, and a `delete_record` whose
-            // single "constraint" is unread is a match-everything delete (#3810)
-            // wearing a key that reads like a constraint. The executor locates rows
-            // through `filter` and refuses the node without `objectName`.
-            // The per-item token is the loop's `iteratorVariable` (default `item`),
-            // NOT `{<node id>.item}` — node outputs are never bound under a node id.
-            config: {
-              objectName: 'log_entry',
-              filter: { id: '{item.id}' },
+              collection: '{oldRecords}',
+              iteratorVariable: 'item',
+              maxIterations: 200,
+              body: {
+                nodes: [
+                  {
+                    id: 'delete_record',
+                    type: 'delete_record',
+                    label: 'Delete Record',
+                    // #4924 — this was the worst of the three shapes: `recordId` was the
+                    // node's ONLY key, no executor reads it, and a `delete_record` whose
+                    // single "constraint" is unread is a match-everything delete (#3810)
+                    // wearing a key that reads like a constraint. The executor locates rows
+                    // through `filter` and refuses the node without `objectName`.
+                    // The per-item token is the loop's `iteratorVariable` (default `item`),
+                    // NOT `{<node id>.item}` — and #5500 moved the node INSIDE the loop
+                    // body, which is what makes `item` actually bound per iteration.
+                    config: {
+                      objectName: 'log_entry',
+                      filter: { id: '{item.id}' },
+                    },
+                  },
+                ],
+                edges: [],
+              },
             },
           },
           { id: 'end', type: 'end', label: 'End' },
@@ -557,9 +646,10 @@ describe('FlowSchema', () => {
         edges: [
           { id: 'e1', source: 'start', target: 'get_old_records' },
           { id: 'e2', source: 'get_old_records', target: 'loop_records' },
-          { id: 'e3', source: 'loop_records', target: 'delete_record' },
-          { id: 'e4', source: 'delete_record', target: 'loop_records' },
-          { id: 'e5', source: 'loop_records', target: 'end', label: 'Done' },
+          // #5500 — the `loop → delete → loop` back-edge pair is gone: the
+          // delete node now lives in `config.body`, so the loop's ordinary
+          // out-edge is simply the after-loop continuation (ADR-0031).
+          { id: 'e3', source: 'loop_records', target: 'end', label: 'Done' },
         ],
         runAs: 'system',
       };
@@ -567,11 +657,36 @@ describe('FlowSchema', () => {
       expect(() => FlowSchema.parse(scheduledFlow)).not.toThrow();
 
       // #4924 — the delete node addresses rows the only way the executor does.
-      // (The `get_old_records` / `loop_records` pair upstream still carries
-      // shapes of its own — a string `filter`, the `object` alias and a
-      // `{<node id>.…}` output reference — tracked separately, see the PR.)
-      const deleteConfig = scheduledFlow.nodes.find(n => n.id === 'delete_record')?.config;
+      // #5500 — it is now reached through the loop's body region.
+      const loopConfig = scheduledFlow.nodes.find(n => n.id === 'loop_records')?.config;
+      const parsedLoop = LoopConfigSchema.safeParse(loopConfig);
+      expect(parsedLoop.success).toBe(true);
+      const deleteConfig = parsedLoop.success
+        ? parsedLoop.data.body?.nodes.find(n => n.id === 'delete_record')?.config
+        : undefined;
       expect(DeleteRecordConfigSchema.safeParse(deleteConfig).success).toBe(true);
+
+      // #5500 — pin the loop as a STRUCTURED container. `body` is what separates
+      // it from the legacy flat-graph shape that iterated nothing, and
+      // `iteratorVariable` is the only thing that binds the `{item.…}` token the
+      // body's filter reads. Dropping `body` puts the fixture back on the
+      // legacy branch and turns both of these red.
+      expect(parsedLoop.success && parsedLoop.data.body).toBeDefined();
+      expect(parsedLoop.success && parsedLoop.data.iteratorVariable).toBe('item');
+      // …and no main-graph edge targets a body node any more.
+      const bodyNodeIds = new Set(
+        parsedLoop.success ? (parsedLoop.data.body?.nodes ?? []).map(n => n.id) : [],
+      );
+      expect(scheduledFlow.edges.filter(e => bodyNodeIds.has(e.target))).toHaveLength(0);
+
+      // #5500 — the upstream read must produce an ARRAY for the loop to iterate:
+      // `limit > 1` is what selects the `find`/`records` branch over
+      // `findOne`/`record`, so it is a contract detail, not a tuning knob.
+      const getConfig = scheduledFlow.nodes.find(n => n.id === 'get_old_records')?.config;
+      const parsedGet = GetRecordConfigSchema.safeParse(getConfig);
+      expect(parsedGet.success).toBe(true);
+      expect(parsedGet.success && (parsedGet.data.limit ?? 0) > 1).toBe(true);
+      expect(parsedGet.success && parsedGet.data.outputVariable).toBe('oldRecords');
     });
 
     it('should accept API flow with webhook', () => {
@@ -975,11 +1090,29 @@ describe('BPMN — Default Sequence Flow (isDefault)', () => {
       source: 'decision_1',
       target: 'branch_a',
       type: 'conditional',
-      condition: '{amount} > 1000',
+      // #5500 — was `'{amount} > 1000'`. An edge condition is BARE CEL
+      // (ADR-0032 §1a); `{…}` template braces parse as a CEL map literal, and
+      // `AutomationEngine.registerFlow` parse-validates every predicate at
+      // registration, so the braced form is a HARD registration failure:
+      // "Flow '…' has 1 invalid expression (ADR-0032 §1a). Predicates … must
+      // not wrap references in `{…}` template braces". This is the #1491 trap.
+      condition: 'amount > 1000',
       label: 'High Value',
     });
     expect(result.type).toBe('conditional');
     expect(result.isDefault).toBe(false);
+    // #5500 — only an explicit assertion keeps this fixture from teaching the
+    // braced form back in. Braces are correct in TEMPLATE slots
+    // (`loop.collection`) and wrong here — the distinction is the whole point.
+    //
+    // Read `.source`, NOT the condition itself: `ExpressionInputSchema`
+    // normalizes a bare-string predicate into the canonical
+    // `{ dialect: 'cel', source }` envelope, so `expect(result.condition)
+    // .not.toContain('{')` asserts against an OBJECT and passes no matter what
+    // the predicate says. That phantom was written here first and caught by
+    // reverse-verification (the braced spelling stayed green) — hence this note.
+    expect(result.condition?.dialect).toBe('cel');
+    expect(result.condition?.source).not.toContain('{');
   });
 
   it('should validate a decision with default and conditional branches', () => {
@@ -997,8 +1130,11 @@ describe('BPMN — Default Sequence Flow (isDefault)', () => {
       ],
       edges: [
         { id: 'e1', source: 'start', target: 'check_priority' },
-        { id: 'e2', source: 'check_priority', target: 'high_path', type: 'conditional', condition: '{priority} == "high"' },
-        { id: 'e3', source: 'check_priority', target: 'medium_path', type: 'conditional', condition: '{priority} == "medium"' },
+        // #5500 — bare CEL, not `{…}` template braces (ADR-0032 §1a; see
+        // 'should accept conditional edge type'). Registering the braced form
+        // threw at `registerFlow`, so this whole fixture was un-runnable.
+        { id: 'e2', source: 'check_priority', target: 'high_path', type: 'conditional', condition: 'priority == "high"' },
+        { id: 'e3', source: 'check_priority', target: 'medium_path', type: 'conditional', condition: 'priority == "medium"' },
         { id: 'e4', source: 'check_priority', target: 'default_path', isDefault: true, label: 'Default' },
         { id: 'e5', source: 'high_path', target: 'end' },
         { id: 'e6', source: 'medium_path', target: 'end' },
@@ -1012,6 +1148,17 @@ describe('BPMN — Default Sequence Flow (isDefault)', () => {
       const defaultEdge = result.data.edges.find(e => e.isDefault);
       expect(defaultEdge).toBeDefined();
       expect(defaultEdge!.target).toBe('default_path');
+      // #5500 — every guarded branch is bare CEL. `FlowSchema.parse` accepts any
+      // string here, so without this the fixture could teach the #1491 braced
+      // form back in while staying green. Assert on the normalized
+      // `condition.source` (see 'should accept conditional edge type') — the
+      // parsed `condition` is an Expression ENVELOPE, and `toContain` against
+      // the envelope object pins nothing.
+      const guardedEdges = result.data.edges.filter(e => e.condition);
+      expect(guardedEdges).toHaveLength(2);
+      for (const guarded of guardedEdges) {
+        expect(guarded.condition?.source).not.toContain('{');
+      }
     }
   });
 });


### PR DESCRIPTION
Fixes #5500

承 #4924 / PR #5502 在同一文件上的工作。issue 列的五类里,**四类属实并已修**;**第 1 类的机制说法经实测不成立,按 Prime Directive 6 如实回报而不硬套模板**。文件面仅 `packages/spec/src/automation/flow.test.ts`。

行号已按当前 `origin/main` 重新定位(issue 里的行号以 #5502 合入时为准,main 已经移动):`object:` 在 `:118` / `:485` / `:527`(issue 写的是 117/433/474),brace-CEL 出边在 `:978` / `:1000` / `:1001`。

## 第 1 类:前提被证伪,未按 issue 的分析实现

issue 说「`{节点id.字段}` 这套输出引用方言,引擎从来不绑」。**不成立。**

- `service-automation/src/engine.ts:4243-4247` 对每个节点的 `result.output` 逐键写入 `` variables.set(`${node.id}.${key}`, value) ``。
- `builtin/template.ts:91` 的 `resolveToken` 有一条**扁平键兜底**(`if (variables.has(trimmed)) return variables.get(trimmed);`),正好读这个键。
- `builtin/crud-nodes.ts:156-158` 的模块文档把它写成**默认绑定**:「Writes the result back to the variable context under `outputVariable` (or under `nodeId.id` / `nodeId.records` by default)」。

实测(临时装一个 probe executor 快照变量表,跑完即删):

```
CLASS1a  create_contact.id  = "mock-contact-1785971151173"
CLASS1a  has(create_contact) = false
```

即 `{create_contact.id}` **能解析**,因此 `:499` 那个 token **原样保留**,只在旁边把机制写清楚。

issue 引的另一处 `:492` `'{get_old_records.records}'` 确实解析不到,但原因窄得多、也不是「方言不绑」:`get_record` 只有在 `limit > 1` 时才走 `find` 并输出 `records` 列表,否则走 `findOne` 输出单个 `record`(`builtin-node-config.zod.ts:208-209` 的契约文档明写)。所以修法是给该节点补 `limit`,见下。

## 第 2 类:assignment 缺 `assignments` 包裹 —— 属实

`logic-nodes.ts:129-132` 规范化三种形状,最后一条分支是「没有 `assignments` 包裹时,顶层 config 键就是变量名」。先证红(实测):

```
CLASS1a  variable var = "contactId"      ← 字面量变量名 variable
CLASS1a  value var    = "mock-contact-…" ← 字面量变量名 value
CLASS1a  contactId    = undefined        ← 声明了 isOutput 的那个,从没被写过
```

改为 `config: { assignments: { contactId: '{create_contact.id}' } }`。

## 第 3 类:legacy flat-graph loop —— 属实,且比 issue 说的更彻底

`loop-node.ts:70-80` 的 back-compat 分支不只是「不迭代」:它把 `config.collection` 当作**裸变量名**(`variables.get(collectionName)`)而非模板,所以 `'{get_old_records.records}'` 连 `$loopItems` 都没设上。实测:

```
CLASS3  $loopItems = undefined / has($loopItems) = false
CLASS3  item       = undefined
```

改成 ADR-0031 结构化容器:`delete_record` 移入 `config.body`,`iteratorVariable: 'item'` 才是真正绑 `{item.id}` 的东西;主图里 `loop -> delete -> loop` 的回边随之删除,loop 的普通出边就是 after-loop 续接。

## 第 4 类:字符串 `filter` —— 别名部分照修,形状部分已测出**有定论的答案**

`object:` -> `objectName:` 机械照修。字符串 `filter` 实测直接 safeParse 失败:

```
CLASS4 string filter parses: false
  {"expected":"record","code":"invalid_type","path":["filter"],
   "message":"Invalid input: expected record, received string"}
```

关于形状:issue 提的候选是 `{ created_at: { $lt: '{TODAY() - 90}' } }`,并担心 `$lt` 的 Zod 声明不含 string。**实测下来这个担心指错了地方,而且有一个不用猜的更好答案:**

- `GetRecordConfigSchema.filter` 是 `z.record(z.string(), z.unknown())`(`builtin-node-config.zod.ts:219`),值一律 `unknown` —— 两个候选**都 parse 绿**,`ComparisonOperatorSchema` 在这条路上**根本不参与校验**。
- 真正该用的是 **spec 自带的 filter 占位符方言**:`{90_days_ago}` 命中 `DATE_MACRO_PARAM_RE`,`isKnownFilterToken('90_days_ago') === true`,于是 `interpolateFilter`(`template.ts:216-235`,#3810 的槽位归属移交)把它**原样透传**给查询引擎的 `resolveFilterTokens` 展开;`date-macros.zod.ts:26-28` 明确把「flow node filters」列为该机制的消费者。

实测两个候选的落点:

```
A  {TODAY() - 90}  -> {"created_at":{"$lt":"2026-05-07"}}   ← 在 flow 层就被吃掉
B  {90_days_ago}   -> {"created_at":{"$lt":"{90_days_ago}"}} ← 透传给拥有该槽位的方言
```

采用 **B**。这不是猜:它是 spec 为这个槽位声明的方言,两处文档都点名。

另补 `limit: 200` + `outputVariable: 'oldRecords'` —— `limit` 是让上游产出**数组**的契约细节(否则 loop 拿到单条 record 会直接报「did not resolve to an array」),不是调参。

**残留的契约问题已单独立 finding:#5685** —— `ComparisonOperatorSchema` 的 `$gt/$gte/$lt/$lte` 声明为 `number | date | FieldReference` 不含 string,而平台自己的日期宏解析器只能产出字符串(`filter-tokens.ts:18-19` 的规范示例就是 `{ $gte: '2026-01-01' }`),一方调用方(`lifecycle-service.ts:991`、`outbox-sweep.ts:160`)也一律传 `.toISOString()`。该 schema **零运行期消费者**,今天不产生失败,故按 observation-class 记录、未在本 PR 顺手改。

## 第 5 类:`object` 别名 + brace-CEL 出边 —— 属实

三处 `object:` 改 `objectName:`。三处 brace-CEL 出边条件改裸 CEL,先证红(实测 `registerFlow` 是硬报错):

```
CLASS5 registerFlow threw: Flow 'm3' has 1 invalid expression (ADR-0032 §1a).
  Predicates … must not wrap references in `{…}` template braces;
  template slots (e.g. `loop.collection`) require them
```

顺带一提:这条报错本身证明了第 3 类里 `collection` 用花括号是**对的** —— 模板槽位要花括号,谓词槽位不要,两者的区别正是这几条钉子要守的东西。

## 钉法与反向验证

每类都按 #5502 在本文件的惯例加了契约断言,并且**逐条把坏形状放回去验证确实转红**(方向事先预测,全部为「红」):

| 还原的形状 | 转红的用例 |
|:---|:---|
| `objectName` -> `object` | `should accept node with config` |
| `assignments` -> `{ variable, value }` | `should accept screen flow for user input` |
| 去掉 loop 的 `body` | `should accept scheduled flow` |
| `filter` 记录形 -> 原字符串 | `should accept scheduled flow` |
| 去掉 `limit` | `should accept scheduled flow` |
| 出边条件加回花括号(两处) | `should accept conditional edge type` / `should validate a decision with default and conditional branches` |

**反向验证抓到了我自己第一版钉子里的一个幽灵断言,值得记一笔**:`ExpressionInputSchema`(`shared/expression.zod.ts:93`)会把裸字符串谓词规范化成 `{ dialect: 'cel', source }` 信封,所以对 **parse 之后**的 `condition` 写 `expect(condition).not.toContain('{')` 是在对一个**对象**断言,无论谓词写成什么都恒绿 —— 把花括号放回去时测试照样全绿,才暴露出来。现在两处都改读 `condition.source`,并在注释里写明这个坑。(#5502 原有的那处 `String(guarded?.condition)` 读的是**未 parse 的原始 fixture**,是真断言,未动。)

## 验证

```
pnpm --filter @objectstack/spec test       → 316 files / 8060 tests passed
pnpm --filter @objectstack/spec typecheck  → tsc --noEmit OK + check:test-typecheck OK
node scripts/check-nul-bytes.mjs           → OK (5581 files, no raw control bytes)
```

另外对本仓做了同形状普查:`DAYS_AGO` 别处无出现;其余 brace-CEL 命中点(`engine.test.ts:385/391`、`validate-expressions.test.ts` 若干)都是**故意的负向 fixture**(断言必须被拒),正确,未动。

## 变更集

纯测试改动,无用户可见行为变化,未加 changeset(tests-only)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018fxLGQdatPbBUvCgiVxg6D)_