### PR TITLE
test(metadata): converge the database-loader mock driver's `supports` to an empty advertisement (#4782)

### DIFF
--- a/packages/metadata/src/loaders/database-loader.test.ts
+++ b/packages/metadata/src/loaders/database-loader.test.ts
@@ -37,17 +37,16 @@ function createMockDriver(): IDataDriver {
   return {
     name: 'mock',
     version: '1.0.0',
-    supports: {
-      transactions: false,
-      joins: false,
-      aggregations: false,
-      streaming: false,
-      bulkOperations: true,
-      nestedObjects: false,
-      fullTextSearch: false,
-      geoQueries: false,
-      changeStreams: false,
-    },
+    // An empty advertisement is a legal advertisement: every bit in
+    // `DriverCapabilities` is optional, and this mock needs none of the three
+    // that survive (#4782). The block used to spell nine — four RETIRED by
+    // #4634 (`transactions`/`joins`/`streaming`/`fullTextSearch`, now
+    // tombstoned as `never`) and five that were never keys of
+    // `DriverCapabilitiesSchema` at all (`aggregations`/`bulkOperations`/
+    // `nestedObjects`/`geoQueries`/`changeStreams`). Nothing here read any of
+    // them; their only effect was to be copied into the next mock. Capability
+    // is METHOD presence, not a boolean — do not re-add bits here.
+    supports: {},
 
     connect: vi.fn().mockResolvedValue(undefined),
     disconnect: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4782

## What

`createMockDriver()` in `packages/metadata/src/loaders/database-loader.test.ts`
advertised nine capability bits in `supports`. Not one of them was a live key:

- **Four were RETIRED by #4634** and are now tombstoned as `never` in
  `DriverCapabilitiesSchema`: `transactions`, `joins`, `streaming`,
  `fullTextSearch`.
- **Five were never keys of `DriverCapabilitiesSchema` at all** — they have no
  tombstone because they never existed: `aggregations`, `bulkOperations`,
  `nestedObjects`, `geoQueries`, `changeStreams`.

Nothing in the file read any of them. Their only effect was to be copied into
the next mock, which is the harm the issue names.

The block is now `supports: {}`. Every surviving bit in `DriverCapabilities`
(`queryDateGranularity` / `autonumber` / `batchSchemaSync`) is optional, so an
empty advertisement is a legal advertisement — the spec's own suite already
pins that shape in `packages/spec/src/data/driver.test.ts`:

> `it('accepts a driver that advertises nothing — capability bits are opt-in')`

A comment replaces the block, recording that capability is METHOD presence and
not a boolean, so the next author does not re-add bits here.

## Evidence — the two halves failed differently, and only one was visible

`packages/metadata` has no `typecheck` script; it is carried in the
`check:type-check-coverage` DEBT ledger, whose numbers come from
`tsc --noEmit -p packages/metadata/tsconfig.json`. That tsconfig includes
`src/**/*`, so the test file **is** inside a tsc program. Measured on the
branch point:

```
src/loaders/database-loader.test.ts(41,7): error TS2322: Type 'false' is not assignable to type 'undefined'.
src/loaders/database-loader.test.ts(42,7): error TS2322: Type 'false' is not assignable to type 'undefined'.
src/loaders/database-loader.test.ts(44,7): error TS2322: Type 'false' is not assignable to type 'undefined'.
src/loaders/database-loader.test.ts(47,7): error TS2322: Type 'false' is not assignable to type 'undefined'.
```

Lines 41/42/44/47 are exactly the four **retired** keys — the tombstones were
doing their job, and those four errors are precisely the `TS2322 x4` component
the ledger note records for this package.

The five **phantom** keys (43/45/46/48/49) produced **no diagnostic at all**.
That is not because the type is loose: a directly annotated literal is checked
normally, as a probe confirmed —

```
error TS2353: Object literal may only specify known properties, and 'phantomKeyXyz' does not exist in type '{ queryDateGranularity?: ...; autonumber?: boolean | undefined; batchSchemaSync?: boolean | undefined; ... }'.
```

The excess-property check was suppressed on the nested literal because that same
literal already had known-property mismatches to report. So the retired half was
loudly wrong and the invented half was silently wrong, in one object.

## Reverse verification

Direction predicted **before** running, and it is the "fewer diagnostics" one —
the deleted keys were themselves the source of the errors, so the honest
prediction is a drop, not a new red:

| | `tsc --noEmit` errors, `@objectstack/metadata` |
|---|---|
| branch point | **92** (matches the recorded ledger entry exactly) |
| after this change | **88** |

The delta is precisely those four TS2322 and nothing else — `diff` of the two
runs shows four deletions and zero additions. `check:type-check-debt` agrees and
stays green, by design:

```
ℹ @objectstack/metadata: DEBT records 92, tsc now reports 88 (-4) -- the entry can be lowered.
  Not an error: an improvement must not have to pay a bookkeeping toll to land.
check-type-check-coverage --re-measure: OK — 34 ledger entr(ies) re-measured, 1758 raw tsc error(s) total, none above its recorded number.
```

The ledger entry in `scripts/check-type-check-coverage.mjs` is left untouched:
it sits outside this issue's file surface, shrinkage is explicitly not red, and
eleven other entries already carry larger un-booked shrinkage on `main`.

## Tests

`pnpm --filter @objectstack/metadata test` — **26 files, 517 tests, all pass.**

No new test is added, and that is deliberate rather than an omission. There is
nothing here to assert: the keys had no reader, so no behaviour changes and any
"test" would restate the literal. The check that actually holds this closed is
the compiler — the four tombstones go red the moment a retired bit comes back,
which is the channel `retiredKey()` exists to provide.

## Gates

Every `check:*` step enumerated from `.github/workflows/lint.yml` was run
locally, one by one — all 30 ESLint-job steps and all TypeScript-job steps —
including `check:nul-bytes`, `check:engine-double-contract`,
`check:route-envelope`, `check:error-code-casing`, `check:type-check-coverage`,
`check:type-check-debt`, the workspace `turbo run typecheck`, and both i18n
gates after a full workspace build. All green. The mock introduces no engine
write verbs and no new fake engine, so `assertEngineDeleteDispatch` does not
apply.

## Changeset

**Tests-only** — one test file, no shipped behaviour, nothing to release, so no
`.changeset/*.md` is included. The `skip-changeset` label applies; per dispatch
it will be applied at acceptance.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KDU3qAuJyajAQm3GkUXdfA)_