### PR TITLE
fix(plugin-security): getReadFilter 补上 controlled_by_parent 主档收窄 —— analytics 读面与 middleware 同一作用域 (#5815)

### DIFF
--- a/.changeset/getreadfilter-controlled-by-parent.md
+++ b/.changeset/getreadfilter-controlled-by-parent.md
@@ -1,0 +1,42 @@
+---
+"@objectstack/plugin-security": patch
+---
+
+fix(plugin-security): `getReadFilter` applies the `controlled_by_parent` derivation — the analytics read scope was missing the master half entirely
+
+`getReadFilter` is the read-scope provider bound by the analytics / raw-SQL
+path: the one read surface that bypasses the engine and therefore has no other
+source of scope. Its contract is that it returns **the same filter the engine
+middleware ANDs into every find**. That middleware injects three things — the
+RLS filter, the ADR-0055 `controlled_by_parent` derivation (`masterFK IN
+(accessible master ids)`), and plugin-sharing's OWD / record-share filter.
+`getReadFilter` composed only the first and third; `computeControlledByParentFilter`
+was never called on that path at all.
+
+For an object whose `sharingModel` is `controlled_by_parent` that is not a
+partial gap but a total one, because the two layers it *did* compose both stand
+down on exactly that object by design: such an object carries no authored RLS
+(the whole point of the model is that access is derived rather than authored),
+and it maps to `public` in plugin-sharing's `effectiveSharingModel`, so
+`buildReadFilter` returns `null`. Both halves returned `null`, the composition
+returned `undefined`, and the analytics path ran with **no predicate**. A caller
+who could not read a single master row through `/data` could still `COUNT(*)`
+and `GROUP BY` its detail rows through `/analytics` — and line-item objects are
+the usual shape here, so the grouped values are per-line prices and discounts.
+
+The derivation is now composed into the same AND on that path, resolved from the
+permission sets `getReadFilter` had already resolved (no second resolution), so
+the two read surfaces enforce identical scoping — which is why
+`computeControlledByParentFilter` was extracted and shared in the first place.
+Failures deny: the derivation is internally fail-closed, and a throw propagates
+to the method's existing fail-closed handler rather than widening the read. The
+delegated (`onBehalfOf`) branch already denied outright on this path (#2852) and
+is unchanged.
+
+This is the same failure shape #4467 fixed for the OWD/sharing layer of this
+method, one layer over; #5386 fixed *which inputs* the derivation folds in, not
+*whether it runs* on this surface.
+
+**Impact.** A deployment with `controlled_by_parent` objects and an analytics /
+raw-SQL consumer will see those queries return fewer rows — the rows the caller
+was never entitled to aggregate. No authoring change is required.

--- a/packages/plugins/plugin-security/src/controlled-by-parent-sharing.test.ts
+++ b/packages/plugins/plugin-security/src/controlled-by-parent-sharing.test.ts
@@ -229,6 +229,18 @@ async function boot(options: BootOptions = {}) {
       .map((r) => String(r.id));
   };
 
+  /**
+   * [#5815] The ANALYTICS read face: the scope `getReadFilter` hands the
+   * raw-SQL path, applied to the same rows. No middleware runs here — this
+   * method IS the whole enforcement on that surface.
+   */
+  const analyticsVisibleContacts = async (context?: any): Promise<string[]> => {
+    const filter = await plugin.getReadFilter('crm_contact', context ?? repContext());
+    return (store.rows.crm_contact ?? [])
+      .filter((r) => matchesFilterCondition(r, (filter ?? null) as any))
+      .map((r) => String(r.id));
+  };
+
   /** The WRITE face: a by-id update of one detail row. Resolves or throws. */
   const updateContact = async (id: string): Promise<void> => {
     const opCtx: any = {
@@ -254,7 +266,16 @@ async function boot(options: BootOptions = {}) {
     return out;
   };
 
-  return { store, ctx, visibleContacts, updateContact, writableContacts };
+  return {
+    store,
+    ctx,
+    plugin,
+    repContext,
+    visibleContacts,
+    analyticsVisibleContacts,
+    updateContact,
+    writableContacts,
+  };
 }
 
 describe('[#5386] controlled_by_parent folds the master\'s ownership and share grants in', () => {
@@ -351,5 +372,98 @@ describe('[#5386] controlled_by_parent folds the master\'s ownership and share g
     const h = await boot({ shareLevel: 'edit', sharing: 'throws' });
     expect(await h.visibleContacts()).toEqual([]);
     await expect(h.updateContact('ct_us')).rejects.toThrow(/record sharing/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+/**
+ * [#5815] The THIRD face of the same contract — `getReadFilter`, the read-scope
+ * provider bound by the analytics / raw-SQL path.
+ *
+ * The suite above pins the engine middleware and the by-id write gate against
+ * one fixture precisely so a third, quieter answer cannot hide between them.
+ * There WAS one: `getReadFilter` composed the RLS layer and the sharing layer
+ * and never called the controlled_by_parent derivation at all. On this exact
+ * fixture both of those layers legitimately return `null` — the app authors no
+ * RLS, and plugin-sharing maps `controlled_by_parent` to `public` — so the
+ * composed scope came back `undefined`: NO predicate. A caller who could not
+ * read `acct_eu` could still `COUNT(*)` and `GROUP BY` its contacts.
+ *
+ * These cases therefore assert AGREEMENT, not a filter shape. The two read
+ * surfaces may compose their layers in any order and produce different ASTs;
+ * what they may never do is disagree about which rows are visible.
+ */
+describe('[#5815] getReadFilter enforces the same read scope as the engine middleware', () => {
+  it('PARITY: the analytics read scope and the middleware-injected `ast.where` see the same rows', async () => {
+    const h = await boot({ shareLevel: 'edit' });
+    const viaMiddleware = await h.visibleContacts();
+    const viaReadFilter = await h.analyticsVisibleContacts();
+    expect(viaReadFilter.sort()).toEqual(viaMiddleware.sort());
+    // …and the agreement carries information: one row is excluded on BOTH
+    // surfaces. Without this, "identical" would be satisfied by two surfaces
+    // that each return everything — which is exactly the broken state.
+    expect(viaReadFilter).not.toContain('ct_eu');
+    expect(viaReadFilter).toHaveLength(2);
+  });
+
+  it('the returned scope is a real predicate, not `undefined` — the defect measured', async () => {
+    const h = await boot({ shareLevel: 'edit' });
+    const filter = await h.plugin.getReadFilter('crm_contact', h.repContext());
+    // Before the fix this was `undefined` (RLS null AND sharing null), which
+    // the raw-SQL path spreads into a WHERE that constrains nothing.
+    expect(filter).toBeDefined();
+    expect(JSON.stringify(filter)).toContain('acct_own');
+    expect(JSON.stringify(filter)).not.toContain('acct_eu');
+  });
+
+  it('PARITY with no grant at all: both surfaces narrow to the caller-owned master', async () => {
+    const h = await boot({ shareLevel: null });
+    expect(await h.analyticsVisibleContacts()).toEqual(await h.visibleContacts());
+    expect(await h.analyticsVisibleContacts()).toEqual(['ct_own']);
+  });
+
+  it('PARITY on a READ-level grant: the read share widens the analytics face too', async () => {
+    const h = await boot({ shareLevel: 'read' });
+    expect(await h.analyticsVisibleContacts()).toEqual(['ct_us', 'ct_own']);
+    expect(await h.analyticsVisibleContacts()).toEqual(await h.visibleContacts());
+  });
+
+  it('PARITY without plugin-sharing: neither surface narrows, for the same reason', async () => {
+    // Both faces stand down together — there is no owner scope and there are no
+    // grants anywhere in the deployment, so a direct find of the master returns
+    // every row. Parity must hold in the WIDE direction as well, or the pin
+    // would merely be asserting that the analytics face is always narrower.
+    const h = await boot({ shareLevel: 'edit', sharing: 'none' });
+    expect(await h.analyticsVisibleContacts()).toEqual(['ct_us', 'ct_eu', 'ct_own']);
+    expect(await h.analyticsVisibleContacts()).toEqual(await h.visibleContacts());
+  });
+
+  it('fail-closed: a sharing service that throws denies the analytics face too', async () => {
+    const h = await boot({ shareLevel: 'edit', sharing: 'throws' });
+    expect(await h.analyticsVisibleContacts()).toEqual([]);
+    expect(await h.analyticsVisibleContacts()).toEqual(await h.visibleContacts());
+  });
+
+  it('fail-closed: the derivation resolves the master ONCE per call, never re-entering the detail', async () => {
+    const h = await boot({ shareLevel: 'edit' });
+    h.store.find.mockClear();
+    await h.analyticsVisibleContacts();
+    const reads = h.store.find.mock.calls.map((c: any[]) => String(c[0]));
+    // Direct evidence the derivation (and its sharing half) ran on THIS path
+    // rather than a filter merely coming back from somewhere.
+    expect(reads).toContain('sys_record_share');
+    expect(reads.filter((o) => o === 'crm_account')).toHaveLength(1);
+    expect(reads).not.toContain('crm_contact');
+  });
+
+  it('a delegated (on-behalf-of) read still denies outright — unchanged by the added layer', async () => {
+    // [#2852] The D10 delegator intersection is not implemented on this path,
+    // so it fails closed BEFORE any layer is composed. Pinned here because the
+    // added layer must not become a reason to compute a scope for a context
+    // this method refuses to scope at all.
+    const h = await boot({ shareLevel: 'edit' });
+    const delegated = { ...h.repContext(), onBehalfOf: { userId: OTHER } };
+    expect(await h.analyticsVisibleContacts(delegated)).toEqual([]);
   });
 });

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -2398,6 +2398,33 @@ export class SecurityPlugin implements Plugin {
     }
   }
 
+  /**
+   * The read scope for `object` under `context` — the filter the analytics /
+   * raw-SQL path ANDs into its query, being the one surface that bypasses the
+   * engine and so has no other source of scope.
+   *
+   * Its contract is agreement: this must be **the same filter the engine
+   * middleware ANDs into every find**. That chain injects THREE things, and
+   * this method composes the same three:
+   *
+   *   1. {@link computeRlsFilter} — tenant Layer 0 + RLS policies;
+   *   2. {@link computeControlledByParentFilter} — ADR-0055, `masterFK IN
+   *      (accessible master ids)`;
+   *   3. {@link resolveSharingReadFilter} — plugin-sharing's OWD / record-share
+   *      visibility filter, contributed by the sibling middleware.
+   *
+   * Each layer has been missing here at some point, and each absence had the
+   * same shape: a caller who cannot read a row through `/data` could still
+   * `COUNT(*)` / `GROUP BY` it through `/analytics`. Layer 3 was #4467; layer 2
+   * was #5815 — for a `controlled_by_parent` object, halves 1 and 3 BOTH
+   * commonly return `null` by design (such an object carries no authored RLS,
+   * and maps to `public` in plugin-sharing's `effectiveSharingModel`), so the
+   * composed scope was `undefined` — no predicate at all over what are usually
+   * line-item rows.
+   *
+   * Fails CLOSED on any resolution failure: a dropped predicate here is the
+   * leak, so an unresolvable layer denies (zero rows) rather than widening.
+   */
   async getReadFilter(
     object: string,
     context?: any,
@@ -2427,6 +2454,11 @@ export class SecurityPlugin implements Plugin {
     // already 401s without a token). Mirrors the middleware's early `return next()`
     // — which is the RLS middleware's early exit only, so the sharing predicate
     // resolved above still applies.
+    // [#5815] The controlled_by_parent derivation is deliberately NOT resolved
+    // ahead of this branch the way the sharing predicate is: it stands down
+    // without a `userId` (`computeControlledByParentFilter` returns null), and
+    // this branch is reached only when there is none — so the middleware adds
+    // nothing here either. Agreement holds by both sides standing down.
     if (positions.length === 0 && explicit.length === 0 && !context?.userId) {
       return sharingFilter ?? undefined;
     }
@@ -2454,10 +2486,23 @@ export class SecurityPlugin implements Plugin {
     try {
       const permissionSets = await this.resolvePermissionSetsForContext(context);
       const filter = await this.computeRlsFilter(permissionSets, object, 'find', context);
-      // [#4467] RLS AND sharing — the same AND-composition the two middlewares
-      // achieve by both writing into `ast.where`. Either half may be absent;
-      // `andComposeLayers` returns the other, or null when neither constrains.
-      return andComposeLayers(filter, sharingFilter) ?? undefined;
+      // [#5815] ADR-0055 — the SECOND thing the middleware ANDs into `ast.where`
+      // for a read. Resolved from the sets already resolved above, exactly as
+      // the middleware feeds it its own, so the derived master id set is
+      // computed for this identity once and never re-resolved. It stands down
+      // (null) for any object that is not controlled_by_parent, and it is
+      // internally fail-closed; a THROW propagates to the catch below, which
+      // denies — the same posture as the surrounding layers.
+      const cbpFilter = await this.computeControlledByParentFilter(
+        permissionSets,
+        object,
+        context,
+      );
+      // [#4467] RLS AND controlled-by-parent AND sharing — the same
+      // AND-composition the middlewares achieve by all writing into `ast.where`.
+      // Any layer may be absent; `andComposeLayers` returns the others, or null
+      // when none constrains.
+      return andComposeLayers(andComposeLayers(filter, cbpFilter), sharingFilter) ?? undefined;
     } catch (e) {
       // Fail CLOSED — a resolution failure must deny (zero rows), never expose
       // every tenant's data through the raw-SQL analytics path.


### PR DESCRIPTION
Fixes #5815

## 问题

`SecurityPlugin.getReadFilter` 是 analytics / raw-SQL 路径绑定的读作用域提供者 —— 这是唯一一个绕过引擎、因而没有任何其它作用域来源的读面。它的契约就是「返回 engine middleware AND 进每次 find 的同一个 filter」。

middleware(step 3)向 `ast.where` 注入的是**三层**:

1. `computeRlsFilter` —— 租户 Layer 0 + RLS 策略;
2. `computeControlledByParentFilter` —— ADR-0055,`masterFK IN (可达主档 id 集)`;
3. plugin-sharing 的 OWD / record-share filter(兄弟 middleware 贡献)。

`getReadFilter` 只合成了 1 和 3(`andComposeLayers(filter, sharingFilter)`),第 2 层在这条路径上**一次都没被调用过**。

对 `sharingModel: controlled_by_parent` 的对象,这不是「少一层」而是「一层都不剩」:这类对象按设计不写 RLS(派生访问正是该模型的全部意义),在 plugin-sharing 的 `effectiveSharingModel` 里又映射为 `public`、`buildReadFilter` 返回 `null` —— 于是 1 和 3 同时返回 `null`,合成结果是 `undefined`,**没有任何谓词**。一个连一行主档都读不到的调用者,仍然可以对其明细行 `COUNT(*)` / `GROUP BY`。这类对象通常就是 line-item,聚合出来的正是逐行单价与折扣。

这与 #4467 为同一方法的 OWD/sharing 半边修的是同一种失效形状,只是低一层。

## 改动

在 `getReadFilter` 的普通调用者路径上调用 `computeControlledByParentFilter`,AND 进同一处合成:

- **复用已解析的 permission sets**,不重复解析(与 middleware 喂给它自己的输入一致);
- **不改派生本身的语义** —— 复用的正是 #5816 增强后的派生(主档 owner scope + `sys_record_share` 已折入);
- **fail-closed**:派生内部本身失败即拒(空主档集),抛出则落到本方法既有的 fail-closed 分支拒绝作用域,姿势与周围各层一致;
- **delegator(`onBehalfOf`)分支不动** —— 该分支(#2852)在合成任何一层之前就已整体拒绝,不需要也不应重复加层;
- 匿名分支(无 `positions` / `permissions` / `userId`)同样不需要提前解析:派生在无 `userId` 时本就 stand down,middleware 侧同理,两面靠「同时让位」达成一致。

顺带给 `getReadFilter` 补了 TSDoc,把三层契约写在方法自己头上 —— 此前「同一个 filter」这句承诺只写在 `resolveSharingReadFilter` 的注释里,而漏掉的恰恰是没被任何注释点名的那一层。

## 测试

扩展 #5816 新增的 `controlled-by-parent-sharing.test.ts`,给同一 fixture 加**第三个面**(analytics 读面)。该文件的论点本就是「两个实现面必须共用一个 fixture,否则看不见它们分歧」—— #5815 正是藏在两者之间的第三个更宽的答案。

核心 pin(验收第二条):同一 object + context 下,middleware 注入的 `ast.where` 与 `getReadFilter` 输出给出**同一可见行集**,且该一致**排除了一行**(`ct_eu`,其主档既不属于调用者也未被分享),所以「一致」是携带信息的,而不是「两面都返回全部」也能满足的空一致。

另加:无 grant / read-level grant / 无 plugin-sharing(宽方向也必须一致)/ sharing 抛错(两面同时拒)/ 主档只解析一次且不回环明细 / 委托上下文仍整体拒绝。

### 反向验证(先红后绿,方向与预期一致)

把实现改动单独回退后重跑,新 pin 应当变红且**更宽** —— 实测 5 条红:

```
× PARITY: the analytics read scope and the middleware-injected `ast.where` see the same rows
  AssertionError: expected [ 'ct_eu', 'ct_own', 'ct_us' ] to deeply equal [ 'ct_own', 'ct_us' ]
× the returned scope is a real predicate, not `undefined` — the defect measured
  AssertionError: expected undefined to be defined
× PARITY with no grant at all: both surfaces narrow to the caller-owned master
  AssertionError: expected [ 'ct_us', 'ct_eu', 'ct_own' ] to deeply equal [ 'ct_own' ]
```

`ct_eu` 出现在 analytics 面的可见集里,正是本单描述的泄漏本体。

如实记录:新增 8 条里有 3 条在未修复代码上**本来就是绿的** —— 「无 plugin-sharing 时两面都不收窄」是宽方向的对照组,「sharing 抛错两面同拒」由 #4467 既有的 fail-closed 覆盖,「委托上下文拒绝」由 #2852 既有守卫覆盖。它们是边界对照而非本单的 pin,不应被读成本单的红转绿证据。

### 命令与结果

```
pnpm --filter @objectstack/plugin-security test       → Test Files 35 passed (35) / Tests 749 passed (749)
pnpm --filter @objectstack/plugin-security typecheck  → tsc --noEmit,无输出(通过)
node scripts/check-nul-bytes.mjs                      → OK (5700 files, no raw control bytes)
```

## 文件面

`packages/plugins/plugin-security/**`(实现 + 测试)+ 一个 changeset(user-visible 安全收紧)。未触 `packages/spec` / `packages/objectql` / rest。

`packages/qa/dogfood/test/authz-conformance.matrix.ts` 的 `controlled-by-parent` 行未动:该行记录的是「哪个机制在执行」,本单只是给同一个机制加了第二个调用面,机制身份未变,门禁(`authz-matrix-gate.test.ts`)绿。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwwiU9bjhwy2SWj13ho8uv


---
_Generated by [Claude Code](https://claude.ai/code/session_01JwwiU9bjhwy2SWj13ho8uv)_