### PR TITLE
fix(service-settings): gate OS_* env overrides on the manifest's declared options table (#5204)

### DIFF
--- a/.changeset/env-settings-option-table-gate.md
+++ b/.changeset/env-settings-option-table-gate.md
@@ -1,0 +1,38 @@
+---
+'@objectstack/service-settings': patch
+---
+
+Settings: an `OS_*` env override is now checked against the specifier's declared `options` table (#5204)
+
+A manifest's `options` table has been enforced on the write path since #5131, but
+`SettingsService.get()` produced an effective value by a second route that never
+consulted it: an `OS_*` override was reshaped by the default's type and returned
+straight from the top of the cascade with `locked: true`. So the providers #5094 and
+#5133 retired from `mail.provider` could walk back in through the one door with no
+gate on it — `OS_MAIL_PROVIDER=sendgrid` reached the mail plugin unchallenged — and a
+plain typo such as `OS_BRANDING_THEME_MODE=drak` was served to every consumer as a
+normal value with normal-looking provenance, each consumer left to improvise.
+
+An override whose value the table does not declare is now **ignored** rather than
+repaired: the value falls through to the next layer of the cascade (a stored
+global/tenant/user value, else the manifest default), and the read API reports that
+layer honestly instead of claiming `source: 'env'` for a value not in force. The
+rejection is logged once at `error`, naming the variable, the rejected value, the legal
+value set and the consequence. The same audit runs at `registerManifest`, so a
+misconfigured deployment learns at boot rather than whenever somebody first opens the
+settings page.
+
+Registration **reports but never refuses**: option tables move, a pin that was legal
+the day it was written must not turn an upgrade into a crash-on-start.
+
+Two behaviour notes for anyone relying on the old shape:
+
+- Keys with no declared option table are untouched — text, boolean, number and
+  password overrides behave exactly as before. The check applies only to
+  `select`/`radio`/`multiselect` specifiers that declare a non-empty table.
+- A **rejected** override no longer pins its key against writes. `setMany` used to
+  refuse on the mere presence of the variable; judged by presence, an ignored value
+  would have left the key configurable by nothing at all — env value discarded, UI
+  refused with `SETTINGS_LOCKED`, and `get()` reporting `locked: false` to a settings
+  page whose save would then fail. An override that *is* in force still locks the key,
+  unchanged.

--- a/packages/services/service-settings/src/index.ts
+++ b/packages/services/service-settings/src/index.ts
@@ -27,6 +27,7 @@ export {
   type SettingsActionHandler,
   type SettingsAuditSink,
   type SettingsContext,
+  type SettingsDiagnosticsLogger,
   type SettingsEngine,
   type SettingsRow,
   type SettingsServiceOptions,

--- a/packages/services/service-settings/src/settings-service-plugin.ts
+++ b/packages/services/service-settings/src/settings-service-plugin.ts
@@ -108,6 +108,13 @@ export class SettingsServicePlugin implements Plugin {
     this.service = new SettingsService({
       crypto: this.opts.crypto,
       env: this.opts.env,
+      // #5204 — the service reports a rejected `OS_*` override at `error`, and
+      // it must land in the deployment's real log pipeline rather than raw
+      // stdout. Passed before `registerManifest` below, because that call is
+      // what audits this namespace's env overrides: constructing the service
+      // without the logger first would send the boot-time report to the
+      // `console.error` fallback instead.
+      logger: ctx.logger,
     });
     for (const m of this.opts.manifests ?? []) this.service.registerManifest(m);
     for (const [ns, handlers] of Object.entries(this.opts.actionHandlers ?? {})) {

--- a/packages/services/service-settings/src/settings-service.test.ts
+++ b/packages/services/service-settings/src/settings-service.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { SettingsService } from './settings-service.js';
 import { SettingsLockedError, UnknownKeyError, UnknownNamespaceError, envKeyOf } from './settings-service.types.js';
 import { NoopCryptoAdapter } from './crypto-adapter.js';
@@ -592,6 +592,356 @@ describe('SettingsService — save-time validation (declared options are enforce
     expect(err.fields[0]).toMatchObject({ field: 'key_ref', code: 'invalid_option' });
     expect(err.fields[0].value).toBeUndefined();
     expect(err.message).not.toContain('s3cr3t-handle');
+  });
+});
+
+/**
+ * #5204 — the option table is enforced on the ENV side too.
+ *
+ * The symmetric half of the suite above. `setMany` has checked the declared
+ * table since #5131, but `get()` produced an effective value by a second route
+ * that never consulted it: an `OS_*` override was reshaped by the default's type
+ * (`coerceEnvValue`) and returned straight out of the top of the cascade with
+ * `locked: true`. So the values #5094/#5133 retired from `mail.provider` could
+ * walk back in through the one door with no gate on it —
+ * `OS_MAIL_PROVIDER=sendgrid` reached the mail plugin unchallenged — and a plain
+ * typo (`OS_BRANDING_THEME_MODE=drak`) was served to every consumer as a normal
+ * value with a normal-looking provenance.
+ *
+ * Per the ruling on #5204 an offending override is IGNORED, not repaired: the
+ * value falls through to the next cascade layer, and the read API reports THAT
+ * layer honestly instead of claiming `source: 'env'` for a value not in force.
+ */
+describe('SettingsService — env overrides are checked against declared options (#5204)', () => {
+  /** Capture the loud channel without stubbing the console. */
+  const spyLogger = () => {
+    const errors: string[] = [];
+    return { errors, logger: { error: (m: string) => void errors.push(m) } };
+  };
+
+  it('ignores an out-of-table env value and resolves the manifest default instead', async () => {
+    const { errors, logger } = spyLogger();
+    // The issue's own example: a typo, one transposition away from 'dark'.
+    const svc = new SettingsService({ env: { OS_BRANDING_THEME_MODE: 'drak' }, logger });
+    svc.registerManifest(brandingSettingsManifest);
+
+    const r = await svc.get('branding', 'theme_mode');
+    expect(r.value).toBe('system'); // the manifest default, not 'drak'
+    expect(r.source).toBe('default');
+    // The override is not in force, so it does not lock anything either.
+    expect(r.locked).toBe(false);
+    expect(r.lockedReason).toBeUndefined();
+    // And it contributes NO cascade entry — an `env` entry here would be read as
+    // a layer that supplied (and locked) the value.
+    expect(r.cascadeChain?.some((e) => e.scope === 'env')).toBe(false);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('OS_BRANDING_THEME_MODE');
+    expect(errors[0]).toContain('drak');
+    expect(errors[0]).toContain('light, dark, system'); // the legal value set
+    expect(errors[0]).toContain('IGNORED');
+  });
+
+  it('falls back to the next cascade layer, not straight to the default', async () => {
+    // "Ignored" means the env layer is skipped, not that the whole cascade is.
+    const { errors, logger } = spyLogger();
+    const svc = new SettingsService({ env: { OS_BRANDING_THEME_MODE: 'drak' }, logger });
+    svc.registerManifest(brandingSettingsManifest);
+    await svc.set('branding', 'theme_mode', 'dark');
+
+    const r = await svc.get('branding', 'theme_mode');
+    expect(r.value).toBe('dark');
+    expect(r.source).toBe('tenant');
+    expect(r.locked).toBe(false);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('still lets a value the table DOES declare win at the top of the cascade', async () => {
+    // The regression pin for the untouched path: a legal override keeps its
+    // precedence, its `locked: true`, and its reason string.
+    const { errors, logger } = spyLogger();
+    const svc = new SettingsService({ env: { OS_BRANDING_THEME_MODE: 'dark' }, logger });
+    svc.registerManifest(brandingSettingsManifest);
+
+    const r = await svc.get('branding', 'theme_mode');
+    expect(r.value).toBe('dark');
+    expect(r.source).toBe('env');
+    expect(r.locked).toBe(true);
+    expect(r.lockedReason).toContain('OS_BRANDING_THEME_MODE');
+    expect(r.cascadeChain?.[0]).toMatchObject({ scope: 'env', effective: true });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('an IN-FORCE override still pins the key against writes', async () => {
+    // The other half of the `locked` contract, unchanged: what `get()` reports as
+    // locked, `setMany` refuses. Pinned here so the coherence fix below cannot be
+    // over-applied into "env never locks anything".
+    const { logger } = spyLogger();
+    const svc = new SettingsService({ env: { OS_BRANDING_THEME_MODE: 'dark' }, logger });
+    svc.registerManifest(brandingSettingsManifest);
+    expect((await svc.get('branding', 'theme_mode')).locked).toBe(true);
+    await expect(svc.set('branding', 'theme_mode', 'light')).rejects.toBeInstanceOf(
+      SettingsLockedError,
+    );
+  });
+
+  it('a REJECTED override pins nothing — read and write agree the key is editable', async () => {
+    // Both halves of `locked` are judged by the same rule, so they cannot
+    // disagree. Before this, `setMany` locked on the mere PRESENCE of the env
+    // var: the read side would have said `locked: false` while the save threw
+    // `SETTINGS_LOCKED`, leaving the key configurable by nothing at all — env
+    // value ignored, UI refused — a lockout only an env edit could clear.
+    const { logger } = spyLogger();
+    const svc = new SettingsService({ env: { OS_BRANDING_THEME_MODE: 'drak' }, logger });
+    svc.registerManifest(brandingSettingsManifest);
+
+    expect((await svc.get('branding', 'theme_mode')).locked).toBe(false);
+    // …and the write the read surface just advertised as possible really is.
+    await expect(svc.set('branding', 'theme_mode', 'light')).resolves.toBeDefined();
+    const after = await svc.get('branding', 'theme_mode');
+    expect(after.value).toBe('light');
+    expect(after.source).toBe('tenant');
+  });
+
+  it('closes the #5094 door: OS_MAIL_PROVIDER cannot smuggle a retired provider back in', async () => {
+    // THE load-bearing case. `sendgrid` and `ses` left `mail.provider` in
+    // #5094/#5133 because this server cannot deliver through them; #5131 stopped
+    // them at the write path on the same day, and this is the other door.
+    const { errors, logger } = spyLogger();
+    const svc = new SettingsService({ env: { OS_MAIL_PROVIDER: 'sendgrid' }, logger });
+    svc.registerManifest(mailSettingsManifest);
+
+    const r = await svc.get('mail', 'provider');
+    expect(r.value).toBe('smtp'); // the manifest default
+    expect(r.source).toBe('default');
+    expect(errors[0]).toContain('smtp, resend, postmark, log');
+    // The consequence is spelled out, not left to the reader.
+    expect(errors[0]).toContain('does NOT take effect');
+    expect(errors[0]).toContain('OS_MAIL_PROVIDER');
+  });
+
+  it('leaves keys with no declared option table completely alone', async () => {
+    // The check must not widen past `select`/`radio`/`multiselect` with a table:
+    // a free-text, a boolean and a number env override behave exactly as before.
+    const { errors, logger } = spyLogger();
+    const svc = new SettingsService({
+      env: {
+        OS_BRANDING_WORKSPACE_NAME: 'EnvCorp', // text — any string is legal
+        OS_FEATURE_FLAGS_AI_ENABLED: 'true',   // boolean — coerced, not enumerated
+      },
+      logger,
+    });
+    svc.registerManifest(brandingSettingsManifest);
+    svc.registerManifest(featureFlagsSettingsManifest);
+
+    const name = await svc.get('branding', 'workspace_name');
+    expect(name.value).toBe('EnvCorp');
+    expect(name.source).toBe('env');
+    expect(name.locked).toBe(true);
+
+    const flag = await svc.get('feature_flags', 'ai_enabled');
+    expect(flag.value).toBe(true);
+    expect(flag.source).toBe('env');
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('reports the misconfiguration at registration, before anything reads the key', async () => {
+    // An override that will never take effect is a misconfigured deployment, and
+    // the operator should learn at boot rather than whenever someone first opens
+    // the settings page (or never, for a key nothing reads this process).
+    const { errors, logger } = spyLogger();
+    const svc = new SettingsService({ env: { OS_MAIL_PROVIDER: 'ses' }, logger });
+    expect(errors).toHaveLength(0);
+
+    svc.registerManifest(mailSettingsManifest);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('OS_MAIL_PROVIDER');
+    expect(errors[0]).toContain('ses');
+  });
+
+  it('registration REPORTS but never refuses — a stale pin must not block a boot', async () => {
+    // The upgrade trap: `sendgrid` was a legal value the day the deployment was
+    // written. Turning today's narrower table into a crash-on-start would punish
+    // exactly the operator the message is trying to help.
+    const { logger } = spyLogger();
+    const svc = new SettingsService({ env: { OS_MAIL_PROVIDER: 'sendgrid' }, logger });
+    expect(() => svc.registerManifest(mailSettingsManifest)).not.toThrow();
+    // The service is fully usable afterwards, including writes to the same key.
+    await expect(
+      svc.setMany('mail', { provider: 'smtp', smtp_host: 's.example.com', from_email: 'a@b.com' }),
+    ).resolves.toBeDefined();
+  });
+
+  it('says it ONCE, not once per read', async () => {
+    // `getNamespace` resolves every specifier on every settings page load, so a
+    // per-read line would be a firehose — and AGENTS.md's "Degradation log
+    // levels" names training people to skim `error` as the mirror-image failure.
+    const { errors, logger } = spyLogger();
+    const svc = new SettingsService({ env: { OS_BRANDING_THEME_MODE: 'drak' }, logger });
+    svc.registerManifest(brandingSettingsManifest); // one report here
+    for (let i = 0; i < 5; i++) await svc.get('branding', 'theme_mode');
+    await svc.getNamespace('branding');
+    await svc.getNamespace('branding');
+    expect(errors).toHaveLength(1);
+  });
+
+  it('reports a DIFFERENT bad value that appears after registration', async () => {
+    // The dedupe is keyed on the value, not just the var name: `this.env` may be
+    // a live `process.env` reference, so a newly-set bad override must not
+    // inherit an earlier line's silence.
+    const { errors, logger } = spyLogger();
+    const env: Record<string, string | undefined> = { OS_BRANDING_THEME_MODE: 'drak' };
+    const svc = new SettingsService({ env, logger });
+    svc.registerManifest(brandingSettingsManifest);
+    expect(errors).toHaveLength(1);
+
+    env.OS_BRANDING_THEME_MODE = 'lite';
+    const r = await svc.get('branding', 'theme_mode');
+    expect(r.source).toBe('default');
+    expect(errors).toHaveLength(2);
+    expect(errors[1]).toContain('lite');
+  });
+
+  it('the read surface reports the layer actually in force, never a phantom env', async () => {
+    // What `GET /api/settings/:ns` serves. Reporting `source: 'env'` with
+    // `locked: true` for a value that was discarded would tell an admin the
+    // field is pinned by the deployment and not editable — about a value nothing
+    // is using.
+    const { logger } = spyLogger();
+    const svc = new SettingsService({ env: { OS_BRANDING_THEME_MODE: 'drak' }, logger });
+    svc.registerManifest(brandingSettingsManifest);
+    await svc.set('branding', 'theme_mode', 'light');
+
+    const payload = await svc.getNamespace('branding');
+    expect(payload.values.theme_mode).toMatchObject({
+      value: 'light',
+      source: 'tenant',
+      locked: false,
+    });
+    expect(payload.values.theme_mode.cascadeChain?.some((e) => e.scope === 'env')).toBe(false);
+    // A sibling key with a legal env override is unaffected in the same payload.
+    expect(payload.values.workspace_name.source).toBe('default');
+  });
+
+  it('falls back to console.error when no logger is injected', async () => {
+    // A service built without a kernel (unit tests, control-plane mock, boot
+    // before the logger exists) must still report — going silent there is the
+    // very failure #5204 is about.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const svc = new SettingsService({ env: { OS_BRANDING_THEME_MODE: 'drak' } });
+      svc.registerManifest(brandingSettingsManifest);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(String(spy.mock.calls[0]![0])).toContain('OS_BRANDING_THEME_MODE');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('rejects the WHOLE multiselect override when any one member is undeclared', async () => {
+    // No manifest ships a `multiselect` today, so this is the shape the first one
+    // to do so will meet. Partial acceptance is deliberately not on the table: it
+    // would synthesise a combination nobody configured.
+    const { errors, logger } = spyLogger();
+    const svc = new SettingsService({
+      // A JSON array, because that is what `coerceEnvValue` produces when the
+      // declared default is an array — verified, not assumed.
+      env: { OS_DIGEST_CHANNELS: '["email","carrier_pigeon"]' },
+      logger,
+    });
+    svc.registerManifest({
+      namespace: 'digest',
+      version: 1,
+      label: 'Digest',
+      scope: 'tenant',
+      readPermission: 'setup.access',
+      writePermission: 'setup.access',
+      specifiers: [
+        {
+          type: 'multiselect',
+          key: 'channels',
+          label: 'Channels',
+          required: false,
+          default: ['email'],
+          options: [
+            { value: 'email', label: 'Email' },
+            { value: 'sms', label: 'SMS' },
+          ],
+        },
+      ],
+    } as any);
+
+    const r = await svc.get('digest', 'channels');
+    // `email` was legal, but the override is dropped whole — not narrowed to it.
+    expect(r.value).toEqual(['email']); // the manifest default, which happens to match
+    expect(r.source).toBe('default');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('carrier_pigeon');
+    expect(errors[0]).toContain('email, sms');
+  });
+
+  it('accepts a multiselect override whose every member is declared', async () => {
+    const { errors, logger } = spyLogger();
+    const svc = new SettingsService({ env: { OS_DIGEST_CHANNELS: '["email","sms"]' }, logger });
+    svc.registerManifest({
+      namespace: 'digest', version: 1, label: 'Digest', scope: 'tenant',
+      readPermission: 'setup.access', writePermission: 'setup.access',
+      specifiers: [
+        { type: 'multiselect', key: 'channels', label: 'Channels', required: false,
+          default: ['email'],
+          options: [{ value: 'email', label: 'Email' }, { value: 'sms', label: 'SMS' }] },
+      ],
+    } as any);
+
+    const r = await svc.get('digest', 'channels');
+    expect(r.value).toEqual(['email', 'sms']);
+    expect(r.source).toBe('env');
+    expect(r.locked).toBe(true);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('compares by string form, so a numeric option survives the env round-trip', async () => {
+    // An env var is always a string and `coerceEnvValue` turns it back into a
+    // number when the default is numeric. Comparing raw would reject the legal
+    // value `30`; the table is compared in string form for exactly this reason.
+    const { errors, logger } = spyLogger();
+    const svc = new SettingsService({ env: { OS_RETENTION_WINDOW_DAYS: '30' }, logger });
+    svc.registerManifest({
+      namespace: 'retention', version: 1, label: 'Retention', scope: 'tenant',
+      readPermission: 'setup.access', writePermission: 'setup.access',
+      specifiers: [
+        { type: 'select', key: 'window_days', label: 'Window', required: false, default: 7,
+          options: [{ value: 7, label: '7 days' }, { value: 30, label: '30 days' }] },
+      ],
+    } as any);
+
+    const r = await svc.get('retention', 'window_days');
+    expect(r.value).toBe(30);
+    expect(r.source).toBe('env');
+    expect(errors).toHaveLength(0);
+  });
+
+  it('never echoes the rejected value for an encrypted specifier', async () => {
+    // An option value is not a secret, but `encrypted` is authorable on ANY
+    // specifier, and this message lands in logs. Same rule as the save path.
+    const { errors, logger } = spyLogger();
+    const svc = new SettingsService({ env: { OS_VAULT_KEY_REF: 's3cr3t-handle' }, logger });
+    svc.registerManifest({
+      namespace: 'vault', version: 1, label: 'Vault', scope: 'tenant',
+      readPermission: 'setup.access', writePermission: 'setup.access',
+      specifiers: [
+        { type: 'select', key: 'key_ref', label: 'Key reference', required: false,
+          encrypted: true,
+          options: [{ value: 'primary', label: 'Primary' }, { value: 'backup', label: 'Backup' }] },
+      ],
+    } as any);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).not.toContain('s3cr3t-handle');
+    // …but it still names the var and the legal set, so the message stays useful.
+    expect(errors[0]).toContain('OS_VAULT_KEY_REF');
+    expect(errors[0]).toContain('primary, backup');
   });
 });
 

--- a/packages/services/service-settings/src/settings-service.ts
+++ b/packages/services/service-settings/src/settings-service.ts
@@ -83,6 +83,34 @@ function declaredOptionValues(options: unknown): string[] {
   return out;
 }
 
+/**
+ * The first member of `value` that the declared table does not admit, or
+ * `null` when every member is admissible.
+ *
+ * ONE comparison, shared by both paths that produce an effective value — the
+ * save path ({@link SettingsService.validatePatch}) and the env path
+ * ({@link SettingsService.get} / `reportRejectedEnvOverride`). #5204 exists
+ * precisely because one of those two checked the option table and the other
+ * did not; two open-coded copies of this comparison would be the same defect
+ * deferred rather than fixed.
+ *
+ * `multiselect` stores an array, `select`/`radio` a scalar; both are checked
+ * element-wise against the one table. A scalar arriving at a multiselect is
+ * wrapped rather than rejected — policing the value's SHAPE is a different
+ * constraint (`invalid_type`) with a different owner, and inventing it here
+ * would reject writes this check was never asked to touch.
+ *
+ * Returns a WRAPPER, not the offending value itself: a bare return cannot
+ * distinguish "nothing was rejected" from "the rejected member WAS
+ * `undefined`", and the latter would slip through the check. Same reason the
+ * implementation uses `findIndex` rather than `find`.
+ */
+function firstRejectedOption(allowed: string[], value: unknown): { value: unknown } | null {
+  const picked = Array.isArray(value) ? value : [value];
+  const at = picked.findIndex((v) => !allowed.includes(String(v)));
+  return at === -1 ? null : { value: picked[at] };
+}
+
 interface RegisteredManifest {
   manifest: SettingsManifest;
   /** Resolved specifier scopes for fast lookup. */
@@ -93,6 +121,19 @@ interface RegisteredManifest {
   defaults: Map<string, unknown>;
   /** Action handlers registered alongside this manifest. */
   actions: Map<string, SettingsActionHandler>;
+  /**
+   * Declared option values (string form) for every option-bearing specifier
+   * that actually declares a non-empty table, keyed by specifier key.
+   *
+   * Precomputed at registration because `get()` is the service's hottest path
+   * — `getNamespace` calls it once per specifier on every settings page load —
+   * and the alternative is re-scanning `manifest.specifiers` per read. A key
+   * ABSENT from this map is a key with nothing to enforce (not option-bearing,
+   * or an option-bearing type whose manifest declares no usable table), so
+   * absence means "unchanged behaviour" at both call sites rather than
+   * "check against an empty set", which would reject everything.
+   */
+  optionTables: Map<string, string[]>;
 }
 
 /**
@@ -108,7 +149,14 @@ export class SettingsService {
   private auditWriter?: import('./settings-service.types.js').SettingsAuditWriter;
   private readonly env: Record<string, string | undefined>;
   private readonly objectName: string;
+  private readonly logger?: import('./settings-service.types.js').SettingsDiagnosticsLogger;
   private readonly registry = new Map<string, RegisteredManifest>();
+  /**
+   * `OS_*` overrides already reported as rejected (#5204), keyed
+   * `<envVar>=<offending value>`. See {@link reportRejectedEnvOverride} for why
+   * the value is part of the key and not just the var name.
+   */
+  private readonly reportedEnvOverrides = new Set<string>();
   /** In-memory fallback when no engine is wired. */
   private readonly memory: SettingsRow[] = [];
   /** Change subscribers, optionally scoped to a namespace. */
@@ -126,6 +174,7 @@ export class SettingsService {
     this.auditWriter = opts.auditWriter;
     this.env = opts.env ?? (typeof process !== 'undefined' ? process.env : {});
     this.objectName = opts.objectName ?? DEFAULT_OBJECT;
+    this.logger = opts.logger;
   }
 
   /**
@@ -223,21 +272,181 @@ export class SettingsService {
   // Manifest registry
   // ---------------------------------------------------------------------
 
-  /** Register (or replace) a manifest. Idempotent. */
+  /**
+   * Register (or replace) a manifest. Idempotent.
+   *
+   * Registration is also where the deployment's `OS_*` overrides for this
+   * namespace are audited against the manifest's option tables (#5204) — see
+   * {@link auditEnvOverrides}. Registration REPORTS, it never rejects: a value
+   * that was legal yesterday and left the table today must not keep an
+   * existing deployment from booting.
+   */
   registerManifest(manifest: SettingsManifest): void {
     const scopes = new Map<string, SpecifierScope>();
     const encryptedKeys = new Set<string>();
     const defaults = new Map<string, unknown>();
+    const optionTables = new Map<string, string[]>();
     const defaultScope = manifest.scope ?? 'tenant';
     for (const spec of manifest.specifiers) {
       if (!spec.key || LAYOUT_ONLY_TYPES.has(spec.type)) continue;
       scopes.set(spec.key, spec.scope ?? defaultScope);
       if (spec.encrypted || spec.type === 'password') encryptedKeys.add(spec.key);
       if (typeof spec.default !== 'undefined') defaults.set(spec.key, spec.default);
+      if (OPTION_BEARING_TYPES.has(spec.type)) {
+        // A manifest with no option table cannot say what is legal. The spec
+        // refuses that shape at parse time, but `registerManifest` takes
+        // manifests as given (no Zod pass), so record nothing rather than
+        // record an empty table — same leniency the save path takes, and the
+        // reason the map's ABSENT key means "nothing to enforce".
+        const allowed = declaredOptionValues((spec as { options?: unknown }).options);
+        if (allowed.length > 0) optionTables.set(spec.key, allowed);
+      }
     }
     const prev = this.registry.get(manifest.namespace);
     const actions = prev?.actions ?? new Map<string, SettingsActionHandler>();
-    this.registry.set(manifest.namespace, { manifest, scopes, encryptedKeys, defaults, actions });
+    this.registry.set(manifest.namespace, {
+      manifest,
+      scopes,
+      encryptedKeys,
+      defaults,
+      actions,
+      optionTables,
+    });
+    this.auditEnvOverrides(manifest.namespace);
+  }
+
+  /**
+   * #5204 — report every `OS_*` override in this namespace whose value the
+   * specifier's declared `options` table does not admit.
+   *
+   * Why at registration and not only on read: an override that will never take
+   * effect is a **misconfigured deployment**, and the operator should learn
+   * that at boot, next to the rest of the startup output — not the first time
+   * somebody happens to open the settings page, and not never (a key nobody
+   * reads during the process's life would otherwise stay silent forever).
+   *
+   * Why it does NOT refuse to boot: the option tables move. #5094 retired
+   * `sendgrid` and `ses` from `mail.provider`; a deployment pinning
+   * `OS_MAIL_PROVIDER=sendgrid` was correct the day it was written, and turning
+   * an upgrade into a crash-on-start would punish exactly the operator this
+   * message is trying to help. The value is ignored either way (see `get`); the
+   * difference is whether the rest of the platform still comes up around it.
+   */
+  private auditEnvOverrides(namespace: string): void {
+    const reg = this.registry.get(namespace);
+    if (!reg || reg.optionTables.size === 0) return;
+    // Only the option-bearing keys can be rejected, so only they are worth
+    // walking. `effectiveEnvOverride` does the judging (and the reporting);
+    // the value it returns is of no interest here.
+    for (const key of reg.optionTables.keys()) {
+      this.effectiveEnvOverride(reg, namespace, key);
+    }
+  }
+
+  /**
+   * The `OS_*` override for this key **if it is actually in force**, else null.
+   *
+   * THE one place that answers "does env win here?", for every site that used to
+   * ask in its own way. There were three, and #5204 is what having three costs:
+   * `get()` coerced the value and returned it, `setMany` locked the key on the
+   * mere PRESENCE of the variable, and neither consulted the `options` table
+   * that the save path had been enforcing since #5131.
+   *
+   * Routing all three through one judgment is what keeps `locked` coherent. A
+   * rejected override is not in force, so it must not pin the key either:
+   * reporting `locked: false` from `get()` while `setMany` still threw
+   * `SETTINGS_LOCKED` would leave the settings UI rendering the field as
+   * editable and then failing the save — and, worse, would leave that key
+   * configurable by NOTHING (env value rejected, UI refused), a lockout only an
+   * env edit could clear. That is strictly worse than the hole #5204 closes,
+   * and it is the same reasoning `validatePatch` already applies when it
+   * refuses to lock a workspace out over historical drift.
+   *
+   * Reporting lives here rather than at the call sites so no future fourth
+   * caller can read an override without the rejection being heard.
+   */
+  private effectiveEnvOverride(
+    reg: RegisteredManifest,
+    namespace: string,
+    key: string,
+  ): { envName: string; value: unknown } | null {
+    const envName = envKeyOf(namespace, key);
+    const envRaw = this.env[envName];
+    if (typeof envRaw !== 'string') return null;
+
+    const value = coerceEnvValue(envRaw, reg.defaults.get(key));
+    // A key with no declared table has nothing to enforce — unchanged behaviour.
+    const allowed = reg.optionTables.get(key);
+    if (!allowed) return { envName, value };
+
+    const rejected = firstRejectedOption(allowed, value);
+    if (!rejected) return { envName, value };
+
+    this.reportRejectedEnvOverride(reg, namespace, key, envName, allowed, rejected.value);
+    return null;
+  }
+
+  /**
+   * Emit the one loud line a rejected `OS_*` override owes its operator, at
+   * most once per (env var, value) for the life of the service.
+   *
+   * **Level is `error`, deliberately.** AGENTS.md → "Degradation log levels"
+   * decides this by one question: afterwards, does the system still look normal
+   * from the outside while something it claims to honour has not landed? Here
+   * it does — the read API answers with a perfectly plausible value tagged with
+   * a perfectly plausible source, and nothing anywhere looks broken, while the
+   * operator's declared intent is simply not in force. #5152 reached the same
+   * verdict for `auth.membership_policy` in `bindAuthSettings` for the same
+   * reason, and that case shows the stakes: a typo'd `invite_only` read as
+   * `auto` leaves an operator believing the wall is up while every sign-up is
+   * auto-bound.
+   *
+   * **Once, not once per read.** Same section: "Say it once, at the first
+   * degradation, not once per failed write." `getNamespace` resolves every
+   * specifier in the namespace on every settings page load, so a per-read line
+   * would be a firehose — and training people to skim `error` is the
+   * mirror-image failure AGENTS.md names in the very next paragraph. Keying the
+   * dedupe on the VALUE as well as the var means a genuinely new bad value is
+   * still reported: `this.env` may be a live `process.env` reference, so an
+   * override can appear or change after registration and must not inherit an
+   * earlier line's silence.
+   *
+   * **No structured `meta`.** Everything an operator needs is in the sentence,
+   * and `Logger.redactSensitive` (`packages/core/src/logger.ts`) redacts any
+   * meta field whose name merely CONTAINS `key`/`token`/`secret`/`password` —
+   * so the obvious `{ key }` / `{ envKey }` field would arrive as
+   * `***REDACTED***` and delete the diagnostic while looking complete (#5573).
+   */
+  private reportRejectedEnvOverride(
+    reg: RegisteredManifest,
+    namespace: string,
+    key: string,
+    envName: string,
+    allowed: string[],
+    offending: unknown,
+  ): void {
+    const dedupeAt = `${envName}=${String(offending)}`;
+    if (this.reportedEnvOverrides.has(dedupeAt)) return;
+    this.reportedEnvOverrides.add(dedupeAt);
+
+    // An option value is not a secret, but `encrypted` is authorable on ANY
+    // specifier — so never echo the rejected value for a key whose contents are
+    // held encrypted, in a message that lands in logs. Same rule, same reason,
+    // as the save path's `invalid_option` error.
+    const secret = reg.encryptedKeys.has(key);
+    const rejected = secret ? '' : ` Rejected value: '${String(offending)}'.`;
+    const message =
+      `[SettingsService] env override ${envName} is not a declared option for ` +
+      `setting '${namespace}.${key}' — IGNORED.${rejected} Allowed values: ${allowed.join(', ')}. ` +
+      `Consequence: this override does NOT take effect and nothing else looks wrong — ` +
+      `'${namespace}.${key}' resolves from the next layer of the cascade instead ` +
+      `(a stored global/tenant/user value, else the manifest default), and reads report ` +
+      `THAT layer as the source rather than 'env'. ` +
+      `Fix: set ${envName} to one of the allowed values, or unset it and configure ` +
+      `'${namespace}.${key}' through the settings UI.`;
+
+    if (this.logger?.error) this.logger.error(message);
+    else console.error(message);
   }
 
   /** Look up a manifest, or throw `UnknownNamespaceError`. */
@@ -306,12 +515,27 @@ export class SettingsService {
     if (!reg) throw new UnknownNamespaceError(namespace);
     if (!reg.scopes.has(key)) throw new UnknownKeyError(namespace, key);
 
-    // 1. OS_* env
-    const envName = envKeyOf(namespace, key);
-    const envRaw = this.env[envName];
-    if (typeof envRaw === 'string') {
-      const def = reg.defaults.get(key);
-      const value = coerceEnvValue(envRaw, def);
+    // 1. OS_* env — but only when the override is actually in force.
+    //
+    // #5204: the `options` table is an ENFORCEMENT surface on this side too.
+    // `setMany` has checked it since #5131, yet an env override reached the
+    // effective value without passing through that path at all, and did so at
+    // the TOP of the cascade with `locked: true` — so `OS_MAIL_PROVIDER=sendgrid`
+    // handed the mail plugin the exact value #5094 had just retired, through the
+    // one door nobody was watching. `coerceEnvValue` only ever reshaped the
+    // string by the default's type; it never consulted the enumeration.
+    //
+    // A rejected value is IGNORED rather than repaired: there is no honest way to
+    // guess which declared option a typo meant, and guessing is worse than not
+    // applying it (#5152, on `invite_only` silently read as `auto`). Ignored
+    // means the env layer contributes NOTHING here — no value and, critically,
+    // no `cascadeChain` entry: an `env` entry carrying `locked: true` would be
+    // picked up by the `lockedEntry` scan below and reported as locking a value
+    // it is not even providing, which is the opposite of what the read API owes
+    // its caller.
+    const envOverride = this.effectiveEnvOverride(reg, namespace, key);
+    if (envOverride) {
+      const { envName, value } = envOverride;
       return {
         value: value as T,
         source: 'env',
@@ -504,8 +728,16 @@ export class SettingsService {
     // Pre-flight: reject the whole batch if any key is locked or unknown.
     for (const key of Object.keys(patch)) {
       if (!reg.scopes.has(key)) throw new UnknownKeyError(namespace, key);
-      const envRaw = this.env[envKeyOf(namespace, key)];
-      if (typeof envRaw === 'string') throw new SettingsLockedError(namespace, key);
+      // An env override pins the key against writes — but only one that is IN
+      // FORCE (#5204). This used to trigger on the mere PRESENCE of the
+      // variable, which after the read-side gate would have produced a key
+      // configurable by nothing at all: the env value rejected and ignored, the
+      // UI refused with `SETTINGS_LOCKED`, and `get()` reporting `locked: false`
+      // to a settings page that would then fail its own save. See
+      // `effectiveEnvOverride`.
+      if (this.effectiveEnvOverride(reg, namespace, key)) {
+        throw new SettingsLockedError(namespace, key);
+      }
 
       // Phase 2 lock: a row at an upper scope marked locked=true
       // refuses writes at this (lower) scope. Writing AT the same
@@ -743,19 +975,11 @@ export class SettingsService {
         // write to a hand-built manifest — same leniency the unparseable
         // `visible` and invalid `pattern` branches already take.
         if (allowed.length > 0) {
-          // `multiselect` stores an array, `select`/`radio` a scalar; both are
-          // checked element-wise against the one table. A scalar arriving at a
-          // multiselect is wrapped rather than rejected — policing the value's
-          // SHAPE is a different constraint (`invalid_type`) with a different
-          // owner, and inventing it here would reject writes this change was
-          // never asked to touch.
-          const picked = Array.isArray(value) ? value : [value];
-          // `findIndex`, not `find`: a `find` returning `undefined` cannot say
-          // whether nothing was rejected or whether the rejected element WAS
-          // `undefined` — and the latter would slip through the check.
-          const at = picked.findIndex((v) => !allowed.includes(String(v)));
-          if (at !== -1) {
-            const offending = picked[at];
+          // Shared with the env path (#5204) — see `firstRejectedOption` for the
+          // array/scalar handling and why the result is wrapped.
+          const rejected = firstRejectedOption(allowed, value);
+          if (rejected) {
+            const offending = rejected.value;
             // An option value is not a secret, but `encrypted` is authorable on
             // any specifier — so never echo the rejected value for a key whose
             // contents are held encrypted, in a message that lands in logs.

--- a/packages/services/service-settings/src/settings-service.types.ts
+++ b/packages/services/service-settings/src/settings-service.types.ts
@@ -180,6 +180,29 @@ export type SettingsActionHandler = (input: {
   ctx: SettingsContext;
 }) => Promise<SettingsActionResult> | SettingsActionResult;
 
+/**
+ * Minimal logging surface the service needs: just the loud channel.
+ *
+ * Deliberately a structural minimum rather than the full `Logger` contract or
+ * `PluginContext['logger']` — this service is framework-agnostic by design (it
+ * must not learn about the plugin context, see the file header), and a caller
+ * can hand over `ctx.logger`, a spec `Logger`, or a two-line test double
+ * interchangeably. `error` is optional so the lean test kernels that already
+ * call `ctx.logger?.info?.()` defensively are assignable unchanged.
+ *
+ * One string parameter, and no `...rest`: the service deliberately passes no
+ * structured `meta` (a meta field name containing `key` would be redacted away
+ * — see `reportRejectedEnvOverride`), and a `...rest: unknown[]` tail would not
+ * even accept the spec `Logger` it is meant to accept — its `error(message,
+ * error?: Error, meta?)` is narrower than `unknown` in those positions, so the
+ * assignment fails contravariantly. Declaring only what is actually called
+ * keeps `Logger`, `ctx.logger`, `console.error` and a one-line spy all
+ * assignable.
+ */
+export interface SettingsDiagnosticsLogger {
+  error?: (message: string) => void;
+}
+
 export interface SettingsServiceOptions {
   /** Persistence engine. When undefined, an in-memory store is used. */
   engine?: SettingsEngine;
@@ -206,6 +229,15 @@ export interface SettingsServiceOptions {
   env?: Record<string, string | undefined>;
   /** Object name backing the K/V store. Defaults to 'sys_setting'. */
   objectName?: string;
+  /**
+   * Sink for the loud-but-non-fatal diagnostics the service emits — today
+   * exactly one: an `OS_*` override whose value the specifier's `options`
+   * table does not declare (#5204). Optional; falls back to `console.error`
+   * so a service built without a kernel (unit tests, control-plane mock,
+   * bootstrap before the logger exists) still reports rather than going
+   * silent, which is the failure mode #5204 is about.
+   */
+  logger?: SettingsDiagnosticsLogger;
 }
 
 /**


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5204

## 前提重验(先对 origin/main 逐条核实,再动手)

Issue 的两条事实与落点都成立,且比 issue 描述的更严重一层:

1. **写入路径确实过表**:`packages/services/service-settings/src/settings-service.ts` 的 `validatePatch` 里 `OPTION_BEARING_TYPES` + `declaredOptionValues` 校验在位,`invalid_option` 由 `settings-service.test.ts:431` 起的一组用例钉住。
2. **env 路径确实不过表**:`get()` 的 env 分支只做 `coerceEnvValue(envRaw, def)`,按默认值的类型做形状转换后直接 `return { source: 'env', locked: true }`,全程不读 `spec.options`。
3. **新发现:同一个 env 覆盖有第三个读取点**,`setMany` 的 pre-flight:

   ```
   const envRaw = this.env[envKeyOf(namespace, key)];
   if (typeof envRaw === 'string') throw new SettingsLockedError(namespace, key);
   ```

   它只看环境变量**是否存在**,不看值是否合法。这条对本单是决定性的:如果只按裁决改读取侧,非法 env 值会变成「读侧 `locked: false`、写侧照旧抛 `SETTINGS_LOCKED`」——设置页把字段渲染成可编辑,保存却失败;更糟的是该键**谁都配不了**(env 值被忽略、UI 被拒),只能改环境变量才能解套,比 #5204 原本的洞更差。所以三个读取点必须共用一个判断,详见下面「locked 语义」。

`auth.membership_policy`(#5152)的那道 `bindAuthSettings` 防线**保留未动**。归并建议见文末。

## 实现

按维护者裁决「方案 1 为主 + 注册时响亮 error(不拒绝启动)」:

- **一个判断,三个调用点**。新增 `effectiveEnvOverride(reg, namespace, key)`:返回「真正生效的 env 覆盖」或 null。`get()`、`setMany` 的写锁、注册时扫描全部走它。报告动作放在这个函数里而不是各调用点,这样将来第四个调用者不可能读到覆盖却让拒绝无声。
- **一个比较,两条路径**。抽出模块级 `firstRejectedOption(allowed, value)`,env 侧与 `validatePatch` 共用。#5204 的成因正是「两条产出有效值的路径只有一条过表」,再开一份手写比较等于把同样的缺陷推迟。
- **非法即忽略,不修补、不猜测**。没有诚实的办法猜一个拼错的值原本想选哪个,猜错比不生效更坏(#5152 里 `invite_only` 被读成 `auto` 就是代价)。忽略意味着回落 cascade 下一层。
- **注册时扫描**(`auditEnvOverrides`):一个永远不会生效的覆盖是**部署配置错误**,运维应该在启动时和其它启动输出一起看到,而不是等谁哪天打开设置页,也不是永远看不到(进程生命周期内没人读的键否则永远沉默)。**只报告,不拒绝启动**:option 表会变,#5094 摘掉 `sendgrid` 之前,`OS_MAIL_PROVIDER=sendgrid` 是当天写下就正确的配置,把升级变成崩溃启动恰好惩罚了这条消息想帮的人。
- **校验面严格限定**在「声明了非空 options 表的 `select`/`radio`/`multiselect`」。`RegisteredManifest.optionTables` 里**没有**该键 = 没有可执行的枚举 = 行为完全不变(text / boolean / number / password 一律照旧)。

### locked 语义(本单的连带修复)

`setMany` 的写锁改为按「是否真正生效」判断,而不是按环境变量是否存在。**生效的**覆盖照旧锁定该键(读侧 `locked: true`,写侧抛 `SETTINGS_LOCKED`),这条没变、并新增用例钉住,防止过度推广成「env 永不锁定」;**被拒绝的**覆盖什么也不锁,读写两侧一致地认为该键可编辑。

被忽略的 env 值也**不进 `cascadeChain`**:带 `locked: true` 的 env 条目会被下面 `chain.find((e) => e.locked === true)` 捡走,变成「报告一个它根本没提供的值被自己锁住」,与读取面该给调用方的信息正相反。

### error 消息

级别取 `error` 而非 `warn`,依 AGENTS.md「Degradation log levels」的判据:降级之后系统从外面看仍然正常(读取面给出一个完全合理的值、挂着一个完全合理的来源),而运维声明的意图根本没生效——#5152 对 `auth.membership_policy` 是同样的裁断。按同一节「Say it once, at the first degradation」,去重键为「环境变量 + 值」,所以 `getNamespace` 每次页面加载不会刷屏,而一个**新的**坏值仍会被报告(`this.env` 可能是活的 `process.env` 引用)。

消息含变量名、被拒的值、合法值集、后果与修复动作。刻意**不带结构化 meta**:`packages/core/src/logger.ts` 的 `redactSensitive` 按 `includes` 匹配 `key`/`token`/`secret`/`password`,顺手写成 `{ key }` / `{ envKey }` 会被脱敏成 `***REDACTED***`,消息看着完整而诊断已被删掉(#5573 的教训)。`encrypted` specifier 不回显被拒的值,与写入侧同规则。

logger 经 `SettingsServicePlugin` 注入(`ctx.logger`),未注入时回落 `console.error`——没有 kernel 的场景(单测、control-plane mock、logger 之前的 bootstrap)也必须出声,沉默正是本单要修的病。

## multiselect 形状:按现状核实的结论

`coerceEnvValue` 里**没有任何逗号切分**:仅当声明的 default 是数组/对象时才 `JSON.parse`。所以

- 声明了数组 default 的 multiselect,env 形状是 JSON 数组,逐成员过表;
- 没有 default 的 multiselect,env 原样是字符串,按标量过表。`"a,b"` 因此会被判非法——这不是回归:今天把字符串 `"a,b"` 交给期待数组的消费方本来就是坏的,现在改为响亮拒绝。

任一成员非法则**整个 env 值作废**(不做部分接受),否则会造出没人配置过的组合。仓库现无 `multiselect`/`radio` 生产 manifest,这两类由手搭 manifest 的用例覆盖——与 `OPTION_BEARING_TYPES` 注释里既有的理由一致:否则第一个写出 multiselect 的 manifest 会静悄悄重开这个洞。

## 一处需要维护者知道的曝光面(未在本 PR 处理)

`localization.timezone` 声明为 `select`,但表里只有 **17 个策展时区**,而它自己的 description 写的是「IANA zone」;`localization.currency` 同形(9 个 ISO 4217 码,description 写「ISO 4217 code」)。这类「策展便利列表」自 #5131 起在写入侧已经是穷尽式执行边界,本 PR 让 env 侧与之一致——于是一个用 `OS_LOCALIZATION_TIMEZONE=Europe/Zurich` 固定未列出合法 IANA 时区的部署,现在会被忽略并回落(带响亮 error)。

仓库内没有任何地方实际设置这些变量(只有 `packages/rest/src/rest-api-plugin.ts` 注释提及),所以不构成在库回归。张力本身是 #5131 引入、由本 PR 传播到 env 的,已另开 issue 记录,方向是在**生产者**侧修(补全表,或换掉 specifier 类型),而不是在消费侧放宽——因此本 PR 不为它开豁免口子。

## 测试

`packages/services/service-settings`:**243 passed(15 文件)**,其中新增 17 个用例,覆盖:非法值忽略 + error + 回落默认值 / 回落下一层(tenant 行)、合法值照常生效并锁定、无 options 键完全不受影响、注册时一次性 error、注册只报告不拒绝、只报一次而非每次读、注册后出现的**新**坏值仍报告、读取面(`getNamespace`)如实报告生效层且 chain 无 env 条目、无 logger 时回落 console.error、multiselect 整体作废与全合法通过、数值 option 经 env 往返仍匹配、encrypted specifier 不回显值,以及 locked 语义两个方向的钉子。

消费半径全绿:`objectql` 1970、`plugin-auth` 786(含 #5152 membership-policy 全套)、`plugin-email` 297、`rest` 751、`cli` 825、`verify` 17。

`plugin-auth` 那套之所以不受影响:它注入的是 mock 读取面(`settingsStore.values` 直接给 `{ value: 'invite_only', source: 'env' }`),不走真实 `get()`,所以 #5152 这道第二防线仍被真实测着。

### 反向验证(先预测方向,再跑)

预测:把删掉的肢体接回去(env 值无条件返回、`setMany` 按存在性锁定、去掉注册扫描),新钉子应**转红**,且是最普通的方向——本单堵的是一个**根本不存在的检查**,不是 `??` 别名链,所以规范非法的值此前是被**接受**的,不存在 #5009 那类反转。同时,描述改动前既有行为的用例应**保持绿**。

实测一致:**12 红 / 231 绿**。转红的正是 12 个新行为钉子;保持绿的 5 个是「合法覆盖照旧胜出」「生效覆盖照旧锁定写入」「无 options 键不受影响」「全合法 multiselect 通过」「数值 option 往返」。

### 门检查

`check:nul-bytes` OK(5610 文件);改动文件 `grep -naP` 扫控制字节无命中;`check:durability-degradation-log-level` OK(24 个 seam 全响亮);`check:type-check-coverage` OK——本包带 13 错的 DEBT 台账未被移动(实测仍为 13,且无一条落在改动文件里);`check:startup-registry-verdict`、`check:init-service-contract`、`check:error-code-casing`、`check:wildcard-fallthrough` 均 OK;改动文件 eslint 干净。changeset 为 patch。

## 关于 #5152 是否归并的建议(按代码证据,不在本 PR 动手)

**建议保留**,理由是它守的不是同一件事:`bindAuthSettings` 的检查跑在 `isExplicit('membership_policy')` 之后、`patch.membershipPolicy` 之前,守的是「进入 AuthManager 的值必须是 `MembershipPolicy`」——数据来源不止 env,还有存储行(`source: 'global'`/`'tenant'`),而存储行可能带着 option 表收紧之前写下的历史值(`validatePatch` 的 TOUCH 闸门刻意允许这种漂移继续存在,以免把工作区锁死在自己的设置页外)。本 PR 关掉的是 env 这扇门,关不掉那条历史漂移路径。归并会把一个仍然可达的输入暴露给 `AuthManager`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BWS4heBoAitLmzCLhcYdbK)_