### PR TITLE
fix(client): data.find 的 top/skip 按存在性发射，limit: 0 不再被静默丢弃 (#6485)

### DIFF
--- a/.changeset/client-find-pagination-presence.md
+++ b/.changeset/client-find-pagination-presence.md
@@ -1,0 +1,46 @@
+---
+"@objectstack/client": patch
+---
+
+fix(client): `data.find()` emits `top`/`skip` on presence, so `limit: 0` reaches the server (#6485)
+
+Both `find` implementations — `ObjectStackClient.data.find` and its
+byte-identical `ScopedProjectClient.data.find` copy — emitted the two pagination
+transport params on **truthiness**:
+
+```ts
+if (normalizedOptions.top) queryParams.set('top', normalizedOptions.top.toString());
+if (normalizedOptions.skip) queryParams.set('skip', normalizedOptions.skip.toString());
+```
+
+while the canonical normalizer ten lines above already tested **presence**
+(`if (v2.limit != null) normalizedOptions.top = v2.limit`). So `0` survived the
+normalizer and was then discarded by the emitter. Both now test presence, in
+both copies.
+
+**What changes on the wire, and why that is the fix rather than a preference.**
+`find('task', { limit: 0 })` — and equally `{ top: 0 }` — used to reach the
+server with **no `top` param at all**. The GET list route has no default page
+size, so an absent `top` returns the *entire* match set: the caller who asked
+for no records received every record, under HTTP 200 with no warning.
+
+The direction was measured before the change rather than assumed, because a
+client fix is only worth having if the server honours what it sends:
+
+| layer | `top=0` |
+|:---|:---|
+| REST list route → `ObjectStackProtocolImplementation.findData` | not rejected, not ignored — folds `top` into `limit`, coerces `Number('0')`, forwards `{ limit: 0 }` to the engine; envelope reports `total: 0, hasMore: false` |
+| `SqlDriver.find` (the driver behind the default file-backed SQLite datasource, and every Postgres/MySQL deployment) | paginates on presence — `LIMIT 0`, **zero rows** |
+| `TursoRemoteTransport` | presence — `LIMIT ?` bound to `0`, zero rows |
+
+So `limit: 0` now means "return no records" end to end, which is what the
+canonical branch already implied.
+
+**`offset: 0` / `skip: 0` were dropped too, and that half is a consistency
+change with no behavioural consequence** — `skip=0` is already the server's
+default, so the request means the same thing whether the param is sent or not.
+They are aligned because one emitter must not hold two rules for one pair, not
+because a wrong answer was being returned.
+
+Callers passing a non-zero `limit`/`top`/`offset`/`skip`, or omitting them
+entirely, are unaffected — the emitted query string is byte-identical.

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1337,6 +1337,40 @@ describe('data.find() — canonical/legacy transport parameters (both copies)', 
         // change that fixes one vocabulary by breaking the other goes red.
         'legacy single key: { top }': { options: { top: 20 }, wire: 'top=20' },
         'legacy single key: { skip }': { options: { skip: 5 }, wire: 'skip=5' },
+
+        // ── #6485: ZERO IS A VALUE, NOT AN ABSENCE ──────────────────────────
+        //
+        // The two pagination params were emitted on TRUTHINESS
+        // (`if (normalizedOptions.top)`) while the canonical branch ten lines
+        // above already normalized them on PRESENCE (`if (v2.limit != null)`).
+        // So `0` survived the normalizer and was then discarded by the
+        // emitter, in both copies.
+        //
+        // `limit: 0` is the half that changes the answer, and the direction is
+        // measured, not assumed. Through the REST list route
+        // (`ObjectStackProtocolImplementation.findData`) `top=0` is neither
+        // rejected nor ignored: it folds to `limit: 0` and reaches the engine,
+        // and `SqlDriver.find` — the driver behind the default file-backed
+        // SQLite datasource — applies pagination on presence
+        // (`if (query.limit !== undefined) b.limit(query.limit)`), so the
+        // statement carries `LIMIT 0` and answers with zero rows. Dropping the
+        // param instead did NOT mean "the server's default page": this route
+        // has no default page size, so an absent `top` returns the ENTIRE
+        // match set. `find('task', { limit: 0 })` therefore answered with every
+        // record when it asked for none — HTTP 200, no warning.
+        //
+        // `offset: 0` / `skip: 0` are the consistency half: `skip=0` is already
+        // the server's default, so sending it or omitting it means the same
+        // thing. They are pinned here because the emitter must not have two
+        // rules for one pair, not because the wire meaning changed.
+        'canonical zero: { limit: 0 }': { options: { limit: 0 }, wire: 'top=0' },
+        'canonical zero: { offset: 0 }': { options: { offset: 0 }, wire: 'skip=0' },
+        'legacy zero: { top: 0 }': { options: { top: 0 }, wire: 'top=0' },
+        'legacy zero: { skip: 0 }': { options: { skip: 0 }, wire: 'skip=0' },
+        'canonical zero pair: { limit: 0, offset: 0 }': {
+            options: { limit: 0, offset: 0 },
+            wire: 'top=0&skip=0',
+        },
         'canonical: where + limit': {
             options: { where: { contact_id: 'c1' }, limit: 20 },
             wire: 'top=20&contact_id=c1',
@@ -1374,6 +1408,28 @@ describe('data.find() — canonical/legacy transport parameters (both copies)', 
         const legacy = await driveBoth(LEGACY_FULL);
         expect(canonical.direct).toBe(legacy.direct);
         expect(canonical.scoped).toBe(legacy.scoped);
+    });
+
+    /**
+     * [#6485] `{ limit: 0 }` and `{}` are DIFFERENT REQUESTS, and the wire has
+     * to be able to tell them apart.
+     *
+     * The table rows above pin each spelling's exact query string. This asserts
+     * the property those rows exist for: the two bags must not collapse onto
+     * one wire. Stated as an inequality rather than as two more literals
+     * because the defect was precisely a collapse — `top` absent in both cases,
+     * so the caller who asked for no records and the caller who asked for
+     * everything sent byte-identical requests and got byte-identical answers.
+     *
+     * Both copies, one property: a fix landing on only one of them leaves the
+     * other's pair equal and this goes red.
+     */
+    it('`{ limit: 0 }` is distinguishable from `{}` on the wire, on both copies', async () => {
+        const zero = await driveBoth({ limit: 0 });
+        const absent = await driveBoth({});
+
+        expect(zero.direct).not.toBe(absent.direct);
+        expect(zero.scoped).not.toBe(absent.scoped);
     });
 
     /**

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -4221,8 +4221,23 @@ export class ObjectStackClient {
         }
 
         // 1. Handle Pagination
-        if (normalizedOptions.top) queryParams.set('top', normalizedOptions.top.toString());
-        if (normalizedOptions.skip) queryParams.set('skip', normalizedOptions.skip.toString());
+        //
+        // [#6485] PRESENCE, not truthiness — the same test the canonical
+        // normalizer directly above already applies (`if (v2.limit != null)`).
+        // Emitting on truthiness made `0` survive the normalizer and then be
+        // discarded here, so `find('task', { limit: 0 })` reached the server
+        // with no `top` param. The GET list route has no default page size, so
+        // an absent `top` returns the ENTIRE match set: the caller who asked
+        // for no records got every record, under a 200 with no warning.
+        // `top=0` is honoured end to end — the protocol normalizer folds it to
+        // `limit: 0` and forwards it, and `SqlDriver.find` paginates on
+        // presence too, so the statement carries `LIMIT 0` and answers empty.
+        // `skip=0` is a consistency change only: it already equals the
+        // server's default, so the request means the same either way — but one
+        // emitter must not hold two rules for one pair.
+        // Mirrored verbatim in `ScopedProjectClient.data.find`.
+        if (normalizedOptions.top != null) queryParams.set('top', normalizedOptions.top.toString());
+        if (normalizedOptions.skip != null) queryParams.set('skip', normalizedOptions.skip.toString());
 
         // 2. Handle Sort
         if (normalizedOptions.sort) {
@@ -4905,8 +4920,10 @@ export class ScopedProjectClient {
         Object.assign(normalizedOptions, options);
       }
 
-      if (normalizedOptions.top) queryParams.set('top', normalizedOptions.top.toString());
-      if (normalizedOptions.skip) queryParams.set('skip', normalizedOptions.skip.toString());
+      // [#6485] Presence, not truthiness — see the twin in
+      // `ObjectStackClient.data.find` for why `0` must reach the wire.
+      if (normalizedOptions.top != null) queryParams.set('top', normalizedOptions.top.toString());
+      if (normalizedOptions.skip != null) queryParams.set('skip', normalizedOptions.skip.toString());
       if (normalizedOptions.sort) {
         if (Array.isArray(normalizedOptions.sort) && typeof normalizedOptions.sort[0] === 'object') {
           queryParams.set('sort', JSON.stringify(normalizedOptions.sort));


### PR DESCRIPTION
Fixes #6485

两处 `find`（`ObjectStackClient.data.find` 与 `ScopedProjectClient.data.find` 的逐字节副本）都以**真值**判断发射分页参数，而其上方十行的 canonical normalizer 早已按**存在性**判断（`if (v2.limit != null)`）。于是 `0` 通过了 normalizer，又被发射端丢掉。两处一并改为 `!= null`。

## 行号漂移

卡片正文记的是 `eb7613c` 上的 `:4224`/`:4225` 与 `:4908`/`:4909`；两条分诊评论分别在 `b7d3be4` 读到 `:4104`/`:4105`、`:4778`/`:4779`，在 `3a1d9c7` 读到 `:4225`/`:4909`。本次在 `53ef05744` 上**按内容定位**，落点回到 `:4224`/`:4225` 与 `:4908`/`:4909` —— 与卡片正文数字重合纯属巧合，中间三次读数各不相同。所以按 pattern 找，不要信任何一处记下的行号。

## 前提复现（改动前，在 `origin/main` 上量的）

新增断言直接跑在未修复的源码上，6 条红：

```
FAIL  canonical zero: { limit: 0 } → `top=0` on both copies
AssertionError: expected '' to be 'top=0'
```

`{ limit: 0 }` 发出的是**空查询串** —— 一个 `top` 参数都没有。

## 服务端 `top=0` 到底怎么处理：先测后改

这半边是本卡的关键。客户端把 `top=0` 发出去，只有在服务端真的认这个值时才算修好。三层都实测过，不是读代码推的：

| 层 | `top=0` 的实测行为 |
|:---|:---|
| REST 列表路由 → `ObjectStackProtocolImplementation.findData` | **既不拒绝也不忽略**。`top` 折叠进 `limit`，`Number('0')` 得 0，`{ limit: 0 }` 原样转发给引擎；信封给出 `total: 0, hasMore: false` |
| `SqlDriver.find`（默认文件型 SQLite 数据源背后的驱动，也是 Postgres/MySQL 部署用的那个） | 按存在性分页 —— `LIMIT 0`，**零行** |
| `TursoRemoteTransport` | 同样按存在性 —— `LIMIT ?` 绑 0，零行 |

探针输出：

```
PROBE top="0" => { engineFindOptions: { limit: 0 }, result: { records: 0, total: 0, hasMore: false } }
PROBE sql-driver => {"limit0_rows":0,"limit2_rows":2,"noLimit_rows":3}
```

即派发单列的三种结局里的第一种：服务端返回零记录，修复如描述般正确。

**顺带纠正卡片正文一处措辞**：丢掉 `top` 之后拿到的不是「服务端默认页大小」—— 这条 GET 列表路由**没有默认页大小**。实测 `no top` 一栏返回 3/3 全量。所以 `find('task', { limit: 0 })` 的旧行为是「要零条、给全部」，比「给一页」更糟。

## `offset: 0` / `skip: 0`：这半边是一致性修改，没有行为后果

明说，不包装成 bug fix：`skip=0` 本就是服务端默认值，发不发这个参数请求含义相同。改它的理由只有一个 —— 一个发射端不该对同一对参数持两套规则。

## 测试：结构上保证半边修复必红

复用 #6322 建立的 `driveBoth` 表格 —— 同一组 options 同时驱动两份 `find`，比对**同一个**期望查询串。新增 5 行表项（`{ limit: 0 }` / `{ offset: 0 }` / `{ top: 0 }` / `{ skip: 0 }` / `{ limit: 0, offset: 0 }`），外加一条性质断言：`{ limit: 0 }` 与 `{}` 在线上必须**可区分**（旧代码里两者都发空串，正是这个坍缩本身）。

### 反向验证：先写下预测，再跑

| 方向 | 预测红 | 实测红 | 失败断言 |
|:---|:---|:---|:---|
| 两份都回退（= `origin/main`） | 6 | **6** | `expect(direct)` L1401 |
| 只回退主 client 一份 | 6 | **6** | `expect(direct)` L1401 |
| 只回退 `ScopedProjectClient` 一份 | 6 | **6** | `expect(scoped)` L1402 |

第三行是本卡要的那条约束：只修一份，另一份的 `scoped` 断言就红。6 条断言**没有一条**在两个方向都是绿的，所以没有需要从红计数里剔除的「不变量 pin」。

## 门禁（真实输出，非声明）

- `pnpm --filter @objectstack/client test` → `Test Files 21 passed (21) / Tests 269 passed (269)`
- `pnpm --filter @objectstack/client typecheck` → `tsc --noEmit` 通过；`check:test-typecheck: OK — 0 file(s) / 0 error(s)`
- `pnpm lint` → 无输出（干净）
- `lint.yml` 枚举的全部 `check:*`：37 条根级门禁 + 11 条 spec 门禁全 PASS，含 `check:query-options-erasure`、`check:route-envelope`、`check:error-code-casing`、`check:engine-double-contract`、`check:nul-bytes`
- `turbo run typecheck --filter='./packages/*' --filter='./packages/*/*' --filter='./apps/*'` → `120 successful, 120 total`
- `check:i18n` / `check:i18n-coverage` 首轮报的是**前置条件未满足**（本 worktree 未构建 CLI），不是发现；补齐构建后两条均 PASS（`12 config(s), 660 baselined, none new`）
- 控制字节自查：`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` 三个改动文件均无命中；`check:nul-bytes` OK

## Changeset

`@objectstack/client: patch`。判断依据：这是缺陷修复，不新增 API、不新增选项、不移除能力；行为变化只落在 `limit: 0` / `top: 0` 这一组此前返回**明确错误答案**的输入上。变更正文把 wire 行为变化写明，以便进入 release notes。

## 范围外发现

- **#6577** — `InMemoryDriver.find` 同样按真值判断 `limit`，`limit: 0` 返回全表（实测 3/3），与 `SqlDriver` 的零行结果相反。本卡文件面只限 `packages/client/src/index.ts`，故按 Prime Directive #10 另开、未认领。该 issue 同时列出 `sql-driver` 自身两处窗口函数/explain 门、`memory-analytics` 两处同形代码，以及 MongoDB「`limit: 0` 即无限制」这一**不应照同一方式修**的边界。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uFVNMmTxLpmfQYiuKM1Yx

---
_Generated by [Claude Code](https://claude.ai/code/session_017uFVNMmTxLpmfQYiuKM1Yx)_