### PR TITLE
fix(spec): 重锚 authorable-surface.base.json 改为显式动作 —— 构建不再顺手推进删除门的锚点

### DIFF
--- a/.changeset/authorable-surface-anchor-explicit.md
+++ b/.changeset/authorable-surface-anchor-explicit.md
@@ -1,0 +1,45 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): re-anchoring `authorable-surface.base.json` is an explicit act, not a build side effect (#5358)
+
+`packages/spec/authorable-surface.base.json` is the in-tree anchor the #4650 deletion gate
+falls back to where `origin/main` is out of reach (#5235). It is not a projection of this
+package's source — it is a snapshot of an **upstream** commit, and it is the baseline
+precisely because the commit under test cannot rewrite it.
+
+Until now every `gen:schema` run rewrote it whenever it had drifted from the git-resolved
+baseline. `gen:schema` is `pnpm build`'s first step, so this fired on any build of any
+package that merely has `@objectstack/spec` in its dependency closure, and on `check:docs`
+(whose first step is `gen:schema`). Three developers hit it independently, from three
+unrelated tasks:
+
+- a plain `pnpm build`: `baseRev` advanced to HEAD, **−110 keys**;
+- `pnpm --filter "@objectstack/cli^..." build`: the same 110;
+- `pnpm --filter "@objectstack/service-automation^..." build`: `baseRev` advanced, +3 keys.
+
+The 110 were the `ui/ComponentAnimation` family that had just been retired. An anchor
+advanced past a retirement cannot see that retirement any more — and the gate is green
+before *and* after, because both states are internally consistent. All three were caught
+only by reading `git status` line by line before committing; a `git add -A` would have
+carried the moved baseline into a PR about something else.
+
+The anchor now moves only in a mode of its own:
+
+```bash
+pnpm --filter @objectstack/spec gen:authorable-surface-base   # build-schemas.ts --update-base
+```
+
+- `gen:schema` and any build: never write it. A lagging anchor prints one ℹ️ line saying so,
+  naming this command — lag was already not an error (on `main` the merge base is HEAD, so
+  the file necessarily trails its own surface by one PR).
+- `check:authorable-surface`: unchanged, still strictly read-only, and still fatal when the
+  committed anchor is missing, malformed, or inauthentic.
+- `--check --update-base` is refused: a check that repairs what it detects can never report it.
+
+Nothing about anchor **authenticity** changes: `baseRev` must still be an ancestor of
+`origin/main` with keys matching that commit's `authorable-surface.json`, the anchor is
+still written only from a git-resolved baseline (never from the build being checked), and
+the write still happens after the deletion gate has adjudicated the run, so the explicit
+mode cannot walk the baseline past an unproven deletion either.

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -186,6 +186,7 @@
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "gen:schema": "OS_EAGER_SCHEMAS=1 tsx scripts/build-schemas.ts",
+    "gen:authorable-surface-base": "OS_EAGER_SCHEMAS=1 tsx scripts/build-schemas.ts --update-base",
     "gen:openapi": "tsx scripts/build-openapi.ts",
     "gen:docs": "tsx scripts/build-docs.ts",
     "check:docs": "pnpm gen:schema && tsx scripts/build-docs.ts --check",

--- a/packages/spec/scripts/build-schemas-check-mode.test.ts
+++ b/packages/spec/scripts/build-schemas-check-mode.test.ts
@@ -47,7 +47,7 @@
 // then a faithful model of a build environment with no route to GitHub — the
 // last describe block below drives exactly that.
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -705,7 +705,10 @@ describe('build-schemas.ts — an in-tree anchor carries the deletion gate offli
       expect(status).toBe(1);
       expect(output).toContain('is not the baseline it claims to be');
       expect(output).toContain(SHED_FROM_ANCHOR);
-      expect(output).toContain('gen:schema');
+      // The remedy names the one command that may write this file — `gen:schema`
+      // stopped being it at #5358, and a prescription pointing at a command that
+      // no longer touches the file is the defect that issue is about.
+      expect(output).toContain('gen:authorable-surface-base');
     },
   );
 
@@ -782,8 +785,8 @@ describe('build-schemas.ts — an in-tree anchor carries the deletion gate offli
   );
 
   it(
-    'is a committed artifact: --check reports it missing without writing it, gen:schema creates it from the git baseline',
-    { timeout: SPAWN_TIMEOUT_MS * 2 },
+    'is a committed artifact: --check reports it missing without writing it, and only --update-base creates it',
+    { timeout: SPAWN_TIMEOUT_MS * 3 },
     () => {
       fs.rmSync(surfaceBasePath);
 
@@ -793,13 +796,217 @@ describe('build-schemas.ts — an in-tree anchor carries the deletion gate offli
       // A check reports; it does not repair (#4711).
       expect(fs.existsSync(surfaceBasePath)).toBe(false);
 
-      const write = run([]);
+      // A plain build says so loudly and still does not create it (#5358) — the
+      // gate above is where a missing committed artifact goes red, not here.
+      const build = run([]);
+      expect(build.status).toBe(0);
+      expect(build.output).toContain('a build no longer creates it (#5358)');
+      expect(build.output).toContain('gen:authorable-surface-base');
+      expect(fs.existsSync(surfaceBasePath)).toBe(false);
+
+      const write = run(['--update-base']);
       expect(write.status).toBe(0);
       expect(write.output).toContain('authorable-surface.base.json created at');
       const doc = JSON.parse(readSurfaceBase()) as { baseRev: string; keys: string[] };
       // Written from the git-resolved baseline — the merge base, not this tree.
       expect(doc.baseRev).toBe(head);
       expect(doc.keys).toEqual((JSON.parse(pristineSurface) as { keys: string[] }).keys);
+    },
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #5358 — the anchor moves only when a human asks for it.
+//
+// #5235 gave the anchor two properties: it may only be written from a
+// git-resolved baseline, and it is verified against origin/main wherever that is
+// reachable. Both are about WHAT gets written. Neither says WHEN — and the answer
+// was "on every run that regenerates", which meant every `pnpm build`, every
+// `pnpm --filter '<pkg>^...' build` whose closure contains @objectstack/spec, and
+// every `check:docs` (whose first step is `gen:schema`).
+//
+// Three developers reported the consequence independently, from three unrelated
+// tasks (#4990, #5155, #5660): a file they had never opened showed up modified in
+// `git status`, with `baseRev` advanced to the tip they branched from. Twice the
+// same run also dropped 110 keys — the `ui/ComponentAnimation` family #4988/#5321
+// had just retired. An anchor advanced past a retirement is an anchor that can no
+// longer SEE that retirement, and the #4650 deletion gate is green before and
+// after, because both states are internally consistent. The only thing standing
+// between that and a merged PR was three people reading `git diff` line by line.
+//
+// The fix is a mode, not a smarter heuristic: `--update-base` writes the anchor,
+// and nothing else does. What these tests pin is the negative — that a run which
+// is NOT that mode leaves the working tree exactly as it found it — because that
+// is the property `git add -A` can silently violate.
+describe('build-schemas.ts — only --update-base moves the in-tree anchor (#5358)', () => {
+  /** A live key held back from the older commit, so the anchor legitimately lags. */
+  const LAGGING_KEY = 'data/Object:label';
+
+  let older: string;
+  let tip: string;
+  let laggingAnchor: string;
+
+  beforeEach(() => {
+    // The real-world shape, built honestly: an OLDER upstream commit whose
+    // baseline is one key short, then the current origin/main tip carrying the
+    // full baseline. The anchor mirrors the older commit — authentic (its keys ARE
+    // that commit's baseline) and legitimately behind the merge base, which is
+    // exactly the state every checkout is in right after a surface change lands.
+    seedManifest((s) => s);
+    older = seedBase((s) => s.filter((k) => k !== LAGGING_KEY));
+    tip = seedBase((s) => s);
+    seedSurface((s) => s);
+    laggingAnchor = seedSurfaceBase(older, (k) => k.filter((x) => x !== LAGGING_KEY));
+    // Commit the fixture so the tree is CLEAN — `git diff --exit-code` is the
+    // acceptance criterion, and it can only mean something from a clean start.
+    // Only the two tracked artifacts: `git add -A` here would track the ~1600-file
+    // json-schema/ output, which every subsequent run rewrites, and the cleanliness
+    // assertions below would then measure the generator's own scratch space.
+    git('add', 'authorable-surface.base.json');
+    git('commit', '-q', '-m', 'fixture: lagging but authentic anchor');
+    git('update-ref', 'refs/remotes/origin/main', tip);
+    expect(git('status', '--porcelain', '-uno')).toBe('');
+  });
+
+  afterEach(() => {
+    git('update-ref', 'refs/remotes/origin/main', tip);
+  });
+
+  it(
+    'a plain build leaves the anchor byte-identical and the working tree clean',
+    { timeout: SPAWN_TIMEOUT_MS },
+    () => {
+      // THE regression test. Before #5358 this run rewrote the anchor to
+      // {baseRev: tip, keys: full} and exited 0, so `git status` showed a file the
+      // build's author never touched. `gen:schema` is `pnpm build`'s first step,
+      // which is why an unrelated PR was one `git add -A` away from carrying it.
+      const { status, output } = run([]);
+
+      expect(status).toBe(0);
+      expect(readSurfaceBase()).toBe(laggingAnchor);
+      expect(git('status', '--porcelain', '-uno')).toBe('');
+      // Silent is not enough: the run says the anchor lags, that this is not an
+      // error, and what the deliberate act would be.
+      expect(output).toContain('trails the baseline at');
+      expect(output).toContain('not an error');
+      expect(output).toContain('gen:authorable-surface-base');
+      expect(output).not.toContain('⚓');
+    },
+  );
+
+  it(
+    'a --check run leaves the anchor byte-identical and the working tree clean',
+    { timeout: SPAWN_TIMEOUT_MS },
+    () => {
+      // The literal acceptance criterion of #5358: run the gate on a clean tree,
+      // then `git diff --exit-code`. Unlike the case above this one already held
+      // on `main` — the anchor's write branch was `!CHECK` before this change too
+      // — so it is a pin, not a repair. It is here because "a check is read-only"
+      // is the property the whole file exists for (#4711), and the entry point
+      // that violated it was the neighbouring one.
+      const { status } = run(['--check']);
+
+      expect(status).toBe(0);
+      expect(readSurfaceBase()).toBe(laggingAnchor);
+      expect(git('status', '--porcelain', '-uno')).toBe('');
+    },
+  );
+
+  it(
+    '--update-base re-anchors to the git-resolved baseline, and says so',
+    { timeout: SPAWN_TIMEOUT_MS },
+    () => {
+      const { status, output } = run(['--update-base']);
+
+      expect(status).toBe(0);
+      expect(output).toContain('⚓');
+      expect(output).toContain(tip.slice(0, 12));
+      const doc = JSON.parse(readSurfaceBase()) as { baseRev: string; keys: string[] };
+      // From the merge base, never from this build's own emitted surface (#5235).
+      expect(doc.baseRev).toBe(tip);
+      expect(doc.keys).toEqual((JSON.parse(pristineSurface) as { keys: string[] }).keys);
+      expect(doc.keys).toContain(LAGGING_KEY);
+      // Restore the fixture for the sibling cases — beforeEach re-commits anyway,
+      // but a dirty tree between tests would make a failure here read as a failure
+      // there.
+      fs.writeFileSync(surfaceBasePath, laggingAnchor);
+    },
+  );
+
+  it(
+    '--update-base on an already-current anchor writes nothing and says nothing to do',
+    { timeout: SPAWN_TIMEOUT_MS },
+    () => {
+      const current = seedSurfaceBase(tip, (k) => k);
+      git('add', 'authorable-surface.base.json');
+      git('commit', '-q', '-m', 'fixture: anchor already at the merge base');
+
+      const { status, output } = run(['--update-base']);
+
+      expect(status).toBe(0);
+      expect(output).toContain('nothing to re-anchor');
+      expect(readSurfaceBase()).toBe(current);
+      expect(git('status', '--porcelain', '-uno')).toBe('');
+    },
+  );
+
+  it(
+    'refuses --check --update-base: a check that repairs what it detects can never report it',
+    { timeout: SPAWN_TIMEOUT_MS },
+    () => {
+      const { status, output } = run(['--check', '--update-base']);
+
+      expect(status).toBe(1);
+      expect(output).toContain('mutually exclusive');
+      expect(readSurfaceBase()).toBe(laggingAnchor);
+      expect(git('status', '--porcelain', '-uno')).toBe('');
+      // Refused before the 1600-schema generation, not after it.
+      expect(output).not.toContain('Generating JSON Schemas');
+    },
+  );
+
+  it(
+    'never writes the anchor from the build being checked — --update-base is powerless offline',
+    { timeout: SPAWN_TIMEOUT_MS },
+    () => {
+      // #5235's rule survives the new mode: with origin/main unreachable there is
+      // no git-resolved baseline, so there is nothing the flag may write FROM. A
+      // `--update-base` that fell back to this build's own surface would be the
+      // tree anchoring itself — the #4650 defect with a flag in front of it.
+      git('update-ref', '-d', 'refs/remotes/origin/main');
+      try {
+        const { status, output } = run(['--update-base']);
+
+        expect(status).toBe(0);
+        expect(output).toContain('origin/main is not resolvable');
+        expect(readSurfaceBase()).toBe(laggingAnchor);
+        expect(git('status', '--porcelain', '-uno')).toBe('');
+      } finally {
+        git('update-ref', 'refs/remotes/origin/main', tip);
+      }
+    },
+  );
+
+  it(
+    'still refuses to bless an unproven deletion in --update-base mode, and leaves the anchor alone',
+    { timeout: SPAWN_TIMEOUT_MS },
+    () => {
+      // Order is load-bearing (see the anchor block in build-schemas.ts): the
+      // deletion gate adjudicates first, so the re-anchoring mode cannot be used to
+      // walk the baseline past a deletion nothing proved. Without this, #5358's
+      // explicit command would be a laundering route the old side effect never was.
+      // The sabotage goes in the merge base — the anchor's own keys stay honest, so
+      // only the gate, not the authenticity check, can be what fires.
+      seedBase((s) => [...s, DELETED_LIVE].sort());
+      seedSurface((s) => s);
+
+      const { status, output } = run(['--update-base']);
+
+      expect(status).toBe(1);
+      expect(output).toContain('deleted without proof (#4650)');
+      expect(output).toContain(DELETED_LIVE);
+      expect(readSurfaceBase()).toBe(laggingAnchor);
+      expect(output).not.toContain('⚓');
     },
   );
 });

--- a/packages/spec/scripts/build-schemas.ts
+++ b/packages/spec/scripts/build-schemas.ts
@@ -46,13 +46,55 @@ const OUT_DIR = path.resolve(__dirname, '../json-schema');
 // ever emitted. json-schema/ itself is a gitignored build artifact, so this
 // file is the durable "last time" — see the disappearance check below (#2978).
 const MANIFEST_PATH = path.resolve(__dirname, '../json-schema.manifest.json');
-// `--check` verifies the two committed snapshots — the schema manifest and the
-// authorable surface — without rewriting either, so CI fails on an uncommitted
-// ADDITION too (the write and check paths share the same code — same discipline
-// as build-docs.ts). "Without rewriting" is load-bearing on both: a check that
-// repairs what it detects can never report it, and it silently edits the tree of
-// whoever ran it (#4711).
+// Three modes, one code path:
+//
+//   (default)       `gen:schema` — regenerate json-schema/ and, when they are
+//                   behind, the two committed PROJECTIONS of this source:
+//                   json-schema.manifest.json and authorable-surface.json.
+//   `--check`       `check:authorable-surface` — verify both snapshots without
+//                   rewriting either, so CI fails on an uncommitted ADDITION too
+//                   (the write and check paths share the same code — same
+//                   discipline as build-docs.ts). "Without rewriting" is
+//                   load-bearing: a check that repairs what it detects can never
+//                   report it, and it silently edits the tree of whoever ran it
+//                   (#4711).
+//   `--update-base` `gen:authorable-surface-base` — the ONLY mode that writes the
+//                   deletion gate's in-tree ANCHOR, authorable-surface.base.json.
+//                   See the flag's own comment below (#5358).
 const CHECK = process.argv.includes('--check');
+// `--update-base` re-anchors the in-tree baseline `authorable-surface.base.json`.
+// It is a MODE OF ITS OWN, and nothing else writes that file — not `--check`, not
+// a plain `gen:schema`, not the `pnpm build` that runs `gen:schema` as its first
+// step (#5358).
+//
+// Why the anchor is different in kind from this script's other two artifacts.
+// `json-schema.manifest.json` and `authorable-surface.json` are projections of
+// the source being built: regenerating them is always right, and their diff is
+// the change under review. The anchor is not a projection of anything local — it
+// is a snapshot of an UPSTREAM commit, the baseline the #4650 deletion gate
+// compares against precisely because the commit under test cannot rewrite it.
+// Refreshing it on every build made that guarantee conditional on nobody ever
+// running a build: three independent reports (#4990, #5155, #5660) each did a
+// `pnpm --filter '<pkg>^...' build` for an unrelated package, found the anchor
+// rewritten in `git status`, and caught it only by reading the diff by hand — one
+// of them net −110 keys, exactly the batch #4988/#5321 had just retired. Anchored
+// forward, the gate can no longer see that retirement, and BOTH states are green,
+// so nothing anywhere reports it. A `git add -A` is all it takes.
+//
+// So the anchor moves only when a human types this flag, and the move is then the
+// whole content of a reviewed diff rather than a rider on somebody else's PR.
+// Staleness stays what it always was — not an error (see the anchor block near
+// the end of this file): the gate proves the anchor AUTHENTIC, never current.
+const UPDATE_BASE = process.argv.includes('--update-base');
+if (CHECK && UPDATE_BASE) {
+  console.error(
+    `\n❌ --check and --update-base are mutually exclusive.\n\n` +
+      `   --check is a verification: it reports and never writes (#4711). --update-base is the\n` +
+      `   deliberate re-anchoring of authorable-surface.base.json (#5358). A run that did both\n` +
+      `   would be a check that repairs what it detects, which can never report it.`,
+  );
+  process.exit(1);
+}
 const SPEC_VERSION = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8')).version;
 const SCHEMA_BASE_URL = `https://schema.objectstack.io/v${SPEC_VERSION}`;
 
@@ -429,6 +471,12 @@ const AUTHORABLE_SURFACE_PATH = path.resolve(__dirname, '../authorable-surface.j
 const AUTHORABLE_SURFACE_BASE_PATH = path.resolve(__dirname, '../authorable-surface.base.json');
 const SURFACE_FILE_NAME = path.basename(AUTHORABLE_SURFACE_PATH);
 const SURFACE_BASE_FILE_NAME = path.basename(AUTHORABLE_SURFACE_BASE_PATH);
+/**
+ * The ONE command that (re)writes the in-tree anchor (#5358). Every prescription
+ * about that file names this and nothing else — a message that still said
+ * `gen:schema` would send the reader to a command that no longer touches it.
+ */
+const REANCHOR_COMMAND = 'pnpm --filter @objectstack/spec gen:authorable-surface-base';
 const RETIRED_MARK = ' [RETIRED]';
 
 interface AuthorableSurface { description: string; keys: string[] }
@@ -792,6 +840,19 @@ function computeSurfaceReachability(): SurfaceReachability {
   };
 }
 
+/**
+ * ⚠️ Every byte of this string is part of the anchor file's canonical form —
+ * `readCommittedSurfaceBase` compares the committed file against
+ * `serializeSurfaceBase()` and treats any difference as a hand-edit, fatally.
+ * So changing this text is not a comment edit: it invalidates the committed
+ * anchor in every checkout until someone re-anchors, which is itself the
+ * deliberate act #5358 made explicit. It is therefore left verbatim here, and
+ * "Written only by `gen:schema`" now UNDER-states the rule rather than
+ * contradicting it: the writer is still this generator (`scripts/build-schemas.ts`),
+ * but only in its `--update-base` mode (`gen:authorable-surface-base`), never on a
+ * plain build. Narrowing in the safe direction. Whoever next re-anchors should
+ * bring the sentence with them, in that same reviewed diff.
+ */
 const SURFACE_BASE_DESCRIPTION =
   'In-tree anchor for the authorable-surface deletion gate (#4650, #5235): a verbatim copy of the ' +
   'keys in authorable-surface.json as they stood at `baseRev`, a commit on origin/main. A build that ' +
@@ -832,7 +893,7 @@ function readCommittedSurfaceBase(): { raw: string; doc: AuthorableSurfaceBase }
       `\n❌ ${SURFACE_BASE_FILE_NAME} is malformed (#5235): it must carry a 40-hex \`baseRev\` and a\n` +
         `   \`keys\` array — the ${SURFACE_FILE_NAME} content at that commit.\n\n` +
         `   Restore it (\`git checkout -- packages/spec/${SURFACE_BASE_FILE_NAME}\`), or delete it and\n` +
-        `   run \`pnpm --filter @objectstack/spec gen:schema\` in a checkout that can reach origin/main.`,
+        `   run \`${REANCHOR_COMMAND}\` in a checkout that can reach origin/main.`,
     );
     process.exit(1);
   }
@@ -840,10 +901,10 @@ function readCommittedSurfaceBase(): { raw: string; doc: AuthorableSurfaceBase }
     console.error(
       `\n❌ ${SURFACE_BASE_FILE_NAME} does not match its generated form (#5235).\n\n` +
         `   This file is the deletion gate's anchor — the baseline a commit is not supposed to be\n` +
-        `   able to rewrite. Every byte in it must come from \`gen:schema\`, so a hand-edit is fatal\n` +
+        `   able to rewrite. Every byte in it must come from the generator, so a hand-edit is fatal\n` +
         `   here rather than repaired (the same call #4662 made for ${SURFACE_FILE_NAME}).\n\n` +
         `   Restore it (\`git checkout -- packages/spec/${SURFACE_BASE_FILE_NAME}\`), or delete it and\n` +
-        `   run \`pnpm --filter @objectstack/spec gen:schema\` in a checkout that can reach origin/main.`,
+        `   run \`${REANCHOR_COMMAND}\` in a checkout that can reach origin/main.`,
     );
     process.exit(1);
   }
@@ -880,8 +941,8 @@ function verifyCommittedSurfaceBase(
   const rev = committed.baseRev;
   const short = rev.slice(0, 12);
   const fix =
-    `   Run \`pnpm --filter @objectstack/spec gen:schema\` and commit the result — the generator\n` +
-    `   writes this file from the git-resolved baseline, which is the only thing it may come from.`;
+    `   Run \`${REANCHOR_COMMAND}\` and commit the result — that mode writes\n` +
+    `   this file from the git-resolved baseline, which is the only thing it may come from.`;
 
   // Fast path, and the common one right after a refresh: the anchor names the
   // very rev this run resolved out of git, so the baseline to compare against is
@@ -975,8 +1036,9 @@ function compareAnchorKeys(
 
 /**
  * Set when THIS run resolved the baseline from git. It is the ONLY input
- * `gen:schema` may write the in-tree anchor from: an offline build must never be
- * able to advance the anchor to its own state (#5235).
+ * `--update-base` may write the in-tree anchor from: an offline build must never
+ * be able to advance the anchor to its own state (#5235). The second half of that
+ * discipline is #5358 — no build writes it at all, only the explicit mode.
  */
 let gitResolvedAnchor: { rev: string; keys: string[] } | null = null;
 
@@ -1186,14 +1248,14 @@ function resolveSurfaceBase(): { rev: string; doc: AuthorableSurface } | null {
   }
 }
 
-// ─── The in-tree baseline anchor (#5235) ─────────────────────────────
+// ─── The in-tree baseline anchor (#5235, #5358) ──────────────────────
 //
-// Refreshed here, AFTER the deletion gate above has adjudicated this build —
-// order is load-bearing: a run that exits on an unproven deletion never reaches
-// this line, so the anchor can never be advanced past a deletion it did not
-// bless. And it is written only from `gitResolvedAnchor`, never from
-// `currentEntries`: an anchor computed from the tree being checked is an anchor
-// that tree can rewrite, which is the whole defect #4650 exists for.
+// Written here, AFTER the deletion gate above has adjudicated this build — order
+// is load-bearing: a run that exits on an unproven deletion never reaches this
+// line, so the anchor can never be advanced past a deletion it did not bless. And
+// it is written only from `gitResolvedAnchor`, never from `currentEntries`: an
+// anchor computed from the tree being checked is an anchor that tree can rewrite,
+// which is the whole defect #4650 exists for.
 //
 // Content therefore lags main by at most the last surface-changing PR — the
 // baseline at the merge base, not this branch's own state. That lag is what
@@ -1201,6 +1263,15 @@ function resolveSurfaceBase(): { rev: string; doc: AuthorableSurface } | null {
 // have to account for. Staleness is NOT an error (on `main` itself the merge base
 // IS HEAD, so the file necessarily trails its own surface by one PR); only
 // inauthenticity is, and `verifyCommittedSurfaceBase` above is what proves it.
+//
+// #5358 adds the third property, the one that makes the other two mean anything
+// outside CI: the write happens ONLY under `--update-base`. Until then this block
+// ran on every `gen:schema`, so every `pnpm build` in the repo — including builds
+// of packages that merely have `@objectstack/spec` in their dependency closure —
+// silently advanced the deletion gate's own baseline in the developer's worktree,
+// where the next `git add -A` swept it into a PR about something else. Lag is
+// harmless (it only ever asks a build to account for MORE keys); an unnoticed
+// advance is not (it asks for fewer, and forgets a retirement in the process).
 {
   const committed = readCommittedSurfaceBase();
   if (gitResolvedAnchor) {
@@ -1212,23 +1283,43 @@ function resolveSurfaceBase(): { rev: string; doc: AuthorableSurface } | null {
           `   It is a committed artifact: builds that cannot reach GitHub (image-build stages,\n` +
           `   air-gapped, fork, historical tag) anchor the #4650 deletion gate on it, and without it\n` +
           `   they have nothing to anchor on and fail.\n\n` +
-          `   Run \`pnpm --filter @objectstack/spec gen:schema\` and commit the result.`,
+          `   Run \`${REANCHOR_COMMAND}\` and commit the result.`,
       );
       process.exit(1);
     }
-    if (drifted && !CHECK) {
-      fs.writeFileSync(AUTHORABLE_SURFACE_BASE_PATH, serializeSurfaceBase(anchor.rev, anchor.keys));
-      console.log(
-        `\n⚓ ${SURFACE_BASE_FILE_NAME} ${committed ? 'refreshed to' : 'created at'} ` +
-          `${anchor.rev.slice(0, 12)} (${anchor.keys.length} keys) — commit it.`,
+    if (UPDATE_BASE) {
+      if (drifted) {
+        fs.writeFileSync(AUTHORABLE_SURFACE_BASE_PATH, serializeSurfaceBase(anchor.rev, anchor.keys));
+        console.log(
+          `\n⚓ ${SURFACE_BASE_FILE_NAME} ${committed ? 'refreshed to' : 'created at'} ` +
+            `${anchor.rev.slice(0, 12)} (${anchor.keys.length} keys) — commit it, on its own.`,
+        );
+      } else {
+        console.log(
+          `\n⚓ ${SURFACE_BASE_FILE_NAME} is already the baseline at ${anchor.rev.slice(0, 12)} ` +
+            `(${anchor.keys.length} keys) — nothing to re-anchor.`,
+        );
+      }
+    } else if (!committed) {
+      // Not fatal outside `--check`: this is a build, and the gate that must go
+      // red about a missing committed artifact already does, above. Loud, though —
+      // silently recreating it is what #5358 removed.
+      console.warn(
+        `\n⚠️  ${SURFACE_BASE_FILE_NAME} is missing, and a build no longer creates it (#5358).\n` +
+          `   It is a committed artifact the #4650 deletion gate anchors on where origin/main is out\n` +
+          `   of reach. Restore it (\`git checkout -- packages/spec/${SURFACE_BASE_FILE_NAME}\`) or\n` +
+          `   re-anchor deliberately: \`${REANCHOR_COMMAND}\`.`,
       );
-    } else if (drifted && committed) {
-      // Reported, never fatal: see the note above on `main`'s own merge base.
+    } else if (drifted) {
+      // Reported, never fatal, and never repaired here: see the notes above on
+      // `main`'s own merge base and on #5358.
       const recorded = new Set(committed.doc.keys);
       const behind = anchor.keys.filter((k) => !recorded.has(k)).length;
       console.log(
-        `ℹ️  ${SURFACE_BASE_FILE_NAME} trails the merge base by ${behind} key(s) — expected right after\n` +
-          `   a surface change lands; \`gen:schema\` refreshes it on the next run that regenerates.`,
+        `ℹ️  ${SURFACE_BASE_FILE_NAME} trails the baseline at ${anchor.rev.slice(0, 12)} by ${behind} key(s)\n` +
+          `   — expected, and not an error: the anchor is a snapshot of an upstream commit, proved\n` +
+          `   AUTHENTIC rather than current. Re-anchoring is a deliberate act with its own reviewed\n` +
+          `   diff — \`${REANCHOR_COMMAND}\` — never a side effect of this build (#5358).`,
       );
     }
   }

--- a/packages/spec/scripts/check-generated-ledger.test.ts
+++ b/packages/spec/scripts/check-generated-ledger.test.ts
@@ -71,6 +71,19 @@ describe('check:generated --reconcile-only', () => {
     expect(output).toContain('all classified');
   });
 
+  it('covers the explicit, manual-only anchor generator (#5358)', () => {
+    // `gen:authorable-surface-base` is the third classification this ledger
+    // carries, and the one most likely to be mis-filed by a later change:
+    // UNGATED_GENERATORS would claim nothing verifies its artifact (false —
+    // check:authorable-surface proves the anchor authentic), while a GATED entry
+    // would put it in reach of `--fix`, which is the side effect #5358 removed.
+    expect(scripts['gen:authorable-surface-base']).toBeDefined();
+    expect(scripts['gen:authorable-surface-base']).toContain('--update-base');
+    const { status, output } = runReconcile();
+    expect(status, output).toBe(0);
+    expect(output).toContain('1 explicit manual-only generators');
+  });
+
   it('covers the test-layer typecheck gate and its writer (#5286)', () => {
     // The specific pair that failed CI on this branch. Named here so a later
     // change that drops either script also has to come back through this file.

--- a/packages/spec/scripts/check-generated.ts
+++ b/packages/spec/scripts/check-generated.ts
@@ -163,6 +163,31 @@ const UNGATED_GENERATORS: ReadonlyArray<{ gen: string; why: string }> = [
   { gen: 'gen:sbom', why: 'the SBOM is a release artifact, regenerated at publish time rather than checked in' },
 ];
 
+/**
+ * Generators that are DELIBERATE, manual-only acts. Their artifact **is** gated —
+ * `gatedBy` names the gate — so `UNGATED_GENERATORS` would be a false
+ * classification in one direction; but a `GATED` entry would be false in the
+ * other, because `--fix` may not run them and "stale" is not a defect for them.
+ *
+ * The distinction is `authorable-surface.base.json`, and it is the whole of
+ * #5358. That file is not a projection of this package's source — it is a
+ * snapshot of an UPSTREAM commit, the baseline the #4650 deletion gate compares
+ * against precisely because the commit under test cannot rewrite it. Its gate
+ * proves it AUTHENTIC (`baseRev` on origin/main, keys matching that commit), never
+ * current, so lag is expected and green. While `gen:schema` refreshed it as a side
+ * effect, any build of any package with spec in its dependency closure moved the
+ * gate's baseline in the developer's worktree, and a `git add -A` carried the move
+ * into an unrelated PR — observed three times (#4990, #5155, #5660), once at
+ * −110 keys covering a retirement that had just landed.
+ */
+const EXPLICIT_GENERATORS: ReadonlyArray<{ gen: string; gatedBy: string; why: string }> = [
+  {
+    gen: 'gen:authorable-surface-base',
+    gatedBy: 'check:authorable-surface',
+    why: 're-anchors authorable-surface.base.json to the git-resolved baseline — a deliberate act with its own reviewed diff, never a build side effect (#5358)',
+  },
+];
+
 /** This aggregate itself — a `check:` script that gates nothing of its own. */
 const SELF = 'check:generated';
 
@@ -179,7 +204,11 @@ const SELF = 'check:generated';
 function reconcileLedger(scripts: Record<string, string>): void {
   const problems: string[] = [];
   const declaredChecks = new Set([...GATED.map((g) => g.check), ...NO_GENERATOR.map((n) => n.check)]);
-  const declaredGens = new Set([...GATED.map((g) => g.gen), ...UNGATED_GENERATORS.map((u) => u.gen)]);
+  const declaredGens = new Set([
+    ...GATED.map((g) => g.gen),
+    ...UNGATED_GENERATORS.map((u) => u.gen),
+    ...EXPLICIT_GENERATORS.map((e) => e.gen),
+  ]);
 
   for (const name of Object.keys(scripts)) {
     if (name === SELF) continue;
@@ -189,13 +218,27 @@ function reconcileLedger(scripts: Record<string, string>): void {
     }
     if (name.startsWith('gen:') && !declaredGens.has(name)) {
       problems.push(`  \`${name}\` exists in package.json but no GATED entry names it and it is not in UNGATED_GENERATORS.\n` +
-        `    Either wire its gate in, or record why its output is unverified.`);
+        `    Either wire its gate in, record why its output is unverified, or — if it is a\n` +
+        `    deliberate manual-only re-anchoring whose artifact another gate already verifies —\n` +
+        `    declare it in EXPLICIT_GENERATORS with the gate that covers it.`);
     }
   }
   for (const { check } of GATED) if (!scripts[check]) problems.push(`  GATED names \`${check}\`, which package.json no longer has.`);
   for (const { gen } of GATED) if (!scripts[gen]) problems.push(`  GATED names \`${gen}\`, which package.json no longer has.`);
   for (const { check } of NO_GENERATOR) if (!scripts[check]) problems.push(`  NO_GENERATOR names \`${check}\`, which package.json no longer has.`);
   for (const { gen } of UNGATED_GENERATORS) if (!scripts[gen]) problems.push(`  UNGATED_GENERATORS names \`${gen}\`, which package.json no longer has.`);
+  for (const { gen, gatedBy } of EXPLICIT_GENERATORS) {
+    if (!scripts[gen]) problems.push(`  EXPLICIT_GENERATORS names \`${gen}\`, which package.json no longer has.`);
+    // The claim that makes this category honest rather than an escape hatch: the
+    // artifact IS covered. A `gatedBy` naming a gate this ledger does not run
+    // would be a coverage hole wearing a classification's clothes.
+    if (!declaredChecks.has(gatedBy)) {
+      problems.push(
+        `  EXPLICIT_GENERATORS says \`${gen}\` is gated by \`${gatedBy}\`, which this ledger does not declare.\n` +
+          `    An explicit generator is only "covered" if some gate here verifies its artifact.`,
+      );
+    }
+  }
 
   if (problems.length) {
     console.error(`✗ check:generated ledger is out of sync with package.json:\n\n${problems.join('\n')}\n`);
@@ -234,7 +277,8 @@ if (reconcileOnly) {
   console.log(
     `✓ check:generated ledger reconciles with package.json: ${checks} check: + ${gens} gen: scripts, ` +
       `all classified (${GATED.length} gated, ${NO_GENERATOR.length} source audits, ` +
-      `${UNGATED_GENERATORS.length} ungated generators, 1 aggregate).\n` +
+      `${UNGATED_GENERATORS.length} ungated generators, ${EXPLICIT_GENERATORS.length} explicit ` +
+      `manual-only generators, 1 aggregate).\n` +
       `  --reconcile-only: no gates were run — this verifies coverage, not artifacts.`,
   );
   process.exit(0);
@@ -265,6 +309,12 @@ console.log(`\nNot run here (${NO_GENERATOR.length} source audits with no artifa
 if (UNGATED_GENERATORS.length) {
   console.log(`Generated but ungated (${UNGATED_GENERATORS.length}): ` +
     UNGATED_GENERATORS.map((u) => u.gen).join(', ') + ' — nothing verifies these are current.');
+}
+// Narrowing is never silent, part two: --fix will not reach these, by design.
+if (EXPLICIT_GENERATORS.length) {
+  console.log(`Explicit, manual-only (${EXPLICIT_GENERATORS.length}): ` +
+    EXPLICIT_GENERATORS.map((e) => `${e.gen} (gated by ${e.gatedBy})`).join(', ') +
+    ' — never run here or by --fix; their artifact may lag and still be green.');
 }
 
 if (!stale.length) {

--- a/scripts/regen-artifacts.mjs
+++ b/scripts/regen-artifacts.mjs
@@ -23,14 +23,26 @@ export const REGEN_ARTIFACTS = Object.freeze([
   { path: 'packages/spec/spec-changes.json', gen: 'gen:spec-changes', check: 'check:spec-changes' },
   { path: 'docs/protocol-upgrade-guide.md', gen: 'gen:upgrade-guide', check: 'check:upgrade-guide' },
   { path: 'packages/spec/authorable-surface.json', gen: 'gen:schema', check: 'check:authorable-surface' },
-  // The deletion gate's in-tree anchor (#5235). Same generator, same sorted-array
-  // shape, same conflict — two branches that each refreshed it differ on the
-  // `baseRev` header and on whatever main added in between, and the resolution is
-  // always "recompute from the merged tree's merge base", never a text merge.
-  // Unlike its neighbours a stale copy of this one is NOT an error (on `main` the
-  // merge base is HEAD, so the file necessarily trails its own surface by one
-  // PR) — `check:authorable-surface` proves it AUTHENTIC rather than current, and
-  // `gen:schema` is still what restores it.
+  // The deletion gate's in-tree anchor (#5235). Same sorted-array shape, same
+  // conflict — two branches that each re-anchored it differ on the `baseRev`
+  // header and on whatever main added in between, and a text merge of that is
+  // never right, so it stays driver-managed.
+  //
+  // But it is the one path here with NOTHING TO REGENERATE after a merge. A stale
+  // copy is not an error (on `main` the merge base is HEAD, so the file
+  // necessarily trails its own surface by one PR): `check:authorable-surface`
+  // proves it AUTHENTIC — `baseRev` on origin/main, keys matching that commit —
+  // never current. Either side of the conflict is an authentic upstream snapshot,
+  // so the driver keeping OURS is already the resolution, and the pre-commit gate
+  // passes on it as-is.
+  //
+  // `gen` therefore still names `gen:schema` — correct for this file's two
+  // neighbours, which a merge defers alongside it, and a harmless no-op for this
+  // one since #5358 took the anchor out of every build. It deliberately does NOT
+  // name the re-anchoring command (`gen:authorable-surface-base`): that mid-merge
+  // is exactly #5370, where `merge-base(HEAD, origin/main)` still resolves to the
+  // branch's OLD fork point and the anchor moves BACKWARDS — authentically, so no
+  // gate objects. Re-anchor after the merge is committed, or not at all.
   { path: 'packages/spec/authorable-surface.base.json', gen: 'gen:schema', check: 'check:authorable-surface' },
   { path: 'packages/spec/json-schema.manifest.json', gen: 'gen:schema', check: 'check:authorable-surface' },
   // `gen:api-surface` reads the BUILT `dist/*.d.ts`, never the source. On a


### PR DESCRIPTION
Fixes #5358

## 前提核验:一半已过期,一半仍然成立

按「issue 是线索不是规格」的要求,先对 `origin/main`(`1624f4ad`)复核了本单的两条现象。

**第 1 条(`--check` 会重写工作区)已经不成立。** `build-schemas.ts` 的锚点写入分支在当前 main 上已经是 `if (drifted && !CHECK)`,`--check` 不写。干净树实测:

```
$ pnpm --filter @objectstack/spec check:authorable-surface
ℹ️  authorable-surface.base.json trails the merge base by 8 key(s) — ...
$ git diff --exit-code ; echo $?
0
```

**第 2 条(构建/`gen:schema` 路径)完全成立**,也正是三条 issue 评论(#4990 / #5155 / #5660)复现的那条。同一棵干净树:

```
$ pnpm --filter @objectstack/spec gen:schema
⚓ authorable-surface.base.json refreshed to 1624f4ad209c (7927 keys) — commit it.
$ git status --porcelain
 M packages/spec/authorable-surface.base.json
-  "baseRev": "5acb93add66435880ffed0d3aff79db29ae1e932"
+  "baseRev": "1624f4ad209c7cbdf254dc7df109c1f2df6a8751"
```

所以本 PR 修的是**写入分支的触发条件**,而不是 `--check` 分支 —— 与评论区三位 dev 的结论一致(「修法覆盖 build 路径而不只是 `--check` 路径」)。`--check` 的只读性作为不变量被补了自证测试,但它今天本来就绿,下面「反向核验」一节如实标注了这一点。

## 为什么这个锚点和它的两个邻居不同

`gen:schema` 写三个受版本控制的产物。其中 `json-schema.manifest.json` 与 `authorable-surface.json` 是**本地源码的投影** —— 重新生成永远是对的,它们的 diff 就是被 review 的改动本身。

`authorable-surface.base.json` 不是任何本地东西的投影:它是**上游某个 commit 的快照**,是 #4650 删除门的基线,而它之所以有资格当基线,恰恰因为受测 commit 改不了它。把它做成「每次构建顺手刷新」,等于让这条保证依赖于「没有人跑过构建」。

代价是可量化的:一次触发 = 110 条删除(#4990 / #5155),而那 110 个正是 #4988/#5321 刚退役的 `ui/ComponentAnimation` 族。锚点越过退役点之后,删除门就再也看不见那次退役 —— 而且推进前后**两种状态门禁都判绿**,因为两者各自自洽(#5660 的观察)。三次都只靠人眼逐行读 `git status` 拦下。

滞后则是**安全方向**的:锚点越旧,离线构建需要交代的键只会更多,不会更少。

## 改法

给锚点一个属于它自己的模式,而不是加一条更聪明的启发式:

| 入口 | 对锚点的行为 |
|:---|:---|
| `gen:schema` / 任何 `pnpm build` / `check:docs` | **不写**。滞后时打印一行 ℹ️,说明这不是错误,并给出显式命令 |
| `check:authorable-surface`(`--check`) | 严格只读(不变);文件缺失/畸形/不真实仍然致命 |
| `gen:authorable-surface-base`(`--update-base`) | **唯一**写入路径 |
| `--check --update-base` | 在生成 1600 个 schema **之前**拒绝 —— 一次会修复自己所检测之物的核验永远报不出问题 |

真实性语义一个字没动:`baseRev` 仍须是 `origin/main` 的祖先且键集与该 commit 逐行一致;仍只从 git 解析出的基线写入(绝不从被检查的构建 —— 离线时 `--update-base` 同样无能为力);写入仍在删除门裁决**之后**,所以新的显式命令也无法把基线推过一次未获证明的删除(有测试)。

顺带修正的处方:所有指向该文件的错误信息此前都写「运行 `gen:schema`」,而 `gen:schema` 已经不再碰它 —— 全部改为指向新命令。这正是本单描述的缺陷类别(声明与实际不符),留着就是新的一处。

## 三处不在改动范围、但被显式处理的相邻面

1. **`SURFACE_BASE_DESCRIPTION` 常量刻意逐字未改。** 该字符串是锚点文件规范形式的一部分(`readCommittedSurfaceBase` 把任何差异判为手改并致命),改它就必须同时重锚该文件 —— 而本单的验收标准要求该文件与 `origin/main` 逐字节一致。因此描述里那句 "Written only by `gen:schema`" 现在是**欠描述**而非错误:写入者仍是同一个生成器 `scripts/build-schemas.ts`,只是收窄到 `--update-base` 一种模式。收窄方向是安全的。代码里留了注释说明,建议下一次真正重锚时把这句一并带上(那会是一个干净的、被 review 的 diff)。
2. **`scripts/regen-artifacts.mjs` 只改注释,`gen` 字段仍是 `gen:schema`。** 合并驱动打印的处方会照抄这个字段;若改成 `gen:authorable-surface-base`,驱动就会在 merge 未 commit 时**指示**用户跑那条命令 —— 那正是 #5370 的重演(MERGE 态下 `merge-base(HEAD, origin/main)` 仍是分支旧分叉点,锚点会向后倒退,且倒退后依然 authentic,没有门会拦)。保留 `gen:schema`:对该文件的两个邻居正确,对它自己是无害空操作。注释写清了这个取舍。
3. **`check:generated` 的账本**新增第三类 `EXPLICIT_GENERATORS`。`UNGATED_GENERATORS` 会谎称「没有门核验它」(`check:authorable-surface` 核验其真实性),`GATED` 又会把它放进 `--fix` 的射程(那正是本次移除的副作用)。新类别要求声明 `gatedBy`,且该门必须是本账本已声明的门,否则 reconcile 失败。

## 测试

新增 `build-schemas-check-mode.test.ts` 的 `#5358` 块(7 例),复用该文件已有的沙箱:把 `scripts/` 拷进临时目录、真建一个带 `refs/remotes/origin/main` 的 git 仓库,生产代码路径逐字节不变。fixture 是真实形状 —— 一个**滞后但真实**的锚点(指向更早的上游 commit,键集与该 commit 的 baseline 逐行一致),提交到干净树后再跑,断言就是本单要求的那条:`git status --porcelain -uno` 为空。

`pnpm --filter @objectstack/spec test`:**319 文件 / 8152 用例全绿**;`typecheck` 绿;`check:merge-driver` 绿;`check:generated --reconcile-only` 绿(`18 check: + 13 gen: scripts, all classified`)。

### 反向核验(方向先说,再跑)

把 `build-schemas.ts` 换回 `origin/main` 的版本、只留新测试,预测「构建路径的两条红、`--check` 那条绿」。实际 5 红 22 绿,与预测一致:

```
× catches the anchor being edited to hide a deletion（处方字符串已改）
× is a committed artifact: ... only --update-base creates it
× a plain build leaves the anchor byte-identical and the working tree clean
× --update-base on an already-current anchor writes nothing
× refuses --check --update-base
```

核心那条的断言就是本单的机制本身:

```
-   "baseRev": "5a9a43914afabfeb1a81a61f01656c612341e23a",
+   "baseRev": "1c9d32fccfc462091465321f34179d2b5cac156f",
+     "data/Object:label",
```

**如实说明:`a --check run leaves the anchor byte-identical` 这一条在旧代码下也是绿的。** 它不是修复的证据,而是不变量的钉子 —— 本单第 1 条现象在派单前就已被别的改动修掉了。把它写成红是不诚实的,所以这里标出来。

### 真仓库上的验收证据

```
$ pnpm --filter @objectstack/spec check:authorable-surface
$ git diff --exit-code -- packages/spec/authorable-surface.base.json   → 0
$ pnpm --filter @objectstack/spec gen:schema
ℹ️  authorable-surface.base.json trails the baseline at 1624f4ad209c by 8 key(s)
   — expected, and not an error: ... `gen:authorable-surface-base` — never a side effect of this build (#5358).
$ git diff --exit-code -- packages/spec/authorable-surface.base.json   → 0
$ pnpm --filter @objectstack/spec gen:authorable-surface-base
$ git status --porcelain -- packages/spec/authorable-surface.base.json → M   （显式命令确实生效）
```

本 PR 中 `packages/spec/authorable-surface.base.json` 与 `origin/main` **逐字节一致**(上面第三步之后已 `git checkout --` 还原),不含任何一次性重锚。

`check:api-surface` 在本地报红,原因是这个全新 worktree 从未 `build` 过、`packages/spec/dist` 不存在(该门读 built `.d.ts`,即 AGENTS.md 记的 stale-dist 幻影)。本 diff 不含任何 `packages/spec/src/**` 文件,导出面不可能变。

## 对三条相邻单的影响(必答)

- **#5370(merge 未 commit 时 `gen:schema` 让锚点倒退)**:**大幅变简单,但没有变得不必要**。该单复现路径的字面触发点(照抄 os-regen 驱动的处方,在 merge 未 commit 时跑 `gen:schema`)在本 PR 之后消失了 —— `gen:schema` 已经完全不碰锚点。但根因(`resolveSurfaceBase()` 在 MERGE 态下把 `merge-base(HEAD, origin/main)` 解析成分支的旧分叉点)一个字没动,只是现在唯一能走到它的入口变成一条需要人手敲的显式命令。本 PR 特意**不**把驱动的处方改成指向新命令,以免把它重新变成一条被指示的路径。
- **#4663(`authorable-surface.json` 字节级 round-trip 门)**:**不受影响**。那是另一个文件(`.json`,不是 `.base.json`),而它的写入路径(`surfaceChanged && !CHECK`)本 PR 完全没动。锚点文件自己的字节级 round-trip 检查(`readCommittedSurfaceBase` 比对 `serializeSurfaceBase()`)也原样保留 —— 只是现在写它的模式变少了一种,这只会让「文件里的每个字节都来自生成器」更容易成立。
- **#4659(检查 (b) 的叶名匹配)**:**不受影响**。`registeredClauseMajors()` / `registeredRetirementSurfaces()` 的 `.split(' / ')` + `endsWith('.' + prop)` 逻辑本 PR 一行未改,判定谁调用它们的时机也没变。

## 越界发现

无。改动严格限于锚点写入分支及其处方,外加两处为保持一致必须同步的账本/注释(见上文第 2、3 点)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01559M8FVm6W6vDLABL3jvdW

---
_Generated by [Claude Code](https://claude.ai/code/session_01559M8FVm6W6vDLABL3jvdW)_