### PR TITLE
test(spec): put the pin file's two prose counts under the counting assertion (#6605)

### DIFF
--- a/packages/spec/src/type-alias-convention.pin.test.ts
+++ b/packages/spec/src/type-alias-convention.pin.test.ts
@@ -264,7 +264,14 @@ import type * as M167 from './ui/view.zod.js';
 import type * as M170 from './ui/component.zod.js';
 
 // ---------------------------------------------------------------------------
-// 717 isomorphic aliases: `z.input` === `z.infer`, so no `XParsed` is declared.
+// 823 isomorphic aliases: `z.input` === `z.infer`, so no `XParsed` is declared.
+//
+// That number is machine-checked, not hand-kept. The runtime companion at the
+// bottom of this file recomputes the pin count from the source and asserts that
+// every sentence stating it — this header and that case's own title — agrees
+// (#6605). Before the check existed this line had been left at 717 while the
+// list grew past 800, because the counting assertion reads the `export type
+// Iso...` declarations and never the prose sitting beside them.
 // ---------------------------------------------------------------------------
 
 // ai/agent.zod.ts
@@ -1604,10 +1611,13 @@ export type AFamilyParsedIsParseState = Assert<
 // ---------------------------------------------------------------------------
 
 describe('ADR-0122 type-alias convention', () => {
-  // The title tracks the assertion below; it had been left at 751 when #6037
-  // moved the count to 754, so it is corrected here rather than left two
-  // numbers behind.
-  it('still declares all 755 isomorphic pins', () => {
+  // The title states the count as well, and hand-tracking it did not hold: it
+  // was corrected once, from 751 to 754 (#6037), and had drifted again to sit
+  // 68 behind by the time #6605 looked. Both prose statements of the number —
+  // this title and the section header above the pin list — are now asserted
+  // against the recomputed count below, so neither can go stale without a red
+  // test naming it.
+  it('still declares all 823 isomorphic pins', () => {
     // The truth of each pin is proved by tsc, not here — an `Assert<Eq<...>>`
     // that stops holding is a compile error with the alias named. What tsc
     // cannot notice is a pin that was DELETED: removing the assertion removes
@@ -1746,6 +1756,36 @@ describe('ADR-0122 type-alias convention', () => {
     const self = readFileSync(fileURLToPath(import.meta.url), 'utf8');
     const pins = self.match(/^export type Iso\d+ = Assert</gm) ?? [];
     expect(pins).toHaveLength(823);
+
+    // The count is stated in PROSE twice as well — this case's title and the
+    // section header above the pin list — and until #6605 nothing read either
+    // one. Both had drifted, by different amounts: the header sat 106 behind,
+    // the title 68. Correcting them is not the fix, because correcting was
+    // already tried on the title once (the receipt at the top of this case)
+    // and it drifted a second time. So the prose is recomputed against the
+    // same operand as the assertion above: the file.
+    //
+    // Matched by PHRASE, deliberately, rather than at two fixed line numbers.
+    // A sentence a later author writes is then covered the moment it is
+    // written — the property a merely-corrected literal does not have, and the
+    // reason this is preferred over deleting the numbers outright: a number
+    // nobody may state cannot be re-stated wrongly, but a number anybody may
+    // state and nobody may state falsely is worth more, and it is the bargain
+    // the pins themselves are built on ("an exemption nobody can state falsely
+    // is the only kind worth having", top of this file).
+    //
+    // Everything else above is HISTORY — `749 -> 822`, `-7`,
+    // `136 - 17 - 40 - 5 - 1` — and is deliberately NOT matched. Those numbers
+    // are true about a past state of the file, and rewriting them to today's
+    // count would destroy the receipts. The phrase caught here is the narrow
+    // one that can only ever mean "how many pins are in this file right now".
+    const stated = [...self.matchAll(/(\d+) isomorphic \w+/g)].map((m) => m[0]);
+    // Guard the guard: if a reword leaves nothing matching, the check below
+    // passes over an empty list and silently stops existing.
+    const phrasingMoved = 'no prose states the pin count any more — has the phrasing moved?';
+    expect(stated.length, phrasingMoved).toBeGreaterThanOrEqual(2);
+    const wrong = stated.filter((s) => !s.startsWith(`${pins.length} `));
+    expect(wrong, `prose disagreeing with the ${pins.length} pins counted above`).toEqual([]);
   });
 
   it('leaves the A-family parse behaviour untouched', () => {


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6605

## What drifted

`packages/spec/src/type-alias-convention.pin.test.ts` states its pin count in three
places. One is asserted; two were not, and both had drifted:

| site | said | actual |
|:---|---:|---:|
| section header above the pin list (`:267`) | 717 | 823 |
| the counting case's own title (`:1620`) | 755 | 823 |
| `expect(pins).toHaveLength(...)` | 823 | 823 |

The assertion matches `/^export type Iso\d+ = Assert` over the file's own source, so it
reads the **declarations** and never the prose sitting beside them — which is exactly
why the other two could rot unwatched.

Re-counted on `origin/main` @ `b127c8b22` rather than taken from the card:
`grep -c '^export type Iso'` = **823**, and `pnpm check:spec-parsed-alias` independently
reports `1517 bare z.input aliases, 823 pinned isomorphic, 694 paired with an XParsed`.
The card's 822 was correct when filed and went stale the same day — #6596 landed
`GetMetaItemLayeredResponseSchema` on top of #4593's backfill.

## One correction to the issue's premise

The issue title calls the header "the only number not covered by a counting assertion".
It is not the only one — the counting case's **own title** is a second, and it had
drifted 68 behind. The substantive premise holds in full (the header stated 717, the
truth is 823, nothing asserted it); only the word "only" does not.

That second site also settles the design question, because it is a *repeat offender*:
the receipt above it records that the title was already hand-corrected once, from 751 to
754 (#6037) — and it drifted again anyway. Hand-maintenance has been tried here and
measured to fail.

## The fix: extend the counting machinery, not the literals

Level 2 of the ruling, enforcement variant. The case already reads its own source to
count declarations; it now recomputes the prose against that same operand:

```ts
const stated = [...self.matchAll(/(\d+) isomorphic \w+/g)].map((m) => m[0]);
expect(stated.length, phrasingMoved).toBeGreaterThanOrEqual(2);
const wrong = stated.filter((s) => !s.startsWith(`${pins.length} `));
expect(wrong, `prose disagreeing with the ${pins.length} pins counted above`).toEqual([]);
```

Three deliberate properties:

- **Matched by phrase, not at two fixed line numbers.** A sentence a later author writes
  is covered the moment it is written. This is the property the alternative — deleting
  the numbers and pointing at the assertion instead — does not have: removal resets the
  drift but does nothing about re-introduction, and "N isomorphic aliases" is a very
  natural thing for the next author (or agent) to write into a section header. Keeping
  the number and making it unfalsifiable is the same bargain the pins themselves are
  built on, in this file's own words at the top: *"An exemption nobody can state falsely
  is the only kind worth having."*
- **The receipts are deliberately NOT matched.** The block above the assertion is dense
  with historical arithmetic — `749 -> 822`, `-7`, `136 - 17 - 40 - 5 - 1`. Those are
  true about past states of the file and rewriting them to today's count would destroy
  the receipts. The matched phrase is the narrow one that can only ever mean "how many
  pins are in this file right now"; verified to match those two sites and nothing else.
- **A guard on the guard.** If a reword leaves no sentence matching, the filter would
  pass over an empty list and the check would silently stop existing — the phantom-check
  shape this repo keeps paying for. `toBeGreaterThanOrEqual(2)` refuses that.

Scope note: `docs/adr/0122-...md` also carries pin counts (`final: 1470 / 754 / 716`),
left untouched on purpose — that is the phase-2 flip's own dated outcome table, history
in the same sense as the receipts, not drift.

## Reverse verification

Direction predicted before running, and both came out as predicted — plain red, no
inversion:

1. **Restore the stale `717` in the header** → the *new* assertion goes red naming the
   sentence, while `toHaveLength(823)` above it still passes. This is the issue's
   mechanism, reproduced: the old machinery cannot see this defect.
   ```
   AssertionError: prose disagreeing with the 823 pins counted above:
     expected [ '717 isomorphic aliases' ] to deeply equal []
   ❯ src/type-alias-convention.pin.test.ts:1788
   ```
2. **Reword both sites so the phrase disappears** → the guard-the-guard goes red, so the
   check cannot pass vacuously.
   ```
   AssertionError: no prose states the pin count any more — has the phrasing moved?:
     expected 0 to be greater than or equal to 2
   ❯ src/type-alias-convention.pin.test.ts:1786
   ```

## Verification

- `pnpm --filter @objectstack/spec exec vitest run` — **345 files / 8844 tests passed**
- `pnpm --filter @objectstack/spec typecheck` — exit 0 (`tsc --noEmit`,
  `check:scripts-typecheck`, `check:test-typecheck`; the last is where these pins'
  compile-time proof actually lands, per #6183)
- `pnpm check:spec-parsed-alias` — OK; self-test 18 assertions. This gate reads this file
  as its exemption registry, so it is the one that would notice a mangled pin line; the
  diff touches only comments, a title string and the case body.
- `pnpm check:nul-bytes` — OK (6237 files); plus a targeted control-byte self-scan of the
  edited file, clean.
- `pnpm exec eslint packages/spec/src/type-alias-convention.pin.test.ts` — exit 0

## Changeset

None: the diff is a single `*.test.ts` file, so nothing user-visible is published.
`skip-changeset` is the intended route — flagged here for the PM to apply at acceptance
rather than self-applied. Precedent for test-only diffs carrying that label: #6607, #6658,
#6582.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk)_