### PR TITLE
fix(spec): 参考页里写在括号中的裸源码路径重新成链接 —— 删掉 tokenizer 之后已无事可做的前后瞻对

### DIFF
--- a/.changeset/docs-gen-bare-path-in-parens.md
+++ b/.changeset/docs-gen-bare-path-in-parens.md
@@ -1,0 +1,28 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): 参考页里写在括号中的裸源码路径重新成链接 (#6420)
+
+参考页开篇那段模块描述由 `packages/spec/scripts/lib/file-description.ts` 渲染。其中
+把 JSDoc 里裸写的 `*.zod.ts` 路径改写成站内链接的那一步,正则两端各挂着一个前后瞻
+——「前面不是 `(`」和「后面不是 `)`」。这对前后瞻是 tokenizer 出现**之前**的产物,
+本意是「别去动已经是链接目标的路径」:`](route)` 恰好把那个路径夹在这两个字符中间。
+它从来表达不了这件事(前后瞻说不出「不在链接内部」,模块注释里写着),而 #6136 之后
+它更是无事可做了 —— 成形的链接是独立的 `link` token,这一步只会看到 `text` token。
+
+它**仍在**做的,是把作者自己写在普通括号里的每一个路径一并拒掉。那是散文,不是链接,
+于是这些路径既没成链接也没成代码,以纯文本发布在三张参考页上:
+
+- `references/automation/etl` —— `- **Enterprise Connector** (integration/connector.zod.ts) - …`
+- `references/integration/connector` —— `- **ETL Pipeline** (automation/etl.zod.ts) - …`
+- `references/shared/mapping` —— `- Integration connectors (integration/connector.zod.ts)` 与 `- External lookups (data/external-lookup.zod.ts)`
+
+现在删掉这对前后瞻,它们原本想守的不变量交还给 tokenizer 守。读者可见的变化就是上面
+四处从纯文本变成可点的站内链接,路由分别指向 `/docs/references/integration/connector`、
+`/docs/references/automation/etl`、`/docs/references/data/external-lookup` —— 三条都
+对应真实存在的页面。
+
+放宽的**实测**半径就是这四处,别无其他:在修好的生成器上重跑 `gen:docs`,231 个产物
+里 3 个文件、4 行发生变化。渲染成链接的前提没有放宽 —— 目标没有页面的路径照旧回退成
+代码段,所以括号位置永远不会产出 404。

--- a/content/docs/references/automation/etl.mdx
+++ b/content/docs/references/automation/etl.mdx
@@ -13,7 +13,7 @@ Inspired by modern data integration platforms like Airbyte, Fivetran, and Apache
 retired in #4738 — narrative-only, zero consumers; see
 `packages/spec/docs/SYNC_ARCHITECTURE.md`):
 - **ETL Pipeline** (THIS FILE) - Data engineers - Aggregate 10 sources to warehouse
-- **Enterprise Connector** (integration/connector.zod.ts) - System integrators - Full SAP integration; connector-attached sync via `syncConfig`
+- **Enterprise Connector** ([integration/connector.zod.ts](/docs/references/integration/connector)) - System integrators - Full SAP integration; connector-attached sync via `syncConfig`
 
 ETL pipelines enable automated data synchronization between systems, transforming
 data as it moves from source to destination.

--- a/content/docs/references/integration/connector.mdx
+++ b/content/docs/references/integration/connector.mdx
@@ -14,7 +14,7 @@ and message queues through a unified protocol.
 **Positioning in the sync/integration layering** (L1 "Simple Sync" was
 retired in #4738 — narrative-only, zero consumers; see
 `packages/spec/docs/SYNC_ARCHITECTURE.md`):
-- **ETL Pipeline** (automation/etl.zod.ts) - Data engineers - Aggregate 10 sources to warehouse
+- **ETL Pipeline** ([automation/etl.zod.ts](/docs/references/automation/etl)) - Data engineers - Aggregate 10 sources to warehouse
 - **Enterprise Connector** (THIS FILE) - System integrators - Full SAP integration; connector-attached sync via `syncConfig`
 
 **SCOPE: Most comprehensive integration layer.**

--- a/content/docs/references/integration/connector.mdx
+++ b/content/docs/references/integration/connector.mdx
@@ -18,11 +18,43 @@ retired in #4738 — narrative-only, zero consumers; see
 - **Enterprise Connector** (THIS FILE) - System integrators - Full SAP integration; connector-attached sync via `syncConfig`
 
 **SCOPE: Most comprehensive integration layer.**
-Includes authentication, webhooks, rate limiting, field mapping, bidirectional sync,
+Includes authentication, webhooks, field mapping, bidirectional sync,
 retry policies, and complete lifecycle management.
 
 This protocol supports multiple authentication strategies, bidirectional sync,
-field mapping, webhooks, and comprehensive rate limiting.
+field mapping, webhooks, and comprehensive retry and resilience policies.
+
+## What this layer does NOT provide
+
+**There is no outbound rate limiting.** This header used to advertise "rate
+limiting" twice — once in the SCOPE line, once as "comprehensive rate limiting" —
+and no engine ever backed either. `connector.rateLimitConfig`, and the entire
+`ConnectorRateLimitConfig` / `RateLimitStrategy` shape behind it, was removed in
+`@objectstack/spec` 17.0.0 (#4911, ADR-0049 D2), because **no outbound
+rate-limiting engine ever existed**. The platform's only token bucket (runtime
+`security/rate-limit.ts`) throttles **INBOUND** requests *to* us; nothing throttles
+the calls a connector makes *out*. Do **not** substitute `shared`'s
+`RateLimitConfig` — that is the inbound limiter and would cap the wrong direction.
+**Until an outbound throttle exists, rate-limit at the connector provider or
+upstream gateway.** What L3 does declare for a rate-limited upstream is
+`retryConfig` — whose `retryableStatusCodes` default `[408, 429, 500, 502, 503,
+504]` includes `429` — and `health.circuitBreaker`. The full removal reasoning is
+recorded at the removal site: the "REMOVED: outbound rate limiting" block in
+`integration/connector.zod.ts`, and `packages/spec/docs/SYNC_ARCHITECTURE.md`.
+
+**Field mapping does not transform values.** This header used to offer "field
+mapping and transformations"; only the first half was ever true.
+`ConnectorFieldMappingSchema` extends the base mapping with exactly three keys —
+`dataType`, `required` and `syncMode`. `FieldMapping.transform` was removed in
+`@objectstack/spec` 17.0.0 (#5552, ADR-0049), and the whole `FieldMappingTransform`
+union went with it (`constant` / `cast` / `lookup` / `javascript` / `map`) — **no
+runtime ever executed any of the five**. An L3 connector mapping moves a value from
+`source` to `target`; it does not compute one. **Value conversion belongs on a
+surface that runs it:** the import mapping's own `mapping.fieldMapping[].transform`
+(`data/mapping.zod.ts` — a string enum,
+`none`/`constant`/`map`/`split`/`join`/`lookup`, with its settings in `params`),
+applied row by row by the REST import path — or an ETL transformation step
+(L2 above). Already authored the retired key? `os migrate meta --from 16` rewrites it.
 
 ## Runtime contract — descriptor vs. registered connector (#2612)
 
@@ -52,8 +84,8 @@ Authentication is now imported from the canonical `auth/config.zod.ts`.
 **Use Enterprise Connector when:**
 - Building enterprise-grade connectors (e.g., Salesforce, SAP, Oracle)
 - Complex OAuth2/SAML authentication required
-- Bidirectional sync with field mapping and transformations
-- Webhook management and rate limiting required
+- Bidirectional sync with field mapping (`dataType` / `syncMode` per field — it moves values, it does not transform them)
+- Webhook management required
 - Full CRUD operations and data synchronization
 - Need comprehensive retry strategies and error handling
 

--- a/content/docs/references/shared/mapping.mdx
+++ b/content/docs/references/shared/mapping.mdx
@@ -13,8 +13,8 @@ This module provides the canonical field mapping schema used across
 ObjectStack for data synchronization.
 
 **Use Cases:**
-- Integration connectors (integration/connector.zod.ts)
-- External lookups (data/external-lookup.zod.ts)
+- Integration connectors ([integration/connector.zod.ts](/docs/references/integration/connector))
+- External lookups ([data/external-lookup.zod.ts](/docs/references/data/external-lookup))
 
 @example Basic field mapping
 ```typescript

--- a/packages/spec/scripts/file-description.test.ts
+++ b/packages/spec/scripts/file-description.test.ts
@@ -554,6 +554,112 @@ describe('renderFileDescription — #6229: a bare path keeps its `../` prefix in
 });
 
 /**
+ * #6420 — a path an author wrote in PARENTHESES is prose, not a link.
+ *
+ * The rewriter carried a lookaround pair, `(?<!\()` … `(?!\))`, from before the
+ * tokenizer existed. Its job was "do not touch a path that is already a link's
+ * destination", because `](route)` puts that path between exactly those two
+ * characters. It never could state that (lookaround cannot say "not nested
+ * inside a link" — the module comment is explicit), and since #6136 it has had
+ * nothing left to state: a formed link is a `link` run and this step is only
+ * ever shown `text` runs. What the pair still did was refuse every path an
+ * author had put in ordinary parentheses, which is neither a link nor code —
+ * so those paths rendered as bare text on three published pages:
+ *
+ *   automation/etl.mdx:16        `- **Enterprise Connector** (integration/connector.zod.ts) - …`
+ *   integration/connector.mdx:17 `- **ETL Pipeline** (automation/etl.zod.ts) - …`
+ *   shared/mapping.mdx:16-17     `- Integration connectors (integration/connector.zod.ts)` (+ external-lookup)
+ *
+ * MEASURED (reverse verification), the ordinary direction: putting either
+ * guard back turns the four parenthesised cases below red — the two-sided pair
+ * and each half on its own, since a path in `(…)` trips both — while the
+ * unparenthesised cases and the whole #6229 block above stay green. Restoring
+ * them also leaves `keeps a formed link's destination out of reach` green,
+ * which is the point of that case: it is the tokenizer that holds the
+ * invariant now, so removing the guards cannot re-open #6136.
+ *
+ * Corpus-wide the widening is exactly those four positions and nothing else
+ * (`gen:docs` on the fixed generator: 231 files, 3 changed, 4 lines), and all
+ * three routes it newly emits resolve to a real page.
+ */
+describe('renderFileDescription — #6420: a bare path in parentheses still links', () => {
+  const ctx = {
+    // Mirrors `build-docs.ts`'s `sourcePathToDocsRoute`, restricted to the two
+    // categories these cases name, so an unroutable path is genuinely
+    // unroutable rather than a stand-in that resolves everything.
+    sourcePathToDocsRoute: (t: string) => {
+      const m = /(?:^|\/)(integration|automation)\/([\w-]+)\.zod\.ts$/.exec(t);
+      return m ? `/docs/references/${m[1]}/${m[2]}` : null;
+    },
+  };
+
+  const describedBy = (line: string) =>
+    renderFileDescription(['/**', ` * ${line}`, ' */', '', "import { z } from 'zod';", ''].join('\n'), ctx);
+
+  it('links a parenthesised path — the published `automation/etl` line', () => {
+    // `packages/spec/src/automation/etl.zod.ts` verbatim — the exact input
+    // behind `content/docs/references/automation/etl.mdx:16`.
+    expect(
+      describedBy('- **Enterprise Connector** (integration/connector.zod.ts) - System integrators'),
+    ).toBe(
+      '- **Enterprise Connector** ([integration/connector.zod.ts](/docs/references/integration/connector)) - System integrators',
+    );
+  });
+
+  it('links a parenthesised path that closes the line — the `shared/mapping` shape', () => {
+    // `content/docs/references/shared/mapping.mdx:16`. Distinct from the case
+    // above on purpose: there the `)` is followed by more prose, here it ends
+    // the line, and the trailing guard `(?!\))` refused both.
+    expect(describedBy('- Integration connectors (integration/connector.zod.ts)')).toBe(
+      '- Integration connectors ([integration/connector.zod.ts](/docs/references/integration/connector))',
+    );
+  });
+
+  it('keeps a `../` prefix inside the link when the path is parenthesised', () => {
+    // #6229 and this fix compose: the prefix belongs inside the link, and the
+    // parentheses stay outside it. Neither fix implies the other.
+    expect(describedBy('The layer (../integration/connector.zod.ts) is the widest.')).toBe(
+      'The layer ([../integration/connector.zod.ts](/docs/references/integration/connector)) is the widest.',
+    );
+  });
+
+  it('prints an unroutable parenthesised path as code, never as a dead link', () => {
+    // Widening the rewriter must not widen what it is willing to LINK. A path
+    // with no page still falls back to a code span, so the parentheses can
+    // never produce a 404 on the site.
+    expect(describedBy('Nothing here (nowhere/absent.zod.ts) resolves.')).toBe(
+      'Nothing here (`nowhere/absent.zod.ts`) resolves.',
+    );
+  });
+
+  it('still links the same path outside parentheses — the fix widens, it does not move', () => {
+    // The vacuity guard for the four cases above. Each of them asserts an
+    // OUTPUT for a path in parentheses; if this `ctx` had stopped resolving
+    // that path, the parenthesised cases could have been written around a
+    // code-span fallback and passed while proving nothing. Pinning the same
+    // path unparenthesised fixes the only variable to the parentheses.
+    expect(describedBy('The layer integration/connector.zod.ts is the widest.')).toBe(
+      'The layer [integration/connector.zod.ts](/docs/references/integration/connector) is the widest.',
+    );
+  });
+
+  it('keeps a formed link destination out of reach — the tokenizer, not the guards', () => {
+    // The case the deleted lookaround was actually written for, and the reason
+    // deleting it is safe. A titled `{@link}` whose target has no page emits
+    // `[label](../nowhere/absent.zod.ts)`: the raw path is now a link
+    // DESTINATION, sitting between the very `(` and `)` the guards tested for.
+    // With them gone the only thing standing between that path and a second
+    // rewrite is #6136's tokenizer, which classifies the whole construct as a
+    // `link` run this step is never shown. Were that protection to regress,
+    // this case reports `[the fallback](\`../nowhere/absent.zod.ts\`)` — the
+    // #6136 shape — while every other case here stays green.
+    expect(describedBy('See {@link ../nowhere/absent.zod.ts|the fallback} for now.')).toBe(
+      'See [the fallback](../nowhere/absent.zod.ts) for now.',
+    );
+  });
+});
+
+/**
  * The corpus half: re-derive the verdict from the real sources, so the six
  * pages the issue measured cannot silently re-acquire a wrong opening, and so a
  * NEW file that puts a helper above its schemas is caught here rather than on
@@ -786,6 +892,32 @@ describe('corpus — every rendered description is well-formed markdown', () => 
     for (const { rel, out } of described) {
       const stranded = out.match(/(?:\.\.\/)+[[`]/);
       if (stranded) offenders.push(`${rel}: ${stranded[0]}`);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('never leaves a bare source path sitting in parentheses (#6420)', () => {
+    // The corpus half of the unit block above. A path this step CAN match —
+    // one with a category segment, `(?:\.\./)*<dir>/<file>.zod.ts` — must never
+    // reach a page still bare: it is a link when a page renders it and a code
+    // span when none does, and "plain text between parentheses" is the one
+    // outcome the lookaround pair used to force. Scanned on the rendered
+    // fragment rather than on the emitted `.mdx` for the same reason the rest
+    // of this file is: `check:docs` reproduces the artifact faithfully and so
+    // stayed green through all three published symptoms.
+    //
+    // Only the head character is examined, not a full `(…)` pair: `- Integration
+    // connectors (integration/connector.zod.ts)` and `(…) - System integrators`
+    // are different closers and both were victims, so what identifies the class
+    // is a `(` immediately before the path. A path that follows `](` is a link
+    // destination and belongs there — the tokenizer put it there.
+    const offenders: string[] = [];
+    for (const { rel, out } of described) {
+      for (const line of withoutFences(out).split('\n')) {
+        const bare = line.replace(/`[^`]*`/g, ''); // a code span is the null-route fallback
+        const hit = /(^|[^\]])\((?:\.\.\/)*[\w-]+\/[\w.-]+\.zod\.ts/.exec(bare);
+        if (hit) offenders.push(`${rel}: ${hit[0].trim()}`);
+      }
     }
     expect(offenders).toEqual([]);
   });

--- a/packages/spec/scripts/lib/file-description.ts
+++ b/packages/spec/scripts/lib/file-description.ts
@@ -386,8 +386,21 @@ function renderProse(text: string, ctx: FileDescriptionContext): string {
   // `*` without moving the `\b` changes nothing, since a group that is never
   // reached repeats zero times either way. Both halves are load-bearing —
   // moving the `\b` alone would still strand the outer level of a `../../`.
+  //
+  // No lookaround guards the parentheses any more (#6420). The pair `(?<!\()`
+  // … `(?!\))` was this step's ORIGINAL, pre-tokenizer attempt at "do not touch
+  // a path that is already a link's destination" — `](route)` puts that path
+  // between exactly those two characters. It never could express that (the
+  // module comment above says why: lookaround cannot say "not nested inside a
+  // link"), and since #6136 it has had nothing left to do — a formed link is a
+  // `link` run and this step is only shown `text` runs. What the pair still did
+  // was refuse every path an AUTHOR wrote in parentheses, which is ordinary
+  // prose and not a link at all: `- **Enterprise Connector**
+  // (integration/connector.zod.ts) - …` rendered as neither a link nor code,
+  // just plain text, on three published pages. So the guards go and the
+  // tokenizer keeps the invariant they were reaching for.
   out = mapProse(out, ['text'], s =>
-    s.replace(/(?<!\()((?:\.\.\/)*\b[\w-]+\/[\w.-]+\.zod\.ts)\b(?!\))/g, (_m, p: string) => {
+    s.replace(/((?:\.\.\/)*\b[\w-]+\/[\w.-]+\.zod\.ts)\b/g, (_m, p: string) => {
       const route = sourcePathToDocsRoute(p);
       return route ? `[${p}](${route})` : `\`${p}\``;
     }));


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6420

## 问题

参考页开篇那段模块描述由 `packages/spec/scripts/lib/file-description.ts` 渲染。其中把 JSDoc 里裸写的 `*.zod.ts` 路径改写成站内链接的那一步(`renderProse()`),正则两端各挂着一个前后瞻 —— 「前面不是左括号」和「后面不是右括号」。

这对前后瞻是 **tokenizer 出现之前**的产物,本意是「别去动已经是链接目标的路径」:`](route)` 恰好把那个路径夹在这两个字符中间。它从来表达不了这件事(前后瞻说不出「不在链接内部」—— 该文件模块注释里就写着这句),而 #6136 之后它更是**无事可做**:成形的链接是独立的 `link` token,这一步只会拿到 `text` token。

它**仍在**做的,是把作者自己写在**普通括号**里的每一个路径一并拒掉。那是散文,不是链接,于是这些路径既没成链接、也没回退成代码段,以**纯文本**发布在三张参考页上:

| 页面 | 原样 |
|:--|:--|
| `references/automation/etl:16` | `- **Enterprise Connector** (integration/connector.zod.ts) - …` |
| `references/integration/connector:17` | `- **ETL Pipeline** (automation/etl.zod.ts) - …` |
| `references/shared/mapping:16` | `- Integration connectors (integration/connector.zod.ts)` |
| `references/shared/mapping:17` | `- External lookups (data/external-lookup.zod.ts)` |

## 变更

删掉这对前后瞻,它们原本想守的不变量交还给 tokenizer 守。渲染成链接的**前提没有放宽** —— 目标没有页面的路径照旧回退成代码段,所以括号位置永远不会产出 404。

四处的前后对照:

```
- **Enterprise Connector** (integration/connector.zod.ts) - System integrators
+ **Enterprise Connector** ([integration/connector.zod.ts](/docs/references/integration/connector)) - System integrators
```

## 放宽的实测半径:就是这四处,别无其他

分诊座位点名这是本单最需要量出来的数,也定了一条 stop-and-report。在修好的生成器上重跑 `pnpm --filter @objectstack/spec gen:docs`:

```
✅ Generated 231 files
 content/docs/references/automation/etl.mdx        | 2 +-
 content/docs/references/integration/connector.mdx | 2 +-
 content/docs/references/shared/mapping.mdx        | 4 ++--
 3 files changed, 4 insertions(+), 4 deletions(-)
```

**231 个产物,3 个文件,4 行** —— 新成链接的位置全语料共 4 处,与 issue 点名的四处完全重合,零附带。三条新路由 `/docs/references/{integration/connector, automation/etl, data/external-lookup}` 均对应真实存在的 `.mdx`;顺带把 `content/docs/references/**` 里发出的全部 214 条站内路由逐条核了一遍,无死链(其中 14 条是分类首页,落在 `分类/index.mdx`)。

**stop-and-report 条件未触发**。

## 反向验证 —— 方向是先预言再跑的

预言:把守卫放回去,四条括号用例 + 语料条转红,其余全绿。实测三种放法结果一致:

| 放回的东西 | 结果 |
|:--|:--|
| 整对前后瞻 | `Tests  5 failed \| 41 passed (46)` |
| 只放回前瞻 | `Tests  5 failed \| 41 passed (46)` |
| 只放回后瞻 | `Tests  5 failed \| 41 passed (46)` |

红的恒是同一组:四条括号用例 + 语料条。**未括号用例、#6229 整块、以及「成形链接的目标不被二次改写」那条,三种放法下全绿** —— 最后这条正是本 PR 的立论:守不变量的现在是 tokenizer,不是被删掉的守卫,所以删它不会重开 #6136。

这一点也单独量过,没有只靠推断:把 bare-path 那步的 token 白名单从「只含 text」改成「text 加 link」(即模拟 tokenizer 保护失效),#6136 的两条与这条一起转红,输出正是注释里写下的那个形状(下面去掉了 vitest 的外层引号):

```
Expected: See [the fallback](../nowhere/absent.zod.ts) for now.
Received: See [the fallback](`../nowhere/absent.zod.ts`) for now.
```

## 测试

`packages/spec/scripts/file-description.test.ts` 新增 6 条单测(与 #6229 的 7 条并列)+ 1 条语料级断言:

- 括号内路径成链接 —— `automation/etl` 已发布那行的逐字输入;
- 括号收尾于行末 —— `shared/mapping` 形状(与上一条的闭合方式不同,后瞻两者都拒);
- 括号内带 `../` 前缀 —— #6229 与本单可组合;
- 括号内**无路由**路径回退成代码段,绝不发死链;
- **反空过守卫**:同一条路径在括号外仍成链接,把唯一变量钉死在括号上(否则前四条大可围着代码段回退去写,写成全绿却什么都没证明);
- **成形链接的目标不被二次改写** —— 被删守卫真正的用意所在,现由 tokenizer 承担;
- 语料级:凡本步能匹配的路径,不得以裸文本留在括号里(在**渲染结果**上判,不读 `.mdx` —— `check:docs` 会忠实复制产物,三处已发布症状正是这样一路绿过来的)。

## 与在飞 #6473 的同页相撞

#6473(#6383)在本单实施途中于 01:38Z 落地,与本单同改 `content/docs/references/integration/connector.mdx`。⛔ **未做文本合并**:合 `main` 后在**合并树上**整体重跑 `gen:schema` 与 `gen:docs`(#4675 第四步,#6224 / #5552 有先例)。仓库自带的 regen merge driver 也正是这样拒绝文本合并并给出这条指令的。`packages/spec/src/integration/connector.zod.ts` 本单**一字未碰**。

合并后同页**实测**两侧效果俱在:#6473 的「What this layer does NOT provide」一节在第 27-43 行;本单的第 17 行已成链接。并逐行复核 #6473 新增散文里的路径(第 43 / 54 / 80 / 106 / 113 行)全在反引号内,是 `code` token,本单放宽够不着 —— 此处为实测,非假定。

## 门禁(全部前台执行,持容器级 `flock` 锁,`--filter` 限定范围)

在**合并后**的树上:

```
pnpm --filter @objectstack/spec test            → Test Files 339 passed (339) / Tests 8706 passed (8706)
pnpm --filter @objectstack/spec typecheck       → tsc --noEmit + check:scripts-typecheck + check:test-typecheck 全绿
pnpm --filter @objectstack/spec check:docs      → 231 generated files in sync with packages/spec
pnpm --filter @objectstack/spec check:generated → All 10 generated artifacts are up to date
node scripts/check-nul-bytes.mjs                → OK(6095 tracked text files,无裸 ASCII 控制字节)
pnpm docs:build                                 → 全语料 MDX 编译通过,390+ 路由预渲染
eslint(两个改动文件,--no-inline-config)         → exit 0
check:doc-authoring / docs-audit-scope / role-word / quick-reference-counts
  / empty-changeset / release-notes / adr-anchors → 全 PASS
```

`Tests 8706` 对得上账:`main` 上是 8699,本单新增 6 + 1 = 7 条。

`check:generated` 首跑曾报 `api-surface/` 陈旧 —— 那是**新 worktree 未 build 的假红**(`gen:api-surface` 直接以 `Could not resolve module symbol … Is the package built?` 失败)。`pnpm --filter @objectstack/spec build` 后复跑 10 项全绿,`api-surface/` 一个字节未变 —— 本单不碰 `packages/spec/src`,结构上不可能影响它。

另在构建产物里核了终态:`.next/server/app/en/docs/references/shared/mapping.html` 与 `automation/etl.html` 里,这几处已是真正的 `a href` 锚点。

## 交付物取舍

- 带 **changeset(`patch`,`@objectstack/spec`)**:有读者可见的产物 —— 三张已发布参考页上四处纯文本变成可点链接。
- ⛔ **未碰 `content/docs/releases/`**。
- 生成物为 `gen:docs` 纯输出,**未手改一个字节**;源码修改与重生成分属不同 commit(合并树上的重跑再单列一个)。

## 顺带扫出、未在本 PR 修

**#6484** —— 同目录裸路径(无分类段,如 `auth.zod.ts`)从来不成链接:改写正则与 `sourcePathToDocsRoute()` 两侧都要求路径里有一个 `/`,所以这类路径带不带括号都以纯文本落地。实测模块描述管线内 9 处 / 4 张已发布页,另有 2 处在 schema 级 description 那条别的管线里。已按 Prime Directive #10 独立立单(未认领、未打标,留给分诊),**不在本 PR 内顺手修** —— 它要动的是 `FileDescriptionContext` 的入参契约,本单一个字节都不碰那个接口。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZgRyPVwi1jLb1mNNuUQ9o
