### PR TITLE
fix(deps): OSV 公告波收口 —— js-yaml 3.15.1/4.3.1 + mermaid 11.16.1 定向锁文件 bump (#6088)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         version: 1.28.0(react@19.2.8)
       mermaid:
         specifier: ^11.16.0
-        version: 11.16.0
+        version: 11.16.1
       next:
         specifier: 16.2.12
         version: 16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -6644,12 +6644,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   js-yaml@5.2.2:
@@ -7131,8 +7131,8 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  mermaid@11.16.0:
-    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -9484,7 +9484,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -13093,12 +13093,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -13624,7 +13624,7 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid@11.16.0:
+  mermaid@11.16.1:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.4
@@ -14531,7 +14531,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       pify: 4.0.1
       strip-bom: 3.0.0
 


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6088

## 背景

新一波上游 OSV 公告(js-yaml + mermaid)把 `Validate Package Dependencies` 判红。该 workflow 是路径触发的,只对 diff 碰到 `**/package.json` / `pnpm-lock.yaml` / `pnpm-workspace.yaml` 等依赖文件的 PR 生效 —— 所以症状表现为「偶发地只咬部分 PR」。这不是任何 PR 引入的,是共享门禁被上游公告波打红,需要一次锁文件收口。

## 前提复核(立单前提仍然成立)

派发时与动手前分别复核了 `origin/main`:

- `pnpm-lock.yaml` 仍解析出 `js-yaml@3.15.0`、`js-yaml@4.3.0`、`mermaid@11.16.0`(6 处条目,`packages:` 与 `snapshots:` 各 3 处);
- 锁文件最后一笔提交仍是 `9c90ea0b7`(sms 功能,非 OSV 修复),期间 `main` 已推进到 `1eb13a0d2`,但**锁文件零变化**,无在飞依赖 bump 撞车。

## 改动

**纯锁文件定向重解析,12 增 12 删,不动任何 `package.json`:**

| OSV | CVSS | 包 | 现版本 | 修复版本 |
|---|---|---|---|---|
| GHSA-5p4m-2wfm-xmqj | 7.5 High | js-yaml | 3.15.0 | 3.15.1 |
| GHSA-5p4m-2wfm-xmqj | 7.5 High | js-yaml | 4.3.0 | 4.3.1 |
| GHSA-2v8p-3f2j-5mp7 | 5.3 | mermaid | 11.16.0 | 11.16.1 |
| GHSA-3rrr-jr9j-h3q3 | 6.5 | mermaid | 11.16.0 | 11.16.1 |
| GHSA-6x64-9x62-f2gx | 5.3 | mermaid | 11.16.0 | 11.16.1 |
| GHSA-c4c3-pg64-4m4v | 2.4 | mermaid | 11.16.0 | 11.16.1 |
| GHSA-rhh3-jpg6-66xh | 5.3 | mermaid | 11.16.0 | 11.16.1 |

### 为什么没有 overrides、没有 package.json 改动

三个修复版本都是 **patch 级**,且都落在各自父包**已声明的 range 之内**,所以普通解析位移就能到达,不需要 `pnpm.overrides` 永久钉版(overrides 是「将来必须有人记得摘掉」的债,能不加就不加):

- `read-yaml-file@1.1.0` 声明 `js-yaml: ^3.6.1` → 3.15.1 在范围内
- `@changesets/parse@0.4.3` 声明 `js-yaml: ^4.1.1` → 4.3.1 在范围内
- `apps/docs` 声明 `mermaid: ^11.16.0` → 11.16.1 在范围内

三对版本的 **dependencies 集合逐字节一致**(已用 registry 元数据比对),所以 diff 只有版本号与 integrity 两类行。

### 归因(`pnpm why`)

```
js-yaml@3.15.1
└─ read-yaml-file@1.1.0 ─ @manypkg/get-packages@1.1.3 ─ @changesets/* ─ @changesets/cli@2.31.1
   └─ @objectstack/spec-monorepo (devDependencies)

js-yaml@4.3.1
└─ @changesets/parse@0.4.3 ─ @changesets/read@0.6.7 ─ @changesets/cli@2.31.1
   └─ @objectstack/spec-monorepo (devDependencies)

mermaid@11.16.1
└─ @objectstack/docs@4.2.1 (dependencies) —— 该包 private: true,不发布
```

两条 js-yaml 都只经由**根 devDependency** `@changesets/cli` 进入(纯发布工具链,不随任何产物出货);mermaid 的唯一消费者是 `apps/docs`,而 `apps/docs` 是 `private: true` 的站点应用。**没有任何已发布包的依赖图发生变化。**

### 刻意不动的部分

- `js-yaml@5.2.2`(`packages/metadata` 的直接依赖)**未被公告命中**,原样保留。中途试过 `pnpm update --recursive js-yaml@3.15.1`,它会把 `packages/metadata/package.json` 的 `^5.2.2` 改写成 `^3.15.1`(**降级已发布 manifest**),并顺带扫动 postcss / seroval / ws / nanoid 等无关依赖 —— 已全部回滚,改用定向编辑。
- 未新增 `osv-scanner.toml` 豁免(7 条全部有修复版本,豁免只留给无修复的公告)。
- 未触碰 `.github/workflows/validate-deps.yml`(devx 车道)。

## 验证

### 1. osv-scanner 实跑(与 CI 同版本 v2.3.8),红 → 绿

`api.osv.dev` 在本会话出口策略下被 403 拦截,故改用 scanner 自带的离线库模式(`--offline-vulnerabilities --download-offline-databases`),扫的是同一份 OSV 数据。

**改动前(`origin/main` 的锁文件)—— 精确复现立单表格的 7 条:**

```
Total 3 packages affected by 7 known vulnerabilities (0 Critical, 2 High, 4 Medium, 1 Low, 0 Unknown)
7 vulnerabilities can be fixed.
| https://osv.dev/GHSA-5p4m-2wfm-xmqj | 7.5 | npm | js-yaml | 3.15.0  | 3.15.1  |
| https://osv.dev/GHSA-5p4m-2wfm-xmqj | 7.5 | npm | js-yaml | 4.3.0   | 4.3.1   |
| https://osv.dev/GHSA-2v8p-3f2j-5mp7 | 5.3 | npm | mermaid | 11.16.0 | 11.16.1 |
| https://osv.dev/GHSA-3rrr-jr9j-h3q3 | 6.5 | npm | mermaid | 11.16.0 | 11.16.1 |
| https://osv.dev/GHSA-6x64-9x62-f2gx | 5.3 | npm | mermaid | 11.16.0 | 11.16.1 |
| https://osv.dev/GHSA-c4c3-pg64-4m4v | 2.4 | npm | mermaid | 11.16.0 | 11.16.1 |
| https://osv.dev/GHSA-rhh3-jpg6-66xh | 5.3 | npm | mermaid | 11.16.0 | 11.16.1 |
exit 1
```

**改动后(本 PR 的锁文件):**

```
Scanned pnpm-lock.yaml file and found 1387 packages
No issues found
exit 0
```

两次扫描的包总数都是 **1387**,这正是「零附带位移」的量化证据。

### 2. `Validate Package Dependencies` 其余步骤本地全绿

```
pnpm install --frozen-lockfile --prefer-offline
  → Lockfile is up to date, resolution step is skipped ... Done in 8s   (exit 0)
node scripts/check-changeset-fixed.mjs
  → ✓ "fixed" group is in sync with 69 public workspace packages        (exit 0)
node scripts/check-override-consistency.mjs
  → ✓ 2 published-manifest declaration(s) ... resolve to their override targets (exit 0)
node scripts/check-osv-exemptions.mjs --self-test && node scripts/check-osv-exemptions.mjs
  → ✓ self-test passed / ✓ zero OSV exemptions (the intended steady state) (exit 0)
```

其中 `Lockfile is up to date, resolution step is skipped` 是关键一行:pnpm 认定手工定向编辑后的锁文件与所有 manifest 完全自洽。

### 3. 消费者侧验证

```
pnpm --filter @objectstack/docs types:check       → ✓ Types generated successfully   (exit 0)
pnpm --filter @objectstack/metadata test          → Test Files 25 passed (25) / Tests 508 passed (508)
pnpm exec changeset status --since=origin/main    → info NO packages to be bumped     (exit 0)
```

运行时冒烟(三条改动版本逐个实际加载):

```
js-yaml 3.15.1 -> load OK: {"a":1,"b":["x","y"]}
js-yaml 4.3.1  -> load OK: {"a":1,"b":["x","y"]}
@changesets/parse 经 js-yaml@4.3.1 解析 frontmatter -> {"releases":[{"name":"@objectstack/spec","type":"patch"}],"summary":"hello world"}
read-yaml-file 经 js-yaml@3.15.1 读取 .changeset/config.json -> OK
mermaid version: 11.16.1 —— initialize / render / run / parse / registerIconPacks 全部为 function
```

符号链接实测:`read-yaml-file` 现指向 `js-yaml@3.15.1`,`@changesets/parse` 现指向 `js-yaml@4.3.1`,旧版本目录零活引用。

## Changeset

**本 PR 不带 changeset。** 判断依据:改动面只有 `pnpm-lock.yaml`,零 `package.json` 变更;两条 js-yaml 只经根 devDependency 进入工具链,mermaid 的唯一消费者 `apps/docs` 是 `private: true`。因此没有任何**已发布包**的版本或依赖声明发生变化,`changeset status` 也确认 `NO packages to be bumped`。按仓库惯例,这类纯锁文件安全 bump 走 `skip-changeset` 路线 —— 标签留给 PM 在验收时按车道统一施加(本次派发明确要求 dev 不自行施加标签)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wbxm29qPKnLf44AbSxizqW)_