### PR TITLE
fix(metadata-protocol): the ADR-0010 lock gate must not fail open (#5706)

### DIFF
--- a/.changeset/lock-gate-fail-closed.md
+++ b/.changeset/lock-gate-fail-closed.md
@@ -1,0 +1,42 @@
+---
+"@objectstack/metadata-protocol": patch
+---
+
+fix(metadata-protocol): the ADR-0010 lock gate refuses an uncertain write instead of allowing it (#5706)
+
+`getEffectiveLock` is the single source of truth for the ADR-0010 §3.3 lock
+gate, and both of its callers are write-path admission — `assertLockAllowsWrite`
+(save / publish / rollback) and `assertLockAllowsDelete`. Its overlay read was
+wrapped in a bare `catch` that fell through to `lock: 'none'`.
+
+`'none'` is not a neutral placeholder there. It is the verdict "the author
+declared no protection", and `evaluateLockForWrite` / `evaluateLockForDelete`
+turn it straight into "allow". So a `sys_metadata` read that **failed** became a
+write that was **performed**, on an item whose overlay row declared it
+protected. Measured before the fix, with the overlay row carrying `_lock` and
+only the gate's own read rejecting: `saveMetaItem` returned `success: true`
+after updating a `_lock: 'no-overlay'` item, and `deleteMetaItem` returned
+`success: true` after deleting a `_lock: 'no-delete'` one — while the very same
+rows, read successfully, produce `403 ITEM_LOCKED`. The audit trail did not
+record the miscarriage either: the allowed path writes its ordinary
+`outcome: 'allowed'` row, so nothing afterwards showed the write should have
+been denied.
+
+**Wire-visible change.** When the lock state cannot be read, `save`, `publish`,
+`rollback` and `delete` now fail with `503` / `SERVICE_UNAVAILABLE` (the driver
+error attached as `cause`) instead of proceeding as if the item were unlocked.
+Refusing one uncertain write is the intended trade against performing one that
+had to be refused. Callers that retry on 503 need no change; callers that
+treated a successful save as proof the item was unlocked never had that
+guarantee.
+
+The discrimination reuses `rethrowUnlessMetadataStoreUnprovisioned`, introduced
+in #5705 for this file's overlay reads, rather than inventing a second
+predicate: an unprovisioned `sys_metadata` genuinely has no overlay row, so
+`'none'` is the truth and first boot still saves normally; every other error is
+an outage.
+
+Unaffected, and covered by regression tests: artifact-level locks (answered from
+the in-memory registry before the overlay read is reached), a genuine miss on a
+healthy store (still allowed), and control-plane kernels (`environmentId`
+undefined), which never enter either gate.

--- a/packages/metadata-protocol/src/protocol.lock-gate-fail-closed.test.ts
+++ b/packages/metadata-protocol/src/protocol.lock-gate-fail-closed.test.ts
@@ -1,0 +1,402 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// [#5706] The ADR-0010 §3.3 lock gate must not fail OPEN.
+//
+// ---------------------------------------------------------------------------
+// The defect
+// ---------------------------------------------------------------------------
+// `getEffectiveLock` is the single source of truth for the lock gate, and both
+// of its callers are write-path admission:
+//
+//   assertLockAllowsWrite   → save / publish / rollback
+//   assertLockAllowsDelete  → delete
+//
+// Its overlay read was wrapped in a bare `catch { /* DB unavailable */ }` that
+// fell through to `lock: 'none'`. `'none'` is not a neutral placeholder there —
+// it is the verdict "the author declared no protection", and
+// `evaluateLockForWrite` / `evaluateLockForDelete` turn it straight into
+// "allow". A `sys_metadata` read that FAILED therefore became a write that was
+// PERFORMED on an item whose overlay row declared it protected.
+//
+// Measured on `origin/main` before the fix, with an overlay row carrying
+// `_lock` and ONLY the gate's own read rejecting (`connect ECONNREFUSED`):
+//
+//   saveMetaItem(_lock='no-overlay')   -> RESOLVED { success: true }   (update:sys_metadata ran)
+//   deleteMetaItem(_lock='no-delete')  -> RESOLVED { success: true }   (delete:sys_metadata ran)
+//
+// while the very same rows, read successfully, produce 403 ITEM_LOCKED. The
+// audit trail does not save it either: the allowed path writes its ordinary
+// `outcome: 'allowed'` row, so nothing afterwards records that the write should
+// have been denied. (This test asserts that fact about `outcome` directly, in
+// the "the audit trail did not compensate" case — it is the reason the defect
+// was invisible.)
+//
+// ADR-0049 is fail-closed; ADR-0110 D3 is the rule that a miss and an outage
+// are different facts. Reading one as the other disarmed a protection gate.
+//
+// ---------------------------------------------------------------------------
+// The window, stated honestly
+// ---------------------------------------------------------------------------
+// NOT "the metadata store is down" — a fully dead store fails the write too.
+// The window is "the READ failed and the write still succeeded": a transient
+// error, one timed-out query, a read-replica fault, partial pool exhaustion.
+// That is exactly what `engineWithTransientLockReadFault` models: the FIRST
+// `sys_metadata` read (the gate's) rejects, every read and write after it
+// works. Narrow — and the shape is wrong at any width.
+//
+// ---------------------------------------------------------------------------
+// Reverse verification, direction predicted BEFORE running
+// ---------------------------------------------------------------------------
+// Ordinary red. Restoring the bare
+// `} catch { /* DB unavailable — fall through to 'none'. */ }` turns the
+// fail-closed cases red — measured 5 red / 7 green — and every one of the five
+// fails in exactly the shape the issue reported, with the resolved value
+// printed in the assertion message:
+//
+//   expected a rejection, but the call resolved with
+//     {"success":true,…,"message":"Saved customization overlay (env-wide, …)"}
+//     {"success":true,"reset":true,…,"message":"Customization overlay deleted — view/v1 …"}
+//
+// Predicted 4 (the four in the first describe); the fifth is the last case of
+// the artifact describe, which is itself a fail-closed assertion and only lives
+// there for narrative reasons. Recorded as measured rather than rounded to the
+// prediction.
+//
+// The seven that stay green under the restored defect are the point of the
+// other describes, and they are green for a *reason*, not by vacuum:
+//   * artifact-level locks never consult the overlay at all (the read is not
+//     reached), so they were never affected — the regression guard proves the
+//     fix did not "fix" something that was already right;
+//   * an unprovisioned `sys_metadata` still resolves to 'none' and still
+//     allows the write, which is first boot and must keep working;
+//   * a genuine miss (healthy store, no lock row) still allows the write —
+//     without this, "fail closed" could be satisfied by refusing everything.
+
+import { describe, it, expect, vi } from 'vitest';
+import { ErrorCode } from '@objectstack/spec/api';
+import { ObjectStackProtocolImplementation } from './protocol.js';
+
+/** A registry holding only what the test explicitly puts in it. */
+function registry(items: Record<string, unknown> = {}) {
+    return {
+        getObject: () => undefined,
+        getItem: (_type: string, name: string) => items[name],
+        listItems: () => [],
+        applyNavContributions: (x: unknown) => x,
+        isPackageDisabled: () => false,
+        getObjectOwner: () => undefined,
+    };
+}
+
+/** An outage: the lock row may well exist and simply was not seen. */
+const connectionRefused = () =>
+    Object.assign(new Error('connect ECONNREFUSED 10.0.0.5:5432'), { code: 'ECONNREFUSED' });
+
+/** The real driver phrasing for "the table has not been provisioned yet". */
+const missingTable = () =>
+    Object.assign(new Error('SQLITE_ERROR: no such table: sys_metadata'), { code: 'SQLITE_ERROR' });
+
+/**
+ * The stored overlay row the gate is supposed to read. `checksum` is what the
+ * optimistic-concurrency check compares against, and it must be present:
+ * without it the save is refused by a 409 from a LATER layer, which would mask
+ * whether the lock gate allowed the write at all.
+ */
+function lockedOverlayRow(lock: string) {
+    return {
+        id: 'row-1',
+        type: 'view',
+        name: 'v1',
+        state: 'active',
+        organization_id: null,
+        package_id: null,
+        checksum: 'sha256:stored-head',
+        metadata: JSON.stringify({ name: 'v1', label: 'Governed', _lock: lock, _lockReason: 'governed by ops' }),
+    };
+}
+
+type Harness = {
+    engine: any;
+    /** Every engine call, in order — the evidence that a write did or did not run. */
+    calls: string[];
+    /** Rows written to `sys_metadata_audit`. */
+    auditRows: any[];
+};
+
+/**
+ * The failure the issue is about: the FIRST `sys_metadata` read — the lock
+ * gate's own — rejects with `error`; everything after it, reads and writes
+ * alike, succeeds. `failFirstRead: false` gives the identical world with a
+ * healthy gate read, which is the control every fail-closed case is compared
+ * against.
+ */
+function engineWithTransientLockReadFault(opts: {
+    lock: string;
+    failFirstRead: boolean;
+    error?: () => unknown;
+    registryItems?: Record<string, unknown>;
+    /** Omit the overlay row entirely — a genuine "nothing is locked" miss. */
+    noOverlayRow?: boolean;
+}): Harness {
+    const calls: string[] = [];
+    const auditRows: any[] = [];
+    const row = lockedOverlayRow(opts.lock);
+    const raise = opts.error ?? connectionRefused;
+    let reads = 0;
+
+    const engine: any = {
+        registry: registry(opts.registryItems ?? {}),
+        findOne: vi.fn(async (object: string, query: any) => {
+            if (object !== 'sys_metadata') {
+                calls.push(`findOne:${object}`);
+                return null;
+            }
+            reads += 1;
+            calls.push(`findOne:sys_metadata#${reads}`);
+            if (opts.failFirstRead && reads === 1) throw raise();
+            if (opts.noOverlayRow) return null;
+            if (query?.where?.state === 'draft') return null;
+            return row;
+        }),
+        find: vi.fn(async (object: string) => { calls.push(`find:${object}`); return []; }),
+        insert: vi.fn(async (object: string, values: any) => {
+            calls.push(`insert:${object}`);
+            if (object === 'sys_metadata_audit') auditRows.push(values);
+            return { id: 'inserted', ...values };
+        }),
+        update: vi.fn(async (object: string) => { calls.push(`update:${object}`); return { ...row }; }),
+        delete: vi.fn(async (object: string) => { calls.push(`delete:${object}`); return { deleted: 1 }; }),
+        count: vi.fn(async () => 0),
+        transaction: vi.fn(async (fn: any) => fn(engine)),
+        execute: vi.fn(async () => ({})),
+        getObjectSchema: vi.fn(async () => undefined),
+    };
+    return { engine, calls, auditRows };
+}
+
+/** A protocol in TENANT scope — control-plane (`environmentId` undefined) skips both gates. */
+function protocolFor(h: Harness) {
+    return new ObjectStackProtocolImplementation(h.engine, undefined, 'env_1');
+}
+
+const save = (p: ObjectStackProtocolImplementation) =>
+    p.saveMetaItem({ type: 'view', name: 'v1', item: { name: 'v1', label: 'Edited' } } as any);
+
+const remove = (p: ObjectStackProtocolImplementation) =>
+    p.deleteMetaItem({ type: 'view', name: 'v1' } as any);
+
+/** Capture a rejection without letting a resolve pass silently. */
+async function rejection(run: () => Promise<unknown>): Promise<any> {
+    let caught: any;
+    let resolved: unknown;
+    let didResolve = false;
+    try {
+        resolved = await run();
+        didResolve = true;
+    } catch (e) {
+        caught = e;
+    }
+    expect(
+        didResolve,
+        `expected a rejection, but the call resolved with ${JSON.stringify(resolved)}`,
+    ).toBe(false);
+    return caught;
+}
+
+/** Every assertion the outage envelope owes a caller (shared with #5532). */
+function expectStoreUnavailable(caught: any) {
+    expect(caught?.status).toBe(503);
+    expect(caught?.code).toBe('SERVICE_UNAVAILABLE');
+    // ADR-0112: the wire code must be in the declared vocabulary, or the
+    // envelope fails `ApiErrorSchema.parse` at the boundary that ships it.
+    expect(ErrorCode.safeParse(caught?.code).success).toBe(true);
+    // The driver's own error rides as `cause` for the operator-side log.
+    expect((caught?.cause as any)?.code).toBe('ECONNREFUSED');
+}
+
+/** No row was written to `sys_metadata` — the write really did not happen. */
+function expectNoOverlayWrite(h: Harness) {
+    expect(h.calls).not.toContain('update:sys_metadata');
+    expect(h.calls).not.toContain('insert:sys_metadata');
+    expect(h.calls).not.toContain('delete:sys_metadata');
+}
+
+describe('[#5706] an unreadable lock state refuses the write instead of allowing it', () => {
+    it('save is refused with 503 when the gate cannot read the overlay lock', async () => {
+        const h = engineWithTransientLockReadFault({ lock: 'no-overlay', failFirstRead: true });
+
+        const caught = await rejection(() => save(protocolFor(h)));
+
+        expectStoreUnavailable(caught);
+        // The regression, verbatim: this used to resolve `{ success: true }`.
+        expectNoOverlayWrite(h);
+        // It really was the GATE's read that failed — it is the first one.
+        expect(h.calls[0]).toBe('findOne:sys_metadata#1');
+    });
+
+    it('delete is refused with 503 on the same unreadable lock state', async () => {
+        const h = engineWithTransientLockReadFault({ lock: 'no-delete', failFirstRead: true });
+
+        const caught = await rejection(() => remove(protocolFor(h)));
+
+        expectStoreUnavailable(caught);
+        expectNoOverlayWrite(h);
+        expect(h.calls[0]).toBe('findOne:sys_metadata#1');
+    });
+
+    it('a `full` lock is protected on both gates by the same read', async () => {
+        const saveH = engineWithTransientLockReadFault({ lock: 'full', failFirstRead: true });
+        const deleteH = engineWithTransientLockReadFault({ lock: 'full', failFirstRead: true });
+
+        expectStoreUnavailable(await rejection(() => save(protocolFor(saveH))));
+        expectStoreUnavailable(await rejection(() => remove(protocolFor(deleteH))));
+        expectNoOverlayWrite(saveH);
+        expectNoOverlayWrite(deleteH);
+    });
+
+    it('the audit trail did not compensate — which is why this was invisible', async () => {
+        // Pre-fix, the allowed path wrote its ordinary `outcome: 'allowed'`
+        // row, so no `outcome: 'denied'` row ever recorded that this write
+        // should have been refused. Post-fix the write never happens, so the
+        // honest audit state is NO row at all — the same semantics #5705 gave
+        // its 503 path, not a widened audit surface.
+        const h = engineWithTransientLockReadFault({ lock: 'no-overlay', failFirstRead: true });
+
+        await rejection(() => save(protocolFor(h)));
+
+        expect(h.auditRows.map((r) => r.outcome)).not.toContain('allowed');
+        expect(h.auditRows).toEqual([]);
+    });
+});
+
+describe('[#5706] the gate still reaches the verdicts it could actually establish', () => {
+    it('a readable overlay lock is still a 403 ITEM_LOCKED, not a 503', async () => {
+        // The control for every case above: same row, same protocol, healthy
+        // read. Without this, "fail closed" could be satisfied by a gate that
+        // merely stopped distinguishing anything.
+        const h = engineWithTransientLockReadFault({ lock: 'no-overlay', failFirstRead: false });
+
+        const caught = await rejection(() => save(protocolFor(h)));
+
+        expect(caught.status).toBe(403);
+        expect(caught.code).toBe('ITEM_LOCKED');
+        expect(caught.lock).toBe('no-overlay');
+        expect(caught.message).toContain('source=overlay');
+        expectNoOverlayWrite(h);
+        // The denial IS audited — this is the row the fail-open path lost.
+        expect(h.auditRows.map((r) => [r.operation, r.outcome])).toEqual([['save', 'denied']]);
+    });
+
+    it('a readable delete lock is still a 403 ITEM_LOCKED', async () => {
+        const h = engineWithTransientLockReadFault({ lock: 'no-delete', failFirstRead: false });
+
+        const caught = await rejection(() => remove(protocolFor(h)));
+
+        expect(caught.status).toBe(403);
+        expect(caught.code).toBe('ITEM_LOCKED');
+        expect(h.auditRows.map((r) => [r.operation, r.outcome])).toEqual([['delete', 'denied']]);
+    });
+
+    it('a genuine miss — healthy store, no lock row — still allows the write', async () => {
+        // "Fail closed" must not become "refuse everything". Nothing is locked
+        // here and the gate established that fact, so the save proceeds.
+        const h = engineWithTransientLockReadFault({ lock: 'none', failFirstRead: false, noOverlayRow: true });
+
+        const res: any = await save(protocolFor(h));
+
+        expect(res.success).toBe(true);
+        expect(h.calls).toContain('insert:sys_metadata');
+    });
+});
+
+describe('[#5706] the benign unprovisioned store is still not an outage', () => {
+    it('first boot: an unprovisioned sys_metadata still resolves to "unlocked" and saves', async () => {
+        // The table does not exist, so there genuinely are no overlay rows and
+        // `'none'` IS the truth. A first boot must not 503 — this is the one
+        // error class `rethrowUnlessMetadataStoreUnprovisioned` lets through.
+        const h = engineWithTransientLockReadFault({
+            lock: 'none',
+            failFirstRead: true,
+            error: missingTable,
+            noOverlayRow: true,
+        });
+
+        const res: any = await save(protocolFor(h));
+
+        expect(res.success).toBe(true);
+        expect(h.calls[0]).toBe('findOne:sys_metadata#1');
+    });
+
+    it('first boot: delete is likewise not turned into a 503', async () => {
+        const h = engineWithTransientLockReadFault({
+            lock: 'none',
+            failFirstRead: true,
+            error: missingTable,
+        });
+
+        const res: any = await remove(protocolFor(h));
+
+        expect(res.success).toBe(true);
+    });
+});
+
+describe('[#5706] artifact-level locks are unaffected — they never reach the overlay read', () => {
+    // The issue records this as a mitigation and it must stay true: a packaged
+    // `_lock` is answered from the in-memory registry BEFORE the overlay read,
+    // so it was never fail-open and must not now become a 503 either. This is
+    // the guard against "fixing" something that was already correct.
+    const packagedLock = (lock: string) => ({
+        v1: { name: 'v1', _packageId: 'pkg-governance', _lock: lock, _lockReason: 'shipped locked' },
+    });
+
+    it('a packaged `full` lock still refuses a save with 403, even mid-outage', async () => {
+        const h = engineWithTransientLockReadFault({
+            lock: 'none',
+            failFirstRead: true,
+            registryItems: packagedLock('full'),
+        });
+
+        const caught = await rejection(() => save(protocolFor(h)));
+
+        expect(caught.status).toBe(403);
+        expect(caught.code).toBe('ITEM_LOCKED');
+        expect(caught.message).toContain('source=artifact');
+        // The overlay read was never even attempted — artifact wins first.
+        expect(h.calls).not.toContain('findOne:sys_metadata#1');
+    });
+
+    it('a packaged `no-delete` lock still refuses a delete with 403, even mid-outage', async () => {
+        const h = engineWithTransientLockReadFault({
+            lock: 'none',
+            failFirstRead: true,
+            registryItems: packagedLock('no-delete'),
+        });
+
+        const caught = await rejection(() => remove(protocolFor(h)));
+
+        expect(caught.status).toBe(403);
+        expect(caught.code).toBe('ITEM_LOCKED');
+        expect(caught.message).toContain('source=artifact');
+        expect(h.calls).not.toContain('findOne:sys_metadata#1');
+    });
+
+    it('an artifact-backed item with NO packaged lock still consults the overlay — and fails closed', async () => {
+        // Measured, not assumed: the artifact branch short-circuits on ANY
+        // non-'none' packaged lock, whichever operation is being judged — it
+        // does not ask whether that lock blocks THIS operation. So the two
+        // cases above pass because the read is skipped, and this case is what
+        // proves the skip is conditional rather than universal: an
+        // artifact-backed item whose packaged `_lock` is 'none' does reach the
+        // overlay read, where the fix now applies.
+        const h = engineWithTransientLockReadFault({
+            lock: 'none',
+            failFirstRead: true,
+            registryItems: { v1: { name: 'v1', _packageId: 'pkg-governance' } },
+        });
+
+        const caught = await rejection(() => save(protocolFor(h)));
+
+        expectStoreUnavailable(caught);
+        expect(h.calls).toContain('findOne:sys_metadata#1');
+    });
+});

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -6889,6 +6889,18 @@ export class ObjectStackProtocolImplementation implements
      * case. Safe to call when `environmentId` is undefined (control-
      * plane bootstrap) — the lock check is only meaningful in tenant
      * scope and the caller is expected to also gate on `environmentId`.
+     *
+     * `'none'` is a VERDICT, not a default: both callers turn it into
+     * "allow". So it is returned only when the absence of a lock was
+     * actually established. When the overlay row cannot be read this
+     * method THROWS (#5706) rather than answering "unlocked" — see the
+     * `catch` below and {@link rethrowUnlessMetadataStoreUnprovisioned}.
+     *
+     * @throws {@link metadataStoreUnavailableError} — 503 /
+     *         `SERVICE_UNAVAILABLE`, when the lock state could not be
+     *         determined. The one non-throwing failure is an
+     *         unprovisioned `sys_metadata`, where "no overlay row" is
+     *         the truth rather than an unknown.
      */
     private async getEffectiveLock(
         type: string,
@@ -6925,8 +6937,45 @@ export class ObjectStackProtocolImplementation implements
                     return { lock: p.lock, lockReason: p.lockReason, lockSource: 'overlay' };
                 }
             }
-        } catch {
-            // DB unavailable — fall through to 'none'.
+        } catch (error) {
+            // #5706 — A LOCK GATE MUST NOT FAIL OPEN. This `catch` used to
+            // swallow every read failure and fall through to `'none'`, and
+            // `'none'` is not a neutral value here: it is the verdict "the
+            // author declared no protection", which `evaluateLockForWrite` /
+            // `evaluateLockForDelete` turn straight into "allow". So an
+            // unreadable `sys_metadata` silently converted a write that had to
+            // be refused into a write that was performed — measured on
+            // `origin/main`: with the overlay row declaring `_lock:
+            // 'no-overlay'` and only the read above failing, `saveMetaItem`
+            // returned `success: true` after an `update` on `sys_metadata`
+            // (and `deleteMetaItem` the same, on `_lock: 'no-delete'`).
+            //
+            // Note what that also costs the audit trail: the allowed path
+            // writes its ordinary `outcome: 'allowed'` row, so nothing
+            // afterwards records that this write should have been denied.
+            //
+            // The window is not "the metadata store is down" — a fully dead
+            // store fails the write too. It is "the READ failed and the write
+            // still succeeded": a transient error, a single timed-out query, a
+            // read-replica fault, partial pool exhaustion. Narrow, but the
+            // shape is wrong at any width, and it is the inverse of ADR-0049's
+            // fail-closed direction.
+            //
+            // The discrimination is the same one #5532 / PR #5705 installed for
+            // the overlay READS in this file, reused verbatim rather than
+            // reinvented: an unprovisioned `sys_metadata` genuinely has no
+            // overlay row, so `'none'` IS the truth and first boot must not
+            // explode; every other error is an outage and becomes a 503, whose
+            // `cause` carries the driver error. ADR-0010 §3.3 is the decision
+            // this defends; ADR-0110 D3 is the rule it was breaking — a miss
+            // and an outage are different facts, and here reading one as the
+            // other disarmed a protection gate.
+            //
+            // Consequence, deliberate and wire-visible: `save` / `publish` /
+            // `rollback` / `delete` now fail with 503 when the lock state
+            // cannot be read, instead of proceeding as if unlocked. Refusing
+            // one uncertain write beats performing one that had to be refused.
+            this.rethrowUnlessMetadataStoreUnprovisioned(error);
         }
         return { lock: 'none', lockReason: undefined, lockSource: undefined };
     }


### PR DESCRIPTION
Fixes #5706

## 缺陷

`getEffectiveLock` 是 ADR-0010 §3.3 锁闸门的唯一判据来源,两个调用点都是写路径准入 —— `assertLockAllowsWrite`(save / publish / rollback)与 `assertLockAllowsDelete`。它读 overlay 行的那段包在一个裸 `catch` 里,失败就落到 `lock: 'none'`。

`'none'` 在这里不是中性缺省值,而是一条**判定**:「作者没有声明保护」。`evaluateLockForWrite` / `evaluateLockForDelete` 直接把它翻译成「放行」。于是一次**读失败**变成一次**已执行的写**,而那一项的 overlay 行明明声明了保护。

## 前提复核(在 origin/main 上实测,不是照抄 issue)

裸 catch 仍在,`rethrowUnlessMetadataStoreUnprovisioned`(#5705)已可复用,fail-open 可复现。关键是把窗口建模对:issue 说的窗口不是「元数据库全挂」(全挂的话写本身也会失败),而是「**读失败但写成功**」。所以 harness 让**第一条** `sys_metadata` 读(正是闸门自己那条)以 `ECONNREFUSED` 失败,其后的读写全部正常。修复前实测:

| 场景 | 结果 |
|---|---|
| `saveMetaItem`,overlay 行 `_lock: 'no-overlay'`,闸门读失败 | **RESOLVED `success: true`**,且 `update:sys_metadata` 真的执行了 |
| `deleteMetaItem`,overlay 行 `_lock: 'no-delete'`,闸门读失败 | **RESOLVED `success: true`**,且 `delete:sys_metadata` 真的执行了 |
| 同样两行,闸门读成功 | `403 ITEM_LOCKED`(闸门本身是好的) |

审计侧也如实核过:放行路径写的是它本来就会写的 `outcome: 'allowed'` 行,所以事后没有任何记录显示这次写本该被拒 —— 这正是它长期不可见的原因。

## 修法

按 issue 建议,一处 catch,复用 #5705 刚落在同文件的 `rethrowUnlessMetadataStoreUnprovisioned`,没有发明第二个判别:未建表(`isMissingTableError`)是良性的 —— 那时确实没有 overlay 行,`'none'` 就是真相,首次启动照常;其余一律 `503` / `SERVICE_UNAVAILABLE`,驱动错误挂 `cause`。

`assertLockAllowsWrite` / `assertLockAllowsDelete` 的判定逻辑**未改动** —— 它们拿到 503 自然上抛。这一点是用测试钉住的,不是假设。

**wire 可见变化**(changeset 已写明):元数据存储读故障时,save / publish / rollback / delete 以 503 失败,而不是当作没锁去写。方向是刻意的:拒绝一次不确定的写,好过放行一次本该被拒的写。

## 反向验证(方向在跑之前就先定好)

普通的红。把裸 `catch` 放回去 —— **实测 5 红 / 7 绿**,五条全部以 issue 描述的那个形状失败,断言消息里直接印出放行的返回值:

```
expected a rejection, but the call resolved with
  {"success":true,…,"message":"Saved customization overlay (env-wide, …)"}
  {"success":true,"reset":true,…,"message":"Customization overlay deleted — view/v1 …"}
```

预测的是 4(第一个 describe 里那四条);第五条是 artifact describe 的最后一例,它本身就是一条 fail-closed 断言,只是为了叙事放在那里。按实测记录,没有凑成预测值。

保持绿的七条是有**原因**地绿,不是空绿:artifact 级锁根本走不到 overlay 读、未建表的首次启动照常保存、健康库上的真 miss 照常放行 —— 少了最后这条,「fail closed」可以靠「什么都拒」来假装满足。

## issue 的「未验证点」:还有没有别的路径读同一行锁状态

枚举了保护信封的全部消费者(`extractProtection` / `resolveLockState`,全仓仅 `protocol.ts` 内四处):

- **`resolveLockState` @ `getMetaItem`** —— **不同病**。它消费的是**已经取到**的 item,而那条读正是 #5705 修好的四处之一,已经 fail-closed;`resolveLockState` 只会看到真读出来的东西。
- **`resolveLockState` @ `getMetaItemLayered`** —— **同一个 catch 形状**,但消费方是读/展示(Studio 三层对比视图),后果类别不同。**已由 #5707 单独持有**(`finding` 标签),且那单里还留着一个未定的设计选择(整体 503,还是给 `overlay` 加「未知」第三态)。按 scope 纪律不在本 PR 修,也不重复开单。

## 验证

前台同步跑完,全部真实输出:

| 命令 | 结果 |
|---|---|
| `pnpm --filter @objectstack/metadata-protocol test` | 46 files / **431 passed** |
| `pnpm --filter @objectstack/objectql test` | 122 files / **1990 passed** |
| `pnpm --filter @objectstack/rest test` | 53 files / **760 passed** |
| `pnpm --filter @objectstack/runtime test` | 98 files / **1436 passed** |
| `pnpm check:durability-log-level` | ✓ 24 seam(s), all loud/rethrowing |
| `pnpm check:query-options-erasure` | ✓ ratchet holds, baseline verified against `e6db317` |
| `pnpm check:type-check-coverage` | ✓ DEBT ledger unmoved(本包无 `typecheck` script,带 28 错的实测 DEBT 条目) |
| `node scripts/check-nul-bytes.mjs` + 控制字符自查 grep | ✓ clean |
| `eslint`(改动的两个文件) | ✓ 0 |

objectql / rest / runtime 是按闸门的**消费半径**扫的,不是按改动包扫的。头一轮它们的「失败」全是新 worktree 里依赖没构建导致的解析错(0 条测试失败),按 AGENTS.md §9 先用 `pnpm --filter` 的 `^...` 形式构建依赖再跑,才是上面的数字。

## 范围

`packages/metadata-protocol/src/protocol.ts` 仅 `getEffectiveLock` 一区(一处 catch + 其 JSDoc)+ 新测试 + changeset。没有碰 #5705 刚落的四处 overlay 读与 `getMetaItemCached`,没有碰 rest / metadata,没有扩审计面。

（顺带记一个实测事实,不是缺陷:`getEffectiveLock` 的 artifact 分支对**任何**非 `'none'` 的打包锁都会短路,不管那把锁是否拦得住当前这个操作 —— 这与「artifact 永远压过 overlay」的既有设计一致,测试里按实测钉住了,没有按我原先的猜测去写。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7WetGmnfoXNn8cLieKKmx