### PR TITLE
feat(lint): view/page 可见性谓词的 CEL 语法构建期闸门 (#6253)

### DIFF
--- a/.changeset/lint-visibility-predicate-syntax-gate.md
+++ b/.changeset/lint-visibility-predicate-syntax-gate.md
@@ -1,0 +1,56 @@
+---
+"@objectstack/lint": minor
+---
+
+feat(lint): view/page 可见性谓词的 CEL 语法构建期闸门 —— `country === "USA"` 不再零诊断(#6253)
+
+新增 **error 级** 规则 `visibility-predicate-syntax`:view/page 的可见性谓词
+(`visibleWhen` 及其两个已弃用别名 `visibleOn` / `visibility`)如果规范 CEL 前端根本
+解析不了,`os validate` / `os build` / `os lint` 一律拒收。`===` 这类写法从此发不出去。
+
+按维护者 2026-08-07 对 #6253 的裁定落地:**判 blocking error**,与其它谓词面
+(validation rule / flow / action,ADR-0032)同级;不设 warning 档,也不为本面写豁免——
+warning 在 CI 里通常不拦,那只是「多绕几步的静默」。
+
+**为什么这一面此前无人判**:`validate-expressions.ts`(ADR-0032)对它遍历到的每条谓词都跑
+`validateExpression`,语法错报 blocking error——但它的遍历面是 objects / flows / actions /
+sharingRules / hooks,**从不走 `views` 与 `pages`**。走这一面的三条规则(ADR-0089 D3b 两条
+advisory,加 #6128 的裸标识符闸)都明确不判语法,理由是「不发明第二个语法判定」。那条政策
+在它自己的调用点上成立(`validateExpression` 就在同一批调用点上跑),**在 view/page 面上不成立:
+那里没有第二个判定,沉默就是没人报**。后果与 #5149 同型:谓词求值失败 → `evalFieldPredicate`
+返回 fallback → 可见性 fallback 是 `true` → 元素无条件渲染,与「没写谓词」在屏幕上一模一样。
+`packages/spec/src/ui/view.test.ts` 的 fixture 就写着 `'country === "USA"'`,正说明这是作者
+(尤其 AI)会写出来的形状。
+
+**判定仍然不是本包给的**——旧政策要保护的正是这一点,它完整保留:判定取 `parseCelToAst`
+(规范前端,带 #3306 改写与 `DEFAULT_LIMITS`,#4812),本规则不自建 `Environment`、不手写
+tokenizer。#6253 加的是**对既有判定的上报**,外加原始报错缺的自纠措辞:cel-js 只说
+`Unexpected character: =` 并画一个 caret,既没点名作者写的运算符,也没给出 CEL 的写法。
+
+**明确不走 `validateExpression` / `celEngine.compile`**,尽管那才是 ADR-0032 的入口:
+`compile()` 是 parse **+ 类型检查**,差别不是理论上的——实测它会以
+`no such overload: type == string` 拒掉 `type == 'grid'`,而那正是本文件**已钉测试的既有盲点**
+(字段名与 CEL 类型名相同时不判,因为改读 overload 消息会误杀合法的 `type(record.x) == string`)。
+从语法分支绕过去会把那条决定悄悄推翻,并把一条 error 级闸门从「解析不了」扩张成「类型检查不过」——
+而这一面的谓词绝大多数是 `dyn`。裁定说的是语法,parse 判定恰好就是语法。
+
+**消息自纠**:实测过的非 CEL 拼法各自点名并给出 CEL 写法——`===`→`==`、`!==`→`!=`、
+`<>`→`!=`、`and`→`&&`、`or`→`||`、`not`→`!`、单个 `=`→`==`。扫描前先把字符串字面量抹平,
+所以 `record.msg == 'a === b' and record.n > 1` 归咎于 `and` 而不是字面量里的 `===`;
+`record.msg == 'a === b'` 本身能解析,压根不报。`??` 与 SQL 的 `IN (…)` 故意不进表:两者
+都会解析失败、都照报(带前端原话),但都没有「换一个 token」就能修好的等价写法,给半个修法
+只会让作者多跑一趟。
+
+**边界**(均已钉测试):空/纯空白谓词不是语法错(`parseCelToAst` 对空源也返回 `null`,
+没有这道 guard 会把「没写谓词」报成坏 CEL);`DEFAULT_LIMITS` 超限属于**边界**错而非语法错,
+照报但引用前端原话、不假装找到了 typo,与 ADR-0032 把两者一并归入「invalid CEL predicate」
+的既有做法一致,且超长谓词在消息里省略,单条 runaway 表达式刷不满控制台;一条坏谓词**只出一个
+finding**——源码解析不出 AST 就没有标识符可判,裸标识符闸自动让位,该互斥性由「断言整个上报集合」
+钉住而不是靠调用方内部实现。
+
+注册表无需改动:`validateVisibilityPredicates` 的 tier 在 #6128 已是 `gating`、commands 已是
+build/lint/validate,本规则的 `error` 直接沿用(已加测试复核该前提仍然成立)。
+
+仓内清扫:除 `packages/spec/src/ui/view.test.ts` 那几条**纯 schema 测试样本**(它们只跑
+`FormFieldSchema.parse`,不经 lint,属于本单援引的证据而非待修点)外,全仓 examples / apps /
+packages 的 view/page 可见性谓词均能通过规范前端解析,无需修改任何示例内容。

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -140,6 +140,7 @@ export {
   VISIBILITY_ALIAS_DEPRECATED,
   VISIBILITY_ROOT_MISLAYERED,
   VISIBILITY_BARE_IDENTIFIER,
+  VISIBILITY_PREDICATE_SYNTAX,
 } from './validate-visibility-predicates.js';
 export type {
   VisibilityFinding,

--- a/packages/lint/src/validate-visibility-predicates.test.ts
+++ b/packages/lint/src/validate-visibility-predicates.test.ts
@@ -6,6 +6,7 @@ import {
   VISIBILITY_ALIAS_DEPRECATED,
   VISIBILITY_ROOT_MISLAYERED,
   VISIBILITY_BARE_IDENTIFIER,
+  VISIBILITY_PREDICATE_SYNTAX,
 } from './validate-visibility-predicates';
 import { AUTHORING_RULES } from './authoring-rules.js';
 
@@ -459,13 +460,16 @@ describe('visibility-bare-identifier (#6128 / #5149 requirement 3)', () => {
       expect(bareFindings(formStack("record.data == 1"))).toEqual([]);
     });
 
-    it('a predicate the canonical front end will not parse is left to the syntax verdict', () => {
-      // `===` is not CEL. `parseCelToAst` returns null and this rule stays
-      // silent rather than inventing a second syntax verdict — the same policy
-      // `validate-null-guards.ts` states. (Documented gap: nothing validates
-      // view/page predicate SYNTAX today, so this one is currently un-reported.)
-      expect(validateVisibilityPredicates(formStack('country === "USA"'))).toEqual([]);
-      expect(validateVisibilityPredicates(formStack('status =='))).toEqual([]);
+    it('a predicate that does not parse yields no BARE-IDENTIFIER verdict (the syntax rule owns it)', () => {
+      // This case used to assert whole-rule SILENCE on an unparseable source,
+      // on the policy that a second syntax verdict must not be invented. #6253
+      // ruled that policy wrong for this surface specifically — nothing else
+      // judges view/page syntax — so the source is now reported, by
+      // `visibility-predicate-syntax`. What survives from the old assertion is
+      // the division of labour: the declaredness check needs an AST and gets
+      // none, so `country` is NOT also reported as a bare identifier.
+      expect(bareFindings(formStack('country === "USA"'))).toEqual([]);
+      expect(bareFindings(formStack('status =='))).toEqual([]);
     });
 
     it('an absent / empty predicate is not a finding', () => {
@@ -500,5 +504,235 @@ describe('visibility-bare-identifier (#6128 / #5149 requirement 3)', () => {
       expect(findings).toHaveLength(1);
       expect(findings[0].message).toContain('`status`');
     });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// `visibility-predicate-syntax` — #6253 (maintainer ruling 2026-08-07:
+// blocking error, same severity as every other predicate surface; no warning
+// tier and no exception for this surface).
+//
+// The surface this closes: `validate-expressions.ts` (ADR-0032) runs
+// `validateExpression` over every predicate it walks, but it walks objects /
+// flows / actions / sharingRules / hooks and never `views` / `pages`. The rules
+// that DO walk views/pages all declined the syntax verdict so as not to invent a
+// second one — correct wherever `validateExpression` runs alongside, and wrong
+// here, where nothing did. Net effect before this rule: `country === "USA"`
+// built clean and then failed OPEN at runtime (#5149).
+// ─────────────────────────────────────────────────────────────────────
+
+/** Only the syntax findings, for assertions that ignore the other three rules. */
+function syntaxFindings(stack: Record<string, unknown>, opts?: { layer: 'runtime' | 'metadata' }) {
+  return validateVisibilityPredicates(stack, opts).filter((f) => f.rule === VISIBILITY_PREDICATE_SYNTAX);
+}
+
+describe('visibility-predicate-syntax (#6253)', () => {
+  describe('the acceptance pair', () => {
+    it('`===` is an ERROR whose message names the token and shows the CEL spelling', () => {
+      // `country === "USA"` is the fixture-proven shape: `packages/spec/src/ui/
+      // view.test.ts` writes it at :1126 / :1240 / :1245 / :1291 / :1373, which
+      // is what the issue cites as evidence that authors reach for it.
+      const findings = validateVisibilityPredicates(formStack('country === "USA"'));
+
+      // The WHOLE reported set, not just "a syntax finding is present" — so the
+      // bare-identifier rule staying out of the way is pinned here too.
+      expect(findings.map((f) => f.rule)).toEqual([VISIBILITY_PREDICATE_SYNTAX]);
+      expect(findings[0].severity).toBe('error');
+      expect(findings[0].path).toBe('views[0].sections[0].fields[0]');
+      expect(findings[0].where).toBe('view "task_form"');
+
+      // Self-correcting, per the ruling: name the offending token, show the CEL
+      // spelling. The raw parser message does neither — cel-js says
+      // `Unexpected character: =` and points a caret, which tells an author
+      // nothing about `==`.
+      expect(findings[0].hint).toContain('`===`');
+      expect(findings[0].hint).toContain('`==`');
+      // The front end's own diagnostic is quoted rather than paraphrased, and
+      // the predicate is echoed so the finding is self-contained.
+      expect(findings[0].message).toContain('Unexpected character: =');
+      expect(findings[0].message).toContain('country === "USA"');
+      // The consequence is stated, because on screen it is invisible.
+      expect(findings[0].message).toContain('#5149');
+    });
+
+    it('the CEL spelling of the SAME predicate is clean — paired so it cannot pass vacuously', () => {
+      // A lone "no syntax finding is reported" assertion is green whenever the
+      // feature is absent, so it can never detect a regression. Pairing it with
+      // the positive case in one test fixes that: delete the rule and the FIRST
+      // expectation goes red.
+      expect(syntaxFindings(formStack('country === "USA"'))).toHaveLength(1);
+      expect(validateVisibilityPredicates(formStack("record.country == 'USA'"))).toEqual([]);
+    });
+  });
+
+  describe('every non-CEL spelling in the table names its own token', () => {
+    // Each row is measured against the canonical front end — `parseCelToAst`
+    // really does refuse all of these — so none of them is a guessed hint.
+    it.each([
+      ['country === "USA"', '===', '=='],
+      ['country !== "USA"', '!==', '!='],
+      ["record.country <> 'USA'", '<>', '!='],
+      ["record.a == 1 and record.b == 2", 'and', '&&'],
+      ["record.a == 1 or record.b == 2", 'or', '||'],
+      ['not record.archived', 'not', '!'],
+      ["record.status = 'open'", '=', '=='],
+    ])('%s → names `%s`, prescribes `%s`', (predicate, wrote, cel) => {
+      const findings = syntaxFindings(formStack(predicate));
+      expect(findings).toHaveLength(1);
+      expect(findings[0].severity).toBe('error');
+      expect(findings[0].hint).toContain(`\`${wrote}\``);
+      expect(findings[0].hint).toContain(`\`${cel}\``);
+    });
+
+    it('a fault with no single-token equivalent still reports, with the parser\'s own words', () => {
+      // `status ==` is a truncated expression: nothing to swap, so the hint
+      // falls back to the general shape instead of inventing a token.
+      const findings = syntaxFindings(formStack('status =='));
+      expect(findings).toHaveLength(1);
+      expect(findings[0].message).toContain('Unexpected token: EOF');
+      expect(findings[0].hint).toContain("record.status == 'open'");
+    });
+
+    it('blames the operator that actually broke it, not one quoted inside a string', () => {
+      // The predicate fails on `and`; the `===` sits inside a string literal and
+      // is none of the reason. Blaming it would send the author to edit a
+      // perfectly good literal. (String literals are blanked before the scan.)
+      const findings = syntaxFindings(formStack("record.msg == 'a === b' and record.n > 1"));
+      expect(findings).toHaveLength(1);
+      expect(findings[0].hint).toContain('`and`');
+      expect(findings[0].hint).not.toContain('`===`');
+    });
+
+    it('a non-CEL operator INSIDE a string literal is not a fault at all', () => {
+      // Same string, no `and` — this parses, so there is no finding to word.
+      expect(validateVisibilityPredicates(formStack("record.msg == 'a === b'"))).toEqual([]);
+    });
+  });
+
+  describe('the boundaries', () => {
+    it('an absent / blank predicate is NOT a syntax fault', () => {
+      // `parseCelToAst` returns null for an empty source too, so without an
+      // explicit guard this rule would report "no predicate" as broken CEL.
+      // Paired with a live case so the assertion can actually fail.
+      expect(syntaxFindings(formStack('country === "USA"'))).toHaveLength(1);
+      expect(validateVisibilityPredicates(formStack(undefined))).toEqual([]);
+      expect(validateVisibilityPredicates(formStack('   '))).toEqual([]);
+      expect(validateVisibilityPredicates(formStack(''))).toEqual([]);
+    });
+
+    it('exactly ONE finding per broken predicate — the syntax rule, not also the bare-ref rule', () => {
+      // `country` is rootless as well as mis-spelled, but a source with no AST
+      // yields no identifiers to judge. Asserting the whole set (not just "a
+      // syntax finding exists") is what pins the exclusivity.
+      expect(validateVisibilityPredicates(formStack('country === "USA"')).map((f) => f.rule))
+        .toEqual([VISIBILITY_PREDICATE_SYNTAX]);
+      // …and the converse: a source that PARSES is judged by the bare-ref rule
+      // and never by this one.
+      expect(validateVisibilityPredicates(formStack("status == 'active'")).map((f) => f.rule))
+        .toEqual([VISIBILITY_BARE_IDENTIFIER]);
+    });
+
+    it('does NOT widen to type-checking — the CEL-type blind spot stays a blind spot', () => {
+      // `type == 'grid'` PARSES; only `celEngine.compile`'s type checker rejects
+      // it (`no such overload: type == string`). Routing this rule through
+      // `compile` / `validateExpression` would silently overturn the deliberate,
+      // separately-pinned decision to stay conservative there — and would widen
+      // an error-level gate from "does not parse" to "does not type-check" on a
+      // surface whose predicates are overwhelmingly `dyn`. The ruling said
+      // syntax; the parse verdict is exactly syntax.
+      expect(validateVisibilityPredicates(formStack("type == 'grid'"))).toEqual([]);
+      // The legitimate CEL the overload message cannot be told apart from.
+      expect(validateVisibilityPredicates(formStack('type(record.x) == string'))).toEqual([]);
+    });
+
+    it('a `DEFAULT_LIMITS` overrun is reported too, in the front end\'s own words', () => {
+      // `parseCelToAst` also returns null for a source over the platform bounds.
+      // That is a bounds fault, not a syntax one, and the message says so rather
+      // than pretending to have found a typo — the same way ADR-0032 already
+      // reports it under the "invalid CEL predicate" heading.
+      const overrun = `record.a${' + record.b'.repeat(400)}`;
+      const findings = syntaxFindings(formStack(overrun));
+      expect(findings).toHaveLength(1);
+      expect(findings[0].message).toContain('Exceeded maxAstNodes');
+      // The echoed predicate is elided, so one runaway expression cannot flood
+      // the console with a 4KB finding.
+      expect(findings[0].message).not.toContain(overrun);
+      expect(findings[0].message).toContain('...');
+    });
+
+    it.each([
+      ['record.a == 1 && record.b == 2', 'the `&&` CEL spells `and` as'],
+      ['record.a == 1 || record.b == 2', 'the `||` CEL spells `or` as'],
+      ['!record.archived', 'the `!` CEL spells `not` as'],
+      ["record.status != 'open'", 'the `!=` CEL spells `<>` as'],
+      ["record.tags.all(t, t != '')", 'a comprehension macro'],
+      ["record.type == 'a' ? record.x > 1 : record.y == 'b'", 'a ternary'],
+      ["record.type in ['lookup', 'master_detail']", 'lowercase `in` — a REAL CEL operator, unlike SQL `IN`'],
+      ["has(record.a) && record.b != null", 'both guard idioms at once'],
+    ])('%s parses and is not reported (%s)', (predicate) => {
+      expect(syntaxFindings(formStack(predicate))).toEqual([]);
+    });
+  });
+
+  describe('every carrier the schema declares, and both layers', () => {
+    it('a form SECTION predicate', () => {
+      const stack = { views: [{ name: 'f', sections: [{ visibleWhen: 'country === "USA"', fields: [] }] }] };
+      expect(syntaxFindings(stack).map((f) => f.path)).toEqual(['views[0].sections[0]']);
+    });
+
+    it('a PAGE COMPONENT predicate', () => {
+      const stack = {
+        pages: [{ name: 'p', regions: [{ components: [{ type: 'element:text', visibleWhen: 'kind === "a"' }] }] }],
+      };
+      const findings = syntaxFindings(stack);
+      expect(findings.map((f) => f.path)).toEqual(['pages[0].regions[0].components[0]']);
+      expect(findings[0].where).toBe('page "p"');
+    });
+
+    it('reads the value through the deprecated `visibleOn` alias (alias + syntax, both reported)', () => {
+      // Two independent defects on one element, so unlike the syntax/bare-ref
+      // pair these DO both report.
+      const stack = { views: [{ name: 'f', sections: [{ visibleOn: 'status === "x"', fields: [] }] }] };
+      expect(validateVisibilityPredicates(stack).map((f) => f.rule).sort())
+        .toEqual([VISIBILITY_ALIAS_DEPRECATED, VISIBILITY_PREDICATE_SYNTAX].sort());
+    });
+
+    it('reads the value through the deprecated page-side `visibility` alias', () => {
+      const stack = {
+        pages: [{ name: 'p', regions: [{ components: [{ type: 'element:text', visibility: 'shown === true' }] }] }],
+      };
+      expect(syntaxFindings(stack)).toHaveLength(1);
+    });
+
+    it('resolves a `{ dialect, source }` envelope the same as a bare string', () => {
+      expect(syntaxFindings(formStack({ dialect: 'cel', source: 'country === "USA"' }))).toHaveLength(1);
+    });
+
+    it('reaches a container\'s `formViews.<key>` — the shape a real stack emits', () => {
+      const stack = {
+        views: [{ object: 'showcase_task', formViews: { edit: { sections: [{ fields: [{ field: 'n', visibleWhen: 'country === "USA"' }] }] } } }],
+      };
+      expect(syntaxFindings(stack).map((f) => f.path)).toEqual([
+        'views[0].formViews.edit.sections[0].fields[0]',
+      ]);
+    });
+
+    it('is layer-agnostic — a syntax fault is a syntax fault on a metadata form too', () => {
+      // Unlike the root rules, nothing about "does it parse" depends on which
+      // namespace the surface binds.
+      expect(syntaxFindings(formStack('country === "USA"'), { layer: 'metadata' })).toHaveLength(1);
+      expect(syntaxFindings(formStack('country === "USA"'))).toHaveLength(1);
+    });
+  });
+
+  it('the registry entry already gates, so this `error` reaches all three commands', () => {
+    // `severity: 'error'` only fails a build because `authoring-rules.ts` marks
+    // the family `gating` and runs it on validate/build/lint alike. That entry
+    // was already `gating` (#6128 promoted it), so #6253 needed no registry
+    // change — this pins that it is still true rather than assuming it.
+    const entry = AUTHORING_RULES.find((r) => r.name === 'validateVisibilityPredicates');
+    expect(entry, 'validateVisibilityPredicates must be registered').toBeDefined();
+    expect(entry!.tier).toBe('gating');
+    expect([...entry!.commands].sort()).toEqual(['build', 'lint', 'validate']);
   });
 });

--- a/packages/lint/src/validate-visibility-predicates.test.ts
+++ b/packages/lint/src/validate-visibility-predicates.test.ts
@@ -7,7 +7,7 @@ import {
   VISIBILITY_ROOT_MISLAYERED,
   VISIBILITY_BARE_IDENTIFIER,
   VISIBILITY_PREDICATE_SYNTAX,
-} from './validate-visibility-predicates';
+} from './validate-visibility-predicates.js';
 import { AUTHORING_RULES } from './authoring-rules.js';
 
 describe('validateVisibilityPredicates (ADR-0089 D3b)', () => {

--- a/packages/lint/src/validate-visibility-predicates.ts
+++ b/packages/lint/src/validate-visibility-predicates.ts
@@ -28,12 +28,16 @@
  * fold carries into `visibleWhen` intact — both still report normally on the
  * normalized tier, and neither is affected by the above.
  *
- * Two advisory rules (both `warning` — nothing is broken, the alias still works
- * and a mis-rooted predicate just never matches) plus one **gating** rule
+ * One advisory rule pair (both `warning` — nothing is broken, the alias still
+ * works and a mis-rooted predicate just never matches) plus TWO **gating** rules
  * (`error` — the predicate can never evaluate at all):
  *
  * - `visibility-alias-deprecated` — a `visibleOn` / `visibility` key in authored
  *   source. Autofix intent: rename the key to `visibleWhen` (same value).
+ * - `visibility-predicate-syntax` (**error**, #6253) — a predicate the canonical
+ *   CEL front end refuses outright (`country === "USA"` — `===` is not CEL). See
+ *   the §Syntax block below for why this surface has to say it and who owns the
+ *   verdict.
  * - `visibility-bare-identifier` (**error**, #6128 / #5149 requirement 3) — a
  *   predicate referencing a top-level identifier that no binding root can
  *   resolve (`status == 'active'` instead of `record.status == 'active'`). See
@@ -62,6 +66,54 @@
  * `page.zod.ts:143`), `visibleOn` is the view-side deprecated alias
  * (`view.zod.ts:1418` / `:1512`) and `visibility` the page-side one
  * (`page.zod.ts:145`). There is no fourth spelling on this surface.
+ *
+ * ## Syntax — the one surface where "don't judge syntax" meant nobody judged it
+ *
+ * `visibility-predicate-syntax` exists because a policy that is right at three
+ * call sites was wrong at this one. Both this rule and `validate-null-guards.ts`
+ * used to skip a source `parseCelToAst` refuses, on the stated grounds that a
+ * second syntax verdict must not be invented. That reasoning holds wherever
+ * `validateExpression` (ADR-0032) runs over the same predicate — it does the
+ * judging, and a duplicate would only disagree. It does NOT hold here:
+ * `validate-expressions.ts` walks objects / flows / actions / sharingRules /
+ * hooks and never `views` or `pages`, so on this surface "leave it to the gate
+ * that owns it" resolved to no gate at all. `country === "USA"` — the spelling
+ * `packages/spec/src/ui/view.test.ts` fixtures prove authors reach for — passed
+ * the build with zero diagnostics, and then failed OPEN in the console for the
+ * #5149 reason the whole family is about: eval faults, `evalFieldPredicate`
+ * returns its fallback, the visibility fallback is `true`, and the element
+ * renders unconditionally, pixel-identical to one carrying no predicate.
+ *
+ * Maintainer ruling (#6253, 2026-08-07): **blocking error**, at the same
+ * severity every other predicate surface already applies to a syntax fault. No
+ * warning tier and no documented exception for this surface — a warning that
+ * does not fail CI is silence with extra steps.
+ *
+ * ### The verdict is still not ours (which is what the old policy was protecting)
+ *
+ * The policy's real content was "one answer to what parses", and that survives
+ * intact: the verdict is `parseCelToAst`'s — the canonical front end, carrying
+ * the #3306 rewrite and `DEFAULT_LIMITS` (#4812) — and this rule builds no
+ * `Environment` and hand-rolls no tokenizer to second-guess it. What #6253 adds
+ * is a REPORT of a verdict already reached, plus the corrective wording the raw
+ * parser message lacks: cel-js says `Unexpected character: =` with a caret, which
+ * names neither the operator the author actually typed nor the CEL spelling of
+ * it. {@link NON_CEL_SPELLINGS} supplies that, and cannot change any verdict —
+ * it is consulted only after the parse has already failed.
+ *
+ * Deliberately NOT `validateExpression` / `celEngine.compile`, though those are
+ * the ADR-0032 entries and the temptation is obvious. `compile()` is parse **+
+ * type-check**, and the difference is not theoretical: measured, it rejects
+ * `type == 'grid'` with `no such overload: type == string`. That shape is this
+ * file's pinned blind spot (see the CEL-TYPE bullet below) — a deliberate,
+ * test-documented decision to stay conservative — and routing this rule through
+ * `compile()` would silently overturn it from the syntax branch, widening an
+ * `error`-level gate from "does not parse" to "does not type-check" on a surface
+ * whose predicates are overwhelmingly `dyn`. The ruling says syntax; the parse
+ * verdict is exactly syntax. `parseCelToAst` also refuses a `DEFAULT_LIMITS`
+ * overrun, which is a bounds fault rather than a syntax one; it is reported here
+ * too, quoting the front end's own words, exactly as ADR-0032 already reports it
+ * under the same "invalid CEL predicate" heading.
  *
  * ## Bare identifiers — the gap between two gates that both wave it through
  *
@@ -125,14 +177,13 @@
  *   `record.x != null` and every other guard idiom stay green here, whichever
  *   way #4953 is eventually settled.
  * - **A predicate the canonical front end will not parse.** `parseCelToAst`
- *   returns `null` for a syntax fault or a `DEFAULT_LIMITS` overrun, and this
- *   rule then stays silent rather than inventing a second syntax verdict
- *   (`validate-null-guards.ts` states the same policy for the same reason).
- *   Worth knowing where that leaves the surface: unlike the object/flow/action
- *   sites, NOTHING validates view/page predicate syntax today, so a `=` typo is
- *   still un-diagnosed here. Widening this rule to own that verdict is a
- *   separate decision about what authors may write, not a wiring gap to close
- *   in passing.
+ *   returns `null` there, so the declaredness check has no AST to reason about
+ *   and this rule gives no BARE-IDENTIFIER verdict on it. That is a division of
+ *   labour, not silence: since #6253 the same source is reported by
+ *   `visibility-predicate-syntax` (§Syntax above), and the two are mutually
+ *   exclusive by construction — a predicate that parses cannot be a syntax
+ *   fault, and one that does not parse yields no identifiers to judge. A single
+ *   broken predicate therefore produces exactly one finding, never two.
  * - **Nested composite / repeater sub-fields** (`fields[].fields[]`,
  *   `view.zod.ts:1477`). The traversal stops at a section's direct fields. A
  *   sub-field of a repeater row is evaluated against a binding this rule cannot
@@ -149,7 +200,7 @@
  *   build error — pinned by a test so it reads as a decision.
  */
 
-import { firstUndeclaredReference, parseCelToAst } from '@objectstack/formula';
+import { collectCelRootIdentifiers, firstUndeclaredReference, parseCelToAst } from '@objectstack/formula';
 import type { CelAstNode } from '@objectstack/formula';
 
 import { walkPageComponents } from './page-walk.js';
@@ -157,6 +208,7 @@ import { walkPageComponents } from './page-walk.js';
 export const VISIBILITY_ALIAS_DEPRECATED = 'visibility-alias-deprecated';
 export const VISIBILITY_ROOT_MISLAYERED = 'visibility-root-mislayered';
 export const VISIBILITY_BARE_IDENTIFIER = 'visibility-bare-identifier';
+export const VISIBILITY_PREDICATE_SYNTAX = 'visibility-predicate-syntax';
 
 export type VisibilitySeverity = 'error' | 'warning';
 
@@ -175,8 +227,9 @@ export interface VisibilityOptions {
 
 export interface VisibilityFinding {
   /**
-   * `warning` for the two ADR-0089 D3b advisories; `error` for
-   * `visibility-bare-identifier`, which gates (see module note).
+   * `warning` for the two ADR-0089 D3b advisories; `error` for the two rules
+   * that gate — `visibility-predicate-syntax` and `visibility-bare-identifier`
+   * (see module note).
    */
   severity: VisibilitySeverity;
   /** Diagnostic rule id, e.g. `visibility-alias-deprecated`. */
@@ -238,6 +291,106 @@ function usesRoot(source: string, root: string): boolean {
   // `(^|[^.\w$])` guard excludes a nested access like `foo.data` (a field named
   // `data`) or `my_record.x` (an identifier that merely ends in `record`).
   return new RegExp(`(^|[^.\\w$])${root}\\.\\w`).test(source);
+}
+
+// ── `visibility-predicate-syntax` (#6253) ───────────────────────────
+
+/**
+ * `source` with every string literal blanked out — same length, so nothing else
+ * shifts. The spelling scan below must never read INSIDE a literal, because the
+ * two things are independent: `record.msg == 'a === b'` parses fine and never
+ * reaches this code at all, while `record.msg == 'x' and record.n > 1` fails on
+ * `and` and would otherwise be blamed on the `===`-free string beside it. Only
+ * the hint could ever be wrong that way — the verdict is already in — but a hint
+ * naming the wrong token is worse than no hint.
+ *
+ * The alternation is unambiguous by construction (`[^'\\]` and `\\.` cannot both
+ * match at one position), so this scans linearly — the same ReDoS discipline
+ * `@objectstack/formula`'s `validate.ts` states for its own scanners.
+ */
+function withoutStringLiterals(source: string): string {
+  return source.replace(/'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"/g, (lit) => ' '.repeat(lit.length));
+}
+
+/**
+ * Non-CEL operator spellings an author — or a model fluent in JavaScript, SQL and
+ * Python — reaches for, each with the CEL token that means the same thing.
+ *
+ * Every row is MEASURED to fail the canonical parse; none is a guess. None can
+ * change a verdict either: the table is consulted only once `parseCelToAst` has
+ * already refused the source, so its whole effect is on the wording of a finding
+ * that was going to be emitted regardless.
+ *
+ * Order matters — `===` and `!==` contain shorter operators, so they match first
+ * and the bare `=` row last.
+ *
+ * Deliberately absent, though both are measured to fail the parse and both are
+ * still reported (with the front end's own diagnostic): `??`, because CEL has no
+ * null-coalescing operator to swap in, and SQL's `IN (…)`, because the CEL
+ * spelling changes the list literal too (`('a','b')` → `['a','b']`). A
+ * "write X instead of Y" hint that is only half the fix sends the author round a
+ * second lap, which is the opposite of self-correcting.
+ */
+const NON_CEL_SPELLINGS: ReadonlyArray<{
+  wrote: string;
+  cel: string;
+  example: string;
+  re: RegExp;
+}> = [
+  { wrote: '===', cel: '==', example: "record.country == 'USA'", re: /===/ },
+  { wrote: '!==', cel: '!=', example: "record.country != 'USA'", re: /!==/ },
+  { wrote: '<>', cel: '!=', example: "record.country != 'USA'", re: /<>/ },
+  { wrote: 'and', cel: '&&', example: "record.a == 1 && record.b == 2", re: /(?<![.\w$])and(?![\w$])/i },
+  { wrote: 'or', cel: '||', example: "record.a == 1 || record.b == 2", re: /(?<![.\w$])or(?![\w$])/i },
+  { wrote: 'not', cel: '!', example: '!record.archived', re: /(?<![.\w$])not(?![\w$])/i },
+  // Assignment where a comparison was meant. Last, and fenced off from every
+  // operator that legitimately contains `=` (`==`, `!=`, `<=`, `>=`).
+  { wrote: '=', cel: '==', example: "record.status == 'open'", re: /(?<![=!<>])=(?!=)/ },
+];
+
+/** What the canonical front end refused, and the corrective wording for it. */
+interface CelSyntaxFault {
+  /** The front end's own one-line diagnostic, quoted rather than paraphrased. */
+  detail: string;
+  /** The recognised non-CEL spelling, when the source contains one. */
+  token: { wrote: string; cel: string; example: string } | null;
+}
+
+/** The predicate as it appears in a message — whitespace flattened, long sources elided. */
+function quoteSource(source: string): string {
+  const flat = source.replace(/\s+/g, ' ').trim();
+  return flat.length > 120 ? `${flat.slice(0, 117)}...` : flat;
+}
+
+/**
+ * The canonical front end's refusal of `source`, or `null` when it parses.
+ *
+ * Two things are deliberately NOT done here (see the module note's §Syntax):
+ * this function neither parses with an environment of its own nor reaches for
+ * `celEngine.compile` / `validateExpression`, which would widen the gate from
+ * "does not parse" to "does not type-check".
+ */
+function celSyntaxFault(source: string): CelSyntaxFault | null {
+  // A blank predicate is not a syntax fault. `parseCelToAst` returns `null` for
+  // an empty or whitespace-only source too, so without this guard the rule would
+  // report `visibleWhen: '   '` — which is "no predicate", exactly what the
+  // author meant, and what `validateExpression` itself short-circuits on.
+  if (!source.trim()) return null;
+  // The verdict, from the one entry that owns it (#4812).
+  if (parseCelToAst(source) !== null) return null;
+  // The MESSAGE, from the same package's parse-only classifier — `compile()`
+  // would answer a wider question, and re-throwing the parse ourselves would be
+  // the private front end #4812 removed.
+  const parsed = collectCelRootIdentifiers(source);
+  const detail = parsed.ok
+    // Unreachable while both entries parse the same source through the same env
+    // under the same limits. Kept as a truthful fallback rather than a `!`
+    // assertion, so a future divergence degrades to a vaguer message instead of
+    // throwing inside a linter.
+    ? 'the expression could not be parsed'
+    : parsed.error.split('\n')[0].trim();
+  const scannable = withoutStringLiterals(source);
+  return { detail, token: NON_CEL_SPELLINGS.find((s) => s.re.test(scannable)) ?? null };
 }
 
 // ── `visibility-bare-identifier` (#6128) ────────────────────────────
@@ -407,12 +560,44 @@ function checkElement(
     });
   }
 
-  // (3) #6128 — a reference no binding root can resolve. Unlike (2) this one
+  // (3) #6253 — the canonical CEL front end refuses the source outright. GATES,
+  // at the severity every other predicate surface already applies to a syntax
+  // fault (ADR-0032 via `validateExpression`); this surface is the one that had
+  // no such gate, so a `===` shipped clean and then failed OPEN in the console.
+  const syntaxFault = source ? celSyntaxFault(source) : null;
+  if (syntaxFault) {
+    findings.push({
+      severity: 'error',
+      rule: VISIBILITY_PREDICATE_SYNTAX,
+      where,
+      path,
+      message:
+        `visibility predicate is not valid CEL — ${syntaxFault.detail} ` +
+        `(predicate: \`${quoteSource(source!)}\`). A predicate that does not parse can never ` +
+        `evaluate, and the console falls OPEN: the element renders unconditionally and looks ` +
+        `exactly like one with no predicate at all (#5149).`,
+      hint: syntaxFault.token
+        ? `\`${syntaxFault.token.wrote}\` is not a CEL operator — CEL spells it ` +
+          `\`${syntaxFault.token.cel}\`. Replace \`${syntaxFault.token.wrote}\` with ` +
+          `\`${syntaxFault.token.cel}\`, e.g. \`${syntaxFault.token.example}\`.`
+        : `Visibility predicates are bare CEL, e.g. \`record.status == 'open'\`. Spellings from ` +
+          `other languages do not parse: write \`==\` (not \`===\`), \`!=\` (not \`!==\` or \`<>\`), ` +
+          `\`&&\` (not \`and\`), \`||\` (not \`or\`), \`!\` (not \`not\`).`,
+    });
+  }
+
+  // (4) #6128 — a reference no binding root can resolve. Unlike (2) this one
   // GATES: a mis-rooted predicate is at least a statement about a namespace
   // someone binds somewhere, while a bare identifier resolves nowhere, on no
   // layer, under neither a total nor a sparse record (#4953) — so there is no
   // reading of the metadata under which it was going to work.
-  if (source) {
+  //
+  // Skipped when (3) fired: the declaredness check needs an AST, and a source
+  // that does not parse has none. Written as an explicit `else` rather than
+  // relying on `firstBareIdentifier`'s own null-AST guard, so the one-finding
+  // -per-broken-predicate property is visible at the call site instead of
+  // depending on a callee's internals.
+  if (source && !syntaxFault) {
     const bare = firstBareIdentifier(source);
     if (bare) {
       const root = CANONICAL_ROOT_BY_LAYER[layer];
@@ -500,8 +685,9 @@ function formViewSites(
  * Runs on the **pre-parse** (normalized) stack so it can see the deprecated
  * `visibleOn` / `visibility` aliases before the schema folds them into
  * `visibleWhen`. Returns findings (empty = clean). The two ADR-0089 D3b rules
- * are advisory (`warning`); `visibility-bare-identifier` is `error` and the
- * caller is expected to fail the build on it (#6128).
+ * are advisory (`warning`); `visibility-predicate-syntax` (#6253) and
+ * `visibility-bare-identifier` (#6128) are `error` and the caller is expected to
+ * fail the build on them.
  *
  * The binding-root check is layer-directional (ADR-0089 D3): pass
  * `opts.layer = 'metadata'` when linting a `*.form.ts` metadata-editing form (so a

--- a/packages/lint/src/validate-visibility-predicates.ts
+++ b/packages/lint/src/validate-visibility-predicates.ts
@@ -565,7 +565,7 @@ function checkElement(
   // fault (ADR-0032 via `validateExpression`); this surface is the one that had
   // no such gate, so a `===` shipped clean and then failed OPEN in the console.
   const syntaxFault = source ? celSyntaxFault(source) : null;
-  if (syntaxFault) {
+  if (source && syntaxFault) {
     findings.push({
       severity: 'error',
       rule: VISIBILITY_PREDICATE_SYNTAX,
@@ -573,7 +573,7 @@ function checkElement(
       path,
       message:
         `visibility predicate is not valid CEL — ${syntaxFault.detail} ` +
-        `(predicate: \`${quoteSource(source!)}\`). A predicate that does not parse can never ` +
+        `(predicate: \`${quoteSource(source)}\`). A predicate that does not parse can never ` +
         `evaluate, and the console falls OPEN: the element renders unconditionally and looks ` +
         `exactly like one with no predicate at all (#5149).`,
       hint: syntaxFault.token


### PR DESCRIPTION
Fixes #6253

view/page 的可见性谓词此前在构建期**无人判语法**。本 PR 新增 error 级规则
`visibility-predicate-syntax`,落在 PR #6248 已经注释过的那个 `parseCelToAst` 返回
`null` 的分支上。

## 裁定与路线

按维护者 2026-08-07 的裁定执行:判 **blocking error**,与 ADR-0032 下其它谓词面
(validation rule / flow / action)同级;**不设 warning 档,不为本面写豁免**。
实施方在这一点上没有裁量,本 PR 也不提替代方案、不加软化开关。

## 为什么这一面此前没人报

`validate-expressions.ts`(ADR-0032)对它遍历到的每条谓词都跑 `validateExpression`,
语法错报 blocking error —— 但它的遍历面是 objects / flows / actions / sharingRules /
hooks,**从不走 `views` 与 `pages`**。走这一面的三条规则都明确不判语法,理由是
「不发明第二个语法判定」。那条政策在它自己的调用点上成立(`validateExpression` 就在
同一批调用点上跑),**在 view/page 面上不成立:那里没有第二个判定,沉默就是没人报**。

后果是 #5149 同型的 fail-open:谓词求值失败 → `evalFieldPredicate` 返回 fallback →
可见性 fallback 是 `true` → 元素无条件渲染,与「没写谓词」在屏幕上一模一样。

## 判定仍然不是本包给的(这正是旧政策要保护的东西)

旧政策的真实内容是「对『什么能解析』只有一个答案」,这一点完整保留:判定取
`parseCelToAst`(规范前端,带 #3306 改写与 `DEFAULT_LIMITS`,#4812),本规则
**不自建 `Environment`、不手写 tokenizer**。新增的是**对既有判定的上报**,外加原始
报错缺的自纠措辞 —— cel-js 只说 `Unexpected character: =` 并画一个 caret,既没点名
作者写的运算符,也没给出 CEL 的写法。

### 明确不走 `validateExpression` / `celEngine.compile`

尽管那才是 ADR-0032 的入口。`compile()` 是 parse **+ 类型检查**,差别不是理论上的 ——
本 PR 实测它会以 `no such overload: type == string` 拒掉 `type == 'grid'`,而那正是
本文件**已钉测试的既有盲点**(字段名与 CEL 类型名相同时不判,因为改读 overload 消息会
误杀合法的 `type(record.x) == string`)。从语法分支绕过去会把那条决定悄悄推翻,并把一条
error 级闸门从「解析不了」扩张成「类型检查不过」—— 而这一面的谓词绝大多数是 `dyn`。
裁定说的是语法,parse 判定恰好就是语法。已加测试钉住这条边界。

## 消息自纠

实测过的非 CEL 拼法各自点名并给出 CEL 写法:`===`→`==`、`!==`→`!=`、`<>`→`!=`、
`and`→`&&`、`or`→`||`、`not`→`!`、单个 `=`→`==`。扫描前先把字符串字面量抹平,
所以 `record.msg == 'a === b' and record.n > 1` 归咎于 `and` 而不是字面量里的 `===`;
`record.msg == 'a === b'` 本身能解析,压根不报。

`??` 与 SQL 的 `IN (…)` 故意不进表:两者都会解析失败、都照报(带前端原话),但都没有
「换一个 token」就能修好的等价写法,给半个修法只会让作者多跑一趟。

真实 CLI 门后的输出(下面「端到端」一节的注入实验):

```
✗ Author-time rules failed (1 issue)
• view "views[0]" · formViews.edit: visibility predicate is not valid CEL — Unexpected character: = (predicate: `record.priority === 'urgent'`). A predicate that does not parse can never evaluate, and the console falls OPEN: the element renders unconditionally and looks exactly like one with no predicate at all (#5149).
    `===` is not a CEL operator — CEL spells it `==`. Replace `===` with `==`, e.g. `record.country == 'USA'`.
    rule: visibility-predicate-syntax  at views[0].formViews.edit.sections[0].fields[6]
```

## 边界(均已钉测试)

- **空/纯空白谓词不是语法错**。`parseCelToAst` 对空源也返回 `null`,没有这道 guard
  会把「没写谓词」报成坏 CEL。
- **`DEFAULT_LIMITS` 超限属于边界错而非语法错**,照报但引用前端原话、不假装找到了
  typo(与 ADR-0032 把两者一并归入「invalid CEL predicate」的既有做法一致);
  超长谓词在消息里省略,单条 runaway 表达式刷不满控制台。
- **一条坏谓词只出一个 finding**。源码解析不出 AST 就没有标识符可判,裸标识符闸自动
  让位。该互斥性由「断言整个上报集合」钉住,而不是靠调用方内部实现。

## 反向验证(先声明,后运行)

**声明的方向:RED**(常规方向)—— 把生产改动摘掉、测试全留,新增的钉子测试应当变红。
预测 **21 红 / 65 绿(共 86)**,并逐条列出了哪些断言会红。

**实测结果:21 failed | 65 passed (86)**,且逐条命中,与声明**完全一致**。

诚实记录的一点:纯「不报」型断言在功能被删掉时是**空绿**的。因此凡是有意义的地方,
都把否定断言与同一测试内的肯定断言配对(如「CEL 写法是干净的 —— 配对以防空绿」、
「空谓词不是语法错」、「一条坏谓词只出一个 finding」),删掉规则时红的是配对里的
**肯定**那一半。仍然空绿的几条(如「字符串字面量里的 `===` 不是错」「不扩张到类型
检查」「若干合法谓词不报」)在报告里按空绿如实标注,不当作证据。

另有一条既有测试原本断言**整条规则沉默**(`'country === "USA"'` → `[]`),它钉的正是
本 PR 删掉的那个分支 —— 按「整条替换」处置,重写为它幸存的那半个事实:解析不出 AST
的源**不产生裸标识符判定**。

## 验证证据

| 闸门 | 结果 |
|---|---|
| `pnpm lint`(ESLint,家族闸在此 job 内) | pass,无输出 |
| `pnpm --filter @objectstack/lint typecheck` | pass |
| `pnpm --filter @objectstack/cli typecheck` | pass(消费方编译面) |
| `pnpm --filter @objectstack/lint test` | 62 files / **1573 passed** |
| `pnpm --filter @objectstack/cli test` | 91 files / **928 passed** |
| `pnpm --filter @objectstack/metadata-protocol test` | 53 files / **552 passed** |
| `pnpm check:nul-bytes` | OK(6093 文件,无裸控制字节) |
| `pnpm check:empty-changeset` | OK(本 diff 新增 1 份声明式 changeset) |
| `pnpm check:adr-anchors` | OK |
| `pnpm --filter @objectstack/lint check:doc-formula-expressions` | OK |

新增 32 条测试。另按字节纪律对改动文件做了闸门之外的自扫描
(`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`),干净。

### 消费半径清扫

规则只有注册表一个调用方,但改动会把原本沉默的谓词变成**阻断**,所以全仓清扫了会喂到
这条规则的 fixture:全仓 examples / apps / packages 的 view/page 可见性谓词都能通过
规范前端解析。唯一的 `===` 出现在 `packages/spec/src/ui/view.test.ts`(:1126 / :1240 /
:1245 / :1291 / :1373)—— 那是**纯 schema 测试样本**,只跑 `FormFieldSchema.parse`,
不经 lint,是本单援引的**证据**而非待修点,按要求只读未改。CLI 的模板与脚手架里没有
任何可见性谓词。

### 端到端(证明真的会拦)

三个示例 app `os validate` 全部通过、零 visibility finding、exit 0。
随后往 `app-showcase` 的表单谓词临时注入 `===`,`os validate` **exit 1**、
`✗ Author-time rules failed (1 issue)`(见上面的输出),随即已还原并复验通过 ——
「坏谓词发不出去」是实测的,不是推断的。

## 明确没有做的事

- **没碰 `validate-expressions.ts`** —— 本单不改 ADR-0032 的遍历面。
- **没碰 `packages/spec/src/ui/view.test.ts`** —— 那里的 `===` 是样本,不是待修点。
- **没碰 `validate-null-guards.ts`** —— 同一条沉默政策的另一条规则,不在本单射程内。
  顺带说明:它的沉默在**它自己的**调用点上仍然成立(`validateExpression` 就在旁边跑),
  本 PR 的论据不构成对它的改动理由。
- **没碰 `content/docs/releases/`**。
- **没改注册表**:`validateVisibilityPredicates` 的 tier 在 #6128 已是 `gating`、
  commands 已是 build/lint/validate,本规则的 `error` 直接沿用(已加测试复核该前提仍然成立)。
- **没加 `skip-changeset` 标签**(本 PR 有 changeset)。
- 未翻 ready-for-review、未开启 auto-merge。

## Changeset

`.changeset/lint-visibility-predicate-syntax-gate.md`,`@objectstack/lint: minor`。
取 minor 的理由是照搬同族先例:同一文件、同样「新增一条 error 级规则」的
`visibility-bare-identifier`(#6128)用的就是 minor。这是新增能力而非破坏性 API 变更 ——
公开签名只是**追加**了一个规则 id 常量,既有类型与函数签名一律未变。

规则 id 常量已按 `rule-id-barrel-exports.test.ts` 的要求加入已发布 barrel
(`packages/lint/src/index.ts`)—— 这是本 PR 唯一一处在 issue 指定文件面之外的改动,
纯机械要求:少了这一行,该闸门会红。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_