### PR TITLE
fix(objectql): 集合算子的标量比较值答 400 INVALID_FILTER 并点名期望形状,不再 500 (#5869)

### DIFF
--- a/.changeset/collection-operator-scalar-comparand-400.md
+++ b/.changeset/collection-operator-scalar-comparand-400.md
@@ -1,0 +1,15 @@
+---
+"@objectstack/objectql": patch
+---
+
+fix(objectql): 集合算子的标量比较值答 400 INVALID_FILTER 并点名期望形状,不再 500 DATABASE_ERROR
+
+`FieldOperatorsSchema` 声明 `$in` / `$nin` 的比较值是数组、`$between` 是 `[min, max]` 二元组,但入口处没有任何一层强制这条声明:`isFilterAST` 只看算子,`parseFilterAST` 照单下降,于是 `['status', 'not_in', 'done']` 变成 `{ status: { $nin: 'done' } }` 一路走到驱动。
+
+**行为变化(用户可见)**:此前 `driver-sql` 把标量交给 `whereIn(field, scalar)`,答 **500 `DATABASE_ERROR`** —— 用服务端故障码报告一个调用方能自己改好的过滤器,且不说明是哪个算子、哪个字段、该写成什么。现在引擎在唯一收口点拒收,答 **400 `INVALID_FILTER`**,信息点名算子(同时给出 `not_in` / `nin` / `notin` 这类作者实际书写的拼法)、字段、收到的值与位置、以及可直接粘贴的正确形状,并声明该过滤器**未被应用**。
+
+覆盖两道门:直接调用引擎(`FilterArray` 下降路径)与 HTTP 面(协议层已自行下降成 `FilterCondition` 对象后再交给引擎)—— 后者正是本问题实测到的那道门。`find` / `findOne` / `count` / `aggregate` / `update` / `delete` 六个入口一致。
+
+`$between` 的非二元组比较值一并收在同一处:`driver-sql` 与 `driver-memory` 各自已经拒收(措辞保持逐字一致),`driver-mongodb` 的分支则直接落空、不发射区间谓词 —— 收在收口点后三家答案一致。
+
+**不变的**:`$in: []` / `$nin: []` 仍是合法谓词(分别表示「不匹配任何行」与「匹配所有行」);列表**成员**的类型不在此处复判(那是 #5234,另一个面);非集合算子的标量比较值不受影响,包括 `$gt` 的 ISO 日期字符串这类 `FieldOperatorsSchema` 声明更严、而各后端一致接受的形状。

--- a/packages/objectql/src/engine-filter-array-lowering.test.ts
+++ b/packages/objectql/src/engine-filter-array-lowering.test.ts
@@ -304,6 +304,197 @@ describe('Door 2 lowers FilterArray to FilterCondition before the driver (#5158)
     expect(reads).toHaveLength(0);
   });
 
+  // ── #5869: the list-shaped operators' comparands ──────────────────────
+  //
+  // `isFilterAST` vouches for the OPERATOR and nothing else, and
+  // `parseFilterAST` lowers whatever comparand it is handed. So the shapes
+  // below passed both, reached the driver, and — on driver-sql, via
+  // `whereIn(field, scalar)` — came back as `500 DATABASE_ERROR`: a
+  // server-fault code for a filter the caller can fix, naming neither the
+  // operator nor the field. Same collection point, same envelope as the
+  // refusals above.
+
+  it.each([
+    ['not_in', [['stage', 'not_in', 'won']]],
+    ['nin', [['stage', 'nin', 'won']]],
+    ['notin', [['stage', 'notin', 'won']]],
+    ['in', [['stage', 'in', 'won']]],
+  ])('refuses a scalar comparand on the collection operator %s', async (_op, where) => {
+    await expect(engine.find('deal', { where } as any))
+      .rejects.toMatchObject({ status: 400, code: 'INVALID_FILTER' });
+    // Nothing ran: a refused filter must not reach the driver at all, or the
+    // 400 would be describing a query that already returned rows.
+    expect(reads).toHaveLength(0);
+  });
+
+  it('the refusal NAMES the operator, the field and the expected shape (#5346/#5348 wording)', async () => {
+    const err = await engine.find('deal', { where: [['stage', 'not_in', 'won']] } as any)
+      .then(() => null, (e: any) => e);
+
+    expect(err).not.toBeNull();
+    // The entry point that refused, matching the sibling refusals above.
+    expect(err.message).toMatch(/^find\('deal'\): /);
+    // The operator, in the lowered spelling…
+    expect(err.message).toMatch(/Operator "\$nin"/);
+    // …and in the spellings an author actually types on a ViewFilterRule —
+    // nobody writes `$nin` into metadata, so a refusal naming only the lowered
+    // form sends them looking for a key their file does not contain.
+    expect(err.message).toMatch(/not_in/);
+    // The member.
+    expect(err.message).toMatch(/field "stage"/);
+    // What was received, and where.
+    expect(err.message).toMatch(/Received string \("won"\)/);
+    expect(err.message).toMatch(/where\.stage\.\$nin/);
+    // The expected shape, as a value the caller can paste.
+    expect(err.message).toMatch(/\["won"\]/);
+    // The alternative, for the caller who meant a scalar comparison.
+    expect(err.message).toMatch(/"!=" \(\$ne\)/);
+    // And the part a status code cannot carry.
+    expect(err.message).toMatch(/NOT applied/);
+    expect(err.message).toMatch(/UNFILTERED result set/);
+  });
+
+  it('the whole refusal survives the REST boundary — it fits under CLIENT_MESSAGE_MAX', async () => {
+    // `rest-server.ts` truncates a declared-4xx message at 500 chars before it
+    // reaches the client (#5423 made it a truncation rather than a swap). The
+    // "NOT applied" sentence is the part a caller cannot infer from a status
+    // code, and it sits at the END — so a message that overflows loses exactly
+    // the sentence the refusal exists to deliver. Pinned here rather than
+    // trusted, because the bound lives in another package.
+    const CLIENT_MESSAGE_MAX = 500;
+    for (const where of [
+      [['stage', 'not_in', 'won']],
+      [['stage', 'in', 'won']],
+      [['amount', 'between', 5]],
+    ]) {
+      const err = await engine.find('deal', { where } as any)
+        .then(() => null, (e: any) => e);
+      expect(err.message.length, JSON.stringify(where)).toBeLessThan(CLIENT_MESSAGE_MAX);
+      expect(err.message, JSON.stringify(where)).toMatch(/UNFILTERED result set/);
+    }
+  });
+
+  it('refuses through the OBJECT door too — the door #5869 was measured through', async () => {
+    // The protocol/HTTP face runs its own `isFilterAST` → `parseFilterAST` and
+    // hands the engine an already-lowered FilterCondition, so the array branch
+    // above never sees a wire query. This is that shape, arriving as an object.
+    await expect(engine.find('deal', { where: { stage: { $nin: 'won' } } } as any))
+      .rejects.toMatchObject({ status: 400, code: 'INVALID_FILTER' });
+    await expect(engine.find('deal', { where: { stage: { $in: 'won' } } } as any))
+      .rejects.toMatchObject({ status: 400, code: 'INVALID_FILTER' });
+  });
+
+  it.each([
+    ['null', { stage: { $in: null } }],
+    ['a number', { amount: { $in: 10 } }],
+    ['an object', { stage: { $in: { a: 1 } } }],
+  ])('refuses a comparand that is %s — every non-list, not just strings', async (_l, where) => {
+    await expect(engine.find('deal', { where } as any))
+      .rejects.toMatchObject({ status: 400, code: 'INVALID_FILTER' });
+  });
+
+  it('walks into $and / $or / $not — a nested scalar is refused with its own path', async () => {
+    const err = await engine.find('deal', {
+      where: ['and', ['amount', '>', 5], ['stage', 'not_in', 'won']],
+    } as any).then(() => null, (e: any) => e);
+    expect(err?.status).toBe(400);
+    expect(err.message).toMatch(/where\.\$and\[1\]\.stage\.\$nin/);
+
+    await expect(engine.find('deal', { where: { $not: { stage: { $in: 'won' } } } } as any))
+      .rejects.toMatchObject({ status: 400, code: 'INVALID_FILTER' });
+  });
+
+  it('every engine entry point refuses it, not just find()', async () => {
+    const where = [['stage', 'not_in', 'won']];
+    await expect(engine.findOne('deal', { where } as any)).rejects.toMatchObject({ status: 400 });
+    await expect(engine.count('deal', { where } as any)).rejects.toMatchObject({ status: 400 });
+    await expect(engine.aggregate('deal', {
+      where, groupBy: ['stage'], aggregations: [{ function: 'count', field: 'id', alias: 'n' }],
+    } as any)).rejects.toMatchObject({ status: 400 });
+    await expect(engine.update('deal', { amount: 1 }, { where, multi: true } as any))
+      .rejects.toMatchObject({ status: 400 });
+    await expect(engine.delete('deal', { where, multi: true } as any))
+      .rejects.toMatchObject({ status: 400 });
+    // Refused before any of them touched the store.
+    expect(reads).toHaveLength(0);
+    expect(writes).toHaveLength(0);
+    expect(await engine.count('deal')).toBe(3);
+  });
+
+  // `$between`'s arity, hoisted to the same seam. driver-sql and driver-memory
+  // each already refuse this (#5328); driver-mongodb's arm falls through
+  // without emitting a range predicate. Checking here is what makes the three
+  // agree — the same reason the collection point exists.
+  it.each([
+    ['a scalar', [['amount', 'between', 5]]],
+    ['a 1-tuple', [['amount', 'between', [1]]]],
+    ['a 3-tuple', [['amount', 'between', [1, 2, 3]]]],
+  ])('refuses a $between comparand that is %s', async (_l, where) => {
+    await expect(engine.find('deal', { where } as any))
+      .rejects.toMatchObject({ status: 400, code: 'INVALID_FILTER' });
+  });
+
+  it('the $between refusal keeps the platform-wide wording and names the field', async () => {
+    const err = await engine.find('deal', { where: [['amount', 'between', 5]] } as any)
+      .then(() => null, (e: any) => e);
+    // Verbatim leading sentence from driver-sql / driver-memory: one condition,
+    // one wording, wherever the caller meets it.
+    expect(err.message).toMatch(
+      /Operator "\$between" on field "amount" requires a \[min, max\] value array\./,
+    );
+    expect(err.message).toMatch(/where\.amount\.\$between/);
+  });
+
+  // ── what must KEEP working: the declared list shapes ───────────────────
+
+  it('a proper list comparand still reaches the driver untouched', async () => {
+    await engine.find('deal', { where: [['stage', 'in', ['won', 'lost']]] } as any);
+    expect(lastWhere()).toEqual({ stage: { $in: ['won', 'lost'] } });
+
+    await engine.find('deal', { where: [['stage', 'not_in', ['lost']]] } as any);
+    expect(lastWhere()).toEqual({ stage: { $nin: ['lost'] } });
+
+    await engine.find('deal', { where: [['amount', 'between', [5, 25]]] } as any);
+    expect(lastWhere()).toEqual({ amount: { $between: [5, 25] } });
+  });
+
+  it('an EMPTY list is a declared predicate, not a malformed one', async () => {
+    // `$in: []` matches nothing and `$nin: []` matches everything — both
+    // drivers say so in as many words. Arity is not this gate's business.
+    await engine.find('deal', { where: { stage: { $in: [] } } } as any);
+    expect(lastWhere()).toEqual({ stage: { $in: [] } });
+    await engine.find('deal', { where: { stage: { $nin: [] } } } as any);
+    expect(lastWhere()).toEqual({ stage: { $nin: [] } });
+  });
+
+  it('the gate does not re-judge list MEMBERS — that is #5234, on another face', async () => {
+    // A `$field` reference and a plain object are both legitimate members here;
+    // this gate asks only whether the comparand is a list at all.
+    const where = { stage: { $in: [{ $field: 'other' }, 'won'] } };
+    await engine.find('deal', { where } as any);
+    expect(lastWhere()).toEqual(where);
+  });
+
+  it('does not descend into a deep-equality comparand that merely LOOKS like an operator map', async () => {
+    // `{ $eq: {...} }` holds DATA. A gate that walked into it would refuse a
+    // stored document whose own key happens to be `$in` — a stricter contract
+    // than any backend applies.
+    const where = { stage: { $eq: { $in: 'not-an-operator-here' } } };
+    await engine.find('deal', { where } as any);
+    expect(lastWhere()).toEqual(where);
+  });
+
+  it('a scalar on a NON-collection operator is untouched', async () => {
+    await engine.find('deal', { where: [['stage', '!=', 'won']] } as any);
+    expect(lastWhere()).toEqual({ stage: { $ne: 'won' } });
+    // String bounds on a range comparison stay legal — `FieldOperatorsSchema`
+    // declares `$gt` as number|Date|FieldReference, but ISO strings are what the
+    // showcase apps send and every backend accepts. This gate enforces the
+    // three list declarations, not the whole schema.
+    await engine.find('deal', { where: [['stage', '>', '2026-01-01']] } as any);
+    expect(lastWhere()).toEqual({ stage: { $gt: '2026-01-01' } });
+  });
+
   // ── the object form is untouched ──────────────────────────────────────
 
   it('a FilterCondition object passes through byte-for-byte', async () => {

--- a/packages/objectql/src/engine-filter-array-lowering.test.ts
+++ b/packages/objectql/src/engine-filter-array-lowering.test.ts
@@ -26,7 +26,31 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
+import type {
+  EngineAggregateOptions,
+  EngineCountOptions,
+  EngineQueryOptions,
+} from '@objectstack/spec/data';
 import { ObjectQL } from './engine.js';
+
+/**
+ * [#4918] `FilterArray` on `where` is off-contract BY DECLARATION, and these
+ * tests exist to drive it: `EngineQueryOptions.where` is a `FilterCondition` /
+ * `Record< string, unknown >`, which an array is not assignable to, because
+ * `FilterArray` is INPUT-ONLY authoring sugar the spec deliberately excludes
+ * (#5285). So a test that hands the engine one has to say so, and
+ * `as unknown as EngineQueryOptions` is how: it names the contract being
+ * bypassed, keeps the rest of the call type-checked, and greps as an
+ * intentional act — none of which a bare `as any` does.
+ *
+ * Deliberately NOT used for the malformed-COMPARAND cases below
+ * (`{ stage: { $nin: 'won' } }`). Those are ordinary objects that `tsc`
+ * accepts, because `where` is declared loosely on purpose — which is the whole
+ * reason the runtime gate this file pins has to exist. Erasing them would hide
+ * that they are type-legal, which is the point.
+ */
+const asFilterArrayQuery = (where: unknown): EngineQueryOptions =>
+  ({ where }) as unknown as EngineQueryOptions;
 
 const deal = {
   name: 'deal',
@@ -320,7 +344,7 @@ describe('Door 2 lowers FilterArray to FilterCondition before the driver (#5158)
     ['notin', [['stage', 'notin', 'won']]],
     ['in', [['stage', 'in', 'won']]],
   ])('refuses a scalar comparand on the collection operator %s', async (_op, where) => {
-    await expect(engine.find('deal', { where } as any))
+    await expect(engine.find('deal', asFilterArrayQuery(where)))
       .rejects.toMatchObject({ status: 400, code: 'INVALID_FILTER' });
     // Nothing ran: a refused filter must not reach the driver at all, or the
     // 400 would be describing a query that already returned rows.
@@ -328,7 +352,7 @@ describe('Door 2 lowers FilterArray to FilterCondition before the driver (#5158)
   });
 
   it('the refusal NAMES the operator, the field and the expected shape (#5346/#5348 wording)', async () => {
-    const err = await engine.find('deal', { where: [['stage', 'not_in', 'won']] } as any)
+    const err = await engine.find('deal', asFilterArrayQuery([['stage', 'not_in', 'won']]))
       .then(() => null, (e: any) => e);
 
     expect(err).not.toBeNull();
@@ -367,7 +391,7 @@ describe('Door 2 lowers FilterArray to FilterCondition before the driver (#5158)
       [['stage', 'in', 'won']],
       [['amount', 'between', 5]],
     ]) {
-      const err = await engine.find('deal', { where } as any)
+      const err = await engine.find('deal', asFilterArrayQuery(where))
         .then(() => null, (e: any) => e);
       expect(err.message.length, JSON.stringify(where)).toBeLessThan(CLIENT_MESSAGE_MAX);
       expect(err.message, JSON.stringify(where)).toMatch(/UNFILTERED result set/);
@@ -378,9 +402,12 @@ describe('Door 2 lowers FilterArray to FilterCondition before the driver (#5158)
     // The protocol/HTTP face runs its own `isFilterAST` → `parseFilterAST` and
     // hands the engine an already-lowered FilterCondition, so the array branch
     // above never sees a wire query. This is that shape, arriving as an object.
-    await expect(engine.find('deal', { where: { stage: { $nin: 'won' } } } as any))
+    // NOT erased: `where` is declared `Record< string, unknown >`, so `tsc`
+    // accepts a malformed comparand. That it type-checks and still has to be
+    // refused at runtime is exactly why this gate exists.
+    await expect(engine.find('deal', { where: { stage: { $nin: 'won' } } }))
       .rejects.toMatchObject({ status: 400, code: 'INVALID_FILTER' });
-    await expect(engine.find('deal', { where: { stage: { $in: 'won' } } } as any))
+    await expect(engine.find('deal', { where: { stage: { $in: 'won' } } }))
       .rejects.toMatchObject({ status: 400, code: 'INVALID_FILTER' });
   });
 
@@ -389,28 +416,31 @@ describe('Door 2 lowers FilterArray to FilterCondition before the driver (#5158)
     ['a number', { amount: { $in: 10 } }],
     ['an object', { stage: { $in: { a: 1 } } }],
   ])('refuses a comparand that is %s — every non-list, not just strings', async (_l, where) => {
-    await expect(engine.find('deal', { where } as any))
+    await expect(engine.find('deal', { where }))
       .rejects.toMatchObject({ status: 400, code: 'INVALID_FILTER' });
   });
 
   it('walks into $and / $or / $not — a nested scalar is refused with its own path', async () => {
-    const err = await engine.find('deal', {
-      where: ['and', ['amount', '>', 5], ['stage', 'not_in', 'won']],
-    } as any).then(() => null, (e: any) => e);
+    const err = await engine.find(
+      'deal',
+      asFilterArrayQuery(['and', ['amount', '>', 5], ['stage', 'not_in', 'won']]),
+    ).then(() => null, (e: any) => e);
     expect(err?.status).toBe(400);
     expect(err.message).toMatch(/where\.\$and\[1\]\.stage\.\$nin/);
 
-    await expect(engine.find('deal', { where: { $not: { stage: { $in: 'won' } } } } as any))
+    await expect(engine.find('deal', { where: { $not: { stage: { $in: 'won' } } } }))
       .rejects.toMatchObject({ status: 400, code: 'INVALID_FILTER' });
   });
 
   it('every engine entry point refuses it, not just find()', async () => {
     const where = [['stage', 'not_in', 'won']];
-    await expect(engine.findOne('deal', { where } as any)).rejects.toMatchObject({ status: 400 });
-    await expect(engine.count('deal', { where } as any)).rejects.toMatchObject({ status: 400 });
+    await expect(engine.findOne('deal', asFilterArrayQuery(where)))
+      .rejects.toMatchObject({ status: 400 });
+    await expect(engine.count('deal', { where } as unknown as EngineCountOptions))
+      .rejects.toMatchObject({ status: 400 });
     await expect(engine.aggregate('deal', {
       where, groupBy: ['stage'], aggregations: [{ function: 'count', field: 'id', alias: 'n' }],
-    } as any)).rejects.toMatchObject({ status: 400 });
+    } as unknown as EngineAggregateOptions)).rejects.toMatchObject({ status: 400 });
     await expect(engine.update('deal', { amount: 1 }, { where, multi: true } as any))
       .rejects.toMatchObject({ status: 400 });
     await expect(engine.delete('deal', { where, multi: true } as any))
@@ -430,12 +460,12 @@ describe('Door 2 lowers FilterArray to FilterCondition before the driver (#5158)
     ['a 1-tuple', [['amount', 'between', [1]]]],
     ['a 3-tuple', [['amount', 'between', [1, 2, 3]]]],
   ])('refuses a $between comparand that is %s', async (_l, where) => {
-    await expect(engine.find('deal', { where } as any))
+    await expect(engine.find('deal', asFilterArrayQuery(where)))
       .rejects.toMatchObject({ status: 400, code: 'INVALID_FILTER' });
   });
 
   it('the $between refusal keeps the platform-wide wording and names the field', async () => {
-    const err = await engine.find('deal', { where: [['amount', 'between', 5]] } as any)
+    const err = await engine.find('deal', asFilterArrayQuery([['amount', 'between', 5]]))
       .then(() => null, (e: any) => e);
     // Verbatim leading sentence from driver-sql / driver-memory: one condition,
     // one wording, wherever the caller meets it.
@@ -448,22 +478,22 @@ describe('Door 2 lowers FilterArray to FilterCondition before the driver (#5158)
   // ── what must KEEP working: the declared list shapes ───────────────────
 
   it('a proper list comparand still reaches the driver untouched', async () => {
-    await engine.find('deal', { where: [['stage', 'in', ['won', 'lost']]] } as any);
+    await engine.find('deal', asFilterArrayQuery([['stage', 'in', ['won', 'lost']]]));
     expect(lastWhere()).toEqual({ stage: { $in: ['won', 'lost'] } });
 
-    await engine.find('deal', { where: [['stage', 'not_in', ['lost']]] } as any);
+    await engine.find('deal', asFilterArrayQuery([['stage', 'not_in', ['lost']]]));
     expect(lastWhere()).toEqual({ stage: { $nin: ['lost'] } });
 
-    await engine.find('deal', { where: [['amount', 'between', [5, 25]]] } as any);
+    await engine.find('deal', asFilterArrayQuery([['amount', 'between', [5, 25]]]));
     expect(lastWhere()).toEqual({ amount: { $between: [5, 25] } });
   });
 
   it('an EMPTY list is a declared predicate, not a malformed one', async () => {
     // `$in: []` matches nothing and `$nin: []` matches everything — both
     // drivers say so in as many words. Arity is not this gate's business.
-    await engine.find('deal', { where: { stage: { $in: [] } } } as any);
+    await engine.find('deal', { where: { stage: { $in: [] } } });
     expect(lastWhere()).toEqual({ stage: { $in: [] } });
-    await engine.find('deal', { where: { stage: { $nin: [] } } } as any);
+    await engine.find('deal', { where: { stage: { $nin: [] } } });
     expect(lastWhere()).toEqual({ stage: { $nin: [] } });
   });
 
@@ -471,7 +501,7 @@ describe('Door 2 lowers FilterArray to FilterCondition before the driver (#5158)
     // A `$field` reference and a plain object are both legitimate members here;
     // this gate asks only whether the comparand is a list at all.
     const where = { stage: { $in: [{ $field: 'other' }, 'won'] } };
-    await engine.find('deal', { where } as any);
+    await engine.find('deal', { where });
     expect(lastWhere()).toEqual(where);
   });
 
@@ -480,18 +510,18 @@ describe('Door 2 lowers FilterArray to FilterCondition before the driver (#5158)
     // stored document whose own key happens to be `$in` — a stricter contract
     // than any backend applies.
     const where = { stage: { $eq: { $in: 'not-an-operator-here' } } };
-    await engine.find('deal', { where } as any);
+    await engine.find('deal', { where });
     expect(lastWhere()).toEqual(where);
   });
 
   it('a scalar on a NON-collection operator is untouched', async () => {
-    await engine.find('deal', { where: [['stage', '!=', 'won']] } as any);
+    await engine.find('deal', asFilterArrayQuery([['stage', '!=', 'won']]));
     expect(lastWhere()).toEqual({ stage: { $ne: 'won' } });
     // String bounds on a range comparison stay legal — `FieldOperatorsSchema`
     // declares `$gt` as number|Date|FieldReference, but ISO strings are what the
     // showcase apps send and every backend accepts. This gate enforces the
     // three list declarations, not the whole schema.
-    await engine.find('deal', { where: [['stage', '>', '2026-01-01']] } as any);
+    await engine.find('deal', asFilterArrayQuery([['stage', '>', '2026-01-01']]));
     expect(lastWhere()).toEqual({ stage: { $gt: '2026-01-01' } });
   });
 

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -21,6 +21,7 @@ import { parseAutonumberFormat, renderAutonumber, missingFieldValues, isTenancyD
 // [#5158] Door 2's lowering sink — the SAME pair the protocol face (Door 1)
 // runs, so `FilterArray` has exactly one lowering in the product.
 import { isFilterAST, parseFilterAST, VALID_AST_OPERATORS } from '@objectstack/spec/data';
+import { assertListComparandShapes } from './filter-comparand-shape.js';
 import {
   DATA_MIGRATION_FLAG_OBJECT,
   FILE_REFERENCES_MIGRATION_ID,
@@ -451,7 +452,16 @@ function lowerWhereFilterArray<T extends object | undefined>(
 ): T {
   if (!bag) return bag;
   const where = (bag as Record<string, unknown>).where;
-  if (!Array.isArray(where)) return bag;
+  if (!Array.isArray(where)) {
+    // [#5869] Door 1 lands HERE, not below: the protocol face runs its own
+    // `isFilterAST` → `parseFilterAST` and hands the engine an already-lowered
+    // `FilterCondition` object, so a gate on the array branch alone would miss
+    // every query that arrived over the wire. The comparand check is the same
+    // one either way — it reads the lowered condition, which is what both doors
+    // produce.
+    assertListComparandShapes(object, operation, where);
+    return bag;
+  }
 
   const lowered: Record<string, unknown> = { ...bag };
 
@@ -488,6 +498,11 @@ function lowerWhereFilterArray<T extends object | undefined>(
       `unfiltered (#5158).`,
     );
   }
+  // [#5869] Door 2's half of the same check. `isFilterAST` vouched for the
+  // OPERATOR and `parseFilterAST` lowered it, but neither looks at the
+  // comparand — `['status', 'not_in', 'done']` lowers to `{status: {$nin:
+  // 'done'}}` and a scalar `$nin` is what reached the driver as a 500.
+  assertListComparandShapes(object, operation, condition);
   lowered.where = condition;
   return lowered as T;
 }

--- a/packages/objectql/src/filter-comparand-shape.ts
+++ b/packages/objectql/src/filter-comparand-shape.ts
@@ -1,0 +1,279 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#5869] The comparand-shape gate for the LIST-SHAPED filter operators, at the
+ * engine's single filter collection point.
+ *
+ * `FieldOperatorsSchema` (`spec/data/filter.zod.ts`) declares three operators
+ * whose comparand is a LIST rather than a scalar:
+ *
+ * ```
+ * $in:      z.array(z.any())
+ * $nin:     z.array(z.any())
+ * $between: z.tuple([min, max])
+ * ```
+ *
+ * Nothing enforced that declaration on the way in. `isFilterAST` checks the
+ * OPERATOR and the tuple's arity, never the comparand's shape, and
+ * `parseFilterAST` lowers `['status', 'not_in', 'done']` to
+ * `{ status: { $nin: 'done' } }` without complaint — so a scalar reached the
+ * driver, where each backend answered differently:
+ *
+ * | comparand              | driver-sql            | driver-memory        | driver-mongodb    |
+ * |:-----------------------|:----------------------|:---------------------|:------------------|
+ * | `$in` / `$nin` scalar  | `whereIn(f, scalar)` → **500 DATABASE_ERROR** | evaluated as-is | emitted as-is |
+ * | `$between` non-2-tuple | refused, 400          | refused, 400 (#5328) | arm falls through, no range predicate |
+ *
+ * The 500 is the reported defect (#5869): a server-fault code for a filter the
+ * CALLER can fix, with no word about which operator, which field, or what shape
+ * was expected. It is also reachable from spec-VALID authoring —
+ * `ViewFilterRuleSchema.value` is `string | number | boolean | null | (string |
+ * number)[]` and does not constrain the value by operator, so
+ * `{ field: 'status', operator: 'not_in', value: 'done' }` publishes cleanly and
+ * 500s on first render.
+ *
+ * ## Why here and not in each driver
+ *
+ * The table above IS the argument: three backends, three answers, one declared
+ * contract. `driver-memory` already carries a shape gate
+ * (`filter-refusal.ts`), but it is that package's own and no other driver reads
+ * it — and both driver families are under a maintainer investment freeze
+ * (#5499). The engine's lowering seam is the ONE place every query passes
+ * through regardless of which door it came in by or which driver it lands on,
+ * so the gate belongs here and every backend inherits one answer.
+ *
+ * ## Both doors, because only one of them carries an array
+ *
+ * The refusal that already lives at this seam only inspects `where` when it
+ * arrives as a `FilterArray`. That is Door 2 (a direct in-process engine call).
+ * Door 1 — the protocol/HTTP face, and the door #5869 was actually measured
+ * through — runs its own `isFilterAST` → `parseFilterAST` in
+ * `metadata-protocol/protocol.ts` and hands the engine an already-lowered
+ * `FilterCondition` OBJECT. A guard on the array branch alone would therefore
+ * have left the reported defect exactly where it was. This gate runs on the
+ * lowered condition, so both doors are covered by one check.
+ *
+ * ## Deliberately NOT refused
+ *
+ * - **`$in: []` / `$nin: []`.** An empty list is a legitimate, declared
+ *   predicate — "matches nothing" and "matches everything" respectively — and
+ *   both drivers say so in as many words. Arity is not this gate's business;
+ *   only "is it a list at all".
+ * - **The MEMBER types of any list.** `$between`'s members are checked by
+ *   nobody (`driver-sql` checks arity and nothing else, and #5041 measured the
+ *   member case and deliberately left it — ISO date strings are a legitimate
+ *   range on every backend); `$in`/`$nin` members are #5234's subject, on the
+ *   `driver-sql` object-syntax face, and are not re-judged here.
+ * - **A field spec with no `$` keys** (`{ author: { name: 'x' } }`) — a
+ *   deep-equality comparand to `driver-memory` and `driver-mongodb` alike. This
+ *   gate does not descend into one, for the same reason `filter-refusal.ts`
+ *   does not: a comparand is data, and a stricter reading here would invent a
+ *   contract no backend agrees with.
+ */
+
+import { StandardErrorCode } from '@objectstack/spec/api';
+
+/**
+ * The operators whose comparand `FieldOperatorsSchema` declares as a list, with
+ * the authoring spellings that lower to each.
+ *
+ * The spellings matter to the message and not to the check: an author writes
+ * `not_in` on a `ViewFilterRule` and never types `$nin`, so a refusal naming
+ * only the lowered form sends them looking for a key that is not in their
+ * metadata. Values are the `AST_OPERATOR_MAP` keys (`spec/data/filter.zod.ts`)
+ * that map to each `$` operator.
+ */
+const LIST_COMPARAND_OPERATORS: ReadonlyMap<string, readonly string[]> = new Map([
+  ['$in', ['in']],
+  ['$nin', ['nin', 'not_in', 'notin']],
+  ['$between', ['between']],
+]);
+
+/** What a caller most likely meant when they wrote a scalar. */
+const SCALAR_ALTERNATIVE: ReadonlyMap<string, string> = new Map([
+  ['$in', '"=" ($eq)'],
+  ['$nin', '"!=" ($ne)'],
+]);
+
+/**
+ * A plain object — filter STRUCTURE rather than a comparand.
+ *
+ * `Date` and other class instances are comparands even though `typeof` calls
+ * them objects, and an array is a comparand at this position too (it is what a
+ * list operator is FOR). Same classification `driver-memory`'s gate makes.
+ */
+function isFilterNode(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object'
+    && value !== null
+    && !Array.isArray(value)
+    && !(value instanceof Date)
+  );
+}
+
+/** `string` / `number` / `null` / `object` … — the word the message uses. */
+function describeOperand(value: unknown): string {
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+  if (Array.isArray(value)) return 'array';
+  if (value instanceof Date) return 'Date';
+  return typeof value;
+}
+
+/**
+ * A short, bounded rendering of the offending value.
+ *
+ * Bounded because the value came off the wire and a filter comparand can be
+ * arbitrarily large; the message is for a human reading a 400, not a dump.
+ *
+ * The whole message has a second, harder bound: `rest-server.ts` TRUNCATES a
+ * declared-4xx message at `CLIENT_MESSAGE_MAX` (500) before it reaches the
+ * client (#5423). Everything a caller needs in order to act — operator, field,
+ * received value, position, corrected shape — is therefore front-loaded, and
+ * the test file pins the assembled length under that bound so a later edit
+ * cannot silently push the tail off the wire.
+ */
+function shapePreview(value: unknown): string {
+  let text: string;
+  try {
+    text = JSON.stringify(value) ?? String(value);
+  } catch {
+    text = String(value);
+  }
+  return text.length > 60 ? `${text.slice(0, 59)}…` : text;
+}
+
+/** The wire envelope every filter refusal in the platform already uses. */
+function invalidFilterError(message: string): Error {
+  const err = new Error(message) as Error & { code?: string; status?: number };
+  err.code = StandardErrorCode.enum.INVALID_FILTER;
+  err.status = 400;
+  return err;
+}
+
+/**
+ * `$in` / `$nin` whose comparand is not a list at all.
+ *
+ * Names the operator (in both the lowered and the authoring spelling), the
+ * field, the received shape, the position, and the expected shape — the #5346 /
+ * #5348 wording contract. The closing sentence is the one a caller cannot infer
+ * from a status code: the query did not run.
+ */
+function nonListComparandError(
+  object: string,
+  operation: string,
+  op: string,
+  field: string,
+  value: unknown,
+  path: string,
+): Error {
+  const spellings = LIST_COMPARAND_OPERATORS.get(op) ?? [];
+  const alternative = SCALAR_ALTERNATIVE.get(op);
+  return invalidFilterError(
+    `${operation}('${object}'): Operator "${op}" on field "${field}" requires an ARRAY of ` +
+    `values. Received ${describeOperand(value)} (${shapePreview(value)}) at ${path}. ` +
+    `"${op}" tests membership of a list — write ${shapePreview([value])} for a single value` +
+    (alternative ? `, or use ${alternative} to compare against it` : '') +
+    `. Authoring spellings: ${spellings.join(', ')}. The filter was NOT applied, and an ` +
+    `unapplied filter would have returned the UNFILTERED result set (#5869).`,
+  );
+}
+
+/**
+ * `$between` whose comparand is not a two-element `[min, max]` array.
+ *
+ * Arity only — the exact condition `driver-sql`'s `$between` arm and
+ * `driver-memory`'s `isBetweenComparand` already apply, hoisted so that the
+ * backends which check NEITHER stop answering silently. The leading sentence is
+ * kept verbatim from those two so one condition keeps one wording across the
+ * platform (#5240's rule, applied across packages rather than within one).
+ */
+function malformedRangeComparandError(
+  object: string,
+  operation: string,
+  field: string,
+  value: unknown,
+  path: string,
+): Error {
+  return invalidFilterError(
+    `${operation}('${object}'): Operator "$between" on field "${field}" requires a [min, max] ` +
+    `value array. Received ${describeOperand(value)} (${shapePreview(value)}) at ${path}. ` +
+    `A range needs exactly two bounds, in order; the authoring spelling that lowers to ` +
+    `"$between" is "between". The filter was NOT applied, and an unapplied filter would have ` +
+    `returned the UNFILTERED result set (#5869).`,
+  );
+}
+
+/**
+ * Walk one `FilterCondition` and refuse every list-shaped operator whose
+ * comparand cannot be one.
+ *
+ * Read-only and allocation-free on the overwhelmingly common path (a filter
+ * with no list operator walks its own keys and returns). Runs on every engine
+ * read and write, so it stays a walk rather than a schema parse:
+ * `FieldOperatorsSchema` cannot be used as the gate directly because it is
+ * stricter than the runtime in ways the runtime deliberately allows — `$gt` is
+ * declared `number | Date | FieldReference`, while `['created_at', '>',
+ * '2026-01-01']` lowers to a STRING bound that every backend accepts and that
+ * the showcase apps rely on. Enforcing the whole schema here would refuse
+ * working queries; this gate enforces the three declarations that the drivers
+ * genuinely cannot agree on.
+ */
+export function assertListComparandShapes(
+  object: string,
+  operation: string,
+  node: unknown,
+  path = 'where',
+): void {
+  if (!isFilterNode(node)) return;
+  for (const [key, value] of Object.entries(node)) {
+    const here = `${path}.${key}`;
+    if (key === '$and' || key === '$or') {
+      // A non-array operand is a different defect, owned by the drivers'
+      // combinator checks; this gate only walks what it can.
+      if (Array.isArray(value)) {
+        value.forEach((child, index) =>
+          assertListComparandShapes(object, operation, child, `${here}[${index}]`));
+      }
+      continue;
+    }
+    if (key === '$not') {
+      assertListComparandShapes(object, operation, value, here);
+      continue;
+    }
+    // Any other `$` key at node level is a logical operator this gate does not
+    // judge — an unknown one is already refused downstream, by name.
+    if (key.startsWith('$')) continue;
+    assertFieldListComparands(object, operation, key, value, here);
+  }
+}
+
+/** One field constraint: `{ field: <spec> }`. */
+function assertFieldListComparands(
+  object: string,
+  operation: string,
+  field: string,
+  spec: unknown,
+  path: string,
+): void {
+  // A spec that is not a plain object is a comparand (implicit equality) and
+  // carries no operator to check.
+  if (!isFilterNode(spec)) return;
+  const keys = Object.keys(spec);
+  // No `$` key at all → a deep-equality comparand or a nested-relation
+  // condition. Not descended into; see the module note.
+  if (!keys.some((key) => key.startsWith('$'))) return;
+  for (const op of keys) {
+    if (!LIST_COMPARAND_OPERATORS.has(op)) continue;
+    const comparand = spec[op];
+    if (op === '$between') {
+      if (!Array.isArray(comparand) || comparand.length !== 2) {
+        throw malformedRangeComparandError(object, operation, field, comparand, `${path}.${op}`);
+      }
+      continue;
+    }
+    if (!Array.isArray(comparand)) {
+      throw nonListComparandError(object, operation, op, field, comparand, `${path}.${op}`);
+    }
+  }
+}


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5869

## 前提复验(origin/main `80f7dc6a3`)

单据前提**成立**,且复验中发现一处会决定落点成败的细节,先记在最前面。

探针实测(`isFilterAST` / `parseFilterAST` 直调):

```
not_in scalar | isFilterAST= true | lowered= {"stage":{"$nin":"won"}}
nin    scalar | isFilterAST= true | lowered= {"stage":{"$nin":"won"}}
notin  scalar | isFilterAST= true | lowered= {"stage":{"$nin":"won"}}
in     scalar | isFilterAST= true | lowered= {"stage":{"$in":"won"}}
```

`isFilterAST` 只看**算子**(`VALID_AST_OPERATORS.has(filter[1])`),不看比较值形状;`parseFilterAST` 照单下降。三种拼法同一条路径,与单据实测一致。

**关键细节 —— 收口点不能只装在数组分支上。** 分诊说的收口点(`lowerWhereFilterArray`)现行代码第一句是 `if (!Array.isArray(where)) return bag;`。但单据实测的那道门(HTTP)走不到数组分支:协议面 `metadata-protocol/protocol.ts:5187` **自己**跑了一遍 `isFilterAST` → `parseFilterAST`,交给引擎的已经是下降完的 `FilterCondition` **对象**。所以只判数组分支的守卫,恰好**漏掉本单实测的那道门**。本 PR 因此把守卫装在**下降后的 condition** 上,两道门同一份判据。

## 为什么必须收在一处(实测的三家答案)

| 比较值 | driver-sql | driver-memory | driver-mongodb |
|:--|:--|:--|:--|
| `$in` / `$nin` 标量 | `whereIn(f, scalar)` → **500 DATABASE_ERROR** | 形状门放行 | 原样发射 |
| `$between` 非二元组 | 拒收 400(arity) | 拒收 400(#5328) | **分支落空,不发射区间谓词** |

`driver-memory` 的形状门(`filter-refusal.ts`)实测逐格结果:

```
ACCEPT $in scalar           {"stage":{"$in":"won"}}
ACCEPT $nin scalar          {"stage":{"$nin":"won"}}
ACCEPT $in null             {"stage":{"$in":null}}
REFUSE $between scalar      | status= 400 code= INVALID_FILTER | Operator "$between" ...
ACCEPT $in ok (control)     {"stage":{"$in":["won"]}}
```

一条声明(`FieldOperatorsSchema` 写着 `$in: z.array`、`$nin: z.array`、`$between: z.tuple`),三家三个答案,且那份形状门只有 `driver-memory` 自己读 —— 这正是「收口点唯一」的论据本身。⛔ 未在任何 driver 侧加拒收(两族冻结,#5499)。

## 改动

- 新增 `packages/objectql/src/filter-comparand-shape.ts` —— 只判「集合算子的比较值整体是不是列表」的走查。独立成文件,让 `engine.ts` 的 diff 只有 17 行(本周 #6114 / #6171 / #6158 刚改过它,且都不在这一带)。
- `engine.ts` 在 `lowerWhereFilterArray` 的**两个**出口各调一次(对象门 / 数组门)。六个入口(`find` / `findOne` / `count` / `aggregate` / `update` / `delete`)因此一致。
- 信封:`400` + `StandardErrorCode.enum.INVALID_FILTER`(标准目录码,**不需要**动 `ERROR_CODE_LEDGER` —— 那是扩展码的账本)。

**⛔ 未改 `packages/spec`。** 这是本单最值得记的一条:期望形状**早就声明了**,缺的只是入口处的强制。`ViewFilterRuleSchema.value` 不按算子约束形状确实是真的,但修 500 不需要动它 —— 详见下方「扩测项」。

错误信息(实测,穿过 REST 后客户端收到的正文):

```
find('showcase_task'): Operator "$nin" on field "status" requires an ARRAY of values.
Received string ("done") at where.status.$nin. "$nin" tests membership of a list —
write ["done"] for a single value, or use "!=" ($ne) to compare against it.
Authoring spellings: nin, not_in, notin. The filter was NOT applied, and an unapplied
filter would have returned the UNFILTERED result set (#5869).
```

点名了算子(**同时给作者实际书写的 `not_in` / `nin` / `notin` 拼法** —— 没人往 metadata 里写 `$nin`,只报下降后的名字会让作者去找一个他文件里没有的键)、字段、收到的值与位置、可直接粘贴的正确形状、以及标量比较该用的替代算子。

## 收益穿过 HTTP 边界后仍在(实测)

`mapDataError` 对声明了 4xx 的错误原样透传:

```
engine   : status=400 code=INVALID_FILTER msgLen=392
REST     : status=400 code=INVALID_FILTER
```

⚠️ 首版信息 633 字符,**被 `CLIENT_MESSAGE_MAX`(500)截断**,掉的正好是尾部那句「filter was NOT applied」—— 即这条拒收存在的理由本身。已把信息压到 392 / 372 / 355,并加了一条钉住该性质的用例(`toBeLessThan(500)` + 尾句仍在),因为那个上界在**另一个包**里。

## 反向验证(方向先写死,再跑)

| 肢 | 预测 | 实测 | 一致 |
|:--|:--|:--|:--|
| A:移除两处新判定 | 新用例翻红,#5158 既有用例保持绿 | **16 red / 30 green** —— 恰为新增的 16 条 | ✅ |
| B:破坏信息组装(去掉算子名与 path) | **只有点名类断言**翻红,status/code 类保持绿 | **3 red / 43 green** —— 恰为 3 条点名断言 | ✅ |

肢 B 的意义:它证明点名断言绑的是**点名**,而不是顺带被「拒收发生了」满足 —— 否则「只把 500 改成 400 不给可操作信息」会照样绿。

肢 A 另有一条值得记的观察:测试替身的匹配器对 `$in: 'won'` **并不抛错**(JS 里 `'won'.includes('won')` 为真),即无守卫时替身面的失败模式是**静默错答**,而 driver-sql 面才是 500。同一形状两种坏法,更说明判据该在引擎侧。

## 测试

新增 16 条,落在既有 `engine-filter-array-lowering.test.ts`(贴现有结构),含正反两侧:四种拼法的标量拒收、点名断言、对象门、`null`/数字/对象比较值、`$and`/`$or`/`$not` 嵌套走查(带 path)、六入口一致、`$between` 三格、REST 截断上界;以及**必须保持工作**的回归:合法数组形状原样下达、`$in: []` / `$nin: []` 仍是合法谓词、列表成员不复判、`$eq` 里形似算子图的深等值比较值不误伤、非集合算子标量不受影响(含 `$gt` 的 ISO 日期字符串)。

```
pnpm --filter @objectstack/objectql test
 Test Files  135 passed (135)
      Tests  2235 passed (2235)

pnpm --filter @objectstack/objectql typecheck
 > tsc --noEmit          (无输出 = 通过)

node scripts/check-engine-double-contract.mjs
 check-engine-double-contract: OK — 73 pinned, 133 in the DEBT ledger, 2 exempt.

node scripts/check-nul-bytes.mjs
 check-nul-bytes: OK (scanned 5920 tracked text file(s); ... no raw ASCII control bytes).
```

**消费半径扫描**(该判据对全仓每一次引擎查询生效,不能只测本包)。全仓 grep 标量 `$in`/`$nin` 命中三处夹具,均在 analytics read-scope 面(`scope:` / `filter:`,不是 `where`),且该面**本就自带**同族拒收(⑧ `$in` 需数组 / ⑨ `$nin` 需数组 / ⑩ `$between` 需 `[min,max]`)—— 与本 PR 无交叠,实测全绿:

```
@objectstack/service-analytics   Test Files 61 passed   Tests 1131 passed
@objectstack/metadata-protocol   Test Files 49 passed   Tests  502 passed
rest/analytics-read-scope-refusal-envelope.test.ts        8 passed
runtime/analytics-query-read-scope-withhold.test.ts      10 passed
```

顺带说明:本单未新增 fake engine 写动词,`assertEngineDeleteDispatch` 不适用;复用的是既有 `makeRecordingDriver`(driver 替身,非 engine double),`check:engine-double-contract` 已绿。

## 必答项

**#5234(driver-sql 对象语法列表成员)—— 定价不变。** 不同轴:本 PR 判「比较值**整体**是不是列表」,#5234 判「合法列表**内部成员**的类型」。`{ status: { $in: ['a', { foo: 1 }] } }` 是数组,本守卫**原样放行**(已加用例钉住这条边界)。LIKE 族的对象比较值也不在本守卫的算子集内。#5234 的落点(`packages/drivers/driver-sql`)、测量范围、文件面均不受影响;其分支 `claude/issue-5234-silent-empty-predicates`(`85ef43d02`)尚未并入 main,与本 PR 零文件交叠。唯一的间接影响是**非**减负:经引擎路由的查询里非数组比较值不再抵达 driver-sql,但直调 driver 的路径仍在,所以接手者要做的事没有变少。

**#5905(having-filter 第五求值面)—— 未触及。** 如预期。`lowerWhereFilterArray` 只读 `bag.where`,`having` 是 aggregate AST 上的另一个键,不经过本守卫。且两者判据正交:#5905 是**无值行的取值语义**(`$nin` 对 `undefined` 该判真还是假),本守卫只问「比较值是不是列表」,即便跑在 having 面上也不会改动 #5905 的任何一格。`engine-aggregate-having.test.ts` / `having-filter.test.ts` 在全量里保持绿。

**扩测项 `between` 的实测结论。** 与 in/not_in **同族但不同格**,如实报告:它**不是 500** —— `driver-sql`(`arr.length !== 2`)与 `driver-memory`(`isBetweenComparand`,#5328)各自**已经**答 400 INVALID_FILTER,且措辞已经点名算子/字段/期望形状。但 `driver-mongodb` 的 `case '$between'` 是 `if (Array.isArray(value) && value.length === 2) {...}` 且**无 else**,即不拒收也不发射区间谓词。所以本 PR 仍把它收进同一收口点:判据是**纯 arity**(与那两家逐字相同的条件,不发明更严的契约),首句措辞逐字保留,收在收口点后三家答案一致。

**是否需要改 spec:否 —— 三格都不需要。** 期望形状 `FieldOperatorsSchema` 已经声明(`$in`/`$nin` 是 `z.array`,`$between` 是 `z.tuple`),缺的只是入口强制,所以本 PR 完全没进 `packages/spec`,无需转 spec 座位。

⚠️ 与此相关但**不在本单范围**的一条,留给 PM 判断是否另立:`ViewFilterRuleSchema.value` 不按算子约束形状仍然是事实 —— 本 PR 把它从「发布通过 → 运行时 500」改善成「发布通过 → 运行时可操作的 400」,但作者仍要到运行时才知道写错了。**在发布期就按算子拒收**是 `domain:spec` 的活,且是明显更大的一刀(要给每个算子定 value 形状并迁移存量 metadata),按纪律未做 rider、也未擅自立案。

## 偏差与风险

- **唯一偏差**:守卫装在下降后的 condition 上,而非分诊字面写的「数组分支」。理由即上文实测 —— 只判数组会漏掉本单实测的那道门。收口点、包、信封均未变。
- 行为变化(500 → 400)对**此前会崩的调用**是纯改善;对此前**恰好**能跑的调用需确认无误伤,已由消费半径扫描 + 五个包全量覆盖。
- `$between` 现在由引擎先答,driver 侧那两条拒收在经引擎路由时不再被触达(直调 driver 仍触达)。全仓仅 `driver-memory` 自己的用例断言该措辞,且为直调,保持绿;首句逐字保留也是为此。

---
_Generated by [Claude Code](https://claude.ai/code/session_019Q7oc7ASjh8yxyS3Yz78We)_