### PR TITLE
fix(objectql,spec): app 声明的 capability 经注册缝获得 registry provenance (#5870)

### DIFF
--- a/.changeset/capabilities-registry-provenance-seam.md
+++ b/.changeset/capabilities-registry-provenance-seam.md
@@ -1,0 +1,54 @@
+---
+"@objectstack/objectql": patch
+"@objectstack/spec": patch
+---
+
+fix(objectql,spec): app-declared `capabilities` reach the registry with package provenance (#5870, #4967 Part 2)
+
+An authorization capability a package DEFINES (`defineCapability` →
+`stack.capabilities`, ADR-0066 D1) never acquired registry provenance, so a
+declaration that did not repeat its owner by hand was **declared but never
+enforced**.
+
+**FROM.** `ObjectQL.registerApp()` decomposes a manifest's metadata arrays and
+calls `SchemaRegistry.registerItem(type, item, 'name', packageId)` — the only
+seam that runs `applyProtection(item, { packageId })` and stamps `_packageId` /
+`_provenance`. The key list driving that decomposition (`metadataArrayKeys`,
+present twice in `packages/objectql/src/engine.ts`: the manifest seam and the
+nested-plugin seam) carried every other Security-Protocol collection —
+`permissions`, `sharingRules`, `roles`, `profiles`, `policies` — but not
+`capabilities`. The other path a stack's security metadata travels,
+`AppPlugin` → `MetadataManager.registerInMemory`, stamps nothing by design. So
+`readDeclared(ql, 'capability')` always returned `[]`, and
+`bootstrapDeclaredCapabilities` — which resolves the owner as
+`cap._packageId ?? cap.packageId` — could never satisfy the first half.
+
+The consequence was a contract that lied in the direction that costs the most:
+`CapabilityDeclarationSchema.packageId` documents itself as the ADR-0086 D3
+*fallback* used "when the registry has not stamped `_packageId`", and the field
+is `.optional()`, but in practice it was **mandatory**. Omitting it produced one
+boot `warn` and one authorization grant that silently never took effect —
+permission sets have rows and materialize, capabilities did not.
+
+**TO.** `capabilities` is registered through the same provenance seam as
+`permissions`, at both `metadataArrayKeys` sites, and `capabilities` →
+`capability` joins `PLURAL_TO_SINGULAR` in `@objectstack/spec` so the items land
+under the singular type name the seeder reads back (the same mapping
+`AppPlugin`'s security bridge already used). A capability declared by a package
+— or by a package's nested plugin — now carries `_packageId` /
+`_provenance: 'package'`, is listable via `registry.listItems('capability')`,
+and is seeded into `sys_capability` with `managed_by:'package'` and a real
+`package_id`.
+
+**What authors should do.** Nothing is required and nothing breaks: an authored
+`packageId` still parses and still wins where the registry has not stamped
+(items registered outside a package context). It is now genuinely optional —
+drop it and the platform supplies the owner. Where both are present the registry
+stamp takes precedence, as the schema always said; the showcase's
+`showcase.export_data` keeps its authored `packageId` and names the same id the
+stack does, so the two agree.
+
+This does not change what may be created at runtime: `capability` has no entry
+in `DEFAULT_METADATA_TYPE_REGISTRY`, and the runtime-create gate reads that
+registry, not the item store — its verdict for the type is the same before and
+after.

--- a/examples/app-showcase/src/security/capabilities.ts
+++ b/examples/app-showcase/src/security/capabilities.ts
@@ -37,17 +37,16 @@ import { defineCapability } from '@objectstack/spec';
  * capability that never existed — one boot `warn` and an inert security
  * declaration.
  *
- * Why it is authored here rather than inferred: the registry stamp never
- * reaches an app-declared capability, because `capabilities` is missing from
- * the metadata-array key list the ObjectQL engine registers a stack's
- * collections through — so the "fallback" is in practice mandatory. That is a
- * PLATFORM gap, filed as #4967 (together with the sharper half: a refused
- * declaration is still counted as declared, which suppresses the back-compat
- * derivation and leaves the capability existing nowhere), not something the
- * showcase should work around. Declaring `packageId` is the spec's own
- * sanctioned entry point, so this both fixes the app and demonstrates the
- * field; when the platform stamps `_packageId` that takes precedence and this
- * stays consistent with it.
+ * Why it is still authored here now that the platform stamps: it used to be
+ * MANDATORY, because `capabilities` was missing from the metadata-array key
+ * list the ObjectQL engine registers a stack's collections through, so the
+ * registry stamp never reached an app-declared capability and the documented
+ * "fallback" was the only provenance there was. #5870 (#4967 Part 2) closed
+ * that seam — `registerApp` now stamps `_packageId` on capabilities exactly as
+ * it does on permission sets — so this line is once again what the spec says it
+ * is: the fallback, kept because it also DEMONSTRATES the field. It names the
+ * same id as the stack (`com.example.showcase`), so the stamp that now takes
+ * precedence agrees with it.
  */
 export const ExportDataCapability = defineCapability({
   name: 'showcase.export_data',

--- a/packages/objectql/src/engine-capability-provenance.test.ts
+++ b/packages/objectql/src/engine-capability-provenance.test.ts
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#5870, #4967 Part 2] `capabilities` in the provenance-stamping seam.
+ *
+ * ADR-0066 D1 says a package DEFINES its authorization capabilities and the
+ * registry attributes them to that package. The attribution only happens on ONE
+ * path: `ObjectQL.registerApp()` decomposes a manifest's metadata arrays and
+ * calls `SchemaRegistry.registerItem(type, item, 'name', packageId)`, which runs
+ * `applyProtection(item, { packageId })` and stamps `_packageId` /
+ * `_provenance`. The key list that drives that decomposition
+ * (`metadataArrayKeys`, twice in `engine.ts`: the manifest seam and the nested
+ * `registerPlugin` seam) carried every other Security-Protocol collection —
+ * `permissions`, `sharingRules`, `roles`, `profiles`, `policies` — but not
+ * `capabilities`.
+ *
+ * Consequence before the fix: `plugin-security`'s `bootstrapDeclaredCapabilities`
+ * resolves the owner as `cap._packageId ?? cap.packageId` and reads its input
+ * with `readDeclared(ql, 'capability')`, which is
+ * `engine.registry.listItems('capability')` mapped through `i?.content ?? i`
+ * (`packages/plugins/plugin-security/src/bootstrap-declared-permissions.ts:61-69`).
+ * With `capabilities` outside the seam that list was ALWAYS empty, so the
+ * `_packageId` half of that `??` could never be satisfied and the author-side
+ * `packageId` — documented in `CapabilityDeclarationSchema` as the *fallback*
+ * for "registry-stamped absent" — was in fact mandatory. Omitting it produced a
+ * boot `warn` and one authorization grant that never took effect: declared ≠
+ * enforced.
+ *
+ * These tests assert the registry state `readDeclared` consumes rather than
+ * importing it — `@objectstack/plugin-security` does not depend on
+ * `@objectstack/objectql` (nor the reverse), and a test-only edge between them
+ * would invent a package dependency the runtime does not have. The expression
+ * under test is quoted from that file above and pinned by
+ * {@link readDeclaredShape} below.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { pluralToSingular } from '@objectstack/spec/shared';
+import { ObjectQL } from './engine';
+
+/**
+ * The exact read `bootstrapDeclaredCapabilities` performs on the engine, kept
+ * in one place so the shape this suite depends on is stated once:
+ * `readDeclared(ql, type)` → `registry.listItems(type)` unwrapped by
+ * `content ?? item`.
+ */
+function readDeclaredShape(engine: ObjectQL, type: string): any[] {
+  return (engine.registry.listItems<any>(type) ?? []).map((i: any) => i?.content ?? i).filter(Boolean);
+}
+
+const PKG = 'com.acme.exporter';
+
+/** A declaration with NO author-side `packageId` — the registry must supply it. */
+function manifestWithCapability() {
+  return {
+    id: PKG,
+    name: 'exporter',
+    capabilities: [
+      { name: 'export_data', label: 'Export Data', description: 'Bulk-export records.', scope: 'org' },
+    ],
+    permissions: [
+      { name: 'ops', label: 'Ops', systemPermissions: ['export_data'] },
+    ],
+  };
+}
+
+describe('registerApp — declared capabilities carry registry provenance (#5870)', () => {
+  it('registers a manifest capability under the singular `capability` type', () => {
+    const engine = new ObjectQL();
+    engine.registerApp(manifestWithCapability());
+
+    const caps = readDeclaredShape(engine, 'capability');
+    expect(caps.map((c) => c.name)).toEqual(['export_data']);
+  });
+
+  it('stamps `_packageId` so the seeder resolves an owner without an author-side packageId', () => {
+    const engine = new ObjectQL();
+    engine.registerApp(manifestWithCapability());
+
+    const cap = readDeclaredShape(engine, 'capability')[0];
+    // The seeder's own expression: registry provenance first (ADR-0010),
+    // author-declared `packageId` (ADR-0086 D3) only as fallback.
+    expect(cap._packageId ?? cap.packageId).toBe(PKG);
+    // …and the fallback really is a fallback: nothing authored `packageId`.
+    expect(cap.packageId).toBeUndefined();
+    expect(cap._packageId).toBe(PKG);
+    expect(cap._provenance).toBe('package');
+  });
+
+  it('reaches the registry on exactly the same terms as its `permissions` sibling', () => {
+    const engine = new ObjectQL();
+    engine.registerApp(manifestWithCapability());
+
+    const cap = readDeclaredShape(engine, 'capability')[0];
+    const permission = readDeclaredShape(engine, 'permission')[0];
+
+    expect(permission?._packageId).toBe(PKG);
+    expect(cap?._packageId).toBe(permission?._packageId);
+    expect(cap?._provenance).toBe(permission?._provenance);
+  });
+
+  it('keeps two packages\' same-named capabilities attributed to their own owner', () => {
+    const engine = new ObjectQL();
+    engine.registerApp({ id: 'com.acme.crm', capabilities: [{ name: 'export_data', label: 'CRM Export' }] });
+    engine.registerApp({ id: 'com.acme.hr', capabilities: [{ name: 'export_data', label: 'HR Export' }] });
+
+    expect(engine.registry.getItem<any>('capability', 'export_data', 'com.acme.crm')?.label).toBe('CRM Export');
+    expect(engine.registry.getItem<any>('capability', 'export_data', 'com.acme.hr')?.label).toBe('HR Export');
+    expect(readDeclaredShape(engine, 'capability')).toHaveLength(2);
+  });
+
+  it('stamps capabilities declared by a NESTED plugin too (the second seam)', () => {
+    // `engine.ts` carries `metadataArrayKeys` twice — the manifest seam and the
+    // `registerPlugin` seam reached via `manifest.plugins[]`. A fix applied to
+    // only one leaves a package's nested plugin declaring capabilities that
+    // still never get stamped, which is the same defect one level down.
+    const engine = new ObjectQL();
+    engine.registerApp({
+      id: PKG,
+      plugins: [
+        { name: 'billing', capabilities: [{ name: 'billing.refund', label: 'Refund' }] },
+      ],
+    });
+
+    const caps = readDeclaredShape(engine, 'capability');
+    expect(caps.map((c) => c.name)).toEqual(['billing.refund']);
+    // Nested plugins contribute UNDER the parent package's ownership.
+    expect(caps[0]._packageId).toBe(PKG);
+  });
+});
+
+describe('metadataArrayKeys ↔ stamping consistency pin (#5870)', () => {
+  /**
+   * The three Security-Protocol collections a boot seeder reads back by
+   * SINGULAR type name: `bootstrapDeclaredPermissions` (`permission`),
+   * `bootstrapDeclaredCapabilities` (`capability`) and
+   * `bootstrapDeclaredSharingRules` (`sharing_rule`). Membership in
+   * `metadataArrayKeys` alone is not enough — the plural key must also map to
+   * the singular type the seeder asks for, or the items land in a store nobody
+   * reads. This pin holds both halves at once.
+   */
+  const SEEDED_SECURITY_COLLECTIONS: ReadonlyArray<readonly [string, string]> = [
+    ['permissions', 'permission'],
+    ['capabilities', 'capability'],
+    ['sharingRules', 'sharing_rule'],
+  ];
+
+  it('maps each seeded security collection to the singular type its seeder reads', () => {
+    for (const [plural, singular] of SEEDED_SECURITY_COLLECTIONS) {
+      expect(pluralToSingular(plural), `${plural} must register as '${singular}'`).toBe(singular);
+    }
+  });
+
+  it('stamps every seeded security collection through the manifest seam', () => {
+    const engine = new ObjectQL();
+    engine.registerApp({
+      id: PKG,
+      permissions: [{ name: 'ops', label: 'Ops' }],
+      capabilities: [{ name: 'export_data', label: 'Export Data' }],
+      sharingRules: [{ name: 'share_all', object: 'account', accessLevel: 'read' }],
+    });
+
+    for (const [, singular] of SEEDED_SECURITY_COLLECTIONS) {
+      const items = readDeclaredShape(engine, singular);
+      expect(items, `nothing registered under '${singular}'`).toHaveLength(1);
+      expect(items[0]._packageId, `'${singular}' reached the registry unstamped`).toBe(PKG);
+    }
+  });
+});

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -2209,8 +2209,17 @@ export class ObjectQL implements IObjectQLEngine {
         // Automation Protocol
         'flows', 'workflows', 'approvals', 'webhooks',
         'jobs',
-        // Security Protocol
-        'roles', 'permissions', 'profiles', 'sharingRules', 'policies',
+        // Security Protocol — `capabilities` is here for the same reason as
+        // `permissions` (#5870, #4967 Part 2): the ONLY seam that stamps
+        // ADR-0010 provenance is `registerItem` → `applyProtection`, so a
+        // collection missing from this list reaches no registry with a
+        // `_packageId`. `bootstrapDeclaredCapabilities` resolves the owning
+        // package as `cap._packageId ?? cap.packageId`; while `capabilities`
+        // sat outside this list the first half could never be satisfied and
+        // `readDeclared(ql, 'capability')` returned nothing, which made the
+        // author-side `packageId` — documented as the FALLBACK — mandatory,
+        // and its omission a silent, unenforced authorization declaration.
+        'roles', 'permissions', 'capabilities', 'profiles', 'sharingRules', 'policies',
         // AI Protocol
         'agents', 'tools', 'skills', 'ragPipelines',
         // API Protocol
@@ -2374,7 +2383,11 @@ export class ObjectQL implements IObjectQLEngine {
       const metadataArrayKeys = [
           'actions', 'views', 'pages', 'dashboards', 'reports', 'datasets', 'themes',
           'flows', 'workflows', 'approvals', 'webhooks',
-          'roles', 'permissions', 'profiles', 'sharingRules', 'policies',
+          // `capabilities` per #5870 — same stamping seam, one level down: a
+          // nested plugin's declarations must carry the parent package's
+          // provenance too, or the same declared-≠-enforced hole reopens for
+          // packages that ship their capabilities from a nested plugin.
+          'roles', 'permissions', 'capabilities', 'profiles', 'sharingRules', 'policies',
           'agents', 'ragPipelines', 'apis',
           'hooks', 'mappings', 'analyticsCubes', 'connectors',
           'docs', 'books',

--- a/packages/spec/src/shared/metadata-collection.zod.ts
+++ b/packages/spec/src/shared/metadata-collection.zod.ts
@@ -121,6 +121,12 @@ export const PLURAL_TO_SINGULAR: Record<string, string> = {
   jobs: 'job',
   positions: 'position',
   permissions: 'permission',
+  // [ADR-0066 D1, #5870] Package-declared authorization capabilities. The
+  // singular form is what `bootstrapDeclaredCapabilities` reads back
+  // (`readDeclared(ql, 'capability')`) and what `AppPlugin` already registers
+  // under; without the mapping the registration seam stored them as
+  // `'capabilities'`, a store nothing reads.
+  capabilities: 'capability',
   sharingRules: 'sharing_rule',
   apis: 'api',
   webhooks: 'webhook',


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5870
Part of objectstack-ai/objectstack#4967(Part 2;父单由 identity 车道跟踪关单)

## 前提复核(先于实现,结论:成立)

issue 正文的四条断言逐条对 `origin/main` 复核,全部成立:

1. `bootstrapDeclaredCapabilities` 以 `cap._packageId ?? cap.packageId` 解析归属(`packages/plugins/plugin-security/src/bootstrap-declared-capabilities.ts`);
2. `AppPlugin` 走 `metadata.registerInMemory(type, item.name, item)`(`packages/runtime/src/app-plugin.ts` ~653),而 `MetadataManager.registerInMemory` 只做 `registry.get(type).set(name, data)`(`packages/metadata/src/metadata-manager.ts:772`)—— 不盖任何章;
3. 唯一盖章路径是 `SchemaRegistry.registerItem(type, item, 'name', packageId)` → `applyProtection(item, { packageId })`(`packages/objectql/src/registry.ts:1375`);
4. 其入口 `metadataArrayKeys` 仓内共两处(engine.ts 的 manifest 缝与嵌套 `registerPlugin` 缝;issue 写的 ~1735 是今日 4 个 PR 搅动前的行号,已按内容定位到 2183 / 2351),Security Protocol 组含 `roles / permissions / profiles / sharingRules / policies`,**独缺 `capabilities`**。

## 一处 issue 未提及、但不修就兑现不了验收的结构点

只把 `'capabilities'` 加进两处清单**还不够**。该缝注册用的是 `pluralToSingular(key)`,而 `PLURAL_TO_SINGULAR`(`packages/spec/src/shared/metadata-collection.zod.ts`)没有 `capabilities` 条目 —— 未命中时原样返回复数键,项会被注册成类型 `'capabilities'`,而 `readDeclared(ql, 'capability')` 读的是单数 `'capability'`,等于换了一个同样没人读的库位。

这不是新造映射:`AppPlugin` 的安全元数据桥早已用 `['capabilities', 'capability']` 这一对(app-plugin.ts:643),`sharingRules → sharing_rule`、`permissions → permission` 也都在这张表里 —— 补的是这张边界表上唯一缺的那格。

## 改动

- `packages/objectql/src/engine.ts` —— 两处 `metadataArrayKeys` 的 Security Protocol 组各加 `'capabilities'`(manifest 缝 + 嵌套 plugin 缝);
- `packages/spec/src/shared/metadata-collection.zod.ts` —— `PLURAL_TO_SINGULAR` 补 `capabilities: 'capability'`;
- `examples/app-showcase/src/security/capabilities.ts` —— 只改注释:原文写着「registry 章永远到不了 app 声明的 capability……那是 PLATFORM gap,已立 #4967」,本 PR 落地后这段自述失效。改为说明 `packageId` 恢复成 schema 所写的「fallback」身份、保留是为了演示该字段,且它与 stack id 同为 `com.example.showcase`,与如今生效的章一致。**未改任何声明值**。
- `.changeset/capabilities-registry-provenance-seam.md` —— `@objectstack/objectql` + `@objectstack/spec` 均 patch,正文写清 FROM → TO。

⛔ 未改 `packages/runtime`(cli 车道)与 `packages/plugins/plugin-security`(identity 车道):实测二者**无需**同步改动即可兑现验收,仅作只读验证。

## 修复的行为(FROM → TO)

**FROM**:`CapabilityDeclarationSchema.packageId` 是 `.optional()`,自述为「registry 未盖 `_packageId` 时的 ADR-0086 D3 fallback」。因为 `capabilities` 不在盖章缝里,`_packageId` 永不存在,这个「fallback」**实为必填**。漏写的失败形态只有一条 boot warn 加一条永不生效的授权 —— permission set 有行、能物化,capability 无章可达,`readDeclared(ql, 'capability')` 恒返回 `[]`。授权面上的 declared ≠ enforced。

**TO**:包(以及包内嵌套 plugin)声明的 capability 携带 `_packageId` / `_provenance: 'package'` 到达 registry,可经 `registry.listItems('capability')` 读到,并以 `managed_by:'package'` + 真实 `package_id` 落进 `sys_capability`。作者侧 `packageId` 恢复成真正的可选 fallback;两者并存时按 schema 一贯所述以 registry 章为准。

**运行时可创建性未变**:`capability` 在 `DEFAULT_METADATA_TYPE_REGISTRY` 无条目,而 `isRuntimeCreateAllowed()` 读的是那张注册表、不是 item store,所以该类型的判定改动前后一致(见下方越界发现)。

## 反向验证 —— 方向为标准「红」,且是先红后绿测得的

本改动是对缝的**纯增补**,预判方向即:去掉增补 → 新 pin 全红。实测按此顺序执行:

- 修改前(仅新增测试)：`Test Files 1 failed | 128 passed`,`Tests 7 failed | 2115 passed`。7 条新例全红,失败点分别为 `listItems('capability')` 返回 `[]`、`pluralToSingular('capabilities')` 得 `'capabilities'`;
- 修改后：`Test Files 129 passed`,`Tests 2122 passed`(合并 main 后 2123)。

无「诊断增多」或「倒置」情形:本改动不删除任何 `??` 支路,也不改变 schema 对任何拼写的判决。

## 测试

新增 `packages/objectql/src/engine-capability-provenance.test.ts`(7 例,真引擎 + 真 registry,无 mock,沿用 `engine-cross-package-collision.test.ts` 的形态):

1. manifest 里的 capability 注册到**单数** `capability` 类型下;
2. 未写作者侧 `packageId` 时,`cap._packageId ?? cap.packageId` 仍解析出归属(并断言 `packageId` 确为 `undefined` —— 证明 fallback 真的是 fallback);
3. 与 `permissions` 同条件平价(`_packageId` / `_provenance` 相同);
4. 两个包的同名 capability 各归其主(`getItem(type, name, pkgId)` 分别解析);
5. **嵌套 plugin 缝**同样盖章(覆盖第二处 `metadataArrayKeys`,防止只修一处);
6-7. **一致性 pin**:三条被 boot seeder 按单数类型读回的安全集合(`permissions/permission`、`capabilities/capability`、`sharingRules/sharing_rule`)—— 既钉 `pluralToSingular` 映射,又钉「经 manifest 缝注册后确实带章」的实际行为。两半同时成立才算接进了缝。

测试断言的是 `readDeclared` 所消费的 registry 状态,而非 import 该函数:`@objectstack/plugin-security` 与 `@objectstack/objectql` **互不依赖**,为测试新增一条包依赖会凭空发明运行时并不存在的边。所读表达式在测试文件头部注明出处(`bootstrap-declared-permissions.ts:61-69`)并收在单个 `readDeclaredShape()` 里。

命令与实测(均在容器共享锁下前台阻塞执行,`--maxWorkers=2`),合并 `origin/main` 后重跑:

```
objectql          Test Files 129 passed   Tests 2123 passed
spec              Test Files 323 passed   Tests 8267 passed
plugin-security   Test Files  35 passed   Tests  768 passed
metadata-protocol Test Files  49 passed   Tests  486 passed
rest              Test Files  60 passed   Tests  833 passed
runtime           Test Files 102 passed   Tests 1468 passed
metadata          Test Files  25 passed   Tests  508 passed

typecheck: objectql / spec / runtime / plugin-security 全 Done
spec check:generated: 10/10 up to date
node scripts/check-nul-bytes.mjs: OK
```

消费半径已按「规则被谁读」而非「改了哪个包」清扫:`PLURAL_TO_SINGULAR` 的全部消费者(`metadata/loaders/database-loader`、`rest/rest-server`、`runtime/domains/packages`、`spec/conversions/stored`、`metadata-protocol/protocol`、`spec/kernel/metadata-authoring-lint`)逐个跑过。其中 authoring-lint 的覆盖面**未变**:它以 `getMetadataTypeSchema(type)` 取 schema,`capability` 无 schema 故直接 `continue`,不影响那条被钉住的覆盖数。

与本 PR 同窗合入的 #5934(plugin-security 派生半边只 reconcile 自家行)与本改动**互补**:本 PR 让 capability 首次产生 `managed_by:'package'` 行,而 #5934 恰好阻止派生占位符每次启动覆盖这些行的 label/description。二者合并后 plugin-security 全绿。

## 决策箱核对(#4636)

不交叠、不预判。#4636 是 `loadMetaFromDb` 的 **object 分支**从 snake_case 行上读 `record.packageId` 导致落到 `'sys_metadata'` 哨兵,发生在 DB 再水化路径、经由 `registerObject`。本 PR 只走 manifest 装配路径的 `registerItem`,`packageId` 取的是 manifest 自己的 `id` —— 与 `permissions` 完全同一个取值,不涉及「capability 该登记在哪个 owner key 下」的任何选择。

## 越界发现(已按 Prime Directive #10 立单,未在本 PR 修)

**#5961** —— `capability` 在 `DEFAULT_METADATA_TYPE_REGISTRY` / `BUILTIN_METADATA_TYPE_SCHEMAS` / `HAND_CRAFTED_SCHEMAS` 三处皆无条目,于是 `isRuntimeCreateAllowed()` 走「无静态注册条目 ⇒ 允许」的兜底,`saveMetaItem` 又走「未注册类型 ⇒ 不校验直接存」,`PUT /api/v1/meta/capability/:name` 收任意 JSON;`/meta/types` 则合成一个 `allowRuntimeCreate: true`、无 schema 的描述符。与 #5271 给 `api` 修掉的是同一形态。

**这不是本 PR 引入的**:写入门只读注册表、不读 item store,该路在本 PR 之前已敞开。本 PR 改变的只是**可见性** —— capabilities 现在真的进 registry,`capability` 于是开始出现在 `getMetaTypes()` 的枚举里。已在 issue 正文中写明这一因果,避免下一位读者误判为回归。修法有三案(补 schema + `allowRuntimeCreate:false` / 只补 schema / 改合成逻辑),取舍不属本单范围,留 PM 分诊。


---
_Generated by [Claude Code](https://claude.ai/code/session_019Q7oc7ASjh8yxyS3Yz78We)_