### PR TITLE
docs(skills): 九份已发布 skill 的 compatibility 声明由 16.x 更正为 17.x (#5245)

### DIFF
--- a/skills/objectstack-ai/SKILL.md
+++ b/skills/objectstack-ai/SKILL.md
@@ -9,10 +9,10 @@ description: >
   them via skills and tools, not by authoring `*.agent.ts`. Do not use for
   general LLM prompting questions unrelated to ObjectStack metadata.
 license: Apache-2.0
-compatibility: Requires @objectstack/spec 16.x (Zod v4 schemas)
+compatibility: Requires @objectstack/spec 17.x (Zod v4 schemas)
 metadata:
   author: objectstack-ai
-  version: "1.2"
+  version: "1.3"
   domain: ai
   tags: agent, tool, skill, conversation, llm, embedding, mcp
 ---

--- a/skills/objectstack-api/SKILL.md
+++ b/skills/objectstack-api/SKILL.md
@@ -11,10 +11,10 @@ description: >
   syntax (see objectstack-query). CEL expressions in route guards or auth
   predicates: load objectstack-formula alongside.
 license: Apache-2.0
-compatibility: Requires @objectstack/spec 16.x (Zod v4 schemas)
+compatibility: Requires @objectstack/spec 17.x (Zod v4 schemas)
 metadata:
   author: objectstack-ai
-  version: "1.3"
+  version: "1.4"
   domain: api
   tags: rest, graphql, endpoint, auth, realtime, server
 ---

--- a/skills/objectstack-automation/SKILL.md
+++ b/skills/objectstack-automation/SKILL.md
@@ -9,10 +9,10 @@ description: >
   / plugin events (see objectstack-platform). CEL expressions in flow
   conditions / edge guards: load objectstack-formula alongside.
 license: Apache-2.0
-compatibility: Requires @objectstack/spec 16.x (Zod v4 schemas)
+compatibility: Requires @objectstack/spec 17.x (Zod v4 schemas)
 metadata:
   author: objectstack-ai
-  version: "1.2"
+  version: "1.3"
   domain: automation
   tags: flow, workflow, trigger, approval, state-machine, scheduled, webhook
 ---

--- a/skills/objectstack-data/SKILL.md
+++ b/skills/objectstack-data/SKILL.md
@@ -15,10 +15,10 @@ description: >
   formulas / validations / sharing rules / dynamic seed values: load
   objectstack-formula alongside.
 license: Apache-2.0
-compatibility: Requires @objectstack/spec 16.x (Zod v4 schemas)
+compatibility: Requires @objectstack/spec 17.x (Zod v4 schemas)
 metadata:
   author: objectstack-ai
-  version: "4.3"
+  version: "4.4"
   domain: data
   tags: object, field, validation, index, relationship, hook, schema, permission, rls, security, seed, fixture
 ---

--- a/skills/objectstack-formula/SKILL.md
+++ b/skills/objectstack-formula/SKILL.md
@@ -9,10 +9,10 @@ description: >
   predicate". Do not use for SQL fragments (driver-native), cron schedules
   (cron dialect), or L2 hook bodies (those belong in objectstack-data).
 license: Apache-2.0
-compatibility: Requires @objectstack/spec 16.x and @objectstack/formula 16.x (CEL)
+compatibility: Requires @objectstack/spec 17.x and @objectstack/formula 17.x (CEL)
 metadata:
   author: objectstack-ai
-  version: "1.1"
+  version: "1.2"
   domain: expression
   tags: cel, formula, predicate, condition, validation, visibility, seed-dynamic
 ---

--- a/skills/objectstack-i18n/SKILL.md
+++ b/skills/objectstack-i18n/SKILL.md
@@ -8,10 +8,10 @@ description: >
   resolving missing-translation warnings. Do not use for general i18n
   library questions unrelated to ObjectStack bundles.
 license: Apache-2.0
-compatibility: Requires @objectstack/spec 16.x (Zod v4 schemas)
+compatibility: Requires @objectstack/spec 17.x (Zod v4 schemas)
 metadata:
   author: objectstack-ai
-  version: "1.2"
+  version: "1.3"
   domain: i18n
   tags: i18n, translation, locale, l10n, bundle, coverage
 ---

--- a/skills/objectstack-platform/SKILL.md
+++ b/skills/objectstack-platform/SKILL.md
@@ -12,10 +12,10 @@ description: >
   objectstack-query); data lifecycle hooks (beforeInsert / afterUpdate)
   belong in objectstack-data — only kernel / service-level events live here.
 license: Apache-2.0
-compatibility: Requires @objectstack/spec 16.x and @objectstack/core 16.x (Zod v4 schemas), Node 22+
+compatibility: Requires @objectstack/spec 17.x and @objectstack/core 17.x (Zod v4 schemas), Node 22+
 metadata:
   author: objectstack-ai
-  version: "1.2"
+  version: "1.3"
   domain: platform
   tags: project, defineStack, driver, adapter, plugin, kernel, service, DI, lifecycle, cli, deploy, ops
 ---

--- a/skills/objectstack-query/SKILL.md
+++ b/skills/objectstack-query/SKILL.md
@@ -8,10 +8,10 @@ description: >
   relationships (see objectstack-data) or for designing the API endpoint
   that exposes a query (see objectstack-api).
 license: Apache-2.0
-compatibility: Requires @objectstack/spec 16.x (Zod v4 schemas)
+compatibility: Requires @objectstack/spec 17.x (Zod v4 schemas)
 metadata:
   author: objectstack-ai
-  version: "1.2"
+  version: "1.3"
   domain: query
   tags: query, filter, sort, paginate, aggregate, ObjectQL, full-text
 ---

--- a/skills/objectstack-ui/SKILL.md
+++ b/skills/objectstack-ui/SKILL.md
@@ -16,10 +16,10 @@ description: >
   ships with the platform). CEL expressions in
   visibility/conditional rules: load objectstack-formula alongside.
 license: Apache-2.0
-compatibility: Requires @objectstack/spec 16.x (Zod v4 schemas)
+compatibility: Requires @objectstack/spec 17.x (Zod v4 schemas)
 metadata:
   author: objectstack-ai
-  version: "1.2"
+  version: "1.3"
   domain: ui
   tags: view, app, page, dashboard, report, chart, action, widget, doc
 ---


### PR DESCRIPTION
Closes #5245

`skills/` 下的 SKILL.md 随 `npx skills add objectstack-ai/objectstack/skills` 原样发给第三方。九份的 frontmatter `compatibility` 仍声明 “Requires @objectstack/spec 16.x”,而正文教的已是 17 的能力 —— 消费者读到的适用版本与实际教的内容差一个 major。按 2026-08-04 分诊裁定的方案①,逐份改写为 17.x 精确行。

## 真值核实(全部实测,非推断)

| 事实 | 实测来源 | 结果 |
| --- | --- | --- |
| spec major | `packages/spec/package.json` | `17.0.0-rc.2` → major 17 |
| formula major | `packages/formula/package.json` | `17.0.0-rc.2` |
| core major | `packages/core/package.json` | `17.0.0-rc.2` |
| “Zod v4” 是否仍准确 | spec 的 `dependencies.zod` | `^4.4.3` → 保留 |
| “Node 22+” 是否仍准确 | 根 `engines.node` | `>=22.0.0` → 保留 |

## 逐份处置

- **七份统一句式** 改 `@objectstack/spec 17.x (Zod v4 schemas)`:ai / api / automation / data / i18n / query / ui。
- **两份变体**,伴随包版本一并改 17.x:
  - `objectstack-formula`:`Requires @objectstack/spec 17.x and @objectstack/formula 17.x (CEL)`
  - `objectstack-platform`:`Requires @objectstack/spec 17.x and @objectstack/core 17.x (Zod v4 schemas), Node 22+`(Node 约束按原样保留)
- **`objectstack-pm-dispatch` 不动**:实测其 `compatibility` 是折叠块,写明 “No @objectstack/spec dependency — process skill”,本无 16.x 声明,不适用本单格式。

均保持既有单行格式。

## 与 issue 记述的差异

issue 说“十份、九份同句”。实测:`skills/` 下确有 10 份 SKILL.md,但携带 `Requires @objectstack/spec 16.x` 的是 **9** 份,其中**同句的只有 7 份**,formula 与 platform 是两份变体。故本单改 9 份、其中 7 份走同一句式。

正文另有两处 `16.x` 按原样保留 —— objectstack-ai:243 “permissions 键在 16.x 移除”、objectstack-api:582 “in 16.x, #2377”,都是历史事实陈述而非适用版本声明,且改正文超出本单范围。

## `metadata.version` 逐份 +0.1

按 git log 实测先例办,并修正了派单里引用的 #5670 测法:

- `objectstack-data` 的三个提交里,`b49ccfdfe` 是该文件的**创建**(`@@ -0,0 +1,1034 @@`,建档即 4.3),不是内容修改;另两个(`72c3c8613`、`28ad90e9a`)确实未 bump,但都是大型代码 PR 顺带改 SKILL.md,不构成“仅改 skill”的先例。
- 唯一的“仅改已发布 skill 内容”先例是 **#5451 / PR #5799(`77adf297f`)**,它 bump 了 `metadata.version` 1.0 → 1.1。本单同类,故逐份 +0.1。

## changeset 路线

不写 changeset,走 `skip-changeset` 标签(gate 的 **路线 2 / PREFERRED**)。依据:`skills/` 不是 workspace 成员,也不随任何 npm 包发布(根包 `private: true`,无 package 的 `files` 收录它),故本 PR 不发布任何包。

一处值得记录的张力:上述先例 `77adf297f`(2026-08-06 06:57)走的是**路线 3 空 frontmatter changeset**,而 #5292 / PR #5467(2026-08-05 13:18)已把路线 3 降级为 LAST RESORT(#4898:全空集合会静默绿灯地卡住 release)。即该先例晚于处方一天却仍用了被降级的路线。本单按**现行处方**取路线 2。

## 门禁(全绿,实跑输出见下)

`check:skill-docs` / `check:skill-refs` / `check:skill-examples` / `check:nul-bytes` / `check:doc-authoring` / `check:skill-frame-sync` 六项全绿。`compatibility` 与 `metadata.version` 经实测**不进任何生成物** —— 改完 `check:skill-docs` 直接报 “Skill docs in sync”,无需重新生成。

Co-authored-by: Claude &lt;noreply@anthropic.com&gt;

---
_Generated by [Claude Code](https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE)_