### PR TITLE
fix(objectql): 标量字段的写入载荷拒收算子对象 (#5922)

### DIFF
--- a/.changeset/wild-pugs-clap.md
+++ b/.changeset/wild-pugs-clap.md
@@ -1,0 +1,23 @@
+---
+'@objectstack/objectql': patch
+---
+
+写入载荷里的算子对象在标量字段上被响亮拒收(#5922)
+
+**行为变化**:此前静默入库的算子对象现在被拒绝。`update('task', { title: { $in: ['a','b'] } }, …)` 会抛
+`VALIDATION_FAILED`(字段码 `invalid_type`),而不再把 `{"$in":["a","b"]}` 原样交给驱动写进 `title` 列。
+
+原本这条错误的命运取决于字段类型,而不取决于错误本身:`number` 会立刻响亮拒绝(`n must be a number`),
+`text` 则零告警落库,之后以「这行的 title 变成了乱码」的形态在读路径上出现,离原因很远。实测(15 种字段类型,
+记录型 driver 驱动真实引擎)显示放行的远不止 `text`:`textarea`、未声明 `options` 的 `select`、以及
+`lookup` 等引用类(ADR-0104 warn-first)同样放行;而 `select`(有 options)/ `url` / `email` / `phone`
+之所以拒绝,只是因为 `String({ $in: […] })` 是 `"[object Object]"`,恰好过不了它们的正则或选项表 —— 一条
+在 4 种类型上偶然成立、在另外 11 种上不成立的规则,作者无法从元数据预测。
+
+现在的规则只有一条:**声明值是标量的字段,一律不接受算子对象**。判定复用 spec 已导出的算子词表
+(`ALL_OPERATORS` + `RETIRED_FILTER_OPERATORS`),不是第六份手抄的 `startsWith('$')`,所以协议新增算子当天即
+自动收口。消息与 ADR-0104 的形状拒绝同族(同一 `invalid_value_shape` 文案,四语言均已本地化),点名字段、
+点名算子、点名声明类型。
+
+刻意不动的两处:`json` 等结构化 JSON 类继续放行(`{ "$in": [...] }` 存在 `json` 列里是用户数据,不是写错的
+filter);多值字段保留既有的 `invalid_type_array` 拒绝。`insert` 与 `update`(单行与 multi)三个校验入口均已覆盖。

--- a/packages/objectql/src/validation/operator-object-write-value.test.ts
+++ b/packages/objectql/src/validation/operator-object-write-value.test.ts
@@ -1,0 +1,281 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#5922] A filter operator object is never a scalar field's VALUE.
+ *
+ * ## The asymmetry this closes
+ *
+ * Measured on `origin/main` @ `70f132c15` with a recording driver behind the
+ * real engine, writing one and the same `{ $in: ['a','b'] }` into fifteen
+ * declared field types:
+ *
+ * | type | before | after |
+ * |:--|:--|:--|
+ * | `text` / `textarea` | **ADMIT** — `driver.update` got `{"title":{"$in":["a","b"]}}` | refuse |
+ * | `select` with NO `options` | **ADMIT** | refuse |
+ * | `lookup` (and the reference class) | **ADMIT** + an ADR-0104 warn | refuse |
+ * | `number` / `percent` | refuse (`invalid_number`) | refuse |
+ * | `boolean` | refuse (`invalid_boolean`) | refuse |
+ * | `date` / `datetime` / `time` | refuse (`invalid_date` / …) | refuse |
+ * | `select` WITH `options`, `url`, `email`, `phone` | refuse — but only because `String({…})` is `"[object Object]"` | refuse |
+ * | `json` (structured-JSON class) | admit | **admit — by design** |
+ *
+ * The four "refuse" cells in the second-to-last row are the reason this rule
+ * had to be a rule rather than a patch on `text`: they were never deciding
+ * anything about operator objects, they were failing a regex on a stringified
+ * object. Eleven of fifteen types disagreed with the other four for no reason
+ * an author could predict from the metadata.
+ *
+ * ## What is deliberately NOT here
+ *
+ * - **`json` and the structured-JSON class** keep admitting. `{ "$in": [...] }`
+ *   in a `json` column is a user's data; nothing distinguishes it from a
+ *   mis-written filter and nothing should try.
+ * - **`data.id`.** Post-#5748/#5919 a non-scalar `data.id` is no longer bound
+ *   as a primary key and rides into `driver.updateMany`'s SET payload instead —
+ *   but `ENGINE_UPDATE_DISPATCH_CASES` rules that exact call ("operator object
+ *   in data.id WITH multi:true — the declared bulk intent is honoured") and
+ *   `engine-update-dispatch.test.ts` drives it against the real engine. That is
+ *   a dispatch-axis contract; refusing it here would be a second answer to a
+ *   question that module exists to answer once. Reported, filed, not patched.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateRecord, ValidationError } from './record-validator.js';
+import { ObjectQL } from '../engine.js';
+
+const OP = { $in: ['a', 'b'] };
+
+/** One field of each declared type the rule now closes. */
+const schema = {
+  fields: {
+    title: { type: 'text', label: 'Title' },
+    note: { type: 'textarea', label: 'Note' },
+    stage: { type: 'select', label: 'Stage', options: [{ value: 'a' }, { value: 'b' }] },
+    stage_free: { type: 'select', label: 'Free stage' },
+    due: { type: 'date', label: 'Due' },
+    done: { type: 'boolean', label: 'Done' },
+    owner: { type: 'lookup', label: 'Owner', reference: 'task' },
+    n: { type: 'number', label: 'N' },
+    payload: { type: 'json', label: 'Payload' },
+    tags: { type: 'select', label: 'Tags', multiple: true, options: [{ value: 'a' }] },
+  },
+};
+
+function errorsOf(data: Record<string, unknown>, mode: 'insert' | 'update' = 'update') {
+  try {
+    validateRecord(schema, data, mode);
+  } catch (e) {
+    if (e instanceof ValidationError) return e.fields;
+    throw e;
+  }
+  return [];
+}
+
+describe('#5922 — an operator object is refused on every scalar-valued field', () => {
+  // The dispatch's four-type survey, plus the two string types the issue
+  // reported and the reference class the ADR-0104 branch used to wave through.
+  for (const field of ['title', 'note', 'stage', 'stage_free', 'due', 'done', 'owner', 'n'] as const) {
+    it(`refuses { ${field}: { $in: [...] } } and NAMES the operator`, () => {
+      const errs = errorsOf({ [field]: OP });
+      expect(errs).toHaveLength(1);
+      expect(errs[0].field).toBe(field);
+      // The wire code stays ADR-0114's `invalid_type` — this is a shape
+      // refusal, not a new vocabulary entry.
+      expect(errs[0].code).toBe('invalid_type');
+      // The message must name the FIELD, the offending OPERATOR and the
+      // DECLARED TYPE — the three facts `invalid_number` gives for its half of
+      // the same mistake, which is what makes the two answers one family.
+      expect(errs[0].message).toContain(schema.fields[field].label);
+      expect(errs[0].message).toContain('$in');
+      expect(errs[0].message).toContain(schema.fields[field].type);
+      expect(errs[0].message).toMatch(/filter/i);
+      // …and the discrete constraint carries the same facts machine-readably.
+      expect(errs[0].constraint).toMatchObject({ type: schema.fields[field].type });
+    });
+  }
+
+  it('names EVERY operator when the payload carries a compound filter', () => {
+    const errs = errorsOf({ title: { $gte: 1, $lte: 9 } });
+    expect(errs).toHaveLength(1);
+    expect(errs[0].message).toContain('$gte');
+    expect(errs[0].message).toContain('$lte');
+    expect(errs[0].message).toContain('are filter operators');
+  });
+
+  it('refuses a LOGICAL combinator too, not only field operators', () => {
+    // `$and`/`$or`/`$not` reach the same payload by the same accident.
+    expect(errorsOf({ title: { $or: [{ a: 1 }] } })).toHaveLength(1);
+  });
+
+  it('refuses a RETIRED operator — a filter spelled `$regex` is still a filter', () => {
+    // `$regex` is retired from the protocol but `plugin-auth` still emits it,
+    // so the shape is live. `RETIRED_FILTER_OPERATORS` is folded into the
+    // lookup set for exactly this.
+    expect(errorsOf({ title: { $regex: '^a' } })).toHaveLength(1);
+  });
+
+  it('applies on INSERT, not only on UPDATE', () => {
+    const errs = errorsOf({ title: OP }, 'insert');
+    expect(errs.map((e) => e.field)).toContain('title');
+  });
+});
+
+describe('#5922 — what the rule deliberately leaves alone', () => {
+  it('admits an operator-shaped object in a `json` column (it is data, not a filter)', () => {
+    expect(() => validateRecord(schema, { payload: OP }, 'update')).not.toThrow();
+  });
+
+  it('leaves a multi-value field on its existing `invalid_type_array` refusal', () => {
+    const errs = errorsOf({ tags: OP });
+    expect(errs).toHaveLength(1);
+    expect(errs[0].message).toMatch(/array/i);
+  });
+
+  it('admits an UNDECLARED $-spelling — not a filter any backend executes', () => {
+    // The rule is derived from the spec's operator vocabulary, not from the
+    // `$` sigil. `{ $inn: … }` is out of scope by construction; judging every
+    // plain object on a scalar field is #5922's option A, which this is not.
+    expect(() => validateRecord(schema, { title: { $inn: ['a'] } }, 'update')).not.toThrow();
+  });
+
+  it('admits a plain non-operator object (same reason)', () => {
+    expect(() => validateRecord(schema, { title: { a: 1 } }, 'update')).not.toThrow();
+  });
+});
+
+describe('#5922 — legal scalars still pass, and the pre-existing refusals still refuse', () => {
+  it('accepts a legal scalar for every closed type', () => {
+    expect(() =>
+      validateRecord(
+        schema,
+        {
+          title: 'Ship it', note: 'a longer note', stage: 'a', stage_free: 'anything',
+          due: '2026-08-07', done: true, owner: 'rec_1', n: 42, payload: { any: 'shape' },
+          tags: ['a'],
+        },
+        'insert',
+      ),
+    ).not.toThrow();
+  });
+
+  it('a Date is a comparand, not an operator object', () => {
+    expect(() => validateRecord(schema, { due: new Date('2026-08-07') }, 'update')).not.toThrow();
+  });
+
+  it('`number` keeps its own `invalid_number` refusal for a non-numeric SCALAR', () => {
+    // The regression pin the issue's premise rests on: the new rule sits in
+    // front of the type branches, so this asserts it did not swallow them.
+    const errs = errorsOf({ n: 'abc' });
+    expect(errs).toHaveLength(1);
+    expect(errs[0].code).toBe('invalid_number');
+    expect(errs[0].message).toBe('N must be a number');
+  });
+
+  it('`boolean` and `select` keep their own refusals for non-operator garbage', () => {
+    expect(errorsOf({ done: 'perhaps' })[0].code).toBe('invalid_boolean');
+    expect(errorsOf({ stage: 'zzz' })[0].code).toBe('invalid_option');
+  });
+});
+
+/**
+ * The end-to-end half: the issue's PROBE, run against the real engine.
+ * A unit test over `validateRecord` proves the rule; only this proves the rule
+ * is REACHED on the write path and that nothing dirty reaches storage.
+ */
+describe('#5922 — write path end to end: no dirty row reaches the driver', () => {
+  function recordingDriver() {
+    const rows = new Map<string, Record<string, unknown>>();
+    const writes: Array<{ fn: string; data: unknown }> = [];
+    const driver: any = {
+      name: 'recording', version: '0.0.0', supports: {},
+      async connect() {}, async disconnect() {}, async checkHealth() { return true; },
+      async execute() { return null; },
+      async find() { return Array.from(rows.values()); },
+      async findOne(_o: string, ast: any) { return rows.get(ast?.where?.id) ?? null; },
+      async create(_o: string, data: Record<string, unknown>) {
+        writes.push({ fn: 'create', data });
+        const id = (data.id as string) ?? `rec_${rows.size + 1}`;
+        const row = { ...data, id };
+        rows.set(id, row);
+        return row;
+      },
+      async update(_o: string, id: string, data: Record<string, unknown>) {
+        writes.push({ fn: 'update', data });
+        const next = { ...(rows.get(id) ?? { id }), ...data, id };
+        rows.set(id, next);
+        return next;
+      },
+      async updateMany(_o: unknown, _ast: unknown, data: Record<string, unknown>) {
+        writes.push({ fn: 'updateMany', data });
+        return rows.size;
+      },
+      async upsert(o: string, data: any) { return this.create(o, data); },
+      async delete(_o: string, id: string) { return rows.delete(id); },
+      async count() { return rows.size; },
+      async bulkCreate(o: string, r: any[]) { return Promise.all(r.map((x) => this.create(o, x))); },
+      async bulkUpdate() { return []; }, async bulkDelete() {},
+      async beginTransaction() { return { commit: async () => {}, rollback: async () => {} }; },
+      async commit() {}, async rollback() {},
+    };
+    return { driver, rows, writes };
+  }
+
+  async function boot() {
+    const engine = new ObjectQL();
+    const stub = recordingDriver();
+    engine.registerDriver(stub.driver, true);
+    await engine.init();
+    engine.registry.registerObject({
+      name: 'op_task',
+      label: 'Task',
+      fields: {
+        id: { name: 'id', label: 'ID', type: 'text', primaryKey: true },
+        title: { name: 'title', label: 'Title', type: 'text' },
+        n: { name: 'n', label: 'N', type: 'number' },
+      },
+    } as any);
+    return { engine, ...stub };
+  }
+
+  it('refuses the issue’s exact update PROBE, and the driver is never touched', async () => {
+    const { engine, rows, writes } = await boot();
+    rows.set('rec_1', { id: 'rec_1', title: 'orig' });
+    writes.length = 0;
+
+    await expect(
+      engine.update('op_task', { title: { $in: ['a', 'b'] } } as any, { where: { id: 'rec_1' } } as any),
+    ).rejects.toThrow(/filter operator/i);
+
+    // The two halves of "no dirty data": the driver saw no write at all…
+    expect(writes).toEqual([]);
+    // …and the stored row still holds the value it had before the attempt.
+    expect(rows.get('rec_1')).toEqual({ id: 'rec_1', title: 'orig' });
+  });
+
+  it('refuses it on insert too, and stores nothing', async () => {
+    const { engine, rows, writes } = await boot();
+    await expect(
+      engine.insert('op_task', { title: { $in: ['a', 'b'] } } as any),
+    ).rejects.toThrow(/filter operator/i);
+    expect(writes).toEqual([]);
+    expect(rows.size).toBe(0);
+  });
+
+  it('refuses it on the MULTI update path (the second validateRecord call site)', async () => {
+    const { engine, rows, writes } = await boot();
+    rows.set('rec_1', { id: 'rec_1', title: 'orig' });
+    writes.length = 0;
+    await expect(
+      engine.update('op_task', { title: { $in: ['a', 'b'] } } as any, { multi: true } as any),
+    ).rejects.toThrow(/filter operator/i);
+    expect(writes).toEqual([]);
+  });
+
+  it('a legal write on the same path still lands', async () => {
+    const { engine, rows } = await boot();
+    rows.set('rec_1', { id: 'rec_1', title: 'orig' });
+    await engine.update('op_task', { title: 'renamed', n: 7 } as any, { where: { id: 'rec_1' } } as any);
+    expect(rows.get('rec_1')).toMatchObject({ title: 'renamed', n: 7 });
+  });
+});

--- a/packages/objectql/src/validation/record-validator.ts
+++ b/packages/objectql/src/validation/record-validator.ts
@@ -11,6 +11,10 @@
  *
  * Rules applied (in order, stop at first error per field):
  *
+ *  - operator object  a value carrying declared filter operators (`{ $in: […] }`)
+ *                   is refused on every field whose declared value is a SCALAR
+ *                   — a `where` clause pasted into the SET half of a write
+ *                   (#5922).
  *  - `required`     ADR-0113 write contract: on INSERT a missing/null/empty
  *                   value is rejected; on UPDATE a SUPPLIED missing value is
  *                   rejected (a PATCH may not null out a required field) while
@@ -36,6 +40,9 @@
 import {
   isMultiValueField as specIsMultiValueField,
   valueSchemaFor,
+  isPlainRecord,
+  ALL_OPERATORS,
+  RETIRED_FILTER_OPERATORS,
   REFERENCE_VALUE_TYPES,
   FILE_REFERENCE_TYPES,
   STRUCTURED_JSON_TYPES,
@@ -281,6 +288,75 @@ function isMultiValueField(def: FieldDef): boolean {
 }
 
 /**
+ * [#5922] Filter-operator keys, as a lookup set — **derived from the spec's own
+ * vocabulary, never restated here.**
+ *
+ * `ALL_OPERATORS` is `FILTER_OPERATORS` + `LOGICAL_OPERATORS`: the keys every
+ * backend is expected to evaluate, plus the three combinators. The retired ones
+ * (`$regex` / `$options`) are folded in from `RETIRED_FILTER_OPERATORS` because
+ * this rule asks *"was a filter written here?"*, and a filter carrying a retired
+ * spelling is still a filter — `plugin-auth`'s ObjectQL adapter emits `$regex`
+ * today, so the shape is live, not historical.
+ *
+ * ## Why derived and not `key.startsWith('$')`
+ *
+ * The repo already carries five hand-rolled `keys.some(k => k.startsWith('$'))`
+ * shape tests (`having-filter.ts`, `driver-memory`'s matcher and
+ * `filter-refusal.ts`, `driver-mongodb`'s `mongodb-filter.ts`, `driver-turso`'s
+ * `remote-transport.ts`). None of them is exported, and none is reachable from
+ * this package without inverting the layering — `@objectstack/objectql` depends
+ * on no driver. Writing a sixth `startsWith('$')` here is the accident #5659
+ * names: one question, N private answers, and the day one of them changes only
+ * some of them follow.
+ *
+ * So this consumes the **shared vocabulary** instead, which is exactly what the
+ * two blessed consumers of `FILTER_OPERATORS` already do (`driver-memory`'s
+ * `SUPPORTED_FIELD_OPERATORS` and `service-analytics`' coverage test — the
+ * spec's own note calls deriving enforcement from it "the right design"). An
+ * operator added to the protocol is refused here the same day it is declared,
+ * with nothing to remember.
+ *
+ * The deliberate consequence: an **undeclared** `$`-spelling (`{ $inn: … }`) is
+ * NOT matched. It is not a filter any backend can execute, so it is not this
+ * rule's business — judging every plain object on a scalar field is the broader
+ * question (#5922's option A), and answering it here by accident would be a
+ * scope this ruling did not take.
+ */
+const FILTER_OPERATOR_KEYS: ReadonlySet<string> = new Set<string>([
+  ...ALL_OPERATORS,
+  ...Object.keys(RETIRED_FILTER_OPERATORS),
+]);
+
+/**
+ * [#5922] The declared filter operators this value carries as own keys — empty
+ * when the value is not an operator object at all.
+ *
+ * `isPlainRecord` (the spec's, shared with the authoring-key lint) is the
+ * object test: a `Date`, an array, a class instance and a `null` are all
+ * comparands or plain garbage, never a filter node.
+ */
+function filterOperatorKeysIn(value: unknown): string[] {
+  if (!isPlainRecord(value) || value instanceof Date) return [];
+  return Object.keys(value).filter((k) => FILTER_OPERATOR_KEYS.has(k));
+}
+
+/**
+ * [#5922] May this field's declared value legitimately BE an object?
+ *
+ * Two classes, and only two: a multi-value field stores an ARRAY (and is
+ * refused as `invalid_type_array` below when it is not one), and the
+ * structured-JSON class (`json` / `composite` / `repeater` / `record` /
+ * `location` / `address` / `vector`) stores an object BY DEFINITION — a `json`
+ * column holding `{ "$in": ["a","b"] }` is a user's data, not a mis-written
+ * filter, and this validator has no way to tell those apart nor any business
+ * trying. Every other declared type stores a SCALAR, which is what makes the
+ * operator-object rejection decidable at all.
+ */
+function valueMayBeAnObject(def: FieldDef): boolean {
+  return isMultiValueField(def) || STRUCTURED_JSON_TYPES.has(def.type);
+}
+
+/**
  * Coerce lone scalars into single-element arrays for multi-value fields,
  * IN PLACE, before validation (#2552). Legacy clients (e.g. pre-#2186
  * console bulk-edit) PATCH `{ labels: "frontend" }` at a multiselect —
@@ -373,6 +449,55 @@ function validateOne(
   if (isMissing(value)) return null; // nothing else to check
 
   const t = def.type;
+
+  // ── [#5922] an operator object is a FILTER, never a scalar VALUE ─
+  // `{ title: { $in: ['a','b'] } }` in a write payload is a `where` clause that
+  // was pasted into the SET half. Before this check the two halves of the same
+  // mistake had two fates chosen by the field's type: `number` said "n must be
+  // a number" and never reached the driver, while `text` handed the operator
+  // object to `driver.update` verbatim — the row then holds a serialized
+  // `{"$in":["a","b"]}` (or whatever the driver makes of it) and the damage
+  // surfaces far from its cause, as "this record's title turned into garbage".
+  //
+  // It runs BEFORE the per-type branches for two reasons. The near one: the
+  // ADR-0104 reference / structured-JSON branch below WARNS and reports the
+  // value to `onAdmittedValueShapeViolation` before returning null, and that
+  // sink means *this deployment stored a non-conforming value* — recording it
+  // for a write we are about to refuse would enter a counterexample against a
+  // contract nothing actually broke (see `AdmittedValueShapeViolation`). The
+  // far one: the branches that happen to refuse this shape today mostly do so
+  // by ACCIDENT — `select`/`url`/`email`/`phone` only because
+  // `String({ $in: [...] })` is `"[object Object]"`, which fails their regex or
+  // their option list. An accident that fires on four types and not on the
+  // other eleven is not a rule; this is.
+  //
+  // Reachability is external, not theoretical (#5922): flow's `update_record`
+  // spreads authored fields straight into `data`
+  // (`service-automation/src/builtin/crud-nodes.ts`), and a REST PATCH body is
+  // the same shape. An AI-authored filter builder emitting into `fields`
+  // instead of `filter` produces exactly this payload — PD #12's lenient
+  // consumer is precisely where such an error would otherwise hide.
+  if (!valueMayBeAnObject(def)) {
+    const ops = filterOperatorKeysIn(value);
+    if (ops.length > 0) {
+      const plural = ops.length > 1 ? 'are filter operators' : 'is a filter operator';
+      return fail(
+        'invalid_type',
+        {
+          type: t,
+          detail:
+            `${ops.join(', ')} ${plural}, not a value — a filter belongs in the query ` +
+            `'where', not in the write payload`,
+        },
+        // Same wire code and same catalog entry as the ADR-0104 shape refusal
+        // one branch down: one sentence for "this value's SHAPE is wrong for
+        // this field's declared type", already localized in all four bundles.
+        // A fifth near-duplicate message key would be catalog drift, not
+        // clarity — the key is keyed by SENTENCE, and this is that sentence.
+        'invalid_value_shape',
+      );
+    }
+  }
 
   // ── string types ────────────────────────────────────────────────
   if (t === 'text' || t === 'textarea' || t === 'email' || t === 'url' || t === 'phone' || t === 'password' || t === 'markdown' || t === 'html' || t === 'richtext' || t === 'code') {


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5922

## 前提复验(先证伪,再实现)

两条可证伪前提都在 `origin/main` @ `70f132c15` 上重跑过。

**P1 —— text 型今天确实放行算子对象:成立。** 正文 PROBE 原样复现:

```
"title": "ADMIT: driver got [{\"title\":{\"$in\":[\"a\",\"b\"]}}]"
"n":     "REJECT: N must be a number"
```

**P2 —— 既有算子形状判定存在且可达:部分不成立,如实报告。** 仓内**没有**任何导出的「这是不是算子对象」**谓词函数**。存在的是五份互不相通的私有手抄(`objectql/src/having-filter.ts:103`、`driver-memory` 的 `memory-matcher.ts:114` 与 `filter-refusal.ts:565`、`driver-mongodb/src/mongodb-filter.ts:421`、`driver-turso/src/remote-transport.ts:176`),全部是 `keys.some(k => k.startsWith('$'))` 的变体,且全部在 driver 包里 —— `@objectstack/objectql` 不依赖任何 driver,导入即倒置分层。

**可复用的是词表,不是函数**,而词表恰好是 spec 明确声明的唯一真源:`ALL_OPERATORS`(= `FILTER_OPERATORS` + `LOGICAL_OPERATORS`)与 `RETIRED_FILTER_OPERATORS`,均从 `@objectstack/spec/data` 导出,record-validator 已在从该入口导入(无环)。所以本 PR **消费词表**而不是写第六份 `startsWith('$')` —— 这正是 spec 自己在 `FILTER_OPERATORS` 的注释里点名称许的用法(`driver-memory` 的 `SUPPORTED_FIELD_OPERATORS` 与 `service-analytics` 的覆盖测试「derive enforcement from it rather than restating it — which is the right design」)。协议新增算子当天即自动收口,手抄做不到这一点。

## 四型普查(分诊必答)

15 种声明类型,同一个 `{ $in: ['a','b'] }`,记录型 driver 驱动真实引擎:

| 类型 | 修复前 | 修复后 |
|:--|:--|:--|
| `text` / `textarea` | **放行** —— driver 收到 `{"title":{"$in":["a","b"]}}` | 拒收 |
| `select`(**未**声明 `options`) | **放行** | 拒收 |
| `lookup`(及 `master_detail`/`user`/`tree` 引用类) | **放行** + 一条 ADR-0104 warn | 拒收 |
| `number` / `percent` | 拒收(`invalid_number`) | 拒收 |
| `boolean` | 拒收(`invalid_boolean`) | 拒收 |
| `date` / `datetime` / `time` | 拒收(`invalid_date` / …) | 拒收 |
| `select`(**有** `options`)/ `url` / `email` / `phone` | 拒收 —— 但**只是因为** `String({ $in: […] })` 是 `"[object Object]"` | 拒收 |
| `json` 等结构化 JSON 类 | 放行 | **放行(刻意)** |

普查改变了裁决的形状:放行面远不止 `text`,而四种「拒收」里没有一种是真的在判断算子对象 —— 它们只是在一个被字符串化的对象上过不了正则或选项表。一条在 4 种类型上偶然成立、在另外 11 种上不成立的规则,作者无法从元数据预测。所以收口面按**声明值是否为标量**统一划线,而不是给 `text` 打一个补丁。

**`data.id`:不在本 PR 收口,理由是分层而非遗漏。** 实测确认 #5919 裁 A 之后它进了「不被校验」格:

```
PROBE data.id operator + multi:
  calls: [{"fn":"updateMany","args":[{"object":"probe_task"},{"id":{"$in":["a","b"]},"title":"x"}]}]
```

但这一格的裁定**已经写在派发层**:`ENGINE_UPDATE_DISPATCH_CASES` 明确列了 `operator object in data.id WITH multi:true — the declared bulk intent is honoured (#5748)` → `expect: 'multi'`,且 `engine-update-dispatch.test.ts` 用真实引擎逐条驱动它。在 record-validator 里拒收同一个调用,就是对同一个问题给出第二个答案 —— 正是 `engine-update-dispatch.ts` 这一族模块被抽出来防的事(#4550 / #4434)。按同族一致性它该收口,按「一个问题一个答案」它不该在这里收口,后者更重。已另立 objectstack-ai/objectstack#6262,给出 A(派发层剥离,倾向)/ B(响亮拒绝,需回退 #5748 裁 A 的一条 case)/ C(留给驱动,不建议)。

## 改动

`packages/objectql/src/validation/record-validator.ts` 一处,`validateOne` 在类型分支**之前**:声明值为标量的字段(即非多值、非结构化 JSON),值若携带已声明的 filter 算子键则拒收。

放在类型分支之前有两个理由,近的一个是必须的:下方 ADR-0104 引用/结构化 JSON 分支会在 `return null` 之前 warn 并向 `onAdmittedValueShapeViolation` 上报,而那个 sink 的语义是「本部署**存下了**一个不合规值」—— 为一次即将被拒绝的写入登记反例,会让部署凭空背上一条它并没有违反的 ADR-0104 记录(见 `AdmittedValueShapeViolation` 的 TSDoc:被拒绝的值 settles nothing)。

消息复用 ADR-0104 的 `invalid_value_shape` 文案(四语言均已本地化),wire code 仍是 `invalid_type`。没有新增消息 key:该 key 按**句子**编目,而「这个值的形状不适合该字段的声明类型」正是这句话,再加一条近义句是 catalog drift 而不是清晰度。渲染结果:

```
Title has an invalid text value: $in is a filter operator, not a value
  — a filter belongs in the query 'where', not in the write payload
```

## 反向验证(方向先写死,实测与预测一致)

**肢 A = 去掉新判定。** 预测:拒收用例翻红,且**分两种原因** —— `title`/`note`/`stage_free`/`owner` 因为根本不抛(放行洞),`stage`/`due`/`done`/`n` 因为仍抛但落回各自偶然的旧 code;端到端用例翻红且脏对象落库;两组「刻意不动」与「合法标量/既有拒收」保持绿。

实测 **15 failed | 9 passed**,逐条对上:

```
× refuses { title: … }      AssertionError: expected [] to have a length of 1 but got +0
× refuses { stage: … }      AssertionError: expected 'invalid_option' to be 'invalid_type'
× refuses { due:   … }      AssertionError: expected 'invalid_date'   to be 'invalid_type'
× refuses { done:  … }      AssertionError: expected 'invalid_boolean' to be 'invalid_type'
× refuses { n:     … }      AssertionError: expected 'invalid_number'  to be 'invalid_type'
× refuses the issue's exact update PROBE, and the driver is never touched
    AssertionError: promise resolved "{ title: { '$in': [ 'a', 'b' ] }, …(1) }" instead of rejecting
```

最后一条就是「脏对象落库」的直接证据 —— 解析出来的行里躺着那个算子对象。保持绿的 9 条正好是两组刻意不动的用例,说明翻红来自新判定而不是用例本身。

## 测试

新增 `packages/objectql/src/validation/operator-object-write-value.test.ts`,24 条:每个收口类型一条拒收(断言点名字段/算子/声明类型)、复合算子、逻辑组合子、退役算子 `$regex`、insert 面;刻意不动面(`json`、多值 `invalid_type_array`、未声明的 `$inn`、普通对象);合法标量回归、`Date` 是 comparand、`number` 既有 `invalid_number` 回归(断言消息仍是 `N must be a number`)、`boolean`/`select` 既有 code 回归;写路径端到端 4 条(单行 update / insert / multi update 三个 `validateRecord` 入口各一条,断言 driver 一次未被调用且库里行未变,外加一条合法写仍然落库)。

```
pnpm --filter @objectstack/objectql test       → Test Files 138 passed, Tests 2273 passed
pnpm --filter @objectstack/objectql typecheck  → tsc --noEmit 通过,无输出
node scripts/check-engine-double-contract.mjs  → OK — 75 pinned, 133 DEBT, 2 exempt
node scripts/check-nul-bytes.mjs               → OK(5957 个文件,无裸控制字节)
```

**消费半径普查**:`validateRecord` 的运行时消费方只有 `engine.ts` 的三个入口(insert / update 单行 / update multi),三条都有端到端用例。跨包 fixture 用 `\.(insert|update|create)\(…\$(in|gt|…)` 扫过 rest / runtime / services / triggers / plugins / client / cli,命中全部落在 `where` 位(正确用法),无一在写入载荷位。另跑了两个最重的写路径消费方作为兜底:

```
packages/rest                  → Test Files 63 passed, Tests 861 passed
packages/services/service-automation → Test Files 66 passed, Tests 789 passed
```

## #5591 是否触面:否

#5591 是 `engine.ts` 里 `stripReadonlyFields` 相对 `beforeUpdate` hook 的**时序**问题,实现在 `rule-validator.ts`(本 PR 未触),调用在 `engine.ts`(本 PR 未触)。文件面不相交;语义上也不相交:`validateRecord` 对 `readonly`/`system` 字段直接 `continue`(`record-validator.ts:944` / `:954`),而 readonly 字段正是 #5591 唯一搬动的那一类,所以新规则在剥离前后都不会对它发火。

## 行为变化的存量风险(只测只答,未修)

已存进库的脏算子对象行,读路径今天**不报错也不修复**,原样交还:

```
READ findOne => {"id":"rec_1","title":{"$in":["a","b"]}}
typeof title => object
filter title=="x"      matches dirty row => false
filter $contains 'a'   matches dirty row => false
REPAIR write => {"err":null,"row":{"id":"rec_1","title":"repaired"}}
```

三点:

1. 声明为 `text` 的列读回来是一个 JS **对象**,凡是假定该列为字符串的消费方(模板渲染、display-name、CSV 导出、表单)拿到的都是对象,无错无警;
2. 该列上的过滤一律**不匹配**,脏行从每个按该列过滤的面上静默消失 —— 正是正文说的「离原因很远」;
3. 经 SQL 驱动往返后列里是序列化字符串 `{"$in":["a","b"]}`,与内存后端保留对象不同,同一条脏数据在不同后端有两种事后形态。

**本改动不会把存量脏行锁死**:对脏行正常写入一个合法标量仍然成功(上面的 `REPAIR write`),存量可用普通 update 修复,无需迁移。是否需要一次扫描/迁移不在本单范围,未修。

---
_Generated by [Claude Code](https://claude.ai/code/session_019Q7oc7ASjh8yxyS3Yz78We)_