### PR TITLE
fix(analytics): $ne / $nin / $notContains 在 Cube 面保留无值行 (#5298 第二批) (#5977)

### DIFF
--- a/.changeset/analytics-filter-normalizer-null-safe-negation.md
+++ b/.changeset/analytics-filter-normalizer-null-safe-negation.md
@@ -1,0 +1,40 @@
+---
+'@objectstack/service-analytics': patch
+'@objectstack/spec': patch
+---
+
+analytics: `$ne` / `$nin` / `$notContains` in a dashboard `where` keep the rows that have no value
+
+Second batch of the #5298 ruling, after PR #5962 landed it on `driver-sql`,
+`read-scope-sql` and `formula`. An analytics filter meaning "not this" now
+returns the rows whose column is empty, the same answer every other backend
+gives — a `stage != 'won'` widget shows the deals with no stage set.
+
+The Cube face was the last surface still splitting on it, and it split three
+ways for one filter. Measured on the package's own fixture before the change,
+for `{stage: {$ne: 'won'}}` with rows 3-4 carrying a NULL `stage`:
+
+| compiler | was | now |
+|---|---|---|
+| `NativeSQLStrategy` raw SQL | `2` | `2,3,4` |
+| `ObjectQLStrategy` display-SQL echo | `2` | `2,3,4` |
+| `ObjectQLStrategy` engine condition | `2,3,4` | `2,3,4` |
+
+The engine column was already right — because `driver-sql` guards for itself
+since #5962, not because the analytics layer did — so which rows a widget drew
+depended on which compiler downstream caught the leaf, and the `/analytics/sql`
+echo described a narrower query than the one that ran.
+
+`filter-normalizer` now emits the guard as tree STRUCTURE (an `or` of the null
+predicate with the comparison) rather than as a SQL trick in one strategy, so
+all three compilers of that tree produce one predicate and none of them needs
+to know the rule. Which operators are guarded is decided by the polarity table
+the `$not` rewrite already consults, not by a second list of operator names:
+positive comparisons (`$eq`, `$in`, `$contains`, the ordering family) compile
+byte-identically to before, `$ne: null` stays `IS NOT NULL`, an empty `$nin`
+stays the TRUE constant, and `{$not: {stage: {$ne: 'won'}}}` still means
+"stage is won" rather than widening.
+
+`FILTER_LOGIC_CASES` is unchanged: the `$ne` and `$not` null rows enrol in
+#5903's PR, which clears the last backend (`driver-turso` remote). The spec
+table's measured blocker matrix drops the Cube row it no longer describes.

--- a/packages/services/service-analytics/src/__tests__/filter-normalizer-not-null-safe.test.ts
+++ b/packages/services/service-analytics/src/__tests__/filter-normalizer-not-null-safe.test.ts
@@ -354,8 +354,16 @@ describe('[#5325] analytics `where` — NULL-safe `$not` and the boolean identit
       // filter excludes. `{$not: {$ne: 'won'}}` means "stage IS won".
       expect(await ids({ $not: { stage: { $ne: 'won' } } })).toEqual(['1']);
       expect(await ids({ $not: { stage: { $nin: ['won'] } } })).toEqual(['1']);
+      // [#5298] The guard now appears TWICE: `nullSafeNegationOperand`'s
+      // `allowNull` arm wraps the field spec, and `fieldLeaves` wraps the `$ne`
+      // leaf itself because the operator is NULL-safe everywhere now, not only
+      // under a `$not`. `X OR (X OR Y)` ≡ `X OR Y`, so the predicate is the one
+      // this case has always asserted — the two id sets above are the guarantee,
+      // and they are unchanged. Asserted as it is actually emitted rather than
+      // trimmed to the prettier form: a pin that describes SQL the compiler does
+      // not produce is how the next reader learns to distrust this file.
       const { sql } = await sqlFor({ $not: { stage: { $ne: 'won' } } });
-      expect(sql).toContain('NOT ((stage IS NULL OR stage != $1))');
+      expect(sql).toContain('NOT ((stage IS NULL OR (stage IS NULL OR stage != $1)))');
     });
 
     it('`$not` of an ordering comparison returns the NULL rows', async () => {
@@ -435,6 +443,103 @@ describe('[#5325] analytics `where` — NULL-safe `$not` and the boolean identit
       const { sql } = await sqlFor({ $not: { account: { region: 'NA' } } });
       expect(sql).toContain('NOT (("account"."region" IS NOT NULL AND "account"."region" = $1))');
       expect(sql).not.toContain('"deal"."account" IS NOT NULL');
+    });
+  });
+
+  // ── [#5298] The operators that carry their OWN negation ───────────────────
+
+  /**
+   * [#5298] `$ne` / `$nin` / `$notContains` OUTSIDE a `$not`.
+   *
+   * The ruling that finished what #5146 started: an operator that means "not
+   * this" answers TRUE for a column with no value, on every backend. Before
+   * this, the Cube face compiled the bare three-valued forms (`stage != $1`,
+   * `NOT IN`, `NOT LIKE`), each of which is UNKNOWN for a NULL column, so a
+   * `WHERE` dropped exactly the rows the JS backends return.
+   *
+   * The ids are the same ones `driver-sql`'s `sql-driver-not-null-safe.test.ts`,
+   * `formula`'s `matches-filter-not-null-safe.test.ts` and this package's
+   * `read-scope-not-null-safe.test.ts` assert for the same filters — moving one
+   * re-opens the divergence rather than adjusting a local expectation.
+   *
+   * Measured before the fix on this exact fixture (#5977), each answering `2`:
+   * `NativeSQLStrategy`, and the display-SQL echo. The ObjectQL ENGINE column
+   * already answered `2,3,4` — because `driver-sql` guards for itself since
+   * #5962, not because this module did — which is the whole reason the guard
+   * belongs here: three compilers of one tree must not need three copies of one
+   * rule to agree.
+   */
+  describe('[#5298] `$ne` / `$nin` / `$notContains` include the no-value rows', () => {
+    const echo = async (where: unknown): Promise<{ sql: string; params: unknown[] }> =>
+      new ObjectQLStrategy().generateSql(query(where), objectqlCtx);
+
+    it('`$ne` returns the NULL-stage rows — was `2`', async () => {
+      expect(await ids({ stage: { $ne: 'won' } })).toEqual(['2', '3', '4']);
+    });
+
+    it('`$nin` returns them — was `2`', async () => {
+      expect(await ids({ stage: { $nin: ['won'] } })).toEqual(['2', '3', '4']);
+    });
+
+    it('`$notContains` returns them — was `2`', async () => {
+      expect(await ids({ stage: { $notContains: 'wo' } })).toEqual(['2', '3', '4']);
+    });
+
+    it('the guard is an OR expansion, the shape #5962 landed everywhere else', async () => {
+      // Not a dialect equivalent (`IS DISTINCT FROM` / `<=>`): `NOT LIKE` has no
+      // such form, so the family would have needed two shapes. The cost-list
+      // measurement (#5298 §2/§3) found the query plans identical either way.
+      expect((await sqlFor({ stage: { $ne: 'won' } })).sql)
+        .toContain('WHERE (stage IS NULL OR stage != $1)');
+      expect((await sqlFor({ stage: { $nin: ['won'] } })).sql)
+        .toContain('WHERE (stage IS NULL OR stage NOT IN ($1))');
+      expect((await sqlFor({ stage: { $notContains: 'wo' } })).sql)
+        .toContain('WHERE (stage IS NULL OR stage NOT LIKE $1 ESCAPE $2)');
+    });
+
+    it('the ObjectQL path and the display SQL agree with the raw-SQL path', async () => {
+      // The three compilers of this tree, one predicate. The echo matters on its
+      // own: a statement that describes a NARROWER query than the one that ran
+      // sends whoever is debugging "why does this chart show empty rows" after a
+      // predicate the engine never applied (#5333's failure, mirrored).
+      expect(await engineIds({ stage: { $ne: 'won' } })).toEqual(['2', '3', '4']);
+      expect(await engineIds({ stage: { $nin: ['won'] } })).toEqual(['2', '3', '4']);
+      expect(await engineIds({ stage: { $notContains: 'wo' } })).toEqual(['2', '3', '4']);
+      expect((await echo({ stage: { $ne: 'won' } })).sql)
+        .toContain('(stage IS NULL OR stage != $1)');
+    });
+
+    it('positive comparisons take NO guard — the polarity table decides, not a name list', async () => {
+      // A blanket null escape would hand back the rows these filters exclude.
+      // `$eq` / `$in` / `$contains` are the family `nullValueSatisfiesOperator`
+      // answers `false` for, and they compile byte-identically to before.
+      expect((await sqlFor({ stage: { $eq: 'won' } })).sql).toContain('WHERE stage = $1');
+      expect((await sqlFor({ stage: { $in: ['won'] } })).sql).toContain('WHERE stage IN ($1)');
+      expect((await sqlFor({ stage: { $contains: 'wo' } })).sql)
+        .toContain('WHERE stage LIKE $1 ESCAPE $2');
+      expect(await ids({ stage: { $eq: 'won' } })).toEqual(['1']);
+      expect(await ids({ stage: { $contains: 'wo' } })).toEqual(['1']);
+    });
+
+    it('the operators that are already TOTAL are not wrapped either', async () => {
+      // `$ne: null` compiles to `set` (`IS NOT NULL`), which is two-valued by
+      // construction — wrapping it would turn "stage has a value" into a
+      // tautology. `operatorIsNullTotal` is what keeps the two apart, and it
+      // reads the COMPARAND, which is why a hard-coded list of three operator
+      // NAMES would have been wrong here as well as duplicated.
+      expect((await sqlFor({ stage: { $ne: null } })).sql).toContain('WHERE stage IS NOT NULL');
+      expect(await ids({ stage: { $ne: null } })).toEqual(['1', '2']);
+      // An empty `$nin` is the TRUE constant (#5134), also total.
+      expect((await sqlFor({ stage: { $nin: [] } })).sql).toContain('1 = 1');
+      expect(await ids({ stage: { $nin: [] } })).toEqual(ALL);
+    });
+
+    it('a guarded leaf still ANDs with its siblings', async () => {
+      // The guard is ONE conjunct — `(stage IS NULL OR stage != 'won')` — so the
+      // OR binds tighter than the AND the node's keys form. Parenthesised
+      // wrongly, `owner = 'u1'` would have been swallowed into the disjunction
+      // and the filter would have widened instead of narrowing.
+      expect(await ids({ stage: { $ne: 'won' }, owner: 'u1' })).toEqual(['3']);
     });
   });
 
@@ -627,9 +732,12 @@ describe('[#5325] analytics `where` — NULL-safe `$not` and the boolean identit
       expect(sql).toContain('WHERE stage = $1');
       expect(params).toEqual(['won']);
       expect(await ids({ stage: 'won' })).toEqual(['1']);
-      // Still three-valued OUTSIDE a negation: `!= 'won'` drops the NULL rows.
-      // That divergence from the JS backends is real and out of #5146's scope.
-      expect(await ids({ stage: { $ne: 'won' } })).toEqual(['2']);
+      // [#5298] `$ne` outside a negation used to answer `['2']` — three-valued
+      // SQL dropping the NULL rows the JS backends return — and this line
+      // recorded that divergence as "real and out of #5146's scope". #5298 ruled
+      // it, so the answer moved to the JS family's; the cases for the whole
+      // trio are in the `$ne` / `$nin` / `$notContains` block below.
+      expect(await ids({ stage: { $ne: 'won' } })).toEqual(['2', '3', '4']);
       expect(await ids({})).toEqual(ALL);
     });
   });
@@ -714,9 +822,12 @@ describe('[#5325] analytics `where` — NULL-safe `$not` and the boolean identit
       expect(normalizeAnalyticsFilterTree({ where: { stage: { $eq: '' } } })).toEqual({
         kind: 'leaf', member: 'stage', operator: 'equals', values: [''],
       });
-      // And a non-null comparand of the same operators is untouched.
+      // And a non-null comparand of the same operators is still a VALUE
+      // comparison — `$eq` unchanged, `$ne` answering the JS family's row set
+      // since #5298 (the NULL rows satisfy "is not 'won'"; what stays out is the
+      // reading of `''` as a null predicate, which is what this case guards).
       expect(await ids({ stage: { $eq: 'won' } })).toEqual(['1']);
-      expect(await ids({ stage: { $ne: 'won' } })).toEqual(['2']);
+      expect(await ids({ stage: { $ne: 'won' } })).toEqual(['2', '3', '4']);
     });
 
     it('the ObjectQL path hands the engine a null predicate, not `\'\'`', async () => {

--- a/packages/services/service-analytics/src/__tests__/filter-operator-coverage.test.ts
+++ b/packages/services/service-analytics/src/__tests__/filter-operator-coverage.test.ts
@@ -64,20 +64,30 @@ const CUBE: Cube = {
  */
 const CASES: Array<{ op: string; filter: FilterCondition; expected: string[]; note?: string }> = [
   { op: '$eq', filter: { name: { $eq: 'alpha-one' } }, expected: ['a_alpha'] },
-  { op: '$ne', filter: { name: { $ne: 'alpha-one' } }, expected: ['b_alphex', 'c_beta'] },
+  {
+    op: '$ne',
+    filter: { name: { $ne: 'alpha-one' } },
+    expected: ['b_alphex', 'c_beta', 'd_null'],
+    note: '#5298: `d_null` has no `name`, and "has no value" satisfies "is not alpha-one" on every backend. It was excluded while this path emitted a bare `name != ?`, which SQL evaluates UNKNOWN for NULL.',
+  },
   { op: '$gt', filter: { score: { $gt: 20 } }, expected: ['c_beta', 'd_null'] },
   { op: '$gte', filter: { score: { $gte: 20 } }, expected: ['b_alphex', 'c_beta', 'd_null'] },
   { op: '$lt', filter: { score: { $lt: 20 } }, expected: ['a_alpha'] },
   { op: '$lte', filter: { score: { $lte: 20 } }, expected: ['a_alpha', 'b_alphex'] },
   { op: '$in', filter: { name: { $in: ['alpha-one', 'beta-one'] } }, expected: ['a_alpha', 'c_beta'] },
-  { op: '$nin', filter: { name: { $nin: ['alpha-one'] } }, expected: ['b_alphex', 'c_beta'] },
+  {
+    op: '$nin',
+    filter: { name: { $nin: ['alpha-one'] } },
+    expected: ['b_alphex', 'c_beta', 'd_null'],
+    note: '#5298: same ruling as `$ne` — `NOT IN` is UNKNOWN for a NULL column, so `d_null` used to fall out of a set it is not a member of.',
+  },
   { op: '$between', filter: { score: { $between: [20, 30] } }, expected: ['b_alphex', 'c_beta'], note: '#4128: was dropped → every row.' },
   { op: '$contains', filter: { name: { $contains: 'one' } }, expected: ['a_alpha', 'c_beta'] },
   {
     op: '$notContains',
     filter: { name: { $notContains: 'one' } },
-    expected: ['b_alphex'],
-    note: 'On the ObjectQL path this had no arm and fell to the default, compiling "does not contain" as an EQUALITY.',
+    expected: ['b_alphex', 'd_null'],
+    note: 'On the ObjectQL path this had no arm and fell to the default, compiling "does not contain" as an EQUALITY. #5298 added `d_null`: `NOT LIKE` is UNKNOWN for a NULL column, so a row with no `name` was dropped from "name does not contain one".',
   },
   {
     op: '$startsWith',

--- a/packages/services/service-analytics/src/__tests__/objectql-contains-canonical-operator.test.ts
+++ b/packages/services/service-analytics/src/__tests__/objectql-contains-canonical-operator.test.ts
@@ -143,6 +143,68 @@ function matchesLikeFamily(row: (typeof FIXTURE)[number], cond: Record<string, u
   return true;
 }
 
+/**
+ * [#5298] Evaluate the whole `FilterCondition` the strategy hands the engine,
+ * not just its `stage` entry.
+ *
+ * `$notContains` is NULL-safe now, so the strategy emits it as
+ * `{$or: [{stage: null}, {stage: {$notContains: …}}]}` and the condition no
+ * longer has `stage` at the top level. Reading `filter.stage` alone therefore
+ * found `undefined`, handed {@link matchesLikeFamily} an EMPTY operator object,
+ * and every row passed the empty loop — the whole fixture came back and the
+ * assertion below would have been green for a filter that matched nothing in
+ * particular. A stand-in engine that cannot read the shape under test measures
+ * the stand-in, so it walks the tree.
+ */
+function matchesCondition(row: (typeof FIXTURE)[number], cond: Record<string, unknown>): boolean {
+  for (const [key, value] of Object.entries(cond)) {
+    if (key === '$and') {
+      if (!(value as Record<string, unknown>[]).every((c) => matchesCondition(row, c))) return false;
+      continue;
+    }
+    if (key === '$or') {
+      if (!(value as Record<string, unknown>[]).some((c) => matchesCondition(row, c))) return false;
+      continue;
+    }
+    if (key !== 'stage') throw new Error(`[test] this face only scopes "stage", got "${key}"`);
+    // A bare `null` comparand is the null PREDICATE — the guard's own disjunct,
+    // and the spelling every driver reads as IS NULL.
+    if (value === null) {
+      if (row.stage !== null) return false;
+      continue;
+    }
+    if (!matchesLikeFamily(row, value as Record<string, unknown>)) return false;
+  }
+  return true;
+}
+
+/**
+ * Every operator key the condition carries for `stage`, at any depth.
+ *
+ * [#5298] Also a tree walk, for the same reason {@link matchesCondition} is: the
+ * NULL-safe guard moves the operator object one level down, and a lookup that
+ * stopped at `filter.stage` reported ZERO operators — which the "is it declared"
+ * assertion would have passed vacuously had it not also demanded a non-empty
+ * set. That non-empty demand is why this file caught the shape change instead
+ * of quietly asserting nothing.
+ */
+function stageOperators(cond: Record<string, unknown>): string[] {
+  const found: string[] = [];
+  const walk = (node: Record<string, unknown>): void => {
+    for (const [key, value] of Object.entries(node)) {
+      if (key === '$and' || key === '$or') {
+        for (const child of value as Record<string, unknown>[]) walk(child);
+        continue;
+      }
+      // `{stage: null}` is the null predicate, not an operator object.
+      if (value === null || typeof value !== 'object') continue;
+      found.push(...Object.keys(value as Record<string, unknown>));
+    }
+  };
+  walk(cond);
+  return found;
+}
+
 /** Point sql.js at the `.wasm` shipped inside its own package (Node-safe). */
 async function locateWasm(): Promise<((file: string) => string) | undefined> {
   try {
@@ -189,8 +251,12 @@ describe('[#5557] `contains` reaches the engine as `$contains`, comparand taken 
     });
 
     it('the three siblings are unchanged — the family is uniform now', async () => {
+      // [#5298] `$notContains` is NULL-safe, so it reaches the engine wrapped in
+      // the null-predicate disjunct. What THIS case asserts is unaffected and
+      // still exact: the operator key is the declared `$notContains` and the
+      // comparand is the author's literal `'a.b'`, not a `$regex` pattern.
       expect(await engineFilter({ stage: { $notContains: 'a.b' } })).toEqual({
-        stage: { $notContains: 'a.b' },
+        $and: [{ $or: [{ stage: null }, { stage: { $notContains: 'a.b' } }] }],
       });
       expect(await engineFilter({ stage: { $startsWith: 'a.b' } })).toEqual({
         stage: { $startsWith: 'a.b' },
@@ -213,7 +279,7 @@ describe('[#5557] `contains` reaches the engine as `$contains`, comparand taken 
         ['$endsWith', 'a.b'],
       ] as const) {
         const filter = await engineFilter({ stage: { [op]: comparand } });
-        const emitted = Object.keys((filter.stage ?? {}) as Record<string, unknown>);
+        const emitted = stageOperators(filter);
         expect(emitted.length, `${op} emitted no operator`).toBeGreaterThan(0);
         for (const key of emitted) {
           expect(declared.has(key), `${op} emitted undeclared operator "${key}"`).toBe(true);
@@ -237,9 +303,8 @@ describe('[#5557] `contains` reaches the engine as `$contains`, comparand taken 
           _object: string,
           options: { filter?: Record<string, unknown> },
         ) => {
-          const cond = ((options.filter ?? {}) as Record<string, unknown>).stage;
-          const pred = (cond ?? {}) as Record<string, unknown>;
-          return FIXTURE.filter((r) => matchesLikeFamily(r, pred)).map((r) => ({
+          const cond = (options.filter ?? {}) as Record<string, unknown>;
+          return FIXTURE.filter((r) => matchesCondition(r, cond)).map((r) => ({
             id: r.id,
             total: 1,
           }));
@@ -271,9 +336,12 @@ describe('[#5557] `contains` reaches the engine as `$contains`, comparand taken 
     it('the anchored siblings stay anchored on the same fixture', async () => {
       expect(await ids({ stage: { $startsWith: 'a.' } })).toEqual(['1']);
       expect(await ids({ stage: { $endsWith: '.b' } })).toEqual(['1']);
-      // NULL `stage` (row 5) satisfies neither direction on this face — a
-      // non-string value fails every LIKE arm, matcher included.
-      expect(await ids({ stage: { $notContains: 'a.b' } })).toEqual(['2', '3', '4']);
+      // [#5298] Row 5 has no `stage`, and "has no value" now satisfies "does not
+      // contain a.b" — the JS family's answer, reached here through the guard's
+      // null-predicate disjunct rather than through the matcher, whose LIKE arms
+      // still reject a non-string. The anchored pair above is the control: they
+      // are positive-polarity, take no guard, and row 5 stays out of both.
+      expect(await ids({ stage: { $notContains: 'a.b' } })).toEqual(['2', '3', '4', '5']);
     });
   });
 

--- a/packages/services/service-analytics/src/__tests__/objectql-daterange.test.ts
+++ b/packages/services/service-analytics/src/__tests__/objectql-daterange.test.ts
@@ -307,9 +307,15 @@ describe('ObjectQLStrategy — window ∧ where on one field (#3650)', () => {
       ctx,
     );
 
+    // [#5298] The `$ne` operand arrives NULL-safe: `fieldLeaves` emits it as an
+    // `or` of the null predicate with the comparison, so "stage is not lost"
+    // keeps the rows that have no stage — the answer every other backend gives.
+    // What this case is about is unchanged and still visible: BOTH operands
+    // survive, the second as its own `$and` conjunct rather than overwriting the
+    // bare equality.
     expect(seen[0].filter).toEqual({
       stage: 'won',
-      $and: [{ stage: { $ne: 'lost' } }],
+      $and: [{ $or: [{ stage: null }, { stage: { $ne: 'lost' } }] }],
     });
   });
 });

--- a/packages/services/service-analytics/src/strategies/filter-normalizer.ts
+++ b/packages/services/service-analytics/src/strategies/filter-normalizer.ts
@@ -94,6 +94,40 @@
  * `NOT (c IS NOT NULL AND (c IS NOT NULL AND c = v))` is the same predicate —
  * so it buys portability for one redundant conjunct.
  *
+ * # `$ne` / `$nin` / `$notContains` are NULL-safe too (#5298)
+ *
+ * Same rule, same reason, one ruling later. The operators that carry their OWN
+ * negation had the defect #5146 fixed for `$not`: a bare `col <> ?` is UNKNOWN
+ * for a NULL column and the `WHERE` drops the row, while the JS backends return
+ * it. Measured on this package's own fixture before the fix (#5977), for
+ * `{stage: {$ne: 'won'}}` over rows whose `stage` is NULL:
+ *
+ *   | path                                   | was       | now (= JS family) |
+ *   |----------------------------------------|-----------|-------------------|
+ *   | `NativeSQLStrategy` (raw SQL)          | `2`       | `2,3,4`           |
+ *   | `ObjectQLStrategy` display SQL echo    | `2`       | `2,3,4`           |
+ *   | `ObjectQLStrategy` → engine condition  | `2,3,4`   | `2,3,4`           |
+ *
+ * The engine column was already right, and that is the whole argument for
+ * fixing it HERE: it was right because `driver-sql` guards for itself (#5962),
+ * so the Cube face's answer depended on which compiler downstream caught the
+ * leaf — three emitters, two answers. `fieldLeaves` now emits the guard as
+ * STRUCTURE, an `or` of `notSet` with the comparison, so all three compile the
+ * same predicate and none of them needs to know the rule. That is the same
+ * trade the `$not` rewrite above took, including its cost: the engine path
+ * guards twice, which is idempotent (`c IS NULL OR (c IS NULL OR c <> v)`).
+ *
+ * Which operators get the guard is NOT a new list — it is
+ * {@link nullValueSatisfiesOperator} and {@link operatorIsNullTotal}, the same
+ * pair `nullGuardForFieldSpec` consults for the `$not` rewrite, asked about one
+ * operator instead of a whole field spec. A leaf is guarded exactly when a NULL
+ * value SATISFIES the operator and the compiled leaf is not already total, which
+ * is that pair's `allowNull` verdict. Hard-coding the three names would have put
+ * a second polarity table in this file, free to drift from the first — and the
+ * `$eq`/`$ne` arms of the existing one already turn on the COMPARAND (`$ne:
+ * null` compiles to `set`, which is total and must never be widened), so a name
+ * list would have been wrong as well as duplicated.
+ *
  * # A `null` COMPARAND is a null predicate, not a value (#5332)
  *
  * `{stage: null}` compiled to `IS NULL` while `{stage: {$eq: null}}` compiled to
@@ -524,7 +558,20 @@ function fieldLeaves(key: string, raw: unknown): NormalizedFilterNode[] {
           );
         }
         const v = wrapper[opKey];
-        leaf(cubeOp, Array.isArray(v) ? v.map(comparand) : [comparand(v)]);
+        const values = Array.isArray(v) ? v.map(comparand) : [comparand(v)];
+        // [#5298] The operators that carry their own negation are NULL-safe,
+        // here as everywhere else — see the module header's section on it.
+        if (nullValueSatisfiesOperator(opKey, v) && !operatorIsNullTotal(opKey, v)) {
+          out.push({
+            kind: 'or',
+            children: [
+              { kind: 'leaf', member: key, operator: 'notSet', values: [] },
+              { kind: 'leaf', member: key, operator: cubeOp, values },
+            ],
+          });
+          continue;
+        }
+        leaf(cubeOp, values);
       }
       return out;
     }

--- a/packages/spec/src/data/filter-logic-conformance.ts
+++ b/packages/spec/src/data/filter-logic-conformance.ts
@@ -95,17 +95,25 @@
  *
  * The FIXTURE half of this work is DONE (#5298): {@link FilterLogicRow.d} is
  * nullable, all eleven harnesses declare and seed it, and the `$null` partition
- * below proves they seeded it as NULL. What remains is two backends, both
- * measured against this fixture on 2026-08-06 rather than assumed:
+ * below proves they seeded it as NULL. What remains is ONE backend, measured
+ * against this fixture on 2026-08-06 rather than assumed:
  *
  * | backend | `{d: {$ne: 'v1'}}` | `{$not: {d: 'v1'}}` | blocker |
  * |---|---|---|---|
  * | `driver-turso` REMOTE | `['2']` | `['2']` | #5903 |
- * | `service-analytics` `filter-normalizer` (Cube) | `['2']` | ✅ | #5298 batch 2 |
  *
  * Everything else already answers `['2','3','4']` on both: `driver-sql`,
  * `driver-sqlite-wasm`, `driver-turso` LOCAL, `read-scope-sql`, `driver-memory`
  * (both surfaces), `driver-mongodb` and `formula`.
+ *
+ * `service-analytics`'s `filter-normalizer` (the Cube face) was the second row
+ * of that table until #5977, answering `['2']` for `$ne` while already answering
+ * `$not` correctly — the #5146 rewrite lived in the normalizer, the three
+ * self-negating operators did not. It now emits the guard as tree STRUCTURE, so
+ * all three compilers of that tree (raw SQL, the ObjectQL engine condition and
+ * the display-SQL echo) answer `['2','3','4']`. That leaves `driver-turso`
+ * remote as the sole blocker for BOTH rows, so `$ne` and `$not` now enrol
+ * together, in #5903's PR.
  *
  * `driver-turso` remote is the interesting one and the reason the pre-#5298
  * version of this note was WRONG where it said "every surface answers this


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5977

#5298 裁决的**第二批**(第一批 PR #5962 已 MERGED:driver-sql 五出口 + read-scope-sql + formula)。方向按「四项确认落档」④:非否定路径 `$ne` / `$nin` / `$notContains` **包含 NULL 行**。

## 一、先实测(派发词第 1 条):前提成立,但发射点与 issue 正文的指认不同

用真实消费端驱动(`NativeSQLStrategy` 端到端跑 sql.js;ObjectQL 路径在 `executeAggregate` 缝上捕获引擎 filter 并真实执行),fixture 为本包既有的 `filter-normalizer-not-null-safe.test.ts` 那张表(行 3/4 的 `stage` 为 NULL)。`{stage: {$ne: 'won'}}` 改动前实测:

| 编译器 | 改前 | 改后 |
|---|---|---|
| `NativeSQLStrategy` 原生 SQL | `2` | `2,3,4` |
| `ObjectQLStrategy` 回显 SQL(`/analytics/sql`) | `2` | `2,3,4` |
| `ObjectQLStrategy` → 引擎 condition | `2,3,4` | `2,3,4` |

改前 WHERE 逐字为 `stage != $1` / `stage NOT IN ($1)` / `stage NOT LIKE $1 ESCAPE $2` —— 三条在 SQL 三值逻辑下对 NULL 列都是 UNKNOWN,`WHERE` 于是丢掉正是 JS 家族会返回的行。**与裁决方向分叉,实锤**,所以本单不是零改动单。

**但正文对落点的指认需要修正**(rule 6:issue body is a lead, not a spec):正文说的 `filter-normalizer.ts:267-275` 是 `MONGO_TO_CUBE_OP` 这张**算子改名表**,它本身不决定 NULL 行为;真正的发射器是 `native-sql-strategy.ts` 的 `buildFilterClause` 与 `objectql-strategy.ts` 的 `buildFilterClauseSql`。成本清单 §1.C 把 Cube 面记成一个发射点,实际是**两个**。

第三列也值得单独读:引擎那列改前就是对的,但**不是因为 analytics 层做对了**,而是因为 #5962 让 `driver-sql` 自己加了守卫。也就是说,一条 widget filter 画出哪些行,取决于下游哪个编译器先接住这枚叶子。回显那列最糟——它描述的语句比真正跑的语句**更窄**,正是 #5333 反过来的失败模式。

## 二、改法:守卫做成**树结构**,而不是某一个 strategy 里的 SQL 技巧

`fieldLeaves` 现在把叶子发成 `or(notSet, 比较)`。这样这棵树的三个编译器产出同一个谓词,**没有一个需要知道这条规则**;也因此**没有触碰 ⛔ 的 `objectql-strategy.ts`**,回显路径是白拿的。

这正是本文件里 #5146 `$not` 改写已经采用的同一笔交易(header 里写着「the rewrite lives HERE rather than in native-sql-strategy on purpose」),包括它的代价:引擎路径会守卫两次,而这是幂等的(`c IS NULL OR (c IS NULL OR c <> v)`)。

**哪些算子被守卫不是新列表**——复用既有极性对 `nullValueSatisfiesOperator` / `operatorIsNullTotal`,守卫恰好落在它们的 `allowNull` 判定上(即 `nullGuardForFieldSpec` 对单算子的问法)。这两个 arm 读的是**比较数**而非算子名,所以:

- `$ne: null` 仍编译成 `set`(`IS NOT NULL`),是 total,绝不能被拓宽 —— 硬编码三个算子**名字**在这里会出错;
- 空 `$nin` 仍是 TRUE 常量;
- 正向比较(`$eq` / `$in` / `$contains` / 序关系族)逐字节不变;
- `{$not: {stage: {$ne: 'won'}}}` 仍然是「stage 就是 won」,没有被拓宽(极性per算子,这条有专门用例)。

## 三、反向验证:方向如预判为 **RED**(非计数门反转)

本改动是直白的谓词变更(不是 PR #5046 那种喂给计数的 alias 肢),所以预判「拆掉守卫 → 新钉子转红」,实测吻合:把守卫条件短路掉后 **15 条转红**,含新增 7 条 #5298 钉子全红,恢复后全绿。

派发词第 4 条预判的「native-sql harness 的 N1 格转绿」**不适用**:N1 至今未入 `FILTER_LOGIC_CASES`(见下),所以 harness 里没有 N1 这一格可转;等效证据是上面那张实测表 + 新增钉子。如实记录而非套模板。

## 四、fixture 三分诊(逐条判,不批量改写)

4 个文件 10 条红,逐条判定:

- **补/改期望值**:`filter-operator-coverage.test.ts` 三格加 `d_null` 行;`objectql-daterange.test.ts` 引擎 filter 形状(它的主题「两个操作数都活下来、后者不覆盖前者」不变且仍可见)。
- **整体替换**:`objectql-contains-canonical-operator.test.ts` 的替身引擎只读 `filter.stage`,而加守卫后条件树顶层已没有 `stage` —— 它于是拿到一个**空**算子对象,循环体一次不执行,**全表通过**。这条断言当时是「因为什么都没产生而绿」,正是要整体替换的那一类:改成走树的求值器;算子键断言同样从 `Object.keys(filter.stage)` 换成树遍历。
- **翻面**:`filter-normalizer-not-null-safe.test.ts` 里那行把此分叉记作「real and out of #5146's scope」的注释,现在正是裁决的答案。

**消费半径按规则的调用面扫**,不是按改动包扫:`rest`(依赖 service-analytics)全绿 854;`cli` / `verify` / `qa-dogfood` 无相关 fixture。

## 五、N1 入表判定(派发词第 3 条):**留给 #5903**

按 #5298 PM 裁定的「后落地者入表」规则,收尾时实测 `git log origin/main` 与 issue 状态:**#5903 仍 open、未 MERGED**(`git log origin/main --grep=5903` 空),本 PR 是两者中的**先落地者**,故 `FILTER_LOGIC_CASES` **一行未加**,N1 如实留给 #5903。

但 spec 表文档里那张**实测 blocker 矩阵**必须订正:它写着 Cube 面 `$ne` 答 `['2']`,本 PR 之后这句话就成了假话。已把该行摘掉,并写明 Cube 面已对齐、`driver-turso` remote 成为 `$ne` 与 `$not` **两行共同的最后一个 blocker**,于是两行随 #5903 一起入表。

## 六、边界与验证

⛔ 全部遵守:未动 `like-pattern.ts` / `strategies/objectql-strategy.ts`(#5234 在飞)、未动任何 driver 包、未动 driver-memory/mongodb、未动 `content/docs/releases/`。

- `pnpm --filter @objectstack/service-analytics test` → **59 files / 1105 passed**(基线 1097,新增 8 条)
- `pnpm --filter @objectstack/spec test` → **323 files / 8288 passed**
- `pnpm --filter @objectstack/rest test` → **62 files / 854 passed**
- 两包 `typecheck` 绿;`check-nul-bytes` 绿;changeset 自带
- 基于最新 `origin/main`(`ffd51fd7a`)rebase 后复跑

⚠️ #5234 与本单同包不同源文件、零源码重叠;其 LIKE 收紧可能与 `objectql-contains-canonical-operator.test.ts` 相邻,后落地者 rebase。


---
_Generated by [Claude Code](https://claude.ai/code/session_01WyvqvKMG6asi9aXjKE6xtx)_