### PR TITLE
fix(spec): `FlowFunctionEntrySchema` 收下 lowered declaration,声明形写手重新扛得住 `objectstack build` (#4976)

### DIFF
--- a/.changeset/flow-function-lowered-declaration.md
+++ b/.changeset/flow-function-lowered-declaration.md
@@ -1,0 +1,70 @@
+---
+"@objectstack/spec": minor
+---
+
+fix(spec): `functions: { fn: { handler, effect: 'writes' } }` survives `objectstack build` (#4976)
+
+`FlowFunctionEntrySchema` gains a fourth union member — the **lowered
+declaration**, a `functions` entry whose `handler` has been replaced by the
+string ref `objectstack build` emits:
+
+```
+functions: {
+  sweepProjectHealth: { handler: 'sweepProjectHealth', effect: 'writes' },
+}
+```
+
+Nothing an author writes changes. This shape is produced by the CLI, not typed
+by a person: `lowerCallables` replaces every inline callable with a serialisable
+ref before the stack is parsed (it must — `z.function()` wraps callables and
+would break the ref mapping), and since #4396 it keeps the declaration beside
+the ref so what a function said about itself survives into the artifact. The
+union was not extended in that change, so the artifact it started emitting was
+rejected by the very schema it had to pass:
+
+```
+  ✗ Validation failed
+
+  functions:
+    ✗ functions
+      invalid_union: Invalid input
+```
+
+Loading from source was unaffected — `objectstack dev`, `objectstack validate`
+and the test suite all passed — so the failure appeared only at build, on the
+one spelling the platform asks writers to use. That is the same asymmetry #4343
+fixed for the bare handler ref, one shape over.
+
+**Why this was worse than a failed build.** `effect: 'writes'` exists so a
+function that writes is not counted as having written nothing (#4396, #4354): a
+`script` step reports no record metrics *because* flow functions are
+contractually pure, and a declared writer instead reports `unmeasuredEffect` so
+the run's broken-sweep query (`selected > 0 AND acted = 0 AND unmeasured = 0`)
+stays off it. The error above names no key, no entry and no reason, so the
+practical repair an author reaches for is deleting the declaration — shipping an
+undeclared writer, which is exactly the state it exists to prevent, recorded
+permanently in `sys_automation_run`.
+
+**One behaviour change worth stating.** `{ handler: 'someName' }` written by
+hand now parses where it used to be rejected as "handler is not callable". The
+rejection could not survive this member and should not have: a bare string entry
+(`functions: { foo: 'foo' }`) has been accepted since #4343 with the caveat that
+it registers nothing, so refusing the record spelling of the same mistake while
+accepting the string spelling was two dialects for one contract. Both fail the
+same way, loudly, at execute: `no function named '…' is registered` (#1870).
+Everything else stays strict — the lowered member is *derived* from the authored
+declaration rather than re-typed beside it, so `{ handler: 'fn', efect: 'writes' }`
+still raises the named surface and the `` `efect` → `effect` `` prescription, an
+unknown `effect` value is still refused, and an empty ref is still not a name.
+
+**Runtime is unchanged and was already correct.** `normalizeFlowFunctionEntry`
+returns `undefined` for a lowered entry in both its shapes, because neither
+carries a callable; `mergeRuntimeModule` re-attaches the sidecar module's
+function to the declaration the JSON carried *before* any collector runs, so
+`effect` reaches `collectBundleFunctionEntries` intact on the built path.
+
+The two halves are now pinned against each other by a round-trip test that
+drives the real pipeline (`defineStack` → `normalizeStackInput` →
+`lowerCallables` → parse) instead of a hand-written sample of what the lowering
+is believed to emit — the crossing neither side previously made, which is why
+both stayed green while the build failed on the join.

--- a/examples/app-showcase/objectstack.config.ts
+++ b/examples/app-showcase/objectstack.config.ts
@@ -214,23 +214,21 @@ export default defineStack({
   // `sweepProjectHealth` — the handler `HealthSweepJob` names — lives here too.
   // It is the case the pure contract does not cover: a nightly sweep has no
   // downstream declarative node to persist for it, so it writes over an engine
-  // handle captured at `onEnable`.
+  // handle captured at `onEnable`. That is why it is spelled the DECLARED way
+  // (#4396) — an undeclared writer is counted as having written nothing, which
+  // is indistinguishable from the broken sweep #4354 exists to detect.
   //
-  // ⚠️ Do NOT rewrite this as `{ handler: sweepProjectHealth, effect: 'writes' }`.
-  // That declared form (#4396) is the honest spelling for a writer and is what
-  // this entry wants — but it cannot survive `objectstack build` today: the CLI
-  // lowers it to `{ handler: 'sweepProjectHealth', effect: 'writes' }` and
-  // `FlowFunctionEntrySchema` accepts a bare callable, a declaration whose
-  // `handler` is a CALLABLE, or a bare string ref — never a declaration whose
-  // handler has been lowered to a string. `pnpm build` fails with
-  // `functions: invalid_union`. Filed as #4976; switch back once it lands.
-  // Nothing is lost at runtime meanwhile: `effect` has exactly one consumer,
-  // the `script` node's `unmeasuredEffect` metric, and the JOB path drops it
-  // (`collectBundleFunctions` keeps only the handler).
+  // This entry authored the bare form until #4976, not because the bare form was
+  // right but because the declared one could not survive `objectstack build`:
+  // the CLI lowers it to `{ handler: 'sweepProjectHealth', effect: 'writes' }`
+  // and `FlowFunctionEntrySchema` had no member for a declaration whose handler
+  // is a ref, so `pnpm build` failed with `functions: invalid_union`. #4976
+  // added that member; the honest spelling is back, and this app is the
+  // end-to-end proof that it builds.
   functions: {
     summarizeCompletedTask: ({ input }: { input: Record<string, unknown> }) =>
       `Completed: ${String(input.title ?? 'task')} (priority ${String(input.priority ?? 'normal')}).`,
-    sweepProjectHealth,
+    sweepProjectHealth: { handler: sweepProjectHealth, effect: 'writes' as const },
   },
   jobs: allJobs,
   emailTemplates: allEmails,

--- a/examples/app-showcase/test/inert-wirings.test.ts
+++ b/examples/app-showcase/test/inert-wirings.test.ts
@@ -96,24 +96,22 @@ describe('declarative jobs resolve their handler (#4774 ①)', () => {
     });
   }
 
-  it('every functions entry is authored in a form `objectstack build` can carry', () => {
-    // `objectstack build` LOWERS each inline callable to a serialisable string
-    // ref before the stack is parsed, and `FlowFunctionEntrySchema` accepts a
-    // bare callable, a declaration whose `handler` is a CALLABLE, or a bare
-    // string ref — but NOT a declaration whose handler has been lowered to a
-    // string, which is exactly what the CLI emits for the declared form
-    // (`{ handler: fn, effect: 'writes' }`, #4396). So authoring the declared
-    // form here builds green from source and fails `pnpm build` with
-    // `functions: invalid_union`. Filed as #4976.
+  it('the sweep DECLARES that it writes — an undeclared writer reads as a broken sweep', () => {
+    // The inverse of the guard that stood here until #4976. That one pinned
+    // every entry to the BARE form, because the declared spelling could not
+    // survive `objectstack build`: the CLI lowers it to
+    // `{ handler: 'sweepProjectHealth', effect: 'writes' }` and
+    // `FlowFunctionEntrySchema` had no member for a declaration whose handler
+    // is a ref, so the reference app was pinned to the dishonest spelling to
+    // keep `pnpm build` green.
     //
-    // Pinning the bare form keeps that failure out of the reference app until
-    // the schema accepts the lowered declaration. Delete this guard — don't
-    // work around it — when #4976 lands.
-    const declared = functionNames().filter((name) => typeof functionEntry(name) !== 'function');
-    expect(
-      declared,
-      `declared-form functions entry/entries cannot survive \`objectstack build\` (#4976): ${declared.join(', ')}`,
-    ).toEqual([]);
+    // #4976 added that member, so the pin inverts rather than disappears — the
+    // thing worth guarding was never "bare", it was that the one entry which
+    // genuinely writes says so. `sweepProjectHealth` is a nightly job with no
+    // downstream declarative node to count its writes, so undeclared it reports
+    // `selected: N, acted: 0` — indistinguishable from the broken sweep #4354
+    // exists to detect, permanently, in `sys_automation_run`.
+    expect(functionEntry('sweepProjectHealth')).toMatchObject({ effect: 'writes' });
   });
 });
 

--- a/packages/cli/src/utils/lower-callables.test.ts
+++ b/packages/cli/src/utils/lower-callables.test.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
+import { defineStack, normalizeStackInput, ObjectStackDefinitionSchema } from '@objectstack/spec';
+import { FlowFunctionEntrySchema } from '@objectstack/spec/automation';
 import { lowerCallables } from './lower-callables.js';
 
 // ── #3855: `target` is the only handler slot ────────────────────────────────
@@ -122,5 +124,97 @@ describe('lowerCallables — declared `functions` entries (#4396)', () => {
     });
     const [entry] = functionsOf(result) as unknown as Array<Record<string, unknown>>;
     expect(entry).toEqual({ name: 'syncBilling', handler: 'syncBilling', effect: 'writes' });
+  });
+});
+
+// ── #4976: the lowering and the schema must round-trip ──────────────────────
+//
+// Every test above stops at the shape `lowerCallables` EMITS, and every spec
+// test parses only shapes an author WRITES. Nothing crossed the boundary — so
+// when #4396 taught this step to keep a declared entry's declaration, and the
+// union in `flow-function.zod.ts` was not extended in the same change, both
+// halves stayed green and `objectstack build` failed on the join with
+// `invalid_union: Invalid input` and no path past `functions`.
+//
+// These tests are that boundary, driven through the real build pipeline
+// (`defineStack` → `normalizeStackInput` → `lowerCallables` → parse) rather
+// than a hand-written sample of what the lowering is believed to emit: a
+// hand-written sample is a third copy of the truth and drifts exactly the way
+// the two halves already did.
+//
+// SCOPE: the map form. The ARRAY form (`functions: [{ name, handler }]`) does
+// not round-trip either — in both its bare and declared spellings, since #4343
+// and #4976 each only ever touched the map — and its member lives in
+// `stack.zod.ts` rather than in `FlowFunctionEntrySchema`. Filed as #6238;
+// extend the parametrisation below when it lands.
+describe('lowerCallables → the spec parses what it emits (#4976)', () => {
+  const base = {
+    manifest: { id: 'com.example.demo', name: 'demo', version: '1.0.0', type: 'app' as const },
+  };
+
+  /** Exactly what `objectstack compile` does, in the order it does it. */
+  const buildPipeline = (functions: Record<string, unknown>) => {
+    const stack = defineStack({ ...base, functions } as never);
+    const normalized = normalizeStackInput(stack as Record<string, unknown>);
+    return lowerCallables(normalized);
+  };
+
+  const cases: Array<[label: string, functions: Record<string, unknown>]> = [
+    ['a bare handler', { scoreLead: () => ({ score: 1 }) }],
+    ['a declared writer', { syncBilling: { handler: () => ({ ok: true }), effect: 'writes' } }],
+    ['a declaration that states the pure default', { scoreLead: { handler: () => ({ score: 1 }), effect: 'pure' } }],
+    ['a declaration that states nothing', { scoreLead: { handler: () => ({ score: 1 }) } }],
+    ['both spellings side by side', {
+      scoreLead: () => ({ score: 1 }),
+      syncBilling: { handler: () => ({ ok: true }), effect: 'writes' },
+    }],
+  ];
+
+  for (const [label, functions] of cases) {
+    it(`parses every entry it emits for ${label}`, () => {
+      const emitted = (buildPipeline(functions).lowered as {
+        functions: Record<string, unknown>;
+      }).functions;
+
+      for (const [name, entry] of Object.entries(emitted)) {
+        const result = FlowFunctionEntrySchema.safeParse(entry);
+        expect(
+          result.success,
+          `emitted entry '${name}' (${JSON.stringify(entry)}) is not a shape FlowFunctionEntrySchema accepts: `
+          + JSON.stringify(result.success ? [] : result.error.issues),
+        ).toBe(true);
+      }
+    });
+
+    it(`parses the whole lowered stack for ${label}`, () => {
+      // The assertion the build itself makes (`compile.ts` step 3). Parsing the
+      // entries one by one can pass while the stack does not — `functions` is a
+      // union of a record and an array, so a rejected entry surfaces only as
+      // `invalid_union` on the parent, which is precisely the unreadable error
+      // the issue is about.
+      const { lowered } = buildPipeline(functions);
+      const result = ObjectStackDefinitionSchema.safeParse(lowered);
+      expect(
+        result.success,
+        `lowered stack rejected: ${JSON.stringify(result.success ? [] : result.error.issues)}`,
+      ).toBe(true);
+    });
+  }
+
+  it('carries the declaration into the artifact, not just past the parse', () => {
+    // Surviving the parse is worthless if `effect` is dropped on the way — that
+    // would re-create #4396's silent un-declaring with a green build. The
+    // artifact must still SAY 'writes', because that string is what
+    // `mergeRuntimeModule` re-attaches the module's callable to at boot.
+    const { lowered } = buildPipeline({
+      syncBilling: { handler: () => ({ ok: true }), effect: 'writes' },
+    });
+    const parsed = ObjectStackDefinitionSchema.parse(lowered) as {
+      functions: Record<string, { handler: string; effect: string }>;
+    };
+    expect(parsed.functions.syncBilling).toEqual({ handler: 'syncBilling', effect: 'writes' });
+    // And it is JSON — the artifact is `objectstack.json`, not a module.
+    expect(JSON.parse(JSON.stringify(lowered)).functions.syncBilling)
+      .toEqual({ handler: 'syncBilling', effect: 'writes' });
   });
 });

--- a/packages/qa/dogfood/test/showcase-declarative-endpoints.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-declarative-endpoints.dogfood.test.ts
@@ -103,7 +103,27 @@ beforeAll(async () => {
   process.chdir(SHOWCASE_DIR);
   tempDir = mkdtempSync(join(tmpdir(), 'os-e8-endpoints-'));
   const artifactPath = join(tempDir, 'objectstack.json');
-  writeFileSync(artifactPath, JSON.stringify(showcaseStack));
+  // `functions` is dropped DELIBERATELY, and saying so is the point (#4976).
+  //
+  // This line stands in for `objectstack build`, but it is only half of it: the
+  // real build runs `lowerCallables` first, replacing every callable with a
+  // string ref and carrying the functions themselves in a sibling ESM module.
+  // A plain `JSON.stringify` has no such step — it simply omits function-valued
+  // keys — so this artifact never carried the showcase's functions at all. It
+  // merely LOOKED like it did, because a bare entry (`sweepProjectHealth: fn`)
+  // vanishes key and all and leaves `functions: {}` behind, which parses.
+  //
+  // That silence broke the moment the showcase spelled its writer the honest,
+  // declared way: `{ handler: fn, effect: 'writes' }` keeps the object and drops
+  // only `handler`, leaving `{ effect: 'writes' }` — an entry declaring an
+  // effect for a function it does not carry, which `FlowFunctionEntrySchema`
+  // refuses in all four of its members, exactly as it should.
+  //
+  // Nothing is lost by omitting the key: the functions this boot actually runs
+  // come from the LIVE stack handed to `bootStack` below, not from this file,
+  // whose job is to give `MetadataPlugin` the `apis:` block to ingest.
+  const { functions: _functionsLiveOnly, ...artifact } = showcaseStack as Record<string, unknown>;
+  writeFileSync(artifactPath, JSON.stringify(artifact));
 
   stack = await bootStack(showcaseStack, {
     // The `flow`-typed endpoint delegates to `IAutomationService.execute`;

--- a/packages/spec/src/automation/flow-function.test.ts
+++ b/packages/spec/src/automation/flow-function.test.ts
@@ -66,8 +66,28 @@ describe('FlowFunctionEntrySchema', () => {
     expect(FlowFunctionEntrySchema.safeParse({ handler: () => 1, effect: 'writes' }).success).toBe(true);
   });
 
-  it('rejects a declaration whose handler is not callable', () => {
-    expect(FlowFunctionEntrySchema.safeParse({ handler: 'scoreLead' }).success).toBe(false);
+  it('rejects a declaration whose handler is neither a callable nor a ref', () => {
+    // Narrowed in #4976, and the narrowing is the point rather than a
+    // concession. This assertion used to read `{ handler: 'scoreLead' }` —
+    // "handler is not callable" — but a string handler is exactly what
+    // `objectstack build` emits for a declared entry, so the union now accepts
+    // it (see the lowered-declaration cases below). What survives is the
+    // verdict on a handler that is neither: no callable, no name.
+    expect(FlowFunctionEntrySchema.safeParse({ handler: 42 }).success).toBe(false);
+    expect(FlowFunctionEntrySchema.safeParse({ handler: '' }).success).toBe(false);
+    expect(FlowFunctionEntrySchema.safeParse({ effect: 'writes' }).success).toBe(false);
+  });
+
+  it('accepts a hand-authored `{ handler: <name> }` for the same reason it accepts a bare name', () => {
+    // The inversion #4976 causes, stated plainly rather than left as a
+    // surprise. Hand-authoring the lowered form registers nothing — but that
+    // was ALREADY true of the bare string member (`functions: { foo: 'foo' }`),
+    // which has been accepted since #4343 with exactly that caveat. Rejecting
+    // the record spelling while accepting the string spelling of one mistake
+    // was two dialects for one contract; the loud failure is the same either
+    // way, at execute: "no function named '…' is registered" (#1870).
+    expect(FlowFunctionEntrySchema.safeParse({ handler: 'scoreLead' }).success).toBe(true);
+    expect(FlowFunctionEntrySchema.safeParse('scoreLead').success).toBe(true);
   });
 
   // #4343 — what `objectstack build` produces. The CLI lowers every inline
@@ -82,10 +102,48 @@ describe('FlowFunctionEntrySchema', () => {
     expect(FlowFunctionEntrySchema.safeParse('').success).toBe(false);
   });
 
-  it('drops a lowered ref when normalizing — it names a function without carrying one', () => {
+  // #4976 — the other half of what `objectstack build` emits. #4396 taught
+  // `lowerCallables` to keep a declared entry's declaration beside its lowered
+  // ref; this union was not extended in the same change, so the artifact
+  // `{ syncBilling: { handler: 'syncBilling', effect: 'writes' } }` failed the
+  // build with `invalid_union: Invalid input` — no path past `functions`, no
+  // key named. An author who cannot read that error deletes the declaration and
+  // ships an undeclared writer, which is the exact state `effect` exists to
+  // prevent (#4354).
+  it('accepts a lowered DECLARATION, the other form a built artifact carries', () => {
+    expect(FlowFunctionEntrySchema.safeParse({ handler: 'syncBilling', effect: 'writes' }).success).toBe(true);
+    expect(FlowFunctionEntrySchema.safeParse({ handler: 'syncBilling', effect: 'pure' }).success).toBe(true);
+  });
+
+  it('applies the pure default to a lowered declaration that states no effect', () => {
+    // `defineStack`'s parse normally materialises `effect` before the lowering
+    // ever runs, but `{ strict: false }` skips that parse — so the member must
+    // accept the shape without it, or that path keeps the failure this fixes.
+    const parsed = FlowFunctionEntrySchema.parse({ handler: 'syncBilling' });
+    expect(parsed).toEqual({ handler: 'syncBilling', effect: 'pure' });
+  });
+
+  it('keeps the declaration strict once lowered — a typo in a built artifact still names itself', () => {
+    // Derived from `FlowFunctionDeclarationSchema` rather than re-typed, so the
+    // surface name, the alias table and the prescription travel with it.
+    const result = FlowFunctionEntrySchema.safeParse({ handler: 'syncBilling', efect: 'writes' });
+    expect(result.success).toBe(false);
+    const messages = JSON.stringify(result.error!.issues);
+    expect(messages).toContain('`functions` entry');
+    expect(messages).toContain('`efect` → `effect`');
+    // And a value the runtime has no meaning for is still refused.
+    expect(FlowFunctionEntrySchema.safeParse({ handler: 'syncBilling', effect: 'write' }).success).toBe(false);
+  });
+
+  it('drops BOTH lowered shapes when normalizing — each names a function without carrying one', () => {
     // The callable for that name comes from the sidecar ESM module the build
-    // emits; binding the string would register a name pointing at nothing.
+    // emits; binding the ref would register a name pointing at nothing. This is
+    // not where `effect` is lost on the built path — `mergeRuntimeModule` has
+    // already re-attached the callable to the declaration by the time a boot
+    // normalizes anything (pinned in `packages/runtime`'s
+    // `artifact-function-declarations.test.ts`).
     expect(normalizeFlowFunctionEntry('scoreLead')).toBeUndefined();
+    expect(normalizeFlowFunctionEntry({ handler: 'syncBilling', effect: 'writes' })).toBeUndefined();
   });
 });
 

--- a/packages/spec/src/automation/flow-function.zod.ts
+++ b/packages/spec/src/automation/flow-function.zod.ts
@@ -165,25 +165,62 @@ export type FlowFunctionDeclarationParsed = z.infer<typeof FlowFunctionDeclarati
 export type FlowFunctionDeclarationInput = z.input<typeof FlowFunctionDeclarationSchema>;
 
 /**
- * One entry of the `functions` map: the handler alone (pure), a
- * {@link FlowFunctionDeclarationSchema} that states its effect, or the
- * **lowered handler ref** a built artifact carries.
+ * The **lowered** form of {@link FlowFunctionDeclarationSchema}: the same
+ * declaration, with its callable replaced by the string ref `objectstack build`
+ * emits (`{ handler: 'syncBilling', effect: 'writes' }`).
  *
- * The first two are what an author writes. The third is what `objectstack
- * build` produces and was, until #4343, the reason `defineStack({ functions })`
- * could not survive a build at all: the CLI lowers every inline callable to a
- * serialisable string ref BEFORE the stack is parsed (it must — `z.function()`
- * wraps callables and would break the ref mapping), so the manifest reaching
- * this schema holds `{ myFn: 'myFn' }`, which neither of the other two members
- * accepts. The build failed on a mechanism its own docs call first-class.
+ * Derived from the authored declaration rather than re-typed beside it, which
+ * is the whole point: the two shapes differ in exactly one field, so a key
+ * added to the declaration is carried by the artifact form automatically, and
+ * the strictness travels with it — a misspelled `effect` in a hand-edited
+ * `objectstack.json` still gets the same named surface, the same alias table
+ * and the same `` `efect` → `effect` `` prescription the authoring door gives.
  *
- * A string entry carries no callable, and that is correct rather than lossy:
- * the real functions ride in the sibling ESM module esbuild emits, and
- * {@link collectBundleFunctionEntries} merges both sources by name. The string
- * is the artifact's record that the NAME exists — which is why
- * {@link normalizeFlowFunctionEntry} deliberately drops it (see there).
+ * `effect` stays optional-with-a-default here for the same reason it is
+ * optional on the authored form. It is normally already present — the callable
+ * that gets lowered has been through `defineStack`'s parse, which materialises
+ * the `'pure'` default — but `defineStack({…}, { strict: false })` skips that
+ * parse, and requiring `effect` would hand that path the identical
+ * `invalid_union` this member exists to end.
+ */
+const FlowFunctionLoweredDeclarationSchema = lazySchema(() => FlowFunctionDeclarationSchema.extend({
+  handler: z.string().min(1)
+    .describe('The lowered handler ref (built artifacts) — the callable rides in the sibling ESM module'),
+}).describe('A lowered `functions` declaration: what the function declared about itself, with its callable replaced by a handler ref (#4976)'));
+
+/**
+ * One entry of the `functions` map, in the four shapes it legitimately takes:
+ * the handler alone (pure), a {@link FlowFunctionDeclarationSchema} that states
+ * its effect, and each of those two **lowered** — a bare handler ref, or a
+ * declaration whose handler is a ref.
  *
- * Authoring a string by hand therefore registers nothing. It fails loudly, not
+ * The first two are what an author writes; the last two are what `objectstack
+ * build` produces. The CLI lowers every inline callable to a serialisable
+ * string ref BEFORE the stack is parsed (it must — `z.function()` wraps
+ * callables and would break the ref mapping), so the manifest reaching this
+ * schema holds `{ myFn: 'myFn' }` for a bare entry and
+ * `{ myFn: { handler: 'myFn', effect: 'writes' } }` for a declared one.
+ *
+ * Both lowered shapes have been the reason `defineStack({ functions })` could
+ * not survive a build, one after the other, and for the same reason each time —
+ * a lowering step taught a new shape while this union was not. #4343 added the
+ * bare ref. #4396 taught `lowerCallables` to keep what a declared entry
+ * declared, and the artifact it started emitting was rejected here until #4976:
+ * `invalid_union: Invalid input`, no path past `functions`, on the honest
+ * spelling of a writer. The practical outcome of that error was worse than a
+ * failed build — an author who cannot see which key is wrong deletes the
+ * declaration and ships an UNDECLARED writer, which is precisely the state
+ * `effect` exists to prevent (#4354).
+ *
+ * A lowered entry carries no callable in either shape, and that is correct
+ * rather than lossy: the real functions ride in the sibling ESM module esbuild
+ * emits, `mergeRuntimeModule` re-attaches each one to the declaration the JSON
+ * carried, and {@link collectBundleFunctionEntries} reads the result. The
+ * lowered entry is the artifact's record of what the function is NAMED and what
+ * it DECLARED — which is why {@link normalizeFlowFunctionEntry} deliberately
+ * drops both lowered shapes (see there).
+ *
+ * Authoring either by hand therefore registers nothing. It fails loudly, not
  * silently: a `script` node naming it refuses at execute with "no function
  * named '…' is registered" (#1870).
  */
@@ -191,7 +228,8 @@ export const FlowFunctionEntrySchema = lazySchema(() => z.union([
   z.function(),
   FlowFunctionDeclarationSchema,
   z.string().min(1).describe('A lowered handler ref (built artifacts) — the callable rides in the sibling ESM module'),
-]).describe('A named handler function, a declaration record stating its effect, or a lowered handler ref'));
+  FlowFunctionLoweredDeclarationSchema,
+]).describe('A named handler function or a declaration record stating its effect — either as authored, or lowered to a handler ref by `objectstack build`'));
 
 export type FlowFunctionEntry = z.infer<typeof FlowFunctionEntrySchema>;
 /** Post-parse shape of {@link FlowFunctionEntry} — defaults applied, transforms run (ADR-0122). */
@@ -229,11 +267,19 @@ export function isFlowFunctionEffect(value: unknown): value is FlowFunctionEffec
  * the entry holds a live function, and the collectors that call this run on the
  * boot path where re-parsing every handler buys nothing.
  *
- * A lowered string ref (the third member of that schema) returns `undefined`
- * here BY DESIGN — it names a function without carrying one. The callable for
- * that name comes from the built sidecar module, which the same collector
- * merges in; treating the string as an entry would register a name bound to
- * nothing.
+ * BOTH lowered shapes return `undefined` here BY DESIGN — the bare ref
+ * (`'syncBilling'`) and the lowered declaration
+ * (`{ handler: 'syncBilling', effect: 'writes' }`) alike. Each names a function
+ * without carrying one, and registering a name bound to nothing is worse than
+ * registering nothing.
+ *
+ * That is not where `effect` goes to die on the built path, and the ordering is
+ * what makes it safe: `mergeRuntimeModule` runs FIRST and rebuilds the entry as
+ * `{ ...declared, handler: <the module's callable> }`, so by the time
+ * {@link collectBundleFunctionEntries} reaches this function the handler is a
+ * real callable and the declaration is intact — the string form is simply never
+ * the value a boot normalizes. `packages/runtime`'s
+ * `artifact-function-declarations.test.ts` pins that seam from the other side.
  */
 export function normalizeFlowFunctionEntry(entry: unknown): NormalizedFlowFunction | undefined {
   if (typeof entry === 'function') {


### PR DESCRIPTION
Fixes #4976

## 前提复核(先证伪,再动手)

在 `origin/main` @ 773f80aab 上直接跑真实流水线,前提成立:

```
map bare lowered        -> OK
map declared lowered    -> FAIL invalid_union@functions   ← 本 issue
array bare lowered      -> FAIL invalid_union@functions   ← 另立 #6238
array declared lowered  -> FAIL invalid_union@functions   ← 另立 #6238
```

`normalizeFlowFunctionEntry({ handler: 'syncBilling', effect: 'writes' })` 返回 `undefined`,与正文所述一致。

## 改了什么

`FlowFunctionEntrySchema` 补第四个 union 成员 —— **lowered declaration**,即 `handler` 已被降级成字符串 ref 的声明形:

```
functions: {
  sweepProjectHealth: { handler: 'sweepProjectHealth', effect: 'writes' },
}
```

作者写法一字未变。这个形状由 CLI 产出、不由人手敲:`lowerCallables` 在 parse 之前把每个内联可调用体换成可序列化 ref(必须如此 —— `z.function()` 会包裹 callable,直接毁掉 ref 映射),而自 #4396 起它会**保留声明**、只替换 handler。当时 union 没有同步扩,于是 CLI 亲手产出的产物被它自己必须通过的 schema 拒收。

**成员是派生的,不是重抄的。** `FlowFunctionDeclarationSchema.extend({ handler })` —— 两者只差一个字段,所以严格性、surface 名、别名表与处方原样随行:`{ handler: 'fn', efect: 'writes' }` 依然报 ``Unrecognized key(s) on this `functions` entry`` 并给出 `` `efect` → `effect` ``;未知 `effect` 值依然拒收;空 ref 依然不是名字。声明形将来加键也自动带过去,不会再漂移一次。**别名区未触碰** —— 用 `.extend()` 而非新开一次 `strictObject`,不向 `strictObjectDeclarations()` 注册第二条记录,与在飞的 #6083 无语义冲突。

**`effect` 保持 optional + 默认值。** 走 `defineStack` 的路径会先把 `'pure'` 默认值落实(实测:`{ handler: fn }` 出来是 `{ handler, effect: 'pure' }`),但 `defineStack(…, { strict: false })` 会跳过那次 parse;要求必填就等于把同一个 `invalid_union` 原样还给那条路径。

## runtime 半边:核对结论是「本就正确,一行未改」

issue 正文说「预计无需改动,但值得确认」。确认结果:

- `normalizeFlowFunctionEntry` 对**两种** lowered 形状都返回 `undefined` —— 裸 ref 和 lowered declaration 都不携带可调用体,注册一个指向空的名字比不注册更糟。
- `effect` 并非在此丢失:`mergeRuntimeModule` 在任何 collector 之前就把 sidecar 模块的函数重新挂回 JSON 携带的声明上(`{ ...declared, handler: fn }`),所以 boot 时 normalizer 看到的 handler 已经是真 callable,声明完好。`packages/runtime/src/artifact-function-declarations.test.ts` 从另一侧钉住这条缝,本 PR 未改动它,全绿。

顺序才是这件事安全的原因,已写进 `normalizeFlowFunctionEntry` 的 docblock。

## 跨界 pin(issue 点名要的那条)

`packages/cli/src/utils/lower-callables.test.ts` 新增 round-trip:走**真实流水线**(`defineStack` → `normalizeStackInput` → `lowerCallables` → parse),而不是手写一份「以为 lowering 会产出什么」的样例 —— 手写样例是真相的第三份拷贝,会以两半已经漂移过的同样方式再漂移一次。

5 组用例 × 2(逐条目 parse + 整栈 `ObjectStackDefinitionSchema.parse`),外加一条「声明必须进产物、不只是过 parse」—— 过了 parse 却把 `effect` 丢在路上,等于用一个绿色的 build 重演 #4396 的静默去声明。

**范围**:map 形。数组形 `functions: [{ name, handler }]` 同样无法往返(裸形与声明形皆然,#4343 / #4976 都只碰过 map),其成员在 `stack.zod.ts` 而非 `FlowFunctionEntrySchema`,已另立 **#6238**,并在测试注释里写明这条边界是刻意的、不是遗漏。

## 反向验证(方向事先声明)

**事先声明的预期方向:摘掉第四成员 → round-trip pin 应转红(常规方向)。**

实测与预期一致,且红得精确:

```
× parses every entry it emits for a declared writer
× parses the whole lowered stack for a declared writer
× parses every entry it emits for a declaration that states the pure default
× parses the whole lowered stack for a declaration that states the pure default
× parses every entry it emits for a declaration that states nothing
× parses the whole lowered stack for a declaration that states nothing
× parses every entry it emits for both spellings side by side
× parses the whole lowered stack for both spellings side by side
× carries the declaration into the artifact, not just past the parse
Tests  9 failed | 9 passed (18)
```

失败的**只有**声明形用例;裸 handler 用例保持绿色 —— 第三个成员本就覆盖它们。报错正是 issue 里那条 `invalid_union` @ `functions`。spec 侧同步 3 红。恢复后全绿。

## 一处行为倒转,明说而非藏着

手写 `{ handler: 'someName' }` 由**拒收**变为**接受**,原断言 `rejects a declaration whose handler is not callable` 因此被就地重判。

这不是让步。裸字符串条目(`functions: { foo: 'foo' }`)自 #4343 起就被接受,并在 docblock 里附带「注册不到任何东西」的说明;只拒 record 拼法而放行 string 拼法,是同一个契约的两种方言。两者失败方式完全一致且响亮 —— execute 时 `no function named '…' is registered`(#1870)。存活下来的是真正的判决:handler **既不是** callable **也不是**名字(`42` / 空串 / 缺失)依然拒收。

按 fixture 三分法,这条属于「逐条重判」而非「批量改写」:旧断言钉的正是本 PR 要接纳的形状,留着它只会在合入后转红。

## showcase:issue 自己的复现点,同 PR 关闭

`examples/app-showcase` 里的注释写着 "switch back once it lands" 和 "Delete this guard — don't work around it — when #4976 lands",照办:

- `objectstack.config.ts` 换回诚实拼法 `{ handler: sweepProjectHealth, effect: 'writes' }`;
- `test/inert-wirings.test.ts` 的「钉死裸形」守卫**倒转**为「唯一真正写数据的条目必须声明」—— 值得守的从来不是「裸」,而是那个夜间 sweep 说出了自己在写。直接删掉会白丢覆盖。

端到端实证(即 issue 的复现命令):

```
✓ Build complete (1445ms)
  Artifact: dist/objectstack.json (677.2 KB)
  Runtime: dist/objectstack-runtime.f266f59d0eb58097.mjs (1325.1 KB, 2 handlers)
```

产物内容:

```json
{
  "summarizeCompletedTask": "summarizeCompletedTask",
  "sweepProjectHealth": { "handler": "sweepProjectHealth", "effect": "writes" }
}
```

## 验证

| 项 | 结果 |
|:---|:---|
| `check:generated` 十门 | ✓ 全部 up to date,**无需重生成**(union 成员不改可授权键面,新 schema 未导出) |
| 「不代跑」6 源审计整组 | ✓ `check:liveness` / `check:empty-state` / `check:skill-examples` / `check:variant-docs` / `check:exported-any` / `check:dual-source-exports` 全 PASS |
| `pnpm lint` | ✓ 干净 |
| ESLint job 家族门(20 项) | ✓ 全 PASS,含 `check:spec-parsed-alias`、`check:engine-double-contract`、`check:shard-attestation`、`check:empty-changeset` |
| `pnpm test` spec | 8383 passed / 47 skipped;2 个文件红,原因是**容器 git 签名器**(`gpg.ssh.program=/tmp/code-sign` 的 MCP 调用超时)使临时仓 `git commit` 失败,与本 diff 无关 —— 关掉签名后同两文件 **70 passed** |
| `pnpm test` cli | ✓ 89 files / **913 passed** |
| `pnpm test` runtime | ✓ 105 files / **1506 passed** |
| `pnpm test` showcase | ✓ 13 files / **146 passed** |
| `pnpm typecheck` ×4 | ✓ spec / cli / runtime / showcase 全绿;spec 的 `check:test-typecheck` 债务台账未增(79 files / 691 errors 不变) |
| `check:nul-bytes` + 控制字节自扫 | ✓ 5930 个文件 OK;改动文件自扫无命中 |

## changeset 定级论证

`@objectstack/spec: minor`。union 接受的输入集合**严格变大**,没有任何原本能 parse 的输入变得不能 parse(唯一变化是 `{ handler: 'name' }` 由拒转收,属加宽而非破坏),故为加性 → minor 而非 patch;也不是 major,因为无任何 FROM → TO 迁移要求作者做。

## 与在飞 issue 的相交(实测,非推断)

| Issue | 分支 | 与本 PR 文件相交 |
|:---|:---|:---|
| **#6083** | `claude/issue-6083-adr0122-phase2-bare-name-flip` | **有** —— 同改 `flow-function.zod.ts`。**纯文本冲突,无语义冲突**:#6083 只翻三条类型别名 `z.infer` → `z.input` 并删 `FlowFunctionDeclarationInput`,这些行我一行未碰;冲突落在它 hunk 的**上下文行**(union 体 + 其 `.describe()`、以及我重写的 `FlowFunctionEntrySchema` docblock),两处均为机械解冲突。语义上还相互补足:`z.input` 作用于新成员后,lowered 形的 `effect` 也正确地成为可选输入 |
| #5051 | 已并入 main(#6240) | 无 —— 它只动 `stack.zod.ts` 的 `composeStacks` 段,我完全未动该文件 |
| #5016 | `claude/issue-5016-action-param-options-vocab` | 无 |
| #5599 | `claude/issue-5599-view-union-identity-precondition` | 无 |
| #5775 | `claude/issue-5775-sdui-props-enforce-or-remove` | 无 |
| #5945 | `claude/issue-5945-hook-context-api-typed` | 无 |
| #5948 | `claude/issue-5948-getuiview-slim-body` | 无 |
| #5055 | 本容器内无本地/远端分支 | 无(按现存分支实测) |

与 PM 预期一致:除 #6083 外全部零相交。

## 范围外发现

- **#6238** —— 数组形 `functions: [{ name, handler }]` 同样无法往返 `objectstack build`,且裸形/声明形皆然(#4343 与 #4976 都只碰过 map 形)。已按 Prime Directive #10 未认领立单,附实测四行对照与「修 or 退役」的取舍(该形状无任何 example / doc / skill 消费者)。


---
_Generated by [Claude Code](https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY)_