### PR TITLE
ci(lint): 把 `check:merge-driver` 的两个 self-test 接进 lint.yml 根 check 行

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -399,6 +399,33 @@ jobs:
       - name: Resume-authority declaration gate
         run: pnpm check:resume-authority-declared
 
+      # Merge-driver wiring gate (#6008, from #4675 / #4868). `merge=os-regen`
+      # is what stops generator-owned artifacts (spec-changes.json, the ADR-0087
+      # registries, the api-surface baselines) from text-merging into a
+      # plausible-looking wrong file: the driver defers the path and records it,
+      # and `.githooks/pre-commit` refuses the commit until the regeneration has
+      # actually happened. Both halves are CONFIG — `.gitattributes` routing on
+      # one side, the table in scripts/regen-artifacts.mjs on the other — and
+      # they drift apart in either direction with nothing failing: a path
+      # declared in the table but unmapped still text-merges, and a path mapped
+      # but undeclared leaves the merge CONFLICTED with no explanation. The
+      # self-test reconciles them both ways, checks the gen:/check: names the
+      # driver advises still resolve, that the hook is executable IN THE INDEX
+      # (git ignores a non-executable hook and says only `advice.ignoredHook`),
+      # that the driver registered in THIS clone resolves here (#4868: it
+      # pointed at a deleted worktree for weeks while every other check stayed
+      # green), and proves the behaviour end to end against real git. The
+      # second half pins the staleness rules' dangerous direction — "says fresh
+      # when stale".
+      # It ran nowhere until now: `pre-commit` runs check-regen-pending's MAIN
+      # path (which exits immediately with no pending marker), never
+      # `--self-test`, and no workflow named the command — so the reconciliation
+      # was verified only when someone happened to run the root script by hand
+      # (#4690's family: a gate archived as "runs elsewhere" that ran nowhere).
+      # Pure git + fs, no build, seconds — so it belongs in this job.
+      - name: Merge-driver wiring gate
+        run: pnpm check:merge-driver
+
   typecheck:
     name: TypeScript Type Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6008

## 改了什么

`.github/workflows/lint.yml` 的 ESLint job 末尾追加一步(全 PR 唯一改动,27 行新增,其中 25 行是解释性注释):

```yaml
      - name: Merge-driver wiring gate
        run: pnpm check:merge-driver
```

位置按分诊指定:加在**已有的那排根 `check:*` 步骤**之后(同形先例就在同一 job:`check:nul-bytes` / `check:doc-authoring` / `check:node-version` / `check:workflow-status-functions`)。⛔ 不新建 job;⛔ 不动 typecheck job 段(#5827 停放中在那段有未落地编辑,与本改动不相交);⛔ 不动任何脚本、`.gitattributes`、`content/docs/releases/`。

## 为什么

`check:merge-driver` = `node scripts/git-merge-regen.mjs --self-test && node scripts/check-regen-pending.mjs --self-test`,此前**没有出现在任何 workflow 里**。`.githooks/pre-commit` 跑的是 `check-regen-pending.mjs` 的**主路径**(无 pending marker 时立即退出),不是 `--self-test`。所以这两个 self-test 在 CI 上从未执行过,只有有人手工跑根脚本时才现形 —— 与 #4690 同类形态(一道被归档为「在别处跑」的门禁,实际哪里都没跑)。

它们守的是 #4675「生成物不走文本合并」那套地基。`merge=os-regen` 的两半都是**配置**:一边 `.gitattributes` 的路由,一边 `scripts/regen-artifacts.mjs` 的表。两边可以在**任一方向**上失衡而全仓无人报错 —— 表里声明了但没路由的路径照旧走文本合并;路由了但表里没声明的路径,驱动拒绝处理、合并留在 CONFLICTED 且没有任何解释。而 `git-merge-regen.mjs` 自己的注释就写着:这类失衡「只有跑 self-test 才看得见」。

## 前提复核(第三遍,独立于 issue 正文与分诊读数)

在 `origin/main` `9e3709a4` 上自己重跑了一遍,零命中成立;并按惯例做了邻近词阳性对照,证明 grep 本身是好的:

```
$ for f in $(git ls-tree -r --name-only origin/main .github/workflows/); do
    git show origin/main:$f | grep -Hn "merge-driver\|git-merge-regen\|check-regen-pending" /dev/stdin | sed "s|/dev/stdin|$f|"
  done
(空 —— 零命中)

$ # 阳性对照:同族根 check 确在
.github/workflows/lint.yml:124:        run: pnpm check:nul-bytes
.github/workflows/lint.yml:132:        run: pnpm check:doc-authoring
```

**接线前先证明它在当前 main 上是绿的**(把一条红的检查接进 CI 是另一件事,那会是 STOP-and-report):

```
$ pnpm check:merge-driver
git-merge-regen --self-test

✓ .gitattributes ↔ regen-artifacts.mjs agree on 9 path(s)
✓ all 18 gen:/check: names resolve in @objectstack/spec
✓ .githooks/pre-commit is executable in the index (100755)
✓ merge.os-regen.driver resolves in THIS worktree (scripts/git-merge-regen.mjs)
✓ end-to-end: conflicting packages/spec/spec-changes.json merged without markers and recorded as pending

✓ merge driver wiring is consistent (7 path(s) deliberately excluded).
✓ a directory with no dist/ reads as STALE (conservative default)
✓ a directory with no json-schema/ reads as STALE (conservative default)

✓ check-regen-pending self-test passed.
```

## CI 可运行性(逐条对过,不是假设)

- 两个 self-test 只用 node 内置模块 + git + 一个 POSIX shell,**不需要 build**,秒级;`check-regen-pending --self-test` 明确「touches no repo state」。
- `registeredDriverResolves()` 在 CI 上两条分支都绿:`pnpm install --frozen-lockfile` 会跑根 `prepare`(`setup-git-hooks.mjs`)把 `merge.os-regen.driver` 注册成 worktree 相对的 `$(git rev-parse --show-toplevel)/scripts/git-merge-regen.mjs`,在检出里可解析;若 CI 以 `--ignore-scripts` 安装则读作「未注册」,脚本明确把它当**受支持状态**(回落到 #4675 之前的文本合并)并返回绿。
- `endToEnd()` 在 `mkdtemp` 的临时仓里 `git init --initial-branch=main` 并自带 `user.email`/`user.name`,不依赖 runner 的全局 git 身份。
- `hookIsExecutable()` 读的是 **index** 里的 mode(`git ls-files -s`),普通检出即可。

同步跑过会被这次改动影响的相邻门禁,均绿:`check:workflow-status-functions`(真 YAML 解析,扫到 22 个 workflow / 39 job)、`check:node-version`(23 个 setup-node,全 Node 22)、`check:nul-bytes`(5780 个 tracked 文本文件,无原始控制字节)。

## 与在飞 #5837 的交互(给 spec 座位的知会,不是异议)

#5837 的 **S4 收尾**会重写 `.gitattributes` 的 os-regen 路由(单体文件退役、路由改指分片路径),而本 PR 接进 CI 的这一步恰好强制 `.gitattributes` ↔ `scripts/regen-artifacts.mjs` 的**双向**对账。因此:S4 若只改其中一边(例如 `.gitattributes` 指向分片、表里仍是单体路径,或反过来),这一步会在你们的 PR 上直接红,报文会点名到具体路径。

这是门禁在做本职工作 —— 分片正是最容易让两边失衡的改动形状,而失衡的后果是合并驱动对某条路径**静默失效**。写在这里只是让 spec 座位提前知道多了这一道,不必等 CI 才发现。同理,S1/S2 若改了 `gen:`/`check:` 的脚本名而没同步表,`reconcileScripts()` 也会红。

## changeset

无。纯 workflow 改动,不发布任何包,按现行惯例(#5292)走 `skip-changeset` 标签路径,不写空 frontmatter changeset(#6049 第二个提交记录了那条只作为最后手段的理由)。

## 自证

本 PR 自己就会跑到这条新步骤 —— `lint.yml` 对每个 PR 生效,所以这次 ESLint job 的 `Merge-driver wiring gate` 一步就是它确实在跑的直接证据。


---
_Generated by [Claude Code](https://claude.ai/code/session_014wsZeReNTqiceBfLb5Pyf5)_