### PR TITLE
ci(devx): type-check ledger 的余量可见化、一键抹平,并拒绝在未构建闭包上测量 (#6376)

### DIFF
--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -37,6 +37,10 @@
 //
 //   node scripts/check-type-check-coverage.mjs                # structural, sub-second
 //   node scripts/check-type-check-coverage.mjs --re-measure   # + runs tsc per ledger entry
+//   node scripts/check-type-check-coverage.mjs --re-measure --lower
+//                                    # + writes each measured number back into
+//                                    #   the ledger below (#6376). Needs the
+//                                    #   workspace built -- see BUILT CLOSURE.
 //   node scripts/check-type-check-coverage.mjs --self-test
 //
 // Invariants, per workspace package (the root workspace package included --
@@ -106,6 +110,40 @@
 //               graduation candidate, and graduating is still a deliberate PR
 //               (add the `typecheck` script, delete the entry -- COVERED and
 //               RECONCILED are what force the pair).
+//
+//               THE SURPLUS (#6376). That asymmetry has a price, and it is not
+//               bookkeeping: the gap between a recorded number and a smaller
+//               measured one is a live PERMISSION ALLOWANCE. Nothing else reads
+//               these layers. A DEBT entry exists ONLY where no `typecheck`
+//               script does (RECONCILED forbids both at once) and a TEST_DEBT
+//               entry ONLY where no tsconfig the typecheck script invokes reads
+//               the tests -- so for EVERY entry in both ledgers, this number is
+//               the sole gatekeeper of the layer it measures, and while the gap
+//               is open any regression smaller than it lands green.
+//
+//               Not a hypothesis. driver-mongodb recorded 43 while measuring 10:
+//               #6210 had narrowed six contract methods and retired 33 errors,
+//               and nothing lowered the entry. Reverting `aggregate(object,
+//               query: DriverQuery)` back to `QueryAST` measured 12 -- and
+//               12 < 43, so the only gate that could pin that signature stayed
+//               silent. PR #6356 lowered the entry to 10; the same reversion
+//               then reported +2 and went red. Read it as the sentence it is:
+//               A LEGITIMATE IMPROVEMENT SILENTLY MUTED THE NEXT PERSON'S PIN.
+//
+//               So the surplus is now REPORTED -- per entry and as a total, on
+//               every green re-measure -- because an allowance nobody can see is
+//               the part that does the damage. Measured on main @ 1818998: 11 of
+//               34 entries carried a combined surplus of 310 raw errors, 15% of
+//               everything the two ledgers record, with 199 of it in a single
+//               entry (plugin-approvals, 547 recorded / 348 measured). What this
+//               gate deliberately does NOT do is make a surplus red: the ruling
+//               above stands and an improvement still lands green. What it does
+//               instead is make closing one FREE -- `--lower` writes the
+//               measured numbers back into the ledger, so flattening an entry
+//               never requires a human to type a measured number. Whether the
+//               surplus should additionally be enforced is #6376's open
+//               question, not this paragraph's, and the cost of guessing it is
+//               argued there.
 //
 //               What drifts is not only the NUMBER but the note's COMPOSITION:
 //               service-automation's note named `engine.test.ts:2547/2577` as
@@ -1067,6 +1105,138 @@ const TSC_SETUP_ERROR = /\berror TS(5058|5083|6053|18003|5012)\b/;
 /** Temp project used to lift a tsconfig's own test exclusion. Never committed. */
 const REMEASURE_CONFIG = 'tsconfig.debt-remeasure.json';
 const REMEASURE_ISSUE = 'https://github.com/objectstack-ai/objectstack/issues/5278';
+const SURPLUS_ISSUE = 'https://github.com/objectstack-ai/objectstack/issues/6376';
+
+// ---------------------------------------------------------------------------
+// BUILT CLOSURE -- the precondition every number in both ledgers is measured
+// under, and until #6376 the only one nothing checked.
+//
+// tsc resolves a workspace import through the DEPENDENCY'S BUILT `dist/*.d.ts`,
+// never through its sources (no `paths` mapping exists anywhere in this repo).
+// So an unbuilt closure does not make the measurement fail -- it makes it
+// MEAN SOMETHING ELSE, and `--re-measure` used to record the result either way.
+// Measured on packages/lint at 1818998, same tree, same commit, twice:
+//
+//   closure built    19  (TS7006 x11, TS2835 x4, TS6059 x4)
+//   closure unbuilt  147 (TS2307 x71 -- cannot find module -- then the cascade
+//                         it causes: TS7006 x38, TS18046 x20, ...)
+//
+// 7.7x, and NEITHER run printed a warning. The direction is not fixed either:
+// an unresolved import degrades every symbol it names to `any`, which INVENTS
+// TS2307/TS7006 while ERASING the structural mismatches (TS2345/TS2322) that
+// are usually the real debt -- driver-mongodb's 33 TS2345 were exactly such
+// mismatches and would have measured 0 against an unbuilt `@objectstack/spec`.
+// So a stale closure can hand an entry a number far above its truth (a false
+// red, loud) or far below it (a false ceiling, silent, and the ledger would
+// then be tightened onto a number nobody can reproduce).
+//
+// This is not theoretical bookkeeping: on 2026-08-08 three readings of ONE
+// entry (`@objectstack/lint`) were in circulation between parallel agents in a
+// single day -- 19, 39 and 147 -- and the ledger's whole discipline is
+// "recorded vs measured". A quantity that is not reproducible cannot carry a
+// policy. lint.yml already builds the closure before invoking this gate; what
+// was missing is that NOTHING SAID SO, so a local run silently measured a
+// different world. Now it refuses instead.
+//
+// Deliberately a PRECONDITION (does each workspace dependency have a built type
+// entry point on disk?) rather than a scan of tsc's output for TS2307: several
+// ledger entries legitimately RECORD unresolved-module errors as part of their
+// debt -- the workspace root's note names TS2307 x17 -- and a gate that cannot
+// tell a recorded defect from a broken measurement would refuse the very
+// entries it exists to measure.
+// ---------------------------------------------------------------------------
+
+/**
+ * Every root-export type entry point a manifest declares, from `types` /
+ * `typings` and from any `exports` condition naming a declaration file. Pure
+ * over the manifest so the self-test can pin the shapes this workspace actually
+ * uses (a flat `types`, a conditional `exports` map, a package that declares
+ * none at all -- `@objectstack/console` publishes a prebuilt artifact and has
+ * no type entry point, and must never read as "unbuilt").
+ *
+ * @param {Record<string, unknown>} manifest
+ * @returns {string[]}
+ */
+function declaredTypeEntries(manifest) {
+  const found = new Set();
+  const collect = (node, depth) => {
+    if (depth > 6 || node == null) return;
+    if (typeof node === 'string') {
+      if (/\.d\.[cm]?ts$/.test(node)) found.add(node.replace(/^\.\//, ''));
+      return;
+    }
+    if (typeof node !== 'object') return;
+    for (const value of Object.values(node)) collect(value, depth + 1);
+  };
+  for (const key of ['types', 'typings']) collect(manifest[key], 0);
+  collect(manifest.exports, 0);
+  return [...found].sort();
+}
+
+/**
+ * Which workspace packages in the ledgered packages' dependency closure have no
+ * built type entry point. Pure over a described graph -- `built` is decided by
+ * the caller's fs read -- so the traversal (transitive, cycle-safe, and blind to
+ * a package that declares no type entry at all) is pinned without a filesystem.
+ *
+ * The ROOTS themselves are never reported: measuring a package reads its own
+ * SOURCES, so its own `dist` is irrelevant to its own number. A root appears
+ * only when some other ledgered package depends on it, which is the case where
+ * its `dist` really is the input.
+ *
+ * @param {string[]} roots ledgered package names
+ * @param {Map<string, {deps: string[], typeEntries: string[], built: boolean}>} graph
+ * @returns {string[]} sorted names
+ */
+function unbuiltClosure(roots, graph) {
+  const unbuilt = new Set();
+  const seen = new Set();
+  const visit = (name) => {
+    if (seen.has(name)) return;
+    seen.add(name);
+    const node = graph.get(name);
+    if (!node) return; // not a workspace member -- node_modules, not our build
+    if (node.typeEntries.length > 0 && !node.built) unbuilt.add(name);
+    for (const dep of node.deps) visit(dep);
+  };
+  for (const root of roots) {
+    for (const dep of graph.get(root)?.deps ?? []) visit(dep);
+  }
+  return [...unbuilt].sort();
+}
+
+/**
+ * The observed build graph: every workspace member, its `workspace:` deps
+ * (runtime, dev and peer -- a hidden test layer imports all three) and whether
+ * any type entry point it declares exists on disk.
+ *
+ * @param {Array<{name: string, dir: string}>} packages
+ * @returns {Map<string, {deps: string[], typeEntries: string[], built: boolean}>}
+ */
+function workspaceBuildGraph(packages) {
+  const graph = new Map();
+  for (const pkg of packages) {
+    let manifest;
+    try {
+      manifest = JSON.parse(readFileSync(join(ROOT, pkg.dir, 'package.json'), 'utf8'));
+    } catch {
+      continue;
+    }
+    const deps = [];
+    for (const field of ['dependencies', 'devDependencies', 'peerDependencies']) {
+      for (const [name, range] of Object.entries(manifest[field] ?? {})) {
+        if (typeof range === 'string' && range.startsWith('workspace:')) deps.push(name);
+      }
+    }
+    const typeEntries = declaredTypeEntries(manifest);
+    graph.set(pkg.name, {
+      deps: [...new Set(deps)].sort(),
+      typeEntries,
+      built: typeEntries.some((entry) => existsSync(join(ROOT, pkg.dir, entry))),
+    });
+  }
+  return graph;
+}
 
 /** @param {string} output */
 function countTscErrors(output) {
@@ -1156,6 +1326,30 @@ function measureTestDebt(dir) {
 function measureLedgers(packages, rootName, state) {
   const dirOf = new Map(packages.map((p) => [p.name, p.dir]));
   dirOf.set(rootName, ''); // the workspace root is a member like any other
+
+  // BUILT CLOSURE, checked ONCE for the whole ledger rather than per entry: an
+  // unbuilt dependency invalidates every number that resolves through it, so
+  // there is nothing useful to report entry by entry, and 34 sequential tsc
+  // runs against the wrong world is four minutes spent measuring nothing.
+  const ledgered = [...new Set([...Object.keys(state.debt), ...Object.keys(state.testDebt)])]
+    .filter((name) => dirOf.has(name));
+  const unbuilt = unbuiltClosure(ledgered, workspaceBuildGraph(packages));
+  if (unbuilt.length > 0) {
+    throw new Error(
+      `--re-measure cannot run: ${unbuilt.length} workspace dependenc(ies) of the ledgered packages have `
+        + `no built type entry point on disk -- ${unbuilt.join(', ')}.\n`
+        + `Every number in DEBT and TEST_DEBT is measured with tsc resolving workspace imports through each `
+        + `dependency's built \`dist/*.d.ts\`, so measuring now would not fail, it would silently measure a `
+        + `DIFFERENT WORLD: packages/lint reports 19 with its closure built and 147 without (TS2307 x71 plus `
+        + `the implicit-any cascade), same tree, same commit. The error is unbounded in BOTH directions -- an `
+        + `unresolved import invents TS2307/TS7006 and erases the structural mismatches that are usually the `
+        + `real debt -- so a number recorded from here is not this package's debt and must not enter the `
+        + `ledger (${SURPLUS_ISSUE}).\n`
+        + `Build the closure first, exactly as lint.yml does before this step:\n`
+        + `  pnpm exec turbo run build --filter='./packages/*' --filter='./packages/*/*'`,
+    );
+  }
+
   const measurements = [];
   for (const [name, entry] of Object.entries(state.debt)) {
     const dir = dirOf.get(name);
@@ -1174,13 +1368,26 @@ function measureLedgers(packages, rootName, state) {
  * MEASURED's verdict, pure over already-taken measurements so the self-test
  * pins the semantics without running a compiler.
  *
+ * `surplus` is the sum of every entry's `recorded - actual`, and it is the
+ * number #6376 is about: not "how stale is the bookkeeping" but "how many
+ * regressions can land in these layers without this gate saying anything".
+ * Reported, never red -- see the SURPLUS paragraph at the top of this file for
+ * why the direction of that ruling is deliberate, and `--lower` for the way out
+ * that costs an improvement nothing.
+ *
  * @param {Array<{ledger: string, name: string, recorded: number, actual: number}>} measurements
- * @returns {{problems: string[], notes: string[]}}
+ * @returns {{problems: string[], notes: string[], surplus: number, surplusEntries: number}}
  */
 function evaluateMeasurements(measurements) {
   const problems = [];
   const notes = [];
+  let surplus = 0;
+  let surplusEntries = 0;
   for (const m of measurements) {
+    if (m.actual < m.recorded) {
+      surplus += m.recorded - m.actual;
+      surplusEntries++;
+    }
     if (m.actual > m.recorded) {
       problems.push(
         `${m.name}: ${m.ledger} records ${m.recorded} raw tsc error(s), \`tsc --noEmit\` now reports ` +
@@ -1195,17 +1402,110 @@ function evaluateMeasurements(measurements) {
       notes.push(
         `${m.name}: ${m.ledger} records ${m.recorded}, and tsc now reports 0 -- graduation candidate. ` +
           `Onboard it (add \`"typecheck": "tsc --noEmit"\`, or drop the test exclusion, and delete the ` +
-          `ledger entry in the same PR).`,
+          `ledger entry in the same PR). \`--lower\` deliberately leaves this one alone: 0 is not a lower ` +
+          `ceiling, it is a graduation, and an entry recording 0 fails the structural half of this gate.`,
       );
     } else if (m.actual < m.recorded) {
       notes.push(
         `${m.name}: ${m.ledger} records ${m.recorded}, tsc now reports ${m.actual} ` +
           `(-${m.recorded - m.actual}) -- the entry can be lowered. Not an error: an improvement must not ` +
-          `have to pay a bookkeeping toll to land.`,
+          `have to pay a bookkeeping toll to land. But the gap is not bookkeeping while it is open: nothing ` +
+          `else reads this layer, so ${m.recorded - m.actual} new error(s) can land here and this gate will ` +
+          `report success (${SURPLUS_ISSUE} -- driver-mongodb's 33 swallowed a whole signature reversion). ` +
+          `Close it with \`pnpm check:type-check-debt --lower\`, which writes the measured number for you.`,
       );
     }
   }
-  return { problems, notes };
+  return { problems, notes, surplus, surplusEntries };
+}
+
+/**
+ * Which entries `--lower` may rewrite, and which it must not. Pure, because the
+ * "must not" half is the part that is easy to get wrong: an entry measuring 0 is
+ * a GRADUATION (delete the entry and add the script -- a deliberate PR), and
+ * writing 0 into the ledger would fail COVERED/TESTS_COVERED on the very next
+ * run, turning a free improvement into a broken tree.
+ *
+ * @param {Array<{ledger: string, name: string, recorded: number, actual: number}>} measurements
+ * @returns {{lowerings: Array<{ledger: string, name: string, from: number, to: number}>, graduations: string[]}}
+ */
+function plannedLowerings(measurements) {
+  const lowerings = [];
+  const graduations = [];
+  for (const m of measurements) {
+    if (m.actual >= m.recorded) continue;
+    if (m.actual <= 0) {
+      graduations.push(`${m.name} (${m.ledger})`);
+      continue;
+    }
+    lowerings.push({ ledger: m.ledger, name: m.name, from: m.recorded, to: m.actual });
+  }
+  return { lowerings, graduations };
+}
+
+/**
+ * The span of one ledger's object literal in this file's own source. Anchored on
+ * `\n};` rather than brace-matched: a `note` is a single-line string
+ * concatenation, so it can contain a brace but never a line that STARTS a
+ * closing one -- and a parser that can be fooled by prose is the wrong tool for
+ * rewriting the file the prose lives in.
+ *
+ * @returns {{start: number, end: number} | null}
+ */
+function ledgerBlockRange(source, ledgerName) {
+  const start = source.indexOf(`const ${ledgerName} = {`);
+  if (start === -1) return null;
+  const end = source.indexOf('\n};', start);
+  if (end === -1) return null;
+  return { start, end };
+}
+
+/**
+ * AUTO-LOWERING (#6376). Rewrites `errors:` downward for the named entries, in
+ * this file's own ledger source, and reports what it refused to touch instead of
+ * guessing. The point is not convenience: the measured number is only knowable
+ * by running the compiler against a built closure, so a human typing it is a
+ * human copying a number out of an environment that may not be the one CI
+ * measures in. The tool that took the measurement is the only honest author of
+ * the number.
+ *
+ * Notes are deliberately NOT rewritten. Raising a count demands a rewritten
+ * composition (the invariant above says so, and says why); lowering one leaves a
+ * note describing a pile LARGER than what exists, which misleads in the safe
+ * direction -- and inventing a composition for errors that are gone would be the
+ * exact sin that rule was written against.
+ *
+ * @param {string} source
+ * @param {Array<{ledger: string, name: string, from: number, to: number}>} lowerings
+ * @returns {{source: string, applied: string[], skipped: string[]}}
+ */
+function lowerLedgerEntries(source, lowerings) {
+  const applied = [];
+  const skipped = [];
+  let out = source;
+  for (const l of lowerings) {
+    const block = ledgerBlockRange(out, l.ledger);
+    if (!block) {
+      skipped.push(`${l.name}: no \`const ${l.ledger} = {\` block in ${SELF}`);
+      continue;
+    }
+    const text = out.slice(block.start, block.end);
+    const pattern = new RegExp(`('${l.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'\\s*:\\s*\\{[\\s\\S]*?errors:\\s*)(\\d+)`);
+    const match = text.match(pattern);
+    if (!match) {
+      skipped.push(`${l.name}: no \`errors:\` found under its ${l.ledger} entry`);
+      continue;
+    }
+    if (Number(match[2]) !== l.from) {
+      // The file moved under the measurement. Refusing is the only safe answer:
+      // writing anyway would record a number measured against a different tree.
+      skipped.push(`${l.name}: ${l.ledger} reads ${match[2]}, not the measured-against ${l.from} -- re-measure`);
+      continue;
+    }
+    out = out.slice(0, block.start) + text.replace(pattern, `$1${l.to}`) + out.slice(block.end);
+    applied.push(`${l.ledger} ${l.name}: ${l.from} -> ${l.to}`);
+  }
+  return { source: out, applied, skipped };
 }
 
 /** The observed non-fixture state. */
@@ -1561,6 +1861,57 @@ function selfTest() {
       ],
       problems: [/grew: DEBT records 3/],
       notes: [/shrank: DEBT records 9, tsc now reports 8/],
+      surplus: 1,
+    },
+    // #6376, THE CASUALTY, as measured on driver-mongodb rather than as a
+    // parable. These two cases are ONE scenario at two ceilings, and the pair is
+    // the whole issue: the tree is identical, the regression is identical, and
+    // only the recorded number decides whether this gate speaks.
+    //
+    // Read the first case for what it is -- a CHARACTERISATION of a live
+    // allowance, not a regression test of a fix. It asserts that the gate says
+    // NOTHING about a 12-error regression, because 12 < 43. That is today's
+    // deliberate behaviour (an improvement must not pay a toll), and it is
+    // pinned here so it is a decision on the record instead of an accident: if
+    // the surplus is ever made red, THIS is the assertion that flips, and the
+    // second case is what it must flip to.
+    {
+      label: '#6376 — a regression SMALLER than the surplus is invisible: 12 errors under a stale 43-ceiling',
+      measurements: [{ ledger: 'TEST_DEBT', name: 'driver-mongodb', recorded: 43, actual: 12 }],
+      problems: [],
+      notes: [/driver-mongodb: TEST_DEBT records 43, tsc now reports 12 \(-31\).*31 new error\(s\) can land here/s],
+      surplus: 31,
+    },
+    {
+      label: '#6376 — the same regression against the flattened ceiling is red: PR #6356 is why 10, not 43',
+      measurements: [{ ledger: 'TEST_DEBT', name: 'driver-mongodb', recorded: 10, actual: 12 }],
+      problems: [/driver-mongodb: TEST_DEBT records 10 raw tsc error\(s\).*now reports 12 \(\+2\)/s],
+      notes: [],
+      surplus: 0,
+    },
+    {
+      label: '#6376 — the surplus total is the allowance, summed over shrunk entries only',
+      measurements: [
+        { ledger: 'TEST_DEBT', name: 'approvals', recorded: 547, actual: 348 },
+        { ledger: 'TEST_DEBT', name: 'lint', recorded: 42, actual: 19 },
+        { ledger: 'DEBT', name: 'exact', recorded: 5, actual: 5 },
+        { ledger: 'DEBT', name: 'grew', recorded: 3, actual: 9 },
+      ],
+      problems: [/grew: DEBT records 3/],
+      notes: [/approvals: TEST_DEBT records 547/, /lint: TEST_DEBT records 42/],
+      surplus: 222,
+      surplusEntries: 2,
+    },
+    {
+      label: '#6376 — an exactly-calibrated ledger reports no allowance at all',
+      measurements: [
+        { ledger: 'DEBT', name: 'a', recorded: 91, actual: 91 },
+        { ledger: 'TEST_DEBT', name: 'b', recorded: 467, actual: 467 },
+      ],
+      problems: [],
+      notes: [],
+      surplus: 0,
+      surplusEntries: 0,
     },
   ];
   for (const c of driftCases) {
@@ -1569,11 +1920,13 @@ function selfTest() {
       got.problems.length === c.problems.length &&
       got.notes.length === c.notes.length &&
       c.problems.every((rx, i) => rx.test(got.problems[i])) &&
-      c.notes.every((rx, i) => rx.test(got.notes[i]));
+      c.notes.every((rx, i) => rx.test(got.notes[i])) &&
+      (c.surplus === undefined || got.surplus === c.surplus) &&
+      (c.surplusEntries === undefined || got.surplusEntries === c.surplusEntries);
     if (!ok) {
       failures.push(
         `evaluateMeasurements — ${c.label}: expected ${c.problems.length} problem(s) / ${c.notes.length} note(s) ` +
-          `matching, got ${JSON.stringify(got)}`,
+          `matching${c.surplus === undefined ? '' : ` / surplus ${c.surplus}`}, got ${JSON.stringify(got)}`,
       );
     }
   }
@@ -1609,6 +1962,181 @@ function selfTest() {
     if (got !== c.expect) failures.push(`countTscErrors — ${c.label}: expected ${c.expect}, got ${got}`);
   }
 
+  // BUILT CLOSURE (#6376). The precondition is only worth having if it can tell
+  // "this package publishes no types" from "this package was never built" --
+  // confusing those two either refuses every run (console has no type entry) or
+  // refuses none.
+  const typeEntryCases = [
+    { label: 'a flat `types` entry', manifest: { types: 'dist/index.d.ts' }, expect: ['dist/index.d.ts'] },
+    {
+      label: 'conditional exports contribute every declaration file they name',
+      manifest: {
+        types: 'dist/index.d.ts',
+        exports: { '.': { import: { types: './dist/index.d.mts' }, require: { types: './dist/index.d.ts' } } },
+      },
+      expect: ['dist/index.d.mts', 'dist/index.d.ts'],
+    },
+    { label: 'a package that publishes no types declares none', manifest: { exports: { './package.json': './package.json' } }, expect: [] },
+    { label: 'runtime entry points are not type entry points', manifest: { main: 'dist/index.js', module: 'dist/index.mjs' }, expect: [] },
+  ];
+  for (const c of typeEntryCases) {
+    const got = declaredTypeEntries(c.manifest);
+    if (JSON.stringify(got) !== JSON.stringify(c.expect)) {
+      failures.push(`declaredTypeEntries — ${c.label}: expected ${JSON.stringify(c.expect)}, got ${JSON.stringify(got)}`);
+    }
+  }
+
+  // The graph below is shared by the next two cases ON PURPOSE, and they are a
+  // PAIR: a "nothing is reported" assertion passes vacuously over an empty
+  // measurement set, so the same 4-package graph is asserted twice -- once
+  // fully built (exactly 0 reported) and once with a single `built` flag
+  // flipped (exactly 1 reported, by name). The second is what proves the first
+  // was measuring something.
+  const built = (deps, isBuilt = true) => ({ deps, typeEntries: ['dist/index.d.ts'], built: isBuilt });
+  const closureGraph = (specBuilt) => new Map([
+    ['ledgered', built(['spec', 'formula'])],
+    ['spec', built([], specBuilt)],
+    ['formula', built(['spec'])],
+    ['untouched', built([], false)], // unbuilt, but nothing in the closure needs it
+  ]);
+  const closureCases = [
+    { label: 'a fully built closure reports nothing, over a graph of 4 packages', roots: ['ledgered'], graph: closureGraph(true), expect: [] },
+    { label: 'flipping one dependency to unbuilt reports exactly that one', roots: ['ledgered'], graph: closureGraph(false), expect: ['spec'] },
+    {
+      label: 'a transitive dependency counts — the closure is walked, not just the direct deps',
+      roots: ['ledgered'],
+      graph: new Map([['ledgered', built(['formula'])], ['formula', built(['spec'])], ['spec', built([], false)]]),
+      expect: ['spec'],
+    },
+    {
+      label: 'a ledgered package\'s OWN dist is irrelevant to its OWN number',
+      roots: ['ledgered'],
+      graph: new Map([['ledgered', built([], false)]]),
+      expect: [],
+    },
+    {
+      label: 'but it IS reported when another ledgered package depends on it',
+      roots: ['a', 'ledgered'],
+      graph: new Map([['a', built(['ledgered'])], ['ledgered', built([], false)]]),
+      expect: ['ledgered'],
+    },
+    {
+      label: 'a package that declares no type entry point is never unbuilt',
+      roots: ['ledgered'],
+      graph: new Map([['ledgered', built(['console'])], ['console', { deps: [], typeEntries: [], built: false }]]),
+      expect: [],
+    },
+    {
+      label: 'a dependency cycle terminates instead of hanging the gate',
+      roots: ['ledgered'],
+      graph: new Map([['ledgered', built(['a'])], ['a', built(['b'])], ['b', built(['a'], false)]]),
+      expect: ['b'],
+    },
+    {
+      label: 'a dependency outside the workspace is npm\'s problem, not the build\'s',
+      roots: ['ledgered'],
+      graph: new Map([['ledgered', built(['zod'])]]),
+      expect: [],
+    },
+  ];
+  for (const c of closureCases) {
+    const got = unbuiltClosure(c.roots, c.graph);
+    if (JSON.stringify(got) !== JSON.stringify(c.expect)) {
+      failures.push(`unbuiltClosure — ${c.label}: expected ${JSON.stringify(c.expect)}, got ${JSON.stringify(got)}`);
+    }
+  }
+
+  // AUTO-LOWERING (#6376). What it refuses matters more than what it writes.
+  const planCases = [
+    {
+      label: 'a shrunk entry is lowered to its measurement',
+      measurements: [{ ledger: 'DEBT', name: 'a', recorded: 52, actual: 42 }],
+      lowerings: [{ ledger: 'DEBT', name: 'a', from: 52, to: 42 }],
+      graduations: [],
+    },
+    { label: 'a grown entry is never lowered', measurements: [{ ledger: 'DEBT', name: 'a', recorded: 3, actual: 7 }], lowerings: [], graduations: [] },
+    { label: 'an exact entry is left alone', measurements: [{ ledger: 'DEBT', name: 'a', recorded: 3, actual: 3 }], lowerings: [], graduations: [] },
+    {
+      label: 'an entry measuring 0 is a graduation, not a lowering — writing 0 would fail the structural gate',
+      measurements: [{ ledger: 'TEST_DEBT', name: 'a', recorded: 4, actual: 0 }],
+      lowerings: [],
+      graduations: ['a (TEST_DEBT)'],
+    },
+  ];
+  for (const c of planCases) {
+    const got = plannedLowerings(c.measurements);
+    if (JSON.stringify(got.lowerings) !== JSON.stringify(c.lowerings) || JSON.stringify(got.graduations) !== JSON.stringify(c.graduations)) {
+      failures.push(`plannedLowerings — ${c.label}: expected ${JSON.stringify(c)}, got ${JSON.stringify(got)}`);
+    }
+  }
+
+  // The rewriter, against a fixture shaped like this file's own ledgers --
+  // including the two traps they really contain: ONE package name that appears
+  // in BOTH ledgers with different numbers (`@objectstack/rest` is 2 in DEBT and
+  // 163 in TEST_DEBT), and a `note` whose PROSE contains the word it is
+  // searching for.
+  const ledgerFixture = [
+    'const DEBT = {',
+    "  '@objectstack/rest': {",
+    '    errors: 2,',
+    "    note: 'code-tier 2. An earlier sweep read errors: 99 here, which is prose and not the field.',",
+    '  },',
+    "  '@objectstack/other': { errors: 5, note: 'x' },",
+    '};',
+    '',
+    'const TEST_DEBT = {',
+    "  '@objectstack/rest': { errors: 163, note: 'y' },",
+    '};',
+    '',
+  ].join('\n');
+  const rewriteCases = [
+    {
+      label: 'lowers the entry in the NAMED ledger, leaving the same name in the other ledger untouched',
+      lowerings: [{ ledger: 'TEST_DEBT', name: '@objectstack/rest', from: 163, to: 144 }],
+      applied: 1,
+      skipped: 0,
+      assert: (out) => /const DEBT[\s\S]*'@objectstack\/rest': \{\n    errors: 2,/.test(out)
+        && /const TEST_DEBT[\s\S]*'@objectstack\/rest': \{ errors: 144,/.test(out),
+    },
+    {
+      label: 'the field is the first `errors:` under the name — prose inside the note is not a field',
+      lowerings: [{ ledger: 'DEBT', name: '@objectstack/rest', from: 2, to: 1 }],
+      applied: 1,
+      skipped: 0,
+      assert: (out) => /errors: 1,/.test(out) && /read errors: 99 here/.test(out),
+    },
+    {
+      label: 'refuses when the file no longer reads the number the measurement was taken against',
+      lowerings: [{ ledger: 'DEBT', name: '@objectstack/other', from: 9, to: 4 }],
+      applied: 0,
+      skipped: 1,
+      assert: (out) => out === ledgerFixture,
+    },
+    {
+      label: 'refuses an entry that is not in that ledger rather than writing somewhere plausible',
+      lowerings: [{ ledger: 'DEBT', name: '@objectstack/absent', from: 3, to: 1 }],
+      applied: 0,
+      skipped: 1,
+      assert: (out) => out === ledgerFixture,
+    },
+    {
+      label: 'an empty plan leaves the source byte-identical',
+      lowerings: [],
+      applied: 0,
+      skipped: 0,
+      assert: (out) => out === ledgerFixture,
+    },
+  ];
+  for (const c of rewriteCases) {
+    const got = lowerLedgerEntries(ledgerFixture, c.lowerings);
+    if (got.applied.length !== c.applied || got.skipped.length !== c.skipped || !c.assert(got.source)) {
+      failures.push(
+        `lowerLedgerEntries — ${c.label}: expected ${c.applied} applied / ${c.skipped} skipped and the ` +
+          `documented source, got ${JSON.stringify({ applied: got.applied, skipped: got.skipped })}`,
+      );
+    }
+  }
+
   if (failures.length) {
     console.error(`✗ check:type-check-coverage --self-test — ${failures.length} failure(s)\n`);
     for (const f of failures) console.error('  • ' + f);
@@ -1617,7 +2145,9 @@ function selfTest() {
   console.log(
     `✓ check:type-check-coverage --self-test — ${cases.length} semantic case(s) + ` +
       `${namedCases.length + coverCases.length + derivedCases.length} observation case(s) + ` +
-      `${driftCases.length + countCases.length} re-measure case(s) hold.`,
+      `${driftCases.length + countCases.length} re-measure case(s) + ` +
+      `${typeEntryCases.length + closureCases.length} built-closure case(s) + ` +
+      `${planCases.length + rewriteCases.length} auto-lowering case(s) hold.`,
   );
 }
 
@@ -1659,9 +2189,34 @@ console.log(
 if (process.argv.includes('--re-measure')) {
   const started = Date.now();
   const measurements = measureLedgers(packages, root.name, state);
-  const { problems: drift, notes } = evaluateMeasurements(measurements);
+  const { problems: drift, notes, surplus, surplusEntries } = evaluateMeasurements(measurements);
   const elapsed = ((Date.now() - started) / 1000).toFixed(1);
   for (const n of notes) console.log('  ℹ ' + n);
+
+  // AUTO-LOWERING. Opt-in, like the `--update` on this repo's other two
+  // ratchets, and run BEFORE the drift verdict so a tree that has both a
+  // regression and a surplus still gets the surplus closed in the same lap.
+  if (process.argv.includes('--lower')) {
+    const { lowerings, graduations } = plannedLowerings(measurements);
+    const file = join(ROOT, SELF);
+    const { source, applied, skipped } = lowerLedgerEntries(readFileSync(file, 'utf8'), lowerings);
+    if (applied.length > 0) writeFileSync(file, source);
+    console.log(
+      `\ncheck-type-check-coverage --lower: ${applied.length} ledger entr(ies) lowered to their measurement.`,
+    );
+    for (const a of applied) console.log('  ↓ ' + a);
+    for (const s of skipped) console.log('  ! ' + s);
+    for (const g of graduations) {
+      console.log(`  ! ${g} measures 0 -- not lowered: that is a graduation, and it is a deliberate PR.`);
+    }
+    if (applied.length > 0) {
+      console.log(
+        `  Review and commit ${SELF}. Each \`note\` still describes the LARGER pile it was written for; ` +
+          `rewrite the ones you can attribute, and leave the rest rather than inventing a composition.`,
+      );
+    }
+  }
+
   if (drift.length) {
     console.error(`\ncheck-type-check-coverage --re-measure: ${drift.length} ledger entr(ies) drifted upward\n`);
     for (const p of drift) console.error('  • ' + p);
@@ -1671,5 +2226,15 @@ if (process.argv.includes('--re-measure')) {
   console.log(
     `check-type-check-coverage --re-measure: OK — ${measurements.length} ledger entr(ies) re-measured ` +
       `in ${elapsed}s, ${measuredTotal} raw tsc error(s) total, none above its recorded number.`,
+  );
+  // Printed on a GREEN run, on purpose. This is the one number the old summary
+  // could not have told you: how much silence the ledger is currently buying
+  // (#6376). Zero is the goal and `--lower` is one command away from it.
+  console.log(
+    surplusEntries === 0
+      ? `  surplus: none — every entry sits exactly at its measurement, so any new error is red.`
+      : `  surplus: ${surplus} raw error(s) across ${surplusEntries} entr(ies) sit BELOW their recorded ` +
+        `ceiling — that many regressions can land in layers no other gate reads without this one saying ` +
+        `anything (${SURPLUS_ISSUE}). Close it with \`pnpm check:type-check-debt --lower\`.`,
   );
 }


### PR DESCRIPTION
Fixes #6376

## 结论先行:判据不是阈值,但**也不是**「有没有第二个看门人」

派单和出处方的分析都建立在一个布尔判据上:**测试层在某个 tsc program 里 vs 被 tsconfig 排除**。这个论证本身是对的,但实测表明它**在账本内部恒为真,因此划不出子集**:

| | 结果 | 为什么是构造性的 |
|:--|:--|:--|
| `TEST_DEBT` 19/19 条 | 唯一看门人 | entry 存在的**充要条件**就是 `excludesTests`(该包 `typecheck` script 调用的 tsconfig 没有一个读测试层),否则 TESTS_COVERED / RECONCILED 二者必红 |
| `DEBT` 15/15 条 | 唯一看门人 | entry 存在的**充要条件**是该包没有 `typecheck` script(否则 RECONCILED 红);根条目 `@objectstack/spec-monorepo` 同理没有 `typecheck:root` |
| 全仓 tsconfig | 无 `paths` 映射 | 跨包 import 一律经由依赖的 `dist/*.d.ts` 解析,别的包的 program **不会**把这些源文件拉进去 |

⇒ **「有第二个看门人」的那一类,恰好就是「压根没有账本条目」的那一类**,而没有条目就不可能有余量。所以方向 3 不是一次收窄,它展开后等于方向 1(全量抹平),也就正好是 #5278 判过不该付的那笔记账过路费。

**出处方那句话仍然成立,而且比原文更强**:余量从来都是许可额度,没有例外。今天全仓 **11 条 entry 合计 310 条余量,占两个账本记录总量(2072)的 15%**,其中 199 条集中在一条上。

## 实测表(main @ `1818998`,全量 build 后 `--re-measure`,两次逐字节一致)

| 条目 | 账本 | 记录 | 实测 | 余量 | 唯一看门人 |
|:--|:--|--:|--:|--:|:--:|
| `@objectstack/plugin-approvals` | TEST_DEBT | 547 | 348 | **-199** | ✅ |
| `@objectstack/plugin-auth` | TEST_DEBT | 131 | 106 | -25 | ✅ |
| `@objectstack/lint` | TEST_DEBT | 42 | 19 | -23 | ✅ |
| `@objectstack/rest` | TEST_DEBT | 163 | 144 | -19 | ✅ |
| `@objectstack/plugin-security` | TEST_DEBT | 21 | 9 | -12 | ✅ |
| `@objectstack/service-storage` | **DEBT** | 52 | 42 | -10 | ✅(无 `typecheck` script,源码层无人读) |
| `@objectstack/mcp` | TEST_DEBT | 63 | 53 | -10 | ✅(**派单点名待确认,已实测确认排除测试层**) |
| `@objectstack/runtime` | TEST_DEBT | 227 | 220 | -7 | ✅ |
| `@objectstack/objectql` | TEST_DEBT | 355 | 353 | -2 | ✅ |
| `@objectstack/service-automation` | **DEBT** | 5 | 3 | -2 | ✅ |
| `@objectstack/http-conformance` | TEST_DEBT | 4 | 3 | -1 | ✅ |
| 其余 23 条 | — | — | — | 0 | ✅ |

⚠️ 正文表格(测于 `d8e8d9cbc`)已全面失效:5 条变 11 条,最大余量从 -19 变 -199,`plugin-approvals` / `plugin-auth` / `plugin-security` 是新出现的。**两条未确认项已实测**:`service-storage` 记的是 `DEBT`(源码层),它同样没有第二个看门人;`@objectstack/mcp` 确实排除测试层。

## ⚠️ 一个比余量更靠底层的发现:这个「实测值」原本是不可复现的

派单方转来同一条 entry(`@objectstack/lint`)当天在并行 agent 之间流通的**三个读数:19 / 39 / 147**。我复现了其中的成因:

```
闭包已构建   19   (TS7006 x11, TS2835 x4, TS6059 x4)
闭包未构建  147   (TS2307 x71 —— cannot find module —— 外加它引发的
                   级联 TS7006 x38, TS18046 x20, ...)
```

**同一棵树、同一个 commit、相差 7.7 倍,而两次运行都没有任何告警。** tsc 经由依赖的 `dist/*.d.ts` 解析工作区导入,闭包没构建时测量不会失败,只会**测到另一个世界**;而且偏差**在两个方向上都无界** —— 未解析的 import 让每个符号退化为 `any`,凭空造出 TS2307/TS7006 的同时**抹掉**真正的结构性不匹配(TS2345/TS2322)。`driver-mongodb` 那 33 条 TS2345 正是这一类,在未构建的 `@objectstack/spec` 面前会实测为 0。

这直接决定了方向:**一个不可复现的量,撑不起任何以「记录值 vs 实测值」为判据的政策**,而方向 1 / 方向 2 都要求人手写下一个实测数字。所以本 PR 先让这个数字变得可信。

同一环境内它是**确定性**的:两次全量 `--re-measure` 逐字节一致(1762 total),所以这不是 tsc 的不确定性,是环境/树的差异 —— 正是 ledger 头部要求先证伪的那一条。

## 本 PR 做了什么(方向:auto-lowering,不判红)

⛔ **没有**把余量判红。#5278 的裁决继续成立,改进仍然全绿落地。做的是三件让余量**可见、可信、一键可抹平**的事:

1. **可见 —— 余量被量化并在绿色运行上报告。** 每条 ℹ 现在直说这道口子允许多少条回归静默通过,收尾行汇总全仓:
   ```
   surplus: 310 raw error(s) across 11 entr(ies) sit BELOW their recorded ceiling
   — that many regressions can land in layers no other gate reads without this one
   saying anything (#6376). Close it with `pnpm check:type-check-debt --lower`.
   ```
   「看不见的额度」才是伤人的部分。

2. **可一键抹平 —— `--lower` 把实测值写回账本。** 抹平一条 entry 不再需要人手敲一个实测数字(见上一节:人手敲的数字来自一个可能不是 CI 那个的环境)。实测跑过一次全量:11 条 entry 精确改写 11 处 `errors:`,notes 与结构零损伤,并正确区分了**同名跨账本**的 `@objectstack/rest`(DEBT 2 未动,TEST_DEBT 163 → 144)。实测值为 0 的条目**不写** —— 那是毕业,写 0 会让下一次结构闸门直接红。

3. **可信 —— 拒绝在未构建的依赖闭包上测量。** 前置检查(每个 `workspace:` 依赖是否有已构建的类型入口),而**不是**扫 tsc 输出里的 TS2307:账本里本来就有条目把 TS2307 记为真实债务(根条目 note 明写 `TS2307 x17`),一个分不清「记录在案的缺陷」和「测坏了的测量」的闸门,会去拒绝它本该测量的条目。

## 钉住缺陷本身的那对用例

自测里最重要的不是新增数量,是这一对 —— **同一棵树、同一次回归,只有天花板不同**:

```
#6376 — a regression SMALLER than the surplus is invisible: 12 errors under a stale 43-ceiling
        recorded 43, actual 12  ->  0 problems(门禁沉默), surplus 31
#6376 — the same regression against the flattened ceiling is red: PR #6356 is why 10, not 43
        recorded 10, actual 12  ->  1 problem  "records 10 ... now reports 12 (+2)"
```

⚠️ 诚实标注:**第一条是对现行行为的 characterisation,不是对某个修复的回归测试** —— 因为我**有意没有**改这个判决。它的价值是把「余量吞掉回归」变成一条**记录在案的决定**而不是一次意外:将来若要把余量判红,**就是这条断言翻面**,而第二条就是它该翻成的样子。

## 门禁

| 闸门 | 结果 | 证据 |
|:--|:--|:--|
| `pnpm lint`(ESLint) | pass | 无输出 |
| `pnpm check:type-check-debt` | pass | `34 ledger entr(ies) re-measured in 199.3s, 1762 raw tsc error(s) total, none above its recorded number.` |
| `--self-test` | pass | `23 semantic + 16 observation + 15 re-measure + 12 built-closure + 9 auto-lowering case(s) hold.`(新增 21 条 + 4 条 #6376 用例) |
| `pnpm check:nul-bytes` | pass | `scanned 6105 tracked text file(s) ... no raw ASCII control bytes` |
| 控制字节自扫(超出闸门扫描面) | pass | `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` → 0 hits |
| 前置检查实测触发 | pass | 藏掉 `packages/formula/dist` 后 `--re-measure` 立即拒绝并点名该包,**未启动任何 tsc** |

## 反向验证(先声明,后运行)

| | 反转 | 声明红 | 实测红 | 一致 |
|:--|:--|--:|--:|:--:|
| R1 | `unbuiltClosure()` 退回宽容分支 | 4 | 4 | ✅ |
| R2 | 余量统计退回(永不累加) | 3 | 3 | ✅ |
| R3 | `lowerLedgerEntries()` 退回恒等 | 2 | **4** | ❌ |
| R4 | `plannedLowerings()` 去掉 0 值守卫 | 1 | 1 | ✅ |
| R5 | 棘轮本体退回(增长不再红) | 5 | 5 | ✅ |

**R3 的分歧就是发现,不改声明**:我按「负向断言会空过」把 3 条 `applied === 0` 的用例整体划为空过,实际只有 1 条是(空计划那条)。另外两条断言的是 `skipped === 1` —— **「拒绝被记录下来了」是一条正向断言**,反转后 `skipped` 变空数组照样红。教训:空过与否要按**每条断言**判,不是按用例的方向判。

R5 是专门用来证明 mongodb 那**一对**不空过的:把棘轮本体反转后,「同一次回归在 10 天花板下判红」立刻红,说明第二条确实在测东西。

**R6(不是反转,是相反方向的一次测量)**:把余量改成判红,会有 **4 条**既有语义翻面,其中包括 `a count that shrank is a note, never red` —— 也就是说,**#5278「改进不该付过路费」的裁决不只是散文,它是一条被钉住的断言**;要把余量判红,就得先把它翻面。这条数据留给维护者决策用。

## ⛔ 有意没做的事

- **没有抹平任何一条 entry。** `--lower` 的全量演示跑过,产出的 11 处改动**已还原、未提交**。派单明确禁止攒批,而 `objectql` / `rest` 是活跃包(#5278 的 option D 输过五次);11 条一把抹平必然在合并前失效。抹平应当**一条一 PR、落地即合**,而现在做这件事不再需要人手敲数字。
- **没有加阈值判据(方向 2)。** 阈值本身是任意的,而且「改进越大、过路费越高」的激励是反的;#5278 已判过这类过路费。
- **没有把余量判红。** 见下面的开放问题 —— 这是一个会改变 CI 与每位作者契约的判决,且我的实测表明它**无法作为单个 PR 落地**(需同时抹平 11 条 = 被禁止的攒批,且新增的红面在两个方向上都会撞上活跃包的漂移)。
- **没有碰** `packages/lint/src/validate-semantic-roles.test.ts:10` 那处缺 `.js` 的 import(单点可消 5 条,净减台账)—— 超出本单文件面,且 #4311 已在追踪该类。

## 留给维护者的一个判决

维护者的推进意见是「auto-lowering(或 surplus ceiling),而不是让改进变红」。本 PR 交付了 auto-lowering 的**机制**,但它是**自愿的**;而实测给出一个不利于「自愿」的证据:ℹ 提示自 #5278 落地起每次 CI 都在打印,五条 entry 的 note 自己写着「tighten immediately after landing」,**至今一条都没被抹平,余量反而从 5 条涨到 11 条**。也就是说,纯提示性的机制在这个仓库里**已被实测证伪**。

所以真正的判决是:**记录值过期,要不要变成红?**

- **A. 维持自愿(本 PR 现状)。** 零新增红面、零竞态;但保证不了紧致度,而上面那条证据说它大概率不会被自觉执行。
- **B. 强制 auto-lowering(记录值必须等于实测值,修复即一条命令)。** 唯一能保证紧致的形状;代价是改进方要多跑一趟,并且**必须先把 11 条抹平**(被禁止的攒批)。可行路径是**排序而非阈值**:先合本 PR,再用 `--lower` 一条一 PR 抹平,最后再开强制。
- **C. surplus ceiling(余量上限)。** 仍是阈值,K 值任意,激励方向同样是反的。

我的建议是 **B,但必须按上面的排序执行**,且只在 11 条全部抹平后再开;在那之前保持 A。理由:(1)真实业务需求 —— 310 条许可额度里有 199 条压在 `plugin-approvals` 这个隐藏测试层最大的包上,而 mongodb 已经**实测**证明这种额度会吞掉真实回退;(2)长期健康 —— 唯一看门人的天花板必须是紧的,否则这两个账本只是在**声称**冻结;(3)让 AI 写的代码难以出错 —— 强制 + `--lower` 意味着数字永远由**做过测量的工具**写下,而不是由人从一个可能不是 CI 的环境里抄来,这正是本 PR 第三项修复要解决的问题。⛔ 但 B 是判决,不是我该替维护者做的猜测,所以本 PR 不实施。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_