### PR TITLE
docs(getting-started): quick-reference 的 Kernel 计数按证据补回两行,并加一道计数校验门 (#6319)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -139,6 +139,21 @@ jobs:
       - name: Reserved-word ("role") docs ratchet
         run: pnpm check:role-word
 
+      # #6319: content/docs/getting-started/quick-reference.mdx is the protocol
+      # index, and each "## <Name> Protocol (N schemas)" heading is a DECLARATION
+      # about the table under it. The page is hand-written (build-docs.ts writes
+      # only content/docs/references/), so the two drift one edit at a time —
+      # #6319 found Kernel claiming 17 over a 15-row table because two kernel
+      # rows had migrated into the Cloud section and only Cloud's heading was
+      # updated. Nothing breaks at runtime; the cost is that content/docs/ is the
+      # corpus humans and AIs copy from, so a miscounted index is read as a fact
+      # about the schema catalog. Declared = enforced.
+      # It lives in this job with the other docs guards: the change that breaks
+      # the count is a docs edit, so a packages/** paths filter would blind it to
+      # its own failure mode.
+      - name: Quick-reference section counts match their tables
+        run: pnpm check:quick-reference-counts
+
       # #3723 ADR anchors: code an accepted ADR governs must keep naming it.
       # That incident reversed three accepted ADRs with a patch-level changeset,
       # and the mechanism was simply that the edited file never mentioned them —

--- a/content/docs/getting-started/quick-reference.mdx
+++ b/content/docs/getting-started/quick-reference.mdx
@@ -66,7 +66,9 @@ Plugin architecture, manifests, and kernel runtime.
 | **[Plugin Capability](/docs/references/kernel/plugin-capability)** | `plugin-capability.zod.ts` | PluginCapability | Plugin capability declarations |
 | **[Plugin Lifecycle Advanced](/docs/references/kernel/plugin-lifecycle-advanced)** | `plugin-lifecycle-advanced.zod.ts` | AdvancedPluginLifecycleConfig, PluginHealthCheck | Advanced lifecycle hooks |
 | **[Plugin Loading](/docs/references/kernel/plugin-loading)** | `plugin-loading.zod.ts` | PluginLoadingConfig | Plugin loading and init |
-| **[Plugin Security](/docs/references/kernel/plugin-security-advanced)** | `plugin-security-advanced.zod.ts` | KernelSecurityPolicy, PluginPermission | Plugin sandboxing |
+| **[Plugin Registry](/docs/references/kernel/plugin-registry)** | `plugin-registry.zod.ts` | PluginRegistryEntry, PluginVendor | Plugin registry entries and quality metrics |
+| **[Plugin Security](/docs/references/kernel/plugin-security)** | `plugin-security.zod.ts` | PluginSecurityProtocol, SBOM | Plugin security policies |
+| **[Plugin Security Advanced](/docs/references/kernel/plugin-security-advanced)** | `plugin-security-advanced.zod.ts` | KernelSecurityPolicy, PluginPermission | Plugin sandboxing |
 | **[Plugin Structure](/docs/references/kernel/plugin-structure)** | `plugin-structure.zod.ts` | OpsPluginStructure | Plugin file conventions |
 | **[Plugin Validator](/docs/references/kernel/plugin-validator)** | `plugin-validator.zod.ts` | ValidationResult, PluginMetadata | Plugin validation |
 | **[Plugin Versioning](/docs/references/kernel/plugin-versioning)** | `plugin-versioning.zod.ts` | PluginCompatibilityMatrix, DeprecationNotice | Version compatibility |
@@ -176,7 +178,7 @@ User identity, organizations, and position management.
 | **[Position](/docs/references/identity/position)** | `position.zod.ts` | Position | Permission-set distribution (岗位, ADR-0090) |
 | **[SCIM](/docs/references/identity/scim)** | `scim.zod.ts` | SCIMUser, SCIMGroup | SCIM 2.0 provisioning |
 
-## Cloud Protocol (5 schemas)
+## Cloud Protocol (3 schemas)
 
 Environments, marketplace, licensing, and multi-tenancy.
 
@@ -184,8 +186,6 @@ Environments, marketplace, licensing, and multi-tenancy.
 |:---------|:-----------|:------------|:--------|
 | **[Environment](/docs/references/cloud/environment)** | `environment.zod.ts` | Environment, EnvironmentType | Deployment environments |
 | **[Marketplace](/docs/references/cloud/marketplace)** | `marketplace.zod.ts` | MarketplaceListing, PackageSubmission | Plugin marketplace |
-| **[Plugin Registry](/docs/references/kernel/plugin-registry)** | `plugin-registry.zod.ts` | PluginRegistryEntry, PluginVendor | Plugin registry entries and quality metrics |
-| **[Plugin Security](/docs/references/kernel/plugin-security)** | `plugin-security.zod.ts` | PluginSecurityProtocol, SBOM | Plugin security policies |
 | **[Tenant](/docs/references/cloud/tenant)** | `tenant.zod.ts` | Tenant | Multi-tenancy isolation |
 
 ## Integration Protocol (1 schema)

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "check:doc-authoring": "node scripts/check-doc-authoring.mjs --self-test && node scripts/check-doc-authoring.mjs",
     "check:docs-audit-scope": "node scripts/docs-audit/affected-docs.mjs --self-test && node scripts/docs-audit/check-audit-scope.mjs --self-test && node scripts/docs-audit/check-audit-scope.mjs",
     "check:role-word": "node scripts/check-role-word.mjs",
+    "check:quick-reference-counts": "node scripts/check-quick-reference-counts.mjs --self-test && node scripts/check-quick-reference-counts.mjs",
     "check:skill-frame-sync": "node scripts/check-skill-frame-sync.mjs --self-test && node scripts/check-skill-frame-sync.mjs",
     "check:skill-frame-freshness": "node scripts/check-skill-frame-freshness.mjs --self-test && node scripts/check-skill-frame-freshness.mjs",
     "check:skill-compatibility": "node scripts/check-skill-compatibility-version.mjs --self-test && node scripts/check-skill-compatibility-version.mjs",

--- a/scripts/check-quick-reference-counts.mjs
+++ b/scripts/check-quick-reference-counts.mjs
@@ -1,0 +1,402 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Quick-reference section-count guard (#6319).
+ *
+ * ## What it guards
+ *
+ * `content/docs/getting-started/quick-reference.mdx` is the protocol index: one
+ * `## <Name> Protocol (N schemas)` section per namespace, each followed by a
+ * table with one row per protocol. The `(N schemas)` in the heading is a
+ * DECLARATION about the table underneath it, and nothing checked it.
+ *
+ * That page is hand-written — `packages/spec/scripts/build-docs.ts` writes only
+ * `content/docs/references/`, and AGENTS.md's Documentation Guardrails table
+ * lists `content/docs/getting-started/` as hand-written. So the declaration and
+ * the table drift apart one edit at a time: #6319 found the Kernel heading
+ * claiming 17 while its table held 15, because two kernel rows had migrated
+ * into the Cloud section and only Cloud's heading was updated. Nobody hit a bug
+ * — the cost is that `content/docs/` is the corpus humans and AIs copy from, so
+ * a miscounted index is read as a fact about the schema catalog and propagates.
+ *
+ * Declared = enforced: the heading now has to be true.
+ *
+ * ## Why the gate counts instead of a reader
+ *
+ * Hand-counting this page is measurably unreliable, and #6319 is the specimen.
+ * Its report listed three mismatches; only one was real. The other two came
+ * from a scanner that recognised a section heading only by the PLURAL
+ * `(N schemas)`, so `## Integration Protocol (1 schema)` and
+ * `## QA Protocol (1 schema)` were invisible and their rows were charged to the
+ * section above — and, because a section then ended only at the next
+ * *recognised* heading, the Shared section also swallowed the six
+ * `| **Path shape** | ... |` rows of the Declarative Endpoints rule table far
+ * below it, reporting 12 rows where there are 5.
+ *
+ * Both traps are pinned by the self-test, and the parser is built to be immune:
+ * a count is `(N schema)` OR `(N schemas)`, and a section ends at the next `##`
+ * heading of ANY kind, counted or not.
+ *
+ * ## Absence must be loud
+ *
+ * A count checker that stops recognising the page silently passes — it finds no
+ * sections, compares nothing, and reports success, which is the "declared but
+ * not enforced" failure this gate exists to prevent, one level up. So every
+ * structural surprise is an error, not a skip: zero counted sections, a
+ * `## ... Protocol` heading with no count, a counted section with no table or
+ * with more than one, a counted section whose table has no rows.
+ *
+ * Run `--self-test` to check the parser against known-good and known-bad pages
+ * before trusting a green run.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+const TARGET = 'content/docs/getting-started/quick-reference.mdx';
+
+/** `## Kernel Protocol (17 schemas)` / `## QA Protocol (1 schema)` */
+const COUNTED_HEADING = /^##\s+(.+?)\s+\((\d+)\s+schemas?\)\s*$/;
+/** Any `##` heading — what ends a section, counted or not. */
+const ANY_H2 = /^##\s+/;
+/** A heading that names a protocol section but carries no count. */
+const PROTOCOL_HEADING = /^##\s+(.*\bProtocol\b.*)$/;
+/** `|:---|:---|` — the alignment row that proves the line above was a header. */
+const TABLE_DIVIDER = /^\|[\s:|-]+\|\s*$/;
+const TABLE_LINE = /^\|/;
+
+/**
+ * Parse the page into counted sections plus structural complaints.
+ *
+ * @returns {{ sections: Array<{title: string, declared: number, actual: number, line: number}>,
+ *             structural: Array<{line: number, message: string}> }}
+ */
+export function parsePage(text) {
+  const lines = text.split('\n');
+  const sections = [];
+  const structural = [];
+
+  /** @type {{title: string, declared: number, line: number, body: string[], bodyStart: number} | null} */
+  let current = null;
+
+  const closeSection = () => {
+    if (!current) return;
+    const { rows, tables } = countTableRows(current.body, current.bodyStart);
+    if (tables === 0) {
+      structural.push({
+        line: current.line,
+        message: `section "${current.title}" declares ${current.declared} but has no table under it`,
+      });
+    } else if (tables > 1) {
+      structural.push({
+        line: current.line,
+        message: `section "${current.title}" has ${tables} tables; the count is ambiguous (expected exactly 1)`,
+      });
+    } else if (rows === 0) {
+      structural.push({
+        line: current.line,
+        message: `section "${current.title}" has a table with no rows; the row format may have changed`,
+      });
+    }
+    sections.push({
+      title: current.title,
+      declared: current.declared,
+      actual: rows,
+      line: current.line,
+    });
+    current = null;
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const counted = COUNTED_HEADING.exec(line);
+    if (counted) {
+      closeSection();
+      current = {
+        title: counted[1],
+        declared: Number(counted[2]),
+        line: i + 1,
+        body: [],
+        bodyStart: i + 1,
+      };
+      continue;
+    }
+    if (ANY_H2.test(line)) {
+      // A `##` heading ALWAYS ends the current section — including one with no
+      // count. This is the containment that stops a section from running to the
+      // end of the file and counting unrelated tables (#6319's Shared/12).
+      closeSection();
+      const protocolish = PROTOCOL_HEADING.exec(line);
+      if (protocolish) {
+        structural.push({
+          line: i + 1,
+          message: `heading "${protocolish[1]}" names a protocol section but declares no "(N schemas)" count`,
+        });
+      }
+      continue;
+    }
+    if (current) current.body.push(line);
+  }
+  closeSection();
+
+  if (sections.length === 0) {
+    structural.push({
+      line: 1,
+      message:
+        'no "## <Name> (N schemas)" sections found at all — the page structure or the heading format changed',
+    });
+  }
+
+  return { sections, structural };
+}
+
+/** Count body rows of the markdown table(s) in a section body. */
+function countTableRows(body, _bodyStart) {
+  let rows = 0;
+  let tables = 0;
+  for (let i = 0; i < body.length; i++) {
+    // A table is a header line immediately followed by an alignment divider.
+    if (!TABLE_LINE.test(body[i]) || !TABLE_DIVIDER.test(body[i + 1] ?? '')) continue;
+    tables++;
+    let j = i + 2;
+    while (j < body.length && TABLE_LINE.test(body[j])) {
+      rows++;
+      j++;
+    }
+    i = j - 1;
+  }
+  return { rows, tables };
+}
+
+/** @returns {{ findings: Array<{line: number, message: string}>, sections: Array }} */
+export function checkPage(text) {
+  const { sections, structural } = parsePage(text);
+  const findings = structural.map((s) => ({ ...s, kind: 'structure' }));
+  for (const s of sections) {
+    if (s.declared !== s.actual) {
+      findings.push({
+        kind: 'count',
+        line: s.line,
+        message: `section "${s.title}" declares ${s.declared} schema(s) but its table has ${s.actual} row(s)`,
+      });
+    }
+  }
+  findings.sort((a, b) => a.line - b.line);
+  return { findings, sections };
+}
+
+const GOOD_PAGE = [
+  '# Quick Reference Guide',
+  '',
+  '## Data Protocol (2 schemas)',
+  '',
+  'Core business logic.',
+  '',
+  '| Protocol | Source File | Key Schemas | Purpose |',
+  '|:---------|:-----------|:------------|:--------|',
+  '| **[Field](/docs/references/data/field)** | `field.zod.ts` | Field | Field types |',
+  '| **[Object](/docs/references/data/object)** | `object.zod.ts` | Object | Object defs |',
+  '',
+  '## QA Protocol (1 schema)',
+  '',
+  '| Protocol | Source File | Key Schemas | Purpose |',
+  '|:---------|:-----------|:------------|:--------|',
+  '| **[Testing](/docs/references/qa/testing)** | `testing.zod.ts` | TestSuite | Tests |',
+  '',
+  '## Common Patterns',
+  '',
+  '### Declarative Endpoints (`apis:`)',
+  '',
+  '| Rule | Value |',
+  '|:---|:---|',
+  '| **Path shape** | only the subpath is yours |',
+  '| **Namespace** | must be declared explicitly |',
+  '',
+].join('\n');
+
+function selfTest() {
+  const failures = [];
+  const expect = (label, got, want) => {
+    const g = JSON.stringify(got);
+    const w = JSON.stringify(want);
+    if (g !== w) failures.push(`  ✗ ${label}: expected ${w}, got ${g}`);
+  };
+
+  // 1. POSITIVE — the measurement itself, per section. A gutted checker that
+  //    returns nothing fails here, which is why this asserts measured values
+  //    rather than "no findings".
+  {
+    const { sections, findings } = checkPage(GOOD_PAGE);
+    expect(
+      'good page measures every section',
+      sections.map((s) => [s.title, s.declared, s.actual]),
+      [
+        ['Data Protocol', 2, 2],
+        ['QA Protocol', 1, 1],
+      ],
+    );
+    // NEGATIVE (declared): "a correct page is clean". Trivially true for a
+    // checker that reports nothing — it is here to catch false positives, and
+    // it can never be the case that turns this gate red.
+    expect('good page is clean', findings.length, 0);
+  }
+
+  // 2. POSITIVE — a wrong count is caught, and the message names the section
+  //    and BOTH numbers. A gate that merely says "mismatch" fails this.
+  {
+    const bad = GOOD_PAGE.replace('## Data Protocol (2 schemas)', '## Data Protocol (3 schemas)');
+    const { findings } = checkPage(bad);
+    expect('wrong count produces exactly one finding', findings.length, 1);
+    expect('wrong count is a count finding', findings[0]?.kind, 'count');
+    expect('names the section', /"Data Protocol"/.test(findings[0]?.message ?? ''), true);
+    expect('names the declared number', /\b3 schema/.test(findings[0]?.message ?? ''), true);
+    expect('names the actual number', /\b2 row/.test(findings[0]?.message ?? ''), true);
+  }
+
+  // 3. POSITIVE — a deleted table row is caught.
+  {
+    const bad = GOOD_PAGE.replace(
+      '| **[Object](/docs/references/data/object)** | `object.zod.ts` | Object | Object defs |\n',
+      '',
+    );
+    const { findings } = checkPage(bad);
+    expect('deleted row produces one finding', findings.length, 1);
+    expect('deleted row names both numbers', /2 schema\(s\).*1 row\(s\)/.test(findings[0]?.message ?? ''), true);
+  }
+
+  // 4. POSITIVE — the SINGULAR "(1 schema)" heading is a real section. #6319's
+  //    report came from a plural-only regex; under one, this page yields no
+  //    finding at all because QA is not a section and its row is charged to
+  //    Data (making Data look like 3, matching nothing).
+  {
+    const bad = GOOD_PAGE.replace('## QA Protocol (1 schema)', '## QA Protocol (2 schemas)');
+    const { findings } = checkPage(bad);
+    expect('singular heading is parsed as a section', findings.length, 1);
+    expect('singular section named in the finding', /"QA Protocol"/.test(findings[0]?.message ?? ''), true);
+  }
+
+  // 5. POSITIVE — a section ends at the next `##` even when that heading has no
+  //    count, so the Declarative Endpoints rule table is NOT charged to QA.
+  //    Asserted as a measured value (1), not as "no findings" — the leaky
+  //    scanner of #6319 would measure 3 here.
+  {
+    const { sections } = checkPage(GOOD_PAGE);
+    const qa = sections.find((s) => s.title === 'QA Protocol');
+    expect('last section stops at the uncounted heading', qa?.actual, 1);
+  }
+
+  // 6. POSITIVE — the heading FORMAT changing is loud, not silent. Both halves
+  //    matter: the section stops being counted (so nothing is compared) and the
+  //    gate must say so.
+  {
+    const bad = GOOD_PAGE.replace('## Data Protocol (2 schemas)', '## Data Protocol - 2 schemas');
+    const { findings } = checkPage(bad);
+    expect('reformatted heading is reported', findings.length, 1);
+    expect('reformatted heading is a structure finding', findings[0]?.kind, 'structure');
+    expect('reformatted heading names itself', /declares no "\(N schemas\)" count/.test(findings[0]?.message ?? ''), true);
+  }
+
+  // 7. POSITIVE — a counted section whose table vanished.
+  {
+    const bad = [
+      '## Data Protocol (2 schemas)',
+      '',
+      'Core business logic.',
+      '',
+      '## Other',
+      '',
+    ].join('\n');
+    const { findings } = checkPage(bad);
+    expect('missing table is a structure finding', findings[0]?.kind, 'structure');
+    expect('missing table says so', /has no table under it/.test(findings[0]?.message ?? ''), true);
+  }
+
+  // 8. POSITIVE — a page the parser no longer recognises at all fails loudly
+  //    instead of passing with zero comparisons.
+  {
+    const { findings } = checkPage('# Quick Reference Guide\n\nnothing here.\n');
+    expect('unrecognised page is reported', findings.length, 1);
+    expect('unrecognised page is a structure finding', findings[0]?.kind, 'structure');
+    expect(
+      'unrecognised page says the structure changed',
+      /no "## <Name> \(N schemas\)" sections found at all/.test(findings[0]?.message ?? ''),
+      true,
+    );
+  }
+
+  // 9. POSITIVE — two tables in one counted section is ambiguous, not silently
+  //    summed.
+  {
+    const bad = GOOD_PAGE.replace(
+      '| **[Object](/docs/references/data/object)** | `object.zod.ts` | Object | Object defs |',
+      [
+        '| **[Object](/docs/references/data/object)** | `object.zod.ts` | Object | Object defs |',
+        '',
+        '| A | B |',
+        '|:--|:--|',
+        '| x | y |',
+      ].join('\n'),
+    );
+    const { findings } = checkPage(bad);
+    expect('two tables is a structure finding', findings.some((f) => /has 2 tables/.test(f.message)), true);
+  }
+
+  if (failures.length) {
+    console.error('\n✗ check-quick-reference-counts self-test failed:\n');
+    for (const f of failures) console.error(f);
+    process.exit(1);
+  }
+  console.log('✓ check-quick-reference-counts self-test: 9 cases pass.');
+}
+
+function main() {
+  if (process.argv.includes('--self-test')) return selfTest();
+
+  const full = join(ROOT, TARGET);
+  if (!existsSync(full)) {
+    // The page moving is itself a finding: a silent skip would retire the gate.
+    console.error(`\n✗ ${TARGET} not found.\n`);
+    console.error(
+      'This guard exists because that page\'s "(N schemas)" headings are a\n' +
+        'declaration about the table under each one. If the page moved, point\n' +
+        'TARGET in scripts/check-quick-reference-counts.mjs at its new home;\n' +
+        'if it is gone, delete this gate and its package.json / lint.yml wiring.\n',
+    );
+    process.exit(1);
+  }
+
+  const { findings, sections } = checkPage(readFileSync(full, 'utf8'));
+
+  if (findings.length === 0) {
+    console.log(
+      `✓ ${TARGET}: ${sections.length} section(s), every "(N schemas)" heading matches its table.`,
+    );
+    return;
+  }
+
+  console.error(`\n✗ ${TARGET} — declared section counts do not match the tables:\n`);
+  for (const f of findings) {
+    console.error(`  ${TARGET}:${f.line}  [${f.kind}] ${f.message}`);
+  }
+  console.error(`
+Each "## <Name> Protocol (N schemas)" heading declares how many rows its table
+has. Decide which side is wrong before editing — the heading is not
+automatically the stale one:
+
+  - the section really did gain or lose a protocol  -> update the heading;
+  - a row is missing, or sits in the wrong section  -> restore or move the row
+    (its "Source File" column and its /docs/references/<domain>/ link both name
+    the section it belongs to);
+  - a row points at a retired schema                -> remove the row AND
+    decrement the heading in the same edit.
+
+A [structure] finding means the page no longer looks the way this gate reads
+it. That is reported rather than skipped on purpose: a count checker that
+quietly stops recognising its page reports success forever.
+`);
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
Fixes #6319

先说结论:issue 报的三处计数**只有一处是真的**,而那一处的真相在**标题那一侧** —— 不是数字过时,是两行漂到了别的小节。另外两处是测量假象,已逐一复现其成因。

⚠️ 基线是 **#6304 合并后**的 `main`(`a585374`,含 `5b103d6`)。立单人的读数取自 #6304 之前,我在自己的基线上重新数过。

## 一、逐小节三数对照

"实测行数" 由脚本给出,不是手数(手数正是本单要防的错误来源,见第二节)。

| 小节 | 标题声明 | 实测行数(修前) | 域内 `.zod.ts` | 判定 | 修后 |
| :--- | ---: | ---: | ---: | :--- | ---: |
| Data | 17 | 17 | 30 | 相符 | 17 |
| UI | 11 | 11 | 17 | 相符 | 11 |
| **Kernel** | **17** | **15** | 32 | **表格漏了两行** | **17** |
| System | 18 | 18 | 37 | 相符(#6304 已同步) | 18 |
| AI | 11 | 11 | 11 | 相符 | 11 |
| API | 17 | 17 | 28 | 相符(#6304 已同步) | 17 |
| Automation | 5 | 5 | 14 | 相符 | 5 |
| Security | 3 | 3 | 4 | 相符 | 3 |
| Identity | 4 | 4 | 5 | 相符 | 4 |
| **Cloud** | 5 | 5 | 11 | **两行本属 Kernel** | **3** |
| Integration | 1 | 1 | 1 | 相符 | 1 |
| Shared | 5 | 5 | 13 | 相符 | 5 |
| QA | 1 | 1 | 1 | 相符 | 1 |

### `(N schemas)` 的语义:是"本表行数",不是"该域 schema 数"

第 4 列存在的意义是**证否**它自己:13 个小节里,声明数与域内 `.zod.ts` 数**一处都对不上**(Data 声明 17 而 `packages/spec/src/data/` 有 30 个 `.zod.ts`;System 18 对 37;API 17 对 28)。而声明数与表格行数在 13 个小节里**对上了 12 个**。所以这一页是一份**精选**索引,`(N schemas)` 说的是"这张表有几行",每行一个源文件。

这个判定是后面所有取舍的前提:**"某个 schema 存在但不在表里" 本身不是缺陷**,否则 Data 就该有 30 行。因此本 PR 不做索引扩编,只修计数确实对不上的那一处。

## 二、Cloud 5/6 与 Shared 5/12 是测量假象 —— 已复现成因

这两处**在我的基线上不存在,在 #6304 之前的 main 上也不存在**(两个版本上实测都是 5/5 与 5/5)。我用同样的错法把 issue 的三个数字**逐一复现**了:

立单人的扫描器把小节标题识别为**复数** `(N schemas)`,于是:

- `## Integration Protocol (1 schema)` 和 `## QA Protocol (1 schema)` 两个**单数**标题不被识别,其行数被记到上一小节;
- 小节只在"下一个**被识别的**标题"处结束,所以 Shared 一路吃到文末,把 `### Declarative Endpoints` 那张规则表的 6 行(`| **Path shape** | ...` 等)也算了进去。

于是:

| 小节 | 复现出的数 | 拆解 |
| :--- | ---: | :--- |
| Kernel | 15 | 真实行数,**这处是真的** |
| Cloud | 6 | 自身 5 + Integration(单数标题)1 |
| Shared | 12 | 自身 5 + QA(单数标题)1 + Declarative Endpoints 规则表 6 |

在 #6304 之前的 main 上跑该错法,输出与 issue 表格**逐字一致**(Kernel 17/15、Cloud 5/6、Shared 5/12)。

⚠️ 这不是挑立单人的错 —— 恰恰相反,它把本单最有价值的部分点出来了:**这一页靠人工清点是不可靠的**,而且错得很像真的。两个陷阱现在都被新门的 self-test 钉住(第五节 case 4/5)。

## 三、真实的那一处:两行漂到了别的小节,标题一侧是真相

Kernel 声明 17、表里 15,差 2 行。这两行没有丢,它们坐在 **Cloud Protocol** 小节里:

| 行 | Source File 列 | 源文件实际位置 | 参考页实际位置 |
| :--- | :--- | :--- | :--- |
| Plugin Registry | `plugin-registry.zod.ts` | `packages/spec/src/kernel/` | `content/docs/references/kernel/plugin-registry.mdx` |
| Plugin Security | `plugin-security.zod.ts` | `packages/spec/src/kernel/` | `content/docs/references/kernel/plugin-security.mdx` |

三项机械证据全部指向 kernel:

1. **源文件在 kernel** —— `packages/spec/src/cloud/` 下**没有**同名文件(`ls packages/spec/src/cloud/plugin-*` 报 No such file);
2. **参考页在 kernel** —— 参考页由 `build-docs.ts` 按 spec 的目录结构生成,两页都生成在 `references/kernel/`,`references/cloud/` 下没有 `plugin-*`;#6304 已经因为这个把 Plugin Security 的链接从 `/docs/references/cloud/...` 改成了 `/docs/references/kernel/...`,也就是说**这两行的链接今天已经指向 kernel,只有它们所在的小节还留在 Cloud**;
3. **数字自洽** —— 15 + 2 = 17,不多不少正是 Kernel 标题声明的数。

所以判定 **标题的 17 是真相**,处置是"移",不是"改标题":

- 两行移回 Kernel(按既有的 `Plugin *` 字母序插在 Plugin Loading 之后),**Kernel 标题 17 保持不动**;
- Cloud 随之 5 → 3。

⛔ 我**没有**采用"把 17 改成 15"这个更省事的写法 —— 那会让声明去迁就现状,而现状恰恰是错的那一侧:两个 kernel schema 会继续挂在 "Cloud Protocol — Environments, marketplace, licensing, and multi-tenancy" 底下,而它们的 Source File 列和链接都写着 kernel。读者用 Source File 列去仓里找 schema,这一列必须和小节自洽。

**一处连带改名**:两行移回后,Kernel 里会出现两个都叫 "Plugin Security" 的条目(一个指 `plugin-security.zod.ts`,一个指 `plugin-security-advanced.zod.ts`)。把后者改名为 **"Plugin Security Advanced"** —— 与其源文件名、与其生成参考页的 `title:` 字段(实测就是 `Plugin Security Advanced`)、与邻座 "Plugin Lifecycle Advanced" 的约定三者一致。同名两行指向不同页面,是移动本身引入的缺陷,必须在同一次改动里消掉。

## 四、该页是手写的(范围 2 的判定)

| 判据 | 实测 |
| :--- | :--- |
| 文件头 AUTO-GENERATED 标记 | 无(`content/docs/references/**` 的生成物都有) |
| 有没有生成器写它 | 没有。`packages/spec/scripts/build-docs.ts` 的输出根是 `content/docs/references`(第 62 行 `DOCS_ROOT`),只写这一棵树 |
| 全仓提到 `quick-reference` 的地方 | 4 处,没有一处是生成:`build-docs.ts` 的一句历史注释、其测试里同一句、`content/docs/getting-started/meta.json` 的导航项、`apps/docs/redirects.mjs` 的两条重定向 |
| AGENTS.md 文档护栏表 | `content/docs/getting-started/` 一行明写 **hand-written** |

⇒ **手写**。所以走范围 2 的第一条:加计数校验门。

## 五、新门:`check:quick-reference-counts`

落点与既有 `check:*` 家族同址:

- `scripts/check-quick-reference-counts.mjs`(新)
- `package.json` 一行:`"check:quick-reference-counts": "... --self-test && ..."`(与家族同写法)
- `.github/workflows/lint.yml` 的 **ESLint job** 一步,紧跟 `check:role-word`,与其余 docs 类守卫同址

门只做一件事:读该页每个 `(N schemas)` 标题,与其表格行数比对,不符即红,**点名小节、声明数、实际行数、行号**。

**两个抗错设计,都是从第二节的假象里学来的:**

1. 标题计数认 `(N schema)` **和** `(N schemas)`(单复数都认);
2. 小节在**下一个 `##` 标题**处结束 —— 不论那个标题有没有计数。这条正是防止小节一路吃到文末、把无关表格算进来。

**结构变化响亮报错,不静默放行。** 一个悄悄不再认识自己页面的计数器会永远报绿,那正是这道门要防的失败模式,只是高了一层。所以以下都是 error 而不是 skip:一个小节都没找到;某个 `... Protocol` 标题没有计数;某个小节没有表 / 有多张表 / 表里零行。

### self-test 覆盖(9 组,`--self-test`)

| # | 断言 | 极性 |
| :-- | :--- | :--- |
| 1 | 好页面**逐小节量出的三元组**等于期望值 | **肯定式** |
| 1b | 好页面零 finding | *否定式*(见下) |
| 2 | 标题数字改错 ⇒ 恰好 1 条 count finding,且消息**含小节名 + 声明数 + 实际数** | **肯定式** |
| 3 | 删掉一行表格 ⇒ 红,且消息含两个数字 | **肯定式** |
| 4 | **单数** `(1 schema)` 标题被当作真小节(把它的数字改错必须变红) | **肯定式** |
| 5 | 末尾小节量出的行数 = 1(不吃下面那张规则表) | **肯定式**(断言实测值,不是断言"无 finding") |
| 6 | 标题格式改掉 ⇒ structure finding 点名它 | **肯定式** |
| 7 | 小节的表没了 ⇒ structure finding | **肯定式** |
| 8 | 整页认不出来 ⇒ structure finding(而不是零比较报绿) | **肯定式** |
| 9 | 一个小节两张表 ⇒ structure finding(不静默相加) | **肯定式** |

case 4 与 case 5 就是第二节两个陷阱的定桩:用复数-only 的正则,case 4 得到 0 条 finding;用"吃到文末"的作用域,case 5 量出 3 而不是 1。

## 六、反向验证(先申报,后执行)

### 声明 A(修正面)—— 成立

预期:改后每个小节的 `(N schemas)`、其表格行数、以及第一节判定的真相三者一致。实测 13/13 相符:

```
✓ content/docs/getting-started/quick-reference.mdx: 13 section(s), every "(N schemas)" heading matches its table.
```

逐小节三数见第一节表格(修后一列)。

### 声明 B(门会咬)—— 三段全部成立,另加一段更强的

预期在执行前写下:B1 改错标题数字 ⇒ 红且点名小节与两个数字;B2 删掉一行表格 ⇒ 红;B3 恢复 ⇒ 绿。另加 **B4**:把门跑在**修复前的基线**上 ⇒ 必须红,且**只**点名 Kernel 17/15(如果 Cloud/Shared 真的也不符,这里会一起报出来 —— 这是对第二节结论的独立检验)。

| 段 | 操作 | 预期 | 实测 |
| :-- | :--- | :--- | :--- |
| B1 | Shared 标题 5 → 7 | 红,点名 | **EXIT=1** `[count] section "Shared Protocol" declares 7 schema(s) but its table has 5 row(s)` |
| B2 | 删掉 Cloud 的 Tenant 行 | 红 | **EXIT=1** `[count] section "Cloud Protocol" declares 3 schema(s) but its table has 2 row(s)` |
| B3 | 恢复 | 绿 | **EXIT=0**,13 小节全绿 |
| B4 | 跑在 `origin/main` 与 #6304 之前的 main 上 | 红,只点 Kernel | 两个版本都是 **1 条** finding:`[count] line 57: section "Kernel Protocol" declares 17 schema(s) but its table has 15 row(s)` |

B4 是本单结论的独立佐证:同一把尺子在两个历史版本上都只报 Kernel 一处,Cloud 与 Shared 一次都没报过。

探针未留残留:`git diff --stat origin/main -- content/docs/getting-started/quick-reference.mdx` 为 `4 insertions(+), 4 deletions(-)`,即本 PR 的意图改动本身。

### 断言极性(申报)

上表 B1/B2/B4 与 self-test 的 case 2–9 都是**肯定式**:门被删空或退化,它们会变红。

**唯一的否定式断言是 self-test case 1b("好页面零 finding")** —— 门若被掏空成"永远返回空",这一条会**平凡成立**、无法转红。所以我没有让它独自承担 case 1:同一组固件里用**肯定式**的 case 1 断言逐小节量出的 `[标题, 声明, 实际]` 三元组等于具体值,掏空的门在这里立刻失败。case 5 也是同样的处理 —— 本可以写成"不误报",改写成断言实测行数 `= 1`,于是它同样是肯定式。

### 声明 C(不造死链)—— 成立

预期:改后该页所有仓内链接目标在仓内存在。

本地无 lychee 二进制,故按 `--offline --root-dir (workspace)/content --fallback-extensions mdx,md` 的同一解析规则逐条判定(root-relative → `content/...` + `{,.mdx,.md,/index.mdx,/index.md}`):**118 条仓内链接,0 条死链**,1 条外链在 `--offline` 下被排除。

结构上也不可能造出死链:本 PR **没有新增任何链接目标** —— 两行是整行搬家(其 `/docs/references/kernel/plugin-registry`、`/docs/references/kernel/plugin-security` 两个目标在 #6304 的绿跑里已被检过),改名那行只改可见文字、目标未动。

## 七、门禁 EXIT 表(均在 `git add` 之后跑)

| 命令 | EXIT | 输出 |
| :--- | ---: | :--- |
| `pnpm check:doc-authoring` | **0** | `365 files clean` |
| `pnpm check:role-word` | **0** | `OK (44 baselined file(s), no new occurrences)` |
| `pnpm check:nul-bytes` | **0** | `scanned 6003 tracked text file(s) ... no raw ASCII control bytes` |
| `pnpm check:docs-audit-scope` | **0** | `scope is in sync with content/docs/: 178 hand-written doc(s)` |
| `pnpm check:quick-reference-counts`(新) | **0** | self-test 9 组 + 13 小节全绿 |
| `pnpm check:workflow-status-functions`(动了 `lint.yml`) | **0** | `scanned 22 workflow file(s), 41 job(s)` |
| `lint.yml` YAML 解析 + 落位核对 | **0** | 解析通过;新步骤在 `jobs.lint`(`name: ESLint`)内,共 35 步 |
| `npx eslint scripts/check-quick-reference-counts.mjs` | **0** | 无输出 |
| `pnpm --filter @objectstack/spec check:generated --reconcile-only` | **0** | 见下 |

最后一条是特意跑的:`check:generated` 的元门会把 `check:`/`gen:` 脚本名与 `package.json` 双向对账,未分类者直接红。实测它读的是 `packages/spec/package.json`(`pkgRoot` = `packages/spec`,脚本第 39/407 行),而新门接在**根** `package.json`,故不在其对账面内 —— 已实跑确认绿(`18 check: + 13 gen: scripts, all classified`)。

另:控制字节自查(`grep -naP` 覆盖 NUL 之外的整个扫描面)对四个改动文件均无命中。

## 八、不在本 PR 里

- ⛔ **`connector-auth` 参考页**(issue 观察二):`packages/spec/src/shared/connector-auth.zod.ts` 存在,`content/docs/references/shared/connector-auth.mdx` **不存在**;#6304 的处置是保留该行、去掉链接,所以今天读起来是"有这个 schema,但没有参考页可看"。补一整页是独立的写作工作量,按派单不在本单;**本 PR 未新建该页,也未动那一行**。需要补页请另立单。
- ⛔ **索引扩编**:不给任何小节补"schema 存在但不在表里"的行(理由见第一节:这一页是精选索引,不是穷举;补了 Cloud 就得补 Data 的另外 13 个)。
- ⛔ **required 集**:未改动。新门与 #6304 同理走 advisory —— 它跑在 ESLint job 里,该 job 本身已是 required,故无需单独动 required 名单。
- ⛔ **未建 changeset**:纯文档 + 一道仓内门禁,不发布任何包 ⇒ 走 `skip-changeset` 标签。
- ⛔ 未动 `packages/spec/**`(只读清点)、`content/docs/references/**`、`.github/workflows/check-links.yml`、`content/docs/releases/**`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_