### PR TITLE
feat(runtime): standalone stack 认 `mysql://`,并对 `OS_DATABASE_DRIVER` 做真校验 (#6265)

### DIFF
--- a/.changeset/standalone-stack-mysql-and-driver-validation.md
+++ b/.changeset/standalone-stack-mysql-and-driver-validation.md
@@ -1,0 +1,21 @@
+---
+'@objectstack/runtime': minor
+---
+
+**`createStandaloneStack` now dispatches `mysql://`, and an unknown `OS_DATABASE_DRIVER` value is refused instead of silently becoming SQLite** (#6265).
+
+Two halves of one defect family: a driver selection this stack could not dispatch.
+
+**`mysql://` — the #5820 split with a different scheme.** The CLI has classified `mysql://` / `mysql2://` as the `mysql` kind since forever (`inferDriverTypeFromUrl`), the shared datasource factory has always been able to build it (`SqlDriver` on the `mysql2` client), and `content/docs/data-modeling/drivers.mdx` lists it in the URL-inference table — only `detectDriverFromUrl()` in this package had no arm. So one `OS_DATABASE_URL=mysql://…` booted under `os start` and hard-failed under `os migrate` (which boots through this stack) with `Unsupported database URL scheme`.
+
+- `mysql://…` and `mysql2://…` resolve to the `mysql` kind, matched by character-for-character the same regex the CLI uses — the two functions answer the same question about the same URL, so a divergence between them *is* the bug.
+- The stack declares `{ driver: 'mysql', config: { url } }` and the shared factory builds it, exactly like `postgres`. No optional package and no new dependency: `mysql2` is already an optional peer of `@objectstack/driver-sql`, the same posture `pg` has, so a missing client surfaces at connect like it always did.
+- `databaseDriver: 'mysql'` and `OS_DATABASE_DRIVER=mysql` are accepted; `sqliteFile` stays `null` for a MySQL target, so `os migrate`'s occupancy probe does not read a DSN as a file path.
+
+**`OS_DATABASE_DRIVER` is validated now.** `databaseDriver` in config was parsed by a zod enum (loud rejection) while the env var was a bare `as` cast — an assertion that checks nothing at runtime. An unrecognised value matched no dispatch arm and landed in the chain's trailing `else`: SQLite, in silence. `OS_DATABASE_DRIVER=mysql` with no URL therefore created a local `standalone.db` while the operator believed they were talking to MySQL, and a typo (`mysq1`, `postgress`) did the same; with a URL set it surfaced as the doubly-misleading "sqlite driver was selected but the URL does not look like a file path" for someone who never selected sqlite. This is the #3276 class.
+
+- Both paths now read **one** declaration (`StandaloneDatabaseDriverSchema`): the config key parses it, the env value parses it, the `ResolvedDriverKind` union is inferred from it, and the refusal enumerates its options rather than repeating them in a hand-written list.
+- An unknown value throws, naming the value and every legal driver: `sqlite, sqlite-wasm, memory, postgres, mysql, mongodb, turso`. The env value is lower-cased first, matching the CLI's reader of the same variable; the accepted vocabulary is the enum and nothing else.
+- The dispatch chain's trailing `else` is no longer "sqlite" — it is a `never` guard, so the *next* kind added to the enum without a dispatch arm is a compile error rather than a wrong database.
+
+Unknown URL schemes still throw (the message now lists `mysql://`), and the "unknown driver" and "unknown URL scheme" refusals stay distinguishable.

--- a/packages/runtime/src/standalone-stack.mysql.test.ts
+++ b/packages/runtime/src/standalone-stack.mysql.test.ts
@@ -1,0 +1,266 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// #6265 — two halves of one defect family in `standalone-stack.ts`, pinned
+// together because they close the same hole from opposite sides: a driver
+// selection this stack could not dispatch.
+//
+// (a) `mysql://` — the #5820 split with a different scheme. The CLI has
+//     classified `mysql[2]://` as `mysql` since forever
+//     (`utils/storage-driver.ts` `inferDriverTypeFromUrl`), the SHARED factory
+//     has always been able to build it (`kind === 'mysql'` → SqlDriver on
+//     `mysql2`), and only `detectDriverFromUrl()` here had no arm — so one
+//     `OS_DATABASE_URL=mysql://…` booted under `os start` and died under
+//     `os migrate` with `Unsupported database URL scheme`.
+//
+// (b) `OS_DATABASE_DRIVER` — `cfg.databaseDriver` was parsed by a zod enum
+//     (loud rejection) while the env var was a bare `as` cast (no runtime check
+//     at all). An unknown value matched no dispatch arm and landed in the
+//     chain's trailing `else`: SQLite, in silence. `OS_DATABASE_DRIVER=mysql`
+//     with no URL therefore created a local `standalone.db` while the operator
+//     believed they were connected to MySQL — the #3276 class, and the value is
+//     one `content/docs/deployment/environment-variables.mdx` advertises.
+//
+// Nothing here talks to a real MySQL server: `createStandaloneStack` builds a
+// DEFINITION and hands it to `DefaultDatasourcePlugin`, which connects later at
+// kernel init (ADR-0062 D1 / #3826). The definition plus the shared factory's
+// own `supports()` is therefore the whole of this package's contract.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  resolveStandaloneDatabase,
+  createStandaloneStack,
+  StandaloneDatabaseDriverSchema,
+} from './standalone-stack.js';
+
+/** Env keys these tests write; restored after every case. */
+const ENV_KEYS = [
+  'OS_DATABASE_URL',
+  'DATABASE_URL',
+  'TURSO_DATABASE_URL',
+  'OS_DATABASE_DRIVER',
+  'OS_HOME',
+] as const;
+const ORIGINAL_ENV: Record<string, string | undefined> = Object.fromEntries(
+  ENV_KEYS.map((k) => [k, process.env[k]]),
+);
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const original = ORIGINAL_ENV[key];
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  }
+});
+
+function clearUrlEnv(): void {
+  for (const key of ENV_KEYS) delete process.env[key];
+}
+
+/** The `default` datasource DEFINITION a built stack carries. */
+function defaultDefOf(stack: Awaited<ReturnType<typeof createStandaloneStack>>): {
+  driver: string;
+  config?: Record<string, unknown>;
+} {
+  const plugin = stack.plugins.find(
+    (p: any) => p?.name === 'com.objectstack.runtime.default-datasource',
+  ) as any;
+  expect(plugin, 'stack must carry the DefaultDatasourcePlugin').toBeDefined();
+  return plugin.def;
+}
+
+const BOOT_TIMEOUT = 60_000;
+
+describe('detectDriverFromUrl — mysql:// resolves to the `mysql` kind (#6265)', () => {
+  it('mysql:// resolves to mysql, keeps the URL, and probes no sqlite file', () => {
+    const url = 'mysql://user:pw@localhost:3306/objectstack';
+    const r = resolveStandaloneDatabase({ databaseUrl: url });
+    expect(r.driver).toBe('mysql');
+    expect(r.url).toBe(url);
+    // The occupancy probe (`os migrate`, #3917) has nothing to say about a
+    // remote server — and must NOT read the DSN as a file path.
+    expect(r.sqliteFile).toBeNull();
+  });
+
+  it('mysql2:// — the second spelling the CLI regex accepts — resolves the same', () => {
+    const r = resolveStandaloneDatabase({ databaseUrl: 'mysql2://user:pw@db.internal:3306/app' });
+    expect(r.driver).toBe('mysql');
+    expect(r.sqliteFile).toBeNull();
+  });
+
+  it('the scheme match is case-insensitive, like every other arm', () => {
+    expect(resolveStandaloneDatabase({ databaseUrl: 'MYSQL://user@host/db' }).driver).toBe('mysql');
+  });
+
+  it('an explicit databaseDriver: "mysql" is accepted by the config schema', () => {
+    const r = resolveStandaloneDatabase({
+      databaseDriver: 'mysql',
+      databaseUrl: 'mysql://user:pw@localhost:3306/db',
+    });
+    expect(r.driver).toBe('mysql');
+    expect(r.sqliteFile).toBeNull();
+  });
+
+  it('OS_DATABASE_DRIVER=mysql selects the same kind', () => {
+    clearUrlEnv();
+    process.env.OS_DATABASE_DRIVER = 'mysql';
+    process.env.OS_DATABASE_URL = 'mysql://user:pw@env-host:3306/db';
+    expect(resolveStandaloneDatabase().driver).toBe('mysql');
+  });
+
+  // The URL source that used to be dispatchable only from the CLI side.
+  it('OS_DATABASE_URL=mysql://… dispatches with no explicit driver at all', () => {
+    clearUrlEnv();
+    process.env.OS_DATABASE_URL = 'mysql://user:pw@env-host:3306/db';
+    const r = resolveStandaloneDatabase();
+    expect(r.driver).toBe('mysql');
+    expect(r.url).toBe('mysql://user:pw@env-host:3306/db');
+  });
+});
+
+describe('createStandaloneStack — a mysql:// boot is dispatched, not refused as unknown (#6265)', () => {
+  it('declares { driver: "mysql", config: { url } } instead of throwing "Unsupported database URL scheme"', async () => {
+    clearUrlEnv();
+    const url = 'mysql://user:pw@localhost:3306/objectstack';
+    const stack = await createStandaloneStack({ databaseUrl: url });
+    const def = defaultDefOf(stack);
+    expect(def.driver).toBe('mysql');
+    expect(def.config).toEqual({ url });
+  }, BOOT_TIMEOUT);
+
+  // The other end of the handshake: the id this stack declares is one the
+  // SHARED factory can build (`kind === 'mysql'` → SqlDriver, client `mysql2`).
+  // Not a connect — `mysql2` is an optional peer of `@objectstack/driver-sql`
+  // and a live server is not this package's contract; what matters is that the
+  // declared id is not an id nobody builds.
+  it('the declared driver id is one the shared factory supports', async () => {
+    const { createDefaultDatasourceDriverFactory } = await import('@objectstack/service-datasource');
+    const factory = createDefaultDatasourceDriverFactory({ dev: false });
+    expect(factory.supports('mysql')).toBe(true);
+  });
+
+  it('an explicit databaseDriver:"mysql" declares mysql — never the sqlite fallback', async () => {
+    clearUrlEnv();
+    const stack = await createStandaloneStack({
+      databaseDriver: 'mysql',
+      databaseUrl: 'mysql://user:pw@localhost:3306/objectstack',
+    });
+    expect(defaultDefOf(stack).driver).toBe('mysql');
+  }, BOOT_TIMEOUT);
+});
+
+describe('OS_DATABASE_DRIVER — an unknown value is refused loudly, never SQLite (#6265)', () => {
+  it('a typo with a URL set throws, naming the value and every legal driver', () => {
+    clearUrlEnv();
+    process.env.OS_DATABASE_DRIVER = 'mysq1';
+    process.env.OS_DATABASE_URL = 'mysql://user:pw@localhost:3306/db';
+    expect(() => resolveStandaloneDatabase()).toThrow(/Unsupported OS_DATABASE_DRIVER value/);
+    expect(() => resolveStandaloneDatabase()).toThrow(/mysq1/);
+    // The legal-values list is DERIVED from the enum, so this loop is the pin:
+    // a kind added to the schema without touching the message still passes.
+    for (const option of StandaloneDatabaseDriverSchema.options) {
+      expect(() => resolveStandaloneDatabase(), `legal value "${option}" must be named`).toThrow(option);
+    }
+  });
+
+  // The insidious one: no URL at all, so the old code resolved the default
+  // `file:…/standalone.db`, cast the env value to a kind nothing matched, and
+  // created a SQLite database for an operator who asked for something else.
+  it('a typo with NO URL set throws too — it does not quietly become the sqlite default', () => {
+    clearUrlEnv();
+    process.env.OS_DATABASE_DRIVER = 'postgress';
+    expect(() => resolveStandaloneDatabase()).toThrow(/Unsupported OS_DATABASE_DRIVER value/);
+    expect(() => resolveStandaloneDatabase()).toThrow(/postgress/);
+  });
+
+  it('the whole boot refuses as well, and produces no sqlite definition (both URL states)', async () => {
+    clearUrlEnv();
+    process.env.OS_DATABASE_DRIVER = 'mysq1';
+    process.env.OS_DATABASE_URL = 'mysql://user:pw@localhost:3306/db';
+    await expect(createStandaloneStack()).rejects.toThrow(/Unsupported OS_DATABASE_DRIVER value/);
+
+    delete process.env.OS_DATABASE_URL;
+    const err = await createStandaloneStack().then(() => null, (e: unknown) => e);
+    expect(err).not.toBeNull();
+    expect(String((err as Error).message)).toMatch(/Unsupported OS_DATABASE_DRIVER value/);
+    // …and nothing anywhere in the refusal offers sqlite as a consolation.
+    expect(String((err as Error).message)).not.toMatch(/falling back to sqlite|using sqlite/i);
+  }, BOOT_TIMEOUT);
+
+  // Two different failures, two different messages: "I don't know that driver"
+  // must not read as "I don't know that URL scheme", or an operator debugging
+  // one goes looking at the other.
+  it('the driver refusal and the URL-scheme refusal stay distinguishable', () => {
+    clearUrlEnv();
+    process.env.OS_DATABASE_DRIVER = 'mysq1';
+    expect(() => resolveStandaloneDatabase()).not.toThrow(/Unsupported database URL scheme/);
+
+    delete process.env.OS_DATABASE_DRIVER;
+    expect(() => resolveStandaloneDatabase({ databaseUrl: 'wat://nope' }))
+      .not.toThrow(/Unsupported OS_DATABASE_DRIVER value/);
+  });
+
+  it('an empty / whitespace-only value is "unset", not an unknown driver', () => {
+    clearUrlEnv();
+    process.env.OS_DATABASE_DRIVER = '   ';
+    process.env.OS_DATABASE_URL = 'memory://blank-driver';
+    expect(resolveStandaloneDatabase().driver).toBe('memory');
+  });
+
+  // Normalization parity with the CLI's reader of this same variable
+  // (`resolveDriverType`: `.toLowerCase().trim()`). The accepted VOCABULARY is
+  // still exactly the enum — only the casing of the operator's typing is
+  // normalized, in both readers, so one env value cannot mean two things.
+  it('accepts the CLI-normalized spellings of a legal value (case + surrounding space)', () => {
+    clearUrlEnv();
+    process.env.OS_DATABASE_URL = 'mysql://user:pw@localhost:3306/db';
+    process.env.OS_DATABASE_DRIVER = ' MySQL ';
+    expect(resolveStandaloneDatabase().driver).toBe('mysql');
+  });
+
+  it('every legal value round-trips through the env path', () => {
+    clearUrlEnv();
+    // A URL that never decides on its own — the env value is what is under test.
+    process.env.OS_DATABASE_URL = 'file:/tmp/os-6265/env-driver.db';
+    for (const option of StandaloneDatabaseDriverSchema.options) {
+      process.env.OS_DATABASE_DRIVER = option;
+      expect(resolveStandaloneDatabase().driver).toBe(option);
+    }
+  });
+});
+
+describe('the existing schemes are untouched (positive controls, #6265)', () => {
+  it.each([
+    ['memory://anything', 'memory'],
+    ['postgres://user:pw@localhost:5432/db', 'postgres'],
+    ['postgresql://user:pw@localhost:5432/db', 'postgres'],
+    ['pg://user:pw@localhost:5432/db', 'postgres'],
+    ['mysql://user:pw@localhost:3306/db', 'mysql'],
+    ['mysql2://user:pw@localhost:3306/db', 'mysql'],
+    ['mongodb://localhost:27017/objectstack', 'mongodb'],
+    ['mongodb+srv://cluster.example.com/db', 'mongodb'],
+    ['libsql://my-db.turso.io', 'turso'],
+    ['https://my-db.turso.io', 'turso'],
+    ['wasm-sqlite:///tmp/x.db', 'sqlite-wasm'],
+    ['file:/tmp/os-6265/plain.db', 'sqlite'],
+    ['/tmp/os-6265/bare-path.db', 'sqlite'],
+  ])('%s → %s', (url, kind) => {
+    expect(resolveStandaloneDatabase({ databaseUrl: url }).driver).toBe(kind);
+  });
+
+  // #6220's e2e pins this exit path from the CLI end — the new mysql arm must
+  // not have turned the trailing throw into a catch-all.
+  it('an unknown scheme still throws, and the message now lists mysql://', () => {
+    expect(() => resolveStandaloneDatabase({ databaseUrl: 'wat://nope' }))
+      .toThrow(/Unsupported database URL scheme/);
+    expect(() => resolveStandaloneDatabase({ databaseUrl: 'wat://nope' }))
+      .toThrow(/mysql:\/\//);
+    // …and it still lists what #5820 added, so neither half erased the other.
+    expect(() => resolveStandaloneDatabase({ databaseUrl: 'wat://nope' }))
+      .toThrow(/libsql:\/\//);
+  });
+
+  it('a non-Turso https URL is still unsupported', () => {
+    expect(() => resolveStandaloneDatabase({ databaseUrl: 'https://example.com/db' }))
+      .toThrow(/Unsupported database URL scheme/);
+  });
+});

--- a/packages/runtime/src/standalone-stack.ts
+++ b/packages/runtime/src/standalone-stack.ts
@@ -16,13 +16,17 @@
  * Auto-detects the appropriate driver from the database URL scheme:
  *   - `memory://*`              → InMemoryDriver
  *   - `postgres[ql]://`, `pg://` → SqlDriver (pg)
+ *   - `mysql[2]://`             → SqlDriver (mysql2)
  *   - `mongodb[+srv]://`        → MongoDBDriver (optional `@objectstack/driver-mongodb`)
  *   - `libsql://`, `http(s)://*.turso.*` → TursoDriver (optional `@objectstack/driver-turso`)
  *   - `file:` / no scheme       → SqlDriver (better-sqlite3)
  *
  * Unknown URL schemes throw — we never silently fall back to sqlite, since
  * that historically created bogus directories on disk (e.g. `mongodb:/`)
- * when an unsupported URL was treated as a file path.
+ * when an unsupported URL was treated as a file path. The SAME refusal now
+ * covers an unknown `OS_DATABASE_DRIVER` value (#6265): that env var used to be
+ * a bare `as` cast, so a typo — or `mysql` before this stack could dispatch it
+ * — fell through the driver chain's trailing `else` into SQLite without a word.
  *
  * NOTE: `libsql://` / Turso support comes from `@objectstack/driver-turso`,
  * which lives in THIS repository (`packages/drivers/driver-turso`) since #4645
@@ -36,6 +40,16 @@
  * under (#5602 / PR #5819); before #5820 the two disagreed, and one
  * `OS_DATABASE_URL=libsql://…` booted under `os start` while `os migrate` — which
  * comes through here — refused it as an unsupported scheme.
+ *
+ * NOTE: `mysql://` is the same family with none of the optional-package weight
+ * (#6265). The CLI has classified it as `mysql` since forever
+ * (`inferDriverTypeFromUrl`), the SHARED factory has always been able to build
+ * it (`kind === 'mysql'` → SqlDriver on `mysql2`), and only this file was
+ * missing the arm — so one `OS_DATABASE_URL=mysql://…` booted under `os start`
+ * and died under `os migrate` with `Unsupported database URL scheme`, exactly
+ * the #5820 split with a different scheme. Nothing lazy is needed here: the
+ * definition goes straight to `DefaultDatasourcePlugin` and the shared factory
+ * builds it like postgres.
  */
 
 import { resolve as resolvePath } from 'node:path';
@@ -69,6 +83,24 @@ export function resolveObjectStackHome(): string {
     return resolvePath(homedir(), '.objectstack');
 }
 
+/**
+ * The driver kinds a standalone boot can dispatch — the ONE list, and the only
+ * one (#6265).
+ *
+ * Three consumers read it and every one of them used to carry its own answer:
+ * the `databaseDriver` config key (a zod enum that rejected loudly), the
+ * `OS_DATABASE_DRIVER` env var (a bare `as` cast that validated nothing, so an
+ * unknown value fell through the dispatch chain's trailing `else` into SQLite),
+ * and the `ResolvedDriverKind` union (a hand-written third copy). They are now
+ * one declaration: the union is `z.infer`red from it, the env value is parsed
+ * through it, and the refusal message enumerates `.options` rather than
+ * repeating them — a kind added here cannot leave a stale legal-values list
+ * behind.
+ */
+export const StandaloneDatabaseDriverSchema = z.enum([
+    'sqlite', 'sqlite-wasm', 'memory', 'postgres', 'mysql', 'mongodb', 'turso',
+]);
+
 export const StandaloneStackConfigSchema = z.object({
     databaseUrl: z.string().optional(),
     /**
@@ -78,7 +110,7 @@ export const StandaloneStackConfigSchema = z.object({
      * reads, and the same pair `--database-auth-token` forwards into).
      */
     databaseAuthToken: z.string().optional(),
-    databaseDriver: z.enum(['sqlite', 'sqlite-wasm', 'memory', 'postgres', 'mongodb', 'turso']).optional(),
+    databaseDriver: StandaloneDatabaseDriverSchema.optional(),
     environmentId: z.string().optional(),
     artifactPath: z.string().optional(),
     /**
@@ -159,11 +191,19 @@ export interface StandaloneStackResult {
     positions?: any[];
 }
 
-type ResolvedDriverKind = 'memory' | 'postgres' | 'mongodb' | 'turso' | 'sqlite' | 'sqlite-wasm';
+type ResolvedDriverKind = z.infer<typeof StandaloneDatabaseDriverSchema>;
 
 function detectDriverFromUrl(dbUrl: string): ResolvedDriverKind {
     if (/^memory:\/\//i.test(dbUrl)) return 'memory';
     if (/^(postgres(ql)?|pg):\/\//i.test(dbUrl)) return 'postgres';
+    // MySQL / MariaDB (#6265). Character-for-character the regex the CLI uses
+    // (`utils/storage-driver.ts` `inferDriverTypeFromUrl`), for the same reason
+    // the turso arm below copies its spellings: the two functions answer the
+    // same question about the same `OS_DATABASE_URL`, so any divergence IS the
+    // bug — `os start` booting a URL `os migrate` refuses. Unlike turso this
+    // needs no optional package: the shared factory's `mysql` arm builds a
+    // SqlDriver on `mysql2`, which `@objectstack/driver-sql` already ships.
+    if (/^mysql2?:\/\//i.test(dbUrl)) return 'mysql';
     if (/^mongodb(\+srv)?:\/\//i.test(dbUrl)) return 'mongodb';
     // libSQL / Turso (#5820). The same two spellings the CLI classifies as
     // `turso` (`utils/storage-driver.ts` `inferDriverTypeFromUrl`, #5602) — kept
@@ -182,8 +222,49 @@ function detectDriverFromUrl(dbUrl: string): ResolvedDriverKind {
     if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(dbUrl)) return 'sqlite';
     throw new Error(
         `[StandaloneStack] Unsupported database URL scheme: ${dbUrl}. ` +
-        `Supported schemes: memory://, postgres://, pg://, mongodb://, mongodb+srv://, ` +
+        `Supported schemes: memory://, postgres://, pg://, mysql://, mysql2://, ` +
+        `mongodb://, mongodb+srv://, ` +
         `libsql:// (optional @objectstack/driver-turso), file:`
+    );
+}
+
+/**
+ * The explicit driver selection for this boot, or `undefined` when none was made.
+ *
+ * Two sources, ONE vocabulary (#6265). `cfg.databaseDriver` has always been
+ * parsed by {@link StandaloneDatabaseDriverSchema}; `OS_DATABASE_DRIVER` was
+ * `process.env.OS_DATABASE_DRIVER?.trim() as ResolvedDriverKind` — an assertion,
+ * which checks nothing at runtime. An unknown value therefore reached the
+ * dispatch chain in `createStandaloneStack`, matched no arm, and landed in the
+ * trailing `else`: SQLite, silently. `OS_DATABASE_DRIVER=mysql` (a value the
+ * CLI advertises and `content/docs/deployment/environment-variables.mdx` lists)
+ * with no URL set therefore created a local `standalone.db` while the operator
+ * believed they were talking to MySQL — the #3276 class exactly, and with a URL
+ * set it surfaced as the doubly-misleading "sqlite driver was selected but the
+ * URL does not look like a file path" for an operator who never selected sqlite.
+ *
+ * So the env value is parsed by the same schema and an unrecognised one is
+ * refused LOUDLY, naming the legal values. The value is lower-cased first, for
+ * the same reason the regexes above are copied verbatim from the CLI: the CLI's
+ * reader of this very variable does `(explicitDriver ?? '').toLowerCase().trim()`,
+ * and a case-sensitive reader here would re-open the divergence this issue is
+ * about, one notch narrower. The accepted VOCABULARY is unchanged either way —
+ * it is the enum, and nothing else.
+ */
+function resolveExplicitDriver(
+    cfg: z.output<typeof StandaloneStackConfigSchema>,
+): ResolvedDriverKind | undefined {
+    if (cfg.databaseDriver) return cfg.databaseDriver;
+    const raw = process.env.OS_DATABASE_DRIVER?.trim();
+    if (!raw) return undefined;
+    const parsed = StandaloneDatabaseDriverSchema.safeParse(raw.toLowerCase());
+    if (parsed.success) return parsed.data;
+    throw new Error(
+        `[StandaloneStack] Unsupported OS_DATABASE_DRIVER value: "${raw}". ` +
+        `Supported drivers: ${StandaloneDatabaseDriverSchema.options.join(', ')}. ` +
+        `Booting on the SQLite default instead would silently ignore the driver you asked for ` +
+        `and write into a local database (#3276). Fix the value, or unset OS_DATABASE_DRIVER ` +
+        `to let the OS_DATABASE_URL scheme select the driver.`
     );
 }
 
@@ -229,12 +310,16 @@ export interface ResolvedStandaloneDatabase {
  * URL was read here and then rejected by `detectDriverFromUrl` as an unsupported
  * scheme, so a host that set it got a hard failure rather than a libSQL
  * connection. Reading a source you cannot dispatch is worse than not reading it.
+ *
+ * Throws on a selection this stack cannot dispatch — an unknown URL scheme
+ * (`detectDriverFromUrl`) or, since #6265, an unknown `OS_DATABASE_DRIVER` value
+ * ({@link resolveExplicitDriver}). Both refusals happen HERE rather than at boot
+ * so `os migrate`'s pre-boot probe reads the same verdict the boot would.
  */
 export function resolveStandaloneDatabase(config?: StandaloneStackConfig): ResolvedStandaloneDatabase {
     const cfg = StandaloneStackConfigSchema.parse(config ?? {});
     const url = resolveDatabaseUrl(cfg);
-    const explicitDriver = cfg.databaseDriver
-        ?? (process.env.OS_DATABASE_DRIVER?.trim() as ResolvedDriverKind | undefined);
+    const explicitDriver = resolveExplicitDriver(cfg);
     const driver: ResolvedDriverKind = explicitDriver || detectDriverFromUrl(url);
     const isSqlite = driver === 'sqlite' || driver === 'sqlite-wasm';
     const filename = isSqlite ? sqliteFilenameFromUrl(url, driver) : null;
@@ -335,6 +420,15 @@ export async function createStandaloneStack(config?: StandaloneStackConfig): Pro
         // Factory applies the pg pool default ({ min: 0, max: 5 }) internally.
         driverId = 'postgres';
         driverConfig = { url: dbUrl };
+    } else if (dbDriver === 'mysql') {
+        // MySQL / MariaDB (#6265). Nothing special: the shared factory's `mysql`
+        // arm builds a SqlDriver on the `mysql2` client from exactly this
+        // config (`MysqlConfigSchema.url` — "passed to mysql2 as-is"), and the
+        // CLI's own `mysql` branch produces the same `{ driverId: 'mysql',
+        // config: { url } }`. The only thing that was missing was this arm, and
+        // the detection arm above it.
+        driverId = 'mysql';
+        driverConfig = { url: dbUrl };
     } else if (dbDriver === 'mongodb') {
         // A missing @objectstack/driver-mongodb peer dep surfaces at boot via
         // the connection service's fail-fast (the factory's "not installed"
@@ -364,12 +458,26 @@ export async function createStandaloneStack(config?: StandaloneStackConfig): Pro
             mkdirSync(resolvePath(filename, '..'), { recursive: true });
         }
         driverConfig = { filename };
-    } else {
+    } else if (dbDriver === 'sqlite') {
         // sqlite (better-sqlite3)
         driverId = 'sqlite';
         const filename = sqliteFilenameFromUrl(dbUrl, 'sqlite');
         mkdirSync(resolvePath(filename, '..'), { recursive: true });
         driverConfig = { filename };
+    } else {
+        // Unreachable by construction — and making it unreachable is half the
+        // fix (#6265). This used to be a bare `else` meaning "sqlite", so every
+        // kind without an arm above became SQLite in silence: an unvalidated
+        // `OS_DATABASE_DRIVER` value landed here, and so would the NEXT kind
+        // added to the enum without a dispatch arm. `dbDriver` is now narrowed
+        // to `never` here, so that omission is a compile error instead of a
+        // wrong database.
+        const unreachable: never = dbDriver;
+        throw new Error(
+            `[StandaloneStack] No dispatch arm for database driver kind: ${String(unreachable)}. ` +
+            `Every kind in StandaloneDatabaseDriverSchema needs one — falling through to SQLite ` +
+            `is the #3276 defect.`
+        );
     }
     const defaultDatasourcePlugin = new DefaultDatasourcePlugin(
         { driver: driverId, config: driverConfig },


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6265

两半同批,同属一个缺陷家族:**一个本栈无法 dispatch 的 driver 选择**。落点全部在 `packages/runtime/src/standalone-stack.ts`。

## 前提重验(当前 `origin/main` = `db59e9c5f`,#6272 已并入,行号按合并后实读)

| issue 断言 | 实读结果 | 位置 |
| :--- | :--- | :--- |
| CLI 认 `mysql[2]://` | `if (/^mysql2?:\/\//i.test(u)) return 'mysql';`,`resolveStorageDefinition` 有 `mysql` 臂,产出 `{ driverId: 'mysql', config: { url, ...autoMigrate } }` | `packages/cli/src/utils/storage-driver.ts:128` / `:288` |
| 共享工厂本来就能造 | `if (kind === 'mysql') { const { SqlDriver } = await import('@objectstack/driver-sql'); … client: 'mysql2' }` | `packages/services/service-datasource/src/default-datasource-driver-factory.ts:423` |
| 本栈无 mysql 臂 | `detectDriverFromUrl()` 依次 memory / postgres / mongodb / libsql / turso-https / wasm / file / 裸路径,随后 throw;**无 mysql** | `standalone-stack.ts:164`(改前) |
| env 路是裸断言 | `?? (process.env.OS_DATABASE_DRIVER?.trim() as ResolvedDriverKind \| undefined)` | `standalone-stack.ts:236`(改前) |
| 未知值静默落 sqlite | 分派链末尾 `} else { // sqlite (better-sqlite3) …` | `standalone-stack.ts:367`(改前) |

三条全部坐实,前提有效。补充两条实读旁证:

- `content/docs/deployment/environment-variables.mdx:52` 已把 `mysql` 列为 `OS_DATABASE_DRIVER` 合法值,`content/docs/data-modeling/drivers.mdx` 的 URL 推断表也已列 `mysql://…` —— 文档早就在宣传本栈不认的能力(declared ≠ enforced),本 PR 让文档变真,故不需要改文档;
- `mysql2` 是 `@objectstack/driver-sql` 的 **optional peer**(与 `pg` 完全同姿势),而 `@objectstack/driver-sql` 已是 `@objectstack/runtime` 的 dependency —— 所以本 PR **零依赖变更**,不碰 `package.json` / `pnpm-lock.yaml`。

## 半 (a):`mysql://` 识别 + 定义

- `detectDriverFromUrl()` 补一臂,正则与 CLI **逐字同款** `/^mysql2?:\/\//i`。理由同 #6272 的 turso 臂:两个函数对同一个 `OS_DATABASE_URL` 回答同一个问题,**分叉本身就是病因**(`os start` 起得来、`os migrate` 起不来)。
- `createStandaloneStack()` 补 `{ driver: 'mysql', config: { url } }` 交给共享工厂 —— 与 postgres 臂同形。不牵扯可选包,不需要 turso 那样的 host factory seam。
- `databaseDriver` enum 补 `'mysql'`;`Supported schemes:` 列表补 `mysql://, mysql2://`。
- mysql 的 `sqliteFile` 恒 `null`(occupancy gate 语义,参照 #6272 对 turso 的处理):CLI 的 `migrate-occupancy-gate.ts` 只读 `target.sqliteFile`,远端 server 无话可说,更不能把 DSN 当文件路径读。

## 半 (b):`OS_DATABASE_DRIVER` 真校验 —— 两条口径归一

改前 `cfg.databaseDriver` 走 zod enum(响亮拒绝),env 那一路是 `as` 断言(运行期零校验)。未知值不匹配任何分派臂,落到末尾 `else` = SQLite,**一声不吭**:

- `OS_DATABASE_DRIVER=mysql` 且未设 URL ⇒ 默认 `file:…/standalone.db` ⇒ 静默建 SQLite 库,操作者以为在连 MySQL;
- 拼写错(`mysq1` / `postgress`)同样静默落 SQLite;
- 设了 URL 时反而报 `sqlite driver was selected but the URL does not look like a file path` —— 对一个从没选过 sqlite 的操作者双重误导。

修法(不留第三份清单):

1. 新增 `StandaloneDatabaseDriverSchema` 作为**唯一**一份 driver 词表:`databaseDriver` 用它、env 值用它 `safeParse`、`ResolvedDriverKind` 由它 `z.infer` 推出;
2. 未知值响亮 throw,合法值全集由 `.options.join(', ')` **推导**输出(⛔ 不手写数组,加一个 kind 不会留下过期清单);
3. 两类错误刻意分辨:`Unsupported OS_DATABASE_DRIVER value: "…"` vs 既有 `Unsupported database URL scheme: …`,互不冒充(有钉子);
4. env 值先 `toLowerCase()`:CLI 读同一个变量时就是 `(explicitDriver ?? '').toLowerCase().trim()`。若这里大小写敏感,等于把本 issue 要消灭的分叉换个更窄的形状再开一遍。**被接受的词表没有变** —— 就是那个 enum,别无其他;
5. 分派链末尾的 `else` 不再等于 sqlite,而是 `const unreachable: never = dbDriver;` —— 下一个加进 enum 却忘了补臂的 kind 是**编译错误**,不再是一个连错库的运行时。

## 反向验证(先预测方向,再跑)

两轮拆除,方向都**事先写死**再执行。

**Pass A —— 摘掉半 (a)(detect 臂 + dispatch 臂 + 消息里的 `mysql://`)。预测:** 走 detect 的钉子红(Unsupported scheme);走 explicit driver 的钉子**仍绿**(它们根本不经过 detect);`supports('mysql')` 那条**仍绿**(它钉的是共享工厂那一端,不是本文件)。**实测 9 红 22 绿,逐条吻合:**

```
× mysql:// resolves to mysql, keeps the URL, and probes no sqlite file
  → [StandaloneStack] Unsupported database URL scheme: mysql://user:pw@localhost:3306/objectstack. …
× mysql2:// — the second spelling the CLI regex accepts — resolves the same
× the scheme match is case-insensitive, like every other arm
× OS_DATABASE_URL=mysql://… dispatches with no explicit driver at all
× declares { driver: "mysql", config: { url } } instead of throwing "Unsupported database URL scheme"
× an explicit databaseDriver:"mysql" declares mysql — never the sqlite fallback
  → [StandaloneStack] No dispatch arm for database driver kind: mysql. …
× 正对照表 mysql:// / mysql2:// 两行
× an unknown scheme still throws, and the message now lists mysql://
✓ an explicit databaseDriver: "mysql" is accepted by the config schema     ← 预测就该绿
✓ OS_DATABASE_DRIVER=mysql selects the same kind                           ← 预测就该绿
✓ the declared driver id is one the shared factory supports                ← 预测就该绿
Tests  9 failed | 22 passed (31)
```

同一状态下 `pnpm --filter @objectstack/runtime typecheck` 也红 —— 这正是 `never` 卫兵的价值,值得单列:

```
src/standalone-stack.ts(464,15): error TS2322: Type '"mysql"' is not assignable to type 'never'.
```

注意这里是「诊断变多/变早」而非单纯变红:改前同样的遗漏是**静默 sqlite**,现在是编译期报错。

**Pass B —— 把半 (b) 原样还原(裸 `as` + 末尾 `else` = sqlite)。预测:** 三条「响亮拒绝」钉子红,外加大小写归一那条红;「两类错误可分辨」和「空白值 = 未设」两条**按构造仍绿**。**实测 4 红 27 绿,逐条吻合:**

```
× a typo with a URL set throws, naming the value and every legal driver
  → expected [Function] to throw an error                      ← 改前:根本不抛
× a typo with NO URL set throws too — it does not quietly become the sqlite default
  → expected [Function] to throw an error
× the whole boot refuses as well, and produces no sqlite definition (both URL states)
  → expected … /Unsupported OS_DATABASE_DRIVER value/ but got '[StandaloneStack] sqlite driver was s…'
                                                              ← 改前那条误导消息的现场
× accepts the CLI-normalized spellings of a legal value (case + surrounding space)
  → expected 'MySQL' to be 'mysql'
✓ the driver refusal and the URL-scheme refusal stay distinguishable  ← 预测就该绿(它钉的是「不互相冒充」)
✓ an empty / whitespace-only value is "unset", not an unknown driver  ← 预测就该绿
Tests  4 failed | 27 passed (31)
```

两轮后源码逐字还原,复跑 31/31 绿。

## 测试与门禁

- 新增 `packages/runtime/src/standalone-stack.mysql.test.ts`:31 条,含识别、整栈定义、env 校验(有 URL / 无 URL 两种情形)、正对照全家(含 libsql/turso)、`wat://nope` 不变(#6220 e2e 从 CLI 端钉着同一条消息)。
- `pnpm --filter @objectstack/runtime test` ⇒ **108 files / 1578 tests passed**(#6272 刚落的 31 条 libsql 钉子在内,其断言面未被触碰)。
- `pnpm --filter @objectstack/runtime typecheck` ⇒ 干净。
- `npx eslint --no-inline-config` 改动两文件 ⇒ 无输出。
- `node scripts/check-nul-bytes.mjs` ⇒ OK;改动文件另做一次 `grep -naP` 控制字符自扫,无命中。
- 消费半径已清扫:`resolveStandaloneDatabase` 的跨包消费方只有 `packages/cli/src/utils/migrate-occupancy-gate.ts`(只读 `sqliteFile`)与 barrel 导出;`Unsupported database URL scheme` 的仓内断言只有 `packages/cli/test/migrate-exit-code.e2e.test.ts:210`(`wat://nope`,行为未变)。

## changeset

`.changeset/standalone-stack-mysql-and-driver-validation.md` = `@objectstack/runtime: minor`。判据同 #6272 的 minor 判例:新增可用 URL scheme + enum 扩值属功能新增;半 (b) 的响亮拒绝是行为变更,但它替换掉的是「静默连错库」,没有任何人能依赖那个旧行为。

## 范围声明

不碰 `content/docs/releases/`、`package.json`、`pnpm-lock.yaml`;不改 assignee、不自贴标签。explicit-driver 的**别名词表**(CLI 收 `pg` / `mysql2` / `mongo` / `libsql` 等,本栈 enum 只收规范拼写)与「显式非文件 driver 却没给 URL」这两点仍有分叉,另行开 issue 记录,不在本 PR 内顺手扩契约。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wbxm29qPKnLf44AbSxizqW)_