### PR TITLE
fix(objectql): bound every lifecycle reap, not just the guarded ones (#5194)

### DIFF
--- a/.changeset/lifecycle-unguarded-reap-batching.md
+++ b/.changeset/lifecycle-unguarded-reap-batching.md
@@ -1,0 +1,37 @@
+---
+'@objectstack/objectql': patch
+---
+
+fix(objectql): bound every lifecycle reap, not just the guarded ones
+
+`LifecycleService.reap()` issued a single unlimited `delete(..., { multi: true })`
+per sweep for any object without a registered reap guard — no limit, no paging.
+Batching existed only on the two side paths (`guardedReap` and the Archiver,
+both 500 × 20 per sweep), whose comment gives the reason plainly: "bound one
+sweep's work, drain the backlog across sweeps". That reason never depended on a
+guard being registered.
+
+Steady state was fine — an hourly sweep deletes a small increment. The cost
+landed exactly once per table, on the first sweep after `retention` is declared
+on a table that already holds history: one DELETE scanning every historical row,
+which on SQLite holds the whole database's write lock for its duration and on
+Postgres arrives later as autovacuum debt.
+
+Unguarded reaps now run the same batched machinery the guarded ones do — an
+object with no guard is simply the empty guard intersection, which confirms
+every candidate row — so there is one reap path rather than two parallel ones.
+Candidates are read a page at a time and deleted by id, at most 500 × 20 rows
+per object per sweep, with the remainder draining on later sweeps. Cutoff and
+`retention.onlyWhen` predicates are unchanged; they now select the candidate
+read. The sweep report's `deleted` count reflects rows actually deleted this
+sweep.
+
+Two consequences worth knowing:
+
+- A reap fires one `afterDelete` hook per reaped row instead of one per object
+  per sweep. Every lifecycle-declaring platform object is in the audit writer's
+  `SKIP_OBJECTS`, and `sys_file` already reaped per id via its guards, so no
+  object in the platform changes its audit output.
+- An engine that does not implement `find` cannot page and keeps the previous
+  single bulk DELETE, so retention enforcement never silently stops on it. Every
+  real engine implements `find`.

--- a/packages/objectql/src/lifecycle/lifecycle-service.test.ts
+++ b/packages/objectql/src/lifecycle/lifecycle-service.test.ts
@@ -361,23 +361,35 @@ describe('LifecycleService.sweep — reap guard', () => {
     expect(report.errors).toEqual([{ object: 'sys_file', error: 'storage unreachable' }]);
   });
 
-  it('a guard on one object never changes the blind reap of others (regression pin)', async () => {
-    const { engine, deletes } = captureEngine(
+  it('a guard on one object is never consulted for the reap of others (regression pin)', async () => {
+    // [#5194] This pin used to read "sys_job_run: classic blind reap" and
+    // assert the unbounded `multi: true` DELETE — the exact limb #5194 removed,
+    // so keeping the assertion would have kept it passing on an empty result.
+    // The property it exists for is untouched and now sharper: an UNGUARDED
+    // object runs the same batched machinery with an empty guard list, so
+    // "can another object's guard reach this reap?" is a live question rather
+    // than a moot one. It must not, and it is never even consulted.
+    const guard = vi.fn(async () => []);
+    const { engine, deletes, finds } = captureEngine(
       [
         ...guarded,
         { name: 'sys_job_run', lifecycle: { class: 'telemetry', retention: { maxAge: '30d' } } },
       ],
-      { findImpl: () => [] },
+      { findImpl: (object) => (object === 'sys_job_run' ? [{ id: 'j1' }] : []) },
     );
     const svc = service(engine);
-    svc.registerReapGuard('sys_file', async () => []);
+    svc.registerReapGuard('sys_file', guard);
 
     const report = await svc.sweep();
 
-    // sys_file: no candidates → no delete. sys_job_run: classic blind reap.
-    expect(deletes).toHaveLength(1);
-    expect(deletes[0].object).toBe('sys_job_run');
-    expect(deletes[0].where).toEqual({ created_at: { $lt: isoCutoff('30d') } });
+    // sys_file: no candidates → nothing to confirm, nothing deleted.
+    expect(guard).not.toHaveBeenCalled();
+    // sys_job_run: read on its own cutoff, deleted by id, guard-free.
+    expect(finds.map((f) => f.object)).toEqual(['sys_file', 'sys_job_run']);
+    expect(finds[1].where).toEqual({ created_at: { $lt: isoCutoff('30d') } });
+    expect(deletes).toEqual([
+      { object: 'sys_job_run', where: { id: 'j1' }, multi: true, context: { isSystem: true, positions: [], permissions: [] } },
+    ]);
     expect(report.errors).toEqual([]);
   });
 
@@ -625,6 +637,141 @@ describe('LifecycleService.sweep — reap guard composition', () => {
   });
 });
 
+describe('LifecycleService.sweep — unguarded reap batching (#5194)', () => {
+  /** An ordinary lifecycle object: retention declared, NO reap guard. */
+  const plain: LifecycleObjectLike[] = [
+    { name: 'sys_job_run', lifecycle: { class: 'telemetry', retention: { maxAge: '30d' } } },
+  ];
+
+  /**
+   * An engine whose rows really disappear, so "what one sweep did" and "what
+   * the next sweep still finds" are both observable. Deletion is by id through
+   * a Map (O(1)) — the ceiling case drives 10k deletes and an array scan per
+   * delete would make this test quadratic.
+   */
+  function storeEngine(objects: LifecycleObjectLike[], rowCount: number) {
+    const store = new Map<string, Record<string, unknown>>();
+    for (let i = 0; i < rowCount; i++) store.set(`r${i}`, { id: `r${i}`, created_at: '2020-01-01T00:00:00Z' });
+    const captured = captureEngine(objects, {
+      findImpl: (_object, options) => {
+        const limit = (options?.limit as number) ?? store.size;
+        const page: Array<Record<string, unknown>> = [];
+        for (const row of store.values()) {
+          if (page.length >= limit) break;
+          page.push(row);
+        }
+        return page;
+      },
+      deleteImpl: (_object, options) => {
+        const id = options?.where?.id as string | undefined;
+        const existed = id !== undefined && store.delete(id);
+        return { deletedCount: existed ? 1 : 0 };
+      },
+    });
+    return { ...captured, store };
+  }
+
+  it('bounds the FIRST sweep over a large backlog, and drains the rest on later sweeps', async () => {
+    // The #5194 scenario: retention declared on a table that already holds
+    // history. Before this change that first sweep was ONE unbounded DELETE
+    // over every historical row — a long write transaction (SQLite locks the
+    // whole database for it). It is now 20 pages of 500, by id, and the
+    // remainder waits for the next sweep.
+    const CEILING = 500 * 20;
+    const { engine, deletes, finds, store } = storeEngine(plain, CEILING + 7);
+    const svc = service(engine);
+
+    const first = await svc.sweep();
+
+    expect(finds).toHaveLength(20);                       // exactly the per-sweep page budget
+    expect(finds.every((f) => f.limit === 500)).toBe(true);
+    expect(deletes).toHaveLength(CEILING);                // …and not one row more
+    expect(first.swept[0].deleted).toBe(CEILING);         // the report says what really happened
+    expect(store.size).toBe(7);                           // backlog left standing, not lost
+
+    // Every delete named ONE row by scalar id — never a predicate, so each is a
+    // short transaction and each gets the by-id cascade path.
+    expect(deletes.every((d) => typeof d.where?.id === 'string')).toBe(true);
+    expect(deletes.every((d) => Object.keys(d.where).length === 1)).toBe(true);
+
+    const second = await svc.sweep();
+
+    expect(second.swept[0].deleted).toBe(7);              // the remainder drains next sweep
+    expect(store.size).toBe(0);
+    expect(finds).toHaveLength(21);                       // 20 + one short page, which ends the pass
+  });
+
+  it('leaves the steady state alone: a small increment is one page and one report line', async () => {
+    const { engine, deletes, finds, store } = storeEngine(plain, 3);
+
+    const report = await service(engine).sweep();
+
+    expect(finds).toHaveLength(1);                        // short page ⇒ no second read
+    expect(finds[0].where).toEqual({ created_at: { $lt: isoCutoff('30d') } });
+    expect(finds[0].context).toEqual({ isSystem: true, positions: [], permissions: [] });
+    expect(deletes.map((d) => d.where)).toEqual([{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]);
+    expect(store.size).toBe(0);
+    expect(report.swept).toEqual([
+      { object: 'sys_job_run', class: 'telemetry', policy: 'retention', cutoff: isoCutoff('30d'), deleted: 3 },
+    ]);
+    expect(report.errors).toEqual([]);
+  });
+
+  it('still honours retention.onlyWhen — the predicate moves to the candidate READ', async () => {
+    const onlyWhen: LifecycleObjectLike[] = [
+      {
+        name: 'sys_automation_run',
+        lifecycle: {
+          class: 'telemetry',
+          retention: { maxAge: '30d', onlyWhen: { status: { $in: ['completed', 'failed'] } } },
+        } as unknown as LifecycleObjectLike['lifecycle'],
+      },
+    ];
+    const { engine, finds, deletes } = storeEngine(onlyWhen, 2);
+
+    await service(engine).sweep();
+
+    // The scope narrows which rows are CANDIDATES; it is not silently dropped
+    // now that the delete addresses rows by id.
+    expect(finds[0].where).toEqual({
+      created_at: { $lt: isoCutoff('30d') },
+      status: { $in: ['completed', 'failed'] },
+    });
+    expect(deletes.map((d) => d.where)).toEqual([{ id: 'r0' }, { id: 'r1' }]);
+  });
+
+  it('an engine that cannot read rows keeps the single bulk DELETE — retention never just stops', async () => {
+    // `find` is optional on LifecycleEngineLike. Batching needs it; enforcement
+    // does not. An engine without it degrades to the pre-#5194 unbounded delete
+    // rather than losing the policy — the fail-safe for guards (skip) would be
+    // the wrong trade here, because no guard is waiting to confirm anything.
+    const { engine, deletes } = captureEngine(plain); // no findImpl → no engine.find
+
+    const report = await service(engine).sweep();
+
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0].multi).toBe(true);
+    expect(deletes[0].where).toEqual({ created_at: { $lt: isoCutoff('30d') } });
+    expect(report.skipped).toEqual([]);
+    expect(report.swept[0].deleted).toBe(3); // whatever the driver reported
+  });
+
+  it('never turns an id-less row into a predicate delete', async () => {
+    // `where: { id: undefined }` + `multi: true` is NOT a by-id delete: the
+    // engine finds no scalar id, routes to deleteMany, and runs the batch's
+    // whole cutoff predicate. With zero guards nothing else narrows the page,
+    // so this is the one place that invariant can be enforced.
+    const { engine, deletes } = captureEngine(plain, {
+      findImpl: () => [{ id: 'r0' }, { id: null }, { created_at: '2020-01-01T00:00:00Z' }],
+    });
+
+    const report = await service(engine).sweep();
+
+    expect(deletes.map((d) => d.where)).toEqual([{ id: 'r0' }]);
+    expect(report.swept[0].deleted).toBe(1);
+  });
+});
+
 describe('LifecycleService.sweep — Archiver (P3)', () => {
   const AUDIT_OBJ: LifecycleObjectLike = {
     name: 'sys_audit_log',
@@ -816,9 +963,15 @@ describe('LifecycleService.sweep — governance (P4)', () => {
   });
 
   it('tenant-scoped overrides sweep each tenant on its own window and everyone else globally', async () => {
-    const { engine, deletes } = captureEngine([TELEMETRY_OBJ]);
-    (engine as any).find = async (object: string) =>
-      object === 'sys_organization' ? [{ id: 'org_reg' }, { id: 'org_plain' }] : [];
+    // [#5194] One candidate row per pass, so each pass is observable both in
+    // the predicate it reads with and in the by-id delete it then issues.
+    const { engine, deletes, finds } = captureEngine([TELEMETRY_OBJ], {
+      findImpl: (object, options) => {
+        if (object === 'sys_organization') return [{ id: 'org_reg' }, { id: 'org_plain' }];
+        const org = (options?.where as Record<string, unknown> | undefined)?.organization_id;
+        return [{ id: org === 'org_reg' ? 'tenant_row' : 'global_row' }];
+      },
+    });
     const settings = fakeSettings(
       {},
       { org_reg: { retention_overrides: { sys_job_run: { maxAge: '2y' } } } },
@@ -826,31 +979,42 @@ describe('LifecycleService.sweep — governance (P4)', () => {
 
     await service(engine, { getSettings: () => settings }).sweep();
 
-    // One tenant-scoped delete on the regulated tenant's 2y window…
-    expect(deletes[0].where).toEqual({
+    // The per-pass predicate is carried by the candidate READ now — the passes
+    // themselves, and their windows, are unchanged.
+    const reaps = finds.filter((f) => f.object === 'sys_job_run');
+    // One tenant-scoped pass on the regulated tenant's 2y window…
+    expect(reaps[0].where).toEqual({
       created_at: { $lt: isoCutoff('2y') },
       organization_id: 'org_reg',
     });
     // …then the global 30d pass excluding it but INCLUDING NULL-org rows.
-    expect(deletes[1].where).toEqual({
+    expect(reaps[1].where).toEqual({
       created_at: { $lt: isoCutoff('30d') },
       $or: [{ organization_id: { $nin: ['org_reg'] } }, { organization_id: null }],
     });
-    expect(deletes).toHaveLength(2);
+    expect(reaps).toHaveLength(2);
+    expect(deletes.map((d) => d.where)).toEqual([{ id: 'tenant_row' }, { id: 'global_row' }]);
   });
 
   it('retention.onlyWhen survives tenant-scoped overrides on every pass', async () => {
-    const { engine, deletes } = captureEngine([
+    const { engine, deletes, finds } = captureEngine(
+      [
+        {
+          name: 'sys_automation_run',
+          lifecycle: {
+            class: 'telemetry',
+            retention: { maxAge: '30d', onlyWhen: { status: { $in: ['completed', 'failed'] } } },
+          } as any,
+        },
+      ],
       {
-        name: 'sys_automation_run',
-        lifecycle: {
-          class: 'telemetry',
-          retention: { maxAge: '30d', onlyWhen: { status: { $in: ['completed', 'failed'] } } },
-        } as any,
+        findImpl: (object, options) => {
+          if (object === 'sys_organization') return [{ id: 'org_reg' }];
+          const org = (options?.where as Record<string, unknown> | undefined)?.organization_id;
+          return [{ id: org === 'org_reg' ? 'tenant_row' : 'global_row' }];
+        },
       },
-    ]);
-    (engine as any).find = async (object: string) =>
-      object === 'sys_organization' ? [{ id: 'org_reg' }] : [];
+    );
     const settings = fakeSettings(
       {},
       { org_reg: { retention_overrides: { sys_automation_run: { maxAge: '2y' } } } },
@@ -858,18 +1022,23 @@ describe('LifecycleService.sweep — governance (P4)', () => {
 
     await service(engine, { getSettings: () => settings }).sweep();
 
+    // [#5194] `onlyWhen` narrows which rows are CANDIDATES; it rides the read
+    // that selects them, on every pass, and is not dropped now that the delete
+    // addresses rows by id.
     const predicate = { status: { $in: ['completed', 'failed'] } };
-    expect(deletes[0].where).toEqual({
+    const reaps = finds.filter((f) => f.object === 'sys_automation_run');
+    expect(reaps[0].where).toEqual({
       created_at: { $lt: isoCutoff('2y') },
       organization_id: 'org_reg',
       ...predicate,
     });
-    expect(deletes[1].where).toEqual({
+    expect(reaps[1].where).toEqual({
       created_at: { $lt: isoCutoff('30d') },
       $or: [{ organization_id: { $nin: ['org_reg'] } }, { organization_id: null }],
       ...predicate,
     });
-    expect(deletes).toHaveLength(2);
+    expect(reaps).toHaveLength(2);
+    expect(deletes.map((d) => d.where)).toEqual([{ id: 'tenant_row' }, { id: 'global_row' }]);
   });
 
   it('raises quota and growth alerts (observe-only — no extra deletes)', async () => {
@@ -1035,9 +1204,9 @@ describe('LifecycleService — retention floors (#5195)', () => {
   });
 
   it('floors a TENANT-scoped override too — the same door one scope down', async () => {
-    const { engine, deletes } = captureEngine([QUEUE_LIKE]);
-    (engine as any).find = async (object: string) =>
-      object === 'sys_organization' ? [{ id: 'org_fast' }] : [];
+    const { engine, finds } = captureEngine([QUEUE_LIKE], {
+      findImpl: (object) => (object === 'sys_organization' ? [{ id: 'org_fast' }] : []),
+    });
     const settings = fakeSettings(
       {},
       { org_fast: { retention_overrides: { app_work_queue: { maxAge: '1h' } } } },
@@ -1049,7 +1218,9 @@ describe('LifecycleService — retention floors (#5195)', () => {
 
     // The tenant pass falls back to the window that DID pass the floor (7d),
     // so no tenant can shorten its way past another package's contract.
-    expect(deletes[0].where).toEqual({
+    // [#5194] The floored window is observable on the candidate read.
+    const reaps = finds.filter((f) => f.object === 'app_work_queue');
+    expect(reaps[0].where).toEqual({
       created_at: { $lt: isoCutoff('7d') },
       organization_id: 'org_fast',
       status: 'done',
@@ -1395,6 +1566,50 @@ describe('LifecycleService teardown (#4747)', () => {
 
     expect(signalDuringAudit!.aborted).toBe(true);
     expect(report.danglingReferences?.aborted).toBe(true);
+  });
+
+  it('stop() mid-reap ends the paging loop instead of running out the page budget', async () => {
+    // [#5194] `sweep()` checks the abort bit between OBJECTS. That used to be
+    // the whole story for an unguarded reap, which was a single `await` between
+    // two such checks; it is now up to 20 pages of reads and deletes, so the
+    // loop has to check too — otherwise teardown keeps pushing writes at a
+    // datasource the host is closing, which is the #4747 defect itself.
+    const store = new Map<string, Record<string, unknown>>();
+    for (let i = 0; i < 5000; i++) store.set(`r${i}`, { id: `r${i}`, created_at: '2020-01-01T00:00:00Z' });
+    const { engine, deletes } = captureEngine(
+      [{ name: 'sys_job_run', lifecycle: { class: 'telemetry', retention: { maxAge: '30d' } } }],
+      {
+        findImpl: (_object, options) => {
+          const limit = (options?.limit as number) ?? store.size;
+          const page: Array<Record<string, unknown>> = [];
+          for (const row of store.values()) {
+            if (page.length >= limit) break;
+            page.push(row);
+          }
+          return page;
+        },
+        deleteImpl: (_object, options) => {
+          const id = options?.where?.id as string | undefined;
+          if (id !== undefined) store.delete(id);
+          return { deletedCount: 1 };
+        },
+      },
+    );
+    const svc = service(engine);
+    // Teardown lands while the first page is being deleted.
+    const original = engine.delete.bind(engine);
+    engine.delete = async (object: string, options: unknown) => {
+      svc.stop();
+      return original(object, options);
+    };
+
+    await svc.sweep();
+
+    // The page in flight finishes (it is already confirmed work), and the loop
+    // stops there rather than reading and deleting 19 more pages.
+    expect(deletes).toHaveLength(500);
+    expect(store.size).toBe(4500);
+    expect(svc.stopped).toBe(true);
   });
 
   it('stop() then start() re-arms the service — teardown is not one-way', async () => {

--- a/packages/objectql/src/lifecycle/lifecycle-service.ts
+++ b/packages/objectql/src/lifecycle/lifecycle-service.ts
@@ -25,11 +25,24 @@ import type {
  *
  * Design constraints (ADR-0057 §3.3):
  *   - One implementation, owned here — not N per-plugin sweepers.
- *   - Sweeps run under a system context (cross-tenant operator policy) and
- *     use bulk `multi: true` deletes, so at most ONE afterDelete hook fires
- *     per object per sweep — audit sees an aggregate, never per-row noise
- *     (telemetry-class sys_* objects are additionally in the audit writer's
- *     SKIP_OBJECTS, so they produce no audit rows at all).
+ *   - Sweeps run under a system context (cross-tenant operator policy).
+ *   - [#5194] Every reap is BOUNDED. Candidates are read a page at a time and
+ *     deleted by id — at most {@link REAP_BATCH_SIZE} ×
+ *     {@link REAP_MAX_BATCHES_PER_SWEEP} rows per object per sweep, with the
+ *     remainder draining across later sweeps. Unguarded objects used to issue
+ *     one `multi: true` DELETE with no limit instead: invisible in the steady
+ *     state (hourly sweeps delete a small increment), and a table-scanning long
+ *     write transaction exactly once per table — the first sweep after a
+ *     retention is declared on an already-large table. SQLite holds the whole
+ *     database's write lock for the duration of that one statement; Postgres
+ *     takes it as autovacuum debt.
+ *
+ *     Stated plainly because it is the cost of that bound: a reap now fires one
+ *     afterDelete hook PER REAPED ROW, not one per object per sweep. That is
+ *     free for today's population — every lifecycle-declaring platform object
+ *     is in the audit writer's SKIP_OBJECTS (telemetry/transient plumbing), so
+ *     it produces no audit rows either way, and `sys_file`, the one that is
+ *     audited, already reaped per id because it carries reap guards.
  *   - A sweep failure is logged and isolated; it never throws into the
  *     scheduler and never blocks other objects' policies.
  */
@@ -300,10 +313,16 @@ interface ArchiveCapableDriver {
 const ARCHIVE_BATCH_SIZE = 500;
 const ARCHIVE_MAX_BATCHES_PER_SWEEP = 20;
 
-/** Guarded reap batching — same posture as the Archiver: bound one sweep's
- * work, drain the backlog across sweeps. */
-const REAP_GUARD_BATCH_SIZE = 500;
-const REAP_GUARD_MAX_BATCHES_PER_SWEEP = 20;
+/**
+ * Reap batching — same posture as the Archiver: bound one sweep's work, drain
+ * the backlog across sweeps.
+ *
+ * [#5194] These govern EVERY reap, not just guarded ones. The reasoning the
+ * Archiver's constants carry ("bound one sweep's work") never depended on a
+ * guard being registered; the unguarded path simply had not had it applied.
+ */
+const REAP_BATCH_SIZE = 500;
+const REAP_MAX_BATCHES_PER_SWEEP = 20;
 
 /**
  * Reap guard (ADR-0057 amendment): a domain callback consulted by the Reaper
@@ -1071,7 +1090,8 @@ export class LifecycleService {
     // A guarded object is NEVER blind-deleted: without row reads the guard
     // cannot confirm, so the reap is skipped (fail-safe), not degraded.
     const guards = this.reapGuardsFor(object);
-    if (guards.length > 0 && typeof engine.find !== 'function') {
+    const canReadRows = typeof engine.find === 'function';
+    if (guards.length > 0 && !canReadRows) {
       if (!report.skipped.some((s) => s.object === object && s.reason === 'reap-guard-unsupported')) {
         report.skipped.push({ object, reason: 'reap-guard-unsupported' });
       }
@@ -1083,9 +1103,21 @@ export class LifecycleService {
       if (n === undefined) total = undefined;
       else if (total !== undefined) total += n;
     };
+    // [#5194] One reap path for every object. Zero guards is not a different
+    // algorithm — it is the empty intersection, i.e. "every candidate row is
+    // confirmed" — so the batching, the per-sweep ceiling and the by-id deletes
+    // are identical either way, and there is exactly one place where a reap
+    // decides what to delete.
+    //
+    // The fallback below is NOT the unguarded path; it is the no-`find` path.
+    // `LifecycleEngineLike.find` is optional (a two-method test double is a
+    // legal engine here), and an engine that cannot read rows cannot page
+    // through them — so it keeps the pre-#5194 single unbounded DELETE rather
+    // than losing retention enforcement entirely. Every real engine has `find`
+    // (`ObjectQL.find`, wired in `plugin.ts`), so production always batches.
     const reapWhere = async (where: Record<string, unknown>): Promise<number | undefined> =>
-      guards.length > 0
-        ? this.guardedReap(engine, object, guards, where)
+      canReadRows
+        ? this.batchedReap(engine, object, guards, where)
         : countDeleted(await engine.delete(object, { where, multi: true, context: { ...SYSTEM_CTX } }));
 
     if (tenantWindows.length === 0) {
@@ -1126,13 +1158,24 @@ export class LifecycleService {
   }
 
   /**
-   * Guarded reap: fetch candidate rows in batches, let every guard confirm
-   * (after performing external cleanup) or veto each, delete only the ids
-   * ALL of them confirmed. A guard error propagates to the per-object handler
-   * in `sweep()` — an erroring guard must never fail open into deletion. A
-   * batch that isn't fully confirmed ends the pass: vetoed rows still match
-   * the cutoff filter and would be re-fetched forever; the next sweep retries
-   * them.
+   * Batched reap: fetch candidate rows a page at a time, let every registered
+   * guard confirm (after performing external cleanup) or veto each, delete
+   * only the ids ALL of them confirmed — by id, page after page, up to
+   * {@link REAP_MAX_BATCHES_PER_SWEEP} pages. A guard error propagates to the
+   * per-object handler in `sweep()` — an erroring guard must never fail open
+   * into deletion. A batch that isn't fully confirmed ends the pass: vetoed
+   * rows still match the cutoff filter and would be re-fetched forever; the
+   * next sweep retries them.
+   *
+   * [#5194] `guards` MAY BE EMPTY, and that is the ordinary case — an object
+   * with no guard registered is the empty intersection, which confirms every
+   * candidate. The guard loop then simply does not execute, and what remains is
+   * exactly the bound this method exists to impose: read ≤ {@link
+   * REAP_BATCH_SIZE} rows, delete them by id, stop after
+   * {@link REAP_MAX_BATCHES_PER_SWEEP} pages and let the next sweep continue.
+   * The alternative — a second, guard-free batching routine beside this one —
+   * would be two implementations of one policy, drifting apart at the first
+   * change to either.
    *
    * [#5535] The intersection is computed as a narrowing pipeline rather than
    * N independent verdicts unioned at the end, because a guard's confirmation
@@ -1143,21 +1186,38 @@ export class LifecycleService {
    * everything ends the batch before the rest are called at all. The delete
    * set is the same whatever the registration order.
    */
-  private async guardedReap(
+  private async batchedReap(
     engine: LifecycleEngineLike,
     object: string,
     guards: readonly LifecycleReapGuard[],
     where: Record<string, unknown>,
   ): Promise<number> {
     let total = 0;
-    for (let batch = 0; batch < REAP_GUARD_MAX_BATCHES_PER_SWEEP; batch++) {
+    for (let batch = 0; batch < REAP_MAX_BATCHES_PER_SWEEP; batch++) {
+      // [#4747] Leg boundary, per page. `sweep()` checks the abort bit between
+      // OBJECTS; before #5194 an unguarded reap was a single `await` between
+      // two such checks, so that was the whole story. A reap is now up to
+      // REAP_MAX_BATCHES_PER_SWEEP pages of reads and deletes, and pushing them
+      // at a datasource the host is closing is precisely what #4747 stopped.
+      if (this.abort.aborted) break;
       const rows = await engine.find!(object, {
         where,
-        limit: REAP_GUARD_BATCH_SIZE,
+        limit: REAP_BATCH_SIZE,
         context: { ...SYSTEM_CTX },
       });
       if (!rows?.length) break;
-      let confirmed = rows;
+      // [#5194] A row with no usable id is dropped before anything is asked
+      // about it or done to it. It cannot be deleted by id, and it must never
+      // reach the delete below: `where: { id: undefined }` with `multi: true`
+      // is not a by-id delete at all — the engine's dispatch reads no scalar
+      // id, routes to `deleteMany`, and the predicate it would run is the
+      // batch's whole cutoff filter. The guard intersection used to drop such
+      // rows as a side effect of matching ids (see {@link idKey}); with zero
+      // guards nothing narrows, so the invariant is stated here instead of
+      // being an emergent property of a loop that may not run. Dropping them
+      // pre-guard also keeps a guard from reclaiming bytes for a row that was
+      // never deletable — the same reason #5535 narrows before it asks.
+      let confirmed = rows.filter((row) => idKey(row?.id) !== undefined);
       for (const guard of guards) {
         const ids = new Set(
           (await guard(object, confirmed)).map(idKey).filter((k): k is string => k !== undefined),
@@ -1179,7 +1239,7 @@ export class LifecycleService {
         });
       }
       total += confirmed.length;
-      if (confirmed.length < rows.length || rows.length < REAP_GUARD_BATCH_SIZE) break;
+      if (confirmed.length < rows.length || rows.length < REAP_BATCH_SIZE) break;
     }
     return total;
   }


### PR DESCRIPTION
Fixes #5194

## 前提核验(基于合并后的 origin/main `488b66c`,含 #5708)

前提成立。`lifecycle-service.ts` 中无 guard 路径仍是单条无上限删除(#5708 之后行号漂到 1089):

```
guards.length > 0
  ? this.guardedReap(engine, object, guards, where)
  : countDeleted(await engine.delete(object, { where, multi: true, context: { ...SYSTEM_CTX } }))
```

分批仍只存在于 `guardedReap` 与 Archiver 两条旁路,注释写明理由「bound one sweep's work, drain the backlog across sweeps」—— 该理由与是否注册 guard 无关。

## 取舍:统一路径成立,已采用

PM 要求优先评估「无 guard 对象直接走 guardedReap(传空 guard 列表)」。逐条核对后成立:

- **零 guard 无额外副作用**:`for (const guard of guards)` 循环体根本不执行,不会有任何多余回调;
- **批量与上限语义一致**:零 guard 时恒有 `confirmed.length === rows.length`,收敛条件退化为 `rows.length < REAP_BATCH_SIZE`(短页即排空),500 × 20 上限与余量跨 sweep 排空的语义完全相同;
- **报告计数语义**:改为「本轮实际删除行数」。原路径取 `countDeleted(driver 返回值)`,driver 不报数时为 `undefined`;分批后每次删除都是单行,逐行累加与逐行 `countDeleted` 求和等价,且恒为已知数 —— 符合 PM「如实反映本轮实际删除数」的要求;
- **行读取代价**:未测出显著代价,因此**没有**据此否决统一。我也**刻意没有**给无 guard 路径加 `fields: ['id']` 投影:那会让两条路径的读形状分叉,恰是统一要消除的东西,而收益我无法在此测量 —— 无实测支撑的优化不该现在建。

所以 `guardedReap` 更名为 `batchedReap`(它存在的意义是「限住一轮的工作量」,不是「咨询 guard」),无 guard 对象即「零 guard 的交集 = 全部确认」。一条删除路径,而不是两份并行分批实现。

⛔ 未改 driver 契约(没有加带 limit 的 delete),未碰 `engine.ts`、未碰 driver 包。

## 统一必须settle 的三件事(各有测试钉住)

1. **无 id 的候选行在 guard 之前就被丢弃**。有 guard 时,交集靠 id 匹配顺带过滤掉了这类行;零 guard 时没有任何东西收窄,而 `where: { id: undefined }` 配 `multi: true` **根本不是 by-id 删除** —— 引擎 dispatch 取不到标量 id,会路由到 `deleteMany`,跑的是这一批的整个 cutoff 谓词。放在 guard 之前丢弃,也顺带避免 guard 为一个根本删不掉的行回收字节(与 #5535「先收窄再询问」同一理由)。
2. **分页循环每页检查 #4747 的 abort 位**。`sweep()` 在**对象之间**检查;从前无 guard reap 是两次检查之间的单个 `await`,那就是全部,现在则是最多 20 页的读与删。
3. **没有 `find` 的引擎无法分页,保留原单条 bulk DELETE**。这是 no-`find` 路径,不是无 guard 路径:此时没有 guard 在等待确认,直接跳过会让 retention 彻底失效,是更坏的取舍。真实引擎恒有 `find`(`ObjectQL.find`,`plugin.ts` 接线),所以生产环境一律分批。

## 代价,写在文件里而不是留给下一个人踩

reap 现在是**每删一行一次 afterDelete hook**,不再是每对象每轮一次 —— 文件头原来那句「at most ONE afterDelete hook fires per object per sweep」自 #5535 起对 guard 对象就已不成立,这次一并改正。

对今天的对象群这是**零代价**,已逐个核对:11 个声明 lifecycle 的平台对象中,10 个在 audit writer 的 `SKIP_OBJECTS` 里(`sys_job_run`/`sys_job_queue`/`sys_automation_run`/`sys_upload_session`/`sys_device_code`/`sys_notification` 及三个 delivery/receipt/inbox、`sys_http_delivery`),本来就不产生 audit 行;唯一被审计的 `sys_file` 因带 reap guard,**本来就是逐 id 删**。

一处如实记录:每轮上限是**按 (对象, where 作用域)** 计的,租户覆写会让一个对象有 N+1 个 pass、各自一份 500 × 20 预算 —— 这是 guard 路径原有性质,本 PR 未改变。

## 测试

新增 `LifecycleService.sweep — unguarded reap batching (#5194)` 五例 + teardown 一例:大表首轮上限(10007 行 → 首轮恰好 10000、`finds` 恰好 20 页、余 7 行次轮排空)、稳态小增量(单页单读)、`onlyWhen` 谓词随候选读生效、无 `find` 回退、无 id 行不落入谓词删除、stop() 中途结束分页。

**既有 fixture 分诊(逐个判,不批量改写)**:

- **整例替换 1 例** —— `a guard on one object never changes the blind reap of others`:它钉的正是被删掉的那条肢(断言无上限 DELETE),留着会因「什么都没产生」而假绿。改为给 `sys_job_run` 真实候选行,断言它被逐 id 删且 `sys_file` 的 guard **从未被调用**(`expect(guard).not.toHaveBeenCalled()`)—— 统一之后「别的对象的 guard 会不会串进来」反而是个更尖锐的问题,不是失效问题。标题里的 "blind reap" 一并更名。
- **改写断言面 3 例** —— 两个租户 governance 用例 + 一个 retention floor 租户用例。它们本来就给 `engine.find` 供租户枚举,所以现在会走分批;被测性质(每个 pass 自己的 cutoff + org 作用域、全局 pass 用 `$or` 覆盖 NULL-org、floor 兜底)完全没变,只是谓词从 `deletes[i].where` 移到了候选读 `finds[i].where`。同时补断言逐 id 删除确实发生,比原来更强而非更弱。

**消费半径扫描**(#5046 的教训 —— 改的是 objectql,坏的 fixture 可能在别的包):`grep` 出所有驱动 `sweep()` 的测试,`packages/services/service-queue`(真实 LifecycleService 跑真实 `SysJobQueue`)与 `packages/qa/dogfood`(真实引擎)都在半径内,已全部跑过。

```
pnpm --filter @objectstack/objectql test        → Test Files 123 passed, Tests 2027 passed
pnpm --filter @objectstack/objectql typecheck   → tsc --noEmit,无输出
pnpm --filter @objectstack/service-queue test   → Test Files 3 passed, Tests 49 passed
pnpm --filter @objectstack/service-storage test → Test Files 21 passed, Tests 283 passed  (#5708 guard 用例在内)
pnpm --filter @objectstack/dogfood test         → Test Files 85 passed | 1 skipped, Tests 513 passed | 3 skipped
pnpm check:query-options-erasure                → ratchet holds;test surface 267 仍在天花板(新测试未引入 any)
node scripts/check-nul-bytes.mjs                → OK (5637 files)
eslint 两个改动文件                              → 无输出
```

**反向验证(方向先判后跑,判的是「红」,结果就是红)**:把 dispatch 改回 `guards.length > 0`(恢复无 guard 单条无上限 DELETE),9 个用例转红 —— 新增 6 例全红,3 个改写的既有租户用例全红。唯一**不**转红的是「无 `find` 引擎保留 bulk DELETE」那例,这正确:该例钉的是回退路径,对 dispatch 的改动本就不敏感。



---
_Generated by [Claude Code](https://claude.ai/code/session_01V7WetGmnfoXNn8cLieKKmx)_