### PR TITLE
fix(cli): `os login --json` 声明为 NDJSON 事件流，每行一份可解析文档 (#6531)

### DIFF
--- a/.changeset/eighty-donuts-tickle.md
+++ b/.changeset/eighty-donuts-tickle.md
@@ -1,0 +1,34 @@
+---
+'@objectstack/cli': patch
+---
+
+fix(cli): `os login --json` is a parseable NDJSON stream (#6531)
+
+`os login --json` produced output that no consumer could read in any shape. The
+device flow wrote its RFC 8628 device-authorization payload compact and, once
+the token poll resolved, the result payload 2-space indented — two JSON
+documents on one stdout. Driven against a live device endpoint, that stream
+failed `JSON.parse(<entire stdout>)` with `Unexpected non-whitespace character
+after JSON at position 200`, and read as NDJSON it failed on 5 of its 6 lines,
+because the second document spanned five of them. The same two-document shape
+appeared on the failure path, where an error payload could follow a
+device-authorization record that had already been written.
+
+`os login --json` is now a **newline-delimited JSON stream**: one compact
+document per line, on every path — the device-authorization record, the
+`--email`/`--password` result, the already-logged-in notice, and the
+`{"success":false,"error":"…"}` failure record alike. Every line parses on its
+own, and the verification-URL record still arrives *before* the user
+authorizes, which is what makes the device flow usable from a script at all.
+
+This is the CLI's **one declared exception** to "`--json` means exactly one JSON
+document on stdout" (#6217), and it is declared rather than silent: the
+`--json` flag's `--help` text says so, and so do the CLI reference page and the
+device-flow section of the authentication docs. Parse this command's stdout
+line by line.
+
+Bumped as a patch: no interface is added or removed and nothing that previously
+worked stops working. The device-flow output was unparseable before, so it had
+no consumers to break; the only other observable change is that the
+email/password result is compact rather than indented, which `JSON.parse` reads
+identically. Human-mode output is untouched.

--- a/content/docs/deployment/cli.mdx
+++ b/content/docs/deployment/cli.mdx
@@ -1078,6 +1078,40 @@ For CI and other non-interactive contexts, pass email/password directly:
 os login --email user@example.com --password secret
 ```
 
+##### `os login --json` is NDJSON — the one exception
+
+Every other ObjectStack command writes **exactly one JSON document** to stdout
+under `--json`, so `JSON.parse(<entire stdout>)` is the way to read it.
+`os login` is the single declared exception: its `--json` output is **NDJSON**,
+one compact JSON document per line. **Parse it line by line.**
+
+The reason is the device flow: it is two events at two points in time, and the
+verification URL is only useful to a script *before* the user authorizes. So the
+CLI emits it as its own record immediately, then a second record when the poll
+resolves:
+
+```console
+$ os login --json --no-browser
+{"device_code":"…","user_code":"WXYZ-1234","verification_uri":"https://…/activate","verification_uri_complete":"https://…/activate?user_code=WXYZ-1234","expires_in":600}
+{"success":true,"email":"user@example.com","userId":"usr_01H…"}
+```
+
+Read the first record, show the user the URL, then block on the next line:
+
+```bash
+os login --json --no-browser | while IFS= read -r line; do
+  echo "$line" | jq -r 'if .verification_uri_complete then "Approve at: \(.verification_uri_complete)" else "Signed in as \(.email)" end'
+done
+```
+
+Every record is one line, on every path — the `--email`/`--password` result and
+the failure payload (`{"success":false,"error":"…"}`) included, since a failure
+can arrive *after* the verification-URL record has already been written. Records
+that report failure also set exit code `1`.
+
+Before this was declared, `os login --json` wrote a compact record followed by a
+pretty-printed one, which parsed as neither a single document nor as NDJSON.
+
 #### `os logout`
 
 Logout calls `POST /api/v1/auth/sign-out` before deleting local credentials, so

--- a/content/docs/permissions/authentication.mdx
+++ b/content/docs/permissions/authentication.mdx
@@ -68,6 +68,12 @@ expire after the server-configured TTL (the CLI assumes a 10-minute / 600s
 default). The device flow requires `plugins: { deviceAuthorization: true }` in
 your `AuthPlugin` configuration.
 
+Under `--json` this command is the CLI's **one declared NDJSON exception**: it
+emits the verification-URL record before you authorize and the result record
+afterwards, one compact JSON document per line, so stdout must be parsed line by
+line rather than with a single `JSON.parse`. See
+[the CLI reference](/docs/deployment/cli#os-login--json-is-ndjson--the-one-exception).
+
 The email/password path is still supported for CI and non-interactive shells:
 
 ```bash

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -1,11 +1,81 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
+/**
+ * `os login --json` is NDJSON — the CLI's ONE declared exception (#6531).
+ *
+ * ## What was broken
+ *
+ * Everywhere else in this CLI `--json` means "stdout is exactly one JSON
+ * document" (#6217). The device-flow path could not honour that and did not
+ * try: it wrote the RFC 8628 device-authorization payload compact, and then,
+ * after the token poll succeeded, the result payload 2-space indented. Measured
+ * against a live device endpoint, stdout came out as
+ *
+ * ```
+ * {"device_code":"…","user_code":"…","verification_uri":"…","expires_in":600}
+ * {
+ *   "success": true,
+ *   …
+ * }
+ * ```
+ *
+ * — which `JSON.parse` rejects (`Unexpected non-whitespace character after JSON
+ * at position 200`) *and* which is not NDJSON either, because the second
+ * document spans five lines: 5 of its 6 lines fail an independent parse. A
+ * consumer had no shape to read it in at all. The same two-document stream
+ * appeared on the failure path too — device record, then an indented error
+ * payload when the poll timed out or was denied.
+ *
+ * ## Why a stream rather than one document
+ *
+ * Maintainer ruling, 2026-08-08 (#6531): this flow genuinely IS two events at
+ * two points in time, and emitting the verification URL **before** the user
+ * authorizes is the entire value of device flow in automation. Buffering both
+ * halves into one trailing document would make stdout parseable by destroying
+ * the thing the output exists for; putting the early record on stderr would
+ * abuse the diagnostic stream for non-diagnostic content. So `os login --json`
+ * is declared a newline-delimited stream, and — the ruling's binding condition
+ * — declared *explicitly*: in this command's `--help` text and in the command
+ * documentation (`content/docs/deployment/cli.mdx`, and the device-flow section
+ * of `content/docs/permissions/authentication.mdx`). An undocumented exception
+ * does the same harm to a consumer as the bug it replaces.
+ *
+ * ## Why EVERY write, not just the device flow's two
+ *
+ * The contract belongs to the command, not to one of its paths. If the
+ * `--email`/`--password` result or the error payload stayed indented, a
+ * consumer that read this command line-by-line — exactly what the docs now
+ * tell it to do — would break on the first run that took another path, and the
+ * failure path is reachable *after* the device record has already been written.
+ * So every `--json` write goes through {@link emitRecord}, which is the only
+ * emitter in this file; that makes "one compact document per line" a property
+ * of the command instead of four call sites that each have to remember an
+ * option. `packages/cli/test/login-json-ndjson.e2e.test.ts` holds both halves:
+ * the stream contract, driven through a real child process against a real
+ * device endpoint, and the source pin that keeps a future write from bypassing
+ * the helper.
+ */
+
 import { Command, Flags } from '@oclif/core';
+import type { CliExitCode } from '../utils/format.js';
 import { printHeader, printSuccess, printError, printKV, emitJson } from '../utils/format.js';
 import { writeAuthConfig, readAuthConfig } from '../utils/auth-config.js';
 import { ObjectStackClient } from '@objectstack/client';
 import * as readline from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
+
+/**
+ * Emit ONE NDJSON record on stdout — the only `--json` writer in this command.
+ *
+ * Compact is not a formatting preference here, it is the contract: a record
+ * that wrapped onto a second line would silently break every consumer reading
+ * this command's stdout a line at a time. Routing all four call sites through
+ * one helper is what makes that structural — see the file header for why the
+ * whole command, and not only the device flow's two writes, has to hold it.
+ */
+async function emitRecord(payload: unknown, exitCode: CliExitCode = 0): Promise<void> {
+  await emitJson(payload, exitCode, { compact: true });
+}
 
 /**
  * Prompt for a password with masked input (shows * per character).
@@ -108,7 +178,8 @@ export default class AuthLogin extends Command {
       default: false,
     }),
     json: Flags.boolean({
-      description: 'Output as JSON',
+      description:
+        'Machine-readable output as NDJSON — one compact JSON document per line. Unlike every other ObjectStack command, whose --json stdout is a single document, this one is a stream: the device flow reports the verification URL as its own record BEFORE you authorize, then the result as a second record. Parse stdout line by line.',
     }),
   };
 
@@ -122,7 +193,7 @@ export default class AuthLogin extends Command {
           const existing = await readAuthConfig();
           if (existing?.token) {
             if (flags.json) {
-              await emitJson({ success: false, error: 'Already logged in', email: existing.email }, 0, { compact: true });
+              await emitRecord({ success: false, error: 'Already logged in', email: existing.email });
             } else {
               printSuccess(`Already logged in as ${existing.email || existing.userId}`);
               console.log('');
@@ -171,7 +242,11 @@ export default class AuthLogin extends Command {
       await this.loginWithPassword(client, flags.url, email, password, flags.json);
     } catch (error: any) {
       if (flags.json) {
-        await emitJson({ success: false, error: error.message });
+        // Reachable AFTER the device-authorization record has already been
+        // written (an expired code, a denied approval, a poll failure), so an
+        // indented payload here recreated the exact two-document stream #6531
+        // is about — on the path a consumer is least able to recover from.
+        await emitRecord({ success: false, error: error.message });
         this.exit(1);
       }
       printError(error.message || String(error));
@@ -206,7 +281,7 @@ export default class AuthLogin extends Command {
     });
 
     if (jsonOutput) {
-      await emitJson({ success: true, email: user?.email || email, userId: user?.id });
+      await emitRecord({ success: true, email: user?.email || email, userId: user?.id });
     } else {
       printSuccess('Authentication successful');
       printKV('Email', user?.email || email);
@@ -252,7 +327,10 @@ export default class AuthLogin extends Command {
     const verificationUrl = verification_uri_complete || `${verification_uri}?user_code=${encodeURIComponent(user_code)}`;
 
     if (jsonOutput) {
-      await emitJson({ device_code, user_code, verification_uri, verification_uri_complete, expires_in }, 0, { compact: true });
+      // Record 1 of 2, and deliberately written BEFORE the poll loop: an
+      // automation consumer needs the verification URL while it can still act
+      // on it, which is the reason this command is a stream at all.
+      await emitRecord({ device_code, user_code, verification_uri, verification_uri_complete, expires_in });
     } else {
       console.log('  To authorize this CLI, visit:');
       console.log('');
@@ -318,7 +396,8 @@ export default class AuthLogin extends Command {
         });
 
         if (jsonOutput) {
-          await emitJson({ success: true, email: user?.email, userId: user?.id });
+          // Record 2 of 2 — same line-per-document shape as record 1.
+          await emitRecord({ success: true, email: user?.email, userId: user?.id });
         } else {
           printSuccess('Authentication successful');
           if (user?.email) printKV('Email', user.email);

--- a/packages/cli/src/utils/format.ts
+++ b/packages/cli/src/utils/format.ts
@@ -47,11 +47,22 @@ export interface EmitJsonOptions {
    * Exists so the sweep onto `emitJson` could be a pure truncation fix with no
    * observable output change: roughly half the CLI's `--json` sites were
    * already compact and half indented, and this preserves whichever each one
-   * emitted. The split is accidental rather than designed — `os login --json`
-   * prints a compact payload and then an indented one in the same run — so
-   * unifying it is worth doing, but as its own decision, not as a side effect
-   * of fixing truncated pipes.
+   * emitted.
    *
+   * This comment used to cite `os login --json` — a compact payload followed by
+   * an indented one in the same run — as proof the split was accidental. That
+   * was true, and worse than a formatting inconsistency: two documents on one
+   * stdout parse as neither a single document nor as NDJSON. #6531 fixed it,
+   * and in doing so gave `compact` its one *designed* use. `os login` is the
+   * CLI's sole declared NDJSON command, because its device flow is genuinely
+   * two events over time and the first one has to reach an automation consumer
+   * before the user authorizes; there, one line per document IS the contract,
+   * enforced through a single emitter in `commands/login.ts` and pinned by
+   * `test/login-json-ndjson.e2e.test.ts`.
+   *
+   * Everywhere else `--json` still means exactly one JSON document on stdout
+   * (#6217), so the remaining compact call sites are still only preserving
+   * historical formatting and unifying them stays worth doing on its own.
    * New code should use the default.
    */
   compact?: boolean;

--- a/packages/cli/test/login-json-ndjson.e2e.test.ts
+++ b/packages/cli/test/login-json-ndjson.e2e.test.ts
@@ -305,7 +305,7 @@ describe('os login --json — the declared NDJSON stream (#6531)', () => {
       expect(ok.stdout).not.toContain('ObjectStack Login');
       // The spinner's carriage returns and the `\x1b[K` erase would corrupt a
       // line-oriented reader even though they carry no visible text.
-      expect(ok.stdout).not.toMatch(/[\r]/);
+      expect(ok.stdout).not.toMatch(/[\r\u001b]/);
     });
   });
 

--- a/packages/cli/test/login-json-ndjson.e2e.test.ts
+++ b/packages/cli/test/login-json-ndjson.e2e.test.ts
@@ -1,0 +1,381 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `os login --json` is NDJSON — every line parses, and the URL comes FIRST
+ * (#6531).
+ *
+ * ## The defect this pins shut
+ *
+ * The device-flow path wrote its RFC 8628 device-authorization payload compact
+ * and, after the token poll resolved, the result payload 2-space indented.
+ * Measured against a live device endpoint on `origin/main`, stdout was:
+ *
+ * ```
+ * {"device_code":"DEV-CODE-6531","user_code":"WXYZ-6531",…,"expires_in":600}
+ * {
+ *   "success": true,
+ *   "email": "device@example.com",
+ *   "userId": "usr_6531"
+ * }
+ * ```
+ *
+ * `JSON.parse(stdout)` → `Unexpected non-whitespace character after JSON at
+ * position 200`; read as NDJSON, 5 of the 6 lines fail their own parse. There
+ * was no shape in which a consumer could read it. The maintainer ruled
+ * (2026-08-08) that this command is a **stream**, so what has to hold is:
+ * every line parses on its own, and the records arrive in the right order.
+ *
+ * ## Why the ordering assertion is TEMPORAL, not an array index
+ *
+ * The ruling picked NDJSON over "buffer both halves and emit one document at
+ * the end" for exactly one reason: an automation consumer needs the
+ * verification URL *while it can still act on it* — before the user authorizes.
+ * Asserting `records[0]` is the device record would not catch a regression to
+ * the buffered shape at all, because a trailing merged emit also puts the URL
+ * fields first.
+ *
+ * So the fake endpoint here withholds the token until THIS TEST has seen the
+ * device record land on the child's stdout. The release is driven by the
+ * observation, which makes "URL before authorization" a fact about the run
+ * rather than a property of the array afterwards. A buffered implementation
+ * never gets released by the watcher, falls through to the escape-hatch timer
+ * ({@link RELEASE_DEADLINE_MS}, so the suite fails instead of hanging), and
+ * lands with `urlSeenAt === null` — red, naming the actual cause.
+ *
+ * ## Why a PTY, and why not a silent skip
+ *
+ * `login.ts` takes the device flow only when `process.stdin.isTTY` — a child
+ * with a piped stdin falls through to the email/password prompt and never
+ * reaches either emission point. A plain `execFile` therefore cannot reach the
+ * defect. `script(1)` allocates the pty; the command it runs redirects stdout
+ * and stderr to files, so fd 0 is a TTY while fd 1 and fd 2 stay separate,
+ * capturable, and non-TTY — which is also the shape a real user gets when they
+ * pipe an interactive `os login --json` into a consumer.
+ *
+ * If `script(1)` is missing this file FAILS rather than skips. A contract test
+ * that quietly opts out on the machine that runs it is the same green-for-the-
+ * wrong-reason hazard the fixtures in #5046 were replaced for; every CI runner
+ * in this repo is `ubuntu-latest`, where `script(1)` is part of the base image.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFile, execFileSync } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const CLI = resolve(HERE, '../bin/run-dev.js');
+const TSX = resolve(HERE, '../../../node_modules/.bin/tsx');
+const LOGIN_SRC = resolve(HERE, '../src/commands/login.ts');
+const REPO_ROOT = resolve(HERE, '../../..');
+const CLI_DOCS = resolve(REPO_ROOT, 'content/docs/deployment/cli.mdx');
+const AUTH_DOCS = resolve(REPO_ROOT, 'content/docs/permissions/authentication.mdx');
+
+/**
+ * How long the endpoint waits for the device record to appear before releasing
+ * anyway. Only reached when the record never arrives early — i.e. when the
+ * contract is broken — and exists so that failure is an assertion rather than a
+ * suite that hangs until the runner kills it.
+ */
+const RELEASE_DEADLINE_MS = 20_000;
+
+/** Poll interval for watching the child's stdout file. */
+const WATCH_MS = 25;
+
+interface DeviceRun {
+  code: number;
+  stdout: string;
+  stderr: string;
+  /** When the device-authorization record was first readable on stdout. */
+  urlSeenAt: number | null;
+  /** When the endpoint first answered the poll with something other than pending. */
+  authorizedAt: number | null;
+  /** Whether the endpoint had to fall back to the deadline instead of the watcher. */
+  releasedByDeadline: boolean;
+}
+
+/**
+ * A minimal RFC 8628 endpoint whose token poll stays `authorization_pending`
+ * until {@link release} is called — see the header for why the test, not the
+ * clock, decides when authorization happens.
+ */
+function startDeviceEndpoint(outcome: 'token' | 'access_denied') {
+  let released = false;
+  let authorizedAt: number | null = null;
+
+  const server: Server = createServer((req, res) => {
+    req.resume();
+    req.on('end', () => {
+      const send = (code: number, obj: unknown) => {
+        res.writeHead(code, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(obj));
+      };
+      const { pathname } = new URL(req.url ?? '/', 'http://placeholder');
+
+      if (pathname === '/api/v1/auth/device/code') {
+        return send(200, {
+          device_code: 'DEV-CODE-6531',
+          user_code: 'WXYZ-6531',
+          verification_uri: 'http://127.0.0.1:9/activate',
+          verification_uri_complete: 'http://127.0.0.1:9/activate?user_code=WXYZ-6531',
+          expires_in: 600,
+          // 1s: the CLI floors anything falsy back to 5s (`interval || 5`).
+          interval: 1,
+        });
+      }
+
+      if (pathname === '/api/v1/auth/device/token') {
+        if (!released) return send(400, { error: 'authorization_pending' });
+        authorizedAt ??= Date.now();
+        return outcome === 'token'
+          ? send(200, { access_token: 'ACCESS-TOKEN-6531', token_type: 'Bearer' })
+          : send(400, { error: 'access_denied' });
+      }
+
+      if (pathname === '/api/v1/auth/get-session') {
+        return send(200, { user: { id: 'usr_6531', email: 'device@example.com' } });
+      }
+
+      return send(404, { error: 'not_found' });
+    });
+  });
+
+  return {
+    server,
+    release: () => { released = true; },
+    authorizedAt: () => authorizedAt,
+    listen: () =>
+      new Promise<number>((res) => {
+        server.listen(0, '127.0.0.1', () => res((server.address() as AddressInfo).port));
+      }),
+    close: () => new Promise<void>((res) => server.close(() => res())),
+  };
+}
+
+/** Every non-empty line of a captured stdout. */
+function lines(stdout: string): string[] {
+  return stdout.split('\n').filter((l) => l.length > 0);
+}
+
+/** The device-authorization record, if one is already readable on stdout. */
+function findDeviceRecord(text: string): Record<string, unknown> | null {
+  for (const line of lines(text)) {
+    try {
+      const rec = JSON.parse(line) as Record<string, unknown>;
+      if (rec && typeof rec === 'object' && 'verification_uri' in rec) return rec;
+    } catch {
+      // A partially-flushed line is not a failure here — the contract
+      // assertions below judge the finished stream.
+    }
+  }
+  return null;
+}
+
+/**
+ * Drive one full device-flow login through a real child process on a PTY.
+ */
+async function runDeviceLogin(outcome: 'token' | 'access_denied'): Promise<DeviceRun> {
+  const dir = mkdtempSync(join(tmpdir(), 'os-login-ndjson-'));
+  const outFile = join(dir, 'stdout.txt');
+  const errFile = join(dir, 'stderr.txt');
+  // HOME is the credentials root (`auth-config.ts` builds every path from
+  // `os.homedir()`), so pointing it at the temp dir keeps the run from reading
+  // — or overwriting — the developer's real ~/.objectstack/credentials.json.
+  const home = join(dir, 'home');
+
+  const endpoint = startDeviceEndpoint(outcome);
+  const port = await endpoint.listen();
+
+  let urlSeenAt: number | null = null;
+  let releasedByDeadline = false;
+
+  const watcher = setInterval(() => {
+    if (urlSeenAt !== null) return;
+    if (!existsSync(outFile)) return;
+    if (findDeviceRecord(readFileSync(outFile, 'utf-8'))) {
+      urlSeenAt = Date.now();
+      endpoint.release();
+    }
+  }, WATCH_MS);
+
+  const deadline = setTimeout(() => {
+    if (urlSeenAt === null) {
+      releasedByDeadline = true;
+      endpoint.release();
+    }
+  }, RELEASE_DEADLINE_MS);
+
+  const shell = [
+    `'${TSX}' '${CLI}' login --json --no-browser`,
+    `--url 'http://127.0.0.1:${port}'`,
+    `> '${outFile}' 2> '${errFile}'`,
+  ].join(' ');
+
+  const code = await new Promise<number>((res) => {
+    execFile(
+      'script',
+      // -q quiet, -e propagate the child's exit status, -c the command.
+      ['-qec', shell, '/dev/null'],
+      { env: { ...process.env, HOME: home, NO_COLOR: '1' }, maxBuffer: 32 * 1024 * 1024 },
+      (err) => res(err ? Number((err as { code?: unknown }).code ?? 1) : 0),
+    );
+  });
+
+  clearInterval(watcher);
+  clearTimeout(deadline);
+  await endpoint.close();
+
+  const read = (f: string) => (existsSync(f) ? readFileSync(f, 'utf-8') : '');
+  const run: DeviceRun = {
+    code,
+    stdout: read(outFile),
+    stderr: read(errFile),
+    urlSeenAt,
+    authorizedAt: endpoint.authorizedAt(),
+    releasedByDeadline,
+  };
+  rmSync(dir, { recursive: true, force: true });
+  return run;
+}
+
+describe('os login --json — the declared NDJSON stream (#6531)', () => {
+  let ok: DeviceRun;
+  let denied: DeviceRun;
+
+  beforeAll(async () => {
+    try {
+      execFileSync('script', ['--version'], { stdio: 'ignore' });
+    } catch {
+      throw new Error(
+        'script(1) is required to drive the TTY-gated device flow — see this file’s header for why this fails instead of skipping.',
+      );
+    }
+    // Sequential: each run owns a port, a HOME and a poll clock, and running
+    // them together would interleave two children's timing for no benefit.
+    ok = await runDeviceLogin('token');
+    denied = await runDeviceLogin('access_denied');
+  }, 180_000);
+
+  describe('the successful flow', () => {
+    it('emits stdout every line of which parses on its own — the NDJSON contract', () => {
+      const all = lines(ok.stdout);
+      expect(all.length).toBeGreaterThan(0);
+      for (const [i, line] of all.entries()) {
+        // Named per line so a regression says WHICH record broke, rather than
+        // only that some parse failed. Under the defect, lines 2-6 were the
+        // fragments of one pretty-printed document.
+        expect(() => JSON.parse(line), `stdout line ${i + 1}: ${JSON.stringify(line)}`).not.toThrow();
+      }
+    });
+
+    it('is exactly two records — device authorization, then the result', () => {
+      const records = lines(ok.stdout).map((l) => JSON.parse(l) as Record<string, unknown>);
+      expect(records).toHaveLength(2);
+      expect(records[0]).toMatchObject({
+        device_code: 'DEV-CODE-6531',
+        user_code: 'WXYZ-6531',
+        verification_uri: 'http://127.0.0.1:9/activate',
+        verification_uri_complete: 'http://127.0.0.1:9/activate?user_code=WXYZ-6531',
+        expires_in: 600,
+      });
+      expect(records[1]).toEqual({ success: true, email: 'device@example.com', userId: 'usr_6531' });
+      expect(ok.code).toBe(0);
+    });
+
+    it('hands over the verification URL BEFORE authorization — the reason this route was chosen', () => {
+      // The endpoint only authorized because the watcher had already read the
+      // record off stdout, so these two facts are the run's own history.
+      expect(ok.releasedByDeadline, 'the device record never reached stdout early').toBe(false);
+      expect(ok.urlSeenAt).not.toBeNull();
+      expect(ok.authorizedAt).not.toBeNull();
+      expect(ok.urlSeenAt!).toBeLessThanOrEqual(ok.authorizedAt!);
+    });
+
+    it('lets nothing but the payload onto stdout — no banner, no spinner, no prompt', () => {
+      // Two records, two lines: any human-mode output would raise the count,
+      // so this subsumes "nothing else was written" rather than listing
+      // banners that a future edit could add to.
+      expect(lines(ok.stdout)).toHaveLength(2);
+      expect(ok.stdout).not.toContain('To authorize this CLI');
+      expect(ok.stdout).not.toContain('Waiting for browser approval');
+      expect(ok.stdout).not.toContain('ObjectStack Login');
+      // The spinner's carriage returns and the `\x1b[K` erase would corrupt a
+      // line-oriented reader even though they carry no visible text.
+      expect(ok.stdout).not.toMatch(/[\r]/);
+    });
+  });
+
+  describe('the failure that arrives AFTER the first record', () => {
+    it('keeps every line parseable when the poll is denied', () => {
+      // The path the issue never named: device record already written, then an
+      // indented error payload — the same unreadable two-document stream, on
+      // the run a consumer can least afford to misread.
+      const all = lines(denied.stdout);
+      for (const [i, line] of all.entries()) {
+        expect(() => JSON.parse(line), `stdout line ${i + 1}: ${JSON.stringify(line)}`).not.toThrow();
+      }
+      const records = all.map((l) => JSON.parse(l) as Record<string, unknown>);
+      expect(records).toHaveLength(2);
+      expect(records[0]).toMatchObject({ user_code: 'WXYZ-6531' });
+      expect(records[1]).toEqual({ success: false, error: 'Login denied by user.' });
+    });
+
+    it('reports the refusal through the exit code as well as the record', () => {
+      expect(denied.code).toBe(1);
+    });
+  });
+});
+
+describe('the exception stays declared, not just implemented (#6531 ruling)', () => {
+  const loginSrc = () => readFileSync(LOGIN_SRC, 'utf-8');
+
+  it('routes every --json write through the single compact emitter', () => {
+    // The contract is "one document per line" for the WHOLE command, so a new
+    // write that called `emitJson` directly could reintroduce a multi-line
+    // record on a path the e2e above does not drive. One emitter is what makes
+    // that structurally impossible; this is the guard on the emitter.
+    const src = loginSrc();
+    const direct = src
+      .split('\n')
+      .map((line, i) => ({ line, n: i + 1 }))
+      .filter(({ line }) => /\bemitJson\s*\(/.test(line))
+      .filter(({ line }) => !/^\s*await emitJson\(payload, exitCode, \{ compact: true \}\);$/.test(line));
+    expect(
+      direct.map(({ n, line }) => `${n}: ${line.trim()}`),
+      'every --json write in login.ts must go through emitRecord()',
+    ).toEqual([]);
+    expect(/async function emitRecord\(/.test(src)).toBe(true);
+  });
+
+  it('declares NDJSON in the --json flag help text', () => {
+    // `--help` is where a consumer looks first, and the ruling made the
+    // declaration a condition of the fix: an undocumented exception harms the
+    // same audience as the bug.
+    const src = loginSrc();
+    const flag = /json:\s*Flags\.boolean\(\{[\s\S]*?\}\)/.exec(src)?.[0] ?? '';
+    expect(flag).toMatch(/NDJSON/);
+    expect(flag).toMatch(/per line/i);
+  });
+
+  // Prose in .mdx is hard-wrapped, so these patterns treat any run of
+  // whitespace as a word gap. A pin that broke when a sentence rewrapped would
+  // train the next editor to delete it rather than to keep the declaration.
+  it('documents the exception on the CLI reference page', () => {
+    const doc = readFileSync(CLI_DOCS, 'utf-8');
+    expect(doc).toMatch(/`os\s+login\s+--json`\s+is\s+NDJSON/);
+    expect(doc).toMatch(/one\s+compact\s+JSON\s+document\s+per\s+line/i);
+    expect(doc).toMatch(/parse\s+it\s+line\s+by\s+line/i);
+  });
+
+  it('documents the exception where the device flow itself is described', () => {
+    const doc = readFileSync(AUTH_DOCS, 'utf-8');
+    expect(doc).toMatch(/NDJSON/);
+    expect(doc).toMatch(/line\s+by\s+line/i);
+  });
+});
+
+afterAll(() => { /* every run cleans up its own temp dir */ });


### PR DESCRIPTION
Fixes #6531

按 2026-08-08 维护者裁定（comment 5226101978）实现**路线 2 —— NDJSON，作为声明式例外**。

## 前提复现（issue 未做，本 PR 做了）

issue 是**读源码**得出的，没有跑通过。本 PR 先在**未修改的 `origin/main`**（`b230e5efd`）上真机复现：搭了一个最小 RFC 8628 假端点，并用 `script(1)` 分配 PTY 驱动真实子进程 —— 因为 `login.ts` 只在 `process.stdin.isTTY` 为真时才走 device flow，管道 stdin 会掉进 email/password 分支，**根本到不了那两个写点**。

实测 stdout（`--json --no-browser`）：

```
{"device_code":"DEV-CODE-6531","user_code":"WXYZ-6531","verification_uri":"…","expires_in":600}
{
  "success": true,
  "email": "device@example.com",
  "userId": "usr_6531"
}
```

两种读法都失败，前提坐实：

- `JSON.parse(整个 stdout)` → `Unexpected non-whitespace character after JSON at position 200`
- 按 NDJSON 逐行读 → **6 行里 5 行解析失败**（第二份文档跨 5 行）

stderr **完全为空**。顺带回答派单里的问题：`os login` **不 boot kernel**（无 `bootSchemaStack`），所以 #6217 的 stdout 保留接缝在这里用不上，日志污染不存在。

## 改动

`os login --json` 现在是**换行分隔的事件流**：每行一份紧凑 JSON 文档。

**为什么是全部四个写点，而不只是裁定字面说的「两次写」**：契约属于**命令**，不属于某条路径。失败记录（`{"success":false,…}`）是在 device 记录**已经写出去之后**才可能到达的（授权被拒、code 过期、poll 失败），所以它若保持缩进，就在消费者最没法恢复的那条路径上原样重建了本 issue 的两文档流。文档已经告诉消费者逐行读，那 `--email`/`--password` 结果与「已登录」提示也必须成立。四个写点统一走 `emitRecord()` —— 全文件唯一的 `--json` 写出口，让「一行一文档」成为命令的结构性属性，而不是四处各自记得传 option。

## 声明式例外的文档落点（裁定的强制条件）

一个没写进文档的例外，和现在这个 bug 是同一类伤害。三处：

1. **`--help` 文案** —— `--json` flag description 直接写明 NDJSON、逐行解析、以及「与其它命令单文档不同」。
2. **`content/docs/deployment/cli.mdx`** —— `#### os login` 下新增 `##### os login --json is NDJSON — the one exception`，含实际输出样例与一段可直接用的 `while read` + `jq` 消费脚本。
3. **`content/docs/permissions/authentication.mdx`** —— device flow 小节加指针（这里才是描述 device flow 本身的地方）。

⛔ 未碰 `content/docs/releases/`。

## `format.ts` 为什么动了

只动注释。`EmitJsonOptions.compact` 的 doc comment 原文把 `os login` 当作「split 是意外而非设计」的**证据**在引用；改完之后那段话描述的是已经不存在的行为，会主动误导下一个读者。改为记录：`compact` 现在有了唯一一个**设计内**用途，其余站点仍只是保留历史格式。

## 反向验证（方向与红数**先写后跑**）

| 回滚 | 预测 | 实测 |
|---|---|---|
| R1 源码回 `origin/main` | 6 红 | **6 红 / 4 绿**，测试名逐条命中 |
| R2 仅回滚两个 .mdx | 2 红 | **2 红 / 8 绿** |
| R3 路线 1 模拟（缓冲后结尾一次写） | 时序钉转红 | **该钉转红**（另有 3 红未预测，见下） |

R1 保持绿的 4 条正是我**事先写明的诚实排除**：时序钉、exit code、两条文档钉 —— R1 只改第二份文档的**格式**，不改第一份**何时**写出，所以时序钉两个方向都绿，它不构成 R1 的证据。

R3 是为此单独做的：把 device 记录缓冲、结尾合并成一份文档（正是裁定否掉的路线 1）。时序钉以 `the device record never reached stdout early: expected true to be false` 转红，且**整个文件耗时从 10.09s 涨到 42.15s** —— 两次运行都掉进 20s 逃生阀，这是缓冲实现的指纹。**诚实差异**：我对 R3 只预测了「该钉转红」这一条，实测另有 3 条记录计数类断言同时转红（合并后 stdout 只剩 1 条记录），这 3 条我没预测到。

## 时序钉为什么不是数组下标

裁定选 NDJSON 而非路线 1，理由只有一个：消费者要在**还能行动时**拿到 verification URL。断言 `records[0]` 是 device 记录**完全抓不到**路线 1 回归 —— 结尾合并写同样把 URL 字段排在前面。所以假端点**扣住 token 不放，直到本测试在子进程 stdout 上真的读到了 device 记录**才放行；「授权前拿到 URL」因此是这次运行的**历史事实**，而不是事后对数组的观察。缓冲实现等不到放行，掉进 `RELEASE_DEADLINE_MS` 逃生阀（所以是断言失败而不是挂死），以 `urlSeenAt === null` 转红。

## 测试

`packages/cli/test/login-json-ndjson.e2e.test.ts`，10 条：真实子进程 + PTY + 真实 RFC 8628 端点。成功流（逐行可解析 / 恰好两条记录且顺序正确 / 时序钉 / stdout 只有 payload，2 行，无 banner 无 spinner 无回车符）、**授权被拒流**（device 记录之后到达的失败仍逐行可解析，`{"success":false,"error":"Login denied by user."}` + exit 1）、以及四条「例外必须保持被声明」的钉（唯一写出口 + `--help` + 两处文档）。

`script(1)` 缺失时该文件**红**而非 skip —— 静默 skip 的契约测试就是 #5046 换掉那批 fixture 的同一种「因为什么都没产生所以绿」。本仓 CI 全部 `ubuntu-latest`。

## 门禁

`pnpm lint` 0 ✅（家族门禁跑在 ESLint job 内）、`pnpm --filter @objectstack/cli typecheck` ✅、CLI 全量 **96 files / 1005 tests 全绿** ✅、`check:nul-bytes` / `check:doc-authoring` / `check:docs-audit-scope` / `check:role-word` / `check:quick-reference-counts` / `check:adr-anchors` / `check:empty-changeset` / `check:release-notes` 全绿 ✅。

**字节纪律（本 PR 自身踩中一次，已修）**：写那条 spinner 断言时，编辑工具把 ESC **实体化成了裸控制字节**（0x1b，文件内 offset 12579）—— 正是「写*关于*控制字符的内容时最容易中招」那条（#4890 / PR #5140 同款）。已改回**六字符转义文本形式**（反斜杠 + 小写 u + 0 + 0 + 1 + b），字节级自扫描 `grep -naP` 0 命中，`check:nul-bytes` 绿。同理，本正文一律**用文字描述该转义**，不粘贴字节本身。

## Changeset

`@objectstack/cli: patch`。理由：无接口增删，且**没有任何原先可用的东西停止可用** —— device flow 输出此前不可解析，本就没有消费者可破坏；唯一另一处可观察变化是 email/password 结果由缩进变紧凑，`JSON.parse` 读法完全相同。与 #6217/PR #6524（同样是修好一个坏掉的 `--json`）取同一档。

## 顺手发现（未在本 PR 修，PD #10）

`os login --json` 在**非 TTY** 下（无 `--email`/`--password`）会把裸提示 `Email: ` 写到 **stdout**，实测 stdout 全文就是 `Email: `，随后以「unsettled top-level await」exit 13。同一 stdout 纯净度家族，但属于**另一条路径**、且「`--json` 下是否还该交互提示」是独立的契约决定，故单独立卡未认领。