### PR TITLE
chore(qa,objectql): 摘除 dogfood 无消费的 driver-memory devDep + 清扫 1 处 stub 注释散文 (#5829)

### DIFF
--- a/packages/objectql/src/protocol-batch-atomic.test.ts
+++ b/packages/objectql/src/protocol-batch-atomic.test.ts
@@ -18,9 +18,9 @@ import { ObjectStackProtocolImplementation } from '@objectstack/metadata-protoco
 import type { IObjectQLEngine } from '@objectstack/spec/contracts';
 
 /**
- * A driver with real transaction semantics: `beginTransaction` snapshots every
- * table, `rollback` restores the snapshot wholesale, `commit` drops it — the
- * same shape `driver-memory` uses, small enough to assert against.
+ * A stub driver with real transaction semantics: `beginTransaction` snapshots
+ * every table, `rollback` restores the snapshot wholesale, `commit` drops it —
+ * a genuine rollback, small enough to assert against.
  */
 function makeSnapshotDriver() {
     const stores = new Map<string, Map<string, any>>();

--- a/packages/qa/dogfood/package.json
+++ b/packages/qa/dogfood/package.json
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "@objectstack/core": "workspace:*",
-    "@objectstack/driver-memory": "workspace:*",
     "@objectstack/driver-sql": "workspace:*",
     "@objectstack/driver-sqlite-wasm": "workspace:*",
     "@types/node": "^26.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1786,9 +1786,6 @@ importers:
       '@objectstack/core':
         specifier: workspace:*
         version: link:../../core
-      '@objectstack/driver-memory':
-        specifier: workspace:*
-        version: link:../../drivers/driver-memory
       '@objectstack/driver-sql':
         specifier: workspace:*
         version: link:../../drivers/driver-sql


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5829

Part of #5704 收口阶段(批次 2/3 已合并,PR #5797 / #5806),本单是留档的两件尾项。

## 任务 1:摘除 `packages/qa/dogfood` 的 driver-memory devDep ✅

摘前按要求全包复核零真实消费(以 `origin/main` 为准):

```
$ git grep -in "memory" origin/main -- packages/qa/dogfood
README.md:13:  seams (analytics strategy routing, in-memory count, REST execution-context).
README.md:18:  This package boots real example apps in-process (in-memory SQLite), wired
package.json:37:  "@objectstack/driver-memory": "workspace:*"
test/read-coercion-conformance.test.ts:9:  // The `driver-memory` arm was removed in #5704 (batch 0) ...
...(其余全部是 in-memory / :memory: / applyInMemoryAggregation 之类与 driver-memory 无关的字样)
```

零 `import ... from '@objectstack/driver-memory'`;唯一提及是 #5715 移除 memory 臂时留下的说明性注释(散文不算消费)。摘除该行后 `pnpm install`,lockfile 只掉了这一条 importer 链接:

```diff
-      '@objectstack/driver-memory':
-        specifier: workspace:*
-        version: link:../../drivers/driver-memory
```

## 任务 2:附录散文清扫 —— 实测后只改了 1 处,另 1 处**原样保留**

`git grep -n "driver-memory" origin/main -- packages/objectql/src/protocol-batch-atomic.test.ts packages/objectql/src/protocol-data.test.ts` 命中的两处,逐处读上下文后判定:

**改写 —— `protocol-batch-atomic.test.ts:23`**:该注释头的是 `makeSnapshotDriver()` 这个本地手写 stub,原文「the same shape `driver-memory` uses」正是 #5704 Phase 1 survey 里让 `grep -i memory` 虚高的措辞(`packages/objectql` 根本不依赖 driver-memory)。按 PR #5797 同款原则改写为指涉 stub 自身,保留其实质信息(这是真会回滚的快照式事务语义,不是玩具):

```
- * A driver with real transaction semantics: ... — the
- * same shape `driver-memory` uses, small enough to assert against.
+ * A stub driver with real transaction semantics: ... —
+ * a genuine rollback, small enough to assert against.
```

**保留 —— `protocol-data.test.ts:759`**:按 PM 派发情报「先读上下文再判,若描述的是真实驱动族语义就原样保留,不要为改而改」复核后,判定属于 #5797 已开的例外类。该句是 #4134 小节 banner 的收尾:

```
// path rejects the SAME unknown name loudly (`INVALID_FIELD`). Mirror of
// #3948's rule for driver-memory: an unapplied filter must not look like a
// satisfied one.
```

它**没有**描述任何 stub —— 该小节的 harness 是纯 `vi.fn()` engine,连 driver 都没有;这句是引用真实 `@objectstack/driver-memory` 包里真实存在、且今天仍在被强制执行的不变量作为先例。证据(均在 `origin/main`):

- `packages/drivers/driver-memory/src/filter-refusal.ts:64`「#3948 made the two backends AGREE that an uncompilable filter ...」
- `packages/drivers/driver-memory/src/memory-driver.ts:753 / 792 / 817`(三处 #3948 锚点)
- `packages/drivers/driver-memory/src/memory-filter-ast-vocabulary.test.ts:2`「Filter-AST vocabulary parity, and no-silent-drop. (#3948)」
- `packages/drivers/driver-memory/CHANGELOG.md:443`「fix(driver-sql,driver-memory): an uncompilable filter now throws instead of matching everything (#3948)」

改写它会把一条准确的跨包交叉引用改成假信息,故原样保留。因此 diff 是 3 个文件而非 issue 预估的 4 个(package.json + lockfile + 1 个测试文件),这是复核后的实测结果。

## 边界遵守

- ⛔ 未动 `packages/runtime` 的 driver-memory devDep 与 `undeclared-field-write-driver-split` 注释(Q2-B 裁定长期保留);
- ⛔ 未动 `plugin-auth/src/auth-contains-filter.test.ts` 及其 devDep(归 finding 单 #5830);
- 零行为变更:无任何运行时代码改动。

## 验证(全部前台阻塞执行,真实输出)

```
pnpm --filter @objectstack/objectql test   -> Test Files 125 passed (125) | Tests 2065 passed (2065)
pnpm --filter @objectstack/objectql typecheck -> tsc --noEmit,无输出即通过
pnpm --filter @objectstack/dogfood  test   -> Test Files 85 passed | 1 skipped (86) | Tests 513 passed | 3 skipped (516)
pnpm --filter @objectstack/dogfood  typecheck -> tsc --noEmit,无输出即通过
node scripts/check-nul-bytes.mjs           -> OK (scanned 5695 tracked text files)
node scripts/check-override-consistency.mjs-> OK
node scripts/check-type-check-coverage.mjs -> OK (63/78)
node scripts/check-published-files.mjs     -> OK (70 publishable packages)
```

依赖闭包在新 worktree 内先 `pnpm --filter '...^...' build` 建过再跑测试;重活全程走共享 `flock /tmp/os-heavy-verify.lock` 串行 + `--max-old-space-size=4096`。

## Changeset

测试/依赖清理,不面向用户 → 无 changeset,`skip-changeset`(label 由 PM 代打)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyvqvKMG6asi9aXjKE6xtx


---
_Generated by [Claude Code](https://claude.ai/code/session_01WyvqvKMG6asi9aXjKE6xtx)_