### PR TITLE
feat(lint): never-fire 族三条规则 warning → error,注册表 tier 同步 gating (#5762)

### DIFF
--- a/.changeset/lint-never-fire-family-gates.md
+++ b/.changeset/lint-never-fire-family-gates.md
@@ -1,0 +1,56 @@
+---
+"@objectstack/lint": minor
+---
+
+never-fire 族三条 lint 规则 warning → error:声明了触发器却确定不会运行的 flow 现在被拒收
+
+`validateFlowTriggerReadiness` 里的规则此前一律是 warning。族内复审(#5762)后按**一个**标准重新定级 ——
+「仅凭这份 stack 是否已经足够断定这个 flow 不会运行」—— 三条规则答「是」,升为 `error`:
+
+- **`flow-time-relative-descriptor-invalid`**(#5496)—— `config.timeRelative` 描述符
+  `TimeRelativeTriggerSchema` 判不过。判它的正是 trigger 在 bind 时 `safeParse` 的同一个 schema,
+  所以 schema 拒的描述符在运行时同样被拒:sweep 永不安装,flow 声明了 time-relative 触发器却永不运行。
+- **`flow-time-relative-descriptor-unroutable`**(#5647)—— `config.timeRelative` 不是对象
+  (`timeRelative: 'daily'` 是典型)。判据就是引擎自己的路由谓词 `typeof … === 'object'`,
+  所以这个值不会被任何部署路由到 time-relative trigger —— 全族里最硬的判定,也是唯一连
+  bind 时那一行 warn 都没有的一条。
+- **`flow-trigger-unknown-event`**(#3427/#3457/#3481)—— `record-*` token 落在文法之外
+  (`record-after-updated` 拼错、`record-change` 缺相位、数组形式)。引擎用硬编码前缀把任何
+  `record-` 开头的 token 路由给 record-change trigger(不查注册表,所以装任何包都无法声明新
+  `record-*` token),该 trigger 再用 `triggerTypeToHookEvents` 的封闭文法映射 —— 文法外就是零
+  hook event,即绑不上任何东西。
+
+**两条对照规则维持 warning,这正是本次定级不是「整个文件都升 error」的原因:**
+
+- `flow-trigger-unknown-object` —— 本 stack 没定义的对象名**可能由另一个已安装包提供**,
+  规则看不见那个包的对象。免责是真的,所以继续 advisory(它自己的 hint 就这么写)。
+- `flow-draft-status-ambiguous` —— draft flow **确实会**触发,这是意图歧义而非死 flow。
+
+## 影响面:P1 运行时发布门(`surfaces: CLI_AND_RUNTIME`)
+
+注册表 tier 同步 `advisory` → `gating`。除 `os validate` / `os build` / `os lint` 之外,本规则也跑在
+元数据写入路径的 publish 门上,`error` 会让 `state: 'active'` 的写入被拒(422)。**边界值得写清,因为
+直觉猜错的方向恰好对租户有利**:该门交给规则的快照里 `flows` 只装**正在写入的那一个** item
+(`runtime-gate.ts`:`candidate = { objects, [stackKey]: [item] }`),并且会减掉 baseline 已产出的
+finding。所以:
+
+- 发布 flow A **不会**因为已存储的 flow B 是死 flow 而被拒;租户既有的死 flow 继续被读取和服务
+  (ADR-0087 读路径不对称);
+- 被拒的是**死 flow 自己的发布**(含再次发布),以及 CLI 侧 —— stack 里含死 flow 的包
+  `os validate` / `os build` / `os lint` 转红;
+- draft 保存从不过门(#4463 D1),只有发布才过。
+
+## 迁移
+
+修死 flow,不要降级规则:
+
+- 描述符判不过 → 按 finding 里 `TimeRelativeTriggerSchema` 的原文改(它会点名该写的键);
+  描述符要 `{ object, dateField, 且 withinDays | offsetDays 恰好其一 }`。
+- `timeRelative` 写成了 `'daily'` 这类节奏值 → 节奏是**同级兄弟键** `config.schedule`
+  (默认每日 08:00 UTC,通常可省),`timeRelative` 只描述扫哪些记录。
+- `record-*` token 落在文法外 → 用 `record-{before,after}-{create,insert,update,delete,write}`;
+  「创建或更新」用 `record-after-write` 一条 flow 覆盖(#3427);多事件数组仍未支持(#3457),
+  按事件各写一条 flow。
+
+仓内三个示例 app(showcase / CRM / todo)`os validate` 升级前后输出逐字一致、均通过,
+本次升级不需要修改任何示例。

--- a/packages/lint/src/authoring-rules.ts
+++ b/packages/lint/src/authoring-rules.ts
@@ -558,18 +558,32 @@ export const AUTHORING_RULES: readonly AuthoringRule[] = [
       + 'severity change on a published rule id and belongs in its own PR, not riding a wiring change.',
     run: (stack) => validateCapabilityReferences(stack),
   },
-  // A record-change flow whose start-node objectName matches nothing never
-  // fires — silently. Reads the pre-parse tier so an author sees what they
-  // wrote. Advisory: the object may come from another installed package.
+  // A flow that LOOKS armed and never launches — silently. Reads the pre-parse
+  // tier so an author sees what they wrote.
+  //
+  // `gating` since #5762, which reviewed the file's rules as one family and
+  // split them on a single question: is THIS STACK enough to know the flow is
+  // dead? Three rules answer yes and now emit `error` — a `config.timeRelative`
+  // the spec's own `TimeRelativeTriggerSchema` refuses, one the engine's routing
+  // predicate cannot route at all, and a `record-*` triggerType outside the
+  // closed token grammar `triggerTypeToHookEvents` maps. None of those verdicts
+  // can be changed by installing a package, so there is no reading under which
+  // the flow fires. `flow-trigger-unknown-object` deliberately stayed `warning`
+  // (the object may come from another installed package — a hedge this rule
+  // cannot decide), as did `flow-draft-status-ambiguous` (draft flows DO fire;
+  // that one is ambiguity of intent, not a dead flow).
   {
     name: 'validateFlowTriggerReadiness',
-    tier: 'advisory',
+    tier: 'gating',
     input: 'normalized',
     commands: ALL,
     source: 'packages/lint/src/validate-flow-trigger-readiness.ts',
-    // Runtime publish gate (#4463): the FLOW family. Advisory at this surface
-    // too — its findings are logged, not thrown (P1 gates on `error` only; P2
-    // puts advisories on the response for Studio to render).
+    // Runtime publish gate (#4463): the FLOW family. Its `error` findings now
+    // REFUSE a `state: 'active'` write (P1 gates on `error` only); the rules that
+    // stayed `warning` keep being logged as advisories. The gate judges a
+    // snapshot whose `flows` holds only the written item and subtracts the
+    // baseline's findings, so this refuses the dead flow's own publish — never
+    // another flow's save on account of a stored one.
     surfaces: CLI_AND_RUNTIME,
     runtimeTypes: ['flow'],
     run: (stack) => validateFlowTriggerReadiness(stack),

--- a/packages/lint/src/validate-flow-trigger-readiness.test.ts
+++ b/packages/lint/src/validate-flow-trigger-readiness.test.ts
@@ -223,7 +223,7 @@ describe('validateFlowTriggerReadiness', () => {
       expect(findings).toHaveLength(1);
       const [f] = findings;
       expect(f.rule).toBe(FLOW_TIME_RELATIVE_DESCRIPTOR_INVALID);
-      expect(f.severity).toBe('warning');
+      expect(f.severity).toBe('error');
       // Criterion 1: the finding NAMES config.timeRelative, in both channels the
       // CLI prints (`• where: message` then `at path`).
       expect(f.path).toBe('flows[0].nodes[0].config.timeRelative');
@@ -410,7 +410,7 @@ describe('validateFlowTriggerReadiness', () => {
         expect(findings).toHaveLength(1);
         const [f] = findings;
         expect(f.rule).toBe(FLOW_TIME_RELATIVE_DESCRIPTOR_UNROUTABLE);
-        expect(f.severity).toBe('warning');
+        expect(f.severity).toBe('error');
         expect(f.path).toBe('flows[0].nodes[0].config.timeRelative');
         expect(f.where).toBe('flow "task_due_reminder" › start node');
         // The value the author wrote AND why it is not a descriptor.
@@ -622,7 +622,7 @@ describe('validateFlowTriggerReadiness', () => {
     const findings = validateFlowTriggerReadiness({ objects: [candidateObject], flows: [flow] });
     expect(findings).toHaveLength(1);
     expect(findings[0].rule).toBe(FLOW_TRIGGER_UNKNOWN_EVENT);
-    expect(findings[0].severity).toBe('warning');
+    expect(findings[0].severity).toBe('error');
     expect(findings[0].message).toContain("'record-after-updated'");
     expect(findings[0].message).toMatch(/never fires/i);
     expect(findings[0].path).toBe('flows[0].nodes[0].config.triggerType');
@@ -691,7 +691,7 @@ describe('validateFlowTriggerReadiness', () => {
     ];
     const findings = validateFlowTriggerReadiness({ objects: [candidateObject], flows: [flow] });
     expect(findings.map((f) => f.rule)).toEqual([FLOW_TRIGGER_UNKNOWN_EVENT]);
-    expect(findings[0].severity).toBe('warning');
+    expect(findings[0].severity).toBe('error');
     expect(findings[0].message).toMatch(/array/i);
     expect(findings[0].message).toMatch(/never fires/i);
     expect(findings[0].path).toBe('flows[0].nodes[0].config.triggerType');
@@ -718,6 +718,166 @@ describe('validateFlowTriggerReadiness', () => {
     (flow.nodes[0] as { config: Record<string, unknown> }).config.triggerType = ['schedule', 'manual'];
     const findings = validateFlowTriggerReadiness({ objects: [candidateObject], flows: [flow] });
     expect(findings.some((f) => f.rule === FLOW_TRIGGER_UNKNOWN_EVENT)).toBe(false);
+  });
+
+  // ── #5762 — the family's severity map ────────────────────────────────────
+  //
+  // The rules in this file were reviewed as ONE family and split on a single
+  // question: is this stack enough to know the flow is dead? Three rules answer
+  // yes and gate; two hedge and advise. The split is the contract, so it is
+  // pinned as a map rather than as five scattered `severity` lines — a later
+  // rule added to this file has to decide which side it is on, and a later edit
+  // that quietly demotes one of the three has to come past this test.
+  //
+  // Every entry is provoked through a real stack, so an id whose criterion stops
+  // firing fails here instead of passing vacuously (the empty-verdict trap: an
+  // assertion about findings that are never produced is green for the wrong
+  // reason).
+  describe('severity (#5762)', () => {
+    /** Minimal stacks, one per rule id, each provoking exactly that finding. */
+    const provoke: Array<[string, 'error' | 'warning', Record<string, unknown>]> = [
+      [
+        FLOW_TIME_RELATIVE_DESCRIPTOR_INVALID,
+        'error',
+        {
+          objects: [{ name: 'task', label: 'Task', fields: {} }],
+          flows: [
+            {
+              name: 'bad_shape',
+              type: 'schedule',
+              status: 'active',
+              nodes: [
+                {
+                  id: 'start',
+                  type: 'start',
+                  config: { timeRelative: { object: 'task', field: 'due_at', offsetDays: -1 } },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      [
+        FLOW_TIME_RELATIVE_DESCRIPTOR_UNROUTABLE,
+        'error',
+        {
+          objects: [{ name: 'task', label: 'Task', fields: {} }],
+          flows: [
+            {
+              name: 'scalar_descriptor',
+              type: 'autolaunched',
+              status: 'active',
+              nodes: [{ id: 'start', type: 'start', config: { timeRelative: 'daily' } }],
+            },
+          ],
+        },
+      ],
+      [
+        FLOW_TRIGGER_UNKNOWN_EVENT,
+        'error',
+        {
+          objects: [candidateObject],
+          flows: [
+            {
+              name: 'typo_token',
+              type: 'autolaunched',
+              status: 'active',
+              nodes: [
+                {
+                  id: 'start',
+                  type: 'start',
+                  config: { objectName: 'app_candidate', triggerType: 'record-after-updated' },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      // ── The controls. Both are hedged, and the hedge is the whole reason the
+      //    promotion above is not "everything in this file is an error now".
+      [
+        FLOW_TRIGGER_UNKNOWN_OBJECT,
+        'warning',
+        {
+          objects: [candidateObject],
+          flows: [
+            {
+              name: 'other_package_object',
+              type: 'autolaunched',
+              status: 'active',
+              nodes: [
+                {
+                  id: 'start',
+                  type: 'start',
+                  config: { objectName: 'billing_invoice', triggerType: 'record-after-update' },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      [
+        FLOW_DRAFT_STATUS_AMBIGUOUS,
+        'warning',
+        {
+          objects: [candidateObject],
+          flows: [recordFlow()],
+        },
+      ],
+    ];
+
+    for (const [rule, severity, stack] of provoke) {
+      it(`${rule} is ${severity}`, () => {
+        const matching = validateFlowTriggerReadiness(stack).filter((f) => f.rule === rule);
+        // Non-vacuous first: the fixture really does provoke this id.
+        expect(matching.length, `${rule} was not provoked by its own fixture`).toBeGreaterThan(0);
+        for (const f of matching) expect(f.severity).toBe(severity);
+      });
+    }
+
+    it('the hedged rules say so in their own hint, and the gating ones do not', () => {
+      // The severity claim and the prose have to agree. A rule that gates while
+      // telling the author the finding "can be ignored" is the contradiction that
+      // makes a gate read as a bug — and the cross-package sentence is exactly
+      // what earns `flow-trigger-unknown-object` its warning.
+      for (const [rule, severity, stack] of provoke) {
+        for (const f of validateFlowTriggerReadiness(stack).filter((x) => x.rule === rule)) {
+          if (severity === 'warning' && rule === FLOW_TRIGGER_UNKNOWN_OBJECT) {
+            expect(f.hint, rule).toMatch(/another installed package/);
+          }
+          if (severity === 'error') {
+            expect(f.hint, rule).not.toMatch(/can be ignored/i);
+            expect(f.hint, rule).not.toMatch(/another installed package/);
+          }
+        }
+      }
+    });
+
+    it('a clean stack produces no finding of any severity', () => {
+      // The floor the promotion must not move: promoting a rule must not make a
+      // correct flow fail. Without this, "everything is an error" would pass
+      // every assertion above.
+      expect(
+        validateFlowTriggerReadiness({
+          objects: [candidateObject, { name: 'task', label: 'Task', fields: {} }],
+          flows: [
+            recordFlow({ status: 'active' }),
+            {
+              name: 'renewal',
+              type: 'schedule',
+              status: 'active',
+              nodes: [
+                {
+                  id: 'start',
+                  type: 'start',
+                  config: { timeRelative: { object: 'task', dateField: 'due_at', withinDays: 30 } },
+                },
+              ],
+            },
+          ],
+        }),
+      ).toEqual([]);
+    });
   });
 
   it('handles map-keyed flows/objects and stacks with no flows', () => {

--- a/packages/lint/src/validate-flow-trigger-readiness.ts
+++ b/packages/lint/src/validate-flow-trigger-readiness.ts
@@ -46,6 +46,44 @@
 // second copy of the descriptor's shape living in this file. It stays inside the
 // package's stated dependency direction — lint → `@objectstack/spec`, never onto
 // a runtime.
+//
+// ## Severity: the never-fire family gates, the hedged rules advise (#5762)
+//
+// The file's rules do not share a severity, and the line between them is not
+// how bad the outcome is — every rule here describes a flow that does not run.
+// It is whether THIS STACK is enough to know that:
+//
+//   - `error` — the never-fire family. `flow-time-relative-descriptor-invalid`,
+//     `flow-time-relative-descriptor-unroutable` and
+//     `flow-trigger-unknown-event` each read a value whose verdict is settled by
+//     a contract that ships in this repo: `TimeRelativeTriggerSchema` for the
+//     first, the engine's own `typeof … === 'object'` routing predicate for the
+//     second, `triggerTypeToHookEvents`' closed token grammar for the third.
+//     Nothing an author or a tenant can INSTALL changes any of those verdicts,
+//     so there is no reading of the stack under which the flow fires. A rule
+//     that can prove a declared trigger is dead should not be asking the author
+//     to notice a warning about it.
+//   - `warning` — `flow-trigger-unknown-object`, both halves. An object name
+//     this stack does not define may be defined by another installed package,
+//     and this rule cannot see that package's objects. The hedge is real, so the
+//     rule advises and says so in its own hint. It is the deliberate control for
+//     the paragraph above: the family was reviewed together (#5762) and this is
+//     the one that stayed advisory.
+//   - `warning` — `flow-draft-status-ambiguous`. Draft flows DO fire, so this is
+//     an ambiguity of intent, not a dead flow. Gating it would refuse a stack
+//     whose flows all work.
+//
+// The consequence of `error` is not confined to `os validate`: this rule runs at
+// the runtime publish gate too (`surfaces: CLI_AND_RUNTIME` in
+// `authoring-rules.ts`), which refuses a `state: 'active'` metadata write whose
+// findings include one. What that does and does NOT reach is worth stating,
+// because the obvious guess is wrong in the tenant's favour: the gate hands this
+// rule a snapshot whose `flows` array holds ONLY the item being written
+// (`runtime-gate.ts` — `candidate = { objects, [stackKey]: [item] }`), and
+// subtracts every finding the baseline already produced. So publishing flow A is
+// never refused because stored flow B is dead, and a tenant's existing dead
+// flows keep being served. What IS refused is the dead flow's own publish — and,
+// on the CLI surface, a package build whose stack contains one.
 
 import { TimeRelativeTriggerSchema } from '@objectstack/spec/automation';
 
@@ -273,7 +311,12 @@ export function validateFlowTriggerReadiness(stack: AnyRec): FlowTriggerReadines
           .map((i) => `${i.path.join('.') || '(root)'}: ${i.message.replace(/\s+/g, ' ').trim()}`)
           .join('; ');
         findings.push({
-          severity: 'warning',
+          // `error` (#5762): the verdict is `TimeRelativeTriggerSchema`'s, and it
+          // is the same schema the trigger safeParses at bind time. A descriptor
+          // it refuses is refused at bind too — the sweep is never installed, on
+          // every deployment, with no installed package able to change the
+          // answer. Nothing is left for the author to weigh.
+          severity: 'error',
           rule: FLOW_TIME_RELATIVE_DESCRIPTOR_INVALID,
           where: `flow "${flowName}" › start node`,
           path: `flows[${flowIndex}].nodes[${start.index}].config.timeRelative`,
@@ -297,7 +340,15 @@ export function validateFlowTriggerReadiness(stack: AnyRec): FlowTriggerReadines
     //     (only a runtime warn). Surface the never-fire defect at authoring time.
     if (start && isRecordTriggered && !VALID_RECORD_TRIGGER.test((triggerType ?? '').trim())) {
       findings.push({
-        severity: 'warning',
+        // `error` (#5762). The token grammar is CLOSED and local: the engine
+        // routes any `record-`-prefixed string to the record-change trigger by a
+        // hardcoded prefix test (no registry lookup, so installing a package
+        // cannot claim a new `record-*` token), and that trigger maps the token
+        // with `triggerTypeToHookEvents` — the same regex this file's
+        // `VALID_RECORD_TRIGGER` mirrors. Off-grammar means zero hook events,
+        // which means bound-to-nothing on every deployment. Unlike an object
+        // name, there is no other-package reading that rescues it.
+        severity: 'error',
         rule: FLOW_TRIGGER_UNKNOWN_EVENT,
         where: `flow "${flowName}" › start node`,
         path: `flows[${flowIndex}].nodes[${start.index}].config.triggerType`,
@@ -317,7 +368,14 @@ export function validateFlowTriggerReadiness(stack: AnyRec): FlowTriggerReadines
     //     single tokens above (same rule id — both are "this token never fires").
     if (start && isArrayRecordTriggered) {
       findings.push({
-        severity: 'warning',
+        // `error` (#5762), same id and same reason as 1c: an array maps to no
+        // hook event either. The engine routes it to the record-change trigger
+        // for the express purpose of making it loud, and its own comment names
+        // THIS rule as the primary catch — a primary catch that only warns is
+        // the "declared ≠ enforced" shape the registry's tier exists to close.
+        // Multi-event arrays are deferred, not unsupported-by-accident (#3457),
+        // so if they land the grammar widens here in the same commit.
+        severity: 'error',
         rule: FLOW_TRIGGER_UNKNOWN_EVENT,
         where: `flow "${flowName}" › start node`,
         path: `flows[${flowIndex}].nodes[${start.index}].config.triggerType`,
@@ -384,7 +442,14 @@ export function validateFlowTriggerReadiness(stack: AnyRec): FlowTriggerReadines
           `never fires — with zero diagnostics at any layer, not even the one bind-time warn a ` +
           `descriptor that IS an object gets when the trigger refuses it.`;
       findings.push({
-        severity: 'warning',
+        // `error` (#5762). The criterion IS the engine's routing predicate, so a
+        // value that fails it is not routed to the time-relative trigger by any
+        // deployment — the strongest verdict in this file, and the one case with
+        // no runtime channel to fall back on (not even the bind-time warn 1b-ii
+        // moves earlier). Note the two consequences below are both defects: one
+        // never fires, the other silently drops the descriptor. Neither is a
+        // shape the author can have meant, so both gate.
+        severity: 'error',
         rule: FLOW_TIME_RELATIVE_DESCRIPTOR_UNROUTABLE,
         where: `flow "${flowName}" › start node`,
         path: `flows[${flowIndex}].nodes[${start.index}].config.timeRelative`,


### PR DESCRIPTION
Closes #5762

按维护者 2026-08-06 批复(三问全批)执行。族内同批定级,单独 PR,不逐条搭车。

## 定级标准:一个问题,不是「后果有多严重」

本文件的规则此前一律 warning。复审后按**一个**标准重新定级 —— **仅凭这份 stack,是否已经足够断定这个 flow 不会运行**。按后果排序是没用的:这里每条规则描述的都是「不运行的 flow」。

### 升 error(三条)

| 规则 | 判据归属 | 为什么没有别的读法 |
|---|---|---|
| `flow-time-relative-descriptor-invalid` (#5496) | `TimeRelativeTriggerSchema` | 判它的正是 trigger 在 bind 时 `safeParse` 的**同一个** schema —— schema 拒的描述符运行时同样被拒,sweep 永不安装 |
| `flow-time-relative-descriptor-unroutable` (#5647) | 引擎的路由谓词 `typeof … === 'object'` | 判据就是引擎自己的谓词,任何部署都不会把它路由到 time-relative trigger;全族最硬,也是唯一连 bind 时那行 warn 都没有的一条 |
| `flow-trigger-unknown-event` (#3427/#3457/#3481) | `triggerTypeToHookEvents` 的封闭文法 | 见下,随批复审的实测结论 |

三条的共同点:判据都是**本仓库内发布的契约**,装任何包都改不了答案。

### 维持 warning(两条,反例)

这两条正是本次**不是**「整个文件都升 error」的原因,已作为反例钉进新增测试:

- **`flow-trigger-unknown-object`** —— 本 stack 没定义的对象名**可能由另一个已安装包提供**,而规则看不见那个包的对象。免责是真的,规则自己的 hint 就这么写(新增测试断言:error 级 finding 的 hint 里不得出现 "another installed package" / "can be ignored",warning 级必须出现)。⛔ 按裁定未动。
- **`flow-draft-status-ambiguous`** —— draft flow **确实会**触发(只有 `obsolete`/`invalid` 停用),这是意图歧义而非死 flow。升它会拒收一个所有 flow 都正常的 stack。

## 随批复审:`flow-trigger-unknown-event` 实测为同性质,故同 PR 升

裁定要求实测其性质:若同为「确定性死 flow、无跨包免责」则同 PR 升;若有真 advisory 理由则维持并写进报告。**实测结论:同性质,无跨包免责。** 证据:

1. **路由不可扩展。** `engine.ts:1532` 用**硬编码前缀**判定 `triggerType.startsWith('record-')` 即路由给 `record_change` —— 不查注册表。所以装任何包都无法声明一个新的 `record-*` token。
2. **文法封闭且本地。** `record-change-trigger.ts:115` 的 `/^record-(before|after)-(create|insert|update|delete|write)$/` 与本规则的 `VALID_RECORD_TRIGGER` 逐字对应;不匹配即 `hookEvents.length === 0`,绑不上任何 hook。
3. **无第二个提供方。** 全仓 `record_change` trigger 只有 `packages/triggers/trigger-record-change` 一个实现,没有可替换的竞争实现给出「另一种读法」。
4. **数组形式同理**,且引擎那段注释本就把**本规则**点名为 primary catch —— 一个只 warn 的 primary catch 正是 tier 机制要消除的「declared ≠ enforced」。

对照 `flow-trigger-unknown-object`:对象名的跨包免责是**结构性**的(对象由包提供、规则看不见),而 token 文法的免责**不存在**(文法不由安装决定)。两者不同性质,故一升一留。

## 影响面:P1 运行时发布门 —— 实测边界与立单时的假设不同

注册表 tier `advisory` → `gating`(两条 surface 本就是 `CLI_AND_RUNTIME`)。`error` 会让 `state: 'active'` 的元数据写入被拒。

⚠️ **立单/派发时写的影响面是「升 error 后租户保存任意 flow 时既有死 flow 被连带拒收」—— 实测该说法不成立,方向恰好对租户有利。** `validateFlowTriggerReadiness(stack)` 确实收整个 stack,但**运行时门从不把租户的整份 flow 集合交给它**:

- `runtime-gate.ts` 构造的候选快照是 `candidate = { objects, [stackKey]: [item] }` —— flow 写入时 `flows` 数组里**只有正在写入的那一个 item**;
- 门还会做差分,减掉 baseline(不含该 item 的上下文)已产出的 finding;
- `RuntimeStackContext` 只有 `objects` 一个通道 —— **已存储的 flow 在结构上进不了快照**。

实测(直接调 `runRuntimeAuthoringRules`):

```
publishing the DEAD flow itself
  errors=1  errorRules=["flow-time-relative-descriptor-unroutable"]
publishing a GOOD flow (dead one already stored elsewhere)
  errors=0  errorRules=[]
```

**真实影响面:**

- 被拒的是**死 flow 自己的发布**(含再次发布)—— 这就是裁定要的强制修复,且精确落在有缺陷的那一个 flow 上;
- 发布 flow A **不会**因为已存储的 flow B 是死 flow 而被拒;租户既有死 flow 继续被读取和服务(ADR-0087 读路径不对称);
- draft 保存从不过门(#4463 D1),只有发布才过;
- **真正的连带压力在 CLI 侧**:`os validate` / `os build` / `os lint` 判整份 stack,所以包里含一个死 flow 会让整包转红 —— 修无关 flow 的作者也会看到它。这是本次强制修复的主要着力点。

## zod history 句噪音(裁定第三问):已实测,本 PR **不**折叠,理由如下

裁定允许「若碍事则同 PR 折叠展示」。实测**噪音是真的**:

- history 句 222 字符,内容是 #4001 的沿革叙述;
- 位置在**「哪个键错了」与「该写什么」之间** —— #5496 那条 finding 全长 709 字符,`Did you mean \`field\` → \`dateField\`?` 落在最末;
- CLI 用 `console.log("  • " + where + ": " + message)` 打**单行**,error 块里作者必须读完才能动手。

但**折叠机制在本 PR 的文件面内都不干净**,故未做:

1. 规则内按结构剥离(正则匹配 `Unrecognized key(s) on …: …. ` + history 句 + ` Did you mean …?`)= 把**生产者的消息结构复制进消费者** —— 恰是本文件模块注释声明要避免的漂移,也违反 contract-first;
2. 按长度截断会把最有用的 `Did you mean` 切掉(它在末尾),使情况更糟;
3. 生产者侧没有可查询的把手:`strictObjectDeclarations()` / `directAliasTables()` 都**刻意不进 barrel**(内部接缝),消费者拿不到 history 原文;
4. 干净的修法在生产者(`strictObject` 把 history 排到末尾或单独暴露),但那涉及 62 个 `strictObject` 站点 / 293 处 history 声明与跨包钉死测试,是 spec 的**授权错误契约对外变更**,应单独立单、单独拍板。

已另立 finding 单记录测量与建议。**不在本 PR 内以「消费者容忍」的方式绕过。**

## 反向验证(方向先预判,两个不同机制,均如预判转红)

1. **tier 声明非自述。** 把 tier 改回 `advisory`(严重度保持 error)→ 预判 `authoring-rule-wiring.test.ts` 的 "every advisory rule really is advisory" 转红(它读规则源码核对声明)。实测:`× every advisory rule really is advisory` / ``A rule that can emit `error` is `gating` and must run on all three commands.``
2. **严重度断言非空转。** 把 `…-unroutable` 降回 warning → 预判新增 severity map 测试转红。实测 2 条红:`× flow-time-relative-descriptor-unroutable is error` 与 #5647 原有那条。

## 仓内自查:三个示例 app 的 `os validate` A/B

裁定要求「若任何 in-repo example/fixture 因此转红,在同 PR 内修掉」。**实测无一转红,无需修改。**

| example | A(升级前) | B(升级后) | 输出 |
|---|---|---|---|
| app-showcase | exit 0 | exit 0 | 逐字一致 |
| app-crm | exit 0 | exit 0 | 逐字一致 |
| app-todo | exit 0 | exit 0 | 逐字一致 |

原因可从 diff 直接读出:规则文件的非注释改动**只有 `severity:` 字面量**,判据一行未动,所以任何 stack 的 finding **集合**与 `main` 逐字节相同,只有四处 severity 字段变了。三个示例本就不产出这三条 id 的 finding(showcase 唯一的 `timeRelative` 描述符是已被测试钉为 spec-valid 的 Task Due Reminder;全部 `record-*` token 都在文法内)。app-todo 的两条 `flow-draft-status-ambiguous` 仍是 warning —— 正是维持 advisory 的那条在真实示例上的体现。

`record-created`(全仓 12 处、文法外)全部位于**其他规则**的测试 fixture 里,那些测试直接调用各自的规则、不经过本规则,故不受影响(已逐一核对;`validateFlowTriggerReadiness` 不在 reference-integrity suite 成员内)。

## 文档

`content/**` 无任何 lint 规则 severity 表引用这一族 id(已实测搜索),`packages/lint/src/docs` 不存在,故无同步项。⛔ 未动 `content/docs/releases/**`。

## 发布

真 changeset:`@objectstack/lint` **minor**(已发布规则严格度的对外行为变更),正文含升级原因、P1 实测边界与迁移指引(**修死 flow,而非降级规则**)。未用 `skip-changeset`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GX3sL71LFq8m2usg6VqTSE)_