### PR TITLE
docs(skills): 已发布 skill `objectstack-pm-dispatch` 的决策框架由两轴升为三轴(裁决 B:泛化内核后搬)

### DIFF
--- a/.changeset/published-pm-dispatch-three-axis-decision-frame.md
+++ b/.changeset/published-pm-dispatch-three-axis-decision-frame.md
@@ -1,0 +1,42 @@
+---
+---
+
+docs(skills): 已发布 skill `objectstack-pm-dispatch` 的决策框架由两轴升为三轴 —— 新增「实际业务需求」轴,内核泛化后搬 (#5451)
+
+#5130 把内部 agent 协议的决策评估轴由两条扩为三条,但同一套框架在**已发布目录**里还有
+一份镜像 —— `skills/objectstack-pm-dispatch/SKILL.md`(#4607 发布,`metadata.domain:
+process`,无 `metadata.internal`,第三方 ObjectStack 项目可 `npx skills add` 安装),
+它仍是两轴。#5130 刻意把范围钉在 `.claude/`(改发布内容是用户可见变更),本单补齐,
+两份文本重新同构。
+
+维护者 2026-08-06 在 #5451 裁决 **B(泛化内核后搬)**,而不是原样搬或不搬:
+
+- **新增 Axis ①「real business need」,排在两条原有轴之前**——每个方案先问它服务的是
+  真实存在的业务场景还是投机性能力面;判据要求**实测而非推断**(谁在写这个键、谁在读
+  这个能力、示例应用与真实部署里的用法),「读起来像有用」不作数;无拉动的声明面按
+  **implementation-first** 处置(收窄声明使 `declared = enforced`,或让词表随未来实现
+  回归),而不是为声明补实现;**已发布但零消费的能力不因沉没成本获得豁免**。并写明这条
+  轴会**改变结论**:技术形状相同的两个发现可以仅凭这条轴得出相反裁决(一个因无业务拉动
+  退役,另一个因真实应用自证方向而裁「响亮拒绝而非退役」),只看后两条轴会得出同一个
+  答案。原两轴(项目长远合理性、防 AI 写代码/写元数据 app 犯错)**原文保留**,仅编号后
+  移为 Axis ② / ③。
+- **泛化纪律**:去掉内部版绑定的「我们是一个创业项目」自我描述,也不带入本仓专属先例
+  单号 —— 发布版是 project-agnostic 的,把我们的处境写进别人的决策机器,会让安装方的
+  PM agent 按错误前提做决策。**扩张姿态改由安装方项目自己的 conventions 文件声明**
+  (核心面尚在成形时从紧、平台面稳定后放宽),接进该 skill 既有的 config-over-hardcoding
+  机制:`conventionsFile` 配置项说明与「Adapting this loop to your project」表格各加
+  一处,与分支命名、release-note 产物、测试命令走同一条覆写路径。
+- 全文 7 处两轴措辞逐处升三轴:分诊一节的 `the deep two-axis`、升级流程的
+  `the two fixed axes below`、`#### The two-axis decision frame (binding)` 标题、
+  框架首句与收尾句的 `**both** axes`,以及**嵌入的 dev-agent 模板**里的
+  `Analyze every option on two fixed axes:` 与 `Justify your recommendation on both
+  axes`。模板那两处是关键:PM 按三轴呈报而开发 agent 按两轴上报,业务轴每次都要 PM 事后
+  补。文中仅保留一处 `the other two axes`,指的是 Axis ② / ③ 这「另外两条」,是三轴语境
+  下的正确表述。
+- `metadata.version` 1.0 → 1.1:已安装 1.0 的第三方据此看到这是一次内容修订。
+
+**空 frontmatter 是刻意的,不是遗漏**,沿 #4607 发布 PR 与 #5130 的同一先例:`skills/`
+不随任何 npm 包发布(没有 package 的 `files` 含它,分发路径是 `npx skills add` 直读
+仓库),因此没有包可署名 —— 署一个包会凭空造出一条其发布物未变更的 release 记录,并把
+PM skill 的说明塞进那个包的 CHANGELOG。本次变更对**装这份 skill 的人**可见,但不发布
+任何包。

--- a/skills/objectstack-pm-dispatch/SKILL.md
+++ b/skills/objectstack-pm-dispatch/SKILL.md
@@ -22,7 +22,7 @@ compatibility: >
   (MCP server) with issue/label/PR write access.
 metadata:
   author: objectstack-ai
-  version: "1.0"
+  version: "1.1"
   domain: process
   tags: pm, dispatch, backlog, triage, multi-agent, delivery, github, escalation, upstream
 ---
@@ -99,7 +99,7 @@ single-repository project work with no configuration at all.
 | `repos` | `string[]` | `[backlogRepo]` | Every repository work may land in. Used for label setup and for validating routing labels. |
 | `batch` | `number` | `3` | Maximum developer agents in flight at once. |
 | `mode` | `"subagent" \| "cloud"` | `"subagent"` | Dispatch backend — see [Dispatch backends](#dispatch-backends). |
-| `conventionsFile` | `string` | first existing of `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md` | Repository-relative path to the file that defines gates, branch rules, release-note artifacts and review policy. Injected by path into every dispatch. |
+| `conventionsFile` | `string` | first existing of `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md` | Repository-relative path to the file that defines gates, branch rules, release-note artifacts, review policy and the capability-expansion stance. Injected by path into every dispatch. |
 | `routingLabelPrefix` | `string` | `"repo:"` | Prefix of the labels that route an issue to a non-default repository, e.g. `repo:hotcrm-web`. Inert when `repos` has one entry. |
 
 **Unknown keys are an error, not a hint.** If the file contains a key not in
@@ -182,7 +182,7 @@ classify each:
 - **Maintainer confirm (`needs-user-decision`)** — design cards, feature or
   contract-shape proposals, multi-week programs needing appetite and
   sequencing, anything touching stored-data migration shape or removing a
-  shipped capability. The label alone is the inbox entry; the deep two-axis
+  shipped capability. The label alone is the inbox entry; the deep three-axis
   analysis is written when the card is actually taken up.
 - **Repair first** — a body truncated by GitHub's sanitizer cannot be
   dispatched. Comment the repair instruction and move on.
@@ -449,23 +449,44 @@ When something *does* pass the bar:
    no issue of its own.
 2. Write the analysis with: background, the precise question, the options, your
    recommendation, and the related issues / PRs / branches — **and analyze
-   every option on the two fixed axes below.**
+   every option on the three fixed axes below.**
 3. If the session is interactive, additionally ask the maintainer directly; the
    labeled issue remains the durable record either way. **Never** answer a
    product or architecture question on the maintainer's behalf.
 
-#### The two-axis decision frame (binding)
+#### The three-axis decision frame (binding)
 
-Every option in an escalation is analyzed on **both** axes. This framing is the
-core of the escalation, not decoration.
+Every option in an escalation is analyzed on **all three** axes. This framing is
+the core of the escalation, not decoration.
 
-**Axis ① — long-term architectural soundness for *this* project.** Which option
+**Axis ① — real business need.** Does this option serve a business scenario that
+**actually exists**, or a speculative capability surface? Ask it of every option
+*first*, before the architecture argument, because it can retire the question
+instead of answering it. The evidence must be **measured, not inferred**: who
+writes this key, who reads this capability, how the project's example apps and
+real deployments use it today. "It reads like it would be useful" does not
+count — and neither does "we already shipped it": a **shipped-but-unconsumed
+capability gets no sunk-cost exemption**. A declared surface with no pull is
+handled **implementation-first** — narrow the declaration until
+`declared = enforced` (retire it, or park the vocabulary and let it return with
+the implementation) rather than building implementation to justify a declaration
+nobody asked for. **How tight that default should be is your project's call, not
+this skill's:** declare the capability-expansion stance in your conventions file —
+tight while the core surface is still forming, more permissive once it is
+stable — and this axis reads it from there, like every other project-specific
+rule. This axis **changes verdicts** rather than decorating them: two findings
+of identical technical shape can be ruled opposite ways on it alone — one
+declared surface retired for lack of pull, another kept and made to *reject
+loudly* because a real app proved the direction. On the other two axes they
+would read the same, and that would be the wrong answer.
+
+**Axis ② — long-term architectural soundness for *this* project.** Which option
 matches where the project is going and a sustainable architecture — no
 workarounds, contract-first — rather than which is cheapest today. **Name the
 long-term cost of any patch-style option explicitly.** "We can special-case it
 here" is a valid option only when its future removal cost is stated.
 
-**Axis ② — making AI-authored code structurally hard to get wrong**, and
+**Axis ③ — making AI-authored code structurally hard to get wrong**, and
 especially AI-authored ObjectStack **metadata**. Prefer the option that
 prevents the mistake at authoring time — a strict schema, publish-time
 validation that rejects loudly, declared = enforced — over consumer-side
@@ -475,7 +496,7 @@ reader turns a whole generation of wrong metadata into something that "works"
 until it does not. Never let an agent declare a capability the runtime does not
 honour.
 
-Your recommendation must be justified on **both** axes. If they conflict,
+Your recommendation must be justified on **all three** axes. If they conflict,
 present the trade-off honestly and let the maintainer decide.
 
 ### 9. Round report, then next round
@@ -571,7 +592,17 @@ or two readings of the issue lead to different architectures: make no guess,
 write no speculative code. Return status "needs_decision" with each question,
 the options, their costs, and your recommendation in open_questions. A wrong
 guess shipped is far more expensive than a round-trip to the maintainer.
-Analyze every option on two fixed axes:
+Analyze every option on three fixed axes:
+- Real business need — does the option serve a business scenario that ACTUALLY
+  EXISTS, or a speculative capability surface? Ask this first. The evidence must
+  be MEASURED, not inferred: who writes this key, who reads this capability, how
+  the project's example apps and real deployments use it today. "It reads like it
+  would be useful" does not count, and a shipped-but-unconsumed capability gets
+  no sunk-cost exemption. A declared surface with no pull is handled
+  implementation-first — narrow the declaration until declared = enforced
+  (retire it, or park the vocabulary until the implementation arrives) rather
+  than building implementation to justify the declaration. How tight the default
+  is comes from the project's conventions file, not from this template.
 - Long-term architectural soundness for THIS project — which option matches a
   sustainable architecture (no workarounds, contract-first), not which is
   cheapest today. Name the long-term cost of any patch-style option.
@@ -580,7 +611,7 @@ Analyze every option on two fixed axes:
   publish-time validation that rejects loudly, declared = enforced) over
   consumer-side tolerance. Lenient consumers are where AI-generated errors hide
   and multiply.
-Justify your recommendation on both axes; if they conflict, present the
+Justify your recommendation on all three axes; if they conflict, present the
 trade-off and let the maintainer decide.
 
 Return "blocked" (with evidence) when the default branch is broken under you, a
@@ -799,6 +830,7 @@ them into every dispatch:
 | Files owned by a release process that a code PR must never touch | conventions file |
 | Test / typecheck / lint commands per package | conventions file |
 | Merge policy (merge queue, serial merge, maintainer-only) | conventions file |
+| Capability-expansion stance the business-need axis reads (tight by default, or permissive) | conventions file |
 | Which repositories exist and which is the backlog | `.claude/pm-dispatch.json` |
 | Recorded architecture decisions the escalation bar defers to | the project's ADR directory |
 


### PR DESCRIPTION
Fixes #5451

#5130 把内部 agent 协议的决策评估轴由两条扩为三条,但同一套 binding 框架在**已发布目录**里还有一份镜像 —— `skills/objectstack-pm-dispatch/SKILL.md`(#4607 发布,`metadata.domain: process`,无 `metadata.internal`,第三方可 `npx skills add` 安装),它仍是两轴。#5130 刻意把范围钉在 `.claude/`(改发布内容是用户可见变更,且要先拍板泛化与否),本 PR 补齐,两份文本重新同构。

按维护者 2026-08-06 裁决 **B(泛化内核后搬)**,不是原样搬(A)也不是不搬(C)。

## 前提复核

issue 表格的 7 处行号基于 `01c0bae`,已漂移(当前 `main` 为 `1624f4ad2`),按内容重新定位 —— **7 处在当前 `main` 上依然全部是两轴**,前提成立。

## 新增 Axis ①「real business need」(排在两条原有轴之前)

保留可泛化内核四件套:

1. 每个方案**先问**它服务的是真实存在的业务场景,还是投机性能力面;
2. 判据必须**实测而非推断** —— 谁在写这个键、谁在读这个能力、示例应用与真实部署里的用法;「读起来像有用」不作数;
3. 无拉动的声明面按 **implementation-first** 处置:收窄声明使 `declared = enforced`(退役,或让词表随未来实现回归),而**不是**为声明补实现;
4. 已发布但零消费的能力**不因沉没成本获得豁免**。

并写明这条轴会**改变结论**而非陪衬:技术形状相同的两个发现可以仅凭这条轴得出相反裁决(一个因无业务拉动退役,另一个因真实应用自证方向而裁「响亮拒绝而非退役」),只看后两条轴会得出同一个答案。原两轴(项目长远合理性、防 AI 写代码/写元数据 app 犯错)**原文保留**,仅编号后移为 Axis ② / ③。

## 泛化纪律(B 与 A 的区别所在)

- ⛔ 去掉内部版绑定的「我们是一个创业项目」自我描述 —— 发布版是 project-agnostic 的,把我们的处境写进别人的决策机器,会让安装方的 PM agent 按错误前提做决策;
- ⛔ 不带入本仓专属先例单号(内部版引的 #5021 / #4988 / #4834 / #4936 一律匿名化为「两个技术形状相同的发现」);
- **扩张姿态改由安装方项目自己的 conventions 文件声明**(核心面尚在成形时从紧、平台面稳定后放宽),接进该 skill **既有的** config-over-hardcoding 机制,而不是新造一条路径:`conventionsFile` 配置项说明、以及「Adapting this loop to your project」表格各加一处,与分支命名、release-note 产物、测试命令走同一条覆写路径(「that file wins」)。

## 7 处措辞逐处升三轴

| 锚点 | 改前 | 改后 |
|---|---|---|
| 分诊一节 | `the deep two-axis` | `the deep three-axis` |
| 升级流程第 2 步 | `every option on the two fixed axes below` | `the three fixed axes below` |
| 框架标题 | `#### The two-axis decision frame (binding)` | `#### The three-axis decision frame (binding)` |
| 框架首句 | 分析 `on **both** axes` | `on **all three** axes` |
| 框架收尾句 | justified `on **both** axes` | `on **all three** axes` |
| **嵌入的 dev-agent 模板** | `Analyze every option on two fixed axes:` | `on three fixed axes:` + 新轴条目 |
| **嵌入的 dev-agent 模板** | `Justify your recommendation on both axes` | `on all three axes` |

模板那两处是关键:PM 按三轴呈报而开发 agent 按两轴上报,业务轴每次都要 PM 事后补。

全文一致性 grep 后,`two-axis` / `two fixed axes` / `both axes` **零残留**;唯一保留的 `axes` 旧词是一处 `the other two axes` —— 指 Axis ② / ③ 这「另外两条」,是三轴语境下的**正确**表述(对应内部版的「只看后两条轴」),不是漏改。

`metadata.version` 1.0 → 1.1:已安装 1.0 的第三方据此看到这是一次内容修订(生成器只读 frontmatter 的 `description`,版本号不进生成物,`check:skill-docs` 仍绿)。

## 与内部版对照(同构性可核)

| 轴 / 位置 | 内部 `.claude/`(#5130) | 本 PR 发布版 |
|---|---|---|
| 轴数 | 三条固定评估轴 | `three fixed axes` |
| Axis ① 名 | 实际业务需求 | `Axis ① — real business need` |
| Axis ① 判据 | 判据来源要求**实测** | `evidence must be measured, not inferred` |
| Axis ① 姿态 | 创业阶段聚焦原则(引维护者原话) | **泛化**:`How tight that default should be is your project's call` → conventions 文件 |
| Axis ① 无拉动处置 | implementation-first(退役 / 停车) | `implementation-first — narrow the declaration until declared = enforced` |
| Axis ① 沉没成本 | 不因沉没成本获得豁免(+ 三个本仓单号) | `no sunk-cost exemption`(单号**去除**) |
| Axis ① 改变结论 | 会改变结论,正反两例引单号 | `changes verdicts`,两例**匿名化** |
| Axis ② | 项目长远合理性 | `long-term architectural soundness`(原文,仅编号) |
| Axis ③ | 防 AI 写代码 / 元数据犯错 | `hard to get wrong`(原文,仅编号) |
| 收尾绑定句 | 必须基于这三条轴;三轴冲突如实呈现 | `justified on **all three** axes` |
| dev-agent 模板 | `.claude/agents/os-dev.md`(`three fixed axes` / `all three axes`) | 本文件内嵌模板同措辞 |

## 验证

- `pnpm check:doc-authoring` —— `362 files clean — no bare metadata literals`
- `pnpm --filter @objectstack/spec check:skill-docs` —— `✅ Skill docs in sync`
- `pnpm --filter @objectstack/spec check:skill-refs` —— `✅ 9 generated files in sync with packages/spec`
- `pnpm check:nul-bytes`(含 self-test)—— `scanned 5678 tracked text file(s) … no raw ASCII control bytes`;改动两文件另做越过门禁盲区的自扫(`grep -naP` 覆盖 0x0b/0x0c/0x0e-0x1f),零命中
- `node scripts/check-changeset-fixed.mjs` —— `"fixed" group is in sync with 70 public workspace packages`

**没有「先证红」环节,如实说明**:本改动是纯散文,`two-axis` → `three-axis` 不被任何门禁读取(这正是 #5798 记录的缺口)。把措辞改回去不会让任何测试变红,所以这里唯一有意义的验证是全文一致性 grep 与上面的两版对照表,而不是伪造一个方向性证据。

## changeset 说明(与派发预期不同,如实记录)

`.changeset/published-pm-dispatch-three-axis-decision-frame.md`,**空 frontmatter**,沿 #4607 发布 PR 与 #5130 的同一先例 —— 实测复核:**没有任何 npm 包的 `files` 含 `skills/`**,分发路径是 `npx skills add` 直读仓库。因此没有包可署名:署一个包会凭空造出一条「其发布物未变更」的 release 记录,并把 PM skill 的说明塞进那个包的 CHANGELOG。本次变更对**装这份 skill 的人**可见,但不发布任何包。

`pr-automation.yml` 现行提示把空 frontmatter 列为 last resort、`skip-changeset` 标签列为 preferred;这里仍取空 changeset,因为维护者在 #5451 明确要求「changeset(包名沿 #4607 先例)」,而该先例本身就是空 frontmatter,且它给这段镜像文本留下了可对账的 prose 记录(#4607 与 #5130 都把该框架的理由记在 changeset 里)。#4898 的全空停滞风险不成立:当前 pending 983 条非空 changeset。

## 范围外发现(未在本 PR 修)

- **#5798** —— 同一套 binding 决策框架在 `.claude/` 与已发布 `skills/` 各存一份手写副本,**无任何门禁保持同构**;#5451 本身就是这个缺口实测发火的产物(分叉两天,并额外耗掉一个 issue + 一轮裁决)。已独立立单(非子单:不在 #5451 的完成范围内;`Blocked-by: #5451` 仅为排序 —— 本 PR 合并前任何此类门禁在 `main` 上会天生红灯)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE)_