### PR TITLE
docs(ui): 给 apps.mdx 补 contextSelectors / defaultAgent 两个作者面键 (#5891)

### DIFF
--- a/content/docs/ui/apps.mdx
+++ b/content/docs/ui/apps.mdx
@@ -49,8 +49,10 @@ const crmApp = defineApp({
 | `isDefault` | `boolean` | optional | Is default app |
 | `navigation` | `NavigationItem[]` | optional | Navigation tree |
 | `areas` | `NavigationArea[]` | optional | Partition navigation by business domain — see [Areas](#areas) |
+| `contextSelectors` | `AppContextSelector[]` | optional | Sidebar scope dropdowns whose value is injected into navigation items — see [Context Selectors](#context-selectors) |
 | `branding` | `AppBranding` | optional | Visual customization |
 | `requiredPermissions` | `string[]` | optional | Required permissions to access |
+| `defaultAgent` | `string` | optional | Platform agent bound to this app's ambient AI chat — see [Default Agent](#default-agent) |
 
 <Callout type="warn">
   **Older app samples no longer parse** — check yours before copying it forward.
@@ -410,6 +412,170 @@ const fieldServiceApp = defineApp({
 });
 ```
 
+## Context Selectors
+
+A **context selector** is an app-level *scope* dropdown — a Package filter, an
+Environment switcher, a Locale picker — rendered at the top of the sidebar,
+above the navigation tree. Its current value is published under the selector's
+own `id` and substituted into navigation items as `{<id>}`, so picking an option
+re-scopes every item below it without the value being wired into each item by
+hand.
+
+The substitution is the one already used by `{current_user_id}` /
+`{current_org_id}` (see [Object Navigation](#object-navigation)). The active
+value is injected into:
+
+- an object item's `recordId`, and each value in its `filters` map;
+- a `page` or `component` item's string `params` values.
+
+A variable with no active value resolves to nothing, and the entry it appears in
+is dropped from the resolved URL rather than emitted empty — an unscoped shell
+still produces well-formed links.
+
+### Selector properties
+
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `id` | `string` | ✅ | Selector id (`snake_case`) — **also the template-variable name**: `id: 'active_package'` is referenced as `{active_package}` |
+| `label` | `string` | ✅ | Dropdown label |
+| `icon` | `string` | optional | Icon name (Lucide) |
+| `optionsSource` | `object` | ✅ | Where the dropdown's options come from — see below |
+| `allValue` | `string` | optional | Sentinel meaning "nothing concrete is selected yet" (default: `''`) |
+| `persist` | `'query' \| 'session' \| 'none'` | optional | How the selection survives navigation (default: `'query'`) |
+
+`optionsSource` re-uses an existing REST surface instead of requiring a bespoke
+option API: the shell fetches `endpoint` and maps each returned row to one
+option.
+
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `endpoint` | `string` | ✅ | REST endpoint returning the option rows (e.g. `/api/v1/packages`) |
+| `valueKey` | `string` | optional | Row property used as the option value; dotted paths allowed (default: `id`) |
+| `labelKey` | `string` | optional | Row property used as the option label; dotted paths allowed (default: `name`) |
+| `filter` | `{ key, op, value }[]` | optional | Predicates (AND) a row must satisfy before it becomes an option |
+
+Each `filter` entry compares the dotted path `key` against `value` using `op` —
+`eq` (default), `ne`, `in` or `nin`. That is what keeps a shared endpoint
+generic while an individual selector narrows what it offers.
+
+### A selector is a mandatory scope
+
+There is no "All" row, and no key asks for one. A selector exists to scope a
+surface, so an "All" choice would clear the very thing it declares — on Studio's
+package scope that would mean listing the platform's own `system` / `cloud`
+kernel metadata to a developer who scoped to their own package. The shell
+instead **auto-selects the first option** as soon as the list resolves and
+nothing concrete is selected yet.
+
+That is what `allValue` names: the value the scope variable holds *before* a
+concrete pick — not an "All" option. Empty string is almost always right; set it
+only if a real option value would collide with `''`. To widen what a selector
+offers, widen `optionsSource.filter`.
+
+<Callout type="warn">
+  **One scope per app today.** `contextSelectors` is an array, but the shipped
+  shell tracks a single active scope: the selection is reflected onto the URL
+  under one fixed query key that *every* declared selector reads back, so a
+  second selector mirrors the first instead of scoping independently. Declare
+  one selector per app.
+</Callout>
+
+### Retired selector keys
+
+<Callout type="warn">
+  `contextSelectors[].includeAll` and `contextSelectors[].placement` were removed
+  in `@objectstack/spec` 17.0.0 (#4509, ADR-0049 enforce-or-remove) and are now
+  **refused at parse time** rather than ignored, so one leftover key fails the
+  whole save. Run `os migrate meta --from 16` to rewrite existing sources
+  automatically.
+
+  - `includeAll` — not merely unread, deliberately **disobeyed**, for the reason
+    above: the renderer never offered an "All" row regardless of the flag, so
+    `includeAll: false` hardened nothing and `includeAll: true` unlocked nothing.
+    Delete the key; widen `optionsSource.filter` to widen the choices.
+  - `placement` — no renderer ever read it. Selectors always render in the
+    sidebar header block, and `'topbar'` placed nothing in the topbar. Delete
+    the key.
+
+  Both carried schema **defaults**, which is why removal was the only channel
+  that could reach an author: a default materialises at parse time, so no lint
+  could tell an authored value from one the schema supplied.
+</Callout>
+
+### Example — a package scope
+
+The platform's own Studio app is the shipped example: one selector scopes every
+metadata surface in its sidebar to the selected package.
+
+{/* os:check */}
+```typescript
+import { defineApp } from '@objectstack/spec';
+
+const studioApp = defineApp({
+  name: 'studio',
+  label: 'Studio',
+  icon: 'hammer',
+
+  contextSelectors: [
+    {
+      // Referenced below as `{active_package}`.
+      id: 'active_package',
+      label: 'Package',
+      icon: 'package',
+      optionsSource: {
+        endpoint: '/api/v1/packages',
+        valueKey: 'manifest.id',
+        labelKey: 'manifest.name',
+        // Keep the platform's own kernel packages out of a developer-facing
+        // scope: only project-scoped packages are selectable.
+        filter: [{ key: 'manifest.scope', op: 'nin', value: ['system', 'cloud'] }],
+      },
+      allValue: '',
+      persist: 'query',
+    },
+  ],
+
+  navigation: [
+    // One entry, scoped to whichever package the dropdown has active.
+    {
+      id: 'nav_objects',
+      type: 'component',
+      label: 'Objects',
+      icon: 'database',
+      componentRef: 'metadata:resource',
+      params: { type: 'object', package: '{active_package}' },
+    },
+  ],
+
+  requiredPermissions: ['studio.access'],
+});
+```
+
+## Default Agent
+
+`defaultAgent` binds this app's **ambient AI chat** — the assistant the shell
+opens inside the app — to one platform agent, so the user never picks from a
+roster. It is a surface-binding knob, not a custom-agent slot:
+
+- **Omit it** on a data app. `ask` is the implicit default for every app that
+  does not pin one, which is what an ordinary data surface wants.
+- **Set `'build'`** on an *authoring* surface (Studio is the built-in example),
+  so the app opens the metadata-authoring assistant instead.
+
+Those two platform agents are the whole resolvable set. Tenant and app-package
+custom agents were withdrawn in ADR-0063, so a name outside it — `sales_copilot`,
+say — parses and then binds nothing: the chat surface falls back to the platform
+default at resolution time. Give an app deeper AI capability by authoring
+**skills**, which attach to the platform agents by surface affinity — see
+[AI Agents](/docs/ai/agents).
+
+<Callout type="info">
+  The in-product chat runtime this key binds ships in **ObjectOS**, not in the
+  open-source framework, which reaches your metadata over MCP (BYO-AI) instead.
+  The key is authorable either way — in the open edition there is simply no
+  in-product chat surface for it to bind.
+</Callout>
+
 ## Branding
 
 Customize the visual appearance of the app:
@@ -500,3 +666,4 @@ const projectApp = defineApp({
 - [Dashboard Metadata](/docs/ui/dashboards) — Dashboards referenced from navigation
 - [View Metadata](/docs/ui/views) — Views displayed within navigation items
 - [Permission Metadata](/docs/permissions/permission-metadata) — Access control for apps
+- [AI Agents](/docs/ai/agents) — The two platform agents `defaultAgent` binds


### PR DESCRIPTION
Fixes #5891

## 为什么

`content/docs/ui/apps.mdx` 的 App Properties 表是作者写 app 的**唯一**手写入口,读起来像作者面的全集;而 `packages/spec/src/ui/app.zod.ts` 的 `APP_KEYS` 里的 `contextSelectors` 与 `defaultAgent` 既不在这张表里,也在整个手写文档树**零覆盖**(此前只存在于生成的 `content/docs/references/ui/app.mdx`)。对作者来说这不是「少写一行」,而是把两个键变成不可发现 —— 与 #4880 / PR #5890 处理的 `areas[]` 完全同一形状的缺口。

## 改了什么

只动 `content/docs/ui/apps.mdx` 一个文件,体例照 PR #5890(`## Areas`)的先例:表格行 + 需要展开的键单独小节。

1. **App Properties 表补两行**,各自链到自己的小节:`contextSelectors`(排在 `areas` 之后)、`defaultAgent`(排在 `requiredPermissions` 之后)。
2. **新增 `## Context Selectors`**
   - 语义:侧边栏顶部(导航树之上)的作用域下拉;当前值以选择器自身的 `id` 命名发布,按模板变量注入导航项 —— 与 `current_user_id` / `current_org_id` 同一套替换。
   - 注入落点逐条列出:object 项的 `recordId` 与 `filters` 各值、`page` / `component` 项的字符串 `params` 值;解析不到的变量整条从 URL 里丢掉,而不是留空。
   - `optionsSource` 子表(`endpoint` / `valueKey` 默认 `id` / `labelKey` 默认 `name` / `filter`),以及 `filter` 谓词的 `eq`(默认)`ne` `in` `nin`。
   - 「选择器是**强制作用域**」一节:没有 All 行、也没有键能要一个;列表解析出来且尚无具体选中时壳层**自动选中第一项**;`allValue` 是「尚未具体选中」的哨兵值而不是 All 选项。
   - 「Retired selector keys」callout:17.0.0(#4509 / ADR-0049)退休的 `includeAll` / `placement`,连同各自的处方 —— 与页面既有的 app 级 / area 级退休 callout 同体例。
   - 例子取平台自身 Studio 的 package scope(`packages/platform-objects/src/apps/studio.app.ts` 的真实形状),带 `{/* os:check */}` 标记。
3. **新增 `## Default Agent`**:可解析值只有 `ask` / `build` 两个平台 agent —— 数据类 app 省略即得 `ask`,授权类(authoring)surface 写 `'build'`;ADR-0063 撤回了租户/包级自定义 agent,所以表外的名字(如 `sales_copilot`)parse 得过但绑不上,解析时回落平台默认。附一条 callout 说明它绑的 in-product chat runtime 属 ObjectOS,开源版没有可绑的 chat surface。
4. Related 补一条到 [AI Agents](/docs/ai/agents) 的链接。

## 事实来源(每条断言都在 origin/main 上核过)

| 断言 | 出处 |
| :--- | :--- |
| 键集 / 必填性 / 默认值 | `packages/spec/src/ui/app.zod.ts` `AppContextSelectorSchema`(`id` `label` `optionsSource` 必填;`allValue` 默认 `''`、`persist` 默认 `'query'`;`valueKey`/`labelKey` 默认 `id`/`name`) |
| 模板变量注入语义 | 同上 `AppContextSelectorSchema` 的 JSDoc + `AppSchema.contextSelectors` 的 `.describe` |
| 注入落点 / 解析不到即丢弃 | objectui `packages/layout/src/NavigationRenderer.tsx` 的 `applyNavTemplate` 与 `resolveHref`(object `recordId`、object `filters`、page `params`、component `params`) |
| 侧边栏渲染位置、自动选中第一项、无 All 行 | objectui `packages/app-shell/src/layout/ContextSelectors.tsx`(`useAppContextSelectors` / `SelectorControl`),挂载点见 `AppSidebar.tsx` / `UnifiedSidebar.tsx` |
| `includeAll` / `placement` 退休处方 | `app.zod.ts` 的 `CONTEXT_SELECTOR_RETIRED_KEY_GUIDANCE` |
| Studio package scope 的真实用法 | `packages/platform-objects/src/apps/studio.app.ts` |
| `defaultAgent` 绑定语义与可解析集合 | `app.zod.ts` `defaultAgent` 的 JSDoc/`.describe`(ADR-0063 §1/§2);解析链见 cloud `packages/service-ai/src/agent-runtime.ts` `resolveDefaultAgent`(app.defaultAgent → `ask` → 首个 active);「表外名字回落平台默认」另有 cloud 用例 `agent-load-platform-gate.test.ts` 直接盯住 |
| 开源版无 in-product chat | `content/docs/ai/agents.mdx` 既有 callout |

新增的「One scope per app today」callout 同样是核过的实现事实,不是推测:`ContextSelectors.tsx` 把选中值反射到 URL 上**一个固定 query key**,而每个声明的 selector 都从同一个 key 读回(`contextValues[sel.id] = (params.get('package') ?? saved) || …`),所以第二个 selector 会镜像第一个而不是独立作用域。写进文档是为了不让作者照着数组类型声明出一份静默失效的元数据;objectui 侧的实现缺陷另行归档,不在本 PR 修。

## 自验

- `node scripts/check-doc-authoring.mjs --self-test && node scripts/check-doc-authoring.mjs` → `✓ doc authoring guard: 362 files clean`
- `pnpm --filter @objectstack/spec run check:skill-examples` → `✅ 208 prose examples type-check against @objectstack/spec`;抽取清单里本页从 3 块变 4 块(新增 `content/docs/ui/apps.mdx:512`),即新例子确实被对着**真实 spec 的 d.ts** 编译过
- **反向验证(方向预判:红)**:往新例子里塞一个已退休的 `placement: 'topbar'`,门禁如期转红,并且报错把 selector 的合法键集原样列了出来 —— `error TS2353: … 'placement' does not exist in type '{ id: string; label: string; optionsSource: {…}; icon?…; allValue?…; persist?… }'`,反过来证实了本 PR 表格里的键集与「退休键在 parse 期被拒」的说法;移除探针后复跑回绿
- `node scripts/docs-audit/check-audit-scope.mjs` → `✓ docs-accuracy-audit scope is in sync with content/docs/: 178 hand-written doc(s)`
- MDX 语法:用 `@mdx-js/mdx@3.1.1` 的 `compile()` 单独编译本页通过(并用一份故意写坏的 MDX 验证过该 harness 不是空跑)
- `node scripts/check-nul-bytes.mjs` 通过;另按控制字节纪律对本文件跑了 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`,零命中

## Changeset

**不带 changeset**,按 PM 裁定走 `skip-changeset` 标签路线:本 PR 只改手写文档页,不发布任何包(空 changeset 会滞留发布,#4898,所以不提交空文件)。标签已在 PR 建好后由本 agent 补上(读回既有标签后写并集,避免覆盖 bot 刚打的 `size/*` 等)。

## 范围

严格按分诊裁定只做 `contextSelectors` / `defaultAgent` 两键。⛔ **`hidden` 没有写** —— 其语义正由 #4829 争议中(`filterAppForUser` 当 builder-only 访问闸门 vs spec `.describe` 的「只从 App Switcher 隐藏」),先定语义再写散文。⛔ 未碰 `packages/spec/**`、未碰 `content/docs/releases/`。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_