### PR TITLE
docs(ui): field-group derivation is authorized by `fieldGroups`, not by `field.group` alone (#5458)

### DIFF
--- a/content/docs/ui/create-vs-edit-form.mdx
+++ b/content/docs/ui/create-vs-edit-form.mdx
@@ -23,14 +23,25 @@ The create-form subset is not an arbitrary pick; it is *derivable* from signals 
 | `readonly` / formula / rollup / autonumber / system-stamped | **never** on create (you can't set it) |
 | `defaultValue` present | **can be omitted** from create (it self-fills) |
 | `hidden` | off everywhere by default |
-| `group` | which section the field belongs to (semantic, travels with the model) |
+| `group` | which section the field belongs to (semantic, travels with the model — and only once that group is **declared** in `fieldGroups`; see §2) |
 | *declaration order* | the order you write fields in **is** the default order everywhere — there is no `field.order` |
 
 So a sensible create form is: *editable, required-or-core fields, in declaration order* — and it **falls out** of the object. This is ADR-0047's guardrail: **omission is correct** — emit nothing extra and you still get a complete, correct form.
 
-### 2. The default (edit) form derives from `field.group`
+### 2. The default (edit) form derives from `field.group` — as authorized by `fieldGroups`
 
-The full edit form materialises each `field.group` into a section. You can omit it entirely and let the platform derive an equivalent grouped form. When you do write it, list fields as **bare strings** so each one inherits its type / validation / FLS / default from the object — the form carries layout only, never data semantics.
+`field.group` on its own does not create a section. The **authorization source is the object's `fieldGroups` declaration**: `deriveFieldGroupLayout` (ADR-0085 §5) — the single derivation every renderer and the i18n walker consume — sections only those fields whose `group` matches a declared `fieldGroups[].key`.
+
+- An **undeclared** `group` renders **exactly like no `group` at all**: the field drops into a trailing untitled bucket.
+- Declare **no** `fieldGroups` at all and grouping does not apply — the derivation yields nothing and you get a flat form.
+- Either way, `os lint` (and `os build` / `os validate`) reports every unmatched reference as **`field-group-undeclared`**.
+
+So tag the fields **and** declare the groups — [`contact.object.ts`](#runnable-example) does both. With both halves present, the full edit form materialises each declared group into a section, and you can omit the `form` view entirely and let the platform derive the grouped form. Two ways the derived form still differs from the hand-written one below:
+
+- fields the platform injects and you never grouped (`owner_id`, under `sharingModel: 'private'`) surface in that trailing untitled section;
+- `columns` is a **form-view** knob, and the group declaration has no column count to give — a derived section carries only `key` / `label` / `icon` / `description` / `collapse` and its member fields — so a hand-written `columns: 2` is not part of what derivation gives back.
+
+When you do write the form, list fields as **bare strings** so each one inherits its type / validation / FLS / default from the object — the form carries layout only, never data semantics.
 
 ### 3. Hand-shape the create form *only when layout or flow diverges*
 
@@ -50,7 +61,8 @@ export const ContactViews = defineView({
     addRecord: { enabled: true, mode: 'form', formView: 'create' },
   },
 
-  // Full edit form — grouped by field.group; bare strings inherit field defs.
+  // Full edit form — one section per group DECLARED in the object's
+  // `fieldGroups`; bare strings inherit field defs.
   form: {
     type: 'simple', data,
     sections: [
@@ -102,7 +114,7 @@ Rule of thumb: **"different field subset" → derive. "different layout or flow"
 
 ## Runnable example
 
-- Object: [`examples/app-showcase/src/data/objects/contact.object.ts`](https://github.com/objectstack-ai/objectstack/blob/main/examples/app-showcase/src/data/objects/contact.object.ts) — flat, grouped, intent-tagged field set.
+- Object: [`examples/app-showcase/src/data/objects/contact.object.ts`](https://github.com/objectstack-ai/objectstack/blob/main/examples/app-showcase/src/data/objects/contact.object.ts) — flat, intent-tagged field set, with the four `fieldGroups` its `group` tags point at.
 - Views: [`examples/app-showcase/src/ui/views/contact.view.ts`](https://github.com/objectstack-ai/objectstack/blob/main/examples/app-showcase/src/ui/views/contact.view.ts) — full edit form + sparse `formViews.create` + `addRecord` binding.
 
 ## Anti-patterns

--- a/content/docs/ui/field-grouping-and-order.mdx
+++ b/content/docs/ui/field-grouping-and-order.mdx
@@ -25,17 +25,34 @@ So "flat vs grouped" is not a contradiction — it's one flat set seen through d
 
 There are **two** grouping concepts. Keep them distinct:
 
-**1. Semantic grouping — `field.group` (on the object).** A field's logical home ("billing", "contact_info", "system"). It travels with the model. The Studio field editor folds fields by it, and auto-generated forms use it as the **default** sectioning — so you are not starting from zero.
+**1. Semantic grouping — `field.group` + `fieldGroups` (on the object).** A field's logical home ("billing", "contact_info", "system"). It travels with the model. The Studio field editor folds fields by it, and auto-generated forms use it as the **default** sectioning — so you are not starting from zero.
 
+Semantic grouping has **two halves, and you need both**. `fieldGroups` on the object is the **authorization source** for the derivation: `deriveFieldGroupLayout` (ADR-0085 §5) — the one implementation every renderer and the i18n walker consume — sections only those fields whose `group` matches a declared `fieldGroups[].key`. An **undeclared** `group` renders **exactly like no `group` at all** (the field falls into a trailing untitled bucket); with **no** `fieldGroups` declared at all, grouping does not apply and the form comes out flat. `os lint` (and `os build` / `os validate`) reports the mismatch as **`field-group-undeclared`**.
+
+{/* os:check */}
 ```ts
-fields: {
-  name:  Field.text({ label: 'Full name', group: 'contact' }),
-  email: Field.email({ label: 'Email',    group: 'contact' }),
-  stage: Field.select({ label: 'Stage',   group: 'status', options: [/* … */] }),
-}
+import { ObjectSchema, Field } from '@objectstack/spec/data';
+
+export const Contact = ObjectSchema.create({
+  name: 'showcase_contact',
+  label: 'Contact',
+
+  // The DECLARATION half — array order is display order (there is no `order` key).
+  fieldGroups: [
+    { key: 'contact', label: 'Contact' },
+    { key: 'status',  label: 'Status' },
+  ],
+
+  // The MEMBERSHIP half — each `group` must match a `key` declared above.
+  fields: {
+    name:  Field.text({ label: 'Full name', group: 'contact' }),
+    email: Field.email({ label: 'Email',    group: 'contact' }),
+    stage: Field.select({ label: 'Stage',   group: 'status', options: [{ label: 'New', value: 'new' }] }),
+  },
+});
 ```
 
-**2. Layout grouping — form `sections` (on a view).** A specific form's explicit arrangement: which fields, which section, how many columns, collapsible. It can **inherit** `field.group` as the default or **override** it per form.
+**2. Layout grouping — form `sections` (on a view).** A specific form's explicit arrangement: which fields, which section, how many columns, collapsible. It can **inherit** the object's declared groups as its default or **override** them per form.
 
 ```ts
 form: {
@@ -68,17 +85,18 @@ Keeping grouping off the field (beyond an optional semantic hint) is what lets *
 
 ## Runnable example
 
-- [`examples/app-showcase/src/data/objects/contact.object.ts`](https://github.com/objectstack-ai/objectstack/blob/main/examples/app-showcase/src/data/objects/contact.object.ts) — fields tagged with `group`.
+- [`examples/app-showcase/src/data/objects/contact.object.ts`](https://github.com/objectstack-ai/objectstack/blob/main/examples/app-showcase/src/data/objects/contact.object.ts) — four declared `fieldGroups`, and the fields tagged with the matching `group`.
 - [`examples/app-showcase/src/ui/views/contact.view.ts`](https://github.com/objectstack-ai/objectstack/blob/main/examples/app-showcase/src/ui/views/contact.view.ts) — sections that materialise those groups.
 
 ## Anti-patterns
 
 - **Adding structural nesting to the data model to satisfy a form.** The model is flat; let the form group.
-- **Re-typing the grouping in every form.** Declare `field.group` once; forms inherit and only override on real divergence.
+- **Re-typing the grouping in every form.** Declare the groups (`fieldGroups`) and tag the fields (`field.group`) once; forms inherit and only override on real divergence.
+- **Tagging fields with a `group` you never declared in `fieldGroups`.** The tag reads as intent but authorizes nothing — the fields render ungrouped, and `os lint` says so as `field-group-undeclared`.
 - **Assuming a grid "group" will section your form fields.** It buckets rows by value — a different axis entirely.
 
 ## See also
 
 - [Create form ≠ edit form](/docs/ui/create-vs-edit-form).
-- Reference: [Field schema](/docs/references/data/field) (`group`), [View schema](/docs/references/ui/view) (`sections`, `grouping`).
+- Reference: [Object schema](/docs/references/data/object) (`fieldGroups`), [Field schema](/docs/references/data/field) (`group`), [View schema](/docs/references/ui/view) (`sections`, `grouping`).
 - Studio: [Object Designer](/docs/references/studio/object-designer) — field editor groups by `field.group`.


### PR DESCRIPTION
Fixes #5458

两篇 UI 指南把表单分组说成「派生自 `field.group` 自身」,全文不出现 `fieldGroups`。读者照抄拿到的是一张**平铺表单**。#5443 已修示例层(showcase `contact.object.ts`,正是这两篇「Runnable example」链接的文件),本 PR 修引用它的文档正文。

## 前提复证(当前 main `889ae474`,实测非读码)

`packages/spec/src/data/field-group-layout.ts` 语义逐字核对通过:

| 场景 | `deriveFieldGroupLayout` 实测 |
|---|---|
| 文档今日样例(只有 `group`,无 `fieldGroups`) | `null` —— 分组根本不适用 |
| 同一对象 + `fieldGroups` 声明 | 两段 `contact` / `status`,成员正确 |
| `group` 值未命中已声明 key | 该字段与**完全没写 `group`** 的字段进同一个尾部无标题桶:`{"fields":["stage","plain"]}` |

第三行是「未声明的 `group` 等同于没写 `group`」的直接证据 —— 两者字面进同一个桶。`packages/lint` 侧:文档今日样例报 **3 条 `field-group-undeclared`**(warning);补上声明后 **0 条**;「部分声明 + 一个未命中」同样报。规则注册为 `commands: ALL` = `['validate','build','lint']`,故正文写「`os lint`(以及 `os build` / `os validate`)」。派生实现的唯一性也复核过:消费者是各渲染面与 `packages/cli/src/utils/i18n-extract.ts` 的 `walkObjectSections`。

顺带实测了 #5443 量到的两处「省略 `form` 后的真实差异」,都在当前 main 复现,因此把 §2 原来的 “derive an **equivalent** grouped form” 一并校准:

- `applySystemFields` 注入的 `owner_id` 未被分组 → 落进尾部无标题段(`FIELD_GROUP_SYSTEM_FIELDS` 不含 `owner_id`);
- 派生段落的键只有 `key` / `label` / `icon` / `description` / `collapse` + 成员 —— **没有 `columns`**,手写的 `columns: 2` 派生给不回来。

## 改动(仅这两篇 mdx)

1. **`content/docs/ui/create-vs-edit-form.mdx`** —— §2 补三要素(授权来源 / 未声明等同没写 / 规则名),`group` 表格行与代码块注释同步;并把 “equivalent” 换成上面两条实测差异。
2. **`content/docs/ui/field-grouping-and-order.mdx`** —— 语义分组小节补同三要素;样例原是 `fields: {…}` 片段(只有成员侧、没有声明侧),改为自包含的 `ObjectSchema.create` + 对齐 showcase 的 `fieldGroups`,并挂 `{/* os:check */}`。

排查过同一谎言的其余落点:全仓 `group: '…'` 且不提 `fieldGroups` 的文件只剩 4 个(`ui/setup-app.mdx`、`automation/approvals.mdx`、`objectstack-automation/SKILL.md`、ADR-0029),经查全是**另一个** `group`(审批分组 / 导航分组),与 `Field.group` 无关 —— 本次修正半径就是这两篇。

## os:check 门禁:存在,且新样例已实际纳入

`{/* os:check */}` 有真实消费者 —— `packages/spec/scripts/check-skill-examples.ts`,对标记块跑 `tsc --noEmit` 打到**已构建的 spec `.d.ts`**;逐块 opt-in。`create-vs-edit-form.mdx` 原本已在册,`field-grouping-and-order.mdx` **一个标记都没有**(其代码块是片段)。所以修正后的样例不是「顺手过门禁」,而是**新纳入**门禁:

- 改前:`204 marked example(s) across 74 file(s)` ✅,列表中无 `field-grouping-and-order.mdx`
- 改后:`205 marked example(s) across 75 file(s)` ✅,新增 `content/docs/ui/field-grouping-and-order.mdx:34`

**反向验证**(方向先判后跑,预判「红,且落在注入行」):把新样例的 `label: 'Status'` 改成 `label: 42` → 门禁转红,报在 `content/docs/ui/field-grouping-and-order.mdx:43:23` —— `error TS2322: Type 'number' is not assignable to type 'string'.`,即注入行本身;还原后复绿 205 ✅。证明这 +1 是活覆盖,不是空跑绿。

## 其他验证

- 本地 `pnpm --filter @objectstack/docs build` → `DOCS_BUILD_EXIT=0`(mdx 语法完整)
- `node scripts/check-nul-bytes.mjs`(含 `--self-test`)✅;改动文件按 `[\x00-\x08\x0b\x0c\x0e-\x1f]` 自扫**零命中**
- `check-doc-authoring`(362 files clean)、`docs-audit/check-audit-scope` 均 ✅
- 本 PR CI:**TypeScript Type Check ✅ / ESLint ✅ / Build Docs ✅**;Build Core、Test Core、Dogfood Regression Gate 按 docs-only filter skip(汇总 job success)。注意 os:check 门禁并非独立 check —— 它是 `lint.yml` 里 **TypeScript Type Check** job 的 “Check skills TypeScript examples compile” 步骤(在 “Build workspace packages” 之后),所以该 job 转绿即代表新纳入的样例在 CI 里真的被编译过。
- **Check Changeset 首 run 红属已知竞态**:job 于 04:13:24 起跑、`skip-changeset` 标签 04:14:20 才落,标签事件触发的后续两次 run 均已 `skipped`。需 PM 重跑该 check 收尾。

## 边界

未碰 `content/docs/releases/`、`examples/`(#5443 已修)、spec/lint 代码。文档-only,无用户可见行为变更 → 走 `skip-changeset` 标签路线,不写空 frontmatter changeset。

> 附注:本地跑 spec / docs 构建会重写生成物 `packages/spec/authorable-surface.base.json`(其 `baseRev` 自动重锚到 merge base,属该机制的设计内自更新),已 `git checkout --` 还原,不随本 PR 提交。