### PR TITLE
fix(scripts): check-single-authz-resolver 的 walk 收 .mts/.cts,排除项同族扩展 (#6070)

### DIFF
--- a/scripts/check-single-authz-resolver.mjs
+++ b/scripts/check-single-authz-resolver.mjs
@@ -20,7 +20,7 @@
 // ## Dead scan roots are a hard error (#4930)
 //
 // Check (1) is a *scan*: it concludes "no duplicate resolver exists" from having
-// read every `.ts` under SCAN_ROOTS. `walk()` used to open with
+// read every TypeScript source under SCAN_ROOTS. `walk()` used to open with
 // `try { entries = readdirSync(dir); } catch { return out; }`, so a root that was
 // renamed, moved or made unreadable produced zero files — and zero files produce
 // zero errors, which is character-for-character the same verdict as a clean
@@ -65,6 +65,28 @@
 // The floor is per-root and never a total: with more than one root, a single
 // populated one would otherwise cover for every evaporated sibling — which is the
 // silent narrowing this assertion exists to stop.
+//
+// ## The extension filter is a family, not a suffix string (#6070)
+//
+// The failure above names its own successor — "sources renamed to an extension `walk`
+// does not collect" — and that case was already live on the day #5916 landed. The
+// collector tested `e.endsWith('.ts')`, and `'x.mts'.endsWith('.ts')` is **false** (the
+// character before `ts` is `m`, not `.`), so every `.mts` / `.cts` source under
+// `packages/` — twelve of them, all build/liveness scripts under `packages/spec/scripts/` —
+// stayed out of the corpus, and check (1)'s "no duplicate resolver exists" was concluded
+// from a set that structurally excluded them.
+//
+// Neither corpus assertion above can see this, by construction. `packages/` resolves,
+// and it yields well over a thousand `.ts` files — far above a per-root floor of one —
+// while every `.mts` under it is invisible. A floor answers "did this root produce
+// anything"; it can never answer "did it produce everything the root declares".
+//
+// So the filter is an extension FAMILY (`SCANNED_EXT` / `EXCLUDED_EXT`), not a suffix
+// string, and the exclusions move with it in the same step — widening only the collector
+// would re-plant the same bug one level down, with `x.test.mts` scannable while
+// `x.test.ts` is not. None of the twelve files trips check (1)'s heuristic, so the wider
+// corpus changes no verdict today; what changes is that the verdict is now drawn from
+// what the gate says it reads.
 
 import {
   mkdirSync, mkdtempSync, readFileSync, readdirSync, renameSync, rmSync, statSync, symlinkSync, writeFileSync,
@@ -92,6 +114,19 @@ const DELEGATORS = [
 const SCAN_ROOTS = ['packages'];
 
 const SKIP_DIRS = new Set(['node_modules', 'dist', '__tests__']);
+
+/**
+ * The extension family check (1) reads, and the two shapes excluded from it.
+ *
+ * Two regexes, deliberately paired and deliberately parallel. `SCANNED_EXT` replaces an
+ * `e.endsWith('.ts')` that silently skipped `.mts` / `.cts` (see the header, #6070);
+ * `EXCLUDED_EXT` carries the SAME family through the test/declaration exclusions, so the
+ * widening cannot leave them one extension behind. The repo has no `.test.mts` or `.d.cts`
+ * today — the shapes are excluded anyway, because the exclusion states what a test or
+ * declaration file IS, not an inventory of the ones that happen to exist.
+ */
+const SCANNED_EXT = /\.[mc]?ts$/;
+const EXCLUDED_EXT = /\.(?:test|d)\.[mc]?ts$/;
 
 /** A declared scan root that could not be resolved to a directory. Carries the names. */
 class DeadRootError extends Error {
@@ -129,7 +164,8 @@ function assertRootsResolvable(root = ROOT, roots = SCAN_ROOTS) {
 }
 
 /**
- * Every non-test `.ts` file under `dir`, recursively.
+ * Every non-test TypeScript source under `dir`, recursively — `.ts`, `.mts` and `.cts`
+ * alike (`SCANNED_EXT`), minus the test and declaration shapes of each (`EXCLUDED_EXT`).
  *
  * Nothing here is wrapped in a catch: an unresolvable root fails loudly above, and
  * an error *inside* the walk (a vanished file, a permission fault) means the corpus
@@ -141,7 +177,7 @@ function walk(dir, out = []) {
     const p = join(dir, e);
     const st = statSync(p);
     if (st.isDirectory()) walk(p, out);
-    else if (e.endsWith('.ts') && !e.endsWith('.test.ts') && !e.endsWith('.d.ts')) out.push(p);
+    else if (SCANNED_EXT.test(e) && !EXCLUDED_EXT.test(e)) out.push(p);
   }
   return out;
 }
@@ -152,7 +188,7 @@ function walk(dir, out = []) {
  */
 class EmptyRootError extends Error {
   constructor(empty, total) {
-    super(`scan root(s) contributed no scannable .ts file: ${empty.join(', ')} (total scanned: ${total})`);
+    super(`scan root(s) contributed no scannable TypeScript file: ${empty.join(', ')} (total scanned: ${total})`);
     this.name = 'EmptyRootError';
     /** @type {string[]} the roots that yielded nothing. */
     this.roots = empty;
@@ -245,7 +281,7 @@ function reportEmptyRoots(err) {
   console.error(
     `\n${err.total} file(s) were found in total across all of SCAN_ROOTS.` +
     `\n\nEvery entry in SCAN_ROOTS (scripts/check-single-authz-resolver.mjs) must yield at least one` +
-    `\nscannable .ts file. The root still being a directory is not enough — that is all #4930's` +
+    `\nscannable .ts/.mts/.cts file. The root still being a directory is not enough — that is all #4930's` +
     `\ncheck can see. If the sources moved to a new directory, point SCAN_ROOTS at it; if the walk` +
     `\nfilter no longer matches them (a new extension, a widened SKIP_DIRS), fix the filter. Do NOT` +
     `\nlower this to a total count: one populated root would then cover for every evaporated one,` +
@@ -293,8 +329,43 @@ function selfTest() {
     // (1) — the walker must not report test/type files or skipped directories.
     write('packages/rest/src/__tests__/fake.ts', "sys_user_role sys_user_permission_set\n");
     write('packages/rest/src/x.test.ts', "sys_user_role sys_user_permission_set\n");
+    // `.d.ts` was named in this assertion's label from the start but never written, so
+    // the exclusion it claims to cover was never exercised. Added with the .mts/.cts
+    // pass below, which extends that same exclusion to the rest of the family (#6070).
+    write('packages/rest/src/x.d.ts', "sys_user_role sys_user_permission_set\n");
     write('packages/rest/dist/x.ts', "sys_user_role sys_user_permission_set\n");
     expect('tests, .d.ts and dist/ are out of scope', audit(dir).length, 0);
+
+    // (1) — `.mts` / `.cts` are the same corpus (#6070). `'x.mts'.endsWith('.ts')` is
+    // false, so the suffix-string collector walked past every module-extension source
+    // under a root it claims to read in full. Pinned in BOTH directions, because either
+    // one alone is satisfiable by a filter that collects nothing:
+    //   * the corpus must GROW by exactly the collectable fixtures — a count a
+    //     regressed filter cannot reach;
+    //   * and the duplicates written in them must be CAUGHT AND NAMED — a verdict an
+    //     empty corpus produces zero of, which is what made the original miss silent.
+    const beforeExt = collectScanFiles(dir).length;
+    write('packages/rest/src/esm-resolver.mts', "sys_user_role sys_user_permission_set\n");
+    write('packages/rest/src/cjs-resolver.cts', "sys_user_role sys_user_permission_set\n");
+    // The exclusions carry the same family: changing a test's or a declaration's
+    // extension must not make it scannable. The repo has none of these four shapes
+    // today — that is exactly why they are asserted here rather than trusted.
+    for (const excluded of ['x.test.mts', 'x.test.cts', 'x.d.mts', 'x.d.cts']) {
+      write(`packages/rest/src/${excluded}`, "sys_user_role sys_user_permission_set\n");
+    }
+    expect('.mts/.cts join the corpus and their test/declaration shapes stay out',
+      collectScanFiles(dir).length, beforeExt + 2);
+    const extErrors = audit(dir);
+    expect('a duplicate resolver in .mts and one in .cts are both flagged', extErrors.length, 2);
+    expect('the .mts duplicate is named', extErrors.some((e) =>
+      e.startsWith('Possible duplicate authorization resolver: packages/rest/src/esm-resolver.mts')), true);
+    expect('the .cts duplicate is named', extErrors.some((e) =>
+      e.startsWith('Possible duplicate authorization resolver: packages/rest/src/cjs-resolver.cts')), true);
+    for (const f of ['esm-resolver.mts', 'cjs-resolver.cts', 'x.test.mts', 'x.test.cts', 'x.d.mts', 'x.d.cts']) {
+      rmSync(join(dir, 'packages/rest/src', f));
+    }
+    expect('removing the module-extension fixtures restores the green', audit(dir).length, 0);
+    expect('...and restores the corpus to its previous size', collectScanFiles(dir).length, beforeExt);
 
     // (2) — an entry point that stops delegating.
     write(DELEGATORS[0], '// re-inlined the session/role reads here\n');
@@ -406,10 +477,11 @@ function selfTest() {
     process.exit(1);
   }
   console.log(
-    '✓ check-single-authz-resolver self-test: duplicate detection, delegation, the dead-root ' +
-    'hard error (red when the scan root is renamed, green when restored) and the empty-scan ' +
-    'hard error (red when one declared root yields nothing and when the whole scan does, green ' +
-    'when restored) all hold.',
+    '✓ check-single-authz-resolver self-test: duplicate detection, delegation, the extension ' +
+    'family (.mts/.cts enter the corpus and their duplicates are named; .test./.d. shapes of ' +
+    'every extension stay out), the dead-root hard error (red when the scan root is renamed, ' +
+    'green when restored) and the empty-scan hard error (red when one declared root yields ' +
+    'nothing and when the whole scan does, green when restored) all hold.',
   );
 }
 


### PR DESCRIPTION
Fixes #6070

`'x.mts'.endsWith('.ts')` 为 **false**(`ts` 前一个字符是 `m` 而非 `.`),所以 `walk()` 从来没收过声明的扫描根 `packages/` 下的任何 `.mts` / `.cts`。检查 (1)「不存在重复的请求上下文解析器」这个结论,是在一个**结构性排除了 12 个文件**的语料上得出的。

按 issue 方向 1(声明即执行)修:门禁声称读遍 `packages/`,那就该真的读遍。

## 过滤器 before / after

单文件改动 `scripts/check-single-authz-resolver.mjs`,`walk()` 的收集条件:

```js
// before —— 后缀字符串,漏掉整个模块扩展名家族
else if (e.endsWith('.ts') && !e.endsWith('.test.ts') && !e.endsWith('.d.ts')) out.push(p);

// after —— 扩展名"家族",两条正则成对声明在模块顶部
const SCANNED_EXT  = /\.[mc]?ts$/;
const EXCLUDED_EXT = /\.(?:test|d)\.[mc]?ts$/;
else if (SCANNED_EXT.test(e) && !EXCLUDED_EXT.test(e)) out.push(p);
```

**排除项与收集项同一步放宽**,这是刻意的:只放宽收集器会把同一个 bug 原样种到下一层 —— `x.test.mts` 变成可扫描,而 `x.test.ts` 不是。仓内今天**没有**这四种形状(`.test.mts` / `.test.cts` / `.d.mts` / `.d.cts` 实测各 0 个),仍然照排 —— 排除项陈述的是"一个测试/声明文件**是什么**",不是"现存哪些文件"的清单。

## 语料 delta:1475 → 1487(+12)

用脚本自己的 `collectScanFiles` 实测(把 `main();` 换成一行计数打印,分别跑改前/改后两版):

```
BEFORE (origin/main filter): corpus: 1475
AFTER  (widened filter):     corpus: 1487
```

新增的正是那 12 个文件,全部在 `packages/spec/scripts/` 下(`check-strictness-ledger.mts`、`liveness/*.mts` 等)。

⚠️ **与 issue / 分诊正文里的 3053 → 3065 不是同一个量,这里如实记下**:3053 是 `packages/` 下 `.ts` 文件的**原始个数**(本 PR 基点 `f6609e6` 实测:全量 3113、去掉 `dist/` `__tests__/` 后 3029),而 **1475 是门禁真正推理的语料**(再去掉 `.test.ts` / `.d.ts`)。两个数都对,量的是不同集合;**+12 这个差值两种口径一致**,也是本单唯一实际变化的量。

## 现状仍绿(复测,非沿用分诊结论)

12 个新入语料的文件对启发式(`sys_user_role` 且 `sys_user_permission_set`)的命中数逐个复测 = **0/0**,放宽后真实运行仍绿:

```
$ node scripts/check-single-authz-resolver.mjs --self-test
✓ check-single-authz-resolver self-test: duplicate detection, delegation, the extension
  family (.mts/.cts enter the corpus and their duplicates are named; .test./.d. shapes of
  every extension stay out), the dead-root hard error ... and the empty-scan hard error ...
  all hold.

$ node scripts/check-single-authz-resolver.mjs
✓ check:authz-resolver: single shared authorization resolver intact; both entry points delegate.
```

语料变大**不改变任何裁决**;改变的是这个裁决从此出自门禁声称读的那个集合。

## self-test delta:双向都钉,单向都不够

新增块(沿用 #6056 的 fixture idiom,真实临时目录 + 真实 walker):

- **正向**:`.mts` 与 `.cts` 各写一个重复解析器形状 ⇒ 必须被抓出且**按名报出**(2 条,逐条断言文件名);
- **反向(排除名单)**:`x.test.mts` / `x.test.cts` / `x.d.mts` / `x.d.cts` 四个形状 ⇒ **不得进语料**;
- **语料计数**:`collectScanFiles` 必须恰好 `beforeExt + 2`,清理后必须回到 `beforeExt`。

第三条不是冗余:只断言"被抓出"的话,一个**收不到任何文件**的过滤器同样产生 0 条错误 —— 那正是原始漏判之所以静默的原因;只断言计数的话,又证不出抓出来的错误指向正确的文件。**两条都要,才封得住。**

顺带补齐一处既有断言的空头支票:`'tests, .d.ts and dist/ are out of scope'` 这个 label 从写下起就宣称覆盖 `.d.ts`,但从来没写过 `.d.ts` fixture —— 本 PR 把它补上(与本次扩到同族排除是同一件事)。

## 反向验证(方向**先声明后运行**)

**声明的预期方向 = 常规 red**:把 `walk()` 的过滤器还原成 `.ts`-only、**保留全部新断言**,则 4 条新断言必须转红,且红必须**指名漏掉了什么**;既有断言(含新补的 `.d.ts`)不受影响。

实跑(在 scratchpad 的脚本副本上,不污染工作树):

```
✗ check-single-authz-resolver self-test failed:
  ✗ .mts/.cts join the corpus and their test/declaration shapes stay out: expected 7, got 5
  ✗ a duplicate resolver in .mts and one in .cts are both flagged: expected 2, got 0
  ✗ the .mts duplicate is named: expected true, got false
  ✗ the .cts duplicate is named: expected true, got false
exit=1
```

与声明**逐条相符**:语料 7 → 5(两个模块扩展名文件根本没被收),诊断数 2 → 0。恢复过滤器 ⇒ self-test 与真实运行双绿(上一节输出)。红只出在 4 条新断言上,说明红确由过滤器本身引起,而非别的改动。

## 范围

严格按分诊钉死的范围:**只改扩展名过滤 + 回归断言**。未动 `SCAN_ROOTS`、未重写 #5916 的下限断言逻辑、未搭高水位棘轮(维护者在 #5916 已明确否掉)。#5475(那 12 个文件不在任何 tsconfig 的 include 内)是**类型检查覆盖**的另一套机制,仅交叉链接,不并单。

改动仅 `scripts/` 单文件,不发布任何东西 ⇒ 无 changeset,带 `skip-changeset`。门禁 `pnpm check:authz-resolver` 在 CI 的 **ESLint** job(`lint.yml` 的 "Single authz resolver guard" 步)内跑。

相关:#5916 / PR #6056(按根下限)、#4930 / #4916(死根按名报错)、#4932(同族先例)、#4690(「提取失败必须红」出处)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_