### PR TITLE
fix(ci): start the shard's affected diff at the merge base, not the frozen base.sha (#6195)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,13 +215,110 @@ jobs:
       # naming the cause, not a silently empty shard. An EMPTY shard file must
       # short-circuit the test step below: `turbo run test` with zero --filter
       # args runs the entire workspace.
+      #
+      # WHERE THE AFFECTED DIFF STARTS (#6195, the #6129 family's third
+      # consumer). The one thing this base must never be is
+      # `github.event.pull_request.base.sha`.
+      #
+      # The payload's `base.sha` is frozen when the PR is OPENED and does not
+      # move on `synchronize`. HEAD, meanwhile, is the merge ref
+      # (`refs/pull/N/merge`) that the checkout above resolves by default on a
+      # `pull_request` event — no `ref:` is given, so this job stands on a merge
+      # commit containing everything main has today. Everything main gained
+      # while the PR sat open therefore lands between the two, and
+      # `turbo ls --affected` reads it as this PR's own changes: packages only
+      # SOMEBODY ELSE's merged PR touched get tested on this shard.
+      #
+      # The direction is conservative — the frozen base is an ancestor of HEAD,
+      # so its file set is a strict SUPERSET of this PR's own. Nothing that
+      # should run is skipped; what degrades is the optimisation itself, and it
+      # degrades with how long the PR has been open. At ~18 merges a day an
+      # affected-only shard drifts back toward a full run.
+      #
+      # Measured on turbo 2.10.7 against a real merge-ref fixture (base branch
+      # moved 1 commit touching pkg-b; this PR touched pkg-a only):
+      #   TURBO_SCM_BASE=<frozen base.sha>            -> pkg-a, pkg-b
+      #   TURBO_SCM_BASE=merge-base(origin/main,HEAD) -> pkg-a
+      #
+      # Four spellings that look like the fix and are not:
+      #   - `base.sha...HEAD` (three dots). Three-dot means
+      #     `merge-base(base.sha, HEAD)..HEAD`, and the frozen sha is ALREADY an
+      #     ancestor of HEAD, so it IS its own merge base and the set does not
+      #     move. Measured: still both packages. (pr-automation.yml records the
+      #     same result for its own diff — same fact, one family.)
+      #   - `HEAD^1`. Correct on a merge ref and silently wrong the day someone
+      #     gives this checkout a `ref:`, where parent^1 becomes the PR's
+      #     previous commit. `merge-base` is right under BOTH checkouts.
+      #   - Dropping the variable and letting turbo default to `main`. Measured
+      #     in a CI-shaped clone: `fetch-depth: 0` populates
+      #     `refs/remotes/origin/*`, NOT local heads, so there is no local `main`
+      #     — and turbo does not error, it silently returns the ENTIRE
+      #     workspace, untouched packages included. Safe, and the whole
+      #     optimisation gone.
+      #   - `TURBO_SCM_BASE=origin/$BASE_REF`, letting turbo resolve the ref.
+      #     Measured correct today, but it rests the shard's package set on
+      #     `turbo ls`'s internal choice of dot-ness — undocumented, and
+      #     `turbo ls` is experimental (see above). Resolving to a commit here
+      #     leaves turbo no choice to make.
       - name: Compute this shard's package set
         env:
-          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PINNED_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
+          SCM_BASE=''
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            pnpm exec turbo ls --affected --output=json > "$RUNNER_TEMP/turbo-ls.json"
+            if [ -z "$BASE_REF" ]; then
+              echo "::warning::This pull_request event carries no base branch, so the affected-set diff base cannot be computed."
+            else
+              # `fetch-depth: 0` above already makes this resolve — the fetch is
+              # the guard for the day that changes, not the normal path.
+              #
+              # `git cat-file -e` rather than the more idiomatic strict
+              # `git rev-parse` spelling, and the reason is not style.
+              # check-shard-attestation.mjs classifies a job as an aggregate GATE
+              # when the job's joined `run:` text contains BOTH the string
+              # "check-shard-attestation.mjs" and, as a bare substring, that
+              # script's own dash-dash-verify flag. This job already carries the
+              # first (its --emit step at the bottom), so spelling that flag
+              # anywhere in this step — including in a comment, since comments
+              # are part of `run:` — silently reclassifies the shard job as a
+              # gate. The drift guard then fails with two complaints that name
+              # nothing to do with the real edit ("its job-level if: is not
+              # always()", "never downloads the shard attestations it claims to
+              # count"). Measured both ways on this very change; do not "tidy"
+              # this back.
+              if ! git cat-file -e "refs/remotes/origin/$BASE_REF^{commit}" 2>/dev/null; then
+                git fetch --no-tags --quiet origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF" \
+                  || echo "::warning::Could not fetch origin/$BASE_REF; the merge-base resolution below will decide."
+              fi
+              # `if !` rather than a bare assignment on purpose: these steps run
+              # under `bash -e`, where a failing command substitution kills the
+              # step with no message at all.
+              if ! SCM_BASE=$(git merge-base "refs/remotes/origin/$BASE_REF" HEAD); then
+                SCM_BASE=''
+              fi
+            fi
+          fi
+          if [ -n "$SCM_BASE" ]; then
+            # The drift is printed, not just corrected: nothing in this log ever
+            # said which commit the affected diff started from, which is why the
+            # decay was invisible.
+            DRIFT=$(git rev-list --count "$PINNED_BASE_SHA..$SCM_BASE" 2>/dev/null || echo '?')
+            echo "Affected-set diff base: $SCM_BASE  (merge-base of origin/$BASE_REF and HEAD)"
+            echo "Frozen payload base.sha: $PINNED_BASE_SHA  -- $BASE_REF has moved $DRIFT commit(s) since it was frozen, and that drift is exactly what this step used to charge to this PR."
+            TURBO_SCM_BASE="$SCM_BASE" pnpm exec turbo ls --affected --output=json > "$RUNNER_TEMP/turbo-ls.json"
           else
+            # Falling back to the FULL package list, never to the frozen
+            # base.sha. This is not the #4690 silent-skip anti-pattern: that is
+            # about a gate PASSING on input it could not read, and the full list
+            # is a strict superset of the affected one — this shard still runs
+            # everything it would have run and more. Cost is minutes; the
+            # alternative is a red Test Core on a PR with nothing wrong with it.
+            # Push and merge-queue builds take this branch by design (the queue
+            # result IS the next main, so it gets main's validation).
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              echo "::warning::Could not resolve merge-base(origin/$BASE_REF, HEAD); falling back to the full package list for this shard rather than diffing from the frozen base.sha (#6195)."
+            fi
             pnpm exec turbo ls --output=json > "$RUNNER_TEMP/turbo-ls.json"
           fi
           node scripts/partition-test-shards.mjs "$RUNNER_TEMP/turbo-ls.json" \


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6195

The third and last consumer of the frozen `github.event.pull_request.base.sha` in this repo's workflows (the #6129 family; PR #6192 fixed the two in `pr-automation.yml`). After this PR, `grep -rn "base.sha" .github/workflows/` finds only #6192's own drift-reporting variable and its comments — no diff, anywhere, starts at the frozen sha.

## The defect

`.github/workflows/ci.yml`, `Compute this shard's package set`, fed `turbo ls --affected` a `TURBO_SCM_BASE` frozen when the PR was **opened**. The same job's checkout is `actions/checkout@v7` + `fetch-depth: 0` with **no** `ref:`, so HEAD is the `refs/pull/N/merge` commit containing everything main has *today*. Everything main gained while the PR sat open lands between the two, and turbo charges it to this PR: packages only somebody else's merged PR touched get tested on this shard.

Direction is conservative — the frozen base is an ancestor of HEAD, so its file set is a strict **superset** of this PR's own. Nothing that should run is skipped. What decays is the optimisation: at ~18 merges/day an affected-only shard drifts back toward a full run the longer a PR stays open.

## The fix

`git merge-base "refs/remotes/origin/$BASE_REF" HEAD`, the same resolution PR #6192 landed for `pr-automation.yml`. On a merge-ref HEAD it lands exactly on parent^1, so the diff is this PR's own side and nothing else.

## Measured, not reasoned about

A real merge-ref fixture (base branch moved 1 commit touching `pkg-b`; the PR touched `pkg-a` only), driven through **turbo 2.10.7** and then through the **exact `run:` body extracted from the YAML**, under `bash -e` as the runner invokes it:

| `TURBO_SCM_BASE` | affected set |
| --- | --- |
| frozen `base.sha` (today) | `pkg-a, pkg-b` — main's package, charged here |
| `merge-base(origin/main, HEAD)` (this PR) | `pkg-a` |

**Reverse verification.** Direction predicted before running it, and it is *not* "a test goes red": reverting this one line makes the affected set **grow**, because the failure mode is over-running, never under-running. Measured: shard goes `1/1 packages -> @probe/pkg-a` back to `2/2 packages -> @probe/pkg-a, @probe/pkg-b`.

**Four spellings that look like the fix and are not** (all measured; recorded in the workflow comment so the next reader does not re-derive them):

- `base.sha...HEAD` (three dots) — three-dot is `merge-base(base.sha, HEAD)..HEAD`, and the frozen sha is *already* an ancestor of HEAD, so it is its own merge base. Set does not move. Same result #6192 recorded for its own diff.
- `HEAD^1` — correct on a merge ref, silently wrong the day someone gives this checkout a `ref:`.
- Dropping the variable and letting turbo default to `main` — in a CI-shaped clone `fetch-depth: 0` populates `refs/remotes/origin/*`, **not** local heads, so there is no local `main`. Turbo does not error: it silently returns the **entire** workspace, untouched packages included. Safe, and the whole optimisation gone.
- `TURBO_SCM_BASE=origin/$BASE_REF`, letting turbo resolve it — measured correct today, but it rests the shard's package set on `turbo ls`'s internal choice of dot-ness, which is undocumented and `turbo ls` is experimental (the step's own comment says so).

## Failure direction differs from #6192, deliberately

`pr-automation.yml` **fails** on an unresolvable base: it *is* the gate, so passing on unread input would be a false green (#4690). Here the affected set only *selects which tests to run*, and the full package list is a strict superset of the affected one. So an unresolvable base falls back to the **full list** with a visible `::warning::` — this shard still runs everything it would have run and more. Never a fallback to the frozen sha. Cost is minutes; the alternative would be a red Test Core on a PR with nothing wrong with it.

All four paths driven end-to-end: base resolvable (affected), base branch missing (full + warning), event with no base ref (full + warning), push/merge-queue (full, unchanged).

## PM mechanism assumptions

1. `ci.yml:220` still carries the frozen sha — **held** at `a36db28`.
2. #6192's pattern transfers — **yes**, with the one deliberate divergence above (failure direction), stated rather than assumed.
3. `fetch-depth: 0` makes `origin/$BASE_REF` resolvable — **yes**, same checkout shape #6192 measured on real CI. The fallback fetch is kept as a guard for the day that changes, not as the normal path.
4. `BASE_REF` available in that step's env — **no, falsified.** It was not there; introduced as `github.event.pull_request.base.ref` rather than assuming `main`.

## One non-obvious landmine, recorded in the file

`check-shard-attestation.mjs` classifies a job as an aggregate **gate** when its joined `run:` text contains both `check-shard-attestation.mjs` and, as a bare substring, that script's own two-dash verify flag. The shard job already carries the first (its `--emit` step), so the idiomatic `git rev-parse` strict spelling reclassified the shard job as a gate and turned the drift guard red with two complaints naming nothing to do with this edit. Hence `git cat-file -e`, with the reason written next to it. Filed separately as #6589 — the classifier's substring heuristic is the actual defect; this PR only routes around it in scope.

## Changeset

None, and `skip-changeset` applied. This is a CI-only change to one workflow step: no package source, no published artifact, no user-visible behaviour — nothing to release. The only observable effect is that PR shards test the packages this PR actually touched instead of also testing whatever main merged meanwhile.

## Verification

- 34/34 gates green, enumerated from `.github/workflows/lint.yml` (every `check:*` of the ESLint job) plus the workflow-reading gates in `pr-automation.yml` — run after `git commit`, since the ADR/registration-style gates read the committed tree.
- `pnpm check:shard-attestation` specifically: red before the `cat-file` change, green after — the collision above, caught and fixed rather than shipped.
- `node scripts/check-nul-bytes.mjs` green; explicit control-byte self-scan over `ci.yml` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_