### PR TITLE
ci(dx): 两个发现型闸门补「发现数」非空断言 —— 语料/驱动轴静默蒸发即红 (#4932)

### DIFF
--- a/scripts/check-doc-authoring.mjs
+++ b/scripts/check-doc-authoring.mjs
@@ -62,6 +62,28 @@
 // at startup and an unresolvable one fails the gate **by name**. There is no
 // optional root and no empty catch — see `assertRootsResolvable` for why a
 // whitelist would be the wrong shape here rather than merely unnecessary.
+//
+// ## A scan that finds nothing is a hard error too (#4932)
+//
+// #4916 closed one spelling of the evaporation: the ROOT no longer resolves.
+// This closes the other, which that assertion cannot see — the root resolves and
+// the corpus is no longer inside it. A subtree moves out, a `SKIP_PATHS` entry
+// widens, an authoring convention changes the extension: the root is still a
+// directory, so `assertRootsResolvable` is satisfied, the walk returns fewer
+// files, and the printed count drops in silence. `✓ 362 files clean` and
+// `✓ 0 files clean` are the same sentence to every reader and the same exit code
+// to CI — which is all of #4932: the count was printed and never asserted.
+//
+// The floor is PER ROOT, not on the total. A total floor is held up by whichever
+// root still has files while another empties (`.claude` alone keeps it positive),
+// and "part of the corpus was read" is precisely the verdict this gate must not
+// resolve in the corpus's favour. It is a floor of one file per declared root,
+// derived from the walk that just ran — deliberately NOT a ratchet against a
+// recorded high-water mark, which would have to be maintained and would turn
+// every legitimate deletion into an argument with a number.
+//
+// It lives in `collectFiles`, not in `main`, so the self-test drives the
+// invariant itself rather than a proxy for it.
 import {
   mkdirSync, mkdtempSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync,
 } from 'node:fs';
@@ -174,16 +196,45 @@ function assertRootsResolvable(roots = ROOTS) {
 }
 
 /**
+ * A declared ROOT that resolved to a directory and yielded no file to scan.
+ * Carries the names, and the total the run would otherwise have reported.
+ */
+class EmptyRootError extends Error {
+  constructor(empty, total) {
+    super(`ROOT(s) contributed no Markdown/MDX file: ${empty.join(', ')} (total scanned: ${total})`);
+    this.name = 'EmptyRootError';
+    /** @type {string[]} the roots that yielded nothing. */
+    this.roots = empty;
+    /** @type {number} files found across all roots — 0 when the whole scan evaporated. */
+    this.total = total;
+  }
+}
+
+/**
  * Every Markdown/MDX file in scope, relative to the current working directory.
  *
  * Nothing here is wrapped in a catch: an unreadable root fails loudly above, and an
  * error *inside* `walk` (a vanished file, a permission fault) means the corpus was
  * only partly read — which must not be reported as a clean scan either.
+ *
+ * Each root must also actually YIELD something (#4932). A root that resolves but
+ * holds no Markdown is the same evaporation as a root that does not resolve, minus
+ * the ENOENT that made the first kind detectable: the walk succeeds, the count
+ * shrinks, and nothing in the output distinguishes "clean" from "never read".
+ *
+ * @throws {DeadRootError} a declared ROOT is not a directory.
+ * @throws {EmptyRootError} a declared ROOT resolved but contributed no file.
  */
 function collectFiles() {
   assertRootsResolvable();
   const files = [];
-  for (const r of ROOTS) walk(r, files);
+  const empty = [];
+  for (const r of ROOTS) {
+    const before = files.length;
+    walk(r, files);
+    if (files.length === before) empty.push(r);
+  }
+  if (empty.length) throw new EmptyRootError(empty, files.length);
   return files;
 }
 
@@ -325,6 +376,41 @@ function selfTest() {
     // ...and restoring both roots restores the green, so the red above was caused
     // by the broken root and nothing else.
     expect('restoring the roots makes the scan green again', collectFiles().length, files.length);
+
+    // --- Reverse proof for the empty-scan hard error (#4932), same discipline. ---
+    // The direction was decided before it was run: a root that resolves and yields
+    // nothing must be RED, and the red must name that root only. This is the case
+    // #4916's assertion cannot reach — nothing is renamed, nothing is unreadable,
+    // the corpus is simply not there any more.
+    const emptiedRoot = join(dir, 'skills', 'legit', 'SKILL.md');
+    rmSync(emptiedRoot);
+    let emptyErr = null;
+    try { collectFiles(); } catch (err) { emptyErr = err; }
+    writeFileSync(emptiedRoot, wrapped);
+
+    expect('a root that resolves but yields nothing is red', emptyErr instanceof EmptyRootError, true);
+    expect('the failure names the empty root', emptyErr?.roots?.join(',') ?? '<none>', 'skills');
+    expect('the failure does not blame the populated roots', /\.claude|docs|content/.test(emptyErr?.roots?.join(',') ?? ''), false);
+    // The other roots were still scanned, so the total proves the run was not
+    // simply aborted: 8 files minus the one just removed.
+    expect('the failure reports what the run did find', emptyErr?.total ?? -1, files.length - 1);
+    expect('restoring the file makes the scan green again', collectFiles().length, files.length);
+
+    // ...and the extreme the issue named: every root resolves, the whole scan
+    // finds nothing, and the old code printed `✓ 0 files clean` and exited 0.
+    const bare2 = mkdtempSync(join(tmpdir(), 'doc-authoring-selftest-empty-'));
+    let allEmptyErr = null;
+    try {
+      for (const r of ROOTS) mkdirSync(join(bare2, r), { recursive: true });
+      process.chdir(bare2);
+      try { collectFiles(); } catch (err) { allEmptyErr = err; }
+    } finally {
+      process.chdir(dir);
+      rmSync(bare2, { recursive: true, force: true });
+    }
+    expect('a scan that finds nothing at all is red, not "0 files clean"', allEmptyErr instanceof EmptyRootError, true);
+    expect('every empty root is named', allEmptyErr?.roots?.join(',') ?? '<none>', ROOTS.join(','));
+    expect('the zero total is reported', allEmptyErr?.total ?? -1, 0);
   } finally {
     process.chdir(cwd);
     rmSync(dir, { recursive: true, force: true });
@@ -334,7 +420,7 @@ function selfTest() {
     console.error(`\n✗ check-doc-authoring self-test failed:\n${failures.join('\n')}\n`);
     process.exit(1);
   }
-  console.log('✓ check-doc-authoring self-test: scope wiring (.claude and the live docs/ corpus in, .claude/worktrees and docs/{audits,handoff,plans} out), detection, and the dead-root hard error (red when a ROOT is renamed, green when restored) all hold.');
+  console.log('✓ check-doc-authoring self-test: scope wiring (.claude and the live docs/ corpus in, .claude/worktrees and docs/{audits,handoff,plans} out), detection, the dead-root hard error (red when a ROOT is renamed, green when restored) and the empty-scan hard error (red when a root yields nothing and when the whole scan does, green when restored) all hold.');
 }
 
 function main() {
@@ -344,18 +430,38 @@ function main() {
   try {
     files = collectFiles();
   } catch (err) {
-    if (!(err instanceof DeadRootError)) throw err;
-    console.error(`\n✗ doc authoring guard: declared ROOT(s) do not resolve, so the scan would have been silently narrower:\n`);
-    for (const d of err.dead) console.error(`  ${d.root} — ${d.reason}`);
-    console.error(
-      `\nEvery entry in ROOTS (scripts/check-doc-authoring.mjs) must be a directory in the checkout,` +
-      `\nand this check runs from the repo root. If a corpus directory was renamed or moved, update` +
-      `\nROOTS to follow it; if it was deleted, remove the entry deliberately. Do NOT restore a` +
-      `\ntolerant skip: this used to be \`catch {}\`, and a dead root simply shrank the reported file` +
-      `\ncount while the gate kept printing green (#4916).\n`,
-    );
-    process.exit(1);
-    return;
+    if (err instanceof DeadRootError) {
+      console.error(`\n✗ doc authoring guard: declared ROOT(s) do not resolve, so the scan would have been silently narrower:\n`);
+      for (const d of err.dead) console.error(`  ${d.root} — ${d.reason}`);
+      console.error(
+        `\nEvery entry in ROOTS (scripts/check-doc-authoring.mjs) must be a directory in the checkout,` +
+        `\nand this check runs from the repo root. If a corpus directory was renamed or moved, update` +
+        `\nROOTS to follow it; if it was deleted, remove the entry deliberately. Do NOT restore a` +
+        `\ntolerant skip: this used to be \`catch {}\`, and a dead root simply shrank the reported file` +
+        `\ncount while the gate kept printing green (#4916).\n`,
+      );
+      process.exit(1);
+      return;
+    }
+    if (err instanceof EmptyRootError) {
+      console.error(
+        `\n✗ doc authoring guard: declared ROOT(s) resolved but contributed no Markdown/MDX file, so` +
+        `\nthis run would have reported a clean corpus it never read:\n`,
+      );
+      for (const r of err.roots) console.error(`  ${r} — 0 files`);
+      console.error(
+        `\n${err.total} file(s) were found in total across all of ROOTS.` +
+        `\n\nEvery entry in ROOTS (scripts/check-doc-authoring.mjs) must yield at least one .md/.mdx` +
+        `\nfile. The root still being a directory is not enough — that is all #4916's check can see.` +
+        `\nIf the corpus moved to a new directory, point ROOTS at it; if a subtree was deliberately` +
+        `\nemptied or removed, remove its ROOT entry in the same change. Do NOT lower this to a total` +
+        `\ncount: one populated root would then cover for every evaporated one, which is the silent` +
+        `\nnarrowing this assertion exists to stop (#4932).\n`,
+      );
+      process.exit(1);
+      return;
+    }
+    throw err;
   }
   const violations = files.flatMap((file) => findViolations(readFileSync(file, 'utf8'), file));
 

--- a/scripts/check-driver-conformance.mjs
+++ b/scripts/check-driver-conformance.mjs
@@ -34,15 +34,31 @@
 //
 // ## Invariants
 //
-//   DISCOVERED  at least one driver package was found. Zero is not an empty
-//               matrix, it is a broken run: the other three invariants iterate
-//               the discovered set, so they all pass vacuously and this script
+//   DISCOVERED  at least one driver package was found, AND every entry under
+//               DRIVERS_DIR was accounted for. Zero is not an empty matrix, it
+//               is a broken run: the other three invariants iterate the
+//               discovered set, so they all pass vacuously and this script
 //               prints OK while checking nothing. The case-set axis cannot fail
 //               this way -- CASE_SETS is a declared expectation, so a vanished
 //               `spec/src/data` fails CLASSIFIED's reverse direction -- but the
 //               driver axis is disk-discovery with nothing declared to
 //               reconcile against, and RECONCILED's reverse direction walks
 //               LEDGER, which is empty in the intended steady state.
+//
+//               The zero floor is only half of that, which is what #4932 adds:
+//               it fires when the WHOLE axis evaporates and is silent when ONE
+//               row does. Rename `driver-sql/` to `sql/` and the package still
+//               builds, still tests, still ships -- only this gate loses it, and
+//               loses it as a matrix with one fewer row and a green verdict. So
+//               the discovery is TOTAL: every entry under DRIVERS_DIR is either a
+//               discovered driver, a non-directory, or a named error
+//               (`discoverDrivers` reports `unnamed` / `manifestless`; nothing is
+//               filtered away in silence). Note which half of that the ledger
+//               covers today and why it cannot be relied on: a vanished driver
+//               that HOLDS a ledger entry does fail RECONCILED, but only while
+//               the ledger is non-empty -- and an empty ledger is the intended
+//               steady state, so that catch is a coincidence of the current
+//               FILTER_TEXT rows, not a mechanism.
 //   CONSUMED    every (driver x case-set) cell is either covered -- some file
 //               under the package's `src/` imports the case-set's marker export
 //               from `@objectstack/spec/data` -- or carries a DEBT/EXEMPT entry
@@ -88,6 +104,12 @@
 // during a walk means the corpus was only partly read, and partial evidence of
 // coverage is exactly the wrong thing to resolve in coverage's favour.
 // Deliberately no whitelist and no optional-root flag — see `assertRootsResolvable`.
+//
+// One swallow outlived that pass: `discoverDrivers`'s manifest probe was
+// `try { ... } catch { return false; }`, so ANY error reading a candidate's
+// package.json — not merely its absence — answered "then it is not a driver" and
+// removed the row. #4932 narrowed it to ENOENT, which is the only errno that
+// actually answers the question the filter asks.
 
 import { mkdirSync, readdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
@@ -419,22 +441,54 @@ function assertRootsResolvable(roots) {
  */
 const listDir = (dir) => readdirSync(dir);
 
-/** Driver packages, from disk — never a hardcoded list. */
-function discoverDrivers() {
-  return listDir(DRIVERS_DIR)
-    .filter((name) => name.startsWith('driver-'))
-    .filter((name) => {
-      try {
-        return statSync(join(DRIVERS_DIR, name, 'package.json')).isFile();
-      } catch {
-        return false;
-      }
-    })
-    .sort();
+/**
+ * Driver packages, from disk — never a hardcoded list.
+ *
+ * Reports the two kinds of entry the filters would otherwise drop in SILENCE
+ * alongside the drivers, because "not discovered" and "not a driver" are
+ * different facts (#4932):
+ *
+ *   unnamed       a real package (it has a package.json) whose directory does not
+ *                 carry the `driver-` prefix. This is the evaporation the zero
+ *                 floor cannot see: rename `driver-sql/` to `sql/` and the row
+ *                 leaves the matrix while pnpm, turbo and its own suite carry on
+ *                 as before, so this gate is the only place it shows up — and it
+ *                 showed up as nothing at all.
+ *   manifestless  a `driver-`-prefixed directory with no package.json. Either the
+ *                 manifest is missing (a broken package, not a covered one) or the
+ *                 directory should not wear the prefix. Both are decisions to
+ *                 make, not states to skip past.
+ *
+ * @param {string} [dir] scan root; parameterised so the self-test drives the real
+ *   function over a synthetic tree instead of a re-implementation of it.
+ */
+function discoverDrivers(dir = DRIVERS_DIR) {
+  const drivers = [];
+  const unnamed = [];
+  const manifestless = [];
+  for (const name of listDir(dir).sort()) {
+    // Not caught: failing to stat an entry `readdirSync` just returned is a read
+    // failure, and a read failure must not be answered "then it is not a driver".
+    if (!statSync(join(dir, name)).isDirectory()) continue;
+    let hasManifest = false;
+    try {
+      hasManifest = statSync(join(dir, name, 'package.json')).isFile();
+    } catch (err) {
+      // ENOENT is this filter's question, answered: there is no manifest here.
+      // Any other errno means the entry could not be READ, which is the swallow
+      // #4930 removed from `listDir` and #4932 removes from here — a measurement
+      // failure resolved in coverage's favour.
+      if (err?.code !== 'ENOENT') throw err;
+    }
+    if (name.startsWith('driver-')) (hasManifest ? drivers : manifestless).push(name);
+    else if (hasManifest) unnamed.push(name);
+  }
+  return { drivers, unnamed, manifestless };
 }
 
 /**
- * DISCOVERED — the errors for a discovery that found nothing.
+ * DISCOVERED — the errors for a discovery that found nothing, or that found
+ * something it would have dropped without saying so.
  *
  * Split out from `audit()` so the self-test can drive the invariant itself
  * rather than a proxy for it. The previous guard lived only in the self-test
@@ -443,15 +497,46 @@ function discoverDrivers() {
  * drivers come from disk and are never listed. Both would have needed editing
  * the next time a driver is added or the packages move, which is exactly when
  * the guard matters.
+ *
+ * The zero floor (#4363) is only half of non-vacuity, which is what #4932 is
+ * about: it fires when the whole axis evaporates and is silent when ONE row
+ * does. A single missing row is caught today only when that driver happens to
+ * hold a ledger entry (RECONCILED's reverse direction) — and the ledger is empty
+ * in the intended steady state, as it was between #5590 and #5701. So the
+ * discovery is TOTAL instead: every entry under DRIVERS_DIR is a discovered
+ * driver, a non-directory, or a named error here.
+ *
+ * @param {{drivers: string[], unnamed?: string[], manifestless?: string[]}} discovery
  */
-function discoveredErrors(drivers) {
-  if (drivers.length) return [];
-  return [
-    `DISCOVERED: no driver package found under ${DRIVERS_DIR.slice(ROOT.length + 1)}/. `
-      + 'Either these packages moved and DRIVERS_DIR is stale, or they are gone. '
-      + 'Every other invariant iterates the discovered set, so a zero-driver run '
-      + 'reports OK having checked nothing — it fails here instead.',
-  ];
+function discoveredErrors({ drivers, unnamed = [], manifestless = [] }) {
+  const errors = [];
+  const rel = DRIVERS_DIR.slice(ROOT.length + 1);
+  if (!drivers.length) {
+    errors.push(
+      `DISCOVERED: no driver package found under ${rel}/. `
+        + 'Either these packages moved and DRIVERS_DIR is stale, or they are gone. '
+        + 'Every other invariant iterates the discovered set, so a zero-driver run '
+        + 'reports OK having checked nothing — it fails here instead.',
+    );
+  }
+  for (const name of unnamed) {
+    errors.push(
+      `DISCOVERED: ${rel}/${name} is a package (it has a package.json) but is not named `
+        + '`driver-*`, so discovery drops it and the matrix is one row short without saying so. '
+        + 'Name it `driver-<backend>` if it implements IDataDriver, or move it out of this directory '
+        + 'if it does not. Nothing else reports this: the driver axis is discovered from disk, and a '
+        + 'renamed package keeps building and testing exactly as before (#4932).',
+    );
+  }
+  for (const name of manifestless) {
+    errors.push(
+      `DISCOVERED: ${rel}/${name} is named like a driver package but has no package.json, so `
+        + 'discovery drops it. Either the manifest is missing — a broken package, which is not the '
+        + 'same as a covered one — or the directory should not carry the `driver-` prefix. Both are '
+        + 'decisions to record rather than states to skip past (#4932).',
+    );
+  }
+  return errors;
 }
 
 /** Every `*-conformance.ts` under spec/src/data, and the case-set exports in it. */
@@ -523,12 +608,14 @@ function audit() {
   // that names the directory rather than the five downstream symptoms (#4930).
   assertRootsResolvable([DRIVERS_DIR, CASE_SETS_DIR]);
 
-  const drivers = discoverDrivers();
+  const discovery = discoverDrivers();
+  const { drivers } = discovery;
   const errors = [];
   const rows = [];
 
-  // DISCOVERED — the precondition the other three iterate over.
-  errors.push(...discoveredErrors(drivers));
+  // DISCOVERED — the precondition the other three iterate over. Zero drivers is a
+  // broken run, and so is one driver silently missing from the axis (#4932).
+  errors.push(...discoveredErrors(discovery));
 
   // CLASSIFIED — both directions between CASE_SETS and the files on disk.
   const onDisk = discoverCaseSets();
@@ -708,9 +795,63 @@ function selfTest() {
   // DISCOVERED: the invariant itself, in both directions, then against the
   // real tree. No driver name or count is asserted — the point of the gate is
   // that the set comes from disk.
-  expect('a discovery that found nothing is an error', discoveredErrors([]).length === 1);
-  expect('a discovery that found something is not', discoveredErrors(['driver-anything']).length === 0);
-  expect('discovers driver packages from disk', discoverDrivers().length > 0);
+  expect('a discovery that found nothing is an error', discoveredErrors({ drivers: [] }).length === 1);
+  expect('a discovery that found something is not', discoveredErrors({ drivers: ['driver-anything'] }).length === 0);
+  expect('discovers driver packages from disk', discoverDrivers().drivers.length > 0);
+
+  // ...and the half the zero floor cannot see (#4932): a row dropped in silence
+  // while the axis stays non-empty. Both drop shapes are errors even though a
+  // driver WAS found, because "one fewer row, still green" is the failure.
+  expect(
+    'a package the `driver-` filter would drop is an error, not a smaller matrix',
+    discoveredErrors({ drivers: ['driver-a'], unnamed: ['sql'] }).length === 1,
+  );
+  expect(
+    'the error names the dropped package',
+    /packages\/drivers\/sql is a package/.test(discoveredErrors({ drivers: ['driver-a'], unnamed: ['sql'] })[0]),
+  );
+  expect(
+    'a driver-named directory with no manifest is an error too',
+    discoveredErrors({ drivers: ['driver-a'], manifestless: ['driver-b'] }).length === 1,
+  );
+
+  // The classification itself, driven over a synthetic tree by the real function
+  // (the alternative — asserting against the live packages/drivers — can only
+  // ever observe the clean case, which is the case that never fails).
+  const tmpDrivers = join(ROOT, 'node_modules', '.check-driver-conformance-selftest-discovery');
+  try {
+    mkdirSync(join(tmpDrivers, 'driver-a'), { recursive: true });
+    writeFileSync(join(tmpDrivers, 'driver-a', 'package.json'), '{}\n');
+    mkdirSync(join(tmpDrivers, 'sql'), { recursive: true });          // a package, misnamed
+    writeFileSync(join(tmpDrivers, 'sql', 'package.json'), '{}\n');
+    mkdirSync(join(tmpDrivers, 'driver-b'), { recursive: true });     // named, no manifest
+    writeFileSync(join(tmpDrivers, 'README.md'), 'not a package\n');  // not a directory
+    const found = discoverDrivers(tmpDrivers);
+    expect('a manifested driver- package is discovered', found.drivers.join(',') === 'driver-a');
+    expect('a manifested package with the wrong name is reported', found.unnamed.join(',') === 'sql');
+    expect('a driver- directory without a manifest is reported', found.manifestless.join(',') === 'driver-b');
+
+    // An entry the discovery cannot stat is a read failure, not an answer — the
+    // same direction as the walkTs case below, at the axis level.
+    symlinkSync(join(tmpDrivers, 'no-such-target'), join(tmpDrivers, 'driver-dangling'));
+    let danglingErr = null;
+    try { discoverDrivers(tmpDrivers); } catch (err) { danglingErr = err; }
+    expect('an entry discovery cannot stat is an error, not a smaller axis', danglingErr?.code === 'ENOENT');
+    rmSync(join(tmpDrivers, 'driver-dangling'));
+
+    // ...and removing the break restores the previous verdict, so the red above
+    // was caused by the dangling entry and nothing else.
+    expect('removing the break restores the discovery', discoverDrivers(tmpDrivers).drivers.join(',') === 'driver-a');
+  } finally {
+    rmSync(tmpDrivers, { recursive: true, force: true });
+  }
+
+  // The real tree is clean on both drop shapes — the assertion is wired in, not
+  // merely defined, and today's packages/drivers has nothing being skipped.
+  const real = discoverDrivers();
+  expect('no live driver package is dropped by the name filter', real.unnamed.length === 0);
+  expect('no live driver directory is missing its manifest', real.manifestless.length === 0);
+  expect('the live discovery raises no DISCOVERED error', discoveredErrors(real).length === 0);
 
   // --- Reverse proof for the dead-root hard error (#4930), made permanent. ---
   // Everything above ran over roots that resolve, which proves nothing about a
@@ -771,8 +912,9 @@ function selfTest() {
     process.exit(1);
   }
   console.log(
-    'OK  self-test: detects driven / unused / re-declared fixtures, discovers both axes, and holds the '
-      + 'dead-root hard error (red when a scan root is renamed, green when restored).',
+    'OK  self-test: detects driven / unused / re-declared fixtures, discovers both axes, accounts for '
+      + 'every entry under DRIVERS_DIR (a dropped or manifestless row is red, not a smaller matrix), and '
+      + 'holds the dead-root hard error (red when a scan root is renamed, green when restored).',
   );
 }
 


### PR DESCRIPTION
Closes #4932

两个闸门都靠「扫描发现目标 → 逐个检查」工作,而空集合天然通过所有检查。本单补的是这一族里**下限断言**那一半。

## 先说前提核对:issue 的两条子断言在 origin/main 上都已不成立

按 origin/main(73571306b)逐条实测,#4932 正文点名的两处 `catch {}` 都已经不在了:

| issue 的子断言 | 实测 |
|:---|:---|
| `check-doc-authoring.mjs:45` 的 `for (const r of ROOTS) { try { walk(r, files); } catch {} }` 吞掉 ROOT 缺失 | **已修**(#4916)。现在是 `assertRootsResolvable()` 先解析全部 ROOT,死根按名报红;`collectFiles` 里没有任何 catch |
| `check-driver-conformance.mjs:150` 的 `listDir` 兜底空数组 → 发现 0 个 driver → 无事可做 → 通过 | **已修**(#4930 + #4363)。`listDir` 现在是裸 `readdirSync`;而且 DISCOVERED 不变量本来就在(`discoveredErrors`),零 driver 直接报红,模块头也已经把「账本可空 ≠ 发现结果可空」这条区分写清楚了 |

所以本 PR 不是照抄 issue 的修法,而是修**它们剩下的那一半**——发现环节成功、发现结果为空/偏少,仍然报绿:

- `check-doc-authoring`:全部四个 ROOT 都解析成功、一个文件都没扫到时,旧代码打印 `✓ 0 files clean` 并 exit 0。这正是 issue 正文写的「极端情况」,而 #4916 的断言看不见它。
- `check-driver-conformance`:DISCOVERED 只在**整根**蒸发时开火,**单行**蒸发时沉默。

## check-doc-authoring:每个 ROOT 至少产出一个 .md/.mdx

`assertRootsResolvable` 只看得见「根不是目录」。根还在、语料搬走了(子树迁出、`SKIP_PATHS` 收得更宽、扩展名换了)时它是满意的:walk 少收一批,打印的计数静默变小,而 `✓ 362 files clean` 与 `✓ 0 files clean` 对读者是同一句话、对 CI 是同一个退出码 —— 这就是 #4932 说的「计数被打印,但从未被断言」。

下限**按根**算而不是按总数:总数会被还有文件的那个根托住(`.claude` 一个就够),而「语料只被读了一部分」恰恰是这道闸不该往语料有利方向解释的判定。断言落在 `collectFiles` 里(不是 `main`),self-test 因此驱动不变量本身而不是它的代理。

**没有加棘轮**:阈值只有「每个声明的根 ≥ 1 个文件」,由本次 walk 现算。高水位棘轮需要有人维护,还会把每次正当删除变成一场跟数字的争论 —— 派发词倾向不加,这里也确实找不到可测不可拍脑袋的阈值来源。

## check-driver-conformance:发现改为「完备」,而不只是「非零」

把 `packages/drivers/driver-sql` 改名成 `sql`,包照样构建、照样测试、照样发布 —— 只有这道闸丢了它,而且丢成「少一行的矩阵 + 绿」。所以发现现在是完备的:DRIVERS_DIR 下每个条目要么是发现到的 driver,要么不是目录,要么在这里按名报红(`unnamed` / `manifestless`),没有任何东西被静默过滤掉。

一个必须说清的细节:今天这类改名**恰好**会被 RECONCILED 抓到(台账里有 driver-sql 的条目),但那只在台账非空时成立,而**空台账是本闸的预期稳态**(#5590 到 #5701 之间就是空的)。模块头自己就写着 RECONCILED 的反向只走 LEDGER —— 所以那是当前 FILTER_TEXT 五行带来的巧合,不是机制。

顺带收掉 #4930 漏下的一处 swallow:manifest 探测的 `catch { return false; }` 会把**任何**读取失败答成「那就不是 driver」。现在只有 ENOENT(即这个过滤器真正要问的问题)才这样解释,其他 errno 直接抛。

## 反向验证:方向先定后跑,四组,含一组颜色不翻的

| 场景 | 预测 | 实测(旧 = origin/main 的脚本副本,同一份夹具) |
|:---|:---|:---|
| 四个 ROOT 都在、语料全空 | 旧绿 → 新红 | 旧 `✓ 0 files clean` **exit 0** → 新 **exit 1** |
| 单根蒸发(content 只剩非 markdown) | 旧绿 → 新红 | 旧 `✓ 3 files clean` **exit 0** → 新 **exit 1**,只点名 `content` 并报出总数 3 |
| ROOT 被改名(#4916 原案) | 旧红、新红 | 两边都 exit 1,同一句 dead-root 文案 —— 这一半没被削弱 |
| DRIVERS_DIR 整体移走(#4930 原案) | 旧红、新红 | 两边都 exit 1 |
| `driver-sql` 改名为 `sql` | **颜色不翻**,诊断改变 | 旧只报 `RECONCILED: ledger entry for driver-sql, which is not a driver package.`(怪台账,点错原因);新多报一条 `DISCOVERED: packages/drivers/sql is a package … but is not named driver-*`。两边都是 2/1 problem(s),都红 |

最后一行是本单唯一「预测就不是 before-green/after-red」的地方,如实记账:今天的台账非空,所以颜色本来就红,新断言改的是**把原因点对**。颜色真正会翻的是空台账稳态 —— 在同一份合成树上跑 origin/main 的发现实现,得到 `discovered=[driver-a]`、`DISCOVERED errors=0`(**绿**),而 `sql` 是个带 package.json 的真包却根本不在矩阵里;这一条已在 self-test 里按 `discoveredErrors` 的判定钉死,不依赖台账当时是什么状态。

## self-test 与门禁实测

两个脚本仓内都已自带 `--self-test`(`package.json` 的 `check:*` 也早已是 `--self-test && ` 的形式),所以是**补用例**,不是新建 self-test。

`check-doc-authoring` 新增:单根为空 → 红且只点名该根、并报出这次真扫到的总数 → 恢复后绿;全空 → 红、点名四个根、总数 0。
`check-driver-conformance` 新增:两种丢行形状各自报红且点名(即使 driver 已发现非零)、合成树上的三分类(discovered / unnamed / manifestless)、一个 stat 不到的条目是报错而不是更小的轴(dangling symlink,ENOENT)、去掉破坏后判定复原,以及活树上两种丢行数都为 0。

实跑(worktree,origin/main 之上):

```
check:doc-authoring        exit=0   ✓ 362 files clean
check:driver-conformance   exit=0   5 drivers x 6 case-sets,25 covered / 5 DEBT / 0 exempt
check:role-word            exit=0   check:org-identifier   exit=0
check:adr-anchors          exit=0   check:docs-audit-scope exit=0
check:nul-bytes            exit=0   (5704 tracked text file(s))
eslint(两个改动文件)      exit=0
```

`node scripts/check-nul-bytes.mjs` 之外另做了越界自扫(`grep -naP` 覆盖 `0x01`–`0x1f`/`0x7f`),无命中。

## 发布物

tooling-only,`scripts/**` 两个文件,不发布任何包 ⇒ 无 changeset,PR 带 `skip-changeset` 标签(标签由本座位落,回读结果写在报告里)。CI 挂载点未动(`.github/workflows/lint.yml` 的两处 `run:` 原样)。

## 范围与另行立单

- 文件面严格为 `scripts/check-doc-authoring.mjs` + `scripts/check-driver-conformance.mjs`。未动 workflows、未动 `content/docs/releases/**`;#4928(Actions 层同族)不在本单。
- 座位互检:动手前把当时全部 11 个 open PR 的文件清单过了一遍(含 #5827 这个同样改 `scripts/` 的),**没有**任何 open PR 在改这两个文件。
- 顺带核到同族第三处:`scripts/check-single-authz-resolver.mjs` 已补 #4916 那一半,但 `collectScanFiles()` 的返回长度从不断言 —— 根解析成功、一个文件都没扫到仍然绿,而它自己的模块头就写着「nobody reads a count that is not printed」。不在本单文件面内,按 Prime Directive #10 立为 observation-class:#5916(`finding` 标签,未入队、未指派)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE)_