### PR TITLE
fix(service-automation): trigger-fired-run failure log keeps the AutomationResult.error envelope in meta, not the message (#6587)

### DIFF
--- a/.changeset/spotty-lions-flash.md
+++ b/.changeset/spotty-lions-flash.md
@@ -1,0 +1,5 @@
+---
+'@objectstack/service-automation': patch
+---
+
+A failed trigger-fired flow run's `error` record now stays on one physical line: the `AutomationResult.error` envelope — which carries a failing node's / driver's text verbatim — moved from the log MESSAGE into the structured meta slot (`error` field), the same #6499/#6568 family shape, applied to the one same-class site that sweep left on the fired-run path. The message keeps its `Trigger-fired run of flow '…' failed` lead phrase and now also names the trigger type and the consequence; anything keyed on the old trailing `: [error text]` splice must read the structured `error` field instead.

--- a/packages/services/service-automation/src/engine-residual-log-cause.test.ts
+++ b/packages/services/service-automation/src/engine-residual-log-cause.test.ts
@@ -602,3 +602,93 @@ describe("#6499 site 14 — validateFlowExpressions' advisory pass: a self-autho
         assertSilent(streams.stderr, "[flow 'expense_check']", 'stderr');
     });
 });
+
+// ═══ the fired-run envelope seam #6499's sweep left (#6587) ════════════════
+
+describe("#6587 — activateFlowTrigger's trigger-fired-run callback: the AutomationResult.error envelope rides meta", () => {
+    // The same class as site 12 (the envelope carries a failing node's /
+    // driver's text VERBATIM, #5912) on the FIRED-RUN path instead of the
+    // subflow path — reported in PR #6568's residual sweep, outside #6499's
+    // list of 13, fixed here.
+
+    /** A record-change flow whose one work node throws the driver's text. */
+    const FIRED_FLOW = {
+        name: 'rc_fired',
+        label: 'rc_fired',
+        type: 'autolaunched',
+        nodes: [
+            { id: 'start', type: 'start', label: 'Start', config: { objectName: 'task', triggerType: 'record-after-update' } },
+            { id: 'boom', type: 'exploder', label: 'Boom' },
+            { id: 'end', type: 'end', label: 'End' },
+        ],
+        edges: [
+            { id: 'e1', source: 'start', target: 'boom' },
+            { id: 'e2', source: 'boom', target: 'end' },
+        ],
+    };
+
+    /**
+     * Register trigger + flow, then fire the captured callback ONCE — the
+     * exact path a real trigger plugin drives. The executor THROWS (rather
+     * than returning `success: false`) so `execute()`'s catch puts the
+     * driver's text into `AutomationResult.error` verbatim, un-prefixed —
+     * the #5912-preserved shape this seam re-splices second-hand.
+     */
+    async function fireOnce(engine: AutomationEngine): Promise<void> {
+        let fire: ((ctx: AutomationContext) => Promise<void>) | undefined;
+        const trigger: FlowTrigger = {
+            type: 'record_change',
+            start(_binding, callback) { fire = callback; },
+            stop() {},
+        };
+        engine.registerTrigger(trigger);
+        engine.registerNodeExecutor({
+            type: 'exploder',
+            async execute() { throw new Error(MULTILINE_DRIVER); },
+        } as NodeExecutor);
+        engine.registerFlow('rc_fired', FIRED_FLOW);
+        expect(fire, 'the engine handed the trigger a callback').toBeDefined();
+        await fire!({ event: 'record-after-update', object: 'task', record: { id: 't1' } } as AutomationContext);
+    }
+
+    it("#4632 stays `error` on its own reasoning (no caller holds the envelope): one stderr line, envelope in meta", async () => {
+        const engine = new AutomationEngine(jsonLogger());
+        const streams = await captureBoth(async () => { await fireOnce(engine); });
+
+        // Behaviour unchanged: the callback resolves (nothing is thrown back
+        // at the trigger plugin) and the failed run still lands in history.
+        const runs = await engine.listRuns('rc_fired');
+        expect(runs).toHaveLength(1);
+        expect((runs[0] as { status?: string }).status).toBe('failed');
+
+        const record = soleRecordWith(streams.stderr, 'Trigger-fired run of flow');
+        expectOneLineWithCause(record, 'error');
+        expect(record.msg, 'the flow-name correlation').toContain("'rc_fired'");
+        expect(record.msg, 'the trigger correlation').toContain("trigger 'record_change'");
+        expect(record.msg, 'the consequence, stated out loud').toContain('no caller holds this result');
+        assertSilent(streams.stdout, 'Trigger-fired run', 'stdout');
+    });
+
+    it('stays one physical line in `pretty`, with every fact on the greppable line', async () => {
+        const engine = new AutomationEngine(new ObjectLogger({ level: 'warn', format: 'pretty' }));
+        const streams = await captureBoth(async () => { await fireOnce(engine); });
+        expect(streams.stderr).toHaveLength(1);
+        expect(streams.stderr[0]).toMatch(RECORD_HEAD);
+        expect(streams.stderr[0]).toContain('Trigger-fired run of flow');
+        expect(streams.stderr[0]).toContain('run `os migrate` for this datasource');
+    });
+
+    it('hands the envelope to error(message, error, meta) — meta THIRD, Error slot empty (#5575)', async () => {
+        const spy = vi.spyOn(ObjectLogger.prototype, 'error');
+        const engine = new AutomationEngine(jsonLogger());
+        await captureBoth(async () => { await fireOnce(engine); });
+
+        const call = spy.mock.calls.find((c) => String(c[0]).includes('Trigger-fired run of flow'));
+        expect(call).toBeDefined();
+        const [message, errorSlot, meta] = call as unknown as [string, unknown, Record<string, unknown>];
+        expect(message).not.toContain('\n');
+        expect(errorSlot).toBeUndefined();
+        expect(meta.error).toBe(MULTILINE_DRIVER);
+        spy.mockRestore();
+    });
+});

--- a/packages/services/service-automation/src/engine.ts
+++ b/packages/services/service-automation/src/engine.ts
@@ -1721,15 +1721,34 @@ export class AutomationEngine implements IAutomationService {
         try {
             // A trigger-fired run's result must not vanish (2026-07-17 eval:
             // a failing record-change flow produced zero output — the failure
-            // lived only in the run-history row). Log failures at ERROR: stderr
-            // survives the CLI's boot-quiet stdout window, and a fired-but-failed
-            // automation is an operational fault. Condition-skipped runs stay
+            // lived only in the run-history row). Condition-skipped runs stay
             // quiet (execute() already debug-logs them — they are high-frequency).
+            //
+            // #6587 — `result.error` is the envelope field that carries a
+            // failing node's / driver's text VERBATIM (#5912 left it that way
+            // on purpose), so foreign newlines reach this message second-hand;
+            // it goes to the structured slot — the identical class as
+            // `bubbleToParent`'s envelope branch, on the fired-run path. See
+            // `forgetSuspendedRun`'s catch for the full mechanism (#6299).
+            //
+            // #4632 verdict: stays `error`, on its own reasoning rather than
+            // inertia. This is the fire-and-forget path: NO caller holds this
+            // result envelope, so after the failure the system looks normal
+            // from the outside — the triggering event was handled and nothing
+            // retries the run — while the flow's declared effects never
+            // landed; the only other trace is the passive run-history row.
+            // That stderr also survives the CLI's boot-quiet stdout window is
+            // stream mechanics, not the verdict.
             trigger.start(resolved.binding, (ctx: AutomationContext) =>
                 this.execute(flowName, ctx).then((result) => {
                     if (!result.success) {
                         this.logger.error(
-                            `Trigger-fired run of flow '${flowName}' failed: ${result.error ?? 'unknown error'}`,
+                            `Trigger-fired run of flow '${flowName}' failed (trigger '${resolved.triggerType}') — ` +
+                                `no caller holds this result and nothing retries the run; the terminal failure ` +
+                                `is recorded in the flow's run history, and the run's failure envelope is in ` +
+                                `this record's meta.`,
+                            undefined,
+                            { error: result.error ?? 'unknown error' },
                         );
                     }
                 }),


### PR DESCRIPTION
Closes #6587

## The site

`activateFlowTrigger`'s trigger callback logged a failed trigger-fired run as `Trigger-fired run of flow '…' failed: ${result.error ?? 'unknown error'}` at `logger.error` — splicing the `AutomationResult.error` envelope, which carries a failing node's / driver's text verbatim (#5912), into the log MESSAGE. This is the one same-class site PR #6568's residual sweep reported and left (it was outside #6499's list of 13), on the fired-run path — the identical class as that PR's site 12 (`bubbleToParent`'s envelope branch), with the same downstream harm: `ObjectLogger.write()` emits one timestamp+level head per call, so foreign newlines shred ONE record into several physical lines of which only the first is greppable.

## The fix (the family shape, not re-derived)

Message and cause separated per the merged family idiom (#6498/#6568): the message stays one physical line and carries only controlled facts — the flow name, the trigger type (`resolved.triggerType`), and the consequence — keeping its original `Trigger-fired run of flow '…' failed` lead phrase so existing greps still match. The envelope rides the logger's structured meta slot (`{ error: result.error ?? 'unknown error' }`), passed THIRD in the `error(message, error?, meta?)` contract with the Error slot deliberately empty (#5575). This is the same treatment #6568 gave site 12's string envelope — not `describeThrownForLog`, which renders THROWN values; the envelope here is already a string, so it maps straight onto the meta's `error` field.

## Per-site #4632 verdict

**Stays `error` — on its own reasoning, not inertia.** The judgment question answers YES here: after the failure the system looks normal from the outside — the triggering event was handled, NO caller holds this result envelope (fire-and-forget path), and nothing retries the run — while the flow's declared effects never landed. The only other trace is the passive run-history row (the 2026-07-17 eval preserved in the site comment: a failing record-change flow produced zero output; the failure lived only in that row). That stderr survives the CLI's boot-quiet stdout window is stream mechanics, not the verdict. The verdict is pinned by test because `check:durability-log-level` does not reach this package.

## Tests

Three new pins appended to `engine-residual-log-cause.test.ts` (the #6568 file), in its exact idiom — real bytes off a real `ObjectLogger`, both streams captured, the family's byte-identical multi-line driver fixture. The seam is driven the way a real trigger plugin drives it: the test's `FlowTrigger.start` captures the engine-built callback and fires it once; the flow's work node THROWS the driver text, so `execute()`'s catch lands it in `result.error` verbatim, un-prefixed (the #5912-preserved shape).

1. JSON: level `error`, exactly one stderr line, message one line leaking no driver fact, the whole envelope in `record.error` (meta spread proves the slot), stdout silent. Behaviour-unchanged assert: the callback resolves (nothing thrown back at the trigger plugin) and the failed run still lands in run history with `status: 'failed'`.
2. Pretty: one physical line carrying the timestamp+ERROR head and every fact greppable on it.
3. Prototype spy: meta THIRD, Error slot deliberately empty (#5575).

## Reverse verification (direction predicted before running)

Predicted: re-splicing the site turns exactly the 3 new pins red — the JSON pin inside `expectOneLineWithCause` (msg gains the newlines + driver text, `record.error` vanishes), the pretty pin's `toHaveLength(1)` (one record becomes 3 physical lines, the driver's first line concatenating onto the message line), the slot pin's message-one-line assert — and the 18 pre-existing pins stay green. Observed: exactly that, 3 failed / 18 passed, each failing on the predicted assertion (the pretty pin reported `expected [ …(3) ] to have a length of 1 but got 3`). Restored: 21/21 green.

## Local runs

- `pnpm --filter @objectstack/service-automation test`: 70 files, 847 tests, all passed.
- `tsc --noEmit` in the package: 3 errors, all pre-existing in `nested-region-parity.test.ts` — the same 3 #6568 ledgered; my files contribute 0.
- `eslint` on both touched files: clean. `node scripts/check-nul-bytes.mjs`: OK; control-byte self-scan of touched files: clean.

## Scope

ONE site, per the dispatch. Explicitly untouched: the name-shaped tail (`engine.ts` `:2719`, `:3365`, `:3598`, `:4209`, `:4899` — a different class; the PM splits it into its own finding at review), `evaluateCondition`, `validateFlowExpressions`' fatal `failures` array, and everything #6568 already fixed. A user-visible log-shape change, so a patch changeset rides along.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USNUyHEr7uaU6MoEWXitei

---
_Generated by [Claude Code](https://claude.ai/code/session_01USNUyHEr7uaU6MoEWXitei)_