### PR TITLE
docs(pm-dispatch): 过滤/谓词语义裁决派发必须枚举编译面清单并逐面申报 (#6410)

### DIFF
--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -1383,6 +1383,56 @@ prompt:
 
 一句话:**一个在缺信封的实现上无法转红的拒收用例,读起来是覆盖,实际不是。**
 
+**过滤 / 谓词语义裁决:派发令枚举完整的编译面清单,PR 逐面申报 —— 派发令的标准
+条款(#5930 裁决的流程半边)。** 适用判据:本单会**改变一条过滤 / 谓词语义**(算子
+的 NULL 处理、组合子恒等、比较数形状、算子词表……)。满足时派发令**把下面那张表逐面
+抄进去**,并带这一句(原话):
+
+> 本单改的这条语义由**多个互相独立的编译器 / 求值器**各自实现。派发令列出的**每一
+> 面**都必须在你的 PR 正文里有一个结论:**已改** / **本就合规**(给出证据)/
+> **明确不在范围**(给出理由)。⛔ 不许静默略过 —— 评审把「没提到的面」一律读作
+> 「漏掉的面」,不读作「不需要改」。
+
+**这条防的不是「做错」,是「做对了一部分然后以为做完了」。** 一个 `FilterCondition`
+语义由 **5 个互相独立的实现**承载(下表)⇒ 每条语义裁决的成本 ×5,而漏面**反复
+复发**,三次都留在代码注释里:
+
+- **#5146 → #5903**:裁决只落到面 1,面 2 是**不继承面 1 的独立编译器**,于是同一个
+  驱动的两种连接模式对同一条过滤给出两种答案。现场记录在
+  `driver-turso/src/remote-transport.ts:1731`:「LOCAL mode inherits that fix
+  (`TursoDriver extends SqlDriver`), this independent compiler inherited none of
+  it」。
+- **#5326 / #5335**:面 3 与面 4 各**又花一圈**才对齐,记录在
+  `spec/src/data/filter.zod.ts:370`。
+- **#5905**:#5298 的裁决由 PR #5962 落到 driver-sql / formula / service-analytics
+  与 conformance 表,**唯独漏了 HAVING 面** —— `objectql/src/having-filter.ts:37` 的
+  原话是「was not in that PR's inventory, which left this file as the lone
+  holdout」。**「inventory」这个词本身就是本条款的缺席证明**:那次派发确实有一份清
+  单,只是它不完整,而没有任何机制要求它完整。
+
+三次都不是难度问题,是**没有一份清单在问「还有几面」**。
+
+编译面清单(逐面实测 @ `main` `48f98b0`,2026-08-07):
+
+| # | 面 | 落点(file:line) | 备注 |
+| --- | --- | --- | --- |
+| 1 | `driver-sql` | `packages/drivers/driver-sql/src/sql-driver.ts:7083`(`applyFilterCondition`) | `driver-sqlite-wasm`(`sqlite-wasm-driver.ts:67`)与 **local 模式**的 `driver-turso`(`turso-driver.ts:174`)都 `extends SqlDriver`,**靠继承共用这一面**,不单独算面 |
+| 2 | turso RemoteTransport | `packages/drivers/driver-turso/src/remote-transport.ts:1526`(`private buildWhereSQL`) | **独立编译器,不继承面 1** —— 一个驱动的两面,由连接模式选中哪面 |
+| 3 | service-analytics read-scope-sql | `packages/services/service-analytics/src/read-scope-sql.ts:259`(`compileScopedFilterToSql`) | RLS 读侧 |
+| 4 | service-analytics filter-normalizer | `packages/services/service-analytics/src/strategies/filter-normalizer.ts:1235`(`lowerAnalyticsWhere`) | analytics / cube 侧 |
+| 5 | `formula` | `packages/formula/src/matches-filter.ts:73`(`matchesFilterCondition`) | RLS 写侧 `check` 与公式求值;JS 两值语义的基准面 |
+| 半面 | objectql `having-filter` | `packages/objectql/src/having-filter.ts:92` / `:98`(`applyHaving` / `matchesHaving`) | 聚合**后**过滤。算半面是因为词表是子集,**但申报义务不打折** —— 它是**唯一没有 conformance 表覆盖的面**(`FILTER_LOGIC_CASES` 不驱动 HAVING 路径),所以漏了它连门禁都不会红 |
+| 冻结 | `driver-memory` / `driver-mongodb` | — | #5499 冻结投入:**pin-annotate,不翻转**。冻结面仍要申报,结论是「不在范围 + #5499」。现场注释见 `read-scope-sql.ts:176`、`having-filter.ts:41` |
+
+**这张表本身由 PR 维护 —— 与域表同一纪律。** 增删一面(新驱动、新求值器、某面被合并
+或退役、冻结状态变化)的那个 PR 顺手改这里,不留给下一次裁决重新数。清单**会**过期是
+必然的,清单**没有维护者**才是缺陷。
+
+⚠️ 派发前复核一遍再抄,⛔ 不要凭这张表的记忆填派发令:本仓的包路径搬过家(驱动进
+`packages/drivers/`、服务进 `packages/services/`),行号更是每天在动。一条够用的复核
+串:`grep -rn 'matchesFilterCondition\|buildWhereSQL\|compileScopedFilterToSql'
+packages --include=*.ts | grep -v node_modules`。
+
 **Issue 正文是线索,不是规格 —— and the dispatch wording is what makes an
 honest "the premise is dead" cheap to return.** Step 1's stale-premise check
 is the PM's sample; the dev's verification is the real thing, so the prompt

--- a/skills/objectstack-pm-dispatch/SKILL.md
+++ b/skills/objectstack-pm-dispatch/SKILL.md
@@ -414,6 +414,43 @@ Non-negotiables for this dispatch:
 Return ONLY the JSON report defined in the operating procedure.
 ```
 
+#### One semantics, N independent implementations — enumerate them in the prompt
+
+**Applicability:** the issue changes a *semantic rule* — how an operator, a
+predicate, a comparison, or an absent/empty value is interpreted — and that rule
+is implemented **more than once**, by compilers or evaluators that share no code.
+Query filters, expression languages, permission predicates and serialization
+formats all tend to grow this shape as a project adds backends.
+
+When it applies, the dispatch prompt carries an **explicit inventory of every
+implementing surface**, and requires the agent to give a verdict **for each one**
+in its PR body: **changed** / **already conformant** (with evidence) /
+**explicitly out of scope** (with a reason). A surface the PR never mentions is
+reviewed as one that was *missed*, not as one that needed no change.
+
+Why this is worth a standing clause instead of case-by-case judgment: the failure
+it prevents is not "implemented it wrong", it is **"implemented part of it and
+believed the work was finished"**. That failure is invisible at review time — the
+diff is correct and the tests are green, while the untouched surfaces keep
+answering the old way until a user hits the divergence. The cost scales with the
+count: a semantics carried by N implementations makes every ruling an N-part
+task, and the parts that get skipped are exactly the ones nobody wrote down.
+
+Two disciplines keep the inventory trustworthy:
+
+- **The inventory is maintained by PR.** Whichever change adds, retires or merges
+  an implementing surface updates the list in that same PR. An inventory going
+  stale is inevitable; an inventory with **no owner** is the defect.
+- **Re-verify before pasting.** Paths move and surfaces get added between
+  rulings, so re-derive the list from the code at dispatch time rather than
+  copying the previous prompt. An inventory that was right last month and is
+  pasted unchecked reintroduces the very miss it exists to prevent.
+
+Surfaces that are **deliberately frozen** (deprecated backends, formats kept only
+for compatibility) stay in the inventory. Their verdict is "out of scope —
+frozen", recorded rather than silently absent: a reader cannot otherwise tell a
+frozen surface from a forgotten one.
+
 #### Dispatch backends
 
 **`mode:subagent` (default).** Sub-agents inside the PM's own session. Reports


### PR DESCRIPTION
Fixes #6410

#5930 裁决的**流程半边**。纯 SKILL 文本改动,不碰任何编译器 / 求值器代码。

---

## 0. 前置:串行链头 #5925 的分支核实(分诊 17:55Z 点名)

分诊列出四张卡同落 `.claude/skills/pm-dispatch/SKILL.md`,并指 #5925(`pm:dispatched`、assignee 非本座位)为链头。动笔前核实:

```
git ls-remote --heads origin | grep -c '5925'   →  0
```

**结论:origin 上不存在 #5925 的分支。** 首次 grep 曾出现一条疑似命中,复核后是 **SHA 里的 `5925` 子串**(`fa68ce39ba55925d6…  refs/heads/claude/peaceful-allen-aZ1ir`),不是分支名 —— 这正是「照抄第一眼结果」会出错的一处,故记录在此。

补充核实:全部远端分支名里没有任何 `issue-5925` / `sediment` 形状的分支;当前仓库仅 2 个 open PR(#6208 changeset-release、#6461 spec 锚点),**都不触及本文件**。

⇒ **与 #5925 的落点不相交**(它没有在飞编辑),正常推进。⛔ 未改其状态、未认领、未催。

---

## 1. 条款落点(before / after)

落在 **step 5 派发提示词指引区**,紧接「拒收类用例的最低断言集」条款之后、「Issue 正文是线索」之前 —— 与该区已有的两条「派发令的标准条款」同构(同样的 `适用判据 → 原话 blockquote → 理由` 骨架)。

**before(`origin/main`):** step 5 只有一条相邻条款「多面组件:测试落点是共享一致性覆盖」(1342–1362 行)。它管的是**测试往哪放**,不管**清单**与**申报**。

**after:** 新增常设条款,含 (a) 派发令必须枚举完整编译面清单,(b) PR 必须逐面申报「已改 / 本就合规(给证据)/ 明确不在范围(给理由)」,(c) 清单由 PR 维护(与域表同一纪律),(d) 派发前必须复核再抄。

关键一句(原话,进派发令):

> 本单改的这条语义由**多个互相独立的编译器 / 求值器**各自实现。派发令列出的**每一面**都必须在你的 PR 正文里有一个结论:**已改** / **本就合规**(给出证据)/ **明确不在范围**(给出理由)。⛔ 不许静默略过 —— 评审把「没提到的面」一律读作「漏掉的面」,不读作「不需要改」。

文本形状参照 **#5298 §1**(已读原文):该节把每个实现面**逐行列进一张表**、每格是**实测结论**而非叙述。本条款的清单沿用这个形状。

---

## 2. 逐面只读核实(⛔ 未照抄卡片,全部实测 @ `main` `48f98b0`)

| # | 面 | 实测 file:line | 与卡片是否一致 |
| --- | --- | --- | --- |
| 1 | `driver-sql` | `packages/drivers/driver-sql/src/sql-driver.ts:7083`(`applyFilterCondition`);NULL-safe 段 `:1483` | ⚠️ **路径不符**:卡片写 `sql-driver.ts`,实际在 **`packages/drivers/`** 下 |
| 1-继承 | wasm / turso-local | `driver-sqlite-wasm/src/sqlite-wasm-driver.ts:67`、`driver-turso/src/turso-driver.ts:174`,均 `extends SqlDriver` | ✅ 卡片「wasm / turso-local 继承」**成立** |
| 2 | turso RemoteTransport | `packages/drivers/driver-turso/src/remote-transport.ts:1526`(`private buildWhereSQL`) | ✅ 成立 |
| 3 | service-analytics read-scope-sql | `packages/services/service-analytics/src/read-scope-sql.ts:259`(`compileScopedFilterToSql`) | ⚠️ **路径不符**:实际在 **`packages/services/`** 下 |
| 4 | service-analytics filter-normalizer | `packages/services/service-analytics/src/strategies/filter-normalizer.ts:1235`(`lowerAnalyticsWhere`) | ⚠️ 同上,且在 **`strategies/`** 子目录 |
| 5 | formula | `packages/formula/src/matches-filter.ts:73`(`matchesFilterCondition`) | ✅ 成立 |
| 半面 | objectql `having-filter` | `packages/objectql/src/having-filter.ts:92` / `:98`(`applyHaving` / `matchesHaving`) | ✅ 成立 |
| 冻结 | `driver-memory` / `driver-mongodb` | 冻结注释实测在 `read-scope-sql.ts:176`、`having-filter.ts:41`、`objectql/src/filter-comparand-shape.ts:41` | ✅ #5499 冻结状态**未变**,仍是 pin-annotate |

**与卡片的差异(以实测为准,已反映进 SKILL 清单):**

1. **三处包路径已搬家** —— 驱动进 `packages/drivers/`、服务进 `packages/services/`,`filter-normalizer` 还在 `strategies/` 子目录。卡片给的是裸文件名,照抄进派发令会指向不存在的路径。已把**完整路径 + 行号**写进清单,并在条款里加了一句「⛔ 不要凭这张表的记忆填派发令 + 复核 grep 串」。
2. **多出一次历史复发** —— 卡片举了两例(#5146→#5903、#5326/#5335),实测代码注释里有**第三例**且最新:`objectql/src/having-filter.ts:37` 原话是 HAVING 面「**was not in that PR's inventory**, which left this file as the lone holdout」(#5298 的裁决由 PR #5962 落地时漏掉)。这一例的判别力最强 —— **那次派发确实有一份 inventory,只是不完整,而没有任何机制要求它完整**,正是本条款要补的位置。已写进条款理由。
3. **半面的措辞** —— 卡片称 `having-filter` 为「半面」,而代码注释称它是 "the FIFTH evaluation face"(两者计数基准不同)。清单保留「半面」标注但写明**申报义务不打折**,并记下它是**唯一没有 conformance 表覆盖的面**(`FILTER_LOGIC_CASES` 不驱动 HAVING 路径)⇒ 漏了它连门禁都不会红。

---

## 3. 反向验证(先申报,后执行)

⚠️ 纯文本纪律改动,**无可执行运行时** ⇒ 模板式「改前红 / 改后绿」**不适用**,未硬套伪造一个红。改为下面三条申报。**每条标明实测还是论证。**

### 声明 A — 条款可判定(本单唯一有判别力的验证)

**申报:** 把三个真实历史漏面案例代入,比较旧文本与新条款各给出什么判断。

**A-1(实测):旧文本给不出「逐面申报」这个判断。** 在 `origin/main` 的内部 SKILL 上逐 token 计数:

| token | `origin/main` | 本分支 |
| --- | --- | --- |
| `编译面` | **0** | 2 |
| `逐面` | **0** | 2 |
| `每一面` | **0** | 1 |
| `本就合规` | **0** | 1 |
| `buildWhereSQL` / `matchesFilterCondition` / `having-filter` | **0 / 0 / 0** | 2 / 2 / 3 |

`origin/main` 上 `实现面` 仅 3 处命中(1343 / 1346 / 1361),**全部属于「多面组件:测试落点」那条测试放置条款** —— 它要求的是「新用例进共享一致性覆盖」,不是「清单」也不是「申报」。

⚠️ 一处**容易误读的命中**,如实记录:`origin/main` 上 `申报` 有 7 处命中(464 / 500 / 503 / 743 / 751–753 / 1698 / 2215),但读上下文全部是 **PM 跨座位的「文件面申报」防撞协议**(申报本单碰哪些**文件**,避免两个 PM 撞车),与「一条语义的哪几个**实现面**各自什么结论」是两个概念。⇒ 旧文本确实零覆盖。

**A-2(论证,非实测):新条款对三例的判断。** 历史不可重跑,以下是把条款文本代入的推演:

| 案例 | 旧文本的判断 | 新条款的判断 |
| --- | --- | --- |
| **#5146 → #5903** | 面 2 是独立编译器,与面 1 无代码共享。旧文本只问「测试放哪」⇒ 只改面 1 且把用例放进共享表,**读起来完全合规** | 派发令列出面 2,PR 必须对它给结论。面 2 既非「已改」也非「本就合规」⇒ 只能写「不在范围 + 理由」,**该理由在评审时就会被看见**,而不是几周后变成 #5903 |
| **#5326 / #5335** | 同上,面 3 / 面 4 无人过问 ⇒ 各自晚一圈 | 两面在**原裁决的**派发令里就被点名,晚来的两圈合并进第一圈 |
| **#5905** | 那次派发**已经有 inventory**,旧文本对 inventory 的**完整性**无任何要求 ⇒ 漏 HAVING 面不违反任何条款 | 清单是**常设**且**由 PR 维护**;HAVING 面在表内,漏掉即违反申报义务 |

**A-3(实测):证据出处不是我的转述。** 三例的成因都写在代码注释里,已逐条读原文:

- `driver-turso/src/remote-transport.ts:1731` — "LOCAL mode inherits that fix (`TursoDriver extends SqlDriver`), this independent compiler inherited none of it"
- `spec/src/data/filter.zod.ts:370` — "`read-scope-sql` was aligned by #5326 (closing #5297) and the analytics `filter-normalizer` by #5335 (closing #5325)"
- `objectql/src/having-filter.ts:37` — "was not in that PR's inventory, which left this file as the lone holdout"

**A 结论:** 判别力成立。**A-1 / A-3 为实测,A-2 为论证** —— 不把 A-2 写成实测。

### 声明 B — 清单与实测一致

**申报:** 逐面 grep,证据表见上文第 2 节,含 3 处与卡片不符之处。**结果:实测通过**,SKILL 里的清单反映的是**实测现状**(完整路径 + 行号)而非卡片原文。

### 声明 C — 三轴框架逐字节相同

见下节。**结果:实测通过。**

---

## 4. 三轴决策框架:diff / cmp / md5 三重取证

⚠️ 直接按行号截取会被本 PR 的插入**整体位移**,故用**内容锚点**提取 4 份拷贝(锚点镜像 `scripts/check-skill-frame-sync.mjs` 的 `COPIES` 表)后再比对。

| 拷贝 | md5 BEFORE | md5 AFTER | cmp | diff | 行号位移 |
| --- | --- | --- | --- | --- | --- |
| `internal-pm` | `b321fc62…d1dd` | `b321fc62…d1dd` | EXIT=0 | 0 行 | 2109 → 2158(+49) |
| `internal-dev` | `82007420…7af2` | `82007420…7af2` | EXIT=0 | 0 行 | 277 → 277(未动该文件) |
| `published-pm` | `8d7c83d1…c5a3` | `8d7c83d1…c5a3` | EXIT=0 | 0 行 | 607 → 644(+37) |
| `published-dev` | `55007a96…3700` | `55007a96…3700` | EXIT=0 | 0 行 | 764 → 801(+37) |

**4/4 逐字节相同。** 位移量与两处插入的行数(内部 +49、发布件 +37)**精确吻合**,即位移全部来自本 PR 的新增段落,frame 段本身未被触碰。`.claude/agents/os-dev.md` **完全未改**。

⚠️ **`check:skill-frame-freshness` 末行读作 `1/3 framework files are byte-identical`,这不是 frame 漂移。** 该计数按**整份文件**计而非 frame 段,本 PR 同时改了 3 份 frame-bearing 文件中的 2 份 ⇒ 必然显示 `1/3`,gate 仍 **EXIT=0**。#6460 已实测并在其 PR 正文澄清过同一现象。

---

## 5. 发布件核实(#5451 route B)

**核实结论:发布件有同构的 step 5 面** —— `skills/objectstack-pm-dispatch/SKILL.md:377 ### 5. Dispatch`,结构与内部件一致(派发令模板 + `#### Dispatch backends` 子节)⇒ **按 route B 加泛化版**,插在派发令模板之后、`#### Dispatch backends` 之前。

泛化写法(实测约束,非假设):

| 约束 | 实测 | 本 PR 是否守住 |
| --- | --- | --- |
| 发布件无 `lane` / `seat` / `domain:` 词汇作为本仓术语 | 各 1 处,均为通用语境 | ✅ **一处都没新增** |
| 发布件是英文、无 `派发令` / `标准条款` 等中文术语(计数 0) | 确认 0 | ✅ 新段落全英文 |
| ⚠️ `role` 词计数必须仍为 **0** | BEFORE 0 → AFTER 0 | ✅ `check:role-word` EXIT=0 |
| ⛔ 不带本仓 issue 号 | — | ✅ `#59` / `#51` 计数 **0 → 0** |
| ⛔ 不带本仓具体文件名 | — | ✅ `buildWhereSQL` / `sql-driver` 计数 **0 → 0** |

发布件只写**机制**:「a semantic rule implemented more than once by compilers or evaluators that share no code ⇒ the prompt carries an explicit inventory of every implementing surface, and the agent gives a verdict for each one」,外加两条同样通用的纪律(inventory 由 PR 维护 / 粘贴前重新核对)与冻结面仍需申报。

---

## 6. 门禁 EXIT 表(`git add` 之后跑)

| 门禁 | 改前 | 改后 |
| --- | --- | --- |
| `pnpm check:skill-frame-sync` | **EXIT=0**(12 self-test + 4 拷贝同构) | **EXIT=0**(同上) |
| `pnpm check:skill-frame-freshness` | **EXIT=0** | **EXIT=0**(`1/3` 见上节说明) |
| `pnpm check:doc-authoring` | — | **EXIT=0**(365 files clean) |
| `pnpm check:role-word` | — | **EXIT=0**(44 baselined, no new occurrences) |
| `pnpm check:nul-bytes` | — | **EXIT=0**(6089 tracked files, no raw control bytes) |
| 控制字节自扫(`grep -naP`,NUL 之外的全部扫描面) | — | **无命中**(两份文件) |
| `pnpm check:published-files` | — | **EXIT=0** |
| `pnpm check:skill-compatibility` | — | **EXIT=0**(11 SKILL.md 对账) |
| `pnpm check:quick-reference-counts` | — | **EXIT=0** |
| `pnpm check:docs-audit-scope` | — | **EXIT=0** |
| `pnpm check:adr-anchors` | — | **EXIT=0** |

⚠️ **偏差记录:派发令里点名的 `pnpm check:skill-docs` 在本仓不存在。** 实测 `package.json` 无该 script;`.github/workflows/lint.yml` 里也没有。已按 os-dev 规程**从 lint.yml 逐个列门**,补跑了发布件相关的真实门禁:`check:published-files`、`check:skill-compatibility`、`check:quick-reference-counts`、`check:docs-audit-scope`、`check:adr-anchors`(见表)。

---

## 7. Changeset

**无** —— 纯文档、不发布任何包(`.claude/**` 不进任何包;`skills/**` 非 npm 发布物)⇒ 路线 2,PR 创建后立即加 `skip-changeset` 标签。

---

## 8. ⛔ 不在本 PR 里

- ⛔ **lowering-layer 收敛调查** —— 维护者已裁 `pm:on-hold`,重启条件记在 **#5930**。本 PR 只做**流程半边**。
- ⛔ **不改任何编译器 / 求值器代码** —— 上表 5 面 + 半面**一行代码都没动**,本 PR 只是把它们**写进清单**。
- ⛔ **不搭 #5925 的车** —— 它是别座位的单,状态未动。
- ⛔ **未触碰三轴决策框架**(第 4 节三重取证)。
- ⛔ 未动 `.claude/agents/os-dev.md`、其他 skill、`content/docs/releases/**`、`packages/**`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_