### PR TITLE
fix(spec): zodShapeOf 补齐 union 分支与 `prefault`,并附 #5056 测量轮 (#6098)

### DIFF
--- a/packages/spec/scripts/lib/zod-graph.ts
+++ b/packages/spec/scripts/lib/zod-graph.ts
@@ -79,10 +79,20 @@ export function zodChildSchemas(schema: z.ZodType): z.ZodType[] {
 /**
  * Wrapper defs that carry their subject in `innerType` and never change its shape.
  *
- * Deliberately the set `zodShapeOf` already used, byte for byte, so #5317 moves
- * ONLY the pipe direction. `prefault` — which the three sibling walkers below do
- * unwrap — is knowingly absent; adding it is a separate, separately measured
- * change (filed as its own finding, not smuggled in here).
+ * `prefault` closes the last spelling gap against the sibling walkers (#6098).
+ * Measured on the shipped graph at that change: the 25 metadata-type roots reach
+ * **zero** `prefault` nodes, and `.prefault(` has no call site anywhere in
+ * `packages/`, so this entry moves no verdict and no bridge today — it is
+ * parity, not a fix. It is worth having anyway because the alternative is the
+ * #4488 failure class: five walkers over the same Zod vocabulary
+ * (`check-liveness.mts`, `metadata-authoring-lint.ts`,
+ * `metadata-form-zod-reconciliation.test.ts`, `metadata-type-schemas.test.ts`,
+ * `shared/strict-object.ts`) already peel `prefault`, so the first author to
+ * write one would have had exactly this walker — the one feeding the deletion
+ * gate — stop resolving a shape, silently.
+ *
+ * Read by `pipeInIsTransform` as well as `zodShapeOf`, so a preprocess transform
+ * parked behind a `prefault` is now seen from both ends, deliberately.
  */
 const SHAPE_WRAPPER_TYPES = new Set([
   'optional',
@@ -91,6 +101,7 @@ const SHAPE_WRAPPER_TYPES = new Set([
   'catch',
   'readonly',
   'nonoptional',
+  'prefault',
 ]);
 
 /** Does this pipe's IN side resolve to a `transform` — i.e. is it a `z.preprocess`? */
@@ -156,11 +167,58 @@ export function pipeAuthorableSide(def: Record<string, unknown>, depth = 0): z.Z
 }
 
 /**
- * Unwrap pipes/wrappers/lazies down to a plain object def's shape, if any.
+ * The merged shape of a `union` node — every member's keys, first member wins on
+ * a name two members both declare (#6098).
  *
- * Returns `null` for anything that is not (or does not unwrap to) a single
- * object node — a union included. See the `zod-graph.test.ts` pin for what that
- * means for `view`, whose preprocess OUT is a union.
+ * Why merge at all: a metadata type may register a UNION of shapes rather than a
+ * single object (#3095 — `view` is the shipped specimen: a `defineView`
+ * container, a flattened list view, a flattened form view). All three sibling
+ * walkers already cross that node — `keyPosture` and `keysOf` by merging every
+ * member, `check-liveness`'s `shapeOf` by taking the first object member — and
+ * only this one stopped there and returned `null`.
+ *
+ * Why the merging rule and not `check-liveness`'s first-member rule: the two
+ * walkers are asked different questions. `shapeOf` governs a ledger of the
+ * canonical authorable CONTAINER, so "first object member" is its answer by
+ * design. This one feeds reachability, where a missed key can only ever waive a
+ * tombstone — so it takes the widest reading, exactly like `keysOf`.
+ *
+ * ⚠️ The one honest narrowing: the return type is one instance per name, while
+ * the consumer's bridge is keyed by (name, INSTANCE). When two members declare
+ * the same name with different instances — measured: 11 of the 92 union nodes in
+ * the root closure — only the first member's instance survives into this record,
+ * so a bridge that would have matched a later member's instance is not tested
+ * for. Measured at #6098 against a last-member-wins build of this same function:
+ * identical verdicts for all 1610 defs, so nothing turns on the choice today. If
+ * it ever does, the fix belongs in the consumer's bridge (a name → instance SET),
+ * never in a looser test here.
+ */
+function mergedUnionShape(def: Record<string, unknown>, depth: number): Record<string, unknown> | null {
+  if (!Array.isArray(def.options)) return null;
+  let merged: Record<string, unknown> | null = null;
+  for (const option of def.options) {
+    if (!(option instanceof z.ZodType)) continue;
+    const shape = zodShapeOf(option, depth + 1);
+    if (!shape) continue;
+    merged ??= {};
+    for (const [name, prop] of Object.entries(shape)) {
+      if (!(name in merged)) merged[name] = prop;
+    }
+  }
+  return merged;
+}
+
+/**
+ * Unwrap pipes/wrappers/lazies/unions down to an object shape, if any.
+ *
+ * Returns `null` for anything that does not resolve to at least one object node
+ * — a union of primitives included, since it has no keys to contribute.
+ *
+ * A union resolves to the MERGE of its members (see `mergedUnionShape`). In Zod
+ * 4.4.3 `z.discriminatedUnion` carries `def.type === 'union'` too (verified,
+ * #6098), so it needs no branch of its own — the `discriminated_union` arms the
+ * sibling walkers carry match nothing in this version and are deliberately not
+ * copied here.
  */
 export function zodShapeOf(schema: z.ZodType, depth = 0): Record<string, unknown> | null {
   if (depth > 12) return null;
@@ -170,6 +228,7 @@ export function zodShapeOf(schema: z.ZodType, depth = 0): Record<string, unknown
     const shape = def.shape;
     return shape && typeof shape === 'object' ? (shape as Record<string, unknown>) : null;
   }
+  if (def.type === 'union') return mergedUnionShape(def, depth);
   if (def.type === 'pipe') {
     const side = pipeAuthorableSide(def);
     return side ? zodShapeOf(side, depth + 1) : null;

--- a/packages/spec/scripts/zod-graph.test.ts
+++ b/packages/spec/scripts/zod-graph.test.ts
@@ -25,16 +25,24 @@
  * the pre-#5317 code, and the live-graph cases fail the moment a NEW preprocess
  * registration appears that the walker cannot resolve.
  *
- * ── What is deliberately NOT asserted ─────────────────────────────────────
- * "Every preprocess root resolves to a real shape" is the pin the issue asked
- * for, and it is not true of `view` — the one preprocess ROOT in the registry —
- * because its OUT is a `z.union`, and `zodShapeOf` has no union branch. Fixing
- * the pipe direction is necessary but not sufficient there. Asserting the
- * literal sentence would mean either a failing test or a union branch smuggled
- * in unmeasured, so what is pinned instead is the fact that actually holds and
- * that actually catches recurrence #5: no pipe in the registry ever resolves its
- * authorable side to a TRANSFORM. `view` passes that (its side is the union);
- * a regressed walker does not.
+ * ── The unwrap surface, completed at #6098 ────────────────────────────────
+ * #5317 fixed the pipe DIRECTION and stopped there, leaving `zodShapeOf` two
+ * spellings narrower than its three sibling walkers: no `union` arm, and no
+ * `prefault` wrapper. Both are now here, measured together (#6098), and the
+ * `view` case below is the one this file used to pin the other way round — it
+ * documented that a corrected direction still derived no shape, and it now pins
+ * the merged shape that direction actually leads to.
+ *
+ * What the measurement found, recorded because it is the part a future edit can
+ * silently undo: widening this walker cannot widen the consumer's derived-clone
+ * BRIDGE, because every object a resolved shape comes from is itself in the BFS
+ * closure (`zodChildSchemas` walks union options, wrapper `innerType`s and both
+ * pipe sides), so it has already contributed the same (name, instance) pairs.
+ * The single new bridge entry the run produced came from a `z.lazy` getter that
+ * mints fresh instances per call (`ui/NavigationItem`) and matches nothing, in
+ * either direction. What DID move is the query side: 18 defs that answered the
+ * `!shape` fail-closed default now answer from their real shape (17 of them
+ * `null`, one — `ui/ViewItem` — `derived-clone`).
  */
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
@@ -92,6 +100,79 @@ describe('zodShapeOf — pipe direction (#4488, #5074, #5317)', () => {
   });
 });
 
+describe('zodShapeOf — union members (#3095, #6098)', () => {
+  it('merges every member’s keys', () => {
+    const schema = z.union([
+      z.object({ shared: z.string(), onlyA: z.string() }),
+      z.object({ shared: z.string(), onlyB: z.number() }),
+    ]);
+
+    // Pre-#6098 this was null: no union arm, so the walker fell through.
+    expect(Object.keys(zodShapeOf(schema) ?? {})).toEqual(['shared', 'onlyA', 'onlyB']);
+  });
+
+  it('keeps the FIRST member’s instance when two members declare one name', () => {
+    // The documented narrowing: the consumer's bridge is keyed by (name,
+    // INSTANCE) and this record holds one instance per name. Pinned so the rule
+    // is a decision someone can find, not an accident of `Object.assign` order.
+    const first = z.string();
+    const second = z.string();
+    const shape = zodShapeOf(
+      z.union([z.object({ dup: first }), z.object({ dup: second })]),
+    );
+
+    expect(shape?.dup).toBe(first);
+    expect(shape?.dup).not.toBe(second);
+  });
+
+  it('descends a union nested inside a union', () => {
+    const schema = z.union([
+      z.union([z.object({ deep: z.string() })]),
+      z.object({ top: z.string() }),
+    ]);
+
+    // `view`'s live shape depends on this: its OUT union's first member is
+    // itself a union, and two of the 89 merged keys come only from there.
+    expect(Object.keys(zodShapeOf(schema) ?? {})).toEqual(['deep', 'top']);
+  });
+
+  it('still returns null for a union with no object member', () => {
+    // Widening the walker must not turn "no keys to contribute" into a shape:
+    // an empty shape would bridge on nothing and read as a resolved answer.
+    expect(zodShapeOf(z.union([z.string(), z.number()]))).toBeNull();
+  });
+
+  it('resolves a discriminated union through the same arm', () => {
+    const schema = z.discriminatedUnion('kind', [
+      z.object({ kind: z.literal('a'), a: z.string() }),
+      z.object({ kind: z.literal('b'), b: z.string() }),
+    ]);
+
+    // In Zod 4.4.3 a discriminated union IS a `union` def, which is why this
+    // walker carries no `discriminated_union` arm — one would match nothing.
+    // If a Zod upgrade ever splits them, this fails rather than going quiet.
+    expect(zodDefOf(schema)?.type).toBe('union');
+    expect(Object.keys(zodShapeOf(schema) ?? {})).toEqual(['kind', 'a', 'b']);
+  });
+});
+
+describe('zodShapeOf — `prefault` wrapper (#6098)', () => {
+  it('peels a `prefault` the way every sibling walker already does', () => {
+    const schema = z.object({ alpha: z.string() }).prefault({ alpha: 'x' });
+
+    expect(Object.keys(zodShapeOf(schema) ?? {})).toEqual(['alpha']);
+  });
+
+  it('sees a preprocess transform parked behind a `prefault`', () => {
+    // `SHAPE_WRAPPER_TYPES` is read by `pipeInIsTransform` too, so this is the
+    // second half of the same entry: IN unwraps to a transform, so the
+    // authorable side is OUT. Reading IN here would hand back the prefault.
+    const schema = z.transform((raw: unknown) => raw).prefault('x').pipe(z.object({ beta: z.string() }));
+
+    expect(Object.keys(zodShapeOf(schema as unknown as z.ZodType) ?? {})).toEqual(['beta']);
+  });
+});
+
 describe('pipeAuthorableSide — the registered metadata-type roots (#5317)', () => {
   /** Every registered root that compiles to a `pipe`, with its resolved side. */
   const pipeRoots = listMetadataTypeSchemaTypes().flatMap((type) => {
@@ -134,15 +215,33 @@ describe('pipeAuthorableSide — the registered metadata-type roots (#5317)', ()
     expect(Object.keys(zodShapeOf(schema!) ?? {}).length).toBeGreaterThan(10);
   });
 
-  it('documents that `view`s preprocess OUT is a union, so it still derives no shape', () => {
-    // Honest pin of the measured state rather than the issue's expectation: the
-    // direction is now right (the side is the union, not the transform), but
-    // `zodShapeOf` has no union branch, so `view` still yields null. Whoever adds
-    // that branch will land here — and should re-measure the derived-clone bridge
-    // before doing so (#5056: a new bridge can mark a dead shape reachable).
+  it('resolves `view`s preprocess OUT union to the MERGE of its members', () => {
+    // ── This case is the converted #5317 pin, not a new one ──────────────
+    // It used to assert `zodShapeOf(view)` was null and to say why: the
+    // direction was right, the union arm was missing, so the one preprocess
+    // ROOT in the registry still derived nothing. #6098 added that arm after the
+    // measurement it was waiting on, so the same case now pins the shape the
+    // corrected direction actually leads to. The direction assertion is kept
+    // verbatim — it is the #4488 recurrence guard and is independent of the
+    // union arm.
     const schema = getMetadataTypeSchema('view');
     expect(schema).toBeDefined();
     expect(defTypeOf(pipeAuthorableSide(zodDefOf(schema!)!))).toBe('union');
-    expect(zodShapeOf(schema!)).toBeNull();
+
+    const shape = zodShapeOf(schema!);
+    expect(shape).not.toBeNull();
+
+    // Not a key count (89 today, and every view feature moves it) — one key that
+    // ONLY a given member declares, so the assertion fails if the merge ever
+    // silently collapses to a single member. All four members are represented,
+    // the first of them a nested union:
+    expect(Object.keys(shape ?? {})).toEqual(
+      expect.arrayContaining([
+        'isPinned', // member 0 only — and member 0 is itself a union
+        'list', //     the defineView container member
+        'pagination', // the flattened list-view member
+        'sections', //  the flattened form-view member
+      ]),
+    );
   });
 });


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6098

`zodShapeOf` 在 #5317 把管道方向修对之后，仍比三个同族 walker 窄两格：**没有 union 分支**、**wrapper 集合缺 `prefault`**。本 PR 把两格补齐，并按 #5056 要求做了完整的测量轮——两格分开量，逐条解释判定移动与桥项变化。

## 改了什么

`packages/spec/scripts/lib/zod-graph.ts`：

1. **union 分支**（`mergedUnionShape`）：union 解为**全部成员键的合并**，递归（`view` 的 OUT union 第 0 个成员本身又是 union），同名键**取第一个成员的实例**。
2. **`prefault`** 加入 `SHAPE_WRAPPER_TYPES`。该常量同时被 `pipeInIsTransform` 读，所以「藏在 `prefault` 后面的 preprocess transform」两端都能看见。

合并规则为什么跟 `keysOf` / `keyPosture`（合并全部成员）而不是 check-liveness `shapeOf`（取第一个 object 成员）：两者被问的问题不同。`shapeOf` 治理的是「规范可编写**容器**」的台账，取首个 object 成员是它的设计答案；这个 walker 喂的是可达性，**漏一个键只会白白豁免一个 tombstone**，所以取最宽的读法。

## #5056 测量轮（本单的核心）

方法同 #5317：在 `computeSurfaceReachability` 末尾临时 dump 全部 1610 个 def 的 `reachableVia` 判定 + 完整 `bridged` 表 + 每个桥项的贡献者 + 每个 def 的 holder（从全部 emitted def 出发的反向 BFS），改前/改后各跑一次 `gen:schema` 做 diff。**该 instrumentation 已在提交前完全还原**，本 PR 不含 `build-schemas.ts` 的任何改动。

### 两格分开量

| | 判定移动 | 桥项变化 | 生成物 |
|---|---|---|---|
| **只加 `prefault`** | **0** | **0**（1518 → 1518，新增/丢失均为 0） | 无 diff |
| **再加 union** | 18 | 1518 → **1519** | 无 diff |

`prefault` 之所以完全惰性：25 个 metadata-type 根的闭包里**一个 `prefault` 节点都没有**，且 `.prefault(` 在整个 `packages/` 下**没有任何调用点**。它是 parity 而不是 fix——五个同族 walker（`check-liveness.mts`、`metadata-authoring-lint.ts`、`metadata-form-zod-reconciliation.test.ts`、`metadata-type-schemas.test.ts`、`shared/strict-object.ts`）都剥 `prefault`，只有这一个不剥；第一个写下 `.prefault()` 的人，会**恰好只在这个喂删除门禁的 walker 上**静默丢掉 shape。

### `bridged` 表：唯一一个新增桥项，逐条解释

```
1518 → 1519 pairs（1518 → 1519 instances），新增 1、丢失 0
  + children@[instance]   贡献者：ui/NavigationItem（一个 z.lazy 节点）
```

- **为什么只有 1 个**（也是本轮最重要的结论）：**放宽这个 walker 原则上不可能扩大桥表**。任何解出的 shape 最终都来自某个 object 节点，而 `zodChildSchemas` 会走 union 的 `options`、wrapper 的 `innerType`、pipe 的两侧和 `lazy` 的 getter——**那个 object 节点本来就在 BFS 闭包里，早已贡献过同样的 (name, instance) 对**。union 节点自己解出的合并 shape 只是它成员已贡献内容的子集。
- **那这 1 个是怎么来的**：`NavigationItemSchema = z.lazy(() => z.discriminatedUnion('type', [... .extend({ children })...]))`，其 getter **没有记忆化**（实测 `getter() !== getter()`），每次调用都会 `.extend()` 出**全新的 `children` 实例**。`zodChildSchemas` 调一次 getter 入队，`zodShapeOf` 又调一次拿到另一份——于是桥表里多了一个**从未被 BFS 访问过的实例**。
- **它是不是 #5056 说的假可达桥？不是，它谁也匹配不上**：实测**0 个 def** 命中该桥项（每次 `zodShapeOf` 都会 mint 新实例，身份永远对不上）。它是惰性的，不改变任何判定。
- 由此还看到一个与本单无关的观察项（已另行开 #6221，不在本 PR 修）：非记忆化 `z.lazy` 的 shape 实例身份不稳定。今天不产生错误答案——`ui/NavigationItem` 自身在 `visited` 里（先于 shape 判定返回 `root-graph`），`data/FilterArray` 则根本解不出 shape、维持 fail-closed。

### 判定移动：18 条，**全部**发生在查询侧

总量：`root-graph` 520 → **502**、`null` 1084 → **1101**、`derived-clone` 6 → **7**。

18 条移动**没有一条**来自新桥项——全部来自 `reachableVia` 里 `if (!shape) return 'root-graph'` 那个 **fail-closed 兜底**：这些 def 自己的 shape 现在解得出来了，于是改由真实判定回答。

⚠️ **这里必须诚实纠正派发令的一处预设。** 派发令要求特别标注 `root-graph → derived-clone`（#5056 的假可达面）。实测这个方向只有 **1 条**，而且它**不改变严格度**——`root-graph` 和 `derived-clone` 对门禁都是「可达」，同样要求 tombstone，变的只是提示语。真正需要盯的是派发令没有预期的**另一个方向**：17 条 `root-graph → null`，而 `null` 是**豁免 tombstone**。这是本轮唯一的放宽，所以下面逐条给证据。

#### (a) 唯一一条 `root-graph → derived-clone`

| def | 判定 | 证据 |
|---|---|---|
| `ui/ViewItem` | root-graph（兜底） → derived-clone | 它是 union、不在 `visited`。现在解出 18 键，其中 `name` 命中的桥实例 `ui/ViewItemName` **与 `view` 根 pipe、其 OUT union、`ui/ViewItemWire` 及两个扁平 view 成员是同一个实例**；`_lock` 等 ADR-0010 provenance 字段同理。这是真桥——ViewItem 确实通过 `view` 根 union 成员的派生克隆可编写。且该桥项**改动前就已存在**（由那两个 object 成员贡献），本次只是它自己的 shape 终于解得出来去命中它。 |

#### (b) 17 条 `root-graph → null`（放宽方向，逐条 holder 证据）

全部 17 个都是 **`union` 类型、`visited=false`**（BFS 身份不可达——这点**本次改动前后完全一致**，`visited` 恒为 4900 个节点），且**没有任何桥命中**。判定它们「不可达」的最强旁证是 holder：**每一个的 holder 家族本来就全部答 `null`**，或者根本没有 holder（顶层 export，没人内嵌）。这正是 #5317 为 `ui/InlineAction` 用过的同一条论证。

| def | holders（方括号内为 holder 当前判定） |
|---|---|
| `ai/KnowledgeSourceKind` | `ai/KnowledgeSource[null]` |
| `ai/MessageContent` | `ai/ConversationMessage[null]` |
| `api/DeviceTokenResponse` | 无（仅顶层 export） |
| `api/WebSocketMessage` | 无（仅顶层 export） |
| `data/DataEngineRequest` | 无（仅顶层 export） |
| `data/FileLikeValue` | 无（仅顶层 export） |
| `data/GroupByNode` | `data/Query[null]` |
| `integration/ConnectorInstanceAuth` | `integration/Connector[null]`、`integration/DeclarativeConnectorEntry[null]` |
| `kernel/ManifestPermissions` | 12 个 holder，全部 `[null]`（`kernel/Manifest`、`kernel/InstalledPackage`、`kernel/UpgradeSnapshot` 及 9 个 `api/*Package*` 请求/响应） |
| `system/CRDTState` | `system/CRDTMergeResult[null]` |
| `system/MigrationOperation` | `system/ChangeSet[null]` |
| `system/OTComponent` | `system/OTOperation[null]`、`system/OTTransformResult[null]` |
| `system/SpecifierHandler` | `system/Specifier[null]` |
| `system/TenantIsolationConfig` | 无（仅顶层 export） |
| `ui/ChartGroupBy` | `ui/ChartAggregate[null]` |
| `ui/RecordHighlightsField` | `ui/RecordHighlightsProps[null]`（react-block props 家族，#5317 记录过 `ui/Element*Props` 早已全体答 null） |
| `ui/WidgetSource` | `ui/WidgetManifest[null]` |

**判定：这 17 条是把兜底换成测量，不是放松门禁。** 它们此前答 `root-graph` 的原因与可达性无关——只是「union 解不出 shape」这一个 walker 缺口；它们的 holder 家族早已全体答 `null`，现在它们和自己的家族答案一致了。#5317 对 `ui/InlineAction` 做的正是同一件事（`root-graph` 兜底 → `null` 实测），并已随 PR #6102 合入。

### 合并顺序（同名键取第一个成员）——已测，今天无差别

同名不同实例的碰撞在闭包的 92 个 union 节点里出现在 **11 个**上（`view` 的 4 成员 union 就碰撞 21 个键）。因为返回类型是「一个名字一个实例」，后面成员的实例不会进入记录，理论上会漏掉一个桥测试。**实测**：把同一函数改成 last-member-wins 重跑一遍，**1610 个 def 的判定完全一致**，桥项总数同为 1519。所以这个选择今天不影响任何结论；真要影响的那天，修法在**消费侧的桥**（name → instance **集合**），而不是在这里放宽测试——这一点写进了函数注释。

### 分片生成物：零移动

`gen:schema` 全程**没有打印任何 `📒 … — commit it.`**（该行只在分片字节真的变化时才打），改动后 `git status` 对 `authorable-surface/`、`json-schema.manifest/`、`api-surface/` 全部干净，`check:generated` 报告 **10/10 up to date**。

> 一处对派发令措辞的更正：#6069 之后 `gen:schema` 并**不**逐分片打印 `IDENTICAL/CHANGED`——`writeShards` 对字节未变的分片直接跳过、不写不报，**沉默即 identical**，只有真写了才打 `touched:` 行。所以「零移动」的凭据是「没有那一行 + `check:generated` 全绿 + `git status` 干净」这三条。

## 测试：那条 `view` 钉子是**转换**，不是删除

`packages/spec/scripts/zod-graph.test.ts` 里 `documents that view's preprocess OUT is a union, so it still derives no shape` 钉的是「方向修对但仍解不出 shape」这一诚实现状，本 PR 恰好消除了这个限制。按要求**转换**为 `resolves view's preprocess OUT union to the MERGE of its members`：

- **保留**方向断言（`pipeAuthorableSide(view)` 仍是 `union`）——那是 #4488 的复发守卫，与 union 分支无关；
- 新增断言改钉合并后的真相，且**不钉键数**（今天 89 个，任何 view 特性都会动它），而是各挑一个**只有某个成员才声明**的键：`isPinned`（只有第 0 个成员有，而它本身是嵌套 union）、`list`（容器成员）、`pagination`（扁平 list 成员）、`sections`（扁平 form 成员）。合并一旦塌回单一成员，这条就红。

另新增 7 条钉子：union 合并 / 同名取首个实例（钉实例身份）/ 嵌套 union / **无 object 成员的 union 仍返回 `null`**（放宽不得把「没有键可贡献」变成空 shape）/ discriminated union 走同一条分支（并钉住 Zod 4.4.3 下 `z.discriminatedUnion` 的 `def.type` 就是 `union`，所以这里**故意不抄**同族 walker 那条永远匹配不上的 `discriminated_union` 分支）/ `prefault` 剥离 / `prefault` 后面的 preprocess transform。

**反向验证**（先写预测再跑）：预测「把两格删掉后，7 条新钉子红、其余 10 条绿，其中『无 object 成员的 union 返回 null』因为旧代码 union 恒返回 null 而**保持绿**」。实测 `Tests 7 failed | 10 passed (17)`，红的正是预测的那 7 条。

## Changeset：不加，改用 `skip-changeset`

`packages/spec` 的 `files` 白名单是 `dist / json-schema / liveness / prompts / llms.txt / README.md / src/**/*.zod.ts / CHANGELOG.md / api-surface / spec-changes.json`——**`scripts/` 不在发布物里**；而会发布的生成物（`json-schema`、`api-surface`、authorable-surface）本轮**逐字节未变**。所以这个 PR 不发布任何东西。同一文件面的父 PR #6102（#5317）也未带 changeset，先例一致。

## 门禁

```
pnpm --filter @objectstack/spec build（含 DTS）        ✓
pnpm --filter @objectstack/spec check:generated       ✓ All 10 generated artifacts are up to date.
pnpm --filter @objectstack/spec typecheck             ✓ tsc --noEmit + check:test-typecheck OK
pnpm --filter @objectstack/spec test                  ✓ 330 files / 8426 tests passed
npx vitest run scripts/zod-graph.test.ts              ✓ 17 passed（含 7 条新/转换钉子）
pnpm --filter @objectstack/spec check:liveness        ✓
pnpm lint                                             ✓
pnpm check:nul-bytes                                  ✓ 5920 files, no raw control bytes
pnpm check:shard-attestation / check:empty-changeset  ✓（合 main 后新落地的两个门禁）
```


---
_Generated by [Claude Code](https://claude.ai/code/session_014wsZeReNTqiceBfLb5Pyf5)_