### PR TITLE
feat(metadata-protocol): 多组织下「平台级 + schedule + create_record + 未显式 organization_id」发布期拒绝 (#6285)

### DIFF
--- a/.changeset/platform-schedule-create-record-org-gate.md
+++ b/.changeset/platform-schedule-create-record-org-gate.md
@@ -1,0 +1,67 @@
+---
+"@objectstack/metadata-protocol": patch
+---
+
+feat(metadata-protocol): publishing a platform-level scheduled `create_record` flow is refused on a multi-organization deployment unless it declares `organization_id` (#6285)
+
+A scheduled flow that creates records now has to say which organization those
+records belong to — but only where the answer matters, and only where nothing
+else can supply it.
+
+## What was open
+
+`ScheduleTrigger` builds its context as
+`{ event: 'schedule', params: { jobId, flowName, schedule } }` — no `tenantId`.
+PR #6153 closed the engine half of #5494 on the rule "stamp what the engine
+KNOWS": a run whose trigger resolved an organization carries it through, and the
+driver's tenant machinery fills `organization_id` on rows that omit it. A
+schedule resolves none, so nothing fills anything — and the dominant production
+shape of the whole issue is a nightly sweep, which fires on a schedule and not
+by hand. Every row it created was born `organization_id` NULL.
+
+That is not a cosmetic NULL. A `(organization_id, …)` unique index does not
+constrain across NULL and an org-scoped query does not see the row, so the
+damage is duplicate and invisible records — hotcrm#698's duplicate numbering —
+in a stored shape no later fix can retroactively repartition.
+
+## What now happens
+
+At the runtime publish gate, this exact combination is refused with the existing
+422 `INVALID_METADATA` envelope (`code` + `status` + `issues[]`, ADR-0112):
+
+- the deployment enforces an organization wall
+  (`postureEnforcesWall(resolveTenancyPosture())` — `group` or `isolated`,
+  ADR-0105 D1), **and**
+- the flow is platform-level (the write carries no organization), **and**
+- it binds to the **schedule** trigger, **and**
+- it contains a `create_record` node, **and**
+- that node declares no `fields.organization_id`.
+
+Every limb's negation still publishes: a single-organization deployment, an
+org-scoped write, any other trigger, a flow that creates nothing, and — the
+fix an author actually applies — a node that declares
+`config.fields.organization_id`. That key is not new: `CreateRecordConfigSchema`
+has always carried `fields`, and #6153's fill-only stamping already guarantees
+an author-supplied value wins over any engine fill. One issue is reported per
+offending node, including nodes nested inside `loop` / `try_catch` / `parallel`
+regions, each addressed at the key the author must write.
+
+Drafts are never gated (#4463 D1) and the draft to active promotion is, so the
+draft door is not a bypass. `OS_ALLOW_UNLINTED_METADATA_WRITES=1` degrades the
+refusal to a loud log exactly as it does for the 26 shared rules, and
+`os migrate meta --stored` stays carved out.
+
+## Where the judgement lives, and why
+
+Runtime publish gate only; `os validate` / `os build` / `os lint` do **not**
+judge this. Both inputs the rule needs are facts about the **deployment**, and
+the CLI runs on a build machine — a shared rule would sentence every
+single-organization repository on whatever `OS_TENANCY_POSTURE` happened to be
+exported in CI. The gate's caller performs the two readings and passes them as
+arguments, so the judgement itself stays a pure function of its inputs.
+
+Migration note for a multi-organization deployment: an existing scheduled flow
+keeps running untouched — the gate blocks new writes only, never stored rows —
+but the next time one is republished it will be refused until the
+`organization_id` is declared, which is the same edit that stops it writing
+outside the organization partition.

--- a/packages/metadata-protocol/src/protocol.platform-schedule-org-gate.test.ts
+++ b/packages/metadata-protocol/src/protocol.platform-schedule-org-gate.test.ts
@@ -1,0 +1,572 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #6285 — the publish refusal for an UNSTAMPED platform-level scheduled writer
+ * (#6155 Q2=A + Q3=A, maintainer ruling 2026-08-07).
+ *
+ * ## What is being pinned
+ *
+ * The refusal combination, all five limbs:
+ *
+ *   multi-organization posture
+ *   && platform-level flow (the write carries no organization)
+ *   && schedule trigger
+ *   && contains a `create_record`
+ *   && that node declares no `fields.organization_id`
+ *   ⇒ refused at publish.
+ *
+ * Every limb's NEGATION is pinned too, because a guardrail that refuses one
+ * more shape than the ruling names is a worse defect than one that refuses one
+ * fewer: it turns a legitimate publish into a support ticket, on a surface
+ * (Studio / MCP author) with no `--force`.
+ *
+ * ## Two faces, two assertion sets
+ *
+ * `evaluateRuntimeAuthoringGate` RETURNS the error and its caller throws it, so
+ * per the dispatch's test guidance the two faces are asserted differently:
+ *
+ *  - the pure function ({@link findPlatformScheduleOrgGaps}) is asserted on its
+ *    VERDICT STRUCTURE — rule id, path, severity, one issue per offending node;
+ *  - the throwing surface (`saveMetaItem` / `publishMetaItem`) is asserted on
+ *    the ADR-0112 ENVELOPE — `code` AND `status` together, never a bare
+ *    `rejects.toThrow()`. A throw-only assertion carries one bit where this
+ *    defect has two, and the unfixed code path here does not throw at all, so
+ *    it would report "the promise resolved" and never "the envelope is
+ *    missing".
+ *
+ * ## Posture is an INPUT, not an env read
+ *
+ * Q3=A puts the deployment-shape reading at the gate's CALLER
+ * (`postureEnforcesWall(resolveTenancyPosture())` in
+ * `assertRuntimeAuthoringRules`), never inside the pure function — the CLI runs
+ * on a build machine whose env says nothing about the serving deployment. The
+ * pure-function tests below therefore pass the posture directly; only the
+ * end-to-end tests, which drive the real caller, set `OS_TENANCY_POSTURE`.
+ *
+ * Harness: the real repository write path over a stub engine — the same shape
+ * as `protocol.runtime-authoring-gate.test.ts`, because a gate INSIDE
+ * `saveMetaItem` cannot be tested against a harness that mocks `saveMetaItem`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+// The producer's OWN write-verb dispatch decisions (#4550 delete / #5480
+// update), so the fake engine below cannot accept a call ObjectQL refuses.
+// Imported from `@objectstack/metadata-core` and not from `@objectstack/objectql`:
+// objectql DEPENDS ON this package, so that import would close a dependency
+// cycle turbo rejects outright (#5619).
+import { assertEngineDeleteDispatch, assertEngineUpdateDispatch } from '@objectstack/metadata-core';
+import { ObjectStackProtocolImplementation } from './protocol.js';
+import {
+    PLATFORM_SCHEDULE_CREATE_RECORD_ORG_MISSING,
+    findPlatformScheduleOrgGaps,
+} from './runtime-authoring-gate.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures — every one of them Zod-valid, so the refusal under test is the one
+// being measured and not a schema failure wearing its clothes. (`saveMetaItem`
+// runs `FlowSchema.safeParse` BEFORE this gate; an invalid fixture would 422
+// with `failed spec validation` and the test would pass for the wrong reason.)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The issue's shape: a nightly sweep that creates rows and names no organization. */
+const scheduledSweep = () => ({
+    name: 'nightly_sweep',
+    label: 'Nightly Sweep',
+    type: 'schedule',
+    status: 'active',
+    runAs: 'system',
+    nodes: [
+        { id: 'start', type: 'start', label: 'Start', config: { schedule: '0 1 * * *' } },
+        {
+            id: 'log',
+            type: 'create_record',
+            label: 'Write sweep log',
+            config: { objectName: 'sweep_log', fields: { note: 'swept' } },
+        },
+    ],
+    edges: [{ id: 'e1', source: 'start', target: 'log' }],
+});
+
+/** The same sweep with the organization declared — Q2=A's author-side answer. */
+const scheduledSweepWithOrg = () => {
+    const flow = scheduledSweep();
+    (flow.nodes[1]!.config as Record<string, unknown>).fields = {
+        note: 'swept',
+        organization_id: 'org_a',
+    };
+    return flow;
+};
+
+/** A record-change flow that creates rows — a different trigger, so a different question. */
+const recordChangeCreator = () => ({
+    name: 'nightly_sweep',
+    label: 'On Create',
+    type: 'record_change',
+    status: 'active',
+    runAs: 'system',
+    nodes: [
+        {
+            id: 'start',
+            type: 'start',
+            label: 'Start',
+            config: { objectName: 'sweep_log', triggerType: 'record-after-create' },
+        },
+        {
+            id: 'log',
+            type: 'create_record',
+            label: 'Write sweep log',
+            config: { objectName: 'sweep_log', fields: { note: 'swept' } },
+        },
+    ],
+    edges: [{ id: 'e1', source: 'start', target: 'log' }],
+});
+
+/** A schedule flow that reads and never creates — nothing is born unpartitioned. */
+const scheduledReader = () => ({
+    name: 'nightly_sweep',
+    label: 'Nightly Read',
+    type: 'schedule',
+    status: 'active',
+    runAs: 'system',
+    nodes: [
+        { id: 'start', type: 'start', label: 'Start', config: { schedule: '0 1 * * *' } },
+        {
+            id: 'read',
+            type: 'get_record',
+            label: 'Read rows',
+            config: { objectName: 'sweep_log', outputVariable: 'rows' },
+        },
+    ],
+    edges: [{ id: 'e1', source: 'start', target: 'read' }],
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. The pure function — verdict structure.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const judge = (over: Record<string, unknown> = {}) =>
+    findPlatformScheduleOrgGaps({
+        type: 'flow',
+        name: 'nightly_sweep',
+        body: scheduledSweep(),
+        orgWallEnforced: true,
+        ...over,
+    } as Parameters<typeof findPlatformScheduleOrgGaps>[0]);
+
+describe('findPlatformScheduleOrgGaps — the refusal combination (#6285)', () => {
+    it('reports one error per unstamped create_record when all five limbs hold', () => {
+        const issues = judge();
+
+        expect(issues).toHaveLength(1);
+        const issue = issues[0]!;
+        expect(issue.rule).toBe(PLATFORM_SCHEDULE_CREATE_RECORD_ORG_MISSING);
+        expect(issue.severity).toBe('error');
+        // The path points at the key the author must WRITE, not at the node —
+        // this is the address Studio highlights.
+        expect(issue.path).toBe('flows[0].nodes[1].config.fields.organization_id');
+        expect(issue.where).toContain('nightly_sweep');
+        expect(issue.where).toContain('Write sweep log');
+        expect(issue.message).toContain('organization_id');
+        expect(issue.message).toContain('sweep_log');
+        expect(issue.hint).toContain('config.fields.organization_id');
+    });
+
+    // ── Limb negations, one test each ────────────────────────────────────
+
+    it('passes on a SINGLE-organization deployment (no wall to land outside of)', () => {
+        expect(judge({ orgWallEnforced: false })).toEqual([]);
+    });
+
+    it('passes when the flow is written INTO an organization', () => {
+        expect(judge({ organizationId: 'org_a' })).toEqual([]);
+    });
+
+    it('passes for a non-schedule trigger — a record-change flow resolves an org', () => {
+        expect(judge({ body: recordChangeCreator() })).toEqual([]);
+    });
+
+    it('passes for a schedule flow that creates nothing', () => {
+        expect(judge({ body: scheduledReader() })).toEqual([]);
+    });
+
+    it('passes when the author declares fields.organization_id (#6153 fill-only, author wins)', () => {
+        expect(judge({ body: scheduledSweepWithOrg() })).toEqual([]);
+    });
+
+    it('passes for a metadata type that is not a flow', () => {
+        expect(judge({ type: 'view', body: scheduledSweep() })).toEqual([]);
+    });
+
+    // ── The "declared" in declared-organization has to mean something ────
+
+    it.each([
+        ['null', null],
+        ['undefined', undefined],
+        ['an empty string', ''],
+        ['whitespace', '   '],
+    ])('does NOT accept %s as a declaration', (_label, value) => {
+        const flow = scheduledSweep();
+        (flow.nodes[1]!.config as Record<string, unknown>).fields = {
+            note: 'swept',
+            organization_id: value,
+        };
+        const issues = judge({ body: flow });
+        expect(
+            issues,
+            'writing the key with no value would silence the refusal without answering it — '
+                + 'the "declared ≠ enforced" shape this gate exists to close.',
+        ).toHaveLength(1);
+    });
+
+    it('accepts a template token as a declaration — it resolves at run time', () => {
+        const flow = scheduledSweep();
+        (flow.nodes[1]!.config as Record<string, unknown>).fields = {
+            organization_id: '{record.organization_id}',
+        };
+        expect(judge({ body: flow })).toEqual([]);
+    });
+
+    // ── Region traversal: the shape a sweep actually has ─────────────────
+
+    it('finds a create_record nested in a loop body, with the nested path', () => {
+        // A sweep that writes one row per matched record keeps its
+        // `create_record` inside a `loop`. A walk over `flow.nodes` alone would
+        // be blind to exactly the shape this rule exists for (the #4380
+        // defect), so the region walk is load-bearing rather than defensive.
+        const flow = {
+            name: 'nightly_sweep',
+            label: 'Nightly Sweep',
+            type: 'schedule',
+            status: 'active',
+            runAs: 'system',
+            nodes: [
+                { id: 'start', type: 'start', label: 'Start', config: { schedule: '0 1 * * *' } },
+                {
+                    id: 'each',
+                    type: 'loop',
+                    label: 'For each row',
+                    config: {
+                        collection: '{rows}',
+                        body: {
+                            nodes: [
+                                {
+                                    id: 'log',
+                                    type: 'create_record',
+                                    label: 'Write sweep log',
+                                    config: { objectName: 'sweep_log', fields: { note: 'swept' } },
+                                },
+                            ],
+                            edges: [],
+                        },
+                    },
+                },
+            ],
+            edges: [{ id: 'e1', source: 'start', target: 'each' }],
+        };
+
+        const issues = judge({ body: flow });
+        expect(issues).toHaveLength(1);
+        expect(issues[0]!.path).toBe(
+            'flows[0].nodes[1].config.body.nodes[0].config.fields.organization_id',
+        );
+    });
+
+    it('reports every offending node, not just the first', () => {
+        const flow = scheduledSweep();
+        flow.nodes.push({
+            id: 'log2',
+            type: 'create_record',
+            label: 'Write audit row',
+            config: { objectName: 'sweep_log', fields: { note: 'audited' } },
+        } as (typeof flow.nodes)[number]);
+        expect(judge({ body: flow }).map((i) => i.path)).toEqual([
+            'flows[0].nodes[1].config.fields.organization_id',
+            'flows[0].nodes[2].config.fields.organization_id',
+        ]);
+    });
+
+    // ── Trigger precedence, copied from the engine rather than guessed ───
+
+    it('leaves a time-relative sweep alone even though it also carries a schedule', () => {
+        // `AutomationEngine.resolveTriggerBinding` checks `timeRelative` BEFORE
+        // `schedule`, so such a flow binds to the time-relative trigger — which
+        // launches once per matched RECORD and therefore has an org to resolve.
+        // Judging it here would refuse a flow that never reaches ScheduleTrigger.
+        const flow = scheduledSweep();
+        (flow.nodes[0]!.config as Record<string, unknown>).timeRelative = {
+            object: 'sweep_log',
+            field: 'due_date',
+            offsetDays: -1,
+        };
+        expect(judge({ body: flow })).toEqual([]);
+    });
+
+    it('judges a flow whose START node carries a schedule even when `type` is not `schedule`', () => {
+        // The engine's own disjunction: `config.schedule != null || flow.type === 'schedule'`.
+        const flow = scheduledSweep();
+        flow.type = 'autolaunched';
+        expect(judge({ body: flow })).toHaveLength(1);
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. The throwing surface — the ADR-0112 envelope, end to end.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface Row {
+    id: string;
+    type: string;
+    name: string;
+    organization_id: string | null;
+    state: string;
+    metadata: string;
+    checksum?: string;
+}
+
+const keyOf = (w: Record<string, unknown>) =>
+    `${w.type}|${w.name}|${w.organization_id ?? '__env__'}|${w.state ?? 'active'}`;
+
+function makeStubEngine() {
+    const rows = new Map<string, Row>();
+    let nextId = 0;
+    const findRow = (w: Record<string, unknown>): { key: string; row: Row } | null => {
+        if (w.id !== undefined) {
+            for (const [k, r] of rows) if (r.id === w.id) return { key: k, row: r };
+            return null;
+        }
+        for (const [k, r] of rows) {
+            if (w.type !== undefined && r.type !== w.type) continue;
+            if (w.name !== undefined && r.name !== w.name) continue;
+            if (w.organization_id !== undefined && r.organization_id !== w.organization_id) continue;
+            if (w.state !== undefined && r.state !== w.state) continue;
+            return { key: k, row: r };
+        }
+        return null;
+    };
+    const engine: any = {
+        async findOne(_t: string, opts: { where: Record<string, unknown> }) {
+            return findRow(opts.where)?.row ?? null;
+        },
+        async find(_t: string, opts: { where: Record<string, unknown> }) {
+            return Array.from(rows.values()).filter((r) => {
+                if (opts.where.type && r.type !== opts.where.type) return false;
+                if (opts.where.organization_id !== undefined
+                    && r.organization_id !== opts.where.organization_id) return false;
+                if (opts.where.state && r.state !== opts.where.state) return false;
+                return true;
+            });
+        },
+        async insert(_t: string, data: Record<string, unknown>) {
+            if (_t === 'sys_metadata_audit') return { id: 'audit_skip' };
+            nextId += 1;
+            const row = { id: `r_${nextId}`, ...(data as any) } as Row;
+            rows.set(keyOf(data), row);
+            return { id: row.id };
+        },
+        async update(_t: string, data: Record<string, unknown>, opts: { where: Record<string, unknown> }) {
+            assertEngineUpdateDispatch(data, opts);
+            const found = findRow(opts.where);
+            if (!found) return { id: null };
+            rows.set(found.key, { ...found.row, ...(data as any) });
+            return { id: found.row.id };
+        },
+        async delete(_t: string, opts: { where: Record<string, unknown> }) {
+            assertEngineDeleteDispatch(opts);
+            const found = findRow(opts.where);
+            if (!found) return { deleted: 0 };
+            rows.delete(found.key);
+            return { deleted: 1 };
+        },
+        registry: {
+            registerItem: () => {},
+            registerObject: () => {},
+            // The live object universe the shared rules resolve names against.
+            listItems: (type: string) =>
+                type === 'object'
+                    ? [{
+                        name: 'sweep_log',
+                        label: 'Sweep Log',
+                        fields: {
+                            note: { type: 'text', label: 'Note' },
+                            due_date: { type: 'date', label: 'Due' },
+                        },
+                    }]
+                    : [],
+            getItem: () => undefined,
+        },
+    };
+    return { engine, rows };
+}
+
+/** `environmentId` set: the gate, like every ADR-0005 authorization gate, is tenant-scoped. */
+function makeProtocol() {
+    const { engine, rows } = makeStubEngine();
+    const protocol = new ObjectStackProtocolImplementation(engine, () => new Map(), 'env_test');
+    return { protocol: protocol as any, rows };
+}
+
+const flowRows = (rows: Map<string, Row>) =>
+    Array.from(rows.values()).filter((r) => r.type === 'flow');
+
+const save = (protocol: any, item: unknown, extra: Record<string, unknown> = {}) =>
+    protocol.saveMetaItem({ type: 'flow', name: 'nightly_sweep', item, ...extra });
+
+describe('#6285 refusal through saveMetaItem / publishMetaItem', () => {
+    let warn: ReturnType<typeof vi.spyOn>;
+    const savedPosture = process.env.OS_TENANCY_POSTURE;
+
+    beforeEach(() => {
+        warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        delete process.env.OS_ALLOW_UNLINTED_METADATA_WRITES;
+        // ADR-0105 D1's canonical knob. `isolated` is the posture formerly
+        // spelled `multi`; `postureEnforcesWall` is true for it and for `group`.
+        process.env.OS_TENANCY_POSTURE = 'isolated';
+    });
+    afterEach(() => {
+        warn.mockRestore();
+        delete process.env.OS_ALLOW_UNLINTED_METADATA_WRITES;
+        if (savedPosture === undefined) delete process.env.OS_TENANCY_POSTURE;
+        else process.env.OS_TENANCY_POSTURE = savedPosture;
+    });
+
+    it('refuses the publish with the ADR-0112 envelope, and persists nothing', async () => {
+        const { protocol, rows } = makeProtocol();
+
+        const err = await save(protocol, scheduledSweep()).catch((e: any) => e);
+
+        // BOTH halves of the envelope. A bare `rejects.toThrow()` here would be
+        // permanently green on a driver that throws a bare `Error`, and would
+        // report "the promise resolved" on the unfixed path — neither of which
+        // is a statement about the envelope (PR #6142 measured both directions).
+        expect(err).toBeInstanceOf(Error);
+        expect(err.code).toBe('INVALID_METADATA');
+        expect(err.status).toBe(422);
+
+        const issue = err.issues.find(
+            (i: any) => i.rule === PLATFORM_SCHEDULE_CREATE_RECORD_ORG_MISSING,
+        );
+        expect(issue, `issues: ${JSON.stringify(err.issues)}`).toBeDefined();
+        expect(issue.path).toBe('flows[0].nodes[1].config.fields.organization_id');
+
+        // The disclosure that lets a caller tell "clean" from "nothing ran".
+        expect(err.rulesRun).toContain(PLATFORM_SCHEDULE_CREATE_RECORD_ORG_MISSING);
+
+        // And nothing landed. A gate that rejects AFTER persisting is a log line.
+        expect(flowRows(rows)).toEqual([]);
+    });
+
+    it('allows the same flow once the author declares fields.organization_id', async () => {
+        const { protocol, rows } = makeProtocol();
+        const result = await save(protocol, scheduledSweepWithOrg());
+        expect(result.success).toBe(true);
+        expect(flowRows(rows).length).toBe(1);
+    });
+
+    it('allows it on a single-organization deployment', async () => {
+        process.env.OS_TENANCY_POSTURE = 'single';
+        const { protocol, rows } = makeProtocol();
+        const result = await save(protocol, scheduledSweep());
+        expect(result.success).toBe(true);
+        expect(flowRows(rows).length).toBe(1);
+    });
+
+    it('refuses under the `group` posture too, not only `isolated`', async () => {
+        // `postureEnforcesWall` is `false` for `single` ONLY. A group-shaped
+        // deployment carries the same `(organization_id, …)` index that does
+        // not constrain across NULL, so it is walled and the guardrail applies.
+        process.env.OS_TENANCY_POSTURE = 'group';
+        const { protocol } = makeProtocol();
+        const err = await save(protocol, scheduledSweep()).catch((e: any) => e);
+        expect(err.code).toBe('INVALID_METADATA');
+        expect(err.status).toBe(422);
+    });
+
+    it('allows an ORG-SCOPED write of the same flow — the row already names its organization', async () => {
+        // The limb negation at the caller face, and worth driving end-to-end
+        // rather than only on the pure function: #6283 flipped flow's
+        // `allowOrgOverride` to `false`, so the ADR-0005 gate now 403s an org
+        // overlay of a PACKAGED flow. A brand-new runtime-created flow is a
+        // different door (`allowRuntimeCreate: true` survived that flip), and
+        // this pins which of the two an org-scoped write of a new flow takes.
+        const { protocol, rows } = makeProtocol();
+        const result = await save(protocol, scheduledSweep(), { organizationId: 'org_a' });
+        expect(result.success).toBe(true);
+        expect(flowRows(rows).map((r) => r.organization_id)).toEqual(['org_a']);
+    });
+
+    it('allows a DRAFT of the identical body, and refuses the publish that promotes it', async () => {
+        const { protocol, rows } = makeProtocol();
+
+        // D1 — a draft is allowed to be half-finished and cannot execute.
+        const draft = await save(protocol, scheduledSweep(), { mode: 'draft' });
+        expect(draft.success).toBe(true);
+        expect(flowRows(rows).map((r) => r.state)).toContain('draft');
+
+        // …and the promotion is gated, so the draft door is not a bypass.
+        const err = await protocol
+            .publishMetaItem({ type: 'flow', name: 'nightly_sweep' })
+            .catch((e: any) => e);
+        expect(err.code).toBe('INVALID_METADATA');
+        expect(err.status).toBe(422);
+        expect(err.issues.map((i: any) => i.rule))
+            .toContain(PLATFORM_SCHEDULE_CREATE_RECORD_ORG_MISSING);
+    });
+
+    it('OS_ALLOW_UNLINTED_METADATA_WRITES=1 degrades it to a loud log, like every other rule', async () => {
+        process.env.OS_ALLOW_UNLINTED_METADATA_WRITES = '1';
+        const { protocol, rows } = makeProtocol();
+
+        const result = await save(protocol, scheduledSweep());
+        expect(result.success).toBe(true);
+        expect(flowRows(rows).length).toBe(1);
+
+        const shouted = (warn.mock.calls as unknown[][])
+            .map((c) => String(c[0]))
+            .filter((m) => m.includes('OS_ALLOW_UNLINTED_METADATA_WRITES'));
+        expect(shouted.length, 'the hatch makes a violation TOLERATED, never invisible').toBe(1);
+        expect(shouted[0]).toContain(PLATFORM_SCHEDULE_CREATE_RECORD_ORG_MISSING);
+    });
+
+    it('does not gate control-plane (package-author) writes — the pre-existing carve-out', async () => {
+        // The dispatch's STOP item. `environmentId === undefined` is the
+        // control-plane / package-author channel, and the short-circuit is
+        // EXISTING DESIGN (`protocol.runtime-authoring-gate.test.ts` pins it for
+        // the other 26 rules). It does not put this guardrail out of reach:
+        // every serving path binds an environment id (`env_local` /
+        // `proj_local` / a cloud project), which is the case the test above
+        // drives.
+        const { engine, rows } = makeStubEngine();
+        const protocol = new ObjectStackProtocolImplementation(engine, () => new Map()) as any;
+        const result = await protocol.saveMetaItem({
+            type: 'flow',
+            name: 'nightly_sweep',
+            item: scheduledSweep(),
+        });
+        expect(result.success).toBe(true);
+        expect(flowRows(rows).length).toBe(1);
+    });
+
+    it('does not gate `os migrate meta --stored`, which rewrites rows that already exist', async () => {
+        const { protocol, rows } = makeProtocol();
+        const result = await save(protocol, scheduledSweep(), { source: 'migrate-stored' });
+        expect(result.success).toBe(true);
+        expect(flowRows(rows).length).toBe(1);
+    });
+
+    it('survives a deployment whose OS_TENANCY_POSTURE is unparseable, by failing CLOSED', async () => {
+        // `resolveTenancyPosture()` THROWS on an unrecognized value rather than
+        // falling back to a wall-less posture. That refusal belongs at boot; on
+        // a metadata write the gate reads it as WALLED, so the guardrail arms
+        // instead of silently disengaging. The write still only fails because
+        // every other limb holds.
+        process.env.OS_TENANCY_POSTURE = 'not_a_posture';
+        const { protocol } = makeProtocol();
+        const err = await save(protocol, scheduledSweep()).catch((e: any) => e);
+        expect(err.code).toBe('INVALID_METADATA');
+        expect(err.status).toBe(422);
+
+        // …and a clean body is still publishable, so the fail-closed reading
+        // never becomes "refuse everything".
+        const { protocol: p2 } = makeProtocol();
+        await expect(save(p2, scheduledSweepWithOrg())).resolves.toMatchObject({ success: true });
+    });
+});

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -4,7 +4,12 @@ import type {
     DataProtocol, MetadataProtocol, PackageProtocol,
 } from '@objectstack/spec/api';
 import { IDataEngine, engineCanRollBack } from '@objectstack/core';
-import { readEnvWithDeprecation } from '@objectstack/types';
+import { readEnvWithDeprecation, resolveTenancyPosture } from '@objectstack/types';
+// [#6285] ADR-0105 D1's authority on "does this deployment wall organizations?".
+// `resolveMultiOrgEnabled()` is DEMOTED and its own doc comment says answering
+// this question with it is a bug (cloud#1020, #5233) — so the posture, and only
+// the posture, is what the runtime authoring gate is told.
+import { postureEnforcesWall } from '@objectstack/spec/security';
 import type { MetadataHostEngine } from './host-engine.js';
 import { evaluateRuntimeAuthoringGate } from './runtime-authoring-gate.js';
 import { SysMetadataRepository, type SysMetadataEngine } from './sys-metadata-repository.js';
@@ -2419,10 +2424,42 @@ export class ObjectStackProtocolImplementation implements
      * strictly better information than the CLI's single-package view — the
      * inversion #4463 D2 points out: the same rule can be more decisive here
      * than it can be at build time.
+     *
+     * [#6285 / #6155 Q3=A] It also supplies the two DEPLOYMENT facts the CLI
+     * cannot know and the shared registry therefore must not read: the
+     * organization partition this write lands in, and whether this deployment
+     * enforces an organization wall. Both are gathered here — the impure side —
+     * and passed as arguments, so `evaluateRuntimeAuthoringGate` stays a pure
+     * function of its inputs and a test can drive both postures without
+     * mutating the process.
      */
     private assertRuntimeAuthoringRules(evt: {
         type: string; name: string; state: 'draft' | 'active'; body: unknown; source?: string;
+        /**
+         * The organization partition of this write (`saveMetaItem`'s
+         * `organizationId`). Absent = a platform-level / environment write,
+         * which is one limb of the #6285 refusal combination.
+         */
+        organizationId?: string | null;
     }): void {
+        // Environment writes only. `environmentId === undefined` is the
+        // package author's own control-plane channel — the same carve-out the
+        // ADR-0005 authorization gate and the #3050 authoring gate below both
+        // make, and pinned as deliberate by `protocol.runtime-authoring-gate.
+        // test.ts` ("does not gate control-plane (package-author) writes").
+        //
+        // [#6285] Measured before adding a guardrail behind it, because the
+        // dispatch asked whether the short-circuit makes the new refusal
+        // unreachable in the deployment shape it protects: it does not. Every
+        // serving path binds an environment id — `os dev` / `os start` default
+        // to `env_local` (`cli/src/commands/dev.ts:225`, `start.ts:197`), the
+        // standalone artifact stack to `proj_local`
+        // (`runtime/src/standalone-stack.ts:378`), and a cloud per-project
+        // kernel to its own — so a multi-organization deployment reaches this
+        // gate. What sits behind the short-circuit is the control-plane
+        // bootstrap kernel, which authors no tenant metadata. Widening it is
+        // therefore not this issue's business (and would change the blast
+        // radius of all 26 shared rules, not just this one).
         if (this.environmentId === undefined) return;
         if (evt.state !== 'active') return;
         // `os migrate meta --stored --apply` rewrites rows that ALREADY EXIST
@@ -2461,8 +2498,42 @@ export class ObjectStackProtocolImplementation implements
             state: evt.state,
             body: evt.body,
             objects,
+            ...(evt.organizationId !== undefined ? { organizationId: evt.organizationId } : {}),
+            orgWallEnforced: this.orgWallEnforced(),
         });
         if (err) throw err;
+    }
+
+    /**
+     * [#6285] Does this deployment enforce an organization wall (ADR-0105 D1)?
+     *
+     * The authoritative reading, and the only one:
+     * `postureEnforcesWall(resolveTenancyPosture())`. `resolveMultiOrgEnabled()`
+     * is the demoted legacy input — a deployment that sets only the canonical
+     * `OS_TENANCY_POSTURE` reads `false` there while genuinely running a walled
+     * posture, which is the bug shape cloud#1020 and #5233 already paid for.
+     *
+     * Read per call rather than memoised: `resolveTenancyPosture()` reads
+     * `process.env` live by contract, and a gate that cached the answer at
+     * construction would disagree with every other consumer for the life of the
+     * process.
+     *
+     * `resolveTenancyPosture()` THROWS on an unrecognized `OS_TENANCY_POSTURE`
+     * — deliberately, so a typo cannot silently remove the wall. That refusal
+     * belongs at boot, not on a metadata write, so it is caught here and read
+     * as WALLED. Fail-closed is the direction ADR-0105 argues for on exactly
+     * this input ("refusing to boot rather than silently falling back to a
+     * posture with no organization wall"), and it costs nothing in practice: a
+     * deployment in that state does not boot, and even when reached it only
+     * arms a guardrail — a publish still has to match every other limb of the
+     * refusal combination to be turned away.
+     */
+    private orgWallEnforced(): boolean {
+        try {
+            return postureEnforcesWall(resolveTenancyPosture());
+        } catch {
+            return true;
+        }
     }
 
     /**
@@ -8089,6 +8160,10 @@ export class ObjectStackProtocolImplementation implements
             state: mode === 'draft' ? 'draft' : 'active',
             body: request.item,
             source: writeSource,
+            // [#6285] The write's organization partition. It was always here;
+            // it simply never travelled to the gate, which is the whole reason
+            // the "platform-level flow" limb could not be judged before.
+            organizationId: request.organizationId ?? null,
         });
 
         // Pre-persistence authoring gate (#3050): a domain plugin may veto the
@@ -8802,6 +8877,10 @@ export class ObjectStackProtocolImplementation implements
                 name: request.name,
                 state: 'active',
                 body: draftForGate.body,
+                // [#6285] Same partition the draft is being promoted in. Without
+                // it the draft door would be a bypass for this refusal alone,
+                // which is the exact hole #4463 D1 closed for the other 26.
+                organizationId: orgId,
             });
         }
 

--- a/packages/metadata-protocol/src/runtime-authoring-gate.ts
+++ b/packages/metadata-protocol/src/runtime-authoring-gate.ts
@@ -47,6 +47,16 @@
  */
 
 import { runRuntimeAuthoringRules, type AuthoringFinding } from '@objectstack/lint/runtime';
+// The ONE declaration of "which `config` key on which container node type holds
+// a nested region" (#4401, `spec/src/automation/region-slots.ts`). Four passes
+// already walk regions over this table — three in `spec`, one in `lint` — and
+// the module's own header records why the WALKS stay separate while the TABLE
+// is shared: they take different inputs and yield different units. The walk
+// below is the fifth reader of the table and the second raw-record one; it is
+// here rather than borrowed from `@objectstack/lint` because the runtime gate
+// may only reach that package through its kernel-safe `/runtime` entry (the
+// wiring guard's third invariant), and `walkFlowNodes` is not on it.
+import { FLOW_REGION_SLOTS_BY_TYPE } from '@objectstack/spec/automation';
 
 /** The structured issue shape a 422 carries — D3's "reuse the Zod envelope". */
 export interface RuntimeAuthoringIssue {
@@ -79,6 +89,252 @@ function unlintedWritesAllowed(): boolean {
 /** One warn per `type|name|rule` per process — Studio republishes the same body a lot. */
 const _advisoryWarned = new Set<string>();
 
+// ─────────────────────────────────────────────────────────────────────────────
+// #6285 — the publish refusal for an UNSTAMPED platform-level scheduled writer
+// (#6155 Q2=A + Q3=A, maintainer 2026-08-07).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A schedule-triggered, platform-level flow creates records without declaring
+ * which organization they belong to, on a deployment that walls organizations.
+ *
+ * ## The defect this refuses (#6155 / #5494 / hotcrm#698)
+ *
+ * `ScheduleTrigger` builds its `AutomationContext` as
+ * `{ event: 'schedule', params: { jobId, flowName, schedule } }`
+ * (`packages/triggers/trigger-schedule/src/schedule-trigger.ts`) — no
+ * `tenantId`. PR #6153 closed the engine half of #5494 on the rule "stamp what
+ * the engine KNOWS": a run whose trigger resolved an org carries it through and
+ * the driver's tenant machinery fills `organization_id` on rows that omit it.
+ * A schedule resolves none, so nothing fills anything, and the dominant
+ * production shape of the whole issue — a nightly sweep, which fires on a
+ * schedule and not by hand — still inserts rows with `organization_id` NULL.
+ *
+ * That is not a cosmetic NULL. A `(organization_id, …)` unique index does not
+ * constrain across NULL and an org-scoped query does not see the row, so the
+ * damage is duplicate and invisible records (hotcrm#698's duplicate numbering),
+ * in a stored shape no later fix can retroactively repartition.
+ *
+ * ## Why the guardrail is here and not in `AUTHORING_RULES`
+ *
+ * Q3=A, quoted verbatim from the ruling:
+ * 「Q3=A:护栏只落运行时发布门——给 `assertRuntimeAuthoringRules` →
+ * `evaluateRuntimeAuthoringGate` 补两个缺失输入(写入 org 与 部署形态
+ * `postureEnforcesWall(resolveTenancyPosture())`),CLI 纯函数侧 ⛔ 不判(构建机
+ * env 是假信号)。」
+ *
+ * Both missing inputs are facts about the DEPLOYMENT, and the CLI runs on a
+ * build machine: `os build`'s environment says nothing about the server the
+ * artifact will be served from, so a shared rule would judge every
+ * single-organization repository by whatever `OS_TENANCY_POSTURE` happened to
+ * be exported in CI. `AUTHORING_RULES` is also structurally closed to a
+ * runtime-only rule — `authoring-rule-wiring.test.ts` requires every
+ * `runtime-publish` rule to also run on `os build` ("the two publish verbs must
+ * not disagree"), which is exactly the disagreement Q3=A is choosing. So the
+ * judgement lives at the gate, the gate stays a gate for the 26 shared rules,
+ * and this file still names none of them.
+ *
+ * ## Why refusing is the right verb (Q2=A)
+ *
+ * The author-side answer already exists and needs no new key: `create_record`'s
+ * `config.fields.organization_id`. #6153's fill-only stamping guarantees an
+ * author-supplied value wins over any engine fill, so declaring it is both the
+ * fix and the only fact source. Refusing at publish is what makes that
+ * declaration *enforced* rather than advertised (Prime Directive #10) — and it
+ * is the containment candidate #6155's own triage costed as the cheap one.
+ */
+export const PLATFORM_SCHEDULE_CREATE_RECORD_ORG_MISSING =
+    'platform-schedule-create-record-org-missing';
+
+/** The organization column an author declares on a `create_record` node's `fields`. */
+const ORGANIZATION_FIELD = 'organization_id';
+
+type AnyRec = Record<string, unknown>;
+
+const isRec = (v: unknown): v is AnyRec => !!v && typeof v === 'object' && !Array.isArray(v);
+
+/** A node's diagnostic name: `label` → `id` → `#index`, as the lint walk spells it. */
+function nodeLabel(node: AnyRec, index: number): string {
+    const label = typeof node.label === 'string' && node.label ? node.label : undefined;
+    const id = typeof node.id === 'string' && node.id ? node.id : undefined;
+    return label ?? id ?? `#${index}`;
+}
+
+/**
+ * Every node of a flow, including those nested in `try_catch` / `loop` /
+ * `parallel` regions, each with the config path a finding must land on.
+ *
+ * Nesting is the common case rather than the exotic one here: a sweep that
+ * creates a record per matched row keeps its `create_record` inside a `loop`
+ * body, so a walk over `flow.nodes` alone would be blind to precisely the shape
+ * this rule exists for — the #4380 defect, re-committed. Region slots come from
+ * the shared spec table; the depth cap is the same cheap promise
+ * `walkFlowNodes` makes (regions are a tree, so this is not a cycle guard).
+ */
+function walkNodes(
+    flow: AnyRec,
+    flowPath: string,
+): Array<{ node: AnyRec; path: string; index: number }> {
+    const out: Array<{ node: AnyRec; path: string; index: number }> = [];
+    const visit = (nodes: unknown, basePath: string, depth: number): void => {
+        if (!Array.isArray(nodes) || depth > 16) return;
+        nodes.forEach((raw, index) => {
+            if (!isRec(raw)) return;
+            const path = `${basePath}[${index}]`;
+            out.push({ node: raw, path, index });
+            const type = typeof raw.type === 'string' ? raw.type : undefined;
+            const slots = type ? FLOW_REGION_SLOTS_BY_TYPE.get(type) : undefined;
+            if (!slots || !isRec(raw.config)) return;
+            for (const slot of slots) {
+                const value = raw.config[slot.key];
+                if (slot.arity === 'many') {
+                    if (!Array.isArray(value)) continue;
+                    value.forEach((branch, b) => {
+                        if (!isRec(branch)) return;
+                        visit(branch.nodes, `${path}.config.${slot.key}[${b}].nodes`, depth + 1);
+                    });
+                    continue;
+                }
+                if (!isRec(value)) continue;
+                visit(value.nodes, `${path}.config.${slot.key}.nodes`, depth + 1);
+            }
+        });
+    };
+    visit(flow.nodes, `${flowPath}.nodes`, 0);
+    return out;
+}
+
+/**
+ * Does this flow bind to the SCHEDULE trigger?
+ *
+ * Mirrors `AutomationEngine.resolveTriggerBinding`
+ * (`packages/services/service-automation/src/engine.ts`) branch for branch,
+ * INCLUDING its precedence — a start node carrying `timeRelative` binds to the
+ * `time_relative` trigger even though it also carries a `schedule` cadence, and
+ * a `record-*` `triggerType` binds to record-change whatever else it declares.
+ * Reproducing the precedence is what keeps the refusal aimed at the flows that
+ * actually reach `ScheduleTrigger`; a looser "has a schedule anywhere" reading
+ * would refuse time-relative sweeps, which resolve a record (and therefore an
+ * org) per launch and are a different question entirely.
+ */
+function bindsToScheduleTrigger(flow: AnyRec): boolean {
+    const nodes = Array.isArray(flow.nodes) ? flow.nodes : [];
+    const startNode = nodes.find((n): n is AnyRec => isRec(n) && n.type === 'start');
+    const config = isRec(startNode?.config) ? startNode.config : {};
+    const triggerType = config.triggerType;
+
+    if (typeof triggerType === 'string' && triggerType.startsWith('record-')) return false;
+    if (
+        Array.isArray(triggerType)
+        && triggerType.some((t) => typeof t === 'string' && t.startsWith('record-'))
+    ) return false;
+    if (isRec(config.timeRelative)) return false;
+
+    return config.schedule != null || flow.type === 'schedule';
+}
+
+/**
+ * Has the author declared an organization for this `create_record` node?
+ *
+ * Reads the ONE canonical key — `config.fields.organization_id`. No `??` alias
+ * chain (Prime Directive #12): `CreateRecordConfigSchema` is a `strictObject`
+ * that names `fieldValues` as a rejected spelling, and the schema gate runs
+ * BEFORE this one in `saveMetaItem`, so a body reaching here spells `fields`.
+ *
+ * A key present with `null` / `undefined` / whitespace does NOT count. The
+ * author-facing promise is a *declaration* of ownership, and the engine's
+ * fill-only stamping treats an absent value as "fill it" — so accepting an
+ * empty one would let the refusal be silenced by writing the key and nothing
+ * else, which is the "declared ≠ enforced" shape this gate exists to close.
+ * Any non-empty value passes, template tokens included: `{record.org_id}` is a
+ * real answer, resolved at run time by the same interpolation every other field
+ * value goes through.
+ */
+function declaresOrganization(config: AnyRec): boolean {
+    const fields = config.fields;
+    if (!isRec(fields)) return false;
+    if (!Object.prototype.hasOwnProperty.call(fields, ORGANIZATION_FIELD)) return false;
+    const value = fields[ORGANIZATION_FIELD];
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string' && value.trim() === '') return false;
+    return true;
+}
+
+/**
+ * Judge one about-to-be-published body for the #6285 refusal combination, and
+ * return one issue per offending `create_record` node.
+ *
+ * PURE — the two deployment facts arrive as arguments (Q3=A). It reads no
+ * `process.env`, which is what lets a test drive both postures without mutating
+ * the process, and what keeps the "is this a walled deployment?" question
+ * answered by ONE authority (`postureEnforcesWall(resolveTenancyPosture())`,
+ * ADR-0105 D1) rather than re-derived here.
+ *
+ * All five limbs must hold; each one's negation is a legitimate publish:
+ *
+ * | limb | negation passes because |
+ * |------|-------------------------|
+ * | walled posture | `single` has no organization partition to land outside of |
+ * | platform-level write | an org-scoped row already carries its organization |
+ * | schedule binding | every other trigger resolves a user or a record, so #6153 stamps |
+ * | has `create_record` | nothing is born, so nothing is born unpartitioned |
+ * | no `fields.organization_id` | the author answered the question |
+ */
+export function findPlatformScheduleOrgGaps(args: {
+    /** Singular metadata type of the item being written. */
+    type: string;
+    /** Metadata name, for the diagnostic `where`. */
+    name: string;
+    /** The body as it will be persisted. */
+    body: unknown;
+    /**
+     * The organization partition this write lands in — `saveMetaItem`'s
+     * `organizationId`. Absent/null IS the platform-level write.
+     */
+    organizationId?: string | null;
+    /** `postureEnforcesWall(resolveTenancyPosture())`, read by the caller. */
+    orgWallEnforced: boolean;
+}): RuntimeAuthoringIssue[] {
+    if (!args.orgWallEnforced) return [];
+    if (args.organizationId != null) return [];
+    if (args.type !== 'flow') return [];
+    if (!isRec(args.body)) return [];
+
+    const flow = args.body;
+    if (!bindsToScheduleTrigger(flow)) return [];
+
+    const flowName = typeof flow.name === 'string' && flow.name ? flow.name : args.name;
+    const issues: RuntimeAuthoringIssue[] = [];
+
+    for (const { node, path, index } of walkNodes(flow, 'flows[0]')) {
+        if (node.type !== 'create_record') continue;
+        const config = isRec(node.config) ? node.config : {};
+        if (declaresOrganization(config)) continue;
+        const objectName = typeof config.objectName === 'string' ? config.objectName : 'the target object';
+        issues.push({
+            severity: 'error',
+            rule: PLATFORM_SCHEDULE_CREATE_RECORD_ORG_MISSING,
+            where: `flow "${flowName}" · node "${nodeLabel(node, index)}"`,
+            path: `${path}.config.fields.${ORGANIZATION_FIELD}`,
+            message:
+                `this platform-level schedule flow creates '${objectName}' records without declaring `
+                + `'${ORGANIZATION_FIELD}', and this deployment walls organizations — a schedule trigger `
+                + `carries no organization, so every row it creates is born with ${ORGANIZATION_FIELD} NULL, `
+                + `outside every organization partition.`,
+            hint:
+                `Declare the owning organization on this node: `
+                + `config.fields.${ORGANIZATION_FIELD}. An author-supplied value always wins over the `
+                + `engine's fill (#6153), so this is the one place the answer can come from for a `
+                + `scheduled run. A NULL ${ORGANIZATION_FIELD} is not merely untidy: an `
+                + `(${ORGANIZATION_FIELD}, …) unique index does not constrain across NULL and org-scoped `
+                + `queries never see the row. Alternatively, publish this flow into an organization, or `
+                + `give it a trigger that resolves one.`,
+        });
+    }
+
+    return issues;
+}
+
 const toIssue = (f: AuthoringFinding): RuntimeAuthoringIssue => ({
     rule: f.rule,
     path: f.path,
@@ -109,6 +365,25 @@ export function evaluateRuntimeAuthoringGate(args: {
     objects?: readonly unknown[];
     /** ADR-0080 SDUI manifest when the host has one. */
     sduiManifest?: unknown;
+    /**
+     * [#6285] The organization partition this write lands in — `saveMetaItem`'s
+     * `organizationId`, absent/null for a platform-level (environment) write.
+     *
+     * One of the two inputs #6155 Q3=A adds. It was always in `saveMetaItem`'s
+     * hand and simply never travelled this far, which is why the guardrail
+     * could not be written before.
+     */
+    organizationId?: string | null;
+    /**
+     * [#6285] Does this deployment enforce an organization wall —
+     * `postureEnforcesWall(resolveTenancyPosture())` (ADR-0105 D1)?
+     *
+     * The second Q3=A input, and an INPUT on purpose: it is a process-level env
+     * reading, so the caller performs it and this function stays pure. Defaults
+     * to `false` — an unstated posture must not manufacture a refusal, and
+     * every call site that can know the answer states it.
+     */
+    orgWallEnforced?: boolean;
 }): Error | null {
     // D1 — drafts are never gated. Publishing one runs this same function.
     if (args.state !== 'active') return null;
@@ -118,6 +393,21 @@ export function evaluateRuntimeAuthoringGate(args: {
         item: args.body,
         context: { objects: args.objects ?? [] },
         ...(args.sduiManifest !== undefined ? { sduiManifest: args.sduiManifest } : {}),
+    });
+
+    // [#6285] The gate-local refusal, folded into the SAME verdict set as the
+    // 26 shared rules — deliberately not a second envelope, a second hatch or a
+    // second throw site. `runtimeTypes` cannot carry it (Q3=A: the CLI must not
+    // judge deployment shape), so this is the one judgement the gate owns; the
+    // wiring guard's invariant that this file names no REGISTRY rule is
+    // untouched, and everything downstream — the 422, the issues array, the
+    // migration hatch, the `rulesRun` disclosure — treats it identically.
+    const localIssues = findPlatformScheduleOrgGaps({
+        type: args.type,
+        name: args.name,
+        body: args.body,
+        ...(args.organizationId !== undefined ? { organizationId: args.organizationId } : {}),
+        orgWallEnforced: args.orgWallEnforced === true,
     });
 
     // P1 gates on `error` only. Advisories are surfaced as a deduped log rather
@@ -134,14 +424,21 @@ export function evaluateRuntimeAuthoringGate(args: {
         );
     }
 
-    if (result.errors.length === 0) return null;
+    if (result.errors.length === 0 && localIssues.length === 0) return null;
 
-    const issues = result.errors.map(toIssue);
+    const issues = [...result.errors.map(toIssue), ...localIssues];
     const summary = issues
         .slice(0, 3)
         .map((i) => `${i.path || i.where || '<root>'}: [${i.rule}] ${i.message}`)
         .join('; ');
     const detail = summary + (issues.length > 3 ? ` (+${issues.length - 3} more)` : '');
+    // The registry's own disclosure, plus the gate-local rule when it was
+    // applicable to this type. `rulesRun` exists so a caller can tell "clean"
+    // from "nothing ran"; a judgement that can refuse a write and never appears
+    // here would reintroduce exactly the ambiguity it was added to remove.
+    const rulesRun = args.type === 'flow'
+        ? [...result.rulesRun, PLATFORM_SCHEDULE_CREATE_RECORD_ORG_MISSING]
+        : result.rulesRun;
 
     if (unlintedWritesAllowed()) {
         // Loud by construction (#4463 acceptance): the operator who set the
@@ -150,7 +447,7 @@ export function evaluateRuntimeAuthoringGate(args: {
         console.warn(
             `[Protocol] OS_ALLOW_UNLINTED_METADATA_WRITES=1 — ALLOWING a publish of `
             + `${args.type}/${args.name} that ${issues.length} author-time gating rule(s) reject: ${detail}. `
-            + `The rules that ran: ${result.rulesRun.join(', ')}. Unset the variable once the metadata is fixed; `
+            + `The rules that ran: ${rulesRun.join(', ')}. Unset the variable once the metadata is fixed; `
             + `the runtime will execute this body as published.`,
         );
         return null;
@@ -165,6 +462,6 @@ export function evaluateRuntimeAuthoringGate(args: {
     // Which rules produced the verdict, so a caller can tell "clean" from
     // "nothing ran" without guessing (route 3 of the surface-ownership rules:
     // absence must be loud).
-    (err as any).rulesRun = result.rulesRun;
+    (err as any).rulesRun = rulesRun;
     return err;
 }


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6285

实现 #6155 维护者 2026-08-07 裁决(Q2=A + Q3=A)的 lint 半边:给运行时发布门补两个缺失输入,拒绝裁决点名的那一个组合。#6283 已落地(flow 行 `allowOrgOverride: false`),拒绝语义已定。

## STOP 项的判定:既有设计,且护栏在它保护的部署形态里可达

dispatch 要求动手前先答 `protocol.ts` 的 `if (this.environmentId === undefined) return;`。测量结论:**既有设计,不是遗漏**,并且它**不会**让本护栏在多组织部署里失效。⛔ 未拓宽 gate 激活面。

证据两条:

1. **它是 ADR-0005 控制面通道的既有 carve-out**,与其下方 #3050 authoring gate 的 `if (this.environmentId !== undefined)` 同一条口径,`protocol.runtime-authoring-gate.test.ts` 早已把它作为**刻意行为**钉住(用例 “does not gate control-plane (package-author) writes”,注释原文:「`environmentId === undefined` is the package author's own channel — the same carve-out every ADR-0005 authorization gate above it makes」)。
2. **每条真实服务路径都绑定 environmentId**,所以多组织部署照常进这道门:

   | 路径 | environmentId | 位置 |
   |---|---|---|
   | `os dev` | `env_local`(默认) | `packages/cli/src/commands/dev.ts:225` |
   | `os start` | `env_local`(默认) | `packages/cli/src/commands/start.ts:197` |
   | standalone artifact stack | `proj_local`(默认) | `packages/runtime/src/standalone-stack.ts:378` |
   | cloud 单项目内核 | 各自项目 id | `packages/objectql/src/plugin.ts:295` |

   短路后面剩下的是控制面 bootstrap 内核 —— 它不写租户元数据。拓宽它会改变全部 26 条共享规则的影响面,不是本单的事。

## 拒绝组合

多组织部署形态 && 平台级流程(写入不带 org)&& schedule 触发 && 含 `create_record` && 未在 `fields` 显式给 `organization_id` ⇒ 发布时 422 拒绝(沿用既有 `INVALID_METADATA` 信封,ADR-0112:`code` + `status` + `issues[]`)。

每个肢体的**反面**都单独钉住,都照常发布:单组织部署、org 归属的写入、其它触发器、不建记录的流程,以及作者写了 `config.fields.organization_id`(#6153 fill-only 保证作者值优先 —— 既有能力,本 PR 只核验不重造)。

三处判定不靠猜:

- **schedule 判定**逐分支照抄 `AutomationEngine.resolveTriggerBinding`,含其**优先级** —— start 节点带 `timeRelative` 的绑到 time-relative 触发器(它按记录逐条启动,有 org 可解析),`record-*` 绑到 record-change。放宽成「哪里有 schedule 就算」会误伤根本到不了 `ScheduleTrigger` 的流程。
- **region 走查**复用 spec 的 `FLOW_REGION_SLOTS_BY_TYPE`(#4401 的唯一声明,已有四个走查读它)。只走 `flow.nodes` 顶层会对**恰恰是本规则要抓的形态**失明 —— 逐行清扫的 `create_record` 就在 `loop` 体里,即 #4380 缺陷重演。
- **「显式声明」**只读唯一正则键 `config.fields.organization_id`,无 `??` 别名链(Prime Directive #12:`CreateRecordConfigSchema` 是 `strictObject`,`fieldValues` 是它点名拒绝的拼写,且 schema 门在本门之前跑)。写了键但值为 `null` / 空串**不算**声明 —— 否则「写个空键就能消音」正是本门要关掉的 declared ≠ enforced 形状。

## 为什么判定不进 `AUTHORING_RULES`

Q3=A 原文:「护栏只落运行时发布门 …… CLI 纯函数侧 ⛔ 不判(构建机 env 是假信号)」。两个输入都是**部署**事实,而 CLI 跑在构建机上。这不只是取舍,也是结构约束:`authoring-rule-wiring.test.ts` 要求每条 `runtime-publish` 规则**同时**上 `os build`(「the two publish verbs must not disagree」),而那正是 Q3=A 选择的分歧。所以判定归 gate 自己,该文件仍**未**指名任何注册表规则,wiring 守卫的三条不变量原样通过。

posture 作为**入参**而非门内 env 读数:`assertRuntimeAuthoringRules`(不纯的一侧)做 `postureEnforcesWall(resolveTenancyPosture())`,纯函数只收结果。⛔ 未改 `packages/spec` / `packages/types`,只消费其导出。

`resolveTenancyPosture()` 对非法 `OS_TENANCY_POSTURE` 会**抛**,那个拒绝属于 boot 而不属于一次元数据写入,故在此 catch 并按**有墙**读(fail-closed)—— 与 ADR-0105 对这个输入的论证同向,且代价为零:该状态下部署根本起不来,即便到达也只是**武装**护栏,发布仍需命中全部肢体才被拒。

## 测试:26 例;反向验证按预判方向命中

两个面按 dispatch 的口径分别断言:纯函数面断**判定结构**,抛出面断 **ADR-0112 信封的 `code` 与 `status`**(不单用 `toThrow()`)。

反向验证**先定方向再跑**:只撤 `protocol.ts` 的两输入管线、保留纯函数 —— 预判「caller 面拒绝用例转红、纯函数与放行用例保持绿」。实测 **5 红 / 21 绿**,红的形状恰好证明为什么 `toThrow()` 不够:

```text
AssertionError: expected { success: true, …(4) } to be an instance of Error
AssertionError: expected undefined to be 'INVALID_METADATA'
AssertionError: the hatch makes a violation TOLERATED, never invisible: expected +0 to be 1
```

第一条即未修路径**根本不抛**(它成功落库),单用 `toThrow()` 会报「promise 已 resolve」,永远说不出「信封缺失」。

本地实测(合入 `origin/main` @ `d6d1a50be` 后重跑):

```text
packages/metadata-protocol test:  Test Files  59 passed (59)   Tests  653 passed (653)
packages/lint test:               Test Files  63 passed (63)   Tests 1612 passed (1612)
packages/objectql test:           Test Files 149 passed (149)  Tests 2532 passed (2532)
tsc --noEmit (metadata-protocol):  63 errors = ledger 记账值,新增/改动文件零错误
```

门禁按 `.github/workflows/lint.yml` 逐条枚举后全部前台执行:**53 个 `check:*` 全 PASS + `pnpm lint` PASS**(含 `check:engine-double-contract` / `check:error-code-casing` / `check:route-envelope` / `check:nul-bytes` / `check:adr-anchors` / `check:type-check-debt`)。

## 影响面(如实)

行为收紧,仅限**多组织**部署。既有定时流程照常运行 —— 本门只挡新写入,不动存量行(#4463 D4)—— 但下次**重新发布**时会被拒,直到补上 `organization_id`;而那正是让它不再往组织分区之外写行的同一处修改。单组织部署不受影响(`postureEnforcesWall('single')` 为 false)。

## 文件面

未越 dispatch 声明的文件面:`runtime-authoring-gate.ts` + `protocol.ts`(`assertRuntimeAuthoringRules` 区域 ~`:2427`–`:2507` + 导入 + 两处调用点)+ 新测试 + 一个 changeset。protocol.ts 的 diff hunk 全部落在上述区域,**未触及** #6479 在飞的 `updateData`(~`:5743`)与 #5079 在飞的 `getMetaItems`/`deleteMetaItem`(~`:3284`/~`:10514`)。

Refs:#6155(裁决与探针证据)、#6283(Q1=B 契约半边)、#6153(fill-only 先例)、#5494、hotcrm#698、ADR-0105 D1、ADR-0118 D1、#4463。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6bLax4KMrSfnE1ydFU8Dw

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6bLax4KMrSfnE1ydFU8Dw)_