### PR TITLE
fix(spec): `systemFields.owner` guidance no longer claims `ownership: 'org'` picks a principal (#6365)

### DIFF
--- a/.changeset/systemfields-owner-guidance-org-skips-owner-id.md
+++ b/.changeset/systemfields-owner-guidance-org-skips-owner-id.md
@@ -1,0 +1,55 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): the `systemFields.owner` rescue no longer tells authors that `ownership: 'org'` picks a different principal (#6365)
+
+`systemFields` has never declared an `owner` key, and the field doc above the
+block names one — so an author (or an AI writing metadata) who follows that
+prose lands on the block's `guidance.owner` prescription. That prescription
+said:
+
+> `owner_id` injection is governed by the object-level `ownership` property
+> (`ownership: 'none'` skips it; `'user'`/`'org'` choose the principal).
+
+The second half was false. `'org'` does not choose a different principal — it
+injects **no** `owner_id` at all. The authority `applySystemFields` consumes,
+`resolveInjectedSystemColumns` (`packages/spec/src/data/injected-system-columns.ts`),
+admits exactly two spellings:
+
+```ts
+const owner = ownershipEligible && (ownership === undefined || ownership === 'user');
+```
+
+and the `ownership` property's own JSDoc, ~90 lines above the guidance, already
+said so correctly (`org` / `none` — no per-record owner; `owner_id` is NOT
+injected). The guidance was the wrong side of that contradiction.
+
+Why it was worth fixing rather than leaving as prose drift: this is the text an
+author is handed at the exact moment they are already confused about where owner
+injection is configured, and it sent them to `ownership: 'org'` expecting an
+org-keyed owner column. Nothing rejects `ownership: 'org'`, so the mistake
+ships silently and every owner-keyed feature quietly does nothing —
+owner-scoped RLS, "My" views, owner reports, the first-admin bootstrap handoff.
+That is the failure mode the `guidance` machinery exists to prevent, inverted:
+a wrong-key rescue handing out a second wrong answer.
+
+The rescue now states the injection rule as the authority implements it —
+`'user'` (or omitted) injects `owner_id`; `'org'` and `'none'` **both** skip it
+and no `owner_id` is injected at all — while keeping the two skipping values
+visibly distinct in intent (`'org'` for an org-wide catalog, `'none'` for a
+junction/link table), since that distinction is the reason the enum carries
+both.
+
+The sibling `guidance.ownership` message is widened in the same pass. It was not
+wrong, only out of date: since #5677 / ADR-0117 D1 the `ownership` property
+governs **both** record-ownership anchors, so the message now says it decides
+whether `owner_id` **and** `owning_business_unit_id` are injected, rather than
+naming only the first.
+
+Text only — no acceptance change. Every value `ObjectSchema` accepted before is
+accepted now, every value it rejected is still rejected, and the injection
+behaviour is untouched. The new pin tests assert the message's substance against
+`resolveInjectedSystemColumns` rather than echoing the sentence, so the
+prescription can only stay green while it still describes what the injection
+pass really does.

--- a/packages/spec/src/data/object-strictness-batch20.test.ts
+++ b/packages/spec/src/data/object-strictness-batch20.test.ts
@@ -47,6 +47,7 @@ import {
   IndexSchema,
   defineObjectExtension,
 } from './object.zod';
+import { resolveInjectedSystemColumns } from './injected-system-columns';
 import { getMetadataTypeSchema } from '../kernel/metadata-type-schemas';
 
 /** Reject `value` through `schema` and return its issues as a searchable string. */
@@ -268,6 +269,54 @@ describe('#4001 批 20 — curation is anchored to the sibling contract that mak
       expect(msg).toContain('ownership');
       // The claim: `ownership` is the real, enforced lever, one level up.
       accept(ObjectSchema, { ...OBJ, ownership: 'none' });
+    });
+
+    // #6365 — the wrong-key rescue used to hand out a SECOND wrong answer. It
+    // said `'user'`/`'org'` "choose the principal", so an author who wanted an
+    // org-owned record was sent to `ownership: 'org'` — which injects no
+    // `owner_id` at all, and nothing rejects it, so every owner-keyed feature
+    // (owner-scoped RLS, "My" views, owner reports, the first-admin bootstrap
+    // handoff) quietly does nothing. The assertions below are anchored to the
+    // injection authority rather than to the sentence, so the prescription can
+    // only stay green while it still describes what really happens.
+    it("`systemFields.owner`'s prescription matches the injection authority — `'org'` SKIPS `owner_id`, it does not pick a different principal (#6365)", () => {
+      // The authority `applySystemFields` consumes (`resolveInjectedSystemColumns`).
+      // `'org'` sits with `'none'` on the withheld side, not opposite it.
+      expect(resolveInjectedSystemColumns({ ...OBJ, ownership: 'org' }).owner).toBe(false);
+      expect(resolveInjectedSystemColumns({ ...OBJ, ownership: 'none' }).owner).toBe(false);
+      expect(resolveInjectedSystemColumns({ ...OBJ, ownership: 'user' }).owner).toBe(true);
+      expect(resolveInjectedSystemColumns(OBJ).owner, 'omitted behaves as `user`').toBe(true);
+
+      const msg = rejectOnObject({ systemFields: { tenant: true, owner: false } });
+      // …and the message says exactly that: the two skipping values are named
+      // TOGETHER, and the absence is stated as an absence.
+      expect(msg).toContain("`'org'` and `'none'` BOTH skip it");
+      expect(msg).toContain('no `owner_id` is injected at all');
+      // The retired claim, pinned by name so it cannot come back by paraphrase
+      // of the same idea — `'org'` as a second *principal*.
+      expect(msg).not.toContain('choose the principal');
+      expect(msg).not.toContain('principal');
+      // …while `'org'` and `'none'` stay visibly DISTINCT in intent, which is
+      // the reason the enum carries both (the `ownership` JSDoc's own split:
+      // Dataverse-style catalog vs junction table).
+      expect(msg).toContain('org-wide catalog');
+      expect(msg).toContain('junction/link');
+    });
+
+    it('`systemFields.ownership` names BOTH ownership anchors — since #5677 the property governs `owning_business_unit_id` too (#6365)', () => {
+      const msg = rejectOnObject({ systemFields: { tenant: true, ownership: 'none' } });
+      expect(msg).toContain('TOP-LEVEL');
+      expect(msg).toContain('owner_id');
+      expect(msg).toContain('owning_business_unit_id');
+
+      // The claim, against the authority: across the whole AUTHORABLE enum the
+      // two anchors move together — injected under `'user'`/omitted, withheld
+      // under `'org'`/`'none'`. (ADR-0117 D1's fourth tier is the one case that
+      // splits them, and it is deliberately unauthorable today — #5678.)
+      for (const ownership of [undefined, 'user', 'org', 'none'] as const) {
+        const plan = resolveInjectedSystemColumns({ ...OBJ, ownership });
+        expect(plan.owningBusinessUnit, `ownership: ${String(ownership)}`).toBe(plan.owner);
+      }
     });
 
     it('`external.allowWrites` names the DOUBLE opt-in — the datasource half and the object half', () => {

--- a/packages/spec/src/data/object.zod.ts
+++ b/packages/spec/src/data/object.zod.ts
@@ -1391,12 +1391,15 @@ const ObjectSchemaBase = z.object({
           // here. `ownership` is the real, enforced lever.
           owner:
             '`owner` is not a `systemFields` key — `owner_id` injection is governed by the ' +
-            "object-level `ownership` property (`ownership: 'none'` skips it; " +
-            "`'user'`/`'org'` choose the principal). `systemFields` controls only `tenant` " +
-            '(organization_id) and `audit` (created_at/created_by/updated_at/updated_by).',
+            "object-level `ownership` property: `'user'` (or omitted) injects it, while " +
+            "`'org'` and `'none'` BOTH skip it and no `owner_id` is injected at all — " +
+            "`'org'` for an org-wide catalog (Dataverse-style), `'none'` for a junction/link " +
+            'table. `systemFields` controls only `tenant` (organization_id) and `audit` ' +
+            '(created_at/created_by/updated_at/updated_by).',
           ownership:
             '`ownership` is a TOP-LEVEL object key, not a `systemFields` key — write it ' +
-            'beside `systemFields`. It, not this block, decides whether `owner_id` is injected.',
+            'beside `systemFields`. It, not this block, decides whether the ownership ' +
+            'anchors (`owner_id` and `owning_business_unit_id`) are injected.',
         },
       }, {
         tenant: z.boolean().optional().describe('Inject the organization_id column. Default true (the column is always provisioned; the multi-tenant flag governs only its index).'),


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6365

## The defect

`packages/spec/src/data/object.zod.ts`, in the `systemFields` `strictObject`'s `guidance` block — the message an author gets when they write the non-existent `systemFields: { owner: ... }` key — said:

> `owner_id` injection is governed by the object-level `ownership` property (`ownership: 'none'` skips it; `'user'`/`'org'` **choose the principal**).

The second half is false. `ownership: 'org'` does not choose a different principal; it injects **no** `owner_id` at all. The authority `applySystemFields` consumes — `resolveInjectedSystemColumns` in `packages/spec/src/data/injected-system-columns.ts` — admits exactly two spellings:

```ts
const owner = ownershipEligible && (ownership === undefined || ownership === 'user');
```

The `ownership` property's own JSDoc, ~90 lines above the guidance, already stated it correctly (`org` / `none` — no per-record owner; `owner_id` is NOT injected). So the guidance contradicted a sibling stanza in the same file, and the guidance was the wrong side.

## Why it was worth fixing

This is not dormant prose. It is the error text an author — or an AI writing metadata — is handed at the exact moment they are already confused about where owner injection is configured, and it sent them to `ownership: 'org'` expecting an owner column keyed to the organization. Nothing rejects `ownership: 'org'`, so the mistake ships silently and every owner-keyed feature quietly does nothing: owner-scoped RLS, "My" views, owner reports, the first-admin bootstrap handoff. That is the failure mode the surrounding `guidance` machinery exists to prevent, inverted — a wrong-key rescue handing out a second wrong answer.

## What changed

Two strings, nothing else.

**`guidance.owner`** now states the rule as the authority implements it: `'user'` (or omitted) injects `owner_id`, while `'org'` and `'none'` **both** skip it and no `owner_id` is injected at all. The two skipping values stay visibly distinct in intent (`'org'` for an org-wide catalog, Dataverse-style; `'none'` for a junction/link table), since that distinction is the reason the enum carries both.

**`guidance.ownership`** is widened in the same pass. It was not wrong, only out of date: since #5677 / ADR-0117 D1 the `ownership` property governs **both** record-ownership anchors, so the message now says it decides whether `owner_id` **and** `owning_business_unit_id` are injected, rather than naming only the first.

Deliberately untouched per the issue's scope ruling: the `ownership` enum's own `error` text and `describe()` (#5678's surface), and any mention of the `business_unit` tier.

## The acceptance surface does not move

Text only. Every value `ObjectSchema` accepted before is accepted now, every value it rejected is still rejected, and the injection behaviour is untouched. `git status` after a full build carries only the three files in this diff — in particular `authorable-surface.base.json` is byte-identical and `content/docs/references/**` did not regenerate, which confirms the expectation that a `guidance` string is an error-message template rather than a `.describe()` input.

## Tests

The batch-20 pin gains two cases. They assert the message's **substance against `resolveInjectedSystemColumns`** rather than echoing the sentence, so the prescription can only stay green while it still describes what the injection pass really does:

- `'org'` and `'none'` both resolve `owner: false`, `'user'` and omitted resolve `owner: true` — and the message names the two skipping values together, states the absence as an absence, keeps them distinct in intent, and no longer contains the word `principal`.
- Across the whole authorable enum the two anchors move together (`plan.owningBusinessUnit === plan.owner`) — and the message names both.

**Reverse verification, direction predicted before running: red.** Restoring the old string turns exactly those two new cases red and leaves the other 43 in the file green, so the pins are load-bearing and additive rather than a re-spelling of an existing assertion.

```
× `systemFields.owner`'s prescription matches the injection authority … (#6365)
× `systemFields.ownership` names BOTH ownership anchors … (#6365)
Tests  2 failed | 43 passed (45)
```

With the fix in place:

```
pnpm --filter @objectstack/spec test
Test Files  338 passed (338)
     Tests  8651 passed (8651)

pnpm --filter @objectstack/spec typecheck   →  PASS (tsc --noEmit + tsconfig.test.json)
pnpm --filter @objectstack/spec check:generated  →  All 10 generated artifacts are up to date.
```

Gates enumerated from `.github/workflows/lint.yml` and run one by one: all 30 ESLint-job `check:*` steps pass, plus the TypeScript-job set (`type-check-coverage`, `driver-conformance`, `stall-guard`, `skill-frame-sync`, `skill-compatibility`, `exported-any`, `dual-source-exports`, `skill-examples`, `doc-formula-expressions`, `type-check-debt`, `i18n`, `i18n-coverage`) and `pr-automation.yml`'s `check-adr-0087-registration` (0 declared-breaking changesets — this is a patch).

One note on build state: `check:i18n` and `check:i18n-coverage` first reported red in the fresh worktree because they run the **built** CLI, which did not exist yet. Both are green after `turbo run build` — the AGENTS.md §9 stale/absent-artefact trap, not a finding.

## Changeset

`.changeset/systemfields-owner-guidance-org-skips-owner-id.md` — `@objectstack/spec: patch`. An author-visible error-message change earns a real changeset; no ADR-0087 marker is required because nothing is declared breaking.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk)_