### PR TITLE
fix(client): `meta.getItem` / `meta.saveItem` 在两个表面标上 spec 已声明的响应类型 (#5545)

### DIFF
--- a/.changeset/client-meta-getitem-saveitem-return-types.md
+++ b/.changeset/client-meta-getitem-saveitem-return-types.md
@@ -1,0 +1,30 @@
+---
+"@objectstack/client": patch
+---
+
+client SDK: `meta.getItem` / `meta.saveItem` declare their spec response types on both surfaces
+
+`ObjectStackClient.meta` and `ScopedProjectClient.meta` each carried a `getItem`
+and a `saveItem` with no return-type annotation, so `unwrapResponse` / `_unwrap`
+resolved without a type argument and every caller received `unknown` — while the
+`getItems` sitting one line above returned `GetMetaItemsResponse`. Two adjacent
+methods on one surface, unequal typing (#5545).
+
+Both now name the type `@objectstack/spec` already declares for their route, and
+both types are re-exported from `@objectstack/client` so a caller can name what
+it received:
+
+- `getItem` → `Promise< GetMetaItemResponse >` — the `{ type, name, item }`
+  envelope. This became the only honest annotation with #5563: before it, the
+  route's default (cached) path answered the bare document and the non-cached
+  path the envelope, so no single type described both.
+- `saveItem` → `Promise< SaveMetaItemResponse >` — including `version`, the
+  ADR-0008 optimistic-concurrency token a caller echoes back as `If-Match`.
+  Nameable only since #5745 completed that schema; against the older
+  `{ success, message }` declaration the annotation would have hidden the OCC
+  carrier.
+
+`patch`, not `minor`: this only narrows `unknown` on existing public signatures.
+`unknown` admits no property read and no assignment to a typed binding, so every
+expression that compiled before still compiles — nothing is removed, and no new
+method or option appears.

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -112,16 +112,42 @@ describe('ObjectStackClient', () => {
             fetch: fetchMock
         });
 
-        const result = await client.meta.getItem('object', 'customer') as any;
+        const result = await client.meta.getItem('object', 'customer');
         expect(fetchMock).toHaveBeenCalledWith('http://localhost:3000/api/v1/meta/object/customer', expect.any(Object));
-        // `meta.getItem` has no declared return type (unlike the `getItems`
-        // beside it — #5545), so its unwrapped payload is `unknown`. Asserted
-        // structurally rather than cast: same assertion strength, without
-        // pretending this surface is typed (#5449).
-        expect(result).toMatchObject({ type: 'object', name: 'customer' });
+        // #5545: `meta.getItem` now declares `Promise< GetMetaItemResponse >`,
+        // matching the `getItems` beside it. These are TYPED field reads, not a
+        // `toMatchObject` shape probe over an `unknown` payload — `result.type`
+        // and `result.name` compile only while the annotation is there, so
+        // removing it turns these two lines red (TS18046) instead of silently
+        // weakening the assertion. No cast: the `as any` this test carried
+        // (#5449) existed solely because the surface was untyped.
+        expect(result.type).toBe('object');
+        expect(result.name).toBe('customer');
         // Load-bearing: the document lives under `item`, not spread at the top
         // level. A regression to the bare shape fails HERE, not on a missing key.
-        expect(result.item).toMatchObject({ label: 'Customer' });
+        // `item` is `unknown` in the spec schema (the envelope is typed, the
+        // document it carries is not), so the document's own keys stay a
+        // structural assertion — that is the schema's shape, not a gap.
+        expect(result.item).toMatchObject({ name: 'customer', label: 'Customer' });
+    });
+
+    it('meta.saveItem surfaces the ADR-0008 OCC carriers the save response declares (#5545)', async () => {
+        // The real `PUT /api/v1/meta/:type/:name` body, as
+        // `SaveMetaItemResponseSchema` has declared it since #5745: `version`
+        // is the `If-Match` token the optimistic-concurrency chain runs on,
+        // and it is reachable from the SDK without a cast only because
+        // `saveItem` names that type.
+        const { client } = createMockClient({
+            success: true,
+            version: 'sha256:' + 'a'.repeat(64),
+            seq: 7,
+            state: 'active',
+        });
+        const saved = await client.meta.saveItem('object', 'customer', { name: 'customer' });
+        expect(saved.success).toBe(true);
+        expect(saved.version).toBe('sha256:' + 'a'.repeat(64));
+        expect(saved.seq).toBe(7);
+        expect(saved.state).toBe('active');
     });
 
     it('meta.getView speaks the path-param dialect both surfaces accept (#3611)', async () => {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -14,6 +14,8 @@ import {
   GetDiscoveryResponse,
   GetMetaTypesResponse,
   GetMetaItemsResponse,
+  GetMetaItemResponse,
+  SaveMetaItemResponse,
   LoginRequest,
   SessionResponse,
   GetPresignedUrlRequest,
@@ -550,15 +552,21 @@ export class ObjectStackClient {
      * @param type - Metadata type (e.g., 'object', 'plugin')
      * @param name - Item name (snake_case identifier)
      * @param options - Optional filters (e.g., packageId to scope by package)
+     *
+     * Answers the spec's `GetMetaItemResponseSchema` envelope: the metadata
+     * document lives under `item`, NOT spread at the top level. Naming that
+     * type here is honest only because #5563 converged every serving path on
+     * it — the cached path (the default one) used to answer the bare document,
+     * so before that convergence no annotation could describe both (#5545).
      */
-    getItem: async (type: string, name: string, options?: { packageId?: string }) => {
+    getItem: async (type: string, name: string, options?: { packageId?: string }): Promise<GetMetaItemResponse> => {
         const route = this.getRoute('metadata');
         const params = new URLSearchParams();
         if (options?.packageId) params.set('package', options.packageId);
         const qs = params.toString();
         const url = `${this.baseUrl}${route}/${type}/${name}${qs ? `?${qs}` : ''}`;
         const res = await this.fetch(url);
-        return this.unwrapResponse(res);
+        return this.unwrapResponse<GetMetaItemResponse>(res);
     },
 
     /**
@@ -566,14 +574,22 @@ export class ObjectStackClient {
      * @param type - Metadata type (e.g., 'object', 'plugin')
      * @param name - Item name
      * @param item - The metadata content to save
+     *
+     * The resolved `version` is the ADR-0008 optimistic-concurrency token:
+     * echo it back as the `If-Match` request header on the next write to the
+     * same item and a concurrent edit is reported as 409 `metadata_conflict`
+     * instead of silently overwriting. It is nameable here only because
+     * `SaveMetaItemResponseSchema` declares the full body since #5745 — the
+     * declaration used to stop at `{ success, message }`, and annotating
+     * against that subset would have hidden the OCC carrier (#5545).
      */
-    saveItem: async (type: string, name: string, item: any) => {
+    saveItem: async (type: string, name: string, item: any): Promise<SaveMetaItemResponse> => {
         const route = this.getRoute('metadata');
         const res = await this.fetch(`${this.baseUrl}${route}/${type}/${name}`, {
             method: 'PUT',
             body: JSON.stringify(item)
         });
-        return this.unwrapResponse(res);
+        return this.unwrapResponse<SaveMetaItemResponse>(res);
     },
 
     /**
@@ -4689,19 +4705,21 @@ export class ScopedProjectClient {
       const res = await this.parent._fetch(this.url(`/meta/${type}${qs ? `?${qs}` : ''}`));
       return this.parent._unwrap<GetMetaItemsResponse>(res);
     },
-    getItem: async (type: string, name: string, options?: { packageId?: string }) => {
+    /** Same `{ type, name, item }` envelope as the unscoped surface (#5563). */
+    getItem: async (type: string, name: string, options?: { packageId?: string }): Promise<GetMetaItemResponse> => {
       const params = new URLSearchParams();
       if (options?.packageId) params.set('package', options.packageId);
       const qs = params.toString();
       const res = await this.parent._fetch(this.url(`/meta/${type}/${name}${qs ? `?${qs}` : ''}`));
-      return this.parent._unwrap(res);
+      return this.parent._unwrap<GetMetaItemResponse>(res);
     },
-    saveItem: async (type: string, name: string, item: any) => {
+    /** Carries the ADR-0008 OCC token in `version` — see the unscoped twin. */
+    saveItem: async (type: string, name: string, item: any): Promise<SaveMetaItemResponse> => {
       const res = await this.parent._fetch(this.url(`/meta/${type}/${name}`), {
         method: 'PUT',
         body: JSON.stringify(item),
       });
-      return this.parent._unwrap(res);
+      return this.parent._unwrap<SaveMetaItemResponse>(res);
     },
     deleteItem: async (type: string, name: string): Promise<{ type: string; name: string; deleted: boolean }> => {
       const res = await this.parent._fetch(this.url(`/meta/${encodeURIComponent(type)}/${encodeURIComponent(name)}`), {
@@ -5043,6 +5061,8 @@ export type {
   GetDiscoveryResponse,
   GetMetaTypesResponse,
   GetMetaItemsResponse,
+  GetMetaItemResponse,
+  SaveMetaItemResponse,
   CheckPermissionRequest,
   CheckPermissionResponse,
   GetObjectPermissionsResponse,


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5545

## 前提复核(先证后改)

基线 `origin/main` @ `a6b3ee7a1`。issue 的事实在最新 main 上**仍然成立**,行号已随 main 漂移:

| 位置 | 方法 | 改前注解 | 改前实际类型 |
|---|---|---|---|
| `:538` | `ObjectStackClient.meta.getItems` | `Promise< GetMetaItemsResponse >` | ✅ 已有 |
| `:554` | `ObjectStackClient.meta.getItem` | **无** | `unwrapResponse(res)` 无泛型实参 → `unknown` |
| `:570` | `ObjectStackClient.meta.saveItem` | **无** | 同上 → `unknown` |
| `:4685` | `ScopedProjectClient.meta.getItems` | `Promise< GetMetaItemsResponse >` | ✅ 已有 |
| `:4692` | `ScopedProjectClient.meta.getItem` | **无** | `parent._unwrap(res)` 无泛型实参 → `unknown` |
| `:4699` | `ScopedProjectClient.meta.saveItem` | **无** | 同上 → `unknown` |

同时复核了两个解锁前提,都已落地:

- **#5563(PR #5895,`d9cac6019`)**:`GET /meta/:type/:name` 的缓存 / 非缓存两条分支现在都经
  `RestServer.translateMetaEnvelope` 重建同一个信封(`rest-server.ts:2714` 的注释把这点写死了:
  "This is the ONE place the single-item read paths rebuild their response body")。因此
  `GetMetaItemResponse` 现在是**唯一诚实注解** —— 在 #5563 之前默认(缓存)分支发裸文档,
  任何一种注解都会在某种服务端配置下撒谎,这正是前任 dev 停手的理由。
- **#5745(PR #5861)**:`SaveMetaItemResponseSchema` 已含 `version` / `seq` / `state` /
  `projectionApplied`(`protocol.zod.ts:273`)。实测确认后才标注 —— 对着旧的
  `{ success, message }` 声明标注会把 ADR-0008 OCC 令牌 `version` 从公开签名里抹掉,
  那才是前任 dev 拒标 `saveItem` 的原因。

## 改动

四处方法(两个表面 × `getItem`/`saveItem`)标上 spec 已声明的响应类型,类型从
`@objectstack/spec/api` **import 而非新增**,与并排的 `getItems` 同源;两个类型同时加进
`packages/client` 既有的 spec 类型再导出块,调用方才有办法给收到的东西命名。

`packages/spec` 一字未动。

## 测试

`client.test.ts` 的 getItem 断言从 `toMatchObject` 权宜写法升级为类型化字段读取,
`as any` 一并摘掉(该 cast 存在的唯一理由就是这个表面没类型):

```ts
const result = await client.meta.getItem('object', 'customer');
expect(result.type).toBe('object');
expect(result.name).toBe('customer');
expect(result.item).toMatchObject({ name: 'customer', label: 'Customer' });
```

`result.item` 保持结构断言,不是遗漏:`GetMetaItemResponseSchema` 里 `item` 就是
`z.unknown()`(信封有类型,它装的文档没有),这是 schema 的形状本身。

新增一条 `saveItem` 测试,钉住 save 响应的 OCC 载体(`version` / `seq` / `state`);
替身按真实路由构造 —— `rest-server.ts:4491` 是 `res.json(result)`,原样发协议层的返回对象。

该测试的 getItem 替身在 #5563 里已翻成信封形状,本 PR 无需再翻。**#5787 记录的替身问题
(`endpoints` 已退役、capabilities 形状错)不在本 PR 范围**,未顺手修。

命令与结果:

```
$ pnpm --filter @objectstack/client typecheck
> tsc --noEmit && pnpm check:test-typecheck
✓ check:test-typecheck --self-test — 8 semantic case(s) + the parser hold.
check:test-typecheck: OK — @objectstack/client's test layer compiles under
packages/client/tsconfig.test.json; 3 file(s) / 6 error(s) held in
test-typecheck-debt.json (shrink-only, #5286).

$ pnpm --filter @objectstack/client test -- --maxWorkers=2
Test Files  19 passed (19)
     Tests  237 passed (237)
```

debt 账本未动(仍是 3 文件 / 6 错误,全部是 #5543 的 objectql `registerObject`
INPUT/OUTPUT 类型问题),`client.test.ts` 不在账本里 —— 按该 gate 的口径,未列入的文件
必须零错误。

## 反向验证(方向事先预测,结果一致)

预测:摘掉四处注解 → 载荷回落 `unknown` → 类型化读取处报 TS18046。实测:

```
$ npx tsc --noEmit -p tsconfig.test.json      # 四处注解已临时摘除
src/client.test.ts(124,16): error TS18046: 'result' is of type 'unknown'.
src/client.test.ts(125,16): error TS18046: 'result' is of type 'unknown'.
src/client.test.ts(131,16): error TS18046: 'result' is of type 'unknown'.
src/client.test.ts(147,16): error TS18046: 'saved' is of type 'unknown'.
src/client.test.ts(148,16): error TS18046: 'saved' is of type 'unknown'.
src/client.test.ts(149,16): error TS18046: 'saved' is of type 'unknown'.
src/client.test.ts(150,16): error TS18046: 'saved' is of type 'unknown'.
```

注解恢复后归零。这条正是 #5449 在 `client.test.ts(106,16)` 报的同一个错 —— 那次是
测试层刚接进 tsc 时暴露的,这次是我们主动把它请回来确认新断言真的挂在注解上。

## 语义:为什么是 patch

公开签名从 `unknown` 收窄。`unknown` 不允许任何属性读取、也不能赋给有类型的绑定,
所以改前能编译的表达式改后一样能编译;没有删除任何东西,没有新方法/新选项。非破坏,patch。

## 未做(明确留白)

- `meta.getHistory` ×2:spec 里**没有**任何 history 响应 schema,不凭空发明形状,保持现状。
  (另注:非作用域表面的那个已带手写内联形状,作用域表面的仍是 `unknown` —— 两者不对等,
  已在报告里留给 PM 转分诊。)
- 11 个 `unwrapResponse< any >` 的 `meta.*` 方法(`getPublished` / `listDrafts` /
  `migrateStored` / `getLegalNextStates` / `getDiagnostics` / `getReferences` /
  `getBookTree` / `getAudit` / `publishItem` / `rollbackItem` / `diffItem`):产出 `any`
  不是 `unknown`,且逐条补注解等于逐条定契约,前任 PM 已裁为另案。
- `meta.getView`:确实产出 `unknown`,但**不能**标 `GetViewResponse` —— 生产端
  `getUiView` 发的是 `{ list: … }` / `{ form: … }`,spec 声明的是 `{ object, view }`,
  两者形状不同。这是 #5563 同族的声明/实际背离,已另行立单,不在本 PR 修。
- `data.*` 两个表面注解齐全(复核确认,无缺口)。
