### PR TITLE
fix(metadata-protocol): 对象 overlay 写路径的 ownership 键切真实 package id + 服务端强制 provenance 盖章 (#4636 裁 B 第一步)

### DIFF
--- a/.changeset/wide-donkeys-repeat.md
+++ b/.changeset/wide-donkeys-repeat.md
@@ -1,0 +1,19 @@
+---
+'@objectstack/metadata-protocol': patch
+'@objectstack/objectql': patch
+---
+
+fix(metadata-protocol): 对象 overlay 写路径按真实 package id 记录 registry 归属,并由服务端强制盖 `_provenance: 'org'`
+
+`applyObjectRegistryMutation` 此前把每一次对象写入都硬编码登记在 `'sys_metadata'` 哨兵下。
+该归属键同时就是包过滤键(`SchemaRegistry.getAllObjects(packageId)` 匹配的是
+`contributor.packageId`),因此通过 Studio 包工作区新建的对象,在自己所属包的过滤结果里
+一直是空的,直到有别的路径重新登记它。现在改为使用该行真实的 `package_id`;哨兵只保留
+给「没有绑定任何包」的写入,`rollbackMetaItem` 则从行本身读出绑定(而不是从请求读)。
+
+同一次改动里,服务端在**副本**上无条件盖 `_provenance: 'org'`,不再采信请求体里的值:
+只搬归属键而不盖章会立刻复活 cloud#970 —— `applyProtection` 会把带包 id 且自身没有
+provenance 的 body 默认标成 `'package'`,`getArtifactItem` 据此认定它是代码制品,
+`object` 又声明了 `allowOrgOverride: false`,于是用户刚建好的对象在下一次保存时收到
+`403 not_overridable`。`metadata-read-decorations.ts` 有意不剥离 `_provenance`,
+Studio 的 GET → PUT 往返会把它原样送回,所以这个事实必须由服务端陈述。

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -7354,12 +7354,61 @@ export class ObjectStackProtocolImplementation implements
      * AFTER `put()` resolves successfully, so a failed write — DB error,
      * optimistic-lock conflict, validation failure — never leaks a
      * stale schema into the registry.
+     *
+     * ── OWNERSHIP KEY (#4636, maintainer ruling 2026-08-07, option B) ──
+     *
+     * The contributor is keyed by the row's REAL `package_id`, not by the
+     * `'sys_metadata'` sentinel this used to hard-write. The sentinel
+     * survives for exactly one case — a package-less write, which has no
+     * real id to use.
+     *
+     * Why the key had to move (and not the other side): the ownership key
+     * IS the package-filter key. `SchemaRegistry.getAllObjects(packageId)`
+     * matches `contributor.packageId`, so an object created through
+     * Studio's package workspace was invisible to its own package's filter
+     * until something re-registered it. The written contract in
+     * `objectql/src/registry.ts` (the `isTenantAuthored` header) already
+     * said the real id is the key and the sentinel is a save-path-only
+     * artefact; this makes the save path say the same thing.
+     *
+     * ── `_provenance: 'org'` IS STAMPED HERE, SERVER-SIDE ──
+     *
+     * On a COPY of the body, unconditionally — the request's own
+     * `_provenance` is never consulted, and never wins.
+     *
+     * That is load-bearing, not defensive coding. `applyProtection` (spec)
+     * stamps `_provenance: 'package'` whenever it is handed a package id
+     * and the body has not already answered, and the registry's artifact
+     * lookup reads exactly that key: a row registered under `app.<slug>`
+     * with package provenance IS a code artifact as far as
+     * `getArtifactItem` is concerned, so `isArtifactBacked` turns true and
+     * `saveMetaItem`'s overlay gate refuses the NEXT write to it with
+     * `not_overridable` — `object` declares `allowOrgOverride: false`.
+     * Moving the key without the stamp therefore re-creates cloud#970 (an
+     * app the user just built becomes silently un-editable) on the write
+     * path, one save later instead of one restart later. Measured, not
+     * assumed: see the reverse-verification limb in
+     * `objectql/src/protocol-writepath-object-ownership.test.ts`.
+     *
+     * Client-supplied provenance cannot be trusted here:
+     * `metadata-read-decorations.ts` deliberately does NOT strip
+     * `_provenance`, so a Studio GET → PUT round-trip echoes whatever the
+     * served document carried. Every row this method sees came out of a
+     * `sys_metadata` write, which is tenant-authored by definition
+     * (ADR-0010 `_provenance: 'org'`) — so the server states that fact
+     * rather than reading it back from the caller. Same sentence the boot
+     * re-hydration already writes for the same rows.
      */
-    private applyObjectRegistryMutation(request: { type: string; name: string; item?: any }): void {
+    private applyObjectRegistryMutation(request: { type: string; name: string; item?: any; packageId?: string | null }): void {
         if (request.type !== 'object' && request.type !== 'objects') return;
         this.engine.registry.registerItem(request.type, request.item, 'name');
         try {
-            this.engine.registry.registerObject(request.item as any, 'sys_metadata');
+            this.engine.registry.registerObject(
+                { ...(request.item as Record<string, unknown>), _provenance: 'org' } as any,
+                // `||`, not `??`: an empty-string binding is "no package", the
+                // same normalisation the boot branch applies to `package_id`.
+                request.packageId || 'sys_metadata',
+            );
         } catch (err: any) {
             console.warn(
                 `[Protocol] registerObject failed for ${request.name}: ${err?.message ?? err}`,
@@ -7524,6 +7573,43 @@ export class ObjectStackProtocolImplementation implements
         } catch (err: any) {
             console.warn(`[Protocol] table sync failed for object '${name}': ${err?.message ?? err}`);
         }
+    }
+
+    /**
+     * [#4636] The package binding of a persisted overlay row, read from the
+     * row itself.
+     *
+     * The write paths that HAVE a `packageId` parameter (`saveMetaItem`, the
+     * publish promotion) pass the caller's binding straight through — the same
+     * value `SysMetadataRepository.put` stamps on the row, so key and row agree
+     * by construction. `rollbackMetaItem` has no such parameter: it addresses a
+     * row that already exists, and the row's own `package_id` is the only
+     * authoritative answer to "who owns this".
+     *
+     * Mirrors the repository's own `whereFor(ref, 'active', undefined)`: no
+     * package predicate (match any package), scoped by org + type + name +
+     * state. Deliberately NOT a `findOne` on the repository — `MetadataItem`
+     * projects the body, not the binding, and widening that shared type to
+     * carry one field for one caller is a contract change PR1 does not need.
+     *
+     * Not caught: a metadata-store outage here means the ownership key would be
+     * a guess, and every caller reads this BEFORE its write, so failing is
+     * still failing closed.
+     */
+    private async resolveOverlayPackageBinding(
+        type: string,
+        name: string,
+        organizationId: string | null,
+    ): Promise<string | null> {
+        const row = await this.engine.findOne('sys_metadata', {
+            where: {
+                type,
+                name,
+                organization_id: organizationId,
+                state: 'active',
+            },
+        });
+        return (row as { package_id?: string | null } | null)?.package_id ?? null;
     }
 
     /**
@@ -10137,6 +10223,19 @@ export class ObjectStackProtocolImplementation implements
             name: request.name,
             org: orgId ?? 'env',
         } as Parameters<typeof repo.restoreVersion>[0];
+        // [#4636] The ownership key the write-through below needs, read from
+        // the ROW rather than from the request — `rollbackMetaItem` has no
+        // `packageId` parameter, and inventing one would let a caller re-key
+        // an object it does not own. `restoreVersion` → `put` preserves an
+        // existing non-null `package_id` on update, so the binding read here
+        // is the binding the restored row still carries.
+        //
+        // Read BEFORE the restore, deliberately: the row exists at this point
+        // and a read failure can still fail the whole rollback cleanly. Reading
+        // it afterwards would put a fallible query downstream of a write that
+        // already succeeded — the shape that ends in a `catch {}` swallowing a
+        // real outage (#4867).
+        const rollbackPackageId = await this.resolveOverlayPackageBinding(singularType, request.name, orgId);
         try {
             const result = await repo.restoreVersion(ref, request.toVersion, {
                 // #4556 — NULL, not 'system', for an actor-less rollback.
@@ -10148,10 +10247,17 @@ export class ObjectStackProtocolImplementation implements
             // #4521 — a rollback is a live write like any other: the restored
             // body must be the one the runtime dispatches on immediately, not
             // after someone lists the type.
+            // #4636 — …under the SAME ownership key `saveMetaItem` used. Left
+            // unpassed, an object row bound to `app.<slug>` re-registered here
+            // under the `'sys_metadata'` sentinel and `registerObject` threw
+            // `already owned by package "app.<slug>"` into the best-effort
+            // `console.warn` — a rollback that reported success while the
+            // registry kept serving the body it was supposed to revert.
             this.applyRegistryWriteThrough({
                 type: singularType,
                 name: request.name,
                 item: result.item.body,
+                packageId: rollbackPackageId,
             });
             return {
                 success: true,

--- a/packages/objectql/src/protocol-writepath-object-ownership.test.ts
+++ b/packages/objectql/src/protocol-writepath-object-ownership.test.ts
@@ -1,0 +1,390 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #4636 PR1 — the object-overlay WRITE path keys SchemaRegistry ownership by
+ * the row's REAL package id, and stamps `_provenance: 'org'` server-side.
+ *
+ * ## What was wrong
+ *
+ * `applyObjectRegistryMutation` hard-wrote `'sys_metadata'` as the ownership
+ * key for every object write. The ownership key IS the package-filter key
+ * (`getAllObjects(packageId)` matches `contributor.packageId`), so an object
+ * created through Studio's package workspace was invisible to its own
+ * package's filter, and the boot re-hydration (#4636 PR2) could not be fixed
+ * to use the real id without the two sides then fighting over the same object:
+ * one registered `app.<slug>`, the other `'sys_metadata'`, and `registerObject`
+ * throws `already owned by package …` on the second claim.
+ *
+ * ## Why the provenance stamp is in the same PR and not a follow-up
+ *
+ * Moving the key alone re-creates cloud#970. `applyProtection` stamps
+ * `_provenance: 'package'` on any body handed to `registerObject` with a
+ * package id and no provenance of its own; `getArtifactItem` reads exactly
+ * that, `isArtifactBacked` turns true, and `object` declares
+ * `allowOrgOverride: false` — so the NEXT save of the object the user just
+ * created answers `403 not_overridable`. The B-minimal counter-example below
+ * reproduces that on the real registry, so the stamp is pinned by the failure
+ * it prevents rather than by a comment.
+ *
+ * The stamp is applied to a COPY, server-side, overriding whatever the body
+ * carried: `metadata-read-decorations.ts` deliberately does not strip
+ * `_provenance`, so a Studio GET → PUT round-trip echoes it back and a
+ * consumer that trusted the request would be trusting its own output.
+ *
+ * This file lives in `@objectstack/objectql` and not next to the code it
+ * tests because the assertion is about the REAL `SchemaRegistry` —
+ * ownership clashes, `applyProtection`'s provenance defaulting,
+ * `getAllObjects` filtering. `@objectstack/objectql` depends on
+ * `@objectstack/metadata-protocol`, so only this direction can hold both
+ * halves; the reverse import would close a cycle turbo rejects.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ObjectStackProtocolImplementation } from '@objectstack/metadata-protocol';
+import { SchemaRegistry } from './registry.js';
+// [#4550 / #5480] The producer's OWN write-verb dispatch decisions, so this
+// double cannot accept a call `ObjectQL.delete` / `ObjectQL.update` refuses.
+import { assertEngineDeleteDispatch } from './engine-delete-dispatch.js';
+import { assertEngineUpdateDispatch } from './engine-update-dispatch.js';
+
+/** A Studio authoring workspace id — writable under ADR-0070. */
+const APP_PKG = 'app.myapp';
+const OTHER_PKG = 'app.otherapp';
+/** The key a package-less overlay write keeps. */
+const SENTINEL = 'sys_metadata';
+
+interface Row {
+    id: string;
+    type: string;
+    name: string;
+    organization_id: string | null;
+    package_id: string | null;
+    state: string;
+    metadata: string;
+    checksum?: string;
+    version?: number;
+}
+
+/** `sys_metadata_history` — the lineage `rollbackMetaItem` resolves through. */
+interface HistoryRow {
+    id: string;
+    event_seq: number;
+    type: string;
+    name: string;
+    version: number;
+    operation_type: string;
+    metadata: string | null;
+    checksum: string | null;
+    organization_id: string | null;
+    recorded_at: string;
+}
+
+function matches(r: Record<string, unknown>, where: Record<string, unknown>): boolean {
+    for (const [k, v] of Object.entries(where)) {
+        if (v === undefined) continue;
+        if ((r as any)[k] !== v) return false;
+    }
+    return true;
+}
+
+function keyOf(w: Record<string, unknown>) {
+    return `${w.type}|${w.name}|${w.organization_id ?? '__env__'}|${w.state ?? 'active'}|${w.package_id ?? '__nopkg__'}`;
+}
+
+function makeHarness() {
+    const registry = new SchemaRegistry({ multiTenant: false });
+    registry.logLevel = 'silent';
+    const rows = new Map<string, Row>();
+    const historyRows: HistoryRow[] = [];
+    const synced: string[] = [];
+    let nextId = 0;
+    const findRow = (w: Record<string, unknown>) => {
+        for (const [k, r] of rows) if (matches(r, w)) return { key: k, row: r };
+        return null;
+    };
+    const engine: any = {
+        registry,
+        async findOne(table: string, opts: { where: Record<string, unknown> }) {
+            if (table === 'sys_metadata_history') {
+                return historyRows.find((h) => matches(h as any, opts.where)) ?? null;
+            }
+            return findRow(opts.where)?.row ?? null;
+        },
+        async find(table: string, opts: { where: Record<string, unknown> }) {
+            if (table === 'sys_metadata_history') {
+                return historyRows.filter((h) => matches(h as any, opts.where));
+            }
+            return Array.from(rows.values()).filter((r) => matches(r, opts.where));
+        },
+        async insert(table: string, data: Record<string, unknown>) {
+            if (table === 'sys_metadata_history') {
+                const h = { id: `h_${++nextId}`, ...(data as any) } as HistoryRow;
+                historyRows.push(h);
+                return { id: h.id };
+            }
+            if (table !== 'sys_metadata') return { id: 'side_table' };
+            const row = { id: `r_${++nextId}`, ...(data as any) } as Row;
+            rows.set(keyOf(data), row);
+            return { id: row.id };
+        },
+        async update(table: string, data: Record<string, unknown>, opts: { where: Record<string, unknown> }) {
+            assertEngineUpdateDispatch(data, opts);
+            if (table !== 'sys_metadata') return { id: null };
+            const found = findRow(opts.where);
+            if (!found) return { id: null };
+            const merged = { ...found.row, ...(data as any) };
+            rows.delete(found.key);
+            rows.set(keyOf(merged), merged);
+            return { id: found.row.id };
+        },
+        async delete(_t: string, opts?: Record<string, unknown>) {
+            assertEngineDeleteDispatch(opts);
+            return { deleted: 0 };
+        },
+        async syncObjectSchema(name: string) { synced.push(name); },
+    };
+    // A PROJECT kernel (`environmentId` set) — the topology cloud#970 was
+    // reported on, and the only one where `saveMetaItem`'s overlay gate is
+    // engaged at all.
+    const protocol = new ObjectStackProtocolImplementation(engine, undefined, 'env_test');
+    return { registry, protocol, rows, historyRows, synced };
+}
+
+function objectBody(name: string, extra?: Record<string, unknown>) {
+    return {
+        name,
+        label: 'Invoice',
+        fields: {
+            name: { name: 'name', type: 'text', label: 'Name' },
+            amount: { name: 'amount', type: 'number', label: 'Amount' },
+        },
+        ...extra,
+    };
+}
+
+/** The owning contributor recorded for `name` (no namespace → fqn === name). */
+const owner = (registry: SchemaRegistry, name: string) =>
+    registry.getObjectOwner(name);
+
+describe('#4636 — object write path keys ownership by the real package id', () => {
+    it('records the request packageId as the contributor, not the sentinel', async () => {
+        const { registry, protocol } = makeHarness();
+
+        const res = await protocol.saveMetaItem({
+            type: 'object',
+            name: 'myapp_invoice',
+            packageId: APP_PKG,
+            item: objectBody('myapp_invoice'),
+        });
+
+        expect(res.success).toBe(true);
+        expect(owner(registry, 'myapp_invoice')?.packageId).toBe(APP_PKG);
+    });
+
+    it('keeps the sentinel for a package-less write', async () => {
+        const { registry, protocol } = makeHarness();
+
+        await protocol.saveMetaItem({
+            type: 'object',
+            name: 'global_invoice',
+            item: objectBody('global_invoice'),
+        });
+
+        expect(owner(registry, 'global_invoice')?.packageId).toBe(SENTINEL);
+    });
+
+    it('getAllObjects(packageId) sees a just-created object on the FIRST save', async () => {
+        const { registry, protocol } = makeHarness();
+
+        await protocol.saveMetaItem({
+            type: 'object',
+            name: 'myapp_invoice',
+            packageId: APP_PKG,
+            item: objectBody('myapp_invoice'),
+        });
+
+        // The sidebar package filter (runtime `meta.ts` → `getAllObjects`).
+        // Pre-fix this was empty until something re-registered the object.
+        expect(registry.getAllObjects(APP_PKG).map((o: any) => o.name)).toEqual(['myapp_invoice']);
+        // …and it does NOT leak into another package's filter.
+        expect(registry.getAllObjects(OTHER_PKG)).toEqual([]);
+    });
+});
+
+describe('#4636 — `_provenance: \'org\'` is stamped by the SERVER', () => {
+    it('stamps org provenance when the body carries none', async () => {
+        const { registry, protocol } = makeHarness();
+
+        await protocol.saveMetaItem({
+            type: 'object',
+            name: 'myapp_invoice',
+            packageId: APP_PKG,
+            item: objectBody('myapp_invoice'),
+        });
+
+        expect((owner(registry, 'myapp_invoice')?.definition as any)?._provenance).toBe('org');
+    });
+
+    it('OVERRIDES a client-supplied `_provenance: \'package\'` — the request never wins', async () => {
+        const { registry, protocol } = makeHarness();
+
+        // The exact shape a Studio GET → PUT round-trip can produce:
+        // `metadata-read-decorations.ts` does not strip `_provenance`, so the
+        // served document hands it back to the write.
+        await protocol.saveMetaItem({
+            type: 'object',
+            name: 'myapp_invoice',
+            packageId: APP_PKG,
+            item: objectBody('myapp_invoice', { _provenance: 'package' }),
+        });
+
+        expect((owner(registry, 'myapp_invoice')?.definition as any)?._provenance).toBe('org');
+    });
+
+    it('does not write the registry stamps back onto the caller\'s body', async () => {
+        const { protocol } = makeHarness();
+        const item = objectBody('myapp_invoice');
+
+        await protocol.saveMetaItem({
+            type: 'object',
+            name: 'myapp_invoice',
+            packageId: APP_PKG,
+            item,
+        });
+
+        // The stamp lands on a COPY: the persisted body (and the caller's
+        // object) keep exactly what the author wrote.
+        expect((item as any)._provenance).toBeUndefined();
+        expect((item as any)._packageId).toBeUndefined();
+    });
+});
+
+describe('#4636 — cloud#970 counter-example: a freshly created app stays editable', () => {
+    it('a second save of the same package-bound object SUCCEEDS and evolves the schema', async () => {
+        const { registry, protocol, rows } = makeHarness();
+
+        await protocol.saveMetaItem({
+            type: 'object',
+            name: 'myapp_invoice',
+            packageId: APP_PKG,
+            item: objectBody('myapp_invoice'),
+        });
+
+        // The edit a user makes one minute later: add a field.
+        const evolved = objectBody('myapp_invoice');
+        (evolved.fields as any).due_date = { name: 'due_date', type: 'date', label: 'Due' };
+        const second = await protocol.saveMetaItem({
+            type: 'object',
+            name: 'myapp_invoice',
+            packageId: APP_PKG,
+            item: evolved,
+        });
+
+        expect(second.success).toBe(true);
+        // In memory: the registry serves the evolved schema, so CRUD on the
+        // new field works without a restart.
+        expect(Object.keys((registry.getObject('myapp_invoice') as any).fields)).toContain('due_date');
+        // On disk: one row, still bound to its package, carrying the new body.
+        const stored = Array.from(rows.values()).filter((r) => r.name === 'myapp_invoice');
+        expect(stored).toHaveLength(1);
+        expect(stored[0].package_id).toBe(APP_PKG);
+        expect(Object.keys(JSON.parse(stored[0].metadata).fields)).toContain('due_date');
+    });
+
+    it('B-minimal counter-example: the SAME key without the stamp answers 403 not_overridable', async () => {
+        const { registry, protocol } = makeHarness();
+
+        // Exactly what `applyObjectRegistryMutation` would do if it moved the
+        // ownership key and left the provenance stamp out — the shape measured
+        // as "B-minimal" on this issue. Nothing else about the run differs.
+        registry.registerObject(objectBody('myapp_invoice') as any, APP_PKG);
+
+        await expect(protocol.saveMetaItem({
+            type: 'object',
+            name: 'myapp_invoice',
+            packageId: APP_PKG,
+            item: objectBody('myapp_invoice'),
+        })).rejects.toThrow(/not_overridable/);
+
+        // The mechanism, stated so a future reader does not have to re-derive
+        // it: with no `_provenance`, `applyProtection` defaults the row to
+        // package provenance, and the registry then answers "code artifact".
+        expect((owner(registry, 'myapp_invoice')?.definition as any)?._provenance).toBe('package');
+    });
+});
+
+describe('#4636 — rollback re-registers under the row\'s own package binding', () => {
+    it('resolves the ownership key from the ROW: a package-less rollback keeps the sentinel', async () => {
+        const { registry, protocol } = makeHarness();
+
+        await protocol.saveMetaItem({
+            type: 'object',
+            name: 'global_invoice',
+            item: objectBody('global_invoice'),
+        });
+        const evolved = objectBody('global_invoice');
+        (evolved.fields as any).due_date = { name: 'due_date', type: 'date', label: 'Due' };
+        await protocol.saveMetaItem({
+            type: 'object',
+            name: 'global_invoice',
+            item: evolved,
+        });
+
+        const back = await protocol.rollbackMetaItem({
+            type: 'object',
+            name: 'global_invoice',
+            toVersion: 1,
+        });
+
+        expect(back.success).toBe(true);
+        // `rollbackMetaItem` has no `packageId` parameter — the key comes from
+        // the row, which here has none, so the sentinel is the right answer and
+        // the registry serves the restored body.
+        expect(owner(registry, 'global_invoice')?.packageId).toBe(SENTINEL);
+        expect(Object.keys((registry.getObject('global_invoice') as any).fields)).not.toContain('due_date');
+        expect((owner(registry, 'global_invoice')?.definition as any)?._provenance).toBe('org');
+    });
+
+    /**
+     * TRIPWIRE — this pins a DEFECT, not a desired behaviour.
+     *
+     * The package-bound half of the ownership key resolved above is
+     * unreachable through `rollbackMetaItem` today, and not because of
+     * anything in this PR: `SysMetadataRepository.restoreVersion` calls `put`
+     * with no `packageId`, `put` scopes its existing-row lookup with
+     * `whereFor(ref, state, opts.packageId ?? null)`, and `null` is a
+     * PREDICATE (`package_id IS NULL`) rather than "any package". So the
+     * lookup misses the package-bound row it is restoring, reads its parent
+     * hash as null, and every rollback of a package-bound row answers 409
+     * before any registry write-through runs. Filed separately — see the
+     * `out_of_scope_findings` link in this PR.
+     *
+     * When that is fixed this test FAILS, which is the point: whoever fixes it
+     * must then assert what the write-through does with the key, and the
+     * assertion is already written one test up.
+     */
+    it('[tripwire] a package-bound rollback still 409s — a pre-existing repository-scoping defect', async () => {
+        const { protocol } = makeHarness();
+
+        await protocol.saveMetaItem({
+            type: 'object',
+            name: 'myapp_invoice',
+            packageId: APP_PKG,
+            item: objectBody('myapp_invoice'),
+        });
+        const evolved = objectBody('myapp_invoice');
+        (evolved.fields as any).due_date = { name: 'due_date', type: 'date', label: 'Due' };
+        await protocol.saveMetaItem({
+            type: 'object',
+            name: 'myapp_invoice',
+            packageId: APP_PKG,
+            item: evolved,
+        });
+
+        await expect(protocol.rollbackMetaItem({
+            type: 'object',
+            name: 'myapp_invoice',
+            toVersion: 1,
+        })).rejects.toThrow(/metadata_conflict/);
+    });
+});

--- a/packages/objectql/src/protocol-writepath-object-ownership.test.ts
+++ b/packages/objectql/src/protocol-writepath-object-ownership.test.ts
@@ -356,8 +356,7 @@ describe('#4636 — rollback re-registers under the row\'s own package binding',
      * PREDICATE (`package_id IS NULL`) rather than "any package". So the
      * lookup misses the package-bound row it is restoring, reads its parent
      * hash as null, and every rollback of a package-bound row answers 409
-     * before any registry write-through runs. Filed separately — see the
-     * `out_of_scope_findings` link in this PR.
+     * before any registry write-through runs. Filed as #6215.
      *
      * When that is fixed this test FAILS, which is the point: whoever fixes it
      * must then assert what the write-through does with the key, and the

--- a/packages/objectql/src/registry.ts
+++ b/packages/objectql/src/registry.ts
@@ -797,11 +797,15 @@ export class NamespaceConflictError extends Error {
  * artifact? (ADR-0010 `_provenance`: `'package'` for loader-introduced items,
  * `'org'` for tenant-authored.)
  *
- * `_packageId !== 'sys_metadata'` alone cannot answer it. That sentinel only
- * holds on the save path; the boot-time rehydration of `sys_metadata` registers
- * each row under its REAL package id (`app.<slug>`), which is exactly what every
- * runtime-authored item has carried since packages became mandatory. So a
- * tenant's own overlay came back from a kernel rebuild looking like a code
+ * `_packageId !== 'sys_metadata'` alone cannot answer it. That sentinel marks
+ * one thing only — an overlay row bound to no package. A row that IS bound to
+ * one is keyed by its real package id on the save path (#4636 PR1) and by the
+ * boot-time rehydration of `sys_metadata` (#4636 PR2 — the branch still reads a
+ * camelCase key off a snake_case row, so today it falls back to the sentinel;
+ * that half of this paragraph describes the contract, not yet the code). Either
+ * way the key is `app.<slug>`, which is exactly what every code-shipped item
+ * carries too, so the sentinel test cannot tell them apart. A tenant's own
+ * overlay came back from a kernel rebuild looking like a code
  * artifact, and the protocol's overlay gate refused the next write to it with
  * `not_overridable` — an app the user had just built through Studio/AI became
  * permanently un-editable at the first kernel rebuild (cloud#970). Provenance is


### PR DESCRIPTION
Part of objectstack-ai/objectstack#4636 — 维护者 2026-08-07 裁决 **B** 的**第一步:写路径半边**。boot 半边(`loadMetaFromDb`)按裁决的次序论证留给 PR2,本 PR **不触**;因此正文不写 `Fixes`,#4636 留给 PR2 关闭。

## 问题

`applyObjectRegistryMutation` 把**每一次**对象 overlay 写入都硬编码登记在 `'sys_metadata'` 哨兵下。这个归属键同时就是**包过滤键** —— `SchemaRegistry.getAllObjects(packageId)` 匹配的是 `contributor.packageId`(`registry.ts:1252`),runtime `meta.ts` 的侧边栏包过滤直接消费它。于是通过 Studio 包工作区新建的对象,在它自己所属包的过滤结果里是空的,直到有别的路径把它重新登记一遍。

也正因为如此,boot 侧不能单独修:两侧一旦一个用 `app.{slug}`、一个用 `'sys_metadata'`,`registerObject` 会在第二次认领时抛 `already owned by package …` —— 这正是前任 dev 实测出来、并让本单转维护者的那条死路。

## 改了什么

三处,都在写路径:

1. **`applyObjectRegistryMutation` 接受 `packageId`**,归属键改为 `request.packageId || 'sys_metadata'`。哨兵只留给「没有绑定任何包」的写入。用 `||` 而不是 `??`:空串绑定就是「没有包」,与 boot 分支对 `package_id` 的归一化写法一致。上游 `applyRegistryWriteThrough` 的两个调用点(`saveMetaItem`、`runPublishSideEffects`)本来就带着 `packageId`,只是没往下传。
2. **服务端在副本上无条件盖 `_provenance: 'org'`**,不采信请求体。
3. **`rollbackMetaItem` 从行本身读出绑定**(新增 `resolveOverlayPackageBinding`)再写透。`rollbackMetaItem` 请求上没有 `packageId` 参数,凭空加一个等于允许调用方重设自己并不拥有的对象的归属;行的 `package_id` 才是权威答案。读在 restore **之前**做:此刻行还在,读失败可以干净地让整个回滚失败,而不是把一个会失败的查询摆在已经成功的写入后面(#4867 那种 `catch {}` 吞掉真实故障的形状)。

### 为什么盖章必须和切键同一个 PR

只切键会**立刻复活 cloud#970**。因果链是机械的:`applyProtection`(spec)拿到一个包 id、而 body 自己没有 `_provenance` 时,默认盖 `'package'` → `getArtifactItem` 读的正是这个键 → `isArtifactBacked` 变真 → 而 `object` 声明了 `allowOrgOverride: false` → `saveMetaItem` 的 overlay 门对**下一次**保存回 `403 not_overridable`。用户刚建好的 app 变成静默不可编辑,只是从「重启一次之后」提前到「保存一次之后」。

客户端的 provenance 在这里不可信:`metadata-read-decorations.ts` **有意**不剥离 `_provenance`,Studio 的 GET → PUT 往返会把服务端自己发出去的值原样送回来 —— 采信它等于采信自己的输出。所以服务端陈述这个事实,而不是读回来。这与 boot 重水合对同一批行早就在写的那句话完全一致。

## 前提复核(在 `origin/main` 上)

| 前提 | 结论 | 证据 |
| --- | --- | --- |
| P1 `applyObjectRegistryMutation` 仍硬写 `'sys_metadata'` | ✅ 成立 | `protocol.ts:7362`(立单时 :7220,行号已漂移):`registerObject(request.item as any, 'sys_metadata')` |
| P2 B-minimal 陷阱仍成立 | ✅ 成立,已重跑探针 | 见下「反向验证 · 肢 A」:真 SchemaRegistry + 真 protocol,只去掉盖章 → `403 not_overridable` 当场复现 |
| P3 `registry.ts` 契约注释的 save-path 半句 | ⚠️ 被本 PR 改动波及,已就地最小修正 | 见下 |

P3 细节:注释原文「That sentinel only holds on the save path」在本 PR 之后**失真** —— save path 现在只对「无包绑定」的写入用哨兵。已就地最小改写成「该哨兵只标记一件事:这行没有绑定任何包」,并把 boot 半句显式标注为「描述的是契约,还不是代码」(PR2 落地后即可去掉该标注)。注释的**结论**(`_packageId !== 'sys_metadata'` 无法回答 provenance)不但没变,而且更成立了:切键之后连 save path 的包绑定行也带真实 id,哨兵判据更不可靠。注释本体的完整同步仍归 PR2。

## 测试

新增 `packages/objectql/src/protocol-writepath-object-ownership.test.ts`(10 例)。放在 objectql 而不是被测代码旁边,是因为断言的对象是**真** `SchemaRegistry`(ownership 冲突、`applyProtection` 的 provenance 默认、`getAllObjects` 过滤);objectql 依赖 metadata-protocol,只有这个方向能同时握住两半,反向 import 会闭合 turbo 拒绝的环。

- 写路径归属:带 `packageId` → contributor 记 `app.myapp`;不带 → 哨兵照旧。
- 服务端盖章:body 不带 `_provenance` → 记 `'org'`;body **回传** `_provenance: 'package'` → 仍记 `'org'`(请求永不胜出);且盖在副本上,调用方 body 不被写回 `_packageId` / `_provenance`。
- **cloud#970 反例**:新建 package-bound 对象 → 二次保存**成功**,`due_date` 进内存 schema,落盘仍是一行、仍绑在包上。
- **B-minimal 反例**(同一个键、去掉盖章)→ `403 not_overridable`,并断言 `_provenance` 被默认成 `'package'`,把因果链本身钉住。
- 包过滤面:`getAllObjects('app.myapp')` **首次保存即**返回该对象,且不串到 `app.otherapp`。
- 回滚:package-less 回滚走通(键从行读出 → 哨兵),恢复体生效。

```
pnpm --workspace-concurrency=2 --filter @objectstack/metadata-protocol --filter @objectstack/objectql test

packages/metadata-protocol test:  Test Files  49 passed (49)
packages/metadata-protocol test:       Tests  502 passed (502)
packages/objectql test:  Test Files  136 passed (136)
packages/objectql test:       Tests  2224 passed (2224)
```

门:

```
check-engine-double-contract: OK — 75 pinned, 133 in the DEBT ledger, 2 exempt.     (本 PR 前 73 pinned;新增的两个 double 已 pinned)
✓ durability-degradation log levels: 24 durability-critical catch seam(s), all loud, rethrowing or propagating to the caller
✓ read-seam invention (#5186, 3 package roots): 64 read seam(s), none invents an unreported empty answer
check-nul-bytes: OK (scanned 5920 tracked text file(s); no raw ASCII control bytes)
✓ No empty-frontmatter changeset introduced by this diff (1 declaring changeset(s) added).
check-type-check-coverage: OK — 62/77 workspace packages type-checked
```

`packages/objectql` `pnpm typecheck` 通过。`metadata-protocol` **没有** `typecheck` 脚本(在 type-check-coverage 的 DEBT ledger 里),直接跑 `tsc --noEmit` 得到 63 条**既存**错误,全部在该包的 `*.test.ts` 里,`src/protocol.ts` 零错误 —— 基线状况,非本 PR 引入。

## 反向验证(方向先写死,再实测)

⚠️ 一个必须先说的测量条件:objectql 的测试通过 package exports 解析到 metadata-protocol 的 **`dist/`**,不是 src。第一次跑肢 A 时忘了重建,得到「全绿」的假阴性;两条肢的下列结果都是**重建之后**的。

| 肢 | 预测 | 实测 | 符合? |
| --- | --- | --- | --- |
| **A** 去掉强制盖章(B-minimal 形态) | cloud#970 反例用例翻红 | 5 例红。核心红就是预测的那条:`[not_overridable] Metadata item 'object/myapp_invoice' is provided by a code package …`;另 `expected 'package' to be 'org'` | ✅ 方向符合,**红的范围比预测大** |
| **B** packageId 管线断开(恢复硬写哨兵) | 写路径用例翻红 | 2 例红:`expected 'sys_metadata' to be 'app.myapp'`;包过滤 `expected [] to deeply equal [ 'myapp_invoice' ]` | ✅ 完全符合 |

肢 A 多出来的 4 例不是预测落空,是**同一个 403 的下游**:盖章一去,第一次保存就把对象标成代码制品,于是两条 provenance 断言直接红,两条回滚用例连第二次保存都做不到(其中包括 tripwire 那条,它拿到的是 `not_overridable` 而不是预期的 `metadata_conflict`)。按「模板是工具不是真相」,如实记下范围差,而不是把它修剪成预测的样子。

另一处如实记录:**肢 B 没有覆盖到回滚那条改动** —— package-bound 回滚在两种形态下都 409(见下),package-less 回滚两种形态下都走哨兵。回滚这一笔的正确性由「键从行读出而不是从请求读」的论证 + package-less 端到端用例承担,不由肢 B 承担。

## 途中发现,已立单不修:#6215

`rollbackMetaItem` / `revertCommit` 对**任何** package-bound overlay 行**必定 409**,与本 PR 无关(`sys-metadata-repository.ts` 一个字都没动)。`restoreVersion` 调 `put` 时不传 `packageId`,`put` 又用 `whereFor(ref, state, opts.packageId ?? null)` —— `null` 是**谓词**(`package_id IS NULL`)而不是「任意包」,于是它找不到自己正在恢复的那一行,parent 读成 null:

```
[metadata_conflict] object/myapp_invoice advanced during rollback.
Expected parent sha256:00ca6e… but current is null.
```

后果:本 PR 回滚改动的 **package-bound 分支今天不可达**。我**没有**顺手修它(不在裁决范围,且改的是仓库写路径,需要自己的 pin 测试和 review),而是留了一条 **tripwire 用例**断言当前的 409 并指向 #6215 —— #6215 修好那天这条用例会红,修的人必须接着断言 ownership 键,而那句断言就写在它上一条用例里。

## 必答项

**#5079(`removeRuntimeShadow`)重新定价 —— 重测结论:治愈条件语义没有变化,成本模型不变;#5079 不应被定价成「等 #4636」。**

探针(真 SchemaRegistry,复现写路径改动后的两次调用,带对照组):

```
metadata.get("object") keys       : [ 'myapp_invoice' ]
objectContributors owner packageId: app.myapp
removeRuntimeShadow("object", …)  : false
removeRuntimeShadow("objects", …) : false
--- pre-#4636 (sentinel key) ---
objectContributors owner packageId: sys_metadata
removeRuntimeShadow("object", …)  : false
--- control: page (non-object) ---
metadata.get("page") keys         : [ 'com.acme.pkg:home', 'home' ]
removeRuntimeShadow("page", home) : true
```

机制:`removeRuntimeShadow` 扫的是 `this.metadata.get(type)` 里的复合键 `pkg:name` 兄弟项,判据 `it._packageId !== 'sys_metadata'` 也是对**那个 Map** 里的条目求值。而 object 这一片**永远只有裸键**:`applyObjectRegistryMutation` 调 `registerItem(type, item, 'name')` 不带 packageId(裸键),而全仓**没有任何**路径以 packageId 调 `registerItem('object', …)` —— `plugin.ts:1908` 对 `type === 'object'` 显式 `return`(注释:objects are registered differently (ownership model))。所以复合兄弟项从不存在,循环根本走不到那个判据。本 PR 搬的是 `objectContributors` 的键,是 `removeRuntimeShadow` 从不触碰的另一个结构。对照组证明探针有效:`page` 这种真的走 `registerItem(..., packageId)` 的类型两个键都在、`true` 治愈成功。

**#5927(deleteMetaItem 回执,同文件)—— 否,未触其面。** 本 PR 只碰 `applyObjectRegistryMutation` / `applyRegistryWriteThrough` 的调用点与 `rollbackMetaItem`;`deleteMetaItem` 及其回执构造、`restoreArtifactRegistryView` 一行未动。

**#5488 / #5311(`saveMetaItem` 的 api 命名空间门,下轮)—— 定价不变,面不相交。** 那两单要动的是 `saveMetaItem` 前半段的类型门/命名空间判定(`environmentId !== undefined` 那一块 gate),本 PR 的 packageId 管线全部落在**持久化之后**的 registry 写透(`if (mode === 'publish')` 之后)以及 `rollbackMetaItem`,两者之间隔着 `repo.put`。唯一的间接影响是正向的:写路径之后 `isArtifactBacked('object', …)` 对租户自建对象**稳定为 false**(靠强制盖章,而不是靠哨兵字符串),那两单要读这个判据时拿到的答案比现在更可靠。

**PR2 的入场券(PR1 合入后 boot 半边还剩什么,精确到行为差异):**

- 唯一代码改动仍是 `loadMetaFromDb` object 分支那一行(现 `protocol.ts:10657` 一带):`record.packageId || 'sys_metadata'` → `(record as { package_id?: string | null }).package_id || 'sys_metadata'`。该分支**已经**在盖 `_provenance: 'org'`,所以 PR2 **不需要**再处理盖章。
- PR1 之后的**行为差异**收敛成一条:一个绑在 `app.myapp` 上的对象,**本次会话内**创建/编辑后归属键是 `app.myapp`(包过滤看得见),**重启之后**归属键退回 `'sys_metadata'`(包过滤又看不见了)。即分类 bug 仍在,但只在重启后出现,且**不再有静默丢编辑的风险** —— 因为两侧都盖 `'org'`,`isArtifactBacked` 在两种键下都是 false,cloud#970 不会因为键不一致而复活。这正是裁决所说「先修写路径,之后任意时点落 boot 都可发布」。
- PR2 需要的 pin 测试:boot 水合一条带 `package_id` 的 object 行 → 断言 registry 归属是真实 id、`_provenance` 是 `'org'`、且**紧接着的一次 `saveMetaItem` 成功**(重启后可编辑,cloud#970 的重启面)。
- PR2 同时收尾 `objectql/src/registry.ts` 那段契约注释:去掉本 PR 加的「描述的是契约,还不是代码」标注。
- 不构成阻塞:PR2 与 #6215 无依赖关系。


---
_Generated by [Claude Code](https://claude.ai/code/session_019Q7oc7ASjh8yxyS3Yz78We)_