### PR TITLE
refactor(trigger-record-change): 摘掉 `input.doc` 这条没有生产者的防御性 alias 读 (#5671)

### DIFF
--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,14 @@
+---
+'@objectstack/trigger-record-change': patch
+---
+
+record-change trigger: drop the unreachable `input.doc` alias read, seed the flow record from `input.data` only
+
+Behaviour is unchanged: no engine path has ever built `input.doc`, so the alias
+limb could not be reached. Every ObjectQL write context spells the payload
+`data` — measured and pinned by `hook-input-shape-contract.test.ts` in
+`@objectstack/objectql` ("insert carries `data` — never `doc`", #5273). The
+branch survived only because the old `HookContext.input` contract table
+documented insert as `{ doc, options }`; that table was corrected in #5668, so
+the fallback no longer had even a documented producer to defend against, and it
+is removed here rather than left as a second de-facto contract (PD #12).

--- a/packages/services/service-storage/src/attachment-lifecycle.test.ts
+++ b/packages/services/service-storage/src/attachment-lifecycle.test.ts
@@ -156,7 +156,10 @@ describe('installAttachmentLifecycleHooks — tombstoning', () => {
     await engine.trigger('afterInsert', {
       object: 'sys_attachment',
       event: 'afterInsert',
-      input: { doc: { file_id: 'f1' } },
+      // [#5671] An insert hook's payload arrives under `data` — `doc` was this
+      // fixture's spelling from the old (wrong) contract table, a key no engine
+      // path builds. Pinned in objectql's `hook-input-shape-contract.test.ts`.
+      input: { data: { file_id: 'f1' } },
       result: { id: 'a9', file_id: 'f1' },
     });
 

--- a/packages/triggers/trigger-record-change/src/record-change-trigger.test.ts
+++ b/packages/triggers/trigger-record-change/src/record-change-trigger.test.ts
@@ -57,7 +57,10 @@ function hookCtx(overrides: Partial<HookContext> = {}): HookContext {
     return {
         object: 'showcase_task',
         event: 'afterUpdate',
-        input: { id: 't1', doc: { status: 'done' } },
+        // `data` is what every engine write path actually builds — see the
+        // objectql pin `hook-input-shape-contract.test.ts` (#5273). The old
+        // spelling here was `doc`, a key no producer ever wrote (#5671).
+        input: { id: 't1', data: { status: 'done' } },
         result: { _id: 't1', status: 'done', assignee: 'u2' },
         previous: { _id: 't1', status: 'open', assignee: 'u1' },
         session: { userId: 'u9' },
@@ -300,7 +303,15 @@ describe('RecordChangeTrigger', () => {
         expect(ctx.params).toEqual(ctx.record);
     });
 
-    it('falls back to input.doc when result is absent (e.g. before-hooks)', async () => {
+    // [#5671] `input.data` is the ONE key a write hook's payload arrives under.
+    // objectql's `hook-input-shape-contract.test.ts` measures that on the engine
+    // ("insert carries `data` — never `doc`"); these two pin that this consumer
+    // reads exactly that key and nothing else. The pair is deliberate: the
+    // positive case alone would stay green if the deleted `doc` alias limb were
+    // put back (`data` sits first in the read, so it wins either way), so the
+    // NEGATIVE case is the one carrying the weight — it goes red the moment any
+    // alias limb returns.
+    it('seeds the record from input.data when result is absent (e.g. before-hooks)', async () => {
         const { engine, hooks } = fakeEngine();
         const trigger = new RecordChangeTrigger(engine, silentLogger());
         let captured: AutomationContext | undefined;
@@ -312,6 +323,30 @@ describe('RecordChangeTrigger', () => {
         await hooks[0].handler(hookCtx({ event: 'beforeUpdate', result: undefined }));
 
         expect(captured?.record).toEqual({ status: 'done' });
+    });
+
+    it('does NOT read a `doc` alias off input — no engine path produces that key', async () => {
+        const { engine, hooks } = fakeEngine();
+        const trigger = new RecordChangeTrigger(engine, silentLogger());
+        let captured: AutomationContext | undefined;
+
+        trigger.start(binding({ event: 'record-before-update' }), async (ctx) => {
+            captured = ctx;
+        });
+
+        // `previous` is dropped too, so the seed can only come from the payload:
+        // with `doc` unread there is nothing left and the record is empty.
+        await hooks[0].handler(
+            hookCtx({
+                event: 'beforeUpdate',
+                result: undefined,
+                previous: undefined,
+                input: { id: 't1', doc: { status: 'done' } } as HookContext['input'],
+            }),
+        );
+
+        expect(captured?.record).toEqual({});
+        expect((captured?.record as Record<string, unknown>).status).toBeUndefined();
     });
 
     it('reads the __previous stash when ctx.previous is absent', async () => {

--- a/packages/triggers/trigger-record-change/src/record-change-trigger.ts
+++ b/packages/triggers/trigger-record-change/src/record-change-trigger.ts
@@ -277,7 +277,7 @@ export class RecordChangeTrigger implements FlowTrigger {
     /**
      * Build the flow execution context from an ObjectQL hook context. The new
      * record comes from `ctx.result` (after-hooks) or falls back to the
-     * mutation input doc / previous row; the old record from `ctx.previous`
+     * mutation input payload / previous row; the old record from `ctx.previous`
      * (with the `__previous` stash audit also uses as a fallback).
      *
      * Async because the seeded `record` is hydrated with read-time computed
@@ -285,28 +285,29 @@ export class RecordChangeTrigger implements FlowTrigger {
      */
     private async buildContext(binding: FlowTriggerBinding, ctx: HookContext): Promise<AutomationContext> {
         // objectql lifecycle hooks carry the written row under `input.data` (insert /
-        // update payload); `id` is on update. (`doc` kept only as a defensive alias.)
-        const input = (ctx.input ?? {}) as { data?: Record<string, unknown>; doc?: Record<string, unknown>; id?: unknown };
+        // update payload); `id` is on update. `data` is the ONLY spelling any engine
+        // path produces — measured and pinned by objectql's
+        // `hook-input-shape-contract.test.ts` ("insert carries `data` — never `doc`",
+        // #5273). A `doc` alias limb used to sit below this read for a producer that
+        // never existed; removed in #5671 rather than left as a second de-facto
+        // contract (PD #12). before/afterDelete carry no payload at all and fall
+        // through to `previous` below.
+        const input = (ctx.input ?? {}) as { data?: Record<string, unknown>; id?: unknown };
         const after = ctx.result as Record<string, unknown> | undefined;
         const previous =
             (ctx.previous as Record<string, unknown> | undefined) ??
             ((ctx as unknown as { __previous?: Record<string, unknown> }).__previous ?? undefined);
 
-        const inputDoc =
-            input.data && typeof input.data === 'object'
-                ? input.data
-                : input.doc && typeof input.doc === 'object'
-                  ? input.doc
-                  : undefined;
+        const inputData = input.data && typeof input.data === 'object' ? input.data : undefined;
         const record: Record<string, unknown> =
             after && typeof after === 'object'
-                ? // #1872 — overlay the after-row on the input doc so fields the
+                ? // #1872 — overlay the after-row on the input payload so fields the
                   // driver did not echo back (notably `multiple: true` lookups,
                   // stored as an array column) stay visible to the flow's start
                   // condition and `{record.<field>}` interpolation. The after-row
                   // wins for every field it DOES return (id, DB-computed values).
-                  { ...(inputDoc ?? {}), ...after }
-                : inputDoc ?? (previous && typeof previous === 'object' ? previous : {});
+                  { ...(inputData ?? {}), ...after }
+                : inputData ?? (previous && typeof previous === 'object' ? previous : {});
 
         const session = (ctx.session ?? {}) as { userId?: string; organizationId?: string };
 


### PR DESCRIPTION
Fixes #5671

## 背景

`record-change-trigger.ts` 的 `buildContext()` 在 `input.data` 之后又兜了一条 `input.doc`。这条分支在任何引擎路径上都**不可达**:ObjectQL 的写事件上下文一律把载荷拼在 `data` 上(insert / update),`before/afterDelete` 两者都不带、直接落到 `previous`。

该 alias 当初留下的唯一依据,是旧的 `HookContext.input` 契约表把 insert 写成 `{ doc, options }` —— 那张表本身是错的,已由 PR #5668(#5273)改成 `{ data, options }` 并加了 pin。依据消失后,按 PD #12 删掉,而不是继续养一套第二事实契约。

**行为零变化** —— 该分支不可达,真值 pin 在 `packages/objectql/src/hook-input-shape-contract.test.ts`(「insert carries `data` — never `doc`」)。本 PR 只引用该 pin,未改动它。

## 改动

1. **`packages/triggers/trigger-record-change/src/record-change-trigger.ts`** —— 删掉 `input.doc` 三元限支与类型里的 `doc?:` 声明,只读 `input.data`;局部变量 `inputDoc` 随之更名 `inputData`(纯局部,不导出),注释改写为指向引擎真值与那条 pin。
   - 保留了同一处 cast 里的 `id?: unknown`:它虽然在本函数内未被读,但**是真的**(update 事件上引擎确实绑 `input.id`)。删的是那个假的键,不是顺手清扫。
2. **`record-change-trigger.test.ts`** —— `hookCtx` fixture 原本拼的就是 `doc`,正是它让这条死分支在测试里保持「活着」(#4984 那一族:fixture 照着错契约表写,于是死逻辑一直绿)。按引擎真值 re-spell 成 `data`,并把原「falls back to input.doc」用例**整条替换**为一对承重 pin。
3. **`packages/services/service-storage/src/attachment-lifecycle.test.ts`** —— insert fixture 同样按引擎真值 re-spell(fixture 三分法里的 re-spell 档)。
4. changeset(patch)。

## 反向验证 —— 方向先判,再测

这条链的**规范键 `data` 排在读取链首位**,所以「把删掉的限支放回去、看新用例转红」对*正向*用例并不成立:正向用例喂 `data`,alias 复活与否它都绿。承重的是**反向**那条 —— 喂一个只拼 `doc` 的上下文,断言它**不播种** record。

把 `doc` 限支临时放回源码后实测:

```
 × does NOT read a `doc` alias off input — no engine path produces that key
 AssertionError: expected { status: 'done' } to deeply equal {}
 Test Files  1 failed | 4 passed (5)
      Tests  1 failed | 55 passed (56)
```

正好 1 红,且正是反向那条;正向用例如预期保持绿。这一对是刻意配的,注释里也写明了哪条承重。恢复后全绿。

## 验证

按 `lint.yml` / `ci.yml` 逐条枚举跑了 diff 可能影响的门,全程持容器级验证锁 + `--max-old-space-size=4096` + `--filter` 范围化:

| 门 | 结果 |
|:--|:--|
| `pnpm --filter @objectstack/trigger-record-change typecheck` | exit 0 |
| `pnpm --filter @objectstack/trigger-record-change test` | Test Files 5 passed / Tests 56 passed |
| `pnpm --filter @objectstack/service-storage test` | Test Files 21 passed / Tests 283 passed |
| `eslint --no-inline-config`(三个改动文件) | exit 0 |
| `pnpm check:nul-bytes` | PASS |
| `pnpm check:engine-double-contract` | PASS |
| `pnpm check:adr-anchors` | PASS |
| `pnpm check:published-files` | PASS |
| `pnpm check:type-check-coverage` | PASS |

(`@objectstack/service-storage` 无 `typecheck` script —— 已在 `check-type-check-coverage.mjs` 的台账里,该门 PASS。)

## 两个必答项

**1. 全仓 `doc` 读者是否归零?——「hook input 形状」这一面归零,但另有三处同族,已另立单 #5906。**

改动后 `input.doc` 的**读者**全仓只剩下注释文本,零代码读点在 `trigger-record-change`。但同一次 grep 翻出另外三处,都不在本 issue 的派发作业面内,按 PD #10 另立 #5906(unassigned,`finding`),未在本 PR 修:

- `packages/services/service-storage/src/attachment-lifecycle.ts:174` —— `ctx?.result ?? ctx?.input?.doc ?? ctx?.input?.data`,注意**次序与本 PR 相反**,`doc` 在 `data` 前面;因 `doc` 恒 undefined 而每次穿到 `data`,纯死码。
- `packages/plugins/plugin-sharing/src/primary-bu-projection.ts:80` —— `(ctx?.input?.data ?? ctx?.input?.doc)?.user_id`,`doc` 限支不可达。
- `packages/runtime/src/sandbox/body-runner.ts:308` —— 读的是顶层 `ctx.doc` / `ctx.previousDoc`,**不是** `ctx.input.doc`,严格说不属于本次 grep 的目标键;但 `HookContext` 只声明 `input` / `result` / `previous`,这两个键同样无生产者,同族,一并列入 #5906 便于一次判。

另需提示:`hook-input-shape-contract.test.ts:23` 的文件头注释写着「`trigger-record-change` still carries a defensive `input.doc` alias read for that reason — filed separately, not fixed here」,本 PR 合入后这句即过时。派发口径明确 ⛔ 不改该 pin 文件,故此处**未动**,留给该文件的座位顺手修一句。

**2. 对 #5886(spec fixture re-spell)的影响:完全无影响,既不变简单也不变难。**

本 PR 的 diff 里**没有任何 `packages/spec` 文件**(已核:`git status` 中 spec 文件数 = 0)。#5886 的作业面是 `packages/spec/src/data/hook.test.ts:422/474/490` 那一组 fixture,喂的是开放形状的 `z.record`,与本包的消费端读取逻辑无耦合 —— 两边既不共享 fixture,也不互为前提。#5886 该怎么 re-spell 仍怎么 re-spell。

## 范围

⛔ 未触 `packages/spec` 任何文件;⛔ 未改 `hook-input-shape-contract.test.ts`;⛔ 未触 `content/docs/releases/`。

---
_Generated by [Claude Code](https://claude.ai/code/session_015a5qkLzpGXhLL2F5gvJ7dD)_