### PR TITLE
fix(example-showcase): project-detail 的 tab token 改用声明的 `value` (#5776)

### DIFF
--- a/examples/app-showcase/src/ui/pages/project-detail.page.ts
+++ b/examples/app-showcase/src/ui/pages/project-detail.page.ts
@@ -40,7 +40,13 @@ export const ProjectDetailPage = definePage({
           {
             // Explicit details sections — each section's `fields` is a
             // field-list bound to showcase_project in the page editor.
-            key: 'details',
+            //
+            // `value` is the tab's stable `?tab=` URL token (#5776): the key
+            // `PageTabsProps.items[]` declares and objectui's tabs renderer
+            // reads. `key` was neither — an unknown prop nothing verifies and
+            // nothing reads, which left both tabs on the index-derived
+            // `tab-<i>` fallback and their deep links non-durable.
+            value: 'details',
             label: 'Details',
             children: [
               {
@@ -56,7 +62,7 @@ export const ProjectDetailPage = definePage({
             ],
           },
           {
-            key: 'tasks',
+            value: 'tasks',
             label: 'Tasks',
             children: [
               {

--- a/examples/app-showcase/test/project-detail-tabs.test.ts
+++ b/examples/app-showcase/test/project-detail-tabs.test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { PageTabsProps } from '@objectstack/spec/ui';
+
+import * as pages from '../src/ui/pages/index.js';
+import { ProjectDetailPage } from '../src/ui/pages/index.js';
+
+/**
+ * Dogfood gate for the project-detail page's tab strip (objectstack#5776).
+ *
+ * `page:tabs` items carry a **stable `?tab=` URL token**, and its one spelling
+ * is `value`: that is the key `PageTabsProps.items[]` declares (#5775) and the
+ * only one objectui's tabs renderer reads — `containers.tsx` takes a non-empty
+ * string `it.value` and otherwise derives the token from the item's index.
+ * This page authored `key` instead — a spelling neither side knows — so both
+ * tabs silently fell back to the index-derived `tab-<i>`: the page renders,
+ * and a deep link comes back to whichever tab happens to sit at that index.
+ * #5068's `component-props-unknown-key` gate reported it as exactly that, twice.
+ *
+ * The assertions pin both halves, so neither can regress in silence:
+ *  - the tokens are authored under the declared key and survive the schema's
+ *    own parse (an undeclared key would be stripped, not carried);
+ *  - `key` — and the other near-miss spellings — appear on no tab item in the
+ *    whole showcase corpus, so a later page cannot re-introduce the shape;
+ *  - the tokens are semantic and distinct, which is the property the
+ *    index-derived fallback does not have.
+ */
+
+type TabItem = Record<string, unknown> & { label?: unknown; value?: unknown };
+type AnyComponent = {
+  type?: unknown;
+  properties?: Record<string, unknown>;
+  [k: string]: unknown;
+};
+
+/** Every component on a page — regions and slots alike, nested tabs included. */
+function allComponents(page: Record<string, unknown>): AnyComponent[] {
+  const out: AnyComponent[] = [];
+  const visit = (node: unknown): void => {
+    if (!node || typeof node !== 'object' || Array.isArray(node)) return;
+    const component = node as AnyComponent;
+    out.push(component);
+    const props = component.properties;
+    if (!props) return;
+    for (const item of Array.isArray(props.items) ? props.items : []) {
+      const children = (item as TabItem)?.children;
+      for (const child of Array.isArray(children) ? children : []) visit(child);
+    }
+    for (const child of Array.isArray(props.children) ? props.children : []) visit(child);
+  };
+
+  for (const region of (page.regions as { components?: unknown[] }[] | undefined) ?? []) {
+    for (const c of region.components ?? []) visit(c);
+  }
+  for (const slot of Object.values((page.slots as Record<string, unknown>) ?? {})) {
+    for (const c of Array.isArray(slot) ? slot : [slot]) visit(c);
+  }
+  return out;
+}
+
+const tabsComponents = (page: Record<string, unknown>): AnyComponent[] =>
+  allComponents(page).filter((c) => c.type === 'page:tabs');
+
+const tabItems = (component: AnyComponent): TabItem[] =>
+  (Array.isArray(component.properties?.items) ? component.properties!.items : []) as TabItem[];
+
+/** Every page the showcase exports (the corpus the #5068 gate runs on). */
+const allPages = (Object.values(pages) as unknown[]).filter(
+  (p) =>
+    !!p && typeof p === 'object' && !Array.isArray(p) && typeof (p as { name?: unknown }).name === 'string',
+) as Record<string, unknown>[];
+
+describe('Project detail — tab tokens are authored under the declared `value` (#5776)', () => {
+  it('gives both tabs a stable `?tab=` token under `value`', () => {
+    const [tabs, ...rest] = tabsComponents(ProjectDetailPage as unknown as Record<string, unknown>);
+    expect(tabs, 'the project-detail page must carry a page:tabs component').toBeTruthy();
+    expect(rest, 'exactly one tab strip on this page').toHaveLength(0);
+
+    const items = tabItems(tabs);
+    expect(items).toHaveLength(2);
+    expect(items.map((it) => it.value)).toEqual(['details', 'tasks']);
+    for (const item of items) {
+      expect(item, `tab "${String(item.label)}" must not carry the undeclared \`key\``).not.toHaveProperty('key');
+    }
+  });
+
+  it('survives `PageTabsProps` parse with the tokens intact — a declared key is CARRIED', () => {
+    // The point of the rename: an undeclared key is dropped by the parse (strip
+    // mode) while looking authored in the source. Parsing here proves the token
+    // reaches a consumer, which is the whole difference between `key` and
+    // `value`.
+    const tabs = tabsComponents(ProjectDetailPage as unknown as Record<string, unknown>)[0]!;
+    const parsed = PageTabsProps.parse(tabs.properties);
+    expect(parsed.items.map((it) => it.value)).toEqual(['details', 'tasks']);
+  });
+
+  it('leaves no near-miss token spelling on any tab item in the showcase corpus', () => {
+    // The regression this pins is a new page (or a rewrite of this one) reaching
+    // for `key` / `id` / `name` again — every one of them renders fine and
+    // sets no token.
+    for (const page of allPages) {
+      for (const tabs of tabsComponents(page)) {
+        for (const item of tabItems(tabs)) {
+          for (const spelling of ['key', 'id', 'name', 'tabKey', 'slug'] as const) {
+            expect(
+              item,
+              `page "${String(page.name)}" tab "${String(item.label)}" must carry its token as \`value\`, not \`${spelling}\``,
+            ).not.toHaveProperty(spelling);
+          }
+        }
+      }
+    }
+  });
+
+  it('uses semantic, distinct tokens — the property the index fallback lacks', () => {
+    const values = tabItems(
+      tabsComponents(ProjectDetailPage as unknown as Record<string, unknown>)[0]!,
+    ).map((it) => it.value as string);
+    expect(new Set(values).size).toBe(values.length);
+    for (const value of values) {
+      expect(value).toMatch(/^[a-z][a-z0-9_:-]*$/);
+      // `tab-<i>` is exactly the derived fallback; authoring it back would make
+      // the token as fragile as having none.
+      expect(value).not.toMatch(/^tab-\d+$/);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #5776

## 做了什么

`examples/app-showcase/src/ui/pages/project-detail.page.ts` 的 `page:tabs` 上,两个 tab 的稳定 `?tab=` URL token 写成了 `key:`。这个拼法两侧都不认识:

- **schema 侧**:`PageTabsProps.items[]`(`packages/spec/src/ui/component.zod.ts`)声明的是 `label` / `icon` / `visibleWhen` / `value` / `count` / `children` —— 没有 `key`。schema 是 strip 模式,parse 直接把它剥掉。
- **renderer 侧**:objectui 的 tabs renderer(`packages/components/src/renderers/layout/containers.tsx`)只认非空字符串的 `it.value`,否则按下标派生 token。

所以两个 tab 的 token 一直是下标派生值,深链回不到原来那个 tab,而作者拿到的是成功回执 —— ADR-0078 的教科书形状。

```diff
-            key: 'details',
+            value: 'details',
-            key: 'tasks',
+            value: 'tasks',
```

**零 spec 改动、零 objectui 改动**:声明与 renderer 早就在 `value` 上一致(声明由 #5775 / PR #6281 补齐),错的只是这份语料 —— 修在生产者侧,不在消费者侧加别名(Prime Directive #12)。

## 前提复核(origin/main `a36db28b7`)

| 断言 | 复核结果 |
|---|---|
| 页面仍写 `key:` | ✅ `project-detail.page.ts:43` / `:59`(行号未漂移) |
| `items[].value` 与 `count` 已声明 | ✅ `component.zod.ts` 的 `PageTabsProps.items[]` 里都在,注释直接点名「Declared for #5776」 |
| renderer 读 `value`、不读 `key` | ✅ `containers.tsx` 只有 `it.value` 一处读;全文件搜不到任何 `.key` 读取 |
| 闸门确实覆盖这个形状(slot 里的组件) | ✅ `page-walk.ts` 既走 `regions[].components[]` 也走 `slots.*`,本页是 `kind: 'slotted'` |

## 逆向验证(方向先判后跑:预期 before 红 / after 绿)

**#5068 闸门 —— `os validate` 实跑,showcase 全量语料:**

| | 总 warning | `page:tabs` 相关 |
|---|---|---|
| before(`key:`) | 49 | 2 条 `` `key` is not a prop `page:tabs` declares `` |
| after(`value:`) | 47 | 0 |

两份输出逐行 diff **只有那 2 行的删除,没有任何新增诊断**。直接调 `validateComponentProps` 对 28 个 showcase page 复量,结论一致(4 → 2;剩下 2 条属别的单,见下)。

**新增的钉子测试 —— 把 `key:` 改回去,4 条断言全红**,而且红的方式本身就是证据:

```
× gives both tabs a stable `?tab=` token under `value`
    AssertionError: expected [ undefined, undefined ] to deeply equal [ 'details', 'tasks' ]
× survives `PageTabsProps` parse with the tokens intact — a declared key is CARRIED
    AssertionError: expected [ undefined, undefined ] to deeply equal [ 'details', 'tasks' ]
× leaves no near-miss token spelling on any tab item in the showcase corpus
    AssertionError: page "showcase_project_detail" tab "Details" must carry its token as `value`, not `key`
× uses semantic, distinct tokens — the property the index fallback lacks
```

第二条的 `[ undefined, undefined ]` 正是 strip 模式的实证:`key` 过不了 parse,token 根本到不了消费者。

**i18n:预期不动,实测不动。** `value` 是 URL token 不是 label,而 `_tabs` 那个翻译槽喂的是**对象筛选预设 tab**(`interfaceConfig.userFilters.tabs`),跟 `page:tabs` 的 items 不是一个载体。`pnpm check:i18n-coverage` → `OK (12 config(s), 660 baselined untranslated string(s), none new)`。

## 闸门台账

`#5068` 没有独立的违例基线文件 —— 清单是 warning 期的实跑输出(上表即是),本 PR 把其中 2 条销账,无文件可改。

一处如实记录:`packages/lint/src/validate-component-props.ts` 的模块头写着「距离 error 升级还差 #5728 与两处页面改写(`page:card.visible`;#5776 的 tab `key`)」。那两处现在都已落地(前者 #6513,后者本 PR),这句话已经过期 —— 但把它改对需要跨全部 example 语料重新盘一遍剩余违例,超出本单一行修复的范围,故未在本 PR 内改写,留给 error 升级那一单连同新清单一起写。

## 测试

- `pnpm --filter @objectstack/example-showcase test` → **15 files / 154 tests 全绿**(含新增 4 条)
- `pnpm --filter @objectstack/example-showcase typecheck` → 通过
- `pnpm --filter @objectstack/example-showcase validate` → `✓ Validation passed`
- `pnpm check:i18n-coverage` → OK, none new
- `node scripts/check-nul-bytes.mjs` → OK(6162 个文件,无裸控制字节)
- `eslint` 两个改动文件 → 无输出

## changeset

`@objectstack/example-showcase` 是 `private: true` 的示例包,不在 `.changeset/config.json` 的 fixed 组里,本 PR 不发布任何包 —— 因此打 `skip-changeset`,不写 changeset(与同类的 #6513 一致)。

## 顺手发现(未在本 PR 内修)

同一轮闸门实跑里,showcase 还剩 2 条违例:`element:button` 的 `action.params` 形状之争已由 #5777 跟踪;另一条 `properties.actionName`(`src/ui/pages/index.ts:82` 的 "Create Task" 按钮)此前无单,已另开 #6597 —— renderer 的 `handleClick` 开头就是 `if (!action ...) return;`,只写 `actionName` 的按钮点了没反应,与本单同一形状。


---
_Generated by [Claude Code](https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY)_