### PR TITLE
fix(ci): Check Changeset 的 skip-changeset 判定加一次「结算读」，首跑不再结构性必红 (#6378)

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -140,10 +140,22 @@ jobs:
     # re-run green. It is permanently red by construction: three PRs in one day
     # (#5467 -- this gate's own fix PR -- plus #5501 and #5577) each left a stale
     # red that a human or agent had to stop and explain away.
-    # The authority is the live re-read in the first step below. This expression
-    # only short-circuits the case where the payload ALREADY shows the label, so
-    # the common path still costs no runner at all. The branch/author half needs
-    # no such treatment: head_ref and the PR author cannot change under a rerun.
+    # The authority is the live label read below. This expression only
+    # short-circuits the case where the payload ALREADY shows the label, so the
+    # common path still costs no runner at all. The branch/author half needs no
+    # such treatment: head_ref and the PR author cannot change under a rerun.
+    #
+    # #6378: ONE live re-read was not enough, and the reason is measured rather
+    # than reasoned. On PR #6426's `opened` run (31204438874) the re-read step
+    # ran at 17:54:07Z for a PR created at 17:53:57Z -- it reads the label list
+    # TEN SECONDS after the PR exists. The `skip-changeset` label cannot be
+    # applied before the PR exists (GitHub offers no create-with-labels path to
+    # this flow), and measured label latency is 10-45s after creation (#6310
+    # ~+15s, #6358 ~+35-45s). So the read is inside the race window by
+    # construction, and the route-2 first run was red 22 times in one day.
+    # The second, SETTLING read further down is what closes it; see the note on
+    # that step for why the wait it costs is charged to nobody who was going to
+    # pass anyway.
     #
     # Keeping the fast path leaves ONE stale cell, in the opposite direction: a
     # label REMOVED after the event fired still short-circuits this run, which is
@@ -165,6 +177,13 @@ jobs:
       # on purpose: when the label is there, every step below is skipped and the
       # whole job costs one API call, so converging on the live state is cheaper
       # than the stale red it replaces.
+      #
+      # This is the FAST PATH read, and #6378 measured that it is only a fast
+      # path: at +10s from PR creation it is too early to be the last word for a
+      # label that lands at +10..45s. It stays exactly as it is -- every run of an
+      # ALREADY-labelled PR (`synchronize`, `labeled`, every rerun, every later
+      # push) still exits here for one API call and no runner. What it must not
+      # do is pronounce a PR guilty; that verdict moved to the settling read.
       #
       # The direction of the tolerance is deliberate: an unreadable label list
       # (API error, no PR number) resolves to `skip=false`, i.e. ENFORCE. A gate
@@ -301,13 +320,20 @@ jobs:
         if: steps.labels.outputs.skip != 'true'
         run: pnpm install --frozen-lockfile
 
-      - name: Check for a changeset added by this PR
+      # COUNTING ONLY -- the verdict is two steps down (#6378). The split is not
+      # cosmetic: it is what lets the label window be settled for exactly the PRs
+      # that would otherwise be failed, and for nobody else. A PR that added a
+      # changeset needs no label and waits for nothing; this step establishes
+      # that fact before any waiting is considered.
+      - name: Count the changesets this PR adds
+        id: changeset_count
         if: steps.labels.outputs.skip != 'true'
         env:
           MERGE_BASE: ${{ steps.diffbase.outputs.merge_base }}
         run: |
           if [ ! -d ".changeset" ]; then
             echo "::warning::.changeset directory not found. Skipping changeset check."
+            echo 'added=n/a' >> "$GITHUB_OUTPUT"
             exit 0
           fi
           # Count changesets THIS PR adds (diff against the base commit), NOT
@@ -341,6 +367,117 @@ jobs:
           # ("the changeset you added declares nothing").
           ADDED=$(git diff --name-only --diff-filter=A "$MERGE_BASE" HEAD -- '.changeset/*.md' \
                   | grep -v '/README\.md$' | wc -l | tr -d '[:space:]')
+          echo "This PR adds $ADDED changeset(s) (diffed from $MERGE_BASE)."
+          echo "added=$ADDED" >> "$GITHUB_OUTPUT"
+
+      # ── The settling read (#6378) ────────────────────────────────────────────
+      #
+      # The one step in this job that is allowed to WAIT, and its `if:` is the
+      # whole design. It runs only when both of these hold:
+      #
+      #   * the fast-path read saw no label, AND
+      #   * this PR added no changeset -- i.e. it is headed for RED.
+      #
+      # So the wait is charged exclusively to PRs that were about to be failed.
+      # A PR that wrote a changeset skips this step entirely and costs neither a
+      # second of wall time nor an API call; that is the answer to the standing
+      # objection against "just poll for a while" (issue #6378, direction 1),
+      # which would have taxed every run instead. It has to be answered rather
+      # than waved away, because the numbers are small: measured on run
+      # 31204438874, the whole job is 43s and only ~45s has elapsed since PR
+      # creation by the time the counting step above finishes. There is no
+      # convenient slow step to hide a wait behind in this job -- so the wait is
+      # not hidden, it is CONDITIONED.
+      #
+      # Polarity, stated because it is the entire hard constraint of #6378: this
+      # step can only ever turn a red into a green by OBSERVING A LABEL THAT IS
+      # REALLY THERE. Every other exit -- no PR number, an unreadable label list,
+      # a closed window, the attempt cap -- writes `skip=false`, i.e. ENFORCE, the
+      # same #4690 direction the fast-path read already takes. A PR that genuinely
+      # forgot its changeset and carries no label is therefore still failed,
+      # having merely been given the same grace period the labelling agent needs.
+      # Delaying a red by at most a window costs nothing anyone values; letting a
+      # red through would cost the gate its meaning.
+      #
+      # The window is measured from PR CREATION, not from this step, and that is
+      # what keeps it self-cancelling: on a `synchronize`, a `labeled` run, or any
+      # `rerun_failed_jobs` replay, `created_at` is long past, the deadline is
+      # already behind us, and the loop does exactly one read and no sleeping.
+      # Only a genuinely fresh PR can wait at all. 120s is ~3x the worst label
+      # latency measured on this repo (~40s, #6358).
+      - name: Settle the skip-changeset window (only when this PR would otherwise fail)
+        id: labels_settled
+        if: >-
+          steps.labels.outputs.skip != 'true'
+          && steps.changeset_count.outputs.added == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_CREATED_AT: ${{ github.event.pull_request.created_at }}
+          WINDOW_SECONDS: '120'
+          POLL_SECONDS: '10'
+        run: |
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::warning::No PR number on this event, so the label window cannot be settled. Enforcing the changeset check."
+            echo 'skip=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # An absent or unparseable created_at collapses the deadline to "now":
+          # one read, no wait. That is the enforcing direction and it matches
+          # every other unreadable input in this job (#4690).
+          DEADLINE=0
+          if [ -n "$PR_CREATED_AT" ] && CREATED=$(date -u -d "$PR_CREATED_AT" +%s 2>/dev/null); then
+            DEADLINE=$((CREATED + WINDOW_SECONDS))
+          else
+            echo "::warning::This event carries no readable pull_request.created_at, so the label window is treated as already closed: one read, no wait."
+          fi
+          ATTEMPT=0
+          while :; do
+            ATTEMPT=$((ATTEMPT + 1))
+            if ! LABELS=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.labels[].name'); then
+              echo "::warning::Could not read the labels of PR #$PR_NUMBER (attempt $ATTEMPT), so this run cannot see a 'skip-changeset' applied after the event fired. Enforcing the changeset check."
+              echo 'skip=false' >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            # Whole-line fixed match, fed by a here-string -- deliberately the
+            # SAME matcher as the fast-path read above, for the same two reasons
+            # (an array-element match, not a substring, so `skip-changeset-audit`
+            # is not newly exempted; and `grep -q` kept out of a pipeline so no
+            # writer can take SIGPIPE under `set -o pipefail`). A divergence
+            # between the two reads would be a gate that exempts on one path and
+            # enforces on the other, so check-empty-changeset.mjs pins them equal.
+            if grep -qxF 'skip-changeset' <<<"$LABELS"; then
+              echo "::notice::'skip-changeset' is on PR #$PR_NUMBER (read live on attempt $ATTEMPT), so this PR declares no release of its own and the changeset check is exempt."
+              echo 'skip=true' >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            NOW=$(date -u +%s)
+            # The attempt cap is belt-and-braces next to the deadline: a clock
+            # that disagrees with GitHub's must not be able to make this loop
+            # unbounded.
+            if [ "$NOW" -ge "$DEADLINE" ] || [ "$ATTEMPT" -ge 20 ]; then
+              break
+            fi
+            echo "No 'skip-changeset' on PR #$PR_NUMBER yet (attempt $ATTEMPT); it is still $((DEADLINE - NOW))s inside the label window. Re-reading in ${POLL_SECONDS}s."
+            sleep "$POLL_SECONDS"
+          done
+          echo "Label window closed after $ATTEMPT read(s). Labels on PR #$PR_NUMBER right now: ${LABELS:-(none)}"
+          echo 'skip=false' >> "$GITHUB_OUTPUT"
+
+      # The VERDICT. Everything it needs was decided above; this step only
+      # announces it, which is what makes the failure message a single block of
+      # prose rather than something interleaved with counting and polling.
+      - name: Require a changeset (or the skip-changeset label)
+        if: >-
+          steps.labels.outputs.skip != 'true'
+          && steps.labels_settled.outputs.skip != 'true'
+        env:
+          ADDED: ${{ steps.changeset_count.outputs.added }}
+        run: |
+          if [ "$ADDED" = 'n/a' ]; then
+            echo "There is no .changeset directory to count; the counting step above said so and this gate stands aside."
+            exit 0
+          fi
           if [ "$ADDED" -eq 0 ]; then
             # The full comparison goes to the job log — that is what an author
             # reading `gh run view --log-failed`, or expanding this step in the
@@ -362,6 +499,13 @@ jobs:
                The label is a gate-level exemption. It produces NO input for
                changesets/action, so it cannot affect a release.
 
+               You do not have to race this run to apply it: the step above waits
+               out a window measured from PR creation before this verdict is
+               reached (#6378), so a label applied promptly after 'gh pr create'
+               is seen by THIS run. If you were slower than that, applying it now
+               still fires a 'labeled' event and that run goes green -- but the
+               red left here does not clear itself.
+
                'skills/**' is on that list, and it is spelled out because the git
                log says otherwise (#5947). Changes to PUBLISHED skills have
                repeatedly shipped with an empty changeset instead -- #4607, #5130,
@@ -373,8 +517,9 @@ jobs:
                EITHER, and pays #4898 for the privilege. Take the label.
 
             3. (CLOSED) An empty-frontmatter changeset. Still present in the
-               repository's history and still counted by this step, but the step
-               below now REJECTS any that a PR newly adds (#5471). It was never worth
+               repository's history and still counted by the counting step above,
+               but the step below now REJECTS any that a PR newly adds (#5471). It
+               was never worth
                taking: it names no package, so its body reaches no CHANGELOG, and it
                buys nothing the label does not. What it uniquely buys is risk --
                unlike the label it is a REAL INPUT to changesets/action, and when
@@ -392,7 +537,7 @@ jobs:
             echo "::error::This PR adds no changeset. If it releases nothing (including any 'skills/**' change -- see #5947), apply the 'skip-changeset' label; otherwise run 'pnpm changeset' and name the packages. An empty-frontmatter changeset is NOT a third option any more: the step below rejects newly added ones (#5471), because it is a real input to changesets/action and an all-empty set stalls the release silently and greenly (#4898). Full comparison in this step's log."
             exit 1
           fi
-          echo "This PR adds $ADDED changeset(s)."
+          echo "This PR adds $ADDED changeset(s), so it declares a release of its own."
 
       # #5471: an empty-frontmatter changeset is rejected when this PR is the one
       # introducing it. Ruled 2026-08-06 after the #5292 / PR #5467 prose route
@@ -422,9 +567,10 @@ jobs:
       # place the red and green directions are pinned. It builds real temp git
       # repositories and costs well under a second.
       #
-      # Label handling: this step carries the same `steps.labels.outputs.skip`
-      # guard as every step above it, so it honours the LIVE label re-read
-      # (#5580 / #5625) and a rerun after labelling converges. That leaves one
+      # Label handling: this step carries the same live-label guard as the verdict
+      # step above it -- BOTH reads, the fast path and the settling one (#5580 /
+      # #5625 / #6378) -- so a label that lands inside the window exempts this
+      # step on the same run, and a rerun after labelling converges. That leaves one
       # cell open and it is recorded rather than implied: a PR carrying BOTH the
       # `skip-changeset` label AND a new empty changeset is not caught, because
       # the whole job is exempt. Closing it would mean running this step outside
@@ -440,7 +586,9 @@ jobs:
       # and reports it against an author who never touched the file. Same defect,
       # opposite direction (a false RED here, a false GREEN up there), one base.
       - name: Reject an empty-frontmatter changeset added by this PR
-        if: steps.labels.outputs.skip != 'true'
+        if: >-
+          steps.labels.outputs.skip != 'true'
+          && steps.labels_settled.outputs.skip != 'true'
         env:
           MERGE_BASE: ${{ steps.diffbase.outputs.merge_base }}
         run: |
@@ -478,7 +626,9 @@ jobs:
       # pinned, and each of them was verified to flip green when the corresponding
       # check is ablated. Real temp git repositories, well under a second.
       - name: Require an ADR-0087 disposition on a declared-breaking changeset
-        if: steps.labels.outputs.skip != 'true'
+        if: >-
+          steps.labels.outputs.skip != 'true'
+          && steps.labels_settled.outputs.skip != 'true'
         env:
           MERGE_BASE: ${{ steps.diffbase.outputs.merge_base }}
         run: |
@@ -491,9 +641,12 @@ jobs:
         # version. During the launch window we ship breaking changes as `minor`.
         # Add the `allow-major` PR label when a whole-stack major is intended.
         #
-        # The first clause keeps this step exempt exactly when the changeset check
-        # above is: before #5580 the `skip-changeset` label skipped the whole job,
-        # this step included, and a live-read label must not quietly re-arm it.
+        # The first two clauses keep this step exempt exactly when the changeset
+        # check above is: before #5580 the `skip-changeset` label skipped the whole
+        # job, this step included, and a live-read label must not quietly re-arm
+        # it. Both reads are named for the same reason -- after #6378 the exemption
+        # can be established by either one, and a step that honoured only the fast
+        # path would re-arm itself on precisely the PRs the settling read rescued.
         #
         # The second clause still reads the frozen payload, and so still carries
         # the #5580 race in its own right: an `allow-major` applied after the event
@@ -506,5 +659,6 @@ jobs:
         # cover of another issue is how exemptions grow unnoticed.
         if: >-
           steps.labels.outputs.skip != 'true'
+          && steps.labels_settled.outputs.skip != 'true'
           && !contains(github.event.pull_request.labels.*.name, 'allow-major')
         run: node scripts/check-changeset-no-major.mjs

--- a/scripts/check-empty-changeset.mjs
+++ b/scripts/check-empty-changeset.mjs
@@ -711,6 +711,77 @@ function selfTest() {
         pinnedDiffs.length === 0,
         `consumer: no \`git diff\` in the workflow may use the frozen base.sha as an endpoint (found ${pinnedDiffs.length})`,
       );
+
+      // ── The label race, and the half of #6378 that also lives in YAML ──────
+      //
+      // Same argument as the block above, one defect along: the fix for #6378 is
+      // shell and `if:` expressions in pr-automation.yml, so nothing that drives
+      // scan() can see it being undone. Two live label reads (a fast path at
+      // ~+10s from PR creation, and a settling one that waits out the window)
+      // are what turn the route-2 first run green; a later edit that deletes the
+      // second, or that lets the FIRST one pronounce a verdict, restores a gate
+      // that was red-by-construction 22 times in one day.
+      //
+      // What is pinned here is deliberately the SHAPE OF THE EXEMPTION, never
+      // its permissiveness: read the assertions below as one sentence -- the
+      // exemption may be established only by a label really observed, the wait
+      // may be charged only to a PR that would otherwise fail, every step that
+      // can fail a PR over the changeset rule must honour both reads, and the
+      // failure must stay a failure.
+      const settle = /steps\.changeset_count\.outputs\.added == '0'/.test(yaml);
+      assert(
+        settle,
+        'consumer: the settling label read must be conditioned on `steps.changeset_count.outputs.added == \'0\'` -- the wait #6378 introduces is charged ONLY to a PR headed for red, and un-conditioning it taxes every run instead',
+      );
+
+      // Both reads, one matcher. A divergence (say a substring `grep -q` on one
+      // path) would be a gate that exempts on one read and enforces on the
+      // other, and `skip-changeset-audit` would newly buy an exemption on
+      // whichever path drifted.
+      const matchers = [...yaml.matchAll(/grep -qxF 'skip-changeset'/g)];
+      assert(
+        matchers.length === 2,
+        `consumer: exactly two live \`grep -qxF 'skip-changeset'\` reads are expected (the fast path and the settling read); found ${matchers.length}`,
+      );
+
+      // Every step that can FAIL a PR over the changeset rule must honour both
+      // reads. Scoped to those steps by what they run, not by name: a step that
+      // shells out to a `check-*.mjs` gate, or that emits the "no changeset"
+      // error. `Resolve the diff base` is deliberately outside this set -- it
+      // exits 1 over an unusable git base, which is not a changeset verdict and
+      // was never label-exempt (recorded, not implied).
+      const jobText = yaml.slice(yaml.indexOf('\n  changeset-check:'));
+      const chunks = jobText
+        .split(/\n(?=      - name: )/)
+        .map((c) => c.split('\n').filter((l) => !/^\s*#/.test(l)).join('\n'))
+        .filter((c) => /node scripts\/check-\S+\.mjs/.test(c) || /::error::This PR adds no changeset/.test(c));
+      assert(
+        chunks.length === 4,
+        `consumer: expected 4 changeset-verdict steps in the Check Changeset job, found ${chunks.length} -- a new one that this rule cannot see is a new way to red an exempt PR`,
+      );
+      const unguarded = chunks.filter((c) => !/steps\.labels_settled\.outputs\.skip != 'true'/.test(c));
+      assert(
+        unguarded.length === 0,
+        `consumer: every changeset-verdict step must honour the settling read as well as the fast path (${unguarded.length} do not) -- a step guarded only by the fast path re-arms itself on exactly the PRs #6378 rescued`,
+      );
+      const halfGuarded = chunks.filter((c) => !/steps\.labels\.outputs\.skip != 'true'/.test(c));
+      assert(
+        halfGuarded.length === 0,
+        `consumer: every changeset-verdict step must honour the fast-path read too (${halfGuarded.length} do not) -- dropping it makes an already-labelled PR pay a whole job (#5580)`,
+      );
+
+      // The hard constraint of #6378, stated as structure: none of this may have
+      // made the gate softer. A PR with no changeset and no label still has to
+      // hit a real non-zero exit, and no step of this job may be excused from
+      // its own failure.
+      assert(
+        /::error::This PR adds no changeset[\s\S]{0,900}?\n\s+exit 1\n/.test(yaml),
+        'consumer: the "no changeset" verdict must still exit 1 -- #6378 removes a structural FALSE red, it does not relax the gate',
+      );
+      assert(
+        !/continue-on-error/.test(yaml),
+        'consumer: no step in pr-automation.yml may carry `continue-on-error` -- that would turn this gate into a warning, which is the one outcome #6378 rules out',
+      );
     }
 
     // ── Parser unit rows ─────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #6378

## 1. 根因复核：时序证据

立单说的是「job 起跑那一刻就读标签」。复核后需要修正一处措辞——`Check Changeset` 早在 #5580 就已经不再读事件负载，而是有一次**活标签读取**。问题不在于它读的是快照，而在于**它读得太早**，且只读一次。

实测取自 PR #6426 的 `opened` 跑（run 31204438874，job 92951930923）：

| 时刻 | 时间 | 距 PR 创建 |
| --- | --- | --- |
| PR 创建 | 17:53:57Z | 0s |
| run 起跑 | 17:54:01Z | +4s |
| job 起跑 | 17:54:04Z | +7s |
| **活标签读取步骤** | **17:54:07Z** | **+10s** |
| checkout | 17:54:08 → 17:54:20 | 12s |
| install deps | 17:54:21 → 17:54:42 | 21s |
| 判定步骤 | 17:54:42Z | +45s |
| job 结束 | 17:54:47Z | +50s |

而 `skip-changeset` 只能在 PR 建立之后才打得上，立单实测其落地在 **+10..45s**（#6310 约 +15s，#6358 约 +35..45s）。**一次 +10s 的读取恒定落在竞态窗口内**——这就是「结构性必红」的机制，也是为什么 #5542 打了标签仍红、#5650 标签早到 41s 就绿：那是运行器启动快慢在决定判决。

这里还顺带**证伪了一个我自己的工作假设**：我原本打算「把等待藏在 install 后面，成本为零」。实测否掉了——整个 job 只有 43s，走到判定步骤时距 PR 创建也才 +45s。这个仓库里**没有一个足够慢的步骤可以藏住等待**。所以等待不能靠藏，只能靠**条件化**。

## 2. 并发修复检查（Operational note 8，两次）

| 时机 | 命令 | 结论 |
| --- | --- | --- |
| 动手前 | `git log origin/main -- .github/workflows/pr-automation.yml` | 最近四笔：`81a4a67`(#6342)、`613c515`(#6192)、`b030c9a`(#6059)、`d97f2a2`。均已在 main，无在飞并发修复 |
| 推送前 | 同上 + `git log 5faa23c..origin/main -- (本单文件面)` | main 已从 `5faa23c` 推进到 `7618ee8`，但**该区间内没有任何提交触及本单文件面**，零冲突 |

另核对在飞 PR 列表（#6426 / #6424 / #6423 / #6389 / #6279 / #6208），无一触及 `pr-automation.yml`。

## 3. 方向选择

**选定：方向 1 的条件化变体**——保留原有的快路径读取，在**计数之后、判定之前**插入第二次活标签读取（「结算读」），并且这次读取**只在该 PR 本来就要变红时才发生**。

拆成三步：

1. `Count the changesets this PR adds`（原判定步骤，改为只产出 `added`，不再自己下结论）
2. `Settle the skip-changeset window`——`if:` 为「快路径无标签」并且「added 等于 0」
3. `Require a changeset (or the skip-changeset label)`——纯判定

关键在第 2 步的 `if:`。写了 changeset 的 PR **完全跳过该步**：不等一秒，不花一次 API 配额。等待只向「本来就要被判红」的 PR 收取，而把一个红推迟至多一个窗口，代价是零。这正面回答了立单对方向 1 的成本质疑（「把等待成本转嫁给每次运行」），而不是回避它。

窗口自 **PR 创建时刻**起算 120s（约实测最坏标签延迟 40s 的三倍），轮询间隔 10s。锚在创建时刻使它**自动失效**：`synchronize`、`labeled`、任何 `rerun_failed_jobs` 重放时 `created_at` 早已过去，截止点已在身后，循环只读一次、不睡眠。

### 被否决的方向

**方向 2（改由 `labeled` 事件唯一判定）——漏洞假设已证伪，即：漏洞是真的，方向不可取。** 立单要求先确认「一个从头到尾没有任何标签动作的 PR 是否仍会被判到」。答案是**不会**：GitHub 的 `labeled` 事件只在标签实际写入时触发，一个没有任何标签动作的 PR 不产生该事件。而本仓恰恰存在这种形状——`.github/labeler.yml` 无匹配路径、且 diff 小到不触发 size 标签的 PR，全程零标签动作。若把唯一判定移到 `labeled`，这类「真的忘了写 changeset」的 PR 将**一次都不会被判**。这是本单最危险的一条，故弃。

**方向 3（推迟到 ready-for-review / 首次 synchronize）** 弃：本仓流程是「PR 先 DRAFT、验收后翻 ready」，但一个建立后直接翻 ready 且再无推送的 PR 不产生 `synchronize`；且 `ready_for_review` 未在 `on:` 里，加它等于改触发面，还要牵动 required 集的语义（本单禁项）。

**方向 4（标签缺失时输出 neutral 而非 failure）** 弃：这是把门禁降级成提示，直接违反本单硬约束。

## 4. ⛔ 硬约束：门禁没有被放宽

结算读**只有在真的看见标签时**才写 `skip=true`。其余每一个出口——无 PR 号、标签读不到、窗口关闭、重试上限——一律写 `skip=false`，即**强制执行**，与 #4690 的既定方向一致。无 changeset 且无 `skip-changeset` 的 PR 仍然 `exit 1`。

## 5. 反向验证（先申报，后执行）

### 声明 A（竞态消失）— 极性：肯定式，会红

**申报**：本 PR 自身走 skip-changeset 路线，`pull_request` 事件取 merge ref 版本的 workflow，故本 PR 即活冒烟——**首跑就该绿，不需要 rerun**。

**实测结果（活体，首跑，已达成）**：本 PR 建立于 `18:22:52Z`，`skip-changeset` 于约 `18:23:2xZ` 打上。`opened` 那一跑的 `Check Changeset`（run 31206681669 / job 92959379121）**首跑 `success`，18:23:01Z 起 18:23:44Z 止，未做任何 rerun**。job 日志：

```
env:
  PR_NUMBER: 6429
  PR_CREATED_AT: 2026-08-07T18:22:52Z
  WINDOW_SECONDS: 120
  POLL_SECONDS: 10
shell: /usr/bin/bash -e {0}

18:23:42  ##[notice]'skip-changeset' is on PR #6429 (read live on attempt 1), so this
          PR declares no release of its own and the changeset check is exempt.
```

关键在于**结算读步骤当时确实执行了**——而它的 `if:` 只在「快路径没看见标签」且「added 为 0」时才成立。也就是说：约 `18:23:05Z` 的快路径读取**没读到**标签（标签尚未落地），是 `18:23:42Z` 的结算读接住了它。**换成改动前的 workflow，这一跑必红。** 竞态在它自己的修复 PR 上被当场复现、当场吃掉。

附带一格实测：`Auto Label` 于 `18:23:38Z` 完成其整组 PUT（新增 `ci/cd`），标签读回为 `["ci/cd", "skip-changeset"]`——本次 #5533 式覆写**没有**发生，结算读在该 PUT 之后仍读到标签。

日志里的 `shell: /usr/bin/bash -e {0}` 也实测确认了本文件注释的说法：**无 pipefail**。

### 声明 B（门没被放宽）— 极性：肯定式，会红

**申报**：构造「无 changeset 且无 skip-changeset」的形状，必须红。

**实测（不是推理）**：把 workflow 里两个新步骤的 `run:` 原样抽出，用桩 `gh` 在 `bash -e -o pipefail` 下**真跑**，11 条全过：

```
=== settle step ===
[PASS] label already present  : EXEMPT, no wait          skip=true    0.0s
[PASS] B: no label, window closed : ENFORCE              skip=false   0.0s
[PASS] B: no label, window OPEN, never arrives : ENFORCE skip=false   4.0s
[PASS] A: label lands on read 3 inside window : EXEMPT   skip=true    2.1s
[PASS] gh unreadable : ENFORCE (#4690)                   skip=false   0.0s
[PASS] no created_at : one read, ENFORCE                 skip=false   0.0s
[PASS] no PR number : ENFORCE                            skip=false   0.0s
[PASS] lookalike `skip-changeset-audit` NOT exempt       skip=false   0.0s
=== verdict step ===
[PASS] B: added=0 : RED   rc=1 (want 1)
[PASS] added=1 : green    rc=0 (want 0)
[PASS] no .changeset dir : stands aside  rc=0 (want 0)
11/11 passed
```

其中第 4 条正是本单的竞态：标签在第 3 次读取时才出现，结算读仍判为豁免。第 2、3 条与末尾 `added=0` 得 `rc=1` 合起来就是硬约束的实测证据。

（注：桩测跑在 `-o pipefail` 下，比 GitHub 默认更严；实际 workflow 无 `shell:` 键，默认 `bash -e` 无 pipefail——这一点在核对计数步骤时反过来咬了我一次，我最初的本地探针误加了 pipefail，导致空 diff 时 `grep -v` 返回 1 而整条管道失败。已按真实语义重跑。）

### 声明 C（既有 CONSUMER 断言未变陈旧）— 极性：肯定式，会红

**申报**：`check-empty-changeset.mjs` 里直接读 workflow 的既有断言，改后必须**仍然真实反映 workflow 现状**；不能只是「还绿」。

**风险点是真实存在的**：我把 `Check for a changeset added by this PR` 改名为 `Count the changesets this PR adds` 并移动了计数行。若既有断言锚在**步骤名**上，它现在就已陈旧。

**实测**：把 #6129 重新植入**改名后的**计数步骤（`$MERGE_BASE` 换回 `$PINNED_BASE_SHA`），自测立刻转红：

```
consumer: the changeset COUNT must diff from $MERGE_BASE (never the frozen base.sha) -- that count going green on main drift is #6129
EXIT=1
```

⇒ 既有断言锚在 diff 拼写而非步骤名上，**穿过了我的重构仍然咬得住**，不是「看不见我的改动」。

### 空绿自查（消融七条，全部转红）

新增断言若不会因构造被拿掉而转红，就是幻检。逐条消融实测：

| 消融 | 自测 |
| --- | --- |
| 结算读不再以 added 等于 0 为条件 | RED |
| 两处标签匹配器分叉（`-qxF` 改 `-qF`） | RED |
| 某判定步骤丢掉结算读守卫 | RED |
| 某判定步骤丢掉快路径守卫 | RED |
| 「无 changeset」判定改成 `exit 0` | RED |
| 判定步骤加 `continue-on-error` | RED |
| 整个结算读步骤被删除 | RED |

**零空绿。** 自测条数 36 改为 43。

## 6. 门禁 EXIT 表

| 门禁 | EXIT | 输出 |
| --- | --- | --- |
| `node scripts/check-empty-changeset.mjs --self-test` | **0** | `✓ 43 assertions over real temp git repos (real scan() path)` |
| `pnpm check:workflow-status-functions` | **0** | `✓ 34 assertions`；`OK (22 workflow files, 41 jobs, 24 job-level if:; 9 read needs.*.outputs.*, all naming a status function)` |
| YAML 解析校验（全部 22 个 workflow） | **0** | `parsed 22 workflow files, 0 errors` |
| 每个 `run:` 块 `bash -n` | **0** | `BAD COUNT 0` |
| `pnpm check:nul-bytes` | **0** | `✓ 56 assertions`；`OK (scanned 6067 tracked text files)` |
| 控制字节自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` | **1**（无命中） | 两个改动文件均无控制字节 |
| `npx eslint scripts/check-empty-changeset.mjs` | **0** | 无输出 |

另：用真实 git 跑通计数步骤——本分支 `added=0`，回退 40 个提交为基准时 `added=26`。

CI 侧（本 PR）：**ESLint `success`**、**TypeScript Type Check `success`**、`Check Changeset` **首跑 `success`**。

## 7. 不在本 PR 里

- **不动 required 集**，不动其他 workflow，不碰 `content/docs/releases/**`。
- **`Resolve the diff base` 仍只带快路径守卫**：它的 `exit 1` 是「git 基准不可用」，不是 changeset 判决，本就不受标签豁免——**如实记录而非顺手扩大**。CONSUMER 断言按「跑 `check-*.mjs` 或发出 no-changeset 错误」来圈定判定步骤，该步骤被有意排除在外。
- **窗口之外仍有一格残留**：标签若晚于窗口才落地，`opened` 那跑的红不会自行清除（`labeled` 那跑会绿，但绿不清红）。这是 #5580 就记录过的方向，本 PR 把窗口从「约 10s」放宽到「120s」，未声称消灭它。
- **`allow-major` 那半仍读冻结负载**（#5620），照旧不在本单范围。
- 无 changeset：本 PR 只改 workflow 与门禁脚本自测面，不发布任何包 ⇒ 走 `skip-changeset` 标签路线。
