### PR TITLE
fix(rest): dashboard requiresService 组件门禁在默认读取路径上真正执行 (#5881)

### DIFF
--- a/.changeset/dashboard-service-gate-default-path.md
+++ b/.changeset/dashboard-service-gate-default-path.md
@@ -1,0 +1,30 @@
+---
+"@objectstack/rest": patch
+---
+
+fix(rest): dashboard 组件门禁在默认配置下真正执行 (#5881)
+
+ADR-0057 D10 的 `requiresService` 组件门禁 —— 剔除指向未注册可选服务的 dashboard
+磁贴 —— 在默认部署里一次都没跑过。`GET /meta/:type/:name` 的单条读取有一条缓存分支,
+它排除了 `app`(per-user RBAC 过滤)与 `doc` / `book`(per-caller audience),唯独没有
+排除 `dashboard`;而 `enableCache` 默认为 `true`。门禁写在非缓存分支里,于是只有显式
+关掉缓存的部署才会执行到它。
+
+后果正是该 ADR 点名要防的那一幕:在没有某个可选服务的部署里(比如单租户运行时里的
+Organizations KPI,其 `org-scoping` 服务不存在),console 会渲染一块绑定到缺失服务的
+死磁贴 —— 尽管服务端的门禁代码在、测试也在。
+
+**修复**:`dashboard` 与 `app` 同款,从缓存分支排除,两种拼写(`/meta/dashboard/x`
+与规范复数 `/meta/dashboards/x`)都覆盖。其它元数据类型的 ETag 快路径不受影响。
+
+**为什么不是"把门禁提到分支之外、两条路径共用"** —— 那读起来更整齐,但 ETag 无法承载
+门禁结论:validator 是**未过滤文档**的哈希,而 `notModified` 在 protocol 内部就已判定,
+REST 层没有机会重判。共用之后送出的就是"过滤过的正文 + 指向未过滤正文的 validator"。
+一次 boot 之内这没有危害(已注册服务集在 bootstrap 之后不可变),但 `Cache-Control:
+private, no-cache` 意味着客户端**存下正文**、之后只做重验证,而存下的正文比进程活得久:
+一次关掉该可选服务的重新部署并不改变文档,ETag 不变 ⇒ 每次重验证都回 304 ⇒ 那块死磁贴
+恰好在移除其服务的那次部署之后被永久缓存下来。放弃快路径的代价则接近于零:
+`getMetaItemCached` 本就委托给 `getMetaItem`,服务端两条路做的是同样的工作,失去的只是
+304 省下的正文字节。
+
+对调用方的可见变化:dashboard 的单条读取不再返回 ETag / 304,每次都是完整的 200。

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -4246,7 +4246,48 @@ export class RestServer {
                         // `doc` and `book` bypass the shared cache: their §6.7
                         // audience gate is per-caller, and a shared ETag would
                         // leak gated content across viewers.
-                        if (metadata.enableCache && p.getMetaItemCached && !isAppType && !isDraftRead && !previewDrafts && !packageScoped && req.params.type !== 'doc' && req.params.type !== 'book') {
+                        //
+                        // [#5881] `dashboard` bypasses it too, and the reason is
+                        // NOT the one above — worth writing down, because the
+                        // obvious reading says a dashboard needn't bypass at all.
+                        // Its ADR-0057 D10 widget gate (`filterDashboardForUser`,
+                        // below) is per-DEPLOYMENT — it asks which optional kernel
+                        // services are registered — never per-caller, so there is
+                        // no cross-viewer leak to avoid. What rules out sharing
+                        // the cached path is the validator itself: the ETag is
+                        // `simpleHash(locale + JSON.stringify(item))` over the
+                        // UNFILTERED document (metadata-protocol `getMetaItemCached`),
+                        // so it cannot express the gate dimension at all, and
+                        // `notModified` is decided inside the protocol before this
+                        // layer could re-judge it. Gating the cached body would
+                        // therefore ship a filtered body under a validator that
+                        // identifies the unfiltered one.
+                        //
+                        // That mismatch is not academic, because the two have
+                        // different lifetimes. Within one boot the registered-service
+                        // set is fixed (`Kernel.use()` throws once bootstrap has
+                        // started, and no deregistration API exists), so the gate
+                        // verdict is stable per process — but `Cache-Control:
+                        // private, no-cache` means the client STORES the body and
+                        // revalidates, and that stored body outlives the process.
+                        // A redeploy that turns the optional service off does not
+                        // change the document, so the ETag is unchanged, every
+                        // revalidation answers 304, and the stale unfiltered body
+                        // stands: the dead tile D10 exists to prevent, now cached
+                        // indefinitely. Bypassing costs nothing to weigh against
+                        // that — `getMetaItemCached` delegates to `getMetaItem`,
+                        // so the server does identical work either way and only
+                        // the 304's saved body bytes are given up.
+                        //
+                        // Compared on the NORMALIZED type, like `isAppType` and
+                        // unlike the two literals at the end of this condition
+                        // (`/meta/dashboards/x` is the canonical plural spelling
+                        // under Prime Directive #3, and an exclusion it could be
+                        // spelled around would not be an exclusion). The `doc` /
+                        // `book` literals have exactly that hole — measured and
+                        // filed as #6241, deliberately not fixed here.
+                        const isDashboardType = RestServer.metaTypeSingular(req.params.type) === 'dashboard';
+                        if (metadata.enableCache && p.getMetaItemCached && !isAppType && !isDashboardType && !isDraftRead && !previewDrafts && !packageScoped && req.params.type !== 'doc' && req.params.type !== 'book') {
                             const cacheRequest = {
                                 ifNoneMatch: req.headers['if-none-match'] as string,
                                 ifModifiedSince: req.headers['if-modified-since'] as string,
@@ -4367,7 +4408,18 @@ export class RestServer {
                             // ADR-0057 D10: gate dashboard widgets by `requiresService`
                             // (mirrors the app-nav gate above) so the console never
                             // renders a tile bound to an absent optional service.
-                            if (RestServer.metaTypeSingular(req.params.type) === 'dashboard' && visible) {
+                            //
+                            // [#5881] This is now on the DEFAULT path. It reads as
+                            // ordinary code either way, which is exactly why the
+                            // defect was invisible: `enableCache` defaults to true
+                            // and `dashboard` was not excluded above, so every
+                            // default deployment took the cached branch and this
+                            // gate ran only where an operator had turned the cache
+                            // off. Declared, tested, and never executed in
+                            // production — the exclusion above is what makes the
+                            // ADR's "the server is the authoritative gate" true
+                            // rather than merely written down.
+                            if (isDashboardType && visible) {
                                 const ctx = await this.resolveExecCtx(environmentId, req).catch(() => undefined);
                                 const registered = await this.resolveRegisteredServices((ctx as any)?.__kernel, [visible]);
                                 const serviceGate = registered ? (n: string) => registered.has(n) : undefined;

--- a/packages/rest/src/rest.test.ts
+++ b/packages/rest/src/rest.test.ts
@@ -3375,9 +3375,12 @@ describe('filterDashboardForUser — ADR-0057 D10 widget requiresService gate', 
     const rest: any = new RestServer(
       createMockServer() as any,
       protocol,
-      // The widget gate lives on the uncached read; the cached branch — which
-      // is the DEFAULT — does not run it at all (pre-existing and unrelated to
-      // #5563, filed as #5881), so this pins the gate where it exists.
+      // [#5881] `enableCache: false` is no longer what makes this reachable —
+      // dashboard reads bypass the cache unconditionally now, and the DEFAULT
+      // configuration is pinned separately below. Kept explicit because an
+      // operator who disables the cache must get the same answer, and because
+      // this case is what the fix had to leave untouched: it was the only
+      // green proof the gate worked at all while the default path skipped it.
       { api: { requireAuth: false }, metadata: { enableCache: false } } as any,
     );
     rest.resolveExecCtx = async () => ({ userId: 'u1', systemPermissions: [] });
@@ -3393,6 +3396,114 @@ describe('filterDashboardForUser — ADR-0057 D10 widget requiresService gate', 
     expect(body).toMatchObject({ type: 'dashboard', name: 'system_overview' });
     expect(ids(body.item)).not.toContain('widget_organizations');
     expect(ids(body.item)).toContain('widget_total_users');
+  });
+
+  // -------------------------------------------------------------------------
+  // [#5881] The gate on the DEFAULT path.
+  //
+  // `enableCache` defaults to true, and the single-item read had a cached
+  // branch that excluded `app` (per-user RBAC) and `doc`/`book` (per-caller
+  // audience) but NOT `dashboard` — so the widget gate above, which lives in
+  // the uncached branch, never ran in a default deployment. Measured on
+  // `origin/main` @ 8e2bbba24 before the fix, against the real RestServer:
+  //
+  //     cachedCalls: 1 | uncachedCalls: 0 | widgetsServed: ["w_users","w_orgs"]
+  //
+  // The fix excludes `dashboard` from the cached branch, as `app` already was.
+  // Why not instead hoist the gate so both branches run it once — which reads
+  // like the tidier shape? Because the ETag cannot carry the gate's verdict:
+  // it is a hash of the UNFILTERED document, and `notModified` is decided
+  // inside the protocol before this layer sees it. Measured, same baseline:
+  //
+  //     etag(unfiltered): 2504e71e | etag(gated body): 75ca17c1 | same? false
+  //     revalidate-with-unfiltered-etag -> notModified: true
+  //     cacheControl: {"directives":["private","no-cache"]}
+  //
+  // So a hoisted gate would ship a filtered body under a validator naming the
+  // unfiltered one. Within one boot that is harmless (the registered-service
+  // set cannot change: `Kernel.use()` throws after bootstrap and nothing
+  // deregisters), but `private, no-cache` means the client stores the body and
+  // only revalidates — and the stored body outlives the process. Turn the
+  // optional service off in a redeploy and the document is unchanged, so every
+  // revalidation answers 304 and the dead tile survives the very deploy that
+  // removed its service. The full-read cost of not caching is nil:
+  // `getMetaItemCached` delegates to `getMetaItem`, so the server does the same
+  // work either way and only the 304's saved bytes are given up.
+  // -------------------------------------------------------------------------
+  /** A protocol offering BOTH reads, so the branch choice is the thing tested. */
+  const bothReads = () => {
+    const protocol: any = createMockProtocol();
+    protocol.getMetaItem = vi.fn().mockResolvedValue({
+      type: 'dashboard', name: 'system_overview', item: dash(),
+    });
+    protocol.getMetaItemCached = vi.fn().mockResolvedValue({
+      data: dash(),
+      etag: { value: 'etag-unfiltered', weak: false },
+      lastModified: new Date().toISOString(),
+      cacheControl: { directives: ['private', 'no-cache'] },
+      notModified: false,
+    });
+    return protocol;
+  };
+  /** Default config — no `metadata` block at all, so `enableCache` is its default. */
+  const defaultServer = (protocol: any) => {
+    const rest: any = new RestServer(createMockServer() as any, protocol, ANON_API as any);
+    rest.resolveExecCtx = async () => ({ userId: 'u1', systemPermissions: [] });
+    rest.serviceExistsProvider = (n: string) => n !== 'org-scoping';
+    rest.registerRoutes();
+    return rest;
+  };
+  const readMeta = async (rest: any, type: string, name: string) => {
+    const route = rest.getRoutes().find(
+      (r: any) => r.method === 'GET' && r.path === '/api/v1/meta/:type/:name',
+    );
+    const res = { json: vi.fn(), status: vi.fn().mockReturnThis(), header: vi.fn(), send: vi.fn() };
+    await route.handler({ params: { type, name }, query: {}, headers: {} }, res);
+    return res;
+  };
+
+  it('runs the gate under the DEFAULT configuration, not only when the cache is off', async () => {
+    const protocol = bothReads();
+    const res = await readMeta(defaultServer(protocol), 'dashboard', 'system_overview');
+
+    const body = res.json.mock.calls.at(-1)![0];
+    expect(ids(body.item)).not.toContain('widget_organizations');
+    expect(ids(body.item)).toContain('widget_total_users');
+    // The envelope the route owes its caller is unchanged by the branch switch.
+    expect(body).toMatchObject({ type: 'dashboard', name: 'system_overview' });
+  });
+
+  it('a dashboard read takes the uncached branch — while other types still cache', async () => {
+    // The positive control matters as much as the assertion above it: excluding
+    // one type from the cached branch is only correct if it excludes exactly
+    // that type. A fix that disabled the cache wholesale would satisfy every
+    // gate assertion here and quietly cost every other metadata read its ETag.
+    const protocol = bothReads();
+    const rest = defaultServer(protocol);
+
+    const dashRes = await readMeta(rest, 'dashboard', 'system_overview');
+    expect(protocol.getMetaItemCached).not.toHaveBeenCalled();
+    expect(protocol.getMetaItem).toHaveBeenCalledTimes(1);
+    // The observable price of the bypass, pinned rather than hidden: a
+    // dashboard read carries no ETag validator now.
+    expect(dashRes.header.mock.calls.map((c: any[]) => c[0])).not.toContain('ETag');
+
+    const viewRes = await readMeta(rest, 'view', 'account_list');
+    expect(protocol.getMetaItemCached).toHaveBeenCalledTimes(1);
+    expect(viewRes.header.mock.calls.map((c: any[]) => c[0])).toContain('ETag');
+  });
+
+  it('the plural spelling cannot spell its way around the exclusion', async () => {
+    // `/meta/dashboards/x` is the CANONICAL REST spelling (Prime Directive #3)
+    // and the route serves both, so an exclusion compared against the literal
+    // `'dashboard'` would leave the default path ungated under the spelling
+    // most callers use — the #3984 defect class, which `metaTypeSingular`'s own
+    // docstring exists to remember.
+    const protocol = bothReads();
+    const res = await readMeta(defaultServer(protocol), 'dashboards', 'system_overview');
+
+    expect(protocol.getMetaItemCached).not.toHaveBeenCalled();
+    expect(ids(res.json.mock.calls.at(-1)![0].item)).not.toContain('widget_organizations');
   });
 
   it('resolveRegisteredServices discovers requiresService declared on widgets', async () => {


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5881

ADR-0057 D10 的 dashboard 组件门禁(`filterDashboardForUser`,按 `widget.requiresService` 剔除指向未注册可选服务的磁贴)在默认配置下一次都没跑过。本 PR 让它在默认路径上真正执行。

## 一、前提重定价(基线已从立单时漂移)

立单基线 `55c74deeb`,此后该 handler 被 #5895(#5563 信封收敛)、#5808、#5821、#6205 多次改写。在全新 worktree 里对 **`origin/main` @ `8e2bbba24`** 重验,**前提仍然成立**:

- 缓存分支进入条件 `packages/rest/src/rest-server.ts:4249`(改前行号):

  ```
  if (metadata.enableCache && p.getMetaItemCached && !isAppType && !isDraftRead && !previewDrafts
      && !packageScoped && req.params.type !== 'doc' && req.params.type !== 'book') {
  ```

  排除了 `app`(`isAppType`,注释写明是为了让 per-user RBAC 过滤能跑)、`doc` / `book`(§6.7 audience 是 per-caller),**没有排除 `dashboard`**。
- 门禁调用点 `rest-server.ts:4374`(改前行号),位于 `else`(非缓存)分支内。
- `enableCache` 默认 `true`(`packages/spec/src/api/rest-server.zod.ts`)。

对真 `RestServer` 跑探针(protocol 同时提供 `getMetaItem` 与 `getMetaItemCached`,`serviceExistsProvider` 报 `org-scoping` 未注册,dashboard 含一块 `requiresService` 磁贴),默认配置(不写 `metadata` 块):

```
P1 cachedCalls: 1 | uncachedCalls: 0 | widgetsServed: ["w_users","w_orgs"]
```

`w_orgs` 原样送出 —— 与立单时的测量一致。

## 二、必答项:ETag / 缓存键与门禁结果的关系(实测)

**ETag 按什么算?** `simpleHash(locale + JSON.stringify(item))`,其中 `item` 是 `getMetaItem` 返回的**未过滤文档**(`packages/metadata-protocol/src/protocol.ts` 的 `getMetaItemCached`)。门禁结论完全不进哈希。实测:

```
P2 etag(unfiltered): 2504e71e | etag(gated body): 75ca17c1 | same? false
   revalidate-with-unfiltered-etag -> notModified: true | body on 304: (空)
   cacheControl: {"directives":["private","no-cache"]}
```

**门禁是 per-deployment 还是 per-caller?** per-deployment。`resolveRegisteredServices` 只问"哪些可选内核服务被注册了"(`kernel.getServiceAsync` 或 `serviceExistsProvider`),从不读调用方身份 —— 这正是它与 `app` / `doc` / `book` 的不对称之处(见第四节)。

**一次 boot 内 serviceGate 结果会不会变(服务晚注册 / 注销)?** 不会。

- `Kernel.use()` 在 `state !== 'idle'` 时抛错(`packages/core/src/kernel.ts:180-183`,`Cannot register plugins after bootstrap has started`)⇒ bootstrap 之后无法再加插件;
- 全仓没有任何注销通道:`unregisterService` / `removeService` / `services.delete` 在 `packages/core/src` + `packages/runtime/src` 命中 0 处;
- `registerService` 对重名抛错;`replaceService` 只换已存在名字的实例,**存在性不变**。

所以进程内门禁结论是稳定的。

**同一 ETag 下发 filtered body 是否正确?** **不正确 —— 这一条否掉了 B。** 稳定性的窗口是"一次 boot",而 validator 的寿命比进程长:`Cache-Control: private, no-cache` 表示客户端**存下正文**、之后每次只做重验证。一次关掉该可选服务的重新部署并不改变文档 ⇒ ETag 不变 ⇒ 每次重验证都回 304 ⇒ 客户端一直复用**旧的、未过滤的**正文。也就是说,那块死磁贴恰好在"移除其服务"的那次部署之后被永久缓存下来 —— 正是 D10 要防的那一幕。

而且 REST 层没有补救余地:`notModified` 在 protocol 内部就已判定,等 REST 拿到结果时 304 已成定局。要让 B 正确,只能 (i) 改 `packages/spec` 的 `GetMetaItemCachedRequest` 契约、把门禁指纹塞进缓存键,或 (ii) 在 REST 层重新实现一遍重验证 —— 前者为一个元数据类型改公共契约,后者把 validator 逻辑复制到消费侧。

## 三、A/B 取舍:取 A

派发令写的是「若实测支持 B ⇒ 做 B;若拿不出证据 ⇒ 退到 A」。实测的结论比"拿不出证据"更强一层:**它主动证伪了 B 的安全前提**,所以取 A —— 把 `dashboard` 加进缓存排除条件,与 `app` 同款。

A 的代价("dashboard 读失去 ETag 快路径")实测下来接近于零:`getMetaItemCached` 本就**委托给 `getMetaItem`**(`protocol.ts`),服务端两条路做的是同样的工作,缓存分支甚至多做一次 stringify + hash。真正失去的只有 304 省下的正文字节,而这些正文是少量小文档。这一项代价已在测试里**明写钉住**(dashboard 读不再带 ETag 头),不藏。

比较用的是**归一化后的类型**(`RestServer.metaTypeSingular(...)`,与 `isAppType` 同款),不是字面量:`/meta/dashboards/x` 是 Prime Directive #3 下的规范复数拼写,一个能被换个拼写绕过去的排除不算排除。

## 四、不对称性:`app` / `doc` / `book` vs `dashboard`

值得写下来,因为两者结论相同、理由完全不同:

| | 门禁维度 | 为什么必须绕开缓存 |
|:--|:--|:--|
| `app` | **per-user**(RBAC / `requiredPermissions`) | 共享 ETag 会跨 admin / member 串正文 |
| `doc` / `book` | **per-caller**(§6.7 audience) | 同上,门禁内容会跨 viewer 泄漏 |
| `dashboard` | **per-deployment**(已注册服务集) | 没有跨调用方泄漏问题;**是 validator 表达不了这个维度**,而客户端存下的正文比"该维度保持稳定的那个进程"活得久 |

立单时点名的那半边不对称(「`app` 为了让 per-user 过滤能跑特意绕开缓存,`dashboard` 的门禁却写在只有绕开缓存才会到达的分支里 —— 同一天同一个 ADR 的两半」)由本 PR 消除。剩下的那半边不对称是**字面量 vs 归一化**:`doc` / `book` 仍用字面量比较,见下。

## 五、反向验证(先预测方向,再跑)

预测:把 `!isDashboardType` 从条件里去掉(其余不动),**三条新用例全红**,而 #5563 那条显式 `enableCache: false` 的老用例**保持绿** —— 后者保持绿正是缺陷能存活至今的原因,所以它必须绿,否则说明我钉错了地方。

实测,完全吻合:

```
❯ src/rest.test.ts (202 tests | 3 failed | 185 skipped)
  × runs the gate under the DEFAULT configuration, not only when the cache is off
  × a dashboard read takes the uncached branch — while other types still cache
  × the plural spelling cannot spell its way around the exclusion
AssertionError: expected [ 'widget_total_users', …(2) ] to not include 'widget_organizations'
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 Tests  3 failed | 14 passed | 185 skipped (202)
```

恢复修复后 17 条全绿。

## 六、测试

- **新增(缓存路径,默认配置)**:复用探针形状,断言 `w_orgs` 被剔除且信封形状不变 —— 修复前红。
- **新增(阳性对照)**:dashboard 读不再调 `getMetaItemCached` 且不带 ETag 头,而**同一个 server 上** `view` 读仍走缓存分支、仍带 ETag。这条比主断言更关键:一个"把缓存整体关掉"的错误修法会让所有门禁断言照样绿,却悄悄让其它元数据读全部失去 ETag。
- **新增(复数拼写)**:`/meta/dashboards/x` 同样被排除且同样被门禁。
- **保留(非缓存路径)**:#5563 那条显式 `enableCache: false` 的用例原样保留,只更新了其中已经过时的注释(它原先写着"缓存分支不跑门禁,所以这里显式关缓存"—— 现在不再是可达性的唯一来源,但作为"运维关掉缓存也必须得到同样答案"的对照仍然有价值)。

```
pnpm --filter @objectstack/rest test  →  Test Files 63 passed (63) | Tests 864 passed (864)
pnpm lint                             →  通过(无输出)
npx eslint --no-inline-config packages/rest/src/rest-server.ts packages/rest/src/rest.test.ts  →  无输出
node scripts/check-nul-bytes.mjs      →  OK (5932 tracked text files)
node scripts/check-type-check-coverage.mjs → OK(`@objectstack/rest` 无 typecheck 脚本,属 DEBT 台账;计数未上涨)
```

消费半径扫过一遍:改的是 REST 路由 handler,除本包测试外唯一的真实 HTTP 消费者是 `packages/qa/dogfood/test/dashboard-designer-roundtrip.dogfood.test.ts`(Dogfood Regression Gate 会跑),已本地实跑 **3 passed** —— 信封形状不因换分支而变。

## 七、顺带发现(已立单,未在本 PR 修)

同一行的 `doc` / `book` 排除写的是**字面量**比较,而复数拼写可路由,于是 `GET /api/v1/meta/books/:name`(规范拼写)进入缓存分支、**ADR-0046 §6.7 audience 门禁一次都不跑**。同一个 book、同一个已登录且不持有该 permission set 的调用方:

```
singular "book" :: cachedCalls=0 status=[403] body={"code":"PERMISSION_DENIED", ...}
plural  "books":: cachedCalls=1 status=[]    body={"type":"book","name":"admin_guide","item":{...}}
```

这是与本单不同的类型、不同的门禁、不同的 ADR,按 Prime Directive #10 **立单不代修**:objectstack-ai/objectstack#6241(查重后立,未认领)。本 PR 只在注释里指了个路标。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wbxm29qPKnLf44AbSxizqW)_