### PR TITLE
fix(objectql): sys_file hydrate 读故障与「无文件」可分辨 (#6116)

### DIFF
--- a/.changeset/sys-file-hydrate-fault-warn.md
+++ b/.changeset/sys-file-hydrate-fault-warn.md
@@ -1,0 +1,48 @@
+---
+"@objectstack/objectql": patch
+---
+
+fix(objectql): a `sys_file` hydrate read fault is no longer indistinguishable from "this record has no file" (#6116)
+
+A file-field value stored as an opaque `sys_file` id is enriched on read into
+`{ id, name, size, mimeType, url }`. That one batched lookup sat behind a bare
+`catch { return records }`: **every** failure — connection drop, timeout,
+permission denial, query error, and the benign "the table was never
+provisioned" — was answered with the same silent pass-through of un-hydrated
+ids. Consumers (UI, export) then receive a bare id where a file reference was
+due and render it as *no attachment*, so a live outage looked exactly like a
+record that genuinely holds no file. That is the ADR-0110 D3 shape — a fault
+wearing the appearance of legitimate absent data — carried here on a functional
+surface rather than a durability one.
+
+**Fail-open behaviour is unchanged, deliberately.** A file-metadata read that
+fails must not take down the record read that asked for it, so the ids still
+pass through un-hydrated and no read starts throwing. This is a
+diagnosability fix: what changes is that the two reasons stop being the same
+silence.
+
+The catch now discriminates by error **type**, through the shared
+`isMissingTableError` predicate (`@objectstack/metadata/errors`) — the same
+call the engine's autonumber seeding already makes, never a hand-rolled
+`code === '42P01'` copy:
+
+- **table never provisioned** — the storage plugin is present but schema sync
+  has not run. There are genuinely no committed rows, so the un-hydrated
+  answer *is* the truth: passed through in silence, exactly as before, so an
+  app whose storage schema is not yet synced gains no per-read noise.
+- **every other read failure** — the rows may well exist and simply were not
+  seen. One `warn` now names the parent object, the fields left un-hydrated,
+  how many ids went unresolved, the driver's own error, the consequence (those
+  ids will render as "no file" for this read) and the fix (check
+  storage/database availability, then re-read). Said once per read, not once
+  per record or per id.
+
+`warn` rather than `error` per the repo's degradation-log-level rule: nothing
+on this path claims to have persisted anything, the answer is visibly smaller
+for this response only, and the next successful read repairs it.
+
+Note for operators reading logs: the generic read handler one frame up already
+logged `Find operation failed` for the failed sub-read. That line is unchanged
+and is not a substitute — it is emitted identically for the benign and the
+non-benign failure and describes the `sys_file` sub-read only, never the parent
+object, the fields, or the degraded answer that was nevertheless returned.

--- a/packages/objectql/src/engine-file-hydrate-outage.test.ts
+++ b/packages/objectql/src/engine-file-hydrate-outage.test.ts
@@ -1,0 +1,419 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #6116 — a `sys_file` hydrate READ FAULT must not be indistinguishable from
+ * "this record has no file".
+ *
+ * `resolveFileReferences` enriches a file-field value stored as an opaque
+ * `sys_file` id into `{ id, name, size, mimeType, url }` (ADR-0104 D3 wave 2).
+ * Its one batched lookup used to sit behind a bare `} catch { return records }`:
+ * EVERY failure — connection drop, timeout, permission denial, query error, and
+ * the benign "the table was never provisioned" — was answered with the same
+ * silent pass-through of un-hydrated ids.
+ *
+ * ONE CORRECTION to the issue body, measured rather than assumed: the catch is
+ * zero-output, but the PATH is not literally silent. The generic read handler
+ * one frame up already logs `error: 'Find operation failed' { object:
+ * 'sys_file' }` before rethrowing into this catch. That line is untouched here,
+ * and `the pre-existing generic line cannot tell the two apart` below pins why
+ * it does not satisfy the acceptance: it is byte-identical for the benign and
+ * the non-benign failure, and it describes the sub-read only — never the parent
+ * object, the fields left un-hydrated, or the consequence.
+ *
+ * The pass-through itself is correct and is NOT what this fixes. A file-metadata
+ * read that fails must not take down the record read that asked for it, so
+ * **fail-open is deliberate and unchanged** — the tests below pin it on both
+ * branches precisely so a future reader cannot mistake this for a behaviour
+ * change. What was wrong is that the degradation was INVISIBLE: consumers
+ * (UI, export) receive a bare id, render it as "no attachment", and the outage
+ * is indistinguishable from a record that genuinely holds no file. That is the
+ * ADR-0110 D3 family — a fault wearing the appearance of legitimate absent data
+ * — carried on a functional surface rather than a durability one.
+ *
+ * The fix discriminates by error TYPE through the shared `isMissingTableError`
+ * predicate (`@objectstack/metadata/errors`, #4825) — the same call
+ * `seedAutonumber` makes in this file (#5979) — never a hand-rolled
+ * `code === '42P01'` copy:
+ *
+ *   - table never provisioned → pass ids through in silence (there are
+ *     genuinely no committed rows, so the un-hydrated answer IS the truth);
+ *   - every other read failure → ONE `warn` naming the object, the fields, the
+ *     consequence and the fix, then pass the ids through anyway.
+ *
+ * `warn` and not `error`, per AGENTS "Degradation log levels": nothing on this
+ * path claims to have persisted anything, the answer is visibly smaller for
+ * this response only, and the next read repairs it — functional degradation.
+ *
+ * Why the gate never caught it (#5186's read-seam invention rule): that rule
+ * matches a catch that RETURNS AN EMPTY LITERAL (`[]`/`null`/`0`/…) for a read
+ * that failed. Returning the input argument unchanged is outside its
+ * vocabulary — see the PR for the stance on whether it should grow.
+ *
+ * These tests drive a fake DRIVER (not a fake engine), so no engine write-verb
+ * dispatch contract is involved.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ObjectQL } from './engine';
+
+/** The stored form: an opaque `sys_file` id token, per `isFileIdToken`. */
+const FILE_ID = 'f_7cQx2Lm90a';
+
+/**
+ * A driver whose `sys_file` read behaves as `sysFileRead` says, while every
+ * other object reads normally out of an in-memory store. Splitting by object
+ * name is the whole point: the RECORD read must succeed so the test observes
+ * what the caller receives for a record that really does hold a file.
+ */
+function makeDriver(sysFileRead: () => Promise<any[]>) {
+  const stores = new Map<string, Map<string, any>>();
+  const storeFor = (object: string) => {
+    if (!stores.has(object)) stores.set(object, new Map());
+    return stores.get(object)!;
+  };
+  const driver: any = {
+    name: 'memory',
+    version: '0.0.0',
+    supports: {},
+    async connect() {},
+    async disconnect() {},
+    async checkHealth() {
+      return true;
+    },
+    async execute() {
+      return null;
+    },
+    async find(object: string) {
+      if (object === 'sys_file') return sysFileRead();
+      return [...storeFor(object).values()];
+    },
+    async findOne(object: string) {
+      if (object === 'sys_file') {
+        const rows = await sysFileRead();
+        return rows[0] ?? null;
+      }
+      return [...storeFor(object).values()][0] ?? null;
+    },
+    async create(object: string, data: Record<string, unknown>) {
+      const id = (data.id as string) ?? `r_${storeFor(object).size + 1}`;
+      const row = { ...data, id };
+      storeFor(object).set(id, row);
+      return row;
+    },
+    async update(object: string, id: string, data: Record<string, unknown>) {
+      const row = { ...storeFor(object).get(id), ...data, id };
+      storeFor(object).set(id, row);
+      return row;
+    },
+    async delete(object: string, id: string) {
+      return storeFor(object).delete(id);
+    },
+    async count() {
+      return 0;
+    },
+    async bulkCreate(object: string, rows: Record<string, unknown>[]) {
+      return Promise.all(rows.map((r) => this.create(object, r)));
+    },
+    async bulkUpdate() {
+      return [];
+    },
+    async bulkDelete() {},
+    async beginTransaction() {
+      return { __trx: true, commit: async () => {}, rollback: async () => {} };
+    },
+    async commit() {},
+    async rollback() {},
+  };
+  return { driver, storeFor };
+}
+
+/**
+ * Records every line the engine writes, per level, for the log-contract pins.
+ *
+ * Captures the raw arg list because the two levels this file asserts on have
+ * DIFFERENT signatures in `Logger` (`warn(msg, meta)` vs
+ * `error(msg, error, meta)`); collapsing them to `(msg, meta)` reads the Error
+ * object as the metadata and quietly mis-asserts.
+ */
+function makeCapturingLogger() {
+  const lines: Record<string, Array<{ msg: string; args: any[] }>> = {
+    debug: [], info: [], warn: [], error: [], trace: [], fatal: [],
+  };
+  const push = (level: string) => (...args: any[]) => {
+    lines[level].push({ msg: String(args[0]), args: args.slice(1) });
+  };
+  const logger: any = {
+    lines,
+    debug: push('debug'),
+    info: push('info'),
+    warn: push('warn'),
+    error: push('error'),
+    trace: push('trace'),
+    fatal: push('fatal'),
+    child() {
+      return logger;
+    },
+  };
+  return logger;
+}
+
+/** The `warn` contract is `(message, meta)` — meta is the FIRST trailing arg. */
+const metaOfWarn = (line: { args: any[] }) => line.args[0];
+
+/** Driver-shaped errors meaning "the table was never provisioned" (benign). */
+const MISSING_TABLE_ERRORS: Array<[string, () => unknown]> = [
+  ['PostgreSQL 42P01 undefined_table', () => Object.assign(new Error('relation "sys_file" does not exist'), { code: '42P01' })],
+  ['MySQL ER_NO_SUCH_TABLE', () => Object.assign(new Error("Table 'app.sys_file' doesn't exist"), { code: 'ER_NO_SUCH_TABLE', errno: 1146 })],
+  ['SQLite message-only', () => new Error('no such table: sys_file')],
+];
+
+/**
+ * Driver-shaped errors meaning "the rows may well exist — I just could not see
+ * them". Each is a real outage class the old bare catch answered with silence.
+ */
+const OUTAGE_ERRORS: Array<[string, () => unknown]> = [
+  ['connection refused', () => Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:5432'), { code: 'ECONNREFUSED' })],
+  ['statement timeout', () => Object.assign(new Error('canceling statement due to statement timeout'), { code: '57014' })],
+  ['permission denied', () => Object.assign(new Error('permission denied for table sys_file'), { code: '42501' })],
+  ['connection terminated mid-query', () => Object.assign(new Error('Connection terminated unexpectedly'), { code: '08006' })],
+];
+
+describe('sys_file hydrate read fault — distinguishable from "no file" (#6116)', () => {
+  let engine: ObjectQL;
+  let logger: ReturnType<typeof makeCapturingLogger>;
+
+  /**
+   * Boots an engine holding ONE `doc` row whose `attachment` field carries a
+   * stored `sys_file` id, with the `sys_file` read wired to `sysFileRead`.
+   */
+  async function boot(sysFileRead: () => Promise<any[]>) {
+    logger = makeCapturingLogger();
+    engine = new ObjectQL({ logger } as any);
+    const { driver, storeFor } = makeDriver(sysFileRead);
+    engine.registerDriver(driver, true);
+    await engine.init();
+    engine.registry.registerObject({
+      name: 'doc',
+      fields: {
+        title: { type: 'text' },
+        attachment: { type: 'file' },
+      },
+    } as any);
+    // `sys_file` must be REGISTERED — the resolver skips without a failing
+    // query when the storage plugin is absent, which is a different branch.
+    engine.registry.registerObject({
+      name: 'sys_file',
+      fields: {
+        name: { type: 'text' },
+        size: { type: 'number' },
+        mime_type: { type: 'text' },
+        status: { type: 'text' },
+      },
+    } as any);
+    storeFor('doc').set('d1', { id: 'd1', title: 'Contract', attachment: FILE_ID });
+    return { driver, storeFor };
+  }
+
+  beforeEach(() => {
+    logger = makeCapturingLogger();
+  });
+
+  // -------------------------------------------------- fail-open, both sides --
+
+  describe('fail-open is UNCHANGED — ids pass through on every failure', () => {
+    for (const [label, make] of [...MISSING_TABLE_ERRORS, ...OUTAGE_ERRORS]) {
+      it(`returns the records with raw ids, never throws — ${label}`, async () => {
+        await boot(async () => {
+          throw make();
+        });
+
+        const rows = await engine.find('doc', {} as any);
+
+        // The read that ASKED for the file still answers. This is the pin that
+        // makes #6116 a diagnosability fix and not a behaviour change: if a
+        // later change turns this seam into a throw, this goes red.
+        expect(rows).toHaveLength(1);
+        expect(rows[0].title).toBe('Contract');
+        expect(rows[0].attachment).toBe(FILE_ID);
+      });
+    }
+
+    it('findOne fails open on the same seam', async () => {
+      await boot(async () => {
+        throw Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:5432'), { code: 'ECONNREFUSED' });
+      });
+
+      const row = await engine.findOne('doc', { where: { id: 'd1' } } as any);
+
+      expect(row?.attachment).toBe(FILE_ID);
+    });
+  });
+
+  // ---------------------------------------------------------------- benign --
+
+  describe('table not provisioned → silent pass-through (benign, unchanged)', () => {
+    for (const [label, make] of MISSING_TABLE_ERRORS) {
+      it(`adds no line of its own — ${label}`, async () => {
+        await boot(async () => {
+          throw make();
+        });
+
+        await engine.find('doc', {} as any);
+
+        // There are genuinely no committed rows, so the un-hydrated answer IS
+        // the truth and there is nothing to report. Reporting it anyway would
+        // fire on every read of an app whose storage schema is not synced —
+        // the noise that makes real lines unreadable.
+        expect(logger.lines.warn).toHaveLength(0);
+        expect(logger.lines.fatal).toHaveLength(0);
+      });
+    }
+  });
+
+  // ------------------------------------------- why a new line was needed --
+
+  /**
+   * The pre-existing signal, measured — and why it does not satisfy the
+   * acceptance on its own.
+   *
+   * #6116's body says the seam logs nothing. Measured on `origin/main` that is
+   * true of the CATCH, but not of the whole path: the generic read handler one
+   * frame up (`engine.ts`, `'Find operation failed'`) already reports the
+   * failed `sys_file` sub-read at `error` before rethrowing into this catch.
+   * That line is real and this fix neither removes nor duplicates it.
+   *
+   * It cannot be the discriminator the acceptance asks for, for two reasons
+   * pinned below: it is emitted IDENTICALLY for the benign and the non-benign
+   * failure, and it describes the sub-read only — never the parent object,
+   * the fields left un-hydrated, or the consequence that those bare ids will
+   * read downstream as "this record has no file".
+   */
+  describe('the pre-existing generic line cannot tell the two apart', () => {
+    async function errorCensus(make: () => unknown) {
+      await boot(async () => {
+        throw make();
+      });
+      await engine.find('doc', {} as any);
+      return logger.lines.error.map((l: any) => l.msg);
+    }
+
+    it('reports the same `error` for a benign and a non-benign failure', async () => {
+      const benign = await errorCensus(() => new Error('no such table: sys_file'));
+      const outage = await errorCensus(() =>
+        Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:5432'), { code: 'ECONNREFUSED' }));
+
+      // Identical — so an operator reading only this line learns that a read
+      // failed, never whether the answer they received can be trusted.
+      expect(benign).toEqual(['Find operation failed']);
+      expect(outage).toEqual(['Find operation failed']);
+    });
+
+    it('names only the sub-read, not the degradation it caused', async () => {
+      await boot(async () => {
+        throw Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:5432'), { code: 'ECONNREFUSED' });
+      });
+
+      await engine.find('doc', {} as any);
+
+      // `error(message, error, meta)` — the meta says which object was read…
+      const [, meta] = logger.lines.error[0].args;
+      expect(meta).toMatchObject({ object: 'sys_file' });
+      // …and nothing about `doc`, `attachment`, or the un-hydrated answer that
+      // was nevertheless returned to the caller. That gap is this issue.
+      expect(JSON.stringify(meta)).not.toMatch(/doc|attachment/);
+    });
+  });
+
+  // ---------------------------------------------------------------- outage --
+
+  describe('read outage → exactly one `warn` that names the loss', () => {
+    for (const [label, make] of OUTAGE_ERRORS) {
+      it(`warns exactly once — ${label}`, async () => {
+        await boot(async () => {
+          throw make();
+        });
+
+        await engine.find('doc', {} as any);
+
+        expect(logger.lines.warn).toHaveLength(1);
+        // Functional degradation, not durability: nothing here claims to have
+        // persisted anything, so escalating to `error` would be the
+        // mirror-image failure AGENTS "Degradation log levels" warns about.
+        // The seam adds no loud line of its own — the single `error` present
+        // is the generic read handler's, pinned in its own block above.
+        expect(logger.lines.error).toHaveLength(1);
+        expect(logger.lines.error[0].msg).toBe('Find operation failed');
+        expect(logger.lines.fatal).toHaveLength(0);
+      });
+    }
+
+    it('the line carries what a reader needs: object, fields, consequence, fix', async () => {
+      await boot(async () => {
+        throw Object.assign(new Error('canceling statement due to statement timeout'), { code: '57014' });
+      });
+
+      await engine.find('doc', {} as any);
+
+      const [line] = logger.lines.warn;
+      // The CONSEQUENCE, spelled out — this is the whole point of the issue:
+      // the reader must learn that bare ids will read as "no file".
+      expect(line.msg).toMatch(/sys_file/);
+      expect(line.msg).toMatch(/no file/i);
+      // …and the FIX, so the line is actionable rather than a bare complaint.
+      expect(line.msg).toMatch(/availability/i);
+      // The locus the generic line above cannot give: which PARENT object and
+      // which fields were left un-hydrated, and how many ids went unresolved.
+      expect(metaOfWarn(line)).toMatchObject({ object: 'doc', fields: ['attachment'], unresolvedIds: 1 });
+      // The driver's own diagnosis, not a synthesized one.
+      expect(String(metaOfWarn(line).error)).toMatch(/statement timeout/);
+    });
+
+    it('says it ONCE per read, not once per record or per id', async () => {
+      const { storeFor } = await boot(async () => {
+        throw Object.assign(new Error('Connection terminated unexpectedly'), { code: '08006' });
+      });
+      storeFor('doc').set('d2', { id: 'd2', title: 'Invoice', attachment: 'f_zz11yy22xx' });
+      storeFor('doc').set('d3', { id: 'd3', title: 'Receipt', attachment: 'f_aa33bb44cc' });
+
+      const rows = await engine.find('doc', {} as any);
+
+      expect(rows).toHaveLength(3);
+      // One batched lookup fails once, so it is reported once — AGENTS: "Say it
+      // once, at the first degradation, not once per failed write."
+      expect(logger.lines.warn).toHaveLength(1);
+      expect(metaOfWarn(logger.lines.warn[0])).toMatchObject({ unresolvedIds: 3 });
+    });
+  });
+
+  // ----------------------------------------------------------- no false red --
+
+  describe('the healthy path stays silent', () => {
+    it('hydrates and logs nothing when the lookup succeeds', async () => {
+      await boot(async () => [
+        { id: FILE_ID, name: 'contract.pdf', size: 1024, mime_type: 'application/pdf', status: 'committed' },
+      ]);
+
+      const rows = await engine.find('doc', {} as any);
+
+      expect(rows[0].attachment).toMatchObject({
+        id: FILE_ID,
+        name: 'contract.pdf',
+        size: 1024,
+        mimeType: 'application/pdf',
+      });
+      expect(logger.lines.warn).toHaveLength(0);
+    });
+
+    it('an id with no committed row is a MISS, not a fault — still silent', async () => {
+      await boot(async () => []);
+
+      const rows = await engine.find('doc', {} as any);
+
+      // A clean miss (the read happened, nothing matched) is legitimate absent
+      // data — exactly the fact the outage branch must not be confused with.
+      // It keeps the raw id and stays quiet.
+      expect(rows[0].attachment).toBe(FILE_ID);
+      expect(logger.lines.warn).toHaveLength(0);
+    });
+  });
+});

--- a/packages/objectql/src/engine-file-hydrate-outage.test.ts
+++ b/packages/objectql/src/engine-file-hydrate-outage.test.ts
@@ -227,7 +227,7 @@ describe('sys_file hydrate read fault — distinguishable from "no file" (#6116)
           throw make();
         });
 
-        const rows = await engine.find('doc', {} as any);
+        const rows = await engine.find('doc');
 
         // The read that ASKED for the file still answers. This is the pin that
         // makes #6116 a diagnosability fix and not a behaviour change: if a
@@ -243,7 +243,7 @@ describe('sys_file hydrate read fault — distinguishable from "no file" (#6116)
         throw Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:5432'), { code: 'ECONNREFUSED' });
       });
 
-      const row = await engine.findOne('doc', { where: { id: 'd1' } } as any);
+      const row = await engine.findOne('doc', { where: { id: 'd1' } });
 
       expect(row?.attachment).toBe(FILE_ID);
     });
@@ -258,7 +258,7 @@ describe('sys_file hydrate read fault — distinguishable from "no file" (#6116)
           throw make();
         });
 
-        await engine.find('doc', {} as any);
+        await engine.find('doc');
 
         // There are genuinely no committed rows, so the un-hydrated answer IS
         // the truth and there is nothing to report. Reporting it anyway would
@@ -293,7 +293,7 @@ describe('sys_file hydrate read fault — distinguishable from "no file" (#6116)
       await boot(async () => {
         throw make();
       });
-      await engine.find('doc', {} as any);
+      await engine.find('doc');
       return logger.lines.error.map((l: any) => l.msg);
     }
 
@@ -313,7 +313,7 @@ describe('sys_file hydrate read fault — distinguishable from "no file" (#6116)
         throw Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:5432'), { code: 'ECONNREFUSED' });
       });
 
-      await engine.find('doc', {} as any);
+      await engine.find('doc');
 
       // `error(message, error, meta)` — the meta says which object was read…
       const [, meta] = logger.lines.error[0].args;
@@ -333,7 +333,7 @@ describe('sys_file hydrate read fault — distinguishable from "no file" (#6116)
           throw make();
         });
 
-        await engine.find('doc', {} as any);
+        await engine.find('doc');
 
         expect(logger.lines.warn).toHaveLength(1);
         // Functional degradation, not durability: nothing here claims to have
@@ -352,7 +352,7 @@ describe('sys_file hydrate read fault — distinguishable from "no file" (#6116)
         throw Object.assign(new Error('canceling statement due to statement timeout'), { code: '57014' });
       });
 
-      await engine.find('doc', {} as any);
+      await engine.find('doc');
 
       const [line] = logger.lines.warn;
       // The CONSEQUENCE, spelled out — this is the whole point of the issue:
@@ -375,7 +375,7 @@ describe('sys_file hydrate read fault — distinguishable from "no file" (#6116)
       storeFor('doc').set('d2', { id: 'd2', title: 'Invoice', attachment: 'f_zz11yy22xx' });
       storeFor('doc').set('d3', { id: 'd3', title: 'Receipt', attachment: 'f_aa33bb44cc' });
 
-      const rows = await engine.find('doc', {} as any);
+      const rows = await engine.find('doc');
 
       expect(rows).toHaveLength(3);
       // One batched lookup fails once, so it is reported once — AGENTS: "Say it
@@ -393,7 +393,7 @@ describe('sys_file hydrate read fault — distinguishable from "no file" (#6116)
         { id: FILE_ID, name: 'contract.pdf', size: 1024, mime_type: 'application/pdf', status: 'committed' },
       ]);
 
-      const rows = await engine.find('doc', {} as any);
+      const rows = await engine.find('doc');
 
       expect(rows[0].attachment).toMatchObject({
         id: FILE_ID,
@@ -407,7 +407,7 @@ describe('sys_file hydrate read fault — distinguishable from "no file" (#6116)
     it('an id with no committed row is a MISS, not a fault — still silent', async () => {
       await boot(async () => []);
 
-      const rows = await engine.find('doc', {} as any);
+      const rows = await engine.find('doc');
 
       // A clean miss (the read happened, nothing matched) is legitimate absent
       // data — exactly the fact the outage branch must not be confused with.

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -4796,8 +4796,42 @@ export class ObjectQL implements IObjectQLEngine {
         'sys_file',
         { where: { id: { $in: uniqueIds } }, context: { ...(execCtx ?? {}), __expandRead: true } as ExecutionContext },
       )) ?? [];
-    } catch {
-      return records; // sys_file unregistered / unreadable — leave ids as-is
+    } catch (error) {
+      // [#6116] Fail-open is deliberate and UNCHANGED — a file-metadata read
+      // that fails must not take down the record read that asked for it, so the
+      // ids pass through un-hydrated on BOTH branches below. What changes is
+      // that the two reasons stop being the same silence.
+      //
+      // Benign: `sys_file` is registered but its TABLE was never provisioned
+      // (storage plugin present, schema sync not run yet). There are genuinely
+      // no committed rows, so "leave the ids as-is" IS the truth and there is
+      // nothing to report. Discriminated through the shared `isMissingTableError`
+      // predicate (`@objectstack/metadata/errors`, #4825) — never a hand-rolled
+      // `code === '42P01'` copy — the same call `seedAutonumber` makes above.
+      //
+      // Everything else (connection drop, timeout, permission denial, query
+      // error) means the rows may well exist and simply were not seen. The
+      // consumer then receives a bare id where `{ id, name, size, mimeType,
+      // url }` was due, and UI/export renders it as "this record has no
+      // attachment": a fault wearing the appearance of legitimate absent data,
+      // indistinguishable from a record that truly holds no file (ADR-0110 D3).
+      // One `warn`, not `error`, per AGENTS "Degradation log levels" — the loss
+      // is FUNCTIONAL and scoped to this response (the answer is visibly
+      // smaller, and the next read repairs it); nothing on this path claims to
+      // have persisted anything.
+      if (!isMissingTableError(error)) {
+        this.logger.warn(
+          'sys_file lookup failed; file fields keep their raw ids and will render as "no file" for this read — '
+            + 'check storage/database availability, then re-read to hydrate',
+          {
+            object: objectName,
+            fields: fileFields,
+            unresolvedIds: uniqueIds.length,
+            error: (error as Error)?.message,
+          },
+        );
+      }
+      return records; // fail-open: leave ids as-is
     }
 
     const fileMap = new Map<string, any>();


### PR DESCRIPTION
Fixes #6116

`resolveFileReferences` 把存成 `sys_file` 不透明 id 的文件字段值富化成
`{ id, name, size, mimeType, url }`(ADR-0104 D3 wave 2)。它那一次批量查找此前
坐在裸 `catch { return records }` 后面:连接中断、超时、权限拒绝、查询错误,与
良性的「表还没建」一样,都被同一次静默的裸 id 穿过所回答。消费方(UI / 导出)
拿到裸 id 后按「无附件」渲染,故障期间的表现与「记录本就没有文件」不可分辨 ——
ADR-0110 D3 的族形,只是载体是功能面而非持久性面。

**fail-open 行为本身不变,这是可诊断性修复,不是行为修复。** 文件元数据读失败
不该拖垮发起它的记录读,所以两个分支都仍然原样返回入参,没有任何读开始抛错。
变的是两种原因不再共用同一份沉默。

## 前提复核表(动手前逐条实测)

| 前提 | 结论 | 证据 |
| --- | --- | --- |
| **P1** catch 位仍是 `catch { return records }` 零日志形状 | ✅ 成立,**但对 issue 正文有一处更正** | 以内容定位(不信行号,#6433/#6440 刚动过 engine.ts):实际落在 `packages/objectql/src/engine.ts` 的 `resolveFileReferences` 内、`sys_file` 批量读之后,原文为 `} catch {` + `return records; // sys_file unregistered / unreadable — leave ids as-is`。**更正**:catch 位确为零输出,但整条路径并非字面无声 —— 见下节。 |
| **P2** `isMissingTableError` 存在且是仓内同职良性判别器的标准判法 | ✅ 成立 | `engine.ts` 第 76 行 `import { isMissingTableError } from '@objectstack/metadata/errors'`;现用调用点在同文件 `seedAutonumber`(#5979 落地),形状完全同族:良性 ⇒ 保持廉价答案,非良性 ⇒ 不当作良性处理。闸门的 `READ_FAILURE_DISCRIMINATORS` 也只登记了这一个判别器。 |
| **P3** 对齐 #5840 `getDiagnosed` 是否需要改调用方契约 | ✅ 需要 ⇒ 按分诊口径**不取该形**,取最小形 | `getDiagnosed` 是 `MetadataManager` 上的读 API,返回 `{ data, degraded, errors }`。本处 `resolveFileReferences` 是 private 方法,两个调用点是 `find`(engine.ts 内)与 `findOne`;要把判定真正交到「调用方」手里,信封必须一路透出到 `find`/`findOne` 的**公开返回契约**上。分诊原话是「仅当不动契约时可选」,故排除。 |

### P1 的更正:通用行存在,但它不是判别器

实测(fake driver 注入故障 + 捕获 logger):上一帧的通用读处理器
`engine.ts` 的 `'Find operation failed'` 已在重抛进本 catch **之前**记了一行
`error`,meta 为 `{ object: 'sys_file' }`。所以 issue 正文的「不记一行日志」在
**catch 位**上成立,在**整条路径**上不精确。

该行**未被本 PR 触碰**(分诊红线:不触 engine.ts 其他区域),也不构成对验收的
替代 —— 测试里 `the pre-existing generic line cannot tell the two apart` 一节
把两条理由钉住:

1. 它对良性与非良性故障**逐字相同**(两次都恰好是 `['Find operation failed']`),
   所以只读这一行的运维无法判断手上的答案能不能信;
2. 它只描述 `sys_file` 子读,meta 里没有 `doc` 也没有 `attachment` —— 从不提及
   父对象、被留作裸 id 的字段,或那个**仍然返回给调用方**的降级答案。

验收要求的「可分辨」正是这两点,所以修复照做。

## 取舍:为什么取最小形

取**最小形**(catch 内按良性判别器分流 + 非良性一条 `warn`),不取 `getDiagnosed` 形:

- `getDiagnosed` 形的收益是把判定交给调用方,但本处真正的「调用方」是 `find` /
  `findOne` 的公开返回值。要透出信封就得改这两个公开契约,而本单是可诊断性修复,
  分诊也明确只在「不动契约」时才允许该形 —— 契约要动,所以不动;
- 最小形与同文件既有形状对齐两处:错误分流对齐 `seedAutonumber`
  (`isMissingTableError`),日志形状对齐**紧邻上方**的 `expandRelatedRecords`
  —— 那个 catch 同样是 fail-open 保留裸外键 id,同样记一条
  `this.logger.warn('Failed to expand relationship field; retaining foreign key IDs', { object, field, … })`。
  file 字段的 hydrate 就是 lookup 展开的孪生路径,孪生路径已经在 warn,这条不该继续沉默。

分流后的两个分支:

- **表未建**(storage 插件在、schema sync 没跑):确实没有已提交的行,未 hydrate 的
  答案就是真相 ⇒ **保持现状,静默穿过**。反过来在这里出声会让所有还没同步存储
  schema 的应用每次读都刷一行,正是让真实告警变得不可读的噪音;
- **其他读故障**:一条 `warn`,带父对象、未 hydrate 的字段、未解析 id 数、driver
  自己的报错、后果与修法;每次读说一次,不是每条记录或每个 id 说一次。

`warn` 不升 `error`,按 AGENTS「Degradation log levels」的判定问句:此路径不声称
任何持久化,损失是功能性的、只影响本次响应,下一次成功读即修复。

## 闸门词表表态(必答项)

**结论:该扩,但作为一条新判据,而不是往 EMPTY 值表里塞一项;且扩之前必须先量
假阳性面。已按 Prime Directive #10 立独立单 #6451(未认领,`finding` 标签),
⛔ 未夹带进本 PR**(闸门在 `scripts/`,devx 车道)。

理由摘要:

- **支持扩**:危害轴与 `[]` / `null` 完全同族 —— 读没发生,调用方却拿到一个与
  合法的「空 / 无」不可分辨的答案。规则名叫 invention,但它真正保护的是**可分辨性**;
- **需审慎**:对富化 / 装饰类函数,「原样返回入参」是它 happy path 上的**已声明
  契约**(inline blob、外部 url 字符串本来就原样穿过),不是编造。要把「作为契约的
  穿过」与「吞掉故障的穿过」分开,需要知道函数的声明语义,而这条语法规则看不到 ——
  与脚本头部自陈的局限 1(信封形状判不了)是同一类盲区;
- 因此判据应是「catch 返回了本函数的某个形参」,仍受原有两条豁免约束(catch 内有
  任意级别日志 ⇒ 豁免;按错误类型判别 ⇒ 豁免)。本 PR 修完后这两条豁免都命中,
  所以将来扩了也不会把这个点判红。

实测佐证:闸门在**修复前后都报绿**(`65 read seam(s), none invents an unreported
empty answer`)—— 缺陷在闸门下存活到人工清扫才被看见,这正是 #6451 的实证样本。

## 反向验证表(方向先写死,再跑)

预测(动手前写定):把分流逻辑回退成裸 `catch { return records }` ⇒ **非良性
`warn` 断言转红,fail-open pin 保持绿**。

| 断言组 | 预测 | 实测 | 判定 |
| --- | --- | --- | --- |
| 非良性 ⇒ 恰好一条 warn(4 类故障)+ 文案含对象 / 字段 / 后果 / 修法 + 每次读只说一次 | 红 | **红,6 例** | ✅ 与预测一致 |
| fail-open pin(7 类故障 × 返回入参不变、不抛;含 findOne) | 绿 | **绿** | ✅ |
| 良性 ⇒ 不新增日志 | 绿 | **绿** | ✅ |
| 通用行无法分辨(documentary,钉的是「为什么需要修」) | 绿 | **绿** | ✅ 诚实标注:这一组**不由本次改动驱动**,它固化的是前提事实而非修复本身 |
| 健康路径 / 干净未命中仍静默 | 绿 | **绿** | ✅ |

回退实测输出:`Tests  6 failed | 15 passed (21)`,红的恰好是
`read outage → exactly one warn that names the loss` 整组。恢复修复后 `21 passed (21)`。

## 命令输出

```
# 新测试文件(21 例)
$ npx vitest run --maxWorkers=2 src/engine-file-hydrate-outage.test.ts
 Test Files  1 passed (1)
      Tests  21 passed (21)

# objectql 全量(merge origin/main 之后重跑)
$ pnpm --workspace-concurrency=2 --filter @objectstack/objectql test -- --maxWorkers=2
 Test Files  143 passed (143)
      Tests  2401 passed (2401)

$ pnpm --workspace-concurrency=2 --filter @objectstack/objectql typecheck
> tsc --noEmit          # 无输出,exit 0

$ node scripts/check-durability-degradation-log-level.mjs
✓ durability-degradation log levels: 24 durability-critical catch seam(s), all loud, rethrowing or propagating to the caller (3 propagating, declared).
✓ read-seam invention (#5186, 3 package roots): 65 read seam(s), none invents an unreported empty answer (7 return an empty value on a type-discriminated benign branch) (1 baselined).

$ pnpm check:engine-double-contract
check-engine-double-contract: OK — 80 pinned, 133 in the DEBT ledger, 4 exempt.

# 先全量 build 再跑棘轮(§9 陈旧产物陷阱)
$ npx turbo run build --concurrency=2 --filter='./packages/*' --filter='./packages/*/*'
 Tasks:    70 successful, 70 total
$ pnpm check:type-check-debt
check-type-check-coverage: OK — 62/77 workspace packages type-checked (plus the root), 15 in the DEBT ledger …
  ℹ @objectstack/objectql: TEST_DEBT records 355, tsc now reports 347 (-8) -- the entry can be lowered.
check-type-check-coverage --re-measure: OK — 34 ledger entr(ies) re-measured in 238.6s, 1771 raw tsc error(s) total, none above its recorded number.

$ node scripts/check-nul-bytes.mjs
check-nul-bytes: OK (scanned 6086 tracked text file(s); … no raw ASCII control bytes).
```

objectql TEST_DEBT 台账 355、本次实测 **347**(低于派单时提到的 351),新增代码
引入的 tsc 错误为 0,⛔ 未抬账。

## 红线遵守

- ⛔ 未触 `engine.ts` 已裁定的显式三态 `{ verified: false, conclusive: false }`(`referenceExists` 一带);
- ⛔ 未触 engine.ts 其他区域 —— 本 PR 对 engine.ts 的改动只有那一个 catch 块;
- ⛔ 未动 `scripts/check-durability-degradation-log-level.mjs`;
- ⛔ 未动 `content/docs/releases/`;changeset 为 patch `@objectstack/objectql`。

## 测试

新增 `packages/objectql/src/engine-file-hydrate-outage.test.ts`(21 例),驱动 fake
**driver**(非 fake engine),不涉及 engine 写动词分发契约,故与
`check:engine-double-contract` 无交集。良性 3 类(PG 42P01 / MySQL ER_NO_SUCH_TABLE /
SQLite message-only)、非良性 4 类(ECONNREFUSED / statement timeout / permission
denied / connection terminated)分别成组。

---
_Generated by [Claude Code](https://claude.ai/code/session_019Q7oc7ASjh8yxyS3Yz78We)_