### PR TITLE
docs(adr-0104): 补词汇别名注记与三处成员事实勘误

### DIFF
--- a/docs/adr/0104-field-runtime-value-shape-contract.md
+++ b/docs/adr/0104-field-runtime-value-shape-contract.md
@@ -5,7 +5,11 @@
   and wave 2's ownership model settled by the 2026-07-27 addendum.
   Strict-default flip of D1/D2 tracked in #3438 — the media half flips per
   deployment (#3681); evidence for the remaining halves decided by the
-  2026-07-30 addendum. Wave 2 sequence in #3459.
+  2026-07-30 addendum. Wave 2 sequence in #3459. The 2026-08-07 addendum is
+  **errata only** — it registers the outside vocabulary (`fieldRuntimeType`,
+  `FileRef`, `RecordRef`, "read-time expansion") against this ADR's names so a
+  grep for those words lands here, and corrects three membership facts; it
+  changes no decision.
 - **Date**: 2026-07-22
 - **Issue**: design follow-up generalizing #3405 / #3406 (inline lookup param
   silently stripped); relates #3407 (silently dropped writes), #1878 / #1891
@@ -949,3 +953,70 @@ fix it.
 17.0 train: the D2 default flip (validator default + env-var swap + dogfood
 duals + release notes), and the scan migration (command, engine wiring,
 creation-time attestation, upgrade-path advertisement).
+
+## Addendum (2026-08-07) — vocabulary aliases and three membership facts (errata; no decision changes)
+
+This addendum decides **nothing**. It exists because decisions recorded above
+were re-proposed as if they had never been made, and the sole cause was
+vocabulary. #5867 asked for a *new* ADR to settle four things — a spec-owned
+`fieldRuntimeType`, named `FileRef` / `RecordRef` reference types, read-time
+expansion, and a typed action handler — every one of which D1, D2 and D3
+settled on 2026-07-22 and shipped as code. The proposal was searched for
+duplicates before it was filed. A repo-wide grep for `fieldRuntimeType`,
+`FileRef` and `RecordRef` returned **zero** hits on the day it was filed — in
+`docs/adr/` and everywhere else, and it is this addendum that changed that —
+because this ADR spells the same contract `valueSchemaFor` /
+`FileReferenceIdValueSchema` / `ReferenceIdValueSchema` / `ValueForm`. One
+failed search produced a phantom design card and spent a maintainer approval
+before the premise check caught it (#5867, closed as already satisfied by this
+ADR; the errata card is #6189).
+
+The lesson is narrow and mechanical. Prime Directive #13 sends every author to
+**grep the ADRs** before changing behaviour under them, so an accepted ADR is
+binding only as far as it is findable — and a grep can only hit words that are
+present. The outside vocabulary is therefore registered here, inside the record
+the search is meant to land in. Nothing below alters D1–D4 or any earlier
+addendum; where a fact and this ADR's own prose disagree, the disagreement is
+named rather than edited away.
+
+### Alias registry — outside or colloquial name → the name this ADR uses
+
+| said elsewhere | this ADR / the shipped contract | defined in |
+|---|---|---|
+| `fieldRuntimeType(type, { multiple })` | **`valueSchemaFor(def, form)`** (D1.2) — the pure derivation from a field definition to its value schema. Note the shape difference: `multiple` is not an option argument, it is read off the definition by `isMultiValueField(def)`. | `packages/spec/src/data/field-value.zod.ts` |
+| `FileRef` | **`FileReferenceIdValueSchema`**, over the `FILE_REFERENCE_TYPES` class (D1.1, D3) | same file |
+| `RecordRef` | **`ReferenceIdValueSchema`**, over the `REFERENCE_VALUE_TYPES` class (D1.1) | same file |
+| "read-time expansion" (读时展开) | **`ValueForm`**, whose two members are `'stored'` and `'expanded'` (D1.2); `valueSchemaFor(def, form)` dispatches on it, and `expanded` ≡ `stored` for types with no expansion | same file |
+| `defineActionHandler` / "typed action handler" | **`ActionHandler`** and `ActionHandlerContext` plus `validateActionParams()` / `ACTION_PARAM_BUILTIN_KEYS` (D2) | `packages/spec/src/ui/action-params.zod.ts` |
+
+Add a row here whenever an outside proposal turns out to be asking for
+something D1–D4 already decided. An unregistered alias costs a duplicate ADR,
+and a duplicate ADR over a live contract is a *second source of truth* for the
+very thing this ADR's Context section opens by counting four of.
+
+### Three membership facts, as shipped
+
+#5867's framing carried three errors about the type classes it was naming.
+They are recorded here because an alias table is worse than useless if a reader
+carries the aliased vocabulary's *coverage* across with its names.
+
+1. **`owner` is not a `FieldType`.** The declared members are enumerated in
+   `packages/spec/src/data/field.zod.ts`, and `owner` is not among them; lines
+   52–53 say why: `user` is "NOT a separate storage primitive … Ownership stays
+   the existing `owner_id` convention (plugin-security); a declarative `owner`
+   is a possible future flag." So ownership is not part of the reference class
+   this ADR contracts over, and `RecordRef` coverage that lists `owner` is
+   describing a type that does not exist.
+2. **`REFERENCE_VALUE_TYPES` includes `tree`.** The shipped class is `lookup`,
+   `master_detail`, `user`, `tree` — `tree` is a hierarchical reference and
+   stores a record id like the rest, so `referenceTargetOf()` and every
+   consumer of the class already cover it. Two errata in one fact: D1.1 above
+   names this constant `REFERENCE_TYPES` and lists three members; the shipped
+   constant is **`REFERENCE_VALUE_TYPES`** and has four. The shipped set is the
+   contract — this sentence corrects the record of it, and changes no decision.
+3. **`FILE_REFERENCE_TYPES` includes `avatar`.** The class is `image`, `file`,
+   `avatar`, `video`, `audio` — as D1.1 already lists it, and as the whole
+   media family D3's 2026-07-24 addendum insists on covering together. A
+   `FileRef` scoped to `file`/`image`/`video`/`audio` would leave `avatar` on
+   the legacy inline shape, which is precisely the per-type carve-out that
+   addendum rejected.


### PR DESCRIPTION
Fixes #6189

## 为什么

ADR-0104(Accepted 2026-07-22)早就把字段运行时值形状契约拍板并落地了,但它用的词汇是 `valueSchemaFor` / `FileReferenceIdValueSchema` / `ReferenceIdValueSchema` / `ValueForm`。#5867 用另一套名字(`fieldRuntimeType` / `FileRef` / `RecordRef` / 「读时展开」)来要求**新立**一份 ADR —— 立单方查过重,但全仓 grep 这三个名字命中为 **0**,于是造出一张幻影设计卡,烧掉一次维护者批复,直到前提核验才拦下(#5867 已关为「已由 ADR-0104 满足」)。

Prime Directive #13 要求每位作者动 ADR 治下的行为前先 grep ADR —— 那么**一份 ADR 的约束力只到它可被检索为止**,而 grep 只能命中文件里真实存在的词。本 PR 把外部词汇登记进这份检索该落地的记录里。

## 改了什么(docs-only,零决策变更)

单文件 `docs/adr/0104-field-runtime-value-shape-contract.md`,照该 ADR 既有 addendum 风格追加一节 `## Addendum (2026-08-07)`,外加 Status 行一句非决策性指针:

1. **别名登记表** —— 外部/口语名 → 本 ADR 名词:
   - `fieldRuntimeType(type, { multiple })` → `valueSchemaFor(def, form)`(并写明形状差异:`multiple` 不是入参,由 `isMultiValueField(def)` 从定义读出)
   - `FileRef` → `FileReferenceIdValueSchema`(`FILE_REFERENCE_TYPES` 类)
   - `RecordRef` → `ReferenceIdValueSchema`(`REFERENCE_VALUE_TYPES` 类)
   - 「读时展开」→ `ValueForm`,两个成员 `'stored'` 与 `'expanded'`
   - 附带一行 `defineActionHandler` → D2 的 `ActionHandler` / `validateActionParams()`(同一次检索失败里的 Q3,同表登记成本为零)
2. **三处成员事实**(勘误对象是 #5867 正文的错误认知,ADR 侧只作记录):
   - `owner` 不是 `FieldType` —— `packages/spec/src/data/field.zod.ts:52-53` 明写所有权仍走 `owner_id` 约定,「a declarative `owner` is a possible future flag」
   - `REFERENCE_VALUE_TYPES` 含 `tree`(实际四员:`lookup` / `master_detail` / `user` / `tree`)
   - `FILE_REFERENCE_TYPES` 含 `avatar`(`image` / `file` / `avatar` / `video` / `audio`)

顺带记录一处**文-码漂移**(只记录、不修改 D1 决策文本):D1.1 的正文把该常量写作 `REFERENCE_TYPES` 且只列三员,而 main 上出厂的常量名是 `REFERENCE_VALUE_TYPES`、四员。出厂集合是契约,addendum 按「说出分歧、不改写决策」的方式登记。

⛔ 未改任何决策内容,⛔ 未动任何代码。

## 事实核对

全部对 `origin/main`(80f7dc6a3)用 `git show origin/main:PATH` 核实:

| 事实 | 出处 |
|---|---|
| `REFERENCE_VALUE_TYPES = { lookup, master_detail, user, tree }` | `packages/spec/src/data/field-value.zod.ts:93-95` |
| `FILE_REFERENCE_TYPES = { image, file, avatar, video, audio }` | 同文件 `:147-149` |
| `FileReferenceIdValueSchema` / `ReferenceIdValueSchema` | 同文件 `:297` / `:348` |
| `ValueForm = 'stored'` 与 `'expanded'` | 同文件 `:362` |
| `valueSchemaFor(def, form = 'stored')` | 同文件 `:375` |
| `owner` 不在 `FIELD_TYPES` 中;所有权走 `owner_id` | `packages/spec/src/data/field.zod.ts:52-53`(全文件 grep `'owner'` 零命中) |
| 无 `REFERENCE_TYPES` 导出 | `field-value.zod.ts` 内 grep 仅命中 `FILE_REFERENCE_TYPES` |

## 验证

```
$ node scripts/check-nul-bytes.mjs --self-test && node scripts/check-nul-bytes.mjs
✓ check-nul-bytes --self-test: 56 assertions over a temp git repo (real scan() path)
check-nul-bytes: OK (scanned 5920 tracked text file(s); ... no raw ASCII control bytes).

$ node scripts/check-doc-authoring.mjs --self-test && node scripts/check-doc-authoring.mjs
✓ check-doc-authoring self-test: scope wiring ... all hold.
✓ doc authoring guard: 364 files clean — no bare metadata literals.

$ node scripts/check-adr-anchors.mjs
check-adr-anchors: OK (37 anchored file(s), every governing ADR still referenced).
```

本 PR 的验收其实就是一次 grep。改前对 `docs/adr/` 搜这三个名字:`fieldRuntimeType` 零命中、`RecordRef` 零命中、`FileRef` 只作为 `verifyFileReferences` 的子串命中(不是这个概念)。改后逐词命中 ADR-0104 —— 即本单要防的那次检索失败不会再发生。

docs-only、无用户可见行为变更,故无 changeset,打 `skip-changeset`。


---
_Generated by [Claude Code](https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY)_