### PR TITLE
docs(runtime): ADR-0076 D11 四条在场锚点入账 —— registry + dispatcher 门序 + 两个代表域 (#5357)

### DIFF
--- a/packages/runtime/src/domains/data.ts
+++ b/packages/runtime/src/domains/data.ts
@@ -6,6 +6,13 @@
  * ObjectQL fallback, ADR-0049 exposure gate inside). On a multi-tenant
  * host (a KernelResolver is registered) an unresolved environment answers
  * 428 instead of silently serving the control plane.
+ *
+ * D11 invariant: the body stays HERE. `HttpDispatcher.handleData` is a thin
+ * back-compat delegate, so folding this module back into it — the tempting
+ * "the indirection buys nothing" cleanup — re-couples the data plane to
+ * dispatcher state and restarts the accretion D11 decomposed. Dispatcher
+ * facilities are reachable only through `DomainHandlerDeps`. Anchored in
+ * scripts/adr-anchors.json.
  */
 
 import * as actionExec from '../action-execution.js';

--- a/packages/runtime/src/http-dispatcher.ts
+++ b/packages/runtime/src/http-dispatcher.ts
@@ -1762,6 +1762,16 @@ export class HttpDispatcher {
     async dispatch(method: string, path: string, body: any, query: any, context: HttpProtocolContext, prefix?: string): Promise<HttpDispatcherResult> {
         let cleanPath = path.replace(/\/$/, ''); // Remove trailing slash if present, but strict on clean paths
 
+        // ── Gates run BEFORE any domain body (ADR-0076 D11 step ③) ──
+        // Scope resolution plus the two gates below are the dispatcher's half of
+        // the D11 contract: a body extracted to `./domains/` receives an
+        // already-scoped, already-gated request. Domains add their OWN
+        // authorization on top (`/ai`'s declared per-route `auth`, `/keys`'
+        // identity gate), but NOTHING downstream re-runs these two — so the
+        // ordering is not overhead to optimize away: moving the domain-registry
+        // resolve (further down) above these lines would un-gate every migrated
+        // domain at once and hand handlers a context whose per-request kernel was
+        // never resolved (#5155). Anchored in scripts/adr-anchors.json.
         await this.resolveRequestScope(context, cleanPath);
 
         // ── ADR-0069 Authentication-policy gate ──

--- a/scripts/adr-anchors.json
+++ b/scripts/adr-anchors.json
@@ -220,6 +220,34 @@
         "ADR-0117"
       ],
       "invariant": "`OWNING_BUSINESS_UNIT_ID` is ADR-0117 D1's record-level BU ownership stamp, RESERVED-BUT-NOT-INJECTED (#4611): open-core provisions no such column yet, so the entry looks like dead weight to anyone reading the table alone — and this repo actively hunts dead surface. It is a NAME registry, not the injected set (tenant_id / user_id / deleted_at are the standing precedents), and reserving the spelling early is what stops consumers minting `business_unit_id` / `bu_id` / `dept_id` — the drift cloud#982 paid for with `tenant_id`/`org_id`/`space`. The enum value `ownership: 'business_unit'` is deliberately NOT added alongside it: `applySystemFields`' `wantOwner` is a DENY-list (`registry.ts` — only 'org'/'none' opt out), so a fourth enum member would be stamped with `owner_id`, the exact inverse of D1's table and an ADR-0049 declare-without-enforce violation. Name first, value with its injection. The public-form denylist entry is fail-closed on purpose: an ownership anchor of the owner_id/organization_id forge class must be un-suppliable on the anonymous surface BEFORE the column exists, because adding the denial after it ships is a hole with a release in it."
+    },
+    {
+      "file": "packages/runtime/src/domain-handler-registry.ts",
+      "adrs": [
+        "ADR-0076"
+      ],
+      "invariant": "ADR-0076 D11's thin dispatcher registry — the framework-agnostic port a capability's routes enter through, as a NORMALIZED handler (`DomainRequest` to `HttpDispatcherResult`), never as framework-specific routes: registering Hono `app.route` from plugin space couples every plugin to Hono and forfeits the multi-adapter property `packages/qa/http-conformance` validates on a second, zero-dependency `node:http` adapter. Deliberately WITHOUT wildcards, params or middleware — routing power belongs to the adapters below the port, and growing it here re-grows the god implementation D11 decomposed. Registration stays dispatcher-owned because most slots are MULTI-PROVIDER (`i18n`: service-i18n OR the AppPlugin in-memory fallback; `analytics`: service-analytics OR the ObjectQLPlugin fallback), so a route bridges to a SLOT and not to a package — moving registration into one provider 404s every stack served by another; a package that owns its slot exclusively self-registers through `HttpDispatcher.registerDomainHandler`. `DomainHandlerDeps` is the WHOLE dependency contract of an extracted body, and every kernel-reading facility takes the request FIRST (#5155): one dispatcher instance serves every tenant, so a cached 'kernel of the request in flight' resolved a request that resumed after an await against whichever environment was most recent — one tenant reading another tenant's data source."
+    },
+    {
+      "file": "packages/runtime/src/http-dispatcher.ts",
+      "adrs": [
+        "ADR-0076"
+      ],
+      "invariant": "What is left of ADR-0076 D11's 'clean port with a god implementation' after step ③: a thin core (request scope, gates, discovery, registry seeding) whose domain bodies live under `./domains/` behind thin delegates. Two orderings inside `dispatch()` carry the decision and both read like removable overhead. (1) `resolveRequestScope` then the ADR-0069 auth gate then project-membership enforcement run BEFORE the domain registry is consulted — hoisting the registry resolve above them as a fast path for migrated domains un-gates every extracted domain at once and hands handlers a context whose per-request kernel was never resolved. The domains cannot compensate: they add their OWN authorization (`/ai`'s declared per-route `auth`, `/keys`' identity gate) but nothing downstream re-runs these two, which are the dispatcher's half of the D11 contract. (2) The registry is consulted before the legacy if-chain, which is now EMPTY of domains and must stay empty: a re-added `startsWith` branch either shadows a registered domain or re-implements a path another package already owns — the 'one route, one owner' hazard whose two specimens (`GET /openapi.json`, the `apis:` `handleApiEndpoint`) were DELETED rather than repaired (#5093, #4936) exactly because grep found them and the runtime never ran them. The service entries this file computes for discovery are D12's honesty rule (`svcAvailable` + `isServiceServeable`), never a slot-presence test."
+    },
+    {
+      "file": "packages/runtime/src/domains/data.ts",
+      "adrs": [
+        "ADR-0076"
+      ],
+      "invariant": "The `/data` body — D11 step ③'s terminal cut (PR-10) and the very handler ADR-0076 names when it describes the god implementation ('the dispatcher hardcodes a handler per domain: handleData / handleMcp / handleAnalytics / handleActions, each getService(...)'). It reaches dispatcher facilities ONLY through `DomainHandlerDeps`, and `HttpDispatcher.handleData` is a thin back-compat delegate: folding this module back into that delegate because 'the indirection buys nothing' re-couples the data plane to dispatcher state and restarts the ~3.8k-LOC accretion D11 decomposed. The multi-tenant refusal belongs to the BODY, not to an upstream gate — on a host with a registered KernelResolver, a data-plane request the resolver did not attach to an environment answers 428 and never falls through to the control-plane kernel (ADR-0006 Phase 5)."
+    },
+    {
+      "file": "packages/runtime/src/domains/i18n.ts",
+      "adrs": [
+        "ADR-0076"
+      ],
+      "invariant": "The concrete instance of D11's registration-ownership rule: the `i18n` slot is MULTI-PROVIDER — I18nServicePlugin when service-i18n is installed, else the AppPlugin in-memory fallback auto-registered for stacks that declare translation bundles — so the dispatcher registers this route, not the provider. Moving `/i18n` registration into service-i18n, the obvious-looking 'the owning package should own its route' cleanup, 404s every stack served by the other provider. The extracted body also keeps the legacy matching semantics deliberately (`match: 'prefix'`, so `/i18nxx` matches too, exactly as the old `startsWith` chain did): normalizing that edge is a behaviour change for the http-conformance suite to re-pin, not a tidy-up to slip into an unrelated diff. The 501 on an unserveable slot is D12's honest-capability rule and is narrow on purpose — both real in-memory providers self-declare `degraded` with `handlerReady: true` and keep serving, so the gate closes only on an occupant that would answer with invented strings."
     }
   ]
 }


### PR DESCRIPTION
Closes #5357

ADR-0076 在 `scripts/adr-anchors.json` 中此前对 `0076` 零命中(实测锚点数 30,issue 正文记的 26 是 8-05 的快照;零命中这一前提在本 worktree 的基线 `origin/main` a6b3ee7a1 上复核仍成立),而 D11 的产物是一整片实打实的代码:14 个域模块、`DomainHandlerRegistry`、收缩到约 1.9k 行的 dispatcher。缺的就是「在场门」这一层:被治理的文件自己不提它所遵从的决定,作者就无从知晓(#3723 的机制)。

## 选点判据(判断题,不是清单题)

`check-adr-anchors.mjs` 自己的纪律是 "Do not anchor everything; a map of everything is a map of nothing, and each entry must earn its failure mode."。所以**不锚**全部 14 个域,只锚四处满足「单看文件会觉得可以合理地『优化』掉,而改了会静默逆转 D11」的落点,且四处的失败模式互不重复:

| 锚点 | 它挣到的失败模式(有人会怎么"改进"它) |
|---|---|
| `packages/runtime/src/domain-handler-registry.ts` | 给注册表加通配/参数/中间件("路由能力不够用");从插件空间直接注册框架特定路由;把某槽位的注册搬进"拥有它的那个包";给 deps 加一个不收请求就能读内核的设施 |
| `packages/runtime/src/http-dispatcher.ts` | 把域注册表的 resolve 提到三道门之前当"已迁移域的快路径";往已经对域为空的 if 链里再加一个 `startsWith` 分支 |
| `packages/runtime/src/domains/data.ts` | 把域体折回 `HttpDispatcher.handleData` 那个薄委托("这层间接没买到任何东西") |
| `packages/runtime/src/domains/i18n.ts` | 把 `/i18n` 的注册搬进 service-i18n("拥有该能力的包理应拥有自己的路由") |

四条失败文案都**携带不变量**——违反了哪条决定、为什么不能这么改——而不是只写一个 ADR id。要点分别是:

1. **registry** 是 D11 的框架无关端口:进来的必须是规范化 handler,不是框架特定路由(从插件空间注册 Hono `app.route` 会让每个插件耦合 Hono,葬掉 `packages/qa/http-conformance` 在第二个零依赖 `node:http` 适配器上验证过的多适配器性质);无通配、无参数、无中间件是刻意的,路由能力属于端口下方的适配器;注册权留在 dispatcher,因为多数槽位是**多提供方**(`i18n` 由 service-i18n 或 AppPlugin 内存兜底填充,`analytics` 由 service-analytics 或 ObjectQLPlugin 兜底填充),路由桥的是**槽位**不是包,搬进某一个提供方就 404 掉由另一个提供方服务的每个栈;`DomainHandlerDeps` 的每个读内核设施都先收请求(#5155:一台主机只造一个 dispatcher,缓存"当前请求的内核"会让 await 之后恢复的请求读到另一租户的数据源)。
2. **dispatcher** 里两处次序是承重的,而且两处都长得像可以省掉的开销:(1) scope 解析 → ADR-0069 认证门 → 成员门跑在域注册表**之前**;(2) 注册表跑在 legacy if 链之前,而 if 链现在对域是空的、必须保持空的(one route, one owner —— 两个标本 `GET /openapi.json` 与 `apis:` 的 `handleApiEndpoint` 当初是被**删掉**而不是被修好的,#5093 / #4936)。
3. **`domains/data.ts`** 是 D11 step ③ 的收尾一刀,也正是 ADR 描述 god implementation 时点名的那个 handler;多租户的 428 属于域体本身而非上游门。
4. **`domains/i18n.ts`** 是注册权归属规则的具体实例(多提供方槽位),同时刻意保留了 legacy 的 `match: 'prefix'` 粗糙边(`/i18nxx` 也匹配),规范化它是要由 http-conformance 重新钉的行为变更,不是能顺手塞进无关 diff 的整理。

## 文件面(逻辑零改动)

- `scripts/adr-anchors.json`:+4 条锚点(30 → 34)。
- `packages/runtime/src/http-dispatcher.ts`:**仅注释**。四个锚点文件本来都已提及 `ADR-0076`(无需补头注),但门序不变量此前在三道门旁**没有任何文字**——本文件现有的 10 处 ADR-0076 提及都在别处,所以在 `dispatch()` 的门段补了一段注释把不变量写在它生效的地方。
- `packages/runtime/src/domains/data.ts`:**仅注释**,一句「域体留在这里」+ 折回薄委托的后果。
- ⛔ 未触碰 `rest-server.ts` 的 7693 行实现问题(分诊明令不属本单),未触碰 `content/docs/releases/**`。

## 验证

```
$ node scripts/check-adr-anchors.mjs
check-adr-anchors: OK (34 anchored file(s), every governing ADR still referenced).

$ pnpm --workspace-concurrency=2 --filter @objectstack/runtime test src/domain-handler-registry.test.ts src/http-dispatcher.test.ts src/route-ledger.conformance.test.ts --maxWorkers=2
Test Files  3 passed (3) ／ Tests  290 passed (290)

$ pnpm --workspace-concurrency=2 --filter @objectstack/runtime typecheck   # tsc --noEmit,退出 0
$ node scripts/check-nul-bytes.mjs
check-nul-bytes: OK (scanned 5723 tracked text file(s); ... no raw ASCII control bytes).
```

### 反向验证(方向先预判,再跑)

预判**红**:这道门是纯在场检查,`domains/data.ts` 恰好只有 1 处 `ADR-0076` 提及(新增注释里写的是 "D11 invariant",不含 id),删掉它必然红一条且只红一条。实测一致:

```
  • packages/runtime/src/domains/data.ts: no longer references ADR-0076.
      The `/data` body — D11 step ③'s terminal cut (PR-10) and the very handler ADR-0076 names ...
```

失败输出把不变量整段带了出来(而非只叫人把字符串粘回去),这正是这道门的价值所在;恢复后复绿。

**顺带实测了这道门的粒度,并如实记录**:`domains/i18n.ts` 有 2 处提及(D11 头注 + 第 44 行的 D12),只删头注那处**仍然绿**,两处都删才红。也就是说在场门守的是"文件仍然指向这个决定",不是"某一行注释仍在原位"——它不能替代行为门,门序与路由归属的行为面仍由 `http-dispatcher.*.test.ts`(multi-tenant-concurrency / kernel-resolver / requireauth)与 `route-ledger.conformance.test.ts` 守。这与脚本自己的声明一致:"It does NOT verify the code still obeys the ADR."

## 无发布物

仅治理账本 + 注释行,不改任何包的行为,故**不写 changeset**,需要 `skip-changeset` 标签(建 PR 后立即回读并写并集)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE)_