### PR TITLE
docs(pm-dispatch): engine-core 再拆 domain:metadata(维护者拍板,座位贴 #6367)

### DIFF
--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -576,7 +576,8 @@ file the fix touches, you have not triaged it yet, and it is not labelable.
 
 | 标签 | 包家族 |
 |:--|:--|
-| `domain:engine-core` | `packages/objectql`、`packages/metadata*`、`packages/platform-objects`、`packages/core`、`packages/formula`(CEL / `matches-filter` / RLS 谓词求值)、`plugin-pinyin-search`(`__search` 伴生列由 SchemaRegistry 声明、engine 把它 OR 进 `$search`,落点在编译/查询核心而非任何 driver;全局写钩子同 #4775 锚定) |
+| `domain:engine-core` | `packages/objectql`、`packages/core`、`packages/formula`(CEL / `matches-filter` / RLS 谓词求值)、`plugin-pinyin-search`(`__search` 伴生列由 SchemaRegistry 声明、engine 把它 OR 进 `$search`,落点在编译/查询核心而非任何 driver;全局写钩子同 #4775 锚定) |
+| `domain:metadata` | `packages/metadata*`(metadata service / registry / directory:加载、注册、持久化、缓存、目录)、`packages/platform-objects`(内置平台对象定义)—— 见下「`engine-core` 再拆 `metadata`」 |
 | `domain:drivers` | `packages/drivers/driver-*`(`driver-memory` / `driver-mongodb` / `driver-sql` / `driver-sqlite-wasm`) |
 | `domain:services` | `packages/services/*`、`packages/connectors/*`、`packages/triggers/*`(flow 触发器)、`packages/plugins/plugin-approvals`、`plugin-webhooks`、`plugin-email`、`plugin-reports`、`embedder-openai`、`knowledge-memory`、`knowledge-ragflow` |
 | `domain:identity` | `packages/plugins/plugin-auth`、`plugin-security`、`plugin-sharing`、`plugin-audit` |
@@ -596,7 +597,7 @@ updated **by PR** — the taxonomy evolves deliberately, never per-claim.
 
 - `packages/apps/*` 今天只是 app manifest + plugin 壳,内容仍从
   `@objectstack/platform-objects/apps` 再导出,落点可能在 platform-objects
-  (`engine-core`)、这三个包本身、或控制台渲染面(`repo:objectui`)—— 按主要
+  (`metadata`)、这三个包本身、或控制台渲染面(`repo:objectui`)—— 按主要
   落地站点在分诊时判定。
 - `packages/console` 是 `../objectui` 构建产物的落盘位:仓内只跟踪
   `package.json` / `README` / `CHANGELOG`,`dist/` 由 `scripts/build-console.sh`
@@ -650,6 +651,26 @@ objectql + metadata\* + platform-objects + core + formula + 全部 `driver-*`,
   一次性重标;拆分时已在飞的打包卡(sweep/工头)由原认领者跟完,不迁移。
 - **运行模式**:surface 席 sweep-first —— 一认领、一 PR、多单 `Fixes`,逐单
   清单复审、零 rider,把认领/PR/CI/验收的固定开销摊薄到 1/N(试点 #6243)。
+
+**`engine-core` 再拆 `metadata`(维护者 2026-08-07 拍板,座位贴 #6367)。**
+首拆后的 engine-core 仍是全仓最大、增长最快的车道:编译/查询核心与元数据
+机制(service / registry / directory + 内置平台对象)的落地节律不同 —— 前者
+深、串行、常挂 ★,后者以机制修缮与观测型 finding 为主,天然可并行。二次
+切分仍按包边界(anchoring rule 无例外,与 spec 拆分不同):**`engine-core` =
+编译/查询核心**(objectql / core / formula / plugin-pinyin-search),
+**`metadata` = 元数据机制与内置对象**(`packages/metadata*`、
+`packages/platform-objects`)。配套纪律:
+
+- **红线**:改变元数据**格式/接受面**的卡照旧归 `domain:spec`(协议席,判据
+  「合法集合变没变」,#6245/#6235 先例);`/meta` HTTP 路由本体在
+  `packages/rest`,归 `domain:cli` —— `metadata` 席只吃 engine 侧机制。跨半边
+  的卡按主要落点判,拿不准 FLAG 回分诊。
+- **迁移**:存量带 `domain:engine-core` 的 open issue 由**分诊座位**按落点
+  逐条改标(只读分类审计留证,逐卡迁移评论);已在飞(`pm:dispatched`)的
+  **改标不改辖** —— 标签随分类走,收尾与复核仍归原认领会话(先例 #6298
+  说明段)。
+- **座位贴新立**:#6367,范围段照抄上表;母席 #6019 范围随表收缩,由其在任
+  PM 自行更新正文(单写手规则),分诊座位只留知会评论。
 
 **Label discipline —— 单一生产者。** `domain:*` 只由**分诊座位**在 backlog
 sweep(round loop step 0)产出,全仓唯一(rule 4)。**打标签 ≠ 认领**:分诊座位


### PR DESCRIPTION
维护者 2026-08-07 对话拍板「同意拆分 domain:metadata」。按 `engine → engine-core + drivers`(#5472)与 `spec → spec + spec-surface`(#6298)两次先例的同一格式,把二次拆分写入 pm-dispatch 车道协议。

## 改了什么

1. **车道表**:新增 `domain:metadata` 行 —— `packages/metadata*`(metadata service / registry / directory:加载、注册、持久化、缓存、目录)+ `packages/platform-objects`(内置平台对象定义);`domain:engine-core` 行相应收缩为编译/查询核心(objectql / core / formula / plugin-pinyin-search)。
2. **`packages/apps/*` 兜底注**:platform-objects 的落点交叉引用 `engine-core` → `metadata` 随迁。
3. **拆分史第三段**「`engine-core` 再拆 `metadata`」,含:
   - **红线**:改变元数据格式/接受面的卡照旧归 `domain:spec`(判据「合法集合变没变」,#6245/#6235 先例);`/meta` HTTP 路由本体在 `packages/rest` 归 `domain:cli`;跨半边按主要落点判,拿不准 FLAG 回分诊。
   - **迁移纪律**:存量由分诊座位按落点逐条改标(只读分类审计留证);在飞卡**改标不改辖**(先例 #6298 说明段)。
   - **座位贴指针**:#6367(新席,⏳ vacant);母席 #6019 由其在任 PM 自行收缩正文(单写手规则)。

## 拆分依据

engine-core 是首拆后仍然最大、增长最快的车道(上一轮清点 37 张可派、★7)。切分仍按包边界 —— anchoring rule 无例外(与 spec 拆分的「一包两席」不同),分诊判据保持机械。

存量迁移不在本 PR:分类审计在途,迁移以逐卡评论留证,完成后计数落在 #6367。

Refs #6367

---
_Generated by [Claude Code](https://claude.ai/code/session_01BickTBKm2JYSNnrtPT8ysa)_