### PR TITLE
fix(metadata-protocol): boot 重水合按行的真实 package_id 登记对象归属 (#4636 裁 B 收官)

### DIFF
--- a/.changeset/lucky-moons-smoke.md
+++ b/.changeset/lucky-moons-smoke.md
@@ -1,0 +1,12 @@
+---
+'@objectstack/metadata-protocol': patch
+'@objectstack/objectql': patch
+---
+
+fix(metadata-protocol): boot 重水合按行的真实 package 绑定登记对象归属(#4636 裁 B 收官)
+
+`loadMetaFromDb` 的 object 分支从 `engine.find` 返回的行上读 `record.packageId`,而 `sys_metadata` 的列是 snake_case 的 `package_id` —— 该表达式恒为 `undefined || 'sys_metadata'`,于是每次重启都把**绑定了包**的对象 overlay 登记在 `'sys_metadata'` 哨兵下。改为读 `package_id`,与写路径、`getMetaItems`、以及相邻的非 object 分支一致。
+
+用户可见的行为差异:归属键同时就是包过滤键(`getAllObjects(packageId)`),所以此前一个对象在**创建时**出现在自己所属包的侧边栏过滤里,**重启之后就消失**;更要紧的是重启后的第一次编辑——boot 登记 `'sys_metadata'`、保存登记 `app.<slug>`,`registerObject` 抛 `already owned by package …` 被 `applyObjectRegistryMutation` 吞成 `console.warn`,保存回 `success: true` 而内存 schema 停在重启时的版本,这一笔编辑被静默丢弃(cloud#970 的重启面)。两侧统一到真实 id 后,过滤与编辑都跨重启成立。
+
+`@objectstack/objectql` 仅同步 `registry.ts` 中 `isTenantAuthored` 的契约注释:PR1 标注的「这半句描述的是契约,还不是代码」随本次落地摘除。

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -10760,9 +10760,23 @@ export class ObjectStackProtocolImplementation implements
                         // the very next write with `not_overridable`. An app the user
                         // had just built became un-editable at the first kernel
                         // rebuild (cloud#970).
+                        //
+                        // The ownership key is the row's REAL package binding
+                        // (#4636 PR2). These rows come off `engine.find`, so
+                        // their columns are snake_case — `package_id`, never
+                        // `packageId`, exactly as `getMetaItems` and the
+                        // sibling branch below already read them. Reading the
+                        // camelCase key made the expression `undefined ||
+                        // 'sys_metadata'`, so every boot registered even a
+                        // package-bound object under the sentinel and the
+                        // sidebar's `getAllObjects(packageId)` filter lost it
+                        // across a restart. `||` and not `??`, symmetric with
+                        // the write path's `request.packageId || 'sys_metadata'`:
+                        // an empty binding is "no package", and the sentinel
+                        // marks exactly that one thing.
                         this.engine.registry.registerObject(
                             { ...(data as Record<string, unknown>), _provenance: 'org' } as any,
-                            record.packageId || 'sys_metadata',
+                            (record as { package_id?: string | null }).package_id || 'sys_metadata',
                         );
                     } else {
                         // Same rule as the getMetaItems read-side hydration and

--- a/packages/objectql/src/protocol-boot-object-package-binding.test.ts
+++ b/packages/objectql/src/protocol-boot-object-package-binding.test.ts
@@ -1,0 +1,310 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #4636 PR2 — BOOT re-hydration (`loadMetaFromDb`) keys object-overlay
+ * ownership by the row's REAL package binding, closing the restart half of
+ * the same defect PR1 closed on the write path.
+ *
+ * ## What was wrong
+ *
+ * The object branch of `loadMetaFromDb` read `record.packageId` off a row
+ * that came straight out of `engine.find('sys_metadata', …)` — and those
+ * rows are keyed by the object's SNAKE_CASE column names. `sys_metadata`
+ * declares `package_id`; the repository writes `package_id`; `getMetaItems`
+ * reads `r.package_id`; the sibling (non-object) branch three lines below
+ * reads `(record as …).package_id`. Only this one branch spelled it
+ * camelCase, so the expression was permanently `undefined || 'sys_metadata'`
+ * and EVERY boot-hydrated object registered under the sentinel, package-bound
+ * or not.
+ *
+ * ## The behaviour that pins it: create, restart, edit
+ *
+ * The ownership key is the package-filter key — `getAllObjects(packageId)`
+ * matches `contributor.packageId` and the runtime sidebar consumes it. After
+ * PR1 the write path records `app.<slug>`, so the surviving defect was
+ * exactly restart-shaped: an object was in its package's filter when you
+ * created it and gone after a reboot.
+ *
+ * Worse than the missing filter row, and the reason this file simulates a
+ * real restart rather than asserting the key in isolation: with the two sides
+ * disagreeing, the FIRST edit after a restart re-claimed ownership under a
+ * different key, `registerObject` threw `already owned by package
+ * "sys_metadata"`, and `applyObjectRegistryMutation` catches that into a
+ * `console.warn`. The save answered `success: true` while the in-memory
+ * schema stayed at the pre-edit version — the edit was dropped silently. It
+ * is cloud#970's restart surface in its post-PR1 form: not a `403`, because
+ * both sides do stamp `_provenance: 'org'` and the overlay gate stays open,
+ * but a swallowed ownership clash. So the assertions below run a full
+ * session-1-writes / session-2-boots / session-2-edits cycle against the
+ * real `SchemaRegistry`, and check the evolved field actually lands.
+ *
+ * This file lives in `@objectstack/objectql` for the same reason PR1's
+ * `protocol-writepath-object-ownership.test.ts` does: the subject is the REAL
+ * `SchemaRegistry` (contributor ownership, `getAllObjects` filtering), and
+ * `@objectstack/objectql` depends on `@objectstack/metadata-protocol` — only
+ * this direction can hold both halves without closing a cycle turbo rejects.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ObjectStackProtocolImplementation } from '@objectstack/metadata-protocol';
+import { SchemaRegistry } from './registry.js';
+// [#4550 / #5480] The producer's OWN write-verb dispatch decisions, so this
+// double cannot accept a call `ObjectQL.delete` / `ObjectQL.update` refuses.
+import { assertEngineDeleteDispatch } from './engine-delete-dispatch.js';
+import { assertEngineUpdateDispatch } from './engine-update-dispatch.js';
+
+/** A Studio authoring workspace id — writable under ADR-0070. */
+const APP_PKG = 'app.myapp';
+const OTHER_PKG = 'app.otherapp';
+/** The key an overlay row bound to NO package keeps. */
+const SENTINEL = 'sys_metadata';
+
+interface Row {
+    id: string;
+    type: string;
+    name: string;
+    organization_id: string | null;
+    package_id: string | null;
+    state: string;
+    metadata: string;
+    checksum?: string;
+    version?: number;
+}
+
+interface HistoryRow {
+    id: string;
+    event_seq: number;
+    type: string;
+    name: string;
+    version: number;
+    operation_type: string;
+    metadata: string | null;
+    checksum: string | null;
+    organization_id: string | null;
+    recorded_at: string;
+}
+
+function matches(r: Record<string, unknown>, where: Record<string, unknown>): boolean {
+    for (const [k, v] of Object.entries(where)) {
+        if (v === undefined) continue;
+        if ((r as any)[k] !== v) return false;
+    }
+    return true;
+}
+
+function keyOf(w: Record<string, unknown>) {
+    return `${w.type}|${w.name}|${w.organization_id ?? '__env__'}|${w.state ?? 'active'}|${w.package_id ?? '__nopkg__'}`;
+}
+
+/**
+ * One kernel process: a fresh `SchemaRegistry` + protocol over a
+ * `sys_metadata` table. `seed` is how a RESTART is expressed — the rows a
+ * previous process persisted, handed to a brand-new registry that knows
+ * nothing about them until `loadMetaFromDb` runs.
+ */
+function makeSession(seed: { rows?: Row[]; history?: HistoryRow[] } = {}) {
+    const registry = new SchemaRegistry({ multiTenant: false });
+    registry.logLevel = 'silent';
+    const rows = new Map<string, Row>();
+    for (const r of seed.rows ?? []) rows.set(keyOf(r), { ...r });
+    const historyRows: HistoryRow[] = (seed.history ?? []).map((h) => ({ ...h }));
+    const synced: string[] = [];
+    let nextId = 0;
+    const findRow = (w: Record<string, unknown>) => {
+        for (const [k, r] of rows) if (matches(r, w)) return { key: k, row: r };
+        return null;
+    };
+    const engine: any = {
+        registry,
+        async findOne(table: string, opts: { where: Record<string, unknown> }) {
+            if (table === 'sys_metadata_history') {
+                return historyRows.find((h) => matches(h as any, opts.where)) ?? null;
+            }
+            return findRow(opts.where)?.row ?? null;
+        },
+        async find(table: string, opts: { where: Record<string, unknown> }) {
+            if (table === 'sys_metadata_history') {
+                return historyRows.filter((h) => matches(h as any, opts.where));
+            }
+            return Array.from(rows.values()).filter((r) => matches(r, opts.where));
+        },
+        async insert(table: string, data: Record<string, unknown>) {
+            if (table === 'sys_metadata_history') {
+                const h = { id: `h_${++nextId}`, ...(data as any) } as HistoryRow;
+                historyRows.push(h);
+                return { id: h.id };
+            }
+            if (table !== 'sys_metadata') return { id: 'side_table' };
+            const row = { id: `r_${++nextId}`, ...(data as any) } as Row;
+            rows.set(keyOf(data), row);
+            return { id: row.id };
+        },
+        async update(table: string, data: Record<string, unknown>, opts: { where: Record<string, unknown> }) {
+            assertEngineUpdateDispatch(data, opts);
+            if (table !== 'sys_metadata') return { id: null };
+            const found = findRow(opts.where);
+            if (!found) return { id: null };
+            const merged = { ...found.row, ...(data as any) };
+            rows.delete(found.key);
+            rows.set(keyOf(merged), merged);
+            return { id: found.row.id };
+        },
+        async delete(_t: string, opts?: Record<string, unknown>) {
+            assertEngineDeleteDispatch(opts);
+            return { deleted: 0 };
+        },
+        async syncObjectSchema(name: string) { synced.push(name); },
+    };
+    // A PROJECT kernel (`environmentId` set) — the topology cloud#970 was
+    // reported on, and the only one where `saveMetaItem`'s overlay gate is
+    // engaged at all.
+    const protocol = new ObjectStackProtocolImplementation(engine, undefined, 'env_test');
+    return { registry, protocol, rows, historyRows, synced };
+}
+
+function objectBody(name: string, extra?: Record<string, unknown>) {
+    return {
+        name,
+        label: 'Invoice',
+        fields: {
+            name: { name: 'name', type: 'text', label: 'Name' },
+            amount: { name: 'amount', type: 'number', label: 'Amount' },
+        },
+        ...extra,
+    };
+}
+
+/** The owning contributor recorded for `name` (no namespace → fqn === name). */
+const owner = (registry: SchemaRegistry, name: string) => registry.getObjectOwner(name);
+
+/**
+ * Session 1: author the object through the REAL write path, then hand its
+ * persisted rows to a brand-new process. Hand-crafting the row would let the
+ * fixture drift from what the repository actually writes — the column
+ * spelling is the entire subject of this test.
+ */
+async function persistThenRestart(opts: { name: string; packageId?: string }) {
+    const first = makeSession();
+    const res = await first.protocol.saveMetaItem({
+        type: 'object',
+        name: opts.name,
+        ...(opts.packageId ? { packageId: opts.packageId } : {}),
+        item: objectBody(opts.name),
+    });
+    expect(res.success).toBe(true);
+    const persisted = Array.from(first.rows.values());
+    return {
+        persisted,
+        reboot: () => makeSession({ rows: persisted, history: first.historyRows }),
+    };
+}
+
+describe('#4636 PR2 — boot re-hydration keys object ownership by the row\'s package_id', () => {
+    it('registers a package-bound row under its REAL package id, not the sentinel', async () => {
+        const { persisted, reboot } = await persistThenRestart({
+            name: 'myapp_invoice',
+            packageId: APP_PKG,
+        });
+
+        // The row the previous process left behind carries the binding in the
+        // snake_case column this branch has to read.
+        expect(persisted).toHaveLength(1);
+        expect(persisted[0].package_id).toBe(APP_PKG);
+        expect((persisted[0] as any).packageId).toBeUndefined();
+
+        const second = reboot();
+        const res = await second.protocol.loadMetaFromDb();
+
+        expect(res.loaded).toBe(1);
+        expect(res.errors).toBe(0);
+        // Pre-fix: `'sys_metadata'` — `record.packageId` was undefined and the
+        // `|| 'sys_metadata'` fallback always won.
+        expect(owner(second.registry, 'myapp_invoice')?.packageId).toBe(APP_PKG);
+    });
+
+    it('still stamps `_provenance: \'org\'` on the hydrated body (cloud#970 unchanged)', async () => {
+        const { reboot } = await persistThenRestart({
+            name: 'myapp_invoice',
+            packageId: APP_PKG,
+        });
+
+        const second = reboot();
+        await second.protocol.loadMetaFromDb();
+
+        // Unchanged by PR2 and deliberately so: the row is tenant-authored
+        // whatever package it is bound to, and this stamp — not the sentinel
+        // string — is what keeps `isArtifactBacked` false so the overlay gate
+        // lets the next write through.
+        expect((owner(second.registry, 'myapp_invoice')?.definition as any)?._provenance).toBe('org');
+    });
+
+    it('the sidebar package filter finds the object again after a restart', async () => {
+        const { reboot } = await persistThenRestart({
+            name: 'myapp_invoice',
+            packageId: APP_PKG,
+        });
+
+        const second = reboot();
+        await second.protocol.loadMetaFromDb();
+
+        // runtime `meta.ts` → `getAllObjects(packageId)`. Pre-fix this was
+        // empty after every restart even though the object was there before it.
+        expect(second.registry.getAllObjects(APP_PKG).map((o: any) => o.name)).toEqual(['myapp_invoice']);
+        expect(second.registry.getAllObjects(OTHER_PKG)).toEqual([]);
+    });
+
+    it('the FIRST edit after a restart lands in the schema (cloud#970 restart surface)', async () => {
+        const { reboot } = await persistThenRestart({
+            name: 'myapp_invoice',
+            packageId: APP_PKG,
+        });
+
+        const second = reboot();
+        await second.protocol.loadMetaFromDb();
+
+        // The user comes back the next morning and adds a field.
+        const evolved = objectBody('myapp_invoice');
+        (evolved.fields as any).due_date = { name: 'due_date', type: 'date', label: 'Due' };
+        const saved = await second.protocol.saveMetaItem({
+            type: 'object',
+            name: 'myapp_invoice',
+            packageId: APP_PKG,
+            item: evolved,
+        });
+
+        expect(saved.success).toBe(true);
+        // THE load-bearing assertion. Pre-fix, `success: true` was already
+        // true — boot claimed `'sys_metadata'`, this save claimed `app.myapp`,
+        // `registerObject` threw `already owned by package "sys_metadata"`, and
+        // `applyObjectRegistryMutation` swallowed it into a `console.warn`. The
+        // write reached the DB and the in-memory schema stayed at the boot
+        // version, so CRUD on the new field failed until the NEXT restart.
+        expect(Object.keys((second.registry.getObject('myapp_invoice') as any).fields)).toContain('due_date');
+        // Ownership survives the re-registration on the same key.
+        expect(owner(second.registry, 'myapp_invoice')?.packageId).toBe(APP_PKG);
+        // On disk: still one row, still bound to its package.
+        const stored = Array.from(second.rows.values()).filter((r) => r.name === 'myapp_invoice');
+        expect(stored).toHaveLength(1);
+        expect(stored[0].package_id).toBe(APP_PKG);
+    });
+});
+
+describe('#4636 PR2 — a package-less row keeps the sentinel (regression)', () => {
+    it('hydrates an unbound row under the sentinel, exactly as before', async () => {
+        const { persisted, reboot } = await persistThenRestart({ name: 'global_invoice' });
+
+        expect(persisted[0].package_id ?? null).toBeNull();
+
+        const second = reboot();
+        const res = await second.protocol.loadMetaFromDb();
+
+        expect(res.loaded).toBe(1);
+        // `||`, not `??`: no binding — including the empty-string spelling —
+        // means "no package", and the sentinel marks that one thing. Same
+        // normalisation the write path applies to `request.packageId`.
+        expect(owner(second.registry, 'global_invoice')?.packageId).toBe(SENTINEL);
+        expect((owner(second.registry, 'global_invoice')?.definition as any)?._provenance).toBe('org');
+        // It is not smuggled into any package's filter.
+        expect(second.registry.getAllObjects(APP_PKG)).toEqual([]);
+    });
+});

--- a/packages/objectql/src/registry.ts
+++ b/packages/objectql/src/registry.ts
@@ -799,12 +799,10 @@ export class NamespaceConflictError extends Error {
  *
  * `_packageId !== 'sys_metadata'` alone cannot answer it. That sentinel marks
  * one thing only — an overlay row bound to no package. A row that IS bound to
- * one is keyed by its real package id on the save path (#4636 PR1) and by the
- * boot-time rehydration of `sys_metadata` (#4636 PR2 — the branch still reads a
- * camelCase key off a snake_case row, so today it falls back to the sentinel;
- * that half of this paragraph describes the contract, not yet the code). Either
- * way the key is `app.<slug>`, which is exactly what every code-shipped item
- * carries too, so the sentinel test cannot tell them apart. A tenant's own
+ * one is keyed by its real package id on BOTH sides that register it: the save
+ * path (#4636 PR1) and the boot-time rehydration of `sys_metadata` (#4636 PR2).
+ * Either way the key is `app.<slug>`, which is exactly what every code-shipped
+ * item carries too, so the sentinel test cannot tell them apart. A tenant's own
  * overlay came back from a kernel rebuild looking like a code
  * artifact, and the protocol's overlay gate refused the next write to it with
  * `not_overridable` — an app the user had just built through Studio/AI became


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4636 — 维护者 2026-08-07 裁决 **B** 的**第二步:boot 半边**,本单收官。PR1(#6219,已合入 `c9bf94009`)已把写路径切到真实 package id 并加上服务端强制盖章;本 PR 落地剩下的一行,两侧从此说同一句话。

## 问题

`loadMetaFromDb` 的 object 分支从 `engine.find('sys_metadata', …)` 返回的行上读 `record.packageId`。但这些行是**数据库行**,列名是 snake_case 的 `package_id`:`sys_metadata` 对象声明 `package_id`,`SysMetadataRepository` 写 `package_id`,`getMetaItems` 读 `r.package_id`,**紧邻的非 object 分支**三行之下就写着 `(record as …).package_id`。只有这一支拼成了 camelCase,于是表达式恒为 `undefined || 'sys_metadata'` —— 无论行有没有绑定包,每次 boot 都登记在哨兵下。

## 为什么这不只是个分类瑕疵

归属键**就是**包过滤键(`getAllObjects(packageId)` 匹配 `contributor.packageId`,runtime `meta.ts` 的侧边栏直接消费)。PR1 之后写路径记的是 `app.` 加真实 slug,所以残留缺陷正好是**重启形状**的:对象创建时在自己所属包的过滤里,重启之后就不见了。

更要紧的是**重启后的第一次编辑**。两侧键不一致时,这次保存会以另一个键重新认领归属,`registerObject` 抛 `already owned by package "sys_metadata"`,而 `applyObjectRegistryMutation` 把它 catch 成 `console.warn`:保存返回 `success: true`、行也确实落盘,但内存 schema 停在 boot 时的版本 —— **这一笔编辑被静默丢弃**,新字段在下一次重启前都不可用。

这是 cloud#970 在 PR1 之后的形态:**不是** `403`(两侧都盖 `_provenance: 'org'`,overlay 门是开的),而是一次被吞掉的 ownership 冲突。所以 pin 测试断言的不是「保存成功」,而是**演进后的字段真的进了 schema**。

## 改了什么

1. `packages/metadata-protocol/src/protocol.ts` —— 一行读法:`record.packageId` → `(record as { package_id?: string | null }).package_id`。用 `||` 而非 `??`,与写路径的 `request.packageId || 'sys_metadata'` 对称:空绑定就是「没有包」,哨兵只标记这一件事。该分支**已经**在盖 `_provenance: 'org'`,本 PR 不动盖章。
2. `packages/objectql/src/registry.ts` —— `isTenantAuthored` 契约注释终版:摘掉 PR1 加的「这半句描述的是契约,还不是代码」标注,改成「两侧都按真实 package id 登记」。注释的**结论**(`_packageId !== 'sys_metadata'` 无法回答 provenance)不变。

## 前提复核(在 `origin/main` 上)

| 前提 | 结论 | 证据 |
| --- | --- | --- |
| P1 PR #6219 已在 main | ✅ | `c9bf94009 fix(metadata-protocol): 对象 overlay 写路径的 ownership 键切真实 package id …(#6219)` |
| P2 该行仍是 `record.packageId \|\| 'sys_metadata'` | ✅ | `protocol.ts:10765`(立单时 ~8958,派发词记 :10657,已再漂移;按内容定位) |
| P3 PR1 的 tripwire 用例原样在 | ✅ | `protocol-writepath-object-ownership.test.ts:365` `[tripwire] a package-bound rollback still 409s`,本 PR 一字未动 |

## 测试

新增 `packages/objectql/src/protocol-boot-object-package-binding.test.ts`(5 例)。放在 objectql 而非被测代码旁,理由与 PR1 同:断言对象是**真** `SchemaRegistry`,而 objectql 依赖 metadata-protocol,只有这个方向能同时握住两半。

用例不手搓行,而是**跑一遍真实写路径持久化、再把落盘的行交给一个全新的 registry + protocol** —— 列名拼写正是本 PR 的全部主题,手搓 fixture 会让它与仓库实际写出的形状脱钩。

- package-bound 行:落盘的行确实带 `package_id`(且**没有** `packageId`)→ boot 后归属是 `app.myapp`;
- `_provenance` 仍是 `'org'`(本 PR 不改盖章,显式钉住);
- 侧边栏过滤:重启后 `getAllObjects('app.myapp')` 重新看得见,且不串到 `app.otherapp`;
- **重启面**:boot 之后的第一次编辑 → `due_date` 真的进内存 schema、归属仍是 `app.myapp`、落盘仍是一行且仍绑在包上;
- package-less 行:哨兵照旧,`_provenance: 'org'`,不混进任何包的过滤(回归)。

```
pnpm --workspace-concurrency=2 --filter @objectstack/metadata-protocol --filter @objectstack/objectql test

packages/metadata-protocol test:  Test Files  49 passed (49)
packages/metadata-protocol test:       Tests  502 passed (502)
packages/objectql test:  Test Files  138 passed (138)
packages/objectql test:       Tests  2254 passed (2254)
```

`packages/objectql` `pnpm typecheck`(`tsc --noEmit`)通过、零输出。`metadata-protocol` 没有 `typecheck` 脚本(在 type-check-coverage 的 DEBT ledger 里),与 PR1 相同。

门:

```
check-engine-double-contract: OK — 77 pinned, 133 in the DEBT ledger, 2 exempt.   (本 PR 前 75 pinned;新文件的两个 double 已 pinned)
check-nul-bytes: OK (scanned 5944 tracked text file(s); no raw ASCII control bytes)
```

## 反向验证(方向先写死,再实测)

⚠️ 同 PR1 的测量条件:objectql 的测试经 package exports 解析到 metadata-protocol 的 **`dist/`**,不是 src。下列结果都是**改完重建 dist 之后**的。

**肢 A —— 还原那一行读法(回到 `record.packageId`)。** 预测写在跑之前,逐条:

| 用例 | 预测 | 实测 | 符合? |
| --- | --- | --- | --- |
| 真实 package id | 红 | 红 `expected 'sys_metadata' to be 'app.myapp'` | ✅ |
| `_provenance: 'org'` | **绿**(本 PR 不动盖章) | 绿 | ✅ |
| 侧边栏过滤 | 红 | 红 `expected [] to deeply equal [ 'myapp_invoice' ]` | ✅ |
| 重启后第一次编辑 | **红,但不在 `success` 上** —— `saved.success` 仍为 `true`(不会 403:两侧都盖 `'org'`,门是开的),红在 `due_date` 断言,因为 `registerObject` 抛 `already owned` 被吞成 warn | 红,正在 `due_date`:`expected [ 'organization_id', …(8) ] to include 'due_date'`;`success` 断言先行通过;stderr 印出 `[Protocol] registerObject failed for myapp_invoice: Object "myapp_invoice" is already owned by package "sys_metadata". Package "app.myapp" cannot claim ownership.` | ✅ |
| package-less 哨兵 | 绿 | 绿 | ✅ |

`Tests 3 failed | 2 passed (5)` —— 逐例符合预测,**范围与方向都没有偏差**。特别记一句:这一支**没有** 403,和裁决前 dev 实测的「boot 单独修」形态不同,正是因为 PR1 已经把盖章补上;红的是归属、包过滤,以及被 `console.warn` 吞掉的那笔编辑。

## 必答项

**#5079 终版定价 —— 成因分析不需要更新,`removeRuntimeShadow` 与本 PR 的结构不相交。** PR1 已实测的机制在 boot 侧原样成立:`removeRuntimeShadow` 扫的是 `this.metadata.get(type)` 里的复合键 `pkg:name` 兄弟项,判据 `it._packageId !== 'sys_metadata'` 也是对**那个 Map** 求值;而 object 这一片永远只有裸键 —— boot 的 object 分支和 `applyObjectRegistryMutation` 一样只调 `registerObject`(动的是 `objectContributors`),`plugin.ts` 对 `type === 'object'` 显式 `return`(注释:objects are registered differently (ownership model)),全仓没有任何路径以 packageId 调 `registerItem('object', …)`。所以复合兄弟项从不存在,循环走不到那个判据。本 PR 搬的仍是 `objectContributors` 的键,是 `removeRuntimeShadow` 从不触碰的另一个结构。**#5079 的成因分析(「object 分支本就无 shadow 可摘」)在 #4636 完整落地后依然成立,无需重写,也不应再被定价成「等 #4636」。**

**#6215 —— 零依赖确认。** 本 PR 只动 `loadMetaFromDb` 的一行读法与一段注释,`sys-metadata-repository.ts` 一字未动,`rollbackMetaItem` / `restoreVersion` 一字未动。#6215 的成因(`restoreVersion` 调 `put` 不传 `packageId`,`put` 用 `whereFor(ref, state, opts.packageId ?? null)`,`null` 是谓词而非「任意包」)与 boot 读法无关;两个方向都不阻塞。

**PR1 tripwire —— 原样未动确认。** `protocol-writepath-object-ownership.test.ts` 整个文件本 PR 未修改(`git diff` 不含该文件),`[tripwire] a package-bound rollback still 409s` 仍在 :365,仍绿。#6215 修好那天它照常翻红,把接手的人指向上一条用例里已经写好的 ownership 断言 —— 这条链路完好。


---
_Generated by [Claude Code](https://claude.ai/code/session_019Q7oc7ASjh8yxyS3Yz78We)_