### PR TITLE
fix(spec): the RLS check clause's enumerated-values @example is CEL, and compiles (#6641)

### DIFF
--- a/.changeset/rls-check-example-cel-bracket-list.md
+++ b/.changeset/rls-check-example-cel-bracket-list.md
@@ -1,0 +1,41 @@
+---
+'@objectstack/spec': patch
+---
+
+fix(spec): the RLS `check` clause's enumerated-values `@example` is CEL, and compiles (#6641)
+
+`RowLevelSecurityPolicySchema.check` in `security/rls.zod.ts` documented
+set membership as `status IN ('draft', 'pending')`. That predicate does not
+compile, and the failure is not cosmetic — an author who copies the schema's
+own example gets a policy that **denies every row**.
+
+The runtime path is `RLSCompiler.compileExpression` → `sqlPredicateToCel` →
+`compileCelToFilter`. The deprecated SQL bridge (ADR-0058 D1) rewrites the
+*word* `IN` to `in` and never the parentheses, and CEL's list literal is
+**bracketed**, so the bridged `status in ('draft', 'pending')` is a parse error
+(`Expected RPAREN, got COMMA`). `compileExpression` then returns `null`,
+`compileFilter` sees `filters.length === 0`, and a single-policy object falls to
+`RLS_DENY_FILTER`. `@objectstack/lint`'s `validateRlsPredicateEnforceability`
+rejects the same predicate at authoring time, so the symptom is "I followed the
+schema's example, and now lint errors and every query comes back empty".
+
+The neighbouring `IN (current_user.team_member_ids)` examples were never broken
+and are unchanged: a single `(expr)` happens to be a legal CEL parenthesised
+group, so that spelling survives the bridge. It collapses only once the list
+holds a second element — which is why measuring one example never covered the
+other.
+
+The example now reads `status in ['draft', 'pending']`, the canonical CEL
+spelling. Measured through the runtime's own path, it compiles to
+`{ status: { $in: ['draft', 'pending'] } }`, and under CHECK-clause semantics it
+accepts a post-image whose `status` is `draft` or `pending` while refusing
+`published`, `null`, and an absent field — which is what "Only allow certain
+statuses" has to mean.
+
+Documentation only: no schema key, type, or accepted value changed, and the
+deprecated bridge was deliberately **not** widened to rewrite parenthesised SQL
+lists (that would add surface to a dialect being retired, and would change what
+compiles). `@objectstack/formula`'s `rls-predicate.test.ts` now pins every
+`@example` on `using` / `check` through the ADR-0056 D4 shape gate, so a
+documentation example that stops compiling fails a test instead of an author's
+first policy.

--- a/packages/formula/src/rls-predicate.test.ts
+++ b/packages/formula/src/rls-predicate.test.ts
@@ -18,7 +18,9 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { isSupportedRlsExpression, sqlPredicateToCel } from './rls-predicate';
-import { isPushdownableCel } from './cel-to-filter';
+import { compileCelToFilter, isPushdownableCel } from './cel-to-filter';
+import { matchesFilterCondition } from './matches-filter';
+import type { FilterCondition } from '@objectstack/spec/data';
 
 // ---------------------------------------------------------------------------
 // ADR-0056 D4 — RLS predicates that won't compile must not vanish in silence
@@ -139,5 +141,106 @@ describe('isSupportedRlsExpression — composition and dependency direction', ()
       dependencies?: Record<string, string>;
     };
     expect(Object.keys(pkg.dependencies ?? {}).sort()).toEqual(['@marcbachmann/cel-js', '@objectstack/spec']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #6641 — the schema's own `@example` predicates must COMPILE
+// ---------------------------------------------------------------------------
+//
+// `packages/spec/src/security/rls.zod.ts` documents `using` / `check` with
+// `@example` predicates, and an author copies them verbatim. An example that
+// does not compile is therefore not a typography defect: `compileExpression`
+// returns `null`, `compileFilter` sees `filters.length === 0` and returns
+// `RLS_DENY_FILTER`, so with a single policy the object denies EVERY row — and
+// `@objectstack/lint`'s `validateRlsPredicateEnforceability` rejects the same
+// predicate at authoring time, because it asks the very function above. The
+// symptom an author gets is "I followed the schema's example, and now lint
+// errors and every query is empty".
+//
+// #6641 was exactly that. `check`'s enumerated-values example read
+// `status IN ('draft', 'pending')`; `sqlPredicateToCel` rewrites the WORD `IN`
+// and never the parentheses, and CEL's list literal is BRACKETED, so the
+// bridged `status in ('draft', 'pending')` is a parse error. The neighbouring
+// `IN (current_user.<array>)` form survives only because a single `(expr)`
+// happens to be a legal CEL parenthesised group — it collapses the moment a
+// second element appears, which is why measuring one example never covered the
+// other.
+//
+// Asserted against the SOURCE TEXT on purpose: a documentation example is not
+// reachable from any import, so no ordinary unit test can ever go red on it.
+// This is the guard that whole defect class was missing.
+
+/** `packages/spec/src/security/rls.zod.ts`, from this file's own location. */
+const RLS_ZOD_SOURCE = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'spec',
+  'src',
+  'security',
+  'rls.zod.ts',
+);
+
+/** The `@example "…"` predicates declared on ONE property's own TSDoc block. */
+function predicateExamples(property: 'using' | 'check'): string[] {
+  const source = readFileSync(RLS_ZOD_SOURCE, 'utf8');
+  const decl = source.indexOf(`\n  ${property}: z.string()`);
+  expect(decl, `\`${property}: z.string()\` not found in rls.zod.ts`).toBeGreaterThan(-1);
+  const block = source.slice(source.lastIndexOf('/**', decl), decl);
+  return [...block.matchAll(/@example\s+"([^"]+)"/g)].map((m) => m[1]!);
+}
+
+describe('rls.zod.ts @example — the schema documents only predicates that compile (#6641)', () => {
+  it.each(['using', 'check'] as const)('every `%s` @example passes the ADR-0056 D4 shape gate', (property) => {
+    const examples = predicateExamples(property);
+    // Anti-vacuity. A green loop over an empty list is this pin's own failure
+    // mode: reshape the docblock, or move the examples, and a bare `for` would
+    // keep reporting success while guarding nothing.
+    expect(examples.length).toBeGreaterThanOrEqual(3);
+    expect(examples.map((source) => ({ source, supported: isSupportedRlsExpression(source) })))
+      .toEqual(examples.map((source) => ({ source, supported: true })));
+  });
+
+  it('the `check` enumerated-values example is a CEL bracket list that means "one of these"', () => {
+    // Substance, not wording: find the example by the idiom it demonstrates,
+    // then read the expectations out of what it COMPILES to, so renaming the
+    // field or the statuses keeps this green while breaking the idiom fails.
+    // Case-INSENSITIVE on purpose: the SQL spelling `IN (…)` must be caught by
+    // this test and fail on the bracket assertion below, not slip past the
+    // filter and leave an empty list that a laxer pin would call green.
+    const [enumerated, ...extra] = predicateExamples('check').filter((e) => /\bin\b/i.test(e));
+    expect(extra).toEqual([]);
+    expect(enumerated).toBeTypeOf('string');
+
+    // Bracketed, never parenthesised — `(a, b)` is not a CEL expression.
+    expect(enumerated).toMatch(/\bin\s*\[/);
+    // Already canonical CEL, so the deprecated SQL bridge is a no-op on it
+    // (ADR-0058 D1): the example teaches the canonical dialect, not the bridge.
+    expect(sqlPredicateToCel(enumerated!)).toBe(enumerated);
+
+    const compiled = compileCelToFilter(enumerated!, { variables: {} });
+    expect(compiled.ok).toBe(true);
+    const filter = (compiled as { ok: true; filter: unknown }).filter as Record<string, { $in?: unknown[] }>;
+    const [field, ...moreFields] = Object.keys(filter);
+    expect(moreFields).toEqual([]);
+    const allowed = filter[field!]?.$in;
+    // More than one member is the whole point — the one-element spelling was
+    // never the broken case.
+    expect(Array.isArray(allowed) && allowed.length > 1).toBe(true);
+
+    // CHECK-clause semantics: the write path validates the POST-IMAGE against
+    // this filter (`plugin-security/security-plugin.ts` step 3.6, via
+    // `matchesFilterCondition`). Only the enumerated values may be written;
+    // anything else — including an absent or null field — is refused. That is
+    // what "Only allow certain statuses" has to mean to be a true example.
+    for (const value of allowed as unknown[]) {
+      expect(matchesFilterCondition({ [field!]: value }, filter as FilterCondition)).toBe(true);
+    }
+    const notEnumerated = '__status_not_in_the_example__';
+    expect(allowed).not.toContain(notEnumerated);
+    expect(matchesFilterCondition({ [field!]: notEnumerated }, filter as FilterCondition)).toBe(false);
+    expect(matchesFilterCondition({ [field!]: null }, filter as FilterCondition)).toBe(false);
+    expect(matchesFilterCondition({}, filter as FilterCondition)).toBe(false);
   });
 });

--- a/packages/formula/src/rls-predicate.test.ts
+++ b/packages/formula/src/rls-predicate.test.ts
@@ -22,6 +22,20 @@ import { compileCelToFilter, isPushdownableCel } from './cel-to-filter';
 import { matchesFilterCondition } from './matches-filter';
 import type { FilterCondition } from '@objectstack/spec/data';
 
+/**
+ * This file's own directory, resolved ONCE.
+ *
+ * Deliberately a single module-level constant rather than a `const here = …` in
+ * each test that needs it. This package's `tsconfig.json` excludes `*.test.ts`,
+ * so `pnpm typecheck` never reads this file — but `check-type-check-coverage`
+ * re-measures it with the exclusion lifted and holds the count to a shrink-only
+ * TEST_DEBT ledger (#5278). `import.meta` costs two raw errors there (TS1470 +
+ * TS2339) under the package's CommonJS-targeted config, so a SECOND occurrence
+ * would raise the ledger by two for no behavioural reason. One occurrence, two
+ * readers.
+ */
+const HERE = dirname(fileURLToPath(import.meta.url));
+
 // ---------------------------------------------------------------------------
 // ADR-0056 D4 — RLS predicates that won't compile must not vanish in silence
 // (moved verbatim from plugin-security/src/security-plugin.test.ts, #4983)
@@ -132,12 +146,11 @@ describe('isSupportedRlsExpression — composition and dependency direction', ()
    * a dependency that is only wrong at build time produces no failing assertion.
    */
   it('never imports a runtime — the hoist direction is pinned, not just intended', () => {
-    const here = dirname(fileURLToPath(import.meta.url));
-    const source = readFileSync(join(here, 'rls-predicate.ts'), 'utf8');
+    const source = readFileSync(join(HERE, 'rls-predicate.ts'), 'utf8');
     const specifiers = [...source.matchAll(/from\s+'([^']+)'/g)].map((m) => m[1]);
     expect(specifiers).toEqual(['./cel-to-filter']);
 
-    const pkg = JSON.parse(readFileSync(join(here, '..', 'package.json'), 'utf8')) as {
+    const pkg = JSON.parse(readFileSync(join(HERE, '..', 'package.json'), 'utf8')) as {
       dependencies?: Record<string, string>;
     };
     expect(Object.keys(pkg.dependencies ?? {}).sort()).toEqual(['@marcbachmann/cel-js', '@objectstack/spec']);
@@ -172,15 +185,7 @@ describe('isSupportedRlsExpression — composition and dependency direction', ()
 // This is the guard that whole defect class was missing.
 
 /** `packages/spec/src/security/rls.zod.ts`, from this file's own location. */
-const RLS_ZOD_SOURCE = join(
-  dirname(fileURLToPath(import.meta.url)),
-  '..',
-  '..',
-  'spec',
-  'src',
-  'security',
-  'rls.zod.ts',
-);
+const RLS_ZOD_SOURCE = join(HERE, '..', '..', 'spec', 'src', 'security', 'rls.zod.ts');
 
 /** The `@example "…"` predicates declared on ONE property's own TSDoc block. */
 function predicateExamples(property: 'using' | 'check'): string[] {

--- a/packages/spec/src/security/rls.zod.ts
+++ b/packages/spec/src/security/rls.zod.ts
@@ -374,7 +374,7 @@ export const RowLevelSecurityPolicySchema = lazySchema(() => strictObject(
    * - Restrict certain operations (e.g., only allow creating "draft" status)
    * 
    * @example "organization_id = current_user.organization_id"
-   * @example "status IN ('draft', 'pending')" - Only allow certain statuses
+   * @example "status in ['draft', 'pending']" - Only allow certain statuses
    * @example "created_by = current_user.id" - Must be the creator
    */
   check: z.string()


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6641

## What was wrong

`packages/spec/src/security/rls.zod.ts:377` documented the `check` clause's
enumerated-values idiom as:

```
@example "status IN ('draft', 'pending')" - Only allow certain statuses
```

That predicate does not compile, and the consequence is not cosmetic.
`RLSCompiler.compileExpression` bridges it with `sqlPredicateToCel`, which
rewrites the **word** `IN` to `in` and never the parentheses. CEL's list literal
is **bracketed**, so `status in ('draft', 'pending')` is a parse error.
`compileExpression` returns `null`, `compileFilter` sees `filters.length === 0`,
and a single-policy object falls to `RLS_DENY_FILTER` — an author who copies the
schema's own example gets a policy that **denies every row**, plus an authoring
error from `@objectstack/lint`'s `validateRlsPredicateEnforceability`.

## Premise re-verified on this branch's base

Verified on `origin/main` at `cfeb9a071`, the branch point. The `@example` is
present verbatim at `:377` — the anchor the PM's E7 re-verification recorded
after #5593 merged (`e0f300ba5`) — so the card's premise holds in full.

## Measurement — the same path the card's table used

`sqlPredicateToCel` + `isSupportedRlsExpression` + `compileCelToFilter`, i.e.
exactly what `RLSCompiler.compileExpression` runs, with
`current_user = { id: 'u1', organization_id: 'o1', team_member_ids: ['u1','u2'] }`.

| `@example` | after the bridge | `isSupportedRlsExpression` | `compileCelToFilter` |
|:--|:--|:--|:--|
| `organization_id = current_user.organization_id` (using) | `organization_id == current_user.organization_id` | true | ok `{"organization_id":"o1"}` |
| `owner_id = current_user.id` (using) | `owner_id == current_user.id` | true | ok `{"owner_id":"u1"}` |
| `status = 'published'` (using) | `status == 'published'` | true | ok `{"status":"published"}` |
| `assigned_to_id IN (current_user.team_member_ids)` (using) | `assigned_to_id in (current_user.team_member_ids)` | true | ok `{"assigned_to_id":{"$in":["u1","u2"]}}` |
| `1 = 1` (using) | `1 == 1` | true | ok `{}` |
| `organization_id = current_user.organization_id` (check) | `organization_id == current_user.organization_id` | true | ok `{"organization_id":"o1"}` |
| **`status IN ('draft', 'pending')` (check, BEFORE)** | `status in ('draft', 'pending')` | **false** | **FAIL `parse-error`** |
| `created_by = current_user.id` (check) | `created_by == current_user.id` | true | ok `{"created_by":"u1"}` |
| **`status in ['draft', 'pending']` (check, AFTER)** | `status in ['draft', 'pending']` (bridge is a no-op) | **true** | **ok `{"status":{"$in":["draft","pending"]}}`** |

The card's table is reproduced row for row, including the reason the neighbouring
`IN (current_user.team_member_ids)` form survives: a single `(expr)` happens to be
a legal CEL parenthesised group. It collapses only once the list holds a second
element, which is why measuring one example never covered the other.

## The semantic check the card asked for

A corrected example that is itself unverified would repeat the defect, so the
replacement was also checked for **meaning**, not just for compiling. The CHECK
clause validates the **post-image** through `matchesFilterCondition`
(`plugin-security/security-plugin.ts` step 3.6). Against the compiled
`{"status":{"$in":["draft","pending"]}}`:

```
post-image {"status":"draft"}     -> true
post-image {"status":"pending"}   -> true
post-image {"status":"published"} -> false
post-image {"status":null}        -> false
post-image {}                     -> false
```

Exactly "Only allow certain statuses": the enumerated values may be written, and
anything else — including an absent or null field — is refused.

## What changed

**Route 1, document side**, per the 2026-08-08T09:29Z triage ruling and the
filer's own preference. One line:

```diff
-   * @example "status IN ('draft', 'pending')" - Only allow certain statuses
+   * @example "status in ['draft', 'pending']" - Only allow certain statuses
```

Route 2 (widening the `@deprecated` `sqlPredicateToCel` bridge to rewrite
parenthesised SQL lists) was **not** taken: it adds surface to a dialect being
retired, and it would change what compiles — an acceptance change, and therefore
not this lane's call. Consistent with ADR-0058 D1 (CEL is canonical), the example
now teaches the canonical dialect rather than the transitional bridge.

**Out of scope and deliberately untouched:** the `using` clause's `@example`s are
also SQL-style, but all five were measured compilable (table above) and are the
transitional bridge's legitimate existing surface.

## The guard this defect class was missing

`packages/formula/src/rls-predicate.test.ts` gains two pins. A documentation
example is not reachable from any import, so no ordinary unit test could ever go
red on it — which is why the defect survived.

1. **Every** `@example` on `using` / `check` is read out of the spec source and
   pushed through the ADR-0056 D4 shape gate. Carries an anti-vacuity assertion:
   reshape the docblock or move the examples and the pin fails rather than
   looping over an empty list and reporting success.
2. The enumerated-values example is found **by the idiom it demonstrates**, not
   by its wording, then its expectations are read out of what it *compiles to* —
   so renaming the field or the statuses keeps this green while breaking the
   idiom fails. It asserts the bracket form, that the deprecated bridge is a
   no-op on it, that it lowers to a set membership with more than one member, and
   the post-image semantics quoted above.

### Reverse verification — direction predicted before running: RED

Restoring `status IN ('draft', 'pending')` in `rls.zod.ts` turns **both** new
tests red, each pointing at its own fact:

```
FAIL  every `check` @example passes the ADR-0056 D4 shape gate
   -   "source": "status IN ('draft', 'pending')",
   -   "supported": false,

FAIL  the `check` enumerated-values example is a CEL bracket list ...
AssertionError: expected 'status IN (\'draft\', \'pending\')' to match /\bin\s*\[/

 Tests  2 failed | 9 passed (11)
```

The filter that locates the enumerated example is case-**insensitive** on
purpose: the SQL spelling has to be caught and fail on the bracket assertion, not
slip past the filter and leave an empty list that a laxer pin would call green.

## A dispatch assumption that did not hold

The dispatch asked whether a TSDoc `@example` reaches `content/docs/references/**`,
and to verify rather than assume. **It does not.** `gen:schema` + `gen:docs` were
re-run on the corrected source and produced **zero** tracked diff; `check:docs`
reports `230 generated files in sync with packages/spec`. The reference pages
render Zod `.describe()` strings and the module-level docblock, never a property's
`@example`. So there is no regen to commit.

The changeset is still `@objectstack/spec: patch` rather than the
`skip-changeset` route, because the example *is* author-visible by a different
path: it ships inside the published package's `dist/*.js` / `dist/*.mjs` (retained
comments) and its source maps, and it is the authoring guidance a reader copies
straight out of the schema. Anyone who already copied the old form is running a
fail-closed policy, which is worth a release-notes line. Happy to swap it for the
label if the seat prefers.

## Verification

| Gate (enumerated one by one from `.github/workflows/lint.yml`) | Result |
|:--|:--|
| ESLint job — `pnpm lint` | pass (clean) |
| ESLint job — Raw control-byte guard | `OK (scanned 6239 tracked text files; no raw ASCII control bytes)` |
| ESLint job — Doc/skill authoring guard | `365 files clean` |
| ESLint job — Spec type-alias convention gate (ADR-0122) | `1517 bare aliases, 823 pinned isomorphic, 694 paired. OK` |
| Typecheck job — `tsc --noEmit` (`@objectstack/spec`) | pass (clean) |
| Typecheck job — `check:generated --reconcile-only` | `19 check: + 13 gen: scripts, all classified` |
| Typecheck job — `check:authorable-surface` | `1308 defaults unchanged; 1596 schemas` |
| Typecheck job — `check:docs` | `230 generated files in sync with packages/spec` |
| Typecheck job — `check:skill-refs` | `9 generated files in sync with packages/spec` |
| Typecheck job — `check:doc-formula-expressions` | `22 formula examples across 378 files / 1397 TS blocks judged clean` |
| `pnpm --filter @objectstack/formula typecheck` | pass (clean) |
| `pnpm --filter @objectstack/formula test` | `Test Files 18 passed (18) / Tests 453 passed (453)` |
| `pnpm --filter @objectstack/spec test` | `Test Files 345 passed (345) / Tests 8844 passed (8844)` |

`content/docs/releases/` untouched. No acceptance-surface bytes: no schema key,
type, or accepted value changed — `check:authorable-surface` confirms the legal
metadata set is byte-identical.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk)_