### PR TITLE
docs(ui): App 页补 `## Areas` 一节 —— 含服务端/客户端闸门不对称 (#4880)

### DIFF
--- a/content/docs/ui/apps.mdx
+++ b/content/docs/ui/apps.mdx
@@ -48,6 +48,7 @@ const crmApp = defineApp({
 | `active` | `boolean` | optional | Is app active (default: `true`) |
 | `isDefault` | `boolean` | optional | Is default app |
 | `navigation` | `NavigationItem[]` | optional | Navigation tree |
+| `areas` | `NavigationArea[]` | optional | Partition navigation by business domain — see [Areas](#areas) |
 | `branding` | `AppBranding` | optional | Visual customization |
 | `requiredPermissions` | `string[]` | optional | Required permissions to access |
 
@@ -212,6 +213,202 @@ rejected — a divider has nothing to label, gate, or badge.)
 | `requiredPermissions` | `string[]` | Permissions required to see/access this item |
 | `requiresObject` | `string` | Hide/disable unless the named object is registered |
 | `requiresService` | `string` | Hide/disable unless the named kernel service is registered |
+
+## Areas
+
+An **area** partitions one app's navigation by business domain — Sales, Service,
+Settings — and each area carries its own independent navigation tree. The active
+area's tree is what the sidebar renders; the shell offers a switcher above it
+once more than one area is visible.
+
+### When to use an area instead of a top-level group
+
+Both split a long sidebar, but they split it differently, and the choice is
+about whether the user needs to see the partitions *at the same time*:
+
+- A **`group` item** keeps everything on screen — a collapsible section inside
+  one tree, with every sibling group still visible beside it. Reach for this
+  first; most apps never need anything else.
+- An **area** *replaces* the sidebar. Only the active area's items are listed;
+  the rest are reached by switching. That is the right shape when a Service rep
+  and a Sales rep share one app but never work in the other's tree, and the
+  wrong shape when the two sets are browsed together.
+
+So: simple apps use `navigation` alone. `areas[]` is for apps large enough that
+a single tree would be unusable, and where the domains are contexts a user
+switches between rather than sections they scan.
+
+### Area properties
+
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `id` | `string` | ✅ | Unique area identifier (`snake_case`) — the switcher's identity and active-area state key |
+| `label` | `string` | ✅ | Area display label |
+| `icon` | `string` | optional | Area icon (Lucide) |
+| `description` | `string` | optional | Authoring annotation only — no surface renders it today |
+| `navigation` | `NavigationItem[]` | ✅ | The area's own navigation tree |
+
+That is the whole key set: `NavigationAreaSchema` is **strict**, so any other
+key fails the parse — see [Retired area-level keys](#retired-area-level-keys)
+for the three that used to be accepted here.
+
+### How `areas[].navigation` relates to the top-level tree
+
+Both trees hold the same `NavigationItem` shape, and every item property means
+the same thing in either one. What differs is which tree the shell renders:
+
+- **Areas take precedence.** With areas declared, the active area's
+  `navigation` is what the sidebar renders; the top-level `navigation` is the
+  fallback, rendered when no area is visible to this user.
+- **Declaration order is display order.** Both the sidebar and
+  `AppSchemaRenderer` iterate the `areas` array exactly as authored — nothing
+  sorts areas. To rearrange them, reorder the array itself.
+- **The first visible area is the initial one**, and the switcher appears only
+  when *more than one* area is visible. A single-area app renders as an ordinary
+  sidebar with no switcher chrome.
+- **Area visibility is derived, never authored.** An area is offered if and only
+  if at least one item inside it survives the item-level gates below. An area
+  whose every item is gated away disappears from the switcher instead of
+  stranding the user on an empty tree, and it is never auto-activated.
+
+### Server-side and client-side gates are not symmetric
+
+<Callout type="warn">
+  **Anything that must never reach the browser goes in `requiredPermissions`,
+  never in `visible`.**
+</Callout>
+
+An area carries no gate of its own — gating lives on the items inside it, and
+the two item-level mechanisms are enforced in *different places*:
+
+| Item property | Enforced where | What it actually does |
+| :--- | :--- | :--- |
+| `requiredPermissions`, `requiresService` | **Server**, in both trees — then re-checked in the shell | The entry is never served: it is absent from the `/meta` body |
+| `visible` (CEL), `requiresObject` | **Client only**, at every level | Hides an entry the browser has already received |
+
+Since #4722 the authoritative server-side filter (`filterAppForUser`) runs the
+**same** item filter over the app's top-level `navigation` *and* over every
+`areas[].navigation`, so an item's `requiredPermissions` / `requiresService` is
+enforced identically in both trees: a gated entry — with its `objectName` /
+`pageName` / `componentRef` target — never leaves the server. An area emptied
+**by** the gate is dropped from the response, mirroring how an emptied `group`
+collapses; an area *authored* empty is passed through untouched, because
+filtering reports what the caller may not see rather than tidying the metadata.
+
+`visible` did **not** move server-side with them, and that asymmetry is
+deliberate: CEL is evaluated in the browser because server-side evaluation needs
+a bound `user` context the read layer does not have. So `visible` is a
+decluttering affordance — it hides an entry the response already contains, and
+reading the JSON defeats it. Use it to reduce noise, never to keep a secret. The
+same holds for `requiresObject`.
+
+### Retired area-level keys
+
+<Callout type="warn">
+  `areas[].order`, `areas[].visible` and `areas[].requiredPermissions` were
+  removed in `@objectstack/spec` 17.0.0 (ADR-0049 enforce-or-remove) and are now
+  **refused at parse time** rather than ignored, so one leftover key fails the
+  whole save. Run `os migrate meta --from 16` to rewrite existing sources
+  automatically.
+
+  - `order` (#4667) — no renderer ever sorted areas, so declaration order
+    already *was* display order and an author who set `order` saw nothing move.
+    Delete the key and reorder the `areas` array. Note the neighbour that
+    behaves differently: a navigation **item's** `order` is genuinely sorted,
+    and this removal does not touch it.
+  - `visible` and `requiredPermissions` (#4651) — these were not merely unread
+    keys, they were **fail-open gates**. No layer read them, so an area "hidden"
+    by one, or restricted to `['sales.admin']`, was served to and rendered for
+    *every* user: the author got a clean parse, a stored value, and no gate at
+    all. Removing a gate that never gated is strictly safer than shipping one
+    that looks like it works. Gate the items **inside** the area instead — an
+    item's `visible` takes the same CEL expression, and its
+    `requiredPermissions` is the server-enforced one — or gate the whole app
+    with the app-level `requiredPermissions`, which *is* checked server-side.
+
+  The removals do not read back onto the items: item-level gating inside an area
+  is fully supported, and since #4722 it is server-enforced.
+</Callout>
+
+### Complete Example
+
+Two areas for one field-service app, showing both gate kinds side by side:
+
+{/* os:check */}
+```typescript
+import { defineApp } from '@objectstack/spec';
+
+const fieldServiceApp = defineApp({
+  name: 'field_service',
+  label: 'Field Service',
+  description: 'Dispatch, work orders, and service analytics',
+  icon: 'wrench',
+  active: true,
+
+  branding: {
+    primaryColor: '#0f766e',
+    logo: '/assets/fs-logo.svg',
+  },
+
+  // Declaration order IS display order — areas carry no `order` key.
+  areas: [
+    {
+      id: 'area_dispatch',
+      label: 'Dispatch',
+      icon: 'calendar-clock',
+      navigation: [
+        { id: 'nav_board', type: 'page', label: 'Dispatch Board', pageName: 'dispatch_board', icon: 'layout-dashboard' },
+        { id: 'nav_work_orders', type: 'object', label: 'Work Orders', objectName: 'work_order', icon: 'clipboard-list', viewName: 'open_work_orders' },
+        {
+          id: 'nav_my_jobs',
+          type: 'object',
+          label: 'My Jobs',
+          objectName: 'work_order',
+          icon: 'user-check',
+          filters: { technician_id: '{current_user_id}', status: 'scheduled' },
+        },
+      ],
+    },
+    {
+      id: 'area_analytics',
+      label: 'Analytics',
+      icon: 'bar-chart',
+      navigation: [
+        { id: 'nav_sla', type: 'dashboard', label: 'SLA Overview', dashboardName: 'service_sla', icon: 'gauge' },
+        {
+          id: 'nav_job_margin',
+          type: 'report',
+          label: 'Job Margin',
+          reportName: 'job_margin',
+          icon: 'file-bar-chart',
+          // SERVER-enforced in both trees: a caller without this permission
+          // never receives this entry, so its `reportName` is not readable
+          // from the /meta body either.
+          requiredPermissions: ['service.finance'],
+        },
+        {
+          id: 'nav_forecast_beta',
+          type: 'dashboard',
+          label: 'Forecast (beta)',
+          dashboardName: 'service_forecast',
+          icon: 'trending-up',
+          // CLIENT-only: this entry IS sent and then hidden. Decluttering,
+          // not access control — never put a secret behind `visible`.
+          visible: "'service_beta' in current_user.positions",
+        },
+      ],
+    },
+  ],
+
+  // The fallback tree: rendered only when NO area is visible to the caller
+  // (every area's items gated away, or the areas list filtered empty).
+  navigation: [
+    { id: 'nav_handbook', type: 'url', label: 'Service Handbook', url: 'https://help.example.com/service', icon: 'book-open', target: '_blank' },
+  ],
+
+  requiredPermissions: ['service_access'],
+});
+```
 
 ## Branding
 


### PR DESCRIPTION
Closes #4880

`content/docs/ui/apps.mdx` 此前一次都没有提到 `areas[]` —— 一个真实可作者化、且带权限相邻语义的键,文档覆盖为零;而 17.0.0 窗口里有三处改动正好落在它上面。只读这一页的作者不但不知道 areas 存在,更不知道他第一反应会去写的那个闸门(`visible`)恰恰是服务端**不**强制的那个。

## 新增 `## Areas` 一节

- **什么时候用 area 而不是顶层 group**:`group` 把同级都留在屏幕上,area 则**替换**整棵侧边栏 —— 所以 area 适合「用户在其间切换的上下文」,不适合「需要并排浏览的分组」。简单应用只用 `navigation`。
- **Area 属性表**:`id` / `label` / `icon` / `description` / `navigation` 就是全集(`NavigationAreaSchema` 是 strict)。`description` 明确标注为「今天没有任何界面渲染它」的作者侧注解,避免作者误期待。
- **`areas[].navigation` 与顶层树的关系**:areas 优先,顶层 `navigation` 是「该用户看不到任何 area 时」的兜底;**声明顺序即显示顺序**(侧边栏与 `AppSchemaRenderer` 都按作者写的顺序迭代,没有任何地方排序 areas);切换器只在**可见 area 多于一个**时出现;**area 的可见性是派生的、不可作者化** —— 内部一项都不剩的 area 会从切换器消失,也不会被自动选中。
- **服务端/客户端闸门不对称**(本节的安全要点):项级 `requiredPermissions` / `requiresService` 自 #4722 起在**两棵树**都由 `filterAppForUser` 服务端剥离、再在 shell 复检;`visible`(CEL)与 `requiresObject` 在**任何层级**依然只在客户端求值。结论一句话写进 Callout:**必须永不到达浏览器的东西写 `requiredPermissions`,不要写 `visible`**。同时写清收紧后的响应形状:被 gate 滤空的 area 整个剥离(与 `group` collapse 同构),而**作者写空**的 area 原样透传。
- **17.0.0 退役说明**:`areas[].order`(#4667)、`areas[].visible` / `areas[].requiredPermissions`(#4651)现在是 parse 期拒收而非静默忽略,一个残留键会让整次保存失败;附上它们当初是 **fail-open 闸门**的历史(干净 parse + 存下的值 + 对**每个**用户照常下发),以及一句边界:退役**不**回读到项级 —— area 内部的项级闸门完整可用,且自 #4722 起是服务端强制的。样例中不出现这三个键。
- **Complete Example 级样例**:一个双 area 的 field-service app,把两类闸门并排展示(`requiredPermissions: ['service.finance']` 服务端强制 vs `visible` 仅客户端去噪),并带 `{/* os:check */}` 标记,让门禁按真实构建产物 type-check 它。

## 措辞蓝本

按 issue 的「谁先做谁定调」约定,配对单 #4749(PR #5336)与相邻单 #5337 均已 closed-completed,本节措辞对齐它们落地后的口径:`packages/spec/src/ui/app.zod.ts` 的 `AREA_REQUIRED_PERMISSIONS_RETIRED` / `AREA_VISIBLE_RETIRED` 处方正文,以及 `packages/spec/liveness/app.json` 的 `areas.navigation` note。

## 实测核对(逐条对 origin/main 验过,非照抄 issue)

| 断言 | 证据 |
| :--- | :--- |
| 项级闸门两棵树服务端强制 | `packages/rest/src/rest-server.ts` `filterAppForUser`:`filterAreas` 对每个 `areas[].navigation` 复用同一个 `filterNav` |
| 滤空的 area 被剥离 / 作者写空的透传 | 同上 `filterAreas`:`kids.length === 0` 时 `continue`;`anav.length === 0` 时 `out.push(a)` |
| `visible` / `requiresObject` 仅客户端 | 同函数的 "NOT gated here" 注释 |
| areas 按作者顺序迭代、无排序 | objectui `AppSidebar` 与 `AppSchemaRenderer` 均为 `areas.filter(...)`,无 sort |
| area 树取代顶层树、顶层为兜底 | `activeArea?.navigation \|\| activeApp?.navigation \|\| []` |
| area 可见性由内部项派生 | 两处 `hasVisibleNavigationItems(area.navigation, ...)`(objectui#3311 / #3319) |

一处**据实测修正了 issue 的隐含表述**:issue 只说 areas「按作者顺序迭代」,实测还有一条它没提、但对作者更要紧的事实 —— **area 的可见性是从内部项派生的**(全被 gate 掉就整个消失且不会被选中)。这正是 #4651 退役 area 级 `visible` 后仍能保住「整个 area 消失」这一 UX 的机制,已写入本节。

## 检查

- `tsx packages/spec/scripts/check-skill-examples.ts` → `206 prose examples type-check against @objectstack/spec`(新样例登记为 `content/docs/ui/apps.mdx:339`,205 → 206)
- `check-doc-authoring.mjs`(含 `--self-test`)→ `362 files clean`
- `docs-audit/affected-docs.mjs --self-test` + `check-audit-scope.mjs`(含 `--self-test`)→ 全绿,`178 hand-written doc(s)` in sync
- `check-nul-bytes.mjs` → OK;另做超出门禁的自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` 零命中
- `check-role-word.mjs` → OK
- MDX 语法:用 `@mdx-js/mdx` + `remark-gfm` 实编译该页通过(门禁的 `lychee` 设了 `include_fragments = false`,所以页内锚点不受 CI 保护 —— 因此把被引用的小节标题改成无标点的 `### Retired area-level keys`,锚点不再依赖 `17.0.0` / 破折号的 slug 化行为)

## 边界

docs-only:仅改 `content/docs/ui/apps.mdx`(+197 行)。⛔ 未动 `packages/**` 源码(spec 处方与其 pin 只读不改),⛔ 未动 `content/docs/releases/**`。不发布任何包,故无 changeset,PR 自带 `skip-changeset` 标签。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE)_