### PR TITLE
docs(pm-dispatch): step 0 扫描判据扩为三个析取,兜住两种不可行动的卡片形状 (#6405)

### DIFF
--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -790,8 +790,48 @@ in-scope,验收依据 …」),维护者可否决。
 
 (**分诊座位的活** —— 执行座位跳过本步,rule 4。)
 The maintainer does not pre-sort the backlog. On every round (and every
-idle check-in), sweep issues that carry no `pm:*` / `needs-user-decision`
-label and classify each:
+idle check-in), sweep every issue matching **任一**析取,并逐张分类:
+
+1. **无 `pm:*`、无 `needs-user-decision`、也无 `domain:*`** —— 全裸卡。今天的
+   规则,判据不变;`domain:*` 一项此前只活在实践里(带车道标签的单被读作
+   「已路由」而跳过),析取 3 出现后必须写明,否则两条互相吞掉。
+2. **有 `pm:queue` 但无 `domain:*`** —— ⚠️ **仅限 `objectstack-ai/objectstack`**。
+3. **有 `domain:*` 但无 pm-state**(`pm:queue` / `pm:dispatched` / `pm:blocked` /
+   `pm:on-hold` / `finding` / `needs-user-decision`)。
+
+⏳ **析取 2、3 只取 `updated_at` 早于 ~2 分钟前的卡**(析取 1 无此限)。
+
+**为什么 2、3 不是可选项。** `domain:*` 是**路由**、pm-state 是**状态机**,只带
+其一的单对两个视图**同时**不可见 —— 队列按 pm-state 取,车道认领按 `domain:*`
+取,而旧判据「带了 `pm:*` 就跳过」把补票的最后一道也关上了。这不是假想:同形
+已四次实测(两次各停滞整日,一次同日六张 11:00–13:55Z 立、16:47Z 才被两个 PM
+会话**手工**报回来才捞起)。
+
+- 析取 2 的生产者是**协议本身**,不是某个车道的坏习惯:跨座位转移卡(转出方
+  按转移协议自带 `pm:queue`)与队列管家 Routine 的队列健康卡,**按设计**预先
+  带队列标签,又**按单一生产者规则不准自打 `domain:*`**(管家原话:「no
+  `domain:*` / `repo:*` label applied — routing labels are the triage seat's
+  single-producer territory. Only `pm:queue` is set here.」)。于是它们在看板上
+  显示可派、实际**谁都不能认领**。
+- 析取 3 那张实测卡是**分诊自己写的纪律的反例**:同一条「立单方别自打
+  `domain:*`、留给分诊」当天早上刚写在另一张卡上,几小时后 PM 立单时照犯,
+  卡片对队列与扫描同时隐身 ~69 分钟。⇒ **纪律写在别处不够,判据本身必须兜
+  住** —— 这是本节存在的理由,不是修辞。
+
+⚠️ **析取 2 必须 repo-scoped,否则它自己就是噪声源。** 兄弟仓(objectui /
+cloud)是**整仓座位**,车道标签在那里**根本不存在**(实测 2026-08-07:objectui
+的 `domain:devx` 查无此标签),所以「有 `pm:queue`、无 `domain:*`」是它们**每一
+张**队列卡的正常形状 —— 不限定就一次扫进 objectui 38 + cloud 19 张(同日实测
+open 计数),把分诊轮淹掉。
+
+⏳ **年龄下限键在 `updated_at`,不是 `created_at`。** 部分标注状态有两个来源:
+刚立还没打完标签的新卡,以及**一次标签写入**把老卡打成半标注 —— 分诊自己打
+标签就是分开的两次写(`domain:*` 与 `pm:queue` 各一次),中间那几秒正好落在
+析取 2 / 3 里。按 `created_at` 判会漏掉后一种,按 `updated_at` 两种都兜住;代价
+是一条评论也会把卡推迟一轮,可接受(下一轮即取到)。
+
+**分类动作**(对上面选中的每一张;析取 2 选中的卡只欠 `domain:*`,补它即可,
+⛔ 不重打已在位的 `pm:queue`):
 
 - **Auto-queue (`pm:queue`)**: a concrete defect with a named location or
   repro; a scoped tooling/gate fix; a restore-invariant finding; a
@@ -816,6 +856,9 @@ label and classify each:
 `tracking` 与 `status:parked` 的 issue(它们的状态由别的机制管,分诊不重判)、
 以及 **#4604 与全部 `pm:seat` 座位贴**(协议载体,不是待分诊的工作)。存量大时**每轮
 限量、优先最新**(试点用 ~15 条/轮),防一轮吃光存量把轮次拖过一个调度周期。
+⚠️ 排除项在析取 3 下更吃重:parked 单**正常形状**就是「带 `domain:*`、无
+pm-state」(2026-08-07 实测:3 张 `status:parked` 全部长这样),漏判排除就是每轮
+把它们重新扫回来一次。
 
 #### 发现分诊轮 —— 队列的出水口(objectstack#4949)
 

--- a/skills/objectstack-pm-dispatch/SKILL.md
+++ b/skills/objectstack-pm-dispatch/SKILL.md
@@ -173,8 +173,56 @@ invariant is what makes the loop resumable and the board honest.
 ### 0. Backlog sweep — classification is a standing duty, not a request
 
 The maintainer does not pre-sort the backlog. On every round (and every idle
-check-in), sweep issues carrying no `pm:*` / `needs-user-decision` label and
+check-in), sweep every issue matching **any one** of these three disjuncts, and
 classify each:
+
+1. **No `pm:*` / `needs-user-decision` label, and no classification label**
+   either — none of the labels your project reads as "already routed" (area,
+   component, owning team, lane). The plain rule.
+2. **`pm:queue` present, classification label absent** — scoped to the
+   repositories that actually use classification labels (see the caution).
+3. **A classification label present, but no queue state** (`pm:queue`,
+   `pm:dispatched`, any other `pm:*` state your setup defines, or
+   `needs-user-decision`).
+
+Disjuncts 2 and 3 take only cards whose `updated_at` is more than a minute or
+two old; disjunct 1 needs no such floor.
+
+**Why the sweep is a disjunction and not one "unlabeled" filter.** Routing and
+queue state are two independent axes, and a card carrying exactly one of them
+is invisible on **both** views at once: the queue lists by queue state, while
+claimants filter by classification — and a predicate that skips anything
+already carrying a `pm:*` label shuts the last door. Neither half is one
+filer's bad habit; both have standing producers:
+
+- A card can arrive **pre-queued by the protocol itself**. Cross-seat transfer
+  tickets (the handing-off side applies the queue label as part of the
+  transfer) and tickets filed mechanically by a steward automation both carry
+  `pm:queue` on arrival, while a single-producer discipline for classification
+  labels forbids those same producers from applying one. The card then reads as
+  dispatchable on the board and is claimable by nobody.
+- The mirror shape — classified but stateless — comes from anyone who files
+  with an area label out of habit. Writing the discipline down elsewhere does
+  not fix it: a project that had published exactly that rule hours earlier
+  still produced such a card the same day. **The predicate itself has to
+  absorb it.**
+
+⚠️ **Any disjunct keyed on a label's absence must be scoped to the
+repositories where that label exists.** Where it does not exist, its absence is
+universal, so the disjunct matches every open queue card in that repository and
+the sweep becomes its own noise source — the check is whether the label exists
+there at all, not whether some card happens to carry it. Whatever your project
+already excludes from the sweep (parked work, tracking issues, protocol posts)
+stays excluded, and disjunct 3 makes that exclusion list load-bearing: a parked
+card's normal shape is precisely "classified, no queue state".
+
+⏳ **Give the partial-labeling disjuncts an age floor keyed on `updated_at`,
+not `created_at`.** A half-labeled card has two sources: one just filed, and an
+older one that a **label write** has just put into that state — and since
+labels are applied one write at a time, the sweep's own labeling passes through
+the half-labeled shape for a few seconds. `created_at` misses the second
+source; `updated_at` covers both, at the cost of a freshly commented card
+waiting one more round.
 
 - **Auto-queue (`pm:queue`)** — a concrete defect with a named location or
   repro; a scoped tooling or gate fix; a restore-invariant finding; a test-only


### PR DESCRIPTION
Fixes #6405

step 0 的 backlog sweep 判据只选「无 `pm:*` 标签」的 issue。两种卡片形状落在判据之外却仍**不可行动**,今日各实测到停滞。本 PR 把判据扩为三个析取,并给两条最容易漏的护栏写进判据本身。

## 1. 判据 before / after

**Before**(`.claude/skills/pm-dispatch/SKILL.md`,step 0 原文):

> The maintainer does not pre-sort the backlog. On every round (and every
> idle check-in), sweep issues that carry no `pm:*` / `needs-user-decision`
> label and classify each:

⚠️ 注意实测到的一处偏差:issue 正文把今天的判据转述为「无 `pm:*` / `domain:*` / `needs-user-decision` / `finding`」,但**文件字面只有 `pm:*` / `needs-user-decision`**。`domain:*` 那一项一直只活在实践里(带车道标签的单被读作「已路由」而跳过)—— 这正是盲区 B 能成立的原因,也是 after 里必须把它**写明**的原因:析取 ③ 一旦存在,① 不写明 `domain:*` 就会和 ③ 互相吞掉。

**After**(改后原文):

> The maintainer does not pre-sort the backlog. On every round (and every
> idle check-in), sweep every issue matching **任一**析取,并逐张分类:
>
> 1. **无 `pm:*`、无 `needs-user-decision`、也无 `domain:*`** —— 全裸卡。今天的
>    规则,判据不变;`domain:*` 一项此前只活在实践里(带车道标签的单被读作
>    「已路由」而跳过),析取 3 出现后必须写明,否则两条互相吞掉。
> 2. **有 `pm:queue` 但无 `domain:*`** —— ⚠️ **仅限 `objectstack-ai/objectstack`**。
> 3. **有 `domain:*` 但无 pm-state**(`pm:queue` / `pm:dispatched` / `pm:blocked` /
>    `pm:on-hold` / `finding` / `needs-user-decision`)。
>
> ⏳ **析取 2、3 只取 `updated_at` 早于 ~2 分钟前的卡**(析取 1 无此限)。

排除项不变(`tracking`、`status:parked`、#4604、`pm:seat` 座位贴),另补一句:析取 ③ 使排除项**更吃重**(见第 3 节反例 3-5)。

### 年龄下限为什么键在 `updated_at` 而不是 `created_at`

派单要求「卡应在存在一两分钟后才被扫」。实现时发现按 `created_at` 判**兜不住一半**:半标注状态有两个来源 —— ① 刚立还没打完标签的新卡(`created_at` 能兜),② **一次标签写入**把老卡打成半标注。而 ② 不是边角情况:**分诊自己打标签就是分开的两次写**(`domain:*` 一次、`pm:queue` 一次),中间那几秒的卡 `created_at` 可能是几天前,却正落在析取 ②/③ 里。`updated_at` 两种都兜住;代价是一条评论也会把卡推迟一轮(下一轮即取到,可接受)。

## 2. 反向验证的方向申报(先申报后执行)

⚠️ 本单是**纯文本纪律改动**,没有可执行的运行时行为 —— 没有测试会因这次改动由红转绿,也**不存在**可以「把删掉的分支放回去看诊断转红」的对象。硬套「改前红 / 改后绿」模板会得到一个伪造的红。故改为申报下面三条声明并逐条执行;每条标注**实测**还是**论证**。

## 3. 声明 A —— 判据可判定(实测标签 + 论证代入)

**方法**:取今日实测的 7 张停滞卡 + 8 张不该被扫的对照卡,把**标签组合**逐一代入新判据。

**取证边界(如实说明)**:本会话的直连 `api.github.com` 被会话策略拒绝(`GitHub access is not enabled for this session`,非配额),**timeline API 读不到**,所以「停滞时刻的标签组合」不是我从 label 事件流直接读出的。它由三项实测证据支撑:(a) 卡片**当前**标签、`created_at`、`updated_at`(我实测);(b) 六张 A 组卡的 `updated_at` 密集落在 **16:56:21Z–16:56:29Z 的 8 秒窗口**内,而 `created_at` 分散在 11:00–13:55Z —— 即 `domain:*` 是 16:56Z 那一轮一次性补的;(c) 其中三张卡在**正文里自陈**了立单时的标签状态。⇒ 标签组合列为**实测+文证**,代入结果为**论证**(判据是纯布尔式,无执行体)。

### A 组 —— 盲区 A(应被析取 ② 选中)

| 卡 | 立单时标签(实测+文证) | 当前标签(实测) | created → updated(实测) | ① | ② | ③ | 选中? |
|:--|:--|:--|:--|:-:|:-:|:-:|:--|
| #6317 | `pm:queue` | `pm:queue` `domain:devx` | 13:39:46Z → 16:56:28Z | ✗ | **✓** | ✗ | ✅ ② |
| #6329 | `pm:queue` | `pm:queue` `domain:engine-core` | 13:55:27Z → 16:56:29Z | ✗ | **✓** | ✗ | ✅ ② |
| #6285 | `pm:queue` | `pm:queue` `domain:metadata` | 13:01:07Z → 16:56:26Z | ✗ | **✓** | ✗ | ✅ ② |
| #6283 | `pm:queue` | `pm:queue` `domain:spec` | 13:00:51Z → 16:56:25Z | ✗ | **✓** | ✗ | ✅ ② |
| #6214 | `pm:queue` | `pm:queue` `domain:spec` | 11:00:17Z → 16:56:21Z | ✗ | **✓** | ✗ | ✅ ② |
| #6274 | `pm:queue` | `pm:queue` `domain:spec` `target:v17` | 12:52:47Z → 16:56:23Z | ✗ | **✓** | ✗ | ✅ ② |

三张卡的正文自陈(文证,逐字):

- **#6317**(队列管家 Routine 立):「⛔ No bump executed, no code touched, no assignee set, no `domain:*` / `repo:*` label applied — routing labels are the triage seat's single-producer territory. **Only `pm:queue` is set here.**」
- **#6329**:「**未指派,标签交分诊**(落点 `packages/core` → 域待分诊判)」
- **#6285**:「域标签交分诊按落点文件定」

⇒ 三张卡是**协议要求它们长成这样**的,不是谁忘了打标签。这就是 issue 说的「稳定生产者」:旧判据「带了 `pm:*` 就跳过」恰好把协议自己造出来的形状全部漏掉。年龄下限对它们无碍(被扫时已 3–4 小时)。

### B 组 —— 盲区 B(应被析取 ③ 选中)

| 卡 | 立单时标签 | 当前标签(实测) | created → 被捞起 | ① | ② | ③ | 选中? |
|:--|:--|:--|:--|:-:|:-:|:-:|:--|
| #6378 | `tooling` `domain:devx`,无 pm-state | `tooling` `pm:dispatched` `domain:devx` | 15:38:56Z → 16:47Z(~69 min) | ✗ | ✗ | **✓** | ✅ ③ |

① 为 ✗ 是因为改后的 ① 显式要求「也无 `domain:*`」—— 而这恰好复现了它当初为什么会停滞:旧判据字面上是「无 `pm:*`」(#6378 确实无 pm:*),但实践把带 `domain:*` 的单读作已路由而跳过。⇒ **只有析取 ③ 能兜住它**,把一条一直靠人记着的实践规则变成判据。

### 反例组 —— 不该被扫的卡(应全部不被选中)

| 卡 | 标签(实测) | 为什么不该被选 | ① | ② | ③ | 结果 |
|:--|:--|:--|:-:|:-:|:-:|:--|
| #6405(本单) | `pm:dispatched` `domain:devx` | 正常流转中 | ✗ | ✗ | ✗(`pm:dispatched` 是 pm-state) | ✅ 不选 |
| #6283(现在) | `pm:queue` `domain:spec` | 分诊已补完标签 | ✗ | ✗(有 domain) | ✗(有 pm-state) | ✅ 不选 |
| #6023 | `pm:seat` | 座位贴 = 协议载体 | ✗ | ✗ | ✗ | ✅ 不选(排除项 + 判据双重) |
| #4606 | `status:parked` `domain:spec` | parked,状态归别的机制 | ✗ | ✗ | ⚠️ **③ 命中** | ✅ 不选(靠 `status:parked` 排除项) |
| #3146 | `enhancement` `status:parked` `domain:engine-core` | 同上 | ✗ | ✗ | ⚠️ **③ 命中** | ✅ 不选(同上) |
| #2776 | `security` `status:parked` `tracking` | 同上 | ✗ | ✗ | ✗(无 domain) | ✅ 不选(双重排除) |
| objectui#3614 | `pm:queue` | 兄弟仓整仓座位 | ✗ | ✗ **靠 repo scope** | ✗ | ✅ 不选(见声明 B) |
| cloud#1198 | `pm:queue` | 同上 | ✗ | ✗ **靠 repo scope** | ✗ | ✅ 不选(见声明 B) |

⚠️ **第 4、5 行是这次代入跑出来的真结论,不是装饰**:`status:parked` 的卡**正常形状**就是「带 `domain:*`、无 pm-state」(今日实测 3 张 parked,两张正是此形),析取 ③ 一加,排除项从「省一次现场判断」升级为**正确性必需** —— 漏判就是每轮把 parked 卡重新扫回来一次。已把这句写进排除项段落。

第 2 行(#6283 的现状)证明判据是**自限的**:分诊补完 `domain:*` 后,卡片自动离开扫描面,不会每轮重扫。

## 4. 声明 B —— 析取 ② 的 repo scope 真的收住了(实测)

**若不加 scope**,②「有 `pm:queue`、无 `domain:*`」在兄弟仓匹配的不是个别卡,而是**全部**:

| 实测项 | 读数 | 方法 |
|:--|:--|:--|
| objectui open `pm:queue` 卡 | **38** | `list_issues objectui labels:[pm:queue] state:OPEN` → `totalCount: 38` |
| cloud open `pm:queue` 卡 | **19** | `list_issues cloud labels:[pm:queue] state:OPEN` → `totalCount: 19` |
| objectui 是否存在 `domain:*` 标签 | **不存在** | `get_label objectui domain:devx` → `label 'domain:devx' not found in objectstack-ai/objectui` |

具体样例(实测标签,全部无 `domain:*`):objectui#3614 `pm:queue`、objectui#3613 `pm:queue`、objectui#3593 `pm:queue`、objectui#3562 `pm:queue`、cloud#1198 `pm:queue`、cloud#1197 `pm:queue`、cloud#1186 `pm:queue`。

关键一步是第三行:`domain:*` 标签在兄弟仓**根本不存在**,所以「无 `domain:*`」在那里是**恒真**的 —— 不是「这些卡碰巧没打」,而是**打不上**。⇒ 未加 scope 时 ② 会一次选中 **38 + 19 = 57 张**设计上完全正常的卡;加了 scope 后这 57 张**全部不匹配**(仓库不符,② 直接不适用)。这条护栏不加,判据本身就是当天最大的噪声源。

- **不加 scope**:57 张误选 —— **实测**(计数与标签不存在性均为实读)。
- **加 scope**:0 张 —— **论证**(scope 是仓库名相等判断,无执行体)。

泛化后写进发布件的版本更有用:**任何以「某个标签缺席」为条件的析取,都必须限定到该标签真实存在的仓库** —— 判据是「那个仓库里到底有没有这个标签」,而不是「有没有卡碰巧带着它」。

## 5. 声明 C —— 三轴决策框架未被触碰(实测,逐字节)

`check:skill-frame-sync` 改前 / 改后各跑一次,输出 **diff 无任何差异、cmp 逐字节相同、md5 相同**:

```
frame-sync BEFORE EXIT=0
frame-sync AFTER  EXIT=0
$ diff frame-sync-before.txt frame-sync-after.txt
(无输出,exit 0)
$ cmp frame-sync-before.txt frame-sync-after.txt
(无输出 → byte-for-byte identical)
$ md5sum
6aa2a81538f6ffa6e0d642a216aa9133  frame-sync-before.txt
6aa2a81538f6ffa6e0d642a216aa9133  frame-sync-after.txt
```

两次输出的正文(相同):

```
✓ check-skill-frame-sync self-test: 12 cases pass.
✓ check-skill-frame-sync: 4 copies of the decision frame are structurally isomorphic across 3 files
  3 axes: business-need → long-term-soundness → ai-authoring-safety
  binding sentence present in all 4; 4 count mention(s) agree; 40 markdown files scanned for undeclared copies.
```

另跑 `check:skill-frame-freshness` EXIT=0:「the decision frame in this tree is current with origin/main … the frame itself is unchanged」。

## 6. 发布件核实结论(去读了文件,不凭印象)

**结论:发布件有同构结构面 ⇒ 按 #5451 route B 加泛化版。**

- `skills/objectstack-pm-dispatch/SKILL.md` L173-188 是同构的 `### 0. Backlog sweep — classification is a standing duty, not a request`,判据同样是「sweep issues carrying no `pm:*` / `needs-user-decision` label」⇒ **同一缺陷在发布件里逐字同形**,它依赖的不是 `domain:*` 这个具体标签名,而是「判据只看一类标签,而不可行动性来自另一类标签的缺席」这个结构。
- 但发布件**没有车道 / 座位词汇**(实测:`grep -i -E 'lane|seat|domain:'` 只命中 frontmatter 的 `domain: process` 与两处 `three-axis`),且其 pm 标签词汇**只有 `pm:queue` 与 `pm:dispatched`**(实测:`grep -o 'pm:[a-z-]+'` → queue ×6、dispatched ×4;`finding` / `pm:on-hold` / `pm:blocked` / `pm:epic` 在该文件里**零定义**)。
- ⇒ 泛化版写成**机制描述**:用 "classification label(area, component, owning team, lane)" 指代那一类标签,queue state 只列该文件真实定义的 `pm:queue` / `pm:dispatched` / `needs-user-decision` 并加「any other `pm:*` state your setup defines」。⛔ 不带本仓 issue 号、⛔ 不引入该文件不存在的标签字面名。
- 两条护栏一并泛化(泛化后适用面比本仓版本更宽):任何以标签缺席为条件的析取必须限定到该标签存在的仓库;半标注类析取的年龄下限键在 `updated_at`。
- `role` 词:发布件全文计数**仍为 0**(`check:role-word` EXIT=0,该文件不在 baseline,新增一次即红)。

## 7. 相邻但不合并 —— #6393 / #6410 未搭车

#6393(一次轮次复盘带出的三条 fleet-wide hazards)与本单**同文件、不同评审面**:本单改的是 step 0 的**选择判据**(哪些卡进入分诊),#6393 是跨车道的风险条款。issue 正文与派单都明示本单不是 #6393 的 rider,本座位对 #6405 / #6393 / #6410 **串行派发**。

⇒ 本 PR **只有 #6405 一条 `Fixes`**,`git diff --stat` 两个文件、全部改动都在 step 0 扫描判据及其排除项段落之内;⛔ 未顺手改 #6393 / #6410 的任何文本,即使它们最终会落在同一份文件的邻近段落。若三者文本相邻处将来产生冲突,按合并序解决,不在本 PR 预先合并。

## 8. 门禁 EXIT 表(均在 `git add` 之后跑)

| 门 | EXIT | 关键输出 |
|:--|:-:|:--|
| `check:skill-frame-sync`(改前) | **0** | `12 cases pass` / `4 copies … 3 axes` |
| `check:skill-frame-sync`(改后) | **0** | 与改前**逐字节相同**(md5 一致) |
| `check:skill-frame-freshness` | **0** | `the frame itself is unchanged — that is fine` |
| `check:doc-authoring` | **0** | `365 files clean — no bare metadata literals` |
| `check:role-word` | **0** | `44 baselined file(s), no new occurrences` |
| `check:nul-bytes` | **0** | `6072 tracked text file(s) … no raw ASCII control bytes` |
| `check:skill-docs`(发布件已改,故跑) | **0** | `✓ skills/README.md` / `✓ content/docs/ai/skills-reference.mdx` / `Skill docs in sync` |
| 控制字节自扫 | 无命中 | `grep -naP` 两个改动文件均 0 命中 |

## 9. 不在本 PR 里

- ⛔ #6393 的三条 fleet-wide hazards、⛔ #6410(串行派发,各自的 PR)。
- ⛔ 三轴决策框架的任何一个字(声明 C 逐字节取证)。
- ⛔ `.claude/agents/os-dev.md`、其它 skill、`content/docs/releases/**`。
- ⛔ changeset:纯内部流程纪律 + 发布件文档,不发布任何包 ⇒ 路线 2,加 `skip-changeset` 标签。
- ⛔ 未改扫描的**实现代码**:step 0 由 PM agent 按 SKILL.md 执行,判据即文本,无独立可执行体 —— 这也是第 2 节申报「模板式改前红不适用」的原因。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_