### PR TITLE
test(plugin-auth): where-operator 覆盖测试迁到 sqlite `:memory:` 见证;contains pin 实测不可迁,留证上报 (#5830)

### DIFF
--- a/packages/plugins/plugin-auth/package.json
+++ b/packages/plugins/plugin-auth/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@objectstack/driver-memory": "workspace:*",
+    "@objectstack/driver-sql": "workspace:*",
     "@objectstack/objectql": "workspace:*",
     "@types/node": "^26.1.2",
     "hono": "^4.12.34",

--- a/packages/plugins/plugin-auth/src/auth-where-operator-coverage.test.ts
+++ b/packages/plugins/plugin-auth/src/auth-where-operator-coverage.test.ts
@@ -40,10 +40,35 @@
  * unhandled operator is refused by name rather than silently widening a query
  * (the #3948 family's discipline — driver-memory's matcher `default:` arm and
  * objectql's `having` were both changed to refuse for this reason).
+ *
+ * ## Backend note (#5830 / #5704)
+ *
+ * Face 3's backend was `InMemoryDriver` when this file landed with #5844; it is
+ * now `@objectstack/driver-sql` + better-sqlite3 `:memory:`, built the way the
+ * rest of the repo builds an ephemeral store (`examples/app-crm`, `cli db
+ * clean`, PR #5715's `makeDefaultDriver()`, PR #5806's batch 3). #5704's
+ * programme replaces driver-memory's in-repo test consumers with sqlite's
+ * memory mode, and this file was a post-survey arrival, not an exemption.
+ *
+ * The swap costs this file nothing, and that is a measured claim rather than an
+ * assumption: #5813's defect was a DROPPED predicate — the filter compiled to
+ * `{}` and the query answered over the whole table. "The predicate reached the
+ * backend and narrowed the read" is witnessed identically by any backend that
+ * really executes it, and `$nin` / `$startsWith` / `$endsWith` are all
+ * `FILTER_OPERATORS` members that driver-sql compiles for real
+ * (`whereNotIn`, and `applyLike` with an explicit `ESCAPE`). Reverse-verified
+ * both ways in #5830: re-dropping the `not_in` arm turns the `not_in` pin red
+ * on sqlite exactly as it did on memory.
+ *
+ * Its sibling `auth-contains-filter.test.ts` is NOT interchangeable this way —
+ * driver-sql compiles `$regex` through the same `applyContainsLike` as
+ * `$contains` (`sql-driver.ts`, the `case '$regex':` fallthrough), so a SQL
+ * backend cannot tell #5710's defect from its fix. That file's disposition is
+ * #5830's open half; do not "finish the job" by copying this harness onto it.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { InMemoryDriver } from '@objectstack/driver-memory';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SqlDriver } from '@objectstack/driver-sql';
 import { assertEngineDeleteDispatch } from '@objectstack/objectql';
 import { whereOperators } from '@better-auth/core/db/adapter';
 import { FILTER_OPERATORS } from '@objectstack/spec/data';
@@ -55,15 +80,24 @@ import {
   SUPPORTED_WHERE_OPERATORS,
 } from './objectql-adapter';
 
-/** Keeps the driver's own lifecycle logging out of the test output. */
-const silentLogger = {
-  debug: () => {},
-  info: () => {},
-  warn: () => {},
-  error: () => {},
-} as any;
-
-const NOW = new Date('2026-08-06T00:00:00.000Z').toISOString();
+/**
+ * The columns face 3 reads, declared — a real table has to be told.
+ *
+ * `emailVerified` / `createdAt` / `updatedAt` used to be seeded alongside these
+ * and are gone: they were camelCase keys no assertion ever read, which only a
+ * schemaless store would have accepted (`sys_user` spells them
+ * `email_verified` / `created_at` / `updated_at`). Declaring the fixture down to
+ * what it actually asserts on is #5806's "resolve by declaring, not by
+ * relaxing" — the alternative would have been to declare three columns to hold
+ * values nothing looks at.
+ */
+const SYS_USER = {
+  name: 'sys_user',
+  fields: {
+    name: { type: 'text', name: 'name' },
+    email: { type: 'text', name: 'email' },
+  },
+};
 
 /**
  * Rows chosen so each of the three operators has something to EXCLUDE that a
@@ -74,12 +108,14 @@ const NOW = new Date('2026-08-06T00:00:00.000Z').toISOString();
  *   ends_with   'abc' → x_abc            (abc_one / abc_z start with it instead)
  *   not_in [abc_one, x_abc] → abc_z, zed
  *
- * All lowercase on purpose. `$startsWith`/`$endsWith` are case-SENSITIVE at the
- * contract layer (#5701 Q2=A) but driver-memory's mingo path compiles them with
- * the `i` flag while its own reference matcher uses `String.prototype
- * .startsWith` — that in-driver divergence is #5702's budget, not this PR's, so
- * no fixture here varies by case and no assertion below depends on which way it
- * is resolved.
+ * All lowercase on purpose, and the reason survived the backend swap intact
+ * (#5830). `$startsWith`/`$endsWith` are case-SENSITIVE at the contract layer
+ * (#5701 Q2=A); sqlite's `LIKE` is ASCII case-INsensitive by default, just as
+ * driver-memory's mingo path compiled the same operators with the `i` flag
+ * while its own reference matcher used `String.prototype.startsWith`. Both are
+ * the same debt — the per-driver alignment is #5702's budget, not this file's —
+ * so no fixture here varies by case and no assertion below depends on which way
+ * it is resolved.
  */
 const SEED = [
   { id: 'u_abc1', name: 'abc_one', email: 'abc-one@example.com' },
@@ -89,7 +125,7 @@ const SEED = [
 ];
 
 /**
- * An engine facade over a REAL `InMemoryDriver`.
+ * An engine facade over a REAL `SqlDriver`.
  *
  * `delete` opens with ObjectQL's OWN dispatch predicate
  * ({@link assertEngineDeleteDispatch}) instead of a hand-mirrored `if`, so this
@@ -99,7 +135,7 @@ const SEED = [
  * absent: nothing here exercises it, and an unexercised write verb is a second
  * contract to keep honest for no gain.
  */
-function memoryEngine(driver: InMemoryDriver): IDataEngine {
+function sqlEngine(driver: SqlDriver): IDataEngine {
   // The query bag keeps its declared driver-side type with no `any` erasure —
   // `query-options/no-any-erasure` (#4674/#4918) counts test-side calls too.
   return {
@@ -116,13 +152,32 @@ function memoryEngine(driver: InMemoryDriver): IDataEngine {
   } as unknown as IDataEngine;
 }
 
-async function seededAdapter() {
-  const driver = new InMemoryDriver({ logger: silentLogger });
-  await driver.connect();
-  for (const row of SEED) {
-    await driver.create('sys_user', { ...row, emailVerified: false, createdAt: NOW, updatedAt: NOW });
+/**
+ * Live `:memory:` databases, closed after each test — the database dies with
+ * its connection, so nothing touches the host filesystem, but a file this size
+ * would otherwise hold one open pool per behavioural case.
+ */
+const openDrivers: SqlDriver[] = [];
+
+afterEach(async () => {
+  while (openDrivers.length) {
+    const driver = openDrivers.pop();
+    try { await driver?.disconnect(); } catch { /* noop */ }
   }
-  const adapter: any = (createObjectQLAdapterFactory(memoryEngine(driver)) as any)({} as any);
+});
+
+async function seededAdapter() {
+  const driver = new SqlDriver({
+    client: 'better-sqlite3',
+    connection: { filename: ':memory:' },
+    useNullAsDefault: true,
+  });
+  openDrivers.push(driver);
+  // Real DDL through the driver's own path — the table every row below lands in
+  // is created by the backend, not conjured by a store on first write.
+  await driver.initObjects([SYS_USER]);
+  for (const row of SEED) await driver.create('sys_user', row);
+  const adapter: any = (createObjectQLAdapterFactory(sqlEngine(driver)) as any)({} as any);
   return { driver, adapter };
 }
 

--- a/packages/runtime/src/sandbox/undeclared-field-write-driver-split.integration.test.ts
+++ b/packages/runtime/src/sandbox/undeclared-field-write-driver-split.integration.test.ts
@@ -43,8 +43,8 @@
 
 /**
  * ⚠️ `@objectstack/driver-memory` is imported here ON PURPOSE, and this is the
- * ONLY place in the repository that still consumes it from a test. It is NOT a
- * migration leftover — do not "finish the job" by deleting or replacing it.
+ * only PERMANENT test consumer of it in the repository. It is NOT a migration
+ * leftover — do not "finish the job" by deleting or replacing it.
  *
  * Why it has to stay: the whole point of this file is a PRODUCT divergence
  * between two driver families — writing an undeclared field is rejected as a
@@ -68,6 +68,25 @@
  * do not even depend on the driver. #5704/#5784 renamed them all to
  * `makeStubDriver`, precisely so that grepping for the driver lands here, and
  * only here.
+ *
+ * [#5830] "Only here" was briefly untrue and is being restored in two steps,
+ * so the grep is honest about what it finds today. Two consumers arrived in
+ * plugin-auth AFTER #5704's survey (#5812 and #5844, the identity lane):
+ *
+ *   - `plugin-auth/src/auth-where-operator-coverage.test.ts` — migrated to
+ *     sqlite `:memory:` by #5830. Its defect (#5813) was a DROPPED predicate,
+ *     which any backend that really executes the filter witnesses.
+ *   - `plugin-auth/src/auth-contains-filter.test.ts` — still on driver-memory,
+ *     pending a maintainer ruling, and NOT an oversight. Its pin is #5710's
+ *     `contains` → `$regex` flip, and driver-sql routes `$regex` through the
+ *     same `applyContainsLike` as `$contains` (the `case '$regex':`
+ *     fallthrough in `sql-driver.ts`), so a SQL witness answers identically
+ *     either way. Measured in #5830: with the defect restored, the memory
+ *     backend fails 3 behavioural pins and a sqlite backend passes all 4.
+ *     Migrating it would leave assertions that pass because nothing
+ *     distinguishes them. Its disposition rides on #5702 (the driver-side
+ *     `$regex` refusal) — once `$regex` is refused rather than aliased, the
+ *     SQL arm can witness it and the file can move.
  */
 
 import { describe, it, expect, afterEach } from 'vitest';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1441,6 +1441,9 @@ importers:
       '@objectstack/driver-memory':
         specifier: workspace:*
         version: link:../../drivers/driver-memory
+      '@objectstack/driver-sql':
+        specifier: workspace:*
+        version: link:../../drivers/driver-sql
       '@objectstack/objectql':
         specifier: workspace:*
         version: link:../../objectql


### PR DESCRIPTION
Fixes #5830

> ⚠️ **本 PR 只做了 #5830 的一半,是刻意的。** 另一半(`auth-contains-filter.test.ts`)的前提在开工第一步被**实测证伪**,按派单第 1 条停手上报 `needs_decision`,证据见下。合并本 PR 会自动关闭 #5830 —— 建议维护者裁决前先重开,或把开放的一半另立单。

## 背景

#5704 的程序是「driver-memory 在项目内的测试消费者迁到 sqlite 内存模式」,Q2-B 只留 `undeclared-field-write-driver-split` 一处参照臂。#5812/#5844 在 #5704 survey(基线 `a58c0b5`)之后给 plugin-auth 带进了**两个**新消费者。本 PR 迁走其中**能迁的那一个**,并把另一个留下的**实测理由**写进注释。

## 验收证据:grep 前后

排除 driver-memory 包自身,`git grep -l "from '@objectstack/driver-memory'" -- 'packages/**/*.test.ts'`:

**BEFORE(`origin/main` @ `e2bfa6ce3`)—— 3 处**

```
packages/plugins/plugin-auth/src/auth-contains-filter.test.ts
packages/plugins/plugin-auth/src/auth-where-operator-coverage.test.ts
packages/runtime/src/sandbox/undeclared-field-write-driver-split.integration.test.ts
```

**AFTER(本分支)—— 2 处**

```
packages/plugins/plugin-auth/src/auth-contains-filter.test.ts
packages/runtime/src/sandbox/undeclared-field-write-driver-split.integration.test.ts
```

派单预期是「只剩 driver-split 一处」。差的那一处不是漏做,是下面这条测量的结论。

## 前提验证:为什么 `auth-contains-filter.test.ts` 不能迁

`packages/drivers/driver-sql/src/sql-driver.ts` 的算子编译里,`$regex` 是 `$contains` 的 **fallthrough 别名** —— 两者走同一个 `applyContainsLike`:

```
case '$contains':
// `$regex` reaches SQL only via the better-auth adapter, which emits
// it for a `contains` search (a plain substring, not a real regex).
case '$regex':
  this.applyContainsLike(builder, method, field, opValue);
  break;
```

也就是说,**SQL 后端分不出 #5710 的缺陷和它的修复**。实测(两个后端、同一份 fixture、同样的 4 个比较数):

| 比较数 | `$contains` sqlite | `$regex` sqlite | `$contains` memory | `$regex` memory |
|:--|:--|:--|:--|:--|
| `a.b` | `["a.b"]` | `["a.b"]` | `["a.b"]` | `["a.b","axb"]` |
| `^a` | `[]` | `[]` | `[]` | `["a.b","axb"]` |
| `(` | `["x(y"]` | `["x(y"]` | `["x(y"]` | THROW(Invalid regular expression) |
| `xb` | `["axb"]` | `["axb"]` | `["axb"]` | `["axb"]` |

sqlite 两列**逐格相同**,memory 两列在前三格**格格不同**,而那三格正好就是该文件行为面的三条 pin。

再把派单第 4 条要求的反向验证按原样跑一遍 —— 把 `objectql-adapter.ts` 的 `contains` 支临时改回裸 `$regex`(即 #5710 的缺陷):

- **现状(memory 见证)**:`4 failed | 3 passed` —— 契约面 1 条 + **行为面 3 条**全红。
  ```
  × does not read `.` as a wildcard — `a.b` matches `a.b`, not `axb`
    AssertionError: expected [ 'a.b', 'axb' ] to deeply equal [ 'a.b' ]
  × does not read `^` as an anchor
    AssertionError: expected [ { name: 'a.b', …(6) }, …(1) ] to deeply equal []
  × matches a value that is not a legal regex, instead of failing on it
  ```
- **迁移后(sqlite 见证,把同一行为面逐字搬到 sqlite 上跑)**:`Tests 4 passed (4)` —— **全绿**,缺陷仍在适配器里。

所以迁移会把三条承重 pin 变成「因为分辨不出任何东西所以恒绿」的断言 —— 正是 fixture 三分法里「整条替换」那一类的反面教材。派单第 1 条的停手条件成立,故**保留现状 + 把理由钉进注释**,不硬做也不悄悄放着。

**它什么时候能迁**:等 #5702 落地。#5710 摘掉了 `$regex` 的最后一个 live producer,上面那个 `case '$regex':` 别名已是死产者代码;一旦 driver 侧改成**按名拒收** `$regex`,SQL 臂就能以「算子不在 allowlist」的方式见证同一个缺陷,该文件即可迁移。

## 本 PR 实际改了什么

### 1. `auth-where-operator-coverage.test.ts` 迁到 sqlite `:memory:`

行为面(face 3)后端换成 `@objectstack/driver-sql` + better-sqlite3 `:memory:`,抄 PR #5806 batch 3 的现成写法,没有自创 harness;建表走 driver 自己的 `initObjects()`,不是 store 首写时凭空长出来的。

**这个文件迁得动,同样是测出来的,不是假设**:#5813 的缺陷是**谓词被丢掉**(filter 编译成 `{}`,查询答成整表),凡是真正执行过滤的后端都见证得到;`$nin` / `$startsWith` / `$endsWith` 都是 `FILTER_OPERATORS` 成员,driver-sql 都真编译(`whereNotIn`,以及带显式 `ESCAPE` 的 `applyLike`)。

pin 实质**零缩水**,双向反验:

- 把 `not_in` 支改回**静默丢弃**(#5813 的原始形状)→ `4 failed | 23 passed`,行为面报的正是整表:
  ```
  × `not_in` really excludes the listed rows
    AssertionError: expected [ 'abc_one', 'abc_z', 'x_abc', 'zed' ] to deeply equal [ 'abc_z', 'zed' ]
  ```
- 更刁的一发:把 `starts_with` 错译成 `$contains`(拼得像、求值错)→ `6 failed | 21 passed`,锚定语义和 count 都抓到了:
  ```
  × `starts_with` excludes a row that merely CONTAINS the value
    AssertionError: expected [ 'abc_one', 'abc_z', 'x_abc' ] to deeply equal [ 'abc_one', 'abc_z' ]
  × `count` counts the matches, not the table
    AssertionError: expected 3 to be 2
  ```
- 改回后全绿:`Test Files 36 passed (36) / Tests 820 passed (820)`。

两处顺带的收敛,都是「靠声明解决,不是靠放松」(#5806 的做法):

- fixture 原来还塞 `emailVerified` / `createdAt` / `updatedAt` 三个**驼峰**键,没有任何断言读它们,也只有 schemaless store 才会收(`sys_user` 拼的是 `email_verified` / `created_at` / `updated_at`)。现在 fixture 收敛到它真正断言的两列。
- **fixture 保持全小写**(派单第 5 条):sqlite 的 `LIKE` 默认 ASCII 大小写不敏感,而 `$startsWith`/`$endsWith` 契约层敏感(#5701 Q2=A)—— 和 driver-memory 的 mingo 走 `i` flag 是同一笔账,归 #5702 预算。没有新增任何依赖大小写收敛方向的断言,规避策略与原文件一致。

`delete` 双件仍以 `assertEngineDeleteDispatch(options)` 开场,原样保留(`check:engine-double-contract` 绿:38 pinned)。

### 2. `plugin-auth/package.json`

新增 `@objectstack/driver-sql` devDep。`@objectstack/driver-memory` devDep **暂留** —— `auth-contains-filter.test.ts` 还在用它;它随该文件的裁决一并摘除。

### 3. driver-split 的 Q2-B 注释(仅注释,零行为改动)

原句 "the ONLY place in the repository that still consumes it from a test" 改为按迁移后的真实事实叙述:它是唯一的**长期**消费点,并补记 #5812/#5844 带进来的两个临时消费者各自的去向与理由。

## 必答项:是否影响 #5702 的预算或前提?

**不影响预算,并且给它的前提补了一条实测。**

- 预算不动:本 PR 没碰任何 driver。#5702 的两件事 —— driver 侧 `$regex` 按名拒收、`$contains`/`$startsWith`/`$endsWith` 大小写对齐 —— 一行都没提前做,也没绕过。
- 大小写那半:迁移后 fixture 仍全小写,不新增任何依赖收敛方向的断言,所以 #5702 怎么裁都不会撞上本 PR 的断言。sqlite `LIKE` 的 ASCII 不敏感与 memory mingo 的 `i` flag 是同一笔账的两个面,#5702 的口径应当把 SQL 族一并覆盖。
- `$regex` 拒收那半:本 PR 测出 `sql-driver.ts` 里 `case '$regex':` 落到 `$contains` 的别名,在 #5710 摘掉最后一个 live producer 之后已是**死产者代码**。建议 #5702 的清理范围把它一并纳入 —— 那不只是清理,它还是 `auth-contains-filter.test.ts` 能迁移的**前置条件**(#5830 的开放一半因此 `Blocked-by: #5702`)。

## 测试

```
pnpm --filter @objectstack/plugin-auth test       →  Test Files 36 passed (36) / Tests 820 passed (820)
pnpm --filter @objectstack/plugin-auth typecheck  →  tsc --noEmit,无输出
pnpm --filter @objectstack/runtime  typecheck     →  tsc --noEmit,无输出
runtime driver-split 单文件                        →  Test Files 1 passed (1) / Tests 6 passed (6)
check:nul-bytes / engine-double-contract / query-options-erasure
  / driver-conformance / published-files / type-check-coverage  →  全 OK
```

tests-only + 注释 + devDep,发布不可见 —— **tests-only, skip-changeset requested**,未提交空 changeset,`skip-changeset` 标签以并集方式自行写入并读回确认。


---
_Generated by [Claude Code](https://claude.ai/code/session_01JwwiU9bjhwy2SWj13ho8uv)_