### PR TITLE
fix(spec,metadata-protocol,runtime): one place decides the unset-NODE_ENV discovery environment

### DIFF
--- a/.changeset/discovery-environment-single-default.md
+++ b/.changeset/discovery-environment-single-default.md
@@ -1,0 +1,42 @@
+---
+"@objectstack/spec": patch
+"@objectstack/metadata-protocol": patch
+"@objectstack/runtime": patch
+---
+
+fix(spec,metadata-protocol,runtime): one place decides what an unset `NODE_ENV` advertises (#5936)
+
+A deployment whose operator never exported `NODE_ENV` must not describe itself as
+`development` on `/discovery`: `environment` is a machine-readable field, a client
+reads it to answer "am I talking to production?", and it may skip production warnings
+or loosen a destructive action's confirmation on the answer. #5673 ruled that in and
+fixed it — but only for one of the two producers, because that dispatch put
+`packages/spec` out of scope. The other one, `MetadataProtocol.getDiscovery()` (served
+by `@objectstack/rest`), went on answering `development` for exactly that input.
+
+The default now lives in the shared mapper, `resolveDiscoveryEnvironment`: an absent —
+or blank — value resolves to `production`, and both producers pass the operator's value
+through as they read it, neither carrying a default of its own. That is what makes it
+one decision instead of two copies, and it means the next discovery producer inherits
+the right answer without anyone remembering to copy a line. Patching only
+metadata-protocol would have left a second copy of the default — precisely the drift the
+shared table was created to prevent (#4828).
+
+"Unset" includes a blank value: `NODE_ENV=` exports an empty string, the runtime's
+`getEnv` has always folded that into its default, and had the mapper treated blank as
+"anything else" the two producers would have drifted again on that one input.
+
+**#4828's rule is untouched, and it points the other way on purpose.** A value that IS
+set but is not a spelling this repo recognises (`qa`, `preview`) still degrades to
+`development`, so nothing ever claims `production` on a guess. Absence is not a guess —
+it is the host declining to say.
+
+Behaviour change to expect: a host that exports no `NODE_ENV` and serves `/discovery`
+through `@objectstack/rest` now advertises `environment: "production"` where it
+previously advertised `"development"`. A deployment that genuinely is development should
+say so — `NODE_ENV=development` — which is what the runtime dispatcher has already
+required since #5673.
+
+The mapping table above `NODE_ENV_TO_DISCOVERY_ENVIRONMENT` is corrected in the same
+pass: its `unset / anything else -> development` row had been false for the runtime
+caller since #5673 and is now two rows, one per rule.

--- a/content/docs/protocol/kernel/http-protocol.mdx
+++ b/content/docs/protocol/kernel/http-protocol.mdx
@@ -187,6 +187,15 @@ field is machine-readable — a client uses it to decide whether it is talking t
 `development`. **An unrecognised spelling** (`qa`, `preview`, `uat`) is a different case: it
 is a guess, and this field never claims production on a guess.
 
+This table is the whole answer for **every** producer of `/discovery` (#5936). The mapping
+and the unset default both live in one shared function, so the dispatcher and the
+`@objectstack/metadata-protocol` builder served by `@objectstack/rest` cannot disagree, and
+a future producer inherits the same answers without copying anything. Until #5936 the unset
+default lived at the dispatcher's own call site, so a deployment with no `NODE_ENV` was
+advertised as `production` there and `development` through `@objectstack/rest`. If you read
+`environment` from a REST-served `/discovery` and relied on the old answer, set
+`NODE_ENV=development` explicitly.
+
 Local development is unaffected: `os dev` runs `serve --dev`, which sets
 `NODE_ENV=development` in-process before the runtime loads. Anything that boots the runtime
 *without* `os dev` — a bare `os serve`, an embedded host, a hand-written container entry

--- a/packages/metadata-protocol/src/discovery-schema-conformance.test.ts
+++ b/packages/metadata-protocol/src/discovery-schema-conformance.test.ts
@@ -29,7 +29,7 @@
 //     from the schema instead of a hand-listed array is what stops this gate
 //     from becoming a third dialect of the contract.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import {
   ApiRoutesSchema,
   DiscoverySchema,
@@ -195,6 +195,87 @@ describe('[#4828] getDiscovery() conforms to DiscoverySchema', () => {
     const discovery: any = await makeImpl().getDiscovery();
 
     expect(['production', 'sandbox', 'development']).toContain(discovery.environment);
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // [#5936] The unset-NODE_ENV default, asserted on THIS producer
+  // ═══════════════════════════════════════════════════════════════════════════
+  //
+  // `/discovery` has two producers. #5673 ruled that a deployment whose operator
+  // never set `NODE_ENV` must not call itself `development` — `environment` is
+  // machine-readable and a client may loosen a destructive action's
+  // confirmation on it — but that dispatch was scoped to the runtime dispatcher
+  // and forbade touching `packages/spec`, so the default landed at that
+  // producer's own call site and THIS producer went on answering `development`
+  // for the same input. The 2026-08-07 ruling (direction 1) folded the default
+  // into `resolveDiscoveryEnvironment`, which is what makes one decision reach
+  // both.
+  //
+  // This case is the half a mapper test cannot cover: that this producer passes
+  // the operator's value through AS READ and adds no default of its own. Its
+  // sibling lives in `packages/runtime/src/discovery-schema-conformance.test.ts`
+  // and asserts the identical fact about the dispatcher — the pair is what makes
+  // "the two producers agree" a checked fact rather than a comment.
+  //
+  // Reverse verification, direction predicted BEFORE running — and the
+  // interesting part is that the two revert shapes go DIFFERENT ways:
+  //
+  //   * Revert the whole change (the mapper back to `development` for a
+  //     non-string AND the dispatcher back to `getEnv('NODE_ENV', 'production')`)
+  //     and the two unset rows HERE go RED reading `development` while the
+  //     runtime's sibling rows stay GREEN. That asymmetry IS the bug #5936
+  //     reports, reproduced on demand.
+  //   * Revert only the mapper and BOTH producers go red, because the
+  //     dispatcher no longer carries a default of its own to fall back on —
+  //     which is the point of the consolidation, stated as a test outcome.
+  //
+  // The unrecognised-spelling rows stay green under every revert; they are
+  // #4828's rule, which this change deliberately leaves alone.
+  describe('[#5936] NODE_ENV defaults are the shared mapper\'s decision, not this producer\'s', () => {
+    const OLD_NODE_ENV = process.env.NODE_ENV;
+    afterEach(() => {
+      if (OLD_NODE_ENV === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = OLD_NODE_ENV;
+    });
+
+    it.each([
+      ['unset', undefined],
+      // `NODE_ENV=` exports an empty string; the mapper reads a blank value as
+      // "the host did not say", the same absence `os serve` / `os doctor` and
+      // the runtime producer already read as production.
+      ['empty', ''],
+    ])('NODE_ENV %s advertises production — never development', async (_label, raw) => {
+      if (raw === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = raw;
+
+      const discovery: any = await makeImpl().getDiscovery();
+
+      expect(discovery.environment).toBe('production');
+      expect(DiscoverySchema.safeParse(discovery).success).toBe(true);
+    });
+
+    it.each(['qa', 'preview', 'nonsense'])(
+      'NODE_ENV=%s is an unrecognised spelling — still development, never production (#4828)',
+      async (raw) => {
+        process.env.NODE_ENV = raw;
+
+        const discovery: any = await makeImpl().getDiscovery();
+
+        expect(discovery.environment).toBe('development');
+      },
+    );
+
+    it.each([
+      ['test', 'development'],
+      ['staging', 'sandbox'],
+      ['production', 'production'],
+    ])('NODE_ENV=%s advertises %s — the same table the dispatcher reads', async (raw, expected) => {
+      process.env.NODE_ENV = raw;
+
+      const discovery: any = await makeImpl().getDiscovery();
+
+      expect(discovery.environment).toBe(expected);
+    });
   });
 
   it('reports a `locale` block derived from the i18n service when one is registered', async () => {

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -2897,6 +2897,15 @@ export class ObjectStackProtocolImplementation implements
             name,
             /** @deprecated Use `name`. Removed in protocol 18 (#4828). */
             apiName: name,
+            // [#5936] The operator's value, passed as read — no local default.
+            // What an ABSENT `NODE_ENV` advertises is decided once, inside
+            // `resolveDiscoveryEnvironment` (`production`, per the 2026-08-07
+            // ruling, direction 1), so this producer and the runtime dispatcher
+            // cannot drift on it. Before that ruling the default lived at the
+            // dispatcher's own call site and this producer had no equivalent, so
+            // a deployment that forgot the variable was told `development` here
+            // and `production` there — the exact drift the shared mapper exists
+            // to prevent (#4828). Do not re-introduce a default here.
             environment: resolveDiscoveryEnvironment(
                 (globalThis as { process?: { env?: Record<string, string | undefined> } })
                     .process?.env?.NODE_ENV,

--- a/packages/runtime/src/discovery-schema-conformance.test.ts
+++ b/packages/runtime/src/discovery-schema-conformance.test.ts
@@ -275,23 +275,37 @@ describe('[#4828] getDiscoveryInfo() conforms to DiscoverySchema', () => {
       expect(DiscoverySchema.safeParse(info).success).toBe(true);
     });
 
-    // [#5673] The pin for this issue, and the reason it is driven through the
-    // REAL producer rather than through `resolveDiscoveryEnvironment` alone:
-    // the UNSET default is decided at THIS call site (`getEnv`'s second
-    // argument), so a green mapper test in `packages/spec` cannot see it. The
-    // whole setup is deleting the variable — that is precisely the state of a
-    // production deployment whose operator never set it.
+    // [#5673] The pin for that issue: the whole setup is deleting the variable
+    // — precisely the state of a production deployment whose operator never set
+    // it — driven through the REAL producer rather than through
+    // `resolveDiscoveryEnvironment` alone.
     //
-    // Reverse verification, direction predicted BEFORE running: restore the old
-    // `getEnv('NODE_ENV', 'development')` and these two cases go RED (they read
-    // `development`), while every `it.each` row above stays green — the old
-    // default was only ever consulted when NODE_ENV was absent, so nothing that
-    // sets it can detect the change. Measured both ways.
+    // [#5936] It stays here, and driven end-to-end, for a reason that survived
+    // the default moving. When #5673 landed, the default WAS this call site
+    // (`getEnv`'s second argument) and a green mapper test in `packages/spec`
+    // could not have seen it. The 2026-08-07 ruling folded the default into the
+    // mapper, so the spec-side case now covers the decision itself — and this
+    // one covers the wiring: that this producer passes the operator's value
+    // through as read and adds no default of its own. A local default here
+    // would satisfy the mapper's test and still be the drift #5936 removed;
+    // only an end-to-end assertion can tell the two apart. Its sibling in
+    // `@objectstack/metadata-protocol` asserts the same fact about the other
+    // producer, which is the pair that makes "one decision" checkable.
+    //
+    // Reverse verification, direction predicted BEFORE running: restore the
+    // mapper's pre-#5936 `development` default and these two cases go RED
+    // reading `development`, while every `it.each` row above stays green,
+    // because the default is only ever consulted when NODE_ENV is absent. Note
+    // this producer no longer has a second place to be fixed: the call site
+    // carries no default, so the mapper's answer IS this producer's answer.
+    // Measured both ways.
     it.each([
       ['unset', undefined],
-      // `getEnv` collapses `''` to its default (`process.env[key] || default`),
-      // so `NODE_ENV=` is the same absence as never exporting it — and the same
-      // absence `doctorNodeEnv()` and `os serve` already read as production.
+      // `NODE_ENV=` exports an empty string. `getEnv` collapses it to its
+      // default (`process.env[key] || default`) and, since #5936, the mapper
+      // reads a blank string as unset too — so this is the same absence
+      // `doctorNodeEnv()` and `os serve` already read as production, and it
+      // answers the same on both producers.
       ['empty', ''],
     ])('NODE_ENV %s advertises production — never development (#5673)', async (_label, raw) => {
       if (raw === undefined) delete process.env.NODE_ENV;

--- a/packages/runtime/src/http-dispatcher.ts
+++ b/packages/runtime/src/http-dispatcher.ts
@@ -1293,24 +1293,31 @@ export class HttpDispatcher {
             // enum on a machine-readable surface. The mapping table and the
             // reasoning per row live with the enum, in `@objectstack/spec/api`.
             //
-            // [#5673] The DEFAULT — what this producer says when the host set no
-            // `NODE_ENV` at all — flipped from `development` to `production` per
-            // the maintainer's 2026-08-06 ruling. Two facts made the old default
-            // the wrong one:
+            // [#5673] The DEFAULT — what a producer says when the host set no
+            // `NODE_ENV` at all — is `production`, per the maintainer's
+            // 2026-08-06 ruling, because `environment` is a MACHINE-READABLE
+            // field: a client reads it to answer "am I talking to production?"
+            // and may skip production warnings or loosen a destructive action's
+            // confirmation on the answer. Of the two ways to be wrong, claiming
+            // `development` on a real production deployment whose operator
+            // forgot the variable is the dangerous one. (Every other reader of
+            // that absence already said `production`: `os start` forces
+            // `NODE_ENV='production'` when unset, `os serve` resolves its
+            // `.env*` cascade for `NODE_ENV || 'production'`, `os doctor`
+            // derives the same expression. Discovery was the one surface
+            // reading it the other way.)
             //
-            //   • Every other reader of the same absence already said
-            //     `production`. `os start` forces `NODE_ENV='production'` when
-            //     unset (`packages/cli/src/commands/start.ts:248`), `os serve`
-            //     resolves its `.env*` cascade for `NODE_ENV || 'production'`
-            //     (`serve.ts:532-533`), and `os doctor` derives the identical
-            //     expression (`doctor.ts` `doctorNodeEnv()`). Discovery was the
-            //     one surface reading that absence the other way.
-            //   • `environment` is a MACHINE-READABLE field: a client reads it to
-            //     answer "am I talking to production?" and may skip production
-            //     warnings or loosen a destructive action's confirmation on the
-            //     answer. Of the two ways to be wrong here, claiming
-            //     `development` on a real production deployment whose operator
-            //     forgot the variable is the dangerous one.
+            // [#5936] That default no longer lives HERE. #5673's ruling put
+            // `packages/spec` out of scope, so this producer carried the default
+            // at its own call site — and the second producer (`getDiscovery()`
+            // in `@objectstack/metadata-protocol`, served by
+            // `@objectstack/rest`) went on answering `development` for the unset
+            // case, which is the drift the shared mapper was built to prevent
+            // (#4828). The 2026-08-07 ruling (direction 1) folded the default
+            // into `resolveDiscoveryEnvironment`, so both producers now inherit
+            // one decision and the next producer gets it without remembering to
+            // copy a line. Pass the operator's value as read; do NOT re-add a
+            // local default here or anywhere else.
             //
             // #4828's rule is untouched and is a DIFFERENT rule: a value that IS
             // set but is not a spelling this repo recognises (`qa`, `preview`)
@@ -1318,17 +1325,7 @@ export class HttpDispatcher {
             // ever CLAIMS production on a guess. Absence is not a guess — it is
             // the host declining to say, and the conservative answer to that is
             // `production`.
-            //
-            // The default is passed as `getEnv`'s second argument rather than
-            // moved into `resolveDiscoveryEnvironment` because the mapper lives
-            // in `@objectstack/spec`, which this issue's ruling put out of scope.
-            // Consequence, stated rather than hidden: the second discovery
-            // producer (`getDiscovery()` in `@objectstack/metadata-protocol`,
-            // served by `@objectstack/rest`) passes a genuinely-absent
-            // `NODE_ENV` straight into the mapper and therefore still answers
-            // `development` for the unset case. Filed as a follow-up (#5936);
-            // do not "fix" it by re-defaulting a consumer somewhere else.
-            environment: resolveDiscoveryEnvironment(getEnv('NODE_ENV', 'production')),
+            environment: resolveDiscoveryEnvironment(getEnv('NODE_ENV')),
             routes,
             // [#4828] `endpoints` (a verbatim duplicate of `routes`, commented
             // "Alias for backward compatibility with some clients") and the

--- a/packages/spec/src/api/discovery.test.ts
+++ b/packages/spec/src/api/discovery.test.ts
@@ -1181,9 +1181,25 @@ describe('[#4828] resolveDiscoveryEnvironment (decision 4 — enum, not passthro
     expect(resolveDiscoveryEnvironment('STAGING')).toBe('sandbox');
   });
 
-  it('never CLAIMS production for an unset or unrecognized value', () => {
-    for (const raw of [undefined, null, '', 'qa', 'preview', 'nonsense']) {
-      expect(resolveDiscoveryEnvironment(raw as any), String(raw)).toBe('development');
+  // [#5936] These were ONE case until the 2026-08-07 ruling folded the unset
+  // default into this mapper (direction 1). They are two different rules and
+  // they now point opposite ways, so they are two cases: absence is the host
+  // declining to answer and resolves conservatively to `production`; a spelling
+  // this repo does not recognise is a GUESS and never claims production.
+  // Collapsing them back into one is the regression these two guard.
+  it('an UNSET value advertises production — the host declined to say (#5673, #5936)', () => {
+    // Blank counts as unset: `NODE_ENV=` exports an empty string, and the
+    // runtime's `getEnv` has always folded that into its default. Were it
+    // treated as "anything else" the two producers would drift again on exactly
+    // that input — the drift this consolidation ends.
+    for (const raw of [undefined, null, '', '   ']) {
+      expect(resolveDiscoveryEnvironment(raw as any), JSON.stringify(raw)).toBe('production');
+    }
+  });
+
+  it('never CLAIMS production for an unrecognized spelling (#4828)', () => {
+    for (const raw of ['qa', 'preview', 'nonsense']) {
+      expect(resolveDiscoveryEnvironment(raw), raw).toBe('development');
     }
   });
 

--- a/packages/spec/src/api/discovery.zod.ts
+++ b/packages/spec/src/api/discovery.zod.ts
@@ -311,11 +311,32 @@ export type DiscoveryEnvironment = z.input<typeof DiscoveryEnvironmentSchema>;
  * | `development`, `dev`    | `development`  | exact / short spelling |
  * | `test`                  | `development`  | ephemeral developer-class run (vitest/CI), not a provisioned pre-production copy |
  * | `staging`               | `sandbox`      | pre-production and production-LIKE; certainly not `production`, and `sandbox` is the enum's pre-production member |
- * | unset / anything else   | `development`  | preserves the pre-existing `getEnv('NODE_ENV', 'development')` default, and never CLAIMS production on a guess |
+ * | unset / blank           | `production`   | the host declined to say; every other reader of that absence already says `production`, and of the two ways to be wrong, calling a real production deployment `development` is the dangerous one (#5673, #5936) |
+ * | anything else           | `development`  | an unrecognised spelling is a GUESS, and this function never claims `production` on a guess (#4828) |
  *
- * The last row is the safety-relevant one: an unknown spelling degrades to
- * `development`, so this function can never advertise `production` for an
- * environment it failed to recognise.
+ * The last two rows carry the whole safety argument, and they point opposite
+ * ways on purpose. An unrecognised spelling (`qa`, `preview`) degrades to
+ * `development`, so nothing here ever advertises `production` for an
+ * environment it failed to recognise. **Absence is not a guess** — it is the
+ * host declining to answer, and the conservative response to that is
+ * `production`: `environment` is machine-readable, and a client may skip
+ * production warnings or loosen a destructive action's confirmation on it.
+ *
+ * The unset row moved from `development` to `production` in #5673 (maintainer
+ * ruling 2026-08-06) and moved HERE, into the shared mapper, in #5936 (ruling
+ * 2026-08-07, direction 1). #5673 could only reach its own producer — the
+ * runtime dispatcher, which flipped the default at its call site — so the
+ * second producer (`getDiscovery()` in `@objectstack/metadata-protocol`, served
+ * by `@objectstack/rest`) went on passing a genuinely absent `NODE_ENV` in and
+ * answering `development`. One default in one place is what stops that: a
+ * producer cannot forget to copy a line it never has to write, so the next
+ * discovery producer inherits the right answer.
+ *
+ * "Unset" includes a **blank** value, not only an absent one. `NODE_ENV=`
+ * exports an empty string, and the runtime's `getEnv('NODE_ENV', …)` has always
+ * folded that into its default (it tests with `||`). Had this treated blank as
+ * "anything else" the two producers would have drifted again on exactly that
+ * input — the drift this consolidation exists to end.
  */
 const NODE_ENV_TO_DISCOVERY_ENVIRONMENT: Readonly<Record<string, DiscoveryEnvironment>> = {
   production: 'production',
@@ -335,12 +356,20 @@ const NODE_ENV_TO_DISCOVERY_ENVIRONMENT: Readonly<Record<string, DiscoveryEnviro
  * `serviceUnavailableMessage` / `inProcessServiceMessage` live in
  * `@objectstack/spec/system` rather than in each builder.
  *
- * @param raw the operator-supplied value, typically `process.env.NODE_ENV`
+ * **The unset default is part of the mapping, not the caller's business**
+ * (#5936). Callers pass the operator's value through as they read it and pass
+ * nothing when the operator set nothing; they do not substitute a default of
+ * their own. A caller that supplies one is re-opening the drift this function
+ * exists to close.
+ *
+ * @param raw the operator-supplied value, typically `process.env.NODE_ENV`;
+ *   `undefined`, `null` and a blank string all mean "the host did not say"
  * @returns a value guaranteed to satisfy {@link DiscoveryEnvironmentSchema}
  */
 export function resolveDiscoveryEnvironment(raw?: string | null): DiscoveryEnvironment {
-  if (typeof raw !== 'string') return 'development';
-  return NODE_ENV_TO_DISCOVERY_ENVIRONMENT[raw.trim().toLowerCase()] ?? 'development';
+  const spelling = typeof raw === 'string' ? raw.trim().toLowerCase() : '';
+  if (spelling === '') return 'production';
+  return NODE_ENV_TO_DISCOVERY_ENVIRONMENT[spelling] ?? 'development';
 }
 
 // ============================================================================


### PR DESCRIPTION
Fixes #5936

裁决方向 1(2026-08-07 决策箱第二轮)落地。前提对 origin/main `3a1d9c7` 逐条复核成立:`discovery.zod.ts:341` 对非字符串输入返回 `development`、`protocol.ts:2900`(`getDiscovery`)原样递传 `process.env.NODE_ENV`、`http-dispatcher.ts:1331` 带着本地默认 `getEnv('NODE_ENV', 'production')` 和「本条残留待 #5936」的注释、`:314` 的过时映射行仍在。缺陷可复现:**同一台忘设 `NODE_ENV` 的部署,dispatcher 的 `/discovery` 宣称 `production`,经 `@objectstack/rest` 服务的同一端点宣称 `development`** —— 同一个问题,两个答案。

## 改动

缺省判定收进共享映射:`resolveDiscoveryEnvironment` 对 absent 值解析为 `production`,两个生产者都原样递传操作员的值。dispatcher 删本地默认;metadata-protocol 本无默认、随映射自动纠正。#4828 的规则不动、方向依旧相反 —— **set 而不识别的拼写**(`qa`、`preview`)降级 `development`(那是猜测),**absent** 是宿主拒答(默认 `production`)。原「unset / anything else」一行拆成两行各述其理。

**裁决未明说、按其理据自判的一点(否决窗口)**:空串算 unset。`NODE_ENV=` 导出空串;runtime 的 `getEnv` 一向用 `||` 折进默认,#5673 的 pin 已断言该情形为 `production`;若映射把空串归「anything else」,两个生产者会在这一个输入上继续分歧 —— 正是本次收敛要消灭的漂移。已写进 TSDoc、changeset,两侧生产者各 pin 一条。

## 验证与逆向验证(方向先判后跑)

- 整体回退到 main 形态:metadata-protocol 红 2、runtime **23/23 全绿** —— 这个不对称就是 #5936 报告的缺陷本身,按需复现;仅回退映射:两侧各红 2(runtime 已无第二处可依赖)。未识别拼写行在两种回退下均绿(#4828 未动的证明)。回退后源文件 diff 逐字节还原。
- 正向读数:spec 8727 / metadata-protocol 571 / runtime 1606 / rest 884 / objectql 2448 / client 263 / hono 73 全绿;`turbo typecheck` 119/119;`check:generated` 10/10(本次无一生成物移动);lint 与门禁族(`check:route-envelope` / `check:error-code-casing` / `check:spec-parsed-alias` / `check:adr-0087-registration` 等)全绿。
- 新 pin 落在**生产者层**而不是只测 mapper:任一调用点重新加回本地默认都能通过 mapper 自测,只有端到端断言能分开它们。changeset 三包 `patch`,无 declared-breaking,无 ADR-0087 标记欠账。

## 界外发现(已记录、未夹带)

1. `packages/rest` 自有 conformance 套件但无 NODE_ENV 块 —— 它组合在 `getDiscovery()` 之上,新 pin 已覆盖其行为;若将来长出第三个形态值得留意。
2. `getEnv`(`core/src/utils/env.ts:15`)用 `||` 把空串折进默认是仓级策略,合法为空串的 `OS_*` 变量无法表达;本改动在一个调用点依赖该行为,未触碰。

## 交付通道注记

云端工头 B 会话(`session_011btrhv6sHn6JkN93YRtGQp`)无 GitHub 工具,走交付降级通道:dev 实现并 push 分支,PM(`session_011M7UwH25Unfi73UHim7ajY`)代开本 PR 并跟进 CI 至合并。完整交付摘要见分支 commit message。

---
_Generated by [Claude Code](https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY)_