### PR TITLE
docs(plugins): packages.mdx 的 multi-org 开关改为 OS_TENANCY_POSTURE，legacy 布尔降为兼容 input (#5887)

### DIFF
--- a/content/docs/plugins/packages.mdx
+++ b/content/docs/plugins/packages.mdx
@@ -331,8 +331,8 @@ All services implement contracts from `@objectstack/spec/contracts` and are kern
 
 **Organization Scoping** — Multi-org (a.k.a. "soft" multi-tenant) row-level scoping. Ships as a **separate, closed-source enterprise package** — it is not part of the open framework repo. It composes with the Layer 0 tenant wall in `plugin-security` (`tenant-layer.ts`).
 
-- **Features**: `organization_id` auto-stamp on insert; every query is AND-composed against the tenant wall so rows never leak across organizations
-- **When to use**: Multi-organization SaaS where every row is scoped to an organization. Enable by setting `OS_MULTI_ORG_ENABLED=true` and installing `@objectstack/organizations`; if the flag is set but the package is missing, the platform refuses to boot (override with `OS_ALLOW_DEGRADED_TENANCY=1`)
+- **Features**: `organization_id` auto-stamp on insert; every query is AND-composed against the tenant wall, so no row outside the caller's organization scope is ever returned
+- **When to use**: Multi-organization SaaS where every row is scoped to an organization. Enable by setting `OS_TENANCY_POSTURE` to a walled posture — `group` (union read across every organization the caller belongs to) or `isolated` (the hard per-organization wall) — and installing `@objectstack/organizations`; if a walled posture is requested but the package is missing, the platform refuses to boot (override with `OS_ALLOW_DEGRADED_TENANCY=1`). The legacy `OS_MULTI_ORG_ENABLED` boolean is still honoured, but only as a fallback **input** when `OS_TENANCY_POSTURE` is unset, and it can only ever select `isolated` — never gate application code on it (ADR-0105 D1). See [Tenancy Postures & Membership](/docs/deployment/tenancy-modes) for how the posture resolves
 
 ### @objectstack/plugin-audit
 


### PR DESCRIPTION
Fixes #5887

`content/docs/plugins/packages.mdx:335`（`@objectstack/organizations (enterprise)` 小节）是全仓 `content/docs` 里最后一处把 legacy `OS_MULTI_ORG_ENABLED=true` 当作**启用 multi-org 的开关**教给读者的地方。**文件面只有这一页**（docs-only，不产出 changeset，PR 带 `skip-changeset`）。

## 前提复核（`origin/main` @ `628b028`，改动前）

| issue 断言 | 核实结果 |
|---|---|
| 该 bullet 原句仍在 | ✅ `git show origin/main:content/docs/plugins/packages.mdx` → 335 行逐字为「Enable by setting `OS_MULTI_ORG_ENABLED=true` and installing `@objectstack/organizations`」 |
| 全仓 `content/docs` 内仅此一处当**启用开关** | ✅ `git grep -c OS_MULTI_ORG_ENABLED origin/main -- content/docs` = 15 行（drivers 1 / environment-variables 3 / tenancy-modes 10 / packages 1）；除本行外的 14 行全部写作「superseded」「back-compat input」「不要 gate」 |
| 权威来源 | ✅ `packages/types/src/env.ts:89-122` 逐字标注 **DEMOTED**（ADR-0105 D1），并点名 cloud#1020（EE licence gate）与 #5233（`organization/create` 在纯 posture 部署上 403）两个已发生缺陷 |
| `group` posture 够不到 | ✅ `resolveTenancyPosture()`：posture 未设置时该布尔只派生 `isolated`；三值枚举在 `packages/spec/src/security/tenancy-posture.ts:40`，`group` 没有任何布尔拼法可达 |

前提全部成立，按 issue 正文的改法实施。

## 改法（一页之内，2 行）

**`When to use`（第 335 行）**：开关换成 `OS_TENANCY_POSTURE`，两个 walled posture 各带一句极短的谓词说明（`group` = 跨调用者所属组织的 union 读；`isolated` = 每组织硬墙），legacy 布尔降为一句「仅在 posture 未设置时作为回落 **input** 读取、且只能选中 `isolated`」并附上「never gate application code on it（ADR-0105 D1）」，末尾链到 `/docs/deployment/tenancy-modes`。

⛔ **不在本页重复 posture 解析表**——解析规则、成员策略、degraded 引导都在那一页，本页只留一个入口链接（与 #5746 的落地样例 PR #5884 同处理）。`OS_ALLOW_DEGRADED_TENANCY=1` 那半句按 issue 说明保留，仅把触发条件由「flag 被设置」改写为「请求了 walled posture」，以覆盖 `group`。

**`Features`（第 334 行，同小节相邻行，说明如下）**：原句「every query is AND-composed against the tenant wall **so rows never leak across organizations**」是 `isolated` 专属措辞——`group` 的墙是 `organization_id IN accessible_org_ids`，跨组织读是它的**设计语义**。上一行刚把 `group` 引入本页，这一行若不动就会在同一小节内自相矛盾，故一并改成「no row outside the caller's organization scope is ever returned」——对两个 walled posture 都成立。这是本次改动的直接后果，不是顺带扩面；文件面仍只有这一页。

## 自验

docs-only 改动，未触碰任何 package 源码，故无「受影响包」的 `pnpm test` / `typecheck` 可跑（如实报告，不凑证据）。实际跑的是覆盖本文件的门禁：

```
### check:nul-bytes
✓ check-nul-bytes --self-test: 56 assertions over a temp git repo (real scan() path)
check-nul-bytes: OK (scanned 5745 tracked text file(s); skipped 5 binary, 1 non-regular; no raw ASCII control bytes).
### check:doc-authoring
✓ doc authoring guard: 362 files clean — no bare metadata literals.
### check:role-word
check-role-word: OK (43 baselined file(s), no new occurrences).
### check:docs-audit-scope
✓ docs-accuracy-audit scope is in sync with content/docs/: 178 hand-written doc(s).
✓ release-owned pages are in scope and read-only: 9 page(s) under content/docs/releases/ review-only (findings → issues, never edited).
```

四项全绿（退出码均 0，均先跑各自 `--self-test`）。`check:role-word` 值得单独一提：本页在 `scripts/role-word-baseline.json` 里的基线是 1（第 326 行 plugin-security 的 "Role-based"），改动未增减该计数。

另外：

- 控制字符自查（超出 `check-nul-bytes` 扫描面）：`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]' content/docs/plugins/packages.mdx` 无命中。
- MDX 结构安全：改动两行内既无 `{`/`}`，也没有「小于号紧跟字母」的写法，不会被当成 JSX；链接写法 `[Tenancy Postures & Membership](/docs/deployment/tenancy-modes)` 与 `content/docs/protocol/objectql/schema.mdx:758` 已在 `main` 上的写法逐字一致（含文本里的裸 `&`），路径与 `content/docs/deployment/tenancy-modes.mdx` 对应。
- 本页 MDX 的编译由 CI 的 `build-docs` job 覆盖：`.github/workflows/ci.yml` 的 `docs` 路径过滤器含 `content/**`，本 PR 命中，会真正跑 `pnpm --filter @objectstack/docs build`。（本地未跑：该 job 需要整仓 `pnpm install` + Next 构建，对一处两行的文案改动不成比例；容器为并行 agent 共用。）

## 范围外发现

无。本次只读了 `content/docs` 的租户相关页与 `packages/types/src/env.ts`、`packages/spec/src/security/tenancy-posture.ts`，未发现新的不一致——`drivers.mdx:315`、`environment-variables.mdx:87-88`、`tenancy-modes.mdx` 三处对 legacy 布尔的描述逐条核对后均与代码相符，无需登记。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_