### PR TITLE
fix(rest): REST 面的执行上下文补齐 ADR-0090 D9/D10 的 principal 分类 (#6071)

### DIFF
--- a/.changeset/rest-exec-ctx-principal-kind.md
+++ b/.changeset/rest-exec-ctx-principal-kind.md
@@ -1,0 +1,37 @@
+---
+"@objectstack/rest": patch
+---
+
+fix(rest): REST 面的执行上下文补齐 ADR-0090 D9/D10 的 principal 分类(#6071)
+
+`resolveAuthzContext`(`@objectstack/core`)被提取出来,正是为了让两个 HTTP 入口
+不再在**授权**上漂移。但它之后的一步 —— 把授权信封组装成 `ExecutionContext` ——
+仍是两份手写副本,而两份的字段集已经不一致:runtime / dispatcher 那份
+(`packages/runtime/src/security/resolve-execution-context.ts`)按 ADR-0090 D9/D10
+设置 `principalKind`(必要时连同 `onBehalfOf`),`rest-server.ts` 的 `computeExecCtx`
+两个都不设。
+
+后果不在装饰面而在 enforcement 面:`plugin-security/explain-engine.ts` 的
+posture 下限、`security-plugin.ts` 的 agent 基线、`observability/perf-timing.ts`
+的披露闸门都读 `principalKind`,于是同一个请求走 dispatcher 与走 REST 会拿到不同
+的上下文,读这个字段的判断在 `os serve` / `dev` 的数据与元数据路由上**从不成立**。
+问题由 #5859 实施时的 dogfood 全栈 boot 插桩测得:到达消费方的键集里 `__kernel`
+在(自证是 rest-server 这条组装路径)、`principalKind` 不在。
+
+本次改动只补这一个传输上缺的字段,口径与 runtime 侧完全一致:
+
+- 会话(cookie)或 API key 背书的主体 ⇒ `principalKind: 'human'` —— 与 runtime
+  侧「an authenticated (API-key) request resolves as a human principal, never
+  guest」的钉子同一判定。
+- `'agent'` 与随之而来的 `onBehalfOf` **在本传输上不可表达**:它需要一个指明已授权
+  客户端的 OAuth access token,而该凭据只在 dispatcher 的 `/mcp` 门上被接受
+  (`acceptOAuthAccessToken`),正是为了不让粗粒度的工具族 scope 溜进 REST。
+- `'guest'` 同样不可表达:`computeExecCtx` 在信封没有 `userId` 时就返回
+  `undefined`,匿名 REST 调用者本来就拿不到任何上下文(随后被 `enforceAuth` 401)。
+  **匿名面零变化** —— 不给匿名调用者凭空发一个 guest 上下文。
+
+行为差量(逐条核过,无一条改变授权结果):`explain-engine.ts` 的 guest ⇒ `EXTERNAL`
+与 `security-plugin.ts` 的 agent 分支在 REST 面仍不成立(前者的 `!context?.userId`
+前肢本就恒真,后者读 `'agent'` 标签、且真正的兜底是委托 LINK);`perf-timing.ts`
+只认 `'service'` / `'system'`,`'human'` 不开闸。唯一可观测的新增是 explain 输出里
+多回显一个 `principalKind: 'human'`(该字段在 explain schema 中本就是 optional)。

--- a/packages/rest/src/rest-exec-ctx-principal-kind.test.ts
+++ b/packages/rest/src/rest-exec-ctx-principal-kind.test.ts
@@ -1,0 +1,220 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// #6071 — the REST transport's `authorization envelope → ExecutionContext`
+// assembly dropped the ADR-0090 D9/D10 principal taxonomy.
+//
+// `resolveAuthzContext` (@objectstack/core) was extracted so the two HTTP entry
+// points could never drift on AUTHORIZATION — but the step AFTER it, assembling
+// the ExecutionContext, is still two hand-written copies. The runtime /
+// dispatcher copy (`packages/runtime/src/security/resolve-execution-context.ts`)
+// set `principalKind` (+ `onBehalfOf` on the agent arm); the REST copy
+// (`rest-server.ts` `computeExecCtx`) set neither, so every enforcement-side
+// judgment that reads `principalKind` was silently NEVER-TRUE on the REST face
+// (explain's guest⇒EXTERNAL floor, the security plugin's agent baseline, the
+// perf-disclosure gate).
+//
+// The issue's own evidence was an instrumented dogfood boot printing the key
+// set of the context that ARRIVED at a consumer plugin — `__kernel` present
+// (proving the rest-server path), `principalKind` absent. These tests reproduce
+// that instrumentation on the wire: a real registered route, the real
+// `computeExecCtx` → `resolveAuthzContext` pipeline, and the captured context
+// the protocol actually receives.
+
+import { describe, it, expect, vi } from 'vitest';
+import { hashApiKey } from '@objectstack/core';
+import { runWithPerfDisclosure, type PerfDisclosureGate } from '@objectstack/observability';
+import { RestServer } from './rest-server';
+
+const TASK = {
+    name: 'task',
+    label: '任务',
+    fields: { id: { type: 'text', label: 'ID' }, title: { type: 'text', label: '标题' } },
+};
+
+const makeServer = () => ({
+    get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn(),
+    use: vi.fn(), listen: vi.fn(), close: vi.fn(),
+});
+
+const FUTURE = '2999-01-01T00:00:00Z';
+/** The raw API key `member1` presents; `sys_api_key` stores only its hash. */
+const RAW_API_KEY = 'osk_6071_rest_face';
+
+/**
+ * A fake data engine holding what a real deployment holds: one `sys_api_key`
+ * row for `member1`, a `member_default` grant for `member1` and an UNSCOPED
+ * `admin_full_access` grant for `admin1` (→ PLATFORM_ADMIN). Everything else
+ * resolves empty.
+ */
+const makeQl = () => ({
+    find: async (object: string, opts: any) => {
+        const where = opts?.where ?? {};
+        if (object === 'sys_api_key') {
+            const row = { id: 'k1', key: hashApiKey(RAW_API_KEY), revoked: false, user_id: 'member1', expires_at: FUTURE };
+            return Object.entries(where).every(([k, v]) => (row as any)[k] === v) ? [row] : [];
+        }
+        if (object === 'sys_user') return [{ id: where.id, email: `${where.id}@example.com` }];
+        if (object === 'sys_user_permission_set') {
+            if (where.user_id === 'admin1') return [{ permission_set_id: 'ps_admin', organization_id: null }];
+            if (where.user_id === 'member1') return [{ permission_set_id: 'ps_member', organization_id: null }];
+            return [];
+        }
+        if (object === 'sys_permission_set') {
+            const ids: string[] = where.id?.$in ?? [];
+            return [
+                ids.includes('ps_admin') ? { id: 'ps_admin', name: 'admin_full_access' } : null,
+                ids.includes('ps_member') ? { id: 'ps_member', name: 'member_default' } : null,
+            ].filter(Boolean);
+        }
+        return [];
+    },
+});
+
+/** A fake auth service whose session is keyed off the request's `cookie` header. */
+const makeAuth = () => ({
+    api: {
+        getSession: async ({ headers }: { headers: any }) => {
+            const cookie = headers?.get?.('cookie');
+            if (cookie === 'admin') return { user: { id: 'admin1' } };
+            if (cookie === 'member') return { user: { id: 'member1' } };
+            return undefined;
+        },
+    },
+});
+
+function makeRes() {
+    let status = 200;
+    const res: any = {
+        write: () => true,
+        end: () => {},
+        header: () => res,
+        status: (code: number) => { status = code; return res; },
+        json: (body: any) => { res._json = body; return res; },
+    };
+    return { res, getStatus: () => status, getJson: () => res._json };
+}
+
+/**
+ * Boot the REAL data route over a stub protocol. `findData` records the
+ * ExecutionContext the transport handed it — the instrumentation point of the
+ * issue, moved into a test.
+ */
+function boot() {
+    const seen: any[] = [];
+    const protocol: any = {
+        getMetaItems: vi.fn().mockResolvedValue({ items: [TASK] }),
+        findData: vi.fn(async (args: any) => { seen.push(args.context); return { object: 'task', records: [] }; }),
+    };
+    const rest = new RestServer(
+        makeServer() as any,
+        protocol as any,
+        {} as any,
+        undefined,              // kernelManager
+        undefined,              // envRegistry
+        undefined,              // defaultEnvironmentIdProvider
+        async () => makeAuth(), // authServiceProvider
+        async () => makeQl(),   // objectQLProvider
+    );
+    rest.registerRoutes();
+    const route = rest.getRoutes().find((r: any) => r.method === 'GET' && r.path === '/api/v1/data/:object');
+    expect(route).toBeDefined();
+    return { rest, route, seen, protocol };
+}
+
+/** Drive `GET /api/v1/data/task` with the given request headers. */
+async function request(headers: Record<string, string>) {
+    const { route, seen, protocol } = boot();
+    const out = makeRes();
+    await route!.handler({ method: 'GET', params: { object: 'task' }, query: {}, headers } as any, out.res);
+    return { ctx: seen[0], out, protocol };
+}
+
+describe('#6071 — REST-face ExecutionContext carries the ADR-0090 D9/D10 principal taxonomy', () => {
+    it('a session-backed request reaches the data layer with principalKind:human', async () => {
+        const { ctx, out } = await request({ cookie: 'member' });
+
+        expect(out.getStatus()).toBe(200);
+        expect(ctx?.userId).toBe('member1');
+        // The regression itself: the key was ABSENT from the key set the issue
+        // measured in a dogfood boot. Assert on the key set, not just the value,
+        // so re-dropping the field fails here even if some consumer defaults it.
+        expect(Object.keys(ctx)).toContain('principalKind');
+        expect(ctx.principalKind).toBe('human');
+    });
+
+    it('an API-key-backed request is a human principal too — the same verdict the runtime face pins', async () => {
+        // Runtime-side pin, verbatim in intent: "an authenticated (API-key)
+        // request resolves as a human principal, never guest"
+        // (packages/runtime/src/security/resolve-execution-context.test.ts).
+        // Same envelope, same provenance, same label — that is the drift closed.
+        const { ctx } = await request({ 'x-api-key': RAW_API_KEY });
+
+        expect(ctx?.userId).toBe('member1');
+        expect(ctx.principalKind).toBe('human');
+        expect(ctx.positions).not.toContain('guest');
+    });
+
+    it('leaves onBehalfOf ABSENT — this transport has no delegation provenance', async () => {
+        // `onBehalfOf` is set ONLY by the runtime resolver's agent arm, which
+        // needs an OAuth access token naming an authorized client. That
+        // credential is honoured on the `/mcp` door alone
+        // (`acceptOAuthAccessToken`), so no REST request can produce a delegated
+        // principal. Absent here == absent for every human principal on the
+        // dispatcher face; it is parity, not a second gap. If REST ever accepts
+        // an OAuth client credential, this pin is the thing that must change.
+        const { ctx } = await request({ cookie: 'member' });
+
+        expect(ctx.onBehalfOf).toBeUndefined();
+        expect(Object.keys(ctx)).not.toContain('onBehalfOf');
+        expect(ctx.principalKind).not.toBe('agent');
+    });
+
+    it('an anonymous request is UNCHANGED: no context at all, 401 — never a guest-labelled one', async () => {
+        // The guest arm of the runtime derivation is not representable here and
+        // is deliberately NOT reproduced: `computeExecCtx` returns undefined
+        // when the envelope carries no userId, so the anonymous REST face keeps
+        // its 401 (`enforceAuth`). Labelling anonymous callers `guest` here
+        // would hand them a context where they previously had none — a behaviour
+        // change well beyond D9/D10's declared intent.
+        const { ctx, out, protocol } = await request({});
+
+        expect(ctx).toBeUndefined();
+        expect(out.getStatus()).toBe(401);
+        expect(protocol.findData).not.toHaveBeenCalled();
+    });
+
+    it('the platform-admin principal is labelled human as well — the label is provenance, not privilege', async () => {
+        const { ctx } = await request({ cookie: 'admin' });
+
+        expect(ctx.principalKind).toBe('human');
+        // Posture keeps saying what it always said; the new field adds no
+        // authority of its own.
+        expect(ctx.posture).toBe('PLATFORM_ADMIN');
+    });
+});
+
+describe('#6071 — activated-branch pin: the perf-disclosure gate (perf-timing.ts:475)', () => {
+    // `isPerfDisclosurePrincipal` reads `principalKind` for 'service' / 'system'
+    // ONLY. The REST face produces neither, so labelling it 'human' cannot open
+    // the per-request `Server-Timing` disclosure — the gate keeps deciding on
+    // `isSystem` / `posture` exactly as before this change.
+    const resolveInGate = async (headers: Record<string, string>) => {
+        const { route } = boot();
+        const gate: PerfDisclosureGate = { allowed: false };
+        const out = makeRes();
+        await runWithPerfDisclosure(gate, () =>
+            route!.handler({ method: 'GET', params: { object: 'task' }, query: {}, headers } as any, out.res),
+        );
+        return gate;
+    };
+
+    it('stays CLOSED for the newly-labelled human member', async () => {
+        expect((await resolveInGate({ cookie: 'member' })).allowed).toBe(false);
+    });
+
+    it('still OPENS for a platform admin (posture, unchanged by the new label)', async () => {
+        const gate = await resolveInGate({ cookie: 'admin' });
+        expect(gate.allowed).toBe(true);
+        expect(gate.privileged).toBe(true);
+    });
+});

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -2404,6 +2404,38 @@ export class RestServer {
                 // enforcement side reads the SAME value the resolver computed,
                 // instead of dropping it here (the boundary this issue closes).
                 ...(authz.posture ? { posture: authz.posture } : {}),
+                // [ADR-0090 D9/D10 / #6071] Principal taxonomy, resolved by the
+                // SAME rule the runtime / MCP entry applies
+                // (`packages/runtime/src/security/resolve-execution-context.ts`)
+                // so the two transports can no longer disagree about WHO is
+                // asking. Enforcement reads this field
+                // (`plugin-security/explain-engine.ts` derivePosture,
+                // `security-plugin.ts` agent baseline, `perf-timing.ts`
+                // disclosure gate), and until now it arrived on the dispatcher
+                // face only — every such judgment was silently never-true on
+                // REST.
+                //
+                // `'human'` is the ONLY kind this transport can produce, and
+                // that is the runtime rule restricted to the provenances this
+                // door accepts, not a second derivation:
+                //  - `agent` (+ the `onBehalfOf` delegation link, which ONLY
+                //    the agent arm sets) requires an OAuth access token naming
+                //    an authorized client. This transport never accepts one:
+                //    OAuth bearers are honoured on the `/mcp` door alone
+                //    (`acceptOAuthAccessToken`, set solely by the dispatcher's
+                //    `/mcp` path match) precisely so coarse tool-family scopes
+                //    cannot ride onto REST. So `onBehalfOf` is not
+                //    representable here — same as every human principal on the
+                //    dispatcher face, which also leaves it undefined.
+                //  - `guest` is not representable either: this method returned
+                //    `undefined` above when the envelope carried no `userId`,
+                //    so an anonymous REST caller gets NO context at all (and
+                //    `enforceAuth` 401s it). Anonymous REST is unchanged.
+                //  - A session-backed OR API-key-backed principal is `human` on
+                //    both faces (pinned on the runtime side by
+                //    resolve-execution-context.test.ts, "an authenticated
+                //    (API-key) request resolves as a human principal").
+                principalKind: 'human',
                 isSystem: false,
                 org_user_ids: authz.org_user_ids,
                 // [ADR-0105 D2] The caller's org access set — the `group`


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6071

## 前提复核(先于实现)

在 `origin/main`(`80f7dc6a3`,rc.5 之后)实读,分诊结论仍成立:

- `packages/rest/src/rest-server.ts` —— `principalKind` **零命中**;阳性对照:`execCtx = {` 在 **:2395**(分诊时记的 :2390,微漂,不是路径写错)。
- `packages/runtime/src/security/resolve-execution-context.ts` —— :190 `ctx.principalKind = 'agent'`、:191 `ctx.onBehalfOf`、:217 `'human'`、:220 `'guest'` 四处仍在。

即:`resolveAuthzContext` 统一的是**授权**那一步,它之后「授权信封 → ExecutionContext」的组装仍是两份手写副本,而两份的字段集已经不一致。

## 改了什么

`computeExecCtx` 的 `execCtx` 组装补上 `principalKind`,口径**取自 runtime 侧的同一条规则**,而不是另起一套推导:

| provenance | runtime / dispatcher | REST(本 PR 之前) | REST(本 PR 之后) |
|:---|:---|:---|:---|
| better-auth 会话 | `human` | 不设 | `human` |
| API key(`osk_`) | `human` | 不设 | `human` |
| OAuth access token + `azp` | `agent` + `onBehalfOf` | 不可达 | 不可达(见下) |
| 匿名 | `guest` + `positions:['guest']` | 无上下文(`undefined`) | 无上下文(不变) |

两个 kind 在本传输上**结构性不可表达**,PR 里把理由写进了代码注释,而不是留一条永远为假的死分支:

- `agent`(以及只由该分支设置的 `onBehalfOf`):需要一个指明已授权客户端的 OAuth access token。该凭据只在 dispatcher 的 `/mcp` 门被接受(`acceptOAuthAccessToken` 只在那条路径置位),这本身就是刻意的 —— 粗粒度的工具族 scope 不该溜到 REST/GraphQL 面。所以 REST 面没有委托来源,`onBehalfOf` 缺席;这与 dispatcher 面上**每一个 human 主体**的状态一致(那边也不设),是**同口径,不是第二个缺口**。
- `guest`:`computeExecCtx` 在信封没有 `userId` 时提前 `return undefined`,匿名 REST 调用者本来就拿不到任何上下文,随后由 `enforceAuth` 401。**没有把 guest 那条肢体搬过来** —— 那需要改掉这个提前返回,等于凭空给匿名调用者发一个上下文,是远超 D9/D10 声明意图的行为变更。

⛔ 按分诊钉死的边界:**没有**把两份组装收敛成 `@objectstack/core` 的共享函数(设计形状,另立单);**没有**把 `principalKind` 收窄成三值枚举(`'service'` / `'system'` 是活值,`perf-timing.ts:475` 在读)。同口径**不需要**收敛即可保证:REST 面可达的 provenance 只有会话与 API key 两种,两种在 runtime 侧都判 `human`,并有该侧的钉子作证(见下)。

## 必答项:被激活的判断,逐条枚举与行为差量

这次改动让 REST 面上从未成立过的分支第一次**有机会**成立。逐条核过后的结论是:**没有任何一条改变授权结果**,guest 面也没有从宽变严。

| # | 消费点 | 读的是什么 | REST 面差量 | 判定 |
|:--|:---|:---|:---|:---|
| 1 | `plugin-security/src/explain-engine.ts:95` | `!context?.userId \|\| context?.principalKind === 'guest'` ⇒ `EXTERNAL` | **不激活**。REST 面产不出 guest 上下文(上文的提前返回);而对匿名请求,这一判断的**前肢 `!context?.userId` 本来就恒真**,判定早已是 `EXTERNAL`。新写的 `'human'` 两肢皆不命中 | 零差量 |
| 2 | `plugin-security/src/security-plugin.ts:2679` | `const isAgent = context?.principalKind === 'agent'` | **不激活**。REST 面永远不产出 `'agent'`;`'human' !== 'agent'` 与原先 `undefined !== 'agent'` 同值,基线仍走 human 的 additive `member_default`,一字不改。issue 自己给的线索也核过了::950 明说真正的触发器是**委托 LINK**(`onBehalfOf`)而非标签,而 `onBehalfOf` 我们也不写 —— 所以那条兜底同样不动 | 零差量 |
| 3 | `packages/runtime/src/action-execution.ts:1025` | `ec?.principalKind === 'agent'` ⇒ 审计行追加 `(AGENT on behalf of …)` | **不激活**,同 #2。审计文案逐字不变 | 零差量 |
| 4 | `packages/observability/src/perf-timing.ts:475` | `principalKind === 'service' \|\| === 'system'` | **不激活**:`'human'` 不在集合里,闸门仍由 `isSystem` / `posture` 决定。已用**真实**的 `runWithPerfDisclosure` + 真实路由钉住:member 面闸门仍关、admin 面仍按 `PLATFORM_ADMIN` 开 | 零差量 |
| 5 | `plugin-security/src/explain-engine.ts:1122` | `...(context?.principalKind ? { principalKind } : {})` | **唯一可观测的新增**:REST 解析出的上下文进 explain 时,`decision.principal` 多回显一个 `principalKind: 'human'`。该字段在 `packages/spec/src/security/explain.zod.ts:260` 本就是 `.optional()`,是**增信息**而非改判定 —— 而且这正是 D9/D10 想要的:explain 面板从此说得出「谁在问」 | 纯增量,非授权结果 |

一句话:`'human'` 这个值在整套 enforcement 里**没有任何消费点以它为条件**(所有读点都是与 `'guest'` / `'agent'` / `'service'` / `'system'` 的单值相等比较),所以补上它在今天是**零授权差量**;它的价值是让 REST 面从此**带着 provenance**,下一个按 D9/D10 写判断的人不必再问「这个字段在这条路上到底有没有」。

## 测试

新增 `packages/rest/src/rest-exec-ctx-principal-kind.test.ts` —— 不是单层单测,而是把 issue 的插桩搬进测试:真实注册的 `GET /api/v1/data/:object` 路由 → 真实 `computeExecCtx` → 真实 `resolveAuthzContext`,断言**到达 protocol 的那个 context**(issue 当时在 dogfood boot 里打印的正是这个对象的键集)。

- 会话请求:`Object.keys(ctx)` **含** `principalKind`(对键集断言,而不是只断言值 —— 这样即便某个消费方将来给了默认值,把字段再丢一次仍然红这里)且为 `'human'`。
- API key 请求(`sys_api_key` 真行 + `hashApiKey`):同样 `'human'`、`positions` 不含 `guest` —— 与 runtime 侧那条钉子「an authenticated (API-key) request resolves as a human principal, never guest」是同一判定,这就是被关掉的漂移。
- `onBehalfOf` 缺席,并写明**它必须缺席的理由**,以及「REST 若哪天接受 OAuth 客户端凭据,第一个该改的就是这条钉子」。
- 匿名请求:仍然 `ctx === undefined`、401、`findData` 未被调用 —— **guest 面零变化**的钉子。
- 激活分支 #4:真实 `runWithPerfDisclosure` 下,member 关、admin 开。

```
pnpm --filter @objectstack/rest test
 Test Files  63 passed (63)
      Tests  861 passed (861)
```

`packages/rest` 无 `typecheck` 脚本(在 `check-type-check-coverage` 的台账里),故本包无 tsc 结果可报;改动经 `tsup` 构建与 ESLint 面把关。

## 范围外(已核,未改,供后续单参考)

- `rest-server.ts:6567` 附近公共表单 submit 自建的那个上下文(`{ publicFormGrant, permissions:['guest_portal'], anonymous:true }`)是一条**刻意窄化的非主体上下文**,不走授权信封,不属于本单说的那两份组装,原样未动。
- 「把两份组装收敛成一处共享函数」按分诊第 2 条**未做**。真要立那一单时,本 PR 已经把两个传输各自可达的 provenance 集合写清楚了 —— 收敛的难点不在字段拷贝,而在匿名面:dispatcher 发 guest 上下文、REST 发 `undefined`,收敛前必须先裁决这一条。

Refs:#5859、#5852、ADR-0090 D9/D10、ADR-0095 D2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wbxm29qPKnLf44AbSxizqW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wbxm29qPKnLf44AbSxizqW)_