### PR TITLE
docs(plugin-auth): `degraded` 注释改为与实现一致 —— 两种有墙 posture 都会降级 (#5360)

### DIFF
--- a/packages/plugins/plugin-auth/src/tenancy-service.ts
+++ b/packages/plugins/plugin-auth/src/tenancy-service.ts
@@ -53,9 +53,9 @@ export type { TenancyPosture };
 export interface TenancyService {
   /**
    * The posture actually IN FORCE. Equals {@link requestedPosture} whenever the
-   * request can be enforced; an `isolated` request that cannot be (the
-   * enterprise package is absent) resolves to `single` — the deployment behaves
-   * single-org-like because nothing isolates its data — and sets
+   * request can be enforced; a walled request that cannot be — `group` or
+   * `isolated` alike (ADR-0105 D12) — resolves to `single`, because the
+   * deployment behaves single-org-like when nothing isolates its data, and sets
    * {@link degraded}.
    */
   readonly posture: TenancyPosture;
@@ -71,8 +71,12 @@ export interface TenancyService {
    * ADR-0093 D5); when it boots anyway, this flag brands the deployment
    * everywhere an operator looks (`/auth/config`, Setup dashboard).
    *
-   * Only reachable for `isolated` — `group` is enforced by the open engine, so
-   * it has no missing dependency to degrade against.
+   * Reachable for BOTH walled postures. `group` probes the enterprise
+   * `org-scoping` runtime exactly like `isolated` does (ADR-0105 D12) — the
+   * wall's CODE is open, but ACTIVATING a multi-organization posture is an
+   * entitlement. So either posture degrades when that runtime is absent, and
+   * also when it is installed but declares (`supportedPostures`) that it does
+   * not entitle the posture requested.
    */
   readonly degraded: boolean;
   /**


### PR DESCRIPTION
Fixes #5360

**comment-only, no runtime change, skip-changeset requested.**

## 问题

`packages/plugins/plugin-auth/src/tenancy-service.ts` 里 `TenancyService.degraded` 的文档注释结尾仍写着:

> Only reachable for `isolated` — `group` is enforced by the open engine, so it has no missing dependency to degrade against.

这是 ADR-0105 D12 修正前那一版的残留(当时 `group` 确实自激活),与**同一个文件 120 行之后的实现相反**。

## 前提复核(origin/main@`1624f4a`)

逐点对着实现核过,issue 的事实全部成立:

- `tenancy-service.ts:196-207` `isolationActive()`:`requestedPosture === 'single'` 直接 `false`,其余**两种有墙 posture 一视同仁**地 `deps.probeIsolation()`,注释里自己写着「BOTH walled postures probe」;
- `tenancy-service.ts:224-226` `degraded` = `postureEnforcesWall(requestedPosture) && !isolationActive()` —— `group` 请求 + 无 `org-scoping` ⇒ `degraded === true`;
- `packages/cli/src/commands/serve.ts:1831` 的 D5 启动闸门是 `const multiTenant = tenancyPosture !== 'single'`,`group` 同样走 FATAL / `OS_ALLOW_DEGRADED_TENANCY` 分支 —— 所以注释前半句「Boot is refused unless ...」对两种 posture 都成立,保留不动。

更强的佐证是**既有测试已经把实现钉死**,即错的是注释而不是代码(`tenancy-service.test.ts`):

- `requested: 'group'` + `probeIsolation: () => false` ⇒ `expect(t.degraded).toBe(true)`;
- `requested: 'group'` + runtime 已装但 `probeEntitledPostures: () => ['isolated']` ⇒ `expect(t.degraded).toBe(true)`。

## 改法

**以实现为准**,而不是照抄 issue 的措辞 —— 实现里降级有**两个**触发条件,issue 只提了第一个:

1. 企业版 `org-scoping` runtime 缺席(`probeIsolation()` 为假);
2. runtime 已装,但用 `supportedPostures` 声明**不授权**所请求的 posture(ADR-0105 D12 的授权接缝,`isolationActive()` 第 200-202 行)。

新注释两条都写了。

另外,**同一 interface 上方 `posture` 的注释有同源的 D12 残留** —— 它只举 `isolated`(「an `isolated` request that cannot be」)、且把原因只归给「the enterprise package is absent」。它不像 `degraded` 那句是直接说反,但属于同一批过时收窄,且就在被修的那句上方 15 行;只改一处会让读者在上一段仍得到同样的错误印象。故一并按同一事实收敛为「a walled request that cannot be — `group` 或 `isolated` alike」。**落点仍是单文件、仅注释。**

## 验证

零行为改动,注释无断言面,故不新增测试;既有测试全绿即为验收标准。

- `pnpm --filter '@objectstack/plugin-auth' typecheck` —— `tsc --noEmit` 无输出(通过);
- `pnpm --filter '@objectstack/plugin-auth' test` —— **Test Files 34 passed (34) / Tests 786 passed (786)**;
- `node scripts/check-nul-bytes.mjs` —— OK(5678 个文件,无裸控制字节)。

## 不做 changeset

注释-only,发布不可见,不提交空 changeset(#4898:空 changeset 滞留发布)。需要 `skip-changeset` 标签。


---
_Generated by [Claude Code](https://claude.ai/code/session_01JwwiU9bjhwy2SWj13ho8uv)_