### PR TITLE
refactor(hooks): 摘掉最后三处 hook 上下文的 `doc` / `previousDoc` 防御性 alias 读 (#5906)

### DIFF
--- a/.changeset/hook-ctx-doc-alias-reads-removed.md
+++ b/.changeset/hook-ctx-doc-alias-reads-removed.md
@@ -1,0 +1,25 @@
+---
+'@objectstack/service-storage': patch
+'@objectstack/plugin-sharing': patch
+'@objectstack/runtime': patch
+---
+
+hooks: drop the last three `doc` / `previousDoc` alias reads on a hook context — read the engine's own keys only
+
+Behaviour is unchanged: every one of these limbs guarded against a producer that
+has never existed, so none of them could be reached.
+
+- `service-storage` attachment lifecycle read `ctx.result ?? ctx.input.doc ?? ctx.input.data`
+- `plugin-sharing` primary-BU projection read `(ctx.input.data ?? ctx.input.doc).user_id`
+- `runtime`'s hook sandbox read `engineCtx.input ?? engineCtx.doc` and `engineCtx.previous ?? engineCtx.previousDoc`
+
+Every ObjectQL write context spells the payload `data` — measured and pinned by
+`hook-input-shape-contract.test.ts` in `@objectstack/objectql` ("insert carries
+`data` — never `doc`", #5273). The top-level pair is the same family one level
+up: `HookContextSchema` declares `input` / `result` / `previous` and neither a
+`doc` nor a `previousDoc`, and `engine.ts` — the sole producer of a HookContext
+— builds neither. The limbs survived only because the old `HookContext.input`
+contract table documented insert as `{ doc, options }`; that table was corrected
+in #5668, and the same alias was removed from `trigger-record-change` in #5671.
+These are the remainder (#5906), removed rather than left as a second de-facto
+contract (PD #12).

--- a/packages/objectql/src/hook-input-shape-contract.test.ts
+++ b/packages/objectql/src/hook-input-shape-contract.test.ts
@@ -19,9 +19,14 @@
  *     filters bind the driver call where no handler can widen them. So the one
  *     field the docs pointed at resolved `undefined`.
  *   - `insert` was documented as `{ doc: Record, ... }`; the engine builds
- *     `{ data: row, ... }`. (`trigger-record-change` still carries a defensive
- *     `input.doc` alias read for that reason — filed separately, not fixed
- *     here.)
+ *     `{ data: row, ... }`. That wrong sentence was the whole reason consumers
+ *     carried defensive `input.doc` alias reads — branches guarding against a
+ *     producer that has never existed. All of them are now gone:
+ *     `trigger-record-change` in #5671, and the last three — service-storage's
+ *     attachment lifecycle, plugin-sharing's primary-BU projection, and the
+ *     runtime hook sandbox (which aliased the top-level `doc`/`previousDoc` of
+ *     the same family) — in #5906. No consumer defends against this key today,
+ *     so the assertions below are what keeps it that way.
  *
  * The table was also silent about #5038: since ADR-0058's bulk-write addendum
  * the `after*` events on a bulk write fire PER MATCHED ROW on a

--- a/packages/plugins/plugin-sharing/src/primary-bu-projection.ts
+++ b/packages/plugins/plugin-sharing/src/primary-bu-projection.ts
@@ -77,7 +77,12 @@ function collectUserIds(ctx: any): string[] {
   const add = (v: unknown) => { if (v != null && v !== '') ids.add(String(v)); };
   add(ctx?.result?.user_id);
   add(ctx?.previous?.user_id);
-  add((ctx?.input?.data ?? ctx?.input?.doc)?.user_id);
+  // `input.data` is the ONE key a write hook's payload arrives under — measured
+  // and pinned by objectql's `hook-input-shape-contract.test.ts` ("insert carries
+  // `data` — never `doc`", #5273). An `input.doc` alias limb sat below this read
+  // for a producer that never existed; removed in #5906 (same family as #5671)
+  // rather than left as a second de-facto contract (PD #12).
+  add(ctx?.input?.data?.user_id);
   add(ctx?.[STASH_KEY]);
   return [...ids];
 }

--- a/packages/runtime/src/sandbox/body-runner.test.ts
+++ b/packages/runtime/src/sandbox/body-runner.test.ts
@@ -156,6 +156,52 @@ describe('hookBodyRunnerFactory', () => {
     await fn!(engineCtx);
     expect(backing.website).toBe('https://acme.com');
   });
+
+  // [#5906] `input` and `previous` are the engine's own spellings, and the only
+  // ones: `HookContextSchema` declares no top-level `doc`/`previousDoc`, and
+  // objectql's `engine.ts` — the sole producer of a HookContext — builds neither.
+  // Alias limbs for both used to sit in `buildSandboxContext`; these two pin that
+  // the sandbox now seeds from the truth keys and from nothing else. The NEGATIVE
+  // one carries the weight: the truth keys sit FIRST in both reads, so the
+  // positive case would stay green if either alias limb were put back.
+  describe('seeds ctx.input / ctx.previous from the engine keys only', () => {
+    /** A `ql` whose single write records what the body observed. */
+    const probingQl = (seen: Array<Record<string, unknown>>) => ({
+      object: () => ({ insert: async (data: any) => { seen.push(data); return data; } }),
+    });
+
+    const probeHook = (seen: Array<Record<string, unknown>>) =>
+      hookBodyRunnerFactory(runner, { ql: probingQl(seen), appId: 'crm' })({
+        name: 'probe',
+        object: 'contact',
+        events: ['beforeUpdate'],
+        body: {
+          language: 'js',
+          source:
+            "await ctx.api.object('probe').insert({"
+            + ' input: JSON.stringify(ctx.input),'
+            + ' previous: JSON.stringify(ctx.previous ?? null) });',
+          capabilities: ['api.write'],
+        },
+      } as any);
+
+    it('reads `input` and `previous`', async () => {
+      const seen: Array<Record<string, unknown>> = [];
+      await probeHook(seen)!({ input: { email: 'new@x.io' }, previous: { email: 'old@x.io' } } as any);
+      expect(seen[0]).toEqual({
+        input: '{"email":"new@x.io"}',
+        previous: '{"email":"old@x.io"}',
+      });
+    });
+
+    it('does NOT read a `doc` / `previousDoc` alias — no engine path produces either', async () => {
+      const seen: Array<Record<string, unknown>> = [];
+      // The spellings the deleted limbs defended, and nothing else on the context:
+      // with them unread the body sees an empty input and no previous at all.
+      await probeHook(seen)!({ doc: { email: 'new@x.io' }, previousDoc: { email: 'old@x.io' } } as any);
+      expect(seen[0]).toEqual({ input: '{}', previous: 'null' });
+    });
+  });
 });
 
 describe('actionBodyRunnerFactory', () => {

--- a/packages/runtime/src/sandbox/body-runner.ts
+++ b/packages/runtime/src/sandbox/body-runner.ts
@@ -305,8 +305,14 @@ function buildSandboxApi(engineCtx: any, ql: any, errLabel: string) {
 }
 
 function buildSandboxContext(engineCtx: any, ql: any): ScriptContext {
-  const inputSnapshot = unwrapProxyToPlain(engineCtx?.input ?? engineCtx?.doc);
-  const previousRaw = engineCtx?.previous ?? engineCtx?.previousDoc;
+  // `input` and `previous` are the engine's own spellings, and the only ones:
+  // `HookContextSchema` (`packages/spec/src/data/hook.zod.ts`) declares neither a
+  // top-level `doc` nor a `previousDoc`, and objectql's `engine.ts` — the sole
+  // producer of a HookContext — builds neither. Alias limbs for both sat here for
+  // producers that never existed; removed in #5906 (same family as #5671) rather
+  // than left as a second de-facto contract (PD #12).
+  const inputSnapshot = unwrapProxyToPlain(engineCtx?.input);
+  const previousRaw = engineCtx?.previous;
   return {
     input: inputSnapshot ?? {},
     // Preserve `undefined` for `previous` on insert events so hooks can

--- a/packages/services/service-storage/src/attachment-lifecycle.test.ts
+++ b/packages/services/service-storage/src/attachment-lifecycle.test.ts
@@ -167,6 +167,52 @@ describe('installAttachmentLifecycleHooks — tombstoning', () => {
     expect(engine.updates[0].data).toMatchObject({ id: 'f1', status: 'committed', deleted_at: null });
   });
 
+  // [#5906] `input.data` is the ONE key an insert payload arrives under — measured
+  // on the real engine by objectql's `hook-input-shape-contract.test.ts` ("insert
+  // carries `data` — never `doc`", #5273). The fixture above cannot pin that: it
+  // supplies `result`, which sits FIRST in the handler's read, so it stays green
+  // whatever the limbs below it spell. These two carry the weight instead, and the
+  // NEGATIVE one is the load-bearing half — it goes red the moment the deleted
+  // `input.doc` alias limb is put back (that limb sat ahead of `data`, so a
+  // `doc`-only context would be read again).
+  const tombstonedFile = () => ({
+    id: 'f1',
+    key: 'attachments/f1.bin',
+    scope: 'attachments',
+    status: 'deleted',
+    deleted_at: '2026-01-01T00:00:00Z',
+  });
+
+  it('un-tombstones from input.data when the context carries no result', async () => {
+    const engine = fakeEngine({ attachments: [], files: [tombstonedFile()] });
+    installAttachmentLifecycleHooks(engine, silentLogger());
+
+    await engine.trigger('afterInsert', {
+      object: 'sys_attachment',
+      event: 'afterInsert',
+      input: { data: { file_id: 'f1' } },
+    });
+
+    expect(engine.updates).toHaveLength(1);
+    expect(engine.updates[0].data).toMatchObject({ id: 'f1', status: 'committed', deleted_at: null });
+  });
+
+  it('does NOT read an `input.doc` alias — no engine path produces that key', async () => {
+    const engine = fakeEngine({ attachments: [], files: [tombstonedFile()] });
+    installAttachmentLifecycleHooks(engine, silentLogger());
+
+    await engine.trigger('afterInsert', {
+      object: 'sys_attachment',
+      event: 'afterInsert',
+      // The spelling the deleted limb defended. With it gone the handler finds no
+      // `file_id` at all, so the tombstone stands.
+      input: { doc: { file_id: 'f1' } },
+    });
+
+    expect(engine.updates).toHaveLength(0);
+    expect(engine.tables.sys_file[0].status).toBe('deleted');
+  });
+
   it('a failing lookup never blocks the delete (best-effort)', async () => {
     const engine = fakeEngine({ attachments: [], files: [] });
     engine.findOne = async () => {

--- a/packages/services/service-storage/src/attachment-lifecycle.ts
+++ b/packages/services/service-storage/src/attachment-lifecycle.ts
@@ -171,7 +171,14 @@ export function installAttachmentLifecycleHooks(
     'afterInsert',
     async (ctx: any) => {
       try {
-        const row: any = ctx?.result ?? ctx?.input?.doc ?? ctx?.input?.data;
+        // An after-insert context carries the stored row on `ctx.result`, and the
+        // written payload under `input.data` — `data` is the ONLY spelling any
+        // engine path produces, measured and pinned by objectql's
+        // `hook-input-shape-contract.test.ts` ("insert carries `data` — never
+        // `doc`", #5273). An `input.doc` alias limb used to sit between these two
+        // for a producer that never existed; removed in #5906 (same family as
+        // #5671) rather than left as a second de-facto contract (PD #12).
+        const row: any = ctx?.result ?? ctx?.input?.data;
         const fileId = row?.file_id;
         if (!fileId) return;
         const file = await engine.findOne('sys_file', { where: { id: String(fileId) }, context: { ...SYSTEM_CTX } });


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5906

#5671(PR #5908)清掉 `trigger-record-change` 那条 `input.doc` alias 之后,#5671 全仓 grep 剩下的三处同族兜底在这里一并收官,外加一句已成假话的注释改写。**行为零变化**:三条限支都在为一个从不存在的生产者兜底,任何引擎路径都不可达。

## 前提核对(对 `origin/main`,四处逐字命中)

| # | 落点 | 现状 |
|---|---|---|
| 1 | `packages/services/service-storage/src/attachment-lifecycle.ts:174` | `ctx?.result ?? ctx?.input?.doc ?? ctx?.input?.data` |
| 2 | `packages/plugins/plugin-sharing/src/primary-bu-projection.ts:80` | `(ctx?.input?.data ?? ctx?.input?.doc)?.user_id` |
| 3 | `packages/runtime/src/sandbox/body-runner.ts:308` | `engineCtx?.input ?? engineCtx?.doc` / `engineCtx?.previous ?? engineCtx?.previousDoc` |
| 4 | `packages/objectql/src/hook-input-shape-contract.test.ts:23` | 文件头注释仍写着 trigger-record-change「still carries a defensive `input.doc` alias read … filed separately, not fixed here」 |

三条真值证据:

- **`input.doc` 无生产者**:`hook-input-shape-contract.test.ts`(PR #5668)在真引擎上钉住「insert carries `data` — never `doc`」;`HookContextSchema.input` 的契约表逐事件写明载荷一律拼在 `data` 上。
- **顶层 `doc` / `previousDoc` 无生产者**:`HookContextSchema` 只声明 `id` / `object` / `event` / `input` / `result` / `previous` / `session` / `provenance` / `transaction` / `ql` / `api` / `user` —— 两个键都不在其中;`engine.ts` 作为 HookContext 的唯一生产者也都不构造。全仓 grep `previousDoc` 只有 body-runner 这一条**读**,零处写。`buildSandboxContext` 的唯一调用点是同文件 `hookBodyRunnerFactory`,喂进来的就是引擎原生 ctx。
- **第 4 处已成假话**:`340a34f75`(PR #5908)已合入 `main`,那条 alias 早被摘掉。

## 改动

1/2/3 各自只保留引擎真值键,`??` 链其余部分不重排;三处都留了注释说明依据(引用 #5273 / #5671 与本单),按 PD #12 而不是继续养成第二套事实契约。第 4 处**只改注释一句**,改写为收官表述——不动 objectql 任何生产代码。

## 承重 pin(正向 + 反向各一对,反向那条才承重)

真值键在两条读取链里都排**首位**,所以正向用例在 alias 限支复活时仍然绿——反向用例才是承重的那条。这跟 #5908 建立的判法一致。

- **1 号点**:正文点名的 fixture 三分法在这里成立——`attachment-lifecycle.test.ts:159` 的既有 insert fixture 同时给了 `result`,`??` 链首位就命中,对本次清理**不承重**。因此另配一对:正向「无 `result`、只有 `input.data`」证明现在只读真值键;反向「只拼 `input.doc`」断言 tombstone 不动。
- **3 号点**:`body-runner.test.ts` 新增一对,反向用例喂一个**只**拼 `doc` / `previousDoc` 的上下文,断言沙箱看到空 input、无 previous。
- **2 号点**:`plugin-sharing` 的 `collectUserIds` / `bindPrimaryBuHooks` 在仓内**没有任何既有测试**覆盖(全包 grep 确认),按派发口径此处不新建测试文件、在此说明:该处 `data` 本就在链首,删的是其后恒 undefined 的限支,行为等价。

### 反向验证(方向**事前**预判为 RED,实测一致)

把两条限支放回去,只有两条反向用例转红,正向用例照绿——正是它们承重的原因:

```
FAIL src/attachment-lifecycle.test.ts > does NOT read an `input.doc` alias …
  AssertionError: expected [ { object: 'sys_file', …(1) } ] to have a length of +0 but got 1
  Tests  1 failed | 24 passed (25)

FAIL src/sandbox/body-runner.test.ts > does NOT read a `doc` / `previousDoc` alias …
  AssertionError: expected { input: '{"email":"new@x.io"}', …(1) } to deeply equal { input: '{}', previous: 'null' }
  Tests  1 failed | 25 passed (26)
```

复原后两文件各自全绿(25 / 26)。

## 验证

```
service-storage  Test Files 22 passed (22)   Tests 284 passed (284)
plugin-sharing   Test Files 13 passed (13)   Tests 359 passed (359)
runtime          Test Files 105 passed (105) Tests 1508 passed (1508)
objectql hook-input-shape-contract.test.ts   Tests 11 passed (11)   ← 注释改动零破坏

typecheck: objectql / plugin-sharing / runtime 全 Done
  (service-storage 无 typecheck 脚本,走 check:type-check-coverage 的 DEBT 台账)

check:type-check-coverage    OK — 62/77 packages type-checked, 15 in DEBT ledger
check:engine-double-contract OK — 75 pinned, 133 DEBT, 2 exempt
check-nul-bytes              OK — 5949 tracked text files, no raw control bytes
```

## changeset

按仓内同类先例(#5908 的 `.changeset/olive-pugs-repeat.md`,同样是零行为变化的死限支清理)出 **patch** changeset,覆盖三个生产包,正文写明 dead alias branch removal / zero behavior change。因此本 PR **不需要** `skip-changeset`。


---
_Generated by [Claude Code](https://claude.ai/code/session_015a5qkLzpGXhLL2F5gvJ7dD)_