### PR TITLE
docs(protocol): 重写 schema.mdx「Multi-Tenant Schemas」为平台实际租户姿势 (#5746)

### DIFF
--- a/content/docs/protocol/objectql/schema.mdx
+++ b/content/docs/protocol/objectql/schema.mdx
@@ -708,24 +708,54 @@ full_name:
 
 ### Multi-Tenant Schemas
 
-Isolate data by tenant:
+Row-level isolation runs on **one platform column**: `organization_id`, a lookup to
+`sys_organization`. The registry injects it into every registered object that has not
+opted out (`hidden`, `readonly`, `required: false` — it is server-populated on insert
+and stays NULL where no organization context exists), so a tenant-scoped object
+declares **nothing** about tenancy:
 
 ```yaml
 name: customer
-tenancy:
-  enabled: true       # Automatically filter by the tenant field (row-level isolation)
-  tenantField: tenant_id
 fields:
-  tenant_id:
-    type: lookup
-    reference: tenant
+  name:
+    type: text
     required: true
 ```
 
-When the kernel runs in multi-tenant mode (`OS_MULTI_ORG_ENABLED=true`), the registry also
-auto-injects an `organization_id` lookup on every user object, and the default
-`tenant_isolation` RLS policy scopes reads/writes to the caller's tenant — so a user in
-Tenant A cannot see Tenant B's records.
+The column's existence does not depend on the deployment's tenancy posture — only its
+*index* does, since nothing filters by organization on a single-organization stack. An
+object opts **out** by declaring `tenancy.enabled: false`
+(or `systemFields.tenant: false`), which withholds both the column and the tenant
+filter — the posture for a platform-global catalog that must stay readable across
+organizations:
+
+```yaml
+name: currency_rate
+tenancy:
+  enabled: false      # platform-global: no organization_id, never tenant-scoped
+fields:
+  code:
+    type: text
+    required: true
+```
+
+`tenantField` is not part of the normal path and carries **no default** — leave it
+undeclared and the driver scopes by `organization_id`, the same column the RLS
+predicates and `RLS.tenantPolicy()` assume. Declare it only for an object whose tenant
+column genuinely is not `organization_id` (`tenantField: workspace_id`), and only when
+the object really carries that field: a declared name for a column that does not exist
+is ignored and the `organization_id` fallback applies.
+
+Enforcement is not a per-object RLS policy. The organization wall is **Layer 0** of the
+authorization kernel — its own code path, always first, AND-composed ahead of and
+independently of business RLS, so no permissive policy, sharing rule or
+`viewAllRecords` / `modifyAllRecords` superuser bit can widen it (ADR-0095 D1). What it
+filters is decided by the deployment's tenancy posture, selected with
+`OS_TENANCY_POSTURE` (ADR-0105 D1): `single` leaves the layer inert, `group` scopes to
+`organization_id IN accessible_org_ids`, `isolated` to
+`organization_id = <active organization>` — so under either walled posture a user in
+organization A cannot see organization B's records. See
+[Tenancy Postures & Membership](/docs/deployment/tenancy-modes).
 
 ## Schema Versioning
 


### PR DESCRIPTION
Closes #5746

`content/docs/protocol/objectql/schema.mdx` 的「Multi-Tenant Schemas」小节整段与平台事实不符，本 PR 按代码逐条重写。**文件面只有这一页**（docs-only，不产出 changeset）。

## 原文教的 vs 实际

| 原文 | 实测（`origin/main`） |
|---|---|
| `tenancy.tenantField: tenant_id` + 手写 `fields.tenant_id` | 租户列就是 registry 注入的 `organization_id`；`tenantField` 自 #5315（已合，`fc5f536a1` / PR #5766）起**没有默认值**，未声明即 `undefined`，由 driver 回落 `organization_id` |
| `reference: tenant` | 平台没有 `tenant` 对象；组织对象是 `sys_organization`（`packages/platform-objects/src/identity/sys-organization.object.ts:14`），也正是注入列的 `reference` |
| 「kernel 运行在 multi-tenant 模式（`OS_MULTI_ORG_ENABLED=true`）时，registry 才注入 `organization_id`」 | 注入是**无条件**的（除 `tenancy.enabled: false` / `systemFields.tenant: false` / `systemFields: false` / `managedBy: 'better-auth'` 四种退出），只有该列的**索引**受 posture 影响：`packages/objectql/src/registry.ts:421` 的 `wantTenant` 与 `indexed: opts.multiTenant` |
| 「注入到 every **user** object」 | 是每个未退出的已注册对象，不限用户自建对象 |
| 「默认的 `tenant_isolation` RLS policy 收敛读写」 | 那条通配 policy 已被 **ADR-0095 D1 退役**，租户墙改为 Layer 0（`packages/plugins/plugin-security/src/tenant-layer.ts`），先于业务 RLS 且与之 AND 合成、不共享 bypass 位 |
| 把 `OS_MULTI_ORG_ENABLED` 当现行开关 | 它是 **LEGACY/DEMOTED**（`packages/types/src/env.ts:89-122`）：仅当 `OS_TENANCY_POSTURE` 未设置时作为回落**输入**读取。现行开关是 `OS_TENANCY_POSTURE`（ADR-0105 D1，`single` / `group` / `isolated`） |

## 改法（取 PM 倾向的「平台默认姿势」）

主示例**不再出现 `tenantField`**：一个租户隔离的对象关于租户**什么都不用声明**。随后补三段正文：

1. 注入条件与范围（未退出即注入；只有索引受 posture 影响），并给出真正的作者杠杆 —— `tenancy.enabled: false` 的**退出**示例（平台级 catalog）；
2. `tenantField` 只作为「租户列确实不是 `organization_id`」的逃生舱一笔带过（`workspace_id`，与 spec 自身 `@example` 及 `content/docs/data-modeling/objects.mdx` 措辞一致），并写明无默认值、且声明的列不存在时被忽略；
3. 执行点改写为 Layer 0 + posture 谓词（`single` 惰性 / `group` 为 `organization_id IN accessible_org_ids` / `isolated` 为按活动组织收敛），并指向已有的权威页 `/docs/deployment/tenancy-modes`，不在本页重复解释 posture 解析规则。

`OS_MULTI_ORG_ENABLED` 在新正文里**一次都不出现** —— 它的 legacy 身份与解析表在 `content/docs/deployment/tenancy-modes.mdx` 与 `deployment/environment-variables.mdx` 已经写全，本页再提只会把降级过的开关重新教一遍。

## 校验

- `node scripts/check-nul-bytes.mjs`（含 `--self-test`）✅ · `check-doc-authoring` ✅（362 files clean）· `check-role-word` ✅（ratchet 无新增）· `docs-audit/check-audit-scope` ✅（178 页在 scope）
- `packages/lint` 的 `check:doc-formula-expressions` ✅（self-test 11 cases + 22 个 formula 例子全绿）
- `packages/spec` 的 `check:skill-examples` ✅（205 prose examples type-check）—— 本页那段 `os:check` 标记的 TS 块未被触碰，跑它是为了确认没被牵连
- 用 `@mdx-js/mdx` 单独编译改后的页面 ✅（内联代码里的 `organization_id = ...` 与跨行代码跨度都不会被当成 JSX）
- 本页示例不在任何 YAML 样例编译门禁内（`os:check` 只覆盖 `ts|typescript|tsx` 块）；docs-only ⇒ 无 changeset，PR 自带 `skip-changeset`

## 顺手记录（未在本 PR 修）

- `content/docs/plugins/packages.mdx:335` 仍把 `OS_MULTI_ORG_ENABLED=true` 当启用 multi-org 的方式（够不到 `group` posture）→ 已单独开 issue
- `content/docs/protocol/kernel/config-resolution.mdx` 通篇教 `context.config.setTenant()` / `setUserPreference()` / `objectstack_tenant_config` 表，仓库里零实现 → 已单独开 issue


---
_Generated by [Claude Code](https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE)_