### PR TITLE
fix(examples): showcase home page "Create Task" button now carries element:button's inline action

### DIFF
--- a/examples/app-showcase/src/ui/pages/index.ts
+++ b/examples/app-showcase/src/ui/pages/index.ts
@@ -79,7 +79,20 @@ export const ComponentGalleryPage = definePage({
             ],
           },
         },
-        { type: 'element:button', properties: { label: 'Create Task', actionName: 'showcase_new_task' } },
+        // The page's primary CTA. `element:button` carries an **inline** action
+        // (`action`, an InlineActionSchema) — it is NOT a by-name reference to a
+        // registered object action; that is `action:button`. This block used to
+        // author `actionName: 'showcase_new_task'`, a key `ElementButtonPropsSchema`
+        // never declared: the strip-mode parse dropped it, the renderer reads only
+        // `props.action`, and its `handleClick` opens with `if (!action) return` —
+        // so the button rendered, was clickable, and the click did nothing at all
+        // (no request, no dialog, no navigation). #6597.
+        //
+        // `type: 'modal'` + a string `target` is resolved page-first, then object
+        // (objectui `useActionModal.resolveModalTarget`); `showcase_task` names no
+        // page, so it lands on the object and opens the Task create form — which is
+        // what a button labelled "Create Task" should do.
+        { type: 'element:button', properties: { label: 'Create Task', icon: 'plus', action: { name: 'showcase_new_task', type: 'modal', target: 'showcase_task', refreshAfter: true } } },
       ],
     },
     {


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6597

## What changed

One line — the primary CTA of `showcase_component_gallery` (the showcase home page) in `examples/app-showcase/src/ui/pages/index.ts`:

```ts
- { type: 'element:button', properties: { label: 'Create Task', actionName: 'showcase_new_task' } },
+ { type: 'element:button', properties: { label: 'Create Task', icon: 'plus',
+     action: { name: 'showcase_new_task', type: 'modal', target: 'showcase_task', refreshAfter: true } } },
```

Per the triage ruling: **fix the corpus, not the contract.** No change to `packages/spec`, no change to the renderer, no change to lint. The declaration side (`action`) and the renderer have agreed all along — this one piece of corpus was the wrong side.

I also added a comment explaining the trap itself. The corpus is read by humans and copied by AI authors, so "why `action` and not `actionName`" is worth more sitting next to the line than sitting in an issue.

## Precondition: is `showcase_new_task` a registered action?

Yes. `examples/app-showcase/src/ui/actions/index.ts:177` defines `NewTaskAction`: `type: 'modal'`, `objectName: showcase_task`, `locations: ['global_nav']`, `refreshAfter: true`, `target: 'showcase_component_gallery'`.

But there is a fact here that decides what belongs inside `action`, and it needs stating plainly: **`element:button` carries an *inline* action (`InlineActionSchema`) — it is not a by-name reference into the action registry.** By-name reference is `action:button`. The ActionRunner's modal branch reads `action.modal || action.target || action.params?.schema`; `name` is only an identifier and triggers no registry lookup at all. So the `type`/`target` written inline *are* the dispatch — they have to be spelled out in full.

Which is why I ran both spellings in a real browser instead of copying the registry entry blind:

| Spelling | Measured result |
|:---|:---|
| `target: 'showcase_component_gallery'` (copy the registry) | Dialog opens, titled "Component Gallery", containing **this very home page**, with **0** form controls |
| `target: 'showcase_task'` (this PR) | Dialog opens on the Task **create form**, 7 controls (Title\* / Project\* / Assignee / Status\* / Priority / Due Date); submitting really creates a record |

Copying the registry does "do something" — but a button labelled "Create Task" that wraps the home page inside a dialog creates no task, and this page's own docblock is explicit that it is "a clean welcome landing … and a primary action". A `type: 'modal'` action with a string `target` is resolved by objectui's `useActionModal.resolveModalTarget` page-first, then object; `showcase_task` is not the name of any page, so it lands on the object and opens the create form. That is what the label says it does.

The registry entry's own `target` pointing at `showcase_component_gallery` (the global_nav command-palette "New Task" wraps the home page in a dialog for the same reason) is **out of scope here and filed separately as #6739** — deliberately not fixed in this PR.

## Acceptance evidence: the click was actually run

The card noted this was only ever measured statically, never clicked. It has now been clicked — a real headless-chromium browser driving the showcase booted with `os dev --ui`, signed in, at `/_console/apps/com.example.showcase/page/showcase_component_gallery`.

**Before** (a no-op, matching the issue):

```
[before] button visible: true | enabled: true
[before] after click  — dialogs: 0
[before] network requests fired by the click: []
[before] toasts: []
[before] VERDICT dialogsBefore=0 dialogsAfter=0 urlChanged=false
```

The button renders, is clickable, `disabled` is false — and the click fires **not a single request**: no dialog, no navigation, no error.

**After**:

```
[final] dialog opened; controls: 7
[final] network requests fired by the click: ["GET /api/v1/meta/page/showcase_task"]
[final] project suggestions: 5 "Mobile App…"
[final] dialogs after submit: 0
[final] toasts: ["Action completed successfully"]
```

The dialog is the Task create form (Title\* / Project\* / Assignee / Status\* / Priority / Due Date + Cancel / Create). Filling only Title and pressing Create triggers validation as expected ("Project is required" plus the toast "Please check the highlighted fields: Project"); filling the rest and submitting closes the dialog with a success toast.

Server-side confirmation (not just the UI):

```
showcase_task total: 12          # 10 seeded rows, plus one per acceptance run
 created: UvIhd9YX0yaEainn | Dogfood 6597 task 1786195341594 | project: 9ic7y91bi9fN-AKW | status: backlog
 created: uf3LN21Th4gRbGtB | Dogfood 6597 task 1786194880686 | project: 9ic7y91bi9fN-AKW | status: backlog
```

## `os validate` before/after

Real run over the showcase corpus, `pnpm --filter @objectstack/example-showcase validate`:

| | `component-props-unknown-key` (this page) | all ⚠ |
|:---|:---|:---|
| Before | **1** | 47 |
| After | **0** | 46 |

The warning that was there before:

```
⚠ page "showcase_component_gallery" · element:button: `actionName` is not a prop
  `element:button` declares (ComponentPropsMap, @objectstack/spec/ui), so nothing verifies it …
```

After the change the whole corpus has zero `is not a prop` hits, and the total warning count drops by exactly one (the other 46 are untouched). This is one of the two entries on #5068's list blocking its error upgrade; the other one (the `action.params` shape) is tracked by #5777 and is not part of this issue.

## Tests and gates

- `pnpm --filter @objectstack/example-showcase typecheck` → pass
- `pnpm --filter @objectstack/example-showcase test` → **15 files / 154 tests passed**
- `pnpm --filter './examples/*' run typecheck` → all Done
- `pnpm lint` → EXIT=0
- All 31 `check:*` gates enumerated one by one from `.github/workflows/lint.yml` → all EXIT=0 (including `check:nul-bytes`)
- `check:type-check-coverage` / `check:driver-conformance` / `check:stall-guard` / `check:skill-frame-sync` / `check:skill-compatibility` / `check:i18n` / `check:i18n-coverage` / `check:app-nav-i18n` → all EXIT=0

## Changeset

None; labelled `skip-changeset`. `@objectstack/example-showcase` is `private: true` and is not in the `fixed` list of `.changeset/config.json` — the package publishes nothing, so this PR carries no user-visible release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_