### PR TITLE
fix(lint): `collectViewRecord` 按运行时视图身份判定容器默认 `list` 的 `_views` 键 (#6038)

### DIFF
--- a/.changeset/lint-views-key-runtime-identity.md
+++ b/.changeset/lint-views-key-runtime-identity.md
@@ -1,0 +1,42 @@
+---
+'@objectstack/lint': patch
+---
+
+`translation-target-unknown` 按运行时视图身份判定容器默认 `list` 的 `_views` 键(#5164 第 2 棒 / lint 段)
+
+`validate-translation-references` 的 `collectViewRecord()` 过去读 `view.list.name`
+来决定容器默认列表贡献哪个 `_views` 名 —— 作者没写 `name` 时它什么也不注册,而组装器
+(`expandViewContainer`,`packages/spec/src/ui/view.zod.ts`)给同一个视图的身份是
+`<object>.default`。第 1 棒(#6124)已把 i18n 提取器改为向组装器查询同一个键,于是
+**同一次 `os lint` 运行里**出现了一对自相矛盾的结论:
+
+- 要求方 `i18n/missing-view`:`objects.<object>._views.default.label` 缺翻译;
+- 否定方 `translation-target-unknown`:`_views.default` 是孤儿键,「no view of object
+  `<object>` declares it」。
+
+作者补了译文被判孤儿,删了译文被判缺翻译,两条都躲不掉。本仓库自带示例上实测有 8 处
+(`examples/app-showcase` 6 处、`examples/app-todo` 2 处)。
+
+本规则现在同样**向组装器查询**这个键,而不是第三次自行推导,因此继承了组装器仅有的三条
+规则:
+
+- 无 `name` 的默认列表键为 `default`;带 `name` 的沿用作者的 `name`;
+- 结构上与某个 `listViews` 条目完全相同的默认列表被组装器按签名**折叠**进该条目,只有
+  存活的那个键合法 —— 被折叠掉的 `list.name` 不再是合法键(`examples/app-crm` 形状);
+- 因命名冲突被改名的键(`default` → `default_2`)按**改名后**判定,因为改名后的名字才是
+  注册表键。
+
+## 判定变化(全是 warning,不改 `os lint` 退出码)
+
+| 形状 | 变化前 | 变化后 |
+|---|---|---|
+| 默认 `list` 无 `name`,包里写 `_views.default.*` | 报孤儿(误报) | 通过 |
+| 默认 `list` 无 `name`,包里写 `_views.list.*` | 报孤儿 | 报孤儿(不变;提示语现在会列出 `default`) |
+| 默认 `list` 与某个 `listViews.<k>` 同签名,包里写 `_views.<list.name>.*` | 通过(漏报) | 报孤儿 —— 该键运行时解析不到 |
+| 默认 `list` 因冲突被改名 `default_2`,包里写 `_views.default_2.*` | 报孤儿(误报) | 通过 |
+
+本仓库 12 个受棘轮覆盖的配置上实测:**新增 0 条**,消除 8 条误报;
+`check:i18n-coverage` 基线不变(该棘轮只数 `i18n/` 前缀,本规则不在其内)。
+
+裁决依据:维护者 2026-08-06(#5164)—— `_views` 翻译键的 canonical 拼写 = 运行时身份的
+裸键。第 3 棒 objectui `viewSuffixes` 去第二候选(objectui#3502)不在本次变更内。

--- a/packages/lint/src/validate-translation-references.test.ts
+++ b/packages/lint/src/validate-translation-references.test.ts
@@ -411,6 +411,13 @@ describe('validateTranslationReferences — the canonical view-record shape', ()
   // Reading `view.name` / `view.data.object` at the record root resolves
   // nothing here, drops the record, and reports every view key the app ships —
   // ~40 correct keys on the real corpus.
+  //
+  // The default list carries a `label` (#6038): without one it is
+  // signature-identical to `listViews.my_leads` (`{type,label,columns}` all
+  // equal), the composer collapses the two, and `all_leads` is not a runtime
+  // view name at all — so the fixture would be asserting that a key nothing
+  // resolves is legal. The label makes it the distinct default list this test
+  // says it is. The collapse itself is pinned separately below.
   const leadViews = {
     objects: [{ name: 'crm_lead', fields: { name: { type: 'text' } } }],
     views: [
@@ -418,6 +425,7 @@ describe('validateTranslationReferences — the canonical view-record shape', ()
         list: {
           type: 'grid',
           name: 'all_leads',
+          label: 'All Leads',
           data: { provider: 'object', object: 'crm_lead' },
         },
         listViews: {
@@ -470,6 +478,159 @@ describe('validateTranslationReferences — the canonical view-record shape', ()
     expect(findings).toHaveLength(1);
     expect(findings[0].path).toBe('translations[0].en.objects.crm_lead._views.hot_leads');
     expect(findings[0].hint).toContain('all_leads');
+  });
+
+  // ── #6038 / #5164 leg 2: the default list's key is the RUNTIME's ─────────
+  //
+  // The composer (`expandViewContainer`) is the single producer of a view's
+  // runtime identity, and these pin that this rule reads the key from it
+  // instead of re-deriving one. Every fixture below is driven through the real
+  // `validateTranslationReferences`, and every "legal" assertion is paired with
+  // a planted bad key on the SAME fixture — a `toEqual([])` that passes because
+  // the rule produced nothing at all would prove nothing.
+  describe('the default list is keyed by the runtime identity, single spelling', () => {
+    /** The showcase shape: a container declaring ONLY a nameless default list. */
+    const namelessDefaultList = {
+      objects: [{ name: 'crm_lead', fields: { name: { type: 'text' } } }],
+      views: [
+        {
+          list: { type: 'grid', label: 'All Leads', data: { provider: 'object', object: 'crm_lead' } },
+        },
+      ],
+    };
+
+    const bundle = (views: Record<string, unknown>) => ({
+      translations: [{ en: { objects: { crm_lead: { label: 'Lead', _views: views } } } }],
+    });
+
+    it('accepts `default` for a nameless default list — the key the registry holds', () => {
+      const findings = validateTranslationReferences({
+        ...namelessDefaultList,
+        ...bundle({ default: { label: '全部线索' } }),
+      });
+      expect(findings).toEqual([]);
+    });
+
+    it('the same fixture still reports a key nothing declares (the green above is not an empty run)', () => {
+      const findings = validateTranslationReferences({
+        ...namelessDefaultList,
+        ...bundle({ default: { label: '全部线索' }, hot_leads: { label: 'Hot' } }),
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0].path).toBe('translations[0].en.objects.crm_lead._views.hot_leads');
+    });
+
+    it('rejects the old `list` spelling — one key per view, and it is the runtime one', () => {
+      const findings = validateTranslationReferences({
+        ...namelessDefaultList,
+        ...bundle({ list: { label: '全部线索' } }),
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0].path).toBe('translations[0].en.objects.crm_lead._views.list');
+      expect(findings[0].hint).toContain('default');
+    });
+
+    it('a named default list keeps the author\'s `name`', () => {
+      const stack = {
+        objects: [{ name: 'crm_lead', fields: { name: { type: 'text' } } }],
+        views: [
+          {
+            list: {
+              type: 'grid',
+              name: 'all_leads',
+              label: 'All Leads',
+              data: { provider: 'object', object: 'crm_lead' },
+            },
+            listViews: { my_leads: { type: 'grid', data: { provider: 'object', object: 'crm_lead' } } },
+          },
+        ],
+      };
+      expect(
+        validateTranslationReferences({ ...stack, ...bundle({ all_leads: { label: 'A' }, my_leads: { label: 'M' } }) }),
+      ).toEqual([]);
+      // …and `default` is NOT legal here: the author named the view, so the
+      // composer never falls back to `default`.
+      const planted = validateTranslationReferences({ ...stack, ...bundle({ default: { label: 'D' } }) });
+      expect(planted).toHaveLength(1);
+      expect(planted[0].path).toBe('translations[0].en.objects.crm_lead._views.default');
+    });
+
+    it('a default list collapsed into a `listViews` entry contributes that entry\'s key, not its own `name`', () => {
+      // Composer fact 2 — the `examples/app-crm` shape: `list` is
+      // signature-identical to `listViews.all` (`{type,label,columns}` equal),
+      // so the two are ONE registry entry named `all`. `list.name` resolves to
+      // nothing and must not be a legal bundle key.
+      const collapsed = {
+        objects: [{ name: 'crm_lead', fields: { name: { type: 'text' } } }],
+        views: [
+          {
+            list: { type: 'grid', name: 'all_leads', data: { provider: 'object', object: 'crm_lead' } },
+            listViews: { all: { type: 'grid', data: { provider: 'object', object: 'crm_lead' } } },
+          },
+        ],
+      };
+      expect(validateTranslationReferences({ ...collapsed, ...bundle({ all: { label: '全部' } }) })).toEqual([]);
+      const findings = validateTranslationReferences({ ...collapsed, ...bundle({ all_leads: { label: '全部' } }) });
+      expect(findings).toHaveLength(1);
+      expect(findings[0].path).toBe('translations[0].en.objects.crm_lead._views.all_leads');
+    });
+
+    it('a collision-renamed default list is legal under the renamed key', () => {
+      // Composer fact 3: `listViews.default` claims `crm_lead.default` first,
+      // so the nameless default list is renamed `crm_lead.default_2` — and the
+      // rename IS the registry key, so it is what a bundle must spell.
+      const collided = {
+        objects: [{ name: 'crm_lead', fields: { name: { type: 'text' } } }],
+        views: [
+          {
+            list: { type: 'grid', data: { provider: 'object', object: 'crm_lead' } },
+            listViews: { default: { type: 'kanban', data: { provider: 'object', object: 'crm_lead' } } },
+          },
+        ],
+      };
+      expect(
+        validateTranslationReferences({ ...collided, ...bundle({ default: { label: 'D' }, default_2: { label: 'D2' } }) }),
+      ).toEqual([]);
+      const findings = validateTranslationReferences({ ...collided, ...bundle({ default_3: { label: 'D3' } }) });
+      expect(findings).toHaveLength(1);
+      expect(findings[0].path).toBe('translations[0].en.objects.crm_lead._views.default_3');
+    });
+
+    it('the default FORM contributes sections but no `_views` name — `_views.*` is a list convention', () => {
+      // The composer does name the default form `crm_lead.form`, but the i18n
+      // walker emits no `_views` entry for any form view, so a `_views.form`
+      // key would be one nothing reads. Its `_sections` still resolve (#5415).
+      const withForm = {
+        objects: [{ name: 'crm_lead', fields: { name: { type: 'text' } } }],
+        views: [
+          {
+            list: { type: 'grid', label: 'All', data: { provider: 'object', object: 'crm_lead' } },
+            form: {
+              type: 'simple',
+              data: { provider: 'object', object: 'crm_lead' },
+              sections: [{ name: 'contact_info', label: 'Contact Info' }],
+            },
+          },
+        ],
+      };
+      expect(
+        validateTranslationReferences({
+          ...withForm,
+          translations: [
+            {
+              en: {
+                objects: {
+                  crm_lead: { label: 'Lead', _views: { default: { label: 'All' } }, _sections: { contact_info: { label: '联系方式' } } },
+                },
+              },
+            },
+          ],
+        }),
+      ).toEqual([]);
+      const findings = validateTranslationReferences({ ...withForm, ...bundle({ form: { label: 'Form' } }) });
+      expect(findings).toHaveLength(1);
+      expect(findings[0].path).toBe('translations[0].en.objects.crm_lead._views.form');
+    });
   });
 
   it('resolves views embedded on the object itself', () => {
@@ -644,6 +805,33 @@ describe('validateTranslationReferences — the showcase contact surface (#5415)
       ),
     );
     expect(findings).toEqual([]);
+  }, 60_000);
+
+  it('accepts `_views.default` — the key this very surface ships, and the one it was told to ship (#6038)', () => {
+    // The specimen behind #5164/#6038, on the real metadata rather than a
+    // reduction: `ContactViews` declares a nameless default `list`, the CLI
+    // i18n walker demands `objects.showcase_contact._views.default.label`
+    // (#6124), and `examples/app-showcase` ships exactly that key. Before this
+    // rule read the key from the composer it answered "no view of object
+    // showcase_contact declares `default`" — one `os lint` run, two rules, no
+    // author action that satisfied both. The control below keeps this honest:
+    // `list`, the spelling the walker used to demand, is NOT legal.
+    expect(
+      validateTranslationReferences(
+        showcaseContactStack([
+          { 'zh-CN': { objects: { showcase_contact: { _views: { default: { label: '联系人' } } } } } },
+        ]),
+      ),
+    ).toEqual([]);
+
+    const stale = validateTranslationReferences(
+      showcaseContactStack([
+        { 'zh-CN': { objects: { showcase_contact: { _views: { list: { label: '联系人' } } } } } },
+      ]),
+    );
+    expect(stale).toHaveLength(1);
+    expect(stale[0].path).toBe('translations[0]["zh-CN"].objects.showcase_contact._views.list');
+    expect(stale[0].hint).toContain('default');
   }, 60_000);
 
   it('still reports a section name nothing declares, and names the real ones', () => {

--- a/packages/lint/src/validate-translation-references.ts
+++ b/packages/lint/src/validate-translation-references.ts
@@ -65,6 +65,7 @@
  *   4. unresolved, unprefixed              → warn on the object key only
  */
 
+import { expandViewContainer } from '@objectstack/spec';
 import { hasPlatformObjectPrefix, isPlatformProvidedObjectName } from '@objectstack/spec/system';
 import { walkPageComponents } from './page-walk.js';
 import { SYSTEM_FIELDS } from './system-fields.js';
@@ -219,6 +220,13 @@ function emptyFacts(): ObjectFacts {
  *     the canonical shape, which silently drops the whole record — a rule that
  *     then reports every view key the app ships.
  *
+ * The default `list` is the ONE place where "read the author's `name`" was
+ * wrong, and #5164 is why: the runtime does not key that view by its `name`,
+ * it keys it by the identity the composer assigns. Its key therefore comes
+ * from {@link defaultListViewKey} — asked of the composer, never re-derived
+ * here. See that function for the three facts that live in the composer and
+ * nowhere else.
+ *
  * A third thing was learned later, from the showcase (#5415): the container's
  * DEFAULT form (`form`) is a section anchor too. It is not one of the
  * `formViews.*` entries and it is not the record's own `sections` either, so
@@ -257,7 +265,7 @@ function collectViewRecord(view: AnyRec, factsFor: (objectName: string) => Objec
   };
 
   const listBinding = isRec(view.list) ? bindingOf(view.list) : undefined;
-  if (isRec(view.list)) addView(listBinding, strName(view.list.name));
+  if (isRec(view.list)) addView(listBinding, defaultListViewKey(listBinding, view));
   addView(recordObject ?? listBinding, strName(view.name));
 
   for (const key of ['listViews', 'formViews'] as const) {
@@ -276,11 +284,63 @@ function collectViewRecord(view: AnyRec, factsFor: (objectName: string) => Objec
   // and `ObjectForm` renders when no named form view is asked for. Bound the
   // way the CLI i18n walker's `viewObjectName` resolves `view.form.data.object`
   // (#5415), so the two agree on which object the headings belong to.
-  // Deliberately sections only: the default form has no map key, and whether it
-  // contributes a `_views` name is the neighbouring question #5164 owns.
+  //
+  // Deliberately sections only, and #5164 is now settled enough to say WHY
+  // rather than defer: the composer does give the default form a runtime
+  // identity (`<object>.form`), but `_views.*` is a LIST-view convention —
+  // `viewLabel` / `viewDescription` resolve view tabs, and the i18n walker
+  // emits no `_views` entry for any form view (`i18n-extract.ts`: "form views
+  // have no counterpart in the `viewLabel` / `_views.*` resolver convention").
+  // A `_views` name registered here for the default form would make a key
+  // legal that no consumer ever reads. Its SECTIONS are a different matter —
+  // `ObjectForm` resolves those, which is exactly what #5415 established.
   if (isRec(view.form)) addSections(view.form, bindingOf(view.form) ?? listBinding);
 
   addSections(view, recordObject ?? listBinding);
+}
+
+/**
+ * The bare `_views` key the RUNTIME assigns to a container's default `list` —
+ * the only key a bundle can legally spell for that view.
+ *
+ * Asked of the composer (`expandViewContainer`, `spec/src/ui/view.zod.ts`)
+ * rather than re-derived here. This rule used to read `view.list.name` and
+ * register nothing when the author wrote none, while the composer named that
+ * very same view `<object>.default` — so a container declaring only a default
+ * `list` produced a registry entry keyed `default` and a lint fact set that
+ * knew no such view. The CLI i18n walker demanded `_views.default.label`
+ * (#6124, leg 1) and this rule called the key an orphan, in ONE `os lint` run:
+ * six instances on the showcase, and no author action could make both green.
+ * Ruled 2026-08-06 (#5164): canonical = the runtime identity's bare key.
+ * Leg 1's `defaultListViewKey` in `packages/cli/src/utils/i18n-extract.ts` is
+ * this function's twin — deliberately, both are thin readers of the composer
+ * rather than a third and fourth derivation of the key.
+ *
+ * Three facts live in the composer and nowhere else, all load-bearing here:
+ *
+ *  1. a nameless default list is keyed **`default`** (never `list`), and a
+ *     named one keeps the author's `list.name`;
+ *  2. a default list whose STRUCTURE merely restates a `listViews` entry is
+ *     **collapsed into that entry** and has no key of its own — the
+ *     `examples/app-crm` shape. The surviving `listViews` key is returned (the
+ *     `listViews` loop registers it anyway, so the set is unchanged), and the
+ *     collapsed-away `list.name` correctly stops being a legal key: nothing
+ *     resolves it;
+ *  3. a key renamed by a collision (`default` → `default_2`, when another view
+ *     already claimed `default`) is returned as renamed, because the rename is
+ *     the registry key too.
+ *
+ * Returns `undefined` when the record declares no default `list`, or when no
+ * object binding resolved — the caller cannot file a fact without one.
+ */
+function defaultListViewKey(object: string | undefined, container: AnyRec): string | undefined {
+  if (!object || !isRec(container.list)) return undefined;
+  const item = expandViewContainer(object, container).find(
+    (i) => i.viewKind === 'list' && i.isDefault,
+  );
+  if (!item) return undefined;
+  const prefix = `${object}.`;
+  return item.name.startsWith(prefix) ? item.name.slice(prefix.length) : item.name;
 }
 
 /** The object a view (or one of its containers) binds to, across the shapes it is authored in. */


### PR DESCRIPTION
Fixes #6038

#5164 裁 A(维护者 2026-08-06:`_views` 翻译键 canonical = 运行时组装器裸键)三段串行的**第 2 棒 / lint 段**。母单 #5164 已关闭,本单自身用 `Fixes`。

---

## 1. 四项串行前置的逐项实测(本单第一项硬任务)

派单要求:⛔ 不采信「母单已关闭」这一个事实,动代码前在 `origin/main`(`e15bf7e`)上逐项实测。结论:**四项全部落地,前置满足**,且实测发现 main 上的实际状态与派单担心的方向**相反** —— 不是「存量仍是 `list` 键、lint 收窄会判红存量」,而是第 1 棒已把两端都迁到 `default`,唯独 lint 不认 `default`,于是 main 上**此刻就有 8 处误报**。本 PR 是**减红**,不是增红。

| # | 前置交付 | 实测方法 | 实测结论 |
|---|---|---|---|
| 1 | 提取器 `view.list.name ?? 'list'` → `default` | `os i18n extract examples/app-showcase/objectstack.config.ts --json --dry-run --filter '_views'` | ✅ 已落地,且**优于**派单词面:PR #6124 没有写死 `'default'`,而是 `defaultListViewKey()` 向组装器 `expandViewContainer` 查询运行时身份(`packages/cli/src/utils/i18n-extract.ts:210`)。实测产出 `_views.default`(`showcase_task._views.default.label = "All Tasks"` 等) |
| 2 | showcase 5 个 `_views.list` 译文块随迁 | grep `examples/*/src` 全量 | ✅ 已落地。`examples/app-showcase/src/system/translations/index.ts` 现有 6 个 `_views` 块全部键为 `default`(project / task / contact / inquiry / business_unit / field_zoo);`examples/**` 内 `_views` 下 `list:` 键**零残留** |
| 3 | 覆盖基线棘轮下调 | `pnpm check:i18n-coverage`(改动前) | ✅ 已落地,且**实测无需下调**(与 #6124 changeset 自述一致):`EXIT=0`,`OK (12 config(s), 660 baselined untranslated string(s), none new)`。两端同批改名,覆盖数不变 |
| 4 | 已发布 bundle 键变更的 conversion / release note | `.changeset/` 目录 | ✅ 已落地且尚未消费:`.changeset/views-translation-key-runtime-identity.md`(`@objectstack/cli: minor`),含 `BREAKING(已发布翻译包的键)` 标注与 FROM → TO 三行对照表 + 一行修法 |

**⛔ 未越界补做第 1 棒的任何活**:`packages/cli/**`、`examples/**` 译文本 PR 一字未动。

---

## 2. `collectViewRecord` 现行形状 → 改后形状

**改前**(`packages/lint/src/validate-translation-references.ts:260`):

```ts
const listBinding = isRec(view.list) ? bindingOf(view.list) : undefined;
if (isRec(view.list)) addView(listBinding, strName(view.list.name));
```

作者没写 `list.name` 时**什么也不注册**。而组装器(`packages/spec/src/ui/view.zod.ts` `expandViewContainerWithDiagnostics`,只读核实、⛔ 未改)给同一个视图的身份是 `< object >.default`。

**改后**:

```ts
if (isRec(view.list)) addView(listBinding, defaultListViewKey(listBinding, view));
```

`defaultListViewKey()` **向组装器查询**,而不是第三次自行推导 —— 与第 1 棒 `packages/cli/src/utils/i18n-extract.ts` 的同名函数刻意成对(两者都只是组装器的薄读取器,而不是第三、第四份推导)。因此继承组装器仅有的三条规则:

1. 无 `name` 的默认列表键为 **`default`**(绝不是 `list`);带 `name` 的沿用作者的 `name`;
2. 结构上(`{type,label,columns}` 签名)与某个 `listViews` 条目**相同**的默认列表被**折叠**进该条目 —— 存活的是那个 `listViews` 键,被折叠掉的 `list.name` **不再合法**(运行时解析不到它);
3. 因命名冲突被改名的键(`default` → `default_2`)按**改名后**判定,因为改名后的名字才是注册表键。

组装器行为实测(探针,非推断):

```
nameless list                                  => crm_lead.default[list,default]
listViews.default 先占 + 无名 list             => crm_lead.default[list] | crm_lead.default_2[list,default]
折叠(list 与 listViews.all 同签名)           => crm_lead.all[list,default]
```

**顺带清理**:该函数注释里「whether it contributes a `_views` name is the neighbouring question #5164 owns」的悬置已删除。⚠️ 没有只删句子了事 —— 换成了**答案**:默认 form 继续只贡献 `_sections`,理由是 `_views.*` 是**列表视图**约定(`viewLabel` / `viewDescription` 解析视图页签),i18n walker 对任何 form 视图都不产 `_views` 条目(`i18n-extract.ts` 原话),所以给默认 form 注册一个 `_views` 名等于让一个**没有消费方**的键变合法。行为不变,零变红风险。

---

## 3. 矛盾对 before / after 实跑取证

⚠️ **全部实跑,无一处推断。**

### 否定方(本规则)

改动前后各跑一遍**全部 12 个受棘轮覆盖的配置**的 `os lint --json`,逐条 issue 做集合差:

```
examples_app-crm:            total 101->101  | +0 -0
examples_app-showcase:       total 518->512  | +0 -6
   GONE  translation-target-unknown | ...showcase_project._views.default
   GONE  translation-target-unknown | ...showcase_task._views.default
   GONE  translation-target-unknown | ...showcase_contact._views.default
   GONE  translation-target-unknown | ...showcase_inquiry._views.default
   GONE  translation-target-unknown | ...showcase_business_unit._views.default
   GONE  translation-target-unknown | ...showcase_field_zoo._views.default
examples_app-todo:           total 124->122  | +0 -2
   GONE  translation-target-unknown | ...todo_task._views.default   ("zh-CN")
   GONE  translation-target-unknown | ...todo_task._views.default   ("ja-JP")
(其余 9 个配置 +0 -0)
=== TOTAL added: 0  removed: 8
```

汇总口径:`_views` 键上的 `translation-target-unknown` **8 → 0**。

⚠️ showcase 上是 **6** 处,不是 #5164 记录的 5 处 —— `showcase_field_zoo` 是第 6 个同族实例;app-todo 另有 2 处(两个语言包),#5164 未记录。

### 要求方(同一次 `os lint`)

否定方的 8 条只是矛盾对的一半。要求方在译文**存在**时不发声,所以另用一个合成 stack(仅含一个无名默认 `list`、无译文)在**同一个 `os lint`** 里取证:

```
$ os lint probe.config.ts --json
warning | i18n/missing-view | translations.zh-CN.objects.probe_lead._views.default.label
```

给同一个 stack 补上 `_views.default` 译文后再跑:

```
total 1 errors 1 warnings 0
  error | security-owd-unset | objects[0].sharingModel     ← 与 i18n 无关(探针没设 sharingModel)
```

**i18n findings 归零**:要求方不再要,否定方不再否 —— 两条规则对同一个键给出同一答案。矛盾**结构性消失**,验收判据达成。(探针文件已删除,`git status` 只剩本 PR 的三个文件。)

---

## 4. 反向验证(先申报,后执行)

### 声明 A —— 矛盾消失

**申报**:修前 showcase 全量 `os lint` 存在 i18n 矛盾对,键为 `objects.< object >._views.default`,两条规则为 `i18n/missing-view`(要求方,`packages/cli/src/utils/i18n-extract.ts`)与 `translation-target-unknown`(否定方,本文件);修后该矛盾对为 0。

**实测**:成立。showcase 6 对 → 0(另发现 app-todo 2 对,一并归零)。两侧取证见上节。

### 声明 B —— 变异体

**申报**(执行前写下):把收窄退回 `addView(listBinding, strName(view.list.name))`、保留全部新断言,预测转红的是四条**肯定式**断言(`default` 合法 / 折叠体拒绝 `list.name` / 改名键 `default_2` 合法 / form fixture 的 `default`)加上配对孤儿计数那条;预测**结构上不会红**的是「具名默认列表沿用作者 `name`」(回归护栏,两侧同绿);并预判「拒绝旧 `list` 拼写」那条**只会经由提示语断言转红**,其 path 断言对本变异体是盲的。

**实测**:`7 failed | 29 passed (36)`,与申报**逐条吻合**:

```
× accepts `default` for a nameless default list — the key the registry holds
× the same fixture still reports a key nothing declares (the green above is not an empty run)
× rejects the old `list` spelling — one key per view, and it is the runtime one
× a default list collapsed into a `listViews` entry contributes that entry's key, not its own `name`
× a collision-renamed default list is legal under the renamed key
× the default FORM contributes sections but no `_views` name — `_views.*` is a list convention
× accepts `_views.default` — the key this very surface ships (#6038)   ← 真实 showcase 元数据
```

**断言极性逐条标注**:

| 断言 | 极性 | 对本变异体 |
|---|---|---|
| `default` 对无名默认列表合法 | 肯定式(`toEqual([])`) | ✅ 红 |
| 同 fixture 仍报植入的未知键(空绿对照) | 肯定式(计数 1) | ✅ 红(变异体下变 2) |
| 拒绝旧 `list` 拼写 | **path 断言=否定式,结构上不会红**;`hint` 断言=肯定式 | ✅ 红,**但只经 hint**:`expected 'Match the key to the view's name (…' to contain 'default'` —— 变异体下 Declared views 尾巴是空的。path 断言两侧同绿,这条如实标注 |
| 折叠体拒绝 `list.name` | 肯定式(计数 1) | ✅ 红 |
| 改名键 `default_2` 合法 | 肯定式(`toEqual([])`) | ✅ 红 |
| 默认 form 不贡献 `_views` 名 | 肯定式(`toEqual([])`,fixture 含 `default`) | ✅ 红 |
| 真实 showcase `_views.default` 合法 | 肯定式(`toEqual([])`) | ✅ 红 |
| **具名默认列表沿用作者 `name`** | 回归护栏 | ⬜ **两侧同绿 —— 结构上不会红,如实申报** |

**空绿自查**(本轮已有四位 dev 撞过这个坑):每一条 `toEqual([])` 都在**同一个 fixture** 上配了一条植入坏键的肯定式断言,证明规则确实跑过、确实会产出 finding,而不是「因为什么都没产出所以绿」。逐条:无名默认列表 fixture 配 `hot_leads`(计数 1);具名列表 fixture 配 `default`(计数 1);折叠 fixture 配 `all_leads`(计数 1);改名 fixture 配 `default_3`(计数 1);默认 form fixture 配 `form`(计数 1);真实 showcase fixture 配 `list`(计数 1)。**无一条真空绿。**

### 声明 C —— 存量不误伤

**申报**:修后跑全量 `os lint`,新增的红必须为 0。

**实测**:成立。12 个配置全跑,`added: 0`。⛔ 未为了让门变绿放宽任何规则。

### fixture 分诊(⚠️ 一处必须的改动,并已证明其必要性)

既有 fixture `leadViews` 的默认 `list`(`{type:'grid', name:'all_leads'}`)与 `listViews.my_leads`(`{type:'grid'}`)**签名完全相同**,组装器会把两者折叠 —— 也就是说 `all_leads` 根本不是运行时视图名,fixture 等于在断言「一个谁也解析不到的键是合法的」。按三分法这属于**补声明(add declarations)**,不是 re-spell、也不是整体替换:给默认 `list` 加 `label: 'All Leads'` 使其成为它自称的那个「独立的默认列表」。

**必要性已实测**(不是「看起来需要」):把这个 `label` 拿掉、保留本 PR 的实现,该 fixture 的两条既有测试**双双转红**(`2 failed | 33 passed`)。折叠语义本身另立独立测试单独 pin。

### 消费半径扫查

按规则的消费半径而非编辑包扫查 fixture:`translation-target-unknown` 的调用方为 `os lint`(经 `packages/lint` 导出)。全仓 grep `_views.list` / `_views` + `list:`,除历史 CHANGELOG(⛔ 不改)与本 PR 自身文件外**零命中**;`packages/cli/test/i18n-extract-view-key-identity.test.ts` 已由第 1 棒 pin 在 `default` 侧,与本 PR 同向。

---

## 5. changeset 级别与依据

`.changeset/lint-views-key-runtime-identity.md` —— **`@objectstack/lint: patch`**(真 changeset,⛔ 未打 `skip-changeset`;`@objectstack/lint` 是发布包)。

依据:

- 仓内惯例「新增规则」minor、「既有规则的判定/遍历修正」patch。本单是**既有规则的判定修正**,无新规则、无 API 变化(`validateTranslationReferences` 签名与 rule id 均不变)。同族先例:`.changeset/adr-0105-d6-unit-and-subordinates.md`(`@objectstack/lint: patch`,同为既有规则词表/判定修正);
- 对已发布行为**确有可见变化**,故 changeset 正文写了完整的四行判定对照表(哪些形状从报→不报、哪些从不报→报)。但变化全在 **warning** 层:本规则 findings 恒为 `severity: 'warning'`,不改 `os lint` 退出码(showcase 496 条 warning 时 `EXIT=0`),也不在 `check:i18n-coverage` 棘轮口径内(该棘轮只数 `i18n/` 前缀);全仓 12 配置实测新增 0 条,消费方 CI 不会因此变红 —— 不足以升 minor;
- ⚠️ v17 窗口期 ⛔ 禁 major,已遵守。

---

## 6. 门禁 EXIT 表(均在 `git add` 之后跑,重活经 `flock` 串行 + 堆上限)

| 门 | 命令 | EXIT | 备注 |
|---|---|---|---|
| 包测试 | `pnpm --workspace-concurrency=2 --filter @objectstack/lint test` | **0** | `62 files / 1527 tests passed` |
| 包 typecheck | `pnpm --workspace-concurrency=2 --filter @objectstack/lint typecheck` | **0** | `tsc --noEmit` |
| ESLint(全仓) | `pnpm lint` | **0** | ⚠️ 4096 MB 下 OOM(`EXIT=134`),提到 8192 MB 后 `EXIT=0`;scoped `eslint packages/lint` 亦 0。仓库规模问题,与本改动无关 |
| 控制字节门 | `pnpm check:nul-bytes` | **0** | |
| 控制字节自扫 | `grep -naP` 控制字节类,扫三个改动文件 | **1**(无命中) | |
| i18n 门 | `pnpm check:i18n` | **0** | |
| i18n 覆盖棘轮 | `pnpm check:i18n-coverage` | **0** | 改动前后**同值**:`12 config(s), 660 baselined, none new` |
| CI 独有 | `pnpm check:type-check-debt` | **0** | `34 ledger entries re-measured, none above its recorded number`。本 PR 未新增测试文件(只改既有 `.test.ts`),无 TS2835 风险 |
| 文档公式门 | `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | **0** | |
| 文档/技能门 | `pnpm check:doc-authoring` | **0** | |
| ADR 锚点门 | `pnpm check:adr-anchors` | **0** | |

⛔ 无一条绕过。

---

## 7. 不在本 PR 里

- ⛔ `packages/cli/**` —— 第 1 棒(#6124)的面,已落地,一字未动;
- ⛔ `examples/**` 译文 —— 同属第 1 棒;实测**无遗留需随迁**(`_views` 下 `list:` 键零残留),故无可报;
- ⛔ `packages/spec/**` —— 裁决否决 B 案,组装器命名不变;本 PR 仅**只读**核实 `expandViewContainerWithDiagnostics` 的命名/折叠/改名三条规则;
- ⛔ objectui `viewSuffixes` 去第二候选 —— 第 3 棒 objectui#3502,跨仓;
- ⛔ `packages/lint/src/validate-form-layout.ts` —— #6251 / PR #6382 的面;
- ⛔ 该包内视图容器阶梯遍历的**三份**独立实现合并 —— #6381 的面(需动 #6248 刚验收的文件)。本 PR 只动 `collectViewRecord` 的键收集语义,未合并任何遍历;
- ⛔ `listViews` / `formViews` 分支「map key 与内层 `name` 两种拼写都收」的收窄 —— 这是**另一处**过宽,与默认 `list` 无关:组装器对具名条目只认 **map key**(忽略 `v.name`)。收窄它会给存量增红,且不在本单验收判据内(要求方对 form 视图不产任何 `_views` 键,故不构成矛盾对)。已作为观察单另记,见下;
- ⛔ `content/docs/releases/**`。

## 8. 顺带发现(已另立观察单,未在本 PR 修)

- **#6422**(`finding`,未自我认领):同一函数的 `listViews` / `formViews` 分支同时接受 map key 与内层 `name`,而组装器对具名条目**只认 map key**;冲突改名场景下两者会正好相反 —— 组装器把 `formViews.default` 改名为 `default_2`,本规则却认 `default`(解析不到)而拒 `default_2`(真键)。目前休眠:`lint-view-refs.ts` 已把视图键冲突判为硬错误,该形状发不出去。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_