### PR TITLE
fix(objectql): Archiver 的批循环尊重 #4747 的 teardown abort 位

### DIFF
--- a/.changeset/lifecycle-archive-abort-check.md
+++ b/.changeset/lifecycle-archive-abort-check.md
@@ -1,0 +1,20 @@
+---
+'@objectstack/objectql': patch
+---
+
+lifecycle: the Archiver's batch loop now honours the teardown abort bit (#4747)
+
+`LifecycleService.stop()` raises an abort bit that the sweep checks at each leg
+boundary — between objects, and (since #5753) between reap pages. The Archiver's
+own batch loop did not check it, so teardown landing mid-archive still ran the
+remaining batches out: up to 20 × 500 rows of `find` + per-row `upsert` +
+`bulkDelete` issued across two datasources the host is already closing.
+
+It now breaks at the batch boundary like the reap loop does. The "hot-delete only
+what the cold store took" safety rule is unaffected: the batch in flight finishes
+its `upsert` → `bulkDelete` pair, and batches not yet begun are left for the next
+sweep to re-read.
+
+Not reachable in any of today's deployments — the Archiver only engages once an
+object declares `archive` with a provisioned cold datasource, and no platform
+object does. This is prevention for the first deployment that declares one.

--- a/packages/objectql/src/lifecycle/lifecycle-service.test.ts
+++ b/packages/objectql/src/lifecycle/lifecycle-service.test.ts
@@ -1612,6 +1612,121 @@ describe('LifecycleService teardown (#4747)', () => {
     expect(svc.stopped).toBe(true);
   });
 
+  /**
+   * [#5755] The Archiver's batch loop is the reap loop's twin: same 20-page
+   * budget, same "teardown lands mid-loop" exposure — except every page costs
+   * a read AND up to 500 writes on a SECOND datasource. These two tests pin the
+   * loop's two ends: the budget it runs when nothing calls it off, and the stop
+   * it makes when something does.
+   */
+  const ARCHIVED_OBJ: LifecycleObjectLike = {
+    name: 'sys_audit_log',
+    lifecycle: {
+      class: 'audit',
+      retention: { maxAge: '90d' },
+      // No `keep`: the cold-side prune is a single call AFTER the loop, so
+      // declaring it here would assert a leg these tests do not govern.
+      archive: { after: '90d', to: 'archive' },
+    } as any,
+  };
+
+  /**
+   * A counting hot/cold pair. Every leg the archive loop can issue — the page
+   * read, the per-row copy, the hot delete — is recorded, so "the loop stopped"
+   * is observable per leg instead of inferred from a row count.
+   */
+  function archivePair(rowCount: number, onCopy?: (copied: number) => void) {
+    let remaining: Array<Record<string, unknown>> = [];
+    for (let i = 0; i < rowCount; i++) {
+      remaining.push({ id: `r${i}`, created_at: '2020-01-01T00:00:00.000Z' });
+    }
+    const pageReads: number[] = [];
+    const copied: string[] = [];
+    const hotDeleted: Array<Array<string | number>> = [];
+    return {
+      pageReads,
+      copied,
+      hotDeleted,
+      remaining: () => remaining,
+      hot: {
+        name: 'default',
+        find: async (_object: string, query: any) => {
+          const limit = (query?.limit as number) ?? remaining.length;
+          pageReads.push(limit);
+          return remaining.slice(0, limit);
+        },
+        upsert: async () => ({}),
+        bulkDelete: async (_object: string, ids: Array<string | number>) => {
+          hotDeleted.push(ids);
+          const gone = new Set(ids);
+          remaining = remaining.filter((r) => !gone.has(r.id as string));
+        },
+        deleteMany: async () => 0,
+      },
+      cold: {
+        name: 'archive',
+        find: async () => [],
+        upsert: async (_object: string, row: Record<string, unknown>) => {
+          copied.push(row.id as string);
+          onCopy?.(copied.length);
+          return row;
+        },
+        bulkDelete: async () => {},
+        deleteMany: async () => 0,
+      },
+    };
+  }
+
+  it('an archive nobody calls off runs its whole 20-batch budget', async () => {
+    // The control for the test below: with the abort bit down, the loop is
+    // bounded only by ARCHIVE_MAX_BATCHES_PER_SWEEP (20 × 500), and the rest of
+    // the backlog waits for the next sweep.
+    const pair = archivePair(10_500);
+    const { engine } = captureEngine([ARCHIVED_OBJ], {
+      driver: pair.hot,
+      datasources: { archive: pair.cold },
+    });
+
+    const report = await service(engine).sweep();
+
+    expect(pair.pageReads).toHaveLength(20);
+    expect(pair.copied).toHaveLength(10_000);
+    expect(pair.hotDeleted).toHaveLength(20);
+    expect(pair.remaining()).toHaveLength(500);
+    expect(report.swept.find((e) => e.policy === 'archive')?.archived).toBe(10_000);
+  });
+
+  it('stop() mid-archive ends the batch loop instead of running out the page budget', async () => {
+    // The #4747 shape on the archive side: teardown lands while batch 2 is
+    // copying, so batches 3…20 must issue nothing at all — no hot read, no cold
+    // copy, no hot delete — at two datasources the host is closing.
+    let svc!: LifecycleService;
+    const pair = archivePair(10_500, (copied) => {
+      if (copied === 501) svc.stop(); // first row of batch 2
+    });
+    const { engine } = captureEngine([ARCHIVED_OBJ], {
+      driver: pair.hot,
+      datasources: { archive: pair.cold },
+    });
+    svc = service(engine);
+
+    const report = await svc.sweep();
+
+    expect(svc.stopped).toBe(true);
+    // Two pages read, not 20 — the loop stopped at the boundary after the batch
+    // that was in flight, and never asked the hot store for page 3.
+    expect(pair.pageReads).toHaveLength(2);
+    expect(pair.copied).toHaveLength(1000);
+    // The safety rule survives the interruption: the batch in flight completed
+    // its pair, so every id the cold store took was hot-deleted and no id was
+    // hot-deleted that the cold store had not taken — no half batch either way.
+    expect(pair.hotDeleted.map((ids) => ids.length)).toEqual([500, 500]);
+    expect(pair.hotDeleted.flat()).toEqual(pair.copied);
+    // …and the batches never begun are still hot, for the next sweep to move.
+    expect(pair.remaining()).toHaveLength(9500);
+    expect(report.swept.find((e) => e.policy === 'archive')?.archived).toBe(1000);
+  });
+
   it('stop() then start() re-arms the service — teardown is not one-way', async () => {
     const { engine } = captureEngine([]);
     let audits = 0;

--- a/packages/objectql/src/lifecycle/lifecycle-service.ts
+++ b/packages/objectql/src/lifecycle/lifecycle-service.ts
@@ -1045,6 +1045,19 @@ export class LifecycleService {
     const cutoff = new Date(this.now() - parseLifecycleDuration(archive.after)).toISOString();
     let archived = 0;
     for (let batch = 0; batch < ARCHIVE_MAX_BATCHES_PER_SWEEP; batch++) {
+      // [#4747] Leg boundary, per batch — the same check the reap loop makes
+      // (see {@link batchedReap}). `sweep()` checks the abort bit between
+      // OBJECTS, which leaves one archive round as up to 20 pages of reads and
+      // writes across TWO datasources (a hot page read, a cold upsert per row,
+      // a hot bulk delete), i.e. ~10k operations issued at stores the host may
+      // already be closing — precisely what #4747 stopped.
+      //
+      // Breaking BETWEEN batches keeps the Archiver's safety rule intact
+      // ("hot-delete only what the cold store has taken"): a batch already in
+      // flight finishes its upsert → bulkDelete pair, and batches not yet begun
+      // are simply left for the next sweep, which re-reads them from the hot
+      // store unchanged.
+      if (this.abort.aborted) break;
       const rows = await hot.find(object, {
         where: { created_at: { $lt: cutoff } },
         limit: ARCHIVE_BATCH_SIZE,


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5755

## 前提复核(先于实现)

按 issue 的 lead 逐条对 `origin/main`(`a6b3ee7a1`)实读,**前提成立**(行号已漂,按内容定位):

| 检查点 | 分诊记录(`f205c32`) | 本次实读(`a6b3ee7a1`) | 结论 |
|---|---|---|---|
| `sweep()` 对象之间 | :571 / :598 | `:571` `if (this.stopped) return report;`、`:598` 同款 | 在 |
| `batchedReap` 每页之间 | :1202(PR #5753) | `:1202` `if (this.abort.aborted) break;` | 在 |
| `archiveObject` 批之间 | :1047–1056 确无 | `:1047` 的 `for` 批循环(上界 `ARCHIVE_MAX_BATCHES_PER_SWEEP`)循环体直接以 `await hot.find(...)` 开头 | **确无** |

一轮 archive 的量级也与正文一致:20 批 × 500 行,每批 = 1 次 `hot.find` + 每行 1 次 `cold.upsert` + 1 次 `hot.bulkDelete`,即最多约一万次**跨两个 datasource** 的读写。stop() 落在其中任何一点,循环都会把剩余批次跑完 —— 这正是 #4747 停掉的形状,reap 那侧已由 #5753 补上,archive 这侧没有。

## 改动

`archiveObject()` 批循环体开头一行,与 `:1202` 同款:

```ts
if (this.abort.aborted) break;
```

外加一段注释,写清两件事:为什么 `sweep()` 的对象间检查不够(一轮 archive 是 20 页跨两个 datasource 的读写),以及**为什么按批 break 不破坏 archive 的安全规则**「归档成功才热删」—— 在飞的那一批会把 `upsert` → `bulkDelete` 这一对做完,未开始的批次原样留在热库,交给下一轮 sweep 重新读。没有重构循环本身。

⛔ 同文件的 #5756(reap 每轮预算按「(对象, where 作用域)」计)是语义取舍、分诊持有中,本 PR **未触碰**。

## 测试(`packages/objectql/src/lifecycle/lifecycle-service.test.ts`)

驱动真 `LifecycleService` + 计数 stub 冷热双 driver(每一条腿都记账:页读、逐行拷贝、热删),加在 `teardown (#4747)` describe 里,与 `stop() mid-reap` 那条并列:

1. **对照** —— `an archive nobody calls off runs its whole 20-batch budget`:不抬 abort 位时页读 20 次、拷贝 10 000 行、热删 20 批,余下 500 行留给下一轮。
2. **主用例** —— `stop() mid-archive ends the batch loop instead of running out the page budget`:在第 2 批的第一行 `cold.upsert` 处抬起 abort 位,断言
   - 页读只有 2 次(第 3–20 批**一次 `hot.find` 都没发**);
   - 拷贝恰好 1000 行,热删 `[500, 500]`;
   - **成对不变量**:`hotDeleted.flat()` 逐项等于 `copied` —— 冷库收下的每个 id 都被热删,且没有任何未被冷库收下的 id 被热删,**两个方向都没有半批**;
   - 余下 9500 行仍在热库,等下一轮。

`archive.keep` 有意未在该 fixture 上声明:冷侧 prune 是循环**之后**的单次调用,本 PR 不改那条腿,fixture 也就不去断言它。

### 反向验证(方向先预测,后运行)

预测:**标准红** —— 去掉新检查后主用例转红,对照用例保持绿(它从不抬 abort 位,本就无法区分两个版本,这正是它作为对照而非第二个 pin 的原因)。

实跑与预测一致:

```
✓ ... > an archive nobody calls off runs its whole 20-batch budget 22ms
× ... > stop() mid-archive ends the batch loop instead of running out the page budget 29ms
  → expected [ 500, 500, 500, 500, 500, 500, …(14) ] to have a length of 2 but got 20
 Test Files  1 failed (1)
```

恢复该行后 72/72 全绿。

## 验证

```
pnpm --filter @objectstack/objectql typecheck   → tsc --noEmit,无输出(通过)
pnpm --filter @objectstack/objectql test        → Test Files 128 passed | Tests 2118 passed
node scripts/check-nul-bytes.mjs                → OK(5723 个文件,无裸控制字节)
node scripts/check-engine-double-contract.mjs   → OK — 70 pinned, 133 DEBT, 2 exempt
eslint(两个改动文件)                            → 无输出
```

上述数字取自 `git merge origin/main`(⛔ 未 rebase)之后的重跑 —— 合入的 `metadata-protocol/protocol.ts` 与 `objectql/protocol-meta.test.ts` 与本改动包重叠,故按 AGENTS §9/§10 重建依赖后整包重跑。

新测试**未引入新的 fake engine**:复用文件内既有的 `captureEngine`;新增的冷热 stub 是 **driver** 替身(`find`/`upsert`/`bulkDelete`/`deleteMany`),不含引擎 `delete`/`update` 派发面,`check:engine-double-contract` 复跑仍为 OK。

## 影响面

今天不可达:archive 策略要求已配置 cold datasource,仓内无平台对象声明 `archive`,未配置时直接 `skipped: 'archive-pending'`。这是为**首个声明 `archive` 的部署**做的预防,changeset 按 `@objectstack/objectql` patch 记。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Q7oc7ASjh8yxyS3Yz78We