### PR TITLE
docs(agents): describe the read-seam invention rule in the durability gate's "It has teeth" passage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -802,6 +802,52 @@ the gate merely cannot classify. If a red seam turns out to hand its failure to
 the caller, declare the propagation vocabulary above; do not baseline correct
 code.
 
+**The same command has a SECOND set of teeth** — the read-seam invention rule
+(#5186; family #4728 → #4825 → #5108 → #6116). Everything above grades *how loud
+the catch is*, which is the right axis for a write or a DDL seam and structurally
+blind to a read: `catch { return []; }` has no log to grade at all, and a read's
+callees are `find` / `findOne` / `count`, names far too generic to declare
+repo-wide. So the second rule asks a different question — **the read did not
+happen; did you make an answer up anyway, and tell nobody?** — and goes red only
+when every part holds: the `try` performs a storage read (the `IDataDriver` read
+methods, or a same-file wrapper over one), the `catch` logs *nothing* at any
+level (same-file helpers followed), some path out of it returns an **invented
+answer** — an empty/zero value for that method (`[]`, `null`, `false`, `0`, `1`,
+…), or one of the enclosing function's own parameters handed straight back
+(#6451, from #6116: for an enrichment function the un-enriched input is the very
+same bytes a successful read with nothing to hydrate returns) — and that path was
+never reached by discriminating the error's **type**. What it protects is
+DISTINGUISHABILITY, not the spelling of the returned value: the fix is to ask the
+error's type, or to report the failure once — never to invent a different empty.
+
+Its scan surface is deliberately narrower than the log-level rule's:
+`packages/metadata/src`, `packages/metadata-protocol/src` and
+`packages/objectql/src` only. That is the maintainer's 2026-08-06 ruling —
+「裁 3 —— 收窄先行」: prove the false-positive surface on the metadata/persistence
+layer first, and evaluate widening as its own issue. It is also the only honest
+way to afford `find`/`findOne`/`count` as a vocabulary at all — the names are
+generic, so the SCOPE is what makes them mean "a storage seam" rather than "any
+data read anywhere". Like its sibling it is a ratchet, not a proof: it cannot see
+a read outside the `try`, nor an empty answer wrapped in a result envelope.
+
+**Found a new read seam?** The symmetric answer to `DURABILITY_CRITICAL_CALLEES`
+above is `READ_FAILURE_DISCRIMINATORS`, in the same script: the declared
+predicates that prove a read failure is benign (today `isMissingTableError`,
+`packages/metadata/src/errors.ts`), which is why a hand-rolled `if (e.code ===
+'42P01')` is flagged on purpose — ask the shared predicate instead of growing a
+second vocabulary of "which driver errors are benign" (#5841). A reviewed,
+genuinely legitimate seam goes in this rule's OWN ledger,
+`scripts/durability-read-invention.baseline.json` — **not** the empty
+`durability-degradation.baseline.json` named above. The two rules share this
+file, one CI step and one AST pass, and share no vocabulary, no baseline and no
+verdict: a seam red under one is untouched by the other. That ledger is
+shrink-only, hand-edited and fails on a stale entry exactly like its sibling, but
+its steady state is *not* "empty": an entry is either a real unfixed instance
+(`unfixed-degradation`, carrying the issue that tracks it) or a
+`reviewed-legitimate` seam whose empty value is a declared "could not determine"
+that a syntactic rule cannot see. Read the entries and the reasons they give —
+never the count.
+
 ---
 
 ## Startup registry reads — never record a verdict the boot can still contradict


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5981

## What this is

A signpost, not a new gate. `pnpm check:durability-log-level` has run **two
independent rules** since #5186, but the AGENTS.md **It has teeth** passage under
"Degradation log levels — `warn` vs `error`" only described the first one. Two
concrete ways the old text misleads a reader:

- "walks the AST for `catch` blocks guarding a declared vocabulary of
  durability-critical operations and fails when one logs below `error` without
  rethrowing" — that is now half of what the command does;
- "Accepted exceptions live in `scripts/durability-degradation.baseline.json` …
  and that file is currently **empty**" — still true of *that* file, but easy to
  read as "this command's baseline is empty", when the second rule has its own
  ledger, `scripts/durability-read-invention.baseline.json`, whose steady state
  is not empty.

This PR adds three paragraphs after the existing passage. **`AGENTS.md` is the
only file touched** — the script, both baselines and every test are untouched.
This is explicitly *not* #5186's rejected "direction 2" (prose enforced by
review): the gate already exists and is green; this documents it.

## What the new prose says

1. **The second rule and its verdict.** The log-level rule grades *how loud the
   catch is*, which is structurally blind to a read seam — `catch { return []; }`
   has no log to grade, and a read's callees are `find` / `findOne` / `count`,
   too generic to declare repo-wide. The read-seam rule asks instead: *the read
   did not happen; did you make an answer up anyway, and tell nobody?* Red needs
   all of: a storage read in the `try` (the `IDataDriver` read methods or a
   same-file wrapper), a `catch` that logs nothing at any level (helpers
   followed), a path returning an invented answer — an empty/zero value, or one
   of the enclosing function's own parameters handed straight back (#6451, from
   #6116) — and that path never reached by discriminating the error's **type**.
   The paragraph names what the rule protects: distinguishability, not the
   spelling of the returned value.
2. **Why the scan surface is narrowed** to `packages/metadata/src`,
   `packages/metadata-protocol/src`, `packages/objectql/src` — the maintainer's
   2026-08-06 ruling, quoted verbatim and untranslated:「裁 3 —— 收窄先行」. Also
   the mechanical reason: the narrow scope is the only honest way to afford
   `find`/`findOne`/`count` as a vocabulary at all.
3. **"Found a new read seam?"** — symmetric with the existing "Found a new one?
   Add it to `DURABILITY_CRITICAL_CALLEES`": the exemption vocabulary is
   `READ_FAILURE_DISCRIMINATORS`, and a reviewed-legitimate seam goes in this
   rule's own ledger, **not** the empty sibling. Both rules share one file, one
   CI step and one AST pass, and share no vocabulary, no baseline and no verdict.

## Deliberately no counts in the prose

The issue body and its triage comment both said the read-invention baseline holds
3 entries. Measured on `origin/main` today: **1** (`referenceExists`, verdict
`reviewed-legitimate`) — #5979 / #5980 landed and shrank it. Since the defect
being fixed *is* prose that fell out of step with the gate, the new text carries
no tally at all: it describes the steady state and the two verdict kinds, and
ends with "Read the entries and the reasons they give — never the count."

The new text also describes the rule as it stands **today**, not as #5186 landed
it: #6451 added the identity-pass-through criterion after the issue was filed,
and the paragraph covers it. Writing a second inaccurate description would have
been worse than the gap.

## Verification

Prose-only change, so the evidence is that the gate list still passes and that
the described behaviour is what the gate really does.

Live run of the command the passage documents, on this branch:

```
✓ durability-degradation log levels: 24 durability-critical catch seam(s), all loud,
  rethrowing or propagating to the caller (3 propagating, declared).
✓ read-seam invention (#5186 + #6451, 3 package roots): 64 read seam(s), none invents
  an unreported answer (6 answer on a type-discriminated benign branch)
  (1 pass an input through, reported) (1 baselined).
```

Every gate in the ESLint job of `.github/workflows/lint.yml`, enumerated from the
workflow and run one by one after `git commit` — all exit 0: `lint`,
`check:slot-lookup`, `check:query-options-erasure`, `check:verify-stand-in`,
`check:nul-bytes`, `check:doc-authoring`, `check:docs-audit-scope`,
`check:role-word`, `check:quick-reference-counts`, `check:adr-anchors`,
`check:org-identifier`, `check:authz-resolver`, `check:service-providers`,
`check:route-envelope`, `check:error-code-casing`, `check:wildcard-fallthrough`,
`check:meta-type-normalized`, `check:init-service-contract`,
`check:durability-log-level`, `check:startup-registry-verdict`,
`check:objectui-changeset`, `check:release-notes`, `check:release-body`,
`check:node-version`, `check:workflow-status-functions`,
`check:shard-attestation`, `check:published-files`,
`check:engine-double-contract`, `check:resume-authority-declared`,
`check:merge-driver`, `check:spec-parsed-alias`. Plus the doc-adjacent gates from
the type-check job: `check:stall-guard`, `check:skill-frame-sync`,
`check:skill-compatibility` — all green.

Byte discipline: `pnpm check:nul-bytes` green, and a direct self-scan of
`AGENTS.md` for raw control bytes returned no matches.

## No changeset — `skip-changeset`

`AGENTS.md` is the agent operating manual. This PR ships no package change, no
public API change and nothing user-visible, so it releases nothing and writes no
changeset. Label applied by hand as the union with the existing labels.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_