### PR TITLE
fix(scripts): bump-objectui.sh --help 用哨兵定界，改 header 不再静默截断 (#6425)

### DIFF
--- a/scripts/bump-objectui.sh
+++ b/scripts/bump-objectui.sh
@@ -24,6 +24,13 @@
 # Assumes sibling layout:
 #   ~/work/objectui
 #   ~/work/objectstack   ← run from here
+# --help ends here
+#
+# ^ SENTINEL, not prose — `--help` prints from the shebang down to the line above
+# and stops there, so the terminator travels with the text it terminates. Add or
+# remove header lines freely; no line number tracks this block any more (#6425).
+# Spell it exactly: the --help branch below refuses to run without it. Everything
+# from here down is internal rationale and is NOT user-facing help.
 #
 # objectui ships @object-ui/console as a static SPA. The framework
 # release pipeline reads .objectui-sha, clones objectui at that commit,
@@ -63,10 +70,25 @@ for arg in "$@"; do
     --no-commit) NO_COMMIT=1 ;;
     --no-changeset) NO_CHANGESET=1 ;;
     -h|--help)
-      # NOTE: this line range is coupled to the header block above (usage → env →
-      # sibling layout, ending at "run from here"). Editing the header means moving
-      # it — #5960 added the pin-update step and had to.
-      sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'
+      # The header block above IS the help text, and the `# --help ends here`
+      # sentinel is what ends it — no line range, so growing the header can no
+      # longer truncate the help (#6425; #5960 grew it and PR #6421 had to move a
+      # hand-kept `2,26p`). The leading `2` addresses the shebang, whose position
+      # is fixed by execve rather than by the header's content, so it cannot drift.
+      #
+      # A missing sentinel EXITS 1 rather than running on to EOF: a truncated help
+      # and a complete one both exit 0 and both print something, which is precisely
+      # why the old coupling could fail in silence — same lesson as the `head -40`
+      # this script used to truncate its changeset list with (#4731). Guarded here,
+      # not at startup: a deleted comment must never stop an actual pin bump.
+      if ! grep -qxF '# --help ends here' "$0"; then
+        echo "✗ ${0##*/}: the '# --help ends here' sentinel is missing — cannot tell" >&2
+        echo "  where the help text ends. Restore it at the end of the header block." >&2
+        exit 1
+      fi
+      sed -n '2,/^# --help ends here$/p' "$0" \
+        | grep -vxF '# --help ends here' \
+        | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *) EXPLICIT_SHA="$arg" ;;


### PR DESCRIPTION
Fixes #6425

## 问题

`scripts/bump-objectui.sh` 的 `--help` 用**硬编码行号**打印自己的头注释：

```bash
# NOTE: this line range is coupled to the header block above (usage → env →
# sibling layout, ending at "run from here"). Editing the header means moving
# it — #5960 added the pin-update step and had to.
sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'
```

行号与 header 内容之间没有任何机制耦合。往 header 加一行，帮助就静默截断；删一行，就越界打进下一段内部说明。两种情况都 `exit 0`、都打印了「一些东西」，所以**截断的帮助和完整的帮助长得一模一样**。

这不是假设的风险，它已经触发过一次：#5960 往 header 加了 pin 更新步骤，把真正的结尾从第 19 行推到第 26 行，PR #6421 只能手工挪这个魔法数字，并留下上面那条「请下一位作者注意」的 NOTE。**注释不是机制**——它把责任转嫁给了下一位作者，而失败是静默的，下一位作者不会被任何东西提醒。

## 改法

把行号换成哨兵 `# --help ends here`，让**终止符与它所终止的内容放在一起**：header 末尾多一行哨兵，`--help` 打到哨兵为止。

```bash
if ! grep -qxF '# --help ends here' "$0"; then
  echo "✗ ${0##*/}: the '# --help ends here' sentinel is missing — cannot tell" >&2
  echo "  where the help text ends. Restore it at the end of the header block." >&2
  exit 1
fi
sed -n '2,/^# --help ends here$/p' "$0" \
  | grep -vxF '# --help ends here' \
  | sed 's/^# \{0,1\}//'
```

相对 issue 里给出的形状，有三处**刻意的偏离**，逐条说明：

1. **`grep -vxF` 而不是 `grep -v -- '--help ends here'`。** issue 的写法按**子串**过滤，会把 header 里任何**提到**这句话的行一并吃掉——而这次改动恰好需要在文件里写下哨兵的说明文字。`-x`（整行）+ `-F`（字面量）只精确剔掉哨兵那一行。实测：脚本里该字符串按子串出现 **6** 次（第 27、73、84、85、89、90 行），整行精确匹配只命中 **1** 次（第 27 行，哨兵本身）——闸自己那行、报错文案那行、sed 那行、以及说明注释都不误伤。

2. **加了哨兵缺失的硬闸。** `sed -n '2,/RE/p'` 在 RE 匹配不到时会**一路打印到 EOF**——那正是本卡要消灭的「静默失败」换了个方向。实测：删掉哨兵后，无闸的管道会吐出 **231 行**整个脚本。现在改为 `exit 1` 并说明如何恢复。闸**只设在 `--help` 分支**，不设在启动路径：删掉一条注释不该让真正的 pin bump 跑不起来。

3. **起始的 `2` 保留。** 严格说 `2` 也是行号，但它定位的是 **shebang**——位置由 execve 固定，不随 header 内容漂移。本卡要消灭的是**结尾**随 header 增删而漂移；开头不会漂。改成起始哨兵反而要多耦合一行文本，得不偿失。

## 删掉的 NOTE（分诊硬要求）

`:66-68` 那条来自 PR #6421 的「手工耦合」NOTE 在哨兵落地后**即成假话**，已在同一次改动里删除。留着它只是把谎言搬个家（同 #6458 的形状）。

## 验证

### 1. 输出逐字节一致

```
$ diff help-before.txt help-after.txt   # 空
$ cmp help-before.txt help-after.txt    # 静默
before: 25 lines, 1363 bytes, exit 0
after : 25 lines, 1363 bytes, exit 0
```

同时断言输出**非空**且**不含**哨兵字符串——两者必须一起断言：单独一条「哨兵没出现」在输出全空时也会**真空通过**。

### 2. 加行探针：机制真的生效（先声明方向，再跑）

对**改前**和**改后**两份脚本施加同一探针，声明的预期方向是「旧红 / 新绿」：

| 探针 | 旧脚本（`2,26p`） | 新脚本（哨兵） |
|:---|:---|:---|
| A：在 header **末尾**加一行 | 25 行，**新行被静默丢弃**，输出与未加时逐字节相同，`exit 0` | 26 行，**新行出现** |
| B：在 header **中部**（Env 段）加一行 | 25 行，新行出现，但末行 `~/work/objectstack   ← run from here` **被丢掉**，`exit 0` | 26 行，两行都在 |

四项实测结果与声明**完全一致**。探针 A 是本 issue 描述的截断；探针 B 是它的镜像（越界/挤掉），两个方向都复现了，且旧脚本两次都 `exit 0`——这正是「静默」的含义。探针改动只作用于仓库外的临时副本，未落入本 PR。

### 3. 哨兵缺失闸

删掉哨兵后：`exit=1`，**stdout 0 字节**（不是把整个文件吐出来），stderr 为 `✗ … sentinel is missing — cannot tell where the help text ends.`

## 门禁

| 门 | 结果 | 说明 |
|:---|:---|:---|
| `pnpm lint` | pass (exit 0) | ESLint job，仓库家族闸都在这里跑 |
| `pnpm typecheck` | pass (exit 0) | Tasks: 125 successful, 125 total |
| `pnpm check:objectui-changeset` | pass (exit 0) | **唯一真正执行本脚本的门**——它的 `--self-test` 会复制并 exec `bump-objectui.sh` |
| `pnpm check:nul-bytes` | pass (exit 0) | scanned 6092 tracked text files；另对改动文件做了超出该门扫描面的控制字符自查，干净 |

本仓库**没有** shellcheck / shfmt 之类的 shell 脚本门（已核对 `.github/workflows/*.yml` 与 `package.json` 全部 `check:*`）——如实记录，未拿别的脚本顶替。

## Changeset

无。仓库内部开发工具，无对外发布面 ⇒ 不写 changeset，改为打 `skip-changeset` 标签。

## 刻意没做的事

- **没有开扫荡。** 分诊已确认「本仓今天只有这一个脚本是这形状，不成族」，全仓复核也只有这一处 `sed -n '2,` 行号打印。#4731 在同一脚本里修 `head -40` 静默截断是**修法先例**，不是额外范围。
- 没有碰 `build-console.sh` / `check-console-sha.mjs` / `check-objectui-pin-fresh.mjs` 等其它 pin/refresh 脚本。
- 没有碰 `content/docs/releases/`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_