### PR TITLE
docs(spec): ISharingService 模块头按 ADR-0111 D3 拆出 canDelete() 门

### DIFF
--- a/packages/spec/src/contracts/sharing-service.test.ts
+++ b/packages/spec/src/contracts/sharing-service.test.ts
@@ -257,3 +257,62 @@ describe('[#5858] HierarchyScopeContext tenancy authority', () => {
     expect(resolver.get('resolveOwnerIds')).toContain('never widen');
   });
 });
+
+/**
+ * [#5817] The MODULE HEADER must route each write verb to its own gate.
+ *
+ * The header's "Per-record gating" item predates ADR-0111 D3 and still said
+ * `canEdit()` answered `update` / `delete` — the exact semantics D3 rejects,
+ * contradicting the `canDelete()` doc 140 lines below it (delete is ownership
+ * or `modifyAllRecords` ONLY; an `edit` share widens which ROWS a principal
+ * reaches, never which VERBS). The header is the first thing a cross-package
+ * caller reads, so following it meant treating an `edit` share as delete
+ * authorization, or not knowing `canDelete` exists.
+ *
+ * A prose pin like #5125's, for the same reason: nothing type-checks a doc
+ * comment, and the drift is only visible against the method docs a reader may
+ * never scroll to. This pins the FILE-level comment rather than a member's, so
+ * it reads the leading comment ranges instead of an interface member.
+ */
+describe('[#5817] ISharingService module header — one gate per write verb', () => {
+  it('routes `update` to canEdit() and `delete` to canDelete(), not both to canEdit()', async () => {
+    const ts = (await import('typescript')).default;
+    const { readFileSync } = await import('node:fs');
+    const { dirname, resolve } = await import('node:path');
+    const { fileURLToPath } = await import('node:url');
+
+    const file = resolve(dirname(fileURLToPath(import.meta.url)), 'sharing-service.ts');
+    const text = readFileSync(file, 'utf8');
+
+    // The module header is one of the comments preceding the first statement;
+    // it identifies itself by the module path it documents (the copyright line
+    // and the first type's own doc are the other two).
+    const header = (ts.getLeadingCommentRanges(text, 0) ?? [])
+      .map((range) => text.slice(range.pos, range.end))
+      .find((comment) => comment.includes('@objectstack/spec/contracts/sharing-service'));
+    expect(header, 'the module header must still open this file').toBeDefined();
+    // Anti-vacuity 1: this really is the header with its numbered concerns, so
+    // a rewrite cannot empty the assertions below by moving the text elsewhere.
+    expect(header).toContain('Per-record gating');
+
+    // THE pin: the header names the gate ADR-0111 D3 split `delete` out to.
+    // Restoring the pre-D3 sentence turns this red.
+    expect(header).toContain('canDelete()');
+
+    // ...and does not hand `delete` back to `canEdit()`. Both indices resolve
+    // in order, so the slice is never empty (a vacuous pass).
+    const editAt = header!.indexOf('canEdit()');
+    const deleteAt = header!.indexOf('canDelete()');
+    expect(editAt, 'canEdit() must still be named in the header').toBeGreaterThan(-1);
+    expect(deleteAt, 'canDelete() must be named AFTER canEdit()').toBeGreaterThan(editAt);
+    expect(
+      header!.slice(editAt, deleteAt),
+      "canEdit()'s clause must not claim the `delete` verb (ADR-0111 D3)",
+    ).not.toMatch(/\bdelete\b/);
+
+    // Anti-vacuity 2: the negative above DISCRIMINATES — the lower-case verb is
+    // still in the header, now attributed to `canDelete()`, so the assertion
+    // cannot pass by `delete` having disappeared from the file altogether.
+    expect(header).toMatch(/\bdelete\b/);
+  });
+});

--- a/packages/spec/src/contracts/sharing-service.ts
+++ b/packages/spec/src/contracts/sharing-service.ts
@@ -12,9 +12,15 @@
  *      engine middleware AND-s into every read query. Callers must
  *      treat `null` as "object is public, do not filter".
  *
- *   2. **Per-record gating** — `canEdit()` answers the access question
- *      for `update` / `delete` operations. Returns `true` when the
- *      caller may modify the record, `false` otherwise.
+ *   2. **Per-record gating** — two SEPARATE gates, one per write verb.
+ *      `canEdit()` answers the access question for `update`: ownership
+ *      (widened by write DEPTH), a write-level (`edit`) share, or the
+ *      `modifyAllRecords` super-user bypass. `canDelete()` answers it
+ *      for `delete` and is deliberately NARROWER (ADR-0111 D3) — a
+ *      share widens which ROWS a principal reaches, never which VERBS
+ *      they may use, so an `edit` share does NOT confer delete:
+ *      ownership or the bypass only. Each returns `true` when the
+ *      caller may perform that operation, `false` otherwise.
  *
  * Manual share CRUD is exposed via `grant()`, `revoke()`, and
  * `listShares()`. The REST layer wires these to


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5817

## 问题

`packages/spec/src/contracts/sharing-service.ts` 的**模块头**第 2 条("Per-record gating")写于 ADR-0111 D3 拆分**之前**,仍然说:

> `canEdit()` answers the access question for `update` / `delete` operations.

这与同一文件 140 行之下的 `canDelete()` 方法文档**直接矛盾**。D3 定下的动词边界是:**share 只放宽一个主体够得着的"行",从不放宽它能用的"动词"** —— 所以 delete 只有 ownership(写 DEPTH 放宽)或 `modifyAllRecords` 超级用户旁路两条路,`edit` share **不**授予删除权(Salesforce 的 Read/Write 不能删,Dataverse 的 `Delete` 是独立权限,Odoo 把 `write`/`unlink` 分开)。实现侧也是两道门:plugin-sharing 的 `canEdit` / `canDelete`,后者根本没有 share 分支。

**为什么值得改**:模块头是跨包调用方进这个文件读到的**第一段**。照它做,要么把 `edit` share 当成删除授权(D3 明确拒绝的语义),要么根本不知道存在 `canDelete`。错的散文比沉默更糟 —— 它看上去权威。

## 改法

把第 2 条拆成两道门,措辞与下方 `canEdit()` / `canDelete()` 两个方法文档对齐:`canEdit()` 管 `update`(ownership / `edit` share / `modifyAllRecords` 旁路),`canDelete()` 管 `delete` 且**显式更窄**并点名 ADR-0111 D3。

**纯注释改动,零 schema / 类型 / 行为变化。**

范围严格限定在模块头这一处:未碰 #5973(#5858)新落的 `HierarchyScopeContext` / `resolveOwnerIds` 段,未碰 #5125 已修的 `canEdit` 方法 doc,未顺手改其它散文。

## 钉子

同文件已有 #5125 / #5858 的 AST 散文钉先例,补一枚同款轻量钉(加在既有 `sharing-service.test.ts` 里,不新建文件)。与前两枚不同的是,它钉的是**文件级** leading comment 而非 interface 成员文档,所以走 `ts.getLeadingCommentRanges(text, 0)`、用模块路径行认出模块头。

两条断言 + 两条反空(anti-vacuity)守卫:

- **正钉**:模块头点名 `canDelete()`。
- **负钉**:`canEdit()` 到 `canDelete()` 之间那一段不得再出现 `delete` 动词(两个下标按序解析,切片不会为空 —— 排除"空切片假绿")。
- **反空 1**:确认取到的确实是带编号条目的模块头(改写不能把断言掏空)。
- **反空 2**:小写 `delete` 仍在模块头里(只是改挂到 `canDelete()` 名下),所以负钉不是靠"这个词整体消失"而通过的。

**反向验证(方向为预期的"红")**:把 D3 之前那句话原样放回去,新钉子**变红**,报错落在 `canDelete()` 那条正钉上,同文件其余 6 条既有测试**全绿** —— 既证明钉子真的咬住了这处漂移,也证明既有的钉子覆盖不到它。

## 验证

- `pnpm --filter @objectstack/spec check:generated` — **10/10 全部 up to date,零生成物漂移**(如预期:模块头不进 `content/docs/references/`)。
- `pnpm --filter @objectstack/spec typecheck` — 通过(`tsc --noEmit` + `check:test-typecheck`,debt 账本未增长)。
- `pnpm --filter @objectstack/spec test` — 全量见 CI;定向跑 `src/contracts/sharing-service.test.ts`:**7 passed**。
- `node scripts/check-nul-bytes.mjs` — OK;两个改动文件另做了越过该 gate 盲区的控制字符自查,零命中。

## Changeset

**建议 `skip-changeset`**:comment-only + test-only,不发布任何东西,不产生 user-visible 变更。

---
_Generated by [Claude Code](https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY)_