### PR TITLE
fix(spec): ADR-0087 别名转换按值处置被遮蔽的旧拼法(等值删除、异值双留) (#4923)

### DIFF
--- a/.changeset/conversion-shadowed-alias-by-value.md
+++ b/.changeset/conversion-shadowed-alias-by-value.md
@@ -1,0 +1,51 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): an ADR-0087 rename resolves a shadowed alias by VALUE, instead of always leaving it behind (#4923)
+
+Every ADR-0087 D2 conversion that renames a key (`renameKey` /
+`renameConfigKey`, so `object` → `objectName`, `filters` → `filter`,
+`flow` → `flowName`, the four `notify` aliases, `description` → `subtitle`,
+the datasource driver-config aliases, …) used to do **nothing at all** when the
+canonical key was already present. The retired spelling then stayed in the
+converted metadata forever — the conversion had not finished converting.
+
+That was invisible while flow-node config contracts were `.strip`: the dead key
+was silently dropped at the execute-time parse and the node ran. Once #4001 批 9
+made those contracts strict it stopped being invisible — a stored `subflow`
+carrying `{ flowName, flow }` loads today and would be refused at execute time
+as a guard failure (not routable through a `fault` edge).
+
+**What changes.** A rename that meets both spellings now splits on whether the
+two values actually disagree:
+
+- **Same value** (structural equality, so two separately-authored
+  `{ status: 'stale' }` filters count as one declaration) → the alias carries
+  nothing the canonical key does not, so it is **deleted** and the conversion
+  emits its usual notice. Lossless hygiene, and it makes the transform
+  idempotent in both shape and notices.
+- **Different values** → **both keys are kept** and no notice is emitted. Two
+  spellings holding two different values is genuine author ambiguity, and an
+  upgrade tool that silently picked the canonical one would be editing a
+  configuration the customer never agreed to. The surviving pair is what lets
+  the strict node-config gates refuse with a prescription that **names both
+  keys** and asks for a decision.
+
+`notify`'s nested `source: { object, id }` lift follows the same rule: a part
+that repeats its flat counterpart is redundant and `source` is dropped, while a
+part that disagrees leaves the node **entirely** untouched so `source` reaches
+the strict contract intact. (The `wait` node's loose-key lift is deliberately
+NOT covered — it moves keys between two locations rather than resolving two
+spellings of one slot.)
+
+**What an author sees.** Metadata that named one slot twice with the same value
+loses the retired spelling at load and gains one deprecation notice per removal
+— the same notice a plain rename already emitted, so `objectstack validate`
+output is unchanged in kind. Metadata that named one slot twice with *different*
+values is unchanged by the conversion and is now refused by the strict
+node-config contracts with a message naming both keys; the fix is to decide
+which value is right, put it on the canonical key, and delete the alias. The
+batch-9 prescriptions were reworded accordingly: they no longer say the
+surviving twin is "dead" (true only under the old rule), because a key that now
+reaches that parse holds a value the canonical key does not.

--- a/packages/spec/src/automation/builtin-node-config.test.ts
+++ b/packages/spec/src/automation/builtin-node-config.test.ts
@@ -244,12 +244,18 @@ describe('MapConfigSchema — strict as of #4001 批 9', () => {
     expect(message).toMatch(/delete/i);
   });
 
-  it('rejects the SHADOWED alias the ADR-0087 conversion deliberately leaves behind', () => {
-    // `renameConfigKey` does nothing when the canonical key is already
-    // present, so `{ flowName, flow }` survives the load-path conversion
-    // intact — and under `.strip` the dead twin was then deleted in silence at
-    // this parse. That silence is the whole point of #4001: the author wrote
-    // two names for one thing and the platform picked one without saying so.
-    expect(MapConfigSchema.safeParse({ collection: '{r}', flowName: 'per_row', flow: 'ignored' }).success).toBe(false);
+  it('rejects the AMBIGUOUS pair the ADR-0087 conversion deliberately leaves behind', () => {
+    // Since #4923 `renameConfigKey` resolves `{ flowName, flow }` itself when
+    // the two agree, so the pair that survives the load-path conversion to
+    // reach this parse is the one naming two DIFFERENT flows. Under `.strip`
+    // the loser was then deleted in silence — the whole point of #4001: the
+    // author wrote two names for one thing and the platform picked one without
+    // saying so. This is the case where picking would be a guess, so the
+    // refusal names both keys instead.
+    expect(MapConfigSchema.safeParse({ collection: '{r}', flowName: 'per_row', flow: 'per_row_v2' }).success)
+      .toBe(false);
+    const message = unknownKeyMessage(MapConfigSchema, { collection: '{r}', flowName: 'per_row', flow: 'per_row_v2' })!;
+    expect(message).toContain('`flow`');
+    expect(message).toContain('`flowName`');
   });
 });

--- a/packages/spec/src/automation/builtin-node-config.zod.ts
+++ b/packages/spec/src/automation/builtin-node-config.zod.ts
@@ -84,11 +84,23 @@ const BUILTIN_NODE_CONFIG_HISTORY =
  * The two ADR-0087 D2 aliases every CRUD node shares.
  *
  * Both are retired SPELLINGS rather than typos, and both are rewritten at load
- * (`flow-node-crud-object-alias`, `flow-node-crud-filter-alias`), so a config
- * still carrying one at parse time carries the canonical key too —
- * `renameConfigKey` leaves a shadowed alias in place instead of clobbering the
- * winner. Hence each prescription answers both readings: the rename, and
- * "delete the dead twin".
+ * (`flow-node-crud-object-alias`, `flow-node-crud-filter-alias`). So each
+ * prescription has to answer two different readers, and since #4923 the split
+ * between them is exact:
+ *
+ *  - whoever **parses this contract directly** (never went through the load
+ *    path) wrote the retired spelling on its own → the fix is the rename;
+ *  - whoever **came through the load path** still has the alias only because
+ *    the conversion refused to resolve it, and it refuses in exactly one
+ *    situation: the canonical key is ALSO present and carries a DIFFERENT
+ *    value. An identical twin is deleted by the conversion now, so it can no
+ *    longer reach this parse.
+ *
+ * That second reader is why the prescription names BOTH keys and asks for a
+ * decision rather than a deletion. Telling them "the canonical one already won,
+ * delete yours" — true while a shadowed alias was left in place — would now be
+ * advice to discard the one value the platform deliberately declined to discard
+ * on their behalf.
  *
  * `object` also earns its entry on distance alone: `object` → `objectName` is
  * four edits against a threshold of two, so the suggester would say nothing at
@@ -97,13 +109,17 @@ const BUILTIN_NODE_CONFIG_HISTORY =
 const CRUD_ALIAS_GUIDANCE = {
   object:
     'The object slot is `objectName`. `object` was the last tenant of the `readAliasedConfig` executor shim; it '
-    + 'graduated into the ADR-0087 D2 conversion `flow-node-crud-object-alias` (#3796), which rewrites it at load — '
-    + 'so a surviving `object` means `objectName` already won and this key is dead. Delete it.',
+    + 'graduated into the ADR-0087 D2 conversion `flow-node-crud-object-alias` (#3796), which rewrites it at load. '
+    + 'If `objectName` is also present, this node names two different objects and the conversion left both keys '
+    + 'alone rather than picking for you (#4923) — decide which object this node acts on, put it on `objectName`, '
+    + 'and delete `object`.',
   filters:
     'The match map is `filter` (singular). `filters` was a consumer-side executor fallback that graduated into the '
     + 'ADR-0087 D2 conversion `flow-node-crud-filter-alias`, which rewrites it at load; delete it once `filter` '
-    + 'carries the pairs. Beware the half-migrated shape: an empty `filter` next to a populated `filters` is what '
-    + 'made this alias dangerous enough to declare (#3810 — a match-everything write).',
+    + 'carries the pairs. If `filter` is also present, the two carry DIFFERENT match maps and the conversion kept '
+    + 'both rather than choosing (#4923) — reconcile them onto `filter`. Beware the half-migrated shape: an empty '
+    + '`filter` next to a populated `filters` is what made this alias dangerous enough to declare (#3810 — a '
+    + 'match-everything write).',
 } as const;
 
 /**
@@ -457,7 +473,9 @@ export const MapConfigSchema = lazySchema(() => strictObject({
     flow:
       'The per-item subflow is named by `flowName`. `flow` was an undeclared executor fallback no schema or form '
       + 'described; it graduated into the ADR-0087 D2 conversion `flow-node-map-flow-alias` (#4045), which rewrites '
-      + 'it at load — so a surviving `flow` means `flowName` already won and this key is dead. Delete it.',
+      + 'it at load. If `flowName` is also present, the two name DIFFERENT subflows and the conversion kept both '
+      + 'rather than picking one to run per item (#4923) — decide which flow this is, put it on `flowName`, and '
+      + 'delete `flow`.',
   },
 }, {
   /** The collection — a `{token}` template / bare variable name, or an inline array. */

--- a/packages/spec/src/automation/io-node-config.test.ts
+++ b/packages/spec/src/automation/io-node-config.test.ts
@@ -64,7 +64,7 @@ describe('NotifyConfigSchema — strict as of #4001 批 9', () => {
     ['url', '/task/1', '`actionUrl`'],
     ['source', { object: 'showcase_task', id: '1' }, '`sourceObject` + `sourceId`'],
   ] as ReadonlyArray<[string, unknown, string]>)(
-    'names the canonical key AND the dead-twin case for the retired `%s` alias',
+    'names the canonical key AND the disagreeing-pair case for the retired `%s` alias',
     (key, value, canonical) => {
       const message = unknownKeyMessage(NotifyConfigSchema, {
         recipients: ['u1'], title: 'hi', [key]: value,
@@ -72,12 +72,15 @@ describe('NotifyConfigSchema — strict as of #4001 批 9', () => {
       expect(message).toContain(canonical);
       // Both readings must be served: the ADR-0087 conversion rewrites this
       // key at load, so a config that still carries it at PARSE time also
-      // carries the canonical key — `renameConfigKey` leaves a shadowed alias
-      // in place rather than clobbering the winner. Without this half the
-      // prescription ("rename it") is wrong for the population that actually
-      // reaches this error.
+      // carries the canonical key — and since #4923 it carries one holding a
+      // DIFFERENT value, because an identical twin is deleted by the
+      // conversion. Without this half the prescription ("rename it") is wrong
+      // for the population that actually reaches this error.
       expect(message).toContain('flow-node-notify-config-aliases');
-      expect(message).toMatch(/delete/i);
+      expect(message).toMatch(/delete|reconcile/i);
+      // The reconciliation reading has to name the OTHER key too, or the
+      // author cannot see which two spellings disagree.
+      expect(message).toMatch(/DIFFERENT|differ/i);
     },
   );
 

--- a/packages/spec/src/automation/io-node-config.zod.ts
+++ b/packages/spec/src/automation/io-node-config.zod.ts
@@ -108,8 +108,9 @@ const NOTIFY_KEY_GUIDANCE: Readonly<Record<string, string>> = {
   source:
     'The click-through target is the flat PAIR `sourceObject` + `sourceId`, never a nested `source: { object, id }`. '
     + '`flow-node-notify-config-aliases` lifts the nested shape at load and drops it once every part is accounted '
-    + 'for, so a surviving `source` means a part of it DISAGREES with the flat key already holding that slot, and '
-    + 'the conversion declined to pick (#4923) — reconcile onto `sourceObject` / `sourceId` and delete `source`. '
+    + 'for, so a surviving `source` means a part of it holds a DIFFERENT value from the flat `sourceObject` / '
+    + '`sourceId` already in that slot, and the conversion declined to pick (#4923) — reconcile onto the flat pair '
+    + 'and delete `source`. '
     + 'Note the pair only takes effect together: a half-specified target is dropped so the inbox never renders a '
     + 'dead link.',
 };

--- a/packages/spec/src/automation/io-node-config.zod.ts
+++ b/packages/spec/src/automation/io-node-config.zod.ts
@@ -74,34 +74,44 @@ const IO_NODE_CONFIG_HISTORY =
  *
  * Each is a RETIRED SPELLING, not a typo, so a bare "did you mean" would
  * under-serve it: `flow-node-notify-config-aliases` rewrites all five at load
- * (including the `registerFlow` rehydration seam), which means a config that
- * still carries one when it reaches this parse carries the canonical key too —
- * `renameConfigKey` leaves a SHADOWED alias in place rather than clobbering the
- * winner. So each prescription answers both readings: the rename, for whoever
- * parses this contract directly, and "delete the dead twin", for whoever came
- * through the load path.
+ * (including the `registerFlow` rehydration seam). Since #4923 that rewrite
+ * also DELETES a retired spelling that merely repeats the canonical key's
+ * value, which sharpens what a surviving one means: it survived because the
+ * canonical key is also present and says something DIFFERENT, and the
+ * conversion will not pick between two values the author wrote.
+ *
+ * So each prescription answers both readings — the rename, for whoever parses
+ * this contract directly, and a reconciliation naming BOTH keys, for whoever
+ * came through the load path.
  */
 const NOTIFY_KEY_GUIDANCE: Readonly<Record<string, string>> = {
   to:
     'The recipient slot is `recipients`. `to` is the pre-17 spelling, rewritten at load by the ADR-0087 D2 '
-    + 'conversion `flow-node-notify-config-aliases` — so if `recipients` is already present, the conversion left '
-    + '`to` behind as a dead twin (a shadowed alias is not clobbered) and it should be deleted.',
+    + 'conversion `flow-node-notify-config-aliases` — so if `recipients` is also present, the two name DIFFERENT '
+    + 'recipients and the conversion kept both rather than choosing who gets notified (#4923). Decide the '
+    + 'recipients, put them on `recipients`, and delete `to`.',
   subject:
     'The heading slot is `title`. `subject` is the pre-17 spelling rewritten at load by '
-    + '`flow-node-notify-config-aliases`; delete it once `title` carries the text.',
+    + '`flow-node-notify-config-aliases`; delete it once `title` carries the text. If `title` is also present with '
+    + 'DIFFERENT text, the conversion kept both rather than choosing (#4923) — reconcile them onto `title`.',
   body:
     'The body slot is `message`. `body` is the pre-17 spelling rewritten at load by '
-    + '`flow-node-notify-config-aliases`; delete it once `message` carries the text. (`body` IS canonical on an '
-    + '`http` node — the key is wrong only here.)',
+    + '`flow-node-notify-config-aliases`; delete it once `message` carries the text. If `message` is also present '
+    + 'with DIFFERENT text, the conversion kept both rather than choosing (#4923) — reconcile them onto `message`. '
+    + '(`body` IS canonical on an `http` node — the key is wrong only here.)',
   url:
     'The click-through slot is `actionUrl`. It was renamed at 17 because `url` elsewhere on the platform means '
     + '"HTTP endpoint to call" (`http` node, webhooks), a different concept from an in-app click target. '
-    + '`flow-node-notify-config-aliases` rewrites it at load; delete it once `actionUrl` carries the link.',
+    + '`flow-node-notify-config-aliases` rewrites it at load; delete it once `actionUrl` carries the link. If '
+    + '`actionUrl` is also present with a DIFFERENT link, the conversion kept both rather than choosing where the '
+    + 'notification points (#4923) — reconcile them onto `actionUrl`.',
   source:
     'The click-through target is the flat PAIR `sourceObject` + `sourceId`, never a nested `source: { object, id }`. '
     + '`flow-node-notify-config-aliases` lifts the nested shape at load and drops it once every part is accounted '
-    + 'for, so a surviving `source` means both flat keys were already set — delete it. Note the pair only takes '
-    + 'effect together: a half-specified target is dropped so the inbox never renders a dead link.',
+    + 'for, so a surviving `source` means a part of it DISAGREES with the flat key already holding that slot, and '
+    + 'the conversion declined to pick (#4923) — reconcile onto `sourceObject` / `sourceId` and delete `source`. '
+    + 'Note the pair only takes effect together: a half-specified target is dropped so the inbox never renders a '
+    + 'dead link.',
 };
 
 // ─── notify ──────────────────────────────────────────────────────────

--- a/packages/spec/src/automation/schemaless-node-config.zod.ts
+++ b/packages/spec/src/automation/schemaless-node-config.zod.ts
@@ -119,10 +119,11 @@ const SCHEMALESS_NODE_CONFIG_HISTORY =
  * `functionName` and `input` are retired SPELLINGS that
  * `flow-node-script-config-aliases` rewrites at load, so — like the notify
  * family — a config still carrying one at parse time carries the canonical key
- * too (`renameConfigKey` leaves a shadowed alias alone). `input` earns its
- * entry twice over: edit distance would suggest `inputs` without ever saying
- * that `input` is *canonical* on `connector_action`'s `connectorConfig`, which
- * is where the spelling leaked in from and where it must NOT be changed.
+ * too, and since #4923 it carries a canonical key holding a DIFFERENT value
+ * (an identical twin is deleted by the conversion). `input` earns its entry
+ * twice over: edit distance would suggest `inputs` without ever saying that
+ * `input` is *canonical* on `connector_action`'s `connectorConfig`, which is
+ * where the spelling leaked in from and where it must NOT be changed.
  *
  * The five `actionType`-branch keys need no entry here: `retiredKey()` puts the
  * prescription in the shape itself, which is strictly stronger (it also types
@@ -132,12 +133,15 @@ const SCHEMALESS_NODE_CONFIG_HISTORY =
 const SCRIPT_KEY_GUIDANCE: Readonly<Record<string, string>> = {
   functionName:
     'The callable reference is `function` (#1870). `functionName` was the AI/template-emitted alias, rewritten at '
-    + 'load by the ADR-0087 D2 conversion `flow-node-script-config-aliases`; if `function` is already present the '
-    + 'conversion left `functionName` behind as a dead twin — delete it.',
+    + 'load by the ADR-0087 D2 conversion `flow-node-script-config-aliases`. If `function` is also present, the two '
+    + 'name DIFFERENT callables and the conversion kept both rather than picking which one runs (#4923) — decide '
+    + 'which it is, put it on `function`, and delete `functionName`.',
   input:
     'The input map on a `script` node is `inputs` (plural). The singular `input` leaked in from '
     + "`connector_action`, where `connectorConfig.input` is a DIFFERENT and canonical surface — do not \"fix\" that "
-    + 'one. `flow-node-script-config-aliases` rewrites this key at load; delete it once `inputs` carries the values.',
+    + 'one. `flow-node-script-config-aliases` rewrites this key at load; delete it once `inputs` carries the values. '
+    + 'If `inputs` is also present with DIFFERENT values, the conversion kept both rather than choosing (#4923) — '
+    + 'reconcile them onto `inputs`.',
 };
 
 /** `subflow` prescriptions — one retired spelling, one wrong layer. */
@@ -145,7 +149,9 @@ const SUBFLOW_KEY_GUIDANCE: Readonly<Record<string, string>> = {
   flow:
     'The invoked flow is named by `flowName`. `flow` was an undeclared executor fallback that no schema or form '
     + 'ever described; it graduated into the ADR-0087 D2 conversion `flow-node-subflow-flow-alias` (#4278), which '
-    + 'rewrites it at load — so a surviving `flow` means `flowName` already won and this key is dead. Delete it.',
+    + 'rewrites it at load. If `flowName` is also present, the two name DIFFERENT flows and the conversion kept '
+    + 'both rather than picking which one this step invokes (#4923) — decide which it is, put it on `flowName`, '
+    + 'and delete `flow`.',
   timeoutMs:
     "A subflow step's timeout is the engine's per-node guard, so it belongs on the NODE, not in its config: "
     + '`{ id, type: "subflow", timeoutMs: 30000, config: { … } }`. `FlowNodeSchema.timeoutMs` is the declared key.',

--- a/packages/spec/src/conversions/conversions.test.ts
+++ b/packages/spec/src/conversions/conversions.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, it } from 'vitest';
 
+import { CreateRecordConfigSchema } from '../automation/builtin-node-config.zod.js';
 import { FlowSchema } from '../automation/flow.zod.js';
 import { ScriptConfigSchema } from '../automation/schemaless-node-config.zod.js';
 import { normalizeStackInput } from '../shared/metadata-collection.zod.js';
@@ -136,7 +137,7 @@ describe('conversion layer (ADR-0087 D2)', () => {
       expect(notices).toHaveLength(1);
     });
 
-    it('does not clobber an existing canonical filter', () => {
+    it('does not clobber an existing canonical filter that says something DIFFERENT', () => {
       const { stack, notices } = collectConversionNotices({
         flows: [
           {
@@ -153,7 +154,146 @@ describe('conversion layer (ADR-0087 D2)', () => {
       });
       const node = (stack.flows as any[])[0].nodes[0];
       expect(node.config.filter).toEqual({ keep: true });
-      expect(notices).toHaveLength(0); // canonical present → no conversion
+      // Two different match maps under two names is the ambiguous half of the
+      // #4923 ruling: BOTH survive, so the strict gate can refuse naming both.
+      expect(node.config.filters).toEqual({ drop: true });
+      expect(notices).toHaveLength(0);
+    });
+  });
+
+  /**
+   * The shadowed-alias rule, split by value (#4923).
+   *
+   * `renameKey` used to do nothing whenever the canonical key was already
+   * present, which left the retired spelling sitting in converted metadata
+   * forever — invisible while the node contracts were `.strip`, an execute-time
+   * refusal once #4001 批 9 made them strict. The maintainer ruling splits that
+   * case by whether the two values actually disagree; these tests pin both
+   * halves, because only one of them is a change.
+   */
+  describe('shadowed alias, split by value (#4923)', () => {
+    const crudFlow = (config: Record<string, unknown>) => ({
+      flows: [{ name: 'f', nodes: [{ id: 'a', type: 'create_record', config }] }],
+    });
+    const configOf = (stack: Record<string, unknown>) =>
+      (stack.flows as Array<{ nodes: Array<{ config: Record<string, unknown> }> }>)[0]!.nodes[0]!.config;
+
+    // ── Direction 1: equal values → the twin is deleted, loudly ──────────
+    //
+    // Predicted BEFORE the run, against unmodified code: red. The old
+    // `renameKey` returned `null` the moment `objectName` was present, so the
+    // dead `object` survived into `after` and no notice was emitted at all.
+
+    it('deletes an alias whose value EQUALS the canonical key, and emits a notice', () => {
+      const { stack, notices } = collectConversionNotices(
+        crudFlow({ objectName: 'task', object: 'task' }),
+      );
+      expect(configOf(stack)).toEqual({ objectName: 'task' });
+      expect(configOf(stack)).not.toHaveProperty('object');
+      expect(notices).toHaveLength(1);
+      expect(notices[0]).toMatchObject({
+        conversionId: 'flow-node-crud-object-alias',
+        from: 'object',
+        to: 'objectName',
+      });
+    });
+
+    it('compares STRUCTURALLY — two separately-authored identical filters are one declaration', () => {
+      // `===` would call these different and keep both; they are the same
+      // authored match map, so the retired spelling carries nothing.
+      const { stack, notices } = collectConversionNotices({
+        flows: [
+          {
+            name: 'f',
+            nodes: [
+              {
+                id: 'a',
+                type: 'delete_record',
+                config: { filter: { status: 'stale' }, filters: { status: 'stale' } },
+              },
+            ],
+          },
+        ],
+      });
+      expect(configOf(stack)).toEqual({ filter: { status: 'stale' } });
+      expect(notices).toHaveLength(1);
+    });
+
+    it('is idempotent in shape AND notices — the deduped result replays to itself', () => {
+      const once = collectConversionNotices(crudFlow({ objectName: 'task', object: 'task' }));
+      expect(once.notices).toHaveLength(1);
+      const twice = collectConversionNotices(once.stack);
+      expect(twice.stack).toEqual(once.stack);
+      expect(twice.notices).toHaveLength(0);
+    });
+
+    // ── Direction 2: different values → BOTH survive ─────────────────────
+    //
+    // Predicted BEFORE the run: GREEN against unmodified code too. Keeping a
+    // differing pair is what the old code already did for every pair, so this
+    // half is a REGRESSION PIN, not a proof of change. What the ruling
+    // actually changed here is the *reason* — and the prescription that reads
+    // it, pinned in the strict-gate test below.
+
+    it('keeps BOTH spellings when the values differ — the upgrade tool does not choose', () => {
+      const before = crudFlow({ objectName: 'task', object: 'ticket' });
+      const { stack, notices } = collectConversionNotices(structuredClone(before));
+      expect(stack).toEqual(before);
+      expect(configOf(stack)).toEqual({ objectName: 'task', object: 'ticket' });
+      expect(notices).toHaveLength(0);
+    });
+
+    it('judges each pair on its own value — one twin dedupes while its neighbour survives', () => {
+      const { stack, notices } = collectConversionNotices(
+        crudFlow({ objectName: 'task', object: 'task', filter: { a: 1 }, filters: { a: 2 } }),
+      );
+      expect(configOf(stack)).toEqual({ objectName: 'task', filter: { a: 1 }, filters: { a: 2 } });
+      expect(notices).toHaveLength(1);
+      expect(notices[0]!.from).toBe('object');
+    });
+
+    it('applies the same rule one level up, on a plain dict rename (page header)', () => {
+      // `renameConfigKey` delegates to `renameKey`, so a non-`config` surface
+      // must not develop its own dialect of the rule.
+      const header = (properties: Record<string, unknown>) => ({
+        pages: [{ name: 'p', regions: [{ name: 'header', components: [{ type: 'page:header', properties }] }] }],
+      });
+      const propsOf = (stack: Record<string, unknown>) =>
+        (stack.pages as Array<{ regions: Array<{ components: Array<{ properties: unknown }> }> }>)[0]!
+          .regions[0]!.components[0]!.properties;
+
+      const equal = collectConversionNotices(header({ title: 'T', subtitle: 'One', description: 'One' }));
+      expect(propsOf(equal.stack)).toEqual({ title: 'T', subtitle: 'One' });
+      expect(equal.notices).toHaveLength(1);
+
+      const differs = header({ title: 'T', subtitle: 'One', description: 'Another' });
+      const kept = collectConversionNotices(structuredClone(differs));
+      expect(kept.stack).toEqual(differs);
+      expect(kept.notices).toHaveLength(0);
+    });
+
+    // ── The half the strict gate owns: the prescription names BOTH keys ───
+    //
+    // Predicted BEFORE the run: red against unmodified guidance, which told
+    // the author the surviving twin was "dead" — true under the old rule and
+    // false under the new one, where a survivor means the two values disagree.
+
+    it('the surviving pair is refused by the strict gate with BOTH keys named', () => {
+      const parsed = CreateRecordConfigSchema.safeParse({
+        objectName: 'task',
+        object: 'ticket',
+        fields: { title: 'x' },
+      });
+      expect(parsed.success).toBe(false);
+      const message = parsed.success ? '' : parsed.error.issues.map((i) => i.message).join('\n');
+      // Both spellings, so the author can see the disagreement they authored…
+      expect(message).toContain('`object`');
+      expect(message).toContain('`objectName`');
+      // …and the refusal must NOT claim the survivor is a dead duplicate: the
+      // conversion now deletes those, so a key that reached this parse carries
+      // a value that differs from the canonical one.
+      expect(message).not.toMatch(/already won and this key is dead/i);
+      expect(message).toMatch(/differ|different/i);
     });
   });
 
@@ -446,7 +586,10 @@ describe('conversion layer (ADR-0087 D2)', () => {
         timerDuration: 'PT5M',
         timeoutMs: 60_000,
       });
-      // The shadowed alias is not deleted — same treatment `renameConfigKey` gives one.
+      // The loose counterpart is not deleted. NOTE this is the wait-node LIFT
+      // (a loose key into a declared block), not a `renameKey` alias pair, so
+      // #4923's by-value split does not reach it — see the comment on
+      // WAIT_EVENT_CONFIG_LIFTS.
       expect(waitNodeOf(stack).config).toEqual({ duration: 'PT9M' });
       expect(notices).toHaveLength(1);
     });
@@ -695,12 +838,13 @@ describe('conversion layer (ADR-0087 D2)', () => {
       expect(componentsOf(stack)[0]!.type).toBe('page-header');
     });
 
-    it('leaves a shadowed `description` alone when `subtitle` is already there (canonical wins)', () => {
-      // The house precedence `renameKey` encodes, same as
-      // flow-node-crud-object-alias: no rewrite, no notice, no deletion.
+    it('keeps a `description` that DISAGREES with an existing `subtitle` (both survive)', () => {
+      // The house precedence `renameKey` encodes since #4923, same as
+      // flow-node-crud-object-alias: two different second lines are the
+      // author's to reconcile, so no rewrite, no notice, no deletion.
       const before = pageWith({
         type: 'page:header',
-        properties: { title: 'Both', subtitle: 'wins', description: 'ignored' },
+        properties: { title: 'Both', subtitle: 'wins', description: 'other' },
       });
       const { stack, notices } = collectConversionNotices(structuredClone(before));
       expect(stack).toEqual(before);

--- a/packages/spec/src/conversions/conversions.test.ts
+++ b/packages/spec/src/conversions/conversions.test.ts
@@ -11,6 +11,7 @@ import { PageSchema } from '../ui/page.zod.js';
 import { applyConversions, collectConversionNotices } from './apply.js';
 import { ALL_CONVERSIONS, CONVERSIONS_BY_MAJOR } from './registry.js';
 import { applyConversionsToStoredItem } from './stored.js';
+import { renameConfigKey, renameKey } from './walk.js';
 import { CONVERSION_NOTICE_CODE, type ConversionNotice } from './types.js';
 
 describe('conversion layer (ADR-0087 D2)', () => {
@@ -250,6 +251,16 @@ describe('conversion layer (ADR-0087 D2)', () => {
       expect(configOf(stack)).toEqual({ objectName: 'task', filter: { a: 1 }, filters: { a: 2 } });
       expect(notices).toHaveLength(1);
       expect(notices[0]!.from).toBe('object');
+    });
+
+    it('never deletes the only copy when a pair renames a key to itself', () => {
+      // Guard on the new equal-value branch: `from === to` would compare the
+      // value against itself, call it a redundant twin, and delete it. No
+      // registry pair is written that way; this pins that one added later
+      // converts nothing instead of erasing the key.
+      const dict = { objectName: 'task' };
+      expect(renameKey(dict, 'objectName', 'objectName')).toBeNull();
+      expect(renameConfigKey({ config: { ...dict } }, 'objectName', 'objectName')).toBeNull();
     });
 
     it('applies the same rule one level up, on a plain dict rename (page header)', () => {

--- a/packages/spec/src/conversions/registry.ts
+++ b/packages/spec/src/conversions/registry.ts
@@ -26,6 +26,7 @@ import {
   renameKey,
 } from './walk.js';
 import { resolveDriverId, type BuiltinDriverId } from '../data/driver/config-registry.zod.js';
+import { deepEqualAuthored } from '../shared/deep-equal.js';
 
 /**
  * Flow callout node type rename (protocol 11.0).
@@ -550,34 +551,13 @@ const pageComponentVisibilityToVisibleWhen: MetadataConversion = {
   surface: 'page.component.visibility',
   summary: "page component key 'visibility' → 'visibleWhen' (ADR-0089)",
   apply(stack, emit) {
-    return mapPages(stack, (page, path) => {
-      const regions = page.regions;
-      if (!Array.isArray(regions)) return page;
-      let regionsChanged = false;
-      const nextRegions = regions.map((region, ri) => {
-        if (!region || typeof region !== 'object' || Array.isArray(region)) return region;
-        const dict = region as Record<string, unknown>;
-        const components = dict.components;
-        if (!Array.isArray(components)) return region;
-        let componentsChanged = false;
-        const nextComponents = components.map((component, ci) => {
-          if (!component || typeof component !== 'object' || Array.isArray(component)) return component;
-          const mapped = renameVisibilityAlias(
-            component as Record<string, unknown>,
-            'visibility',
-            `${path}.regions[${ri}].components[${ci}]`,
-            emit,
-          );
-          if (mapped !== component) componentsChanged = true;
-          return mapped;
-        });
-        if (!componentsChanged) return region;
-        regionsChanged = true;
-        return { ...dict, components: nextComponents };
-      });
-      if (!regionsChanged) return page;
-      return { ...page, regions: nextRegions };
-    });
+    // The region→component descent this used to open-code is the shared
+    // `mapPageComponents` walker (#5509, adopted per #5511): identical
+    // copy-on-write contract, identical `pages[i].regions[j].components[k]`
+    // paths, and one fewer hand-rolled traversal to keep in step with
+    // `PageComponentSchema`'s reach.
+    return mapPageComponents(stack, (component, path) =>
+      renameVisibilityAlias(component, 'visibility', path, emit));
   },
   fixture: {
     before: {
@@ -923,8 +903,12 @@ const flowNodeCrudObjectAlias: MetadataConversion = {
           nodes: [
             { id: 'n1', type: 'start' },
             { id: 'n2', type: 'get_record', config: { object: 'lead', recordId: '{leadId}' } },
-            // canonical already present → the shadowed alias is left alone (no notice)
-            { id: 'n3', type: 'create_record', config: { objectName: 'task', object: 'ignored' } },
+            // Both spellings, DIFFERENT objects (#4923): real author ambiguity,
+            // so both keys survive and the strict gate refuses naming both.
+            { id: 'n3', type: 'create_record', config: { objectName: 'task', object: 'ticket' } },
+            // Both spellings, SAME object: the alias carries nothing the
+            // canonical key does not, so it is deleted (with a notice).
+            { id: 'n4', type: 'update_record', config: { objectName: 'lead', object: 'lead' } },
           ],
         },
       ],
@@ -936,12 +920,15 @@ const flowNodeCrudObjectAlias: MetadataConversion = {
           nodes: [
             { id: 'n1', type: 'start' },
             { id: 'n2', type: 'get_record', config: { objectName: 'lead', recordId: '{leadId}' } },
-            { id: 'n3', type: 'create_record', config: { objectName: 'task', object: 'ignored' } },
+            { id: 'n3', type: 'create_record', config: { objectName: 'task', object: 'ticket' } },
+            { id: 'n4', type: 'update_record', config: { objectName: 'lead' } },
           ],
         },
       ],
     },
-    expectedNotices: 1,
+    // n2's rename + n4's redundant-twin deletion. n3 is the ambiguous pair: no
+    // rewrite, no notice — the refusal is the strict gate's to make.
+    expectedNotices: 2,
   },
 };
 
@@ -951,14 +938,26 @@ const flowNodeCrudObjectAlias: MetadataConversion = {
  *
  * The fifth notify alias, and the only one that is not a 1:1 rename — it is a
  * 1→2 destructuring, so {@link renameFlowConfigAliases}' pair mechanism cannot
- * express it. Semantics mirror the `??` precedence the executor used to carry:
- * a canonical key already present WINS and its nested counterpart is left
- * shadowed, exactly as {@link renameConfigKey} treats a shadowed alias.
+ * express it. It nevertheless follows {@link renameConfigKey}'s rule for a
+ * shadowed alias, which #4923 settled **by value**:
  *
- * `source` is dropped once at least one part was lifted — every part is by then
- * either lifted or shadowed by a canonical key, so nothing observable is lost
- * (the executor only ever read `.object` / `.id`). A `source` that is not a dict,
- * or carries neither key, is left untouched rather than silently deleted.
+ *  - a nested part whose flat counterpart is ABSENT is lifted (a notice each);
+ *  - a nested part that merely REPEATS the value already on its flat key is
+ *    redundant — nothing to lift, but the part is accounted for, and the notice
+ *    still fires so the removal is loud;
+ *  - a nested part that DISAGREES with its flat key is genuine author
+ *    ambiguity. The node is then left **entirely** untouched — no partial lift,
+ *    no notice — so `source` survives to the strict `notify` contract, which
+ *    refuses naming both the nested key and the flat pair. Choosing here would
+ *    mean rewriting a click-through target the author never agreed to.
+ *
+ * `source` is dropped only when every part it carries was lifted or found
+ * redundant, so nothing observable is lost. Leaving the ambiguous node whole
+ * rather than half-converted also keeps the pass idempotent: a replay of the
+ * unresolved shape re-derives the same verdict and emits nothing.
+ *
+ * A `source` that is not a dict, or carries neither key, is left untouched
+ * rather than silently deleted.
  */
 function liftNotifySourceShape(stack: Dict, emit: Emit): Dict {
   return mapFlowNodes(stack, (node, path) => {
@@ -969,15 +968,22 @@ function liftNotifySourceShape(stack: Dict, emit: Emit): Dict {
     if (!isDict(source)) return node;
 
     const nextConfig: Dict = { ...config };
-    let lifted = false;
+    const pending: ConversionApplication[] = [];
+    let ambiguous = false;
     for (const [from, to] of [['object', 'sourceObject'], ['id', 'sourceId']] as const) {
       if (source[from] == null) continue;
-      if (nextConfig[to] != null) continue; // canonical already wins
-      nextConfig[to] = source[from];
-      emit({ from: `source.${from}`, to, path: `${path}.config.${to}` });
-      lifted = true;
+      if (nextConfig[to] == null) {
+        nextConfig[to] = source[from];
+      } else if (!deepEqualAuthored(source[from], nextConfig[to])) {
+        ambiguous = true;
+        break;
+      }
+      pending.push({ from: `source.${from}`, to, path: `${path}.config.${to}` });
     }
-    if (!lifted) return node;
+    // The author named one slot twice, differently — hand the whole shape to
+    // the strict gate rather than resolving part of it (#4923).
+    if (ambiguous || pending.length === 0) return node;
+    for (const application of pending) emit(application);
     delete nextConfig.source;
     return { ...node, config: nextConfig };
   });
@@ -1043,15 +1049,29 @@ const flowNodeNotifyConfigAliases: MetadataConversion = {
                 source: { object: 'showcase_task', id: '{record.id}' },
               },
             },
-            // A canonical `sourceObject` WINS: only the unshadowed `id` is
-            // lifted, and `source` is dropped since every part is accounted for.
+            // `source.object` DISAGREES with the flat `sourceObject` (#4923).
+            // The node is left whole — not even the unambiguous `id` is
+            // lifted — so `source` reaches the strict `notify` contract and is
+            // refused there, naming both the nested key and the flat pair.
             {
               id: 'n3',
               type: 'notify',
               config: {
                 recipients: ['{record.owner}'],
                 sourceObject: 'showcase_project',
-                source: { object: 'ignored', id: '{record.project}' },
+                source: { object: 'crm_account', id: '{record.project}' },
+              },
+            },
+            // `source.object` merely REPEATS the flat `sourceObject`: redundant,
+            // so it counts as accounted for, `id` lifts, and `source` is
+            // dropped — two notices, nothing observable lost.
+            {
+              id: 'n4',
+              type: 'notify',
+              config: {
+                recipients: ['{record.reviewer}'],
+                sourceObject: 'showcase_task',
+                source: { object: 'showcase_task', id: '{record.task}' },
               },
             },
           ],
@@ -1083,16 +1103,26 @@ const flowNodeNotifyConfigAliases: MetadataConversion = {
               config: {
                 recipients: ['{record.owner}'],
                 sourceObject: 'showcase_project',
-                sourceId: '{record.project}',
+                source: { object: 'crm_account', id: '{record.project}' },
+              },
+            },
+            {
+              id: 'n4',
+              type: 'notify',
+              config: {
+                recipients: ['{record.reviewer}'],
+                sourceObject: 'showcase_task',
+                sourceId: '{record.task}',
               },
             },
           ],
         },
       ],
     },
-    // 4 renames on n2 + `source.object`/`source.id` lifted on n2 + the single
-    // unshadowed `source.id` on n3 (its `source.object` is shadowed → no notice).
-    expectedNotices: 7,
+    // 4 renames on n2 + `source.object`/`source.id` lifted on n2 = 6; n3 is the
+    // ambiguous pair and converts nothing; n4 adds 2 (the redundant `object`
+    // and the lifted `id`).
+    expectedNotices: 8,
   },
 };
 
@@ -1135,8 +1165,15 @@ const WAIT_EVENT_CONFIG_LIFTS: ReadonlyArray<readonly [target: string, candidate
  *
  * Precedence mirrors those `??` chains, so the rewrite is behaviour-preserving:
  * a value already on `waitEventConfig` WINS and its loose counterpart is left
- * shadowed (as {@link renameConfigKey} treats a shadowed alias), and among loose
- * candidates the first one present decides.
+ * shadowed in place, and among loose candidates the first one present decides.
+ *
+ * This is a LIFT between two locations, not an alias pair in one dict, so
+ * #4923's by-value split (delete a redundant twin, keep a disagreeing one)
+ * deliberately does NOT apply — {@link renameConfigKey} judges two spellings of
+ * one slot, while here the loose `config` location is itself the retired thing
+ * and `WAIT_EVENT_CONFIG_LIFTS` may map several candidate names onto one
+ * target. Extending the rule here would be a separate ruling on a different
+ * question; the shadowed loose key is left for the strict contract to reject.
  *
  * `eventType` is defaulted to `'timer'` whenever lifting would otherwise leave
  * the block without one. That is load-bearing, not tidiness: the loader parses
@@ -1275,8 +1312,11 @@ const flowNodeMapFlowAlias: MetadataConversion = {
           nodes: [
             { id: 'n1', type: 'start' },
             { id: 'n2', type: 'map', config: { collection: '{tasks}', flow: 'one_task_signoff' } },
-            // canonical already present → the shadowed alias is left alone (no notice)
-            { id: 'n3', type: 'map', config: { collection: '{rows}', flowName: 'per_row', flow: 'ignored' } },
+            // Both spellings naming DIFFERENT flows (#4923): which subflow runs
+            // per item is the author's call, so both keys survive to the gate.
+            { id: 'n3', type: 'map', config: { collection: '{rows}', flowName: 'per_row', flow: 'per_row_v2' } },
+            // Both spellings naming the SAME flow: redundant, so deleted.
+            { id: 'n4', type: 'map', config: { collection: '{items}', flowName: 'per_item', flow: 'per_item' } },
           ],
         },
       ],
@@ -1288,12 +1328,14 @@ const flowNodeMapFlowAlias: MetadataConversion = {
           nodes: [
             { id: 'n1', type: 'start' },
             { id: 'n2', type: 'map', config: { collection: '{tasks}', flowName: 'one_task_signoff' } },
-            { id: 'n3', type: 'map', config: { collection: '{rows}', flowName: 'per_row', flow: 'ignored' } },
+            { id: 'n3', type: 'map', config: { collection: '{rows}', flowName: 'per_row', flow: 'per_row_v2' } },
+            { id: 'n4', type: 'map', config: { collection: '{items}', flowName: 'per_item' } },
           ],
         },
       ],
     },
-    expectedNotices: 1,
+    // n2's rename + n4's redundant-twin deletion; n3 converts nothing.
+    expectedNotices: 2,
   },
 };
 
@@ -1327,8 +1369,11 @@ const flowNodeSubflowFlowAlias: MetadataConversion = {
           nodes: [
             { id: 'n1', type: 'start' },
             { id: 'n2', type: 'subflow', config: { flow: 'escalation_flow', input: { caseId: '{record.id}' } } },
-            // canonical already present → the shadowed alias is left alone (no notice)
-            { id: 'n3', type: 'subflow', config: { flowName: 'audit_flow', flow: 'ignored' } },
+            // Both spellings naming DIFFERENT flows (#4923): both survive, and
+            // the strict `subflow` contract refuses naming both.
+            { id: 'n3', type: 'subflow', config: { flowName: 'audit_flow', flow: 'audit_flow_v2' } },
+            // Both spellings naming the SAME flow: redundant, so deleted.
+            { id: 'n4', type: 'subflow', config: { flowName: 'notify_flow', flow: 'notify_flow' } },
           ],
         },
       ],
@@ -1340,12 +1385,14 @@ const flowNodeSubflowFlowAlias: MetadataConversion = {
           nodes: [
             { id: 'n1', type: 'start' },
             { id: 'n2', type: 'subflow', config: { flowName: 'escalation_flow', input: { caseId: '{record.id}' } } },
-            { id: 'n3', type: 'subflow', config: { flowName: 'audit_flow', flow: 'ignored' } },
+            { id: 'n3', type: 'subflow', config: { flowName: 'audit_flow', flow: 'audit_flow_v2' } },
+            { id: 'n4', type: 'subflow', config: { flowName: 'notify_flow' } },
           ],
         },
       ],
     },
-    expectedNotices: 1,
+    // n2's rename + n4's redundant-twin deletion; n3 converts nothing.
+    expectedNotices: 2,
   },
 };
 
@@ -3148,9 +3195,10 @@ const DATASOURCE_CONFIG_KEY_ALIASES: Readonly<
  * So the tolerance graduates here: every stored-row rehydration seam replays
  * the full chain (`applyConversionsToStoredItem`, #3903), hands the factory
  * the canonical key, and the factory reads ONE spelling. Precedence follows
- * {@link renameKey}: a canonical key already present wins and the alias is
- * left shadowed in place, which is also what the factory's `??` chains
- * resolved to.
+ * {@link renameKey}: a canonical key already present wins, which is also what
+ * the factory's `??` chains resolved to — and since #4923 the alias beside it
+ * is deleted when it merely repeats that value, or kept (for the authoring
+ * gate to refuse naming both) when the two disagree.
  *
  * **Retired from the load path** — not because the keys misdescribed
  * themselves (they were honest spellings, merely undeclared), but because the
@@ -3179,7 +3227,7 @@ const datasourceConfigDriverKeyAliases: MetadataConversion = {
       let nextConfig = config;
       for (const [from, to] of pairs) {
         const renamed = renameKey(nextConfig, from, to);
-        if (!renamed) continue; // absent, or canonical already wins (alias stays shadowed)
+        if (!renamed) continue; // absent, or an ambiguous pair `renameKey` refuses (#4923)
         emit({ from, to, path: `${path}.config.${to}` });
         nextConfig = renamed;
       }
@@ -3200,8 +3248,9 @@ const datasourceConfigDriverKeyAliases: MetadataConversion = {
         // `database` is CANONICAL for mysql — only `user` converts
         { name: 'orders', driver: 'mysql', config: { host: 'db.internal', database: 'orders', user: 'svc_orders' } },
         { name: 'events', driver: 'mongodb', config: { uri: 'mongodb://mongo.internal:27017/events' } },
-        // canonical already present → the shadowed alias is left alone (no notice)
-        { name: 'scratch', driver: 'sqlite', config: { filename: ':memory:', file: 'ignored.db' } },
+        // Both spellings, DIFFERENT files (#4923): kept, so the authoring gate
+        // can refuse naming both rather than the loader picking a database.
+        { name: 'scratch', driver: 'sqlite', config: { filename: ':memory:', file: './scratch.db' } },
       ],
     },
     after: {
@@ -3215,7 +3264,7 @@ const datasourceConfigDriverKeyAliases: MetadataConversion = {
         },
         { name: 'orders', driver: 'mysql', config: { host: 'db.internal', database: 'orders', username: 'svc_orders' } },
         { name: 'events', driver: 'mongodb', config: { url: 'mongodb://mongo.internal:27017/events' } },
-        { name: 'scratch', driver: 'sqlite', config: { filename: ':memory:', file: 'ignored.db' } },
+        { name: 'scratch', driver: 'sqlite', config: { filename: ':memory:', file: './scratch.db' } },
       ],
     },
     // app_db 1 + archive_db 1 + warehouse 2 + orders 1 + events 1 + scratch 0.
@@ -3620,12 +3669,13 @@ const retryPolicyConverged: MetadataConversion = {
     // below and for the same reason, reached one level up: `errorHandling`
     // hangs off the flow document, not off a node, so `mapFlowNodes` walks
     // straight past it — which is a small echo of why this divergence survived
-    // #4661 at all. `renameKey` leaves an already-canonical `backoffMs` alone
-    // and, when BOTH spellings are present, leaves the alias shadowed rather
-    // than guessing which number the author meant; the strict block then
-    // rejects naming both. (#4923 is queued to revisit that shadowing rule —
-    // this entry deliberately relies on the shared helper's semantics rather
-    // than open-coding its own, so it moves with that ruling.)
+    // #4661 at all. `renameKey` leaves an already-canonical `backoffMs` alone;
+    // when BOTH spellings are present it now (#4923) deletes `retryDelayMs`
+    // only if it repeats the same number, and otherwise keeps both rather than
+    // guessing which delay the author meant — the strict block then rejects
+    // naming both. This entry relied on the shared helper's semantics rather
+    // than open-coding its own precisely so it would move with that ruling,
+    // and it did: no change was needed here.
     const withErrorHandling = mapCollection(stack, 'flows', (flow, path) => {
       const eh = flow.errorHandling;
       if (!eh || typeof eh !== 'object' || Array.isArray(eh)) return flow;
@@ -4187,8 +4237,9 @@ const pageHeaderSubtitleAlias: MetadataConversion = {
                 // The canonical type authored with the legacy key: converted too,
                 // because today this second line is dropped on the floor.
                 { type: 'page:header', properties: { title: 'Lead', description: 'One lead' } },
-                // Canonical already present → the shadowed alias is left alone (no notice).
-                { type: 'page:header', properties: { title: 'Both', subtitle: 'wins', description: 'ignored' } },
+                // Both spellings, DIFFERENT text (#4923): kept, so the author
+                // reconciles the two second lines rather than the loader picking.
+                { type: 'page:header', properties: { title: 'Both', subtitle: 'wins', description: 'other' } },
                 // `description` is this component's OWN declared prop (helper text) — untouched.
                 { type: 'element:text_input', properties: { label: 'Note', description: 'Helper text' } },
               ],
@@ -4207,7 +4258,7 @@ const pageHeaderSubtitleAlias: MetadataConversion = {
               components: [
                 { type: 'page-header', properties: { title: 'Leads', subtitle: 'All open leads' } },
                 { type: 'page:header', properties: { title: 'Lead', subtitle: 'One lead' } },
-                { type: 'page:header', properties: { title: 'Both', subtitle: 'wins', description: 'ignored' } },
+                { type: 'page:header', properties: { title: 'Both', subtitle: 'wins', description: 'other' } },
                 { type: 'element:text_input', properties: { label: 'Note', description: 'Helper text' } },
               ],
             },

--- a/packages/spec/src/conversions/stored.test.ts
+++ b/packages/spec/src/conversions/stored.test.ts
@@ -116,11 +116,20 @@ describe('applyConversionsToStoredItem (stored sys_metadata rows, #3903)', () =>
       expect(applyConversionsToStoredItem('datasource', row)).toBe(row);
     });
 
-    it('lets a canonical key win over a shadowed legacy alias', () => {
+    it('keeps BOTH spellings on a stored row when they disagree', () => {
       const row = { name: 'ds', driver: 'sqlite', config: { filename: './real.db', file: './stale.db' } };
       const out = applyConversionsToStoredItem('datasource', row) as { config: Record<string, unknown> };
-      // renameKey convention: canonical present → alias left shadowed, untouched.
+      // `renameKey` convention since #4923: two DIFFERENT files under two names
+      // is the author's ambiguity to resolve, so the replay picks neither.
       expect(out.config).toEqual({ filename: './real.db', file: './stale.db' });
+    });
+
+    it('drops a redundant alias on a stored row when it repeats the canonical value', () => {
+      const row = { name: 'ds', driver: 'sqlite', config: { filename: './real.db', file: './real.db' } };
+      const out = applyConversionsToStoredItem('datasource', row) as { config: Record<string, unknown> };
+      // Data at rest gets the same hygiene as a fresh load (#3903 replays the
+      // full chain), so a rehydrated row is canonical rather than half-migrated.
+      expect(out.config).toEqual({ filename: './real.db' });
     });
   });
 

--- a/packages/spec/src/conversions/walk.ts
+++ b/packages/spec/src/conversions/walk.ts
@@ -14,6 +14,7 @@
  */
 
 import { FLOW_REGION_SLOTS_BY_TYPE } from '../automation/region-slots.js';
+import { deepEqualAuthored } from '../shared/deep-equal.js';
 
 type Dict = Record<string, unknown>;
 
@@ -266,27 +267,66 @@ export function mapCollection(
 }
 
 /**
- * Rename `dict[from]` → `dict[to]`, immutably, only when `from` is present
- * (non-null) and the canonical `to` is absent. Returns `null` when there is
- * nothing to do — the caller keeps the original reference.
+ * Rename `dict[from]` → `dict[to]`, immutably. Returns `null` when there is
+ * nothing to do — the caller keeps the original reference and emits no notice.
+ *
+ * Three cases, and the third is the one #4923 ruled on:
+ *
+ * 1. **`from` absent (or null)** → `null`. Nothing to convert.
+ * 2. **`from` present, `to` absent** → the plain rename. The value moves to the
+ *    canonical key and the old spelling is deleted.
+ * 3. **BOTH present** — the author wrote two names for one slot — splits *by
+ *    value*, because the two halves are genuinely different facts:
+ *    - **values structurally equal** → the alias carries nothing the canonical
+ *      key does not already carry, so deleting it is **lossless hygiene** and
+ *      squarely inside the D2 contract ("the runtime only ever sees the
+ *      canonical shape"). The alias is dropped and the caller emits its notice,
+ *      so the rewrite stays loud.
+ *    - **values differ** → `null`, and BOTH spellings survive. This is real
+ *      author ambiguity, and an upgrade tool that picked the canonical one
+ *      would be editing a configuration the customer never agreed to. The
+ *      surviving pair is what lets the strict node-config gates refuse with a
+ *      prescription that NAMES BOTH KEYS (`builtin-node-config.zod.ts` and
+ *      friends) instead of the platform choosing silently.
+ *
+ * Before #4923 case 3 was uniformly "leave the alias shadowed", which is why
+ * every `renameFlowConfigAliases` entry's fixture used to pin a retired
+ * spelling surviving in its `after` half. Case 3's equal branch also makes the
+ * transform **idempotent in both shape and notices**: once the twin is gone,
+ * a replay hits case 1.
+ *
+ * Structural equality (not `===`) is the right test because these values are
+ * authored data, not identities: two separately-written `{ status: 'stale' }`
+ * filters are the same declaration. It is the same predicate the composer uses
+ * for "same value composes fine" (#5005) — deliberately one definition, so the
+ * two surfaces cannot disagree about whether a pair of values is "the same".
  */
 export function renameKey(dict: Dict, from: string, to: string): Dict | null {
   if (!(from in dict) || dict[from] == null) return null;
-  if (dict[to] != null) return null; // canonical already wins — nothing to do
   const next: Dict = { ...dict };
+  if (dict[to] != null) {
+    // Both spellings present (#4923). Only a redundant twin may be removed.
+    if (!deepEqualAuthored(dict[from], dict[to])) return null;
+    delete next[from];
+    return next;
+  }
   next[to] = next[from];
   delete next[from];
   return next;
 }
 
-/** Rename `config[from]` → `config[to]` on a node dict, immutably, only if `to` is absent. */
+/**
+ * Rename `config[from]` → `config[to]` on a node dict, immutably.
+ *
+ * A thin positional wrapper over {@link renameKey} — deliberately delegating
+ * rather than re-implementing, so the shadowed-alias rule #4923 settled has
+ * exactly one definition and a flow node's `config` cannot drift from every
+ * other dict the conversion layer rewrites.
+ */
 export function renameConfigKey(node: Dict, from: string, to: string): Dict | null {
   const config = node.config;
   if (!isDict(config)) return null;
-  if (!(from in config) || config[from] == null) return null;
-  if (config[to] != null) return null; // canonical already wins — nothing to do
-  const nextConfig: Dict = { ...config };
-  nextConfig[to] = nextConfig[from];
-  delete nextConfig[from];
+  const nextConfig = renameKey(config, from, to);
+  if (!nextConfig) return null;
   return { ...node, config: nextConfig };
 }

--- a/packages/spec/src/conversions/walk.ts
+++ b/packages/spec/src/conversions/walk.ts
@@ -302,6 +302,11 @@ export function mapCollection(
  * two surfaces cannot disagree about whether a pair of values is "the same".
  */
 export function renameKey(dict: Dict, from: string, to: string): Dict | null {
+  // A pair that renames a key to itself has no work to do, and the equal-value
+  // branch below would otherwise read it as "a twin identical to the canonical
+  // key" and delete the only copy. No registry pair is written that way today;
+  // this is here so one added later fails to convert instead of erasing data.
+  if (from === to) return null;
   if (!(from in dict) || dict[from] == null) return null;
   const next: Dict = { ...dict };
   if (dict[to] != null) {

--- a/packages/spec/src/shared/deep-equal.ts
+++ b/packages/spec/src/shared/deep-equal.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Structural equality for **authored declarations** — the one predicate that
+ * answers "did the author write the same thing twice?".
+ *
+ * It exists because two independent surfaces need that exact question and must
+ * not answer it differently:
+ *
+ *  - **compose** (#5005, `stack.zod.ts`): two stacks declaring the same key
+ *    compose fine when the declarations are the SAME, and are a reported
+ *    conflict when they differ;
+ *  - **the ADR-0087 conversion layer** (#4923, `conversions/walk.ts`): an alias
+ *    sitting next to its canonical key is redundant when the two values are the
+ *    SAME (the conversion deletes it), and is genuine author ambiguity when
+ *    they differ (both survive, and the strict gate refuses naming both).
+ *
+ * Both are the same judgement — *same declaration or not* — and neither is
+ * allowed to guess how to reconcile two different ones. Keeping one definition
+ * is what stops the conversion layer and the composer from disagreeing about
+ * whether a given pair of values is "the same", which would be visible to
+ * authors as two different verdicts on one stack.
+ *
+ * Deliberately strict and deliberately small:
+ *
+ *  - keys explicitly set to `undefined` are treated as absent, matching how the
+ *    composer reads a declaration in the first place;
+ *  - callables compare by reference (`Object.is`) — two distinct closures are
+ *    two distinct declarations, which is the honest answer for a config value;
+ *  - anything past {@link MAX_COMPARE_DEPTH} compares as NOT equal.
+ *
+ * @internal — not re-exported from `shared/index`; import by path.
+ */
+
+/**
+ * Depth ceiling for the recursion.
+ *
+ * A stack handed to `defineStack` is hand-built objects rather than parsed
+ * JSON, so a self-referencing value is reachable and would otherwise be an
+ * unbounded recursion on the load path — the same exposure, for the same
+ * reason, that `conversions/walk.ts` guards with `MAX_REGION_DEPTH`.
+ *
+ * Bailing out as **not equal** is the safe direction at both call sites: the
+ * composer reports a conflict naming the two stacks, and the conversion layer
+ * keeps both spellings so the strict gate names both keys. Neither degrades
+ * toward silently dropping an author's value.
+ */
+const MAX_COMPARE_DEPTH = 32;
+
+/**
+ * Deep structural equality between two authored values.
+ *
+ * @param a - left value
+ * @param b - right value
+ * @param depth - current recursion depth (internal)
+ */
+export function deepEqualAuthored(a: unknown, b: unknown, depth = 0): boolean {
+  if (Object.is(a, b)) return true;
+  if (depth >= MAX_COMPARE_DEPTH) return false;
+  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((item, i) => deepEqualAuthored(item, b[i], depth + 1));
+  }
+
+  const left = a as Record<string, unknown>;
+  const right = b as Record<string, unknown>;
+  const leftKeys = Object.keys(left).filter((k) => left[k] !== undefined);
+  const rightKeys = Object.keys(right).filter((k) => right[k] !== undefined);
+  if (leftKeys.length !== rightKeys.length) return false;
+  return leftKeys.every((k) => deepEqualAuthored(left[k], right[k], depth + 1));
+}

--- a/packages/spec/src/stack.zod.ts
+++ b/packages/spec/src/stack.zod.ts
@@ -10,6 +10,7 @@ import { TranslationBundleSchema, TranslationConfigSchema } from './system/trans
 import { StackServerConfigSchema } from './system/stack-server.zod';
 import { hasPlatformObjectPrefix } from './system/constants/platform-object-names';
 import { objectStackErrorMap, formatZodError } from './shared/error-map.zod';
+import { deepEqualAuthored } from './shared/deep-equal';
 import { normalizeStackInput, type MetadataCollectionInput, type MapSupportedField } from './shared/metadata-collection.zod';
 import type { ConversionNotice } from './conversions/types.js';
 import { formatUnknownAuthoringKey } from './data/authoring-key-lint';
@@ -1446,34 +1447,6 @@ const CONCAT_ARRAY_FIELDS = (Object.keys(COMPOSE_KEY_DISPOSITIONS) as (keyof Obj
   .filter((key) => COMPOSE_KEY_DISPOSITIONS[key] === 'concat');
 
 /**
- * Structural deep equality for the "same value composes fine" rule (#5005).
- *
- * Deliberately strict and deliberately small: it decides only whether two
- * authored declarations are the SAME, never how to reconcile two different
- * ones. Keys explicitly set to `undefined` are treated as absent, matching how
- * the composer reads a declaration in the first place. Callables compare by
- * reference (`Object.is`) — two distinct closures are two distinct
- * declarations, which is the honest answer for a config value.
- * @internal
- */
-function deepEqualDeclarations(a: unknown, b: unknown): boolean {
-  if (Object.is(a, b)) return true;
-  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false;
-  if (Array.isArray(a) !== Array.isArray(b)) return false;
-
-  if (Array.isArray(a) && Array.isArray(b)) {
-    return a.length === b.length && a.every((item, i) => deepEqualDeclarations(item, b[i]));
-  }
-
-  const left = a as Record<string, unknown>;
-  const right = b as Record<string, unknown>;
-  const leftKeys = Object.keys(left).filter((k) => left[k] !== undefined);
-  const rightKeys = Object.keys(right).filter((k) => right[k] !== undefined);
-  if (leftKeys.length !== rightKeys.length) return false;
-  return leftKeys.every((k) => deepEqualDeclarations(left[k], right[k]));
-}
-
-/**
  * Name a stack the way its author would recognise it (#5005).
  *
  * A composition error is only actionable if it says WHICH stacks disagree, and
@@ -1512,7 +1485,7 @@ function composeSingleValue(
       continue;
     }
     const held = (stacks[holder] as Record<string, unknown>)[key];
-    if (deepEqualDeclarations(held, value)) continue;
+    if (deepEqualAuthored(held, value)) continue;
 
     throw new Error(
       `composeStacks conflict: top-level key '${key}' is declared with different values by ` +


### PR DESCRIPTION
Fixes #4923

按 issue 线程中已记录的**维护者裁决(2026-08-04)**执行,纯执行、无自由裁量。

## 前提复核(对 origin/main)

裁决前提**仍然成立**,但 issue 正文的定位有一处过期:

- `renameConfigKey` **仍在 `packages/spec/src/conversions/walk.ts`**(现 283 行,issue 写的 235 行是旧行号),并未如派发单推测的那样迁移到 `registry.ts`;#5621 动的是 registry 的语义迁移条目,没搬这个 helper。
- 短路行为逐字未变:`if (config[to] != null) return null;`。
- #5516 删掉的那条 `grid_` 碰撞不在本单的别名族里;issue 点名的 5 条 fixture(`flow-node-crud-object-alias`、`flow-node-map-flow-alias`、`flow-node-subflow-flow-alias`、`flow-node-notify-config-aliases` 及其 `liftNotifySourceShape`)**全部仍在**,`after` 半边仍写着被遮蔽的旧拼法。

另有一处仓库内的**主动指认**:`retry-policy-converged` 的注释原文写着「#4923 is queued to revisit that shadowing rule — this entry deliberately relies on the shared helper's semantics rather than open-coding its own, so it moves with that ruling」。这句话直接回答了「裁决该落在哪个 helper 上」——落在共享 helper,而不是只落在 `renameConfigKey`。因此实现落在 `renameKey`,由 `renameConfigKey` 委托,`renameKey` 的其余调用方(datasource driver-config 别名、page:header `description`、`retryDelayMs`)随之统一,不留第二套方言。

## 改了什么

**按值拆分**(`walk.ts`):`renameKey` 遇到两个拼法同时存在时——

- **值结构相等** → 删掉旧拼法 + 照常发 notice。旧拼法不携带规范键没有的信息,属无损卫生,在 D2 契约内;顺带让转换在**形状和 notice 上都幂等**(重放命中「from 不存在」分支)。
- **值不同** → 返回 `null`,**双键都保留**,不发 notice。作者给一个槽写了两个不同的值,这是真歧义,升级工具替客户择一等于改了客户没同意的配置。活下来的这一对,正是 strict 门能够**点名双键**拒绝的依据。

相等性用**结构比较**而非 `===`:两处分别写出的 `{ status: 'stale' }` 是同一份声明。这个谓词正是 #5005 的 compose 已经在用的那个(「same value composes fine」),抽到 `shared/deep-equal.ts` 共用,免得两个面对「这两个值算不算同一个」给出不同答案(未加入 `shared/index`,不动公共 API 面)。抽取时补了递归深度上限:两个调用点在触顶时都退化为「不相等」,即 compose 报冲突、转换保留双键——都是**朝响的方向**降级,不会静默丢作者的值。

`liftNotifySourceShape` 同理(issue 点名):嵌套部件与扁平键**重复**则算已交代、`source` 照常删除;**不一致**则整个节点**原样不动**(连无歧义的那半也不抬),让 `source` 完整抵达 strict 契约。`wait` 节点的松散键 lift **刻意不纳入**,并在注释里写明理由:它是**跨位置搬迁**、且一个 target 对多个候选名,与「一个槽的两种拼法」不是同一个问题,扩张需要另一次裁决。

**fixture 按新语义修正**:原来 5 条 fixture 的 `after` 半边都靠「值不同」才恰好维持原状,但它们的注释写的是「canonical 已存在 → 别名原样留下」——那是旧规则的措辞,且只覆盖了两分支中的一支。逐条改为:歧义节点改用真正不同的值(`object: 'ticket'` 而非 `'ignored'`,后者读起来像「这个值被忽略」,在新规则下恰是误导),并各补一个**等值节点**演示删除。notify 的 n3 由此从「抬一半、丢 source」变成「原样不动」,n4 新增演示等值冗余,`expectedNotices` 7 到 8。

**批 9 guidance 同步措辞**:活下来的孪生键不再是「dead」——转换现在会删掉等值的那种,所以能抵达该 parse 的键必然携带规范键没有的值。每条处方改为**点名双键 + 要求作出决定**(`builtin-node-config.zod.ts` CRUD 与 `map`、`io-node-config.zod.ts` notify 五条、`schemaless-node-config.zod.ts` script 与 subflow)。

**Rider(#5511)**:protocol-15 `page-component-visibility-to-visibleWhen` 的就地走查换成 #5509 的 `mapPageComponents`,25 行手写遍历变 2 行。

## 验证

**先证红(方向在跑之前就写死在测试注释里)。** 把 `renameKey` 的规则临时还原成旧语义(保留 import,确保红是行为红不是编译红)后跑新增的 7 条:

```
× deletes an alias whose value EQUALS the canonical key, and emits a notice
× compares STRUCTURALLY — two separately-authored identical filters are one declaration
× is idempotent in shape AND notices — the deduped result replays to itself
✓ keeps BOTH spellings when the values differ — the upgrade tool does not choose
× judges each pair on its own value — one twin dedupes while its neighbour survives
× applies the same rule one level up, on a plain dict rename (page header)
× the surviving pair is refused by the strict gate with BOTH keys named
Tests  6 failed | 1 passed
```

**这里要如实说明:两个方向的证红结构并不对称,报告模板预设的「两边都 before-red」在本单不成立。**

- **等值 → 删除 + notice**:真的 before-red / after-green,如上 6 条。
- **异值 → 双保留**:那唯一一条 `✓` 就是它。旧代码对**所有**成对情形都保留双键,所以「双保留」这半**改前改后都是绿的**——它是**回归钉**,不是变更证明。这一方向真正变的是**理由**和**读这条理由的处方**,所以证红落在 strict 门那条上(`not.toMatch(/already won and this key is dead/)`),旧 guidance 的原文正是 `so a surviving object means objectName already won and this key is dead`,红得干净。

**Rider 等价性**:按 #5511 的验收口径,由**既有 fixture** 判定。`pageComponentVisibilityToVisibleWhen` 的 fixture 一个字节未动(diff 里 `apply` 之后直接进 `fixture:`),在全量跑中保持绿。路径构造也逐字相同:`mapPageComponents` 产出 `pages[i].regions[j].components[k]`,与原手写的 `path + .regions[ri].components[ci]`(path = `pages[pi]`)一致;非数组 `regions`/`components`、非 dict region/component 的短路分支也一一对应。**无 fixture 需要修改,故不触发 stop-and-report。**

**绿跑**

```
pnpm --filter @objectstack/spec test
  Test Files  317 passed (317)
  Tests  8090 passed (8090)          # 基线 8082,+8 为本单新增

pnpm --filter @objectstack/spec typecheck
  tsc --noEmit && check:test-typecheck: OK

pnpm --filter @objectstack/spec check:generated
  ✓ All 10 generated artifacts are up to date.

node scripts/check-nul-bytes.mjs
  OK (scanned 5610 tracked text file(s); no raw ASCII control bytes)
```

消费半径已按「规则的调用方」而非「改动的包」扫过:`metadata` / `objectql` / `service-automation` / `service-datasource` / `metadata-protocol` / `lint`(即 `applyConversions` 系列与 `normalizeStackInput` 的全部调用方)。

## 生成物

`check:generated` 十项全绿,**没有任何生成物移动**——本单改的是转换的 `apply` 行为与 fixture,而 `spec-changes.json` / `upgrade-guide` 投影的是条目的 id / surface / summary / toMajor,这些一个没动。

`packages/spec/authorable-surface.base.json` 在本地 build 时被 `gen:schema` 重锚了(`baseRev` 指向新的 main,并带进 `api/Discovery:scoping` 等**别人已合并的**键)——与本单无关,按 #5358 已 `git checkout` 剔除,未进提交。

## 风险与边界

- **对存量元数据是「删键」**:等值分支会真的从加载结果里删掉旧拼法。按定义该键不携带任何规范键没有的信息,且每次删除都发 notice(与普通改名同一种 notice,`validate` 输出的种类不变)。
- **异值的存量 flow 仍会在 17 上硬停**——这是裁决明确选择的结果(不替客户择一),处方现在点名双键。
- **`wait` / `connector_action` 的 lift 未纳入**,已在代码注释中写明是「不同的问题」而非遗漏。

## Changeset

`@objectstack/spec: patch` —— 没有新增/移除任何可写的键或导出,是既有 D2 转换在一个边界情形上的行为订正,与仓库里同类行为修正(如 `webhook-authoring-surface-bridge` 给 spec 的 patch)同级。变更在升级时对作者可见,changeset 正文写清了作者看得到的两种结果。


---
_Generated by [Claude Code](https://claude.ai/code/session_018fxLGQdatPbBUvCgiVxg6D)_