### PR TITLE
fix(spec)!: tenancy.tenantField 不再默认 'tenant_id' —— 未声明如实为 undefined,driver 回落为唯一真相 (#5315)

### DIFF
--- a/.changeset/tenancy-tenantfield-no-default.md
+++ b/.changeset/tenancy-tenantfield-no-default.md
@@ -1,0 +1,42 @@
+---
+"@objectstack/spec": minor
+---
+
+fix(spec)!: `tenancy.tenantField` no longer defaults to `'tenant_id'` — an undeclared tenant column stays `undefined` and the driver's `organization_id` fallback is the single source of truth (#5315)
+
+`TenancyConfigSchema.tenantField` carried `.default('tenant_id')`, so parsing
+`tenancy: { enabled: true }` materialized `tenantField: 'tenant_id'` onto every
+object that never asked for it. The platform's tenant column is
+`organization_id` — the one the kernel injects, the one `rls.zod.ts`'s
+`tenantPolicy()` defaults to, and the one the SQL driver actually scopes by.
+The default was therefore a value **no consumer could use**: `computeTenantField`
+in `driver-sql` honours a declared `tenantField` only when the object really has
+that column, so the materialized `'tenant_id'` sent it looking for a column that
+does not exist, the branch was skipped, and the fallback to `organization_id`
+produced the right answer anyway. A declaration nobody reads (ADR-0078), spelling
+a word the vocabulary rejects (ADR-0120 §Terminology fixes the authorable term at
+`organization`, refusing `tenant`/`org`).
+
+**What changes for an author**
+
+| | before | after |
+|:---|:---|:---|
+| `tenancy: { enabled: true }` (parsed) | `{ enabled: true, tenantField: 'tenant_id' }` | `{ enabled: true }` |
+| effective tenant column | `organization_id` | `organization_id` (unchanged) |
+| `tenancy: { enabled: true, tenantField: 'workspace_id' }` | honoured when the column exists | unchanged |
+
+**The effective tenant column does not move.** That equivalence is pinned end to
+end — parse through `ObjectSchema` and then resolve through the driver — by
+`#5315 undeclared tenantField resolves to organization_id` in
+`packages/drivers/driver-sql/src/sql-driver-tenant-scope.test.ts`.
+
+**Type-level**: `TenancyConfig['tenantField']` widens from `string` to
+`string | undefined`. Code that read the parsed value as a guaranteed string must
+handle `undefined` — the correct fallback is `'organization_id'`, matching
+`computeTenantField` and `tenantPolicy()`. No such reader existed in this repo,
+`objectui`, or `cloud`: both real consumers already guarded (`driver-sql`
+`computeTenantField` truthiness-checks it; `@objectstack/lint`
+`authoredTenantColumn` falls back to `'organization_id'`).
+
+Declaring `tenantField` explicitly is unchanged and still honoured — this only
+stops the spec from inventing a value the author never wrote.

--- a/content/docs/data-modeling/objects.mdx
+++ b/content/docs/data-modeling/objects.mdx
@@ -111,7 +111,20 @@ not object metadata.
 ```typescript
 tenancy: {
   enabled: true,
-  tenantField: 'tenant_id',
+}
+```
+
+The tenant column defaults to nothing at the spec level: leave `tenantField`
+undeclared and the driver scopes by `organization_id` — the kernel-injected
+column the RLS predicates use. Declare it only when an object's tenant column
+genuinely is not `organization_id`, and only when the object really has that
+field (a declared name for a column that does not exist is ignored, and the
+`organization_id` fallback applies):
+
+```typescript
+tenancy: {
+  enabled: true,
+  tenantField: 'workspace_id',
 }
 ```
 

--- a/content/docs/references/data/object.mdx
+++ b/content/docs/references/data/object.mdx
@@ -312,7 +312,7 @@ Boolean-or-predicates override for a built-in row CRUD affordance.
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **enabled** | `boolean` | ✅ | Enable multi-tenancy for this object |
-| **tenantField** | `string` | ✅ | Field name for tenant identifier |
+| **tenantField** | `string` | optional | Column this object is tenant-scoped by. Omit it unless the tenant column genuinely is not the platform's: when undeclared the driver falls back to `organization_id`, the kernel-injected column the RLS predicates and `tenantPolicy()` also assume. A declared name is honoured only when the object really has that field — otherwise the same `organization_id` fallback applies. No default is materialized here on purpose (#5315). |
 
 
 ---

--- a/packages/drivers/driver-sql/src/sql-driver-tenant-scope.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-tenant-scope.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ObjectSchema } from '@objectstack/spec/data';
 import { SqlDriver } from '../src/index.js';
 
 /**
@@ -216,6 +217,63 @@ describe('SqlDriver tenant scope (organization_id)', () => {
       await driver.create('global_flag', { id: 'g1', name: 'G1' });
       const rows = await driver.find('global_flag', { object: 'global_flag' }, { tenantId: 'org_a' });
       expect(rows).toHaveLength(1);
+    });
+  });
+
+  /**
+   * #5315 — behavioural-equivalence pin for dropping `.default('tenant_id')`
+   * from `TenancyConfigSchema.tenantField`.
+   *
+   * The contract this pins is deliberately end-to-end: metadata goes through
+   * `ObjectSchema.parse` (the seam where the default used to materialise) and
+   * *then* to the driver, because the default was only ever observable on a
+   * PARSED object. An author who writes `tenancy: { enabled: true }` and no
+   * `tenantField` must land on `organization_id` — the platform's real tenant
+   * column — and must keep landing there across this change:
+   *
+   *   - before: parse filled `tenantField: 'tenant_id'`, `computeTenantField`
+   *     looked for a `tenant_id` column, did not find one, and fell through to
+   *     `organization_id`. The right answer by accident.
+   *   - after: parse leaves `tenantField` undefined, the declared branch is
+   *     skipped outright, and the same fallback yields `organization_id`.
+   *     The right answer on purpose (ADR-0078: no declaration nobody reads).
+   *
+   * Same answer, one fewer fiction in between — so this test is GREEN on both
+   * sides of the change by construction. That is the claim, not a weakness of
+   * the pin: its job is to fail if anyone reintroduces a default that steers
+   * the driver at a column the object does not have.
+   */
+  describe('#5315 undeclared tenantField resolves to organization_id (parse → driver)', () => {
+    it('an object declaring only `tenancy: { enabled: true }` scopes by organization_id', async () => {
+      await driver.disconnect();
+      driver = new SqlDriver({
+        client: 'better-sqlite3',
+        connection: { filename: ':memory:' },
+        useNullAsDefault: true,
+      });
+
+      // Parse through the real spec schema — this is the seam under test.
+      const parsed = ObjectSchema.parse({
+        name: 'ticket',
+        label: 'Ticket',
+        tenancy: { enabled: true },
+        fields: {
+          organization_id: { type: 'text' },
+          subject: { type: 'text' },
+        },
+      });
+
+      await driver.initObjects([parsed as any]);
+
+      // The effective tenant column, whatever the parse did or did not fill in.
+      expect((driver as any).tenantFieldByTable['ticket']).toBe('organization_id');
+
+      // …and it actually isolates, rather than merely being recorded.
+      await driver.create('ticket', { id: 't1', subject: 'A' }, { tenantId: 'org_a' });
+      await driver.create('ticket', { id: 't2', subject: 'B' }, { tenantId: 'org_b' });
+      const rowsA = await driver.find('ticket', { object: 'ticket' }, { tenantId: 'org_a' });
+      expect(rowsA.map((r) => r.id)).toEqual(['t1']);
+      expect(rowsA[0].organization_id).toBe('org_a');
     });
   });
 

--- a/packages/spec/src/data/object.test.ts
+++ b/packages/spec/src/data/object.test.ts
@@ -1404,10 +1404,18 @@ describe('ADR-0066 — object access posture (D2) + requiredPermissions (D3)', (
 });
 
 describe('TenancyConfigSchema — #2763 strategy/crossTenantAccess removal', () => {
-  it('accepts the two live knobs and applies the tenantField default', () => {
+  it('accepts the two live knobs and materializes NO tenantField default (#5315)', () => {
+    // An undeclared tenant column stays undeclared. The old `.default('tenant_id')`
+    // invented a column name the platform does not use and no consumer could act
+    // on — the effective column is resolved by the driver, which falls back to
+    // `organization_id`. Parsing must not put words in the author's mouth.
     const result = TenancyConfigSchema.parse({ enabled: true });
     expect(result.enabled).toBe(true);
-    expect(result.tenantField).toBe('tenant_id');
+    expect(result.tenantField).toBeUndefined();
+    expect(result).toEqual({ enabled: true });
+    expect('tenantField' in result).toBe(false);
+
+    // An explicitly declared column still round-trips untouched.
     expect(TenancyConfigSchema.parse({ enabled: false, tenantField: 'workspace_id' }))
       .toEqual({ enabled: false, tenantField: 'workspace_id' });
   });

--- a/packages/spec/src/data/object.zod.ts
+++ b/packages/spec/src/data/object.zod.ts
@@ -395,15 +395,39 @@ const strictTenancyError: z.core.$ZodErrorMap = (issue) => {
  * `.strict()`: unknown keys (incl. the retired `strategy` /
  * `crossTenantAccess`, #2763) are rejected with guidance, not stripped (#1535).
  *
- * @example Shared database with tenant_id row isolation
+ * `tenantField` carries **no default** (#5315). It used to default to
+ * `'tenant_id'`, which no consumer could act on: the platform's tenant column
+ * is `organization_id` (kernel-injected; the same column `tenantPolicy()` in
+ * `security/rls.zod.ts` and the RLS predicates assume), and the SQL driver's
+ * `computeTenantField` honours a declared name only when the object actually
+ * has that field — so the materialized `'tenant_id'` merely sent it looking for
+ * a column that did not exist before falling back to `organization_id` anyway.
+ * A declaration nobody reads is exactly what ADR-0078 prohibits, and `tenant`
+ * is a word ADR-0120 §Terminology refuses for the authorable vocabulary
+ * (`organization` is the product's noun). Undeclared now stays `undefined` and
+ * the driver's fallback is the single source of truth.
+ *
+ * @example Shared database, platform-default tenant column (organization_id)
+ * {
+ *   enabled: true
+ * }
+ *
+ * @example An object whose tenant column is genuinely not organization_id
  * {
  *   enabled: true,
- *   tenantField: 'tenant_id'
+ *   tenantField: 'workspace_id'
  * }
  */
 export const TenancyConfigSchema = lazySchema(() => z.object({
   enabled: z.boolean().describe('Enable multi-tenancy for this object'),
-  tenantField: z.string().default('tenant_id').describe('Field name for tenant identifier'),
+  tenantField: z.string().optional().describe(
+    'Column this object is tenant-scoped by. Omit it unless the tenant column ' +
+    "genuinely is not the platform's: when undeclared the driver falls back to " +
+    '`organization_id`, the kernel-injected column the RLS predicates and ' +
+    '`tenantPolicy()` also assume. A declared name is honoured only when the ' +
+    'object really has that field — otherwise the same `organization_id` ' +
+    'fallback applies. No default is materialized here on purpose (#5315).',
+  ),
 }, { error: strictTenancyError }).strict());
 
 /**


### PR DESCRIPTION
Fixes #5315

按 #5315 评论区 2026-08-05 22:31Z 排程注记预记的**方向 2**(否决窗口未被行使):去掉 `TenancyConfigSchema.tenantField` 的默认值,让「未声明」如实表达为 `undefined`,`driver-sql` `computeTenantField` 的既有回落作为唯一真相。依据 ADR-0078(不留没人读的声明)+ ADR-0120 §Terminology(可授权词汇定死 `organization`,`tenant` / `org` 拒收)。

## 一处实现细节:不是单删 `.default()`

**单删 `.default('tenant_id')` 是错的** —— Zod 里 `z.string()` 是**必填**,单删会让 `tenancy: { enabled: true }` 直接 parse 失败,那是个真正的破坏性变更。裁定要的语义(未声明 = `undefined`)对应的是 `.optional()`。三种写法实测:

| 写法 | `parse({ enabled: true })` |
|:---|:---|
| `z.string().default('tenant_id')`(改前) | `{"enabled":true,"tenantField":"tenant_id"}` |
| `z.string()`(单删 default) | **FAIL** — `invalid_type:tenantField` |
| `z.string().optional()`(本 PR) | `{"enabled":true}` |

## 前提复核:消费方清单 + 各自 undefined 处理实测

全仓扫描 `tenantField`(objectstack / objectui / cloud,排除 `node_modules`、`dist`、CHANGELOG)。绝大多数命中是 `driver-sql` 内部 `string | null` 的**局部参数/变量**(`schema-drift.ts` 等),与 spec 声明面无关。**真正读取 spec 声明值**的只有两处:

| # | 消费方 | 位置 | 读法 | undefined 处理 | 会看到物化默认值吗 |
|:--|:---|:---|:---|:---|:---|
| 1 | `computeTenantField` | `driver-sql/src/sql-driver.ts:3531` | `tenancyDecl?.tenantField` | truthy 守卫 → 跳过声明分支,回落 `organization_id` | 会(parse 后元数据) |
| 2 | `authoredTenantColumn` | `lint/src/data-model-rules.ts:88` | `obj?.tenancy?.tenantField` | `typeof === 'string' && trim()`,否则 `'organization_id'` | **不会** —— 读的是作者原文,未经 parse |
| 3 | `tenantPolicy()` | `spec/src/security/rls.zod.ts:601` | 函数默认参数 `= 'organization_id'` | 与 schema 无关 | 不适用 |
| 4 | `isTenancyDisabled` ×2 | `object.zod.ts:419`、`lint/validate-org-axis-red-lines.ts:187` | 只读 `.enabled` | 不适用 | 不适用 |
| 5 | `TenancyConfig` 类型 | `object.zod.ts:2095` | `z.infer` 导出 | **三仓零消费方** | 不适用 |

第 2 条值得单独点名:lint 的注释原文就是 "The organization column, **as an AUTHOR would have spelled it**",其测试喂的是 `tenancy: { tenantField: 'tenant_ref' }`(**没有** `enabled`,这个输入根本过不了 `TenancyConfigSchema.parse`)—— 证明该路径读的是未经 parse 的作者原文,物化默认值从来不在它的视野里。

补充核实:

- `SqliteWasmDriver` / `TursoDriver` 均 `extends SqlDriver`,共用 #1 的 `computeTenantField`,无独立实现。
- `driver-mongodb` 的 tenancy guard(`mongodb-tenancy-guard.ts:96`)只读 `.enabled`。
- 运行时另有一个**同名但不同**的 `tenancy`(`tenancy.posture` / `tenancy.defaultOrgId()`,ADR-0105 的租户服务),与对象 schema 的 `tenancy` 块无关,不受影响。
- objectui / cloud 两仓对 `tenantField` 与 `TenancyConfig` 均零代码引用(仅 objectui 一处 CHANGELOG 历史文本)。

**结论:不存在依赖「parse 后 `tenantField` 恒有值」的消费方(运行时或类型),硬前置 1、2 通过,无 #4666 家族停手条件。**

类型面:`TenancyConfig['tenantField']` 由 `string` 变为 `string | undefined`。因零消费方,无一处需要改逻辑,**未使用任何 `!` 或 cast**。

顺带一提,全仓唯一声明了 `tenancy` 块的对象是 `sys_sso_provider`(`{ enabled: false }`),走 `isTenancyDisabled` 直接返回 `null`,压根不读 `tenantField`。物化的 `'tenant_id'` 在本仓真的是零效果。

## 行为等价性:先证红

先按**错误预期**写断言,在**未改动的 `origin/main`** 上跑红:

```
FAIL  src/sql-driver-tenant-scope.test.ts > #5315 undeclared tenantField resolves to organization_id (parse → driver)
AssertionError: expected 'organization_id' to be 'tenant_id' // Object.is equality
Expected: "tenant_id"
Received: "organization_id"

 Test Files  1 failed | 62 passed | 4 skipped (67)
      Tests  1 failed | 860 passed | 46 skipped (907)
```

`Received: "organization_id"` 一行同时给出两个事实:**(a)** 改动前的基线实测值就是 `organization_id`(硬前置 3 要的那条);**(b)** 物化的 `'tenant_id'` 从未抵达 driver —— 它确实是死声明。翻正断言后前后同绿。

**关于验证方向,按实情报告:这条 pin 按设计两侧皆绿**,不是「改前绿改后红」那种反向验证。它证明的是*等价性*,这正是本单要的东西;它的长期职责是防止有人再塞回一个指向不存在列的默认值。真正的红证据是上面那次故意写错预期的运行。

## 测试与门禁

合并 `origin/main`(前移 9 个 commit,无一触及本 PR 文件面)后整体复验:

```
packages/spec        Test Files  317 passed (317)      Tests  8106 passed (8106)
packages/lint        Test Files   60 passed (60)       Tests  1383 passed | 4 skipped (1387)
driver-sql           Test Files   63 passed | 4 skipped (67)   Tests  861 passed | 46 skipped (907)
```

`typecheck`:spec / driver-sql / lint 三包全绿。(lint 首轮报 `Cannot find module '@objectstack/formula'` 等,是未构建依赖的老陷阱,补 `pnpm --filter '@objectstack/lint^...' build` 后清零,与本改动无关。)

生成物走 os-regen 四步:`check:generated` 只报 `content/docs/references/**` 一项 stale → `gen:docs` 重生成,`tenantField` 由 `✅ required` 变为 `optional` 并带上新 describe(顺带修正了该页原有的不一致:上方内联类型早已写 `tenantField?: string`,下方属性表却标 required)。合并后复跑 `✓ All 10 generated artifacts are up to date.`

`authorable-surface.base.json` 在每次 spec build 时被重锚,带进 `api/Discovery:scoping`、`ui/ActionSession:*` 等**他人在飞的无关键**,已按 #5358 纪律 `git checkout` 还原,**不进本 PR**(还原后 `check:authorable-surface` 仍 ✓)。`check-nul-bytes` OK,并对本 PR 全部改动文件做了超出该门禁扫描范围的控制字符自查,干净。

## 范围外发现

- **#5746**:`content/docs/protocol/objectql/schema.mdx` 的多租户小节仍教 `tenantField: tenant_id`、指向一个不存在的 `reference: tenant` 对象,并把 legacy 的 `OS_MULTI_ORG_ENABLED` 当现行开关介绍(`packages/types/src/env.ts:89` 原文标注 LEGACY)。改对它要先定该示例的教学意图(保留「自定义租户列」演示 vs 改成平台默认姿势),超出本单裁定面,已另立单,未在本 PR 修改。

本 PR 内 `content/docs/data-modeling/objects.mdx` 是**直接**记录这个键的授权指引,其示例正是 issue 点名的「AI 会照抄」的面,故随 schema 一并更正为「省略即回落 `organization_id`」,并把自定义列的例子换成 `workspace_id`。

---
_Generated by [Claude Code](https://claude.ai/code/session_018fxLGQdatPbBUvCgiVxg6D)_