### PR TITLE
docs(spec-property-retirement): 收尾清单补两条 —— 「不代跑」源审计整组跑、dogfood 纳入退役默认消费半径

### DIFF
--- a/.claude/skills/spec-property-retirement/SKILL.md
+++ b/.claude/skills/spec-property-retirement/SKILL.md
@@ -310,6 +310,20 @@ Work top to bottom; each line has a gate behind it.
       as `CHANGELOG.md` in the npm package and is what an upgrading agent greps
       after the tombstone error. `.changeset/tool-inert-keys-removed.md` is the
       model — its "The retirement kit:" section is the template to copy.
+- [ ] **The source audits `check:generated` explicitly does NOT run — run them
+      as one group, never à la carte.** Its output names them; the trap is
+      running five and skipping the sixth. `check:variant-docs` is the one that
+      bites retirements: deleting a discriminated union orphans its
+      variant/doc-ledger entry, and the gate reds only in CI if you skipped it
+      locally (#5552 / PR #6078: the `type:cast|constant|javascript|lookup|map`
+      entry outlived its union by one review round).
+- [ ] **`packages/qa/dogfood` is in the default consumption radius of a
+      retirement** — not just the packages that import the schema. It holds the
+      ADR-0058 D7 expression-surface conformance ledger
+      (`test/expression-conformance.test.ts`), so removing any schema member
+      that carries an expression surface strands a `covers` entry
+      ("STALE covers — surface no longer in source", same PR, second miss).
+      Run its targeted suite before pushing, whatever your import graph says.
 
 **A correction (§1) must propagate to every one of these lines too.** When
 `form.data` flipped back to `live`, the ledger, the conversion and the tests were


### PR DESCRIPTION
#5552 / PR #6078 三轮补圈的实测沉淀,写入退役剧本的 surface checklist(+14 行,docs-only,`.claude/` 内部工具面):

1. **`check:generated` 明确「不代跑」的源审计要当一个整组跑完,不可点单** —— `check:variant-docs` 是咬退役单的那一个:删掉判别联合会孤儿化它的 variant/doc 账本条目;#6078 实测跑五漏一,让 `type:cast|constant|javascript|lookup|map` 条目多活了一个复核轮。
2. **`packages/qa/dogfood` 属于退役类改动的默认消费半径**,与 import 图无关 —— 它持有 ADR-0058 D7 表达式合规账本(`test/expression-conformance.test.ts`),摘除任何携带 expression 面的成员都会搁浅一条 cover(同 PR 第二处漏检,"STALE covers" 签名)。

两处漏检均为可定位剧本缺口而非随机疏忽;修剧本使后续退役单一次过。前置:#6120(同分支前一单)已合并,本 PR 为分支重启后的后续单。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY

---
_Generated by [Claude Code](https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY)_