### PR TITLE
fix(plugin-sharing): tenancy slot 查找改用契约类型 SharingTenancyProbe —— 止血 main 上红着的 check:slot-lookup (#6100)

### DIFF
--- a/packages/plugins/plugin-sharing/src/sharing-plugin.ts
+++ b/packages/plugins/plugin-sharing/src/sharing-plugin.ts
@@ -6,7 +6,7 @@ import type { EngineMiddleware, OperationContext } from '@objectstack/objectql';
 import type { IHttpServer, IHttpRequest, ShareLinkExecutionContext } from '@objectstack/spec/contracts';
 import { SysRecordShare, SysSharingRule, SysShareLink } from './objects/index.js';
 import { SysBusinessUnit, SysBusinessUnitMember } from '@objectstack/platform-objects/identity';
-import { SharingService, type SharingEngine } from './sharing-service.js';
+import { SharingService, type SharingEngine, type SharingTenancyProbe } from './sharing-service.js';
 import { SharingRuleService } from './sharing-rule-service.js';
 import { ShareLinkService } from './share-link-service.js';
 import { registerShareLinkRoutes } from './share-link-routes.js';
@@ -456,7 +456,7 @@ export class SharingServicePlugin implements Plugin {
         // widen a hierarchy scope that carries no organization; an unresolvable
         // posture is not evidence of `single`.
         tenancy: () => {
-          try { return ctx.getService<any>('tenancy'); }
+          try { return ctx.getService<SharingTenancyProbe>('tenancy'); }
           catch { return null; }
         },
       });


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6100

## 背景:main 上的共享损伤

PR #6067(`Fixes #5859`,merge commit `f226605`,01:13Z 落地)在 `sharing-plugin.ts` 新增了一处 `tenancy` slot 查找,写法是把结果擦除到 `any`。`check:slot-lookup` 棘轮因此在 **main 上判红**:

```
✗ slot-lookup ratchet (1 problem(s)):
  • packages/plugins/plugin-sharing/src/sharing-plugin.ts: erasure count grew 10 → 11.
    The file is grandfathered for its EXISTING sites only; new ones must carry the slot's contract type.
```

该门禁跑在 **ESLint job**(`Lint & Type Check` 的 step 9,`pnpm check:slot-lookup`)内,所以每一个后续 PR 的 merge ref 都会带上这条红 —— 属于共享损伤,需要止血。

## 改动(立单人的首选方案 1,最小 diff)

把那一处的类型擦除换成 **该 slot 在本包里的契约类型**:`SharingTenancyProbe`。

- 它就在同一个包里、且**已经**是这个回调的声明类型 —— `SharingServiceOptions.tenancy` 声明为 `() =>` `SharingTenancyProbe | null | undefined`(`sharing-service.ts`)。换句话说,`any` 擦掉的正是这个回调自己承诺的类型;补上后编译器才真的在这一行检查它。
- 它的文档注释写明「Kept structural (and identical in shape to what `SecurityPlugin` reads)」—— 正是 #6067 注释里承诺的「两层永不分歧」:`SecurityPlugin` 读 Layer 0 wall 用的是 `{ posture?: TenancyPosture; isolationActive?: boolean }`(`security-plugin.ts`),`SharingTenancyProbe` 就是同一形状的具名版本。
- **没有对编译器撒谎**:真正注册进 `'tenancy'` 槽位的是 plugin-auth 的 `TenancyService`(`auth-plugin.ts` 的 `ctx.registerService('tenancy', tenancy)`),它声明了 `readonly posture: TenancyPosture` 与 `readonly isolationActive: boolean`,对 `SharingTenancyProbe` 结构可赋值。
- 用本包的结构化探针而不是 `TenancyService`,是为了不让 plugin-sharing 依赖 plugin-auth —— 开源版没有 plugin-auth 时这个 slot 本来就查不到,探针形状是刻意保持无适配器的。

diff 只有两行:call site 的类型参数 + 同一条既有 import 语句里补一个 `type` 名字。⛔ 未动 `SLOT_LOOKUP_UNSWEPT` / `scripts/check-slot-lookup-ratchet.mjs`,⛔ 未 revert #6067。

## 反向验证(方向事先预测:红 → 绿)

在同一个 worktree 里,先在**未改动的 `origin/main`**(`acb10f66a`)上跑,拿到上面那条红(exit 1);打上本 PR 的两行后再跑:

```
✓ slot-lookup ratchet holds: 143 unswept site(s) in 32 file(s), none new.
  baseline key set verified against acb10f6: no files added.
```

总数 144 → 143,该文件回到基线里 grandfather 的 10 —— 棘轮没有被放宽,只是把新增的那一处扫掉了。

## 其它验证

- `pnpm --filter @objectstack/plugin-sharing typecheck` → `tsc --noEmit` 通过(exit 0)。这一条同时是「类型确实成立」的证据:如果 `SharingTenancyProbe` 与该 slot 的实际用法不符,这里就会红。
- `pnpm --filter @objectstack/plugin-sharing test` → **13 files / 359 tests 全通过**。
- `npx eslint --no-inline-config packages/plugins/plugin-sharing/src/sharing-plugin.ts` → exit 0。
- `node scripts/check-nul-bytes.mjs` → OK。

## changeset

**本 PR 不带 changeset**:改动是纯编译期的类型标注,TypeScript 擦除后运行时字节完全相同,既没有行为变化也没有新的发布面(`SharingTenancyProbe` 本来就是 `sharing-service.ts` 导出的类型)。按仓库约定它「declares no release of its own」,应走 `skip-changeset` 标签这一路 —— 该标签由 PM 座位在验收时施加(本座位按派发指令不自贴标签)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wbxm29qPKnLf44AbSxizqW)_