### PR TITLE
fix(runtime): 退役 callData 的 batch 分支 —— 唯一一支「返回成功」的未实现 action (#5856) + 401 信封注释纠正 (#5800)

### DIFF
--- a/.changeset/calldata-batch-arm-retired.md
+++ b/.changeset/calldata-batch-arm-retired.md
@@ -1,0 +1,34 @@
+---
+"@objectstack/runtime": patch
+---
+
+fix(runtime): `callData` no longer has a `batch` arm that answers a silent, empty success (#5856)
+
+`callData`'s `action === 'batch'` arm returned `{ object, results: [] }` — an
+HTTP 200 whose body a consumer cannot tell apart from "the batch ran and matched
+nothing" — while opening no transaction and writing nothing. It was the only arm
+in that function answering an unimplemented action with **success**: every other
+unhandled action throws `400 Unknown data action: …`, and `aggregate` throws
+`503` when the engine cannot serve it. Retry, idempotency and audit logic all
+read a 200 + empty result set as one successful empty operation.
+
+Nothing could reach it, and that is the point: its safety lived **upstream**, in
+a route table that happens not to spell `batch`, not in any guard of its own —
+the ADR-0115 Evidence 5 / #4451 shape, where one route-table extension silently
+turns a dormant branch into a live "successfully did nothing". Every entry point
+was enumerated before removal (`/data` compares `parts[1]` against the literal
+`'query'` and otherwise reads it as a record id; the MCP bridge, the actions
+domain and `invokeBusinessAction` pass literals; the declarative endpoint
+executor is bounded by `ApiEndpointSchema.objectParams.operation`, a closed enum
+of find/get/create/update/delete; and `callData` is not part of this package's
+export surface), so the arm is removed under ADR-0049 enforce-or-remove rather
+than converted to a 501 nobody would ever receive.
+
+**Behaviour on every live path is unchanged** — no reachable request produced
+that response. What changed is the answer waiting for the first caller who ever
+does spell `batch`: a loud `400 Unknown data action: batch`, identical to any
+other unknown action, instead of a silent success. Batching itself is untouched
+and keeps its single owner: `@objectstack/rest`'s `registerBatchEndpoints`
+mounts both `POST /batch` (atomic, cross-object) and `POST /data/:object/batch`
+(per-object, ADR-0119) — which is exactly why a host serving only the
+dispatcher reports `capabilities.transactionalBatch: false` (#5672).

--- a/packages/runtime/src/action-execution-calldata-batch-retired.test.ts
+++ b/packages/runtime/src/action-execution-calldata-batch-retired.test.ts
@@ -1,0 +1,248 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #5856 — `callData` has no `batch` arm, and `batch` is refused like every
+ * other action it does not serve.
+ *
+ * The removed code was three lines:
+ *
+ * ```ts
+ * if (action === 'batch') {
+ *     // Batch operations — not yet supported via direct service dispatch
+ *     return { object: params.object, results: [] };
+ * }
+ * ```
+ *
+ * It was the ONLY arm in `callData` that answered an unimplemented action with
+ * SUCCESS. Every other unhandled action throws `400 Unknown data action: …`,
+ * and `aggregate` throws `503` when the engine cannot serve it — this one
+ * returned an HTTP 200 whose body is shaped exactly like a batch that ran and
+ * matched nothing, having opened no transaction and written nothing. Retry,
+ * idempotency and audit all read that as one successful empty operation.
+ *
+ * ## Why deleting it changed no online behaviour — the enumeration
+ *
+ * Nothing could reach the arm, and its unreachability lived UPSTREAM of it
+ * (ADR-0115 Evidence 5 / #4451: "the slot exists, nobody registers it"), which
+ * is why removal is the fix rather than a comment. Every entry point into
+ * `callData`, on `main` at the time of the fix:
+ *
+ * | entry point | what it passes as `action` |
+ * |---|---|
+ * | `domains/data.ts` (`/data`) | the literals `query` / `get` / `create` / `update` / `delete`; `parts[1]` is compared against `'query'` and otherwise read as a record **id**, never as an action |
+ * | `domains/mcp.ts` (MCP bridge, `run_action`) | the literals `query` / `get` / `aggregate` / `create` / `update` / `delete` |
+ * | `domains/actions.ts` + `invokeBusinessAction` | the literal `get` |
+ * | `endpoint-executor.ts` (declarative endpoints, bound in `dispatcher-plugin.ts`) | one literal per `ObjectOperation`, and that type is `ApiEndpointSchema.objectParams.operation` — a CLOSED enum of find/get/create/update/delete |
+ * | outside this package | nothing: `callData` is not re-exported from `packages/runtime/src/index.ts` |
+ *
+ * The two structural halves of that table are pinned below (the `/data` route
+ * table, and the endpoint vocabulary) so a future re-wiring has to face them.
+ *
+ * ## What this suite pins
+ *
+ * 1. `batch` is refused with the SAME `{ statusCode: 400, message }` shape as
+ *    any other unknown action — on a deployment WITH the `protocol` slot and
+ *    on one WITHOUT it, since the removed arm sat past both paths;
+ * 2. the actions `callData` really serves are untouched (positive control);
+ * 3. the two upstream facts that made the arm unreachable.
+ *
+ * Reverse verification (direction predicted BEFORE running, then measured —
+ * see the PR): restoring the three lines turns case 1 RED in the ordinary
+ * direction — the call RESOLVES `{ object: 'task', results: [] }` instead of
+ * rejecting, so every `rejects` assertion in `describe('batch is refused …')`
+ * fails with "promise resolved instead of rejected". Cases 2 and 3 stay green
+ * under the restore: they describe the paths the arm never sat on, which is
+ * the same claim the enumeration above makes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ObjectStackProtocolImplementation } from '@objectstack/metadata-protocol';
+import { ApiEndpointSchema } from '@objectstack/spec/api';
+
+import { callData, type ActionExecutionDeps } from './action-execution.js';
+import { HttpDispatcher, type HttpProtocolContext } from './http-dispatcher.js';
+
+const EC = { userId: 'u1', isSystem: false, positions: [], permissions: [] } as any;
+/** [#5155] Every service lookup resolves off the REQUEST's kernel. */
+const REQ = { request: {} } as HttpProtocolContext;
+const SCHEMA = { name: 'task', fields: { title: { name: 'title', type: 'text' } } };
+
+// ---------------------------------------------------------------------------
+// Harnesses — the same row set behind both deployments
+// ---------------------------------------------------------------------------
+
+function rows() {
+    return [{ id: 'r1', title: 'one' }];
+}
+
+/** The read surface both harnesses share. No write verb is defined: this suite
+ *  never writes, and a double that declares one it does not need is a contract
+ *  to keep in sync for nothing (`check:engine-double-contract`'s subject). */
+function engine(store = rows()) {
+    return {
+        // `registry` is what `HttpDispatcher.getObjectQLService` requires before
+        // it will hand the service to `callData` — not decoration.
+        registry: { getObject: (n: string) => (n === 'task' ? SCHEMA : undefined) },
+        find: async (_o: string, bag: any) => {
+            const id = bag?.where?.id;
+            return id == null ? [...store] : store.filter((r) => r.id === String(id));
+        },
+        findOne: async (_o: string, opts: any) => store.find((r) => r.id === String(opts?.where?.id)) ?? null,
+    } as any;
+}
+
+/** No `protocol` slot — every verb takes `callData`'s ObjectQL fallback. */
+function fallbackHarness() {
+    const ql = engine();
+    const services: Record<string, any> = {
+        metadata: { getObject: async () => ({ name: 'task', fields: {} }) },
+        objectql: ql,
+    };
+    const deps: ActionExecutionDeps = {
+        resolveService: (async (_c: HttpProtocolContext, name: string) => services[name]) as any,
+        getObjectQL: async () => ql,
+    };
+    return { deps, ql, services };
+}
+
+/** Protocol-first, with the REAL `@objectstack/metadata-protocol` occupant. */
+function protocolHarness() {
+    const ql = engine();
+    const services: Record<string, any> = {
+        metadata: { getObject: async () => ({ name: 'task', fields: {} }) },
+        protocol: new ObjectStackProtocolImplementation(ql),
+        objectql: ql,
+    };
+    const deps: ActionExecutionDeps = {
+        resolveService: (async (_c: HttpProtocolContext, name: string) => services[name]) as any,
+        getObjectQL: async () => ql,
+    };
+    return { deps, ql, services };
+}
+
+const DEPLOYMENTS: Array<[string, () => { deps: ActionExecutionDeps }]> = [
+    ['without the protocol slot (ObjectQL fallback)', fallbackHarness],
+    ['with the protocol slot', protocolHarness],
+];
+
+/** Capture a rejection as plain data so two of them can be compared. */
+async function rejection(p: Promise<unknown>) {
+    try {
+        const resolved = await p;
+        return { rejected: false as const, resolved };
+    } catch (e) {
+        return { rejected: true as const, error: e as any };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. `batch` is refused, and refused like everything else unknown
+// ---------------------------------------------------------------------------
+
+describe('batch is refused with the unknown-action answer (#5856)', () => {
+    it.each(DEPLOYMENTS)('%s → 400 Unknown data action: batch', async (_label, harness) => {
+        const { deps } = harness();
+        await expect(
+            callData(deps, REQ, 'batch', { object: 'task' }, undefined, undefined, EC),
+        ).rejects.toEqual({ statusCode: 400, message: 'Unknown data action: batch' });
+    }, 60_000);
+
+    it('answers `batch` in the SAME shape as any other unknown action', async () => {
+        // The claim the issue is about, stated as an identity rather than as a
+        // literal: `batch` is no longer a special case of anything. Only the
+        // action name may differ between the two rejections.
+        const { deps } = fallbackHarness();
+        const forBatch = await rejection(callData(deps, REQ, 'batch', { object: 'task' }, undefined, undefined, EC));
+        const forOther = await rejection(callData(deps, REQ, 'frobnicate', { object: 'task' }, undefined, undefined, EC));
+
+        expect(forBatch.rejected).toBe(true);
+        expect(forOther.rejected).toBe(true);
+        expect(Object.keys(forBatch.error).sort()).toEqual(Object.keys(forOther.error).sort());
+        expect(forBatch.error.statusCode).toBe(forOther.error.statusCode);
+        expect(forBatch.error.message.replace('batch', 'X')).toBe(forOther.error.message.replace('frobnicate', 'X'));
+    }, 60_000);
+
+    it('never answers a 200 whose body reads as "the batch ran and matched nothing"', async () => {
+        // The was-red assertion in its narrowest form. `{ results: [] }` is
+        // indistinguishable from a real empty batch, which is what made this
+        // worse than a 501: nothing downstream can tell the two apart.
+        for (const [, harness] of DEPLOYMENTS) {
+            const outcome = await rejection(
+                callData(harness().deps, REQ, 'batch', { object: 'task' }, undefined, undefined, EC),
+            );
+            expect(outcome.rejected).toBe(true);
+            expect(outcome).not.toMatchObject({ resolved: { results: [] } });
+        }
+    }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// 2. Positive control — the actions `callData` DOES serve are untouched
+// ---------------------------------------------------------------------------
+
+describe('the served actions still answer (positive control)', () => {
+    it.each(DEPLOYMENTS)('%s → query lists, get reads', async (_label, harness) => {
+        const { deps } = harness();
+        const list: any = await callData(deps, REQ, 'query', { object: 'task', query: {} }, undefined, undefined, EC);
+        expect(list.object).toBe('task');
+        expect(list.records).toEqual([{ id: 'r1', title: 'one' }]);
+
+        const one: any = await callData(deps, REQ, 'get', { object: 'task', id: 'r1' }, undefined, undefined, EC);
+        expect(one).toMatchObject({ object: 'task', id: 'r1', record: { id: 'r1', title: 'one' } });
+    }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// 3. The two upstream facts that made the arm unreachable
+// ---------------------------------------------------------------------------
+
+describe('nothing upstream can spell `batch` (#5856 enumeration)', () => {
+    it('the dispatcher’s `/data` domain declines `/data/:object/batch` — it routes only `query`', async () => {
+        // `handleDataRequest` compares `parts[1]` against the literal 'query'
+        // and otherwise reads it as a record id, so this POST matches no branch
+        // and the domain DECLINES it (`handled: false`). This is the upstream
+        // constraint the removed arm was relying on for its safety.
+        //
+        // Note what this does NOT say: `POST /data/:object/batch` is a real
+        // endpoint — `@objectstack/rest` mounts it (`registerBatchEndpoints`,
+        // `rest-server.ts`), together with the cross-object `POST /batch`.
+        // That is the point of route-ownership rule 1: batching has one owner,
+        // and a host that wants it mounts REST. What is pinned here is that
+        // THIS domain is not a second owner of the same path.
+        const h = fallbackHarness();
+        const resolve = (name: string) =>
+            name === 'objectql' ? h.ql
+            : name === 'metadata' ? h.services.metadata
+            : name === 'auth' ? { api: { getSession: async () => ({ user: { id: 'u1' } }) } }
+            : undefined;
+        const kernel: any = { getService: resolve, getServiceAsync: async (n: string) => resolve(n) };
+        const dispatcher = new HttpDispatcher(kernel);
+
+        const res: any = await dispatcher.dispatch('POST', '/data/task/batch', { operations: [] }, {}, { request: {} } as HttpProtocolContext);
+        expect(res.handled).toBe(false);
+
+        // The sibling that IS routed, so the assertion above cannot pass by the
+        // whole domain being broken.
+        const served: any = await dispatcher.dispatch('POST', '/data/task/query', {}, {}, { request: {} } as HttpProtocolContext);
+        expect(served.handled).toBe(true);
+        expect(served.response.status).toBe(200);
+    }, 60_000);
+
+    it('a declared endpoint cannot ask for `batch` — the operation enum is closed', () => {
+        // `endpoint-executor.ts`'s `ObjectOperation` is this enum, so the
+        // declarative-endpoint path can only ever hand `callData` one of five
+        // literals. Publish rejects the rest.
+        const declare = (operation: string) =>
+            ApiEndpointSchema.safeParse({
+                name: 'task_batch',
+                path: '/api/v1/apps/showcase/task',
+                method: 'POST',
+                type: 'object_operation',
+                target: 'task',
+                objectParams: { object: 'task', operation },
+            });
+
+        expect(declare('batch').success).toBe(false);
+        expect(declare('create').success).toBe(true);
+    });
+});

--- a/packages/runtime/src/action-execution.ts
+++ b/packages/runtime/src/action-execution.ts
@@ -347,11 +347,28 @@ export async function callData(deps: ActionExecutionDeps,
         throw { statusCode: 503, message: 'Data service not available' };
     }
 
-    if (action === 'batch') {
-        // Batch operations — not yet supported via direct service dispatch
-        return { object: params.object, results: [] };
-    }
-
+    // [#5856] `batch` deliberately has NO arm here. It used to answer
+    // `{ object, results: [] }` — an HTTP 200 whose body a consumer cannot
+    // tell apart from "the batch ran and matched nothing" — on a path that
+    // opened no transaction and wrote nothing. Its safety was never its own:
+    // no caller of `callData` can spell `batch` (`domains/data.ts` compares
+    // `parts[1]` against the literal `'query'`; `domains/mcp.ts`,
+    // `domains/actions.ts` and `invokeBusinessAction` pass literals; the
+    // declarative endpoint executor is bounded by
+    // `ApiEndpointSchema.objectParams.operation`, a closed enum of
+    // find/get/create/update/delete; and `callData` is not part of this
+    // package's export surface), so the arm's only live effect was to
+    // pre-decide — wrongly — what the FIRST caller to arrive would get:
+    // a silent success where every other unhandled action gets a loud
+    // refusal. Removed under ADR-0049 enforce-or-remove, so `batch` falls to
+    // the same 400 as any other unknown action. Batching itself is untouched
+    // and keeps its ONE owner (route-ownership rule 1): both the atomic
+    // cross-object `POST /batch` and the per-object `POST /data/:object/batch`
+    // are mounted by `@objectstack/rest`'s `registerBatchEndpoints`
+    // (ADR-0119) — which is exactly why this dispatcher answers
+    // `capabilities.transactionalBatch: false` (#5672,
+    // `http-dispatcher.ts`). Pinned by
+    // `action-execution-calldata-batch-retired.test.ts`.
     throw { statusCode: 400, message: `Unknown data action: ${action}` };
 }
 

--- a/packages/runtime/src/domains/data.ts
+++ b/packages/runtime/src/domains/data.ts
@@ -53,7 +53,18 @@ export async function handleDataRequest(deps: DomainHandlerDeps, path: string, m
 
     const m = method.toUpperCase();
 
-    // 1. Custom Actions (query, batch)
+    // 1. Custom Actions (query)
+    //
+    // [#5856] `batch` was listed here too, and was the last trace of a wiring
+    // that never happened: no branch below routes it, and `callData`'s
+    // `action === 'batch'` arm (which answered a silent `{ results: [] }`) has
+    // been removed with it. Batching has ONE owner and it is not this domain
+    // (route-ownership rule 1): `@objectstack/rest`'s `registerBatchEndpoints`
+    // mounts both `POST /batch` (atomic, cross-object) and `POST
+    // /data/:object/batch` (per-object) — which is exactly why a host serving
+    // only this dispatcher reports `capabilities.transactionalBatch: false`
+    // (#5672). Re-adding `batch` HERE would be a second implementation of a
+    // path REST already serves, not the missing half of one.
     if (parts.length > 1) {
         const action = parts[1];
 

--- a/packages/runtime/src/endpoint-policy.ts
+++ b/packages/runtime/src/endpoint-policy.ts
@@ -270,7 +270,23 @@ export function computeCacheControl(
     return `private, max-age=${Math.floor(ttl)}`;
 }
 
-/** The 401 every seam on this platform answers — same code, same message, same envelope. */
+/**
+ * The anonymous 401 this seam answers: the same DECISION, {@link ANONYMOUS_DENY_CODE}
+ * and {@link ANONYMOUS_DENY_MESSAGE} as every other seam — in the **dispatcher's**
+ * envelope, `{ success: false, error: { code, message, httpStatus } }`, which is
+ * what `apiErrorResponse` builds.
+ *
+ * NOT the platform's only 401 body, and this comment used to say it was ("same
+ * code, same message, same envelope"). The REST seam — `@objectstack/rest`'s
+ * `enforceAuth`, writing `ANONYMOUS_DENY_BODY` — answers the flat
+ * `{ error, message }`. Both envelopes are live and sanctioned by ADR-0112's
+ * 2026-07-30 amendment (#4007); converging them is a breaking wire change owned
+ * by the envelope-convergence line (#3843 family), not by this function. The
+ * full two-envelope table lives on `ANONYMOUS_DENY_BODY`
+ * (`@objectstack/core`, `security/anonymous-deny.ts`), narrowed there by #5632
+ * — this was the same claim surviving on the side that PRODUCES the wrapper,
+ * where it reads as authoritative (#5800).
+ */
 function anonymousDenial(): EndpointPolicyVerdict {
     const { status, body } = apiErrorResponse({
         code: ANONYMOUS_DENY_CODE,

--- a/packages/runtime/src/http-dispatcher.ts
+++ b/packages/runtime/src/http-dispatcher.ts
@@ -1409,8 +1409,13 @@ export class HttpDispatcher {
                 // (`registerBatchEndpoints`) — this dispatcher has no batch
                 // branch at all: `domains/data.ts` routes only `query` as a
                 // custom action, and `callData`'s vestigial `action === 'batch'`
-                // arm is unreachable from here and returns `{ results: [] }`
-                // without opening a transaction. Answering `engine.transaction`
+                // arm — unreachable from here, and returning `{ results: [] }`
+                // without opening a transaction — was REMOVED under ADR-0049
+                // enforce-or-remove (#5856), so `batch` now falls to the same
+                // `400 Unknown data action` as any other unhandled action.
+                // Nothing about this verdict changed with it: the reason was
+                // "this face does not serve `/batch`" both before and after.
+                // Answering `engine.transaction`
                 // instead would advertise atomicity for an endpoint this host
                 // does not serve — the `declared ≠ enforced` lie the flag was
                 // introduced (#3298/#1604) to remove. A host that mounts REST


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5856
Fixes objectstack-ai/objectstack#5800

主体是 #5856(删除 `callData` 的 `batch` 分支);#5800 是**搭车**的一行注释纠正,理由见第 7 节。

按分诊倾向走 **选项 1(删除该分支)**:`callData` 的 `action === 'batch'` 分支落到默认的 `throw { statusCode: 400, message: 'Unknown data action: batch' }`,与同函数其它未知 action 完全同形;`domains/data.ts` 注释里的 `batch` 一并清掉。**实施过程中没有发现任何真实接线计划的证据**(依据见第 3 节),因此不改走选项 2(501)。

## 1. 前提重验(against `origin/main` @ `8e2bbba24`)

| 前提 | 结论 |
|---|---|
| 分支仍在、仍返回成功 | ✅ `packages/runtime/src/action-execution.ts:350`(立单时行号即当前行号),`return { object: params.object, results: [] }` |
| 它是该函数唯一「返回成功」的未实现分支 | ✅ 其它未知 action → 400;`aggregate` 引擎缺能力 → 503;仅此一支返回 200 |
| 当前不可达 | ✅ 见下方枚举 |
| `domains/data.ts` 的 `// 1. Custom Actions (query, batch)` 仍在 | ✅ 已清理 |

## 2. 不可达性枚举 —— 「删除安全」的论证主体

`callData` 的**全部**入口,以及每个入口能送进来的 `action` 取值:

| 入口 | 送进来的 `action` | 为什么送不进 `batch` |
|---|---|---|
| `domains/data.ts`(`/data` 域) | 字面量 `query` / `get` / `create` / `update` / `delete` | 路由表只把 `parts[1]` 与字面量 `'query'` 比较;其余分支把 `parts[1]` 当作**记录 id** 读,从不当作 action 转发。`POST /data/:object/batch` 在本域**不匹配任何分支**,返回 `handled: false` |
| `domains/mcp.ts`(MCP 桥 / `run_action`) | 字面量 `query` / `get` / `aggregate` / `create` / `update` / `delete` | `const callData = actionExec.callData.bind(null, deps, context)` 之后每个调用点都是硬编码字面量 |
| `domains/actions.ts:300` 与 `action-execution.ts` 的 `invokeBusinessAction` | 字面量 `get` | 同上 |
| `endpoint-executor.ts`(声明式端点,在 `dispatcher-plugin.ts:1434` 绑定) | 每个 `ObjectOperation` 一个字面量 | `ObjectOperation` 就是 `ApiEndpointSchema.objectParams.operation` 的**封闭枚举** find/get/create/update/delete;`executeObjectOperation` 的兜底分支是 `delete`,不是透传 |
| 包外调用者 | 无 | `callData` **不在** `packages/runtime/src/index.ts` 的导出面上,`@objectstack/runtime` 的 `exports` 只有 `.` 一个入口 |

这份枚举里的两条**结构性**约束已经写成可执行断言(见新增测试第 3 组):`/data` 域拒收 `/data/:object/batch`,以及 `ApiEndpointSchema` 拒收 `operation: 'batch'`。

⚠️ 一处必须说清楚的**否定之否定**:`POST /data/:object/batch` **是真实存在的端点** —— 由 `@objectstack/rest` 的 `registerBatchEndpoints` 挂载(`rest-server.ts:8406`),连同跨对象的 `POST /batch`(`rest-server.ts:8236`)。本 PR 钉的是 **dispatcher 的 `/data` 域不是这条路径的第二个 owner**(route-ownership 规则 1),而不是「这条路径不存在」。批处理的 owner 唯一且不变。

## 3. 选项 1 的依据

1. **ADR-0049 enforce-or-remove**:没有生产者、没有消费者、没有路由的能力,不留在代码里假装存在;
2. **与 #5672 同向**:该 host 的 `capabilities.transactionalBatch: false` 正是「本 face 不交付 `/batch`」,分支即便可达也不开事务、不写入 —— 它是该结论的证据而非反例;
3. **501 的「响亮」在这里兑现不了**:501 只有在有人来探测时才有价值,而枚举证明没有任何入口能探测到它;留着一个 501 分支,等于把「接线」这件事继续挂在半空;
4. **ADR-0076 D11 worklist 第 (1) 条**原文即 “kill or delegate the dead callable branches”;
5. 200 + `{ results: [] }` 是「declared ≠ enforced」里最难查的一种:消费者无法把它与「批处理成功但零匹配」区分开,重试 / 幂等 / 审计三条链路都会记成一次成功的空操作。

**没有找到接线计划的证据**(找过的地方,均无命中):`docs/adr/` 全文(ADR-0119 是治理 `/batch` 原子性的那一本,**通篇不提 dispatcher / callData**)、`ROADMAP.md`、该分支的 git 历史、以及仓库内 open issue(搜 `callData` / `action-execution` / dispatcher batch,除 #5856 外无相关单)。

## 4. 改动面

| 文件 | 改动 |
|---|---|
| `packages/runtime/src/action-execution.ts` | 删除 `batch` 分支;在默认 400 处留下墓碑注释(为什么删、枚举摘要、批处理的真正 owner、钉子测试位置) |
| `packages/runtime/src/domains/data.ts` | `// 1. Custom Actions (query, batch)` → `(query)`,并写明「在这里重新加 `batch` 是给 REST 已服务的路径造第二个实现」 |
| `packages/runtime/src/http-dispatcher.ts` | **超出既定文件面,故说明**:`transactionalBatch` 那段 #5672 注释逐字描述了我删掉的分支(“`callData`'s vestigial `action === 'batch'` arm … returns `{ results: [] }`”)。删完不改,它就是一句事实错误的注释 —— 正是本仓库反复付学费的那类漂移。只改这段描述,`transactionalBatch: false` 的裁定与理由**一字未动** |
| `packages/runtime/src/action-execution-calldata-batch-retired.test.ts` | 新增钉子(8 个用例,见第 6 节) |
| `.changeset/calldata-batch-arm-retired.md` | `@objectstack/runtime` patch(**只描述 #5856**) |
| `packages/runtime/src/endpoint-policy.ts` | #5800 搭车,仅注释,见第 7 节 |

**在线行为零变化**:没有任何可达请求曾经拿到过那个响应。变的只是「第一个真的写出 `batch` 的调用者」拿到什么 —— 从静默成功变成响亮的 400。

## 5. 反向验证(先预测方向,再跑)

**预测(动手前写进测试文件头)**:恢复被删的三行 ⇒ 第 1 组(`batch is refused …`)转红,失败形态为「promise 解析成 `{ object: 'task', results: [] }` 而非 reject」;第 2 组(阳性对照)与第 3 组(枚举)保持绿 —— 因为它们描述的是那条分支从未坐落其上的路径。

**实测**(临时恢复分支后跑同一文件,随后已还原,`grep -c "action === 'batch'" packages/runtime/src/action-execution.ts` = 0):

```
× batch is refused … > without the protocol slot (ObjectQL fallback) → 400 Unknown data action: batch
   → promise resolved "{ object: 'task', results: [] }" instead of rejecting
× batch is refused … > with the protocol slot → 400 Unknown data action: batch
   → promise resolved "{ object: 'task', results: [] }" instead of rejecting
× batch is refused … > answers `batch` in the SAME shape as any other unknown action
× batch is refused … > never answers a 200 whose body reads as "the batch ran and matched nothing"
✓ the served actions still answer (positive control) > without the protocol slot → query lists, get reads
✓ the served actions still answer (positive control) > with the protocol slot → query lists, get reads
✓ nothing upstream can spell `batch` … > the dispatcher's `/data` domain declines /data/:object/batch
✓ nothing upstream can spell `batch` … > a declared endpoint cannot ask for `batch`
 Tests  4 failed | 4 passed (8)
```

方向与预测一致(常规红向)。一处与模板的偏差,如实记:预测写的是「第 1 组转红」,该组实际有 **4** 个用例(2 个参数化 + 2 个),4/4 全红,不是我脑子里默数的 3 个;其余 4/4 全绿。

## 6. 测试与门禁

新增钉子 `packages/runtime/src/action-execution-calldata-batch-retired.test.ts`,三组:

1. **钉子**:`batch` 在**有 protocol slot** 与**无 protocol slot** 两种部署下都 reject `{ statusCode: 400, message: 'Unknown data action: batch' }`(被删的分支坐在两条路径之后,所以两种都要钉);并断言它与任意其它未知 action(`frobnicate`)的**拒绝形状逐字段一致**,只有 action 名不同 —— 即「`batch` 不再是任何东西的特例」;
2. **阳性对照**:`query` / `get` 在两种部署下照常返回;
3. **枚举的可执行部分**:`/data` 域拒收 `/data/:object/batch`(同时用 `/data/:object/query` 走通作对照,防止「整个域坏掉」也能让断言通过);`ApiEndpointSchema` 拒收 `operation: 'batch'`、接受 `create`。

```
pnpm --filter @objectstack/runtime test      → Test Files 106 passed (106) / Tests 1514 passed (1514)
pnpm --filter @objectstack/runtime typecheck → tsc --noEmit,无输出
npx eslint --no-inline-config(改动的 5 个 .ts) → 无输出
```
(两次都跑过:#5856 提交后一次,#5800 搭车提交后再一次,结果相同。)

ESLint job 内的家族门禁本地逐条跑过,全 PASS:`check:nul-bytes`、`check:engine-double-contract`、`check:route-envelope`、`check:error-code-casing`、`check:wildcard-fallthrough`、`check:adr-anchors`、`check:durability-log-level`、`check:startup-registry-verdict`、`check:slot-lookup`、`check:query-options-erasure`。

新增的 fake engine 只声明 `find` / `findOne`,不声明任何写动词 —— `check:engine-double-contract` 的检查面是 double 的 `delete` / `update`,一个用不到却要跟着契约走的写动词本身就是它治理的对象。

## 7. 搭车项:#5800(`endpoint-policy.ts` 的 401 信封注释)

**为什么搭车**:#5800 的分诊建议即为搭车,且维护者本轮示意加速 —— 处置是**一行注释**、零行为变更、零测试、零 changeset 条目,单独跑一趟 CI 的成本远高于其收益,而它与本 PR 同包(`packages/runtime`)、同「注释与事实漂移」类别。

**改了什么**:`packages/runtime/src/endpoint-policy.ts` 的 `anonymousDenial()` docstring 原文是 “The 401 every seam on this platform answers — same code, same message, **same envelope**”。前两项成立,第三项不成立:此处的 `apiErrorResponse` 产出的是 dispatcher 的 wrapper 信封 `{ success: false, error: { code, message, httpStatus } }`,而 REST seam(`@objectstack/rest` `enforceAuth` → `ANONYMOUS_DENY_BODY`)写的是扁平 `{ error, message }`。新注释说明:code / message 与其它 seam 一致,envelope 是 dispatcher 自己的 wrapper,两个信封都是 ADR-0112 2026-07-30 修正案(#4007)记录在案的 live 信封,收敛归 #3843 family;完整的两信封对照表**继续单源**在 `@objectstack/core` 的 `security/anonymous-deny.ts`(#5632 已窄化的那段),此处只指过去、不复制,措辞与其保持一致。

这正是 #5632 修掉的同一条谎言长在**产出 wrapper 的那一侧**,而那一侧读起来更像权威 —— 也是不该让它继续躺着的原因。`packages/runtime` 的行为一行未动。