### PR TITLE
docs(automation): flows.mdx 的 Scheduled flow 示例补 runAs: 'system' (#5692)

### DIFF
--- a/content/docs/automation/flows.mdx
+++ b/content/docs/automation/flows.mdx
@@ -1244,6 +1244,7 @@ export const contractExpirationCheck: Flow = {
   label: 'Contract Expiration Check',
   type: 'schedule',
   status: 'active',
+  runAs: 'system', // a schedule run has no trigger user — elevate explicitly
   nodes: [
     {
       id: 'start',


### PR DESCRIPTION
Fixes #5692

## 问题

`content/docs/automation/flows.mdx` 的 "Scheduled flow" worked example `contract_expiration_check` 是 `type: 'schedule'`、nodes 含 top-level `get_record`(`find_expiring`)的流程,却没有声明 `runAs`。

schedule run 解析不到 trigger user,生效的 `runAs` 是 spec 默认 `'user'`,`get_record` 没有身份可 scope —— `flow-runas-unscoped` 按 `severity: 'error'` 判红。**照抄这段的作者会得到一次失败的构建**;硬闯过去则运行时被引擎拒绝(#3760)。

这份文档在同一个文件里把这条约束讲了两遍,然后在最可能被整段复制的示例里违反了它:

- ~35 行之下的 time-relative 邻例 `renewal_reminder` 写对了,还把理由带成一行注释;
- 同文档 `runAs` 属性表散文写明 "declare `'system'` for schedule / time-relative / API triggers"。

## 改动

一行,docs-only:

```diff
   name: 'contract_expiration_check',
   label: 'Contract Expiration Check',
   type: 'schedule',
   status: 'active',
+  runAs: 'system', // a schedule run has no trigger user — elevate explicitly
   nodes: [
```

注释理由照抄邻例(`// a sweep has no trigger user — elevate explicitly`),句式与结尾逐字保持一致,只把主语换成本例真实的触发形态:在本文档里 "sweep" 是 `timeRelative` 描述符那一形态的术语("a `schedule` flow whose `start` node declares a `timeRelative` descriptor is **swept** on a schedule"),而本例是普通 cron schedule,照搬 "a sweep" 会把错误的术语带进语料。

## 实测(A/B,两侧都跑)

探针不是手抄片段,而是**直接从 `flows.mdx` 抽取 fenced typescript 代码块**、求值成 flow 对象后跑真规则 `lintFlowPatterns()`(`packages/lint` 的构建产物),所以测的就是作者会复制的那段文本本身。

**Before**(`origin/main` @ `f192981`,未改动的文件):

```
doc: content/docs/automation/flows.mdx
snippets evaluated: contract_expiration_check, renewal_reminder

1 x flow-runas-unscoped  <-  contract_expiration_check (type: 'schedule', no runAs)
      error: schedule-triggered flow runs as the default `runAs:'user'`, but a schedule run has no trigger user — so its data node 'find_expiring' (get_record) has no identity to scope to and will be REFUSED at run time.
      where: flow 'contract_expiration_check' · runAs
0 x flow-runas-unscoped  <-  renewal_reminder (type: 'schedule', runAs: 'system')

TOTAL flow-runas-unscoped findings: 1
```

**After**(本 PR):

```
doc: content/docs/automation/flows.mdx
snippets evaluated: contract_expiration_check, renewal_reminder

0 x flow-runas-unscoped  <-  contract_expiration_check (type: 'schedule', runAs: 'system')
0 x flow-runas-unscoped  <-  renewal_reminder (type: 'schedule', runAs: 'system')

TOTAL flow-runas-unscoped findings: 0
```

方向是跑之前就定好的:目标片段 1 次(error)→ 0,邻例 `renewal_reminder` 作为**对照**两侧都是 0。全文件 `type: 'schedule'` 的示例只有这两个(L1245 / L1282),改完之后该规则对本文件命中归零。

## 与 #5633 的关系

本片段的证据节点 `find_expiring` 是 **top-level** `get_record`,所以 #5633(把同一条规则加宽到 nested regions)前后对它的判定逐字节一致 —— 这是既有的语料缺陷,不是回归,也不在 #5633 的范围内。

## 门禁(本地,已跑)

```
✓ doc authoring guard: 362 files clean — no bare metadata literals.
check-nul-bytes: OK (scanned 5763 tracked text file(s); ... no raw ASCII control bytes).
✓ docs-accuracy-audit scope is in sync with content/docs/: 178 hand-written doc(s).
```

## Changeset

docs-only,没有可发布的包变更 —— 不提交空 changeset(空 frontmatter 的 changeset 会真的进 changesets/action,#4898),改为打 `skip-changeset` 标签。

## 不扩面

issue 正文末尾提的「提取 fenced flow 片段、对其跑 authoring rules 的语义门禁」是另立单范围,本 PR 不做,也不动其它示例。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_