### PR TITLE
fix(metadata): `capabilities.write` 同时约束 `save()` —— 可写 datasource loader 必须实现写入与删除两半 (#5654)

### DIFF
--- a/.changeset/metadata-loader-save-contract.md
+++ b/.changeset/metadata-loader-save-contract.md
@@ -1,0 +1,50 @@
+---
+"@objectstack/metadata": patch
+---
+
+fix(metadata): `capabilities.write` now also binds `save()` — a writable datasource loader must implement both halves of the write (#5654)
+
+#5276 (shipped in v17.0.0-rc) made `capabilities.write` binding on `delete()`:
+a loader declaring `protocol: 'datasource:'` with `capabilities.write: true`
+and no `delete()` is refused at registration, because `unregister()` used to
+skip it silently and announce the deletion anyway. The gate stopped there, so
+**one declaration was binding at one end of an item's life and decorative at
+the other**.
+
+`MetadataManager.register()` had the identical hole one direction over. Its
+persistence loop read `loader.save &&` first, so a `datasource:` loader
+declaring `capabilities.write: true` **without** a `save()` method was
+**silently skipped** — no warn, no error. `register()` then wrote the in-memory
+registry, invalidated the list cache, announced `created`/`updated` and notified
+watchers, so the caller (Studio/Setup, REST PUT, the CLI, a package publish) was
+told the write succeeded. The item read back correctly for the life of the
+process and was **gone at the next restart**, with nothing to retry it — a
+durability degradation that leaves the system looking entirely healthy.
+
+`registerLoader()`'s gate (renamed `assertWritableLoaderContract`) now requires
+**both** `save()` and `delete()` for that combination, and rejects with one
+message naming which method is missing, the consequence, and both repairs.
+`registerLoader()` is the sole writer of the loader map — the constructor's
+`config.loaders` funnel through it — so the combination can no longer reach the
+runtime and lose a write there. The `save` short-circuit inside `register()`
+survives as defensive code whose unreachability is now guaranteed by
+construction, exactly like `unregister()`'s.
+
+**Does this affect you?** Only if you register a custom metadata loader that
+declares `protocol: 'datasource:'` with `capabilities.write: true`. If it does
+and has no `save()`, registration now throws where it previously succeeded and
+quietly discarded your writes. Two ways to fix it, both stated in the error:
+
+1. implement
+   `async save(type: string, name: string, data: any, options?: MetadataSaveOptions): Promise<MetadataSaveResult>`
+   on the loader, persisting the item into its store (`DatabaseLoader` in this
+   package is the reference implementation); or
+2. if the loader is genuinely read-only, declare `capabilities.write: false` — a
+   read-only `datasource:` loader registers without complaint and is never
+   written to in the first place.
+
+Loaders on the other protocols (`file:`, `memory:`, `http:`, `s3:`) are
+unaffected: `MetadataManager` never persists to them at runtime, so they may
+declare `capabilities.write` without a `save()`/`delete()` exactly as before.
+The one `datasource:` loader shipped in this package, `DatabaseLoader`, has
+always implemented both and is unchanged.

--- a/packages/metadata/src/loaders/loader-interface.ts
+++ b/packages/metadata/src/loaders/loader-interface.ts
@@ -73,7 +73,27 @@ export interface MetadataLoader {
   list(type: string): Promise<string[]>;
 
   /**
-   * Save metadata item
+   * Save metadata item into this loader's store.
+   *
+   * [#5654] Optional on the interface, **mandatory for a `datasource:` loader
+   * that declares `capabilities.write`** — `MetadataManager.registerLoader()`
+   * refuses to register such a loader when this method is missing, so the
+   * combination "declared writable, cannot persist" never reaches the runtime.
+   *
+   * The reason it is enforced at registration rather than tolerated at the write
+   * site: `MetadataManager.register()` persists into every writable
+   * `datasource:` loader, and it used to read `loader.save &&` first — a loader
+   * that declares it can be written to but has no `save()` made every write a
+   * silent lie. `register()` would skip it, then write the in-memory registry,
+   * invalidate the list cache, announce a `created`/`updated` event and notify
+   * watchers, so the caller is told the write succeeded; the item reads back
+   * correctly for the life of the process and is **gone at the next restart**,
+   * with nothing to retry it.
+   *
+   * Loaders on the other protocols (`file:`, `memory:`, `http:`, `s3:`) are not
+   * gated: `MetadataManager` never persists to them at runtime — `register()`
+   * filters on `datasource:` — so a missing `save()` there loses nothing.
+   *
    * @param type The metadata type
    * @param name The item name
    * @param data The data to save
@@ -89,8 +109,8 @@ export interface MetadataLoader {
   /**
    * Delete a metadata item from this loader's store.
    *
-   * [#5276] Optional on the interface, **mandatory for a `datasource:` loader
-   * that declares `capabilities.write`** — `MetadataManager.registerLoader()`
+   * [#5276, #5654] Optional on the interface, **mandatory for a `datasource:`
+   * loader that declares `capabilities.write`** — `MetadataManager.registerLoader()`
    * refuses to register such a loader when this method is missing, so the
    * combination "declared writable, cannot delete" never reaches the runtime.
    *
@@ -104,6 +124,12 @@ export interface MetadataLoader {
    * back out of this loader by the next `list()`/`get()`. `capabilities.write`
    * therefore means *both* directions of the write, on both ends of the item's
    * life — declared = enforced.
+   *
+   * One gate covers both halves: `assertWritableLoaderContract` in
+   * `metadata-manager.ts` requires `save()` **and** `delete()` for this
+   * combination and names whichever is missing. #5276 built it for `delete`;
+   * #5654 widened it to `save`, which had the identical silent skip in
+   * `register()` — see the note on `save?` above.
    *
    * Loaders on the other protocols (`file:`, `memory:`, `http:`, `s3:`) are not
    * gated: `MetadataManager` never writes to them at runtime, so it never has a

--- a/packages/metadata/src/metadata-manager-loader-delete-contract.test.ts
+++ b/packages/metadata/src/metadata-manager-loader-delete-contract.test.ts
@@ -35,6 +35,14 @@
  *      register without a `delete`, because the manager never writes to them;
  *   5. `DatabaseLoader`, the repo's only real `datasource:` loader, passes the
  *      gate unchanged.
+ *
+ * [#5654] The gate this file pins has since been widened — it is
+ * `assertWritableLoaderContract` now, and `capabilities.write` requires `save()`
+ * as well, because `register()` had the identical silent skip one direction
+ * over. Everything below still holds verbatim: these loaders all implement
+ * `save`, so `delete` is the only thing missing and the message is unchanged.
+ * The `save` half is pinned next door in
+ * `metadata-manager-loader-save-contract.test.ts`.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/packages/metadata/src/metadata-manager-loader-save-contract.test.ts
+++ b/packages/metadata/src/metadata-manager-loader-save-contract.test.ts
@@ -1,0 +1,350 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #5654 — the `save` half of the same gate #5276 built for `delete`.
+ *
+ * `register()` persists into every writable `datasource:` loader, and it read
+ * `loader.save &&` FIRST: a loader declaring `protocol: 'datasource:'` with
+ * `capabilities.write: true` but implementing no `save()` was **silently
+ * skipped** — no warn, no error, nothing. `register()` then wrote the in-memory
+ * registry, invalidated the list cache, announced `created`/`updated` and
+ * notified watchers, so the caller was told the write succeeded. The item read
+ * back correctly for the life of the process and was gone at the next restart,
+ * with nothing to retry it. Durability degradation of the exact shape AGENTS.md
+ * → "Degradation log levels" says must not even be a `warn`.
+ *
+ * #5276 (PR #5652) closed the mirror-image hole on `delete` and deliberately
+ * stopped there, which left ONE declaration binding at one end of an item's
+ * life and decorative at the other:
+ *
+ *   - delete side: declared = enforced (registration throws);
+ *   - save side:   declared ≠ enforced (registration passes, the write is lost).
+ *
+ * The fix is the same cure one direction over — `registerLoader()`'s gate,
+ * renamed `assertWritableLoaderContract`, now requires BOTH methods and says so
+ * in one message. `register()`'s `save` short-circuit survives as defensive
+ * code whose unreachability is guaranteed by construction, exactly like
+ * `unregister()`'s.
+ *
+ * What these tests pin:
+ *   1. the rejection of a `save`-less writable datasource loader, on both entry
+ *      points (constructor config and the direct `registerLoader()` call),
+ *      including that nothing is half-registered;
+ *   2. the message is actionable — it names the loader, the consequence, and
+ *      both repairs — and is the ONE text `buildWritableLoaderMissingMethodsMessage`
+ *      builds, quoted rather than paraphrased;
+ *   3. a loader missing BOTH methods is rejected once, naming both;
+ *   4. the positive case is untouched and really durable: a loader with both
+ *      methods registers, `register()` reaches its store, and the row is still
+ *      there for a fresh manager over the same store — the "restart" the silent
+ *      skip used to lose;
+ *   5. the gate's scope is exactly the combination `register()` acts on — a
+ *      read-only `datasource:` loader and every non-`datasource:` protocol
+ *      register without a `save`, because the manager never persists to them;
+ *   6. `DatabaseLoader`, the repo's only real `datasource:` loader, passes the
+ *      widened gate unchanged.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type {
+    MetadataLoadResult,
+    MetadataLoaderContract,
+    MetadataSaveResult,
+    MetadataStats,
+} from '@objectstack/spec/system';
+import type { IDataDriver } from '@objectstack/spec/contracts';
+import { MetadataManager, buildWritableLoaderMissingMethodsMessage } from './metadata-manager.js';
+import { DatabaseLoader } from './loaders/database-loader.js';
+import type { MetadataLoader } from './loaders/loader-interface.js';
+
+const logger = vi.hoisted(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+}));
+
+vi.mock('@objectstack/core', () => ({
+    createLogger: () => logger,
+}));
+
+type Protocol = MetadataLoaderContract['protocol'];
+
+/**
+ * A loader whose contract is dictated per test and whose `save`/`delete` are
+ * present or absent on demand — the axes the gate reads, and nothing else. The
+ * backing store is shared by reference so a second manager can be pointed at it
+ * to play "restart".
+ */
+function makeLoader(opts: {
+    name: string;
+    protocol: Protocol;
+    write: boolean;
+    withSave: boolean;
+    withDelete: boolean;
+    store?: Map<string, unknown>;
+}): MetadataLoader & {
+    store: Map<string, unknown>;
+    saveCalls: Array<[string, string]>;
+    deleteCalls: Array<[string, string]>;
+} {
+    const saveCalls: Array<[string, string]> = [];
+    const deleteCalls: Array<[string, string]> = [];
+    const store = opts.store ?? new Map<string, unknown>();
+    const key = (type: string, name: string) => `${type}/${name}`;
+
+    const loader: MetadataLoader & {
+        store: Map<string, unknown>;
+        saveCalls: Array<[string, string]>;
+        deleteCalls: Array<[string, string]>;
+    } = {
+        contract: {
+            name: opts.name,
+            protocol: opts.protocol,
+            capabilities: { read: true, write: opts.write, watch: false, list: true },
+        },
+        store,
+        saveCalls,
+        deleteCalls,
+        async load(type: string, name: string): Promise<MetadataLoadResult> {
+            const data = store.get(key(type, name));
+            return data === undefined ? { data: null } : { data };
+        },
+        async loadMany<T = unknown>(): Promise<T[]> {
+            return Array.from(store.values()) as T[];
+        },
+        async exists(type: string, name: string): Promise<boolean> {
+            return store.has(key(type, name));
+        },
+        async stat(): Promise<MetadataStats | null> {
+            return null;
+        },
+        async list(): Promise<string[]> {
+            return [];
+        },
+    };
+
+    if (opts.withSave) {
+        loader.save = async (type: string, name: string, data: unknown): Promise<MetadataSaveResult> => {
+            saveCalls.push([type, name]);
+            store.set(key(type, name), data);
+            return { success: true };
+        };
+    }
+
+    if (opts.withDelete) {
+        loader.delete = async (type: string, name: string): Promise<void> => {
+            deleteCalls.push([type, name]);
+            store.delete(key(type, name));
+        };
+    }
+
+    return loader;
+}
+
+/** Read the manager's private loader map — the thing registration writes. */
+const registeredLoaderNames = (mgr: MetadataManager): string[] =>
+    Array.from((mgr as unknown as { loaders: Map<string, unknown> }).loaders.keys());
+
+const messageOf = (run: () => unknown): string => {
+    try {
+        run();
+    } catch (error) {
+        return error instanceof Error ? error.message : String(error);
+    }
+    throw new Error('expected the call to throw, but it returned normally');
+};
+
+beforeEach(() => {
+    logger.info.mockClear();
+    logger.warn.mockClear();
+    logger.error.mockClear();
+    logger.debug.mockClear();
+});
+
+describe('a `datasource:` loader that declares `capabilities.write` MUST implement `save()`', () => {
+    const unsavable = () =>
+        makeLoader({
+            name: 'half_writable_store',
+            protocol: 'datasource:',
+            write: true,
+            withSave: false,
+            withDelete: true,
+        });
+
+    it('registerLoader() throws rather than accepting a loader it can never persist into', () => {
+        const mgr = new MetadataManager({ formats: ['json'], loaders: [] });
+
+        expect(() => mgr.registerLoader(unsavable())).toThrow(/half_writable_store/);
+    });
+
+    it('…and nothing is half-registered — the rejected loader is not in the map', () => {
+        const mgr = new MetadataManager({ formats: ['json'], loaders: [] });
+
+        expect(() => mgr.registerLoader(unsavable())).toThrow();
+        expect(registeredLoaderNames(mgr)).not.toContain('half_writable_store');
+    });
+
+    it('the constructor rejects it too — `config.loaders` is not a back door', () => {
+        expect(
+            () => new MetadataManager({ formats: ['json'], loaders: [unsavable()] }),
+        ).toThrow(/half_writable_store/);
+    });
+
+    it('the message names the loader, the consequence, and BOTH repairs', () => {
+        const mgr = new MetadataManager({ formats: ['json'], loaders: [] });
+        const message = messageOf(() => mgr.registerLoader(unsavable()));
+
+        // Which loader, and what it declared.
+        expect(message).toContain('half_writable_store');
+        expect(message).toContain("protocol: 'datasource:'");
+        expect(message).toContain('capabilities.write: true');
+        expect(message).toContain('implements no `save()` method');
+        // The consequence: the write is announced, never lands, and vanishes at
+        // restart while everything keeps looking healthy.
+        expect(message).toContain('`register()`');
+        expect(message).toContain('`created`/`updated`');
+        expect(message).toContain('gone at the next restart');
+        // Repair A — implement it. Repair B — stop declaring the capability.
+        expect(message).toContain('save(type: string, name: string, data: any');
+        expect(message).toContain('capabilities.write: false');
+        // …and it is the one text the builder owns, not a paraphrase of it.
+        expect(message).toBe(buildWritableLoaderMissingMethodsMessage('half_writable_store', ['save']));
+    });
+
+    it('a loader missing BOTH methods is rejected once, naming both', () => {
+        const mgr = new MetadataManager({ formats: ['json'], loaders: [] });
+        const neither = makeLoader({
+            name: 'inert_store',
+            protocol: 'datasource:',
+            write: true,
+            withSave: false,
+            withDelete: false,
+        });
+
+        const message = messageOf(() => mgr.registerLoader(neither));
+
+        expect(message).toContain('implements neither a `save()` nor a `delete()` method');
+        expect(message).toContain('save(type: string, name: string, data: any');
+        expect(message).toContain('delete(type: string, name: string)');
+        expect(message).toBe(
+            buildWritableLoaderMissingMethodsMessage('inert_store', ['save', 'delete']),
+        );
+    });
+
+    it('the `delete`-only rejection #5276 shipped still reads exactly as it did', () => {
+        const mgr = new MetadataManager({ formats: ['json'], loaders: [] });
+        const undeletable = makeLoader({
+            name: 'append_only_store',
+            protocol: 'datasource:',
+            write: true,
+            withSave: true,
+            withDelete: false,
+        });
+
+        const message = messageOf(() => mgr.registerLoader(undeletable));
+
+        expect(message).toContain('implements no `delete()` method');
+        expect(message).toContain('`unregister()`');
+        expect(message).toContain('`deleted`');
+        expect(message).not.toContain('`save()`');
+    });
+});
+
+describe('the positive case is untouched — and the write is really durable', () => {
+    it('a loader with both methods registers, is written to, and survives a restart', async () => {
+        const store = new Map<string, unknown>();
+        const writable = makeLoader({
+            name: 'writable_store',
+            protocol: 'datasource:',
+            write: true,
+            withSave: true,
+            withDelete: true,
+            store,
+        });
+
+        const mgr = new MetadataManager({ formats: ['json'], loaders: [writable] });
+        expect(registeredLoaderNames(mgr)).toContain('writable_store');
+
+        await mgr.register('object', 'account', { name: 'account' });
+        expect(writable.saveCalls).toEqual([['object', 'account']]);
+
+        // The restart the silent skip used to lose: a fresh manager holding an
+        // empty registry, reading the same store.
+        const afterRestart = new MetadataManager({
+            formats: ['json'],
+            loaders: [
+                makeLoader({
+                    name: 'writable_store',
+                    protocol: 'datasource:',
+                    write: true,
+                    withSave: true,
+                    withDelete: true,
+                    store,
+                }),
+            ],
+        });
+        expect(await afterRestart.get('object', 'account')).toEqual({ name: 'account' });
+
+        // …and the other half of the contract still works through the same gate.
+        await mgr.unregister('object', 'account');
+        expect(writable.deleteCalls).toEqual([['object', 'account']]);
+        expect(store.has('object/account')).toBe(false);
+    });
+});
+
+describe('the gate covers exactly the combination `register()` acts on', () => {
+    it('a read-only `datasource:` loader needs no `save` — nothing ever writes to it', async () => {
+        const readOnly = makeLoader({
+            name: 'reporting_replica',
+            protocol: 'datasource:',
+            write: false,
+            withSave: false,
+            withDelete: false,
+        });
+
+        const mgr = new MetadataManager({ formats: ['json'], loaders: [readOnly] });
+        expect(registeredLoaderNames(mgr)).toContain('reporting_replica');
+
+        await expect(mgr.register('object', 'account', { name: 'account' })).resolves.toBeUndefined();
+        expect(readOnly.saveCalls).toEqual([]);
+    });
+
+    it.each<Protocol>(['file:', 'memory:', 'http:', 's3:'])(
+        'a `%s` loader may declare write without a `save` — the manager never persists there',
+        (protocol) => {
+            const loader = makeLoader({
+                name: `loader_${protocol.replace(':', '')}`,
+                protocol,
+                write: true,
+                withSave: false,
+                withDelete: false,
+            });
+
+            const mgr = new MetadataManager({ formats: ['json'], loaders: [] });
+            expect(() => mgr.registerLoader(loader)).not.toThrow();
+            expect(registeredLoaderNames(mgr)).toContain(loader.contract.name);
+        },
+    );
+});
+
+describe('regression — the real `datasource:` loader is unaffected', () => {
+    /**
+     * `DatabaseLoader` declares `datasource:` + `capabilities.write` and has
+     * implemented both `save()` and `delete()` all along; the widened gate must
+     * be a no-op for it. The driver is a stub because registration touches no
+     * storage — construction and the contract are the whole surface here.
+     */
+    it('DatabaseLoader registers under the widened gate', () => {
+        const loader = new DatabaseLoader({ driver: {} as IDataDriver });
+
+        expect(loader.contract.protocol).toBe('datasource:');
+        expect(loader.contract.capabilities.write).toBe(true);
+        expect(typeof loader.save).toBe('function');
+        expect(typeof loader.delete).toBe('function');
+
+        const mgr = new MetadataManager({ formats: ['json'], loaders: [] });
+        expect(() => mgr.registerLoader(loader)).not.toThrow();
+        expect(registeredLoaderNames(mgr)).toContain('database');
+    });
+});

--- a/packages/metadata/src/metadata-manager.ts
+++ b/packages/metadata/src/metadata-manager.ts
@@ -79,27 +79,73 @@ import type { ApiEndpointMatch } from '@objectstack/spec/contracts';
 export type WatchCallback = (event: MetadataWatchEvent) => void | Promise<void>;
 
 /**
- * [#5276] The registration gate's message for a loader that declares it can be
- * written to but cannot be deleted from.
+ * [#5654] The two methods `capabilities.write` promises on a `datasource:`
+ * loader, in the order an item meets them: written by
+ * {@link MetadataManager.register}, taken back out by
+ * {@link MetadataManager.unregister}. Both are `?` on {@link MetadataLoader}
+ * because the other protocols legitimately have neither.
+ */
+export type WritableLoaderMethod = 'save' | 'delete';
+
+const WRITABLE_LOADER_METHODS: readonly WritableLoaderMethod[] = ['save', 'delete'];
+
+/** How the message names each method, and what the author has to write. */
+const WRITABLE_LOADER_METHOD_SIGNATURE: Record<WritableLoaderMethod, string> = {
+  save: 'save(type: string, name: string, data: any, options?: MetadataSaveOptions): Promise<MetadataSaveResult>',
+  delete: 'delete(type: string, name: string): Promise<void>',
+};
+
+/**
+ * [#5276, #5654] The registration gate's message for a loader that declares it
+ * can be written to but cannot actually carry out one (or both) halves of that
+ * write.
  *
  * Built here rather than inline so the gate and its tests quote one text, in the
  * shape AGENTS.md → "Degradation log levels" asks of a loud failure: the
  * **consequence** (concretely, and that the system keeps looking healthy) and
  * the **fix** (both ways out, so the author does not have to guess which one
  * their loader wants).
+ *
+ * `missing` is the subset of {@link WRITABLE_LOADER_METHODS} the loader does not
+ * implement; each one contributes its own consequence sentence, because the two
+ * failures are durability failures in opposite directions — a `save`-less loader
+ * loses the row that was never written, a `delete`-less one keeps the row that
+ * was supposed to go.
  */
-export function buildWritableLoaderMissingDeleteMessage(loaderName: string): string {
+export function buildWritableLoaderMissingMethodsMessage(
+  loaderName: string,
+  missing: readonly WritableLoaderMethod[],
+): string {
+  const missingPhrase =
+    missing.length === 2
+      ? 'implements neither a `save()` nor a `delete()` method'
+      : `implements no \`${missing[0]}()\` method`;
+
+  const consequences = missing.map((method) =>
+    method === 'save'
+      ? 'Registered as-is, every write would be a silent lie: `register()` skips a loader that cannot save, then ' +
+        'writes the in-memory registry, invalidates the list cache, announces a `created`/`updated` event and ' +
+        'notifies watchers, so the caller (Studio/Setup, REST PUT, the CLI, a package publish) is told the write ' +
+        `succeeded while nothing ever reaches \`${loaderName}\` — the item reads back correctly for the life of ` +
+        'this process and is gone at the next restart, with nothing to retry it. '
+      : 'Registered as-is, every deletion would be a silent lie: `unregister()` skips a loader that cannot delete, ' +
+        'then drops the registry entry, invalidates the list cache and announces a `deleted` event, so the caller ' +
+        '(Studio/Setup, REST DELETE, the CLI, a package teardown) is told the delete succeeded while the row stays ' +
+        `in \`${loaderName}\` and is read straight back out by the very next \`list()\`/\`get()\` — across ` +
+        'restarts, with nothing to retry it. ',
+  );
+
+  const repair = missing
+    .map((method) => `\`${WRITABLE_LOADER_METHOD_SIGNATURE[method]}\``)
+    .join(' and ');
+
   return (
     `[MetadataManager] Refusing to register metadata loader \`${loaderName}\`: it declares ` +
-    "`protocol: 'datasource:'` with `capabilities.write: true` but implements no `delete()` method. " +
+    `\`protocol: 'datasource:'\` with \`capabilities.write: true\` but ${missingPhrase}. ` +
     'A write-capable datasource loader is written to AND deleted from — `register()` persists every item into it, ' +
     'and `unregister()` has to take those rows back out again. ' +
-    'Registered as-is, every deletion would be a silent lie: `unregister()` skips a loader that cannot delete, then ' +
-    'drops the registry entry, invalidates the list cache and announces a `deleted` event, so the caller ' +
-    '(Studio/Setup, REST DELETE, the CLI, a package teardown) is told the delete succeeded while the row stays in ' +
-    `\`${loaderName}\` and is read straight back out by the very next \`list()\`/\`get()\` — across restarts, with ` +
-    'nothing to retry it. ' +
-    `Fix: either implement \`delete(type: string, name: string): Promise<void>\` on \`${loaderName}\` ` +
+    consequences.join('') +
+    `Fix: either implement ${repair} on \`${loaderName}\` ` +
     '(`DatabaseLoader` in this package is the reference implementation), or, if the loader is genuinely read-only, ' +
     "declare `capabilities.write: false` — a read-only `datasource:` loader registers without complaint and is " +
     'never written to in the first place.'
@@ -107,30 +153,36 @@ export function buildWritableLoaderMissingDeleteMessage(loaderName: string): str
 }
 
 /**
- * [#5276] Registration gate: a `datasource:` loader that declares
- * `capabilities.write` MUST implement `delete()`.
+ * [#5276, #5654] Registration gate: a `datasource:` loader that declares
+ * `capabilities.write` MUST implement **both** `save()` and `delete()`.
  *
- * `capabilities.write` used to mean two different things at the two ends of an
- * item's life — "persist into me" to {@link MetadataManager.register}, and
- * nothing at all to {@link MetadataManager.unregister}, which duck-typed
- * `delete` at the call site and **silently skipped** a loader that had none
- * before announcing the deletion anyway. That is the declared ≠ enforced shape
- * (Prime Directive #10), and the cure it prescribes is to enforce the
- * declaration, not to tolerate the gap: the loader is rejected at registration,
- * where the author is standing, instead of losing a row at delete time in a
- * deployment nobody is watching.
+ * `capabilities.write` used to mean three different things at the three places
+ * it is read — "persist into me" to {@link MetadataManager.register}, which
+ * duck-typed `save` and **silently skipped** a loader that had none; nothing at
+ * all to {@link MetadataManager.unregister}, which did the same with `delete`;
+ * and, on the contract, a flat promise that the store can be written. That is
+ * the declared ≠ enforced shape (Prime Directive #10), and the cure it
+ * prescribes is to enforce the declaration, not to tolerate the gap: the loader
+ * is rejected at registration, where the author is standing, instead of losing a
+ * row at write or delete time in a deployment nobody is watching.
  *
- * Scope is deliberately exactly the combination `unregister()` acts on. Other
- * protocols (`file:`, `memory:`, `http:`, `s3:`) are never written to by the
- * manager at runtime — `register()` filters on `datasource:` too — so they have
- * no deletion of their own to take back and are not gated. A `datasource:`
- * loader with `capabilities.write: false` is likewise untouched by both paths.
+ * #5276 closed the `delete` half; #5654 closed the `save` half, which was the
+ * same shape one direction over — and leaving it open meant one declaration was
+ * binding at one end of an item's life and decorative at the other.
+ *
+ * Scope is deliberately exactly the combination `register()`/`unregister()` act
+ * on. Other protocols (`file:`, `memory:`, `http:`, `s3:`) are never written to
+ * by the manager at runtime — both loops filter on `datasource:` too — so they
+ * have neither a write nor a deletion of their own to lose and are not gated. A
+ * `datasource:` loader with `capabilities.write: false` is likewise untouched by
+ * both paths.
  */
-function assertWritableLoaderCanDelete(loader: MetadataLoader): void {
+function assertWritableLoaderContract(loader: MetadataLoader): void {
   const { name, protocol, capabilities } = loader.contract;
   if (protocol !== 'datasource:' || capabilities.write !== true) return;
-  if (typeof loader.delete === 'function') return;
-  throw new Error(buildWritableLoaderMissingDeleteMessage(name));
+  const missing = WRITABLE_LOADER_METHODS.filter((method) => typeof loader[method] !== 'function');
+  if (missing.length === 0) return;
+  throw new Error(buildWritableLoaderMissingMethodsMessage(name, missing));
 }
 
 /**
@@ -600,14 +652,15 @@ export class MetadataManager implements IMetadataService {
   /**
    * Register a new metadata loader (data source)
    *
-   * [#5276] Rejects — loudly, before the loader is stored — a `datasource:`
-   * loader that declares `capabilities.write` without implementing `delete()`.
-   * This is the **only** way into `this.loaders` (the constructor's
-   * `config.loaders` come through here too), which is what lets every later
-   * delete-capability guard be defensive rather than load-bearing.
+   * [#5276, #5654] Rejects — loudly, before the loader is stored — a
+   * `datasource:` loader that declares `capabilities.write` without
+   * implementing `save()` **and** `delete()`. This is the **only** way into
+   * `this.loaders` (the constructor's `config.loaders` come through here too),
+   * which is what lets every later write-capability guard be defensive rather
+   * than load-bearing.
    */
   registerLoader(loader: MetadataLoader) {
-    assertWritableLoaderCanDelete(loader);
+    assertWritableLoaderContract(loader);
     this.loaders.set(loader.contract.name, loader);
     this.logger.info(`Registered metadata loader: ${loader.contract.name} (${loader.contract.protocol})`);
   }
@@ -662,9 +715,18 @@ export class MetadataManager implements IMetadataService {
     // FilesystemLoader is read-only at runtime — writing to it can crash in
     // read-only environments (e.g. serverless, containerized deployments).
     for (const loader of this.loaders.values()) {
-      if (loader.save && loader.contract.protocol === 'datasource:' && loader.contract.capabilities.write) {
-        await loader.save(type, name, data);
-      }
+      if (loader.contract.protocol !== 'datasource:' || !loader.contract.capabilities.write) continue;
+      // [#5654] Defensive only — unreachable for a registered loader, and read
+      // in this order on purpose: the protocol/capability test is the policy,
+      // the method test is the type narrowing. This exact combination
+      // (`datasource:` + `capabilities.write`, no `save`) is rejected by
+      // `registerLoader()`, the sole writer of `this.loaders`, so reaching this
+      // `continue` would mean a loader entered the map without passing the
+      // gate. Kept because the alternative is a TypeError on the line below,
+      // and because `save?` stays optional on the interface for the protocols
+      // the gate does not cover. Mirrors the same guard in `unregister()`.
+      if (typeof loader.save !== 'function') continue;
+      await loader.save(type, name, data);
     }
 
     // Publish metadata.{type}.created / .updated event to realtime service.


### PR DESCRIPTION
Fixes #5654

## 前提复核（先证伪，再动手）

在 `origin/main` 上逐条复核了单子的前提，**成立**：

- `packages/metadata/src/metadata-manager.ts:129` 的 `assertWritableLoaderCanDelete` 只查 `delete`；
- 同文件 `:665` 的持久化循环把 `loader.save &&` 排在最前，声明了 `protocol: 'datasource:'` + `capabilities.write: true` 却没有 `save()` 的 loader 会被**一声不吭地跳过**；
- 全仓 `datasource:` 协议的 loader 只有 `DatabaseLoader`，`save`/`delete` 都有 —— 所以今天没有用户路径踩得到，这是留给第三方 / AI 照接口新写 loader 的坑（单子的判断准确）。

## 改动

一句话：**#5276 在 `delete` 一侧立的门禁，补齐 `save` 一侧**。同一个 `capabilities.write` 声明，此前在一个生命周期端点上是强制的、在另一端是装饰性的。

- `assertWritableLoaderCanDelete` → **`assertWritableLoaderContract`**，判据从「必须有 `delete`」扩为「必须同时有 `save` 与 `delete`」，缺哪个查哪个，`registerLoader()` 注册期响亮拒绝。
- `buildWritableLoaderMissingDeleteMessage` → **`buildWritableLoaderMissingMethodsMessage(loaderName, missing)`**，措辞与 #5652 同族（后果 + 两条修法），按缺失方法各贡献一句后果：
  - 缺 `save`：`register()` 跳过 → 内存 registry 照写、listCache 照失效、`created`/`updated` 照广播、watcher 照通知 → 调用方被告知写入成功，本进程读得回，**重启即消失**；
  - 缺 `delete`：#5652 原文逐字保留（`unregister()` 宣告删除但行还在）。
  - 两个都缺时只抛一次，措辞为 `implements neither a save() nor a delete() method`，修法列出两个签名。
- 两个符号都不在包 barrel（`packages/metadata/src/index.ts` 只导出 `MetadataManager` 等），改名不触及已发布 API 面。
- `loaders/loader-interface.ts`：`save?` 补上与 `delete?` 对称的 TSDoc（对 `datasource:` + `write` 而言是强制的、注册期由 `assertWritableLoaderContract` 强制、其余协议合法缺席），`delete?` 上 #5276 那段改为指向加宽后的同一个门禁。纯注释，无签名变化 —— 详见下方「作者面」一节。

## 关于 `:665` 的 `loader.save &&` 短路（按认领评论的方向）

**保留**，并改写成与 `unregister()` 完全对称的两行 + 注释：

```ts
if (loader.contract.protocol !== 'datasource:' || !loader.contract.capabilities.write) continue;
// [#5654] Defensive only — unreachable for a registered loader ...
if (typeof loader.save !== 'function') continue;
await loader.save(type, name, data);
```

推理：`registerLoader()` 是 `this.loaders` 的**唯一写入口**（构造函数的 `config.loaders` 也走它），所以「`datasource:` + `write` + 无 `save`」对已注册 loader 不可达；但 `save?` 在 `MetadataLoader` 接口上仍是可选的（门禁不覆盖的协议合法地没有它），删掉这行的代价是下一行直接 TypeError。所以它从「策略」降级为「类型收窄」，而不是被删除 —— 与 #5652 对 `delete` 的处理一字不差。读取顺序也调成先协议/能力（策略）后方法（收窄），与删除侧一致。

## 反向验证（先定方向，再跑）

**预测**：把门禁的 `save` 一臂摘掉（`WRITABLE_LOADER_METHODS` 只留 `'delete'`），save 侧的拒绝用例应转**红**，delete 侧与作用域/正向用例应保持绿。

**实测**：`Tests 5 failed | 19 passed (24)` —— 方向一致，但**数量与预测差一个**，如实记录：转红的是 5 条而非 6 条。第 6 条（`the delete-only rejection #5276 shipped still reads exactly as it did`）钉的是「只缺 delete 时消息与 #5652 逐字一致」，摘掉 save 一臂后这条消息仍然产生，所以它**应当**保持绿 —— 它本来就不是 save 一臂的钉子。delete 侧 11 条全绿，证明本次改动没有动到 #5276 的既有语义。

## 测试

新增 `packages/metadata/src/metadata-manager-loader-save-contract.test.ts`（13 条），钉住：

1. 缺 `save` 的可写 datasource loader 在 `registerLoader()` 与构造函数两条入口都被拒，且**没有半注册**（不在私有 loaders map 里）；
2. 消息可执行：点名 loader、点名声明、点名后果（`created`/`updated` 已广播、`gone at the next restart`）、两条修法；并且 `toBe(buildWritableLoaderMissingMethodsMessage(...))` —— 是 builder 那一份文本本身，不是转述（顺带让这个 export 真正被引用）；
3. 两个方法都缺 → 只抛一次、两个都点名；
4. 正向用例的**耐久性**：带两个方法的 loader 注册 → `register()` 真的写进 store → 用同一个 store 新建一个 manager（模拟重启）仍读得到 —— 正是静默跳过会丢的那一次重启；
5. 作用域恰好是 `register()` 作用的组合：只读 `datasource:`、以及 `file:`/`memory:`/`http:`/`s3:` 四种协议即使 `write: true` 且无 `save` 也照常注册；
6. `DatabaseLoader` 在加宽后的门禁下不受影响。

命令与真实输出（均在共享 verify 锁内、`--max-old-space-size=4096`、`--maxWorkers=2`）：

```
pnpm --workspace-concurrency=2 --filter @objectstack/metadata test
  Test Files  25 passed (25)
       Tests  508 passed (508)

npx vitest run src/metadata-manager-loader-save-contract.test.ts src/metadata-manager-loader-delete-contract.test.ts --reporter=verbose
  Test Files  2 passed (2)
       Tests  24 passed (24)
```

类型：`@objectstack/metadata` 无 `typecheck` script（在 `check-type-check-coverage.mjs` 的 DEBT 账本里）。所以直接跑了 `tsc --noEmit -p packages/metadata/tsconfig.json` 并与改动前对拍：

```
改动前 92 raw errors  →  改动后 92 raw errors（增量 0；补完 TSDoc 后复跑仍为 92）
我改动的四个文件中的报错数：0
check:type-check-coverage    OK — 63/78 packages type-checked, 15 DEBT, 1 exempt
```

其他门禁：

```
check:nul-bytes                 OK（5649 files；另对改动文件做了越过门禁盲区的 grep -naP 自扫，干净）
check:durability-log-level      OK — 24 seams, all loud
check:startup-registry-verdict  OK — 40 seams, none recording a contradictable verdict
eslint --no-inline-config（四个改动文件）  无输出
```

合入前已 `git merge origin/main`（无冲突，来项不触及 `packages/metadata`），重建依赖后重跑上述 metadata 用例仍 508/508。

## 影响面与 changeset

`.changeset/metadata-loader-save-contract.md`（patch）写明了 FROM → TO：只影响注册自定义 `datasource:` + `write: true` loader 且没有 `save()` 的使用者 —— 此前注册成功并静默丢写，现在注册即抛，错误里同时给出两条修法（实现 `save(type, name, data, options?): Promise< MetadataSaveResult >`，或诚实地声明 `capabilities.write: false`）。仓内唯一的 `datasource:` loader `DatabaseLoader` 两个方法都有，不受影响。

## 作者面：接口 TSDoc 已按 PM 裁决补齐

`delete?` 上本来带着 #5276 写下的「对 `datasource:` + `write` 而言是强制的」那段，而 `save?` 上没有 —— 门禁加宽后，这个不对称正好指反了：接口只讲了一个约束两半的契约的其中一半。已按 PM 裁决（#5654 评论 5200271661）在同一分支追加一次纯注释提交补齐：

- `save?` 用自己的措辞讲同一件事：`register()` 的静默跳过、写入被宣告却没落地、重启即消失，其余协议合法缺席；
- `delete?` 那段改为按名字指向加宽后的同一个门禁（`assertWritableLoaderContract`，#5276 + #5654），不再描述一个只管 delete 的门禁。

无签名变化、无运行时影响；`tsc` 增量 0、eslint 无输出。