### PR TITLE
fix(agents): 把 os-dev 的模型钉死为 opus,不再继承 PM 会话模型 (#6686)

### DIFF
--- a/.claude/agents/os-dev.md
+++ b/.claude/agents/os-dev.md
@@ -6,7 +6,28 @@ description: >
   code, tests, changeset, push, draft PR — and returns a structured JSON
   report to the PM. Use only with a single fully-specified issue as input;
   never for open-ended or multi-issue work.
+model: opus
 ---
+
+<!--
+`model: opus` is pinned deliberately (#6686). Without it this definition declares
+no model, so every dispatched dev INHERITS the PM session's model — making "what
+model does a dev run on" a property of whoever happened to dispatch it, at
+whatever moment, rather than a property of this role.
+
+That is not theoretical. On 2026-08-08 a PM seat dispatched four devs while its
+own session sat on a smaller model; all four died mid-task on the same shared
+quota wall, at four different stages, three of them leaving uncommitted and
+wholly unverified work behind in their worktrees. The failure is BATCHED — one
+exhausted quota takes out the entire batch at once rather than degrading one
+agent — and it is invisible to the dispatcher, whose pre-dispatch checks have no
+reason to ask what model the batch will run on.
+
+If a dispatch genuinely needs a different model, pass `model` on the Agent call:
+that override takes precedence over this line, so pinning here costs nothing and
+removes the silent-inheritance failure mode. Removing this line puts it back.
+-->
+
 
 You are an ObjectStack developer agent. You were dispatched by a PM agent with
 exactly one GitHub issue. Your entire deliverable is that issue implemented,


### PR DESCRIPTION
Fixes #6686

一行 frontmatter:`.claude/agents/os-dev.md` 增加 `model: opus`,外加一段说明成因的注释。

## 缺陷

该定义的 frontmatter 此前只有 `name` 与 `description`。按 Agent 工具的语义,未声明 `model` 时 **agent 继承父会话(即 PM 座位)的模型**。于是「一个 dev 跑在什么模型上」成了「谁、在什么时刻派的它」的函数,而不是这个角色自身的属性 —— 一个进程属性被绑在了偶然状态上。

## 事故(实测,不是推演)

2026-08-08 12:3xZ,`domain:spec-tooling` 座位在自己会话挂在小模型时并行派出四个 dev(#6629 / #6585 / #6566 / #6569)。四个**全部**以同一条 API 错误死亡:

```
Agent terminated early due to an API error:
You've reached your <model> limit.
```

死亡分布在四个不同阶段,说明与任务本身无关,是**共享配额被同一批次一次性耗尽**:

| 单 | 死亡点 | 工作树残留 |
|---|---|---|
| #6569 | 探索阶段 | 干净 |
| #6585 | 语料扫描后进入实现 | 2 个文件已改 |
| #6629 | 「准备跑门禁」前 | 1 改 + 1 新建测试 |
| #6566 | 「准备验证」前 | 2 个文件已改 |

**四个工作树里三个躺着未提交、未经任何门禁验证的改动**(全部 0 commits ahead)。恢复因此不是「重跑一遍」:重派时必须让接手的 dev 先读既有 diff、判断优劣、明确交代继承还是弃用,否则要么白扔工作,要么把未验证的改动当成已验证的继承下去。

## 为什么值得钉死,而不是「派单时记得传参」

1. **失败是批量的。** 配额共享,撞墙时整批一起死而不是逐个降级 —— 批次越大,单次损失越大。
2. **它对派单方不可见。** PM 的派单前置检查(落点提交、竞态复读、文件不相交)没有任何一条会暴露「这批 dev 将跑在什么模型上」。事故前该座位派过十几个 dev 都没显式传过 `model`,因为会话模型正常时这**完全看不出问题** —— 这正是它作为默认值的危险之处。
3. **临时绕法依赖人记得。** 事故后四单已在显式传 `model` 的情况下重派,但那要求每个 PM 每次都记得传参,正是本单要消除的那种依赖。

## 不牺牲灵活性

Agent 调用上的 `model` 参数**优先于**定义里的这一行(工具契约明写 "takes precedence over the agent definition's model frontmatter")。所以需要别的模型时照常显式传参即可;钉死只关掉「静默继承」这一条路径。旁边的 HTML 注释把成因写下,免得后来者当成冗余行删掉。

## 验证

- **frontmatter 以 YAML 实际解析复核**:`keys = ['description', 'model', 'name']`,`model == 'opus'`,`name` 与 `description` 逐字未变。
- **定义正文一条指令未改** —— diff 是纯增(+21 / −0),正文首行仍是 `You are an ObjectStack developer agent.`。
- `node scripts/check-nul-bytes.mjs` → `OK (scanned 6237 tracked text file(s); … no raw ASCII control bytes)`。
- **无 changeset,依据是门禁自己的判据**:`scripts/check-empty-changeset.mjs:286` 与 `pr-automation.yml:582` 都把 `.claude/` 明列为「releases nothing」,故走 `skip-changeset`。

## 刻意未做

`/pm-dispatch` 侧是否也该强制显式传 `model` 作为双保险(定义与调用两处一致,任一失效另一处仍成立),**不在本 PR** —— 那是派单纪律而非定义缺陷,已作为开放问题留在 #6686 正文里交分诊判断值不值这份重复。批次大小与配额的关系(四个并行是否本身过激)是排程策略,另一回事。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZgRyPVwi1jLb1mNNuUQ9o

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZgRyPVwi1jLb1mNNuUQ9o)_