### PR TITLE
fix(service-settings): company.country adopts the iso_3166_alpha2 value domain (#6579)

### DIFF
--- a/.changeset/company-country-value-domain.md
+++ b/.changeset/company-country-value-domain.md
@@ -1,0 +1,5 @@
+---
+'@objectstack/service-settings': patch
+---
+
+`company.country` adopts the `iso_3166_alpha2` value domain (#6579), the fourth case of the hole #5712 closed on localization: `pattern: '^[A-Za-z]{2}$'` constrains shape only, so `ZZ` (assigned to nobody) and `UK` (a CLDR alias, not an ISO 3166-1 code) passed the write door while the description promised ISO 3166-1. Both doors now judge membership against the explicit 249-code list (`invalid_value` with `constraint: { valueDomain: 'iso_3166_alpha2' }` on save; loud ignore on `OS_COMPANY_COUNTRY`). The pattern stays — a shape breach still speaks first as `invalid_format`. Deliberate tightening, same as #5712: membership is exact uppercase, so lowercase spellings like `us` are now refused.

--- a/packages/services/service-settings/src/manifests/company.manifest.test.ts
+++ b/packages/services/service-settings/src/manifests/company.manifest.test.ts
@@ -30,6 +30,27 @@ describe('companySettingsManifest', () => {
     expect(byKey('country').pattern).toBe('^[A-Za-z]{2}$');
   });
 
+  it('country declares the iso_3166_alpha2 value domain (#6579)', () => {
+    // #5712's fourth case: the description promised ISO 3166-1 all along while
+    // `^[A-Za-z]{2}$` constrained shape only (`ZZ` and `UK` passed the write
+    // door). The declaration is what makes the promise true; `SettingsService`
+    // enforces it on both doors. The pattern STAYS — shape still speaks first.
+    const specs = companySettingsManifest.specifiers as any[];
+    const byKey = (k: string) => specs.find((s) => s.key === k);
+    expect(byKey('country').valueDomain).toBe('iso_3166_alpha2');
+    expect(byKey('country').pattern).toBe('^[A-Za-z]{2}$');
+    // Every other key stays UNDECLARED on purpose: free-text legal-identity
+    // fields, not published standards.
+    for (const s of specs.filter((x) => x.key && x.key !== 'country')) {
+      expect(s.valueDomain, `${s.key} must not declare a domain`).toBeUndefined();
+    }
+    // And the declaration round-trips the spec parse (the enum is closed —
+    // a misspelt member would throw here, not silently strip).
+    const parsed = SettingsManifestSchema.parse(companySettingsManifest) as any;
+    expect(parsed.specifiers.find((s: any) => s.key === 'country').valueDomain)
+      .toBe('iso_3166_alpha2');
+  });
+
   it('has no required fields — every key is optional for v1', () => {
     const specs = companySettingsManifest.specifiers as any[];
     for (const s of specs.filter((x) => x.key)) {

--- a/packages/services/service-settings/src/manifests/company.manifest.ts
+++ b/packages/services/service-settings/src/manifests/company.manifest.ts
@@ -54,7 +54,11 @@ export const companySettingsManifest: SettingsManifest = {
     {
       type: 'text', key: 'country', label: 'Country', required: false,
       description: 'ISO 3166-1 alpha-2 code (e.g. US, GB, CN).',
+      // Fourth case of the hole #5712 closed on timezone/currency (#6579): the
+      // pattern constrains SHAPE only, and `ZZ` is a shape-valid code assigned
+      // to nobody. The domain constrains membership; both still apply.
       pattern: '^[A-Za-z]{2}$', minLength: 2, maxLength: 2,
+      valueDomain: 'iso_3166_alpha2',
     },
 
     // ── Contact ───────────────────────────────────────────────────────────

--- a/packages/services/service-settings/src/settings-service.test.ts
+++ b/packages/services/service-settings/src/settings-service.test.ts
@@ -8,6 +8,7 @@ import { mailSettingsManifest, mailTestActionHandler } from './manifests/mail.ma
 import { aiSettingsManifest } from './manifests/ai.manifest.js';
 import { authSettingsManifest } from './manifests/auth.manifest.js';
 import { localizationSettingsManifest } from './manifests/localization.manifest.js';
+import { companySettingsManifest } from './manifests/company.manifest.js';
 import { brandingSettingsManifest } from './manifests/branding.manifest.js';
 import { featureFlagsSettingsManifest } from './manifests/feature-flags.manifest.js';
 import { SettingsManifestSchema } from '@objectstack/spec/system';
@@ -2284,6 +2285,98 @@ describe('SettingsService — env overrides are judged against the declared valu
     const ok = new SettingsService({ env: { OS_LOCALIZATION_DEFAULT_COUNTRY: 'CH' }, logger: okLogger });
     ok.registerManifest(localizationSettingsManifest);
     expect((await ok.get('localization', 'default_country')).value).toBe('CH');
+    expect(okErrors).toHaveLength(0);
+  });
+});
+
+/**
+ * #6579 — `company.country` adopts `iso_3166_alpha2`, the fourth case of the
+ * hole #5712 closed on localization: the description promised ISO 3166-1 all
+ * along while `^[A-Za-z]{2}$` constrained shape only, so `ZZ` (assigned to
+ * nobody) and `UK` (a CLDR alias, not an ISO 3166-1 code) passed the write
+ * door. Same enforcement machinery, same verdicts — these pins only cover the
+ * adoption, not the machinery (that lives in the #5712 blocks above).
+ */
+describe('SettingsService — company.country adopts iso_3166_alpha2 (#6579)', () => {
+  const companyService = () => {
+    const svc = new SettingsService({ env: {} });
+    svc.registerManifest(companySettingsManifest);
+    return svc;
+  };
+
+  it('write door: admits an assigned code, refuses ZZ/UK with the domain in the constraint', async () => {
+    const svc = companyService();
+    await expect(svc.setMany('company', { country: 'CH' })).resolves.toBeDefined();
+    expect((await svc.get('company', 'country')).value).toBe('CH');
+    for (const cc of ['ZZ', 'UK']) {
+      await expect(svc.setMany('company', { country: cc })).rejects.toMatchObject({
+        code: 'SETTINGS_VALIDATION',
+        fields: [
+          {
+            field: 'country',
+            code: 'invalid_value',
+            label: 'Country',
+            constraint: { valueDomain: 'iso_3166_alpha2' },
+            value: cc,
+          },
+        ],
+      });
+    }
+  });
+
+  it('shape breach still speaks first, in the pattern vocabulary', async () => {
+    // `pattern` stays on the specifier: shape and membership narrow
+    // independently, and the shape verdict is the coarser, more actionable
+    // fact (the same window-before-grid ordering argument as #5712).
+    const svc = companyService();
+    await expect(svc.setMany('company', { country: 'ZZZ' })).rejects.toMatchObject({
+      fields: [{ field: 'country', code: 'invalid_format' }],
+    });
+  });
+
+  it('pins the deliberate tightening: lowercase `us` moves from pattern-accept to domain-reject', async () => {
+    // Before the adoption `^[A-Za-z]{2}$` admitted `us`; domain membership is
+    // exact uppercase, as ISO 3166-1 spells its codes — the same tightening
+    // #5712 recorded for `localization.default_country`. No in-repo runtime
+    // reader consumes `company.country` today, so the risk grade matches.
+    const svc = companyService();
+    await expect(svc.setMany('company', { country: 'us' })).rejects.toMatchObject({
+      fields: [
+        { field: 'country', code: 'invalid_value', constraint: { valueDomain: 'iso_3166_alpha2' } },
+      ],
+    });
+  });
+
+  it('env door judges OS_COMPANY_COUNTRY against the domain too — both doors move together', async () => {
+    // Domain membership ONLY: the env door does not enforce `pattern` for
+    // company keys — that gap is #6580's card, deliberately untouched here.
+    const errors: string[] = [];
+    const svc = new SettingsService({
+      env: { OS_COMPANY_COUNTRY: 'ZZ' },
+      logger: { error: (m: string) => void errors.push(m) },
+    });
+    svc.registerManifest(companySettingsManifest);
+
+    const r = await svc.get('company', 'country');
+    // Not in force: `country` declares no default, so the read resolves to the
+    // empty default layer rather than the rejected override.
+    expect(r.source).toBe('default');
+    expect(r.value).toBeNull();
+    expect(r.locked).toBe(false);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('OS_COMPANY_COUNTRY');
+    expect(errors[0]).toContain('ISO 3166-1');
+
+    // And a legal member is honored.
+    const okErrors: string[] = [];
+    const ok = new SettingsService({
+      env: { OS_COMPANY_COUNTRY: 'CH' },
+      logger: { error: (m: string) => void okErrors.push(m) },
+    });
+    ok.registerManifest(companySettingsManifest);
+    const okR = await ok.get('company', 'country');
+    expect(okR.value).toBe('CH');
+    expect(okR.source).toBe('env');
     expect(okErrors).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Closes #6579

## 变更内容

#5712 同一洞的第四例:`company.country` 的 description 一直承诺 ISO 3166-1,而 `pattern: '^[A-Za-z]{2}$'` 只约束形状——`ZZ`(未分配)与 `UK`(CLDR 别名,非 ISO 3166-1 码)均能通过写入门。#6581 合入后 `iso_3166_alpha2` 的执行(显式 249 码表,两扇门共判)已在库,本 PR 即该单裁定的「一行 + 测试」:

1. **`company.manifest.ts`**:`country` specifier 增加 `valueDomain: 'iso_3166_alpha2'`。`pattern` 保留——形状裁决仍先说话(`ZZZ` → `invalid_format`),形状与域各自独立收窄。
2. **测试**(沿用 #6581 建立的写法,localization 的 manifest + service 测试为模板):
   - manifest 测试:声明存在、round-trip 过 spec parse、其余键刻意不声明域;
   - 写入门:`CH` 收;`ZZ`/`UK` 拒(`invalid_value` + `constraint: { valueDomain: 'iso_3166_alpha2' }`);`ZZZ` 仍以 `invalid_format` 先拒;
   - **收紧钉死**:小写 `us` 从「pattern 收」变「域拒」——域成员按标准大写精确匹配,与 #5712 对 `localization.default_country` 的处理一致;库内无 `company.country` 运行时读者,风险同级;
   - env 门:`OS_COMPANY_COUNTRY` 同样按域裁决(`ZZ` 大声忽略、`CH` 生效)。**仅域**——env 门不执行 `pattern` 是 #6580 的独立卡,本 PR 刻意不触碰。

## 反向验证(先定方向再跑)

预测:删掉 `valueDomain` 一行后,声明测试、写入门 `ZZ`/`UK`、小写收紧钉、env 门测试变红;`ZZZ` 形状测试保持绿(pattern 仍在)。实测完全一致:4 红 1 绿,复原后 16 文件 / 323 测试全绿。

## 验证

- `pnpm --filter @objectstack/service-settings test`:16 文件 / 323 测试全过(本 PR 新增 5 条);
- 触碰文件 eslint 干净(exit 0);
- 包内 `tsc --noEmit` 错误数 13,与 DEBT 账本持平(未新增);
- `node scripts/check-nul-bytes.mjs` OK;
- changeset:`@objectstack/service-settings` patch(用户可见的校验收紧)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USNUyHEr7uaU6MoEWXitei

---
_Generated by [Claude Code](https://claude.ai/code/session_01USNUyHEr7uaU6MoEWXitei)_