### PR TITLE
docs(analytics): `err.code` 的线上落点是 `error.code`,不是 `error.details.code` (#6123)

### DIFF
--- a/.changeset/analytics-read-scope-compile-failed-500.md
+++ b/.changeset/analytics-read-scope-compile-failed-500.md
@@ -67,7 +67,12 @@ the disclosure question to be re-decided message by message).
   `@objectstack/service-analytics` (ADR-0112 D3) and typed as
   `RegisteredErrorCode` at the constructor, so an unregistered code is a compile
   error. It is legible on the wire through the sibling `/analytics/query` exit,
-  which puts a thrown `err.code` in `error.details.code` (#3842).
+  which puts a thrown `err.code` at **`error.code`** (#3842) — read it there.
+  `errorResponseBase` only stages the code inside a `details` object;
+  `buildApiError` then runs `splitSemanticCode`, which promotes it into the
+  declared `error.code` field and drops the now-empty `details`, so the key is
+  omitted from the body and `error.details.code` is never present:
+  `{"success":false,"error":{"code":"READ_SCOPE_COMPILE_FAILED","message":"Internal server error","httpStatus":500}}`.
 
 **Which inputs are refused did not change.** No refusal condition moved: nothing
 that used to lower now throws, and nothing that used to throw now lowers. That is

--- a/packages/services/service-analytics/src/read-scope-sql.ts
+++ b/packages/services/service-analytics/src/read-scope-sql.ts
@@ -123,9 +123,26 @@ import { likePattern, LIKE_ESCAPE_CHAR } from './like-pattern.js';
  * remove; the route keys on the DECLARATION instead.
  *
  * The code is what a machine reads: `dispatcher-plugin.errorResponseBase`, the
- * sibling `/analytics/query` exit, puts a thrown `err.code` in
- * `error.details.code` (#3842), so `READ_SCOPE_COMPILE_FAILED` is legible there
- * without anyone parsing prose.
+ * sibling `/analytics/query` exit, puts a thrown `err.code` on the wire at
+ * `error.code` (#3842), so `READ_SCOPE_COMPILE_FAILED` is legible there without
+ * anyone parsing prose.
+ *
+ * ⚠️ At `error.code` — NOT `error.details.code`, which is where this note
+ * pointed until #6123 corrected it. `errorResponseBase` only STAGES the code in
+ * a `details` object; `buildApiError` then runs `splitSemanticCode`
+ * (`@objectstack/runtime`, `src/error-envelope.ts:117`), which PROMOTES it into
+ * the declared `ApiErrorSchema` field and returns the now-empty `details` as
+ * `undefined` — so the key is omitted from the body and `error.details.code` is
+ * never present to read. The measured 500 body is exactly:
+ *
+ * ```json
+ * {"success":false,"error":{"code":"READ_SCOPE_COMPILE_FAILED",
+ *  "message":"Internal server error","httpStatus":500}}
+ * ```
+ *
+ * Pinned end-to-end in `@objectstack/runtime`'s
+ * `analytics-query-read-scope-withhold.test.ts`, which asserts the code at
+ * `error.code` against a real `AnalyticsService` on a real mounted route.
  *
  * ⚠️ Deliberately NOT a 4xx of any flavour, including a 422. Option A on the
  * decision card was `READ_SCOPE_INVALID` / 422 ("not your fault, not a crash");


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6123

## 这是什么

**纯文字修正,零行为变化。** 两个已合入的说明面把 `err.code` 的线上落点写成了 `error.details.code`,而实际落点是 `error.code` —— `error.details` 这个键在这条路上根本不存在。分类信息没丢,丢的是「去哪读」这条指引。

## 机制(本次实测复核,与 issue 描述逐行一致)

`errorResponseBase`(`packages/runtime/src/dispatcher-plugin.ts:510`-`:517`)确实把 `err.code` 放进 `details` —— 但那是**进程内的暂存**:

```ts
const details =
    err?.code || validation
        ? { ...(err?.code ? { code: err.code } : {}), ...(validation ?? {}) }
        : undefined;
res.json({ success: false, error: buildApiError({ message, httpStatus, details }) });
```

交给共享构造器 `buildApiError`(`packages/runtime/src/error-envelope.ts:117`,**行号核对无误**)之后,`splitSemanticCode` 把它**提升**进 `ApiErrorSchema` 声明的字段:

```ts
export function buildApiError(input: ApiErrorInput): ApiErrorEnvelope {
    const { code: promoted, details } = splitSemanticCode(input.details);
    return {
        code: input.code ?? promoted ?? standardErrorCodeForHttpStatus(input.httpStatus),
        message: input.message,
        httpStatus: input.httpStatus,
        ...(input.extra ?? {}),
        ...(details !== undefined ? { details } : {}),
    };
}
```

`splitSemanticCode` 取走 `code` 后 `rest` 为空,按其自述注释「`undefined` rather than `{}` so a details payload that held nothing but the code disappears from the wire」返回 `details: undefined`(`error-envelope.ts:112`),于是最后一行的展开被跳过、`details` 键整个消失。真实 500 body:

```json
{"success":false,"error":{"code":"READ_SCOPE_COMPILE_FAILED",
 "message":"Internal server error","httpStatus":500}}
```

这不是本 PR 新测的孤证:PR #6122 落地的端到端用例 `packages/runtime/src/analytics-query-read-scope-withhold.test.ts:218` 已经按实测断言在 `error.code` 上(真 `AnalyticsService` + 真挂载路由),并在其上方写明了同一套提升机制。本 PR 做的只是让另外两处文字追上它。

## 三处修正的 before / after

### 1. `.changeset/analytics-read-scope-compile-failed-500.md`(#5367 的 changeset,已合入未发布)

改这个文件的理由:它会原样进 `CHANGELOG.md` 随 npm 发出去,而按本仓惯例 changeset 正文正是「升级中的 agent 在 tombstone 报错后 grep 的东西」。指向一个永远读不到的键,正是下一个 `??` 兜底的起点。

**Before**

```
  error. It is legible on the wire through the sibling `/analytics/query` exit,
  which puts a thrown `err.code` in `error.details.code` (#3842).
```

**After**

```
  error. It is legible on the wire through the sibling `/analytics/query` exit,
  which puts a thrown `err.code` at **`error.code`** (#3842) — read it there.
  `errorResponseBase` only stages the code inside a `details` object;
  `buildApiError` then runs `splitSemanticCode`, which promotes it into the
  declared `error.code` field and drops the now-empty `details`, so the key is
  omitted from the body and `error.details.code` is never present:
  `{"success":false,"error":{"code":"READ_SCOPE_COMPILE_FAILED","message":"Internal server error","httpStatus":500}}`.
```

### 2. `packages/services/service-analytics/src/read-scope-sql.ts` 文件头

**Before**

```
 * The code is what a machine reads: `dispatcher-plugin.errorResponseBase`, the
 * sibling `/analytics/query` exit, puts a thrown `err.code` in
 * `error.details.code` (#3842), so `READ_SCOPE_COMPILE_FAILED` is legible there
 * without anyone parsing prose.
```

**After**(改第一句 + 增补一段提升机制与实测 body;⛔ 文件其余部分一行未动)

```
 * The code is what a machine reads: `dispatcher-plugin.errorResponseBase`, the
 * sibling `/analytics/query` exit, puts a thrown `err.code` on the wire at
 * `error.code` (#3842), so `READ_SCOPE_COMPILE_FAILED` is legible there without
 * anyone parsing prose.
 *
 * ⚠️ At `error.code` — NOT `error.details.code`, which is where this note
 * pointed until #6123 corrected it. `errorResponseBase` only STAGES the code in
 * a `details` object; `buildApiError` then runs `splitSemanticCode`
 * (`@objectstack/runtime`, `src/error-envelope.ts:117`), which PROMOTES it into
 * the declared `ApiErrorSchema` field and returns the now-empty `details` as
 * `undefined` — so the key is omitted from the body and `error.details.code` is
 * never present to read. The measured 500 body is exactly:
 *
 * ```json
 * {"success":false,"error":{"code":"READ_SCOPE_COMPILE_FAILED",
 *  "message":"Internal server error","httpStatus":500}}
 * ```
 *
 * Pinned end-to-end in `@objectstack/runtime`'s
 * `analytics-query-read-scope-withhold.test.ts`, which asserts the code at
 * `error.code` against a real `AnalyticsService` on a real mounted route.
```

### 3. #5811 正文的同误说法 —— 以**评论**更正,不改正文

#5811 已完成关闭,其「验收建议」第 1 条与「参考」小节照抄了同一说法。按分诊要求以评论形式留更正注记:objectstack-ai/objectstack#5811 (comment 5217110807)。同时在注记里说明 PR #6122 的**实现本身没有跟着错**(用例断言在 `error.code`),受影响的只有该单正文文字,验收结论不变。

## 范围

- ⛔ 未触 `content/docs/releases/`。编辑一个**已合入**的 `.changeset/*.md` 是本单分诊明文确认的合法面,与 releases 禁区无关。
- ⛔ 未改 `error-envelope.ts` / `dispatcher-plugin.ts` 的任何一行(它们是被引用的实现面,只读核对)。
- ⛔ `read-scope-sql.ts` 除文件头那一段外一行未动。整个 diff 是 `2 files changed, 26 insertions(+), 4 deletions(-)`,**没有一行可执行代码**。

## changeset 处理

本 PR 是纯文档/注释修正,自身**不发布任何东西**,按仓约定走 `skip-changeset` 标签而非空 changeset(`.github/workflows/pr-automation.yml` 的 route 2 / PREFERRED;空 changeset 已由 #5471 关闭)。⚠️ 注意本 PR 修改的对象之一**恰好是一个旧 changeset 文件**,但那是被修正的文本,不是本 PR 新增的发布声明 —— `check-empty-changeset` 与计数步骤都只看 `--diff-filter=A` 的新增文件,本 PR 新增 0 个。

## 验证

改动全部是注释/文档,所以验证目标是「零破坏」+「被引用的行号与描述仍然一致」。

| 命令 | 结果 |
|---|---|
| `pnpm --filter @objectstack/service-analytics test` | `Test Files 62 passed (62)` / `Tests 1206 passed (1206)` |
| `pnpm --filter @objectstack/service-analytics build`(该包无 `typecheck` 脚本,tsup 的 DTS emit 即其类型闸口) | `DTS Build success in 3689ms` |
| `vitest run error-envelope.conformance analytics-query-read-scope-withhold`(runtime,提升机制的钉子) | `Test Files 2 passed (2)` / `Tests 53 passed (53)` |
| `npx eslint packages/services/service-analytics/src/read-scope-sql.ts --no-inline-config` | exit 0 |
| `node scripts/check-nul-bytes.mjs --self-test && node scripts/check-nul-bytes.mjs` | `56 assertions` / `OK (scanned 5949 tracked text file(s))` |
| `node scripts/check-doc-authoring.mjs` | `365 files clean` |
| `node scripts/check-empty-changeset.mjs --base origin/main` | `0 declaring changeset(s) added` |

**引用行的实测核对**(issue 正文声称的位置,本次逐行复核):

- `packages/runtime/src/error-envelope.ts:117` = `export function buildApiError(input: ApiErrorInput): ApiErrorEnvelope {` —— **一致**;`:118` 即 `splitSemanticCode(input.details)`,`:120` 是 `input.code ?? promoted ?? …` 的提升,`:124` 是 `...(details !== undefined ? { details } : {})` 的条件展开。
- `packages/runtime/src/dispatcher-plugin.ts` 的 `details` 组装在 `:510`-`:513`,`buildApiError` 调用在 `:516` —— 与 issue 引用的代码片段**逐字一致**(issue 未给该文件行号,只给了片段)。
- `splitSemanticCode` 的 `details: Object.keys(rest).length > 0 ? rest : undefined`(`error-envelope.ts:112`)是 `details` 被省略的**直接原因**,这一句是本次为两处文字新补的解释。

**反向验证的方向说明(如实,不套模板):** 本 PR 不含可执行改动,所以「还原改动看诊断变红」在这里没有可测的对象 —— 没有任何 gate 会因为一句注释指向错误的键而变红(这正是这两处文字能漂移这么久的原因,也正是 #6123 按 observation-class 立单的理由)。代替它的是**正方向的实测锚点**:改后文字所声称的落点,由已在 `main` 上的 `analytics-query-read-scope-withhold.test.ts:218` 用真服务真路由断言着;改前文字所声称的落点,在同一 body 上不存在。与其编造一个不存在的红,不如把锚点指出来。

## 顺带发现(未在本 PR 修,已按 PD #10 单独立单)

`packages/runtime/src/dispatcher-plugin.ts:467`-`:469` 的 `errorResponseBase` 文件头有**同族第四处**同样的措辞(`details.code` (#3842, below) carries `READ_SCOPE_COMPILE_FAILED` to the client untouched)。本单红线明确 ⛔ 不动 `dispatcher-plugin.ts`,故只记录不修。

---
_Generated by [Claude Code](https://claude.ai/code/session_015a5qkLzpGXhLL2F5gvJ7dD)_