### PR TITLE
fix(mcp): a metadata outage stops being answered as `Agent "X" not found` (#6055)

### DIFF
--- a/.changeset/mcp-metadata-outage-vs-miss.md
+++ b/.changeset/mcp-metadata-outage-vs-miss.md
@@ -1,0 +1,34 @@
+---
+'@objectstack/mcp': patch
+---
+
+mcp: a metadata outage stops being reported to MCP clients as `Agent "X" not found`
+
+The `agent_prompt` prompt resolved its body through `metadataService.get('agent', name)`
+and answered the resulting `undefined` with `Error: Agent "X" not found`. That `undefined`
+carries two opposite facts (#5840, ADR-0110 D3): the name was never declared, or every
+loader behind the metadata service was down. So during a metadata outage an MCP client was
+told, positively, what the author had declared — from a read that never happened. The same
+shape sat one bridge over: the `objectstack://objects/{objectName}` resource answered
+`getObject()`'s `undefined` with `Object "X" not found`.
+
+**Both surfaces now separate the two.** A degraded read answers `SERVICE_UNAVAILABLE` —
+the same catalogued code and the same "whether it exists is unknown, retry once it is
+reachable" sentence the `sys_metadata` half of this family already emits (#5532 / #5843) —
+and a genuine miss keeps its not-found answer, byte for byte on the prompt surface.
+MCP's `prompts/get` and `resources/read` results carry no error envelope, so the
+classification travels in the payload each surface already had: the prompt's text, and the
+resource's JSON body, which now names `code` and `status` on **both** answers
+(`SERVICE_UNAVAILABLE`/503 vs `RESOURCE_NOT_FOUND`/404) so a client can tell them apart
+without parsing prose.
+
+**This is a diagnosis fix, not an access change.** Both surfaces were already fail-closed:
+no instructions and no schema were served during an outage before this, and none are now.
+The defect was the description.
+
+Hosts whose `metadata` slot predates the optional `getDiagnosed` member report nothing
+degraded — exactly what they could express before — so their behaviour is unchanged. The
+object resource additionally keeps `getObject()` as its resolver and consults the
+diagnosed read only as a verdict probe on the miss path, because `getObject` is its own
+contract member with no documented equivalence to `get('object', name)` (and
+`MetadataFacade.getObject` is not that).

--- a/packages/mcp/src/mcp-server-runtime.metadata-outage.test.ts
+++ b/packages/mcp/src/mcp-server-runtime.metadata-outage.test.ts
@@ -1,0 +1,344 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#6055, ADR-0110 D3 — MCP side] A metadata plane that could not be READ is
+ * not an agent (or an object) that nobody declared.
+ *
+ * ---------------------------------------------------------------------------
+ * The defect
+ * ---------------------------------------------------------------------------
+ * `mcp-server-runtime.ts` resolved the `agent_prompt` body through
+ * `metadataService.get('agent', name)` and answered its `undefined` with
+ * `Error: Agent "X" not found`. `MetadataManager.get()` answers an unreachable
+ * loader chain with exactly the `undefined` a never-declared name produces
+ * (#5840), so during a metadata outage an MCP client was told, positively, what
+ * the author had declared — from a read that never happened.
+ *
+ * The same shape sat one bridge over in the same file: the
+ * `objectstack://objects/{objectName}` resource answered `getObject()`'s
+ * `undefined` with `Object "X" not found`.
+ *
+ * Both were **fail-closed** — no instructions and no schema were served either
+ * way — so this is a diagnosis defect, not a security one, and the fix must
+ * keep it that way. Every degraded case below therefore asserts BOTH halves:
+ * the answer is correctly classified, AND nothing was served.
+ *
+ * ---------------------------------------------------------------------------
+ * Why the assertions are not `toThrow()`, and what stands in for an envelope
+ * ---------------------------------------------------------------------------
+ * Neither surface throws, before or after: MCP answers `prompts/get` with a
+ * `GetPromptResult` and `resources/read` with a `ReadResourceResult`, and
+ * neither type carries an error envelope (only `CallToolResult` has `isError`).
+ * There is no ADR-0112 `code`+`status` on the wire to pin, so the strongest
+ * available discriminator is used instead, per surface:
+ *
+ *   - the RESOURCE body is JSON, so it carries `code`/`status` structurally and
+ *     both answers are pinned on them (`SERVICE_UNAVAILABLE`/503 vs
+ *     `RESOURCE_NOT_FOUND`/404);
+ *   - the PROMPT body is plain text, so the classification travels in the text
+ *     and is pinned as: carries `SERVICE_UNAVAILABLE`, says "unknown", and does
+ *     NOT say "not found".
+ *
+ * On top of that, every pair is pinned as a pair: the outage answer and the
+ * miss answer must not be equal. That is the fact the defect was — before the
+ * fix the two were byte-identical — and it is the one assertion that cannot be
+ * satisfied by a mis-worded improvement.
+ *
+ * ---------------------------------------------------------------------------
+ * Reverse verification, direction predicted BEFORE running
+ * ---------------------------------------------------------------------------
+ * Ordinary red, taken on this consumer. These doubles feed `getDiagnosed`'s
+ * return contract directly, so reverting the producer (`MetadataManager`)
+ * cannot move this file — only restoring the pre-#6055 reads here can. The
+ * reversion is defined as: `agent_prompt` back to
+ * `await metadataService.get('agent', name)` with the single `if (!raw)`, and
+ * the resource back to `getObject()` with the bare
+ * `{ error: 'Object "X" not found' }` body.
+ *
+ * Predicted, written down before running: **8 red / 9 green**, split
+ * 4 red / 6 green on the prompt and 4 red / 3 green on the resource.
+ *
+ * ⚠️ One case is predicted GREEN in BOTH directions, and that is the point of
+ * it rather than a gap: *"DEGRADED: access is still refused"*. The pre-fix code
+ * served no instructions during an outage either — it was fail-closed and
+ * merely mis-described — so an assertion that pins the affordance CANNOT go red
+ * on this fix's reversion. It is an invariant pin, not coverage of the change,
+ * and it is what would go red if a future "fix" here started serving a body.
+ * Reporting it as part of the red count would be a fabricated number; the
+ * measured result is recorded in the PR body as it came out.
+ *
+ * The doubles declare metadata reads only — no engine write verb — so there is
+ * no `delete`/`update` dispatch for `check:engine-double-contract` to scan and
+ * no guard to hand-mirror.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { IMetadataService } from '@objectstack/spec/contracts';
+import {
+  buildAgentPromptResult,
+  buildObjectSchemaResource,
+} from './mcp-server-runtime.js';
+
+type AnyRecord = Record<string, any>;
+
+const LOADER_FAILURE = 'database: connect ECONNREFUSED 10.0.0.5:5432';
+
+const AGENT = { name: 'data_chat', instructions: 'You answer questions about the data.' };
+const OBJECT = { name: 'acct', label: 'Account', fields: { title: { type: 'text' } } };
+
+function makeLogger() {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as AnyRecord;
+}
+
+/**
+ * Build a metadata-service double.
+ *
+ * Every REQUIRED member of `IMetadataService` is present and throws, so a code
+ * path that reaches one this fix should not touch fails loudly instead of
+ * resolving `undefined` and looking like the very absence under test.
+ */
+function makeService(overrides: AnyRecord): IMetadataService {
+  const unexpected = (member: string) => async () => {
+    throw new Error(`double: ${member}() should not be called by this surface`);
+  };
+  return {
+    register: unexpected('register'),
+    get: unexpected('get'),
+    list: unexpected('list'),
+    unregister: unexpected('unregister'),
+    exists: unexpected('exists'),
+    listNames: unexpected('listNames'),
+    getObject: unexpected('getObject'),
+    listObjects: unexpected('listObjects'),
+    ...overrides,
+  } as unknown as IMetadataService;
+}
+
+/** Every loader behind the metadata service is down; nothing answered. */
+const inOutage = (extra: AnyRecord = {}) =>
+  makeService({
+    get: vi.fn(async () => undefined),
+    getObject: vi.fn(async () => undefined),
+    getDiagnosed: vi.fn(async () => ({ data: undefined, degraded: true, errors: [LOADER_FAILURE] })),
+    ...extra,
+  });
+
+/** The read HAPPENED and nobody declared this name. */
+const withMiss = (extra: AnyRecord = {}) =>
+  makeService({
+    get: vi.fn(async () => undefined),
+    getObject: vi.fn(async () => undefined),
+    getDiagnosed: vi.fn(async () => ({ data: undefined, degraded: false, errors: [] })),
+    ...extra,
+  });
+
+/** A healthy service holding `body`. */
+const holding = (body: unknown, extra: AnyRecord = {}) =>
+  makeService({
+    get: vi.fn(async () => body),
+    getObject: vi.fn(async () => body),
+    getDiagnosed: vi.fn(async () => ({ data: body, degraded: false, errors: [] })),
+    ...extra,
+  });
+
+/**
+ * A service that predates `getDiagnosed` (#5840 declared it OPTIONAL). It
+ * cannot report the distinction, so this surface must degrade to exactly what
+ * it did before — never probe a member that is not there, never throw.
+ */
+const legacy = (body?: unknown) =>
+  makeService({
+    get: vi.fn(async () => body),
+    getObject: vi.fn(async () => body),
+  });
+
+const promptText = (r: { messages: Array<{ content: { text: string } }> }) => r.messages[0].content.text;
+const promptRole = (r: { messages: Array<{ role: string }> }) => r.messages[0].role;
+const resourceBody = (r: { contents: Array<{ text: string }> }) => JSON.parse(r.contents[0].text);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// agent_prompt — the call site the issue names
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('agent_prompt — a metadata outage is not "Agent not found" (#6055)', () => {
+  it('PRESENT: serves the agent instructions (unchanged)', async () => {
+    const svc = holding(AGENT);
+    const result = await buildAgentPromptResult(svc, { agentName: 'data_chat' });
+
+    expect(promptRole(result)).toBe('assistant');
+    expect(promptText(result)).toContain('You answer questions about the data.');
+  });
+
+  it('PRESENT: still folds the UI context hints in (unchanged)', async () => {
+    const result = await buildAgentPromptResult(holding(AGENT), {
+      agentName: 'data_chat',
+      objectName: 'acct',
+      recordId: 'r1',
+      viewName: 'all',
+    });
+
+    expect(promptText(result)).toContain('--- Current Context ---');
+    expect(promptText(result)).toContain('Current object: acct');
+    expect(promptText(result)).toContain('Selected record ID: r1');
+    expect(promptText(result)).toContain('Current view: all');
+  });
+
+  it('GENUINELY ABSENT: the not-found answer is preserved, byte for byte', async () => {
+    const result = await buildAgentPromptResult(withMiss(), { agentName: 'data_chat' });
+
+    // Verbatim: a miss is a real fact about what the author declared, and this
+    // surface was always right to state it. The fix must not reword it.
+    expect(promptText(result)).toBe('Error: Agent "data_chat" not found');
+  });
+
+  it('DEGRADED: answers SERVICE_UNAVAILABLE, and never the not-found claim', async () => {
+    const result = await buildAgentPromptResult(inOutage(), { agentName: 'data_chat' });
+    const text = promptText(result);
+
+    expect(text).toContain('SERVICE_UNAVAILABLE');
+    expect(text).toContain('whether agent "data_chat" exists is unknown');
+    expect(text).not.toMatch(/not found/);
+  });
+
+  it('DEGRADED: access is still refused — no instructions are served', async () => {
+    const result = await buildAgentPromptResult(inOutage(), { agentName: 'data_chat' });
+
+    // Fail-closed, before and after. A body here would be a security
+    // regression, not a nicety — the defect was the DESCRIPTION, never the
+    // affordance.
+    expect(promptRole(result)).toBe('user');
+    expect(promptText(result)).not.toContain(AGENT.instructions);
+  });
+
+  it('the outage and the miss no longer collapse to the same answer', async () => {
+    const outage = promptText(await buildAgentPromptResult(inOutage(), { agentName: 'data_chat' }));
+    const miss = promptText(await buildAgentPromptResult(withMiss(), { agentName: 'data_chat' }));
+
+    // Same surface, same agent name, same (absent) result — only the health of
+    // the metadata plane differs. Before #6055 both produced
+    // `Error: Agent "data_chat" not found`.
+    expect(outage).not.toBe(miss);
+    expect(miss).toMatch(/not found/);
+    expect(outage).toMatch(/SERVICE_UNAVAILABLE/);
+  });
+
+  it('reads through getDiagnosed, not get, when the service offers it', async () => {
+    const svc = inOutage();
+    await buildAgentPromptResult(svc, { agentName: 'data_chat' });
+
+    // If `get` were still the read, the verdict would be unreachable and the
+    // case above could only pass by accident.
+    expect((svc as AnyRecord).getDiagnosed).toHaveBeenCalledWith('agent', 'data_chat');
+    expect((svc as AnyRecord).get).not.toHaveBeenCalled();
+  });
+
+  it('logs the outage once, with the consequence and the fix', async () => {
+    const logger = makeLogger();
+    await buildAgentPromptResult(inOutage(), { agentName: 'data_chat' }, logger as any);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const [line, detail] = logger.warn.mock.calls[0];
+    expect(String(line)).toContain('no instructions were served');
+    expect(String(line)).toContain('Fix:');
+    expect(detail).toMatchObject({ agentName: 'data_chat', errors: [LOADER_FAILURE] });
+    // A miss is not a degradation and must not log at all.
+    const quiet = makeLogger();
+    await buildAgentPromptResult(withMiss(), { agentName: 'data_chat' }, quiet as any);
+    expect(quiet.warn).not.toHaveBeenCalled();
+  });
+
+  it('a service that predates getDiagnosed behaves exactly as it did', async () => {
+    const missing = legacy();
+    expect(promptText(await buildAgentPromptResult(missing, { agentName: 'data_chat' })))
+      .toBe('Error: Agent "data_chat" not found');
+    expect((missing as AnyRecord).get).toHaveBeenCalledWith('agent', 'data_chat');
+
+    const present = legacy(AGENT);
+    expect(promptText(await buildAgentPromptResult(present, { agentName: 'data_chat' })))
+      .toContain(AGENT.instructions);
+  });
+
+  it('a missing agentName argument is still refused before any read', async () => {
+    // `makeService`'s required members all throw, so reaching a read here fails
+    // the test rather than passing quietly.
+    const result = await buildAgentPromptResult(makeService({}), {});
+    expect(promptText(result)).toBe('Error: agentName argument is required');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// objectstack://objects/{objectName} — the same family, one bridge over
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('object_schema resource — a metadata outage is not "Object not found" (#6055)', () => {
+  it('PRESENT: serves the object schema (unchanged)', async () => {
+    const body = resourceBody(await buildObjectSchemaResource(holding(OBJECT), 'acct'));
+
+    expect(body).toMatchObject({ name: 'acct', label: 'Account' });
+    expect(body.fields).toEqual([{ name: 'title', type: 'text', label: 'title', required: false }]);
+  });
+
+  it('PRESENT: the hit path costs no second read', async () => {
+    const svc = holding(OBJECT);
+    await buildObjectSchemaResource(svc, 'acct');
+
+    // `getObject` stays the resolver (it is its own contract member, and
+    // `MetadataFacade.getObject` is NOT `get('object', name)`); the diagnosed
+    // read is a verdict probe on the MISS path only.
+    expect((svc as AnyRecord).getObject).toHaveBeenCalledWith('acct');
+    expect((svc as AnyRecord).getDiagnosed).not.toHaveBeenCalled();
+  });
+
+  it('GENUINELY ABSENT: not-found, classified 404 / RESOURCE_NOT_FOUND', async () => {
+    const body = resourceBody(await buildObjectSchemaResource(withMiss(), 'acct'));
+
+    expect(body).toEqual({
+      error: 'Object "acct" not found',
+      code: 'RESOURCE_NOT_FOUND',
+      status: 404,
+    });
+  });
+
+  it('DEGRADED: unavailable, classified 503 / SERVICE_UNAVAILABLE, no schema served', async () => {
+    const body = resourceBody(await buildObjectSchemaResource(inOutage(), 'acct'));
+
+    expect(body.code).toBe('SERVICE_UNAVAILABLE');
+    expect(body.status).toBe(503);
+    expect(body.error).toContain('whether object "acct" exists is unknown');
+    expect(body.error).not.toMatch(/not found/);
+    // Fail-closed: still no schema.
+    expect(body.fields).toBeUndefined();
+    expect(body.name).toBeUndefined();
+  });
+
+  it('the outage and the miss no longer collapse to the same answer', async () => {
+    const outage = resourceBody(await buildObjectSchemaResource(inOutage(), 'acct'));
+    const miss = resourceBody(await buildObjectSchemaResource(withMiss(), 'acct'));
+
+    expect(outage).not.toEqual(miss);
+    expect([outage.code, outage.status]).toEqual(['SERVICE_UNAVAILABLE', 503]);
+    expect([miss.code, miss.status]).toEqual(['RESOURCE_NOT_FOUND', 404]);
+  });
+
+  it('probes the object type by name when the resolver came back empty', async () => {
+    const svc = inOutage();
+    await buildObjectSchemaResource(svc, 'acct');
+
+    expect((svc as AnyRecord).getObject).toHaveBeenCalledWith('acct');
+    expect((svc as AnyRecord).getDiagnosed).toHaveBeenCalledWith('object', 'acct');
+  });
+
+  it('a service that predates getDiagnosed behaves exactly as it did', async () => {
+    const missing = legacy();
+    const body = resourceBody(await buildObjectSchemaResource(missing, 'acct'));
+
+    expect(body.error).toBe('Object "acct" not found');
+    expect((missing as AnyRecord).getObject).toHaveBeenCalledWith('acct');
+
+    const present = legacy(OBJECT);
+    expect(resourceBody(await buildObjectSchemaResource(present, 'acct'))).toMatchObject({
+      name: 'acct',
+      label: 'Account',
+    });
+  });
+});

--- a/packages/mcp/src/mcp-server-runtime.ts
+++ b/packages/mcp/src/mcp-server-runtime.ts
@@ -68,6 +68,308 @@ const DESTRUCTIVE_TOOLS = new Set([
   'delete_field',
 ]);
 
+// ── Metadata outage vs. metadata miss (#6055, ADR-0110 D3) ───────────────────
+
+/**
+ * [#6055] The classification this file gives "the metadata read did not
+ * happen", and the classification it gives "the read happened and found
+ * nothing". Both are the standard catalog's own codes for their status
+ * (`HttpStatusErrorCodeMap[503]` / `[404]`, ADR-0112) — the same spelling the
+ * `sys_metadata` half of this family already emits (#5532 / #5843 / #5705), not
+ * a vocabulary invented for MCP.
+ *
+ * There is no HTTP status on this surface: MCP answers `prompts/get` with a
+ * `GetPromptResult` and `resources/read` with a `ReadResourceResult`, and
+ * neither carries an error envelope (only `CallToolResult` has `isError`). So
+ * the code travels in the payload the surface already had — text for a prompt,
+ * the JSON body for a resource — and that is the strongest discriminator this
+ * transport offers. See the PR body for why the channel was not changed.
+ */
+const METADATA_UNAVAILABLE_CODE = 'SERVICE_UNAVAILABLE';
+const METADATA_MISS_CODE = 'RESOURCE_NOT_FOUND';
+
+/**
+ * [#6055] The sentence for "a read that would have decided this did not
+ * happen", modelled on `METADATA_STORE_UNAVAILABLE_MESSAGE` (#5532) —
+ * *whether it exists is unknown*, plus the retry advice — with two deliberate
+ * differences:
+ *
+ * 1. It names the **metadata service**, not "the metadata store". The verdict
+ *    behind it is `getDiagnosed`'s `degraded`, whose meaning is "at least one
+ *    LOADER threw and nothing answered this item" — a loader-set fact, not a
+ *    single-store one. PR #6051 records that distinction explicitly (it is why
+ *    `degraded` did not copy #5897's `storeUnavailable` spelling), so echoing
+ *    "store" here would import the narrower claim.
+ * 2. It states what the caller is NOT getting. This surface is fail-CLOSED
+ *    both before and after this change — the defect was never that an outage
+ *    widened access, only that it was **described** as an author's decision —
+ *    and saying so keeps the next reader from "restoring" a body here.
+ */
+function metadataUnavailableSentence(subject: string, withheld: string): string {
+  return (
+    `The metadata service could not be read, so whether ${subject} exists is unknown. `
+    + `No ${withheld} is being served for this call. `
+    + 'Retry once the metadata service is reachable.'
+  );
+}
+
+/** What {@link diagnosedGet} and {@link diagnoseEmptyRead} report. */
+interface DiagnosedRead {
+  data: unknown;
+  degraded: boolean;
+  errors: string[];
+}
+
+/**
+ * [#6055] Read one metadata item, keeping the ADR-0110 D3 verdict instead of
+ * flattening an outage into the same `undefined` a never-declared name
+ * produces.
+ *
+ * `IMetadataService.getDiagnosed` is **optional** (#5840): implementations that
+ * predate it cannot report the distinction at all, so a service without it is
+ * read exactly as before and reports nothing degraded — which is precisely what
+ * it could express. Same probe, same fallback, as the two consumers PR #6051
+ * landed (`metadata-protocol/src/protocol.ts`, `objectql/src/plugin.ts`).
+ *
+ * `getDiagnosed` is the diagnosed twin of `get` (registry-first, and
+ * `metadata-manager-get-diagnosed.test.ts` pins that `get()` and
+ * `getDiagnosed().data` agree on every case), so swapping it in for a `get`
+ * call site changes what the caller LEARNS, never what it resolves.
+ */
+async function diagnosedGet(
+  metadataService: IMetadataService,
+  type: string,
+  name: string,
+): Promise<DiagnosedRead> {
+  if (typeof metadataService.getDiagnosed === 'function') {
+    const diagnosed = await metadataService.getDiagnosed(type, name);
+    return {
+      data: diagnosed?.data,
+      degraded: diagnosed?.degraded === true,
+      errors: Array.isArray(diagnosed?.errors) ? diagnosed.errors : [],
+    };
+  }
+  return { data: await metadataService.get(type, name), degraded: false, errors: [] };
+}
+
+/**
+ * [#6055] The verdict for a lookup that did NOT go through `get` — used by the
+ * `object_schema` resource, whose resolver is `getObject(name)`.
+ *
+ * Deliberately a **verdict-only probe run after the empty answer**, rather than
+ * swapping `getObject` out for `getDiagnosed('object', name)`. `getObject` is
+ * its own member of `IMetadataService` with no documented equivalence to
+ * `get('object', name)`, and the equivalence does not hold in general:
+ * `MetadataManager.getObject` delegates to `get('object', name)`, but
+ * `MetadataFacade.getObject` (objectql) returns `registry.getObject(name)` — a
+ * different shape from its own `get()`. Presuming the equivalence at a consumer
+ * is exactly the private dialect Prime Directive #12 forbids, so the resolver
+ * is left untouched and only the *question* "could this answer be trusted as
+ * complete?" is asked of the contract member that is declared to answer it.
+ *
+ * Consequences of that choice, both acceptable and both deliberate:
+ * - one extra read on the MISS path only (never on a hit, never on success);
+ * - on a host that implements `getDiagnosed` *and* a `getObject` resolving
+ *   somewhere else, a degraded loader set makes this answer "unknown" for an
+ *   object that is genuinely absent. That is the conservative direction — it
+ *   withholds, it never admits — and no such host exists today
+ *   (`MetadataManager` is the only `getDiagnosed` implementation on `main`).
+ */
+async function diagnoseEmptyRead(
+  metadataService: IMetadataService,
+  type: string,
+  name: string,
+): Promise<{ degraded: boolean; errors: string[] }> {
+  if (typeof metadataService.getDiagnosed !== 'function') {
+    return { degraded: false, errors: [] };
+  }
+  const diagnosed = await metadataService.getDiagnosed(type, name);
+  return {
+    degraded: diagnosed?.degraded === true,
+    errors: Array.isArray(diagnosed?.errors) ? diagnosed.errors : [],
+  };
+}
+
+/**
+ * What MCP's `prompts/get` answers with — the text-content subset of the SDK's
+ * `GetPromptResult` this surface produces.
+ *
+ * The index signature is not decoration: the SDK's own result types are
+ * `{ [x: string]: unknown; … }` (protocol passthrough plus `_meta`), and a
+ * named interface without it is rejected by `registerPrompt`'s callback
+ * signature. Narrower than `GetPromptResult` on the `content` union so the pin
+ * tests can read `.text` without narrowing at every assertion.
+ */
+export interface AgentPromptResult {
+  [key: string]: unknown;
+  messages: Array<{ role: 'user' | 'assistant'; content: { type: 'text'; text: string } }>;
+}
+
+/** An `Error: …` answer on the prompt surface — this file's existing shape. */
+function promptError(text: string): AgentPromptResult {
+  return { messages: [{ role: 'user' as const, content: { type: 'text' as const, text } }] };
+}
+
+/**
+ * [#6055] Resolve the `agent_prompt` answer for one call.
+ *
+ * Exported so the three states below can be pinned directly: the handler is
+ * registered on a private `McpServer`, and driving it over a transport would
+ * test the SDK rather than this decision.
+ *
+ * The three states, and why each answers what it does:
+ *
+ * - **present** — the agent's instructions plus any UI context. Unchanged.
+ * - **genuinely absent** — `Error: Agent "X" not found`, byte-identical to
+ *   before. A miss is a real fact about what the author declared and this
+ *   surface was always right to state it.
+ * - **degraded** — an honest {@link METADATA_UNAVAILABLE_CODE} sentence.
+ *   Before #6055 this case produced the *not found* text: an availability
+ *   failure reported to an MCP client as a declaration fact, the ADR-0110 D3
+ *   shape. It never widened access (no instructions were served either way),
+ *   so this is a diagnosis fix and MUST stay one — a body served here would be
+ *   a security regression, not a nicety.
+ *
+ * Order matters and is the same narrowing PR #6051 applied to `getMetaItem`:
+ * `degraded` only decides the answer once the read has resolved NOTHING, i.e.
+ * only when the answer would otherwise have been the unfounded "not found".
+ * A read that answered a body is served as it always was.
+ */
+export async function buildAgentPromptResult(
+  metadataService: IMetadataService,
+  args: { agentName?: unknown; objectName?: unknown; recordId?: unknown; viewName?: unknown },
+  logger?: Logger,
+): Promise<AgentPromptResult> {
+  const agentName = String(args.agentName ?? '');
+  if (!agentName) {
+    return promptError('Error: agentName argument is required');
+  }
+
+  const read = await diagnosedGet(metadataService, 'agent', agentName);
+
+  if (read.data === undefined || read.data === null) {
+    if (read.degraded) {
+      logger?.warn(
+        '[MCP] agent prompt refused — the metadata service could not be read, so whether this agent '
+          + 'exists is unknown. The caller was told SERVICE_UNAVAILABLE and no instructions were served '
+          + '(unchanged: nothing is served on a miss either). '
+          + 'Fix: check the loaders behind the metadata service (datasource connection, credentials, table).',
+        { agentName, errors: read.errors },
+      );
+      return promptError(
+        `Error: ${METADATA_UNAVAILABLE_CODE} — `
+          + metadataUnavailableSentence(`agent "${agentName}"`, 'agent instruction'),
+      );
+    }
+    return promptError(`Error: Agent "${agentName}" not found`);
+  }
+
+  const agent = read.data as Agent;
+
+  // Build system prompt from agent instructions + context
+  const parts: string[] = [];
+  parts.push(agent.instructions ?? '');
+
+  const contextHints: string[] = [];
+  if (args.objectName) contextHints.push(`Current object: ${args.objectName}`);
+  if (args.recordId) contextHints.push(`Selected record ID: ${args.recordId}`);
+  if (args.viewName) contextHints.push(`Current view: ${args.viewName}`);
+  if (contextHints.length > 0) {
+    parts.push('\n--- Current Context ---\n' + contextHints.join('\n'));
+  }
+
+  return {
+    messages: [{
+      role: 'assistant' as const,
+      content: { type: 'text' as const, text: parts.join('\n') },
+    }],
+  };
+}
+
+/**
+ * What MCP's `resources/read` answers with — the text-content subset of the
+ * SDK's `ReadResourceResult`. Carries an index signature for the same reason
+ * {@link AgentPromptResult} does.
+ */
+export interface ObjectSchemaResourceResult {
+  [key: string]: unknown;
+  contents: Array<{ uri: string; mimeType: string; text: string }>;
+}
+
+/**
+ * [#6055] Resolve the `objectstack://objects/{objectName}` answer for one call.
+ *
+ * The `agent_prompt` sibling of this fix, on the second occurrence of the same
+ * family in this package: `getObject()` returning `undefined` was read as
+ * `Object "X" not found` whether the object was never declared or every loader
+ * behind the metadata service was down.
+ *
+ * A resource body is JSON, so unlike the prompt surface it can carry the
+ * classification structurally — and both answers now do, so an MCP client can
+ * tell an outage from a miss without parsing prose. The `error` sentence of the
+ * miss is unchanged; `code`/`status` are additive.
+ *
+ * Why the resolver is still `getObject` and the verdict is a second, probe-only
+ * read: see {@link diagnoseEmptyRead}.
+ */
+export async function buildObjectSchemaResource(
+  metadataService: IMetadataService,
+  objectName: string,
+  logger?: Logger,
+): Promise<ObjectSchemaResourceResult> {
+  const uri = `objectstack://objects/${objectName}`;
+  const body = (payload: unknown): ObjectSchemaResourceResult => ({
+    contents: [{ uri, mimeType: 'application/json', text: JSON.stringify(payload) }],
+  });
+
+  const objectDef = await metadataService.getObject(objectName);
+
+  if (!objectDef) {
+    const { degraded, errors } = await diagnoseEmptyRead(metadataService, 'object', objectName);
+    if (degraded) {
+      logger?.warn(
+        '[MCP] object schema withheld — the metadata service could not be read, so whether this object '
+          + 'exists is unknown. The caller was told SERVICE_UNAVAILABLE and no schema was served '
+          + '(unchanged: nothing is served on a miss either). '
+          + 'Fix: check the loaders behind the metadata service (datasource connection, credentials, table).',
+        { objectName, errors },
+      );
+      return body({
+        error: metadataUnavailableSentence(`object "${objectName}"`, 'schema'),
+        code: METADATA_UNAVAILABLE_CODE,
+        status: 503,
+      });
+    }
+    return body({
+      error: `Object "${objectName}" not found`,
+      code: METADATA_MISS_CODE,
+      status: 404,
+    });
+  }
+
+  const def = objectDef as ObjectDef;
+  const fields = def.fields ?? {};
+  const fieldSummary = Object.entries(fields).map(([key, f]) => ({
+    name: key,
+    type: f.type,
+    label: f.label ?? key,
+    required: f.required ?? false,
+  }));
+
+  return {
+    contents: [{
+      uri,
+      mimeType: 'application/json',
+      text: JSON.stringify({
+        name: def.name,
+        label: def.label ?? def.name,
+        fields: fieldSummary,
+        enableFeatures: def.enable ?? {},
+      }, null, 2),
+    }],
+  };
+}
+
 /**
  * MCPServerRuntime — Bridges ObjectStack kernel services to the Model Context Protocol.
  *
@@ -291,42 +593,10 @@ export class MCPServerRuntime {
         description: 'Get the full schema of a specific data object including fields and features',
         mimeType: 'application/json',
       },
-      async (_uri, variables) => {
-        const objectName = String(variables.objectName);
-        const objectDef = await metadataService.getObject(objectName);
-
-        if (!objectDef) {
-          return {
-            contents: [{
-              uri: `objectstack://objects/${objectName}`,
-              mimeType: 'application/json',
-              text: JSON.stringify({ error: `Object "${objectName}" not found` }),
-            }],
-          };
-        }
-
-        const def = objectDef as ObjectDef;
-        const fields = def.fields ?? {};
-        const fieldSummary = Object.entries(fields).map(([key, f]) => ({
-          name: key,
-          type: f.type,
-          label: f.label ?? key,
-          required: f.required ?? false,
-        }));
-
-        return {
-          contents: [{
-            uri: `objectstack://objects/${objectName}`,
-            mimeType: 'application/json',
-            text: JSON.stringify({
-              name: def.name,
-              label: def.label ?? def.name,
-              fields: fieldSummary,
-              enableFeatures: def.enable ?? {},
-            }, null, 2),
-          }],
-        };
-      },
+      async (_uri, variables) =>
+        // [#6055] Outage vs. miss lives in the builder — see
+        // {@link buildObjectSchemaResource}.
+        buildObjectSchemaResource(metadataService, String(variables.objectName), logger),
     );
     resourceCount++;
 
@@ -448,48 +718,10 @@ export class MCPServerRuntime {
           viewName: z.string().optional().describe('Current view name'),
         },
       },
-      async (args) => {
-        const agentName = String(args.agentName ?? '');
-        if (!agentName) {
-          return {
-            messages: [{
-              role: 'user' as const,
-              content: { type: 'text' as const, text: 'Error: agentName argument is required' },
-            }],
-          };
-        }
-
-        const raw = await metadataService.get('agent', agentName);
-        if (!raw) {
-          return {
-            messages: [{
-              role: 'user' as const,
-              content: { type: 'text' as const, text: `Error: Agent "${agentName}" not found` },
-            }],
-          };
-        }
-
-        const agent = raw as Agent;
-
-        // Build system prompt from agent instructions + context
-        const parts: string[] = [];
-        parts.push(agent.instructions ?? '');
-
-        const contextHints: string[] = [];
-        if (args.objectName) contextHints.push(`Current object: ${args.objectName}`);
-        if (args.recordId) contextHints.push(`Selected record ID: ${args.recordId}`);
-        if (args.viewName) contextHints.push(`Current view: ${args.viewName}`);
-        if (contextHints.length > 0) {
-          parts.push('\n--- Current Context ---\n' + contextHints.join('\n'));
-        }
-
-        return {
-          messages: [{
-            role: 'assistant' as const,
-            content: { type: 'text' as const, text: parts.join('\n') },
-          }],
-        };
-      },
+      async (args) =>
+        // [#6055] Outage vs. miss lives in the builder — see
+        // {@link buildAgentPromptResult}.
+        buildAgentPromptResult(metadataService, args, logger),
     );
 
     logger?.info('[MCP] Agent prompts bridged');


### PR DESCRIPTION
Fixes #6055

An MCP client asking for an agent prompt during a metadata outage was told `Error: Agent "X" not found` — an availability failure reported as a fact about what the author declared. This PR makes the two answers different. It does **not** change what is served: the surface was fail-closed before and is fail-closed after.

---

## 1. Premise re-check (first action, against `origin/main`)

Holds, with the line drift the dispatch predicted. Located by content, not by line number:

| Claim | Verdict on `origin/main` |
|---|---|
| `mcp-server-runtime.ts:443` reads `metadataService.get('agent', agentName)` | **True**, now at **:462** |
| the `undefined` is answered as `Agent "X" not found` | **True**, verbatim |
| fail-closed, not a security defect | **True** — no instructions are served on either branch |
| `getDiagnosed` landed and is consumable | **True** — `IMetadataService.getDiagnosed?` at `packages/spec/src/contracts/metadata-service.ts:262`, `MetadataManager.getDiagnosed` at `packages/metadata/src/metadata-manager.ts:836` |

## 2. The PM's mechanism assumptions, verified rather than assumed

**`getDiagnosed` is OPTIONAL — confirmed, and handled explicitly.** The contract declares it `getDiagnosed?(…)` and says so in prose: *"Optional: implementations that predate it simply cannot report the distinction, and a consumer that probes for it must keep reading `get` when it is absent."* Both new read paths probe with `typeof … === 'function'` and fall back; a legacy service is pinned by two tests (`a service that predates getDiagnosed behaves exactly as it did`), one per surface.

**Both landed consumer samples were read; this surface takes the shape of the 503 one and the level of the warn one.** They are not two styles of the same choice — they answer two different questions, and this surface answers both:

- `packages/metadata-protocol/src/protocol.ts` (**503**) — its caller is a REST boundary that will render the answer. The MCP surfaces are the same: an external caller is waiting and *will be told something*, so it must be told the truth. This PR takes that shape, and narrows it exactly as PR #6051 narrowed `getMetaItem`: `degraded` changes the answer **only after the read has resolved nothing**, i.e. only when the answer would otherwise have been the unfounded "not found". A read that answered a body is served exactly as before.
- `packages/objectql/src/plugin.ts` (**warn**) — its subject is the *log level*, decided by AGENTS.md "Degradation log levels" rather than by analogy. Asked honestly here: does something this code claims is persisted fail to land while the system looks normal? No — nothing was written, a read failed, and the caller is told in the same breath. So `warn`, carrying the consequence and the fix, exactly as that sample does.

**Sibling-occurrence sweep inside `packages/mcp` — one more found, and it is in the same file.** Every metadata read in the package:

| Site | Read | Verdict |
|---|---|---|
| `mcp-server-runtime.ts:462` `agent_prompt` | `get('agent', n)` | the issue's subject — **fixed** |
| `mcp-server-runtime.ts:296` `object_schema` resource | `getObject(n)` | same family, same file — **fixed** |
| `mcp-server-runtime.ts:268` `objectstack://objects` | `listObjects()` | plural read; no diagnosed counterpart exists — **filed, not fixed** (§6) |
| `mcp-server-runtime.ts:499` skill prompts | `list('skill')` | same as above — **filed, not fixed** (§6) |
| `mcp-server-runtime.ts:398` metadata types | `getRegisteredTypes()` | not the family (no absence claim) |

The one sibling PR #6051 named outside this package — `service-datasource/src/plugin.ts:82` — is untouched, per the dispatch.

## 3. What changed

Two call sites, both in `packages/mcp/src/mcp-server-runtime.ts`, each extracted into an exported builder so the decision can be pinned directly (the handlers are registered on a private `McpServer`; driving them over a transport would test the SDK, not this decision).

**`agent_prompt`** reads through `getDiagnosed('agent', name)` when the service offers it. Three answers:

- present → the instructions, unchanged;
- genuinely absent → `Error: Agent "X" not found`, **byte-identical** to before;
- degraded → `Error: SERVICE_UNAVAILABLE — the metadata service could not be read, so whether agent "X" exists is unknown. No agent instruction is being served for this call. Retry once the metadata service is reachable.`

**`object_schema`** keeps `getObject(name)` as its resolver and consults `getDiagnosed('object', name)` as a **verdict-only probe on the miss path**. Why not just swap the resolver: `getObject` is its own contract member with no documented equivalence to `get('object', name)`, and the equivalence does not hold — `MetadataManager.getObject` delegates to `get('object', name)`, but `MetadataFacade.getObject` (objectql) returns `registry.getObject(name)`, a different lookup returning a different shape. Presuming that equivalence at a consumer is the private dialect Prime Directive #12 forbids. The trade is one extra read on the miss path only (never on a hit), and on a hypothetical host with both a `getDiagnosed` and a divergent `getObject` the probe can only make the answer *more* conservative — it withholds, it never admits. Written up in `diagnoseEmptyRead`'s TSDoc, and the contract gap itself is filed (§6).

### Wording and classification

`SERVICE_UNAVAILABLE` / 503 and `RESOURCE_NOT_FOUND` / 404 are the standard catalog's own codes for their statuses (ADR-0112), the same spelling the `sys_metadata` half of this family already emits (#5532 / #5705 / #5843) — no vocabulary invented for MCP. The sentence is modelled on `METADATA_STORE_UNAVAILABLE_MESSAGE` (*whether it exists is unknown*, plus retry advice) with two deliberate departures, both argued in the code: it names the **metadata service**, not "the metadata store", because `degraded` is a loader-set fact and PR #6051 explicitly declined #5897's single-store `storeUnavailable` spelling for that reason; and it states what is **not** being served, so the next reader does not "restore" a body here.

## 4. Where the ADR-0112 envelope could not go, and what stands in for it

Reported as the dispatch asked. **This transport has no error envelope on either surface.** MCP answers `prompts/get` with a `GetPromptResult` and `resources/read` with a `ReadResourceResult`; neither type carries an error channel — only `CallToolResult` has `isError`. Neither handler threw before this change and neither throws after, so there is no `code` + `status` on the wire to pin.

The channel was deliberately **not** changed to a thrown JSON-RPC error. Both surfaces answer their *existing* error convention (a `user`-role `Error: …` message; an `{ error }` JSON body), and converting one of the two branches to a throw would leave the surface answering a miss one way and an outage another — a larger behavioural change than the diagnosis fix the issue asks for, and one that lands on every MCP client. If the maintainer wants these surfaces to fail loudly at the transport level, that is a separate contract decision.

So the strongest available discriminator is pinned instead, per surface:

- the **resource** body is JSON, so the classification travels structurally and **both** answers carry it (`SERVICE_UNAVAILABLE`/503 vs `RESOURCE_NOT_FOUND`/404). The miss's `error` sentence is unchanged; `code`/`status` are additive;
- the **prompt** body is plain text, so it is pinned as: carries `SERVICE_UNAVAILABLE`, says "unknown", does **not** say "not found".

On top of both, each pair is pinned *as a pair*: the outage answer and the miss answer must not be equal. That is the fact the defect was — before this they were byte-identical — and it is the one assertion a merely mis-worded improvement cannot satisfy.

## 5. Tests and reverse verification

New: `packages/mcp/src/mcp-server-runtime.metadata-outage.test.ts`, 17 cases covering all three states on both surfaces — **present** (resolves), **genuinely absent** (not-found preserved), **degraded** (unavailable, and access still refused) — plus the legacy-service path, the "reads through `getDiagnosed`, not `get`" pin, and the log line. The doubles fill every REQUIRED member of `IMetadataService` with a throwing stub, so a path that reaches a read it should not fails loudly instead of resolving `undefined` and looking like the very absence under test. No engine write verb is declared, so there is no `delete` dispatch for `check:engine-double-contract` to scan and no guard to hand-mirror.

**Reverse verification — direction and counts written down before running.** Reversion defined as restoring the pre-#6055 reads (`get('agent', name)` with the single `if (!raw)`; `getObject()` with the bare `{ error: 'Object "X" not found' }`). Predicted **8 red / 9 green**, split 4/6 on the prompt and 4/3 on the resource. Measured, exactly the eight named:

```
× DEGRADED: answers SERVICE_UNAVAILABLE, and never the not-found claim
× the outage and the miss no longer collapse to the same answer          (prompt)
× reads through getDiagnosed, not get, when the service offers it
× logs the outage once, with the consequence and the fix
× GENUINELY ABSENT: not-found, classified 404 / RESOURCE_NOT_FOUND
× DEGRADED: unavailable, classified 503 / SERVICE_UNAVAILABLE, no schema served
× the outage and the miss no longer collapse to the same answer          (resource)
× probes the object type by name when the resolver came back empty
Test Files  1 failed (1)     Tests  8 failed | 9 passed (17)
```

⚠️ **One case is green in both directions, and that is reported rather than counted as coverage.** `DEGRADED: access is still refused — no instructions are served` cannot go red on this fix's reversion: the pre-fix code served no instructions during an outage either. It is an *invariant* pin — the thing that must not change, and what would go red if a future edit here started serving a body. Folding it into the red count would have been a fabricated number.

## 6. Out-of-scope findings (filed, not fixed here)

- **#6504** — `IMetadataService.list()` presents a known-partial answer as a complete one: `readListUncached` computes `degraded` and `list()` spends it on a cache TTL, so no consumer can learn it. The #5840 shape on the plural read, and the one that carries a **count**. Two of its consumers are in this very file (`objectstack://objects`, the skill-prompt snapshot) but the fix is a contract addition (`listDiagnosed`), which is a maintainer call and outside this issue's file surface. Unlabeled, for PM triage.
- **#6505** — `IMetadataService.getObject` has no declared relationship to `get('object', name)` and its two implementations disagree. This is the gap that forced the verdict-probe shape in §3. Observation-class (`finding`, not queued).

## 7. Commands and real output

```
pnpm --filter @objectstack/mcp test
  Test Files  10 passed (10)        Tests  114 passed (114)

pnpm --filter @objectstack/mcp exec vitest run mcp-server-runtime.metadata-outage
  Test Files  1 passed (1)          Tests  17 passed (17)

pnpm --filter @objectstack/mcp typecheck            (tsc --noEmit)  → clean, no output
pnpm lint                                            → clean, no output
pnpm check:type-check-coverage                       → OK, 62/77 + root, 15 ledgered
```

⚠️ `packages/mcp/tsconfig.json` excludes `**/*.test.ts` (pre-existing `TEST_DEBT` entry, recorded 63), so `pnpm typecheck` does **not** read the new test file. Rather than report a green it did not earn, the ledger measurement was reproduced by hand the way `--re-measure` does it (sibling config, test globs dropped from `exclude`): **53 errors, none in the new file** — below the recorded 63, i.e. informational, never a failure. The exclusion was not touched; lifting it is not this PR's business.

Every `check:*` step enumerated from `.github/workflows/lint.yml`, run one by one, all green:

```
slot-lookup query-options-erasure nul-bytes doc-authoring docs-audit-scope role-word
quick-reference-counts adr-anchors org-identifier authz-resolver service-providers
route-envelope error-code-casing wildcard-fallthrough meta-type-normalized
init-service-contract durability-log-level startup-registry-verdict objectui-changeset
release-notes release-body node-version workflow-status-functions shard-attestation
published-files engine-double-contract resume-authority-declared merge-driver
spec-parsed-alias                                                        → all OK
```

`node scripts/check-nul-bytes.mjs` → OK (6106 tracked text files), plus a direct
`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over the three changed files → clean.

Changeset added: `.changeset/mcp-metadata-outage-vs-miss.md` (`@objectstack/mcp: patch`) — the change is user-visible (an MCP client's answer during an outage changes, and the resource body gains `code`/`status`).


---
_Generated by [Claude Code](https://claude.ai/code/session_017uFVNMmTxLpmfQYiuKM1Yx)_