### PR TITLE
ci(check-links): 恢复 pull_request 断链门,仅检仓内链接、advisory-first (#6028)

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,21 +1,33 @@
 name: Check Links
 
+# Repo-internal link gate (#6028).
+#
+# `pull_request` was commented out in a59dc59e (2026-01-28) as a rider on an
+# unrelated commit, with no rationale recorded; the gate then sat dormant for
+# six months while `lychee.toml` and `fail: true` kept it looking alive.
+# Maintainer ruling 2026-08-07: restore the trigger, check REPO-INTERNAL links
+# only, and land it advisory-first (NOT in the required set) until it has shown
+# a stable green streak.
+#
+# ⛔ No `merge_group` trigger on purpose: this is an advisory lane, and an
+# advisory gate does not get to consume merge-queue capacity. If it is ever
+# promoted into the required set, `merge_group` MUST be added in the same
+# change or the queue stalls on a required check that never reports (#6121).
 on:
   workflow_dispatch:
-  # push:
-  #   branches:
-  #     - main
-  # pull_request:
-  #   branches:
-  #     - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   link-checker:
     name: Check Documentation Links
     runs-on: ubuntu-latest
+    # Least privilege: the job only reads the tree and runs lychee offline.
+    # There is no issue-filing step, and `--offline` makes zero network
+    # requests, so neither `issues: write` nor a GITHUB_TOKEN is needed.
     permissions:
       contents: read
-      issues: write
 
     steps:
       - name: Checkout repository
@@ -24,14 +36,32 @@ jobs:
       - name: Check links with lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          # Use configuration file for path remapping and settings
+          # `--offline` is the internal-only mechanism, and it lives HERE rather
+          # than in lychee.toml on purpose: the equivalent `offline = true`
+          # config key is silently ignored by older lychee (measured: ignored on
+          # 0.19.1, honoured on the 0.24.2 this action pins). A determinism
+          # guarantee must not depend on which lychee the action happens to
+          # install, so it is asserted at the invocation site.
+          #
+          # Offline means only `file://` targets are resolved -- every http(s)
+          # link is reported EXCLUDED, never requested. That is what makes this
+          # gate deterministic and free of external-network flake.
+          #
+          # --root-dir is what makes ROOT-RELATIVE links checkable. Most internal
+          # links in content/** are site routes (`/docs/permissions`), and lychee
+          # hard-errors on those unless it is told which directory `/` means.
+          # The Fumadocs content root is `content/`, so `/docs/x` resolves to
+          # content/docs/x -- and --fallback-extensions supplies the .mdx/.md
+          # suffix that a site route omits. Without this pair the gate cannot go
+          # green at all: 1286 root-relative links fail as "Cannot resolve
+          # root-relative link ... provide a root dir".
           args: >-
+            --offline
+            --root-dir ${{ github.workspace }}/content
+            --fallback-extensions mdx,md
             --config lychee.toml
             'content/**/*.md'
             'content/**/*.mdx'
             'README.md'
           # Fail the job if broken links are found
           fail: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/README.md
+++ b/README.md
@@ -321,7 +321,6 @@ For the browser, the typed client SDK and React hooks (`useQuery` / `useMutation
 | [`@objectstack/service-analytics`](packages/services/service-analytics) | Analytics — aggregations, time series, funnels, dashboards |
 | [`@objectstack/service-automation`](packages/services/service-automation) | Automation engine — flows, triggers, and workflow state machines |
 | [`@objectstack/service-cache`](packages/services/service-cache) | Cache — in-memory, Redis, multi-tier |
-| [`@objectstack/service-feed`](packages/services/service-feed) | Activity feed / chatter |
 | [`@objectstack/service-i18n`](packages/services/service-i18n) | Internationalization service |
 | [`@objectstack/service-job`](packages/services/service-job) | Cron & interval job scheduler |
 | [`@objectstack/service-package`](packages/services/service-package) | Package registry — publish, version, retrieve metadata packages |
@@ -343,7 +342,7 @@ For the browser, the typed client SDK and React hooks (`useQuery` / `useMutation
 | [`@objectstack/cli`](packages/cli) | CLI binary (`os` / `objectstack`) — `init`, `dev`, `start`, `serve`, `compile`, `publish`, `validate`, `generate`, `lint`, `doctor` |
 | [`create-objectstack`](packages/create-objectstack) | Project scaffolder (`npx create-objectstack`) |
 | [`@object-ui/console`](https://github.com/objectstack-ai/objectui/tree/main/apps/console) | Fork-ready runtime console SPA (lives in objectstack-ai/objectui, served via `@object-ui/console` on npm) |
-| [`@objectstack/account`](apps/account) | Account & identity portal — sign in, organizations, connected apps |
+| [`@objectstack/account`](packages/apps/account) | Account & identity portal — sign in, organizations, connected apps |
 | [`@objectstack/docs`](apps/docs) | Documentation site (Fumadocs + Next.js) |
 
 ### Examples

--- a/content/blog/metadata-driven-architecture.mdx
+++ b/content/blog/metadata-driven-architecture.mdx
@@ -583,4 +583,4 @@ ObjectStack is our answer.
 
 ---
 
-*Want to dive deeper? Explore our [technical specifications](/docs/specifications) or join the discussion on [GitHub](https://github.com/objectstack-ai/spec/issues).*
+*Want to dive deeper? Explore our [technical specifications](/docs/references) or join the discussion on [GitHub](https://github.com/objectstack-ai/spec/issues).*

--- a/content/docs/ai/connect-mcp.mdx
+++ b/content/docs/ai/connect-mcp.mdx
@@ -113,7 +113,7 @@ full-authority local agent, mint the key on a platform-admin or dedicated
 **service** identity; for a scoped one, mint it on a user with exactly the
 access it should have. See
 [environment variables](/docs/deployment/environment-variables#mcp-server) for
-the switches and [ADR-0101](/adr/0101-mcp-stdio-principal-admission) for the
+the switches and [ADR-0101](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0101-mcp-stdio-principal-admission.md) for the
 decision.
 
 ## What the agent gets

--- a/content/docs/getting-started/quick-reference.mdx
+++ b/content/docs/getting-started/quick-reference.mdx
@@ -76,13 +76,12 @@ Plugin architecture, manifests, and kernel runtime.
 | **[Metadata Loader](/docs/references/kernel/metadata-loader)** | `metadata-loader.zod.ts` | MetadataLoaderContract | Metadata loading |
 | **[Package Registry](/docs/references/kernel/package-registry)** | `package-registry.zod.ts` | InstalledPackage, InstallPackageRequest | Package resolution |
 
-## System Protocol (19 schemas)
+## System Protocol (18 schemas)
 
 Runtime environment, logging, jobs, caching, and observability.
 
 | Protocol | Source File | Key Schemas | Purpose |
 |:---------|:-----------|:------------|:--------|
-| **[Audit](/docs/references/system/audit)** | `audit.zod.ts` | AuditEvent, AuditConfig | Audit trail logging |
 | **[Auth Config](/docs/references/system/auth-config)** | `auth-config.zod.ts` | AuthConfig | Authentication configuration |
 | **[Cache](/docs/references/system/cache)** | `cache.zod.ts` | CacheConfig | Caching layer |
 | **[Change Management](/docs/references/system/change-management)** | `change-management.zod.ts` | ChangeRequest, RollbackPlan | Change tracking |
@@ -120,7 +119,7 @@ AI/ML capabilities - agents, skills, tools, MCP exposure, RAG, and cost tracking
 | **[Usage](/docs/references/ai/usage)** | `usage.zod.ts` | AIUsageRecord, TokenUsage | AI usage and cost tracking |
 | **[Solution Blueprint](/docs/references/ai/solution-blueprint)** | `solution-blueprint.zod.ts` | BlueprintObject, BlueprintApp | Blueprint format for AI app generation |
 
-## API Protocol (19 schemas)
+## API Protocol (17 schemas)
 
 REST/GraphQL endpoints, real-time subscriptions, and discovery.
 
@@ -130,7 +129,6 @@ REST/GraphQL endpoints, real-time subscriptions, and discovery.
 | **[Endpoint](/docs/references/api/endpoint)** | `endpoint.zod.ts` | ApiEndpoint, ApiMapping | REST endpoint configuration |
 | **[Router](/docs/references/api/router)** | `router.zod.ts` | Router, Route | API routing rules |
 | **[OData](/docs/references/api/odata)** | `odata.zod.ts` | ODataQuery | OData protocol support |
-| **[GraphQL](/docs/references/api/graphql)** | `graphql.zod.ts` | GraphQLConfig, FederationEntity | GraphQL API config |
 | **[Realtime](/docs/references/api/realtime)** | `realtime.zod.ts` | Subscription, RealtimeEvent | WebSocket subscriptions |
 | **[WebSocket](/docs/references/api/websocket)** | `websocket.zod.ts` | WebSocketConfig | WebSocket protocol |
 | **[Discovery](/docs/references/api/discovery)** | `discovery.zod.ts` | Discovery, ServiceInfo | API discovery and metadata |
@@ -143,7 +141,6 @@ REST/GraphQL endpoints, real-time subscriptions, and discovery.
 | **[Analytics](/docs/references/api/analytics)** | `analytics.zod.ts` | Analytics | API usage analytics |
 | **[Documentation](/docs/references/api/documentation)** | `documentation.zod.ts` | Documentation | API docs generation |
 | **[Metadata](/docs/references/api/metadata)** | `metadata.zod.ts` | Metadata | API metadata endpoints |
-| **[Registry](/docs/references/api/registry)** | `registry.zod.ts` | Registry | API registry |
 | **[Storage](/docs/references/api/storage)** | `storage.zod.ts` | Storage | API storage operations |
 
 ## Automation Protocol (5 schemas)
@@ -188,7 +185,7 @@ Environments, marketplace, licensing, and multi-tenancy.
 | **[Environment](/docs/references/cloud/environment)** | `environment.zod.ts` | Environment, EnvironmentType | Deployment environments |
 | **[Marketplace](/docs/references/cloud/marketplace)** | `marketplace.zod.ts` | MarketplaceListing, PackageSubmission | Plugin marketplace |
 | **[Plugin Registry](/docs/references/kernel/plugin-registry)** | `plugin-registry.zod.ts` | PluginRegistryEntry, PluginVendor | Plugin registry entries and quality metrics |
-| **[Plugin Security](/docs/references/cloud/plugin-security)** | `plugin-security.zod.ts` | PluginSecurityProtocol, SBOM | Plugin security policies |
+| **[Plugin Security](/docs/references/kernel/plugin-security)** | `plugin-security.zod.ts` | PluginSecurityProtocol, SBOM | Plugin security policies |
 | **[Tenant](/docs/references/cloud/tenant)** | `tenant.zod.ts` | Tenant | Multi-tenancy isolation |
 
 ## Integration Protocol (1 schema)
@@ -214,7 +211,7 @@ Common utilities used across all protocols.
 | **[HTTP](/docs/references/shared/http)** | `http.zod.ts` | HttpRequest, HttpMethod, CorsConfig | HTTP utilities |
 | **[Identifiers](/docs/references/shared/identifiers)** | `identifiers.zod.ts` | SystemIdentifier, SnakeCaseIdentifier | Standard ID patterns |
 | **[Mapping](/docs/references/shared/mapping)** | `mapping.zod.ts` | FieldMapping | Field mapping utilities |
-| **[Connector Auth](/docs/references/shared/connector-auth)** | `connector-auth.zod.ts` | ConnectorAuthConfig | Connector auth patterns |
+| **Connector Auth** | `connector-auth.zod.ts` | ConnectorAuthConfig | Connector auth patterns |
 
 ## QA Protocol (1 schema)
 

--- a/content/docs/kernel/services-checklist.mdx
+++ b/content/docs/kernel/services-checklist.mdx
@@ -185,7 +185,7 @@ no message. Below is the former — the fallback case:
 
 A service may self-declare that it is not the full thing (ADR-0076 D12), via a
 `__serviceInfo: { status, handlerReady?, message? }` property on the registered
-instance — see [Services → presence is not capability](./services.mdx) for how
+instance — see [Services → presence is not capability](./services-probe-6028-does-not-exist.mdx) for how
 an in-process caller reads it. The two values mean different things, and for the
 HTTP surface the difference is load-bearing (#4058):
 

--- a/content/docs/kernel/services-checklist.mdx
+++ b/content/docs/kernel/services-checklist.mdx
@@ -185,7 +185,7 @@ no message. Below is the former — the fallback case:
 
 A service may self-declare that it is not the full thing (ADR-0076 D12), via a
 `__serviceInfo: { status, handlerReady?, message? }` property on the registered
-instance — see [Services → presence is not capability](./services-probe-6028-does-not-exist.mdx) for how
+instance — see [Services → presence is not capability](./services.mdx) for how
 an in-process caller reads it. The two values mean different things, and for the
 HTTP surface the difference is load-bearing (#4058):
 

--- a/content/docs/permissions/attachments-access.mdx
+++ b/content/docs/permissions/attachments-access.mdx
@@ -103,7 +103,7 @@ an auth service is wired, and stamp `owner_id` on the new `sys_file`.
 
 Deleting attachments does not immediately delete the underlying bytes (a file
 can be shared across records). Reclamation is handled by the platform LifecycleService via declarative
-[reap guards](/adr/0057-system-data-lifecycle-and-retention):
+[reap guards](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0057-system-data-lifecycle-and-retention.md):
 
 - **`sys_file`** — when the last `sys_attachment` referencing an
   attachments-scope file is deleted, the file is tombstoned; a reap guard

--- a/content/docs/permissions/authorization.mdx
+++ b/content/docs/permissions/authorization.mdx
@@ -409,16 +409,16 @@ The complete, prioritized gap map lives in issue **#2561** (the production
 
 | ADR | Owns |
 |---|---|
-| [0049](/adr/0049-no-unenforced-security-properties) | No unenforced security properties (enforce / mark / remove) |
-| [0054](/adr/0054-runtime-proof-for-authorable-surface) | Prove-it-runs — high-risk classes need runtime proofs |
-| [0056](/adr/0056-permission-model-landing-verification) | Permission-model landing: OWD, anonymous deny default, D10 matrix |
-| [0057](/adr/0057-erp-authorization-core-business-units-and-scope-depth) | Business units, scope depth, declarative RBAC seeding, platform-owned assignment |
-| [0066](/adr/0066-unified-authorization-model) | Unified model: capability registry, posture, precedence, future refinements |
-| [0068](/adr/0068-unified-user-context-and-built-in-identity-roles) | Built-in identity positions (formerly "identity roles"), `EvalUser` |
-| [0069](/adr/0069-enterprise-authentication-hardening) | Enterprise authentication hardening (phased) |
-| [0078](/adr/0078-no-silently-inert-metadata) | No inert declarable metadata |
-| [0086](/adr/0086-authz-metadata-config-boundary-and-cross-package-composition) | Metadata↔config boundary, package provenance, cross-package composition |
+| [0049](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0049-no-unenforced-security-properties.md) | No unenforced security properties (enforce / mark / remove) |
+| [0054](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0054-runtime-proof-for-authorable-surface.md) | Prove-it-runs — high-risk classes need runtime proofs |
+| [0056](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0056-permission-model-landing-verification.md) | Permission-model landing: OWD, anonymous deny default, D10 matrix |
+| [0057](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0057-erp-authorization-core-business-units-and-scope-depth.md) | Business units, scope depth, declarative RBAC seeding, platform-owned assignment |
+| [0066](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0066-unified-authorization-model.md) | Unified model: capability registry, posture, precedence, future refinements |
+| [0068](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0068-unified-user-context-and-built-in-identity-roles.md) | Built-in identity positions (formerly "identity roles"), `EvalUser` |
+| [0069](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0069-enterprise-authentication-hardening.md) | Enterprise authentication hardening (phased) |
+| [0078](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0078-no-silently-inert-metadata.md) | No inert declarable metadata |
+| [0086](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0086-authz-metadata-config-boundary-and-cross-package-composition.md) | Metadata↔config boundary, package provenance, cross-package composition |
 | 0090 | Permission Model v2: position rename + vocabulary freeze, profile removal, fail-closed OWD default + external dial, audience anchors, principal taxonomy, publish linter, delegated administration, explain engine + access matrix |
 | 0091 | Grant lifecycle: validity windows + resolution-time filtering (L1, landed), delegation, break-glass, recertification substrate |
-| [0096](/adr/0096-execution-surface-identity-admission) | Execution-surface identity admission — no data-engine call without an explicit principal (the MCP HTTP surface admits identity here) |
-| [0101](/adr/0101-mcp-stdio-principal-admission) | MCP stdio principal admission — env-supplied API-key identity, fail-closed, no `system` bypass |
+| [0096](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0096-execution-surface-identity-admission.md) | Execution-surface identity admission — no data-engine call without an explicit principal (the MCP HTTP surface admits identity here) |
+| [0101](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0101-mcp-stdio-principal-admission.md) | MCP stdio principal admission — env-supplied API-key identity, fail-closed, no `system` bypass |

--- a/content/docs/references/automation/state-machine.mdx
+++ b/content/docs/references/automation/state-machine.mdx
@@ -21,7 +21,7 @@ The ledger carried these shapes as `authorable (p)` — provisional, because
 
 nobody had checked. Checking matters here more than usual, because
 
-[ADR-0020](../../../docs/adr/0020-state-machine-converge-and-enforce.md)
+[ADR-0020](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0020-state-machine-converge-and-enforce.md)
 
 **retired this shape as a record-lifecycle declaration**: the top-level
 

--- a/content/docs/references/automation/state-machine.mdx
+++ b/content/docs/references/automation/state-machine.mdx
@@ -8,69 +8,42 @@ description: State Machine protocol schemas
 @module automation/state-machine
 
 XState-inspired State Machine Protocol — hierarchical states, guarded
-
 transitions, entry/exit actions. Used to declare strict business-logic
-
 constraints and lifecycle management, so an AI author cannot "hallucinate" a
-
 transition the machine never declared.
 
 ## Where this is authored — the question #4001 had to answer first
 
 The ledger carried these shapes as `authorable (p)` — provisional, because
-
 nobody had checked. Checking matters here more than usual, because
-
 [ADR-0020](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0020-state-machine-converge-and-enforce.md)
-
 **retired this shape as a record-lifecycle declaration**: the top-level
-
 `workflow` metadata type and `object.stateMachines` are both gone, and a
-
 record's legal transitions are declared as a `state_machine` **validation
-
-rule** (`[data/validation.zod.ts](/docs/references/data/validation)`, a flat `\{ from: [to] \}` table — closed
-
+rule** (`data/validation.zod.ts`, a flat `{ from: [to] }` table — closed
 since #4001 batch 3b). A schema whose only doors were those two would be
-
 dead surface, and the campaign's own rule is that dead surface gets its
-
 ledger class corrected, not tightened.
 
-One door survives, and it is an authoring door: **`[ai/agent.zod.ts](/docs/references/ai/agent)`'s
-
+One door survives, and it is an authoring door: **`ai/agent.zod.ts`'s
 `lifecycle`** is `StateMachineSchema`, and `agent` is a registered metadata
-
-type — so `defineStack(\{ agents \})`, `POST /api/v1/meta/types/agent` and the
-
+type — so `defineStack({ agents })`, `POST /api/v1/meta/types/agent` and the
 Studio agent form all reach this file through `AgentSchema.parse()`. Verified
-
 by parse, not by reading: before this change,
 
 ```ts
-
-AgentSchema.parse(\{ …, lifecycle: \{
-
-id: 'probe_machine', initial: 'draft', stats: \{ runs: 3 \},
-
-states: \{ draft: \{ onn: \{ APPROVE: 'done' \}, meta: \{ labell: 'Draft', owner: 'ops' \} \},
-
-done: \{ type: 'final' \} \},
-
-\} \})
-
+AgentSchema.parse({ …, lifecycle: {
+  id: 'probe_machine', initial: 'draft', stats: { runs: 3 },
+  states: { draft: { onn: { APPROVE: 'done' }, meta: { labell: 'Draft', owner: 'ops' } },
+            done: { type: 'final' } },
+} })
 ```
 
 **succeeded**, returning
-
-`\{ id, initial, states: \{ draft: \{ type: 'atomic', meta: \{\} \}, done: … \} \}` —
-
+`{ id, initial, states: { draft: { type: 'atomic', meta: {} }, done: … } }` —
 `stats` gone, `meta`'s two keys gone, and `onn` (one keystroke from `on`)
-
 gone with every transition the author declared. A state machine whose whole
-
 purpose is to *deny* undeclared transitions had silently become one with no
-
 transitions at all, and reported success.
 
 So: `authorable`, and every shape below is `strictObject`.
@@ -78,23 +51,14 @@ So: `authorable`, and every shape below is `strictObject`.
 ## `meta` is closed, deliberately
 
 XState treats `meta` as an open bag, so leaving it open was the plausible
-
 call and it was checked rather than assumed (the #4909 precedent: a slot
-
 whose openness is real should say `.passthrough()`, not strip). Three facts
-
 say closed here: the hand-written `StateNodeConfig` type beside this
-
 schema declares exactly four `meta` keys, so `passthrough` would open the
-
 Zod while `tsc` stayed shut — a new declared-≠-enforced split; nothing in
-
 this repo reads any `meta` key (`aiInstructions` has no consumer outside
-
 this file's own test); and the current behaviour is not openness but
-
-*strip* — the probe above shows an author's `meta` arriving as `\{\}`. There
-
+*strip* — the probe above shows an author's `meta` arriving as `{}`. There
 is no openness here to preserve, only a silence to end.
 
 <Callout type="info">

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,38 +1,51 @@
 # Lychee Link Checker Configuration
-# This configuration enables checking of internal Fumadocs links by remapping
-# Next.js routes to actual file system paths
+#
+# Scope (#6028, maintainer ruling 2026-08-07): this gate checks REPO-INTERNAL
+# links only, deterministically, with zero external-network dependency.
+# `--offline`, `--root-dir` and `--fallback-extensions` are passed on the
+# invocation in .github/workflows/check-links.yml; that file also records why
+# `--offline` is asserted there rather than as a config key here.
+#
+# ⛔ Two keys in this file were HARD parse errors (exit 3 -- the gate dies
+# without checking anything) on the lychee the action pins, and stayed
+# undetected for the six months the gate was dormant. Do not reintroduce them:
+#   - `follow_redirects` is not a valid key at all;
+#   - `include_fragments` is an enum, not a boolean.
+# Whenever this file changes, run lychee against it locally before pushing --
+# a config typo here disables the gate rather than failing it loudly.
 
-# Maximum number of concurrent requests
+# Maximum number of concurrent requests.
+# ⚠️ Inert under `--offline` (no requests are made); kept for a future online lane.
 max_concurrency = 10
 
 # Accept status codes (2xx = success)
+# ⚠️ Inert under `--offline`.
 accept = [200, 204, 206, 301, 302, 307, 308, 429]
 
 # Timeout for requests (in seconds)
+# ⚠️ Inert under `--offline`.
 timeout = 30
 
 # Retry failed requests
+# ⚠️ Inert under `--offline`.
 max_retries = 2
 
-# Follow redirects
-follow_redirects = true
-
-# Check anchors/fragments in links
-include_fragments = false
+# Check anchors/fragments in links.
+# ⛔ Not a boolean on the pinned lychee (0.24.2) -- it takes one of
+# none | anchor-only | text-only | full, and a bare `false` is a HARD parse
+# error. "none" preserves the original `false` semantics: fragments unchecked.
+include_fragments = "none"
 
 # Verbose output
 # Accepts log level: "error", "warn", "info", "debug", "trace"
 verbose = "info"
 
-# Remap internal documentation links to actual file paths
-# Maps /docs/* routes to content/docs/*.mdx or content/docs/*.md files
-# Lychee remap uses simple "pattern" = "replacement" syntax
-remap = [
-    # Primary remapping for .mdx files
-    "^/docs/(.*)$ content/docs/$1.mdx",
-    # Fallback for .md files  
-    "^/docs/(.*)$ content/docs/$1.md"
-]
+# ⛔ No `remap` block. There used to be one claiming to map `/docs/*` routes onto
+# content/docs/*.mdx, and it never fired even once: a root-relative link fails
+# URI construction before remapping is reached. Route resolution is now done by
+# `--root-dir <workspace>/content` + `--fallback-extensions mdx,md`, which is
+# both the supported mechanism and one that demonstrably runs -- 1286 previously
+# unresolvable root-relative links are checked as a result.
 
 # Exclude file paths matching these regex patterns
 exclude_path = [
@@ -41,31 +54,31 @@ exclude_path = [
     "(^|.*/)meta\\.cn\\.json$"
 ]
 
-# Additional exclude patterns for internal paths
+# Additional exclude patterns.
+# ⚠️ Every entry below is inert under `--offline`, which already excludes all
+# non-file schemes; they are kept so a future online lane inherits the intent.
+#
+# ⛔ Do NOT add a `file://...content/docs...` entry here. The old one
+# ("Fumadocs relative links are handled by the framework at runtime") matched
+# nothing, which is the only reason the gate had any coverage left -- had it
+# matched as written it would have excluded the entire scan surface, i.e. the
+# exact links this gate exists to check.
 exclude = [
     # Local development
     "http://localhost*",
     "http://127.0.0.1*",
-    
+
     # Example/placeholder links
     "https://example.com*",
     "http://example.com*",
-    
+
     # Social media (prevents anti-bot false positives)
     "https://twitter.com*",
     "https://x.com*",
-    
+
     # Email links
-    "mailto:*",
-    
-    # Fumadocs relative links (handled by framework at runtime)
-    # These are links like ./agent that resolve to .mdx files
-    "file://**/content/docs/**"
+    "mailto:*"
 ]
 
 # Cache results to speed up subsequent runs
 cache = true
-
-# Specify schemes to check (include file:// for local files)
-# Leaving this unset allows all schemes including file://
-# scheme = ["https", "http", "file"]

--- a/packages/spec/src/automation/state-machine.zod.ts
+++ b/packages/spec/src/automation/state-machine.zod.ts
@@ -12,7 +12,7 @@
  *
  * The ledger carried these shapes as `authorable (p)` — provisional, because
  * nobody had checked. Checking matters here more than usual, because
- * [ADR-0020](../../../docs/adr/0020-state-machine-converge-and-enforce.md)
+ * [ADR-0020](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0020-state-machine-converge-and-enforce.md)
  * **retired this shape as a record-lifecycle declaration**: the top-level
  * `workflow` metadata type and `object.stateMachines` are both gone, and a
  * record's legal transitions are declared as a `state_machine` **validation


### PR DESCRIPTION
Fixes #6028

按维护者 2026-08-07 裁决恢复 `Check Links` 断链门。裁决原文与本 PR 的逐条对应见下。

## 一、裁决 → 实现的逐条对应

| 裁决要求 | 本 PR 的落点 |
| :--- | :--- |
| "re-enable the `pull_request` trigger" | `.github/workflows/check-links.yml` 恢复 `pull_request` (branches: main),`workflow_dispatch` 保留 |
| "with external URLs excluded … checks **repo-relative links deterministically**" | 调用处加 `--offline`(理由见第三节),外链一律 EXCLUDED、零网络请求 |
| "Option ② (keep it dormant, document why) is explicitly rejected" | 被注释掉的 `push:` 残骸按「declared = enforced」**直接删除**,不留空壳 |
| "Land it advisory-first: keep it out of the required set" | ⛔ 未碰 required 集;⛔ 未加 `merge_group` |
| "If the internal-only run turns out noisy in practice, come back here" | 实跑不吵:PR 上 `Check Documentation Links` 绿,1697 条链接 0 error(第六节) |

`fail: true` 原样保留。

## 二、触发器 diff(before / after)

before:

```yaml
on:
  workflow_dispatch:
  # push:
  #   branches:
  #     - main
  # pull_request:
  #   branches:
  #     - main
```

after:

```yaml
on:
  workflow_dispatch:
  pull_request:
    branches:
      - main
```

`push:` 两行注释残骸没有被"恢复",而是被删除 —— **push 触发不在裁决范围内,如需恢复请另议**。裁决只点名了 `pull_request`,而方向②被明确否决之后,把一段注释掉的触发器继续留在文件里就是它反对的那种空壳。

## 三、仅检仓内链接的机制:选 `--offline`,且写在调用处

裁决允许机制自选。选 `--offline` 而不是 `exclude = ["^https?://"]`,并且写在 workflow 的 `args:` 里而不是 `lychee.toml`,两个选择都由实测决定:

**为什么是 `--offline` 而不是 exclude pattern** —— exclude 要逐个枚举远程 scheme,漏一个(`ftp:`、协议相对 `//host/path`、将来任何新 scheme)就重新引入外网依赖;`--offline` 是"不发任何网络请求"的硬保证,结构上做不到漏。

**为什么写在调用处而不是配置文件** —— 实测 `offline = true` 这个配置键:

- lychee **0.19.1**:静默忽略,照常发网络请求(实测 16 个 network error);
- lychee **0.24.2**(`lycheeverse/lychee-action@v2` 当前 `lycheeVersion` 默认值):生效。

一个"确定性"保证不能取决于 action 恰好装了哪个版本 —— 一旦 action 改了默认版本,配置键式的写法会**静默**退回联网。写在调用处则两个版本都生效。

## 四、门休眠半年,配置已经漂移到跑不起来(裁决没预料到的部分)

这是本 PR 比"取消两行注释"多出来的工作量,也是必需的:**只恢复触发器的话,门会以 exit 3 直接死掉,一条链接都不检**。`lychee.toml` 里有两个键在 action 钉住的 0.24.2 上是硬解析错误:

- `follow_redirects` —— 在 0.24.2 上根本不是合法键;
- `include_fragments = false` —— 已从 bool 改成枚举 `none | anchor-only | text-only | full`,裸 `false` 同样硬报错。改为 `"none"`,保持原语义(不检 fragment)。

半年没人跑,所以半年没人发现。这正是"看起来在守而实际不守"的代价。**旁证**:该 workflow 最后几次真实运行(2026-01-28,即触发器被注释掉的当天)全部 failure;此后唯一一次 `pull_request` 运行是 2026-07-17 的 `docs/generator-fixes` 分支,4 次全红。

另外,`content/**` 里的主力内部链接写法是 **root-relative 站点路由**(`/docs/permissions` 这种),而 lychee 在没有 `--root-dir` 时对它们直接报错("Cannot resolve root-relative link ... provide a root dir")。补上 `--root-dir ${{ github.workspace }}/content` + `--fallback-extensions mdx,md` 之后:

| | 检查面 |
| :--- | :--- |
| 修复前(假设配置能解析) | 134 条被检,**1286 条 root-relative 链接完全没检** |
| 修复后 | **1475 条被检**,0 error |

原来的 `remap` 块声称把 `/docs/*` 映射到 `content/docs/*.mdx`,**一次都没生效过**(root-relative 链接在 remap 之前就 URI 构造失败)。按 declared = enforced 删除,能力由真正生效的 `--root-dir` 承接。同时删掉一条 `file://**/content/docs/**` 的 exclude:它实测匹配不到任何东西 —— 而这恰恰是门还剩一点覆盖的唯一原因,**它要是真按字面生效,会把整个扫描面排除掉**。

⚠️ 另一条尝试过并被实测否掉的路线:`--exclude '^/'`(把 root-relative 链接整体排除)。在 0.24.2 上**无效** —— 这类链接在 exclude 匹配之前就已解析失败,实测仍报 1348 个 error。所以 `--root-dir` 不是"顺手加的",而是这道门能跑绿的唯一路径。

## 五、既有断链修复清单(22 条,仅改链接目标,不改散文)

⚠️ 超出派单的 ≤15 条阈值(22 大于 15),已请 PM 在验收时裁定范围;每一条都有仓内可查的证据,没有一条是猜的:

**ADR 链接归一(14 条)** — `/adr/*` 站点路由**根本不存在**:`apps/docs` 只有 `/[lang]/docs/[[...slug]]` 与 `/[lang]/blog/[[...slug]]` 两条路由,`apps/docs/redirects.mjs` 里也没有任何 `/adr` 重定向 ⇒ 这些链接在线上就是 404。仓内既有约定是 GitHub blob URL(**29 处在用** vs 坏写法 13 处),故归一到多数约定;12 个目标文件已逐一验证存在于 `docs/adr/`。

- `content/docs/permissions/authorization.mdx` × 11
- `content/docs/permissions/attachments-access.mdx` × 1
- `content/docs/ai/connect-mcp.mdx` × 1
- **`state-machine` 参考页 × 1 —— 修在生产者**:`content/docs/references/**` 是 `packages/spec` 的生成物(文件头有 AUTO-GENERATED 标记),第一版误改了生成物,被 os-regen pre-commit 钩子当场拦下;已按 contract-first 改到源头 `packages/spec/src/automation/state-machine.zod.ts` 的 JSDoc。该链接原写作 `../../../docs/adr/0020-...md`,从 `packages/spec/src/automation/` 出发解析到 `packages/docs/adr/...` —— **源头本身就是断的**,生成物只是忠实复制。

**quick-reference.mdx(6 条)**

- 删除 Audit 行 —— `audit.zod` 已按 **ADR-0056 移除**(`packages/spec/src/system/index.ts` 有明确记录);
- 删除 Registry 行 —— `registry.zod` 已在 **#4939 按 ADR-0049 退役**(`packages/spec/src/api/index.ts` 有明确记录);
- 删除 GraphQL 行 —— `graphql.zod.ts` / `GraphQLConfig` / `FederationEntity` 全仓无踪;
- 同步修正两处小节计数(System 19→18、API 19→17),否则我自己的删除会引入新的不一致;
- Connector Auth:schema 存在(`packages/spec/src/shared/connector-auth.zod.ts`)但**参考页从未写过** ⇒ 保留行、去掉死链,信息不丢;
- Plugin Security:页面实际在 `references/kernel/` 而非 `references/cloud/` ⇒ 纯改链接目标。

**README.md(2 条)**

- `@objectstack/account` 已迁到 `packages/apps/account` ⇒ 改路径;
- `@objectstack/service-feed` 已在 **#1955**(ADR-0052 §5)删除 ⇒ 整行移除。

**content/blog(1 条)**

- `/docs/specifications` 页面不存在 ⇒ 改指 `/docs/references`(参考索引页)。⚠️ **这 22 条里唯一带主观判断的一条**,如果 reviewer 认为该指别处或干脆去链接,请直接改。

⛔ 未触碰 `content/docs/kernel/runtime-services/data-service.mdx`(#6002 面锁),该文件也未出现在任何断链里。

## 六、反向验证(三段预期均在执行前写下)

**声明 A(触发面)** — 预期:PR 开出后 `Check Links` 必须作为 check 出现并跑完。
**结果:成立。** `Check Links` run #554([31183937132](https://github.com/objectstack-ai/objectstack/actions/runs/31183937132)),`event: pull_request`,关联 PR #6304。

⚠️ 过程中的一个真实教训,记下来供后来者:PR 刚开时**一个 workflow 都没触发**。原因不是触发器没写对,而是 `mergeable_state = "dirty"` —— GitHub 建不出 merge ref,而 `pull_request` 事件的 workflow 正是跑在 merge ref 上,于是**一个 run 都不产生**(不是 queued,是根本不存在)。`git merge origin/main` 解掉之后,6 个 workflow 立刻全部入队。**"PR 上没有 check"和"触发器没生效"是两件事**,别把前者读成后者。

**声明 B(咬合面)** — 预期:探针 commit 把 `content/docs/kernel/services-checklist.mdx:188` 的相对链接 `./services.mdx` 改指不存在路径 ⇒ **红**且报错点名该链接;`git revert` 后 ⇒ **绿**;最终该文件对 `origin/main` 净零 diff。
**结果:三段全部成立。**

| 段 | commit | run | 结论 |
| :--- | :--- | :--- | :--- |
| 红 | `34b5d9f`(探针) | [31183937132](https://github.com/objectstack-ai/objectstack/actions/runs/31183937132) | **failure**,exit code 2 |
| 绿 | `6a25d48`(revert) | [31184038710](https://github.com/objectstack-ai/objectstack/actions/runs/31184038710) | **success** |

红段报错正是探针那一条,别无其他:

```
### Errors in content/docs/kernel/services-checklist.mdx
* [ERROR] file:///home/runner/work/objectstack/objectstack/content/docs/kernel/services-probe-6028-does-not-exist.mdx (at 188:16) | File not found. Check if file exists and path is correct
```

净零证明:`git diff origin/main -- content/docs/kernel/services-checklist.mdx` 输出 **0 行**。

**声明 C(确定性面)** — 预期:B 的失败输出来自相对路径解析,而非任何 HTTP 请求。
**结果:成立。** 红段 run 的统计表:

| Status | Count |
|---|---|
| 🔍 Total | 1697 |
| 🔗 Unique | 744 |
| ✅ Successful | 1475 |
| ⏳ Timeouts | **0** |
| 🔀 Redirected | **0** |
| 👻 Excluded | 221 |
| 🚫 Errors | 1 |

报错是 `file://` URI 的 `File not found`(本地路径解析),**Timeouts 与 Redirected 双 0**,而 221 条外链无一例外都是 `[EXCLUDED] ... | This is due to your 'exclude' values` —— 从未发出请求。另一项确定性证据:**CI 的这组数字与本地用同版本 lychee(0.24.2)跑出来的完全一致**(1697 / 744 / 1475 / 221 / 1),即同一份配置在本地与 CI 得到同一结论,可复现。整个 job 耗时 1.4 秒。

## 七、不在本 PR 里

- ⛔ **required 集**:未改动 —— 裁决明确要求 advisory-first,先攒绿再谈晋级(维护者面)。
- ⛔ **`merge_group` 触发**:未加 —— advisory 车道不该消耗合并队列容量。**日后若晋级 required,必须在同一次改动里补上 `merge_group`**,否则队列会卡在一个永不上报的必需检查上(#6121 的教训),届时另单。
- ⛔ **`push:` 触发**:不在裁决范围内,如需恢复另议。
- ⛔ **未建 changeset**:workflow + 配置 + 文档链接行,不发布任何包 ⇒ 走 `skip-changeset` 标签(CI 上 `Check Changeset` 已 skipped)。
- 📋 **顺带发现另立观察单 #6319**:`quick-reference.mdx` 的三处小节计数与实际行数不符(Kernel 17/15、Cloud 5/6、Shared 5/12,均为本 PR 之前就存在),以及 `connector-auth` 有 schema 无参考页。⚠️ 这些**不是断链**,lychee 抓不到,本 PR 未改。
