### PR TITLE
docs(spec): fallbackNodeId 墓碑迁移文案 `condition 'fault'` → `type: 'fault'` (#6094)

### DIFF
--- a/.changeset/fault-edge-tombstone-type.md
+++ b/.changeset/fault-edge-tombstone-type.md
@@ -1,0 +1,29 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): the `fallbackNodeId` tombstone names the key that actually routes faults (#6094)
+
+`flow.errorHandling.fallbackNodeId` was retired in 17.0.0 (#3896), and its
+migration message tells the author what to draw instead. It named the wrong key:
+
+- FROM: "the engine routes unrecoverable node errors via per-node fault edges
+  (an edge with **condition `'fault'`**)"
+- TO: "… (an edge with **`type: 'fault'`**)"
+
+`condition` on `FlowEdgeSchema` is a **CEL predicate** returning boolean
+(`flow.zod.ts` — `ExpressionInputSchema`), while the fault/default/conditional/back
+routing lives on `type` (`z.enum([...])`). An author following the old wording
+verbatim would write `{ source, target, condition: 'fault' }`, which **parses
+clean** — `condition` accepts any expression string — and produces an ordinary
+edge that is not a fault path. So the tombstone handed them a second silently
+inert key in exchange for the one it took away: they delete a fallback that never
+existed, then draw a fault edge that isn't one.
+
+The repo already states the correct rule elsewhere (`flows.mdx`: "`type: 'fault'`
+is what routes — a label is not"), and every other mention in the tree spells it
+`type: 'fault'`; this was the only site out of step. The closing sentence
+("draw a fault edge from the failing node to the handler node instead") was
+already correct and is unchanged.
+
+Message text only — no schema, validation, or runtime behaviour changes.

--- a/packages/spec/src/automation/flow.zod.ts
+++ b/packages/spec/src/automation/flow.zod.ts
@@ -712,7 +712,7 @@ export const FlowSchema = lazySchema(() => z.object({
     fallbackNodeId: retiredKey(
       '`flow.errorHandling.fallbackNodeId` was removed in @objectstack/spec 17.0.0 (#3896 ' +
       'audit close-out) — the engine routes unrecoverable node errors via per-node fault ' +
-      "edges (an edge with condition 'fault'), and never read this key: a fallback " +
+      "edges (an edge with type: 'fault'), and never read this key: a fallback " +
       'configured here silently did not exist. Delete the key and draw a fault edge from ' +
       'the failing node to the handler node instead.',
     ),


### PR DESCRIPTION
Fixes #6094

一行修正:`flow.zod.ts:715` 的退役墓碑教作者画「an edge with condition 'fault'」,但 fault 路由在 `type`(:440 枚举),`condition` 是 CEL 谓词 —— 照抄会得到 parse 干净却永不路由的普通边。改为 `an edge with type: 'fault'`。全仓唯一错拼写(正控:`type: 'fault'` 命中 flows.mdx:864 / bpmn-mapping.ts:269 / flow.test.ts ×2);末句本就正确,保留;范围钉死单句。changeset patch。

> 本 PR 由 PM 代云端工头 dev(`session_017LsRBm4LohvZJcjbSfkfeH`,wave-5 卡 1/6)开出。dev 终报将转录至 #6094。spec 8476 测试绿;check:docs 绿;api-surface 陈旧为 main 既存(stash 对照实证),未夹带重生成。

---
_Generated by [Claude Code](https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY)_