### PR TITLE
fix(analytics): `where` 门拒收 `$` 算子与非 `$` 键混写的字段约束（#6444）

### DIFF
--- a/.changeset/mixed-wrapper-refusal.md
+++ b/.changeset/mixed-wrapper-refusal.md
@@ -1,0 +1,43 @@
+---
+'@objectstack/service-analytics': patch
+---
+
+fix(analytics): a field constraint mixing `$` operators with non-`$` sibling keys is refused (400 `INVALID_FILTER`), not silently narrowed to its operators
+
+**Observable behaviour change.** A `where` field wrapper that carries `$`-operator
+keys and non-`$` keys at once used to compile its operators and silently DROP
+every non-`$` sibling. It is now refused with `INVALID_FILTER` / 400, the
+envelope every other refusal at this door already carries. Ruled Option A
+(refuse) on #6444, 2026-08-08; Option B (flattening the siblings as nested
+paths) was rejected because it would compile the likely-real cause — a dropped
+`$` — into a predicate on a non-existent member such as `amount.gte`.
+
+| `where` | used to normalize to | reading |
+|---|---|---|
+| `{d: {$eq: 1, nested: 'x'}}` | `d equals [1]` | the `nested` conjunct vanished in silence |
+| `{amount: {gte: 10, $lte: 20}}` | `amount lte 20` | the missing-`$` typo: the lower bound silently gone |
+| `{$not: {d: {$null: true, nested: 'x'}}}` | `NOT(d set AND d notSet)` | a contradiction that negates to TRUE — every row |
+
+Every row WIDENED the query — a dropped conjunct returns rows the author
+excluded, with nothing to read (the #3650 family this module refuses everywhere
+else). Unlike #6386's `undefined` comparand, this shape survives JSON, so it can
+sit in stored dashboard / report / dataset metadata as well as in-process
+callers of `AnalyticsService.query({ where })`.
+
+**What to change if this refuses your filter.** The message names the offending
+key(s) and both repairs, because the shape has two readings this door cannot
+tell apart:
+
+- an operator missing its `$` was meant → spell it with the prefix
+  (`gte` → `$gte`: `{ "amount": { "$gte": 10, "$lte": 20 } }`);
+- a nested-relation member was meant → give it a wrapper of its own with no `$`
+  siblings (`{ "d": { "nested": "x" } }` compiles to the member `d.nested`) and
+  AND it with the operator constraint explicitly via `$and`.
+
+⛔ **The two pure shapes do not move.** A wrapper that is all `$`-operators
+compiles exactly as before (`{amount: {$gte: 10, $lte: 20}}` stays the AND of
+its bounds), and a wrapper that is all non-`$` keys keeps flattening to the
+dotted member (`{d: {nested: 'x'}}` → `d.nested`). `$null` / `$exists` flag
+semantics, the `null` comparand rulings (#5332 / #5526) and the sibling door
+`read-scope-sql.ts` — which has always failed closed on this shape — are
+untouched.

--- a/packages/services/service-analytics/src/__tests__/filter-normalizer-mixed-wrapper.test.ts
+++ b/packages/services/service-analytics/src/__tests__/filter-normalizer-mixed-wrapper.test.ts
@@ -1,0 +1,354 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#6444, ruled Option A on 2026-08-08] A field wrapper mixing `$`-operator
+ * keys with non-`$` sibling keys is REFUSED — `INVALID_FILTER` / 400 — and the
+ * two pure shapes on either side of it do not move.
+ *
+ * ## What was wrong
+ *
+ * The value-independent sibling of #6386, in the same function. `fieldLeaves`'s
+ * operator arm iterated `opKeys` only and returned, and the nested-relation
+ * flatten sits after that early return — so with even one `$` key in the
+ * wrapper, every non-`$` sibling was silently dropped, whatever its value.
+ * Measured on `origin/main` (`1a53a0253`) by calling
+ * `normalizeAnalyticsFilterTree({ where })` directly:
+ *
+ * | `where`                                   | normalized to             | reading |
+ * |---|---|---|
+ * | `{d: {$eq: 1, nested: 'x'}}`              | `d equals [1]`            | the `nested` conjunct vanished in silence |
+ * | `{d: {$eq: 1, nested: undefined}}`        | `d equals [1]`            | same — value-independent, unlike #6386 |
+ * | `{amount: {gte: 10, $lte: 20}}`           | `amount lte 20`           | the missing-`$` typo: the LOWER BOUND silently gone |
+ * | `{$not: {d: {$eq: 1, nested: 'x'}}}`      | `NOT(d set AND d = 1)`    | the sibling vanished INSIDE the negation |
+ * | `{$not: {d: {$null: true, nested: 'x'}}}` | `NOT(d set AND d notSet)` | a CONTRADICTION that negates to TRUE — every row |
+ *
+ * Every row WIDENS — a dropped conjunct does not narrow the query (#3650 /
+ * #4128), the failure mode this module's own `MONGO_TO_CUBE_OP` miss-branch
+ * comment forbids. The last row is the strangest: `nullGuardForFieldSpec`
+ * judged the wrapper while the sibling still existed (`requireValue`), the
+ * sibling then vanished in `fieldLeaves`, and the surviving guard was
+ * contradictory — so the negation returned the WHOLE dataset.
+ *
+ * ## The ruling, and what the message owes (#6444, 2026-08-08)
+ *
+ * Option A — refuse, through the module's one envelope (#5352). Option B
+ * (flatten the siblings as nested paths) was rejected: it would compile the
+ * likely-real cause — a dropped `$` — into a predicate on a non-existent
+ * member `amount.gte`. Because the refused shape has TWO legitimate repairs
+ * answering two intents the module cannot tell apart, the message must name
+ * the offending non-`$` key(s) and show BOTH rewrites: the operator spelling
+ * (`gte` → `$gte`) and the nested-relation form — asserted below as the
+ * message contract, not prose.
+ *
+ * ## The blocks, and which one is the change
+ *
+ * `the mixed wrapper is ONE refusal` is the change: run it against pre-#6444
+ * code and every row fails, because every row COMPILES (dropping siblings).
+ *
+ * `the two pure shapes do not move` is the risk. The gate must move the
+ * refusal set by EXACTLY the mixed shape: all-`$` wrappers keep compiling,
+ * all-non-`$` wrappers keep flattening to dotted members. An over-reaching
+ * gate shows up there as a throw.
+ *
+ * `the #5146 rewrite cannot swallow the wrapper` is the gate-side question,
+ * same as #6386's: the gate sits in `fieldLeaves`, downstream of
+ * `nullSafeNegationOperand`. For a MIXED wrapper the carry-through is
+ * structural: a non-`$` key never satisfies `operatorIsNullTotal`, so
+ * `nullGuardForFieldSpec` never answers `none` for one — the disposition is
+ * always `requireValue`/`allowNull`, both of which push the spec by
+ * reference, so the gate always sees the author's wrapper.
+ *
+ * ## Reverse verification — direction predicted BEFORE running
+ *
+ * Ordinary direction, one knob (the `assertUnmixedFieldWrapper` call in
+ * `fieldLeaves`). Predicted with the call removed: every refusal row in this
+ * file goes red (the mixed shapes compile again, siblings dropped), the
+ * flipped pin in `filter-normalizer-undefined-comparand.test.ts` goes red,
+ * and the #6444 ledger row in `filter-refusal-envelope.test.ts` goes red —
+ * while both pure-shape control blocks and the #6386/`null` groups stay
+ * green (they never depended on this gate). One deliberate exception stays
+ * green in THIS file too: `{d: {$eq: undefined, nested: 'x'}}` is refused by
+ * the #6386 gate, not this one. Measured counts are in the PR body.
+ *
+ * ## Scope, so a later reader does not "finish the job"
+ *
+ * ⛔ `read-scope-sql.ts` is the sibling door; it has ALWAYS failed closed on
+ * this shape (`compileField`'s non-`$`-key check) and is not touched — this
+ * change makes the two doors give one answer, in this door's own envelope
+ * (400: the `where` is caller input; that door compiles a platform artifact
+ * and answers 500).
+ * ⛔ `$null` / `$exists` flag semantics (#5347 / #5369 / #6387), `comparand()`
+ * (#5526) and the null-predicate identity (#5332) are RULED elsewhere and
+ * untouched; the `null` control group lives in
+ * `filter-normalizer-undefined-comparand.test.ts` and did not move.
+ * ⛔ The other compiler faces (#5930's five) are out of scope per the ruling;
+ * the per-face statement is in PR #6444's body per the #6410 checklist.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { normalizeAnalyticsFilterTree } from '../strategies/filter-normalizer.js';
+
+/** The ADR-0112 fields a refusal must carry. */
+interface FilterRefusal extends Error {
+  code?: unknown;
+  status?: unknown;
+}
+
+function refusalFor(where: unknown): FilterRefusal | undefined {
+  try {
+    normalizeAnalyticsFilterTree({ where });
+    return undefined;
+  } catch (e) {
+    return e as FilterRefusal;
+  }
+}
+
+function treeFor(where: unknown): unknown {
+  return normalizeAnalyticsFilterTree({ where });
+}
+
+/**
+ * The mixed shapes, one per position the wrapper can sit in. `field` is the
+ * member the refusal must name (for a nested mix, the DOTTED member —
+ * `fieldLeaves` recurses before the gate sees it). `opKeys`/`nonOpKeys` are
+ * the two lists the message quotes, in wrapper key order. `wasReadAs` is the
+ * pre-fix normalisation — recorded so each row says what it protects against.
+ */
+const MIXED: Array<{
+  name: string;
+  where: unknown;
+  field: string;
+  opKeys: string[];
+  nonOpKeys: string[];
+  wasReadAs: string;
+}> = [
+  {
+    name: '① operator + nested member in one wrapper',
+    where: { d: { $eq: 1, nested: 'x' } },
+    field: 'd',
+    opKeys: ['$eq'],
+    nonOpKeys: ['nested'],
+    wasReadAs: "d equals [1] — `nested` dropped in silence",
+  },
+  {
+    name: '② the same mix with an undefined sibling VALUE (value-independent)',
+    where: { d: { $eq: 1, nested: undefined } },
+    field: 'd',
+    opKeys: ['$eq'],
+    nonOpKeys: ['nested'],
+    wasReadAs: 'd equals [1] — the drop never read the value (#6386 pinned this)',
+  },
+  {
+    name: '③ the canonical agent typo — an operator missing its $',
+    where: { amount: { gte: 10, $lte: 20 } },
+    field: 'amount',
+    opKeys: ['$lte'],
+    nonOpKeys: ['gte'],
+    wasReadAs: 'amount lte 20 — the LOWER BOUND silently gone',
+  },
+  {
+    name: '④ a $between beside a stray member',
+    where: { d: { $between: [1, 5], nested: 'x' } },
+    field: 'd',
+    opKeys: ['$between'],
+    nonOpKeys: ['nested'],
+    wasReadAs: 'd gte [1] AND d lte [5] — the range survived, the member did not',
+  },
+  {
+    name: '⑤ a $null flag beside a stray member',
+    where: { d: { $null: true, nested: 'x' } },
+    field: 'd',
+    opKeys: ['$null'],
+    nonOpKeys: ['nested'],
+    wasReadAs: 'd notSet — the flag survived, the member did not',
+  },
+  {
+    name: '⑥ the mix one relation DOWN, refused on the DOTTED member',
+    where: { profile: { verified: { $eq: 1, extra: 'x' } } },
+    field: 'profile.verified',
+    opKeys: ['$eq'],
+    nonOpKeys: ['extra'],
+    wasReadAs: 'profile.verified equals [1]',
+  },
+  {
+    name: '⑦ inside a $and branch',
+    where: { $and: [{ d: { $eq: 1, nested: 'x' } }] },
+    field: 'd',
+    opKeys: ['$eq'],
+    nonOpKeys: ['nested'],
+    wasReadAs: 'd equals [1]',
+  },
+  {
+    name: '⑧ inside a $or branch — the branch quietly LOST a conjunct',
+    where: { $or: [{ d: { gte: 1, $lte: 2 } }, { stage: 'won' }] },
+    field: 'd',
+    opKeys: ['$lte'],
+    nonOpKeys: ['gte'],
+    wasReadAs: "(d lte 2) OR (stage = 'won') — the branch widened, so the whole $or did",
+  },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('[#6444] a mixed $/non-$ field wrapper is ONE refusal', () => {
+  for (const c of MIXED) {
+    it(`refuses ${c.name} (was: ${c.wasReadAs})`, () => {
+      const err = refusalFor(c.where);
+      expect(err, 'compiled instead of refusing — the #3650 sibling-drop widening is back').toBeInstanceOf(Error);
+      const message = String(err?.message);
+      // Names the field, the operator side, and — the ruling requirement —
+      // every offending non-$ key.
+      expect(message).toContain(`"${c.field}" mixes $-operator keys (${c.opKeys.join(', ')})`);
+      for (const k of c.nonOpKeys) expect(message).toContain(`"${k}"`);
+      // The envelope every refusal in this module carries since #5352: the
+      // `where` is caller input, so 400. A bare toThrow() would carry one bit
+      // where this defect has two (the ADR-0112 refusal-test rule).
+      expect(err?.code).toBe('INVALID_FILTER');
+      expect(err?.status).toBe(400);
+    });
+  }
+
+  it('names EVERY offending sibling when there are several, not just the first', () => {
+    const err = refusalFor({ d: { $eq: 1, a: 1, b: 2 } });
+    expect(err).toBeInstanceOf(Error);
+    const message = String(err?.message);
+    expect(message).toContain('non-$ sibling key(s) "a", "b"');
+    // Both get the operator rewrite, so the author repairs the wrapper once.
+    expect(message).toContain('"a" → "$a"');
+    expect(message).toContain('"b" → "$b"');
+    expect(err?.code).toBe('INVALID_FILTER');
+    expect(err?.status).toBe(400);
+  });
+
+  it('says ONE thing, differing only in the field and the two key lists (#5240)', () => {
+    // Erase the parts that legitimately vary and every message must be the
+    // same string. Restricted to the single-op/single-sibling rows so the
+    // erased skeletons are comparable; the multi-sibling wording is asserted
+    // in its own case above. Longest tokens first, so `"$gte"` is consumed
+    // before a bare `"gte"` replacement could split it.
+    const generic = MIXED.map((c) => {
+      const err = refusalFor(c.where);
+      // Load-bearing (measured on #6386's twin of this case): without it the
+      // wording check is VACUOUSLY green when nothing throws — every row maps
+      // to the same "undefined" string.
+      expect(err, `${c.name} did not refuse — the wording check would pass on nothing`).toBeInstanceOf(Error);
+      const k = c.nonOpKeys[0];
+      return String(err?.message)
+        .split(`"${c.field}.${k}"`).join('"<field>.<key>"')
+        .split(`(${c.opKeys.join(', ')})`).join('(<ops>)')
+        .split(`"$${k}"`).join('"$<key>"')
+        .split(`"${k}" → `).join('"<key>" → ')
+        .split(`"${k}"`).join('"<key>"')
+        .split(`"${c.field}"`).join('"<field>"');
+    });
+    expect(new Set(generic).size, `expected one wording, got:\n${[...new Set(generic)].join('\n\n')}`).toBe(1);
+  });
+
+  it('shows BOTH legal rewrites — the two intents it cannot disambiguate (ruling req.)', () => {
+    const message = String(refusalFor({ amount: { gte: 10, $lte: 20 } })?.message);
+    // Intent 1 — an operator missing its $: the prefixed spelling, named
+    // key-by-key and shown in place.
+    expect(message).toContain('"gte" → "$gte"');
+    expect(message).toContain('{ "amount": { "$gte": ... } }');
+    // Intent 2 — a nested-relation member: a wrapper of its own, the dotted
+    // member it compiles to, and the explicit $and (one JSON object cannot
+    // spell the same field key twice).
+    expect(message).toContain('{ "amount": { "gte": ... } }');
+    expect(message).toContain('"amount.gte"');
+    expect(message).toContain('"$and"');
+    // …and why it refuses rather than picking: the drop it replaces WIDENED.
+    expect(message).toContain('WIDENS');
+    expect(message).toContain('read-scope-sql.ts');
+  });
+});
+
+describe('[#6444] the #5146 rewrite cannot swallow the wrapper', () => {
+  // The gate lives in `fieldLeaves`, DOWNSTREAM of `nullSafeNegationOperand`.
+  // A mixed wrapper reaches it because a non-$ key never satisfies
+  // `operatorIsNullTotal`, so `nullGuardForFieldSpec` never answers `none` for
+  // one — `requireValue` and `allowNull` both push the author's spec by
+  // REFERENCE. One case per rewrite path that can carry a mixed wrapper.
+  const REWRITE_PATHS: Array<{ name: string; where: unknown; field: string }> = [
+    {
+      name: '`requireValue` — pushes {k: {$null: false}}, {k: spec}; spec kept by reference',
+      where: { $not: { d: { $eq: 1, nested: 'x' } } },
+      field: 'd',
+    },
+    {
+      name: 'a null-total operator whose SIBLING forces the guard (was the every-row contradiction)',
+      where: { $not: { d: { $null: true, nested: 'x' } } },
+      field: 'd',
+    },
+    {
+      name: '`$eq: null` beside a sibling — null-total op, still guarded because of the mix',
+      where: { $not: { d: { $eq: null, nested: 'x' } } },
+      field: 'd',
+    },
+    {
+      name: 'the nested-relation recursion in `guardFieldEntry`, which guards the DOTTED member',
+      where: { $not: { profile: { verified: { $eq: 1, extra: 2 } } } },
+      field: 'profile.verified',
+    },
+  ];
+
+  for (const c of REWRITE_PATHS) {
+    it(`throws rather than changing shape: ${c.name}`, () => {
+      const err = refusalFor(c.where);
+      expect(err, 'the rewrite swallowed the wrapper and the gate blessed the new shape').toBeInstanceOf(Error);
+      expect(String(err?.message)).toContain(`"${c.field}" mixes $-operator keys`);
+      expect(err?.code).toBe('INVALID_FILTER');
+      expect(err?.status).toBe(400);
+    });
+  }
+});
+
+describe('[#6444] the two pure shapes do not move', () => {
+  it('an ALL-non-$ wrapper still flattens to the dotted member (the nested-relation path)', () => {
+    // The pin the issue's own control row named: the ONLY reason the siblings
+    // were droppable is that this legitimate path sat after the early return.
+    expect(treeFor({ d: { nested: 'x' } })).toEqual({
+      kind: 'leaf', member: 'd.nested', operator: 'equals', values: ['x'],
+    });
+    expect(treeFor({ a: { b: { c: 1 } } })).toEqual({
+      kind: 'leaf', member: 'a.b.c', operator: 'equals', values: [1],
+    });
+    // A nested member carrying an OPERATOR wrapper (all-$ one level down) is
+    // legal on both levels and keeps compiling.
+    expect(treeFor({ profile: { verified: { $eq: true } } })).toEqual({
+      kind: 'leaf', member: 'profile.verified', operator: 'equals', values: [true],
+    });
+  });
+
+  it('an ALL-$ wrapper still compiles exactly as before, multi-operator included', () => {
+    expect(treeFor({ amount: { $gte: 10, $lte: 20 } })).toEqual({
+      kind: 'and',
+      children: [
+        { kind: 'leaf', member: 'amount', operator: 'gte', values: [10] },
+        { kind: 'leaf', member: 'amount', operator: 'lte', values: [20] },
+      ],
+    });
+    expect(treeFor({ d: { $null: true } })).toEqual({ kind: 'leaf', member: 'd', operator: 'notSet', values: [] });
+    expect(treeFor({ d: { $exists: false } })).toEqual({ kind: 'leaf', member: 'd', operator: 'notSet', values: [] });
+    expect(treeFor({ stage: { $in: [] } })).toEqual({ kind: 'const', value: false });
+  });
+
+  it('the neighbouring refusals keep their OWN wordings — the set moved by exactly one shape', () => {
+    // #5240's zero-operator refusal is disjoint by construction ({} has no
+    // keys of either kind) and must not borrow the mixed wording.
+    expect(String(refusalFor({ stage: {} })?.message)).toContain('zero operators');
+    // #3948's vocabulary refusal still owns the all-$-but-unknown wrapper.
+    expect(String(refusalFor({ stage: { $sortOf: 'won' } })?.message)).toContain('Unsupported filter operator');
+  });
+
+  it('a mixed wrapper whose $-comparand is undefined is refused by the #6386 gate first', () => {
+    // Measured ordering, pinned as a fact rather than a contract:
+    // `assertDefinedComparands` runs at `fieldLeaves`'s entry, this gate in the
+    // wrapper arm below it. Both refusals share the envelope, so the REST face
+    // answers 400 either way — which is why the ordering is allowed to be an
+    // implementation fact.
+    const err = refusalFor({ d: { $eq: undefined, nested: 'x' } });
+    expect(String(err?.message)).toContain('comparand at "d".$eq is undefined');
+    expect(err?.code).toBe('INVALID_FILTER');
+    expect(err?.status).toBe(400);
+  });
+});

--- a/packages/services/service-analytics/src/__tests__/filter-normalizer-undefined-comparand.test.ts
+++ b/packages/services/service-analytics/src/__tests__/filter-normalizer-undefined-comparand.test.ts
@@ -469,17 +469,24 @@ describe('[#6386] what the sweep deliberately leaves alone', () => {
     }
   });
 
-  it('a non-$ SIBLING of an operator is still dropped — a different defect, not this one', () => {
-    // `{d: {$eq: 1, nested: <anything>}}` ignores `nested` whatever its value, so
-    // this is not an `undefined` reading and is out of scope here. Pinned so the
-    // measurement is on the record rather than mistaken for coverage: filed
-    // separately per Prime Directive #10.
-    expect(treeFor({ d: { $eq: 1, nested: undefined } })).toEqual({
-      kind: 'leaf', member: 'd', operator: 'equals', values: [1],
-    });
-    expect(treeFor({ d: { $eq: 1, nested: 'x' } })).toEqual({
-      kind: 'leaf', member: 'd', operator: 'equals', values: [1],
-    });
+  it('a non-$ SIBLING of an operator is now REFUSED — the pin this case held flipped (#6444)', () => {
+    // ⚠️ FLIPPED, not deleted. Until #6444 this case PINNED the measurement
+    // that `{d: {$eq: 1, nested: <anything>}}` silently dropped `nested` — a
+    // different defect from #6386's, filed separately per Prime Directive #10
+    // and ruled Option A (refuse) on 2026-08-08. The full position list, the
+    // two-rewrite message contract and the pure-shape control groups live in
+    // `filter-normalizer-mixed-wrapper.test.ts`; this case keeps the SAME two
+    // inputs the pin measured, so the record of what changed stays readable:
+    // both rows compiled to `d equals [1]` then, both refuse now, and the
+    // `undefined` row is why the refusal is value-INDEPENDENT — the drop never
+    // read the sibling's value, and neither does the gate that replaced it.
+    for (const where of [{ d: { $eq: 1, nested: undefined } }, { d: { $eq: 1, nested: 'x' } }]) {
+      const err = refusalFor(where);
+      expect(err, 'the non-$ sibling was silently dropped again — #6444 regressed').toBeInstanceOf(Error);
+      expect(String(err?.message)).toContain('"d" mixes $-operator keys ($eq) with non-$ sibling key(s) "nested"');
+      expect(err?.code).toBe('INVALID_FILTER');
+      expect(err?.status).toBe(400);
+    }
   });
 
   it('every ACCEPTED shape the module already had still compiles identically', () => {

--- a/packages/services/service-analytics/src/__tests__/filter-refusal-envelope.test.ts
+++ b/packages/services/service-analytics/src/__tests__/filter-refusal-envelope.test.ts
@@ -154,6 +154,21 @@ const REFUSALS: Array<{
     issueBullet: false,
     addedAfter5352: '#6386',
   },
+  {
+    // [#6444] A field wrapper mixing $-operator keys with non-$ siblings.
+    // Before it, the non-$ siblings were silently DROPPED — `fieldLeaves`'s
+    // operator arm iterated `opKeys` only and returned, so
+    // `{amount: {gte: 10, $lte: 20}}` (the missing-$ typo) lost its lower
+    // bound with nothing to read. The full position list, the two-rewrite
+    // message contract and the pure-shape control groups live in
+    // `filter-normalizer-mixed-wrapper.test.ts`; this row exists so the
+    // envelope block below covers the eleventh site the way it covers the ten.
+    name: 'a mixed $/non-$ field wrapper (#6444)',
+    where: { amount: { gte: 10, $lte: 20 } },
+    message: /"amount" mixes \$-operator keys \(\$lte\) with non-\$ sibling key\(s\) "gte"/,
+    issueBullet: false,
+    addedAfter5352: '#6444',
+  },
 ];
 
 /**
@@ -290,7 +305,8 @@ describe('[#5352] every refusal carries the ADR-0112 envelope (INVALID_FILTER / 
     ]);
     expect(REFUSALS.filter((c) => c.addedAfter5352).map((c) => `${c.name} · ${c.addedAfter5352}`)).toEqual([
       'an undefined comparand (#6386) · #6386',
+      'a mixed $/non-$ field wrapper (#6444) · #6444',
     ]);
-    expect(REFUSALS).toHaveLength(10);
+    expect(REFUSALS).toHaveLength(11);
   });
 });

--- a/packages/services/service-analytics/src/strategies/filter-normalizer.ts
+++ b/packages/services/service-analytics/src/strategies/filter-normalizer.ts
@@ -286,6 +286,52 @@
  * (#5526) keep their exact lowering, pinned as a control group in
  * `filter-normalizer-undefined-comparand.test.ts`.
  *
+ * # A field wrapper cannot MIX $-operators with non-$ members (#6444)
+ *
+ * The value-independent sibling of the #6386 defect, in the same function, ruled
+ * Option A (refuse) by the maintainer on 2026-08-08. A field constraint object
+ * that carries `$`-operator keys AND non-`$` keys at once used to compile its
+ * operators and silently DROP every non-`$` sibling — `fieldLeaves`'s
+ * `if (opKeys.length > 0) { …; return out; }` arm never looked at them, and the
+ * nested-relation flatten sits after that early return. Measured on
+ * `origin/main` (`1a53a0253`):
+ *
+ *   | `where`                            | normalized to                    | reading |
+ *   |---|---|---|
+ *   | `{d: {$eq: 1, nested: 'x'}}`       | `d equals [1]`                   | the `nested` conjunct vanished in silence |
+ *   | `{amount: {gte: 10, $lte: 20}}`    | `amount lte 20`                  | the missing-`$` typo: the LOWER BOUND silently gone |
+ *   | `{$not: {d: {$null: true, nested: 'x'}}}` | `NOT(d set AND d notSet)` | a contradiction that negates to TRUE — EVERY row |
+ *
+ * Row two is the likeliest producer — a dropped `$` is a canonical agent typo —
+ * and row three is the strangest: the #5146 guard was computed while the sibling
+ * still existed (`requireValue`), the sibling then vanished inside
+ * `fieldLeaves`, and the surviving conjunction was contradictory, so the
+ * negation widened to the whole dataset. All three WIDEN — the #3650 failure
+ * mode the note at {@link MONGO_TO_CUBE_OP}'s miss branch forbids in this very
+ * function.
+ *
+ * The refusal is {@link mixedFieldWrapperError} via
+ * {@link assertUnmixedFieldWrapper}, in this module's one envelope
+ * (`INVALID_FILTER` / 400, #5352). The message must do one thing more than the
+ * module's other refusals: the shape has TWO legitimate repairs answering two
+ * intents this module cannot tell apart — an operator missing its `$`
+ * (`gte` → `$gte`) and a nested-relation member that needs a wrapper of its own
+ * — so the message names the offending key(s) and shows BOTH rewrites (ruling
+ * requirement, #6444).
+ *
+ * Option B — flattening the non-`$` siblings as nested paths next to the
+ * operators — was REJECTED by the same ruling: it would compile the likely-real
+ * cause (a dropped `$`) into a predicate on a non-existent member `amount.gte`,
+ * turning a diagnosable mistake into a harder one.
+ *
+ * ⛔ What does not move: a wrapper that is ALL non-`$` keys keeps flattening to
+ * the dotted member (`{d: {nested: 'x'}}` → `d.nested`); a wrapper that is ALL
+ * `$`-operators compiles exactly as before; `$null` / `$exists` flag semantics
+ * (#5526 / #5332 / #5347) and {@link comparand} are untouched. The sibling door
+ * `read-scope-sql.ts` already fails closed on this exact shape
+ * (`compileField`'s non-`$`-key check) and is not touched — this change makes
+ * the two doors give one answer.
+ *
  * Row-result cover: `filter-operator-coverage.test.ts` for the operator
  * vocabulary, `native-sql-filter-logic-conformance.test.ts`, which runs the
  * SHARED combinator table (`FILTER_LOGIC_CASES`, #3774) that the SQL compiler,
@@ -294,9 +340,11 @@
  * deliberately does not carry (NULL handling, boolean identities),
  * `filter-array-lowering.test.ts` for the array door (#5334),
  * `filter-value-type-fidelity.test.ts` for what each comparand TYPE binds on both
- * consumers (#5526, carrying #5528's cases forward as end-to-end assertions), and
+ * consumers (#5526, carrying #5528's cases forward as end-to-end assertions),
  * `filter-normalizer-undefined-comparand.test.ts` for the `undefined` refusal and
- * its `null` control group (#6386).
+ * its `null` control group (#6386), and
+ * `filter-normalizer-mixed-wrapper.test.ts` for the mixed `$`/non-`$` wrapper
+ * refusal and its pure-shape control groups (#6444).
  */
 
 import { isFilterAST, parseFilterAST, VALID_AST_OPERATORS } from '@objectstack/spec/data';
@@ -660,6 +708,98 @@ function assertDefinedComparands(field: string, spec: unknown): void {
 }
 
 /**
+ * [#6444, ruled Option A on 2026-08-08] A field wrapper mixing `$`-operator
+ * keys with non-`$` sibling keys.
+ *
+ * ONE wording whatever the mix (#5240 — one condition, one wording); only the
+ * field and the two key lists vary, because only those do. Where this message
+ * has to do MORE than the module's other refusals: the shape has two
+ * legitimate repairs answering two different intents, and the module cannot
+ * tell which one the author held — that inability is exactly why the shape is
+ * refused rather than read. So the message must present BOTH (ruling
+ * requirement):
+ *
+ *   - an OPERATOR missing its `$` — the canonical agent typo
+ *     `{amount: {gte: 10, $lte: 20}}` — repaired by the prefixed spelling
+ *     (`"gte" → "$gte"`);
+ *   - a NESTED-RELATION member that strayed into an operator wrapper —
+ *     repaired by giving it a wrapper of its own (`{ "d": { "nested": … } }`
+ *     compiles to the member `d.nested`), ANDed with the operator constraint
+ *     explicitly, since one JSON object cannot spell the same field key twice.
+ *
+ * Option B — flattening the sibling as a nested path beside the operators —
+ * was rejected by the same ruling: it would compile the missing-`$` typo into
+ * a predicate on a non-existent member `amount.gte`, converting a diagnosable
+ * mistake into a harder one.
+ */
+function mixedFieldWrapperError(field: string, opKeys: string[], nonOpKeys: string[]): Error {
+  const offending = nonOpKeys.map((k) => `"${k}"`).join(', ');
+  const rewrites = nonOpKeys.map((k) => `"${k}" → "$${k}"`).join(', ');
+  const example = nonOpKeys[0];
+  return invalidFilterError(
+    `[analytics] "${field}" mixes $-operator keys (${opKeys.join(', ')}) with non-$ sibling key(s) ` +
+    `${offending} in ONE field constraint — refusing to compile this filter. A $-prefixed key is an ` +
+    `OPERATOR and a bare key is a NESTED-RELATION member; the two readings of ${offending} lead to ` +
+    `different predicates and this module cannot tell which was meant, so any silent choice is a ` +
+    `guess. If an operator missing its "$" was meant — the usual authoring slip — spell it with the ` +
+    `prefix: ${rewrites}, as in { "${field}": { "$${example}": ... } }. If a nested-relation member ` +
+    `was meant, give it a wrapper of its OWN with no $ siblings — { "${field}": { "${example}": ... } } ` +
+    `compiles to the member "${field}.${example}" — and AND it with the operator constraint ` +
+    `explicitly: { "$and": [{ "${field}": { "$op": ... } }, { "${field}": { "${example}": ... } }] }. ` +
+    `This shape used to compile by silently DROPPING every non-$ sibling, and a dropped conjunct ` +
+    `does not narrow the query, it WIDENS it: the chart included rows the author excluded, with ` +
+    `nothing to read (#3650's failure mode, which this module refuses everywhere else). The sibling ` +
+    `door in this package (read-scope-sql.ts) already fails closed on this exact shape — one shape, ` +
+    `one answer (#6444).`,
+  );
+}
+
+/**
+ * [#6444] Refuse ONE field wrapper that mixes `$`-operator keys with non-`$`
+ * sibling keys — the value-independent sibling of {@link assertDefinedComparands}.
+ *
+ * What made the mix silent: {@link fieldLeaves}'s operator arm iterates
+ * `opKeys` only and returns, and the nested-relation flatten sits after that
+ * early return — so with even one `$` key present, every non-`$` sibling was
+ * simply never visited. Dropping a conjunct WIDENS (#3650), and inside a `$not`
+ * it did worse than widen by one conjunct: {@link nullGuardForFieldSpec} judged
+ * the wrapper while the sibling still existed (a non-`$` key never satisfies
+ * {@link operatorIsNullTotal}, so the disposition was `requireValue` or
+ * `allowNull`, never `none`), the sibling then vanished here, and for a
+ * null-predicate operator the surviving guard was CONTRADICTORY —
+ * `{$not: {d: {$null: true, nested: 'x'}}}` compiled to `NOT(d set AND d
+ * notSet)`, which is TRUE for every row. That same never-`none` fact is what
+ * guarantees the #5146 rewrite carries a mixed wrapper to this gate by
+ * reference instead of swallowing it — pinned in
+ * `filter-normalizer-mixed-wrapper.test.ts`'s rewrite block.
+ *
+ * ## Ordering against the neighbouring gates
+ *
+ * Runs in {@link fieldLeaves}'s wrapper arm, after the #5240 zero-operator
+ * refusal (disjoint by construction: `{}` has no keys of either kind) and
+ * after {@link assertDefinedComparands} at the function's entry — so
+ * `{d: {$eq: undefined, nested: 'x'}}` is refused as an undefined comparand,
+ * not as a mix. Both are refusals in the same envelope, so the REST face
+ * answers 400 either way; the ordering is pinned as a measured fact, not a
+ * contract.
+ *
+ * ## What is deliberately not judged here
+ *
+ * A wrapper that is ALL `$`-operators or ALL non-`$` members passes untouched —
+ * this gate moves the refusal set by exactly the mixed shape. Whether a non-`$`
+ * KEY is a real member of the modeled object is the schema's question at a
+ * different layer, not this compiler's.
+ */
+function assertUnmixedFieldWrapper(field: string, wrapper: Record<string, unknown>): void {
+  const keys = Object.keys(wrapper);
+  const opKeys = keys.filter((k) => k.startsWith('$'));
+  if (opKeys.length === 0) return;
+  const nonOpKeys = keys.filter((k) => !k.startsWith('$'));
+  if (nonOpKeys.length === 0) return;
+  throw mixedFieldWrapperError(field, opKeys, nonOpKeys);
+}
+
+/**
  * Compile one `field: value | { $op: … }` entry into its leaves.
  *
  * Multiple operators on one field AND together — the rule
@@ -700,6 +840,12 @@ function fieldLeaves(key: string, raw: unknown): NormalizedFilterNode[] {
         `shape refused on every backend.`,
       );
     }
+    // [#6444] A wrapper mixing $-operator keys with non-$ siblings is refused
+    // BEFORE the operator arm below gets to iterate `opKeys` only and return —
+    // that early return is exactly how the non-$ siblings used to vanish. See
+    // {@link assertUnmixedFieldWrapper} for the two-intent message contract and
+    // the `$not` interaction.
+    assertUnmixedFieldWrapper(key, wrapper);
     const opKeys = Object.keys(wrapper).filter((k) => k.startsWith('$'));
     if (opKeys.length > 0) {
       for (const opKey of opKeys) {


### PR DESCRIPTION
Closes #6444

按 2026-08-08 02:12Z 维护者裁决（Option A——拒收）实施，基于已并入 #6445 的 `origin/main`（`1a53a0253`）。**只动 `strategies/filter-normalizer.ts` 与其测试**；同包另一扇门 `read-scope-sql.ts` **零字节未动**（不在 diff 中）。未实现任何展平回退（Option B 被裁决否决）。

## 实测（先验前提，再实现）

在 `origin/main` @ `1a53a0253` 上直接调 `normalizeAnalyticsFilterTree({ where })` 逐行复测。**前提成立**：`opKeys.length > 0` 的分支只遍历 `$` 键就 `return`，嵌套关系展平在其后，走不到——非 `$` 兄弟键静默消失，与值无关：

| `where` | 归一化结果 | 读法 |
|---|---|---|
| `{d: {$eq: 1, nested: 'x'}}` | `d equals [1]` | `nested` 合取项静默消失 |
| `{d: {$eq: 1, nested: undefined}}` | `d equals [1]` | 同上——与值无关，正是 #6386 钉住的测量 |
| `{amount: {gte: 10, $lte: 20}}` | `amount lte 20` | 漏写 `$` 的典型手误：**下界静默没了** |
| `{$not: {d: {$eq: 1, nested: 'x'}}}` | `NOT(d set AND d = 1)` | 兄弟键在取反**内部**消失 |
| `{$not: {d: {$null: true, nested: 'x'}}}` | `NOT(d set AND d notSet)` | **矛盾式取反成 TRUE ⇒ 每一行** |

最后一行是本轮实测新量到的、比 issue 正文更响的一格：#5146 的守卫在兄弟键**还在**时判的 `requireValue`，兄弟键随后在 `fieldLeaves` 里消失，剩下的合取自相矛盾，取反后放行**整个数据集**。每一行方向都是**加宽**——同一个函数 `MONGO_TO_CUBE_OP` 未命中分支的注释明令禁止的 #3650 败法。

## 裁决四项要求——逐项合规

| # | 要求 | 落点 |
|---|---|---|
| 1 | 消息点名非 `$` 键并给出**两种**合法改写（算子拼法 `gte` → `$gte` **和**嵌套关系形），区分两种无法消歧的意图 | `mixedFieldWrapperError`：逐键点名（多键全列，有专门用例）、`"gte" → "$gte"` 加原位示例、嵌套形加它编成的点号成员 `"amount.gte"` 加显式 `$and` 组合（一个 JSON 对象写不了两次同名键）。消息合同由 `shows BOTH legal rewrites` 用例逐片断言；措辞唯一性（#5240）由擦除比对用例钉死 |
| 2 | 拒收测试断言 **`code` + `status`**（ADR-0112），裸 `toThrow()` 不算 | 新文件每条拒收用例（8 位置 + 多键 + 4 条改写路径）都断言 `code === 'INVALID_FILTER'` 且 `status === 400`；账本的 envelope 块对第 11 行自动覆盖同两项 |
| 3 | #6445 留下的 pin（`a non-$ SIBLING … still dropped`）翻成正向拒收断言 | `filter-normalizer-undefined-comparand.test.ts` 同一用例原位翻转，**保留原 pin 的同两条输入**（`nested: undefined` / `nested: 'x'`），断言消息 + code + status；注释记下翻转前后的可读历史 |
| 4 | 范围只此一门；#5930 五编译面收敛维持 on hold；按 #6410 条款逐面申报 | 见下表；`read-scope-sql.ts` 零字节 |

## #6410 编译面清单——逐面申报

| 面 | 处置 | 依据（实读代码，非推断） |
|---|---|---|
| service-analytics `filter-normalizer.ts` | **changed（本 PR）** | `assertUnmixedFieldWrapper` 于 `fieldLeaves` 包装分支、#5240 空约束闸之后 |
| service-analytics `read-scope-sql.ts` | **already conformant** | `compileField`：`keys.some((k) => !k.startsWith('$'))` 即 fail-closed 拒收（:379-382）。零字节未动 |
| driver-sql `sql-driver.ts`（wasm / turso-local 继承） | **already conformant（方向上）** | 对象比较数**所有**键都按算子迭代，非 `$` 兄弟键落到发射器 `default: throw unsupportedFilterError("Unsupported filter operator …")`（:7416-7422）——响亮拒收、点名键，不丢 |
| turso RemoteTransport `buildWhereSQL` | **already conformant** | `unsupportedOperator` 对非 `$` 键有**专门措辞**（`object comparand whose key "…" is not an operator`，:2189-2196），`invalidFilterError` 信封 |
| formula `matchesFilterCondition` | **out of scope（如实记差异）** | `evalField`：任何非 `$` 键使整个约束 `return false`（matches-filter.ts:161）——**静默收窄**（该行被排除），既不丢键加宽也不响亮拒收。与裁决面向不一致但方向相反且无声；按裁决要求 4 与 #5930 hold 不在本单动，差异如实记档 |
| objectql `having-filter.ts`（半面，#5905） | **already conformant（方向上）** | `isOperatorObject` 只要有 `$` 键即真，随后**全部**键按算子迭代，非 `$` 键落 `default: throw unknownOperator(op, 'condition')`（:194-196） |
| driver-memory / driver-mongodb | **out of scope** | #5499 冻结：pin-annotate 而非翻转 |

## 反向验证（方向先预判、写进测试文件头，再跑）

唯一旋钮：摘掉 `fieldLeaves` 里 `assertUnmixedFieldWrapper(key, wrapper)` 这一次调用。

**预判**：新文件 19 条中 **15 红**（8 个位置行 + 多键行 + 措辞唯一性行 + 双改写行 + 4 条 `$not` 改写路径行），4 条对照绿（两条纯形状、邻座拒收措辞、`$eq: undefined` 混写行——它由 #6386 的闸先拒，与本闸无关）；翻转的 pin **1 红**；账本第 11 行在两个循环里 **2 红**；其余全绿。合计 **18 红**。

**实测**：`Test Files 3 failed | 66 passed / Tests 18 failed | 1393 passed`——红的正是预判的 18 条、只在预判的 3 个文件里，逐条名单核对一致；两个纯形状对照块、#6386 全部用例、`null` 对照组全程未红一行。恢复闸后全绿。

措辞唯一性用例带着 #6445 在孪生用例上量出的防空转守卫（先逐行断言确实拒收，再擦除比对），反向档位下它按预期红在「did not refuse」一步，而不是空着绿。

## `null` 对照组与 #6386 的闸：零字节

`filter-normalizer-undefined-comparand.test.ts` 的 diff **只有翻转的那一个用例**：13 行 `NULL_CONTROL`、七行表、位置清单、`$null`/`$exists` 旗标块逐字节未动，全程绿。`comparand()`、`$null`/`$exists` 恒等读、#5332/#5526 裁决——不在 diff 中。两闸次序为实测事实并钉了一条用例：`{d: {$eq: undefined, nested: 'x'}}` 由 #6386 的闸先答（同信封，REST 面无差别），注释写明这是实现事实而非契约。

## 夹具分诊与消费半径

- **翻转（裁决点名）**：#6386 的 sibling-drop pin，原位翻正，同输入。
- **账本补声明**：`filter-refusal-envelope.test.ts` 的 `covers every refusing site in the module` 是全量声明，新增第 11 行（`addedAfter5352: '#6444'`，尊重 #6445 立下的历史/全量双职责区分——不混入 `issueBullet: false` 集合），计数 10 → 11。
- **REST 面镜像表**（`packages/rest/analytics-filter-refusal-envelope.test.ts`）是采样表而非全量账本（#6445 同样未加行），不动；信封经由通用读取跨 seam，下游全绿见下。
- **消费半径扫**：`normalizeAnalyticsFilterTree` 调用方 3 个文件全在本包；examples / plugin-reports 的库存 metadata 过滤器全文扫过——全部纯 `$` 包装或标量等值，**无一处**混写形状；下游 `rest`、`runtime` 全量跑过。

## 门禁（全部实跑）

| 门 | 结果 |
|---|---|
| `pnpm --filter @objectstack/service-analytics test` | `Test Files 69 passed (69) / Tests 1411 passed (1411)`（基线 68 文件；本 PR +1 文件 +19 用例，另 3 条用例原位改写） |
| `tsc --noEmit -p packages/services/service-analytics` | 10 errors，与 `check-type-check-coverage.mjs` 账本记录的 10 **一致**；逐文件核对，全部在原有 3 个测试文件，本 PR 改动文件**零**类型错误 |
| `eslint`（4 个改动 ts 文件） | exit 0 |
| `node scripts/check-nul-bytes.mjs` | `OK (scanned 6158 tracked text file(s))`；另对 5 个改动文件跑 `grep -naP` 控制字节自扫描，clean |
| `pnpm check:engine-double-contract` | `OK — 92 pinned, 133 in the DEBT ledger, 2 exempt.` |
| `check:error-code-casing` | `✓ no lowercase error codes in 3198 scanned file(s) (ADR-0112).` |
| `check:route-envelope` | `✓ Dispatcher domains — 16 audited … (0 ratcheted)` |
| `check:empty-changeset` | `✓ … (1 declaring changeset(s) added)` |
| 下游 `pnpm --filter @objectstack/rest test` | `Test Files 66 passed (66) / Tests 939 passed (939)` |
| 下游 `pnpm --filter @objectstack/runtime test` | `Test Files 111 passed (111) / Tests 1611 passed (1611)` |

Changeset：`.changeset/mixed-wrapper-refusal.md`，patch @ `@objectstack/service-analytics`（可观测行为变更：一个此前被静默收窄读取的形状改为 400 拒收）。

## 触达性（与 #6386 的一个实质差别）

`undefined` 过不了 JSON，本形状**过得了**：它可以躺在库存 dashboard `filter` / report `runtimeFilter` / dataset `filter` 里，也可以由 AI 直接写出（`{amount: {gte: 10, $lte: 20}}` 正是漏 `$` 的典型手误）。examples 全扫无现存实例，issue 正文「未证实触达」维持成立；本 PR 把这个形状从「静默画一张比作者写的宽的图」变成一句点名键、给出两种改法的 400。

---
_Generated by [Claude Code](https://claude.ai/code/session_01USNUyHEr7uaU6MoEWXitei)_