### PR TITLE
fix(example-showcase): my-work 的 admin 卡片改用 ADR-0089 组件级 visibleWhen (#6274)

### DIFF
--- a/examples/app-showcase/src/ui/pages/my-work.page.ts
+++ b/examples/app-showcase/src/ui/pages/my-work.page.ts
@@ -8,7 +8,7 @@ import { definePage } from '@objectstack/spec/ui';
  *   • a KPI hero row of live `object-metric` tiles in an equal-width `grid`;
  *   • a personal work queue — `object-grid` filtered to the signed-in user
  *     via the `{current_user_id}` token (records I own);
- *   • sidebar shortcuts + a per-user `visible`-gated note on `user.email`.
+ *   • sidebar shortcuts + a card gated by component-level `visibleWhen` (ADR-0089).
  */
 export const MyWorkPage = definePage({
   name: 'showcase_my_work',
@@ -71,15 +71,22 @@ export const MyWorkPage = definePage({
             ],
           },
         },
-        // Admin-only card — per-user rendering via `visible` on the signed-in
-        // user (the renderer now feeds `user` into the expression context).
+        // Admin-only card — gated by the ADR-0089 canonical, COMPONENT-LEVEL
+        // `visibleWhen`: a sibling of `properties`, never a key inside it.
+        // `properties` is the widget's own prop bag (`PageCardProps`), which
+        // declares no visibility key; a predicate written there only worked
+        // because objectui's SchemaRenderer hoists `properties` onto the node
+        // before evaluating, i.e. by accident of the renderer rather than by
+        // contract. The predicate binds `current_user` — the identity root
+        // ADR-0089 declares for page-component predicates (`record`,
+        // `current_user`, `page.<var>`).
         {
           type: 'page:card',
+          visibleWhen: "current_user.email == 'admin@objectos.ai'",
           properties: {
             title: 'Leadership View',
-            visible: "user.email == 'admin@objectos.ai'",
             children: [
-              { type: 'element:text', properties: { content: 'Admin-only — shown because user.email matches the card’s visible expression.' } },
+              { type: 'element:text', properties: { content: 'Admin-only — shown because current_user.email matches the card’s visibleWhen predicate.' } },
             ],
           },
         },

--- a/examples/app-showcase/test/my-work-visibility.test.ts
+++ b/examples/app-showcase/test/my-work-visibility.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+
+import { MyWorkPage } from '../src/ui/pages/index.js';
+
+/**
+ * Dogfood gate for the My Work page's admin-only card (objectstack#6274).
+ *
+ * ADR-0089 makes `visibleWhen` the one conditional-visibility predicate, and on
+ * a page it is a **component-level** key — a sibling of `properties`, not a key
+ * inside it. `properties` is the widget's own prop bag (`PageCardProps` in
+ * `ComponentPropsMap`), which declares no visibility key at all; a predicate
+ * written there rendered correctly only because objectui's `SchemaRenderer`
+ * hoists every `properties` entry onto the node before evaluating visibility.
+ * That is a renderer accident, not a contract — and #5068's
+ * `component-props-unknown-key` gate reported it as exactly that.
+ *
+ * These assertions pin the shape AND the semantics, so neither half can regress
+ * silently:
+ *  - the predicate lives at the component level and NO `page:card` carries a
+ *    visibility key inside `properties` again;
+ *  - the binding root is `current_user` — the identity root ADR-0089 declares
+ *    for page-component predicates (`record`, `current_user`, `page.<var>`).
+ *    Measured in a browser against the pinned console (objectui `7dfbeb70`) on
+ *    2026-08-08: as `admin@objectos.ai` the card renders, as a non-admin it does
+ *    not. A `data.`-rooted spelling (the metadata-form root) would never match;
+ *  - the predicate actually gates the way the page's own comment claims.
+ */
+
+type AnyComponent = {
+  type: string;
+  visibleWhen?: unknown;
+  properties?: Record<string, unknown>;
+  [k: string]: unknown;
+};
+
+/** Flatten every component across the page's regions. */
+function allComponents(): AnyComponent[] {
+  const out: AnyComponent[] = [];
+  for (const region of MyWorkPage.regions ?? []) {
+    for (const c of region.components ?? []) out.push(c as AnyComponent);
+  }
+  return out;
+}
+
+/** CEL source, whether stored bare or as the normalized `{ dialect, source }`. */
+function predicateSource(v: unknown): string | undefined {
+  if (typeof v === 'string') return v;
+  if (v && typeof v === 'object' && typeof (v as { source?: unknown }).source === 'string') {
+    return (v as { source: string }).source;
+  }
+  return undefined;
+}
+
+/** Evaluate the card's comparison-only predicate against a bound scope. */
+function evalPredicate(source: string, scope: Record<string, unknown>): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+  const fn = new Function('current_user', `"use strict"; return (${source});`) as (
+    u: unknown,
+  ) => boolean;
+  return Boolean(fn(scope.current_user));
+}
+
+const leadershipCard = () =>
+  allComponents().find(
+    (c) => c.type === 'page:card' && c.properties?.title === 'Leadership View',
+  );
+
+describe('My Work — admin-only card gating (ADR-0089 component-level visibleWhen)', () => {
+  it('carries the predicate at the COMPONENT level, not inside `properties`', () => {
+    const card = leadershipCard();
+    expect(card, 'the "Leadership View" page:card must exist').toBeTruthy();
+    expect(card!.visibleWhen, 'predicate must be a sibling of `properties`').toBeDefined();
+    expect(
+      card!.properties,
+      '`PageCardProps` declares no visibility key — a predicate here is an unknown prop (#5068)',
+    ).not.toHaveProperty('visibleWhen');
+  });
+
+  it('leaves no visibility key inside any page:card `properties` bag', () => {
+    // The failure this pins is a rewrite that moves one card and forgets the
+    // other, or a later card re-introducing the hoisted spelling.
+    for (const card of allComponents().filter((c) => c.type === 'page:card')) {
+      for (const key of ['visible', 'visibleWhen', 'visibleOn', 'visibility', 'hidden'] as const) {
+        expect(
+          card.properties,
+          `page:card "${String(card.properties?.title)}" must not carry \`${key}\` in properties`,
+        ).not.toHaveProperty(key);
+      }
+    }
+  });
+
+  it('binds `current_user` — the ADR-0089 identity root for a page predicate', () => {
+    const source = predicateSource(leadershipCard()!.visibleWhen);
+    expect(source).toBeDefined();
+    expect(source).toContain('current_user.email');
+    // `data.` is the metadata-editing-form root; on a runtime page surface it
+    // never matches (validate-visibility-predicates, `visibility-root-mislayered`).
+    expect(source).not.toMatch(/(^|[^.\w$])data\.\w/);
+  });
+
+  it('gates the card the way the page claims: admin sees it, others do not', () => {
+    const source = predicateSource(leadershipCard()!.visibleWhen)!;
+    expect(evalPredicate(source, { current_user: { email: 'admin@objectos.ai' } })).toBe(true);
+    expect(evalPredicate(source, { current_user: { email: 'analyst@objectos.ai' } })).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6274

## 做了什么

`examples/app-showcase/src/ui/pages/my-work.page.ts` 里 "Leadership View" 那张 `page:card`,
可见性谓词原先写在 `properties.visible`。`properties` 是控件自己的 prop 包(`PageCardProps`,
`ComponentPropsMap`),它不声明任何可见性键 —— 那行之所以能生效,只是因为 objectui 的
`SchemaRenderer` 在求值前把 `properties` 的每个键 hoist 到节点上,是渲染器的巧合而非契约,
#5068 的 `component-props-unknown-key` 闸门正是这样报的它。

改为 ADR-0089 的规范拼法:**组件节点的兄弟键** `visibleWhen`(不是 `properties` 里的键),
绑定根 `current_user`。

```
- properties: { title: 'Leadership View', visible: "user.email == '...'", children: [...] }
+ visibleWhen: "current_user.email == '...'",
+ properties: { title: 'Leadership View', children: [...] }
```

侧栏共 2 处 `page:card`:"Shortcuts" 不带任何可见性键(其 `title` / `children` 都是
`PageCardProps` 声明的键,闸门不报),无需改写;带谓词的只有 "Leadership View" 这一处。

## 浏览器实测证据(绑定名判定 + 双身份可见性)

分诊把「绑定名」标为 load-bearing:ADR-0089 声明 page 组件谓词绑定 `record` /
`current_user` / `page.`,**没有 `user`**,机械改写疑似会得到恒假谓词。所以先量后写。

**环境**:worktree 内 `objectstack dev --ui --seed-admin -p 3862`,console 用
`@objectstack/console@17.0.0-rc.5` 的 dist —— 其 CHANGELOG 记为 "refreshed to `7dfbeb704e1e`",
正是本仓 `.objectui-sha` pin 的那个 objectui commit,所以量到的就是 main 会 serve 的那份 UI。
非 admin 身份由 `POST /api/v1/auth/sign-up/email` 新建(`analyst@objectos.ai`,role `user`)。

**探针**:临时在同一侧栏加 4 张 `page:card`,各带一个组件级 `visibleWhen`,双身份各看一次
(探针已在提交前删除,不在本 PR 的 diff 里):

| 卡片 | 组件级 `visibleWhen` | admin | 非 admin |
|---|---|---|---|
| PROBE ALWAYS | `1 == 1` | 显示 | 显示 |
| PROBE CURRENT_USER | `current_user.email == 'admin@objectos.ai'` | **显示** | **不显示** |
| PROBE USER | `user.email == 'admin@objectos.ai'` | 显示 | 不显示 |
| PROBE UNKNOWN ROOT | `nosuchroot.email == 'admin@objectos.ai'` | 显示 | 显示 |
| Leadership View(改写前基线,`properties.visible`) | — | 显示 | 不显示 |

服务端下发的 page 元数据确认 `visibleWhen` 过了 parse 并以 CEL 信封到达前端:
`{"dialect":"cel","source":"current_user.email == 'admin@objectos.ai'"}`。

**结论 1 — 绑定名**:`current_user` 实测可用。选它而不是 `user`,因为 ADR-0089 为这层声明的
身份根就是 `current_user`(`user` 只是 ADR-0068 那组向后兼容别名之一,由 app-shell 的
`ExpressionProvider` 一起喂进谓词 scope:`current_user` / `user` / `ctx.user` / `os.user`)。

**结论 2 — 分诊那条陷阱假设,实测两半都不成立**(照实报,不套模板):

- 「`user` 不在绑定里 ⇒ 机械改写会得到恒假谓词」:不成立。`user` 在这层是活的绑定,
  机械改写并不会让卡片消失。
- 「静默消失且无诊断」:方向也反了。真正解析不了的根(`nosuchroot.`)是 **fail-open** —— 卡片
  照常渲染,并在 console 打出一条实名警告:
  `[object-ui] A conditional predicate failed to evaluate and was treated as its safe default (true): "nosuchroot.email == ..." . Reason: [type] Unknown variable: nosuchroot`。
  所以既不静默、也不消失。

这两点不改变本单的结论(`properties.visible` 仍是写错了位置的键,仍该改成组件级 `visibleWhen`),
只是把「为什么要先量」的那条理由校正掉,免得下一个读者按错误的失败模型去推断。

**结论 3 — 改写后双身份复验**(最终代码,探针已删除):

| 身份 | Shortcuts | Leadership View | 页面渲染 | pageerror | 谓词警告 |
|---|---|---|---|---|---|
| `admin@objectos.ai` | 显示 | **显示**(正文为新的 `visibleWhen` 措辞) | 正常 | 0 | 0 |
| `analyst@objectos.ai`(非 admin) | 显示 | **不显示** | 正常 | 0 | 0 |

截图两份(admin / 非 admin)均已目视确认,行为与改写前的 `properties.visible` 基线一致。

## #5068 闸门(`component-props-unknown-key`)

`os lint` 对 showcase config,反向验证按预期方向(before 红 / after 绿):

- **before**(origin/main 的写法):4 条,含
  `⚠ page "showcase_my_work" · page:card: 'visible' is not a prop 'page:card' declares`
  at `pages[18].regions[2].components[1].properties.visible`;总计 `490 warning(s)`。
- **after**(本 PR):3 条,`page:card.visible` 那条消失;总计 `489 warning(s)`。

整份 lint 输出 diff 只有那一行的删除,**没有任何新增诊断**(既没有新的
`visibility-root-mislayered`,也没有 #6472 新加的 `visibility-predicate-syntax`)。

## 测试

- 新增 `examples/app-showcase/test/my-work-visibility.test.ts`,同时钉形状与语义:谓词必须在
  组件级、任何 `page:card` 的 `properties` 里不得再出现可见性键(`visible` / `visibleWhen` /
  `visibleOn` / `visibility` / `hidden`)、绑定根是 `current_user` 且不是 `data.`、以及谓词
  按页面自己声称的方式门控(admin 真 / 非 admin 假)。
- `pnpm --filter @objectstack/example-showcase typecheck` → 通过。
- `pnpm --filter @objectstack/example-showcase test` → 14 files / 150 tests 全绿。

## changeset

`@objectstack/example-showcase` 是 `private: true` 的示例包,不在 `.changeset/config.json`
的 fixed 组里,本 PR 不发布任何包 —— 因此打 `skip-changeset`,不写 changeset。

---
_Generated by [Claude Code](https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY)_