### PR TITLE
fix(tooling): the ADR-0087 prescription detector reads real prescriptions, not the FROM/TO placeholder (#6419)

### DIFF
--- a/scripts/check-adr-0087-registration.mjs
+++ b/scripts/check-adr-0087-registration.mjs
@@ -102,10 +102,10 @@
 //                            two cannot be confused because base decides.
 //   no-migration-prescription
 //                         -- REFUSED when the changeset's own body carries a
-//                            FROM -> TO migration prescription. A changeset that
-//                            ships instructions for rewriting a consumer's code
-//                            cannot also claim no consumer has to rewrite
-//                            anything: that is a self-contradiction, checked
+//                            migration prescription. A changeset that ships
+//                            instructions for rewriting a consumer's code cannot
+//                            also claim no consumer has to rewrite anything: that
+//                            is a self-contradiction, checked
 //                            statement-against-statement, not a retirement
 //                            detector.
 //
@@ -115,6 +115,13 @@
 // mechanically-verified category. Measured on the same 400 commits: 11 of the 32
 // breaking changesets carry such a prescription, and it covers 4 of the 5 that did
 // register -- a genuine forcing function, not a blanket demand.
+//
+// #6419 repaired the detector behind it. It had been matching the literal
+// PLACEHOLDER words `FROM`/`TO` -- so `迁移:FROM → TO` (the template) was caught
+// while `迁移:`aggregate:` → `aggregations:`` (a real prescription) was not, and
+// the better the prescription the more invisible it was. It now also reads
+// framing-anchored rewrites in both languages. The full argument, the measured
+// numbers and the deliberate residual blind spot are at hasMigrationPrescription.
 //
 // ## Absence is never a pass (#4690)
 //
@@ -224,23 +231,177 @@ export function breakingDeclaration(parsed) {
   return { breaking: signals.length > 0, signals };
 }
 
+// ---------------------------------------------------------------------------
+// Migration-prescription detection
+//
+// ## What went wrong the first time (#6419)
+//
+// The original detector had an English branch and a Chinese branch, and BOTH
+// required the literal uppercase words `FROM` and `TO`:
+//
+//     迁移:FROM → TO                          (the TEMPLATE PLACEHOLDER)  -> caught
+//     迁移:`aggregate:` → `aggregations:`     (a REAL prescription)       -> MISSED
+//
+// So it detected the SHAPE OF ONE HISTORICAL CHANGESET (#6048's) rather than the
+// presence of a prescription, and the failure was worst exactly where it mattered
+// most: a prescription is only useful when it names real identifiers, so the
+// better an author wrote one, the more invisible it became. That is a gate not
+// checking what it claims to check, so it is repaired rather than documented.
+//
+// ## What replaced it
+//
+// Two branches, unioned. The first is the OLD pattern, kept verbatim, so the new
+// detector is a strict SUPERSET of the old one: nothing that used to be refused
+// can now slip through, and the `no-migration-prescription` exemption can only
+// have got harder to claim, never easier.
+//
+//   1. THE LABEL CONVENTION -- `FROM`/`TO` used as a section label, table header
+//      or code comment. Measured: this is a genuine house convention, not one
+//      changeset's quirk (`## FROM → TO` x16, `FROM → TO:` x15, `**FROM → TO**`
+//      x11, `Migration (FROM → TO):` x4 in the current stock).
+//
+//   2. A FRAMING-ANCHORED REWRITE -- a REWRITE (`X → Y` where both sides are
+//      code-ish: a backticked span, or a dotted/slashed identifier path) that
+//      appears either ON a line carrying migration framing, or ANYWHERE UNDER a
+//      heading that carries it. This is the branch that catches
+//      `**迁移**:`aggregate:` → `aggregations:`` and every other honestly-written
+//      prescription in either language.
+//
+// ## What it moved (measured on the stock, both versions run over it)
+//
+// 1342 changesets, 235 of them declared-breaking (the only population this gate
+// judges). Old detector: 113 hits, 87 of them breaking. New detector: 122 hits,
+// 92 breaking. NINE newly flagged, ZERO no longer flagged -- the superset property
+// is a measurement, not a claim. Seven of the nine are prescriptions the old
+// pattern missed (`r.deleted` → `r.success`; `改名 HttpMethodSchema →
+// HttpMethodSubsetSchema`; `rename `group` → `team``; a `OLD.x` → `previous.x`
+// migration table; ...). Two are false positives, both on changesets that declare
+// NO breaking change and are therefore never judged -- an error-message template
+// diagram (`[ Did you mean `k1` → `canonical`? ]`) and a docs-only changeset
+// describing a theme engine's internal token mapping. Verdict impact of the false
+// positives on the current tree: zero.
+//
+// ## Why anchored on framing rather than on the arrow alone (measured)
+//
+// An arrow is not a prescription. The current stock carries 933 distinct
+// arrow-bearing lines across 480 changesets, and the great majority are ordinary
+// prose: pipelines (`analytics→engine`), version steps (`16→17`), request/response
+// traces (`→ 200 {...}`), dependency directions (`runtime → objectql`). Requiring
+// code-ish operands on both sides removes the numeric and single-word cases but
+// still leaves behavioural mappings that nobody has to rewrite anything for
+// (`.yml` → `'yaml'` inside a format detector, `test` → `development` inside a
+// NODE_ENV normalizer). Framing is what separates "here is what you must rewrite"
+// from "here is what the code does".
+//
+// ## The residual blind spot, stated rather than hidden (measured)
+//
+// Framing-anchored means an UNFRAMED rename table is still missed. Measured over
+// the same stock: 128 changesets carry a code-to-code rewrite that this detector
+// does not flag, 21 of them declared-breaking -- typically the
+// `unknown-key-strictness-*` and `adr-0112-*` batches, whose bodies list
+// `old` → `new` pairs under a plain heading with no migration word anywhere near
+// them. Anyone widening this later should start there, with these numbers to
+// beat.
+//
+// Two wider rules were measured and REJECTED as noisier than they are useful:
+// firing on any line carrying >=2 rewrites takes the declared-breaking hit count
+// 92 -> 102 but adds 35 changesets to hand-check, of which a clear minority are
+// prescriptions; firing on ANY code-to-code arrow takes it to 250 hits / 113
+// breaking and is plainly a different check (it flags behaviour tables and worked
+// examples). An honestly-scoped detector beats a noisy one here because a FALSE
+// POSITIVE has no honest escape: the author is refused an exemption they are
+// entitled to and the closed vocabulary offers them nothing else -- which is the
+// #6419 shape itself, one category over.
+//
+// Consequence to keep in mind when reading a green run: this branch answers
+// "did the author FRAME a rewrite as a migration", not "is a rewrite required".
+// It is a contradiction check on one exemption, never a trigger and never a
+// retirement detector.
+// ---------------------------------------------------------------------------
+
+/** The three arrow spellings this repo's changesets use. */
+const ARROW = '(?:→|->|—>)';
+
 /**
- * Does the changeset carry a FROM -> TO migration prescription?
+ * One side of a rewrite: a backticked code span, or a dotted/slashed identifier
+ * path. A BARE word is deliberately not an operand -- `runtime → objectql` is a
+ * dependency direction, not a rename -- and neither is a bare number, which is
+ * what keeps `16 → 17` and `60 → 3` out.
+ */
+const OPERAND = '(?:`[^`\\n]+`|[A-Za-z_$][A-Za-z0-9_$]*(?:[./][A-Za-z0-9_$]+)+)';
+
+/** `X → Y`, both sides code-ish. Stateless (no `g`): it is used inside a loop. */
+export const REWRITE_RE = new RegExp(`${OPERAND}\\s*${ARROW}\\s*${OPERAND}`);
+
+/**
+ * Migration framing, in the spellings THIS repo's changesets actually use.
  *
- * Case-SENSITIVE and anchored on this repo's house spellings only. An earlier,
- * case-insensitive draft matched ordinary prose ("from the old value to the new")
- * and fired on 14 of 32 breaking changesets instead of 11; the uppercase
- * convention is what authors actually use for a prescription, so the pattern reads
- * that and nothing else.
+ * Derived from the stock, not invented: the Chinese side comes from `## 迁移`,
+ * `**迁移**:`, `**迁移面**:`, `## 破坏性变更 · 迁移`, `## 作者需要知道的迁移`,
+ * `## 升级说明`, `## 升级影响`, `应改写为`, `改名`; the English side from
+ * `## Migration`, `## Migrating`, `**Migration.**`, `Migration (FROM → TO):`.
  *
- * This is a CONTRADICTION check on one exemption, never a trigger and never a
- * retirement detector: a changeset that ships instructions for rewriting a
- * consumer's code cannot simultaneously claim no consumer must rewrite anything.
+ * The English alternatives are WORD-ANCHORED on purpose. Without `\b` the token
+ * matches inside identifiers -- `sys_migration_journal`, `renameConfigKey`,
+ * `migrations/registry.ts`, `onUpgrade` -- and those appear in ordinary prose
+ * next to arrows. Measured: word-anchoring removed one false positive
+ * (`conversion-shadowed-alias-by-value.md`, whose only "framing" was the
+ * identifier `renameConfigKey`) and removed no true positive.
+ */
+export const MIGRATION_FRAMING_RE =
+  /迁移|改写|改名|升级|\bmigrat(?:e|es|ed|ing|ion|ions)\b|\brename[sd]?\b|\brewrit(?:e|es|ten|ing)\b|\bupgrade[sd]?\b/i;
+
+/** The `FROM`/`TO` label convention -- branch 1, unchanged from #6148. */
+const FROM_TO_LABEL_RE =
+  /(?:^|[^A-Za-z])FROM(?:\s|\*|`|\)|:)[^\n]{0,60}?(?:→|->|—>)[^\n]{0,60}?TO(?![A-Za-z])|^\s*\|?\s*\**FROM\**\s*(?:\(|\|)|^\s*\/\/\s*FROM\b|迁移[^\n]{0,12}FROM\s*(?:→|->)\s*TO/m;
+
+/**
+ * The prescription this changeset carries, with the LINE that evidences it, or
+ * `null`.
+ *
+ * The evidence is returned rather than a bare boolean because the refusal message
+ * is read by an author who believes their changeset has no prescription. "Your
+ * body carries one" is unarguable-with; "your body carries one, here it is" is
+ * checkable, and it is the only way an author can tell a real contradiction from
+ * a detector they should be arguing about (#6419 exists because nobody could see
+ * what the old pattern was actually reading).
+ *
+ * See the block comment above for what each branch reads, what was measured, and
+ * which shapes are deliberately out of reach.
  *
  * @param {string} body
+ * @returns {{ branch: 'from-to-label' | 'framed-line' | 'framed-section', line: string } | null}
+ */
+export function findMigrationPrescription(body) {
+  const label = FROM_TO_LABEL_RE.exec(body);
+  if (label) {
+    const at = body.slice(0, label.index).split(/\r?\n/).length - 1;
+    return { branch: 'from-to-label', line: (body.split(/\r?\n/)[at] ?? label[0]).trim() };
+  }
+
+  // A heading carrying migration framing opens a framed region that runs to the
+  // next heading. Without it, the most natural way to write a prescription --
+  // `## 迁移` followed by a list of `old` → `new` lines -- would be invisible,
+  // which is the #6419 defect in a second spelling.
+  let framedSection = false;
+  for (const line of body.split(/\r?\n/)) {
+    if (/^\s{0,3}#{1,6}\s/.test(line)) framedSection = MIGRATION_FRAMING_RE.test(line);
+    if (!REWRITE_RE.test(line)) continue;
+    if (MIGRATION_FRAMING_RE.test(line)) return { branch: 'framed-line', line: line.trim() };
+    if (framedSection) return { branch: 'framed-section', line: line.trim() };
+  }
+  return null;
+}
+
+/**
+ * Does the changeset carry a migration prescription -- instructions for
+ * rewriting a consumer's code?
+ *
+ * @param {string} body
+ * @returns {boolean}
  */
 export function hasMigrationPrescription(body) {
-  return /(?:^|[^A-Za-z])FROM(?:\s|\*|`|\)|:)[^\n]{0,60}?(?:→|->|—>)[^\n]{0,60}?TO(?![A-Za-z])|^\s*\|?\s*\**FROM\**\s*(?:\(|\|)|^\s*\/\/\s*FROM\b|迁移[^\n]{0,12}FROM\s*(?:→|->)\s*TO/m.test(body);
+  return findMigrationPrescription(body) !== null;
 }
 
 /**
@@ -742,10 +903,13 @@ export function scan({ cwd, base, head = 'HEAD' }) {
     }
 
     // no-migration-prescription
-    if (hasMigrationPrescription(parsed.body)) {
+    const prescription = findMigrationPrescription(parsed.body);
+    if (prescription) {
       push(
         '`not-required (no-migration-prescription)` contradicts the changeset\'s own body, which carries\n' +
-        '      a FROM -> TO migration prescription.\n' +
+        '      a migration prescription.\n' +
+        `      Evidence (${prescription.branch}):\n` +
+        `        ${prescription.line.slice(0, 160)}\n` +
         '      A changeset that ships instructions for rewriting a consumer\'s code cannot also claim\n' +
         '      that no consumer has to rewrite anything. This is the shape #6048 had: its changeset\n' +
         '      carried a worked `迁移:FROM → TO` block and the ledger got no entry.\n' +
@@ -931,7 +1095,7 @@ function selfTest() {
       ),
     },
     pkgs: { '@objectstack/runtime': { dir: 'packages/runtime', private: false }, '@objectstack/spec': { dir: 'packages/spec', private: false } },
-  })), [/contradicts the changeset's own body/, /FROM -> TO/, /#6048/]);
+  })), [/contradicts the changeset's own body/, /Evidence \(from-to-label\)/, /#6048/]);
 
   // ---- G2: THE RECONCILIATION STEP -- register it and the same input passes --
   green('G2 same input, registered by this diff', run(mk({
@@ -1015,6 +1179,58 @@ function selfTest() {
     },
   })), [/markers -- exactly one disposition is expected/]);
 
+  // ---- R10: THE #6419 SHAPE -- a REAL prescription, written in Chinese with -
+  // real identifiers, claiming the catch-all exemption.
+  //
+  // This is the case the gate was blind to on the day it landed: the body ships a
+  // worked rewrite (`aggregate:` -> `aggregations:`) and simultaneously claims no
+  // consumer has to rewrite anything, and the old detector passed it because the
+  // author had written real identifiers instead of the placeholder words FROM/TO.
+  // Reverse-verified: restore the old pattern and this case reports "expected RED,
+  // got green" -- it is green for the empty reason, which is exactly the defect.
+  red('R10 the #6419 shape (a real Chinese prescription under the catch-all)', run(mk({
+    files: {
+      '.changeset/x.md': CS({
+        body:
+          '**BREAKING**: 驱动 `aggregate()` 的两个宽容分支删除\n\n' +
+          '**迁移**:`aggregate:` → `aggregations:`,`func:` → `function:`。\n\n' +
+          '<!-- adr-0087: not-required (no-migration-prescription) these keys were never a declared surface anywhere -->\n',
+      }),
+    },
+  })), [/contradicts the changeset's own body/, /Evidence \(framed-line\)/, /aggregations/]);
+
+  // ---- R11: the same, framed by a HEADING instead of an inline label ---------
+  // `## 迁移` + a list of rewrites is the other natural spelling; a line-only rule
+  // would read the list as unframed prose and pass it.
+  red('R11 a prescription under a migration HEADING', run(mk({
+    files: {
+      '.changeset/x.md': CS({
+        body:
+          '**BREAKING**: two config keys renamed\n\n' +
+          '## 迁移\n\n- `node.config.filters` → `node.config.filter`\n\n' +
+          '<!-- adr-0087: not-required (no-migration-prescription) nothing downstream reads either spelling today -->\n',
+      }),
+    },
+  })), [/contradicts the changeset's own body/, /Evidence \(framed-section\)/]);
+
+  // ---- G7: ordinary prose arrows under the catch-all stay GREEN --------------
+  // The false-positive floor. Every arrow here is real corpus prose: a pipeline, a
+  // version step, a dependency direction, a request trace. None is a prescription,
+  // and refusing them would leave an entitled author with no honest disposition --
+  // the #6419 shape pointed the other way.
+  green('G7 prose arrows are not prescriptions', run(mk({
+    files: {
+      '.changeset/x.md': CS({
+        body:
+          '**BREAKING** an internal error string changed\n\n' +
+          'The analytics→engine bridge forwards the context; 16 → 17 is already a\n' +
+          'substantial migration, and the dependency direction (runtime → objectql)\n' +
+          'permits no other home. A bad request now answers → 400 instead of 500.\n\n' +
+          '<!-- adr-0087: not-required (no-migration-prescription) an internal error string changed; no key, symbol or stored value moves -->\n',
+      }),
+    },
+  })));
+
   // ---- G6: a changeset that was ALREADY breaking at base is inherited -------
   {
     const r = mk({ files: {} });
@@ -1077,11 +1293,34 @@ function selfTest() {
   }
 
   // ---- Unit pins on the two pattern-shaped judgements ----------------------
+  //
+  // P1-P3 are the LABEL branch, unchanged since #6148 -- the template placeholder
+  // must keep matching, or the #6048 shape stops being caught. P4-P5 are the
+  // original false-positive floor. P9-P17 are #6419: the branch that reads real
+  // prescriptions, and the prose shapes it must still refuse.
   assert(hasMigrationPrescription('### 迁移:FROM → TO\n'), 'P1: the Chinese prescription heading must match');
   assert(hasMigrationPrescription('**FROM → TO**\n'), 'P2: the inline FROM -> TO heading must match');
   assert(hasMigrationPrescription('| FROM (legacy) | TO (primitives) |\n'), 'P3: a FROM/TO table header must match');
   assert(!hasMigrationPrescription('moved from the old value to the new one\n'), 'P4: ordinary lowercase prose must NOT match');
   assert(!hasMigrationPrescription('this is from A to B in prose\n'), 'P5: lowercase "from ... to" must NOT match');
+
+  // #6419 -- REAL prescriptions, which the placeholder-only pattern all missed.
+  assert(hasMigrationPrescription('**迁移**:`aggregate:` → `aggregations:`\n'), 'P9: a real Chinese prescription with backticked identifiers must match');
+  assert(hasMigrationPrescription('一行修复:把 `ctx.user.roles` 改写成 `ctx.user.positions`(`req.user.roles` → `req.user.positions`)\n'), 'P10: a 改写 prescription must match');
+  assert(hasMigrationPrescription('**Migration.** `r.deleted` → `r.success`. That is the whole migration.\n'), 'P11: an English inline Migration prescription must match');
+  assert(hasMigrationPrescription('## 迁移\n\n- `node.config.filters` → `node.config.filter`\n'), 'P12: a rewrite under a migration HEADING must match');
+  assert(hasMigrationPrescription('## Migration\n\n- `sharedWith.type` → `sharedWith.recipientType`\n'), 'P13: the same, in English');
+  // and the prose it must still refuse -- every one of these is real corpus text.
+  assert(!hasMigrationPrescription('ceremony — 16→17 is already a substantial, tested migration — to postpone\n'), 'P14: a version step next to the word migration must NOT match');
+  assert(!hasMigrationPrescription('dependency direction (runtime → objectql) permits no other home.\n'), 'P15: a dependency direction must NOT match');
+  assert(!hasMigrationPrescription('No `sys_migration_journal` registered → the scan is skipped in silence.\n'), 'P16: the framing word inside an identifier must NOT anchor');
+  assert(!hasMigrationPrescription('`renameConfigKey`, so `object` → `objectName`, `filters` → `filter`\n'), 'P17: `renameConfigKey` is an identifier, not framing');
+  // the evidence line is what makes a refusal checkable rather than assertive
+  assert(findMigrationPrescription('**迁移**:`a.b` → `a.c`\n')?.branch === 'framed-line', 'P18: an inline framed rewrite reports the framed-line branch');
+  assert(findMigrationPrescription('## 迁移\n\n`a.b` → `a.c`\n')?.branch === 'framed-section', 'P19: a heading-framed rewrite reports the framed-section branch');
+  assert(findMigrationPrescription('### 迁移:FROM → TO\n')?.branch === 'from-to-label', 'P20: the placeholder label reports the label branch');
+  assert(findMigrationPrescription('nothing here\n') === null, 'P21: a body with no prescription reports null, not a shrug');
+
   assert(breakingDeclaration(parseChangeset(CS({ body: 'feat(spec)!: x\n' }))).breaking, 'P6: a conventional-commit bang is a declaration');
   assert(!breakingDeclaration(parseChangeset(CS({ bumps: [['a', 'patch']], body: 'plain\n' }))).breaking, 'P7: a plain patch is not');
   assert(extractIds("  id: 'object-titleFormat-to-nameField',\n").length === 1, 'P8: an id with a capital letter must be extracted');


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6419

Scope: **Ruling 2 only.** The `CATEGORIES` vocabulary stays three entries, byte-identical — Ruling 1 (a fourth `never-declared` category) was withdrawn on the thread and is not touched here. The ledger / `registered` path is likewise byte-identical (verified: the only diff line matching `registered` is a new test string).

## The defect

`hasMigrationPrescription` had an English branch and a Chinese branch, and **both required the literal uppercase words `FROM` and `TO`**:

| written in the changeset | old detector |
|:--|:--|
| `迁移:FROM → TO` (the **template placeholder**) | caught |
| ``迁移:`aggregate:` → `aggregations:` `` (a **real prescription**) | missed |

So it detected the *shape of one historical changeset* (#6048's), not the presence of a prescription — and because a useful prescription names real identifiers, **the better an author wrote one, the more invisible it became**. Since `not-required (no-migration-prescription)` is a self-contradiction check that rests entirely on this detector, the category was trivially abusable.

Premise re-verified against `origin/main` (`e8dc61e`) before implementing: the regex is exactly as the issue describes, the Chinese branch `迁移[^\n]{0,12}FROM\s*(?:→|->)\s*TO` requires the same two uppercase words, and the detector is consulted at exactly one site — the `no-migration-prescription` arm of `scan()`.

## The fix

A union of two branches.

1. **The label convention — the old pattern, kept verbatim.** This makes the new detector a strict **superset**: nothing that used to be refused can now slip through, and the exemption can only have got harder to claim. Corpus-attested as a real house convention, not one changeset's quirk: `## FROM → TO` x16, `FROM → TO:` x15, `**FROM → TO**` x11, `Migration (FROM → TO):` x4.
2. **A framing-anchored rewrite.** `X → Y` where *both* sides are code-ish (a backticked span, or a dotted/slashed identifier path), appearing either on a line carrying migration framing or anywhere under a heading that carries it. The framing vocabulary is derived from the stock, not invented — Chinese `迁移` / `改写` / `改名` / `升级` (from `## 迁移`, `**迁移面**:`, `## 破坏性变更 · 迁移`, `## 升级说明`, `应改写为`), English `migrat*` / `rename*` / `rewrit*` / `upgrade*`, word-anchored.

Word-anchoring the English alternatives is load-bearing: without `\b` the token matches inside `sys_migration_journal`, `renameConfigKey`, `migrations/registry.ts`, `onUpgrade`, all of which appear in prose next to arrows. Measured, it removed one false positive and no true positive.

`findMigrationPrescription()` now returns the **evidence line and which branch matched**, and the refusal message quotes it. An author who believes their changeset has no prescription can now see exactly what the gate read — the thing nobody could see when #6419 was filed.

## Measurement (old detector vs new, both run over the real corpus)

Both versions were imported as modules (CLI trailer stripped, functions byte-identical to the shipping ones) and run over the current `.changeset` stock, parsed with the gate's own `parseChangeset` / `breakingDeclaration`.

```
CORPUS                 1342 changesets  (declared-breaking: 235)
old detector hits      113  (declared-breaking: 87)
new detector hits      122  (declared-breaking: 92)

DIFFERENCES: +9 newly flagged, -0 no longer flagged
```

`-0` is the superset property, measured rather than argued.

Corpus reach: the current tree's `.changeset/*.md` set — the whole v17 train's accumulated stock, 1342 files. Historical changesets consumed by past releases are **not** included: they are deleted at version time, so reaching them means replaying `git log` over deleted paths across the whole history, which is not cheap and would measure a corpus written under older conventions. The v17 stock is 1342 files against the gate's own design sample of 400 first-parent commits, so it is already the larger measurement.

### Hand-checked classification of all 9 differences

| changeset | breaking? | evidence line the new branch matched | verdict |
|:--|:--|:--|:--|
| `client-delete-result-success.md` | yes | `` `r.deleted` → `r.success`. That is the whole migration. `` | **caught FN** — the changeset says this *is* the migration |
| `close-out-sweep-inert-keys.md` | yes | ``the protocol-17 `topics`→`sources` rename is absorbed`` | **caught FN** — 14 keys retired with `retiredKey` prescriptions and `os migrate meta` |
| `dual-source-cross-form-convergence.md` | yes | ``**Renamed — `./contracts` `ShareRecipientType` → `RecordShareRecipientType`:**`` | **caught FN** — export rename, consumers rewrite imports |
| `http-method-defkey-collision.md` | yes | ``改名 `HttpMethodSchema` → `HttpMethodSubsetSchema` `` | **caught FN** — the Chinese-framed rename the old regex was blind to |
| `sharing-rule-recipient-reconcile.md` | yes | ``rename `group` → `team` `` | **caught FN** — enum member wire-rename |
| `hook-condition-previous-binding.md` | no (minor) | ``migration table maps `OLD.x` → `previous.x` `` | **caught FN** — a literal migration table |
| `object-parse-path-strict.md` | no (minor) | ``the semantic renames … (`capabilities` / `features` → `enable`)`` | **caught FN** — names the rewrite that survives the strict flip |
| `strict-unknown-key-history-last.md` | no (patch) | ``[ Did you mean `k1` → `canonical`? ]  fix, channel 1 (renames)`` | **FALSE POSITIVE** — a diagram of an error-message *template*, inside a fenced block, in a `patch` changeset |
| `widget-contract-theme-token-vocabulary.md` | no (no bump) | ``` `colors` 出门时的改名(`surface` → `--card`… ``` | **FALSE POSITIVE** — describes the theme engine's internal CSS-variable mapping; docs-only, "releases nothing" |

**False positives: 2, both individually justified.** Neither changeset declares a breaking change, so `breakingDeclaration()` filters both out before the detector is ever consulted — their flag is visible only in the `--list` audit column. **Verdict impact on the current tree: zero.**

Caution the drivers lane raised on the thread, and it is right: this corpus was itself written under the broken detector, so "historical zero false positives" would prove nothing about safety. That is why the classification above is per-changeset by hand, and why the two false positives are named rather than netted out.

### Residual blind spot, measured and documented in the script

Framing-anchored means an **unframed** rename table is still missed. Measured over the same stock: **128 changesets carry a code-to-code rewrite this detector does not flag, 21 of them declared-breaking** — typically the `unknown-key-strictness-*` and `adr-0112-*` batches, which list `old` → `new` pairs under a plain heading with no migration word near them. The numbers and the class are written into the script's header so the next person to widen it starts from them.

Two wider rules were measured and **rejected**:

| candidate | hits | declared-breaking | why rejected |
|:--|--:|--:|:--|
| shipped (label + framing-anchored) | 122 | 92 | — |
| also fire on any line with >=2 rewrites | 157 | 102 | +35 changesets, a clear minority of them prescriptions |
| fire on any code-to-code arrow | 250 | 113 | a different check — flags behaviour tables and worked examples |

The asymmetry that decides it: a **false positive here has no honest escape**. The author is refused an exemption they are entitled to and the closed vocabulary offers them nothing else — which is the #6419 shape itself, one category over. So the honestly-scoped detector wins, with its blind spot stated rather than hidden.

## Tests

The gate's pin tests live in the script's own `--self-test` (real temp git repositories driven through the shipping `scan()`), per the #6342 template. **46 -> 67 assertions.**

New scan-level cases (real repos, real `scan()`):

- **R10 — the #6419 shape**: a real Chinese prescription (``**迁移**:`aggregate:` → `aggregations:` ``) claiming `no-migration-prescription`. Must be RED.
- **R11 — the same, framed by a heading**: `## 迁移` followed by a rewrite list. Must be RED; a line-only rule would read the list as unframed prose.
- **G7 — the false-positive floor**: prose arrows only (`analytics→engine`, `16 → 17`, `runtime → objectql`, `→ 400`) under the catch-all. Must stay GREEN.
- **R2 — the template placeholder still caught**: unchanged #6048 fixture, expectation retargeted to the new evidence line.

New unit pins: P9-P13 (real prescriptions in both languages, inline and under a heading), P14-P17 (the prose shapes that must still be refused — all real corpus text), P18-P21 (the evidence branch each shape reports).

### Reverse verification — direction predicted first

**Prediction (recorded before running):** ablate branch 2 (delete the framing-anchored limb, leaving the placeholder-only detector) and expect **red** — P9-P13 and P18-P19 fail on the unit side, R10/R11 report "expected RED, got green" plus their message assertions; and expect P1-P5, P14-P17, P21, G7, R2, G5 to stay **green**, since branch 1 is unchanged and the false-positive floor is independent of the fix.

**Result — exactly as predicted, 14 failures:**

```
R10 the #6419 shape (a real Chinese prescription under the catch-all): expected RED, got green
R10 ... message must match /contradicts the changeset's own body/   (actual: empty)
R10 ... message must match /Evidence \(framed-line\)/               (actual: empty)
R10 ... message must match /aggregations/                           (actual: empty)
R11 a prescription under a migration HEADING: expected RED, got green
R11 ... message must match /contradicts the changeset's own body/   (actual: empty)
R11 ... message must match /Evidence \(framed-section\)/            (actual: empty)
P9:  a real Chinese prescription with backticked identifiers must match
P10: a 改写 prescription must match
P11: an English inline Migration prescription must match
P12: a rewrite under a migration HEADING must match
P13: the same, in English
P18: an inline framed rewrite reports the framed-line branch
P19: a heading-framed rewrite reports the framed-section branch
```

Nothing else moved — which is the second half of the proof: the label branch and the false-positive floor are green under **both** versions.

## Observable behaviour on the current tree

Requirement: no changeset in the tree may currently claim `no-migration-prescription` while carrying a real prescription. Measured:

```
changesets in the current tree claiming `no-migration-prescription`: 0
changesets in the current tree carrying ANY adr-0087 marker:         0
```

The gate landed today (#6148 / PR #6342) and no changeset in stock carries a marker yet, so **no verdict anywhere in the tree changes**. There is no live self-contradiction to report and nothing to file. The only observable difference on stock is the `--list` audit column (`prescription=yes/no`) for the 9 changesets above.

## Gates run

Enumerated from `.github/workflows/lint.yml` and `.github/workflows/pr-automation.yml`, not from memory. **Every `check:*` step in both, one by one — all PASS.**

ESLint job (30 steps): `pnpm lint`, `slot-lookup`, `query-options-erasure`, `nul-bytes`, `doc-authoring`, `docs-audit-scope`, `role-word`, `quick-reference-counts`, `adr-anchors`, `org-identifier`, `authz-resolver`, `service-providers`, `route-envelope`, `error-code-casing`, `wildcard-fallthrough`, `meta-type-normalized`, `init-service-contract`, `durability-log-level`, `startup-registry-verdict`, `objectui-changeset`, `release-notes`, `release-body`, `node-version`, `workflow-status-functions`, `shard-attestation`, `published-files`, `engine-double-contract`, `resume-authority-declared`, `merge-driver`, `spec-parsed-alias`.

TypeScript Type Check job: `type-check-coverage`, `driver-conformance`, `stall-guard`, spec `tsc --noEmit`, spec `check:generated --reconcile-only`, `skill-docs`, `spec-changes`, `upgrade-guide`, `authorable-surface`, `docs`, `skill-refs`, `skill-frame-sync`, `skill-compatibility`, `react-blocks`, `type-check-debt`, `api-surface`, `exported-any`, `dual-source-exports`, `skill-examples`, lint `doc-formula-expressions`, `i18n`, `i18n-coverage`.

Check Changeset job: `check-empty-changeset.mjs` (self-test + base), `check-adr-0087-registration.mjs` (self-test + base), `check-changeset-no-major.mjs`.

Two of these needed a build before they said anything, and both reported the prerequisite honestly rather than passing: `check:i18n` / `check:i18n-coverage` ("PREREQUISITE NOT MET — the workspace CLI is not built" / "COULD NOT MEASURE"), and `check:type-check-debt`, which reported `@objectstack/spec-monorepo` drifting 80 -> 84. That last one was checked rather than assumed: **84 with this change and 84 with it reverted**, so it is not this diff — it was an unbuilt-tree artifact, and after `turbo run build --filter='./packages/*' --filter='./packages/*/*'` the gate passes. (`tsc --showConfig` also confirms the root program has `allowJs` off and does not include `scripts/*.mjs` at all, so no TypeScript program reads this file.)

## Why `skip-changeset`

One file changed, `scripts/check-adr-0087-registration.mjs` — a zero-dependency CI gate script that no workspace package imports and that ships in no published tarball. It releases nothing, so it writes no changeset and needs the `skip-changeset` label.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AZgRyPVwi1jLb1mNNuUQ9o)_