### PR TITLE
fix(formula): classifyError 把 cel-js 的 parse 错误按错误类归为 syntax/parse,不再误报 runtime (#6133)

### DIFF
--- a/.changeset/cel-parse-fault-kind.md
+++ b/.changeset/cel-parse-fault-kind.md
@@ -1,0 +1,15 @@
+---
+'@objectstack/formula': patch
+---
+
+fix(formula): 括号/引号/转义等 parse 期错误不再被误报为 `runtime`
+
+`celEngine` 的错误分类此前完全靠**错误文案关键词**判定,而 cel-js 8.0.0 的 parse 期错误有约 19 种措辞,只有 3 种含 `parse` / `unexpected` / `syntax`。其余整类 —— 最典型的括号/方括号/花括号不配对(`Expected RPAREN, got EOF`)、未闭合字符串、非法转义、保留字 —— 全部落到默认值 `runtime`。
+
+`kind` 不是内部字段:它被原样拼进作者可见的写入拒绝文案(`@objectstack/objectql` 的 `rule-validator` / `cel-fault`)与 REST 错误响应体的 `reason`。少写一个右括号的校验规则,作者读到的是 `(runtime: …)` —— 指向数据与求值期,而真正该改的是表达式本身,与 ADR-0032 D1d 的"消息面向自纠"相悖。
+
+改为按 cel-js 抛出的**错误类**判定:`ParseError` → `parse`(其中 `code: 'limit_exceeded'` 仍 → `bounds`,cel-js 的越界一律由 parser 抛出)。这一层不再读文案,因此也修掉了关键词方案无法修的一格:cel-js 会把**作者自己的源码行**嵌进 `message`(`formatErrorWithHighlight`),于是字段名能决定错误分类 —— 实测 `((record.type_id)` 这条普通的括号不配对,此前被判为 `type`,只因回显的源码里含子串 "type"。
+
+`type` / `runtime` 两支暂仍走原关键词表:cel-js 的 `TypeChecker` 按**阶段**而非按故障选择错误类(`isEvaluating ? evaluationError : typeError`),同一个 `unknown_variable` 在 check 期是 `TypeError`、在 eval 期是 `EvaluationError`,整体结构化会改变这些既有判定。审计见 #6133。
+
+kind 词表本身(`parse` / `type` / `runtime` / `bounds` / `dialect`)未变,消费方未改。

--- a/packages/formula/src/cel-engine.ts
+++ b/packages/formula/src/cel-engine.ts
@@ -13,7 +13,7 @@
  *    third-party plugins can't ship runaway predicates.
  */
 
-import { Environment, serialize } from '@marcbachmann/cel-js';
+import { Environment, ParseError, serialize } from '@marcbachmann/cel-js';
 import type { ASTNode } from '@marcbachmann/cel-js';
 import type { Expression } from '@objectstack/spec';
 
@@ -800,12 +800,63 @@ function hydrateOverloadStrings(value: unknown): unknown {
   return value;
 }
 
+/**
+ * cel-js's code for a bounds violation. Raised **only** from the parser
+ * (`Parser#limitExceeded`, one call site per limit key), so it always arrives as
+ * a {@link ParseError} and must be read before the ParseError → `parse` rule
+ * below — otherwise every `maxAstNodes` / `maxDepth` overrun would be reported
+ * as a syntax fault.
+ */
+const CEL_LIMIT_EXCEEDED_CODE = 'limit_exceeded';
+
+/**
+ * Grade a cel-js fault off the error **class** the parser threw, not off its
+ * prose. Returns `undefined` for anything that is not a cel-js error, so the
+ * caller can fall back to the legacy keyword table.
+ *
+ * Why the class and not the message (#6133): `classifyError` used to decide
+ * between `parse` / `type` / `runtime` by regex-matching the error text, and
+ * cel-js has ~19 distinct parse-time wordings of which only three contain
+ * `parse` / `unexpected` / `syntax`. Everything else — `Expected RPAREN, got
+ * EOF` (unbalanced parens), `Expected RBRACKET, got EOF`, `Unterminated
+ * string`, `Reserved identifier: package`, the seven escape-sequence faults —
+ * fell through to the default `runtime`, and `kind` is not an internal field:
+ * it is interpolated verbatim into the author-facing rejection text
+ * (`objectql`'s `rule-validator` / `cel-fault`) and into the REST `reason`.
+ * An author who forgot a closing paren was told their *data* was at fault.
+ *
+ * Topping the keyword list up cannot fix this, because cel-js embeds the
+ * **author's own source line** in `message` (see `formatErrorWithHighlight` in
+ * `lib/errors.js`), so the author controls the text being matched. Measured on
+ * cel-js 8.0.0: `((record.type_id)` — a plain unbalanced paren — classified as
+ * `type`, purely because the echoed source contains the substring "type".
+ * Classifying on prose is not a table with holes in it; it is the hole.
+ *
+ * Scope note, deliberate: only the ParseError arm is structural here. cel-js's
+ * `TypeChecker` picks its error class **by phase**, not by fault
+ * (`this.createError = isEvaluating ? evaluationError : typeError`), so the same
+ * `unknown_variable` fault is a `TypeError` at check time and an
+ * `EvaluationError` at evaluate time. Routing `EvaluationError` → `runtime`
+ * wholesale would therefore silently re-grade faults the keyword table gets
+ * right today (`Unknown variable: x` → `type`). Those arms stay on the keyword
+ * table until that mapping is measured per code — see #6133 for the audit.
+ */
+function classifyCelParseFault(err: unknown): 'parse' | 'bounds' | undefined {
+  if (!(err instanceof ParseError)) return undefined;
+  return err.code === CEL_LIMIT_EXCEEDED_CODE ? 'bounds' : 'parse';
+}
+
 function classifyError(err: unknown): EvalResult<never> {
   const message = err instanceof Error ? err.message : String(err);
-  let kind: 'parse' | 'type' | 'runtime' | 'bounds' = 'runtime';
-  if (/Exceeded max/i.test(message)) kind = 'bounds';
-  else if (/parse|unexpected|syntax/i.test(message)) kind = 'parse';
-  else if (/type|unknown variable|undeclared/i.test(message)) kind = 'type';
+  let kind: 'parse' | 'type' | 'runtime' | 'bounds' | undefined = classifyCelParseFault(err);
+  if (kind === undefined) {
+    // Legacy keyword table — the residual path for faults that carry no
+    // structured contract at all (our own stdlib, a native JS throw).
+    kind = 'runtime';
+    if (/Exceeded max/i.test(message)) kind = 'bounds';
+    else if (/parse|unexpected|syntax/i.test(message)) kind = 'parse';
+    else if (/type|unknown variable|undeclared/i.test(message)) kind = 'type';
+  }
   return { ok: false, error: { kind, message } };
 }
 

--- a/packages/formula/src/cel-error-classification.test.ts
+++ b/packages/formula/src/cel-error-classification.test.ts
@@ -1,0 +1,169 @@
+/**
+ * #6133 — `EvalResult.error.kind` is an author-facing field, not an internal
+ * one. It is interpolated verbatim into the write-rejection text
+ * (`@objectstack/objectql`'s `rule-validator` / `cel-fault`) and into the REST
+ * error body's `reason`. A missing closing paren reported as `runtime` points
+ * the author at their data instead of at their expression, which is exactly the
+ * misdirection ADR-0032 D1d asks these messages to avoid.
+ *
+ * cel-js 8.0.0 has ~19 distinct parse-time wordings; only three of them contain
+ * `parse` / `unexpected` / `syntax`. This file pins **one fixture per wording
+ * class** so a cel-js re-wording can never silently re-open the hole, and pins
+ * the two things the classification must not lose along the way: bounds faults
+ * (a `ParseError` carrying `code: 'limit_exceeded'`) and the non-parse kinds
+ * the keyword table still owns.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { celEngine } from './cel-engine';
+import type { Expression } from '@objectstack/spec';
+
+const cel = (source: string): Expression => ({ dialect: 'cel', source });
+
+/** The kind both entry points report for `source`, asserted to agree. */
+function kindOf(source: string): string {
+  const compiled = celEngine.compile(source);
+  const evaluated = celEngine.evaluate(cel(source), {});
+  expect(compiled.ok).toBe(false);
+  expect(evaluated.ok).toBe(false);
+  if (compiled.ok || evaluated.ok) throw new Error('expected both entries to fault');
+  // `classifyError` serves compile() and evaluate() alike — build-time
+  // (`os build` / `os validate` / `os lint`) and run-time (write rejection,
+  // REST) must never disagree about what kind of mistake the author made.
+  expect(evaluated.error.kind).toBe(compiled.error.kind);
+  return compiled.error.kind;
+}
+
+describe('celEngine error classification (#6133)', () => {
+  describe('unbalanced delimiters are syntax faults, not runtime faults', () => {
+    // The headline regression: cel-js reports these as `Expected <TOKEN>, got
+    // EOF`, which contains none of `parse` / `unexpected` / `syntax`, so the
+    // keyword table dropped the whole family to the `runtime` default.
+    it.each([
+      ['unclosed paren', '((record.a)', 'RPAREN'],
+      ['unclosed bracket', '[1, 2', 'RBRACKET'],
+      ['unclosed brace', '{"a": 1', 'RBRACE'],
+      ['ternary missing colon', 'record.a ? 1', 'COLON'],
+    ])('%s → kind=parse', (_label, source, token) => {
+      const compiled = celEngine.compile(source);
+      expect(compiled.ok).toBe(false);
+      if (compiled.ok) return;
+      expect(compiled.error.kind).toBe('parse');
+      // The message was always right; only the classification was wrong. Pin
+      // that the fix did not "fix" it by rewriting the author's diagnostic.
+      expect(compiled.error.message).toContain(`Expected ${token}`);
+      expect(kindOf(source)).toBe('parse');
+    });
+  });
+
+  describe('every other cel-js parse-time wording (audited on 8.0.0)', () => {
+    // Codes that also missed every keyword and defaulted to `runtime`.
+    it.each([
+      ['unterminated_string', '"abc'],
+      ['unterminated_triple_quoted_string', '"""abc'],
+      ['newline_in_string', "'a\nb'"],
+      ['invalid_hex_integer', '0xZZ'],
+      ['invalid_escape_sequence', '"\\q"'],
+      ['invalid_unicode_escape', '"\\u12"'],
+      ['invalid_hex_escape', '"\\xZZ"'],
+      ['invalid_octal_escape', '"\\07"'],
+      ['reserved_identifier', 'record.a && package'],
+    ])('%s → kind=parse', (_code, source) => {
+      expect(kindOf(source)).toBe('parse');
+    });
+
+    // Codes the keyword table already graded correctly — they must stay put.
+    it.each([
+      ['unexpected_token (trailing operator)', 'record.budget >'],
+      ['unexpected_token (QUESTION)', 'record.a ?? 3'],
+      ['unexpected_character', 'record.a $$ 1'],
+    ])('%s → kind=parse (unchanged)', (_code, source) => {
+      expect(kindOf(source)).toBe('parse');
+    });
+  });
+
+  it('does not read the author source echoed into the message (#6133)', () => {
+    // cel-js embeds the offending source line in `message`
+    // (`formatErrorWithHighlight`), so a keyword classifier is matching text
+    // the AUTHOR controls. Before the fix this exact fixture — an ordinary
+    // unbalanced paren — was graded `type`, purely because the echoed line
+    // contains the substring "type". A field name must not be able to pick the
+    // error kind.
+    const compiled = celEngine.compile('((record.type_id)');
+    expect(compiled.ok).toBe(false);
+    if (compiled.ok) return;
+    expect(compiled.error.message).toContain('record.type_id');
+    expect(compiled.error.kind).toBe('parse');
+
+    // Same shape, a field name containing "parse": it must land on `parse` for
+    // the structural reason, not by accident of spelling.
+    const alsoParse = celEngine.compile('((record.parsed_at)');
+    expect(alsoParse.ok).toBe(false);
+    if (alsoParse.ok) return;
+    expect(alsoParse.error.kind).toBe('parse');
+  });
+
+  describe('the kinds that are NOT parse keep their verdicts', () => {
+    it('bounds: limit_exceeded is a ParseError but must stay kind=bounds', () => {
+      // cel-js raises every bounds violation through the parser, so the
+      // structured route has to read `code` before it reads the class.
+      const overNodes = Array.from({ length: 500 }, (_, i) => `${i}`).join(' + ');
+      const r = celEngine.compile(overNodes);
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.error.kind).toBe('bounds');
+        expect(r.error.message).toContain('Exceeded maxAstNodes');
+      }
+
+      const overList = `[${Array.from({ length: 200 }, (_, i) => i).join(',')}]`;
+      const rl = celEngine.compile(overList);
+      expect(rl.ok).toBe(false);
+      if (!rl.ok) expect(rl.error.kind).toBe('bounds');
+    });
+
+    it('type: an unknown function is still kind=type (#1877)', () => {
+      const r = celEngine.compile('PRIOR(status) != "promoted"');
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error.kind).toBe('type');
+    });
+
+    it('type: an undeclared variable at evaluate time is still kind=type', () => {
+      // cel-js's TypeChecker picks its error CLASS by phase
+      // (`isEvaluating ? evaluationError : typeError`), so this fault arrives
+      // as an EvaluationError. It stays on the keyword table on purpose — the
+      // structured route only claims the ParseError arm.
+      const r = celEngine.evaluate(cel('nope.a'), {});
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.error.message).toContain('Unknown variable');
+        expect(r.error.kind).toBe('type');
+      }
+    });
+
+    it('runtime: a genuine evaluation fault is still kind=runtime', () => {
+      const r = celEngine.evaluate(cel('1 / 0'), {});
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error.kind).toBe('runtime');
+
+      const overload = celEngine.evaluate(cel('1 + "a"'), {});
+      expect(overload.ok).toBe(false);
+      if (!overload.ok) expect(overload.error.kind).toBe('runtime');
+    });
+
+    it('dialect: a mismatched dialect is untouched', () => {
+      const r = celEngine.evaluate({ dialect: 'cron', source: 'x' }, {});
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error.kind).toBe('dialect');
+    });
+  });
+
+  it('parseCelToAst never reaches the classifier — it returns null (#4812)', async () => {
+    // Recorded because the classification fix has a natural blast radius
+    // question: does the #4812 canonical parse entry re-emit `kind`? It does
+    // not — it swallows the fault and answers `null`, leaving the verdict to
+    // compile()/validateExpression. Nothing here changes for it.
+    const { parseCelToAst } = await import('./cel-engine');
+    expect(parseCelToAst('((record.a)')).toBeNull();
+    expect(parseCelToAst('record.a > 1')).not.toBeNull();
+  });
+});

--- a/packages/formula/src/cel-error-classification.test.ts
+++ b/packages/formula/src/cel-error-classification.test.ts
@@ -15,7 +15,7 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { celEngine } from './cel-engine';
+import { celEngine, parseCelToAst } from './cel-engine';
 import type { Expression } from '@objectstack/spec';
 
 const cel = (source: string): Expression => ({ dialect: 'cel', source });
@@ -157,12 +157,11 @@ describe('celEngine error classification (#6133)', () => {
     });
   });
 
-  it('parseCelToAst never reaches the classifier — it returns null (#4812)', async () => {
+  it('parseCelToAst never reaches the classifier — it returns null (#4812)', () => {
     // Recorded because the classification fix has a natural blast radius
     // question: does the #4812 canonical parse entry re-emit `kind`? It does
     // not — it swallows the fault and answers `null`, leaving the verdict to
     // compile()/validateExpression. Nothing here changes for it.
-    const { parseCelToAst } = await import('./cel-engine');
     expect(parseCelToAst('((record.a)')).toBeNull();
     expect(parseCelToAst('record.a > 1')).not.toBeNull();
   });

--- a/packages/objectql/src/validation/rule-unevaluable-fault-kind.test.ts
+++ b/packages/objectql/src/validation/rule-unevaluable-fault-kind.test.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #6133 — consumer-side pin for the CEL fault `kind`.
+ *
+ * `@objectstack/formula` decides the kind; THIS is where an author reads it.
+ * `unevaluableRuleError` puts `faultSummary(error)` — literally
+ * `` `${kind}: ${first line}` `` — into both the rejection sentence and
+ * `constraint.fault`, and `packages/rest` re-emits the same kind as the HTTP
+ * body's `reason`. So a misclassification upstream is not an internal detail:
+ * it is the word the author is handed when their write is refused.
+ *
+ * Before #6133 an unbalanced paren produced `(runtime: Expected RPAREN, got
+ * EOF)` — "runtime" pointing the author at their DATA when the fault is in
+ * their expression. This file reads the consumer without changing it, so the
+ * formula-side fix is pinned where it is actually visible.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { evaluateValidationRules } from './rule-validator';
+import { ValidationError } from './record-validator';
+
+const schemaWithPredicate = (source: string) => ({
+  fields: {
+    status: { name: 'status', label: 'Status', type: 'text' },
+    amount: { name: 'amount', label: 'Amount', type: 'number' },
+  },
+  validations: [
+    {
+      type: 'script' as const,
+      name: 'broken_predicate',
+      condition: { dialect: 'cel', source },
+      message: 'Amount is out of range.',
+      events: ['insert', 'update'] as Array<'insert' | 'update'>,
+    },
+  ],
+});
+
+/** Run the write and hand back the rejection the author would see. */
+function rejectionOf(source: string): ValidationError {
+  try {
+    evaluateValidationRules(schemaWithPredicate(source), { status: 'open', amount: 10 }, 'insert');
+  } catch (err) {
+    if (err instanceof ValidationError) return err;
+    throw err;
+  }
+  throw new Error(`expected the write to be rejected for predicate: ${source}`);
+}
+
+describe('#6133 — the kind an author reads for an unparseable predicate', () => {
+  it('reports an unbalanced paren as a SYNTAX fault, not a runtime one', () => {
+    const err = rejectionOf('((record.amount > 100)');
+
+    // The sentence the author reads.
+    expect(err.fields[0]?.message).toContain('parse: Expected RPAREN');
+    expect(err.fields[0]?.message).not.toContain('runtime:');
+
+    // The machine-readable twin, and the value `packages/rest` re-emits as the
+    // HTTP `reason`.
+    expect(err.fields[0]?.constraint).toMatchObject({
+      rule: 'broken_predicate',
+      reason: 'unevaluable',
+      fault: expect.stringMatching(/^parse: Expected RPAREN/),
+    });
+  });
+
+  it('reports an unbalanced bracket the same way', () => {
+    const err = rejectionOf('record.amount in [1, 2');
+    expect(err.fields[0]?.constraint).toMatchObject({
+      fault: expect.stringMatching(/^parse: Expected RBRACKET/),
+    });
+  });
+
+  it('still fails CLOSED — a broken predicate rejects the write (#4649)', () => {
+    // The classification fix must not soften the fail-closed guarantee: an
+    // unevaluable rule still refuses the write, it just names the fault
+    // correctly now.
+    expect(() =>
+      evaluateValidationRules(
+        schemaWithPredicate('((record.amount > 100)'),
+        { status: 'open', amount: 10 },
+        'insert',
+      ),
+    ).toThrow(ValidationError);
+  });
+
+  it('leaves a genuine RUNTIME fault reported as runtime', () => {
+    // The counter-case: a predicate that parses fine and faults while
+    // evaluating must keep pointing at evaluation. Ordering a text field
+    // against a number is the cleanest such fault — the record is total, so no
+    // missing key, and the message carries no `null`, so `describeCelFault`'s
+    // null-comparison sentence does not claim it either.
+    const err = rejectionOf('record.status > 1');
+    expect(err.fields[0]?.constraint).toMatchObject({
+      fault: expect.stringMatching(/^runtime:/),
+    });
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6133

## 前提重验(`origin/main` `80f7dc6a3`)

单据成立,且**比单据描述的更大**。`packages/formula/src/cel-engine.ts:803` 的 `classifyError` 与单据引用逐字一致(默认 `runtime`,三条关键词分支)。

## 词表核查结论(必答项 1)

从 cel-js 8.0.0 源码枚举全部 `parseError(...)` 抛出点,再逐条实测各措辞在**改前**分类器下的判定。共 20 类 parse 期错误 code,**只有 3 类**命中关键词:

| cel-js code | 首行文案 | 改前 kind | 改后 |
|:--|:--|:--|:--|
| `unexpected_character` | `Unexpected character: $` | `parse` ✅ | `parse` |
| `unexpected_token` | `Unexpected token: EOF` / `: QUESTION` | `parse` ✅ | `parse` |
| `limit_exceeded` | `Exceeded maxAstNodes (256)` | `bounds` ✅ | `bounds` |
| `expected_token` | `Expected RPAREN, got EOF`(括号) | **`runtime`** ❌ | `parse` |
| `expected_token` | `Expected RBRACKET, got EOF`(方括号) | **`runtime`** ❌ | `parse` |
| `expected_token` | `Expected RBRACE, got EOF`(花括号) | **`runtime`** ❌ | `parse` |
| `expected_token` | `Expected COLON, got EOF`(三元缺冒号) | **`runtime`** ❌ | `parse` |
| `unterminated_string` | `Unterminated string` | **`runtime`** ❌ | `parse` |
| `unterminated_triple_quoted_string` | `Unterminated triple-quoted string` | **`runtime`** ❌ | `parse` |
| `newline_in_string` | `Newlines not allowed in single-quoted strings` | **`runtime`** ❌ | `parse` |
| `invalid_hex_integer` | `Invalid hex integer: 0x` | **`runtime`** ❌ | `parse` |
| `invalid_escape_sequence` | `Invalid escape sequence: \q` | **`runtime`** ❌ | `parse` |
| `invalid_unicode_escape` | `Invalid Unicode escape: \u12` | **`runtime`** ❌ | `parse` |
| `invalid_hex_escape` | `Invalid hex escape: \xZZ` | **`runtime`** ❌ | `parse` |
| `invalid_octal_escape` | `Octal escape must be 3 digits` | **`runtime`** ❌ | `parse` |
| `reserved_identifier` | `Reserved identifier: package` | **`runtime`** ❌ | `parse` |
| `invalid_number` † | `Invalid number: …` | 无关键词 -> `runtime` | `parse` |
| `invalid_integer` / `invalid_exponent` † | `Invalid integer: …` / `Invalid exponent` | 无关键词 -> `runtime` | `parse` |
| `octal_escape_out_of_range` † | `Octal escape out of range: \…` | 无关键词 -> `runtime` | `parse` |
| `invalid_unicode_surrogate` † | `Invalid Unicode surrogate: \…` | 无关键词 -> `runtime` | `parse` |
| `bytes_unicode_escape` † | `\u not allowed in bytes literals` | 无关键词 -> `runtime` | `parse` |
| `expression_must_be_string` † | `Expression must be a string` | 无关键词 -> `runtime` | `parse` |
| `invalid_macro_argument` † | (宏参数,文案未取到) | 未测 | `parse` |

† = 从 cel-js 源码枚举得到、但**未实测复现**(构造触发它的源码不划算)。上半 16 行是逐条实测的(见新增测试)。带 † 的行"改前"一列是按现有关键词表推演,不是量测;"改后"一列则是确定的 —— 结构化判定覆盖 `ParseError` **全类**,不依赖逐条枚举,这正是换掉关键词表的收益,也是"补关键词"永远做不到的:下一次 cel-js 改措辞或加一个 code,关键词表就再破一次,类判定不会。

**关键词补表补不完,也补不对 —— 这是本 PR 偏离派单的原因。** cel-js 把**作者自己的源码行**嵌进 `message`(`lib/errors.js` 的 `formatErrorWithHighlight`),所以关键词匹配的是**作者可控的文本**。实测:

```
((record.type_id)   -> 改前 kind = 'type'      (普通括号不配对,只因回显源码含子串 "type")
((record.parsed_at) -> 改前 kind = 'parse'     (碰巧对,理由是错的)
```

字段名能决定错误分类。这不是"表里有洞",这**就是**洞。所以本 PR 按单据与分诊双方都点名的**根治方向**改:读 cel-js 抛出的错误**类**(`ParseError` / `EvaluationError` / `TypeError` 均为 cel-js 的 public export,`lib/index.d.ts:188-225` 有类型声明),不读文案。

**拿不准 / 刻意不改的一格(留报告,未猜)**:`type` 与 `runtime` 两支**仍走原关键词表**。原因是实测出的一条契约事实 —— cel-js 的 `TypeChecker` 按**阶段**而非按故障选择错误类:

```js
// node_modules/@marcbachmann/cel-js/lib/type-checker.js:16
this.createError = isEvaluating ? evaluationError : typeError
```

同一个 `unknown_variable` 故障,check 期抛 `TypeError`、eval 期抛 `EvaluationError`。若把 `EvaluationError` 整体判为 `runtime`,`Unknown variable: x` 会从今天正确的 `type` 变成 `runtime` —— 这是本单据没要求、也没量化过的判定迁移。逐 code 的映射(18 个 evaluation code)需要单独定价,已写进代码注释与 changeset。

## 改动

`packages/formula/src/cel-engine.ts` 一处:

- 新增 `classifyCelParseFault(err)`:`err instanceof ParseError` 时返回 `parse`,但 **`code === 'limit_exceeded'` 先判为 `bounds`** —— cel-js 的越界一律经 parser 抛出(`Parser#limitExceeded`,每个 limit key 一个调用点),顺序反了会把所有 `maxAstNodes` 超限报成语法错;
- `classifyError` 先问结构化判定,未命中(非 cel-js 抛出的错误,如自家 stdlib / 原生 JS throw)才落回原关键词表,原表逐字未动。

⛔ `kind` 词表本身未变(仍是 `parse` / `type` / `runtime` / `bounds` / `dialect`);⛔ 消费方(`rule-validator` / `cel-fault` / `rest-server`)一行未改;⛔ `cel-to-filter` 未触。

> 派单写的目标 kind 是 `'syntax'`,但仓库现有词表里没有这一格(`cel-engine.ts:805` 声明为 `'parse' | 'type' | 'runtime' | 'bounds'`),且派单同时禁止改词表。按单据正文与既有词表,正确目标是 **`parse`**;本 PR 取 `parse`。

## 测试

新增 `packages/formula/src/cel-error-classification.test.ts`(23 例),每类措辞一条 fixture,并钉住"不许丢"的另一半:`bounds`(`limit_exceeded` 是 `ParseError`,必须先判)、`type`(未知函数 #1877、eval 期 `Unknown variable`)、`runtime`(除零、overload)、`dialect`。每条 parse 用例都断言 `compile()` 与 `evaluate()` 给出**同一个** kind —— build 期与运行期不许对"作者错在哪"有分歧。

新增 `packages/objectql/src/validation/rule-unevaluable-fault-kind.test.ts`(4 例,**只读消费方,未改一行源码**):走真实 `evaluateValidationRules` 路径,断言作者读到的句子已是 `parse: Expected RPAREN`、`constraint.fault` 同步,且 #4649 的 fail-closed 未被削弱。

```
pnpm --filter @objectstack/formula test        Test Files 18 passed (18)  Tests 422 passed (422)
pnpm --filter @objectstack/formula typecheck   tsc --noEmit (clean)
pnpm --filter @objectstack/objectql test       Test Files 136 passed (136) Tests 2218 passed (2218)
pnpm --filter @objectstack/objectql typecheck  tsc --noEmit (clean)
pnpm --filter @objectstack/lint test           Test Files 61 passed (61)  Tests 1466 passed (1466)
node scripts/check-nul-bytes.mjs               OK (scanned 5920 tracked text file(s))
```

消费半径已 grep 扫过:全仓无第二处测试对 parse 故障断言 `runtime`。

## 反向验证(方向先写死,再跑)

**肢 A**:移除结构化判定(`classifyCelParseFault(err)` -> `undefined`),回落纯关键词表。

**预测(跑之前写下)**:formula 侧 23 例中 **14 例翻红** —— 4 条分隔符 + 9 条其余措辞 + 1 条源码污染;3 条本就命中关键词的、`bounds`/`type`/`runtime`/`dialect`/`parseCelToAst` 共 9 例保持绿。源码污染那条应**特异性地退化为 `type`**(不是 `runtime`)。消费面 4 例中 **2 例翻红**。

**实测**:

```
 Tests  14 failed | 9 passed (23)
AssertionError: expected 'runtime' to be 'parse'
AssertionError: expected 'runtime' to be 'parse'
AssertionError: expected 'type' to be 'parse'      (源码污染那条,方向如预测)
```

消费面(肢 A 下重建 formula dist 后):

```
 Tests  2 failed | 2 passed (4)
Received: "Validation rule 'broken_predicate' could not be evaluated (runtime: Expected RPAREN, got EOF) — write rejected."
```

**逐条吻合**,含那条特异的 `type` 退化。最后一行正是单据主张的作者可见字符串,原样复现。

一处记录:消费面测试读的是 formula 的 **dist**,不是 src —— 第一次只改 src 跑肢 A 时消费面 4 例全绿(AGENTS.md §9 的陈旧产物陷阱),重建 dist 后才现红。

## 必答项 2 —— #6132(`cel-to-filter` 第三入口)

**未触其面。** `cel-to-filter.ts` 从不调用 `classifyError`:它自建 `new Environment({ unlistedVariablesAreDyn: true, enableOptionalTypes: true })`(:93,注意**没有** `limits`、没有 stdlib —— 那正是 #6132 的问题),parse 失败在 :125 / :145 就地 catch,产出自己的 `reason: 'parse-error'` 词表(与 `kind` 是两套词)。本 PR 与它零交集。

**对 #6132 定价的参考价值**:本次审计给出了一条可复用的事实 —— cel-js 的错误**类与 code 是 public 契约**(`ParseError` / `EvaluationError` / `TypeError` 均在 `lib/index.d.ts` 导出,带 `readonly code: string`),而**文案不是**,因为文案里嵌着作者源码。#6132 若要把第三入口并回 `parseCelToAst`,其 `reason: 'parse-error'` 与本文的 `kind: 'parse'` 就是同一件事的两种拼写,合并时可以共用同一个结构化判定,不必各自维护一张关键词表。另:#6132 那个 env 缺 `limits`,意味着它今天对超限表达式**不产生** `limit_exceeded` —— 合并时这条会从"不报"变成"报 bounds",属于行为变更,值得单独钉一条 fixture。

## 必答项 3 —— #4812 / PR #6130 的 `parseCelToAst`

**不在 `classifyError` 路径上,实测确认。** `parseCelToAst`(`cel-engine.ts:241`)的 catch 是空的,直接 `return null`,从不构造 `EvalResult`、也从不读 kind:

```ts
} catch {
  return null;
}
```

已在 `cel-error-classification.test.ts` 最后一条用例把这个事实钉住(`parseCelToAst('((record.a)')` 返回 `null`,合法源码返回非 null)。所以本 PR 对 #6130 新增的入口零影响 —— 它把语法裁决留给 `compile()` / `validateExpression`,而后者拿到的正是被本 PR 修正的 kind。

## 风险

低。改动是一个函数内的一次前置判定,关键词表逐字保留作兜底;全部行为变化都在"改前判为 `runtime`/`type`、改后判为 `parse`"这一格,且该格改前的判定是**错的**。词表未扩、消费方未改、公开 API 签名未变。


---
_Generated by [Claude Code](https://claude.ai/code/session_019Q7oc7ASjh8yxyS3Yz78We)_