### PR TITLE
refactor(lint)!: retire the unreachable `visibility-alias-deprecated` rule (#6318)

### DIFF
--- a/.changeset/visibility-alias-deprecated-retired.md
+++ b/.changeset/visibility-alias-deprecated-retired.md
@@ -1,0 +1,67 @@
+---
+"@objectstack/lint": minor
+---
+
+refactor(lint)!: retire `visibility-alias-deprecated` — the rule could not fire on any real CLI input (#6318, ADR-0049)
+
+`@objectstack/lint` shipped a fourth conditional-visibility rule whose only job
+was to report the deprecated predicate **key** (`visibleOn` on a view form
+section/field, `visibility` on a page component) and steer the author to
+`visibleWhen`. It never reported on anything a command actually loads.
+
+**Why it could not fire.** The rule is registered `input: 'normalized'`, so what
+`os validate` / `os build` / `os lint` hand it is the output of
+`normalizeStackInput`. The two ADR-0087 D2 conversions that fold the alias —
+`view-visibleOn-to-visibleWhen` and `page-component-visibility-to-visibleWhen` —
+run **inside** `normalizeStackInput`, one layer above. The key is therefore
+already renamed by the time the rule sees the stack. Re-measured per site:
+
+| alias site | rule fed the raw authored object | rule fed the `normalized` tier |
+|---|---|---|
+| `views[].form.sections[]` | 1 finding | **0** |
+| `views[].formViews.edit.sections[]` | 1 finding | **0** |
+| `pages[].regions[].components[]` | 1 finding | **0** |
+
+The one shape it did still fire on is a view **container** carrying top-level
+`sections` — the shape its own unit tests used, and the shape strict
+`ViewSchema` refuses outright (`Unrecognized key(s) on this view container:
+\`sections\``). A green unit test over a fixture production can never send.
+
+**No working app loses a signal.** Authors were never hearing this rule, and
+they do hear the conversion: the same D2 entry emits a `warnConversionNotice`
+from `defineStack` that names the site, the conversion id and the retirement
+window — wording the lint rule never had.
+
+```
+defineStack: views[0].form.sections[0].visibleWhen: 'visibleOn' -> 'visibleWhen'
+  (converted at load; conversion 'view-visibleOn-to-visibleWhen', retires in protocol 16).
+  Update the source to the canonical shape — the conversion stops running then.
+```
+
+**Authored metadata is unaffected.** `visibleOn` / `visibility` remain accepted
+exactly as before, still fold to `visibleWhen`, and still retire with protocol
+16. Nothing an app author writes has to change.
+
+**Consumer migration — one removed export.** The rule id constant leaves the
+published barrel:
+
+- `VISIBILITY_ALIAS_DEPRECATED` (`'visibility-alias-deprecated'`) is removed from
+  `@objectstack/lint`. Delete the import; no finding carries that `rule` value
+  any more, so a `suppressWarnings: ['visibility-alias-deprecated']` entry or a
+  filter comparing against it is now dead code and can go with it.
+
+The other three rules in the same module are **unchanged** — they judge the
+predicate's *value*, which crosses the fold into `visibleWhen` intact, and each
+still reports normally on the `normalized` tier:
+`visibility-root-mislayered`, `visibility-bare-identifier`,
+`visibility-predicate-syntax`. `checkElement` also keeps reading the predicate
+through the deprecated keys (canonical-first, so an alias can never override
+`visibleWhen`), which is what lets those three still judge an alias-spelled
+predicate handed to the exported function directly.
+
+Retired rather than re-anchored: making the rule read a genuine pre-normalize
+value would have changed `runAuthoringRules`' external input contract, which is
+a `packages/lint` public-API decision for the maintainer rather than a rule
+file's to take.
+
+<!-- adr-0087: not-required (already-registered view-visibleOn-to-visibleWhen, page-component-visibility-to-visibleWhen) The authored alias surface is already covered by those two D2 conversions, which are unchanged by this PR — they keep accepting `visibleOn` / `visibility`, keep folding them to `visibleWhen`, and keep their protocol-16 retirement window. This change removes only a lint rule id from a TS export surface; no authored or stored metadata shape changes, so there is nothing new for the ledger to carry. -->

--- a/packages/lint/src/authoring-rule-input-tier.test.ts
+++ b/packages/lint/src/authoring-rule-input-tier.test.ts
@@ -212,20 +212,42 @@ describe('premise 2 (FALSE): "the parse strips `userFilters`/`quickFilters` on a
 describe('premise 3 (FALSE): "the `visibleOn` alias survives until the parse"', () => {
   // The fold is an ADR-0087 D2 conversion inside `normalizeStackInput` — one
   // layer BEFORE this tier — not a parse-time `.transform()`. So the alias is
-  // gone from the tier's own input on every door, `os lint` included. #6318.
-  const aliasSites: Array<[string, AnyRec]> = [
+  // gone from the tier's own input on every door, `os lint` included.
+  //
+  // #6318 acted on that measurement: the alias-KEY rule this premise was
+  // written to justify (`visibility-alias-deprecated`) has been RETIRED, so the
+  // assertions below no longer count its findings. They pin the mechanism that
+  // outlives it, which is what makes the retirement safe to keep:
+  //
+  //   * the KEY does not cross the fold — nothing downstream can judge it;
+  //   * the VALUE does cross it intact — which is why the three surviving rules
+  //     work on this tier and were not swept in;
+  //   * the author is not silent — the D2 conversion notice fires in
+  //     `defineStack`, and that notice IS the recorded guard for this surface.
+  //
+  // Read `toHaveLength(0)` on the raw leg as "the alias key is nobody's verdict
+  // any more"; the fold measurement itself now lives in the VALUE assertions,
+  // which are non-empty and can actually fail.
+  /**
+   * The three spec-valid alias sites, each carrying `predicate` under its
+   * DEPRECATED key. Parameterised on the predicate so the same three shapes can
+   * be measured twice: once with a clean value (nothing to find but the retired
+   * key) and once with a bare-identifier value (a VALUE defect the surviving
+   * gate must still reach through the fold).
+   */
+  const aliasSitesWith = (predicate: string): Array<[string, AnyRec]> => [
     ['views[].form.sections[]', {
       manifest,
       views: [{
         name: 'tier_form',
-        form: { type: 'simple', sections: [{ label: 'S', visibleOn: 'record.a == 1', fields: [{ field: 'name' }] }] },
+        form: { type: 'simple', sections: [{ label: 'S', visibleOn: predicate, fields: [{ field: 'name' }] }] },
       }],
     }],
     ['views[].formViews.edit.sections[]', {
       manifest,
       views: [{
         name: 'tier_form2',
-        formViews: { edit: { type: 'simple', sections: [{ label: 'S', visibleOn: 'record.a == 1', fields: [{ field: 'name' }] }] } },
+        formViews: { edit: { type: 'simple', sections: [{ label: 'S', visibleOn: predicate, fields: [{ field: 'name' }] }] } },
       }],
     }],
     ['pages[].regions[].components[]', {
@@ -235,19 +257,55 @@ describe('premise 3 (FALSE): "the `visibleOn` alias survives until the parse"', 
         label: 'P',
         type: 'home',
         object: 'tier_task',
-        regions: [{ name: 'main', components: [{ type: 'element:text', visibility: "page.selectedId != ''" }] }],
+        regions: [{ name: 'main', components: [{ type: 'element:text', visibility: predicate }] }],
       }],
     }],
   ];
 
-  it.each(aliasSites)('%s: the alias is folded BEFORE the tier, so the rule reports 0', (_site, stack) => {
-    // Fed the raw authored object (what the rule's own unit tests do) it reports.
-    expect(validateVisibilityPredicates(structuredClone(stack))).toHaveLength(1);
-    // Fed the `normalized` tier (what all three commands do) it does not.
+  /** Clean, canonically-rooted predicate: the only thing wrong is the key spelling. */
+  const aliasSites = aliasSitesWith('record.a == 1');
+  /** Same three sites, predicate rooted nowhere (#5149 Repro 1) — a VALUE defect. */
+  const aliasSitesBadValue = aliasSitesWith('approved');
+
+  it.each(aliasSites)('%s: no rule judges the alias KEY any longer (#6318 retirement)', (_site, stack) => {
+    // Both doors report nothing, and for TWO DIFFERENT reasons that must not be
+    // conflated. Raw: the rule that would have judged the key is retired.
+    // Normalized: the key is not even there — the D2 fold renamed it one layer
+    // up. The `normalized` leg is a VACUOUS green after the retirement (it is
+    // empty because no rule exists, not because of the fold), so it is labelled
+    // as such and carries no weight on its own; the leg below is the one that
+    // measures the fold.
+    expect(validateVisibilityPredicates(structuredClone(stack))).toHaveLength(0);
     expect(validateVisibilityPredicates(normalizeStackInput(structuredClone(stack)) as AnyRec)).toEqual([]);
   });
 
+  it.each(aliasSitesBadValue)(
+    '%s: the KEY does not cross the fold but the VALUE does — measured on a NON-EMPTY finding set',
+    (_site, stack) => {
+      // The replacement for the vacuous green above, and the assertion that
+      // actually measures the fold. Same three sites, but the predicate is now
+      // a bare identifier — a VALUE defect. If the fold dropped the predicate
+      // instead of renaming its key, or if the surviving gate stopped reaching
+      // it, this set would be EMPTY and the assertion would fail. It cannot
+      // pass by producing nothing, which is exactly what the leg above can do.
+      const normalized = normalizeStackInput(structuredClone(stack)) as AnyRec;
+      // The KEY is gone from the tier's own input …
+      expect(JSON.stringify(normalized)).not.toContain('visibleOn');
+      expect(JSON.stringify(normalized)).not.toContain('"visibility"');
+      // … and the VALUE arrived under the canonical key, where the surviving
+      // gate reads it. Exactly one finding, named.
+      expect(validateVisibilityPredicates(normalized).map((f) => f.rule)).toEqual([
+        'visibility-bare-identifier',
+      ]);
+    },
+  );
+
   it('the author is NOT left silent — the D2 conversion notice names the site and its retirement', () => {
+    // This notice is the RECORDED GUARD for the alias surface: it is why #6318
+    // could retire the lint rule instead of re-anchoring it, and why no working
+    // app lost a signal. If this test ever goes red, the retirement's premise is
+    // gone and the surface is genuinely unguarded — re-open #6318, do not delete
+    // this assertion.
     const { error, warnings } = quietly(() => defineStack(structuredClone(aliasSites[0][1]) as never));
     expect(error).toBeUndefined();
     expect(warnings).toHaveLength(1);
@@ -257,8 +315,9 @@ describe('premise 3 (FALSE): "the `visibleOn` alias survives until the parse"', 
   });
 
   it('the predicate-VALUE rules in the same file are unaffected — do not connect them', () => {
-    // The value moves into `visibleWhen` intact, so these two still report on the
-    // tier. #6318 is about the alias-KEY rule only.
+    // The value moves into `visibleWhen` intact, so these still report on the
+    // tier. #6318 was about the alias-KEY rule only, and this is the pin that
+    // says so from the far side of the retirement.
     const bare = {
       manifest,
       views: [{

--- a/packages/lint/src/authoring-rules.ts
+++ b/packages/lint/src/authoring-rules.ts
@@ -236,7 +236,11 @@ export type AuthoringRuleTier = 'gating' | 'advisory';
  *     ADR-0087 D2 conversion (`view-visibleOn-to-visibleWhen`,
  *     `page-component-visibility-to-visibleWhen`) folds it into `visibleWhen`
  *     INSIDE `normalizeStackInput` — one layer before the tier, not during the
- *     parse. See #6318.
+ *     parse. #6318 acted on that: the alias-KEY rule this premise justified
+ *     (`visibility-alias-deprecated`) was retired, since the D2 conversion
+ *     notice already covers its whole evidence surface with better wording and
+ *     a stated retirement window. The alias-KEY half of premise 3 is therefore
+ *     no longer merely false — there is nothing left reading it.
  *
  * ## What it does buy, and why the tier stays
  *
@@ -746,17 +750,29 @@ export const AUTHORING_RULES: readonly AuthoringRule[] = [
     surfaceReason: RUNTIME_NEEDS_FULL_SNAPSHOT,
     run: (stack) => validateSeedStateMachine(stack),
   },
-  // ADR-0089 D3b — deprecated visibility aliases and a mis-layered binding root,
-  // plus (#6128) the bare-identifier gate. This entry used to read "pre-parse:
-  // the schema folds `visibleOn`/`visibility` into `visibleWhen` during parse,
-  // so the alias the author wrote is gone from `result.data`". Measured false
-  // at #6073: the ADR-0087 D2 conversions do that fold INSIDE
+  // ADR-0089 D3b — a mis-layered binding root, plus (#6128) the bare-identifier
+  // gate and (#6253) the syntax gate. This entry used to read "pre-parse: the
+  // schema folds `visibleOn`/`visibility` into `visibleWhen` during parse, so
+  // the alias the author wrote is gone from `result.data`". Measured false at
+  // #6073: the ADR-0087 D2 conversions do that fold INSIDE
   // `normalizeStackInput`, one layer BEFORE this tier, so on every spec-valid
-  // alias site `visibility-alias-deprecated` reports zero here too — see #6318,
-  // which carries the per-site table and the retire-or-rewire question. The two
-  // predicate-VALUE rules (`visibility-bare-identifier`,
-  // `visibility-root-mislayered`) are unaffected: the value moves into
-  // `visibleWhen` intact and both still report on this tier.
+  // alias site the alias-KEY rule reported zero here too.
+  //
+  // #6318 closed that: `visibility-alias-deprecated` was RETIRED rather than
+  // re-anchored. Re-anchoring would have had to move this entry's input to a
+  // pre-`normalizeStackInput` value that `runAuthoringRules` does not accept —
+  // a change to this package's external input contract, and the maintainer's
+  // call, not a rule file's. Retirement is ADR-0049 (declared ≠ enforced) and
+  // costs no author a signal: the same D2 conversion already shouts through
+  // `warnConversionNotice` in `defineStack`, naming the site, the conversion and
+  // the protocol-16 retirement window — better wording than the rule ever had.
+  //
+  // Every rule left in the family judges the predicate's VALUE, and the value
+  // moves into `visibleWhen` intact, so all three report normally on this tier.
+  // The tier therefore stays `normalized` on its SURVIVING justification (a
+  // finding still reaches the author when an unrelated schema error would stop
+  // the parse — see `AuthoringRuleInputTier`), never on the retired
+  // "pre-parse evidence" one.
   //
   // `gating` since #6128: `visibility-bare-identifier` emits `error`. The two
   // ADR-0089 rules stay advisory findings within it — the tier is a property of

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -137,7 +137,6 @@ export type { FormLayoutFinding, FormLayoutSeverity } from './validate-form-layo
 
 export {
   validateVisibilityPredicates,
-  VISIBILITY_ALIAS_DEPRECATED,
   VISIBILITY_ROOT_MISLAYERED,
   VISIBILITY_BARE_IDENTIFIER,
   VISIBILITY_PREDICATE_SYNTAX,

--- a/packages/lint/src/validate-visibility-predicates.test.ts
+++ b/packages/lint/src/validate-visibility-predicates.test.ts
@@ -3,7 +3,6 @@
 import { describe, it, expect } from 'vitest';
 import {
   validateVisibilityPredicates,
-  VISIBILITY_ALIAS_DEPRECATED,
   VISIBILITY_ROOT_MISLAYERED,
   VISIBILITY_BARE_IDENTIFIER,
   VISIBILITY_PREDICATE_SYNTAX,
@@ -37,40 +36,88 @@ describe('validateVisibilityPredicates (ADR-0089 D3b)', () => {
     expect(validateVisibilityPredicates(stack)).toEqual([]);
   });
 
-  it('flags a deprecated `visibleOn` alias on a form section (→ visibleWhen)', () => {
-    const stack = {
-      views: [
-        { name: 'task_form', sections: [{ label: 'S', visibleOn: "record.a == 1", fields: [] }] },
-      ],
-    };
-    const findings = validateVisibilityPredicates(stack);
-    expect(findings).toHaveLength(1);
-    expect(findings[0].rule).toBe(VISIBILITY_ALIAS_DEPRECATED);
-    expect(findings[0].severity).toBe('warning');
-    expect(findings[0].path).toBe('views[0].sections[0].visibleOn');
-  });
+  // ── #6318: the alias-KEY rule is RETIRED; the alias-VALUE read is not ──
+  //
+  // Three tests here used to assert that a `visibleOn` / `visibility` KEY
+  // produced a `visibility-alias-deprecated` finding, one per carrier. That
+  // rule never reached a real input: through all three CLI commands the stack
+  // arrives at the `normalized` tier, and the ADR-0087 D2 conversions rename the
+  // key INSIDE `normalizeStackInput`, one layer above. Measured at retirement,
+  // per site: raw object 1 finding, `normalized` tier 0. The only shape that
+  // still fired is the one those three fixtures used — a view CONTAINER with
+  // top-level `sections` — which strict `ViewSchema` refuses outright
+  // ("Unrecognized key(s) on this view container: `sections`"). Green unit test,
+  // impossible fixture: #4984 / #6251.
+  //
+  // What SURVIVES those three assertions, and is what the replacements below
+  // pin instead: the traversal reaches all three carriers, and `checkElement`
+  // still reads the predicate VALUE through the deprecated key, so a value
+  // defect written under an alias is judged rather than skipped. Each asserts
+  // the EXACT finding set — non-empty and named, so it cannot pass by producing
+  // nothing, and restoring the retired rule would fail it on set inequality.
+  //
+  // The surface itself is not unguarded: the same D2 conversion emits a
+  // `warnConversionNotice` from `defineStack` naming the site, the conversion
+  // and the protocol-16 retirement window. `authoring-rule-input-tier.test.ts`
+  // (premise 3) pins that notice as the recorded guard.
+  describe('the deprecated alias keys (#6318 — key rule retired, value read kept)', () => {
+    it('a `visibleOn` KEY with a clean value is clean — no rule judges the spelling', () => {
+      const stack = {
+        views: [
+          { name: 'task_form', sections: [{ label: 'S', visibleOn: "record.a == 1", fields: [] }] },
+        ],
+      };
+      // Deliberately labelled: this green is VACUOUS with respect to the fold —
+      // it is empty because the rule is gone, not because anything normalized.
+      // It earns its place only as the retirement's direct statement, and the
+      // three assertions below are what carry the real evidence.
+      expect(validateVisibilityPredicates(stack)).toEqual([]);
+    });
 
-  it('flags a deprecated `visibleOn` alias on a form field', () => {
-    const stack = {
-      views: [
-        { name: 'task_form', sections: [{ fields: [{ field: 'notes', visibleOn: "record.a == 1" }] }] },
-      ],
-    };
-    const findings = validateVisibilityPredicates(stack);
-    expect(findings.map((f) => f.rule)).toEqual([VISIBILITY_ALIAS_DEPRECATED]);
-    expect(findings[0].path).toBe('views[0].sections[0].fields[0].visibleOn');
-  });
+    it('a form SECTION predicate is still read through `visibleOn` (value verdict survives)', () => {
+      const stack = {
+        views: [
+          { name: 'task_form', sections: [{ label: 'S', visibleOn: "data.a == 1", fields: [] }] },
+        ],
+      };
+      const findings = validateVisibilityPredicates(stack);
+      expect(findings.map((f) => f.rule)).toEqual([VISIBILITY_ROOT_MISLAYERED]);
+      expect(findings[0].path).toBe('views[0].sections[0]');
+    });
 
-  it('flags a deprecated `visibility` alias on a page component', () => {
-    const stack = {
-      pages: [
-        { name: 'p', regions: [{ components: [{ type: 'element:text', visibility: "page.x != ''" }] }] },
-      ],
-    };
-    const findings = validateVisibilityPredicates(stack);
-    expect(findings).toHaveLength(1);
-    expect(findings[0].rule).toBe(VISIBILITY_ALIAS_DEPRECATED);
-    expect(findings[0].path).toBe('pages[0].regions[0].components[0].visibility');
+    it('a form FIELD predicate is still read through `visibleOn`', () => {
+      const stack = {
+        views: [
+          { name: 'task_form', sections: [{ fields: [{ field: 'notes', visibleOn: "data.a == 1" }] }] },
+        ],
+      };
+      const findings = validateVisibilityPredicates(stack);
+      expect(findings.map((f) => f.rule)).toEqual([VISIBILITY_ROOT_MISLAYERED]);
+      expect(findings[0].path).toBe('views[0].sections[0].fields[0]');
+    });
+
+    it('a PAGE COMPONENT predicate is still read through the page-side `visibility` key', () => {
+      const stack = {
+        pages: [
+          { name: 'p', regions: [{ components: [{ type: 'element:text', visibility: "data.x != ''" }] }] },
+        ],
+      };
+      const findings = validateVisibilityPredicates(stack);
+      expect(findings.map((f) => f.rule)).toEqual([VISIBILITY_ROOT_MISLAYERED]);
+      expect(findings[0].path).toBe('pages[0].regions[0].components[0]');
+    });
+
+    it('the canonical key still wins over an alias on the same element (ADR-0089 ordering)', () => {
+      // Why the surviving alias limbs can only add coverage and never change a
+      // verdict: `visibleWhen` is read first, so a stale alias beside it is
+      // ignored rather than allowed to overrule the canonical spelling.
+      const stack = {
+        views: [
+          { name: 'f', sections: [{ visibleWhen: "record.ok == 1", visibleOn: "data.stale == 1", fields: [] }] },
+        ],
+      };
+      expect(validateVisibilityPredicates(stack)).toEqual([]);
+    });
   });
 
   it('flags a `data.`-rooted predicate in a runtime view as mis-layered', () => {
@@ -84,14 +131,16 @@ describe('validateVisibilityPredicates (ADR-0089 D3b)', () => {
     expect(findings[0].severity).toBe('warning');
   });
 
-  it('reports BOTH alias + mis-layer when a `visibleOn` predicate is `data.`-rooted', () => {
+  it('a `data.`-rooted predicate under `visibleOn` reports the mis-layer ALONE (#6318)', () => {
+    // Was: "reports BOTH alias + mis-layer". The alias half is retired; the
+    // surviving half — the mis-layer verdict is reached THROUGH the deprecated
+    // key — is what this now pins, as an exact one-element set.
     const stack = {
       views: [
         { name: 'task_form', sections: [{ visibleOn: "data.status == 'x'", fields: [] }] },
       ],
     };
-    const rules = validateVisibilityPredicates(stack).map((f) => f.rule).sort();
-    expect(rules).toEqual([VISIBILITY_ALIAS_DEPRECATED, VISIBILITY_ROOT_MISLAYERED].sort());
+    expect(validateVisibilityPredicates(stack).map((f) => f.rule)).toEqual([VISIBILITY_ROOT_MISLAYERED]);
   });
 
   it('does not confuse a field literally named `data` (e.g. `record.data`) for a data root', () => {
@@ -117,12 +166,20 @@ describe('validateVisibilityPredicates (ADR-0089 D3b)', () => {
   });
 
   it('walks legacy `groups` (alias of sections) too', () => {
+    // The `groups` bucket has no other test in this file, so the half-fact this
+    // used to carry — the traversal descends `groups` at all — had to survive
+    // #6318's retirement of the alias-KEY rule that used to demonstrate it. It
+    // is re-demonstrated with a rule that still exists, and with the alias key
+    // kept on the fixture so the group walk and the alias-value read are pinned
+    // together exactly as before.
     const stack = {
       views: [
-        { name: 'f', groups: [{ visibleOn: "record.a == 1", fields: [] }] },
+        { name: 'f', groups: [{ visibleOn: "data.a == 1", fields: [{ field: 'x', visibleWhen: 'approved' }] }] },
       ],
     };
-    expect(validateVisibilityPredicates(stack).map((f) => f.rule)).toEqual([VISIBILITY_ALIAS_DEPRECATED]);
+    const findings = validateVisibilityPredicates(stack);
+    expect(findings.map((f) => f.rule)).toEqual([VISIBILITY_ROOT_MISLAYERED, VISIBILITY_BARE_IDENTIFIER]);
+    expect(findings.map((f) => f.path)).toEqual(['views[0].groups[0]', 'views[0].groups[0].fields[0]']);
   });
 
   it('is clean on an empty / model-less stack', () => {
@@ -164,13 +221,21 @@ describe('validateVisibilityPredicates (ADR-0089 D3b)', () => {
       expect(validateVisibilityPredicates(stack, { layer: 'metadata' })).toEqual([]);
     });
 
-    it('still flags a deprecated alias key in the metadata layer (alias check is layer-agnostic)', () => {
+    it('reads the value through a deprecated alias key on the metadata layer too (#6318)', () => {
+      // Was: "still flags a deprecated alias key in the metadata layer (alias
+      // check is layer-agnostic)". The alias-KEY rule is retired, so the
+      // layer-agnostic claim about it is gone. What survives — and is the half
+      // that ever mattered — is that the alias-VALUE read is layer-agnostic:
+      // the same key feeds the layer-directional root verdict in BOTH
+      // directions. Pinned bidirectionally on one fixture, exact sets both ways.
       const stack = {
-        views: [{ name: 'f', sections: [{ visibleOn: "data.a == 1", fields: [] }] }],
+        views: [{ name: 'f', sections: [{ visibleOn: "record.a == 1", fields: [] }] }],
       };
-      const rules = validateVisibilityPredicates(stack, { layer: 'metadata' }).map((f) => f.rule);
-      // alias present, but `data.` is correct for the metadata layer → only the alias finding.
-      expect(rules).toEqual([VISIBILITY_ALIAS_DEPRECATED]);
+      // metadata layer forbids the runtime `record.` root → reported through the alias key…
+      expect(validateVisibilityPredicates(stack, { layer: 'metadata' }).map((f) => f.rule))
+        .toEqual([VISIBILITY_ROOT_MISLAYERED]);
+      // …and the same alias-spelled predicate is correct on the runtime layer.
+      expect(validateVisibilityPredicates(stack)).toEqual([]);
     });
 
     it('does not confuse an identifier ending in `record` (e.g. `my_record.x`) for a record root', () => {
@@ -236,10 +301,13 @@ describe('visibility-bare-identifier (#6128 / #5149 requirement 3)', () => {
       expect(bareFindings(stack).map((f) => f.path)).toEqual(['pages[0].regions[0].components[0]']);
     });
 
-    it('reads the value through the deprecated `visibleOn` alias too (alias + bare, both reported)', () => {
+    it('reads the value through the deprecated `visibleOn` alias too (bare ALONE since #6318)', () => {
+      // Was an "alias + bare, both reported" pair. The alias half is retired;
+      // the half this test existed for — the gate reaches a bare identifier
+      // written under the deprecated key — is unchanged and is now the whole
+      // expected set.
       const stack = { views: [{ name: 'f', sections: [{ visibleOn: "status == 'x'", fields: [] }] }] };
-      const rules = validateVisibilityPredicates(stack).map((f) => f.rule).sort();
-      expect(rules).toEqual([VISIBILITY_ALIAS_DEPRECATED, VISIBILITY_BARE_IDENTIFIER].sort());
+      expect(validateVisibilityPredicates(stack).map((f) => f.rule)).toEqual([VISIBILITY_BARE_IDENTIFIER]);
     });
 
     it('reads the value through the deprecated page-side `visibility` alias too', () => {
@@ -689,12 +757,14 @@ describe('visibility-predicate-syntax (#6253)', () => {
       expect(findings[0].where).toBe('page "p"');
     });
 
-    it('reads the value through the deprecated `visibleOn` alias (alias + syntax, both reported)', () => {
-      // Two independent defects on one element, so unlike the syntax/bare-ref
-      // pair these DO both report.
+    it('reads the value through the deprecated `visibleOn` alias (syntax ALONE since #6318)', () => {
+      // Was an "alias + syntax, both reported" pair, whose point was that two
+      // INDEPENDENT defects on one element both report. The alias half is
+      // retired, so what is left is the syntax verdict reached through the
+      // deprecated key — and the independence claim it was making now belongs
+      // to the syntax/bare-ref exclusivity pin, which states it directly.
       const stack = { views: [{ name: 'f', sections: [{ visibleOn: 'status === "x"', fields: [] }] }] };
-      expect(validateVisibilityPredicates(stack).map((f) => f.rule).sort())
-        .toEqual([VISIBILITY_ALIAS_DEPRECATED, VISIBILITY_PREDICATE_SYNTAX].sort());
+      expect(validateVisibilityPredicates(stack).map((f) => f.rule)).toEqual([VISIBILITY_PREDICATE_SYNTAX]);
     });
 
     it('reads the value through the deprecated page-side `visibility` alias', () => {

--- a/packages/lint/src/validate-visibility-predicates.ts
+++ b/packages/lint/src/validate-visibility-predicates.ts
@@ -7,33 +7,55 @@
  * canonical key **`visibleWhen`** across data fields, view form sections/fields,
  * and page components. The deprecated spellings — `visibleOn` (view form) and
  * `visibility` (page component) — stay accepted and are folded into `visibleWhen`
- * at the schema boundary (a zod `.transform()`).
+ * before this file ever sees them.
  *
- * **The fold does NOT happen during `parse()` (measured, #6073).** This header
- * used to say it did, and that running on the pre-parse (normalized) stack was
- * therefore enough to see what the author wrote. It is not: the ADR-0087 D2
- * conversions `view-visibleOn-to-visibleWhen` and
- * `page-component-visibility-to-visibleWhen` rename the key INSIDE
- * `normalizeStackInput` — whose output *is* the normalized tier. On all three
- * spec-valid alias sites (`views[].form.*`, `views[].formViews.*`,
- * `pages[].regions[].components[]`) `visibility-alias-deprecated` therefore
- * reports ZERO through every CLI door, `os lint` on a raw config included. The
- * only shape on which it still fires is `views[].sections[]` — the shape the
- * unit tests below use, and the one strict `ViewSchema` refuses. The author is
- * not left silent (the D2 conversion emits its own, better-worded notice naming
- * the protocol-16 retirement), so nothing is broken for a user today; #6318
- * carries the per-site table and the retire-or-rewire question.
+ * ## Why there is no alias-KEY rule here any more (#6318, retired)
  *
- * The other two rules in this file judge the predicate's **value**, which the
- * fold carries into `visibleWhen` intact — both still report normally on the
- * normalized tier, and neither is affected by the above.
+ * This file used to carry a fourth rule, `visibility-alias-deprecated`, whose
+ * whole job was to report the alias KEY. It was **unreachable on every real
+ * input shape** and is gone. The measurement, re-run at retirement time:
  *
- * One advisory rule pair (both `warning` — nothing is broken, the alias still
- * works and a mis-rooted predicate just never matches) plus TWO **gating** rules
- * (`error` — the predicate can never evaluate at all):
+ * | alias site | rule fed the RAW authored object | rule fed the `normalized` tier |
+ * |---|---|---|
+ * | `views[].form.sections[]` | 1 finding | **0** |
+ * | `views[].formViews.edit.sections[]` | 1 finding | **0** |
+ * | `pages[].regions[].components[]` | 1 finding | **0** |
  *
- * - `visibility-alias-deprecated` — a `visibleOn` / `visibility` key in authored
- *   source. Autofix intent: rename the key to `visibleWhen` (same value).
+ * The `normalized` tier is what all three commands hand this rule family
+ * (`authoring-rules.ts`, `input: 'normalized'`), and the ADR-0087 D2 conversions
+ * `view-visibleOn-to-visibleWhen` / `page-component-visibility-to-visibleWhen`
+ * rename the key INSIDE `normalizeStackInput` — whose output *is* that tier. So
+ * the key was always already gone. The one shape the rule did still fire on,
+ * `views[].sections[]` (a view CONTAINER with top-level sections), is the shape
+ * its own unit tests used and the one strict `ViewSchema` refuses outright:
+ * "Unrecognized key(s) on this view container: `sections`". A green unit test
+ * over a fixture production can never send — the #4984 / #6251 signature.
+ *
+ * **The surface is still guarded, and better.** The same D2 conversion shouts
+ * through `warnConversionNotice` in `defineStack`, with wording this rule never
+ * had — it names the site, the conversion, and the retirement window:
+ *
+ * ```
+ * defineStack: views[0].form.sections[0].visibleWhen: 'visibleOn' -> 'visibleWhen'
+ *   (converted at load; conversion 'view-visibleOn-to-visibleWhen', retires in protocol 16).
+ *   Update the source to the canonical shape — the conversion stops running then.
+ * ```
+ *
+ * So no working app lost a signal when the rule went: authors were never hearing
+ * this rule, and they do hear the conversion notice. Retired under ADR-0049
+ * (declared ≠ enforced) rather than re-anchored, because re-anchoring would have
+ * had to change `runAuthoringRules`' external input contract — a `packages/lint`
+ * public-API question that is the maintainer's to settle, not this file's.
+ * `authoring-rule-input-tier.test.ts` (premise 3) holds the regression pins.
+ *
+ * The three rules that remain judge the predicate's **value**, which the fold
+ * carries into `visibleWhen` intact — all three report normally on the
+ * normalized tier, and none was affected by the retirement.
+ *
+ * One advisory rule (`warning` — nothing is broken, a mis-rooted predicate just
+ * never matches) plus TWO **gating** rules (`error` — the predicate can never
+ * evaluate at all):
+ *
  * - `visibility-predicate-syntax` (**error**, #6253) — a predicate the canonical
  *   CEL front end refuses outright (`country === "USA"` — `===` is not CEL). See
  *   the §Syntax block below for why this surface has to say it and who owns the
@@ -205,7 +227,6 @@ import type { CelAstNode } from '@objectstack/formula';
 
 import { walkPageComponents } from './page-walk.js';
 
-export const VISIBILITY_ALIAS_DEPRECATED = 'visibility-alias-deprecated';
 export const VISIBILITY_ROOT_MISLAYERED = 'visibility-root-mislayered';
 export const VISIBILITY_BARE_IDENTIFIER = 'visibility-bare-identifier';
 export const VISIBILITY_PREDICATE_SYNTAX = 'visibility-predicate-syntax';
@@ -227,12 +248,12 @@ export interface VisibilityOptions {
 
 export interface VisibilityFinding {
   /**
-   * `warning` for the two ADR-0089 D3b advisories; `error` for the two rules
-   * that gate — `visibility-predicate-syntax` and `visibility-bare-identifier`
-   * (see module note).
+   * `warning` for the ADR-0089 D3b advisory (`visibility-root-mislayered`);
+   * `error` for the two rules that gate — `visibility-predicate-syntax` and
+   * `visibility-bare-identifier` (see module note).
    */
   severity: VisibilitySeverity;
-  /** Diagnostic rule id, e.g. `visibility-alias-deprecated`. */
+  /** Diagnostic rule id, e.g. `visibility-root-mislayered`. */
   rule: string;
   /** Human-readable location, e.g. `view "contact_form"`. */
   where: string;
@@ -246,9 +267,13 @@ export interface VisibilityFinding {
 
 type AnyRec = Record<string, unknown>;
 
-/** The canonical key and its two deprecated aliases (ADR-0089). */
+/**
+ * The canonical predicate key (ADR-0089). The two deprecated spellings
+ * (`visibleOn` / `visibility`) are read inline in `checkElement`, canonical-first
+ * — the `ALIASES` list that used to sit here existed only to iterate the retired
+ * alias-KEY rule, and went with it (#6318).
+ */
 const CANONICAL = 'visibleWhen';
-const ALIASES = ['visibleOn', 'visibility'] as const;
 
 /**
  * Every record in a collection authored either as an array or as a name-keyed
@@ -516,9 +541,13 @@ const MISLAYER_BY_LAYER: Record<
 };
 
 /**
- * Inspect one element carrying a visibility predicate. Emits the alias-deprecated
- * finding (when an alias key is present) and the mis-layered-root finding (when
- * the effective predicate's binding root does not match `layer`).
+ * Inspect one element carrying a visibility predicate. Emits the mis-layered-root
+ * finding (when the effective predicate's binding root does not match `layer`),
+ * the syntax finding, and the bare-identifier finding.
+ *
+ * There is no alias-KEY step here: `visibility-alias-deprecated` was retired
+ * under #6318 (see the module note for the per-site measurement and for the D2
+ * conversion notice that guards the surface instead).
  */
 function checkElement(
   el: AnyRec,
@@ -527,25 +556,19 @@ function checkElement(
   layer: VisibilityLayer,
   findings: VisibilityFinding[],
 ): void {
-  // (1) deprecated alias key present → steer to `visibleWhen`.
-  for (const alias of ALIASES) {
-    if (el[alias] !== undefined) {
-      findings.push({
-        severity: 'warning',
-        rule: VISIBILITY_ALIAS_DEPRECATED,
-        where,
-        path: `${path}.${alias}`,
-        message:
-          `\`${alias}\` is the deprecated spelling of the conditional-visibility ` +
-          `predicate (ADR-0089). It still works — it is normalized to \`visibleWhen\` ` +
-          `at parse — but the canonical key is \`visibleWhen\`.`,
-        hint: `Rename the key \`${alias}\` → \`visibleWhen\` (same CEL value).`,
-      });
-    }
-  }
-
-  // (2) mis-layered binding root — check the effective predicate (canonical wins)
+  // (1) mis-layered binding root — check the effective predicate (canonical wins)
   // against the root expected for this layer.
+  //
+  // The two alias limbs STAY, and are not the thing #6318 retired. That issue is
+  // about the alias KEY as a verdict; this is the predicate VALUE, and the value
+  // is what all three surviving rules judge. Through the three CLI commands the
+  // limbs are already unreachable (the D2 fold renamed the key one layer up), but
+  // `validateVisibilityPredicates` is a PUBLISHED export that a caller — this
+  // package's own unit tests included — may hand a raw authored object, and on
+  // that door an alias-spelled predicate must still be judged rather than skipped
+  // silently. Ordering is canonical-first per ADR-0089, so an alias can never
+  // override a `visibleWhen` that is present: the limbs can only ever add
+  // coverage, never change a verdict.
   const raw = el[CANONICAL] ?? el.visibleOn ?? el.visibility;
   const source = predicateSource(raw);
   const rule = MISLAYER_BY_LAYER[layer];
@@ -560,7 +583,7 @@ function checkElement(
     });
   }
 
-  // (3) #6253 — the canonical CEL front end refuses the source outright. GATES,
+  // (2) #6253 — the canonical CEL front end refuses the source outright. GATES,
   // at the severity every other predicate surface already applies to a syntax
   // fault (ADR-0032 via `validateExpression`); this surface is the one that had
   // no such gate, so a `===` shipped clean and then failed OPEN in the console.
@@ -586,13 +609,13 @@ function checkElement(
     });
   }
 
-  // (4) #6128 — a reference no binding root can resolve. Unlike (2) this one
+  // (3) #6128 — a reference no binding root can resolve. Unlike (1) this one
   // GATES: a mis-rooted predicate is at least a statement about a namespace
   // someone binds somewhere, while a bare identifier resolves nowhere, on no
   // layer, under neither a total nor a sparse record (#4953) — so there is no
   // reading of the metadata under which it was going to work.
   //
-  // Skipped when (3) fired: the declaredness check needs an AST, and a source
+  // Skipped when (2) fired: the declaredness check needs an AST, and a source
   // that does not parse has none. Written as an explicit `else` rather than
   // relying on `firstBareIdentifier`'s own null-AST guard, so the one-finding
   // -per-broken-predicate property is visible at the call site instead of
@@ -680,12 +703,17 @@ function formViewSites(
 }
 
 /**
- * Validate conditional-visibility keys across authored views and pages.
+ * Validate conditional-visibility predicates across authored views and pages.
  *
- * Runs on the **pre-parse** (normalized) stack so it can see the deprecated
- * `visibleOn` / `visibility` aliases before the schema folds them into
- * `visibleWhen`. Returns findings (empty = clean). The two ADR-0089 D3b rules
- * are advisory (`warning`); `visibility-predicate-syntax` (#6253) and
+ * Every rule here judges the predicate's **VALUE**, which survives both the
+ * ADR-0087 D2 alias fold and the Zod parse intact — so the registered
+ * `normalized` tier sees exactly what a `parsed` one would. (It is registered
+ * `normalized` for the tier's surviving reason, not the retired one: a
+ * normalized-tier finding still reaches the author when an unrelated schema
+ * error elsewhere would have stopped the parse. See `AuthoringRuleInputTier`.)
+ *
+ * Returns findings (empty = clean). `visibility-root-mislayered` is advisory
+ * (`warning`); `visibility-predicate-syntax` (#6253) and
  * `visibility-bare-identifier` (#6128) are `error` and the caller is expected to
  * fail the build on them.
  *
@@ -693,7 +721,7 @@ function formViewSites(
  * `opts.layer = 'metadata'` when linting a `*.form.ts` metadata-editing form (so a
  * `record.`-rooted predicate is flagged), or leave it at the `'runtime'` default for
  * `*.view.ts` / `*.page.ts` surfaces (so a `data.`-rooted predicate is flagged). The
- * alias-deprecated check is layer-agnostic.
+ * syntax and bare-identifier checks are layer-agnostic.
  */
 export function validateVisibilityPredicates(
   stack: AnyRec,


### PR DESCRIPTION
Fixes #6318

退役 `packages/lint` 的 `visibility-alias-deprecated` —— 一条在任何真实 CLI 输入形状上都**永不触发**的规则。

## 复现:我自己重测了一遍(base `3510e4a2`,非引用立单人的 `a7e7851`)

规则注册为 `input: 'normalized'`,三条命令(`os validate` / `os build` / `os lint`)交给它的就是 `normalizeStackInput` 的**输出**;而折叠别名的两条 ADR-0087 D2 转换(`view-visibleOn-to-visibleWhen`、`page-component-visibility-to-visibleWhen`)跑在 `normalizeStackInput` **之内**,比这一层高一层。所以规则拿到手时 key 已经被改名了。

逐 site 实测(spec/lint 均本地 `dist` 构建后测):

| 别名 site | 规则读**原始对象**(= 老单测的喂法) | 规则读 `normalized` 层(= 三条命令的喂法) |
|---|---|---|
| `views[].form.sections[].visibleOn` | 1 finding | **0** |
| `views[].formViews.edit.sections[].visibleOn` | 1 finding | **0** |
| `pages[].regions[].components[].visibility` | 1 finding | **0** |
| `views[].sections[].visibleOn`(老单测 `:42` 用的形状) | 1 finding | 1 finding |

最后一行是唯一还能报的形状,而它被 `.strict()` 的 `ViewSchema` 直接拒收:

```
Unrecognized key(s) on this view container: `sections`. Until #4001 closed these
shapes an unknown key was dropped silently — the view still rendered, without
whatever the key was meant to configure.
```

同时确认折叠确实发生在 `normalizeStackInput` 内:

```
normalized section keys: ["label","fields","visibleWhen"]
visibleWhen value      : "record.a == 1"
visibleOn still there? : false
```

**单测绿,是因为 fixture 用的形状生产环境永远不会送进来** —— #4984 / #6251 那一族的签名。

## 走的是「退役」,另一条为什么出界

立单正文写明:重锚要让规则读真正的 pre-parse 值,**会改动 `runAuthoringRules` 的对外输入契约**,属于 `packages/lint` 公共 API 的措辞问题,「须由维护者定」。我的实测没有推翻这一点 —— 折叠位置正如立单所述,重锚确实需要一个 `runAuthoringRules` 今天不接受的输入层。所以按 ADR-0049(declared ≠ enforced)退役,不自行改公共输入契约。

## 这个面为什么现在算「有守卫」

同一条 D2 转换在 `defineStack` 里经 `warnConversionNotice` 喊出来,措辞比规则本身更好(点名 site、转换 id、退役窗口):

```
defineStack: views[0].form.sections[0].visibleWhen: 'visibleOn' -> 'visibleWhen'
  (converted at load; conversion 'view-visibleOn-to-visibleWhen', retires in protocol 16).
  Update the source to the canonical shape — the conversion stops running then.
```

**没有任何在用的 app 因此少了一个信号**:作者本来就听不见这条规则,而转换通知他们听得见。这条理由记录在三处,免得下一个读者把它重新当成覆盖漏洞再立一单:规则文件的模块头、`authoring-rules.ts` 的注册块注释、以及 `authoring-rule-input-tier.test.ts` 里那条把通知本身钉住的断言(注释写明:此断言若变红,退役的前提就没了,应重开 #6318,而不是删断言)。

## 退役不是只删 —— 每条断言替换成了什么

⚠️ 「别名不再报」在规则删掉后是**空真**。所以每条负向断言都配了正向:断言的是**精确 finding 集合**且**非空**,不能靠「什么都没产出」而通过。

| 原断言钉的 | 幸存的那半个事实 | 替换后钉的 |
|---|---|---|
| form section 上 `visibleOn` → 1 条 alias finding | 遍历到得了 section;`checkElement` 仍**经别名 key 读谓词值** | 同 site 放 `data.`-rooted 值 → 精确 `['visibility-root-mislayered']`,path `views[0].sections[0]` |
| form field 上 `visibleOn` → alias finding | 同上,field 载体 | 精确 `['visibility-root-mislayered']`,path `views[0].sections[0].fields[0]` |
| page component 上 `visibility` → alias finding | 同上,page component 载体 | 精确 `['visibility-root-mislayered']`,path `pages[0].regions[0].components[0]` |
| alias + mis-layer **两条都报** | mis-layer 判决是**穿过别名 key**拿到的 | 精确 `['visibility-root-mislayered']`(单元素集) |
| 走 legacy `groups` 桶 | **`groups` 桶被遍历**这件事本身 —— 全文件没有第二条测它 | `groups` 上放 mis-layer + bare 两个值缺陷,断言精确 rules 与 paths 两个数组 |
| metadata 层仍报 alias(「alias 检查与层无关」) | 与层无关的是**别名值的读取**:同一个 key 双向喂进层向判决 | 同一 fixture 双向断言:metadata 层 `['visibility-root-mislayered']`,runtime 层 `[]` |
| alias + bare 两条都报 | gate 能读到写在别名 key 下的裸标识符 | 精确 `['visibility-bare-identifier']` |
| alias + syntax 两条都报 | syntax 判决同样穿过别名 key | 精确 `['visibility-predicate-syntax']` |
| 层级单测 premise 3:raw 1 条 / normalized 0 条 | **key 过不了折叠、value 过得了** | 见下 |

新增一条正向断言(`the canonical key still wins over an alias on the same element`):同一元素上 `visibleWhen` 与 `visibleOn` 并存时按 ADR-0089 规范先读 canonical —— 这解释了保留的两条别名读取支**只可能增加覆盖、永远改不了判决**。

### 层级单测 premise 3

原来两条腿:raw `toHaveLength(1)` / normalized `toEqual([])`。退役后 raw 腿变 0、normalized 腿保持 `[]` —— 但**后者已成空真**(空是因为没规则了,不是因为折叠)。所以:

- 保留 raw/normalized 那条并**如实标注 normalized 腿是空真**,它只作为退役本身的直述;
- **新增**一条用同样三个 site、但谓词换成裸标识符(值缺陷)的 `it.each`:先断言 normalized 层字符串里既没有 `visibleOn` 也没有 `"visibility"`,再断言精确 `['visibility-bare-identifier']`。这条**非空、能失败**,它才是真正测量折叠的那条 —— 若折叠丢了谓词、或幸存规则读不到它,集合会变空而断言失败。

`the author is NOT left silent`(转换通知)与 `the predicate-VALUE rules are unaffected` 两条原样保留,它们本就是正向证据。

## 兄弟规则未受牵连(证明)

同文件另三条判的是**谓词值**,值在折叠后原样搬进 `visibleWhen`。规则恢复前后、在 `normalized` 层实测:

```
mislayered (data.-rooted, via visibleOn): ["visibility-root-mislayered"]
bare identifier (via visibleOn)         : ["visibility-bare-identifier"]
```

`checkElement` 里 `el[CANONICAL] ?? el.visibleOn ?? el.visibility` 这条读取**保留**,并在代码里写明理由:它读的是**值**不是 key 的判决,`validateVisibilityPredicates` 是已发布导出、调用方(含本包单测)可能直接喂原始对象,而 canonical-first 的次序保证别名永远盖不过 `visibleWhen`。

## 反向验证 —— 先声明,后运行

方向与常规**相反**,声明先落盘再跑。恢复规则(仅源文件 + barrel,测试保持替换后的样子):

- **声明 (A) 会红**:所有在**原始对象**这道门上断言精确集合的替换项 —— 7 组。
- **声明 (B) 会绿**:所有在 `normalized` 层测量的断言 —— 因为折叠比规则所在层高一层,恢复规则改不了那一层。**这就是本单的缺陷本身,被写成了测试。**

实测:

- (A) **13 个用例红**,恰是那 7 组(`it.each` 与 describe 展开后的个数),失败全部是集合不等而非空/非空之差,例如 `expected [ 'visibility-alias-deprecated', …(1) ] to deeply equal [ 'visibility-root-mislayered' ]`。
- (B) 规则恢复后单独测量 `normalized` 层:

```
RULE RESTORED — normalized tier:
  views[].form.sections[]              ["visibility-bare-identifier"]
  views[].formViews.edit.sections[]    ["visibility-bare-identifier"]
  pages[].regions[].components[]       ["visibility-bare-identifier"]
RULE RESTORED — raw door (for contrast):
  views[].form.sections[]              ["visibility-alias-deprecated","visibility-bare-identifier"]
  ...
```

与退役后的结果**逐字相同** —— 绿,如声明。恢复规则只改变 raw 那道门,对三条命令实际走的 `normalized` 层毫无影响。**声明与实测一致**,无分歧。

## 空真断言的如实标注

- 层级单测 premise 3 的 **normalized 腿**(`toEqual([])`):对**折叠**而言是空真,已在代码注释中明确标注,不计作证据;测量折叠的是新增的非空那条。
- 顺带一个实测到的细节:`a visibleOn KEY with a clean value is clean` 这条虽然对折叠空真,但它测在 **raw** 门上,恢复规则时确实会红 —— 即它对**退役本身**不空真。注释按这个精度写,没有含糊带过。

## barrel

`VISIBILITY_ALIAS_DEPRECATED` 从 `packages/lint/src/index.ts` 的已发布 barrel 移除(`barrel_touched: true`)。`rule-id-barrel-exports.test.ts` 两个方向都过:规则文件不再声明它,barrel 也不再导出它。

## changeset

`.changeset/visibility-alias-deprecated-retired.md` —— `@objectstack/lint: minor`。

选 `minor` 而非 `major`:移除已发布导出是破坏性的,但仓规在发布窗口内把破坏性变更一律降到 `minor`(`scripts/check-changeset-no-major.mjs`:全仓 lockstep,任何一个 `major` 会把约 70 个包整体推到下一个大版本;pre-1.0 语义下破坏性变更不烧主版本号)。实测在库存 changeset 里 `@objectstack/lint` 是 38 minor / 34 patch / **0 major**。选 `minor` 而非 `patch`,因为这是**已发布面的变更**而非缺陷修复。

正文含破坏性标记(`refactor(lint)!:`),因此按仓规带 ADR-0087 处置行,取可机检的 `not-required (already-registered ...)`:作者能写的别名面本来就由那两条 D2 转换承载,本 PR 不动它们;变的只是一个 TS 导出面上的规则 id,没有任何 authored/stored 元数据形状变化。已过 `check:adr-0087-registration`。

## Gates

| gate | 结果 |
|---|---|
| `pnpm lint` (eslint) | pass(无输出) |
| `pnpm --filter @objectstack/lint test` | pass — **62 files / 1584 tests** |
| `pnpm --filter @objectstack/cli test` | pass — **91 files / 928 tests** |
| `pnpm check:type-check-debt` | pass — `@objectstack/lint` 19 → **19**(ledger 上限 42,未动 ledger) |
| `turbo run typecheck` (lint + cli) | pass — 56 tasks |
| `pnpm check:nul-bytes` + `grep -naP` 自扫 | pass — 无控制字节 |
| `check:adr-0087-registration` / `check:empty-changeset` / `check-changeset-no-major` | pass |
| `check:spec-parsed-alias` / `adr-anchors` / `published-files` / `engine-double-contract` / `error-code-casing` / `route-envelope` / `doc-authoring` / `quick-reference-counts` / `release-notes` / `objectui-changeset` | pass |

`check:type-check-debt` 按提示先跑了 `turbo run build --filter='./packages/*' --filter='./packages/*/*'` 建全闭包再测,否则它会拒跑(未建闭包时测的是「另一个世界」)。

## 文件面

- `packages/lint/src/validate-visibility-predicates.ts`
- `packages/lint/src/authoring-rules.ts`(注册块注释 + `AuthoringRuleInputTier` premise 3 段)
- `packages/lint/src/index.ts`(barrel)
- `packages/lint/src/validate-visibility-predicates.test.ts`
- `packages/lint/src/authoring-rule-input-tier.test.ts`
- `.changeset/visibility-alias-deprecated-retired.md`

未碰:`packages/spec/src/conversions/registry.ts`(D2 转换是**证据**不是待修点)、同文件另三条规则的判决逻辑、`content/docs/releases/`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDmDsu2575gDxeMCxXhDE3)_