### PR TITLE
docs(spec): HookEvent 枚举注释不再声称批量写把行级谓词放在 `input` (#5899)

### DIFF
--- a/packages/spec/src/data/hook.zod.ts
+++ b/packages/spec/src/data/hook.zod.ts
@@ -134,10 +134,16 @@ export const HookEvent = z.enum([
 
   // Write — before/after per mutation kind. These fire on BOTH single-id and
   // bulk (`multi: true`) writes: a bulk update/delete runs the SAME
-  // `beforeUpdate`/`beforeDelete`/`afterUpdate`/`afterDelete` with the
-  // row-scoping predicate carried in `input` (there is no per-cardinality
-  // `*Many` event — one write event covers one row or many, Salesforce's
-  // bulk-first model). See #3195.
+  // `beforeUpdate`/`beforeDelete`/`afterUpdate`/`afterDelete` (there is no
+  // per-cardinality `*Many` event — one write event covers one row or many,
+  // Salesforce's bulk-first model). The row-scoping predicate is NOT reachable
+  // from `input` on those write events: it lives on the engine-internal
+  // `OperationContext.ast` (#2982) so that the filters middleware composes onto
+  // it, where no handler can widen it — scope a bulk batch through
+  // `options.where` at the CALLER, or work per row on the `after*` events. Full
+  // per-event shapes in the `HookContextSchema.input` contract table below,
+  // pinned against the real engine by
+  // `packages/objectql/src/hook-input-shape-contract.test.ts`. See #3195.
   'beforeInsert', 'afterInsert',
   'beforeUpdate', 'afterUpdate',
   'beforeDelete', 'afterDelete',


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5899

## 问题

`packages/spec/src/data/hook.zod.ts` 的 `HookEvent` 枚举注释里,写事件那段说批量写「with the
row-scoping predicate carried in `input`」。这是假的:引擎从不在写路径的 `HookContext.input` 上放
谓词,它在引擎内部 `OperationContext.ast`(#2982)。

这与 **同一个文件 200 行外** 的 `HookContextSchema.input` 契约表(`:340` 起,PR #5668 落地 #5273
时写下)直接矛盾 —— 那段已经写着「The row-scoping predicate is NOT reachable from `input` at
all」。#5668 只改了契约表那一处,枚举注释这半句没被覆盖到(`git log -L` 显示该段最后一次变动是
#5306),于是文件自相矛盾:同一份契约,两个相反的答案,读者按哪一处写代码都说得通。

## 改动

纯注释订正,只动枚举注释那一段:

- 删掉 `with the row-scoping predicate carried in `input`` 这半句;
- 补上与 `:340` 契约表**已落地措辞一致**的说法:谓词不在 `input`,在引擎内部
  `OperationContext.ast`(#2982),这样 filters 中间件才能 compose 到它上面、无 handler 能放宽;
  批量写的正确做法是在 CALLER 处用 `options.where` 圈定,或落到 `after*` 逐行处理;
- 把读者指向下方契约表及其钉子测试 `packages/objectql/src/hook-input-shape-contract.test.ts`。

主句保留:批量写触发**同名** `beforeUpdate`/`beforeDelete`/`afterUpdate`/`afterDelete`,没有
per-cardinality 的 `*Many` 事件(#3195)。

未触及 `.describe()`、任何键或类型;未触及 #5900 的 skills / `content/docs` 那一面(devx 车道)。

## 真值来源

无需新测 —— PR #5668 已在 main 上留下钉子 `packages/objectql/src/hook-input-shape-contract.test.ts`,
其中三条直接钉死本句(含阳性对照:读路径确实带 `input.ast`,所以「写路径没有 `ast`」是测量而非空断言)。
本 PR 的新措辞即是那些断言的自然语言版本。

## 验证

```
pnpm --filter @objectstack/spec check:generated   -> 10/10 artifacts up to date(零生成物漂移)
pnpm --filter @objectstack/spec typecheck         -> tsc --noEmit 通过 + check:test-typecheck OK
pnpm --filter @objectstack/spec test              -> 323 files / 8267 tests passed
pnpm --filter @objectstack/objectql test          -> 128 files / 2116 tests passed
node scripts/check-nul-bytes.mjs                  -> OK(5726 个文件,无控制字节)
```

`check:generated` 首次因 `api-surface.json` 报 stale —— 该 gate 读的是 **BUILT dist**,fresh
worktree 尚未 build,gate 自己的提示即指出这是 phantom;`pnpm --filter @objectstack/spec build`
后复跑,10 项全绿,确认本改动零生成物漂移。

## 无 changeset

零生成物、零行为变化、`.describe()` 未涉及 —— 本 PR 不发布任何东西,故不加 changeset,改用
`skip-changeset` 标签。

https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY


---
_Generated by [Claude Code](https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY)_