### PR TITLE
chore(ci): ADR-0087 台账存量一次性回补审计口 `--audit-stock` —— 238 条 breaking 逐条过一遍门禁自己的判定逻辑 (#6350)

### DIFF
--- a/scripts/check-adr-0087-registration.mjs
+++ b/scripts/check-adr-0087-registration.mjs
@@ -987,6 +987,194 @@ function list(cwd, head) {
 }
 
 // ---------------------------------------------------------------------------
+// `--audit-stock` -- the ONE-OFF backfill audit (#6350)
+//
+// ## What this is, and what it is deliberately NOT
+//
+// The gate above is FORWARD-ONLY: it judges the PR's own diff, for the #6129
+// reason its sibling `check-empty-changeset.mjs` documents at length. That
+// direction is correct and this mode does not overturn it -- judging the stock on
+// every PR would turn the whole repo red on adoption day and would hold the
+// current author answerable for changesets that landed on main months before their
+// branch existed.
+//
+// The cost of forward-only is that the STOCK was never compared even once. At the
+// time #6350 was filed the v17 train carried 227 declared-breaking changesets, none
+// of which any version of this logic had ever looked at, and hand-sampling had
+// already turned up 2 suspected ledger misses of exactly the #6011 shape. This mode
+// runs the gate's OWN judging functions -- `breakingDeclaration`, `readDisposition`,
+// `findMigrationPrescription`, `workspacePackagesAt` -- once over that stock, so the
+// audit cannot drift from the gate: there is no second copy of the logic here, only
+// a different population fed to it.
+//
+// It is NOT wired into CI, and must not be. `package.json`'s
+// `check:adr-0087-registration` and the Check Changeset workflow both invoke the
+// gate with no flag; this mode is reachable only by typing it. It is `--list`'s
+// neighbour -- a standing audit surface an operator runs on purpose -- not a
+// second gate.
+//
+// ## How it narrows 238 rows to a hand-checkable residue
+//
+// A stock changeset carries no disposition marker (nothing ever asked it for one),
+// so replaying the gate verbatim would report every one of them and say nothing.
+// What is informative is which disposition the changeset WOULD have been ENTITLED
+// to, judged mechanically:
+//
+//   answered              -- it already carries a marker (landed after the gate).
+//   exempt-unpublished    -- every package it bumps is `private: true`, so nothing
+//                            it breaks reaches a consumer. Fully mechanical.
+//   exempt-no-prescription-- its body frames no rewrite, so the catch-all is open
+//                            to it. This is the gate's own contradiction check,
+//                            run in the direction that grants rather than refuses.
+//   RESIDUE               -- a published break whose body ships instructions for
+//                            rewriting a consumer's code. Both mechanical
+//                            exemptions are closed to it, so the only honest
+//                            dispositions left are `registered` /
+//                            `already-registered` -- and BOTH require a ledger
+//                            entry that covers the surface. Whether one does is a
+//                            judgment about meaning, which no script makes.
+//
+// For each residue row the audit adds the one further MECHANICAL fact that
+// separates "the author registered it" from "nobody ever asked": did any commit
+// that touched this changeset also touch an ADR-0087 registry source? That is the
+// signal #6350's hand-sampling used, computed for the whole population instead of
+// three spot checks.
+//
+// The output is a worklist for a human, not a verdict. It exits 0 whatever it
+// finds -- a non-zero exit here would be a gate, and this is not one.
+// ---------------------------------------------------------------------------
+
+/**
+ * Did any commit that touched `path` also touch an ADR-0087 registry source?
+ *
+ * Every commit in the changeset's history is considered, not just the one that
+ * added it: a changeset can be edited into breaking after the fact, and the
+ * registration may ride either commit. Cheap because it only runs on the residue.
+ *
+ * ⚠️ Unusable in a SHALLOW clone, and the failure is silent-and-plausible rather
+ * than loud, so it is refused rather than approximated. In a graft-truncated
+ * history every pre-graft file reads as "added by the graft commit", and that
+ * commit contains the whole tree -- including both ledger sources. Measured on the
+ * default CI-shaped checkout of this repo (104 commits, grafted at 2bc187641,
+ * 5978 files in that one commit): 91 of 92 residue rows came back "the author
+ * registered something", every one of them wrong, and the answer looks entirely
+ * reasonable on the page. `git fetch --unshallow` (a `--filter=blob:none` partial
+ * fetch is enough -- this reads trees, never blobs) is the fix.
+ *
+ * @returns {{ available: boolean, shas: string[] }}
+ */
+function ledgerTouchingCommits(path, head, cwd) {
+  let shas;
+  try {
+    shas = git(['log', '--format=%h', head, '--', path], cwd).split('\n').map((s) => s.trim()).filter(Boolean);
+  } catch { return { available: true, shas: [] }; }
+  const hits = [];
+  for (const sha of shas) {
+    let names;
+    try { names = git(['show', '--name-only', '--format=', sha], cwd); } catch { continue; }
+    if (LEDGER_SOURCES.some((src) => names.includes(src))) hits.push(sha);
+  }
+  return { available: true, shas: hits };
+}
+
+/** Is this checkout shallow? A shallow history makes the ledger-touch signal a lie. */
+function isShallow(cwd) {
+  try { return git(['rev-parse', '--is-shallow-repository'], cwd).trim() === 'true'; } catch { return false; }
+}
+
+/**
+ * Classify one stock changeset by which disposition it would be ENTITLED to.
+ *
+ * Exported so the self-test can pin it: this classifier decides which rows a human
+ * ever looks at, so a silent widening of `exempt-*` would shrink the worklist
+ * invisibly -- the #4690 failure mode wearing an audit's clothes.
+ *
+ * @param {ReturnType<typeof parseChangeset>} parsed
+ * @param {Map<string, {private: boolean, file: string}>} pkgs
+ * @returns {{ klass: 'answered'|'exempt-unpublished'|'exempt-no-prescription'|'residue', detail?: string, prescription?: ReturnType<typeof findMigrationPrescription> }}
+ */
+export function classifyStockChangeset(parsed, pkgs) {
+  const d = readDisposition(parsed.body);
+  if (d.ok) {
+    return { klass: 'answered', detail: d.verdict === 'registered' ? `registered ${d.ids.join(',')}` : `not-required (${d.category})` };
+  }
+  // `unpublished` first: a private package ships nothing, so the prescription in
+  // its body reaches no consumer of a published artifact and the question the
+  // ledger answers does not arise. A changeset declaring NO package cannot claim
+  // it -- the gate refuses that too ("nothing to verify").
+  if (parsed.bumps.length > 0 && parsed.bumps.every((b) => pkgs.get(b.pkg)?.private === true)) {
+    return { klass: 'exempt-unpublished', detail: parsed.bumps.map((b) => b.pkg).join(', ') };
+  }
+  const prescription = findMigrationPrescription(parsed.body);
+  if (!prescription) return { klass: 'exempt-no-prescription' };
+  return { klass: 'residue', prescription };
+}
+
+/** `--audit-stock`: run the gate's judging logic once over the whole stock (#6350). */
+function auditStock(cwd, head) {
+  const stock = changesetsAt(head, cwd);
+  const texts = showManyOrNull(head, stock, cwd);
+  const pkgs = workspacePackagesAt(head, cwd);
+
+  const buckets = { answered: [], 'exempt-unpublished': [], 'exempt-no-prescription': [], residue: [] };
+  let breaking = 0;
+  for (const path of stock) {
+    const text = texts.get(path);
+    if (text === undefined) continue;
+    const parsed = parseChangeset(text);
+    const decl = breakingDeclaration(parsed);
+    if (!decl.breaking) continue;
+    breaking++;
+    const c = classifyStockChangeset(parsed, pkgs);
+    buckets[c.klass].push({ path, signals: decl.signals.join('+'), ...c });
+  }
+
+  console.log(`ADR-0087 stock backfill audit (#6350) -- ${stock.length} changeset(s) in stock, ${breaking} declared breaking.\n`);
+  for (const [klass, label] of [
+    ['answered', 'ALREADY ANSWERED -- carries an adr-0087 marker (landed after the gate)'],
+    ['exempt-unpublished', 'EXEMPT (unpublished) -- every bumped package is private; nothing ships'],
+    ['exempt-no-prescription', 'EXEMPT (no-migration-prescription) -- the body frames no rewrite'],
+  ]) {
+    console.log(`${label}: ${buckets[klass].length}`);
+    for (const r of buckets[klass]) {
+      if (klass !== 'exempt-no-prescription') console.log(`    ${r.path}${r.detail ? `  [${r.detail}]` : ''}`);
+    }
+    console.log('');
+  }
+
+  console.log(`RESIDUE -- published break + migration prescription, so only \`registered\` /`);
+  console.log(`\`already-registered\` remain, and both need a ledger entry: ${buckets.residue.length}\n`);
+  const shallow = isShallow(cwd);
+  if (shallow) {
+    console.log(
+      '  ⚠️  SHALLOW CLONE -- the ledger-touch signal is SUPPRESSED, not approximated. Every pre-graft\n' +
+      '      file reads as "added by the graft commit", which carries the whole tree including both\n' +
+      '      ledger sources, so the signal would report a plausible-looking "registered" for almost\n' +
+      '      every row and be wrong on almost every row. Run `git fetch --unshallow --filter=blob:none`\n' +
+      '      (trees are enough; no blobs are read) and re-run.\n',
+    );
+  }
+  for (const r of buckets.residue) {
+    const touching = shallow ? null : ledgerTouchingCommits(r.path, head, cwd);
+    const mark = touching === null ? '?' : touching.shas.length ? '~' : '!';
+    console.log(`  ${mark} ${r.path}  [${r.signals}]`);
+    console.log(`      prescription (${r.prescription.branch}): ${r.prescription.line.slice(0, 120)}`);
+    if (touching === null) {
+      console.log('      ledger-touch: UNAVAILABLE (shallow clone)');
+    } else if (touching.shas.length) {
+      console.log(`      ledger touched by: ${touching.shas.join(', ')} -- the author did register something; check it COVERS this surface`);
+    } else {
+      console.log('      ledger NEVER touched by any commit that touched this changeset -- the #6011 shape');
+    }
+  }
+  console.log(
+    '\nThis is a WORKLIST, not a verdict: `!` rows are candidates for a missing registration, and only a\n' +
+    'reader deciding what the surface means can say whether one is owed. This mode exits 0 whatever it\n' +
+    'finds -- it audits stock, which the gate deliberately never does (#6129).',
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Self-test -- pins the RED paths so the gate cannot rot into a no-op.
 //
 // Real temp git repositories driven through the SAME exported scan()/assertInputs(),
@@ -1321,6 +1509,44 @@ function selfTest() {
   assert(findMigrationPrescription('### 迁移:FROM → TO\n')?.branch === 'from-to-label', 'P20: the placeholder label reports the label branch');
   assert(findMigrationPrescription('nothing here\n') === null, 'P21: a body with no prescription reports null, not a shrug');
 
+  // ---- S1-S5: the `--audit-stock` classifier (#6350) ------------------------
+  //
+  // The stock audit's classifier decides which rows a human ever reads, so a
+  // silent widening of either `exempt-*` arm shrinks the worklist invisibly --
+  // #4690's failure mode wearing an audit's clothes. These pin all four arms plus
+  // the one precedence rule between them. They live in the self-test (which CI
+  // runs) even though the audit itself is operator-invoked, because the classifier
+  // reuses the gate's judging functions and would rot with them.
+  {
+    const PKGS = new Map([
+      ['@objectstack/spec', { private: false, file: 'packages/spec/package.json' }],
+      ['@objectstack/example-showcase', { private: true, file: 'examples/showcase/package.json' }],
+    ]);
+    const cls = (text) => classifyStockChangeset(parseChangeset(text), PKGS).klass;
+    const PRESCRIPTION = '**BREAKING** x\n\n## 迁移\n\n- `a.b` → `a.c`\n';
+    assert(
+      cls(CS({ body: `${PRESCRIPTION}\n<!-- adr-0087: not-required (unpublished) whatever it says, a marker means the question was answered -->\n` })) === 'answered',
+      'S1: a changeset carrying a parseable marker is ANSWERED, whatever else it contains',
+    );
+    assert(
+      cls(CS({ bumps: [['@objectstack/example-showcase', 'major']], body: PRESCRIPTION })) === 'exempt-unpublished',
+      'S2: an all-private bump is exempt even carrying a prescription -- nothing it breaks ships',
+    );
+    assert(
+      cls(CS({ body: '**BREAKING** an internal error string changed; no key or symbol moves\n' })) === 'exempt-no-prescription',
+      'S3: a published break that frames no rewrite is exempt',
+    );
+    assert(cls(CS({ body: PRESCRIPTION })) === 'residue', 'S4: THE #6011 SHAPE -- published break + prescription -- is RESIDUE');
+    assert(
+      cls(`---\n---\n\n${PRESCRIPTION}`) === 'residue',
+      'S5: a changeset declaring NO package cannot buy the unpublished exemption (the gate refuses it too)',
+    );
+    assert(
+      cls(CS({ bumps: [['@objectstack/spec', 'major'], ['@objectstack/example-showcase', 'major']], body: PRESCRIPTION })) === 'residue',
+      'S6: ONE published package among the bumps is enough to close the unpublished exemption',
+    );
+  }
+
   assert(breakingDeclaration(parseChangeset(CS({ body: 'feat(spec)!: x\n' }))).breaking, 'P6: a conventional-commit bang is a declaration');
   assert(!breakingDeclaration(parseChangeset(CS({ bumps: [['a', 'patch']], body: 'plain\n' }))).breaking, 'P7: a plain patch is not');
   assert(extractIds("  id: 'object-titleFormat-to-nameField',\n").length === 1, 'P8: an id with a capital letter must be extracted');
@@ -1349,6 +1575,8 @@ if (argv.includes('--self-test')) {
   selfTest();
 } else if (argv.includes('--list')) {
   list(REPO_ROOT, 'HEAD');
+} else if (argv.includes('--audit-stock')) {
+  auditStock(REPO_ROOT, readFlag('--head') ?? 'HEAD');
 } else {
   const head = readFlag('--head') ?? 'HEAD';
   const requested = readFlag('--base');


### PR DESCRIPTION
Refs #6350

⚠️ **刻意不写 `Fixes`。** 本 PR 落地的是 #6350 的**器械**半边(一次性存量审计口),**没有**动任何一条台账。原因见下「为什么这一版不带回补」—— 抽样那 2 条以及审计新翻出来的另外 49 条,判定全部悬在**同一个未回答的口径问题**上,而登记决定是维护者的。#6350 需要保持 open 直到那个口径被裁定,否则 51 条待判清单会随 issue 一起消失。

## 一、落地了什么

`scripts/check-adr-0087-registration.mjs` 新增 `--audit-stock`,把 #6148 门禁**自己的**判定函数(`breakingDeclaration` / `readDisposition` / `findMigrationPrescription` / `workspacePackagesAt`)对着存量跑一遍。

**这里没有第二份逻辑** —— 只是换一批被判对象。这一点是刻意的:审计若自己抄一份判定,它就会和门禁各自漂移,那样得出的清单谁也不敢信。

**刻意不接 CI,也不该接。** `package.json` 的 `check:adr-0087-registration` 与 Check Changeset 工作流都是**不带旗标**地调门禁;`--audit-stock` 只能手敲。它是 `--list` 的邻居 —— 算子按需跑的常设审计面 —— 不是第二道门。⛔ 把门禁改成回溯全量比对是 #6129 明确拒绝的那条路(会给每个 PR 加上与其改动无关的历史负担),本 PR 一个字都没往那个方向动:`scan()` 与 CI 的调用点原样未改。

### 分桶:238 收窄成人可核的残差

存量 changeset 一条都没有处置标记(从来没有东西问过它们),所以把门禁逐字重放只会把 238 条全报一遍、什么也没说。有信息量的是**它本来有资格拿哪条处置**:

| 桶 | 判据 | 条数 |
| :--- | :--- | ---: |
| answered | 已带处置标记(门禁上线后才落地的) | 3 |
| exempt-unpublished | 所有 bump 的包都 `private: true`,破坏不出门 | 0 |
| exempt-no-prescription | 正文没框出任何改写,catch-all 对它开着 | 143 |
| **RESIDUE** | **已发布的破坏 + 正文带改写指令** ⇒ 只剩 `registered` / `already-registered`,**两者都要台账条目** | **92** |

残差再叠一条**机械**事实,把「作者确实登记过」和「从来没人问过」分开:动过这条 changeset 的 commit 里,有没有哪个**同时**动了台账源?这正是 #6350 手工抽样用的信号,只是算到了全量而不是三个点上。结果:**41 条动过台账**(标 `~`,需核对该条目是否**覆盖**本次面),**51 条一次都没动过**(标 `!`)。

### 一条踩到的坑,已写进脚本

浅克隆下这个信号会**说谎,而且谎得很像真的**:嫁接历史里每个 pre-graft 文件都读作「由嫁接 commit 添加」,而那个 commit 携带整棵树、含**两个**台账源。本容器默认检出就是浅的(104 commit,graft 在 `2bc187641`,该 commit 5978 个文件),实测 92 条残差里 **91 条**被报成「作者登记过」—— **条条都是错的**,而输出在纸面上完全合理。

所以浅克隆时该信号**被抑制,而不是被近似**:打印 `?` 与一段说明,并告诉算子跑 `git fetch --unshallow --filter=blob:none`(只读 tree、不拉 blob 就够)。照 #4690 的口径 —— 报不出来就说报不出来,不许拿一个像样的答案顶上。

### self-test

新增 S1-S6 钉住分类器四个臂与其间的优先级(`unpublished` 优先于 prescription;**不声明任何包**的 changeset 买不到 unpublished 豁免 —— 门禁本身也拒)。

**反向验证(事前判定方向:删守卫 ⇒ 恰好 S5 转红)**:删掉 `parsed.bumps.length > 0` 守卫后,`[].every()` 真空为真,空 frontmatter 的 changeset 会被静默判成 exempt。实测**恰好 S5 一条转红**,方向与事前判定一致。

## 二、抽样那 3 条:逐条落到结论

先说**事实层**(穷举 grep 两个 registry,不是抽查):

| changeset | 台账命中 | 结论 |
| :--- | :--- | :--- |
| `runtime-httpserver-wrapper-retired.md`(#5122) | `HttpServer` 仅 2 处,均为**别的条目正文里顺带提到 `HttpServerConfig`**(#4938) | **确无条目** |
| `record-details-sections-object-form.md`(#5611) | `RecordDetails` / `hideFields` / `record:details` 两个 registry 各 **0** 命中 | **确无条目** |
| `data-driver-query-omit-object.md`(#5181) | `DriverQuery` 仅 1 处,在 **aggregate 别名条目**正文里(作为参数变成的类型),不是被登记的面;`IDataDriver` 的命中全是 `findStream` 与无关行 | **确无条目**(#6350 存疑的第 3 条,现已确认) |

**三条都没有覆盖它们的条目。** 这一层是可核的事实,#6350 的抽样成立。

判定层见第三节 —— 三条的**方向不一致**,而且分歧全部来自同一个口径。

## 三、为什么这一版不带回补(#6350 派单里那条例外条款)

派单写明:「若审计发现的真实漏登记**多于寥寥几条**,不要闷头批量修 —— 先报数量和形状」。**实测 51 条**(去掉正文自带 tombstone / D2 conversion 的 17 条后仍有 34 条),不是 2 条。数量已经改变了这件事的性质。

更要紧的是:**51 条(含抽样那 2 条)的判定全部悬在同一个未回答的问题上。** 台账里五条同族条目(`data-driver-find-stream-retired` #4484、`storage-service-list-retired` #5540、`actor-user-roles-to-positions` #6011、`spec-type-alias-input-suffix-retired` #6083、`driver-aggregate-undeclared-key-aliases-removed` #6321)各自写下了**两条**触发口径,措辞几乎逐字相同:

- **T1** —— 无类型的 JS 消费者**根本没有被强制的渠道**;
- **T2** —— 强制渠道(tsc)**对「缺了什么」很响亮,对「改成什么」却是哑的**,升级指南是唯一承载后半句的渠道。

按 T1/T2 的字面读法,`HttpServer` 退役(T2:`TypeError` 不会说「改成直接注册适配器实例」)与 `RecordDetails.sections`(#5611 当时 `properties` 根本不被 parse ⇒ T1;#5068 接上门后 safeParse 报 `expected object` 也不说「每个 ID 换成 `{ fields: [...] }`」⇒ T2)**都该登记**;而 `IDataDriver` 那条反而**最弱** —— 它的运行期行为零变化,无类型 JS 调用方多传 `object:` 会被静默忽略、**什么都不用做**,TS 侧 TS2353 又逐字点名了要删的键(对「改成什么」并不哑)。

**同一条口径,三条给出三个方向,而按字面读法要补的是 ~34 条而不是 2 条。** 台账是被声明的 **forever artifact**(每次发布 CI 全链重放,条目喂 `migrate meta` / `spec-changes.json` / 已发布的升级指南),一条**错加**的条目会直接发到消费者手里且很难撤回。这个不对称让「先问」明显优于「先猜」,故本 PR 不带回补,问题连同三轴分析回给维护者裁。

## 四、顺带发现,已另立单:#6497

**#6350 抽样的第 1 条(`runtime-httpserver-wrapper-retired.md`),门禁的探测器今天根本够不着它。** 它的迁移说明写成 `## Migration` 标题下的**无箭头两列表**,而 `findMigrationPrescription()` 两条分支都要求出现箭头 —— 于是它落进 `exempt-no-prescription`,压根进不了残差面(它是**人眼**发现的,不是门禁)。

这是**前向**缺口而不只是存量问题:今后任何 PR 把迁移说明写成表格,就能合法写下 `not-required (no-migration-prescription)` 并被批准 —— #6419 那个形状的第三种拼写。实测存量 13 条带此形状,其中 **4 条**声明为 breaking 且正靠这条盲区拿豁免。

按派单口径,**门禁本身的改动另立一单,不在本 PR 内落地** ⇒ #6497。

## 五、验证(真实输出)

```
$ node scripts/check-adr-0087-registration.mjs --self-test
✓ check-adr-0087-registration --self-test: 73 assertions over real temp git repos (real scan()/assertInputs() path)

$ node scripts/check-adr-0087-registration.mjs          # 门禁本体,路径未改
✓ check-adr-0087-registration: this PR adds no declared-breaking changeset (0 non-breaking changeset(s) seen).

$ node scripts/check-nul-bytes.mjs
check-nul-bytes: OK (scanned 6106 tracked text file(s); skipped 5 binary, 1 non-regular; no raw ASCII control bytes).

$ npx eslint scripts/check-adr-0087-registration.mjs
(exit 0)

$ node scripts/check-adr-0087-registration.mjs --audit-stock | head -12
ADR-0087 stock backfill audit (#6350) -- 1372 changeset(s) in stock, 238 declared breaking.

ALREADY ANSWERED -- carries an adr-0087 marker (landed after the gate): 3
    .changeset/adr-0122-phase-2-bare-name-flip.md  [registered spec-type-alias-input-suffix-retired]
    .changeset/aggregate-driver-query-and-alias-retirement.md  [registered driver-aggregate-undeclared-key-aliases-removed]
    .changeset/ui-widget-i18n-family-retired.md  [registered ui-widget-i18n-family-retired]

EXEMPT (unpublished) -- every bumped package is private; nothing ships: 0

EXEMPT (no-migration-prescription) -- the body frames no rewrite: 143
```

**检测器自身的标定**:审计在没有被告知的情况下,把 `tidy-donkeys-yawn.md`(#6048,唯一已确证的那次漏登记)独立地标成了 `!`。它同时说明 `!` **不等于**漏登记 —— 该面早已由 PR #6138 另行补登,今天正确的处置是 `not-required (already-registered actor-user-roles-to-positions)`。

## 六、changeset

**没有**,故需 `skip-changeset`:本 PR 只改一个仓内工具脚本(`scripts/**`),不发布任何东西,读者/消费者可见面零变化。标签已由本座位手动打上。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZgRyPVwi1jLb1mNNuUQ9o

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZgRyPVwi1jLb1mNNuUQ9o)_