### PR TITLE
fix(scripts): digest 的回落读取不再刷一屏 git `fatal:`,改说一句可读事实 (#6175)

### DIFF
--- a/scripts/objectui-changeset-digest.mjs
+++ b/scripts/objectui-changeset-digest.mjs
@@ -69,12 +69,45 @@
 //
 // This criterion changes the ANNOTATION and the COUNT only. The collected set is
 // untouched: nothing is admitted or dropped because of it.
+//
+// WHY THE FALLBACK IS QUIET, AND WHY IT STILL SAYS SO (#6175)
+// ----------------------------------------------------------
+// `readAt` reads each changeset at `to` and falls back to the commit that ADDED
+// it, because a changeset consumed by a release INSIDE the range is gone at `to`
+// (the reason `collectAddedChangesets` walks the log instead of diffing the
+// endpoints). The fallback works, and the artifact it produces is complete.
+//
+// It used to ANNOUNCE ITSELF AS A FAILURE anyway. `execFileSync` sends the
+// child's stderr to ours unless `stdio` says otherwise, so the first `git show`
+// printed git's own `fatal: path … does not exist in …` before `catch` could run
+// — one line per changeset, then one line saying everything succeeded. Measured
+// on the real pin bump `f995a452d2ca..7dfbeb704e1e` (#6159 / PR #6173): 9
+// `fatal:` lines, 9 complete entries, exit 0.
+//
+// That is the MIRROR of the rule this file already enforces. #4731 wrote "a
+// degraded list and a complete one must never look alike"; here a COMPLETE list
+// looked like a failure. The two failure modes cost the same, because the next
+// reader's first instinct is "the digest is broken, write the changeset by hand
+// with `--no-changeset`" — and that hand-written path really does drop all 9
+// releasing entries. Noise that points at the wrong remedy is not merely noise.
+//
+// So the first attempt CAPTURES its stderr instead of inheriting it, and the
+// fallback is reported once, as a fact, beside the accounting line
+// (`absentAtTo`). Two things this deliberately does not do:
+//
+//   * It does not go silent. Silence would trade a misleading line for no line,
+//     and "this range crossed a release" is worth exactly one sentence — the
+//     same reason the cap and the degraded list announce themselves (#4731).
+//   * It does not mute FAILURE. When BOTH reads fail nothing was read and the
+//     entry would vanish, so both captured diagnostics are re-emitted, named by
+//     attempt, and the error still propagates. Quiet is earned by the fallback
+//     that worked; it is never extended to the one that did not.
 
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -84,11 +117,20 @@ export const DEFAULT_MAX_ENTRIES = 100;
 
 const LEVEL_RANK = { patch: 1, minor: 2, major: 3 };
 
-/** @param {string} cwd @param {string[]} args */
-function git(cwd, args) {
+/**
+ * @param {string} cwd
+ * @param {string[]} args
+ * @param {{ captureStderr?: boolean }} [options] `captureStderr` routes the
+ *   child's stderr into the thrown error instead of ours. Leave it OFF by
+ *   default: an unset `stdio` inherits our stderr (`execFileSync`'s documented
+ *   behaviour), which is what a call whose failure is a real failure should do.
+ *   Turn it on only where a failure is EXPECTED and retried — `readAt` (#6175).
+ */
+function git(cwd, args, { captureStderr = false } = {}) {
   return execFileSync('git', ['-C', cwd, ...args], {
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,
+    ...(captureStderr ? { stdio: ['ignore', 'pipe', 'pipe'] } : {}),
   });
 }
 
@@ -309,12 +351,54 @@ export function collectAddedChangesets(objectuiRoot, from, to) {
   };
 }
 
-/** Read a changeset's content at `to`, falling back to the commit that added it. */
-function readAt(objectuiRoot, to, sha, path) {
+/** A failed `execFileSync` rendered as the child's own diagnostic, indented. */
+function gitDiagnostic(err) {
+  const captured = typeof err?.stderr === 'string' ? err.stderr : '';
+  const text = captured.trim() || err?.message || String(err);
+  return text
+    .split('\n')
+    .map((line) => `    ${line}`)
+    .join('\n');
+}
+
+/**
+ * Read a changeset's content at `to`, falling back to the commit that added it.
+ *
+ * `fellBack` is the caller's only handle on "this range crossed a release".
+ * git's own `fatal:` used to be that handle by accident — which made a complete
+ * result read as a failed one, the defect #6175 records; see the header note.
+ *
+ * Exported for the self-test: the both-reads-failed branch cannot be reached
+ * through `classifyRange`, whose `sha` always comes from `--diff-filter=A` and
+ * therefore always has the path. An error path no test can enter is an error
+ * path that quietly rots into silence, which is the one outcome #6175 forbids.
+ *
+ * @returns {{ text: string, fellBack: boolean }}
+ */
+export function readAt(objectuiRoot, to, sha, path) {
   try {
-    return git(objectuiRoot, ['show', `${to}:${path}`]);
-  } catch {
-    return git(objectuiRoot, ['show', `${sha}:${path}`]);
+    return {
+      text: git(objectuiRoot, ['show', `${to}:${path}`], { captureStderr: true }),
+      fellBack: false,
+    };
+  } catch (atTo) {
+    try {
+      return {
+        text: git(objectuiRoot, ['show', `${sha}:${path}`], { captureStderr: true }),
+        fellBack: true,
+      };
+    } catch (atSha) {
+      // BOTH reads failed: nothing was read, and this entry is about to be lost
+      // from the release record. Say so with everything git told us, twice over.
+      console.error(
+        `✗ objectui-changeset-digest: cannot read ${path} — neither at \`to\` nor at the commit that added it.`,
+      );
+      console.error(`  at \`to\` (${to}):`);
+      console.error(gitDiagnostic(atTo));
+      console.error(`  at the commit that added it (${sha}):`);
+      console.error(gitDiagnostic(atSha));
+      throw atSha;
+    }
   }
 }
 
@@ -366,7 +450,11 @@ export function inPreMode(frameworkRoot) {
  * Nothing here reads a commit type. Grouping output BY type is presentation and
  * belongs to the caller; it must never become a filter again.
  *
- * @returns {{ releasing: Array<object>, releaseNothingEntries: Array<object>, noChangesetCommits: Array<object>, releaseNothing: number, noChangeset: number, changesetsAdded: number, totalCommits: number }}
+ * `absentAtTo` counts the changesets that were gone at `to` and had to be read
+ * from the commit that added them — the readable form of what used to arrive as
+ * a screenful of git `fatal:` lines (#6175).
+ *
+ * @returns {{ releasing: Array<object>, releaseNothingEntries: Array<object>, noChangesetCommits: Array<object>, releaseNothing: number, noChangeset: number, changesetsAdded: number, absentAtTo: number, totalCommits: number }}
  */
 export function classifyRange({ objectuiRoot, from, to }) {
   const { entries, commits, totalCommits, commitsWithChangesetShas } = collectAddedChangesets(
@@ -377,10 +465,11 @@ export function classifyRange({ objectuiRoot, from, to }) {
 
   const releasing = [];
   const releaseNothingEntries = [];
+  let absentAtTo = 0;
   for (const entry of entries) {
-    const { packages, summary, body } = parseChangeset(
-      readAt(objectuiRoot, to, entry.sha, entry.path),
-    );
+    const read = readAt(objectuiRoot, to, entry.sha, entry.path);
+    if (read.fellBack) absentAtTo++;
+    const { packages, summary, body } = parseChangeset(read.text);
     const level = highestLevel(packages);
     if (!level) {
       releaseNothingEntries.push({ ...entry, summary: summary || entry.subject });
@@ -414,6 +503,7 @@ export function classifyRange({ objectuiRoot, from, to }) {
     releaseNothing: releaseNothingEntries.length,
     noChangeset: noChangesetCommits.length,
     changesetsAdded: entries.length,
+    absentAtTo,
     totalCommits,
   };
 }
@@ -421,7 +511,7 @@ export function classifyRange({ objectuiRoot, from, to }) {
 /**
  * Build the digest for a range.
  *
- * @returns {{ bump: string, declaredLevel: string|null, breaking: number, breakingByLevel: number, breakingByAnnotation: number, releasing: Array<object>, releaseNothing: number, noChangeset: number, totalCommits: number, downgradedMajor: boolean, body: string }}
+ * @returns {{ bump: string, declaredLevel: string|null, breaking: number, breakingByLevel: number, breakingByAnnotation: number, releasing: Array<object>, releaseNothing: number, noChangeset: number, changesetsAdded: number, absentAtTo: number, totalCommits: number, downgradedMajor: boolean, body: string }}
  */
 export function buildDigest({
   objectuiRoot,
@@ -431,11 +521,12 @@ export function buildDigest({
   max = DEFAULT_MAX_ENTRIES,
   bumpOverride = '',
 }) {
-  const { releasing, releaseNothing, noChangeset, changesetsAdded, totalCommits } = classifyRange({
-    objectuiRoot,
-    from,
-    to,
-  });
+  const { releasing, releaseNothing, noChangeset, changesetsAdded, absentAtTo, totalCommits } =
+    classifyRange({
+      objectuiRoot,
+      from,
+      to,
+    });
 
   const declaredLevel = releasing.length
     ? releasing.reduce(
@@ -533,6 +624,8 @@ export function buildDigest({
     releasing,
     releaseNothing,
     noChangeset,
+    changesetsAdded,
+    absentAtTo,
     totalCommits,
     downgradedMajor,
     body,
@@ -611,6 +704,22 @@ function main(argv) {
       `${digest.releaseNothing} release-nothing, ${digest.noChangeset} commit(s) without a changeset` +
       (digest.downgradedMajor ? ' — declared major recorded as minor (launch window)' : ''),
   );
+
+  // #6175: the one sentence that replaces the screenful of git `fatal:` lines.
+  // It lands HERE, beside the accounting line on stderr, and NOT in the
+  // changeset body: the body records what the range released, and how the tool
+  // had to read a file is not a fact about the release. The reader who needs it
+  // is the operator watching this run — the same reader the `fatal:` lines used
+  // to mislead. Printed only when it fires, so a range that crossed no release
+  // gains no new line (silence here means "nothing to explain", never "nothing
+  // happened" — the absence itself is not load-bearing).
+  if (digest.absentAtTo > 0) {
+    console.error(
+      `→ ${digest.absentAtTo} of ${digest.changesetsAdded} changeset(s) added in this range ` +
+        `no longer exist at ${short} — a release consumes the changesets it ships; ` +
+        `each was read from the commit that added it, so the account above is complete.`,
+    );
+  }
 
   if (out) {
     mkdirSync(dirname(out), { recursive: true });
@@ -1038,6 +1147,140 @@ function selfTest() {
         degraded.includes('**Degraded list**') &&
         degraded.includes('NOT a\ncomplete account'),
       degraded,
+    );
+
+    // --- #6175: a range whose `to` endpoint is a RELEASE COMMIT -------------
+    // The shape that made a COMPLETE result look like a failure. A release
+    // consumes the changesets it ships, so every changeset added in the range
+    // is gone at `to` and every read falls back. Its own repo on purpose: the
+    // #4731 / #6099 fixtures above pin exact counts and must not shift under it.
+    const ui3 = join(tmp, 'objectui-released');
+    mkdirSync(join(ui3, '.changeset'), { recursive: true });
+    const g3 = (...args) => git(ui3, args);
+    g3('init', '-q', '-b', 'main');
+    g3('config', 'user.email', 'selftest@objectstack.ai');
+    g3('config', 'user.name', 'self test');
+    g3('config', 'commit.gpgsign', 'false');
+    const commit3 = (subject, files, removals = []) => {
+      for (const [path, content] of Object.entries(files)) {
+        mkdirSync(dirname(join(ui3, path)), { recursive: true });
+        writeFileSync(join(ui3, path), content);
+      }
+      for (const path of removals) rmSync(join(ui3, path), { force: true });
+      g3('add', '-A');
+      g3('commit', '-q', '-m', subject);
+      return g3('rev-parse', 'HEAD').trim();
+    };
+
+    const base3 = commit3('chore: base', { 'README.md': 'base\n' });
+    commit3('feat(grid): column pinning survives a layout reload (#3401)', {
+      '.changeset/grid-column-pinning-survives-reload.md':
+        '---\n"@object-ui/plugin-grid": minor\n---\n\nGrid column pinning survives a layout reload.\n',
+      'src/grid.ts': 'a\n',
+    });
+    commit3('fix(fields): the lookup picker keeps the authored value (#3402)', {
+      '.changeset/lookup-picker-keeps-authored-value.md':
+        '---\n"@object-ui/fields": patch\n---\n\nThe lookup picker keeps the authored value.\n',
+      'src/fields.ts': 'b\n',
+    });
+    const release3 = commit3(
+      'chore: release packages (#3403)',
+      { 'package.json': '{"version":"17.1.0"}\n' },
+      [
+        '.changeset/grid-column-pinning-survives-reload.md',
+        '.changeset/lookup-picker-keeps-authored-value.md',
+      ],
+    );
+
+    const released = buildDigest({
+      objectuiRoot: ui3,
+      frameworkRoot: fwPlain,
+      from: base3,
+      to: release3,
+    });
+    check(
+      '#6175 a range crossing a release still collects every changeset',
+      released.releasing.length === 2 && released.changesetsAdded === 2,
+      `releasing=${released.releasing.length} added=${released.changesetsAdded}`,
+    );
+    check(
+      '#6175 the fallback is COUNTED, not merely survived',
+      released.absentAtTo === 2,
+      `got ${released.absentAtTo}`,
+    );
+
+    // The CLI runs as a CHILD so its real stderr can be read: that stream is
+    // where git's `fatal:` used to land, and no in-process assertion can see it.
+    const selfPath = fileURLToPath(import.meta.url);
+    const runCli = (root, from, to, label) =>
+      spawnSync(
+        process.execPath,
+        [
+          selfPath,
+          '--objectui-root', root,
+          '--framework-root', fwPlain,
+          '--from', from,
+          '--to', to,
+          '--out', join(tmp, `cli-${label}.md`),
+        ],
+        { encoding: 'utf8' },
+      );
+
+    const fellBack = runCli(ui3, base3, release3, 'released');
+    check(
+      '#6175 the fallback no longer leaks git `fatal:` onto stderr',
+      fellBack.status === 0 && !fellBack.stderr.includes('fatal:'),
+      fellBack.stderr,
+    );
+    check(
+      '#6175 the fallback SAYS SO — once, with the real count',
+      /^→ 2 of 2 changeset\(s\) added in this range no longer exist at [0-9a-f]{12} —/m.test(
+        fellBack.stderr,
+      ) && fellBack.stderr.split('no longer exist at').length === 2,
+      fellBack.stderr,
+    );
+    const quietArtifact = readFileSync(join(tmp, 'cli-released.md'), 'utf8');
+    check(
+      '#6175 the artifact stays COMPLETE — the quiet read is the whole read',
+      quietArtifact.includes('Grid column pinning survives') &&
+        quietArtifact.includes('lookup picker keeps the authored value'),
+      quietArtifact,
+    );
+
+    const noFallback = runCli(ui, base, head, 'plain');
+    check(
+      '#6175 a range that crossed no release gains NO new line',
+      noFallback.status === 0 &&
+        !noFallback.stderr.includes('no longer exist at') &&
+        !noFallback.stderr.includes('fatal:'),
+      noFallback.stderr,
+    );
+
+    // Both reads failing is a REAL failure — nothing was read and the entry
+    // would vanish from the record. Quiet is earned by the fallback that
+    // worked; it is never extended to this. Driven through the exported
+    // `readAt` because `classifyRange` cannot reach the branch: its `sha`
+    // comes from `--diff-filter=A` and therefore always has the path.
+    const probe = join(tmp, 'probe-both-reads-fail.mjs');
+    writeFileSync(
+      probe,
+      `import { readAt } from ${JSON.stringify(pathToFileURL(selfPath).href)};\n` +
+        `readAt(${JSON.stringify(ui3)}, ${JSON.stringify(release3)}, ${JSON.stringify(base3)}, ` +
+        `'.changeset/never-existed.md');\n`,
+    );
+    const bothFail = spawnSync(process.execPath, [probe], { encoding: 'utf8' });
+    check(
+      '#6175 when BOTH reads fail the failure is LOUD, naming both attempts',
+      bothFail.status !== 0 &&
+        bothFail.stderr.includes('cannot read .changeset/never-existed.md') &&
+        bothFail.stderr.includes(release3) &&
+        bothFail.stderr.includes(base3),
+      bothFail.stderr,
+    );
+    check(
+      "#6175 both attempts' git diagnostics are re-emitted, not swallowed",
+      (bothFail.stderr.match(/fatal:/g) ?? []).length >= 2,
+      bothFail.stderr,
     );
   } finally {
     rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
Fixes #6175

`readAt()` 的回落路径本身是对的 —— 坏的是它把一次**完整**的结果打成了一次失败的样子。本 PR 落地分诊 07:57Z 同意的 **B + C** 组合:B 消掉误导,C 把「发生了回落」从噪声变成一句可读的事实。

## 前提复核(#6289 合并后)

- 分支从 `origin/main` @ `3264516` 切出,已含 PR #6289(`7330c1d`,判据扩到「声明 major 或作者正文标注」)。
- issue 正文把 `readAt()` 记在 :186–192;#6289 之后**行号漂移到 :313–319**,函数体逐字一致(`try { git show ${to}:${path} } catch { git show ${sha}:${path} }`)。按内容定位,前提成立。
- 机制当场复现,不是推断:`execFileSync` 未指定 `stdio` 时子进程 stderr 直接接到父进程的 stderr,所以第一次 `git show` 的 `fatal:` 在 `catch` 跑起来之前就已经写出去了。

### 一处派发单事实更正

派发单称重放区间 `f5bc4c78be76...f995a452d2ca` 的 `to` 是 release commit。实测**不是**:

| sha | 真实 subject |
| --- | --- |
| `f995a452d2ca` | `ci(scripts): type-check scripts/ via a standalone tsconfig.scripts.json (#3494)` |
| `7dfbeb704e1e` | `chore: release packages (#3248)` ← 真正的 release commit |

`7dfbeb704e1e` 正是 issue 正文自己观察到的那次 pin bump 的 `to`。所以主重放改用 issue 自己的区间 `f995a452d2ca..7dfbeb704e1e`(**会**回落),并把派发单给的 `f5bc4c78be76..f995a452d2ca`(**不**回落)留作零回落对照组 —— 比原计划多出一个方向的证据。

## 实现(仅 `scripts/objectui-changeset-digest.mjs`)

### B — 第一次尝试静默,但只静默「成功的回落」

`git()` 增加 `captureStderr` 选项(默认关):打开时用 `stdio: ['ignore', 'pipe', 'pipe']` 把子进程 stderr 收进抛出的 error,而不是接到我们自己的 stderr。默认关是有意的 —— 失败即失败的调用(例如 `main()` 里那次 `git cat-file -e` 端点探测)应当继续把 git 的诊断直接打出来。

`readAt()` 因此变成:第一次尝试捕获 stderr;失败则回落到「添加它的那个 commit」,同样捕获;**两次都失败**时把两次的诊断按尝试点名重新打出来再继续抛错:

```
✗ objectui-changeset-digest: cannot read .changeset/never-existed.md — neither at `to` nor at the commit that added it.
  at `to` (9b4f60aa1055f38a27a159d1ab2779fae2735d2e):
    fatal: path '.changeset/never-existed.md' does not exist in '9b4f60aa1055…'
  at the commit that added it (9b4f60aa1055f38a27a159d1ab2779fae2735d2e):
    fatal: path '.changeset/never-existed.md' does not exist in '9b4f60aa1055…'
```

安静是「回落成功」挣来的,永不外借给真正的失败 —— 彻底失败比改前更响(多了一行点名摘要和两段按尝试标注的诊断,退出码不变)。

### C — 回落发生时,在 accounting 行旁说一句事实

`classifyRange()` 统计 `absentAtTo`(实际发生回落的 changeset 数,`entries` 已按 path 去重,故一条只记一次),经 `buildDigest()` 透传到 CLI,在 accounting 行**之后**打一句、且仅在大于 0 时打:

```
→ 9 of 9 changeset(s) added in this range no longer exist at 7dfbeb704e1e — a release consumes the changesets it ships; each was read from the commit that added it, so the account above is complete.
```

两个刻意的落点选择:

1. **落在 stderr,不落在 changeset 正文。** 正文记录的是「这个区间发布了什么」,而「工具怎么读到这个文件」不是发布事实;需要这句话的是盯着这次运行的操作者,也正是当初被那九行 `fatal:` 误导的那个读者。
2. **措辞不做主观断言。** 不去读 `to` 的 subject 判断它是不是 release commit —— 那正是 #4731 从这个文件里清掉的 subject 推断。只陈述实测事实(N 条在 `to` 处不存在、各自从添加它的 commit 读到),再用一句通用机制解释。

## 真实区间重放(改前 / 改后)

**主重放 `f995a452d2ca..7dfbeb704e1e`(`to` = release commit,9 次回落)**

| | 改前 | 改后 |
| --- | --- | --- |
| stdout sha256 | `539eb31c7b0674b9…` | `539eb31c7b0674b9…` **逐字节不变**(`cmp` exit 0) |
| stderr `fatal:` 行数 | **9** | **0** |
| stderr accounting 行 | `→ 9 releasing changeset(s), 0 breaking (0 declared major, 0 annotated), 0 release-nothing, 20 commit(s) without a changeset` | 同上,**逐字不变** |
| stderr 新增 | — | 一行 C 句(`→ 9 of 9 changeset(s) … the account above is complete.`) |
| 退出码 | 0 | 0 |

**对照组 `f5bc4c78be76..f995a452d2ca`(0 次回落)**:stdout **和** stderr **双流逐字节不变**(`cmp` 两次 exit 0)—— 没有回落就没有新行,C 不制造新噪声。

## 反向验证(先申报,后执行)

两个变异体都**先申报预期方向再跑**,实测逐条对上:

**M1 —— 撤掉 B(第一次尝试恢复继承 stderr),保留全部新断言**

- 申报:`#6175 the fallback no longer leaks git fatal: onto stderr` 转红;其余 7 条 #6175 断言应**保持绿**(零回落那条的区间根本不失败;两条彻底失败断言里,第一次的 `fatal:` 泄漏到同一条流、第二次仍被捕获重发,`fatal:` 计数与双 sha 断言都还成立)。
- 实测:**恰好 1 红**,正是申报那条;真实区间同时恢复刷九行 `fatal:`。申报命中。

**M2 —— 删掉 C 的输出,其余不动**

- 申报:`#6175 the fallback SAYS SO — once, with the real count` 转红。并且**明确申报另外两条不会转红**,理由是结构性的,不是运气:`a range that crossed no release gains NO new line` 是一条**否定式**断言,把 C 整个删掉恰好平凡地满足它;`the fallback is COUNTED` 读的是返回值上的 `absentAtTo` 字段而不是打印出来的那行。
- 实测:**恰好 1 红**,正是申报那条;那两条如申报保持绿。

这一条与派发单模板不同,如实记录:派发单写的是「删掉 C ⇒ (a/c 相关断言转红」,实测只有 (a) 侧那条**肯定式**断言会红。一条否定式断言在构造上无法察觉「它所禁止的东西被删掉了」—— 这正是那条 CLI 子进程肯定式断言必须单独存在的原因,两条并不冗余。

## self-test

`--self-test` 从 #6289 的 37 条 → **45 条**,新增 8 条独立成组,⛔ 未改 #4731 / #6099 既有 fixture 的任何精确计数(新建第三个临时仓库 `objectui-released`:两条 changeset 各自被一个 commit 添加,再由一个 `chore: release packages` commit 一并删除,范围 `base..release` 同时含增与删)。

其中 3 条通过 **spawnSync 子进程跑真实 CLI**:git 的 `fatal:` 落在真实 stderr 上,进程内断言根本看不见它。彻底失败那条通过新导出的 `readAt` 驱动 —— `classifyRange` 到不了那个分支(它的 `sha` 来自 `--diff-filter=A`,路径必然存在),而一条测试进不去的错误路径,正是会悄悄烂成静默的那条。

## 门禁(均在 `git add` 之后跑)

| 门禁 | EXIT |
| --- | --- |
| `pnpm check:objectui-changeset`(digest 45 条 + objectui-range 自测) | **0** |
| `pnpm exec eslint scripts/objectui-changeset-digest.mjs --no-inline-config` | **0** |
| `pnpm check:nul-bytes` | **0**(56 断言自测 + 扫 5978 个跟踪文本文件) |
| 控制字节自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` | grep exit **1**(无命中 = 干净) |

## 不在本 PR 里

- **A 方案(先 `git cat-file -e` 探测再读)未采纳**:它把回落变得**完全无声**,与本仓刚立的 absence/degradation must be loud 反向。B + C 保留「发生了回落」这个事实,只是把它从九行噪声压成一句可读的话。
- **`bump-objectui.sh` 一字未动** —— 它只是调用方,`fatal:` 出自 digest 的 `readAt()`。
- **`scripts/objectui-range.mjs` 未动**(#6174 的面,该单在本 PR 合并后才派)。它经 `classifyRange` 消费本文件,新增的 `absentAtTo` 是纯增量字段,不改变任何既有返回值。
- **pin 一律不动**:不重跑、不改任何 pin;#6159 / PR #6173 的产物已核对无误,产物正确性不在本单范围。
- **`main()` 里 `git cat-file -e` 端点探测的 `fatal:` 保留**:那条路径失败即真失败(随后 `✗ … cannot walk …` 并 exit 2),响亮是对的,与本单要修的「完整结果长得像失败」不是一回事。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_