### PR TITLE
fix(spec): put the fix before the explanation in the three hand-written unrecognized_keys error maps (#6416)

### DIFF
--- a/.changeset/handwritten-errmap-fix-before-history.md
+++ b/.changeset/handwritten-errmap-fix-before-history.md
@@ -1,0 +1,9 @@
+---
+'@objectstack/spec': patch
+---
+
+Reorder the three hand-written `unrecognized_keys` error maps so the fix is read before the explanation (#6416, applying #5955's ruling).
+
+`strictVisibilityError` (`shared/visibility.ts`), `strictWidgetAnalyticsError` (`ui/dashboard.zod.ts`) and `strictTenancyError` (`data/object.zod.ts`) are independent `$ZodErrorMap` functions rather than `strictUnknownKeyError` call sites, so #5955's reorder of the shared template did not reach them and #5593's `strictObject` migration cannot either. Each reproduced the exact shape #5955 was filed against: a non-actionable explanatory sentence sitting between the offending key and the prescription that fixes it, which on the single-line renders several consumers use (`os validate`'s `• where: message`, CI logs, `validateFlowTriggerReadiness`) pushed the fix out of the part an author actually reads.
+
+Every message now emits front matter (which key is wrong) → every fix channel (the `visibleWhen` alias pointer; the ADR-0021 dataset / objectui-quarantine / #5022 drill branches; the per-key `tenancy` tombstone bullets) → the explanatory sentence last. Nothing is deleted and nothing becomes conditional — each sentence is still emitted verbatim, once per message, and all seven message variants are byte-identical in length and character multiset to their previous spelling. No input changes acceptance: these maps only shape the text of an already-failing parse, and the `visibility.ts` alias tables are untouched.

--- a/packages/spec/src/data/object.test.ts
+++ b/packages/spec/src/data/object.test.ts
@@ -1521,6 +1521,73 @@ describe('TenancyConfigSchema — #2763 strategy/crossTenantAccess removal', () 
   });
 });
 
+/**
+ * Message ORDER on `strictTenancyError` (#6416, applying #5955's ruling).
+ *
+ * A hand-written `$ZodErrorMap`: it never calls `strictUnknownKeyError`, so
+ * #5955's reorder of the shared template did not reach it, and it is not one of
+ * the 44 direct call sites #5593 migrates to `strictObject` either. Its
+ * explanatory sentence is the standing two-modes explainer, and its FIX channel
+ * is the per-key `  • ` bullets built just above it — the tombstone that tells
+ * an upgrading author what to write instead. Those bullets used to sit BEHIND
+ * ~160 characters of standing background, which is past the front of the
+ * single-line renders several consumers use (`os validate`'s `• where: message`,
+ * CI logs).
+ *
+ * ORDER pins, not presence checks. Every `toContain` in the block above stays
+ * green under either order — that is exactly why they cannot carry this fact.
+ */
+describe('strictTenancyError message order — bullets before the explainer (#6416)', () => {
+  const EXPLAINER =
+    'The two supported tenancy modes are: database-per-tenant = environment-level ' +
+    'deployment (no object config); row-level isolation = `tenancy.enabled` + ' +
+    '`tenancy.tenantField`.';
+
+  const messageFor = (body: Record<string, unknown>) => {
+    const res = TenancyConfigSchema.safeParse({ enabled: true, ...body });
+    expect(res.success).toBe(false);
+    const unknown = res.error!.issues.find((i) => i.code === 'unrecognized_keys');
+    expect(unknown).toBeDefined();
+    return unknown!.message;
+  };
+
+  it('names the wrong key first, then the tombstone bullet, then the explainer', () => {
+    const m = messageFor({ strategy: 'isolated' });
+    // 1. which key is wrong — and nothing before it
+    expect(m.startsWith('Unrecognized key(s) on `tenancy`: `strategy`.\n')).toBe(true);
+    // 2. the fix channel: the per-key bullet, on the line right after
+    expect(m).toContain('\n  • `tenancy.strategy` was removed from @objectstack/spec after v15.0');
+    // 3. the explainer, verbatim, last — moved, never dropped
+    expect(m.indexOf('Delete the key.')).toBeLessThan(m.indexOf(EXPLAINER));
+    expect(m.endsWith(` ${EXPLAINER}`)).toBe(true);
+  });
+
+  it('keeps EVERY per-key bullet ahead of the explainer, not just the first', () => {
+    // One issue names every offending key, so the explainer is a per-MESSAGE
+    // sentence: a reorder that put it after the first bullet would bury the rest.
+    const m = messageFor({ strategy: 'isolated', crossTenantAccess: true, tenantfield: 'org_id' });
+    for (const bullet of [
+      '`tenancy.strategy` was removed',
+      '`tenancy.crossTenantAccess` was removed',
+      '`tenantfield` is not a `tenancy` key.',
+    ]) {
+      expect(m).toContain(bullet);
+      expect(m.indexOf(bullet), bullet).toBeLessThan(m.indexOf(EXPLAINER));
+    }
+    expect(m.split(EXPLAINER)).toHaveLength(2);
+    expect(m.endsWith(` ${EXPLAINER}`)).toBe(true);
+  });
+
+  it('is a full-message pin for the plain unknown-key case', () => {
+    // Any stray separator, dropped newline or duplicated clause fails here.
+    expect(messageFor({ tenantfield: 'org_id' })).toBe(
+      'Unrecognized key(s) on `tenancy`: `tenantfield`.\n' +
+      '  • `tenantfield` is not a `tenancy` key. ' +
+      EXPLAINER,
+    );
+  });
+});
+
 describe('isTenancyDisabled — platform-global posture predicate (#3249, ADR-0066)', () => {
   it('is true only for an explicit tenancy.enabled === false', () => {
     expect(isTenancyDisabled({ name: 'sys_license', tenancy: { enabled: false } })).toBe(true);

--- a/packages/spec/src/data/object.zod.ts
+++ b/packages/spec/src/data/object.zod.ts
@@ -421,6 +421,24 @@ const TENANCY_RETIRED_KEY_GUIDANCE: Record<string, string> = {
  * `strategy`/`crossTenantAccess` or a typo — is a loud, *fixable* parse error
  * instead of a silent strip (#1535), and a retired key's error carries its
  * upgrade prescription. Every other issue code defers to zod's default.
+ *
+ * ## Message order: the fix comes before the explainer (#5955 / #6416)
+ *
+ * ```text
+ * Unrecognized key(s) on `tenancy`: `k1`.       ← which key is wrong
+ *   • {per-key tombstone / "not a `tenancy` key"} ← the fix
+ * The two supported tenancy modes are: …        ← the standing explainer
+ * ```
+ *
+ * Same emission order the shared `strictUnknownKeyError` template took in
+ * #5955 — bullets first, the surface-level sentence appended to the last one.
+ * A hand-written `$ZodErrorMap` is reachable by neither that fix nor #5593's
+ * `strictObject` migration, so #6416 applies the ruling here directly. The
+ * two-modes explainer used to sit between the key statement and the bullets,
+ * which on the single-line renders several consumers use (`os validate`'s
+ * `• where: message`, CI logs) buried each key's actual prescription behind
+ * ~160 characters of standing background. Nothing is dropped: the explainer is
+ * still emitted verbatim, just last.
  */
 const strictTenancyError: z.core.$ZodErrorMap = (issue) => {
   if (issue.code !== 'unrecognized_keys') return undefined;
@@ -429,11 +447,11 @@ const strictTenancyError: z.core.$ZodErrorMap = (issue) => {
     TENANCY_RETIRED_KEY_GUIDANCE[key] ?? `\`${key}\` is not a \`tenancy\` key.`,
   );
   return (
-    `Unrecognized key(s) on \`tenancy\`: ${keys.map((k) => `\`${k}\``).join(', ')}. ` +
-    'The two supported tenancy modes are: database-per-tenant = environment-level ' +
+    `Unrecognized key(s) on \`tenancy\`: ${keys.map((k) => `\`${k}\``).join(', ')}.\n` +
+    lines.map((l) => `  • ${l}`).join('\n') +
+    ' The two supported tenancy modes are: database-per-tenant = environment-level ' +
     'deployment (no object config); row-level isolation = `tenancy.enabled` + ' +
-    '`tenancy.tenantField`.\n' +
-    lines.map((l) => `  • ${l}`).join('\n')
+    '`tenancy.tenantField`.'
   );
 };
 

--- a/packages/spec/src/shared/visibility.ts
+++ b/packages/spec/src/shared/visibility.ts
@@ -90,22 +90,42 @@ function looksLikeVisibilityKey(key: string): boolean {
  *   .strict()
  *   .transform(normalizeVisibleWhen)
  * ```
+ *
+ * ## Message order: the fix comes before the history (#5955 / #6416)
+ *
+ * ```text
+ * Unrecognized key(s) on this view/page schema: `k1`.   ← which key is wrong
+ * [ If this is the conditional-visibility predicate … ] ← the fix
+ * Before ADR-0089 D3a these were dropped silently …     ← why it used to be silent
+ * ```
+ *
+ * This map is a hand-written `$ZodErrorMap`, so #5955's fix to the shared
+ * `strictUnknownKeyError` template could not reach it and #5593's
+ * `strictObject` migration cannot either — #6416 applies the same ruling here.
+ * The history sentence used to sit between the key statement and the alias
+ * pointer, which is the position several consumers render on ONE line
+ * (`os validate`'s `• where: message`, CI logs, and
+ * `validateFlowTriggerReadiness`, which flattens the newlines): an author —
+ * often an AI — reads the front of that line and acts on it, so the canonical
+ * key has to be there. Nothing is dropped and nothing is conditional; the
+ * sentence is still emitted verbatim, just last.
  */
 export const strictVisibilityError: z.core.$ZodErrorMap = (issue) => {
   if (issue.code !== 'unrecognized_keys') return undefined;
   const keys = (issue as { keys?: readonly string[] }).keys ?? [];
   const list = keys.map((k) => `\`${k}\``).join(', ');
-  const base =
-    `Unrecognized key(s) on this view/page schema: ${list}. ` +
+  const front = `Unrecognized key(s) on this view/page schema: ${list}.`;
+  const history =
     `Before ADR-0089 D3a these were dropped silently, shipping inert metadata; ` +
     `a mis-layered or stale key is now a loud parse error.`;
   if (keys.some(looksLikeVisibilityKey)) {
     return (
-      base +
+      front +
       ' If this is the conditional-visibility predicate, the canonical key is ' +
       '`visibleWhen` (ADR-0089) — `visibleOn` (view form) and `visibility` (page ' +
-      'component) are still accepted as deprecated aliases.'
+      'component) are still accepted as deprecated aliases. ' +
+      history
     );
   }
-  return base;
+  return `${front} ${history}`;
 };

--- a/packages/spec/src/ui/dashboard.test.ts
+++ b/packages/spec/src/ui/dashboard.test.ts
@@ -125,6 +125,91 @@ describe('DashboardWidgetSchema (dataset-bound)', () => {
   });
 });
 
+/**
+ * Message ORDER on `strictWidgetAnalyticsError` (#6416, applying #5955's ruling).
+ *
+ * This map is a hand-written `$ZodErrorMap`, so neither #5955 (which moved the
+ * history sentence to the end inside the shared `strictUnknownKeyError`) nor
+ * #5593 (which migrates the direct call sites to `strictObject`) reached it. It
+ * carried the same defect: a ~150-char history sentence sitting BETWEEN the
+ * offending key and whichever of the three prescription branches fixes it —
+ * the ADR-0021 dataset migration, the objectui `component`/`data` quarantine,
+ * and the #5022 drill near-key answer — pushing all three past the front of the
+ * single-line renders several consumers use.
+ *
+ * ORDER pins, not presence checks: the reorder deletes nothing, so every
+ * `toContain` in the block above stays green either way. An edit that folds the
+ * sentence back into the middle passes all of them and fails here.
+ */
+describe('strictWidgetAnalyticsError message order — fix before history (#6416)', () => {
+  const HISTORY =
+    'Undeclared top-level keys were dropped silently before strict validation, ' +
+    'shipping inert metadata; a stale or mis-layered key is now a loud parse error.';
+
+  const base = { id: 'w1', type: 'metric', dataset: 'sales', values: ['revenue'] };
+  const messageFor = (extra: Record<string, unknown>) => {
+    const res = DashboardWidgetSchema.safeParse({ ...base, ...extra } as any);
+    expect(res.success).toBe(false);
+    const unknown = res.error!.issues.find((i) => i.code === 'unrecognized_keys');
+    expect(unknown).toBeDefined();
+    return unknown!.message;
+  };
+
+  const orderPin = (label: string, extra: Record<string, unknown>, key: string, fix: string) => {
+    it(label, () => {
+      const m = messageFor(extra);
+      // 1. which key is wrong — and nothing before it
+      expect(m.startsWith(`Unrecognized key(s) on this dashboard widget: \`${key}\`.`)).toBe(true);
+      // 2. the fix, ahead of the history
+      expect(m).toContain(fix);
+      expect(m.indexOf(fix)).toBeLessThan(m.indexOf(HISTORY));
+      // 3. the history sentence, verbatim, last — moved, never dropped
+      expect(m.endsWith(` ${HISTORY}`)).toBe(true);
+    });
+  };
+
+  orderPin(
+    'legacy inline-analytics branch: the ADR-0021 dataset prescription comes first',
+    { categoryField: 'stage' },
+    'categoryField',
+    'The pre-ADR-0021 inline analytics shape',
+  );
+
+  orderPin(
+    'quarantine branch: the objectui-internal verdict comes first',
+    { component: {} },
+    'component',
+    '`component` and inline `data` are objectui-internal renderer capabilities',
+  );
+
+  orderPin(
+    'drill branch (#5022): the "AUTOMATIC" answer comes first',
+    { drillDown: { enabled: true } },
+    'drillDown',
+    'Drill-through on a dashboard is AUTOMATIC and not configurable per widget',
+  );
+
+  it('keeps the whole drill answer ahead of the history, not just its opening', () => {
+    // The #5022 branch is the longest of the three; its two "where the real
+    // drills live" pointers are the actionable part and must not slip behind.
+    const m = messageFor({ drillDown: { enabled: true } });
+    expect(m.indexOf('`ChartDrillDownSchema`')).toBeLessThan(m.indexOf(HISTORY));
+    expect(m.indexOf('`ReportSchema.drilldown` (ADR-0021 D2, on by default).'))
+      .toBeLessThan(m.indexOf(HISTORY));
+  });
+
+  it('is unchanged in SHAPE when no branch matches — full-message pin', () => {
+    expect(messageFor({ colourVariant: 'blue' }))
+      .toBe(`Unrecognized key(s) on this dashboard widget: \`colourVariant\`. ${HISTORY}`);
+  });
+
+  it('emits the history exactly once, whatever the key count', () => {
+    const m = messageFor({ categoryField: 'stage', alsoWrong: 1, andThis: 2 });
+    expect(m.split(HISTORY)).toHaveLength(2);
+    expect(m.endsWith(` ${HISTORY}`)).toBe(true);
+  });
+});
+
 describe('DashboardSchema', () => {
   it('parses a dataset-bound dashboard', () => {
     const d = DashboardSchema.parse({

--- a/packages/spec/src/ui/dashboard.zod.ts
+++ b/packages/spec/src/ui/dashboard.zod.ts
@@ -141,29 +141,48 @@ const QUARANTINED_WIDGET_KEYS = new Set(['component', 'data']);
  * objectui-internal prop it points the author at the ADR-0021 dataset shape
  * (and `options` for renderer-specific extras). Mirrors `strictVisibilityError`
  * (ADR-0089 D3a); every other issue code defers to zod's default.
+ *
+ * ## Message order: the fix comes before the history (#5955 / #6416)
+ *
+ * ```text
+ * Unrecognized key(s) on this dashboard widget: `k1`.   ← which key is wrong
+ * [ one of the three prescription branches ]            ← the fix
+ * Undeclared top-level keys were dropped silently …     ← why it used to be silent
+ * ```
+ *
+ * Hand-written `$ZodErrorMap`s were out of reach of both #5955 (which moved the
+ * sentence inside the shared `strictUnknownKeyError`) and #5593 (which migrates
+ * the direct call sites to `strictObject`); #6416 applies the same ruling here.
+ * The history sentence used to sit between the key statement and the branch that
+ * fixes it, pushing every prescription — the ADR-0021 dataset migration, the
+ * objectui quarantine, the #5022 drill answer — past character ~220 of a message
+ * several consumers render on ONE line. Nothing is dropped or made conditional:
+ * the sentence is still emitted verbatim, just last.
  */
 const strictWidgetAnalyticsError: z.core.$ZodErrorMap = (issue) => {
   if (issue.code !== 'unrecognized_keys') return undefined;
   const keys = (issue as { keys?: readonly string[] }).keys ?? [];
   const list = keys.map((k) => `\`${k}\``).join(', ');
-  const base =
-    `Unrecognized key(s) on this dashboard widget: ${list}. ` +
+  const front = `Unrecognized key(s) on this dashboard widget: ${list}.`;
+  const history =
     `Undeclared top-level keys were dropped silently before strict validation, ` +
     `shipping inert metadata; a stale or mis-layered key is now a loud parse error.`;
   if (keys.some((k) => LEGACY_WIDGET_ANALYTICS_KEYS.has(k))) {
     return (
-      base +
+      front +
       ' The pre-ADR-0021 inline analytics shape (`object` + `categoryField` + ' +
       '`valueField` + `aggregate`, pivot `rowField`/`columnField`) was removed — ' +
       'bind a `dataset` and select `dimensions` + `values` by name. Renderer-only ' +
-      'settings belong under `options`.'
+      'settings belong under `options`. ' +
+      history
     );
   }
   if (keys.some((k) => QUARANTINED_WIDGET_KEYS.has(k))) {
     return (
-      base +
+      front +
       ' `component` and inline `data` are objectui-internal renderer capabilities, ' +
-      'not part of the author-facing dashboard spec (framework#3251).'
+      'not part of the author-facing dashboard spec (framework#3251). ' +
+      history
     );
   }
   // #5022 — the drill near-key, in all three spellings an author reaches for.
@@ -175,7 +194,7 @@ const strictWidgetAnalyticsError: z.core.$ZodErrorMap = (issue) => {
   // between two real keys on two other surfaces.
   if (keys.some((k) => k === 'drillDown' || k === 'drilldown' || k === 'drill')) {
     return (
-      base +
+      front +
       ' Drill-through on a dashboard is AUTOMATIC and not configurable per widget: ' +
       'a dataset-bound widget derives the drill target and filter from the dataset row ' +
       'that was clicked, and a `table`/`pivot` widget is the one to reach for when you ' +
@@ -183,10 +202,11 @@ const strictWidgetAnalyticsError: z.core.$ZodErrorMap = (issue) => {
       'The two configurable drills live elsewhere and neither is a widget key: ' +
       '`drillDown` (camelCase, a config object) is the react-tier `<ObjectChart drillDown={…}>` ' +
       'prop — `ChartDrillDownSchema`; `drilldown` (all lowercase, a boolean) is ' +
-      '`ReportSchema.drilldown` (ADR-0021 D2, on by default).'
+      '`ReportSchema.drilldown` (ADR-0021 D2, on by default). ' +
+      history
     );
   }
-  return base;
+  return `${front} ${history}`;
 };
 
 /**

--- a/packages/spec/src/ui/view.test.ts
+++ b/packages/spec/src/ui/view.test.ts
@@ -2954,6 +2954,76 @@ describe('ADR-0089 D3a — strict view form schemas (loud mis-layered keys)', ()
 });
 
 /**
+ * Message ORDER on `strictVisibilityError` (#6416, applying #5955's ruling).
+ *
+ * The map in `shared/visibility.ts` is a hand-written `$ZodErrorMap`: it never
+ * calls `strictUnknownKeyError`, so #5955's reorder of the shared template did
+ * not reach it, and it is not one of the 44 direct call sites #5593 migrates to
+ * `strictObject` either. It had the same defect the ruling was filed against —
+ * a ~120-char history sentence sitting BETWEEN the offending key and the
+ * canonical-key pointer that fixes it, which is past the front of the single-
+ * line renders several consumers use (`os validate`'s `• where: message`, CI
+ * logs, and `validateFlowTriggerReadiness`, which flattens the newlines).
+ *
+ * These are ORDER pins, not presence checks. The reorder deletes nothing, so
+ * every existing `toContain` in the block above stays green either way; a
+ * future edit that folds the sentence back into the middle passes all of them
+ * and fails here.
+ */
+describe('strictVisibilityError message order — fix before history (#6416)', () => {
+  const HISTORY =
+    'Before ADR-0089 D3a these were dropped silently, shipping inert metadata; ' +
+    'a mis-layered or stale key is now a loud parse error.';
+  const PRESCRIPTION = 'the canonical key is `visibleWhen` (ADR-0089)';
+
+  const messageFor = (body: Record<string, unknown>) => {
+    const res = FormFieldSchema.safeParse({ field: 'state', ...body });
+    expect(res.success).toBe(false);
+    const unknown = res.error!.issues.find((i) => i.code === 'unrecognized_keys');
+    expect(unknown).toBeDefined();
+    return unknown!.message;
+  };
+
+  it('names the wrong key first, then the alias pointer, then the history', () => {
+    const m = messageFor({ visibleWhenn: 'record.a == 1' });
+    // 1. which key is wrong — and nothing before it
+    expect(m.startsWith('Unrecognized key(s) on this view/page schema: `visibleWhenn`.')).toBe(true);
+    // 2. the fix, immediately after it — this is the whole point of the reorder
+    expect(m).toContain('`visibleWhenn`. If this is the conditional-visibility predicate');
+    // 3. the history sentence, verbatim, last — moved, never dropped
+    expect(m).toContain(PRESCRIPTION);
+    expect(m.indexOf(PRESCRIPTION)).toBeLessThan(m.indexOf(HISTORY));
+    expect(m.endsWith(` ${HISTORY}`)).toBe(true);
+  });
+
+  it('still emits the whole alias table after the reorder — nothing was trimmed', () => {
+    // The prescription names all three spellings; a reorder that quietly lost
+    // one of them would still satisfy the order assertions above.
+    const m = messageFor({ visibleWhenn: 'record.a == 1' });
+    expect(m).toContain('`visibleOn` (view form)');
+    expect(m).toContain('`visibility` (page component) are still accepted as deprecated aliases.');
+  });
+
+  it('is unchanged in SHAPE when there is no visibility hint to offer', () => {
+    // No prescription branch — the sentence follows the key statement directly,
+    // exactly as it always did. Full-message pin, so a stray separator or a
+    // duplicated clause fails here.
+    const res = FormSectionSchema.safeParse({ label: 'S', fields: [], bogusKey: true });
+    expect(res.success).toBe(false);
+    const m = res.error!.issues.find((i) => i.code === 'unrecognized_keys')!.message;
+    expect(m).toBe(`Unrecognized key(s) on this view/page schema: \`bogusKey\`. ${HISTORY}`);
+  });
+
+  it('emits the history exactly once, whatever the key count', () => {
+    // One `unrecognized_keys` issue names every offending key, so "last" is a
+    // well-defined position: the sentence is appended to that one message once.
+    const m = messageFor({ visibleWhenn: 'record.a == 1', alsoWrong: 2, andThis: 3 });
+    expect(m.split(HISTORY)).toHaveLength(2);
+    expect(m.endsWith(` ${HISTORY}`)).toBe(true);
+  });
+});
+
+/**
  * ObjectUI Studio derives the View inspector's authoring JSONSchema from
  * ViewSchema via `z.toJSONSchema` (objectui#2561). FormFieldSchema is a
  * self-recursive `.strict().transform(…)` pipe reached through


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6416

Direction 1 only, per the 2026-08-07T17:54Z triage ruling: three in-place reorders applying the shape PR #6375 landed for the shared template to the three sites that ruling's scope missed. Direction 2 (folding them into `guidance` with a set-keyed form) is **not** touched — it stays a separate card. The two clean sibling maps named in the issue (`ai/tool.zod.ts` `strictToolError`, `object.zod.ts` `strictCapabilitiesError`) are untouched.

## Premise re-anchored on fresh `origin/main`

Read at `9bc846bff` (the issue's anchors were read at `bbd2d8d3d`, before #6279 / #6423 / #6364 landed). All three hand-written maps are still present and still carry the mid-message sentence; the premise holds in full.

| site | symbol | anchor at `bbd2d8d3d` | anchor at `9bc846bff` |
|:--|:--|:--|:--|
| `packages/spec/src/shared/visibility.ts` | `strictVisibilityError` | 94-112 | 94-111 (unchanged text) |
| `packages/spec/src/ui/dashboard.zod.ts` | `strictWidgetAnalyticsError` | 145-190 | 145-190 (unchanged text) |
| `packages/spec/src/data/object.zod.ts` | `strictTenancyError` | 428-438 | 425-438 (unchanged text; #6423 edited a different stanza) |

## What changed

Every message now emits **front matter → every fix channel → the explanatory sentence last**, matching `strictUnknownKeyError`'s emission order exactly:

- **`strictVisibilityError`** — the `visibleWhen` alias pointer moves ahead of the "Before ADR-0089 D3a these were dropped silently…" sentence.
- **`strictWidgetAnalyticsError`** — all three prescription branches (the ADR-0021 dataset migration, the objectui `component`/`data` quarantine, the #5022 drill near-key answer) move ahead of the "Undeclared top-level keys were dropped silently…" sentence.
- **`strictTenancyError`** — the per-key `  • ` tombstone bullets move ahead of the two-modes explainer, which is now appended to the last bullet with a single space. This is byte-for-byte the shape `strictUnknownKeyError` uses for `history` after its own bullets.

Nothing is deleted and nothing becomes conditional. The acceptance surface does not move: these are `$ZodErrorMap`s shaping the text of an already-failing parse, and `visibility.ts`'s alias tables are untouched.

### Byte parity: measured, not asserted

The ruling asked for ideally byte-identical lengths. All **seven** message variants are identical in both length and character multiset — a pure permutation, no joiner space gained or lost anywhere:

```
OK   visibility  alias branch:     old=386 new=386 delta=0 multiset-identical=true
OK   visibility  no-fix branch:    old=189 new=189 delta=0 multiset-identical=true
OK   dashboard   legacy branch:    old=467 new=467 delta=0 multiset-identical=true
OK   dashboard   quarantine branch:old=353 new=353 delta=0 multiset-identical=true
OK   dashboard   drill branch:     old=817 new=817 delta=0 multiset-identical=true
OK   dashboard   no-fix branch:    old=215 new=215 delta=0 multiset-identical=true
OK   tenancy     multi-key:        old=648 new=648 delta=0 multiset-identical=true
```

## Pins

13 new order pins, placed next to each surface's existing test conventions:

- `packages/spec/src/ui/view.test.ts` — next to `ADR-0089 D3a — strict view form schemas`, exercised through the real `FormFieldSchema` / `FormSectionSchema` doors.
- `packages/spec/src/ui/dashboard.test.ts` — after `DashboardWidgetSchema (dataset-bound)`, one order pin per prescription branch.
- `packages/spec/src/data/object.test.ts` — after `TenancyConfigSchema — #2763 strategy/crossTenantAccess removal`.

Each asserts all three facts the ruling names: front matter first (`startsWith`), every fix channel strictly before the explanatory sentence (`indexOf < indexOf`), and the sentence still present verbatim at the end (`endsWith`), plus an "emitted exactly once whatever the key count" pin and a full-message `toBe` for the branch with no fix to offer.

## Reverse verification

**Direction predicted before running: red** — restoring the old concatenation must fail exactly the new order pins, while every pre-existing assertion on these three surfaces stays green, because the reorder deletes nothing and those are all `toContain` fragment pins.

Method: the three source files were reverted to `origin/main` with `git checkout --` while the new tests stayed in place; the patch was re-applied afterwards.

```
$ git checkout -- packages/spec/src/shared/visibility.ts \
                  packages/spec/src/ui/dashboard.zod.ts \
                  packages/spec/src/data/object.zod.ts
$ npx vitest run --maxWorkers=2 src/ui/view.test.ts src/ui/dashboard.test.ts \
      src/data/object.test.ts src/ui/page.test.ts src/ui/chart.test.ts

 × src/ui/dashboard.test.ts > strictWidgetAnalyticsError message order … > legacy inline-analytics branch: the ADR-0021 dataset prescription comes first
 × src/ui/dashboard.test.ts > strictWidgetAnalyticsError message order … > quarantine branch: the objectui-internal verdict comes first
 × src/ui/dashboard.test.ts > strictWidgetAnalyticsError message order … > drill branch (#5022): the "AUTOMATIC" answer comes first
 × src/ui/dashboard.test.ts > strictWidgetAnalyticsError message order … > keeps the whole drill answer ahead of the history, not just its opening
 × src/ui/dashboard.test.ts > strictWidgetAnalyticsError message order … > emits the history exactly once, whatever the key count
 × src/data/object.test.ts  > strictTenancyError message order … > names the wrong key first, then the tombstone bullet, then the explainer
 × src/data/object.test.ts  > strictTenancyError message order … > keeps EVERY per-key bullet ahead of the explainer, not just the first
 × src/data/object.test.ts  > strictTenancyError message order … > is a full-message pin for the plain unknown-key case
 × src/ui/view.test.ts      > strictVisibilityError message order … > names the wrong key first, then the alias pointer, then the history
 × src/ui/view.test.ts      > strictVisibilityError message order … > emits the history exactly once, whatever the key count

 Test Files  3 failed | 2 passed (5)
      Tests  10 failed | 545 passed (555)
```

Prediction confirmed. The representative failure shows the defect precisely:

```
AssertionError: expected 'Unrecognized key(s) on this view/page…' to contain '`visibleWhenn`. If this is the condit…'
Received: "Unrecognized key(s) on this view/page schema: `visibleWhenn`. Before ADR-0089 D3a
these were dropped silently, shipping inert metadata; a mis-layered or stale key is now
a loud parse error. If this is the conditional-visibility predicate, the canonical key is
`visibleWhen` (ADR-0089) — …"
```

**Two honest notes on the transcript, rather than a tidier number:**

1. **545 pre-existing tests stayed green under the old order** — including every `toContain` on these three messages. That is the point of the exercise: fragment pins cannot carry an ordering fact, which is exactly why the issue asked for order pins.
2. **3 of the 13 new pins are green in BOTH directions, by design, and I did not "fix" them to go red.** Two are full-message `toBe` pins on the *no-fix* branch of `strictVisibilityError` / `strictWidgetAnalyticsError`: that branch emits front matter + sentence and has no fix channel, so there is genuinely nothing to reorder and the message is byte-identical before and after. Their job is the complementary one — proving the reorder did not perturb the branch it should not touch. The third (`still emits the whole alias table after the reorder`) is a deliberate presence check guarding against a reorder that quietly drops one of the three alias spellings, which the order assertions alone would not catch. Reported rather than manufactured into a red.

After re-applying the patch: `Test Files 5 passed (5) / Tests 555 passed (555)`.

## Verification

Gate list enumerated from `.github/workflows/lint.yml` (both jobs), run one by one — no from-memory list:

- **ESLint job (30 steps)** — `pnpm lint`, then `check:` `slot-lookup`, `query-options-erasure`, `nul-bytes`, `doc-authoring`, `docs-audit-scope`, `role-word`, `quick-reference-counts`, `adr-anchors`, `org-identifier`, `authz-resolver`, `service-providers`, `route-envelope`, `error-code-casing`, `wildcard-fallthrough`, `meta-type-normalized`, `init-service-contract`, `durability-log-level`, `startup-registry-verdict`, `objectui-changeset`, `release-notes`, `release-body`, `node-version`, `workflow-status-functions`, `shard-attestation`, `published-files`, `engine-double-contract`, `resume-authority-declared`, `merge-driver`, `spec-parsed-alias` — **all PASS**.
- **TypeScript Type Check job** — `check:type-check-coverage`, `check:driver-conformance`, `check:stall-guard`, `tsc --noEmit` (spec), `check:generated --reconcile-only`, `check:skill-frame-sync`, `check:skill-compatibility`, workspace `turbo build` (66/66), workspace `turbo typecheck` (120/120), `check:type-check-debt`, examples typecheck, downstream-contract typecheck, `check:api-surface`, `check:exported-any`, `check:dual-source-exports`, `check:skill-examples` — **all PASS**.
- **Generated artifacts** — `pnpm --filter @objectstack/spec check:generated` after a real build: **all 10 up to date**, nothing regenerated. This confirms the dispatch's mechanism assumption: these strings are not `.describe()` inputs, so `content/docs/references/**` sees zero regen, and `authorable-surface.base.json` is byte-identical (never hand-edited).
- **Tests** — `@objectstack/spec` 339 files / 8652 tests pass; `@objectstack/lint` 62 / 1541 pass; `@objectstack/cli` 91 / 928 pass (the two message consumers named in #5955 — `os validate`'s renderer and `validateFlowTriggerReadiness`).
- **Byte discipline** — `node scripts/check-nul-bytes.mjs` OK over 6082 files, plus a widened self-scan (`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`) over every changed file: clean.

`content/docs/releases/` untouched. File-disjoint from in-lane PR #6447.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk


---
_Generated by [Claude Code](https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk)_