### PR TITLE
chore(console): bump objectui pin f995a452 -> 7dfbeb70 (28 commits / 9 releasing changesets, all patch) — rides rc.5

### DIFF
--- a/.changeset/console-7dfbeb704e1e.md
+++ b/.changeset/console-7dfbeb704e1e.md
@@ -1,0 +1,19 @@
+---
+"@objectstack/console": patch
+---
+
+Console (objectui) refreshed to `7dfbeb704e1e`. Frontend changes in this range:
+
+Derived from the changesets objectui declared over the range — 9 releasing of 9 changesets added across 28 non-merge commits; omitted: 20 commits carrying no changeset (they ship no package code).
+
+- **patch** — The bulk selection bar now applies the ADR-0066 D4 `requiredPermissions` capability gate, and short-circuits a boolean `visible` instead of treating it as a broken expression (#34… (objectui `d915c47b3`)
+- **patch** — Relation fields (`lookup` / `master_detail` / `user` / `tree`) are now usable in action and conditional-formatting predicates: they bind as the stored foreign key on every surface… (objectui `d915c47b3`)
+- **patch** — Conditional-rule predicates that fail to evaluate are no longer silent (objectstack#5149, appeal 2). `evalFieldPredicate` — the canonical funnel for `visibleWhen` / `readonlyWhen`… (objectui `a4cff5bd1`)
+- **patch** — `useAppContextSelectors` now derives each context selector's URL scope key from its own `id` instead of hardcoding the literal `package` query key. `App.contextSelectors` is an ar… (objectui `f59406d4e`)
+- **patch** — `toPredicateInput` is now re-exported from `@object-ui/core` instead of being reimplemented in `@object-ui/react`. Behaviour is byte-for-byte identical — the renderer-side copy in… (objectui `175bd79d8`)
+- **patch** — The group-tenancy write-target badge is now translated in all ten locales (objectui#3517) (objectui `7e2406abf`)
+- **patch** — Give `CommentThread`'s `+` reaction picker a real accessible name (objectui#3478) (objectui `d0d71df0e`)
+- **patch** — `RecordFormPage` no longer passes an inline `defaultValue` to the seven `t()` lookups whose keys are defined in all ten locale packs (`form.createTitle`, `form.editTitle`, `form.c… (objectui `c0c771c2f`)
+- **patch** — `createSafeTranslation`'s no-provider fallback interpolation now replaces **all** occurrences of each placeholder, matching i18next semantics on the provider path. (objectui `a6ec93d24`)
+
+objectui range: `f995a452d2ca...7dfbeb704e1e`

--- a/.objectui-sha
+++ b/.objectui-sha
@@ -1,1 +1,1 @@
-f995a452d2ca97fcc4b92ec6d004ee5571f3d6b7
+7dfbeb704e1eace5dc5eae1d6168c4ded805a32b


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6159

Moves `.objectui-sha` from `f995a452d2ca97fcc4b92ec6d004ee5571f3d6b7` to `7dfbeb704e1eace5dc5eae1d6168c4ded805a32b` — objectui `origin/main` as read at 2026-08-07T07:03:22Z — and adds the one `@objectstack/console` changeset `scripts/bump-objectui.sh` generates from the range.

**Target is rc.5.** 17.0.0-rc.4 was published at 04:17Z from `a10cbc77` with the pin still at `f995a452`, via a lane that bypassed `check:objectui-pin-fresh` (#6169 / #6170). The 9 releasing frontend changesets below are therefore absent from rc.4's release record; this changeset puts them back into the release pipeline on the next Version Packages cycle, repairing the record gap rc.4 shipped with.

## Maintainer direction (2026-08-07, in chat — quoted verbatim)

> 6159 你也认领,并更新到最新版本的 objectui

The bump target is accordingly the **current** objectui `origin/main` head at execution time, not the `a4cff5b` of the issue title nor the `ce12564` of the 06:26Z range refresh. objectui advanced twice more while this issue sat: `a4cff5b` → `ce12564` → `7dfbeb7`. The SHA was passed explicitly to the script rather than inherited from whatever the sibling checkout had checked out.

## Range: 28 non-merge commits, 9 releasing changesets — all declared `patch`

The digest derives inclusion and level from the `.changeset/*.md` files objectui itself **declared** over the range (#4731), never from commit subjects. All 9 are listed in the changeset body, unabridged. Declared levels, verified individually against the adding commit:

| objectui changeset | declared level | packages | adding commit |
|---|---|---|---|
| `bulk-action-capability-gate` | `patch` | `types`, `plugin-grid` | `d915c47b3` (objectui#3548) |
| `lookup-fields-in-predicates` | `patch` | `core`, `react`, `components`, `plugin-grid`, `plugin-list`, `plugin-kanban` | `d915c47b3` (objectui#3548) |
| `predicate-eval-failures-warn-once` | `patch` | `core`, `components`, `plugin-form`, `app-shell` | `a4cff5bd1` (objectui#3541) |
| `context-selector-per-selector-scope-key` | `patch` | `app-shell` | `f59406d4e` (objectui#3531) |
| `react-predicate-input-reexports-core` | `patch` | `react` | `175bd79d8` (objectui#3511) |
| `create-target-org-translated-3517` | `patch` | `i18n`, `app-shell` | `7e2406abf` (objectui#3526) |
| `collaboration-reaction-picker-accessible-name-3478` | `patch` | `collaboration` | `d0d71df0e` (objectui#3503) |
| `record-form-page-dead-i18n-defaultvalue-3469` | `patch` | `app-shell` | `c0c771c2f` (objectui#3516) |
| `safe-translation-fallback-replace-all` | `patch` | `i18n` | `a6ec93d24` (objectui#3510) |

Highest declared level = `patch`, so the generated `@objectstack/console` changeset declares `patch`. The remaining 20 commits in the range carry no changeset (docs, ci, dependabot bumps, and objectui's own release commit) and the changeset body states that count rather than omitting it silently.

`objectui-changeset-digest.mjs` accounting line, verbatim from the run:

```
9 releasing changeset(s), 0 breaking, 0 release-nothing, 20 commit(s) without a changeset
```

## #6099 re-verification — done, and it clears

The issue's standing caveat is that the digest only flags `major`-declared breaking, while objectui declares v17-window breaking as `minor` plus a body annotation. Every one of the 9 changeset bodies was read in full and then scanned mechanically for `BREAKING` / `breaking change` / `不兼容` / `破坏性` / `migration required` / `no longer accepts` / `renamed to` / `removed the export`. **Zero hits, and every declared level is `patch` on every package.** Three of the nine state non-breakage explicitly in their own words — `context-selector-per-selector-scope-key` ("Existing URLs are byte-identical before and after"), `react-predicate-input-reexports-core` ("Behaviour is byte-for-byte identical… every existing import path keeps working with an unchanged signature") and `record-form-page-dead-i18n-defaultvalue-3469` ("Rendered copy is unchanged in every locale"). No under-labelling to escalate.

## Two things about this range worth recording

**1. The target is objectui's own release commit.** `7dfbeb7` is `chore: release packages (#3248)`, which consumed and deleted all 88 pending changesets — 9 of them ours, 79 added before the pin and already accounted for by #6097's bump. This is the first pin bump to cross an objectui release commit, and the digest handles it exactly as designed: `collectAddedChangesets` walks the log with `--diff-filter=A` rather than diffing the endpoints, precisely so a changeset consumed by an in-range release is not dropped, and `readAt` falls back from the tip to the adding commit when the file is gone at the tip. All 9 resolved. Pinning at a released tree is if anything the cleaner choice.

**2. objectui#3518 shipped without a changeset.** `0e50440` ("fix(form): bind `previous` for field rules and stop resubmitting read-only fields") is in this range, touches 26 files across `components` / `plugin-form` / `types` / `data-objectstack` / `app-shell` / ten locale packs, and adds no `.changeset/*.md` — confirmed with `git show --name-status 0e50440 -- .changeset/`, which returns nothing. It is therefore one of the 20 no-changeset commits, not one of the 9 releasing entries. (The 06:26Z range refresh on the issue attributed one changeset to #3518; the count of 9 was right, the attribution was not — objectui#3548 contributed two, #3518 none.) The code ships in the console build either way; only the release record loses it. Filed separately as a finding rather than papered over here.

## Verification

Gate list enumerated from `.github/workflows/lint.yml`, `.github/workflows/objectui-pin-freshness.yml`, `.github/workflows/pr-automation.yml`, `.github/workflows/validate-deps.yml` and `.github/workflows/ci.yml`, restricted to those that read the changed files. All run locally, all green:

| gate | where it runs in CI | result |
|---|---|---|
| `check:nul-bytes` | lint.yml / ESLint | `OK (scanned 5914 tracked text file(s)… no raw ASCII control bytes)` |
| `check:objectui-changeset` | lint.yml / ESLint | both self-tests pass |
| `check:objectui-pin-fresh` | Console Pin Freshness | **`FRESH` — `.objectui-sha` is objectui `main` (objectui@7dfbeb704e1e)** |
| `check-empty-changeset.mjs --base origin/main` | pr-automation.yml | `No empty-frontmatter changeset introduced by this diff (1 declaring changeset(s) added)` |
| `check-changeset-no-major.mjs` | pr-automation.yml | exit 0 (dormant inside the RC pre-window; every pending `major` reported as a notice) |
| `check-changeset-fixed.mjs` | validate-deps.yml, release.yml | `"fixed" group is in sync with 69 public workspace packages` |
| `check:console-sha` | ci.yml Console Pin Gate, showcase-smoke, release | `No console dist… skipping` (expected: `packages/console/dist` is gitignored and untouched here) |

A targeted control-byte self-scan of the two changed files (`grep -naP` over the full `0x00-0x08 0x0b 0x0c 0x0e-0x1f 0x7f` set) returns no matches.

The heavy proof — clone objectui at the pin and build the SPA — is **ci.yml's Console Pin Gate** and was deliberately not run locally; that gate answers "does the pinned SHA still build?", which is the opposite question from the freshness gate above, and both must be green.

## File surface

Exactly two files, both written by `scripts/bump-objectui.sh`:

- `.objectui-sha` — the pin
- `.changeset/console-7dfbeb704e1e.md` — the generated `@objectstack/console` `patch` changeset

`packages/console/**` is untouched and un-hand-edited. No `.changeset/pre.json` change. No `content/docs/releases/` change. Nothing published, no tags pushed, no workflow triggered — per the maintainer ruling that 版本发布必须人工.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BickTBKm2JYSNnrtPT8ysa)_