### PR TITLE
test(runtime,dogfood): 批次 0 —— 两个真依赖测试后端迁到 sqlite `:memory:`

### DIFF
--- a/packages/qa/dogfood/test/read-coercion-conformance.test.ts
+++ b/packages/qa/dogfood/test/read-coercion-conformance.test.ts
@@ -1,10 +1,17 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 //
 // Driver read-coercion conformance — exercises the reusable `checkReadCoercion`
-// helper (from @objectstack/verify) against the framework's own SQL + memory
-// drivers. A stored value must read back as its DECLARED type on every driver:
-// a boolean as a boolean (not the integer 0/1 SQLite stores), a json field as
-// an object, an integer as a number.
+// helper (from @objectstack/verify) against the framework's own SQL driver
+// (better-sqlite3 `:memory:`). A stored value must read back as its DECLARED
+// type: a boolean as a boolean (not the integer 0/1 SQLite stores), a json
+// field as an object, an integer as a number.
+//
+// The `driver-memory` arm was removed in #5704 (batch 0): driver-memory is the
+// project's legacy test-convenience backend and its in-project test surface is
+// being replaced by sqlite `:memory:` (#5499). Nothing is lost here — SQLite is
+// the driver that actually stores booleans as integers, so it is the arm that
+// carries the invariant; a mingo store that never had to coerce anything could
+// only ever be green.
 //
 // This is the invariant behind the 2026-07-06 case_escalation incident: a
 // boolean guard `field != true` read the field back as integer `1` on Turso, so
@@ -15,7 +22,6 @@
 import { describe, it, expect } from 'vitest';
 import { checkReadCoercion } from '@objectstack/verify';
 import { SqlDriver } from '@objectstack/driver-sql';
-import { InMemoryDriver } from '@objectstack/driver-memory';
 
 const DRIVERS = [
   {
@@ -26,12 +32,6 @@ const DRIVERS = [
         connection: { filename: ':memory:' },
         useNullAsDefault: true,
       }),
-  },
-  {
-    name: 'driver-memory',
-    // `persistence: false` → pure in-memory, so the probe object does not leak to
-    // a shared on-disk snapshot and collide with other suites in the full run.
-    make: () => new InMemoryDriver({ persistence: false }),
   },
 ];
 

--- a/packages/runtime/src/datasource-autoconnect.test.ts
+++ b/packages/runtime/src/datasource-autoconnect.test.ts
@@ -7,9 +7,18 @@
 //
 // This boots the host-config shape (instantiated plugins, no MetadataPlugin —
 // the same shape `examples/app-showcase` runs under `os dev`) with the REAL
-// driver factory (`createDefaultDatasourceDriverFactory`) building an in-memory
-// driver, so the full AppPlugin → `datasource-connection` → engine path runs
-// without any native driver dependency.
+// driver factory (`createDefaultDatasourceDriverFactory`) building a real
+// sqlite `:memory:` pool, so the full AppPlugin → `datasource-connection` →
+// engine path runs against the same engine production uses.
+//
+// Backend note (#5704 batch 0): both the host default driver and the declared
+// datasources ran on `@objectstack/driver-memory` until this file was migrated
+// to `@objectstack/driver-sql` + better-sqlite3 `:memory:` — the repo's
+// canonical ephemeral store (`examples/app-crm`, `cli db clean`). driver-memory
+// is the project's legacy test-convenience backend and its in-project test
+// surface is being retired (#5499). `:memory:` keeps every acceptance below
+// hermetic: the database lives and dies inside the process, so nothing reaches
+// the host filesystem and each boot starts empty.
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import { existsSync, rmSync } from 'node:fs';
@@ -20,6 +29,32 @@ import { AppPlugin } from './app-plugin.js';
 import type { DatasourceConnectPolicy } from '@objectstack/service-datasource';
 
 const BOOT_TIMEOUT = 60_000;
+
+/** The host's default driver — sqlite `:memory:`, constructed the canonical way. */
+async function makeDefaultDriver() {
+  const { SqlDriver } = await import('@objectstack/driver-sql');
+  return new SqlDriver({
+    client: 'better-sqlite3',
+    connection: { filename: ':memory:' },
+    useNullAsDefault: true,
+  });
+}
+
+/**
+ * `schemaMode: 'external'` forbids DDL through the driver (ADR-0015 — ObjectStack
+ * is a guest in that database), so the federated table has to already exist,
+ * exactly as the real remote database an external datasource points at would
+ * hold it. Raw `execute()` is the out-of-band channel that stands in for
+ * "somebody else's migration already ran".
+ *
+ * With driver-memory this step did not exist: a mingo store materialises a
+ * collection on first write, so an undeclared table was indistinguishable from a
+ * declared one. Making it explicit is the point of the migration, not a
+ * workaround for it.
+ */
+async function ensureRemoteExtNoteTable(driver: any): Promise<void> {
+  await driver.execute('CREATE TABLE IF NOT EXISTS ext_note (id text primary key, title text)');
+}
 
 // One external datasource (auto-connect target) + one managed, unrouted
 // datasource (must stay metadata-only). NO `onEnable` anywhere.
@@ -41,11 +76,11 @@ function artifact() {
     datasources: [
       {
         name: 'autoconn_ext',
-        label: 'External (in-memory)',
-        driver: 'memory',
+        label: 'External (sqlite :memory:)',
+        driver: 'sqlite',
         schemaMode: 'external',
         origin: 'code',
-        config: {},
+        config: { filename: ':memory:' },
         external: { allowWrites: false, validation: { onMismatch: 'warn', checkOnBoot: false } },
         active: true,
       },
@@ -54,10 +89,10 @@ function artifact() {
       {
         name: 'decorative',
         label: 'Decorative (unrouted)',
-        driver: 'memory',
+        driver: 'sqlite',
         schemaMode: 'managed',
         origin: 'code',
-        config: {},
+        config: { filename: ':memory:' },
         active: true,
       },
     ],
@@ -66,17 +101,13 @@ function artifact() {
 
 async function boot(opts: { connectPolicy?: DatasourceConnectPolicy } = {}) {
   const { ObjectQLPlugin } = await import('@objectstack/objectql');
-  const { InMemoryDriver } = await import('@objectstack/driver-memory');
   const { DatasourceAdminServicePlugin, createDefaultDatasourceDriverFactory } = await import(
     '@objectstack/service-datasource'
   );
 
   const runtime = new Runtime({ cluster: false });
   const kernel = runtime.getKernel();
-  // `persistence: false` keeps the acceptance hermetic. The driver's own default
-  // is `'auto'` — in Node a file adapter at `.objectstack/data/…` under the CWD,
-  // which both reloads and rewrites ambient state between runs (#4083).
-  await kernel.use(new DriverPlugin(new InMemoryDriver({ persistence: false }))); // default driver
+  await kernel.use(new DriverPlugin(await makeDefaultDriver())); // default driver
   await kernel.use(new ObjectQLPlugin());
   await kernel.use(new AppPlugin(artifact()));
   await kernel.use(
@@ -127,6 +158,7 @@ describe('ADR-0062 declared-datasource auto-connect', () => {
     // Seed the live external driver directly (bypassing the read-only write gate,
     // exactly as a real remote DB would already hold the rows).
     const driver = engine.getDriverByName('autoconn_ext');
+    await ensureRemoteExtNoteTable(driver);
     await driver.bulkCreate('ext_note', [
       { id: 'n1', title: 'first' },
       { id: 'n2', title: 'second' },
@@ -136,20 +168,36 @@ describe('ADR-0062 declared-datasource auto-connect', () => {
   });
 });
 
-// #4083 — the acceptance above passed on a clean checkout and failed on every
-// subsequent run, reading 2×N rows on the Nth: the auto-connected `memory`
-// datasource inherited `InMemoryDriver`'s then-default `persistence: 'auto'`
-// (#4065 has since made that default `false`), so it
-// flushed `ext_note` into `.objectstack/data/memory-driver.json` under the CWD
-// and the next boot's connect() loaded those rows back before this file seeded
-// its own. CI never caught it because CI always runs #1 on a fresh checkout.
+// ADR-0062 D1 acceptance — an auto-connected in-memory federated pool leaves
+// nothing behind and does not outlive its kernel.
 //
-// The intermittency ("passes once in four") came from WHEN the flush lands: the
-// file adapter writes on a 2s unref'd autosave timer, so a run short enough to
-// finish first left nothing behind. `flush()` below stands in for that timer, so
-// this pins the property that was actually broken — a federated in-memory pool
-// leaves nothing behind and does not outlive its kernel — without a timing race
-// and without depending on run-to-run state.
+// ## What this pinned before, and why it still says the same thing
+//
+// #4083: the acceptance above passed on a clean checkout and failed on every
+// subsequent run, reading 2×N rows on the Nth. The auto-connected `memory`
+// datasource inherited `InMemoryDriver`'s then-default `persistence: 'auto'`
+// (#4065 has since made that default `false`), so it flushed `ext_note` into
+// `.objectstack/data/memory-driver.json` under the CWD and the next boot's
+// connect() loaded those rows back before this file seeded its own. CI never
+// caught it because CI always runs #1 on a fresh checkout. The intermittency
+// ("passes once in four") came from WHEN the flush landed — the file adapter
+// wrote on a 2s unref'd autosave timer — so the original block called
+// `driver.flush?.()` to force the timer's work and remove the race.
+//
+// Those three things — `memory-driver.json`, `flush()`, the autosave timer —
+// are driver-memory FILE-ADAPTER specifics, and this file no longer runs on
+// driver-memory (#5704 batch 0). The acceptance target was never the file
+// adapter: ADR-0062 D1 asks for a runtime property — a federated in-memory pool
+// leaves nothing on the host and a restart starts empty — so the block is
+// rewritten against sqlite `:memory:` rather than deleted (deleting it would
+// drop D1's acceptance) and rather than moved into driver-memory's own suite
+// (the factory-level #4083 pin already lives in service-datasource's tests).
+//
+// Under `:memory:` the property is asserted more directly than before: a fresh
+// pool has no `ext_note` TABLE at all, not merely no rows — the one thing a
+// reloaded snapshot could never look like. The filesystem half is unchanged and
+// still load-bearing: `filename: ':memory:'` is one config typo away from a
+// relative file path, and that typo is exactly what #4083 was.
 describe('ADR-0062 D1 — the auto-connected in-memory pool leaves nothing behind (#4083)', () => {
   const STATE_DIR = join(process.cwd(), '.objectstack');
   const clearState = () => { try { rmSync(STATE_DIR, { recursive: true, force: true }); } catch { /* noop */ } };
@@ -159,25 +207,49 @@ describe('ADR-0062 D1 — the auto-connected in-memory pool leaves nothing behin
   beforeAll(clearState);
   afterAll(clearState);
 
+  function externalDriver(kernel: Awaited<ReturnType<typeof boot>>) {
+    const engine = kernel.getService<{ getDriverByName(n: string): any }>('data');
+    return engine.getDriverByName('autoconn_ext');
+  }
+
+  /** Rows knex returns for a raw SELECT, whichever envelope the dialect uses. */
+  function rowsOf(result: any): any[] {
+    if (Array.isArray(result)) return result;
+    if (Array.isArray(result?.rows)) return result.rows;
+    return result == null ? [] : [result];
+  }
+
+  /**
+   * Does this pool's database already hold the federated table? A pool that
+   * reloaded a previous boot's state would; a genuinely fresh `:memory:` one
+   * cannot, because nothing in this composition is allowed to run DDL on an
+   * `external` datasource.
+   */
+  async function hasExtNoteTable(kernel: Awaited<ReturnType<typeof boot>>) {
+    const result = await externalDriver(kernel).execute(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'ext_note'",
+    );
+    return rowsOf(result).length > 0;
+  }
+
   async function seedAndRead(kernel: Awaited<ReturnType<typeof boot>>) {
     const engine = kernel.getService<{
       getDriverByName(n: string): any;
       find(object: string, query?: any): Promise<any[]>;
     }>('data');
     const driver = engine.getDriverByName('autoconn_ext');
+    await ensureRemoteExtNoteTable(driver);
     await driver.bulkCreate('ext_note', [
       { id: 'n1', title: 'first' },
       { id: 'n2', title: 'second' },
     ]);
-    const titles = (await engine.find('ext_note')).map((r) => r.title).sort();
-    // Whatever the autosave timer would have written, written now.
-    await driver.flush?.();
-    return titles;
+    return (await engine.find('ext_note')).map((r) => r.title).sort();
   }
 
   it('writes no state file, and a second boot in the same process starts empty', async () => {
     const first = await boot();
     try {
+      expect(await hasExtNoteTable(first)).toBe(false);
       expect(await seedAndRead(first)).toEqual(['first', 'second']);
       // The seeded rows must not have reached the host filesystem at all.
       expect(existsSync(STATE_DIR)).toBe(false);
@@ -187,8 +259,11 @@ describe('ADR-0062 D1 — the auto-connected in-memory pool leaves nothing behin
 
     const second = await boot();
     try {
-      // Was ['first','first','second','second'] — the first boot's rows, reloaded.
+      // The whole point: not "no rows carried over" but "no database carried
+      // over". Was ['first','first','second','second'] under the #4083 defect.
+      expect(await hasExtNoteTable(second)).toBe(false);
       expect(await seedAndRead(second)).toEqual(['first', 'second']);
+      expect(existsSync(STATE_DIR)).toBe(false);
     } finally {
       try { await (second as any)?.stop?.(); } catch { /* noop */ }
     }
@@ -206,10 +281,10 @@ describe('ADR-0062 credentials fail-closed (D3)', () => {
       datasources: [
         {
           name: 'needs_secret',
-          driver: 'memory',
+          driver: 'sqlite',
           schemaMode: 'external',
           origin: 'code',
-          config: {},
+          config: { filename: ':memory:' },
           external: {
             allowWrites: false,
             credentialsRef: 'sys_secret:does-not-exist',
@@ -223,13 +298,12 @@ describe('ADR-0062 credentials fail-closed (D3)', () => {
 
   it('bricks boot with a clear message when a required credential cannot be resolved', async () => {
     const { ObjectQLPlugin } = await import('@objectstack/objectql');
-    const { InMemoryDriver } = await import('@objectstack/driver-memory');
     const { DatasourceAdminServicePlugin, createDefaultDatasourceDriverFactory } = await import(
       '@objectstack/service-datasource'
     );
     const runtime = new Runtime({ cluster: false });
     const kernel = runtime.getKernel();
-    await kernel.use(new DriverPlugin(new InMemoryDriver()));
+    await kernel.use(new DriverPlugin(await makeDefaultDriver()));
     await kernel.use(new ObjectQLPlugin());
     await kernel.use(new AppPlugin(credArtifact()));
     await kernel.use(
@@ -275,13 +349,12 @@ describe('ADR-0062 D5 — an explicitly-bound datasource that cannot connect bri
 
   async function bootBound() {
     const { ObjectQLPlugin } = await import('@objectstack/objectql');
-    const { InMemoryDriver } = await import('@objectstack/driver-memory');
     const { DatasourceAdminServicePlugin, createDefaultDatasourceDriverFactory } = await import(
       '@objectstack/service-datasource'
     );
     const runtime = new Runtime({ cluster: false });
     const kernel = runtime.getKernel();
-    await kernel.use(new DriverPlugin(new InMemoryDriver()));
+    await kernel.use(new DriverPlugin(await makeDefaultDriver()));
     await kernel.use(new ObjectQLPlugin());
     await kernel.use(new AppPlugin(boundArtifact()));
     await kernel.use(


### PR DESCRIPTION
Part of objectstack-ai/objectstack#5704 (Batch 0)

(不是 `Fixes` —— 该程序跨批次持续开放,收口在 41 文件清零之后。)

## 前提复核(先做的事)

Survey(#5704 的 Phase 1 交付评论,基线 `a58c0b5`)距派发约 1 小时,先在 `origin/main` (`eb26126`) 上逐条核对,**全部仍然成立**:

- `read-coercion-conformance.test.ts` 的 `DRIVERS` 数组确实已经有一条绿的 SqlDriver `:memory:` 臂,driver-memory 是第二条。
- `datasource-autoconnect.test.ts` 确实有 3 处真 `import('@objectstack/driver-memory')` + `new InMemoryDriver(...)`(`boot()`、credentials 用例、`bootBound()`)。
- `ADR-0062 D1 …(#4083)` describe 块原样存在。
- 依赖面也确认无需改动:`@objectstack/runtime` 与 `@objectstack/dogfood` 都已声明 `@objectstack/driver-sql`,better-sqlite3 由 driver-sql 的 optionalDependency 提供。**零 package.json 改动。**

## 改了什么

### 1. `packages/qa/dogfood/test/read-coercion-conformance.test.ts`

删掉 driver-memory 条目与 import,SQL 臂原样保留。文件抬头的覆盖声明同步改写 —— 原文写的是「against the framework's own SQL + memory drivers」,留着就不真了。

顺带把「为什么不亏」写进注释:SQLite 才是真把 boolean 存成整数的那个驱动,读回强制转换这条不变式本来就由它承载;一个从来不需要转换的 mingo store 只可能恒绿。

### 2. `packages/runtime/src/datasource-autoconnect.test.ts`

**主体**:3 处默认驱动统一走新的 `makeDefaultDriver()`,构造仓库的规范形态(与 `examples/app-crm`、`cli db clean` 同款):

```ts
new SqlDriver({ client: 'better-sqlite3', connection: { filename: ':memory:' }, useNullAsDefault: true })
```

声明面的 datasource 也从 `driver: 'memory'` 改为 `driver: 'sqlite'` + `config: { filename: ':memory:' }` —— 否则联邦池仍然是 driver-memory,D1 块的改写就落空了。

**schema 按真实 DDL 路径处理,而不是放松断言**:`schemaMode: 'external'` 在驱动层禁止 DDL(ADR-0015,ObjectStack 是那个库的客人),所以 `ext_note` 物理表改为通过 raw `execute()` 建出来,正对应「真实远端库里这张表本来就在」。driver-memory 下不存在这一步 —— mingo store 首次写入即物化集合,未声明的表和已声明的表长得一模一样。把它显式化正是这次迁移买到的保真度,不是绕过。

### 3. `ADR-0062 D1 …(#4083)` 块 —— 按 PM 裁定 Q3-B 改写

未删除(删了就丢掉 D1 验收),未搬进 driver-memory 自己的 suite(工厂层 #4083 钉点已由 service-datasource 测试独立覆盖,搬过去是覆盖重复)。

`memory-driver.json` / `driver.flush?.()` / 2 秒 autosave 定时器这三样是 driver-memory 文件适配器的实现细节;D1 要的是运行时属性「联邦内存池不落盘、重启为空」。改写后:

- `:memory:` 后端不在宿主留下任何文件(`.objectstack/**` 不存在) —— 两次 boot 各断言一次(原来只断言了第一次);
- 新一轮 boot 的池里**连 `ext_note` 表都不存在**,而不只是没有行。这比原断言更直接:一个「重新加载了上一轮快照」的池不可能长这样。

## 反向验证 —— 方向与派发单预判一致(应当保持绿,红则说明配置误指文件)

改后该块**保持绿**。为了证明新断言不是空转,主动制造派发单点名的那个错误 —— 把 `autoconn_ext` 的 `filename` 从 `':memory:'` 改成 `.objectstack/data/ext-note.sqlite`(即 #4083 的形状在 SQL 后端上的复刻):

1. 只改 filename → 在 `expect(existsSync(STATE_DIR)).toBe(false)` 处红(`expected true to be false`);
2. 再临时注掉两处 `existsSync` 断言,让执行走到第二次 boot → 在 `expect(await hasExtNoteTable(second)).toBe(false)` 处红。

两条新断言各自独立见红,随后完整还原、复跑 11/11 绿。

## 验证(真实输出)

```
# packages/runtime
 Test Files  98 passed (98)
      Tests  1436 passed (1436)

# packages/qa/dogfood
 Test Files  85 passed | 1 skipped (86)
      Tests  513 passed | 3 skipped (516)

# 迁移文件本身
 Test Files  1 passed (1)
      Tests  11 passed (11)      # 与迁移前基线同数

# typecheck(两包)
packages/runtime typecheck: Done
packages/qa/dogfood typecheck: Done

# eslint(两个改动文件)exit 0,无输出

check-nul-bytes: OK (scanned 5614 tracked text file(s); ... no raw ASCII control bytes).
✓ query-options-erasure ratchet holds: 84 unswept non-test site(s) ... none new.
  test surface: 267 site(s) in 51 file(s) — at the ceiling      # 天花板未升
check-driver-conformance: OK — 25 covered cell(s), 0 in the DEBT ledger, 0 exempt.
check-engine-double-contract: OK — 27 pinned, 65 in the DEBT ledger, 1 exempt.
```

Changeset:测试行为改动,不面向用户,按派发约定用 `skip-changeset`。**该 label 我无权添加,请 PM 代打。**

## 留给后续批次的两件事(本 PR 不做)

1. `packages/qa/dogfood` 的 `@objectstack/driver-memory` devDependency 现已无人使用(全包内仅剩本文件的散文提及)。清理属于 #5704 收口阶段的依赖声明面,不在本批次的两文件范围内,故未动 —— 也正是 survey 说的「grep driver-memory 系统性高估」那个度量陷阱的一个实例。
2. `packages/runtime` 的 driver-memory 依赖**必须保留**:`sandbox/undeclared-field-write-driver-split.integration.test.ts`(Q2 待裁)与 `standalone-stack.test.ts`(已判域外)仍在真用。

## 范围外发现

已另开 objectstack-ai/objectstack#5714(未指派、未打标,交 PM 分诊):datasource 的 `pool` 声明在 sqlite / sqlite-wasm 驱动臂被静默丢弃(pg / mysql 生效),`examples/app-crm` 的 `CrmDatasource` 是现网标本。核对连接池行为时发现,已用工厂真实构造实测确认;修法涉及公开契约形状(`:memory:` 下照着接反而会引入静默数据丢失),故只报事实不带方案。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyvqvKMG6asi9aXjKE6xtx)_