### PR TITLE
fix(cli,lint): 分区标题只读声明拼写 `label`,删掉两处 `?? title` 容忍读 (#5730)

### DIFF
--- a/.changeset/tame-donkeys-repeat.md
+++ b/.changeset/tame-donkeys-repeat.md
@@ -1,0 +1,33 @@
+---
+'@objectstack/cli': patch
+'@objectstack/lint': patch
+---
+
+i18n section headings: read only the declared `label` spelling, never `title`
+
+`record:details` sections and form-view sections declare exactly one heading key —
+`label` (`RecordDetailsProps.sections[]` and `FormSectionSchema`; #5611 settled this
+by declaring `label` and deliberately NOT declaring `title`). Two consumers still
+read `label ?? title`:
+
+- `os i18n extract` / `os lint`'s coverage walk (`i18n-extract.ts`) scaffolded
+  `objects.<object>._sections.<name>.label` from a `title`;
+- the `translation-section-name-missing` lint rule accepted a `title` as the
+  heading it reports on.
+
+Both now read `label` only. Per Prime Directive #12 the tolerance was the bug: a
+consumer that reads an undeclared spelling turns it into a second de-facto contract,
+and here it did so on the loudest possible surface — the extractor would seed a
+translation bundle key from a spelling the schema rejects, teaching the wrong key to
+every translator downstream.
+
+FROM → TO: a section authored as `{ name: 'timeline', title: 'Timeline' }` becomes
+`{ name: 'timeline', label: 'Timeline' }`. No migration is expected in practice —
+every `record:details` section in this repo and in `packages/platform-objects`
+already authors `label` (~12 sections, zero `title`).
+
+Behaviour change if you do author `title`: the heading is treated as absent. The
+extractor still emits the section's expected key (it is derived from `name`) but
+seeds it with the section name instead of your `title` text, and the lint rule no
+longer reports that section. Rename the key to `label` — which is also what the
+schema itself will tell you, since `title` is not a declared key there.

--- a/packages/cli/src/utils/i18n-extract.ts
+++ b/packages/cli/src/utils/i18n-extract.ts
@@ -439,10 +439,14 @@ function addSectionList(index: SectionIndex, sections: unknown, objectName: unkn
   for (const section of sections) {
     if (!section || typeof section !== 'object') continue;
     const s = section as Record<string, unknown>;
-    // `record:details` reads `title ?? label`, form views author `label`; a
-    // localized-map label (`{ en, 'zh-CN' }`) is already multilingual and
+    // `label` is the ONE heading spelling both surfaces declare —
+    // `RecordDetailsProps.sections[]` and `FormSectionSchema` (#5611, #5730).
+    // A `title` here is off-spec and deliberately unread: reading it would
+    // scaffold a bundle key for a heading the schema rejects, which is how a
+    // consumer-side tolerance grows into a second de-facto contract (PD #12).
+    // A localized-map label (`{ en, 'zh-CN' }`) is already multilingual and
     // `inlineText` drops it to "nothing authored in plain text".
-    addSection(index, objectName, s.name, s.label ?? s.title);
+    addSection(index, objectName, s.name, s.label);
   }
 }
 

--- a/packages/cli/test/i18n-section-coverage.test.ts
+++ b/packages/cli/test/i18n-section-coverage.test.ts
@@ -217,7 +217,7 @@ describe('authored record-page sections', () => {
                   properties: {
                     sections: [
                       { name: 'overview', label: 'Overview', fields: ['name'] },
-                      { name: 'timeline', title: 'Timeline', fields: ['close_date'] },
+                      { name: 'timeline', label: 'Timeline', fields: ['close_date'] },
                     ],
                   },
                 },
@@ -236,9 +236,28 @@ describe('authored record-page sections', () => {
     ]);
   });
 
-  it('reads `title` as the source text too — that is what `record:details` renders', () => {
+  it('reads `label` as the source text', () => {
     const timeline = sectionEntries({ pages: [slottedPage] }).find((e) => e.path[3] === 'timeline');
     expect(timeline?.inline).toBe('Timeline');
+  });
+
+  it('does NOT read an off-spec `title` as the source text — the key is still emitted, empty', () => {
+    // #5730: `label` is the only heading spelling `RecordDetailsProps.sections[]`
+    // declares (#5611). The walk keys sections off `name`, so a `title`-only
+    // section STILL contributes its expected key — what it must not contribute
+    // is source text, because scaffolding `"Timeline"` into a bundle from an
+    // off-spec key is how the second spelling would become self-documenting.
+    // Asserting the key survives is what keeps this non-vacuous: the entry is
+    // present and its `inline` is empty, not absent because nothing was walked.
+    const titled = JSON.parse(JSON.stringify(slottedPage));
+    const sections = titled.slots.tabs.properties.items[0].children[0].properties.sections;
+    sections[1] = { name: 'timeline', title: 'Timeline', fields: ['close_date'] };
+
+    const entries = sectionEntries({ pages: [titled] });
+    expect(entries.map((e) => e.path.join('.'))).toContain(
+      'objects.crm_opportunity._sections.timeline.label',
+    );
+    expect(entries.find((e) => e.path[3] === 'timeline')?.inline).toBeUndefined();
   });
 
   it('reaches the plain `regions[].components[]` shape, and never mines a page REGION name', () => {

--- a/packages/lint/src/validate-translatable-sections.test.ts
+++ b/packages/lint/src/validate-translatable-sections.test.ts
@@ -314,22 +314,35 @@ describe('validateTranslatableSections — what it deliberately leaves alone', (
     expect(findings).toEqual([]);
   });
 
-  it('reads a detail section\'s `title` as its heading', () => {
-    // `record:details` reads `title ?? label` — a nameless section with only a
-    // `title` renders a heading just the same.
-    const findings = validateTranslatableSections({
-      objects: [crmCase],
-      pages: [
-        {
-          name: 'case_detail',
-          object: 'crm_case',
-          regions: [{ components: [{ type: 'record:details', properties: { sections: [{ title: 'SLA' }] } }] }],
-        },
-      ],
-      translations: caseTranslated,
-    });
+  // #5730: `label` is the only heading spelling `RecordDetailsProps.sections[]`
+  // declares (#5611). The rule used to read `label ?? title`, which meant an
+  // off-spec `title` earned a translation-shaped warning — telling the author
+  // their `title` heading needed a `name` to be translatable, i.e. teaching the
+  // spelling the schema rejects. The two cases below are one pin, deliberately
+  // PAIRED: the `label` case proves the walk reaches this component at all, so
+  // the `title` case's empty result is the tolerance being gone and not the
+  // fixture failing to arrive (#5046's "green because nothing was produced").
+  const namelessDetailSection = (section: Record<string, unknown>) => ({
+    objects: [crmCase],
+    pages: [
+      {
+        name: 'case_detail',
+        object: 'crm_case',
+        regions: [{ components: [{ type: 'record:details', properties: { sections: [section] } }] }],
+      },
+    ],
+    translations: caseTranslated,
+  });
+
+  it('reads a detail section\'s `label` as its heading', () => {
+    const findings = validateTranslatableSections(namelessDetailSection({ label: 'SLA' }));
     expect(findings).toHaveLength(1);
     expect(findings[0].where).toContain('section "SLA"');
+  });
+
+  it('does NOT read a detail section\'s off-spec `title` as its heading', () => {
+    const findings = validateTranslatableSections(namelessDetailSection({ title: 'SLA' }));
+    expect(findings).toEqual([]);
   });
 
   it('keys a retargeted component under the object it actually binds', () => {

--- a/packages/lint/src/validate-translatable-sections.ts
+++ b/packages/lint/src/validate-translatable-sections.ts
@@ -323,10 +323,12 @@ export function validateTranslatableSections(stack: AnyRec): TranslatableSection
       const section = site.sections[i];
       if (!isRec(section)) continue;
       if (strName(section.name)) continue;
-      // `record:details` reads `title ?? label`; form views author `label`. A
-      // section with neither has no heading rendered at all, so there is
-      // nothing untranslated to report — that is `required/label`'s question.
-      const heading = strName(section.label) ?? strName(section.title);
+      // `label` is the ONE heading spelling both surfaces declare —
+      // `RecordDetailsProps.sections[]` and `FormSectionSchema` (#5611, #5730).
+      // A section with no `label` has no heading the schema recognises, so
+      // there is nothing untranslated to report — that is `required/label`'s
+      // question, and an off-spec `title` is its business, not this rule's.
+      const heading = strName(section.label);
       if (!heading) continue;
 
       const slug = suggestedName(heading);


### PR DESCRIPTION
Fixes #5730

## 做了什么

`record:details` 分区标题只有一个声明拼写 —— `label`。#5611 落地时已经把
`RecordDetailsProps.sections[]` 声明为 `{ name?, label?, columns?, fields }`,
**刻意不声明 `title`**;`FormSectionSchema` 同样只有 `label`。但仓内两个消费方仍在读
`label ?? title`,本 PR 把这两处容忍读收敛到只读 `label`。

| 消费方 | 位置 | 改动 |
|---|---|---|
| i18n 抽取 | `packages/cli/src/utils/i18n-extract.ts` `addSectionList()` | `s.label ?? s.title` → `s.label` |
| lint 规则 | `packages/lint/src/validate-translatable-sections.ts` | `strName(section.label) ?? strName(section.title)` → `strName(section.label)` |

按 PD #12,容忍侧才是 bug:消费方读一个 schema 不认的拼写,就把它变成第二套事实契约。
这里尤其严重 —— 抽取器是**写**翻译包的那一端,它会把一个 schema 拒绝的拼写**播种成
bundle key**,把错误拼写教给下游每一个译者。

## 真实语料证据(零迁移)

`origin/main` 上每一个 `record:details` 的 `sections[]` 数组逐个复核:

- `examples/app-showcase/src/ui/pages/project-detail.page.ts`(3 个)
- `examples/app-showcase/src/ui/pages/settings.page.ts`(2 个)
- `examples/app-showcase/src/ui/pages/task-detail.page.ts`(3 个)
- `packages/platform-objects/src/pages/sys-user.page.ts`(4 个,写的是内联多语言 map)

**~12 个 section 全部写 `label`,零个写 `title`。** 全仓 `sections` 与 `title` 同现的
grep 命中只有两处,都是本 PR 改掉的测试件;其余命中全是 `fields: ['title']`,那是**字段名**
不是分区标题 —— #5730 分诊评论专门标注过这个假阳性陷阱。

## 行为变化

作者若写 `title`,该分区标题按**缺失**处理:

- 抽取器仍然产出该 section 的期望 key(key 来自 `name`,与标题无关),但 `inline` 源文本为空,
  种子退回 section 名;
- `translation-section-name-missing` 不再对该 section 报告。

这正是收敛目的 —— 第二方言停止被喂养。作者拿到的指引来自 schema 本身(`title` 不是声明键)。

## 夹具处置(#5046 三分法)

两处测试件按**类别**分别处置,不是批量改拼写:

1. `packages/cli/test/i18n-section-coverage.test.ts:220` —— **改拼写**。合成夹具
   `{ name: 'timeline', title: 'Timeline' }` → `label`。
2. `packages/lint/src/validate-translatable-sections.test.ts` 的 “reads a detail
   section's `title` as its heading” —— **整体替换**。它钉的正是要删的那条分支;删掉后它会
   因为“什么都没产生”而继续通过(#5046 记下的空绿陷阱)。

替换后的两个新钉子都**成对**写,避免空绿:

- lint:同一夹具形状,`label` 版断言产生 1 条 finding(证明遍历确实到达了这个组件),
  `title` 版断言产生 0 条 —— 空结果才能读作“容忍没了”,而不是“夹具没走到”。
- cli:`title`-only 的 section **仍然产出它的期望 key**(key 来自 `name`),断言 key 在、
  `inline` 为空 —— 同样是“存在但为空”,不是“什么都没有”。

## 逆向验证(方向先判后跑)

预判:把两处 `?? title` 半边加回去,**两个新的否定钉子应转红**,两个肯定钉子保持绿
(因为 `label` 在 `??` 链首位,肯定路径不受影响)。这是普通的「红」方向 —— 值得记的是
**原有那两个测试**给不出这个方向:它们钉的就是容忍本身,所以改动前绿、改动后红,这正是
它们被整体替换而不是保留的原因。

## objectui 姊妹改动:**本 PR 不带,前提被证伪**

#5730 第 3 条要求 objectui `record-details.tsx` 同样去掉 `s.title ??`。核完 `origin/main`
后**没有开这个 PR** —— issue 的前提在 objectui 侧不成立:那条容忍读是**活的**,服务的是
objectui 自己的真实生产者,不是合成夹具。实测(临时探针,已删):

```
DERIVED: { "name": "basics", "title": "Basic Information", "columns": 1,
           "fields": [ { "name": "name", "label": "Name", "type": "text" } ] }
NODE TYPE: record:details   SECTION KEYS: [ 'name', 'title', 'columns', 'fields' ]
```

`deriveFieldGroupDetailSections()` 与 `RecordDetailView` 的 `splitPrimarySecondary()`
都会把 `title`(以及 `icon` / `description` / `defaultCollapsed` / `showBorder`,和
descriptor 形态而非 `string[]` 的 `fields`)写到同一个 `record:details` 节点上,再由
`SchemaRenderer` 渲染。所以那条 `??` 不是“渲染器偏爱错拼写”,而是**两套形状的接缝**:
删掉它,所有 `fieldGroups` 派生的分区会丢标题;没有显式写 `showBorder` 的调用方
(`PagePreview`、metadata-admin `anchors.ts`)还会连卡片边框一起丢(渲染器里 `showBorder`
默认值由标题推导)。已按「不猜」升级为待决策,详见 issue 上的复核评论。

本仓这一半与之完全独立 —— 两个消费方只走**授权的 stack config**,永远看不到 objectui
的运行时合成,可独立合并。

---
_Generated by [Claude Code](https://claude.ai/code/session_011M7UwH25Unfi73UHim7ajY)_