### PR TITLE
feat(runtime): ScriptContext.user 由 unknown 收窄为 ScriptUser 联合 (#5521)

### DIFF
--- a/.changeset/light-berries-tickle.md
+++ b/.changeset/light-berries-tickle.md
@@ -1,0 +1,26 @@
+---
+'@objectstack/runtime': patch
+---
+
+sandbox: `ScriptContext.user` 由 `unknown` 收窄为命名联合 `ScriptUser`(#5521)
+
+沙箱接缝 `ScriptContext`(`packages/runtime/src/sandbox/script-runner.ts`)把交给 hook /
+action body 的调用者声明为 `user?: unknown`,类型系统对这个字段一无所知 —— 第四个
+dispatch 面明天再手搓一个 user 字面量,编译器不会说一句话。而"三个 dispatcher 手搓出三种
+形状"正是 #5372 的成因:它能存在几个版本,部分原因就是没有任何声明可以违背。
+
+现在它是 `user?: ScriptUser`,`ScriptUser = ActorUser | HookContext['user']` —— 两个**实测
+的真实生产者形状**的联合,与 33 行外的姊妹字段 `ScriptSession`(#5613 / #5991)同构:
+
+- action body 收 `ActorUser`(`security/actor-user.ts`,#5372 起的唯一生产者,#6011 后
+  `positions` 为唯一拼法);
+- hook body 收 `HookContext['user']`(ObjectQL `buildUser()` 的 `session.userId` 快捷方式:
+  `id` / `name` / `email` / `organizationId`,全部可选)。
+
+刻意**不**收成单一类型:hook 快捷方式不带 `positions` / `permissions` / `systemPermissions`,
+收成 `ActorUser` 会在 hook 面断言一套它从未生产过的授权词汇;也**不**收成 spec 的
+`EvalUser`(issue 选项 1)—— 实测 `buildUser()` 根本不产 `positions`,而 `EvalUser` 要求它,
+那是套着 spec 外衣的同一种过度声明。
+
+行为零变化:两个写入方从 `any` 引擎上下文赋值,唯一的 VM 侧读取方收 `unknown`。TS 消费者
+可见,故走 patch。`ActorUser` 同时作为**类型**从包入口导出,使联合的两支都可被消费者命名。

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -100,6 +100,7 @@ export {
     type RateLimitKeyInput,
     type RateLimitKeyKind,
     type RateLimitLogger,
+    type ActorUser,
 } from './security/index.js';
 
 // ── Observability primitives ──────────────────────────────────────────
@@ -157,6 +158,7 @@ export type {
   ScriptResult,
   ScriptRunOptions,
   ScriptSession,
+  ScriptUser,
   QuickJSScriptRunnerOptions,
 } from './sandbox/index.js';
 

--- a/packages/runtime/src/sandbox/index.ts
+++ b/packages/runtime/src/sandbox/index.ts
@@ -10,6 +10,7 @@ export type {
   ScriptResult,
   ScriptRunOptions,
   ScriptSession,
+  ScriptUser,
 } from './script-runner.js';
 export { QuickJSScriptRunner, SandboxError } from './quickjs-runner.js';
 export type { QuickJSScriptRunnerOptions } from './quickjs-runner.js';

--- a/packages/runtime/src/sandbox/script-runner.ts
+++ b/packages/runtime/src/sandbox/script-runner.ts
@@ -38,6 +38,8 @@
 import type { HookBody, ScriptBody, ExpressionBody, HookContext } from '@objectstack/spec/data';
 import type { ActionSession } from '@objectstack/spec/ui';
 
+import type { ActorUser } from '../security/actor-user.js';
+
 /**
  * The caller session a sandboxed body receives on `ctx.session` — the union of
  * the two DECLARED producer shapes this one seam carries (#5613).
@@ -52,6 +54,57 @@ import type { ActionSession } from '@objectstack/spec/ui';
  * which is the practical payoff of the rename.
  */
 export type ScriptSession = ActionSession | HookContext['session'];
+
+/**
+ * The caller a sandboxed body receives on `ctx.user` — the union of the two
+ * REAL producer shapes this one seam carries (#5521).
+ *
+ * Same construction, and for the same reason, as {@link ScriptSession}
+ * (#5613/#5991) one field over: the seam is genuinely generic over both body
+ * kinds, so collapsing it to either single type would be a contract lie in the
+ * other direction.
+ *
+ *  - an ACTION body gets {@link ActorUser} — the ONE producer of the dispatch
+ *    user shape (`../security/actor-user.ts`), built through the spec's
+ *    `createEvalUser` factory and shared by REST `/actions`, MCP `run_action`
+ *    and the AI routes since #5372. Every key is present with a defined value
+ *    except `email` / `organizationId`;
+ *  - a HOOK body gets `HookContext['user']` (`@objectstack/spec/data`) —
+ *    ObjectQL's `buildUser()` shortcut, whose whole key set is
+ *    `id` / `name` / `email` / `organizationId`, every one of them optional.
+ *
+ * The two do NOT converge, which is exactly why this is a union and not
+ * `ActorUser`: the hook shortcut carries no `positions`, no `permissions`, no
+ * `systemPermissions` and no `userId` / `displayName` alias, so declaring
+ * `ActorUser` alone here would assert an authority vocabulary the hook path has
+ * never produced — the "one key, two realities" defect #5613 exists to close,
+ * pointed at the other field.
+ *
+ * ⚠️ It is NOT `EvalUser` either, and that was measured rather than assumed.
+ * `EvalUser` (ADR-0068 D1) is what the issue's option 1 proposed as the
+ * "minimum common denominator", but it requires `id: string` and
+ * `positions: string[]`, and `buildUser()` (`packages/objectql/src/engine.ts`)
+ * emits neither guarantee — no `positions` key at all. So `EvalUser` is a
+ * SUPERSET of what the hook side delivers, and declaring it would have been the
+ * same over-claim in a spec-shaped disguise. `ActorUser extends EvalUser`, so
+ * the action arm still carries the ADR-0068 contract on the path that has it.
+ *
+ * The `?? …session?.user` fallback chain both writers carry (`body-runner.ts`
+ * `:315` / `:340`) forces no THIRD arm — measured, not presumed: neither
+ * session shape reaching this seam declares a `user` key
+ * (`HookContext['session']`, `ActionSession`) and neither producer writes one
+ * (`buildSession()` in objectql, `buildActionSession()` in
+ * `../action-execution.ts`), so that arm is unreachable on every real path —
+ * the #4984 dead-limb family. It is left in place here because this change
+ * types a seam and does not get to re-decide a runtime expression; the limb is
+ * filed separately.
+ *
+ * `undefined` is a member (via `HookContext['user']`'s own optionality, exactly
+ * as in {@link ScriptSession}) and it is a REAL value on this seam, not just
+ * spelling: ObjectQL's `ScopedRepo.execute()` — the second `executeAction` call
+ * site — passes an action context with no `user` and no `session` at all.
+ */
+export type ScriptUser = ActorUser | HookContext['user'];
 
 /**
  * Identity / origin information used by the sandbox for diagnostics, capability
@@ -83,7 +136,36 @@ export interface ScriptContext {
    */
   input: unknown;
   previous?: unknown;
-  user?: unknown;
+  /**
+   * The acting caller. TWO different shapes reach this one field, for the same
+   * structural reason {@link session} does — this interface is a single generic
+   * seam over both body kinds:
+   *
+   *  - a HOOK body gets `HookContext.user` (`@objectstack/spec/data`), the
+   *    engine's `session.userId` shortcut: `id` / `name` / `email` /
+   *    `organizationId`, built by ObjectQL's `buildUser()`;
+   *  - an ACTION body gets an {@link ActorUser} (`../security/actor-user.ts`) —
+   *    the identity core (`EvalUser`, ADR-0068 D1) plus the transport aliases
+   *    (`userId` / `displayName`) and the two authority channels
+   *    (`permissions` = permission-SET names, `systemPermissions` =
+   *    CAPABILITIES, never merged, #4705).
+   *
+   * Typed as {@link ScriptUser}, the union of those two REAL producer shapes,
+   * since #5521. It was `unknown` because the seam's two dispatch faces had
+   * never been measured against each other — and under `unknown` a fourth
+   * dispatch face could hand-roll a fifth user shape here without the compiler
+   * saying a word, which is precisely how #5372's three disagreeing shapes
+   * lived for several versions: there was no declaration to violate. The
+   * runtime shape has been correct and pin-tested since #5372
+   * (`../action-ctx-user-shape.test.ts` asserts the three dispatch paths key
+   * for key and value for value); this adds the compile-time half that pin
+   * cannot give, because a pin can only check the producers it names.
+   *
+   * ⚠️ Deliberately NOT narrowed to `ActorUser` alone, and deliberately not
+   * declared as the spec's `EvalUser`: the hook shortcut satisfies neither.
+   * See {@link ScriptUser} for the measurement behind both refusals.
+   */
+  user?: ScriptUser;
   /**
    * The caller session. TWO different shapes reach this one field, because
    * this interface is a single generic seam over both body kinds:

--- a/packages/runtime/src/sandbox/script-user-type-assertions.ts
+++ b/packages/runtime/src/sandbox/script-user-type-assertions.ts
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Compile-level pins for `ScriptContext.user` / {@link ScriptUser} (#5521).
+ *
+ * ## Why a plain src module and not a test
+ *
+ * `packages/runtime/tsconfig.json` EXCLUDES every `.test.ts` and `.spec.ts`
+ * file, and the package's `typecheck` script is a bare `tsc --noEmit` over that
+ * config (the exclusion glob is not spelled here because it cannot be: its
+ * leading wildcard pair would close this comment) — so a
+ * `@ts-expect-error` written in a runtime test file is compiled by NOTHING and
+ * evaluates never. Deleting such a directive leaves every gate just as green,
+ * which is the definition of a phantom check; `check:type-check-coverage`'s
+ * PINS_CHECKED invariant fails on one, and its PHANTOM_PIN_DEBT ledger is
+ * closed to new entries. The same reasoning put
+ * `packages/spec/src/ui/app.nav-type-assertions.ts` in src, and this file
+ * follows it.
+ *
+ * The file is referenced by no tsup entry (`entry: ['src/index.ts']`) and
+ * re-exported by no barrel, so it adds nothing to any build. Everything is
+ * `export`ed because the repo compiles with `noUnusedLocals`.
+ *
+ * ## What is pinned, and in which direction
+ *
+ * The runtime VALUE has been right and pin-tested since #5372 —
+ * `../action-ctx-user-shape.test.ts` asserts the three dispatch paths key for
+ * key and value for value. That pin cannot see the case this file exists for:
+ * a FOURTH dispatch face hand-rolling a fifth user shape, which is what
+ * `user?: unknown` used to permit in silence and is the mechanism by which
+ * #5372's three disagreeing shapes survived several versions — there was no
+ * declaration to violate.
+ *
+ * So the assertions come in two families, and BOTH matter:
+ *
+ *  - POSITIVE — each of the two REAL producer shapes still assigns. These are
+ *    the over-narrowing guard: collapse the union to `ActorUser` and the hook
+ *    arm's assertions go red, which is the whole reason this is a union.
+ *  - NEGATIVE (`@ts-expect-error`) — shapes that must NOT assign. If the type
+ *    ever widens back toward `unknown`, the now-unused suppressions become the
+ *    compile error. This is the half that catches "accepts too much", and it is
+ *    the half the seam was missing entirely.
+ */
+
+import type { HookContext } from '@objectstack/spec/data';
+import type { EvalUser } from '@objectstack/spec/identity';
+
+import type { ActorUser } from '../security/actor-user.js';
+import type { ScriptContext, ScriptUser } from './script-runner.js';
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * POSITIVE — the two real producers, and the third real VALUE.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * The ACTION arm, exactly as `buildActorUser()` emits it (`../security/actor-user.ts`):
+ * the `EvalUser` identity core, the two transport aliases, and the two separate
+ * authority channels. Post-#6011 there is no `roles` alias — `positions` is the
+ * one spelling, and adding `roles` back here would fail the excess-property
+ * check, which is a bonus pin on that retirement.
+ */
+export const actionProducerShape: ScriptUser = {
+  id: 'usr_admin',
+  userId: 'usr_admin',
+  name: 'Ada Lovelace',
+  displayName: 'Ada Lovelace',
+  email: 'ada@objectos.ai',
+  positions: ['platform_admin'],
+  isPlatformAdmin: true,
+  organizationId: 'org_1',
+  permissions: ['admin_full_access'],
+  systemPermissions: ['manage_metadata'],
+};
+
+/** The same shape arriving under its own name, not as a literal. */
+export const actionProducerNamed = (u: ActorUser): ScriptUser => u;
+
+/**
+ * The HOOK arm, exactly as ObjectQL's `buildUser()` emits it
+ * (`packages/objectql/src/engine.ts`) for a fully-populated execution context.
+ * Note what is absent and must STAY absent-legal: `positions`, `permissions`,
+ * `systemPermissions`, `userId`, `displayName`.
+ */
+export const hookProducerShape: ScriptUser = {
+  id: 'usr_admin',
+  email: 'ada@objectos.ai',
+  organizationId: 'org_1',
+};
+
+/**
+ * `buildUser()`'s minimum: an execution context with a `userId` and nothing
+ * else. This is the assertion that goes red first if anyone collapses the union
+ * to `ActorUser`.
+ */
+export const hookProducerMinimal: ScriptUser = { id: 'usr_admin' };
+
+/** The same shape arriving under its declared spec name. */
+export const hookProducerNamed = (u: HookContext['user']): ScriptUser => u;
+
+/**
+ * `undefined` is a REAL value on this seam, not merely the optionality of the
+ * key: ObjectQL's `ScopedRepo.execute()` — the second `executeAction` call site
+ * — passes an action context carrying neither `user` nor `session`, so both
+ * arms of `body-runner.ts:340` resolve to `undefined`.
+ */
+export const absentUser: ScriptUser = undefined;
+
+/** Both faces assembled at the real seam, so the field's own type is pinned too. */
+export const actionSeamContext: ScriptContext = {
+  input: { amount: 100 },
+  user: actionProducerShape,
+  session: { userId: 'usr_admin', organizationId: 'org_1', positions: ['platform_admin'] },
+};
+
+export const hookSeamContext: ScriptContext = {
+  input: { id: 'rec_1' },
+  user: hookProducerShape,
+  session: { userId: 'usr_admin', organizationId: 'org_1' },
+  event: 'beforeInsert',
+  object: 'crm_case',
+};
+
+/** A body-less / system dispatch: the seam carries no caller at all. */
+export const anonymousSeamContext: ScriptContext = { input: {} };
+
+/**
+ * The practical payoff, and the same one the sibling `ScriptSession` states:
+ * `id` is declared on BOTH arms, so a consumer reading only the shared key needs no
+ * discrimination. It is `string | undefined` because the hook arm's `id` is
+ * optional — narrower than `unknown` by exactly the useful amount.
+ */
+export const sharedIdIsReadable = (ctx: ScriptContext): string | undefined => ctx.user?.id;
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * NEGATIVE — must NOT assign. An unused suppression here IS the failure.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/** A fourth dispatch face inventing its own vocabulary — the #5372 mechanism. */
+// @ts-expect-error - an arbitrary shape is not a producer shape (#5521)
+export const inventedShape: ScriptUser = { currentUser: 'usr_admin', tenant: 'org_1' };
+
+/** A declared key carrying the wrong type. */
+// @ts-expect-error - `id` is a string on both arms (#5521)
+export const wrongIdType: ScriptUser = { id: 42 };
+
+/** The caller is an object on every path, never a bare identifier. */
+// @ts-expect-error - a user id string is not a user (#5521)
+export const primitiveUser: ScriptUser = 'usr_admin';
+
+/**
+ * Action-SHAPED but incomplete — the failure mode #5372 actually shipped, where
+ * a dispatcher hand-rolled a partial envelope. Rejected because it satisfies
+ * neither arm: `ActorUser` requires the aliases and both authority channels,
+ * and this shares no key with the hook shortcut, so the weak-type check refuses
+ * it there ("no properties in common").
+ */
+// @ts-expect-error - a partial ActorUser is not an ActorUser (#5521)
+export const partialActionShape: ScriptUser = { userId: 'usr_admin', positions: ['platform_admin'] };
+
+/**
+ * ⚠️ The limit of this union, pinned as a POSITIVE because it is what actually
+ * compiles — stated here rather than left for the next reader to discover.
+ *
+ * A partial action envelope that happens to carry a hook-arm key assigns, via
+ * the hook arm. Two ordinary TypeScript rules combine to allow it: the hook arm
+ * is a WEAK type (every key optional), so one matching key is enough to satisfy
+ * it; and excess-property checking on a union rejects only keys present in NO
+ * member, so `positions` — real on the `ActorUser` arm — is not excess here.
+ *
+ * A union of two undiscriminated producer shapes cannot do better, and neither
+ * can the sibling `ScriptSession`, whose `ActionSession` arm is all-optional
+ * for the same reason. What the declaration buys is not a proof of
+ * well-formedness; it is that a shape sharing NOTHING with either producer
+ * ({@link inventedShape}) is now refused where `unknown` accepted it silently.
+ * Closing the remaining gap would need a discriminant on the seam — the body
+ * kind, which this interface deliberately does not carry (see `ScriptSession`).
+ */
+export const partialShapeBorrowingHookArm: ScriptUser = {
+  id: 'usr_admin',
+  positions: ['platform_admin'],
+};
+
+/**
+ * The spec's `EvalUser` (ADR-0068 D1) — the issue's option 1, refused on
+ * MEASUREMENT rather than taste. It is a SUPERSET of what the hook side
+ * delivers (`buildUser()` emits no `positions`) and a SUBSET of what the action
+ * side delivers, so it describes neither producer. `ActorUser extends EvalUser`
+ * keeps the ADR-0068 contract on the path that actually has it.
+ */
+// @ts-expect-error - EvalUser is not a producer shape on this seam (#5521)
+export const bareEvalUser = (u: EvalUser): ScriptUser => u;
+
+/**
+ * The union did not collapse to `ActorUser`: `positions` is unreadable without
+ * discriminating the body kind, because the hook arm has no such key. This is
+ * the over-narrowing guard stated from the READ side — if someone later
+ * declares `user?: ActorUser`, this suppression goes unused and fails.
+ */
+export const positionsNeedDiscrimination = (ctx: ScriptContext): unknown =>
+  // @ts-expect-error - `positions` exists on the action arm only (#5521)
+  ctx.user?.positions;

--- a/packages/runtime/src/security/index.ts
+++ b/packages/runtime/src/security/index.ts
@@ -26,6 +26,14 @@ export {
   type RateLimitKeyKind,
   type RateLimitLogger,
 } from './inbound-rate-limit.js';
+// The dispatch-side arm of the sandbox seam's `ScriptUser` union (#5521).
+// Exported as a TYPE only: `ScriptUser` is public, so both its arms must be
+// nameable by a consumer that wants to discriminate one — the sibling
+// `ScriptSession`'s arms (`ActionSession`, `HookContext['session']`) already
+// are, being spec types. The builders stay internal; nothing outside this
+// package produces an `ActorUser`, and #5372's whole point is that there is
+// exactly ONE producer.
+export type { ActorUser } from './actor-user.js';
 export {
   API_KEY_PREFIX,
   hashApiKey,


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5521

沙箱接缝 `ScriptContext` 的 `user` 字段此前是 `unknown`,类型系统对它一无所知。issue 说得很准:第四个 dispatch 面明天再手搓一个 user 字面量,编译器不会说一句话 —— 而"三个 dispatcher 手搓出三种形状"正是 #5372 的成因,它能存在几个版本,部分原因就是**没有任何声明可以违背**。

本 PR 按 #5991 的模子,把它收窄成命名联合 `ScriptUser = ActorUser | HookContext['user']`。**行为零变化**,纯类型面。

---

## 一、测量(#5991 同一测法,针对 `user` 面 —— 先测后改)

基线 `origin/main` @ `f6609e6ae`。

### 写入方(2 处,均在 `packages/runtime/src/sandbox/body-runner.ts`)

| # | 位置 | 表达式 | 第一支的真实生产者 | 第二支 |
|---|---|---|---|---|
| W1 | `body-runner.ts:315` `buildSandboxContext` | `engineCtx?.user ?? engineCtx?.session?.user` | `HookContext['user']` — ObjectQL `buildUser()`(`packages/objectql/src/engine.ts:1745`) | **死支**,见第二节 |
| W2 | `body-runner.ts:340` `buildActionSandboxContext` | `actionCtx?.user ?? actionCtx?.session?.user` | `ActorUser`(`packages/runtime/src/security/actor-user.ts:76`),由 REST `/actions`(`domains/actions.ts:325`)与 MCP `run_action`(`action-execution.ts:1013`)经 `actorUserFromExecutionContext()` 构造 | **死支** |

两个形参类型都是 `any` ⇒ 收窄后表达式类型仍是 `any`,两处赋值一律编译通过,无需改写入方。

### 读取方(全仓,非测试)—— 逐点:文件:行号 / 收的类型 / 收窄后是否仍编译

| # | 位置 | 收的类型 | 收窄后仍编译 |
|---|---|---|---|
| R1 | `packages/runtime/src/sandbox/quickjs-runner.ts:489` `installCtx` → `setObjectJson(vm, ctxObj, 'user', ctx.user)` | `setObjectJson(…, v: unknown)`(同文件 `:1031`) | ✅ |

**全仓非测试读取方就这一处。** 派发令转述的分诊预判"`user` 的读取方比 `session` 多"在 **TS 类型面上不成立**,如实记录:多出来的读取方全部在 VM **内部**(body 作者写的 `ctx.user.id` 之类),那是交给 QuickJS 的 JS 源码字符串,不经 tsc,收窄影响不到它们。所以 `user` 面的读取点拓扑与 `session` 面**相同**,不是更复杂。

测试面构造 `ScriptContext` 字面量而带 `user` 的只有 `quickjs-runner.test.ts:275`(`user: { id: 'u1' }`),经 `HookContext['user']` 支合法。

### 跨仓

分诊 08-07 06:55Z 已核 `ScriptContext` 在 objectui / cloud **零命中**(含阳性对照),本轮按派发令免重跑。收窄面止于 `packages/runtime` —— 并由下面的全仓 `turbo run typecheck` 125/125 独立复核。

---

## 二、必答项:两写入方的 `?? …session?.user` 兜底链是否逼出联合第三支?

**否 —— 而且这条兜底链的第二支在两个写入方上都是死支(#4984 死肢家族)。** 逐条证据:

- **hook 侧(W1)**:`HookContext['session']` 的键集是 `userId` / `actor` / `organizationId` / `accessToken` / `isSystem` / `skipTriggers` / `skipAutomations` / `positions` / `preserveAudit`(外加 `roles` 墓碑),**没有 `user` 键**(`packages/spec/src/data/hook.zod.ts:386-536`);唯一生产者 `ObjectQLEngine.buildSession()`(`packages/objectql/src/engine.ts:1647-1690`)逐字段构造,同样不写 `user`。
- **action 侧(W2)**:`ActionSession` 的键集是 `userId` / `organizationId` / `positions` / `roles`(弃用别名),**没有 `user` 键**(`packages/spec/src/ui/action-params.zod.ts:237-336`);唯一生产者 `buildActionSession()`(`packages/runtime/src/action-execution.ts:811-823`)只写这四个键。

⇒ 联合恰好两支,**未越出照抄 `ScriptSession` 模子的范围**。

本 PR **不动**这条死肢:它是运行时表达式,本单的授权是"给接缝钉类型",顺手删表达式属于扩范围;已按 Prime Directive #10 另行立单(见文末)。

### 一处真实的第三种取值(是取值,不是第三个形状)

`ScopedRepo.execute()`(`packages/objectql/src/engine.ts:7400-7407`)是 `executeAction` 的**第二个**调用点,传的 ctx 是 `{ ...params, userId, tenantId, roles }` —— 既无 `user` 也无 `session`,该路径上 `ctx.user` 恒为 `undefined`。`undefined` 已被 `user?:` 的可选性(以及 `HookContext['user']` 自带的 optional)覆盖,不需要额外联合支。这条已写进 `ScriptUser` 的 docblock,免得下个读者以为 `undefined` 只是拼写上的宽松。

---

## 三、与 #5991(`ScriptSession`)模子的对齐 / 偏离

**对齐**(照抄):导出命名联合而非单型;成员是**真实生产者形状**而非发明的契约;`undefined` 经 spec 侧 optional 自然成为成员;类型放在同一个 `script-runner.ts`、紧邻姊妹字段;docblock 写清"为什么不是单型"。

**偏离,三处,均有测量支撑:**

1. **成员不是两个 spec 契约,而是"一个 runtime interface + 一个 spec 契约"**。`ScriptSession` 两支都来自 spec(`ActionSession` / `HookContext['session']`);`user` 的 action 侧生产者 `ActorUser` 今天只有 runtime 的 TS interface、无 spec 契约 —— 这一点已记在 #6011,按派发令**不归本单**,本 PR ⛔ 不发明 spec 契约。
2. **⛔ 不用 `EvalUser`(issue 选项 1),这是被实测否掉的,不是口味问题**。`EvalUser`(ADR-0068 D1)要求 `id: string` **且** `positions: string[]`,而 hook 侧的 `buildUser()` 根本不产 `positions` 键。所以 `EvalUser` 是 hook 侧交付形状的**超集**,拿它当"最小公分母"会在 hook 面断言一个从不存在的键 —— 与直接收成 `ActorUser` 是同一种过度声明,只是套了层 spec 外衣。`ActorUser extends EvalUser`,所以真正有这套契约的 action 路径一点没丢。选项 3(改用闸门)未采纳:类型是这里更便宜、更精确的通道,且 `ScriptSession` 已立先例。
3. **额外导出 `ActorUser`(仅类型)**。`ScriptSession` 两支都能被消费者命名(都是公开 spec 类型),`ScriptUser` 要对等就得让 `ActorUser` 也可命名,否则导出了联合却没法指名它的一支。只导出 `type`,构造函数保持内部 —— #5372 的要义就是**只有一个生产者**。

---

## 四、类型钉子放在哪(#6220 的教训)

⚠️ `packages/runtime/tsconfig.json` **排除**所有 `.test.ts` / `.spec.ts`,而它的 `typecheck` 就是一句 `tsc --noEmit`。**钉在 runtime 的测试文件里 = phantom check** —— 没有任何 tsc program 编译它,删掉指令每个闸门照样绿,这正是 `check:type-check-coverage` 的 `PINS_CHECKED` 不变式所说的情形,且 `PHANTOM_PIN_DEBT` 已对新条目关闭。

所以钉子落在 **`packages/runtime/src/sandbox/script-user-type-assertions.ts`** —— `include` 覆盖 `src` 树、不被测试排除规则命中的普通 src 模块,与既有先例 `packages/spec/src/ui/app.nav-type-assertions.ts` 同形。它不被任何 tsup entry 或 barrel 引用(`entry: ['src/index.ts']`),不进产物。

已有的运行时钉 `packages/runtime/src/action-ctx-user-shape.test.ts`(#5372,逐键逐值断言三条 dispatch 路径相等)**按派发令引用而不重复**:它钉的是 VALUE,本文件钉的是 TYPE,而 VALUE 钉恰好覆盖不到本单要防的那种事 —— 一个**新的**第四 dispatch 面,因为 pin 只能检查它点名的生产者。

钉子分两族:正向(两个真实生产者形状仍可赋 —— 这是**防过度收窄**的一半:一旦有人把联合塌成 `ActorUser`,hook 支的断言立刻红)与反向 `@ts-expect-error`(垃圾形状、错类型 `id`、裸字符串、缺键的 action envelope、裸 `EvalUser`,以及读取侧 `ctx.user?.positions` 必须先判别 body 种类)。

### 一条钉子的预设被证伪,如实改掉而不是硬凑

原本想钉"`{ id, positions }` 这种半截 action envelope 应当编译红"。**实测它是绿的**,tsc 报 `TS2578: Unused '@ts-expect-error' directive`。原因是两条普通 TS 规则叠加:hook 支是 weak type(键全可选),命中一个键即满足;而联合上的 excess-property 检查只拒绝**在所有成员里都不存在**的键,`positions` 在 `ActorUser` 支上是真键,所以不算 excess。

于是把它改成两条**诚实**的钉子:一条反向钉真正成立的情形(`{ userId, positions }` —— 与 hook 支无公共键,被 weak-type 检查拒绝),一条把上面那个能编译的情形**作为正向断言显式写下来**,并在注释里说明这就是"两个无判别式的生产者形状取联合"的能力上限,姊妹字段 `ScriptSession` 因为 `ActionSession` 同样全可选而有完全一样的上限。声明买到的不是形状良构性证明,而是"与两个生产者都毫无交集的形状(如 `inventedShape`)从此被拒",这是 `unknown` 下静悄悄放行的那一类。

---

## 五、反向验证(先预测,后执行)

**做法**:把 `ScriptUser` 与字段**一起**临时放宽回 `unknown`。两处一起放宽才是真正的"改动前"状态 —— 只改字段而留着别名的话,直接标注 `: ScriptUser` 的钉子根本不受影响,那是假反向验证。

**预测(执行前写死,含一条反模板的)**:方向是红,但**不是**均匀的 6 条 TS2578。5 条赋值型反向钉会因"任何形状都能赋给 `unknown`"变成未使用(TS2578);正向读取钉 `sharedIdIsReadable` 没有抑制指令,会真错;而 `positionsNeedDiscrimination` **不会红** —— 它压的错误只是从"联合上无此键"换成"读不了无类型值",抑制指令照样用得上。

**实测**:6 条错误,与预测的**条数与归属完全一致**:

```
script-user-type-assertions.ts(132,1): error TS2339: Property 'id' does not exist on type '{}'.   ← sharedIdIsReadable(正向,无抑制)
script-user-type-assertions.ts(139,1): error TS2578: Unused '@ts-expect-error' directive.          ← inventedShape
script-user-type-assertions.ts(143,1): error TS2578: Unused '@ts-expect-error' directive.          ← wrongIdType
script-user-type-assertions.ts(147,1): error TS2578: Unused '@ts-expect-error' directive.          ← primitiveUser
script-user-type-assertions.ts(157,1): error TS2578: Unused '@ts-expect-error' directive.          ← partialActionShape
script-user-type-assertions.ts(190,1): error TS2578: Unused '@ts-expect-error' directive.          ← bareEvalUser
```

`positionsNeedDiscrimination` 如预测**未报错**。

**与预测的唯一出入(如实记录)**:132 行的错误码是 `TS2339`(`'{}'` 上没有 `id`)而非我预测的 `TS18046`(值为 `unknown`)—— 因为 `?.` 先把 `unknown` 里的 null/undefined 排掉,剩下 `{}`,再去读属性。同一类事实(无类型的值读不出属性),错误码不同。

已还原,并与放宽前的备份逐字节 `diff` 确认一致。

---

## 六、验证

| 命令 | 结果 |
|---|---|
| `pnpm --filter @objectstack/runtime typecheck` | ✅ 绿(`tsc --noEmit` 无输出) |
| `pnpm --filter @objectstack/runtime test` | ✅ **106 个测试文件 / 1514 个用例全通过** |
| `turbo run typecheck --concurrency=2`(全仓) | ✅ **125 / 125 successful** —— 与 #5991 同一口径,证明收窄面止于 runtime 包内 |
| `pnpm lint` | ✅ 无输出 |
| `pnpm check:type-check-coverage` | ✅ OK(含 `PINS_CHECKED`:新钉子确实在 tsc program 内) |
| `pnpm check:nul-bytes` | ✅ OK(5958 个 tracked 文本文件,无裸控制字节) |
| `pnpm check:empty-changeset` / `check:adr-anchors` / `check:org-identifier` | ✅ OK |

---

## 七、文件面

- `packages/runtime/src/sandbox/script-runner.ts` —— 新增 `ScriptUser` 联合 + `user?: ScriptUser`(唯一的行为无关类型改动)
- `packages/runtime/src/sandbox/script-user-type-assertions.ts` —— **新增**,类型钉子
- `packages/runtime/src/sandbox/index.ts` / `src/index.ts` —— 导出 `ScriptUser`
- `packages/runtime/src/security/index.ts` / `src/index.ts` —— 导出 `type ActorUser`
- `.changeset/light-berries-tickle.md` —— `@objectstack/runtime` patch

`body-runner.ts` / `quickjs-runner.ts` 按派发令**只读,零改动** —— 收窄没有暴露任何写入方类型错误(两个写入方从 `any` 赋值)。⛔ 未触碰 `standalone-stack.ts`(#5820 在飞)与 `action-execution.ts` / `domains/data.ts` / `endpoint-policy.ts`(#6244 落地中);未碰 `content/docs/releases/`、未碰 `pnpm-lock.yaml`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wbxm29qPKnLf44AbSxizqW)_