### PR TITLE
test(service-sms): sms settings provider 表 ↔ transports 双向契约测试 (#5773)

### DIFF
--- a/packages/services/service-settings/src/manifests/sms.manifest.ts
+++ b/packages/services/service-settings/src/manifests/sms.manifest.ts
@@ -21,6 +21,26 @@ const manifest = {
     { type: 'group', id: 'provider', label: 'Provider', required: false,
       description: 'Choose how this workspace sends outbound SMS.' },
 
+    // ⚠️ This options table is a CONTRACT, not a menu of aspirations: every
+    // value here must be one `@objectstack/service-sms` can actually build a
+    // transport for, and every transport it can build must appear here. The two
+    // sets are held equal by an executable assertion —
+    // `packages/services/service-sms/src/sms-manifest-providers.contract.test.ts`
+    // compares these values against `SMS_TRANSPORT_PROVIDERS` / `makeSmsTransport`
+    // and goes red the moment they diverge, in either direction, naming the
+    // value that drifted.
+    //
+    // Adding an option without a transport is not a harmless placeholder: the
+    // form validates, the save succeeds, and every send is silently downgraded
+    // to `LogSmsTransport` — a workspace that reports `status: 'sent'` and
+    // delivers nothing. That is exactly what mail shipped before #5094
+    // (`sendgrid` / `ses` offered with nothing behind them, while `resend` had a
+    // working transport nobody could pick), and what `os serve` did with an
+    // out-of-table `OS_SMS_PROVIDER` before #5713.
+    //
+    // `log` is listed and labelled for what it does. It is the one option that
+    // does not deliver, but it does not *pretend* to — which is what makes
+    // "offered" and "deliverable" the same set rather than merely overlapping.
     { type: 'select', key: 'provider', label: 'Provider', required: true, default: 'log',
       options: [
         { value: 'log', label: 'None (log only — no real delivery)' },

--- a/packages/services/service-sms/package.json
+++ b/packages/services/service-sms/package.json
@@ -22,6 +22,7 @@
     "@objectstack/spec": "workspace:*"
   },
   "devDependencies": {
+    "@objectstack/service-settings": "workspace:*",
     "@types/node": "^26.1.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"

--- a/packages/services/service-sms/src/sms-manifest-providers.contract.test.ts
+++ b/packages/services/service-sms/src/sms-manifest-providers.contract.test.ts
@@ -1,0 +1,203 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// The `sms` settings dropdown ↔ this package's transports (#5773).
+//
+// The invariant, made executable: **every provider an admin can select must be
+// one this package can actually deliver through, and every provider this
+// package can deliver through must be selectable.** Two halves of one fact, and
+// the mail side has already paid for both of them coming apart (#5094):
+// `sendgrid` / `ses` were offered by `mail.manifest.ts` with no transport
+// behind them — the form validated, the save succeeded, and no mail was ever
+// sent — while `resend`, which had a working transport all along, could not be
+// picked at all.
+//
+// The sms sides are, today, exactly equal. That is the whole reason this file
+// exists: nothing was holding them equal. `sms.manifest.ts` carried one literal
+// list and `transports/index.ts` carried another, maintained independently, and
+// a drift in either direction would have shipped in silence — an admin picking
+// a provider that logs instead of sending (the #5713 failure, from the settings
+// face rather than the `OS_SMS_PROVIDER` face), or a working transport nobody
+// can reach.
+//
+// This is deliberately a CROSS-PACKAGE assertion rather than a third mirrored
+// literal. A list pinned inside this package can be "fixed" by editing the
+// other list, which is precisely how two hand-maintained copies drift.
+// `@objectstack/service-settings` is therefore a **devDependency** here —
+// test-only, no runtime edge, and no cycle: service-settings' dependency
+// closure (core, metadata-core, platform-objects, spec, types) does not contain
+// this package. Same shape and same direction as the mail precedent, where
+// `plugin-email` (the transport owner) holds
+// `mail-manifest-providers.contract.test.ts` and devDepends on the settings
+// service. The registry of manifests must not have to know every provider
+// implementation; the provider proves it satisfies the published contract.
+
+import { describe, it, expect } from 'vitest';
+import { smsSettingsManifest } from '@objectstack/service-settings';
+import {
+  makeSmsTransport,
+  SMS_TRANSPORT_PROVIDERS,
+  isSmsTransportProvider,
+  type MakeSmsTransportOptions,
+} from './transports/index.js';
+import { LogSmsTransport } from './sms-service.js';
+import { AliyunSmsTransport } from './transports/aliyun.js';
+import { TwilioSmsTransport } from './transports/twilio.js';
+
+/**
+ * The `provider` specifier, read off the shipped manifest.
+ *
+ * Every read in this file is scoped to `key === 'provider'` on purpose: the
+ * `sms` namespace is expected to grow keys that have nothing to do with the
+ * transport vocabulary (#2814 adds `daily_quota` / `daily_quota_per_tenant`
+ * number specifiers to this same manifest). Those carry no `options` table and
+ * a different key, so they never enter this assertion surface — adding them
+ * neither needs a change here nor can break these tests.
+ */
+function providerSpecifier(): Record<string, any> {
+  const spec = (smsSettingsManifest.specifiers as Array<Record<string, any>>).find(
+    (s) => s.key === 'provider',
+  );
+  expect(spec, 'sms manifest must declare a `provider` specifier').toBeDefined();
+  return spec!;
+}
+
+/** The `provider` select's option values. */
+function providerOptions(): string[] {
+  const options = providerSpecifier().options as Array<{ value: string }> | undefined;
+  expect(options, 'the `provider` specifier must declare an `options` table').toBeDefined();
+  return options!.map((o) => o.value);
+}
+
+/**
+ * Per-provider fixture: the minimal credentials that let the provider be built
+ * for real, and the transport class it must build INTO.
+ *
+ * Keeping the expected class beside the build args (rather than as a row of
+ * standalone `toBeInstanceOf` assertions) is what stops this file from becoming
+ * the third hand-maintained copy of the vocabulary it exists to police: the
+ * table's key set is asserted equal to `SMS_TRANSPORT_PROVIDERS` below, so a
+ * provider added to the vocabulary without a fixture fails here instead of
+ * quietly going unexercised.
+ */
+const PROVIDER_FIXTURES: Record<
+  string,
+  { args: MakeSmsTransportOptions; transport: abstract new (...args: any[]) => unknown }
+> = {
+  log: { args: { provider: 'log' }, transport: LogSmsTransport },
+  aliyun: {
+    args: {
+      provider: 'aliyun',
+      options: { accessKeyId: 'LTAI_test', accessKeySecret: 'test-secret', signName: 'ObjectStack' },
+    },
+    transport: AliyunSmsTransport,
+  },
+  twilio: {
+    args: {
+      provider: 'twilio',
+      options: { accountSid: 'AC_test', authToken: 'test-token', from: '+15005550006' },
+    },
+    transport: TwilioSmsTransport,
+  },
+};
+
+describe('sms settings dropdown ↔ sms transports', () => {
+  // The two directions are separate `it`s so each drift fails on its own and
+  // names its own values, rather than one set-equality that reds for both and
+  // leaves the reader to work out which way it went.
+
+  it('offers no provider the transports cannot build (⊆)', () => {
+    const buildable: readonly string[] = SMS_TRANSPORT_PROVIDERS;
+    const orphanOptions = providerOptions().filter((p) => !buildable.includes(p));
+    expect(
+      orphanOptions,
+      `sms.manifest.ts offers provider(s) with no transport behind them: ${JSON.stringify(orphanOptions)}. `
+        + `An admin can select one, the form validates, the save succeeds — and every send is silently `
+        + `downgraded to LogSmsTransport (the #5094 defect shape). Either add a transport to `
+        + `SMS_TRANSPORT_PROVIDERS / makeSmsTransport, or drop the option.`,
+    ).toEqual([]);
+  });
+
+  it('hides no provider the transports can build (⊇)', () => {
+    const offered = providerOptions();
+    const unreachable = SMS_TRANSPORT_PROVIDERS.filter((p) => !offered.includes(p));
+    expect(
+      unreachable,
+      `SMS_TRANSPORT_PROVIDERS can deliver through provider(s) the settings page never lists: `
+        + `${JSON.stringify(unreachable)}. That is the 'resend' half of #5094 — a working transport `
+        + `nobody can pick. Add the option to the \`provider\` select in sms.manifest.ts.`,
+    ).toEqual([]);
+  });
+
+  it('lists each provider exactly once', () => {
+    // Set equality above cannot see a duplicated option value; the rendered
+    // dropdown would show the same provider twice.
+    const offered = providerOptions();
+    const duplicated = offered.filter((p, i) => offered.indexOf(p) !== i);
+    expect(duplicated, `duplicate option value(s) in the \`provider\` select: ${JSON.stringify(duplicated)}`)
+      .toEqual([]);
+  });
+
+  it('exercises every provider in the vocabulary — no fixture, no coverage', () => {
+    // Deliberately a RUNTIME assertion rather than typing the table as
+    // `Record<SmsProviderTag, …>`: this package's tsconfig excludes its own
+    // test files (its TEST_DEBT entry in scripts/check-type-check-coverage.mjs),
+    // so a type-level exhaustiveness check written here would be evaluated by
+    // no tsc program at all — green forever, deletable without a trace. That is
+    // the phantom-check shape #5286 is about; an assertion vitest runs is not.
+    expect(new Set(Object.keys(PROVIDER_FIXTURES))).toEqual(new Set(SMS_TRANSPORT_PROVIDERS));
+  });
+
+  it('builds the right transport class for every option the dropdown offers', () => {
+    for (const provider of providerOptions()) {
+      const fixture = PROVIDER_FIXTURES[provider];
+      expect(fixture, `no build recipe for offered provider '${provider}'`).toBeDefined();
+      // Not just "did not throw" — the right transport class per tag. A
+      // `switch` arm that fell through to the wrong constructor would pass a
+      // bare truthiness check and deliver through the wrong vendor.
+      expect(
+        makeSmsTransport(fixture!.args),
+        `provider '${provider}' must build a ${fixture!.transport.name}`,
+      ).toBeInstanceOf(fixture!.transport);
+    }
+  });
+
+  it('defaults to a provider that is both offered and buildable', () => {
+    const fallback = providerSpecifier().default;
+    // `log` is the one option that does not deliver — and it does not pretend
+    // to: the label says "no real delivery". SMS has no credential-free real
+    // transport, so the default has to be the visible opt-out rather than a
+    // vendor that would fail on the first send.
+    expect(fallback).toBe('log');
+    expect(providerOptions()).toContain(fallback);
+    expect(isSmsTransportProvider(fallback)).toBe(true);
+  });
+});
+
+describe('isSmsTransportProvider ↔ the same option list', () => {
+  // The CLI's start-up refusal of an out-of-table `OS_SMS_PROVIDER` (#5713,
+  // PR #5771) judges operator input with this predicate. It and the settings
+  // dropdown must be the same vocabulary, or the two configuration faces of one
+  // provider choice disagree about what is configurable.
+
+  it('accepts every provider the dropdown offers', () => {
+    for (const provider of providerOptions()) {
+      expect(isSmsTransportProvider(provider), `dropdown offers '${provider}' but the predicate refuses it`)
+        .toBe(true);
+    }
+  });
+
+  it('refuses values the dropdown does not offer', () => {
+    // `twilo` is the real typo #5713 opens with: it reached makeSmsTransport,
+    // threw, was caught, and became a LogSmsTransport that answered every OTP
+    // send `status: 'sent'`.
+    for (const bogus of ['twilo', 'aliyun_sms', 'sendgrid', '', 'LOG']) {
+      expect(isSmsTransportProvider(bogus), `'${bogus}' must not narrow to a provider tag`).toBe(false);
+      expect(providerOptions()).not.toContain(bogus);
+    }
+  });
+
+  it('refuses to build a provider outside the vocabulary', () => {
+    expect(() => makeSmsTransport({ provider: 'twilo' as never }))
+      .toThrow(/unknown provider 'twilo'/);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2349,6 +2349,9 @@ importers:
         specifier: workspace:*
         version: link:../../spec
     devDependencies:
+      '@objectstack/service-settings':
+        specifier: workspace:*
+        version: link:../service-settings
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -262,7 +262,7 @@ const TEST_DEBT = {
   '@objectstack/platform-objects': { tests: 8, errors: 3, note: 'TS2339 x2, TS7006 x1.' },
   '@objectstack/plugin-sharing': { tests: 11, errors: 3, note: 'TS6133 x2, TS18048 x1.' },
   '@objectstack/http-conformance': { tests: 2, errors: 1, note: 'TS2740 x1.' },
-  '@objectstack/service-sms': { tests: 3, errors: 1, note: 'TS2493 x1.' },
+  '@objectstack/service-sms': { tests: 4, errors: 1, note: 'TS2493 x1, in transports.test.ts. Re-measured at 4 files in #5773, which added sms-manifest-providers.contract.test.ts: the count moved, the error did not — the new file is type-clean with the exclusion lifted.' },
   '@objectstack/connector-rest': { tests: 3, errors: 1, note: 'TS6133 x1.' },
 };
 


### PR DESCRIPTION
Fixes #5773

mail 侧自 #5094 起有一道可执行的闸门,把 `mail.manifest.ts` 的 provider 取值与 `EMAIL_TRANSPORT_PROVIDERS` / `makeTransport` **双向**锁死;sms 侧一直只是两份独立维护的字面量「恰好一致」,任一方向漂移都不会有任何东西报警。PR #5771(#5713)把 sms transports 的词表提成具名导出 `SMS_TRANSPORT_PROVIDERS` 之后,写这道测试的原料齐备,本 PR 补上。

## 前提复核(实施前,基于 origin/main `5582e18`)

正文四条事实全部成立,无一失效:

- `SMS_TRANSPORT_PROVIDERS = ['log','aliyun','twilio'] as const` 在 `transports/index.ts:27`,`isSmsTransportProvider()` 在 :38,均经 `service-sms/src/index.ts:13-14` 出包;`SmsProviderTag` 由数组派生。
- `sms.manifest.ts` 的 `provider` select 仍是三项字面量,未变。
- `sms.manifest.test.ts` 仍只断言 schema / 权限 / 两个密钥字段,**无任何取值集合比对**。
- `grep smsSettingsManifest` 全仓命中只在 `service-settings` 包内部,transport 侧无消费者。

## 落点判定(正文列的第一步待决项)

**实测两个方向都不成环**,所以这不是被依赖图逼出来的选择,而是架构选择:

| 方向 | 依赖闭包(含自身 devDeps) | 成环? |
|---|---|---|
| `service-settings` | core, metadata-core, platform-objects, spec, types | 不含 service-sms |
| `service-sms` | core, spec | 不含 service-settings |

**选了「测试住 `service-sms`(transport owner),`service-settings` 作 devDependency」**,与 mail 先例同向(`plugin-email` 持 `mail-manifest-providers.contract.test.ts`,`service-settings` 是它的 devDependency,test-only 无运行时边)。理由:`service-settings` 是与具体 provider 无关的 manifest 注册表,它为 mail / sms / storage… 各发一张表;若让它反向 import 每一个 provider 实现,每加一张表就多一条边,注册表逐步变成所有实现的汇聚点。**由 provider 自证它满足已发布的契约**,箭头才只有一个方向。

一条不构成区分度、但值得写明的事实:**两侧今天都不会对这个测试文件做类型检查** —— `service-sms` 有 `typecheck` 脚本但 tsconfig 排除了 `**/*.test.ts`(TEST_DEBT 在册),`service-settings` 则根本没有 `typecheck` 脚本(DEBT 在册)。所以此项不参与落点判定,由上面的分层理由定。

## 测试内容(两层比对,照 mail 先例)

第一层 —— 集合等价,**两个方向各自独立成 `it`**(正文要求「各自变红」),断言信息点名漂移的取值:

- `offers no provider the transports cannot build (⊆)` —— 提供了却没有 transport(#5094 的 `sendgrid`/`ses` 形状)
- `hides no provider the transports can build (⊇)` —— 有 transport 却选不到(#5094 的 `resend` 形状)
- 外加 `lists each provider exactly once` —— 集合等价看不见重复项

第二层 —— 可构建性:每个下拉项都要 `makeSmsTransport` 出**正确的 transport 类**(不是「没抛异常」);再加 `isSmsTransportProvider` 与下拉框同词表(#5713 的 CLI 启动期拒收判据必须与 settings 面同一份词表),以及默认值 `log` 既在表内又可构建。

## 反向验证(方向先预测,含一次预测落空)

三个探针,每次改完重新 build `service-settings` 再跑(测试读的是构建产物):

| 探针 | 预测 | 实测 |
|---|---|---|
| A:manifest 加假 provider `sendgrid_sms` | ⊆ 红并点名 | ✅ 3 红:⊆ 点名 `["sendgrid_sms"]`、无 build recipe、predicate 拒收 |
| B:manifest 删掉 `twilio` 选项 | ⊇ 红并点名,**恰好 1 条** | ⚠️ **首轮实测 2 条**,见下 |
| C:从数组侧删掉 `twilio` | ⊆ 红 + fixture 覆盖红 | ✅ 3 红,均点名 `twilio` |

**探针 B 首轮预测落空,而且落空是有价值的**:多出来的第二条红来自我原先照抄 mail 先例写的三行 `expect(byProvider.twilio).toBeInstanceOf(TwilioSmsTransport)` —— 那三行把词表在本文件里又抄了**第三遍**,而这正是本测试存在的理由(「一份字面量可以靠改另一份字面量来『修好』」)。它的副作用是双向的:删一项时重复报红,加一项时反而**静默不覆盖**(新 provider 没有对应断言行也不会红)。

改法:把 build 参数与期望类合并成 `PROVIDER_FIXTURES` 表,并加一条 `exercises every provider in the vocabulary` 断言表的键集 ≡ `SMS_TRANSPORT_PROVIDERS`。改完后 B 恰好 1 红(⊇ 点名 `["twilio"]`),A 仍 3 红,C 变成 3 红(新增的 fixture 覆盖断言接住了「加了 provider 没加 fixture」)。

该断言**刻意写成运行时断言而非 `Record< SmsProviderTag, … >` 类型层穷尽**:本包 tsconfig 排除自己的测试文件,类型层写在这里没有任何 tsc program 会求值 —— 就是 #5286 的 phantom check 形状,删掉它每道闸门照样绿。

## 其余改动

- `sms.manifest.ts` provider 表处加注释(「a CONTRACT, not a menu of aspirations」形),指名执行它的测试文件路径与两个方向。
- `scripts/check-type-check-coverage.mjs` 的 service-sms TEST_DEBT:`tests: 3 → 4`。实测(临时解除 exclusion 跑 `tsc --noEmit`)错误数**仍是 1**(`transports.test.ts` 那条既有 TS2493),新文件本身零类型错误 —— 数在动、错误没动,note 里写明了。

## 验证

逐条枚举 `.github/workflows/lint.yml`,凡 diff 可能触及的全跑(容器级验证锁 + heap 上限 + `--filter` 范围化):`lint` / `check:nul-bytes` / `check:type-check-coverage` / `check:published-files` / `check:engine-double-contract` / `check:startup-registry-verdict` / `check:durability-log-level` / `check:service-providers` / `check:adr-anchors` / `check:doc-authoring` / `check:i18n` / `check:i18n-coverage` 全绿;`service-sms` + `cli` typecheck 绿;`service-settings` 15 文件 243 测试、`service-sms` 4 文件 39 测试全绿。

(`check:i18n` / `check:i18n-coverage` 首轮红是新 worktree 的前置未满足 —— 未构建 CLI、未全量 build,AGENTS.md §9 那一类;补上 `turbo run build` 后两者均绿,与本 diff 无关。)

## ⛔ 无 changeset

最终 diff = 新测试 + 一段源码注释 + 一条 devDependency + lockfile + 一个 ledger 计数,**不含任何运行时行为变化**,按 issue 要求不写空 changeset。已自行打 `skip-changeset` 标签。

---
_Generated by [Claude Code](https://claude.ai/code/session_015a5qkLzpGXhLL2F5gvJ7dD)_