### PR TITLE
fix(service-analytics): 只当窗口用的 timeDimensions 条目不再被补默认粒度、不再静默拆网格 (#5688)

### DIFF
--- a/.changeset/analytics-window-timedimension-no-bucket.md
+++ b/.changeset/analytics-window-timedimension-no-bucket.md
@@ -1,0 +1,60 @@
+---
+"@objectstack/service-analytics": patch
+---
+
+fix(service-analytics): a `timeDimensions` entry used only as a date WINDOW no longer buckets the grid (#5688)
+
+**Observable behaviour change — read this if you render, page, or assert on
+dataset responses.** A selection that used a date dimension only as a window —
+`timeDimensions: [{ dimension, dateRange }]` with no `granularity`, and the
+dimension NOT listed in `selection.dimensions` — used to have the dataset
+dimension's declared `dateGranularity` filled in anyway. That made the entry a
+`GROUP BY` item, so the response grew a time column nobody selected and every
+row split per bucket. "Count by Owner" plus a dashboard date-range filter came
+back as "by Owner × month":
+
+```
+before  fields  [owner, close_date, opp_count]
+        rows    [{owner:'u1', close_date:'2026-01', opp_count:1},
+                 {owner:'u1', close_date:'2026-02', opp_count:1},
+                 {owner:'u2', close_date:'2026-01', opp_count:1}]
+
+after   fields  [owner, opp_count]
+        rows    [{owner:'u1', opp_count:2},
+                 {owner:'u2', opp_count:1}]
+```
+
+Both the **row count and the column set** change for such a selection: the extra
+month column disappears and rows that were split per bucket collapse back into
+one row per selected dimension tuple. A KPI single-value card that was reading
+the first of several month rows now reads the only row. Consumers that pinned
+the previous shape (a snapshot of `fields`, a row count, a hard-coded column
+index) need updating; consumers that render the response's own `fields` do not.
+
+Three conditions had to hold together to be affected, so a selection outside
+them is byte-identical: the dataset dimension declares an explicit
+`dateGranularity`, the `timeDimensions` entry states no `granularity`, and
+`selection.dateGranularity` is unset.
+
+**What still buckets, unchanged.** An entry is bucketed when the request says
+that date is being bucketed: the dimension is one of the selection's own
+`dimensions`, the entry carries its own `granularity` (#4033 — still projected
+as a column even when not selected), or `selection.dateGranularity` is set. The
+granularity *precedence* chain is untouched. A dataset dimension's
+`dateGranularity` says how that date renders **when** grouped — it is no longer
+read as a request to group by it.
+
+**`compareTo` alignment (#3588/#4870) holds by construction.** The comparison
+pass re-enters the same query builder with the same grid dimensions, differing
+only in the shifted `dateRange`, so both passes bucket an entry alike or not at
+all — never one of each, which was the state that left every `__compare` column
+empty. For a window-only anchor this **repairs** the comparison rather than
+preserving it: the merge has always keyed on `selection.dimensions` alone, so
+the backfilled bucket column sat outside the merge key, and with several
+month-split rows per group the comparison value landed on whichever row the
+index held last while the others read a confident `0`.
+
+Also fixed, same root cause: a time column that IS projected via
+`timeDimensions` (an entry carrying its own `granularity`, never listed under
+`dimensions`) now carries its dataset `label` in `fields` instead of a bare
+`type` — the label enrichment walked `selection.dimensions` only.

--- a/packages/services/service-analytics/src/__tests__/dataset-dimension-field-descriptors.test.ts
+++ b/packages/services/service-analytics/src/__tests__/dataset-dimension-field-descriptors.test.ts
@@ -53,6 +53,17 @@
  * the change ADDS field entries that were absent, it narrows no rule and
  * removes no `??` limb, so nothing downstream can gain a finding from it.
  * Predicted 8 red / 4 green; measured exactly that.
+ *
+ * ## Amended by #5688
+ *
+ * Two cases here were written as a deliberate FLIP TARGET: the pair that fed a
+ * `timeDimensions` entry carrying only a `dateRange` asserted, verbatim, that
+ * the entry acquired the dataset's default bucket and became a second GROUP BY.
+ * #5688 narrowed that backfill, so both now assert the opposite column set and,
+ * additionally, the grid substance the descriptors describe (one row per owner,
+ * no month split). The reverse verification above is unaffected — reverting
+ * #5537's seam still reds exactly the "all base measures filter-scoped" cases,
+ * and the flipped pair differs only in what the correct column set IS.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -253,27 +264,26 @@ describe('#5537 — the single-query path already described its dimensions (guar
   });
 
   /**
-   * The CONTROL for the `compareTo` case in the next block, and the reason the
-   * expectation there carries an unlabelled `close_date`.
+   * The CONTROL for the `compareTo` case in the next block: the two selections
+   * differ only in whether their measures carry filters, so their descriptors
+   * must agree column for column.
    *
-   * A `timeDimensions` entry that resolves a granularity is GROUPED BY, so it is
-   * a COLUMN of the result and every producer of this shape projects it (#4033),
-   * even when the caller never listed it under `dimensions`. It reaches `fields`
-   * with a `type` and no `label`, because the label enrichment in `queryDataset`
-   * walks `selection.dimensions` — and that is true on THIS path, which never
-   * had the #5537 defect. Pinned here so the pair reads as convergence rather
-   * than as something the fix introduced.
+   * **This pin was FLIPPED by #5688 and now carries the opposite fact.** It used
+   * to assert an unlabelled `close_date` descriptor and three month-split rows,
+   * because a `timeDimensions` entry carrying only a `dateRange` had the
+   * dataset's default granularity filled in — turning a WINDOW into a second
+   * GROUP BY. #5688 narrowed that backfill: a window-only entry stays a filter,
+   * so there is no `close_date` column on either path and `usr_1` is one row
+   * again. Asserted as substance, not as an absence: the row values pin that the
+   * three in-window opportunities landed in ONE `usr_1` bucket rather than being
+   * split across months, which is the defect's actual signature.
    *
-   * That the column exists AT ALL is itself a defect, filed as #5688 and
-   * deliberately not fixed here: a `timeDimensions` entry carrying only a
-   * `dateRange` gets the dataset's default granularity filled in, which turns a
-   * WINDOW into a second GROUP BY — so this selection also comes back split by
-   * month. It reproduces identically on this path, i.e. independently of #5537,
-   * and settling it changes the response SHAPE (a row count, not a label), which
-   * is not a call to make as a rider. Both asserted verbatim so the day #5688
-   * lands, this pair goes red and gets updated on purpose.
+   * The projection rule itself is unchanged (#4033: an entry that DOES resolve a
+   * granularity is grouped, so it is a column) — see
+   * `dataset-window-timedimension-bucketing.test.ts`, which pins both sides of
+   * the narrowed criterion plus the label the projected column now carries.
    */
-  it('a granular `timeDimensions` column is projected here too — unlabelled, on this path as well', async () => {
+  it('a window-only `timeDimensions` entry adds no column here — same as the filtered path', async () => {
     const result = await svc().queryDataset(
       dataset,
       {
@@ -286,18 +296,19 @@ describe('#5537 — the single-query path already described its dimensions (guar
     );
     expect(descriptors(result.fields)).toEqual([
       { name: 'owner', type: 'string', label: 'Owner' },
-      { name: 'close_date', type: 'time' },
       { name: 'opp_count', type: 'number', label: 'Opportunities' },
       { name: 'opp_count__compare', type: 'number', label: 'Opportunities' },
     ]);
-    // #5688, stated as data rather than as prose: `usr_1` is one owner and comes
-    // back as two rows because the window entry acquired a `month` bucket. The
-    // descriptors are honest about the grid — the grid is what is wrong.
-    expect(result.rows.map((r) => [r.owner, r.close_date])).toEqual([
-      ['usr_1', '2026-01'],
-      ['usr_1', '2026-02'],
-      ['usr_2', '2026-02'],
+    // The grid the descriptors describe: one row per owner, the window applied
+    // as a filter. `usr_1` has three in-window opportunities (two in January,
+    // one in February) and they aggregate into a single bucket — before #5688
+    // this was two rows carrying 2 and 1.
+    expect(result.rows).toEqual([
+      { owner: 'usr_1', opp_count: 3, opp_count__compare: 0 },
+      { owner: 'usr_2', opp_count: 1, opp_count__compare: 0 },
     ]);
+    // …and no row carries a column no descriptor mentions.
+    expect(result.rows.every((r) => !('close_date' in r))).toBe(true);
   });
 });
 
@@ -398,14 +409,19 @@ describe('#5537 — all base measures filter-scoped: the dimension is described 
       },
       CTX,
     );
-    // Identical to the control in the previous block, measure for measure —
-    // including the unlabelled `close_date` a granular `timeDimensions` entry
-    // projects on BOTH paths.
+    // Identical to the control in the previous block, column for column —
+    // including the ABSENCE of a `close_date` column, which since #5688 a
+    // window-only `timeDimensions` entry no longer mints on either path.
     expect(descriptors(result.fields)).toEqual([
       { name: 'owner', type: 'string', label: 'Owner' },
-      { name: 'close_date', type: 'time' },
       { name: 'won_count', type: 'number', label: 'Won' },
       { name: 'won_count__compare', type: 'number', label: 'Won' },
+    ]);
+    // Same substance as the control: one row per owner, no month split. The two
+    // paths converge on the grid as well as on the descriptors.
+    expect(result.rows).toEqual([
+      { owner: 'usr_1', won_count: 1, won_count__compare: 0 },
+      { owner: 'usr_2', won_count: 1, won_count__compare: 0 },
     ]);
   });
 

--- a/packages/services/service-analytics/src/__tests__/dataset-window-timedimension-bucketing.test.ts
+++ b/packages/services/service-analytics/src/__tests__/dataset-window-timedimension-bucketing.test.ts
@@ -1,0 +1,442 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #5688 — a `timeDimensions` entry used only as a WINDOW must stay a filter.
+ *
+ * A dashboard date-range picker emits `timeDimensions: [{ dimension, dateRange }]`
+ * — no `granularity` — and does not list that dimension under
+ * `selection.dimensions`. The executor filled in the dataset dimension's own
+ * `dateGranularity` anyway, which made the entry a GROUP BY item: the response
+ * grew a time column nobody selected and every row split per bucket. "Count by
+ * Owner" plus a date filter came back as "by Owner × month":
+ *
+ * ```
+ * fields [{"name":"owner",…},{"name":"close_date","type":"time"},{"name":"opp_count",…}]
+ * rows   [{"owner":"u1","close_date":"2026-01","opp_count":1},
+ *         {"owner":"u1","close_date":"2026-02","opp_count":1},
+ *         {"owner":"u2","close_date":"2026-01","opp_count":1}]
+ * ```
+ *
+ * A KPI single-value card then read the first of those rows. The invariant it
+ * broke is the one every filter obeys: a `dateRange` removes rows — it does not
+ * mint a column, split a row, or change the column set.
+ *
+ * ## The narrowed criterion (all three arms pinned below)
+ *
+ * An entry that states NO granularity is bucketed only when the request says
+ * that date is being bucketed: the dimension is one of the grid dimensions this
+ * query groups by, or `selection.dateGranularity` is set. An entry carrying its
+ * own `granularity` was never in question and stays grouped (#4033). The dataset
+ * dimension's `dateGranularity` alone is NOT such a signal — it says how this
+ * date renders WHEN grouped, not that it should be grouped.
+ *
+ * ## compareTo — the same question, answered on both passes (#3588/#4870)
+ *
+ * The backfill existed because the comparison pass must bucket exactly like the
+ * primary one; a month-bucketed primary grid merged against raw-timestamp
+ * comparison rows shares no dimension key, and every `__compare` column comes
+ * back empty. That still holds, and holds BY CONSTRUCTION: `runCompare` re-enters
+ * `buildQuery` with the same grid dimensions and the same
+ * `selection.dateGranularity`, differing only in the shifted `dateRange`, so both
+ * passes reach the same verdict for the same entry. Pinned as a PAIR here — the
+ * bucketed anchor and the window-only anchor, each asserted on both passes — so
+ * neither demand can be re-broken in the other's name.
+ *
+ * For a window-only anchor the narrowing does not merely preserve the merge, it
+ * REPAIRS it. `mergeByDimensions` has always keyed on `selection.dimensions`
+ * alone, never on the projected bucket column, so the backfilled month column
+ * was outside the merge key: with several month-split rows per owner the
+ * comparison value landed on whichever row the index happened to hold last and
+ * the others read a confident `0`. Both numbers are asserted below.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DatasetSchema } from '@objectstack/spec/ui';
+import type { ExecutionContext } from '@objectstack/spec/kernel';
+import { AnalyticsService } from '../analytics-service.js';
+
+const CTX = { tenantId: 'org_A' } as ExecutionContext;
+
+// ── fixture ─────────────────────────────────────────────────────────────────
+
+/**
+ * The issue's dataset: a lookup dimension whose label differs from its
+ * humanized key, and a date dimension declaring an explicit `dateGranularity` —
+ * the necessary condition for the defect, and the shape HotCRM-class datasets
+ * ship.
+ */
+const dataset = DatasetSchema.parse({
+  name: 'opportunity_metrics',
+  label: 'Opportunity Metrics',
+  object: 'opportunity',
+  include: [],
+  dimensions: [
+    { name: 'owner', field: 'owner_id', type: 'lookup', label: 'Owner' },
+    { name: 'close_date', field: 'close_date', type: 'date', label: 'Close Date', dateGranularity: 'month' },
+    // The control: same shape, no declared `dateGranularity`, so nothing was
+    // ever backfilled for it — which is what makes the declaration the trigger.
+    { name: 'created_at', field: 'created_at', type: 'date', label: 'Created' },
+  ],
+  measures: [{ name: 'opp_count', aggregate: 'count', label: 'Opps' }],
+});
+
+/**
+ * Current window (2026-01-01..2026-02-28): `u1` → 2 (one per month), `u2` → 1.
+ * Previous year (2025-01-01..2025-02-28): `u1` → 3 (one in Jan, TWO in Feb),
+ * `u2` → 1.
+ *
+ * `u1`'s comparison total deliberately spans two months and is not equal to
+ * either month alone (3 = 1 + 2), so a per-month merge cannot accidentally
+ * produce the right answer.
+ */
+const OPPS: Array<{ owner_id: string; close_date: string; created_at: string }> = [
+  { owner_id: 'u1', close_date: '2026-01-05', created_at: '2025-11-01' },
+  { owner_id: 'u1', close_date: '2026-02-11', created_at: '2025-11-02' },
+  { owner_id: 'u2', close_date: '2026-01-20', created_at: '2025-11-03' },
+  { owner_id: 'u1', close_date: '2025-01-07', created_at: '2024-11-01' },
+  { owner_id: 'u1', close_date: '2025-02-03', created_at: '2024-11-02' },
+  { owner_id: 'u1', close_date: '2025-02-04', created_at: '2024-11-03' },
+  { owner_id: 'u2', close_date: '2025-01-15', created_at: '2024-11-04' },
+];
+
+type GroupByItem = string | { field: string; dateGranularity?: string };
+type AggOptions = { groupBy?: unknown; aggregations?: unknown; filter?: unknown };
+
+function matches(row: Record<string, unknown>, filter: unknown): boolean {
+  if (filter == null || typeof filter !== 'object') return true;
+  for (const [key, cond] of Object.entries(filter as Record<string, unknown>)) {
+    if (key === '$and') {
+      if (!(cond as unknown[]).every((c) => matches(row, c))) return false;
+      continue;
+    }
+    if (key === '$or') {
+      if (!(cond as unknown[]).some((c) => matches(row, c))) return false;
+      continue;
+    }
+    const value = row[key];
+    if (cond != null && typeof cond === 'object' && !Array.isArray(cond)) {
+      const ops = cond as Record<string, unknown>;
+      if ('$gte' in ops && !(String(value) >= String(ops.$gte))) return false;
+      if ('$lte' in ops && !(String(value) <= String(ops.$lte))) return false;
+      continue;
+    }
+    if (value !== cond) return false;
+  }
+  return true;
+}
+
+/** Bucket keys for the granularities this fixture exercises. */
+function bucket(raw: unknown, granularity?: string): unknown {
+  const s = String(raw);
+  if (granularity === 'month') return s.slice(0, 7);
+  if (granularity === 'year') return s.slice(0, 4);
+  return raw;
+}
+
+/** Group `OPPS` the way a real `GROUP BY` would, over the filtered row set. */
+function evaluateAggregate(opts: AggOptions): Record<string, unknown>[] {
+  const groupBy = (opts.groupBy ?? []) as GroupByItem[];
+  const aggregations = (opts.aggregations ?? []) as Array<{ field: string; method: string; alias: string }>;
+  const buckets = new Map<string, { key: Record<string, unknown>; rows: unknown[] }>();
+  for (const opp of OPPS) {
+    if (!matches(opp as unknown as Record<string, unknown>, opts.filter)) continue;
+    const key: Record<string, unknown> = {};
+    for (const g of groupBy) {
+      const field = typeof g === 'string' ? g : g.field;
+      const raw = (opp as unknown as Record<string, unknown>)[field];
+      key[field] = bucket(raw, typeof g === 'string' ? undefined : g.dateGranularity);
+    }
+    const id = JSON.stringify(groupBy.map((g) => key[typeof g === 'string' ? g : g.field] ?? null));
+    let b = buckets.get(id);
+    if (!b) {
+      b = { key, rows: [] };
+      buckets.set(id, b);
+    }
+    b.rows.push(opp);
+  }
+  return [...buckets.values()].map(({ key, rows }) => {
+    const row: Record<string, unknown> = { ...key };
+    for (const a of aggregations) row[a.alias] = rows.length;
+    return row;
+  });
+}
+
+/**
+ * The ObjectQL-aggregate service — the path every date-bucketed query lands on
+ * — recording each lowered aggregate call, so the GROUP BY itself is asserted
+ * rather than inferred from the rows.
+ */
+function svc() {
+  const calls: AggOptions[] = [];
+  const service = new AnalyticsService({
+    queryCapabilities: () => ({ nativeSql: false, objectqlAggregate: true, inMemory: false }),
+    executeAggregate: async (_object: string, options: Record<string, unknown>) => {
+      calls.push(options as AggOptions);
+      return evaluateAggregate(options as AggOptions);
+    },
+  });
+  return { service, calls };
+}
+
+const groupByOf = (call: AggOptions) => (call.groupBy ?? []) as GroupByItem[];
+const names = (fields: Array<{ name: string }>) => fields.map((f) => f.name);
+const descriptor = (fields: Array<{ name: string; type?: string; label?: string }>, name: string) => {
+  const f = fields.find((x) => x.name === name);
+  return f ? { name: f.name, type: f.type, label: f.label } : undefined;
+};
+
+const WINDOW: [string, string] = ['2026-01-01', '2026-02-28'];
+
+// ── 1) the window-only entry stays a filter ─────────────────────────────────
+
+describe('#5688 — a dateRange-only entry filters rows and nothing else', () => {
+  it('the issue verbatim: "by Owner" + a date filter is by Owner, not Owner × month', async () => {
+    const { service, calls } = svc();
+    const result = await service.queryDataset(
+      dataset,
+      {
+        dimensions: ['owner'],
+        measures: ['opp_count'],
+        timeDimensions: [{ dimension: 'close_date', dateRange: WINDOW }],
+      },
+      CTX,
+    );
+    // The column set is the selection's own: no time column nobody asked for.
+    expect(names(result.fields)).toEqual(['owner', 'opp_count']);
+    // Two rows, not three — `u1`'s January and February records are one owner.
+    expect(result.rows).toEqual([
+      { owner: 'u1', opp_count: 2 },
+      { owner: 'u2', opp_count: 1 },
+    ]);
+    // Where it is settled: the entry never reaches the GROUP BY, and its
+    // `dateRange` is still applied as a predicate — fewer rows, same columns.
+    expect(groupByOf(calls[0])).toEqual(['owner_id']);
+    expect(calls[0].filter).toMatchObject({ close_date: { $gte: WINDOW[0], $lte: WINDOW[1] } });
+  });
+
+  it('adding the window changes the ROW COUNT and nothing about the column set', async () => {
+    const selection = { dimensions: ['owner'], measures: ['opp_count'] };
+    const unfiltered = await svc().service.queryDataset(dataset, selection, CTX);
+    const filtered = await svc().service.queryDataset(
+      dataset,
+      { ...selection, timeDimensions: [{ dimension: 'close_date', dateRange: WINDOW }] },
+      CTX,
+    );
+    // Identical columns; the window only removed the 2025 records from the counts.
+    expect(names(filtered.fields)).toEqual(names(unfiltered.fields));
+    expect(unfiltered.rows).toEqual([
+      { owner: 'u1', opp_count: 5 },
+      { owner: 'u2', opp_count: 2 },
+    ]);
+    expect(filtered.rows).toEqual([
+      { owner: 'u1', opp_count: 2 },
+      { owner: 'u2', opp_count: 1 },
+    ]);
+  });
+
+  it('a KPI single-value card gets ONE row, not the first of several buckets', async () => {
+    const { service } = svc();
+    const result = await service.queryDataset(
+      dataset,
+      {
+        dimensions: [],
+        measures: ['opp_count'],
+        timeDimensions: [{ dimension: 'close_date', dateRange: WINDOW }],
+      },
+      CTX,
+    );
+    expect(result.rows).toEqual([{ opp_count: 3 }]);
+    expect(names(result.fields)).toEqual(['opp_count']);
+  });
+
+  it('mints no descriptor for the window dimension — the lookup widened, the projection did not', async () => {
+    const { service } = svc();
+    const result = await service.queryDataset(
+      dataset,
+      {
+        dimensions: ['owner'],
+        measures: ['opp_count'],
+        timeDimensions: [{ dimension: 'close_date', dateRange: WINDOW }],
+      },
+      CTX,
+    );
+    // #5688 widened the label enrichment's lookup set to dimensions reached via
+    // `timeDimensions`. It must still describe only columns that EXIST: an entry
+    // that stayed a window is not a column, so no `close_date` field appears.
+    expect(descriptor(result.fields, 'close_date')).toBeUndefined();
+    expect(result.rows.every((r) => !('close_date' in r))).toBe(true);
+  });
+});
+
+// ── 2) the entries that ARE asking for a bucket keep it ─────────────────────
+
+describe('#5688 — an entry asking to be bucketed still is (#3588/#4033/#4870 guard)', () => {
+  it('the dimension is also a GRID dimension → bucketed, exactly as before', async () => {
+    const { service, calls } = svc();
+    const result = await service.queryDataset(
+      dataset,
+      {
+        dimensions: ['owner', 'close_date'],
+        measures: ['opp_count'],
+        timeDimensions: [{ dimension: 'close_date', dateRange: WINDOW }],
+      },
+      CTX,
+    );
+    // Left unbucketed this would group RAW TIMESTAMPS — one bucket per row,
+    // which is the #3588 defect the backfill was introduced to fix.
+    expect(groupByOf(calls[0])).toEqual(['owner_id', { field: 'close_date', dateGranularity: 'month' }]);
+    // Chronological by default on the time axis (#3916), ties in grouping order.
+    expect(result.rows).toEqual([
+      { owner: 'u1', close_date: '2026-01', opp_count: 1 },
+      { owner: 'u2', close_date: '2026-01', opp_count: 1 },
+      { owner: 'u1', close_date: '2026-02', opp_count: 1 },
+    ]);
+    expect(descriptor(result.fields, 'close_date')).toEqual({
+      name: 'close_date', type: 'time', label: 'Close Date',
+    });
+  });
+
+  it('the entry states its OWN granularity → bucketed and projected, though never selected (#4033)', async () => {
+    const { service, calls } = svc();
+    const result = await service.queryDataset(
+      dataset,
+      {
+        dimensions: ['owner'],
+        measures: ['opp_count'],
+        timeDimensions: [{ dimension: 'close_date', dateRange: WINDOW, granularity: 'month' }],
+      },
+      CTX,
+    );
+    expect(groupByOf(calls[0])).toEqual(['owner_id', { field: 'close_date', dateGranularity: 'month' }]);
+    expect(names(result.fields)).toEqual(['owner', 'close_date', 'opp_count']);
+    // #5691's blind spot, closed here: the projected time column reaches
+    // `fields` with a `label` now, not a bare `type`. The enrichment loop used
+    // to walk `selection.dimensions` only, which this column is not in.
+    expect(descriptor(result.fields, 'close_date')).toEqual({
+      name: 'close_date', type: 'time', label: 'Close Date',
+    });
+  });
+
+  it('`selection.dateGranularity` is set → the presentation asked for buckets, so it gets them', async () => {
+    const { service, calls } = svc();
+    const result = await service.queryDataset(
+      dataset,
+      {
+        dimensions: ['owner'],
+        measures: ['opp_count'],
+        dateGranularity: 'year',
+        timeDimensions: [{ dimension: 'close_date', dateRange: WINDOW }],
+      },
+      CTX,
+    );
+    // The selection's granularity beats the dataset's `month` default — the
+    // precedence chain in `resolveDimensionGranularity` is untouched by #5688.
+    expect(groupByOf(calls[0])).toEqual(['owner_id', { field: 'close_date', dateGranularity: 'year' }]);
+    expect(result.rows).toEqual([
+      { owner: 'u1', close_date: '2026', opp_count: 2 },
+      { owner: 'u2', close_date: '2026', opp_count: 1 },
+    ]);
+  });
+
+  it('control — a dimension declaring NO dateGranularity was never backfilled either way', async () => {
+    const { service, calls } = svc();
+    await service.queryDataset(
+      dataset,
+      {
+        dimensions: ['owner'],
+        measures: ['opp_count'],
+        timeDimensions: [{ dimension: 'created_at', dateRange: ['2025-01-01', '2025-12-31'] }],
+      },
+      CTX,
+    );
+    // Same outcome as `close_date` now has, reached for a different reason:
+    // there was no default to fill in. Pinned so the declaration is visibly the
+    // trigger condition rather than an assumed one.
+    expect(groupByOf(calls[0])).toEqual(['owner_id']);
+  });
+});
+
+// ── 3) compareTo — the pair ─────────────────────────────────────────────────
+
+describe('#5688 — compareTo buckets both passes alike, whichever verdict it reaches', () => {
+  it('window-only anchor: NEITHER pass buckets, and the comparison merges on `owner`', async () => {
+    const { service, calls } = svc();
+    const result = await service.queryDataset(
+      dataset,
+      {
+        dimensions: ['owner'],
+        measures: ['opp_count'],
+        timeDimensions: [{ dimension: 'close_date', dateRange: WINDOW }],
+        compareTo: { kind: 'previousYear', dimension: 'close_date' },
+      },
+      CTX,
+    );
+    // Both passes ran, both grouped by `owner` alone — same verdict, so the two
+    // grids are shaped alike (the #4870 invariant, at the other verdict).
+    expect(calls).toHaveLength(2);
+    expect(groupByOf(calls[0])).toEqual(['owner_id']);
+    expect(groupByOf(calls[1])).toEqual(['owner_id']);
+    expect(calls[1].filter).toMatchObject({ close_date: { $gte: '2025-01-01', $lte: '2025-02-28' } });
+    // `u1`: 2 this window against 3 last year — 3 spans two months, so the
+    // number is only reachable by merging the WHOLE shifted window onto the
+    // owner. Before #5688 this row set was three month-split rows carrying
+    // `__compare` 0 / 2 / 1: the January row read a confident 0 and the other
+    // two months' comparison values were overwritten by whichever landed last.
+    expect(result.rows).toEqual([
+      { owner: 'u1', opp_count: 2, opp_count__compare: 3 },
+      { owner: 'u2', opp_count: 1, opp_count__compare: 1 },
+    ]);
+    expect(names(result.fields)).toEqual(['owner', 'opp_count', 'opp_count__compare']);
+  });
+
+  it('bucketed anchor: BOTH passes bucket by month — the #4870 fix, unregressed', async () => {
+    const { service, calls } = svc();
+    const result = await service.queryDataset(
+      dataset,
+      {
+        dimensions: ['close_date'],
+        measures: ['opp_count'],
+        timeDimensions: [{ dimension: 'close_date', dateRange: WINDOW }],
+        compareTo: { kind: 'previousYear', dimension: 'close_date' },
+      },
+      CTX,
+    );
+    expect(calls).toHaveLength(2);
+    // The comparison pass must bucket EXACTLY like the primary one. Hand-rolled
+    // without granularity resolution it grouped raw timestamps, and no dimension
+    // key ever matched.
+    expect(groupByOf(calls[0])).toEqual([{ field: 'close_date', dateGranularity: 'month' }]);
+    expect(groupByOf(calls[1])).toEqual([{ field: 'close_date', dateGranularity: 'month' }]);
+    expect(calls[1].filter).toMatchObject({ close_date: { $gte: '2025-01-01', $lte: '2025-02-28' } });
+    expect(descriptor(result.fields, 'close_date')).toEqual({
+      name: 'close_date', type: 'time', label: 'Close Date',
+    });
+    // Long-standing behaviour, unchanged by #5688 and asserted so the pair is
+    // read as a whole: the shifted grid keys by its OWN buckets, so a comparison
+    // bucket with no current-window twin arrives as its own row (the append
+    // `fillEmptyGroups` is documented to expect).
+    expect(result.rows).toEqual([
+      { close_date: '2025-01', opp_count: 0, opp_count__compare: 2 },
+      { close_date: '2025-02', opp_count: 0, opp_count__compare: 2 },
+      { close_date: '2026-01', opp_count: 2, opp_count__compare: 0 },
+      { close_date: '2026-02', opp_count: 1, opp_count__compare: 0 },
+    ]);
+  });
+
+  it('window-only anchor with NO grid dimensions: one row, both totals comparable', async () => {
+    const { service } = svc();
+    const result = await service.queryDataset(
+      dataset,
+      {
+        dimensions: [],
+        measures: ['opp_count'],
+        timeDimensions: [{ dimension: 'close_date', dateRange: WINDOW }],
+        compareTo: { kind: 'previousYear', dimension: 'close_date' },
+      },
+      CTX,
+    );
+    // The period-over-period tile: 3 this window, 4 last year. Before #5688 this
+    // came back as two month rows and the tile read the first one.
+    expect(result.rows).toEqual([{ opp_count: 3, opp_count__compare: 4 }]);
+  });
+});

--- a/packages/services/service-analytics/src/analytics-service.ts
+++ b/packages/services/service-analytics/src/analytics-service.ts
@@ -1022,9 +1022,31 @@ export class AnalyticsService implements IAnalyticsService {
     // entry in `fields` for this pass to enrich. Fixed where the grid is
     // assembled (see that method's #5537 note), which is also the only place
     // that knows what the active strategy actually projected.
-    if (result.fields?.length && selectedDims.length) {
-      const dimByName = new Map(selectedDims.map((d) => [d.name, d]));
-      const dimByField = new Map(selectedDims.filter((d) => !!d.field).map((d) => [d.field as string, d]));
+    //
+    // #5688 — the set to describe FROM is wider than `selection.dimensions`. A
+    // `timeDimensions` entry that resolves a granularity is GROUPED BY, so it is
+    // a result column even when the caller never listed it under `dimensions`
+    // (#4033's `projectedDimensions`) — and reading `selection.dimensions` alone
+    // left exactly that column carrying a `type` and no `label`, the blind spot
+    // #5537's PR pinned as a control case. Widening the LOOKUP is not the same
+    // as widening the projection: the loop still enriches only entries
+    // `result.fields` already carries, so an entry that stays a pure window
+    // contributes no column and receives no descriptor.
+    //
+    // Kept out of `selectedDims` deliberately. Drill metadata and row-value
+    // label resolution above answer a different question — which dimensions the
+    // caller GROUPED THE GRID BY, i.e. what a click can be turned back into
+    // records — and widening those would change drill payloads and row values,
+    // not table headers.
+    const describableDims = [...selectedDims];
+    for (const t of selection.timeDimensions ?? []) {
+      if (describableDims.some((d) => d.name === t.dimension)) continue;
+      const d = dataset.dimensions?.find((x) => x.name === t.dimension);
+      if (d) describableDims.push(d);
+    }
+    if (result.fields?.length && describableDims.length) {
+      const dimByName = new Map(describableDims.map((d) => [d.name, d]));
+      const dimByField = new Map(describableDims.filter((d) => !!d.field).map((d) => [d.field as string, d]));
       for (const f of result.fields) {
         if (f.label != null) continue;
         // Result fields may be keyed by the dataset dimension NAME or the

--- a/packages/services/service-analytics/src/dataset-executor.ts
+++ b/packages/services/service-analytics/src/dataset-executor.ts
@@ -286,7 +286,16 @@ export type DateGranularityValue = NonNullable<DatasetSelection['dateGranularity
  *
  * The unit of precedence is the GRANULARITY, not the entry: a `timeDimensions`
  * entry carrying only a `dateRange` (what `compareTo` needs) states a WINDOW,
- * not a bucket size, and must not suppress bucketing.
+ * not a bucket size, and so cannot VETO a bucket size stated elsewhere for a
+ * dimension that is being grouped.
+ *
+ * This answers "how big is the bucket", never "is this dimension bucketed at
+ * all" — a separate question, decided per query by `buildQuery`'s
+ * `bucketsUnstatedEntry` (#5688), because a window-only entry for a dimension
+ * nobody grouped must stay a filter. Every caller here is already past that
+ * question: `buildQuery` asks it first, and the post-processing sites in
+ * `analytics-service` iterate `selection.dimensions`, which are grouped by
+ * definition.
  *
  * **Why this is exported.** The bucket size chosen here decides three things
  * that MUST agree: the `GROUP BY` the query compiles to, the humanized label
@@ -927,23 +936,77 @@ export class DatasetExecutor {
     //      `dateGranularity` to a single-entry `granularities`; the 5-entry
     //      "all granularities" list means the dataset stated no default).
     //
-    // Note the unit of precedence is the GRANULARITY, not the entry. A
-    // `timeDimensions` entry that only carries a `dateRange` (which is exactly
-    // what `compareTo` needs) states a WINDOW, not a bucket size — letting its
-    // mere presence suppress bucketing left the compared pass grouping raw
-    // timestamps while the primary pass grouped months, so the two grids shared
-    // no dimension key and every `__compare` column came back empty.
+    // Note the unit of precedence is the GRANULARITY, not the entry: a stated
+    // `granularity` is never overridden, and an entry that states none does not
+    // veto a bucket size the selection or the dataset supplies for a dimension
+    // that IS being grouped. That is `resolveDimensionGranularity`'s job, and it
+    // is unchanged — see `granularityFor` below.
+    //
+    // What an entry that carries only a `dateRange` decides is something else:
+    // whether the dimension is grouped AT ALL (#5688). It is a WINDOW — a
+    // filter, and a dashboard date-range picker is the usual source. A filter
+    // removes rows; it does not add a grid column or split rows. Backfilling the
+    // dataset's default bucket size onto such an entry turned "by Owner, this
+    // quarter" into "by Owner × month": one extra column nobody selected, and
+    // one row per owner PER MONTH, with a KPI card then reading the first of
+    // them. So the backfill is scoped by {@link bucketsUnstatedEntry} to the
+    // entries that are genuinely asking for a bucket.
+    //
+    // `compareTo` alignment survives that narrowing BY CONSTRUCTION, and this is
+    // the pairing to keep in mind before widening or narrowing it again
+    // (#3588/#4870 vs #5688 — the two demands meet exactly here):
+    //
+    //   - the comparison pass re-enters this method through `runMeasurePass`
+    //     with the SAME `opts.dimensions` and the same `selection.dateGranularity`,
+    //     differing only in the shifted `dateRange`. Both passes therefore reach
+    //     the same verdict for the same entry, so the two grids are bucketed
+    //     alike or not at all — never one of each, which is the state #4870
+    //     fixed (a month-bucketed primary grid merged against raw-timestamp
+    //     comparison rows shared no dimension key, and every `__compare` column
+    //     came back empty);
+    //   - an anchor that IS grouped (listed in `dimensions`, or carrying its own
+    //     `granularity`) keeps its bucket on both passes — #3588/#4870 intact;
+    //   - an anchor used only as a window is grouped on NEITHER pass, so it is
+    //     not a column on either side and the two grids align on the dimensions
+    //     `mergeByDimensions` actually keys by. That merge has always keyed on
+    //     `dimensions` alone, so the bucket column the backfill added was never
+    //     part of the key: with several month-split rows per group the
+    //     comparison value landed on whichever one the index happened to hold
+    //     last and the rest read a confident `0`. Not bucketing the window
+    //     restores the alignment rather than weakening it.
     const selTimeDims = opts.selection.timeDimensions ?? [];
     const selDims = new Set(selTimeDims.map((t) => t.dimension));
+    const groupedDims = new Set(opts.dimensions);
     const granularityFor = (name: string): string | undefined => {
       const cd = compiled.cube.dimensions[name];
       if (cd?.type !== 'time') return undefined;
       const datasetDefault = cd.granularities?.length === 1 ? String(cd.granularities[0]) : undefined;
       return resolveDimensionGranularity(opts.selection, name, datasetDefault);
     };
-    // Fill in a bucket size for caller-supplied entries that named none.
+    /**
+     * Does a caller-supplied entry that stated NO granularity get one filled in?
+     *
+     * Only when something in the request says this date is being bucketed:
+     *   - the dimension is one of the grid dimensions this query groups by (so
+     *     it is a column regardless, and leaving it unbucketed would group raw
+     *     timestamps — one bucket per row, the #3588 defect); or
+     *   - `selection.dateGranularity` is set, which is the presentation stating
+     *     a bucket size for its date axes.
+     * An entry carrying its own `granularity` never reaches here (nothing to
+     * fill in), and stays grouped.
+     *
+     * The dataset dimension's own `dateGranularity` is deliberately NOT such a
+     * signal on its own: it is how this date renders WHEN grouped, not a request
+     * to group by it. Reading it as one is what made a date-range filter behave
+     * like a second GROUP BY.
+     */
+    const bucketsUnstatedEntry = (dimension: string): boolean =>
+      groupedDims.has(dimension) || opts.selection.dateGranularity != null;
+    // Fill in a bucket size for caller-supplied entries that named none — for
+    // the entries that are asking to be bucketed at all.
     const resolvedTimeDims = selTimeDims.map((t) => {
       if (t.granularity) return t;
+      if (!bucketsUnstatedEntry(t.dimension)) return t;
       const granularity = granularityFor(t.dimension);
       return granularity ? { ...t, granularity } : t;
     });


### PR DESCRIPTION
Fixes #5688

## 前提重验(对 origin/main `628b028`,含 fb3d99b/#5808 与 #5963/#5716)

**前提成立,三个必要条件逐字复现。** 以正文的 dataset 与三条数据实测,输出与立单描述逐字节一致:

```
fields [{"name":"owner","type":"string","label":"Owner"},{"name":"close_date","type":"time"},{"name":"opp_count",…}]
rows   [{"owner":"u1","close_date":"2026-01","opp_count":1},
        {"owner":"u1","close_date":"2026-02","opp_count":1},
        {"owner":"u2","close_date":"2026-01","opp_count":1}]
```

附带症状同样成立:被投影的 `close_date` 在 `fields` 里只有 `type` 没有 `label`;同一 dataset 里把 `close_date` 写进 `selection.dimensions` 时则有 `label: "Close Date"` —— 富化循环只读 `selection.dimensions` 的盲区。

## 改动

按裁决「回填判据收窄」,落在 `buildQuery` 的 `resolvedTimeDims` 一处:未写 `granularity` 的条目**仅当**该 dimension 是本次查询的网格维度、或 `selection.dateGranularity` 已设时才回填默认粒度(条目自带 `granularity` 的走不到这里,照旧分桶并投影,#4033 不变)。

`resolveDimensionGranularity` **未改**:它回答「桶多大」,不回答「要不要分桶」。两个问题拆开写在注释里,因为它们在同一处打架正是本单的成因 —— dataset 维度的 `dateGranularity` 说的是「这个日期**被分组时**怎么渲染」,不是「请按它分组」。

## compareTo 的对齐语义(同场必答项)

**定义**:compareTo 不隐含分桶需求;它锚定的条目按与其它条目**完全相同**的判据决定是否分桶,主趟与比较趟因此**按构造**得到同一结论 —— `runCompare` 经 `runMeasurePass` 回到同一个 `buildQuery`,网格维度与 `selection.dateGranularity` 都相同,只有 `dateRange` 被平移。

- **锚定条目被选中 / 显式粒度** → 两趟都分桶,#3588/#4870 的刻意修复原样保留(用例断言两趟 groupBy 都是 `{field:'close_date', dateGranularity:'month'}`)。
- **锚定条目纯窗口** → 两趟都不分桶,收窄不是「保住」而是**修好**了对齐。`mergeByDimensions` 一直只按 `selection.dimensions` 建键,回填出来的桶列从来不在合并键里:实测同一 owner 被裂成多行时,比较值落在索引最后写入的那一行上,其余行读到一个自信的 `0`。

实测(比较窗口内**有**数据,且 u1 的比较值跨两个月 = 1 + 2,单月凑不出来):

```
改前  [{owner:u1, close_date:'2026-01', opp_count:1, opp_count__compare:0},
       {owner:u1, close_date:'2026-02', opp_count:1, opp_count__compare:2},
       {owner:u2, close_date:'2026-01', opp_count:1, opp_count__compare:1}]
改后  [{owner:u1, opp_count:2, opp_count__compare:3},
       {owner:u2, opp_count:1, opp_count__compare:1}]
```

KPI 单值卡(`dimensions: []`)同理:改前是两行月桶、卡片读第一行,改后一行 `{opp_count:3, opp_count__compare:4}`。

**PM 机制假设 1 未被证伪** —— 未发现「窗口-only 不分桶」与「compareTo 对齐」不可同时满足的形状,不报 fork。

## label 富化盲区(#5691 现状 + 顺手收掉)

先读了 #5691:它是 #5537 的 PR,已 **closed/merged**(2026-08-06T00:49:29Z),不是待认领的单,无撞车。它把盲区作为**成对控制用例**钉在 `dataset-dimension-field-descriptors.test.ts` 里并指向本单。

修法:`fields` 的维度 label 富化,查找集合从 `selection.dimensions` 扩到「本次 selection 通过 `timeDimensions` 引用到的 dataset 维度」。**扩的是查找,不是投影** —— 循环仍然只富化 `result.fields` 里已经存在的条目,所以停留为纯窗口的条目不产生列、也拿不到描述符(#5691 在该处写下的「只富化、不造列」边界原样保留,并另加注释说明为什么没有并进 `selectedDims`:钻取元数据与行值 label 解析回答的是另一个问题,动它们会改钻取载荷与行值,而不是表头)。

## 翻 pin:承重,不是删断言

`dataset-dimension-field-descriptors.test.ts` 的成对控制用例是明写的翻转靶,两条都翻了,并且都**加重**了:

- 除列集外,新增断言网格实质 —— 一个 owner 一行、窗口内三条记录聚成一桶(改前是 2 + 1 两行),以及「没有哪一行带着描述符没提的列」;
- 两个 block 的用例仍然逐列相同,收敛关系不变。

新增 `dataset-window-timedimension-bucketing.test.ts`(11 例)钉住收窄判据的**三条正向臂**与**反向臂**、compareTo 成对双向行为、以及一条「dataset 未声明 `dateGranularity`」的对照(证明声明本身就是触发条件,而不是假定)。

## 反向验证(先预测方向,再跑;拆成两半各自隔离)

方向普通(红),无反转、无计数移动。

- **只还原 executor 收窄**:预测 8 红 —— block 1 四例 + compareTo 窗口-only 两例 + 翻转的 #5537 两例;block 2 四条守卫与 compareTo 分桶锚定例保持绿。**实测 8 红,逐例吻合**。
- **只还原 analytics-service 的 label 扩集**:预测 1 红 —— 仅「条目自带 granularity 且未被选中」那条的 label 断言。**实测 1 红**,正是该例。

两半各自承重,互不代偿。

## 范围与门禁

- ⛔ 未触 #5963 刚信封化的四处 throw;`dataset-refusal-envelope` / `filter-refusal-envelope` / `unlisted-refusal-envelope` / `read-scope-refusal-envelope` 与 `dataset-compare-dimension-resolution` 全绿,拒收到达条件无变化(判据只影响 granularity 回填,不影响 `dateRange` 是否存在)。
- ⛔ 未触 `packages/spec`、dataset-compiler、strategies 的拒收面。
- 消费半径已清扫:`packages/rest`(62 文件 / 854 例绿)、`packages/qa/dogfood` 的 analytics/temporal 四个文件(18 例绿,其中 #4033 那条走的正是「条目自带 granularity」这条保留分桶的路径)。`examples/app-crm`、`app-showcase` 确有声明 `dateGranularity` 的 dataset(可达性属实),但仓库内无一处 fixture 把窗口-only 条目与声明了 `dateGranularity` 的维度组合起来,故无其它 fixture 需要改判。

## 必答项:对 #5717(`isMissingSourceError` 嗅探器)的影响

**完全无影响**,三条独立理由:

1. 位置不同 —— 嗅探器包在 `DatasetExecutor.execute()` 的 `catch` 上(`analytics-service.ts` :796),判的是**驱动抛出的 relation-missing 错误**;本改动只动 `buildQuery` 里成功路径的 granularity 判据,不新增、不消除、不改写任何异常。
2. 到达条件不变 —— 收窄只可能让某条 timeDimensions 条目**不再**进入 GROUP BY,而 `isMissingSourceError` 关心的是表/关系是否存在,与是否分桶正交。
3. 已实测 —— `dataset-cross-datasource-registration.test.ts` 等相关用例全绿,未出现新的空结果吞没路径。

既没让它变简单,也没让它变难,更没让它变得不必要。

## 验证

`.github/workflows/lint.yml` 逐个枚举全跑(lint / slot-lookup / query-options-erasure / nul-bytes / doc-authoring / docs-audit-scope / role-word / adr-anchors / org-identifier / authz-resolver / service-providers / route-envelope / error-code-casing / wildcard-fallthrough / init-service-contract / durability-log-level / startup-registry-verdict / objectui-changeset / release-notes / release-body / node-version / workflow-status-functions / published-files / engine-double-contract / resume-authority-declared),全绿;typecheck 侧 `check:type-check-coverage`(本包 3 error 的实测台账**未移动**)/ `check:driver-conformance` / `check:stall-guard` 全绿。

`@objectstack/service-analytics`:59 文件 / 1092 例(改前基线)→ **60 文件 / 1103 例全绿**。

changeset 已加(用户可见行为变更:窗口-only selection 的**行数与列集**同时变化 —— 此前多出的月列与裂行消失)。


---
_Generated by [Claude Code](https://claude.ai/code/session_015a5qkLzpGXhLL2F5gvJ7dD)_