### PR TITLE
fix(cli): load driver-sql's schema-work classifier lazily (#5726)

### DIFF
--- a/.changeset/cli-lazy-driver-sql-import.md
+++ b/.changeset/cli-lazy-driver-sql-import.md
@@ -1,0 +1,25 @@
+---
+'@objectstack/cli': patch
+---
+
+CLI: load the SQL driver's schema-work classifier lazily, so an unbuilt driver no longer breaks command discovery (#5726)
+
+`packages/cli/src/utils/schema-migrate.ts` statically value-imported
+`isInPlaceSchemaWork` from `@objectstack/driver-sql`. oclif's `findCommand`
+`import()`s every command module on every CLI invocation, and nine commands
+reach that file (`meta:resync`, `migrate`, and seven `migrate:*`), so a
+workspace whose `packages/drivers/driver-sql/dist` was not built printed nine
+`MODULE_NOT_FOUND` blocks — naming nine commands the operator never invoked —
+in front of whatever command they actually ran, and dropped all nine out of the
+command table (`os migrate plan` answered `Command migrate:plan not found.`).
+
+The import is now `await import('@objectstack/driver-sql')` at the point of use,
+inside the two renderers that need the classifier. The classifier keeps its one
+definition in the driver — it is a fact about `PendingSchemaWorkKind` and a copy
+in the CLI could disagree, listing a row rewrite under the heading that promises
+the work is never data-losing.
+
+No user-visible behaviour change: this is local/worktree developer experience
+only, and CI always builds before running the CLI. `renderPendingSchemaWork` and
+`summarizePendingSchemaWork` — internal helpers, not part of the package's
+public entry — are now `async`.

--- a/packages/cli/src/commands/migrate/apply.ts
+++ b/packages/cli/src/commands/migrate/apply.ts
@@ -161,9 +161,9 @@ export default class MigrateApply extends Command {
       if (!flags.json) {
         printInfo(`Database: ${chalk.white(stack.dbLabel)}`);
         console.log('');
-        renderPendingSchemaWork(pending);
+        await renderPendingSchemaWork(pending);
         renderPlan(drift);
-        if (pending.length > 0) printInfo(summarizePendingSchemaWork(pending));
+        if (pending.length > 0) printInfo(await summarizePendingSchemaWork(pending));
         printInfo(summarize(drift));
         if (deferred.length > 0) {
           printWarning(`${deferred.length} destructive change(s) will be SKIPPED (re-run with --allow-destructive to include them).`);
@@ -211,7 +211,7 @@ export default class MigrateApply extends Command {
 
       console.log('');
       if (created.length > 0) {
-        printSuccess(`Created/extended ${created.length} table(s): ${summarizePendingSchemaWork(created)}.`);
+        printSuccess(`Created/extended ${created.length} table(s): ${await summarizePendingSchemaWork(created)}.`);
       }
       printSuccess(`Applied ${applied.length} change(s).`);
       if (skipped.length > 0) {

--- a/packages/cli/src/commands/migrate/plan.ts
+++ b/packages/cli/src/commands/migrate/plan.ts
@@ -158,9 +158,9 @@ export default class MigratePlan extends Command {
         return;
       }
 
-      renderPendingSchemaWork(pending);
+      await renderPendingSchemaWork(pending);
       renderPlan(drift);
-      if (pending.length > 0) printInfo(summarizePendingSchemaWork(pending));
+      if (pending.length > 0) printInfo(await summarizePendingSchemaWork(pending));
       printInfo(summarize(drift));
       console.log(chalk.dim('  Apply with: ') + chalk.white('os migrate apply') +
         chalk.dim(' (add --allow-destructive for drops / tightenings)'));

--- a/packages/cli/src/utils/schema-migrate.lazy-driver-import.test.ts
+++ b/packages/cli/src/utils/schema-migrate.lazy-driver-import.test.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #5726 — no CLI production module may STATICALLY value-import a driver.
+ *
+ * The cost of one such import is not paid by the command that needs the driver.
+ * oclif's `findCommand` walks the command table and `import()`s every command
+ * module on **every** CLI invocation, so a broken import chain anywhere in that
+ * table is charged to whatever command you actually ran. `schema-migrate.ts` is
+ * shared by nine commands (`meta:resync`, `migrate`, and seven `migrate:*`), and
+ * its one static `import { isInPlaceSchemaWork } from '@objectstack/driver-sql'`
+ * meant that an unbuilt `packages/drivers/driver-sql/dist` made `os dev` print
+ * nine `MODULE_NOT_FOUND` blocks (eighteen — `dev` forks a child) naming nine
+ * commands the operator never invoked, and made all nine vanish from the command
+ * table: `os migrate plan` answered `Command migrate:plan not found.` The real
+ * cause was `pnpm build`, which nothing in that output said.
+ *
+ * These are source-level assertions on purpose. The defect lives in the shape of
+ * the import graph, which is decided at authoring time and is invisible to any
+ * test that merely calls the functions — every behavioural test in this package
+ * runs in a workspace where the driver happens to be built.
+ *
+ * Scanning `src` rather than `dist` is the same choice: `dist` is what oclif
+ * loads, but building it inside a unit test would be far slower than the thing
+ * it guards, and `tsc` does not move imports between the two forms — a static
+ * value import in `src` is a static import in `dist`, and an `await import()`
+ * stays dynamic.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** `packages/cli/src` — this file lives in `src/utils/`. */
+const SRC_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+/** Every production `.ts` under `packages/cli/src`, as `[relativePath, source]`. */
+function productionSources(): Array<[string, string]> {
+  return readdirSync(SRC_ROOT, { recursive: true, encoding: 'utf8' })
+    .filter((rel) => rel.endsWith('.ts') && !rel.endsWith('.d.ts'))
+    .filter((rel) => !/\.(test|spec)\.ts$/.test(rel))
+    .map((rel) => [rel, readFileSync(join(SRC_ROOT, rel), 'utf8')] as [string, string]);
+}
+
+/**
+ * Static `import … from '<specifier>'` statements, with the leading `type`
+ * keyword captured when present.
+ *
+ * `[^;]*?` cannot cross a statement terminator, so a multi-line import clause is
+ * matched whole while two adjacent statements can never be spliced together.
+ */
+const STATIC_IMPORT = /^[ \t]*import[ \t]+(?:(type)[ \t]+)?([^;]*?)[ \t]*from[ \t]*['"]([^'"]+)['"]/gm;
+
+/** Bare side-effect imports — `import '<specifier>';` — which also load the module. */
+const SIDE_EFFECT_IMPORT = /^[ \t]*import[ \t]*['"]([^'"]+)['"]/gm;
+
+const DRIVER_PACKAGE = /^@objectstack\/driver-/;
+
+describe('#5726 — CLI command modules must not statically value-import a driver', () => {
+  it('has no static value import of any @objectstack/driver-* package in production sources', () => {
+    const offenders: string[] = [];
+
+    for (const [rel, src] of productionSources()) {
+      for (const m of src.matchAll(STATIC_IMPORT)) {
+        const [, typeKeyword, clause, specifier] = m;
+        if (!DRIVER_PACKAGE.test(specifier)) continue;
+        // `import type { … } from` erases entirely — no runtime edge, no cost.
+        if (typeKeyword) continue;
+        // A clause of inline `type` specifiers still emits the module under
+        // `verbatimModuleSyntax`. Flagged deliberately: the fix (hoisting the
+        // keyword to `import type`) is trivial and always available, so there is
+        // no reason to let the risky spelling through on a technicality.
+        offenders.push(`${rel}: import ${clause.trim()} from '${specifier}'`);
+      }
+      for (const m of src.matchAll(SIDE_EFFECT_IMPORT)) {
+        if (DRIVER_PACKAGE.test(m[1])) offenders.push(`${rel}: import '${m[1]}'`);
+      }
+    }
+
+    expect(
+      offenders,
+      'A static value import of a driver package makes EVERY command that reaches this module ' +
+      'fail oclif command discovery when the driver is not built, and prints one MODULE_NOT_FOUND ' +
+      'block per such command in front of whatever the operator actually ran (#5726). ' +
+      'Use `await import(\'@objectstack/driver-…\')` at the point of use, or `import type` when ' +
+      'only the types are needed.',
+    ).toEqual([]);
+  });
+
+  it('still reaches the driver for the in-place classifier, lazily — one definition, loaded later', () => {
+    const src = readFileSync(join(SRC_ROOT, 'utils/schema-migrate.ts'), 'utf8');
+
+    // The point of the fix is NOT "stop depending on driver-sql". The
+    // additive/in-place split is a fact about `PendingSchemaWorkKind`, declared
+    // beside that union in the driver; re-deriving it here would let the CLI
+    // disagree with the driver the day a kind is added — by listing a row
+    // rewrite under a heading that promises the work is never data-losing
+    // (#3954). Pin that the dependency survives, in its dynamic form.
+    expect(src).toMatch(/await import\((['"])@objectstack\/driver-sql\1\)/);
+    expect(src).toContain('isInPlaceSchemaWork');
+  });
+
+  it('awaits every call of the now-async pending-work renderers', () => {
+    // `renderPendingSchemaWork` returns `Promise<void>`, so a dropped `await` is
+    // not a type error — it is output that races the process exit. (The repo
+    // already carries an eslint rule for exactly this shape on `formatOutput`.)
+    const CALL = /(\bawait\s+|\bfunction\s+|\.)?\b(renderPendingSchemaWork|summarizePendingSchemaWork)\s*\(/g;
+    const unawaited: string[] = [];
+
+    for (const [rel, src] of productionSources()) {
+      for (const m of src.matchAll(CALL)) {
+        const prefix = m[1] ?? '';
+        if (/^function\s+$/.test(prefix)) continue; // the declaration itself
+        if (/^await\s+$/.test(prefix)) continue;
+        unawaited.push(`${rel}: ${m[0].trim()}`);
+      }
+    }
+
+    expect(unawaited, 'These renderers became async in #5726 — await them.').toEqual([]);
+  });
+});

--- a/packages/cli/src/utils/schema-migrate.pending-render.test.ts
+++ b/packages/cli/src/utils/schema-migrate.pending-render.test.ts
@@ -46,13 +46,13 @@ const IN_PLACE: PendingSchemaWork[] = [
 ];
 
 describe('renderPendingSchemaWork (#3954)', () => {
-  it('renders nothing at all when there is nothing pending', () => {
-    renderPendingSchemaWork([]);
+  it('renders nothing at all when there is nothing pending', async () => {
+    await renderPendingSchemaWork([]);
     expect(out()).toBe('');
   });
 
-  it('keeps the additive section exactly as it was when only additive work is pending', () => {
-    renderPendingSchemaWork(ADDITIVE);
+  it('keeps the additive section exactly as it was when only additive work is pending', async () => {
+    await renderPendingSchemaWork(ADDITIVE);
     expect(out()).toContain('New (additive — created when you apply)');
     expect(out()).toContain('widgets');
     expect(out()).toContain('[create_table, 2 column(s)]');
@@ -61,16 +61,16 @@ describe('renderPendingSchemaWork (#3954)', () => {
     expect(out()).not.toContain('In place');
   });
 
-  it('puts the datetime convergence under its OWN heading, not the additive one', () => {
-    renderPendingSchemaWork(IN_PLACE);
+  it('puts the datetime convergence under its OWN heading, not the additive one', async () => {
+    await renderPendingSchemaWork(IN_PLACE);
     expect(out()).toContain('In place (existing rows converged when you apply)');
     // The additive heading claims the work is never data-losing; a row rewrite
     // must never be listed beneath it.
     expect(out()).not.toContain('New (additive');
   });
 
-  it('names the columns and the size of each in-place step', () => {
-    renderPendingSchemaWork(IN_PLACE);
+  it('names the columns and the size of each in-place step', async () => {
+    await renderPendingSchemaWork(IN_PLACE);
     expect(out()).toContain('normalize_datetime_storage: at');
     expect(out()).toContain('1,234,567 row update(s)');
     expect(out()).toContain('widen_datetime_columns: at, created_at');
@@ -83,30 +83,30 @@ describe('renderPendingSchemaWork (#3954)', () => {
     expect(out()).toContain('9 row table rebuild');
   });
 
-  it('shows both sections when both kinds are pending', () => {
-    renderPendingSchemaWork([...ADDITIVE, ...IN_PLACE]);
+  it('shows both sections when both kinds are pending', async () => {
+    await renderPendingSchemaWork([...ADDITIVE, ...IN_PLACE]);
     expect(out()).toContain('New (additive — created when you apply)');
     expect(out()).toContain('In place (existing rows converged when you apply)');
   });
 
-  it('reads an unmeasured count as unknown rather than zero', () => {
-    renderPendingSchemaWork([{ table: 'evt', kind: 'normalize_datetime_storage', columns: ['at'] }]);
+  it('reads an unmeasured count as unknown rather than zero', async () => {
+    await renderPendingSchemaWork([{ table: 'evt', kind: 'normalize_datetime_storage', columns: ['at'] }]);
     expect(out()).toContain('? row update(s)');
     expect(out()).not.toContain('0 row update(s)');
   });
 });
 
 describe('summarizePendingSchemaWork (#3954)', () => {
-  it('is unchanged for purely additive work', () => {
-    expect(summarizePendingSchemaWork(ADDITIVE)).toBe('1 table(s) to create, 1 column(s) to add');
+  it('is unchanged for purely additive work', async () => {
+    expect(await summarizePendingSchemaWork(ADDITIVE)).toBe('1 table(s) to create, 1 column(s) to add');
   });
 
-  it('is unchanged when nothing is pending', () => {
-    expect(summarizePendingSchemaWork([])).toBe('0 table(s) to create, 0 column(s) to add');
+  it('is unchanged when nothing is pending', async () => {
+    expect(await summarizePendingSchemaWork([])).toBe('0 table(s) to create, 0 column(s) to add');
   });
 
-  it('never omits in-place work — this is the line read before confirming', () => {
-    const summary = summarizePendingSchemaWork([...ADDITIVE, ...IN_PLACE]);
+  it('never omits in-place work — this is the line read before confirming', async () => {
+    const summary = await summarizePendingSchemaWork([...ADDITIVE, ...IN_PLACE]);
     expect(summary).toContain('1 table(s) to create');
     expect(summary).toContain('1 column(s) to add');
     expect(summary).toContain('5 temporal column(s) to converge in place');

--- a/packages/cli/src/utils/schema-migrate.ts
+++ b/packages/cli/src/utils/schema-migrate.ts
@@ -14,7 +14,6 @@
  */
 import chalk from 'chalk';
 import type { ManagedDriftEntry, DriftCategory, PendingSchemaWork } from '@objectstack/driver-sql';
-import { isInPlaceSchemaWork } from '@objectstack/driver-sql';
 import type { IObjectQLEngine } from '@objectstack/spec/contracts';
 import { describeDriverConnection } from './connection-display.js';
 
@@ -269,6 +268,42 @@ export async function bootSchemaStack(
 
 // ── Rendering ───────────────────────────────────────────────────────
 
+/**
+ * Load the driver's additive/in-place classifier at the moment it is used,
+ * rather than when this module is loaded (#5726).
+ *
+ * `isInPlaceSchemaWork` is the ONLY thing this module needs from
+ * `@objectstack/driver-sql` at runtime — everything else it takes from that
+ * package is `import type`, which erases. A *static* value import for it was
+ * not a local cost, because this file is not loaded only when someone migrates:
+ * oclif's `findCommand` `import()`s every command module on **every** CLI
+ * invocation, and nine commands reach this file (`meta:resync`, `migrate`, and
+ * seven `migrate:*`). So an unbuilt `packages/drivers/driver-sql/dist` did not
+ * merely break those nine — running *any* command, `os dev` included, printed
+ * one `MODULE_NOT_FOUND` block per command in front of the output you asked for
+ * (and `os dev` forks a child, so you saw each one twice), while the nine
+ * dropped out of the command table entirely: `os migrate plan` answered
+ * `Command migrate:plan not found.` None of that noise named the real cause
+ * (`pnpm build`) and the one actionable line it ended on pointed elsewhere.
+ *
+ * Deliberately a lazy import of the driver's own predicate rather than a copy
+ * of it here. The additive/in-place split is a fact about
+ * `PendingSchemaWorkKind`, declared next to that union in the driver; a second
+ * copy in the CLI would be free to disagree the day a kind is added — and the
+ * way it would disagree is by listing a row rewrite under a heading that
+ * promises the work is never data-losing (#3954). One definition, loaded later.
+ *
+ * By the time either renderer runs, the caller is holding a live SQL driver
+ * (the entries it renders came from `previewDeferredSchemaWork()`), so the
+ * module is already in the loader cache and this costs nothing. It is
+ * deliberately not wrapped in a `try`: if it ever did fail, rendering must fail
+ * loudly rather than fall back to a guess about which work rewrites data.
+ */
+async function loadIsInPlaceSchemaWork(): Promise<(kind: PendingSchemaWork['kind']) => boolean> {
+  const { isInPlaceSchemaWork } = await import('@objectstack/driver-sql');
+  return isInPlaceSchemaWork;
+}
+
 const CATEGORY_ORDER: DriftCategory[] = ['safe', 'needs_confirm', 'destructive'];
 
 const CATEGORY_META: Record<DriftCategory, { label: string; color: (s: string) => string; icon: string }> = {
@@ -328,9 +363,10 @@ export function summarize(drift: ManagedDriftEntry[]): string {
  * get their own heading, and their row counts, because "how long will this hold
  * the table" is the question they raise and the additive kinds do not.
  */
-export function renderPendingSchemaWork(pending: PendingSchemaWork[]): void {
+export async function renderPendingSchemaWork(pending: PendingSchemaWork[]): Promise<void> {
   if (pending.length === 0) return;
 
+  const isInPlaceSchemaWork = await loadIsInPlaceSchemaWork();
   const additive = pending.filter((p) => !isInPlaceSchemaWork(p.kind));
   const inPlace = pending.filter((p) => isInPlaceSchemaWork(p.kind));
 
@@ -367,7 +403,7 @@ function formatRows(rows: number | undefined): string {
   return rows === undefined ? '?' : rows.toLocaleString('en-US');
 }
 
-export function summarizePendingSchemaWork(pending: PendingSchemaWork[]): string {
+export async function summarizePendingSchemaWork(pending: PendingSchemaWork[]): Promise<string> {
   const creates = pending.filter((p) => p.kind === 'create_table').length;
   const columns = pending
     .filter((p) => p.kind === 'add_columns')
@@ -376,6 +412,7 @@ export function summarizePendingSchemaWork(pending: PendingSchemaWork[]): string
 
   // Only mentioned when there is some, so the common in-sync summary is
   // unchanged — but never omitted when there is, which is the #3954 point.
+  const isInPlaceSchemaWork = await loadIsInPlaceSchemaWork();
   const inPlace = pending.filter((p) => isInPlaceSchemaWork(p.kind));
   if (inPlace.length > 0) {
     const cols = inPlace.reduce((n, p) => n + p.columns.length, 0);


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5726

## 问题

`packages/cli/src/utils/schema-migrate.ts:17` 有一处顶层 value import:

```ts
import { isInPlaceSchemaWork } from '@objectstack/driver-sql';
```

这一行的代价**不由「需要 driver 的那条命令」承担**。oclif 的 `findCommand` 在**每次** CLI 调用时都会遍历命令表并 `import()` 每个命令模块,而这个文件被 **9 条命令**共用(`meta:resync`、`migrate`,以及 7 条 `migrate:*`)。所以只要 `packages/drivers/driver-sql/dist` 没构建:

1. 跑**任何**命令(包括 `os dev`)都会为这 9 条各打一段 `MODULE_NOT_FOUND`,刷在你真正要的输出前面(`dev` 还 fork 子进程,于是翻倍);
2. 更严重的是,这 9 条命令**直接从命令表里消失** —— `os migrate plan` 回答 `Command migrate:plan not found.`。

issue 记录时是 6 条命令 / 12 段;在当前 `origin/main` 上已经涨到 **9 条**(`migrate:meta`、`migrate:recorded-by`、`migrate:resume` 是后来加的)。这个放大器会随 migrate 子命令增加而继续变大。

## 改法(方向 1)

把那一处 value import 改成在**真正用到的地方**惰性加载:

```ts
async function loadIsInPlaceSchemaWork() {
  const { isInPlaceSchemaWork } = await import('@objectstack/driver-sql');
  return isInPlaceSchemaWork;
}
```

`renderPendingSchemaWork` / `summarizePendingSchemaWork` 随之变成 async,`migrate plan` / `migrate apply` 里的 5 处调用点加 `await`。第 16 行的 `import type` 不动 —— 纯类型导入会被完全擦除,不产生运行时边。

**刻意不在 CLI 里重写这个谓词。** 加性 / 原地(additive / in-place)的划分是关于 `PendingSchemaWorkKind` 的事实,声明在 driver 里那个联合类型旁边;CLI 复制一份,就等于哪天 driver 加一个 kind 时它**有权和 driver 不一致** —— 而它不一致的方式,恰恰是把「重写现有行」的工作列在那个承诺「绝不丢数据」的标题下面(#3954)。所以这是「一个定义,晚一点加载」,不是「各写各的」。

同理,`loadIsInPlaceSchemaWork` 刻意**不包 `try`**:渲染时调用方手里已经握着一个活的 SQL driver(要渲染的条目正是 `previewDeferredSchemaWork()` 返回的),模块必然已在 loader 缓存里;万一真加载失败,必须响亮地失败,而不是退回去猜哪些工作会重写数据。

## 实证(把 driver-sql 的 dist 临时 mv 走)

| | `os --version` | `os migrate plan --help` |
|---|---|---|
| 改前 | 9 段 MODULE_NOT_FOUND | 9 段 + `Command migrate:plan not found.`(exit 2) |
| 改后 | **0 段**,干净输出 | **完整 help,exit 0** |

构建产物侧:`packages/cli/dist/utils/schema-migrate.js` 改前有静态的 `import { isInPlaceSchemaWork } from '@objectstack/driver-sql';`,改后只剩动态的 `await import('@objectstack/driver-sql')`。

## 测试

新增 `packages/cli/src/utils/schema-migrate.lazy-driver-import.test.ts`,三条源码级钉子:

1. `packages/cli/src` 的生产代码里不允许有任何 `@objectstack/driver-*` 的静态 value import(`import type` 放行);
2. `schema-migrate.ts` 仍然通过 `await import()` 依赖 driver-sql —— 防止有人用「在 CLI 里重抄一份谓词」来满足第 1 条;
3. 两个 async 渲染函数的每个调用点都必须 `await`(丢 await 不是类型错误,只是输出和进程退出赛跑;仓库里已有 `formatOutput` 的同形 eslint 规则)。

之所以是**源码级**断言:缺陷长在 import 图的形状上,这是在编写期决定的,任何「把函数调起来跑一遍」的测试都看不见 —— 本包所有行为测试都跑在一个 driver 恰好已构建的工作区里。

**反向验证(方向:红,与事前预期一致)** —— 把第 17 行的静态 import 放回去,钉子 1 立刻变红并点名:

```
- []
+ [ "utils/schema-migrate.ts: import { isInPlaceSchemaWork } from '@objectstack/driver-sql'" ]
```

钉子 2、3 保持绿。这是诚实的方向:放回静态 import 既不会删掉动态 import,也不会把调用点的 await 拿掉,所以只有守护「静态导入形状」的那一条应该动。

`pnpm --filter @objectstack/cli typecheck` 通过;`pnpm --filter @objectstack/cli test` **85 文件 / 836 用例全绿**。

## ⚠️ 给下一个人:issue 里那份「假漂移」清单是假的,别去修

排查这类问题时,你很可能会顺手跑 `pnpm --filter @objectstack/driver-sql build`,然后拿到 20+ 条**看起来非常像真实类型契约漂移**的错误:

```
src/schema-drift.ts(33,10): error TS2305: Module '"@objectstack/spec/data"' has no exported member 'isAppResolvedDefaultToken'.
src/schema-drift.ts(442,9): error TS2322: Type '"default_mismatch"' is not assignable to type 'SchemaDiffEntryKind'.
src/memory-driver.ts(174,12): error TS2416: Property 'supports' ... Type '{}' is missing ... create, read, update, delete, and 27 more.
```

**这些全部是假象。** `isAppResolvedDefaultToken` 在 `packages/spec/src/data/default-value-tokens.ts:143` 好好地导出着;`'default_mismatch'` 也在 `packages/spec/src/shared/external-errors.ts` 的 `SchemaDiffEntryKind` 联合里 —— 只是**不在陈旧的 `packages/spec/dist` 里**。`pnpm install && pnpm build` 之后全部消失(issue 报告者实测 72/72 绿)。

正确修法永远是 `pnpm build`,不是去改 driver-sql / spec 的源码。**在正确的代码上「修」出真 bug,是这个 issue 最贵的失败模式** —— 这一节按分诊要求原样保留在这里当疫苗。

## 范围

严格限于分诊裁定的**方向 1**。issue 里的另外两个方向**均未触碰**,留给各自车道立单:

- 方向 2(`packages/services/service-datasource`):让 datasource 的 fail-fast 认出「工作区未构建」这个成因。**现状未变** —— 它仍然建议「Fix the datasource configuration」或设 `OS_ALLOW_DRIVER_CONNECT_FAILURE=1`,对这个成因两条都是有害建议(后者只会让一个构建不完整的工作区「启动成功」,然后对所有请求报错)。
- 方向 3(根 `dev` 脚本):加一次廉价的前置构建判定。

无用户可见行为变化:纯本地 / worktree 首启 DX;CI 里 build 永远在前,跑不出这个形态。changeset 为 `@objectstack/cli` patch 档。


---
_Generated by [Claude Code](https://claude.ai/code/session_01DWUR56YsttL5sTF72Q75TQ)_