### PR TITLE
fix(lint): remove the `primaryField` phantom key from both title-face rules (#6326)

### DIFF
--- a/.changeset/lint-primaryfield-phantom-key-removed.md
+++ b/.changeset/lint-primaryfield-phantom-key-removed.md
@@ -1,0 +1,44 @@
+---
+"@objectstack/lint": patch
+---
+
+fix(lint): 摘掉 `primaryField` 这个幽灵键——两条规则不再把它当作标题面(#6326)
+
+`primaryField` 在 `packages/spec` 里**没有任何声明**。实测(`17.0.0-rc.5` dist):
+
+```
+ObjectSchema.safeParse({ name: 'probe_obj', label: 'Probe', primaryField: 'code',
+                         fields: { code: { type: 'text', label: 'Code' } } })
+// => success: false
+// => issues: [{ code: 'unrecognized_keys', keys: ['primaryField'], path: [] }]
+
+ObjectSchema.create(/* 同上 */)
+// => throws: ObjectSchema.create('probe_obj'): unknown key(s) — primaryField.
+```
+
+同一形状换成 `nameField: 'code'` 则 `safeParse` 通过。也就是说,这个键**从来不是可声明面**,
+而三处消费者没跟上——两面同源,却各自有一个可达面:
+
+- **文档面(作者会照做,当下活着的那一半)**:`skills/objectstack-data/SKILL.md` 是 AI 编写
+  元数据时读的技能文档,它把 `primaryField` 明说成 `object/missing-name-field` 的合法逃逸口。
+  照它写出来的对象在 `ObjectSchema.create()` 上被 ADR-0032「不静默丢弃未知键」的闸硬拒——
+  **这是在教 AI 写出必然失败的元数据。**
+- **规则面(判定永不成立)**:`data-model-rules.ts` 的 `!!obj.primaryField` 一支,以及
+  `validate-semantic-roles.ts` 标题解析链里的那一项,对任何 schema 收得下的对象恒为 false,
+  属于 #4984 家族的死支——看起来在保护什么,实际什么都判不到。
+
+本次按维护者裁定 **remove,不 declare**(`nameField` 已是 ADR-0079 的规范主标题指针,
+再立一个平行指针没有拉力,且与 Prime Directive #7「One Zod source per metadata type」相悖):
+
+- `data-model-rules.ts`:`object/missing-name-field` 的谓词收敛为
+  `!!obj.nameField || fields.some(name-like)`;
+- `validate-semantic-roles.ts`:规则 (d) 的标题解析链收敛为
+  `[nameField, displayNameField]`(`displayNameField` 实测可声明,保留);
+- `skills/objectstack-data/SKILL.md`:该规则的表述改为只点名作者真正能声明的面——
+  `nameField` 与 name-like 字段(并列出这七个名字)。
+
+**零 `packages/spec` 改动,不需要迁移:`primaryField` 从来不是可声明键,写了它的对象在
+schema 上本来就发布不了,所以没有任何能工作的 app 会因此回归。** 行为上唯一的变化是:
+一个只靠 `primaryField` 充当标题面的对象,现在会新得一条 `object/missing-name-field`
+的 suggestion(severity 为 suggestion,不失败命令)——而这类对象本就通不过 `ObjectSchema`。
+真正的修法是改声明 `nameField`。

--- a/packages/cli/test/data-model-rules.test.ts
+++ b/packages/cli/test/data-model-rules.test.ts
@@ -133,9 +133,23 @@ describe('lintDataModel — fields & objects', () => {
     expect(has(issues, 'object/missing-name-field')).toBe(true);
   });
 
-  it('accepts an object with a name field or primaryField', () => {
+  // #6326 replaced the second assertion here wholesale. It used to read
+  // `{ name: 'b', primaryField: 'code', fields: { code: … } }` and claim to pin
+  // the `primaryField` limb of `object/missing-name-field`. It pinned nothing,
+  // in two independent ways: (1) the fixture is one `ObjectSchema` REJECTS
+  // (`unrecognized_keys: ['primaryField']`), so no author could ever write the
+  // shape it was green about; and (2) `code` is itself in NAME_LIKE_FIELDS, so
+  // the name-like limb accepted the object regardless — the assertion stayed
+  // green with the `primaryField` limb deleted, which is exactly what makes it
+  // a vacuous green rather than coverage. What SURVIVES is the first assertion
+  // (a name-like field is a title face). The replacement below pins the limb
+  // that actually exists — the explicit `nameField` pointer — on a fixture no
+  // other limb can rescue, so it can genuinely fail.
+  it('accepts an object with a name-like field, or an explicit nameField', () => {
     expect(has(lintDataModel([{ name: 'a', fields: { name: { type: 'text' } } }]), 'object/missing-name-field')).toBe(false);
-    expect(has(lintDataModel([{ name: 'b', primaryField: 'code', fields: { code: { type: 'text' } } }]), 'object/missing-name-field')).toBe(false);
+    // `invoice_number` is deliberately NOT in NAME_LIKE_FIELDS: the explicit
+    // ADR-0079 pointer is the only thing that can clear this object.
+    expect(has(lintDataModel([{ name: 'b', nameField: 'invoice_number', fields: { invoice_number: { type: 'text' } } }]), 'object/missing-name-field')).toBe(false);
   });
 
   it('handles array-shaped fields', () => {
@@ -186,25 +200,32 @@ describe('lintDataModel — object/missing-name-field (ADR-0079 title face)', ()
     expect(has(issues, 'object/missing-name-field')).toBe(true);
   });
 
-  // (c) The two untouched limbs, isolated from each other: neither fixture
-  // carries a field name that the other limb would also rescue.
-  it('leaves the primaryField and name-like limbs unchanged', () => {
+  // (c) #6326 — `primaryField` is NOT a title face, and the limb that read it
+  // is gone. The key is declared nowhere in `packages/spec`: measured on
+  // 17.0.0-rc.5, `ObjectSchema.safeParse` returns
+  // `unrecognized_keys: ['primaryField']` and `ObjectSchema.create()` throws,
+  // so the limb was dead for every object the spec accepts (#4984 family)
+  // while still reading, here and in the skill doc, as a legal escape hatch.
+  //
+  // This fixture is DELIBERATELY off-spec — that is the point. `lintDataModel`
+  // runs over metadata as AUTHORED, before/independently of schema parse, so a
+  // rejected key can physically reach it; the assertion is that the rule
+  // IGNORES the key, not that the key is legal. Do not "fix" the fixture by
+  // making it schema-valid: that would delete the coverage.
+  //
+  // Asserted as the EXACT reported set rather than as the absence of a string,
+  // so it fails in both directions: put the `primaryField` limb back and
+  // `objects[0]` drops out (set becomes `[]`); break the name-like limb and
+  // `objects[1]` joins it. `period_key` is not in NAME_LIKE_FIELDS and carries
+  // no `nameField`, so nothing else can rescue objects[0]; `crm_campaign` has
+  // a `name` field and must stay clean.
+  it('does not treat primaryField as a title face — it is not a declarable key (#6326)', () => {
     expect(
-      has(
-        lintDataModel([
-          { name: 'crm_forecast_period', primaryField: 'period_key', fields: { period_key: { type: 'text' } } },
-        ]),
-        'object/missing-name-field',
-      ),
-    ).toBe(false);
-    expect(
-      has(
-        lintDataModel([
-          { name: 'crm_campaign', fields: { name: { type: 'text' }, budget: { type: 'currency' } } },
-        ]),
-        'object/missing-name-field',
-      ),
-    ).toBe(false);
+      flagged([
+        { name: 'crm_forecast_period', primaryField: 'period_key', fields: { period_key: { type: 'text' } } },
+        { name: 'crm_campaign', fields: { name: { type: 'text' }, budget: { type: 'currency' } } },
+      ]),
+    ).toEqual(['objects[0].fields']);
   });
 
   // (d) DELIBERATE FLIP, not a regression: a titleFormat-only object is now
@@ -241,8 +262,16 @@ describe('lintDataModel — object/missing-name-field (ADR-0079 title face)', ()
   // The suggestion must name the canonical pointer — an author who reads it
   // and reaches for `titleFormat` lands straight back in the contradiction.
   // It must equally NOT name `primaryField`: that key is declared nowhere in
-  // `packages/spec`, so `ObjectSchema.create()` rejects it (#6326). The
-  // predicate still reads the limb; the diagnostic must not advertise it.
+  // `packages/spec`, so `ObjectSchema.create()` rejects it (#6326).
+  //
+  // ⚠️ Honest labelling of the `not.toContain('primaryField')` line: it is a
+  // NEGATIVE assertion and it was already green before #6326 (PR for #6108 had
+  // scrubbed the message text; #6326 only removed the predicate limb, which
+  // this message never mentioned). It is NOT evidence of the removal — the
+  // real pin for that is case (c) above. It is kept because it is paired with
+  // the three positive assertions below, which fail if the message stops
+  // steering to `nameField`/ADR-0079 at all; on its own it would be a bare
+  // vacuous green.
   it('steers the author to nameField, and names no key the schema rejects', () => {
     const issue = lintDataModel([
       { name: 'crm_quote_line_item', fields: { quantity: { type: 'number' } } },

--- a/packages/lint/src/data-model-rules.ts
+++ b/packages/lint/src/data-model-rules.ts
@@ -392,22 +392,23 @@ export function lintDataModel(objects: any[]): LintIssue[] {
     // Reading `titleFormat` while ignoring `nameField` made this rule
     // contradict its own package (#6108): an author who followed the platform's
     // own migration advice earned a "records will display as raw IDs"
-    // suggestion, while one who kept the retired key did not. `primaryField`
-    // and the name-like derivation are unchanged.
+    // suggestion, while one who kept the retired key did not. The name-like
+    // derivation is unchanged.
     //
-    // `primaryField` is kept as-is, but do NOT read it as evidence that the key
-    // is authorable: measured on 17.0.0-rc.5, `ObjectSchema.safeParse` reports
-    // `unrecognized_keys: ['primaryField']` and `ObjectSchema.create()` rejects
-    // it outright, so this limb can never be true for an object the spec
-    // accepts. Filed as #6326 (it is declared nowhere in `packages/spec`, yet
-    // this rule, `validate-semantic-roles` and the objectstack-data skill doc
-    // all treat it as a title face) — removing the limb is that issue's call,
-    // not a rider here. The MESSAGE, however, must not advertise it: telling an
-    // author to reach for `primaryField` earns them a hard schema rejection, so
-    // the diagnostic names only the surfaces they can actually declare.
+    // A third limb, `!!obj.primaryField`, was REMOVED here in #6326. That key
+    // is declared nowhere in `packages/spec`: measured on 17.0.0-rc.5,
+    // `ObjectSchema.safeParse` reports `unrecognized_keys: ['primaryField']`
+    // and `ObjectSchema.create()` rejects it outright, so the limb could never
+    // be true for an object the spec accepts — a #4984-family dead branch that
+    // nonetheless read as a title face here, in `validate-semantic-roles` and
+    // in the objectstack-data skill doc. The maintainer ruled remove, not
+    // declare: `nameField` is ADR-0079's one canonical title pointer and a
+    // second parallel pointer contradicts "one Zod source per metadata type"
+    // (Prime Directive #7). Do not reintroduce it as a tolerated alias — a
+    // consumer-side `??` for a key the producer rejects is exactly the second
+    // de-facto contract Prime Directive #12 bans.
     const hasNameField =
       !!obj.nameField ||
-      !!obj.primaryField ||
       fields.some((f) => NAME_LIKE_FIELDS.includes(f.name));
     if (fields.length > 0 && !hasNameField) {
       issues.push({

--- a/packages/lint/src/validate-semantic-roles.test.ts
+++ b/packages/lint/src/validate-semantic-roles.test.ts
@@ -128,6 +128,66 @@ describe('validateSemanticRoles (ADR-0085)', () => {
     expect(hiddenMember.map((f) => f.rule)).toEqual([FIELD_GROUP_SHADOWED]);
   });
 
+  // #6326 — rule (d)'s title resolution used to read
+  // `[nameField, primaryField, displayNameField]`. `primaryField` is declared
+  // NOWHERE in `packages/spec`: measured on 17.0.0-rc.5,
+  // `ObjectSchema.safeParse` returns `unrecognized_keys: ['primaryField']` and
+  // `ObjectSchema.create()` throws, so the entry could never match on an object
+  // the spec accepts, while advertising a title pointer authors cannot write.
+  // `nameField` is ADR-0079's canonical one; the entry is gone.
+  //
+  // The fixture is DELIBERATELY off-spec — that is what is under test.
+  // `validateSemanticRoles` lints metadata as AUTHORED, so a schema-rejected
+  // key can physically reach it; the assertion is that it is IGNORED. Do not
+  // make the fixture schema-valid: that deletes the coverage.
+  //
+  // The pair below is the discriminating one. Title resolution matters here
+  // because the title is filtered OUT of the 4-entry strip, so whether
+  // `ref_no` counts as the title decides whether entry #5 (`d`) lands inside
+  // the strip. Read as the title → strip is [a,b,c,d], group "tail" (only
+  // member `d`) is fully hidden → SHADOWED. Not read → strip is
+  // [ref_no,a,b,c], `d` still renders → clean. No field here is one of the
+  // conventional fallbacks (name/full_name/title/subject/display_name), and
+  // none is an injected system column, so nothing else can supply a title.
+  it('ignores primaryField in title resolution; nameField still resolves (#6326)', () => {
+    const withPhantomKey = validateSemanticRoles(stack([{
+      name: 'ledger_entry',
+      primaryField: 'ref_no',
+      highlightFields: ['ref_no', 'a', 'b', 'c', 'd'],
+      fieldGroups: [{ key: 'tail', label: 'Tail' }],
+      fields: {
+        ref_no: { type: 'text' }, a: { type: 'text' }, b: { type: 'text' },
+        c: { type: 'text' }, d: { type: 'text', group: 'tail' },
+      },
+    }]));
+    // Goes red the moment the `primaryField` entry returns to the chain:
+    // `ref_no` would become the title, `d` would fall inside the strip, and
+    // one FIELD_GROUP_SHADOWED finding would appear.
+    expect(withPhantomKey).toEqual([]);
+
+    // Paired positive — the SAME shape with the one declarable pointer. This
+    // proves the assertion above is about `primaryField` being ignored, not
+    // about the rule being inert on this fixture.
+    const withNameField = validateSemanticRoles(stack([{
+      name: 'ledger_entry',
+      nameField: 'ref_no',
+      highlightFields: ['ref_no', 'a', 'b', 'c', 'd'],
+      fieldGroups: [{ key: 'tail', label: 'Tail' }],
+      fields: {
+        ref_no: { type: 'text' }, a: { type: 'text' }, b: { type: 'text' },
+        c: { type: 'text' }, d: { type: 'text', group: 'tail' },
+      },
+    }]));
+    // Indexed rather than `.map((f) => f.rule)` on purpose: this file's
+    // relative import of the module under test omits the `.js` extension, so
+    // under NodeNext every symbol it names degrades to `any` (TS2835) and each
+    // callback over a finding adds a TS7006 to the package's TEST_DEBT ledger.
+    // Same assertion strength, no new ledger entry.
+    expect(withNameField).toHaveLength(1);
+    expect(withNameField[0]?.rule).toBe(FIELD_GROUP_SHADOWED);
+    expect(withNameField[0]?.message).toContain('tail');
+  });
+
   it('flags stageField pointing at a missing field; false is fine', () => {
     const bad = validateSemanticRoles(stack([{
       name: 'lead', stageField: 'pipeline', fields: { status: {} },

--- a/packages/lint/src/validate-semantic-roles.ts
+++ b/packages/lint/src/validate-semantic-roles.ts
@@ -185,9 +185,15 @@ export function validateSemanticRoles(stack: AnyRec): SemanticRoleFinding[] {
     );
     if (declaredStrings.length > 0 && declaredGroups.size > 0) {
       // Mirror the renderer's title resolution: declared role first
-      // (nameField / primaryField / deprecated displayNameField), else the
-      // first conventional display-field name present on the object.
-      const declaredTitle = [obj.nameField, obj.primaryField, obj.displayNameField]
+      // (nameField, else the deprecated displayNameField), else the first
+      // conventional display-field name present on the object.
+      //
+      // `primaryField` sat between those two until #6326 removed it. It is
+      // declared nowhere in `packages/spec` — `ObjectSchema` rejects it with
+      // `unrecognized_keys` — so the entry could never match on an object the
+      // spec accepts, and reading it here advertised a title pointer authors
+      // cannot write. `nameField` is ADR-0079's canonical one.
+      const declaredTitle = [obj.nameField, obj.displayNameField]
         .find((v): v is string => typeof v === 'string' && v.length > 0 && fieldNames.has(v));
       const titleField = declaredTitle
         ?? ['name', 'full_name', 'title', 'subject', 'display_name'].find((c) => fieldNames.has(c));

--- a/skills/objectstack-data/SKILL.md
+++ b/skills/objectstack-data/SKILL.md
@@ -998,7 +998,7 @@ Data-model rules (in addition to naming/label/i18n):
 | `relationship/association-inline-edit` | warning | an association (comment/audit/activity) marked `inlineEdit` (clutters the parent form — use a detail-page related list) |
 | `rollup/missing-summary` | suggestion | a parent of numeric master_detail children with no roll-up `summary` |
 | `field/select-missing-options` | warning | a `select`/`multiselect`/`radio` with no `options` (or options source) |
-| `object/missing-name-field` | suggestion | an object with no name/title field or `primaryField` |
+| `object/missing-name-field` | suggestion | an object with no `nameField` (ADR-0079's canonical title pointer) and no name-like field (`name`/`title`/`subject`/`label`/`full_name`/`display_name`/`code`) |
 
 These same rules are the **rubric for AI-generated metadata** — a generation is
 "good" exactly when it is schema-valid and lint-clean:


### PR DESCRIPTION
Fixes #6326

按 2026-08-07 17:00Z 的**维护者裁定：remove，不 declare**。`nameField` 已是 ADR-0079 的规范主标题指针，再立一个平行指针没有拉力，且与 Prime Directive #7「One Zod source per metadata type」相悖。**本 PR 零 `packages/spec` 改动。**

## 一、先复核前提：幽灵键确认仍然成立

在本 worktree 现场重跑了 issue 里那段探针（`packages/spec` 现场构建，17.0.0-rc.5）：

```
--- primaryField: safeParse ---
success: false
issues: [
  {
    "code": "unrecognized_keys",
    "keys": [ "primaryField" ],
    "path": [],
    "message": "Unrecognized key(s) on this object: `primaryField`. ..."
  }
]
--- primaryField: create() ---
create() threw: ObjectSchema.create('probe_obj'): unknown key(s) — primaryField.
  • `primaryField` is not an ObjectSchema field.
--- control: nameField safeParse ---
success: true
--- control: displayNameField safeParse ---
success: true
```

结论：`primaryField` 仍被硬拒；`nameField` 与 `displayNameField` 同形状均通过——所以标题链里**只摘 `primaryField` 一项**，`displayNameField` 是真实可声明面，保留。

## 二、四处文件面（行号已在 `origin/main` 上逐一复核，均已位移）

派发单给的行号来自分诊时的读数，#6108 的 PR 落地后已经全部前移，下面是实际行号。

| 文件 | 派发单行号 | 实际行号 | 改动 |
|---|---|---|---|
| `packages/lint/src/data-model-rules.ts` | `:384` / `:391` | `:410`（谓词）/ `:398-407`（注释） | 摘掉 `!!obj.primaryField ||` 一支，谓词收敛为 `!!obj.nameField \|\| fields.some(name-like)`；注释改为记录「已移除」及不得以 `??` 别名复活的理由 |
| `packages/lint/src/validate-semantic-roles.ts` | `:190` | `:190` ✔ | 规则 (d) 标题解析链由 `[nameField, primaryField, displayNameField]` 收敛为 `[nameField, displayNameField]` |
| `skills/objectstack-data/SKILL.md` | `:1001` | `:1001` ✔ | 规则表该行改为只点名真实可声明面 |
| `packages/cli/test/data-model-rules.test.ts` | `:136-138` | `:136-139` ✔（另有 `:191-208`、`:243-252` 两处同源） | 见下节 |

`:391` 那条「author-facing message」经复核**在本 PR 前已经不含 `primaryField`**——#6108 的 PR 已把文案收敛过了，本 PR 只动谓词。

**文档面是当下活着的那一半。** `skills/objectstack-data/SKILL.md` 是 AI 编写元数据时读的技能文档，旧文案把 `primaryField` 明说成这条规则的合法逃逸口，等于**在教 AI 写出 `ObjectSchema.create()` 必然硬拒的元数据**。改后：

```
| `object/missing-name-field` | suggestion | an object with no `nameField` (ADR-0079's canonical
title pointer) and no name-like field (`name`/`title`/`subject`/`label`/`full_name`/`display_name`/`code`) |
```

## 三、`packages/cli/test/data-model-rules.test.ts:136-139`——整条替换，并附一个额外发现

派发单要求：不要只删不补，写下幸存的半个事实。**复核后发现它比预想的更空：它是双重空绿。**

旧断言：

```ts
it('accepts an object with a name field or primaryField', () => {
  expect(has(lintDataModel([{ name: 'a', fields: { name: { type: 'text' } } }]), …)).toBe(false);
  expect(has(lintDataModel([{ name: 'b', primaryField: 'code', fields: { code: { type: 'text' } } }]), …)).toBe(false);
});
```

**它原本在钉什么**：号称钉住 `object/missing-name-field` 的 `primaryField` 一支。

**为什么是空绿——两条独立的理由**：

1. 喂的是一个 `ObjectSchema` 会拒收的 fixture（`unrecognized_keys`），它绿着的那个形状没有任何作者写得出来；
2. **更要命的一条，是本次现场量出来的**：`code` 本身就在 `NAME_LIKE_FIELDS`（`data-model-rules.ts:36` 的七个名字之一），所以这个对象**本来就被 name-like 那一支接住**。实测：

```
OLD :138 fixture {primaryField:'code', fields:{code}} -> flagged? false  → 摘掉支后仍然 GREEN（从未钉住该支）
same fixture WITHOUT primaryField at all            -> flagged? false  → 证明干活的一直是 name-like 支
isolated fixture {primaryField:'period_key'}        -> flagged? true   → 这个才真正依赖该支
```

也就是说这条断言**从来没有钉住 `primaryField` 支**，删掉该支它照样绿。

**幸存的半个事实**：第一条断言（name-like 字段即标题面）是真的，保留。

**替换后钉什么**：把第二条换成唯一真实存在的显式指针 `nameField`，且 fixture 刻意用 `invoice_number`——**不在** `NAME_LIKE_FIELDS` 里，所以没有别的支能接住它，这条断言真的能失败。

同源的另外两处：

- `:191-208`「leaves the primaryField and name-like limbs unchanged」——**整条替换**。它的判定值正好从「不报」翻成「报」，属于派发单说的第三类。改为**断言精确的上报集合**而不是某个字符串的缺席，两个方向都能红：把支放回去 `objects[0]` 掉出集合（变 `[]`），name-like 支坏掉 `objects[1]` 会加进来。
- `:243-252` 的 `not.toContain('primaryField')`——**保留，但在文件里如实标注**：它是负向断言，**在本 PR 之前就已经是绿的**（#6108 已清过文案，本 PR 只动谓词、不动文案），所以**它不是本次移除的证据**；真正的证据是上面 (c) 那条。它之所以留着，是因为它和同一个 `it` 里三条正向断言配对（`toContain('nameField')`、`fix` 含 ADR-0079 / `titleFormat`），单独存在才是裸空绿。

**新增一条 `validate-semantic-roles` 的钉子**：标题链那处**此前全仓没有任何测试**（全仓 grep 证实没有任何 fixture 声明 `primaryField` 去喂它）。新增 `ignores primaryField in title resolution; nameField still resolves (#6326)`，用的是能区分两种实现的 fixture——标题字段会被**排除**出 4 格 strip，所以 `ref_no` 算不算标题，决定了第 5 个 highlight `d` 是否落进 strip：读 `primaryField` → `d` 被藏 → 报 SHADOWED；不读 → `d` 仍渲染 → 干净。并配一条**同形状、只把键换成 `nameField`** 的正向断言，证明前一条是「`primaryField` 被忽略」而不是「规则在这个 fixture 上本来就不动」。

> 两个新 fixture 都**刻意是 off-spec 的**，这正是被测对象：`lintDataModel` / `validateSemanticRoles` 跑在**作者写下的**元数据上，早于 schema parse，所以被拒的键物理上到得了它们；断言的是「规则忽略它」，不是「这个键合法」。文件里已写明**不要**把 fixture 改成 schema-valid，那会把覆盖面删掉。

## 四、反向验证——先声明方向，再跑

方向与常规**相反**：本 PR 是**移除**一支，所以钉住移除的断言在**把支放回去**时才变红。声明写在跑之前。

| # | 声明 | 实测 | 一致 |
|---|---|---|---|
| 1 | CLI (c) 案 `does not treat primaryField as a title face` → **红**，`flagged()` 返回 `[]` 而非 `['objects[0].fields']` | 红，报文逐字为 `expected [] to deeply equal [ 'objects[0].fields' ]` | ✅ |
| 2 | semantic-roles 新钉子第一条断言 → **红**，多出一条 `FIELD_GROUP_SHADOWED` | 红，`expected [ { severity: 'warning', …(5) } ] to deeply equal []`，`path: objects[0].fieldGroups`、group `tail`、成员 `d` | ✅ |
| 3 | 同测试第二条（`nameField` 正向）→ **保持绿**（`nameField` 在链首，放不放该支都不影响） | **未被执行**：第一条断言先抛，同一个 `it` 就此中止。逻辑上必然绿，但本次 revert 下**没有观测到**，如实记录，不算已验证 | ⚠️ 部分 |
| 4 | 替换后的 `accepts an object with a name-like field, or an explicit nameField` → 保持绿 | 绿（该文件 51 条里 50 条通过，唯一红的是 (c)） | ✅ |
| 5 | `steers the author to nameField…`（含 `not.toContain`）→ 保持绿 | 绿 | ✅ |
| 6 | 旧 `:138` 断言在**摘支后**仍然绿（即它从未钉住该支） | 绿，见上节实测三行 | ✅ |

**方法学上有一处值得记下来**：第一次跑 (c) 的反向验证时它**是绿的**，看起来推翻了声明。原因不是判断错，而是 `packages/cli` 的测试 `import { lintDataModel } from '@objectstack/lint'`——走的是**构建产物 `dist`**，而我在 revert 之前就已经构建过 lint。`grep -c primaryField packages/lint/dist/index.js` 当时是 **0**，即测试跑的仍是「已移除」的那份。revert 后重新 `pnpm --filter @objectstack/lint build`（`grep -c` 变成 **2**）再跑，才拿到上表第 1 行的红。这正是 AGENTS.md §9 陈旧产物陷阱的镜像形态。

## 五、闸门

| 闸门 | 结果 | 说明 |
|---|---|---|
| `pnpm lint`（ESLint，含仓内各族闸） | ✅ pass | 无输出即通过 |
| `pnpm check:type-check-debt` | ✅ pass | 见下节，**这是本单必跑的那一条** |
| `pnpm exec turbo run typecheck`（packages + apps） | ✅ pass | `120 successful, 120 total` |
| `pnpm --filter @objectstack/lint test` | ✅ pass | `62 files, 1542 passed` |
| `pnpm --filter @objectstack/cli test` | ✅ pass | `91 files, 928 passed` |
| `pnpm check:nul-bytes` | ✅ pass | 6094 个文件，无裸控制字节；另对本 PR 改动的 6 个文件单独跑了 `grep -naP` 控制字节自扫，干净 |
| `pnpm check:doc-authoring` | ✅ pass | 365 个文件 |
| `pnpm check:empty-changeset` | ✅ pass | `1 declaring changeset(s) added` |
| `pnpm check:adr-anchors` | ✅ pass | 37 个锚定文件 |
| `pnpm check:quick-reference-counts` | ✅ pass | |
| `pnpm check:skill-frame-sync` / `-freshness` / `check:skill-compatibility` | ✅ pass | 已按派发单要求确认：这些 SKILL 同步闸覆盖的是 `pm-dispatch` 的四份拷贝，**不覆盖** `objectstack-data/SKILL.md`；仍全部跑过 |
| `spec check:skill-docs` / `check:skill-refs` / `check:skill-examples` | ✅ pass | 205 个 prose example 仍能 type-check |

### `check:type-check-debt`：本单最容易咬人的一条

`@objectstack/lint` 是那 19 个「把自己的测试排除在 typecheck 之外」的包之一（`tsconfig.json` 的 `exclude` 含 `**/*.test.ts`），所以包级 `typecheck` **结构性看不见**测试文件里的类型错误。

- **改动前基线**：39（本 worktree 现场按闸门同样的方式抬起排除项实测）
- **首次改完**：40（**+1**）——我新增的 `.map((f) => f.rule)` 引入了一条 TS7006
- **修正后**：**39**，与基线持平

台账记的是 42，40 其实也过闸。**但我没有吃这 3 格余量**：那条 TS7006 的根因是该文件第 10 行的相对 import 少了 `.js` 扩展名（TS2835），NodeNext 下模块里每个符号退化成 `any`，于是每个遍历 finding 的回调都白送一条 TS7006（同文件已有 4 条同样成因的）。我把断言改成 `toHaveLength(1)` + 下标取值，断言强度不变、不新增台账条目，并在原地注明了原因。**没有抬高台账数字。**

## 六、Changeset

`.changeset/lint-primaryfield-phantom-key-removed.md`，`@objectstack/lint: patch`。

**为什么是 patch**：无导出增删（`packages/lint/src/index.ts` 未动）、零 spec 改动、不涉及可声明键的退役，因此不触发「breaking changeset 必须带迁移」。changeset 里已按要求写明：**`primaryField` 从来不是可声明键，写了它的对象在 schema 上本来就发布不了，所以没有任何能工作的 app 会因此回归**；唯一的行为变化是这类对象会新得一条 `suggestion`（该 severity 不失败命令），而真正的修法是改声明 `nameField`。

## 七、刻意没做的事

- ⛔ **没碰 `packages/spec`** —— 裁定是 remove 不是 declare，本单零 spec 改动。
- ⛔ **没碰 `packages/spec/src/shared/suggestions.test.ts:100`** —— 那只是 camelCase 拼写建议的语料字符串，不是声明点，分诊已单独点出。
- ⛔ **没碰 `packages/lint/src/index.ts`** —— PR #6472 正在改这个 barrel。复核确认：删两支谓词分支不增删任何规则 id，确实不需要动它。
- ⛔ **没碰 `content/docs/releases/`**。
- **没有改 `.changeset/lint-missing-name-field-reads-name-field.md`**（#6108 的 changeset，其中一行说「`primaryField` 两支行为不变」）。它是那次改动的历史记录，按时间顺序读是自洽的（那次确实没动，本次移除），改别人 PR 的 changeset 不对。
- **没有顺手修 `validate-semantic-roles.test.ts:10` 的 import 扩展名**。它能一次消掉该文件 5 条 TS2835/TS7006、净减台账，但属于本单文件面之外的改动；已在台账 ℹ 提示里可见，且 #4311 / #5278 已在跟踪，不另立单以免重复。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_