### PR TITLE
fix(scripts): give check-engine-double-contract a scoped-repository arm

### DIFF
--- a/scripts/check-engine-double-contract.mjs
+++ b/scripts/check-engine-double-contract.mjs
@@ -46,8 +46,39 @@
 //
 // A slice is exactly two facts: which member of the double to look at, and
 // which producer-side predicate that member must reach. Everything else --
-// engine-vs-driver attribution, the one-helper-deep indirection, the ledger,
+// the shape attribution below, the one-helper-deep indirection, the ledger,
 // the both-directions reconciliation -- is one implementation serving both.
+//
+// ## Three data-access shapes, not two (#6327, from #5945)
+//
+// A discovered literal is attributed to one of THREE contracts, because the
+// repo has three. The write verbs side by side are the whole taxonomy:
+//
+//   IDataEngine            update(objectName, data, options?)   object name FIRST
+//   IDataDriver            update(objectName, id, data, …)      primary key SECOND
+//   IScopedObjectRepository update(data, options?)              NO object name
+//
+// Only the first is this gate's subject. The driver is vetoed by
+// DRIVER_ONLY_MEMBERS and the primary-key parameter test; the scoped repository
+// -- added by #5945 as `packages/spec/src/contracts/scoped-context.ts`, and
+// implemented by objectql's `ObjectRepository` -- is vetoed by
+// REPOSITORY_ONLY_MEMBERS. Both vetoes put their shape OUT OF SCAN SCOPE rather
+// than into the ledger, because neither is a looser copy of `ObjectQL.<verb>`:
+// it is a different function with a different arity, so there is no dispatch
+// contract for it to be looser THAN.
+//
+// Why the third arm had to be built rather than baselined: a scoped repository
+// binds to one object, so its literal reads as engine-shaped to a scan that can
+// only see member names (`find`/`findOne`/`count`/`insert`, and `insert` is in
+// ENGINE_ONLY_MEMBERS). Accurate for what the scan can see, wrong about what the
+// object is. `@objectstack/spec` -- where the contract and both of its
+// conformance witnesses live -- cannot import `assertEngineUpdateDispatch` even
+// in principle, since the predicate's two homes both DEPEND ON spec, so every
+// witness of this interface could only ever leave the gate through a
+// hand-written EXEMPT. A gate that reddens correct code and can only be digested
+// through its ledger grows the ledger into noise, and the ledger's readability
+// is this gate's whole value (see the baseline's `$comment`: shrink-only, hand
+// reviewed).
 //
 // Deliberately NOT covered, and why (each wants its own slice, not a vaguer
 // version of these -- a gate whose scope is fuzzy is indistinguishable from
@@ -64,6 +95,16 @@
 //     unknown-option rejection). Same family, but each needs its own
 //     producer-side predicate extracted first -- the two write verbs have one
 //     because #4434 and #5480 paid for them.
+//   - a scoped repository that declares NO repository-only member. Measured on
+//     the corpus this landed against: `packages/runtime/src/action-body-identity
+//     .test.ts:71` is a real scoped facade (`createContext().object(name)`)
+//     spelling only `find`/`count`/`insert`/`update`/`delete`, and it stays in
+//     the ledger. Seeing it would mean reading its parameter NAMES, and `o` is
+//     ambiguous in exactly this repo: `o: string` is the object name in twelve
+//     discovered doubles and `o?: any` is the options bag in that facade. A
+//     criterion that guessed would trade a ledger row for the risk of putting a
+//     genuine engine double out of scan scope, which is the one error this gate
+//     cannot report. One ledger row is the cheaper half.
 //
 // ## Invariants
 //
@@ -242,6 +283,44 @@ const DRIVER_ONLY_MEMBERS = new Set([
  */
 const ENGINE_ONLY_MEMBERS = new Set(['insert', 'insertMany', 'aggregate', 'getSchema', 'registry']);
 
+/**
+ * The third arm of the same evidence architecture (#6327, from #5945): members
+ * present on the SCOPED REPOSITORY — `IScopedObjectRepository`
+ * (`packages/spec/src/contracts/scoped-context.ts`) and the `ObjectRepository`
+ * class that declares `implements` it — and on NEITHER `IDataEngine` NOR
+ * `IDataDriver` NOR the ObjectQL class. Declaring one is positive evidence of
+ * an object-BOUND repository, which is not this gate's subject.
+ *
+ * Verified member by member rather than assumed, on the tree this landed
+ * against: `IDataEngine` declares find/findOne/insert/update/delete/count/
+ * aggregate/vectorFind/execute and no by-id form; `IDataDriver` reaches for
+ * records by `id` in a PARAMETER (`update(object, id, data)`) and spells its
+ * bulk forms `bulkUpdate`/`updateMany`/`bulkDelete`/`deleteMany`; and inside
+ * `packages/objectql/src/engine.ts` the only declarations of these two names
+ * are on `class ObjectRepository implements IScopedObjectRepository`.
+ *
+ * Kept to the names that answer, exactly as DRIVER_ONLY_MEMBERS is. The
+ * repository's `create` / `upsert` / `delete` / `aggregate` / `execute` are
+ * real members and are deliberately absent: every one of them is also on the
+ * driver or the engine, so it separates nothing. (`create` already sits in
+ * DRIVER_ONLY_MEMBERS, so a repository double spelling it leaves scan scope
+ * through that veto instead — the right outcome by the wrong name, recorded
+ * here so the next reader does not read it as a gap.)
+ */
+const REPOSITORY_ONLY_MEMBERS = new Set(['updateById', 'deleteById']);
+
+/**
+ * Parameter names that mean "this position holds an OBJECT NAME" — the
+ * complement of ID_PARAM, and the first position rather than the second.
+ *
+ * Both contracts this gate DOES judge take the object name first, so positive
+ * evidence of one is positive evidence that the literal is NOT an object-bound
+ * repository. `t` and `table` are here because this repo's fakes use them
+ * (`_t: string` is the commonest spelling in the discovered corpus after
+ * `object: string`).
+ */
+const OBJECT_NAME_PARAM = /^_*(o|obj|object|objectName|objectname|name|table|tableName|t)$/i;
+
 // ── Discovery ───────────────────────────────────────────────────────────────
 
 function walk(dir, out = []) {
@@ -329,6 +408,25 @@ function memberName(member) {
  * the native-aggregate driver above, and "no driver members" alone admits any
  * `{ find, findOne, update, delete }` store mock that is neither contract.
  */
+/**
+ * Does this verb take an OBJECT NAME in first position? Positive evidence only
+ * — an unreadable or absent first parameter answers `false`, never `true`.
+ *
+ * The asymmetry is deliberate and is the whole safety property of the scoped-
+ * repository veto below: this function's `true` KEEPS a literal in scan scope,
+ * so being generous with it can only cost a ledger row, while being generous
+ * with `false` would put a genuine engine double out of scan scope — the one
+ * error a gate cannot report about itself.
+ */
+function takesObjectNameFirst(fn) {
+  const first = (fn.parameters ?? [])[0];
+  if (!first) return false;
+  const name = ts.isIdentifier(first.name) ? first.name.text : '';
+  if (OBJECT_NAME_PARAM.test(name)) return true;
+  const t = first.type ? first.type.getText().trim() : '';
+  return /^(string|string \| number)$/.test(t);
+}
+
 function isEngineVerbShape(fn, memberNames = new Set()) {
   const params = fn.parameters ?? [];
   // The DRIVER veto outranks everything, at every arity (#5480).
@@ -347,6 +445,30 @@ function isEngineVerbShape(fn, memberNames = new Set()) {
   // of them), so it decides first. Same precedence the arity path always used,
   // now applied uniformly.
   for (const n of memberNames) if (DRIVER_ONLY_MEMBERS.has(n)) return false;
+  // The SCOPED-REPOSITORY veto (#6327), same precedence and the same shape as
+  // the driver veto above: a name only the third contract has, decided at ANY
+  // arity, before ENGINE_ONLY_MEMBERS gets to read `insert` as engine evidence
+  // — which is precisely how #5945's two conformance witnesses were attributed
+  // to the engine and could only leave through a hand-written EXEMPT.
+  //
+  // BOTH halves are required, and each has a job. The member is the evidence
+  // that this is a repository; the parameter test is what stops the member from
+  // silencing a fake that is ALSO engine-shaped — a double spelling
+  // `update(objectName, data, opts)` takes the object name the engine takes, so
+  // it stays in scope and stays pinnable however many convenience members it
+  // hangs off the side. Requiring the member is the other half: object-lessness
+  // alone would have to be inferred from parameter names, and `o` means the
+  // object in twelve discovered doubles and the options bag in one scoped
+  // facade, so a member-free reading would be guessing on a corpus that
+  // genuinely disagrees with itself.
+  //
+  // Measured before it was written, over the 250 doubles this gate discovers:
+  // the pair moves exactly 2, both of them #5945's witnesses, and 0 of the 82
+  // PINNED doubles. Widening it is a measurement, not an opinion — re-run that
+  // count before adding a name here.
+  if (!takesObjectNameFirst(fn)) {
+    for (const n of memberNames) if (REPOSITORY_ONLY_MEMBERS.has(n)) return false;
+  }
   if (params.length < 2) {
     let engineEvidence = false;
     for (const n of memberNames) {
@@ -977,6 +1099,106 @@ const driver = {
   expect("objectql's relative import of the update producer counts",
     d.length === 1 && d[0].pinned === true);
 
+  // ── The SCOPED REPOSITORY, the third shape (#6327, from #5945).
+  //
+  // Driven as an A/B on ONE literal, because every assertion here is a negative
+  // ("not reported") and a negative passes vacuously the day the scan stops
+  // discovering anything. The two fixtures below differ by a single member, so
+  // the control does not merely accompany the claim — it is the same object
+  // with the evidence removed, which is the only version that can distinguish
+  // "the veto fired" from "discovery died".
+  const repoBody = `
+  find: async (query?: any) => [],
+  findOne: async (query?: any) => null,
+  count: async (query?: any) => 0,
+  insert: async (data: any) => data,
+  update: async (data: any, options?: any) => data,`;
+  const scopedRepo = `const repo = {${repoBody}
+  updateById: async (id: string | number, data: any) => ({ id, ...data }),
+};
+`;
+  const sameRepoWithoutMarker = `const repo = {${repoBody}
+};
+`;
+  expect('a scoped-repository witness is out of scope for the update slice',
+    scanSource('sr.test.ts', scopedRepo, U).length === 0);
+  expect('…and the SAME literal without updateById is still discovered',
+    scanSource('sr.test.ts', sameRepoWithoutMarker, U).length === 1);
+
+  // The second spelling #5945 actually wrote, and the one direction-2 ("look
+  // for a `: IScopedObjectRepository` annotation") cannot see: the repository
+  // handed back by `object(name)`, which carries no annotation anywhere.
+  const returnedRepo = `
+const liveApi = {
+  object: (_name: string) => ({
+    find: async () => [],
+    findOne: async () => null,
+    count: async () => 0,
+    insert: async (data: unknown) => data,
+    update: async (data: unknown) => data,
+    updateById: async (id: string | number, data: object) => ({ id, ...data }),
+  }),
+};
+`;
+  expect('an UNANNOTATED repository handed back by object(name) is out of scope',
+    scanSource('rr.test.ts', returnedRepo, U).length === 0);
+
+  // The veto must not be a licence the member alone grants. A fake that takes
+  // the object name where the ENGINE takes it is an engine double no matter
+  // what convenience members hang off it — otherwise adding one `updateById`
+  // to any fake would silently retire it from this gate.
+  const engineWithByIdHelper = `
+const engine = {
+  async find(objectName: string, q?: any) { return []; },
+  async insert(objectName: string, data: any) { return data; },
+  async delete(objectName: string, opts?: any) { return true; },
+  async update(objectName: string, data: any, opts?: any) { return data; },
+  async updateById(id: string, data: any) { return data; },
+};
+`;
+  d = scanSource('eb.test.ts', engineWithByIdHelper, U);
+  expect('an engine double that ALSO declares updateById stays in scope',
+    d.length === 1 && d[0].pinned === false);
+
+  // The delete slice needs its own arm exercised, and its own marker: the
+  // repository's delete is `delete(options)` — no object name, no id.
+  const scopedRepoDelete = `
+const repo = {
+  find: async (query?: any) => [],
+  findOne: async (query?: any) => null,
+  count: async (query?: any) => 0,
+  insert: async (data: any) => data,
+  delete: async (options?: any) => ({ ok: true }),
+  deleteById: async (id: string | number) => true,
+};
+`;
+  expect("a scoped repository's delete is out of scope when the literal declares deleteById",
+    scanSource('srd.test.ts', scopedRepoDelete).length === 0);
+
+  // The sharpest form of the same guard, and the one the negative-assertion
+  // asymmetry actually demands: one fixture holding BOTH shapes, asserted on
+  // the EXACT reported set rather than on a count of zero. A criterion that
+  // silenced everything would pass every assertion above and fail this one.
+  const mixed = `${UIMPORT}
+const repo = {
+  find: async (query?: any) => [],
+  findOne: async (query?: any) => null,
+  count: async (query?: any) => 0,
+  insert: async (data: any) => data,
+  update: async (data: any, options?: any) => data,
+  updateById: async (id: string | number, data: any) => ({ id, ...data }),
+};
+const engine = {
+  async find(o: string, opts?: any) { return []; },
+  async insert(o: string, data: any) { return data; },
+  async delete(o: string, opts?: any) { return true; },
+  async update(o: string, data: any, opts?: any) { return data; },
+};
+`;
+  const mixedFound = scanSource('mx.test.ts', mixed, U);
+  expect('a mixed fixture reports EXACTLY the engine double, not the repository',
+    mixedFound.length === 1 && mixedFound[0].line === 11 && mixedFound[0].pinned === false);
+
   // Discovery must reach the real tree, for EVERY slice, and specifically must
   // reach the fake #4434 was shipped past. Everything above is synthetic; this
   // is the wiring.
@@ -1002,10 +1224,12 @@ const driver = {
     process.exit(1);
   }
   console.log(
-    'OK  self-test: separates engine doubles from driver doubles on BOTH write verbs, admits a '
-      + 'verb that declares fewer than two parameters only on engine-vs-driver sibling evidence, '
-      + "accepts only that slice's producer predicate (direct or one helper deep) and never the "
-      + 'other slice\'s, rejects unused imports, hand-mirrored guards and look-alikes, and proves '
+    'OK  self-test: separates engine doubles from driver doubles AND from scoped repositories on '
+      + 'BOTH write verbs, admits a verb that declares fewer than two parameters only on '
+      + "engine-vs-driver sibling evidence, accepts only that slice's producer predicate (direct or "
+      + "one helper deep) and never the other slice's, rejects unused imports, hand-mirrored guards "
+      + 'and look-alikes, keeps an engine double in scope however many by-id helpers it declares, '
+      + 'reports EXACTLY the engine double out of a fixture holding both shapes, and proves '
       + 'discovery reaches the real tree for every slice.',
   );
 }

--- a/scripts/engine-double-contract.baseline.json
+++ b/scripts/engine-double-contract.baseline.json
@@ -23,6 +23,16 @@
     "`unguarded` is measured by the scan, not asserted by hand. `why` says what stands between",
     "the file and being pinned; `closes` says what removes the entry.",
     "",
+    "NOT EVERY DATA-ACCESS DOUBLE BELONGS HERE. The checker attributes a discovered literal to one",
+    "of THREE contracts and only the engine's is this ledger's subject: a DRIVER double and a SCOPED",
+    "REPOSITORY double (`IScopedObjectRepository`, #5945) are out of SCAN SCOPE, not exempt. Neither",
+    "is a looser copy of `ObjectQL.<verb>` — a repository binds to one object, so its `update(data,",
+    "options?)` is a different function with a different arity and there is no dispatch contract for",
+    "it to be looser than. #6327 added that third arm and the two EXEMPT rows this ledger carried for",
+    "`scoped-context.test.ts` and `hook.test.ts` left with it; a witness of that interface needs no",
+    "row at all now. If you are here because a scoped-repository double came out red, the fix is the",
+    "checker's REPOSITORY_ONLY_MEMBERS, not a row here.",
+    "",
     "WHAT THESE ENTRIES DO AND DO NOT CLAIM. They record that the double is structurally",
     "looser than the contract. They do NOT claim the looseness is currently harmless — proving",
     "that per file means running each suite with the guard installed, and the one package where",
@@ -1113,22 +1123,6 @@
       "kind": "EXEMPT",
       "why": "MEASURED (#5480): the `update` slice of this gate is NEW — `resolveEngineUpdateDispatch` did not exist before #5480, so no double in the repo could route through it and the whole discovered set enters this ledger in one act. Not newly written looseness and not a raised ratchet: it is the first measurement of a contract that had no producer-side predicate to measure against, which is exactly what this script's header used to list under deliberately-not-covered (\"update's twin dispatch ... needs its own producer-side predicate extracted first\"). Discovered at lines 24, 46, 82, 119, 152. EXEMPT for the same reason the delete-slice entry for this file is, restated for the update verb because a per-verb ledger may not inherit a verdict: these are not stand-ins that code under test drives, they are TYPE-CONFORMANCE witnesses that `IDataEngine` is implementable, and `update` is present on each only because the interface requires the member. They cannot be pinned even in principle — @objectstack/objectql depends on @objectstack/spec, so the import would invert the dependency. WHAT THIS ENTRY DOES NOT CLAIM: unlike the #5629 delete batch above it carries NO per-file dormancy probe. Nothing here says the looseness is unexercised — only that the double is structurally free to be looser than ObjectQL.update on the shape a hand-written guard always drops (`where: { id: { $in: [...] } }` looks like an id and is a multi-row predicate) — a shape the producer refuses in `data.id` too since objectstack#5748 put the payload half through the SAME scalar test, so `data.id` still outranks `where` and `multi`, but only when it IS a scalar id.",
       "closes": "nothing — permanent"
-    },
-    {
-      "file": "packages/spec/src/contracts/scoped-context.test.ts",
-      "verb": "update",
-      "unguarded": 1,
-      "kind": "EXEMPT",
-      "why": "MEASURED (#5945): NOT an engine double — a conformance witness for the NEW `IScopedObjectRepository` contract (`packages/spec/src/contracts/scoped-context.ts`), which is a THIRD species this gate's two-way engine-vs-driver attribution has no arm for. A scoped REPOSITORY is bound to one object, so its write verb is `update(data, options?)` — the object name is not a parameter at all, where `IDataEngine.update(objectName, data, options?)` takes it first and `IDataDriver` takes an id second. Discovery reaches it anyway because the literal carries `find`/`findOne`/`count`/`insert` (four ENGINE_SIBLINGS, and `insert` is in ENGINE_ONLY_MEMBERS, which attributes it to the engine side) — accurate for what the scan can see, wrong about what the object is. EXEMPT, not DEBT, on the same ground already recorded twice for `packages/spec/src/contracts/data-engine.test.ts`: it cannot be pinned even in principle, because `assertEngineUpdateDispatch` lives in @objectstack/objectql / @objectstack/metadata-core and BOTH depend on @objectstack/spec — the import would invert the dependency graph. DORMANCY PROBED, not assumed (the #5629 method, which the two update entries above explicitly say they lack): a `process.stderr.write` marker injected as the first statement of this `update` printed NOTHING across a full run of both files (83/83 tests green). The control that makes that silence evidence rather than a broken probe: the same injection in this witness's sibling `updateById` — which the transaction test does call — DID print, in the same run of the same harness. So the looseness is unexercised today. Dormant is not harmless: a future test that starts updating through this witness inherits a double free to accept what ObjectQL.update refuses (`where: { id: { $in: [...] } }` reads as an id and is a multi-row predicate). Discovered at line 296 — the `IScopedObjectRepository` literal in the 'IScopedContext is implementable' block.",
-      "closes": "nothing — permanent, unless this gate grows a scoped-repository arm (then this witness becomes out of scope rather than exempt)"
-    },
-    {
-      "file": "packages/spec/src/data/hook.test.ts",
-      "verb": "update",
-      "unguarded": 1,
-      "kind": "EXEMPT",
-      "why": "MEASURED (#5945): NOT an engine double — a conformance witness for the NEW `IScopedObjectRepository` contract (`packages/spec/src/contracts/scoped-context.ts`), which is a THIRD species this gate's two-way engine-vs-driver attribution has no arm for. A scoped REPOSITORY is bound to one object, so its write verb is `update(data, options?)` — the object name is not a parameter at all, where `IDataEngine.update(objectName, data, options?)` takes it first and `IDataDriver` takes an id second. Discovery reaches it anyway because the literal carries `find`/`findOne`/`count`/`insert` (four ENGINE_SIBLINGS, and `insert` is in ENGINE_ONLY_MEMBERS, which attributes it to the engine side) — accurate for what the scan can see, wrong about what the object is. EXEMPT, not DEBT, on the same ground already recorded twice for `packages/spec/src/contracts/data-engine.test.ts`: it cannot be pinned even in principle, because `assertEngineUpdateDispatch` lives in @objectstack/objectql / @objectstack/metadata-core and BOTH depend on @objectstack/spec — the import would invert the dependency graph. DORMANCY PROBED, not assumed (the #5629 method, which the two update entries above explicitly say they lack): a `process.stderr.write` marker injected as the first statement of this `update` printed NOTHING across a full run of both files (83/83 tests green). The control that makes that silence evidence rather than a broken probe: the same injection in this witness's sibling `updateById` — which the transaction test does call — DID print, in the same run of the same harness. So the looseness is unexercised today. Dormant is not harmless: a future test that starts updating through this witness inherits a double free to accept what ObjectQL.update refuses (`where: { id: { $in: [...] } }` reads as an id and is a multi-row predicate). Discovered at line 1176 — the repository the `liveApi` ScopedContext stand-in returns from `object(name)`, which exists so the #5945 block can assert `HookContextSchema.parse` neither rejects nor clones a live engine object. Nothing in that block calls any repository method at all.",
-      "closes": "nothing — permanent, unless this gate grows a scoped-repository arm (then this witness becomes out of scope rather than exempt)"
     }
   ]
 }


### PR DESCRIPTION
Fixes #6327

`scripts/check-engine-double-contract.mjs` 的归属判据一直是**二分**的：一个字面量要么是 engine double，要么是 driver double。#5945 引入的 `IScopedObjectRepository` 是**第三种**数据访问形状，这道门没有它的那一支 —— 于是该接口的每一个类型符合性见证都被判成 engine double，只能靠手写 EXEMPT 出场。本 PR 加上第三支。

> 排版说明：本仓的 GitHub 正文消毒器会把引号转义成实体（`&#39;` / `&#34;`），连代码块里也不放过。下面的代码块因此**刻意不写引号** —— 真实拼写以 diff 为准。

## 一、立单前提的复核（在 `origin/main` 上重测，未引用卡片）

三者的写动词并排，逐条对着源文件核过：

| 契约 | 写动词签名 | 对象名的位置 |
| --- | --- | --- |
| `IDataEngine` | `update(objectName, data, options?)` | 第一位 |
| `IDataDriver` | `update(object, id, data, options?)` | 第一位，主键在第二位 |
| `IScopedObjectRepository` | `update(data, options?)` | **不是参数** |

- `packages/spec/src/contracts/data-engine.ts:138` / `data-driver.ts:179` / `contracts/scoped-context.ts:160`。
- 该接口成员集 `find` / `findOne` / `count` / `insert` / `update` / `updateById` —— 四个 `ENGINE_SIBLINGS`，且 `insert` 在 `ENGINE_ONLY_MEMBERS` 里。所以 `isEngineVerbShape` 在 `params.length` 不足 2 的分支上拿 `insert` 当 engine 证据，把见证归到 engine 侧。**对扫描能看见的信息而言准确，对那个对象究竟是什么而言错误** —— 立单正文的这句话成立。
- 「spec 原则上无法路由 `assertEngineUpdateDispatch`」也成立：谓词在 `@objectstack/objectql` / `@objectstack/metadata-core`，两者都依赖 `@objectstack/spec`，import 会反转依赖。所以此后每个实现或见证都只能再手写一条 EXEMPT。

改门前的门是绿的：`OK — 82 pinned, 133 in the DEBT ledger, 4 exempt`。**这不是一道报红的门，是一道把正确代码判成债务的门** —— 代价落在 ledger 的可读性上，而它的 `$comment` 明写 shrink-only、手工评审。

## 二、走了哪条方向，以及数据为什么这么说

**取方向 1（形状归属支），但两半合取，并且成员那一半是必需的。** 判据与 `DRIVER_ONLY_MEMBERS` 完全同构 —— 新增 `REPOSITORY_ONLY_MEMBERS`，成员为 `updateById` 与 `deleteById`：

```js
// REPOSITORY_ONLY_MEMBERS = { updateById, deleteById }
if (!takesObjectNameFirst(fn)) {
  for (const n of memberNames) if (REPOSITORY_ONLY_MEMBERS.has(n)) return false;
}
```

放在 DRIVER veto 之后、`ENGINE_ONLY_MEMBERS` 读 `insert` 之前，任何 arity 都判 —— 和 driver veto 同一个优先级理由。命中即**出扫描范围**（像 driver double 那样），不进 ledger。

选名字不是拍脑袋：`updateById` / `deleteById` 逐个核对过 —— `IDataEngine` 没有任何 by-id 形式，`IDataDriver` 用参数里的 `id` 加 `bulkUpdate` / `updateMany` / `bulkDelete` / `deleteMany`，而 `packages/objectql/src/engine.ts` 里这两个名字的**唯一**声明处是 `class ObjectRepository implements IScopedObjectRepository`（7831 / 7846 行）。repository 的 `create` / `upsert` / `delete` / `aggregate` / `execute` 故意不收：每一个都同时在 driver 或 engine 上，分不开任何东西。

**为什么不取方向 2（按声明类型）**：测下来它只覆盖一半。250 个已发现 double 里带 `: IScopedObjectRepository` 标注的只有 **1** 个；`packages/spec/src/data/hook.test.ts:1176` 的 repository 是 `object(name)` 返回的字面量，**没有任何标注**，方向 2 看不见它 —— 那条 EXEMPT 会永远留在 ledger 里。判据的覆盖面取决于作者当时有没有顺手写标注，这不是判据。

**为什么不取方向 3（维持现状）**：见上面的成本论证，且方向 1 的测量结果足够干净（下一节），没有理由把它记进「deliberately not covered」。

**为什么两半必须合取**：

- 只要成员、不看参数 —— 那么给任何 fake 挂一个 `updateById` 就能把它悄悄移出这道门。参数测试挡住这个：`update(objectName, data, opts)` 拿了 engine 拿对象名的位置，就留在范围内。
- 只要参数、不要成员 —— 得靠参数名白名单，而**本仓的 `o` 本身歧义**：12 个已发现 double 里 `o: string` 是对象名，而 `packages/runtime/src/action-body-identity.test.ts:71` 的 `o?: any` 是 options 包。猜错的方向是把真 engine double 挪出扫描范围，那是这道门唯一无法自报的错误。

`takesObjectNameFirst` 因此**只给正面证据**：读不出来或没有第一个参数一律返回 `false`，绝不返回 `true`。这个不对称是安全性质本身 —— 它的 `true` 是「留在范围内」，宽松只会多留一条 ledger；宽松地给 `false` 才会造成假阴性。

## 三、判据的分辨力测量（先测量，后落笔）

对全语料 **250 个已发现 double（115 delete + 135 update，其中 82 个 pinned）** 逐个打分：

| 候选判据 | 移出扫描范围 | 其中 pinned（会停止被检查的真 engine double） |
| --- | --- | --- |
| 本 PR：成员 ∧ 第一参数非对象名 | **2 / 250** | **0** |
| 仅成员（`updateById` 或 `deleteById`） | 2 / 250 | 0 |
| 仅声明类型标注（方向 2） | 1 / 250 | 0 |
| 仅第一参数（无成员要求） | 3 / 250 | 0 |

移动的两个恰好是 #5945 的两个见证，**没有一个 pinned double 被影响，没有一个真 engine double 受影响**。语料库范围内把 `updateById` / `deleteById` 声明为成员的测试文件也只有这两个。

**故意没有覆盖到的一个，写进了脚本头**：`packages/runtime/src/action-body-identity.test.ts:71` 是一个真的 scoped facade（`createContext().object(name)` 返回的对象），但它只写了 `find` / `count` / `insert` / `update` / `delete`，没有 repository 专属成员，所以**留在 ledger 里**，条目数不变（该文件两个 verb 各 `unguarded: 2`，未动）。要看见它就得读参数名，而 `o` 恰恰在本仓两头都用 —— 用一条 ledger 换假阴性风险不划算，这个取舍已写在脚本头的「deliberately NOT covered」里，而不是留给下一个读者去踩。

## 四、两条现有 EXEMPT 的去向（前后实测）

⚠️ 没有把它们当「缺陷证据」删掉。先测量它们在新判据下确实**出扫描范围**，才删：

| | 改动前 | 改动后 |
| --- | --- | --- |
| delete slice | 115 doubles / 98 files，49 pinned，66 baseline | **不变** |
| update slice | 135 doubles / 119 files，33 pinned，102 baseline | **133 / 117**，33 pinned，100 baseline |
| 汇总 | 82 pinned，133 DEBT，**4 exempt** | 82 pinned，133 DEBT，**2 exempt** |

- **删除**（各 1 条，verb=update）：`packages/spec/src/contracts/scoped-context.test.ts`、`packages/spec/src/data/hook.test.ts`。删除是 RECONCILED 逼出来的 —— 改完门后主跑直接报「baseline entry ... which declares no engine double with a update any more」。两条条目自己的 `closes` 早就预告了这一步：*「permanent, unless this gate grows a scoped-repository arm (then this witness becomes out of scope rather than exempt)」*。
- **保留**：`packages/spec/src/contracts/data-engine.test.ts` 的两条（delete / update，各 `unguarded: 5`）。它们是 `IDataEngine` 见证 —— 对象名在第一位、不含任何 repository 专属成员，新判据碰不到它们，实测计数 5 未变。
- 两个见证的**测试内容一字未动**（它们是证据），`packages/spec/src/contracts/scoped-context.ts` 也未动（那是 #5945 的面）。

## 五、反向验证（先声明方向，再跑）

只回退 veto 本身（保留新自测 fixture、保留已删的两条 baseline），**声明在前**：

预期变红：4 条新断言 + 主跑 2 个 PINNED 错误。预期**保持绿**：A/B 对照「同一字面量去掉 `updateById` 仍被发现」与「带 `updateById` 的 engine double 仍在范围内」，以及全部既有断言。

实测完全一致：

```
  x self-test: a scoped-repository witness is out of scope for the update slice
  x self-test: an UNANNOTATED repository handed back by object(name) is out of scope
  x self-test: a scoped repository delete is out of scope when the literal declares deleteById
  x self-test: a mixed fixture reports EXACTLY the engine double, not the repository
check-engine-double-contract --self-test: 4 failure(s).

  x PINNED [update]: packages/spec/src/contracts/scoped-context.test.ts ... (line 296)
  x PINNED [update]: packages/spec/src/data/hook.test.ts ... (line 1176)
```

两条对照断言均未出现在失败列表里 —— 这正是要点。**「不再被报告」在扫描彻底失灵时会空过**，所以新增断言全部配了正面对照：

- A/B 对照用的是**同一个字面量加减一个 `updateById`**（带标记 ⇒ 出范围；去掉 ⇒ 仍被发现 1 个）。不是「另找一个对照」，而是同一个对象拿掉证据，这是唯一能区分「veto 生效」和「发现能力死了」的写法。
- 混合 fixture 里同时放 repository 和 engine double，断言的是**精确集合**（长度等于 1 且行号等于 11），不是「等于 0」。一个把什么都静音掉的判据能通过前面每一条，唯独过不了这条。

## 六、门

| 门 | 结果 |
| --- | --- |
| `pnpm lint`（ESLint） | pass，无输出 |
| `pnpm check:engine-double-contract`（CI 的原命令，含 `--self-test`） | pass — `OK — 82 pinned, 133 in the DEBT ledger, 2 exempt` |
| `pnpm check:nul-bytes` | pass — 6105 个文件，无裸控制字节 |
| `pnpm exec turbo run typecheck` | pass — `125 successful, 125 total` |
| 改动文件控制字节自扫（`grep -naP`，越过门的盲区） | 无命中 |
| CI · ESLint（家族门都在这个 job 里跑） | **success** |
| CI · TypeScript Type Check | **success** |
| CI · Check Changeset | **success**（`skip-changeset` 在其重读之前落地） |

`scripts/` 不在任何 tsconfig 的编译范围内，所以 typecheck 对本改动没有判别力 —— 仍然全量跑了一遍，只为证明没有连带回归，不当作本改动的证据。

## 七、changeset

无。仓库内部门禁工具，无对外交付面，不发布任何包 ⇒ 已打 `skip-changeset`（读回确认：`size/m` + `skip-changeset`）。
