### PR TITLE
fix(lint): validateFormLayout 走视图容器阶梯,两条规则不再对真实 app 全盘报绿 (#6251)

### DIFF
--- a/.changeset/form-layout-view-container-ladder.md
+++ b/.changeset/form-layout-view-container-ladder.md
@@ -1,0 +1,55 @@
+---
+"@objectstack/lint": patch
+---
+
+fix(lint): `validateFormLayout` walks the view CONTAINER ladder, so both its rules stop reporting clean on every real app (#6251)
+
+`form-field-unknown` and `absolute-colspan-discouraged` read a `sections` array
+off the **`views[]` entry itself** and skipped everything else. But a `views[]`
+entry is a view CONTAINER, not a view: `ViewSchema` declares exactly `name` /
+`label` / `object` / `list` / `form` / `listViews` / `formViews`, and form
+sections live one level down, under `form` and each `formViews.<key>`. So the
+one shape the traversal read is the one shape strict `ViewSchema` **refuses** —
+measured, `unrecognized_keys` naming `sections` — and the shapes every app
+actually ships were never inspected at all.
+
+Measured on the three shipped example apps, before and after: `app-showcase`,
+`app-crm` and `app-todo` carry **0** form sites at the entry root and **14**
+under `form` / `formViews.<key>`. The old traversal therefore had nothing to
+read on any of them, and reported clean for that reason — the "ghost check"
+shape (#4984 / #5009): a rule that is green because it never read anything is
+worse than no rule, because it occupies the slot that would otherwise look
+empty.
+
+One broken form, three placements, before → after:
+
+| placement | before | after |
+| --- | --- | --- |
+| `views[0].sections` (entry IS a bare form view) | reports | reports |
+| `views[0].form.sections` (container default form) | silent | reports |
+| `views[0].formViews.edit.sections` (named form view) | silent | reports |
+
+What changed, precisely:
+
+- The traversal is the one `validate-visibility-predicates.ts` landed in #6248
+  for the identical hole on the sibling rule — copied, not re-derived, so two
+  rules on one surface cannot drift apart about which forms exist. `list` /
+  `listViews.<key>` are `ObjectListViewSchema` and carry no `sections`, so they
+  are deliberately not walked; `objects[].views` stays out because
+  `object.zod.ts` tombstones that key by name.
+- The legacy `groups` bucket (`FormSectionSchema[]`, the documented alias of
+  `sections`) is read too. Measured: it is **not** folded into `sections` at
+  parse, so a `groups`-authored form was a second silent shape.
+- A finding names its sub-container — `view "contact_views" · formViews.create`
+  — because an artifact-emitted container carries neither `name` nor `object`,
+  and without it two forms under one view were indistinguishable.
+- A sub-container inherits the container's object binding when it declares no
+  `data.object` of its own, resolved through the same `objectName` → `object` →
+  `data.object` ladder the other view-walking rules in this package use.
+- A map-shaped `views` reports at the key it sits at (`views.contact_views.…`)
+  rather than a synthetic index, so a finding stays usable as an edit target.
+
+Both rules remain advisory `warning`s and their messages, hints and severities
+are unchanged. No new finding appeared on any example app, so nothing that was
+green goes red on existing metadata — what changes is that a form defect in the
+places apps actually put forms is now reported instead of silently passed.

--- a/packages/lint/src/validate-form-layout.test.ts
+++ b/packages/lint/src/validate-form-layout.test.ts
@@ -6,7 +6,7 @@ import {
   validateFormLayout,
   FORM_FIELD_UNKNOWN,
   FORM_COLSPAN_ABSOLUTE,
-} from './validate-form-layout';
+} from './validate-form-layout.js';
 
 type AnyRec = Record<string, unknown>;
 

--- a/packages/lint/src/validate-form-layout.test.ts
+++ b/packages/lint/src/validate-form-layout.test.ts
@@ -315,6 +315,12 @@ describe('#6251 — reachable on a REAL parsed app stack', () => {
     ]);
   });
 
+  // EMPTY-GREEN, declared. Revert the container ladder and this test still
+  // passes — because nothing was read, not because nothing is wrong. It is kept
+  // (a false-positive guard is worth having) but it is only meaningful PAIRED
+  // with the test above, which proves on the same fixture family that the
+  // traversal does read these sites. If that one is ever weakened, this one
+  // stops guarding anything; do not treat it as independent cover.
   it('a CLEAN app stack of the same shape reports nothing — the fix adds no false positives', () => {
     const clean = structuredClone(appShape);
     const view = (clean.views as AnyRec[])[0];

--- a/packages/lint/src/validate-form-layout.test.ts
+++ b/packages/lint/src/validate-form-layout.test.ts
@@ -1,11 +1,14 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { defineStack, normalizeStackInput } from '@objectstack/spec';
 import {
   validateFormLayout,
   FORM_FIELD_UNKNOWN,
   FORM_COLSPAN_ABSOLUTE,
 } from './validate-form-layout';
+
+type AnyRec = Record<string, unknown>;
 
 const objects = [
   { name: 'contract', fields: { name: {}, amount: {}, status: {}, notes: {} } },
@@ -110,5 +113,218 @@ describe('validateFormLayout (#2578)', () => {
   it('tolerates an empty / shapeless stack', () => {
     expect(validateFormLayout({})).toEqual([]);
     expect(validateFormLayout({ views: [], objects: [] })).toEqual([]);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// #6251 — `views[]` is a view CONTAINER, and both rules above were unreachable
+// on the shape real apps actually ship.
+//
+// The measurement that opened the issue: one broken form, three placements.
+// Only the placement the strict schema REFUSES was being read, so an app whose
+// forms all live under `form` / `formViews.<key>` — i.e. every app — got a
+// clean report from a rule that had read nothing at all. That is the ghost
+// check #4984 / #5009 name: green because nothing was inspected.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** The one broken form, reused verbatim in every placement below. */
+const brokenForm = {
+  data: { provider: 'object', object: 'contract' },
+  sections: [{ columns: 2, fields: ['name', 'ghost_field'] }],
+};
+
+describe('#6251 — the view CONTAINER ladder', () => {
+  it('reports the SAME broken form in all three placements', () => {
+    const at = (view: AnyRec) =>
+      validateFormLayout({ objects, views: [view] }).map((f) => `${f.rule}@${f.path}`);
+
+    // (1) the entry IS a bare form view — the only shape read before #6251.
+    expect(at({ name: 'contract_form', ...brokenForm })).toEqual([
+      `${FORM_FIELD_UNKNOWN}@views[0].sections[0].fields[1]`,
+    ]);
+    // (2) the container's DEFAULT form.
+    expect(at({ name: 'contract_views', object: 'contract', form: brokenForm })).toEqual([
+      `${FORM_FIELD_UNKNOWN}@views[0].form.sections[0].fields[1]`,
+    ]);
+    // (3) a NAMED form view — where `os build` on app-showcase actually puts them.
+    expect(at({ name: 'contract_views', object: 'contract', formViews: { edit: brokenForm } })).toEqual([
+      `${FORM_FIELD_UNKNOWN}@views[0].formViews.edit.sections[0].fields[1]`,
+    ]);
+  });
+
+  it('names the sub-container in `where`, so two forms under one view are distinguishable', () => {
+    const findings = validateFormLayout({
+      objects,
+      views: [{
+        name: 'contract_views',
+        object: 'contract',
+        form: brokenForm,
+        formViews: { edit: brokenForm, create: brokenForm },
+      }],
+    });
+    expect(findings.map((f) => f.where)).toEqual([
+      'view "contract_views" · form',
+      'view "contract_views" · formViews.edit',
+      'view "contract_views" · formViews.create',
+    ]);
+  });
+
+  it('a sub-container INHERITS the container binding when it declares none', () => {
+    // The canonical container carries `object`; a `formViews.<key>` entry that
+    // omits its own `data.object` still renders against that object, so a
+    // dangling field reference there is as real as anywhere else.
+    const findings = validateFormLayout({
+      objects,
+      views: [{
+        name: 'contract_views',
+        object: 'contract',
+        formViews: { edit: { sections: [{ fields: ['ghost_inherited'] }] } },
+      }],
+    });
+    expect(findings.map((f) => f.rule)).toEqual([FORM_FIELD_UNKNOWN]);
+    expect(findings[0].message).toContain('ghost_inherited');
+    expect(findings[0].message).toContain('"contract"');
+  });
+
+  it('reads the legacy `groups` bucket too — measured NOT folded into `sections` at parse', () => {
+    const findings = validateFormLayout({
+      objects,
+      views: [{
+        name: 'contract_views',
+        object: 'contract',
+        form: { data: { object: 'contract' }, groups: [{ fields: ['name', { field: 'ghost_g', colSpan: 3 }] }] },
+      }],
+    });
+    expect(findings.map((f) => `${f.rule}@${f.path}`)).toEqual([
+      `${FORM_FIELD_UNKNOWN}@views[0].form.groups[0].fields[1]`,
+      `${FORM_COLSPAN_ABSOLUTE}@views[0].form.groups[0].fields[1].colSpan`,
+    ]);
+  });
+
+  it('reports a map-shaped `views` at the key it sits at, not a synthetic index', () => {
+    const findings = validateFormLayout({
+      objects,
+      views: { contract_views: { object: 'contract', formViews: { edit: brokenForm } } },
+    });
+    expect(findings.map((f) => f.path)).toEqual(['views.contract_views.formViews.edit.sections[0].fields[1]']);
+  });
+
+  // NEGATIVE polarity — this one cannot go red when the traversal is reverted
+  // (a narrower walk trivially satisfies "does not walk list views"). It is
+  // here to pin the SCHEMA fact, not the fix: `list` / `listViews.<key>` are
+  // `ObjectListViewSchema`, which declares no `sections`, so a `sections` key
+  // there is not a form and must not be judged as one.
+  it('does not walk `list` / `listViews.*` (they carry no sections by schema)', () => {
+    expect(validateFormLayout({
+      objects,
+      views: [{ name: 'contract_views', object: 'contract', list: brokenForm, listViews: { all: brokenForm } }],
+    })).toEqual([]);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// The anti-ghost pin: the rule must fire on a stack built through the REAL
+// authoring door, not only on a hand-shaped object literal.
+//
+// `cliTierFor` is exactly what `os validate` / `os compile` hand the registry:
+// `defineStack` (which Zod-PARSES) followed by `normalizeStackInput`. So a
+// fixture that survives it is a shape an author can really ship — and a rule
+// that reports on it is really reachable. Without this, "the fix works" could
+// still mean "the fix works on shapes the schema refuses", which is how this
+// rule was silently dead for four minor versions.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** `defineStack` warns on the D2 conversion channel; keep test output clean. */
+function quietly<T>(fn: () => T): { value?: T; error?: Error } {
+  const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    return { value: fn() };
+  } catch (e) {
+    return { error: e as Error };
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+const cliTierFor = (stack: AnyRec): AnyRec =>
+  normalizeStackInput(defineStack(stack as never) as unknown as AnyRec);
+
+describe('#6251 — reachable on a REAL parsed app stack', () => {
+  const manifest = {
+    id: 'com.example.formlayout',
+    namespace: 'fl',
+    version: '1.0.0',
+    type: 'app',
+    name: 'Form Layout Probe',
+    engines: { protocol: '^17' },
+  };
+
+  const data = { provider: 'object' as const, object: 'fl_contact' };
+
+  /**
+   * The container ladder copied from `examples/app-showcase/src/ui/views/
+   * contact.view.ts` — default `form` grouped into sections, plus a sparse
+   * `formViews.create` override — with one dangling field planted in each.
+   */
+  const appShape: AnyRec = {
+    manifest,
+    objects: [{
+      name: 'fl_contact',
+      label: 'Contact',
+      fields: {
+        name: { type: 'text', label: 'Name' },
+        email: { type: 'email', label: 'Email' },
+        phone: { type: 'phone', label: 'Phone' },
+      },
+    }],
+    views: [{
+      name: 'fl_contact',
+      object: 'fl_contact',
+      list: { label: 'Contacts', type: 'grid', data, columns: [{ field: 'name' }] },
+      form: {
+        type: 'simple',
+        data,
+        sections: [{ name: 'contact', label: 'Contact', columns: 2, fields: ['name', 'email', 'ghost_default'] }],
+      },
+      formViews: {
+        create: {
+          type: 'simple',
+          data,
+          title: 'New contact',
+          sections: [{ label: 'Who is this?', columns: 1, fields: ['name', { field: 'ghost_named', colSpan: 2 }] }],
+        },
+      },
+    }],
+  };
+
+  it('the fixture is a shape the strict schema ACCEPTS (so the pin is not testing a rejected stack)', () => {
+    const { error, value } = quietly(() => cliTierFor(structuredClone(appShape)));
+    expect(error).toBeUndefined();
+    // And it really is the container shape: no `sections` at the entry root.
+    const view = (value!.views as AnyRec[])[0];
+    expect(Object.keys(view).sort()).toEqual(['form', 'formViews', 'list', 'name', 'object']);
+    expect(view.sections).toBeUndefined();
+  });
+
+  it('reports every planted defect on that stack — this is the assertion #6251 exists for', () => {
+    const { value } = quietly(() => cliTierFor(structuredClone(appShape)));
+    expect(validateFormLayout(value!).map((f) => `${f.rule}@${f.path}`)).toEqual([
+      `${FORM_FIELD_UNKNOWN}@views[0].form.sections[0].fields[2]`,
+      `${FORM_FIELD_UNKNOWN}@views[0].formViews.create.sections[0].fields[1]`,
+      `${FORM_COLSPAN_ABSOLUTE}@views[0].formViews.create.sections[0].fields[1].colSpan`,
+    ]);
+  });
+
+  it('a CLEAN app stack of the same shape reports nothing — the fix adds no false positives', () => {
+    const clean = structuredClone(appShape);
+    const view = (clean.views as AnyRec[])[0];
+    (view.form as AnyRec).sections = [{ name: 'contact', label: 'Contact', columns: 2, fields: ['name', 'email', 'phone'] }];
+    (view.formViews as AnyRec).create = {
+      type: 'simple', data, title: 'New contact',
+      sections: [{ label: 'Who is this?', columns: 1, fields: ['name', { field: 'email', span: 'full' }] }],
+    };
+    const { error, value } = quietly(() => cliTierFor(clean));
+    expect(error).toBeUndefined();
+    expect(validateFormLayout(value!)).toEqual([]);
   });
 });

--- a/packages/lint/src/validate-form-layout.ts
+++ b/packages/lint/src/validate-form-layout.ts
@@ -20,9 +20,13 @@
  *   span only lines up at the one width the author imagined; the renderer
  *   clamps it. The robust primitive is the relative `span: 'full'`.
  *
- * Scope: top-level form `views` (a `sections` array). Forms embedded inside
- * page component trees are a follow-up — the walker deliberately stays shallow
- * so it never guesses at an arbitrary component's object binding.
+ * Scope: every form view reachable from a `views[]` entry — the entry itself
+ * when it IS a bare form view, plus the container's default `form` and each
+ * `formViews.<key>` (see {@link formViewSites} for why reading only the first
+ * shape left both rules reporting clean on real app metadata, #6251). Forms
+ * embedded inside page component trees are a follow-up — the walker
+ * deliberately stays shallow so it never guesses at an arbitrary component's
+ * object binding.
  */
 
 export const FORM_FIELD_UNKNOWN = 'form-field-unknown';
@@ -35,9 +39,9 @@ export interface FormLayoutFinding {
   severity: FormLayoutSeverity;
   /** Diagnostic rule id, e.g. `form-field-unknown`. */
   rule: string;
-  /** Human-readable location, e.g. `view "contract_form"`. */
+  /** Human-readable location, e.g. `view "contract_form" · formViews.create`. */
   where: string;
-  /** Config path, e.g. `views[2].sections[0].fields[3]`. */
+  /** Config path, e.g. `views[2].formViews.create.sections[0].fields[3]`. */
   path: string;
   /** What is wrong. */
   message: string;
@@ -56,6 +60,110 @@ function asArray(v: unknown): AnyRec[] {
   return [];
 }
 
+function isRec(v: unknown): v is AnyRec {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function strName(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+/**
+ * Every record in a collection authored either as an array or as a name-keyed
+ * map, each with its config PATH — `views[2]` for the array shape,
+ * `views.contact_views` for the map. Findings here are consumed as edit targets
+ * (`os lint --json`, Studio's finding renderer), so a map-shaped collection must
+ * not report a synthetic index nobody can look up. Same helper, same reasoning
+ * as `validate-visibility-predicates.ts` and `validate-translatable-sections.ts`.
+ */
+function collectionEntries(v: unknown, base: string): Array<{ rec: AnyRec; path: string }> {
+  if (Array.isArray(v)) {
+    const out: Array<{ rec: AnyRec; path: string }> = [];
+    for (let i = 0; i < v.length; i++) {
+      if (isRec(v[i])) out.push({ rec: v[i] as AnyRec, path: `${base}[${i}]` });
+    }
+    return out;
+  }
+  if (isRec(v)) {
+    return Object.entries(v)
+      .filter(([, def]) => isRec(def))
+      .map(([name, def]) => ({ rec: { name, ...(def as AnyRec) }, path: `${base}.${name}` }));
+  }
+  return [];
+}
+
+/**
+ * Every FORM VIEW reachable from one `views[]` entry, with the path each sits at.
+ *
+ * **Copied from `validate-visibility-predicates.ts`'s `formViewSites` (#6248)**
+ * rather than re-derived: that file fixed this exact traversal hole on the
+ * sibling rule one PR earlier, and a second hand-rolled ladder is how two rules
+ * on one surface start disagreeing about which forms exist. The only thing added
+ * here is the object binding each site inherits (below) — this rule resolves a
+ * field reference, the visibility rules do not.
+ *
+ * Two shapes, and reading only the first is how BOTH rules in this file were
+ * dead on real app metadata until #6251 measured it. `os build` on
+ * `examples/app-showcase` emits its form sections at
+ * `views[0].formViews.edit.sections[…]`; the traversal read `views[0].sections`,
+ * found nothing, and reported clean on a stack that DOES carry form sections:
+ *
+ *  - **View CONTAINER** (the runtime app shape). `ViewSchema` declares exactly
+ *    `name` / `label` / `object` / `list` / `form` / `listViews` / `formViews`
+ *    (`view.zod.ts:1890-1903` — the strict error map spells the container's own
+ *    keys out in prose). Form sections therefore live one level down, under
+ *    `form` and each `formViews.<key>`.
+ *  - **A bare FORM VIEW** (`FormViewSchema`, `view.zod.ts:1623-1624`), whose
+ *    `sections` / `groups` sit at the top.
+ *
+ * `list` / `listViews.<key>` are `ObjectListViewSchema`
+ * (`view.zod.ts:1838` — `ListViewSchema` minus `userFilters`) and carry no
+ * `sections` at all, so they are deliberately NOT walked. This is the one point
+ * where the other in-repo ladder, `validate-translatable-sections.ts`'s
+ * `collectViewSites`, is wider: it also visits `listViews.*.sections`. Measured
+ * against the schema, that rung can only ever read `undefined` — it costs
+ * nothing there and buys nothing here, so the narrower #6248 ladder is the one
+ * copied. Both agree on every rung that can hold a section.
+ *
+ * `objects[].views` is deliberately absent for the reason #6248 states:
+ * `object.zod.ts:1833` tombstones the key by name ("`views` is not an
+ * ObjectSchema field"), so a branch keyed on it could only fire for stacks the
+ * schema already rejects — the phantom check #4984 / #5017 removed elsewhere.
+ *
+ * The bare-form site (the entry itself) is NOT such a phantom, and the
+ * distinction is worth keeping straight: strict `ViewSchema` refuses a `views[]`
+ * entry carrying root `sections` — measured, `unrecognized_keys` naming
+ * `sections` — so on a parsed `defineStack` config only the container rungs can
+ * fire. But this rule is registered `input: 'parsed'`, and `os lint` never
+ * parses: `runAuthoringRules` hands `parsed` rules the NORMALIZED stack, where a
+ * raw (non-`defineStack`) config's root `sections` is still present and still
+ * the author's mistake to hear about.
+ */
+function formViewSites(
+  view: AnyRec,
+  basePath: string,
+): Array<{ form: AnyRec; path: string; surface: string }> {
+  // `surface` names the sub-container in the human-readable `where`. It earns
+  // its place on exactly the shape this traversal was extended for: a runtime
+  // container carries neither `name` nor `object` in the emitted artifact, so
+  // without it every finding under one view reads `view "views[0]"` and the
+  // author cannot tell the `edit` form from the `create` one.
+  const sites = [{ form: view, path: basePath, surface: '' }];
+  const dflt = view.form;
+  if (isRec(dflt)) {
+    sites.push({ form: dflt, path: `${basePath}.form`, surface: 'form' });
+  }
+  const named = view.formViews;
+  if (isRec(named)) {
+    for (const [key, sub] of Object.entries(named)) {
+      if (isRec(sub)) {
+        sites.push({ form: sub, path: `${basePath}.formViews.${key}`, surface: `formViews.${key}` });
+      }
+    }
+  }
+  return sites;
+}
+
 /** A section field entry is either a bare field name or `{ field, colSpan, … }`. */
 function fieldNameOf(entry: unknown): string | null {
   if (typeof entry === 'string') return entry.length > 0 ? entry : null;
@@ -66,13 +174,30 @@ function fieldNameOf(entry: unknown): string | null {
   return null;
 }
 
-/** The object a form view binds to: `data.object` (canonical) or `objectName`. */
+/**
+ * The object a view — or one of its sub-containers — binds to, across the shapes
+ * it is authored in.
+ *
+ * The ladder is `objectName` → `object` → `data.object`, identical to
+ * `validate-translation-references.ts` and `validate-translatable-sections.ts`'s
+ * `viewObjectName` (and to the CLI i18n walker's), so all of them agree on which
+ * object a form belongs to. On the canonical container shape the binding lives
+ * INSIDE the sub-container (`form.data.object`) while the container itself
+ * carries `object`, which is why the caller resolves the site first and falls
+ * back to the container — a record-level lookup alone resolves to nothing on the
+ * shape real apps ship.
+ *
+ * `name` is deliberately NOT a rung. A stack-level container's `name` may be the
+ * object name (`view.zod.ts` says so for object-scoped containers), but a form
+ * view's `name` is its own — `contract_form`, not `contract` — and reading it
+ * here would bind the wrong object and report every field on the form as unknown.
+ */
 function boundObject(view: AnyRec): string | undefined {
-  const data = view.data;
-  if (data && typeof data === 'object' && typeof (data as AnyRec).object === 'string') {
-    return (data as AnyRec).object as string;
-  }
-  return typeof view.objectName === 'string' ? (view.objectName as string) : undefined;
+  return (
+    strName(view.objectName) ??
+    strName(view.object) ??
+    (isRec(view.data) ? strName(view.data.object) : undefined)
+  );
 }
 
 /**
@@ -93,64 +218,71 @@ export function validateFormLayout(stack: AnyRec): FormLayoutFinding[] {
     objectFields.set(name, new Set(fields));
   }
 
-  const views = asArray(stack.views);
-  for (let i = 0; i < views.length; i++) {
-    const view = views[i];
-    if (!view || typeof view !== 'object') continue;
-    const sections = Array.isArray(view.sections) ? view.sections : null;
-    if (!sections) continue; // only form views carry a sections array
+  for (const { rec: view, path: viewPath } of collectionEntries(stack.views, 'views')) {
+    // A container names itself with `name`, or binds with `object` — and an
+    // artifact-emitted one may carry neither, so the path is the last resort.
+    const viewName = strName(view.name) ?? strName(view.object) ?? viewPath;
+    const containerObject = boundObject(view);
 
-    const viewName = typeof view.name === 'string' ? view.name : `(view ${i})`;
-    const objName = boundObject(view);
-    // Only reference-check when the bound object resolves; otherwise we can't.
-    const known = objName ? objectFields.get(objName) : undefined;
-    const where = `view "${viewName}"`;
-    const base = `views[${i}]`;
+    for (const site of formViewSites(view, viewPath)) {
+      // A sub-container declares its own binding (`form.data.object`) and
+      // otherwise inherits the container's — the resolution order every other
+      // view-walking rule in this package uses.
+      const objName = boundObject(site.form) ?? containerObject;
+      // Only reference-check when the bound object resolves; otherwise we can't.
+      const known = objName ? objectFields.get(objName) : undefined;
+      const where = site.surface ? `view "${viewName}" · ${site.surface}` : `view "${viewName}"`;
 
-    for (let s = 0; s < sections.length; s++) {
-      const sec = sections[s];
-      const secFields = sec && typeof sec === 'object' && Array.isArray((sec as AnyRec).fields)
-        ? ((sec as AnyRec).fields as unknown[])
-        : [];
-      for (let f = 0; f < secFields.length; f++) {
-        const entry = secFields[f];
-        const fname = fieldNameOf(entry);
-        const fpath = `${base}.sections[${s}].fields[${f}]`;
+      // `sections` (canonical) and `groups` (legacy alias → sections,
+      // `view.zod.ts:1624`) both hold FormSection objects. Reading both is what
+      // #6248 does on this surface, for the same reason: a rule that judges only
+      // the canonical spelling is silent on the legacy one, which is exactly the
+      // half-coverage this issue is about.
+      for (const bucket of ['sections', 'groups'] as const) {
+        const sections = Array.isArray(site.form[bucket]) ? (site.form[bucket] as unknown[]) : [];
 
-        // ── (a) section field references a real field on the bound object ──
-        if (fname && known && !known.has(fname)) {
-          findings.push({
-            severity: 'warning',
-            rule: FORM_FIELD_UNKNOWN,
-            where,
-            path: fpath,
-            message:
-              `${viewName}: field "${fname}" is not a field on object "${objName}" — ` +
-              `it is silently skipped and never renders on the form`,
-            hint:
-              `Fix the field name, or add "${fname}" to ${objName}. Section field ` +
-              `references must match the object's field names exactly.`,
-          });
-        }
+        for (let s = 0; s < sections.length; s++) {
+          const sec = sections[s];
+          const secFields = isRec(sec) && Array.isArray(sec.fields) ? (sec.fields as unknown[]) : [];
+          for (let f = 0; f < secFields.length; f++) {
+            const entry = secFields[f];
+            const fname = fieldNameOf(entry);
+            const fpath = `${site.path}.${bucket}[${s}].fields[${f}]`;
 
-        // ── (b) absolute colSpan → steer to the surface-independent span ──
-        const colSpan = entry && typeof entry === 'object' && !Array.isArray(entry)
-          ? (entry as AnyRec).colSpan
-          : undefined;
-        if (colSpan != null) {
-          findings.push({
-            severity: 'warning',
-            rule: FORM_COLSPAN_ABSOLUTE,
-            where,
-            path: `${fpath}.colSpan`,
-            message:
-              `${viewName}: field "${fname ?? '?'}" sets absolute colSpan ${String(colSpan)} — ` +
-              `the form's column count is derived per surface (mobile 1 / modal 2 / page 3-4), ` +
-              `so a fixed span only aligns at one width`,
-            hint:
-              `Prefer span: 'full' (whole row at any column count), or omit for auto ` +
-              `width. The renderer clamps colSpan to the current column count.`,
-          });
+            // ── (a) section field references a real field on the bound object ──
+            if (fname && known && !known.has(fname)) {
+              findings.push({
+                severity: 'warning',
+                rule: FORM_FIELD_UNKNOWN,
+                where,
+                path: fpath,
+                message:
+                  `${viewName}: field "${fname}" is not a field on object "${objName}" — ` +
+                  `it is silently skipped and never renders on the form`,
+                hint:
+                  `Fix the field name, or add "${fname}" to ${objName}. Section field ` +
+                  `references must match the object's field names exactly.`,
+              });
+            }
+
+            // ── (b) absolute colSpan → steer to the surface-independent span ──
+            const colSpan = isRec(entry) ? entry.colSpan : undefined;
+            if (colSpan != null) {
+              findings.push({
+                severity: 'warning',
+                rule: FORM_COLSPAN_ABSOLUTE,
+                where,
+                path: `${fpath}.colSpan`,
+                message:
+                  `${viewName}: field "${fname ?? '?'}" sets absolute colSpan ${String(colSpan)} — ` +
+                  `the form's column count is derived per surface (mobile 1 / modal 2 / page 3-4), ` +
+                  `so a fixed span only aligns at one width`,
+                hint:
+                  `Prefer span: 'full' (whole row at any column count), or omit for auto ` +
+                  `width. The renderer clamps colSpan to the current column count.`,
+              });
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes #6251

## 1. 前提复核 —— 成立,且比 issue 描述更强

按内容定位(不靠行号),`packages/lint/src/validate-form-layout.ts` 遍历入口原文:

```
const views = asArray(stack.views);
for (let i = 0; i < views.length; i++) {
  const view = views[i];
  if (!view || typeof view !== 'object') continue;
  const sections = Array.isArray(view.sections) ? view.sections : null;
  if (!sections) continue; // only form views carry a sections array
```

即只读容器**自身的** `sections`,其余一律跳过。issue 的前提成立。

复核中多测出一条 issue 没写的事实,方向一致但更严重 —— **唯一被读的那种形状,正是严格 `ViewSchema` 会拒绝的形状**:

```
ViewSchema.safeParse({ name:'v', data:{object:'task'}, sections:[…] }).success = false
issues = [{ code: 'unrecognized_keys',
            message: 'Unrecognized key(s) on this view container: `data`, `sections`. …
                      The container's own keys are `list`, `form`, `listViews`, `formViews`.' }]

ViewSchema.safeParse({ name:'v', object:'task', form:{…}, formViews:{ edit:{…} } }).success = true
```

所以在 `defineStack` 走过的 parsed 栈上,旧遍历能读到的站点数恒为 0。

⚠️ 但**不能**据此把「条目自身即裸表单视图」那一支当幽灵删掉,这是本单最容易踩反的一步:`validateFormLayout` 在注册表里是 `input: 'parsed'`,而 `runAuthoringRules` 对 `parsed` 规则在 `os lint` 下**交的是 normalized 栈**(`stack = rule.input === 'normalized' ? run.normalized : (run.parsed ?? run.normalized)`)—— `os lint` 从不 parse。所以裸表单那一支在「raw 配置 + os lint」这道门上是真实可达的,保留;这一判断连同依据写进了代码注释,免得下一位读者按「schema 会拒 ⇒ 幽灵」再删一次。

## 2. 全包扫描(`packages/lint/src/`,不只判 `validate-form-layout.ts`)

判定方法,两轮:

1. `\.sections|'sections'|"sections"` 全包命中,逐个人工判 surface;
2. 「只读容器自身键」的**等价形状**扫描 —— 直接搜视图级键的根部读法:
   `grep -nE "view\.(columns|filters|sort|viewKind|type|fields|searchableFields|actions|bulkActionDefs|conditionalFormatting|sections|groups|subforms|data)\b" *.ts`(去掉测试文件)。
   全包只剩 5 行命中:2 行在 `validate-form-layout.ts` 自己身上(即本缺陷,`view.sections` + `view.data`),另 3 行是两个阶梯实现里的**其中一级**,见下表最后一行。

| 文件 | 读 `views[]` 的方式 | 同族缺陷? | 判定依据 |
| --- | --- | --- | --- |
| **`validate-form-layout.ts`** | 只读容器根 `sections`(+ 根 `data`) | ✅ **是,本 PR 修** | 见 §1 实测 |
| `validate-visibility-predicates.ts` | `formViewSites`:自身 + `form` + `formViews.*`;pages 走 `walkPageComponents` | 否,#6248 已修 | 不动(刚验收) |
| `validate-translatable-sections.ts` | `collectViewSites` 阶梯:`sections` / `form.sections` / `listViews.*.sections` / `formViews.*.sections` | 否 | 已走全阶梯 |
| `validate-translation-references.ts` | `collectViewRecord` → `addSections` 作用于 `formViews.*`、`view.form`、`view` 自身 | 否 | 已走全阶梯 |
| `lint-view-refs.ts` | `isAggregatedViewContainer` + spec 的 `expandViewContainerWithDiagnostics` | 否 | 用的是 spec 的官方展开 |
| `validate-action-locations.ts` | `view.list` + `view.listViews.*` | 否 | 只关心 list 族放置 |
| `validate-action-name-refs.ts` | `view.list` + `view.listViews.*` | 否 | 同上 |
| `validate-chart-bindings.ts` | `view.list` + `view.listViews.*` | 否 | 图表只在 list 族 |
| `validate-searchable-fields.ts` | `view.list` + `view.listViews.*` | 否 | `searchableFields` 是 list 键 |
| `validate-list-view-mode.ts` | `view.list` + `view.listViews.*` | 否 | 规则本身就是 list 族 |
| `validate-functional-completeness.ts` | `container.list` + `container.listViews.*` | 否 | 文件内已注明「表单视图无布局绑定契约」 |
| `validate-dashboard-action-refs.ts` | 只收容器名 | 否 | 不读容器内部 |
| `validate-view-containers.ts` | 判的就是容器形状本身 | 否 | 主体即容器 |
| `validate-page-field-bindings.ts` / `validate-react-page-props.ts` | `properties.sections`,页面组件树 | 否 | 另一个 surface |
| (等价形状扫描剩余命中)`validate-translatable-sections.ts:130,200`、`validate-translation-references.ts:291` | `view.data` / `view.sections` 是**完整阶梯里的一级**,同一函数另有 `form` / `formViews.*` 级 | 否 | 上下文即证 |

结论:**`validate-form-layout.ts` 是包内该缺陷仅存的一例**。没有拿不准需要另立单的同族命中。

## 3. 遍历实现的来源 —— 照抄 #6248,不另造第三套

抄的是 `validate-visibility-predicates.ts` 的 `formViewSites`(#6248 落地):容器自身 + `view.form` + 每个 `view.formViews` 具名项,返回 `{ form, path, surface }`。本 PR 只加了一件 #6248 不需要的东西:每个站点继承的**对象绑定**(本规则要解析字段引用,可见性规则不需要)。

两份 repo 内的实现有一处出入,按实测取舍并在代码里写明:

- `validate-translatable-sections.ts` 的 `collectViewSites` 额外走 `listViews.*.sections`;
- #6248 的 `formViewSites` 不走。

判据取自 schema 而非印象:`ObjectListViewSchema = ListViewSchema.omit({userFilters}).extend(…)`,`ListViewSchema` 不声明 `sections`;spec 的 `expandViewContainerWithDiagnostics` 也把 `list` / `listViews.*` 归为 list 族、`form` / `formViews.*` 归为 form 族。所以那一级只可能读到 `undefined` —— 在那边不花钱,在这边也不买东西。**取 #6248 的窄阶梯**;两份实现在「可能装 section 的每一级」上完全一致。

`objects[].views` 两边都不走:`object.zod.ts` 已具名墓碑化(「`views` is not an ObjectSchema field」),读它只能对 schema 本就拒绝的栈生效 —— #4984 / #5017 清掉的那种幽灵分支。

## 4. 三位置对照实测(同一个坏表单,三个位置)

| 位置 | 修前 | 修后 |
| --- | --- | --- |
| `views[0].sections`(条目自身即裸表单) | `form-field-unknown@views[0].sections[0].fields[0]` | 同左 |
| `views[0].form.sections`(容器默认表单) | `[]` | `form-field-unknown@views[0].form.sections[0].fields[0]` |
| `views[0].formViews.edit.sections`(具名表单视图) | `[]` | `form-field-unknown@views[0].formViews.edit.sections[0].fields[0]` |

## 5. 反向验证 A / B / C(先申报,后执行)

### 声明 A —— 不可达 → 可达

**申报**:修前只有第一个位置报,修后三个都报。
**实测**:与 §4 表格一致,修前修后各跑一次取证,完全命中。

### 声明 B —— 变异体(遍历退回 origin/main 形状,保留全部新断言)

**申报(执行前写死)**:6 条转红 / 3 条按设计不转红。
**实测:6 红 3 绿,与申报逐条一致。**

| # | 断言 | 极性 | 申报 | 实测 |
| --- | --- | --- | --- | --- |
| 1 | 三位置同报 | 肯定式 | 红 | ✅ 红 |
| 2 | `where` 标注子容器 | 肯定式 | 红 | ✅ 红 |
| 3 | 子容器继承容器绑定 | 肯定式 | 红 | ✅ 红 |
| 4 | 读 legacy `groups` 桶 | 肯定式 | 红 | ✅ 红 |
| 5 | map 形态 `views` 报在真实键上 | 肯定式 | 红 | ✅ 红 |
| 6 | **真实 app 形状上确实报了** | 肯定式 | 红 | ✅ 红 |
| 7 | 不走 `list` / `listViews.*` | **否定式** | **不红**(遍历被削空后平凡成立) | ✅ 绿 |
| 8 | 干净 app 栈报 0 | **否定式** | **不红,且是空绿** | ✅ 绿 |
| 9 | fixture 能通过严格 schema | 结构守卫 | **不红**(测的是 schema 不是规则) | ✅ 绿 |

vitest 原文:

```
❯ src/validate-form-layout.test.ts (16 tests | 6 failed) 68ms
     × reports the SAME broken form in all three placements
     × names the sub-container in `where`, so two forms under one view are distinguishable
     × a sub-container INHERITS the container binding when it declares none
     × reads the legacy `groups` bucket too — measured NOT folded into `sections` at parse
     × reports a map-shaped `views` at the key it sits at, not a synthetic index
     × reports every planted defect on that stack — this is the assertion #6251 exists for
 Test Files  1 failed (1)
      Tests  6 failed | 10 passed (16)
```

**空绿自查(逐条,不只报有没有)**:全 16 条断言按「功能回退后是否仍通过、以及**为什么**通过」过了一遍,查出 **1 条真空绿**:

- **#8「干净 app 栈报 0」**——变异体下它照样通过,而且是因为**什么都没读到**才通过,不是因为没有缺陷。这正是本单在讨伐的那种绿。它**不删**(误报守卫仍有价值),但只在与 #6 配对时才成立:#6 用同一族 fixture 证明遍历确实读到了东西,#8 才有资格证明「读到了也不乱报」。这层依赖已写进测试文件的注释,免得日后 #6 被削弱而 #8 被当成独立保障。
- #7 是否定式断言,削空遍历必然平凡成立,申报时即预期为绿,**不是**发现;它钉的是 schema 事实(`ObjectListViewSchema` 不带 `sections`),不是本次修法。
- #9 走 `defineStack` + `normalizeStackInput`,断言的是 fixture 本身合法,属结构守卫。按 key-vs-value 判据:这里守的是「容器形状是不是真实可授权面」并且规则要判**值**(字段引用),故要求 **full safeParse 绿**(经 `defineStack` 真解析),而不是只看 `unrecognized_keys`。
- 其余 7 条(#6251 之前就有的既有断言)在变异体下全绿 —— 那正是它们的职责,不计入自查发现。

### 声明 C —— 不误报(真实 examples 实跑)

**申报**:修后新增报告必须都是真缺陷;若报出存量问题,如实报数量与样例,⛔ 不为让门变绿而放宽规则。
**实测**:把规则跑在三个真实 example 栈上(`normalizeStackInput` 后的真实配置,非合成 fixture),并同时跑 origin/main 版本做对照:

```
### app-showcase: 6 container(s) | form sites: root-sections=0 (read before) + form/formViews=10 (read ONLY after)
    findings before=0  after=0
### app-crm:      3 container(s) | form sites: root-sections=0 (read before) + form/formViews=4  (read ONLY after)
    findings before=0  after=0
### app-todo:     1 container(s) | form sites: root-sections=0 (read before) + form/formViews=0  (read ONLY after)
    findings before=0  after=0
```

两层结论:

1. **0 误报**,也**没有存量真缺陷**被翻出来 —— 三个 example 的表单本来就是干净的,无需任何放宽。
2. 顺带把「幽灵」量化了:三个 app 在条目根部的表单站点数合计 **0**,在 `form` / `formViews` 下合计 **14**。旧遍历在所有出货 example 上**无物可读**,报绿正是因为读了 0 个站点。

## 6. Changeset 级别依据

`@objectstack/lint` 是发布包 ⇒ 走真 changeset(**未**打 `skip-changeset`)。

级别 **patch**。依据:本单是**既有规则的遍历/判定修正**,没有新增规则、没有新增导出、没有改 severity / rule id / 消息文案。仓内同类先例即 patch:`flow-lint-loop-body-descent.md`(flow 规则族补 loop 体下降)、`body-write-lint-message-driver-truth.md`。v17 窗口期禁 major,本单也够不上 minor。

## 7. 门禁 EXIT 表

| 门 | 命令 | EXIT |
| --- | --- | --- |
| 包测试 | `pnpm --workspace-concurrency=2 --filter @objectstack/lint test` | **0**(62 files / **1528** tests passed) |
| 包类型检查 | `pnpm --workspace-concurrency=2 --filter @objectstack/lint typecheck` | **0** |
| 仓库 ESLint(CI 的 ESLint job 主步) | `pnpm lint` | **0** |
| 控制字节门 | `pnpm check:nul-bytes` | **0**(scanned 6016 tracked text files) |
| 控制字节自扫(超出门禁范围) | `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]' (改动的三个文件)` | **1 = 无命中** |
| ADR 锚点 | `pnpm check:adr-anchors` | **0** |
| role 词 ratchet | `pnpm check:role-word` | **0** |
| docs-audit scope | `pnpm check:docs-audit-scope` | **0** |
| release-notes 漂移 | `pnpm check:release-notes` | **0** |

规则的既有测试就在 `packages/lint/src/validate-form-layout.test.ts`(未散落到 `packages/cli/test/`)。消费半径也扫了:`packages/cli/test/authoring-rule-command-parity.test.ts` 里 `formView()` 造的是 `sections: []`,且断言只过滤 `severity === 'error'`,本族两条是 `warning`,不受影响;`packages/cli/test/doctor-refs.test.ts` 的 `sections` fixture 喂的是 `findUnusedObjects`,不是本规则。`examples/**` 里没有任何真正写下的 `colSpan:` 键(只有一处注释提到它)。

## 8. 不在本 PR 里

- ⛔ 未动 `validate-visibility-predicates.ts`(#6248 刚验收的面)、`authoring-rules.ts`(#6340 刚落地)、`packages/spec/**`、`examples/**`(只读参考形状)、`content/docs/releases/**`。
- **未抽公共 helper**。三份阶梯实现(#6248 的 `formViewSites`、`collectViewSites`、本 PR)确有可合并空间,但合并必然要改 #6248 刚验收的文件,超出本单授权;而只为本 PR 新建一个 helper 文件只会把三份变四份。已按 Prime Directive #10 另立观察单 **#6381**(`finding` 标签,未自我认领),不在此 PR 动手。
- **页面组件树里的内嵌表单**仍不走(`walkPageComponents` 那一支)。文件原有注释即声明该 walker「刻意保持浅层,以免猜测任意组件的对象绑定」—— 本单只修容器阶梯,不扩到新 surface。
- **未改 severity / 未改 tier / 未改注册表**:两条规则仍是 advisory `warning`,不 gating。
- 未翻 ready、未挂 auto-merge、未合并、未在 #6251 下评论。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_