### PR TITLE
feat(spec): share-link enforcement 路径改收完整 ExecutionContext,窄类型只服务路由 401 (#6430)

### DIFF
--- a/.changeset/share-link-enforcement-full-envelope.md
+++ b/.changeset/share-link-enforcement-full-envelope.md
@@ -1,0 +1,35 @@
+---
+"@objectstack/spec": minor
+---
+
+feat(spec): share-link enforcement takes the full `ExecutionContext`; the narrow context is route-401 only (#6430, #6206 ruling A)
+
+`IShareLinkService.createLink` / `revokeLink` / `listLinks` now declare their
+context parameter as the complete `ExecutionContext` envelope instead of the
+five-field `ShareLinkExecutionContext`. All three ADJUDICATE access — the
+[Finding-2] visibility re-read on create, the ADR-0111 D8 share-manager probe
+on revoke, the context-scoped listing — so each needs the whole
+`resolveAuthzContext` result, `accessible_org_ids` / `org_user_ids` /
+`systemPermissions` / `posture` / `tabPermissions` included.
+
+The measured failure behind the ruling: the share-link route assembled exactly
+those five fields and handed the result straight to `engine.find` as the
+enforcement context. Under the `group` tenancy posture `accessible_org_ids` IS
+the Layer 0 wall (ADR-0105 D2) and an absent set denies, so link creation
+returned a blanket 403 on a posture that ships. Fail-closed, not a leak — but a
+trimmed envelope feeding enforcement is a bypass-shaped pattern, and ADR-0095
+D2 already rules that posture is resolved once and carried, never re-derived at
+the enforcement site. This was the third assembly site of that family (#5997,
+#6071), so the contract converges on the whole envelope rather than keeping a
+per-site subset.
+
+`ShareLinkExecutionContext` is retained and unchanged in shape — it is the
+route's own "authenticated or 401?" vocabulary — with TSDoc that now states the
+boundary and why TypeScript cannot enforce it (structural subtyping accepts a
+narrow object wherever the wide type is expected, so the declared parameter
+type plus the caller's obligation are what hold the line).
+
+Contract-only, no runtime behaviour change here: existing implementations keep
+compiling (method parameters are bivariant), and the `@objectstack/plugin-sharing`
+consumer that actually threads the envelope through is the follow-up half
+tracked on #6206.

--- a/packages/spec/src/contracts/share-link-service.test.ts
+++ b/packages/spec/src/contracts/share-link-service.test.ts
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// [#6430 / #6206 ruling A] Share-link contract pins — the enforcement/401 line.
+//
+// ## What the ruling decided
+//
+// The share-link visibility check must run on the FULL `ExecutionContext` (the
+// complete `resolveAuthzContext` envelope: `accessible_org_ids`,
+// `org_user_ids`, `systemPermissions`, `posture`, `tabPermissions`, …).
+// `ShareLinkExecutionContext` — the five-field shape the route assembled — may
+// keep serving the route's own 401 decision, but must never reach an
+// enforcement path. ADR-0095 D2 (posture resolved once, carried, never
+// re-derived at enforcement) and ADR-0105 D2 (`accessible_org_ids` IS the
+// `group`-posture Layer 0 wall, absent ⇒ deny) are the anchors; #5997 and
+// #6071 were the two prior assembly sites of the same family.
+//
+// ## What is pinned here, and what deliberately is NOT
+//
+// PINNED: (1) each `IShareLinkService` method that adjudicates access declares
+// its context parameter as `ExecutionContext` — by TYPE IDENTITY, so
+// re-narrowing it to anything (including back to `ShareLinkExecutionContext`)
+// goes red; (2) a call site may state the whole envelope, which under the old
+// signature was a TS2353 excess-property error on every one of the five
+// dropped keys — that is this file's before-red direction; (3) the narrow type
+// survives, unchanged in shape, as the route's 401 vocabulary.
+//
+// NOT PINNED, on purpose: there is no `@ts-expect-error` asserting that a
+// `ShareLinkExecutionContext` is REJECTED by an enforcement parameter, because
+// it is not. Structural subtyping makes the narrow type assignable to
+// `ExecutionContext` — its five fields all exist there with compatible types,
+// and nothing in `ExecutionContext` is required — so such a directive would be
+// unsatisfied and fail the build. TypeScript cannot express "this optional
+// field had better have been populated". A pin shaped to look like compiler
+// enforcement, where only documentation exists, would read as verified and be
+// worse than the honest statement, so the last case below pins the assignment
+// as the legal-but-unwanted fact it is and names what actually holds the line:
+// the declared parameter type, which makes any narrowing visible at the call
+// site, plus the caller's obligation to pass the resolved envelope through
+// whole.
+
+import { describe, expect, it } from 'vitest';
+
+import type { ExecutionContext } from '../kernel/execution-context.zod';
+import type {
+  CreateShareLinkInput,
+  IShareLinkService,
+  ListShareLinksFilter,
+  ShareLink,
+  ShareLinkExecutionContext,
+} from './share-link-service';
+
+/** Type-level identity: true iff A and B are the same type. */
+type Eq<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+  ? true
+  : false;
+/** Compile error when the argument is not `true`. */
+type Assert<T extends true> = T;
+/** Compile error when the argument is not `false`. */
+type Refute<T extends false> = T;
+
+type CreateCtx = Parameters<IShareLinkService['createLink']>[1];
+type RevokeCtx = Parameters<IShareLinkService['revokeLink']>[1];
+type ListCtx = Parameters<IShareLinkService['listLinks']>[1];
+
+// Every adjudicating method takes the full envelope, by identity.
+export type EnforcementTakesFullEnvelope0 = Assert<Eq<CreateCtx, ExecutionContext>>;
+export type EnforcementTakesFullEnvelope1 = Assert<Eq<RevokeCtx, ExecutionContext>>;
+export type EnforcementTakesFullEnvelope2 = Assert<Eq<ListCtx, ExecutionContext>>;
+
+// …and none of them takes the route's narrow 401 shape.
+export type EnforcementIsNotNarrow0 = Refute<Eq<CreateCtx, ShareLinkExecutionContext>>;
+export type EnforcementIsNotNarrow1 = Refute<Eq<RevokeCtx, ShareLinkExecutionContext>>;
+export type EnforcementIsNotNarrow2 = Refute<Eq<ListCtx, ShareLinkExecutionContext>>;
+
+// The narrow type keeps exactly the five route-401 fields — it was not widened
+// as a shortcut around the ruling. Widening it would recreate the subset this
+// card removed, one field at a time.
+export type NarrowTypeKeepsRouteShape = Assert<
+  Eq<keyof ShareLinkExecutionContext, 'userId' | 'tenantId' | 'isSystem' | 'positions' | 'permissions'>
+>;
+
+/** Records what the service actually received, so no assertion is vacuous. */
+function makeRecordingService(): {
+  service: IShareLinkService;
+  seen: ExecutionContext[];
+} {
+  const seen: ExecutionContext[] = [];
+  const link: ShareLink = {
+    id: 'shl_pin',
+    token: 'tok_0123456789012345678901',
+    object_name: 'contract',
+    record_id: 'rec_1',
+    permission: 'view',
+    audience: 'link_only',
+  };
+  const service: IShareLinkService = {
+    async createLink(_input: CreateShareLinkInput, context: ExecutionContext) {
+      seen.push(context);
+      return link;
+    },
+    async revokeLink(_idOrToken: string, context: ExecutionContext) {
+      seen.push(context);
+    },
+    async listLinks(_filter: ListShareLinksFilter, context: ExecutionContext) {
+      seen.push(context);
+      return [link];
+    },
+    async resolveToken() {
+      return null;
+    },
+  };
+  return { service, seen };
+}
+
+describe('share-link contract — enforcement takes the full ExecutionContext (#6430)', () => {
+  it('accepts the whole resolveAuthzContext envelope at an enforcement call site', async () => {
+    const { service, seen } = makeRecordingService();
+
+    // The before-red direction of this file. Written as an object LITERAL on
+    // purpose: excess-property checking applies to literals, so under the old
+    // `ShareLinkExecutionContext` parameter every key below the first five was
+    // a TS2353 error ("does not exist in type ShareLinkExecutionContext") —
+    // which is precisely why the route hand-assembled a subset instead of
+    // passing what it had already resolved. Restore the narrow parameter type
+    // and this call stops compiling.
+    await service.createLink(
+      { object: 'contract', recordId: 'rec_1' },
+      {
+        userId: 'usr_1',
+        tenantId: 'org_plant_a',
+        positions: ['sales'],
+        permissions: ['standard_user'],
+        // The five dimensions the trimmed envelope dropped (#6206):
+        accessible_org_ids: ['org_plant_a', 'org_plant_b'],
+        org_user_ids: ['usr_1', 'usr_2'],
+        systemPermissions: ['manage_sharing'],
+        posture: 'MEMBER',
+        tabPermissions: { crm: 'visible' },
+      },
+    );
+
+    const received = seen[0]!;
+    // ADR-0105 D2: this set IS the `group`-posture Layer 0 wall. Its absence
+    // was the blanket 403 — so its arrival is the fact worth observing.
+    expect(received.accessible_org_ids).toEqual(['org_plant_a', 'org_plant_b']);
+    // ADR-0095 D2: resolved once upstream, carried — never re-derived here.
+    expect(received.posture).toBe('MEMBER');
+    expect(received.org_user_ids).toEqual(['usr_1', 'usr_2']);
+    expect(received.systemPermissions).toEqual(['manage_sharing']);
+    expect(received.tabPermissions).toEqual({ crm: 'visible' });
+  });
+
+  it('carries the envelope through revokeLink and listLinks too', async () => {
+    const { service, seen } = makeRecordingService();
+    const envelope: ExecutionContext = {
+      userId: 'usr_1',
+      accessible_org_ids: ['org_plant_a'],
+      posture: 'TENANT_ADMIN',
+    };
+
+    // Both are adjudicating paths: revoke authority is creator ∪ record
+    // share-manager (ADR-0111 D8, probed with `context`), and the listing is
+    // read under `context`.
+    await service.revokeLink('shl_pin', envelope);
+    await service.listLinks({ object: 'contract' }, envelope);
+
+    expect(seen).toHaveLength(2);
+    for (const received of seen) {
+      expect(received.accessible_org_ids).toEqual(['org_plant_a']);
+      expect(received.posture).toBe('TENANT_ADMIN');
+    }
+  });
+
+  it('keeps the narrow type for the route 401 — and states why no compiler pin exists', () => {
+    // Still exported, still the route's vocabulary: `userId` present ⇒ the
+    // request is authenticated, absent ⇒ 401. That decision reads no
+    // authorization dimension, so it needs no authorization envelope.
+    const anonymous: ShareLinkExecutionContext = {};
+    const authenticated: ShareLinkExecutionContext = { userId: 'usr_1', positions: ['sales'] };
+    expect(anonymous.userId).toBeUndefined();
+    expect(authenticated.userId).toBe('usr_1');
+
+    // The honest half. This assignment is LEGAL and compiles — five optional
+    // fields, all present in the wider type. So the enforcement boundary is
+    // held by the declared parameter type and the caller's obligation, not by
+    // tsc; an `@ts-expect-error` here would be unsatisfied and fail the build.
+    // What the contract change buys is that the narrowing is now visible where
+    // it happens — the call site names `ExecutionContext` and a reviewer can
+    // see a five-field object being handed to it — instead of being hidden
+    // behind a parameter type that looked purpose-built for the job.
+    const widened: ExecutionContext = authenticated;
+    expect(widened.userId).toBe('usr_1');
+    expect(widened.accessible_org_ids).toBeUndefined();
+  });
+});

--- a/packages/spec/src/contracts/share-link-service.ts
+++ b/packages/spec/src/contracts/share-link-service.ts
@@ -30,7 +30,15 @@
  *      access only to its single `(object, recordId)` tuple at the
  *      declared `permission` level. This keeps audit trails clean and
  *      prevents lateral movement.
+ *
+ *   5. **Enforcement runs on the FULL envelope.** Every method that
+ *      adjudicates access takes a complete {@link ExecutionContext} — the
+ *      whole `resolveAuthzContext` envelope, not a per-site subset. See
+ *      {@link ShareLinkExecutionContext} for the boundary this draws and
+ *      why (#6206 / #6430).
  */
+
+import type { ExecutionContext } from '../kernel/execution-context.zod.js';
 
 /** Levels selectable when issuing a link. */
 export type ShareLinkPermission = 'view' | 'comment' | 'edit';
@@ -96,16 +104,65 @@ export interface ResolveShareLinkResult {
   redactFields: string[];
 }
 
-/** Minimal context interface — kept compatible with `SharingExecutionContext`. */
+/**
+ * ROUTE-LOCAL identity shape — what the share-link HTTP routes need to answer
+ * **"is this request authenticated at all?"** (their own 401), and nothing
+ * more.
+ *
+ * ## ⛔ Never an enforcement context (#6206, maintainer ruling 2026-08-07)
+ *
+ * This type must never reach a path that ADJUDICATES access — no
+ * `engine.find` / `engine.update` `context`, no visibility probe, no
+ * capability gate. Those take a full {@link ExecutionContext}; see
+ * {@link IShareLinkService}, whose every context parameter is now that type.
+ *
+ * The reason is a measured failure, not a style preference. The share-link
+ * route used to assemble exactly these five fields out of the
+ * `resolveAuthzContext` envelope and hand the result straight to `engine.find`
+ * as the [Finding-2] visibility check's context. Dropped on the floor:
+ * `accessible_org_ids`, `org_user_ids`, `systemPermissions`, `posture`,
+ * `tabPermissions`. Under the `group` tenancy posture `accessible_org_ids` IS
+ * the Layer 0 wall (ADR-0105 D2) and an absent set denies — so the check
+ * failed closed for every caller and share-link creation returned a blanket
+ * 403 on a posture that ships. A trimmed envelope feeding enforcement is a
+ * bypass-SHAPED pattern even when today's instance happens to fail closed;
+ * ADR-0095 D2 already rules that posture is resolved once and flows with the
+ * context, never re-derived (or re-assembled) at the enforcement site. This
+ * was the third assembly site of that family (#5997, #6071), which is why the
+ * governance default converged on the whole envelope instead of yet another
+ * per-site subset.
+ *
+ * ## What it is still legitimately for
+ *
+ * A route handler that only has to decide *authenticated vs anonymous* before
+ * dispatching — `userId` present ⇒ proceed, absent ⇒ 401. That decision reads
+ * no authorization dimension, so it needs no authorization envelope. Anything
+ * past that gate hands the request's **complete** resolved context down.
+ *
+ * ## A note for implementors and reviewers
+ *
+ * TypeScript cannot police this boundary for you. Structural subtyping makes a
+ * value of this type assignable to {@link ExecutionContext} — every field here
+ * exists there with a compatible type, and the ones that matter are optional —
+ * so a narrowed context passed to an enforcement path still COMPILES. What the
+ * contract can do, and now does, is state the enforcement parameter type as
+ * the full envelope so the narrowing is visible at the call site instead of
+ * hidden behind a type that looked like it was designed for the job. Producing
+ * that envelope is the caller's obligation: pass the `resolveAuthzContext`
+ * result through whole.
+ */
 export interface ShareLinkExecutionContext {
   userId?: string;
   tenantId?: string;
   isSystem?: boolean;
   /**
    * [Finding-2] The caller's resolved positions / permissions. Populated by the
-   * verified route wiring so RLS-aware checks (e.g. "can this caller actually
-   * read the record being shared?") evaluate against the real principal rather
-   * than a spoofable header identity.
+   * verified route wiring so the route's own principal checks read the real
+   * identity rather than a spoofable header.
+   *
+   * These are NOT sufficient for an RLS-aware visibility check — that check
+   * lives on {@link IShareLinkService} and takes the full
+   * {@link ExecutionContext}.
    */
   positions?: string[];
   permissions?: string[];
@@ -117,16 +174,47 @@ export interface ShareLinkExecutionContext {
  * Implementations MUST treat `context.isSystem === true` as a bypass
  * (skip the per-object opt-in check) so platform bootstrappers can seed
  * demo links.
+ *
+ * ## The context every method takes (#6206 ruling, #6430)
+ *
+ * `createLink` / `revokeLink` / `listLinks` all ADJUDICATE access, so each
+ * takes a full {@link ExecutionContext} — the complete `resolveAuthzContext`
+ * envelope, threaded through unchanged. Callers MUST NOT rebuild a subset of
+ * it: `accessible_org_ids` (the `group`-posture Layer 0 wall, ADR-0105 D2),
+ * `org_user_ids`, `systemPermissions`, `posture` (ADR-0095 D2: resolved once,
+ * carried, never re-derived at enforcement) and `tabPermissions` are all read
+ * downstream of these calls, and a caller cannot know which of them the
+ * deployment's posture makes load-bearing.
+ *
+ * {@link ShareLinkExecutionContext} is the route's own 401 shape and is
+ * deliberately NOT accepted here — its doc comment carries the full rationale.
  */
 export interface IShareLinkService {
-  /** Mint a new link. Throws when the object is not opt-in or limits are exceeded. */
-  createLink(input: CreateShareLinkInput, context: ShareLinkExecutionContext): Promise<ShareLink>;
+  /**
+   * Mint a new link. Throws when the object is not opt-in or limits are exceeded.
+   *
+   * ENFORCEMENT PATH: implementations re-read the target record under
+   * `context` ([Finding-2] — you may only link-share a record you can
+   * yourself see), so `context` must be the caller's complete resolved
+   * envelope. A trimmed one silently changes the verdict of that read.
+   */
+  createLink(input: CreateShareLinkInput, context: ExecutionContext): Promise<ShareLink>;
 
-  /** Mark a link as revoked. No-op when already revoked or not found. */
-  revokeLink(idOrToken: string, context: ShareLinkExecutionContext): Promise<void>;
+  /**
+   * Mark a link as revoked. No-op when already revoked or not found.
+   *
+   * ENFORCEMENT PATH: revoke authority is creator ∪ record share-manager
+   * (ADR-0111 D8), and the share-manager probe evaluates `context`.
+   */
+  revokeLink(idOrToken: string, context: ExecutionContext): Promise<void>;
 
-  /** List links for a record, an object, or a creator. */
-  listLinks(filter: ListShareLinksFilter, context: ShareLinkExecutionContext): Promise<ShareLink[]>;
+  /**
+   * List links for a record, an object, or a creator.
+   *
+   * ENFORCEMENT PATH: the listing is read under `context`, so row visibility
+   * is decided by it.
+   */
+  listLinks(filter: ListShareLinksFilter, context: ExecutionContext): Promise<ShareLink[]>;
 
   /**
    * Resolve a token at request-handling time. Returns null when the


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6430

#6206 维护者 2026-08-07 裁决 A 案(comment 5219847367)的**契约半边**。只动 `packages/spec` 契约面,`plugin-sharing` 消费半边一行未碰。

## 改了什么

`packages/spec/src/contracts/share-link-service.ts`:

1. **三个 enforcement 方法改收完整 `ExecutionContext`** —— `createLink` / `revokeLink` / `listLinks` 的 context 参数从五字段的 `ShareLinkExecutionContext` 换成 `ExecutionContext`(`z.input`,即 caller 侧信封形状)。三个方法都在**裁定访问**:
   - `createLink` —— [Finding-2] 的可见性重读(只能为自己看得见的记录建链接);
   - `revokeLink` —— ADR-0111 D8 的 record share-manager 探针吃 `context`;
   - `listLinks` —— 列表本身在 `context` 下读,行可见性由它决定。

   所以三处都需要整份 `resolveAuthzContext` 结果:`accessible_org_ids`、`org_user_ids`、`systemPermissions`、`posture`、`tabPermissions`。`resolveToken` 不收 context,未动。

2. **窄类型保留、形状不变,但 TSDoc 把边界写死**:`ShareLinkExecutionContext` 明确降级为**路由自身 401 的词汇**(`userId` 在 ⇒ 放行,不在 ⇒ 401 —— 这个判断不读任何授权维度,所以不需要授权信封),并写明 ⛔ 不得进入任何 enforcement 路径,附上失效实据(`group` 姿态下 `accessible_org_ids` 就是 Layer 0 墙,ADR-0105 D2,缺席即拒 ⇒ 建链全量 403)与治理理由(ADR-0095 D2:posture 解析一次、随上下文流动、永不在 enforcement 处重推;本例是同族第三处组装,前两处 #5997 / #6071)。

3. **pin 测试** `packages/spec/src/contracts/share-link-service.test.ts`(3 cases + 7 条类型级断言)。

## ⚠️ 一个必须说清的事实:本次契约收紧**不会**让消费方编译红

分诊评论预期「今天能编译的 caller 之后编译不过」。**实测不成立**,方向要反过来读:

- TypeScript 的结构化子类型让 `ShareLinkExecutionContext` **可以**赋给 `ExecutionContext`(五个字段在宽类型里都存在且类型兼容,而宽类型没有任何必填字段);方法参数又是双变的,所以 `ShareLinkService implements IShareLinkService` 也照样成立。
- 实测:`pnpm --filter @objectstack/plugin-sharing typecheck` 在本分支上**绿**。

也就是说,**没有编译器在等着推消费半边一把** —— 那半边必须被有意识地做掉,不能指望 CI 变红来提醒。这条我已写进窄类型的 TSDoc 与 pin 测试的头注释,免得下一个读者把「没有 `@ts-expect-error`」误读成疏漏。

契约能做的、也是本 PR 做到的,是把 enforcement 参数类型声明成完整信封,于是**裁剪动作在调用点可见**(调用点写着 `ExecutionContext`,评审能看见一个五字段对象被塞进去),而不再藏在一个「看起来就是为这活儿设计的」类型后面。

## 反向验证(方向在跑之前先定,结果与预测一致)

预测:把三处签名改回 `ShareLinkExecutionContext`,**测试层**应当变红 —— 身份断言 TS2344 + 整信封字面量的 TS2353 excess-property。实测(`tsc --noEmit -p tsconfig.test.json`)恰好 7 条新错误(274 vs. debt 基线 267):

```
share-link-service.test.ts(66,52): error TS2344: Type 'false' does not satisfy the constraint 'true'.
share-link-service.test.ts(67,52): error TS2344: Type 'false' does not satisfy the constraint 'true'.
share-link-service.test.ts(68,52): error TS2344: Type 'false' does not satisfy the constraint 'true'.
share-link-service.test.ts(71,46): error TS2344: Type 'true' does not satisfy the constraint 'false'.
share-link-service.test.ts(72,46): error TS2344: Type 'true' does not satisfy the constraint 'false'.
share-link-service.test.ts(73,46): error TS2344: Type 'true' does not satisfy the constraint 'false'.
share-link-service.test.ts(134,9): error TS2353: Object literal may only specify known properties,
  and 'accessible_org_ids' does not exist in type 'ShareLinkExecutionContext'.
```

前 6 条是三个方法的类型身份 pin(参数类型 **是** `ExecutionContext`、**不是**窄类型);第 7 条是本文件真正的 before-red:整份信封写成**对象字面量**,excess-property 检查因此生效 —— 旧签名下 `accessible_org_ids` 等五个键每一个都是 TS2353,这正是当初路由宁可手工拼一个子集也不肯把已解析好的信封原样传下去的原因。

三个运行时 case 不是空跑:fake service 记录收到的 context,断言 `accessible_org_ids` / `posture` / `org_user_ids` / `systemPermissions` / `tabPermissions` 确实整份抵达。

## 下游半边的解锁点

本卡落地后,identity 车道的消费半边(`Blocked-by: #6430`)可以开工,落点两处:

1. `packages/plugins/plugin-sharing/src/sharing-plugin.ts` 的 `contextFromRequest`(:633-639)—— 不再裁剪,把 `resolveAuthzContext` 结果整份传下去;
2. `packages/plugins/plugin-sharing/src/share-link-service.ts` —— 实现类三个方法的参数类型跟着契约改成 `ExecutionContext`(以及 `ShareLinkServiceOptions.canManageShares` 的 context 参数),`engine.find` 处因此吃到完整信封。

`ShareLinkExecutionContext` **保留导出**,`share-link-routes.ts` 的 `contextFromRequest` 类型位仍可用它 —— 但按裁决,它到路由 401 为止。

before-red 证据同时兑现分诊留下的 repro 义务(`group` 姿态建链 403 实测 → 修后 200);若 repro 不复现,按分诊 caveat 摘 `target:v17` 并回报。

## 测试与闸门(实跑输出)

- `pnpm --filter @objectstack/spec typecheck` —— 绿(含 `check:scripts-typecheck` 与 `check:test-typecheck`:`OK — test layer compiles; 58 file(s) / 267 error(s) held in test-typecheck-debt.json`,债务未增)。
- `pnpm --filter @objectstack/spec test` —— `Test Files 340 passed (340) / Tests 8702 passed (8702)`。
- `pnpm --filter @objectstack/spec check:generated` —— `✓ All 10 generated artifacts are up to date.`(未增删导出,`api-surface/contracts.json` 不动;contracts 无生成参考文档)。
- `pnpm --filter @objectstack/plugin-sharing typecheck` —— 绿(见上文,这是「不会红」的实据)。
- `pnpm lint` 全仓绿;family gates 逐个实跑绿:`adr-anchors` / `authz-resolver` / `role-word` / `org-identifier` / `doc-authoring` / `error-code-casing` / `route-envelope` / `query-options-erasure` / `slot-lookup` / `spec-parsed-alias` / `engine-double-contract` / `wildcard-fallthrough` / `meta-type-normalized`。
- `node scripts/check-nul-bytes.mjs` —— `OK (scanned 6099 tracked text file(s))`;改动文件另做控制字节自扫,无命中。

ADR-0122 的 pin 计数陷阱(`type-alias-convention.pin.test.ts:1491` 硬编码 751)不受影响:本次未新增任何 zod schema 或裸别名,`check:spec-parsed-alias` 只扫 `*.zod.ts`,已实跑绿。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY


---
_Generated by [Claude Code](https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY)_