### PR TITLE
fix(objectql): hook 层用 Logger 契约形状写诊断,不再自带方言 (#5637)

### DIFF
--- a/.changeset/hook-logger-contract-shape.md
+++ b/.changeset/hook-logger-contract-shape.md
@@ -1,0 +1,49 @@
+---
+"@objectstack/objectql": patch
+---
+
+fix(objectql): the hook layer logs through the `Logger` contract instead of a local dialect (#5637)
+
+`packages/spec/src/contracts/logger.ts` declares `error(message, error?: Error,
+meta?)` — the `Error` slot is **second**, the meta bag **third**. Both hook
+modules declared their own four-method logger shape instead, and that shape
+spelled `error` as `(msg, meta?)`, so every call site put its diagnostic in the
+`Error` slot.
+
+Nothing caught it. The contract's type satisfies the local shape structurally
+(a function of fewer parameters is assignable, and `any` is compatible both
+ways), so `tsc` never spoke; and the implementation the platform injects today,
+`ObjectLogger`, dispatches its second argument **by shape**
+(`errorOrMeta instanceof Error`), so the meta landed anyway. That tolerance is
+not something the contract declares. Its two sibling implementations —
+`ConsoleLogger` / `JsonLogger` in `@objectstack/observability` — follow the
+contract literally: the meta object lands in the `error` slot, `error.message`
+and `error.stack` read `undefined`, `meta` **is** `undefined`, and the whole
+diagnostic evaporates, leaving a bare sentence. The first host to plug a
+faithful structured logger into `ctx.logger` would have lost the fields of every
+hook diagnostic, with a symptom ("the log has fewer fields than it used to")
+that is close to unattributable.
+
+So the dialect is gone rather than being met halfway (Prime Directive #12 — one
+contract, no consumer-side dialects):
+
+- `WrapDeclarativeOptions.logger` and `BindHooksOptions.logger` are now
+  `HookDiagnosticsLogger` = `Pick<Logger, 'debug' | 'info' | 'warn' | 'error'>`,
+  taken from `@objectstack/spec/contracts` — the four levels this layer calls,
+  and nothing more.
+- All four `error(...)` call sites pass the meta in the contract's third
+  parameter (`error(msg, undefined, { … })`). The values in hand at each site
+  are a `CelFault` (`{ kind, message }`) or a `catch` binding of type `unknown`,
+  none of them statically an `Error`, so the `Error` slot stays empty and each
+  message is carried in meta exactly as before.
+
+`debug`/`info`/`warn` already matched the contract and are unchanged.
+
+No behaviour change for hosts on `ObjectLogger` (the default, and what
+`ctx.logger` / `engine.logger` supply): it accepts all three shapes since #5575,
+so an empty `Error` slot renders the same record it rendered before. Callers
+passing a full `Logger` are unaffected — a `Logger` satisfies the narrowed type
+unchanged. A caller that hand-rolled a four-method object still satisfies it too,
+as long as its `error` does not *require* a meta object in the second position;
+if yours does, move that parameter to third — the contract's order is now the
+one the hook layer calls with.

--- a/packages/objectql/src/hook-binder.ts
+++ b/packages/objectql/src/hook-binder.ts
@@ -24,7 +24,7 @@
 import type { Hook } from '@objectstack/spec/data';
 import { normalizeFlowFunctionEntry, type FlowFunctionEntry } from '@objectstack/spec/automation';
 import type { ObjectQL, HookHandler } from './engine.js';
-import { wrapDeclarativeHook } from './hook-wrappers.js';
+import { wrapDeclarativeHook, type HookDiagnosticsLogger } from './hook-wrappers.js';
 import type { HookMetricsRecorder } from './hook-metrics.js';
 
 export interface BindHooksOptions {
@@ -73,16 +73,19 @@ export interface BindHooksOptions {
   /** Per-hook execution metrics sink. Defaults to no-op. */
   metrics?: HookMetricsRecorder;
 
-  /** Logger; defaults to a silent no-op. */
-  logger?: {
-    debug: (msg: string, meta?: any) => void;
-    info: (msg: string, meta?: any) => void;
-    warn: (msg: string, meta?: any) => void;
-    error: (msg: string, meta?: any) => void;
-  };
+  /**
+   * Logger; defaults to a silent no-op.
+   *
+   * The `Logger` contract, narrowed to the levels this layer uses — the SAME
+   * type the wrapper takes, since every logger handed to the binder is passed
+   * straight through to `wrapDeclarativeHook`. See
+   * {@link HookDiagnosticsLogger} for why this is not a locally-declared shape
+   * (#5637).
+   */
+  logger?: HookDiagnosticsLogger;
 }
 
-const noopLogger = {
+const noopLogger: HookDiagnosticsLogger = {
   debug: () => {},
   info: () => {},
   warn: () => {},
@@ -240,7 +243,11 @@ export function bindHooksToEngine(
       // Under strict, every bind failure is fatal, as advertised.
       if (opts.strict) throw err;
       result.errors.push({ hook: hook.name, reason: err?.message ?? String(err) });
-      logger.error('[hook-binder] failed to bind hook', {
+      // Contract arg order (#5637): `error(message, error?: Error, meta?)`.
+      // `err` is the `any` of a catch clause — a bind failure may be thrown by
+      // user code and need not be an `Error` — so the Error slot stays empty
+      // and the diagnostic travels as meta, in the third parameter.
+      logger.error('[hook-binder] failed to bind hook', undefined, {
         hook: hook.name,
         error: err?.message,
       });

--- a/packages/objectql/src/hook-logger-contract-shape.test.ts
+++ b/packages/objectql/src/hook-logger-contract-shape.test.ts
@@ -1,0 +1,229 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#5637] The hook layer writes its diagnostics through the `Logger` CONTRACT.
+ *
+ * `packages/spec/src/contracts/logger.ts` declares
+ * `error(message, error?: Error, meta?)` — the `Error` slot is SECOND and the
+ * meta bag is THIRD. Both hook modules used to declare their own logger shape
+ * with `error(msg, meta?)`, and their call sites passed the diagnostic in the
+ * second slot accordingly.
+ *
+ * Nothing caught it: the contract type satisfies that local shape structurally,
+ * so `tsc` stayed silent, and the implementation the platform happens to inject
+ * (`ObjectLogger`) dispatches its second argument BY SHAPE, so the meta landed
+ * anyway. The contract's other implementations (`ConsoleLogger` / `JsonLogger`
+ * in `@objectstack/observability`) follow the contract literally — the meta bag
+ * lands in the `error` slot, `error.message`/`error.stack` read `undefined`,
+ * `meta` IS `undefined`, and the whole diagnostic evaporates.
+ *
+ * So these tests judge the call sites with a logger that is FAITHFUL to the
+ * contract — one that keeps its three parameters apart and records them
+ * separately. Under the old dialect every one of them fails with
+ * `meta === undefined` and the diagnostic sitting in `error`.
+ *
+ * The last block guards the other direction: `ObjectLogger`'s shape dispatch
+ * must keep working with `undefined` in the `Error` slot (it is the
+ * implementation every host gets today, and #5575 is what made its third
+ * parameter honest).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ObjectLogger } from '@objectstack/core';
+import type { Hook, HookContext } from '@objectstack/spec/data';
+import { ObjectQL } from './engine.js';
+import { bindHooksToEngine } from './hook-binder.js';
+import { wrapDeclarativeHook, type HookDiagnosticsLogger } from './hook-wrappers.js';
+
+/** One `error(...)` call, with its three contract parameters kept apart. */
+interface ErrorCall {
+  message: string;
+  error: Error | undefined;
+  meta: Record<string, any> | undefined;
+}
+
+/**
+ * A logger that implements the contract EXACTLY as declared — the behaviour
+ * `ConsoleLogger`/`JsonLogger` have and `ObjectLogger` generalises. It performs
+ * no shape dispatch on purpose: that tolerance is what hid the defect, so a
+ * test that reproduced it could not see anything.
+ */
+function makeContractLogger() {
+  const errors: ErrorCall[] = [];
+  const logger: HookDiagnosticsLogger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: (message: string, error?: Error, meta?: Record<string, any>) => {
+      errors.push({ message, error, meta });
+    },
+  };
+  return { logger, errors };
+}
+
+const silentLogger: HookDiagnosticsLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+function makeCtx(overrides: Partial<HookContext> = {}): HookContext {
+  return {
+    object: 'account',
+    event: 'beforeInsert',
+    input: { data: { name: 'acme' } },
+    ql: undefined,
+    ...overrides,
+  } as HookContext;
+}
+
+/** Every recorded call kept its meta in the meta slot and left `error` empty. */
+function expectContractShape(call: ErrorCall) {
+  expect(call.error).toBeUndefined();
+  expect(call.meta).toBeTypeOf('object');
+  expect(call.meta).not.toBeNull();
+}
+
+describe('[#5637] wrapDeclarativeHook writes diagnostics in the Logger contract shape', () => {
+  it("onError: 'log' — the suppressed failure keeps its hook/object/event/error meta", async () => {
+    const { logger, errors } = makeContractLogger();
+    const meta: Hook = {
+      name: 'audit_task',
+      object: 'account',
+      events: ['beforeInsert'],
+      onError: 'log',
+      handler: async () => { throw new Error('handler exploded'); },
+    } as Hook;
+
+    const wrapped = wrapDeclarativeHook(meta, (async () => { throw new Error('handler exploded'); }) as any, { logger });
+    // `onError: 'log'` suppresses — the call must not reject.
+    await wrapped(makeCtx());
+
+    expect(errors).toHaveLength(1);
+    const call = errors[0]!;
+    expect(call.message).toContain('onError=log');
+    expectContractShape(call);
+    expect(call.meta).toMatchObject({
+      hook: 'audit_task',
+      object: 'account',
+      event: 'beforeInsert',
+      error: 'handler exploded',
+    });
+  });
+
+  it('fire-and-forget — the async after-hook failure keeps its meta', async () => {
+    const { logger, errors } = makeContractLogger();
+    const meta: Hook = {
+      name: 'async_audit',
+      object: 'account',
+      events: ['afterInsert'],
+      async: true,
+      onError: 'abort',
+      handler: async () => { throw new Error('async exploded'); },
+    } as Hook;
+
+    const wrapped = wrapDeclarativeHook(meta, (async () => { throw new Error('async exploded'); }) as any, { logger });
+    await wrapped(makeCtx({ event: 'afterInsert' }));
+    // Fire-and-forget: the rejection is reported on a later turn.
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(errors).toHaveLength(1);
+    const call = errors[0]!;
+    expect(call.message).toContain('fire-and-forget');
+    expectContractShape(call);
+    expect(call.meta).toMatchObject({ hook: 'async_audit', error: 'async exploded' });
+  });
+
+  it('an uncompilable condition keeps the condition source in its meta', () => {
+    const { logger, errors } = makeContractLogger();
+    const meta: Hook = {
+      name: 'broken_condition',
+      object: 'account',
+      events: ['beforeInsert'],
+      condition: 'record.done == = true',
+      handler: async () => {},
+    } as Hook;
+
+    // The diagnostic is emitted at WRAP time (the compile failure is known
+    // then); the rejection itself happens per invocation.
+    wrapDeclarativeHook(meta, (async () => {}) as any, { logger });
+
+    expect(errors).toHaveLength(1);
+    const call = errors[0]!;
+    expect(call.message).toContain('failed to compile');
+    expectContractShape(call);
+    expect(call.meta).toMatchObject({
+      hook: 'broken_condition',
+      condition: 'record.done == = true',
+    });
+    expect(String(call.meta?.error)).not.toBe('undefined');
+  });
+});
+
+describe('[#5637] bindHooksToEngine writes its bind failure in the Logger contract shape', () => {
+  it('a throwing registerHook is reported with the hook name and cause in meta', () => {
+    const engine = new ObjectQL({ logger: silentLogger } as any);
+    (engine as any).registerHook = () => { throw new Error('registry refused'); };
+
+    const { logger, errors } = makeContractLogger();
+    const hook: Hook = {
+      name: 'h_bind_fail',
+      object: 'account',
+      events: ['beforeInsert'],
+      handler: async () => {},
+    } as Hook;
+
+    const result = bindHooksToEngine(engine, [hook], { packageId: 'app:test', logger });
+
+    expect(result.registered).toBe(0);
+    expect(result.errors).toEqual([{ hook: 'h_bind_fail', reason: 'registry refused' }]);
+    expect(errors).toHaveLength(1);
+    const call = errors[0]!;
+    expect(call.message).toContain('failed to bind hook');
+    expectContractShape(call);
+    expect(call.meta).toMatchObject({ hook: 'h_bind_fail', error: 'registry refused' });
+  });
+});
+
+describe('[#5637] ObjectLogger keeps rendering the meta with an empty Error slot', () => {
+  /**
+   * The compatibility half. `ObjectLogger` is what every host injects today
+   * (`ctx.logger` / `engine.logger`), and since #5575 its `error` honours all
+   * three shapes — `(msg, Error)`, `(msg, meta)` and `(msg, undefined, meta)`.
+   * This pins the third one, which is what the hook layer now emits: a bare
+   * message with the fields gone would be the regression.
+   */
+  it('emits the hook diagnostic fields on a contract-shaped call', async () => {
+    const written: string[] = [];
+    const realErrWrite = process.stderr.write.bind(process.stderr);
+    (process.stderr as { write: unknown }).write = (chunk: string) => {
+      written.push(String(chunk));
+      return true;
+    };
+
+    try {
+      const logger = new ObjectLogger({ level: 'error', format: 'json' });
+      const meta: Hook = {
+        name: 'audit_task',
+        object: 'account',
+        events: ['beforeInsert'],
+        onError: 'log',
+        handler: async () => { throw new Error('handler exploded'); },
+      } as Hook;
+      const wrapped = wrapDeclarativeHook(meta, (async () => { throw new Error('handler exploded'); }) as any, { logger });
+      await wrapped(makeCtx());
+    } finally {
+      (process.stderr as { write: unknown }).write = realErrWrite;
+    }
+
+    const line = written.find((l) => l.includes('onError=log'));
+    expect(line, 'the suppressed-failure diagnostic reached stderr').toBeTruthy();
+    const record = JSON.parse(line!.trim());
+    expect(record.level).toBe('error');
+    expect(record.hook).toBe('audit_task');
+    expect(record.object).toBe('account');
+    expect(record.event).toBe('beforeInsert');
+    expect(record.error).toBe('handler exploded');
+  });
+});

--- a/packages/objectql/src/hook-wrappers.ts
+++ b/packages/objectql/src/hook-wrappers.ts
@@ -15,25 +15,52 @@
  */
 import type { Hook, HookContext } from '@objectstack/spec/data';
 import type { Expression } from '@objectstack/spec';
+import type { Logger } from '@objectstack/spec/contracts';
 import type { HookHandler } from './engine.js';
 import { ExpressionEngine, collectCelRootIdentifiers } from '@objectstack/formula';
 import { noopHookMetricsRecorder, type HookMetricsRecorder, type HookMetricOutcome } from './hook-metrics.js';
 import { materializeDeclaredFields } from './declared-fields.js';
 import { describeCelFault, type CelFault } from './cel-fault.js';
 
+/**
+ * The logger the hook layer writes its diagnostics to — the `Logger` CONTRACT
+ * (`@objectstack/spec/contracts`), narrowed to the four levels this layer uses.
+ *
+ * ## Why this is a `Pick` of the contract and not a local shape (#5637)
+ *
+ * Both hook modules used to declare their own four-method logger shape, and
+ * that local shape spelled `error` as `(msg, meta?)` — the OPPOSITE of the
+ * contract, whose second parameter is an `Error` and whose `meta` is THIRD.
+ * The contract's type satisfies the local shape structurally (a function of
+ * fewer parameters is assignable, and `any` is compatible in both directions),
+ * so `tsc` never said a word: the conflict lived only at runtime.
+ *
+ * It stayed invisible because the injected implementation happened to be
+ * `ObjectLogger`, which dispatches its second argument BY SHAPE
+ * (`errorOrMeta instanceof Error`) and so recorded a meta object in the `Error`
+ * slot anyway. The contract's other two implementations —
+ * `ConsoleLogger` / `JsonLogger` in `@objectstack/observability` — follow the
+ * contract literally: the meta object lands in the `error` slot, `error.message`
+ * and `error.stack` read `undefined`, `meta` IS `undefined`, and every field of
+ * the diagnostic disappears, leaving a bare sentence. The symptom ("the log
+ * lost its fields") is close to unattributable at the host that first hits it.
+ *
+ * So the shape is taken from the contract rather than re-typed here (Prime
+ * Directive #12: one contract, no consumer-side dialects) — a `Pick` of exactly
+ * what this layer calls, so a caller owes these four methods and nothing more.
+ * A full `Logger` satisfies it unchanged, which is what every production caller
+ * passes (`ctx.logger` / `engine.logger`).
+ */
+export type HookDiagnosticsLogger = Pick<Logger, 'debug' | 'info' | 'warn' | 'error'>;
+
 export interface WrapDeclarativeOptions {
   /** Logger for declarative-layer diagnostics (timeouts, retries, swallowed errors). */
-  logger?: {
-    debug: (msg: string, meta?: any) => void;
-    info: (msg: string, meta?: any) => void;
-    warn: (msg: string, meta?: any) => void;
-    error: (msg: string, meta?: any) => void;
-  };
+  logger?: HookDiagnosticsLogger;
   /** Optional per-execution metrics sink. Defaults to no-op. */
   metrics?: HookMetricsRecorder;
 }
 
-const noopLogger = {
+const noopLogger: HookDiagnosticsLogger = {
   debug: () => {},
   info: () => {},
   warn: () => {},
@@ -269,7 +296,11 @@ export function wrapDeclarativeHook(
         conditionFn = (ctx: HookContext) => {
           throw uncompilableConditionError(meta, ctx, source, fault);
         };
-        logger.error('[hook] condition formula failed to compile; every operation on this hook\'s object will be rejected until it is fixed', {
+        // Contract arg order (#5637): `error(message, error?: Error, meta?)`.
+        // The fault in hand is a `CelFault` (`{ kind, message }`), not an
+        // `Error`, so the Error slot is genuinely empty and the diagnostic
+        // travels as meta — where every implementation of the contract reads it.
+        logger.error('[hook] condition formula failed to compile; every operation on this hook\'s object will be rejected until it is fixed', undefined, {
           hook: meta.name,
           condition: source,
           error: check.error.message,
@@ -338,7 +369,10 @@ export function wrapDeclarativeHook(
       await runWithRetry(ctx);
     } catch (err) {
       if (onError === 'log') {
-        logger.error('[hook] handler failed (onError=log; suppressing)', {
+        // Contract arg order (#5637). `err` is `unknown` — a hook handler may
+        // throw anything — so it is not put in the `Error` slot; its message
+        // is already carried in the meta bag, which is the third parameter.
+        logger.error('[hook] handler failed (onError=log; suppressing)', undefined, {
           hook: meta.name,
           object: ctx.object,
           event: ctx.event,
@@ -391,7 +425,8 @@ export function wrapDeclarativeHook(
           .then(() => recordOutcome())
           .catch((err) => {
             recordOutcome(err);
-            logger.error('[hook] async handler error (fire-and-forget)', {
+            // Contract arg order (#5637) — see the `onError=log` site above.
+            logger.error('[hook] async handler error (fire-and-forget)', undefined, {
               hook: meta.name,
               error: (err as any)?.message,
             });


### PR DESCRIPTION
Fixes #5637

按分诊/PM 一致裁决的**方向 1**执行:`packages/objectql` 的 hook 层不再自带 logger 方言,改用 `@objectstack/spec/contracts` 的契约形状(PD #12)。⛔ 未改动 spec 契约(方向 2 未采纳)。

## 改了什么

**1. 两处本地 logger 形状 → 契约的 `Pick`**

`hook-wrappers.ts` / `hook-binder.ts` 各自手写的四方法形状删除,改为一个从契约派生的类型别名:

```ts
import type { Logger } from '@objectstack/spec/contracts';

export type HookDiagnosticsLogger = Pick< Logger, 'debug' | 'info' | 'warn' | 'error' >;
```

取 `Pick` 而不是整个 `Logger`,是因为这一层只调这四个级别(「最小可用面」);完整的 `Logger` 无改动即满足它,而生产上注入的两个 logger(`ctx.logger` / `engine.logger`)正是完整契约实现。`hook-binder` 直接复用 `hook-wrappers` 导出的同一个类型 —— binder 拿到的 logger 原样转交 `wrapDeclarativeHook`,两者的形状必须同源,不能各写各的。

**2. 四个调用点改为契约参数序 `error(msg, undefined, { … })`**

issue 正文点名三个,实际是**四个** —— `hook-wrappers.ts` 的 condition 编译失败诊断是第四个,同缺陷同文件;改类型之后 `tsc` 会直接把它顶红(见下方反向验证),所以它不是扩大范围,而是这次修复的必然一环:

| 文件 | 诊断 |
|:--|:--|
| `hook-wrappers.ts` | `[hook] condition formula failed to compile; …`(issue 未列) |
| `hook-wrappers.ts` | `[hook] handler failed (onError=log; suppressing)` |
| `hook-wrappers.ts` | `[hook] async handler error (fire-and-forget)` |
| `hook-binder.ts` | `[hook-binder] failed to bind hook` |

**第二参一律留 `undefined`**:四个点手头的值分别是 `CelFault`(`{ kind, message }`,不是 `Error`)和 `catch` 绑定(类型 `unknown` / `any`,hook handler 可以 throw 任何东西),没有一个在静态上是真正的 `Error`。它们的 message 本来就在 meta 里,原样保留,所以这次改动不增删任何诊断字段。把 catch 值提升进 Error 位会把每个宿主渲染出来的 `error` 从字符串换成 `{ message, stack }` 对象 —— 那是另一个决定,不搭这趟车。

**3. `debug` / `info` / `warn` 与契约签名完全一致(`(message, meta?)`),未改动。**

## 兼容性

`ObjectLogger` 是今天所有宿主实际拿到的实现,自 #5575 起三种形状都认(`(msg, Error)` / `(msg, meta)` / `(msg, undefined, meta)`),所以第二参 `undefined` 渲染出的记录与改动前逐字段相同 —— 对现有部署零行为变化。真正变的是契约的另外两个实现(`@objectstack/observability` 的 `ConsoleLogger` / `JsonLogger`):它们此前会把 meta 整块吞掉(落进 `error` 位 → `error.message` / `error.stack` 皆 `undefined`,`meta` 本身 `undefined`),现在如实记录。

导出类型 `BindHooksOptions` / `WrapDeclarativeOptions` 的 `logger` 字段收窄了,但全仓库(含 examples/apps)除 objectql 自身外没有第二个 `bindHooksToEngine` / `wrapDeclarativeHook` 调用点,包内既有测试传的 `{ debug, info, warn, error }` 字面量也仍然满足新类型 —— 全量 typecheck + 全量测试可证。

## 测试

新增 `packages/objectql/src/hook-logger-contract-shape.test.ts`(5 例)。关键在于用一个**忠于契约**的 logger stub(三个参数分开记录、不做形状分派)去审这些调用点 —— 正是 `ObjectLogger` 的那份宽容让旧缺陷看不见,所以复刻宽容的 stub 什么也测不出来。

- 4 例覆盖四个调用点:断言 `error` 位为空、meta 完整落在第三参(hook / object / event / error 等字段逐一 `toMatchObject`)。
- 第 5 例是兼容性钉子:真实 `ObjectLogger`(`format: 'json'`,捕获 stderr)必须照常输出全部字段,证明「第二参 undefined 无害」。

```
✓ onError: 'log' — the suppressed failure keeps its hook/object/event/error meta
✓ fire-and-forget — the async after-hook failure keeps its meta
✓ an uncompilable condition keeps the condition source in its meta
✓ a throwing registerHook is reported with the hook name and cause in meta
✓ ObjectLogger — emits the hook diagnostic fields on a contract-shaped call
Test Files 1 passed (1)  Tests 5 passed (5)
```

合并 `origin/main`(带入 #5760 / #5753 两个同包改动)后重跑全量:

```
pnpm --filter @objectstack/objectql typecheck   → tsc --noEmit,0 error
pnpm --filter @objectstack/objectql test        → Test Files 124 passed (124) / Tests 2042 passed (2042)
```

门禁(合并后重跑,全绿):`check:nul-bytes`(5659 files,无裸控制字节)、`check:query-options-erasure`(ratchet 84 sites,none new)、`check:engine-double-contract`(27 pinned / 65 debt / 1 exempt)、`check:durability-log-level`、`check:startup-registry-verdict`。

### 反向验证(方向先判后跑)

预判三条,跑完三条全中:

1. **恢复方言参数序 → 4 个契约 stub 用例转红。** 实测:`AssertionError: expected { hook: 'audit_task', …(3) } to be undefined` 等 4 条 —— meta 对象落进了 `error` 位,`meta` 为 `undefined`,正是忠于契约的 logger 会丢字段的那一刻。
2. **第 5 例(真实 `ObjectLogger`)保持绿。** 这是**预期**的,不是漏网:`ObjectLogger` 按形状分派,两种参数序都认,所以它天然不是判别器,只是兼容性钉子。照实记下,不假装它会翻转。
3. **`tsc` 也一起转红** —— 这是修复新增的类型级防线,改动前并不存在:

```
src/hook-binder.ts(251,9): error TS2353: Object literal may only specify known properties, and 'hook' does not exist in type 'Error'.
src/hook-wrappers.ts(304,11): error TS2353: …
src/hook-wrappers.ts(376,11): error TS2353: …
src/hook-wrappers.ts(430,15): error TS2353: …
```

第 3 条正是这单最实质的收益:方言之所以能存活,就是因为契约类型在结构上满足本地形状(参数少的一方可赋值,`any` 双向兼容),`tsc` 一句话都不说。换成契约类型之后,同一个错误再写一次会在编译期被顶回来。

## 范围

仅 `packages/objectql/src/hook-wrappers.ts`、`packages/objectql/src/hook-binder.ts` + 同包新增测试 + changeset(patch)。未碰 engine.ts / integrity / lifecycle / spec / observability / core,未碰 `content/docs/releases/`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01V7WetGmnfoXNn8cLieKKmx)_