### PR TITLE
test(spec): 门测量 BFS 只留一份实现,并给仪器本身补上对照 (#5056)

### DIFF
--- a/packages/spec/src/ui/chart.test.ts
+++ b/packages/spec/src/ui/chart.test.ts
@@ -14,111 +14,9 @@ import {
 } from './chart.zod';
 import { ReportChartSchema, ReportSchema } from './report.zod';
 import { REACT_BLOCKS } from './react-blocks';
-import { getMetadataTypeSchema, listMetadataTypeSchemaTypes } from '../kernel/metadata-type-schemas';
-import { ObjectStackSchema } from '../stack.zod';
-
-/**
- * Reachability of a schema from every metadata-type root plus `defineStack`'s
- * `ObjectStackSchema`, by BFS over this build's in-memory Zod graph.
- *
- * Mirrors `computeSurfaceReachability` in `scripts/build-schemas.ts` (the
- * #4650 closure). `derived-clone` counts as reachable: `.extend()` / `.strip()`
- * produce a clone that shares no identity with the original but DOES share its
- * per-property schema instances, which is exactly how `ChartConfigSchema` is
- * reached through `ReportChartSchema`.
- *
- * ⚠️ Identity-keyed, so it must see the REAL schema instances. `lazySchema`
- * returns a Proxy unless `OS_EAGER_SCHEMAS=1`, and comparing a Proxy against
- * the instance stored in the graph reports every root as unreachable — which
- * is precisely how the first run of this measurement produced three failing
- * positive controls. Hence the resolve step.
- */
-function reachableFromMetadataRoots(): (schema: unknown) => boolean {
-  // Identity is the schema's `_zod.def` OBJECT, never the schema binding.
-  // `lazySchema` hands out a Proxy unless `OS_EAGER_SCHEMAS=1`, and the graph
-  // holds the real instances — so comparing bindings reports every root as
-  // unreachable. That is not hypothetical: it is what the first run of this
-  // assertion did, and the positive controls above are the only reason it was
-  // caught instead of shipping as a green that proved nothing. `def` survives
-  // the Proxy (the `_zod` facade delegates to the real internals), so it is
-  // the one stable key for both identities.
-  const defOf = (s: unknown): unknown => (s as { _zod?: { def?: unknown } })?._zod?.def;
-
-  const childrenOf = (node: unknown): unknown[] => {
-    const out: unknown[] = [];
-    const seen = new Set<unknown>();
-    const walk = (v: unknown): void => {
-      // `typeof v !== 'object'` alone is WRONG here and silently halves the
-      // graph: `lazySchema`'s Proxy target is `function lazyZod() {}`, so every
-      // lazy schema is `typeof 'function'`. Skipping those made the BFS stop at
-      // the first lazy node and report the whole chart family unreachable —
-      // caught only because the positive controls above went red.
-      // (`build-schemas.ts`'s equivalent walk never hit this: it runs under
-      // `OS_EAGER_SCHEMAS=1`, where there are no proxies at all.)
-      if (v === null || (typeof v !== 'object' && typeof v !== 'function') || seen.has(v)) return;
-      seen.add(v);
-      if (defOf(v)) { out.push(v); return; }
-      if (Array.isArray(v)) { for (const x of v) walk(x); return; }
-      if (v instanceof Map) { for (const x of v.values()) walk(x); return; }
-      for (const x of Object.values(v as Record<string, unknown>)) walk(x);
-    };
-    walk(defOf(node));
-    return out;
-  };
-  const shapeOf = (node: unknown): Record<string, unknown> | null => {
-    const def = defOf(node) as { type?: string; shape?: Record<string, unknown> } | undefined;
-    return def?.type === 'object' && def.shape ? def.shape : null;
-  };
-
-  const roots: unknown[] = [];
-  for (const type of listMetadataTypeSchemaTypes()) {
-    const s = getMetadataTypeSchema(type);
-    if (s) roots.push(s);
-  }
-  roots.push(ObjectStackSchema);
-
-  const visitedDefs = new Set<unknown>();
-  const visitedNodes: unknown[] = [];
-  const queue = [...roots];
-  while (queue.length > 0) {
-    const node = queue.pop();
-    const def = defOf(node);
-    if (!def || visitedDefs.has(def)) continue;
-    visitedDefs.add(def);
-    visitedNodes.push(node);
-    for (const child of childrenOf(node)) queue.push(child);
-  }
-
-  // (propName → prop def) pairs of every visited object node — the bridge that
-  // recognises a derived clone (`.extend()` / `.strip()` share no identity with
-  // the original but DO share its per-property schema instances, which is how
-  // `ChartConfigSchema` is reached through `ReportChartSchema`).
-  const bridged = new Map<unknown, Set<string>>();
-  for (const node of visitedNodes) {
-    const shape = shapeOf(node);
-    if (!shape) continue;
-    for (const [name, prop] of Object.entries(shape)) {
-      const d = defOf(prop);
-      if (!d) continue;
-      let names = bridged.get(d);
-      if (!names) { names = new Set<string>(); bridged.set(d, names); }
-      names.add(name);
-    }
-  }
-
-  return (schema: unknown): boolean => {
-    const def = defOf(schema);
-    if (!def) return false;
-    if (visitedDefs.has(def)) return true;
-    const shape = shapeOf(schema);
-    if (!shape) return false;
-    for (const [name, prop] of Object.entries(shape)) {
-      const d = defOf(prop);
-      if (d && bridged.get(d)?.has(name)) return true;
-    }
-    return false;
-  };
-}
+import { getMetadataTypeSchema } from '../kernel/metadata-type-schemas';
+import { measureDoors } from './door-reachability.testkit';
+import { z } from 'zod';
 
 describe('ChartTypeSchema', () => {
   it('should accept all comparison chart types', () => {
@@ -563,21 +461,46 @@ describe('#4001 批 15 — the two chart sites deliberately LEFT OPEN (measured,
     // closure `build-schemas.ts` uses for the #4650 deletion check — NOT a
     // string search over a serialized schema, which cannot see a shape at all
     // and would pass no matter what (the vacuous-green this campaign keeps
-    // paying for). The positive controls below are what prove that.
-    const reachable = reachableFromMetadataRoots();
+    // paying for). The controls below are what prove that.
+    //
+    // ⚠️ #5056: this file used to carry its OWN copy of that walk, and the copy
+    // kept the defective `any one shared property ⇒ derived clone` bridge after
+    // the shared walker had been fixed to a whole-shape overlap ratio. One
+    // implementation now, in `door-reachability.testkit.ts`, whose own controls
+    // live in `door-reachability.testkit.test.ts`.
+    const { verdict, nodeCount, rootCount } = measureDoors();
 
-    // Positive controls, in the SAME run: the five closed sites of this file
-    // resolve. An instrument that says "unreachable" to everything is broken,
-    // not informative.
-    expect(reachable(ChartConfigSchema), 'positive control').toBe(true);
-    expect(reachable(ChartAxisSchema), 'positive control').toBe(true);
-    expect(reachable(ChartSeriesSchema), 'positive control').toBe(true);
-    expect(reachable(ChartAnnotationSchema), 'positive control').toBe(true);
-    expect(reachable(ChartInteractionSchema), 'positive control').toBe(true);
+    // Controls FIRST, in the SAME run. An instrument that reached nothing at
+    // all produces the same output as a correct "no door" verdict.
+    expect(rootCount, 'roots must include every metadata type plus ObjectStackSchema').toBeGreaterThan(20);
+    expect(nodeCount, 'the graph must actually have been walked').toBeGreaterThan(1000);
+
+    // Positive controls: the five closed sites of this file resolve.
+    expect(verdict(ChartConfigSchema), 'positive control').toBe('direct');
+    expect(verdict(ChartAxisSchema), 'positive control').toBe('direct');
+    expect(verdict(ChartSeriesSchema), 'positive control').toBe('direct');
+    expect(verdict(ChartAnnotationSchema), 'positive control').toBe('direct');
+    expect(verdict(ChartInteractionSchema), 'positive control').toBe('direct');
+
+    // Negative control: a shape this graph has never seen must stay out.
+    expect(verdict(z.object({ osChartProbe: z.string() })), 'negative control').toBe('unreachable');
 
     // The measurement itself.
-    expect(reachable(ChartAggregateSchema), 'a carrier key would make this reachable — re-read chart.zod.ts').toBe(false);
-    expect(reachable(ChartGroupBySchema), 'a carrier key would make this reachable — re-read chart.zod.ts').toBe(false);
+    expect(verdict(ChartAggregateSchema), 'a carrier key would make this reachable — re-read chart.zod.ts').toBe('unreachable');
+    expect(verdict(ChartGroupBySchema), 'a carrier key would make this reachable — re-read chart.zod.ts').toBe('unreachable');
+  });
+
+  it('a synthetic carrier flips both — the verdict is the graph, not the walker', () => {
+    // The third control #5056 requires and this file never had. Without it the
+    // assertion above is satisfiable by a walker that finds no doors anywhere,
+    // which is the vacuous green 批 15 shipped once already.
+    const carrier = z.object({
+      aggregate: ChartAggregateSchema,
+      groupBy: ChartGroupBySchema,
+    });
+    const { verdict } = measureDoors([carrier]);
+    expect(verdict(ChartAggregateSchema), 'must become reachable once something carries it').toBe('direct');
+    expect(verdict(ChartGroupBySchema), 'must become reachable once something carries it').toBe('direct');
   });
 });
 

--- a/packages/spec/src/ui/door-reachability.testkit.test.ts
+++ b/packages/spec/src/ui/door-reachability.testkit.test.ts
@@ -1,0 +1,194 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #5056 — the controls the door measurement itself owes.
+ *
+ * `door-reachability.testkit.ts` decides whether a #4001 batch tightens a shape
+ * or reclassifies it as `no door`. Its consumers (`chart.test.ts`,
+ * `widget.test.ts`, `i18n.test.ts`) each carry the three controls for THEIR
+ * shapes; nothing carried the controls for the instrument. This file does, so
+ * that the walker's own limbs — the `.describe()` premise the bridge rests on,
+ * the derived-clone bridge, and the overlap threshold that bounds it — cannot
+ * rot behind green consumer tests.
+ *
+ * Every number asserted here was measured on this build, not reasoned about.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { measureDoors } from './door-reachability.testkit';
+import { PageSchema } from './page.zod';
+import { ObjectListViewSchema } from './view.zod';
+import { WidgetManifestSchema } from './widget.zod';
+import { I18nLabelSchema } from './i18n.zod';
+import { SnakeCaseIdentifierSchema } from '../shared/identifiers.zod';
+
+/** The walker's identity key, mirrored here so the premise tests can assert on it. */
+const defOf = (s: unknown): unknown => (s as { _zod?: { def?: unknown } })?._zod?.def;
+
+// ============================================================================
+// 1. The PREMISE the derived-clone bridge rests on.
+//
+// The bridge exists because zod builders return a clone that shares the base's
+// per-property schema INSTANCES. Which builders share the `_zod.def` OBJECT
+// itself, and which do not, is what decides whether the bridge sees a real
+// derivation or a coincidence. A zod upgrade that changes `clone()` semantics
+// changes the bridge's meaning, and that must be LOUD rather than silent.
+// ============================================================================
+describe('#5056 premise — which zod builders share the `_zod.def` object', () => {
+  it('`.describe()` shares the def of the instance it was called on', () => {
+    // THE mechanism behind #5056. `clone(inst)` without an explicit def reuses
+    // `inst._zod.def`, so a described clone is def-IDENTICAL to its receiver.
+    const base = z.string();
+    expect(defOf(base.describe('x')), '.describe() clone vs its receiver').toBe(defOf(base));
+    expect(defOf(base.describe('x')), 'two different descriptions of ONE instance').toBe(defOf(base.describe('y')));
+  });
+
+  it('but two independently constructed schemas do NOT share a def', () => {
+    // #5056's issue body spells the fact as
+    //   `defOf(z.string().describe('x')) === defOf(z.string())` → true
+    // and that spelling is FALSE on this build: two separate `z.string()` calls
+    // build two separate defs, so there is nothing to share. Measured, not
+    // assumed — the corrected statement is the one above: sharing follows the
+    // RECEIVER INSTANCE, not the shape. That distinction is the whole reason
+    // the bug bites this repo: the spec funnels dozens of shapes through a
+    // handful of SHARED leaf instances, and every `.describe()` of one of them
+    // is def-identical to every other.
+    expect(defOf(z.string().describe('x'))).not.toBe(defOf(z.string()));
+    expect(defOf(z.string())).not.toBe(defOf(z.string()));
+  });
+
+  it('the repo\'s shared leaves are therefore def-identical across every site that describes them', () => {
+    // `SnakeCaseIdentifierSchema` and `I18nLabelSchema` are the two the campaign
+    // actually tripped over: `name:` and `label:` are on nearly every authorable
+    // shape in this repo, described in place at each site.
+    expect(defOf(SnakeCaseIdentifierSchema.describe('a'))).toBe(defOf(SnakeCaseIdentifierSchema.describe('b')));
+    expect(defOf(I18nLabelSchema.describe('a'))).toBe(defOf(I18nLabelSchema.describe('b')));
+  });
+
+  it('`.optional()` / `.extend()` / `.strip()` each build a NEW def', () => {
+    // The other half of the premise: these are the builders whose clones the
+    // bridge must still recognise, and they can only be recognised through
+    // shared PROPERTY instances, because the def itself is new.
+    const base = z.string();
+    expect(defOf(base.optional())).not.toBe(defOf(base));
+    const obj = z.object({ a: z.string() });
+    expect(defOf(obj.extend({ b: z.number() }))).not.toBe(defOf(obj));
+    expect(defOf(obj.strip())).not.toBe(defOf(obj));
+  });
+});
+
+// ============================================================================
+// 2. The three controls, on the instrument itself.
+// ============================================================================
+describe('#5056 controls — the walker finds doors, and only real ones', () => {
+  it('positive: live authoring roots resolve, and the graph is really walked', () => {
+    const { verdict, nodeCount, rootCount } = measureDoors();
+    expect(rootCount, 'every metadata type plus ObjectStackSchema').toBeGreaterThan(20);
+    expect(nodeCount, 'the graph must actually have been walked').toBeGreaterThan(1000);
+    expect(verdict(PageSchema), 'positive control').toBe('direct');
+    expect(verdict(ObjectListViewSchema), 'positive control').toBe('direct');
+  });
+
+  it('positive: a GENUINE derived clone is recognised — this is the bridge limb', () => {
+    // The limb #5056 narrowed. Nothing else in the repo exercises it: every
+    // shape the consumers assert as reachable measures `direct`, so a bridge
+    // that had been narrowed all the way to "never fires" would leave all
+    // three consumer files green. `.extend()` and `.strip()` are exactly the
+    // builders the bridge was written for.
+    const { verdict, cloneOverlap } = measureDoors();
+
+    const extended = PageSchema.extend({ osDoorProbeExtra: z.string() });
+    expect(verdict(extended), 'PageSchema.extend(...) is a real derivation').toBe('derived-clone');
+    expect(cloneOverlap(extended), 'one added key out of 25 kept').toBeGreaterThan(0.9);
+
+    const stripped = ObjectListViewSchema.strip();
+    expect(verdict(stripped), 'ObjectListViewSchema.strip() is a real derivation').toBe('derived-clone');
+    expect(cloneOverlap(stripped), 'strip() keeps the whole shape').toBe(1);
+  });
+
+  it('negative: a look-alike that shares no property instance stays out', () => {
+    // #5056's own negative control, verbatim: deliberately spelled to look like
+    // every authorable shape in the repo, but built from fresh `z.string()`
+    // instances, so it shares nothing with the graph.
+    const { verdict, cloneOverlap } = measureDoors();
+    const lookAlike = z.object({ name: z.string(), label: z.string() });
+    expect(verdict(lookAlike), 'negative control').toBe('unreachable');
+    expect(cloneOverlap(lookAlike)).toBe(0);
+  });
+
+  it('flip: injecting a synthetic carrier turns an unreachable shape reachable', () => {
+    // Without this, "unreachable" and "the walker is broken" are the same
+    // output. `extraRoots` exists for exactly this control.
+    const orphan = z.object({ osDoorProbeOrphanKey: z.string() });
+    expect(measureDoors().verdict(orphan), 'before').toBe('unreachable');
+    const carrier = z.object({ orphan });
+    expect(measureDoors([carrier]).verdict(orphan), 'after — a carrier makes the door').toBe('direct');
+  });
+});
+
+// ============================================================================
+// 3. The #5056 regression boundary itself.
+// ============================================================================
+describe('#5056 regression — the any-one-shared-property bridge stays dead', () => {
+  it('WidgetManifestSchema shares leaves with the live graph but is NOT derived from it', () => {
+    // The reverse verification, standing rather than one-shot.
+    //
+    // The OLD bridge fired when ANY one property of the candidate was def-equal
+    // to a same-named property of ANY visited object node. `cloneOverlap` is
+    // the max shared-property count over visited shapes, normalised — so
+    // `cloneOverlap(x) > 0` is EXACTLY the condition under which the old bridge
+    // fired. Asserting both halves here pins the fix without keeping a second,
+    // defective copy of the walker alive to demonstrate it:
+    //
+    //   > 0    ⇒ the old bridge WOULD have called this file reachable, and did
+    //   < 0.5  ⇒ the fixed bridge correctly does not.
+    //
+    // 2 shared keys (`name`, `label`, both described shared LEAVES) out of 19.
+    // A coincidence, not a derivation — and a false door here would have spent
+    // a v17 breaking to tighten a file nothing imports (#4583's "precisely
+    // validated dead slot").
+    const { verdict, cloneOverlap } = measureDoors();
+    const overlap = cloneOverlap(WidgetManifestSchema);
+    expect(overlap, 'it DOES share leaves — the old bridge fired on exactly this').toBeGreaterThan(0);
+    expect(overlap, 'but nothing structural: measured 2/19').toBeLessThan(0.2);
+    expect(verdict(WidgetManifestSchema)).toBe('unreachable');
+  });
+
+  it('the threshold discriminates by SHARE OF SHAPE, not by count of shared keys', () => {
+    // Why 0.5 and not "at least 2 shared keys": the same two shared leaves
+    // decide opposite verdicts depending on how much of the shape they are.
+    const { cloneOverlap } = measureDoors();
+    const shared = {
+      name: SnakeCaseIdentifierSchema.describe('Machine name'),
+      label: I18nLabelSchema.describe('Display label'),
+    };
+    const withFiller = z.object({ ...shared, a: z.string(), b: z.string(), c: z.string() });
+    expect(cloneOverlap(withFiller), '2 shared of 5 keys').toBeCloseTo(0.4, 5);
+  });
+
+  it('KNOWN BOUND — a shape made ENTIRELY of shared leaves still bridges, whatever the threshold', () => {
+    // Measured limitation, pinned deliberately rather than left latent for a
+    // later batch to rediscover as a second false door.
+    //
+    // The ratio is taken over the CANDIDATE's own keys, so a 2-key shape whose
+    // both keys are shared leaves scores 1.0 and is judged `derived-clone` —
+    // no threshold in (0, 1] excludes it, because a genuine `.strip()` of a
+    // live 2-key schema scores 1.0 too and must stay reachable. The instrument
+    // cannot separate those two by overlap alone.
+    //
+    // It costs nothing today: this is a synthetic shape, and the smallest real
+    // `no door` shapes the campaign has measured sit far below the threshold
+    // (WidgetManifestSchema at 2/19). It becomes a real hazard the moment a
+    // batch measures a SMALL shape (roughly 4 keys or fewer) whose keys are all
+    // shared leaves — measure `cloneOverlap` and read this pin before trusting
+    // a `derived-clone` verdict on one. Filed for the campaign as #5828.
+    const { verdict, cloneOverlap } = measureDoors();
+    const allSharedLeaves = z.object({
+      name: SnakeCaseIdentifierSchema.describe('Machine name'),
+      label: I18nLabelSchema.describe('Display label'),
+    });
+    expect(cloneOverlap(allSharedLeaves), '2 shared of 2 keys').toBe(1);
+    expect(verdict(allSharedLeaves), 'the residual false-reachable case — see #5828').toBe('derived-clone');
+  });
+});

--- a/packages/spec/src/ui/door-reachability.testkit.ts
+++ b/packages/spec/src/ui/door-reachability.testkit.ts
@@ -28,18 +28,34 @@
  *    no identity with its base but DOES share the base's per-property schema
  *    instances, so a bridge over shared property defs is genuinely needed. The
  *    bridge as first written fired when **any one** property matched under the
- *    same name — and zod's `.describe()` returns a clone that shares the
- *    original `_zod.def` OBJECT, which makes every described
- *    `SnakeCaseIdentifierSchema` / `I18nLabelSchema` def-identical across the
- *    whole spec. Two unrelated shapes that both declare `name` and `label` (i.e.
- *    almost every authorable shape here) therefore bridged, and
- *    `WidgetManifestSchema` — a file nothing imports — measured as REACHABLE.
- *    The error is one-directional: it can only produce a false door, i.e. it can
- *    only cause a batch to tighten something dead.
+ *    same name — and zod's `.describe()` returns a clone that reuses the
+ *    `_zod.def` OBJECT **of the instance it was called on**. Because this repo
+ *    funnels dozens of shapes through a handful of SHARED leaf instances, every
+ *    `SnakeCaseIdentifierSchema.describe(…)` in the spec is def-identical to
+ *    every other one, and likewise `I18nLabelSchema`. Two unrelated shapes that
+ *    both declare `name` and `label` (i.e. almost every authorable shape here)
+ *    therefore bridged, and `WidgetManifestSchema` — a file nothing imports —
+ *    measured as REACHABLE. The error is one-directional: it can only produce a
+ *    false door, i.e. it can only cause a batch to tighten something dead.
+ *
+ *    ⚠️ Sharing follows the **receiver instance**, not the shape: two separate
+ *    `z.string()` calls build two separate defs and share nothing. #5056's issue
+ *    body spelled the fact the other way; the corrected, measured statement and
+ *    every builder's verdict are pinned in `door-reachability.testkit.test.ts`,
+ *    so a zod upgrade that changes `clone()` semantics goes red rather than
+ *    silently changing what this bridge means.
  *
  *    The fix is to ask how much of the shape is shared rather than whether
  *    anything is: a real derived clone carries nearly all of its base's
  *    properties, while a coincidence carries one or two out of twenty.
+ *
+ *    **Residual bound (#5828), measured and pinned, not latent:** the ratio is
+ *    taken over the CANDIDATE's own keys, so a shape whose keys are *all* shared
+ *    leaves scores 1.0 however few they are, and still bridges. No threshold in
+ *    (0, 1] excludes it, because a genuine `.strip()` scores 1.0 too. It costs
+ *    nothing today (the real `no door` shapes measured so far sit far below the
+ *    threshold — `WidgetManifestSchema` at 2/19), but read `cloneOverlap` and
+ *    the key count before trusting a `derived-clone` verdict on a SMALL shape.
  */
 
 import { getMetadataTypeSchema, listMetadataTypeSchemaTypes } from '../kernel/metadata-type-schemas';
@@ -97,11 +113,19 @@ export interface DoorMeasurement {
  * its own shape, by property def identity under the same name, with one visited
  * object node.
  *
- * Chosen against both ends of the measured range rather than by taste: 批 15's
- * real derivation (`ChartConfigSchema` reached through `ReportChartSchema`,
- * which re-narrows two of its keys) sits far above it, and 批 16's false
- * positive (`WidgetManifestSchema`, 2 shared keys of 20 — `name` and `label`,
- * both shared LEAVES rather than shared structure) sits far below.
+ * Chosen against both ends of the measured range rather than by taste: real
+ * derivations sit far above it (`PageSchema.extend(…)` at 0.96,
+ * `ObjectListViewSchema.strip()` at 1.0 — both pinned as the bridge's positive
+ * control), and 批 16's false positive sits far below (`WidgetManifestSchema`,
+ * 2 shared keys of 19 — `name` and `label`, both shared LEAVES rather than
+ * shared structure, measured 0.105).
+ *
+ * Note the chart family this bridge was originally written for measures
+ * `direct`, not `derived-clone`: `ChartConfigSchema` is in the graph outright.
+ * So `chart.test.ts` does not exercise this limb at all, and neither does any
+ * other consumer — which is why the testkit's own test file owns the positive
+ * control for it. Without that, narrowing the bridge to "never fires" would
+ * leave every consumer green.
  */
 const DERIVED_CLONE_MIN_OVERLAP = 0.5;
 


### PR DESCRIPTION
Fixes #5056

## 前提核对(先说结论:issue 仍然成立,但清单跟 issue 写的不一样)

Issue 是 08-04 写的,#4001 战役跑得快。对着 `origin/main`(28f2e04)重新点了一遍拷贝清单:

| 位置 | 状态 |
|---|---|
| `packages/spec/src/ui/door-reachability.testkit.ts` | **已存在**,已是重合度(≥ 0.5)版本,已带 `extraRoots` 翻转支持和 `cloneOverlap` |
| `packages/spec/src/ui/widget.test.ts` | 已 import 该工具,三组对照齐 |
| `packages/spec/src/ui/i18n.test.ts` | 已 import 该工具,三组对照齐 |
| `packages/spec/src/ui/chart.test.ts` | ⛔ **仍带内联拷贝,而且是缺陷版** —— 停在「任意单属性命中即判可达」 |

也就是说 issue 建议 1 做了一半:共享工具已经抽出来了,但 **issue 点名的引入处 `chart.test.ts` 自己没迁移**,留下的那份恰好是有 bug 的那份。全仓再无第四份(`visitedDefs` / `childrenOf` 全仓搜过,另一处命中是无关的 `packages/lint/src/validate-responsive-styles.ts`)。

所以本 PR 的实际工作是「迁移最后一份拷贝」,不是「新建共享工具」。

## 改动

1. **`chart.test.ts` 删掉 100 行内联 BFS**,改 import `measureDoors()`。全仓只剩一份实现。
2. **`chart.test.ts` 补齐缺的对照**。它原本只有正对照,现在补上负对照和合成载体翻转对照(issue 建议 2 要求的三者)。
3. **新增 `door-reachability.testkit.test.ts`** —— 仪器自己的对照。三个消费者各自为**自己的形状**带对照,却没人为**走图器**带,于是它的两条腿都可能在一片绿里烂掉。

## 两处必须说明的实测修正

### A. issue body 里那行 `.describe()` 复现是**错的**

Issue 写:

```
defOf(z.string().describe('x')) === defOf(z.string())  →  true
```

**本 build 实测为 false。** 两次独立的 `z.string()` 调用建两个独立的 def,压根没有东西可共享。真正成立的是:

```
const base = z.string();
defOf(base.describe('x')) === defOf(base)              →  true   ← 共享跟着「接收者实例」走
defOf(base.describe('x')) === defOf(base.describe('y'))→  true
defOf(SnakeCaseIdentifierSchema.describe('a'))
  === defOf(SnakeCaseIdentifierSchema.describe('b'))   →  true   ← 真正咬到本仓的那条
defOf(base.optional()) / .extend() / .strip()          →  false  ← 与 issue 一致
```

机制和结论都对,一行复现写反了。**共享跟着接收者实例走,不跟着形状走** —— 而这恰恰是 bug 咬本仓的原因:spec 把几十个形状都灌进少数几个**共享叶子实例**,于是每个 `SnakeCaseIdentifierSchema.describe(…)` 彼此 def-同一。

按派发要求把这条事实钉成了测试,但钉的是**修正后**的说法 —— 照 issue 原文钉会钉住一个假命题。zod 升级改了 `clone()` 语义,这组会响。

### B. bridge 那条腿,全仓此前**没有任何测试走到**

Issue 和派发都建议拿 `ChartConfigSchema` 经 `ReportChartSchema.extend()` 当 derived-clone 正对照。实测:

```
ChartConfigSchema   →  direct   (重合度 1.0000)
ReportChartSchema   →  direct
```

它本来就在图里,判定是 `direct` 而不是 `derived-clone`。三个消费者断言可达的形状**全部**是 `direct`。也就是说:把 bridge 收紧到「永不触发」,三个文件依然全绿。

所以正对照另找了真派生场景,并钉进测试:

```
PageSchema.extend({ osDoorProbeExtra })  →  derived-clone  (重合度 0.9600)
ObjectListViewSchema.strip()             →  derived-clone  (重合度 1.0000)
```

## 阈值:保持 0.5,对照没有推翻它

| 形状 | 重合度 | 判定 |
|---|---|---|
| `ObjectListViewSchema.strip()`(真派生) | 1.0000 | derived-clone |
| `PageSchema.extend(…)`(真派生) | 0.9600 | derived-clone |
| `WidgetManifestSchema`(批 16 假可达) | 0.1053(2/19) | unreachable ✅ |
| `z.object({ name: z.string(), label: z.string() })`(issue 的负对照) | 0.0000 | unreachable ✅ |

两端离 0.5 都很远。

## 反向验证(方向是**事先**定的:标准红向)

把 `DERIVED_CLONE_MIN_OVERLAP` 临时改回「任意单属性命中」,预测 → 实测:

| 文件 | 预测 | 实测 |
|---|---|---|
| `door-reachability.testkit.test.ts` | 红(`WidgetManifestSchema`) | ✅ 红:`expected 'derived-clone' to be 'unreachable'` |
| `widget.test.ts` | 红(`WidgetManifestSchema`) | ✅ 红:`WidgetManifestSchema must have no door` |
| `chart.test.ts` | **绿(不变)** | ✅ 绿 |
| `i18n.test.ts` | 绿 | ✅ 绿 |
| 负对照 / KNOWN BOUND | 绿 | ✅ 绿 |

`chart.test.ts` 预测为绿并且实测为绿,这条值得单独讲:**迁移它并不改变它自己的任何判定**(它那几个形状重合度是 0.0000,老 bridge 在那儿根本不触发)。迁移的价值是「杀掉真相的第二份拷贝」,不是「改一个答案」—— 那份拷贝的危害在于它是批 17-22 复制粘贴时会拿到的那一份。

## 一个残余边界:钉住了,没有顺手改仪器

重合度的分母是**候选形状自己的键数**,于是一个键很少、且每个键都是共享叶子的形状恒为 1.0:

```
z.object({
  name:  SnakeCaseIdentifierSchema.describe('Machine name'),
  label: I18nLabelSchema.describe('Display label'),
})
```

实测重合度 1.0000 → 判 `derived-clone` → 可达。**任何阈值都排不掉**:真 `.strip()` 也是 1.0000 且必须保持可达,两者在「重合度」这一个维度上不可分。

今天代价为零(真实 `no door` 形状都远低于阈值),而且修它需要另一个判据(例如要求共享属性里至少有一个是结构性节点),那是对仪器契约的改动 —— 不该塞进一个测试层 PR。所以:**作为具名 pin 钉住**(用例名以 `KNOWN BOUND` 开头),并作为观察类发现另开 #5828,让后续批次遇到小形状时知道去读那条 pin。

## 验证

```
pnpm --filter @objectstack/spec test        →  320 files / 8176 tests passed   (基线 8164,本 PR +12)
pnpm --filter @objectstack/spec typecheck   →  tsc --noEmit 通过;check:test-typecheck OK
pnpm --filter @objectstack/spec check:generated → 10/10 artifacts up to date
npx eslint (三个改动文件)                    →  无输出
node scripts/check-nul-bytes.mjs            →  OK (5687 files)
```

## 范围

严格测试层:仅 `chart.test.ts`、`door-reachability.testkit.ts`、新增 `door-reachability.testkit.test.ts`。未碰任何 `*.zod.ts`、任何 schema 语义、任何 `scripts/`。逐文件核对过 `git status`,`authorable-surface.base.json` **不在** diff 中。

## Changeset

**skip-changeset** —— 纯测试层改动,不发布任何东西,对使用者无可见变化(`*.testkit.ts` 不从 `ui/index.ts` 导出,也不是 tsup entry,`check:api-surface` 已验证导出面无变化)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01559M8FVm6W6vDLABL3jvdW


---
_Generated by [Claude Code](https://claude.ai/code/session_01559M8FVm6W6vDLABL3jvdW)_