### PR TITLE
fix(tooling): check-i18n-coverage 逐 config 收集失败,第一个失败不再吃掉其余十一个 (#6033)

### DIFF
--- a/scripts/check-i18n-coverage.mjs
+++ b/scripts/check-i18n-coverage.mjs
@@ -57,6 +57,23 @@
 // ownership §3): the prerequisite verdict is a HARD failure that states it
 // measured nothing — never a skip, and never anything a reader can mistake for
 // "no config declares an untranslated label".
+//
+// That answered ONE prerequisite. The OTHER one — an example's own workspace
+// dependencies unbuilt — kept the original shape until #6033: three bare `throw`s
+// inside the per-config measurement, an uncaught exception, and a node stack:
+//
+//     Error: os lint failed for examples/app-showcase/objectstack.config.ts:
+//       Cannot find module '…/@objectstack/connector-mcp/dist/index.mjs'
+//         at countI18nIssues (…/check-i18n-coverage.mjs:185:29)
+//
+// That diagnosis did NOT lie — the missing module is real and actionable, which is
+// why #6033 was filed as an observation rather than a defect. What it cost was the
+// other eleven configs: the loop died at the second one, so the remaining ten were
+// never attempted and their causes — which need not be this one — were never seen.
+// #5217's rule is "one cause must not be reported as N results"; this is its
+// converse, and one discipline serves both: measure EVERY config, then report every
+// DISTINCT cause once, with the configs it covers. A config that cannot be linted is
+// now collected (`measureI18nIssues` returns a failure), never thrown.
 import { execFileSync } from 'node:child_process';
 import { readdirSync, readFileSync, writeFileSync, existsSync, openSync, closeSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
@@ -75,6 +92,16 @@ const EXAMPLES_DIR = 'examples';
 const BASELINE_PATH = 'scripts/i18n-coverage-baseline.json';
 /** The one command this gate invokes per config, as oclif topic/command parts. */
 const LINT_COMMAND_ID = ['lint'];
+
+/**
+ * The remedy when a config's OWN workspace dependencies were never built (#6033) —
+ * distinct from `CLI_BUILD_FIX`, which clears only the CLI. An example config
+ * imports workspace packages by name, so a tree with just the CLI built still
+ * cannot be linted, and the two remedies must not be confused for each other.
+ */
+const WORKSPACE_BUILD_FIX = 'pnpm build';
+/** …and when the package is not on disk at all, a build alone cannot help. */
+const INSTALL_THEN_BUILD_FIX = 'pnpm install && pnpm build';
 
 const update = process.argv.includes('--update');
 
@@ -121,8 +148,113 @@ function countI18nRuleIssues(report) {
   return issues.filter((i) => typeof i?.rule === 'string' && i.rule.startsWith('i18n/')).length;
 }
 
+/** The command that reproduces one config's failure by hand, for the reader. */
+function rerunFix(configPath) {
+  return `node ${CLI} lint ${configPath} --json`;
+}
+
 /**
- * Untranslated declared strings `os lint` would show for one config.
+ * One bounded, readable line of evidence. A conclusion needs a reading to stand on,
+ * but a reading is not a stack: multi-line output is flattened the way
+ * `looksLikeMissingCliCommand` flattens oclif's wrapping, and a long one is cut.
+ */
+function evidenceLine(text, max = 200) {
+  const flat = String(text ?? '')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .join(' ');
+  return flat.length > max ? `${flat.slice(0, max)}…` : flat;
+}
+
+/**
+ * The per-config failure classifier (#6033): WHY one config could not be linted,
+ * as a conclusion plus the command that clears it. Pure — string in, verdict out —
+ * so `--self-test` drives it with recorded CLI output instead of a build.
+ *
+ * The one classification worth making is module resolution. On a tree where only
+ * the CLI was built, an example whose config imports a workspace package by name
+ * fails with node's `Cannot find module`, and the useful thing to say is WHICH
+ * package and that the remedy is a build. Everything else keeps the CLI's own
+ * words and sends the reader to run the same command by hand: claiming "not built"
+ * over a genuinely broken config would be the #5862 defect — a confident diagnosis
+ * pointing somewhere innocent — rebuilt one layer down.
+ *
+ * @param {string} configPath the config being measured, for the rerun command
+ * @param {string} text the CLI's own failure text (`report.error`, or a thrown message)
+ * @returns {{ reason: string, evidence: string, fix: string }}
+ */
+function explainConfigFailure(configPath, text) {
+  const evidence = evidenceLine(text);
+  const missing = String(text ?? '').match(/Cannot find (?:module|package) '([^']+)'/);
+  if (missing) {
+    const pkg = packageNameFromSpecifier(missing[1]);
+    // A specifier that reaches INTO a package's build output is installed but
+    // unbuilt; one that names the package alone was never installed at all.
+    if (pkg && /(?:^|\/)dist\//.test(missing[1])) {
+      return {
+        reason: `\`os lint\` could not load the config: \`${pkg}\` is installed but has no build output in this worktree`,
+        evidence,
+        fix: WORKSPACE_BUILD_FIX,
+      };
+    }
+    return {
+      reason: `\`os lint\` could not load the config: ${pkg ? `\`${pkg}\`` : 'a module it imports'} cannot be resolved from this worktree`,
+      evidence,
+      fix: INSTALL_THEN_BUILD_FIX,
+    };
+  }
+  return {
+    reason: '`os lint` failed on this config — the reading below is the CLI\'s own words, not this gate\'s',
+    evidence,
+    fix: rerunFix(configPath),
+  };
+}
+
+/**
+ * The package a failed specifier belongs to, or '' when it names none. Handles the
+ * two shapes node produces: a resolved absolute path (`…/node_modules/@scope/name/
+ * dist/index.mjs`) and a bare specifier (`@scope/name/sub`).
+ */
+function packageNameFromSpecifier(specifier) {
+  const marker = 'node_modules/';
+  const at = String(specifier ?? '').lastIndexOf(marker);
+  const tail = at === -1 ? String(specifier ?? '') : specifier.slice(at + marker.length);
+  if (!tail || tail.startsWith('/') || tail.startsWith('.')) return '';
+  const parts = tail.split('/');
+  const name = parts[0].startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
+  return name.endsWith('.mjs') || name.endsWith('.js') || name.endsWith('.ts') ? '' : name;
+}
+
+/**
+ * Distinct CAUSES, each carrying the configs it explains. Keyed on the CONCLUSION
+ * (reason + fix) rather than the raw reading, because one unbuilt package produces
+ * a different absolute path per config and those are the same fact told twelve
+ * times — exactly the "one cause reported as N results" shape #5217 closed on the
+ * neighbouring gate. The first reading is kept as the group's evidence.
+ *
+ * @param {{configPath: string, reason: string, evidence: string, fix: string}[]} failures
+ */
+function groupFailuresByCause(failures) {
+  const groups = new Map();
+  for (const f of failures) {
+    const key = JSON.stringify([f.reason, f.fix]);
+    const group = groups.get(key) ?? { reason: f.reason, fix: f.fix, evidence: f.evidence, configPaths: [] };
+    group.configPaths.push(f.configPath);
+    groups.set(key, group);
+  }
+  return [...groups.values()];
+}
+
+/**
+ * Untranslated declared strings `os lint` would show for one config — or WHY that
+ * could not be measured.
+ *
+ * Returns `{ count }` or `{ failure }` and never throws for a per-config problem
+ * (#6033), so one unlintable example cannot hide the eleven configs behind it. The
+ * one thing that still stops the round from in here is the missing-CLI
+ * prerequisite, deliberately: every remaining config would fail for that same
+ * single reason (#5862), so continuing would print one environment fact N times.
  *
  * Captured to a FILE rather than a pipe. Node writes stdout synchronously to a
  * file and asynchronously to a pipe, so a command that exits right after a
@@ -131,7 +263,7 @@ function countI18nRuleIssues(report) {
  * until the `emitJson` fix. A gate must never be able to read a truncated
  * payload and quietly report a smaller number, so it does not use a pipe at all.
  */
-function countI18nIssues(configPath) {
+function measureI18nIssues(configPath) {
   const tmp = join(tmpdir(), `os-lint-${randomUUID()}.json`);
   const fd = openSync(tmp, 'w');
   try {
@@ -175,18 +307,70 @@ function countI18nIssues(configPath) {
       ]);
     }
 
-    if (!raw.trim()) throw new Error(`os lint produced no output for ${configPath}`);
+    // The three ways one config can fail to yield a number. Each is that config's
+    // OWN cause, so each comes back as a collected failure rather than an
+    // exception: the round continues, and the reader gets all of them at once.
+    if (!raw.trim()) {
+      return {
+        failure: {
+          reason: '`os lint` produced no output at all — no JSON payload to count',
+          // stderr is the only reading there is when stdout was empty. It was
+          // already captured for the signature net above; discarding it here would
+          // leave the reader a verdict with nothing under it.
+          evidence: evidenceLine(stderr),
+          fix: rerunFix(configPath),
+        },
+      };
+    }
     let report;
     try {
       report = JSON.parse(raw);
     } catch (err) {
-      throw new Error(`os lint produced unparseable JSON for ${configPath} (${raw.length} bytes): ${err.message}`);
+      return {
+        failure: {
+          reason: `\`os lint\` wrote ${raw.length} byte(s) that are not JSON (${err.message})`,
+          evidence: evidenceLine(raw, 160),
+          fix: rerunFix(configPath),
+        },
+      };
     }
-    if (report.error) throw new Error(`os lint failed for ${configPath}: ${report.error}`);
-    return countI18nRuleIssues(report);
+    if (report.error) return { failure: explainConfigFailure(configPath, report.error) };
+    return { count: countI18nRuleIssues(report) };
   } finally {
     try { unlinkSync(tmp); } catch { /* already gone */ }
   }
+}
+
+/**
+ * The round: measure every config, collect the ones that could not be measured,
+ * and never let one of them end the round (#6033).
+ *
+ * `measure` is injected so `--self-test` can prove the collecting behaviour with no
+ * CLI and no build — the behaviour CI can never observe, because CI builds the whole
+ * workspace before this gate runs and therefore only ever sees the green path.
+ *
+ * The try/catch is the outer net, not the mechanism: `measureI18nIssues` reports its
+ * own failures as values, and anything that still throws (a spawn that fails, an
+ * unreadable temp file) is one more config-shaped failure — never a reason for the
+ * other eleven to go unmeasured.
+ *
+ * @param {string[]} configPaths
+ * @param {(configPath: string) => {count: number} | {failure: {reason: string, evidence: string, fix: string}}} measure
+ */
+function measureAllConfigs(configPaths, measure) {
+  const current = {};
+  const failures = [];
+  for (const configPath of configPaths) {
+    let result;
+    try {
+      result = measure(configPath);
+    } catch (err) {
+      result = { failure: explainConfigFailure(configPath, err?.message ?? String(err)) };
+    }
+    if (result?.failure) failures.push({ configPath, ...result.failure });
+    else current[configPath] = result.count;
+  }
+  return { current, failures };
 }
 
 // ---------------------------------------------------------------------------
@@ -278,12 +462,88 @@ function selfTest() {
   );
   expect('#5862 tolerates an issue-less report', countI18nRuleIssues({}) === 0, 'a clean report is 0, never a crash');
 
+  // -------------------------------------------------------------------------
+  // The per-config failure classifier and the collecting round (#6033). Pinned
+  // here or nowhere, for the same reason as the prerequisite above: CI builds the
+  // whole workspace before this gate runs, so nothing in CI ever reaches this path.
+  // -------------------------------------------------------------------------
+
+  // Recorded VERBATIM from `os lint examples/app-showcase/objectstack.config.ts
+  // --json` on a tree where ONLY `@objectstack/cli` had been built (the #6033
+  // repro), with the absolute worktree prefix normalised to `/repo`. This exact
+  // string is what the CLI puts in `report.error` — i.e. what the gate used to
+  // interpolate into a thrown Error and hand to node as a stack.
+  const REAL_UNBUILT_DEP_ERROR =
+    "Cannot find module '/repo/examples/app-showcase/node_modules/@objectstack/connector-mcp/dist/index.mjs' " +
+    "imported from /repo/examples/app-showcase/objectstack.config.bundled_yqbr4ytyonb.mjs";
+
+  const unbuilt = explainConfigFailure('examples/app-showcase/objectstack.config.ts', REAL_UNBUILT_DEP_ERROR);
+  expect('#6033 blames the package, not the config', unbuilt.reason.includes('@objectstack/connector-mcp'), `got ${JSON.stringify(unbuilt.reason)}`);
+  expect('#6033 concludes "installed but not built"', /has no build output/.test(unbuilt.reason), `got ${JSON.stringify(unbuilt.reason)}`);
+  expect('#6033 prescribes the workspace build', unbuilt.fix === WORKSPACE_BUILD_FIX, `got ${JSON.stringify(unbuilt.fix)}`);
+  expect('#6033 keeps the CLI reading as evidence', unbuilt.evidence.includes('Cannot find module'), 'a conclusion with no reading under it is not auditable');
+  expect('#6033 evidence is one line', !unbuilt.evidence.includes('\n'), 'evidence must be a line, not a stack');
+
+  // A package that is not installed at all cannot be fixed by a build alone.
+  const uninstalled = explainConfigFailure('x/y.ts', "Cannot find package '@objectstack/nope' imported from /repo/x/y.ts");
+  expect('#6033 uninstalled is not unbuilt', uninstalled.fix === INSTALL_THEN_BUILD_FIX, `got ${JSON.stringify(uninstalled.fix)}`);
+
+  // A genuinely broken config must NOT be told to run a build: sending a reader to
+  // a build that changes nothing, over a config that really is at fault, is the
+  // #5862 defect (a confident diagnosis pointing somewhere innocent) inverted.
+  const brokenConfig = explainConfigFailure('examples/app-crm/objectstack.config.ts', "Duplicate object name 'contacts'");
+  expect('#6033 a config error is not a missing build', brokenConfig.fix !== WORKSPACE_BUILD_FIX, `got ${JSON.stringify(brokenConfig.fix)}`);
+  expect('#6033 a config error keeps the CLI words', brokenConfig.evidence.includes("Duplicate object name 'contacts'"), `got ${JSON.stringify(brokenConfig.evidence)}`);
+
+  // Anti-#4690 applied to the fallback branch: an unrecognised cause must still
+  // yield a COMPLETE verdict. A collected failure with a blank reason or no fix is
+  // how this path would go quiet — the report would render an empty bullet and the
+  // round would still exit 1 with nothing for the reader to act on.
+  for (const [name, sample] of [['unknown wording', 'something nobody has recorded yet'], ['empty', ''], ['absent', undefined]]) {
+    const verdict = explainConfigFailure('x/y.ts', sample);
+    expect(`#6033 complete verdict (${name})`, !!verdict.reason && !!verdict.fix, `got ${JSON.stringify(verdict)}`);
+  }
+
+  // The round itself: one config's failure must not end it. Injected `measure`, so
+  // this runs with no CLI and no build. Configs 1 and 3 fail with DIFFERENT causes
+  // (one thrown, one returned), 2 and 4 measure.
+  const visited = [];
+  const round = measureAllConfigs(['a.ts', 'b.ts', 'c.ts', 'd.ts'], (p) => {
+    visited.push(p);
+    if (p === 'a.ts') throw new Error("Cannot find module '/repo/a/node_modules/@objectstack/spec/dist/index.mjs'");
+    if (p === 'c.ts') return { failure: explainConfigFailure(p, "Cannot find module '/repo/c/node_modules/@objectstack/connector-rest/dist/index.mjs'") };
+    return { count: 7 };
+  });
+  expect('#6033 attempts every config', visited.length === 4, `the round stopped after ${visited.length} of 4 config(s)`);
+  expect('#6033 collects both failures', round.failures.length === 2, `got ${round.failures.length}`);
+  expect('#6033 a thrown failure is collected, not escaped', round.failures.some((f) => f.configPath === 'a.ts'), 'an exception ended the round');
+  expect(
+    '#6033 keeps the configs that did measure',
+    Object.keys(round.current).length === 2 && round.current['b.ts'] === 7 && round.current['d.ts'] === 7,
+    `got ${JSON.stringify(round.current)}`,
+  );
+
+  // Two different causes stay two; ONE cause shared by several configs is stated
+  // once, with the configs it covers — #5217's rule, which the collecting shape
+  // must not undo on its way to satisfying #6033.
+  expect('#6033 distinct causes stay distinct', groupFailuresByCause(round.failures).length === 2, `got ${groupFailuresByCause(round.failures).length}`);
+  const sharedCause = groupFailuresByCause(
+    ['a.ts', 'b.ts', 'c.ts'].map((p) => ({
+      configPath: p,
+      // Same missing package, different absolute path per config — the same fact
+      // told three times, which must not become three verdicts.
+      ...explainConfigFailure(p, `Cannot find module '/repo/${p}/node_modules/@objectstack/spec/dist/index.mjs'`),
+    })),
+  );
+  expect('#6033 one cause is stated once', sharedCause.length === 1, `got ${sharedCause.length} cause(s) for one missing package`);
+  expect('#6033 …carrying every config it covers', sharedCause[0]?.configPaths.length === 3, `got ${JSON.stringify(sharedCause[0]?.configPaths)}`);
+
   if (failures.length) {
     console.error(`✗ check:i18n-coverage --self-test — ${failures.length} failure(s)\n`);
     for (const f of failures) console.error(`  ${f}`);
     process.exit(1);
   }
-  console.log('✓ check:i18n-coverage --self-test — the missing-CLI-build and i18n-rule classifiers both go red, and stay distinct.');
+  console.log('✓ check:i18n-coverage --self-test — the missing-CLI-build, i18n-rule and per-config-failure classifiers all go red, stay distinct, and a failing config does not end the round.');
 }
 
 if (process.argv.includes('--self-test')) {
@@ -330,6 +590,56 @@ function reportPrerequisiteNotMet(headline, detail) {
 }
 
 /**
+ * The collected verdict for configs that could not be measured (#6033) — one
+ * entry per DISTINCT cause, each naming the configs it covers.
+ *
+ * Reached only after the whole round has been attempted, which is the point: the
+ * reader gets every cause at once instead of the first one plus a node stack.
+ *
+ * It preempts the ratchet comparison, and that is deliberate rather than lazy. A
+ * partial round cannot judge this gate's question: an unmeasured config is
+ * indistinguishable from a deleted one, so the DOWN direction would tell the reader
+ * to `--update` — and `--update` runs before any comparison, so it would freeze the
+ * survivors and silently drop the rest, ratcheting real debt out of the baseline.
+ * The same invariant `reportPrerequisiteNotMet` states: nothing measured, nothing
+ * written.
+ *
+ * Exits 1, the same code every other verdict here uses.
+ */
+function reportUnmeasuredConfigs(failures, measuredCount) {
+  const groups = groupFailuresByCause(failures);
+  const total = failures.length + measuredCount;
+  const blocks = groups.map((g, i) =>
+    [
+      `Cause ${i + 1} of ${groups.length} — ${g.configPaths.length} config(s):`,
+      ...g.configPaths.map((p) => `  ${p}`),
+      ``,
+      `  why:  ${g.reason}`,
+      ...(g.evidence ? [`  saw:  ${g.evidence}`] : []),
+      `  fix:  ${g.fix}`,
+    ]
+      .map((l) => (l ? `  ${l}` : ''))
+      .join('\n'),
+  );
+  console.error(
+    `\ncheck-i18n-coverage: COULD NOT MEASURE — ${failures.length} of ${total} config(s) failed to lint ` +
+      `(${groups.length} distinct cause${groups.length === 1 ? '' : 's'})\n\n` +
+      blocks.join('\n\n') +
+      `\n\n  Every config was attempted, so the list above is EVERY one that failed — not\n` +
+      `  merely the first. One config's failure no longer ends the round (#6033), and a\n` +
+      `  cause shared by several configs is stated once, not once per config (#5217).\n\n` +
+      `  Nothing was compared: ${measuredCount} config(s) did lint, but a partial round cannot judge\n` +
+      `  the ratchet — an unmeasured config is indistinguishable from a deleted one, and\n` +
+      `  \`--update\` would freeze the survivors while silently dropping the rest. So this\n` +
+      `  result says NOTHING about whether any declared label went untranslated, and the\n` +
+      `  baseline was left exactly as committed (\`--update\` included).\n` +
+      `  (Exit code 1 — but piping this gate reports the PIPE's status, so\n` +
+      `  \`pnpm check:i18n-coverage | tail -4\` reads green either way. Use \`echo "EXIT=$?"\`.)`,
+  );
+  process.exit(1);
+}
+
+/**
  * Answered once, before the per-config loop — so a missing build costs one
  * verdict instead of an exception thrown from inside the first example, and
  * costs zero CLI spawns.
@@ -364,10 +674,13 @@ function checkCliBuildPrerequisite() {
 
 checkCliBuildPrerequisite();
 
-const current = {};
-for (const configPath of [...discoverExamples(), ...discoverPackages()]) {
-  current[configPath] = countI18nIssues(configPath);
-}
+const { current, failures: unmeasured } = measureAllConfigs(
+  [...discoverExamples(), ...discoverPackages()],
+  measureI18nIssues,
+);
+// Before `--update` writes anything, and before any comparison: a round that could
+// not measure every config has no verdict to give and no baseline to rewrite.
+if (unmeasured.length) reportUnmeasuredConfigs(unmeasured, Object.keys(current).length);
 
 if (update) {
   writeFileSync(BASELINE_PATH, JSON.stringify(current, null, 2) + '\n');


### PR DESCRIPTION
Fixes #6033

## 前提复核(行号漂移核对)

分诊评论(2026-08-07T06:56Z)的落点是按 `ede5a8e` 给的行号。在本 PR 的基点
`6131d90` 上按**内容**重新定位,四处全部命中,且行号几乎没有漂移:

| 分诊所指 | 本 worktree 实际 | 结论 |
|:---|:---|:---|
| `:178` 无输出裸 throw | `:178` `if (!raw.trim()) throw …` | 一致 |
| `:183` JSON 不可解析裸 throw | `:183` | 一致 |
| `:185` `report.error` 裸 throw | `:185` | 一致 |
| `:367-369` per-config 循环无 try/catch | `:367-370`(`const current = {}` 占 367) | 一致,差一行是起算点不同 |
| `:380-411` `errors[]` 收集器 | `:380-409` | 一致 |

premise **成立**,并且是实测复现的,不是读代码推断的。在一棵 `pnpm install`
之后只跑了 `pnpm exec turbo run build --filter=@objectstack/cli` 的树上,跑
`origin/main` 版本(逐字节原样,存放在 worktree 之外):

```
Error: os lint failed for examples/app-showcase/objectstack.config.ts: Cannot find module
'/…/examples/app-showcase/node_modules/@objectstack/connector-mcp/dist/index.mjs'
imported from /…/examples/app-showcase/objectstack.config.bundled_yqbr4ytyonb.mjs
    at countI18nIssues (…/check-i18n-coverage.mjs:185:29)
    at …/check-i18n-coverage.mjs:369:25
Node.js v22.22.2
```

注意它死在**第 2 个** config:第 1 个(app-crm)已经量到了数,第 3 到第 12 个
从未被尝试。这正是本单要修的形状 —— 诊断没说谎,但它吃掉了其余十一个。

## 改动叙述(单文件:`scripts/check-i18n-coverage.mjs`)

1. `countI18nIssues` 改名 `measureI18nIssues`,返回 `{count}` 或 `{failure}`,
   **不再为单个 config 抛异常**。原来三处裸 throw 各自变成一条带成因的失败:
   无输出(附 stderr 读数 —— 此前 stderr 只喂给签名网,其余丢弃)、JSON 不可
   解析(附截断后的载荷头)、`report.error`(交给分类器)。改名是因为职责变了;
   头注释里保留了含旧函数名的那段栈,grep 旧名仍能落到本文件。
2. 新增纯分类器 `explainConfigFailure`:把 CLI 原话变成「结论 + 一句修法」。
   唯一值得做的判别是模块解析 —— 指向某个包 `dist/` 的 `Cannot find module`
   ⇒ 「已安装但没有构建产物」+ `pnpm build`;只点名包 ⇒ `pnpm install && pnpm build`;
   其余一律保留 CLI 原话并给出手动重跑命令。**真正坏掉的 config 不会被判成
   「没构建」**——那会是 #5862 那个「自信却指向无辜处」的缺陷换个层级重演。
3. 新增 `measureAllConfigs(configPaths, measure)`:跑完整轮、收集失败;`measure`
   是注入的,所以 `--self-test` 能在没有 CLI、没有构建的情况下证明「一个 config
   失败不中止整轮」——而这恰恰是 CI 永远观察不到的行为。
4. 新增 `reportUnmeasuredConfigs`:整轮结束后一次性报告,**按结论去重**。
   #5217 的规矩(一个原因不要报成 N 个结果)在这里必须继续成立:十二个 config
   因同一个包没构建而失败,是同一个事实说了十二遍,只能算一条成因、列出它覆盖的
   config。反方向(本单)则是 N 个不同成因各占一条,不被第一个吃掉。
5. **失败时抢在 `--update` 写盘与比对之前退出**。这一条不是省事,是安全性:
   半轮没有结论可给 —— 没测到的 config 与被删掉的 config 无法区分,DOWN 方向会
   叫读者去 `--update`,而 `--update` 跑在任何比对之前,会冻结幸存者、悄悄丢掉
   其余,把真实债务从 baseline 里棘轮出去。与 `reportPrerequisiteNotMet` 同一条
   不变量:没测就不写。
6. CLI 未构建那条前置**仍然**在第一个 config 就中止 —— 有意保留:每个后续 config
   都会因同一个环境原因失败,继续跑只会把一个事实印十二遍。

用户可见面为零(仓内工具链,不发布任何包)⇒ 无 changeset,PR 打 `skip-changeset`。

## 反向验证(先申报预期,后执行)

### 声明 A(回归面)—— 申报

完整构建后(等价 lint.yml 的 *Build workspace packages*),`origin/main` 版与本版
在同一棵树上跑,stdout/stderr 与退出码**逐字节一致**。

**实测:一致。**

```
sha256(A-main.out) = ebccfd34d946968f7647affbbc72c559707a306981e14e992f1c715538a99b34
sha256(A-mine.out) = ebccfd34d946968f7647affbbc72c559707a306981e14e992f1c715538a99b34   ← 同
stderr 双方均为 0 字节(e3b0c442…855 = 空串)
MAIN EXIT=0        MINE EXIT=0
输出:check-i18n-coverage: OK (12 config(s), 660 baselined untranslated string(s), none new).
```

`--update` 写盘路径同样未变:完整构建后跑 `--update`,baseline 的 md5 与提交态相同。

**唯一的合理差异(申报在此,不算违反 A)**:`--self-test` 的成功摘要行按惯例列出
它证明了哪些分类器,本 PR 新增了一个,所以那一行文字变了:

- 之前:`… the missing-CLI-build and i18n-rule classifiers both go red, and stay distinct.`
- 之后:`… the missing-CLI-build, i18n-rule and per-config-failure classifiers all go red, stay distinct, and a failing config does not end the round.`

### 声明 B(目标面)—— 申报

树的状态:`pnpm install` 后仅 `pnpm exec turbo run build --filter=@objectstack/cli`
(55 个 task;`packages/connectors/*` 四个包确认无 dist)。N = 12 个 config
(3 个 example + 9 个 package extract config),先数出来再跑。

预期:① 输出中不出现 node 栈;② 12 个 config 全部被尝试;③ 恰好 1 个失败 ——
`examples/app-showcase`,成因点名 `@objectstack/connector-mcp`「已安装但没有构建
产物」,修法 `pnpm build`,其余 11 个量到数;④ 末尾一次性报告,退出码 1;
⑤ baseline 不被改写。

(为什么只预期 1 个:app-crm / app-todo 只 import `@objectstack/spec`(已构建),
9 个 extract config 只 import `../src/*` 与 spec,唯有 app-showcase import 了四个
未构建的 connector。这是数出来的,不是猜的。)

**实测:五条全中。**

```
EXIT=1

check-i18n-coverage: COULD NOT MEASURE — 1 of 12 config(s) failed to lint (1 distinct cause)

  Cause 1 of 1 — 1 config(s):
    examples/app-showcase/objectstack.config.ts

    why:  `os lint` could not load the config: `@objectstack/connector-mcp` is installed but has no build output in this worktree
    saw:  Cannot find module '/…/examples/app-showcase/node_modules/@objectstack/connector-mcp/dist/index.mjs' imported from /…/objectstac…
    fix:  pnpm build

  Every config was attempted, so the list above is EVERY one that failed — not
  merely the first. …
  Nothing was compared: 11 config(s) did lint, but a partial round cannot judge
  the ratchet — … the baseline was left exactly as committed (`--update` included).
```

`md5sum -c` 确认 baseline 未被改写;同状态下再跑 `--update`,同样是这条判词、
EXIT=1、baseline 未动(改动第 5 点的安全性,实测过,不是只写在注释里)。

### 声明 B2(多 config / 共有成因)—— 申报过、结果与预期不符,如实记录

申报:把 `packages/spec/dist` 移走,12 个 config 应全部以**同一个**成因失败,
报告应显示 **1 条成因覆盖 12 个 config**(而不是 12 条判词)。

**实测:不符,原因是探针选错了,不是实现不符预期。** 移走 spec 的 dist 会让
**CLI 自己**跑不起来,于是 #5862 的签名网先一步命中,整轮在第 1 个 config 就以
`PREREQUISITE NOT MET — the built CLI cannot resolve the command this gate runs`
中止 —— 这正是那条前置**应有**的行为,顺带成了「本 PR 没弄坏 #5862 那条路径」的
回归证据。

第二次尝试:改为移走三个叶子包的 dist(`observability` / `trigger-record-change`
/ `plugin-sharing`),预期这些 extract config 会各自失败。**实测仍只有 1 个失败**
—— 因为 9 个 extract config 只 import `../src/` 下的对象与译文定义文件,那些文件
只依赖 `@objectstack/spec`,压根不碰这些运行时包。同一棵树上跑 `origin/main` 版,
它照旧只报 app-showcase 一条然后带栈死掉。

结论(如实申报,不改预期迁就结果):**今天这棵仓库的拓扑下,不动 `examples/**`
就构造不出「多个 config 因不同成因失败」的自然状态** —— 唯一能这样失败的是
app-showcase。所以「N 个成因不被第一个吃掉」这条性质由 `--self-test` 里的注入式
`measure` 确定性地钉住(4 个 config、2 个不同成因、其中一个还是 throw 出来的),
而不是靠一次凑出来的实跑。这些断言不是摆设,已用变异体验证会红:

| 变异体(仅在 worktree 之外的副本上) | 结果 |
|:---|:---|
| 去掉 `measureAllConfigs` 的 try/catch | 断言未及执行,注入的异常直接逃逸整轮 → EXIT=1 |
| 分组键从「结论」换成「读数」 | `#6033 one cause is stated once — got 3 cause(s) for one missing package` 等 2 条红 → EXIT=1 |

## 门禁 EXIT 表(均在 `git add` 之后跑)

| 门 | 命令 | EXIT |
|:---|:---|:---|
| NUL / 控制字节 | `pnpm check:nul-bytes` | **0**(自测 56 断言 + 扫描 5961 个已跟踪文本文件) |
| 语法 | `node --check scripts/check-i18n-coverage.mjs` | **0** |
| ESLint | `pnpm exec eslint scripts/check-i18n-coverage.mjs --no-inline-config` | **0** |
| 本门自身 | `pnpm check:i18n-coverage`(self-test && 实跑) | **0** |
| 同族邻门(共享模块未动的回归) | `pnpm check:i18n` | **0** |
| 自扫控制字节(超出门禁盲区) | `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` | 无命中 |

`package.json` 未改(`check:i18n-coverage` 早已接好 `--self-test`,新断言直接进
既有自测,不需要新文件、不需要新接线)。

## 不在本 PR 里

- **不动** `.github/workflows/**`、`examples/**`、`packages/**`、`content/**`;文件面
  就是 `scripts/check-i18n-coverage.mjs` 一个文件。
- **不动**共享的 `scripts/cli-build-prerequisite.mjs`,也不改 #5862 那条前置的措辞与
  时机(它在第一个 config 中止是对的)。
- 家族 #5795(根 `dev` 入口)/ #5794(datasource fail-fast)只读参考,**未顺手修**。
- 未新建 `.changeset/`:仓内工具链,不发布任何包 ⇒ 走 `skip-changeset` 标签。
- 过程中未发现需要另立单的缺陷(B2 那两次探针的结果是拓扑事实,不是缺陷)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_