### PR TITLE
fix(cli): doctor 的账本读取失败行改报真实解析出的目录,install 提示注明其字面量为描述性 (#6643)

### DIFF
--- a/.changeset/doctor-ledger-failure-dir.md
+++ b/.changeset/doctor-ledger-failure-dir.md
@@ -1,0 +1,12 @@
+---
+"@objectstack/cli": patch
+---
+
+fix(cli): `os doctor`'s ledger-failure row names the directory it actually read (#6643)
+
+Removes divergence surface; not a live defect. `DEFAULT_INSTALLED_PACKAGES_DIR` — `@objectstack/cloud-connection`'s export, the single authority on what the installed-package ledger directory is called — exists in every version ever shipped and has never changed value, so the literal this change deletes currently agrees with it. What it buys is that the agreement stops being a coincidence nobody would notice breaking.
+
+The residue of #5996, which fixed the same restatement one row over (`installedPackageLedgerSkippedEntriesCheck`) and enumerated the rest rather than widening in place:
+
+- `installedPackageLedgerFailureCheck` takes the resolved `dir` — already carried on the reading since #5996 — and quotes it. Its `fix` used to open with a re-hardcoded ``.objectstack/installed-packages/`` "under the project root", which was the consumer restating a value only the producer decides, and a vaguer answer than the one doctor was holding: the reading's `dir` is `cwd`-joined and absolute. Under `--verbose` the row now reads ``The ledger is `/srv/app/.objectstack/installed-packages`;`` and drops the now-redundant project-root hedge. The parameter is required, so the row cannot quietly fall back to a guess.
+- `os package install`'s post-install hint keeps its literal, now with the reasons written down. That sentence describes the **remote** runtime host's directory: the CLI never touches that disk, the host's directory is configurable (`MarketplaceInstallLocalPlugin` builds `new LocalManifestSource(config.storageDir)`, so the export is only its default), and the install response carries no `storageDir` to quote. Resolving it locally would state this machine's default as an observed fact about another one — so the literal stays, marked as the description of a convention rather than a consumer read.

--- a/packages/cli/src/commands/doctor-ledger-read-failure.test.ts
+++ b/packages/cli/src/commands/doctor-ledger-read-failure.test.ts
@@ -210,11 +210,20 @@ async function assertLedgerReaderIsBuilt(): Promise<void> {
 }
 
 describe('installedPackageLedgerFailureCheck — the finding the shared catch used to eat', () => {
+  /**
+   * The resolved ledger directory the reading carries (#5996), which this row
+   * has taken as a required parameter since #6643. Deliberately rooted at
+   * `/srv/app` rather than left relative: the old hard-coded literal was
+   * `.objectstack/installed-packages/` with no root, so any assertion naming
+   * this path is one the literal cannot satisfy.
+   */
+  const DIR = '/srv/app/.objectstack/installed-packages';
+
   it('quotes what was thrown, in the row AND in the verbose detail', () => {
     const err = Object.assign(new Error("ENOTDIR: not a directory, scandir '/p/.objectstack'"), {
       code: 'ENOTDIR',
     });
-    const check = installedPackageLedgerFailureCheck(err);
+    const check = installedPackageLedgerFailureCheck(err, DIR);
 
     // Before #5412 this text existed nowhere in any doctor output under any
     // flag — the error object was discarded at the point it was caught.
@@ -223,7 +232,7 @@ describe('installedPackageLedgerFailureCheck — the finding the shared catch us
   });
 
   it('takes the `Installed packages` name column, so the row is present rather than missing', () => {
-    const check = installedPackageLedgerFailureCheck(new Error('boom'));
+    const check = installedPackageLedgerFailureCheck(new Error('boom'), DIR);
 
     // Load-bearing, not cosmetic. An operator scans the report by its name
     // column, and this row has to be somewhere findable rather than absent —
@@ -238,22 +247,25 @@ describe('installedPackageLedgerFailureCheck — the finding the shared catch us
   });
 
   it('stays a warning — the environment runs, doctor’s sight of it is what broke', () => {
-    expect(installedPackageLedgerFailureCheck(new Error('boom')).status).toBe('warning');
+    expect(installedPackageLedgerFailureCheck(new Error('boom'), DIR).status).toBe('warning');
   });
 
   it('says WHICH half did not run, rather than that "something" failed', () => {
-    const check = installedPackageLedgerFailureCheck(new Error('boom'));
+    const check = installedPackageLedgerFailureCheck(new Error('boom'), DIR);
     const fix = check.fix ?? '';
 
     // The harm the issue names is a reader treating a partial check as a whole
     // one. The row has to state its own incompleteness in both channels.
     expect(check.message).toContain('installed packages NOT checked');
     expect(fix).toContain('two halves and only one of them ran');
-    expect(fix).toContain('.objectstack/installed-packages/');
+    // Re-pointed by #6643. This used to assert the bare
+    // `.objectstack/installed-packages/` literal the fix restated; the row now
+    // names the directory doctor actually read, so the assertion follows it.
+    expect(fix).toContain(DIR);
   });
 
   it('folds a multi-line cause onto the row and keeps it whole in the detail', () => {
-    const check = installedPackageLedgerFailureCheck(new Error('line one\nline two: the reason'));
+    const check = installedPackageLedgerFailureCheck(new Error('line one\nline two: the reason'), DIR);
 
     expect(check.message).toContain('line two: the reason');
     // One row is one line.
@@ -262,15 +274,37 @@ describe('installedPackageLedgerFailureCheck — the finding the shared catch us
   });
 
   it('never trails off into nothing for an Error with no message', () => {
-    const check = installedPackageLedgerFailureCheck(new TypeError());
+    const check = installedPackageLedgerFailureCheck(new TypeError(), DIR);
 
     expect(check.message.endsWith('— ')).toBe(false);
     expect(check.message).toContain('TypeError');
   });
 
   it('reports a thrown non-Error rather than swallowing it', () => {
-    expect(installedPackageLedgerFailureCheck('boom').message).toContain('boom');
-    expect(installedPackageLedgerFailureCheck(42).message).toContain('42');
+    expect(installedPackageLedgerFailureCheck('boom', DIR).message).toContain('boom');
+    expect(installedPackageLedgerFailureCheck(42, DIR).message).toContain('42');
+  });
+
+  it('a NON-default directory flows through — the assertion a re-hardcoded literal cannot pass', () => {
+    // #6643, the sibling of #5996's identical case on
+    // `installedPackageLedgerSkippedEntriesCheck`. The parameter exists so this
+    // row tracks the producer's `DEFAULT_INSTALLED_PACKAGES_DIR` instead of
+    // restating the consumer's old guess. A directory sharing NO substring with
+    // that guess is what separates the two: if the literal ever creeps back,
+    // both assertions below go red at once.
+    const check = installedPackageLedgerFailureCheck(new Error('boom'), '/var/lib/os-ledger');
+
+    expect(check.fix).toContain('The ledger is `/var/lib/os-ledger`;');
+    expect(check.fix).not.toContain('.objectstack/installed-packages');
+  });
+
+  it('drops the "under the project root" hedge — the resolved dir already says where it is', () => {
+    // The old literal was relative, so the row had to add a sentence locating
+    // it. `dir` is `cwd`-joined and absolute, which makes that sentence both
+    // redundant and (for a non-default `storageDir`) wrong.
+    const check = installedPackageLedgerFailureCheck(new Error('boom'), DIR);
+
+    expect(check.fix).not.toContain('project root');
   });
 });
 
@@ -428,6 +462,31 @@ describe('os doctor, end to end, against an unreadable installed-package ledger'
     // Gauge: warning, the report finishes, exit stays 0.
     expect(run.out).toContain('Environment is functional but has some warnings');
     expect(run.exitCode).toBeUndefined();
+  }, 60_000);
+
+  it('the verbose fix names the directory doctor actually read, resolved from the authority (#6643)', async () => {
+    writeConfig();
+    fs.mkdirSync(path.dirname(ledgerPath()), { recursive: true });
+    fs.writeFileSync(ledgerPath(), 'not a directory\n');
+
+    // The expectation is COMPUTED FROM THE AUTHORITY, never hard-coded: the
+    // whole point of #6643 is that this row stops restating a value only
+    // `@objectstack/cloud-connection` decides. Writing `.objectstack/
+    // installed-packages` here would move the literal into the test and pin
+    // the row against the guess a second time — the defect, relocated.
+    // Re-imported rather than read off `LEDGER_REL` for the same reason.
+    const { DEFAULT_INSTALLED_PACKAGES_DIR } = await import('@objectstack/cloud-connection');
+    // `mkdtemp` makes this unique per run, which is what makes "the resolved
+    // dir, not the literal" assertable at all: no literal can contain it.
+    const resolved = path.join(tmp, DEFAULT_INSTALLED_PACKAGES_DIR);
+
+    const run = await runDoctor(['--verbose']);
+
+    expect(run.out).toContain(LEDGER_HEADLINE);
+    expect(run.out).toContain(`The ledger is \`${resolved}\`;`);
+    // And the relative literal it replaced is gone from the report entirely.
+    expect(run.out).not.toContain('The ledger is `.objectstack/installed-packages/` directory');
+    expect(run.out).not.toContain('under the\n      project root');
   }, 60_000);
 
   it('expands the detail under --verbose, and only under --verbose', async () => {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1408,17 +1408,25 @@ const LEDGER_ROW_NAME = 'Installed packages';
  *   • **The cause is quoted, not paraphrased** (#5390 / #5403). `ENOTDIR: not
  *     a directory, scandir '…'` names the file that is in the way; no sentence
  *     doctor could invent would beat it.
+ *   • **`dir` is the directory doctor actually read** (#6643) — resolved from
+ *     `DEFAULT_INSTALLED_PACKAGES_DIR` and carried on the reading, exactly as
+ *     its `skipped` sibling takes it since #5996. It used to open with a
+ *     re-hardcoded ``.objectstack/installed-packages/`` literal "under the
+ *     project root": the consumer restating a value only the producer decides,
+ *     and — since the resolved directory is `cwd`-joined — a vaguer answer than
+ *     the one doctor was holding. A row reporting an unreadable directory owes
+ *     the reader the directory it actually tried.
  */
-export function installedPackageLedgerFailureCheck(err: unknown): HealthCheckResult {
+export function installedPackageLedgerFailureCheck(err: unknown, dir: string): HealthCheckResult {
   const cause = describeThrown(err);
   return {
     name: LEDGER_ROW_NAME,
     status: 'warning',
     message: `Could not read the installed-package ledger (installed packages NOT checked) — ${reportRowHeadline(cause)}`,
     fix:
-      'The ledger is the `.objectstack/installed-packages/` directory under the\n'
-      + '      project root; it exists here, which is why this is reported rather than\n'
-      + '      treated as "nothing was ever installed". Every package it lists is one\n'
+      `The ledger is \`${dir}\`; it exists here, which is why\n`
+      + '      this is reported rather than treated as "nothing was ever\n'
+      + '      installed". Every package it lists is one\n'
       + '      this runtime ALSO cannot rehydrate at boot — not registered with the\n'
       + '      kernel, absent from the console’s installed-apps list — so an app missing\n'
       + '      from this environment is very likely in there.\n'
@@ -1675,7 +1683,14 @@ export function installedPackageLedgerChecks(
     return [installedPackageLedgerDirAuthorityMissingCheck(reading.dirAuthorityMissing.received)];
   }
   const out: HealthCheckResult[] = [];
-  if (reading.failure) out.push(installedPackageLedgerFailureCheck(reading.failure.cause));
+  // Same invariant as the `skipped` row below, one boundary out (#6643): a
+  // `failure` reading always carries the directory the failure was ABOUT.
+  // `failure` is set only in the `catch` of `readInstalledPackageEntries()`,
+  // and that `try` opens after `dir` is already resolved — the two are set on
+  // the same return. The `!` states that where the flat reading shape cannot,
+  // and the parameter stays required so this row can never quietly fall back
+  // to a guessed literal.
+  if (reading.failure) out.push(installedPackageLedgerFailureCheck(reading.failure.cause, reading.dir!));
   // Independent of the row above, not an `else`: `failure` means the directory
   // could not be enumerated at all, `skipped` means it enumerated fine and
   // named files inside it would not parse. Each names packages the other does

--- a/packages/cli/src/commands/package/install.ts
+++ b/packages/cli/src/commands/package/install.ts
@@ -215,6 +215,41 @@ export default class PackageInstall extends Command {
       printKV('  Runtime',   runtime);
       if (data.installedAt) printKV('  Installed', String(data.installedAt));
       console.log('');
+      // ⚠️ This path is a DESCRIPTION OF THE DEFAULT CONVENTION, deliberately
+      // left as a literal — not a consumer restating a value it could have read
+      // (#6643, the sibling half of #5996). Do not "fix" it into a reference to
+      // `DEFAULT_INSTALLED_PACKAGES_DIR`. Four measured reasons, in order:
+      //
+      //   1. **The directory is on the REMOTE host.** Everything above this
+      //      line came back over HTTP from `runtime`; this command never
+      //      touches the target's disk. A constant resolved HERE describes the
+      //      machine typing the command, not the one that stored the manifest.
+      //   2. **The remote's directory is configurable, so the constant is only
+      //      its default.** `MarketplaceInstallLocalPlugin` builds its ledger as
+      //      `new LocalManifestSource(config.storageDir)` — the export is the
+      //      fallback that ctor applies when the host configured nothing.
+      //      Interpolating it would state a default as an observed fact.
+      //   3. **The response we just read does not carry the real answer.** The
+      //      POST returns `{ manifestId, version, versionId, installedAt,
+      //      hotLoaded, upgradedFrom, translationsLoaded, seeded, note }` — no
+      //      `storageDir`. The GET listing endpoint does carry one; this one
+      //      does not, and asking for it would be an extra round-trip (and a
+      //      new failure mode) bolted onto a success hint.
+      //   4. **Importing it would cost this command its independence.** Every
+      //      CLI reference to `@objectstack/cloud-connection` is a DYNAMIC load
+      //      behind `loadOptionalPackage()` (doctor.ts) or a guarded `import()`
+      //      (serve.ts), because the CLI must keep working where that package
+      //      is absent or unbuilt. A static import for one hint line would make
+      //      a pure-HTTP command fail at module load; a dynamic one needs a
+      //      literal fallback — the exact `??` Prime Directive #12 forbids and
+      //      #5996 deleted.
+      //
+      // So the divergence surface is accepted here, knowingly: if the constant
+      // ever changes value, this sentence goes stale and no gate will say so.
+      // The honest fix is upstream — the POST response carrying `storageDir`
+      // like its GET sibling — which would let this line quote the real remote
+      // directory. Tracked separately; `@objectstack/cloud-connection` is out
+      // of scope for #6643.
       console.log('  The manifest is cached under .objectstack/installed-packages/ on the');
       console.log('  runtime host and re-registers on every boot (survives restarts).');
     } catch (error) {


### PR DESCRIPTION
Fixes #6643

#5996 / PR #6645 确立了一条边界:`DEFAULT_INSTALLED_PACKAGES_DIR` —— `@objectstack/cloud-connection` 的导出 —— 是安装包账本目录名的**唯一权威**,消费端既不得容忍它缺失(PD #12),也不得复述它的取值。那张卡按枚举出的三件套收口,并把扫描消费半径时发现的另外两处字面量记进了 #6643。本 PR 收这两处。

## ⚠️ 这不是缺陷修复

该导出在**每一个发布过的版本里都存在,取值也从未变过**,所以今天每一处字面量都与权威一致 —— 没有用户能触达的错误行为,没有可复现的故障。本 PR 消除的是**未来的分歧面**:让这份一致不再是「没人会注意到它何时破裂」的巧合。请按此定级,不要当成 bug fix 读。

## 两处站点,逐处核验

### 站点一 —— `doctor.ts` 的 `installedPackageLedgerFailureCheck`(已收敛)

其 `fix` 开头写死 ``.objectstack/installed-packages/`` 「under the project root」。核验结论:**doctor 此刻手里确实有真实解析值**,与 #6645 已改的 skipped 那处完全同形 —— `failure` 只在 `readInstalledPackageEntries()` 的 `catch` 里被置上,而那个 `try` 开在 `const dir = path.join(cwd, declaredDir)` **之后**,两者在同一个 return 上,故 `reading.dir` 必然在场。

改法同形:签名加必填 `dir: string`,`fix` 引用之。必填是刻意的 —— 可选参数就等于给这一行留了一条悄悄退回猜测的路。

顺带修掉一个精度损失:reading 的 `dir` 是 `cwd`-joined 的**绝对路径**,而被删掉的字面量是相对的,所以原文才需要补一句「under the project root」来定位它。绝对路径自己就说清了位置,那句 hedge 既冗余、在宿主配了非默认 `storageDir` 时又是错的,一并删去。`--verbose` 下现在读作:

```
→ The ledger is `/srv/app/.objectstack/installed-packages`; it exists here, which is why
  this is reported rather than treated as "nothing was ever installed". …
```

### 站点二 —— `package/install.ts` 的安装后提示(**无法收敛,保留字面量并注明**)

按任务要求逐处核验「是否真的握有已解析目录」。**没有。** 四条量到的事实:

1. **该目录在远端主机上。** 这条提示之上的一切都是 HTTP 从 `runtime` 取回的;这条命令从不碰目标机的磁盘。在**本地**解析出的常量描述的是敲命令的那台机器,不是存了 manifest 的那台。
2. **远端目录是可配的,常量只是它的默认值。** `MarketplaceInstallLocalPlugin` 建账本用的是 `new LocalManifestSource(config.storageDir)`(plugin L157)—— 该导出是宿主什么都没配时 ctor 才落到的兜底。内插它等于把一个默认值陈述成观测到的事实。
3. **刚读完的那个响应里没有答案。** POST 返回 `{ manifestId, version, versionId, installedAt, hotLoaded, upgradedFrom, translationsLoaded, seeded, note }` —— 没有 `storageDir`。GET 列表端点**有**(L765),这个没有。
4. **静态引入会让这条命令失去独立性。** CLI 对 `@objectstack/cloud-connection` 的每一处引用都是动态的 —— doctor 走 `loadOptionalPackage()`,serve 走带守卫的 `import()` —— 因为该包缺失或未构建时 CLI 仍须可用。为一行提示加静态 import,会让一条纯 HTTP 命令在模块加载期就失败;改成动态则需要一个字面量兜底,即 PD #12 禁止、#5996 刚删掉的那个 `??`。

故此处**打印文本一字未改**,改为在旁边写下这四条理由,并明确写出「不要把它『修』成对常量的引用」。这是 issue triage 里维护者点名认可的解法(「an explicit "descriptive" annotation is a legitimate resolution for that half」)。真正的修法在上游 —— 让 POST 响应像 GET 那样带上 `storageDir` —— 已单独立为 #6721(观察类,不带 `pm:queue`)。

考虑过但未采纳:把这句改成「(default: …)」以承认可配性。那会改动用户可见输出,而本卡的题目是字面量复述,不是文案精度;留给 #6721 连同字面量一起删更干净。

## 前提核验(对 `origin/main`)

三项都在,#6645 的合并没有顺带覆盖其中任何一处,卡无需收窄:

| 事实 | 位置 | 结论 |
|:---|:---|:---|
| 站点一字面量 | `doctor.ts:1419` | 仍在 |
| 站点二字面量 | `install.ts:218` | 仍在 |
| 权威导出 | `local-manifest-source.ts:163`,经 `index.ts:41` 再导出 | 仍在 |

## 反向验证 —— 预测先写,再测

预测写于实现之前(方向:还原字面量 ⇒ 新钉子转红),测得与预测**逐条吻合,4 预测 / 4 实测**。做法是只把 `doctor.ts` 还原到 `origin/main`、保留测试:

| 用例 | 预测 | 实测 |
|:---|:---|:---|
| `says WHICH half did not run`(断言重新指向 `dir`) | RED | RED |
| `a NON-default directory flows through` | RED | RED |
| `drops the "under the project root" hedge` | RED | RED |
| e2e:`the verbose fix names the directory doctor actually read` | RED | RED |

```
× says WHICH half did not run, rather than that "something" failed 15ms
× a NON-default directory flows through — the assertion a re-hardcoded literal cannot pass 3ms
× drops the "under the project root" hedge — the resolved dir already says where it is 2ms
× the verbose fix names the directory doctor actually read, resolved from the authority (#6643) 502ms

Tests  4 failed | 23 passed (27)
```

**无双向绿的钉子**,这四条都是真红。两点说明:

- e2e 的期望值是**从权威算出来的**,不是硬编码:测试里 `await import('@objectstack/cloud-connection')` 取 `DEFAULT_INSTALLED_PACKAGES_DIR` 再与 `mkdtemp` 出的临时 cwd 拼接。若在测试里写死 `.objectstack/installed-packages`,只是把字面量搬进测试、对着同一个猜测再钉一遍 —— 正是本卡要消除的缺陷换个地方复发。`mkdtemp` 的唯一性也正是「解析值而非字面量」可断言的前提:任何字面量都不可能包含它。
- **站点二没有加测试,这是有意的。** 打印文本一字未改,改动纯为注释,任何断言都不可能观测到它。为它加一条断言只能是把那个字符串字面量在第二个地方再写一遍 —— 同样是复发。如实报告为不可观测,而非补一条假覆盖。

## 单侧站点的既有 fixture

`doctor-ledger-read-failure.test.ts` 里那条 `expect(fix).toContain('.objectstack/installed-packages/')` 钉的正是本 PR 删掉的那条肢体。按 fixture 三分法属**重新拼写**:它原本只是用了那个字面量,现在改为断言传入的 `dir`。同 describe 内其余调用点补上必填参数。

## 验证

- `pnpm lint` —— 通过(无输出)
- `pnpm --filter @objectstack/cli typecheck`(`tsc --noEmit`)—— 通过
- `packages/cli` 全量 vitest —— **95 个测试文件 / 998 tests 全通过**
- `.github/workflows/lint.yml` 的全部 31 个 `check:*` —— **31/31 通过**(含 `check:nul-bytes`)

## Changeset

`@objectstack/cli`: **patch**。站点一是用户可见的:`os doctor --verbose` 里运维读到的那段文字变了(绝对解析路径取代相对字面量,去掉 project-root hedge)。不是新能力,故非 minor;导出的 `installedPackageLedgerFailureCheck` 虽新增必填形参,但 CLI 以 bin 分发、无 `exports` 公开面,该导出只是测试接缝 —— 与 #6645 对同族 `installedPackageLedgerSkippedEntriesCheck` 做同样签名变更时的判级一致。站点二纯注释,不构成用户可见变更,不单独计入。

---
_Generated by [Claude Code](https://claude.ai/code/session_017uFVNMmTxLpmfQYiuKM1Yx)_