### PR TITLE
fix(ci): 无法解析的 diff 基准改为落成 output，由已认两次标签读取的步骤裁决 (#6434)

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -274,6 +274,23 @@ jobs:
       #     someone gives the checkout a `ref:`, where parent^1 becomes the PR's
       #     previous commit. `merge-base` is right under BOTH checkouts, which is
       #     why it is the one written here.
+      #
+      # #6434: this step REPORTS an unusable base, it does not adjudicate one.
+      # Both of its former `exit 1`s are now `base_error` outputs, and the verdict
+      # moved to `Require a usable diff base` further down -- the one place that
+      # has seen BOTH label reads. The reason is the same #5580/#6378 race one
+      # defect along: this step runs before the settling read, so a
+      # `skip-changeset` label that lands in its window (the COMMON case, ~+10..45s
+      # from PR creation) was still invisible here. Failing on the spot therefore
+      # reddened a PR the job was about to exempt -- two conditions at once, the
+      # late label plus a genuine git-base failure, which is why no instance was
+      # ever observed and why the gap was recorded rather than guessed at.
+      #
+      # What is deliberately NOT changed: an unusable base is still a FAILURE for
+      # every PR the changeset gate applies to. #4690 governs the verdict, not its
+      # address. The warning below is emitted where the fact is discovered so the
+      # infrastructure flake stays visible in the log even on the exempt path,
+      # where nothing else would ever mention it.
       - name: Resolve the diff base (merge base with the base branch)
         id: diffbase
         if: steps.labels.outputs.skip != 'true'
@@ -282,8 +299,9 @@ jobs:
           PINNED_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           if [ -z "$BASE_REF" ]; then
-            echo "::error::This event carries no base branch, so the changeset diff base cannot be computed. A gate that cannot read its input has verified nothing, so this is a failure rather than a pass (#4690)."
-            exit 1
+            echo "::warning::This event carries no base branch, so the changeset diff base cannot be computed. Adjudicated below, once the skip-changeset window has settled."
+            echo 'base_error=This event carries no base branch, so the changeset diff base cannot be computed.' >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           if ! git rev-parse --verify --quiet "refs/remotes/origin/$BASE_REF^{commit}" >/dev/null; then
             git fetch --no-tags --quiet origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF" \
@@ -292,11 +310,17 @@ jobs:
           # `if !` rather than a bare assignment on purpose: these steps run under
           # `bash -e` (no `shell:` key anywhere in this file), where a failing
           # command substitution kills the step with no message at all. The gate
-          # is allowed to fail here -- it is NOT allowed to fail unexplained.
+          # is allowed to fail over this -- it is NOT allowed to fail unexplained.
           if ! MERGE_BASE=$(git merge-base "refs/remotes/origin/$BASE_REF" HEAD); then
-            echo "::error::Could not compute merge-base(origin/$BASE_REF, HEAD), so the changeset diff has no trustworthy starting point. Failing rather than falling back to the frozen base.sha, which is the #6129 defect itself."
-            exit 1
+            echo "::warning::Could not compute merge-base(origin/$BASE_REF, HEAD), so the changeset diff has no trustworthy starting point. Adjudicated below, once the skip-changeset window has settled."
+            echo "base_error=Could not compute merge-base(origin/$BASE_REF, HEAD), so the changeset diff has no trustworthy starting point." >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          # Written explicitly rather than left unset. An unwritten output already
+          # reads as the empty string, but every downstream `if:` here spells the
+          # success case as `base_error == ''`, and a contract that load-bearing
+          # should be visible in the shell that establishes it.
+          echo 'base_error=' >> "$GITHUB_OUTPUT"
           echo "merge_base=$MERGE_BASE" >> "$GITHUB_OUTPUT"
           # The drift is printed, not just corrected. #6129 was invisible for as
           # long as it was because nothing in the log ever said which commit the
@@ -306,18 +330,37 @@ jobs:
           echo "Diff base: $MERGE_BASE  (merge-base of origin/$BASE_REF and HEAD)"
           echo "Frozen payload base.sha: $PINNED_BASE_SHA  -- $BASE_REF has moved $DRIFT commit(s) since it was frozen, and that drift is exactly what this gate used to count as this PR's own."
 
+      # The three toolchain steps and the counting step below all carry the
+      # `base_error == ''` conjunct as well (#6434). For the counting step it is
+      # CORRECTNESS: handed an empty `$MERGE_BASE`, `git diff --diff-filter=A ""
+      # HEAD` fails, but it fails inside a pipeline whose last command is `tr`, so
+      # the step would report `added=0` -- a fabricated count that reads exactly
+      # like "this PR forgot its changeset" and would send the verdict step to the
+      # wrong error message entirely. For the three toolchain steps it is COST and
+      # legibility: an unusable base can no longer be adjudicated until the label
+      # window settles, and there is no reason to buy a Node toolchain and a
+      # `--frozen-lockfile` install first for a run that will either be exempted or
+      # failed without ever compiling anything. It also keeps the failure signature
+      # single: on this path the only red is the adjudication step, never an
+      # install that happened to flake on the same shaky network.
       - name: Setup Node.js
-        if: steps.labels.outputs.skip != 'true'
+        if: >-
+          steps.labels.outputs.skip != 'true'
+          && steps.diffbase.outputs.base_error == ''
         uses: actions/setup-node@v7
         with:
           node-version: '22'
 
       - name: Enable Corepack
-        if: steps.labels.outputs.skip != 'true'
+        if: >-
+          steps.labels.outputs.skip != 'true'
+          && steps.diffbase.outputs.base_error == ''
         run: corepack enable
 
       - name: Install dependencies
-        if: steps.labels.outputs.skip != 'true'
+        if: >-
+          steps.labels.outputs.skip != 'true'
+          && steps.diffbase.outputs.base_error == ''
         run: pnpm install --frozen-lockfile
 
       # COUNTING ONLY -- the verdict is two steps down (#6378). The split is not
@@ -327,7 +370,9 @@ jobs:
       # that fact before any waiting is considered.
       - name: Count the changesets this PR adds
         id: changeset_count
-        if: steps.labels.outputs.skip != 'true'
+        if: >-
+          steps.labels.outputs.skip != 'true'
+          && steps.diffbase.outputs.base_error == ''
         env:
           MERGE_BASE: ${{ steps.diffbase.outputs.merge_base }}
         run: |
@@ -405,11 +450,21 @@ jobs:
       # already behind us, and the loop does exactly one read and no sleeping.
       # Only a genuinely fresh PR can wait at all. 120s is ~3x the worst label
       # latency measured on this repo (~40s, #6358).
+      #
+      # #6434 adds the second disjunct, and it is the SAME invariant rather than a
+      # widening of it: "charge the wait only to a PR that is headed for red". A PR
+      # whose diff base could not be resolved is headed for red just as surely as
+      # one that added no changeset -- it simply gets there by the other route, and
+      # the counting step is skipped on that path, so `added` is `''` and the first
+      # disjunct can never speak for it. No PR waits that would not have waited
+      # under #6378: a resolvable base plus a changeset still skips this step
+      # entirely, at no wall time and no API call.
       - name: Settle the skip-changeset window (only when this PR would otherwise fail)
         id: labels_settled
         if: >-
           steps.labels.outputs.skip != 'true'
-          && steps.changeset_count.outputs.added == '0'
+          && (steps.changeset_count.outputs.added == '0'
+          || steps.diffbase.outputs.base_error != '')
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -463,6 +518,37 @@ jobs:
           done
           echo "Label window closed after $ATTEMPT read(s). Labels on PR #$PR_NUMBER right now: ${LABELS:-(none)}"
           echo 'skip=false' >> "$GITHUB_OUTPUT"
+
+      # #6434: the verdict on an unusable diff base. It is a SEPARATE step rather
+      # than a branch inside the step below, for the reason this job already gives
+      # for splitting `Reject an empty-frontmatter changeset` off: the two failures
+      # are different facts and deserve different messages. "The git base is
+      # unavailable" is not "you forgot a changeset", and an author who reads the
+      # second when the first is true will go looking in the wrong place.
+      #
+      # It sits HERE, immediately after the settling read, because both of its
+      # neighbours constrain it. It cannot move up: above the settling read there
+      # is no settled label state, which is the whole defect being fixed. It cannot
+      # move down: the step below evaluates `[ "$ADDED" -eq 0 ]` on an `ADDED` that
+      # is the empty string whenever the counting step was skipped, and `test`
+      # answering "not a number" is a NON-zero status, so the `if` would take its
+      # else branch and announce "This PR adds  changeset(s)" -- a green verdict on
+      # a gate that never ran. The ordering is load-bearing in both directions.
+      #
+      # This is NOT the route-2 move #6378's cost argument rules out. The settling
+      # read stays exactly where it is, after the count; nothing about which PRs
+      # pay for the window changed. What moved is one verdict, downward, past a
+      # read that had already been paid for.
+      - name: Require a usable diff base (adjudicated after the label window)
+        if: >-
+          steps.labels.outputs.skip != 'true'
+          && steps.labels_settled.outputs.skip != 'true'
+          && steps.diffbase.outputs.base_error != ''
+        env:
+          BASE_ERROR: ${{ steps.diffbase.outputs.base_error }}
+        run: |
+          echo "::error::$BASE_ERROR Failing rather than falling back to the frozen base.sha, which is the #6129 defect itself: a gate that cannot read its input has verified nothing, so this is a failure rather than a pass (#4690). Neither live label read found 'skip-changeset' on this PR, so the changeset gate does apply to it and cannot be evaluated. If this PR releases nothing, apply the label and re-run; if the base branch is genuinely fetchable, this is infrastructure and a re-run will clear it."
+          exit 1
 
       # The VERDICT. Everything it needs was decided above; this step only
       # announces it, which is what makes the failure message a single block of

--- a/scripts/check-empty-changeset.mjs
+++ b/scripts/check-empty-changeset.mjs
@@ -733,6 +733,20 @@ function selfTest() {
         settle,
         'consumer: the settling label read must be conditioned on `steps.changeset_count.outputs.added == \'0\'` -- the wait #6378 introduces is charged ONLY to a PR headed for red, and un-conditioning it taxes every run instead',
       );
+      // The condition above is a substring test, so it would go on passing if a
+      // later edit bolted an unrelated `|| <anything>` onto it and quietly taxed
+      // every run again. #6434 legitimately adds ONE disjunct -- the unusable diff
+      // base, which is the other way a PR arrives at red and which the count
+      // cannot speak for, because the counting step is skipped on that path. So
+      // the whole condition is pinned, not just its first term: exactly these two
+      // ways in, and no third without an argument.
+      const settleIf = yaml.match(
+        /steps\.labels\.outputs\.skip != 'true'\s*\n\s*&& \(steps\.changeset_count\.outputs\.added == '0'\s*\n\s*\|\| steps\.diffbase\.outputs\.base_error != ''\)/,
+      );
+      assert(
+        settleIf !== null,
+        "consumer: the settling read's condition must be exactly `no fast-path label AND (added == '0' OR base_error != '')` -- both disjuncts are ways of being headed for RED, which is the only thing that may buy the #6378 wait",
+      );
 
       // Both reads, one matcher. A divergence (say a substring `grep -q` on one
       // path) would be a gate that exempts on one read and enforces on the
@@ -744,20 +758,56 @@ function selfTest() {
         `consumer: exactly two live \`grep -qxF 'skip-changeset'\` reads are expected (the fast path and the settling read); found ${matchers.length}`,
       );
 
-      // Every step that can FAIL a PR over the changeset rule must honour both
-      // reads. Scoped to those steps by what they run, not by name: a step that
-      // shells out to a `check-*.mjs` gate, or that emits the "no changeset"
-      // error. `Resolve the diff base` is deliberately outside this set -- it
-      // exits 1 over an unusable git base, which is not a changeset verdict and
-      // was never label-exempt (recorded, not implied).
+      // Every step of this job that can FAIL a PR must honour both reads. Scoped
+      // by what a step RUNS, never by its name: it shells out to a `check-*.mjs`
+      // gate, or it contains a literal `exit 1` outside a comment.
+      //
+      // #6434 widened this boundary, and the widening is the point rather than an
+      // accident of it. The predicate used to be "runs a `check-*.mjs` OR emits
+      // the no-changeset error", which described the four steps that existed and
+      // nothing else. `Resolve the diff base` sat outside it carrying two `exit
+      // 1`s of its own -- deliberately, on the argument that "the git base is
+      // unavailable" is not a changeset verdict and so was never label-exempt.
+      // That argument is sound about the VERDICT and wrong about its ADDRESS: the
+      // step ran before the settling read, so on a PR whose `skip-changeset` label
+      // landed in the ordinary +10..45s window it could red a run the job was
+      // about to exempt. #6434 moved that verdict to `Require a usable diff base`,
+      // which honours both reads, and the boundary here moved with it.
+      //
+      // Naming `exit 1` instead of one specific error string is what makes the
+      // rule outlive the steps it was written for: the gap #6434 closed existed
+      // precisely because the old predicate could not see a failing step it had
+      // not been told about, and the next one added here would have been invisible
+      // the same way. Residual, stated rather than implied: a step that fails by
+      // running a command that returns non-zero, with no literal `exit 1` and no
+      // `check-*.mjs`, is still outside this set. That is a smaller hole than the
+      // one it replaces, not no hole.
       const jobText = yaml.slice(yaml.indexOf('\n  changeset-check:'));
       const chunks = jobText
         .split(/\n(?=      - name: )/)
         .map((c) => c.split('\n').filter((l) => !/^\s*#/.test(l)).join('\n'))
-        .filter((c) => /node scripts\/check-\S+\.mjs/.test(c) || /::error::This PR adds no changeset/.test(c));
+        .filter((c) => /node scripts\/check-\S+\.mjs/.test(c) || /\bexit 1\b/.test(c));
       assert(
-        chunks.length === 4,
-        `consumer: expected 4 changeset-verdict steps in the Check Changeset job, found ${chunks.length} -- a new one that this rule cannot see is a new way to red an exempt PR`,
+        chunks.length === 5,
+        `consumer: expected 5 failable steps in the Check Changeset job, found ${chunks.length} -- a new one that this rule cannot see is a new way to red an exempt PR`,
+      );
+      // The step whose relocation #6434 IS. Pinned in the negative as well as the
+      // positive: base resolution reports into an output and the verdict is taken
+      // downstream, so re-introducing an `exit 1` here would restore the fast-path
+      // -only failure this card exists to remove. The count above would catch that
+      // as a 6th failable step; this says which one and why, so the next reader
+      // gets the reason and not just an arithmetic mismatch.
+      const diffbaseStep = jobText
+        .split(/\n(?=      - name: )/)
+        .map((c) => c.split('\n').filter((l) => !/^\s*#/.test(l)).join('\n'))
+        .find((c) => /- name: Resolve the diff base/.test(c));
+      assert(
+        diffbaseStep !== undefined && !/\bexit 1\b/.test(diffbaseStep),
+        'consumer: `Resolve the diff base` must not fail on the spot -- it runs BEFORE the settling read, so its verdict would be taken on the fast path alone and would red a PR whose skip-changeset label was still in flight (#6434). It reports `base_error` and the adjudication step below decides.',
+      );
+      assert(
+        diffbaseStep !== undefined && /base_error=/.test(diffbaseStep),
+        'consumer: `Resolve the diff base` must report an unusable base as a `base_error` output -- dropping it silently would leave the downstream adjudication permanently un-triggerable, i.e. a gate that passes because it never runs (#4690)',
       );
       const unguarded = chunks.filter((c) => !/steps\.labels_settled\.outputs\.skip != 'true'/.test(c));
       assert(
@@ -777,6 +827,21 @@ function selfTest() {
       assert(
         /::error::This PR adds no changeset[\s\S]{0,900}?\n\s+exit 1\n/.test(yaml),
         'consumer: the "no changeset" verdict must still exit 1 -- #6378 removes a structural FALSE red, it does not relax the gate',
+      );
+      // The same constraint for #6434, and the reason it is written as a POSITIVE
+      // is the asymmetry that makes the negative one above worthless on its own:
+      // "the diff base no longer reds an exempt PR" is satisfied just as well by a
+      // step that stopped running, or by an adjudication whose `if:` can never be
+      // true. So the exempt direction is not asserted at all -- what is asserted
+      // is that the enforcing direction survived, in the one place it now lives.
+      const adjudication = jobText
+        .split(/\n(?=      - name: )/)
+        .map((c) => c.split('\n').filter((l) => !/^\s*#/.test(l)).join('\n'))
+        .find((c) => /- name: Require a usable diff base/.test(c));
+      assert(adjudication !== undefined, 'consumer: the unusable-diff-base verdict step must exist (#6434) -- without it `base_error` is written and never read, which is a gate deleted rather than relocated');
+      assert(
+        /steps\.diffbase\.outputs\.base_error != ''/.test(adjudication ?? '') && /\n\s+exit 1\n/.test(adjudication ?? ''),
+        "consumer: the unusable-diff-base verdict must fire on `base_error != ''` and exit 1 -- #6434 relocates a failure past the settling read, it does not forgive one. A PR the label reads did not exempt is still failed over a base that could not be resolved (#4690).",
       );
       assert(
         !/continue-on-error/.test(yaml),


### PR DESCRIPTION
Fixes #6434

`changeset-check` 中能让 PR 变红的步骤共五个。PR #6429（#6378）让其中四个同时认两次活标签读取；第五个 `Resolve the diff base` 只带快路径守卫却自带两处 `exit 1`，跑在结算读之前，因此标签晚到叠加 git 基准真的失败时会红一个本该豁免的 PR。本 PR 采**路线 3**：该步骤只报告不裁决，裁决下移到一个已认两次读取的步骤。

## 前提自核（自测，不引用分诊结论）

分诊 2026-08-07 21:58Z 说 `.github/workflows/pr-automation.yml` 最后一次改动是 `35353bd`，此后无人动过。**本 PR 未引用该结论，而是自己重测**，结论一致：

```
$ git log -1 --format='%H %ci %s' origin/main -- .github/workflows/pr-automation.yml
35353bd7fb2a0b81a06a70d4d22dd3442969b49a 2026-08-07 18:48:35 +0000
fix(ci): Check Changeset 的 skip-changeset 判定加一次「结算读」，首跑不再结构性必红 (#6378) (#6429)
```

按「跑 `check-*.mjs` 或含非注释 `exit 1`」逐步扫描 `origin/main`（`1fe436d`）上的 job，五步 / 四步带结算读的划分**属实**：

| 步骤 | exit 1 | check-\*.mjs | 快路径读 | 结算读 |
|---|---|---|---|---|
| Resolve the diff base | ✅ ×2 | | ✅ | ❌ |
| Require a changeset | ✅ | | ✅ | ✅ |
| Reject an empty-frontmatter changeset | | ✅ | ✅ | ✅ |
| Require an ADR-0087 disposition | | ✅ | ✅ | ✅ |
| Guard against accidental major bumps | | ✅ | ✅ | ✅ |

改动后同一扫描得到 5/5 全部带两次读取。

## 路线选择

**采路线 3。** 路线 1（只补注释）被否：意图已记在 PR #6429 正文，搬一句话不解决问题。**路线 2 未采用，也未测量** —— 它与 #6378 的成本结论直接冲突，本 PR 不碰结算读的位置（见下）。

## 改了什么

1. `Resolve the diff base` 的两处 `exit 1` → 写 `base_error` output + `exit 0`；发现点仍发 `::warning::`，使基础设施抖动在豁免路径上也留痕（否则无人会提它）。
2. 新增 `Require a usable diff base (adjudicated after the label window)`：同时认两次读取 + `base_error != ''` → `exit 1`。
3. 计数步骤加 `base_error == ''` 守卫 —— 这是**正确性**而非成本：空 `$MERGE_BASE` 下 `git diff` 失败在管道中段，末端 `tr` 仍返回 0，该步会报出伪造的 `added=0`，把判决引向「你忘了写 changeset」这个完全错误的错误信息。
4. 三个工具链步骤（Setup Node / Corepack / Install）同加该守卫 —— 成本与可读性：该路径上唯一的红只会是裁决步骤，不会是恰好在同一段抖动网络上失败的 install。
5. 结算读的条件加一个析取项 `|| base_error != ''`。

**为什么第 5 条不是路线 2**：结算读的**位置没动**（仍在计数之后）。#6429 的成本论证是「等待只向将红的 PR 收取」，而基准不可用同样是将红 —— 且计数步骤在该路径上被跳过，`added` 为 `''`，第一个析取项无法为它发声。有可解析基准且写了 changeset 的 PR 仍完全跳过该步，零等待零 API 调用。**没有任何 PR 因此新增等待。**

## 改动后的失败签名

供未来读者比对真实事故：

- job 日志中 `Resolve the diff base` **绿色**，但带 `::warning::Could not compute merge-base(origin/main, HEAD) ... Adjudicated below, once the skip-changeset window has settled.`
- `Setup Node.js` / `Enable Corepack` / `Install dependencies` / `Count the changesets this PR adds` 四步**全部 skipped**。
- `Settle the skip-changeset window` **运行**（这是修复的关键：它是唯一看得到结算后标签状态的地方）。
- 之后二选一：
  - 标签落地 → `Require a usable diff base` skipped，四个判定步骤全部 skipped，**job 绿**（本 PR 修的就是这一格）；
  - 标签始终没来 → `Require a usable diff base` **红**，annotation 以 `::error::Could not compute merge-base(...)` 开头并附「两次活标签读取都没找到 skip-changeset」的说明，`exit 1`。

若看到 `Resolve the diff base` 自己红，说明本改动被回退了。

## 执行 vs 推理 —— 这是 workflow 文件，分清楚

**执行（有真实输出）：**

- YAML 解析 + 逐步打印折叠后的 `if:` 表达式（`>-` 折叠正确，括号析取正确）。
- **case matrix 模拟器**：把文件里**真实的** `if:` 表达式机械翻译成 JS，按 GitHub 的步骤门控语义（无状态函数的 `if:` 隐含 `success() &&`；skipped 步骤的 output 读作空串）跑 7 个场景。改动后 7/7 符合预期；对**改动前**的文件跑同一矩阵，**恰好一个**场景背离 —— 即本卡片描述的缺陷。
- `node scripts/check-empty-changeset.mjs --self-test` → 48 断言通过（#6429 时为 43）。
- `pnpm check:empty-changeset` / `check:workflow-status-functions` / `check:nul-bytes` / `pnpm lint` / `check-adr-0087-registration`（commit 后跑）全绿。
- 三次消融全部转红（见下）。

**推理（未执行，也不声称已验证）：**

- 真实 GitHub Actions runner 上的行为。模拟器执行的是**表达式**，不是 GitHub。`success()` 隐含包裹、skipped 步骤 output 为空串这两条语义来自文档与本文件既有设计，未在真实 runner 上重跑。
- 触发条件（标签晚到 **且** git 基准真的失败）无法按需构造，本仓库也无已知实例 —— 这正是该缺口当初被记录而非修复的原因。
- `[ "$ADDED" -eq 0 ]` 在 `ADDED` 为空串时返回非零、从而使 `if` 走 else 分支（即「若裁决步骤放在判定步骤之后会得到伪绿」）—— 由 POSIX `test` 语义推得，并据此把裁决步骤放在判定步骤**之前**；未在 runner 上实测该伪绿。

### 负向断言的对称配对

「豁免的 PR 不再被红」若单独成立可以是**空洞**的（步骤根本没跑，或 fixture 压根到不了它）。因此矩阵里 D 与 E 成对：

- **D（修复方向）**：基准死 + 标签在窗口内落地 → 绿。**非空洞**：日志显示 `Settle the skip-changeset window` 确实运行了，裁决步骤是被自己的 `if:` 跳过的，不是因为 job 已经失败。
- **E（正向配对）**：基准死 + 标签始终不来 → **红**，且红在 `Require a usable diff base`。基准真的不可用且 PR 未被豁免时仍然失败。

改动前后 E 都是红（判决未变，只换了地址）；只有 D 从红变绿。

## CONSUMER 断言的边界决定

#6429 **有意**把这一步排除在判定步骤集合外，谓词是「跑 `check-*.mjs` 或发出 no-changeset 错误」，理由是不想把一个没论证过的豁免钉成契约。**路线 3 改变了这个边界，因此断言必须同步外扩并给出论证**（本 PR 不做静默放宽）：

新谓词 = 「跑 `check-*.mjs` **或**含非注释的 `exit 1`」，计数 4 → 5。论证：

- 该豁免**不再是「没论证过的」** —— 它现在是一条明确契约：基准不可用的判决在结算读**之后**作出。钉住它正是要防止有人把它挪回去。
- 用 `exit 1` 而非某个特定错误串，是为了让规则活得比它当初描述的那几步更久。**#6434 这个缺口之所以存在，恰恰是因为旧谓词看不见一个它没被告知的可失败步骤** —— 下一个加进来的也会同样隐形。
- 残留（写明而非暗示）：一个靠命令返回非零失败、既无字面 `exit 1` 也不跑 `check-*.mjs` 的步骤仍在集合外。这是比它替换掉的那个**更小**的洞，不是没有洞。

另加三条：`Resolve the diff base` 不得就地失败、必须写 `base_error`、裁决步骤必须存在且仍 `exit 1`。最后一条是**正向**写法，正是因为负向断言可被「步骤没跑」空洞满足。

同时把结算读的条件由子串断言升级为**整条**断言 —— 否则后来者再挂一个 `|| 任意条件` 会静默通过并重新向所有 PR 收取等待。

## 反向验证（先声明，后执行）

**声明**（运行前写下）：

1. 整体回退 `pr-automation.yml` → 红，首条为结算读整条断言；`chunks.length === 5` **仍成立**（旧文件里 diffbase 自己的 `exit 1` 恰好填满第五格），因此不会由计数断言抓住。
2. 仅给 `Resolve the diff base` 加回 `exit 1` → 红在「不得就地失败」。
3. 仅删除裁决步骤 → 红在 `chunks.length === 5`（found 4）。

**观察**：三条**方向全部相符**，且比声明更强 —— 消融 2、3 各触发 3 条断言（我只点名了 1 条）。消融 1 的 6 条中第一条正是结算读整条断言，且**确实没有** `chunks.length` 失败，与声明中那个反直觉的预测一致。

模拟器侧：对改动前文件跑同一矩阵，仅 D 背离（`RED (failed at: Resolve the diff base)`），E 保持红。

## 门禁

| 门禁 | 结果 |
|---|---|
| `pnpm lint`（eslint，已确认未 ignore 改动脚本） | pass |
| `node scripts/check-empty-changeset.mjs --self-test` | pass（48 断言） |
| `pnpm check:empty-changeset` | pass |
| `pnpm check:workflow-status-functions` | pass（22 workflow / 41 job） |
| `pnpm check:nul-bytes` | pass（6109 文件，无裸控制字节） |
| `check-adr-0087-registration`（commit 后跑） | pass（67 断言） |
| actionlint / yamllint | **本仓库没有**，未替代为别的脚本；YAML 有效性由 `yaml` 包解析确认 |

## Changeset

无。CI 内部改动，无对外发布面 ⇒ 建 PR 时即加 `skip-changeset`。

## 本 PR 是否影响对它自己的判定

**是，需要写明。** 本 PR 改的正是裁决自己的那个 job，但**判定用的是 `main` 上的 workflow 定义**（`pull_request` 事件按 base 分支的 workflow 执行），因此本 PR 的 `changeset-check` 走的是**改动前**的逻辑；改动只对合并后的 PR 生效。

更值得记下的一点：`check-empty-changeset.mjs --self-test`（连同 `check-adr-0087-registration`、`check-changeset-no-major`）**只**在 `pr-automation.yml` 的 `changeset-check` 里跑，没有接进 `lint.yml`。而该 job 在 PR 带 `skip-changeset` 时整体豁免 —— 本 PR 正是这种情况。所以**本 PR 修改的那些断言，不会在本 PR 的 CI 上执行**，上面的 48 断言与三次消融全部是本地跑的。这条已作为观察类 finding 另单记录。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_