### PR TITLE
fix(objectql): 悬空引用巡检为「预算没轮到」的对象建诚实桶 unscannedObjects (#5718)

### DIFF
--- a/.changeset/dangling-audit-unscanned-bucket.md
+++ b/.changeset/dangling-audit-unscanned-bucket.md
@@ -1,0 +1,48 @@
+---
+"@objectstack/objectql": patch
+---
+
+fix(objectql): the dangling-reference audit names the objects a finite row
+budget never reached, instead of dropping them (#5718)
+
+`auditDanglingReferences` stops the moment `report.scanned >= maxRows`
+(default 5 000). Every object behind that stop was never opened — and left no
+trace in the report at all. Its `dangling: []` was indistinguishable from the
+`dangling: []` of a table that really was read and really was clean, which is
+the one reading this module is written to prevent: it already carries
+`truncatedObjects` (the budget ran out INSIDE a table), `unreadableObjects`
+(the datasource refused) and `aborted` (#4747, the run was called off), and the
+module header says outright that together they are what stops `0 dangling` from
+being read as `everything is fine`. Object-level budget exhaustion was the one
+incompleteness path with no bucket of its own.
+
+| Key | Means |
+|:--|:--|
+| `unscannedObjects: string[]` | objects this run never opened — the overall row budget was gone before their turn, or the run was called off first |
+
+Notes on the shape:
+
+- **Names, in scan order** (the `prioritise` tiers), so a caller can feed them
+  straight back as `options.objects` to finish the picture on a second run.
+- **Optional in the type, always set at runtime** — same contract as `aborted`
+  and #4743's `provenance`: a hand-written report literal (a test double) still
+  compiles, while every report this module produces states the key explicitly,
+  `[]` included. `undefined` therefore never has to be guessed at; it can only
+  mean "a report shape that predates the key", never "complete".
+- **Two things are deliberately absent from it.** Objects with no reference
+  field at all (nothing referential can break on them, so their silence is
+  proven rather than assumed) and objects the caller excluded via
+  `options.objects` (that is the caller's own narrowing, not the audit missing
+  something).
+- **It does not raise the summary warning on its own**, exactly like
+  `truncatedObjects` and for the reason #4747 wrote down: a large database
+  exhausts a finite budget on every healthy run, and an alarm that always fires
+  trains its reader past the run that had a real finding. It rides itemised in
+  the warning payload and is always in the returned report.
+
+#4743 did not cause this — it made it easy to reach. Admitting the provenance
+family means nearly every object now has an auditable field, so a bounded run
+spreads the same budget over far more tables and hits the stop sooner. The
+three-tier scan order that shipped with it decides WHO gets a finite budget;
+this bucket reports who got none. Only the second one can make a bounded run
+honest.

--- a/packages/objectql/src/integrity/dangling-reference-audit.test.ts
+++ b/packages/objectql/src/integrity/dangling-reference-audit.test.ts
@@ -20,6 +20,8 @@
  *  - restore the readonly SKIP → every [#4743] test below fails: the provenance
  *    bucket goes empty and the probe is never issued
  *  - merge provenance into `dangling` → the [#4743] separation tests fail
+ *  - drop the `unscannedObjects` filing → the [#5718] tests fail: the budget
+ *    stop goes back to being silent about the objects it never opened
  */
 
 import { describe, it, expect } from 'vitest';
@@ -736,5 +738,229 @@ describe('[#4743] provenance references are audited, in their OWN bucket', () =>
     const out = await auditDanglingReferences(port);
     expect(out.provenance).toEqual([]);
     expect(out.provenanceUndetermined).toBe(0);
+  });
+});
+
+/**
+ * [#5718] A budget that runs out BETWEEN objects used to end the run in
+ * silence.
+ *
+ * `truncatedObjects` covers the budget running out INSIDE a table. The overall
+ * `maxRows` budget also runs out between tables — the loop just stopped, and
+ * every object behind the stop left no trace in the report at all. Their
+ * `dangling: []` was indistinguishable from the `dangling: []` of a table that
+ * really was read and really was clean, which is the exact confusion every
+ * bucket in this file exists to prevent.
+ *
+ * Reverse verification, direction predicted BEFORE running it: delete the
+ * `fileUnscanned` call at the budget stop and every test in this block goes
+ * RED — the list empties while the run keeps returning `dangling: []`. Note
+ * which assertion does the work: a test that only checked `dangling` (or
+ * `scanned`) would stay GREEN under the old silent break, because nothing about
+ * the findings changes. The names ARE the behaviour under test.
+ */
+describe('[#5718] objects a finite budget never reached are named, not dropped', () => {
+  /** Every object below carries a reference field, so all three are scannable. */
+  const budgetPort = (objects: AuditableObject[]) => makePort({
+    objects,
+    rows: {
+      sys_position_permission_set: [{ id: 'ppr_1', permission_set_id: 'ps_real' }],
+      showcase_task: [{ id: 't1', title: 'T', project: 'proj_real' }],
+      showcase_note: [{ id: 'n1', body: 'b', created_by: 'usr_alive' }],
+    },
+    existing: new Set([
+      'sys_permission_set ps_real', 'showcase_project proj_real', 'sys_user usr_alive',
+    ]),
+  });
+
+  it('the objects behind the stop are listed, in the order the run would have read them', async () => {
+    // Registration order is the worst case (provenance-only first, security
+    // surface last) so the list can only be right if it comes from the SCAN
+    // order — which is what makes it feedable straight back as `objects` on a
+    // second run.
+    const reads: string[] = [];
+    const port = budgetPort([note, task, binding]);
+    const findSpy = port.find.bind(port);
+    port.find = async (o, opts) => { reads.push(o); return findSpy(o, opts); };
+
+    const out = await auditDanglingReferences(port, { maxRows: 1 });
+
+    expect(reads).toEqual(['sys_position_permission_set']);   // budget bought one table
+    expect(out.scanned).toBe(1);
+    // …and the report SAYS the other two were never opened, instead of leaving
+    // them inside an empty `dangling`.
+    expect(out.unscannedObjects).toEqual(['showcase_task', 'showcase_note']);
+    expect(out.dangling).toEqual([]);
+  });
+
+  it('a run that reached everything says so explicitly — `[]`, never absent', async () => {
+    // Same reason `aborted: false` is explicit: `undefined` must never be the
+    // consumer's only clue, because it cannot tell "complete" from "a report
+    // shape that predates the key".
+    const port = budgetPort([binding, task, note]);
+
+    const out = await auditDanglingReferences(port);
+
+    expect(out.unscannedObjects).toEqual([]);
+    expect('unscannedObjects' in out).toBe(true);
+  });
+
+  it('an object with NO reference field is not listed — its silence was already proven', async () => {
+    // Nothing referential can break on it, so `prioritise` drops it before the
+    // loop and the audit reads zero rows of it by design. Filing it as
+    // "unscanned" would report a table that has nothing to find as a gap.
+    const plain: AuditableObject = {
+      name: 'plain', fields: { id: { type: 'text' }, n: { type: 'number' } },
+    };
+    const port = budgetPort([binding, plain, task]);
+
+    const out = await auditDanglingReferences(port, { maxRows: 1 });
+
+    expect(out.unscannedObjects).toEqual(['showcase_task']);
+    expect(out.unscannedObjects).not.toContain('plain');
+  });
+
+  it('an object the CALLER excluded is not listed — that narrowing is not the audit missing it', async () => {
+    const port = budgetPort([binding, task, note]);
+
+    const out = await auditDanglingReferences(port, {
+      maxRows: 1,
+      objects: ['sys_position_permission_set', 'showcase_task'],
+    });
+
+    // `showcase_note` was never on this run's list, so it is not something the
+    // run failed to reach; `showcase_task` was, and the budget ate it.
+    expect(out.unscannedObjects).toEqual(['showcase_task']);
+  });
+
+  it('a zero budget reads nothing and names EVERYTHING — the whole report is "not looked at"', async () => {
+    const reads: string[] = [];
+    const port = budgetPort([binding, task, note]);
+    const findSpy = port.find.bind(port);
+    port.find = async (o, opts) => { reads.push(o); return findSpy(o, opts); };
+
+    const out = await auditDanglingReferences(port, { maxRows: 0 });
+
+    expect(reads).toEqual([]);
+    expect(out.scanned).toBe(0);
+    expect(out.dangling).toEqual([]);   // …and this says NOTHING, which is the point
+    expect(out.unscannedObjects).toEqual([
+      'sys_position_permission_set', 'showcase_task', 'showcase_note',
+    ]);
+  });
+
+  it('a called-off run names what it never reached too, so empty keeps meaning "reached"', async () => {
+    // The bucket would be a liar otherwise: `unscannedObjects: []` next to
+    // `aborted: true` reads as "stopped early, but missed nothing". The object
+    // whose listing the teardown cut off is in the list as well — its rows were
+    // never examined either (#4747 keeps it out of `unreadableObjects`, which
+    // is a different fact: the datasource refused).
+    const signal = { aborted: false };
+    const port = makePort({
+      objects: [binding, task, note],
+      rows: { sys_position_permission_set: [{ id: 'ppr_1', permission_set_id: 'ps_gone' }] },
+      unreadable: new Set(['showcase_task']),
+    });
+    const findSpy = port.find.bind(port);
+    port.find = async (o, opts) => {
+      if (o === 'showcase_task') signal.aborted = true;   // the pool closes mid-query
+      return findSpy(o, opts);
+    };
+
+    const out = await auditDanglingReferences(port, { signal });
+
+    expect(out.aborted).toBe(true);
+    expect(out.unreadableObjects).toEqual([]);
+    expect(out.unscannedObjects).toEqual(['showcase_task', 'showcase_note']);
+    // The finding made before the teardown is untouched by any of this.
+    expect(out.dangling).toHaveLength(1);
+  });
+
+  it('called off MID-object lists what is BEHIND it, not the object it was inside', async () => {
+    // The `i` vs `i + 1` distinction, pinned: this object was opened and partly
+    // examined — its findings so far are real and `aborted` is what says the
+    // rest of it is unreliable. Listing it as "never reached" would be a
+    // different lie from the one #5718 fixes.
+    const signal = { aborted: false };
+    const port = makePort({
+      objects: [binding, task, note],
+      rows: { sys_position_permission_set: [{ id: 'ppr_1', permission_set_id: 'ps_x' }] },
+      // The probe blows up because the pool went away under it — the #4747
+      // race, which is what makes the answer "withdrawn" rather than a verdict.
+      throwingTargets: new Set(['sys_permission_set']),
+    });
+    const probeSpy = port.probe.bind(port);
+    port.probe = async (target, id) => { signal.aborted = true; return probeSpy(target, id); };
+
+    const out = await auditDanglingReferences(port, { signal });
+
+    expect(out.aborted).toBe(true);
+    expect(out.unscannedObjects).toEqual(['showcase_task', 'showcase_note']);
+    expect(out.unscannedObjects).not.toContain('sys_position_permission_set');
+  });
+
+  it('called off BEFORE the registry was enumerated: `aborted` carries it, the list is empty', async () => {
+    // The one boundary of "empty means reached", pinned rather than left to be
+    // discovered: this run never asked which objects exist, so it has no names
+    // to give. Completeness is read from `aborted === false` AND an empty list,
+    // exactly as `truncatedObjects` / `unreadableObjects` are already composed.
+    const port = budgetPort([binding, task, note]);
+
+    const out = await auditDanglingReferences(port, { signal: { aborted: true } });
+
+    expect(out.aborted).toBe(true);
+    expect(out.unscannedObjects).toEqual([]);
+  });
+
+  it('a truncated run and an unscanned run are DIFFERENT reports', async () => {
+    // The distinction this bucket exists for: `truncatedObjects` = "this table
+    // was sampled", `unscannedObjects` = "this table was not opened". Before
+    // #5718 the second case had no field of its own and borrowed nothing —
+    // it simply vanished.
+    const port = makePort({
+      objects: [task, note],
+      rows: {
+        showcase_task: [
+          { id: 't1', title: 'A', project: 'proj_real' },
+          { id: 't2', title: 'B', project: 'proj_real' },
+        ],
+        showcase_note: [{ id: 'n1', body: 'b', created_by: 'usr_alive' }],
+      },
+      existing: new Set(['showcase_project proj_real', 'sys_user usr_alive']),
+    });
+
+    // Budget of 2 rows: `showcase_task` is read to its budget (sampled), and
+    // `showcase_note` never comes up at all.
+    const out = await auditDanglingReferences(port, { maxRows: 2, rowsPerObject: 2 });
+
+    expect(out.truncatedObjects).toEqual(['showcase_task']);
+    expect(out.unscannedObjects).toEqual(['showcase_note']);
+  });
+
+  it('rides along in the warning payload, and does NOT raise the line on its own', async () => {
+    // Same judgement as `truncatedObjects` and as #4743's provenance bucket: a
+    // large database exhausts a finite budget on EVERY healthy run, so an alarm
+    // fired by this alone would be #4747's broken alarm — the reader would be
+    // trained straight past the run that had a real finding in it.
+    const quiet = budgetPort([binding, task, note]);
+    await auditDanglingReferences(quiet, { maxRows: 1 });
+    expect(quiet.warnings).toEqual([]);   // budget exhausted, nothing found, silence
+
+    const loud = makePort({
+      objects: [binding, task, note],
+      rows: {
+        sys_position_permission_set: [{ id: 'ppr_1', permission_set_id: 'ps_gone' }],
+        showcase_task: [{ id: 't1', title: 'T', project: 'proj_gone' }],
+        showcase_note: [{ id: 'n1', body: 'b', created_by: 'usr_deleted' }],
+      },
+    });
+    await auditDanglingReferences(loud, { maxRows: 1 });
+
+    const summary = loud.warnings.find((w) => w[0].includes('#4551'));
+    expect(summary).toBeDefined();
+    const meta = summary![1] as Record<string, unknown>;
+    // Itemised, not merely counted: object-scale, and a reader who has to act
+    // on it needs the names to re-run them.
+    expect(meta.unscannedObjects).toEqual(['showcase_task', 'showcase_note']);
   });
 });

--- a/packages/objectql/src/integrity/dangling-reference-audit.ts
+++ b/packages/objectql/src/integrity/dangling-reference-audit.ts
@@ -120,6 +120,30 @@ import { PLATFORM_OBJECTS_BY_PACKAGE } from '@objectstack/spec/system';
  * {@link DanglingReferenceReport.provenanceUndetermined}, on its own side of
  * the same line.
  *
+ * ## …and NEVER-REACHED is the last incompleteness (#5718)
+ *
+ * `truncatedObjects` says the budget ran out INSIDE a table. The overall budget
+ * ({@link DanglingReferenceAuditOptions.maxRows}) also runs out BETWEEN tables:
+ * the object loop simply stops, and before #5718 every object behind that stop
+ * left no trace in the report at all. `dangling: []` covered them exactly as it
+ * covered the tables that WERE read and found clean — which is precisely the
+ * reading this whole file is written to prevent.
+ * {@link DanglingReferenceReport.unscannedObjects} names them, so the report
+ * keeps saying "not looked at" wherever it cannot say "looked at and clean".
+ *
+ * #4743 did not cause this, it made it easy to reach: admitting the provenance
+ * family means nearly every object now has an auditable field, so a bounded run
+ * spreads the same budget over far more tables and hits the stop sooner. Note
+ * that `prioritise` and this bucket answer different questions — the tiers
+ * decide WHO gets a finite budget, the bucket reports who did not get any. A
+ * scan order cannot make a bounded run complete; only saying what it missed
+ * can make it honest.
+ *
+ * Like `truncatedObjects`, it does **not** raise the summary warning by itself.
+ * A large database exhausts the default 5 000-row budget on every healthy run,
+ * and an alarm that always fires is #4747's broken alarm again. It rides along
+ * in the warning payload and is always present in the returned report.
+ *
  * ## Scope — the same judgments #4441 already made, not new ones
  *
  * - **Which fields are references** is `referenceTargetOf` — the single
@@ -210,6 +234,45 @@ export interface DanglingReferenceReport {
    * disguised as a fact about the audited data.
    */
   provenanceUndetermined?: number;
+  /**
+   * [#5718] Objects this run never reached — the overall row budget
+   * ({@link DanglingReferenceAuditOptions.maxRows}) was gone before their turn,
+   * or the run was called off first. **Not one of their rows was read**, so the
+   * report holds no verdict about them whatsoever.
+   *
+   * The sibling of `truncatedObjects`, one level up: that one says "this table
+   * was sampled", this one says "this table was not opened". The two together
+   * are what keeps `dangling: []` from ever meaning more than "clean among what
+   * was read" — the difference between them is only whether the budget ran out
+   * inside a table or before it.
+   *
+   * Names are in **scan order** (the `prioritise` tiers), so a caller that
+   * wants the rest of the picture can feed them straight back as
+   * {@link DanglingReferenceAuditOptions.objects} on a second run.
+   *
+   * Two things are deliberately NOT in here, because neither is something this
+   * run failed to look at:
+   *
+   * - **Objects with no reference field at all.** Nothing referential can
+   *   break on them, so their absence from `dangling` is proven rather than
+   *   assumed — `prioritise` drops them before the loop ever sees them.
+   * - **Objects the caller excluded** via
+   *   {@link DanglingReferenceAuditOptions.objects}. Those were never asked
+   *   for; filing them would report the caller's own narrowing back to it as
+   *   an incompleteness of the audit.
+   *
+   * Empty means every object this run had queued was reached — with one
+   * boundary that {@link DanglingReferenceReport.aborted} covers instead: a run
+   * called off before it enumerated the registry has no list to give, so a
+   * consumer reads completeness from `aborted === false` AND this being empty,
+   * the same way it already composes `truncatedObjects` and `unreadableObjects`.
+   *
+   * Optional in the type only, like {@link DanglingReferenceReport.aborted} and
+   * for the same reason (a hand-written report literal predates the key); every
+   * report this module produces sets it explicitly — `[]` on a run that reached
+   * everything, never absent, so `undefined` cannot be misread as "complete".
+   */
+  unscannedObjects?: string[];
 }
 
 /** Minimal object shape the audit reads — duck-typed so tests need no registry. */
@@ -379,9 +442,11 @@ export async function auditDanglingReferences(
   // predate them); every report this function produces sets them, so the local
   // view of it requires them and no call site below has to guard.
   const report: DanglingReferenceReport &
-    Required<Pick<DanglingReferenceReport, 'provenance' | 'provenanceUndetermined'>> = {
+    Required<Pick<DanglingReferenceReport,
+      'provenance' | 'provenanceUndetermined' | 'unscannedObjects'>> = {
     scanned: 0, dangling: [], undetermined: 0, unreadableObjects: [], truncatedObjects: [],
     provenance: [], provenanceUndetermined: 0,
+    unscannedObjects: [],
     aborted: false,
   };
 
@@ -440,11 +505,34 @@ export async function auditDanglingReferences(
     return answer;
   };
 
-  objects: for (const { obj, refFields } of prioritise(all)) {
-    if (report.scanned >= maxRows) break;
+  // Materialised rather than iterated inline (#5718): once the loop stops early
+  // the report has to name what is BEHIND the stop, which needs the queue and
+  // the position in it, not just the current element.
+  const targets = prioritise(all);
+  /**
+   * [#5718] File every object from `from` onward as never-reached. Applies the
+   * caller's `only` narrowing for the same reason the loop does: an object the
+   * caller excluded was not missed by this run, it was never on its list.
+   */
+  const fileUnscanned = (from: number): void => {
+    for (let i = from; i < targets.length; i++) {
+      const n = targets[i]?.obj?.name;
+      if (!n || (only && !only.has(n))) continue;
+      report.unscannedObjects.push(n);
+    }
+  };
+
+  objects: for (let i = 0; i < targets.length; i++) {
+    const { obj, refFields } = targets[i]!;
+    // Budget gone BETWEEN objects. This one and everything behind it is never
+    // opened, and `dangling: []` about a table nobody read is not a verdict —
+    // so the run names them instead of stopping in silence (#5718).
+    if (report.scanned >= maxRows) { fileUnscanned(i); break; }
     // Called off before this object was read: it was never attempted, so it is
     // not a finding about the object — the run reports that it stopped instead.
-    if (calledOff()) { report.aborted = true; break; }
+    // The objects behind the stop are just as unread as a budget stop leaves
+    // them, so they are filed the same way; `aborted` records WHY it stopped.
+    if (calledOff()) { report.aborted = true; fileUnscanned(i); break; }
     const name = obj?.name;
     if (!name || (only && !only.has(name))) continue;
 
@@ -460,8 +548,9 @@ export async function auditDanglingReferences(
       // A read that failed because the run was called off underneath it is not
       // evidence about the datasource — the pool was closed on purpose. Filing
       // it would put a non-finding in the one bucket that must only ever hold
-      // findings (#4747).
-      if (calledOff()) { report.aborted = true; break; }
+      // findings (#4747). Its rows were never examined either, so THIS object
+      // is filed as unreached too — `from = i`, not `i + 1` (#5718).
+      if (calledOff()) { report.aborted = true; fileUnscanned(i); break; }
       // Unreadable ⇒ unknown. Recorded so the report cannot be mistaken for a
       // clean bill of health on an object nothing could look at.
       report.unreadableObjects.push(name);
@@ -483,7 +572,13 @@ export async function auditDanglingReferences(
           // An expanded record in the slot is a read shape, not an id write.
           if (typeof v === 'object') continue;
           const answer = await exists(target, v);
-          if (answer === 'called-off') { report.aborted = true; break objects; }
+          // Called off mid-object: this one WAS opened and partly examined, so
+          // it is not unreached — only the objects behind it are (#5718).
+          if (answer === 'called-off') {
+            report.aborted = true;
+            fileUnscanned(i + 1);
+            break objects;
+          }
           // [#4743] Both verdicts are routed by the field's class, not merged:
           // a provenance answer never lands in a bucket a business reference
           // shares, in EITHER direction (absent or unknown).
@@ -518,6 +613,12 @@ export async function auditDanglingReferences(
       undetermined: report.undetermined,
       unreadableObjects: report.unreadableObjects,
       truncatedObjects: report.truncatedObjects,
+      // [#5718] Itemised like `truncatedObjects` and for the same reason: this
+      // is object-scale, not row-scale, and a reader who has to act on it needs
+      // the names to re-run them. It does not appear in the condition above —
+      // a bounded run on a large database exhausts its budget every time, and
+      // an alarm that always fires is #4747's broken alarm.
+      unscannedObjects: report.unscannedObjects,
       // Carried into the log line too: findings from a run that stopped early
       // are real, but its silence about everything else is not a verdict.
       aborted: report.aborted,


### PR DESCRIPTION
Fixes #5718

## 问题

`packages/objectql/src/integrity/dangling-reference-audit.ts` 主循环在
`report.scanned >= maxRows`(默认 `DEFAULT_MAX_ROWS = 5_000`)时直接 `break`,
其后所有对象**既没被读、也没进任何桶**。它们的 `dangling: []` 与「真的读过且
干净」的表在报告里完全无法区分 —— 而这正是本文件所有诚实桶存在的理由:

| 已有桶 | 覆盖的不完整路径 |
|:--|:--|
| `truncatedObjects` | 某张表**内部**的行预算用完,只看了样本 |
| `unreadableObjects` | 试着读了,数据源不给 |
| `aborted`(#4747) | 运行被叫停 |

「整张表没轮到」是唯一没有对应桶的一条 —— 模块头注释原话:*Together they are
what stops `0 dangling` from ever being read as `everything is fine`*。

## 改动

新增 `unscannedObjects: string[]`,在主循环每一处提前退出前把未轮到的对象名记下:

- **按扫描顺序**(#5719 落地的 `prioritise` 三档:安全面 → 业务引用 → 仅溯源),
  所以调用方可以把它直接回喂 `options.objects` 续跑,补齐画面。
- **类型 optional,运行时永远赋值** —— 与 `aborted`、#4743 的 `provenance`
  同一契约:手写 report 字面量(测试替身)仍可编译;而本模块产出的每一份报告
  都显式写入,走到底就是 `[]`,永不缺席。因此 `undefined` 不需要被猜,它只可能
  意味着「旧报告形状」,绝不会意味着「完整」。
- **两类刻意不入桶**:①无任何引用字段的对象 —— `prioritise` 在循环前就丢弃了
  它们,它们不出现在 `dangling` 里是被**证明**的而非假设的;②调用方用
  `options.objects` 排除的对象 —— 那是调用方自己的收窄,把它报回去等于把调用方
  的选择说成巡检的漏看。
- **不单独抬告警**,与 `truncatedObjects` 同族:大库每次健康运行都会耗尽预算,
  常亮告警就是 #4747 的坏警报,会把读者训练得跳过那一行。它在告警载荷里**逐项**
  带出(对象量级而非行量级,读者要拿名字去续跑),并始终留在返回的报告里。
- **被叫停的运行同样填桶**:否则 `unscannedObjects: []` 与 `aborted: true` 并排
  会读成「早停了但什么都没漏」。唯一边界是**在枚举注册表之前**就被叫停 —— 那时
  没有名单可给,由 `aborted` 承担,已用一条测试把这个边界钉住而不是留给下一个人踩。

与 #5719 的关系:#4743 不是成因,只是把这条路径抬到「容易踩到」—— 溯源族入巡检
后几乎每个对象都有可审计字段,同样的预算摊到多得多的表上,提前 break 的概率显著
上升。三档 `prioritise` 决定**谁**拿到有限预算,本桶报告**谁一点也没拿到**,两件
事独立:扫描顺序无法让有界运行变完整,只有说出漏了什么才能让它诚实。

## 反向验证(方向在跑之前就预测好了)

预测:删掉预算处的 `fileUnscanned(i)` → 依赖预算停的用例转红;不依赖它的用例
(显式 `[]`、被叫停、枚举前叫停)保持绿。实测完全一致:

```
× the objects behind the stop are listed, in the order the run would have read them
× an object with NO reference field is not listed — its silence was already proven
× an object the CALLER excluded is not listed — that narrowing is not the audit missing it
× a zero budget reads nothing and names EVERYTHING — the whole report is "not looked at"
× a truncated run and an unscanned run are DIFFERENT reports
× rides along in the warning payload, and does NOT raise the line on its own
AssertionError: expected [] to deeply equal [ 'showcase_task', 'showcase_note' ]
Tests  6 failed | 3 passed | 29 skipped (38)
```

第二处限位单独验:只删 abort 分支的 `fileUnscanned(i)` →
`a called-off run names what it never reached too` 单独转红
(`expected [] to deeply equal [ 'showcase_task', 'showcase_note' ]`),其余保持绿。

注意这里断言的选择是关键:**只断言 `dangling` 或 `scanned` 的测试在旧的静默
break 下同样是绿的** —— 发现数一个都不变。名字本身才是被测行为。

## 测试证据

```
pnpm --filter @objectstack/objectql exec vitest run \
  src/integrity/dangling-reference-audit.test.ts \
  src/engine-dangling-reference-audit.test.ts --maxWorkers=2
 Test Files  2 passed (2)
      Tests  45 passed (45)

# 新增 [#5718] 块 10 例全绿
 Tests  10 passed | 29 skipped (39)

pnpm --filter @objectstack/objectql test        # 全包
 Test Files  123 passed (123)
      Tests  2031 passed (2031)

pnpm --filter @objectstack/objectql typecheck   # tsc --noEmit,无输出即通过
```

门禁:

```
check:nul-bytes                OK (5641 tracked text files, no raw control bytes)
check:query-options-erasure    ratchet holds, baseline verified against 5e3c83b
check:engine-double-contract   OK — 27 pinned, 65 DEBT, 1 exempt
check:type-check-coverage      OK — 63/78 packages
check:durability-log-level     OK — 24 seams, all loud
eslint (两个改动文件, --no-inline-config)  clean
```

## 改动面

- `packages/objectql/src/integrity/dangling-reference-audit.ts`(主循环 + 报告类型)
- `packages/objectql/src/integrity/dangling-reference-audit.test.ts`(新增 `[#5718]` 块 10 例)
- `.changeset/dangling-audit-unscanned-bucket.md`(patch)

未碰 `engine.ts` / `lifecycle-service.ts`(有其他 dev 在飞),未碰
`content/docs/releases/`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01V7WetGmnfoXNn8cLieKKmx)_