### PR TITLE
docs(spec): `ApiEndpointSchema.path` 的 `.describe()` 换成 ADR-0121 carve-out 形状的示例 (#5310)

### DIFF
--- a/.changeset/endpoint-path-describe-carveout.md
+++ b/.changeset/endpoint-path-describe-carveout.md
@@ -1,0 +1,33 @@
+---
+'@objectstack/spec': patch
+---
+
+**`ApiEndpointSchema.path` 的 `.describe()` 换成 carve-out 形状的示例(#5310)**
+
+这段文案过去是 `URL Path (e.g. /api/v1/customers)`。ADR-0121 D1 把声明路径收紧为
+`运行前缀 + /apps/ + 命名空间 + 子路径`(`appEndpointMountPrefix()` =
+`/api/v1/apps/<namespace>/`),publish 门 `namespaceGate` 对 carve-out 之外的路径直接拒绝
+—— 也就是说,**词表自己举的例子,publish 会当场拒**。
+
+**为什么现在要紧。** #5271 之前 `api` 没有注册 schema,`/meta/types` 不为它出 JSON Schema,
+Studio 只能给一个 raw-JSON 文本框,这段 `.describe()` 没有渲染面。#5271 之后它成为
+metadata-admin 端点表单里 `path` 字段的说明文字,并进入生成的 JSON Schema —— 于是一段会被
+拒绝的示例,变成了作者(按 ADR-0033,常常是 AI 作者)照抄的第一手提示。
+
+**新文案**给出 carve-out 形状 `/api/v1/apps/<manifest.namespace>/<subpath>`、一个具体示例
+`/api/v1/apps/crm/leads`,并说明命名空间段派生自 `manifest.namespace`(ADR-0121 D2)而不是
+作者的自由字段。措辞直接复用 `endpoint-publish-gate.ts` 里 `namespaceGate` 的拒绝文案,
+没有新发明判据 —— 作者在表单里读到的,和被拒时读到的,是同一条规则。
+
+**只改了文案。** schema 结构、`/^\//` 正则、门逻辑一律未动:`path` 仍是一个以斜杠开头的
+字符串,carve-out 仍然只由 publish 门(和运行期匹配器)判定。因此这不是破坏性变更,今天能
+发布的声明明天照样能发布。
+
+`ApiMappingSchema` 的三条 `.describe()` 逐条复核后**保持原样**:`source` / `target`
+(*Source field/path* / *Target field/path*)不举例,也没有说错;`transform`
+(*Transformation function name*)描述的键确实会被门整键拒绝,但那属于「词表冻结后,被拒键
+是否应在表单里自陈」的另一类问题,已另行归档,不在本次文案修正内。
+
+配套:`packages/spec/src/api/apis-publish-gates.test.ts` 新增一条断言,把 `.describe()` 的
+文本**读回来**再喂给门 —— 文案里出现的每个具体示例路径都必须在它自己命名的命名空间下通过
+`validateApiEndpointDeclarations`。把一个会被拒的路径写回 `.describe()`,这条测试就红。

--- a/content/docs/references/api/endpoint.mdx
+++ b/content/docs/references/api/endpoint.mdx
@@ -32,7 +32,7 @@ const result = ApiEndpointSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **name** | `string` | ✅ | Unique endpoint ID |
-| **path** | `string` | ✅ | URL Path (e.g. /api/v1/customers) |
+| **path** | `string` | ✅ | URL Path — must be inside this stack's endpoint carve-out: `/api/v1/apps/<manifest.namespace>/<subpath>` with a non-empty subpath (ADR-0121 D1), e.g. `/api/v1/apps/crm/leads` for a stack whose `manifest.namespace` is `crm`. Only the subpath is yours to name; the namespace segment is derived from `manifest.namespace` (ADR-0121 D2), never authored here. A path outside the carve-out is rejected at publish and would match NOTHING at runtime. |
 | **method** | `Enum<'GET' \| 'POST' \| 'PUT' \| 'DELETE' \| 'PATCH' \| 'HEAD' \| 'OPTIONS'>` | ✅ | HTTP Method |
 | **summary** | `string` | optional |  |
 | **description** | `string` | optional |  |

--- a/packages/spec/src/api/apis-publish-gates.test.ts
+++ b/packages/spec/src/api/apis-publish-gates.test.ts
@@ -199,6 +199,65 @@ describe('[#5111] gate (c) — namespace carve-out (ADR-0121 D1/D2)', () => {
   });
 });
 
+describe('[#5310] the `path` vocabulary text is itself publishable', () => {
+  /**
+   * `ApiEndpointSchema.path`'s `.describe()` is not a code comment. Since `api`
+   * became a registered metadata kind (#5271) it is the field help the
+   * metadata-admin endpoint form renders, and it lands in the generated JSON
+   * Schema — so it is the first-hand prompt an author copies, and the author is
+   * very often an AI maintainer (ADR-0033) that copies it verbatim. It used to
+   * read `URL Path (e.g. /api/v1/customers)`, an example `namespaceGate` rejects
+   * on sight (ADR-0121 D1): the vocabulary's own example was the one shape
+   * publish refuses.
+   *
+   * The assertion reads the text back OUT of the schema instead of restating
+   * it, so it cannot drift from the string an author actually sees — put a
+   * rejected path back into the `.describe()` and this file goes red.
+   */
+  const description = ApiEndpointSchema.shape.path.description ?? '';
+
+  /** Concrete paths in that text. `<manifest.namespace>` is a placeholder, not an example. */
+  const concreteExamples = (description.match(/\/[A-Za-z0-9_<>./-]+/g) ?? []).filter(
+    (candidate) => !candidate.includes('<'),
+  );
+
+  it('shows the author at least one CONCRETE example path', () => {
+    expect(description, '`path` must carry a description — it is the form\'s field help').not.toBe('');
+    expect(
+      concreteExamples,
+      `no concrete example path found in: ${description}`,
+    ).not.toHaveLength(0);
+  });
+
+  it('every concrete example it shows PASSES the gate that judges authored paths', () => {
+    for (const path of concreteExamples) {
+      const carveOut = /^\/api\/v1\/apps\/([a-z][a-z0-9_]{1,19})\/(.+)$/.exec(path);
+      expect(
+        carveOut,
+        `example '${path}' is not \`/api/v1/apps/[namespace]/[subpath]\` — the shape ADR-0121 D1 requires`,
+      ).not.toBeNull();
+
+      // Judged under the namespace the example itself names: the carve-out is
+      // derived from `manifest.namespace` (D2), so an example is only honest
+      // paired with the manifest that could declare it.
+      const namespace = carveOut![1]!;
+      const issues = validateApiEndpointDeclarations(
+        [ApiEndpointSchema.parse({ ...validObjectEndpoint, path })],
+        { namespace },
+      );
+      expect(
+        issues.map((issue) => issue.message).join('\n'),
+        `example '${path}' must publish under \`manifest.namespace: '${namespace}'\``,
+      ).toBe('');
+    }
+  });
+
+  it('the example it USED to show is still rejected — the defect itself, pinned', () => {
+    const message = reject({ manifest, apis: [{ ...validObjectEndpoint, path: '/api/v1/customers' }] });
+    expect(message).toMatch(/not inside this stack's endpoint carve-out/);
+  });
+});
+
 describe('[#5111] gate (a) — the supported subset (mirrors `planEndpointTarget`)', () => {
   it("rejects `type: 'script'` with the flow prescription", () => {
     const message = reject({

--- a/packages/spec/src/api/endpoint.zod.ts
+++ b/packages/spec/src/api/endpoint.zod.ts
@@ -56,7 +56,14 @@ export const ApiMappingSchema = lazySchema(() => z.object({
 export const ApiEndpointSchema = z.object({
   /** Identity */
   name: z.string().regex(/^[a-z_][a-z0-9_]*$/).describe('Unique endpoint ID'),
-  path: z.string().regex(/^\//).describe('URL Path (e.g. /api/v1/customers)'),
+  path: z.string().regex(/^\//).describe(
+    'URL Path — must be inside this stack\'s endpoint carve-out: '
+    + '`/api/v1/apps/<manifest.namespace>/<subpath>` with a non-empty subpath (ADR-0121 D1), '
+    + 'e.g. `/api/v1/apps/crm/leads` for a stack whose `manifest.namespace` is `crm`. '
+    + 'Only the subpath is yours to name; the namespace segment is derived from '
+    + '`manifest.namespace` (ADR-0121 D2), never authored here. A path outside the carve-out '
+    + 'is rejected at publish and would match NOTHING at runtime.',
+  ),
   method: HttpMethod.describe('HTTP Method'),
 
   /** Documentation */


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5310

> 正文里的路径占位符统一写成方括号(`[manifest.namespace]`),避开 GitHub 正文清洗把 `<` 加字母当成 HTML 标签吞掉。源码 `.describe()` 里用的是尖括号。

## 前提复核(先证再改)

在 `origin/main`(`efedd28`)上逐条核对,问题描述的两个事实都成立:

- `packages/spec/src/api/endpoint.zod.ts:59` 仍然一字未改:
  `path: z.string().regex(/^\//).describe('URL Path (e.g. /api/v1/customers)')`
- `packages/spec/src/api/endpoint-publish-gate.ts:87` 的 `appEndpointMountPrefix(namespace)` 返回
  `` `${DEFAULT_RUNTIME_PREFIX}/${APP_ENDPOINT_SEGMENT}/${namespace}/` ``,即 `/api/v1/apps/[namespace]/`。

`/api/v1/customers` 不以该挂载前缀开头,`namespaceGate` 走的是拒绝分支 —— **词表自己举的例子,publish 会当场拒**。

## 为什么现在才要紧

#5271 之前 `api` 没有注册 schema,`/meta/types` 不为它出 JSON Schema,Studio 只能给一个 raw-JSON 文本框,这段 `.describe()` 没有渲染面。#5271 之后它成为 metadata-admin 端点表单里 `path` 字段的说明文字,并进入生成的 JSON Schema —— 于是一段会被拒绝的示例,变成了作者(按 ADR-0033,常常是 AI 作者)照抄的第一手提示。

## 改了什么

`ApiEndpointSchema.path` 的 `.describe()` 换成 carve-out 形状:

- 给出形状 `/api/v1/apps/[manifest.namespace]/[subpath]`,并点明子路径必须非空(ADR-0121 D1);
- 给出一个**具体**示例 `/api/v1/apps/crm/leads`,并说明它对应 `manifest.namespace` 为 `crm` 的栈;
- 说明命名空间段派生自 `manifest.namespace`(ADR-0121 D2),不是作者的自由字段;
- 说明 carve-out 之外的路径会在 publish 被拒、且运行期匹配不到任何东西。

措辞直接复用 `endpoint-publish-gate.ts` 里 `namespaceGate` 的拒绝文案(`must be ... with a non-empty subpath`、`Only the subpath is yours to name`、`would parse today and match NOTHING at runtime`),**没有新发明判据** —— 作者在表单里读到的规则,和被拒时读到的规则,是同一条。

**只动文案。** schema 结构、`/^\//` 正则、门逻辑一律未动,`endpoint-publish-gate.ts` 一个字节没改。`path` 仍然只是一个以斜杠开头的字符串,carve-out 仍然只由 publish 门(和运行期匹配器)判定,所以这不是破坏性变更:今天能发布的声明明天照样能发布。

## `ApiMappingSchema` 的 `.describe()` — 逐条复核结果

问题里点名要一并复核,复核完的处置是**三条都保持原样**,理由逐条不同:

| 字段 | 现文案 | 判定 |
|---|---|---|
| `source` | *Source field/path* | 不举例,也没说错 —— 门对路径形状的额外要求(空段、原型键)是门的判据,不是文案的失实。**不改** |
| `target` | *Target field/path* | 同上。**不改** |
| `transform` | *Transformation function name* | 这个键确实会被 `mappingGate` 整键拒绝。但它不是「举例失实」,而是「冻结词表里的被拒键,该不该在表单里自陈」——另一类问题,且这段文案被 `packages/runtime/src/api-mapping.ts` 的词表小节**逐字引用**为规范来源(改它要连带动 `packages/runtime`)。按 Prime Directive #10 另行归档,不在本 PR 修 |

`inputMapping` / `outputMapping` 的两条(*Map Request Body to Internal Params* / *Map Internal Result to Response Body*)与运行期实现一致,也不改。

## 测试

新增的断言不复述文案,而是把 `.describe()` 的文本**从 schema 里读回来**再喂给门 —— 这样断言不可能和作者真正看到的字符串漂移:

```ts
const description = ApiEndpointSchema.shape.path.description ?? '';
const concreteExamples = (description.match(/\/[A-Za-z0-9_<>./-]+/g) ?? [])
  .filter((candidate) => !candidate.includes('<'));   // 占位符不是示例
```

三条:

1. 文案里必须至少有一个**具体**示例路径(反空转);
2. 每个具体示例都必须是 `/api/v1/apps/[namespace]/[subpath]` 形状,并在它**自己命名的那个命名空间**下通过 `validateApiEndpointDeclarations`(carve-out 由 D2 派生,示例只有配上能声明它的 manifest 才算诚实);
3. 旧示例 `/api/v1/customers` 仍然被拒 —— 把缺陷本身钉住。

### 反向验证(方向在跑之前就先定好:**红**)

预测:把旧文案换回去,新断言应当因为「示例不是 carve-out 形状」而失败。实测正是这个方向、这个原因:

```
59:  path: z.string().regex(/^\//).describe('URL Path (e.g. /api/v1/customers)'),
     × every concrete example it shows PASSES the gate that judges authored paths
AssertionError: example '/api/v1/customers' is not `/api/v1/apps/[namespace]/[subpath]`
               — the shape ADR-0121 D1 requires: expected null not to be null
 Test Files  1 failed (1)
      Tests  1 failed | 45 passed (46)
```

恢复改动后:

```
 ✓ [#5310] the `path` vocabulary text is itself publishable > shows the author at least one CONCRETE example path
 ✓ [#5310] the `path` vocabulary text is itself publishable > every concrete example it shows PASSES the gate that judges authored paths
 ✓ [#5310] the `path` vocabulary text is itself publishable > the example it USED to show is still rejected — the defect itself, pinned
 Test Files  1 passed (1)   Tests  46 passed (46)
```

既有的 5 条拒绝例(carve-out 外、别人的命名空间、空子路径、`showcasex` 近似前缀、无 `manifest.namespace`)全部保留且仍然拒。

### 全量

```
pnpm --filter @objectstack/spec test        → Test Files 325 passed (325) | Tests 8312 passed (8312)
pnpm --filter @objectstack/spec typecheck   → TYPECHECK_EXIT=0(tsc --noEmit + check:test-typecheck OK)
```

## 生成物

按 os-regen 纪律,不手改、不整包扫射:`check:generated` 先判定失效面,只有 `content/docs/references/**` 一项失效,`--fix` 只重生成这一项,随后补跑 `gen:openapi`(#5371,该生成器无门)。复跑后 `✓ All 10 generated artifacts are up to date.`

问题描述里预计会动 `authorable-surface.json` / `json-schema.manifest.json`,**实测没有动**:前者不收录 `.describe()` 文本,后者只是 schema 名字的棘轮清单。实际落点只有 `content/docs/references/api/endpoint.mdx` 一行表格。

## 变更集

`.changeset/endpoint-path-describe-carveout.md`,`@objectstack/spec: patch` —— `.describe()` 是发布面文案(进 JSON Schema、进参考文档、进 Studio 表单),不是代码注释。

---
_Generated by [Claude Code](https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY)_