### PR TITLE
docs(spec): FieldWidgetPropsSchema 的 required/error JSDoc 不再教 objectui#3222 裁掉的双份显示

### DIFF
--- a/packages/spec/src/ui/widget.zod.ts
+++ b/packages/spec/src/ui/widget.zod.ts
@@ -458,13 +458,27 @@ export const FieldWidgetPropsSchema = lazySchema(() => z.object({
 
   /**
    * Whether the field is required.
-   * Widget should indicate required state visually and validate accordingly.
+   *
+   * The required MARKER (the `*`) is owned by the host's field label, not by
+   * the widget — a widget that draws its own produces two markers for one
+   * field (objectui#3222, landed in objectui#3289). Validation is likewise the
+   * host's: it owns the form state that decides whether the field passes.
+   *
+   * A widget reflects the state on the control it renders, via
+   * `aria-required` — `AriaAttributes` already declares that key, so this
+   * needs no additional contract key (objectui#3290).
    */
   required: z.boolean().default(false).describe('Required field flag'),
 
   /**
-   * Validation error message to display.
-   * When present, widget should display the error in its UI.
+   * The active validation message for this field; `undefined` while the field
+   * is valid.
+   *
+   * Consumed as a SIGNAL, not as content: a widget reads it only to drive
+   * `aria-invalid` on the control it renders, which is the one element the
+   * host cannot reach. The message TEXT is rendered by the host's form message
+   * slot (`FormMessage` in objectui); a widget that renders it too
+   * double-displays it (objectui#3222, landed in objectui#3289).
    */
   error: z.string().optional().describe('Validation error message'),
 


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5920

## 问题

`packages/spec/src/ui/widget.zod.ts` 里 `FieldWidgetPropsSchema` 的两段 JSDoc,教的正是 objectui#3222 裁定**反对**、且已在 objectui PR #3289 落地的两件事:

| 原文 | 为什么是反向指导 |
|---|---|
| `required`:"Widget should indicate required state visually and validate accordingly." | 必填标记 `*` 归宿主 `FormLabel`(objectui `form.tsx:1484` 起);widget 再画一遍就是同一个星号两遍。objectui 的 widget props 里干脆没有 `required` 布尔键,`spec-symbol-batch7.test.ts` 的 `_RequiredIsAbsent` 钉住 |
| `error`:"When present, widget should display the error in its UI." | 校验消息**文案**归宿主 `FormMessage`(objectui `form.tsx:1614`);widget 只把 `error` 当**信号**驱动 `aria-invalid`(`form.tsx:1563-1574`)。再画一遍就是同一句文案两遍 |

这与 #4866 / PR #5914 是同一处失实的两层:文档那层(`widget-contract.mdx`)已修,而 #4866 的边界明确写死「不改 `widget.zod.ts`」,所以 schema 这层留到了本单。

危害面不是最终用户——实测这两句**不进** `content/docs/references/`(生成文档只吃 `.describe()`)——而是**读 schema 源码的人和 AI**:AGENTS.md 要求 agent grep spec 判断契约,`spec-property-retirement` playbook 也把这个文件当权威。

## 改法

仅改 JSDoc 散文,4 行原文换成新的两段:

- `required`:必填标记归宿主 label,widget 不自己画;校验同属宿主(它持有表单状态);widget 把状态反映到控件上的 `aria-required` —— `AriaAttributes` 已声明该键,无需新增契约键(objectui#3290)。
- `error`:活动校验消息,字段有效时为 `undefined`;**当信号用**驱动 `aria-invalid`(控件是宿主够不到的那个元素),文案由宿主渲染,widget 再画一遍就是双份显示。

⛔ 边界(严格按 issue 与认领评论):`.describe()`(`'Required field flag'` / `'Validation error message'`)、键名、类型**一律未动**;同文件其它散文未动;#4866 / PR #5914 已修的 docs 面未动。

## 与 #5055 的关系

#5055(同文件的 ADR-0049 enforce-or-remove,`pm:on-hold` / `target:v18`)问的是「这套词表该不该存在」。本 PR 只动散文、不动契约面,**无论 #5055 最终选退役还是选给载体,这两段都该是现在这个说法**,因此不构成前置也不被它阻塞。

## 验证

- `pnpm --filter @objectstack/spec build` + `check:generated`:**10/10 全绿,零生成物漂移**(含 `check:docs`)—— 与预期一致,JSDoc 不进 `.describe()` 生成流,工作树在 gate 跑完后仍然干净。
- `pnpm --filter @objectstack/spec typecheck`:通过(`tsc --noEmit` + `check:test-typecheck` OK)。
- `pnpm --filter @objectstack/spec test`:全绿。
- `node scripts/check-nul-bytes.mjs`:OK;另对改动文件做了控制字符自扫,无命中。

## Changeset

comment-only(纯 JSDoc 散文),不发布任何用户可见变更 ⇒ 无 changeset,建议 `skip-changeset`。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY

---
_Generated by [Claude Code](https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY)_