### PR TITLE
fix(plugin-auth): better-auth 的 `contains` 下译为 `$contains`,比较值不再当正则求值 (#5710)

### DIFF
--- a/.changeset/auth-contains-literal-substring.md
+++ b/.changeset/auth-contains-literal-substring.md
@@ -1,0 +1,27 @@
+---
+"@objectstack/plugin-auth": patch
+---
+
+fix(plugin-auth): better-auth 的 `contains` 下译为 `$contains`,比较值不再当正则求值 (#5710)
+
+`convertWhere()` 把 better-auth 的 `contains` 译成 `{ field: { $regex: value } }`,
+于是一个**未转义、来自调用方**的比较值(`/admin/list-users` 的 `searchValue`、
+SCIM 过滤值)坐进了正则的**模式位**。它的含义随后端分叉:
+
+- `driver-memory` 用 `new RegExp(value)` 求值 —— `contains('a.b')` 命中 `axb`,
+  `^x` 变成锚定,而值里一个不配对的 `(` 让模式非法(mingo 查询路径直接抛
+  `SyntaxError`,参考匹配器则吞成静默零命中);
+- `driver-sql` / `driver-sqlite-wasm` / `driver-turso` 编成子串
+  `LIKE '%value%'`(`%`/`_`/`\` 有转义、带显式 `ESCAPE`),元字符是字面量。
+
+同一个认证查询,在应用测试常用的内存替身上和生产的 SQL 后端上给出**不同答案**,
+且分叉发生在认证路径上。
+
+现在这一支发出 `$contains` —— 协议 `FILTER_OPERATORS` 里的算子,五后端都必须按
+**字面子串**求值,正是 better-auth `contains` 的本意(其 `Where.mode` 默认
+`"sensitive"`,与 #5701 Q2=A 裁定的 `$contains` 大小写敏感契约同向)。
+
+**对使用方的影响**:凭 `/admin/list-users?searchValue=…` 之类接口依赖「元字符按正则
+生效」的调用会改变结果 —— 那是本次修复的缺陷本身,不是可依赖的行为。搜索
+`a.b` 从此只命中含字面 `a.b` 的行,不再命中 `axb`;含非法正则字符的搜索值不再
+报错或静默返回空,而是按字面子串匹配。

--- a/packages/plugins/plugin-auth/package.json
+++ b/packages/plugins/plugin-auth/package.json
@@ -33,6 +33,7 @@
     "jose": "^6.2.5"
   },
   "devDependencies": {
+    "@objectstack/driver-memory": "workspace:*",
     "@objectstack/objectql": "workspace:*",
     "@types/node": "^26.1.2",
     "hono": "^4.12.34",

--- a/packages/plugins/plugin-auth/src/auth-contains-filter.test.ts
+++ b/packages/plugins/plugin-auth/src/auth-contains-filter.test.ts
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#5710] better-auth's `contains` is a LITERAL substring search — the adapter
+ * must not translate it into a bare `$regex`.
+ *
+ * `convertWhere()` used to emit `{ field: { $regex: condition.value } }`, which
+ * puts an unescaped, caller-supplied comparand (`/admin/list-users`'
+ * `searchValue`, a SCIM filter value) into a PATTERN position. What that value
+ * then means depended on the backend under the auth path:
+ *
+ *   - driver-memory compiled it to `new RegExp(value)` — `a.b` matched `axb`,
+ *     `^x` anchored, and an unbalanced `(` was an illegal pattern;
+ *   - driver-sql / -sqlite-wasm / -turso compiled it to a substring
+ *     `LIKE '%value%'` with `%`/`_`/`\` escaped — metacharacters literal.
+ *
+ * So one better-auth query answered differently on the memory double an app's
+ * tests run against and on the SQL backend production runs (#4706's shape, on
+ * the authentication path). These pins hold the operator at `$contains` — a
+ * member of the spec's `FILTER_OPERATORS`, i.e. one every backend is required
+ * to evaluate, as a literal substring.
+ *
+ * Two faces, deliberately: the first pins WHAT the adapter emits (the contract),
+ * the second pins what a real backend then ANSWERS (the behaviour). The first
+ * alone cannot see a translation that is spelled right and evaluated wrong; the
+ * second alone cannot say which operator earned the result.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { InMemoryDriver } from '@objectstack/driver-memory';
+import { FILTER_OPERATORS } from '@objectstack/spec/data';
+import type { IDataEngine } from '@objectstack/core';
+import { createObjectQLAdapterFactory } from './objectql-adapter';
+
+/** Keeps the driver's own lifecycle logging out of the test output. */
+const silentLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+} as any;
+
+/**
+ * A read-only engine facade over a REAL `InMemoryDriver`.
+ *
+ * Only the three read verbs the `contains` path uses are declared. The write
+ * verbs are deliberately absent rather than stubbed: seeding goes through the
+ * driver directly (below), so a hand-written `delete`/`update` here would be a
+ * dispatch contract this test neither needs nor is able to honour
+ * (`check:engine-double-contract`, #4550).
+ */
+function memoryReadEngine(driver: InMemoryDriver): IDataEngine {
+  return {
+    find: (object: string, query?: any) => driver.find(object, (query ?? {}) as any),
+    findOne: (object: string, query?: any) => driver.findOne(object, (query ?? {}) as any),
+    count: (object: string, query?: any) => driver.count(object, (query ?? {}) as any),
+  } as unknown as IDataEngine;
+}
+
+const NOW = new Date('2026-08-06T00:00:00.000Z').toISOString();
+
+/** Rows whose `name`s differ only in how a regex would read the comparand. */
+const SEED = [
+  { id: 'u_literal', name: 'a.b', email: 'literal@example.com' },
+  { id: 'u_wildcard', name: 'axb', email: 'wildcard@example.com' },
+  { id: 'u_paren', name: 'x(y', email: 'paren@example.com' },
+];
+
+async function seededAdapter() {
+  const driver = new InMemoryDriver({ logger: silentLogger });
+  await driver.connect();
+  for (const row of SEED) {
+    await driver.create('sys_user', { ...row, emailVerified: false, createdAt: NOW, updatedAt: NOW });
+  }
+  const adapter: any = (createObjectQLAdapterFactory(memoryReadEngine(driver)) as any)({} as any);
+  return { driver, adapter };
+}
+
+/** `findMany` with a single better-auth `contains` condition on `name`. */
+function containsQuery(value: string) {
+  return {
+    model: 'user',
+    where: [{ field: 'name', value, operator: 'contains', connector: 'AND' }],
+    limit: 100,
+  } as any;
+}
+
+describe('[#5710] convertWhere: better-auth `contains` → `$contains`', () => {
+  let engine: IDataEngine;
+
+  beforeEach(() => {
+    engine = {
+      insert: vi.fn().mockResolvedValue({ id: '1' }),
+      findOne: vi.fn().mockResolvedValue(null),
+      find: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue(0),
+    } as unknown as IDataEngine;
+  });
+
+  it('emits `$contains`, never a bare `$regex`, for a `contains` search', async () => {
+    const adapter: any = (createObjectQLAdapterFactory(engine) as any)({} as any);
+    await adapter.findMany(containsQuery('a.b'));
+
+    const [object, query] = (engine.find as any).mock.calls[0];
+    expect(object).toBe('sys_user');
+    expect(query.where).toEqual({ name: { $contains: 'a.b' } });
+    // Spelled out separately: `toEqual` above would still pass if a second,
+    // regex-shaped limb were added under a different field.
+    expect(JSON.stringify(query.where)).not.toContain('$regex');
+  });
+
+  it('emits an operator every backend is required to evaluate', () => {
+    // The whole point of the flip: `$contains` is in the protocol's runtime
+    // allowlist, `$regex` never was — it survived only because this adapter
+    // produced it (driver-memory's `filter-refusal.ts` says so in as many
+    // words), which is why #5702's loud refusal is ordered after this PR.
+    expect(FILTER_OPERATORS).toContain('$contains');
+    expect(FILTER_OPERATORS).not.toContain('$regex');
+  });
+
+  it('leaves the other operators untouched', async () => {
+    const adapter: any = (createObjectQLAdapterFactory(engine) as any)({} as any);
+    await adapter.findMany({
+      model: 'user',
+      where: [
+        { field: 'email', value: 'a@b.com', operator: 'eq', connector: 'AND' },
+        { field: 'name', value: ['x', 'y'], operator: 'in', connector: 'AND' },
+      ],
+      limit: 100,
+    } as any);
+
+    const [, query] = (engine.find as any).mock.calls[0];
+    expect(query.where).toEqual({ email: 'a@b.com', name: { $in: ['x', 'y'] } });
+  });
+});
+
+describe('[#5710] the comparand is a literal substring on a real backend', () => {
+  it('does not read `.` as a wildcard — `a.b` matches `a.b`, not `axb`', async () => {
+    const { adapter } = await seededAdapter();
+    const rows: any[] = await adapter.findMany(containsQuery('a.b'));
+
+    // The pin, stated in both directions: the metacharacter row is NOT matched
+    // (a bare `$regex` matched it through `.`), and the literal row still is.
+    expect(rows.map((r) => r.name)).toEqual(['a.b']);
+  });
+
+  it('does not read `^` as an anchor', async () => {
+    const { adapter } = await seededAdapter();
+    const rows: any[] = await adapter.findMany(containsQuery('^a'));
+
+    // As a pattern, `^a` matched `a.b` and `axb`. As a substring, nothing here
+    // contains the two characters `^a`.
+    expect(rows).toEqual([]);
+  });
+
+  it('matches a value that is not a legal regex, instead of failing on it', async () => {
+    const { adapter } = await seededAdapter();
+    const rows: any[] = await adapter.findMany(containsQuery('('));
+
+    // `new RegExp('(')` throws — under `$regex` this comparand could not
+    // produce an answer at all (the mingo path threw, the reference matcher
+    // swallowed it into a silent no-match). It is just a character now.
+    expect(rows.map((r) => r.name)).toEqual(['x(y']);
+  });
+
+  it('answers an ordinary metacharacter-free search unchanged', async () => {
+    const { adapter } = await seededAdapter();
+    const rows: any[] = await adapter.findMany(containsQuery('xb'));
+
+    expect(rows.map((r) => r.name)).toEqual(['axb']);
+  });
+});

--- a/packages/plugins/plugin-auth/src/auth-contains-filter.test.ts
+++ b/packages/plugins/plugin-auth/src/auth-contains-filter.test.ts
@@ -29,6 +29,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { InMemoryDriver } from '@objectstack/driver-memory';
 import { FILTER_OPERATORS } from '@objectstack/spec/data';
+import type { QueryAST } from '@objectstack/spec/data';
 import type { IDataEngine } from '@objectstack/core';
 import { createObjectQLAdapterFactory } from './objectql-adapter';
 
@@ -50,10 +51,13 @@ const silentLogger = {
  * (`check:engine-double-contract`, #4550).
  */
 function memoryReadEngine(driver: InMemoryDriver): IDataEngine {
+  // The query bag is forwarded with its declared driver-side type and no `any`
+  // erasure: `query-options/no-any-erasure` (#4674/#4918) counts a test-side
+  // `find(obj, … as any)` too, and nothing here needs to be off-contract.
   return {
-    find: (object: string, query?: any) => driver.find(object, (query ?? {}) as any),
-    findOne: (object: string, query?: any) => driver.findOne(object, (query ?? {}) as any),
-    count: (object: string, query?: any) => driver.count(object, (query ?? {}) as any),
+    find: (object: string, query: QueryAST) => driver.find(object, query),
+    findOne: (object: string, query: QueryAST) => driver.findOne(object, query),
+    count: (object: string, query?: QueryAST) => driver.count(object, query),
   } as unknown as IDataEngine;
 }
 

--- a/packages/plugins/plugin-auth/src/objectql-adapter.ts
+++ b/packages/plugins/plugin-auth/src/objectql-adapter.ts
@@ -134,7 +134,34 @@ function convertWhere(where: CleanedWhere[]): Record<string, any> {
     } else if (condition.operator === 'lte') {
       filter[fieldName] = { $lte: condition.value };
     } else if (condition.operator === 'contains') {
-      filter[fieldName] = { $regex: condition.value };
+      // [#5710] `$contains`, NOT `$regex`. better-auth's `contains` is a
+      // LITERAL substring search (`Where.mode` defaults to `"sensitive"`, and
+      // the value comes straight from a caller — `/admin/list-users`'
+      // `searchValue`), while `$regex` puts that value in a PATTERN position.
+      //
+      // What the bare `$regex` did, per backend, to one `contains('a.b')`:
+      //   - driver-memory: `new RegExp('a.b')` — `.` is a wildcard, so it
+      //     matched `axb`; an unbalanced `(` in the value made the pattern
+      //     illegal (a throw on the mingo path, a silent no-match on the
+      //     reference matcher's).
+      //   - driver-sql / -sqlite-wasm / -turso: compiled to a substring
+      //     `LIKE '%a.b%'` — metacharacters literal.
+      // One operator, two answers, and the divergence only shows up when the
+      // app's tests run on the memory double and production runs SQL (#4706).
+      //
+      // `$contains` is in the spec's `FILTER_OPERATORS` and every backend
+      // evaluates it as a literal substring (SQL side escapes `%`/`_`/`\` and
+      // emits an explicit `ESCAPE`), which is exactly better-auth's meaning.
+      // Case semantics follow the #5701 Q2=A ruling (`$contains` is
+      // case-SENSITIVE at the contract layer; the per-driver alignment is
+      // #5702's budget), which matches better-auth's own `mode: 'sensitive'`
+      // default.
+      //
+      // This is also the last live producer of `$regex` — it is what
+      // `driver-memory/src/filter-refusal.ts` means by "refusing it here would
+      // break a live producer", and the reason #5702's loud refusal is ordered
+      // after this flip.
+      filter[fieldName] = { $contains: condition.value };
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1432,6 +1432,9 @@ importers:
         specifier: ^6.2.5
         version: 6.2.7
     devDependencies:
+      '@objectstack/driver-memory':
+        specifier: workspace:*
+        version: link:../../drivers/driver-memory
       '@objectstack/objectql':
         specifier: workspace:*
         version: link:../../objectql


### PR DESCRIPTION
Fixes #5710

`packages/plugins/plugin-auth/src/objectql-adapter.ts` 的 `convertWhere()` 把 better-auth 的 `contains` 译成 `{ field: { $regex: value } }`,一个**未转义、来自调用方**的比较值坐进了正则的**模式位**,而且发生在认证路径上。本 PR 把这一支翻成 `$contains`。

## 前提复核(origin/main@`1624f4a`)

- 生产者仍在:`objectql-adapter.ts:137` 是 `filter[fieldName] = { $regex: condition.value }`(翻转前)。
- 活体消费面仍在:`driver-memory/src/filter-refusal.ts:145-158` 的 `SUPPORTED_FIELD_OPERATORS` 仍为 `new Set([...FILTER_OPERATORS, '$regex', '$options'])`,注释原话仍是「Refusing it here would break a live producer」。
- 真实调用方仍在:`GET /api/v1/auth/admin/list-users`(`auth-route-ledger.ts:161`)把 `searchOperator`(默认 `contains`)与 `filterOperator` 直接推进 `where`(better-auth `dist/plugins/admin/routes.mjs:358-368`)。
- 前提成立,按裁决实施。

## 目标算子:`$contains`,不是 `$icontains`(动手前验证的前提)

派发令要求先验证「`$icontains` 仍是纯声明面」再动手 —— 已验证,前提成立:

- `packages/spec/src/data/filter.zod.ts:1086-1096` 的 `FILTER_OPERATORS` **不含** `$icontains`(只有 `$contains`/`$notContains`/`$startsWith`/`$endsWith`);
- 该文件 1066-1081 行把这件事写成了刻意分期:`$icontains` 「joins this array in the PR that implements it (#5702), not before」;
- 因此若翻成 `$icontains`,driver-memory 的形状门会先拒收(fail-closed),而任何绕过拒收的面会走匹配器 `default: break` —— 谓词被静默丢弃,过滤放大成全匹配,在认证读路径上是越权读。

所以本单的目标算子是 `$contains`;`$icontains` 的执行面归 #5702。

## 大小写语义(派发令要求写进正文的判断)

**上游期望**:better-auth 的 `Where` 类型自带 `mode?: "sensitive" | "insensitive"`,**默认 `"sensitive"`**(`@better-auth/core/src/db/adapter/index.ts:324-343`)。也就是说 better-auth 的 `contains` 默认要的就是大小写**敏感**的字面子串,这与 #5701 Q2=A 裁定的 `$contains` 契约(大小写敏感)同向。spec 自己的退役处方也明写了这个二选一:`RETIRED_FILTER_OPERATORS.$regex.why` —— 「Write `$icontains` for the case-insensitive substring search …, **or `$contains` for a case-sensitive one**」。

**一处要诚实纠正的说法**:issue 正文与派发令都写了「裸 `$regex` 在 memory 上本来也是大小写敏感的,所以翻转对该 driver 等价」。这句话只对 driver-memory 的**参考匹配器**(`memory-matcher.ts` 的 `match()`,用 `String.includes`)成立,对**查询路径不成立**:

- 查询路径 `normalizeFieldOperators`(`memory-driver.ts:939-941`)把 `$contains` 降为 `new RegExp(escapeRegex(v), 'i')` —— 转义 + **`i` 标志**;
- 而裸 `$regex` 交给 mingo 时没有任何 flags,是大小写敏感的。

所以在 driver-memory 的**实际查询路径**上,本次翻转把大小写行为从「敏感」改成了「不敏感(全 Unicode 折叠)」。这不是本 PR 引入的越契约行为,而是该 driver 今天既有的状态 —— `scripts/check-driver-conformance.mjs` 的 driver-memory DEBT 行已按测量写明这一点,并指向 #5702 去把它对齐回敏感。本 PR 不钉这条大小写行为(钉了会与 #5702 的对齐相冲突),只把它记录在此。

## 反向验证:先红后绿(实测)

新 pin 先在**未翻转**的代码上跑,四条按预期红:

```
FAIL src/auth-contains-filter.test.ts > emits `$contains`, never a bare `$regex`, for a `contains` search
AssertionError: expected { name: { '$regex': 'a.b' } } to deeply equal { name: { '$contains': 'a.b' } }

FAIL ... > does not read `.` as a wildcard — `a.b` matches `a.b`, not `axb`
AssertionError: expected [ 'a.b', 'axb' ] to deeply equal [ 'a.b' ]

FAIL ... > does not read `^` as an anchor
AssertionError: expected [ { name: 'a.b', …(6) }, …(1) ] to deeply equal []

FAIL ... > matches a value that is not a legal regex, instead of failing on it
SyntaxError: Invalid regular expression: /(/: Unterminated group
  ❯ new Query mingo/cjs/query.js:44:10
  ❯ _InMemoryDriver.find packages/drivers/driver-memory/src/memory-driver.ts:293:30

Test Files  1 failed | 34 passed (35)
     Tests  4 failed | 789 passed (793)
```

翻转后全绿(`Test Files 35 passed (35) / Tests 793 passed (793)`)。

第四条要单独说明:issue 预测非法模式会「静默不匹配」,那是**参考匹配器**那一面的行为(`catch { return false }`);实测**查询路径**是直接抛 `SyntaxError`(mingo 在编译 `Query` 时构造 `RegExp`),连 ADR-0112 信封都没进。两种都是坏答案,只是坏法不同 —— 按实测记录,而不是按预测记录。

## 测试落点

`packages/plugins/plugin-auth/src/auth-contains-filter.test.ts`,两面:

1. **契约面**(spy engine):发出的过滤器就是 `{ name: { $contains: 'a.b' } }`,且整棵树里没有 `$regex`;另加一条词表 pin(`FILTER_OPERATORS` 含 `$contains`、不含 `$regex`)—— 这是「五后端都必须求值」这句话的凭据。
2. **行为面**(真实 `InMemoryDriver`,经 `createObjectQLAdapterFactory` 的 better-auth 适配器):`a.b` 只命中 `a.b` 不命中 `axb`;`^a` 一行不中;`(` 按字面命中 `x(y`;无元字符的 `xb` 照旧命中 `axb`。

只有契约面看不出「拼对了但求值错了」,只有行为面说不清是哪个算子换来的结果,所以两面都要。测试没有落进 spec 的 `FILTER_TEXT_CASES` 共享一致性表 —— 那是 #5701/#5702 的领地,这里钉的是 adapter 这一个实现面。

为跑行为面,plugin-auth 增加了 `@objectstack/driver-memory` 的 **devDependency**(不进发布产物)。测试里的引擎替身**只声明三个读动词**,写动词是刻意不声明的:种子数据直接经 driver 写入,避免手写一个本测试既不需要、也无法遵守的 delete/update dispatch 契约(`check:engine-double-contract`)。

## 对 #5702 的影响(必答项)

**变简单,且是「解锁」而非「减负」**:#5702 的「校验期响亮拒收 `$regex`」原本被这一个活体生产者挡着(`filter.zod.ts:1150-1155`「Hard order: #5710 flips the producer, then #5702 turns these strings into refusals」、`check-driver-conformance.mjs:279-282`「#5710 flips that producer before any of these four cells may be cleared」)。本 PR 合并后:

- 仓内已无 `$regex` 生产者(全仓扫描:剩下的 `$regex` 出现点都是消费面、退役处方文本或拒收断言),四个 driver 的 `$regex` 求值臂可以按 #5702 计划直接删/改拒收,不再有「会打断登录」的顺序约束;
- `driver-memory/src/filter-refusal.ts` 的 `SUPPORTED_FIELD_OPERATORS` 里 `$regex`/`$options` 两个额外成员,其唯一存在理由(注释里写死的那句)随之消失,可以整段删掉;
- `$contains` 大小写对齐(#5702 预算内)的工作量**不变**,但现在多了一个受益者:认证路径的 `contains` 会随对齐一起从「memory 上不敏感」回到契约的敏感,与 better-auth 的 `mode: 'sensitive'` 默认对齐。

一处**给 #5702 的备注**(不另立单,因为这几行正是 #5702 要改的):`packages/spec/src/data/filter-text-conformance.ts:272` 把 `{ $regex, $options }` 说成「The exact shape plugin-auth's adapter can emit」。实测该 adapter 从不发 `$options`(它只写 `{ $regex: value }`),所以那条用例钉的是一个本 adapter 产生不出来的形状 —— 用例本身仍有价值(拒收要同时点名两个拼写),只是这句归因不准。

## 越界发现(已另立单,本 PR 不修)

同一个 `convertWhere()` 上另有两个与本单不同类的缺陷,均按 Prime Directive #10 单独立单:

- **#5813**:`not_in` / `starts_with` / `ends_with` 三个 better-auth 算子在 `convertWhere` 里**没有分支**,谓词被整条丢弃 —— 过滤放大(admin list-users 的 `filterOperator`/`searchOperator` 是活体调用方)。
- **#5814**:`Where.mode: 'insensitive'` 被整体忽略(`@better-auth/scim` 对 `caseExact: false` 的属性会发它;需要 #5702 的 `$icontains` 执行面才修得了)。

## 验证命令

```
pnpm --filter @objectstack/plugin-auth test        # 35 files / 793 tests passed
pnpm --filter @objectstack/plugin-auth typecheck   # tsc --noEmit,无输出
node scripts/check-nul-bytes.mjs                   # OK (5678 files)
node scripts/check-engine-double-contract.mjs      # OK — 37 pinned, 165 DEBT, 2 exempt
```
