### PR TITLE
fix(service-analytics): dataset 降级路径先读 ADR-0112 信封,再读措辞 (#5717)

### DIFF
--- a/.changeset/analytics-dataset-degradation-envelope-first.md
+++ b/.changeset/analytics-dataset-degradation-envelope-first.md
@@ -1,0 +1,66 @@
+---
+"@objectstack/service-analytics": patch
+---
+
+fix(analytics): a dataset refusal that declares an ADR-0112 envelope is never degraded to an empty result (#5717)
+
+`queryDataset` wraps execution in a catch that exists for one deliberate reason
+(#5033): a widget whose backing object is not mounted in this kernel renders
+"no data" instead of failing with a 500. The criterion for "not mounted" was
+`isMissingSourceError` — a substring match over the error MESSAGE. So the
+leniency was available to any error that happened to phrase itself like a
+driver, and #5352 / #5367's finding on the REST face — "the wire shape of an
+error family must not be a property of its wording" — applied here one level
+worse: the outcome was not a wrong status code but a **silent empty result**.
+No exception, no 4xx, no 5xx; one `warn` line and a confident empty chart, which
+is the "populated table, Total Spend: 0" symptom #5033 was filed about.
+
+One refusal already matched. `dataset-compiler.ts` refuses an `include` naming a
+relationship the object graph does not have with
+
+> `[dataset-compiler] dataset "X" includes relationship "R" which does not exist on object "O".`
+
+which carries both `relation` (inside "relationship") and `does not exist` — and
+that conjunction was the postgres limb. It has never gone off for one reason:
+`queryDataset` compiles **before** the try, so that throw has never been inside
+the catch's reach. A mine, wired and unarmed.
+
+**Two independent defences, so the disarming does not depend on either one.**
+
+- **The criterion (main change).** An error carrying an ADR-0112 envelope —
+  numeric `status` + non-empty `code`, the same structural fact
+  `rest-server.ts`'s `/analytics/dataset/query` catch reads — is re-thrown
+  untouched, ahead of any message inspection. Its producer already answered the
+  classification question. The status RANGE is deliberately not part of the
+  test: a `DATASET_INVALID` / 400 rendered as an empty grid is the loud case,
+  but a declared 5xx (`READ_SCOPE_COMPILE_FAILED` — an RLS lowering that failed
+  closed) is if anything worse to swallow, since nobody is told at all.
+- **The sniffer.** Its postgres limb is now anchored to postgres's actual
+  wording (`relation "x" does not exist`) instead of "any sentence containing
+  both words" — the same pattern the sibling `missingSourceRelation` already
+  used, so "is something missing" and "what is missing" can no longer disagree.
+
+**Observable behaviour change — read this if you alert on empty widgets.** The
+guarantee is new, not the status of any shipped message: measured over the 13
+real wordings this repo carries (three driver families including sql-prefixed
+and schema-qualified forms, the framework's not-registered signals, and this
+package's own refusals), exactly one verdict moves — the compiler refusal above,
+which reaches callers as `400 DATASET_INVALID` either way because its throw site
+sits outside the try. What changes is that a caller-shaped refusal raised
+**during execution** can no longer become `{rows: [], fields: [], totals: []}`
+by phrasing alone: it now propagates and the route answers its declared code
+(4xx as itself, declared 5xx through `ANALYTICS_QUERY_FAILED`). A dashboard that
+silently rendered an empty chart for such a refusal will now surface the error.
+
+**#5033's leniency is untouched, and that is asserted rather than claimed.** A
+bare driver error is still classified by its words and still degrades: `no such
+table` (sqlite/libsql), postgres's real `relation "x" does not exist`, mysql's
+`doesn't exist`, the framework's not-registered signals — and a bare error
+naming a JOINED table still fails loudly as a cross-datasource dataset. Those
+cases are green in all four states of the reverse verification
+(`dataset-degradation-envelope.test.ts`), including with both defences reverted.
+
+The compile point deliberately stays outside the try. Moving it in would newly
+expose the compiler's own bare invariants and the host-supplied relationship
+resolver to this degradation path — widening leniency in the opposite direction
+from the fix.

--- a/packages/services/service-analytics/src/__tests__/dataset-degradation-envelope.test.ts
+++ b/packages/services/service-analytics/src/__tests__/dataset-degradation-envelope.test.ts
@@ -1,0 +1,335 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#5717] The dataset degradation path judges an error by its ENVELOPE first,
+ * and only then by its words.
+ *
+ * ## What was wrong
+ *
+ * `queryDataset` wraps execution in a catch whose whole job is #5033's
+ * deliberate leniency: a widget whose backing object is not mounted in this
+ * kernel renders "no data" instead of a 500. The criterion for "not mounted"
+ * was `isMissingSourceError` — a substring match over the error MESSAGE. So the
+ * degradation was available to any error that happened to phrase itself like a
+ * driver, and #5352/#5367's finding on the REST face ("the HTTP status of an
+ * error family must not be a property of its wording") applied here one level
+ * worse: the outcome was not a wrong status code but a SILENT EMPTY RESULT —
+ * no exception, no 4xx, no 5xx, one `warn`, and a confident empty chart.
+ *
+ * One refusal already matched. `dataset-compiler.ts`'s
+ *
+ *   `[dataset-compiler] dataset "X" includes relationship "R" which does not
+ *    exist on object "O".`
+ *
+ * carries both `relation` (inside "relationship") and `does not exist`, which
+ * is exactly what the postgres limb tested for. It never went off for one
+ * reason: `queryDataset` compiles BEFORE the try, so that throw has never been
+ * inside the catch's reach. A mine, wired and unarmed — armed by any future
+ * edit that moves the compile in, or by any executor/strategy refusal that ever
+ * phrases itself the same way.
+ *
+ * ## The two defences, and which case pins which
+ *
+ * They are independent, and this file keeps them separable on purpose:
+ *
+ *   - **B (the criterion)** — an error carrying an ADR-0112 envelope (numeric
+ *     `status` + non-empty `code`) is re-thrown untouched, whatever it says.
+ *     Its producer already answered the classification question. Pinned by the
+ *     cases whose message STILL matches the sniffer after C: the real
+ *     `CUBE_NOT_FOUND` / 404 gate error (which says "…is not a registered
+ *     object…") and the declared-5xx case.
+ *   - **C (the sniffer)** — the postgres limb is anchored to postgres's actual
+ *     wording instead of "any sentence with both words", so the compiler
+ *     refusal no longer matches it even stripped of its envelope. Pinned by the
+ *     BARE compiler-wording case.
+ *
+ * The compiler refusal itself is therefore covered TWICE — by B because #5963
+ * gave it `DATASET_INVALID` / 400, and by C because the anchor no longer reads
+ * "relationship" as "relation". Both are asserted, and the pair is the reason
+ * the mine is disarmed rather than merely stepped around.
+ *
+ * ## What deliberately did NOT change
+ *
+ * #5033's semantics, verbatim: a BARE driver error is still classified by its
+ * words and still degrades to `{rows: [], fields: [], totals: []}` + a `warn`
+ * (`no such table`, postgres's real `relation "x" does not exist`), and a bare
+ * error naming a JOINED table still fails loudly as a cross-datasource dataset.
+ * The compile point also stays OUTSIDE the try — see the PR for the
+ * measurement: moving it in would newly expose the compiler's own bare
+ * invariants and the host-supplied relationship resolver to the degradation
+ * path, which widens leniency in the opposite direction from this fix.
+ *
+ * ## Reverse verification — direction predicted BEFORE running
+ *
+ * Ordinary direction (red), but SPLIT, and the split is the point: reverting
+ * one defence leaves the other holding the compiler case, so "revert the fix
+ * and watch it all go red" would be a false expectation here.
+ *
+ *   - revert **B** only (drop the `hasDeclaredErrorEnvelope` branch):
+ *     `CUBE_NOT_FOUND` and declared-5xx go RED (both degrade to an empty
+ *     result); both compiler cases stay GREEN — C alone still saves them.
+ *   - revert **C** only (restore `includes('relation') && includes('does not
+ *     exist')`): the BARE compiler case goes RED; the enveloped one stays
+ *     GREEN — B alone still saves it.
+ *   - revert BOTH: all four go RED.
+ *
+ * MEASURED, one revert at a time, on this file (11 cases):
+ *   B only reverted → **2 red / 9 green** — `CUBE_NOT_FOUND`, declared-5xx.
+ *   C only reverted → **1 red / 10 green** — the bare compiler wording.
+ *   both reverted   → **4 red / 7 green** — those three plus the ENVELOPED
+ *   compiler wording, the mine itself, which is the one case that needs BOTH
+ *   defences gone before it fires. (This line predicted "3" first: the union of
+ *   the two single-revert sets is 3, and the mine is the fourth — it is exactly
+ *   the case neither single revert can reach. The prediction is left corrected
+ *   rather than quietly fixed, because that fourth row IS the finding.)
+ *
+ * The #5033 cases are green in every one of those four states, which is what
+ * "the deliberate leniency is untouched" means as evidence rather than as a
+ * claim.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { DatasetSchema } from '@objectstack/spec/ui';
+import type { ExecutionContext } from '@objectstack/spec/kernel';
+import { AnalyticsService } from '../analytics-service.js';
+import { compileDataset } from '../dataset-compiler.js';
+
+/** The ADR-0112 fields the REST boundary classifies on. */
+interface Refusal extends Error {
+  code?: unknown;
+  status?: unknown;
+}
+
+const EMPTY = { rows: [], fields: [], totals: [] };
+
+const dataset = DatasetSchema.parse({
+  name: 'sales',
+  label: 'Sales',
+  object: 'opportunity',
+  include: ['account'],
+  dimensions: [{ name: 'region', field: 'account.region', type: 'string' }],
+  measures: [{ name: 'revenue', aggregate: 'sum', field: 'amount' }],
+});
+
+const SELECTION = { dimensions: ['region'], measures: ['revenue'] };
+const CTX = { tenantId: 'org_A' } as ExecutionContext;
+
+function logger() {
+  return { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() } as any;
+}
+
+/**
+ * A service whose execution throws `thrown` — the only way into the catch under
+ * test. `isRegisteredObject` answers true so the #5033 cross-datasource triage
+ * behaves as it does in a real kernel.
+ */
+function serviceThatThrows(thrown: unknown, log = logger()) {
+  return new AnalyticsService({
+    queryCapabilities: () => ({ nativeSql: true, objectqlAggregate: false, inMemory: false }),
+    executeRawSql: async () => { throw thrown; },
+    isRegisteredObject: () => true,
+    logger: log,
+  });
+}
+
+async function refusalFrom(thunk: () => unknown | Promise<unknown>): Promise<Refusal | undefined> {
+  try {
+    await thunk();
+    return undefined;
+  } catch (e) {
+    return e as Refusal;
+  }
+}
+
+// ── the real producers, captured rather than re-typed ────────────────────────
+
+/**
+ * `dataset-compiler.ts`'s resolveHop refusal — the exact error object the real
+ * producer builds, wording and `DATASET_INVALID` / 400 envelope included. Its
+ * throw site is outside `queryDataset`'s try today; re-throwing it from INSIDE
+ * the try is precisely the "what if the compile moved in" question the mine
+ * poses, asked without moving anything.
+ */
+async function compilerRelationshipRefusal(): Promise<Refusal> {
+  const err = await refusalFrom(() =>
+    compileDataset(
+      DatasetSchema.parse({
+        name: 'sales',
+        label: 'Sales',
+        object: 'opportunity',
+        include: ['bogus'],
+        dimensions: [{ name: 'stage', field: 'stage', type: 'string' }],
+        measures: [{ name: 'revenue', aggregate: 'sum', field: 'amount' }],
+      }),
+      () => undefined,
+    ),
+  );
+  if (!err) throw new Error('the compiler accepted an unresolvable relationship — fixture is stale');
+  return err;
+}
+
+/**
+ * `analytics-service.ts`'s own `assertInferableCube` gate (#3867) —
+ * `CUBE_NOT_FOUND` / 404, and its message ends "…and it is not a registered
+ * object either…", which matches the sniffer's framework limb VERBATIM. Same
+ * shape of luck as the compiler refusal: on the dataset path `queryDataset`
+ * registers the compiled cube before executing, so this gate is not reachable
+ * there today. It is the case that isolates B, because no narrowing of the
+ * postgres limb can save it.
+ */
+async function cubeNotFoundRefusal(): Promise<Refusal> {
+  const svc = new AnalyticsService({
+    queryCapabilities: () => ({ nativeSql: true, objectqlAggregate: false, inMemory: false }),
+    executeRawSql: async () => [],
+    isRegisteredObject: () => false,
+    logger: logger(),
+  });
+  const err = await refusalFrom(() => svc.query({ cube: 'ghost', measures: ['count'] }));
+  if (!err) throw new Error('the cube-existence gate accepted an unregistered name — fixture is stale');
+  return err;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('[#5717] an error that declares an ADR-0112 envelope is never degraded to an empty result', () => {
+  it('the fixtures are the real producers, and both still match the sniffer’s framework limb', async () => {
+    // Guards the two captures above against silently becoming vacuous — the
+    // #5046 lesson: a case that passes because nothing is produced.
+    const compilerErr = await compilerRelationshipRefusal();
+    expect(compilerErr.message).toMatch(/includes relationship "bogus" which does not exist on object "opportunity"/);
+    expect(compilerErr.code).toBe('DATASET_INVALID');
+    expect(compilerErr.status).toBe(400);
+
+    const cubeErr = await cubeNotFoundRefusal();
+    expect(cubeErr.message).toMatch(/is not a registered object/);
+    expect(cubeErr.code).toBe('CUBE_NOT_FOUND');
+    expect(cubeErr.status).toBe(404);
+  });
+
+  it('CUBE_NOT_FOUND / 404 propagates — the case that no message narrowing can save', async () => {
+    // Isolates defence B: "…is not a registered object either…" is a verbatim
+    // sniffer hit before AND after the postgres limb was anchored, so only the
+    // envelope check keeps a 404 from rendering as "no data".
+    const log = logger();
+    const refusal = await cubeNotFoundRefusal();
+    const err = await refusalFrom(() =>
+      serviceThatThrows(refusal, log).queryDataset(dataset, SELECTION, CTX),
+    );
+    expect(err, 'a 404 was swallowed into an empty grid').toBeInstanceOf(Error);
+    expect(err?.code).toBe('CUBE_NOT_FOUND');
+    expect(err?.status).toBe(404);
+    // Not degraded ⇒ not warned about as an absent backing object either.
+    expect(log.warn).not.toHaveBeenCalledWith(expect.stringContaining('returning an empty result'));
+  });
+
+  it('a DECLARED 5xx propagates too — the envelope, not its range, is the criterion', async () => {
+    // A declared server fault (`read-scope-sql.ts`'s family — an RLS lowering
+    // that failed closed) is if anything worse to swallow than a 400: the
+    // widget would render a confident empty chart for a fault nobody is told
+    // about. The WORDING here is synthesised, deliberately: the rule under test
+    // is "the producer classified it", so the case must carry a message the
+    // sniffer would otherwise take (`unknown object`), which today's ten real
+    // read-scope messages do not.
+    const declared = Object.assign(
+      new Error('[read-scope-sql] read scope references unknown object "crm_account" (fail-closed).'),
+      { code: 'READ_SCOPE_COMPILE_FAILED', status: 500 },
+    );
+    const err = await refusalFrom(() => serviceThatThrows(declared).queryDataset(dataset, SELECTION, CTX));
+    expect(err?.code).toBe('READ_SCOPE_COMPILE_FAILED');
+    expect(err?.status).toBe(500);
+  });
+
+  it('the compiler’s relationship refusal is not swallowed — the mine, disarmed', async () => {
+    // The direct assertion #5717 asks for: the exact refusal, thrown from
+    // INSIDE the try (which is what moving the compile point would do), reaches
+    // the caller with its 400 envelope intact instead of becoming an empty grid.
+    const refusal = await compilerRelationshipRefusal();
+    const log = logger();
+    const err = await refusalFrom(() =>
+      serviceThatThrows(refusal, log).queryDataset(dataset, SELECTION, CTX),
+    );
+    expect(err, 'the mine went off — a 400 refusal became an empty result').toBeInstanceOf(Error);
+    expect(err?.code).toBe('DATASET_INVALID');
+    expect(err?.status).toBe(400);
+    expect(String(err?.message)).toMatch(/includes relationship "bogus" which does not exist/);
+    expect(log.warn).not.toHaveBeenCalledWith(expect.stringContaining('returning an empty result'));
+  });
+
+  it('…and stays unswallowed with the envelope STRIPPED — defence C, standing alone', async () => {
+    // The same wording as a bare `Error`: what this refusal was before #5963,
+    // and what any future re-worded refusal looks like. Nothing here declares
+    // anything, so only the anchored postgres limb can tell it apart from a
+    // driver reporting a missing table — and it does: "relationship" is not
+    // `relation "x"`, and the missing thing is a RELATIONSHIP, not a table.
+    const refusal = await compilerRelationshipRefusal();
+    const err = await refusalFrom(() =>
+      serviceThatThrows(new Error(refusal.message)).queryDataset(dataset, SELECTION, CTX),
+    );
+    expect(err, 'a bare refusal with the compiler wording was still swallowed').toBeInstanceOf(Error);
+    expect(String(err?.message)).toMatch(/includes relationship "bogus" which does not exist/);
+    // Bare ⇒ nothing to classify it with; it must arrive unclassified, not
+    // wearing an envelope this layer invented for it.
+    expect(err?.code).toBeUndefined();
+    expect(err?.status).toBeUndefined();
+  });
+
+  it('an enveloped 400 whose message says nothing driver-ish propagates as it always did', async () => {
+    // The neighbour a character away: this one never matched the sniffer, so it
+    // propagated before this change too. It is here so the block is not read as
+    // "only sniffer-matching refusals are protected" — the criterion is the
+    // envelope, and the guarantee is now independent of what the message says.
+    const { datasetInvalidError } = await import('../dataset-refusal.js');
+    const err = await refusalFrom(() =>
+      serviceThatThrows(datasetInvalidError('[dataset-executor] compareTo needs a dated window to shift.'))
+        .queryDataset(dataset, SELECTION, CTX),
+    );
+    expect(err?.code).toBe('DATASET_INVALID');
+    expect(err?.status).toBe(400);
+  });
+});
+
+describe('[#5717] #5033’s deliberate leniency for BARE driver errors is untouched', () => {
+  it('sqlite/libsql "no such table" still degrades to an empty result, with the warn', async () => {
+    const log = logger();
+    const result = await serviceThatThrows(
+      new Error('SELECT COUNT(*) FROM "opportunity" - no such table: opportunity'),
+      log,
+    ).queryDataset(dataset, SELECTION, CTX);
+    expect(result).toEqual(EMPTY);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('backing object "opportunity" is unavailable'),
+    );
+  });
+
+  it('postgres’s REAL wording still degrades — the anchor keeps the limb it was written for', async () => {
+    const result = await serviceThatThrows(
+      new Error('select "region" from "opportunity" - relation "opportunity" does not exist'),
+    ).queryDataset(dataset, SELECTION, CTX);
+    expect(result).toEqual(EMPTY);
+  });
+
+  it('mysql’s "doesn’t exist" still degrades', async () => {
+    const result = await serviceThatThrows(
+      new Error("Table 'app.opportunity' doesn't exist"),
+    ).queryDataset(dataset, SELECTION, CTX);
+    expect(result).toEqual(EMPTY);
+  });
+
+  it('a bare missing JOINED table still fails loudly as a cross-datasource dataset (#5033)', async () => {
+    // The louder half of #5033: the base table resolved, a JOINED one did not,
+    // and the joined object IS registered — a topology error, never "no data".
+    // Regression guard that the new envelope branch did not short-circuit past it.
+    const err = await refusalFrom(() =>
+      serviceThatThrows(new Error('no such table: account')).queryDataset(dataset, SELECTION, CTX),
+    );
+    expect(String(err?.message)).toMatch(/cannot be executed as one statement/);
+    expect(String(err?.message)).toMatch(/A dataset JOIN cannot cross datasources/);
+  });
+
+  it('a bare non-missing-source error still surfaces (real query bugs are not hidden)', async () => {
+    const err = await refusalFrom(() =>
+      serviceThatThrows(new Error('syntax error near "FROM"')).queryDataset(dataset, SELECTION, CTX),
+    );
+    expect(String(err?.message)).toMatch(/syntax error/);
+  });
+});

--- a/packages/services/service-analytics/src/analytics-service.ts
+++ b/packages/services/service-analytics/src/analytics-service.ts
@@ -81,6 +81,31 @@ type AnalyticsResultWithDrill = AnalyticsResult & {
 };
 
 /**
+ * [#5717] Does this error carry an ADR-0112 envelope — i.e. did its PRODUCER
+ * already classify it?
+ *
+ * The structural fact, read exactly as `rest-server.ts`'s
+ * `/analytics/dataset/query` catch reads it (`envelopeStatus`/`envelopeCode`):
+ * a numeric `status` plus a non-empty string `code`. Deliberately the SAME
+ * predicate rather than a second dialect of "looks enveloped" — a producer that
+ * ships half an envelope has a bug of its own and must be found, not guessed at
+ * from either end of the wire.
+ *
+ * Status RANGE is deliberately not part of it. The 4xx case is the loud one
+ * (#5717's own: a `DATASET_INVALID` / 400 refusal must reach the caller as a
+ * 400, never as an empty grid), but a DECLARED 5xx — `read-scope-sql.ts`'s
+ * `READ_SCOPE_COMPILE_FAILED` / 500 fail-closed refusals — is if anything worse
+ * to swallow: an RLS lowering that failed closed, rendered as a confident empty
+ * chart, is a server fault nobody is told about. Either way the producer has
+ * ANSWERED the classification question, and {@link isMissingSourceError} — a
+ * heuristic over DRIVER phrasing — has no business re-opening it.
+ */
+function hasDeclaredErrorEnvelope(err: unknown): boolean {
+  const e = err as { code?: unknown; status?: unknown } | null | undefined;
+  return typeof e?.status === 'number' && typeof e?.code === 'string' && e.code.length > 0;
+}
+
+/**
  * Detect the "backing object/table isn't present in this kernel" class of
  * error so a dataset query can degrade to an empty result instead of failing
  * the widget with a 500. Matches the missing-relation signatures across the
@@ -88,12 +113,43 @@ type AnalyticsResultWithDrill = AnalyticsResult & {
  * framework's own unknown-object signal. Deliberately scoped to MISSING SOURCE
  * (table/object/relation) — not column/syntax errors, which stay hard failures
  * so real query bugs still surface.
+ *
+ * ⚠️ It is a heuristic over driver PHRASING, so it is the SECOND question the
+ * degradation path asks, never the first: {@link hasDeclaredErrorEnvelope} runs
+ * ahead of it (#5717), and only an error whose producer declared nothing is
+ * classified by its words here.
+ *
+ * [#5717] The postgres limb is ANCHORED to postgres's actual wording
+ * (`relation "x" does not exist`, relation name quoted or bare) instead of the
+ * `includes('relation') && includes('does not exist')` conjunction it used to
+ * be. That conjunction matched any sentence carrying both words — including
+ * `dataset-compiler.ts`'s `… includes relationship "R" which does not exist on
+ * object "O"`, where the "relation" is inside "relationship" and the missing
+ * thing is a RELATIONSHIP, not a table. The anchor is the same pattern the
+ * sibling {@link missingSourceRelation} already uses for postgres (and the same
+ * shape as `metadata/src/utils/schema-sync-errors.ts`), so "is something
+ * missing" and "what is missing" can no longer disagree on this limb.
+ *
+ * MEASURED over the wordings this repo actually carries — 13 strings: the three
+ * driver families' phrasings (including sql-prefixed and schema-qualified
+ * forms), the framework's not-registered signals, and this package's own
+ * refusals — exactly ONE verdict moves, the compiler refusal above. No driver
+ * wording changes, which is what makes this a narrowing rather than a
+ * behaviour change for #5033's leniency.
+ *
+ * Known residue, filed as #6035 rather than widened into here: postgres spells
+ * a missing COLUMN on the write path as `column "c" of relation "t" does not
+ * exist`, which carries a whole missing-relation phrase inside it and so is a
+ * hit both before and after this anchor. Dormant on a read-only face (a SELECT
+ * says `column "c" does not exist`, no `relation`), but it is the one case
+ * where this predicate is still wider than the paragraph above it.
  */
 function isMissingSourceError(err: unknown): boolean {
-  const msg = String((err as { message?: unknown })?.message ?? err ?? '').toLowerCase();
+  const raw = String((err as { message?: unknown })?.message ?? err ?? '');
+  const msg = raw.toLowerCase();
   return (
     msg.includes('no such table') ||      // sqlite / libsql
-    (msg.includes('relation') && msg.includes('does not exist')) || // postgres
+    /relation\s+[`"']?[A-Za-z0-9_$.]+[`"']?\s+does not exist/i.test(raw) || // postgres
     msg.includes("doesn't exist") ||      // mysql ("table ... doesn't exist")
     msg.includes('not registered') ||     // framework: object not in registry
     msg.includes('unknown object') ||
@@ -789,10 +845,22 @@ export class AnalyticsService implements IAnalyticsService {
     // wearing a new cause: the base table is right there, and the widget would keep
     // rendering the confident `0` this issue is about. So triage by WHICH relation
     // the driver named, and let a cross-datasource dataset fail loudly.
+    //
+    // #5717 — and the leniency is scoped to errors NOBODY classified. The
+    // triage below reads message text, so before it runs, an error that carries
+    // an ADR-0112 envelope is re-thrown untouched: its producer already said
+    // what it is, and a `DATASET_INVALID` / 400 turned into `{rows: []}` is the
+    // #5033 symptom wearing the opposite disguise — the caller's own mistake
+    // reported as "no data", with no exception, no 4xx, no 5xx, just a warn and
+    // a confident empty chart. See {@link hasDeclaredErrorEnvelope}.
     let result: AnalyticsResult;
     try {
       result = await new DatasetExecutor(this, orderLabels).execute(compiled, selection, context);
     } catch (err) {
+      // The producer answered the classification question — the route's
+      // envelope reader serves it (4xx as itself, declared 5xx through the
+      // `ANALYTICS_QUERY_FAILED` path). Nothing here may re-judge it by wording.
+      if (hasDeclaredErrorEnvelope(err)) throw err;
       if (isMissingSourceError(err)) {
         const missing = missingSourceRelation(err);
         const detail = String((err as Error)?.message ?? err);


### PR DESCRIPTION
Fixes #5717

## 前提复核(立单行号已过期,以 origin/main `b5bdf48` 现状为准)

| 立单说法 | 现状 | 结论 |
|---|---|---|
| 嗅探器 `isMissingSourceError` | `analytics-service.ts:92` | 在 |
| 降级 catch | `:795`(`isMissingSourceError` 判据在 `:796`) | 在 |
| compiler 命中措辞 | `dataset-compiler.ts:281-284`,且 #5963 后自带 `DATASET_INVALID`/400 | 在,且已带信封 |
| 抛点在 try 之外 | 编译在 `:722`(`registerDataset`),try 在 `:793` 才开始 | 成立 —— 雷仍未接电 |

前提全部成立,`premise_still_valid: true`。

## 改了什么(范围 B + C,均落在 `analytics-service.ts` 一个文件)

**B(主判据)** —— catch 里新增优先分支:带 ADR-0112 信封的错误原样上抛,先于任何读措辞的逻辑。

信封判据抄仓内既有惯例、不发明第二种:`rest-server.ts` 的 `/analytics/dataset/query` catch 用的就是 `typeof status === 'number'` + 非空字符串 `code`(`envelopeStatus`/`envelopeCode`)。

**状态码区间刻意不入判据**,这一点与派发令里的示例(`status` 小于 500)不同,理由写在代码注释里:400 那一支是本单的明面(一条 `DATASET_INVALID`/400 变成空网格),但**已声明的 5xx**(`read-scope-sql.ts` 的 `READ_SCOPE_COMPILE_FAILED`/500 —— fail-closed 的 RLS 下推)被吞掉只会更糟:一个服务端故障被画成一张自信的空图,没有任何人被告知。两者的共同事实是「生产者已经回答了分类问题」,措辞启发式没有资格重新打开它。issue 正文 B 的原话也正是「降级路径只对**不带 ADR-0112 信封的错误**生效」,4xx 是其动机实例而非判据本身。

**C(可选支,做了)** —— postgres 那一支从 `includes('relation') && includes('does not exist')` 收紧为锚定 postgres 真实措辞的 `/relation\s+["'`]?[A-Za-z0-9_$.]+["'`]?\s+does not exist/i`,与同文件里**已经存在**的兄弟函数 `missingSourceRelation` 用的是同一条模式(`metadata/src/utils/schema-sync-errors.ts` 也是这个形状)。收紧后「是不是缺了什么」与「缺的是什么」这两个函数不会再在这一支上互相矛盾。

### C 的量化(实测,13 条仓内真实措辞)

| 措辞 | 收紧前 | 收紧后 |
|---|---|---|
| sqlite/libsql `no such table: t` | HIT | HIT |
| sqlite 经 knex(SQL 前缀) | HIT | HIT |
| postgres `relation "t" does not exist` | HIT | HIT |
| postgres schema 限定 `relation "public.acct" …` | HIT | HIT |
| postgres 缺列(写路径)`column "c" of relation "t" …` | HIT | HIT |
| postgres 缺列(读路径)`column "c" does not exist` | — | — |
| mysql `Table 'app.t' doesn't exist` | HIT | HIT |
| objectql `Datasource '…' … is not registered.` | HIT | HIT |
| rest `Object 'x' is not registered` | HIT | HIT |
| analytics `CUBE_NOT_FOUND`(#3867) | HIT | HIT |
| **dataset-compiler 关系拒收** | **HIT** | **—** |
| read-scope `nested/relation value …` | — | — |
| analytics measure 闸门(#4437) | — | — |

**13 条里只有 1 条改判,就是那条雷;没有任何真实驱动措辞改判** —— 这正是「收紧而非改变 #5033 行为」的证据。

## 为什么不把编译点移进 try(实测后的判断)

派发令把这一步留给实测。结论:**不移**,并说明未覆盖面。

移进去会让 `registerDataset` 路径上的**裸**错误新落入降级面:`dataset-compiler.ts:135` 的内部不变量(`non-derived measure … has no aggregate`)、以及宿主提供的 `relationshipResolver` / `getObjectDatasource` / `isExternalObject` 三个回调抛出的任何东西 —— 其中宿主回调抛 `Object 'x' is not registered` 一类会**新**被吞成空网格。那是把宽容度朝与本单相反的方向扩大(「Absence must be loud」/「prefer failing to falling back」),而本单要的是收窄。

雷本身不需要靠移编译点来拆:测试里直接把**真实 producer 造出来的那个错误对象**从 try 内部抛出(见下),这与「编译点被移进来」在 catch 看来是同一件事,却不引入上面那片新面。

## 测试

新增 `packages/services/service-analytics/src/__tests__/dataset-degradation-envelope.test.ts`(11 例),两块:

1. **带信封不降级** —— 三例都用**真实 producer** 捕获的错误对象,不是手抄字符串:
   - `CUBE_NOT_FOUND`/404(`assertInferableCube`,消息里含「is not a registered object」,收紧后**仍然**命中嗅探器 —— 这一例专门隔离 B,任何措辞收紧都救不了它);
   - 已声明 5xx(`READ_SCOPE_COMPILE_FAILED` 形状,措辞为合成,注释里写明为什么必须合成);
   - **compiler 那条拒收本体**(`compileDataset` 真跑出来的错误,含 `DATASET_INVALID`/400),从 try 内部抛出 —— 雷被正式拆除的直接断言。外加同一措辞**剥掉信封**的裸 Error 一例:那一例只有 C 能救。
2. **#5033 语义原样保留** —— `no such table`、postgres 真实措辞、mysql 措辞照旧降级为 `{rows: [], fields: [], totals: []}` + warn;裸的「join 表缺失」照旧响亮报跨库拓扑错误;裸的语法错误照旧上抛。

### 反向验证(方向在跑之前就写死了,并且是**分裂**的)

预测:两条防线互相独立,单独回退任何一条,另一条仍然接住 compiler 那一例 —— 所以「回退就全红」在这里是错误期待。实测(逐个回退,11 例):

| 回退 | 结果 | 红的是 |
|---|---|---|
| 只回退 B | 2 红 / 9 绿 | `CUBE_NOT_FOUND`、已声明 5xx |
| 只回退 C | 1 红 / 10 绿 | 裸措辞的 compiler 拒收 |
| 两条都回退 | **4 红 / 7 绿** | 上面三例 + **带信封的 compiler 拒收**(雷本身,唯一需要两条防线同时消失才会引爆的一例) |

最后一行我第一版预测写的是 3 红(两个单退集合的并集),实测 4 —— 差的那一例正是雷本身。测试文件头把这个更正**留在原处**而不是悄悄改掉,因为那第四行才是这一单的发现。四种状态下 #5033 的五条用例**全绿**,这就是「刻意宽容未被触动」的证据形态。

## 验证记录(全部前台阻塞执行,持容器级 `flock` 锁,`--max-old-space-size=4096`)

- `pnpm --filter @objectstack/service-analytics exec vitest run --maxWorkers=2` → **61 files / 1127 tests passed**
- `packages/rest` 消费半径(路由侧读信封的 7 个用例文件:`analytics-dataset-refusal-envelope` / `analytics-dataset-unlisted-refusal-envelope` / `analytics-dataset-dimension-gate` / `analytics-dataset-where-gate` / `analytics-filter-refusal-envelope` / `analytics-read-scope-refusal-envelope` / `analytics-routes`)→ **7 files / 84 tests passed**
- `lint.yml` 逐个枚举后跑过的门:`pnpm lint`(全仓 ESLint)、`check:nul-bytes`、`check:doc-authoring`、`check:adr-anchors`、`check:route-envelope`、`check:error-code-casing`、`check:wildcard-fallthrough`、`check:durability-log-level`、`check:startup-registry-verdict`、`check:engine-double-contract`、`check:slot-lookup`、`check:query-options-erasure`、`check:release-notes`、`check:type-check-coverage` —— 全 PASS(该包在 DEBT 账本里冻结 3 个错误,新测试文件没有改变计数)
- 控制字节自扫:`grep -naP` 扫三个改动文件的控制字节区间 → 干净

未触:`packages/spec`、drivers、`buildQuery` 粒度判据(#6003 面)、各拒收 throw 本体(#5963 面)。

## 必答项:对 #6007(compareTo 合并键错位)的影响

**完全无影响**,与预期一致。#6007 落在 `dataset-executor.ts` 的 compareTo 行合并逻辑(合并键构造),本 PR 只改 `analytics-service.ts` 里 `queryDataset` catch 的**分类顺序**与嗅探器的一条正则;两者不共享函数、不共享数据流。唯一的接触面是「若 compareTo 路径抛 `datasetInvalidError`,它现在保证不被降级」—— 那是本 PR 给 #6007 所在文件的**保障**,不改变 #6007 要修的合并行为,既不使其变简单也不使其变难、更不使其变得不必要。

## 出界发现

- 已立 #6035(`finding`,未派单):postgres **写路径**的缺列措辞 `column "c" of relation "t" does not exist` 内含一整段缺表措辞,收紧前后**都**命中嗅探器,而嗅探器自己的文档写明「不含列/语法错误」。只读面上不产生该措辞(SELECT 说的是 `column "c" does not exist`,不含 `relation`),属 observation 类;仓内已有先例(`rest-server.ts:825` 先摘缺列再判缺表)。本 PR 在 `isMissingSourceError` 的注释里指名了这条残留与 issue 号,不在本单顺手改 —— 它超出 C 的既定范围(C 是「只匹配 postgres 真实缺表措辞」,而这条措辞字面上**就是**它)。

---
_Generated by [Claude Code](https://claude.ai/code/session_015a5qkLzpGXhLL2F5gvJ7dD)_