### PR TITLE
test(plugin-security): feed the VAMA DELETE half a call shape the engine accepts (#6277)

### DIFF
--- a/packages/plugins/plugin-security/package.json
+++ b/packages/plugins/plugin-security/package.json
@@ -24,6 +24,7 @@
     "@objectstack/spec": "workspace:*"
   },
   "devDependencies": {
+    "@objectstack/metadata-core": "workspace:*",
     "@objectstack/plugin-sharing": "workspace:*",
     "@types/node": "^26.1.2",
     "typescript": "^6.0.3",

--- a/packages/plugins/plugin-security/src/vama-write-path-convergence.test.ts
+++ b/packages/plugins/plugin-security/src/vama-write-path-convergence.test.ts
@@ -26,6 +26,13 @@
 // side breaks it, which is the only property worth pinning here: not "explain
 // says X", but "explain and the write it explains say the same thing".
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  assertEngineDeleteDispatch,
+  assertEngineUpdateDispatch,
+  resolveEngineDeleteDispatch,
+  ENGINE_DELETE_REJECT_MESSAGE,
+  ENGINE_UPDATE_REJECT_MESSAGE,
+} from '@objectstack/metadata-core';
 import { SharingService, buildSharingMiddleware } from '@objectstack/plugin-sharing';
 import { PermissionSetSchema } from '@objectstack/spec/security';
 import type { PermissionSet } from '@objectstack/spec/security';
@@ -125,20 +132,98 @@ function makeEngine() {
       (tables[object] ??= []).push({ ...data });
       return data;
     },
+    /**
+     * The two WRITE VERBS the middleware chain below terminates in. Both open
+     * with the **producer's own dispatch predicate** (#4550 / #5480) rather
+     * than a hand-mirrored guard, so this double cannot accept a call
+     * `ObjectQL.update` / `ObjectQL.delete` would refuse.
+     *
+     * That line is not decoration here — it is the pin for #6277. This file's
+     * `write('delete', …)` used to hand the chain `options: { id }`, a shape
+     * the real engine REJECTS (`resolveEngineDeleteDispatch` reads
+     * `options.where.id`), so the whole DELETE half was asserting against a
+     * call that could never happen. A boolean terminal could not notice; these
+     * two can, and do, by throwing exactly what a running server throws.
+     */
+    async update(object: string, data: any, options?: any) {
+      const dispatch = assertEngineUpdateDispatch(data, options);
+      const rows = (tables[object] ??= []);
+      const targets =
+        dispatch.kind === 'by-id'
+          ? rows.filter((r) => r.id === dispatch.id)
+          : rows.filter((r) => matches(r, options?.where));
+      for (const r of targets) Object.assign(r, data);
+      // `driver.updateMany` resolves a COUNT; a by-id update resolves the row.
+      return dispatch.kind === 'by-id' ? (targets[0] ?? null) : targets.length;
+    },
+    async delete(object: string, options?: any) {
+      const dispatch = assertEngineDeleteDispatch(options);
+      const rows = (tables[object] ??= []);
+      const targets =
+        dispatch.kind === 'by-id'
+          ? rows.filter((r) => r.id === dispatch.id)
+          : rows.filter((r) => matches(r, options?.where));
+      tables[object] = rows.filter((r) => !targets.includes(r));
+      // `driver.deleteMany` resolves a COUNT; a by-id delete resolves a boolean.
+      return dispatch.kind === 'by-id' ? targets.length > 0 : targets.length;
+    },
   };
 }
+
+/**
+ * The by-id DELETE options this fixture feeds the chain — the **canonical**
+ * shape, and the subject of #6277.
+ *
+ * `ObjectQL.delete` dispatches by-id on a truthy scalar `options.where.id` and
+ * on nothing else, and `SecurityPlugin.extractSingleId` reads the same two
+ * places (`data.id`, then `options.where.id`). The old spelling here,
+ * `options: { id }`, satisfied neither — it is not even a legal delete option
+ * bag, since `id` is outside `{ context, where, multi }` + driver passthrough
+ * and `rejectUnknownEngineOptions` refuses it at the entry point (#4371). So
+ * the security extractor answered `null` and the #1994 row-level pre-image
+ * write gate was skipped wholesale on this half: `write('delete', …)` reached
+ * only plugin-sharing's `canDelete`, one of the two gates the case name claims.
+ * Measured on this branch over all three principals below:
+ *
+ * ```
+ *   options: { id }             extractSingleId -> null              computeRlsFilter: never called
+ *   options: { where: { id } }  extractSingleId -> 'rec_ownerless'   computeRlsFilter('delete'): 1 call
+ * ```
+ *
+ * Note what that measurement does NOT say. The gate is now *reached*; its DENY
+ * branch is still not exercised here, because `computeRlsFilter` resolves
+ * `null` for all three of this file's permission sets — none of them authors an
+ * RLS policy, unlike the real `member_default` whose wildcard `owner_only_writes`
+ * is the co-gate #5492 measures. So this file pins gate REACHABILITY, not the
+ * gate's verdict; the verdict is #5492's subject, and when its paired PR makes
+ * `modifyAllRecords` widen the row write gate, the DELETE case below is the
+ * place in this file where that becomes load-bearing.
+ */
+const byIdDeleteOptions = (recordId: string) => ({ where: { id: recordId } });
+
+/** What a dispatch REJECTION reads like — a fixture defect, never a 403. */
+const ENGINE_DISPATCH_REJECTIONS: readonly string[] = [
+  ENGINE_DELETE_REJECT_MESSAGE,
+  ENGINE_UPDATE_REJECT_MESSAGE,
+];
 
 // ── the stack: real SecurityPlugin + real SharingService, one engine ───────
 
 interface Stack {
   security: any;
   sharing: SharingService;
-  /** Run a by-id write through the REAL middleware chain (security → sharing). */
+  /**
+   * Run a by-id write through the REAL middleware chain (security → sharing)
+   * and, when both gates admit it, through the engine's own write verb — so
+   * `{ ok: true }` means the row was really written, not that a boolean was set.
+   */
   write: (
     operation: 'update' | 'delete',
     recordId: string,
     context: any,
   ) => Promise<{ ok: true } | { ok: false; code?: string; message: string }>;
+  /** The fixture's rows, for asserting that an admitted write actually landed. */
+  rows: (object: string) => any[];
 }
 
 async function makeStack(): Promise<Stack> {
@@ -179,6 +264,7 @@ async function makeStack(): Promise<Stack> {
   return {
     security,
     sharing,
+    rows: (object: string) => (engine._tables[object] ??= []),
     async write(operation, recordId, context) {
       const opCtx: any = {
         object: 'crm_contract',
@@ -186,14 +272,27 @@ async function makeStack(): Promise<Stack> {
         context: { ...context },
         ...(operation === 'update'
           ? { data: { id: recordId, signed_by: 'x' } }
-          : { options: { id: recordId } }),
+          // [#6277] The canonical by-id delete shape — see `byIdDeleteOptions`.
+          : { options: byIdDeleteOptions(recordId) }),
       };
       let reached = false;
       try {
         await securityMw(opCtx, async () => {
-          await sharingMw(opCtx, async () => { reached = true; });
+          await sharingMw(opCtx, async () => {
+            // The terminal is the ENGINE's own write verb, not a boolean. This
+            // is what keeps the call shape above honest: both verbs open with
+            // the producer's dispatch predicate, so a fixture that drifts back
+            // to a call the engine refuses fails LOUDLY here instead of quietly
+            // collecting a green from gates that never ran (#6277).
+            if (operation === 'delete') await engine.delete(opCtx.object, opCtx.options);
+            else await engine.update(opCtx.object, opCtx.data, opCtx.options);
+            reached = true;
+          });
         });
       } catch (e: any) {
+        // A dispatch rejection is a defect in THIS fixture, never a permission
+        // verdict — it must never be readable as a 403.
+        if (ENGINE_DISPATCH_REJECTIONS.includes(String(e?.message))) throw e;
         return { ok: false, code: e?.code, message: String(e?.message ?? e) };
       }
       return reached ? { ok: true } : { ok: false, message: 'middleware swallowed the write' };
@@ -245,11 +344,54 @@ describe('[#4647] VAMA holder + private OWD + ownerless record — explain vs. t
   });
 
   it('DELETE: same triple, same convergence (canDelete has no share branch to hide behind)', async () => {
+    // [#6277] The precondition the rest of this case rests on, asserted
+    // against the PRODUCER'S predicate rather than assumed: the options bag
+    // `write('delete', …)` builds is one `ObjectQL.delete` dispatches BY ID.
+    // Until this file was fixed it was `options: { id }` — `reject` — and both
+    // the engine and `SecurityPlugin.extractSingleId` refused to see an id in
+    // it, so the #1994 row-level pre-image write gate never ran on this half
+    // and the assertions below were green for want of anything executing.
+    expect(resolveEngineDeleteDispatch(byIdDeleteOptions(OWNERLESS.id))).toEqual({
+      kind: 'by-id',
+      id: OWNERLESS.id,
+    });
+
     const decision = await explainOf(stack, ADMIN_CTX, 'delete');
     const write = await stack.write('delete', OWNERLESS.id, ADMIN_CTX);
     expect(decision.allowed).toBe(true);
     expect(decision.record).toMatchObject({ visible: true, decidedBy: 'vama_bypass' });
     expect(write).toEqual({ ok: true });
+    // …and `ok: true` now means the row is GONE, because the chain terminates
+    // in the engine's own `delete` rather than in a boolean.
+    expect(stack.rows('crm_contract').map((r) => r.id)).toEqual([OWNED_BY_OTHER.id]);
+  });
+
+  // ── the #6277 pin: the shape this fixture used to feed cannot come back ──
+  it('[#6277] the DELETE shape this fixture used to feed is one the engine REJECTS', async () => {
+    // Reverse verification, committed rather than performed once by hand: put
+    // the old spelling back and the producer's predicate — the same one the
+    // fake engine's `delete` opens with — refuses it. `options: { id }` names
+    // neither one row (no `where.id`) nor a bulk intent (no `multi`).
+    //
+    // Worth stating exactly, because a real server refuses that bag TWICE and
+    // this assertion only pins the second refusal: `ObjectQL.delete` runs
+    // `rejectUnknownEngineOptions` FIRST (#4371 — `id` is not among delete's
+    // legal keys `context`/`where`/`multi` + driver passthrough), so a running
+    // server never reaches the dispatch below, and never reaches its middleware
+    // chain either — no gate, security's or sharing's, runs for this bag on the
+    // real write path. The dispatch verdict pinned here is what the call would
+    // get if the key were legal, and it is the one the fake engine enforces.
+    expect(resolveEngineDeleteDispatch({ id: OWNERLESS.id })).toEqual({
+      kind: 'reject',
+      message: ENGINE_DELETE_REJECT_MESSAGE,
+    });
+    await expect(makeEngine().delete('crm_contract', { id: OWNERLESS.id })).rejects.toThrow(
+      ENGINE_DELETE_REJECT_MESSAGE,
+    );
+    // The asymmetry that let it hide for so long: plugin-sharing's
+    // `inferTargetId` DOES accept `options.id`, so `canDelete` kept running and
+    // kept answering — one of the two gates, doing the work of two.
+    expect(await stack.sharing.canDelete('crm_contract', OWNERLESS.id, MEMBER_CTX as any)).toBe(false);
   });
 
   it("the sys_attachment canEdit(parent) gate converges too — it calls the SAME gate", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1658,6 +1658,9 @@ importers:
         specifier: workspace:*
         version: link:../../spec
     devDependencies:
+      '@objectstack/metadata-core':
+        specifier: workspace:*
+        version: link:../../metadata-core
       '@objectstack/plugin-sharing':
         specifier: workspace:*
         version: link:../plugin-sharing


### PR DESCRIPTION
Fixes #6277

## 问题

`packages/plugins/plugin-security/src/vama-write-path-convergence.test.ts` 的 `write('delete', …)` 把一次 by-id delete 构造成 `options: { id }`。这是一个**真实引擎会拒绝两次**的调用袋:

1. `ObjectQL.delete` 入口先跑 `rejectUnknownEngineOptions`(#4371)——`id` 不在 delete 的合法键 `context` / `where` / `multi` + driver passthrough 之内,直接抛错;
2. 即便该键合法,`resolveEngineDeleteDispatch` 只认 `options.where.id`,该形状落 `reject`(#4550)。

后果:`SecurityPlugin.extractSingleId` 读的是 `data.id` 与 `options.where.id`,对 `options.id` 返回 `null`,于是 **#1994 行级前像写门在 delete 半边整段跳过**。用例名声称「explain 与它所解释的那次写答案一致」,而写的那一侧只跑了两个门里的一个——plugin-sharing 的 `canDelete` 之所以还在跑,是因为它的 `inferTargetId` 恰好也认 `options.id`(`sharing-plugin.ts:922`),这个不对称正是这件事藏了这么久的原因。

## 修法

1. **形状改成引擎真正 dispatch 的 `options: { where: { id } }`**(`byIdDeleteOptions`)。
2. **不只是重新拼写,而是钉住**:中间件链的终点从一个布尔量改成 fake engine 自己的写动词,`delete()` / `update()` 分别以 `assertEngineDeleteDispatch(options)` / `assertEngineUpdateDispatch(data, options)` 开头(#4550 / #5480 的既有纪律,抄 pinned fake 而非手写守卫)。`check:engine-double-contract` 现在把本文件的两个 slice 都报为 `pinned`。往回漂回旧形状会在终点**大声炸掉**,而不是从没跑过的门那里再买一次绿。
3. 新增一条 `[#6277]` 用例,把旧形状的拒绝面**作为断言提交下来**(反向验证不再是一次性手工动作)。
4. `{ ok: true }` 现在意味着「行真的没了」——DELETE 用例断言 `crm_contract` 只剩 `rec_owned`。

## 实测:门确实从「没被问过」变成「被问了」

在本分支上对三个 principal 逐一测量(探针在提交前已删除):

| delete 调用形状 | `extractSingleId` | `computeRlsFilter` |
|---|---|---|
| `options: { id }`(旧) | `null`(admin / auditor / member 全部) | **从未调用** |
| `options: { where: { id } }`(新) | `'rec_ownerless'`(全部) | `('delete')` 各 1 次 |

## 诚实边界:没有任何断言变红,原因要说清楚

派单预期「门首次真正执行后既有断言可能变红,需按 main 现状重钉」。**本文件没有一条断言需要重钉**,而这不是因为门没执行,是因为门执行后答的是「不适用」:

`computeRlsFilter` 对本文件三个 permission set **全部返回 `null`**——它们都没有 authored RLS policy,不像真实的 `member_default`(带通配 `owner_only_writes`,即 #5492 量到的那个 co-gate)。所以前像门的**重读/拒绝分支在本 fixture 里仍未被行使**;本 PR 钉住的是门的**可达性**,不是门的**判决**。

issue 正文引用的「同一个 manager 的 delete 从 `ok: true` 变成 403 (row-level security)」是在 **#5492 的复现装置**(带 manager + authored RLS)里量到的,不是本文件的 fixture;本文件三个 principal 都没有 RLS,所以形状修正前后判决一致。这一点已写进 fixture 注释,并指明:当 #5492 配对 PR 让 `modifyAllRecords` 真正扩到行级写门时,本文件的 DELETE 用例就是那个变化在这里变得 load-bearing 的地方。

## 反向验证(方向:红,且两道防线各自独立)

把 `byIdDeleteOptions` 改回 `{ id: recordId }`:

- 只留显式前置断言 → `AssertionError: expected { kind: 'reject', … } to deeply equal { kind: 'by-id', id: 'rec_ownerless' }`,附 `"message": "Delete requires an ID or options.multi=true"`;
- 把该前置断言临时注释掉、只靠引擎终点 → `Error: Delete requires an ID or options.multi=true`,并且**没有**被 `write()` 的 catch 吞成 403(`ENGINE_DISPATCH_REJECTIONS` 直接重抛)。

两次都只有 DELETE 一条红,其余 11 条绿——即两道防线互不遮蔽。

## 验证

```
pnpm --filter @objectstack/plugin-security test
  Test Files  35 passed (35)
       Tests  769 passed (769)      # 改前 768,新增 1 条 [#6277] 用例

pnpm --filter @objectstack/plugin-security typecheck    # tsc --noEmit,无输出
pnpm --filter @objectstack/plugin-security build        # DTS Build success

node scripts/check-engine-double-contract.mjs
  pinned [delete]  packages/plugins/plugin-security/src/vama-write-path-convergence.test.ts
  pinned [update]  packages/plugins/plugin-security/src/vama-write-path-convergence.test.ts
  check-engine-double-contract: OK — 84 pinned, 133 in the DEBT ledger, 4 exempt.

node scripts/check-nul-bytes.mjs        # OK,6106 files,无裸控制字节
node scripts/check-type-check-coverage.mjs   # OK
node scripts/check-override-consistency.mjs  # OK
npx eslint packages/plugins/plugin-security/src/vama-write-path-convergence.test.ts   # exit 0
```

## 关于 `package.json` 与 changeset

为了 import 生产者自己的 dispatch predicate,给 `@objectstack/plugin-security` 加了 **devDependency** `@objectstack/metadata-core`(该包依赖仅 `@objectstack/spec` + `zod`,门禁的 `modules` 白名单显式接受这个拼写)。无环已实测:`turbo run build --filter=@objectstack/plugin-security --dry` 无 circular / cyclic 告警——与本仓 ledger 中 `audience-anchors.test.ts` 条目记录的结论一致。

本 PR **test-only**,不发布任何用户可见变更,故不写 changeset,挂 `skip-changeset` 标签。

## 在飞零相交

`git ls-remote --heads origin | grep -iE 'issue-(6277|5491|5492|6428)'` 零命中;#5491/#5492 配对批次被 `Blocked-by: #6428` 阻塞、未起飞,本单先落即满足分诊的串行约束。


---
_Generated by [Claude Code](https://claude.ai/code/session_01JwwiU9bjhwy2SWj13ho8uv)_