### PR TITLE
feat(spec): HookContext.session 补声明 `positions` / `preserveAudit`(#5605)

### DIFF
--- a/.changeset/hook-context-session-positions-preserve-audit.md
+++ b/.changeset/hook-context-session-positions-preserve-audit.md
@@ -1,0 +1,53 @@
+---
+"@objectstack/spec": minor
+---
+
+feat(spec): `HookContext.session` declares `positions` and `preserveAudit` (#5605)
+
+Two keys the engine has been **producing** all along, that consumers have been
+**reading** and the docs have been **teaching**, were missing from the contract:
+`HookContextSchema.session` declared `userId` / `actor` / `organizationId` /
+`accessToken` / `isSystem` / `skipTriggers` / `skipAutomations` and nothing else.
+Both are now declared, per the maintainer ruling on #5605.
+
+This is the mirror of the `session.roles` retirement (#5050). That key was
+declared-never-produced, so it was removed; these two are
+produced-never-declared, so they are added. Same `session` block, opposite
+drift, opposite fix.
+
+**What was broken.** `HookContextSchema` is deliberately not `.strict()` — it is
+the runtime shape the engine hands a handler, and strictness there would make
+every engine-side enrichment a breaking change for anyone parsing a context they
+were given. The cost of that tolerance is that an undeclared key is **stripped
+in silence**:
+
+- `HookContextSchema.parse(ctx)` — the exact call the generated reference page
+  documents as the way to consume a context — returned a session with the
+  caller's `positions` and the import's `preserveAudit` dropped on the floor.
+- A handler typed the way the automation docs teach, `(ctx: HookContext)`, could
+  not read either key: `ctx.session?.positions` was a `TS2339`. The two
+  `kernel/runtime-services` pages that teach
+  `positions: ctx.session?.positions` compiled only because they annotate `ctx`
+  as `any` — copying both the code and the documented annotation did not build.
+
+**`positions`** (`string[]`, optional) is the ADR-0090 D3 placement vocabulary,
+copied verbatim from `ExecutionContext.positions` by ObjectQL's `buildSession()`.
+Its `.describe()` states the boundary the ruling asked for, because the boundary
+is the whole reason this key needed a decision rather than a patch: it is
+**readable context, never an authorization input**. A hook may forward it as the
+sharing service's evaluation context, tailor a message, or log it. A hook must
+not make the access decision itself by testing it — privilege is judged by the
+security service on the execution context (capability grants `permissions`,
+placements `positions`, and the derived posture). A hook re-deciding access from
+this array decides, somewhere with no access to the grant model, something that
+was already decided; that is structurally the mistake the `roles` tombstone
+exists to prevent, one vocabulary later.
+
+**`preserveAudit`** (`boolean`, optional) is the #3493 historical-import flag:
+server-set, opt-in, absent on normal writes, and read by the built-in audit hook
+to keep a caller-supplied `updated_at`/`updated_by` instead of stamping the
+import instant. It has a live consumer, so it could only ever be declared.
+
+Purely additive — both keys are optional, the shape stays non-strict, and no
+existing context, handler or stored metadata changes. Contexts are built per
+operation and never persisted, so there is nothing to migrate.

--- a/packages/spec/src/data/hook.test.ts
+++ b/packages/spec/src/data/hook.test.ts
@@ -975,3 +975,170 @@ describe('session.roles retirement (#5050, ADR-0049)', () => {
     expect(built.userId).toBe('user_123');
   });
 });
+
+/**
+ * `HookContext.session.positions` / `.preserveAudit` declaration (#5605,
+ * maintainer ruling A of 2026-08-06).
+ *
+ * The MIRROR of the retirement above, and the reason both blocks live in this
+ * file: `roles` was declared-never-produced (delete it), these two are
+ * produced-never-declared (declare them). Same `session` object, opposite
+ * drift, opposite fix — which is why #5605 was filed apart from #5050 rather
+ * than folded into it.
+ *
+ * What was actually broken before the declaration, on `origin/main`:
+ *
+ *   - PARSE — `HookContextSchema` is deliberately non-strict (see the
+ *     `hook.zod.ts` header), so both keys were silently STRIPPED. Measured
+ *     before the change: parsing a session of
+ *     `{ userId, positions, preserveAudit }` returned `{"userId":"u1"}`. That
+ *     is not hypothetical: the generated reference page documents
+ *     `HookContextSchema.parse(data)` as the way to consume a context, so a
+ *     consumer following the docs dropped the caller's positions on the floor.
+ *   - TSC — a handler typed the way `content/docs/automation/index.mdx` teaches,
+ *     `(ctx: HookContext)`, could not read either key: two TS2339s, on
+ *     `ctx.session?.positions` and `ctx.session?.preserveAudit`. The two
+ *     `runtime-services` pages that teach `positions: ctx.session?.positions`
+ *     only look fine because they annotate `ctx` as `any` — copy the code AND
+ *     the documented annotation and it did not compile.
+ *
+ * REVERSE VERIFICATION, direction predicted first: delete either declaration
+ * from `hook.zod.ts` and this block fails BOTH ways — the parse assertions go
+ * red (the key is stripped, so `toHaveProperty` fails), and
+ * `pnpm --filter @objectstack/spec typecheck` reports TS2339 on the typed
+ * reads below. No `@ts-expect-error` is involved here and none should be
+ * added: the fact under test is that documented code COMPILES, so the pin is
+ * a positive typed read, and its failure mode on revert is a hard type error
+ * rather than an unused-directive TS2578.
+ *
+ * Boundary, restated because it is the whole reason the ruling needed a
+ * maintainer: `positions` is readable context, NOT an authorization input.
+ * The `.describe()` says so and the assertion below pins that it keeps saying
+ * so — the next author (or the next AI) reaching for
+ * `session.positions.includes(...)` as an access check is exactly what the
+ * `roles` tombstone above was written to stop.
+ */
+describe('session.positions / session.preserveAudit declaration (#5605)', () => {
+  it('PRESERVES `positions` through a parse instead of stripping it', () => {
+    const context = HookContextSchema.parse({
+      object: 'account',
+      event: 'beforeUpdate',
+      input: {},
+      session: { userId: 'user_123', positions: ['sales_manager', 'org_admin'] },
+      ql: {},
+    });
+
+    expect(context.session).toHaveProperty('positions');
+    expect(context.session?.positions).toEqual(['sales_manager', 'org_admin']);
+  });
+
+  it('PRESERVES `preserveAudit` through a parse (#3493 has a live consumer)', () => {
+    const context = HookContextSchema.parse({
+      object: 'account',
+      event: 'beforeInsert',
+      input: {},
+      session: { userId: 'user_123', preserveAudit: true },
+      ql: {},
+    });
+
+    expect(context.session).toHaveProperty('preserveAudit');
+    expect(context.session?.preserveAudit).toBe(true);
+  });
+
+  it('keeps both OPTIONAL — a normal write produces neither', () => {
+    // `buildSession()` writes `preserveAudit` only under the historical-import
+    // opt-in, and `positions` is absent whenever the execution context carried
+    // none. Declaring them must not start requiring them.
+    //
+    // ⚠️ HONEST NOTE — this one is a COMPANION, not a pin. It asserts absence,
+    // and absence is also what a stripped (undeclared) key produces, so it
+    // stayed green under the reverse verification while its four siblings went
+    // red. It is kept because "declaring them did not make them required" is a
+    // real regression it would catch (a missing `.optional()` turns it red),
+    // but it is not evidence that the declaration exists — do not read it as
+    // such. The pins are the two preserve tests, the `buildSession()` shape,
+    // and the tsc read below.
+    const context = HookContextSchema.parse({
+      object: 'account',
+      event: 'beforeInsert',
+      input: {},
+      session: { userId: 'user_123' },
+      ql: {},
+    });
+
+    expect(context.session?.positions).toBeUndefined();
+    expect(context.session?.preserveAudit).toBeUndefined();
+  });
+
+  it('accepts the exact session shape `buildSession()` builds', () => {
+    // Field-for-field the object ObjectQL assembles (engine.ts `buildSession`)
+    // for a historical import by an authenticated caller. Before #5605 this
+    // parse quietly returned a session two keys shorter than the one the
+    // engine handed the handler.
+    const built = {
+      userId: 'user_123',
+      organizationId: 'org_456',
+      positions: ['sales_manager'],
+      accessToken: 'token_abc123',
+      isSystem: true,
+      actor: 'svc:flow:import_history',
+      skipTriggers: true,
+      skipAutomations: true,
+      preserveAudit: true,
+    };
+
+    const context = HookContextSchema.parse({
+      object: 'account',
+      event: 'beforeInsert',
+      input: {},
+      session: built,
+      ql: {},
+    });
+
+    expect(context.session).toEqual(built);
+  });
+
+  it('type-checks the code the docs teach — `(ctx: HookContext)` reading both keys', () => {
+    // The TSC channel. Both reads were TS2339 before the declaration; this is
+    // `content/docs/kernel/runtime-services/sharing-service.mdx`'s snippet with
+    // the `any` annotation removed, which is what made the omission invisible
+    // there. Explicit annotations, so a widened or renamed declaration fails
+    // here too rather than being absorbed by inference.
+    const readCallerContext = (ctx: HookContext) => {
+      const positions: string[] | undefined = ctx.session?.positions;
+      const preserveAudit: boolean | undefined = ctx.session?.preserveAudit;
+      return { positions, preserveAudit };
+    };
+
+    // ...and the PRODUCER side: the literal `buildSession()` returns must be
+    // assignable to the declared session type.
+    const session: NonNullable<HookContext['session']> = {
+      userId: 'user_123',
+      positions: ['sales_manager'],
+      preserveAudit: true,
+    };
+
+    expect(readCallerContext({
+      object: 'account',
+      event: 'beforeUpdate',
+      input: {},
+      session,
+      ql: {},
+    })).toEqual({ positions: ['sales_manager'], preserveAudit: true });
+  });
+
+  it('carries the "not an authorization input" boundary in the `.describe()`', () => {
+    // The ruling's wording is load-bearing, not decoration: it is the only
+    // thing standing between this key and the next author using it as an
+    // access check. A `.describe()` reaches the generated reference page and
+    // every schema-driven surface, so pin that the boundary survives edits.
+    const sessionShape = HookContextSchema.shape.session.unwrap().shape;
+
+    const positionsDoc = sessionShape.positions.description ?? '';
+    expect(positionsDoc).toMatch(/security service/i);
+    expect(positionsDoc).toMatch(/not an authorization input/i);
+
+    const preserveAuditDoc = sessionShape.preserveAudit.description ?? '';
+    expect(preserveAuditDoc).toMatch(/not an authorization input/i);
+  });
+});

--- a/packages/spec/src/data/hook.zod.ts
+++ b/packages/spec/src/data/hook.zod.ts
@@ -405,6 +405,66 @@ export const HookContextSchema = lazySchema(() => z.object({
     isSystem: z.boolean().optional().describe('True when the call was made with an elevated system context (engine self-writes)'),
     skipTriggers: z.boolean().optional().describe('True when record-change automation (flow triggers) must be suppressed for this write — e.g. package seed replay. Lifecycle hooks still run.'),
     skipAutomations: z.boolean().optional().describe('True when metadata-bound automation hooks must be suppressed for this write — e.g. data import with "run automations" unchecked, or import undo. Implies skipTriggers; code-registered system hooks (audit, security) still run.'),
+    /**
+     * Position names held by the caller (ADR-0090 D3 vocabulary — the schema
+     * comment on `ExecutionContext.positions` spells it "Formerly `roles`").
+     * Copied verbatim from `ExecutionContext.positions` by ObjectQL's
+     * `buildSession()` (`packages/objectql/src/engine.ts`).
+     *
+     * ⚠️ **Descriptive, NOT an authorization input.** A hook may READ this to
+     * describe the caller — forwarding it as the sharing service's evaluation
+     * context (`services.sharing.canEdit(..., { positions })`, the shape both
+     * `content/docs/kernel/runtime-services/` pages teach), tailoring a
+     * message, logging — and nothing more. It grants nothing on its own, no
+     * security middleware keys on it here, and a hook must never make the
+     * access decision itself by testing it
+     * (`session.positions.includes('sales_manager')` is the anti-pattern).
+     * PRIVILEGE is judged by the security service on the ExecutionContext:
+     * capability grants (`permissions`), placements (`positions`) and the
+     * derived posture (ADR-0095 D3). A hook that re-decides access from this
+     * array is deciding, in a place with no access to the grant model,
+     * something already decided — structurally the same mistake as the
+     * `roles` tombstone below (#5050), one vocabulary later. That is why this
+     * key is declared with the boundary written down rather than left to be
+     * inferred from its name.
+     *
+     * Declared in #5605 (maintainer ruling A): it was PRODUCED by
+     * `buildSession()` and TAUGHT by two kernel doc pages while the contract
+     * omitted it — so `HookContextSchema.parse()` silently stripped it (this
+     * shape is deliberately non-strict, see the header) and a handler typed
+     * `(ctx: HookContext)` could not read it without TS2339. Produced-never-
+     * declared, the mirror of `roles`' declared-never-produced.
+     */
+    positions: z.array(z.string()).optional().describe(
+      'Position names held by the caller (ADR-0090 D3; formerly `roles`), copied from '
+      + 'ExecutionContext.positions. For hook READS only — e.g. forwarding to the sharing '
+      + 'service as evaluation context. Authorization is decided by the security service on '
+      + 'the ExecutionContext (permissions / positions / derived posture); this is NOT an '
+      + 'authorization input and a hook must not gate a write by testing it.',
+    ),
+    /**
+     * Historical-import audit-preservation flag (#3493). Set by
+     * `buildSession()` only when the write context carries it, so a normal
+     * write leaves it absent.
+     *
+     * Its one consumer is the built-in audit hook
+     * (`packages/objectql/src/plugin.ts`, `applyToRecord`): when true, a
+     * client-supplied `updated_at` / `updated_by` is PREFERRED and kept —
+     * reinstating the original timeline of imported history — instead of
+     * being overwritten with the import instant, symmetric with how
+     * `created_at` / `created_by` behave on insert. It also whitelists the
+     * audit/timestamp family through `stripReadonlyFields()`.
+     *
+     * Server-set and opt-in; like {@link positions} it authorizes nothing —
+     * it selects a stamping policy for a write the security service has
+     * already allowed.
+     */
+    preserveAudit: z.boolean().optional().describe(
+      'True when this write is a historical import that must KEEP its caller-supplied '
+      + 'updated_at/updated_by (and the readonly audit family) instead of being stamped with '
+      + 'the import instant (#3493). Server-set, opt-in, absent on normal writes; read by the '
+      + 'built-in audit hook. A stamping policy, not an authorization input.',
+    ),
     // `roles` REMOVED (#5050, ADR-0049 D2). It was DECLARED here, READ by two
     // dead exemption branches in plugin-approvals (the approval record lock and
     // the delegation write guard, both deleted in #4839 / PR #5049), and NEVER


### PR DESCRIPTION
Fixes #5605

按维护者 2026-08-06 的裁定 **A**:两个键都补进 `HookContextSchema.session`,并用 `.describe()` 把边界钉死。

## 这是 #5050 的镜像,不是它的另一半措辞

`session.roles` 是 **declared-never-produced** —— 声明了、没人产,所以 #5050 把它退役成墓碑。这两个键是 **produced-never-declared** —— 引擎在产、消费方在读、文档在教,契约里没有,所以补声明。同一个 `session` 块、方向相反、修法相反,这就是 #5605 单独立单的理由。

## 前提复核(对 `origin/main` 逐条核实,四条全部成立)

- **生产方**:`packages/objectql/src/engine.ts` 的 `buildSession()` —— :1494 写 `positions: execCtx.positions`,:1518 条件写 `preserveAudit`。
- **消费方**:`packages/objectql/src/plugin.ts:782` `const preserveAudit = session?.preserveAudit === true;`(该处 `session` 形参是 `any`,所以类型层看不见这条读)。
- **文档在教**:`content/docs/kernel/runtime-services/examples.mdx:37` 与 `sharing-service.mdx:67`,都是 `positions: ctx.session?.positions`。
- **契约没有**:补之前 `session` 只有 `userId` / `actor` / `organizationId` / `accessToken` / `isSystem` / `skipTriggers` / `skipAutomations` + `roles` 墓碑。

⚠️ issue 指出该文件近期被 #5621 / #5668 连改两次 —— 已基于合并后的当前 `origin/main` 重新定位,行号与结构均以本分支基线为准。

## 先证红(两条通道,都是改动前在 `origin/main` 上实测)

**parse 通道** —— `HookContextSchema` 刻意非 strict(文件头有说明:它是引擎交给 handler 的运行时形状,strict 会让引擎侧任何一次内部增强变成消费方的破坏性变更)。代价就是未声明的键被**静默 strip**:

```
输入 session: { userId: 'u1', positions: ['sales_manager'], preserveAudit: true }
parse 输出   : {"userId":"u1"}
has positions     : false
has preserveAudit : false
```

生成的 reference 页恰恰以 `HookContextSchema.parse(data)` 作为消费示例 —— 照文档消费,调用方的任职信息就掉在地上。

**tsc 通道** —— 按 `content/docs/automation/index.mdx` 的写法把 handler 标成 `(ctx: HookContext)`:

```
error TS2339: Property 'positions' does not exist on type '{ userId?: string | undefined; ... }'.
error TS2339: Property 'preserveAudit' does not exist on type '{ userId?: string | undefined; ... }'.
```

两页 runtime-services 示例之所以看不出来,是因为它们把 `ctx` 标成了 `any`。**照文档抄 + 照文档标类型 = 编译失败**。

## 改了什么

**1. 两个键的声明**(`packages/spec/src/data/hook.zod.ts`),都放在 `roles` 墓碑**上方** —— 墓碑注释自己写明的排序约束(见下文「渲染器陷阱」)。

- `positions: z.array(z.string()).optional()`
- `preserveAudit: z.boolean().optional()`

**2. `.describe()` 按裁定措辞钉边界。** 这不是装饰,是这单需要维护者拍板的**全部原因**:`positions` 是**可读上下文,不是授权输入**。hook 可以读它去描述调用方(转给 sharing service 当评估上下文、调整消息、打日志),但**不得**用它自己做访问判断 —— 权限由 security service 在 ExecutionContext 上裁决(能力授予 `permissions`、任职 `positions`、以及派生的 posture,ADR-0095 D3)。一个用这个数组重新决定访问的 hook,是在一个拿不到授权模型的地方重判一件已经判过的事 —— 结构上正是 `roles` 墓碑要防的那个错误,只是换了一代词汇。措辞纪律与 `roles` 退役处方一致,针对的是下一个作者(尤其 AI)。

`preserveAudit` 的 describe 写它真实的消费语义:#3493 的历史导入保留标记,server-set、opt-in、普通写不带,由内置审计 hook 读取,用来保留调用方提交的 `updated_at` / `updated_by` 而不是盖上导入时刻 —— 是一条盖戳策略,同样不是授权输入。

**3. Pin(`packages/spec/src/data/hook.test.ts`,新增一个 describe 块)**,与 #5050 的墓碑块并列,两块互为镜像正好把这张契约表的两个漂移方向都钉住。

## 反向验证(方向先预测,再运行)

预测:删掉任一声明,**两条通道都应转红**。实测:

- parse 通道:`vitest run src/data/hook.test.ts` → `4 failed | 68 passed`(两条 preserve、`buildSession()` 形状、describe 边界)。
- tsc 通道:`check:test-typecheck` → `src/data/hook.test.ts: 9 type error(s) in a file the ledger does not cover`。该文件**不在** `test-typecheck-debt.json` 里,所以这是硬门,不是被 ledger 兜住的软红。

**一条诚实说明**:新增的 5 条断言里,`keeps both OPTIONAL` 在反向验证下**仍然绿**。它断言的是「缺席」,而键被 strip 之后同样缺席 —— 它是伴随断言,不是 pin(少写 `.optional()` 会让它转红,这是它留下的理由)。测试注释里已如实写明「不要把它当作声明存在的证据」,以免下一个读者把一条因空而绿的断言读成覆盖。这里没有用 `@ts-expect-error`:本单要证的事实是「文档教的代码**能**编译」,所以类型 pin 是一条正向标注读,回退时的失败形态是硬类型错误,而不是 TS2578 未使用指令。

## 生成物与渲染器陷阱(#5606)

`roles` 墓碑注释写明:生成的 reference 把内联对象渲染成**前四个声明键加省略号**,而 `z.never()` 没有 JSON-Schema `type`,会印成 `any` —— 所以墓碑必须待在形状底部,否则 `references/data/hook.mdx` 会开始宣传 `roles?: any`。新键因此加在墓碑**上方**,落在第 8/9 位。

结果:`content/docs/references/data/hook.mdx` 的 session 行**一字未变**,仍是 `{ userId?: string; actor?: string; organizationId?: string; accessToken?: string; … }`。已两路确认 —— `check:docs` 绿(文件无需重新生成),并逐行目视核对生成页。

`pnpm --filter @objectstack/spec check:generated`:**10/10 全绿**(api-surface 读的是 built dist,必须先 `build` 才有效,已 build 后复跑)。

一处**刻意未提交**:跑生成器时 `authorable-surface.base.json` 被重锚到本分支的 merge base,带进了别人落的 `api/Discovery:scoping` 两个键 + baseRev。那不是本次改动的产物,已回退 —— 该 gate 复跑后自述「trails the merge base by 2 key(s) — expected right after a surface change lands」,是信息性提示,不红。删除类 ratchet 的锚点不该搭在无关 PR 里顺带前移。

## 验证

| 命令 | 结果 |
|:---|:---|
| `pnpm --filter @objectstack/spec test` | `317 passed (317)` / `8088 passed (8088)`;合入 `main` 后复跑 `8090 passed (8090)` |
| `pnpm --filter @objectstack/spec typecheck` | 绿(`tsc --noEmit` + `check:test-typecheck` OK),合入后复跑仍绿 |
| `pnpm --filter @objectstack/spec check:generated` | `All 10 generated artifacts are up to date`,合入后复跑仍 10/10 |
| `pnpm --filter @objectstack/objectql typecheck` | 绿 |
| `pnpm --filter @objectstack/objectql test` | `121 passed (121)` / `1970 passed (1970)` |
| `node scripts/check-nul-bytes.mjs` | OK(另做控制字符自扫,无命中) |
| 远端 CI(本 PR head) | 24 项 check runs 全部 success/skipped,无 failure |

objectql 一并跑了,因为它是生产方:`buildSession()` 的返回值现在被真正声明的类型覆盖(此前 `as HookContext['session']` 把两个键遮了过去)。

## 影响面

纯增量:两个键都 optional,形状仍非 strict,现存 context / handler / 存量元数据都不受影响。HookContext 按操作构造、从不落库,没有任何东西需要迁移。changeset 记 `@objectstack/spec` minor。

## 一处如实说明:本地有两个未推上来的提交

本分支在本地还有两个提交没能推送 —— push 被拒,原因是本 PR 已被(非本 session 的动作)标记 ready 并加入 merge queue,排队中的分支不允许更新。两个提交都**不含内容变更**:

1. 一个 `origin/main` 的合并提交(AGENTS.md §10 的合并后复验;merge queue 本身就是把 PR 作为「合并到当前 main 的结果」来构建的,所以这个合并对正确性是冗余的);
2. 一处**纯注释**措辞订正 —— 上面「诚实说明」那段的行内注释原写作「四条兄弟断言」,准确说法是「五条兄弟里的四条,第五条是 tsc 通道的 pin,vitest 判不了它」。

即入队的 head 与我的最终状态在本 PR 涉及的文件上只差这 6 行注释。留此说明以免后来者对不上分支状态;若需要,订正可作为后续小 PR。

## 附带发现(未在本 PR 修)

**#5720** —— 同两页文档还在教 `ctx.services?.sharing?.canEdit(...)`,而 hook 上下文(引擎构造的 handler ctx 与 body-runner 的沙箱 ctx)**都没有** `services` 这个键(它是 action ctx 的词汇)。可选链短路成 `undefined`,`if (!ok) throw` 于是无条件抛出 —— 照抄这个示例的 hook 会拒掉该对象上的每一次写入。同一个 `ctx: any` 标注同时架空了那段 `{/* os:check */}` 门禁,也正是它掩盖了本单的 TS2339。修法取决于「hook 访问 kernel service 的受支持通道是什么」这个待定问题,故按 Prime Directive #10 单独立单,未在本 PR 顺手改文档。