### PR TITLE
test(rest): getDiscovery 测试替身发 `routes`,不再发 #4828 已退役的 `endpoints` (#5674)

### DIFF
--- a/packages/rest/src/analytics-dataset-dimension-gate.test.ts
+++ b/packages/rest/src/analytics-dataset-dimension-gate.test.ts
@@ -72,7 +72,7 @@ function mockServer() {
 }
 function mockProtocol() {
   return {
-    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: {} }),
+    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '' } }),
     getMetaTypes: vi.fn().mockResolvedValue([]),
     getMetaItems: vi.fn().mockResolvedValue([]),
   };

--- a/packages/rest/src/analytics-dataset-refusal-envelope.test.ts
+++ b/packages/rest/src/analytics-dataset-refusal-envelope.test.ts
@@ -70,7 +70,7 @@ function mockServer() {
 }
 function mockProtocol() {
   return {
-    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: {} }),
+    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '' } }),
     getMetaTypes: vi.fn().mockResolvedValue([]),
     getMetaItems: vi.fn().mockResolvedValue([]),
   };

--- a/packages/rest/src/analytics-dataset-where-gate.test.ts
+++ b/packages/rest/src/analytics-dataset-where-gate.test.ts
@@ -64,7 +64,7 @@ function mockServer() {
 }
 function mockProtocol() {
   return {
-    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: {} }),
+    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '' } }),
     getMetaTypes: vi.fn().mockResolvedValue([]),
     getMetaItems: vi.fn().mockResolvedValue([]),
   };

--- a/packages/rest/src/analytics-filter-refusal-envelope.test.ts
+++ b/packages/rest/src/analytics-filter-refusal-envelope.test.ts
@@ -58,7 +58,7 @@ function mockServer() {
 }
 function mockProtocol() {
   return {
-    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: {} }),
+    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '' } }),
     getMetaTypes: vi.fn().mockResolvedValue([]),
     getMetaItems: vi.fn().mockResolvedValue([]),
   };

--- a/packages/rest/src/analytics-routes.test.ts
+++ b/packages/rest/src/analytics-routes.test.ts
@@ -12,7 +12,7 @@ function mockServer() {
   };
 }
 function mockProtocol() {
-  return { getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: {} }), getMetaTypes: vi.fn().mockResolvedValue([]), getMetaItems: vi.fn().mockResolvedValue([]) };
+  return { getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '' } }), getMetaTypes: vi.fn().mockResolvedValue([]), getMetaItems: vi.fn().mockResolvedValue([]) };
 }
 function mockRes() {
   const res: any = { statusCode: 200, body: undefined };

--- a/packages/rest/src/discovery-double-retired-key.test.ts
+++ b/packages/rest/src/discovery-double-retired-key.test.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#5674] No `getDiscovery` test double in this package may spell `endpoints`.
+ *
+ * ## What was wrong
+ *
+ * 25 test files in `packages/rest/src` mocked the protocol like this:
+ *
+ * ```ts
+ * getDiscovery: vi.fn().mockResolvedValue({
+ *   version: 'v0',
+ *   endpoints: { data: '', metadata: '', ui: '', auth: '/auth' },
+ * })
+ * ```
+ *
+ * The real producer (`ObjectStackProtocolImplementation.getDiscovery()` in
+ * `packages/metadata-protocol/src/protocol.ts`) emits `routes` — declared as
+ * `ApiRoutesSchema` and REQUIRED by `DiscoverySchema` — and has never emitted
+ * `endpoints`. That key existed only on the dispatcher path, as a verbatim
+ * copy of `routes`, and #4828 removed it under ADR-0049. The producer side is
+ * already pinned next door: `discovery-schema-conformance.test.ts` asserts the
+ * live `/discovery` body has no `endpoints` property.
+ *
+ * Those doubles were inert — `rest-server`'s discovery handler reads
+ * `discovery.routes`, so `if (discovery.routes)` was simply false and the
+ * route-augmentation block was skipped — which is exactly why they survived
+ * the retirement: nothing they asserted depended on the key at all.
+ *
+ * ## Why a pin, and why THIS pin
+ *
+ * The harm is authoring-time, not runtime: these were the last places in the
+ * repo still spelling a retired key, and a test double is the most-copied
+ * artifact there is. Copy one and the key is back in the fixture layer, still
+ * inert, still teaching a producer shape that never existed. A conformance
+ * test over the live producer cannot see that — no producer is involved.
+ *
+ * Scope, stated honestly:
+ *
+ * - It scans the `mockResolvedValue({ … })` form only, which is the form all
+ *   26 doubles in this package use and therefore the form that gets copied. A
+ *   double written some other way (`vi.fn(async () => ({ … }))`) is not read.
+ * - It asserts only the NEGATIVE — no `endpoints` key. It deliberately does
+ *   not require `routes`, because `rest-server` guards with
+ *   `if (discovery.routes)` and a future test is entitled to drive that guard's
+ *   falsy branch with a double that omits it.
+ * - The floor below is anti-vacuity, in the sense of #4642: a scanner that
+ *   silently stops matching would otherwise pass by finding nothing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC_DIR = fileURLToPath(new URL('.', import.meta.url));
+
+/** Matches an `endpoints` key at the start of a line or after `{` / `,`. */
+const ENDPOINTS_KEY = /(^|[{,])\s*endpoints\s*:/;
+
+interface Double {
+    file: string;
+    /** The source text of the object the double resolves to, braces included. */
+    literal: string;
+}
+
+/**
+ * Capture the balanced `{ … }` that follows `getDiscovery: …mockResolvedValue(`.
+ *
+ * Brace counting is enough here: the doubles are plain data literals, and a
+ * `{` inside a string would only ever make this capture MORE text, i.e. fail
+ * loud rather than pass quiet.
+ */
+function collectDoubles(file: string, source: string): Double[] {
+    const found: Double[] = [];
+    const opener = /getDiscovery\s*:[\s\S]{0,80}?mockResolvedValue\(\s*\{/g;
+    let m: RegExpExecArray | null;
+    while ((m = opener.exec(source)) !== null) {
+        const start = m.index + m[0].length - 1; // index of the `{`
+        let depth = 0;
+        let end = -1;
+        for (let i = start; i < source.length; i++) {
+            const ch = source[i];
+            if (ch === '{') depth++;
+            else if (ch === '}') {
+                depth--;
+                if (depth === 0) { end = i; break; }
+            }
+        }
+        if (end === -1) throw new Error(`${file}: unbalanced getDiscovery double literal`);
+        found.push({ file, literal: source.slice(start, end + 1) });
+    }
+    return found;
+}
+
+const DOUBLES: Double[] = readdirSync(SRC_DIR)
+    .filter((f) => f.endsWith('.test.ts'))
+    .flatMap((f) => collectDoubles(f, readFileSync(join(SRC_DIR, f), 'utf8')));
+
+describe('[#5674] getDiscovery doubles carry the producer key, not the retired one', () => {
+    it('finds the doubles it claims to police (anti-vacuity)', () => {
+        // 26 doubles across 25 files when this pin was written. The floor is
+        // deliberately slack — it exists so a scanner that matches NOTHING
+        // fails instead of reporting a clean sweep of an empty set.
+        expect(
+            DOUBLES.length,
+            'the scanner found (almost) no getDiscovery doubles — it has drifted from how this package writes them, so its verdict below means nothing',
+        ).toBeGreaterThanOrEqual(20);
+    });
+
+    it('no double resolves to an object carrying `endpoints` (retired in #4828)', () => {
+        const offenders = DOUBLES
+            .filter((d) => ENDPOINTS_KEY.test(d.literal))
+            .map((d) => d.file);
+
+        expect(
+            Array.from(new Set(offenders)),
+            'the discovery producer emits `routes` (ApiRoutesSchema) and never emitted `endpoints`; '
+            + '`endpoints` was the dispatcher-only copy retired by #4828 (ADR-0049). A double that spells '
+            + 'it teaches a shape no producer ever had, and is the seed the next copy-paste grows from (#5674).',
+        ).toEqual([]);
+    });
+});

--- a/packages/rest/src/discovery-double-retired-key.test.ts
+++ b/packages/rest/src/discovery-double-retired-key.test.ts
@@ -55,6 +55,18 @@ import { fileURLToPath } from 'node:url';
 
 const SRC_DIR = fileURLToPath(new URL('.', import.meta.url));
 
+/**
+ * This file is excluded from its own scan, EXPLICITLY.
+ *
+ * The docblock above quotes the defective double verbatim — that is the point
+ * of it — so the scanner does match a "double" here. It happens to escape the
+ * key check only because a docblock line prefixes the key with `* `, which the
+ * `[{,]\s*` lead-in does not accept. Depending on that is depending on comment
+ * formatting: re-wrap the docblock and this pin fails on its own prose. Name
+ * the exclusion instead of inheriting the luck.
+ */
+const SELF = 'discovery-double-retired-key.test.ts';
+
 /** Matches an `endpoints` key at the start of a line or after `{` / `,`. */
 const ENDPOINTS_KEY = /(^|[{,])\s*endpoints\s*:/;
 
@@ -94,13 +106,15 @@ function collectDoubles(file: string, source: string): Double[] {
 }
 
 const DOUBLES: Double[] = readdirSync(SRC_DIR)
-    .filter((f) => f.endsWith('.test.ts'))
+    .filter((f) => f.endsWith('.test.ts') && f !== SELF)
     .flatMap((f) => collectDoubles(f, readFileSync(join(SRC_DIR, f), 'utf8')));
 
 describe('[#5674] getDiscovery doubles carry the producer key, not the retired one', () => {
     it('finds the doubles it claims to police (anti-vacuity)', () => {
-        // 26 doubles across 25 files when this pin was written. The floor is
-        // deliberately slack — it exists so a scanner that matches NOTHING
+        // 27 doubles across 26 files when this pin was written (the 26 #5674
+        // corrected, plus `rest-route-ledger.conformance.test.ts`, which
+        // resolves to a bare `{}` and never spelled the retired key). The floor
+        // is deliberately slack — it exists so a scanner that matches NOTHING
         // fails instead of reporting a clean sweep of an empty set.
         expect(
             DOUBLES.length,

--- a/packages/rest/src/meta-app-area-nav-gate.test.ts
+++ b/packages/rest/src/meta-app-area-nav-gate.test.ts
@@ -65,7 +65,7 @@ function makeRes() {
  */
 function setup(perms: string[], services: string[] = ['org-scoping']) {
     const protocol: any = {
-        getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: { data: '', metadata: '', ui: '', auth: '/auth' } }),
+        getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '', ui: '', auth: '/auth' } }),
         getMetaTypes: vi.fn().mockResolvedValue([]),
         // Deep-clone per call: the filter must never mutate stored metadata, and
         // a shared object would hide that by carrying a prior call's damage.

--- a/packages/rest/src/meta-audience-plural.test.ts
+++ b/packages/rest/src/meta-audience-plural.test.ts
@@ -30,7 +30,7 @@ function makeRes() {
 
 function setup() {
   const protocol: any = {
-    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: { data: '', metadata: '', ui: '', auth: '/auth' } }),
+    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '', ui: '', auth: '/auth' } }),
     getMetaTypes: vi.fn().mockResolvedValue([]),
     // The real implementation normalizes singular↔plural, so BOTH spellings
     // resolve to the same items.

--- a/packages/rest/src/meta-public-book-grant.test.ts
+++ b/packages/rest/src/meta-public-book-grant.test.ts
@@ -36,7 +36,7 @@ function makeRes() {
 /** Secure-by-default: `requireAuth` is ON for every case below. */
 function setup() {
   const protocol: any = {
-    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: { data: '', metadata: '', ui: '', auth: '/auth' } }),
+    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '', ui: '', auth: '/auth' } }),
     getMetaTypes: vi.fn().mockResolvedValue([]),
     getMetaItems: vi.fn(async ({ type }: any) => {
       const t = RestServerTypes.singular(String(type ?? ''));

--- a/packages/rest/src/public-form-routes.test.ts
+++ b/packages/rest/src/public-form-routes.test.ts
@@ -59,7 +59,7 @@ const ticketObject = {
 function buildServer(sections: any[]) {
   const createData = vi.fn().mockResolvedValue({ object: 'ticket', id: 'rec_1', record: {} });
   const protocol: any = {
-    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: {} }),
+    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '' } }),
     getMetaTypes: vi.fn().mockResolvedValue([]),
     getMetaItems: vi.fn(async ({ type }: { type: string }) => {
       if (type === 'view') return [formView(sections)];

--- a/packages/rest/src/request-schema-gate.conformance.test.ts
+++ b/packages/rest/src/request-schema-gate.conformance.test.ts
@@ -60,7 +60,7 @@ function setup() {
     deleteManyData: vi.fn().mockResolvedValue({ success: true, total: 0, succeeded: 0, failed: 0, results: [] }),
   };
   const protocol: any = {
-    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: { data: '', metadata: '', ui: '', auth: '/auth' } }),
+    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '', ui: '', auth: '/auth' } }),
     getMetaTypes: vi.fn().mockResolvedValue([]),
     getMetaItems: vi.fn().mockResolvedValue([{ name: 'invoice' }]),
     getMetaItem: vi.fn().mockResolvedValue({}),

--- a/packages/rest/src/rest-4xx-message-truncation.test.ts
+++ b/packages/rest/src/rest-4xx-message-truncation.test.ts
@@ -189,7 +189,7 @@ function makeRes() {
 function setup(protocolOverrides: Record<string, unknown> = {}) {
     const protocol: any = {
         getDiscovery: vi.fn().mockResolvedValue({
-            version: 'v0', endpoints: { data: '', metadata: '', ui: '', auth: '/auth' },
+            version: 'v0', routes: { data: '', metadata: '', ui: '', auth: '/auth' },
         }),
         getMetaTypes: vi.fn().mockResolvedValue([]),
         getMetaItems: vi.fn().mockResolvedValue([]),

--- a/packages/rest/src/rest-5xx-message-sanitization.test.ts
+++ b/packages/rest/src/rest-5xx-message-sanitization.test.ts
@@ -104,7 +104,7 @@ function mountRest(protocol: any) {
 function setup(protocolOverrides: Record<string, unknown> = {}) {
     const protocol: any = {
         getDiscovery: vi.fn().mockResolvedValue({
-            version: 'v0', endpoints: { data: '', metadata: '', ui: '', auth: '/auth' },
+            version: 'v0', routes: { data: '', metadata: '', ui: '', auth: '/auth' },
         }),
         getMetaTypes: vi.fn().mockResolvedValue([]),
         getMetaItems: vi.fn().mockResolvedValue([]),

--- a/packages/rest/src/rest-batch-endpoint.test.ts
+++ b/packages/rest/src/rest-batch-endpoint.test.ts
@@ -72,7 +72,7 @@ function makeCreateData(ql: any, opts: { readonlyFields?: string[] } = {}) {
 function buildServer(opts: { ql?: any; objects?: any[]; readonlyFields?: string[] } = {}) {
   const server = mockServer();
   const protocol: any = {
-    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: {} }),
+    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '' } }),
     getMetaTypes: vi.fn().mockResolvedValue([]),
     getMetaItems: vi.fn().mockResolvedValue(opts.objects ?? []),
     createData: opts.ql

--- a/packages/rest/src/rest-batch-size-cap.test.ts
+++ b/packages/rest/src/rest-batch-size-cap.test.ts
@@ -35,7 +35,7 @@ function setup(maxBatchSize?: number) {
     batchData: vi.fn().mockResolvedValue({ success: true, total: 0, succeeded: 0, failed: 0, results: [] }),
   };
   const protocol: any = {
-    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: { data: '', metadata: '', ui: '', auth: '/auth' } }),
+    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '', ui: '', auth: '/auth' } }),
     getMetaTypes: vi.fn().mockResolvedValue([]),
     getMetaItems: vi.fn().mockResolvedValue([{ name: 'invoice' }]),
     getMetaItem: vi.fn().mockResolvedValue({}),

--- a/packages/rest/src/rest-bulk-path-object.test.ts
+++ b/packages/rest/src/rest-bulk-path-object.test.ts
@@ -41,7 +41,7 @@ function setup() {
     success: true, operation: 'delete', total: 1, succeeded: 1, failed: 0, results: [],
   });
   const protocol: any = {
-    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: { data: '', metadata: '', ui: '', auth: '/auth' } }),
+    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '', ui: '', auth: '/auth' } }),
     getMetaTypes: vi.fn().mockResolvedValue([]),
     getMetaItems: vi.fn().mockResolvedValue([
       { name: 'open' },

--- a/packages/rest/src/rest-delete-many-ingress.test.ts
+++ b/packages/rest/src/rest-delete-many-ingress.test.ts
@@ -33,7 +33,7 @@ function setup() {
     success: true, operation: 'delete', total: 1, succeeded: 1, failed: 0, results: [],
   });
   const protocol: any = {
-    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: { data: '', metadata: '', ui: '', auth: '/auth' } }),
+    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '', ui: '', auth: '/auth' } }),
     getMetaTypes: vi.fn().mockResolvedValue([]),
     getMetaItems: vi.fn().mockResolvedValue([{ name: 'invoice' }]),
     getMetaItem: vi.fn().mockResolvedValue({}),

--- a/packages/rest/src/rest-dropped-fields.test.ts
+++ b/packages/rest/src/rest-dropped-fields.test.ts
@@ -29,7 +29,7 @@ function mockRes() {
 
 function buildServer(protocolOverrides: Record<string, any>) {
   const protocol: any = {
-    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: {} }),
+    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '' } }),
     getMetaTypes: vi.fn().mockResolvedValue([]),
     // No object registered → enforceApiAccess default-allows and the handler
     // proceeds straight to the (mocked) write method.

--- a/packages/rest/src/rest-endpoint-surfaces-served-only.test.ts
+++ b/packages/rest/src/rest-endpoint-surfaces-served-only.test.ts
@@ -140,7 +140,7 @@ async function managerHolding(items: Array<Record<string, unknown>>): Promise<Me
 function mountRest(enumerated: Array<Record<string, unknown>>, authority: unknown | undefined) {
   const protocol: any = {
     getDiscovery: vi.fn().mockResolvedValue({
-      version: 'v0', endpoints: { data: '', metadata: '', ui: '', auth: '/auth' },
+      version: 'v0', routes: { data: '', metadata: '', ui: '', auth: '/auth' },
     }),
     getMetaTypes: vi.fn().mockResolvedValue([]),
     getMetaItems: vi.fn(async ({ type }: any) => {

--- a/packages/rest/src/rest-env-resolution.test.ts
+++ b/packages/rest/src/rest-env-resolution.test.ts
@@ -34,7 +34,7 @@ function createMockServer() {
 
 function createMockProtocol() {
   return {
-    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: {} }),
+    getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '' } }),
     getMetaTypes: vi.fn().mockResolvedValue([]),
     getMetaItems: vi.fn().mockResolvedValue([]),
     getMetaItem: vi.fn().mockResolvedValue({}),

--- a/packages/rest/src/rest-expected-error-logging.test.ts
+++ b/packages/rest/src/rest-expected-error-logging.test.ts
@@ -66,7 +66,7 @@ function noDraftError(target: string) {
 function setup(protocolOverrides: Record<string, unknown> = {}) {
     const protocol: any = {
         getDiscovery: vi.fn().mockResolvedValue({
-            version: 'v0', endpoints: { data: '', metadata: '', ui: '', auth: '/auth' },
+            version: 'v0', routes: { data: '', metadata: '', ui: '', auth: '/auth' },
         }),
         getMetaTypes: vi.fn().mockResolvedValue([]),
         getMetaItems: vi.fn().mockResolvedValue([{ name: 'showcase_account' }]),

--- a/packages/rest/src/rest-meta-outage-vs-miss.test.ts
+++ b/packages/rest/src/rest-meta-outage-vs-miss.test.ts
@@ -42,7 +42,7 @@ function makeRes() {
 function setup(protocolOverrides: Record<string, unknown> = {}) {
     const protocol: any = {
         getDiscovery: vi.fn().mockResolvedValue({
-            version: 'v0', endpoints: { data: '', metadata: '', ui: '', auth: '/auth' },
+            version: 'v0', routes: { data: '', metadata: '', ui: '', auth: '/auth' },
         }),
         getMetaTypes: vi.fn().mockResolvedValue([]),
         getMetaItems: vi.fn().mockResolvedValue([]),

--- a/packages/rest/src/rest-unclassified-fault-status.test.ts
+++ b/packages/rest/src/rest-unclassified-fault-status.test.ts
@@ -87,7 +87,7 @@ function makeRes() {
 function setup(protocolOverrides: Record<string, unknown> = {}) {
     const protocol: any = {
         getDiscovery: vi.fn().mockResolvedValue({
-            version: 'v0', endpoints: { data: '', metadata: '', ui: '', auth: '/auth' },
+            version: 'v0', routes: { data: '', metadata: '', ui: '', auth: '/auth' },
         }),
         getMetaTypes: vi.fn().mockResolvedValue([]),
         getMetaItems: vi.fn().mockResolvedValue([]),

--- a/packages/rest/src/rest-unknown-object-heuristic.test.ts
+++ b/packages/rest/src/rest-unknown-object-heuristic.test.ts
@@ -384,7 +384,7 @@ describe('[#5462] a real unknown object is still 404 OBJECT_NOT_FOUND, still sil
         // trace per request (#4886).
         const rest = mountRest({
             getDiscovery: vi.fn().mockResolvedValue({
-                version: 'v0', endpoints: { data: '', metadata: '', ui: '', auth: '/auth' },
+                version: 'v0', routes: { data: '', metadata: '', ui: '', auth: '/auth' },
             }),
             getMetaTypes: vi.fn().mockResolvedValue([]),
             findData: vi.fn().mockRejectedValue(driverError('no such table: ghost')),
@@ -416,7 +416,7 @@ describe('[#5462] the declared-status band is untouched', () => {
         );
         const rest = mountRest({
             getDiscovery: vi.fn().mockResolvedValue({
-                version: 'v0', endpoints: { data: '', metadata: '', ui: '', auth: '/auth' },
+                version: 'v0', routes: { data: '', metadata: '', ui: '', auth: '/auth' },
             }),
             getMetaTypes: vi.fn().mockResolvedValue([]),
             saveMetaItem: vi.fn().mockRejectedValue(err),

--- a/packages/rest/src/rest.test.ts
+++ b/packages/rest/src/rest.test.ts
@@ -30,7 +30,11 @@ function createMockProtocol() {
   return {
     getDiscovery: vi.fn().mockResolvedValue({
       version: 'v0',
-      endpoints: { data: '', metadata: '', ui: '', auth: '/auth' },
+      // The producer's key is `routes` (`ApiRoutesSchema`, required by
+      // `DiscoverySchema`). `endpoints` was a dispatcher-only verbatim copy of
+      // it, retired in #4828 — a double that spells it is teaching a shape no
+      // producer ever emitted (#5674). Copy this mock, not that one.
+      routes: { data: '', metadata: '', ui: '', auth: '/auth' },
     }),
     getMetaTypes: vi.fn().mockResolvedValue([]),
     getMetaItems: vi.fn().mockResolvedValue([]),

--- a/packages/rest/src/security-routes.test.ts
+++ b/packages/rest/src/security-routes.test.ts
@@ -13,7 +13,7 @@ function mockServer() {
   };
 }
 function mockProtocol() {
-  return { getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', endpoints: {} }), getMetaTypes: vi.fn().mockResolvedValue([]), getMetaItems: vi.fn().mockResolvedValue([]) };
+  return { getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: { data: '', metadata: '' } }), getMetaTypes: vi.fn().mockResolvedValue([]), getMetaItems: vi.fn().mockResolvedValue([]) };
 }
 function mockRes() {
   const res: any = { statusCode: 200, body: undefined };


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5674

## 前提复核(基线 origin/main `fc5f536`)

issue 写 14 个文件,派发单实测 15 个 —— 复核结论:**15 个文件 / 16 处**写 `endpoints: { data: … }`,与派发单一致,issue 的 14 偏低。真实 producer(`packages/metadata-protocol/src/protocol.ts:2767` 起)发的是 `routes`(`ApiRoutesSchema`,在 `DiscoverySchema:353` 是**必填**键),`endpoints` 从来没被任何 producer 发过,#4828 已删除并由 `discovery-schema-conformance.test.ts:197-201` 钉死。前提成立。

`openapi-endpoints.*` / `served-endpoints.test.ts:48` / `request-schema-gate.conformance.test.ts:173` 的 `endpoints` 是「声明式端点清单」语义,不是 discovery 键 —— 甄别后不动,已复核。

## 逐文件复核:issue 担心的行为变更,实测中不存在

issue 说改成 `routes` 会让 `if (discovery.routes)` 从假翻真、handler 开始跑路由增补块(含 `probeMcpServeable`),所以要一次一个文件复核断言。逐个文件查完,**没有一个文件会执行那个块** —— 原因不是块被跳过了,而是**这 25 个替身没有一个被喂给 discovery handler**:每个文件驱动的都是 `/api/v1/data/:object`、`/api/v1/meta/:type/:name`、`/batch` 等具体路由,没有一处取 `GET /api/v1/discovery` 的 handler 来调用。

这一点有个很强的旁证:全仓唯一真正调用 discovery handler 的两个 describe 就在 `rest.test.ts`(`discovery — routes.mcp`、`discovery — capabilities.transactionalBatch`),而它们**各自覆盖掉了 `createMockProtocol()` 的 getDiscovery**,换成 `{ routes: { data: '', metadata: '' } }`(`rest.test.ts:2601`)—— 那次覆盖本身就是在说「共享替身的键是错的,这里用不了」。

所以:**没有任何文件的断言需要靠「块不执行」才成立**,派发单里预留的那种例外(显式去掉 routes 键 + 注释说明)一处都没有用到。

## 改动(4 个 commit,26 个文件)

1. `1d2c4f5` — 15 个文件 / 16 处 `endpoints: { data: … }` → `routes: { data: … }`。**纯键名翻正,值保持作者原样**:handler 每次请求都用服务端配置覆写 `data`/`metadata`/`ui`,这些槽位按构造就是占位符,键才是缺陷。另在最容易被抄的那个共享替身(`rest.test.ts` 的 `createMockProtocol()`)上加了 4 行说明。
2. `7d5ec37` — 另外 10 个文件写 `endpoints: {}`,同一个退役键的退化写法。issue 与派发单的清单来自 `endpoints: { data:` 这个 grep,看不见它们。只修 15 个会让 issue 自己写下的第一条理由(「唯一还在拼写已退役键的地方」)原样留存,所以一并翻正为 `routes: { data: '', metadata: '' }` —— `ApiRoutesSchema` 里 `data`/`metadata` 必填,`routes: {}` 不是合法生产者形状;这个字面量取自仓库里早已存在的正确先例 `rest.test.ts:2601`,而不是另发明一种。这 10 个文件同样一处也不碰 discovery 路由。
3. `8b92c51` — 新增 pin `packages/rest/src/discovery-double-retired-key.test.ts`。没有它,退役键可以随下一次复制粘贴无声回来:生产面的 conformance 测试只看真实 producer 发出的 body,fixture 层它看不见。
4. `d51adee` — 修 pin 自身的一个缺陷(见下)。

pin 的边界写在文件头,不含糊:只扫 `mockResolvedValue({ … })` 这一种形态(排除自身后实测 **27 处 / 26 个文件**,即本 PR 翻正的 26 处 + `rest-route-ledger.conformance.test.ts` 的 `mockResolvedValue({})` —— 后者 resolve 成裸 `{}`,从来没拼过退役键);**只断言否定面**(不得有 `endpoints`),不要求必须有 `routes` —— handler 是 `if (discovery.routes)`,将来有测试要驱动这条假分支是正当的,`rest-route-ledger` 那处就是现成的例子;并带一条 anti-vacuity 下限(#4642 的教训:扫不到东西的扫描器会以「全部干净」的样子通过)。

### commit 4:pin 自身的缺陷,自查发现

扫描目录下所有 `*.test.ts` **包括 pin 自己**,而它的 docblock 为了说明问题原样引用了带 `endpoints:` 的坏替身。它当时没红,只是因为 docblock 行把键前缀成了 `* `,而 `[{,]\s*` 这个 lead-in 不接受 `*` —— 也就是说这条钉子的绿由注释排版决定,重排一次 docblock 它就会在自己的散文上失败。改为**显式**排除自身文件名并把理由写在常量旁,不继承这份侥幸。

## 反向验证(方向为事前预测的 RED)

预测:把任一文件改回 `endpoints`,新 pin 应当**变红并点名该文件**(它是新增的钉子,不是既有断言,所以是标准 Red 方向,不是 #5046 那种「诊断变多」或 #5018 那种反转)。两种拼法各验一次:

```
# ① rest-batch-size-cap.test.ts 改回 `endpoints: { data: … }`
AssertionError: … expected [ 'rest-batch-size-cap.test.ts' ] to deeply equal []
Test Files  1 failed (1) | Tests  1 failed | 1 passed (2)

# ② rest-dropped-fields.test.ts 改回 `endpoints: {}`(commit 4 之后复验)
AssertionError: … expected [ 'rest-dropped-fields.test.ts' ] to deeply equal []
Test Files  1 failed (1) | Tests  1 failed | 1 passed (2)
```

两次改回后均转绿。方向与预测一致。

## 测试

```
pnpm --workspace-concurrency=2 --filter @objectstack/rest test
 Test Files  56 passed (56)
      Tests  784 passed (784)
```

（改前基线 55 files / 782 tests 全绿,改后 56/784 —— 增量正是新 pin 的 2 条。）

其余本地闸门:`pnpm lint`(仓库级 ESLint,CI 同一条)干净;`pnpm check:type-check-coverage` OK(63/78 包 type-checked);`node scripts/check-nul-bytes.mjs` OK,并按控制字符自查规则对改动文件跑了 `grep -naP` 扫描,无命中。

`@objectstack/rest` **不声明 `typecheck` 脚本**(它在 DEBT + TEST_DEBT 台账里),所以本包的 `pnpm typecheck` 无法运行 —— `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT`。这是既有台账状态、不是本 PR 造成的;不伪造一条绿的 typecheck 证据。

## 界外发现

- **#5787**(已 filed,未认领,`finding` 标签):`packages/client/src/client.test.ts:36-44` 的 discovery 替身同样拼 `endpoints`,且把 `capabilities` 写成字符串数组(spec 里是 record)。生产类型与生产代码都是对的(`DiscoveryResult = GetDiscoveryResponse`,无一处读 `discovery.endpoints`),同属 observation-class。按「只改本 issue 的范围」不在本 PR 处理;本 PR 的 pin 按包扫描,不覆盖 `packages/client`。

## Changeset

tests-only,不发布任何东西,故无 changeset,已带 `skip-changeset` 标签(读回确认:`tests`, `skip-changeset`)。首个 `opened` 事件那次 Check Changeset 早于打标一步开跑、判红,属已知竞态;打标后由 `labeled` 事件触发的两次 Check Changeset 均为 `skipped`(豁免生效)。
