### PR TITLE
fix(scripts): release 页 Console 段改按破坏性判据分节,Breaking changes 不再结构性永不渲染 (#6294)

### DIFF
--- a/scripts/objectui-range.mjs
+++ b/scripts/objectui-range.mjs
@@ -49,9 +49,29 @@
 // The output is a release page's body, so a reader cannot tell a filtered list
 // from a complete one. Hence: the accounting footer is UNCONDITIONAL — every
 // excluded item is counted out loud in the artifact itself, and `--all` names
-// them. Headings group by the level objectui declared; grouping is presentation
-// and must never become a filter again. Declaration over inference, per
-// AGENTS.md Prime Directive #12.
+// them. Grouping into headings is presentation and must never become a filter
+// again. Declaration over inference, per AGENTS.md Prime Directive #12.
+//
+// WHICH HEADING AN ENTRY LANDS UNDER (#6294)
+// ------------------------------------------
+// The section table used to key entirely on the DECLARED LEVEL, `major` →
+// "Breaking changes". objectui does not declare `major` in a release window — it
+// ships a breaking change as `minor` plus a prose annotation the author writes,
+// and `scripts/check-changeset-no-major.mjs` holds that line deliberately. So
+// that heading was structurally unable to render, and the breaking entries were
+// presented to upgraders under "Features". Measured on the same real range
+// #6099 was measured on, `f5bc4c78be76..f995a452d2ca`: 64 releasing changesets,
+// 0 declared `major`, `### Breaking changes` absent, and all four
+// author-annotated breaking entries (`042e09d77` / `6e794a19e` / `8ec406728` /
+// `d22ae31ce`) under `### Features`.
+//
+// The leading section therefore keys on `r.breaking` — the verdict
+// `classifyRange` already computes for every releasing entry ("declared `major`
+// OR the author's own breaking annotation", #6099 / PR #6289). This file
+// CONSUMES that verdict and does not restate it: a second copy would drift, and
+// the first thing it would drift on is this exact class. That is why #6289 put
+// the criterion in the shared implementation rather than in `buildDigest`. The
+// remaining sections still key on the declared level.
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
@@ -116,12 +136,25 @@ function scopeOf(subject) {
   return m ? m[2] || '' : '';
 }
 
-/** Declared level → the release-page heading it belongs under. */
-const SECTIONS = [
-  ['major', 'Breaking changes'],
+/**
+ * The release-page headings, in page order.
+ *
+ * The LEADING group is keyed on the shared breaking verdict `r.breaking`, not on
+ * a declared level (#6294 — see the header block). The rest key on the level
+ * objectui declared.
+ *
+ * TOTALITY: a `major` entry always satisfies `r.breaking` — `classifyRange`
+ * computes `breaking = level === 'major' || annotated` — so the level table only
+ * has to cover what the breaking group leaves behind, `minor` and `patch`.
+ * `renderRange` still prints anything this table cannot place, under a heading
+ * that says so: grouping is presentation and must never become a filter (#4843).
+ */
+const BREAKING_HEADING = 'Breaking changes';
+const LEVEL_SECTIONS = [
   ['minor', 'Features'],
   ['patch', 'Fixes'],
 ];
+const UNPLACED_HEADING = 'Other changes';
 
 /**
  * Render the Console section for a classified range.
@@ -159,8 +192,19 @@ export function renderRange({ fromSha, toSha, classified, showExcluded = false }
     out.push('', `_Largest areas: ${topAreas.map(([a, n]) => `${a} (${n})`).join(', ')}_`);
   }
 
-  for (const [level, heading] of SECTIONS) {
-    const group = releasing.filter((r) => r.level === level);
+  // Breaking FIRST, keyed on the shared verdict — declared `major` OR the
+  // author's own annotation — then the remainder by declared level (#6294).
+  const rest = releasing.filter((r) => !r.breaking);
+  const groups = [
+    [BREAKING_HEADING, releasing.filter((r) => r.breaking)],
+    ...LEVEL_SECTIONS.map(([level, heading]) => [heading, rest.filter((r) => r.level === level)]),
+  ];
+  // An entry no heading above claims is still printed, never dropped (#4843).
+  const keyed = new Set(LEVEL_SECTIONS.map(([level]) => level));
+  const unplaced = rest.filter((r) => !keyed.has(r.level));
+  if (unplaced.length) groups.push([UNPLACED_HEADING, unplaced]);
+
+  for (const [heading, group] of groups) {
     if (group.length) out.push('', `### ${heading}`, ...group.map(line));
   }
 
@@ -313,7 +357,8 @@ function selfTest() {
 
     const base = commit('chore: base', { 'README.md': 'base\n' });
 
-    // The five shapes measured on 7d9734d5e321..785b8a5d432c.
+    // Shapes 1-5 measured on 7d9734d5e321..785b8a5d432c; shapes 6-7 on
+    // f5bc4c78be76..f995a452d2ca, the range #6099/#6294 were measured on.
     // 1. an ordinary releasing `feat` — the only shape the old filter got right
     commit('feat(grid): aggregate single-call mode for bulk actions (#3201)', {
       '.changeset/bulk-action-aggregate.md':
@@ -345,7 +390,38 @@ function selfTest() {
     commit('fix(ci): never render a budget FAIL for a run that measured nothing (#3198)', {
       '.github/workflows/y.yml': 'on: push\n',
     });
+    // 6. THE RELEASE-WINDOW SHAPE (#6294), after `042e09d77`: breaking, but
+    //    declared `minor` with the author's own `**BREAKING (v17)**` label —
+    //    the only spelling objectui actually uses, and the one a level-keyed
+    //    section table could not represent at all.
+    const annotatedSha = commit(
+      'feat(field): field widgets receive the record, not the raw value (#3244)',
+      {
+        '.changeset/field-widget-record-arg.md':
+          '---\n"@object-ui/plugin-field": minor\n---\n\nField widgets receive the whole record, not the raw value.\n\n' +
+          '**BREAKING (v17)** — a widget that read the raw value must read `record[field]`.\n',
+        'src/field.ts': 'c\n',
+      },
+    );
+    // 7. the NEAR MISS, after `9e9e9a92f`: a `patch` whose prose merely mentions
+    //    "breaking" mid-sentence. Not annotated, so it must stay under Fixes.
+    commit('fix(tree): stop re-sorting children on every keystroke (#3251)', {
+      '.changeset/tree-sort-stability.md':
+        '---\n"@object-ui/plugin-tree": patch\n---\n\nStop re-sorting tree children on every keystroke.\n\n' +
+        'Reordering here is technically breaking for anyone who relied on the churn, but only in the sense that the order was never specified.\n',
+      'src/tree.ts': 'd\n',
+    });
     const head = g('rev-parse', 'HEAD').trim();
+
+    /** The lines under `### <heading>`, up to the next `###` (or the end). */
+    const sectionOf = (md, heading) => {
+      const lines = md.split('\n');
+      const start = lines.indexOf(`### ${heading}`);
+      if (start < 0) return null;
+      const after = lines.slice(start + 1);
+      const end = after.findIndex((l) => l.startsWith('### '));
+      return (end < 0 ? after : after.slice(0, end)).join('\n');
+    };
 
     console.log('objectui-range --self-test');
 
@@ -358,10 +434,15 @@ function selfTest() {
       markdown.includes('PageNodeRenderer') && markdown.includes(breakingSha.slice(0, 9)),
       markdown,
     );
+    // Every conjunct is an EXISTENCE check on a heading this fixture really
+    // renders (`indexOf(...) > -1` first, so a missing heading fails rather than
+    // ordering vacuously against -1). All three sections are populated here:
+    // shape 2 or 6 → Breaking, shapes 1/3 → Features, shape 7 → Fixes.
     check(
-      'breaking changes get their own leading section (declared major)',
+      'the three sections render in page order: Breaking changes, Features, Fixes',
       markdown.indexOf('### Breaking changes') > -1 &&
-        markdown.indexOf('### Breaking changes') < markdown.indexOf('### Features'),
+        markdown.indexOf('### Breaking changes') < markdown.indexOf('### Features') &&
+        markdown.indexOf('### Features') < markdown.indexOf('### Fixes'),
       markdown,
     );
     check(
@@ -370,9 +451,64 @@ function selfTest() {
       markdown,
     );
     check(
-      'commit type never filters: all 3 releasing changesets are listed',
-      classified.releasing.length === 3,
+      'commit type never filters: all 5 releasing changesets are listed',
+      classified.releasing.length === 5,
       `got ${classified.releasing.length}`,
+    );
+
+    // --- #6294: the leading section is keyed on the SHARED breaking verdict ---
+    // objectui never declares `major` in a release window, so a level-keyed
+    // table left `### Breaking changes` structurally unrenderable and filed the
+    // author-annotated breaking entries under "Features".
+    check(
+      'a `minor` entry the AUTHOR annotated breaking is under Breaking changes',
+      (sectionOf(markdown, 'Breaking changes') ?? '').includes('not the raw value'),
+      markdown,
+    );
+    check(
+      'that annotated entry is NOT left under Features',
+      !(sectionOf(markdown, 'Features') ?? '').includes('not the raw value'),
+      markdown,
+    );
+    check(
+      'sectioning consumes the verdict, it does not restate the level: still `minor`/annotation',
+      classified.releasing.find((r) => r.sha === annotatedSha)?.level === 'minor' &&
+        classified.releasing.find((r) => r.sha === annotatedSha)?.breakingSource === 'annotation',
+      JSON.stringify(classified.releasing.find((r) => r.sha === annotatedSha)),
+    );
+    check(
+      'a `patch` merely MENTIONING "breaking" mid-sentence stays under Fixes',
+      (sectionOf(markdown, 'Fixes') ?? '').includes('re-sorting tree children') &&
+        !(sectionOf(markdown, 'Breaking changes') ?? '').includes('re-sorting tree children'),
+      markdown,
+    );
+    check(
+      'grouping never filters: every releasing entry appears exactly once',
+      classified.releasing.every(
+        (r) => markdown.split(`(objectui \`${r.sha.slice(0, 9)}\`)`).length === 2,
+      ),
+      markdown,
+    );
+
+    // The ordering guard above is carried in this fixture by BOTH breaking
+    // sources at once. Pin it a second time on a range whose ONLY breaking entry
+    // is annotation-sourced — the real release-window shape, and the one a
+    // level-keyed table cannot render at all. This is the check that goes red if
+    // the section ever reverts to keying on `r.level === 'major'`.
+    const annotationOnly = renderRange({
+      fromSha: base,
+      toSha: head,
+      classified: {
+        ...classified,
+        releasing: classified.releasing.filter((r) => r.breakingSource !== 'declared-major'),
+      },
+    });
+    check(
+      'with NO declared `major` in range, Breaking changes still renders and still leads',
+      annotationOnly.markdown.indexOf('### Breaking changes') > -1 &&
+        annotationOnly.markdown.indexOf('### Breaking changes') <
+          annotationOnly.markdown.indexOf('### Features'),
+      annotationOnly.markdown,
     );
 
     // --- what ships nothing is excluded, and SAYS SO in the artifact ---
@@ -398,7 +534,7 @@ function selfTest() {
     );
     check(
       'the accounting footer is unconditional and states the totals',
-      markdown.includes('3 releasing of 4 added across 5 non-merge commit(s)'),
+      markdown.includes('5 releasing of 6 added across 7 non-merge commit(s)'),
       markdown,
     );
 
@@ -448,7 +584,7 @@ function selfTest() {
     check(
       'the CLI JSON reports the declared criterion and the excluded counts',
       cliJson.criterion === 'declared-changeset' &&
-        cliJson.count === 3 &&
+        cliJson.count === 5 &&
         cliJson.releaseNothing === 1 &&
         cliJson.noChangeset === 1,
       JSON.stringify(cliJson).slice(0, 200),
@@ -458,6 +594,13 @@ function selfTest() {
       cliJson.releasing.every((r) => ['major', 'minor', 'patch'].includes(r.level)) &&
         cliJson.releasing.filter((r) => r.level === 'major').length === 1,
       JSON.stringify(cliJson.releasing.map((r) => r.level)),
+    );
+    check(
+      'the CLI JSON carries both breaking sources, so a consumer can tell them apart',
+      cliJson.releasing.filter((r) => r.breakingSource === 'declared-major').length === 1 &&
+        cliJson.releasing.filter((r) => r.breakingSource === 'annotation').length === 1 &&
+        cliJson.releasing.filter((r) => r.breaking).length === 2,
+      JSON.stringify(cliJson.releasing.map((r) => r.breakingSource)),
     );
   } finally {
     rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
Fixes #6294

`scripts/objectui-range.mjs` 的分节表按**声明级别**分节,首项 `['major', 'Breaking changes']`。objectui 在发布窗内不声明 `major`(破坏性一律 `minor` + 作者正文标注,`scripts/check-changeset-no-major.mjs` 刻意守这条线),因此 `### Breaking changes` 这个节头**结构性永不渲染**,而升级者最该先读的那一类被呈现在 `### Features` 标题下。

本 PR 把首节的分节判据从「声明级别 == major」改为共享判据 **`r.breaking`**。**判据一字未改** —— 它在 `scripts/objectui-changeset-digest.mjs` 里,本 PR 只消费。

## 1. 前提复核(在 `origin/main` 上)

`SECTIONS` 现行形状,`scripts/objectui-range.mjs:119-124`(改前):

```js
/** Declared level → the release-page heading it belongs under. */
const SECTIONS = [
  ['major', 'Breaking changes'],
  ['minor', 'Features'],
  ['patch', 'Fixes'],
];
```

`r.breaking` / `r.breakingSource` 确实可用 —— `classifyRange` 已经为每条 releasing 条目算出(`objectui-changeset-digest.mjs:531-539`,PR #6289 落下),而本文件第 80 行本来就在 import 并调用 `classifyRange`:

```js
    const annotated = hasBreakingAnnotation(body);
    releasing.push({
      …
      breaking: level === 'major' || annotated,
      breakingSource: level === 'major' ? 'declared-major' : annotated ? 'annotation' : null,
    });
```

真实区间实测(改前,`f5bc4c78be76..f995a452d2ca`,与 #6099 同一现场):64 条 releasing、0 条 `major`,只渲染出 `### Features` / `### Fixes` 两节,作者亲手标注的 4 条破坏性条目全部落在 Features 下。前提成立。

## 2. ⚠️ 节序断言的空绿审计(本单的硬要求)

分诊的假设是:`:363-364` 那条节序断言「今天之所以通过,很可能正是因为那个节从不渲染」。**实测把这个假设证伪了 —— 如实报告,不套模板。**

**改前它并不是空绿。** 两条独立证据:

1. **断言本身是肯定式的。** 它的第一个合取项是**存在性检查** `indexOf('### Breaking changes') > -1`,节不存在时直接判假;不存在时也不会退化成「-1 小于 indexOf(Features)」这种平凡真。
2. **fixture 里本来就有一条 `major`。** self-test 的形状 2(`refactor(layout)!`)显式声明 `"@object-ui/layout": major`,所以该节在 fixture 中**确实渲染**。用探针在改前的代码上跑同一 fixture:

```
--- headings (BEFORE) ---
### Breaking changes
### Features
### Fixes
```

所以「结构性永不渲染」是**生产窗口**的事实(objectui 从不声明 major),不是 self-test fixture 的事实。fixture 用的是 `declared-major` 这条**在真实发布窗内不存在**的路径。

**真正的缺口不是空绿,而是覆盖错位:** 改前这条断言只被 `declared-major` 承载,而真实世界唯一会走的 `annotation` 路径**完全无覆盖**。改后如果只换判据不动 fixture,断言仍会被同一条 `major` 承载,**新代码路径一条断言也不碰** —— 那才是这一单真正的空绿风险。

**改后靠什么承载(三层,逐层加严):**

- fixture 新增形状 6:`minor` + 作者 `**BREAKING (v17)**` 标注(仿真实提交 `042e09d77`),于是该节**同时**被 `declared-major` 与 `annotation` 两条来源承载;
- 节序断言本身加严成三节全序 —— `Breaking changes` 先于 `Features` 先于 `Fixes`,每个合取项都是对**本 fixture 真实渲染**的节的存在性检查(新增形状 7 让 `### Fixes` 也首次真的渲染,改前 fixture 里根本没有 patch 条目);
- 新增一条**只有 annotation 破坏性**的节序断言:把 `declared-major` 条目从区间里滤掉后重渲染,`### Breaking changes` 仍须渲染且仍须领先。这条就是真实发布窗的形状,也是**判据一旦退回 `major` 就必然转红**的那条(见下方 B)。

## 3. 真实区间重放(`f5bc4c78be76..f995a452d2ca`)

```
                       改前            改后
### Breaking changes   (缺席)          4 条
### Features           14 条           10 条
### Fixes              50 条           50 条
条目总数                64              64
```

4 条作者标注的破坏性条目逐条归位:

```
042e09d77  ### Features  ->  ### Breaking changes
6e794a19e  ### Features  ->  ### Breaking changes
8ec406728  ### Features  ->  ### Breaking changes
d22ae31ce  ### Features  ->  ### Breaking changes
```

总数 64 -> 64:无丢失、无重复,只是换了标题。

## 4. 反向验证(先申报后执行)

### 声明 A —— 节活过来

**申报**:改前 `### Breaking changes` 不出现,改后出现且恰好收进那 4 条。

**实测:符合。** 见上表(真实区间)与探针 fixture:改后 `level=minor breaking=true src=annotation` 的条目落到 `### Breaking changes`(改前落在 `### Features`)。

### 声明 B —— 变异体

**申报(执行前写下)**:把首节判据退回 `r.level === 'major'`、保留全部断言,预测 **3 条转红**(两条归属断言 + annotation-only 节序断言),而**三节全序断言不会红**,因为 fixture 里仍有一条 `major`,该节照样渲染、照样领先。

**实测:与申报逐条吻合,3 红。**

```
  ✓ the three sections render in page order: Breaking changes, Features, Fixes
  ✗ a `minor` entry the AUTHOR annotated breaking is under Breaking changes
  ✗ that annotated entry is NOT left under Features
  ✓ sectioning consumes the verdict, it does not restate the level: still `minor`/annotation
  ✓ a `patch` merely MENTIONING "breaking" mid-sentence stays under Fixes
  ✓ grouping never filters: every releasing entry appears exactly once
  ✗ with NO declared `major` in range, Breaking changes still renders and still leads
⛔ objectui-range --self-test: 3 failure(s)
```

**断言极性逐条标明:**

| 断言 | 极性 | 变异体下 | 为什么 |
| --- | --- | --- | --- |
| 三节全序(Breaking 先于 Features 先于 Fixes) | 肯定式(三个存在性合取) | **绿** | fixture 仍有一条 `major`,节照样渲染并领先。它守的是**节序**,不是判据 —— 单靠它抓不到本回归。这是本 PR 最该说清的一点。 |
| 标注条目**在** Breaking changes 节内 | 肯定式(成员归属) | **红** | 该条目退回 Features,节内找不到。 |
| 标注条目**不在** Features 节内 | 否定式,但**有内容**、非结构性 | **红** | 条目真实存在且真的会被渲染到 Features,所以否定式在此有判别力 —— 不是「因为什么都没产生所以通过」。 |
| annotation-only 区间下节仍渲染且领先 | 肯定式(存在性优先) | **红** | 滤掉 `declared-major` 后,级别键控下该节一条都取不到,`indexOf` 返回 -1,第一个合取项即判假。**这条是本次改动的真正守卫。** |
| 「分组永不过滤:每条恰好出现一次」 | 肯定式(计数) | 绿 | 变异体下 major/minor/patch 仍完备,不丢条目。 |
| 「消费判据而不复述级别:仍是 minor/annotation」 | 肯定式 | 绿 | 级别与 `breakingSource` 未被本 PR 触碰,本就该保持绿 —— 它守的是「判据没被改写」。 |

变异体已完全还原(`grep -n MUTANT` 无命中,还原后 self-test 21/21 绿)。

### 声明 C —— 非 breaking 条目不误入

**申报**:普通 minor/patch 仍进各自节,不因改判而漂到 Breaking 节。

**实测:符合。** 真实区间 Fixes 50 条纹丝不动,Features 恰好少掉那 4 条。fixture 侧新增形状 7 是**近似样本**:一条 `patch`,正文只在句中提到 "breaking"(`Reordering here is technically breaking for anyone who relied on the churn…`,仿真实的 `9e9e9a92f`),既不是强调标签也不在块首 —— 断言它必须留在 `### Fixes` 且不得出现在 Breaking 节。这条从消费端钉住了判据的精度,而没有改判据。

### 声明 D —— 下游未破

**申报**:`objectui-range.mjs` 的既有消费者行为不变,至少跑它们的 self-test 取证。

**实测:符合。** 消费面已枚举:`package.json` 的 `check:objectui-changeset`(digest + range 双自测)、`scripts/check-objectui-pin-fresh.mjs`(仅在帮助文本里提到本脚本)、`docs/releases-maintenance.md`(用法文档,用法未变)。`scripts/bump-objectui.sh` 走的是 `buildDigest`,不经过 `renderRange`。digest self-test 与 pin-fresh self-test 均全绿(见门禁表)。CLI 的 `--json` 形状未变(字段直出 `classifyRange`),只是 markdown 的标题归属变了。

## 5. 门禁 EXIT 表(均在 `git add` 之后跑)

| 门禁 | EXIT | 结果 |
| --- | --- | --- |
| `pnpm check:objectui-changeset` | 0 | digest self-test 全绿;objectui-range self-test **21/21** 绿(改前 14 条) |
| `pnpm exec eslint scripts/objectui-range.mjs --no-inline-config` | 0 | 无输出 |
| `pnpm check:nul-bytes` | 0 | 自测 56 断言 + 扫描 6046 个跟踪文本文件,无裸控制字节 |
| 控制字节自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` | grep=1 | 无命中(本 PR 未书写任何控制字符) |
| `node scripts/check-objectui-pin-fresh.mjs --self-test` | 0 | 11 条全绿(下游) |

## 6. 不在本 PR 里

- ⛔ `scripts/objectui-changeset-digest.mjs` —— 判据所在地,本 PR 只消费,一字未动。
- ⛔ `content/docs/releases/**` —— CLAUDE.md 铁律,发布页集中编写,绝不在代码 PR 里改。
- ⛔ `v17.mdx` —— #6115 另有其单。
- ⛔ 判据本身与收录集(哪些条目算 releasing)—— 均未触碰。
- ⛔ 未加 `.changeset/`:`scripts/` 工具链、不发布任何包,走 `skip-changeset` 路线。
- 未给 Breaking 节内条目再加 `**BREAKING**` 前缀标记(digest 侧 `markBreaking` 的做法)—— 节头已经说明了这件事,且超出本单范围。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_