### PR TITLE
fix(scripts): digest 的破坏性判据扩到「声明 major 或作者正文标注」(#6099)

### DIFF
--- a/scripts/objectui-changeset-digest.mjs
+++ b/scripts/objectui-changeset-digest.mjs
@@ -43,6 +43,32 @@
 // added over the range: package names say whether it releases, and the declared
 // level (major/minor/patch) IS the bump — nothing is inferred from a subject
 // line any more. Declaration over inference, per AGENTS.md Prime Directive #12.
+//
+// WHY "BREAKING" IS BROADER THAN THE DECLARED LEVEL (#6099)
+// --------------------------------------------------------
+// #4731 got breaking changes back INTO the list. #6099 is the other half: they
+// get in, but they could not be RECOGNISED. The criterion used to be `level ===
+// 'major'`, and objectui never declares `major` inside a launch window — the
+// same convention this repo's `check-changeset-no-major.mjs` enforces ships a
+// breaking change as `minor` plus a prose annotation the author writes. Measured
+// on the range `f5bc4c78be76..f995a452d2ca`: 64 releasing changesets, 14 `minor`
+// / 50 `patch` / **0 `major`**. So the count was structurally pinned at 0 and the
+// `⚠️` hint could never fire, while unmarked breaking migrations flowed into
+// `@objectstack/console`'s CHANGELOG input layer.
+//
+// The criterion is therefore "declared level `major` OR the AUTHOR annotated the
+// change as breaking in the changeset body" — see `hasBreakingAnnotation`. Note
+// what it still refuses to read: the commit SUBJECT. A conventional-commit `!`
+// is the tool's classification of a commit, not the author's statement about the
+// release, and re-admitting subject parsing is precisely the inference #4731
+// removed. Reading the body keeps this inside "declaration": it is the author's
+// own prose, in the same file that already declares the level. It also measures
+// strictly better than `!` would — over that same range `!` marks 2 commits,
+// while the authors' own annotations mark 4, including `app.homePageId` being
+// retired (a `feat(deps):` subject with no `!`).
+//
+// This criterion changes the ANNOTATION and the COUNT only. The collected set is
+// untouched: nothing is admitted or dropped because of it.
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
@@ -67,15 +93,20 @@ function git(cwd, args) {
 }
 
 /**
- * Parse a changeset file: the frontmatter package→level map plus the first
- * paragraph of the summary.
+ * Parse a changeset file: the frontmatter package→level map, the first
+ * paragraph of the summary, and the FULL body after the frontmatter.
  *
  * An EMPTY frontmatter block (`---\n---`) is changesets' own "release-nothing"
  * marker — the file exists so the repo's own gate is satisfied, but it releases
  * no package. That is precisely the signal the old type filter could not see.
  *
+ * `summary` stays the first paragraph — that is what an entry line renders. But
+ * a breaking annotation is not reliably in the first paragraph (#6099: one of
+ * the two live specimens puts it in the last), so `body` carries the whole text
+ * for `hasBreakingAnnotation` to scan.
+ *
  * @param {string} text
- * @returns {{ packages: Record<string, string>, summary: string }}
+ * @returns {{ packages: Record<string, string>, summary: string, body: string }}
  */
 export function parseChangeset(text) {
   const lines = text.split(/\r?\n/);
@@ -93,13 +124,18 @@ export function parseChangeset(text) {
       if (m && LEVEL_RANK[m[2].toLowerCase()]) packages[m[1].trim()] = m[2].toLowerCase();
     }
   }
-  const body = [];
   while (i < lines.length && !lines[i].trim()) i++;
+  const body = lines.slice(i).join('\n');
+  const firstParagraph = [];
   for (; i < lines.length; i++) {
     if (!lines[i].trim()) break;
-    body.push(lines[i].trim());
+    firstParagraph.push(lines[i].trim());
   }
-  return { packages, summary: body.join(' ').replace(/\s+/g, ' ').trim() };
+  return {
+    packages,
+    summary: firstParagraph.join(' ').replace(/\s+/g, ' ').trim(),
+    body: body.trimEnd(),
+  };
 }
 
 /** Highest declared level in a package→level map, or null when release-nothing. */
@@ -115,6 +151,97 @@ export function highestLevel(packages) {
 export function clampSummary(summary, limit = 180) {
   if (summary.length <= limit) return summary;
   return `${summary.slice(0, limit - 1).trimEnd()}…`;
+}
+
+/**
+ * An emphasis run whose FIRST word is "breaking": `**BREAKING**`,
+ * `**BREAKING (v17)**`, `__Breaking change__`.
+ *
+ * Scanned anywhere in the body, because bolding a word is a deliberate act —
+ * nobody emphasises "breaking" by accident. Requiring it to OPEN the run is what
+ * keeps an emphasised ordinary sentence that happens to contain the word (real
+ * shape: `**Removed — … is technically breaking for anyone who wrote one**`)
+ * from matching, and the bounded, `*`/`_`-free tail keeps a run from swallowing
+ * a whole paragraph.
+ */
+const BREAKING_EMPHASIS_LABEL = /(\*\*|__)[ \t]*breaking\b[^*_\n]{0,48}\1/i;
+
+/** The same label, but required to OPEN the text — used to avoid restating it. */
+const OPENS_WITH_BREAKING_LABEL = /^[ \t]*(?:\*\*|__)[ \t]*breaking\b/i;
+
+/**
+ * A block (paragraph, heading or top-level bullet) that OPENS with the word
+ * "breaking" — `## Breaking note …`, `Breaking for anyone reading \`node.ui\` …`,
+ * `BREAKING CHANGE: …` (the conventional-commit footer needs no separate rule;
+ * it opens a block by construction).
+ */
+const BREAKING_BLOCK_OPENER = /^[ \t]*(?:#{1,6}[ \t]+)?(?:[-*+][ \t]+)?(?:\*\*|__|\*|_)?[ \t]*breaking\b/i;
+
+/**
+ * Did the AUTHOR annotate this change as breaking, in the changeset body?
+ *
+ * THE PRECISION RULE IS POSITIONAL, NOT LEXICAL. "breaking" is an ordinary
+ * English word that appears in changeset prose all the time; what makes an
+ * occurrence a *declaration* is where the author put it — in an emphasis label,
+ * or at the head of a block. It is never enough that the word merely occurs.
+ *
+ * Measured over `f5bc4c78be76..f995a452d2ca` (65 changesets, 5 mention the word):
+ *
+ *   FLAGGED   `042e09d77` `**BREAKING (v17)** — field widgets receive …`  (label)
+ *   FLAGGED   `6e794a19e` `Breaking for anyone reading \`node.ui\` …`      (block, LAST paragraph)
+ *   FLAGGED   `8ec406728` `## Breaking note — read before tracking …`     (heading)
+ *   FLAGGED   `d22ae31ce` `Breaking semantics, in FROM → TO form:`        (block)
+ *   NOT       `9e9e9a92f` `… is technically breaking for anyone who wrote one, but only in
+ *                          the sense that TypeScript now reports what was already true`
+ *
+ * Two negatives fall out of the positional anchor with no lexical guard, which
+ * is why there is none: a hedged mid-sentence mention is not at a block head,
+ * and a negated form ("non-breaking", "not breaking", "no breaking changes" —
+ * `d22ae31ce` carries the second) does not START with the word, so the anchor
+ * rejects it. Same for words that merely CONTAIN it ("groundbreaking").
+ *
+ * Deliberately line-INSENSITIVE: block-initial, never line-initial. Changeset
+ * prose is hard-wrapped, so any sentence containing "breaking" can land it first
+ * on a line by accident — but only the author's own paragraphing puts it first
+ * in a block.
+ *
+ * @param {string} body full changeset text after the frontmatter
+ */
+export function hasBreakingAnnotation(body) {
+  if (!body) return false;
+  if (BREAKING_EMPHASIS_LABEL.test(body)) return true;
+  const lines = body.split(/\r?\n/);
+  let atBlockStart = true;
+  for (const line of lines) {
+    if (!line.trim()) {
+      atBlockStart = true;
+      continue;
+    }
+    // A heading opens a block whether or not a blank line precedes it.
+    if (atBlockStart || /^[ \t]*#{1,6}[ \t]+/.test(line)) {
+      if (BREAKING_BLOCK_OPENER.test(line)) return true;
+    }
+    atBlockStart = false;
+  }
+  return false;
+}
+
+/**
+ * The uniform marker the digest stamps on a breaking entry, so the compiled
+ * release record shows the class without a human having to rescue it by hand
+ * (#6110 did exactly that rescue, which is what #6099 records).
+ *
+ * Uniform, and deliberately WITHOUT a version tag: the digest cannot derive one,
+ * and inventing "(v17)" would be the script asserting something no input says.
+ * Where the author wrote their own richer label it survives verbatim instead —
+ * `markBreaking` never restates a summary that already opens with one.
+ */
+export const BREAKING_MARKER = '**BREAKING**';
+
+/** Prefix an entry's text with `BREAKING_MARKER` unless it already carries one. */
+export function markBreaking(text) {
+  if (OPENS_WITH_BREAKING_LABEL.test(text)) return text;
+  return `${BREAKING_MARKER} — ${text}`;
 }
 
 /**
@@ -196,10 +323,24 @@ function readAt(objectuiRoot, to, sha, path) {
  *
  * Mirrors `scripts/check-changeset-no-major.mjs`: outside an RC window a
  * `major` on any package promotes the WHOLE lockstep group, and that gate
- * rejects it. objectui marks its breaking symbol renames `major` routinely, so
- * a mechanical `major` here would make every ordinary pin refresh red. Inside
- * pre-mode a `major` only ever yields `X.0.0-<tag>.N`, which is what an RC
- * window is for — so the level passes through untouched.
+ * rejects it. Inside pre-mode a `major` only ever yields `X.0.0-<tag>.N`, which
+ * is what an RC window is for — so the level passes through untouched.
+ *
+ * WHAT OBJECTUI ACTUALLY DECLARES (corrected #6099). This comment used to assert
+ * that "objectui marks its breaking symbol renames `major` routinely", and the
+ * `downgradedMajor` path below was written as the ROUTINE case that assertion
+ * implies. Measured, the opposite holds: over `f5bc4c78be76..f995a452d2ca`,
+ * **0 of 64** releasing changesets declared `major` — including both commits
+ * whose subject carries a conventional-commit `!`. objectui observes the same
+ * launch-window convention this repo does, and ships a breaking change as
+ * `minor` plus an annotation the author writes in the changeset body.
+ *
+ * So `downgradedMajor` is a SAFETY NET for a level not observed in practice, not
+ * the common path — it stays because it is still the right answer if a `major`
+ * ever does arrive (an RC window closing upstream would do it), but nothing may
+ * be built on the premise that it fires. In particular the breaking COUNT must
+ * not be derived from it: that was the #6099 defect, and `hasBreakingAnnotation`
+ * is what actually carries the class now.
  */
 export function inPreMode(frameworkRoot) {
   try {
@@ -237,17 +378,25 @@ export function classifyRange({ objectuiRoot, from, to }) {
   const releasing = [];
   const releaseNothingEntries = [];
   for (const entry of entries) {
-    const { packages, summary } = parseChangeset(readAt(objectuiRoot, to, entry.sha, entry.path));
+    const { packages, summary, body } = parseChangeset(
+      readAt(objectuiRoot, to, entry.sha, entry.path),
+    );
     const level = highestLevel(packages);
     if (!level) {
       releaseNothingEntries.push({ ...entry, summary: summary || entry.subject });
       continue;
     }
+    // The breaking verdict lives HERE, in the single shared implementation, for
+    // the same reason the releasing verdict does: two copies would drift, and
+    // the first thing they would drift on is this exact class (#4731 / #6099).
+    const annotated = hasBreakingAnnotation(body);
     releasing.push({
       ...entry,
       level,
       packages: Object.keys(packages),
       summary: summary || entry.subject,
+      breaking: level === 'major' || annotated,
+      breakingSource: level === 'major' ? 'declared-major' : annotated ? 'annotation' : null,
     });
   }
 
@@ -272,7 +421,7 @@ export function classifyRange({ objectuiRoot, from, to }) {
 /**
  * Build the digest for a range.
  *
- * @returns {{ bump: string, declaredLevel: string|null, breaking: number, releasing: Array<object>, releaseNothing: number, noChangeset: number, totalCommits: number, downgradedMajor: boolean, body: string }}
+ * @returns {{ bump: string, declaredLevel: string|null, breaking: number, breakingByLevel: number, breakingByAnnotation: number, releasing: Array<object>, releaseNothing: number, noChangeset: number, totalCommits: number, downgradedMajor: boolean, body: string }}
  */
 export function buildDigest({
   objectuiRoot,
@@ -294,7 +443,12 @@ export function buildDigest({
         'patch',
       )
     : null;
-  const breaking = releasing.filter((r) => r.level === 'major').length;
+  // #6099: declared `major` OR the author's own breaking annotation. Level alone
+  // pinned this at 0 for every launch-window range objectui has ever shipped.
+  const breakingEntries = releasing.filter((r) => r.breaking);
+  const breaking = breakingEntries.length;
+  const breakingByLevel = breakingEntries.filter((r) => r.breakingSource === 'declared-major').length;
+  const breakingByAnnotation = breaking - breakingByLevel;
 
   let bump = bumpOverride || declaredLevel || 'patch';
   let downgradedMajor = false;
@@ -308,9 +462,11 @@ export function buildDigest({
 
   const lines = [];
   for (const r of shown) {
-    lines.push(
-      `- **${r.level}** — ${clampSummary(r.summary)} (objectui \`${r.sha.slice(0, 9)}\`)`,
-    );
+    // Mark AFTER clamping, so the marker can never be the thing truncation eats
+    // — a breaking entry silently losing its marker is the #6099 failure again,
+    // one layer down. The clamp budget stays spent on the author's own text.
+    const text = r.breaking ? markBreaking(clampSummary(r.summary)) : clampSummary(r.summary);
+    lines.push(`- **${r.level}** — ${text} (objectui \`${r.sha.slice(0, 9)}\`)`);
   }
   if (hidden > 0) {
     // A cap that fires SAYS SO, with the real count. Silent truncation and no
@@ -343,11 +499,25 @@ export function buildDigest({
 
   const notes = [];
   if (breaking > 0) {
+    // The hint must NAME its source. Saying "declare a **major** bump" when the
+    // source is a body annotation would be false on every launch-window range,
+    // which is every range objectui has shipped so far (#6099).
+    const byLevel = `${breakingByLevel} by a declared \`major\` level`;
+    const byAnnotation = `${breakingByAnnotation} by the author's own breaking annotation in the changeset body`;
+    const source =
+      breakingByLevel && breakingByAnnotation
+        ? `${byLevel}, ${byAnnotation}`
+        : breakingByLevel
+          ? byLevel
+          : `${byAnnotation} — objectui declares no \`major\` inside a launch window ` +
+            `(\`scripts/check-changeset-no-major.mjs\`)`;
     notes.push(
-      `⚠️ ${breaking} of these declare a **major** (breaking) bump in objectui` +
+      `⚠️ ${breaking} of these ${breaking === 1 ? 'carries' : 'carry'} a breaking change: ${source}. ` +
+        `Each is marked ${BREAKING_MARKER} in the list above — read them before compiling the release record` +
         (downgradedMajor
-          ? `; recorded here as \`minor\` because the launch-window convention ships breaking as minor ` +
-            `(\`scripts/check-changeset-no-major.mjs\`) — the breaking entries are listed above, unabridged.`
+          ? `. The declared \`major\` is recorded here as \`minor\` because the launch-window convention ` +
+            `ships breaking as minor (\`scripts/check-changeset-no-major.mjs\`) — the breaking entries are ` +
+            `listed above, unabridged.`
           : '.'),
     );
   }
@@ -358,6 +528,8 @@ export function buildDigest({
     bump,
     declaredLevel,
     breaking,
+    breakingByLevel,
+    breakingByAnnotation,
     releasing,
     releaseNothing,
     noChangeset,
@@ -433,7 +605,9 @@ function main(argv) {
     `objectui range: \`${rangeLabel}\`\n`;
 
   console.error(
-    `→ ${digest.releasing.length} releasing changeset(s), ${digest.breaking} breaking, ` +
+    `→ ${digest.releasing.length} releasing changeset(s), ` +
+      `${digest.breaking} breaking (${digest.breakingByLevel} declared major, ` +
+      `${digest.breakingByAnnotation} annotated), ` +
       `${digest.releaseNothing} release-nothing, ${digest.noChangeset} commit(s) without a changeset` +
       (digest.downgradedMajor ? ' — declared major recorded as minor (launch window)' : ''),
   );
@@ -563,7 +737,16 @@ function selfTest() {
     );
     check('the accounting states the omissions', digest.body.includes('omitted:'));
     check('the declared level drives the bump (major declared)', digest.declaredLevel === 'major');
-    check('breaking count is surfaced in the body', digest.body.includes('⚠️ 1 of these declare'));
+    check(
+      'breaking count is surfaced in the body, NAMING its source',
+      digest.body.includes('⚠️ 1 of these carries a breaking change: 1 by a declared `major` level'),
+      digest.body,
+    );
+    check(
+      'a declared-major entry is marked in the list too',
+      digest.body.includes('- **major** — **BREAKING** — Remove `PageNodeRenderer`'),
+      digest.body,
+    );
     check('in RC pre-mode a declared major stays major', digest.bump === 'major');
 
     const plain = buildDigest({
@@ -597,6 +780,213 @@ function selfTest() {
       'a cap that fires ANNOUNCES itself with the real count',
       capped.body.includes('…and 2 more releasing changesets'),
       capped.body,
+    );
+
+    // --- #6099: the `minor` + prose-annotation family ----------------------
+    // This is the form objectui ACTUALLY ships breaking changes in (0 of 64
+    // declared `major` over the live range), so it needs its own repo: the
+    // #4731 fixtures above pin exact counts and must not shift under it.
+    //
+    // Both recognised shapes are here, because the two live specimens differ in
+    // WHERE the author put the annotation — one leads with it, one buries it in
+    // the last paragraph — and a criterion that reads only the first paragraph
+    // (which is all `summary` is) catches the first and misses the second.
+    const ui2 = join(tmp, 'objectui-annotated');
+    mkdirSync(join(ui2, '.changeset'), { recursive: true });
+    const g2 = (...args) => git(ui2, args);
+    g2('init', '-q', '-b', 'main');
+    g2('config', 'user.email', 'selftest@objectstack.ai');
+    g2('config', 'user.name', 'self test');
+    g2('config', 'commit.gpgsign', 'false');
+    const commit2 = (subject, files) => {
+      for (const [path, content] of Object.entries(files)) {
+        mkdirSync(dirname(join(ui2, path)), { recursive: true });
+        writeFileSync(join(ui2, path), content);
+      }
+      g2('add', '-A');
+      g2('commit', '-q', '-m', subject);
+      return g2('rev-parse', 'HEAD').trim();
+    };
+
+    const base2 = commit2('chore: base', { 'README.md': 'base\n' });
+
+    // (A) RECOGNISED — the annotation LEADS, as an emphasis label the author
+    //     spelled with their own version tag. Mirrors objectui `042e09d77`.
+    commit2('refactor(fields)!: converge the widget metadata carrier to `field` (#3233)', {
+      '.changeset/field-widget-single-metadata-carrier.md':
+        '---\n"@object-ui/fields": minor\n---\n\n' +
+        '**BREAKING (v17)** — field widgets receive their metadata on ONE key, `field`.\n' +
+        '`schema` is removed from the widget contract (objectui#3233).\n\n' +
+        '## What changed\n\n' +
+        '`schema` was a second carrier for what `field` already means.\n',
+      'src/fields.ts': 'a\n',
+    });
+    // (B) RECOGNISED — the annotation is in the LAST paragraph, opening a block
+    //     in plain prose. Mirrors objectui `6e794a19e`, the specimen whose entry
+    //     #6110 had to rescue by hand.
+    commit2('fix(app-shell)!: converge flow node geometry to spec `FlowNode.position` (#3172)', {
+      '.changeset/flow-node-geometry-is-spec-position.md':
+        '---\n"@object-ui/app-shell": minor\n---\n\n' +
+        "The flow designer writes node geometry as the spec's `FlowNode.position`, not\n" +
+        'its own `ui: { x, y }` (objectui#3172).\n\n' +
+        'FROM: dragging, adding-at-a-point and insert-on-edge each wrote `node.ui`.\n' +
+        'TO: all three write `position: { x, y }`.\n\n' +
+        'Breaking for anyone reading `node.ui` off a flow draft: after the first edit\n' +
+        'the key is gone and the coordinates live under `node.position`.\n',
+      'src/flow.ts': 'b\n',
+    });
+    // (C) RECOGNISED — the annotation is a HEADING. Mirrors objectui `8ec406728`,
+    //     which the conventional-commit `!` convention does NOT mark.
+    commit2('fix(app-shell): entitlement context reads `error.details.*` only (#3329)', {
+      '.changeset/entitlement-error-context-reads-details.md':
+        '---\n"@object-ui/app-shell": minor\n---\n\n' +
+        'The environment entitlement dialog now reads its context from\n' +
+        '`error.details.*` — the single declared location (objectui#3329).\n\n' +
+        '## Breaking note — read before tracking objectui `main` directly\n\n' +
+        'This is a wire-shape change with no consumer-side fallback.\n',
+      'src/entitlement.ts': 'c\n',
+    });
+    // (D) NOT RECOGNISED — the word appears MID-SENTENCE inside an emphasised
+    //     paragraph, hedged and then discounted. Mirrors objectui `9e9e9a92f`,
+    //     the real near-miss: an ordinary entry that merely discusses breakage.
+    commit2('fix(types): DrillDownConfig declares only keys a renderer reads (#3354)', {
+      '.changeset/drilldown-config-declared-equals-delivered.md':
+        '---\n"@object-ui/types": minor\n---\n\n' +
+        '`DrillDownConfig` now declares only keys a renderer reads (objectui#3354).\n\n' +
+        '**Removed — two keys no renderer has ever read.** Removing a declared key from\n' +
+        'a published interface is technically breaking for anyone who wrote one, but\n' +
+        'only in the sense that TypeScript now reports what was already true at\n' +
+        'runtime: the key did nothing.\n',
+      'src/types.ts': 'd\n',
+    });
+    // (E) NOT RECOGNISED — negated forms, and a word that merely CONTAINS it.
+    //     "Fixes that are not breaking…" is verbatim objectui `d22ae31ce`.
+    commit2('chore(deps): follow-up cleanups (#3287)', {
+      '.changeset/rc2-followup-cleanups.md':
+        '---\n"@object-ui/core": patch\n---\n\n' +
+        'Fixes that are not breaking, but were only found because rc.2 stopped being\n' +
+        'lenient — each had been passing vacuously.\n\n' +
+        'Non-breaking cleanup throughout; this groundbreaking refactor changes no\n' +
+        'contract.\n',
+      'src/core.ts': 'e\n',
+    });
+    // (F) NOT RECOGNISED — hard wrapping lands the word first on a LINE, still
+    //     mid-sentence. This is why the anchor is block-initial, not line-initial:
+    //     an author's paragraphing is a choice, a wrap column is not.
+    commit2('fix(fields): the record picker sends the authored option value (#3336)', {
+      '.changeset/record-picker-authored-option-value.md':
+        '---\n"@object-ui/fields": patch\n---\n\n' +
+        'The record picker sends the AUTHORED value of a picked `select` option.\n\n' +
+        'Radix `Select` speaks strings, so a numeric option value used to arrive as\n' +
+        'its stringified form. Nothing about the change is\n' +
+        'breaking for existing authors — the stored wire shape is unchanged.\n',
+      'src/picker.ts': 'f\n',
+    });
+    const head2 = g2('rev-parse', 'HEAD').trim();
+
+    const annotated = buildDigest({
+      objectuiRoot: ui2,
+      frameworkRoot: fwPlain,
+      from: base2,
+      to: head2,
+    });
+
+    check(
+      '#6099 the whole family is collected, breaking or not (6 releasing)',
+      annotated.releasing.length === 6,
+      `got ${annotated.releasing.length}`,
+    );
+    check(
+      '#6099 no `major` is declared anywhere — the form objectui actually ships',
+      annotated.declaredLevel === 'minor' && annotated.breakingByLevel === 0,
+      `declaredLevel=${annotated.declaredLevel} byLevel=${annotated.breakingByLevel}`,
+    );
+    check(
+      '#6099 a `minor` whose FIRST paragraph carries the annotation is recognised',
+      annotated.releasing.some(
+        (r) => r.path.includes('field-widget') && r.breaking && r.breakingSource === 'annotation',
+      ),
+    );
+    check(
+      '#6099 a `minor` whose LAST paragraph carries the annotation is recognised',
+      annotated.releasing.some(
+        (r) => r.path.includes('flow-node') && r.breaking && r.breakingSource === 'annotation',
+      ),
+    );
+    check(
+      '#6099 a `minor` annotated by a HEADING is recognised',
+      annotated.releasing.some((r) => r.path.includes('entitlement') && r.breaking),
+    );
+    check(
+      '#6099 a hedged MID-SENTENCE "technically breaking" is NOT flagged',
+      annotated.releasing.some((r) => r.path.includes('drilldown') && !r.breaking),
+    );
+    check(
+      '#6099 "not breaking" / "Non-breaking" / "groundbreaking" are NOT flagged',
+      annotated.releasing.some((r) => r.path.includes('rc2-followup') && !r.breaking),
+    );
+    check(
+      '#6099 a wrapped line STARTING with the word mid-sentence is NOT flagged',
+      annotated.releasing.some((r) => r.path.includes('record-picker') && !r.breaking),
+    );
+    check(
+      '#6099 exactly the three annotated entries are flagged, no more',
+      annotated.breaking === 3 && annotated.breakingByAnnotation === 3,
+      `breaking=${annotated.breaking} byAnnotation=${annotated.breakingByAnnotation}`,
+    );
+    check(
+      "#6099 the author's own label survives verbatim — never restated",
+      // The `r.breaking` clause is load-bearing: the `(v17)` label is the
+      // AUTHOR's text, so the two body clauses alone would pass whether or not
+      // this entry is flagged at all — green for an empty reason.
+      annotated.releasing.find((r) => r.path.includes('field-widget'))?.breaking === true &&
+        annotated.body.includes('- **minor** — **BREAKING (v17)** — field widgets receive') &&
+        !annotated.body.includes('**BREAKING** — **BREAKING'),
+      annotated.body,
+    );
+    check(
+      '#6099 markBreaking pins both directions directly (renderer, not criterion)',
+      markBreaking('**BREAKING (v17)** — x') === '**BREAKING (v17)** — x' &&
+        markBreaking('__Breaking change__ y') === '__Breaking change__ y' &&
+        markBreaking('An ordinary summary.') === '**BREAKING** — An ordinary summary.',
+    );
+    check(
+      '#6099 hasBreakingAnnotation pins both directions directly (criterion)',
+      hasBreakingAnnotation('## Breaking note\n\nx') &&
+        hasBreakingAnnotation('a\n\nBreaking for anyone reading `node.ui`.') &&
+        hasBreakingAnnotation('**BREAKING (v17)** — x') &&
+        !hasBreakingAnnotation('is technically breaking for anyone who wrote one') &&
+        !hasBreakingAnnotation('Non-breaking cleanup; a groundbreaking refactor.') &&
+        !hasBreakingAnnotation('wrapped so the word lands first on a line:\nbreaking for authors'),
+    );
+    check(
+      '#6099 an entry annotated further down GETS the marker on its line (#6110 by hand)',
+      annotated.body.includes(
+        '- **minor** — **BREAKING** — The flow designer writes node geometry',
+      ),
+      annotated.body,
+    );
+    check(
+      '#6099 an ordinary entry is NOT marked',
+      annotated.body.includes('- **minor** — `DrillDownConfig` now declares') &&
+        annotated.body.includes('- **patch** — The record picker sends'),
+      annotated.body,
+    );
+    check(
+      '#6099 the ⚠️ hint fires on a range with NO declared major — the whole point',
+      annotated.body.includes('⚠️ 3 of these carry a breaking change') &&
+        annotated.body.includes("by the author's own breaking annotation in the changeset body"),
+      annotated.body,
+    );
+    check(
+      '#6099 the hint no longer claims a **major** bump it cannot have',
+      !annotated.body.includes('declare a **major**'),
+      annotated.body,
+    );
+    check(
+      '#6099 nothing was downgraded — there was no major to downgrade',
+      annotated.bump === 'minor' && annotated.downgradedMajor === false,
+      `bump=${annotated.bump} downgraded=${annotated.downgradedMajor}`,
     );
 
     // --- end-to-end through the shell driver -------------------------------


### PR DESCRIPTION
Fixes #6099

只做分诊钉死的**方向 1**:判据扩为「声明级 `major` **或** 作者在 changeset 正文里写下的破坏性标注」。**没有**去读提交标题的 conventional-commit `!`(方向 2),也没有改收录集——只改标注与计数。文件面仅 `scripts/objectui-changeset-digest.mjs`。

---

## 判据定义

```js
breaking = (level === 'major') || hasBreakingAnnotation(body)
```

`parseChangeset` 过去只返回首段(`summary`,条目行渲染用的就是它)。两个真实样本里有一个把破坏性陈述放在**最后一段**,所以现在额外返回 frontmatter 之后的**全文** `body` 供判据扫描;`summary` 语义不变。

判据落在 `classifyRange` 里——和 releasing 判据同一处。理由与文件里原有的那句一致:两份拷贝一定会漂移,而第一个漂移的就是这个类。

**为什么读正文不算越 #4731 的线。** `!` 是工具对**提交**的分类,正文标注是作者对**发布**的陈述;后者与声明级别写在同一个文件里,是同一份声明的另一半。顺带一提,实测这个区间 `!` 只标了 2 条提交,而作者自己的标注标了 4 条——正文这个面比 `!` 更全,见下。

## 标记集与其理由

标记集是从 objectui **实际在用的**写法反推的,不是预设的:

| 记号 | 形状 | 真实出处 |
|:--|:--|:--|
| 强调标签 | `**BREAKING**` / `**BREAKING (v17)**` / `__Breaking change__` —— 强调段的**第一个词**是 breaking | `042e09d77` 首段 |
| 块首词 | 某个块(段落 / 标题 / 顶层列表项)**以** breaking **开头** | `6e794a19e` 末段、`8ec406728` 的 `## Breaking note` 标题 |

conventional-commit 的 `BREAKING CHANGE:` 页脚不需要单独规则:它天然就在块首,已被第二条覆盖。

**精度靠位置,不靠词形。** "breaking" 是个日常英文词,changeset 正文里随处可见;让一次出现成为**声明**的是作者把它放在哪儿——放进强调标签,或放到块首。仅仅出现过,永远不够。

**刻意按块锚定,而不是按行。** changeset 正文是硬换行的,任何含该词的句子都可能因换行把它甩到**行首**;但只有作者自己的分段才会把它放到**块首**。样本 F 就钉这一点。

## 误报面(实测,不是推演)

区间 `f5bc4c78be76..f995a452d2ca` 的 65 条 changeset 里,**5 条**提到了这个词。逐条过判据:

| commit | 出现形态 | 判据 |
|:--|:--|:--|
| `042e09d77` | `**BREAKING (v17)** — field widgets receive …` | ✅ 认出(强调标签) |
| `6e794a19e` | `Breaking for anyone reading \`node.ui\` …`(**末段**) | ✅ 认出(块首) |
| `8ec406728` | `## Breaking note — read before tracking …` | ✅ 认出(标题) |
| `d22ae31ce` | `Breaking semantics, in FROM → TO form:` | ✅ 认出(块首) |
| `9e9e9a92f` | `… is technically breaking for anyone who wrote one, but only in the sense that TypeScript now reports what was already true` | ❌ 不认(句中,且作者自己在打折扣) |

两类否定**由位置锚点自然排除,因而没有加任何词形护栏**(不加投机性护栏是刻意的):

- **句中顺带提及**不在块首——`9e9e9a92f` 就是这一类,真实存在,不是假想;
- **否定式**("non-breaking" / "not breaking" / "no breaking changes")不**以**该词开头,锚点直接拒掉。`d22ae31ce` 正文里就有一句 "Fixes that are **not breaking**, but were only found because…",它没有被误判。同理 "groundbreaking" 这类**包含**该词的词也进不来。

self-test 里 D / E / F 三条反例分别钉住这三种形态,文本都取自上面这些真实样本。

## ⚠️ 计数行是否计入正文标注:计入

计入,这正是这句提示存在的目的——它服务的是「编译发布记录的人需要看见破坏性迁移」,而不是「谁声明了 major」。同时**改写措辞**,因为原话在正文标注这个来源下是**假的**:

- 之前:`⚠️ N of these declare a **major** (breaking) bump in objectui`
- 之后:`⚠️ N of these carry a breaking change: A by a declared \`major\` level, B by the author's own breaking annotation in the changeset body. Each is marked **BREAKING** in the list above — read them before compiling the release record.`

两个来源分别报数(`breakingByLevel` / `breakingByAnnotation` 也进了 `--json` 与 stderr 摘要),读的人能直接看出这批是「窗口内 minor + 标注」还是「真声明了 major」。

## 输出形状(#6110 手工做过的那件事)

条目行按 #6110 的形状带标记:

```
- **minor** — **BREAKING (v17)** — field widgets receive their metadata on ONE key, `field`. … (objectui `042e09d77`)
- **minor** — **BREAKING** — The flow designer writes node geometry as the spec's `FlowNode.position` … (objectui `6e794a19e`)
```

两点决定:

1. **标记统一为 `**BREAKING**`,不带版本号。** 脚本推导不出 "(v17)",硬编上去就是脚本在断言输入里没有的东西。作者**自己**写了更丰富的标签时原样保留、绝不复述——所以第一条仍然显示作者的 `**BREAKING (v17)**`,与 #6110 手工结果逐字一致;第二条是脚本自己加的,少一个版本尾巴。
2. **标记在 clamp 之后施加**,否则 180 字截断可能把标记本身吃掉——那就是 #6099 的失效模式往下再走一层。

## 过时上游模型注释:before / after

分诊点名的 `:197-201`。原文断言与实测相反:

```diff
- * rejects it. objectui marks its breaking symbol renames `major` routinely, so
- * a mechanical `major` here would make every ordinary pin refresh red. Inside
- * pre-mode a `major` only ever yields …
+ * rejects it. Inside pre-mode a `major` only ever yields …
+ *
+ * WHAT OBJECTUI ACTUALLY DECLARES (corrected #6099). This comment used to assert
+ * that "objectui marks its breaking symbol renames `major` routinely" … Measured,
+ * the opposite holds: over `f5bc4c78be76..f995a452d2ca`, **0 of 64** releasing
+ * changesets declared `major` — including both commits whose subject carries a
+ * conventional-commit `!`. objectui observes the same launch-window convention
+ * this repo does, and ships a breaking change as `minor` plus an annotation …
+ *
+ * So `downgradedMajor` is a SAFETY NET for a level not observed in practice, not
+ * the common path — it stays because it is still the right answer if a `major`
+ * ever does arrive …, but nothing may be built on the premise that it fires. In
+ * particular the breaking COUNT must not be derived from it: that was the #6099
+ * defect …
```

`downgradedMajor` 路径(`:301`)**保留**——它在真出现 `major` 时(上游 RC 窗口关闭就会)依然是对的。改的是它的定位:从「常态路径」降为「安全网」,并写明破坏性计数不得建立在它之上。

## 重放:真实区间 `f5bc4c78be76...f995a452d2ca`

```
BEFORE (origin/main)
→ 64 releasing changeset(s), 0 breaking, 1 release-nothing, 33 commit(s) without a changeset
   正文里 ⚠️ 提示行:0 处;条目带标记:0 条

AFTER
→ 64 releasing changeset(s), 4 breaking (0 declared major, 4 annotated), 1 release-nothing, 33 commit(s) without a changeset

- **minor** — **BREAKING** — The environment entitlement dialog now reads its context from `error.details.*` … (objectui `8ec406728`)
- **minor** — **BREAKING** — Track `@objectstack/spec` 17.0.0-rc.2 (objectui#3235, #3208, #3287, #3264). (objectui `d22ae31ce`)
- **minor** — **BREAKING** — The flow designer writes node geometry as the spec's `FlowNode.position` … (objectui `6e794a19e`)
- **minor** — **BREAKING (v17)** — field widgets receive their metadata on ONE key, `field`. … (objectui `042e09d77`)

⚠️ 4 of these carry a breaking change: 4 by the author's own breaking annotation in the changeset body
   — objectui declares no `major` inside a launch window (`scripts/check-changeset-no-major.mjs`).
   Each is marked **BREAKING** in the list above — read them before compiling the release record.
```

### ⚠️ 与派单预期的偏差:认出 **4** 条,不是 2 条(如实报告,未调参凑数)

派单写的是「两条都应被认出(且只有这两条)」。实际是 **4** 条,issue 点名的两条**都在其中**。这不是误报,原因是那个「2」来自 issue 表格的选取口径——**提交标题带 `!`**,也就是方向 2 的产出;而方向 1 的口径是**作者正文标注**,两者是不同的集合,前者是后者的真子集:

- `8ec406728` —— 作者自己写了 `## Breaking note — read before tracking objectui \`main\` directly`,正文说明「wire-shape change with no consumer-side fallback」,并点名自建部署会失去 entitlement 上下文。提交标题是 `fix(app-shell):`,**无 `!`**。
- `d22ae31ce` —— 作者写了 `Breaking semantics, in FROM → TO form:`,下面列的是 `app.homePageId` 退役(硬报错 + `os migrate meta --from 16` 迁移)、`NavigationArea.visible/order/requiredPermissions` 移除、`@object-ui/core` 不再导出 `NotificationProtocol`。这些是作者升级时**确实会踩到**的破坏性迁移。提交标题是 `feat(deps): track …`,**无 `!`**。

两条都是作者亲手标注的真破坏性,漏掉它们才是 #4731 说的那种「must never vanish from a release record」。所以这个偏差反过来是**支持**分诊划的边界的:方向 1 的召回严格优于方向 2,而且不用去读提交类型。按「模板是工具不是真相」的规矩如实记在这里,而不是把正则收紧到恰好凑出 2 条。

## self-test 计数增量

**19 → 37 条断言**(+18)。新增的 `#6099` 族用**独立的临时仓库**(`objectui-annotated`),不动 #4731 那套 fixture 的精确计数。

识别方向(应认出):

- (A) `minor`,标注在**首段**,强调标签 `**BREAKING (v17)**` —— 对应 `042e09d77`
- (B) `minor`,标注在**末段**,块首散文 `Breaking for anyone reading …` —— 对应 `6e794a19e`,即 #6110 手工补标的那条
- (C) `minor`,标注是**标题** `## Breaking note — …` —— 对应 `8ec406728`

不认方向(应放过):

- (D) 句中 hedged 提及,且整段是强调段(`**Removed — …**`)—— 对应 `9e9e9a92f`
- (E) `not breaking` / `Non-breaking` / `groundbreaking` —— 前者逐字取自 `d22ae31ce`
- (F) 硬换行把该词甩到**行首**但仍在句中 —— 钉「按块不按行」这个决定

外加两条直接单测(`markBreaking` 与 `hasBreakingAnnotation` 各自的正反两向),以及一条把已有 major fixture 的条目行标记也钉住。

`pnpm check:objectui-changeset`(digest --self-test + objectui-range --self-test)全绿;`objectui-range.mjs`(#4843 那个消费者)未改动且自测仍全绿——新增的 `breaking` / `breakingSource` 字段对它是纯增量。

## 反向验证(先声明方向,再跑)

**声明的预期**:把判据扩展在调用点回退(`breaking: level === 'major' || annotated` → `breaking: level === 'major'`),**保留全部 fixture**,则依赖判据的 **7** 条断言转红;三条反例断言、两条直接单测、以及「整族仍被收录」那条**按设计保持绿**。

**实跑结果:与预期逐条吻合,7 红。**

```
✗ #6099 a `minor` whose FIRST paragraph carries the annotation is recognised
✗ #6099 a `minor` whose LAST paragraph carries the annotation is recognised
✗ #6099 a `minor` annotated by a HEADING is recognised
✗ #6099 exactly the three annotated entries are flagged, no more — breaking=0 byAnnotation=0
✗ #6099 the author's own label survives verbatim — never restated
✗ #6099 an entry annotated further down GETS the marker on its line (#6110 by hand)
✗ #6099 the ⚠️ hint fires on a range with NO declared major — the whole point
```

同一回退下重放真实区间,退回 `0 breaking`。恢复后 37 条全绿、重放回到 4 条。

保持绿的那几条**是有意的,不是漏网**,分三类说明:

1. **三条反例断言**(D/E/F 不被标记)——否定式断言在功能被移除时不可能转红,因为此时什么都没被标记,"不被标记"平凡成立。这是预期的不对称。
2. **两条直接单测**——`markBreaking` 测的是**渲染器**、`hasBreakingAnnotation` 测的是**判据函数**本身;这次回退删的是判据的**调用**,不是这两个函数,所以它们钉的是另一个事实。
3. **「整族 6 条仍被收录」**——回退后依然绿,这恰恰是**设计属性的证明**:判据不改变收录集(#4731 的边界),改的只有标注与计数。

另外修掉了我自己写的一条**空绿**:「作者标签原样保留」最初只断言正文里有 `- **minor** — **BREAKING (v17)** — …` 且没有重复标记——但那个 `(v17)` 是**作者自己的**文本,这两句在判据被回退后**照样通过**,属于「因为什么都没产生所以断言通过」。已加上 `r.breaking === true` 这一必要子句,回退后它才真正转红(上面 7 红里就有它)。

## 门禁

- `pnpm check:objectui-changeset` ✅(37 + objectui-range 全绿)
- `npx eslint scripts/objectui-changeset-digest.mjs` ✅ rc=0
- `pnpm check:nul-bytes` ✅ 5956 个文件、无裸控制字节;另按规矩对改动文件做了超出门禁范围的自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`,干净
- `pnpm check:skill-frame-sync` ✅(该脚本注释里引用了本文件)

无 changeset:仅改 `scripts/`,不发布任何包,已打 `skip-changeset`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_