### PR TITLE
docs(spec): `ImportRequest.dryRun` states the no-automations boundary an import preview has (#6537)

### DIFF
--- a/.changeset/import-dryrun-hook-boundary-docs.md
+++ b/.changeset/import-dryrun-hook-boundary-docs.md
@@ -1,0 +1,28 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): `ImportRequest.dryRun` states the boundary an import preview has — no automations run (#6537)
+
+An import dry run routes through the engine's own write-path validation
+(`DataProtocol.validateData`, #6037 / #4633 ruling D) and applies no
+`runAutomations` gate, because gating it would leave the common dry run with no
+validation at all — the false all-clear that work set out to close. The engine's
+validate-only path deliberately runs **no hooks**: a preview that fired
+user-authored side effects (mail, outbound calls, writes to other objects) would
+be the retired `BatchOptions.validateOnly` defect (#4052) in a new spelling.
+
+The consequence an author can meet is narrow and, until now, written down only in
+the engine's and the import runner's source comments: on an object whose
+`beforeInsert` hook derives a **required business field**, a dry run with
+`runAutomations: true` can report `required` for a row the real import would have
+created. Audit and ownership stamps (`created_by`, `owner_id`,
+`organization_id`, …) are `system`/`readonly` and skipped by validation anyway, so
+they cannot produce this.
+
+`ImportRequest.dryRun`'s description now says so, which puts it on the reference
+page an author reads before sending the request — the same schema backs
+`CreateImportJobRequest`, so the synchronous route and the async import job both
+carry it. **Zero behaviour change**: one description string, and the
+`content/docs/references/api/export.mdx` cells regenerated from it by
+`gen:schema && gen:docs` (no hand edits).

--- a/content/docs/references/api/export.mdx
+++ b/content/docs/references/api/export.mdx
@@ -76,7 +76,7 @@ const result = CreateExportJobRequestSchema.parse(data);
 | **xlsxBase64** | `string` | optional | Base64-encoded .xlsx workbook bytes (when format = xlsx); parsed server-side |
 | **sheet** | `string \| integer` | optional | Worksheet name or 1-based index to read (xlsx; defaults to the first sheet) |
 | **mapping** | `Record<string, string> \| { sourceField: string; targetField: string; targetLabel?: string; transform: Enum<'none' \| 'uppercase' \| 'lowercase' \| 'trim' \| 'date_format' \| 'lookup'>; … }[]` | optional | Source column → target field mapping |
-| **dryRun** | `boolean` | ✅ | Validate + coerce every row without persisting |
+| **dryRun** | `boolean` | ✅ | Validate + coerce every row without persisting. The verdict is the engine's own write-path validation, with one boundary an author should know: a preview runs NO automations. Hooks never fire in a dry run (#6037) — a preview that executed user-authored side effects (mail, outbound calls, writes to other objects) would be the retired `validateOnly` defect in a new spelling. So a dry run with `runAutomations: true` can report `required` for a field a `beforeInsert` hook would populate during the real import; for hook-derived fields the real write is authoritative. |
 | **writeMode** | `Enum<'insert' \| 'update' \| 'upsert'>` | ✅ | insert / update / upsert semantics |
 | **matchFields** | `string[]` | optional | Fields that identify an existing record (required for update/upsert) |
 | **runAutomations** | `boolean` | ✅ | Fire triggers/hooks for each imported row (off by default for bulk) |
@@ -365,7 +365,7 @@ Type: `{ sourceField: string; targetField: string; targetLabel?: string; transfo
 | **xlsxBase64** | `string` | optional | Base64-encoded .xlsx workbook bytes (when format = xlsx); parsed server-side |
 | **sheet** | `string \| integer` | optional | Worksheet name or 1-based index to read (xlsx; defaults to the first sheet) |
 | **mapping** | `Record<string, string> \| { sourceField: string; targetField: string; targetLabel?: string; transform: Enum<'none' \| 'uppercase' \| 'lowercase' \| 'trim' \| 'date_format' \| 'lookup'>; … }[]` | optional | Source column → target field mapping |
-| **dryRun** | `boolean` | ✅ | Validate + coerce every row without persisting |
+| **dryRun** | `boolean` | ✅ | Validate + coerce every row without persisting. The verdict is the engine's own write-path validation, with one boundary an author should know: a preview runs NO automations. Hooks never fire in a dry run (#6037) — a preview that executed user-authored side effects (mail, outbound calls, writes to other objects) would be the retired `validateOnly` defect in a new spelling. So a dry run with `runAutomations: true` can report `required` for a field a `beforeInsert` hook would populate during the real import; for hook-derived fields the real write is authoritative. |
 | **writeMode** | `Enum<'insert' \| 'update' \| 'upsert'>` | ✅ | insert / update / upsert semantics |
 | **matchFields** | `string[]` | optional | Fields that identify an existing record (required for update/upsert) |
 | **runAutomations** | `boolean` | ✅ | Fire triggers/hooks for each imported row (off by default for bulk) |

--- a/packages/spec/src/api/export.zod.ts
+++ b/packages/spec/src/api/export.zod.ts
@@ -328,7 +328,14 @@ export const ImportRequestSchema = lazySchema(() => z.object({
   mapping: ImportMappingSchema.optional()
     .describe('Source column → target field mapping'),
   dryRun: z.boolean().default(false)
-    .describe('Validate + coerce every row without persisting'),
+    .describe(
+      'Validate + coerce every row without persisting. The verdict is the engine\'s own write-path ' +
+      'validation, with one boundary an author should know: a preview runs NO automations. Hooks never ' +
+      'fire in a dry run (#6037) — a preview that executed user-authored side effects (mail, outbound ' +
+      'calls, writes to other objects) would be the retired `validateOnly` defect in a new spelling. So a ' +
+      'dry run with `runAutomations: true` can report `required` for a field a `beforeInsert` hook would ' +
+      'populate during the real import; for hook-derived fields the real write is authoritative.',
+    ),
   writeMode: ImportWriteMode.default('insert')
     .describe('insert / update / upsert semantics'),
   matchFields: z.array(z.string()).optional()


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6537

Maintainer ruling (2026-08-08, on the issue): disposition 1 — keep the shipped behavior exactly as is, document the boundary in the import docs, where an author actually meets it. The warnings-channel split and the safe-derivation subset are both rejected. **Zero behavior change.**

## Premise re-verified against `origin/main` before writing anything

All four facts still hold at `d6d1a50be` (PR #6532 merged 2026-08-08T04:56Z):

1. The dry run routes through `validateData` with **no** `runAutomations` gate — `packages/rest/src/import-runner.ts`, `previewVerdict` and the comment above it: "Runs on EVERY dry run, whatever `runAutomations` says."
2. The engine's validate-only path runs **no hooks** — `packages/objectql/src/engine.ts`, the `validate()` doc comment section "What it deliberately does NOT simulate": "No hooks run. `beforeInsert` fires BEFORE validation on the real path, so a hook that derives a business field could in principle change a verdict this method reports."
3. `runAutomations` is on by default at the route — `packages/rest/src/import-prepare.ts:262`, `body?.runAutomations !== false`.
4. **No page in `content/docs` stated the boundary.** Searched for `dryRun` / "dry run" / "dry-run", for import headings, and for `hook` next to `validate` across `content/docs/**`; the word "hook" does not appear in `content/docs/references/api/protocol.mdx` (the `ValidateDataRequest` page) at all, and no page mentioned it for import.

## Falsified PM assumption: the natural home is a GENERATED page

The dispatch assumed the import/dry-run docs are hand-written pages under `content/docs/**`. They are not. **There is no hand-written page documenting the generic data import at all** — `content/docs/api/data-api.mdx` covers CRUD, batch, clone and analytics and never mentions the import endpoint; `content/docs/api/wire-format.mdx` only points at it in one sentence; `content/docs/permissions/*` document the separate `auth/admin/import-users` wizard. The one page that documents `ImportRequest.dryRun` is:

- `content/docs/references/api/export.mdx` — which opens with "AUTO-GENERATED — DO NOT EDIT. Run build-docs.ts to regenerate." and names its source as `packages/spec/src/api/export.zod.ts`.

So, per the dispatch's own instruction for that case, the text lands in the **generating source** and the page is regenerated — not hand-edited.

## The change

`ImportRequest.dryRun`'s `.describe()` in `packages/spec/src/api/export.zod.ts` now carries the boundary in author-facing terms: the verdict is the engine's own write-path validation, a preview runs no automations, hooks never fire in a dry run (#6037 — a preview that executed user-authored side effects would be the retired `validateOnly` defect in a new spelling), so a dry run with `runAutomations: true` can report `required` for a field a `beforeInsert` hook would populate during the real import, and for hook-derived fields the real write is authoritative.

`content/docs/references/api/export.mdx` was regenerated by `pnpm --filter @objectstack/spec gen:schema && ... gen:docs`. It is the whole regenerated diff: **two cells, no hand edits.** They are the `ImportRequest` and `CreateImportJobRequest` tables — the same schema backs both, so the synchronous route and the async import job each carry the boundary.

Deliberately **not** written: any claim about what `runAutomations` defaults to. The sentence says "a dry run with `runAutomations: true`", matching the ruling's own wording, because the schema and the route disagree about that default — filed separately, see below.

The optional pointer comment in `packages/rest` was **not** added. `import-runner.ts` already carries a 15-line comment stating this exact boundary and its rationale; a second pointer to a generated table cell would add a sync obligation without adding a fact.

## Changeset

Included — `@objectstack/spec: patch`. This is the exception the dispatch named: the change lands in generating source that rewrites a generated reference page, and the repo's convention for that is a changeset (measured on the four most recent commits touching `content/docs/references/**`: `361bd5b75`, `251e888ac`, `d0a5ceb16`, `78f0be872` — all four carry one, including `d0a5ceb16`, whose only tracked output was regenerated `.mdx`). It is also honest about what ships: the description string is published in `@objectstack/spec`'s JSON Schema, not only on the docs site. No `skip-changeset` label is therefore needed.

## Verification

- Reference-doc synchrony: `pnpm --filter @objectstack/spec check:docs` — PASS (this is the gate that would catch a hand-edited generated page).
- Every `check:*` step enumerated from `.github/workflows/lint.yml`, run one by one — all PASS. ESLint job: 32 gates (`slot-lookup`, `query-options-erasure`, `verify-stand-in`, `nul-bytes`, `doc-authoring`, `docs-audit-scope`, `role-word`, `quick-reference-counts`, `adr-anchors`, `org-identifier`, `authz-resolver`, `service-providers`, `route-envelope`, `error-code-casing`, `wildcard-fallthrough`, `meta-type-normalized`, `init-service-contract`, `durability-log-level`, `startup-registry-verdict`, `objectui-changeset`, `release-notes`, `release-body`, `node-version`, `workflow-status-functions`, `shard-attestation`, `published-files`, `engine-double-contract`, `kernel-hook-pairs`, `resume-authority-declared`, `merge-driver`, `spec-parsed-alias`) plus `pnpm lint`. Type-check job: `type-check-coverage`, `driver-conformance`, `stall-guard`, spec `tsc --noEmit`, `check:generated --reconcile-only`, `skill-docs`, `spec-changes`, `upgrade-guide`, `authorable-surface`, `docs`, `skill-refs`, `skill-frame-sync`, `skill-compatibility`, `react-blocks`, workspace build (57 + 69 tasks), workspace typecheck (120 tasks), `type-check-debt`, examples typecheck, downstream-contract typecheck, `api-surface`, `exported-any`, `dual-source-exports`, `skill-examples`, `doc-formula-expressions`, `i18n`, `i18n-coverage`, `app-nav-i18n`. Also `check:adr-0087-registration` (patch changeset, no disposition marker required) — PASS.
- `pnpm --filter @objectstack/spec test` — 345 files / 8831 tests passed.
- The three i18n gates first reported PREREQUISITE NOT MET (workspace not built); they were re-run green after `turbo run build`, which is why the build appears in the list.

## Out of scope, filed

- #6704 — `ImportRequest.runAutomations` declares `.default(false)` and its describe text says "off by default for bulk", while `POST /data/:object/import` defaults it ON (`import-prepare.ts:262`). Filed as an observation-class `finding`, not fixed here: reconciling it is a contract call about the published schema's declared default, and this PR is a zero-behavior-change docs edit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K94yzy5CVgC2JtrqYAuDk2)_