### PR TITLE
docs(releases): v17 升级指南收录两条 console 破坏性迁移,console 段 pin 区间推到 f995a452d2ca (#6106)

### DIFF
--- a/content/docs/releases/v17.mdx
+++ b/content/docs/releases/v17.mdx
@@ -1085,6 +1085,86 @@ The Console side follows: `@object-ui/types` drops its
 pointed at the same retired cluster (objectui#2860). Import what you still need
 from `@objectstack/spec` directly.
 
+### Field widgets receive their metadata on one key, `field` (objectui#3233)
+
+`FieldWidgetComponentProps` no longer declares `schema`. The prop was a second
+carrier for what `field` already means: `SchemaRenderer` passed the authored
+node as `schema`, the form renderer's `renderFieldComponent` passed
+`schema={props.field || props.schema || props}` *alongside* `field`, and about
+thirty widgets settled the disagreement themselves with `field || schema` — one
+concept, two spellings, a de-facto second contract.
+
+**Reading the metadata** — drop the fallback:
+
+```diff
+-const config = field || (props as any).schema;
++const config = field;
+```
+
+**Registering a widget** that can be rendered from a schema node — anything
+`SchemaRenderer` dispatches, not just forms — wrap it once so it still receives
+`field`:
+
+```diff
++import { withFieldCarrier } from '@object-ui/fields';
++
+-ComponentRegistry.register('color', ColorField, { namespace: 'field' });
++ComponentRegistry.register('color', withFieldCarrier(ColorField), { namespace: 'field' });
+```
+
+`withFieldCarrier` forwards the node **by reference** — nothing is copied,
+narrowed or renamed — and consumes `schema` so it cannot reach the DOM through a
+widget's `...props` spread. The SDUI node → `field` translation now happens
+exactly once, in that adapter, and every built-in field widget is registered
+through it.
+
+**Who is affected:** anyone who wrote a field widget. In TypeScript, reading
+`props.schema` is now a compile error rather than a silent `any`; a third-party
+widget that keeps reading it and is **not** re-registered through the adapter
+reads `undefined` in 17 and renders its empty or default state without
+complaining. That is the deliberate cost of a major boundary — one contract
+beats N dialects, and picking the wrong spelling should fail at compile time
+rather than work under one host and not another.
+
+**Host metadata is untouched.** No authored SDUI JSON changes — this is a change
+to how widgets are *written*, not to what apps declare. `schema` also remains the
+universal SDUI prop every registered component receives from `SchemaRenderer`
+(`element:*`, `page:*`, grids, reports); only the *field-widget* contract retired
+it.
+
+### Flow node geometry is the spec's `FlowNode.position` (objectui#3172)
+
+The flow designer writes node coordinates as `position: { x, y }` — the key
+`@objectstack/spec` has modelled all along — instead of its own `ui: { x, y }`.
+Dragging, adding-at-a-point and insert-on-edge each wrote the local spelling;
+all three now write `position`, and the canvas migrates on write: a stored
+flow's legacy `ui` is lifted onto `position` and the key removed in the first
+patch the canvas emits, geometry-related or not.
+
+**This is a behaviour fix, not a rename.** `FlowNodeSchema` has been `.strict()`
+since #4001, so `ui` is an `unrecognized_keys` error: client validation flagged
+the draft on every keystroke and the server rejected the save with a 422. In
+other words, dragging a node made the flow unsavable — the convergence is what
+makes the designer's most basic gesture round-trip again.
+
+**Who is affected:** anything reading `node.ui` off a flow draft. After the
+author's first edit the key is gone and the coordinates live under
+`node.position`:
+
+```diff
+-const { x, y } = node.ui;
++const { x, y } = node.position;
+```
+
+**Reading a stored flow stays backwards-compatible.** `manualPosition()` prefers
+`position` and falls back to a legacy `ui`, so a flow saved before this change
+still opens with its nodes exactly where the author left them. The fallback is a
+migration path, not a second contract: nothing writes `ui`, and the canvas
+strips it at its input boundary, so no patch can re-emit it. Nothing in this
+repo or the engine ever read the key — it was designer-local, and the schema
+rejected it — so the migration reaches only code written against the designer's
+own drafts.
+
 ### Smaller breaking changes
 
 - **MongoDB driver declares itself single-tenant** and refuses to boot in a
@@ -1966,12 +2046,16 @@ rc.1, and administrators should know what changed:
   the generated upgrade guide and the `spec_changes` MCP tool actually
   report the 16 → 17 chain (they still said 16.0.0).
 
-### New in Console — bundled objectui advanced `4a4829d0ef39 → 785b8a5d432c`
+### New in Console — bundled objectui advanced `4a4829d0ef39 → f995a452d2ca`
 
 143 objectui commits across five pin moves, released as **objectui 17.1.0**.
 (The pin changesets enumerate 79 of them; one range under-enumerated its own
 window and is recorded by `console-bebaebd39ace-backfill` — the fixes it
 covers are folded into the list below rather than left to the changelog.)
+Two later pin moves carried the bundle on to `f995a452d2ca` — 129 further
+commits, enumerated in `console-f5bc4c78be76` and `console-f995a452d2ca`. The
+two author-facing breaking migrations in that range are documented under
+*Breaking changes & migration* above.
 
 - **The lockstep half of ADR-0110 — release-critical.** The rc.0 pin predates
   the client fix, so the Console it built still posted `action.target` to
@@ -2058,11 +2142,11 @@ covers are folded into the list below rather than left to the changelog.)
 These changes are on `main` after the `rc.1` cut and **roll into 17.0.0-rc.2**.
 At the time of writing the window has left 209 changesets pending — 46
 `major`-class, 74 `minor`, 55 `patch`, and 34 that release nothing (CI, tooling
-and docs). The Console pin is **unchanged** at `785b8a5d432c`, so the objectui
-delta rc.2 bundles is the one already documented in the section above; there is
-no new Console delta this round. (If `scripts/bump-objectui.sh` advances the pin
-before the cut, that range needs its own section — objectui `main` has moved
-past `785b8a5d432c`.)
+and docs). The Console pin was `785b8a5d432c` when this window was written and
+has since advanced to `f995a452d2ca` in two moves; that delta is carried by the
+range on *New in Console* above and enumerated in the two pin changesets. Its
+two author-facing breaking migrations are documented with the other breaking
+changes above.
 
 Two campaigns dominate the window, and both are *finishing* rather than
 starting: the #4535 dual-source convergence and #4001's close of the authorable


### PR DESCRIPTION
Fixes #6106

rc.4 发布前置的 **PR A(docs-only)**。只改 `content/docs/releases/v17.mdx` 一个文件,不含任何代码/脚本改动,因此没有 changeset(走 `skip-changeset`)。这是 CLAUDE.md「不要在代码 PR 里改 `content/docs/releases/`」条款所指的那条正当路径:专门的 docs-only PR 修正该页的事实错误。

## 为什么现在改

PR #6097 把 console pin 推到 objectui `f995a452d2ca`,随之 vendored 进来两条 **作者侧破坏性迁移**。它们此前只活在 `.changeset/`(发布记录的输入层),整个 `content/docs/` 下对 `withFieldCarrier` / `FieldWidgetComponentProps` / `FlowNode.position` / `node.ui` **零命中** —— rc.4 一发,正在升级的作者在文档站上读不到,这是新用户第一眼撞上的坑。

## 改了什么(三处 hunk)

### 1. 「Breaking changes & migration」新增两条 `###` 条目

插在 `### Dead spec clusters removed` 与 `### Smaller breaking changes` 之间(不动任何既有条目顺序)。格式对齐同章节里唯一的 objectui 来源前例 `### An action param's picker target is 'reference', and only 'reference' (objectui#3203)`:声明句式标题 + 源链接括注、`diff` 迁移块、加粗小结句。

- **`### Field widgets receive their metadata on one key, 'field' (objectui#3233)`** —— `FieldWidgetComponentProps` 不再声明 `schema`;两个生产者收敛,约 30 处 `field || schema` 消失。给出两段机械迁移:读法去掉 fallback;能被 `SchemaRenderer` 派发的 widget 用 `withFieldCarrier` 包一次注册。点名受影响者(第三方 widget 继续读 `props.schema` 会拿到 `undefined` 并静默渲染空态),并保留源 changeset 的两条「没变的东西」——宿主元数据(SDUI JSON)不变、`schema` 仍是非 field-widget 组件的通用 SDUI prop。
- **`### Flow node geometry is the spec's 'FlowNode.position' (objectui#3172)`** —— 三处写入点统一写 `position: { x, y }`,画布在首个 patch 上把遗留 `ui` 抬到 `position` 并删键。保留源 changeset 的关键定性:**这是行为修复而非改名**(`FlowNodeSchema` 自 #4001 起 `.strict()`,`ui` 是 `unrecognized_keys`,服务端 422 —— 拖一下节点就存不了流程);读取侧向后兼容(`manualPosition()` 优先 `position`、回落遗留 `ui`),但那是迁移路径不是第二契约。

两条正文均取自 objectui@`f995a452d2ca` 的源 changeset(`field-widget-single-metadata-carrier.md` / `flow-node-geometry-is-spec-position.md`)与 objectui#3233 / objectui#3172。

### 2. console 段 pin 区间行(原第 1969 行)

```
- ### New in Console — bundled objectui advanced `4a4829d0ef39 → 785b8a5d432c`
+ ### New in Console — bundled objectui advanced `4a4829d0ef39 → f995a452d2ca`
```

并在该段说明后补四行(既有的 143 commits / five pin moves 叙述原样保留,不重写):

```
+ Two later pin moves carried the bundle on to `f995a452d2ca` — 129 further
+ commits, enumerated in `console-f5bc4c78be76` and `console-f995a452d2ca`. The
+ two author-facing breaking migrations in that range are documented under
+ *Breaking changes & migration* above.
```

数字是实测的,不是估的:`git rev-list --count --no-merges 785b8a5d432c..f995a452d2ca` = **129**,与两份 pin changeset 自报的 31 + 98 non-merge commits 吻合;`git merge-base --is-ancestor` 确认该区间内的 pin 落点只有 `f5bc4c78be76` 与 `f995a452d2ca` 两次(其余 console changeset 的 sha 都不在 `785b8a5d432c` 之后)。

### 3. rc.1 窗口开头的同一陈旧事实(独立 hunk,可单独回退)

Issue 只点名了第 2 处,但那句话与它是**同一个事实的另一处落点**;只改标题行会让该页在一屏之内自相矛盾(上面说推进到 `f995a452d2ca`,下面说 pin **unchanged** 在 `785b8a5d432c`)。故按事实更正,行数不变(5 行换 5 行):

```
- and docs). The Console pin is **unchanged** at `785b8a5d432c`, so the objectui
- delta rc.2 bundles is the one already documented in the section above; there is
- no new Console delta this round. (If `scripts/bump-objectui.sh` advances the pin
- before the cut, that range needs its own section — objectui `main` has moved
- past `785b8a5d432c`.)
+ and docs). The Console pin was `785b8a5d432c` when this window was written and
+ has since advanced to `f995a452d2ca` in two moves; that delta is carried by the
+ range on *New in Console* above and enumerated in the two pin changesets. Its
+ two author-facing breaking migrations are documented with the other breaking
+ changes above.
```

若维护者认为这一处应留给 rc.4 的发布记录统一处理,这是**独立的第三个 hunk**,单独 revert 不影响前两处。

## 验证

纯文本改动,没有反向验证可做(不存在会因这次改动翻转的断言);跑的是 CI 对 `content/docs/**` 实际会跑的门禁,全绿:

| 门禁 | 结果 |
|:--|:--|
| `pnpm check:release-notes` | `OK — every released major has a curated, navigable release page.` |
| `pnpm check:doc-authoring` | self-test 通过 + `363 files clean — no bare metadata literals.` |
| `pnpm check:docs-audit-scope` | `178 hand-written doc(s)` 同步 + `9 page(s) under content/docs/releases/ review-only` |
| `pnpm check:adr-anchors` | `OK (34 anchored file(s), every governing ADR still referenced).` |
| `pnpm check:nul-bytes` | `OK (scanned 5857 tracked text file(s) … no raw ASCII control bytes).` |
| `pnpm check:prerelease-pins` | self-test 通过 + `No stable release yet for 11 prerelease pin(s)` |
| MDX 可解析性 | `apps/docs` 的 `fumadocs-mdx` 重新生成通过;另用 `@mdx-js/mdx@3.1.1` 直接 `compile(v17.mdx, { format: 'mdx' })` → **MDX COMPILE OK** |

改动面:`1 file changed, 90 insertions(+), 6 deletions(-)`,只有 `content/docs/releases/v17.mdx`。

## 关联

- 配套 **PR B**:`.changeset/console-f995a452d2ca.md` 的 flow 条目补 `**BREAKING (v17)**` 标注(同一 issue 的第 3 项,单独 PR)。
- #6099 —— digest 只读首段导致该标注丢失的机制盲区,**不在本 PR 范围**。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_