### PR TITLE
docs(agents): make the os-dev termination contract explicit and honest about its measured failure rate (#6586)

### DIFF
--- a/.claude/agents/os-dev.md
+++ b/.claude/agents/os-dev.md
@@ -136,7 +136,9 @@ build/test runs OOM it.** Binding rules:
    completion message reading "build still in progress" or "I'll resume
    when…" is not a report; it is the stall. The one long wait that IS
    legitimate is `flock` queueing on the shared lock in rule 1 — that one
-   blocks by design, so waiting it out is the rule, not a stall.
+   blocks by design, so waiting it out is the rule, not a stall. A monitor
+   firing *after* you have finished is the mirror image of this and does
+   happen — see "Terminating cleanly" below.
 
 **Toolchain traps — each of these cost at least one agent a false-red lap:**
 
@@ -220,7 +222,70 @@ Definition of done, in order:
   This wait is **foreground polling** — the same legitimate blocking wait as
   `flock` in resource rule 1, and ⛔ never a background watcher you return from
   mid-task (resource rule 6 still binds).
-- Tear down anything you started (dev servers on random ports).
+- Tear down anything you started — dev servers on random ports, **and every
+  background monitor you armed** (see "Terminating cleanly" immediately below:
+  a monitor left running outlives the thing it watched and re-fires your whole
+  report at the PM).
+
+**Terminating cleanly — the structured report is your terminal action, and this
+contract is measured to fail.** Everything above converges here: push, draft PR,
+`skip-changeset`, the foreground CI-convergence read — then you return the JSON
+below, and **nothing of yours runs after it**. Ownership either side of that
+point: remote CI **up to** the report is yours, because the PM deliberately does
+not subscribe to a dev's PR before the report lands
+(`.claude/skills/pm-dispatch/SKILL.md`, "报告前是 dev 的领地" — two pilots on one
+control); ready-flip, auto-merge and landing after it are the PM's, and reverting
+any of those is never yours (rule 2).
+
+1. **No background child outlives the run, and no monitor outlives what it
+   watches.** A monitor is bound to its own deadline, never to its subject's
+   lifetime: when the watched process finishes early — or you kill it yourself —
+   the monitor runs on and then fires a completion notification shaped exactly
+   like a real handback. Measured on #5330 / PR #6703: one card emitted **six**
+   notifications, five of them redundant replays of the same full report, and one
+   of those monitors was watching a run the agent had **itself cancelled via
+   `TaskStop`** before it ever acquired the lock — its wake condition could never
+   match, and it reported anyway. So: cancel a watched process ⇒ cancel its
+   monitor in the same step; finish reading a run's output ⇒ its monitor is
+   finished too. This is resource rule 5 ("operate on the PID you recorded")
+   pointed at the watcher instead of the process, and resource rule 6's foreground
+   pipeline is what keeps the count at zero to begin with. It does **not**
+   contradict rule 6's "that wake-up never arrives": a monitor fires on its own
+   deadline, not on your need — it will not rescue a mid-task stop, and it will
+   re-invoke you long after you have finished. Both readings are the same missing
+   binding, seen from either side.
+2. **If a monitor fires anyway, its first line says what it watched and whether
+   that thing is still alive** — before the JSON, e.g. `stale wake: monitor for
+   the post-merge test run, which finished 40 min ago; issue #6586 already
+   reported`. Those six notifications were indistinguishable at arrival — same
+   shape, same full JSON — so the PM had to read and re-adjudicate each one to
+   discover it was a repeat. Same class of cost, and the same mitigation, as the
+   PM's own dispatch timers, where *a deleted timer still delivers, and by
+   delivery time its text may be several rounds behind reality*: every such text
+   must open with **idempotent — re-read state before acting**
+   (`.claude/skills/pm-dispatch/SKILL.md`, the quota-handoff notes). Apply that to
+   yourself in the other direction too — **before** acting on any wake, re-read
+   the real state (branch pushed? PR open? report already delivered?), and never
+   redo work or open a second PR on the strength of a wake alone.
+3. **⚠️ Following this contract does not mean you will be heard, and you must
+   plan for that.** On 2026-08-08, **7 of 7** dispatches failed to hand back
+   cleanly after opening a correct PR — silent deaths, plus stalls on wakers that
+   were never running. **Three of them carried this clause verbatim in their
+   dispatch prompt and failed anyway** (one a fresh dispatch, not a resumed
+   session): 3 of the 4 clause-carrying runs, which puts the cause outside
+   anything this file can say — the process ending between the PR push and the
+   report turn (#6586). This section therefore reduces the failure; it does not
+   remove it. Two consequences, both binding:
+   - **Never read your own silence as success.** An absent report is not "the PM
+     saw the PR and inferred it went fine" — it blocks ACCEPT/REJECT outright, and
+     the PM is instructed never to treat a missing report as success.
+   - **The PM's probe-and-revive loop is the standing backstop, not an exception
+     path.** Being probed after your PR is already open is the normal shape of
+     this failure, not a reprimand. When it happens, re-read state per point 2 and
+     deliver the report from your transcript: every death so far was fully
+     recoverable that way, with **zero work lost**. The cost of this failure is
+     latency, not correctness — so ⛔ never "recover" by redoing the work or
+     opening a second PR.
 
 **Reverse verification — decide the expected direction BEFORE you run it.**
 "Put the deleted limb back / revert the fix and watch the diagnostics" proves


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6586

## What this changes

One file: `.claude/agents/os-dev.md`. Three edits, all in the dev agent's own operating manual.

**1. A new "Terminating cleanly" section**, placed directly after the `Definition of done` list, because termination is the last step of that order. It states:

- The structured report is the **terminal action** — push, draft PR, `skip-changeset`, the foreground CI-convergence read, then the JSON, and nothing of the dev's runs after it.
- **A monitor is bound to its own deadline, never to its subject's lifetime.** Cancel a watched process, cancel its monitor in the same step; finish reading a run's output, its monitor is finished too. The measured case is #5330 / PR #6703: one card emitted six notifications, five redundant replays of the same full report, one of them from a monitor watching a run the agent had itself cancelled via `TaskStop` before it ever acquired the lock.
- **Stale-wake identifiability** — if a monitor fires anyway, its first line names what it watched and whether that thing is still alive, before the JSON. Today those six arrivals were indistinguishable: same shape, same full JSON, so the PM had to re-adjudicate each one to discover it was a repeat.
- The **ownership split** either side of the report, which the issue's suggested direction guessed the other way round (see below).

**2. The honesty clause, which is the point of the card.** The section states plainly that following it does not mean the dev will be heard: 7 of 7 dispatches on 2026-08-08 failed to hand back cleanly after opening a correct PR, and **three of those carried this clause verbatim in their dispatch prompt and failed anyway** — 3 of 4 clause-carrying runs, which puts the cause outside anything a documentation change can reach. Two binding consequences follow in the text: never read your own silence as success, and the PM's probe-and-revive loop is the **standing backstop, not an exception path**. Every death so far was fully recoverable from transcript with zero work lost, so the cost is latency and not correctness — and the text says so, precisely so that a revived dev does not "recover" by redoing the work or opening a second PR.

**3. Two existing sentences fixed in the same pass**, because the addition would otherwise leave them misleading:

- Resource rule 6 says a background watcher's wake-up "never arrives". Read against the #5330 evidence that is flatly contradictory, so rule 6 now points forward, and the new section reconciles the two explicitly: a monitor fires on its own deadline, not on the dev's need — it will not rescue a mid-task stop, and it will re-invoke a dev long after it finished. Same missing binding, seen from either side.
- The `Definition of done` teardown bullet said "dev servers on random ports". Background monitors are also things the dev started, and they were the whole fifth sub-shape, so the bullet now names them.

## Cross-reference, per the issue's third ask

The stale monitor is the same class of cost as the PM's own dispatch timers, where *a deleted timer still delivers, and by delivery time its text may be several rounds behind reality* — whose mitigation is that every such text opens with **idempotent, re-read state before acting**. The new section cites that convention by name and applies it to the dev in the other direction: before acting on any wake, re-read the real state rather than replaying the deliverable.

## Deliberately NOT done, with pointers

- **`.claude/skills/pm-dispatch/SKILL.md` is untouched.** PR #6720 is in the merge queue editing that file. The PM-side half of this card — that the probe-and-revive loop is load-bearing rather than a fallback, and that a stale wake should be recognisable without re-reading the deliverable — belongs there and is left for a follow-up on top of #6720. The producer-side half, which is this PR, is the one the PM skill already points at ("The producer-side half of this rule lives in `.claude/agents/os-dev.md`'s resource discipline").
- **The issue's suggested direction 2 was not implemented, and I believe it is inverted.** It proposes that remote CI belongs to the dispatching PM and the dev should report from local verification only. The current convention is the opposite and is deliberate: `pm-dispatch/SKILL.md` forbids the PM from subscribing to a dev's PR before the report lands, because before the report the PR is the dev's territory and two pilots step on each other. The agent definition's own CI-convergence bullet, added after #5584 merged red and poisoned main's merge ref, depends on the dev doing that read. So this PR keeps the CI wait and instead makes explicit that it is a **foreground** read ending in the report, never a licence for a background waker. The ownership sentence in the new section records the handoff point rather than moving it.

## Verification

No package code changed, so there is no unit test to add and no `pnpm test` or `pnpm typecheck` that is meaningful for this diff. Saying so beats manufacturing evidence that fits the template. What was run is the gate list enumerated from `.github/workflows/lint.yml`, after commit, all green:

- `check:skill-frame-sync` — the one that reads this exact file: `4 copies of the decision frame are structurally isomorphic across 3 files`, `3 axes`, `40 markdown files scanned for undeclared copies`.
- `check:doc-authoring` — `365 files clean`.
- `check:nul-bytes` — `scanned 6258 tracked text file(s); no raw ASCII control bytes`. Plus a manual scan of the edited file beyond the gate's surface, no matches.
- `check:role-word` — `44 baselined file(s), no new occurrences`.
- `check:docs-audit-scope`, `check:quick-reference-counts`, `check:adr-anchors`, `check:skill-compatibility` — all OK.
- `pnpm lint` — clean, exit 0.

## Labels

`skip-changeset`: this PR touches only `.claude/agents/os-dev.md`, which is internal agent tooling and publishes nothing to any package, so it releases nothing and writes no changeset. Applied as a union with the labels already on the PR, not as a bare set.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_