### PR TITLE
fix(lint): 字段级 *When 的用户根拒绝覆盖 ADR-0068 的全部三种拼写 (#6585)

### DIFF
--- a/.changeset/field-when-user-root-aliases.md
+++ b/.changeset/field-when-user-root-aliases.md
@@ -1,0 +1,45 @@
+---
+"@objectstack/lint": patch
+---
+
+fix(lint): the field-level user-root rejection covers all three ADR-0068 spellings, not just `current_user` (#6585)
+
+#6290 gave field-level `visibleWhen` / `readonlyWhen` / `requiredWhen` a
+surface-level rejection when the predicate reaches for the signed-in user, with
+a prescription that names surfaces which actually bind one. That check matched a
+single spelling — `current_user` — while ADR-0068 D1 makes `user` and `ctx.user`
+**the same object under different names**: `buildScope` hangs one `EvalUser`
+reference on `current_user` / `user` / `ctx.user` / `os.user`. So the identical
+semantic error produced an error under one spelling and **total silence** under
+the other two (both have always been in `SCOPE_ROOTS`, so the bare-reference
+check never fired on them either). Which of three ADR-equivalent spellings the
+author happened to pick decided whether they got a build-time diagnostic at all.
+
+The failure direction is the one #6146 named: an unbound root faults, the fault
+falls back, and visibility's fallback is `true` — so a predicate written to HIDE
+a field by role left it visible to everyone, silently.
+
+All three roots now share one verdict, one prescription and one message; only
+the root named in the message varies. Nothing about the option level changes:
+per-option `visibleWhen` resolves against the host's predicate scope, which
+binds the user under every spelling, so the showcase's role-gated option
+(`'admin' in current_user.positions`) stays legal — under the aliases too.
+
+**`ctx` is judged as a whole root, not only in `ctx.user` form.** At this
+surface that is simply what is true: `buildScope` creates the `ctx` root *only*
+when the evaluation carries a user, and no field-level site passes one — the
+server binds `record` + `previous` (+ `parent`) and the client's
+`evalFieldPredicate` binds `record` + `previous` + a caller scope that is only
+ever `{ parent }`. `ctx.locale` therefore faults exactly like `ctx.user.id`
+here. The narrower reading was rejected because it needs a source-level spelling
+match, which would re-open this very fork one level down (`ctx["user"].id`
+silent, `ctx.user.id` rejected) while leaving a real fail-open fault
+unreported. `ctx` remains ActionEngine's predicate root elsewhere and is
+untouched there — the platform's own `ctx.user` predicates all sit on action
+`visible` (`sys-user.object.ts`, `sys-invitation.object.ts`), a surface this
+rule never reads, and that acceptance is pinned.
+
+Sweep: field-level `*When` predicates reading any user root measure **zero**
+across `examples/`, `packages/` and the downstream `objectui` repo, by both a
+slot-keyed scan and an alias-keyed one — so no shipping metadata is refused by
+the widening. `objectstack validate` stays clean on all three example apps.

--- a/packages/lint/src/validate-expressions.test.ts
+++ b/packages/lint/src/validate-expressions.test.ts
@@ -752,6 +752,170 @@ describe('validateStackExpressions (ADR-0032 build-time)', () => {
     });
 
     /**
+     * ── The ADR-0068 aliases get the SAME field-level verdict (#6585) ────────
+     *
+     * D1 makes `user` and `ctx.user` aliases of `current_user` — `buildScope`
+     * hangs one `EvalUser` reference on all three spellings — so the semantic
+     * error above is the same error under any of them. #6584's first cut
+     * matched only the canonical spelling: `'admin' in user.positions` and
+     * `'admin' in ctx.user.positions` sailed through in silence (both roots
+     * have always been in `SCOPE_ROOTS`, so the bare-ref check never fired
+     * either), and which spelling the author picked decided whether they got a
+     * diagnostic. These tests close that fork and pin its edges.
+     *
+     * `ctx` is pinned WHOLE-ROOT deliberately: at field level `buildScope`
+     * never creates `ctx` at all (it exists only when the evaluation carries a
+     * user, which no field-level site passes), so `ctx.locale` faults exactly
+     * like `ctx.user.id`. The other side of that decision is pinned too —
+     * `ctx.user` on an ACTION `visible` (ActionEngine's surface, where `ctx`
+     * genuinely binds — the platform's own `sys_user` actions ship it) must
+     * stay accepted.
+     */
+    describe('`user` / `ctx.user` aliases at field level (#6585)', () => {
+      const slots = ['visibleWhen', 'readonlyWhen', 'requiredWhen'] as const;
+
+      it.each(slots)('rejects `user` on %s — same object as `current_user`, same unbound surface', (slot) => {
+        const issues = validateStackExpressions({
+          objects: [{
+            name: 'showcase_deal',
+            fields: { amount: { type: 'number', [slot]: "'admin' in user.positions" } },
+          }],
+        });
+        const hit = issues.filter((i) => i.where === `object 'showcase_deal' · field 'amount' ${slot}`);
+        expect(hit).toHaveLength(1);
+        expect(hit[0]!.severity).toBe('error');
+        // The message names the spelling the author WROTE — a diagnostic that
+        // talks about `current_user` to an author who typed `user` sends them
+        // hunting for text that is not in their file.
+        expect(hit[0]!.message).toMatch(/`\w+` reads `user`/);
+      });
+
+      it.each(slots)('rejects `ctx.user` on %s', (slot) => {
+        const issues = validateStackExpressions({
+          objects: [{
+            name: 'showcase_deal',
+            fields: { amount: { type: 'number', [slot]: "'admin' in ctx.user.positions" } },
+          }],
+        });
+        const hit = issues.filter((i) => i.where === `object 'showcase_deal' · field 'amount' ${slot}`);
+        expect(hit).toHaveLength(1);
+        expect(hit[0]!.severity).toBe('error');
+        expect(hit[0]!.message).toMatch(/`\w+` reads `ctx`/);
+      });
+
+      /**
+       * The whole-root half of the `ctx` decision: a `ctx` read that never
+       * touches `.user` is just as unbound at field level — `buildScope` only
+       * creates the root when a user is carried, and no field-level site
+       * carries one — so it must not slip through a `.user`-form-only match.
+       */
+      it('rejects a bare-`ctx` NON-user read too — the root itself is unbound at field level', () => {
+        const issues = validateStackExpressions({
+          objects: [{
+            name: 'showcase_deal',
+            fields: { amount: { type: 'number', visibleWhen: "ctx.locale == 'en'" } },
+          }],
+        });
+        const hit = issues.filter((i) => i.where.includes("field 'amount' visibleWhen"));
+        expect(hit).toHaveLength(1);
+        expect(hit[0]!.message).toMatch(/`visibleWhen` reads `ctx`/);
+      });
+
+      it.each(["'admin' in user.positions", "'admin' in ctx.user.positions"])(
+        'gives %s the SAME prescriptions as the canonical spelling — no per-spelling fork',
+        (predicate) => {
+          const [issue] = validateStackExpressions({
+            objects: [{
+              name: 'showcase_deal',
+              fields: { amount: { type: 'number', visibleWhen: predicate } },
+            }],
+          }).filter((i) => i.where.includes('visibleWhen'));
+          // Same three prescriptions the #6290 message test pins for
+          // `current_user`, plus the same direction-of-failure sentence.
+          expect(issue!.message).toMatch(/falls back to VISIBLE/);
+          expect(issue!.message).toMatch(/option's own `visibleWhen`/);
+          expect(issue!.message).toMatch(/readable: false/);
+          expect(issue!.message).not.toContain('record.current_user');
+        },
+      );
+
+      /**
+       * The whole-root widening makes root-vs-MEMBER discrimination newly
+       * load-bearing: `record.user_id` and `record.ctx_key` name the very
+       * strings this rule now rejects, but as MEMBERS of `record` — and
+       * `collectCelRootIdentifiers` drops member names by design. A rule that
+       * confused the two would reject the single most ordinary predicate an
+       * author writes (an owner check), which is the failure mode that would
+       * make this widening worse than the hole it closes.
+       */
+      it('does NOT trip on a `record` MEMBER merely spelled like one of the roots', () => {
+        const issues = validateStackExpressions({
+          objects: [{
+            name: 'showcase_deal',
+            fields: {
+              user_id: { type: 'text' },
+              ctx_key: { type: 'text' },
+              amount: {
+                type: 'number',
+                visibleWhen: "record.user_id != '' && record.ctx_key == 'x'",
+              },
+            },
+          }],
+        });
+        expect(issues).toHaveLength(0);
+      });
+
+      /**
+       * The widening is FIELD-level only. Option-level `visibleWhen` resolves
+       * against the host predicate scope, where `buildScope` mounts the SAME
+       * user object under every ADR-0068 spelling — so an option predicate is
+       * legal under the aliases exactly as it is under `current_user`.
+       */
+      it('still ACCEPTS an option-level `visibleWhen` spelling the `user` alias', () => {
+        const issues = validateStackExpressions({
+          objects: [{
+            name: 'showcase_cascading_select',
+            fields: {
+              tier: {
+                type: 'select',
+                options: [
+                  { label: 'Standard', value: 'standard', default: true },
+                  { label: 'Restricted', value: 'restricted', visibleWhen: "'admin' in user.positions" },
+                ],
+              },
+            },
+          }],
+        });
+        expect(issues).toHaveLength(0);
+      });
+
+      /**
+       * The blast-radius pin the #6585 measurement was for: `ctx` IS
+       * ActionEngine's predicate root, and the platform's own metadata ships
+       * `ctx.user` action predicates (`sys-user.object.ts` "visible:
+       * record.id == ctx.user.id", `sys-invitation.object.ts`). The field-level
+       * rejection must not leak onto the action surface.
+       */
+      it('still ACCEPTS `ctx.user` on an action `visible` — ActionEngine binds `ctx`', () => {
+        const issues = validateStackExpressions({
+          objects: [{
+            name: 'sys_user',
+            fields: { email: { type: 'text' } },
+            actions: [{
+              // The exact shape `packages/platform-objects/src/identity/
+              // sys-user.object.ts:291` ships (`id` is a registry-injected
+              // column, so the field-existence pass resolves it too).
+              name: 'change_password',
+              type: 'script',
+              visible: 'record.id == ctx.user.id',
+            }],
+          }],
+        });
+        expect(issues).toHaveLength(0);
+      });
+    });
+
+    /**
      * ── The option-level traversal itself (#6290 half 3) ────────────────────
      *
      * Accepting `current_user` at the option level cannot be the only evidence

--- a/packages/lint/src/validate-expressions.ts
+++ b/packages/lint/src/validate-expressions.ts
@@ -393,10 +393,14 @@ export function validateStackExpressions(stack: AnyRec): ExprIssue[] {
 
   /**
    * A FIELD-level conditional rule (`visibleWhen` / `readonlyWhen` /
-   * `requiredWhen`) that reaches for `current_user` — the one root the field
-   * level does not bind (#6146, measured at both ends: `evalFieldPredicate` /
-   * `resolveFieldRuleState` bind `record` + `previous` + `parent` and nothing
-   * else, and objectui#1582's authoring autocomplete pins the same three).
+   * `requiredWhen`) that reaches for the signed-in user — under its canonical
+   * spelling `current_user` or either of its ADR-0068 D1 aliases, `user` and
+   * `ctx.user` — the one thing the field level does not bind (#6146, measured
+   * at both ends: `evalFieldPredicate` / `resolveFieldRuleState` bind `record`
+   * + `previous` + `parent` and nothing else, and objectui#1582's authoring
+   * autocomplete pins the same three). The third root is matched WHOLE (any
+   * `ctx` read, not only `ctx.user`) — see "Why THREE roots" below for the
+   * measurement that decides it.
    *
    * ## Why this is a rule of its own rather than a missing root
    *
@@ -430,18 +434,58 @@ export function validateStackExpressions(stack: AnyRec): ExprIssue[] {
    * options resolve against the host's predicate scope, which binds
    * `current_user` (ADR-0068 / objectui#2284) — that surface is where such a
    * predicate belongs, which is why it is also the first prescription below.
+   *
+   * ## Why THREE roots, and why `ctx` is judged whole-root (#6585)
+   *
+   * ADR-0068 D1 makes `user` and `ctx.user` ALIASES of `current_user` — one
+   * `EvalUser` object under every spelling (`buildScope` in
+   * `formula/stdlib.ts` hangs the same reference on `current_user` / `user` /
+   * `ctx.user` / `os.user`). Matching only the canonical spelling meant the
+   * identical semantic error got a diagnostic under `current_user` and total
+   * silence under the aliases — which spelling the author picked decided
+   * whether they got the diagnostic, the exact fork AI authors cannot
+   * self-check. All three roots now share one verdict and one prescription;
+   * the message names the spelling found, nothing else varies.
+   *
+   * `ctx` is judged as a WHOLE root, not only in `ctx.user` form, because at
+   * this surface that is simply what is true: `buildScope` creates the `ctx`
+   * root ONLY when the evaluation carries a user (`scope.ctx = { user }`
+   * inside `if (ctx.user !== undefined)`), and no field-level site passes one
+   * — the server binds `record`+`previous`(+`parent`) (`rule-validator.ts`
+   * `readonlyWhenBindings` / the `requiredWhen` block) and the client's
+   * `evalFieldPredicate` binds `record`+`previous`+caller `scope` (only ever
+   * `{ parent }`). So `ctx.locale` faults exactly like `ctx.user.id` here.
+   * `ctx` IS ActionEngine's predicate root elsewhere — the platform's real
+   * `ctx.user` predicates all sit on action `visible` (`sys-user.object.ts`,
+   * `sys-invitation.object.ts`), a surface this helper never reads — and
+   * measured usage of field-level `*When` with ANY user root is zero across
+   * examples/, packages/ and objectui (#6585's sweep).
+   *
+   * The rejected alternative was matching `ctx` only in its `ctx.user` form.
+   * `collectCelRootIdentifiers` reports ROOTS and drops member names by
+   * design, so that reading needs a source-level spelling match — and a
+   * spelling match is precisely the defect this rule exists to remove: it
+   * would re-open the same fork one level down (`ctx["user"].id` silent,
+   * `ctx.user.id` rejected), while leaving a real fail-open fault (`ctx.locale`)
+   * unreported for the sake of a narrower rule NAME.
    */
+  const FIELD_UNBOUND_USER_ROOTS = ['current_user', 'user', 'ctx'] as const;
   const checkFieldRuleUserRoot = (where: string, slot: string, raw: unknown): void => {
     const source = celSourceOf(raw);
     if (!source) return;
     const roots = collectCelRootIdentifiers(source);
-    if (!roots.ok || !roots.roots.includes('current_user')) return;
+    if (!roots.ok) return;
+    // One issue per slot even when a predicate reaches for two of them; the
+    // tie-break is this list's order (canonical spelling first), so the message
+    // is stable rather than dependent on AST walk order.
+    const root = FIELD_UNBOUND_USER_ROOTS.find((r) => roots.roots.includes(r));
+    if (root === undefined) return;
     issues.push({
       where,
       message:
-        `\`${slot}\` reads \`current_user\`, but a field-level conditional rule binds only ` +
+        `\`${slot}\` reads \`${root}\`, but a field-level conditional rule binds only ` +
         `\`record\` (plus \`previous\`, and \`parent\` on a master-detail line item) — ` +
-        `\`current_user\` is unbound here, so the predicate faults and falls back to VISIBLE, ` +
+        `\`${root}\` is unbound here, so the predicate faults and falls back to VISIBLE, ` +
         `leaving the field the test was meant to hide showing for everyone (#6146). ` +
         `To gate the CHOICES of a select by user, move the predicate to the option's own ` +
         `\`visibleWhen\` (\`options: [{ …, visibleWhen: … }]\`) — per-option is the one \`*When\` ` +


### PR DESCRIPTION
Fixes #6585

## 缺陷

PR #6584 给字段级 `visibleWhen` / `readonlyWhen` / `requiredWhen` 加了
`checkFieldRuleUserRoot` —— 一条按**面**给出的拒绝,处方也指向真实存在的面。
但它只匹配 `current_user` 一个拼写:

```ts
if (!roots.ok || !roots.roots.includes('current_user')) return;
```

而 ADR-0068 D1 把 `user` / `ctx.user` 定为**同一个 `EvalUser` 对象的别名** ——
`formula/stdlib.ts` 的 `buildScope` 把同一个引用同时挂在 `current_user` /
`user` / `ctx.user` / `os.user` 下。于是同一个语义错误,写 `current_user`
报错,写 `user` 或 `ctx.user` **完全静默**(两者一直在 `SCOPE_ROOTS` 里,
裸引用检查也从不报它们)。作者随手挑了三个 ADR 认定等价的拼写里的哪一个,
决定了他拿不拿得到构建期诊断 —— 这正是 AI 作者最难自查的一类分岔。

失败方向就是 #6146 那个:未绑定根 ⇒ fault ⇒ 可见性 fallback 为 `true` ⇒
本想按角色藏起来的字段对所有人恒可见,且无任何构建期信号。

## 改动

走路线 1(路线 2 已按分诊维持否决):根集合从一个拼写扩到三个,共用**一条**
判定、**一条**处方、**一条**文案 —— 只有文案里点名的那个根不同,没有按拼写
分叉。选项级不受影响:per-option `visibleWhen` 走宿主谓词作用域,那里每种
拼写都绑定用户,showcase 的角色门控选项在别名下同样合法(已钉为测试)。

## `ctx` 的显式决定:按整根判,不是只判 `ctx.user` 形态

**决定:整根。** 依据是实测,不是偏好:

1. `buildScope` 只在 `if (ctx.user !== undefined)` 内部才创建 `scope.ctx`
   (`stdlib.ts:311-323`)。字段级**没有任何调用点**传用户,所以在这个面上
   `ctx` 根压根不存在 —— `ctx.locale` 与 `ctx.user.id` 同样 fault。
2. 服务端绑定实测:`readonlyWhen` 走 `rule-validator.ts:577`
   (`{ record, previous, extra: { parent } }`),`requiredWhen` 走 `:1403`
   (`{ record, previous, ...parentScope }`)。都没有 user。对照组:选项级
   `visibleWhen` 走 `:1300`,签名里**有** `user` —— 这就是两个面判定相反的原因。
3. 客户端绑定实测:`evalFieldPredicate` 传 `extra: scope`,而 objectui 里
   全部五个字段级调用点(`form.tsx` ×3、`WizardForm.tsx`、`GridField.tsx`)
   传的 `scope` 只可能是 `undefined` 或 `{ parent: contextRecord }`。
4. 作者端第三方证据:objectui 的 `FIELD_RULE_ROOTS = ['record','previous','parent']`
   (`ObjectFieldInspector.tsx:127`)—— 一个白名单,注释明写 "no `current_user`"。
5. 窄读法(只判 `ctx.user` 形态)被否:`collectCelRootIdentifiers` 按设计只报
   ROOT、丢掉成员名,所以窄读法需要**源码层面的拼写匹配** —— 而拼写匹配正是
   本条规则要消灭的东西。那会把同一个分岔下移一层(`ctx["user"].id` 静默、
   `ctx.user.id` 报错),同时为了一个更窄的规则**名字**放掉一个真实的
   fail-open fault(`ctx.locale`)。
6. `ctx` 在别处仍是 ActionEngine 的谓词根,**不受影响**:平台自己的 `ctx.user`
   谓词全在 action `visible` 上(`sys-user.object.ts` ×8、
   `sys-invitation.object.ts` ×2、`sys-user.page.ts` ×1),本规则从不读那个面。
   两个方向都已钉进测试。

## 实测扫描(派单前置 a)

字段级 `*When` 读取任一用户根的用例:**全域为零**。两遍独立扫描:

| 范围 | 按槽位名扫 | 按别名拼写本身扫(防逗号谓词藏匿) |
|---|---|---|
| `examples/` | 53 处 `*When`,含用户根 **0** | `ctx.*` 命中全是 JS hook/script 源码(`ctx.api` / `ctx.ql` / `ctx.logger`),非 CEL;`current_user` 仅 2 处,都在别的面 |
| `packages/` | 1173 处 `*When`(非测试),含用户根 **0** | 命中全是 `.describe()` 文案与 `json-schema/` 生成物;真实元数据里的 `ctx.user` 全在 action `visible` |
| `objectui`(下游) | 527 处 `*When`,含用户根 **0** | `current_user` 命中全是**选项级** `visibleWhen`;`ctx.user` 命中全是 action `visible` / 容器 / kanban 卡片谓词 |

仅有的两处合法 `current_user` 用法都在别的面上,与 #6585 正文一致:
`my-work.page.ts:85`(page component)与 `cascading-select.object.ts:85`(option 级)。

**结论:扩宽不会拒绝任何在别处能工作的东西。**

## 反向验证(方向在运行前已预判)

预判:把 `FIELD_UNBOUND_USER_ROOTS` 改回 `['current_user']`,应有 **9** 条新增
用例转红(3 槽 × `user`、3 槽 × `ctx.user`、裸 `ctx`、2 条处方一致性),而
**3** 条接受类钉子保持绿,因为它们断言的是零发现,两个版本下都成立。

实测完全吻合 —— `Tests 9 failed | 161 passed`,失败形态是:

```
AssertionError: expected [] to have a length of 1 but got +0
```

即**完全静默**,而不是文案不同 —— 正是本单描述的缺陷形态。恢复后 170/170 全绿。

## 测试

新增 12 条(`validate-expressions.test.ts`),含两条方向相反的钉子:
`ctx.locale` 在字段级被拒(整根决定的一面)、`ctx.user` 在 action `visible`
上仍被接受(另一面)。另加一条 root-vs-成员歧视钉:`record.user_id` /
`record.ctx_key` 不得误伤 —— 整根扩宽让这条歧视新变得关键。

## Changeset

**已加**(`.changeset/field-when-user-root-aliases.md`,`@objectstack/lint: patch`)。
理由:这是已发布包的对外行为变更 —— 此前静默通过的元数据现在会在
`objectstack validate` 上报错,消费者可见。且与直接先例 #6584 一致
(同文件、同规则,该 PR 也发了 changeset)。

## 门禁

- `pnpm --filter @objectstack/lint test` —— `Test Files 63 passed (63)` / `Tests 1620 passed | 4 skipped`
- `pnpm --filter @objectstack/lint typecheck` —— 干净
- 三个示例 app 的 `pnpm validate` —— `app-showcase` / `app-crm` / `app-todo` 全部 `✓ Validation passed`,零新增发现
- `node scripts/check-nul-bytes.mjs` —— OK(6237 个文件);另对本 PR 三个文件做了超出门禁的控制字符自扫,零命中

Refs: #6290、#6584、#6146、ADR-0068 D1、objectui#1582


---
_Generated by [Claude Code](https://claude.ai/code/session_01AZgRyPVwi1jLb1mNNuUQ9o)_