### PR TITLE
feat(tooling): SKILL.md compatibility 声明与仓库实际大版本对账门禁

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -717,6 +717,27 @@ jobs:
       - name: Check the decision frame is in sync across its four copies
         run: pnpm check:skill-frame-sync
 
+      # The third gate over SKILL.md, covering the one line the other two cannot see
+      # (#5331). check:skill-docs / check:skill-refs compare generated artifacts and
+      # check:skill-examples typechecks `os:check` blocks; none of them reads the
+      # `compatibility:` frontmatter line. That blind spot is measured, not theoretical:
+      # nine of ten skills declared `@objectstack/spec 16.x` for an entire major cycle
+      # while teaching 17's capabilities, with all three gates green throughout (#5245).
+      # #5245 corrected the values by hand; this reconciles them against
+      # packages/spec/package.json on every run so they cannot drift again.
+      #
+      # Note the contract is the wording that actually LANDED for #5245 — an exact
+      # `<major>.x` pin. If the wording is ever changed to an unpinned range, this gate
+      # goes RED rather than quietly matching nothing (#4690): a gate that cannot find
+      # its input must fail, never skip.
+      #
+      # Same job and same reasons as its neighbours: no paths filter and required, so it
+      # cannot go dormant on exactly the PR that breaks it — and a `skills/**` filter in
+      # particular would blind it to the other half of its input, packages/*/package.json,
+      # where a major bump is what makes the declarations stale in the first place.
+      - name: Check SKILL.md compatibility declarations match the workspace majors
+        run: pnpm check:skill-compatibility
+
       - name: Check the react-blocks contract is in sync with the spec
         run: pnpm --filter @objectstack/spec check:react-blocks
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "check:role-word": "node scripts/check-role-word.mjs",
     "check:skill-frame-sync": "node scripts/check-skill-frame-sync.mjs --self-test && node scripts/check-skill-frame-sync.mjs",
     "check:skill-frame-freshness": "node scripts/check-skill-frame-freshness.mjs --self-test && node scripts/check-skill-frame-freshness.mjs",
+    "check:skill-compatibility": "node scripts/check-skill-compatibility-version.mjs --self-test && node scripts/check-skill-compatibility-version.mjs",
     "check:adr-anchors": "node scripts/check-adr-anchors.mjs",
     "check:org-identifier": "node scripts/check-org-identifier.mjs",
     "check:authz-resolver": "node scripts/check-single-authz-resolver.mjs --self-test && node scripts/check-single-authz-resolver.mjs",

--- a/scripts/check-skill-compatibility-version.mjs
+++ b/scripts/check-skill-compatibility-version.mjs
@@ -1,0 +1,694 @@
+#!/usr/bin/env node
+// check-skill-compatibility-version — reconciles the `compatibility:` line of every
+// published SKILL.md against the workspace's real package versions (#5331).
+//
+// WHY THIS EXISTS. `compatibility` is a skill's only self-declared applicability
+// range, and it ships to third parties verbatim via `npx skills add
+// objectstack-ai/objectstack/skills`. Nothing compared it to reality, so it drifted
+// a whole major: while the repo was on `@objectstack/spec@17.0.0-rc.2` — a major
+// whose headline is REMOVAL (seven `App` keys, 31 `DriverCapabilities` bits,
+// `restServer.openApi31`, the plugin-runtime family, all tombstones or TS2305) —
+// nine of ten SKILL.md files still declared `Requires @objectstack/spec 16.x`
+// (#5245). The skills taught 17 and called themselves 16, in both directions
+// wrongly: a 16.x reader copies declarations that 16 hard-rejects, and a 17.x
+// reader discounts the very text they should trust.
+//
+// The three existing skill gates were all green through that entire drift, by
+// construction: `check:skill-docs` / `check:skill-refs` compare only GENERATED
+// artifacts against packages/spec/src, and `check:skill-examples` only typechecks
+// fenced blocks tagged `os:check`. None of them reads this line. #5245 fixed the
+// values by hand; this gate fixes the MECHANISM that let them rot — that division
+// of labour is exactly why #5331 was split out of #5245 rather than folded into it.
+//
+// THE CONTRACT IT ENFORCES IS THE ONE THAT LANDED, NOT THE ONE #5245 IMAGINED.
+// #5245 offered three wordings and deliberately refused to choose: (①) rewrite to
+// `17.x`, (②) an unpinned range like `>= 17`, (③) this gate. What actually landed
+// on main is ① — an exact major pin, spelled `Requires @objectstack/spec 17.x
+// (Zod v4 schemas)`. So this gate reconciles an exact major. Had ② landed, an
+// exact-major gate would have been red on day one; if ② is ever adopted later,
+// this gate goes RED rather than quietly passing (see NO_PINS_AT_ALL below), which
+// forces the wording change to be a decision instead of an erosion.
+//
+// #4690 IS THE NAMED COUNTER-EXAMPLE: a gate that cannot find its input and exits 0
+// is worse than no gate, because it converts "nobody is looking" into "something is
+// looking and it is fine". Every absence here is therefore RED, never a skip:
+//   • skills/ missing, or holding no skill directory                → red
+//   • a skill directory with no SKILL.md                            → red
+//   • a SKILL.md with no frontmatter, or no `compatibility:` key    → red
+//   • a non-exempt file declaring no pinned major                   → red
+//   • ZERO pinned majors found across the whole repo                → red
+//   • an exemption whose written justification no longer holds      → red
+// The last two are the ones that matter most: they are what stop this gate from
+// decaying into a no-op the day someone reflows the wording.
+//
+// EXEMPTIONS ARE NAMED, JUSTIFIED, AND SELF-INVALIDATING. Two SKILL.md files
+// deliberately pin no major, for two different and legitimate reasons, and both are
+// written down in EXEMPT below with a `rationale` regex that must still match the
+// live text. If the justification is edited away, the exemption dies with it and
+// the file falls back to the normal rule. An exemption never covers a pinned claim:
+// exempt files' pins, if they ever grow any, are reconciled like everyone else's.
+// This is the difference between "we thought about this file" and a silent hole.
+//
+// LAYERING — why a root script and not `pnpm --filter @objectstack/spec`: same
+// reason as its neighbour check:skill-frame-sync. The spec package's skill gates are
+// GENERATORS whose source is packages/spec/src and whose output is in its
+// check:generated ledger. This gate generates nothing and reads no spec source; it
+// compares hand-written frontmatter against every workspace package.json, which is
+// repo-wide knowledge the spec package has no business holding. Repo-wide policy
+// gates over prose live in root scripts/ (check:role-word, check:doc-authoring,
+// check:nul-bytes all scan skills/ from here).
+//
+//   node scripts/check-skill-compatibility-version.mjs [--self-test]
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SKILLS_DIR = 'skills';
+
+// Roots holding workspace package.json files. The declared package name (not the
+// directory name) is what a `compatibility:` line cites, so the map is keyed by
+// name — `@objectstack/spec` happens to live in packages/spec, but nothing
+// guarantees that for the next package someone cites.
+const PACKAGE_ROOTS = ['packages', 'apps', 'examples'];
+
+/**
+ * A `compatibility:` pin, e.g. `@objectstack/spec 17.x`.
+ *
+ * Deliberately narrow: the major, a literal `.x`. It does NOT match a bare mention
+ * (`@objectstack/cli` in prose) or a prose protocol number ("protocol 10 at the time
+ * of writing"), both of which appear in the exempt files and neither of which is a
+ * version claim about this workspace.
+ */
+const PIN_RE = /@objectstack\/([a-z0-9][a-z0-9-]*)\s+(\d+)\.x/g;
+
+/** Any mention of a workspace-scoped package, pinned or not. */
+const MENTION_RE = /@objectstack\/([a-z0-9][a-z0-9-]*)/g;
+
+/**
+ * Files allowed to declare no pinned major.
+ *
+ * `rationale` is not decoration — it is re-matched against the live `compatibility:`
+ * text on every run. An exemption whose stated reason has been edited away stops
+ * applying, so this list cannot quietly outlive the thing it describes.
+ */
+const EXEMPT = [
+  {
+    file: 'skills/objectstack-pm-dispatch/SKILL.md',
+    // A process skill: it drives a GitHub backlog and imports nothing from the
+    // workspace, so there is no major to be compatible WITH. Its compatibility text
+    // says so in as many words, and that self-declaration is the exemption's warrant.
+    why: 'process skill with no @objectstack/spec dependency — it declares so explicitly',
+    rationale: /No\s+@objectstack\/spec\s+dependency/i,
+  },
+  {
+    file: 'skills/objectstack-upgrade/SKILL.md',
+    // The cross-major upgrade skill. Pinning it to the current major would be
+    // actively wrong: its whole job is to carry a project ACROSS majors, so it is
+    // correct at whatever the target major happens to be. Its text says "at the
+    // TARGET major" for exactly this reason.
+    why: 'cross-major upgrade skill — correct at the TARGET major, so a current-major pin would be wrong',
+    rationale: /at\s+the\s+TARGET\s+major/i,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Frontmatter parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the `compatibility:` value from YAML frontmatter, supporting both spellings
+ * in the tree: an inline scalar (`compatibility: Requires ... 17.x`) and a folded
+ * block (`compatibility: >` followed by indented continuation lines).
+ *
+ * Returns `{ ok: true, value }`, or `{ ok: false, reason }` — never a silent empty
+ * string, so a parse miss is reportable as a parse miss rather than masquerading as
+ * "declared nothing".
+ */
+export function extractCompatibility(text) {
+  const lines = text.split('\n');
+  if (lines[0]?.trim() !== '---') {
+    return { ok: false, reason: 'no YAML frontmatter (file does not start with `---`)' };
+  }
+  const end = lines.findIndex((l, i) => i > 0 && l.trim() === '---');
+  if (end === -1) {
+    return { ok: false, reason: 'frontmatter is not terminated by a closing `---`' };
+  }
+
+  const body = lines.slice(1, end);
+  const keyIdx = body.findIndex((l) => /^compatibility:/.test(l));
+  if (keyIdx === -1) {
+    return { ok: false, reason: 'frontmatter has no `compatibility:` key' };
+  }
+
+  const inline = body[keyIdx].slice('compatibility:'.length).trim();
+  // Folded (`>`) or literal (`|`) block scalars, with any chomping indicator.
+  if (/^[>|][+-]?$/.test(inline)) {
+    const collected = [];
+    for (let i = keyIdx + 1; i < body.length; i += 1) {
+      const line = body[i];
+      if (line.trim() === '') { collected.push(''); continue; }
+      if (!/^\s/.test(line)) break; // dedented to column 0 → next key
+      collected.push(line.trim());
+    }
+    const value = collected.join(' ').trim();
+    if (value === '') {
+      return { ok: false, reason: '`compatibility:` opens a block scalar but the block is empty' };
+    }
+    return { ok: true, value };
+  }
+
+  if (inline === '') {
+    return { ok: false, reason: '`compatibility:` is present but empty' };
+  }
+  return { ok: true, value: inline };
+}
+
+// ---------------------------------------------------------------------------
+// Checks (pure — the self-test drives these with in-memory inputs)
+// ---------------------------------------------------------------------------
+
+function majorOf(version) {
+  const m = /^(\d+)\./.exec(String(version));
+  return m ? Number(m[1]) : null;
+}
+
+/**
+ * @param files   [{ file, text }]           — every discovered SKILL.md
+ * @param pkgs    Map<name, {version, file}> — workspace packages by declared name
+ * @param exempt  same shape as EXEMPT
+ */
+export function runAllChecks(files, pkgs, exempt = EXEMPT) {
+  const problems = [];
+  const results = [];
+  let pinCount = 0;
+
+  // ---- input assertions (#4690): an empty scan is a failure, not a pass. -----
+  if (files.length === 0) {
+    problems.push(
+      `no SKILL.md files found under ${SKILLS_DIR}/.\n` +
+      `    This gate reconciles skill version declarations; with no input it would ` +
+      `otherwise exit 0 and\n    report success while checking nothing (#4690).\n` +
+      `    fix: run from the repo root, or fix the ${SKILLS_DIR}/ layout.`,
+    );
+    return { problems, results, pinCount };
+  }
+  if (pkgs.size === 0) {
+    problems.push(
+      `no workspace package.json files found under ${PACKAGE_ROOTS.join('/, ')}/.\n` +
+      `    Without them there is nothing to reconcile against (#4690).`,
+    );
+    return { problems, results, pinCount };
+  }
+
+  const exemptByFile = new Map(exempt.map((e) => [e.file, e]));
+
+  // ---- stale-exemption sweep: an exemption for a file that is not scanned is ----
+  // dormant config that will silently outlive its subject.
+  const scanned = new Set(files.map((f) => f.file));
+  for (const e of exempt) {
+    if (!scanned.has(e.file)) {
+      problems.push(
+        `stale exemption: ${e.file} is on the exemption list but was not found.\n` +
+        `    reason on file: ${e.why}\n` +
+        `    fix: delete the entry from EXEMPT in scripts/check-skill-compatibility-version.mjs, ` +
+        `or restore the file.`,
+      );
+    }
+  }
+
+  for (const { file, text } of files) {
+    const got = extractCompatibility(text);
+    if (!got.ok) {
+      problems.push(
+        `${file}\n` +
+        `    cannot read a compatibility declaration: ${got.reason}\n` +
+        `    Every published skill must declare the majors it applies to — that line is ` +
+        `a skill's only\n    self-described applicability range (#5245).\n` +
+        `    fix: add a frontmatter line such as ` +
+        '`compatibility: Requires @objectstack/spec <major>.x (Zod v4 schemas)`.',
+      );
+      continue;
+    }
+
+    const value = got.value;
+    const pins = [...value.matchAll(PIN_RE)].map((m) => ({ pkg: `@objectstack/${m[1]}`, major: Number(m[2]) }));
+    const mentions = [...value.matchAll(MENTION_RE)].map((m) => `@objectstack/${m[1]}`);
+    const exemption = exemptByFile.get(file);
+    pinCount += pins.length;
+
+    // ---- pins are ALWAYS reconciled, exempt or not. An exemption covers the
+    // absence of a pin, never the correctness of one that exists.
+    for (const pin of pins) {
+      const actual = pkgs.get(pin.pkg);
+      if (!actual) {
+        problems.push(
+          `${file}\n` +
+          `    declares ${pin.pkg} ${pin.major}.x, but no workspace package is named ${pin.pkg}\n` +
+          `    fix: correct the package name, or drop the claim if the package no longer exists.`,
+        );
+        continue;
+      }
+      const actualMajor = majorOf(actual.version);
+      if (actualMajor === null) {
+        problems.push(
+          `${file}\n` +
+          `    declares ${pin.pkg} ${pin.major}.x, but ${actual.file} has an unparseable ` +
+          `version "${actual.version}"`,
+        );
+        continue;
+      }
+      if (actualMajor !== pin.major) {
+        problems.push(
+          `${file}\n` +
+          `    declared: ${pin.pkg} ${pin.major}.x   (frontmatter \`compatibility:\`)\n` +
+          `    actual:   ${pin.pkg} ${actual.version}  → major ${actualMajor}   (${actual.file})\n` +
+          `    fix: edit the \`compatibility:\` line to read "${pin.pkg} ${actualMajor}.x".\n` +
+          `    This is the drift #5245 found by hand: skills taught ${actualMajor} while ` +
+          `declaring ${pin.major}.`,
+        );
+      }
+    }
+
+    if (exemption) {
+      // The exemption must still be true of the live text, or it stops applying.
+      if (!exemption.rationale.test(value)) {
+        problems.push(
+          `${file}\n` +
+          `    is exempt from the "must pin a major" rule because: ${exemption.why}\n` +
+          `    but its compatibility text no longer matches that justification ` +
+          `(/${exemption.rationale.source}/).\n` +
+          `    declared: ${value}\n` +
+          `    fix: restore the justification in the text, or remove the file's entry from ` +
+          `EXEMPT and\n         declare a real major pin.`,
+        );
+      }
+      if (pins.length > 0) {
+        problems.push(
+          `${file}\n` +
+          `    is on the EXEMPT list (no-pin allowed) yet now declares a pinned major ` +
+          `(${pins.map((p) => `${p.pkg} ${p.major}.x`).join(', ')}).\n` +
+          `    The exemption is doing no work and would hide the next unpinned mention.\n` +
+          `    fix: delete this file's entry from EXEMPT in ` +
+          `scripts/check-skill-compatibility-version.mjs.`,
+        );
+      }
+      results.push({ file, value, pins, exempt: true });
+      continue;
+    }
+
+    if (pins.length === 0) {
+      problems.push(
+        `${file}\n` +
+        `    declares no pinned major. declared: ${value}\n` +
+        `    Expected a pin of the form "@objectstack/<pkg> <major>.x" — the wording that ` +
+        `landed for #5245.\n` +
+        `    fix: write e.g. "Requires @objectstack/spec ` +
+        `${majorOf(pkgs.get('@objectstack/spec')?.version) ?? '<major>'}.x (Zod v4 schemas)", ` +
+        `or add a\n         justified entry to EXEMPT if this skill genuinely has no ` +
+        `version dependency.`,
+      );
+      results.push({ file, value, pins, exempt: false });
+      continue;
+    }
+
+    // A half-pinned line is the quiet hole: one pin satisfies "has a pin" while a
+    // second package rides along unchecked.
+    const unpinned = mentions.filter((name) => !pins.some((p) => p.pkg === name));
+    for (const name of [...new Set(unpinned)]) {
+      problems.push(
+        `${file}\n` +
+        `    mentions ${name} without a "<major>.x" pin. declared: ${value}\n` +
+        `    An unpinned mention is unreconcilable, so it would drift silently beside its ` +
+        `pinned neighbours.\n` +
+        `    fix: write "${name} ${majorOf(pkgs.get(name)?.version) ?? '<major>'}.x", or drop ` +
+        `the mention.`,
+      );
+    }
+
+    results.push({ file, value, pins, exempt: false });
+  }
+
+  // ---- the anti-no-op assertion. If the wording is ever changed wholesale (e.g.
+  // to #5245's option ②, an unpinned range like ">= 17"), every file stops matching
+  // PIN_RE and this gate would have nothing to compare — the exact shape of a gate
+  // rotting into a green no-op. Fail loudly and make it a decision.
+  if (pinCount === 0 && problems.length === 0) {
+    problems.push(
+      `not one "@objectstack/<pkg> <major>.x" pin was found in any of ${files.length} ` +
+      `SKILL.md file(s).\n` +
+      `    This gate compares pinned majors; with zero pins it is a no-op reporting ` +
+      `success (#4690).\n` +
+      `    If the compatibility wording was deliberately changed to an unpinned range ` +
+      `(#5245 option ②),\n    then this gate's contract changed with it — update PIN_RE ` +
+      `and this assertion together,\n    rather than leaving a green gate that checks nothing.`,
+    );
+  }
+
+  return { problems, results, pinCount };
+}
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+export function readSkillFiles(root = REPO_ROOT) {
+  const dir = join(root, SKILLS_DIR);
+  if (!existsSync(dir)) return { files: [], problems: [`${SKILLS_DIR}/ does not exist`] };
+
+  const problems = [];
+  const files = [];
+  const entries = readdirSync(dir).filter((n) => statSync(join(dir, n)).isDirectory()).sort();
+  for (const name of entries) {
+    const rel = `${SKILLS_DIR}/${name}/SKILL.md`;
+    const abs = join(root, rel);
+    if (!existsSync(abs)) {
+      // A skill directory without a SKILL.md is either a broken skill or a layout
+      // change this gate must not scan past in silence.
+      problems.push(
+        `${SKILLS_DIR}/${name}/ has no SKILL.md.\n` +
+        `    fix: add one, or remove the directory.`,
+      );
+      continue;
+    }
+    files.push({ file: rel, text: readFileSync(abs, 'utf8') });
+  }
+  return { files, problems };
+}
+
+function readWorkspacePackages(root = REPO_ROOT) {
+  const pkgs = new Map();
+  const walk = (abs, depth) => {
+    if (depth > 3) return;
+    let entries;
+    try { entries = readdirSync(abs, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      if (e.name === 'node_modules' || e.name === 'dist' || e.name.startsWith('.')) continue;
+      const child = join(abs, e.name);
+      if (e.isDirectory()) {
+        const manifest = join(child, 'package.json');
+        if (existsSync(manifest)) {
+          try {
+            const json = JSON.parse(readFileSync(manifest, 'utf8'));
+            if (json.name && json.version && !pkgs.has(json.name)) {
+              pkgs.set(json.name, { version: json.version, file: relative(root, manifest) });
+            }
+          } catch { /* an unparseable manifest is another gate's problem */ }
+        }
+        walk(child, depth + 1);
+      }
+    }
+  };
+  for (const r of PACKAGE_ROOTS) {
+    const abs = join(root, r);
+    if (existsSync(abs)) walk(abs, 1);
+  }
+  return pkgs;
+}
+
+function report(problems) {
+  console.error(
+    `\n✗ check-skill-compatibility-version: ${problems.length} problem(s).\n\n` +
+    problems.map((p) => `  • ${p}`).join('\n\n') +
+    `\n\n  The \`compatibility:\` line is a skill's only self-declared applicability range, ` +
+    `and it ships\n  verbatim to third parties via \`npx skills add ` +
+    `objectstack-ai/objectstack/skills\`. See #5331 / #5245.\n`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Self-test — pins the RED paths so the gate cannot rot into a no-op.
+// ---------------------------------------------------------------------------
+
+function selfTest() {
+  console.log('check-skill-compatibility-version self-test\n');
+
+  const PKGS = new Map([
+    ['@objectstack/spec', { version: '17.0.0-rc.5', file: 'packages/spec/package.json' }],
+    ['@objectstack/core', { version: '17.0.0-rc.5', file: 'packages/core/package.json' }],
+    ['@objectstack/formula', { version: '17.0.0-rc.5', file: 'packages/formula/package.json' }],
+  ]);
+
+  const fm = (compat) => `---\nname: x\nlicense: Apache-2.0\n${compat}\nmetadata:\n  author: objectstack-ai\n---\n\n# body\n`;
+  const ok = (n = 'skills/objectstack-ai/SKILL.md') => ({
+    file: n, text: fm('compatibility: Requires @objectstack/spec 17.x (Zod v4 schemas)'),
+  });
+  const exemptDispatch = {
+    file: 'skills/objectstack-pm-dispatch/SKILL.md',
+    text: fm('compatibility: >\n  No @objectstack/spec dependency — process skill. Needs a GitHub repository\n  with issues enabled.'),
+  };
+  const exemptUpgrade = {
+    file: 'skills/objectstack-upgrade/SKILL.md',
+    text: fm('compatibility: >\n  Needs `@objectstack/spec` and `@objectstack/cli` at the TARGET major\n  (protocol 10 at the time of writing).'),
+  };
+
+  const cases = [
+    {
+      label: 'the landed wording (exact 17.x pin) → GREEN',
+      files: [ok(), exemptDispatch, exemptUpgrade],
+      expect: 'green',
+    },
+    {
+      label: 'R1 — a stale major (17.x → 16.x, the #5245 drift) → RED naming file/declared/actual/fix',
+      files: [{ file: 'skills/objectstack-ai/SKILL.md', text: fm('compatibility: Requires @objectstack/spec 16.x (Zod v4 schemas)') }, exemptDispatch, exemptUpgrade],
+      expect: 'red',
+      wants: [
+        /skills\/objectstack-ai\/SKILL\.md/,
+        /declared: @objectstack\/spec 16\.x/,
+        /actual:\s+@objectstack\/spec 17\.0\.0-rc\.5/,
+        /fix: edit the `compatibility:` line to read "@objectstack\/spec 17\.x"/,
+      ],
+    },
+    {
+      label: 'R3 — no `compatibility:` key at all → RED (absence is never a skip, #4690)',
+      files: [{ file: 'skills/objectstack-ai/SKILL.md', text: '---\nname: x\n---\n\n# body\n' }, exemptDispatch, exemptUpgrade],
+      expect: 'red',
+      wants: [/no `compatibility:` key/],
+    },
+    {
+      label: 'an empty `compatibility:` value → RED',
+      files: [{ file: 'skills/objectstack-ai/SKILL.md', text: fm('compatibility:') }, exemptDispatch, exemptUpgrade],
+      expect: 'red',
+      wants: [/present but empty/],
+    },
+    {
+      label: 'no frontmatter at all → RED',
+      files: [{ file: 'skills/objectstack-ai/SKILL.md', text: '# just a heading\n' }, exemptDispatch, exemptUpgrade],
+      expect: 'red',
+      wants: [/no YAML frontmatter/],
+    },
+    {
+      label: 'R4 — wording switched to an unpinned range (#5245 option ②) → RED, not a silent no-op',
+      files: [
+        { file: 'skills/objectstack-ai/SKILL.md', text: fm('compatibility: Requires @objectstack/spec >= 17') },
+        exemptDispatch, exemptUpgrade,
+      ],
+      expect: 'red',
+      // The per-file "no pinned major" fires first; both are the same refusal to
+      // pass on zero comparable input.
+      wants: [/declares no pinned major/],
+    },
+    {
+      label: 'R4b — zero pins repo-wide with every file exempt → RED via the anti-no-op assertion',
+      files: [exemptDispatch, exemptUpgrade],
+      expect: 'red',
+      wants: [/not one "@objectstack\/<pkg> <major>\.x" pin was found/],
+    },
+    {
+      label: 'R5 — an exemption naming a file that is not scanned → RED (anti-dormancy)',
+      files: [ok(), exemptDispatch],
+      expect: 'red',
+      wants: [/stale exemption: skills\/objectstack-upgrade\/SKILL\.md/],
+    },
+    {
+      label: 'R7 — an exempt file whose written justification is gone → RED (exemption self-invalidates)',
+      files: [
+        ok(),
+        { file: 'skills/objectstack-pm-dispatch/SKILL.md', text: fm('compatibility: >\n  Needs a GitHub repository with issues enabled.') },
+        exemptUpgrade,
+      ],
+      expect: 'red',
+      wants: [/no longer matches that justification/],
+    },
+    {
+      label: 'an exempt file that grows a pin → RED (the exemption is now dead config)',
+      files: [
+        ok(),
+        { file: 'skills/objectstack-pm-dispatch/SKILL.md', text: fm('compatibility: >\n  No @objectstack/spec dependency — process skill, but @objectstack/core 17.x.') },
+        exemptUpgrade,
+      ],
+      expect: 'red',
+      wants: [/is on the EXEMPT list \(no-pin allowed\) yet now declares a pinned major/],
+    },
+    {
+      label: 'an exempt file whose pin is ALSO wrong → RED on the pin (exemptions never cover a claim)',
+      files: [
+        ok(),
+        { file: 'skills/objectstack-pm-dispatch/SKILL.md', text: fm('compatibility: >\n  No @objectstack/spec dependency — process skill, but @objectstack/core 16.x.') },
+        exemptUpgrade,
+      ],
+      expect: 'red',
+      wants: [/declared: @objectstack\/core 16\.x/],
+    },
+    {
+      label: 'R8 — a half-pinned line (one pinned, one bare mention) → RED on the bare one',
+      files: [
+        { file: 'skills/objectstack-ai/SKILL.md', text: fm('compatibility: Requires @objectstack/spec 17.x and @objectstack/core') },
+        exemptDispatch, exemptUpgrade,
+      ],
+      expect: 'red',
+      wants: [/mentions @objectstack\/core without a "<major>\.x" pin/],
+    },
+    {
+      label: 'a pin naming a package the workspace does not have → RED',
+      files: [
+        { file: 'skills/objectstack-ai/SKILL.md', text: fm('compatibility: Requires @objectstack/nonesuch 17.x') },
+        exemptDispatch, exemptUpgrade,
+      ],
+      expect: 'red',
+      wants: [/no workspace package is named @objectstack\/nonesuch/],
+    },
+    {
+      label: 'R6 — an empty scan → RED, never a green skip (#4690, the whole point)',
+      files: [],
+      expect: 'red',
+      wants: [/no SKILL\.md files found/],
+    },
+    {
+      label: 'no workspace packages discovered → RED',
+      files: [ok(), exemptDispatch, exemptUpgrade],
+      pkgs: new Map(),
+      expect: 'red',
+      wants: [/no workspace package\.json files found/],
+    },
+    {
+      label: 'multi-package line, both pinned correctly → GREEN',
+      files: [
+        { file: 'skills/objectstack-ai/SKILL.md', text: fm('compatibility: Requires @objectstack/spec 17.x and @objectstack/core 17.x (Zod v4 schemas), Node 22+') },
+        exemptDispatch, exemptUpgrade,
+      ],
+      expect: 'green',
+    },
+    {
+      // The anti-false-positive direction: prose around the pin is free to change.
+      label: 'wording reflowed around a correct pin → stays GREEN',
+      files: [
+        { file: 'skills/objectstack-ai/SKILL.md', text: fm('compatibility: Works with @objectstack/spec 17.x — Zod v4 schemas throughout') },
+        exemptDispatch, exemptUpgrade,
+      ],
+      expect: 'green',
+    },
+    {
+      label: 'a prerelease major still reconciles by major (17.0.0-rc.5 ↔ 17.x) → GREEN',
+      files: [ok(), exemptDispatch, exemptUpgrade],
+      expect: 'green',
+    },
+  ];
+
+  let failed = 0;
+  for (const c of cases) {
+    let problems;
+    try {
+      ({ problems } = runAllChecks(c.files, c.pkgs ?? PKGS, EXEMPT));
+    } catch (err) {
+      console.error(`  ✗ ${c.label}\n      threw: ${err.message}`);
+      failed += 1;
+      continue;
+    }
+    const isRed = problems.length > 0;
+    if (isRed !== (c.expect === 'red')) {
+      failed += 1;
+      console.error(
+        `  ✗ ${c.label}\n      expected ${c.expect}, got ${isRed ? 'red' : 'green'}` +
+        (isRed ? `\n      ${problems.join('\n      ')}` : ''),
+      );
+      continue;
+    }
+    const blob = problems.join('\n');
+    const missing = (c.wants ?? []).filter((rx) => !rx.test(blob));
+    if (missing.length > 0) {
+      failed += 1;
+      console.error(
+        `  ✗ ${c.label}\n      red as expected, but the message does not name ` +
+        `${missing.map((m) => `/${m.source}/`).join(', ')}\n      ${blob}`,
+      );
+      continue;
+    }
+    console.log(`  ✓ ${c.label}`);
+  }
+
+  // Discovery-level assertions. These cannot be driven through runAllChecks (they
+  // are about the filesystem walk itself), so they get a fixture tree and the real
+  // tree, in that order.
+  const fixture = mkdtempSync(join(tmpdir(), 'skill-compat-'));
+  try {
+    mkdirSync(join(fixture, SKILLS_DIR, 'has-one'), { recursive: true });
+    mkdirSync(join(fixture, SKILLS_DIR, 'missing-its-skill-md'), { recursive: true });
+    writeFileSync(join(fixture, SKILLS_DIR, 'has-one', 'SKILL.md'), ok().text);
+    const d = readSkillFiles(fixture);
+    if (d.files.length !== 1 || !d.problems.some((p) => /missing-its-skill-md\/ has no SKILL\.md/.test(p))) {
+      failed += 1;
+      console.error(
+        '  ✗ a skill directory with no SKILL.md → RED\n' +
+        `      got ${d.files.length} file(s), problems: ${JSON.stringify(d.problems)}`,
+      );
+    } else {
+      console.log('  ✓ a skill directory with no SKILL.md → RED (discovery walk)');
+    }
+
+    const empty = readSkillFiles(mkdtempSync(join(tmpdir(), 'skill-compat-empty-')));
+    if (empty.files.length !== 0) {
+      failed += 1;
+      console.error('  ✗ a tree with no skills/ should yield no files');
+    } else {
+      console.log('  ✓ a tree with no skills/ yields an empty scan, which runAllChecks turns RED');
+    }
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+
+  const disc = readSkillFiles();
+  if (disc.files.length === 0) {
+    failed += 1;
+    console.error('  ✗ real-tree discovery found no SKILL.md — the gate would be scanning nothing');
+  } else {
+    console.log(`  ✓ real-tree discovery: ${disc.files.length} SKILL.md file(s), ${disc.problems.length} layout problem(s)`);
+  }
+
+  if (failed > 0) {
+    console.error(`\n✗ check-skill-compatibility-version self-test failed (${failed} case(s)).`);
+    process.exit(1);
+  }
+  console.log(`\n✓ check-skill-compatibility-version self-test: ${cases.length} cases pass.`);
+}
+
+// ---------------------------------------------------------------------------
+
+function main() {
+  if (process.argv.includes('--self-test')) return selfTest();
+
+  const { files, problems: layout } = readSkillFiles();
+  const pkgs = readWorkspacePackages();
+  const { problems, results, pinCount } = runAllChecks(files, pkgs, EXEMPT);
+
+  const all = [...layout, ...problems];
+  if (all.length > 0) {
+    report(all);
+    process.exit(1);
+  }
+
+  const exemptCount = results.filter((r) => r.exempt).length;
+  const specMajor = majorOf(pkgs.get('@objectstack/spec')?.version);
+  console.log(
+    `✓ check-skill-compatibility-version: ${results.length} SKILL.md file(s) reconciled against ` +
+    `${pkgs.size} workspace packages\n` +
+    `  ${pinCount} pinned major(s) all match the workspace (@objectstack/spec is ${specMajor}.x)\n` +
+    `  ${exemptCount} justified exemption(s), each with its stated reason still true of the file.`,
+  );
+}
+
+if (resolve(process.argv[1] ?? '') === resolve(fileURLToPath(import.meta.url))) {
+  main();
+}


### PR DESCRIPTION
Fixes #5331

## 背景

`skills/*/SKILL.md` frontmatter 的 `compatibility:` 行是一份 skill **唯一的自述适用范围**,并且随 `npx skills add objectstack-ai/objectstack/skills` 原样发给第三方。此前没有任何门看守它:

- `check:skill-docs` / `check:skill-refs` 只比对**生成物**与 `packages/spec/src`;
- `check:skill-examples` 只 typecheck 打了 `os:check` 的代码块。

三道门对着一句错的版本声明**全绿**。实证即 #5245:仓库已在 `17.0.0-rc.2`(七个 `App` 键、`DriverCapabilities` 31 位、`restServer.openApi31`、plugin-runtime 家族在 17 里已是墓碑或 TS2305),而十份 SKILL.md 里九份仍写 `Requires @objectstack/spec 16.x` —— **教 17 的能力、自称 16 兼容**,静默漂移了整个大版本周期。

#5245 手工改正了值;本单修的是**产生漂移的机制**。这正是 #5331 从 #5245 拆出时的分工。

## 先核实了「实际落地的措辞」,而不是照原单想象

#5245 给了三个写法并明确拒绝替维护者选:①改写成 `17.x`、②不钉小版本的范围写法(如 `>= 17`)、③加门禁(本单)。**本单的门禁契约必须对齐实际落地的那一个** —— 若落地的是②,一个要求精确大版本的门禁上线即红。

核实结果(`origin/main` @ `01faeb13a`):**落地的是方案①,精确大版本钉**,拼写为 `Requires @objectstack/spec 17.x (Zod v4 schemas)`。9 份带钉(7 份单钉 + `objectstack-formula` / `objectstack-platform` 各带一个附加包),2 份折叠块不钉。`packages/spec/package.json` = `17.0.0-rc.5`。所以门禁对账的是**精确大版本**。

> 原单只提到 `objectstack-pm-dispatch` 一份折叠块;实际是**两份**(另一份是 `objectstack-upgrade`),见下。

## 做了什么

新增 `scripts/check-skill-compatibility-version.mjs`,把每份 SKILL.md 声明的 `@objectstack/…` 大版本与工作区实际 `package.json` 对账,不一致即红,报错带「哪份文件 / 声明值 / 实际值 / 怎么改」:

```
skills/objectstack-ai/SKILL.md
    declared: @objectstack/spec 16.x   (frontmatter `compatibility:`)
    actual:   @objectstack/spec 17.0.0-rc.5  → major 17   (packages/spec/package.json)
    fix: edit the `compatibility:` line to read "@objectstack/spec 17.x".
    This is the drift #5245 found by hand: skills taught 17 while declaring 16.
```

按包**名**(而非目录名)建映射,因此 `@objectstack/core` / `@objectstack/formula` 这类附加钉同样对账;钉了一个不存在的包名也报红。

### 落点

根 `scripts/`,与邻居 `check:skill-frame-sync` 同一层 —— 理由也相同:spec 包里的那几道 skill 门是**生成器**,源是 `packages/spec/src`、产物在其 `check:generated` 账本里;本门禁不生成任何产物、不读 spec 源码,它比对的是手写 frontmatter 与**全工作区** package.json,那是 spec 包没有理由持有的知识。跨仓 prose 策略门一贯落在根 `scripts/`(`check:role-word`、`check:doc-authoring`、`check:nul-bytes` 都从这里扫 `skills/`)。已用 `check:generated --reconcile-only` 确认根脚本不需进 spec 包账本。

接进 `.github/workflows/lint.yml` 的 `TypeScript Type Check` job,紧挨 `check:skill-frame-sync`。**不加 paths filter**:加了 `skills/**` 过滤反而会瞎掉另一半输入 —— `packages/*/package.json` 的大版本 bump 才是让声明变陈旧的那一下。

### 引 #4690 为戒:一切缺输入都是红,不做静默 skip 退出 0

- `skills/` 不存在、或没有任何 skill 目录 → 红
- skill 目录里没有 SKILL.md → 红
- 没有 frontmatter、`compatibility:` 键缺失或为空 → 红
- 非豁免文件声明不出任何钉 → 红
- **全仓一个钉都没扫到** → 红(这条最关键:若日后措辞整体改成方案②的范围写法,本门禁会**响亮报红**,逼出一次决策,而不是悄悄匹配为空、退化成绿色 no-op)
- 半钉的行(一个包钉了、另一个只是裸提及)→ 红,堵住「有一个钉就算过」的洞

### 两份折叠块:豁免,理由写进代码,且每次运行重新校验

| 文件 | 理由 | 校验锚 |
|---|---|---|
| `objectstack-pm-dispatch` | 流程 skill,不 import 工作区任何东西,没有「与之兼容」的大版本;正文自述「No @objectstack/spec dependency」 | 该自述句仍在 |
| `objectstack-upgrade` | 跨大版本升级 skill,正确于 **TARGET major**;钉当前大版本反而是错的 | 正文「at the TARGET major」仍在 |

豁免不是空白支票:

- 理由文本被改掉 → 豁免**自失效**,文件退回普通规则(红);
- 豁免只覆盖「**可以不钉**」,**不覆盖已有的钉** —— 豁免文件若长出钉,照样对账,错了照样红;
- 豁免文件真长出钉之后,该豁免已无事可做 → 报红要求删条目(反休眠);
- 豁免指向一份扫不到的文件 → 报红(陈旧条目)。

## 反向验证(预测**先写后跑**)

预测写在 `predictions.md` 后才动手,逐条对照:

| # | 变异 | 预测 | 实测 | |
|---|---|---|---|---|
| R1 | `objectstack-ai` 的 `17.x` → `16.x` | 红,报错含 文件/声明值/实际值/修法 | 红,四要素齐全(见上方报错原文) | ✅ |
| R2 | 保留 R1 变异,**摘掉对账那一步**(只留解析+存在性断言,即今天的现状) | 绿,变异完全无人察觉 | 绿,`EXIT=0` | ✅ |
| R3 | 整行删掉 `compatibility:` | 红(声明缺失),不是「无声即通过」 | 红,`frontmatter has no compatibility: key` | ✅ |
| R4 | 全部改写成方案②范围写法(零钉) | 红,而不是静默 no-op | 红,9 处 `declares no pinned major` | ✅ |
| R5 | 豁免条目指向不存在的文件 | 红(陈旧豁免) | 红,self-test 覆盖 | ✅ |
| R6 | 两份折叠块,未变异 | 绿(经校验的豁免) | 绿 | ✅ |
| R7 | 抹掉豁免文件里的理由句 | 红(豁免自失效) | 红,`no longer matches that justification` | ✅ |
| R8 | 半钉的行 | 红(裸提及那个) | 红 | ✅ |

**无落空预测**。R2 值得单独说:摘掉对账后,门禁不但放行了 `16.x`,汇总行还照旧印出 `11 pinned major(s) all match the workspace` —— 一句字面为假的成功报告。这正是 #4690 那个失败模式的样子,也是为什么 R2 这一格必须是绿:它证明**对账那一步**才是承重的,解析和存在性断言都不是。

## 自测 / 门禁不会腐化成 no-op

`--self-test` 18 例,红路径逐条钉死(含上表 R1/R3/R4/R5/R7/R8,及「钉了不存在的包」「空扫描」「无工作区包」),外加两条走真实文件系统的发现层断言(临时 fixture 树里「skill 目录缺 SKILL.md → 红」、真实树扫描非空)。按仓库惯例注册为 `check:skill-compatibility`,先跑 self-test 再跑真扫。

## 验证

```
$ pnpm check:skill-compatibility
✓ check-skill-compatibility-version self-test: 18 cases pass.
✓ check-skill-compatibility-version: 11 SKILL.md file(s) reconciled against 77 workspace packages
  11 pinned major(s) all match the workspace (@objectstack/spec is 17.x)
  2 justified exemption(s), each with its stated reason still true of the file.

$ pnpm lint                          # 全仓 ESLint,EXIT=0
$ pnpm check:nul-bytes               # 5949 文件,无裸控制字节
$ pnpm check:doc-authoring           # 365 文件 clean
$ pnpm check:published-files         # 69 publishable package 全绿
$ pnpm check:workflow-status-functions   # 22 workflow / 41 job 全绿
$ pnpm --filter @objectstack/spec check:generated --reconcile-only   # 根脚本不需进 spec 账本
```

**门禁在当前 `origin/main` 上是绿的** —— 不是靠放宽换来的:上表 R1–R8 证明它在该红的地方都红。

## Changeset

**`skip-changeset`** —— 本 PR 不发布任何东西:

- 根 `package.json` 是 `private: true`(`@objectstack/spec-monorepo`),只加了一行 script 注册;
- `scripts/` 不在任何已发布包的 `files` 白名单里(`check:published-files` 枚举了 69 个包的白名单);
- `.github/workflows/` 是 CI 配置。

没有落在 `packages/lint` 之类已发布包里,所以按三选一规则取 `skip-changeset`,不写 changeset(空 frontmatter changeset 是被 #6059/#5471 的门禁禁止的)。

## 边界

零运行时、零词表、零 spec 改动。未碰 `packages/spec/src/**/*.zod.ts`、严格度账本、`content/docs/releases/`。

---
_Generated by [Claude Code](https://claude.ai/code/session_014wsZeReNTqiceBfLb5Pyf5)_