### PR TITLE
docs(spec): flip `OWNING_BUSINESS_UNIT_ID` to INJECTED and sync the `systemFields` injection list (ADR-0117 D1, #5767)

### DIFF
--- a/.changeset/owning-business-unit-injected-jsdoc.md
+++ b/.changeset/owning-business-unit-injected-jsdoc.md
@@ -1,0 +1,39 @@
+---
+"@objectstack/spec": patch
+---
+
+Declaration sync for ADR-0117 D1: `owning_business_unit_id` is documented as INJECTED,
+while the `business_unit` ownership tier is documented as still unauthorable.
+
+#5677 landed D1's execution surface in `packages/objectql`: `applySystemFields`' owner
+decision became an allow-list and the `owning_business_unit_id` column is now injected on
+every ownership-eligible object — i.e. under `ownership: 'user'` and when `ownership` is
+omitted, withheld under `'org' | 'none'` and on `managedBy` / `sys_*` tables. The spec's
+own prose had not followed: `SystemFieldName.OWNING_BUSINESS_UNIT_ID` still read
+"**NOT injected by open-core** — nothing provisions this column today", which had become
+false on the default tier every ordinary business object uses.
+
+The flip is deliberately PARTIAL, because the condition it was written against was
+two-part and only one half landed. The JSDoc gated itself on both (a) the `ownership`
+enum gaining a `business_unit` member and (b) the `wantOwner` deny-list becoming an
+allow-list. Only (b) shipped. `ObjectSchema`'s `ownership` enum is still
+`'user' | 'org' | 'none'`, so `ownership: 'business_unit'` remains deliberately rejected
+(the enum member is tracked separately). A flat "INJECTED" would have deleted a true
+sentence and implied an authorable tier that does not exist — declaring what the runtime
+rejects, which is the dangerous direction of ADR-0049, and the inverse of the benign
+runtime-ahead-of-docs gap this closes. Both facts are therefore stated together, in every
+place that states either:
+
+- `SystemFieldName.OWNING_BUSINESS_UNIT_ID` — INJECTED, plus an explicit "the column
+  being injected does not mean the tier is authorable" paragraph, plus the
+  provisioned-but-inert note (the D2/D4 stamping middleware has not landed, so nothing
+  writes a value yet).
+- `ObjectSchema.systemFields` — the injected-column list gains `owning_business_unit_id`,
+  with its governing property, its `organization_id`-shaped column definition, and the
+  same tier caveat.
+- `resolveInjectedSystemColumns` — its per-tier table already matched D1; it gains one
+  note that the `business_unit` row is implemented ahead of the acceptance surface, so
+  the row is not misread as a claim that the tier is available.
+
+Documentation only: no schema, no value, and no injected column changes, so no metadata
+document changes what it parses to.

--- a/packages/spec/src/data/injected-system-columns.ts
+++ b/packages/spec/src/data/injected-system-columns.ts
@@ -121,6 +121,15 @@ export interface InjectedSystemColumnPlan {
  * ownership tier inherits `owner_id` by accident, which for a unit-owned tier
  * is the exact inverse of what it means.
  *
+ * ⚠️ The `ownership: 'business_unit'` row is implemented here AHEAD of the
+ * acceptance surface: `ObjectSchema`'s `ownership` enum is still
+ * `'user' | 'org' | 'none'`, so that value cannot be authored today and is
+ * deliberately rejected (the enum member is #5678). The row exists so the tier's
+ * first appearance is judged by D1's table rather than by a deny-list default —
+ * it is not a claim that the tier is available. This function is deliberately
+ * typed on `string` rather than the enum for exactly that reason; see the
+ * `ownership` read below.
+ *
  * @param def An object definition, or any bare record shaped like one.
  */
 export function resolveInjectedSystemColumns(def: unknown): InjectedSystemColumnPlan {

--- a/packages/spec/src/data/object.test.ts
+++ b/packages/spec/src/data/object.test.ts
@@ -935,23 +935,32 @@ describe('ObjectSchema.create()', () => {
     // ADR-0117 (Accepted, D1/D3 scoped) reserves a fourth tier,
     // `ownership: 'business_unit'`, whose contract is: NO `owner_id`, and a
     // kernel-stamped `owning_business_unit_id` instead (D1's table). The
-    // protocol name is already registered —
-    // `SystemFieldName.OWNING_BUSINESS_UNIT_ID` — but the VALUE must not be
-    // added here yet, because `applySystemFields` decides owner injection with
-    // a DENY-list (`packages/objectql/src/registry.ts`):
+    // protocol name is registered (`SystemFieldName.OWNING_BUSINESS_UNIT_ID`)
+    // and, since #5677, open-core INJECTS the column — but the enum VALUE is
+    // still not added here.
     //
-    //   wantOwner = ownership !== 'org' && ownership !== 'none' && …
+    // ⚠️ The ORIGINAL reason recorded here has EXPIRED, and the pin outlived it.
+    // It read: `applySystemFields` decides owner injection with a DENY-list
+    // (`wantOwner = ownership !== 'org' && ownership !== 'none' && …`), so a
+    // fourth value would fall through and be stamped with `owner_id` — the exact
+    // INVERSE of what D1 declares. #5677 flipped that judgement to an ALLOW-list
+    // (`packages/objectql/src/registry.ts`, and the shared derivation
+    // `resolveInjectedSystemColumns` in `./injected-system-columns.ts`), so the
+    // engine now implements D1's `business_unit` row correctly and the inverse-
+    // stamping hazard is gone. Do NOT re-derive the old argument from this pin.
     //
-    // so a fourth value would fall through to the default branch and be
-    // stamped with `owner_id` — the exact INVERSE of what D1 declares. Adding
-    // the value alone therefore converts today's loud rejection into a silent
-    // wrong result: ADR-0049's "spec must not declare what the runtime does not
-    // enforce", in miniature.
+    // What survives is the plain sequencing fact: extending the acceptance
+    // surface is its own change, tracked as #5678 (protocol seat). Until it
+    // lands, the value is rejected, and the rejection is the honest answer — a
+    // tier an author cannot write is not a tier the schema should advertise.
     //
-    // The enum member lands in the SAME PR that flips `wantOwner` to an
-    // allow-list and injects the column. Until then this pin holds the line —
-    // and when that PR arrives, this test failing is the intended signal to
-    // rewrite it (not to delete the guard).
+    // When #5678 arrives, this test failing is the intended signal to REWRITE it
+    // (not to delete the guard) — assert the fourth value is accepted and that a
+    // fifth is still rejected naming four legal values. Co-update targets in the
+    // same PR, both of which currently state "still rejected" in prose:
+    //   • `packages/spec/src/system/constants/system-names.ts` — the
+    //     `OWNING_BUSINESS_UNIT_ID` JSDoc (its "not authorable yet" paragraph);
+    //   • the `systemFields` JSDoc in this directory's `object.zod.ts`.
     //
     // NOTE the direction: 'business_unit' was ALREADY rejected before #4611 —
     // this test does not change behaviour, it PINS the pre-existing rejection

--- a/packages/spec/src/data/object.zod.ts
+++ b/packages/spec/src/data/object.zod.ts
@@ -1334,6 +1334,28 @@ const ObjectSchemaBase = z.object({
    *     business objects (auto-stamped to the creating user on insert;
    *     reassignable). Governed by the object-level `ownership` property
    *     (`'user' | 'org' | 'none'`), NOT by `owner` below.
+   *   - `owning_business_unit_id` — `lookup → sys_business_unit`, the
+   *     record-level ORG-UNIT ownership tier between `owner_id` (a person) and
+   *     `organization_id` (the tenant wall). [ADR-0117 D1, landed in #5677]
+   *     Governed by the same `ownership` property, on the same objects
+   *     `owner_id` is: injected under `'user'` and when `ownership` is omitted,
+   *     withheld under `'org' | 'none'`. Shaped after `organization_id`
+   *     (`readonly` + `hidden` + `system`), not after `owner_id` — it is a
+   *     server-stamped scope anchor. Provisioned but **inert**: the stamping
+   *     middleware (ADR-0117 D2/D4) has not landed, so nothing writes a value
+   *     yet.
+   *
+   *     ⚠️ D1 also defines a fourth tier, `ownership: 'business_unit'` (owning
+   *     unit, no owning person), which `applySystemFields` already implements —
+   *     but the `ownership` enum below is still `'user' | 'org' | 'none'`, so
+   *     that value is still deliberately REJECTED by this schema (the enum
+   *     member is #5678). The column being injected does NOT mean the tier is
+   *     authorable.
+   *
+   * The authority on which of these an object actually carries is
+   * `resolveInjectedSystemColumns` (`@objectstack/spec/data`): `applySystemFields`
+   * consumes it, and author-time lint reads the same derivation rather than
+   * re-deriving the conditions from this prose.
    *
    * Author-declared fields with the same name always win over injection
    * (no overwrite). Objects with `managedBy` set (and the `sys_*` namespace)

--- a/packages/spec/src/system/constants/system-names.test.ts
+++ b/packages/spec/src/system/constants/system-names.test.ts
@@ -89,18 +89,21 @@ describe('SystemFieldName', () => {
     expect(SystemFieldName.OWNING_BUSINESS_UNIT_ID).toBe('owning_business_unit_id');
   });
 
-  // [#4611 / ADR-0117 D1] The BU ownership stamp's canonical spelling is
-  // reserved here BEFORE open-core injects it, so consumers stop inventing
+  // [#4611 / ADR-0117 D1] The BU ownership stamp's canonical spelling was
+  // reserved here BEFORE open-core injected it, so consumers stop inventing
   // `business_unit_id` / `bu_id` / `dept_id` — the same drift that put
   // `tenant_id`/`org_id`/`space` into three hand-copied lists (cloud#982).
   //
-  // This table is a NAME registry, not the injected set, so a reserved-but-not-
-  // injected entry is a legitimate row (tenant_id / user_id / deleted_at are the
-  // precedents). The gate that keeps the classification honest lives in objectql
-  // (`system-managed-fields-conformance.test.ts`): it pins the public-form
-  // denylist to exactly (actively-injected ∪ documented-reserved), and this name
-  // is currently in the RESERVED half.
-  it('reserves the ADR-0117 business-unit ownership stamp without claiming injection (#4611)', () => {
+  // The name has since MOVED out of the reserved half: #5677 landed D1's
+  // injection, so `system-managed-fields-conformance.test.ts` (objectql) now
+  // derives it into Group A — the actively-injected side of the public-form
+  // partition — and the constant's JSDoc says INJECTED. What has NOT moved is
+  // the acceptance surface: `ObjectSchema`'s `ownership` enum is still
+  // `'user' | 'org' | 'none'`, so D1's fourth tier `ownership: 'business_unit'`
+  // remains unauthorable (#5678), pinned in `../../data/object.test.ts`. Both
+  // halves of that state are asserted below, because reading either one alone
+  // gets the contract wrong in a different direction.
+  it('registers the ADR-0117 business-unit ownership stamp, distinct from the user attribute (#4611)', () => {
     expect(SystemFieldName.OWNING_BUSINESS_UNIT_ID).toBe('owning_business_unit_id');
     // Guard the naming discipline ADR-0117 D10 spells out: the record stamp must
     // NOT be confused with `sys_user.primary_business_unit_id`, which is a USER
@@ -109,6 +112,13 @@ describe('SystemFieldName', () => {
     const names: readonly string[] = Object.values(SystemFieldName);
     expect(names).not.toContain('primary_business_unit_id');
   });
+
+  // Fact 2 of the pair — `ownership: 'business_unit'` still being unauthorable —
+  // is pinned ONCE, by `../../data/object.test.ts`, which asserts the rejection
+  // and its message. Deliberately not re-asserted here: a second copy of that
+  // fact is the drift mode this whole file exists to prevent. That pin's comment
+  // names this constant's JSDoc as a co-update target, so #5678 cannot flip the
+  // enum and leave "still deliberately REJECTED" standing in a doc comment.
 
   it('should be readonly (const assertion)', () => {
     const names: readonly string[] = Object.values(SystemFieldName);
@@ -135,6 +145,11 @@ describe('SystemFieldName', () => {
       'updated_at',
       'updated_by',
       'owner_id',
+      // [ADR-0117 D1 / #5677] Injected since the `wantOwner` allow-list landed,
+      // on the same objects `owner_id` is (default / `ownership: 'user'`). It
+      // belongs in THIS list, not in the reserved half — that reclassification
+      // is what the constant's JSDoc flip records.
+      'owning_business_unit_id',
     ]) {
       expect(names, injected).toContain(injected);
     }

--- a/packages/spec/src/system/constants/system-names.ts
+++ b/packages/spec/src/system/constants/system-names.ts
@@ -181,25 +181,44 @@ export const SystemFieldName = {
    * {@link SystemFieldName.ORGANIZATION_ID} (the tenant wall): *which department
    * / legal entity does this row belong to*. A lookup to `sys_business_unit`.
    *
-   * **NOT injected by open-core** — nothing provisions this column today. The
-   * NAME is reserved here by ADR-0117 (Accepted, D1/D3 scoped) so the canonical
-   * spelling has one reference before the injection lands, and so consumers stop
-   * inventing their own (`business_unit_id`, `bu_id`, `dept_id` …) — the drift
-   * mode framework#4330 / cloud#982 already paid for with `tenant_id`/`org_id`/
-   * `space`.
+   * **INJECTED** (ADR-0117 D1, landed in #5677) — `applySystemFields` provisions
+   * the column on every ownership-eligible object, i.e. wherever
+   * {@link SystemFieldName.OWNER_ID} is injected. Withheld on `managedBy` /
+   * `sys_*` tables and under `ownership: 'org' | 'none'`, exactly like
+   * `owner_id`. The per-object derivation both the engine and author-time lint
+   * read is `resolveInjectedSystemColumns` (`@objectstack/spec/data`) — its
+   * table, not this sentence, is the authority on the per-tier answer.
    *
-   * It is on the public-form denylist as defense-in-depth: once stamped it is a
-   * kernel-owned ownership anchor, and a forged value on the anonymous surface
-   * would move the row behind another department's wall — the same forge class
-   * `owner_id`/`organization_id` are denied for. Denying it before it exists is
-   * free and fail-closed; adding it after would be a hole with a release in it.
+   * ⚠️ Injected — but the unit-owned TIER is **not authorable yet**, and the two
+   * facts must be read together. D1's table adds `ownership: 'business_unit'`
+   * (an owning unit, deliberately no owning person) and `applySystemFields`
+   * already implements that row, yet the `ownership` enum in
+   * `packages/spec/src/data/object.zod.ts` is still `'user' | 'org' | 'none'`:
+   * `ownership: 'business_unit'` is therefore still deliberately REJECTED by
+   * `ObjectSchema` (pinned in `packages/spec/src/data/object.test.ts`; the enum
+   * member is #5678). Today the column reaches objects through the DEFAULT
+   * (`ownership` omitted) and `'user'` tiers only. Do not read "INJECTED" as
+   * "the business-unit tier is available".
    *
-   * When injection lands (ADR-0117 D1 — gated on the `ownership` enum gaining
-   * its `business_unit` tier AND `applySystemFields`' `wantOwner` deny-list
-   * becoming an allow-list), this doc must flip to INJECTED and the objectql
-   * conformance test moves it from the reserved group to the injected group.
-   * Until then `ownership: 'business_unit'` is deliberately REJECTED by
-   * `ObjectSchema` — see `packages/spec/src/data/object.test.ts`.
+   * The column is also provisioned but **inert**: it is shaped after
+   * `organization_id` (`readonly`, `hidden`), not after `owner_id`, because it
+   * is a server-stamped scope anchor — and the stamping middleware (ADR-0117
+   * D2/D4) has not landed, so nothing writes a value yet. See
+   * `applySystemFields`' injection site (`packages/objectql/src/registry.ts`)
+   * for why that shape presumes nothing about the undecided D2 policy.
+   *
+   * The NAME was reserved here by ADR-0117 (Accepted, D1/D3 scoped) ahead of the
+   * injection so the canonical spelling had one reference from the start, and so
+   * consumers stopped inventing their own (`business_unit_id`, `bu_id`,
+   * `dept_id` …) — the drift mode framework#4330 / cloud#982 already paid for
+   * with `tenant_id`/`org_id`/`space`.
+   *
+   * It is on the public-form denylist as defense-in-depth: it is a kernel-owned
+   * ownership anchor, and a forged value on the anonymous surface would move the
+   * row behind another department's wall — the same forge class
+   * `owner_id`/`organization_id` are denied for. Denying it before it existed
+   * was free and fail-closed; adding it only now that open-core injects it would
+   * have been a hole with a release in it.
    *
    * @see docs/adr/0117-owning-business-unit-record-stamp.md
    */


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5767

The spec-side half of ADR-0117 D1. #5677 (PR #5802) landed D1's execution surface in `packages/objectql`, but `packages/spec` still declared the opposite. This closes that window. **Text only** — no schema, no value, no injected column changes, so nothing changes what a metadata document parses to.

## 1. Premise, verified against `origin/main` before editing

Still live, both halves:

- `packages/spec/src/system/constants/system-names.ts:184` read **"NOT injected by open-core — nothing provisions this column today."** False since #5677: `packages/objectql/src/registry.ts:320` defines `OWNING_BUSINESS_UNIT_FIELD`, `:412` reads `plan.owningBusinessUnit`, and the per-tier table at `:403-406` puts the column on the `undefined`/`user` tier — the default every ordinary business object uses.
- The `systemFields` JSDoc in `object.zod.ts` enumerated the injected columns and did not list `owning_business_unit_id`.

## 2. The flip is deliberately PARTIAL — this is the load-bearing part of the diff

The old JSDoc stated its own flip condition as **two-part**: gated on (a) the `ownership` enum gaining its `business_unit` tier **and** (b) `applySystemFields`' `wantOwner` deny-list becoming an allow-list. **Only (b) landed.** On `origin/main`, `packages/spec/src/data/object.zod.ts` still declares:

```ts
ownership: z.enum(['user', 'org', 'none'], {
```

So the block's closing sentence — "`ownership: 'business_unit'` is deliberately REJECTED by `ObjectSchema`" — is **still true**, and survives the edit. Flipping to a flat "INJECTED" would have deleted a true statement and implied an authorable tier that does not exist: spec declaring what the runtime rejects, which is ADR-0049's **dangerous** direction and the inverse of the benign runtime-ahead-of-docs gap this PR closes.

Every place that states either fact now states both:

| file | change |
|---|---|
| `packages/spec/src/system/constants/system-names.ts` | `OWNING_BUSINESS_UNIT_ID` JSDoc: INJECTED (with the withheld tiers spelled out) + an explicit "the column being injected does NOT mean the business-unit tier is available" paragraph + the provisioned-but-inert note (D2/D4 stamping has not landed, so nothing writes a value yet). |
| `packages/spec/src/data/object.zod.ts` | `systemFields` JSDoc: the injected-column list gains `owning_business_unit_id` — governing property, `organization_id`-shaped definition (`readonly` + `hidden` + `system`, not `owner_id`-shaped), inert, and the same tier caveat. Points at `resolveInjectedSystemColumns` as the authority rather than making this prose one. |

## 3. Three-way consistency check (the PM's mechanism assumption), and one wording alignment

`resolveInjectedSystemColumns()` in `packages/spec/src/data/injected-system-columns.ts` (added by PR #5904) is the third statement of the same D1 fact. **Verified: its per-tier table agrees with D1 exactly**, including the `business_unit` row. What it did not carry, in the JSDoc, was the fact that that row is implemented *ahead of* the acceptance surface — the caveat lived only in an implementation comment further down (the one explaining why `ownership` is read as `string` rather than the enum). Added one note to the JSDoc table so all three read the same way. **Pure wording alignment in a JSDoc, no logic touched** — flagged here per the dispatch's instruction not to rewrite that file silently.

## 4. Pin tests: updated, not weakened

Two pin tests state this same D1 fact and had gone stale. Neither loses an assertion:

- `packages/spec/src/system/constants/system-names.test.ts` — the test was literally titled *"reserves the ADR-0117 business-unit ownership stamp **without claiming injection**"*, with a comment asserting the name "is currently in the RESERVED half". Both false since #5677 moved it to Group A in objectql's `system-managed-fields-conformance.test.ts`. Retitled, comment rewritten to carry both facts, all four original naming-discipline assertions kept — **and** `owning_business_unit_id` added to the `names every column the registry actually injects` list, which is the substantive new assertion: the injected list now includes it.
- `packages/spec/src/data/object.test.ts` — comment only, the `business_unit` rejection pin itself is untouched. Its recorded rationale had **expired**: it argued the enum member must not be added because `wantOwner` was a deny-list that would stamp the new tier with `owner_id`. #5677 removed that hazard, so the argument no longer holds and must not be re-derived by the next reader. Replaced with the surviving reason (extending the acceptance surface is #5678's own change) and a co-update list naming the two JSDoc blocks that say "still rejected", so #5678 cannot flip the enum and leave a confident lie in a doc comment nothing executes. This file is the authority my new JSDoc cites; leaving it self-contradictory would have been my own inconsistency.

Fact 2 (`business_unit` unauthorable) is deliberately pinned in exactly **one** place — `object.test.ts`, which asserts the rejection *and* its message. A second copy is the drift mode these files exist to prevent, so `system-names.test.ts` records a pointer instead of a duplicate assertion.

## 5. Generated artifacts: measured **zero** regen — contra the dispatch's expectation

The dispatch expected `content/docs/references/**` and json-schema manifest description fields to move. **They do not, and I can say why**: `content/docs/references/` is rendered from `packages/spec/json-schema/`, which `build-schemas.ts` derives from Zod `.describe()` strings. This change touches **TSDoc/JSDoc and code comments only** — no `.describe()` string. The one `describe()` that does enumerate ownership values belongs to the `ownership` enum, which is #5678's surface and out of scope here.

Measured, not assumed — every generated-artifact gate reports in sync with no rewrite:

```
check:authorable-surface   1622 schemas generated; anchor NOT rewritten (zero key drift, as predicted)
check:docs                 232 generated files in sync with packages/spec
check:skill-refs           9 generated files in sync with packages/spec
check:spec-changes         spec-changes.json is up to date
check:upgrade-guide        protocol-upgrade-guide.md is up to date
check:react-blocks         2 generated files in sync with packages/spec
```

`git status` after the full `gen:schema` run showed only the five hand-edited source files. Nothing outside description fields changed, because nothing changed at all.

## 6. Effect on #5678

**Easier, and strictly so.** #5678's work items 2 and 3 are partly done by this PR, and its blocking rationale is now recorded accurately instead of stale:

- Its item 2 (the `systemFields` / `ownership` prose gaining the new tier and injection rule) is half-landed here: the `systemFields` stanza already describes `owning_business_unit_id` and its per-tier rule, so #5678 edits a caveat rather than writing the section.
- Its item 3 (rewrite the `#4611` pin) now finds that pin carrying a *correct* description of why it still stands, plus an explicit rewrite prescription and a co-update list — instead of an expired deny-list argument that would have had to be untangled first.
- Nothing here makes the enum extension harder: the `ownership` enum, its `error` text and its `describe()` are untouched, so #5678's diff surface is unchanged.

## Verification

- `pnpm --filter @objectstack/spec test` — **332 files / 8496 tests passed**
- `pnpm --filter @objectstack/spec typecheck` — `tsc --noEmit` clean; `check:test-typecheck` OK
- `pnpm lint` — clean
- Every `check:*` step enumerated from `.github/workflows/lint.yml`, both jobs, run one by one: **28 ESLint-job gates PASS**, and the TypeScript-job gates runnable without a full workspace build PASS (`check:type-check-coverage`, `check:driver-conformance`, `check:stall-guard`, `check:generated --reconcile-only`, `check:skill-docs`, `check:skill-frame-sync`, `check:skill-compatibility`, plus the six artifact gates above)
- `node scripts/check-nul-bytes.mjs` OK, plus a targeted self-scan of all five touched files for the wider control-byte range

### On reverse verification

Reported straight rather than forced into the template: **no reverse direction exists for this change.** The diff is prose in comments; no gate reads it, so reverting it cannot turn anything red. The only new *assertion* — `owning_business_unit_id` in the injected-names list — goes red if the constant is renamed or dropped, which is what it is for. The honest measurement here is the **zero-regen** result in §5, which is a real prediction that could have failed (the dispatch predicted it would).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JTSZAjgtL3oR6YcpNDhW3T)_