### PR TITLE
fix(lint): `flow-runas-unscoped` 用一句两读皆真的措辞命名有效身份 (#5693)

### DIFF
--- a/.changeset/flow-runas-unscoped-region-descent.md
+++ b/.changeset/flow-runas-unscoped-region-descent.md
@@ -36,16 +36,20 @@ is a flow property and the region only supplies the evidence. The region is name
 in the **message** so you can find the node:
 
 ```
-flow 'nightly_sweep' · runAs: schedule-triggered flow runs as `runAs:'user'`, but a
-schedule run has no trigger user — so its data node 'touch' (update_record), in loop
-'loop_rows' body, has no identity to scope to and will be REFUSED at run time.
+flow 'nightly_sweep' · runAs: schedule-triggered flow runs under `runAs:'user'`
+(the default when none is declared), but a schedule run has no trigger user — so its
+data node 'touch' (update_record), in loop 'loop_rows' body, has no identity to scope
+to and will be REFUSED at run time.
 ```
 
+(The sentence's opening was re-worded by #5693 in this same release window; the
+sample above is the wording that actually ships.)
+
 **Nothing about the top-level case moved.** A flow whose evidence is a top-level
-data node produces the byte-identical message it always did (no region clause),
-and when a flow has data nodes at both altitudes the top-level one is still the
-node cited — `collectFlowGraphs` yields the flow's own graph before it descends.
-Both are pinned by tests.
+data node produces the same message with no region clause, and when a flow has
+data nodes at both altitudes the top-level one is still the node cited —
+`collectFlowGraphs` yields the flow's own graph before it descends. Both are
+pinned by tests.
 
 **If this newly fails your build:** the flow was already broken at run time. Add
 `runAs: 'system'` to declare the elevation the sweep needs (a schedule /

--- a/.changeset/flow-runas-unscoped-two-way-true-wording.md
+++ b/.changeset/flow-runas-unscoped-two-way-true-wording.md
@@ -1,0 +1,64 @@
+---
+"@objectstack/lint": patch
+---
+
+fix(lint): `flow-runas-unscoped` stops telling an author they declared a `runAs` they never wrote (#5693)
+
+The rule's message branched on whether `runAs` was **authored** or **defaulted**:
+
+```ts
+typeof flow.runAs === 'string' ? `runAs:'user'` : `the default runAs:'user'`
+```
+
+That distinction is real and useful — "you wrote something incoherent" is not
+"you inherited a default that does not fit a user-less trigger" — but the rule
+cannot observe it, and which arm an author got depended on the **surface** rather
+than on their file.
+
+**On the CLI, only the explicit arm was reachable.** `FlowSchema.runAs` carries
+`.default('user')` and the registry wires this rule `input: 'parsed'`, so
+`flow.runAs` is the string `'user'` whether the author wrote it or not. `os lint`
+does not Zod-parse, and would have escaped that — except `defineStack` /
+`defineFlow` parse at *definition* time, so the config module hands even the
+non-parsing command a stack with the default already filled in.
+
+Measured on `examples/app-todo`, `overdue_escalation` with its `runAs` line
+deleted — the author declared nothing:
+
+```
+BEFORE — os validate
+  flow 'overdue_escalation' · runAs: schedule-triggered flow runs as `runAs:'user'`, but a
+  schedule run has no trigger user — so its data node 'get_overdue_tasks' (get_record) …
+
+BEFORE — os lint
+  ✗ flow 'overdue_escalation' · runAs: schedule-triggered flow runs as `runAs:'user'`, but a
+  schedule run has no trigger user — so its data node 'get_overdue_tasks' (get_record) …
+```
+
+Both commands told someone who had written no `runAs` that their flow "runs as
+`runAs:'user'`" — which invites *"I never wrote that, the tool is confused"* at
+exactly the moment the tool is right and the fix is one line away.
+
+Meanwhile the **runtime publish gate** (#4463) judges the verbatim authored body,
+so it really did reach the other arm — the same flow was told two different
+things by two shipped surfaces.
+
+**What changed.** One sentence, true of both authoring inputs, on every surface:
+
+```
+AFTER — os validate and os lint, identical
+  flow 'overdue_escalation' · runAs: schedule-triggered flow runs under `runAs:'user'`
+  (the default when none is declared), but a schedule run has no trigger user — so its
+  data node 'get_overdue_tasks' (get_record) has no identity to scope to and will be
+  REFUSED at run time.
+```
+
+The parenthetical is a statement about the **value**, not an accusation about the
+author, so it stays true for someone who did write `runAs:'user'`. This is the
+house pattern rather than a new one: `flow-draft-status-ambiguous` says `has
+status 'draft' (the default when none is authored)` for the same reason, on the
+same mechanism.
+
+Only the wording moved: the same flows are flagged, with the same
+`severity: 'error'`, the same `where`, the same `hint`, and the same region
+clause when the evidence node is nested.

--- a/packages/lint/src/lint-flow-patterns.test.ts
+++ b/packages/lint/src/lint-flow-patterns.test.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
-import { TimeRelativeTriggerSchema, LoopConfigSchema } from '@objectstack/spec/automation';
+import { TimeRelativeTriggerSchema, LoopConfigSchema, FlowSchema } from '@objectstack/spec/automation';
+import { AUTHORING_RULES } from './authoring-rules.js';
 import {
   lintFlowPatterns,
   FLOW_TIME_RELATIVE_ANTIPATTERN,
@@ -339,7 +340,8 @@ describe('lintFlowPatterns — user-less runAs unscoped (#1888 / ADR-0049 / ADR-
     expect(fnds).toHaveLength(1);
     expect(fnds[0].rule).toBe(FLOW_RUNAS_UNSCOPED);
     expect(fnds[0].where).toContain('nightly_sweep');
-    expect(fnds[0].message).toMatch(/default .*runAs:'user'/);
+    // #5693 — one wording for both authoring inputs; see the dedicated block below.
+    expect(fnds[0].message).toMatch(/runAs:'user'` \(the default when none is declared\)/);
     expect(fnds[0].message).toMatch(/REFUSED/);
     expect(fnds[0].hint).toMatch(/runAs:'system'/);
   });
@@ -552,8 +554,11 @@ describe('lintFlowPatterns — user-less runAs unscoped (#1888 / ADR-0049 / ADR-
     });
 
     // The A/B twin. Same flow, same node, moved out of the body — this was
-    // already flagged before #5633, and its message must not have moved a byte.
-    it('leaves the TOP-LEVEL twin byte-identical (no region clause, no regression)', () => {
+    // already flagged before #5633, and its message must carry no region clause.
+    // (The sentence itself was re-worded once since, by #5693 — see the block at
+    // the end of this file for why the authored-vs-defaulted branch it used to
+    // carry could not survive.)
+    it('leaves the TOP-LEVEL twin without a region clause (no regression)', () => {
       const fnds = lintFlowPatterns({
         flows: [{
           name: 'nightly_sweep',
@@ -568,8 +573,8 @@ describe('lintFlowPatterns — user-less runAs unscoped (#1888 / ADR-0049 / ADR-
       expect(fnds).toHaveLength(1);
       expect(fnds[0].where).toBe("flow 'nightly_sweep' · runAs");
       expect(fnds[0].message).toBe(
-        "schedule-triggered flow runs as the default `runAs:'user'`, but a schedule run has no trigger " +
-        "user — so its data node 'touch' (update_record) has no identity to scope to and " +
+        "schedule-triggered flow runs under `runAs:'user'` (the default when none is declared), but a " +
+        "schedule run has no trigger user — so its data node 'touch' (update_record) has no identity to scope to and " +
         "will be REFUSED at run time.",
       );
       expect(fnds[0].message).not.toContain('in loop');
@@ -671,6 +676,104 @@ describe('lintFlowPatterns — user-less runAs unscoped (#1888 / ADR-0049 / ADR-
         expect(lintFlowPatterns(sweepFlow({ bodyNodeType: 'notify' }))
           .filter((f) => f.rule === FLOW_RUNAS_UNSCOPED)).toHaveLength(0);
       });
+    });
+  });
+
+  /**
+   * #5693 — ONE wording, true whether the author declared `runAs:'user'` or
+   * declared nothing.
+   *
+   * The message used to branch: `` `runAs:'user'` `` when `flow.runAs` was a
+   * string, `the default …` when it was absent. The distinction is real and
+   * useful — "you wrote something incoherent" is not "you inherited a default
+   * that does not fit a user-less trigger" — but *this rule cannot observe it*,
+   * and which arm an author got depended on the SURFACE rather than on their
+   * file:
+   *
+   *  - **CLI** — always the explicit arm. `FlowSchema.runAs` carries
+   *    `.default('user')` and the registry wires this rule `input: 'parsed'`, so
+   *    `flow.runAs` is the string `'user'` either way. `os lint` does not parse,
+   *    but `defineStack`/`defineFlow` parse at *definition* time, so even it
+   *    receives the default already materialized. Measured on `app-todo` with the
+   *    `runAs` line deleted: `os validate` AND `os lint` both told an author who
+   *    had declared nothing that their flow "runs as `runAs:'user'`".
+   *  - **Runtime publish gate (#4463)** — both arms, because it judges the
+   *    verbatim authored body (`saveMetaItem` keeps `request.item` past the
+   *    schema check).
+   *
+   * So the branch was not merely dead: it made one flow get two different
+   * sentences from two shipped surfaces, and on the surface authors meet first it
+   * produced the one that reads as an accusation. #5693 removed it in favour of a
+   * sentence that is true of both inputs on every surface.
+   *
+   * These two cases split the work deliberately, and only the second has teeth
+   * against a re-introduction — say so rather than let the pair read as one
+   * assertion made twice:
+   *
+   *  - the PARSED case pins *why* the branch was pointless (both inputs arrive as
+   *    the same object). A re-introduced branch would still pass it — that is the
+   *    point: the CLI cannot tell these apart, which is the whole defect.
+   *  - the UNPARSED case is the regression guard. It is the one input shape where
+   *    the two authoring choices are still distinguishable (and the shape the
+   *    runtime gate really passes), so any future `typeof flow.runAs === 'string'`
+   *    branch in the message fails it immediately.
+   */
+  describe("#5693 — one wording for authored `runAs:'user'` and for none at all", () => {
+    /**
+     * Authorable on purpose: `FlowSchema` requires `label` on the flow and on
+     * every node, so the raw literals the rest of this file feeds would fail the
+     * parse — and a fixture that cannot be parsed cannot demonstrate anything
+     * about the parsed tier. This one is the same sweep, declared in full.
+     */
+    const sweep = (runAs?: 'user') => ({
+      name: 'nightly_sweep',
+      label: 'Nightly Sweep',
+      type: 'schedule',
+      ...(runAs ? { runAs } : {}),
+      nodes: [
+        { id: 'start', type: 'start', label: 'Start', config: { triggerType: 'schedule', cron: '0 8 * * *' } },
+        { id: 'op', type: 'update_record', label: 'Touch', config: { objectName: 'thing', fields: { a: 1 } } },
+      ],
+      edges: [{ id: 'e1', source: 'start', target: 'op' }],
+    });
+
+    const EXPECTED =
+      "schedule-triggered flow runs under `runAs:'user'` (the default when none is declared), but a " +
+      "schedule run has no trigger user — so its data node 'op' (update_record) has no identity to scope to and " +
+      "will be REFUSED at run time.";
+
+    const messagesFor = (flow: unknown) =>
+      lintFlowPatterns({ flows: [flow] })
+        .filter((f) => f.rule === FLOW_RUNAS_UNSCOPED)
+        .map((f) => f.message);
+
+    it('is wired to the tier where the default has already been filled in', () => {
+      const wiring = AUTHORING_RULES.find((r) => r.name === 'lintFlowPatterns');
+      expect(wiring?.input).toBe('parsed');
+    });
+
+    it('PARSED input: the two authoring choices are literally the same object here', () => {
+      const authored = FlowSchema.parse(sweep('user'));
+      const defaulted = FlowSchema.parse(sweep());
+      // The premise, asserted rather than assumed: the parse materializes the
+      // default, so `flow.runAs` carries no trace of what was authored.
+      expect(defaulted.runAs).toBe('user');
+      expect(authored.runAs).toBe('user');
+
+      expect(messagesFor(defaulted)).toEqual([EXPECTED]);
+      expect(messagesFor(authored)).toEqual([EXPECTED]);
+    });
+
+    it('UNPARSED input: an absent key and an explicit one still get the same sentence', () => {
+      // The runtime publish gate's shape — the only surface where the omission
+      // survives to the rule. Both must read the same, or the surfaces disagree
+      // about one flow again.
+      expect(messagesFor(sweep())).toEqual([EXPECTED]);
+      expect(messagesFor(sweep('user'))).toEqual([EXPECTED]);
+    });
+
+    it('says the same thing to both surfaces about the same flow', () => {
+      expect(messagesFor(FlowSchema.parse(sweep()))).toEqual(messagesFor(sweep()));
     });
   });
 });

--- a/packages/lint/src/lint-flow-patterns.ts
+++ b/packages/lint/src/lint-flow-patterns.ts
@@ -122,14 +122,18 @@
  * flow-level, and the region is named in the **message** rather than in `where`
  * (`its data node 'touch' (update_record), in loop 'loop_rows' body,`): `where`
  * says which declaration is wrong, the message says where to find the proof. A
- * top-level hit yields the byte-identical message it always did — pinned in the
- * tests, since the wording is what every existing author already sees.
+ * top-level hit adds no region clause at all — pinned in the tests, since a
+ * top-level finding is what most authors see.
  *
  * What this fixes is not a corner. Query a set, loop it, write per item is *the*
  * shape of a scheduled data flow, so the write is almost always the nested node —
  * and because this rule gates the build, the shape it was missing built clean and
  * then could not run at all. That is precisely what promoting it to `error`
  * (#3760) was for.
+ *
+ * #5693 rewrote how that same message names the identity — one wording true of
+ * both authoring inputs instead of a branch on `flow.runAs` that no CLI command
+ * could take. See {@link RUNAS_EFFECTIVE_IDENTITY}.
  */
 
 import {
@@ -248,6 +252,49 @@ const INERT_CONDITION_NODE_TYPES = new Set([
 
 /** Node types that perform a data operation — the ones `flow.runAs` governs (#1888). */
 const DATA_NODE_TYPES = new Set(['get_record', 'create_record', 'update_record', 'delete_record']);
+
+/**
+ * How {@link FLOW_RUNAS_UNSCOPED} names the identity the run would use — ONE
+ * wording, true whether the author wrote `runAs:'user'` or wrote nothing (#5693).
+ *
+ * It replaces a ternary that told the author which of the two they had done:
+ * `` `runAs:'user'` `` when `flow.runAs` was a string, `the default …` when it
+ * was absent. That distinction is real, but the rule cannot observe it, and the
+ * arm it picked depended on the SURFACE rather than on the metadata:
+ *
+ *  - **CLI (`os validate` / `os build` / `os lint`) — always the explicit arm.**
+ *    `FlowSchema.runAs` carries `.default('user')`, and the registry wires this
+ *    rule `input: 'parsed'`, so `flow.runAs` is the string `'user'` either way.
+ *    `os lint` does not parse and would have escaped that, except that
+ *    `defineStack` (and `defineFlow`) parse at *definition* time, so the config
+ *    module hands even the non-parsing command a stack with the default already
+ *    materialized. Measured on `examples/app-todo` with the `runAs` line deleted:
+ *    both commands printed the EXPLICIT arm at an author who had declared nothing.
+ *  - **Runtime publish gate (#4463) — both arms.** It judges `request.item`, the
+ *    verbatim authored body (`saveMetaItem` keeps it verbatim past the schema
+ *    check), so an omitted key really is absent there.
+ *
+ * So the same flow was told two different things by two shipped surfaces, and on
+ * the surface an author uses first it was told the one that reads as an
+ * accusation: *"you declared `runAs:'user'`"* to someone who declared nothing —
+ * inviting "the tool is confused" at the exact moment the tool is right and the
+ * fix is one line. Restoring the distinction would mean giving a `parsed`-tier
+ * rule a second, pre-parse input; #5693 chose the wording instead.
+ *
+ * The parenthetical is a statement about the VALUE, not an accusation about the
+ * author, so it stays true for someone who did write `runAs:'user'`. That is the
+ * house pattern, not a new one: `flow-draft-status-ambiguous` says `has status
+ * 'draft' (the default when none is authored)` for exactly this reason, on
+ * exactly this mechanism (`validate-flow-trigger-readiness.ts`).
+ *
+ * `'user'` is spelled out rather than interpolated from `flow.runAs` because the
+ * branch that uses this has already excluded `'system'` and the enum holds only
+ * those two — so on every surface that reaches the message (CLI: parsed; runtime
+ * gate: `safeParse`d against the overlay schema before the gate runs) the
+ * effective identity IS `'user'`. Interpolating would re-introduce a limb only
+ * an off-spec literal could reach, which is the defect this replaced.
+ */
+const RUNAS_EFFECTIVE_IDENTITY = "`runAs:'user'` (the default when none is declared)";
 
 /**
  * The first data node ANYWHERE in a flow, with the region it was found in —
@@ -1034,22 +1081,24 @@ export function lintFlowPatterns(stack: AnyRec): FlowLintFinding[] {
     //      build-GATING rule is its own change with its own blast radius — this
     //      is that change. The shape it was missing is the DEFAULT one for a
     //      scheduled data flow: query a set, loop it, write per item.
+    //      #5693 — the message states the EFFECTIVE identity in one wording that
+    //      is true of both authoring inputs, and does not branch on whether the
+    //      author wrote `runAs` (see {@link RUNAS_EFFECTIVE_IDENTITY}).
     const runAs = typeof flow.runAs === 'string' ? flow.runAs : 'user';
     const userLessKind = userLessTriggerKind(flow, startCfg);
     if (userLessKind && runAs !== 'system') {
       const dataNode = findDataNodeAnywhere(nodes, edges);
       if (dataNode) {
-        const declared = typeof flow.runAs === 'string' ? `\`runAs:'${runAs}'\`` : `the default \`runAs:'user'\``;
         // The region is named in the MESSAGE, not in `where`: `where` says which
         // declaration is wrong (`flow 'x' · runAs`, unchanged), the message says
         // where to look for the node that proves it. A top-level hit adds nothing
-        // here, so its wording is byte-identical to before (pinned in the tests).
+        // here, so its wording carries no region clause (pinned in the tests).
         const at = dataNode.scope ? `, in ${dataNode.scope},` : '';
         findings.push({
           where: `flow '${flowName}' · runAs`,
           message:
-            `${userLessKind}-triggered flow runs as ${declared}, but a ${userLessKind} run has no trigger ` +
-            `user — so its data node '${dataNode.node.id}' (${dataNode.node.type})${at} has no identity to scope to and ` +
+            `${userLessKind}-triggered flow runs under ${RUNAS_EFFECTIVE_IDENTITY}, but a ${userLessKind} run ` +
+            `has no trigger user — so its data node '${dataNode.node.id}' (${dataNode.node.type})${at} has no identity to scope to and ` +
             `will be REFUSED at run time.`,
           hint:
             `Declare \`runAs:'system'\` to make the elevation explicit and intended (the run reads/writes ` +


### PR DESCRIPTION
Fixes #5693

按分诊两轮裁定走**方向 (3)**:一句两读皆真的措辞,无新输入、无死支。⛔ 方向 (1)(规则增读 pre-parse stack)未做;也没有需要升级到 `needs_decision` 的开放问题 —— 理由写在「改了什么」一节里(本仓在同一机制上已有裁定过的先例)。

## 前提复核(先证伪再实现)

issue 的核心断言成立,并且我实测出一处它没有的**修正**,这处修正让方向 (3) 更站得住:

| 面 | 作者未写 `runAs` | 作者写了 `runAs:'user'` |
|:---|:---|:---|
| `os validate` / `os build` | explicit 支(**唯一可达**) | explicit 支 |
| `os lint` | explicit 支(**唯一可达**) | explicit 支 |
| runtime publish gate(#4463) | **default 支** | explicit 支 |

- **CLI 侧 issue 说对了**,机制比它写的更强一层:`FlowSchema.runAs` 带 `.default('user')`,registry 把规则接为 `input: 'parsed'`;`os lint` 本身**不** Zod-parse(`runAuthoringRules('lint', { normalized: config })`,`authoring-rules.ts:1035` 无 `parsed` 时回落 normalized),照理应该逃过 —— 但 `defineStack` / `defineFlow` 在**定义时**就 `parse`(`stack.zod.ts:1245` `ObjectStackDefinitionSchema.safeParse` 后返回 `result.data`),所以连 `os lint` 拿到的也是默认值已物化的 stack。实测确认:两条命令对「没写 runAs」的作者打的都是 explicit 支。
- **issue 没有的一条:default 支并非全局死支。** runtime publish gate 判的是逐字原文 body(`protocol.ts:7724` 注释 "Keep the body verbatim",schema 检查后 `request.item` 不被 parsed 结果替换),所以那一面两支都可达。

也就是说,缺陷比 issue 描述的更整齐一点:**同一个 flow 被两个 shipped 面告知两件不同的事**,而在作者最先遇到的那个面上,拿到的恰是读起来像指控的那支。

## 改了什么

删掉 `typeof flow.runAs === 'string'` 的三元,换成一个常量 `RUNAS_EFFECTIVE_IDENTITY`:

```
runs under `runAs:'user'` (the default when none is declared)
```

括号是对**取值**的陈述,不是对作者的指控,所以对确实写了 `runAs:'user'` 的人同样为真。这不是新发明的写法,而是本仓在**同一机制**上已有的做法 —— `flow-draft-status-ambiguous`(`validate-flow-trigger-readiness.ts:480`)说 `has status 'draft' (the default when none is authored)`,它的行内注释写的正是同一个原因:「authored or defaulted(`defineFlow` parses at definition time, so the two are the same here)」。**这条先例也是不需要升级决策的理由**:同一诊断措辞合同在本仓已被裁定过一次,方向 (3) 就是那次的结论,不存在两种读法导向不同架构的岔口。

`'user'` 写死而不是从 `flow.runAs` 插值,是刻意的:分支已排除 `'system'`,enum 只有这两个值,而每一个能走到这句话的面上取值都已被 schema 认可(CLI 是 parsed;runtime gate 在 gate 之前已按 overlay schema `safeParse`)。插值会重新长出一条只有 off-spec 字面量才能喂到的支 —— 正是这次要删掉的那个形状。

只有措辞变了:命中的 flow、`severity: 'error'`、`where`、`hint`、以及嵌套证据节点的 region 从句都不变。

## 实跑证据(照 issue 的实测方法)

`examples/app-todo` 的 `overdue_escalation`,只改 `runAs` 一行(测完已还原,不在本 PR diff 里):

**BEFORE — 作者未写 `runAs`**

```
os validate: flow 'overdue_escalation' · runAs: schedule-triggered flow runs as `runAs:'user'`, but a
             schedule run has no trigger user — so its data node 'get_overdue_tasks' (get_record) …
os lint:   ✗ flow 'overdue_escalation' · runAs: schedule-triggered flow runs as `runAs:'user'`, but a
             schedule run has no trigger user — so its data node 'get_overdue_tasks' (get_record) …
```

**BEFORE — 作者写了 `runAs:'user'`**:与上面逐字相同(这就是「区分不可达」的直接证据)。

**AFTER — 两种输入 × 两条命令,四次输出完全相同:**

```
flow 'overdue_escalation' · runAs: schedule-triggered flow runs under `runAs:'user'`
(the default when none is declared), but a schedule run has no trigger user — so its
data node 'get_overdue_tasks' (get_record) has no identity to scope to and will be
REFUSED at run time.
```

runtime publish gate 直调 `runRuntimeAuthoringRules({ type: 'flow', item })`,改前无 `runAs` 键走 default 支、有键走 explicit 支;改后两者同样收敛到上面这一句。

三个 example app 的 `os validate` 均通过(app-todo / app-crm / app-showcase),无新增发现。

## 测试:把「可达性」钉住,不再让死支只被裸字面量喂绿

新增 `#5693` 一组四个用例,并且**两个形状分工不同、只有第二个有牙** —— 这点写在用例注释里,不含糊:

- **parsed 形状**(`FlowSchema.parse`,production 输入):先断言 `parsed.runAs === 'user'` 对两种作者输入都成立,再断言消息逐字相同。它证明的是**分支为什么无意义**;分支若复活,这个用例**照样绿** —— 这正是缺陷本身。
- **unparsed 形状**(runtime gate 的输入):是唯一还能区分两种作者输入的形状,因此是防复活的那道闸。
- 加一条「同一 flow,两个面说同一句话」的对照。
- 另有一条把 registry 接线钉住:`AUTHORING_RULES` 里 `lintFlowPatterns` 的 `input` 必须是 `'parsed'`。

既有走 default 支的两个用例按新措辞更新(含 #5633 那条逐字断言的 top-level twin)。新 fixture 补齐了 `FlowSchema` 要求的 `label`(flow 与每个 node),否则它根本 parse 不过 —— parse 不过的 fixture 证明不了任何关于 parsed 面的事。

**反向验证(方向先声明后跑)。** 第一次把整条三元原样放回时,四个用例连同两个老用例一起红 —— 但那一次同时撤掉了括号,证不出想证的东西,如实记在这里。于是做了**隔离版**:只让「CLI 不可达的那一支」不同,可达支保留新措辞。预期 parsed 绿 / unparsed 红,实测正是如此:

```
隔离版(分支复活,可达支措辞不变):
  ✓ PARSED input: the two authoring choices are literally the same object here
  × UNPARSED input: an absent key and an explicit one still get the same sentence
  × says the same thing to both surfaces about the same flow
  × leaves the TOP-LEVEL twin without a region clause (no regression)
  × flags a schedule flow whose runAs is unset
  Tests  4 failed | 104 passed (108)
```

## Changeset

带 changeset,`@objectstack/lint` **patch**:`lint` 是发布包,这句话是每个 `os validate` / `os build` / `os lint` 使用者都会看到的诊断正文,措辞变更用户可见 —— 但没有 API/行为/severity 变化,所以是 patch 而非 minor。

顺带**改了 #5633(PR #5695)那份尚未发布的 changeset 里的样例输出**:它逐字引用了旧句子,与我这份同处一个发布窗口,不改的话编译出来的 release notes 会自相矛盾地给出一句从未 ship 过的措辞。只动样例和一句「byte-identical」的措辞,不动它的任何结论。

## 验证

- `pnpm --filter @objectstack/lint test` → `Test Files 61 passed (61)` / `Tests 1457 passed (1457)`
- `pnpm --filter @objectstack/lint typecheck` → 干净
- `eslint packages/lint/src/lint-flow-patterns{,.test}.ts` → 无输出
- `pnpm check:nul-bytes` → `OK (scanned 5780 tracked text file(s) … no raw ASCII control bytes)`;另按逐字节自扫改动文件,无控制字节
- `check:release-notes` / `check:adr-anchors` / `check:doc-authoring` / `check:engine-double-contract` / `check:error-code-casing` 全绿

## 范围

严格限于申报文件面:`packages/lint/src/lint-flow-patterns.ts`、其测试文件、`.changeset/`。⚠️ 同文件家族的 #5700(loop fixture 的 `itemVar`)本轮**未触碰** —— 本 PR 新增的 loop 类 fixture 一律用 canonical 的 `iteratorVariable`。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3