### PR TITLE
feat(objectql): 悬空引用巡检纳入 readonly 溯源族,单独分桶为 `provenance` (#4743 事实二)

### DIFF
--- a/.changeset/dangling-audit-provenance-bucket.md
+++ b/.changeset/dangling-audit-provenance-bucket.md
@@ -1,0 +1,61 @@
+---
+"@objectstack/objectql": minor
+---
+
+feat(objectql): the dangling-reference audit stops skipping `readonly`
+references and files them in their own `provenance` bucket (#4743)
+
+`auditDanglingReferences` used to drop every `readonly` reference field before
+reading a single row. That skip rested on two grounds, and #4556 removed one of
+them: the platform no longer writes a NON-ID into a reference column
+(`sys_metadata_history.recorded_by` stored the sentinel string `'system'`; it
+stores `NULL` now). What the skip still covered afterwards was exactly one
+family — the audit-provenance fields `created_by` / `updated_by` /
+`organization_id` that `applySystemFields` injects, all `readonly: true`.
+
+Those hold **genuine ids, and genuine ids dangle**: delete one user and every
+row they ever created points `created_by` at a row that is gone. "Who did this"
+failing to resolve is precisely the question an audit trail exists to answer,
+so the remaining skip was blindness rather than economy. The audit now probes
+them.
+
+**They do not join `dangling`.** A deleted actor and a broken business foreign
+key are different findings with different remedies (usually nothing to do vs.
+re-seed the target or clear the link), and merging them would bury the second
+under the first. Two new report keys carry the new class, mirroring the
+unknown/absent split the report already makes everywhere else:
+
+| Key | Means |
+|:--|:--|
+| `provenance: DanglingReference[]` | a `readonly` provenance reference that resolves to nothing — same row shape as `dangling` |
+| `provenanceUndetermined: number` | a provenance reference whose target could not be probed at all |
+
+Both are **additive and optional in the type**, exactly like `aborted`: an
+existing consumer keeps compiling and keeps reading `dangling` with its meaning
+unchanged (a link the model *declares* is broken). Every report this module
+produces sets both explicitly.
+
+⚠️ **Expect `provenance` to be large on the first run against an aged
+database.** One deleted user dangles every row they ever touched. That number
+is pre-existing state being reported for the first time — not damage the audit
+caught being done, and not a regression introduced by looking at it.
+
+For the same reason `provenance` **alone does not raise the summary warning**.
+On a database of any age it is non-empty on every healthy run, and a line that
+always fires is the #4747 broken alarm again — it would train its reader
+straight past the run where `dangling` had something in it. The counts ride
+along in the payload whenever the line fires for a real finding, and the
+itemised rows are always in the returned report. `provenanceUndetermined` is
+separate from `undetermined` for the same reason: on a stack that never
+registers `sys_user`, every provenance value probes "cannot tell", and that is
+a fact about which platform tables are mounted, not about the audited data.
+
+Scan order gained a third tier to keep the change from costing the signal it
+sits next to: security surface, then objects carrying a business reference,
+then the provenance-only remainder. Admitting the family means nearly every
+object now has an auditable field, so without the tier a bounded run would
+spend its row budget on tables carrying only provenance and never reach the
+business findings the budget was built for.
+
+Part of #4743 (fact 2). The stale `assertReferencesResolve` comment in
+`engine.ts` (fact 1) is deliberately untouched here.

--- a/packages/objectql/src/engine-dangling-reference-audit.test.ts
+++ b/packages/objectql/src/engine-dangling-reference-audit.test.ts
@@ -50,7 +50,10 @@ const history = {
     id: { name: 'id', label: 'ID', type: 'text' as const, primaryKey: true },
     note: { name: 'note', label: 'Note', type: 'text' as const },
     // `sys_metadata_history.recorded_by` in miniature: a readonly lookup the
-    // platform fills with the sentinel string `actor ?? 'system'`.
+    // platform USED to fill with the sentinel string `actor ?? 'system'` (NULL
+    // since #4556). The stored `'system'` below is therefore a legacy row —
+    // still the honest specimen for what a readonly reference that resolves to
+    // nothing looks like (#4743).
     recorded_by: {
       name: 'recorded_by', label: 'Recorded By',
       type: 'lookup' as const, reference: 'aud_permission_set', readonly: true,
@@ -207,16 +210,31 @@ describe('[#4551] the engine reports the dangling rows its own `isSystem` exempt
     expect(snapshot()).toBe(before);
   });
 
-  it('a readonly lookup holding a SENTINEL string is not reported', async () => {
-    // `recorded_by: 'system'` is not a user id and never was. #4441 skips it on
-    // the write path; the audit must not undo that by reporting the same value
-    // from the other side.
+  it('[#4743] a readonly lookup that resolves to nothing lands in `provenance`, not `dangling`', async () => {
+    // This case used to assert "not reported at all", on the grounds that the
+    // platform wrote the SENTINEL STRING `actor ?? 'system'` here. #4556 made
+    // that write NULL, so the only readonly references left are real ids — and
+    // a real id that names no row is a finding. It is filed apart from
+    // `dangling` because it answers a different question: not "a declared link
+    // is broken" but "the actor this row records is gone".
+    //
+    // Note what the retired assertion would have done: `dangling: []` still
+    // passes, because the finding MOVED rather than vanished. Asserting where
+    // it moved to is the only version of this test that can go red.
     await engine.insert(
       'aud_history', { id: 'h1', note: 'n', recorded_by: 'system' }, { context: { isSystem: true } } as any,
     );
     const out = await engine.inspectDanglingReferences({ objects: ['aud_history'] });
+
     expect(out.dangling).toEqual([]);
     expect(out.undetermined).toBe(0);
+    expect(out.provenance).toEqual([{
+      objectName: 'aud_history',
+      recordId: 'h1',
+      field: 'recorded_by',
+      target: 'aud_permission_set',
+      value: 'system',
+    }]);
   });
 
   it('an unregistered TARGET is `undetermined`, not a finding', async () => {

--- a/packages/objectql/src/integrity/dangling-reference-audit.test.ts
+++ b/packages/objectql/src/integrity/dangling-reference-audit.test.ts
@@ -16,8 +16,10 @@
  *  - condemn on a failed probe → "an unprobeable target is undetermined" fails
  *  - report on an existing row → "does NOT report a reference that resolves" fails
  *  - add any write            → "NEVER rewrites" fails (data JSON compared)
- *  - drop the readonly skip   → "a readonly reference is not audited" fails
  *  - drop the empty-value skip → "empty is not a reference" fails
+ *  - restore the readonly SKIP → every [#4743] test below fails: the provenance
+ *    bucket goes empty and the probe is never issued
+ *  - merge provenance into `dangling` → the [#4743] separation tests fail
  */
 
 import { describe, it, expect } from 'vitest';
@@ -48,10 +50,23 @@ const task: AuditableObject = {
     project: { type: 'lookup', reference: 'showcase_project' },
     tags: { type: 'lookup', reference: 'showcase_tag', multiple: true },
     // Audit-provenance shape: readonly, platform-minted (`applySystemFields`
-    // stamps `created_by` exactly like this). #4441 skips it on the write path
-    // because the value there is never the caller's; the audit skips it for the
-    // same reason — `sys_metadata_history.recorded_by` legitimately holds the
-    // SENTINEL STRING 'system'.
+    // stamps `created_by` exactly like this). #4441 still skips it on the WRITE
+    // path — the value there is never the caller's. The audit no longer skips
+    // it (#4743): it holds a genuine user id, and a deleted user dangles it.
+    created_by: { type: 'lookup', reference: 'sys_user', readonly: true },
+  },
+};
+
+/**
+ * [#4743] A table whose ONLY reference field is the injected provenance family
+ * — what `applySystemFields` leaves on an object that declares no lookup of its
+ * own. Before #4743 the audit read zero rows of a table shaped like this.
+ */
+const note: AuditableObject = {
+  name: 'showcase_note',
+  fields: {
+    id: { type: 'text', primaryKey: true },
+    body: { type: 'text' },
     created_by: { type: 'lookup', reference: 'sys_user', readonly: true },
   },
 };
@@ -218,21 +233,12 @@ describe('[#4551] dangling stored references are reported, never rewritten', () 
     expect(JSON.stringify(rows)).toBe(before);        // …and changed none of them
   });
 
-  it('a READONLY reference field is not audited — its value was minted by the platform', async () => {
-    // Same judgment #4441 makes on the write path, and for the same reason:
-    // `stripReadonlyFields` removes a caller's value first, so what remains is
-    // the platform's. `sys_metadata_history.recorded_by` is the real case — a
-    // `lookup('sys_user')` filled with the SENTINEL STRING `actor ?? 'system'`.
-    const port = makePort({
-      objects: [task],
-      rows: { showcase_task: [{ id: 't1', title: 'T', created_by: 'system' }] },
-    });
-
-    const out = await auditDanglingReferences(port);
-    expect(out.dangling).toEqual([]);
-    // Not merely unreported — never even probed.
-    expect(port.probes).not.toContain('sys_user system');
-  });
+  // The former "a READONLY reference field is not audited" case lived here. It
+  // was retired by #4743 rather than re-spelled: its `dangling: []` assertion
+  // still PASSES under the new behaviour — the finding simply moved one bucket
+  // over — so keeping it would have been a test that is green because nothing
+  // is produced rather than because the logic is right. Its replacements, which
+  // assert where the value actually goes, are in the [#4743] block below.
 
   it('empty values are not references — null / "" / [] are skipped', async () => {
     // `deleteBehavior: 'set_null'` writes exactly these. Matching #4441's
@@ -529,5 +535,206 @@ describe('[#4747] a run that was called off is not a finding about the data', ()
 
     const noSignal = await auditDanglingReferences(port);
     expect(noSignal.aborted).toBe(false);
+  });
+});
+
+/**
+ * [#4743] "The user who created this is gone" is a finding, and it is not the
+ * same finding as a broken business foreign key.
+ *
+ * The `readonly` family used to be skipped whole. Two grounds; #4556 deleted
+ * one of them (the platform stopped writing the `recorded_by` SENTINEL STRING
+ * into a lookup column), and what the skip covered afterwards was only the
+ * audit-provenance family — genuine user/organization ids that genuinely
+ * dangle the moment their target row is deleted.
+ *
+ * Reverse verification, direction predicted BEFORE running it: restoring the
+ * wholesale skip turns every test in this block RED — `provenance` goes empty
+ * and the probe is never issued. Note the direction the *retired* test would
+ * have gone instead: its `dangling: []` assertion stays GREEN under the new
+ * behaviour, because the finding moved rather than vanished. That is exactly
+ * the "green because nothing is produced" trap, which is why it was replaced
+ * rather than re-spelled.
+ */
+describe('[#4743] provenance references are audited, in their OWN bucket', () => {
+  it('a dangling `created_by` is reported — in `provenance`, not in `dangling`', async () => {
+    // Delete a user and every row they created points at a row that is gone.
+    // "Who made this" failing to resolve is what an audit trail exists for.
+    const port = makePort({
+      objects: [task],
+      rows: {
+        showcase_task: [
+          { id: 't1', title: 'T', project: 'proj_real', created_by: 'usr_deleted' },
+        ],
+      },
+      existing: new Set(['showcase_project proj_real']),
+    });
+
+    const out = await auditDanglingReferences(port);
+
+    // The business link is fine, so `dangling` must stay empty — and it must be
+    // empty for the RIGHT reason, which the bucket below is what proves.
+    expect(out.dangling).toEqual([]);
+    expect(out.provenance).toEqual([{
+      objectName: 'showcase_task',
+      recordId: 't1',
+      field: 'created_by',
+      target: 'sys_user',
+      value: 'usr_deleted',
+    }]);
+    // …and it really was probed, which the old wholesale skip never did.
+    expect(port.probes).toContain('sys_user usr_deleted');
+  });
+
+  it('a resolvable `created_by` is not reported at all', async () => {
+    const port = makePort({
+      objects: [task],
+      rows: { showcase_task: [{ id: 't1', title: 'T', created_by: 'usr_alive' }] },
+      existing: new Set(['sys_user usr_alive']),
+    });
+
+    const out = await auditDanglingReferences(port);
+    expect(out.provenance).toEqual([]);
+    expect(out.dangling).toEqual([]);
+    // Silent because it RESOLVED, not because nobody looked — without this the
+    // case would pass just as well under the old wholesale skip.
+    expect(port.probes).toContain('sys_user usr_alive');
+  });
+
+  it('the two buckets never merge — a broken FK and a deleted user are filed apart', async () => {
+    // The whole point of B over C: one report, two questions, two remedies
+    // (re-seed the project vs. nothing to do about a user who left).
+    const port = makePort({
+      objects: [task],
+      rows: {
+        showcase_task: [
+          { id: 't1', title: 'T', project: 'proj_gone', created_by: 'usr_deleted' },
+        ],
+      },
+    });
+
+    const out = await auditDanglingReferences(port);
+
+    expect(out.dangling.map((d) => d.field)).toEqual(['project']);
+    expect(out.provenance!.map((d) => d.field)).toEqual(['created_by']);
+  });
+
+  it('an unprobeable provenance target counts in `provenanceUndetermined`, never in `undetermined`', async () => {
+    // `sys_user` unregistered is a fact about which platform tables are
+    // mounted, not about the audited data — and `undetermined` raises the
+    // summary warning, so folding it in there would ring an alarm about the
+    // wrong thing on every run of a stack that never mounts `sys_user`.
+    const port = makePort({
+      objects: [task],
+      rows: {
+        showcase_task: [
+          { id: 't1', title: 'T', project: 'proj_real', created_by: 'usr_x' },
+        ],
+      },
+      unprobeable: new Set(['sys_user']),
+      existing: new Set(['showcase_project proj_real']),
+    });
+
+    const out = await auditDanglingReferences(port);
+
+    expect(out.provenanceUndetermined).toBe(1);
+    expect(out.undetermined).toBe(0);
+    expect(out.provenance).toEqual([]);   // unknown is not a verdict, here either
+  });
+
+  it('a table whose ONLY reference is provenance is now read — it used to be skipped whole', async () => {
+    const reads: string[] = [];
+    const port = makePort({
+      objects: [note],
+      rows: { showcase_note: [{ id: 'n1', body: 'b', created_by: 'usr_deleted' }] },
+    });
+    const findSpy = port.find.bind(port);
+    port.find = async (o, opts) => { reads.push(o); return findSpy(o, opts); };
+
+    const out = await auditDanglingReferences(port);
+
+    expect(reads).toEqual(['showcase_note']);
+    expect(out.scanned).toBe(1);
+    expect(out.provenance).toHaveLength(1);
+  });
+
+  it('provenance-only tables are scanned LAST, so a finite budget still answers the business question', async () => {
+    // Admitting the family means nearly every object has an auditable field,
+    // so without this the budget would be spent on tables carrying only
+    // provenance and the business findings would be what a bounded run never
+    // reached. Same argument as the security surface, one tier down.
+    const reads: string[] = [];
+    const port = makePort({
+      // Registration order is deliberately the WORST case: provenance-only
+      // first, security surface last.
+      objects: [note, task, binding],
+      rows: {
+        showcase_note: [{ id: 'n1', body: 'b', created_by: 'usr_deleted' }],
+        showcase_task: [{ id: 't1', title: 'T', project: 'proj_gone' }],
+        sys_position_permission_set: [{ id: 'ppr_1', permission_set_id: 'ps_gone' }],
+      },
+    });
+    const findSpy = port.find.bind(port);
+    port.find = async (o, opts) => { reads.push(o); return findSpy(o, opts); };
+
+    await auditDanglingReferences(port);
+
+    expect(reads).toEqual(['sys_position_permission_set', 'showcase_task', 'showcase_note']);
+  });
+
+  it('provenance ALONE does not raise the summary warning', async () => {
+    // On a database of any age this bucket is non-empty on every healthy run.
+    // A line that always fires is #4747's broken alarm, and it would train its
+    // reader straight past the run where `dangling` had something in it.
+    const port = makePort({
+      objects: [note],
+      rows: { showcase_note: [{ id: 'n1', body: 'b', created_by: 'usr_deleted' }] },
+    });
+
+    const out = await auditDanglingReferences(port);
+
+    expect(out.provenance).toHaveLength(1);   // found, and reported in the report
+    expect(port.warnings).toEqual([]);        // …just not shouted about
+  });
+
+  it('…but rides along in the payload once the line fires for a real finding', async () => {
+    const port = makePort({
+      objects: [task],
+      rows: {
+        showcase_task: [
+          { id: 't1', title: 'T', project: 'proj_gone', created_by: 'usr_deleted' },
+        ],
+      },
+      unprobeable: new Set(['sys_user']),
+    });
+
+    const out = await auditDanglingReferences(port);
+
+    const summary = port.warnings.find((w) => w[0].includes('#4551'));
+    expect(summary).toBeDefined();
+    const meta = summary![1] as Record<string, unknown>;
+    expect(meta.dangling).toBe(1);
+    expect(meta.provenanceUndetermined).toBe(1);
+    // Counted, never itemised: on an aged database this outnumbers every other
+    // finding, and the rows themselves are in the returned report.
+    expect(meta.provenance).toBe(0);
+    expect(meta.references).toEqual([
+      'showcase_task#t1.project → showcase_project#proj_gone',
+    ]);
+    expect(out.provenanceUndetermined).toBe(1);
+  });
+
+  it('a run with nothing to say still states both provenance buckets explicitly', async () => {
+    // Same reason `aborted: false` is explicit: a consumer must never have to
+    // guess whether `undefined` meant "clean" or "old report shape".
+    const port = makePort({
+      objects: [binding],
+      rows: { sys_position_permission_set: [{ id: 'ppr_1', permission_set_id: 'ps_real' }] },
+      existing: new Set(['sys_permission_set ps_real']),
+    });
+
+    const out = await auditDanglingReferences(port);
+    expect(out.provenance).toEqual([]);
+    expect(out.provenanceUndetermined).toBe(0);
   });
 });

--- a/packages/objectql/src/integrity/dangling-reference-audit.ts
+++ b/packages/objectql/src/integrity/dangling-reference-audit.ts
@@ -16,12 +16,15 @@ import { PLATFORM_OBJECTS_BY_PACKAGE } from '@objectstack/spec/system';
  * kind: **the platform itself can still write a reference into the void, and
  * nothing says so.**
  *
- * Removing the exemption is not the fix. Beyond the boot-ordering problem, the
- * platform has legitimate non-id writes of its own — `sys_metadata_history.
- * recorded_by` is a `lookup('sys_user')` the metadata repository fills with the
- * SENTINEL STRING `actor ?? 'system'` (that one is already out of scope via
- * #4441's `readonly` narrowing). Rejecting the platform's own write is not the
- * right way to report the problem. Making it VISIBLE is.
+ * Removing the exemption is not the fix. Rejecting the platform's own write is
+ * not the right way to report the problem. Making it VISIBLE is.
+ *
+ * (Historical note, because it is load-bearing for the scope section below: the
+ * platform used to have a legitimate NON-ID write of its own —
+ * `sys_metadata_history.recorded_by`, a `lookup('sys_user')` the metadata
+ * repository filled with the SENTINEL STRING `actor ?? 'system'`. #4556
+ * replaced that sentinel with NULL. Nothing writes a non-id into a reference
+ * column any more, which is what #4743 re-scoped the `readonly` skip on.)
  *
  * ## Reports; never rewrites
  *
@@ -70,14 +73,55 @@ import { PLATFORM_OBJECTS_BY_PACKAGE } from '@objectstack/spec/system';
  * datasource. `aborted` keeps the incompleteness loud (the report can never be
  * read as a clean bill of health) without spending the finding bucket on it.
  *
+ * ## …and PROVENANCE is a fourth answer (#4743)
+ *
+ * `readonly` reference fields used to be skipped outright, on two grounds. The
+ * first is #4441's and still holds: a non-system caller's value is stripped
+ * before the write (`stripReadonlyFields` / `stripReadonlyForInsert`), so what
+ * survives was minted by the platform and was never the caller's to answer for.
+ * The second was the `recorded_by` sentinel above — the platform wrote a
+ * NON-ID into a reference column, and probing it could only ever produce a
+ * finding about a value that was never an id. **#4556 deleted that ground**,
+ * and with it the only argument the skip ever had beyond "not the caller's
+ * fault".
+ *
+ * What the skip covered after that was exactly one family: the audit-provenance
+ * fields (`created_by` / `updated_by` / `organization_id`, all `readonly: true`
+ * from `applySystemFields`). Those hold GENUINE ids, and genuine ids dangle —
+ * delete one user and every row they ever created points `created_by` at a row
+ * that is gone. "Who did this" failing to resolve is precisely what an audit
+ * trail exists to answer, so skipping it is blindness rather than economy.
+ *
+ * They are still not the SAME finding as a broken business foreign key, so they
+ * do not share its bucket. `dangling` keeps meaning "a link the model declares
+ * is broken"; {@link DanglingReferenceReport.provenance} means "the actor this
+ * row records no longer exists". Same discipline, same reason, as the
+ * unknown/absent split above — mixing them would drown the business findings in
+ * the provenance ones, which is the failure mode this whole file is written
+ * against.
+ *
+ * ⚠️ **Expect `provenance` to be BIG the first time you look at it**, on any
+ * database that has ever deleted a user or an organization: one deleted user
+ * dangles every row they ever touched. That number is PRE-EXISTING STATE being
+ * reported for the first time — not damage this audit caught being done, and
+ * not a regression introduced by looking. It is also why `provenance` alone
+ * does NOT raise the summary warning: an alarm that fires on every run of an
+ * ordinarily-aged database is #4747's broken alarm all over again, and it would
+ * cost the buckets next to it the attention they were built for. The count
+ * rides along whenever the line fires for a real finding, and the itemised rows
+ * are always in the returned report for a caller that asked the question.
+ *
+ * The unknown/absent split applies INSIDE the new bucket too, and it bites at
+ * once: `undetermined` counts probes that could not run, and on a stack where
+ * `sys_user` is not registered every provenance value probes `null`. Folding
+ * those into `undetermined` would inflate a bucket that DOES raise the warning,
+ * with a fact about which platform tables are mounted rather than about the
+ * data being audited. Hence
+ * {@link DanglingReferenceReport.provenanceUndetermined}, on its own side of
+ * the same line.
+ *
  * ## Scope — the same judgments #4441 already made, not new ones
  *
- * - **`readonly` reference fields are skipped**, exactly as the write-path
- *   check skips them: a non-system caller's value is stripped before the write
- *   (`stripReadonlyFields` / `stripReadonlyForInsert`), so what remains was
- *   minted by the platform — including the audit-provenance family
- *   (`created_by` / `updated_by` / `organization_id`, all `readonly: true` from
- *   `applySystemFields`) and the `recorded_by` sentinel above.
  * - **Which fields are references** is `referenceTargetOf` — the single
  *   arbiter the write-path check and the expand gate already share, covering
  *   `lookup` / `master_detail` / `user` / `tree`. A hand-written type list here
@@ -134,6 +178,38 @@ export interface DanglingReferenceReport {
    * it explicitly.
    */
   aborted?: boolean;
+  /**
+   * [#4743] Audit-provenance references that resolve to nothing: `created_by` /
+   * `updated_by` / `organization_id` — the `readonly` family `applySystemFields`
+   * injects — naming a user or organization that no longer exists.
+   *
+   * Its own bucket rather than an entry in `dangling`, because it answers a
+   * different question with a different remedy: `dangling` says a link the
+   * model DECLARES is broken (re-seed the target, or clear the link);
+   * `provenance` says the actor a row records has since been deleted, which is
+   * usually nothing to fix and everything to know.
+   *
+   * **Read a large number here as history, not as damage.** Every row a deleted
+   * user ever created lands in it, and this is the first release that reports
+   * them at all (before #4743 the whole family was skipped) — so the first run
+   * on an aged database measures accumulated state, not a new defect.
+   *
+   * Same optionality as {@link DanglingReferenceReport.aborted}, for the same
+   * reason: hand-written reports (test doubles) predate the key. Every report
+   * this module produces sets it.
+   */
+  provenance?: DanglingReference[];
+  /**
+   * [#4743] Provenance reference values whose target could NOT be probed — the
+   * `undetermined` axis, kept on the provenance side of the line.
+   *
+   * Separate from {@link DanglingReferenceReport.undetermined} because that
+   * count raises the summary warning and this one must not: on a stack that
+   * never registers `sys_user`, EVERY provenance value probes `null`, and a
+   * fact about which platform tables are mounted would otherwise arrive
+   * disguised as a fact about the audited data.
+   */
+  provenanceUndetermined?: number;
 }
 
 /** Minimal object shape the audit reads — duck-typed so tests need no registry. */
@@ -218,33 +294,75 @@ function isEmptyStoredReference(v: unknown): boolean {
   return v === null || v === undefined || v === '';
 }
 
+/** One reference field worth reading an object for, and which bucket it feeds. */
+interface AuditableField {
+  name: string;
+  target: string;
+  /**
+   * [#4743] `true` for a `readonly` reference — the audit-provenance family.
+   * Findings on it are still findings; they just answer a different question,
+   * so they land in {@link DanglingReferenceReport.provenance}.
+   */
+  provenance: boolean;
+}
+
 /**
- * Reference fields worth auditing on one object: declared target, not
- * `readonly`. Returns `[]` for an object with none, which is how the audit
- * avoids reading a single row of the vast majority of tables.
+ * Reference fields worth auditing on one object: everything with a declared
+ * target, each tagged with the bucket its findings belong in. Returns `[]` for
+ * an object with none, which is how the audit avoids reading a single row of
+ * the tables that have nothing referential on them at all.
+ *
+ * `readonly` is no longer a reason to drop a field (#4743) — it is the reason
+ * to file its findings separately. See the provenance section in the module
+ * header for why the skip's second ground stopped existing at #4556.
  */
-function auditableReferenceFields(obj: AuditableObject): Array<{ name: string; target: string }> {
+function auditableReferenceFields(obj: AuditableObject): AuditableField[] {
   const fields = obj?.fields;
   if (!fields || typeof fields !== 'object') return [];
-  const out: Array<{ name: string; target: string }> = [];
+  const out: AuditableField[] = [];
   for (const [name, def] of Object.entries(fields)) {
-    if ((def as { readonly?: unknown })?.readonly === true) continue;
     const target = referenceTargetOf(def);
     if (!target) continue;
-    out.push({ name, target });
+    out.push({ name, target, provenance: (def as { readonly?: unknown })?.readonly === true });
   }
   return out;
 }
 
+/** An object paired with the reference fields the audit will read it for. */
+interface AuditTarget {
+  obj: AuditableObject;
+  refFields: AuditableField[];
+}
+
 /**
- * Security-surface objects first, everything else after, each group keeping
- * registration order so a run is deterministic.
+ * Scan order for a finite budget: security surface, then objects carrying a
+ * business reference, then the provenance-only remainder. Each group keeps
+ * registration order so a run is deterministic, and objects with no reference
+ * field at all are dropped here — they are the ones the audit reads zero rows
+ * of.
+ *
+ * The third tier is #4743's doing and is the reason it is safe. Admitting the
+ * provenance family means nearly EVERY object now has an auditable field
+ * (`applySystemFields` injects `created_by` almost everywhere), so without an
+ * ordering rule a bounded scan would start spending its row budget on tables
+ * that carry only provenance — and the business findings that budget was built
+ * for would be the ones it ran out before reaching. Same argument as
+ * {@link SECURITY_SURFACE_OBJECTS}, one tier down: when the budget is finite,
+ * order is what decides which question actually gets answered.
  */
-function prioritise(objects: AuditableObject[]): AuditableObject[] {
-  const security: AuditableObject[] = [];
-  const rest: AuditableObject[] = [];
-  for (const o of objects) (SECURITY_SURFACE_OBJECTS.has(o?.name) ? security : rest).push(o);
-  return [...security, ...rest];
+function prioritise(objects: AuditableObject[]): AuditTarget[] {
+  const security: AuditTarget[] = [];
+  const business: AuditTarget[] = [];
+  const provenanceOnly: AuditTarget[] = [];
+  for (const obj of objects) {
+    const refFields = auditableReferenceFields(obj);
+    if (refFields.length === 0) continue;   // nothing referential here — read nothing
+    const tier = SECURITY_SURFACE_OBJECTS.has(obj?.name)
+      ? security
+      : refFields.some((f) => !f.provenance) ? business : provenanceOnly;
+    tier.push({ obj, refFields });
+  }
+  return [...security, ...business, ...provenanceOnly];
 }
 
 /**
@@ -257,8 +375,13 @@ export async function auditDanglingReferences(
   port: DanglingReferenceAuditPort,
   options?: DanglingReferenceAuditOptions,
 ): Promise<DanglingReferenceReport> {
-  const report: DanglingReferenceReport = {
+  // The optional keys are optional in the TYPE only (hand-written test doubles
+  // predate them); every report this function produces sets them, so the local
+  // view of it requires them and no call site below has to guard.
+  const report: DanglingReferenceReport &
+    Required<Pick<DanglingReferenceReport, 'provenance' | 'provenanceUndetermined'>> = {
     scanned: 0, dangling: [], undetermined: 0, unreadableObjects: [], truncatedObjects: [],
+    provenance: [], provenanceUndetermined: 0,
     aborted: false,
   };
 
@@ -317,15 +440,13 @@ export async function auditDanglingReferences(
     return answer;
   };
 
-  objects: for (const obj of prioritise(all)) {
+  objects: for (const { obj, refFields } of prioritise(all)) {
     if (report.scanned >= maxRows) break;
     // Called off before this object was read: it was never attempted, so it is
     // not a finding about the object — the run reports that it stopped instead.
     if (calledOff()) { report.aborted = true; break; }
     const name = obj?.name;
     if (!name || (only && !only.has(name))) continue;
-    const refFields = auditableReferenceFields(obj);
-    if (refFields.length === 0) continue;   // nothing referential here — read nothing
 
     const budget = Math.min(rowsPerObject, maxRows - report.scanned);
     let rows: Array<Record<string, unknown>>;
@@ -353,7 +474,7 @@ export async function auditDanglingReferences(
     if (rows.length >= budget) report.truncatedObjects.push(name);
 
     for (const row of rows) {
-      for (const { name: field, target } of refFields) {
+      for (const { name: field, target, provenance } of refFields) {
         const raw = row?.[field];
         if (isEmptyStoredReference(raw)) continue;
         const values = Array.isArray(raw) ? raw : [raw];
@@ -363,9 +484,16 @@ export async function auditDanglingReferences(
           if (typeof v === 'object') continue;
           const answer = await exists(target, v);
           if (answer === 'called-off') { report.aborted = true; break objects; }
-          if (answer === null) { report.undetermined++; continue; }
+          // [#4743] Both verdicts are routed by the field's class, not merged:
+          // a provenance answer never lands in a bucket a business reference
+          // shares, in EITHER direction (absent or unknown).
+          if (answer === null) {
+            if (provenance) report.provenanceUndetermined++;
+            else report.undetermined++;
+            continue;
+          }
           if (answer) continue;
-          report.dangling.push({
+          (provenance ? report.provenance : report.dangling).push({
             objectName: name,
             recordId: String(row?.id ?? ''),
             field,
@@ -377,6 +505,12 @@ export async function auditDanglingReferences(
     }
   }
 
+  // [#4743] The provenance buckets deliberately do NOT appear in this
+  // condition. On a database of any age they are non-empty on every healthy
+  // run, and a line that always fires is the #4747 broken alarm — it would
+  // train its reader past the one run where `dangling` had something in it.
+  // They ride along whenever the line fires for a real finding; the full
+  // report always carries them for a caller that came looking.
   if (report.dangling.length || report.undetermined || report.unreadableObjects.length) {
     port.warn?.('[integrity] stored references that resolve to nothing (#4551)', {
       scanned: report.scanned,
@@ -387,6 +521,11 @@ export async function auditDanglingReferences(
       // Carried into the log line too: findings from a run that stopped early
       // are real, but its silence about everything else is not a verdict.
       aborted: report.aborted,
+      // Counted here, never itemised: on a database that has deleted users this
+      // can outnumber every other finding by orders of magnitude, and the rows
+      // themselves are in the returned report.
+      provenance: report.provenance.length,
+      provenanceUndetermined: report.provenanceUndetermined,
       references: report.dangling.map(
         (d) => `${d.objectName}#${d.recordId}.${d.field} → ${d.target}#${d.value}`,
       ),


### PR DESCRIPTION
Part of #4743 —— **仅事实二**(巡检跳过收窄)。⛔ 事实一(`engine.ts` 里 `assertReferencesResolve` 的过期注释)未做,#5504 在飞同文件,所以这里写 `Part of` 而非 `Fixes`,issue 不随本 PR 关闭。

## 前提核验(动手前对 origin/main 逐条确认)

issue 是线索不是规格,三条前提都在 `origin/main`(39e43c8)上核过:

| 前提 | 结论 | 证据 |
|:--|:--|:--|
| 整体跳过仍在 | ✅ 成立 | `dangling-reference-audit.ts:231` `if ((def as { readonly?: unknown })?.readonly === true) continue;` |
| #4556 的 NULL 化已落 | ✅ 成立 | `packages/metadata/src/loaders/database-loader.ts:585` 是 `recorded_by: historyRecord.recordedBy`,`?? 'system'` 已不存在;`recordedBy` 一路 optional 传入,无上游兜底 |
| 被豁免的只剩溯源族 | ✅ 成立 | `registry.ts` `AUDIT_FIELD_DEFS`(`created_by`/`updated_by` 均 `lookup → sys_user, readonly: true`)+ `organization_id`(`lookup → sys_organization, readonly: true`);`owner_id` 是 `readonly: false`,本来就在巡检里 |

## 改了什么(按 PM 裁决取方向 B)

`readonly` 不再是「丢弃字段」的理由,而是「findings 归哪个桶」的理由。

新增两个报告键,形状与该文件既有分组一致:

| 键 | 含义 |
|:--|:--|
| `provenance: DanglingReference[]` | readonly 溯源引用解析不到行 —— 样本行形状与 `dangling` 完全一致 |
| `provenanceUndetermined: number` | 溯源引用的目标压根探测不了 |

两个键都是**追加的、类型上 optional**,与 `aborted` 同一处理、同一理由(手写的 report 测试替身仍然满足类型);本模块产出的每一份报告都显式赋值。`dangling` 的语义一字未动。

### 三个判断,每个都有它必须那样的理由

**1. 为什么另起一桶而不是同桶(C)**:「引用了一个被删掉的用户」和「模型声明的外键断了」补救方式不同(通常无事可做 vs. 补种目标行或清链接),混在一起会让后者被前者淹没 —— 这正是该文件「Unknown and absent are DIFFERENT answers」一节最在意的失效模式。

**2. 为什么 `provenance` 单独存在不触发 summary warn**:在任何有年头的库上它每次健康运行都非空。每次都响的告警就是 #4747 刚花代价拆掉的坏告警,会把读者训练到跳过这一行 —— 而下一次 `dangling` 真有东西时也一起被跳过了。所以:**计数随行**(warn 因真实 finding 触发时把两个计数一起带上),**明细常驻**(返回的报告永远带全量行,给主动来问的调用方)。

**3. 为什么 `provenanceUndetermined` 不并进 `undetermined`**:`undetermined` 是**会触发 warn** 的桶。在一个不注册 `sys_user` 的栈上,每一个溯源值都探测为「说不准」—— 那是关于「哪些平台表被挂载」的事实,不是关于被审计数据的事实,并进去等于每次运行都为错误的事情拉响警报。这一条不是假想:现存的 `engine-dangling-reference-audit.test.ts` 里 `expect(out.undetermined).toBe(0/1)` 两处断言,正是靠这个分离才保持原义为真。

### 一处必要的连带改动:扫描顺序加了第三档

纳入溯源族意味着**几乎每个对象都有可审计字段**(`applySystemFields` 到处注入 `created_by`),于是有限的行预算会开始花在只带溯源的表上,而预算本来是为业务发现建的。`prioritise` 因此从两档变三档:安全面 → 带业务引用的对象 → 仅溯源的剩余。理由与 `SECURITY_SURFACE_OBJECTS` 完全同构,只是低一档:预算有限时,顺序决定哪个问题真的被回答。

## 反向验证(方向在跑之前就已预测:**红**)

把整体跳过临时改回去(`if (readonly) continue;`),9 条新用例 **8 条转红**:

```
× a dangling `created_by` is reported — in `provenance`, not in `dangling`
× the two buckets never merge — a broken FK and a deleted user are filed apart
× an unprobeable provenance target counts in `provenanceUndetermined`, never in `undetermined`
× a table whose ONLY reference is provenance is now read — it used to be skipped whole
× provenance-only tables are scanned LAST, so a finite budget still answers the business question
× provenance ALONE does not raise the summary warning
× …but rides along in the payload once the line fires for a real finding
× [engine] a readonly lookup that resolves to nothing lands in `provenance`, not `dangling`
Tests  8 failed | 27 passed (35)
```

**如实报告剩下的 1 条**:`a run with nothing to say still states both provenance buckets explicitly` 两边都绿 —— 它钉的是「键必须显式出现」这一结构性事实(`aborted: false` 的同构用例),按定义不会随行为翻转。另有一条 `a resolvable created_by is not reported at all` 原本也两边绿,已加 `expect(port.probes).toContain('sys_user usr_alive')` 使其转红 —— 沉默必须是「查过且解析成功」,不能是「没人看」。

## fixture 处置:整条替换,而非改写

原 `a READONLY reference field is not audited` 用例**被整条退休**,不是重新拼写。原因写在代码注释里:它的 `expect(out.dangling).toEqual([])` 在新行为下**依然通过** —— finding 只是挪了一个桶,不是消失了。留着它就是一条「因为什么都没产出所以绿」的用例。替换它的是断言「值到底去了哪里」的版本,那才是唯一能转红的写法。同一处置也应用在 `engine-dangling-reference-audit.test.ts` 的哨兵用例上。

## 消费方核验(按巡检的消费半径扫,不按被改包扫)

逐个核过,新增键均安全:

| 消费方 | 读法 | 结论 |
|:--|:--|:--|
| `engine.ts` `inspectDanglingReferences` | 原样返回 | 追加键透明 ✅ 未改动 |
| `lifecycle/lifecycle-service.ts` | 整体赋给 `report.danglingReferences` | 追加键透明 ✅ 未改动 |
| `lifecycle/lifecycle-service.test.ts` | 手写 report 字面量作测试替身 | **正是新键必须 optional 的原因** —— 必填会让这些字面量类型报错;55 tests 全绿 ✅ 未改动 |
| `packages/cli` `schema-migrate.teardown.integration.test.ts` | 结构性子集 `{ unreadableObjects, aborted? }` | 追加键透明,1 test 绿 ✅ 未改动 |
| `index.ts` 类型导出 | 复用既有 `DanglingReference` 作样本行类型 | **无需新增导出** ✅ 未改动 |
| `packages/cli` `migrate/value-shapes.ts` | 名字撞车但读的是 `scan-value-shapes` 的另一份报告 | 无关 ✅ |

无 snapshot 钉住该报告形状(已全仓查过)。

## 顺带发现(未在本 PR 修)

- **filed as #5718**:行预算 `>= maxRows` 耗尽后 `break`,**其后所有对象既没读也没记进任何桶** —— 而该文件为「不完整」专门造了 `truncatedObjects` / `unreadableObjects` / `aborted` 三个桶,唯独对象级预算耗尽这条路径没有对应桶。本 PR 的第三档排序缓解了「谁先被读」,但没解决「没轮到的不被记录」,两者独立,故分开填。
- `engine.ts:2876` 的 `@link` 文案仍写着 "(readonly skip, empty values, unknown ≠ absent)",现在应为 "readonly split"。⛔ 本单不碰 `engine.ts`(#5504 在飞),留给事实一的注释校准一并处理。

## 验证

```
pnpm --filter @objectstack/objectql test       →  Test Files 121 passed (121) / Tests 1978 passed (1978)
pnpm --filter @objectstack/objectql typecheck  →  tsc --noEmit,无输出,exit 0
pnpm --filter @objectstack/cli   test src/utils/schema-migrate.teardown.integration.test.ts
                                               →  Test Files 1 passed / Tests 1 passed
pnpm check:query-options-erasure               →  ratchet holds: 84 unswept non-test site(s) in 19 file(s), none new
node scripts/check-nul-bytes.mjs               →  OK (scanned 5608 tracked text file(s); no raw ASCII control bytes)
```

已加 changeset(`@objectstack/objectql: minor` —— 报告形状对消费方可见)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7WetGmnfoXNn8cLieKKmx


---
_Generated by [Claude Code](https://claude.ai/code/session_01V7WetGmnfoXNn8cLieKKmx)_