### PR TITLE
refactor(service-messaging): migrate isUniqueViolation onto the shared @objectstack/types predicate (#6542)

### DIFF
--- a/.changeset/messaging-shared-unique-violation-predicate.md
+++ b/.changeset/messaging-shared-unique-violation-predicate.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/service-messaging": patch
+---
+
+Migrate the inbox read-receipt race fallback onto the shared `isUniqueViolationError` predicate from `@objectstack/types` (#6542), deleting the last hand-written `isUniqueViolation()` copy that #6250 inventoried. One behaviour change, in the direction the call site wants: the shared predicate follows a bounded step down the `cause` chain, so a unique-constraint conflict wrapped by a pool or query-builder layer now triggers the `flipToRead()` convergence instead of being rethrown as a failed mark-read.

--- a/packages/services/service-messaging/package.json
+++ b/packages/services/service-messaging/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "@objectstack/core": "workspace:*",
     "@objectstack/platform-objects": "workspace:*",
-    "@objectstack/spec": "workspace:*"
+    "@objectstack/spec": "workspace:*",
+    "@objectstack/types": "workspace:*"
   },
   "devDependencies": {
     "@objectstack/metadata-core": "workspace:*",

--- a/packages/services/service-messaging/src/messaging-service.test.ts
+++ b/packages/services/service-messaging/src/messaging-service.test.ts
@@ -568,6 +568,80 @@ describe('MessagingService — inbox read API (ADR-0030)', () => {
         expect(receipts[0]).toMatchObject({ id: 'r_concurrent', state: 'read' });
     });
 
+    it('markRead converges when the conflict arrives wrapped in a cause chain (#6542)', async () => {
+        // Pool and query-builder layers re-throw with the driver error attached
+        // as `cause`. The retired local isUniqueViolation() read only the
+        // top-level code/message, judged this wrapper "not a conflict", and
+        // rethrew — markRead logged the failure and reported readCount 0 with
+        // the receipt stuck at `delivered`. The shared isUniqueViolationError
+        // (@objectstack/types, #6250) follows the bounded cause chain, so the
+        // race fallback now converges exactly as it does for a bare driver
+        // error. This is the ONE behaviour change of the migration, in the
+        // direction the call site wants: a wrapped conflict is still a conflict.
+        const engine = inboxEngine({
+            inbox: [{ id: 'm1', user_id: 'u1', notification_id: 'n1', title: 'A', created_at: '1' }],
+        });
+        const realInsert = engine.insert.bind(engine);
+        let raced = false;
+        engine.insert = async (object: string, row: any) => {
+            if (object === 'sys_notification_receipt' && !raced) {
+                raced = true;
+                engine.store.sys_notification_receipt.push({
+                    id: 'r_concurrent', notification_id: 'n1', user_id: 'u1', channel: 'inbox', state: 'delivered',
+                });
+                // The wrapper's own text deliberately matches neither the codes
+                // nor the message substrings the predicate knows — only the
+                // attached driver error carries the conflict signal.
+                const wrapper = new Error('receipt insert failed (pool retry exhausted)');
+                (wrapper as Error & { cause?: unknown }).cause = {
+                    code: '23505',
+                    message: 'duplicate key value violates unique constraint "sys_notification_receipt_notification_id_user_id_channel_key"',
+                };
+                throw wrapper;
+            }
+            return realInsert(object, row);
+        };
+        const svc = new MessagingService({ logger, getData: () => engine });
+
+        const res = await svc.markRead('u1', ['n1']);
+        expect(res).toEqual({ success: true, readCount: 1 });
+        const receipts = engine.store.sys_notification_receipt;
+        expect(receipts).toHaveLength(1); // converged, not duplicated
+        expect(receipts[0]).toMatchObject({ id: 'r_concurrent', state: 'read' });
+    });
+
+    it.each([
+        ['postgres', { code: '23505', message: 'duplicate key value violates unique constraint "sys_notification_receipt_uniq"' }],
+        ['mysql', { code: 'ER_DUP_ENTRY', errno: 1062, message: "Duplicate entry 'n1-u1-inbox' for key 'sys_notification_receipt_uniq'" }],
+        ['sqlite', { message: 'UNIQUE constraint failed: sys_notification_receipt.notification_id, sys_notification_receipt.user_id, sys_notification_receipt.channel' }],
+    ])('markRead race fallback is unchanged for a plain (unwrapped) %s conflict (#6542)', async (_dialect, shape) => {
+        // Pin that the migration onto the shared predicate did not move any
+        // verdict the old local copy already gave: a bare three-dialect driver
+        // error still converges identically.
+        const engine = inboxEngine({
+            inbox: [{ id: 'm1', user_id: 'u1', notification_id: 'n1', title: 'A', created_at: '1' }],
+        });
+        const realInsert = engine.insert.bind(engine);
+        let raced = false;
+        engine.insert = async (object: string, row: any) => {
+            if (object === 'sys_notification_receipt' && !raced) {
+                raced = true;
+                engine.store.sys_notification_receipt.push({
+                    id: 'r_concurrent', notification_id: 'n1', user_id: 'u1', channel: 'inbox', state: 'delivered',
+                });
+                throw Object.assign(new Error(shape.message), shape);
+            }
+            return realInsert(object, row);
+        };
+        const svc = new MessagingService({ logger, getData: () => engine });
+
+        const res = await svc.markRead('u1', ['n1']);
+        expect(res).toEqual({ success: true, readCount: 1 });
+        const receipts = engine.store.sys_notification_receipt;
+        expect(receipts).toHaveLength(1);
+        expect(receipts[0]).toMatchObject({ id: 'r_concurrent', state: 'read' });
+    });
+
     it('markAllRead flips every unread message and leaves already-read ones', async () => {
         const engine = inboxEngine({
             inbox: [

--- a/packages/services/service-messaging/src/messaging-service.ts
+++ b/packages/services/service-messaging/src/messaging-service.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import type { IDataEngine } from '@objectstack/spec/contracts';
+import { isUniqueViolationError } from '@objectstack/types';
 import type {
     MessagingChannel,
     MessagingChannelContext,
@@ -17,24 +18,6 @@ export const NOTIFICATION_EVENT_OBJECT = 'sys_notification';
 
 /** Receipt states that count as "read" for the inbox unread badge (ADR-0030). */
 const READ_RECEIPT_STATES = new Set(['read', 'clicked', 'dismissed']);
-
-/**
- * Whether a driver error is a unique/primary-key constraint violation. Spans the
- * SQL drivers we ship: SQLite (`UNIQUE constraint failed`), Postgres (`23505` /
- * `duplicate key`), and MySQL (`ER_DUP_ENTRY` / `Duplicate entry`). Used to turn
- * a lost check-then-act race on a unique index into a fallback update.
- */
-function isUniqueViolation(err: unknown): boolean {
-    const e = err as { code?: string | number; message?: string } | undefined;
-    if (!e) return false;
-    if (e.code === '23505' || e.code === 'ER_DUP_ENTRY' || e.code === 'SQLITE_CONSTRAINT_UNIQUE') return true;
-    const msg = String(e.message ?? '').toLowerCase();
-    return (
-        msg.includes('unique constraint failed') ||
-        msg.includes('duplicate key') ||
-        msg.includes('duplicate entry')
-    );
-}
 
 /**
  * One row of the inbox list REST response — the `Notification` shape in the API
@@ -569,7 +552,7 @@ export class MessagingService {
             });
             return 1;
         } catch (err) {
-            if (isUniqueViolation(err) && (await flipToRead())) return 1;
+            if (isUniqueViolationError(err) && (await flipToRead())) return 1;
             throw err;
         }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2249,6 +2249,9 @@ importers:
       '@objectstack/spec':
         specifier: workspace:*
         version: link:../../spec
+      '@objectstack/types':
+        specifier: workspace:*
+        version: link:../../types
     devDependencies:
       '@objectstack/metadata-core':
         specifier: workspace:*


### PR DESCRIPTION
Closes #6542

## What

Migrates `service-messaging` off its private hand-written `isUniqueViolation()` (the last of the four copies #6250 inventoried, and the one the shared predicate was seeded from) onto `isUniqueViolationError` from `@objectstack/types` (landed in PR #6541).

- `packages/services/service-messaging/src/messaging-service.ts` — import swap at the single call site (the inbox read-receipt check-then-act race fallback in `upsertReadReceipt`), local function deleted.
- `packages/services/service-messaging/package.json` — the card said the dep was already present; re-verification showed it was NOT, so `@objectstack/types` (workspace) is added here, with the lockfile entry. This is the one deviation from the card's premise, and it was declared in scope by dispatch for exactly this case.

## The one behaviour change, tested at the call site

The shared predicate additionally follows a bounded number of steps down the `cause` chain (pool and query-builder layers wrap the driver error). The old copy read only the top-level `code`/`message`, judged a wrapped conflict "not a conflict", and rethrew — `markRead` logged the failure, reported `readCount: 0`, and the receipt stayed `delivered`. Now the wrapped conflict triggers the `flipToRead()` convergence, same as a bare driver error. That is the direction the call site wants: a wrapped conflict is still a conflict.

Tests added in `messaging-service.test.ts`:

- **Wrapped conflict** (new behaviour): a wrapper whose own text matches none of the predicate's signals, carrying the Postgres conflict as `cause`, exercised through the real `markRead` → `upsertReadReceipt` path; asserts `readCount: 1` and convergence to the concurrent row.
- **Unwrapped three-dialect pin** (unchanged behaviour): `it.each` over plain Postgres (`23505`), MySQL (`ER_DUP_ENTRY`/`errno 1062`), and SQLite (`UNIQUE constraint failed`) error shapes through the same path — each converges identically to before.

## Reverse verification (direction decided beforehand)

With the old local predicate temporarily restored at the call site: exactly the wrapped-conflict test goes red (1 failed) and the three dialect pins plus the rest of the file stay green (51 passed). Restored, all green.

## Verification

- `pnpm --filter '@objectstack/service-messaging' test` — 16 files, **199 passed, 0 failed** (main had 195; +4 new).
- `pnpm --filter '@objectstack/service-messaging' typecheck` — clean.
- `npx eslint` on both touched source files — exit 0.
- `node scripts/check-nul-bytes.mjs` — OK.

Changeset: `.changeset/messaging-shared-unique-violation-predicate.md` (patch, `@objectstack/service-messaging`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USNUyHEr7uaU6MoEWXitei

---
_Generated by [Claude Code](https://claude.ai/code/session_01USNUyHEr7uaU6MoEWXitei)_