### PR TITLE
feat(scripts): digest 把「无 changeset 的 commit」从计数升级为按 subject 逐条点名 (#6174)

### DIFF
--- a/scripts/objectui-changeset-digest.mjs
+++ b/scripts/objectui-changeset-digest.mjs
@@ -102,6 +102,50 @@
 //     entry would vanish, so both captured diagnostics are re-emitted, named by
 //     attempt, and the error still propagates. Quiet is earned by the fallback
 //     that worked; it is never extended to the one that did not.
+//
+// WHY THE UNDECLARED COMMITS ARE NAMED, NOT ONLY COUNTED (#6174)
+// --------------------------------------------------------------
+// "Read what objectui declared" is the right criterion, and this changes none
+// of it. What it fixes is a REPORTING gap on the criterion's own shadow: a
+// commit that declared nothing is correctly kept out of the releasing list, and
+// used to leave the artifact as one digit inside `omitted: N commits carrying
+// no changeset`. Which commits those were, the record did not say.
+//
+// Measured on the real pin bump `f995a452d2ca..7dfbeb704e1e` (#6159 / PR
+// #6173), the 20 undeclared commits are 1 release commit, 3 dependabot bumps,
+// 15 docs/ci/scripts commits — and `0e50440e8`, `fix(form): bind `previous` for
+// field rules and stop resubmitting read-only fields` (objectui#3518): 26 files
+// across 5 packages and all ten locale packs, a user-visible form behaviour
+// change. Inside the number 20 it is indistinguishable from `chore(deps-dev):
+// Bump postcss from 8.5.25 to 8.5.26`. It shipped in the console build and is
+// in no CHANGELOG anywhere — not even objectui's, because there was no
+// changeset to compile. A count cannot be read; a subject can.
+//
+// Three boundaries this deliberately keeps:
+//
+//   * It does not touch the CRITERION. `noChangesetCommits` is rendered exactly
+//     as `classifyRange` produced it — unfiltered, unreordered. Nothing enters
+//     or leaves the releasing list, no count moves, and the accounting line is
+//     byte-for-byte what it was. Presentation only, the same separation
+//     `objectui-range.mjs` already keeps; the rows are spelled in that script's
+//     `--all` vocabulary (`- _(no changeset)_ …`) so the two artifacts read as
+//     one, which is what "wire up the capability that already exists" means.
+//   * It does not CLASSIFY them. `chore: release packages` and the form fix are
+//     both listed, flatly. Deciding which undeclared commit "matters" means
+//     inferring from a subject line — the exact move #4731 removed, and it
+//     would fail the same way, since the commit worth naming here carries a
+//     `fix(form)` subject no more distinctive than the `fix(ci)` beside it. The
+//     reader judges; the tool only stops hiding.
+//   * It is NOT the stderr fallback line (#6175). That one reports how the tool
+//     READ A FILE, which is not a fact about the release, so it stays on stderr
+//     beside the accounting. This one reports WHICH COMMITS entered the build
+//     with nothing declared for them — which is precisely what a release record
+//     is for. Adjacent facts, different readers, different destinations.
+//
+// The gate that would stop this at the source is objectui#3387 (a PR touching
+// `packages/*/src/**` with no changeset fails). Until it lands, this is the only
+// place the class is visible at all; after it lands, this list goes quiet on its
+// own, because there will be nothing to name.
 
 import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
@@ -112,7 +156,13 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
 
-/** Default cap on the rendered list. A cap that fires ANNOUNCES itself (#4731). */
+/**
+ * Default cap on EACH rendered list. The releasing entries (#4731) and the
+ * undeclared commits (#6174) are capped INDEPENDENTLY, so a long release can
+ * never squeeze the other list down to nothing — one budget shared between them
+ * would make the second list's length depend on the first's, which no reader
+ * could infer. A cap that fires ANNOUNCES itself, with the real total (#4731).
+ */
 export const DEFAULT_MAX_ENTRIES = 100;
 
 const LEVEL_RANK = { patch: 1, minor: 2, major: 3 };
@@ -511,7 +561,7 @@ export function classifyRange({ objectuiRoot, from, to }) {
 /**
  * Build the digest for a range.
  *
- * @returns {{ bump: string, declaredLevel: string|null, breaking: number, breakingByLevel: number, breakingByAnnotation: number, releasing: Array<object>, releaseNothing: number, noChangeset: number, changesetsAdded: number, absentAtTo: number, totalCommits: number, downgradedMajor: boolean, body: string }}
+ * @returns {{ bump: string, declaredLevel: string|null, breaking: number, breakingByLevel: number, breakingByAnnotation: number, releasing: Array<object>, releaseNothing: number, noChangeset: number, noChangesetCommits: Array<object>, changesetsAdded: number, absentAtTo: number, totalCommits: number, downgradedMajor: boolean, body: string }}
  */
 export function buildDigest({
   objectuiRoot,
@@ -521,12 +571,19 @@ export function buildDigest({
   max = DEFAULT_MAX_ENTRIES,
   bumpOverride = '',
 }) {
-  const { releasing, releaseNothing, noChangeset, changesetsAdded, absentAtTo, totalCommits } =
-    classifyRange({
-      objectuiRoot,
-      from,
-      to,
-    });
+  const {
+    releasing,
+    releaseNothing,
+    noChangeset,
+    noChangesetCommits,
+    changesetsAdded,
+    absentAtTo,
+    totalCommits,
+  } = classifyRange({
+    objectuiRoot,
+    from,
+    to,
+  });
 
   const declaredLevel = releasing.length
     ? releasing.reduce(
@@ -613,7 +670,58 @@ export function buildDigest({
     );
   }
 
-  const body = [accounting, '', ...lines, ...(notes.length ? ['', ...notes] : [])].join('\n');
+  // --- #6174: NAME the commits that declared nothing, don't only count them ---
+  // Rendered straight from `classifyRange`'s own `noChangesetCommits`, in its
+  // order, with no predicate of any kind: presentation, never a criterion (see
+  // the header note). Zero-suppressed, and the silence is safe because this
+  // block is never the SOLE record of the fact — whenever the count is non-zero
+  // the accounting line above already carries it, so an absent block can only
+  // mean "every commit in this range declared something", never "the section
+  // was not written" (the same reasoning that lets #6175's fallback sentence
+  // stay quiet on a range that crossed no release).
+  const undeclared = [];
+  if (noChangesetCommits.length > 0) {
+    const n = noChangesetCommits.length;
+    undeclared.push(
+      `**In this console build, declared nowhere** — objectui merged ${n} ` +
+        `commit${n === 1 ? '' : 's'} in this range with no \`.changeset/*.md\`. ` +
+        `The code is inside the pin above and ships here, but nothing upstream declared ` +
+        `${n === 1 ? 'it' : 'them'}, so ${n === 1 ? 'it appears' : 'they appear'} in no objectui ` +
+        `CHANGELOG and in no entry above. Listed by subject rather than counted, because a ` +
+        `count cannot tell a dependency bump from a form-behaviour change (objectstack#6174); ` +
+        `the upstream gate that would prevent this is objectui#3387.`,
+      '',
+    );
+    const shownUndeclared = noChangesetCommits.slice(0, Math.max(0, max));
+    for (const c of shownUndeclared) {
+      undeclared.push(
+        `- _(no changeset)_ ${clampSummary(c.subject)} (objectui \`${c.sha.slice(0, 9)}\`)`,
+      );
+    }
+    const hiddenUndeclared = n - shownUndeclared.length;
+    if (hiddenUndeclared > 0) {
+      // Same rule as the releasing cap, and the reason it is worth repeating:
+      // this list's whole purpose is that a number hides which commits it is
+      // made of, so truncating it back into a number in silence would restore
+      // the exact defect. The marker carries the REAL TOTAL and the command
+      // that produces the rest (#4731: a degraded list and a complete one must
+      // never look alike).
+      undeclared.push(
+        `- …and ${hiddenUndeclared} more commit${hiddenUndeclared === 1 ? '' : 's'} with no ` +
+          `changeset — this list is capped at ${max}, the range has ${n} in total. ` +
+          `Run \`node scripts/objectui-range.mjs --from ${from.slice(0, 12)} ` +
+          `--to ${to.slice(0, 12)} --all\` for the complete list.`,
+      );
+    }
+  }
+
+  const body = [
+    accounting,
+    '',
+    ...lines,
+    ...(notes.length ? ['', ...notes] : []),
+    ...(undeclared.length ? ['', ...undeclared] : []),
+  ].join('\n');
 
   return {
     bump,
@@ -624,6 +732,7 @@ export function buildDigest({
     releasing,
     releaseNothing,
     noChangeset,
+    noChangesetCommits,
     changesetsAdded,
     absentAtTo,
     totalCommits,
@@ -835,8 +944,18 @@ function selfTest() {
       !digest.body.includes('cross-repo token'),
     );
     check(
-      'a `fix(ci)` commit with no changeset at all is NOT represented',
-      !digest.body.includes('budget FAIL'),
+      'a `fix(ci)` commit with no changeset at all is NOT represented as a releasing entry',
+      // #6174 repaired the PROXY, never the claim. This check has always meant
+      // "the criterion did not admit it", and tested that by looking for the
+      // subject ANYWHERE in the body — which stopped expressing it the moment
+      // the body began naming undeclared commits on purpose. It now says what it
+      // always meant, at both layers: the classified set, and the rendered
+      // releasing lines. The other half — that it IS named, under the undeclared
+      // block — is pinned in the #6174 group below.
+      !digest.releasing.some((r) => r.subject.includes('budget FAIL')) &&
+        !digest.body
+          .split('\n')
+          .some((l) => /^- \*\*(?:major|minor|patch)\*\* —/.test(l) && l.includes('budget FAIL')),
     );
     check('release-nothing changesets are counted, not dropped in silence', digest.releaseNothing === 1);
     check(
@@ -1281,6 +1400,214 @@ function selfTest() {
       "#6175 both attempts' git diagnostics are re-emitted, not swallowed",
       (bothFail.stderr.match(/fatal:/g) ?? []).length >= 2,
       bothFail.stderr,
+    );
+
+    // --- #6174: the undeclared commits are NAMED, not only counted -----------
+    // Its own repos, for the reason the two groups above have theirs: the #4731
+    // / #6099 / #6175 fixtures pin exact counts and must not shift underneath.
+    // The row count here is deliberately > 1 so "the list agrees with the count"
+    // is a real claim, and the cap can be made to fire without touching `max`
+    // anywhere else.
+    const SUBJECT_3518 =
+      'fix(form): bind `previous` for field rules and stop resubmitting read-only fields (#3518)';
+
+    const ui4 = join(tmp, 'objectui-undeclared');
+    mkdirSync(join(ui4, '.changeset'), { recursive: true });
+    const g4 = (...args) => git(ui4, args);
+    g4('init', '-q', '-b', 'main');
+    g4('config', 'user.email', 'selftest@objectstack.ai');
+    g4('config', 'user.name', 'self test');
+    g4('config', 'commit.gpgsign', 'false');
+    const commit4 = (subject, files) => {
+      for (const [path, content] of Object.entries(files)) {
+        mkdirSync(dirname(join(ui4, path)), { recursive: true });
+        writeFileSync(join(ui4, path), content);
+      }
+      g4('add', '-A');
+      g4('commit', '-q', '-m', subject);
+      return g4('rev-parse', 'HEAD').trim();
+    };
+
+    const base4 = commit4('chore: base', { 'README.md': 'base\n' });
+    commit4('feat(grid): row virtualization for long lists (#3600)', {
+      '.changeset/grid-row-virtualization.md':
+        '---\n"@object-ui/plugin-grid": patch\n---\n\nThe grid virtualizes long lists.\n',
+      'src/grid.ts': 'a\n',
+    });
+    // The live specimen this issue is named after: a real, user-visible change
+    // that declared nothing. Committed FIRST of the three so the newest-first
+    // order puts it LAST — which is what lets the cap below hide it.
+    const undeclared3518 = commit4(SUBJECT_3518, {
+      'packages/plugin-form/src/rules.ts': 'previous\n',
+      'packages/components/src/form.tsx': 'readonly\n',
+    });
+    const undeclaredDeps = commit4('chore(deps-dev): Bump postcss from 8.5.25 to 8.5.26 (#3519)', {
+      'package.json': '{"devDependencies":{"postcss":"8.5.26"}}\n',
+    });
+    const undeclaredDocs = commit4('docs(guide): retarget two dead examples/ links (#3509)', {
+      'docs/guide.md': 'links\n',
+    });
+    const head4 = g4('rev-parse', 'HEAD').trim();
+
+    const named = buildDigest({
+      objectuiRoot: ui4,
+      frameworkRoot: fwPlain,
+      from: base4,
+      to: head4,
+    });
+    const namedRows = named.body
+      .split('\n')
+      .filter((l) => l.startsWith('- _(no changeset)_'));
+
+    check(
+      '#6174 every commit with no changeset is NAMED by subject, carrying its sha',
+      namedRows.length === 3 &&
+        named.body.includes(
+          `- _(no changeset)_ ${SUBJECT_3518} (objectui \`${undeclared3518.slice(0, 9)}\`)`,
+        ) &&
+        named.body.includes(
+          `- _(no changeset)_ chore(deps-dev): Bump postcss from 8.5.25 to 8.5.26 (#3519) (objectui \`${undeclaredDeps.slice(0, 9)}\`)`,
+        ) &&
+        named.body.includes(
+          `- _(no changeset)_ docs(guide): retarget two dead examples/ links (#3509) (objectui \`${undeclaredDocs.slice(0, 9)}\`)`,
+        ),
+      named.body,
+    );
+    check(
+      '#6174 the rendered rows AGREE with the count — no list/number drift',
+      namedRows.length === named.noChangeset && named.noChangesetCommits.length === namedRows.length,
+      `rows=${namedRows.length} noChangeset=${named.noChangeset}`,
+    );
+    check(
+      '#6174 the block says WHAT it is — shipped in this build, declared nowhere',
+      named.body.includes(
+        '**In this console build, declared nowhere** — objectui merged 3 commits in this range with no `.changeset/*.md`.',
+      ) && named.body.includes('objectui#3387'),
+      named.body,
+    );
+    check(
+      '#6174 naming is ADDITIVE — the releasing list is unchanged and still leads',
+      named.releasing.length === 1 &&
+        named.body.includes('- **patch** — The grid virtualizes long lists.') &&
+        named.body.indexOf('- _(no changeset)_') > named.body.indexOf('- **patch** —'),
+      named.body,
+    );
+    check(
+      '#6174 the accounting line is untouched — a section was added, no count moved',
+      named.body.includes(
+        'Derived from the changesets objectui declared over the range — 1 releasing of 1 changeset added across 4 non-merge commits; omitted: 3 commits carrying no changeset (they ship no package code).',
+      ),
+      named.body,
+    );
+
+    const named2 = buildDigest({
+      objectuiRoot: ui4,
+      frameworkRoot: fwPlain,
+      from: base4,
+      to: head4,
+      max: 2,
+    });
+    const named2Rows = named2.body.split('\n').filter((l) => l.startsWith('- _(no changeset)_'));
+    check(
+      '#6174 a capped undeclared list SAYS SO, with the real total and the way to the rest',
+      named2Rows.length === 2 &&
+        named2.body.includes(
+          '- …and 1 more commit with no changeset — this list is capped at 2, the range has 3 in total.',
+        ) &&
+        named2.body.includes('--all'),
+      named2.body,
+    );
+    check(
+      '#6174 truncation CAN hide the one commit worth naming — which is why it is loud',
+      // Not a restatement of the check above: it measures the stake. The
+      // specimen is the oldest of the three, so a cap eats it first, and a
+      // SILENT cap would restore exactly the defect this issue is about — a
+      // number where objectui#3518 used to be.
+      !named2.body.includes(SUBJECT_3518) && named2.body.includes('the range has 3 in total'),
+      named2.body,
+    );
+    check(
+      '#6174 the two caps are INDEPENDENT — truncating the releasing list empties nothing else',
+      capped.body.includes('…and 2 more releasing changesets') &&
+        capped.body.includes(
+          '- _(no changeset)_ fix(ci): never render a budget FAIL for a run that measured nothing (#3198)',
+        ),
+      capped.body,
+    );
+    check(
+      '#6174 the commit the old body could only COUNT is now in the record by name',
+      digest.body.includes(
+        '- _(no changeset)_ fix(ci): never render a budget FAIL for a run that measured nothing (#3198)',
+      ),
+      digest.body,
+    );
+    check(
+      '#6174 only the no-changeset class is named — a release-nothing changeset DID declare',
+      // The count clause is the load-bearing one: it goes red both if the block
+      // disappears (1 → 0) and if release-nothing entries are swept in (1 → 2).
+      // The substring clause alone would be green for an empty reason.
+      digest.body.split('\n').filter((l) => l.startsWith('- _(no changeset)_')).length === 1 &&
+        !digest.body.includes('- _(no changeset)_ fix(ci): hand the cross-repo token'),
+      digest.body,
+    );
+    check(
+      '#6174 body names the commits, #6175 keeps the read-fallback on stderr — adjacent, not merged',
+      quietArtifact.includes('- _(no changeset)_ chore: release packages (#3403)') &&
+        !quietArtifact.includes('no longer exist at') &&
+        fellBack.stderr.includes('no longer exist at') &&
+        !fellBack.stderr.includes('_(no changeset)_'),
+      quietArtifact,
+    );
+
+    // NEGATIVE POLARITY, declared as such: this one cannot go red when the
+    // feature is deleted, because deleting it also produces no line. It pins a
+    // DIFFERENT regression — a block that fires on an empty list — so it stays,
+    // with the two positive guards that keep it from passing vacuously: the
+    // fixture must really be the zero case AND must really have produced a
+    // digest. Without them "no new line" would also be satisfied by an empty
+    // range, or by a `body` that failed to build at all.
+    const ui5 = join(tmp, 'objectui-all-declared');
+    mkdirSync(join(ui5, '.changeset'), { recursive: true });
+    const g5 = (...args) => git(ui5, args);
+    g5('init', '-q', '-b', 'main');
+    g5('config', 'user.email', 'selftest@objectstack.ai');
+    g5('config', 'user.name', 'self test');
+    g5('config', 'commit.gpgsign', 'false');
+    const commit5 = (subject, files) => {
+      for (const [path, content] of Object.entries(files)) {
+        mkdirSync(dirname(join(ui5, path)), { recursive: true });
+        writeFileSync(join(ui5, path), content);
+      }
+      g5('add', '-A');
+      g5('commit', '-q', '-m', subject);
+      return g5('rev-parse', 'HEAD').trim();
+    };
+    const base5 = commit5('chore: base', { 'README.md': 'base\n' });
+    commit5('feat(core): every commit in this range declares (#3700)', {
+      '.changeset/core-declares.md':
+        '---\n"@object-ui/core": minor\n---\n\nA declared change.\n',
+      'src/core.ts': 'a\n',
+    });
+    commit5('fix(fields): and so does this one (#3701)', {
+      '.changeset/fields-declares.md':
+        '---\n"@object-ui/fields": patch\n---\n\nAnother declared change.\n',
+      'src/fields.ts': 'b\n',
+    });
+    const head5 = g5('rev-parse', 'HEAD').trim();
+
+    const allDeclared = buildDigest({
+      objectuiRoot: ui5,
+      frameworkRoot: fwPlain,
+      from: base5,
+      to: head5,
+    });
+    check(
+      '#6174 a range where every commit declared gains NO new line (negative polarity)',
+      allDeclared.noChangeset === 0 &&
+        allDeclared.releasing.length === 2 &&
+        !allDeclared.body.includes('_(no changeset)_') &&
+        !allDeclared.body.includes('declared nowhere'),
+      allDeclared.body,
     );
   } finally {
     rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
Fixes #6174

本 PR 只做分诊 07:51Z 钉死的**选项 C**:把 console changeset 正文里「无 changeset 的 commit」从一个计数升级为按 subject 逐条点名。

## 1. 前提复核(对 `origin/main` a5ca08d,#6289 / #6335 两棒落地之后)

三条内容读数逐条复核,全部仍成立:

| 复核项 | 现状 | 结论 |
|:--|:--|:--|
| `objectui-range.mjs` 的点名能力 | `const SHOW_EXCLUDED = has('--all')`,渲染 `- _(no changeset)_ …` 行,self-test 有 `` `--all` itemizes the excluded commits by subject `` | 能力已在,本单只消费不改造 |
| `objectui-changeset-digest.mjs` 只计数不点名 | 正文 accounting 行写 `omitted: 20 commits carrying no changeset (they ship no package code).`,再无别的痕迹 | 缺口真实且当前 |
| `classifyRange` 已产出所需数据 | 返回值里已有 `noChangesetCommits`(`{ sha, subject }` 数组),`objectui-range.mjs` 正是从这里取数 | 只差接线,无需新增采集逻辑 |

同文件前序两棒均已在 main 且未被本 PR 触碰:#6289(`hasBreakingAnnotation`,破坏性判据扩到作者正文标注)、#6335(`readAt` 回落静默,那句回落事实在 stderr)。

**为什么这不是「已经有了」**:`--all` 的点名只存在于 `objectui-range.mjs` 产出的**发布页 Console 段**;写进平台发布记录的 **console changeset 正文**由 `buildDigest` 生成,它从未消费 `noChangesetCommits`。两个产物,一个有名字一个只有数字。

## 2. 这次漏掉的到底是什么(实测,不是推断)

区间 `f995a452d2ca..7dfbeb704e1e`(#6159 / PR #6173)的 20 条无 changeset commit,按内容归类:

- 1 条 release commit(`chore: release packages (#3248)`)
- 3 条 dependabot bump
- 15 条 docs / ci / scripts
- **1 条 `0e50440e8 fix(form): bind `previous` for field rules and stop resubmitting read-only fields (#3518)`** —— 26 个文件、5 个包、全部十个 locale pack,真实用户可见的表单行为变更

在数字 `20` 里,这一条和 `chore(deps-dev): Bump postcss from 8.5.25 to 8.5.26` 完全无从分辨。这就是「计数不可读、subject 可读」的全部理由。

## 3. 设计决定与理由

**(a) 落点 = changeset 正文,不是 stderr。** #6175 刚把回落事实放在 stderr 的 accounting 行旁边,理由是「工具怎么读到文件」不是关于这次发布的事实。本段是**相邻但不同**的事实:「哪些 commit 的代码进了 console build 却没有任何上游声明」恰恰是发布记录该有的内容,读者是读发布记录的人而不是看这次运行的操作员。故落正文。self-test 里有一条断言专门钉这条边界(见 §5)。

**(b) 措辞。** 正文段首为:

> **In this console build, declared nowhere** — objectui merged 20 commits in this range with no `.changeset/*.md`. The code is inside the pin above and ships here, but nothing upstream declared them, so they appear in no objectui CHANGELOG and in no entry above. Listed by subject rather than counted, because a count cannot tell a dependency bump from a form-behaviour change (objectstack#6174); the upstream gate that would prevent this is objectui#3387.

三点是刻意的:代码**确实进了 build**(不是「丢了」);**没有任何上游声明**,所以 objectui 自己的 CHANGELOG 里也没有;指向 objectui#3387 让读者知道根因闸门在哪。

**(c) 行格式沿用 `objectui-range.mjs --all` 的 `- _(no changeset)_ …` 词汇。** 同一件事在两个产物里用同一套词汇,读者不必学两遍;这也正是「接进已有能力」而不是「另造一套」的含义。

**(d) 不分类、不筛选。** `chore: release packages` 和那条 form fix 一起平铺列出。判断哪条「重要」等于对 subject 做推断 —— 正是 #4731 拆掉的那一步,而且会以同样方式失败:值得点名的那条挂着 `fix(form)`,和旁边的 `fix(ci)` 一样不特别。工具只负责停止隐藏,判断交给读者。

**(e) 规模护栏:点名清单与 releasing 清单各自独立套用同一个 `max`(默认 100)。** 两个真实区间是 20 条和 33 条,默认下**都完整列出、不触发截断**。截断只作为病态区间的兜底存在,且必须响亮 —— 下面是 self-test 里 `max: 2` / 总数 3 时的实测输出:

```
- …and 1 more commit with no changeset — this list is capped at 2, the range has 3 in total. Run `node scripts/objectui-range.mjs --from a1b2c3d4e5f6 --to f6e5d4c3b2a1 --all` for the complete list.
```

带**真实总数**,并给出取全量的命令。选独立配额而非共享配额的理由:共享时第二个清单的长度取决于第一个清单有多长,而读者无从推断这层耦合 —— 一次长发布就能把点名段挤成零条,那正好是本 PR 要消灭的形态。

**(f) 零条不打。** 无漏声明 commit 时不产生任何新行。这里的静默是安全的:计数非零时 accounting 行**同时**也在说这件事,本段从不是该事实的唯一载体,所以「没有这一段」只可能是「本区间每条 commit 都声明了」,不可能是「这段没实现」。

**(g) ⛔ 不改判据。** `noChangesetCommits` 原样渲染,不过滤、不重排、不新增谓词。判据、收录集、分类、计数、accounting 行一律未动 —— §4 的逐字节 diff 是证据。

## 4. 真实区间重放 before / after

改前改后各跑一次,两个区间:

| 区间 | 非合并 commit | releasing | 无 changeset | 退出码 before/after | 正文 diff |
|:--|--:|--:|--:|:--|:--|
| `f995a452d2ca..7dfbeb704e1e`(#6159 实测) | 28 | 9 | **20** | 0 / 0 | 纯插入 23 行,**零删除** |
| `f5bc4c78be76..f995a452d2ca`(对照) | 98 | 64 | **33** | 0 / 0 | 纯插入 36 行,**零删除** |

`diff -u0` 对区间 A 只有一个 hunk 头 `@@ -18,0 +19,23 @@` —— 纯插入,accounting 行与 9 条 releasing 清单**逐字节不变**,`objectui range:` 页脚仍在末尾。区间 B 同形(`@@ -75,0 +76,36 @@`,被删除行计数为 0)。两个区间的 **stderr 逐字节相同**(`diff` 无输出),即 #6175 的回落句与 accounting 行都未受影响。

新增段实测节选(区间 A):

```
**In this console build, declared nowhere** — objectui merged 20 commits in this range with no `.changeset/*.md`. …

- _(no changeset)_ chore: release packages (#3248) (objectui `7dfbeb704`)
- _(no changeset)_ chore(deps): Bump fumadocs-core from 16.13.0 to 16.14.0 (#3255) (objectui `ce12564fa`)
- _(no changeset)_ fix(form): bind `previous` for field rules and stop resubmitting read-only fields (#3518) (objectui `0e50440e8`)
…
```

issue 正文点名的那条,现在在平台发布记录里有名字了。

## 5. 反向验证:申报在先,实测在后

**变异体**:把点名段的生成条件短路(`if (false && noChangesetCommits.length > 0)`),即删空功能、其余不动。

**事先申报**:10 条转红(肯定式)、3 条保持绿(结构上不会红,已分别说明理由)。

**实测结果:`10 failure(s)`,与申报逐条一致。**

转红的 10 条(肯定式,真覆盖):

| 断言 | 变异后 |
|:--|:--|
| 每条无 changeset commit 按 subject 点名且带 sha | 行数 3 → 0 |
| 渲染行数与计数一致 | `rows=0 noChangeset=3` |
| 段首说明「进了 build、无处声明」 | 段首消失 |
| 点名是追加的,releasing 清单在前且未变 | `indexOf` 为 -1,顺序断言失败 |
| 截断时响亮报出真实总数与取全量命令 | 行数 0 ≠ 2 |
| 截断**能**藏掉最该点名的那条 | 第二子句(`the range has 3 in total`)失败 |
| 两个 cap 相互独立 | 点名行消失 |
| 「旧正文只能计数」的那条现已具名 | 子串消失 |
| 只点名无 changeset 类,release-nothing 不扫进来 | 计数 1 → 0 |
| 正文点名 / stderr 回落 两个事实各归其位(#6175 边界) | 第一子句失败 |

保持绿的 3 条 —— **申报为结构上不会红,不得当作覆盖度**:

1. **「零漏声明 ⇒ 无新增行」(否定式)** —— 功能被删空时同样「没有新增行」,故平凡成立、无法转红。它钉的是另一类回归(空清单时误打段落),因此保留。为防**空绿**,配了两条肯定式护栏:`allDeclared.noChangeset === 0` 与 `releasing.length === 2`,确保 fixture 确实是零漏声明的场景、且确实产出了 digest —— 没有它们,「无新增行」也会被空区间或根本没构建出 body 的情况满足。护栏防的是 fixture 退化,**不**能让这条在变异体下转红,故如实申报为否定式。
2. **「accounting 行未动」** —— 变异体不影响 accounting,故绿。它是**对照断言**,钉的是「本 PR 没碰计数」,不是点名功能的覆盖。
3. **#4731 那条被修复的断言(见下)** —— 否定式,变异前后皆绿。

**空绿自查(逐条过了一遍新增断言的每个子句)**:发现两条断言各含一个在变异体下平凡为真的否定子句 —— `!named2.body.includes(SUBJECT_3518)` 与 `!digest.body.includes('- _(no changeset)_ fix(ci): hand the cross-repo token')`。两条都**已经**各自配了肯定式子句(`includes('the range has 3 in total')`;`filter(...).length === 1`)承载判定,实测也确实随变异转红,故不是空绿;此处如实记录,是因为若单独保留那个否定子句就会是空绿。除此之外未发现同类。

**#4731 一条既有断言的实现方式必须修复(不是改判据、不是改计数)**:

原断言 `a `fix(ci)` commit with no changeset at all is NOT represented` 用 `!digest.body.includes('budget FAIL')` 实现。它的**原意**始终是「判据没有把它收进 releasing」,而实现方式是「整段 body 里找不到这个 subject」—— 当 body 开始**有意**点名无 changeset commit 之后,这个代理就不再表达原意了。改为在两层直接断言原意:`!digest.releasing.some(...)`(分类集合)+ 渲染行不匹配 releasing 行的形状(渲染层)。**fixture 与其精确计数一字未动**;另在 #6174 组补了正向的另一半:它现在确实出现在点名段里。

一并核对:`cross-repo token` 那条是 **release-nothing**(空 frontmatter,作者**确实声明了**),不属无 changeset 类,因此不会被点名 —— 依赖它的两条既有断言(#4731 组与端到端组)实测均未受影响。

## 6. 门禁(均在 `git add` 之后跑)

| 门禁 | EXIT |
|:--|:--|
| `pnpm check:objectui-changeset`(digest 57 条 + objectui-range 自测) | **0** |
| `pnpm exec eslint scripts/objectui-changeset-digest.mjs --no-inline-config` | **0** |
| `pnpm check:nul-bytes`(自测 56 断言 + 扫描 6003 文件) | **0** |
| 控制字节自扫(`grep -naP` 控制字节类) | **1**(无命中,clean) |
| `node scripts/check-objectui-pin-fresh.mjs --self-test`(下游消费者,Console Pin Freshness) | **0** |

digest self-test 45 → **57**(新增 12 条,独立成 #6174 组)。下游 `check-objectui-pin-fresh.mjs` 只消费 `classifyRange`,而 `classifyRange` 本 PR 一行未改。

## 7. 不在本 PR 里

- **选项 A**(objectui 侧 `packages/*/src/**` 改动必须带 changeset 的闸门)—— 归 **objectui#3387**(该仓 `pm:queue`,2026-08-05 转过去)。⛔ 本仓不开第二个入口,本 PR 不跨仓改 objectui。
- **选项 B**(给 objectui#3518 补追溯 changeset)—— 分诊未入队,不做。
- **pin 不动** —— 未重跑、未修改任何 pin;`.objectui-sha` 未触碰。
- **产物正确性** —— #6159 / PR #6173 已核对无误,不在本单。
- ⛔ 判据、收录集、分类未改;`scripts/objectui-range.mjs`、`scripts/bump-objectui.sh`、`scripts/check-objectui-pin-fresh.mjs` 均未触碰。

本 PR 不发布任何包(纯 `scripts/` 工具链),故走 `skip-changeset` 路线,不建 `.changeset/` 文件。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_