### PR TITLE
fix(spec): 锚点漂移提示按实测方向措辞,不再把「领先」说成 trails … by 0 key(s) (#5847)

### DIFF
--- a/packages/spec/scripts/build-schemas-check-mode.test.ts
+++ b/packages/spec/scripts/build-schemas-check-mode.test.ts
@@ -1327,6 +1327,257 @@ describe('build-schemas.ts — --update-base moves the anchor forward or not at 
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// #5847 — the drift notice names the direction it MEASURED.
+//
+// The anchor and the baseline a build resolves disagree constantly, and the
+// notice that reports it used to have one sentence for both directions:
+// "trails the baseline at <rev> by <n> key(s)", with `n` counted as
+// `resolved keys ∖ anchor keys`. That count is only the size of the gap when the
+// anchor is the OLDER of the two. When the committed anchor is newer — the
+// resolved baseline's keys are then a subset of the anchor's — `n` is 0 and the
+// line reads "trails the baseline at 9ce056a879ef by 0 key(s)": the direction
+// backwards, and the one number that could have contradicted it zeroed out.
+//
+// Both states are ordinary. #5370 catalogues the two ways in (a build during an
+// uncommitted merge, and a branch that forked before the anchor advanced), and
+// since #5370 `--update-base` REFUSES in exactly this state and explains the
+// direction correctly — so one situation was being described by two of our own
+// messages in contradictory language. Nothing about the gate changes here: same
+// exit code, same (absent) writes, same verdicts. Only the sentence.
+//
+// The direction is decided by the SAME `merge-base --is-ancestor` reading the
+// re-anchor guard decides on (`probeAncestry`), never by a second key
+// subtraction — a subtraction is what said the wrong thing in the first place,
+// and two independent determinations of one direction is how the two answers
+// drift apart again.
+describe('build-schemas.ts — the drift notice names the direction it measured (#5847)', () => {
+  /** In `tip` and `mainTip`, absent from `older`: the key the anchor holds and the resolved baseline does not. */
+  const AHEAD_KEY = 'data/Object:label';
+  /** Only in `mainTip`: what origin/main added after the anchor. */
+  const LANDED_KEY = 'data/Object:description';
+  /** A key in a DIFFERENT shard, so the unordered fixture's two sides merge without conflict. */
+  const UI_KEY = 'ui/View:form';
+
+  /** The branch's fork point: upstream, and behind the committed anchor. */
+  let older: string;
+  /** Ahead of `older`, on origin/main — what the AHEAD fixture's anchor mirrors. */
+  let tip: string;
+  /** origin/main, ahead of both. */
+  let mainTip: string;
+
+  /** `git()` throws on a non-zero exit, which is exactly what a NEGATIVE ancestry
+   *  probe returns — so fixture validation needs its own non-throwing runner. */
+  const isAncestor = (a: string, b: string): boolean =>
+    spawnSync('git', ['merge-base', '--is-ancestor', a, b], { cwd: sandbox }).status === 0;
+
+  const shallowFile = (): string => path.join(sandbox, '.git', 'shallow');
+
+  beforeAll(() => {
+    for (const k of [AHEAD_KEY, LANDED_KEY, UI_KEY]) {
+      expect(pristineSurface, `${k} is no longer in the baseline — pick another live key`).toContain(k);
+    }
+  });
+
+  beforeEach(() => {
+    seedManifest((s) => s);
+    // Three upstream commits, linear, each one key richer than the last — the
+    // same ladder #5370 uses, because these are the same two states it named.
+    older = seedBase((s) => s.filter((k) => k !== AHEAD_KEY && k !== LANDED_KEY));
+    tip = seedBase((s) => s.filter((k) => k !== LANDED_KEY));
+    mainTip = seedBase((s) => s);
+    seedSurface((s) => s);
+  });
+
+  afterEach(() => {
+    fs.rmSync(shallowFile(), { force: true });
+    git('checkout', '-q', '-f', 'main');
+    // Hand `main` back current and CLEAN: an anchor that mirrors main's own tip,
+    // so the describes after this one start from a tree with no drift of ours in it.
+    seedSurface((s) => s);
+    seedSurfaceBase(git('rev-parse', 'HEAD'), (k) => k);
+    git('add', AUTHORABLE_SURFACE_DIR_NAME, 'authorable-surface.base.json');
+    git('commit', '-q', '--allow-empty', '-m', 'fixture: restore a current anchor on main');
+    git('update-ref', 'refs/remotes/origin/main', 'HEAD');
+  });
+
+  /** Commit the anchor — and the surface the fork restored alongside it, since a
+   *  `checkout` to an older commit takes the shards back with it — so that
+   *  `git status` staying empty across a run can mean "this run wrote nothing". */
+  function commitAnchor(baseRev: string, mutate: (keys: string[]) => string[]): string {
+    const bytes = seedSurfaceBase(baseRev, mutate);
+    git('add', AUTHORABLE_SURFACE_DIR_NAME, 'authorable-surface.base.json');
+    git('commit', '-q', '-m', `fixture: anchor at ${baseRev.slice(0, 12)}`);
+    expect(git('status', '--porcelain', '-uno')).toBe('');
+    return bytes;
+  }
+
+  it(
+    'says the anchor TRAILS when it is the older of the two, and names both revs and both deltas',
+    { timeout: SPAWN_TIMEOUT_MS },
+    () => {
+      // The ordinary lag: HEAD is on main, the anchor mirrors an older upstream
+      // commit. This direction was never wrong — what it lacked was the anchor's
+      // own rev (so the reader could see WHICH two commits disagree) and the
+      // reverse delta.
+      const anchorAtOlder = commitAnchor(older, (k) =>
+        k.filter((x) => x !== AHEAD_KEY && x !== LANDED_KEY),
+      );
+      expect(isAncestor(older, mainTip)).toBe(true);
+
+      const { status, output } = run([]);
+
+      expect(status).toBe(0);
+      expect(readSurfaceBase()).toBe(anchorAtOlder);
+      expect(git('status', '--porcelain', '-uno')).toBe('');
+      expect(output).toContain(`trails the baseline at ${mainTip.slice(0, 12)}: it mirrors the older`);
+      expect(output).toContain(`${older.slice(0, 12)}, and they differ by 2 key(s) only that baseline has`);
+      expect(output).toContain('not an error');
+      expect(output).toContain('gen:authorable-surface-base');
+      expect(output).not.toContain('AHEAD of');
+      expect(output).not.toMatch(/by 0 key\(s\)/);
+      expect(output).not.toContain('⚓');
+    },
+  );
+
+  it(
+    'says the anchor is AHEAD when it is the newer of the two — never "trails … by 0 key(s)"',
+    { timeout: SPAWN_TIMEOUT_MS },
+    () => {
+      // THE regression. The anchor mirrors `tip`; HEAD forked at `older`, so the
+      // baseline this build resolves is `older` and its keys are a strict SUBSET
+      // of the anchor's. The old subtraction therefore counted 0 and the line
+      // claimed the file trailed a baseline it is a descendant of.
+      git('checkout', '-q', '-B', 'issue-5847-ahead', older);
+      seedSurface((s) => s);
+      const anchorAtTip = commitAnchor(tip, (k) => k.filter((x) => x !== LANDED_KEY));
+      expect(git('merge-base', 'HEAD', mainTip)).toBe(older);
+      expect(isAncestor(older, tip)).toBe(true);
+      expect(isAncestor(tip, older)).toBe(false);
+
+      const { status, output } = run([]);
+
+      // Exit code and files are the half that must NOT move: this is a sentence
+      // fix, and a diagnostic that starts deciding things is a different change.
+      expect(status).toBe(0);
+      expect(readSurfaceBase()).toBe(anchorAtTip);
+      expect(git('status', '--porcelain', '-uno')).toBe('');
+      expect(output).toContain('is AHEAD of the baseline this build resolved');
+      expect(output).toContain(
+        `${tip.slice(0, 12)}, a DESCENDANT of the merge base ${older.slice(0, 12)} that HEAD resolves to`,
+      );
+      expect(output).toContain('they differ by 1 key(s) only the anchor has');
+      // The two halves of the defect, pinned as negatives so a future edit cannot
+      // reintroduce either one without this going red.
+      expect(output).not.toContain('trails the baseline');
+      expect(output).not.toMatch(/by 0 key\(s\)/);
+      expect(output).not.toContain('⚓');
+    },
+  );
+
+  it(
+    'claims NO direction in a shallow checkout, and names truncation as the reason',
+    { timeout: SPAWN_TIMEOUT_MS },
+    () => {
+      // CI's own typecheck job is a shallow checkout, and so is every agent
+      // container — so this is the common environment, not an exotic one.
+      //
+      // Truncation moves TWO things here, and the second was a surprise worth
+      // writing down: `merge-base HEAD origin/main` itself fails once the walk is
+      // cut, so `resolveSurfaceBase` falls back to origin/main's TIP as the
+      // baseline (it says so — "using origin/main tip … as the baseline anchor").
+      // The pair being compared is therefore anchor-at-`tip` vs baseline-at-
+      // `mainTip`, not the fork point at all. And the ancestry between them is
+      // exactly what a grafted history cannot answer: `mainTip` is its own shallow
+      // root, so walking down from it to reach `tip` is the walk that was cut, and
+      // the reverse is a plain negative. Neither probe yields a usable answer.
+      //
+      // The old line printed "trails the baseline at <mainTip> by 1 key(s)" here,
+      // which happens to be TRUE of the untruncated history — and that is the
+      // point: it was never measured, it was assumed, and one fixture over the
+      // same assumption printed the exact opposite of the truth. Declining is the
+      // same disposition #5370 already took for the write.
+      git('checkout', '-q', '-B', 'issue-5847-shallow', older);
+      seedSurface((s) => s);
+      const anchorAtTip = commitAnchor(tip, (k) => k.filter((x) => x !== LANDED_KEY));
+      fs.writeFileSync(shallowFile(), `${mainTip}\n`);
+      expect(git('rev-parse', '--is-shallow-repository')).toBe('true');
+
+      const { status, output } = run([]);
+
+      expect(status).toBe(0);
+      expect(readSurfaceBase()).toBe(anchorAtTip);
+      expect(git('status', '--porcelain', '-uno')).toBe('');
+      expect(output).toContain('differs from the baseline this build resolved');
+      expect(output).toContain(
+        `${tip.slice(0, 12)}, that baseline is at ${mainTip.slice(0, 12)}, and they differ by ` +
+          `1 key(s) only that baseline has`,
+      );
+      expect(output).toContain(
+        'shallow checkout — a "not an ancestor" answer is not usable about a truncated history',
+      );
+      // A direction nobody could establish is never asserted — in EITHER wording.
+      expect(output).not.toContain('trails the baseline');
+      expect(output).not.toContain('AHEAD of');
+      expect(output).not.toMatch(/by 0 key\(s\)/);
+    },
+  );
+
+  it(
+    'claims NO direction when the two revs are genuinely unordered',
+    { timeout: SPAWN_TIMEOUT_MS },
+    () => {
+      // Two authentic origin/main ancestors that sit on opposite sides of a merge:
+      // each passes every check the gate makes about a single rev, and neither is
+      // an ancestor of the other. There is no direction to report, so the notice
+      // reports the delta and says so — the disposition `probeAncestry`'s
+      // `unknown` gets here, as against the re-anchor guard's fail-closed refusal.
+      const base = seedBase((s) => s);
+
+      git('checkout', '-q', '-B', 'issue-5847-side-a', base);
+      seedSurface((s) => s.filter((k) => k !== AHEAD_KEY));
+      git('add', AUTHORABLE_SURFACE_DIR_NAME);
+      git('commit', '-q', '-m', 'fixture: one side of the merge (data shard)');
+      const sideA = git('rev-parse', 'HEAD');
+
+      git('checkout', '-q', '-B', 'issue-5847-side-b', base);
+      seedSurface((s) => s.filter((k) => k !== UI_KEY));
+      git('add', AUTHORABLE_SURFACE_DIR_NAME);
+      git('commit', '-q', '-m', 'fixture: other side of the merge (ui shard)');
+      const sideB = git('rev-parse', 'HEAD');
+
+      // Conflict-free by construction: the two sides touch different shards.
+      git('merge', '--no-ff', '-q', '-m', 'fixture: merge the two sides', sideA);
+      const merged = git('rev-parse', 'HEAD');
+      git('update-ref', 'refs/remotes/origin/main', merged);
+      expect(isAncestor(sideA, merged)).toBe(true);
+      expect(isAncestor(sideA, sideB)).toBe(false);
+      expect(isAncestor(sideB, sideA)).toBe(false);
+
+      // HEAD forks on side B; the anchor authentically mirrors side A.
+      git('checkout', '-q', '-B', 'issue-5847-unordered', sideB);
+      seedSurface((s) => s);
+      const anchorAtSideA = commitAnchor(sideA, (k) => k.filter((x) => x !== AHEAD_KEY));
+      expect(git('merge-base', 'HEAD', merged)).toBe(sideB);
+
+      const { status, output } = run([]);
+
+      expect(status).toBe(0);
+      expect(readSurfaceBase()).toBe(anchorAtSideA);
+      expect(git('status', '--porcelain', '-uno')).toBe('');
+      expect(output).toContain('differs from the baseline this build resolved');
+      expect(output).toContain(
+        `${sideA.slice(0, 12)}, that baseline is at ${sideB.slice(0, 12)}, and they differ by ` +
+          `1 key(s) only that baseline has, 1 only the anchor has`,
+      );
+      expect(output).toContain('neither commit is an ancestor of the other');
+      expect(output).not.toContain('trails the baseline');
+      expect(output).not.toContain('AHEAD of');
+      expect(output).not.toMatch(/by 0 key\(s\)/);
+    },
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // #5371 — the output clean is scoped to THIS generator's artifacts.
 //
 // `packages/spec/json-schema/` has two writers: this script emits

--- a/packages/spec/scripts/build-schemas.ts
+++ b/packages/spec/scripts/build-schemas.ts
@@ -1278,6 +1278,100 @@ function compareAnchorKeys(
 }
 
 /**
+ * `merge-base --is-ancestor`, read as the THREE answers it gives (#5370).
+ *
+ * Extracted so the two places that need this direction — the re-anchor guard
+ * below and the drift notice further down (#5847) — decide it ONCE, with one
+ * reading of the exit codes. Two independent determinations of one direction is
+ * how the two answers drift apart later, and this file already paid for the
+ * drift: the notice used to infer direction from a key subtraction and printed
+ * the opposite of what the guard said about the very same pair of revs.
+ *
+ * 0 is "ancestor", 1 is "not an ancestor", and anything else (128 with a
+ * `fatal:`, or `null` from the timeout) is git declining to answer. Folded into
+ * a `&&`/`||` chain the third collapses into the second and an ERROR becomes a
+ * verdict — the trap cloud#1116 paid for.
+ *
+ * Shallow history makes a FOURTH reading necessary, and it is asymmetric. A
+ * truncated walk can only ever LOSE reachability, never invent it, so exit 0 is
+ * proof wherever it appears — while exit 1 in a shallow checkout means nothing at
+ * all (#5358's own first CI run was failed by exactly that answer, about a commit
+ * that plainly was an ancestor; the same false 1 is reproducible today in any
+ * agent container, where the anchor's `baseRev` sits in `.git/shallow` as its own
+ * grafted root). So shallowness is consulted only to decide whether a NEGATIVE
+ * counts — never to discard a positive, which would refuse re-anchors that are
+ * demonstrably fine.
+ *
+ * What each caller DOES with `unknown` is the caller's own disposition, and the
+ * two differ on purpose: the guard fails closed (refuses the write), the notice
+ * simply declines to name a direction. Neither may turn it into a verdict.
+ */
+type Ancestry =
+  | { answer: 'yes' }
+  | { answer: 'no' }
+  | { answer: 'unknown'; reason: 'git-declined'; status: number | null; stderr: string }
+  | { answer: 'unknown'; reason: 'shallow' };
+
+function probeAncestry(git: GitRun, ancestor: string, descendant: string): Ancestry {
+  const probe = git('merge-base', '--is-ancestor', ancestor, descendant);
+  // Reachability was demonstrated. Truncation cannot fake that, so this is the
+  // one answer that stands in every checkout, shallow included.
+  if (probe.status === 0) return { answer: 'yes' };
+  if (probe.status !== 1) {
+    return {
+      answer: 'unknown',
+      reason: 'git-declined',
+      status: probe.status,
+      stderr: (probe.stderr || '').trim().split('\n')[0] || '(no output)',
+    };
+  }
+  // A negative, on the other hand, is only meaningful where history is WALKABLE —
+  // the same truncation `verifyCommittedSurfaceBase` accounts for. There it SKIPS
+  // a verification, which is safe; for the guard below it would BLESS a write,
+  // which is not, and for the notice it would print a direction backwards.
+  if (git('rev-parse', '--is-shallow-repository').stdout.trim() === 'true') {
+    return { answer: 'unknown', reason: 'shallow' };
+  }
+  return { answer: 'no' };
+}
+
+/**
+ * Where the committed anchor sits relative to the baseline THIS build resolved
+ * (#5847) — the question the drift notice has to answer before it can word
+ * itself, decided on `probeAncestry` above rather than on a key subtraction.
+ *
+ * `unordered` is not a failure and not a fallback: it is the honest answer in a
+ * shallow checkout (CI's own typecheck job is one), when git declines, and in
+ * the genuinely unordered case where two authentic origin/main ancestors sit on
+ * different branches of a merge. Naming a direction there would be exactly the
+ * defect this exists to remove, one state over.
+ */
+type AnchorRelation = { kind: 'behind' } | { kind: 'ahead' } | { kind: 'unordered'; why: string };
+
+function relateAnchorToBaseline(git: GitRun, committedRev: string, resolvedRev: string): AnchorRelation {
+  const forward = probeAncestry(git, committedRev, resolvedRev);
+  if (forward.answer === 'yes') return { kind: 'behind' };
+  const backward = probeAncestry(git, resolvedRev, committedRev);
+  if (backward.answer === 'yes') return { kind: 'ahead' };
+  // Only a definitive negative BOTH ways is a real fork; anything else is an
+  // answer nobody has, and the two are told apart because their remedies differ.
+  const unusable = forward.answer === 'unknown' ? forward : backward.answer === 'unknown' ? backward : null;
+  if (!unusable) {
+    return {
+      kind: 'unordered',
+      why: 'neither commit is an ancestor of the other — they sit on different branches of a merge',
+    };
+  }
+  return {
+    kind: 'unordered',
+    why:
+      unusable.reason === 'shallow'
+        ? 'shallow checkout — a "not an ancestor" answer is not usable about a truncated history'
+        : `\`git merge-base --is-ancestor\` did not answer (exit ${unusable.status}): ${unusable.stderr}`,
+  };
+}
+
+/**
  * The anchor moves FORWARD, or it does not move (#5370).
  *
  * Called immediately before the only write, so a re-anchor may replace `baseRev`
@@ -1291,22 +1385,11 @@ function compareAnchorKeys(
  * comes back, the deletion gate stops seeing it, and the offline consumers of
  * #5235 get a baseline older than the published one.
  *
- * Three exit codes from `merge-base --is-ancestor`, and they must be read as
- * three answers, not two: 0 is "ancestor", 1 is "not an ancestor", and anything
- * else (128 with a `fatal:`, or `null` from the timeout) is git declining to
- * answer. Folded into a `&&`/`||` chain the third collapses into the second and
- * an ERROR becomes a verdict — the trap cloud#1116 paid for. Here it fails
- * CLOSED: an ancestry nobody could establish refuses the write.
- *
- * Shallow history makes a FOURTH reading necessary, and it is asymmetric. A
- * truncated walk can only ever LOSE reachability, never invent it, so exit 0 is
- * proof wherever it appears — while exit 1 in a shallow checkout means nothing at
- * all (#5358's own first CI run was failed by exactly that answer, about a commit
- * that plainly was an ancestor; the same false 1 is reproducible today in any
- * agent container, where the anchor's `baseRev` sits in `.git/shallow` as its own
- * grafted root). So shallowness is consulted only to decide whether a NEGATIVE
- * counts — never to discard a positive, which would refuse re-anchors that are
- * demonstrably fine.
+ * The three-plus-one readings of `merge-base --is-ancestor` live in
+ * `probeAncestry` above, shared with the drift notice (#5847). What is decided
+ * HERE is the disposition on `unknown`, and it is to fail CLOSED: an ancestry
+ * nobody could establish refuses the write rather than defaulting to one of the
+ * two answers.
  */
 function assertAnchorMovesForward(git: GitRun, committedRev: string, resolvedRev: string): void {
   if (committedRev === resolvedRev) return;
@@ -1326,24 +1409,16 @@ function assertAnchorMovesForward(git: GitRun, committedRev: string, resolvedRev
     process.exit(1);
   };
 
-  const probe = git('merge-base', '--is-ancestor', committedRev, resolvedRev);
-  // Reachability was demonstrated. Truncation cannot fake that, so this is the
-  // one answer that stands in every checkout, shallow included.
-  if (probe.status === 0) return;
-  if (probe.status !== 1) {
+  const probe = probeAncestry(git, committedRev, resolvedRev);
+  if (probe.answer === 'yes') return;
+  if (probe.answer === 'unknown') {
     return refuseIndeterminate(
-      `\`git merge-base --is-ancestor ${from} ${to}\` did not answer (exit ${probe.status}):\n` +
-        `   ${(probe.stderr || '').trim().split('\n')[0] || '(no output)'}`,
-    );
-  }
-  // A negative, on the other hand, is only meaningful where history is WALKABLE —
-  // the same truncation `verifyCommittedSurfaceBase` accounts for. There it SKIPS
-  // a verification, which is safe; here it would BLESS a write, which is not.
-  if (git('rev-parse', '--is-shallow-repository').stdout.trim() === 'true') {
-    return refuseIndeterminate(
-      'This is a shallow checkout: history is truncated, so `merge-base --is-ancestor` reports\n' +
-        `   "not an ancestor" about commits that plainly are one — ${from} is very likely one of\n` +
-        '   them (a `--depth=1` fetch grafts it in as its own root, unreachable from origin/main).',
+      probe.reason === 'git-declined'
+        ? `\`git merge-base --is-ancestor ${from} ${to}\` did not answer (exit ${probe.status}):\n` +
+            `   ${probe.stderr}`
+        : 'This is a shallow checkout: history is truncated, so `merge-base --is-ancestor` reports\n' +
+            `   "not an ancestor" about commits that plainly are one — ${from} is very likely one of\n` +
+            '   them (a `--depth=1` fetch grafts it in as its own root, unreachable from origin/main).',
     );
   }
   console.error(
@@ -1818,14 +1893,67 @@ function checkManifestRemovals(git: GitRun, baseRev: string | null): void {
     } else if (drifted) {
       // Reported, never fatal, and never repaired here: see the notes above on
       // `main`'s own merge base and on #5358.
+      //
+      // The DIRECTION is asked, not assumed (#5847). This used to print one fixed
+      // sentence — "trails the baseline at <rev> by <n> key(s)" — with `n` counted
+      // as `resolved keys ∖ anchor keys`. In the state where the committed anchor
+      // is NEWER than the baseline this build resolved, the resolved keys are a
+      // subset of the anchor's, so that count is 0 and the line degrades to
+      // "trails the baseline at <rev> by 0 key(s)": the direction backwards, and
+      // the one number that could have contradicted it zeroed out. That state is
+      // ordinary, not a corner — a build during an uncommitted merge, or a branch
+      // that forked before the anchor advanced and then took a newer anchor
+      // (#5370 catalogues both) — and since #5370 `--update-base` REFUSES there
+      // and explains the direction correctly, so the two were describing one
+      // situation in contradictory language.
+      //
+      // Both key deltas are reported now, because either can be the empty one and
+      // the pair is what makes the sentence say something. Only the wording and
+      // the counts change here: this arm still writes nothing, exits nothing, and
+      // decides nothing.
       const recorded = new Set(committed.doc.keys);
-      const behind = anchor.keys.filter((k) => !recorded.has(k)).length;
-      console.log(
-        `ℹ️  ${SURFACE_BASE_FILE_NAME} trails the baseline at ${anchor.rev.slice(0, 12)} by ${behind} key(s)\n` +
-          `   — expected, and not an error: the anchor is a snapshot of an upstream commit, proved\n` +
-          `   AUTHENTIC rather than current. Re-anchoring is a deliberate act with its own reviewed\n` +
-          `   diff — \`${REANCHOR_COMMAND}\` — never a side effect of this build (#5358).`,
-      );
+      const resolvedKeys = new Set(anchor.keys);
+      const onlyBaseline = anchor.keys.filter((k) => !recorded.has(k)).length;
+      const onlyAnchor = committed.doc.keys.filter((k) => !resolvedKeys.has(k)).length;
+      const anchorShort = committed.doc.baseRev.slice(0, 12);
+      const baseShort = anchor.rev.slice(0, 12);
+      const delta =
+        onlyBaseline > 0 && onlyAnchor > 0
+          ? `${onlyBaseline} key(s) only that baseline has, ${onlyAnchor} only the anchor has`
+          : onlyBaseline > 0
+            ? `${onlyBaseline} key(s) only that baseline has`
+            : onlyAnchor > 0
+              ? `${onlyAnchor} key(s) only the anchor has`
+              : 'the same keys in a different order';
+      const reanchor =
+        `   Re-anchoring is a deliberate act with its own reviewed diff — \`${REANCHOR_COMMAND}\`\n` +
+        `   — never a side effect of this build (#5358).`;
+      const relation = relateAnchorToBaseline(gitInPackage, committed.doc.baseRev, anchor.rev);
+      if (relation.kind === 'behind') {
+        console.log(
+          `ℹ️  ${SURFACE_BASE_FILE_NAME} trails the baseline at ${baseShort}: it mirrors the older\n` +
+            `   ${anchorShort}, and they differ by ${delta}\n` +
+            `   — expected, and not an error: the anchor is a snapshot of an upstream commit, proved\n` +
+            `   AUTHENTIC rather than current.\n${reanchor}`,
+        );
+      } else if (relation.kind === 'ahead') {
+        console.log(
+          `ℹ️  ${SURFACE_BASE_FILE_NAME} is AHEAD of the baseline this build resolved: it mirrors\n` +
+            `   ${anchorShort}, a DESCENDANT of the merge base ${baseShort} that HEAD resolves to, and\n` +
+            `   they differ by ${delta}\n` +
+            `   — not an error, and not something to re-anchor: the anchor only ever moves forward, so\n` +
+            `   what closes this gap is bringing HEAD up to date with origin/main (and committing it),\n` +
+            `   never a re-anchor onto the older baseline.\n${reanchor}`,
+        );
+      } else {
+        console.log(
+          `ℹ️  ${SURFACE_BASE_FILE_NAME} differs from the baseline this build resolved: it mirrors\n` +
+            `   ${anchorShort}, that baseline is at ${baseShort}, and they differ by ${delta}\n` +
+            `   — which of the two is newer could not be established here, so this run names no\n` +
+            `   direction: ${relation.why}.\n` +
+            `   Not an error either way.\n${reanchor}`,
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #5847

## 前提复核(立单读数已失效,结论:前提仍然成立)

立单引用的 `origin/main 77adf29` 第 1313–1323 行已被两次改动移走,我在当前
`origin/main`(`4dd9cbd15`)上重新定位:

| 立单时 | 现在 |
|---|---|
| `build-schemas.ts:1313–1323` | `build-schemas.ts:1817–1830` |

中间落地的 PR #6200(#5371,`lib/json-schema-out-dir.ts` + `clearOwnedOutputs()`)
与 PR #6256(#5898,重写检查 (c) 的墓碑老化时钟)都没有碰这条代码路径 —— 它们改的
是**删除门禁**,本单改的是**锚点漂移提示**。缺陷本体逐字未变:

```js
const behind = anchor.keys.filter((k) => !recorded.has(k)).length;
```

并且在沙箱夹具里实测复现了原文所述的那一行(见下方「反向验证」):

```
ℹ️  authorable-surface.base.json trails the baseline at b20f3c44e610 by 0 key(s)
```

## 缺陷

这句提示对两个方向只有一套措辞,而 `behind` 算的是 `解析基线的键 ∖ 锚点的键`。
只有当锚点是两者中**较旧**的一方时,这个数才等于差距。当已提交的锚点更新时,
解析基线的键是锚点键的**子集**,`behind` 恒为 0,整句退化成「方向说反 + 唯一能
反驳它的数字被清零」。

这不是角落状态:#5370 已经把两条进入路径写清楚了(未 commit 的 merge 中途构建;
分支分叉早于锚点推进后又带入较新锚点),而且**自 #5370 起 `--update-base` 在同一
状态下会拒绝并把方向解释对** —— 于是我们自己的两条消息在描述同一件事时互相矛盾。

## 方向判定:复用,而不是新造

派发单要求「若 #5370 的判定在该点真的可用则优先复用」。**可用,并且已复用。**

把 #5370 对 `merge-base --is-ancestor` 的三值解读(0 = 祖先 / 1 = 非祖先 / 其余 =
git 拒绝作答)外加 shallow 那第四读(截断只会**丢失**可达性、绝不会**凭空造出**
可达性 ⇒ 0 在任何检出下都算数,1 只在 history 可走时才算数)抽成共享的
`probeAncestry()`,再由 `relateAnchorToBaseline()` 给出 `behind` / `ahead` /
`unordered`。

- `assertAnchorMovesForward()`(#5370 的重锚门禁)现在是它的消费者之一,**输出逐字节
  不变** —— #5370 的四条测试原样通过。
- 漂移提示是另一个消费者。两者对 `unknown` 的**处置**故意不同,并且写进了注释:
  门禁 fail-closed(拒绝写入),提示只是不声称方向。

一个方向存在两套独立判定,正是它们日后各说各话的原因 —— 而本单就是那次分歧的账单,
所以没有再造第二套「锚点键 ⊇ 解析基线键」的子集推断。

三条消息都同时报告两侧键差(`N key(s) only that baseline has, M only the anchor has`),
因为任一侧都可能为空,成对出现才有信息量;没有任何一条会再打印
`by 0 key(s)` 式的零信息断言。

`unordered` 不是兜底而是诚实答案,三种可达来源:shallow 检出(**CI 自己的
typecheck job 与所有 agent 容器都是**)、git 拒绝作答、两个 authentic 的
origin/main 祖先分处一次 merge 的两侧。在这些情形下声称方向,就是本单要消灭的
缺陷换个状态重演。

## 反向验证(预测在跑之前写下,并且**有一条没中**)

| 新测试 | 预测 | 实测 | |
|---|---|---|---|
| 1. 锚点 BEHIND ⇒ 说 trails,并写出两个 rev 与两侧差 | RED | RED | ✅ |
| 2. 锚点 AHEAD ⇒ 说 AHEAD,绝不 trails-by-zero | RED | RED | ✅ |
| 3. shallow 检出 | 预测**仍判定为 AHEAD**(反向探针能证明) | **实测判定为「无方向」** | ❌ **预测错** |
| 4. 真正无序的一对 rev ⇒ 不声称方向 | RED | RED | ✅ |
| 既有 51 条(含 #5358 的 `trails the baseline at` 与 #5370 全部四条) | 保持 GREEN | GREEN | ✅ |

回退 `build-schemas.ts` 到 `origin/main`、保留新测试后的实跑:

```
❯ scripts/build-schemas-check-mode.test.ts (55 tests | 4 failed)
  × says the anchor TRAILS when it is the older of the two, and names both revs and both deltas
  × says the anchor is AHEAD when it is the newer of the two — never "trails … by 0 key(s)"
  × claims NO direction in a shallow checkout, and names truncation as the reason
  × claims NO direction when the two revs are genuinely unordered
 Tests  4 failed | 51 passed (55)
```

### 那条没中的预测(照实报告)

我预测 shallow 夹具下方向**仍然可测**:正向探针 `tip → older` 因截断不可用,但反向
探针 `older → tip` 是走 parent 一步、不需要被截断的那段 history,exit 0 在任何检出
下都算数 ⇒ 判定为 `ahead`。

实测两处都不对:

1. 截断先动的不是探针,而是 **`merge-base` 本身**。`resolveSurfaceBase()` 里
   `git merge-base HEAD origin/main` 在 grafted history 下直接失败,于是基线**回退到
   origin/main 的 tip**(脚本自己会打印 `(shallow history — using origin/main tip … as
   the baseline anchor)`)。被比较的一对因此是 锚点@`tip` vs 基线@`mainTip`,
   根本不是分叉点。
2. 这一对的祖先关系恰好是 grafted history 答不了的那个:`mainTip` 是它自己的 shallow
   root,从它往下走去够到 `tip` 正是被剪掉的那段;反向则是普通否定。两个探针都给不出
   可用答案 ⇒ `unordered`。

旧代码在这里打印的是 `trails the baseline at (mainTip) by 1 key(s)` —— 对**未截断**的
history 而言**恰好是真的**。这正是重点:它从来不是测出来的,而是假设出来的,而同一个
假设在隔壁一个夹具里打印了与事实完全相反的话。所以第 3 条测试改成钉「shallow 下不声称
方向,并说出截断这个理由」,与 #5370 对写入所采取的处置一致。

这条 miss 让 `unordered` 分支拿到了两个夹具(shallow 与真分叉),其中 shallow 那个才是
CI 每天都在跑的环境 —— 比我原来的预测更值得钉。

## 退出码与写入文件:实测逐字节相同,不是断言

两个内容完全相同、commit 日期固定(因而 SHA 相同)的沙箱,分别跑
`origin/main` 版与本 PR 版的 `build-schemas.ts`,在 behind / ahead 两个状态下对比:

| 状态 | exit code | `git status --porcelain -uno` | 锚点 sha256 | authorable-surface/ | json-schema.manifest/ | json-schema/ 整棵树 |
|---|---|---|---|---|---|---|
| behind | 0 = 0 | 空 = 空 | `07036bf2…` = `07036bf2…` | `2b33f6b8…` = `2b33f6b8…` | `7c1a3738…` = `7c1a3738…` | `eae4cc78…` = `eae4cc78…` |
| ahead | 0 = 0 | 空 = 空 | `c60c5967…` = `c60c5967…` | `2b33f6b8…` = `2b33f6b8…` | `7c1a3738…` = `7c1a3738…` | `eae4cc78…` = `eae4cc78…` |

```
IDENTICAL (exit code + git status + every written artifact): YES   (behind)
IDENTICAL (exit code + git status + every written artifact): YES   (ahead)
```

唯一的差异是那句提示本身:

```
behind  OLD: ℹ️  authorable-surface.base.json trails the baseline at 957a099b093c by 2 key(s)
        NEW: ℹ️  authorable-surface.base.json trails the baseline at 957a099b093c: it mirrors the older
                cdcfbec5b75b, and they differ by 2 key(s) only that baseline has

ahead   OLD: ℹ️  authorable-surface.base.json trails the baseline at cdcfbec5b75b by 0 key(s)
        NEW: ℹ️  authorable-surface.base.json is AHEAD of the baseline this build resolved: it mirrors
                (锚点 rev), a DESCENDANT of the merge base cdcfbec5b75b that HEAD resolves to, and
                they differ by 1 key(s) only the anchor has
```

(`cdcfbec5b75b` 就是分叉点 `older`;旧行把「锚点是它的后代」说成了「锚点 trails 它」,
并且把唯一能拆穿这句话的数字打成了 0。)

`json-schema/` 是 `packages/spec` 已发布 `files` 白名单里的目录,上表那一列因此同时也是
「本 PR 不改变任何已发布产物」的直接证据。

## 测试

```
pnpm --filter @objectstack/spec exec vitest run scripts/build-schemas-check-mode.test.ts
  Test Files  1 passed (1)
       Tests  55 passed (55)          # 51 既有 + 4 新增

pnpm --filter @objectstack/spec typecheck
  ✓ tsc --noEmit
  ✓ check:test-typecheck: OK

pnpm lint                              # 全仓 eslint,无输出即通过
pnpm check:nul-bytes                   # OK (5959 tracked text files)
check:doc-authoring / adr-anchors / error-code-casing / route-envelope /
org-identifier / role-word / slot-lookup / query-options-erasure  → 全部 OK
```

## Changeset:`skip-changeset`(实测,非默认假设)

改动只有 `packages/spec/scripts/` 下两个文件。`packages/spec` 的已发布
`files` 白名单是
`["dist","json-schema","liveness","prompts","llms.txt","README.md","src/**/*.zod.ts","CHANGELOG.md","api-surface","spec-changes.json"]`
—— 不含 `scripts/`。#6256 今天之所以合法地拿了 `@objectstack/spec` patch,是因为它的
registry JSDoc 会进 `dist/*.d.ts`;本 PR 不导出任何东西,`dist` 与 `json-schema` 都在
上面的对比表里被实测为逐字节不变 ⇒ 什么都不发布 ⇒ 取 `skip-changeset` 标签,
不写 changeset(⛔ 空 frontmatter changeset 是被门禁禁止的)。

## 未触碰

`packages/spec/src/**/*.zod.ts`、strictness ledger、`content/docs/releases/` 均未改动;
门禁的**判定**一处未动。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wsZeReNTqiceBfLb5Pyf5

---
_Generated by [Claude Code](https://claude.ai/code/session_014wsZeReNTqiceBfLb5Pyf5)_