### PR TITLE
fix(spec): openapi 静态产物摘除 built-in 路由段，只保留契约半边 (#5744)

### DIFF
--- a/.changeset/openapi-static-artifact-contract-only.md
+++ b/.changeset/openapi-static-artifact-contract-only.md
@@ -1,0 +1,22 @@
+---
+"@objectstack/spec": major
+---
+
+**`@objectstack/spec/openapi.json` 不再描述任何路由 —— 静态产物收缩为它真正拥有的契约半边(#5744,#5588 裁定 C 第二棒)**
+
+`packages/spec/scripts/build-openapi.ts` 里手写的 built-in 路由段(`generateCrudPaths` / `generateMetadataPaths` / `generateDiscoveryPaths`,7 条 path、10 个 operation)整体摘除。这一段在真实 boot 上逐条探测 **0/10 命中**:路径按字面量 `basePath = '/api'` 拼接,于是全部缺 `/v1`(CRUD 还缺 `/data`);`PUT {object}/{id}` 的动词服务器明确回 405;`/api/meta/types` 全仓无此路由;`/api/.well-known/objectstack` 是 runtime dispatcher 的路由、挂在**根路径**上。而且它在这个座位上原理上就写不对 —— `apiPath` 是部署级配置(`api.apiPath ?? api.basePath + '/' + version`),随包发布的静态 JSON 无法为所有部署拼对前缀。
+
+段落的唯一属主是**挂载这些路由的包**(ADR-0076 一路由一属主;本文档的属主由 #5078 的真实 boot 坐实为 `@objectstack/rest`)。第一棒 #5821 已让 REST 服务在 serve 期从 `routeManager.getAll()` 产出该段、并**整体丢弃**静态产物带来的 `paths`,所以本次摘除对服务出的 `GET {apiPath}/openapi.json` 是**零行为变化**:那份文档的路由段早已逐字节来自 rest。
+
+发布出去的静态产物现在只剩 `openapi` / `info` / `servers` / `components`(`schemas` + `securitySchemes`)/ `security` 五个顶层键 —— 正是 rest serve 期会从产物里读走的那几项。
+
+**破坏性**:直接 `import '@objectstack/spec/openapi.json'` 的消费者会看到
+
+- **`paths` 键消失**(不是变成 `{}`)。OpenAPI 3.1 里 `paths` 可省(`paths` / `components` / `webhooks` 三者有其一即为合法文档),而两种写法说的不是一件事:`paths: {}` 断言「这个 API 什么都不服务」——假的;键不存在则对路由不作任何断言 —— 这才是这份产物有资格作出的声明。`doc.paths` 上直接取值的代码需要改成防御式读取,或者改去读服务出的 `GET {apiPath}/openapi.json`(那份是完整文档)。
+- **`tags` 键消失**。`CRUD` / `Metadata` / `Discovery` 三个 tag 只为命名被摘掉的三段而存在,任何文档里都没有 operation 携带它们;服务出的文档的 tag 列表由 rest 与路由段一起产出。
+
+要一份**带路由**的文档,唯一正确的来源是运行中的服务:`GET {apiPath}/openapi.json`。
+
+**门禁随形状调整,不靠留活口维持覆盖**:#5168 的产物自恰门保留,但如实标注 —— 9 个 `$ref` 全部住在被摘掉的 operation 请求/响应体里,所以 `assertRefsResolve` 在**今天**的产物上是空断言。留着它是因为幸存的那半边仍然能走到它防的形状:`z.toJSONSchema` 会把复用/递归子 schema 放进它**返回值**根部的 `$defs`,并用根相对的 `#/$defs/…` 指过去;这些 schema 各自独立转换后被停在 `components.schemas[Name]` 下,于是该指针指的是整份 OpenAPI 文档的根 —— 那里没有 `$defs`。九个契约 schema 今天都不是递归形状,反向验证用变异复现了这一天(注入 `#/$defs/Recursive` → 生成器非零退出)。另新增两条钉子:产物**不含**路由段(七条幽灵路径与三个 tag 逐条断言不存在),以及产物**仍完整保留** spec 拥有的五个顶层键 —— 后者防的是把这次收缩做过头、连 rest 要读的东西一起删掉。
+
+`check:generated` 台账里 `gen:openapi` 那条 `why` 同步改写:原文「no check gate compares it to the routes」在裁定 C 之下已无第二方可对账,现在如实记录真正剩下的缺口 —— 没有任何东西把产物的 `components.schemas` 与 `src/api` 对账,产物过期不会让任何东西变红(自恰性由 #5168 在写盘前自检覆盖,**时效性**没有)。

--- a/packages/spec/scripts/build-openapi.ts
+++ b/packages/spec/scripts/build-openapi.ts
@@ -14,227 +14,44 @@ const pkg = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../package.json'
 const SPEC_VERSION = pkg.version;
 
 /**
- * Generates an OpenAPI 3.1 specification from the ObjectStack REST API protocol schemas.
- * This auto-generates documentation for all CRUD operations and platform endpoints.
+ * Generates the OpenAPI 3.1 **contract half** of `GET {apiPath}/openapi.json`
+ * from this package's REST API protocol schemas: `components.schemas`, `info`,
+ * `securitySchemes`, the document-level `security` requirement, and a fallback
+ * `servers` entry. That is the whole artifact, and the whole of what
+ * `packages/spec` owns.
+ *
+ * ## It deliberately describes NO routes (#5588 ruling C, #5744)
+ *
+ * This generator used to hand-write a built-in route section —
+ * `generateCrudPaths` / `generateMetadataPaths` / `generateDiscoveryPaths`,
+ * 7 paths and 10 operations under a literal `basePath = '/api'`. A real boot
+ * probed it row by row and matched **0 of 10**: every path was missing `/v1`
+ * (CRUD also missing `/data`), `PUT {object}/{id}` named a verb the server
+ * answers 405 to, `/api/meta/types` exists nowhere in the repo, and
+ * `/api/.well-known/objectstack` is the runtime dispatcher's route, served at
+ * the ROOT rather than under the API base.
+ *
+ * It could not be written correctly from this seat, either: `apiPath` is
+ * per-deployment configuration (`api.apiPath ?? api.basePath + '/' + version`),
+ * so no statically published JSON can spell the prefix right for every
+ * deployment. A route section can only be produced by the package that MOUNTS
+ * the routes — ADR-0076 (one route, one owner), with `packages/rest` confirmed
+ * as this document's owner by the real boot in #5078.
+ *
+ * So the section has one producer, and it is not here: since #5821 the REST
+ * server builds it at serve time from `routeManager.getAll()` — the same table
+ * the router matches requests against — and DISCARDS whatever `paths` the
+ * static artifact carries. #5744 (this change) removes the emission, which is
+ * why the removal is a zero-behaviour-change cleanup rather than a regression:
+ * the served document's route section was already rest's, byte for byte.
+ *
+ * `paths` is therefore ABSENT from the emitted document rather than present
+ * and empty. OpenAPI 3.1 makes `paths` optional (a document is valid with any
+ * one of `paths` / `components` / `webhooks`), and the two spellings say
+ * different things: `paths: {}` asserts "this API serves nothing", which is
+ * false, while an absent key asserts nothing about routes, which is exactly
+ * the claim this artifact is entitled to make.
  */
-
-interface OpenApiPath {
-  [method: string]: {
-    summary: string;
-    description?: string;
-    tags: string[];
-    operationId: string;
-    parameters?: Array<{
-      name: string;
-      in: string;
-      required: boolean;
-      schema: Record<string, unknown>;
-      description?: string;
-    }>;
-    requestBody?: {
-      required: boolean;
-      content: Record<string, { schema: Record<string, unknown> }>;
-    };
-    responses: Record<string, {
-      description: string;
-      content?: Record<string, { schema: Record<string, unknown> }>;
-    }>;
-  };
-}
-
-function generateCrudPaths(basePath: string): Record<string, OpenApiPath> {
-  const paths: Record<string, OpenApiPath> = {};
-
-  // List records
-  paths[`${basePath}/{object}`] = {
-    get: {
-      summary: 'List records',
-      description: 'Query records with filtering, sorting, and pagination',
-      tags: ['CRUD'],
-      operationId: 'listRecords',
-      parameters: [
-        { name: 'object', in: 'path', required: true, schema: { type: 'string' }, description: 'Object name (snake_case)' },
-        { name: 'top', in: 'query', required: false, schema: { type: 'integer', default: 25 }, description: 'Page size' },
-        { name: 'skip', in: 'query', required: false, schema: { type: 'integer', default: 0 }, description: 'Offset' },
-        { name: 'sort', in: 'query', required: false, schema: { type: 'string' }, description: 'Sort field (prefix with - for desc)' },
-        { name: 'fields', in: 'query', required: false, schema: { type: 'string' }, description: 'Comma-separated field list' },
-      ],
-      responses: {
-        '200': {
-          description: 'List of records',
-          content: { 'application/json': { schema: { $ref: '#/components/schemas/ListRecordResponse' } } },
-        },
-        '400': { description: 'Invalid query', content: { 'application/json': { schema: { $ref: '#/components/schemas/ApiError' } } } },
-        '401': { description: 'Unauthorized' },
-      },
-    },
-    post: {
-      summary: 'Create a record',
-      description: 'Create a new record in the specified object',
-      tags: ['CRUD'],
-      operationId: 'createRecord',
-      parameters: [
-        { name: 'object', in: 'path', required: true, schema: { type: 'string' }, description: 'Object name (snake_case)' },
-      ],
-      requestBody: {
-        required: true,
-        content: { 'application/json': { schema: { $ref: '#/components/schemas/CreateRequest' } } },
-      },
-      responses: {
-        '201': {
-          description: 'Record created',
-          content: { 'application/json': { schema: { $ref: '#/components/schemas/SingleRecordResponse' } } },
-        },
-        '400': { description: 'Validation error', content: { 'application/json': { schema: { $ref: '#/components/schemas/ApiError' } } } },
-        '401': { description: 'Unauthorized' },
-      },
-    },
-  };
-
-  // Single record operations
-  paths[`${basePath}/{object}/{id}`] = {
-    get: {
-      summary: 'Get a record',
-      description: 'Retrieve a single record by ID',
-      tags: ['CRUD'],
-      operationId: 'getRecord',
-      parameters: [
-        { name: 'object', in: 'path', required: true, schema: { type: 'string' }, description: 'Object name' },
-        { name: 'id', in: 'path', required: true, schema: { type: 'string' }, description: 'Record ID' },
-      ],
-      responses: {
-        '200': {
-          description: 'Record found',
-          content: { 'application/json': { schema: { $ref: '#/components/schemas/SingleRecordResponse' } } },
-        },
-        '404': { description: 'Record not found' },
-        '401': { description: 'Unauthorized' },
-      },
-    },
-    put: {
-      summary: 'Update a record',
-      description: 'Update an existing record by ID',
-      tags: ['CRUD'],
-      operationId: 'updateRecord',
-      parameters: [
-        { name: 'object', in: 'path', required: true, schema: { type: 'string' }, description: 'Object name' },
-        { name: 'id', in: 'path', required: true, schema: { type: 'string' }, description: 'Record ID' },
-      ],
-      requestBody: {
-        required: true,
-        content: { 'application/json': { schema: { $ref: '#/components/schemas/UpdateRequest' } } },
-      },
-      responses: {
-        '200': {
-          description: 'Record updated',
-          content: { 'application/json': { schema: { $ref: '#/components/schemas/SingleRecordResponse' } } },
-        },
-        '400': { description: 'Validation error' },
-        '404': { description: 'Record not found' },
-        '401': { description: 'Unauthorized' },
-      },
-    },
-    delete: {
-      summary: 'Delete a record',
-      description: 'Delete a record by ID',
-      tags: ['CRUD'],
-      operationId: 'deleteRecord',
-      parameters: [
-        { name: 'object', in: 'path', required: true, schema: { type: 'string' }, description: 'Object name' },
-        { name: 'id', in: 'path', required: true, schema: { type: 'string' }, description: 'Record ID' },
-      ],
-      responses: {
-        '200': {
-          description: 'Record deleted',
-          content: { 'application/json': { schema: { $ref: '#/components/schemas/DeleteResponse' } } },
-        },
-        '404': { description: 'Record not found' },
-        '401': { description: 'Unauthorized' },
-      },
-    },
-  };
-
-  return paths;
-}
-
-function generateMetadataPaths(basePath: string): Record<string, OpenApiPath> {
-  const paths: Record<string, OpenApiPath> = {};
-
-  paths[`${basePath}/meta`] = {
-    get: {
-      summary: 'Get platform metadata',
-      description: 'Returns platform-level metadata including registered types and capabilities',
-      tags: ['Metadata'],
-      operationId: 'getMetadata',
-      responses: {
-        '200': { description: 'Platform metadata' },
-      },
-    },
-  };
-
-  paths[`${basePath}/meta/types`] = {
-    get: {
-      summary: 'List metadata types',
-      description: 'Returns all registered metadata type names',
-      tags: ['Metadata'],
-      operationId: 'listMetadataTypes',
-      responses: {
-        '200': { description: 'List of metadata type names' },
-      },
-    },
-  };
-
-  paths[`${basePath}/meta/{type}`] = {
-    get: {
-      summary: 'List metadata by type',
-      description: 'Returns all metadata entries for the specified type',
-      tags: ['Metadata'],
-      operationId: 'listMetadataByType',
-      parameters: [
-        { name: 'type', in: 'path', required: true, schema: { type: 'string' }, description: 'Metadata type (e.g., object, view, flow)' },
-      ],
-      responses: {
-        '200': { description: 'List of metadata entries' },
-        '404': { description: 'Unknown metadata type' },
-      },
-    },
-  };
-
-  paths[`${basePath}/meta/{type}/{name}`] = {
-    get: {
-      summary: 'Get metadata by type and name',
-      description: 'Returns a single metadata entry by type and name',
-      tags: ['Metadata'],
-      operationId: 'getMetadataByName',
-      parameters: [
-        { name: 'type', in: 'path', required: true, schema: { type: 'string' }, description: 'Metadata type' },
-        { name: 'name', in: 'path', required: true, schema: { type: 'string' }, description: 'Metadata name' },
-      ],
-      responses: {
-        '200': { description: 'Metadata entry' },
-        '404': { description: 'Metadata not found' },
-      },
-    },
-  };
-
-  return paths;
-}
-
-function generateDiscoveryPaths(basePath: string): Record<string, OpenApiPath> {
-  return {
-    [`${basePath}/.well-known/objectstack`]: {
-      get: {
-        summary: 'Platform discovery',
-        description: 'Returns ObjectStack platform discovery information including available services and capabilities',
-        tags: ['Discovery'],
-        operationId: 'discover',
-        responses: {
-          '200': { description: 'Discovery response with platform info, services, and capabilities' },
-        },
-      },
-    },
-  };
-}
 
 function generateComponentSchemas(): Record<string, Record<string, unknown>> {
   const schemas: Record<string, Record<string, unknown>> = {};
@@ -282,8 +99,6 @@ function generateComponentSchemas(): Record<string, Record<string, unknown>> {
 
 // ─── Build OpenAPI Spec ──────────────────────────────────────────────
 
-const basePath = '/api';
-
 const openapi: Record<string, unknown> = {
   openapi: '3.1.0',
   info: {
@@ -299,19 +114,16 @@ const openapi: Record<string, unknown> = {
       url: 'https://www.apache.org/licenses/LICENSE-2.0',
     },
   },
+  // Kept: the REST server prepends the live request origin and keeps this as a
+  // trailing fallback entry, so dropping it would change the SERVED document —
+  // and this change is meant to be invisible there.
   servers: [
     { url: 'http://localhost:3000', description: 'Local development' },
   ],
-  tags: [
-    { name: 'CRUD', description: 'Data record operations' },
-    { name: 'Metadata', description: 'Platform metadata and introspection' },
-    { name: 'Discovery', description: 'Service discovery and capabilities' },
-  ],
-  paths: {
-    ...generateCrudPaths(basePath),
-    ...generateMetadataPaths(basePath),
-    ...generateDiscoveryPaths(basePath),
-  },
+  // No `tags`. The three that used to sit here (`CRUD` / `Metadata` /
+  // `Discovery`) existed only to name the removed route sections; no operation
+  // in any document carries them, and the served document's tag list is
+  // produced with its route section, from the tags the routes register.
   components: {
     schemas: generateComponentSchemas(),
     securitySchemes: {
@@ -335,10 +147,27 @@ const openapi: Record<string, unknown> = {
 // ─── Self-consistency gate (#5168) ───────────────────────────────────
 //
 // Runs BEFORE the write, so a document whose `$ref`s do not resolve is never
-// emitted at all. `gen:openapi` has no staleness gate (`check:generated`
+// emitted at all. `gen:openapi` still has no staleness gate (`check:generated`
 // reports it as one of the two ungated generators), so this is the only thing
-// standing between a silently-broken collector and the published
-// `GET /api/v1/openapi.json`. Throwing exits non-zero and fails the build.
+// standing between a silently-broken collector and the published artifact.
+// Throwing exits non-zero and fails the build.
+//
+// Since #5744 removed the hand-written route section, the emitted document
+// happens to carry ZERO `$ref`s — every one of the nine lived in a path
+// operation's request/response body. Be honest about what that means: on
+// today's document this call is VACUOUS, and it is retained for a reason that
+// is about tomorrow's, not a reason to feel covered by it now.
+//
+// The live hazard it guards is `$defs`. `z.toJSONSchema` emits reused and
+// recursive subschemas into a `$defs` block at the root of the schema it
+// RETURNS, pointing at them with root-relative `#/$defs/…` pointers. Each of
+// the nine is converted independently and then parked at
+// `components.schemas[Name]`, so the moment any contract schema becomes
+// recursive or shares a subschema, the pointer means `#/$defs/…` of the whole
+// OpenAPI document — which has no `$defs` — and every consumer that resolves it
+// gets nothing. None of the nine is in that shape today; `findDanglingRefs`
+// resolves by JSON Pointer rather than by a `#/components/schemas/` prefix
+// precisely so that day costs nobody a debugging session.
 assertRefsResolve(openapi);
 
 // Write output
@@ -350,5 +179,8 @@ const outPath = path.join(OUT_DIR, 'openapi.json');
 fs.writeFileSync(outPath, JSON.stringify(openapi, null, 2));
 console.log(`✅ Generated OpenAPI spec: ${outPath}`);
 console.log(`   Version: ${SPEC_VERSION}`);
-console.log(`   Paths: ${Object.keys(openapi.paths as object).length}`);
+// No `Paths:` line — the document has no `paths`, and a `Paths: 0` would read
+// as "the collector produced nothing" rather than "this artifact does not
+// describe routes". The route section is served by @objectstack/rest (#5588).
 console.log(`   Components: ${Object.keys((openapi.components as any).schemas).length}`);
+console.log(`   Route sections: none — served by @objectstack/rest (#5588, ADR-0076)`);

--- a/packages/spec/scripts/check-generated.ts
+++ b/packages/spec/scripts/check-generated.ts
@@ -159,7 +159,18 @@ const NO_GENERATOR: ReadonlyArray<{ check: string; why: string }> = [
  * follow-up, not a formality.
  */
 const UNGATED_GENERATORS: ReadonlyArray<{ gen: string; why: string }> = [
-  { gen: 'gen:openapi', why: 'the OpenAPI document is generated but no check gate compares it to the routes' },
+  // The `why` used to read "no check gate compares it to the routes". Since
+  // #5744 that names a reconciliation with no second party: the document
+  // carries no route section at all — built-in routes are produced at serve
+  // time by the package that mounts them (#5588 ruling C, #5078, ADR-0076), so
+  // there is nothing here to compare against a route table. What IS still
+  // ungated is staleness against `src/api`: nothing fails when a contract
+  // schema changes and the artifact is not regenerated. Coherence is covered
+  // (the generator self-checks before writing, #5168) — currency is not.
+  {
+    gen: 'gen:openapi',
+    why: 'the OpenAPI document is generated but nothing compares its components.schemas against src/api — a stale artifact fails nothing (it IS self-checked for coherence at write time, #5168, and since #5744 it describes no routes to reconcile)',
+  },
   { gen: 'gen:sbom', why: 'the SBOM is a release artifact, regenerated at publish time rather than checked in' },
 ];
 

--- a/packages/spec/scripts/lib/openapi-self-consistency.ts
+++ b/packages/spec/scripts/lib/openapi-self-consistency.ts
@@ -37,6 +37,23 @@
  *    is covered without touching this file.
  * 2. **No schema is silently degraded.** See `assertNoDegradedSchemas`.
  *
+ * ## Rule 1 after #5744 — vacuous today, retained for `$defs`
+ *
+ * Every `$ref` the document carried lived in the hand-written route section
+ * that #5744 removed (its producer is `packages/rest`, at serve time — #5588
+ * ruling C, ADR-0076). The artifact now emits **zero** refs, so rule 1 walks an
+ * empty set and is honestly described as vacuous rather than as coverage.
+ *
+ * It is kept because the shape it guards is one the surviving half can still
+ * reach: `z.toJSONSchema` parks reused and recursive subschemas in a `$defs`
+ * block at the root of the schema it RETURNS, and points at them with
+ * root-relative `#/$defs/…`. Each contract schema is converted independently
+ * and then parked under `components.schemas[Name]`, so such a pointer would
+ * address the OpenAPI document's root — which has no `$defs` — and resolve to
+ * nothing. None of the nine is recursive today; the "resolve by pointer, not by
+ * prefix" choice above is what makes that day cheap instead of a debugging
+ * session. `openapi-self-consistency.test.ts` reproduces it as a mutation.
+ *
  * Both are consulted BEFORE the document is written: a self-inconsistent
  * artifact is never emitted at all, rather than emitted and then complained
  * about. The gate is wired into the generator itself (not a separate `check:`

--- a/packages/spec/scripts/openapi-self-consistency.test.ts
+++ b/packages/spec/scripts/openapi-self-consistency.test.ts
@@ -23,6 +23,25 @@
 //      second group is the reverse verification: a gate that has never been
 //      observed failing is not known to be a gate.
 //
+// ── What #5744 changed here, and what it did NOT ──────────────────────────
+// The route section this generator used to hand-write is gone: it hit 0 of its
+// 10 operations on a real boot, and its one legitimate producer is the package
+// that mounts the routes (#5588 ruling C, ADR-0076, #5078). Two consequences,
+// both reflected below rather than papered over:
+//
+//   • All nine `$ref`s the document carried lived in those operations' request
+//     and response bodies, so `assertRefsResolve` on TODAY's artifact is
+//     vacuous — it walks a document with zero refs. The honest reaction is not
+//     to keep a route section alive so the assertion has something to chew on;
+//     it is to say so (`emits a document with no $ref at all`, below) and keep
+//     the reverse verification pointed at a shape the document can still reach.
+//     The mutations therefore inject their dangling ref into `components`, the
+//     surviving surface — including the `#/$defs/…` shape `z.toJSONSchema`
+//     really does emit the day a contract schema becomes recursive.
+//   • "This artifact describes no routes" is now an ownership boundary, not an
+//     accident, so it is pinned as one (`publishes no route section`, below).
+//     Re-adding a `paths` block here goes red on that test.
+//
 // ── Why a sandbox for the subprocess group ────────────────────────────────
 // The script resolves its output dir from its own `__dirname` (`../json-schema`
 // -> the package's real, gitignored artifact) and a concurrent
@@ -147,7 +166,9 @@ describe('assertNoDegradedSchemas', () => {
 let sandbox: string;
 
 /** Run a (possibly mutated) copy of `build-openapi.ts` in an isolated tree. */
-function runGenerator(mutate?: (src: string) => string): { status: number; output: string } {
+function runGenerator(
+  mutate?: (src: string) => string,
+): { status: number; output: string; dir: string; artifact: string } {
   const dir = fs.mkdtempSync(path.join(sandbox, 'gen-'));
   fs.cpSync(path.join(PKG_ROOT, 'scripts'), path.join(dir, 'scripts'), { recursive: true });
   for (const entry of ['src', 'node_modules', 'package.json']) {
@@ -167,8 +188,35 @@ function runGenerator(mutate?: (src: string) => string): { status: number; outpu
     encoding: 'utf-8',
     env: { ...process.env, NODE_OPTIONS: '--max-old-space-size=4096' },
   });
-  return { status: res.status ?? -1, output: `${res.stdout ?? ''}${res.stderr ?? ''}` };
+  return {
+    status: res.status ?? -1,
+    output: `${res.stdout ?? ''}${res.stderr ?? ''}`,
+    dir,
+    artifact: path.join(dir, 'json-schema', 'openapi.json'),
+  };
 }
+
+/** Read back the artifact a `runGenerator()` call just wrote. */
+function readArtifact(run: ReturnType<typeof runGenerator>): any {
+  expect(fs.existsSync(run.artifact), `the generator wrote no artifact:\n${run.output}`).toBe(true);
+  return JSON.parse(fs.readFileSync(run.artifact, 'utf-8'));
+}
+
+/**
+ * The seven paths the removed hand-written section published. Every one of them
+ * was a phantom — see `packages/rest/src/rest-openapi-route.test.ts`, which
+ * asserts the same list is absent from the SERVED document. Here the claim is
+ * the other half: the static artifact stopped producing them at the source.
+ */
+const REMOVED_BUILTIN_PATHS = [
+  '/api/{object}',
+  '/api/{object}/{id}',
+  '/api/meta',
+  '/api/meta/types',
+  '/api/meta/{type}',
+  '/api/meta/{type}/{name}',
+  '/api/.well-known/objectstack',
+];
 
 describe('build-openapi.ts end to end', () => {
   beforeAll(() => {
@@ -186,24 +234,91 @@ describe('build-openapi.ts end to end', () => {
     expect(status).toBe(0);
   });
 
-  it('writes a document in which every $ref resolves', () => {
-    const { status } = runGenerator();
-    expect(status).toBe(0);
+  it('writes a document whose components are complete and self-contained', () => {
+    const run = runGenerator();
+    expect(run.status).toBe(0);
     // Re-read the artifact the run just produced and check it independently of
     // the generator's own gate.
-    const dirs = fs
-      .readdirSync(sandbox)
-      .map((d) => path.join(sandbox, d, 'json-schema', 'openapi.json'))
-      .filter((p) => fs.existsSync(p));
-    const doc = JSON.parse(fs.readFileSync(dirs[dirs.length - 1], 'utf-8'));
+    const doc = readArtifact(run);
     expect(Object.keys(doc.components.schemas)).toHaveLength(9);
     expect(findDanglingRefs(doc)).toEqual([]);
   });
 
+  it('emits a document with no $ref at all — so the ref gate is vacuous TODAY', () => {
+    // Stated rather than hidden. All nine `$ref`s lived in the route section
+    // #5744 removed, so `findDanglingRefs(doc) === []` above is currently true
+    // because there is nothing to walk, not because a check passed. This test
+    // exists so that fact is written down where the next reader of the ref gate
+    // will see it — and so that the day a contract schema starts emitting
+    // `$defs` pointers, this expectation goes red and points at the reason the
+    // gate was kept (see `build-openapi.ts`'s comment above `assertRefsResolve`).
+    const doc = readArtifact(runGenerator());
+    const refs: string[] = [];
+    const walk = (node: any): void => {
+      if (!node || typeof node !== 'object') return;
+      if (Array.isArray(node)) return void node.forEach(walk);
+      for (const [k, v] of Object.entries(node)) {
+        if (k === '$ref' && typeof v === 'string') refs.push(v);
+        else walk(v);
+      }
+    };
+    walk(doc);
+    expect(refs).toEqual([]);
+  });
+
+  it('publishes no route section — those belong to @objectstack/rest (#5588, #5744)', () => {
+    // The ownership boundary, pinned. `paths` is ABSENT rather than `{}`:
+    // OpenAPI 3.1 makes it optional, and an empty object would assert "this API
+    // serves nothing" — false — where an absent key asserts nothing about
+    // routes, which is the only claim this artifact is entitled to make.
+    const doc = readArtifact(runGenerator());
+    expect(doc.paths, 'the static artifact must not describe routes').toBeUndefined();
+    // The three tags described exactly the removed sections; nothing carries
+    // them, and the served document produces its own tag list with its routes.
+    expect(doc.tags).toBeUndefined();
+
+    // Not just the container: none of the seven phantom paths may survive
+    // anywhere in the document, under any key.
+    const serialized = JSON.stringify(doc);
+    for (const phantom of REMOVED_BUILTIN_PATHS) {
+      expect(serialized, `'${phantom}' is still described by the static artifact`).not.toContain(
+        phantom,
+      );
+    }
+    for (const tag of ['CRUD', 'Metadata', 'Discovery']) {
+      expect(serialized).not.toContain(`"${tag}"`);
+    }
+  });
+
+  it('keeps exactly what packages/spec owns', () => {
+    // The other direction of the removal: the surviving half is a whole
+    // document, not a husk. These five keys are what `rest`'s serve-time
+    // pipeline reads out of the artifact (`rest-server.ts`), so a later
+    // "cleanup" that drops one of them changes the SERVED document.
+    const doc = readArtifact(runGenerator());
+    expect(Object.keys(doc).sort()).toEqual(['components', 'info', 'openapi', 'security', 'servers']);
+    expect(doc.openapi).toBe('3.1.0');
+    expect(doc.info.title).toBe('ObjectStack REST API');
+    expect(doc.info.version).toBe(
+      JSON.parse(fs.readFileSync(path.join(PKG_ROOT, 'package.json'), 'utf-8')).version,
+    );
+    expect(Object.keys(doc.components.securitySchemes).sort()).toEqual(['apiKey', 'bearerAuth']);
+    expect(doc.security).toEqual([{ bearerAuth: [] }]);
+    // The fallback server entry rest appends behind the live request origin.
+    expect(doc.servers).toEqual([{ url: 'http://localhost:3000', description: 'Local development' }]);
+  });
+
   // ── Reverse verification ────────────────────────────────────────────────
-  // Predicted direction for BOTH: RED (non-zero exit). These are not
+  // Predicted direction for ALL FOUR: RED (non-zero exit). These are not
   // decoration — before #5168 the generator exited 0 on a document with six
   // dangling refs, so "the gate can fail" is the claim under test.
+  //
+  // Since #5744 the ref mutations inject their dangling pointer into
+  // `components` rather than into a path operation: the literals they used to
+  // rewrite (`#/components/schemas/ApiError'` inside `generateCrudPaths`) no
+  // longer exist in the source, so the old mutations would fail
+  // `runGenerator`'s "mutation must actually change the source" guard and
+  // report a broken test rather than a working gate.
 
   it('goes RED when the lazySchema Proxy is rejected again (the original bug)', () => {
     const { status, output } = runGenerator((src) =>
@@ -217,22 +332,50 @@ describe('build-openapi.ts end to end', () => {
     expect(output).toContain('ApiError');
   });
 
-  it('goes RED when a $ref points at a schema that does not exist', () => {
+  it('goes RED when a component $ref points at a schema that does not exist', () => {
+    // A component referencing a sibling that was renamed — the shape the ref
+    // gate now guards, since nothing else in the document carries a `$ref`.
     const { status, output } = runGenerator((src) =>
-      src.replace(/#\/components\/schemas\/ApiError'/g, "#/components/schemas/ApiErrorTypo'"),
+      src.replace(
+        '  return schemas;',
+        "  return { ...schemas, Broken: { $ref: '#/components/schemas/ApiErrorTypo' } };",
+      ),
     );
     expect(status).not.toBe(0);
     expect(output).toMatch(/unresolvable \$ref/);
     expect(output).toContain('#/components/schemas/ApiErrorTypo');
   });
 
-  it('refuses to WRITE the artifact when the document is inconsistent', () => {
-    const dirsBefore = new Set(fs.readdirSync(sandbox));
-    runGenerator((src) =>
-      src.replace(/#\/components\/schemas\/ApiError'/g, "#/components/schemas/ApiErrorTypo'"),
+  it('goes RED on the `$defs` pointer z.toJSONSchema emits for a recursive schema', () => {
+    // The LIVE hazard the gate is retained for, reproduced as the converter
+    // really shapes it: `z.toJSONSchema` parks reused/recursive subschemas in a
+    // `$defs` block at the root of the schema it RETURNS and points at them
+    // with root-relative `#/$defs/…`. Parked under `components.schemas[Name]`,
+    // that pointer addresses the OpenAPI document's root — which has no
+    // `$defs` — so it resolves to nothing for every consumer. None of the nine
+    // contract schemas is recursive today; this is what happens on the day one
+    // becomes so.
+    const { status, output } = runGenerator((src) =>
+      src.replace(
+        '  return schemas;',
+        "  return { ...schemas, Recursive: { type: 'object', " +
+          "properties: { next: { $ref: '#/$defs/Recursive' } } } };",
+      ),
     );
-    const newDir = fs.readdirSync(sandbox).find((d) => !dirsBefore.has(d))!;
+    expect(status).not.toBe(0);
+    expect(output).toMatch(/unresolvable \$ref/);
+    expect(output).toContain('#/$defs/Recursive');
+  });
+
+  it('refuses to WRITE the artifact when the document is inconsistent', () => {
+    const run = runGenerator((src) =>
+      src.replace(
+        '  return schemas;',
+        "  return { ...schemas, Broken: { $ref: '#/components/schemas/ApiErrorTypo' } };",
+      ),
+    );
+    expect(run.status).not.toBe(0);
     // The gate runs before the write, so no half-broken document is published.
-    expect(fs.existsSync(path.join(sandbox, newDir, 'json-schema', 'openapi.json'))).toBe(false);
+    expect(fs.existsSync(run.artifact)).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5744

#5588 维护者裁定 **C** 的**第二棒(spec 半边)**。第一棒 PR #5821 已合入 `origin/main`(`75f82f3ac`),`registerOpenApiEndpoints` 流水线里 `enriched.paths = builtin.paths` —— serve 期已由 rest 按自身路由表自产 built-in 段并**整体丢弃**静态产物的 `paths`。因此本单是**零行为变化的清理**。

## 前置复核(在 `origin/main` 上)

| 事实 | 证据 |
|:---|:---|
| 第一棒已合入 | `git merge-base --is-ancestor 75f82f3ac origin/main` → YES |
| serve 期整体丢弃静态段 | `packages/rest/src/rest-server.ts:3271` `enriched.paths = builtin.paths;`(注释显式写 DISCARDED rather than merged) |
| 静态产物旧段确实还在发 | 摘除前 `pnpm --filter @objectstack/spec gen:openapi` → `Paths: 7`,9 个 `$ref` **全部**在 paths 段内、components 外 0 个 |

## 改了什么

**`packages/spec/scripts/build-openapi.ts`**

- 摘除 `generateCrudPaths` / `generateMetadataPaths` / `generateDiscoveryPaths` 三个函数、`interface OpenApiPath`、`const basePath = '/api'` 及其调用;
- 顺带摘除 `tags: [CRUD, Metadata, Discovery]` —— 这三个 tag 只为命名被摘掉的三段而存在,任何文档里都没有 operation 携带它们,serve 期的 tag 列表由 rest 与路由段一起产出(`enriched.tags = builtin.tags`),所以移除同样是零行为变化;
- **保留** `servers`(rest 把它作为兜底项接在实时请求源之后,删了会改变**服务出的**文档)、`security`、`info`、`components`;
- 控制台摘要去掉 `Paths:` 行(`Paths: 0` 会被读成「收集器什么都没产出」而不是「这份产物不描述路由」),换成一行明说路由段归属。

**`paths` 是「键不存在」而不是 `paths: {}`** —— 这是本单唯一需要拍板的形状细节,理由写在文件头注释里:OpenAPI 3.1 里 `paths` 可省(`paths`/`components`/`webhooks` 三者有其一即合法),而两种写法说的不是一件事。`paths: {}` 断言「这个 API 什么都不服务」,是假的;键不存在则对路由不作任何断言,这才是这份产物有资格作出的声明。消费侧唯一的读取点是 rest 的 `spec.paths ?? {}` 与 `enriched.paths = builtin.paths`,两种写法它都吃。

**产物新形状**(顶层 5 键):`openapi` / `info` / `servers` / `components`(`schemas` 9 条 + `securitySchemes`)/ `security`。

## #5168 自洽门:按新形状调整,**不留活口**

摘段后 9 个 `$ref` 一个不剩 —— 它们全住在被摘掉的 operation 请求/响应体里。这正是「断言还绿着,是因为什么都没产出」那一类,所以按三条处理,而不是为了让门「有东西可断言」保留任何静态段:

1. **如实标注空断言**:新增 `emits a document with no $ref at all — so the ref gate is vacuous TODAY`,把这个事实写在门旁边,而不是让下一位读者以为 `findDanglingRefs(doc) === []` 是覆盖。
2. **反向验证改指向幸存面**:旧的两条变异改写 `generateCrudPaths` 里的 `#/components/schemas/ApiError'` 字面量 —— 该字面量已随段消失,旧变异会撞上 `runGenerator` 的「mutation must actually change the source」守卫,变成报告测试坏了而不是报告门有效。新变异注入 `components`:
   - `Broken: { $ref: '#/components/schemas/ApiErrorTypo' }`(组件引用被改名的兄弟);
   - `Recursive: { ... $ref: '#/$defs/Recursive' }` —— **门保留下来真正要防的活风险**:`z.toJSONSchema` 把复用/递归子 schema 放进它**返回值**根部的 `$defs`,用根相对 `#/$defs/…` 指过去;九条各自独立转换后停在 `components.schemas[Name]` 下,该指针于是指向整份 OpenAPI 文档的根 —— 那里没有 `$defs`。九条今天都不是递归形状,这条变异就是「哪天有一条变成递归」的预演。

   **三条反向验证的预期方向都是 RED(非零退出),实测三条全 RED**,并各自匹配到具体的报错文本。
3. **补两条新钉子**:产物**不含**路由段(七条幽灵路径 + 三个 tag 逐条断言不存在,`paths`/`tags` 键为 undefined),以及产物**仍完整保留** spec 拥有的五个顶层键 —— 后者防的是把这次收缩做过头、连 rest serve 期要读的东西一起删掉。

`lib/openapi-self-consistency.ts` 的模块 TSDoc 同步补上「规则 1 今天为空断言、保留它是为了 `$defs`」这一节。

## `check:generated` 台账

`gen:openapi` 那条 `why` 原文是「no check gate compares it to the routes」。裁定 C 之下产物里没有路由,这句话名指的对账**没有第二方**。改写为真正剩下的缺口:没有任何东西把产物的 `components.schemas` 与 `src/api` 对账,**产物过期不会让任何东西变红**;自恰性由 #5168 在写盘前自检覆盖,**时效性**没有。(#5456 已依此关闭 not planned。)

`AGENTS.md` 里「Two generators have no gate at all — nothing verifies their output is **current**」未提路由,新现实下仍然成立,故未改。

## 验收对照

| 验收项 | 结果 |
|:---|:---|
| `gen:openapi` 绿、产物 `paths` 不含手写 built-in 段 | ✅ `Components: 9` / `Route sections: none`;`"paths" in doc === false`,七条幽灵路径与三个 tag 在整份 JSON 里 0 命中 |
| 服务出的 built-in 段仍在且正确 | ✅ `packages/rest` 全量 60 files / 833 tests 绿,含 #5588 那一组 7 条(`publishes no path the server does not mount`、`documents the real CRUD surface, with the real verbs` 等) |
| #5168 门与台账措辞与新现实一致 | ✅ 见上 |

### 关于 #5821 那条 serve 期钉子(`discards the static artifact section even though spec still emits it`)

按派单要求如实报告:该钉子直接读**本进程加载的**静态产物做比对,摘段后它的输入集合 `Object.keys(artifact.paths ?? {})` 变成**空集**,那个 `for` 循环因此成为空断言。从 rest 的解析路径实测:

```
resolved artifact: packages/spec/json-schema/openapi.json
artifact top-level keys: [ 'openapi', 'info', 'servers', 'components', 'security' ]
#5821 pin input set (stale paths): [] -> size 0
```

**它仍然是绿的,而且没有整体退化为空断言** —— 同一条 test 里循环之后的三条断言仍然咬合:`components.schemas` 键集与产物逐字相等、`securitySchemes` 深等、`info.title` 相等。也就是说它现在钉的是「spec 拥有的那半边原样穿过 serve 期」,这半边我这次特意没动。⛔ 没有为了让它「有东西可断言」而保留任何静态段。该 test 的**标题与注释**(「even though spec still emits it」)现在措辞过期了 —— 属 `packages/rest`,第一棒收官后本单不碰,已作为观察项记在报告里交 PM 决定。

## 变更集

`.changeset/openapi-static-artifact-contract-only.md`,`@objectstack/spec: major`。判 major 而非 minor:`@objectstack/spec/openapi.json` 是 `exports` + `files` 里的**已发布导出**,`paths` 与 `tags` 两个顶层键**消失**(不是变空),直接 `doc.paths` 取值的外部消费者会拿到 undefined。被删内容本身 0/10 命中、照它生成的客户端每个数据调用都 404,但「消费者会看到破坏」这一事实与「被删的东西本来就是错的」是两回事,按前者定档。要一份带路由的文档,唯一正确来源是运行中的服务:`GET {apiPath}/openapi.json`。

## 验证记录(全部前台阻塞执行)

```
pnpm --filter @objectstack/spec test scripts/openapi-self-consistency.test.ts --reporter=verbose
  → Test Files 1 passed (1) / Tests 21 passed (21)
    含 3 条反向验证全部 RED-as-predicted

pnpm --filter @objectstack/spec test          → Test Files 323 passed / Tests 8271 passed
pnpm --filter @objectstack/spec typecheck     → tsc --noEmit 绿;check:test-typecheck OK
pnpm --filter @objectstack/spec check:generated --reconcile-only
  → 18 check: + 13 gen: scripts, all classified (…2 ungated generators…)
pnpm --filter @objectstack/rest test          → Test Files 60 passed / Tests 833 passed
npx eslint (4 个改动文件) --no-inline-config   → exit 0
pnpm check:nul-bytes / doc-authoring / docs-audit-scope / role-word / adr-anchors /
     org-identifier / route-envelope / error-code-casing / published-files /
     engine-double-contract / release-notes   → 全绿
grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]' (4 个改动文件 + changeset) → clean
```

生成物纪律:`packages/spec/json-schema/` 已被根 `.gitignore` 忽略,产物不入库;`gen:schema`(在 `pnpm --filter '@objectstack/rest^...' build` 里)跑完后已复核 `openapi.json` 仍在且为新形状(#5371 的 rmSync 陷阱)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY


---
_Generated by [Claude Code](https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY)_