### PR TITLE
fix(lint): record_picker 字段绑定表删除 #5775 已退役的 `displayField` / `searchFields` (#6629)

### DIFF
--- a/.changeset/record-picker-retired-field-binding-entries.md
+++ b/.changeset/record-picker-retired-field-binding-entries.md
@@ -1,0 +1,31 @@
+---
+"@objectstack/lint": patch
+---
+
+fix(lint): the `element:record_picker` field-binding entry drops #5775's retired `displayField` / `searchFields` (#6629)
+
+`COMPONENT_FIELD_SPECS` — the one hand-written table naming which component
+props carry FIELD NAMES — still listed `displayField` and `searchFields` for
+`element:record_picker`, with a comment ("The schema says `displayField`; real
+pages author `labelField`. Accept both.") describing a spec that no longer
+exists. #5775 retired both: `displayField` was renamed to `labelField`
+(ADR-0087 D2) and `searchFields` was deleted (ADR-0049), and both are
+`retiredKey()` tombstones on `ElementRecordPickerPropsSchema`. The entry now
+names `labelField` alone.
+
+What changes for an author: a page that writes one of the retired keys no
+longer collects a second `page-field-unknown` finding on top of the #5068 props
+gate's rename/delete prescription. That finding was the misleading half — it
+reported that the field named by a key which no longer exists does not exist
+either, while the prescription is what actually moves the page forward. No
+spec-conformant page is affected; nothing else in the table moves.
+
+The harder half of the residue is that nothing reconciled this hand-written
+table against the spec, which is how a retirement that disposed of the schema,
+the tombstone, the ADR-0087 conversion and the generated artifacts still left
+dead spelling standing in a live rule — the ADR-0078 reader face, where the
+next author infers the spelling is current. `component-field-specs-liveness.test.ts`
+closes that class table-wide: every prop the table names must exist on the
+corresponding `ComponentPropsMap` schema and must not be a tombstone, so the
+next retirement that forgets this table goes red naming the entry instead of
+surviving as residue.

--- a/packages/lint/src/component-field-specs-liveness.test.ts
+++ b/packages/lint/src/component-field-specs-liveness.test.ts
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#6629] `COMPONENT_FIELD_SPECS` ↔ `ComponentPropsMap` liveness.
+ *
+ * `COMPONENT_FIELD_SPECS` is the one hand-written, centralized declaration of
+ * "which component props carry FIELD NAMES", and until this test nothing
+ * reconciled it against the spec: a spec-side retirement disposes of the schema
+ * (tombstone, ADR-0087 conversion, generated artifacts) but no gate reached into
+ * this table — which is exactly how #5775's `displayField` / `searchFields`
+ * stayed listed here as apparently-valid spelling (#6629). A retired key listed
+ * in a live rule is the ADR-0078 reader face: the next author infers the
+ * spelling is current.
+ *
+ * This closes that residue class table-wide rather than per-incident: every prop
+ * name the table declares must exist on the corresponding `ComponentPropsMap`
+ * schema and must not be a `retiredKey()` tombstone (`never`-typed once the
+ * optional wrapper is unwrapped — the shape
+ * `packages/spec/src/shared/retired-key.ts` constructs, and the same
+ * introspection `packages/spec/src/ui/theme.test.ts` uses to assert the
+ * tombstone route). The next retirement that forgets this table goes red HERE,
+ * naming the entry, instead of surviving as dead spelling.
+ *
+ * ── Why the detector is self-tested ─────────────────────────────────────
+ *
+ * The reconciliation below is a "no violations" assertion, so it passes both
+ * when the table is clean AND when {@link isRetiredTombstone} has stopped
+ * recognising a tombstone at all — a zod internals change is enough to disarm it
+ * into permanent green with nothing to show for it. So the detector is pinned
+ * against a KNOWN tombstone and a KNOWN live key from the very schema this issue
+ * is about, which is what keeps the gate falsifiable rather than decorative.
+ *
+ * Deliberately NOT covered:
+ * - `record:related_list` — special-cased off the table (`RELATED_LIST_TYPE`);
+ *   its props are read structurally by `relatedListFieldRefs`, not declared as a
+ *   name list this test could reconcile.
+ * - The `fields[]` shape INSIDE a `nestedSections` entry — that is the walker's
+ *   business. This test pins that the section prop itself (`sections`) is a live
+ *   key.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ComponentPropsMap } from '@objectstack/spec/ui';
+import { COMPONENT_FIELD_SPECS } from './validate-page-field-bindings.js';
+
+/** As much of a zod (v4) node as this file reads. */
+interface ZodDef {
+  type?: string;
+  shape?: Record<string, unknown>;
+  in?: unknown;
+  getter?: () => unknown;
+  innerType?: unknown;
+}
+
+function defOf(node: unknown): ZodDef | undefined {
+  return (node as { _zod?: { def?: ZodDef } } | undefined)?._zod?.def;
+}
+
+/**
+ * Resolve a props schema to its object shape. Tolerates the two wrappers the
+ * spec composes over plain objects — `.transform()` pipes (`def.in`) and
+ * `z.lazy` (`def.getter`); `lazySchema` proxies resolve transparently on the
+ * `_zod` read itself.
+ */
+function shapeOf(schema: unknown): Record<string, unknown> | undefined {
+  let def = defOf(schema);
+  for (let hops = 0; def && !def.shape && hops < 4; hops++) {
+    if (def.type === 'pipe') def = defOf(def.in);
+    else if (def.type === 'lazy' && def.getter) def = defOf(def.getter());
+    else break;
+  }
+  return def?.shape;
+}
+
+/**
+ * A `retiredKey()` tombstone is `z.never().optional().describe(…)`: unwrap the
+ * optional/default wrapper chain and look for `never` at the core.
+ */
+function isRetiredTombstone(propSchema: unknown): boolean {
+  let node: unknown = propSchema;
+  for (let hops = 0; defOf(node)?.innerType && hops < 8; hops++) node = defOf(node)?.innerType;
+  return defOf(node)?.type === 'never';
+}
+
+const map = ComponentPropsMap as unknown as Record<string, unknown>;
+
+describe('COMPONENT_FIELD_SPECS liveness against ComponentPropsMap (#6629)', () => {
+  // ── 0. the detector, before anything is asserted THROUGH it ─────────────
+  describe('the tombstone detector actually detects (anti-vacuity)', () => {
+    // `element:record_picker` is the incident's own schema, and it carries both
+    // halves of the discrimination at once: `labelField` live, `displayField`
+    // and `searchFields` tombstoned by #5775. If any of these four assertions
+    // goes red the reconciliation below is reporting nothing, whatever colour
+    // it shows.
+    const shape = shapeOf(map['element:record_picker']);
+
+    it('reaches a real object shape through the lazySchema proxy', () => {
+      expect(shape, 'ElementRecordPickerPropsSchema resolved to no object shape').toBeDefined();
+      // Both spellings are PRESENT in the shape — that is the tombstone route
+      // (declared-but-unwritable), and it is why "absent from the shape" and
+      // "retired" have to be two separate verdicts below.
+      expect(Object.keys(shape!)).toEqual(expect.arrayContaining(['labelField', 'displayField', 'searchFields']));
+    });
+
+    it.each(['displayField', 'searchFields'])('recognises the #5775 `%s` tombstone', (key) => {
+      expect(isRetiredTombstone(shape![key])).toBe(true);
+    });
+
+    it('does not mistake the live `labelField` for one', () => {
+      expect(isRetiredTombstone(shape!.labelField)).toBe(false);
+    });
+  });
+
+  // ── 1. the reconciliation ───────────────────────────────────────────────
+  it('names only types that have a registered props schema', () => {
+    // The component-type universe is open (`z.union([PageComponentType,
+    // z.string()])`), so an unregistered type in the table would not be wrong
+    // per se — but every entry today is registered, and an unregistered one
+    // could never be reconciled below. If a future entry must name an
+    // unregistered type, exempt it here explicitly with the reasoning.
+    const unregistered = Object.keys(COMPONENT_FIELD_SPECS).filter((type) => !map[type]);
+    expect(unregistered).toEqual([]);
+  });
+
+  it('every prop the table names is a live, non-retired key on its schema', () => {
+    const violations: string[] = [];
+    for (const [type, spec] of Object.entries(COMPONENT_FIELD_SPECS)) {
+      const schema = map[type];
+      if (!schema) continue; // reported by the registration pin above
+      const shape = shapeOf(schema);
+      if (!shape) {
+        violations.push(`${type}: props schema has no resolvable object shape`);
+        continue;
+      }
+      for (const prop of [...(spec.props ?? []), ...(spec.nestedSections ?? [])]) {
+        if (!(prop in shape)) {
+          violations.push(
+            `${type}.${prop}: not declared on its ComponentPropsMap schema — ` +
+              'either a typo in COMPONENT_FIELD_SPECS or a schema key that was removed outright',
+          );
+        } else if (isRetiredTombstone(shape[prop])) {
+          violations.push(
+            `${type}.${prop}: RETIRED on its ComponentPropsMap schema (retiredKey tombstone) — ` +
+              'no spec-conformant page can carry it, and the #5068 props gate already reports it ' +
+              'by name with its rename/delete prescription, so this entry only adds a second ' +
+              'finding about a key that no longer exists; drop it (the #5775/#6629 residue class)',
+          );
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it('the record_picker entry is exactly the #5775 survivor set', () => {
+    // The incident pin under the general rule above, and NOT redundant with it:
+    // the reconciliation is silent about a prop that is simply gone, so dropping
+    // `labelField` would leave it green with nothing left to check. This is the
+    // half that notices.
+    expect(COMPONENT_FIELD_SPECS['element:record_picker']).toEqual({ props: ['labelField'] });
+  });
+});

--- a/packages/lint/src/validate-page-field-bindings.ts
+++ b/packages/lint/src/validate-page-field-bindings.ts
@@ -32,11 +32,14 @@
  * authored in the wild. The table below names the field-bearing props
  * explicitly; an unknown component type is SKIPPED silently, never flagged.
  *
- * The table also covers shapes the props schemas do not yet describe but real
- * pages authored anyway (they pass only because `properties` is unvalidated):
- * `record:details` `sections[].fields[]` and `hideFields[]`, and the record
- * picker's `labelField`. Linting the schema's shape alone would find nothing on
- * the actual corpus.
+ * The table once also covered shapes the props schemas did not describe but
+ * real pages authored anyway (`record:details` `sections[].fields[]` /
+ * `hideFields[]`, the record picker's `labelField`). #5611 and #5775 settled
+ * those the other way — the delivered shape got declared — so today every prop
+ * this table names is a live (non-retired) key on its `ComponentPropsMap`
+ * schema, and `component-field-specs-liveness.test.ts` pins that: a future
+ * retirement that forgets this table turns that test red instead of leaving a
+ * tombstoned key listed here as if it were still-valid spelling (#6629).
  *
  * ── Shared with the react page surface ──────────────────────────────────
  *
@@ -174,8 +177,21 @@ export const COMPONENT_FIELD_SPECS: Readonly<Record<string, ComponentFieldSpec>>
   'element:number': { props: ['field'] },
   'element:filter': { props: ['fields'] },
   'element:form': { props: ['fields'] },
-  // The schema says `displayField`; real pages author `labelField`. Accept both.
-  'element:record_picker': { props: ['displayField', 'labelField', 'searchFields'] },
+  // `labelField` is the one field-bearing prop this element declares. Its former
+  // companions `displayField` (renamed to `labelField`, ADR-0087 D2) and
+  // `searchFields` (deleted, ADR-0049) were retired in #5775 and are
+  // `retiredKey()` tombstones on `ElementRecordPickerPropsSchema` — so no
+  // spec-conformant page carries either, and this rule's job (resolve a field
+  // NAME against the object) is not the question a retired key raises (#6629).
+  //
+  // A non-conformant page that writes one anyway is not left unattended: the
+  // #5068 props gate reports the key with its rename/delete prescription. That
+  // gate is advisory and CLI-only and lives in a different registry
+  // (`authoring-rules`) from this suite, so it neither precedes nor suppresses
+  // this rule — what these two entries actually added was a SECOND finding,
+  // saying a field named by a key that no longer exists does not exist either.
+  // The prescription is the useful half; this half was noise on top of it.
+  'element:record_picker': { props: ['labelField'] },
 };
 
 /**


### PR DESCRIPTION
Fixes #6629

## 改了什么

`COMPONENT_FIELD_SPECS` 是「哪些组件 props 承载字段名」的唯一集中声明表。它的 `element:record_picker` 条目仍列着 #5775 已退役的两个键,还挂着一条描述已不存在的 spec 的注释:

```
// The schema says `displayField`; real pages author `labelField`. Accept both.
'element:record_picker': { props: ['displayField', 'labelField', 'searchFields'] },
```

`displayField` 在 #5775 改名为 `labelField`(ADR-0087 D2),`searchFields` 被删除(ADR-0049),两者在 `ElementRecordPickerPropsSchema` 上都是 `retiredKey()` 墓碑。条目现在只留 `labelField`。

## 一处需要更正的前提(单据与派单口径)

单据和我接手的前一版注释都写着「一个仍写 `displayField` 的页面**会先在 props 闸门被拒**,走不到字段绑定规则这一层」。核验后这句在机制上不成立,两半都不对:

- **不是「拒」**:#5068 props 闸门是 `tier: 'advisory'`,每条 finding 都是 `severity: 'warning'`(`validate-component-props.ts:199/228/239`),而且 `surfaces: CLI_ONLY`;
- **不存在「先」**:`validateComponentProps` 注册在 `authoring-rules.ts:542`,`validatePageFieldBindings` 注册在 `reference-integrity-suite.ts:113`,两个**互不相同的规则登记表**,既无先后也无短路(`grep -c validateComponentProps reference-integrity-suite.ts` = 0)。

所以这两条表项并不是「永远不可命中的死枝」,而是**只能命中非 spec-conformant 页面**的枝:一个仍写 `displayField: 'ghost'` 的页面,今天会拿到 props 闸门的改名处方**加上**本规则的第二条 finding —— 后者说「一个已不存在的键所指的字段不存在」,是两条里误导的那半。

结论与处置面不变(该删),但**理由变了**,所以代码注释按核实到的写,没有沿用「先被拒」的说法。这也是本 PR 带 changeset 而非 `skip-changeset` 的原因:对上述这一类输入,`@objectstack/lint` 的诊断输出确有可观察变化。

## 自检闸门(取了带自检的那一面)

单据把「表 ↔ `ComponentPropsMap` 对账自检」留给实施时决定。取了:新增 `component-field-specs-liveness.test.ts`,把表里每个 prop 名与对应 schema 对账 —— 必须存在,且不能是墓碑。#5775 处置了 schema、墓碑、ADR-0087 conversion 和生成物,却仍在活规则里留下死拼写,正是因为**没有任何东西扫这张手写表**。

**探测器本身也被钉住了。** 对账断言的形状是「violations 为空」,所以它在表干净时通过,在 `isRetiredTombstone` 因 zod 内部结构变动而**不再认得墓碑**时同样通过 —— 会静默退化成永久绿。因此探测器针对本单这张 schema 上的已知墓碑(`displayField` / `searchFields`)和已知活键(`labelField`)各钉一条。

## 反向验证(红集在运行**之前**预测,5 个变异全部命中)

共 7 条用例(4 条探测器自检 + 3 条对账)。

| 变异 | 预测 | 实测 |
| --- | --- | --- |
| M1 加回 `displayField` | 对账红(措辞须为 `RETIRED`,**不是** "not declared")+ record_picker 钉红 = 2 | 2 failed / 5 passed,violations 恰好 1 条,`RETIRED on its ComponentPropsMap schema` ✓ |
| M2 加回 `searchFields` | 同上 2 条 | 2 failed / 5 passed,`element:record_picker.searchFields: RETIRED` ✓ |
| M3 加入不存在的 `nope` | 对账红,措辞须为 **"not declared"**(区分两条支路) | 2 failed / 5 passed,`not declared on its ComponentPropsMap schema` ✓ |
| M4 删掉 `labelField` | 对账**空转变绿**,只有 record_picker 钉红 = 1 | 1 failed / 6 passed ✓ |
| M5 = M1 + 探测器改为恒 `false` | 对账**变绿**(证明静默退化真实存在),2 条探测器自检 + 钉红 = 3 | 3 failed / 4 passed,对账绿 ✓ |

M3 与 M1/M2 措辞不同,证明「未声明」与「已退役」是两条真正分开的判定,而不是一条支路吃掉另一条;M4 证明 record_picker 钉与对账不冗余;**M5 是最关键的一条** —— 探测器被拆掉后,`displayField` 回到表里而对账依然全绿,这正是我在继承版本上加自检的理由。

## 消费半径清扫

`COMPONENT_FIELD_SPECS` 的消费方是 `validate-page-field-bindings`(metadata 面)与 `validate-react-page-props`(react 面,#4340 共用同一张表)。全仓 grep `displayField` / `searchFields` / `record_picker`:`packages/lint`、`packages/cli`、`packages/sdui-parser`、`examples` 内**没有任何 fixture** 依赖被删的两项(`examples/app-showcase/.../page-variables.page.ts` 的 picker 不写这两个键)。`packages/spec/src/conversions/registry.ts` 里的 `displayField` 是 ADR-0087 D2 迁移路径自身的样例,走 conversion 不走本表,未受影响。因此本次**无需 fixture 分诊**。

## 闸门实测

- `pnpm --filter @objectstack/lint test` — **64 files / 1615 passed | 4 skipped**
- `pnpm --filter @objectstack/lint typecheck`(`tsc --noEmit`)— 干净无输出
- `pnpm exec eslint`(两个改动文件,`--no-inline-config`)— exit 0
- `node scripts/check-nul-bytes.mjs` — OK(6237 tracked,含两个新文件);另按纪律做了超出闸门的自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`,无命中
- `check:empty-changeset` / `check:role-word` / `check:doc-authoring` — 均绿

## 不在范围内

`sort[].field` 也是字段名,但这张表的模型是「prop 直接持有字段名」,不支持数组内嵌路径;纳入校验属新能力,按单据与派单口径⛔ 不搭车。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZgRyPVwi1jLb1mNNuUQ9o


---
_Generated by [Claude Code](https://claude.ai/code/session_01AZgRyPVwi1jLb1mNNuUQ9o)_