### PR TITLE
docs(lint): 按实测改正 `normalized` 输入层的三条依据,并补回归 pin (#6073)

### DIFF
--- a/packages/lint/src/authoring-rule-input-tier.test.ts
+++ b/packages/lint/src/authoring-rule-input-tier.test.ts
@@ -1,0 +1,313 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// #6073 — what `AuthoringRuleInputTier`'s `normalized` value actually buys.
+//
+// ## Why this file exists
+//
+// The tier's doc comment used to justify itself with three examples — "the rules
+// that need it check keys the parse strips (a flat list view in `views: []`,
+// `userFilters` on an object list view, a `visibleOn` alias): by the time
+// `result.data` exists the evidence is gone". All three were measured FALSE
+// under #6073, each for a different reason, and a comment is not something CI
+// can keep honest. Every claim the corrected comment makes is pinned here, so
+// the next reader inherits the measurement instead of re-deriving it — and so a
+// change that silently restores one of the old premises goes red.
+//
+// The mechanism half was never in doubt (#5693 measured it, this file re-pins
+// it): `defineStack` PARSES at definition time, so for a TS config — the
+// documented and universal way to declare a stack — the value the CLI hands the
+// registry is already `result.data`, and re-normalizing it cannot resurrect
+// anything the parse resolved. What was in doubt was the CONSEQUENCE, and the
+// consequence is not the blind spot it looked like: the two view schemas the
+// comment cited went strict at #4001, so they REFUSE where the comment says they
+// STRIP, and refuse earlier and better than any lint rule could.
+//
+// ## What this file does NOT claim
+//
+// It does not claim the tier is useless. The reason
+// `validate-functional-completeness.ts` gives for it is real and pinned in the
+// last describe block: on the raw (non-`defineStack`) door, `os lint` — which
+// never parses — still reports rule findings on a stack whose schema step would
+// have failed. `normalized` means "needs no PARSED stack", never "is guaranteed
+// to see pre-parse evidence".
+
+import { describe, expect, it, vi } from 'vitest';
+import { defineStack, normalizeStackInput } from '@objectstack/spec';
+
+import { validateListViewMode } from './validate-list-view-mode.js';
+import { validateViewContainers } from './validate-view-containers.js';
+import { validateVisibilityPredicates } from './validate-visibility-predicates.js';
+import { runAuthoringRules } from './authoring-rules.js';
+
+type AnyRec = Record<string, unknown>;
+
+const manifest = {
+  id: 'com.example.tier',
+  namespace: 'tier',
+  version: '1.0.0',
+  type: 'app',
+  name: 'Tier Probe',
+  engines: { protocol: '^17' },
+};
+
+/** `defineStack` warns on the D2 conversion channel; keep test output clean. */
+function quietly<T>(fn: () => T): { value?: T; error?: Error; warnings: string[] } {
+  const warnings: string[] = [];
+  const spy = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+    warnings.push(args.join(' '));
+  });
+  try {
+    return { value: fn(), warnings };
+  } catch (e) {
+    return { error: e as Error, warnings };
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+/**
+ * The value the three commands hand `runAuthoringRules` for a `defineStack`
+ * config: `loadConfig()` returns the module's default export (= `result.data`),
+ * and `lint.ts` / `validate.ts` / `compile.ts` then call `normalizeStackInput`
+ * on THAT. Modelled here rather than imported so this package does not depend
+ * on the CLI; the shape is asserted against reality in the first block.
+ */
+const cliTierFor = (stack: AnyRec): AnyRec =>
+  normalizeStackInput(defineStack(stack as never) as unknown as AnyRec);
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('the mechanism: for a defineStack config the `normalized` tier is POST-parse', () => {
+  const flowStack = {
+    manifest,
+    flows: [
+      {
+        name: 'tier_flow',
+        label: 'Tier Flow',
+        type: 'schedule',
+        nodes: [
+          { id: 'start', type: 'start', label: 'Start' },
+          { id: 'end', type: 'end', label: 'End' },
+        ],
+        edges: [{ id: 'e1', source: 'start', target: 'end' }],
+      },
+    ],
+  };
+
+  it('carries parse-time DEFAULTS that a truly pre-parse stack does not have', () => {
+    // The tell #5693 tripped over: `os lint` printed a message arm reachable only
+    // when `flow.runAs` IS a string, which only `FlowSchema`'s `.default('user')`
+    // can produce. If this ever goes back to `undefined`, the whole premise below
+    // changes and the comment on `AuthoringRuleInputTier` must be re-measured.
+    const trulyPreParse = normalizeStackInput(structuredClone(flowStack)) as AnyRec;
+    const cliTier = quietly(() => cliTierFor(structuredClone(flowStack)));
+    expect(cliTier.error).toBeUndefined();
+
+    const pre = (trulyPreParse.flows as AnyRec[])[0];
+    const post = (cliTier.value!.flows as AnyRec[])[0];
+
+    expect(pre.runAs).toBeUndefined();
+    expect(pre.status).toBeUndefined();
+    expect(post.runAs).toBe('user');
+    expect(post.status).toBe('draft');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('premise 1 (FALSE): "the parse strips a flat list view in `views: []`"', () => {
+  const flatView = {
+    name: 'tier_flat',
+    label: 'Tier Flat',
+    type: 'grid',
+    data: { provider: 'object', object: 'tier_task' },
+    columns: [{ field: 'name' }],
+  };
+
+  it('defineStack REFUSES it by name instead — ViewSchema is strict since #4001', () => {
+    const { error } = quietly(() => defineStack({ manifest, views: [flatView] } as never));
+    expect(error).toBeDefined();
+    // The schema names every offending key AND prints the wrap-it fix, which is
+    // strictly more than `view-container-shape` would have said.
+    expect(error!.message).toContain('views.0');
+    expect(error!.message).toContain('Unrecognized key(s) on this view container');
+    for (const key of ['type', 'data', 'columns']) expect(error!.message).toContain(key);
+    expect(error!.message).toContain('defineView({ list:');
+  });
+
+  it('still fires on the doors the strict parse never sees (raw input, no defineStack)', () => {
+    // `os lint` on a raw object-literal config, `defineStack(x, { strict: false })`,
+    // and direct API callers all reach the rule with the flat shape intact. This
+    // is the arm that keeps the `looksFlat` branch alive — deleting it would take
+    // the only diagnostic those three doors get.
+    const findings = validateViewContainers(
+      normalizeStackInput({ manifest, views: [flatView] }) as AnyRec,
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe('view-container-shape');
+    expect(findings[0].message).toContain('Flat list-view object');
+  });
+
+  it('the arm that DOES survive the parse is the all-slots-empty container', () => {
+    // Every key here is declared, so nothing is refused and nothing is stripped:
+    // this is the shape `validateViewContainers` is genuinely the only reporter of.
+    const emptyContainer = { manifest, views: [{ name: 'tier_empty' }] };
+    const cli = quietly(() => cliTierFor(structuredClone(emptyContainer)));
+    expect(cli.error).toBeUndefined();
+
+    const findings = validateViewContainers(cli.value!);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe('view-container-shape');
+    expect(findings[0].message).toContain('defines no views');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('premise 2 (FALSE): "the parse strips `userFilters`/`quickFilters` on an object list view"', () => {
+  const objectWithBadFilters = {
+    manifest,
+    objects: [
+      {
+        name: 'tier_task',
+        label: 'Task',
+        fields: {
+          name: { type: 'text', label: 'Name' },
+          status: { type: 'text', label: 'Status' },
+        },
+        listViews: {
+          my_pending: {
+            label: 'My Pending',
+            type: 'grid',
+            columns: [{ field: 'name' }],
+            quickFilters: [{ field: 'status', label: 'Status' }],
+            userFilters: { element: 'tabs', fields: ['status'] },
+          },
+        },
+      },
+    ],
+  };
+
+  it('defineStack REFUSES both — strict key rejection AND an enum refusal', () => {
+    const { error } = quietly(() => defineStack(structuredClone(objectWithBadFilters) as never));
+    expect(error).toBeDefined();
+    // `quickFilters` — refused as an unrecognized KEY, with the rename suggestion.
+    expect(error!.message).toContain('Unrecognized key(s) on this list view');
+    expect(error!.message).toContain('quickFilters');
+    // `element: 'tabs'` — refused as an invalid VALUE. Two different rejection
+    // mechanisms; both louder than the rule, both at definition time.
+    expect(error!.message).toContain("Invalid value 'tabs'");
+    expect(error!.message).toContain('dropdown');
+  });
+
+  it('still fires on raw input, which is the door that keeps the rule honest', () => {
+    const findings = validateListViewMode(
+      normalizeStackInput(structuredClone(objectWithBadFilters)) as AnyRec,
+    );
+    expect(findings.map((f) => f.rule)).toEqual([
+      'list-view-filters-in-views-mode',
+      'list-view-filters-in-views-mode',
+    ]);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('premise 3 (FALSE): "the `visibleOn` alias survives until the parse"', () => {
+  // The fold is an ADR-0087 D2 conversion inside `normalizeStackInput` — one
+  // layer BEFORE this tier — not a parse-time `.transform()`. So the alias is
+  // gone from the tier's own input on every door, `os lint` included. #6318.
+  const aliasSites: Array<[string, AnyRec]> = [
+    ['views[].form.sections[]', {
+      manifest,
+      views: [{
+        name: 'tier_form',
+        form: { type: 'simple', sections: [{ label: 'S', visibleOn: 'record.a == 1', fields: [{ field: 'name' }] }] },
+      }],
+    }],
+    ['views[].formViews.edit.sections[]', {
+      manifest,
+      views: [{
+        name: 'tier_form2',
+        formViews: { edit: { type: 'simple', sections: [{ label: 'S', visibleOn: 'record.a == 1', fields: [{ field: 'name' }] }] } },
+      }],
+    }],
+    ['pages[].regions[].components[]', {
+      manifest,
+      pages: [{
+        name: 'tier_page',
+        label: 'P',
+        type: 'home',
+        object: 'tier_task',
+        regions: [{ name: 'main', components: [{ type: 'element:text', visibility: "page.selectedId != ''" }] }],
+      }],
+    }],
+  ];
+
+  it.each(aliasSites)('%s: the alias is folded BEFORE the tier, so the rule reports 0', (_site, stack) => {
+    // Fed the raw authored object (what the rule's own unit tests do) it reports.
+    expect(validateVisibilityPredicates(structuredClone(stack))).toHaveLength(1);
+    // Fed the `normalized` tier (what all three commands do) it does not.
+    expect(validateVisibilityPredicates(normalizeStackInput(structuredClone(stack)) as AnyRec)).toEqual([]);
+  });
+
+  it('the author is NOT left silent — the D2 conversion notice names the site and its retirement', () => {
+    const { error, warnings } = quietly(() => defineStack(structuredClone(aliasSites[0][1]) as never));
+    expect(error).toBeUndefined();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("'visibleOn' → 'visibleWhen'");
+    expect(warnings[0]).toContain('views[0].form.sections[0].visibleWhen');
+    expect(warnings[0]).toContain('retires in protocol 16');
+  });
+
+  it('the predicate-VALUE rules in the same file are unaffected — do not connect them', () => {
+    // The value moves into `visibleWhen` intact, so these two still report on the
+    // tier. #6318 is about the alias-KEY rule only.
+    const bare = {
+      manifest,
+      views: [{
+        name: 'tier_form3',
+        form: { type: 'simple', sections: [{ label: 'S', visibleWhen: "status == 'active'", fields: [{ field: 'name' }] }] },
+      }],
+    };
+    const cli = quietly(() => cliTierFor(structuredClone(bare)));
+    expect(cli.error).toBeUndefined();
+    expect(validateVisibilityPredicates(cli.value!).map((f) => f.rule)).toEqual([
+      'visibility-bare-identifier',
+    ]);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('what `normalized` DOES buy: findings survive a schema error that stops the parse', () => {
+  it('the registry reports on a stack whose parse would have failed outright', () => {
+    // This is the surviving justification, and it is not theoretical: on the raw
+    // door `os validate` stops at the schema step and prints zero rule findings,
+    // while `os lint` — which never parses — still names both rules. A `parsed`
+    // tier could not have run here at all.
+    const unparseable = {
+      manifest,
+      objects: [{
+        name: 'tier_task',
+        label: 'Task',
+        fields: { name: { type: 'text', label: 'Name' } },
+        listViews: {
+          my_pending: {
+            label: 'My Pending',
+            type: 'grid',
+            columns: [{ field: 'name' }],
+            quickFilters: [{ field: 'status', label: 'Status' }],
+          },
+        },
+      }],
+      views: [{ name: 'tier_flat', label: 'F', type: 'grid', columns: [{ field: 'name' }] }],
+    };
+
+    // The parse refuses it — that is the premise of this test, not an aside.
+    expect(quietly(() => defineStack(structuredClone(unparseable) as never)).error).toBeDefined();
+
+    // …and the `normalized`-tier rules still deliver their verdicts.
+    const findings = runAuthoringRules('lint', {
+      normalized: normalizeStackInput(structuredClone(unparseable)) as AnyRec,
+    });
+    const rules = new Set(findings.map((f) => f.rule));
+    expect(rules.has('list-view-filters-in-views-mode')).toBe(true);
+    expect(rules.has('view-container-shape')).toBe(true);
+  });
+});

--- a/packages/lint/src/authoring-rules.ts
+++ b/packages/lint/src/authoring-rules.ts
@@ -201,10 +201,8 @@ export type AuthoringRuleTier = 'gating' | 'advisory';
 /**
  * Which tier of the stack a rule reads.
  *
- * - `normalized` — the `normalizeStackInput` output, BEFORE the Zod parse. The
- *   rules that need it check keys the parse strips (a flat list view in
- *   `views: []`, `userFilters` on an object list view, a `visibleOn` alias): by
- *   the time `result.data` exists the evidence is gone.
+ * - `normalized` — the `normalizeStackInput` output, run before this package's
+ *   caller had a chance to Zod-parse.
  * - `parsed` — the post-parse stack, where defaults are filled and shapes are
  *   settled.
  *
@@ -212,6 +210,49 @@ export type AuthoringRuleTier = 'gating' | 'advisory';
  * `os validate`'s verdict to give), so it runs BOTH tiers on the normalized
  * stack. Every rule here is written to tolerate that — it is what `os lint`
  * already did for the reference-integrity suite and the security linter.
+ *
+ * ## What `normalized` does NOT buy, measured (#6073)
+ *
+ * This tier used to be justified as "the rules that need it check keys the
+ * parse strips — a flat list view in `views: []`, `userFilters` on an object
+ * list view, a `visibleOn` alias — by the time `result.data` exists the
+ * evidence is gone". **All three of those examples were measured false**, each
+ * for its own reason, and the pins live in `authoring-rule-input-tier.test.ts`:
+ *
+ *  1. `defineStack` — the documented and universal way a TS config declares a
+ *     stack — PARSES at definition time, so for such a config the value every
+ *     command hands this registry is already `result.data`: parse-time defaults
+ *     filled (`flow.runAs === 'user'`), unknown keys resolved. Re-normalizing it
+ *     cannot resurrect anything. That half was measured in #5693 and re-measured
+ *     here.
+ *  2. But nothing is lost, because since #4001 the two cited view schemas do not
+ *     STRIP — they REFUSE. `ViewSchema` and `ObjectListViewSchema` are strict, so
+ *     `defineStack` throws on the flat list view and on `quickFilters` /
+ *     `userFilters: { element: 'tabs' }`, naming the same sites the rules name,
+ *     one layer earlier and with the schema's own fix hint. Measured end to end:
+ *     `os lint` and `os validate` on an example app carrying the flat view both
+ *     refuse the config at LOAD, before any rule runs.
+ *  3. The `visibleOn` alias never reaches this tier on ANY input shape: the
+ *     ADR-0087 D2 conversion (`view-visibleOn-to-visibleWhen`,
+ *     `page-component-visibility-to-visibleWhen`) folds it into `visibleWhen`
+ *     INSIDE `normalizeStackInput` — one layer before the tier, not during the
+ *     parse. See #6318.
+ *
+ * ## What it does buy, and why the tier stays
+ *
+ * The surviving reason is the one `validate-functional-completeness.ts` states
+ * and the measurement confirms: a `normalized`-tier finding reaches the author
+ * even when an unrelated schema error elsewhere would stop the parse. On the
+ * raw (non-`defineStack`) path that is not theoretical — `os validate` stops at
+ * the schema step and reports zero rule findings, while `os lint`, which never
+ * parses, still names `view-container-shape` and
+ * `list-view-filters-in-views-mode`. Plus the plain fact that `os lint` has no
+ * parsed stack to give.
+ *
+ * So: read `normalized` as "does not REQUIRE a parsed stack", never as "is
+ * guaranteed to see pre-parse evidence". A new rule whose only evidence is a key
+ * a strict schema rejects is a rule that will never fire — put the diagnostic in
+ * the schema instead, where #4001 already puts it.
  */
 export type AuthoringRuleInputTier = 'normalized' | 'parsed';
 
@@ -349,8 +390,12 @@ export const AUTHORING_RULES: readonly AuthoringRule[] = [
       })),
   },
   // ADR-0053 — `userFilters`/`quickFilters` on an object list view ("views"
-  // mode) are silently dropped: `ObjectListViewSchema` omits them, so this must
-  // read the pre-parse tier or the evidence is already gone.
+  // mode). NOT "silently dropped" any more: since #4001 `ObjectListViewSchema`
+  // is strict and refuses `quickFilters` by name, and `ObjectUserFiltersSchema`
+  // refuses `element: 'tabs'` by enum — measured under #6073, `defineStack`
+  // THROWS on both. `normalized` here therefore means "needs no parsed stack"
+  // (so `os lint`, which never parses, can run it), not "sees evidence the
+  // parse would have eaten".
   {
     name: 'validateListViewMode',
     tier: 'gating',
@@ -381,9 +426,13 @@ export const AUTHORING_RULES: readonly AuthoringRule[] = [
     surfaceReason: RUNTIME_OBJECT_WRITES_P2,
     run: (stack) => validateFunctionalCompleteness(stack),
   },
-  // A flat list-view object in `views: []` parses to an EMPTY container
-  // (ViewSchema strips unknown keys): the schema step passes, zero views
-  // register, and the Console renders nothing. Pre-parse for the same reason.
+  // A view container in `views: []` that registers zero views: nothing appears
+  // in the Console, and the schema step cannot tell it from an intentionally
+  // empty one. The FLAT-list-view arm no longer needs this tier — `ViewSchema`
+  // went strict at #4001, so `defineStack` now REFUSES `{ name, type, columns,
+  // data }` by name with the wrap-it hint (measured under #6073); the arm that
+  // still needs a rule is the all-slots-empty container, whose keys are all
+  // declared and which survives the parse untouched.
   {
     name: 'validateViewContainers',
     tier: 'gating',
@@ -694,9 +743,16 @@ export const AUTHORING_RULES: readonly AuthoringRule[] = [
     run: (stack) => validateSeedStateMachine(stack),
   },
   // ADR-0089 D3b — deprecated visibility aliases and a mis-layered binding root,
-  // plus (#6128) the bare-identifier gate. Pre-parse: the schema folds
-  // `visibleOn`/`visibility` into `visibleWhen` during parse, so the alias the
-  // author wrote is gone from `result.data`.
+  // plus (#6128) the bare-identifier gate. This entry used to read "pre-parse:
+  // the schema folds `visibleOn`/`visibility` into `visibleWhen` during parse,
+  // so the alias the author wrote is gone from `result.data`". Measured false
+  // at #6073: the ADR-0087 D2 conversions do that fold INSIDE
+  // `normalizeStackInput`, one layer BEFORE this tier, so on every spec-valid
+  // alias site `visibility-alias-deprecated` reports zero here too — see #6318,
+  // which carries the per-site table and the retire-or-rewire question. The two
+  // predicate-VALUE rules (`visibility-bare-identifier`,
+  // `visibility-root-mislayered`) are unaffected: the value moves into
+  // `visibleWhen` intact and both still report on this tier.
   //
   // `gating` since #6128: `visibility-bare-identifier` emits `error`. The two
   // ADR-0089 rules stay advisory findings within it — the tier is a property of

--- a/packages/lint/src/validate-list-view-mode.ts
+++ b/packages/lint/src/validate-list-view-mode.ts
@@ -12,13 +12,27 @@
 // A `dropdown` (value-chip) `userFilters` IS allowed on object views since the
 // ADR-0047 amendment (framework #2679 / objectui #2338) and is NOT flagged.
 //
-// Runs PRE-parse (on the normalizeStackInput output, before the
-// ObjectStackDefinition parse): the object-list schema (ObjectListViewSchema)
-// narrows `userFilters` to ObjectUserFiltersSchema (dropdown/toggle only), so a
-// post-parse stack has already had a `tabs` user-filter stripped and this rule
-// would never see it. The layering is deliberate — tsc rejects it at author
-// time, the schema strips it at runtime (no throw, back-compat), and this rule
-// reports it at `os validate` with a fix hint. See objectui #2338 and ADR-0047.
+// Registered `input: 'normalized'` — which means "needs no PARSED stack", so
+// `os lint` (which never parses) can run it and its findings survive an
+// unrelated schema error that would stop the parse.
+//
+// ## It is NOT the last line of defence any more (#6073)
+//
+// This header used to say the schema "strips a `tabs` user-filter at runtime
+// (no throw, back-compat)" and that a post-parse stack would therefore have
+// lost the evidence. Measured false at #6073: since #4001 `ObjectListViewSchema`
+// is strict and refuses `quickFilters` BY NAME (with the
+// `quickFilters` → `userFilters` suggestion), and `ObjectUserFiltersSchema`
+// refuses `element: 'tabs'` by enum ("Expected one of: dropdown, toggle").
+// `defineStack` throws on both, so a TS config carrying either never loads —
+// `os lint` and `os validate` report the schema's message, not this rule's.
+//
+// The rule still earns its place on the doors the strict parse never sees:
+// `os lint` on a raw object-literal config (measured: it names
+// `list-view-filters-in-views-mode` twice where `os validate` stops at the
+// schema step), `defineStack(x, { strict: false })`, and direct API callers.
+// tsc rejects it at author time on top of all of that. See objectui #2338 and
+// ADR-0047.
 
 export type ListViewModeSeverity = 'error' | 'warning';
 

--- a/packages/lint/src/validate-view-containers.ts
+++ b/packages/lint/src/validate-view-containers.ts
@@ -3,17 +3,34 @@
 // Build-time guardrail for the `defineView` container shape.
 //
 // A pure `(stack) => Finding[]` rule (ADR-0019), run from `os validate`. It
-// catches the "flat view object" authoring mistake the schema alone cannot
-// surface: `ViewSchema` is a container (`{ list, form, listViews, formViews }`)
-// whose slots are all optional, and Zod strips unknown keys — so a flat list
-// view (`{ name: 'all_tasks', label, type: 'grid', columns: [...] }`) parses
-// to an EMPTY container. The stack validates, the loader finds nothing to
+// catches the container that registers ZERO views: `ViewSchema` is a container
+// (`{ list, form, listViews, formViews }`) whose slots are all optional, so a
+// container with none of them set is schema-valid, the loader finds nothing to
 // expand, and the Console silently renders no view (no switcher entry). The
 // third-party 15.1 evaluation hit exactly this via the old docs.
 //
-// Runs PRE-parse (on the normalizeStackInput output, before the
-// ObjectStackDefinition parse): post-parse the flat keys are already stripped
-// and the mistake is indistinguishable from an intentionally empty container.
+// ## The flat-list-view arm is now the SCHEMA's verdict, not this rule's (#6073)
+//
+// This header used to say `ViewSchema` "strips unknown keys — so a flat list
+// view (`{ name: 'all_tasks', label, type: 'grid', columns: [...] }`) parses to
+// an EMPTY container", and that the rule therefore had to run pre-parse.
+// Measured false at #6073: `ViewSchema` went `.strict()` at #4001. `defineStack`
+// now THROWS on that shape, naming `type` / `data` / `columns` and printing the
+// wrap-it-in-defineView fix; `os lint` and `os validate` on an example app
+// carrying it both refuse the config at LOAD, before any rule runs. `defineView`
+// refuses it a step earlier still (`view.zod.ts:1951`, viewCount === 0).
+//
+// So `input: 'normalized'` in the registry means "this rule needs no PARSED
+// stack" — which is what lets `os lint` (which never parses) run it, and what
+// keeps its findings alive when an unrelated schema error stops the parse. It
+// does NOT mean the rule is the only thing standing between the author and the
+// flat-view mistake; the schema is, and it says it better.
+//
+// The `looksFlat` branch below is kept deliberately: it still fires on the
+// non-`defineStack` doors the strict parse never sees — `os lint` on a raw
+// object-literal config (measured: reports `view-container-shape` where
+// `os validate` stops at the schema step), `defineStack(x, { strict: false })`,
+// and direct API callers.
 //
 // Independent ViewItems (`viewKind` + `config`) are legal `views: []` entries
 // (the loader registers them as-is) and are not flagged.

--- a/packages/lint/src/validate-visibility-predicates.ts
+++ b/packages/lint/src/validate-visibility-predicates.ts
@@ -7,10 +7,26 @@
  * canonical key **`visibleWhen`** across data fields, view form sections/fields,
  * and page components. The deprecated spellings — `visibleOn` (view form) and
  * `visibility` (page component) — stay accepted and are folded into `visibleWhen`
- * at the schema boundary (a zod `.transform()`). Because that fold happens during
- * `parse()`, the aliases are gone from the *parsed* stack — so this rule runs on
- * the **pre-parse** (normalized) stack, exactly like `validate-list-view-mode`,
- * to see what the author actually wrote.
+ * at the schema boundary (a zod `.transform()`).
+ *
+ * **The fold does NOT happen during `parse()` (measured, #6073).** This header
+ * used to say it did, and that running on the pre-parse (normalized) stack was
+ * therefore enough to see what the author wrote. It is not: the ADR-0087 D2
+ * conversions `view-visibleOn-to-visibleWhen` and
+ * `page-component-visibility-to-visibleWhen` rename the key INSIDE
+ * `normalizeStackInput` — whose output *is* the normalized tier. On all three
+ * spec-valid alias sites (`views[].form.*`, `views[].formViews.*`,
+ * `pages[].regions[].components[]`) `visibility-alias-deprecated` therefore
+ * reports ZERO through every CLI door, `os lint` on a raw config included. The
+ * only shape on which it still fires is `views[].sections[]` — the shape the
+ * unit tests below use, and the one strict `ViewSchema` refuses. The author is
+ * not left silent (the D2 conversion emits its own, better-worded notice naming
+ * the protocol-16 retirement), so nothing is broken for a user today; #6318
+ * carries the per-site table and the retire-or-rewire question.
+ *
+ * The other two rules in this file judge the predicate's **value**, which the
+ * fold carries into `visibleWhen` intact — both still report normally on the
+ * normalized tier, and neither is affected by the above.
  *
  * Two advisory rules (both `warning` — nothing is broken, the alias still works
  * and a mis-rooted predicate just never matches) plus one **gating** rule


### PR DESCRIPTION
Fixes #6073

本单是「测量决定结论」型。分诊 2026-08-06T17:57Z 钉死三条范围:先测量后改码、必答 `warnUnknownAuthoringKeys` 通道覆盖问题、若修法触及 `AuthoringRuleInputTier` 的 pre-parse 声明或 `runAuthoringRules` 对外契约则升 `needs-user-decision`。

**测量做完了,结论是假设不成立 —— 但不成立的方式和单子预设的两个分支都不同**,所以这里如实记录实测方向,不套模板(见「所走分支」)。**未触碰升级闸**:`AuthoringRuleInputTier` 的两个成员、`runAuthoringRules` 的签名与 `AuthoringRuleRun` 的形状一字未动。

---

## 一、测量记录(命令 + 输出)

环境:worktree @ `origin/main` `a7e7851`,`packages/{spec,lint,cli}` 本地构建。行号以实测为准。

### 1. 机制半边:defineStack 配置交给三条命令的「normalized」层是 POST-parse

`loadConfig()` 返回模块 default export(= `defineStack(...)` = `result.data`),`lint.ts:428` / `validate.ts` / `compile.ts` 再对**它**跑 `normalizeStackInput`。实测同一个 flow 走两条门:

```
### (a) parse-time defaults in the tier each door produces
  TRUE pre-parse   flows[0].runAs = undefined   status = undefined
  CLI defineStack  flows[0].runAs = "user"      status = "draft"
  ⇒ the CLI's "normalized" tier is POST-parse: true
```

正文与 #5693 的观察成立:`FlowSchema` 的 `.default('user')` 已生效,再 normalize 一次也回不去。

### 2. example app 实测:`os lint` / `os validate`,defineStack 门

在 `examples/app-todo/objectstack.config.ts` 的 `views: []` 里加一个扁平 list view(`{ name, label, type: 'grid', data, columns }`),即 `validate-view-containers` 的证据形状:

```
########## os lint --skip-i18n ##########
  → Loading configuration...
  ✗ defineStack validation failed (1 issue):
  ✗ views.1: Unrecognized key(s) on this view container: `type`, `data`, `columns`. …
  • `type` belongs to a single VIEW, not to the container. Wrap it:
    `defineView({ list: { type, data, columns, … } })`, or name it — …
LINT_EXIT=1
```

```
########## os validate ##########
  → Loading configuration...
  ✗ defineStack validation failed (1 issue):
  ✗ views.1: Unrecognized key(s) on this view container: `type`, `data`, `columns`. …
VALIDATE_EXIT=1
```

**两条命令都在 LOAD 阶段拒绝配置,规则一条都没跑到 —— 也不需要跑。** #4001 之后 `ViewSchema` 是 `.strict()`,不是 strip:它点名了规则会点名的同一批键,而且早一层、还附修法。`defineView` 更早一步(`view.zod.ts:1951`,`viewCount === 0` 直接 throw)。

### 3. 对照:同一份 stack 走 raw 门(不经 defineStack)

同目录放一份 `export default { … }` 的纯对象字面量配置(= raw JSON/YAML / `strict: false` / 直接 API 调用这条路),同时带两条规则的证据:

```
########## os lint  probe-raw-6073.config.ts ##########
  Errors (7)
  ✗ object "probe_task" › listViews.my_pending: `quickFilters` is a page filters-mode control …
    list-view-filters-in-views-mode  at objects[0].listViews.my_pending.quickFilters
  ✗ object "probe_task" › listViews.my_pending: `userFilters` with `element: "tabs"` is page-only …
    list-view-filters-in-views-mode  at objects[0].listViews.my_pending.userFilters
  ✗ views[0] ("probe_flat_view"): Flat list-view object is not a view container …
    view-container-shape  at views[0]
  …
LINT_EXIT=1
```

```
########## os validate  probe-raw-6073.config.ts ##########
  ✗ Validation failed
  objects:
    ✗ objects.0.listViews.my_pending.userFilters.element
      invalid_value: Invalid option: expected one of "dropdown"|"toggle"
    ✗ objects.0.listViews.my_pending
      unrecognized_keys: Unrecognized key(s) on this list view: `quickFilters`. … Did you mean `quickFilters` → `userFilters`?
  views:
    ✗ views.0
      unrecognized_keys: Unrecognized key(s) on this view container: `type`, `data`, `columns`. …
  4 validation error(s) total
VALIDATE_EXIT=1
```

**差异表:**

| 门 | `os lint`(从不 parse) | `os validate`(parse) |
|---|---|---|
| defineStack TS 配置(文档化的唯一写法) | 配置在 LOAD 被拒,schema 点名 | 同左 |
| raw 对象字面量(无 defineStack) | 两条 `normalized` 规则**按名报告** | schema 步先拒,规则不产出 finding |

即:正文预测的「差异」确实存在,但**方向是反的** —— defineStack 那条路是三条里**最响**的,不是静默的那条。

### 4. 逐规则测量(六条 `input: 'normalized'` 全覆盖)

每条规则各喂它自己的证据形状,fixture 按「补声明」原则补齐到「除刻意埋的那一个缺陷外全部 spec-valid」(两个 fixture 首轮因缺 `type`/`edges`/`label` 而被 schema 以无关理由拒收,已修正后重测):

| 规则 | 证据 | TRUE pre-parse | defineStack | CLI 层(post-defineStack) | 判定 |
|---|---|---|---|---|---|
| `validateViewContainers`(扁平臂) | `views: []` 里的扁平 list view | 1 | **抛错**(点名 type/data/columns) | — | 被 schema 拒收 |
| `validateViewContainers`(空容器臂) | 四个槽全缺的容器 | 1 | 通过 | **1** | 存活 |
| `validateListViewMode` | `quickFilters` + `userFilters: { element: 'tabs' }` | 2 | **抛错**(键拒收 + 枚举拒收) | — | 被 schema 拒收 |
| `validateFunctionalCompleteness` | `summary` 字段无 `summaryOperations` | 1 | 通过 | **1** | 存活 |
| `validateComponentProps` | `properties` 里未声明的 `titel` | 1 | 通过 | **1** | 存活 |
| `validateFlowTriggerReadiness` | schema 拒绝的 `config.timeRelative` | 3 | 通过 | **3** | 存活 |
| `validateVisibilityPredicates`(别名臂) | `visibleOn` 别名 | **0** | 通过(发转换通知) | 0 | 见下 |
| `validateVisibilityPredicates`(值臂 ×2) | 裸标识符 / 错层根 | 1 / 1 | 通过 | **1 / 1** | 存活 |

**没有任何一条规则处在「本该报却静默、且作者因此受损」的状态。**

### 5. 别名臂的定位(与正文的猜测都不同)

`validate-visibility-predicates.ts:8-13` 自称别名「folded … during `parse()`」。实测**假**:折叠由 ADR-0087 D2 的两条转换完成,而它们跑在 `normalizeStackInput` **之内** —— 该函数的输出就是 `normalized` 层本身。

```
▸ views[].form.sections[].visibleOn
  0. rule on RAW authored object (bypasses normalizeStackInput) → 1
  1. rule on the `normalized` tier (normalizeStackInput output)  → 0
  2. defineStack() → returns; 1 warning
       WARN defineStack: views[0].form.sections[0].visibleWhen: 'visibleOn' → 'visibleWhen'
            (converted at load; conversion 'view-visibleOn-to-visibleWhen', retires in protocol 16). …
  3. rule on CLI tier post-defineStack → 0
```

三个 spec-合法别名 site(`views[].form.*` / `views[].formViews.*.*` / `pages[].regions[].components[]`)一律 0;唯一还能报的形状是 `views[].sections[]` —— 单测 `:42` 用的那个,被 strict `ViewSchema` 直接拒收。这与本单不是同一个机制(与 defineStack 无关,raw 门也一样),已按 Prime Directive #10 单独立观察单 **#6318**,本 PR 只改注释、不修法。

---

## 二、必答项:`warnUnknownAuthoringKeys` 通道对六条规则证据面的逐条覆盖

分诊必答的是:`defineStack` 在 parse 前已跑 `warnUnknownAuthoringKeys(normalized)`(`stack.zod.ts:1237`),这条通道是否已覆盖那六条规则关心的证据?

**实测答案:一条都没覆盖 —— 六个 case 的 `warnUnknownAuthoringKeys` 输出均为 0 条。** 原因分两类,都由该 walker 自己的 posture 规则决定(`metadata-authoring-lint.ts:78-154`:`strip` → 报,`strict` → **跳过**,`passthrough` → 跳过):

| 规则 | 证据性质 | 该通道是否覆盖 | 为什么 |
|---|---|---|---|
| `validateViewContainers`(扁平臂) | 未声明的**键** | ❌ 0 条 | `ViewSchema` 是 `strict` ⇒ walker 按设计闭嘴,**由 parse 自己大声拒绝**(实测已拒) |
| `validateViewContainers`(空容器臂) | 键全部已声明 | ❌ 0 条 | 无未知键可报;这是「声明齐全但语义空」,键级 lint 结构上看不见 |
| `validateListViewMode` | `quickFilters` 是未声明键;`element: 'tabs'` 是**值** | ❌ 0 条 | 键侧同上(strict ⇒ 跳过,parse 拒);值侧本就不在键级 lint 的判定面内 |
| `validateFunctionalCompleteness` | 键全部已声明,**值**惰性 | ❌ 0 条 | 正文自己写过:「#4001 的未知键拒绝看不见它」 |
| `validateComponentProps` | `properties` 内未声明键 | ❌ 0 条 | `PageComponent.properties` 是 `z.record(z.string(), z.unknown())`,walker 走到载体就停;该规则反过来**自己调用** `lintUnknownKeysAgainstSchema` 并先按 `type` 派发(#5068) |
| `validateFlowTriggerReadiness` | `config.timeRelative` 的**值** | ❌ 0 条 | `flow` 属 #4001 Tier-A `strict` 集 ⇒ walker 跳过;且 node `config` 槽按设计开放,值级判定与键级无关 |
| `validateVisibilityPredicates`(别名臂) | 别名**键** | ❌ 0 条 | 真正覆盖它的是**另一条通道**:`warnConversionNotice`(ADR-0087 D2),实测 1 条,措辞更好且带 protocol 16 退役期 |

**结论对修法的意义**(这正是分诊说「答案决定修法」的那一步):既然该通道一条都没覆盖,「把六条规则接到 `warnUnknownAuthoringKeys` 那条缝上」不是可行修法 —— 它判的是**键是否被声明**,而这六条规则里有四条判的是**值是否有意义**,两者不是同一个判定面。而键侧那两条,证据早已被 strict schema 以更好的措辞拒掉了,不需要第二个声音。

---

## 三、所走分支及依据

分诊给了两支:α(规则照常报 ⇒ 假设不成立,注释按实测补句)/ β(规则不报 ⇒ #4984 族真盲点,接线修法)。

**实测落在 α 的实质上,但机制是第三种,报告如实写明**:六条规则里四条「照常报」(α 的字面情形),另两条不报**不是因为静默失效,而是因为配置根本加载不了** —— schema 在更早一层拒绝,措辞比规则更好。对作者而言这严格更优,不是缺陷。同时 β 的前提(#4984 族「规则只在生产从不发送的形状上被证明过」)在**别名臂**上确实成立,但其成因与本单的 defineStack-parse 无关,故按 #10 外立 #6318,不在本 PR 修。

因此本 PR 收束为「已测量、无缺陷」形态,改动仅为**注释按实测改正 + 一个回归 pin**。⛔ 升级闸未触发:`AuthoringRuleInputTier` 的两个成员保持原样,`runAuthoringRules` / `AuthoringRuleRun` 的对外契约一字未动。

改正的四处陈述(全部是当年为真、如今为假的句子):

1. `authoring-rules.ts` 的 tier 文档 —— 三个自证例子全部改写,并写下**真正保留它的理由**:无关 schema 错误中止 parse 时,`normalized` 层的 findings 仍能到达作者(raw 门实测:`os validate` 停在 schema 步零 finding,`os lint` 仍点名两条规则);外加 `os lint` 本就没有 parsed stack 可给。附一句给后来者的判据:`normalized` 读作「不**需要** parsed stack」,永远不是「保证看得见 pre-parse 证据」。
2. `validate-view-containers.ts` 头注 —— 「ViewSchema strips unknown keys」改为 strict 拒收;说明 `looksFlat` 分支**故意保留**,因为它仍服务 strict parse 看不到的三扇门。
3. `validate-list-view-mode.ts` 头注 —— 「schema strips it at runtime (no throw, back-compat)」改为键拒收 + 枚举拒收。
4. `validate-visibility-predicates.ts` 头注 + 注册表条目 —— 折叠发生在 `normalizeStackInput` 内而非 `parse()`;并明确**两条值级规则不受连坐**(实测各报 1),避免下一个读者顺手把它们一起摘掉。

---

## 四、反向验证(先申报,后执行)

模板默认的「修复前红 / 修复后绿」在这里**不成立**:本 PR 非注释代码行零改动,不存在可翻转的行为。可翻转的是**前提**,所以反向验证做成对 pin 的**变异测试** —— 先申报预测方向,再执行。

**申报 A**:把 premise-1 的 fixture 由扁平 view 换成规范容器 `{ list: { … } }`。**预测 RED** —— `defineStack` 不再抛错,`expect(error).toBeDefined()` 失败。若仍绿,说明该断言读的是某个无关 schema 错误,而非「扁平」这一事实。

**实测 A**:RED,2 例失败,与预测一致 ——

```
FAIL … defineStack REFUSES it by name instead — ViewSchema is strict since #4001
    125|     expect(error).toBeDefined();
FAIL … still fires on the doors the strict parse never sees (raw input, no defineStack)
AssertionError: expected [] to have a length of 1 but got +0
```

**申报 B**:把 premise-3 里喂 `normalized` 层的那一次改成喂**原始对象**(即抽掉 `normalizeStackInput`)。**预测 RED** —— 规则会返回 1 条,`toEqual([])` 失败。若仍绿,说明该 pin 根本没在读转换层的折叠。

**实测 B**:RED,三个别名 site 全部失败,与预测一致。而且返回的 finding 里带着的正是本 PR 改正的那句陈旧措辞 ——

```
+   {
+     "message": "`visibility` is the deprecated spelling … It still works — it is normalized to
+                 `visibleWhen` at parse — but the canonical key is `visibleWhen`.",
+     "rule": "visibility-alias-deprecated",
+   }
```

两个变异各自 RED、恢复后 12/12 绿,证明 pin 读的是真事实,不是空过。

**另外**,测量本身天然是双向的,已在上文一并取证:同一份 stack,唯一变量是走不走 `defineStack` / 走不走 `normalizeStackInput`,两个方向的输出都记录在案。

---

## 五、门禁 EXIT 表

| 门禁 | 命令 | EXIT |
|---|---|---|
| packages/lint 单测 | `pnpm --workspace-concurrency=2 --filter @objectstack/lint test` | **0** — 62 files / **1516** passed(含新增 pin 12 例) |
| 新 pin 单独跑 | `vitest run src/authoring-rule-input-tier.test.ts --maxWorkers=2` | **0** — 12 passed |
| 注册表接线闸 | `vitest run src/authoring-rule-wiring.test.ts` | **0** — 25 passed |
| typecheck | `pnpm --workspace-concurrency=2 --filter @objectstack/lint typecheck` | **0** |
| ESLint(改动的 5 个文件) | `npx eslint …` | **0** |
| 控制字节闸 | `node scripts/check-nul-bytes.mjs` | **0** — scanned 5966,无裸控制字节 |
| 自扫(超出闸门盲区) | `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` | 无命中 |
| `check:spec-parsed-alias` / `check:engine-double-contract` / `check:error-code-casing` / `check:route-envelope` / `check:adr-anchors` / `check:doc-authoring` / `check:role-word` / `check:type-check-coverage` | 本地逐条 | **0** |

### CI 实测(head `e6225d2`)

| Job | 结论 |
|---|---|
| **ESLint**(含全部 35 条同族闸:engine-double-contract / error-code-casing / route-envelope / raw control-byte / spec type-alias …) | **success** |
| **TypeScript Type Check**(含 `check:type-check-coverage` 与 DEBT/TEST_DEBT re-measure) | **success** |
| Test Core(3 分片) | **success** |
| Dogfood Regression Gate(3 分片)/ Dogfood Verify CLI | **success** |
| Temporal Conformance(live PG + MySQL) | **success** |
| Check Changeset | 首跑 **failure**(标签竞态:该 job 在启动时重读标签,早于我写入 `skip-changeset`),确认标签在位后 rerun 一次 ⇒ **success**;由 `labeled` 事件触发的那次本身即 `skipped` |
| Check PR Size / Auto Label / Console Pin Freshness / 其余 | **success** |

📝 **一处自我更正,记录在案**:本地跑 `check:type-check-debt` 时读到 `@objectstack/spec-monorepo` DEBT 80 → 84(+4)。我先按纪律排除了「是我造成的」——把本 PR 五个改动**全部撤掉**后重跑,读数一字不差,故与本 PR 无关(该 ledger 条目的程序面自述为「the root program is `scripts/` and the top-level configs」,`packages/lint` 不在其中)。但当时我进一步推断「`origin/main` 上已经是红的」,**这一步推过头了**:CI 上同一条 re-measure 步骤(TypeScript Type Check 第 27 步)实测 **green**。所以那 +4 是我本地 worktree 环境的产物,不是 main 红。原文保留此更正而非删改,因为「把本地读数当成 main 状态」正是本单这一族(注释陈述与实测脱节)要防的错误,值得留痕。

---

## 六、不在本 PR 里

- **`visibility-alias-deprecated` 的死分支修法** —— 已立 **#6318**(观察类,`finding`,不打 `pm:queue`)。退役 vs 接活是 lint 公共 API 的取舍,按分诊⛔第 3 条不自行拍板。
- **`validate-visibility-predicates.ts` 里那条 finding 的 message 文案**("it is normalized to `visibleWhen` at parse" —— 同一句陈旧陈述)。故意不动:① 该 finding 在 CLI 任何一扇门上都不可达,改它今天不改变任何用户可见行为;② 它是 #6318 决定「退役还是接活」时要一并处理的东西,先改会抢跑那个决定;③ 改已发布包的字符串会把本 PR 从 skip 路线拖成真 changeset,为一句用户读不到的话不值。
- **把六条规则接到 `warnUnknownAuthoringKeys` 那条缝上** —— 第二节实测排除:两条判定面不同(键是否声明 vs 值是否有意义)。
- **改 `AuthoringRuleInputTier` 的成员 / `runAuthoringRules` 的输入契约** —— 升级闸,未触碰。
- **`validate-form-layout` 的同族遍历洞** —— 已有 #6251 在跟,文件面不相交。
- **`packages/lint/src/data-model-rules.ts`** —— #6108 在飞面锁,未触碰。
- **`packages/spec` 本体、`content/` 全部、`content/docs/releases/` 全部** —— 未触碰。
- **测量 fixture** —— 全部撤净,`git diff origin/main -- examples/` 终态为**空**(已核)。回归覆盖改由 `packages/lint` 的 pin 测试承担,不在 examples 留常驻 fixture。

## Changeset

**路线 2(`skip-changeset`)**。依据:非注释代码行改动为 **0**(已用 diff 过滤核实),其余是新增测试文件 —— 本 PR 不发布任何行为变化,写不出诚实的 changeset 条目。标签读回确认:`["size/m", "skip-changeset"]`(并集写入,`size/m` 未被覆盖)。