### PR TITLE
feat(plugin-auth): 定窗计数件独立成 `./rate-limit-storage` 子路径入口 (#6040)

### DIFF
--- a/.changeset/rate-limit-storage-subpath-export.md
+++ b/.changeset/rate-limit-storage-subpath-export.md
@@ -1,0 +1,54 @@
+---
+"@objectstack/plugin-auth": minor
+"@objectstack/runtime": patch
+"@objectstack/service-sms": patch
+---
+
+feat(plugin-auth): the fixed-window counter gets its own `./rate-limit-storage` entry (#6040)
+
+`rate-limit-storage.ts` is the repo's ONE fixed-window counter —
+`incrementFixedWindow` / `createLazyCounterStore` / `InProcessCounterStore`,
+ADR-0069 D2 — and #4790's cross-reference asks later arrivals to reuse it
+rather than write a third copy. They did, and from outside auth:
+`@objectstack/runtime` counts inbound requests and endpoint policy through it,
+and `@objectstack/service-sms` counts its daily SMS budget through it (#2814).
+
+`@objectstack/plugin-auth` published exactly one entry, `"."`, whose `export *`
+chain takes **value** imports on `better-auth/adapters`
+(`objectql-adapter.ts`) and `@better-auth/core/db` (`backfill-account-issuer.ts`).
+Value imports are evaluated eagerly, so reaching those ~90 lines of counting
+loaded `better-auth` + `@better-auth/{core,oauth-provider,scim,sso}` + `jose` +
+`@noble/hashes` + `@objectstack/rest` + `@objectstack/platform-objects` first.
+Measured against the built package: `require('@objectstack/plugin-auth')` puts
+109 modules in `require.cache`; the counter needs one.
+
+So the counter is now published on its own:
+
+```ts
+// before — 109 modules, the whole better-auth family
+import { incrementFixedWindow } from '@objectstack/plugin-auth';
+// after — 1 module, 3.7 KB
+import { incrementFixedWindow } from '@objectstack/plugin-auth/rate-limit-storage';
+```
+
+`tsup` emits the second entry with `splitting: false`, so it is a self-contained
+bundle rather than a nominal split: `dist/rate-limit-storage.mjs` is 3.71 KB
+against `dist/index.mjs`'s 330.28 KB, contains zero top-level imports and zero
+occurrences of the string `better-auth`. The one better-auth reference that
+survives is `import type { BetterAuthRateLimitStorage }`, which is erased at
+build and costs a consumer nothing at runtime.
+
+**Nothing is removed.** The root still re-exports every one of these symbols, so
+existing `@objectstack/plugin-auth` imports keep working unchanged — this is a
+new entry point, which is why it is `minor` rather than breaking. The `patch` on
+`runtime` and `service-sms` is the import-specifier switch in those packages;
+their behaviour is identical.
+
+`src/rate-limit-storage-isolation.test.ts` pins the invariant from both sides,
+in the shape `packages/types/src/node-isolation.test.ts` (#4700) established for
+the `./node` split: it walks the real import graph from the subpath entry and
+fails on any better-auth **value** import or any undeclared external package,
+it fails if a consumer reaches the counter through the package root again, and
+it fails if the root ever *stops* pulling better-auth eagerly — because at that
+point the split stopped buying anything and deserves re-measuring rather than a
+suite that passes for the wrong reason.

--- a/packages/plugins/plugin-auth/package.json
+++ b/packages/plugins/plugin-auth/package.json
@@ -8,13 +8,18 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
+    },
+    "./rate-limit-storage": {
+      "types": "./dist/rate-limit-storage.d.ts",
+      "import": "./dist/rate-limit-storage.mjs",
+      "require": "./dist/rate-limit-storage.js"
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/plugins/plugin-auth/src/rate-limit-storage-isolation.test.ts
+++ b/packages/plugins/plugin-auth/src/rate-limit-storage-isolation.test.ts
@@ -1,0 +1,306 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #6040 — the `./rate-limit-storage` subpath entry must stay free of the
+ * better-auth family at RUNTIME.
+ *
+ * `rate-limit-storage.ts` is the repo's one fixed-window counter (ADR-0069 D2,
+ * #4790). Three packages outside auth count through it — `@objectstack/runtime`
+ * (`security/inbound-rate-limit.ts`, `endpoint-policy.ts`,
+ * `dispatcher-plugin.ts`) and `@objectstack/service-sms` (`sms-plugin.ts`,
+ * `sms-daily-quota.ts`) — and until #6040 they could only reach it through the
+ * package root, whose `export *` chain takes **value** imports on
+ * `better-auth/adapters` and `@better-auth/core/db`. Importing 90 lines of
+ * counting therefore eagerly evaluated `better-auth` +
+ * `@better-auth/{core,oauth-provider,scim,sso}` + `jose` + `@noble/hashes` +
+ * `@objectstack/rest` + `@objectstack/platform-objects`.
+ *
+ * That is now a packaging invariant, and an invariant nobody checks is a
+ * comment. The regression it guards is silent: someone adds one convenient
+ * import to this module — `@objectstack/rest` for an error type, a better-auth
+ * helper, anything — every existing test still passes, the counter still
+ * counts, and the whole family quietly comes back into `service-sms`'s load
+ * graph. Nothing in the build, the type-check or the unit suites can see it.
+ *
+ * So this walks the real import graph from `src/rate-limit-storage.ts` and
+ * pins the external surface it is allowed to reach.
+ *
+ * Deliberately a SOURCE-level scan rather than a probe of `dist/`. A gate that
+ * reads build output passes or fails by local build state, which is exactly the
+ * boundary `scripts/check-published-files.mjs` states for itself ("it does not
+ * exist in a fresh checkout … a gate that passes or fails by accident is worse
+ * than one with a stated boundary"). The dist-level reading is real but
+ * one-shot, and it is recorded in the PR: after `pnpm --filter
+ * @objectstack/plugin-auth build`, `dist/rate-limit-storage.mjs` is 3.71 KB
+ * against `dist/index.mjs`'s 330.28 KB, and a `node -e "import(…)"` subprocess
+ * loads zero better-auth modules.
+ *
+ * Same shape as `packages/types/src/node-isolation.test.ts` (#4700), which pins
+ * the identical class of invariant for the `./node` subpath.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+
+/**
+ * This package is CJS-typed (no `"type": "module"` — it publishes
+ * `dist/index.js` as CommonJS), so `module: NodeNext` forbids `import.meta`
+ * here. Walk up from the CWD instead, which works wherever vitest is invoked
+ * from.
+ */
+function findUp(predicate: (dir: string) => boolean, what: string): string {
+  let dir = process.cwd();
+  for (;;) {
+    if (predicate(dir)) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) throw new Error(`could not locate ${what}`);
+    dir = parent;
+  }
+}
+
+const PKG = findUp((dir) => {
+  const manifest = join(dir, 'package.json');
+  if (!existsSync(manifest)) return false;
+  const { name } = JSON.parse(readFileSync(manifest, 'utf8')) as { name?: string };
+  return name === '@objectstack/plugin-auth';
+}, 'the @objectstack/plugin-auth package root');
+
+const REPO = findUp(
+  (dir) => existsSync(join(dir, 'pnpm-workspace.yaml')),
+  'the workspace root (pnpm-workspace.yaml)',
+);
+
+const SRC = join(PKG, 'src');
+
+/**
+ * Strip comments before scanning. The distinction this file turns on — a
+ * `import type` versus a value `import` of the same specifier — is invisible to
+ * a raw-text regex the moment a doc comment quotes an import line, and this
+ * module's own header quotes several. Handles `//`, block comments and the
+ * three string forms so a `'http://…'` literal is not mistaken for a comment.
+ */
+function stripComments(src: string): string {
+  let out = '';
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i]!;
+    const next = src[i + 1];
+    if (c === '/' && next === '/') {
+      while (i < src.length && src[i] !== '\n') i++;
+      continue;
+    }
+    if (c === '/' && next === '*') {
+      i += 2;
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) i++;
+      i += 2;
+      continue;
+    }
+    if (c === "'" || c === '"' || c === '`') {
+      out += c;
+      i++;
+      while (i < src.length && src[i] !== c) {
+        if (src[i] === '\\') {
+          out += src[i]! + (src[i + 1] ?? '');
+          i += 2;
+          continue;
+        }
+        out += src[i];
+        i++;
+      }
+      out += c;
+      i++;
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+interface Ref {
+  spec: string;
+  /** `import type … from` / `export type … from` — erased at build, costs nothing at runtime. */
+  typeOnly: boolean;
+}
+
+/** `import|export … from 'x'`, bare `import 'x'`, and `await import('x')`. */
+const FROM = /(?:^|[\n;}])\s*(?:import|export)\b([^'"]*?)\bfrom\s*['"]([^'"]+)['"]/g;
+const SIDE_EFFECT = /(?:^|[\n;}])\s*import\s*['"]([^'"]+)['"]/g;
+const DYNAMIC = /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+function refsOf(file: string): Ref[] {
+  const src = stripComments(readFileSync(file, 'utf8'));
+  const out: Ref[] = [];
+  for (const m of src.matchAll(FROM)) {
+    out.push({ spec: m[2]!, typeOnly: /^\s*type\b/.test(m[1]!) });
+  }
+  // A side-effect import and a dynamic import are always value loads.
+  for (const m of src.matchAll(SIDE_EFFECT)) out.push({ spec: m[1]!, typeOnly: false });
+  for (const m of src.matchAll(DYNAMIC)) out.push({ spec: m[1]!, typeOnly: false });
+  return out;
+}
+
+/** Resolve a relative TS import (`./x.js` → `src/x.ts`). */
+function resolveRelative(fromFile: string, spec: string): string | undefined {
+  const base = join(dirname(fromFile), spec);
+  for (const cand of [base.replace(/\.js$/, '.ts'), `${base}.ts`, join(base, 'index.ts')]) {
+    if (existsSync(cand)) return cand;
+  }
+  return undefined;
+}
+
+/**
+ * Every source file reachable from an entry, following relative imports —
+ * type-only relative hops included, because a `.ts` file reached only by a type
+ * import can still carry value imports of its own.
+ */
+function reachableFrom(entry: string): Map<string, Ref[]> {
+  const seen = new Map<string, Ref[]>();
+  const queue = [entry];
+  while (queue.length > 0) {
+    const file = queue.shift()!;
+    if (seen.has(file)) continue;
+    const refs = refsOf(file);
+    seen.set(file, refs);
+    for (const ref of refs) {
+      if (!ref.spec.startsWith('.')) continue;
+      const next = resolveRelative(file, ref.spec);
+      if (next) queue.push(next);
+    }
+  }
+  return seen;
+}
+
+const isBetterAuth = (spec: string): boolean =>
+  spec === 'better-auth' ||
+  spec.startsWith('better-auth/') ||
+  spec === '@better-auth/core' ||
+  spec.startsWith('@better-auth/');
+
+/**
+ * The complete set of packages `./rate-limit-storage` may reach, and how.
+ *
+ * An allowlist rather than a better-auth denylist on purpose: the expensive
+ * import is not necessarily spelled `better-auth`. `@objectstack/rest` and
+ * `@objectstack/platform-objects` both drag the family in transitively, and a
+ * denylist would wave either through. Anything new here is a deliberate
+ * decision that has to be written down — including its runtime cost.
+ */
+const ALLOWED_EXTERNAL: ReadonlyArray<{ spec: string; typeOnly: boolean }> = [
+  // Type-only: `BetterAuthRateLimitStorage` is the shape
+  // `createLazyCacheRateLimitStorage` returns for better-auth's
+  // `rateLimit.customStorage`. `import type` is erased at build, so it costs a
+  // consumer nothing at runtime — which is the whole reason this entry can be
+  // split out while still typing better-auth's seam.
+  { spec: '@better-auth/core', typeOnly: true },
+];
+
+describe('@objectstack/plugin-auth — ./rate-limit-storage stays free of better-auth (#6040)', () => {
+  it('nothing reachable from the subpath entry VALUE-imports better-auth', () => {
+    const graph = reachableFrom(join(SRC, 'rate-limit-storage.ts'));
+    const offenders: string[] = [];
+    for (const [file, refs] of graph) {
+      for (const ref of refs) {
+        if (isBetterAuth(ref.spec) && !ref.typeOnly) {
+          offenders.push(`${relative(PKG, file)} -> ${ref.spec}`);
+        }
+      }
+    }
+    expect(
+      offenders,
+      'The ./rate-limit-storage entry exists so @objectstack/runtime and ' +
+        '@objectstack/service-sms can use the ~90-line fixed-window counter without ' +
+        'eagerly loading better-auth + @better-auth/* + jose + @noble/hashes. A value ' +
+        'import (anything but `import type`) re-couples them. Keep better-auth types ' +
+        'type-only, and put anything that needs the runtime in a root-only module.',
+    ).toEqual([]);
+  });
+
+  it('the subpath entry reaches exactly the external packages it declares', () => {
+    const graph = reachableFrom(join(SRC, 'rate-limit-storage.ts'));
+    const actual = new Map<string, boolean>();
+    for (const refs of graph.values()) {
+      for (const ref of refs) {
+        if (ref.spec.startsWith('.') || ref.spec.startsWith('node:')) continue;
+        // A specifier imported both ways is a value import.
+        actual.set(ref.spec, (actual.get(ref.spec) ?? true) && ref.typeOnly);
+      }
+    }
+    const sort = (a: { spec: string }, b: { spec: string }): number => a.spec.localeCompare(b.spec);
+    expect(
+      [...actual].map(([spec, typeOnly]) => ({ spec, typeOnly })).sort(sort),
+      'A new external import on this entry is a new runtime dependency for every ' +
+        'consumer of the subpath — including the transitive better-auth pull that ' +
+        '@objectstack/rest and @objectstack/platform-objects carry. Add it to ' +
+        'ALLOWED_EXTERNAL only with its cost written down.',
+    ).toEqual([...ALLOWED_EXTERNAL].sort(sort));
+  });
+
+  it('the ROOT entry really does value-import better-auth — otherwise this suite proves nothing', () => {
+    // Guards against the vacuous pass: if the root ever stopped pulling
+    // better-auth eagerly, the two cases above would go green for the wrong
+    // reason and the subpath split would look justified when it no longer was.
+    const graph = reachableFrom(join(SRC, 'index.ts'));
+    const rootValueImports = new Set<string>();
+    for (const refs of graph.values()) {
+      for (const ref of refs) if (isBetterAuth(ref.spec) && !ref.typeOnly) rootValueImports.add(ref.spec);
+    }
+    expect(
+      [...rootValueImports].sort(),
+      'The root no longer eagerly loads better-auth. That is good news, but it means ' +
+        'the ./rate-limit-storage split may have stopped buying anything — re-measure ' +
+        'before trusting the cases above.',
+    ).toContain('better-auth/adapters');
+  });
+
+  it('package.json publishes the ./rate-limit-storage subpath', () => {
+    const pkg = JSON.parse(readFileSync(join(PKG, 'package.json'), 'utf8')) as {
+      exports: Record<string, Record<string, string>>;
+      files?: string[];
+    };
+    expect(Object.keys(pkg.exports)).toContain('./rate-limit-storage');
+    expect(pkg.exports['./rate-limit-storage']).toEqual({
+      // `types` first: conditions are first-match-wins, so a `types` key behind
+      // `import`/`require` is only ever read by accident. 84 of the 85 exports
+      // conditions on main are written this way.
+      types: './dist/rate-limit-storage.d.ts',
+      import: './dist/rate-limit-storage.mjs',
+      require: './dist/rate-limit-storage.js',
+    });
+    // `check:published-files` SUFFICIENT covers this too; pinned here so the
+    // entry cannot be declared and then left out of the published whitelist.
+    expect(pkg.files).toContain('dist');
+  });
+
+  it('no cross-package consumer reaches the counter through the package ROOT', () => {
+    // The other half of the invariant. Switching an import back to
+    // `@objectstack/plugin-auth` costs nothing visible — it type-checks, it
+    // tests green, it just silently reinstates the whole better-auth load for
+    // that package. Scanned by directory rather than by filename so moving a
+    // consumer file does not quietly retire the check.
+    const COUNTER_SYMBOLS = /\b(incrementFixedWindow|createLazyCounterStore|InProcessCounterStore|CounterStore|FixedWindowCount|LazyCounterStoreOptions)\b/;
+    const roots = ['packages/runtime/src', 'packages/services/service-sms/src'];
+    const offenders: string[] = [];
+    for (const root of roots) {
+      const abs = join(REPO, root);
+      expect(existsSync(abs), `${root} — consumer directory moved; re-point this check`).toBe(true);
+      for (const entry of readdirSync(abs, { recursive: true, withFileTypes: true })) {
+        if (!entry.isFile() || !entry.name.endsWith('.ts')) continue;
+        const file = join(entry.parentPath, entry.name);
+        for (const m of stripComments(readFileSync(file, 'utf8')).matchAll(FROM)) {
+          if (m[2] !== '@objectstack/plugin-auth') continue;
+          if (COUNTER_SYMBOLS.test(m[1]!)) {
+            offenders.push(`${relative(REPO, file)} -> ${m[1]!.trim()} from the package root`);
+          }
+        }
+      }
+    }
+    expect(
+      offenders,
+      'Import the counter from "@objectstack/plugin-auth/rate-limit-storage". Reaching ' +
+        'it through the package root pulls better-auth + @better-auth/* + jose + ' +
+        '@noble/hashes into this package for ~90 lines of counting (#6040).',
+    ).toEqual([]);
+  });
+});

--- a/packages/plugins/plugin-auth/tsup.config.ts
+++ b/packages/plugins/plugin-auth/tsup.config.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { defineConfig } from 'tsup';
+
+/**
+ * Two entries, deliberately (#6040).
+ *
+ * `src/index.ts` is the full plugin: `export *` over ~20 modules, several of
+ * which take a **value** import on the better-auth family
+ * (`objectql-adapter.ts` → `better-auth/adapters`, `backfill-account-issuer.ts`
+ * → `@better-auth/core/db`). Loading the root therefore eagerly evaluates
+ * `better-auth` + `@better-auth/{core,oauth-provider,scim,sso}` + `jose` +
+ * `@noble/hashes` + `@objectstack/rest` + `@objectstack/platform-objects`.
+ *
+ * `src/rate-limit-storage.ts` is the ~90-line fixed-window counter
+ * (`incrementFixedWindow` / `createLazyCounterStore` / `InProcessCounterStore`,
+ * ADR-0069 D2). It is the repo's ONE fixed-window counter and #4790 asks later
+ * arrivals to reuse it rather than write a third copy — which they did, from
+ * outside auth: `@objectstack/runtime` (`security/inbound-rate-limit.ts`,
+ * `endpoint-policy.ts`, `dispatcher-plugin.ts`) and `@objectstack/service-sms`
+ * (`sms-plugin.ts`, `sms-daily-quota.ts`). With only a `"."` export those
+ * consumers had to reach the counter through the root and took the whole
+ * better-auth family with it. The `./rate-limit-storage` subpath is the entry
+ * they import instead.
+ *
+ * `splitting: false` is what makes the isolation real rather than nominal: each
+ * entry is emitted as a self-contained bundle, so nothing the root pulls in can
+ * reach the counter entry through a shared chunk.
+ * `rate-limit-storage-isolation.test.ts` pins the source-level half of the same
+ * invariant.
+ *
+ * (Identical shape to `packages/types/tsup.config.ts` and
+ * `packages/core/tsup.config.ts`, which ship `./node` and `./logger` this way.
+ * The only reason this file exists at all — rather than the shared
+ * `../../../tsup.config.ts` — is the second entry.)
+ */
+export default defineConfig({
+  entry: ['src/index.ts', 'src/rate-limit-storage.ts'],
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  dts: !process.env.OS_SKIP_DTS,
+  format: ['esm', 'cjs'],
+  target: 'es2020',
+});

--- a/packages/runtime/src/api-endpoint-step.test.ts
+++ b/packages/runtime/src/api-endpoint-step.test.ts
@@ -20,7 +20,7 @@
 import { describe, it, expect } from 'vitest';
 import { ApiEndpointSchema, type ApiEndpoint } from '@objectstack/spec/api';
 import type { ApiEndpointMatch } from '@objectstack/spec/contracts';
-import type { CounterStore } from '@objectstack/plugin-auth';
+import type { CounterStore } from '@objectstack/plugin-auth/rate-limit-storage';
 
 import {
     APP_ENDPOINT_SEGMENT,

--- a/packages/runtime/src/dispatcher-plugin.ts
+++ b/packages/runtime/src/dispatcher-plugin.ts
@@ -4,7 +4,7 @@ import { Plugin, PluginContext, IHttpServer } from '@objectstack/core';
 import { looksLikeInternalErrorLeak, declaresServerFault, INTERNAL_ERROR_MESSAGE } from '@objectstack/types';
 import { DispatcherErrorCode } from '@objectstack/spec/api';
 import type { IAuthService, IMetadataService } from '@objectstack/spec/contracts';
-import type { CounterStore } from '@objectstack/plugin-auth';
+import type { CounterStore } from '@objectstack/plugin-auth/rate-limit-storage';
 import { HttpDispatcher, HttpDispatcherResult, type HttpProtocolContext } from './http-dispatcher.js';
 import { isServiceServeable } from './service-serveable.js';
 import { validationFailureDetails, VALIDATION_FAILED_STATUS } from './validation-failure.js';

--- a/packages/runtime/src/endpoint-policy.test.ts
+++ b/packages/runtime/src/endpoint-policy.test.ts
@@ -17,7 +17,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { ApiEndpointSchema, type ApiEndpoint } from '@objectstack/spec/api';
-import type { CounterStore } from '@objectstack/plugin-auth';
+import type { CounterStore } from '@objectstack/plugin-auth/rate-limit-storage';
 
 import {
     applyEndpointPolicies,

--- a/packages/runtime/src/endpoint-policy.ts
+++ b/packages/runtime/src/endpoint-policy.ts
@@ -64,7 +64,7 @@ import {
     ANONYMOUS_DENY_STATUS,
     shouldDenyAnonymous,
 } from '@objectstack/core';
-import { createLazyCounterStore, type CounterStore } from '@objectstack/plugin-auth';
+import { createLazyCounterStore, type CounterStore } from '@objectstack/plugin-auth/rate-limit-storage';
 import type { ApiEndpoint } from '@objectstack/spec/api';
 
 import { apiErrorResponse, type ApiErrorEnvelope } from './error-envelope.js';

--- a/packages/runtime/src/security/inbound-rate-limit.test.ts
+++ b/packages/runtime/src/security/inbound-rate-limit.test.ts
@@ -19,7 +19,7 @@ import {
     resolveRateLimitKey,
     SharedTokenBucketLimiter,
 } from './inbound-rate-limit.js';
-import type { CounterStore } from '@objectstack/plugin-auth';
+import type { CounterStore } from '@objectstack/plugin-auth/rate-limit-storage';
 
 /** An in-test counter store that also records whether it was ever consulted. */
 function memoryStore() {

--- a/packages/runtime/src/security/inbound-rate-limit.ts
+++ b/packages/runtime/src/security/inbound-rate-limit.ts
@@ -36,7 +36,7 @@
  */
 
 import type { Middleware, IHttpRequest, IHttpResponse } from '@objectstack/core';
-import { createLazyCounterStore, type CounterStore } from '@objectstack/plugin-auth';
+import { createLazyCounterStore, type CounterStore } from '@objectstack/plugin-auth/rate-limit-storage';
 
 import { buildApiError } from '../error-envelope.js';
 import {

--- a/packages/services/service-sms/src/sms-daily-quota.test.ts
+++ b/packages/services/service-sms/src/sms-daily-quota.test.ts
@@ -8,7 +8,7 @@ import {
   secondsUntilNextUtcMidnight,
   utcDayStamp,
 } from './sms-daily-quota.js';
-import type { CounterStore } from '@objectstack/plugin-auth';
+import type { CounterStore } from '@objectstack/plugin-auth/rate-limit-storage';
 
 /** A memory counter store with the same tolerance the cache adapters have. */
 function memoryStore(): CounterStore & { entries: Map<string, unknown> } {

--- a/packages/services/service-sms/src/sms-daily-quota.ts
+++ b/packages/services/service-sms/src/sms-daily-quota.ts
@@ -70,7 +70,7 @@ import {
   InProcessCounterStore,
   incrementFixedWindow,
   type CounterStore,
-} from '@objectstack/plugin-auth';
+} from '@objectstack/plugin-auth/rate-limit-storage';
 
 /**
  * The error code a quota-refused send answers with, as the `CODE: message`

--- a/packages/services/service-sms/src/sms-plugin.ts
+++ b/packages/services/service-sms/src/sms-plugin.ts
@@ -2,7 +2,7 @@
 
 import type { Plugin, PluginContext } from '@objectstack/core';
 import type { ISmsTransport } from '@objectstack/spec/contracts';
-import { createLazyCounterStore, type CounterStore } from '@objectstack/plugin-auth';
+import { createLazyCounterStore, type CounterStore } from '@objectstack/plugin-auth/rate-limit-storage';
 import { SmsService, LogSmsTransport, maskPhoneNumber, normalizeSmsRecipient } from './sms-service.js';
 import { SmsDailyQuota } from './sms-daily-quota.js';
 import { makeSmsTransport, type SmsProviderTag } from './transports/index.js';


### PR DESCRIPTION
Fixes #6040

按分诊晋级裁定，**只做方向 1**（给 plugin-auth 加 `"./rate-limit-storage"` 子路径 export）。方向 2 的中立包迁移不做 —— 其触发条件（第 4 个消费方）未满足。

## 前提实测（逐条，全部成立）

| # | 前提 | 实测结果 |
|:--|:--|:--|
| 1 | `rate-limit-storage.ts` 静态子图不含 better-auth | ✅ 全文件唯一 import 是第 3 行 `import type { BetterAuthRateLimitStorage } from '@better-auth/core'` —— `import type`，编译期擦除，运行期为零 |
| 2 | plugin-auth `exports` 只有 `"."` | ✅ `origin/main` 上确实只有一个入口 |
| 3 | 三个消费点从包根导入 | ⚠️ 成立但**计数偏低** —— 见下节 |
| 4 | 在飞分支零相交 | ✅ 遍历 897 个 remote 分支，与本单文件面零相交 |

## ⚠️ 与派发令的一处偏差：消费点是 9 个，不是 3 个

issue 正文和派发令都点名三个消费文件。实测 `grep -rn "from '@objectstack/plugin-auth'"` 全仓，**除 `qa/dogfood` 与 `packages/verify`（它们真的要 `AuthPlugin` / `reconcileMembership`）之外，其余每一个根导入都只取计数件符号**，共 9 个文件：

```
packages/runtime/src/security/inbound-rate-limit.ts      createLazyCounterStore  (值导入)
packages/runtime/src/endpoint-policy.ts                  createLazyCounterStore  (值导入)
packages/runtime/src/dispatcher-plugin.ts                CounterStore            (类型)
packages/runtime/src/security/inbound-rate-limit.test.ts CounterStore            (类型)
packages/runtime/src/endpoint-policy.test.ts             CounterStore            (类型)
packages/runtime/src/api-endpoint-step.test.ts           CounterStore            (类型)
packages/services/service-sms/src/sms-plugin.ts          createLazyCounterStore  (值导入)   ← 派发令未列
packages/services/service-sms/src/sms-daily-quota.ts     incrementFixedWindow 等 (值导入)
packages/services/service-sms/src/sms-daily-quota.test.ts CounterStore           (类型)
```

关键的一条是 `sms-plugin.ts` —— 它是 service-sms 的**插件入口**，也走根导入取 `createLazyCounterStore`。**只切 `sms-daily-quota.ts` 而留下它，本 PR 对 service-sms 的实际加载图就是空操作**：整串 better-auth 照样在插件注册时被急切求值，也就是本 issue 唯一想消掉的那笔成本。所以 9 个全切。类型导入本来就会被擦除、不花运行期成本，一并切是为了让不变量成为一句可 grep、可钉死的话：「计数件符号一律不从包根来」。

## 改了什么

1. **`packages/plugins/plugin-auth/package.json`** —— 新增 `"./rate-limit-storage"` 子路径；`build` 从 `tsup --config ../../../tsup.config.ts` 改为 `tsup`（读包内配置）。
2. **`packages/plugins/plugin-auth/tsup.config.ts`**（新增）—— 两个 entry，`splitting: false`。形状照抄 `packages/types/tsup.config.ts`（`./node`）与 `packages/core/tsup.config.ts`（`./logger`），这两个包的第二 entry 是同一个动机、同一个写法。
3. **9 个消费点**只改 import 行，别的一个字没动。
4. **回归钉** `rate-limit-storage-isolation.test.ts`（5 例）。
5. **changeset**：plugin-auth minor（新增公开入口）、runtime / service-sms patch（import 切换会进各自 dist）。

**根导出保持不变** —— index 仍 `export *` 出全部符号，存量根导入方零破坏。这是加入口，不是搬家。

## `exports` 写法：偏离派发令的「照抄 `.`」，理由是实测

派发令要求新子路径「照抄既有 `.` 入口的形状」。照抄前先量了一下全仓：

```
origin/main 上 packages/ + apps/ 全部带 types 的 exports 条件：
  TYPES_FIRST  84
  TYPES_LAST    1   ← 就是 plugin-auth 自己的 "."
```

即「照抄」会把全仓**唯一**的那个反例复制一份，而且是在新铸一个公开入口的时刻。conditions 是 first-match-wins，`types` 排在 `import`/`require` 之后只会被偶然读到。所以新入口按 84:1 的主流写法（`types` 优先），并顺手把 `"."` 也归一 —— 这是零语义改动（tsup 同时产出 `.d.ts` 与 `.d.mts`，两种顺序今天都能解析，下面 tsc 三档实测为证），留一个文件内两种顺序反而像是手滑。这一处偏离在此显式申报，若 reviewer 认为 `"."` 该原样不动，我改回来。

## 实测数字

**构建产物**（`pnpm --filter @objectstack/plugin-auth build`）：

```
ESM  dist/rate-limit-storage.mjs     3.71 KB      dist/index.mjs   330.28 KB
CJS  dist/rate-limit-storage.js      4.94 KB      dist/index.js    337.94 KB
DTS  dist/rate-limit-storage.d.ts    6.59 KB      dist/index.d.ts  199.13 KB
```

**模块图探针**（在 `packages/services/service-sms/` 下跑真实解析）：

```
require('@objectstack/plugin-auth/rate-limit-storage')
  → require.cache: 1 个模块，better-auth 命中 0
  → exports: InProcessCounterStore, createLazyCacheRateLimitStorage,
             createLazyCounterStore, incrementFixedWindow

require('@objectstack/plugin-auth')
  → require.cache: 109 个模块，better-auth 命中 2
  → better-auth/dist/adapters/index.mjs, @better-auth/core/dist/db/index.mjs
```

**产物内的 better-auth 字符串命中**：`rate-limit-storage.mjs` 0、`rate-limit-storage.js` 0、`index.mjs` 160、`index.js` 160。子路径产物顶层 `import` / `require(` 语句数为 0 —— `splitting: false` 让它是自足 bundle，不是名义上的切分。（`.d.ts` 里 3 处是那条 `import type`，运行期不存在。）

**运行期 + 类型两面**：ESM `await import(...)` 解析成功并跑通一次 `incrementFixedWindow`（`{"count":1,"resetAt":...}`）；一个最小消费样例 `tsc --noEmit` 在 `module/moduleResolution = nodenext` 与 `esnext/bundler` 两档均 exit 0。

## 回归钉能抓住什么

`rate-limit-storage-isolation.test.ts` 走真实 import 图，形状沿用 `packages/types/src/node-isolation.test.ts`（#4700）为 `./node` 立的那套：

1. 子路径入口可达范围内出现任何 better-auth **值导入** → 红（`import type` 放行）；
2. 可达的**外部包集合**必须等于白名单 `[{ '@better-auth/core', typeOnly }]` —— 用白名单而不是 better-auth 黑名单，因为贵的那个 import 未必拼作 better-auth：`@objectstack/rest` 和 `@objectstack/platform-objects` 都会把全家带进来，黑名单会放行；
3. `packages/runtime/src` / `packages/services/service-sms/src` 下任何文件从**包根**取计数件符号 → 红（按目录扫描而非文件名，消费文件改名不会悄悄让检查失效）；
4. **空转守卫**：根入口若不再值导入 better-auth → 红。那时前两条会因为「没有东西可查」而变绿，切分也就不再买到任何东西，该重新测量而不是让套件为错误的理由通过；
5. `package.json` 确实发布该子路径，且 `files` 覆盖 `dist`。

刻意做**源码级**扫描而非探 `dist/`：读构建产物的门禁会随本地构建状态时绿时红，正是 `scripts/check-published-files.mjs` 给自己划的那条界（"a gate that passes or fails by accident is worse than one with a stated boundary"）。dist 层的读数是真的，但一次性，所以写在上面这段里而不是钉进套件。

## 反向验证（先定方向，再跑）

预判：**两处回填都应让新钉子转红**。实跑：

- 往 `rate-limit-storage.ts` 加一行 `import { createAdapterFactory } from 'better-auth/adapters'` → 第 1 条红（`src/rate-limit-storage.ts -> better-auth/adapters`）、第 2 条红（白名单多出一项）；
- 把 `sms-plugin.ts` 的 import 改回包根 → 第 3 条红（`packages/services/service-sms/src/sms-plugin.ts -> { createLazyCounterStore, type CounterStore } from the package root`）。

`Tests 3 failed | 2 passed`，方向与预判一致；回填撤销后恢复 5/5 绿。

## 验证

| 项 | 结果 |
|:--|:--|
| `turbo run test --filter=plugin-auth --filter=runtime --filter=service-sms` | **33/33 tasks 绿** |
| plugin-auth `test` | Test Files 39 passed (39) / Tests **972 passed (972)** |
| runtime `test` | Test Files 105 passed (105) / Tests **1506 passed (1506)** |
| service-sms `test` | Test Files 5 passed (5) / Tests **70 passed (70)** |
| 三包 `typecheck` | 33/33 tasks successful |
| `pnpm check:published-files` | ✓ 69 publishable packages，覆盖 every entry point（新子路径在内） |
| `node scripts/check-nul-bytes.mjs` | OK，scanned 5923 tracked text files，no raw ASCII control bytes |
| `pnpm check:empty-changeset` | ✓ |
| `eslint`（改动文件） | exit 0 |

日志里的 `ERROR Find operation failed` / `DEGRADED BOOT` 是 runtime 既有降级用例自己制造的噪声，不是失败 —— 33 个 task 全成功。

## 范围外发现

无。


---
_Generated by [Claude Code](https://claude.ai/code/session_01JwwiU9bjhwy2SWj13ho8uv)_