### PR TITLE
fix(spec): `InboxListResult.unreadCount` stops documenting the window count it stopped being (#6438)

### DIFF
--- a/.changeset/inbox-list-result-unread-count-jsdoc.md
+++ b/.changeset/inbox-list-result-unread-count-jsdoc.md
@@ -1,0 +1,37 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): `InboxListResult.unreadCount` no longer documents the window count it stopped being (#6438)
+
+`INotificationService` is a published contract — its JSDoc ships in the `.d.ts` and is
+the sentence a TS SDK consumer reads in their editor. The `unreadCount` member said:
+
+> Unread count over the returned window.
+
+That recorded the implementation as it was *before* #6363. After #6363 (Option A,
+maintainer ruling 2026-08-07; PR #6439, merged as `17d095413`) `service-messaging`
+counts the **total** unread across the user's whole matching inbox, and the window
+bounds `notifications[]` only. The wire declaration one directory over had already said
+the same thing all along —
+`ListNotificationsResponseSchema.unreadCount.describe('Total number of unread
+notifications')` (`api/protocol.zod.ts`) — so one package carried two opposite sentences
+about one field, with the implementation standing on the `.describe()` side and this
+JSDoc the last statement of the retired semantics.
+
+Left alone, it is the sentence that teaches the bug back. A consumer told the number is
+"over the returned window" writes exactly the adaptation #6363 exists to delete: counting
+`notifications` themselves, or clamping the badge to the page size. That holds double for
+AI-written consumers, which are generated from this JSDoc and nothing else.
+
+Both members are now documented, because after #6363 their bounds differ **on purpose**
+and the interface had never written that difference down anywhere:
+
+* `notifications` — the `limit`-bounded window, one page, implementations may clamp.
+* `unreadCount` — the total across the whole matching inbox, explicitly NOT the window,
+  with the "do not re-derive, do not clamp" consequence spelled out for consumers.
+
+Text only. No schema, no value, no behavior: every input that validated before validates
+byte-for-byte after, and the generated artifacts (`check:docs`, `check:authorable-surface`,
+`check:skill-refs`, `check:api-surface`) are unchanged — the reference docs render from
+Zod `.describe()` strings, none of which this touches.

--- a/packages/spec/src/contracts/notification-service.ts
+++ b/packages/spec/src/contracts/notification-service.ts
@@ -96,10 +96,34 @@ export interface InboxNotification {
     createdAt: string;
 }
 
-/** Result of {@link INotificationService.listInbox}. */
+/**
+ * Result of {@link INotificationService.listInbox}.
+ *
+ * Its two members carry deliberately DIFFERENT bounds (#6363): `notifications`
+ * is the requested page, `unreadCount` is the whole matching inbox.
+ */
 export interface InboxListResult {
+    /**
+     * The `limit`-bounded window — at most {@link InboxQuery.limit} rows
+     * (implementations may clamp), newest first. One page of the inbox, not
+     * the whole of it.
+     */
     notifications: InboxNotification[];
-    /** Unread count over the returned window. */
+    /**
+     * Total unread across the user's whole matching inbox — NOT the window
+     * above (#6363). The same quantity the wire contract publishes as
+     * `ListNotificationsResponseSchema.unreadCount` ("Total number of unread
+     * notifications", `api/protocol.zod.ts`).
+     *
+     * This is the number a bell badge shows, so it must not saturate at the
+     * page size: do not re-derive it by counting `notifications`, and do not
+     * clamp it to `notifications.length`. Counting over the window is exactly
+     * the defect #6363 fixed — a user with 60 unread was told 50, and
+     * `?limit=10` told them 10.
+     *
+     * {@link InboxQuery.read} does not zero it either: asking for the READ half
+     * of an inbox is not a claim that nothing is unread.
+     */
     unreadCount: number;
 }
 


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6438

## The contradiction, and which side was wrong

`INotificationService` is a **published** contract: this JSDoc ships in the `.d.ts` and is the sentence a TS SDK consumer reads in their editor. The `unreadCount` member said:

> Unread count over the returned window.

That recorded the implementation as it stood *before* #6363. After #6363 (Option A, maintainer ruling 2026-08-07; PR #6439, merged to `main` as `17d095413`), `service-messaging` counts the **total** unread across the user's whole matching inbox, and the window bounds `notifications[]` only. The wire declaration one directory over had been saying that all along:

```
// packages/spec/src/api/protocol.zod.ts:924
unreadCount: z.number().describe('Total number of unread notifications'),
```

So one package carried two opposite sentences about one field, with the implementation standing on the `.describe()` side — and this JSDoc was the **last** statement of the retired semantics left in the repo. Verified rather than assumed: `grep -rn "returned window"` over all `*.ts` / `*.md` / `*.mdx` now matches nothing but #6363's own changeset, where the phrase correctly describes what was fixed.

Left alone it is the sentence that teaches the bug back. A consumer told the number is "over the returned window" writes exactly the adaptation #6363 exists to delete — re-counting `notifications` themselves, or clamping the badge to the page size. On the anti-AI-error axis it is the same point: an AI-written consumer is generated from this JSDoc and nothing else.

## What changed

Both members are now documented, because after #6363 their bounds differ **on purpose** and the interface had never written that difference down anywhere:

- **`notifications`** — the `limit`-bounded window; one page, implementations may clamp. Worded to match `InboxQuery.limit`'s own existing "Implementations may clamp", so the contract does not bake `service-messaging`'s default 50 / cap 200 into a surface every provider must honour.
- **`unreadCount`** — the total across the whole matching inbox, explicitly NOT the window, anchored to the `.describe()` text, with the consequence spelled out for consumers ("do not re-derive by counting `notifications`, do not clamp to `notifications.length`") and the measured #6363 symptom kept as the reason.

One clause beyond the two sentences the card scoped: `InboxQuery.read` does not zero the count. Reason it earned its place — "whole matching inbox" alone is ambiguous under `read: true`, and both in-repo implementations already agree on the answer, so this states an existing fact rather than declaring a new obligation: `messaging-service.ts` says it outright ("asking for the read half of the inbox does not mean the badge is zero"), and the contract test's own fake computes `all.filter((r) => !r.read).length` over the **unfiltered** set, not over the sliced window.

Deliberately **not** promoted to the contract: how a `type` filter interacts with the count. That is stated at the implementation level by #6363 and is a per-implementation decision; promoting it here would be a new contract clause, not a truth repair.

## Scope

Text only — no schema, no value, no behavior. Every input that validated before validates byte-for-byte after. Nothing request-side (`cursor` / `limit` parsing, #6361), no response-side `cursor` removal, no `.zod.ts` byte, no `content/docs/releases/` byte.

## Changeset

Carried, `@objectstack/spec: patch` — not skipped. This JSDoc ships in the published `.d.ts`, so it is user-visible in the only sense that matters for a contract package, and it matches the precedent of #6364 (`b70e534cc`), a JSDoc-truth flip in the same package that carried a `patch` changeset for the same reason.

## Verification

**Premise re-verified against fresh `origin/main` before implementing** (the issue is a lead, not a spec) — all three anchors held: #6439 merged (`17d095413`, the count is now a reverse join over the whole matching inbox), `protocol.zod.ts:924` already reads `'Total number of unread notifications'`, and the stale JSDoc was still present at `notification-service.ts:102`.

Gate list enumerated from `.github/workflows/lint.yml`, not from memory — **every** `check:*` step of both jobs, run one by one:

- **ESLint job (30/30 pass)**: `lint`, `check:slot-lookup`, `check:query-options-erasure`, `check:nul-bytes`, `check:doc-authoring`, `check:docs-audit-scope`, `check:role-word`, `check:quick-reference-counts`, `check:adr-anchors`, `check:org-identifier`, `check:authz-resolver`, `check:service-providers`, `check:route-envelope`, `check:error-code-casing`, `check:wildcard-fallthrough`, `check:meta-type-normalized`, `check:init-service-contract`, `check:durability-log-level`, `check:startup-registry-verdict`, `check:objectui-changeset`, `check:release-notes`, `check:release-body`, `check:node-version`, `check:workflow-status-functions`, `check:shard-attestation`, `check:published-files`, `check:engine-double-contract`, `check:resume-authority-declared`, `check:merge-driver`, `check:spec-parsed-alias`.
- **Type Check job (all pass)**: `check:type-check-coverage`, `check:driver-conformance`, `check:stall-guard`, `tsc --noEmit` on spec, `check:generated --reconcile-only`, `check:skill-docs`, `check:spec-changes`, `check:upgrade-guide`, `check:authorable-surface`, `check:docs`, `check:skill-refs`, `check:skill-frame-sync`, `check:skill-compatibility`, `check:react-blocks`, workspace build, workspace typecheck, `check:type-check-debt`, examples typecheck, downstream-contract typecheck, `check:api-surface`, `check:exported-any`, `check:dual-source-exports`, `check:skill-examples`, `check:doc-formula-expressions`, `check:i18n`, `check:i18n-coverage`.

`check:i18n` and `check:i18n-coverage` first refused to measure ("PREREQUISITE NOT MET — the workspace CLI is not built", then a chain of unbuilt connector packages). Both are prerequisite refusals, not verdicts — the scripts say so explicitly and warn that piping them reads green either way — so they were made measurable by running CI's own workspace build rather than reported as unmeasured. Final: `check-i18n-bundles: OK (9 package(s) — all bundles in sync)` and `check-i18n-coverage: OK (12 config(s), 660 baselined untranslated string(s), none new)`, both with `REAL_EXIT=0` captured unpiped.

Tests: `pnpm --workspace-concurrency=2 --filter @objectstack/spec test` — **339 files / 8679 tests passed**.

**No pin test, stated plainly rather than manufactured.** Interface JSDoc has no runtime surface — there is nothing a test can read, so a "pin" here could only assert the file's own text back at itself. The semantics this prose describes are already pinned where they are executable: #6363's service tests and wire-route property test, plus the `.describe()` string. The repo's JSDoc-pinning precedents (e.g. `object-strictness-batch20.test.ts` from #6423) pin Zod `.describe()` values, which are runtime data; this file has none.

**Reverse verification does not apply here, and saying so beats inventing it.** There is no diagnostic that can change direction: reverting the diff restores the false sentence and every gate stays green in both states, because no gate reads TS doc comments. The check that *does* discriminate is the grep above — before this change the repo contained one live TS statement of the retired semantics, after it contains zero.

Generated-artifact assumption **confirmed, not assumed**: `git status` after the full gate run shows exactly two files (the source and the changeset); `authorable-surface.base.json` is byte-identical and `check:authorable-surface`, `check:docs`, `check:skill-refs` and `check:api-surface` all report in sync with no rewrite.

---
Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk)_