### PR TITLE
fix(metadata-protocol): cold boot names the org-scoped rows it cannot hydrate (#6190)

### DIFF
--- a/.changeset/org-scoped-cold-boot-audit.md
+++ b/.changeset/org-scoped-cold-boot-audit.md
@@ -1,0 +1,29 @@
+---
+'@objectstack/metadata-protocol': patch
+---
+
+冷启动跳过的 org 作用域元数据行不再无声消失
+
+`loadMetaFromDb` 按 ADR-0005(2026-05 修订)只水合 `organization_id IS NULL` 的行,
+per-org overlay 由 `getMetaItem`/`getMetaItems` 按需加载——对注册表里
+`allowOrgOverride: true` 的类型(`view`/`dashboard`/`report` 等)这是设计本身。但对
+**其余类型**,一条 org 作用域的行是平台根本没有 per-org 通道的行,而在此之前这个跳过
+是**完全静默**的。
+
+实测标本是 `flow`:它是 `allowOrgOverride: false`(#6283 / PR #6478 按 ADR-0005:57
+回滚),同时 `allowRuntimeCreate: true`,所以租户在 Studio 里新建一条 flow 仍会写出
+`sys_metadata.organization_id = '<org>'`——运行时 `PUT /metadata/:type/:name` 把
+`resolveActiveOrganizationId` 透传给 `saveMetaItem`,而 `SysMetadataRepository.put`
+对任何类型都按 `organization_id: this.organizationId` 落库。该 flow 在本进程内一直正常
+触发(发布时写穿进了进程级 registry),下一次重启后被这条过滤器丢掉,`kernel:ready` 的
+绑定器读的是 `getMetaItems({ type: 'flow' })`(不带 org),于是它**再也不触发,且没有任何
+日志说它消失了**——`kernel:bootstrapped` 的 unbound 审计也看不见它(它压根没注册)。
+
+现在冷启动会打一条聚合的 `warn`,按类型给出计数、抽样的 `name@org`,以及后果本身
+(「A 'flow' listed here will NOT bind its triggers in this process」)和处置建议。
+查询默认为空:两个收窄谓词(`organization_id IS NOT NULL` + 类型清单,清单由
+`DEFAULT_METADATA_TYPE_REGISTRY` 派生而非手写)让健康部署读不到行、也不打印任何东西;
+驱动若无法下推其中一个谓词,退化为多读几行而不是打出误报(JS 侧会复核两个谓词)。
+
+加载行为**未改变**:这次只是把缺席变响亮。这类行到底该不该存在(写入侧拒绝 / 强制写成
+env-wide / 让绑定器按 org 读)是 #6190 上待裁决的契约问题。

--- a/packages/metadata-protocol/src/protocol.org-scoped-cold-boot-audit.test.ts
+++ b/packages/metadata-protocol/src/protocol.org-scoped-cold-boot-audit.test.ts
@@ -1,0 +1,307 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #6190 — cold boot must SAY which org-scoped rows it walked past.
+ *
+ * ---------------------------------------------------------------------------
+ * What survived the upstream ruling, measured against `origin/main`
+ * ---------------------------------------------------------------------------
+ * #6155 Q1=B → #6283 → PR #6478 rolled `flow`'s `allowOrgOverride` back to
+ * `false` and proved declared=enforced on the write side: overlaying a
+ * PACKAGED flow per org is now a 403 `NOT_OVERRIDABLE` before persistence.
+ *
+ * That closed one of the two write tiers. The other is still open BY DESIGN —
+ * `flow` keeps `allowRuntimeCreate: true`, which is ADR-0005's "a deployment,
+ * not an overlay" — and it is the tier the tenant scenario in #6190 actually
+ * uses: authoring a BRAND-NEW flow in Studio. Measured on current main, that
+ * write still lands `sys_metadata.organization_id = '<org>'`, because
+ * `SysMetadataRepository.put` stamps `organization_id: this.organizationId`
+ * for every type and the runtime `PUT /metadata/:type/:name` threads
+ * `resolveActiveOrganizationId` into `saveMetaItem`:
+ *
+ *     PROBE rows = [{"name":"org_sweep","org":"org_a"},
+ *                   {"name":"platform_sweep","org":null}]
+ *     PROBE loadMetaFromDb = {"loaded":1,...}   // only platform_sweep
+ *     PROBE logs during cold boot = []          // ← the defect
+ *     PROBE getMetaItems({type:flow}) no org = ["platform_sweep"]
+ *
+ * So the symptom #6190 filed — an org-scoped flow that fires all day and never
+ * fires again after a restart — is still reachable, and the third line is why
+ * nobody can tell: the skip was completely silent. `kernel:bootstrapped`'s
+ * unbound audit cannot report it either, because the flow was never registered.
+ *
+ * This file pins the loud half. It does NOT change what boot loads — whether
+ * such a row should exist at all (refuse the write / force it env-wide / teach
+ * the binder to read per-org) is a contract ruling recorded on the issue.
+ *
+ * ---------------------------------------------------------------------------
+ * Reverse verification, direction predicted BEFORE running
+ * ---------------------------------------------------------------------------
+ * Ordinary red, with a deliberately green control. Deleting the
+ * `reportUnhydratableOrgScopedRows()` call from `loadMetaFromDb` turns the
+ * three "warns" cases red AND the probe-failure case with them — that one
+ * asserts the second `find` happened at all, so it goes red counting calls
+ * rather than reading a message. The two silence cases and the registry
+ * premise pin stay green: they assert an ABSENCE of output, which a deleted
+ * producer trivially satisfies. Predicted 4 red / 3 green; measured 4 red /
+ * 3 green, and the reds fail in the shape that names the defect:
+ *
+ *   AssertionError: no [metadata_org_scoped_unhydrated] line in: []
+ *   AssertionError: expected 1 to be greater than 1
+ *
+ * — the silent cold boot of the PROBE output above, reproduced on demand.
+ *
+ * The silence cases are not slack: a "fix" that warned about every skipped
+ * org-scoped row would pass the red half and fail there, and that shape is
+ * wrong — for `view` and friends (`allowOrgOverride: true`) the skip IS the
+ * ADR-0005 design, loaded on demand by `getMetaItem`/`getMetaItems`.
+ */
+import { describe, expect, it, vi } from 'vitest';
+// [#5619] The producer's OWN write-verb dispatch decisions (#4550 delete /
+// #5480 update). From `@objectstack/metadata-core`, never `@objectstack/objectql`
+// — objectql depends on THIS package, so that import would close a cycle.
+import { assertEngineDeleteDispatch, assertEngineUpdateDispatch } from '@objectstack/metadata-core';
+import { DEFAULT_METADATA_TYPE_REGISTRY } from '@objectstack/spec/kernel';
+import { ObjectStackProtocolImplementation } from './protocol.js';
+
+interface Row {
+    id: string;
+    type: string;
+    name: string;
+    organization_id: string | null;
+    state: string;
+    metadata: string;
+}
+
+/**
+ * A stub that honours the two predicates the audit query relies on
+ * (`organization_id: { $null: false }` and `type: { $in: [...] }`) plus the
+ * plain equality the boot query uses. `driver-memory`, `driver-sql` and
+ * `driver-mongodb` all lower `$null`; this mirrors that, and the
+ * dropped-predicate case gets its own stub below.
+ */
+function matchesWhere(r: Row, where: Record<string, unknown>): boolean {
+    for (const [k, v] of Object.entries(where)) {
+        if (v === undefined) continue;
+        const actual = (r as any)[k];
+        if (v !== null && typeof v === 'object') {
+            const ops = v as Record<string, unknown>;
+            if ('$null' in ops) {
+                const isNull = actual === null || actual === undefined;
+                if (isNull !== ops.$null) return false;
+            }
+            if ('$in' in ops) {
+                if (!(ops.$in as unknown[]).includes(actual)) return false;
+            }
+            continue;
+        }
+        if (actual !== v) return false;
+    }
+    return true;
+}
+
+function makeEngine(rows: Row[], opts: { dropPredicates?: boolean } = {}) {
+    const registered: Array<{ type: string; name: string }> = [];
+    const engine: any = {
+        async find(_table: string, q: { where: Record<string, unknown> }) {
+            // A driver that cannot lower `$null`/`$in` hands back a superset —
+            // the exact degradation the JS re-check exists for.
+            if (opts.dropPredicates) return rows.filter((r) => r.state === q.where.state);
+            return rows.filter((r) => matchesWhere(r, q.where));
+        },
+        async findOne() { return null; },
+        async insert() { return { id: 'x' }; },
+        async update(_t: string, data: Record<string, unknown>, o?: Record<string, unknown>) {
+            assertEngineUpdateDispatch(data, o);
+            return { id: null };
+        },
+        async delete(_t: string, o?: Record<string, unknown>) {
+            assertEngineDeleteDispatch(o);
+            return { deleted: 0 };
+        },
+        registry: {
+            registerItem: (type: string, item: any) => { registered.push({ type, name: item?.name }); },
+            registerObject: (item: any) => { registered.push({ type: 'object', name: item?.name }); },
+            listItems: () => [],
+            getItem: () => undefined,
+            getArtifactItem: () => undefined,
+            isPackageDisabled: () => false,
+        },
+    };
+    return { engine, registered };
+}
+
+const flowBody = (name: string) => JSON.stringify({
+    name,
+    label: 'Escalate overdue tasks',
+    type: 'record_change',
+    status: 'active',
+    nodes: [
+        { id: 'start', type: 'start', label: 'Start', config: { objectName: 'task', triggerType: 'record-after-update' } },
+        { id: 'end', type: 'end', label: 'End' },
+    ],
+    edges: [{ id: 'e1', source: 'start', target: 'end' }],
+});
+
+const viewBody = (name: string) => JSON.stringify({
+    name, label: 'Overdue', object: 'task', columns: [{ field: 'name', label: 'Name' }],
+});
+
+const row = (over: Partial<Row> & Pick<Row, 'type' | 'name'>): Row => ({
+    id: `r_${over.type}_${over.name}_${over.organization_id ?? 'env'}`,
+    organization_id: null,
+    state: 'active',
+    metadata: over.type === 'view' ? viewBody(over.name) : flowBody(over.name),
+    ...over,
+});
+
+/** One `console.warn` capture, returned as the lines the boot printed. */
+async function bootAndCapture(engine: any): Promise<{ result: any; warns: string[] }> {
+    const warns: string[] = [];
+    const spy = vi.spyOn(console, 'warn').mockImplementation((...a: unknown[]) => {
+        warns.push(a.map(String).join(' '));
+    });
+    try {
+        const protocol = new ObjectStackProtocolImplementation(engine) as any;
+        const result = await protocol.loadMetaFromDb();
+        return { result, warns };
+    } finally {
+        spy.mockRestore();
+    }
+}
+
+const AUDIT = '[metadata_org_scoped_unhydrated]';
+
+describe('#6190 — cold boot names the org-scoped rows it cannot hydrate', () => {
+    // ── the premise, read from the registry rather than restated ──────────
+
+    it('flow is the specimen: not per-org overridable, still runtime-creatable', () => {
+        // Both halves matter. `allowOrgOverride: false` (#6283 / PR #6478) is
+        // why an org-scoped flow row can never be read back as an overlay;
+        // `allowRuntimeCreate: true` is why one can still be WRITTEN. If a
+        // later ruling closes the second flag, this case goes red and the
+        // whole file should be re-read, not repaired.
+        expect(DEFAULT_METADATA_TYPE_REGISTRY.find((e) => e.type === 'flow')).toMatchObject({
+            allowOrgOverride: false,
+            allowRuntimeCreate: true,
+        });
+        // The control specimen's flag, likewise read and not assumed.
+        expect(DEFAULT_METADATA_TYPE_REGISTRY.find((e) => e.type === 'view')).toMatchObject({
+            allowOrgOverride: true,
+        });
+    });
+
+    // ── the acceptance criterion: the absence is loud ─────────────────────
+
+    it('warns, naming type/name/org, when an org-scoped FLOW row is skipped', async () => {
+        const { engine } = makeEngine([
+            row({ type: 'flow', name: 'org_sweep', organization_id: 'org_a' }),
+            row({ type: 'flow', name: 'platform_sweep' }),
+        ]);
+
+        const { result, warns } = await bootAndCapture(engine);
+
+        // Hydration itself is UNCHANGED — this issue's fix is the log, not a
+        // load. The org row stays out of the process-wide registry.
+        expect(result).toMatchObject({ loaded: 1, errors: 0, invalid: 0, storeUnavailable: false });
+
+        const line = warns.find((w) => w.includes(AUDIT));
+        expect(line, `no ${AUDIT} line in: ${JSON.stringify(warns)}`).toBeDefined();
+        expect(line).toContain('flow×1');
+        expect(line).toContain('org_sweep@org_a');
+        // The consequence, not just the fact — an operator reading this must
+        // learn why an automation stopped firing after a restart.
+        expect(line).toContain('bind its triggers');
+        // And it must not name the row that DID load.
+        expect(line).not.toContain('platform_sweep');
+    });
+
+    it('counts every row but samples the names, so a thousand rows cost one line', async () => {
+        const rows: Row[] = [];
+        for (let i = 0; i < 9; i++) {
+            rows.push(row({ type: 'flow', name: `sweep_${i}`, organization_id: `org_${i}` }));
+        }
+        const { engine } = makeEngine(rows);
+
+        const { warns } = await bootAndCapture(engine);
+
+        const audit = warns.filter((w) => w.includes(AUDIT));
+        expect(audit).toHaveLength(1);
+        expect(audit[0]).toContain('flow×9');
+        expect(audit[0]).toContain('+4 more');
+    });
+
+    it('still warns when the driver drops the predicates and returns a superset', async () => {
+        // `driver-memory` historically dropped `is_null` outright (see its
+        // `memory-filter-ast-vocabulary.test.ts`), so the audit re-checks both
+        // predicates in JS. A superset must produce the SAME line — not a
+        // false accusation against the env-wide and view rows in it.
+        const { engine } = makeEngine([
+            row({ type: 'flow', name: 'org_sweep', organization_id: 'org_a' }),
+            row({ type: 'flow', name: 'platform_sweep' }),
+            row({ type: 'view', name: 'org_grid', organization_id: 'org_a' }),
+        ], { dropPredicates: true });
+
+        const { warns } = await bootAndCapture(engine);
+
+        const line = warns.find((w) => w.includes(AUDIT));
+        expect(line).toBeDefined();
+        expect(line).toContain('org_sweep@org_a');
+        expect(line).not.toContain('platform_sweep');
+        expect(line).not.toContain('org_grid');
+    });
+
+    // ── the silence that is the design, not a miss ────────────────────────
+
+    it('says NOTHING about an org-scoped VIEW — that skip is ADR-0005 working', async () => {
+        // `view` is `allowOrgOverride: true`: the row is a per-org overlay,
+        // deliberately not hydrated process-wide and served on demand by
+        // `getMetaItem`/`getMetaItems({ organizationId })`. Warning here would
+        // print a line at every boot of every healthy tenant.
+        const { engine } = makeEngine([
+            row({ type: 'view', name: 'org_grid', organization_id: 'org_a' }),
+            row({ type: 'view', name: 'platform_grid' }),
+        ]);
+
+        const { result, warns } = await bootAndCapture(engine);
+
+        expect(result.loaded).toBe(1);
+        expect(warns.filter((w) => w.includes(AUDIT))).toEqual([]);
+    });
+
+    it('says nothing at all on a store with no org-scoped rows', async () => {
+        const { engine } = makeEngine([
+            row({ type: 'flow', name: 'platform_sweep' }),
+            row({ type: 'view', name: 'platform_grid' }),
+        ]);
+
+        const { result, warns } = await bootAndCapture(engine);
+
+        expect(result.loaded).toBe(2);
+        expect(warns.filter((w) => w.includes(AUDIT))).toEqual([]);
+    });
+
+    // ── the diagnostic can never become the outage ────────────────────────
+
+    it('a failing audit probe does not change the boot verdict', async () => {
+        // #5897 draws a hard line between "the store had no rows" and "the
+        // store could not be read". A best-effort extra probe must not be able
+        // to cross it: the first `find` succeeds, so this boot is HEALTHY, and
+        // `storeUnavailable` must stay false even though the probe threw.
+        let call = 0;
+        const { engine } = makeEngine([row({ type: 'flow', name: 'platform_sweep' })]);
+        const inner = engine.find;
+        engine.find = async (t: string, q: any) => {
+            call++;
+            if (call > 1) throw new Error('probe exploded');
+            return inner(t, q);
+        };
+
+        const { result, warns } = await bootAndCapture(engine);
+
+        expect(call).toBeGreaterThan(1);
+        expect(result).toMatchObject({ loaded: 1, errors: 0, storeUnavailable: false });
+        expect(warns.filter((w) => w.includes('DB hydration skipped'))).toEqual([]);
+        expect(warns.filter((w) => w.includes(AUDIT))).toEqual([]);
+    });
+});

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -10955,6 +10955,9 @@ export class ObjectStackProtocolImplementation implements
                     console.warn(`[Protocol] Failed to hydrate ${record.type}/${record.name}: ${e instanceof Error ? e.message : String(e)}`);
                 }
             }
+            // #6190 — say out loud which org-scoped rows this filter just
+            // walked past. See {@link reportUnhydratableOrgScopedRows}.
+            await this.reportUnhydratableOrgScopedRows();
         } catch (e: unknown) {
             // #5841 — the ONE benign reason this whole read can fail is
             // `sys_metadata` not being provisioned yet: on a first boot, before
@@ -10998,6 +11001,127 @@ export class ObjectStackProtocolImplementation implements
             }
         }
         return { loaded, errors, invalid, storeUnavailable };
+    }
+
+    /**
+     * [#6190] Cold boot walks past every `organization_id IS NOT NULL` row.
+     * For the types the registry declares per-org overridable that is the
+     * design (ADR-0005 revised 2026-05 — those overlays are loaded on demand
+     * by `getMetaItem`/`getMetaItems`, which is why the filter above exists).
+     * For every OTHER type it is a stored row the platform has no per-org
+     * channel for, and until this method the skip was **completely silent**.
+     *
+     * The measured specimen is `flow`. `flow` is `allowOrgOverride: false`
+     * (rolled back in #6283 / PR #6478, matching ADR-0005:57) but
+     * `allowRuntimeCreate: true`, so a tenant authoring a BRAND-NEW flow in
+     * Studio still writes `sys_metadata.organization_id = '<org>'` — the
+     * runtime `PUT /metadata/:type/:name` threads `resolveActiveOrganizationId`
+     * into `saveMetaItem`, and `SysMetadataRepository.put` stamps
+     * `organization_id: this.organizationId` whatever the type is. That flow
+     * binds its triggers for the rest of the process's life (the publish-time
+     * write-through puts it in the process-wide registry) and then, on the
+     * next restart, this filter drops it and the `kernel:ready` binder —
+     * `getMetaItems({ type: 'flow' })`, no `organizationId`, so
+     * `orgRecords = []` — never sees it. It stops firing, and nothing said so:
+     * the `kernel:bootstrapped` unbound audit cannot report a flow that was
+     * never registered.
+     *
+     * This method does not change what boot loads. It makes the absence
+     * LOUD — AGENTS.md's rule, and the half of #6190 that is implementable
+     * without a contract ruling. Whether such a row should exist at all
+     * (refuse the write / force it env-wide / teach the binder to read per-org)
+     * is the maintainer decision recorded on the issue; the operator-visible
+     * consequence is the same either way and it is what an operator needs
+     * TODAY to explain an automation that stopped after a restart.
+     *
+     * Shape decisions, all deliberate:
+     *
+     *  - **Which rows.** Registry-derived, never a hand-written list
+     *    (Prime Directive #7): the complement of
+     *    {@link OVERLAY_ALLOWED_TYPES}'s source flag. Derived from
+     *    `DEFAULT_METADATA_TYPE_REGISTRY` and NOT from
+     *    {@link isOverlayAllowed}, because the `OS_METADATA_WRITABLE` escape
+     *    hatch only unlocks the WRITE — an env-unlocked type's org rows are
+     *    hydrated no more than any other's, so silencing the line on that
+     *    flag would hide exactly the deployment most likely to have these rows.
+     *  - **Two predicates, both narrowing.** `organization_id IS NOT NULL`
+     *    plus the type list keeps the query empty-by-default: a healthy
+     *    deployment reads nothing and prints nothing. A driver that drops
+     *    either predicate degrades to reading more rows, never to a false
+     *    line — the JS filter re-checks both.
+     *  - **One aggregated line.** Counts per type plus a capped sample of
+     *    names, so a tenant with a thousand such rows costs one line rather
+     *    than a thousand.
+     *  - **Best-effort, and non-fatal by construction.** A diagnostic must
+     *    never be the reason a boot fails, so its own catch swallows: the
+     *    caller's outer catch classifies REAL hydration outages
+     *    (`storeUnavailable`, #5897) and this must not be able to reach it.
+     */
+    private async reportUnhydratableOrgScopedRows(): Promise<void> {
+        /** Names printed per type before the line collapses to a count. */
+        const SAMPLE_PER_TYPE = 5;
+        try {
+            const orgOverridable = new Set<string>();
+            const scannedTypes: string[] = [];
+            for (const entry of DEFAULT_METADATA_TYPE_REGISTRY) {
+                if (entry.allowOrgOverride) {
+                    orgOverridable.add(entry.type);
+                    continue;
+                }
+                scannedTypes.push(entry.type);
+                const plural = SINGULAR_TO_PLURAL[entry.type];
+                if (plural) scannedTypes.push(plural);
+            }
+            if (scannedTypes.length === 0) return;
+
+            const rows = await this.engine.find('sys_metadata', {
+                where: {
+                    state: 'active',
+                    organization_id: { $null: false },
+                    type: { $in: scannedTypes },
+                },
+            });
+            if (!rows || rows.length === 0) return;
+
+            // Re-check both predicates in JS: a driver that cannot lower one
+            // of them hands back a superset, and a superset must not become a
+            // false accusation.
+            const counts = new Map<string, number>();
+            const samples = new Map<string, string[]>();
+            let total = 0;
+            for (const row of rows) {
+                const org = (row as { organization_id?: string | null }).organization_id;
+                if (org === null || org === undefined || org === '') continue;
+                const singular = PLURAL_TO_SINGULAR[String(row.type)] ?? String(row.type);
+                if (orgOverridable.has(singular)) continue;
+                total++;
+                counts.set(singular, (counts.get(singular) ?? 0) + 1);
+                const names = samples.get(singular) ?? [];
+                if (names.length < SAMPLE_PER_TYPE) names.push(`${String(row.name)}@${String(org)}`);
+                samples.set(singular, names);
+            }
+            if (total === 0) return;
+
+            const detail = Array.from(counts.entries())
+                .map(([type, count]) => {
+                    const names = samples.get(type) ?? [];
+                    const more = count > names.length ? `, +${count - names.length} more` : '';
+                    return `${type}×${count} (${names.join(', ')}${more})`;
+                })
+                .join('; ');
+            console.warn(
+                `[Protocol] [metadata_org_scoped_unhydrated] ${total} active sys_metadata row(s) are ` +
+                `org-scoped on types the registry declares NOT per-org overridable, so boot hydration ` +
+                `skipped them and they are absent from the process-wide registry: ${detail}. ` +
+                `A 'flow' listed here will NOT bind its triggers in this process (the kernel:ready binder ` +
+                `reads flows env-wide) — it fired until the last restart and stops now. ` +
+                `Re-save the item env-wide (no active organization), or delete the row. See #6190 / ADR-0005.`,
+            );
+        } catch {
+            // Diagnostics never break boot — see the TSDoc. Deliberately not
+            // routed to the caller's outer catch: that one classifies real
+            // hydration outages, and a failed extra probe is not one.
+        }
     }
 
     // ==========================================


### PR DESCRIPTION
Part of objectstack-ai/objectstack#6190 (the loud-log half; the contract half awaits the maintainer ruling on the issue)

This was dispatched verification-first, on the reading that PR #6478 had closed the card. **It had not** — it closed one of the two write tiers, and the tenant scenario #6190 describes uses the other. Everything below is measured against `origin/main`, not inferred.

## What #6478 closed, and what it deliberately did not

#6155 Q1=B → #6283 → PR #6478 rolled `flow`'s `allowOrgOverride` back to `false` and proved declared=enforced on the write side. Re-measured here on current main, that half holds:

```
PROBE P4 err  = {"code":"NOT_OVERRIDABLE","status":403,...}
PROBE P4 rows = []                       // refused BEFORE persistence
```

The other tier is open by design, and PR #6478 says so in its own test name — "a BRAND-NEW org flow still saves — allowRuntimeCreate is a different tier". That is ADR-0005's "a deployment, not an overlay", and this PR does not touch it.

But that tier is exactly the one a tenant uses when they author a **new** flow in Studio. `SysMetadataRepository.put` stamps `organization_id: this.organizationId` for **every** type, and the runtime `PUT /metadata/:type/:name` threads `resolveActiveOrganizationId` into `saveMetaItem`. So the org-scoped flow row #6190 measured is still minted today:

```
PROBE P1 save result = {"success":true,
  "message":"Saved flow 'org_sweep' (org=org_a, state=active) [seq=1]"}
PROBE P1 rows = [{"type":"flow","name":"org_sweep","org":"org_a","state":"active"},
                 {"type":"flow","name":"platform_sweep","org":null,"state":"active"}]
```

and the original symptom reproduces unchanged, including the part the issue titled itself after:

```
PROBE P2 loadMetaFromDb = {"loaded":1,...}          // only platform_sweep
PROBE P2 logs during cold boot = []                 // ← nothing said so
PROBE P2 getMetaItems({type:flow}) no org = ["platform_sweep"]
```

The `kernel:ready` binder reads `getMetaItems({ type: 'flow' })` with no `organizationId`, so `orgRecords` is `[]` and the flow never registers. `kernel:bootstrapped`'s unbound audit cannot report it either — it was never registered. It fired all day, it stops after the restart, and the third line above is why nobody can tell.

## What this PR changes

**Only the silence.** `loadMetaFromDb` loads exactly what it loaded before; a new `reportUnhydratableOrgScopedRows()` prints one aggregated `warn` naming the rows the filter walked past, with counts per type, a capped sample of `name@org`, the consequence ("A 'flow' listed here will NOT bind its triggers in this process") and what to do about it.

Whether such a row should exist at all — refuse the write, force it env-wide, or teach the binder to read per-org — is a contract ruling and is escalated on the issue, not guessed at here.

Shape decisions, all deliberate and all in the TSDoc:

- **Which rows.** Registry-derived, never a hand-written list (Prime Directive #7): the types `DEFAULT_METADATA_TYPE_REGISTRY` declares NOT per-org overridable. Derived from the registry and **not** from `isOverlayAllowed`, because `OS_METADATA_WRITABLE` only unlocks the *write* — an env-unlocked type's org rows hydrate no more than anyone else's, so keying the line on that flag would silence exactly the deployment most likely to hold these rows.
- **Silent for `view` and friends.** For `allowOrgOverride: true` types the skip **is** the ADR-0005 design (loaded on demand by `getMetaItem` / `getMetaItems`). Warning there would print a line at every boot of every healthy tenant, so it does not.
- **Empty by default.** Two narrowing predicates (`organization_id IS NOT NULL` plus the type list) mean a healthy deployment reads nothing and prints nothing. A driver that cannot lower either predicate degrades to reading *more* rows, never to a false accusation — the JS filter re-checks both, and that degradation has its own test.
- **A diagnostic can never become the outage.** Its own catch swallows, so it cannot reach the outer catch that classifies real hydration outages (`storeUnavailable`, #5897). Pinned.

## Reverse verification — direction predicted before running

Ordinary red, with a deliberately green control. Deleting the `reportUnhydratableOrgScopedRows()` call turns the three "warns" cases red **and** the probe-failure case with them (it asserts the second `find` happened at all, so it fails counting calls rather than reading a message). The two silence cases and the registry premise pin stay green — they assert an absence of output, which a deleted producer trivially satisfies. Predicted 4 red / 3 green; measured 4 red / 3 green:

```
× warns, naming type/name/org, when an org-scoped FLOW row is skipped
× counts every row but samples the names, so a thousand rows cost one line
× still warns when the driver drops the predicates and returns a superset
× a failing audit probe does not change the boot verdict
  Tests  4 failed | 3 passed (7)

AssertionError: no [metadata_org_scoped_unhydrated] line in: []
AssertionError: expected 1 to be greater than 1
```

The silence cases are not slack: a "fix" that warned about every skipped org-scoped row would pass the red half and fail there.

## Tests

```
pnpm --filter @objectstack/metadata-protocol test
  Test Files  58 passed (58)
       Tests  618 passed (618)

pnpm --filter @objectstack/objectql exec vitest run src/protocol-meta.test.ts \
  src/plugin-restore-metadata-outage.test.ts src/plugin-metadata-event-outage.test.ts \
  src/overlay-precedence.test.ts src/protocol-package-lifecycle.test.ts
  Test Files  5 passed (5)
       Tests  141 passed (141)

tsc --noEmit -p packages/metadata-protocol/tsconfig.json  → 63 errors
  (exactly the ledgered DEBT count; neither changed file contributes one)
```

Every `check:*` step enumerated from `.github/workflows/lint.yml` was run one by one — 45 steps, all PASS, including `check:engine-double-contract`, `check:route-envelope`, `check:error-code-casing`, `check:durability-log-level`, `check:startup-registry-verdict` and `check:nul-bytes`.

## Not in this PR

Impact ② of the issue (an org-scoped row entering the **process-wide** SchemaRegistry through `applyRegistryWriteThrough`, whose gate blocks only `environmentId !== undefined`) is real and measured, applies to every org-overridable type rather than to `flow`, and has a read-side twin in `getMetaItems`. Filed separately per Prime Directive #10 rather than widened into this diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KDU3qAuJyajAQm3GkUXdfA)_