### PR TITLE
fix(ci): ADR-0087 迁移说明探测器读得懂「无箭头的改写表」(#6497)

### DIFF
--- a/scripts/check-adr-0087-registration.mjs
+++ b/scripts/check-adr-0087-registration.mjs
@@ -116,12 +116,17 @@
 // breaking changesets carry such a prescription, and it covers 4 of the 5 that did
 // register -- a genuine forcing function, not a blanket demand.
 //
-// #6419 repaired the detector behind it. It had been matching the literal
-// PLACEHOLDER words `FROM`/`TO` -- so `迁移:FROM → TO` (the template) was caught
-// while `迁移:`aggregate:` → `aggregations:`` (a real prescription) was not, and
-// the better the prescription the more invisible it was. It now also reads
-// framing-anchored rewrites in both languages. The full argument, the measured
-// numbers and the deliberate residual blind spot are at hasMigrationPrescription.
+// #6419 and #6497 repaired the detector behind it, twice, for one recurring
+// reason: the more carefully an author writes a prescription, the less it looks
+// like the shape the detector was pattern-matching. #6419 -- it had been matching
+// the literal PLACEHOLDER words `FROM`/`TO`, so `迁移:FROM → TO` (the template)
+// was caught while `迁移:`aggregate:` → `aggregations:`` (a real prescription) was
+// not. #6497 -- both branches then required an ARROW, so a rewrite written as a
+// two-column table under `## Migration` read as no prescription at all, and four
+// declared-breaking changesets were holding the exemption on that gap. It now
+// reads framing-anchored rewrites in both languages, in arrow form and in table
+// form. The full argument, the measured numbers and the deliberate residual blind
+// spot are at hasMigrationPrescription.
 //
 // ## Absence is never a pass (#4690)
 //
@@ -250,10 +255,10 @@ export function breakingDeclaration(parsed) {
 //
 // ## What replaced it
 //
-// Two branches, unioned. The first is the OLD pattern, kept verbatim, so the new
-// detector is a strict SUPERSET of the old one: nothing that used to be refused
-// can now slip through, and the `no-migration-prescription` exemption can only
-// have got harder to claim, never easier.
+// Three branches, unioned, each ADDED without touching the ones before it, so the
+// detector is a strict SUPERSET at every step: nothing that used to be refused can
+// now slip through, and the `no-migration-prescription` exemption can only have got
+// harder to claim, never easier.
 //
 //   1. THE LABEL CONVENTION -- `FROM`/`TO` used as a section label, table header
 //      or code comment. Measured: this is a genuine house convention, not one
@@ -267,19 +272,58 @@ export function breakingDeclaration(parsed) {
 //      `**迁移**:`aggregate:` → `aggregations:`` and every other honestly-written
 //      prescription in either language.
 //
-// ## What it moved (measured on the stock, both versions run over it)
+//   3. A FRAMED REWRITE TABLE -- a markdown table row inside a heading-framed
+//      region, carrying an OPERAND in two or more DISTINCT cells (#6497). Branches
+//      1 and 2 both require an ARROW, and a large class of this repo's changesets
+//      writes its rewrite instructions as a two-column table under `## Migration`
+//      with no arrow anywhere:
 //
-// 1342 changesets, 235 of them declared-breaking (the only population this gate
-// judges). Old detector: 113 hits, 87 of them breaking. New detector: 122 hits,
-// 92 breaking. NINE newly flagged, ZERO no longer flagged -- the superset property
-// is a measurement, not a claim. Seven of the nine are prescriptions the old
-// pattern missed (`r.deleted` → `r.success`; `改名 HttpMethodSchema →
-// HttpMethodSubsetSchema`; `rename `group` → `team``; a `OLD.x` → `previous.x`
-// migration table; ...). Two are false positives, both on changesets that declare
-// NO breaking change and are therefore never judged -- an error-message template
-// diagram (`[ Did you mean `k1` → `canonical`? ]`) and a docs-only changeset
-// describing a theme engine's internal token mapping. Verdict impact of the false
-// positives on the current tree: zero.
+//          ## Migration
+//
+//          | Wrote                                   | Write instead                 |
+//          | ---                                     | ---                           |
+//          | `new HttpServer(new HonoHttpServer(p))` | register the `HonoHttpServer` |
+//
+//      That is `runtime-httpserver-wrapper-retired.md` (#5122), verbatim shape. The
+//      arrowless table was read as "no prescription at all", so the changeset
+//      landed in the exempt bucket -- and the lesson from #6419 applies word for
+//      word one spelling over: a table that spells out "what you wrote / what to
+//      write instead" carries MORE information than one arrow line, and was
+//      precisely the shape the detector could not read. In a table the CELL
+//      BOUNDARY does the arrow's job, which is why the arm asks for the same thing
+//      the arrow arm asks for -- code-ish operands on two sides -- and reads the
+//      `|` instead of the `→`.
+//
+// ## What it moved (measured on the stock, every version run over it)
+//
+// #6419, branch 2 added. 1342 changesets, 235 of them declared-breaking (the only
+// population this gate judges). Old detector: 113 hits, 87 of them breaking. New
+// detector: 122 hits, 92 breaking. NINE newly flagged, ZERO no longer flagged --
+// the superset property is a measurement, not a claim. Seven of the nine are
+// prescriptions the old pattern missed (`r.deleted` → `r.success`; `改名
+// HttpMethodSchema → HttpMethodSubsetSchema`; `rename `group` → `team``; a `OLD.x`
+// → `previous.x` migration table; ...). Two are false positives, both on changesets
+// that declare NO breaking change and are therefore never judged -- an error-message
+// template diagram (`[ Did you mean `k1` → `canonical`? ]`) and a docs-only
+// changeset describing a theme engine's internal token mapping. Verdict impact of
+// the false positives on the current tree: zero.
+//
+// #6497, branch 3 added. 1384 changesets, 241 declared-breaking. Before: 129 hits,
+// 97 breaking. After: 133 hits, 101 breaking. FOUR newly flagged, ZERO no longer
+// flagged, and the superset property is STRUCTURAL here rather than measured --
+// branches 1 and 2 are evaluated first and return on the spot, so the table hit is
+// only ever consulted when they found nothing (it is `old(body) ?? table(body)`,
+// written as one pass).
+//
+// The table arm's FALSE-POSITIVE surface was measured before it was written, on the
+// whole stock rather than on the four changesets that motivated it: it fires on 7
+// changesets in 1384, ALL SEVEN declared-breaking, and all seven are genuine rewrite
+// prescriptions on inspection -- three were already refused via branch 1, and the
+// four new ones are `runtime-httpserver-wrapper-retired.md`,
+// `etl-author-shape-aliases.md`, `retire-three-deprecated-aliases.md`,
+// `unknown-key-strictness-ui-batch15.md`. Zero false positives, breaking or not.
+// That is not luck; it is what the framing anchor buys, and the two wider rules
+// measured alongside it (below) show what the same table rule costs without it.
 //
 // ## Why anchored on framing rather than on the arrow alone (measured)
 //
@@ -293,25 +337,69 @@ export function breakingDeclaration(parsed) {
 // NODE_ENV normalizer). Framing is what separates "here is what you must rewrite"
 // from "here is what the code does".
 //
-// ## The residual blind spot, stated rather than hidden (measured)
+// ## The residual blind spot, stated rather than hidden (measured, re-measured)
 //
-// Framing-anchored means an UNFRAMED rename table is still missed. Measured over
-// the same stock: 128 changesets carry a code-to-code rewrite that this detector
-// does not flag, 21 of them declared-breaking -- typically the
-// `unknown-key-strictness-*` and `adr-0112-*` batches, whose bodies list
-// `old` → `new` pairs under a plain heading with no migration word anywhere near
-// them. Anyone widening this later should start there, with these numbers to
-// beat.
+// ⚠️ The version of this paragraph that shipped with #6419 was WRONG, and #6497 is
+// what it cost. It said the residue was the UNFRAMED rewrite table -- which read as
+// "everything an author frames is seen". It was not: a table framed by a textbook
+// `## Migration` heading was missed too, because both branches required an arrow
+// and a table has none. Four declared-breaking changesets were holding the
+// `no-migration-prescription` exemption on exactly that gap. A self-description
+// that under-states a gate's blind spot is worse than none, because it is what the
+// next reader trusts instead of measuring; so the number below is what remains
+// AFTER branch 3, and it says which shapes, not just how many.
 //
-// Two wider rules were measured and REJECTED as noisier than they are useful:
-// firing on any line carrying >=2 rewrites takes the declared-breaking hit count
-// 92 -> 102 but adds 35 changesets to hand-check, of which a clear minority are
-// prescriptions; firing on ANY code-to-code arrow takes it to 250 hits / 113
-// breaking and is plainly a different check (it flags behaviour tables and worked
-// examples). An honestly-scoped detector beats a noisy one here because a FALSE
-// POSITIVE has no honest escape: the author is refused an exemption they are
-// entitled to and the closed vocabulary offers them nothing else -- which is the
-// #6419 shape itself, one category over.
+// What is still missed, measured over the 1384-changeset stock after branch 3
+// (each number is "changesets / of those, declared-breaking"):
+//
+//   * NO FRAMING AT ALL -- an `old` → `new` list or table under a plain heading
+//     with no migration word anywhere near it: 132 / 21. Typically the
+//     `unknown-key-strictness-*` and `adr-0112-*` batches. This is the honest
+//     residue of anchoring on framing, and it is deliberate.
+//   * FRAMED BY A LABEL, NOT A HEADING -- `**Migration.**` on its own line, then
+//     the table: 4 / 2 (`data-driver-find-stream-retired.md`,
+//     `storage-service-list-retired.md`). A framing LABEL does not open a framed
+//     region today; only a HEADING does.
+//   * FRAMED ONLY BY THE TABLE'S OWN HEADER CELLS in a vocabulary
+//     MIGRATION_FRAMING_RE does not carry -- `| Wrote | Write instead |`,
+//     `| Removed | Live replacement |`, `| you wrote | write instead |`,
+//     `| Was | Now |`: 14 / 11. This is a real house convention (four spellings,
+//     11 declared-breaking changesets) and reading it needs a NEW closed
+//     vocabulary of old/new column words, which is its own measurement job and its
+//     own false-positive surface. Not done here on purpose.
+//
+// Anyone widening this later should start with the last two, with these numbers to
+// beat, and should re-measure the false-positive surface FIRST -- as #6419 and
+// #6497 both did, and as the four rules below were rejected for failing.
+//
+// FOUR wider rules were measured and REJECTED as noisier than they are useful.
+//
+//   * (#6419) firing on any line carrying >=2 rewrites takes the declared-breaking
+//     hit count 92 -> 102 but adds 35 changesets to hand-check, of which a clear
+//     minority are prescriptions.
+//   * (#6419) firing on ANY code-to-code arrow takes it to 250 hits / 113 breaking
+//     and is plainly a different check (it flags behaviour tables and worked
+//     examples).
+//   * (#6497) firing on any coded table row with NO framing anchor -- the table
+//     analogue of the arrow-alone rule -- newly flags 114 changesets, 33 of them
+//     declared-breaking. Changeset bodies use tables for capability matrices,
+//     behaviour comparisons and version comparisons far more often than for
+//     rewrites, and this rule cannot tell those apart.
+//   * (#6497) taking the framing from the TABLE'S OWN HEADER ROW via the existing
+//     MIGRATION_FRAMING_RE -- tempting, since it needs no new vocabulary and reads
+//     `| 原写法 | 改写为 |` correctly. Measured, it buys ONE true positive with no
+//     verdict impact (`filter-icontains-and-regex-retirement.md`, which declares no
+//     breaking change and is therefore never judged) and costs ONE false positive:
+//     `rate-limit-config-dual-source-c9.md`, whose table is a two-TYPE comparison
+//     matrix -- `| | @objectstack/spec/shared (unchanged) | .../integration
+//     (renamed) |` -- caught only because the word `renamed` sits in a header cell
+//     naming a column, not framing a rewrite. Rejected on that trade alone: nothing
+//     gained on the judged population, a new way to be wrong on it.
+//
+// An honestly-scoped detector beats a noisy one here because a FALSE POSITIVE has
+// no honest escape: the author is refused an exemption they are entitled to and the
+// closed vocabulary offers them nothing else -- which is the #6419 shape itself,
+// one category over.
 //
 // Consequence to keep in mind when reading a green run: this branch answers
 // "did the author FRAME a rewrite as a migration", not "is a rewrite required".
@@ -332,6 +420,48 @@ const OPERAND = '(?:`[^`\\n]+`|[A-Za-z_$][A-Za-z0-9_$]*(?:[./][A-Za-z0-9_$]+)+)'
 
 /** `X → Y`, both sides code-ish. Stateless (no `g`): it is used inside a loop. */
 export const REWRITE_RE = new RegExp(`${OPERAND}\\s*${ARROW}\\s*${OPERAND}`);
+
+/** One operand anywhere in the text -- the per-CELL half of the table arm (#6497). */
+const OPERAND_RE = new RegExp(OPERAND);
+
+/**
+ * A markdown table's delimiter row (`| --- | :---: |`) -- the line that turns the
+ * row above it into a header and everything below it into data. Requiring it is
+ * what keeps ordinary prose containing a pipe out of the table arm, and it is why
+ * the HEADER row is never reported as evidence: it is scanned before the delimiter
+ * has been seen. Two columns minimum, which the arm needs anyway.
+ */
+const TABLE_DELIM_RE = /^\s{0,3}\|?(?:\s*:?-{2,}:?\s*\|)+\s*:?-{2,}:?\s*\|?\s*$/;
+
+/**
+ * A markdown table row. The outer pipes are REQUIRED, which is the narrow
+ * direction: GFM permits `a | b` without them, and a rule that accepted it would
+ * read every prose line containing a pipe as a table row. Missing a borderless
+ * table is a false negative; reading prose as a table is a false positive, and only
+ * one of those refuses an author an exemption they are entitled to.
+ */
+const TABLE_ROW_RE = /^\s{0,3}\|.*\|\s*$/;
+
+/**
+ * Does this table row read as a REWRITE -- an OPERAND in two or more DISTINCT
+ * cells?
+ *
+ * The cell boundary is doing the arrow's job, so the arm asks for exactly what the
+ * arrow arm asks for: code-ish operands on two sides. One coded cell is a
+ * description, a definition or a capability row (`| `getPort?()` | the real bound
+ * port after listen(0) |`), and those are not prescriptions.
+ *
+ * Split on an UNESCAPED pipe: `\|` inside a cell is GFM's escape and does not end
+ * it. Over-splitting could only ever make this fire MORE often, so getting it right
+ * is a false-positive matter, not a cosmetic one.
+ *
+ * @param {string} line
+ */
+function isRewriteRow(line) {
+  const cells = line.trim().replace(/^\|/, '').replace(/\|\s*$/, '').split(/(?<!\\)\|/);
+  if (cells.length < 2) return false;
+  return cells.filter((c) => OPERAND_RE.test(c)).length >= 2;
+}
 
 /**
  * Migration framing, in the spellings THIS repo's changesets actually use.
@@ -370,7 +500,7 @@ const FROM_TO_LABEL_RE =
  * which shapes are deliberately out of reach.
  *
  * @param {string} body
- * @returns {{ branch: 'from-to-label' | 'framed-line' | 'framed-section', line: string } | null}
+ * @returns {{ branch: 'from-to-label' | 'framed-line' | 'framed-section' | 'framed-table', line: string } | null}
  */
 export function findMigrationPrescription(body) {
   const label = FROM_TO_LABEL_RE.exec(body);
@@ -384,13 +514,33 @@ export function findMigrationPrescription(body) {
   // `## 迁移` followed by a list of `old` → `new` lines -- would be invisible,
   // which is the #6419 defect in a second spelling.
   let framedSection = false;
+  let inTable = false;
+  // The table arm's first hit, held back rather than returned (#6497). The arrow
+  // branches above `return` the moment they match, so holding this until the loop
+  // ends makes the whole function exactly `arrowBranches(body) ?? tableArm(body)`:
+  // every body the old detector flagged is still flagged, on the same branch, with
+  // the same evidence line. The superset property is then structural -- it cannot
+  // be broken by a future edit that only touches the table arm -- rather than a
+  // measurement someone has to remember to repeat.
+  let table = null;
   for (const line of body.split(/\r?\n/)) {
-    if (/^\s{0,3}#{1,6}\s/.test(line)) framedSection = MIGRATION_FRAMING_RE.test(line);
-    if (!REWRITE_RE.test(line)) continue;
-    if (MIGRATION_FRAMING_RE.test(line)) return { branch: 'framed-line', line: line.trim() };
-    if (framedSection) return { branch: 'framed-section', line: line.trim() };
+    if (/^\s{0,3}#{1,6}\s/.test(line)) {
+      framedSection = MIGRATION_FRAMING_RE.test(line);
+      inTable = false; // a table cannot span a heading
+    }
+    if (REWRITE_RE.test(line)) {
+      if (MIGRATION_FRAMING_RE.test(line)) return { branch: 'framed-line', line: line.trim() };
+      if (framedSection) return { branch: 'framed-section', line: line.trim() };
+    }
+    // Delimiter first: it also matches TABLE_ROW_RE, and it is the row that opens
+    // the data region rather than a row inside it.
+    if (TABLE_DELIM_RE.test(line)) { inTable = true; continue; }
+    if (!TABLE_ROW_RE.test(line)) { inTable = false; continue; }
+    if (inTable && framedSection && table === null && isRewriteRow(line)) {
+      table = { branch: 'framed-table', line: line.trim() };
+    }
   }
-  return null;
+  return table;
 }
 
 /**
@@ -1419,6 +1569,55 @@ function selfTest() {
     },
   })));
 
+  // ---- R12: THE #6497 SHAPE -- a rewrite TABLE with no arrow in it ----------
+  //
+  // `runtime-httpserver-wrapper-retired.md` (#5122), reduced to its shape: a
+  // textbook `## Migration` heading, a two-column "what you wrote / what to write
+  // instead" table, not one arrow in the body, and the catch-all exemption claimed
+  // on top. Both pre-#6497 branches required an arrow, so this was read as "no
+  // prescription at all" and the exemption was granted. Reverse-verified: delete
+  // the table arm and this case reports "expected RED, got green".
+  const SIX497 = CS({
+    bumps: [['@objectstack/runtime', 'major']],
+    body:
+      '**BREAKING**: the `HttpServer` delegating wrapper is retired\n\n' +
+      '## Migration\n\n' +
+      '| Wrote | Write instead |\n' +
+      '| --- | --- |\n' +
+      '| `new HttpServer(new HonoHttpServer(port))` | register the `HonoHttpServer` directly |\n' +
+      '| `import { HttpServer }` | remove it — `tsc` reports this one |\n\n' +
+      '<!-- adr-0087: not-required (no-migration-prescription) the wrapper had zero constructions anywhere, we grepped -->\n',
+  });
+  red('R12 the #6497 shape (an arrowless rewrite table under the catch-all)', run(mk({
+    files: { '.changeset/x.md': SIX497 },
+    pkgs: { '@objectstack/runtime': { dir: 'packages/runtime', private: false }, '@objectstack/spec': { dir: 'packages/spec', private: false } },
+  })), [/contradicts the changeset's own body/, /Evidence \(framed-table\)/, /HonoHttpServer/]);
+
+  // ---- G8: a CAPABILITY table under the same framing stays GREEN ------------
+  // The table arm's false-positive floor, and the reason it asks for two coded
+  // cells rather than one: this is a real shape from the same changeset -- a member
+  // named in column 1, prose about it in column 2. One coded cell is a description,
+  // not a prescription, and refusing it would take an exemption from an author who
+  // is entitled to it with nothing else in the vocabulary to offer them.
+  //
+  // NOTE, honestly: this case is green with the table arm and green without it.
+  // Deleting an arm can only make a detector match LESS, so no false-positive floor
+  // can move under reverse verification. It pins the boundary, not the capability.
+  green('G8 a one-coded-cell capability table is not a prescription', run(mk({
+    files: {
+      '.changeset/x.md': CS({
+        body:
+          '**BREAKING** the delegating wrapper is gone\n\n' +
+          '## Migration\n\n' +
+          '| Optional member | What wrapping it cost |\n' +
+          '| --- | --- |\n' +
+          '| `getPort?()` | the real bound port after listening on an ephemeral port |\n' +
+          '| `getRawApp?()` | the framework-native escape hatch four consumers feature-detect |\n\n' +
+          '<!-- adr-0087: not-required (no-migration-prescription) an internal error string changed; no key, symbol or stored value moves -->\n',
+      }),
+    },
+  })));
+
   // ---- G6: a changeset that was ALREADY breaking at base is inherited -------
   {
     const r = mk({ files: {} });
@@ -1509,6 +1708,28 @@ function selfTest() {
   assert(findMigrationPrescription('### 迁移:FROM → TO\n')?.branch === 'from-to-label', 'P20: the placeholder label reports the label branch');
   assert(findMigrationPrescription('nothing here\n') === null, 'P21: a body with no prescription reports null, not a shrug');
 
+  // #6497 -- the REWRITE TABLE, which has no arrow for either arrow branch to read.
+  const TABLE_EN = '## Migration\n\n| Wrote | Write instead |\n| --- | --- |\n| `new HttpServer(port)` | register the `HonoHttpServer` directly |\n';
+  const TABLE_ZH = '## 破坏性变更 · 迁移\n\n| 旧写法 | 改成 |\n|---|---|\n| `typography.fontWeight: { base }` | `normal` |\n';
+  assert(hasMigrationPrescription(TABLE_EN), 'P22: an arrowless rewrite table under `## Migration` must match');
+  assert(hasMigrationPrescription(TABLE_ZH), 'P23: the same, in Chinese, with the `|---|---|` delimiter spelling');
+  assert(findMigrationPrescription(TABLE_EN)?.branch === 'framed-table', 'P24: a framed table reports the framed-table branch');
+  // ...and the two things that keep it narrow. Both are false-positive floors: they
+  // are green with the arm and green without it, so reverse verification cannot
+  // move them -- they pin where the arm STOPS, which no deletion can widen.
+  assert(
+    !hasMigrationPrescription(TABLE_EN.replace('## Migration', '## What changed')),
+    'P25: the SAME table under a heading with no migration framing must NOT match -- the anchor is load-bearing',
+  );
+  assert(
+    !hasMigrationPrescription('## Migration\n\n| Member | What it cost |\n| --- | --- |\n| `getPort?()` | the real bound port after listening |\n'),
+    'P26: one coded cell is a description, not a rewrite -- two DISTINCT cells are required',
+  );
+  assert(
+    !hasMigrationPrescription('## Migration\n\nprose about `a.b` and `c.d` with a | pipe in it but no table at all\n'),
+    'P27: a pipe in prose is not a table -- the delimiter row is what opens one',
+  );
+
   // ---- S1-S5: the `--audit-stock` classifier (#6350) ------------------------
   //
   // The stock audit's classifier decides which rows a human ever reads, so a
@@ -1545,6 +1766,12 @@ function selfTest() {
       cls(CS({ bumps: [['@objectstack/spec', 'major'], ['@objectstack/example-showcase', 'major']], body: PRESCRIPTION })) === 'residue',
       'S6: ONE published package among the bumps is enough to close the unpublished exemption',
     );
+    // S7 (#6497): the four stock changesets this arm moves are moved HERE -- out of
+    // `exempt-no-prescription` and into the residue a human reads. Without the table
+    // arm this returns `exempt-no-prescription`, which is the audit's half of the
+    // same bypass: the worklist silently omitted them.
+    const TABLE_PRESCRIPTION = '**BREAKING** x\n\n## Migration\n\n| Wrote | Write instead |\n| --- | --- |\n| `new HttpServer(p)` | register the `HonoHttpServer` |\n';
+    assert(cls(CS({ body: TABLE_PRESCRIPTION })) === 'residue', 'S7: THE #6497 SHAPE -- published break + arrowless rewrite TABLE -- is RESIDUE');
   }
 
   assert(breakingDeclaration(parseChangeset(CS({ body: 'feat(spec)!: x\n' }))).breaking, 'P6: a conventional-commit bang is a declaration');


### PR DESCRIPTION
Fixes #6497

## 缺陷

`not-required (no-migration-prescription)` 这条豁免的唯一守门人是 `findMigrationPrescription()`:正文带改写指令 ⇒ 拒绝该豁免。它此前的两条分支 —— #6148 的 `FROM`/`TO` 标签约定、#6419 的框架锚定改写 —— **都要求出现箭头**(`REWRITE_RE` 是 `OPERAND ARROW OPERAND`,循环里 `if (!REWRITE_RE.test(line)) continue`)。

而本仓相当一批 changeset 把改写指令写成迁移框架标题下的**两列 markdown 表**,一个箭头都没有。探测器判它「无迁移说明」,于是这条自相矛盾的豁免被门禁**批准** —— 这是 #6419 那个形状的第三种拼写,它的教训逐字适用:**作者写得越认真,探测器越看不见**。一张写清了「原来怎么写 / 改成怎么写」的表,比一行箭头信息量更大,却恰恰是探测器唯一读不到的形状。

## 改法

新增第三条分支 `framed-table`:**迁移框架标题所辖区域内**、markdown 表格的**数据行**、**两个及以上不同单元格各带一个 `OPERAND`**。

表格里由**单元格边界承担箭头的职责**,所以这条分支对两侧的要求与箭头分支完全一致(代码形操作数:反引号代码段,或点/斜线标识符路径),只是读 `|` 而不读 `→`。三处收窄都是刻意的,方向都是「宁可漏,不可误」:

- 必须有分隔行(`| --- | --- |`)才算表 —— 正文里带竖线的散文不是表,分隔行同时保证**表头行永远不会被当成证据**(扫到表头时分隔行还没出现);
- 外侧竖线必须写全 —— GFM 允许 `a | b`,但认它就等于把每一行带竖线的散文读成表格行;
- **一个代码单元格不算改写** —— 那是描述、定义或能力行(`| \`getPort?()\` | the real bound port |`),不是处方。

## 先量误报面,再放宽(#6419 的打法,本单照抄)

**误报没有诚实的出口**:作者被错误拒掉一条他有权使用的豁免,封闭词表里没有别的选项给他。所以放宽之前先在**整个存量**上量,而不是在触发本单的那 4 条上量。

| 口径 | 数字 |
|---|---|
| 存量 | 1384 条 changeset,241 条声明 breaking |
| 探测器 改前 | 129 命中 / 97 breaking |
| 探测器 改后 | 133 命中 / 101 breaking |
| 净变化 | **+4 / −0** |
| 新分支单独命中 | **7 条**(全部声明 breaking),逐条人工核对**全部是真改写处方** |
| **误报** | **0 条**(breaking 与非 breaking 都是 0) |

超集性质在此是**结构性**的而非测量出来的:箭头两支先判并当场 `return`,表格命中被扣到循环结束才返回,整个函数就是 `arrowBranches(body) ?? tableArm(body)` —— 改前命中的每一条,仍以**同一分支、同一条证据行**命中。将来只动表格分支的编辑无法破坏它。

### 经测量后**拒绝**的两条更宽规则

- **不要框架锚,任何两代码格的表格行都算** —— 新增命中 114 条(33 条 breaking)。changeset 正文里表格的用途很杂(能力矩阵、行为对照、版本对照),这条规则分不开它们。
- **用表格自己的表头取框架**(复用现有 `MIGRATION_FRAMING_RE`,能正确读出 `| 原写法 | 改写为 |`)—— 很诱人,不需要新词表。实测:只买到 **1 条无判决影响的真阳性**(`filter-icontains-and-regex-retirement.md`,不声明 breaking,门禁从不judge它),却带来 **1 条真实误报** —— `rate-limit-config-dual-source-c9.md`,它那张表是**两个类型的对照矩阵**,只因表头单元格里有 `(renamed)` 一词被命中,而那个词在给列命名,不在框改写。在被判决的人群上一无所得、却多一种判错的方式 ⇒ 拒绝。

## 4 条存量按名核对(`--audit-stock`)

残差面 **92 → 96,恰好 +4,无一移出**;`exempt-no-prescription` 桶 143 → 139。

| changeset | 改前 | 改后 |
|---|---|---|
| `runtime-httpserver-wrapper-retired.md` | `exempt-no-prescription` | 残差 `!`(framed-table) |
| `etl-author-shape-aliases.md` | `exempt-no-prescription` | 残差 `!`(framed-table) |
| `retire-three-deprecated-aliases.md` | `exempt-no-prescription` | 残差 `~`(framed-table) |
| `unknown-key-strictness-ui-batch15.md` | `exempt-no-prescription` | 残差 `!`(framed-table) |

⚠️ 这是**工作清单,不是判决**:移入残差面并不决定其中哪一条欠一条台账记录。登记判准本身是 #6350 挂在维护者那儿的未决题,**本 PR 不回补任何 ADR-0087 台账条目** —— 那等于用实现去替维护者做决定。

## 一并改写的自述

脚本正文那段「残余盲区」此前只说**未加框架**的改写表读不到 —— 而本单这 4 条恰恰是**加了框架**的。**那句自述本身就是 #6497 的成因**:它读起来像「凡是作者框起来的都看得见」,于是下一个读者信了它而不去测。现在给的是分支 3 之后**剩下**的形状,分项带数:

- **完全无框架**的 `old → new` 清单/表:132 条 / 21 条 breaking —— 锚定框架的诚实残差,故意保留;
- **由标签而非标题起框**(`**Migration.**` 独占一行,紧跟表格):4 条 / 2 条 breaking;
- **只由表头单元格起框**、且用的词不在现有框架词表里(`| Wrote | Write instead |`、`| Removed | Live replacement |`、`| you wrote | write instead |`、`| Was | Now |`):14 条 / 11 条 breaking —— 这是一条真实的房规(4 种拼法),读它需要一套**新的**老/新列词表,那是它自己的测量任务和自己的误报面,本单**刻意不做**,已另行归档为 finding。

## 自测与反向验证

`--self-test` 从 73 条断言增至 85 条(CI 的 Check Changeset 步骤跑它)。新增:`P22`-`P27`(表格分支的能力与三条边界)、`R12`(#6497 形状走完整 `scan()` 路径被拒,证据分支为 `framed-table`)、`G8`(同一框架下的**能力表**保持 GREEN)、`S7`(`--audit-stock` 分类器把它归入 `residue`)。

**反向验证 —— 红集在运行前就预测好了**:删掉表格分支,预测 `R12`(1 条「expected RED, got green」+ 3 条消息断言)、`P22`、`P23`、`P24`、`S7` 转红,共 **8 条**;实跑 **8 条,与预测逐条一致**,既有断言无一移动。

**诚实标注方向**:`P25` / `P26` / `P27` / `G8` 是**误报地板**,**删掉分支后仍然是绿的**。删一条分支只会让探测器**匹配得更少**,所以任何误报地板在反向验证下都不可能转红 —— 它们钉的是分支**停在哪里**,不是分支的能力。把它们写进红集预测才是编造证据。

## 为什么没有 changeset

本 PR 只改 `scripts/` 下的 CI 脚本,不属于任何已发布包,**不发布任何东西** ⇒ 按 AGENTS.md「纯 bug 修复不需要 changeset」走**不写 changeset**这一支,并给 PR 打 `skip-changeset` 标签。

## 本地门禁

- `node scripts/check-adr-0087-registration.mjs --self-test` ✅ 85 assertions
- `node scripts/check-adr-0087-registration.mjs`(门禁本体)✅
- `pnpm lint`(全仓 ESLint)✅;`lint.yml` 里的全部 `check:*` 家族门禁 ✅
- `pnpm check:nul-bytes` ✅;并对改动文件做了超出门禁的控制字符自扫(0 命中)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZgRyPVwi1jLb1mNNuUQ9o

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZgRyPVwi1jLb1mNNuUQ9o)_