### PR TITLE
docs(spec): ISharingService.canEdit 补上 modifyAllRecords 旁路分支 (#5125)

### DIFF
--- a/packages/spec/src/contracts/sharing-service.test.ts
+++ b/packages/spec/src/contracts/sharing-service.test.ts
@@ -51,3 +51,78 @@ describe('Sharing Service Contract — recipient vocabularies (#4539)', () => {
     expect(ruleRecipient).toBe(notAuthorable);
   });
 });
+
+/**
+ * [#5125] The three WRITE gates must all document the `modifyAllRecords`
+ * super-user bypass.
+ *
+ * #4647 made the bypass EXPLICIT on the enforcement side: `canEdit`,
+ * `canDelete` and `canManageShares` all fold through the one
+ * `ISecurityService.hasWriteBypass` predicate (`hasModifyAllBypass` in
+ * `@objectstack/plugin-sharing`'s `SharingService`). Two of the three
+ * docstrings said so; `canEdit`'s did not, and its omission read as a
+ * deliberate exclusion — the exact opposite of the implementation, and
+ * strictly worse than silence because `canDelete` sits four lines below
+ * naming the bypass it supposedly does not share.
+ *
+ * A prose pin rather than a behavioural one, because prose is what drifted:
+ * nothing type-checks a doc comment, and this interface's whole job is to be
+ * the thing cross-package callers read instead of the plugin. Deleting the
+ * sentence again turns this red.
+ */
+describe('[#5125] ISharingService write-gate bypass documentation parity', () => {
+  it('canEdit / canDelete / canManageShares each name the `modifyAllRecords` bypass', async () => {
+    const ts = (await import('typescript')).default;
+    const { readFileSync } = await import('node:fs');
+    const { dirname, resolve } = await import('node:path');
+    const { fileURLToPath } = await import('node:url');
+
+    const file = resolve(dirname(fileURLToPath(import.meta.url)), 'sharing-service.ts');
+    const source = ts.createSourceFile(
+      file,
+      readFileSync(file, 'utf8'),
+      ts.ScriptTarget.Latest,
+      /* setParentNodes */ true,
+    );
+
+    const iface = source.statements.find(
+      (s): s is import('typescript').InterfaceDeclaration =>
+        ts.isInterfaceDeclaration(s) && s.name.text === 'ISharingService',
+    );
+    expect(iface, 'ISharingService must still be an interface in this file').toBeDefined();
+
+    // `getFullText` carries a member's LEADING TRIVIA — its doc comment — so
+    // the pin reads exactly what an IDE shows on hover, with no assumption
+    // about how the comment is wrapped.
+    const docOf = new Map<string, string>();
+    for (const member of iface!.members) {
+      if (!ts.isMethodSignature(member) || !member.name || !ts.isIdentifier(member.name)) continue;
+      docOf.set(member.name.text, member.getFullText(source));
+    }
+
+    // Anti-vacuity 1: the enumeration found the real contract surface, so a
+    // rename cannot quietly empty the assertions below.
+    expect([...docOf.keys()].sort()).toEqual([
+      'buildReadFilter',
+      'canDelete',
+      'canEdit',
+      'canManageShares',
+      'grant',
+      'listShares',
+      'revoke',
+    ]);
+
+    for (const gate of ['canEdit', 'canDelete', 'canManageShares'] as const) {
+      expect(docOf.get(gate), `${gate} must document the modifyAllRecords bypass`)
+        .toContain('modifyAllRecords');
+    }
+
+    // Anti-vacuity 2: the search DISCRIMINATES — it is not matching text every
+    // member happens to carry. `buildReadFilter` is the honest negative: the
+    // read path has no `hasWriteBypass` branch at all (a View/Modify All Data
+    // holder reaches every row because the security layer resolves read DEPTH
+    // to `org`, which short-circuits the filter before sharing is consulted),
+    // so naming the write bypass there would itself be drift.
+    expect(docOf.get('buildReadFilter')).not.toContain('modifyAllRecords');
+  });
+});

--- a/packages/spec/src/contracts/sharing-service.ts
+++ b/packages/spec/src/contracts/sharing-service.ts
@@ -126,9 +126,18 @@ export interface ISharingService {
 
   /**
    * Return `true` when the principal in `context` may UPDATE the record
-   * `(object, recordId)`. Ownership (widened by write DEPTH) OR a write-level
-   * ({@link ShareAccessLevel} `edit`) share. Always true for system context,
+   * `(object, recordId)`. Ownership (widened by write DEPTH), a write-level
+   * ({@link ShareAccessLevel} `edit`) share, OR — [#4647] — the
+   * `modifyAllRecords` super-user bypass. Always true for system context,
    * `public` objects, and objects with no owner field.
+   *
+   * The bypass is the same `ISecurityService.hasWriteBypass` predicate
+   * {@link canDelete} and {@link canManageShares} consult, so the three write
+   * gates cannot drift from each other or from what `security/explain`
+   * reports. It is asked LAST — after ownership and shares — so an ordinary
+   * write costs no extra resolution, and it **fails CLOSED** (ADR-0111 D2):
+   * no security service, a throwing probe, or a principal-less /
+   * on-behalf-of context leaves the answer at owner-plus-share only.
    */
   canEdit(
     object: string,


### PR DESCRIPTION
Fixes #5125

## 前提复核(先证伪,再动手)

对 `origin/main` @ `5ab0842` 逐条核过 issue 的两个前提,**都成立**:

**(a) 实现确实有第三条 `modifyAllRecords` 写旁路。** `packages/plugins/plugin-sharing/src/sharing-service.ts`:

- `canEdit` 在 366-401 行,分三步:1) ownership(write DEPTH 放宽,`matchesOwnerScope`)→ 2) `WRITE_ACCESS_LEVELS` 的 share 行 → 3) **398-400 行** `return this.hasModifyAllBypass(object, context);`
- `hasModifyAllBypass` 在 341-351 行,走 late-bound 的 `probe.hasWriteBypass(object, context)`,并且 fail CLOSED(无 security service / probe 抛错 → `false`)。

**(b) 契约文档确实还没这一条。** 改前 `packages/spec/src/contracts/sharing-service.ts` 里 `modifyAllRecords` 只出现 2 次(`canDelete`、`canManageShares`),`canEdit` 的 doc comment 只写到 ownership + share 为止。

**权限名逐层确认过,没有分叉**(任务书要求不能盲抄 `canDelete` 的措辞):`ISecurityService.hasWriteBypass` 的契约就写明是 `modifyAllRecords`(`packages/spec/src/contracts/security-service.ts:220-237`);实现 `packages/plugins/plugin-security/src/security-plugin.ts:676-692` 调 `permissionEvaluator.hasSuperuserWriteBypass`;再往下 `permission-evaluator.ts:296-311` 的 `superuserBypassSets` 在 `bit === 'modify'` 分支上读的正是 `op.modifyAllRecords`。所以 EDIT 路径和 `canDelete` 是**同一个 bit、同一个谓词**,措辞可以直接对齐。

## 改动

一句话级的 doc comment 修正,措辞与 `canDelete` 对齐(`the modifyAllRecords super-user bypass`),另补两句说明这条旁路与 `canDelete` / `canManageShares` 是同一个 `ISecurityService.hasWriteBypass` 谓词、放在最后问、fail closed —— 这三点都是实现里已有的事实,不是新约定。

外加一条**文档对偶 pin**(`packages/spec/src/contracts/sharing-service.test.ts`):三道写门(`canEdit` / `canDelete` / `canManageShares`)的 JSDoc 必须各自点名 `modifyAllRecords`。没有任何东西会对 doc comment 做类型检查,而这次漂移的恰恰是 prose,所以用 TS AST 读接口成员的 leading trivia 来钉。两道反空转保护:成员枚举整体断言(改名不能把断言掏空),外加 `buildReadFilter` 必须**不**含该词作为判别性负例 —— 读路径确实没有 `hasWriteBypass` 分支(View/Modify All Data 持有者读到全部行,是因为 security 层把 read DEPTH 解析成 `org` 而在 sharing 之前短路,`buildReadFilter` 202 行 `if (readScope === 'org') return null;`),所以在那里写上写旁路本身就会是新的漂移。

## 生成物投影:没有

`contracts/` 这一目录**不产任何生成物**,证据三条:

1. `packages/spec/scripts/build-docs.ts:106` 只收 `*.zod.ts`(`if (!entry.name.endsWith('.zod.ts')) continue;`),而 `packages/spec/src/contracts/` 下一个 `.zod.ts` 都没有;
2. `content/docs/references/contracts/` 里只有 `meta.json`,内容是 `"pages": []`;`check:docs` 跑起来自己也这么说 —— `Skipping clean of contracts/ — no JSON schemas found in .../json-schema/contracts`;
3. `api-surface.json` 的 `./contracts` 条目只记导出名与种类(`"ISharingService (interface)"`),不含任何文档正文;本 PR 也没有增删任何导出,所以 `check:api-surface` 结构上不可能动。

跑过的门:`check:docs` ✅(`240 generated files in sync with packages/spec`)、`check:authorable-surface` ✅。⚠️ 两者都会顺手重写 `packages/spec/authorable-surface.base.json`(已知 #5358),已 `git checkout --` 还原,PR 里**没有**这个文件 —— 本 PR 只含上述两个文件。

## Changeset:选 `skip-changeset`

`packages/spec` 发布的 `files` 是 `dist` + `src/**/*.zod.ts`,本文件是普通 `.ts`,源码不随包走;上面已证没有生成物投影;导出面、类型、schema、运行时行为全部零变化。按 `pr-automation.yml` changeset 门自己的处方,这属于"releases nothing → 打 `skip-changeset` 标签(PREFERRED)"。同形先例:`.changeset/auth-database-hooks-middleware-claim-corrected.md`(同样是已发布包里的 comment-only 更正,结论 "Comments only — no runtime behaviour changes, nothing released")。诚实起见记一句:更正后的文字仍会经 `dist/*.d.ts` 到达 consumer 的 IDE 悬浮提示 —— 但那不改变本 PR 不发布任何东西这一事实,所以走标签而不是 changeset。标签已由我在建 PR 后立即打上。

## 验证

```
pnpm --filter @objectstack/spec test        → Test Files 319 passed (319) | Tests 8145 passed (8145)
vitest run src/contracts/sharing-service.test.ts → Test Files 1 passed (1) | Tests 3 passed (3)
pnpm --filter @objectstack/spec typecheck   → tsc --noEmit ✅ + check:test-typecheck OK
node scripts/check-nul-bytes.mjs            → OK (5684 files, no raw ASCII control bytes)
```

**反向验证(方向是事先预判的:红)。** 把 `canEdit` 的 doc comment 还原成改前那段,新 pin 应该转红、两条既有断言应该保持绿 —— 实测正是如此:

```
FAIL  src/contracts/sharing-service.test.ts > [#5125] ... > canEdit / canDelete / canManageShares each name the `modifyAllRecords` bypass
      → canEdit must document the modifyAllRecords bypass
 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

还原修正后重跑回到 3 passed。

## 越界发现(已另开 issue,未在本 PR 修)

- **#5817** —— 同一文件的**模块头**(第 15-17 行)还写着 "`canEdit()` answers the access question for `update` / `delete` operations",而 ADR-0111 D3 早已把 delete 拆成故意更窄的 `canDelete()`,与它下面 20 行的方法文档直接矛盾。同一类漂移,但任务书把本 PR 的改动面明确限定为 `canEdit` 的 doc comment,故只记录不顺手改。

---
_Generated by [Claude Code](https://claude.ai/code/session_01559M8FVm6W6vDLABL3jvdW)_