### PR TITLE
docs(core): narrow ANONYMOUS_DENY_BODY to the REST seam + pin both declared 401 envelopes (#5632)

### DIFF
--- a/packages/core/src/security/anonymous-deny.ts
+++ b/packages/core/src/security/anonymous-deny.ts
@@ -39,7 +39,49 @@ export const ANONYMOUS_DENY_STATUS = 401 as const;
 export const ANONYMOUS_DENY_CODE = 'UNAUTHENTICATED' as const;
 /** Human-facing message. */
 export const ANONYMOUS_DENY_MESSAGE = 'Authentication is required to access this endpoint.';
-/** The single 401 body shape every seam returns: `{ error, message }`. */
+/**
+ * The **REST seam's** 401 body — flat `{ error, message }`. NOT the platform's
+ * only one; see the two-envelope table below before you reuse this shape.
+ *
+ * Exactly one consumer writes it: `@objectstack/rest`'s `enforceAuth`
+ * (`rest-server.ts` — `res.status(ANONYMOUS_DENY_STATUS).json(ANONYMOUS_DENY_BODY)`),
+ * which owns the `/data/*` and `/meta` surfaces.
+ *
+ * ## Two live envelopes, one denial (#5632)
+ *
+ * Every HTTP seam shares the DECISION ({@link shouldDenyAnonymous}) and the
+ * semantics ({@link ANONYMOUS_DENY_STATUS} / {@link ANONYMOUS_DENY_CODE} /
+ * {@link ANONYMOUS_DENY_MESSAGE}). What differs is the **wrapper**:
+ *
+ *  - **REST seam** — `@objectstack/rest` `enforceAuth`, this constant, verbatim:
+ *    `{ error: 'UNAUTHENTICATED', message: '…' }`. The code is the value of the
+ *    top-level `error` key; there is no `success` key and no nesting.
+ *  - **Dispatcher seams** — the five runtime domains `domains/ai.ts`,
+ *    `domains/meta.ts`, `domains/security.ts`, `domains/actions.ts` and
+ *    `domains/automation.ts` do NOT use this constant. Each calls
+ *    `deps.error(ANONYMOUS_DENY_MESSAGE, ANONYMOUS_DENY_STATUS, { code: ANONYMOUS_DENY_CODE })`,
+ *    so the wire body is the dispatcher's standard wrapper:
+ *    `{ success: false, error: { code, message, httpStatus } }`.
+ *
+ * Both shapes are **live and sanctioned** — ADR-0112's 2026-07-30 amendment
+ * (#4007) records the flat and wrapped envelopes as the two live ones, and
+ * assigns retiring one of them to the envelope-convergence line (#3843 family).
+ * Converging them is a breaking wire change; it is not this module's to make,
+ * and this constant must not be read as if it had already happened.
+ *
+ * ## Reading this from a consumer (human or AI author)
+ *
+ * Read the envelope the seam you called DECLARES — flat from `/data` + `/meta`,
+ * wrapped from a dispatcher-mounted surface. Do **not** write a tolerant
+ * `body.error?.code ?? body.error` chain that swallows both: that fallback is
+ * precisely where an envelope regression hides, and this docstring claiming to
+ * be "the single shape every seam returns" is what used to invite it (#5632).
+ *
+ * Both shapes are pinned against a real booted showcase by
+ * `packages/qa/dogfood/test/showcase-anonymous-deny-surfaces.dogfood.test.ts`,
+ * which classifies every anonymous 401 into exactly one of the two families and
+ * fails on a third dialect or on a seam that changes family.
+ */
 export const ANONYMOUS_DENY_BODY = {
   error: ANONYMOUS_DENY_CODE,
   message: ANONYMOUS_DENY_MESSAGE,

--- a/packages/qa/dogfood/test/showcase-anonymous-deny-surfaces.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-anonymous-deny-surfaces.dogfood.test.ts
@@ -39,6 +39,12 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import { type VerifyStack } from '@objectstack/verify';
+import {
+  ANONYMOUS_DENY_BODY,
+  ANONYMOUS_DENY_CODE,
+  ANONYMOUS_DENY_MESSAGE,
+  ANONYMOUS_DENY_STATUS,
+} from '@objectstack/core';
 import { getSharedShowcase } from './shared-showcase.js';
 
 const OBJ = '/data/showcase_private_note';
@@ -54,6 +60,89 @@ const ACTION = '/actions/showcase_task/showcase_mark_done/anon-probe-id';
 // A real showcase flow declaration, so the deregister case names something that
 // genuinely exists in the app's metadata.
 const FLOW = 'showcase_reassign_wizard';
+
+// ── #5632 — the TWO declared anonymous-401 envelopes, as executable rules ───
+//
+// `ANONYMOUS_DENY_BODY`'s docstring in `@objectstack/core` used to call itself
+// "the single 401 body shape every seam returns". It never was: it is the REST
+// seam's shape, and the five dispatcher-mounted domains answer their own
+// wrapper. #5632 narrowed that docstring; the declarations here are the
+// executable half of the same statement, so the narrowed comment cannot rot
+// back into a lie without CI saying so.
+//
+// ── Division of labour with the #5631 slice at the bottom of this file ─────
+//
+// That case reads EACH FAMILY in its own declared shape and pins the code and
+// message the two share, spelled as string literals. Two things it cannot fail
+// on, by construction:
+//   1. a body that satisfies NEITHER declared envelope yet still survives —
+//      `toMatchObject` ignores unknown keys, so a re-nested or hybrid third
+//      dialect can pass it as long as the matched subset is still in there;
+//   2. drift between the literals spelled in this file and the constants
+//      `@objectstack/core` actually exports — the literals would just go stale.
+//
+// The cases added below close exactly those two and nothing else: every
+// anonymous 401 body is classified into EXACTLY ONE of the two declared
+// families by mutually exclusive predicates, that family is checked against a
+// declared seam→owner map, and only then are the code and message read —
+// through THAT family's own reader — and compared to the exported constants.
+// Deliberately NO `??` chain across the families: a tolerant cross-family read
+// is the very shape #5632 exists to keep out of this codebase.
+
+type DenyFamily = 'rest-flat' | 'dispatcher-wrapper';
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+/**
+ * The REST seam's envelope — `@objectstack/rest` `enforceAuth` writing
+ * `ANONYMOUS_DENY_BODY` verbatim. The machine code IS the top-level `error`
+ * value; there is no wrapper around it and no `success` flag.
+ */
+const isRestFlatDeny = (body: unknown): boolean =>
+  isRecord(body)
+  && typeof body.error === 'string'
+  && typeof body.message === 'string'
+  && !('success' in body);
+
+/**
+ * The dispatcher's envelope — what `deps.error(msg, status, { code })` writes
+ * in `domains/{ai,meta,security,actions,automation}.ts`. The code lives one
+ * level down under `error.code` and the status is restated in the body.
+ */
+const isDispatcherWrapperDeny = (body: unknown): boolean => {
+  if (!isRecord(body) || body.success !== false || 'message' in body) return false;
+  const err = body.error;
+  return isRecord(err)
+    && typeof err.code === 'string'
+    && typeof err.message === 'string'
+    && typeof err.httpStatus === 'number';
+};
+
+// The closed world. The two predicates are mutually exclusive where it counts:
+// `error` is a STRING in one and an OBJECT in the other, and each rejects the
+// other's discriminating key. Anything else on the wire matches neither.
+const DENY_ENVELOPES: Record<DenyFamily, (body: unknown) => boolean> = {
+  'rest-flat': isRestFlatDeny,
+  'dispatcher-wrapper': isDispatcherWrapperDeny,
+};
+
+/**
+ * Every declared envelope a body satisfies. The contract is EXACTLY ONE entry:
+ * an empty result means a third dialect reached the wire, two entries would
+ * mean the declarations stopped being mutually exclusive, and the wrong single
+ * entry means that seam changed family.
+ */
+const declaredFamiliesOf = (body: unknown): DenyFamily[] =>
+  (Object.keys(DENY_ENVELOPES) as DenyFamily[]).filter((family) => DENY_ENVELOPES[family](body));
+
+/** Read code + message with the family's OWN reader. Never a cross-family `??`. */
+const readDenial = (family: DenyFamily, body: unknown): { code: unknown; message: unknown } => {
+  if (!isRecord(body)) return { code: undefined, message: undefined };
+  if (family === 'rest-flat') return { code: body.error, message: body.message };
+  const err: Record<string, unknown> = isRecord(body.error) ? body.error : {};
+  return { code: err.code, message: err.message };
+};
 
 describe('showcase: anonymous posture is uniform across surfaces (#2567)', () => {
   let stack: VerifyStack;
@@ -199,5 +288,79 @@ describe('showcase: anonymous posture is uniform across surfaces (#2567)', () =>
     ]);
     expect([...codes]).toEqual(['UNAUTHENTICATED']);
     expect([...messages]).toEqual(['Authentication is required to access this endpoint.']);
+  });
+
+  // ── #5632: every 401 body is IN, and only in, one declared envelope ──────
+  //
+  // The ownership map. `owner` names the producer, so a failure reads as "this
+  // seam changed family" rather than "some assertion moved".
+  //
+  // Coverage, stated as measured rather than as assumed: five dispatcher
+  // domains hold an anonymous gate (ai / meta / security / actions /
+  // automation) and only the last two are drivable on THIS boot — probed on
+  // the same shared showcase stack these cases use:
+  //   - `GET /ai/status` answers 501 `NOT_IMPLEMENTED` (no
+  //     `@objectstack/service-ai` ships in the open framework, and that
+  //     domain's gate sits BEHIND its route match, so it never runs here);
+  //   - `GET /security/permissions` answers 404 (the showcase registration
+  //     path mounts no `/security`);
+  //   - `/meta` on this stack is served by `@objectstack/rest`, so it exercises
+  //     the flat family, not the dispatcher's meta domain.
+  // The wrapper family is therefore represented by actions + automation. Adding
+  // a row is the whole change needed the day another domain becomes reachable.
+  const DENIED_SEAMS: Array<{
+    seam: string;
+    owner: string;
+    family: DenyFamily;
+    call: () => Promise<Response>;
+  }> = [
+    { seam: 'GET /meta', owner: '@objectstack/rest enforceAuth', family: 'rest-flat', call: () => anon('GET', '/meta') },
+    { seam: `GET ${OBJ}`, owner: '@objectstack/rest enforceAuth', family: 'rest-flat', call: () => anon('GET', OBJ) },
+    { seam: 'POST /actions/:object/:action/:id', owner: 'runtime domains/actions.ts', family: 'dispatcher-wrapper', call: () => anon('POST', ACTION, { params: {} }) },
+    { seam: 'POST /automation/:name/trigger', owner: 'runtime domains/automation.ts', family: 'dispatcher-wrapper', call: () => anon('POST', `/automation/${FLOW}/trigger`, {}) },
+    { seam: 'GET /automation', owner: 'runtime domains/automation.ts', family: 'dispatcher-wrapper', call: () => anon('GET', '/automation') },
+    { seam: 'DELETE /automation/:name', owner: 'runtime domains/automation.ts', family: 'dispatcher-wrapper', call: () => anon('DELETE', `/automation/${FLOW}`) },
+  ];
+
+  it.each(DENIED_SEAMS)(
+    'anonymous $seam denies in exactly one declared envelope — $family, the one $owner writes (#5632)',
+    async ({ seam, family, call }) => {
+      const res = await call();
+      expect(res.status, `${seam}: anonymous must be denied with the shared status`).toBe(ANONYMOUS_DENY_STATUS);
+
+      const body = await res.json();
+
+      // ∈ the two declared shapes, and in ONLY one of them. No match at all =
+      // a third dialect reached the wire; the other family = this seam swapped
+      // wrappers. Both are red, and the message carries the body that did it.
+      expect(
+        declaredFamiliesOf(body),
+        `${seam}: body must satisfy the ${family} envelope and no other — got ${JSON.stringify(body)}`,
+      ).toEqual([family]);
+
+      // Only now the values, read through THAT family's own reader and compared
+      // to the exported constants themselves — so this pin follows the constants
+      // if they ever move, instead of quietly disagreeing with them.
+      const { code, message } = readDenial(family, body);
+      expect(code, `${seam}: machine code must be ANONYMOUS_DENY_CODE`).toBe(ANONYMOUS_DENY_CODE);
+      expect(message, `${seam}: message must be ANONYMOUS_DENY_MESSAGE`).toBe(ANONYMOUS_DENY_MESSAGE);
+    },
+  );
+
+  it('`ANONYMOUS_DENY_BODY` is the REST seam body, and NOT the dispatcher one (#5632)', async () => {
+    const flat = await anon('GET', '/meta').then((r) => r.json());
+    const wrapped = await anon('GET', '/automation').then((r) => r.json());
+
+    // The narrowed docstring's positive claim, on the wire: the exported
+    // constant IS what the REST seam writes, whole.
+    expect(flat, 'the REST seam must write ANONYMOUS_DENY_BODY verbatim').toEqual(ANONYMOUS_DENY_BODY);
+
+    // ...and its negative half, which is the part that was missing. If the
+    // envelope-convergence line (#3843 family) ever lands and the dispatcher
+    // adopts the flat body, THIS is the case that goes red and says the comment
+    // above `ANONYMOUS_DENY_BODY` is due for a rewrite — the constant would
+    // have become platform-wide, which is exactly what it must not claim today.
+    expect(wrapped, 'a dispatcher seam must NOT be writing the REST constant').not.toEqual(ANONYMOUS_DENY_BODY);
+    expect(declaredFamiliesOf(wrapped)).toEqual(['dispatcher-wrapper']);
   });
 });


### PR DESCRIPTION
Fixes #5632

按分诊预裁范围(评论 5197848801 = 正文方案 **1 + 3**)执行。**方案 2(wire 收敛)未做**:`rest-server.ts` 与 runtime `domains/*.ts` 行为一行未动,两个 live 信封的收敛归 envelope-convergence 线(#3843 family)统一排期。

最终 diff **仅注释 + 测试**,无运行时可见改动 → 请 PM 打 `skip-changeset` 标签(#4898 路线)。`packages/qa/dogfood` 是 `private: true`,不发版。

## 前提复核(先证后改,rule 6)

在动手时刻的 `origin/main`(`f205c32`)上重核:**前提成立**。

- `ANONYMOUS_DENY_BODY` 的唯一消费者是 `packages/rest/src/rest-server.ts:1961`(`res.status(ANONYMOUS_DENY_STATUS).json(ANONYMOUS_DENY_BODY)`),全仓 grep 除测试与 `security/index.ts` 的再导出外零命中。
- 五个 dispatcher domain 各自调 `deps.error(ANONYMOUS_DENY_MESSAGE, ANONYMOUS_DENY_STATUS, { code: ANONYMOUS_DENY_CODE })`:`domains/ai.ts:131`、`domains/meta.ts:62`、`domains/security.ts:95`、`domains/actions.ts:132`、`domains/automation.ts:154`。
- 因此「The single 401 body shape **every seam** returns」确为假。

## 两形状归属表

| 面 | 生产者 | 匿名 401 body | 族 |
|---|---|---|---|
| `GET /meta` | `@objectstack/rest` `enforceAuth` | `ANONYMOUS_DENY_BODY` 原样:`{ error: 'UNAUTHENTICATED', message }` | 扁平 |
| `GET /data/...` | 同上 | 同上 | 扁平 |
| `POST /actions/:object/:action/:id` | runtime `domains/actions.ts` | `{ success: false, error: { code, message, httpStatus } }` | wrapper |
| `POST /automation/:name/trigger` | runtime `domains/automation.ts` | 同上 | wrapper |
| `GET /automation` | 同上 | 同上 | wrapper |
| `DELETE /automation/:name` | 同上 | 同上 | wrapper |

status / code / message 三者全平台一致,**分歧只在 wrapper**;两者均为 live(ADR-0112 2026-07-30 修正案 / #4007 记录在案)。

## 1. 说谎的 docstring(`packages/core/src/security/anonymous-deny.ts`,仅注释)

`ANONYMOUS_DENY_BODY` 的一行注释扩成一段,窄化为 **REST seam 的形状**,并写全另一半:五个 dispatcher domain 走 `deps.error(...)` 的 wrapper 信封;两个信封均 live 且收敛归 #3843 family;**明确劝阻** `body.error?.code ?? body.error` 这类跨族容忍读(#5632 立单理由之一,#5569 的集成用例里就出现过这条 `??` 链);末尾指向本 PR 的 conformance 用例文件。导出值一字未改。

写法上刻意让下一个读者(尤其 AI)拿不到「唯一形状」这个读法:第一句就是 "NOT the platform's only one",并给出「你调哪个面就读哪个面 DECLARES 的信封」的操作性指令。

## 2. conformance 用例(`packages/qa/dogfood/test/showcase-anonymous-deny-surfaces.dogfood.test.ts`,+7 例,11 → 18)

落在 PR #5631 的匿名面切片同一文件,沿用其既有 harness(`getSharedShowcase()`,`shared-showcase` project),**未新建基建、未改 vitest 配置、未增加 boot 开销**。

**与 #5631 切片的分工**(测试注释里也写了这一段):#5631 那条用例把两族**各按自身声明显式断言**、并单独钉住共享的 code/message —— 用的是字符串字面量。它按构造无法失败的两件事:

1. 一个 **两族都不满足**却仍能通过的 body:dispatcher 那半用 `toMatchObject`,忽略未知键,重新嵌套 / 混合的第三种方言只要保留被匹配的子集就能过;
2. 文件里的字面量与 `@objectstack/core` 实际导出的常量之间的漂移 —— 字面量只会静静变陈旧。

本 PR 补的正是这两处,不重复已覆盖的部分:

- `DENY_ENVELOPES` 把两个信封声明成**互斥谓词**的闭世界(一族 `error` 是字符串且无 `success`,另一族 `success === false` 且 `error` 是带 `code`/`message`/`httpStatus` 的对象且顶层无 `message`);`declaredFamiliesOf(body)` 返回它满足的所有已声明族,**契约是恰好一个**。
- `DENIED_SEAMS` 是 seam → owner → 族 的**归属映射**;`it.each` 逐 seam 断言 `declaredFamiliesOf(body)` 恰等于 `[该 seam 声明的族]`。第三种方言 → `[]` 红;某 seam 换族 → 另一个族名 红,且两种失败在报错里可区分。
- code/message 用**该族自己的 reader** 读出后,直接与导出的 `ANONYMOUS_DENY_CODE` / `ANONYMOUS_DENY_MESSAGE` 比较(不再是本文件里的字面量)。⛔ 全程无 `??` 跨族容忍读。
- 追加一条常量归属用例:REST 面 body `toEqual(ANONYMOUS_DENY_BODY)`(窄化后 docstring 的正面主张,落到线上),且 dispatcher 面 `not.toEqual(ANONYMOUS_DENY_BODY)`(反面那半)。将来 #3843 家族真收敛、dispatcher 改发扁平信封时,红的就是这条 —— 它同时是「该回去重写那段注释」的提醒。

**覆盖面据实申报(实测,非假设)**:五个带匿名门的 dispatcher domain 里,本 boot 只有 actions / automation 可驱动。同一 shared showcase 上探针实测:`GET /ai/status` 答 501 `NOT_IMPLEMENTED`(开源框架不含 `@objectstack/service-ai`,且 ai domain 的门位于路由匹配**之后**,本 boot 根本不执行);`GET /security/permissions` 答 404(showcase 注册路径不挂 `/security`);`/meta` 在本 stack 由 `@objectstack/rest` 提供,走的是扁平族而非 dispatcher 的 meta domain。所以 wrapper 族由 actions + automation 代表 —— 这段话写进了测试注释,哪天某个 domain 变得可达,加一行表项即可。

## 反向验证(方向先判后跑)

预判**先写**(仅测试内 fixture 层面,产品代码零改动):

| 变异 | 预判 |
|---|---|
| M1 `GET /automation` 行喂第三种方言 `{ error: { code, message } }`(无 `success`/`httpStatus`) | 该行红,`declaredFamiliesOf` 得 `[]` |
| M2 `POST /actions/...` 行喂扁平信封(换族) | 该行红,得 `[ 'rest-flat' ]`,报错与 M1 **可区分** |
| M3 常量归属用例里 dispatcher body 换成 `ANONYMOUS_DENY_BODY` | 红在 `.not.toEqual(ANONYMOUS_DENY_BODY)` |
| 其余 4 条表项 + #5631 与更早的 11 条 | **照常绿** |
| 合计 | 15 passed / 3 failed |

实跑,逐条命中:

```
× anonymous 'POST /actions/:object/:action/:id' denies in exactly one declared envelope — 'dispatcher-wrapper', the one 'runtime domains/actions.ts' writes (#5632)
  AssertionError: POST /actions/:object/:action/:id: body must satisfy the dispatcher-wrapper envelope and no other
    — got {"error":"UNAUTHENTICATED","message":"..."}: expected [ 'rest-flat' ] to deeply equal [ 'dispatcher-wrapper' ]
× anonymous 'GET /automation' denies in exactly one declared envelope — 'dispatcher-wrapper', ...
  AssertionError: GET /automation: body must satisfy the dispatcher-wrapper envelope and no other
    — got {"error":{"code":"UNAUTHENTICATED","message":"..."}}: expected [] to deeply equal [ 'dispatcher-wrapper' ]
× `ANONYMOUS_DENY_BODY` is the REST seam body, and NOT the dispatcher one (#5632)
  AssertionError: a dispatcher seam must NOT be writing the REST constant

 Tests  3 failed | 15 passed (18)
```

变异已用 `git checkout` 还原,树与提交 `08111f5` 一致。

## 实跑记录(还原后)

```
pnpm --filter @objectstack/dogfood typecheck            -> tsc --noEmit,无输出,exit 0
pnpm --filter @objectstack/core build                   -> exit 0(core 无 typecheck 脚本,tsup 即编译门)
packages/core   npx vitest run src/security             -> Test Files 11 passed (11) | Tests 120 passed (120)
packages/qa/dogfood npx vitest run test/showcase-anonymous-deny-surfaces.dogfood.test.ts
                                                        -> Test Files 1 passed (1) | Tests 18 passed (18)   (main 基线 11,+7 = 本 PR)
node scripts/check-nul-bytes.mjs                        -> OK (scanned 5654 tracked text file(s); no raw ASCII control bytes)
node scripts/check-route-envelope.mjs                   -> ✓ 8 route module(s) audited;✓ Dispatcher domains 16 audited(0 ratcheted)
npx eslint --no-inline-config (两个改动文件)             -> exit 0,无输出
grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' (两个改动文件)  -> clean
```

## 自限

- 文件面只有两个:`packages/core/src/security/anonymous-deny.ts`(**仅注释**,导出值一字未改)与 `packages/qa/dogfood/test/showcase-anonymous-deny-surfaces.dogfood.test.ts`。
- 未触碰 `packages/rest/**`、`packages/runtime/**`、`content/docs/releases/`;未改 `authz-conformance.matrix.ts`(#5631 已按 #2567 惯例登记 actions / automation 两行,本 PR 不重复登记)。
- 运行 build 时 `packages/spec/authorable-surface.base.json` 被 `gen:schema` 顺带重锚到本分支基点,已 `git checkout` 还原,未进提交。

## 顺带发现(未在本 PR 修)

`packages/runtime/src/endpoint-policy.ts:273` 的 `anonymousDenial()` 注释写着 "same code, same message, **same envelope**",而它调用的 `apiErrorResponse`(`error-envelope.ts:129`)产出的正是 wrapper 信封 —— 与 REST seam 并非同一个信封,是 #5632 同一句谎话的第二个落点,而 #5632 正文未枚举到。已按 Prime Directive #10 单独立单 **#5800**(unassigned,查重后无重复),不在本 PR 修:分诊预裁把文件面锁死在上述两个文件,改第三个文件越界。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7WetGmnfoXNn8cLieKKmx