### PR TITLE
ci(dx): TEST_DEBT 的隐藏测试文件数改由闸门实时导出，删掉手写 `tests` 字段 (#5826)

### DIFF
--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -388,14 +388,18 @@ const EXEMPT = {
     'Published objectui build artifact -- package.json/README/CHANGELOG plus a dist/ pulled in by `pnpm objectui:refresh`. No TypeScript sources, no tsconfig; the sources are type-checked in the objectui repo.',
 };
 
-// Package name -> { tests, errors, note? } for packages whose tsconfig excludes
-// their own test files. `tests` is the number of hidden `*.test.ts`/`*.spec.ts`
-// files, `errors` what `tsc --noEmit` reports once the exclusion is lifted --
-// both measured by re-running each package's own config with the test globs
-// dropped. These packages are NOT uncovered: their src type-checks and most
-// declare `typecheck`. What they hide is the test layer, which is where #4311
-// found the defects (a passing vitest run proves the code executes, not that
-// the call shapes match). Sorted by what each is hiding, worst first.
+// Package name -> { errors, note? } for packages whose tsconfig excludes their
+// own test files. `errors` is what `tsc --noEmit` reports once the exclusion is
+// lifted, measured by re-running each package's own config with the test globs
+// dropped. HOW MANY files that exclusion hides is NOT recorded here: this gate
+// counts them on every run (`testCoverage()` -> `pkg.testFiles`, sub-second, no
+// compiler), so the summary derives the number instead of reading a copy of it
+// (#5826). An entry that carries a `tests` field is rejected -- see the
+// RECONCILED loop in evaluate(). These packages are NOT uncovered: their src
+// type-checks and most declare `typecheck`. What they hide is the test layer,
+// which is where #4311 found the defects (a passing vitest run proves the code
+// executes, not that the call shapes match). Sorted by what each is hiding,
+// worst first.
 // `@objectstack/spec` graduated in #5286: `tsconfig.test.json` (a sibling of
 // the build config, named by the `typecheck` script) compiles its 295 test
 // files, so nothing is hidden any more and TESTS_COVERED no longer wants an
@@ -404,31 +408,38 @@ const EXEMPT = {
 // PER-FILE exact ratchet re-measured by tsc on every run, which is strictly
 // stronger than the frozen package-level number this ledger could hold. The
 // number that used to sit here (272 files / 902 errors) was also stale by 23
-// files, which is the other argument for a measurement the gate derives.
+// files, which is the other argument for a measurement the gate derives -- an
+// argument this ledger has now acted on rather than only recorded (#5826).
 //
 // Re-measured wholesale on main @ 5ab08428 (2026-08-06) with the DEBT ledger
 // above, for the same reason (#5278): 10 of these 19 `errors` numbers were
-// understated, 2 overstated, 7 exact. `errors` is now re-run by --re-measure;
-// `tests` is not, and it had drifted just as far in the same direction (66 ->
-// 101 for runtime, 87 -> 125 for objectql) because adding a test file to an
-// excluded package is invisible to everything. Both fields are accurate as of
-// that sha; only one of them is enforced, which is filed rather than silently
-// widened here.
+// understated, 2 overstated, 7 exact. That sweep also refreshed a SECOND
+// hand-written number, `tests`, which had drifted just as far in the same
+// direction (66 -> 101 for runtime, 87 -> 125 for objectql; 12 of 19 entries
+// stale, every one of them understated) because adding a test file to an
+// excluded package was invisible to everything. The two numbers needed
+// OPPOSITE repairs, which is why they were two issues: `errors` cannot be
+// known without running the compiler, so freeze + re-measure (#5278) is the
+// only shape available to it; the file count is FREE -- this gate already
+// computes it on every run to decide TESTS_COVERED -- so the fix is to delete
+// the copy and read the live count (#5826). A refreshed copy would have been
+// accurate for exactly as long as it took the next test file to land; a
+// derived one cannot drift at all, which is why this one is gone rather than
+// re-ratcheted.
 const TEST_DEBT = {
   '@objectstack/plugin-approvals': {
-    tests: 19,
     errors: 547,
     note: 'TS2339 x296, TS2345 x213, TS2550 x20, TS18048 x10. Re-measured 547 at 5ab08428, up from 467. '
       + 'Still larger than driver-sql ever was, and still entirely test-only (src is clean), so nothing '
       + 'but this ledger has ever seen it. 443 of the 547 are in one file, src/approval-service.test.ts.',
   },
   '@objectstack/objectql': {
-    tests: 130,
     errors: 355,
     note: 'TS2339 x115, TS2554 x93 (wrong arity), TS7006 x47, TS2345 x19, TS2322 x12, TS2749 x11. '
       + 'Re-measured 333 at 5ab08428, up from 219 -- the largest absolute growth in either ledger. The '
-      + 'shape held (TS2339/TS2554/TS7006 still lead) but every number roughly tripled, and the file count '
-      + 'went 87 -> 127; src/engine.test.ts alone carries 103. Then +2 at 909895dc (+1 TS2339 in '
+      + 'shape held (TS2339/TS2554/TS7006 still lead) but every number roughly tripled, and the hidden '
+      + 'test layer took on ~40 more files over the same window; src/engine.test.ts alone carries 103 of '
+      + 'the errors. Then +2 at 909895dc (+1 TS2339 in '
       + 'src/registry.test.ts, #5802 having added ~116 lines of registry tests; +1 TS2554 in the file '
       + '#5850 introduced, src/engine-update-prior-read-scope.test.ts), and +4 more at c15fcee4c -- ALL '
       + 'FOUR in one file #5861 added, src/save-meta-response-conformance.test.ts: one TS2554 at :115, '
@@ -447,7 +458,6 @@ const TEST_DEBT = {
       + 'after landing (#5278 option A).',
   },
   '@objectstack/runtime': {
-    tests: 102,
     errors: 227,
     note: 'TS18048 x98 (possibly-undefined), TS2345 x26, TS18046 x20, TS2339 x16, TS2493 x15, TS2835 x11, '
       + 'TS2554 x11. Src '
@@ -459,7 +469,6 @@ const TEST_DEBT = {
       + '`GET /meta/:type/:name` envelope convergence). Nothing else in the package moved.',
   },
   '@objectstack/rest': {
-    tests: 62,
     errors: 163,
     note: 'TS2835 x67 (NodeNext extensions), TS7006 x57, TS2554 x13, TS2550 x10. Also in DEBT. Measured '
       + '105 -> 136 (5ab08428) -> 143 (77adf29, hours later the same day) -> 153 (e8db1a230). Read the '
@@ -479,7 +488,6 @@ const TEST_DEBT = {
       + 'hint immediately after landing (#5278 option A).',
   },
   '@objectstack/plugin-auth': {
-    tests: 38,
     errors: 131,
     note: 'TS2493 x42 (tuple index out of range), TS18048 x24, TS2740 x19, TS2322 x11, TS2532 x9, '
       + 'TS2339 x8, TS2741 x8. '
@@ -490,7 +498,6 @@ const TEST_DEBT = {
       + 'src/admin-import-users.test.ts and 18 in src/admin-user-endpoints.test.ts.',
   },
   '@objectstack/mcp': {
-    tests: 9,
     errors: 63,
     note: 'TS18046 x51 -- `json` is of type unknown, one `await res.json()` idiom repeated across four '
       + 'files (23 in mcp-server-runtime.http.test.ts, 14 in mcp-action-tools.test.ts, 8 in '
@@ -502,7 +509,8 @@ const TEST_DEBT = {
       + 're-measured against a moving base. The +1 is fully attributed: '
       + 'src/skill-prompts.test.ts(185,23), a TS2352 casting `SkillPrompt | null` to `Record< string, '
       + 'unknown >` -- the file #3905 / PR #6077 added when it projected skill `instructions` as MCP '
-      + 'prompt primitives, which is also why the file count moved 8 -> 9. The old note\'s composition '
+      + 'prompt primitives, which is also why this package\'s hidden test-file count moved up by one '
+      + '(the count itself is derived by this gate, not recorded here -- #5826). The old note\'s composition '
       + 'was misleading in the way the top of this ledger warns about: it read "`error` is of type '
       + 'unknown, one catch-block idiom", while all 51 are the response-body `json` binding, not a '
       + 'catch block. packages/mcp took a feature landing the same day, so it is an actively-moving '
@@ -511,7 +519,6 @@ const TEST_DEBT = {
       + 'tighten via the ℹ hint immediately after landing (#5278 option A).',
   },
   '@objectstack/driver-mongodb': {
-    tests: 15,
     errors: 43,
     note: 'TS2345 x33, TS1309 x7, TS2550 x3. Re-measured 43 at 5ab08428, DOWN from 44 -- but the '
       + 'composition changed completely: the TS2591 x15 the old note pinned on a missing `types:["node"]` '
@@ -520,7 +527,6 @@ const TEST_DEBT = {
       + 'to describe debt (#5278).',
   },
   '@objectstack/lint': {
-    tests: 61,
     errors: 42,
     note: 'TS7006 x22, TS2835 x6, TS6059 x4. Measured 26 -> 30 (5ab08428, the +4 being TS6059, a file '
       + 'outside rootDir, a class the pre-#5278 note did not list) -> 32 (e8db1a230). The latest +2 are '
@@ -531,14 +537,13 @@ const TEST_DEBT = {
       + 'measured at e8db1a230 and re-confirmed at 32 an hour later at 77c7c884b) -- tighten via the ℹ '
       + 'hint immediately after landing (#5278 option A).',
   },
-  '@objectstack/plugin-security': { tests: 35, errors: 21, note: 'TS2739 x8, TS2740 x5, TS2345/TS2322/TS2741 x2 each -- incomplete literals. Re-measured 21 at 5ab08428, up from 20, and still 21 at e8db1a230 across 35 test files rather than 34 -- the file count moved, the error count did not.' },
-  '@objectstack/formula': { tests: 16, errors: 17, note: 'TS2591 x6 (`process`), TS2345 x3, TS2352 x3, TS1470 x2, TS2339 x2. Re-measured 17 at 5ab08428, up from 12; the TS2591 half doubled, which is the missing `types:["node"]` again rather than five new defects.' },
-  '@objectstack/trigger-record-change': { tests: 5, errors: 9, note: 'TS2353 x9 -- still the one unknown-property shape repeated, now in four files. Re-measured 9 at 5ab08428, up from 8.' },
-  '@objectstack/verify': { tests: 4, errors: 8, note: 'TS2835 x4, TS7006 x4. Re-measured 8 at 5ab08428, up from 6; both classes are the NodeNext pair from the top-of-ledger note.' },
-  '@objectstack/connector-mcp': { tests: 3, errors: 5, note: 'TS2339 x5. Re-measured 5 at 5ab08428, exact.' },
-  '@objectstack/connector-openapi': { tests: 3, errors: 5, note: 'TS2339 x5. Re-measured 5 at 5ab08428, exact.' },
+  '@objectstack/plugin-security': { errors: 21, note: 'TS2739 x8, TS2740 x5, TS2345/TS2322/TS2741 x2 each -- incomplete literals. Re-measured 21 at 5ab08428, up from 20, and still 21 at e8db1a230 after the package gained a test file -- the file count moved, the error count did not (which is why the file count is derived here rather than written down, #5826).' },
+  '@objectstack/formula': { errors: 17, note: 'TS2591 x6 (`process`), TS2345 x3, TS2352 x3, TS1470 x2, TS2339 x2. Re-measured 17 at 5ab08428, up from 12; the TS2591 half doubled, which is the missing `types:["node"]` again rather than five new defects.' },
+  '@objectstack/trigger-record-change': { errors: 9, note: 'TS2353 x9 -- still the one unknown-property shape repeated, now in four files. Re-measured 9 at 5ab08428, up from 8.' },
+  '@objectstack/verify': { errors: 8, note: 'TS2835 x4, TS7006 x4. Re-measured 8 at 5ab08428, up from 6; both classes are the NodeNext pair from the top-of-ledger note.' },
+  '@objectstack/connector-mcp': { errors: 5, note: 'TS2339 x5. Re-measured 5 at 5ab08428, exact.' },
+  '@objectstack/connector-openapi': { errors: 5, note: 'TS2339 x5. Re-measured 5 at 5ab08428, exact.' },
   '@objectstack/http-conformance': {
-    tests: 2,
     errors: 4,
     note: 'TS2307 x2, TS2304 x1, TS2740 x1. Re-measured 4 at 5ab08428, up from 1. Worth knowing before '
       + 'anyone tries to graduate it: 2 of the 4 are reported inside node_modules `.d.ts` files '
@@ -546,10 +551,10 @@ const TEST_DEBT = {
       + 'this package\'s own code. Raw `tsc --noEmit` counts are what every number in these ledgers means, '
       + 'so they are counted here rather than filtered out -- but they are not this package\'s debt to fix.',
   },
-  '@objectstack/platform-objects': { tests: 9, errors: 3, note: 'TS2339 x2, TS7006 x1. Re-measured 3 at 5ab08428, exact.' },
-  '@objectstack/plugin-sharing': { tests: 13, errors: 3, note: 'TS6133 x2, TS18048 x1. Re-measured 3 at 5ab08428, exact.' },
-  '@objectstack/service-sms': { tests: 5, errors: 1, note: 'TS2493 x1, in transports.test.ts. Re-measured 1 at 5ab08428 and still 1 at e8db1a230, across 5 test files rather than 3: #5773 added sms-manifest-providers.contract.test.ts and #2814 / PR #6042 added sms-daily-quota.test.ts. The file count moved twice while the error count did not -- both new files are type-clean with the exclusion lifted.' },
-  '@objectstack/connector-rest': { tests: 3, errors: 1, note: 'TS6133 x1. Re-measured 1 at 5ab08428, exact.' },
+  '@objectstack/platform-objects': { errors: 3, note: 'TS2339 x2, TS7006 x1. Re-measured 3 at 5ab08428, exact.' },
+  '@objectstack/plugin-sharing': { errors: 3, note: 'TS6133 x2, TS18048 x1. Re-measured 3 at 5ab08428, exact.' },
+  '@objectstack/service-sms': { errors: 1, note: 'TS2493 x1, in transports.test.ts. Re-measured 1 at 5ab08428 and still 1 at e8db1a230, after two more hidden test files: #5773 added sms-manifest-providers.contract.test.ts and #2814 / PR #6042 added sms-daily-quota.test.ts. The file count moved twice while the error count did not -- both new files are type-clean with the exclusion lifted.' },
+  '@objectstack/connector-rest': { errors: 1, note: 'TS6133 x1. Re-measured 1 at 5ab08428, exact.' },
 };
 
 // Repo-relative path -> why this test file's `@ts-expect-error` directives are
@@ -778,7 +783,7 @@ function workspacePackages() {
  * @param {{name: string, scripts: Record<string,string>}} root
  * @param {{ debt: Record<string, {errors: number, note?: string}>,
  *           exempt: Record<string, string>,
- *           testDebt: Record<string, {tests: number, errors: number, note?: string}>,
+ *           testDebt: Record<string, {errors: number, note?: string}>,
  *           phantomPins: Record<string, string>,
  *           turboHasTask: boolean, ciInvokesTask: boolean, ciInvokesRoot: boolean }} state
  * @returns {string[]} problems, empty when the ratchet holds
@@ -937,9 +942,27 @@ function evaluate(packages, root, state) {
       problems.push(`EXEMPT entry for "${name}" names no workspace package -- remove it from ${SELF}.`);
     }
   }
-  for (const name of Object.keys(state.testDebt)) {
+  for (const [name, entry] of Object.entries(state.testDebt)) {
     if (!byName.has(name)) {
       problems.push(`TEST_DEBT entry for "${name}" names no workspace package -- remove it from ${SELF}.`);
+      continue;
+    }
+    // The ledger is closed to a hand-written file count (#5826). `errors` has to
+    // be recorded because knowing it means running the compiler; the number of
+    // hidden test files does NOT -- `testCoverage()` counts it on every run, in
+    // under a second, and TESTS_COVERED already judges by that live count. A
+    // copy beside it is a second source of truth for a fact the gate holds, and
+    // it drifted exactly as #5278's `errors` did: 12 of 19 entries were stale
+    // when this was measured, all understated, the worst by 53% (runtime 66 vs
+    // 101 real files). Deriving it removes the drift by construction; this
+    // branch is what stops the copy from being pasted back in.
+    if (entry && typeof entry === 'object' && Object.hasOwn(entry, 'tests')) {
+      problems.push(
+        `${name}: TEST_DEBT entry carries a hand-written \`tests\` count -- that number is DERIVED from ` +
+          `this run's own scan (\`testCoverage()\` already counts the hidden files to decide TESTS_COVERED), ` +
+          `so a copy here is a second source of truth that drifts silently and nothing compares. ` +
+          `Delete the field; the summary reports the live count (#5826).`,
+      );
     }
   }
   // RECONCILED for PINS_CHECKED: an entry survives only while the file really
@@ -977,6 +1000,32 @@ function evaluate(packages, root, state) {
   }
 
   return problems;
+}
+
+/**
+ * How many test files the TEST_DEBT packages are hiding RIGHT NOW -- summed from
+ * what this run's own scan counted, never from a number written down beside the
+ * entry (#5826).
+ *
+ * This is the one summary figure the gate can know for free: `testCoverage()`
+ * walks each package's include roots on every run to decide TESTS_COVERED, so
+ * `pkg.testFiles` is already in hand before the summary is printed. A recorded
+ * copy could only ever agree with it by coincidence -- adding a test file to an
+ * excluded package moves the real count and nothing asks the ledger to follow.
+ *
+ * Sums over PACKAGES rather than over ledger entries, so an entry naming no live
+ * package contributes nothing instead of throwing; RECONCILED has already made
+ * that state a failure, and the summary only prints after the verdict is clean.
+ *
+ * @param {Array<{name: string, testFiles?: number}>} packages
+ * @param {Record<string, unknown>} testDebt
+ * @returns {number}
+ */
+function hiddenTestFiles(packages, testDebt) {
+  return packages.reduce(
+    (sum, pkg) => (Object.hasOwn(testDebt, pkg.name) ? sum + (pkg.testFiles ?? 0) : sum),
+    0,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -1206,8 +1255,21 @@ function selfTest() {
         pkg('b', { scripts: { typecheck: 'tsc --noEmit' }, excludesTests: true, testFiles: 4 }),
       ],
       root: okRoot,
-      state: { ...okState, testDebt: { a: { tests: 3, errors: 9 }, b: { tests: 4, errors: 0 } } },
+      state: { ...okState, testDebt: { a: { errors: 9 }, b: { errors: 0 } } },
       expect: [/b: TEST_DEBT entry has no measured error count/],
+    },
+    {
+      // #5826. The rejection is STRUCTURAL, not a reconciliation: this fixture's
+      // copy agrees exactly with the live count (7 and 7) and is still refused,
+      // because agreement is a property of the moment a number was written, not
+      // of the field. Comparing the two instead would bill the next author for
+      // adding a clean test file -- a bookkeeping toll on the one action this
+      // ledger exists to encourage, which is what #5278 ruled out for `errors`.
+      label: 'a TEST_DEBT entry that writes the derived file count down fails, even when it is right today',
+      packages: [pkg('a', { scripts: { typecheck: 'tsc --noEmit' }, excludesTests: true, testFiles: 7 })],
+      root: okRoot,
+      state: { ...okState, testDebt: { a: { tests: 7, errors: 9 } } },
+      expect: [/a: TEST_DEBT entry carries a hand-written `tests` count/],
     },
     {
       label: 'a pin in a file no tsc program compiles fails PINS_CHECKED',
@@ -1256,14 +1318,14 @@ function selfTest() {
       label: 'dropping the exclusion without deleting TEST_DEBT fails RECONCILED',
       packages: [pkg('a', { scripts: { typecheck: 'tsc --noEmit' }, excludesTests: false, testFiles: 5 })],
       root: okRoot,
-      state: { ...okState, testDebt: { a: { tests: 5, errors: 7 } } },
+      state: { ...okState, testDebt: { a: { errors: 7 } } },
       expect: [/a: has a TEST_DEBT entry but no longer excludes its tests/],
     },
     {
       label: 'TEST_DEBT for a vanished package fails RECONCILED',
       packages: [pkg('a', { scripts: { typecheck: 'tsc --noEmit' } })],
       root: okRoot,
-      state: { ...okState, testDebt: { gone: { tests: 1, errors: 1 } } },
+      state: { ...okState, testDebt: { gone: { errors: 1 } } },
       expect: [/TEST_DEBT entry for "gone" names no workspace package/],
     },
     {
@@ -1405,6 +1467,47 @@ function selfTest() {
     if (got !== c.expect) failures.push(`configCovers — ${c.label}: expected ${c.expect}, got ${got}`);
   }
 
+  // The summary's hidden-file figure (#5826). It used to be the sum of a
+  // hand-written `tests` field, which nothing reconciled -- so the third case
+  // below is the whole issue in one line: the same ledger, one more test file,
+  // a total that follows without anybody editing anything.
+  const derivedCases = [
+    {
+      label: 'the total is the live count of the ledgered packages',
+      packages: [pkg('a', { testFiles: 3 }), pkg('b', { testFiles: 4 })],
+      testDebt: { a: { errors: 9 }, b: { errors: 2 } },
+      expect: 7,
+    },
+    {
+      label: 'a package outside the ledger contributes nothing, however many tests it has',
+      packages: [pkg('a', { testFiles: 3 }), pkg('covered', { testFiles: 99 })],
+      testDebt: { a: { errors: 9 } },
+      expect: 3,
+    },
+    {
+      label: 'one more test file moves the total with no ledger edit — the drift, removed by construction',
+      packages: [pkg('a', { testFiles: 4 }), pkg('b', { testFiles: 4 })],
+      testDebt: { a: { errors: 9 }, b: { errors: 2 } },
+      expect: 8,
+    },
+    {
+      label: 'an entry naming no live package contributes nothing rather than throwing',
+      packages: [pkg('a', { testFiles: 3 })],
+      testDebt: { a: { errors: 9 }, gone: { errors: 1 } },
+      expect: 3,
+    },
+    {
+      label: 'a package the scan never counted reads as zero, not as NaN',
+      packages: [pkg('a', {})],
+      testDebt: { a: { errors: 9 } },
+      expect: 0,
+    },
+  ];
+  for (const c of derivedCases) {
+    const got = hiddenTestFiles(c.packages, c.testDebt);
+    if (got !== c.expect) failures.push(`hiddenTestFiles — ${c.label}: expected ${c.expect}, got ${got}`);
+  }
+
   // MEASURED (#5278). The whole point of this invariant is a DIRECTION, so both
   // directions are pinned: up is red, down is a note, equal is silence. A
   // symmetric implementation would pass a "does it notice a change" test and
@@ -1506,7 +1609,7 @@ function selfTest() {
   }
   console.log(
     `✓ check:type-check-coverage --self-test — ${cases.length} semantic case(s) + ` +
-      `${namedCases.length + coverCases.length} observation case(s) + ` +
+      `${namedCases.length + coverCases.length + derivedCases.length} observation case(s) + ` +
       `${driftCases.length + countCases.length} re-measure case(s) hold.`,
   );
 }
@@ -1529,7 +1632,9 @@ if (problems.length) {
 const covered = packages.filter((p) => p.scripts.typecheck !== undefined).length;
 const debtTotal = Object.values(DEBT).reduce((sum, e) => sum + (e.errors ?? 0), 0);
 const testDebtErrors = Object.values(TEST_DEBT).reduce((sum, e) => sum + (e.errors ?? 0), 0);
-const testDebtFiles = Object.values(TEST_DEBT).reduce((sum, e) => sum + (e.tests ?? 0), 0);
+// Counted on this run, not read from the ledger: the file count is the one
+// number here the gate already knows (#5826).
+const testDebtFiles = hiddenTestFiles(packages, TEST_DEBT);
 // Both numbers, always. Reporting only the src figure is how the first pass of
 // this gate read as 48/77 green while 568 test files went unchecked.
 console.log(
@@ -1537,7 +1642,7 @@ console.log(
     `(plus the root), ${Object.keys(DEBT).length} in the DEBT ledger (${debtTotal} frozen raw errors, ` +
     `${TRACKING_ISSUE}), ${Object.keys(EXEMPT).length} exempt.\n` +
     `  test layer: ${Object.keys(TEST_DEBT).length} package(s) still exclude their own tests ` +
-    `(${testDebtFiles} files, ${testDebtErrors} frozen raw errors in TEST_DEBT).`,
+    `(${testDebtFiles} files hidden as counted by this run, ${testDebtErrors} frozen raw errors in TEST_DEBT).`,
 );
 
 // MEASURED runs only when asked, and only after the structural verdict above is


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5826

## 做了什么

TEST_DEBT 每条条目有**两个**手写数字。#5278 / PR #5827 给 `errors` 装上了真棘轮（每次 `--re-measure` 重跑 `tsc --noEmit`，实测 > 记录即红），`tests` 没有——而 `tests`（被 tsconfig 排除、因而对 tsc 隐形的测试文件数）恰恰是这个脚本**每次运行都已经算出来的量**：`testCoverage()` 返回的 `pkg.testFiles`，亚秒级、不需要编译器，`evaluate()` 里就在用它判 TESTS_COVERED。

两个数字需要**相反**的修法，这也是它们是两单的原因：`errors` 不跑编译器就不可知，所以「冻结 + 重测」是它唯一可用的形状；文件数是**免费**的，所以正确的修法是删掉副本、直接读活数（issue 的选项 1，也是本文件自己在 #5286 毕业 `packages/spec` 时就写下过的结论）。

- **19 条 TEST_DEBT 条目的 `tests` 字段全部删除。** `errors` 值与 note 一律未动，包括 #5827 新增的五条 Option A 记档余量（objectql 355 / rest 163 / lint 42 / service-storage 52 / mcp 63）及其 note。
- **摘要行改为实时导出**：新增纯函数 `hiddenTestFiles(packages, TEST_DEBT)`，按包求和本次扫描得到的 `pkg.testFiles`。输出从「N files」变为「N files hidden as counted by this run」。
- **RECONCILED 增一条**：TEST_DEBT 条目再带 `tests` 字段即红。这是**结构性拒绝**，哪怕今天的数值恰好正确——见下。
- **note 散文同样去重**：四条 note 复述了闸门现在实时导出的文件总数（plugin-security「across 35 test files rather than 34」、service-sms「across 5 test files rather than 3」、mcp「file count moved 8 -&gt; 9」、objectql「file count went 87 -&gt; 127」）。这是同一个「两个事实源」缺陷下沉一层，改成保留**事件**（哪个 PR 加了哪个文件、文件数动了而错误数没动）、不再留数字副本。
- **台账顶部注释重写**：说明为什么 `errors` 记、文件数不记，以及这两者需要相反的修法。

## 为什么不是「加一条对账」

新增的检查在数值**一致**时也拒绝（self-test 里那条 fixture 写的就是 `tests: 7` 对 `testFiles: 7`）。理由是：一致只是「写下那一刻」的属性，不是这个字段的属性；改成「不一致才红」会把「新增一个干净的测试文件」变成一次记账费，而 #5278 的裁决明确排除了这个方向（改善不得制造记账 churn）。删字段 + 结构性拒绝，是唯一按构造消除漂移、且代码比现状更少的选项。

## 漂移实测（issue 正文的表已过期，这里是本分支上重量的）

#5827 昨夜（约 03:5xZ）刚把 12 个漂移的 `tests` 刷成实测值。今天在 `origin/main @ 80f7dc6a3` 上重量，**19 条里已有 3 条重新漂移**：

| 包 | #5827 记录 | 本次实算 | 差 |
|:---|---:|---:|---:|
| `@objectstack/objectql` | 130 | 135 | +5 |
| `@objectstack/runtime` | 102 | 105 | +3 |
| `@objectstack/formula` | 16 | 17 | +1 |
| 合计（19 条） | **534** | **543** | **+9** |

（三个数字都用 `find packages/formula/src packages/runtime/src packages/objectql/src -name '*.test.ts' -o -name '*.spec.ts' | wc -l`（逐包）独立复核过：17 / 105 / 135，与闸门实算一致。objectql 的 +5 来自 #6158 / #6165 / #6171 等本窗口新增的测试文件。）

也就是说：一次「刷新副本」的有效期，就是到下一个测试文件落地为止——这正是本单的论点，与今天差值是不是 0 无关。

## 反向验证（方向为**先声明后运行**：应当变红）

把删掉的字段原样放回一条条目（objectql `tests: 130`），闸门必须红；这是新检查不是幽灵检查的证明。

```
$ node scripts/check-type-check-coverage.mjs        # 放回 tests: 130 之后
check-type-check-coverage: 1 problem(s)

  • @objectstack/objectql: TEST_DEBT entry carries a hand-written `tests` count -- that number is
    DERIVED from this run's own scan ... Delete the field; the summary reports the live count (#5826).
exit=1
```

移除后立刻恢复绿。摘要总数在两种状态下都是 543——即恢复的副本不再参与任何计算，这是「删掉副本」而非「换个地方读副本」的证据。

## 验证

```
$ node scripts/check-type-check-coverage.mjs --self-test
✓ check:type-check-coverage --self-test — 23 semantic case(s) + 16 observation case(s) + 11 re-measure case(s) hold.

$ node scripts/check-type-check-coverage.mjs
check-type-check-coverage: OK — 62/77 workspace packages type-checked (plus the root), 15 in the DEBT
ledger (457 frozen raw errors, ...), 1 exempt.
  test layer: 19 package(s) still exclude their own tests (543 files hidden as counted by this run,
  1648 frozen raw errors in TEST_DEBT).

$ flock /tmp/os-heavy-verify.lock -c 'pnpm exec turbo run build --filter=./packages/* --filter=./packages/*/*'
 Tasks:    70 successful, 70 total

$ flock /tmp/os-heavy-verify.lock -c 'pnpm check:type-check-debt'     # 完整 --re-measure
  ℹ @objectstack/service-storage: DEBT records 52, tsc now reports 42 (-10) -- the entry can be lowered.
  ℹ @objectstack/objectql: TEST_DEBT records 355, tsc now reports 344 (-11) -- ...
  ℹ @objectstack/rest: TEST_DEBT records 163, tsc now reports 153 (-10) -- ...
  ℹ @objectstack/mcp: TEST_DEBT records 63, tsc now reports 53 (-10) -- ...
  ℹ @objectstack/lint: TEST_DEBT records 42, tsc now reports 32 (-10) -- ...
check-type-check-coverage --re-measure: OK — 34 ledger entr(ies) re-measured in 223.3s, 2054 raw tsc
error(s) total, none above its recorded number.

$ pnpm exec eslint scripts/check-type-check-coverage.mjs        # 无输出
$ node scripts/check-nul-bytes.mjs
check-nul-bytes: OK (scanned 5920 tracked text file(s); ... no raw ASCII control bytes).
```

五条 `ℹ ... can be lowered` 是 #5827 记档余量的既有输出（本 PR 未动那些 `errors` 与 note），不是本 PR 引入的。

## 新增/更新的 self-test 用例

语义层 1 条：

- `a TEST_DEBT entry that writes the derived file count down fails, even when it is right today` —— 副本与实算相等（7 对 7）仍拒绝，钉死「结构性拒绝，不是对账」。

observation 层 5 条（`hiddenTestFiles`）：总数取自活扫描；台账外的包不计入；**同一份台账、多一个测试文件、总数自动跟随**（本单要消除的漂移，钉成正向断言）；条目指向不存在的包时计 0 而不抛；未扫描到的包读作 0 而不是 NaN。

另有 3 条既有 fixture 去掉了 `tests` 键。

## 发布面

`scripts/` 只在仓库根，根 package 是 `private: true`，不在任何包的 `files` 白名单里——本 PR 不发布任何东西，故走 `skip-changeset` 标签而非 changeset（#6059 已禁止空 frontmatter changeset，所以只能二选一）。

## 范围

只改 `scripts/check-type-check-coverage.mjs`。未碰任何包的源码 / tsconfig / typecheck 脚本（不做毕业），未碰 `packages/spec/scripts/**`，未碰 `content/docs/releases/`，未改动任何 `errors` 数值或其 note。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wsZeReNTqiceBfLb5Pyf5

---
_Generated by [Claude Code](https://claude.ai/code/session_014wsZeReNTqiceBfLb5Pyf5)_