### PR TITLE
fix(spec)!: HierarchyScopeContext 声明 organizationId 为权威租户字段并转必填 (#5858)

### DIFF
--- a/.changeset/hierarchy-scope-organization-authority.md
+++ b/.changeset/hierarchy-scope-organization-authority.md
@@ -1,0 +1,49 @@
+---
+"@objectstack/spec": major
+---
+
+fix(spec)!: `HierarchyScopeContext.organizationId` is the authoritative tenancy field, and it is now required (#5858)
+
+`HierarchyScopeContext` declared `organizationId?: string | null` and
+`tenantId?: string | null` side by side with no doc saying which one carries the
+caller's active organization. That silence had a measured cost (#5852): the
+single in-repo producer (`@objectstack/plugin-sharing`) filled `organizationId`
+from a `SharingExecutionContext` whose only tenancy member is `tenantId`, so the
+read was structurally always `null`, while the real consumer — the enterprise
+`hierarchy-scope-resolver` — reads `organizationId`, saw `null`, and skipped
+tenant isolation. Both ends were individually contract-compliant; the pair was a
+reachable cross-organization read.
+
+The contract now says which field is authoritative, and enforces it structurally
+rather than in prose:
+
+- **`organizationId` is the authority** — the caller's active organization,
+  `null` = platform/unscoped, the same meaning `EvalUser.organizationId`
+  already carries. This is the repo's settled name for the concept, not a new
+  one: #3280 blessed `organizationId` as the developer-facing name for the
+  caller's active org (matching the `organization_id` column and
+  `current_user.organizationId` in RLS), #3290 removed the `session.tenantId`
+  alias in v11, and `scripts/check-org-identifier.mjs` gates it in CI.
+- **It is REQUIRED** — `organizationId: string | null`, never omitted. A
+  producer that forgets to state the caller's org now fails to compile instead
+  of handing every resolver an `undefined` it will read as "unscoped". Stating
+  "no org" is still allowed, but it must be stated: `null` is a value, not an
+  omission.
+- **`tenantId` is retained as a deprecated alias**, not removed. It stays the
+  generic driver-layer tenancy knob (a database-per-tenant kernel legitimately
+  puts an *environment* id there), and its doc now says a resolver must not
+  depend on it alone or use it as a stand-in for a `null` `organizationId`.
+  Its removal is a separate, deliberate retirement.
+- **`IHierarchyScopeResolver.resolveOwnerIds` documents the fail-closed
+  obligation**: when `organizationId` is `null`, an implementation must not
+  build the owner set as though no tenancy constraint applied — "no org" is
+  never "every org". Return owner-only (or throw, which the sharing layer
+  treats the same way); never widen.
+
+**Migration.** Breaking for *producers* of the context only — implementers of
+`IHierarchyScopeResolver` are unaffected (a required property is strictly easier
+to consume). A producer that omitted the key adds `organizationId: <the caller's
+active org, or null>`; a producer that was passing the org under `tenantId` must
+move it, which is the bug this closes rather than a rename to absorb. The only
+in-repo producer already supplied the key, so nothing in this repo changed
+shape.

--- a/packages/spec/src/contracts/sharing-service.test.ts
+++ b/packages/spec/src/contracts/sharing-service.test.ts
@@ -1,7 +1,11 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
-import type { RecordShareRecipientType, SharingRuleRecipientType } from './sharing-service';
+import type {
+  HierarchyScopeContext,
+  RecordShareRecipientType,
+  SharingRuleRecipientType,
+} from './sharing-service';
 import { ShareRecipientType } from '../security/sharing.zod';
 
 /**
@@ -124,5 +128,132 @@ describe('[#5125] ISharingService write-gate bypass documentation parity', () =>
     // to `org`, which short-circuits the filter before sharing is consulted),
     // so naming the write bypass there would itself be drift.
     expect(docOf.get('buildReadFilter')).not.toContain('modifyAllRecords');
+  });
+});
+
+/**
+ * [#5858] `HierarchyScopeContext` names ONE authoritative tenancy field.
+ *
+ * The interface declared `organizationId?` and `tenantId?` side by side with no
+ * doc saying which one carries the caller's active organization. The single
+ * in-repo producer filled `organizationId` from a `SharingExecutionContext`
+ * that only has `tenantId`, so the read was structurally always `null`; the
+ * real consumer (cloud `security-enterprise`) reads `organizationId`, saw
+ * `null`, and skipped tenant isolation. Both ends were "contract-compliant" and
+ * the pair leaked across organizations (#5852).
+ *
+ * The fix is on the contract, not on either consumer: `organizationId` is the
+ * authority (repo convention — #3280 blessed the name, #3290 removed the
+ * `session.tenantId` alias, `scripts/check-org-identifier.mjs` gates it) and is
+ * now REQUIRED, so a producer that forgets it fails to compile rather than
+ * handing every resolver an `undefined` org. `tenantId` survives as a
+ * deprecated alias — removal is its own retirement, not a rider here.
+ *
+ * Two kinds of pin below, because the change has two halves: type-level ones
+ * that tsc evaluates (`tsconfig.test.json` compiles this file — #5286), and
+ * prose ones, because prose is the other half of what was missing.
+ */
+describe('[#5858] HierarchyScopeContext tenancy authority', () => {
+  it('requires `organizationId` and keeps `tenantId` optional (compile-time)', () => {
+    // A caller with no active org states so EXPLICITLY. `null` is a value the
+    // contract carries (platform/unscoped), never an omission.
+    const platformScoped: HierarchyScopeContext = { userId: 'usr_1', organizationId: null };
+    const orgScoped: HierarchyScopeContext = {
+      userId: 'usr_1',
+      organizationId: 'org_east',
+      tenantId: 'env_prod',
+    };
+
+    // THE pin for the required-ness. Omitting the authoritative field is the
+    // exact producer bug #5852 measured; it must not compile. Deleting the `?`
+    // again turns this directive into an unused-`@ts-expect-error` error, and
+    // this file carries no entry in `test-typecheck-debt.json` — so its budget
+    // is zero and the gate goes red.
+    // @ts-expect-error `organizationId` is REQUIRED — omitting it must not compile (#5858)
+    const missingOrg: HierarchyScopeContext = { userId: 'usr_1' };
+
+    // The deprecated alias is NOT a substitute: supplying only `tenantId`
+    // leaves the authoritative field unstated, which is the same defect.
+    // @ts-expect-error `tenantId` does not satisfy the authoritative field (#5858)
+    const tenantOnly: HierarchyScopeContext = { userId: 'usr_1', tenantId: 'env_prod' };
+
+    expect(platformScoped.organizationId).toBeNull();
+    expect(orgScoped.organizationId).toBe('org_east');
+    expect(missingOrg.userId).toBe('usr_1');
+    expect(tenantOnly.tenantId).toBe('env_prod');
+  });
+
+  it('pins WHICH keys are mandatory, in both directions (compile-time)', () => {
+    // `-?` strips optionality, then `object extends Pick<T, K>` is true exactly
+    // when K was optional — so the union is the mandatory keys.
+    type RequiredKeys<T> = {
+      [K in keyof T]-?: object extends Pick<T, K> ? never : K;
+    }[keyof T];
+
+    const mandatory: Array<RequiredKeys<HierarchyScopeContext>> = ['userId', 'organizationId'];
+
+    // The other direction, and the ⛔-not-deleted guard in one: `tenantId` is
+    // still a member (a removal breaks the reference below) and still OPTIONAL
+    // (making the deprecated alias mandatory would be the mirror mistake).
+    // @ts-expect-error `tenantId` stays optional — it is a deprecated alias, not a second authority (#5858)
+    const notMandatory: RequiredKeys<HierarchyScopeContext> = 'tenantId';
+
+    expect(mandatory).toEqual(['userId', 'organizationId']);
+    expect(notMandatory).toBe('tenantId');
+  });
+
+  it('documents the authority, the deprecation, and the fail-closed obligation', async () => {
+    const ts = (await import('typescript')).default;
+    const { readFileSync } = await import('node:fs');
+    const { dirname, resolve } = await import('node:path');
+    const { fileURLToPath } = await import('node:url');
+
+    const file = resolve(dirname(fileURLToPath(import.meta.url)), 'sharing-service.ts');
+    const source = ts.createSourceFile(
+      file,
+      readFileSync(file, 'utf8'),
+      ts.ScriptTarget.Latest,
+      /* setParentNodes */ true,
+    );
+
+    const memberDocs = (name: string): Map<string, string> => {
+      const iface = source.statements.find(
+        (s): s is import('typescript').InterfaceDeclaration =>
+          ts.isInterfaceDeclaration(s) && s.name.text === name,
+      );
+      expect(iface, `${name} must still be an interface in this file`).toBeDefined();
+      const out = new Map<string, string>();
+      for (const member of iface!.members) {
+        if (!member.name || !ts.isIdentifier(member.name)) continue;
+        // `getFullText` carries leading trivia — the doc comment an IDE shows
+        // on hover — with no assumption about how it is wrapped.
+        out.set(member.name.text, member.getFullText(source));
+      }
+      return out;
+    };
+
+    const ctx = memberDocs('HierarchyScopeContext');
+    // Anti-vacuity 1: the enumeration found the real members, so a rename or a
+    // deletion cannot quietly empty the assertions. `tenantId` being listed IS
+    // the "not removed" pin — its retirement is a separate, deliberate change.
+    expect([...ctx.keys()]).toEqual(['userId', 'organizationId', 'tenantId']);
+
+    expect(ctx.get('organizationId')).toContain('AUTHORITATIVE');
+    expect(ctx.get('organizationId')).toContain('platform/unscoped');
+    expect(ctx.get('organizationId')).toContain('MUST scope its owner set by this field');
+
+    expect(ctx.get('tenantId')).toContain('@deprecated');
+    expect(ctx.get('tenantId')).toContain('Not the authority for hierarchy scoping');
+
+    // Anti-vacuity 2: the search DISCRIMINATES. `userId` is the honest negative
+    // — it is identity, not tenancy, and calling it authoritative would itself
+    // be drift.
+    expect(ctx.get('userId')).not.toContain('AUTHORITATIVE');
+
+    const resolver = memberDocs('IHierarchyScopeResolver');
+    expect([...resolver.keys()]).toEqual(['resolveOwnerIds']);
+    // A `null` organization is "no org", never "every org".
+    expect(resolver.get('resolveOwnerIds')).toContain('Fail CLOSED');
+    expect(resolver.get('resolveOwnerIds')).toContain('never widen');
   });
 });

--- a/packages/spec/src/contracts/sharing-service.ts
+++ b/packages/spec/src/contracts/sharing-service.ts
@@ -393,9 +393,40 @@ export interface IBusinessUnitGraphService {
  */
 export type HierarchyScope = 'unit' | 'unit_and_below' | 'own_and_reports';
 
+/**
+ * Caller identity a {@link IHierarchyScopeResolver} resolves a
+ * {@link HierarchyScope} against.
+ *
+ * **`organizationId` is the AUTHORITATIVE tenancy field** — the one a resolver
+ * scopes its owner-set query by. It is REQUIRED (`string | null`, never
+ * omitted) so a producer that forgets to supply it fails to compile instead of
+ * silently handing every resolver an `undefined` org: two sides can each look
+ * contract-compliant while the pair leaks across organizations (#5852/#5858).
+ * The name follows the repo-wide convention: #3280 made `organizationId` the
+ * blessed developer-facing name for the caller's active org (matching the
+ * `organization_id` column and `current_user.organizationId` in RLS) and #3290
+ * removed the `session.tenantId` alias in v11; `scripts/check-org-identifier.mjs`
+ * keeps it that way.
+ */
 export interface HierarchyScopeContext {
   userId: string;
-  organizationId?: string | null;
+  /**
+   * AUTHORITATIVE. Active organization ID of the caller (`null` =
+   * platform/unscoped) — same meaning as `EvalUser.organizationId`. A resolver
+   * MUST scope its owner set by this field; see
+   * {@link IHierarchyScopeResolver.resolveOwnerIds} for the `null` obligation.
+   */
+  organizationId: string | null;
+  /**
+   * Generic driver-layer tenancy knob, carried through for kernels that key
+   * isolation off something other than the organization (database-per-tenant
+   * deployments legitimately put an *environment* id here).
+   *
+   * @deprecated Not the authority for hierarchy scoping — a resolver MUST NOT
+   * depend on it alone, and MUST NOT treat it as a substitute for a `null`
+   * {@link HierarchyScopeContext.organizationId}. Read `organizationId`.
+   * Retained for compatibility only; removal goes through the retirement flow.
+   */
   tenantId?: string | null;
 }
 
@@ -420,6 +451,13 @@ export interface IHierarchyScopeResolver {
   /**
    * Owner ids whose records the caller may see under `scope` (must include the
    * caller). Empty/throw → caller falls back to owner-only.
+   *
+   * **Fail CLOSED on a missing organization.** When the authoritative
+   * {@link HierarchyScopeContext.organizationId} is `null`, an implementation
+   * MUST NOT build the owner set as though no tenancy constraint applied —
+   * "no org" is not "every org". Return owner-only (or throw, which the sharing
+   * layer treats the same way); never widen. Falling back to
+   * {@link HierarchyScopeContext.tenantId} instead is not fail-closed either.
    */
   resolveOwnerIds(context: HierarchyScopeContext, scope: HierarchyScope): Promise<string[]>;
 }


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5858

按 issue 上 PM 2026-08-06 裁决执行(B + C + fail-closed doc)。⛔ 未重开方向讨论。

## 改了什么

`packages/spec/src/contracts/sharing-service.ts` 一处契约:

1. **B —— `organizationId` 定为权威字段**。doc 写明「承载调用方的活动组织,`null` = platform/unscoped」,措辞与 `packages/spec/src/identity/eval-user.zod.ts:129` 的 `EvalUser.organizationId` describe 对齐,并在注释里点名依据(#3280 定名、#3290 v11 移除 `session.tenantId` 别名、`scripts/check-org-identifier.mjs` 硬门)。
2. **C —— 权威字段转必填**:`organizationId?: string | null` 改为 `organizationId: string | null`。producer 漏填从「doc 没说清楚」变成 typecheck 失败;「没有组织」仍然合法,但必须显式写成 `null` —— `null` 是值,不是缺省。
3. **`tenantId` 保留为 deprecated 别名,⛔ 未删除**。JSDoc 标 `@deprecated`,写明它仍是通用 driver 层租户旋钮(database-per-tenant 内核里合法地放 environment id),并明确「resolver 不得单独依赖它,也不得拿它顶替为 `null` 的 `organizationId`」。退役另行立单。
4. **`IHierarchyScopeResolver.resolveOwnerIds` 补 fail-closed 义务**:权威字段为 `null` 时实现方必须 fail-closed —— 「没有组织」永远不等于「所有组织」,返回 owner-only 或抛出(sharing 层同等处理),⛔ 不得静默按无租户约束构建 owner set,也不得退回读 `tenantId`。

外加 `.changeset/hierarchy-scope-organization-authority.md`(`@objectstack/spec: major`)与钉子测试。**未碰 `packages/plugins/plugin-sharing` 的任何代码**(生产逻辑与测试都没动 —— 见下方「机械补齐:零处」)。

## P1 / P2 / P3 前提核验(全部成立)

**P1 —— `check-org-identifier.mjs` 门与 #3280/#3290 公约仍活着:成立。**

```
$ git ls-tree origin/main -- scripts/check-org-identifier.mjs
100644 blob 007057a39f42e2e53e0d67b903efa86e8faa450d	scripts/check-org-identifier.mjs

$ git grep -n "check-org-identifier\|check:org-identifier" origin/main -- .github/workflows/ package.json
origin/main:.github/workflows/lint.yml:171:        run: pnpm check:org-identifier
origin/main:package.json:41:    "check:org-identifier": "node scripts/check-org-identifier.mjs",
```

脚本头部原文仍在陈述该公约:「#3280 made `organizationId` the blessed developer-facing name for the caller's active org across the JS authoring surface … #3290 REMOVED it from the hook/action `ctx.session` surface entirely (v11 major)」。同一段还自己记录了本裁决援引的那条:driver 层 `tenantId` 在 database-per-tenant 内核里合法地是 environment id,门禁刻意不匹配它。本地跑过一遍:`check-org-identifier: OK (1660 author-facing source file(s), no removed session.tenantId alias)`。

**P2 —— 仓内唯一 producer 仍是 `plugin-sharing/src/sharing-service.ts:875-880`:成立。**

`HierarchyScopeContext` 是结构化类型,构造点即「传给 `resolveOwnerIds` 的第一实参」。两轮普查:

```
$ git grep -n "HierarchyScopeContext" origin/main
origin/main:packages/spec/api-surface.json:3603:    "HierarchyScopeContext (interface)",
origin/main:packages/spec/src/contracts/sharing-service.ts:396:export interface HierarchyScopeContext {
origin/main:packages/spec/src/contracts/sharing-service.ts:424:  resolveOwnerIds(context: HierarchyScopeContext, scope: HierarchyScope): Promise...

$ git grep -n "resolveOwnerIds(" origin/main -- '*.ts' '*.tsx' '*.mts' '*.mjs' | grep -v CHANGELOG
origin/main:packages/plugins/plugin-sharing/src/sharing-service.ts:875:      const ids = await resolver.resolveOwnerIds(     ← 唯一构造点
origin/main:packages/qa/dogfood/test/showcase-scope-depth-fallback.dogfood.test.ts:71:    async resolveOwnerIds(c: any, sc: string)
origin/main:packages/qa/dogfood/test/showcase-scope-depth-write.dogfood.test.ts:82:      async resolveOwnerIds(c: any, sc: string)
origin/main:packages/qa/dogfood/test/showcase-scope-depth.dogfood.test.ts:60:    async resolveOwnerIds(c: any, sc: string)
origin/main:packages/spec/src/contracts/sharing-service.ts:424: (契约声明本身)
```

该类型在 spec 之外零 import,所以不存在「显式标注了该类型的第三处」。后 4 处全是 **resolver 实现**(消费侧,签名 `c: any`),不是构造点;`plugin-sharing/src/sharing-service.test.ts:853/867/881/893` 同理,是 stub resolver 而非 stub context。

**机械补齐:零处。** 唯一构造点 :875-880 本来就填了 `organizationId` 这个键(填的是恒 `null` 的值 —— 语义修复归 #5859,本单⛔不做),所以必填化在本仓内是零破坏。实测两个可能受影响的包 typecheck 全绿,没有一处需要补 `organizationId: null`:

```
$ pnpm --workspace-concurrency=2 --filter @objectstack/plugin-sharing --filter @objectstack/dogfood typecheck
packages/plugins/plugin-sharing typecheck: Done
packages/qa/dogfood typecheck: Done
```

如实申报一处与裁决预期的偏差:裁决预计「qa/dogfood 与 plugin-sharing 测试 stub」需要补键,实测不需要 —— 因为它们是 resolver 实现而不是 context 构造点。裁决对生产构造点「预计不红」的判断则完全成立。

**P3 —— PM 裁决评论仍是最后一条裁决:成立。** issue #5858 共 2 条评论:认领评论(12:28:59Z)+ PM 裁决评论(12:41:15Z)。裁决之后无任何评论,不存在更晚的维护者否决。

## 测试

钉子落在 `packages/spec/src/contracts/sharing-service.test.ts`(该文件在 `packages/spec/test-typecheck-debt.json` 里**无条目**,即错误预算为 0 —— 任何新错误直接让 `check:test-typecheck` 变红;#5286 的机制)。

- **编译期探针 ×2(钉 C 不回退)**:漏写 `organizationId` 的对象字面量、以及只给 `tenantId` 的对象字面量,各带一条 `@ts-expect-error`。
- **必填键双向钉**:用一个 RequiredKeys 映射类型取出必填键集合,正向断言恰为 `['userId', 'organizationId']`,反向用 `@ts-expect-error` 钉住 `tenantId` **仍是可选** —— 这同时是「⛔ 不删除 `tenantId`」的守卫(删了它,反向那行引用即断)。
- **散文钉(钉 B 与 fail-closed doc)**:走 TypeScript AST 读成员的 leading trivia(沿用同文件 #5125 那条钉子的写法),断言成员集合恰为 `['userId', 'organizationId', 'tenantId']`(反空过),`organizationId` doc 含 `AUTHORITATIVE` / `platform/unscoped` / `MUST scope its owner set by this field`,`tenantId` doc 含 `@deprecated` / `Not the authority for hierarchy scoping`,`resolveOwnerIds` doc 含 `Fail CLOSED` / `never widen`;并以 `userId` 作诚实反例(断言它**不**含 `AUTHORITATIVE` —— 它是身份不是租户),证明匹配是有区分度的。

**反向验证(方向为预先判定的「红」,实测吻合)。** 把 `?` 放回去、其余不动,重跑测试层 tsc:

```
src/contracts/sharing-service.test.ts(172,5): error TS2578: Unused '@ts-expect-error' directive.
src/contracts/sharing-service.test.ts(177,5): error TS2578: Unused '@ts-expect-error' directive.
src/contracts/sharing-service.test.ts(193,78): error TS2322: Type '"organizationId"' is not assignable to type '"userId"'.
```

3 条错误落在预算为 0 的文件上 → 红。恢复后复跑,`typecheck` 与 `check:test-typecheck` 均绿。

**正向证据(全部前台阻塞执行,共享 flock 串行):**

```
$ pnpm --filter @objectstack/spec test
 Test Files  323 passed (323)
      Tests  8270 passed (8270)

$ pnpm --filter @objectstack/spec typecheck
✓ check:test-typecheck --self-test — 8 semantic case(s) + the parser hold.
check:test-typecheck: OK — @objectstack/spec's test layer compiles under packages/spec/tsconfig.test.json;
  79 file(s) / 691 error(s) held in test-typecheck-debt.json (shrink-only)

$ pnpm --filter @objectstack/plugin-sharing test
 Test Files  13 passed (13)
      Tests  347 passed (347)

$ pnpm lint            # eslint . --no-inline-config,零输出
$ pnpm check:nul-bytes # OK (scanned 5726 tracked text file(s); no raw ASCII control bytes)
$ pnpm check:org-identifier / check:doc-authoring / check:adr-anchors / check:authz-resolver
  / check:error-code-casing / check:engine-double-contract / check:role-word   # 全绿
```

## 生成物

按纪律整体重生成(⛔ 未手改任何生成物,⛔ 未动 `authorable-surface.base.json` 锚点):`gen:schema` → `gen:openapi`(#5371)→ `gen:api-surface`。**结果:生成物零 diff** —— 本单改的是纯 TypeScript 接口(无 Zod schema、无新增/删除导出),`api-surface.json` 只记录名字级别的存在性,`HierarchyScopeContext` 早已在册。

```
$ git status --short
 M packages/spec/src/contracts/sharing-service.test.ts
 M packages/spec/src/contracts/sharing-service.ts

$ pnpm --filter @objectstack/spec check:generated
✓ All 10 generated artifacts are up to date.
$ pnpm --filter @objectstack/spec check:api-surface
@objectstack/spec public API surface + factory signatures unchanged ✓
$ pnpm --filter @objectstack/spec check:authorable-surface / check:docs / check:spec-changes
  / check:upgrade-guide / check:exported-any / check:dual-source-exports   # 全绿
```

`authorable-surface.base.json` 相对 `72bd873` 滞后 16 个 key —— 生成器自己声明这是预期而非错误,按纪律不做重锚。

## changeset 档位

`@objectstack/spec: major`。必填化对 **producer** 是 breaking(implementer 反而更容易 —— 必填属性只会让消费更简单)。当前处于 v17 rc 窗口(`packages/spec` 版本 `17.0.0-rc.2`,`.changeset/pre.json` 为 `mode: pre` / `tag: rc`),窗口内 `@objectstack/spec: major` 是既有惯例而非新开先例,同窗口在库的同档 changeset 包括 `adr-0113-required-write-contract.md`(同为「把一个宽松契约收紧成必填/强制」)、`adr-0114-field-errors-rename.md`、多个 `retire-*`。故本单按 major 落,⛔ 未为了凑档位把字段降级回 optional。

## 与同批其他单的关系(如实申报)

- **#5540**(`packages/spec/src/contracts/storage-service.ts` 摘 `IStorageService.list`):同目录不同文件,零共享符号。PM 预警的「生成物基线相交」在本单侧**没有发生** —— 本 PR 生成物零 diff(上面已实测),而 #5540 摘导出必然改 `api-surface.json`,所以串行接力时冲突面是单向的,只在 #5540 那一侧。
- **#5744**(`packages/spec/scripts/build-openapi.ts` 摘路由段):不同文件;本单未动任何 Zod schema,重跑 `gen:openapi` 后 `openapi.json` 零 diff。
- **#5832**(`shared/http.zod.ts` 的 `HttpMethod` def-key 碰撞):不同文件,且 `HierarchyScopeContext` 是纯 TS 接口、根本不进 json-schema 的 def-key 命名空间。
- **#5899**(`data/hook.zod.ts` 的 `HookEvent` 注释订正):不同文件,纯注释。

四单**均为「完全无影响」** —— 既没变简单,也没变难,更没变得不必要。没有任何一单的完成范围被本 PR 覆盖或抢跑。

## 未做的事(范围红线)

- ⛔ 未删除 `tenantId`(也未删 `organizationId`)—— 退役走单独流程。
- ⛔ 未碰 `packages/plugins/plugin-sharing`:producer 把租户值真正映射进 `organizationId` 的语义修复归 #5859(identity 车道),本单只把契约面钉住,让那处修复有一个明确的目标字段。
- ⛔ 未碰 cloud;consumer 侧的 fail-closed 断言归 cloud 对应单。


---
_Generated by [Claude Code](https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY)_