### PR TITLE
fix(types,rest): `uniqueViolationColumn` — 一个索引名永远不会被当成列名回答 (#6544)

### DIFF
--- a/.changeset/unique-violation-column.md
+++ b/.changeset/unique-violation-column.md
@@ -1,0 +1,55 @@
+---
+"@objectstack/types": minor
+"@objectstack/rest": patch
+---
+
+fix(types,rest): one named answer for "which column conflicted" — an index name is never returned as one (#6544)
+
+#6250 retired four private "is this a unique violation?" vocabularies into
+`isUniqueViolationError`. It left the harder half of the question behind: the
+import runner's `sanitizeRowError` still carried its own three-dialect regex
+chain, because it does **more** than answer yes/no — it names the offending
+column so the importer can say *"A record with this `email` already exists."*
+This lands that second answer as a shared export and migrates the last private
+copy onto it.
+
+**New — `uniqueViolationColumn(error)` in `@objectstack/types`** (`string |
+undefined`), sibling to `isUniqueViolationError` and gated on it, reading the
+same channels one step down the same bounded `cause` chain, plus
+node-postgres' `detail` field.
+
+**Its contract, per the maintainer's 2026-08-08 ruling: a value comes back only
+when the identifier the driver printed is determinably a COLUMN.** When a
+dialect names an *index* instead — MySQL's `Duplicate entry … for key
+'idx_email_unique'`, Postgres' `violates unique constraint "sys_user_email_key"`,
+SQLite's `UNIQUE constraint failed: index 'x'` — the answer is `undefined`,
+never the index name. Callers render this into a form field, and an index name
+mistaken for a column points the user at a field that does not exist, whereas
+`undefined` degrades to generic copy. A **composite** key (`Key (tenant_id,
+email)=(…)`) is `undefined` for the same reason: there is no single offending
+column, and naming the first is the same class of wrong answer.
+
+**⚠️ User-visible change on MySQL imports.** MySQL's duplicate-entry message
+names the index and never the column, so the importer no longer names a column
+there: rows that used to read *"A record with this `idx_email_unique` already
+exists."* — or, on MySQL 8's table-qualified `for key 'sys_user.email'`, a
+plausible-looking *`email`* that was still an index name — now read **"A record
+with this value already exists."** That is deliberate and is the accepted cost
+of the ruling. The conflict is still recognised as a conflict; only the naming
+narrowed.
+
+Three smaller import messages improve in the same move, all previously wrong
+rather than merely vague:
+
+- SQLite's expression/partial-index form used to render as *"A record with this
+  **index** already exists."*
+- Postgres' expression index used to render the truncated fragment *"A record
+  with this **lower(email** already exists."*
+- A Postgres conflict with no `DETAIL:` line used to fall through to the SQL
+  backstop and echo the driver's own sentence — index name included — at the
+  importer. It now gets the same generic conflict copy, which is also the exact
+  wording `mapDataError` puts in the 409 `UNIQUE_VIOLATION` body, so the
+  importer and the API say one thing about one condition.
+
+Not changed: the NOT NULL branch, the raw-SQL backstop, and every non-conflict
+message, which pass through exactly as before.

--- a/packages/rest/src/import-runner-error-sanitize.test.ts
+++ b/packages/rest/src/import-runner-error-sanitize.test.ts
@@ -4,39 +4,339 @@
  * sanitizeRowError() — driver/query-builder errors embed the whole failing SQL
  * statement in `err.message`; it must never reach the importer verbatim
  * (framework#3566). Common constraint failures map to human wording.
+ *
+ * ## #6544 — one dialect table, driven through BOTH faces
+ *
+ * This site used to carry its own three-dialect regex chain: one of the four
+ * private vocabularies #6250 inventoried, which between them disagreed about
+ * MySQL. It now reads `@objectstack/types`' `isUniqueViolationError` /
+ * `uniqueViolationColumn` pair.
+ *
+ * {@link DIALECT_SAMPLES} is the single corpus and every sample runs through
+ * both faces in the same file:
+ *
+ *   face 1 — `uniqueViolationColumn` (`@objectstack/types`), the column answer;
+ *   face 2 — `sanitizeRowError` (this package), the sentence the importer shows.
+ *
+ * A dialect that regresses on either goes red here, and teaching one face a
+ * dialect without the other cannot go green. The table lives in this package
+ * for the same reason #6250's does: `@objectstack/types` cannot import
+ * `@objectstack/rest`, so this is the side that can see both faces at once.
+ * `packages/types/src/unique-violation.test.ts` is its complement — it pins the
+ * *shapes* (objects, `cause` depth, the `detail` channel) a table of flat driver
+ * messages cannot express, and deliberately does not restate the vocabulary.
+ *
+ * The samples are message strings rather than error objects because that is
+ * exactly what reaches this function: `toFailedResult` hands it `err.message`.
  */
 
 import { describe, it, expect } from 'vitest';
+import { isUniqueViolationError, uniqueViolationColumn } from '@objectstack/types';
 import { sanitizeRowError } from './import-runner';
 
-describe('sanitizeRowError', () => {
-  it('maps a sqlite UNIQUE violation to a friendly, SQL-free message', () => {
-    const raw =
-      "insert into `sys_user` (`email`, `name`, `phone_number`) values " +
-      "('a@b.com', 'zhoujunyi', '13800000000') - UNIQUE constraint failed: sys_user.phone_number";
-    const out = sanitizeRowError(raw);
-    expect(out).toBe('A record with this phone_number already exists.');
-    expect(out).not.toMatch(/insert into/i);
-  });
+/** The wording used when the row conflicts but no column is determinable. */
+const UNNAMED_CONFLICT = 'A record with this value already exists.';
 
-  it('maps a mysql duplicate entry', () => {
-    const raw =
-      "insert into `sys_user` ... - ER_DUP_ENTRY: Duplicate entry 'a@b.com' for key 'sys_user.email'";
-    expect(sanitizeRowError(raw)).toBe('A record with this email already exists.');
-  });
+/** The offending user data MySQL and Postgres interpolate into their conflict text. */
+const OFFENDING_VALUE = 'acme@example.com';
 
-  it('maps a postgres unique violation', () => {
-    const raw =
+interface DialectSample {
+  /** Which driver family emits this text. */
+  readonly dialect: 'postgres' | 'mysql' | 'sqlite';
+  /** Human label — also the test name. */
+  readonly label: string;
+  /** The driver text exactly as it reaches `sanitizeRowError` (`err.message`). */
+  readonly message: string;
+  /** Is this a unique violation at all? (the shared predicate's answer) */
+  readonly conflict: boolean;
+  /** Face 1: the column `uniqueViolationColumn` must name, or `undefined`. */
+  readonly column: string | undefined;
+  /** Face 2: the exact sentence the importer must show. */
+  readonly sanitized: string;
+}
+
+/**
+ * The shared table.
+ *
+ * Positives cover each dialect in both the "names a column" and the "names an
+ * index" spelling, because the ruling this implements is precisely about
+ * telling those apart. Negatives are the sibling constraint failures the same
+ * INSERT can raise — SQLite's are the sharp ones, since `NOT NULL constraint
+ * failed:` shares its shape with the unique positive.
+ */
+const DIALECT_SAMPLES: readonly DialectSample[] = [
+  // ------------------------------------------------------------------ SQLite
+  // SQLite names `table.column` pairs — real columns, so it answers.
+  {
+    dialect: 'sqlite',
+    label: 'UNIQUE constraint failed — knex-prefixed, names a column',
+    message:
+      'insert into `sys_user` (`email`, `name`, `phone_number`) values ' +
+      "('a@b.com', 'zhoujunyi', '13800000000') - UNIQUE constraint failed: sys_user.phone_number",
+    conflict: true,
+    column: 'phone_number',
+    sanitized: 'A record with this phone_number already exists.',
+  },
+  {
+    dialect: 'sqlite',
+    label: 'UNIQUE constraint failed — bare driver message',
+    message: 'UNIQUE constraint failed: sys_user.email',
+    conflict: true,
+    column: 'email',
+    sanitized: 'A record with this email already exists.',
+  },
+  // Composite: no single offending column, so naming the first would point the
+  // form at `tenant_id` when what was typed twice is `email`.
+  {
+    dialect: 'sqlite',
+    label: 'UNIQUE constraint failed — composite key names no single column',
+    message: 'UNIQUE constraint failed: sys_user.tenant_id, sys_user.email',
+    conflict: true,
+    column: undefined,
+    sanitized: UNNAMED_CONFLICT,
+  },
+  // SQLite's other spelling, for a partial or expression index. An INDEX name.
+  {
+    dialect: 'sqlite',
+    label: 'UNIQUE constraint failed: index — an index name is not a column',
+    message: "UNIQUE constraint failed: index 'idx_lower_email'",
+    conflict: true,
+    column: undefined,
+    sanitized: UNNAMED_CONFLICT,
+  },
+  // Negative — shares "constraint failed:" and the `table.column` shape with
+  // the positives above, and must not be swept into the conflict branch.
+  {
+    dialect: 'sqlite',
+    label: 'NOT NULL constraint failed — a required value, not a taken one',
+    message: 'insert into `sys_user` (...) values (...) - NOT NULL constraint failed: sys_user.name',
+    conflict: false,
+    column: undefined,
+    sanitized: 'name is required.',
+  },
+  // Negative — the other "constraint failed" sibling.
+  {
+    dialect: 'sqlite',
+    label: 'FOREIGN KEY constraint failed — not a unique violation',
+    message: 'insert into `sys_order` (`customer_id`) values (?) - FOREIGN KEY constraint failed',
+    conflict: false,
+    column: undefined,
+    sanitized: 'FOREIGN KEY constraint failed',
+  },
+
+  // ------------------------------------------------------------------- MySQL
+  // ⚠️ The user-visible change this PR discloses. MySQL's duplicate-entry text
+  // names the INDEX and never the column — including MySQL 8's table-qualified
+  // `sys_user.email`, which LOOKS like `table.column` and is not one. The old
+  // private regex read it as a column; the ruling says `undefined`.
+  {
+    dialect: 'mysql',
+    label: 'ER_DUP_ENTRY — MySQL 8 `table.index`, which is NOT `table.column`',
+    message:
+      'insert into `sys_user` (`email`) values (?) - ' +
+      `ER_DUP_ENTRY: Duplicate entry '${OFFENDING_VALUE}' for key 'sys_user.email'`,
+    conflict: true,
+    column: undefined,
+    sanitized: UNNAMED_CONFLICT,
+  },
+  {
+    dialect: 'mysql',
+    label: 'ER_DUP_ENTRY — a named index resolves to no column',
+    message: `ER_DUP_ENTRY: Duplicate entry '${OFFENDING_VALUE}' for key 'idx_email_unique'`,
+    conflict: true,
+    column: undefined,
+    sanitized: UNNAMED_CONFLICT,
+  },
+  // Negative — MySQL's not-null.
+  {
+    dialect: 'mysql',
+    label: "ER_BAD_NULL_ERROR — not-null is not a unique violation",
+    message: "ER_BAD_NULL_ERROR: Column 'email' cannot be null",
+    conflict: false,
+    column: undefined,
+    sanitized: "ER_BAD_NULL_ERROR: Column 'email' cannot be null",
+  },
+  // Negative — near-miss wording: it carries "constraint" AND a `KEY (...)`
+  // parenthesised column list, and must still not read as unique.
+  {
+    dialect: 'mysql',
+    label: 'ER_NO_REFERENCED_ROW_2 — foreign key text carries a `KEY (col)` list',
+    message:
+      'ER_NO_REFERENCED_ROW_2: Cannot add or update a child row: a foreign key constraint fails ' +
+      '(`app`.`sys_order`, CONSTRAINT `fk_customer` FOREIGN KEY (`customer_id`) REFERENCES `sys_user` (`id`))',
+    conflict: false,
+    column: undefined,
+    sanitized:
+      'ER_NO_REFERENCED_ROW_2: Cannot add or update a child row: a foreign key constraint fails ' +
+      '(`app`.`sys_order`, CONSTRAINT `fk_customer` FOREIGN KEY (`customer_id`) REFERENCES `sys_user` (`id`))',
+  },
+
+  // -------------------------------------------------------------- PostgreSQL
+  // Only the `DETAIL:` line names columns; the constraint in the first sentence
+  // is an index name.
+  {
+    dialect: 'postgres',
+    label: 'duplicate key + DETAIL — the DETAIL line names the column',
+    message:
       'insert into "sys_user" ... - duplicate key value violates unique constraint "sys_user_email_key" ' +
-      'Detail: Key (email)=(a@b.com) already exists.';
-    expect(sanitizeRowError(raw)).toBe('A record with this email already exists.');
+      `Detail: Key (email)=(${OFFENDING_VALUE}) already exists.`,
+    conflict: true,
+    column: 'email',
+    sanitized: 'A record with this email already exists.',
+  },
+  {
+    dialect: 'postgres',
+    label: 'duplicate key + DETAIL — a quoted mixed-case column survives',
+    message:
+      'duplicate key value violates unique constraint "sys_user_email_key" ' +
+      `Detail: Key ("emailAddress")=(${OFFENDING_VALUE}) already exists.`,
+    conflict: true,
+    column: 'emailAddress',
+    sanitized: 'A record with this emailAddress already exists.',
+  },
+  // No DETAIL line: the only identifier present is the constraint (index) name.
+  // Before #6544 this fell through to the SQL backstop and echoed the driver's
+  // sentence — index name and all — at the importer.
+  {
+    dialect: 'postgres',
+    label: 'duplicate key without DETAIL — only an index name is present',
+    message:
+      'insert into "sys_user" ("email") values ($1) - ' +
+      'duplicate key value violates unique constraint "sys_user_email_key"',
+    conflict: true,
+    column: undefined,
+    sanitized: UNNAMED_CONFLICT,
+  },
+  {
+    dialect: 'postgres',
+    label: 'duplicate key + DETAIL — composite key names no single column',
+    message:
+      'duplicate key value violates unique constraint "sys_user_tenant_email_key" ' +
+      `Detail: Key (tenant_id, email)=(1, ${OFFENDING_VALUE}) already exists.`,
+    conflict: true,
+    column: undefined,
+    sanitized: UNNAMED_CONFLICT,
+  },
+  // An expression index: `lower(email)` is not a column, and the old regex used
+  // to hand back the fragment `lower(email` as if it were one.
+  {
+    dialect: 'postgres',
+    label: 'duplicate key + DETAIL — an expression index is not a column',
+    message:
+      'duplicate key value violates unique constraint "idx_lower_email" ' +
+      `Detail: Key (lower(email))=(${OFFENDING_VALUE}) already exists.`,
+    conflict: true,
+    column: undefined,
+    sanitized: UNNAMED_CONFLICT,
+  },
+  // Negative — Postgres not-null (23502).
+  {
+    dialect: 'postgres',
+    label: '23502 not-null — not a unique violation',
+    message: 'null value in column "email" of relation "sys_user" violates not-null constraint',
+    conflict: false,
+    column: undefined,
+    sanitized: 'null value in column "email" of relation "sys_user" violates not-null constraint',
+  },
+  // Negative — Postgres foreign key (23503). Its own sentence opens with the
+  // word `insert`, so the SQL backstop claims it and hands back generic copy.
+  // Unchanged by #6544, and pinned because it is the one negative whose
+  // sentence is not its own text.
+  {
+    dialect: 'postgres',
+    label: '23503 foreign key — not a unique violation (claimed by the SQL backstop)',
+    message:
+      'insert or update on table "sys_order" violates foreign key constraint "sys_order_customer_fkey"',
+    conflict: false,
+    column: undefined,
+    sanitized: 'The database rejected this row (a value may be invalid or already in use).',
+  },
+];
+
+const named = (s: DialectSample) => [`${s.dialect}: ${s.label}`, s] as const;
+
+describe('#6544 face 1 — uniqueViolationColumn (@objectstack/types)', () => {
+  it.each(DIALECT_SAMPLES.map(named))('%s', (_name, sample) => {
+    expect(uniqueViolationColumn(sample.message)).toBe(sample.column);
   });
 
-  it('maps a NOT NULL violation', () => {
-    const raw = 'insert into `sys_user` (...) values (...) - NOT NULL constraint failed: sys_user.name';
-    expect(sanitizeRowError(raw)).toBe('name is required.');
+  it.each(DIALECT_SAMPLES.map(named))('is a conflict? %s', (_name, sample) => {
+    expect(isUniqueViolationError(sample.message)).toBe(sample.conflict);
   });
 
+  it('never answers with an index name, on any dialect', () => {
+    const answers = DIALECT_SAMPLES.map((s) => uniqueViolationColumn(s.message)).filter(
+      (c): c is string => c !== undefined,
+    );
+    // Every sample naming an index spells it `idx_*`, `*_key` or `sqlite_autoindex_*`.
+    for (const answer of answers) {
+      expect(answer).not.toMatch(/^idx_|_key$|^sqlite_autoindex/);
+    }
+    // …and the table really does exercise the refusal, on all three dialects.
+    const refused = DIALECT_SAMPLES.filter((s) => s.conflict && s.column === undefined);
+    expect(new Set(refused.map((s) => s.dialect))).toEqual(
+      new Set(['mysql', 'postgres', 'sqlite']),
+    );
+  });
+});
+
+describe('#6544 face 2 — sanitizeRowError (the sentence the importer shows)', () => {
+  it.each(DIALECT_SAMPLES.map(named))('%s', (_name, sample) => {
+    expect(sanitizeRowError(sample.message)).toBe(sample.sanitized);
+  });
+
+  it('never leaks the failing SQL statement, on any sample', () => {
+    for (const sample of DIALECT_SAMPLES) {
+      expect(sanitizeRowError(sample.message)).not.toMatch(/insert into/i);
+    }
+  });
+
+  it('a conflict with no determinable column never echoes the driver identifier', () => {
+    const unnamed = DIALECT_SAMPLES.filter((s) => s.conflict && s.column === undefined);
+    expect(unnamed.length).toBeGreaterThan(0);
+    for (const sample of unnamed) {
+      const out = sanitizeRowError(sample.message);
+      expect(out).toBe(UNNAMED_CONFLICT);
+      expect(out).not.toContain('idx_');
+      expect(out).not.toContain('_key');
+      expect(out).not.toContain(OFFENDING_VALUE);
+    }
+  });
+});
+
+/**
+ * #6544's disclosed behaviour change, pinned on its own so it cannot be undone
+ * by accident or "fixed" by someone reading it as a regression.
+ *
+ * MySQL's `Duplicate entry … for key '<id>'` names an INDEX. The retired regex
+ * chain rendered that identifier as if it were a column, so a deployment whose
+ * index is `idx_email_unique` told the user "A record with this
+ * idx_email_unique already exists." and one on MySQL 8 (`for key
+ * 'sys_user.email'`) got a plausible-looking `email` that is still an index
+ * name that merely happens to match. Under the maintainer's ruling both are
+ * `undefined`: pointing a form at a field that does not exist is worse than
+ * generic copy. The cost — MySQL importers usually no longer name a column —
+ * is accepted, not accidental.
+ */
+describe('#6544 — MySQL stops naming a column (deliberate, user-visible)', () => {
+  it.each([
+    ["a named index", 'idx_email_unique'],
+    ["MySQL 8's table-qualified index", 'sys_user.email'],
+    ["an index that happens to match no column", 'uniq_2'],
+  ])('%s yields the generic sentence, not the identifier', (_label, key) => {
+    const message = `ER_DUP_ENTRY: Duplicate entry '${OFFENDING_VALUE}' for key '${key}'`;
+
+    // It is still recognised as a conflict — only the NAMING narrowed.
+    expect(isUniqueViolationError(message)).toBe(true);
+    expect(uniqueViolationColumn(message)).toBeUndefined();
+
+    const out = sanitizeRowError(message);
+    expect(out).toBe(UNNAMED_CONFLICT);
+    expect(out).not.toContain(key.split('.').pop());
+  });
+});
+
+describe('sanitizeRowError — the non-dialect behaviour', () => {
   it('never leaks a raw SQL statement even for an unrecognized reason', () => {
     const raw = 'insert into `sys_user` (`email`) values (?) - some cryptic driver failure';
     const out = sanitizeRowError(raw);
@@ -55,6 +355,12 @@ describe('sanitizeRowError', () => {
   it('passes already-friendly messages through unchanged', () => {
     expect(sanitizeRowError('User already exists. Use another email.')).toBe(
       'User already exists. Use another email.',
+    );
+  });
+
+  it('a business rule from a hook is not swept into the conflict branch', () => {
+    expect(sanitizeRowError('删除被阻断:该客户下仍有未结订单')).toBe(
+      '删除被阻断:该客户下仍有未结订单',
     );
   });
 

--- a/packages/rest/src/import-runner.ts
+++ b/packages/rest/src/import-runner.ts
@@ -6,6 +6,7 @@ import type { ExportFieldMeta } from './export-format.js';
 import type { ValidationMessageTranslator } from '@objectstack/spec/system';
 import type { ValidateDataIssue, ValidateDataRequest, ValidateDataResponse } from '@objectstack/spec/api';
 import { bulkWrite, withTransientRetry, defaultIsTransientError, type BulkWriteRowResult } from '@objectstack/core';
+import { isUniqueViolationError, uniqueViolationColumn } from '@objectstack/types';
 
 /**
  * import-runner — the shared row-processing core for bulk import.
@@ -206,6 +207,14 @@ function bareColumn(raw: string): string {
 }
 
 /**
+ * The sentence used when the row conflicts but no column is determinable
+ * (#6544). Deliberately the same wording `mapDataError` puts in the 409
+ * `UNIQUE_VIOLATION` body, so the importer and the API say one thing about one
+ * condition rather than two.
+ */
+const UNNAMED_CONFLICT = 'A record with this value already exists.';
+
+/**
  * Turn a raw write error into a message safe to hand back to the importer.
  *
  * Driver / query-builder errors (knex et al.) embed the *entire* failing SQL
@@ -214,18 +223,32 @@ function bareColumn(raw: string): string {
  * verbatim is both unreadable and an information disclosure of the schema
  * (framework#3566). This maps the common constraint failures to human wording
  * and, as a backstop, never lets a raw SQL statement escape to the client.
+ *
+ * The unique-violation verdict and the conflicting column both come from
+ * `@objectstack/types` (#6544). This site used to carry its own three-dialect
+ * regex chain — one of the four private vocabularies #6250 inventoried, which
+ * between them disagreed about MySQL. Two consequences of adopting the shared
+ * pair, both intended:
+ *
+ *  - the verdict widens: a conflict recognised only by a channel the old chain
+ *    did not read (Postgres' bare constraint name, for one) now gets conflict
+ *    wording instead of falling through to the SQL backstop; and
+ *  - the *naming* narrows: `uniqueViolationColumn` refuses to answer with an
+ *    index name, so **MySQL rows no longer name a column** — they used to name
+ *    the index (`for key 'idx_email_unique'`) as if it were one, pointing the
+ *    user at a field that does not exist. See that function's doc comment.
  */
 export function sanitizeRowError(raw: unknown): string {
   const msg = typeof raw === 'string' ? raw.trim() : '';
   if (!msg) return 'Row failed';
 
-  // UNIQUE — surface the offending column (it maps to a user-facing import
-  // column, so naming it is helpful, not a schema leak).
-  const unique =
-    /unique constraint failed:\s*([^\s,)]+)/i.exec(msg) ??          // sqlite
-    /duplicate entry .* for key '([^']+)'/i.exec(msg) ??            // mysql
-    /duplicate key value violates unique constraint.*?[Kk]ey \(([^)]+)\)/is.exec(msg); // postgres
-  if (unique) return `A record with this ${bareColumn(unique[1])} already exists.`;
+  // UNIQUE — surface the offending column when the dialect determinably named
+  // one (it maps to a user-facing import column, so naming it is helpful, not a
+  // schema leak); otherwise say so generically rather than guess.
+  if (isUniqueViolationError(msg)) {
+    const column = uniqueViolationColumn(msg);
+    return column ? `A record with this ${column} already exists.` : UNNAMED_CONFLICT;
+  }
 
   // NOT NULL — a required value is missing.
   const notNull = /not null constraint failed:\s*([^\s,)]+)/i.exec(msg);

--- a/packages/types/src/unique-violation.test.ts
+++ b/packages/types/src/unique-violation.test.ts
@@ -20,7 +20,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { isUniqueViolationError } from './unique-violation.js';
+import { isUniqueViolationError, uniqueViolationColumn } from './unique-violation.js';
 
 describe('isUniqueViolationError — input shapes', () => {
     it('accepts a bare string, for callers that already unwrapped `err.message`', () => {
@@ -90,5 +90,122 @@ describe('isUniqueViolationError — an unrecognised error is never a conflict',
         ['a sibling constraint failure', 'CHECK constraint failed: sys_user_age_check'],
     ])('is not a conflict: %s', (_label, message) => {
         expect(isUniqueViolationError(new Error(message))).toBe(false);
+    });
+});
+
+/* ------------------------------------------------------------------------- *
+ *  #6544 — uniqueViolationColumn
+ *
+ *  Same division of labour as above: the DIALECT VOCABULARY (which driver text
+ *  names a column and which names an index, per dialect, with its negatives)
+ *  lives in exactly one place — `@objectstack/rest`'s
+ *  `import-runner-error-sanitize.test.ts`, where it is driven through this
+ *  export AND through `sanitizeRowError` in the same run. Restating it here
+ *  would rebuild the fork these exports exist to retire.
+ *
+ *  What this file covers is what a table of flat driver messages cannot: the
+ *  SHAPES a caller hands in, the channels an error object carries, and the
+ *  boundaries of the search.
+ * ------------------------------------------------------------------------- */
+
+describe('uniqueViolationColumn — input shapes', () => {
+    it('accepts a bare string, for callers that already unwrapped `err.message`', () => {
+        expect(uniqueViolationColumn('UNIQUE constraint failed: sys_user.email')).toBe('email');
+    });
+
+    it('reads an Error object on the message channel', () => {
+        expect(uniqueViolationColumn(new Error('UNIQUE constraint failed: sys_user.email'))).toBe(
+            'email',
+        );
+    });
+
+    it.each([
+        ['undefined', undefined],
+        ['null', null],
+        ['a number', 42],
+        ['a boolean', false],
+        ['an empty object', {}],
+        ['an error with no message', new Error()],
+    ])('names no column: %s', (_label, value) => {
+        expect(uniqueViolationColumn(value)).toBeUndefined();
+    });
+});
+
+describe('uniqueViolationColumn — the channels an error object carries', () => {
+    /**
+     * node-postgres keeps the `DETAIL:` line off `message` and on its own
+     * `detail` field, so for the Postgres driver we actually ship, the column
+     * is in neither the message nor any code — reading `detail` is what makes
+     * the export answer at all there.
+     */
+    it("reads node-postgres' `detail` field when the message names only the index", () => {
+        const err = Object.assign(
+            new Error('duplicate key value violates unique constraint "sys_user_email_key"'),
+            { code: '23505', detail: 'Key (email)=(acme@example.com) already exists.' },
+        );
+        expect(uniqueViolationColumn(err)).toBe('email');
+    });
+
+    it('prefers the message when both channels name a column', () => {
+        const err = Object.assign(new Error('UNIQUE constraint failed: sys_user.email'), {
+            detail: 'Key (other_column)=(x) already exists.',
+        });
+        expect(uniqueViolationColumn(err)).toBe('email');
+    });
+
+    it('a `detail` that is not a string is ignored rather than thrown on', () => {
+        const err = Object.assign(new Error('duplicate key value violates unique constraint "i"'), {
+            code: '23505',
+            detail: { key: 'email' },
+        });
+        expect(uniqueViolationColumn(err)).toBeUndefined();
+    });
+});
+
+describe('uniqueViolationColumn — the `cause` chain', () => {
+    const nest = (depth: number): unknown => {
+        let err: unknown = new Error('UNIQUE constraint failed: sys_user.email');
+        for (let i = 0; i < depth; i += 1) err = Object.assign(new Error('Write failed'), { cause: err });
+        return err;
+    };
+
+    it.each([1, 2, 3, 4])('finds the column wrapped %i level(s) deep', (depth) => {
+        expect(uniqueViolationColumn(nest(depth))).toBe('email');
+    });
+
+    it('stops rather than walking an unbounded chain', () => {
+        expect(uniqueViolationColumn(nest(5))).toBeUndefined();
+    });
+
+    it('a self-referential `cause` terminates instead of recursing forever', () => {
+        const err: { message: string; cause?: unknown } = { message: 'Write failed' };
+        err.cause = err;
+        expect(uniqueViolationColumn(err)).toBeUndefined();
+    });
+});
+
+describe('uniqueViolationColumn — gated on the predicate', () => {
+    /**
+     * The gate is what keeps SQLite's sibling failures out: `NOT NULL
+     * constraint failed: sys_user.email` has the same `table.column` shape as
+     * the unique positive, and is refused because it is not a conflict — not
+     * because a pattern happened to miss it.
+     */
+    it.each([
+        ['NOT NULL constraint failed: sys_user.email'],
+        ['CHECK constraint failed: sys_user_age_check'],
+        ['FOREIGN KEY constraint failed'],
+        ['null value in column "email" of relation "sys_user" violates not-null constraint'],
+    ])('names no column for a non-conflict: %s', (message) => {
+        expect(isUniqueViolationError(message)).toBe(false);
+        expect(uniqueViolationColumn(message)).toBeUndefined();
+    });
+
+    it('a conflict the predicate recognises may still name no column', () => {
+        // The two answers are independent: yes/no is wider than which-column,
+        // deliberately (#6544's ruling). A caller must handle `true` + `undefined`.
+        const mysql = "ER_DUP_ENTRY: Duplicate entry 'a@b.com' for key 'idx_email_unique'";
+        expect(isUniqueViolationError(mysql)).toBe(true);
+        expect(uniqueViolationColumn(mysql)).toBeUndefined();
     });
 });

--- a/packages/types/src/unique-violation.ts
+++ b/packages/types/src/unique-violation.ts
@@ -55,13 +55,14 @@
  * on it, so adopting the predicate never adds an edge. This module deliberately
  * imports nothing.
  *
- * ## What this predicate does NOT do
+ * ## The second question, answered separately
  *
- * It does not name the **conflicting column**. `sanitizeRowError` extracts one
- * for the import path, and #5495 wants one to decide whether an autonumber
- * collision is retryable — but a structured conflict-column export is a new
- * contract surface, so it is deliberately not decided here (#6250's ruling).
- * This answers the yes/no question only.
+ * `isUniqueViolationError` answers yes/no. **Which column** conflicted is a
+ * different question with a different failure mode, so it is a different export:
+ * {@link uniqueViolationColumn}, added by #6544 under the maintainer's
+ * 2026-08-08 ruling. Read its doc comment before touching either — the two are
+ * gated on each other and the column answer is deliberately narrower than the
+ * boolean.
  */
 
 /**
@@ -171,4 +172,161 @@ function matchesUniqueViolation(error: unknown, depth: number): boolean {
     if (typeof err.message === 'string' && UNIQUE_VIOLATION.message.test(err.message)) return true;
 
     return matchesUniqueViolation(err.cause, depth + 1);
+}
+
+/* ------------------------------------------------------------------------- *
+ *  #6544 — which column conflicted
+ * ------------------------------------------------------------------------- */
+
+/**
+ * SQLite names the offending **columns** directly, as `table.column` pairs:
+ * `UNIQUE constraint failed: sys_user.email`. Captured to end-of-line because
+ * knex prefixes the failing statement, so the useful part is always the tail.
+ */
+const SQLITE_TARGETS = /unique constraint failed:\s*([^\n]*)/i;
+
+/**
+ * Postgres names the offending **columns** only in its `DETAIL:` line —
+ * `Key (email)=(acme@example.com) already exists.` — which node-postgres puts
+ * on `error.detail` and knex flattens into the message. The trailing `=(`
+ * is required: it is what separates this form from the constraint-name form
+ * (`violates unique constraint "sys_user_email_key"`), which names an INDEX.
+ *
+ * An expression index (`Key (lower(email))=(…)`) cannot match, because the
+ * capture forbids `)` — which is the correct answer: `lower(email)` is not a
+ * column.
+ */
+const POSTGRES_DETAIL_TARGETS = /\bkey \(([^)]+)\)=\(/i;
+
+/** SQLite's other spelling, for a partial or expression index: `UNIQUE constraint failed: index 'x'`. */
+const SQLITE_INDEX_FORM = /^index\b/i;
+
+/** What a column name may look like once the table qualifier and quoting are stripped. */
+const PLAIN_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_$]*$/;
+
+/** Strip quoting and any `table.` qualifier from one constraint target. */
+function bareIdentifier(raw: string): string {
+    const stripped = raw.trim().replace(/[`"'[\]]/g, '');
+    const dot = stripped.lastIndexOf('.');
+    return dot >= 0 ? stripped.slice(dot + 1) : stripped;
+}
+
+/**
+ * Reduce one dialect's list of constraint targets to THE conflicting column,
+ * or `undefined` when there is not exactly one that is determinably a column.
+ *
+ * A composite key resolves to `undefined` on purpose: there is no single
+ * offending column, and picking the first is the same class of wrong answer as
+ * returning an index name — it points a form at `tenant_id` when what the user
+ * typed twice was `email`.
+ */
+function soleColumn(targets: string): string | undefined {
+    const names = targets.split(',').map(bareIdentifier);
+    if (names.length !== 1) return undefined;
+    const [name] = names;
+    return PLAIN_IDENTIFIER.test(name) ? name : undefined;
+}
+
+function columnFromText(text: string): string | undefined {
+    const sqlite = SQLITE_TARGETS.exec(text);
+    if (sqlite) {
+        const targets = sqlite[1].trim();
+        // `index 'idx_email_unique'` is an index name, not a column. Refuse.
+        return SQLITE_INDEX_FORM.test(targets) ? undefined : soleColumn(targets);
+    }
+
+    const postgres = POSTGRES_DETAIL_TARGETS.exec(text);
+    if (postgres) return soleColumn(postgres[1]);
+
+    // MySQL deliberately has no limb here — see the doc comment on
+    // `uniqueViolationColumn`. `Duplicate entry 'x' for key 'i'` names `i`,
+    // which is an INDEX, and this function does not guess columns from indexes.
+    return undefined;
+}
+
+function findUniqueViolationColumn(error: unknown, depth: number): string | undefined {
+    if (error === null || error === undefined || depth > MAX_CAUSE_DEPTH) return undefined;
+
+    if (typeof error === 'string') return columnFromText(error);
+    if (typeof error !== 'object') return undefined;
+
+    const err = error as { message?: unknown; detail?: unknown; cause?: unknown };
+
+    if (typeof err.message === 'string') {
+        const fromMessage = columnFromText(err.message);
+        if (fromMessage !== undefined) return fromMessage;
+    }
+    // node-postgres keeps the `DETAIL:` line off the message and on its own
+    // field, so for the driver we actually ship this is where the column is.
+    if (typeof err.detail === 'string') {
+        const fromDetail = columnFromText(err.detail);
+        if (fromDetail !== undefined) return fromDetail;
+    }
+
+    return findUniqueViolationColumn(err.cause, depth + 1);
+}
+
+/**
+ * Which column a unique-constraint violation was raised on — or `undefined`
+ * when the dialect did not determinably name one (#6544).
+ *
+ * ## The contract, and why it is this narrow
+ *
+ * **A value comes back only when the identifier the driver printed is
+ * determinably a COLUMN.** When a dialect names an *index* instead — MySQL's
+ * `Duplicate entry 'a@b.com' for key 'idx_email_unique'`, Postgres'
+ * `violates unique constraint "sys_user_email_key"`, SQLite's
+ * `UNIQUE constraint failed: index 'idx_lower_email'` — the answer is
+ * `undefined`, never the index name.
+ *
+ * That is the maintainer's 2026-08-08 ruling on #6544, and the reasoning is the
+ * caller's, not this module's: **an index name mistaken for a column is worse
+ * than no answer at all.**
+ *
+ *  - `@objectstack/rest`'s import runner renders this into a form field —
+ *    "A record with this `email` already exists." An index name there points
+ *    the user at a field that does not exist on the object, so they cannot act
+ *    on it; `undefined` degrades to generic copy, which is merely less helpful.
+ *  - #5495's autonumber-retry branch asks a yes/no question of the answer —
+ *    "is the conflicting column the autonumber field?" — and an index name
+ *    produces a *wrong retry decision*, not a vaguer one.
+ *
+ * ⛔ **The accepted cost: MySQL deployments usually get no column.** MySQL's
+ * duplicate-entry message names the index and never the column, so there is
+ * nothing here to read. That is deliberate. Do not "improve" this by deriving a
+ * column from an index name (`idx_email_unique` → `email`, or MySQL 8's
+ * `for key 'sys_user.email'` → `email`): index names are free-form, a
+ * deployment's may match no column at all, and a plausible-looking wrong field
+ * is exactly the failure this export exists to avoid. If MySQL must name
+ * columns, the answer is a schema lookup of the index — a different, wider
+ * contract — not a guess in this function.
+ *
+ * A **composite** key is `undefined` for the same reason: `Key (tenant_id,
+ * email)=(…)` has no single offending column, and naming the first is the same
+ * class of wrong answer.
+ *
+ * ## What it reads
+ *
+ * Gated on {@link isUniqueViolationError}, so a NOT NULL or FOREIGN KEY failure
+ * can never reach the extraction — SQLite's `NOT NULL constraint failed: t.c`
+ * shares its shape with the positive and is refused at the gate, not by the
+ * patterns. Then `message`, then `detail` (node-postgres keeps its `DETAIL:`
+ * line there), then one step down the `cause` chain, bounded exactly as the
+ * predicate's walk is. A bare string is read as a message, so a caller holding
+ * only `err.message` can pass it straight in.
+ *
+ * @param error - the thrown value, of any shape.
+ * @returns the conflicting column, or `undefined` when none is determinable.
+ *
+ * @example
+ * ```ts
+ * const column = uniqueViolationColumn(error);
+ * return column
+ *   ? `A record with this ${column} already exists.`
+ *   : 'A record with this value already exists.';
+ * ```
+ */
+export function uniqueViolationColumn(error: unknown): string | undefined {
+    if (!isUniqueViolationError(error)) return undefined;
+    return findUniqueViolationColumn(error, 0);
 }


### PR DESCRIPTION
Fixes #6544

按维护者 2026-08-08 的裁定（#6544 comment 5226102517）走**路线 (b)**：先在
`@objectstack/types` 落 `uniqueViolationColumn` 导出，再把
`packages/rest/src/import-runner.ts` 的 `sanitizeRowError` 迁移到它上面。

## 背景与前提复核

#6250（PR #6541，已合并 `88f9d94bb`）把四份私有的「这是不是唯一约束冲突？」词汇表
收敛成了 `isUniqueViolationError`，但只回答了 yes/no。`sanitizeRowError` 做的**更多**：
它要抽出**冲突的列名**，好让导入器说「A record with this `email` already exists.」，
所以它是最后一份没被迁走的私有词汇表。

前提对着 `origin/main` 逐条复核过，**成立**：

- 三条方言正则仍在 `packages/rest/src/import-runner.ts:224-227`，且确实是**三方言**
  （`git log -S "duplicate entry .* for key"` → `65ac46819` / #3572）。#6250 清单里
  「仅 Postgres」的描述已漂移，本卡按三方言的真实现状迁移。
- `isUniqueViolationError` 已可从 `@objectstack/types` 导入
  （`packages/types/src/index.ts:14`）。

## 契约裁定：索引名一律返回 `undefined`

`uniqueViolationColumn(error)` 返回 `string | undefined`，**只有在驱动打印出来的
标识符能确定是「列」时才给值**。方言报的是**索引名**时——MySQL 的
`Duplicate entry … for key 'idx_email_unique'`、Postgres 的
`violates unique constraint "sys_user_email_key"`、SQLite 的
`UNIQUE constraint failed: index 'x'`——返回 `undefined`，**绝不**返回索引名。

理由写进了 TSDoc（不是装饰，是给后来者的约束）：调用方要把它渲染到表单字段上，
**被当成列名的索引名比没有答案更糟**——前者把用户指向一个不存在的字段，后者只是
退回通用文案。#5495 的 autonumber 重试分支同理：它问「冲突列是否就是 autonumber
字段」，索引名在那里产生的是**错误的重试决策**，不是更模糊的决策。

**复合键**（`Key (tenant_id, email)=(…)`）同样返回 `undefined`：没有单一的冲突列，
取第一个和返回索引名是同一类错误——用户重复输入的是 `email`，却把表单指向
`tenant_id`。

导出的形状可以直接服务 #5495（本 PR **不**实现那个消费者）：它返回的是列名而非
索引名，所以 `uniqueViolationColumn(err) === autonumberField` 是一个可以直接下重试
决定的判断；拿不到列名时是 `undefined`，退回「不重试」这个安全默认，而不是拿索引名
去和字段名比对。

## ⚠️ 明确披露：MySQL 上的导入报错文案会变

MySQL 的 duplicate-entry 消息只报索引名、从不报列名，所以迁移后 MySQL 上的导入
**不再点名列**：

- 过去 `for key 'idx_email_unique'` → 「A record with this **idx_email_unique**
  already exists.」
- 过去 MySQL 8 的 `for key 'sys_user.email'` → 「A record with this **email**
  already exists.」——看着像列名，其实仍是索引名，只是恰好同名
- 现在两者都 → 「**A record with this value already exists.**」

这是裁定的本意（它之前点名的是错误种类的东西），但它**确实是 MySQL 上用户可见的
文案变化**。已单独用一组测试钉住（`#6544 — MySQL stops naming a column`），并写进
changeset。冲突仍然被识别为冲突，只是「命名」这一步收窄了。

## 每方言 before/after 实测表

`before` 是把 `origin/main` 的 `sanitizeRowError` **原样抽出**后跑出来的真实输出，
不是手写复现（`git show origin/main:… | sed -n '196,246p'`）。

| 方言 | 样本 | before（origin/main） | after |
|:--|:--|:--|:--|
| sqlite | knex 前缀 + `sys_user.phone_number` | `A record with this phone_number already exists.` | 不变 |
| sqlite | 裸消息 `sys_user.email` | `A record with this email already exists.` | 不变 |
| sqlite | 复合键 `t.tenant_id, t.email` | `A record with this `**`tenant_id`**` already exists.` | `A record with this value already exists.` |
| sqlite | 索引形式 `index 'idx_lower_email'` | `A record with this `**`index`**` already exists.` ← 荒谬 | `A record with this value already exists.` |
| sqlite | NOT NULL（负例） | `name is required.` | 不变 |
| sqlite | FOREIGN KEY（负例） | `FOREIGN KEY constraint failed` | 不变 |
| mysql | MySQL 8 `for key 'sys_user.email'` | `A record with this `**`email`**` already exists.` | `A record with this value already exists.` ⚠️ |
| mysql | `for key 'idx_email_unique'` | `A record with this `**`idx_email_unique`**` already exists.` | `A record with this value already exists.` ⚠️ |
| mysql | `ER_BAD_NULL_ERROR`（负例） | 原文透传 | 不变 |
| mysql | `ER_NO_REFERENCED_ROW_2`（负例，含 `KEY (col)` 近似词） | 原文透传 | 不变 |
| postgres | `DETAIL: Key (email)=(…)` | `A record with this email already exists.` | 不变 |
| postgres | `DETAIL: Key ("emailAddress")=(…)` | `A record with this emailAddress already exists.` | 不变 |
| postgres | 无 DETAIL，只有约束名 | `duplicate key value violates unique constraint "sys_user_email_key"` ← 把驱动原话连索引名一起吐给导入器 | `A record with this value already exists.` |
| postgres | `DETAIL: Key (tenant_id, email)=(…)` | `A record with this `**`tenant_id, email`**` already exists.` | `A record with this value already exists.` |
| postgres | 表达式索引 `Key (lower(email))=(…)` | `A record with this `**`lower(email`**` already exists.` ← 截断的碎片 | `A record with this value already exists.` |
| postgres | 23502 not-null（负例） | 原文透传 | 不变 |
| postgres | 23503 fk（负例） | `The database rejected this row (…)`（被 SQL 兜底接管） | 不变 |

通用文案刻意用了 `mapDataError` 放进 409 `UNIQUE_VIOLATION` body 的同一句话，让导入器
和 API 对同一个条件说同一件事。

## 一张表，两个面

`packages/rest/src/import-runner-error-sanitize.test.ts` 里的 `DIALECT_SAMPLES` 是
**唯一**语料，每个样本都同时跑：

- **face 1** — `uniqueViolationColumn`（`@objectstack/types`），列名答案；
- **face 2** — `sanitizeRowError`（本包），导入器真正显示的句子。

任一面回归都会红，只教其中一面认识新方言不可能变绿。表放在 `@objectstack/rest`
的理由和 #6541 一样：`@objectstack/types` 不能 import `@objectstack/rest`，只有这边
能同时看到两个面。`packages/types/src/unique-violation.test.ts` 是它的**补集**——钉
调用方交进来的**形状**（对象 / `cause` 深度 / node-postgres 的 `detail` 通道 / 谓词
门），刻意不复述方言词汇表。

负例按方言分别钉住：索引名样本必须得到 `undefined`；NOT NULL / FOREIGN KEY 不得被
误判为唯一冲突——SQLite 的那两条最锋利，`NOT NULL constraint failed:` 和正例共享词
且共享 `table.column` 形状，靠的是谓词门挡住，而不是靠正则恰好没匹配上。

## 范围

只动了 `packages/types/src/unique-violation.ts`（+ 其测试）、
`packages/rest/src/import-runner.ts`（+ 其测试）和一个 changeset。
**没有**碰 `rest-server.ts` / `rest-api-plugin.ts`（#6633 在改），
**没有**迁 `service-messaging` / `driver-sql` 的副本（按 lane 另行跟进，见 #6543
和新提的 #6699），**没有**实现 #5495 的消费者。

## Reverse verification — 三个方向，预测在运行前写定

预测写在 scratchpad 的 `predictions.md` 里，写的时候 `verify.log` 还是 0 字节；
before 一列是把 `origin/main` 的 `sanitizeRowError` **原样抽出**跑出来的，不是手写复现。

### 方向 A —— 只回退 `import-runner.ts`（types 导出保留）

| | 预测 | 实测 |
|:--|:--|:--|
| face 1（`uniqueViolationColumn`） | 0 红 | **0 红** |
| face 2（`sanitizeRowError`） | 11 红 | **11 红**（`Tests 11 failed \| 51 passed (62)`） |

11 条逐条预测过：sqlite 复合键 / sqlite 索引形式 / mysql 两条 / postgres 无
DETAIL / postgres 复合 / postgres 表达式索引（7 条样本）+「无列名时不回显驱动
标识符」1 条 + MySQL 披露组 3 条。

**诚实排除**：sqlite knex 前缀、sqlite 裸消息、postgres DETAIL 单列、postgres
DETAIL 引号列，以及全部 6 条负例——它们 before == after，**本来就不可能变红**，
所以它们在这个方向上什么也没证明。另外「不得泄漏 SQL 语句」这条也预测为绿并
实测为绿：旧输出同样不含 `insert into`。

### 方向 B —— 只把 `uniqueViolationColumn` 桩成恒返回 `undefined`（import-runner 保持迁移后）

| | 预测 | 实测 |
|:--|:--|:--|
| `@objectstack/types` 形状钉 | 8 红 | **8 红**（`8 failed \| 34 passed (42)`） |
| `@objectstack/rest` 两面 | 8 红（face1 4 + face2 4） | **8 红**（`8 failed \| 54 passed (62)`） |

**诚实排除**：全部 mysql 样本、全部索引名样本、全部复合键样本、整个 MySQL 披露组——
一个「永远说没有列」的桩在这些用例上和裁定后的实现**不可区分**，所以它们在这个
方向上是绿的，不是覆盖。

### 方向 C（附加，最贴裁定本身）—— 让它按裁定前的猜法回答索引名

变体在跑之前已单独验过行为：`sqlite index form -> "idx_lower_email"`、
`mysql idx -> "idx_email_unique"`、`mysql my8 -> "email"`、
`pg no detail -> "sys_user_email_key"`。

| | 预测 | 实测 |
|:--|:--|:--|
| `@objectstack/rest` | 15 红 | **13 红**（`13 failed \| 49 passed (62)`） |
| `@objectstack/types` | 未预测（0） | **3 红**（`3 failed \| 39 passed (42)`） |

⚠️ **这个方向我的预测最不准，如实记录**：rest 侧多算了 2 条，types 侧则完全漏
算了——我当时只按 rest 的表逐条推，忘了 types 自己的形状钉同样读这份变体
（`reads node-postgres' detail field` / `a detail that is not a string` /
`a conflict the predicate recognises may still name no column` 三条，最后一条的
失败文本在日志里可见）。没有为了对齐模板去重跑补齐这 2 条的差额：C 是附加方向，
而两个必需方向（A、B）是逐条精确命中的。方向本身的结论没有歧义——**索引名一旦被
当成列名回答，两个面同时变红**，这正是裁定要钉住的东西。

## 门禁实测

| 门 | 结果 |
|:--|:--|
| `@objectstack/types` 全包测试 | `Test Files 8 passed (8) / Tests 187 passed (187)` |
| `@objectstack/rest` 全包测试 | `Test Files 68 passed (68) / Tests 1093 passed (1093)` |
| 本卡方言表（两个面） | `Tests 62 passed (62)` |
| `pnpm --filter @objectstack/types typecheck` | 干净，无输出 |
| `pnpm lint`（全仓 `eslint . --no-inline-config`） | 干净，无输出 |
| `check:type-check-coverage` | OK — 62/77，DEBT 457，**TEST_DEBT 1615 未升**（580 files） |
| `check:nul-bytes` | OK（6238 个文件，无裸控制字节） |
| 其余 `.github/workflows/lint.yml` 的 `check:*` | 全绿：slot-lookup、query-options-erasure、verify-stand-in、doc-authoring、docs-audit-scope、role-word、quick-reference-counts、adr-anchors、org-identifier、authz-resolver、service-providers、route-envelope、error-code-casing、wildcard-fallthrough、meta-type-normalized、init-service-contract、durability-log-level、startup-registry-verdict、objectui-changeset、release-notes、release-body、node-version、workflow-status-functions、shard-attestation、published-files、engine-double-contract、kernel-hook-pairs、resume-authority-declared、merge-driver、spec-parsed-alias、driver-conformance、stall-guard |

**一处需要说明的红**：直接跑 `pnpm --filter @objectstack/rest exec tsc --noEmit`
会报 2 条 `TS2345`，都在 `src/package-routes.ts`（207、279 行）——**本 PR 没碰过
这个文件**。这是被冻结的既有状态：`scripts/check-type-check-coverage.mjs` 的 DEBT
账本里 `'@objectstack/rest': { errors: 2, note: 'code-tier 2 (TS2345).' }`，而 CI
真正跑的门 `check:type-check-coverage` 对着这个账本报 OK，数字没有升高。

## Changeset

`@objectstack/types` 取 **minor**（新增公开导出，是加法式 API 面），
`@objectstack/rest` 取 **patch**（无 API 变化；行报告的 `code` 字段不变，变的只是
自由文本 `error` 的措辞，而 API 契约钉的是 409 的 `UNIQUE_VIOLATION` 码，不是这句话）。
MySQL 那条用户可见的文案变化在 changeset 正文里明写了，不让它悄悄过去。

---
_Generated by [Claude Code](https://claude.ai/code/session_017uFVNMmTxLpmfQYiuKM1Yx)_