### PR TITLE
fix(services): listInbox 的 unreadCount 数总未读,不再只数取回窗口 (#6363)

### DIFF
--- a/.changeset/notification-unread-count-true-total.md
+++ b/.changeset/notification-unread-count-true-total.md
@@ -1,0 +1,44 @@
+---
+"@objectstack/service-messaging": patch
+---
+
+fix(services): `unreadCount` counts the TOTAL unread, not the returned window (#6363)
+
+`ListNotificationsResponseSchema.unreadCount` is published into the API
+reference as **"Total number of unread notifications"** — a `.describe()`, so it
+is the documentation shipped to every consumer of
+`GET /api/v1/notifications`. It was counted inside `rows.map(...)` in
+`MessagingService.listInbox`, i.e. over the rows that `limit` had already
+truncated, so the badge saturated at the window size forever.
+
+Measured on a real stack (sqlite-wasm + ObjectQL + service-messaging + hono +
+dispatcher) with 60 unread messages:
+
+| request | `notifications[]` | `unreadCount` (before) | `unreadCount` (after) |
+|:---|---:|---:|---:|
+| no `limit` | 50 | **50** | **60** |
+| `?limit=10` | 10 | **10** | **60** |
+
+The declaration was right and the implementation was wrong, so the
+implementation moved (maintainer ruling, 2026-08-07). Every consumer that
+renders `unreadCount` as a bell badge now gets the number it asked for; nothing
+had to learn an implementation detail to read the field correctly.
+
+**The list itself is unchanged.** `notifications[]` is still the window —
+`limit` rows, default 50, hard cap 200, newest first. The two bounds were
+conflated, not shared.
+
+Read-state lives on `sys_notification_receipt`, not on the inbox row
+(ADR-0030), so the total is a reverse join rather than a `count()`. It is
+computed only when the window came back **saturated** (`rows.length === limit`)
+— a short window is already the whole matching set, so the common inbox costs
+exactly what it cost before. When the window does saturate, the extra work is
+one projection read of a single column (`notification_id`) under the same
+`where`, no `orderBy` and no `limit`: the same order as the receipt scan
+`listInbox` already performs unconditionally, and exact under a `type` filter
+and for rows carrying no `notification_id`.
+
+Two related behaviours are unchanged and now pinned: a `read` filter narrows
+the list and never the badge (asking for the read half does not mean zero
+unread), and a `type` filter narrows both (the count answers the query that was
+asked).

--- a/packages/runtime/src/notification-schema-conformance.integration.test.ts
+++ b/packages/runtime/src/notification-schema-conformance.integration.test.ts
@@ -254,6 +254,10 @@ describe('[#5792] the notification wire bodies conform to the schemas the catalo
       // which is what a user with more unread than the page size was told
       // forever. The parse was green either way; only this assertion can tell.
       expect(windowed.unreadCount).toBe(all.unreadCount);
+      // Stated as the property rather than only as an equality, so the pin
+      // cannot go quietly vacuous if a future fixture change flattens both
+      // sides: the count MUST be able to exceed the window it came back in.
+      expect(windowed.unreadCount).toBeGreaterThan(windowed.notifications.length);
       expect(ListNotificationsResponseSchema.safeParse(windowed).success).toBe(true);
     });
 

--- a/packages/runtime/src/notification-schema-conformance.integration.test.ts
+++ b/packages/runtime/src/notification-schema-conformance.integration.test.ts
@@ -216,36 +216,44 @@ describe('[#5792] the notification wire bodies conform to the schemas the catalo
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
-  // Declared, not delivered — recorded, NOT endorsed
+  // The gaps the double assertion cannot see — one now closed, one still open
   // ═══════════════════════════════════════════════════════════════════════════
   //
-  // The two assertions above are 3/3 green for this family. These two facts are
-  // real inconsistencies that BOTH assertions are structurally blind to, and
-  // that is the point worth writing down for #3877's Stage D ratchet:
+  // The two assertions above are 3/3 green for this family. These two facts
+  // were real inconsistencies that BOTH assertions are structurally blind to,
+  // and that is the point worth writing down for #3877's Stage D ratchet:
   //
   //   * `unreadCount` is a `number` whether it counts the total or the window,
   //     so a VALUE assertion cannot see a wrong semantic;
   //   * `cursor` is `optional`, so "no producer ever emits it" is a legal
   //     parse and the KEY assertion (⊆, not =) cannot see it either.
   //
-  // Pinned as the measured behaviour of `origin/main`, with the issues that own
-  // the judgement call. Whichever way #6361 / #6363 are ruled, these two
-  // assertions are the ones that must flip — which is why they are here rather
-  // than left for the next reader to rediscover.
+  // Both were pinned here as the measured behaviour of `origin/main`, on the
+  // note that whichever way #6361 / #6363 were ruled, these assertions are the
+  // ones that must flip. #6363 has been ruled (2026-08-07, Option A: make the
+  // declaration true) and its assertion has flipped — it now pins the fix, over
+  // the wire, which is the only place the whole stack is in play. The `cursor`
+  // half is unchanged: it is one capability's two halves and is being retired
+  // with #6361, so it stays pinned as measured until that lands.
+  //
+  // The Stage D input stands either way, and is if anything sharper now: the
+  // ratchet still cannot see EITHER fact. Both had to be written by hand, and
+  // the fix below would have been just as invisible to it as the defect was.
   describe('[#6361 / #6363] the gaps the double assertion cannot see', () => {
-    it('[#6363] `unreadCount` counts the RETURNED WINDOW, not the total the schema describes', async () => {
+    it('[#6363] `unreadCount` is the TOTAL the schema describes, and survives a smaller window', async () => {
       const all = await getJson(GAP_USER, '/api/v1/notifications');
       expect(all.unreadCount, 'fixture must leave more than one unread for this to mean anything')
         .toBeGreaterThan(1);
 
       const windowed = await getJson(GAP_USER, '/api/v1/notifications?limit=1');
 
+      // The LIST is still windowed — that half never changed.
       expect(windowed.notifications).toHaveLength(1);
-      // Declared: 'Total number of unread notifications'. Delivered: the unread
-      // count within the fetched window. See #6363.
-      expect(windowed.unreadCount).toBe(1);
-      expect(windowed.unreadCount).not.toBe(all.unreadCount);
-      // …and it still parses, which is exactly the blind spot.
+      // The BADGE is not: declared 'Total number of unread notifications', and
+      // now delivered as one. Before #6363 this read `1` — the window's size,
+      // which is what a user with more unread than the page size was told
+      // forever. The parse was green either way; only this assertion can tell.
+      expect(windowed.unreadCount).toBe(all.unreadCount);
       expect(ListNotificationsResponseSchema.safeParse(windowed).success).toBe(true);
     });
 

--- a/packages/services/service-messaging/src/messaging-service.test.ts
+++ b/packages/services/service-messaging/src/messaging-service.test.ts
@@ -592,3 +592,204 @@ describe('MessagingService — inbox read API (ADR-0030)', () => {
         expect(await svc.listInbox('')).toEqual({ notifications: [], unreadCount: 0 });
     });
 });
+
+/**
+ * `n` inbox rows for one user, oldest first. `created_at` carries a padded
+ * millisecond index so the fake engine's lexicographic `desc` sort is the real
+ * newest-first order for any `n` — the window tests below all depend on
+ * knowing exactly WHICH rows a truncated window holds.
+ */
+function seedInbox(
+    userId: string,
+    n: number,
+    topicAt: (i: number) => string = () => 'task.assigned',
+): Array<Record<string, unknown>> {
+    return Array.from({ length: n }, (_, i) => ({
+        id: `m${i + 1}`,
+        user_id: userId,
+        notification_id: `n${i + 1}`,
+        topic: topicAt(i),
+        title: `Notification ${i + 1}`,
+        body_md: 'body',
+        created_at: `2026-01-01T00:00:00.${String(i).padStart(3, '0')}Z`,
+    }));
+}
+
+/** An inbox receipt in a read state, for the message `seedInbox` numbered `i`. */
+function readReceipt(userId: string, i: number): Record<string, unknown> {
+    return { id: `r${i}`, notification_id: `n${i}`, user_id: userId, channel: 'inbox', state: 'read' };
+}
+
+/**
+ * Record every `find` an existing engine is asked to run, in order. Wraps the
+ * double rather than declaring another one: the cost claims below are about how
+ * many reads `listInbox` issues, which is only observable at the call site.
+ */
+function recordFinds(engine: any): Array<{ object: string; query: any }> {
+    const calls: Array<{ object: string; query: any }> = [];
+    const real = engine.find.bind(engine);
+    engine.find = async (object: string, query: any = {}) => {
+        calls.push({ object, query });
+        return real(object, query);
+    };
+    return calls;
+}
+
+/**
+ * [#6363] `ListNotificationsResponseSchema.unreadCount` is published into the
+ * API reference as "Total number of unread notifications". It was counted
+ * inside `rows.map(...)`, i.e. over the `limit`-truncated window, so the badge
+ * saturated at the window size forever: measured on a real stack with 60
+ * unread, the route answered `unreadCount: 50` unfiltered and `10` at
+ * `?limit=10`. Maintainer ruling (2026-08-07, Option A): make the declaration
+ * true — count the total — and leave the list itself windowed.
+ *
+ * The fixtures below are the issue's measured shape (60 unread, `limit=10`).
+ */
+describe('[#6363] listInbox — unreadCount is the TOTAL unread, not the fetched window', () => {
+    const logger = silentLogger();
+
+    it('counts every unread message when the window truncates the inbox', async () => {
+        const engine = inboxEngine({ inbox: seedInbox('u1', 60) });
+        const svc = new MessagingService({ logger, getData: () => engine });
+
+        // No `limit`: the default clamp windows the LIST at 50 — unchanged.
+        const unfiltered = await svc.listInbox('u1');
+        expect(unfiltered.notifications).toHaveLength(50);
+        expect(unfiltered.unreadCount).toBe(60); // was 50 — the window's size
+
+        // `?limit=10`: the list shrinks with the window, the badge does not.
+        const windowed = await svc.listInbox('u1', { limit: 10 });
+        expect(windowed.notifications).toHaveLength(10);
+        expect(windowed.unreadCount).toBe(60); // was 10 — the window's size
+    });
+
+    it('subtracts read-state across the whole inbox, not just inside the window', async () => {
+        // The 20 read messages are the OLDEST, so none of them is inside a
+        // newest-first `limit=10` window: a window-scoped count cannot see
+        // them, and a total that ignored receipts would answer 60.
+        const engine = inboxEngine({
+            inbox: seedInbox('u1', 60),
+            receipts: Array.from({ length: 20 }, (_, i) => readReceipt('u1', i + 1)),
+        });
+        const svc = new MessagingService({ logger, getData: () => engine });
+
+        const res = await svc.listInbox('u1', { limit: 10 });
+        expect(res.notifications).toHaveLength(10);
+        expect(res.notifications.every((n) => n.read === false)).toBe(true); // window is all-unread
+        expect(res.unreadCount).toBe(40);
+    });
+
+    it('counts rows carrying no notification_id — never receipted, so never read', async () => {
+        const inbox = seedInbox('u1', 60);
+        // A synthetic/legacy row with no event id keys no receipt at all.
+        for (const row of inbox.slice(0, 5)) row.notification_id = null;
+        const engine = inboxEngine({ inbox });
+        const svc = new MessagingService({ logger, getData: () => engine });
+
+        expect((await svc.listInbox('u1', { limit: 10 })).unreadCount).toBe(60);
+    });
+
+    it('answers the `type` filter it was asked, over the whole inbox', async () => {
+        // 60 messages alternating between two topics ⇒ 30 of each.
+        const engine = inboxEngine({
+            inbox: seedInbox('u1', 60, (i) => (i % 2 === 0 ? 'deal.won' : 'task.assigned')),
+        });
+        const svc = new MessagingService({ logger, getData: () => engine });
+
+        const res = await svc.listInbox('u1', { type: 'deal.won', limit: 10 });
+        expect(res.notifications).toHaveLength(10);
+        expect(res.notifications.every((n) => n.type === 'deal.won')).toBe(true);
+        expect(res.unreadCount).toBe(30);
+    });
+
+    it('counts only the addressed user, at any window size', async () => {
+        const engine = inboxEngine({ inbox: [...seedInbox('u1', 60), ...seedInbox('u2', 7)] });
+        const svc = new MessagingService({ logger, getData: () => engine });
+
+        expect((await svc.listInbox('u1', { limit: 10 })).unreadCount).toBe(60);
+        expect((await svc.listInbox('u2', { limit: 10 })).unreadCount).toBe(7);
+    });
+
+    it('the `read` filter narrows the list and never the badge', async () => {
+        const engine = inboxEngine({
+            inbox: seedInbox('u1', 60),
+            receipts: Array.from({ length: 20 }, (_, i) => readReceipt('u1', i + 1)),
+        });
+        const svc = new MessagingService({ logger, getData: () => engine });
+
+        // Asking for the READ half does not mean the unread badge is zero.
+        const readOnly = await svc.listInbox('u1', { read: true, limit: 10 });
+        expect(readOnly.notifications).toEqual([]); // the newest 10 are all unread
+        expect(readOnly.unreadCount).toBe(40);
+
+        const unreadOnly = await svc.listInbox('u1', { read: false, limit: 10 });
+        expect(unreadOnly.notifications).toHaveLength(10);
+        expect(unreadOnly.unreadCount).toBe(40);
+    });
+
+    it('a window that came back SHORT costs no second read', async () => {
+        // Nothing was truncated, so the window count already IS the total and
+        // the reverse join would re-read what the first `find` returned.
+        const engine = inboxEngine({ inbox: seedInbox('u1', 3) });
+        const calls = recordFinds(engine);
+        const svc = new MessagingService({ logger, getData: () => engine });
+
+        const res = await svc.listInbox('u1');
+        expect(res.unreadCount).toBe(3);
+        expect(calls.filter((c) => c.object === 'sys_inbox_message')).toHaveLength(1);
+    });
+
+    it('the total read is one narrow projection, unwindowed, over the same predicate', async () => {
+        const engine = inboxEngine({ inbox: seedInbox('u1', 60) });
+        const calls = recordFinds(engine);
+        const svc = new MessagingService({ logger, getData: () => engine });
+
+        await svc.listInbox('u1', { type: 'task.assigned', limit: 10 });
+
+        const inboxReads = calls.filter((c) => c.object === 'sys_inbox_message');
+        expect(inboxReads).toHaveLength(2);
+        const [windowRead, totalRead] = inboxReads;
+        expect(windowRead.query.limit).toBe(10);
+        // Same predicate as the windowed read — the count answers the same
+        // question, minus the window — and one column, so the extra work stays
+        // the same order as the receipt scan `listInbox` already performs.
+        expect(totalRead.query.where).toEqual(windowRead.query.where);
+        expect(totalRead.query.limit).toBeUndefined();
+        expect(totalRead.query.fields).toEqual(['notification_id']);
+    });
+
+    it('a failing total read is NOT swallowed into a window-sized answer', async () => {
+        // The receipt read degrades (different object, may be absent from a
+        // minimal stack); this one re-reads the object whose `find` just
+        // succeeded, so a failure is a data-layer outage — not a licence to
+        // quietly re-tell the window-sized lie.
+        const engine = inboxEngine({ inbox: seedInbox('u1', 60) });
+        const real = engine.find.bind(engine);
+        engine.find = async (object: string, query: any = {}) => {
+            if (object === 'sys_inbox_message' && query.fields) throw new Error('connection lost');
+            return real(object, query);
+        };
+        const svc = new MessagingService({ logger, getData: () => engine });
+
+        await expect(svc.listInbox('u1', { limit: 10 })).rejects.toThrow('connection lost');
+    });
+
+    /* ------------------------------------------------------------------ */
+    /*  The other half of the ruling: the LIST window is unchanged.        */
+    /* ------------------------------------------------------------------ */
+
+    it('the list keeps its window: default 50, hard cap 200, floor 1, newest first', async () => {
+        const engine = inboxEngine({ inbox: seedInbox('u1', 250) });
+        const svc = new MessagingService({ logger, getData: () => engine });
+
+        const dflt = await svc.listInbox('u1');
+        expect(dflt.notifications).toHaveLength(50);
+        expect(dflt.notifications[0].id).toBe('n250'); // newest first, still
+        expect(dflt.unreadCount).toBe(250);
+
+        expect((await svc.listInbox('u1', { limit: 500 })).notifications).toHaveLength(200);
+        expect((await svc.listInbox('u1', { limit: 0 })).notifications).toHaveLength(1);
+        expect((await svc.listInbox('u1', { limit: 120 })).notifications).toHaveLength(120);
+    });
+});

--- a/packages/services/service-messaging/src/messaging-service.ts
+++ b/packages/services/service-messaging/src/messaging-service.ts
@@ -277,9 +277,26 @@ export class MessagingService {
      *
      * A message is unread until its event has a `read`/`clicked`/`dismissed`
      * receipt; the `read` filter (when given) is applied in-memory after the
-     * join. `unreadCount` is computed over the fetched window (bounded by
-     * `limit`, like the Console bell's poll). Returns the REST contract shape
-     * (`ListNotificationsResponseSchema`): `{ notifications, unreadCount }`.
+     * join.
+     *
+     * Two different bounds, deliberately (#6363):
+     *
+     *   * `notifications[]` is the fetched WINDOW — `limit` rows, defaulting to
+     *     50 and hard-capped at 200, newest first. Unchanged: the Console
+     *     bell's poll and every other caller page through this list.
+     *   * `unreadCount` is the **total** unread across the user's whole
+     *     matching inbox, which is what `ListNotificationsResponseSchema`
+     *     publishes into the API reference ("Total number of unread
+     *     notifications"). Counting it over `rows` — the window — made the
+     *     badge saturate at the window size forever: a user with 60 unread was
+     *     told 50, and `?limit=10` told them 10. The declaration was right and
+     *     the implementation was wrong (maintainer ruling, #6363 Option A).
+     *
+     * The `read` filter never moves `unreadCount`: asking for the read half of
+     * the inbox does not mean the badge is zero. A `type` filter does — the
+     * count answers the query that was asked, as it always has.
+     *
+     * Returns the REST contract shape: `{ notifications, unreadCount }`.
      */
     async listInbox(
         userId: string,
@@ -313,12 +330,12 @@ export class MessagingService {
             }
         }
 
-        let unreadCount = 0;
+        let windowUnread = 0;
         const all: InboxNotificationView[] = rows.map((m) => {
             const nid = m?.notification_id != null ? String(m.notification_id) : null;
             const state = nid ? stateByNotif.get(nid) : undefined;
             const read = state ? READ_RECEIPT_STATES.has(state) : false;
-            if (!read) unreadCount += 1;
+            if (!read) windowUnread += 1;
             return {
                 id: nid ?? String(m.id),
                 type: (m.topic as string) ?? 'notification',
@@ -330,8 +347,60 @@ export class MessagingService {
             };
         });
 
+        // A window that came back SHORT is the whole matching set — nothing was
+        // truncated, so the window count already IS the total and the second
+        // read would be a duplicate of the first. Only a saturated window
+        // (`rows.length === limit`) can be hiding rows, and that is exactly the
+        // case #6363 is about. So the common inbox — fewer messages than the
+        // page size — costs precisely what it cost before this change.
+        const unreadCount = rows.length < limit
+            ? windowUnread
+            : await this.countUnreadTotal(data, where, stateByNotif);
+
         const notifications = opts.read === undefined ? all : all.filter((n) => n.read === opts.read);
         return { notifications, unreadCount };
+    }
+
+    /**
+     * Total unread across the user's whole matching inbox — the reverse join
+     * `unreadCount` is declared to answer (#6363).
+     *
+     * Read-state lives on `sys_notification_receipt`, not on the inbox row
+     * (ADR-0030), so no single `count()` answers this: the predicate spans two
+     * objects. The receipt side is already fully in memory — `listInbox` reads
+     * every one of the user's inbox receipts, unbounded, to build the join —
+     * so all that is missing is the message side, and it is read as a
+     * PROJECTION of one column with no `orderBy` and no `limit`. That keeps
+     * this the same order of work as the receipt scan the method already
+     * performs unconditionally, one column wide, and it stays exact under a
+     * `type` filter and for rows carrying no `notification_id` (never
+     * receipted, therefore always unread) — neither of which a
+     * `count(messages) - count(read receipts)` subtraction survives.
+     *
+     * NOT best-effort, unlike the receipt read above. That one degrades because
+     * receipts are a DIFFERENT object which a minimal stack may not have
+     * registered at all; this one re-reads the very object whose `find` just
+     * succeeded with the very same `where`. There is no state in which it fails
+     * and the caller still holds a trustworthy list — and swallowing it would
+     * silently restore the window-sized lie this method exists to stop telling.
+     */
+    private async countUnreadTotal(
+        data: IDataEngine,
+        where: Record<string, unknown>,
+        stateByNotif: ReadonlyMap<string, string>,
+    ): Promise<number> {
+        const ids = (await data.find(INBOX_OBJECT, {
+            where,
+            fields: ['notification_id'],
+        })) as Array<Record<string, unknown>>;
+
+        let unread = 0;
+        for (const row of ids) {
+            const nid = row?.notification_id != null ? String(row.notification_id) : null;
+            const state = nid ? stateByNotif.get(nid) : undefined;
+            if (!state || !READ_RECEIPT_STATES.has(state)) unread += 1;
+        }
+        return unread;
     }
 
     /**


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6363

按维护者 2026-08-07 17:00Z 的裁决实施 **Option A**：让声明成真 —— `unreadCount` 数**总**未读，而不是取回窗口内的；列表本身保持既有窗口行为。

## 前提复核（先证伪，再动手）

三条都对着 `origin/main` 复核过，全部成立：

| issue 的断言 | 复核结果 |
|:---|:---|
| `protocol.zod.ts:924` 声明 `'Total number of unread notifications'` | ✅ 在 |
| 计数发生在 `messaging-service.ts` 的 `rows.map(...)` 里，而 `rows` 已被 `limit` 截断（clamp `[1,200]`，默认 50） | ✅ 在（`:316-331`；行号因本 PR 前的上游改动略有平移，位置与形状一致） |
| 实测 60 条未读 → 无 limit 得 50、`?limit=10` 得 10 | ✅ 可复现（见下方「反向验证」的真实输出） |

另有一条不在 issue 正文里、但影响设计的复核：`find` 无 `limit` 时**不会**被隐式截断（`driver-sql/src/sql-driver.ts:2743` 是 `if (query.limit !== undefined)`），所以既有的收据全量读是真·无界，本 PR 的反连接读同理。

## 改了什么

`MessagingService.listInbox` 里两个界**故意分开**：

- `notifications[]` —— 仍是取回窗口：`limit` 行，默认 50，硬上限 200，最新在前。**一行没动**。
- `unreadCount` —— 整个匹配信箱的总未读，即 `ListNotificationsResponseSchema` 发布到 API 参考里的那句话。

## 取舍与成本（裁决点名的「真实设计工作」）

读态在 `sys_notification_receipt`、不在收件箱行上（ADR-0030），所以总未读的谓词**跨两个对象**，没有任何单条 `count()` 能回答。三条候选：

| 方案 | 判定 |
|:---|:---|
| **维护计数列** | 快，但要处理并发写与历史回填，且给一个每次读都能精确算出的量引入一份可漂移的副本。本单范围内不值。 |
| **`count(消息) - count(已读收据)` 相减** | 一次查询最省，但**不正确**：收据不带 `topic`，所以 `type` 过滤下直接错；`notification_id` 为空的行（从未被收据键住 ⇒ 恒未读）也算不进去；收据与消息若 TTL 不同步还会长期漂移。 |
| **反连接（本 PR 采用）** | 精确，且在 `type` 过滤与空 `notification_id` 两种情况下都对。 |

反连接的代价是被**刻意夹住**的：

1. **只在窗口被打满时才发生。** `rows.length < limit` 说明这一页就是全集，窗口计数**已经**是总数，第二次读只会把第一次读的东西再读一遍。所以常见信箱（消息数少于页大小）的读路径开销**与本 PR 之前逐字节相同** —— 有一条钉子专门量这件事（`a window that came back SHORT costs no second read`，断言 `sys_inbox_message` 上恰好 1 次 `find`）。
2. **打满时，多的那次读是一列投影**：同一个 `where`，`fields: ['notification_id']`，无 `orderBy`、无 `limit`。收据那半本来就已经全量在内存里（`listInbox` 一直无界地读用户的全部收件箱收据来做 join），所以补上的是消息那半 —— **与该方法本来就无条件付出的收据扫描同一量级**，宽度一列。同样有钉子把这个查询形状钉死。

**没有做成 best-effort，这是刻意的。** 收据那次读之所以 `catch` 后降级，是因为收据是**另一个对象**、极简栈里可能压根没注册；而这次读重读的是刚刚 `find` 成功的**同一个对象、同一个 `where`**。它失败的世界里调用方手上那份列表也不可信 —— 而吞掉异常等于把这个方法刚刚不再讲的那个「窗口大小的谎」悄悄讲回去。有一条钉子断言异常向上抛。

## 反向验证（方向是**事先**定的：红）

把 `unreadCount` 改回 `windowUnread` 单行还原，预测新钉子里 **9 条转红、1 条保持绿**（`a window that came back SHORT costs no second read` 钉的是「没有回归」而不是「修好了」，旧实现同样只发 1 次读，本就该绿）。实测与预测逐条一致：

```
× counts every unread message when the window truncates the inbox
× subtracts read-state across the whole inbox, not just inside the window
× counts rows carrying no notification_id — never receipted, so never read
× answers the `type` filter it was asked, over the whole inbox
× counts only the addressed user, at any window size
× the `read` filter narrows the list and never the badge
✓ a window that came back SHORT costs no second read      ← 预测即为绿
× the total read is one narrow projection, unwindowed, over the same predicate
× a failing total read is NOT swallowed into a window-sized answer
× the list keeps its window: default 50, hard cap 200, floor 1, newest first

AssertionError: expected 50 to be 60 // Object.is equality
```

`expected 50 to be 60` 就是 issue 实测那一行：60 条未读、无 limit，旧实现答 50。

## 测试

新增 10 条钉子（`messaging-service.test.ts`），fixture 照 issue 实测形状造（60 条未读 / `limit=10`）：

- **核心**：60 条未读时，无 limit → 列表 50 条、`unreadCount` **60**；`?limit=10` → 列表 10 条、`unreadCount` **60**。
- 已读态在**整个信箱**上相减（20 条最旧的已读落在 `limit=10` 的窗口之外 —— 窗口计数看不见它们）⇒ 40。
- `notification_id` 为空的行恒未读；只数被寻址的那个用户；`type` 过滤两边都收窄；`read` 过滤只收窄列表、**从不**动角标。
- 成本与查询形状各一条（见上）。
- **窗口行为不变的回归钉**：默认 50 / 上限 200 / 下限 1 / 最新在前。

翻转了 #5792 在真栈上留下的那条测量钉（`packages/runtime/src/notification-schema-conformance.integration.test.ts`）—— 它当初就写明「无论 #6361 / #6363 怎么裁，这两条断言都是必须翻的那两条」。现在它在真 socket + 真 SQL driver 上钉的是修好后的行为：窗口变小，角标不变。

```
pnpm --filter @objectstack/service-messaging test        →  Test Files 16 passed (16) / Tests 185 passed (185)
pnpm --filter @objectstack/service-messaging typecheck   →  clean
pnpm --filter @objectstack/runtime typecheck             →  clean
runtime 通知三件套(含真栈 integration)                    →  Test Files 3 passed (3) / Tests 28 passed (28)
runtime http-dispatcher + domain-handler-registry         →  Test Files 2 passed (2) / Tests 285 passed (285)
消费半径 SDK: pnpm --filter @objectstack/client test      →  Test Files 20 passed (20) / Tests 244 passed (244)
根门: check:nul-bytes / check:engine-double-contract / check:empty-changeset /
      check:query-options-erasure / check:route-envelope / check:service-providers /
      check:doc-authoring                                 →  全绿
eslint(三个改动文件)                                      →  clean
```

`check:engine-double-contract` 特别说明：没有新增 engine double —— 测试里的 `recordFinds` 是**包住**既有 `inboxEngine` 记录调用，不是另起一个替身，门保持 `80 pinned / 133 DEBT / 4 exempt` 不变。

## 范围（红线）

- ⛔ **`cursor` 半边不在本 PR**。裁决明确「分页能力不半删」，响应侧 `cursor` 随 **#6361** 同向处理，其移除落 `packages/spec`，归 spec 座位。上面那条 integration 里的 `cursor` 钉子**原样保留**为已测量事实。
- ⛔ 没有改 `.describe()`（Option A 是让声明成真），也没有改 `packages/spec` 的任何一行。

## 顺带发现（已另立单，未在本 PR 修）

- **#6436** —— `markAllRead` 只清窗口内的 200 条。这不是本 PR 引入的，但本 PR 把掩盖它的布揭掉了：以前清完 200 条后窗口内确实空了、角标显示 0；现在同一条路径会自己暴露 `readCount: 200` 而 `unreadCount: 150`。
- **#6438** —— `packages/spec/src/contracts/notification-service.ts` 里 `InboxListResult.unreadCount` 的 JSDoc 仍写着 `Unread count over the returned window`，与本 PR 落地后的实现、以及同包 `protocol.zod.ts:924` 的 `.describe()` 都相反。按本单红线（不改 `packages/spec`）留给 spec 座位，与 #6361 一并处理。


---
_Generated by [Claude Code](https://claude.ai/code/session_015a5qkLzpGXhLL2F5gvJ7dD)_