### PR TITLE
docs(sdui): declare the declaration-parity ratchet an on-demand gate triggered by the objectui pin bump (#5960)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,8 @@ This repo ships **backend only**. All Studio/Console UI work happens in `../obje
 
 Other scripts: `objectui:bump` (pull only), `objectui:build`, `objectui:clean`. ⚠️ Never hand-edit `packages/console/dist/` or `.cache/objectui-*/` — regenerated.
 
+**Moving the pin has a second half: `pnpm sdui:manifest`.** ADR-0082 D4's spec↔registry declaration-parity ratchet reads objectui's `sdui.manifest.json`, which changes only when `.objectui-sha` moves — so the pin bump is the ratchet's trigger, and its only one. It is an **on-demand gate by decision** (#5960), never a CI job; `objectui:bump` and `objectui:refresh` both print the reminder. Needs Playwright chromium. Full procedure: `docs/releases-maintenance.md` → "After the pin moves".
+
 **Fast iteration on `../objectui` src (no commit/refresh loop):** run objectui's own console dev server — `cd ../objectui && pnpm --filter @object-ui/console dev` (Vite on **:5180**, HMR). Its `/api` proxy targets `DEV_PROXY_TARGET || http://localhost:3000`, so **run the backend you're testing on :3000** (`PORT=3000 pnpm dev` for showcase) and browse `:5180`. Note `:3001/_console` (or whatever the backend serves) is the **published** console, not your `../objectui` src — only `:5180` reflects local UI edits. See `../objectui/AGENTS.md` for the app-id / localStorage / auth gotchas.
 
 ---
@@ -555,9 +557,16 @@ unavailable` and **exited 0**, so no path existed on which this gate could go re
 **exits 1** when it has no usable manifest, because "could not run" is a failure, not a
 skip (Route & surface ownership §3, *Absence must be loud*). Run it the one way that
 works: `pnpm sdui:manifest` (or `OBJECTUI_ROOT=../objectui pnpm objectui:build` first),
-which dumps the manifest and runs the ratchet against it. Where the manifest *should* come
-from in CI is an open provenance question, tracked separately — do not "fix" the red by
-re-adding a skip.
+which dumps the manifest and runs the ratchet against it. Where the manifest comes from is
+**settled** (#5960, maintainer ruling 2026-08-07): **not from CI**. It is an on-demand
+gate whose trigger is the **objectui pin bump** — `.objectui-sha` is the only thing that
+moves the manifest, so `scripts/bump-objectui.sh` and `scripts/build-console.sh` print the
+`pnpm sdui:manifest` step and `docs/releases-maintenance.md` carries the procedure.
+Producing it here was rejected outright: the sole producer drives Playwright chromium over
+objectui's built console, so a CI-side dump means a full objectui build plus a browser
+download on every matching PR. So: do not "fix" the red by re-adding a skip, and do not
+"fix" it by wiring the gate into a workflow either — run it where it belongs, at the pin
+bump.
 
 `check:exported-any` is the one of those that also reads the built `dist/*.d.ts`, so the
 stale-`dist` caveat above applies to it too. It asks the other half of the

--- a/docs/adr/0082-react-component-contract-governance.md
+++ b/docs/adr/0082-react-component-contract-governance.md
@@ -3,7 +3,7 @@
 **Status**: Accepted (2026-06-30)
 **Deciders**: ObjectStack Protocol Architects
 **Builds on**: [ADR-0080](./0080-ai-authored-ui-jsx-source.md) (AI authors UI; the component registry `inputs` are the contract; **capability ≠ contract** — curate a small public surface, not the full capability set), [ADR-0081](./0081-trusted-react-page-tier.md) (the `kind:'react'` tier executes real React; its safety boundary is **trust + review**, and its prop ceiling is the **injected scope**), [ADR-0033](./0033-ai-assisted-metadata-authoring.md) (AI writes metadata via draft-gated review), [ADR-0054](./0054-runtime-proof-for-authorable-surface.md) (ratchet a snapshot; flag regressions, not the accepted baseline), [ADR-0078](./0078-no-silently-inert-metadata.md) (no silently-inert metadata — a prop the author writes must be honored or rejected, never silently dropped).
-**Consumers**: `@objectstack/spec` (`packages/spec/src/ui/react-blocks.ts` — the block→schema index + React overlay; `scripts/build-react-blocks-contract.ts` — the generator; `scripts/check-react-blocks-declaration-parity.ts` + `react-declaration-parity.baseline.json` — the ratchet), `@objectstack/lint` (`validate-react-page-props.ts` — the authoring prop gate), `@objectstack/cli` (`os validate` wires the gate), `scripts/build-console.sh` (runs the ratchet at console-build time), `../objectui` (the component registry `inputs` are the projected surface the ratchet checks against).
+**Consumers**: `@objectstack/spec` (`packages/spec/src/ui/react-blocks.ts` — the block→schema index + React overlay; `scripts/build-react-blocks-contract.ts` — the generator; `scripts/check-react-blocks-declaration-parity.ts` + `react-declaration-parity.baseline.json` — the ratchet), `@objectstack/lint` (`validate-react-page-props.ts` — the authoring prop gate), `@objectstack/cli` (`os validate` wires the gate), `scripts/gen-sdui-manifest.sh` (`pnpm sdui:manifest` — dumps the manifest and runs the ratchet; **this is the producer**, corrected here in #5960: the ratchet moved out of `scripts/build-console.sh` in #4472 and this row still named the old file), `../objectui` (the component registry `inputs` are the projected surface the ratchet checks against).
 
 **Premise**: ADR-0081 gave authors (and AI) a `kind:'react'` page tier whose blocks are the curated public data components (`<ObjectForm>`, `<ListView>`, charts, record:* panels). For AI to author those blocks *correctly* it must know each block's props — and for that knowledge to be trustworthy, the props must come from an authoritative, machine-readable, **non-drifting** source. The problem: **there is no single such source.** Three prop surfaces exist for the same components, and nothing keeps them in lockstep:
 
@@ -24,9 +24,9 @@ They drift silently: a component can accept a prop the spec never declared (an u
 1. **[source of truth] The spec zod schema is the protocol.** The AI-facing component contract is **generated** from the spec schemas (`z.toJSONSchema`) plus a thin React-interaction overlay — never hand-authored. Generated ⇒ it cannot drift into fiction.
 2. **[registry is a subset] Registry `inputs` are the designer palette, not the protocol.** A prop the spec declares but the registry doesn't expose is a *soft* signal (panel gap), not a violation. A prop the component exposes that the spec doesn't declare is the *actionable* signal (undocumented extension).
 3. **[overlay] React-interaction props live in a thin overlay, not the spec.** Callbacks (`onSuccess`, `onRowClick`), controlled props (`recordId`, `mode`, `filters`), and binding escape-hatches (`objectName`, a chart's static `data`, a list's `fields`/`options`) are real React surface the *view metadata* schema neither models nor should. They are declared in `react-blocks.ts`'s overlay so the contract documents them.
-4. **[declaration parity = ratchet, not per-PR gate] Spec↔registry parity is checked where the manifest is free.** The registry-inputs manifest only exists at console-build time (the registry is a browser app). So it runs **inside `build-console.sh`** as a **baseline ratchet** (ADR-0054 shape): it flags only NEW registry-only inputs or vanished blocks against a committed baseline — not the accepted divergence, and not every PR. *(Amended by #4472: this said "conformance", ran warn-only, and was read as confirming the components implement the spec props. It compares two declarations and now runs `--strict`. See the addendum.)*
+4. **[declaration parity = ratchet, not per-PR gate] Spec↔registry parity is checked where the manifest is free.** The registry-inputs manifest only exists once a real browser has enumerated the built console registry. So it runs **inside `scripts/gen-sdui-manifest.sh`** (`pnpm sdui:manifest`) as a **baseline ratchet** (ADR-0054 shape): it flags only NEW registry-only inputs or vanished blocks against a committed baseline — not the accepted divergence, and not every PR. Its **trigger is the objectui pin bump** — see addendum 2. *(Amended by #4472: this said "conformance", ran warn-only, and was read as confirming the components implement the spec props. It compares two declarations and now runs `--strict`. Amended by #5960: it said `build-console.sh`, which is where it shipped and no longer where it lives — #4472 moved it into `gen-sdui-manifest.sh`. See both addenda.)*
 5. **[authoring = a hard gate] `os validate` enforces correct prop *usage*.** A separate `validate-react-page-props` gate parses each `kind:'react'` page's real JSX and checks block usage against the contract: a missing **required binding** is an error; a near-miss **prop typo** is a warning; arbitrary unknown props are *not* flagged (the contract's data props are a curated subset, so false positives stay near zero).
-6. **[the chain] Five links, each with one job.** protocol source (spec) → generated contract (`react-blocks.md`) → declaration-parity ratchet (build-console.sh) → authoring prop gate (os validate) → a dogfood golden page proving the loop closes. **No link in this chain observes a render** — see the addendum for what that costs and where the missing evidence now comes from.
+6. **[the chain] Five links, each with one job.** protocol source (spec) → generated contract (`react-blocks.md`) → declaration-parity ratchet (gen-sdui-manifest.sh) → authoring prop gate (os validate) → a dogfood golden page proving the loop closes. **No link in this chain observes a render** — see addendum 1 for what that costs and where the missing evidence now comes from.
 
 ---
 
@@ -57,15 +57,17 @@ These are declared in the `react-blocks.ts` overlay with a `kind` of `binding`/`
 
 ### 4. Declaration parity is a build-time baseline ratchet, not a per-PR gate
 
-> **Corrected by #4472 — see the addendum.** This decision was written and implemented as "conformance": the check was named `check:react-conformance`, and its script header claimed it confirmed the components "ACTUALLY implement" the spec props. It does not and never did — it compares **two declarations**, and it was **warn-only** besides. The mechanism below is real and kept; the words for it are now `check:react-declaration-parity`, and the gate now runs `--strict`.
+> **Corrected by #4472 — see addendum 1.** This decision was written and implemented as "conformance": the check was named `check:react-conformance`, and its script header claimed it confirmed the components "ACTUALLY implement" the spec props. It does not and never did — it compares **two declarations**, and it was **warn-only** besides. The mechanism below is real and kept; the words for it are now `check:react-declaration-parity`, and the gate now runs `--strict`.
+>
+> **Corrected by #5960 — see addendum 2.** This section shipped saying the ratchet runs *inside `build-console.sh`*. That was true when it was written and stopped being true at #4472, which moved it into `scripts/gen-sdui-manifest.sh`; the file names below are corrected in place, because a reader who followed this ADR opened the wrong file. #5960 also answers the question this decision left open — "not every PR" never said *when*, and the answer is **at the objectui pin bump**.
 
-`scripts/check-react-blocks-declaration-parity.ts` compares the spec props (per block, via `z.toJSONSchema`) against the registry-inputs manifest (`sdui.manifest.json`). The manifest **only exists at console-build time** — the registry is a browser app pulling browser-only deps, so a framework PR has no manifest to check against. Running it on every PR is therefore not worth it.
+`scripts/check-react-blocks-declaration-parity.ts` compares the spec props (per block, via `z.toJSONSchema`) against the registry-inputs manifest (`sdui.manifest.json`). The manifest **only exists once a real browser has enumerated the built console registry** — the registry is a browser app pulling browser-only deps, so a framework PR has no manifest to check against. Running it on every PR is therefore not worth it.
 
-Instead, it runs **inside `build-console.sh`**, immediately after it dumps the manifest (near-zero marginal cost), as a **baseline ratchet** modeled on ADR-0054:
+Instead, it runs **inside `scripts/gen-sdui-manifest.sh`** (`pnpm sdui:manifest`), immediately after that script dumps the manifest (near-zero marginal cost *there*, because the browser is already open), as a **baseline ratchet** modeled on ADR-0054:
 
 - `react-declaration-parity.baseline.json` stores each block's accepted registry-only input *set* + whether it is missing.
 - `--baseline` reports **only regressions**: a block declaring a NEW registry-only input, or a previously-present block that vanished. The soft spec-only signal is not gated.
-- It runs `--strict` in the console build, so a regression **fails** it. `--update` re-accepts the current state after a deliberate registry change.
+- It runs `--strict` there, so a regression **fails** the run. `--update` re-accepts the current state after a deliberate registry change.
 
 Because the baseline was driven to **0 registry-only** (decision 3), the ratchet is noise-free: any future registry-only input is a real, actionable signal rather than one sitting in an accepted baseline.
 
@@ -85,8 +87,9 @@ This is the ADR-0078 boundary applied to react pages: a prop the author writes i
 spec zod schema  ──gen──►  react-blocks.md      (AI reads it — decisions 1–3)
    (protocol)              (generated contract)
                                 │
-        registry inputs ──────► declaration-parity ratchet  (build-console.sh — decision 4)
-        (designer subset)       (strict baseline; two declarations, no renderer)
+        registry inputs ──────► declaration-parity ratchet  (gen-sdui-manifest.sh — decision 4)
+        (designer subset)       (strict baseline; two declarations, no renderer;
+                                 on demand, at the objectui pin bump)
                                 │
                                 ▼
                            prop gate                  (os validate — decision 5)
@@ -101,7 +104,7 @@ spec zod schema  ──gen──►  react-blocks.md      (AI reads it — decis
 
 - **Future contributors don't re-litigate the model.** Adding a public block = add it to the `react-blocks.ts` index + regenerate; the contract, the conformance baseline, and the prop gate all follow from that one edit.
 - **The contract can't lie.** It is generated from the spec schemas, so it always reflects the real protocol — there is no hand-maintained list to fall behind.
-- **New frontend divergence is caught at the release point, for free**, without taxing every PR or false-failing on the accepted (subset) baseline.
+- **New frontend divergence is caught when the frontend the repo ships actually moves**, without taxing every PR or false-failing on the accepted (subset) baseline. *(#5960: this said "at the release point, for free". Neither half survived #4472 moving the ratchet out of the console build — the trigger is the objectui pin bump, and it costs whoever bumps the pin one `pnpm sdui:manifest` run. See addendum 2.)*
 - **AI authoring is enforced, not hoped for.** A wrong prop is caught at `os validate` before it ever renders.
 - **Cost**: the contract regen + baseline are committed artifacts that must be regenerated on a deliberate change (an extra step, guarded by `gen:api-surface` for public exports and the ratchet for frontend changes). This is the price of zero-drift and is intentional.
 
@@ -115,7 +118,7 @@ spec zod schema  ──gen──►  react-blocks.md      (AI reads it — decis
 
 ---
 
-## Addendum (2026-08-01, #4472) — the ratchet compares two declarations; it was named and described as if it compared a declaration to an implementation
+## Addendum 1 (2026-08-01, #4472) — the ratchet compares two declarations; it was named and described as if it compared a declaration to an implementation
 
 **What was wrong.** Decision 4 shipped as `check:react-conformance`, and the script's header opened by saying it "confirms the objectui components **ACTUALLY implement** the props the spec protocol declares. The spec is the protocol; the frontend must conform." Both halves of its comparison are declarations:
 
@@ -139,3 +142,28 @@ This is Prime Directive #10 (declared ≠ enforced) landing on a gate — the sa
 **What is still true.** Decision 2's signal taxonomy is unchanged and worth keeping: `spec-only` (palette gap, soft), `registry-only` (undocumented extension, ratcheted), `missing` (not registered / not public). Exactly one class is invisible: both sides declare it, nothing reads it.
 
 **Where the missing evidence now comes from.** Evidence about the render path has to be taken from the render path, which lives in objectui. `apps/console/src/__tests__/public-block-binding-reach.test.tsx` (objectui) mounts every public block that declares an `objectName` input through `SchemaRenderer` with nothing but that binding, under a provider whose `dataSource` records every call, and asserts some call carried the object name. Deliberately narrow — "is this binding wired", not "is every declared input consumed", which is not decidable from outside without heuristics — and every non-reaching block carries a written reason in a ledger asserted to equal the observed set in both directions. Its first run separated five bound blocks from three unbound ones and surfaced two real defects of the #4413 shape (objectui#3144), which is the confirmation that this evidence was never obtainable from here.
+
+---
+
+## Addendum 2 (2026-08-07, #5960) — the ratchet's producer, and the trigger decision 4 never named
+
+**What was wrong, and it was two things.**
+
+1. **The file name.** Decision 4, its TL;DR line, the chain diagram and the **Consumers** row all said the ratchet runs inside `scripts/build-console.sh`. It did when this ADR was written; #4472 moved it into `scripts/gen-sdui-manifest.sh` (`pnpm sdui:manifest`) and nothing came back to correct the ADR. `build-console.sh` now *deliberately* produces no manifest — dumping one needs a real browser, and the console build must not drag a browser dependency in — so a reader following this ADR opened a file whose closing comment says the opposite of what the ADR sent them there for. `docs/audits/2026-06-react-blocks-conformance.md` carried the same stale pointer and is corrected with it.
+2. **The trigger was never stated.** "Not every PR" is a statement about where the check does *not* run. Decision 4 never said where it *does*, and the measured answer (#4690, #5960) was: nowhere automatic. No workflow runs `pnpm sdui:manifest`; no workflow installs Playwright for it; `packages/console/dist/` is gitignored; the published `@objectstack/console` tarball ships no `sdui.manifest.json`. The ratchet ran exactly when a human chose to run it, and no procedure told anyone to.
+
+**Decision (maintainer, 2026-08-07).** The ratchet is an **on-demand gate**, and its trigger is the **objectui pin bump**:
+
+> `sdui.manifest.json` only changes when the objectui pin moves, so the correct trigger has always been the pin-update flow, not every PR. The procedure gains one line: run `pnpm sdui:manifest` when bumping the objectui pin, and the ratchet runs there. #4690 already guarantees this cannot go falsely green — a missing manifest fails loudly — so honest on-demand coverage beats expensive full coverage.
+
+**Why not produce the manifest in CI.** Rejected explicitly. The only producer drives Playwright chromium over objectui's built console and reads `window.__MANIFEST`, so CI-side production means a full objectui workspace build plus a browser download on every matching PR — a cost this repo declined while paying down merge-queue health (#6082). Having objectui publish the manifest as a release artefact (leaving the browser cost on the side that already runs one) is the structurally right end state and is **deferred, not rejected**: there is no pull for it today, and it waits for the next time objectui's release pipeline is opened.
+
+**Why on-demand is honest rather than a hole.** Since #4690 the gate has no green path it has not earned: a missing `MANIFEST`, an unreadable path, malformed JSON, or a dump declaring zero components each **exit 1** with a prescription naming the producer. So the failure mode this leaves is "unrun", never "falsely passed" — and "unrun" is what the procedure line closes.
+
+**Where the line lives** (all three, because the operator meets them in this order):
+
+- `scripts/bump-objectui.sh` prints it as a NEXT STEP on every successful bump, including `--no-commit`. A **reminder, not a hard gate** — a machine without Playwright must still be able to move the pin, and hard-failing there would be CI-side cost wearing a local disguise.
+- `scripts/build-console.sh` closes with it too, because `pnpm objectui:refresh` runs bump-then-build and that output is the last thing an operator sees.
+- `docs/releases-maintenance.md` carries it as prose, in the pin-bump procedure and in the pin-freshness "fix when it fires" step.
+
+**What is unchanged.** Decision 4's mechanism and its "not every PR" verdict both stand, and this addendum records no reversal — it names the producer correctly and supplies the trigger the decision left blank.

--- a/docs/audits/2026-06-react-blocks-conformance.md
+++ b/docs/audits/2026-06-react-blocks-conformance.md
@@ -72,6 +72,10 @@ something this audit measured.)* So:
    **frontend-only** props (e.g. `object-form` formType/drawer*/modal*) to the
    spec so the protocol covers what the component accepts; and run this check in
    CI (with a console manifest dump) as a ratchet so new divergence is caught.
+   *(⚠️ The last clause was **rejected** on 2026-08-07, #5960: a console manifest dump
+   in this repo's CI means a full objectui build plus Playwright/chromium on every
+   matching PR. The ratchet is on-demand, triggered by the objectui pin bump — see
+   the correction under "Ratchet (implemented)" below.)*
 3. The `record:*` blocks declaring **zero inputs** means the visual designer can't
    configure them — likely a real gap to close.
 
@@ -85,10 +89,22 @@ MANIFEST=/path/to/sdui.manifest.json pnpm --filter @objectstack/spec check:react
 
 ## Ratchet (implemented)
 
-Running this on every framework PR isn't worth it — the manifest only exists at
-console-build time. So the conformance check is wired in as a **baseline ratchet**
-at the one place the manifest is produced for free: `scripts/build-console.sh`,
-right after it dumps `sdui.manifest.json` from the freshly-built console registry.
+Running this on every framework PR isn't worth it — the manifest only exists once a
+real browser has enumerated the built console registry. So the conformance check is
+wired in as a **baseline ratchet** at the one place the manifest is produced for free:
+`scripts/gen-sdui-manifest.sh` (`pnpm sdui:manifest`), right after it dumps
+`sdui.manifest.json` from the freshly-built console registry.
+
+> **Corrected 2026-08-07 (#5960).** This paragraph named `scripts/build-console.sh`,
+> which is where the ratchet shipped and, since #4472, no longer where it lives —
+> `build-console.sh` deliberately dumps no manifest, because the console build must not
+> drag in a browser dependency. ADR-0082 carried the same stale pointer and is corrected
+> with it. #5960 also settled *when* the ratchet runs: it is an **on-demand gate**, and
+> its trigger is the **objectui pin bump** (`scripts/bump-objectui.sh` prints the step;
+> `docs/releases-maintenance.md` carries the procedure). Producing the manifest in this
+> repo's CI was rejected — a full objectui build plus a Playwright/chromium download on
+> every matching PR — and since #4690 a missing manifest exits 1 rather than skipping, so
+> the residual risk is "unrun", never "falsely green". See ADR-0082 addendum 2.
 
 - The accepted state lives in `packages/spec/react-declaration-parity.baseline.json`
   (per block: the registry-only input set + whether the block is missing).

--- a/docs/releases-maintenance.md
+++ b/docs/releases-maintenance.md
@@ -50,6 +50,34 @@ CONSOLE_BUMP=patch scripts/bump-objectui.sh   # force the bump type
 scripts/bump-objectui.sh --no-changeset       # opt out (rarely)
 ```
 
+#### After the pin moves: run the declaration-parity ratchet (#5960)
+
+The bump has a second half, and it is not optional:
+
+```bash
+pnpm sdui:manifest    # rebuild objectui at the new pin, dump sdui.manifest.json, run the ratchet
+```
+
+`sdui.manifest.json` is objectui's registry-inputs dump — the right-hand side of
+ADR-0082 D4's spec↔registry **declaration-parity ratchet** (`scripts/gen-sdui-manifest.sh`
+produces it and runs the ratchet against it; note it is *not* `scripts/build-console.sh`,
+which the ADR named until #5960 corrected it). That file changes when — and only when —
+this pin moves, so **the pin bump is the ratchet's trigger, and its only one.**
+
+This is an **on-demand gate by decision** (maintainer ruling, 2026-08-07). No workflow
+produces the manifest and none should: the only producer drives a Playwright chromium
+over objectui's built console and reads `window.__MANIFEST`, so wiring it into this
+repo's CI would put a full objectui build plus a browser download on every matching PR.
+The trade is deliberate — honest on-demand coverage over expensive full coverage —
+and it is safe because the gate has no unearned green: since #4690 a missing, unreadable,
+malformed or empty manifest **exits 1** rather than skipping. The one failure mode left is
+that nobody runs it, which is what this step exists to close. `scripts/bump-objectui.sh`
+and `scripts/build-console.sh` both print the reminder when they finish.
+
+Needs a Playwright browser (`pnpm exec playwright install chromium-headless-shell`). When
+the ratchet fires, the fix is a spec/overlay edit or an explicit `--update` to re-accept
+the baseline — see ADR-0082 D4 and its addendum 2.
+
 ## 3. Platform layer — `content/docs/releases/vN.mdx` (curated)
 
 The curated, developer-facing "big picture", written for third parties building on
@@ -134,8 +162,10 @@ node scripts/check-objectui-pin-fresh.mjs --ref v17.0.0 --json
   down without turning red into green — the degradation is printed, not swallowed. An
   unreachable remote is reported as `unreadable` and exits non-zero.
 - **Fix when it fires:** `scripts/bump-objectui.sh` to move the pin (which writes the
-  `@objectstack/console` changeset for the crossed range), then re-source the Console
-  section with `scripts/objectui-range.mjs`.
+  `@objectstack/console` changeset for the crossed range), then `pnpm sdui:manifest` to
+  run the declaration-parity ratchet at the new pin (see "After the pin moves" above —
+  the bump is that ratchet's only trigger), then re-source the Console section with
+  `scripts/objectui-range.mjs`.
 
 ## Drift guard
 

--- a/scripts/build-console.sh
+++ b/scripts/build-console.sh
@@ -190,5 +190,12 @@ echo "✓ @objectstack/console dist ready (${BYTES} KB) from objectui@${PINNED_S
 # real browser (Playwright) to enumerate the console registry, and the console
 # build must not drag in a browser dependency. Regenerate them on demand instead:
 #   pnpm sdui:manifest        (see scripts/gen-sdui-manifest.sh)
+#
+# The reminder names the TRIGGER, not just the command (#5960): `pnpm objectui:refresh`
+# runs bump-objectui.sh and then this script, so this is the last output an operator
+# sees while moving the pin — and the pin bump is the ratchet's only trigger, by
+# decision. bump-objectui.sh prints the same step; this repeats it because that one
+# has scrolled past a whole console build by now.
 echo "ℹ SDUI manifest + declaration-parity ratchet are decoupled from the console build."
-echo "  Run 'pnpm sdui:manifest' on demand to regenerate (requires Playwright)."
+echo "  Run 'pnpm sdui:manifest' whenever you move the objectui pin — that is the"
+echo "  ratchet's only trigger, on demand by decision (#5960). Requires Playwright."

--- a/scripts/bump-objectui.sh
+++ b/scripts/bump-objectui.sh
@@ -7,6 +7,13 @@
 #   scripts/bump-objectui.sh --no-commit    # update files only, don't commit
 #   scripts/bump-objectui.sh --no-changeset # skip the @objectstack/console changeset
 #
+# After the bump — the second half of the pin-update procedure (#5960):
+#   pnpm sdui:manifest        # dump objectui's sdui.manifest.json and run the
+#                             # spec↔registry declaration-parity ratchet (ADR-0082 D4).
+#                             # The pin bump is that ratchet's ONLY trigger; it is an
+#                             # on-demand gate by decision, never a CI job. Needs
+#                             # Playwright chromium. This script prints the reminder.
+#
 # Env:
 #   CONSOLE_BUMP=major|minor|patch  # force the changeset bump type (default: auto —
 #                             # the HIGHEST level objectui itself declared in the
@@ -56,7 +63,10 @@ for arg in "$@"; do
     --no-commit) NO_COMMIT=1 ;;
     --no-changeset) NO_CHANGESET=1 ;;
     -h|--help)
-      sed -n '2,19p' "$0" | sed 's/^# \{0,1\}//'
+      # NOTE: this line range is coupled to the header block above (usage → env →
+      # sibling layout, ending at "run from here"). Editing the header means moving
+      # it — #5960 added the pin-update step and had to.
+      sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *) EXPLICIT_SHA="$arg" ;;
@@ -157,8 +167,36 @@ EOF
   echo "→ wrote changeset $(basename "$CS_FILE") (@objectstack/console: ${BUMP})"
 fi
 
+# --- The other half of the pin-update procedure (#5960) ----------------------
+# ADR-0082 D4's spec↔registry declaration-parity ratchet reads objectui's
+# `sdui.manifest.json`, and that file changes when — and only when — this pin
+# moves. So the pin bump is the ratchet's trigger, and it is the ONLY one:
+# measured on origin/main, no workflow runs `pnpm sdui:manifest`, no workflow
+# installs Playwright for it, `packages/console/dist/` is gitignored and the
+# published @objectstack/console tarball ships no manifest. Producing it in this
+# repo's CI was considered and REJECTED (#5960) — it would put a full objectui
+# build plus a chromium download on every matching PR.
+#
+# Deliberately a REMINDER, not a hard gate: a machine without Playwright must
+# still be able to move the pin, and hard-failing here would be the rejected
+# CI cost wearing a local disguise. The gate itself cannot go falsely green —
+# since #4690 a missing or unusable manifest exits 1 instead of skipping — so
+# the only failure mode left is "nobody ran it", which is what this prints to
+# prevent. Printed on BOTH exits below: --no-commit still moved the pin.
+print_sdui_next_step() {
+  echo
+  echo "→ NEXT STEP — run the declaration-parity ratchet (ADR-0082 D4):"
+  echo "      pnpm sdui:manifest"
+  echo "  It rebuilds objectui at the new pin, dumps packages/console/dist/sdui.manifest.json"
+  echo "  and ratchets spec↔registry declaration parity. A pin bump is its only trigger:"
+  echo "  it is an on-demand gate by decision (#5960), never a CI job."
+  echo "  Needs a Playwright browser — 'pnpm exec playwright install chromium-headless-shell'."
+  echo "  Procedure: docs/releases-maintenance.md → 'After the pin moves'."
+}
+
 if [[ "$NO_COMMIT" -eq 1 ]]; then
   echo "→ --no-commit: leaving files unstaged."
+  print_sdui_next_step
   exit 0
 fi
 
@@ -170,3 +208,4 @@ ${SUBJECT_LINE}
 
 objectui@${NEW_SHA}" -- .objectui-sha ${CS_FILE:+"$CS_FILE"}
 echo "✓ Committed. Push with: git push"
+print_sdui_next_step

--- a/scripts/objectui-changeset-digest.mjs
+++ b/scripts/objectui-changeset-digest.mjs
@@ -1226,10 +1226,25 @@ function selfTest() {
     for (const f of ['bump-objectui.sh', 'objectui-changeset-digest.mjs']) {
       writeFileSync(join(fwRun, 'scripts', f), readFileSync(join(__dirname, f), 'utf8'));
     }
-    execFileSync('bash', [join(fwRun, 'scripts', 'bump-objectui.sh'), '--no-commit', head], {
-      encoding: 'utf8',
-      env: { ...process.env, OBJECTUI_ROOT: ui },
-    });
+    const bumpStdout = execFileSync(
+      'bash',
+      [join(fwRun, 'scripts', 'bump-objectui.sh'), '--no-commit', head],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, OBJECTUI_ROOT: ui },
+      },
+    );
+    // #5960: the pin bump is the ONLY trigger of ADR-0082 D4's declaration-parity
+    // ratchet — no workflow produces `sdui.manifest.json`, by ruling — so the
+    // procedure's second half lives in this script's output. Prose alone is
+    // deletable in silence; pinning it here is what makes "the procedure gained a
+    // line" a fact a gate can lose. Asserted on the `--no-commit` path on purpose:
+    // that path moved the pin too, and it is the one that returns early.
+    check(
+      '#5960 a bump prints the `pnpm sdui:manifest` step (the ratchet has no other trigger)',
+      bumpStdout.includes('pnpm sdui:manifest') && bumpStdout.includes('NEXT STEP'),
+      bumpStdout,
+    );
     const written = join(fwRun, '.changeset', `console-${head.slice(0, 12)}.md`);
     const body = existsSync(written) ? readFileSync(written, 'utf8') : '';
     check('bump-objectui.sh writes the digest-derived changeset', body.length > 0);


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5960

Implements the maintainer's ruling of 2026-08-07 (option D), quoted verbatim from the issue thread:

> **Ruling (maintainer, 2026-08-07): option D — declare it an on-demand gate and write it into the pin-update procedure.**
>
> `sdui.manifest.json` only changes when the objectui pin moves, so the correct trigger has always been the pin-update flow, not every PR. The procedure gains one line: run `pnpm sdui:manifest` when bumping the objectui pin, and the ratchet runs there. #4690 already guarantees this cannot go falsely green — a missing manifest fails loudly — so honest on-demand coverage beats expensive full coverage.
>
> Rider, no ruling needed: ADR-0082's Consumers/D4 note and the audit doc still point at `build-console.sh` when the producer is `gen-sdui-manifest.sh` — correct that in passing.

Option A (produce the manifest in this repo's CI) and option B (objectui publishes it as a release artefact) are **not** implemented here: no workflow was touched, no trigger added, no artefact published. `packages/spec/**` is untouched.

---

## Premise check against `origin/main` (761a0ba)

Every claim in the issue body was re-measured before editing. All four hold:

| claim | measured |
|:--|:--|
| no workflow runs `pnpm sdui:manifest` | `grep -rl 'sdui:manifest' .github/workflows/` returns nothing |
| `build-console.sh` deliberately produces no manifest | lines 188-194: `"SDUI manifest + declaration-parity ratchet are decoupled from the console build."` |
| the pin-update procedure carries no such line | `docs/releases-maintenance.md`, `scripts/bump-objectui.sh` and `AGENTS.md` all name the bump; none named the ratchet |
| the ADR and the audit doc misname the producer | 5 sites in `docs/adr/0082-*.md`, 1 in `docs/audits/2026-06-react-blocks-conformance.md` |

The PM's mechanism assumptions were checked too, and one needed widening. `scripts/bump-objectui.sh` is indeed where a pin bump is *executed*, but it is not where the procedure is *written down* — that is `docs/releases-maintenance.md` §"The frontend is a package too" plus its pin-freshness "fix when it fires" step, with `AGENTS.md` §Frontend as the third place an operator looks. The line went into all of them, plus the two scripts whose output an operator actually reads.

## What changed

**1. The pin-update procedure gains the step** (five places, ordered by when the operator meets them):

- `scripts/bump-objectui.sh` prints a `NEXT STEP` block on **both** successful exits, including `--no-commit` (that path moved the pin too). Deliberately a **reminder, not a hard gate**: hard-failing a bump on a machine with no Playwright would be the rejected CI cost wearing a local disguise. The header gains the same step, and the `--help` window (`sed -n '2,19p'`) moved with it.
- `scripts/build-console.sh`'s closing line now names the **trigger**, not just the command. `pnpm objectui:refresh` runs bump-then-build, so this is the last thing an operator sees while moving the pin — the bump script's reminder has scrolled past a whole console build by then.
- `docs/releases-maintenance.md` gains "After the pin moves: run the declaration-parity ratchet", and the pin-freshness **Fix when it fires** bullet gains the run between the bump and the range re-source.
- `AGENTS.md` §Frontend gains the step; its `check:generated` note stops calling the manifest's provenance "an open provenance question, tracked separately" and records the answer.

**2. The reminder is pinned by a gate.** `scripts/objectui-changeset-digest.mjs --self-test` already drives `bump-objectui.sh` end-to-end in throwaway git repos; it now asserts that a bump prints the `pnpm sdui:manifest` step. That self-test is CI's `check:objectui-changeset` (lint.yml, ESLint job), so the procedure line cannot be deleted in silence. Prose alone was the thing that failed here for two months.

**3. The rider.** ADR-0082's Consumers row, TL;DR item 4, decision 4's body, the chain diagram and one Consequences bullet all pointed at `scripts/build-console.sh`. Corrected in place — with the correction annotated, matching the file's existing house style — plus a new **Addendum 2** recording the ruling, the rejected/deferred options, and why on-demand is honest rather than a hole. The existing addendum is now "Addendum 1" and its three inbound references were updated. `docs/audits/2026-06-react-blocks-conformance.md` gets the same correction, and its 2026-06 recommendation to "run this check in CI" is marked as rejected rather than left standing against the ruling.

No ADR decision is reversed (Prime Directive #13): decision 4's mechanism and its "not every PR" verdict both stand. The addendum names the producer correctly and supplies the trigger the decision left blank.

## Verification

Reverse verification, direction predicted **before** running it: **red** — the new assertion reads the bump script's stdout for a string this change introduces, so deleting the reminder must fail it.

```
# reminder deleted from the --no-commit path:
  ✗ #5960 a bump prints the `pnpm sdui:manifest` step (the ratchet has no other trigger)
self-test exit code with the reminder deleted = 1
# restored:
restored self-test exit code = 0
```

Functional proof that both exit paths print (fixture: throwaway objectui + framework repos):

```
===== --no-commit path =====
→ --no-commit: leaving files unstaged.

→ NEXT STEP — run the declaration-parity ratchet (ADR-0082 D4):
      pnpm sdui:manifest
===== commit path =====
✓ Committed. Push with: git push

→ NEXT STEP — run the declaration-parity ratchet (ADR-0082 D4):
      pnpm sdui:manifest
```

`bash scripts/bump-objectui.sh --help` was re-read to confirm the moved window still prints usage through "run from here", and now includes the new step.

**Gates, enumerated from `.github/workflows/lint.yml` and run one by one — all green.** ESLint job: `pnpm lint`, `check:slot-lookup`, `check:query-options-erasure`, `check:nul-bytes`, `check:doc-authoring`, `check:docs-audit-scope`, `check:role-word`, `check:quick-reference-counts`, `check:adr-anchors`, `check:org-identifier`, `check:authz-resolver`, `check:service-providers`, `check:route-envelope`, `check:error-code-casing`, `check:wildcard-fallthrough`, `check:meta-type-normalized`, `check:init-service-contract`, `check:durability-log-level`, `check:startup-registry-verdict`, `check:objectui-changeset`, `check:release-notes`, `check:release-body`, `check:node-version`, `check:workflow-status-functions`, `check:shard-attestation`, `check:published-files`, `check:engine-double-contract`, `check:resume-authority-declared`, `check:merge-driver`, `check:spec-parsed-alias`. TypeScript Type Check job: `check:type-check-coverage`, `check:driver-conformance`, `check:stall-guard`, spec `tsc --noEmit`, `check:generated --reconcile-only`, `check:skill-docs`, `check:spec-changes`, `check:upgrade-guide`, `check:authorable-surface`, `check:docs`, `check:skill-refs`, `check:skill-frame-sync`, `check:skill-compatibility`, `check:react-blocks`, `check:type-check-debt`, `check:api-surface`, `check:exported-any`, `check:dual-source-exports`, `check:skill-examples`, `check:doc-formula-expressions`, `check:i18n`, `check:i18n-coverage`.

Two of those needed their CI prerequisite before they meant anything, and said so loudly rather than passing: `check:i18n` refused with "PREREQUISITE NOT MET — the workspace CLI is not built" and `check:i18n-coverage` with "COULD NOT MEASURE — 1 of 12 config(s) failed to lint". Both went green after `turbo run build`, which is the order lint.yml runs them in.

Byte discipline: `node scripts/check-nul-bytes.mjs` clean over 6051 tracked files, plus a self-scan of every edited file with `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` — no hits.

## Changeset

**None — this PR needs the `skip-changeset` label**, route 2 of the Check Changeset gate's own prescription. It releases nothing: the diff is `scripts/**`, `docs/**` and `AGENTS.md`, none of which is a workspace member or appears in any package's `files` whitelist (`check:published-files` covers 69 publishable packages and none of these paths). An empty-frontmatter changeset is explicitly **not** an option here (#5471 closed that route, #4898 is why). The label is applied on this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AZgRyPVwi1jLb1mNNuUQ9o)_