### PR TITLE
test(lint): loop fixtures 改拼 canonical 的 iteratorVariable 并上 schema pin (#5700)

### DIFF
--- a/packages/lint/src/lint-flow-patterns.test.ts
+++ b/packages/lint/src/lint-flow-patterns.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
-import { TimeRelativeTriggerSchema, LoopConfigSchema, FlowSchema } from '@objectstack/spec/automation';
+import { TimeRelativeTriggerSchema, LoopConfigSchema, ParallelConfigSchema, FlowSchema } from '@objectstack/spec/automation';
 import { AUTHORING_RULES } from './authoring-rules.js';
 import {
   lintFlowPatterns,
@@ -50,6 +50,35 @@ const flow = (condition: unknown, triggerType = 'record-after-update') => ({
     edges: [],
   }],
 });
+
+/**
+ * The keys a container schema REFUSED on a fixture — `[]` when the shape spells
+ * only declared keys, whatever the schema thinks of their VALUES (#5700).
+ *
+ * The criterion is deliberately key-level, and the same one
+ * `validate-security-posture.test.ts` writes down for its reachability guard: a
+ * rejected KEY and a rejected VALUE are different facts. A key the schema does
+ * not declare is not an authoring surface at all — a fixture spelling one
+ * describes a container no author can save, which is exactly the defect #5700
+ * catalogued. A rejected value is a fixture choice these rules are often
+ * entitled to make.
+ *
+ * So the container audits below use this, NOT flat `safeParse` success: most of
+ * this file's fixtures are hand-written raw literals that omit the `label`
+ * `FlowNodeSchema` requires on every node, and demanding full-parse green would
+ * either delete that coverage or drag in a file-wide re-write #5700 explicitly
+ * defers. Where a fixture IS fully authorable, it is pinned with full green
+ * instead (see the `LoopConfigSchema` pins).
+ */
+function refusedKeys(result: {
+  success: boolean;
+  error?: { issues: readonly { code: string; path: readonly PropertyKey[]; message: string }[] };
+}): string[] {
+  if (result.success) return [];
+  return (result.error?.issues ?? [])
+    .filter((i) => i.code === 'unrecognized_keys')
+    .map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`);
+}
 
 describe('lintFlowPatterns — time-relative anti-pattern (#1874)', () => {
   it('flags record-change date-EQUALITY against a time function', () => {
@@ -620,21 +649,24 @@ describe('lintFlowPatterns — user-less runAs unscoped (#1888 / ADR-0049 / ADR-
     // container's config physically contains its body, and the walk visits the
     // body in its own right, so a rule that pushed per hit would double-report.
     it('reports ONCE for a flow whose regions hold several data nodes', () => {
+      const fanConfig = {
+        branches: [
+          { name: 'writes', nodes: [{ id: 'w1', type: 'update_record', label: 'Write', config: { objectName: 'a' } }], edges: [] },
+          { name: 'deletes', nodes: [{ id: 'w2', type: 'delete_record', label: 'Delete', config: { objectName: 'b' } }], edges: [] },
+        ],
+      };
+      // #5700 container audit — the `parallel` twin of the `loop` pin above. This
+      // block already declares `name`/`nodes`/`edges` and labels its branch nodes,
+      // so it clears the strongest bar available: full `safeParse` green.
+      expect(ParallelConfigSchema.safeParse(fanConfig).success).toBe(true);
+
       const fnds = lintFlowPatterns({
         flows: [{
           name: 'nightly_sweep',
           type: 'schedule',
           nodes: [
             { id: 'start', type: 'start', config: { triggerType: 'schedule', cron: '0 8 * * *' } },
-            {
-              id: 'fan', type: 'parallel',
-              config: {
-                branches: [
-                  { name: 'writes', nodes: [{ id: 'w1', type: 'update_record', label: 'Write', config: { objectName: 'a' } }], edges: [] },
-                  { name: 'deletes', nodes: [{ id: 'w2', type: 'delete_record', label: 'Delete', config: { objectName: 'b' } }], edges: [] },
-                ],
-              },
-            },
+            { id: 'fan', type: 'parallel', config: fanConfig },
           ],
           edges: [{ id: 'e1', source: 'start', target: 'fan' }],
         }],
@@ -1090,6 +1122,17 @@ describe('flow-inert-node-condition (#4414)', () => {
  * future flattening of the walk fails here instead of going quiet again.
  */
 
+/**
+ * The `loop` container `loopBodyFlow` builds, factored out (#5700) so the pin
+ * below reads the REAL config object every case in this family descends into,
+ * rather than a retyped copy that can drift away from it silently.
+ */
+const loopLeadsConfig = (body: { nodes: unknown[]; edges: unknown[] }) => ({
+  collection: '{vars.leads}',
+  iteratorVariable: 'lead',
+  body,
+});
+
 /** A scheduled sweep: `loop` over leads, with `body` holding the per-item graph. */
 function loopBodyFlow(body: { nodes: unknown[]; edges: unknown[] }) {
   return {
@@ -1100,7 +1143,7 @@ function loopBodyFlow(body: { nodes: unknown[]; edges: unknown[] }) {
         { id: 'start', type: 'start', config: { triggerType: 'schedule', schedule: 'cron:0 9 * * *' } },
         {
           id: 'loop_leads', type: 'loop', label: 'Loop Leads',
-          config: { collection: '{vars.leads}', itemVar: 'lead', body },
+          config: loopLeadsConfig(body),
         },
         { id: 'end', type: 'end' },
       ],
@@ -1111,6 +1154,71 @@ function loopBodyFlow(body: { nodes: unknown[]; edges: unknown[] }) {
     }],
   };
 }
+
+/**
+ * #5700 — the container every case below nests its per-item graph inside must be
+ * a shape the schema ACCEPTS, or those cases prove their rule against metadata
+ * no author can write. That is the #4966 trap (the `TimeRelativeTriggerSchema`
+ * pin near the top of this file) one container down, and it was not hypothetical
+ * here: this helper bound the item with `itemVar` until #5700. `LoopConfigSchema`
+ * is a `strictObject` whose declared key is `iteratorVariable`, so `itemVar` is
+ * reported as an `unrecognized_key` rather than dropped (#4001) — while region
+ * collection reads only `config.body`, so every assertion downstream kept passing
+ * and nothing went red.
+ *
+ * The near-miss direction is already pinned once, in the #5633 block above
+ * (`itemVar` really is refused, so this family's pins have teeth); it is not
+ * repeated here.
+ *
+ * Full `safeParse` green rather than the key-level `refusedKeys` bar, because
+ * what the rules built on this helper judge is a VALUE verdict about a node that
+ * must really be REACHABLE inside a really-authorable container — so the body
+ * has to parse too, `label` and all.
+ *
+ * What is pinned is the container SHELL plus one representative body: the body
+ * is this helper's parameter, and the bodies the call sites pass are raw
+ * literals that omit the node `label` `FlowNodeSchema` requires. Bringing this
+ * whole file to full-flow-parse green is the separate, much broader change
+ * #5700 defers by name.
+ */
+describe('#5700 — the shared loop container is a shape an author can actually write', () => {
+  it('pins loopBodyFlow’s `loop` config against LoopConfigSchema', () => {
+    const parsed = LoopConfigSchema.safeParse(loopLeadsConfig({
+      nodes: [{ id: 'enroll', type: 'create_record', label: 'Enroll', config: { objectName: 'campaign_member' } }],
+      edges: [],
+    }));
+    expect(parsed.success).toBe(true);
+  });
+
+  /**
+   * Why the two nested cases below carry their OWN pins instead of leaning on
+   * this one. `FlowRegionSchema.nodes` is an array of `FlowNodeSchema`, whose
+   * `config` is declared `z.record(z.string(), z.unknown())` — an OPEN record.
+   * So a nested container's config is accepted wholesale by the enclosing parse:
+   * this shell pin stays GREEN while an inner `loop` spells `itemVar`. Measured,
+   * not assumed — the assertion below is that blindness, stated as a fact, so a
+   * future reader does not mistake one pin at the top for coverage of the tree.
+   */
+  it('does NOT see into a nested container’s config — the inner pins are load-bearing', () => {
+    const shellWithBadInnerLoop = LoopConfigSchema.safeParse(loopLeadsConfig({
+      nodes: [{
+        id: 'loop_touchpoints', type: 'loop', label: 'Loop Touchpoints',
+        config: {
+          collection: '{lead.touchpoints}', itemVar: 'tp',
+          body: { nodes: [{ id: 'reset', type: 'update_record', label: 'Reset', config: {} }], edges: [] },
+        },
+      }],
+      edges: [],
+    }));
+    expect(shellWithBadInnerLoop.success).toBe(true);
+
+    // …whereas the very same inner config, parsed as the container it is, is refused.
+    expect(refusedKeys(LoopConfigSchema.safeParse({
+      collection: '{lead.touchpoints}', itemVar: 'tp',
+      body: { nodes: [{ id: 'reset', type: 'update_record', label: 'Reset', config: {} }], edges: [] },
+    })).join(' ')).toMatch(/Unrecognized key\(s\) on this loop container config: `itemVar`/);
+  });
+});
 
 describe('#5383 — flow-inert-node-condition descends into a loop body', () => {
   // The shipped shape, reduced: a per-item gate inside a sweep, whose predicate
@@ -1155,18 +1263,29 @@ describe('#5383 — flow-inert-node-condition descends into a loop body', () => 
     expect(fnds[0].where).not.toContain('loop');
   });
 
+  /**
+   * The INNER container, named so the pin below reads the object the fixture
+   * really descends into. The planted defect is the decision's inert
+   * `config.condition` — everything else about this shape is authorable, and
+   * has to be, or the case proves the descent against a `loop` the schema
+   * refuses (#5700; the enclosing shell pin cannot see in here — `FlowNodeSchema`
+   * declares `config` as an open record).
+   */
+  const nestedTouchpointsLoop = {
+    collection: '{lead.touchpoints}', iteratorVariable: 'tp',
+    body: {
+      nodes: [{ id: 'check_recent', type: 'decision', label: 'Check Recent', config: { condition: 'tp.age_days < 7' } }],
+      edges: [],
+    },
+  };
+
+  it('pins that inner loop container against LoopConfigSchema (#5700)', () => {
+    expect(LoopConfigSchema.safeParse(nestedTouchpointsLoop).success).toBe(true);
+  });
+
   it('descends a loop nested inside a loop — same depth semantics as the engine', () => {
     const fnds = lintFlowPatterns(loopBodyFlow({
-      nodes: [{
-        id: 'loop_touchpoints', type: 'loop',
-        config: {
-          collection: '{lead.touchpoints}', itemVar: 'tp',
-          body: {
-            nodes: [{ id: 'check_recent', type: 'decision', config: { condition: 'tp.age_days < 7' } }],
-            edges: [],
-          },
-        },
-      }],
+      nodes: [{ id: 'loop_touchpoints', type: 'loop', label: 'Loop Touchpoints', config: nestedTouchpointsLoop }],
       edges: [],
     })).filter((f) => f.rule === FLOW_INERT_NODE_CONDITION);
     expect(fnds).toHaveLength(1);
@@ -1177,21 +1296,25 @@ describe('#5383 — flow-inert-node-condition descends into a loop body', () => 
   });
 
   it('descends a parallel branch too — the scope names the branch index', () => {
+    const fanConfig = {
+      branches: [
+        { name: 'owner', nodes: [{ id: 'gate', type: 'decision', config: { condition: 'a == b' } }], edges: [] },
+        { name: 'watchers', nodes: [{ id: 'ping', type: 'notify', config: { title: 'Hi {record.name}' } }], edges: [] },
+      ],
+    };
+    // #5700 container audit, key-level bar (see `refusedKeys`): every key here is
+    // one `ParallelConfigSchema` declares. The branch nodes omit the `label`
+    // `FlowNodeSchema` requires, which is the file-wide convention #5700 defers —
+    // a rejected VALUE, not a key that is no authoring surface at all.
+    expect(refusedKeys(ParallelConfigSchema.safeParse(fanConfig))).toEqual([]);
+
     const fnds = lintFlowPatterns({
       flows: [{
         name: 'fan_out',
         runAs: 'system',
         nodes: [
           { id: 'start', type: 'start', config: { triggerType: 'schedule', schedule: 'cron:0 9 * * *' } },
-          {
-            id: 'fan', type: 'parallel',
-            config: {
-              branches: [
-                { name: 'owner', nodes: [{ id: 'gate', type: 'decision', config: { condition: 'a == b' } }], edges: [] },
-                { name: 'watchers', nodes: [{ id: 'ping', type: 'notify', config: { title: 'Hi {record.name}' } }], edges: [] },
-              ],
-            },
-          },
+          { id: 'fan', type: 'parallel', config: fanConfig },
         ],
         edges: [{ id: 'e1', source: 'start', target: 'fan' }],
       }],
@@ -1281,21 +1404,25 @@ describe('#5383 — the branch-routing family reads the region’s own edges', (
         { id: 'g2', source: 'gate', target: 'y', isDefault: true },
       ],
     });
+    const fanConfig = {
+      branches: [
+        { name: 'a', ...branch('lead.score > 50') },
+        { name: 'b', ...branch('lead.score > 90') },
+      ],
+    };
+    // #5700 container audit, key-level bar (see `refusedKeys`). Covers the branch
+    // EDGES too: `condition` and `isDefault` are the keys this case turns on, and
+    // both are declared — so what it pins is real edge vocabulary, not a shape
+    // the schema would refuse.
+    expect(refusedKeys(ParallelConfigSchema.safeParse(fanConfig))).toEqual([]);
+
     const fnds = lintFlowPatterns({
       flows: [{
         name: 'twin_regions',
         runAs: 'system',
         nodes: [
           { id: 'start', type: 'start', config: { triggerType: 'schedule', schedule: 'cron:0 9 * * *' } },
-          {
-            id: 'fan', type: 'parallel',
-            config: {
-              branches: [
-                { name: 'a', ...branch('lead.score > 50') },
-                { name: 'b', ...branch('lead.score > 90') },
-              ],
-            },
-          },
+          { id: 'fan', type: 'parallel', config: fanConfig },
         ],
         edges: [{ id: 'e1', source: 'start', target: 'fan' }],
       }],
@@ -1510,18 +1637,32 @@ describe('lintFlowPatterns — unbounded bulk write (#5482)', () => {
       expect(fnds[0].message).toContain("every row of 'campaign_member' is deleted");
     });
 
+    /**
+     * The INNER container for the two-regions-deep case, named so the pin below
+     * reads the object the fixture descends into (#5700). The planted defect is
+     * the body node's unfiltered `multi: true`; the container around it has to
+     * be authorable or the case proves this rule against a `loop` the schema
+     * refuses — and the enclosing shell pin cannot see in here, because
+     * `FlowNodeSchema` declares `config` as an open record.
+     */
+    const nestedTouchpointsResetLoop = {
+      collection: '{lead.touchpoints}', iteratorVariable: 'tp',
+      body: {
+        nodes: [{
+          id: 'reset', type: 'update_record', label: 'Reset Touchpoints',
+          config: { objectName: 'touchpoint', fields: { done: false }, multi: true },
+        }],
+        edges: [],
+      },
+    };
+
+    it('pins that inner loop container against LoopConfigSchema (#5700)', () => {
+      expect(LoopConfigSchema.safeParse(nestedTouchpointsResetLoop).success).toBe(true);
+    });
+
     it('flags an update_record two regions deep', () => {
       const fnds = lintFlowPatterns(loopBodyFlow({
-        nodes: [{
-          id: 'loop_touchpoints', type: 'loop', label: 'Loop Touchpoints',
-          config: {
-            collection: '{lead.touchpoints}', itemVar: 'tp',
-            body: {
-              nodes: [{ id: 'reset', type: 'update_record', config: { objectName: 'touchpoint', fields: { done: false }, multi: true } }],
-              edges: [],
-            },
-          },
-        }],
+        nodes: [{ id: 'loop_touchpoints', type: 'loop', label: 'Loop Touchpoints', config: nestedTouchpointsResetLoop }],
         edges: [],
       }));
       expect(fnds).toHaveLength(1);


### PR DESCRIPTION
Fixes #5700

test-only,无 changeset(`skip-changeset`)。文件面仅 `packages/lint/src/lint-flow-patterns.test.ts`;未动 `packages/spec`,未动 `packages/lint/src/` 下任何规则源。

## 前提复核(基于 origin/main@be59695,已含 #5693 → PR #6060)

前提新鲜。三处 fixture 仍以 `itemVar` 绑定循环项:

| 站点 | 原行号 | 出处 |
| --- | --- | --- |
| `loopBodyFlow()` 共享 helper | 1103 | #5383 |
| 嵌套 loop 用例 | 1163 | #5383 |
| 嵌套 loop 用例 | 1518 | #5482 |

`LoopConfigSchema`(`packages/spec/src/automation/control-flow.zod.ts:163`)是 `strictObject`,声明键为 `iteratorVariable`;`itemVar` 既非声明键、也不在 `aliases`(那里只登记了 `itemVariable`,用途是压过 edit-distance 建议器,避免把想要 ITEM 的作者指向 `indexVariable`)。实测:

```
=== outer itemVar (main 上的状态)
    success=false
    - code=unrecognized_keys path=[] keys=["itemVar"]
      msg=Unrecognized key(s) on this loop container config: `itemVar`. Until #4001 an
          undeclared key here was dropped silently — ...
```

region 收集只读 `config.body`,所以这些 fixture 照常下潜、断言照常通过。规则本身没错,错的是 fixture 描述了一个作者写不出来的 `loop` —— #4966 在 trigger 描述符上的同类发现,下沉一层。

`:518` / `:533`(#5695 自带的 pin 与 near-miss)本来就正确,不在本单面内,未改动。

## 改了什么

1. **三处改拼** `itemVar` → `iteratorVariable`。
2. **body 节点补 `label`**(`FlowNodeSchema.label` 是必填,#5695 对自带 fixture 的同样处理);#5383 嵌套用例的 `loop_touchpoints` 节点本身也缺 `label`,一并补上。属于「补声明」而非「重拼」:fixture 本就不是 spec-valid,补齐后它只剩那一处**故意埋的**缺陷(decision 的惰性 `config.condition` / `reset` 的无 filter `multi: true`)。
3. **三处 loop config 提成具名常量并各自 pin** `LoopConfigSchema` 全绿。提成常量是为了让 pin 读到 fixture **真正下潜的那个对象**,而不是一份会静默漂移的重抄副本。

### 为什么嵌套用例要各自 pin(实测,不是推断)

`FlowNodeSchema.config` 声明为 `z.record(z.string(), z.unknown())` —— 开放记录。所以外层 parse 会**整块接受**内层容器的 config:

```
=== 外层 canonical,内层 loop 写 itemVar
    success=true      ← 外壳 pin 全绿,看不见内层
=== 同一份内层 config 直接 parse
    success=false
    - code=unrecognized_keys keys=["itemVar"]
```

这条盲区已经作为**一条断言**写进测试(`does NOT see into a nested container's config — the inner pins are load-bearing`),免得后来者把顶层一条 pin 误当成整棵树的覆盖。

### 门槛的选择:full green 还是 key 级

- **loop 三处 + `parallel` @630**:fixture 本身可做到完全可 authoring,用 **full `safeParse` green** —— 沿用 #5695 写下的理由(这些规则判的是 VALUE 结论,证据节点必须**真的可达**于一个**真的可写**的容器内)。
- **另两处 `parallel`**:分支节点缺 `label`,那是 #5700 正文**明确另案**的全文件约定。这里用 key 级门槛 `refusedKeys(...)`,判据沿用本仓 `validate-security-posture.test.ts:501-513` 已写下的那条:**被拒的 KEY 与被拒的 VALUE 是两回事**。对 key 级规则强行要求 full-parse-green 会删掉正当覆盖;反过来对 value 级规则只要 `unrecognized_keys` 干净则会养出幻检查。

## 容器键位审计(本单 durable 半边)

按容器 slot 全表清点(`FLOW_REGION_SLOTS`:`loop.body` / `parallel.branches` / `try_catch.try` / `try_catch.catch`):

| 容器 | 文件内 fixture 数 | 结论 |
| --- | --- | --- |
| `loop` | 6 | 3 处本单修复;`loopConfig()` @510 与两层嵌套 @622/627 早已 canonical 且实测全绿,未动 |
| `parallel` | 3 | **审计干净 —— 0 处未声明键**;3 处都已加审计断言 |
| `try_catch` | 0 | 文件内没有该容器的 fixture,如实报告,不为凑数造一个 |

`parallel` 三处的 `name` / `nodes` / `edges`,以及 `twin_regions` 分支边上的 `condition` / `isDefault`,实测全部是已声明键。

审计断言**有牙**:往一个分支塞 `bogusKey: 1`,断言按名报红 —— 详见下方回归验证第 4 段。

## 全量测试

`pnpm --filter @objectstack/lint test`:

```
 Test Files  61 passed (61)
      Tests  1457 passed | 4 skipped (1461)
```

基线(改动前,同一 worktree)为 1453 passed / 4 skipped;+4 恰为本 PR 新增的 4 条 `it`。

## 回归验证(方向先声明,后运行)

预先声明的三条预期:(1) 还原 site 1 → 外壳 pin 报红;(2) 还原 site 2 → **只有它自己的内层 pin 报红,外壳 pin 保持绿**(这才证明内层 pin 是承重的,而非冗余);(3) 还原 site 3 → 同理。三条全部命中。

**1. 还原 site 1(`loopLeadsConfig` 改回 `itemVar`)**

```
× pins loopBodyFlow's `loop` config against LoopConfigSchema
× does NOT see into a nested container's config — the inner pins are load-bearing
 Tests  2 failed | 110 passed (112)
```

**2. 还原 site 2(#5383 嵌套)**

```
× pins that inner loop container against LoopConfigSchema (#5700)
 FAIL  #5383 — flow-inert-node-condition descends into a loop body > pins that inner loop container ...
 Tests  1 failed | 111 passed (112)
```

只红了内层那一条,外壳 pin **仍然绿** —— 与上面 `FlowNodeSchema.config` 是开放记录的实测一致。

**3. 还原 site 3(#5482 嵌套)**

```
× pins that inner loop container against LoopConfigSchema (#5700)
 FAIL  lintFlowPatterns — unbounded bulk write (#5482) > inside a nested region (#5383 / #5635) > pins that inner loop container ...
 Tests  1 failed | 111 passed (112)
```

**4. 审计断言有牙(往 `twin_regions` 分支塞未声明键)**

```
× does NOT merge two regions into one bag — a shared node id is not a fan-out
AssertionError: expected [ Array(1) ] to deeply equal []
+   "branches.0: Unrecognized key(s) on this parallel branch: `bogusKey`. ..."
 Tests  1 failed | 111 passed (112)
```

四处均已还原,末次全量为上面的 61 files / 1457 passed。

## 其余门禁

| 门禁 | 结果 |
| --- | --- |
| `pnpm --filter @objectstack/lint typecheck` | 干净(`tsc --noEmit` 无输出) |
| `npx eslint packages/lint/src/lint-flow-patterns.test.ts` | 干净(exit 0) |
| `node scripts/check-nul-bytes.mjs` | `OK (scanned 5839 tracked text file(s); ... no raw ASCII control bytes)` |
| 越过门禁的自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` | 无命中 |

## 不在本单范围

- 全文件 full-`FlowSchema`-green(每个 flow、每个节点补 `label`):#5700 正文明确另案,未做。
- `packages/spec` 未动;`packages/lint/src/` 下任何规则源未动。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_