### PR TITLE
test(runtime,service-messaging): notification 族响应体一致性 —— 双断言口径,8 个 emit 站点逐条覆盖 (#5792)

### DIFF
--- a/packages/runtime/src/notification-schema-conformance.integration.test.ts
+++ b/packages/runtime/src/notification-schema-conformance.integration.test.ts
@@ -1,0 +1,270 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// [#5792 / Part of #3877] Stage A, notification family — the WIRE half.
+//
+// The other two gates check the two halves in isolation: the producer
+// (`service-messaging/src/notification-schema-conformance.test.ts`) and the
+// dispatcher domain (`./notification-schema-conformance.test.ts`). This one
+// checks the composed shape a browser actually receives, over a real socket,
+// through a real SQL driver — the same call #5682 made for the REST discovery
+// gate, and for the same reason: neither producer alone is the thing a client
+// parses.
+//
+// Two facts are only measurable here:
+//
+//   1. `createdAt` is `z.string().datetime()`, i.e. an ISO-8601 instant and not
+//      merely "a string". The value makes a full round trip through
+//      `sys_inbox_message.created_at` (`Field.datetime()`) and back out of the
+//      driver. A driver dialect (`2026-01-01 00:00:00`, or a `Date` object)
+//      would satisfy the in-memory producer gate's fixture and fail here.
+//   2. `actionUrl` is written unconditionally as `… ?? undefined`, so
+//      `Object.keys()` sees the key on every row while `JSON.stringify` drops
+//      it from the empty ones. The producer gate reads the object view; only
+//      this file reads the JSON view. Both must conform — the `routes.mcp`
+//      nuance #5679 measured, in this family.
+//
+// The boot mirrors `notifications.hono.integration.test.ts` (the #3362
+// regression), deliberately: that suite proved the routes are REACHABLE, this
+// one proves what comes back is what the catalog declares. Kept as a separate
+// file rather than bolted onto it so the conformance gate can be read, moved
+// or ratcheted (#3877 Stage D) without dragging a reachability regression with
+// it.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ObjectKernel, Plugin, PluginContext } from '@objectstack/core';
+import { HonoServerPlugin } from '@objectstack/plugin-hono-server';
+import { ObjectQLPlugin } from '@objectstack/objectql';
+import { SqliteWasmDriver } from '@objectstack/driver-sqlite-wasm';
+import { MessagingServicePlugin, MessagingService } from '@objectstack/service-messaging';
+import {
+  envelopeViolations,
+  ListNotificationsResponseSchema,
+  MarkNotificationsReadResponseSchema,
+  MarkAllNotificationsReadResponseSchema,
+  NotificationSchema,
+} from '@objectstack/spec/api';
+import type { IHttpServer } from '@objectstack/spec/contracts';
+
+import { createDispatcherPlugin } from './dispatcher-plugin.js';
+import { DriverPlugin } from './driver-plugin.js';
+
+// One inbox per concern. The mark-read routes MUTATE read-state, so a shared
+// user would make these suites order-dependent — the unread fixture the gap
+// suite needs would be consumed by whichever mark-read test ran first.
+const LIST_USER = 'usr_notif_conformance_list';
+const MARK_USER = 'usr_notif_conformance_mark';
+const GAP_USER = 'usr_notif_conformance_gap';
+
+/** Declared key sets — derived from the schemas, never hand-listed. */
+const declaredListKeys = () => new Set(Object.keys((ListNotificationsResponseSchema as any).shape));
+const declaredNotificationKeys = () => new Set(Object.keys((NotificationSchema as any).shape));
+const declaredMarkReadKeys = () => new Set(Object.keys((MarkNotificationsReadResponseSchema as any).shape));
+const declaredMarkAllReadKeys = () => new Set(Object.keys((MarkAllNotificationsReadResponseSchema as any).shape));
+
+/** Minimal `auth` service — `x-test-user` names the principal, absent = anonymous. */
+function fakeAuthPlugin(): Plugin {
+  return {
+    name: 'com.objectstack.test.fake-auth-notif-conformance',
+    version: '1.0.0',
+    init: async (ctx: PluginContext) => {
+      ctx.registerService('auth', {
+        api: {
+          getSession: async ({ headers }: { headers: any }) => {
+            const uid = typeof headers?.get === 'function'
+              ? headers.get('x-test-user')
+              : headers?.['x-test-user'];
+            return uid ? { user: { id: uid } } : undefined;
+          },
+        },
+      });
+    },
+  };
+}
+
+describe('[#5792] the notification wire bodies conform to the schemas the catalog declares', () => {
+  let kernel: ObjectKernel;
+  let baseUrl: string;
+  let messaging: MessagingService;
+
+  beforeAll(async () => {
+    kernel = new ObjectKernel({ logLevel: 'silent' });
+    await kernel.use(new DriverPlugin(new SqliteWasmDriver({ filename: ':memory:' })));
+    await kernel.use(new ObjectQLPlugin());
+    // Inline delivery so `emit()` materializes the inbox row synchronously.
+    await kernel.use(new MessagingServicePlugin({ reliableDelivery: false }));
+    await kernel.use(fakeAuthPlugin());
+    await kernel.use(new HonoServerPlugin({ port: 0 }));
+    await kernel.use(createDispatcherPlugin({ prefix: '/api/v1', securityHeaders: false, requireAuth: false }));
+    await kernel.bootstrap();
+
+    const httpServer = kernel.getService<IHttpServer>('http.server');
+    baseUrl = `http://127.0.0.1:${httpServer.getPort!()}`;
+    messaging = kernel.getService<MessagingService>('notification');
+
+    // Three notifications per inbox: one WITH an `actionUrl`, two without — so
+    // the optional key is exercised in both states on the wire.
+    for (const user of [LIST_USER, MARK_USER, GAP_USER]) {
+      await messaging.emit({ topic: 'deal.won', audience: [user], payload: { title: 'Deal one', body: 'first', actionUrl: '/records/1' } });
+      await messaging.emit({ topic: 'task.assigned', audience: [user], payload: { title: 'Task two', body: 'second' } });
+      await messaging.emit({ topic: 'task.assigned', audience: [user], payload: { title: 'Task three', body: 'third' } });
+    }
+  }, 60_000);
+
+  afterAll(async () => {
+    if (kernel) {
+      await Promise.race([
+        kernel.shutdown(),
+        new Promise<void>((resolve) => setTimeout(resolve, 10_000)),
+      ]);
+    }
+  }, 30_000);
+
+  /** Drive one route as `user`, asserting the shared envelope, and hand back `data`. */
+  const getJson = async (user: string, path: string, init?: RequestInit) => {
+    const res = await fetch(`${baseUrl}${path}`, {
+      ...init,
+      headers: { 'x-test-user': user, 'content-type': 'application/json', ...(init?.headers ?? {}) },
+    });
+    expect(res.status, `${path} must answer 200`).toBe(200);
+    const body = await res.json();
+    expect(envelopeViolations(body), `${path} is not the declared envelope: ${JSON.stringify(body)}`).toEqual([]);
+    return body.data;
+  };
+
+  describe('GET /api/v1/notifications', () => {
+    it('satisfies ListNotificationsResponseSchema (VALUE assertion)', async () => {
+      const data = await getJson(LIST_USER, '/api/v1/notifications');
+
+      const parsed = ListNotificationsResponseSchema.safeParse(data);
+      expect(
+        parsed.success ? [] : parsed.error!.issues.map((i) => `${i.path.join('.')}: ${i.code}`),
+        'the wire body must satisfy ListNotificationsResponseSchema',
+      ).toEqual([]);
+      // Anti-vacuity: an empty list parses too.
+      expect(parsed.data?.notifications).toHaveLength(3);
+      expect(parsed.data?.unreadCount).toBe(3);
+    });
+
+    it('emits NO key the protocol does not declare, at the top level and one level down (KEY assertion)', async () => {
+      const data = await getJson(LIST_USER, '/api/v1/notifications');
+
+      expect(
+        Object.keys(data).filter((k) => !declaredListKeys().has(k)),
+        'undeclared top-level keys on the wire body',
+      ).toEqual([]);
+
+      const rows: Array<Record<string, unknown>> = data.notifications;
+      expect(
+        [...new Set(rows.flatMap((n) => Object.keys(n).filter((k) => !declaredNotificationKeys().has(k))))],
+        'undeclared keys inside notifications[] on the wire body',
+      ).toEqual([]);
+    });
+
+    it('`createdAt` survives the driver round trip as a real ISO-8601 instant', async () => {
+      const data = await getJson(LIST_USER, '/api/v1/notifications');
+
+      for (const row of data.notifications as Array<{ id: string; createdAt: string }>) {
+        expect(typeof row.createdAt, `createdAt on ${row.id}`).toBe('string');
+        // The refinement the in-memory fixture cannot prove: a SQL-flavoured
+        // `2026-01-01 00:00:00` is a string and would fail here.
+        expect(new Date(row.createdAt).toISOString(), `createdAt on ${row.id} is not ISO-8601`).toBe(row.createdAt);
+        expect(NotificationSchema.safeParse(row).success).toBe(true);
+      }
+    });
+
+    it('the JSON view of an absent `actionUrl` is a conforming body too', async () => {
+      const data = await getJson(LIST_USER, '/api/v1/notifications');
+      const rows: Array<Record<string, unknown>> = data.notifications;
+
+      const withUrl = rows.find((n) => n.title === 'Deal one')!;
+      const withoutUrl = rows.find((n) => n.title === 'Task two')!;
+
+      expect(withUrl.actionUrl).toBe('/records/1');
+      // In-process the key is present carrying `undefined` (pinned by the
+      // producer gate); `JSON.stringify` drops it here. Both views conform —
+      // `actionUrl` is declared `optional`, not `nullable`.
+      expect(Object.prototype.hasOwnProperty.call(withoutUrl, 'actionUrl')).toBe(false);
+      expect(NotificationSchema.safeParse(withoutUrl).success).toBe(true);
+    });
+  });
+
+  describe('POST /api/v1/notifications/read and /read/all', () => {
+    it('both bodies satisfy their declared schemas and emit no undeclared key', async () => {
+      const ids: string[] = (await getJson(MARK_USER, '/api/v1/notifications')).notifications.map((n: any) => n.id);
+
+      const readOne = await getJson(MARK_USER, '/api/v1/notifications/read', {
+        method: 'POST',
+        body: JSON.stringify({ ids: [ids[0]] }),
+      });
+      const parsedOne = MarkNotificationsReadResponseSchema.safeParse(readOne);
+      expect(
+        parsedOne.success ? [] : parsedOne.error!.issues.map((i) => `${i.path.join('.')}: ${i.code}`),
+        'POST /read wire body must satisfy MarkNotificationsReadResponseSchema',
+      ).toEqual([]);
+      expect(Object.keys(readOne).filter((k) => !declaredMarkReadKeys().has(k))).toEqual([]);
+      expect(parsedOne.data?.readCount).toBe(1); // anti-vacuity: a no-op also parses
+
+      const readAll = await getJson(MARK_USER, '/api/v1/notifications/read/all', { method: 'POST' });
+      const parsedAll = MarkAllNotificationsReadResponseSchema.safeParse(readAll);
+      expect(
+        parsedAll.success ? [] : parsedAll.error!.issues.map((i) => `${i.path.join('.')}: ${i.code}`),
+        'POST /read/all wire body must satisfy MarkAllNotificationsReadResponseSchema',
+      ).toEqual([]);
+      expect(Object.keys(readAll).filter((k) => !declaredMarkAllReadKeys().has(k))).toEqual([]);
+      expect(parsedAll.data?.readCount).toBe(2); // the two still unread
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Declared, not delivered — recorded, NOT endorsed
+  // ═══════════════════════════════════════════════════════════════════════════
+  //
+  // The two assertions above are 3/3 green for this family. These two facts are
+  // real inconsistencies that BOTH assertions are structurally blind to, and
+  // that is the point worth writing down for #3877's Stage D ratchet:
+  //
+  //   * `unreadCount` is a `number` whether it counts the total or the window,
+  //     so a VALUE assertion cannot see a wrong semantic;
+  //   * `cursor` is `optional`, so "no producer ever emits it" is a legal
+  //     parse and the KEY assertion (⊆, not =) cannot see it either.
+  //
+  // Pinned as the measured behaviour of `origin/main`, with the issues that own
+  // the judgement call. Whichever way #6361 / #6363 are ruled, these two
+  // assertions are the ones that must flip — which is why they are here rather
+  // than left for the next reader to rediscover.
+  describe('[#6361 / #6363] the gaps the double assertion cannot see', () => {
+    it('[#6363] `unreadCount` counts the RETURNED WINDOW, not the total the schema describes', async () => {
+      const all = await getJson(GAP_USER, '/api/v1/notifications');
+      expect(all.unreadCount, 'fixture must leave more than one unread for this to mean anything')
+        .toBeGreaterThan(1);
+
+      const windowed = await getJson(GAP_USER, '/api/v1/notifications?limit=1');
+
+      expect(windowed.notifications).toHaveLength(1);
+      // Declared: 'Total number of unread notifications'. Delivered: the unread
+      // count within the fetched window. See #6363.
+      expect(windowed.unreadCount).toBe(1);
+      expect(windowed.unreadCount).not.toBe(all.unreadCount);
+      // …and it still parses, which is exactly the blind spot.
+      expect(ListNotificationsResponseSchema.safeParse(windowed).success).toBe(true);
+    });
+
+    it('[#6361 / #6363] `cursor` is declared on both sides and honoured on neither', async () => {
+      const page1 = await getJson(GAP_USER, '/api/v1/notifications?limit=2');
+      const ids1 = page1.notifications.map((n: any) => n.id);
+
+      // Response half (#6363): the declared `cursor` key is never emitted.
+      expect(Object.prototype.hasOwnProperty.call(page1, 'cursor')).toBe(false);
+      expect(declaredListKeys().has('cursor')).toBe(true);
+
+      // Request half (#6361): sending the declared `cursor` returns the SAME
+      // page. An SDK caller paginating by the published contract loops forever.
+      const page2 = await getJson(GAP_USER, `/api/v1/notifications?limit=2&cursor=${encodeURIComponent(ids1[ids1.length - 1])}`);
+      expect(page2.notifications.map((n: any) => n.id)).toEqual(ids1);
+
+      // Both pages conform — the whole reason this needed measuring by hand.
+      expect(ListNotificationsResponseSchema.safeParse(page1).success).toBe(true);
+      expect(ListNotificationsResponseSchema.safeParse(page2).success).toBe(true);
+    });
+  });
+});

--- a/packages/runtime/src/notification-schema-conformance.test.ts
+++ b/packages/runtime/src/notification-schema-conformance.test.ts
@@ -1,0 +1,351 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// [#5792 / Part of #3877] Stage A, notification family — the DISPATCHER half.
+//
+// The producer gate lives next to the producer
+// (`service-messaging/src/notification-schema-conformance.test.ts`); it proves
+// `MessagingService` authors bodies that satisfy the schemas
+// `DEFAULT_NOTIFICATION_ROUTES` declares. This file proves the OTHER half: that
+// `/notifications` hands those bodies to the wire unchanged, and that every one
+// of the domain's emit sites — not only the three happy ones — answers in a
+// declared shape.
+//
+// ## Why a pass-through needs its own gate
+//
+// `domains/notifications.ts` forwards `deps.success(result)`. "Forwards" is a
+// property of today's code, not of the contract: a domain that starts folding
+// in a computed `cursor`, an `unreadTotal`, or a re-keyed row would emit keys
+// no schema declares, and the producer-side gate could not see it. `safeParse`
+// on its own could not see it either — a zod object strips unknown keys — which
+// is why this file carries the SAME two assertions as the producer gate:
+//
+//   * `Schema.safeParse(body.data)` judges VALUES;
+//   * `Object.keys(body.data) ⊆ Schema.shape` judges KEYS.
+//
+// Both allowed sets are derived from the schemas' own `shape` (#5682 / the
+// maintainer's 2026-08-06 ruling point 3) — never hand-listed here.
+//
+// ## The eight emit sites of this family
+//
+// #3877 measured the notification family at EIGHT thin emit sites. They are the
+// eight `return`s of `domains/notifications.ts`, and three of them are the ones
+// carrying a `responseSchema`:
+//
+//   1  :79  capabilityUnavailable — no service / not serveable / no `listInbox`
+//   2  :86  deps.error('Authentication required', 401)
+//   3  :111 deps.success(listInbox result)      ← ListNotificationsResponseSchema
+//   4  :116 capabilityUnavailable — `markRead` absent
+//   5  :128 throw validationFailure(...) — malformed mark-read body
+//   6  :134 deps.success(markRead result)       ← MarkNotificationsReadResponseSchema
+//   7  :139 capabilityUnavailable — `markAllRead` absent
+//   8  :141 deps.success(markAllRead result)    ← MarkAllNotificationsReadResponseSchema
+//
+// (`return { handled: false }` for an unmatched sub-path is not an emit — the
+// plugin's single exit turns it into 404 ROUTE_NOT_FOUND — but it is pinned
+// below so the count is closed rather than assumed.)
+//
+// The five non-success sites carry no `responseSchema`; what they DO declare is
+// the shared envelope, so they are gated against `envelopeViolations` plus the
+// status each one owes. A family whose error exits were never checked is a
+// family whose conformance claim covers only its happy path.
+
+import { describe, it, expect } from 'vitest';
+import {
+    BaseResponseSchema,
+    envelopeViolations,
+    ListNotificationsRequestSchema,
+    ListNotificationsResponseSchema,
+    MarkNotificationsReadResponseSchema,
+    MarkAllNotificationsReadResponseSchema,
+    NotificationSchema,
+    SERVICE_SELF_INFO_KEY,
+} from '@objectstack/spec/api';
+import { serviceUnavailableMessage } from '@objectstack/spec/system';
+import { HttpDispatcher } from './http-dispatcher.js';
+import { validationFailureDetails } from './validation-failure.js';
+
+const USER = 'usr_dispatch_conformance';
+
+/** Declared key sets — derived from the schemas, never hand-listed. */
+const declaredListKeys = () => new Set(Object.keys((ListNotificationsResponseSchema as any).shape));
+const declaredNotificationKeys = () => new Set(Object.keys((NotificationSchema as any).shape));
+const declaredMarkReadKeys = () => new Set(Object.keys((MarkNotificationsReadResponseSchema as any).shape));
+const declaredMarkAllReadKeys = () => new Set(Object.keys((MarkAllNotificationsReadResponseSchema as any).shape));
+
+/**
+ * The bodies the REAL `MessagingService` emits, measured by the producer gate
+ * in `service-messaging` and restated here as the double's returns. Restated
+ * rather than imported so `packages/runtime` does not take a dependency on the
+ * provider that happens to fill the slot today — the domain must forward ANY
+ * conforming provider's body, and `INotificationService` is what it is typed
+ * against.
+ */
+const LIST_BODY = {
+    notifications: [
+        {
+            id: 'n1', type: 'deal.won', title: 'Deal one', body: 'first',
+            read: false, actionUrl: '/records/1', createdAt: '2026-08-07T15:02:26.891Z',
+        },
+        {
+            id: 'n2', type: 'task.assigned', title: 'Task two', body: 'second',
+            read: true, actionUrl: undefined, createdAt: '2026-08-07T15:02:26.897Z',
+        },
+    ],
+    unreadCount: 1,
+};
+const MARK_READ_BODY = { success: true, readCount: 1 };
+const MARK_ALL_BODY = { success: true, readCount: 2 };
+
+/**
+ * A dispatcher over a notification slot filled by `capabilities`. Omitting a
+ * method is how a real send-only provider presents (`listInbox` / `markRead` /
+ * `markAllRead` are separately OPTIONAL on `INotificationService`), which is
+ * what makes emit sites 1 / 4 / 7 reachable.
+ */
+function makeDispatcher(capabilities: Record<string, unknown> | null = {
+    listInbox: async () => LIST_BODY,
+    markRead: async () => MARK_READ_BODY,
+    markAllRead: async () => MARK_ALL_BODY,
+}) {
+    const resolve = (name: string) => (name === 'notification' ? capabilities : null);
+    const kernel: any = {
+        getService: resolve,
+        getServiceAsync: async (name: string) => resolve(name),
+        context: { getService: resolve },
+    };
+    return new HttpDispatcher(kernel);
+}
+
+const CTX = { request: {}, executionContext: { userId: USER } } as any;
+const ANON_CTX = { request: {} } as any;
+
+/** Every body this domain emits must satisfy the shared envelope in full. */
+function expectEnvelope(body: unknown, success: boolean) {
+    expect(BaseResponseSchema.safeParse(body).success, `not a BaseResponse: ${JSON.stringify(body)}`).toBe(true);
+    // `safeParse` alone passes a success body with no `data`, or a payload
+    // duplicated into a stray top-level key (#4049) — `envelopeViolations` is
+    // the declared envelope in full.
+    expect(envelopeViolations(body), `not the declared envelope: ${JSON.stringify(body)}`).toEqual([]);
+    expect((body as { success?: boolean }).success).toBe(success);
+}
+
+describe('[#5792] /notifications conforms to the schemas the catalog declares', () => {
+    // ═══════════════════════════════════════════════════════════════════════
+    // Emit site 3 — GET /notifications
+    // ═══════════════════════════════════════════════════════════════════════
+    describe('emit site 3 — GET / → ListNotificationsResponseSchema', () => {
+        it('satisfies the declared schema (VALUE assertion)', async () => {
+            const result = await makeDispatcher().handleNotification('', 'GET', undefined, {}, CTX);
+
+            expect(result.response?.status).toBe(200);
+            expectEnvelope(result.response?.body, true);
+            const parsed = ListNotificationsResponseSchema.safeParse(result.response?.body?.data);
+            expect(
+                parsed.success ? [] : parsed.error!.issues.map((i) => `${i.path.join('.')}: ${i.code}`),
+                'GET /notifications body must satisfy ListNotificationsResponseSchema',
+            ).toEqual([]);
+            // Anti-vacuity: an empty list also parses.
+            expect(parsed.data?.notifications).toHaveLength(2);
+        });
+
+        it('emits NO top-level key the protocol does not declare (KEY assertion)', async () => {
+            const result = await makeDispatcher().handleNotification('', 'GET', undefined, {}, CTX);
+
+            const declared = declaredListKeys();
+            expect(
+                Object.keys(result.response?.body?.data ?? {}).filter((k) => !declared.has(k)),
+                'undeclared top-level keys on the GET /notifications body',
+            ).toEqual([]);
+        });
+
+        it('emits NO `notifications[]` key the protocol does not declare (KEY assertion, one level down)', async () => {
+            const result = await makeDispatcher().handleNotification('', 'GET', undefined, {}, CTX);
+
+            const declared = declaredNotificationKeys();
+            const rows: Array<Record<string, unknown>> = result.response?.body?.data?.notifications ?? [];
+            expect(rows.length, 'fixture must produce rows for this gate to mean anything').toBe(2);
+            expect(
+                [...new Set(rows.flatMap((n) => Object.keys(n).filter((k) => !declared.has(k))))],
+                'undeclared keys inside notifications[] on the GET /notifications body',
+            ).toEqual([]);
+        });
+
+        it('forwards the provider body UNCHANGED — no key added, none dropped', async () => {
+            // The pass-through property stated as an assertion rather than
+            // assumed from reading the handler. `deps.success(result)` must put
+            // the provider's object under `data` verbatim.
+            const result = await makeDispatcher().handleNotification('', 'GET', undefined, {}, CTX);
+
+            expect(result.response?.body?.data).toBe(LIST_BODY);
+            expect(Object.keys(result.response?.body?.data)).toEqual(Object.keys(LIST_BODY));
+        });
+
+        it('reads the declared query filters (`read` / `type` / `limit`) off the request', async () => {
+            // Anti-vacuity for the route itself: the three filters
+            // `ListNotificationsRequestSchema` declares AND `InboxQuery` accepts
+            // must reach the provider, or the conforming body above would be a
+            // conforming answer to a question nobody asked (#3676's shape).
+            const seen: unknown[] = [];
+            const dispatcher = makeDispatcher({
+                listInbox: async (_userId: string, options: unknown) => { seen.push(options); return LIST_BODY; },
+                markRead: async () => MARK_READ_BODY,
+                markAllRead: async () => MARK_ALL_BODY,
+            });
+
+            await dispatcher.handleNotification('', 'GET', undefined, { read: 'false', type: 'deal.won', limit: '7' }, CTX);
+
+            expect(seen[0]).toEqual({ read: false, type: 'deal.won', limit: 7 });
+        });
+
+        it('[#6361] recorded, not endorsed: the declared `limit` DEFAULT never reaches the provider', async () => {
+            // `ListNotificationsRequestSchema.limit` is `z.number().default(20)`,
+            // but this route never parses the query through that schema — with no
+            // `limit` the domain forwards `undefined` and the provider applies its
+            // own window (50). So the declared default has never been in effect.
+            //
+            // Pinned as the measured fact it is, NOT as the desired behaviour:
+            // #6361 is the judgement call (align the declaration to 50, or wire
+            // the query through the schema so 20 takes effect). Whichever way it
+            // is ruled, this assertion is the one that must change — which is the
+            // point of pinning it rather than leaving it for the next reader.
+            const seen: unknown[] = [];
+            const dispatcher = makeDispatcher({
+                listInbox: async (_userId: string, options: unknown) => { seen.push(options); return LIST_BODY; },
+                markRead: async () => MARK_READ_BODY,
+                markAllRead: async () => MARK_ALL_BODY,
+            });
+
+            await dispatcher.handleNotification('', 'GET', undefined, {}, CTX);
+
+            expect(seen[0]).toEqual({ read: undefined, type: undefined, limit: undefined });
+            expect((ListNotificationsRequestSchema as any).shape.limit._zod.def.defaultValue).toBe(20);
+        });
+    });
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Emit sites 6 and 8 — the two mark-read routes
+    // ═══════════════════════════════════════════════════════════════════════
+    describe('emit site 6 — POST /read → MarkNotificationsReadResponseSchema', () => {
+        it('satisfies the declared schema (VALUE assertion)', async () => {
+            const result = await makeDispatcher().handleNotification('/read', 'POST', { ids: ['n1'] }, {}, CTX);
+
+            expect(result.response?.status).toBe(200);
+            expectEnvelope(result.response?.body, true);
+            const parsed = MarkNotificationsReadResponseSchema.safeParse(result.response?.body?.data);
+            expect(
+                parsed.success ? [] : parsed.error!.issues.map((i) => `${i.path.join('.')}: ${i.code}`),
+                'POST /notifications/read body must satisfy MarkNotificationsReadResponseSchema',
+            ).toEqual([]);
+            expect(parsed.data?.readCount).toBe(1);
+        });
+
+        it('emits NO key the protocol does not declare (KEY assertion)', async () => {
+            const result = await makeDispatcher().handleNotification('/read', 'POST', { ids: ['n1'] }, {}, CTX);
+
+            const declared = declaredMarkReadKeys();
+            expect(
+                Object.keys(result.response?.body?.data ?? {}).filter((k) => !declared.has(k)),
+                'undeclared keys on the POST /notifications/read body',
+            ).toEqual([]);
+        });
+    });
+
+    describe('emit site 8 — POST /read/all → MarkAllNotificationsReadResponseSchema', () => {
+        it('satisfies the declared schema (VALUE assertion)', async () => {
+            const result = await makeDispatcher().handleNotification('/read/all', 'POST', undefined, {}, CTX);
+
+            expect(result.response?.status).toBe(200);
+            expectEnvelope(result.response?.body, true);
+            const parsed = MarkAllNotificationsReadResponseSchema.safeParse(result.response?.body?.data);
+            expect(
+                parsed.success ? [] : parsed.error!.issues.map((i) => `${i.path.join('.')}: ${i.code}`),
+                'POST /notifications/read/all body must satisfy MarkAllNotificationsReadResponseSchema',
+            ).toEqual([]);
+            expect(parsed.data?.readCount).toBe(2);
+        });
+
+        it('emits NO key the protocol does not declare (KEY assertion)', async () => {
+            const result = await makeDispatcher().handleNotification('/read/all', 'POST', undefined, {}, CTX);
+
+            const declared = declaredMarkAllReadKeys();
+            expect(
+                Object.keys(result.response?.body?.data ?? {}).filter((k) => !declared.has(k)),
+                'undeclared keys on the POST /notifications/read/all body',
+            ).toEqual([]);
+        });
+    });
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Emit sites 1 / 4 / 7 — the capability-unavailable exits
+    // ═══════════════════════════════════════════════════════════════════════
+    //
+    // No `responseSchema` covers these; the envelope and the status ARE their
+    // contract. 501 (not 404, not 503) is the ADR-0076 D12 answer for "the
+    // route is mounted, the implementation is not" — see `domains/unavailable.ts`.
+    describe('emit sites 1 / 4 / 7 — capabilityUnavailable(…, "notification")', () => {
+        it.each([
+            ['site 1 — empty slot', null, '', 'GET'],
+            // The marker key is taken from the spec's own constant, not spelled
+            // here — a hand-written `__serviceInfo` would make this row pass for
+            // the wrong reason the day the marker is renamed.
+            ['site 1 — a slot filled by a self-declared non-handler', { [SERVICE_SELF_INFO_KEY]: { status: 'stub', handlerReady: false }, listInbox: async () => LIST_BODY }, '', 'GET'],
+            ['site 1 — a send-only provider with no `listInbox`', { send: async () => ({ success: true }) }, '', 'GET'],
+            ['site 4 — an inbox provider with no `markRead`', { listInbox: async () => LIST_BODY }, '/read', 'POST'],
+            ['site 7 — an inbox provider with no `markAllRead`', { listInbox: async () => LIST_BODY }, '/read/all', 'POST'],
+        ])('%s → 501, declared envelope, the slot\'s own remedy sentence', async (_label, service, path, method) => {
+            const dispatcher = makeDispatcher(service as Record<string, unknown> | null);
+
+            const result = await dispatcher.handleNotification(path, method, { ids: ['n1'] }, {}, CTX);
+
+            expect(result.handled).toBe(true);
+            expect(result.response?.status).toBe(501);
+            expectEnvelope(result.response?.body, false);
+            // The message is the SAME sentence discovery reports for this slot,
+            // by construction (`serviceUnavailableMessage`) — so the 501 body and
+            // the discovery entry cannot name different remedies.
+            expect(result.response?.body?.error?.message).toBe(serviceUnavailableMessage('notification'));
+        });
+    });
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Emit site 2 — the auth gate
+    // ═══════════════════════════════════════════════════════════════════════
+    it('emit site 2 — an unauthenticated caller gets 401 in the declared envelope', async () => {
+        const result = await makeDispatcher().handleNotification('', 'GET', undefined, {}, ANON_CTX);
+
+        expect(result.handled).toBe(true);
+        expect(result.response?.status).toBe(401);
+        expectEnvelope(result.response?.body, false);
+        expect(result.response?.body?.error?.message).toBe('Authentication required');
+    });
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Emit site 5 — the request-schema gate (#3899)
+    // ═══════════════════════════════════════════════════════════════════════
+    it('emit site 5 — a malformed mark-read body is a VALIDATION_FAILED throw naming the field', async () => {
+        // `{"notificationIds": [...]}` used to become `markRead(userId, [])` —
+        // a 200 with `readCount: 0` and a badge that never cleared (#3899).
+        const dispatcher = makeDispatcher();
+
+        let thrown: unknown;
+        try {
+            await dispatcher.handleNotification('/read', 'POST', { notificationIds: ['n1'] }, {}, CTX);
+        } catch (e) {
+            thrown = e;
+        }
+
+        const details = validationFailureDetails(thrown);
+        expect(details?.code).toBe('VALIDATION_FAILED');
+        expect(details?.fields.map((f) => f.field)).toContain('ids');
+    });
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // The ninth return: not an emit, and pinned so the count is closed
+    // ═══════════════════════════════════════════════════════════════════════
+    it('an unmatched sub-path is `handled: false` — no body, so nothing to conform', async () => {
+        const result = await makeDispatcher().handleNotification('/unknown', 'GET', undefined, {}, CTX);
+
+        expect(result.handled).toBe(false);
+        expect(result.response).toBeUndefined();
+    });
+});

--- a/packages/services/service-messaging/package.json
+++ b/packages/services/service-messaging/package.json
@@ -24,6 +24,7 @@
     "@objectstack/spec": "workspace:*"
   },
   "devDependencies": {
+    "@objectstack/metadata-core": "workspace:*",
     "@types/node": "^26.1.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"

--- a/packages/services/service-messaging/src/notification-schema-conformance.test.ts
+++ b/packages/services/service-messaging/src/notification-schema-conformance.test.ts
@@ -1,0 +1,344 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// [#5792 / Part of #3877] Stage A, notification family — the PRODUCER half.
+//
+// `/api/v1/notifications` is served by the dispatcher's `/notifications` domain,
+// which forwards `deps.success(result)` untouched. So the body on the wire is
+// authored HERE: `MessagingService.listInbox / markRead / markAllRead` are the
+// only things that decide its shape, and the catalog
+// (`plugin-rest-api.zod.ts`, `DEFAULT_NOTIFICATION_ROUTES`) declares one
+// `responseSchema` per route:
+//
+//   GET  /notifications        → ListNotificationsResponseSchema      → listInbox()
+//   POST /notifications/read   → MarkNotificationsReadResponseSchema  → markRead()
+//   POST /notifications/read/all → MarkAllNotificationsReadResponseSchema → markAllRead()
+//
+// Until this file nothing had ever put an emitted body and its declaring schema
+// in the same assertion — every existing inbox test compares the result against
+// a hand-written literal, which proves the code does what the test author
+// believed, never what the contract declares (#3877's founding observation).
+//
+// ## The two assertions, and why one is not enough (#5682's lesson)
+//
+// Each route gets TWO deliberately different questions:
+//
+//   * `Schema.safeParse()` judges VALUES — required keys present, `createdAt`
+//     a real ISO-8601 instant, `read` a boolean, `unreadCount` a number.
+//   * the key-set subset check judges KEYS — nothing emitted that the protocol
+//     never declared. `safeParse` is BLIND to this: a zod object strips unknown
+//     keys by default, so a producer that grows an extra key parses clean
+//     forever. That is exactly how `features` / `endpoints` survived on the
+//     discovery surface until #4828.
+//
+// The allowed key set is derived from the schema's own `shape` — never a
+// hand-written array — so this gate cannot become a third dialect of the
+// contract (#5682, and the maintainer's 2026-08-06 ruling point 3).
+//
+// ## Extended one level down, not recursed
+//
+// `notifications[]` rows are checked against `NotificationSchema` the same way.
+// That is where this family's whole payload lives — a top-level-only gate would
+// see two keys and nothing else, i.e. it would be nearly vacuous. Same call
+// #5679 made for `routes`: extend to the level with a measured producer, do not
+// recurse into open `z.record`s.
+//
+// ## Why the fixture is written by the REAL inbox channel
+//
+// `listInbox` maps stored rows, so a hand-written row fixture would let the test
+// author invent the input as well as expect the output. The seed here is
+// produced by driving the real single ingress (`emit()`) through the real
+// `inbox` channel (`createInboxChannel`) into an in-memory engine, so only the
+// STORAGE is a double. The row shape under test is the one `sys_inbox_message`
+// actually receives in production.
+
+import { describe, it, expect } from 'vitest';
+import { assertEngineUpdateDispatch } from '@objectstack/metadata-core';
+import {
+    ListNotificationsResponseSchema,
+    MarkNotificationsReadResponseSchema,
+    MarkAllNotificationsReadResponseSchema,
+    NotificationSchema,
+} from '@objectstack/spec/api';
+import { MessagingService } from './messaging-service.js';
+import { createInboxChannel } from './inbox-channel.js';
+
+const USER = 'usr_conformance';
+
+/** Declared top-level keys of the list response — derived, never hand-listed. */
+function declaredListKeys(): Set<string> {
+    return new Set(Object.keys((ListNotificationsResponseSchema as any).shape));
+}
+
+/** Declared keys of ONE inbox row (`notifications[]`) — the level down. */
+function declaredNotificationKeys(): Set<string> {
+    return new Set(Object.keys((NotificationSchema as any).shape));
+}
+
+/** Declared keys of the mark-read responses (both routes share the shape). */
+function declaredMarkReadKeys(): Set<string> {
+    return new Set(Object.keys((MarkNotificationsReadResponseSchema as any).shape));
+}
+
+function declaredMarkAllReadKeys(): Set<string> {
+    return new Set(Object.keys((MarkAllNotificationsReadResponseSchema as any).shape));
+}
+
+const silentLogger = () => ({
+    debug() {}, info() {}, warn() {}, error() {},
+}) as any;
+
+/**
+ * In-memory stand-in for the data engine, supporting the flat-equality `where`
+ * filters the inbox read API issues plus the receipt upsert. The STORAGE is the
+ * only fake here.
+ *
+ * `update` opens with `assertEngineUpdateDispatch(data, options)` — the
+ * PRODUCER's own dispatch predicate (`@objectstack/metadata-core`), not a
+ * hand-mirrored `if`. `check:engine-double-contract` requires it, and the
+ * reason is this file's whole subject one layer down: a double looser than the
+ * real engine accepts calls a real server refuses, and the suite stays green
+ * over a route that is dead in production (#4434 / #5197). Declared members are
+ * exactly the ones the inbox read path calls — a fake verb nothing exercises is
+ * a second contract nobody checks.
+ */
+function inboxEngine() {
+    const store: Record<string, any[]> = {};
+    let seq = 0;
+    const matches = (row: any, where: any = {}) =>
+        Object.entries(where).every(([k, v]) => String(row[k]) === String(v));
+    return {
+        store,
+        async find(object: string, query: any = {}) {
+            let rows = (store[object] ?? []).filter((r) => matches(r, query.where));
+            const ob = Array.isArray(query.orderBy) ? query.orderBy : [];
+            if (ob.some((o: any) => o.field === 'created_at' && o.order === 'desc')) {
+                rows = [...rows].sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)));
+            }
+            return typeof query.limit === 'number' ? rows.slice(0, query.limit) : rows;
+        },
+        async findOne(object: string, query: any = {}) {
+            return (store[object] ?? []).find((r) => matches(r, query.where)) ?? null;
+        },
+        async insert(object: string, row: any) {
+            const created = { id: `row_${++seq}`, ...row };
+            (store[object] ??= []).push(created);
+            return created;
+        },
+        async update(object: string, data: any, options: any = {}) {
+            assertEngineUpdateDispatch(data, options);
+            for (const r of store[object] ?? []) {
+                if (matches(r, options.where)) Object.assign(r, data);
+            }
+            return {};
+        },
+    } as any;
+}
+
+/**
+ * A service whose inbox rows were written by the REAL `inbox` channel through
+ * the REAL `emit()` ingress. Two notifications: one carrying an `actionUrl`,
+ * one without — so the optional key is exercised in both states.
+ */
+async function seededService() {
+    const engine = inboxEngine();
+    const service = new MessagingService({ logger: silentLogger(), getData: () => engine });
+    service.registerChannel(createInboxChannel({ getData: () => engine }));
+
+    await service.emit({
+        topic: 'deal.won',
+        audience: [USER],
+        payload: { title: 'Deal one', body: 'first', actionUrl: '/records/1' },
+    });
+    await service.emit({
+        topic: 'task.assigned',
+        audience: [USER],
+        payload: { title: 'Task two', body: 'second' },
+    });
+
+    return { service, engine };
+}
+
+describe('[#5792] MessagingService conforms to the schemas the catalog declares', () => {
+    describe('GET /notifications → listInbox() / ListNotificationsResponseSchema', () => {
+        it('satisfies the declared schema (VALUE assertion)', async () => {
+            const { service } = await seededService();
+
+            const body = await service.listInbox(USER);
+
+            const result = ListNotificationsResponseSchema.safeParse(body);
+            expect(
+                result.success ? [] : result.error.issues.map((i) => `${i.path.join('.')}: ${i.code}`),
+                'listInbox() must satisfy ListNotificationsResponseSchema',
+            ).toEqual([]);
+        });
+
+        it('emits NO top-level key the protocol does not declare (KEY assertion)', async () => {
+            const { service } = await seededService();
+
+            const body = await service.listInbox(USER);
+
+            const declared = declaredListKeys();
+            const undeclared = Object.keys(body).filter((k) => !declared.has(k));
+            expect(undeclared, 'undeclared top-level keys on the listInbox() body').toEqual([]);
+        });
+
+        it('emits NO `notifications[]` key the protocol does not declare (KEY assertion, one level down)', async () => {
+            const { service } = await seededService();
+
+            const body = await service.listInbox(USER);
+
+            const declared = declaredNotificationKeys();
+            const undeclared = [
+                ...new Set(body.notifications.flatMap((n) => Object.keys(n).filter((k) => !declared.has(k)))),
+            ];
+            expect(undeclared, 'undeclared keys inside notifications[] on the listInbox() body').toEqual([]);
+        });
+
+        it('anti-vacuity: the fixture really produces rows, so neither assertion passes on an empty list', async () => {
+            const { service } = await seededService();
+
+            const body = await service.listInbox(USER);
+
+            // Without this, both gates above are satisfied by `{notifications: [], unreadCount: 0}`
+            // — the empty-verdict green #5046 warns about.
+            expect(body.notifications).toHaveLength(2);
+            expect(body.unreadCount).toBe(2);
+            expect(body.notifications.every((n) => NotificationSchema.safeParse(n).success)).toBe(true);
+        });
+
+        it('every row carries the REQUIRED keys, with `createdAt` a real ISO-8601 instant', async () => {
+            const { service } = await seededService();
+
+            const body = await service.listInbox(USER);
+
+            for (const row of body.notifications) {
+                // `NotificationSchema.createdAt` is `z.string().datetime()`, which is
+                // stricter than "a string": a SQL-flavoured `2026-01-01 00:00:00`
+                // would parse as a string and fail the datetime refinement. This is
+                // the one value in the family a driver could plausibly hand back in
+                // the wrong dialect, so it is asserted as a value, not a type.
+                expect(typeof row.createdAt, `createdAt on ${row.id}`).toBe('string');
+                expect(
+                    NotificationSchema.safeParse(row).success,
+                    `row ${row.id} does not satisfy NotificationSchema: ${JSON.stringify(row)}`,
+                ).toBe(true);
+                expect(new Date(row.createdAt).toISOString()).toBe(row.createdAt);
+            }
+        });
+
+        it('`actionUrl` is a DECLARED optional — the key is present either way, value `undefined` when absent', async () => {
+            const { service } = await seededService();
+
+            const body = await service.listInbox(USER);
+            const withUrl = body.notifications.find((n) => n.title === 'Deal one')!;
+            const withoutUrl = body.notifications.find((n) => n.title === 'Task two')!;
+
+            expect(withUrl.actionUrl).toBe('/records/1');
+            // The mapper writes `actionUrl: … ?? undefined` unconditionally, so
+            // `Object.keys()` sees the key on BOTH rows while `JSON.stringify`
+            // drops it from the one that is empty. The key gate above reads
+            // `Object.keys()`, i.e. the stricter of the two views — the same
+            // `routes.mcp` nuance #5679 measured on the discovery producer.
+            expect(Object.prototype.hasOwnProperty.call(withoutUrl, 'actionUrl')).toBe(true);
+            expect(withoutUrl.actionUrl).toBeUndefined();
+            expect(declaredNotificationKeys().has('actionUrl')).toBe(true);
+        });
+    });
+
+    describe('POST /notifications/read → markRead() / MarkNotificationsReadResponseSchema', () => {
+        it('satisfies the declared schema (VALUE assertion)', async () => {
+            const { service } = await seededService();
+            const ids = (await service.listInbox(USER)).notifications.map((n) => n.id);
+
+            const body = await service.markRead(USER, [ids[0]]);
+
+            const result = MarkNotificationsReadResponseSchema.safeParse(body);
+            expect(
+                result.success ? [] : result.error.issues.map((i) => `${i.path.join('.')}: ${i.code}`),
+                'markRead() must satisfy MarkNotificationsReadResponseSchema',
+            ).toEqual([]);
+            // Anti-vacuity: a no-op `{success:true, readCount:0}` also parses, so
+            // pin that this call really transitioned a notification.
+            expect(body.readCount).toBe(1);
+        });
+
+        it('emits NO key the protocol does not declare (KEY assertion)', async () => {
+            const { service } = await seededService();
+            const ids = (await service.listInbox(USER)).notifications.map((n) => n.id);
+
+            const body = await service.markRead(USER, [ids[0]]);
+
+            const declared = declaredMarkReadKeys();
+            expect(
+                Object.keys(body).filter((k) => !declared.has(k)),
+                'undeclared keys on the markRead() body',
+            ).toEqual([]);
+        });
+
+        it('the degraded exit (no data engine) is a CONFORMING body too', async () => {
+            // The early return `{ success: true, readCount: 0 }` is its own emit
+            // site; a shape that only conforms on the happy path is not a
+            // conforming route.
+            const noData = new MessagingService({ logger: silentLogger() });
+
+            const body = await noData.markRead(USER, ['n1']);
+
+            expect(MarkNotificationsReadResponseSchema.safeParse(body).success).toBe(true);
+            expect(Object.keys(body).filter((k) => !declaredMarkReadKeys().has(k))).toEqual([]);
+        });
+    });
+
+    describe('POST /notifications/read/all → markAllRead() / MarkAllNotificationsReadResponseSchema', () => {
+        it('satisfies the declared schema (VALUE assertion)', async () => {
+            const { service } = await seededService();
+
+            const body = await service.markAllRead(USER);
+
+            const result = MarkAllNotificationsReadResponseSchema.safeParse(body);
+            expect(
+                result.success ? [] : result.error.issues.map((i) => `${i.path.join('.')}: ${i.code}`),
+                'markAllRead() must satisfy MarkAllNotificationsReadResponseSchema',
+            ).toEqual([]);
+            expect(body.readCount).toBe(2);
+        });
+
+        it('emits NO key the protocol does not declare (KEY assertion)', async () => {
+            const { service } = await seededService();
+
+            const body = await service.markAllRead(USER);
+
+            const declared = declaredMarkAllReadKeys();
+            expect(
+                Object.keys(body).filter((k) => !declared.has(k)),
+                'undeclared keys on the markAllRead() body',
+            ).toEqual([]);
+        });
+
+        it('the empty-inbox exit is a CONFORMING body too', async () => {
+            const { service } = await seededService();
+            await service.markAllRead(USER);
+
+            const body = await service.markAllRead(USER); // nothing left unread
+
+            expect(MarkAllNotificationsReadResponseSchema.safeParse(body).success).toBe(true);
+            expect(body.readCount).toBe(0);
+        });
+    });
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // The two mark-read routes declare SEPARATE schemas for one shape
+    // ═══════════════════════════════════════════════════════════════════════
+    //
+    // #5682 added an equivalence pin because discovery had a lenient response
+    // schema beside a strict producer schema, and either could grow a key alone.
+    // This family has no lenient/strict pair — the catalog's `responseSchema`
+    // IS the producer contract, and no consumer parses a second, looser copy
+    // (`client.notifications.*` types its returns with `z.infer` of these very
+    // schemas and performs no runtime parse). What it DOES have is the other
+    // shape of the same risk: two separately-declared schemas that must stay
+    // identical because ONE producer method (`markAllRead` delegates to
+    // `markRead`) emits both bodies. Pinned for the same reason.
+    it('MarkNotificationsRead and MarkAllNotificationsRead declare the SAME key set', () => {
+        expect(declaredMarkAllReadKeys()).toEqual(declaredMarkReadKeys());
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2245,6 +2245,9 @@ importers:
         specifier: workspace:*
         version: link:../../spec
     devDependencies:
+      '@objectstack/metadata-core':
+        specifier: workspace:*
+        version: link:../../metadata-core
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5792

Part of #3877(Stage A 逐族推进,维护者 2026-08-06 裁决第 1 条:discovery 已落地,下一族 notification)。
照 PR #5682(discovery 族)的成套做法。**纯测试 PR**(外加一条为过门禁必需的 devDependency,见下),
不改任何生产代码。

---

## 1. 前置侦察:这个族到底是什么(实读 `origin/main@881a3cc06`)

### 1.1 「8 条薄 emit 路由」的口径更正 —— 是 8 个 **emit 站点**,不是 8 条路由

#3877 正文 Stage A 表里写 `notification (8)`。实读之后这个 8 **不是路由数**:

| 计法 | 数 | 出处 |
|:--|--:|:--|
| catalog 声明的端点(`DEFAULT_NOTIFICATION_ROUTES`) | **3** | `packages/spec/src/api/plugin-rest-api.zod.ts:1042-1103`(`endpoints` 在 `:1059-1097`) |
| route-ledger 记录的挂载路由 | **3** | `packages/runtime/src/route-ledger.ts:168-170` |
| **该族唯一域文件里的 emit 站点** | **8** | `packages/runtime/src/domains/notifications.ts` |
| #3899 之前 catalog 里的端点数(含 4 条从未建过的幽灵) | 7 | `git show a1b61e01c^` |

`DEFAULT_NOTIFICATION_ROUTES` 曾经声明 devices / preferences 共 4 条**从未被任何服务器挂载**的端点,
#3899(2026-07-31 合并)把它们摘掉了 —— 而 #3877 是 2026-07-28 立的单,**早三天**。所以那个 8
最可能是当时的旧表遗留。

本 PR 按**站点**口径落实「8 条逐条覆盖」,这是今天唯一说得通、也是覆盖面最大的读法:

| # | 行 | emit 站点 | 形状来源 | 本 PR 怎么覆盖 |
|--:|--:|:--|:--|:--|
| 1 | :79 | `capabilityUnavailable(deps,'notification')` — 槽位空 / 自称非 handler / 无 `listInbox` | inline literal | 501 + 声明信封 + `serviceUnavailableMessage('notification')` |
| 2 | :86 | `deps.error('Authentication required', 401)` | inline literal | 401 + 声明信封 |
| 3 | :111 | `deps.success(listInbox 结果)` | forwarded(producer 在 service-messaging) | **双断言** vs `ListNotificationsResponseSchema` |
| 4 | :116 | `capabilityUnavailable` — 无 `markRead` | inline literal | 501 + 声明信封 |
| 5 | :128 | `throw validationFailure(...)` — mark-read body 不合法 | inline literal | `VALIDATION_FAILED` + `fields` 指名 `ids` |
| 6 | :134 | `deps.success(markRead 结果)` | forwarded | **双断言** vs `MarkNotificationsReadResponseSchema` |
| 7 | :139 | `capabilityUnavailable` — 无 `markAllRead` | inline literal | 501 + 声明信封 |
| 8 | :141 | `deps.success(markAllRead 结果)` | forwarded | **双断言** vs `MarkAllNotificationsReadResponseSchema` |
| — | :144 | `return { handled: false }` — 未匹配子路径 | 非 emit | 也钉了一条,把「8」这个数**关上**而不是默认 |

### 1.2 三条路由 / 声明 schema / emit 形状来源

| 路由 | 声明的 `responseSchema` | emit 形状真正的作者 |
|:--|:--|:--|
| `GET /api/v1/notifications` | `ListNotificationsResponseSchema`(行内 `NotificationSchema`) | `MessagingService.listInbox` — `messaging-service.ts:284-333` |
| `POST /api/v1/notifications/read` | `MarkNotificationsReadResponseSchema` | `MessagingService.markRead` — `:344-361` |
| `POST /api/v1/notifications/read/all` | `MarkAllNotificationsReadResponseSchema` | `MessagingService.markAllRead` — `:365-370` |

关键结构事实:`domains/notifications.ts` 对三条成功路径都是 `deps.success(result)` **原样透传**,
所以线上 body 的作者是 `service-messaging`,域层只是通道。这决定了 gate 必须分两处放
—— 只测域层等于只测通道,只测 producer 又看不见通道会不会加键。

### 1.3 模板沿用 / 偏离(#5682)

**沿用**:每条路由两条刻意不同的断言;允许集一律 `Object.keys(Schema.shape)` 推导,⛔ 不手写数组;
按 producer 分文件(#5682 是 metadata-protocol / rest / runtime 三个,本族是
service-messaging / runtime 单元 / runtime 集成三个);向下延伸**一层**不递归(#5679 对
`routes` 的同一判断,这里是 `notifications[]`)。

**偏离,逐条给理由**:

1. **没有等价性钉子,因为本族没有宽严 schema 并存。** #5682 的钉子是因为 discovery 有
   `GetDiscoveryResponseSchema`(宽松 consumer 解析)与 `DiscoverySchema`(严格 producer)两份。
   本族 catalog 的 `responseSchema` **就是** producer 契约,没有第二份宽松副本:
   `client.notifications.*` 用 `z.infer` 取类型、**运行时不 parse**
   (`packages/client/src/index.ts:3675-3712`)。改钉了**同一风险的另一形状**:
   `MarkNotificationsRead` 与 `MarkAllNotificationsRead` 是两份分别声明的 schema,而
   `markAllRead` 委托给 `markRead`,**一个 producer 方法产出两个 body** —— 钉住两者键集相等。
2. **多了一个集成 gate**。有两个事实只有真实 boot 能测:`createdAt` 经真实 SQL 驱动往返后是否
   仍是 ISO-8601(`z.string().datetime()` 比「是个字符串」严),以及 `actionUrl` 的
   **JSON 视图**(`JSON.stringify` 丢弃 `undefined`)与**对象视图**(`Object.keys` 看得见)
   是否都合规 —— 后者正是 #5679 在 `routes.mcp` 上量到的同一处细节。
3. **非成功站点也覆盖**。Stage A 只要求「带 responseSchema 的路由」,但只覆盖 happy path 的
   一致性主张是半个主张,所以 5 个非成功站点按它们**确实**声明的东西(共享信封 + 状态码)钉住。

---

## 2. 违规清单:双断言 **3/3 全绿,两个方向都没有**

本单的心理预期是按 discovery 族的 **2/2 双向**排的。实测**不成立**,如实报告:

| 方向 | 结果 |
|:--|:--|
| 漏发必填键(`schema.parse` 判值) | 0 处 —— 三条路由的 body 都满足声明 schema,`notifications[]` 每行也满足 `NotificationSchema` |
| 多发未声明键(键集 ⊆ 声明键集) | 0 处 —— 顶层与 `notifications[]` 一层下都没有多余键 |

实测证据(真实 boot,sqlite-wasm + ObjectQL + service-messaging + hono + dispatcher,真实 socket):

```
GET /api/v1/notifications
  data keys              ["notifications","unreadCount"]
  declared list keys     ["notifications","unreadCount","cursor"]
  parse                  OK
  row keys               ["id","type","title","body","read","createdAt"]
                         ["id","type","title","body","read","actionUrl","createdAt"]
  declared row keys      ["id","type","title","body","read","data","actionUrl","createdAt"]
  row parse              OK / OK
  createdAt              "2026-08-07T15:02:26.891Z"   (string, 真实驱动往返)

POST /api/v1/notifications/read      → {"success":true,"readCount":1}   parse OK,无未声明键
POST /api/v1/notifications/read/all  → {"success":true,"readCount":1}   parse OK,无未声明键
```

顺带排除的一个假设:`createdAt` 可能被驱动还回 `Date` 或 SQL 方言 —— **不成立**,
`driver-sql` 在读路径上已经统一归一成 `toISOString()`(`sql-driver.ts:225` 起,注释原文
"so reads are uniform and unambiguous")。这条也钉进了集成 gate,不靠推断。

### 2.1 但测量出了两条**双断言结构上看不见**的真实缺口(已另立单,本 PR 不修)

这是本族最有价值的产出,也是给 #3877 Stage D 棘轮设计的直接输入。

| 单 | 缺口 | 为什么两条断言都看不见 |
|:--|:--|:--|
| **#6361**(请求侧) | `ListNotificationsRequestSchema` 在本路由**从不被解析**:`cursor` 声明了但服务端不读,而 `client.notifications.list({cursor})` **确实会发**;`limit` 声明默认 20,服务端实际默认 50 | 请求侧根本不在「响应体一致性」的射程内 |
| **#6363**(响应侧) | `unreadCount` 声明为 "Total number of unread notifications",实际只数 `limit` 窗口内的未读;响应侧声明的 `cursor` 从无 producer 发出 | `unreadCount` 无论对错都是 `number`,**值断言**看不见语义;`cursor` 是 `optional`,「从不发出」是合法解析,**键断言是 ⊆ 而不是 =**,也看不见 |

实测(60 条未读):

```
无 limit  →  rows 50   unreadCount 50      (真值 60;声明说是 total)
limit=10  →  rows 10   unreadCount 10
page1 = ?limit=5                                   ids [Ymk…, N4e…, PsG…, 6xL…, tZx…]
page2 = ?limit=5&cursor=tZx2EQQ4MfeKKfWp            ids [Ymk…, N4e…, PsG…, 6xL…, tZx…]
page2 === page1 ?  true      ← 照 SDK 声明分页的调用者会无限停在第一页
```

**处置:两条都是判断题,⛔ 不猜,本 PR 一条都不修。** #3676 的结论是「删声明」,#3847 的结论是
「改实现」,方向相反;而且 `cursor` 的请求侧与响应侧**必须同向裁决**(分页是一个能力的两半)。
两单里都按三轴(真实业务需求 / 长远合理性 / 防 AI 犯错)逐条列了证据和建议,请维护者定。

一条对判断有用的实测:`GET /api/v1/notifications` 的**实测消费者只有 SDK**。objectui 的通知铃
**不走这条路由** —— 它直接 `dataSource.find('sys_inbox_message', …)`、自己 join 回执、自己算未读
(`objectui/packages/app-shell/src/layout/AppHeader.tsx:354/391/496`),只用本族的两条 mark-read POST。

本 PR 对这两条缺口的处理是**如实钉住现状、标明「recorded, not endorsed」并写上单号**
(#6348 对 ETag 代价的同一做法):裁决一旦落地,该翻的就是这几条断言 —— 这正是钉它们而不是
留给下一个人重新发现的意义。

### 2.2 #5679 的嵌套键盲区:本族无同形状

`notifications[]` 这一层本 PR **是查了**的(否则顶层只有两个键,gate 近乎空转),结果为 0。
再往下 `data` 是 `z.record`,按 #5679/#4828 的既定判断属于开放键,不递归。

---

## 3. 三个文件,分别证明什么

| 文件 | 驱动的真实对象 | 唯一的 double |
|:--|:--|:--|
| `packages/services/service-messaging/src/notification-schema-conformance.test.ts` | REAL `MessagingService`;fixture 由 REAL `createInboxChannel` 经 REAL `emit()` 写入 | 存储引擎 |
| `packages/runtime/src/notification-schema-conformance.test.ts` | REAL `HttpDispatcher.handleNotification` + REAL `domainDeps`(真信封构造器) | notification 槽位的 provider |
| `packages/runtime/src/notification-schema-conformance.integration.test.ts` | 全真:sqlite-wasm + ObjectQL + service-messaging + hono + dispatcher,真实 socket | 只有 auth |

producer gate 的 fixture 刻意**不手写行**:行由真实的 inbox channel 写进存储,再由真实的
`listInbox` 读出来 —— 否则测试作者既发明了输入又期待了输出。

---

## 4. 反向验证(**先预测方向,再跑**)

这个族没有可以「把删掉的肢体装回去」的缺陷,所以反向验证是**注入**式的,而且刻意做了
**两个相反方向**,因为这一族要证明的正是「两条断言各自看得见对方看不见的东西」。

### 实验一 —— 多发一个未声明键

**预测**:**键**断言转红,**每一条 `safeParse` 值断言保持绿**(zod object 默认 strip 未知键)。
这个不对称正是第二条断言存在的全部理由;如果值断言也红了,反倒说明我误解了 zod 的行为。

在 producer 的行映射器上临时加 `severity: (m.severity as string) ?? 'info'`:

```
producer gate:   1 failed | 12 passed
  × emits NO `notifications[]` key the protocol does not declare (KEY assertion, one level down)
    AssertionError: undeclared keys inside notifications[] on the listInbox() body:
      expected [ 'severity' ] to deeply equal []

wire gate:       1 failed | 6 passed
  × emits NO key the protocol does not declare, at the top level and one level down (KEY assertion)
    AssertionError: undeclared keys inside notifications[] on the wire body:
      expected [ 'severity' ] to deeply equal []
```

方向与逐条身份都吻合:**只有键断言红,所有值断言绿**。

### 实验二 —— 漏发一个必填键(相反方向)

**预测**:**值**断言转红(`invalid_type`),**键**断言保持**绿** —— ⊆ 检查对「缺失」结构上是瞎的。

临时删掉行映射器里的 `type: (m.topic as string) ?? 'notification'`:

```
producer gate:   3 failed | 10 passed
  × satisfies the declared schema (VALUE assertion)
      expected []  received [ "notifications.0.type: invalid_type",
                              "notifications.1.type: invalid_type" ]
  × every row carries the REQUIRED keys, with `createdAt` a real ISO-8601 instant
      row row_4 does not satisfy NotificationSchema:
      {"id":"row_4","title":"Task two","body":"second","read":false,"createdAt":"2026-08-07T15:16:39.032Z"}
  × anti-vacuity: the fixture really produces rows …
```

两条**键**断言("emits NO top-level key…" / "emits NO `notifications[]` key…")**保持绿**,
与预测一致。两个实验合起来正是维护者裁决第 3 条要求的那件事:任一条断言单独都不够。

两个实验都已还原,复跑全绿(见验证段)。

### 一个顺带量到的 harness 事实,写下来免得下一个人误判

实验一第一次跑时**集成 gate 是绿的**,不是因为它不敏感,而是因为 `packages/runtime` 的 vitest
没有给 `@objectstack/service-messaging` 配 src alias,它读的是**已构建的 dist** —— 我改的是 src。
`pnpm --filter @objectstack/service-messaging build` 之后立刻转红(上面那份输出)。
CI 不受影响:`turbo.json` 里 `test` 的 `dependsOn: ["^build"]`,依赖恒为新构建。
不加 alias 是刻意的 —— 既有的 `notifications.hono.integration.test.ts` 一直是这个解析方式,
加 alias 会顺带改变它,属越界。

---

## 5. 一条非测试改动:`service-messaging` 新增 `@objectstack/metadata-core` devDependency

`check:engine-double-contract` 要求 fake engine 的 `update()` 以生产者自己的
`assertEngineUpdateDispatch(data, options)` 开场,而 `service-messaging` 此前没有这条依赖。
本地实测:不加则该门禁 **exit 1**(2 处 PINNED);加上并改写后 **OK — 80 pinned, 133 DEBT, 4 exempt**。

- 选 `metadata-core` 而非 `objectql`:谓词自 #5619 起就住在这里,依赖面更小;
  五个兄弟 service 包已有先例(`service-package` 用 metadata-core,
  `service-automation` / `service-knowledge` / `service-queue` / `service-storage` 用 objectql)。
- `pnpm-lock.yaml` 的 diff 是 **3 行**,只在 importers 段加了一个 workspace link,别无他物。
  这是为过门禁**必需**的最小改动;另一条路(往 shrink-only 的 baseline 里加豁免)会把棘轮**放宽**,更差。
- 同时把 double 收敛成「只声明 inbox 读路径真正调用的成员」,删掉了没人跑的 `delete`/`count`/`aggregate`
  —— 没人跑的假动作就是没人检查的第二份契约。

`devDependencies` 不随包发布(`files: ["dist", …]`),对使用者零影响。
CI 的 `Validate Package Dependencies` 已 **success**。

---

## 6. 验证

```
pnpm --filter @objectstack/service-messaging test    → Test Files 16 passed, Tests 175 passed
pnpm --filter @objectstack/runtime test              → Test Files 110 passed, Tests 1603 passed
pnpm --filter @objectstack/{runtime,service-messaging} typecheck → 两个包 Done,无错
npx eslint --no-inline-config 3 个新文件              → 无输出,exit 0
node scripts/check-nul-bytes.mjs                     → OK(6005 个文件,无裸控制字节)
grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]' 3 个新文件 → 无命中
check:engine-double-contract                         → OK — 80 pinned, 133 DEBT, 4 exempt
check:route-envelope / error-code-casing / empty-changeset /
  type-check-coverage / published-files / override-consistency /
  slot-lookup / service-providers / authz-resolver /
  wildcard-fallthrough / query-options-erasure / spec-parsed-alias → 全部 PASS
node scripts/check-changeset-fixed.mjs               → ✓ 与 69 个 public 包同步
pnpm --filter @objectstack/spec check:generated      → All 10 generated artifacts up to date
```

rebase 到 `origin/main@881a3cc06` 之后重跑(§9:`pnpm install --frozen-lockfile` + 重建依赖 +
`rm -rf packages/runtime/.objectstack`)。进入的 8 个提交里 `packages/runtime/src/standalone-stack.ts`
与 `packages/objectql/src/engine.ts` 有改动,与本 PR 的 diff(notification 域 + service-messaging)无重叠;
`packages/spec` 那侧动的是 `bulk-action.zod.ts` / `flow.zod.ts`,不是本族的 schema。

**changeset:无,且这是刻意的。** 纯测试 + 一条不发布的 devDependency,不释放任何东西。
因此 `Check Changeset` 现在是红的,**需要 `skip-changeset` 标签**才会转绿 —— 按本次派工要求,
本 agent 不自贴任何标签,请 PM 落标(读回现有标签后写并集:`size/l` + `dependencies` + `tests` + `skip-changeset`)。

---

## 7. 回报 #3877(PM 验收后转发)

**notification 族违规率:双断言 0/3,两个方向都没有。**

- 排期意义上这是好消息:本族不需要任何破坏性线上变更,#3877 风险 1(「20% 率 ⇒ ~30 个破坏性变更」)
  在这一族**不成立**。样本至此:i18n **4/5**、discovery **2/2**、notification **0/3** ——
  三个样本方差极大,建议后续族(analytics / automation 已声明路由)**不要再预设违规率**,
  按「小步买信息」逐族实测。
- **但本族测出的最有价值的东西不是那个 0**:测量中发现两条真实的 declared-vs-delivered 缺口
  (#6361 / #6363),而**双断言结构上两条都看不见**:
  - 值断言看不见**语义**漂移 —— `unreadCount` 声明「总未读」实际「窗口内未读」,两种实现都是 `number`;
  - 键断言是 **⊆ 而不是 =**,所以看不见**声明了却从没被任何 producer 发出**的可选键(`cursor`)。
- **对 Stage D 棘轮的具体建议**:维护者 2026-08-06 裁决第 3 条定的两问(值 + 键)建议**补第三问**——
  「**每个声明的键都要有 producer 交付,或显式记为不交付**」。它的对象正是 #3676 那一类
  (声明了服务器不读 / 不发的东西),也是本族仅有的两条真实缺陷所在。代价可控:它只需要在
  已有 gate 上加一次「declared − emitted」的差集,并允许一份带理由的豁免表。
- 一条实施经验:本族三条成功路由是**透传**(域层 `deps.success(result)`,body 的作者在
  service 包),与 discovery 的「域层自己拼 body」不同。透传族要把 gate 放**两处**——
  只测域层等于只测通道,只测 producer 又看不见通道加键。后续 analytics / automation
  的已声明路由属同一形状,建议照此分文件。

---

_Generated by [Claude Code](https://claude.ai/code/session_01Wbxm29qPKnLf44AbSxizqW)_