### PR TITLE
fix(scripts): objectui digest 声明破坏性时写入门仍判红的 ADR-0087 处置脚手架 (#6494)

### DIFF
--- a/scripts/objectui-changeset-digest.mjs
+++ b/scripts/objectui-changeset-digest.mjs
@@ -1904,15 +1904,27 @@ function selfTest() {
     // The other half. Same file, same range, same generator — only the human's
     // answer is added, and the gate's verdict flips. A red that no answer can
     // clear would be a broken gate, not a scaffold.
-    writeFileSync(
-      gateCs,
-      readFileSync(gateCs, 'utf8').replace(
-        ADR_0087_SCAFFOLD,
-        '<!-- adr-0087: not-required (already-registered old-entry-one) the pinned frontend range carries no spec surface beyond that entry -->',
-      ),
+    //
+    // The replacement is CHECKED before it is committed, and the commit allows an
+    // empty tree. Found while reverse-verifying this group: with the emission
+    // ablated there is no placeholder to replace, so the write was a no-op, `git
+    // commit` exited 1 on a clean tree and threw — the whole self-test died with
+    // a raw `execFileSync` stack instead of naming a failed check. An ablation is
+    // exactly when the next reader needs a NAME, not a stack trace.
+    const answered = readFileSync(gateCs, 'utf8').replace(
+      ADR_0087_SCAFFOLD,
+      '<!-- adr-0087: not-required (already-registered old-entry-one) the pinned frontend range carries no spec surface beyond that entry -->',
     );
+    check(
+      '#6494 the answer replaces the placeholder IN PLACE — one marker before, one after',
+      answered !== readFileSync(gateCs, 'utf8') &&
+        !answered.includes('adr-0087: TODO') &&
+        markersIn(answered).length === 1,
+      answered.slice(-400),
+    );
+    writeFileSync(gateCs, answered);
     gg('add', '-A');
-    gg('commit', '-q', '-m', 'answer the ADR-0087 question');
+    gg('commit', '-q', '--allow-empty', '-m', 'answer the ADR-0087 question');
     const gateGreen = runGate();
     check(
       '#6494 ROUND TRIP (green): a real disposition written in that same place clears it',

--- a/scripts/objectui-changeset-digest.mjs
+++ b/scripts/objectui-changeset-digest.mjs
@@ -146,6 +146,24 @@
 // `packages/*/src/**` with no changeset fails). Until it lands, this is the only
 // place the class is visible at all; after it lands, this list goes quiet on its
 // own, because there will be nothing to name.
+//
+// WHY THE ARTIFACT CARRIES AN UNANSWERED ADR-0087 MARKER (#6494)
+// --------------------------------------------------------------
+// #6099 made this script DECLARE breaking changes (`**BREAKING**`), and #6148's
+// gate requires every declared-breaking changeset to state an ADR-0087
+// disposition. The first pin bump after #6289 hit exactly that (PR #6476), was
+// patched by hand — and a hand-patched marker in a GENERATED file survives only
+// until the next bump rewrites it. The recurrence condition is objectui's
+// standing practice, not an edge case: its release window bans `major`, so
+// breaking changes arrive as `minor` plus a body annotation, which is precisely
+// what this script now recognises.
+//
+// So the artifact carries the QUESTION. `<!-- adr-0087: TODO … -->` is a marker
+// the gate parses, refuses, and reports as unanswered — the operator answers it
+// at bump time, in writing, every time. The generator never picks a disposition:
+// #6148's whole design is that the gate does not answer for you, and a generator
+// that answers for you is the same hole with a different author. The argument in
+// full, including the two rejected alternatives, is at `ADR_0087_SCAFFOLD`.
 
 import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
@@ -334,6 +352,84 @@ export const BREAKING_MARKER = '**BREAKING**';
 export function markBreaking(text) {
   if (OPENS_WITH_BREAKING_LABEL.test(text)) return text;
   return `${BREAKING_MARKER} — ${text}`;
+}
+
+/**
+ * The ADR-0087 disposition SCAFFOLD — a question, never an answer (#6494).
+ *
+ * `scripts/check-adr-0087-registration.mjs` (#6148) requires every changeset
+ * that DECLARES a breaking change to carry exactly one `adr-0087:` disposition
+ * marker. From #6099 onward this script declares one as soon as an upstream
+ * entry is annotated — and that is objectui's ORDINARY shape, not an exotic
+ * one: its release window bans `major` (`scripts/check-changeset-no-major.mjs`),
+ * so a breaking change ships as `minor` plus the author's own body annotation,
+ * which is exactly what `hasBreakingAnnotation` above finds. Measured on the
+ * range PR #6476 bumped: 24 changesets, 2 of them annotated-breaking. So the
+ * gate's red is the COMMON case on any substantive pin bump, and a marker
+ * patched in by hand lives exactly until the next bump regenerates the file.
+ *
+ * Hence a placeholder that the gate STILL JUDGES:
+ *
+ *   * `TODO` parses as neither `registered ...` nor `not-required (...) ...`,
+ *     so the gate reports `unparseable disposition: "TODO …"` and stays RED.
+ *     Present-but-unanswered reads differently from absent, and it lands the
+ *     gate's own fix-it block listing the four accepted forms.
+ *   * It is ONE marker. Two would produce a different red ("N markers -- exactly
+ *     one disposition is expected") that names the tooling instead of the
+ *     question, so nothing else in the emitted body may spell `adr-0087:`.
+ *   * It says NOTHING about which disposition applies. Writing `not-required
+ *     (...)` here — even the category that is usually right — would make this
+ *     script perform the judgement #6148 exists to extract from a human, and it
+ *     would then be written unread on every bump forever. That gate's whole
+ *     design is that it never answers for you; a generator that answers for you
+ *     is the same hole with a different author.
+ *
+ * An HTML comment for the reason the gate's own header gives: a changeset body
+ * is copied VERBATIM into CHANGELOG.md, so the marker must render as nothing for
+ * end users while staying fully visible in the diff, in `git grep` and in the
+ * gate's log.
+ */
+export const ADR_0087_SCAFFOLD =
+  '<!-- adr-0087: TODO — the pin bump cannot answer this; a human must (objectstack#6494) -->';
+
+/**
+ * Will `check-adr-0087-registration.mjs` judge THIS ARTIFACT as declaring a
+ * breaking change? Read the artifact we actually rendered, not our belief about
+ * it — the scaffold has to appear on exactly the files that gate will judge.
+ *
+ * That gate's `breakingDeclaration()` unions three signals, and this mirrors the
+ * two a generated console changeset can ever raise:
+ *
+ *   1. a `major` bump in the frontmatter — reachable here in RC pre-mode and via
+ *      `CONSOLE_BUMP=major`, and it arms the gate ON ITS OWN, with no marker
+ *      anywhere in the body.
+ *   2. `**BREAKING` (or a `BREAKING CHANGE:` line) in the body.
+ *   3. a conventional-commit `!` on the summary line — UNREACHABLE, deliberately
+ *      not mirrored: the first line of the emitted file is this script's own
+ *      fixed sentence (`Console (objectui) refreshed to …`) and the gate's
+ *      pattern `^[a-z]+(\([^)]*\))?!:` is case-sensitive, so nothing this
+ *      generator writes can start it.
+ *
+ * Why the RENDERED body rather than the `breaking` count: the two nearly agree,
+ * and the gap runs one way. `breaking > 0` always renders `**BREAKING**` (the ⚠️
+ * note restates the marker by construction), so the count implies the signal;
+ * the converse can fail. An entry whose own summary carries an emphasis run too
+ * long for `BREAKING_EMPHASIS_LABEL`'s 48-character tail is NOT counted breaking
+ * here, yet its text reaches the rendered line where the gate's looser
+ * `/\*\*BREAKING/` matches it. Reading the artifact closes that by construction
+ * instead of by agreement between two predicates.
+ *
+ * Why the gate's own function is not imported: that module's CLI dispatch runs
+ * at TOP LEVEL (it has no `import.meta.url === argv[1]` guard), so importing it
+ * would execute the gate; and it would put the release-critical bump path one
+ * rename away from failing. The agreement is pinned in the self-test instead,
+ * which runs the real gate as a child process over a real temp repository.
+ *
+ * @param {{ bump: string, body: string }} artifact
+ */
+export function artifactDeclaresBreaking({ bump, body }) {
+  if (bump === 'major') return true;
+  return /\*\*BREAKING/i.test(body) || /^\s*BREAKING[ -]CHANGE/mi.test(body);
 }
 
 /**
@@ -561,7 +657,7 @@ export function classifyRange({ objectuiRoot, from, to }) {
 /**
  * Build the digest for a range.
  *
- * @returns {{ bump: string, declaredLevel: string|null, breaking: number, breakingByLevel: number, breakingByAnnotation: number, releasing: Array<object>, releaseNothing: number, noChangeset: number, noChangesetCommits: Array<object>, changesetsAdded: number, absentAtTo: number, totalCommits: number, downgradedMajor: boolean, body: string }}
+ * @returns {{ bump: string, declaredLevel: string|null, breaking: number, breakingByLevel: number, breakingByAnnotation: number, releasing: Array<object>, releaseNothing: number, noChangeset: number, noChangesetCommits: Array<object>, changesetsAdded: number, absentAtTo: number, totalCommits: number, downgradedMajor: boolean, adr0087Scaffold: boolean, body: string }}
  */
 export function buildDigest({
   objectuiRoot,
@@ -715,13 +811,27 @@ export function buildDigest({
     }
   }
 
-  const body = [
+  const rendered = [
     accounting,
     '',
     ...lines,
     ...(notes.length ? ['', ...notes] : []),
     ...(undeclared.length ? ['', ...undeclared] : []),
   ].join('\n');
+
+  // --- #6494: the artifact carries the ADR-0087 QUESTION, never its answer ---
+  // A changeset that declares breaking must carry a disposition marker (#6148),
+  // and THIS changeset is generated: a marker written by hand survives exactly
+  // until the next pin bump rewrites the file, which is how PR #6476's answer
+  // was already scheduled to disappear. So the generator emits the question and
+  // leaves it deliberately unanswered — see ADR_0087_SCAFFOLD.
+  //
+  // Zero-suppressed against the gate's own subject: on an artifact the gate does
+  // not judge, an unanswered marker would sit there unjudged forever and teach
+  // the next reader that this marker is decoration. It appears exactly where it
+  // is enforced.
+  const adr0087Scaffold = artifactDeclaresBreaking({ bump, body: rendered });
+  const body = adr0087Scaffold ? `${rendered}\n\n${ADR_0087_SCAFFOLD}` : rendered;
 
   return {
     bump,
@@ -737,6 +847,7 @@ export function buildDigest({
     absentAtTo,
     totalCommits,
     downgradedMajor,
+    adr0087Scaffold,
     body,
   };
 }
@@ -827,6 +938,21 @@ function main(argv) {
       `→ ${digest.absentAtTo} of ${digest.changesetsAdded} changeset(s) added in this range ` +
         `no longer exist at ${short} — a release consumes the changesets it ships; ` +
         `each was read from the commit that added it, so the account above is complete.`,
+    );
+  }
+
+  // #6494: the one line the operator running the bump must act on. It goes to
+  // stderr beside the accounting, which is where a `BUMP="$(…)"` caller lets it
+  // through — the shell driver captures stdout only. Saying it here is not the
+  // enforcement (the gate is); it is what stops the operator discovering the red
+  // one push later, and it names the marker so the fix is a search away.
+  if (digest.adr0087Scaffold) {
+    console.error(
+      `→ this changeset DECLARES a breaking change, so it carries an UNANSWERED ADR-0087 ` +
+        `disposition placeholder. Replace the \`adr-0087: TODO\` marker in ` +
+        `${out ?? 'the changeset'} with the real disposition before you push: ` +
+        `\`Check Changeset\` rejects the placeholder on purpose, and the generator cannot ` +
+        `answer it for you (objectstack#6494).`,
     );
   }
 
@@ -1623,6 +1749,178 @@ function selfTest() {
         !allDeclared.body.includes('_(no changeset)_') &&
         !allDeclared.body.includes('declared nowhere'),
       allDeclared.body,
+    );
+
+    // --- #6494: the ADR-0087 disposition scaffold ---------------------------
+    // The gate's own marker pattern (check-adr-0087-registration.mjs:416),
+    // copied rather than imported: that module's CLI dispatch is top-level, so
+    // importing it would RUN the gate. The copy is belt-and-braces — the REAL
+    // gate binary judges a real artifact in the round trip below, and that, not
+    // this regex, is the authority on what the marker means.
+    const markersIn = (text) =>
+      [...text.matchAll(/<!--\s*adr-0087\s*:\s*([\s\S]*?)-->/g)].map((m) =>
+        m[1].replace(/\s+/g, ' ').trim(),
+      );
+
+    // A range with NOTHING breaking in it, forced to `major` the way
+    // `CONSOLE_BUMP=major` does. The frontmatter alone is a breaking declaration
+    // to the gate, so this is the artifact a `breaking > 0` proxy would miss.
+    const majorOverride = buildDigest({
+      objectuiRoot: ui5,
+      frameworkRoot: fwPlain,
+      from: base5,
+      to: head5,
+      bumpOverride: 'major',
+    });
+
+    check(
+      '#6494 an artifact that DECLARES breaking carries EXACTLY ONE adr-0087 marker',
+      annotated.adr0087Scaffold === true &&
+        markersIn(annotated.body).length === 1 &&
+        annotated.body.includes(ADR_0087_SCAFFOLD) &&
+        digest.adr0087Scaffold === true &&
+        markersIn(digest.body).length === 1,
+      annotated.body,
+    );
+    check(
+      '#6494 the marker is a PLACEHOLDER — it names no disposition at all',
+      // Both legal forms must MISS it, or the generator would have answered the
+      // question on the human's behalf — the one thing #6148 forbids.
+      (markersIn(annotated.body)[0] ?? '').startsWith('TODO') &&
+        !/^registered\b/i.test(markersIn(annotated.body)[0] ?? '') &&
+        !/^not-required\b/i.test(markersIn(annotated.body)[0] ?? ''),
+      markersIn(annotated.body)[0],
+    );
+    check(
+      '#6494 a `major` FRONTMATTER alone arms the gate — the scaffold follows it there',
+      // The gate declares breaking on the frontmatter ALONE, with no marker in
+      // the body, so a `breaking > 0` proxy would have missed this artifact.
+      majorOverride.bump === 'major' &&
+        majorOverride.breaking === 0 &&
+        !/\*\*BREAKING/i.test(majorOverride.body) &&
+        majorOverride.adr0087Scaffold === true &&
+        markersIn(majorOverride.body).length === 1,
+      majorOverride.body,
+    );
+    check(
+      '#6494 a NON-breaking artifact carries no marker at all (negative polarity)',
+      // Declared as negative polarity: deleting the emission also produces no
+      // marker, so this cannot go red under that ablation. It pins a DIFFERENT
+      // regression — a marker on an artifact the gate never judges, which would
+      // sit unanswered forever and teach the next reader to ignore it. The three
+      // positive guards keep it from passing for the vacuous reason (an empty or
+      // unbuilt body would satisfy "no marker" just as well).
+      allDeclared.releasing.length === 2 &&
+        allDeclared.breaking === 0 &&
+        allDeclared.bump === 'minor' &&
+        allDeclared.adr0087Scaffold === false &&
+        markersIn(allDeclared.body).length === 0,
+      allDeclared.body,
+    );
+    check(
+      '#6494 the flag, the rendered marker and the gate criterion agree on EVERY fixture',
+      [digest, plain, overridden, capped, annotated, named, named2, released, allDeclared, majorOverride].every(
+        (d) =>
+          d.adr0087Scaffold === (markersIn(d.body).length === 1) &&
+          d.adr0087Scaffold === (d.bump === 'major' || /\*\*BREAKING/i.test(d.body)),
+      ),
+      [digest, plain, overridden, capped, annotated, named, named2, released, allDeclared, majorOverride]
+        .map((d) => `${d.bump}/${d.adr0087Scaffold}/${markersIn(d.body).length}`)
+        .join(' '),
+    );
+
+    // --- #6494 THE ROUND TRIP, through the REAL gate ------------------------
+    // The claim "the gate recognises this as present-but-unanswered" is about
+    // ANOTHER script, so nothing short of that script's own verdict settles it.
+    // A throwaway repo carrying the gate's required inputs (#4690: it refuses to
+    // report a verdict without them) plus a COPY of the gate, so its REPO_ROOT
+    // resolves here — the same idiom the bump-objectui.sh run above uses.
+    const gateRepo = join(tmp, 'fw-gate');
+    mkdirSync(gateRepo, { recursive: true });
+    const gg = (...args) => git(gateRepo, args);
+    const gw = (rel, text) => {
+      mkdirSync(dirname(join(gateRepo, rel)), { recursive: true });
+      writeFileSync(join(gateRepo, rel), text);
+    };
+    gg('init', '-q', '-b', 'main');
+    gg('config', 'user.email', 'selftest@objectstack.ai');
+    gg('config', 'user.name', 'self test');
+    gg('config', 'commit.gpgsign', 'false');
+    const LEDGER_ENTRY = (id) =>
+      `export const X = {\n  semantic: [\n    {\n      id: '${id}',\n      surface: 's',\n    },\n  ],\n};\n`;
+    gw('packages/spec/src/migrations/registry.ts', LEDGER_ENTRY('old-entry-one'));
+    gw('packages/spec/src/conversions/registry.ts', LEDGER_ENTRY('a-conversion'));
+    gw(
+      'packages/spec/spec-changes.json',
+      `${JSON.stringify({ perMajor: [{ to: 17, migrated: [{ migrationId: 'old-entry-one' }] }] }, null, 2)}\n`,
+    );
+    // One declared-breaking changeset in STOCK (committed at base, so it is not
+    // in the judged diff) — the gate's convention-rot assertion needs its
+    // breaking detector to match something.
+    gw('.changeset/stock-breaking.md', '---\n"@objectstack/spec": major\n---\n\nstock\n\n**BREAKING** something\n');
+    gw(
+      'scripts/check-adr-0087-registration.mjs',
+      readFileSync(join(__dirname, 'check-adr-0087-registration.mjs'), 'utf8'),
+    );
+    gg('add', '-A');
+    gg('commit', '-q', '-m', 'base');
+    const gateBase = gg('rev-parse', 'HEAD').trim();
+
+    // The range is the #6099 fixture: `minor` + the author's own annotation,
+    // objectui's ORDINARY breaking shape and the one that reopens this every bump.
+    const gateCs = join(gateRepo, '.changeset', `console-${head2.slice(0, 12)}.md`);
+    const generated = spawnSync(
+      process.execPath,
+      [selfPath, '--objectui-root', ui2, '--framework-root', gateRepo, '--from', base2, '--to', head2, '--out', gateCs],
+      { encoding: 'utf8' },
+    );
+    gg('add', '-A');
+    gg('commit', '-q', '-m', 'chore(console): bump objectui pin');
+    const runGate = () =>
+      spawnSync(process.execPath, [join(gateRepo, 'scripts', 'check-adr-0087-registration.mjs'), '--base', gateBase], {
+        encoding: 'utf8',
+        cwd: gateRepo,
+      });
+
+    const gateRed = runGate();
+    check(
+      '#6494 ROUND TRIP (red): the REAL gate reads the marker and refuses it as UNANSWERED',
+      generated.status === 0 &&
+        gateRed.status !== 0 &&
+        // The EXACT verdict, not merely "it is red": present-but-unparseable is a
+        // different fact from absent, and only the first one proves the scaffold
+        // reached the gate at all.
+        /but unparseable disposition: "TODO/.test(gateRed.stderr) &&
+        gateRed.stderr.includes(`console-${head2.slice(0, 12)}.md`) &&
+        gateRed.stderr.includes('<!-- adr-0087: not-required (no-migration-prescription) why -->'),
+      `generator=${generated.status} gate=${gateRed.status}\n${gateRed.stderr}`,
+    );
+    check(
+      '#6494 the operator is told at BUMP time, not one push later',
+      generated.stderr.includes('UNANSWERED ADR-0087') && generated.stderr.includes('adr-0087: TODO'),
+      generated.stderr,
+    );
+
+    // The other half. Same file, same range, same generator — only the human's
+    // answer is added, and the gate's verdict flips. A red that no answer can
+    // clear would be a broken gate, not a scaffold.
+    writeFileSync(
+      gateCs,
+      readFileSync(gateCs, 'utf8').replace(
+        ADR_0087_SCAFFOLD,
+        '<!-- adr-0087: not-required (already-registered old-entry-one) the pinned frontend range carries no spec surface beyond that entry -->',
+      ),
+    );
+    gg('add', '-A');
+    gg('commit', '-q', '-m', 'answer the ADR-0087 question');
+    const gateGreen = runGate();
+    check(
+      '#6494 ROUND TRIP (green): a real disposition written in that same place clears it',
+      gateGreen.status === 0 &&
+        gateGreen.stdout.includes(
+          '✓ check-adr-0087-registration: 1 declared-breaking changeset(s), each carrying an ADR-0087 disposition.',
+        ),
+      `status=${gateGreen.status}\n${gateGreen.stdout}\n${gateGreen.stderr}`,
     );
   } finally {
     rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
Fixes #6494

`objectui-changeset-digest.mjs` 从 #6099 起会在正文打 `**BREAKING**`，而 #6148 的门要求任何**声明**破坏性的 changeset 必须携带 `adr-0087:` 处置标记。生成器不写这个标记，`Check Changeset` 判红。PR #6476 手工补了一行而绿 —— 但那份 changeset 是**生成的**，下一次 pin bump 重新生成时手工标记消失，同一个红复现。

按分诊钉死的**方向 1**：生成器写入一份**门仍会判红**的脚手架，逼出一个书面答案。⛔ 方向 2（生成器硬写 `not-required`）与方向 3（门侧豁免）未被采用，也未被自行替换。

## 锚点自核（未引用卡片，在本工作树 `origin/main` @ `3510e4a25` 重测）

分诊在 `3a1d9c7` 上核过的两条，在 `3510e4a25` 上仍然成立：

| 事实 | 重测结果 |
| --- | --- |
| `BREAKING_MARKER` 常量位置 | `scripts/objectui-changeset-digest.mjs:331`，应用于 `:336`（改前） |
| digest / `bump-objectui.sh` 中 `adr-0087` 命中数 | `0` / `0` |
| `.objectui-sha` | `0cf8f0f70d10…`，正是 issue 所指 `.changeset/console-0cf8f0f70d10.md` 那次 bump |
| 门的破坏性判据 | `check-adr-0087-registration.mjs:225-231` `breakingDeclaration()`，三个信号取并集 |
| 门的标记解析 | 同文件 `:416` 收集标记、`:423` / `:430` 解析两种合法写法 |

改后新常量落在 `:349`（`BREAKING_MARKER`）、`:392`（`ADR_0087_SCAFFOLD`）、`:430`（`artifactDeclaresBreaking`）。

## 脚手架的确切写法

⚠️ **本仓 PR 正文会把字面的 HTML 注释整段吞掉。** 这不是已知那条「删除 `<` 加字母」的 sanitizer 规则（`<` 加感叹号不在其内），是第三种损坏形态 —— 本 PR 初版正文的三处标记全被渲染成空。因此下面凡展示标记字面处，尖括号一律写成 `&lt;` / `&gt;` 实体，且**不放进代码围栏**（围栏内实体不解码）。权威字节见 `scripts/objectui-changeset-digest.mjs:392`。

正文末尾追加**恰好一个**标记：一行 HTML 注释，注释体是 `adr-0087: TODO — the pin bump cannot answer this; a human must (objectstack#6494)`。连同注释定界符的完整一行：

&lt;!-- adr-0087: TODO — the pin bump cannot answer this; a human must (objectstack#6494) --&gt;

门为什么把它认成「**有标记但未作答**」而不是「无标记」：

1. `:416` 用 `adr-0087\s*:` 收集标记 —— 这一行**命中**，所以不会走「no `adr-0087:` disposition marker」那条。
2. `:423` 的 `^registered\s+` 与 `:430` 的 `^not-required\s*\(` **双双落空**（正文以 `TODO` 开头），于是落到 `:437` 的 `unparseable disposition: "…"`，把占位原文**逐字引回日志**，并带出门自己的四种合法写法。
3. 只有一个标记：两个会触发另一条红（`N markers -- exactly one disposition is expected`），那条红说的是工具而不是问题，所以正文里不允许出现第二处 `adr-0087:`。

用 HTML 注释的理由与门自己头注一致：changeset 正文会**逐字**进 CHANGELOG.md，标记对终端用户渲染为空，而在 diff、`git grep` 和门日志里始终可见。

**生成器不选处置。** 写 `not-required (…)`（哪怕是通常正确的那一类）等于让生成器代替人做 #6148 要提取的判断，而且此后每次 bump 都会被无人阅读地写一遍 —— 那道门的全部设计就是它从不替你作答；生成器替你作答只是同一个洞换了作者。

## 判定读的是「刚渲染出的产物」，不是 `breaking` 计数

`artifactDeclaresBreaking({ bump, body })` 镜像门三个信号中本生成器可能触发的两个：

- **frontmatter `major`** —— RC pre-mode 与 `CONSOLE_BUMP=major` 都可达，且它**单独**就能触发门，正文里可以一个标记也没有。因此 `breaking > 0` 这种代理判据会漏掉这类产物（自测里有一条专门钉它）。
- **正文 `**BREAKING`**（或 `BREAKING CHANGE:` 行）。
- 第三个信号（conventional-commit `!`）**不可达**：产物首行是本脚本自己的固定句 `Console (objectui) refreshed to …`，而门的 `^[a-z]+(\([^)]*\))?!:` 区分大小写。注释里写明了理由，而不是默默不实现。

为什么读产物而不读计数：两者几乎一致，缺口是单向的。`breaking > 0` 必然渲染出 `**BREAKING**`（⚠️ 提示句按构造会复述该标记），所以计数蕴含信号；反向不成立 —— 作者自写的强调标签若超过 `BREAKING_EMPHASIS_LABEL` 的 48 字符尾巴，就**不计入** `breaking`，但其文本仍进入渲染行，被门更宽的 `/\*\*BREAKING/` 命中。读产物按构造堵住这个缝，而不是靠两个判据保持一致。

**没有 import 门的函数**：那个模块的 CLI 派发在**顶层**执行（没有 `import.meta.url === argv[1]` 守卫），import 它等于运行它；而且会让发布路径上的脚本多一个「门被改名就崩」的耦合点。一致性改为在自测里用**子进程 + 临时仓**驱动真实门来钉。

## 往返实证：真实区间、真实门二进制

用真实 objectui 区间（`7dfbeb704e1e..e6fdbdcc4bb2`，6 份 releasing、2 份标注式破坏，正是 objectui 的常规形状），生成一份**新增**的 `.changeset/console-e6fdbdcc4bb2.md`，**提交后**跑真实门（该门读已提交树，见 issue 同源观察）：

**RUN 1 —— 带占位（本 PR 的产物）：红，且是「未作答」这一条**

```text
✗ check-adr-0087-registration: 1 problem(s).

  • .changeset/console-e6fdbdcc4bb2.md
      declares a breaking change (BREAKING) but unparseable disposition: "TODO — the pin
      bump cannot answer this; a human must (objectstack#6494)" -- expected `registered ...`
      or `not-required (...) ...`.
      …
      Add ONE of these lines to the changeset body:
      （门在此逐行列出四种合法写法；因正文吞注释，转录到下方）
GATE_EXIT=1
```

门列出的四种合法写法，逐字转录（HTML 注释包裹，尖括号为实体）：

- &lt;!-- adr-0087: registered SOME-MIGRATION-ID --&gt;
- &lt;!-- adr-0087: not-required (unpublished) why --&gt;
- &lt;!-- adr-0087: not-required (already-registered SOME-MIGRATION-ID) why --&gt;
- &lt;!-- adr-0087: not-required (no-migration-prescription) why --&gt;

占位之所以是「未作答」而非「答错」，正是因为它一条都不匹配。

**RUN 2 —— 对照组，把标记整行删掉（= 本 PR 之前的产物形状）：同样红，但是另一条**

```text
  • .changeset/console-e6fdbdcc4bb2.md
      declares a breaking change (BREAKING) but no `adr-0087:` disposition marker.
GATE_EXIT=1
```

两条红的**文案不同**，这正是「present-but-unanswered」与「absent」在日志里可分的证据 —— 不是「门不再报错」这种会真空通过的负向断言。

**RUN 3 —— 把占位换成真实处置：绿**

```text
✓ check-adr-0087-registration: 1 declared-breaking changeset(s), each carrying an ADR-0087 disposition.
    .changeset/console-e6fdbdcc4bb2.md  [BREAKING]  not-required (already-registered)
        reason: 本区间的两处破坏都落在 objectui 自家 npm 包的 TypeScript 导出面…
GATE_EXIT=0
```

三次探针提交跑完即 `git reset --hard` 丢弃，本 PR 只含 1 个文件的改动。

### 再生存活性（本 issue 的真正交付物）

把 issue 里那份**已被手工补过标记**的 changeset 原地重新生成一次：

```text
$ node scripts/objectui-changeset-digest.mjs --from 7dfbeb704e1e --to 0cf8f0f7… \
      --out .changeset/console-0cf8f0f70d10.md
→ 24 releasing changeset(s), 2 breaking (0 declared major, 2 annotated), …

$ git diff .changeset/console-0cf8f0f70d10.md | grep adr-0087
（两行输出转录到下方 —— 同样因为正文吞注释）
```

`grep` 的两行（`-` 是被再生冲掉的**手工**标记，`+` 是再生后的占位；尖括号为实体）：

- `-` &lt;!-- adr-0087: not-required (already-registered dashboard-widget-action-aria-removed) 本条目声明的两处破坏都落在 objectui 自家 npm 包的 TypeScript 导出面… --&gt;
- `+` &lt;!-- adr-0087: TODO — the pin bump cannot answer this; a human must (objectstack#6494) --&gt;

手工标记被再生冲掉是**实测到的**，不是推断；改后它冲掉之后留下的是一个**门会判红的问题**，而不是一片沉默。（该文件已 `git checkout` 还原，不在本 PR 内。）

### bump 时刻的提示

生成器同时向 stderr 打一行（shell driver 用 `BUMP="$(…)"` 只截 stdout，所以这行能到操作者眼前）：

```text
→ this changeset DECLARES a breaking change, so it carries an UNANSWERED ADR-0087 disposition
  placeholder. Replace the `adr-0087: TODO` marker in .changeset/console-e6fdbdcc4bb2.md with
  the real disposition before you push: `Check Changeset` rejects the placeholder on purpose,
  and the generator cannot answer it for you (objectstack#6494).
```

## 门

| 门 | 结果 |
| --- | --- |
| `pnpm lint`（eslint，含 lint.yml 的族门） | `LINT_EXIT=0`；CI 的 **ESLint** job 亦已 success |
| `pnpm check:objectui-changeset`（digest 自测 + objectui-range 自测） | `DIGEST_GATE_EXIT=0`，`✓ all checks passed` |
| `node scripts/check-nul-bytes.mjs` | `OK (scanned 6128 tracked text file(s) … no raw ASCII control bytes)` |
| `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` 自扫改动文件 | 无命中 |
| `check-adr-0087-registration` 往返 | 见上，红→绿 |

`turbo run typecheck` 未在本地跑：改动是仓根 `scripts/*.mjs`，实测**不在任何 TS program 的 include 内**（唯一提到 scripts 的是 `packages/spec/tsconfig.scripts.json`，指的是该包自己的 `scripts/`），没有可用的 typecheck 输入；CI 的 TypeScript Type Check job 仍会跑全量，本 PR 会盯到它出结论。

## 反向验证：先声明，再运行 —— **两处与声明不符，如实记录**

消融方式：只把发射改回 `const body = rendered;`，常量、判定、断言全部保留。

**声明（运行前写下）**：5 条转红（EXACTLY ONE / PLACEHOLDER / major FRONTMATTER / ROUND TRIP red / ROUND TRIP green），2 条仍绿（负极性那条；「三方一致」那条 —— 理由是两边一起变 false）。

**观测**：

1. **「三方一致」那条实际转红了 —— 声明错了。** 它的第二个子句 `d.adr0087Scaffold === (d.bump === 'major' || /\*\*BREAKING/i.test(d.body))` 右侧锚在**门的判据**上，不随发射消失；于是 flag=false 对 criterion=true，等式破裂。这条断言比我声明的**更强**，声明的推理只看了第一个子句。
2. **ROUND TRIP (green) 没能报告，而是把整份自测崩掉了。** 没有占位可替换 → `replace()` 空操作 → 干净树上 `git commit` 退出 1 → `execFileSync` 抛出，只剩一段栈。方向与声明一致（它确实不会绿），但**诊断质量**不合格：消融正是下一个读者最需要「哪条断言红了」的时刻。这是本 PR 自己的毛病，就地修好（第二个 commit）：替换先经 `check()` 断言（占位确实在、文件确实变了、前后各恰好一个标记），提交带 `--allow-empty`。

**硬化后重跑**：消融时 9 条中 **8 条具名判红、0 崩溃**，仍绿的只有那条声明为负极性的；恢复发射后 **9 条全绿**。

自测新增 9 条（含真实门往返 2 条 + 替换到位 1 条）。其中「非破坏性产物不带任何标记」一条被**显式标注为负极性**：消融时它同样不会红，保留是因为它钉的是另一类回归（在门根本不判的产物上留一个永远无人作答的标记，那会教会下一个读者忽略这个标记），并配了三条正向守卫防止真空通过。

## 文件面与 changeset

只改 `scripts/objectui-changeset-digest.mjs`（含其内联自测）。⛔ 未触碰 `scripts/check-adr-0087-registration.mjs`（只读）、`scripts/bump-objectui.sh`、`.github/workflows/**`、`content/docs/releases/**`。

仓内工具改动，不发布任何包 ⇒ 无 changeset，已贴 `skip-changeset`。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_
