### PR TITLE
docs(kernel): runtime-services 的 hook 示例改教真实通道 —— 去掉不存在的 `ctx.services` (#5720)

### DIFF
--- a/content/docs/kernel/runtime-services/examples.mdx
+++ b/content/docs/kernel/runtime-services/examples.mdx
@@ -5,42 +5,153 @@ description: Practical examples for flow nodes, hooks, and plugin event subscrip
 
 # Runtime Service Examples
 
-## 1) Flow custom node: read related records
+<Callout type="warn" title="Which data channel each surface actually gets">
+
+These pages document the `services.*` **contract surface** — the signatures, not a
+binding every surface receives (see the [binding note](/docs/kernel/runtime-services)).
+The examples below therefore use the channel each runtime surface is really handed:
+
+| Surface | Data channel |
+|:--|:--|
+| Data hook (`beforeInsert`, `beforeUpdate`, …) | `ctx.api` — the scoped cross-object API the engine binds per operation (`buildHookApi`, `packages/objectql/src/engine.ts`) |
+| Flow `script` function | none — a function is **pure** by contract (`handlerContract: 'pure'`), so its record I/O lives on the flow graph |
+| Plugin | the plugin context (`ctx.hook`, the kernel service registry) |
+
+A hook context is built key by key by the engine and carries **no `services` key**, so
+`ctx.services?.sharing?.canEdit(…)` there evaluates to `undefined` — and a guard written on
+it (`if (!ok) throw new Error('PERMISSION_DENIED')`) rejects **every** write instead of
+checking anything ([#5720](https://github.com/objectstack-ai/objectstack/issues/5720)).
+
+</Callout>
+
+## 1) Flow: read related records, then compute in a pure function
+
+The read is a declarative `get_record` node that binds its rows to a flow variable; the
+`script` node maps that variable into a registered function's `inputs`, and the function
+**returns** its result for a later declarative node to persist. A flow function is handed
+`input` / `variables` / `automation` / `logger` and **no data engine** — see
+[Flows](/docs/automation/flows) for why that purity rule keeps a run's record counts honest.
 
 {/* os:check */}
 ```ts
-export async function run(ctx: any) {
-  const { record: order } = await ctx.services.data.get('sales_order', ctx.input.orderId);
-  const lines = await ctx.services.data.find('sales_order_line', {
-    where: { sales_order_id: order.id },
-    orderBy: [{ field: 'line_no', order: 'asc' }],
-    limit: 200,
-  });
+import { defineFlow, defineStack } from '@objectstack/spec';
 
+interface OrderTotalsInput {
+  lines: Array<{ amount?: number }>;
+}
+
+/** Pure: it computes from its mapped `inputs` and returns — no data handle needed. */
+function orderTotals(ctx: { input: OrderTotalsInput }) {
+  const lines = ctx.input.lines ?? [];
   return {
-    order,
-    lines: lines.records ?? [],
+    line_count: lines.length,
+    total: lines.reduce((sum, line) => sum + (line.amount ?? 0), 0),
   };
 }
+
+export const stack = defineStack({
+  functions: { 'sales.orderTotals': orderTotals },
+});
+
+export const RollUpOrderTotals = defineFlow({
+  name: 'sales_order_roll_up_totals',
+  label: 'Roll up order line totals',
+  type: 'autolaunched',
+  status: 'active',
+  nodes: [
+    {
+      id: 'start',
+      type: 'start',
+      label: 'On Order Update',
+      config: { objectName: 'sales_order', triggerType: 'record-after-update' },
+    },
+    {
+      id: 'read_lines',
+      type: 'get_record',
+      label: 'Read the order lines',
+      config: {
+        objectName: 'sales_order_line',
+        filter: { sales_order_id: '{record.id}' },
+        fields: ['amount'],
+        limit: 200,
+        outputVariable: 'lines',
+      },
+    },
+    {
+      id: 'totals',
+      type: 'script',
+      label: 'Sum the lines',
+      config: {
+        function: 'sales.orderTotals',
+        inputs: { lines: '{lines}' },
+        outputVariable: 'totals',
+      },
+    },
+    {
+      id: 'apply',
+      type: 'update_record',
+      label: 'Write the totals back',
+      config: {
+        objectName: 'sales_order',
+        filter: { id: '{record.id}' },
+        fields: { line_count: '{totals.line_count}', amount_total: '{totals.total}' },
+      },
+    },
+    { id: 'end', type: 'end', label: 'End' },
+  ],
+  edges: [
+    { id: 'e1', source: 'start', target: 'read_lines' },
+    { id: 'e2', source: 'read_lines', target: 'totals' },
+    { id: 'e3', source: 'totals', target: 'apply' },
+    { id: 'e4', source: 'apply', target: 'end' },
+  ],
+});
 ```
 
-## 2) Hook: check sharing permission before mutation
+## 2) Hook: validate a write against another object
+
+A `before*` hook reaches other objects through `ctx.api`, bound to the caller's execution
+context and transaction, and rejects the write by throwing.
+
+Record-level **sharing is not a hook's job**: when `@objectstack/plugin-sharing` is
+installed its engine middleware gates every by-id write itself — `canEdit` before an
+update, `canDelete` before a delete — and throws `FORBIDDEN` on denial, before any hook
+could re-ask ([`services.sharing`](/docs/kernel/runtime-services/sharing-service)). What a
+hook adds is the **business** rule the engine cannot know.
 
 {/* os:check */}
 ```ts
-export async function beforeUpdate(ctx: any) {
-  const ok = await ctx.services?.sharing?.canEdit('contract', ctx.input.id, {
-    userId: ctx.session?.userId,
-    // Read the caller's org under `organizationId` (the `session.tenantId` alias
-    // was removed in v11, #3290); it feeds the sharing context's `tenantId`.
-    tenantId: ctx.session?.organizationId,
-    positions: ctx.session?.positions,
-  });
+import { defineHook, type HookContext } from '@objectstack/spec/data';
 
-  if (!ok) {
-    throw new Error('PERMISSION_DENIED');
-  }
-}
+/**
+ * The one call this hook makes on `ctx.api`. The contract declares
+ * `HookContext.api` opaque (`api: unknown`) because the object the engine binds is
+ * ObjectQL's `ScopedContext`, so a typed handler names the slice it uses.
+ */
+type CrossObjectApi = {
+  object(name: string): {
+    findOne(query: { where: Record<string, unknown> }): Promise<{ credit_limit?: number } | null>;
+  };
+};
+
+export const ContractWithinCreditLimit = defineHook({
+  name: 'contract_within_credit_limit',
+  object: 'contract',
+  events: ['beforeInsert', 'beforeUpdate'],
+  handler: async (ctx: HookContext) => {
+    const accountId = ctx.input.account_id;
+    if (typeof accountId !== 'string') return;
+
+    const api = ctx.api as CrossObjectApi;
+    const account = await api.object('crm_account').findOne({ where: { id: accountId } });
+
+    const limit = account?.credit_limit ?? 0;
+    const amount = Number(ctx.input.amount ?? 0);
+    if (limit > 0 && amount > limit) {
+      throw new Error('VALIDATION_FAILED: contract amount exceeds the account credit limit');
+    }
+  },
+});
 ```
 
 ## 3) Plugin: subscribe to kernel lifecycle events

--- a/content/docs/kernel/runtime-services/sharing-service.mdx
+++ b/content/docs/kernel/runtime-services/sharing-service.mdx
@@ -56,15 +56,44 @@ mask AND-ed with object CRUD, not a fourth `access_level`.
 - `CONFLICT` (409) — `revoke` on a rule-materialised share (`source != 'manual'`); the next rule reconciliation would silently re-grant it. Deactivate or edit the sharing rule instead.
 - `SHARING_NOT_ENABLED` (422) — `grant` on an object the sharing gates never consult (public sharing model, no `owner_id` field, a bypass object, or `controlled_by_parent`).
 
+## Enforcement is automatic — do not re-check it in a hook
+
+With `@objectstack/plugin-sharing` installed, the gates run **inside the engine**: its
+middleware picks the gate by verb — `canEdit` before a by-id update, `canDelete` before a
+delete — and throws `FORBIDDEN` before the hook chain could ask anything. A hook that
+re-checks adds nothing, and it cannot ask this service at all: a hook context is built key
+by key by the engine (`object` / `event` / `input` / `session` / `provenance` / `user` /
+`api` / `transaction` / `ql`) and carries **no `services` key**, so
+`ctx.services?.sharing?.canEdit(…)` is `undefined` there and `if (!ok) throw …` rejects
+every write ([#5720](https://github.com/objectstack-ai/objectstack/issues/5720)). A hook's
+own channel is `ctx.api` — use it for *business* rules
+([examples](/docs/kernel/runtime-services/examples)).
+
 ## Example
 
+Call `canEdit` only from code that **holds** the service — a plugin that resolved it from
+the kernel service registry, or a managed runtime's `services.sharing` binding — for
+example to pre-flight an affordance before offering it:
+
+{/* os:check */}
 ```ts
-const allowed = await services.sharing.canEdit('contract', ctx.input.id, {
-  userId: ctx.session?.userId,
-  // The hook exposes the caller's org as `organizationId` (the `session.tenantId`
-  // alias was removed in v11, #3290); it feeds the sharing context's `tenantId`.
-  tenantId: ctx.session?.organizationId,
-  positions: ctx.session?.positions,
-});
-if (!allowed) throw new Error('PERMISSION_DENIED');
+import type { ISharingService } from '@objectstack/spec/contracts';
+
+export async function mayEditContract(
+  sharing: ISharingService,
+  recordId: string,
+  session: { userId?: string; organizationId?: string; positions?: string[] },
+): Promise<boolean> {
+  return sharing.canEdit('contract', recordId, {
+    userId: session.userId,
+    // `SharingExecutionContext` names the org `tenantId`; a session exposes the
+    // same value as `organizationId` (the `session.tenantId` alias was removed in
+    // v11, #3290).
+    tenantId: session.organizationId,
+    positions: session.positions,
+  });
+}
 ```
+
+`canEdit` returns `false` rather than throwing, so a caller decides what a denial means —
+hiding a button, or raising its own error.


### PR DESCRIPTION
Closes #5720

按维护者 2026-08-06 批复裁「改教 `ctx.api`」执行:**docs-only**,⛔ 不新增「hook ctx 注入 services」公共契约 —— `packages/spec/**`、`packages/objectql/**` 零改动。

## 为什么是缺陷

hook 上下文由引擎逐键构造(`object` / `event` / `input` / `session` / `provenance` / `user` / `api` / `transaction` / `ql`,`engine.ts` 五处构造点同构),沙箱 `buildHookSandboxContext` 同样不产 —— **从来没有 `services` 键**。照抄旧示例写 `beforeUpdate` 授权检查,`ctx.services?.sharing?.canEdit(…)` 因可选链短路成 `undefined`,`if (!ok) throw new Error('PERMISSION_DENIED')` 于是**无条件抛出**:该对象上所有更新一律 403,而失败方向伪装成"正常拒绝",极难归因到文档。

`services.*` 本身不是幻觉,是这几页记录的**契约签名面**(索引页 binding note 已写明:开放框架不往 hook ctx 注入 `services`,托管运行时才提供该绑定)。缺陷在于把它当成 hook 能拿到的东西来教。

## 改了什么

**`content/docs/kernel/runtime-services/examples.mdx`**

- 页首新增一张「各运行面真实拿到的数据通道」表(hook → `ctx.api`;flow `script` 函数 → 无;plugin → 插件上下文),并点名 `ctx.services` 的短路后果。
- **第 1 节**(旧:flow custom node 用 `ctx.services.data`)改写为真实通道:声明式 `get_record` 节点读行 → `script` 节点把变量映射进注册函数的 `inputs` → 函数返回值由后续声明式节点落库。
- **第 2 节**(旧:hook 手查 `ctx.services?.sharing?.canEdit`)改为 hook 的真实数据通道 `ctx.api.object(…)`;示例语义(写前校验 + 拒绝路径)保留,但换成引擎无法代劳的**业务**规则(合同金额 vs 客户信用额度)。共享强制由 `plugin-sharing` 的引擎中间件按动词自动执行(update 走 `canEdit`、delete 走 `canDelete`,拒绝抛 `FORBIDDEN`),hook 手查是冗余教学,故删。
- 两块入参 `ctx: any` → `(ctx: HookContext)`(#5605 落地后 `session.positions` 已可正常标类型)。

**`content/docs/kernel/runtime-services/sharing-service.mdx`**

- 新增「Enforcement is automatic — do not re-check it in a hook」一节:中间件按动词自动执行 + hook 无 `services` 键 + hook 自己的通道是 `ctx.api`。
- Example 改为「由**持有**该服务的代码调用」(契约类型 `ISharingService`,来自 `@objectstack/spec/contracts`),并首次给该块补 `os:check` 标记 —— 本页自称 canonical source 是那个契约文件,现在真的被钉住了。

## 与 issue / 裁定子断言不符的两处(按实测办)

1. **examples.mdx 第 1 节不是「同病同修 `ctx.api`」**。实测它是 flow `script` 节点调用的注册函数:按契约是**纯函数**(`handlerContract: 'pure'`,#4396),运行时只交 `input` / `variables` / `automation` / `logger`,**没有任何数据句柄** —— 既没有 `services`,也没有 `ctx.api`(`skills/objectstack-automation/SKILL.md` 原话:hooks get `ctx.api`; flow functions don't)。所以第 1 节不能改成 `ctx.api`,只能改成"读在声明式节点、算在纯函数"。旧示例是双重失真:键不存在,且它教的行为本身违反纯函数契约。
2. **sharing-service.mdx 的 Example 不是 action 面**。实测它教的是 hook:注释自称 "The hook exposes the caller's org as `organizationId`",读的是 `ctx.input.id` / `ctx.session`(action ctx 是 `params` / `record` / `recordId`)。故按 hook 处置,不是"仅标注语境"。

## 验证

**反向验证(方向先定后跑:预期红)** —— 把两处**旧**函数体的 `any` 换成如实的 `HookContext` 后编译,两处都报同一条:

```
old1.ts(5,24): error TS2339: Property 'services' does not exist on type '{ object: string; event: …; input: Record< string, unknown >; … 8 more …; }'
old2.ts(5,39): error TS2339: Property 'services' does not exist on type '{ … }'
```

即:键确实不存在,而 `check:skill-examples` 此前是**绿**的 —— `ctx: any` 让块内每一次属性访问都不被检查,`os:check` 标记成了空门(issue 正文第 2 点)。

**新示例不止过类型,还真解析/真跑**:
- `defineFlow` 实际 parse 通过(`flow parsed ok: sales_order_roll_up_totals 5 nodes`);
- `defineHook` 实际 parse 通过,并用手搭 ctx 跑了两条路径:超限 → `rejected as expected: VALIDATION_FAILED: contract amount exceeds the account credit limit`;未超限 → `within limit: passed (expected)`。旧示例是"恒抛",新示例只在业务规则被违反时抛。

**门禁(全绿)**
| 门 | 结果 |
|:--|:--|
| `check:skill-examples` | `✅ 207 prose examples type-check` —— **206 → 207**(sharing-service 新增 1 块);runtime-services 三块从"标记了但零覆盖"变为真检查 |
| `check:doc-authoring` | `✓ 362 files clean` |
| `check:nul-bytes` | `OK (scanned 5723 tracked text file(s))` |
| `check:docs-audit-scope` | `✓ scope in sync (178 hand-written docs)`,releases 只读未动 |
| fumadocs MDX 生成 | 通过(新增的 Callout 内嵌表格可解析) |

docs-only,不发布任何包 ⇒ 无 changeset,已加 `skip-changeset` 标签。

## 分开交付(不在本 PR)

- `check:skill-examples` 加「os:check 块内禁止把入参标 `any`」约束 —— 落 `packages/spec/scripts/`,属 spec 座位面,已拆子单。
- `packages/spec/src/data/hook.zod.ts:416` 的 JSDoc 同病 —— 已在 #5899 留证据评论归拢(该文件属 spec 座位面,不自改)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE

---
_Generated by [Claude Code](https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE)_