### PR TITLE
fix(spec): stop teaching the retired ETL layer as a live retry surface in flow.zod.ts (#6630, part 2)

### DIFF
--- a/packages/spec/src/automation/flow.zod.ts
+++ b/packages/spec/src/automation/flow.zod.ts
@@ -637,13 +637,14 @@ export const FlowSchema = lazySchema(() => strictObject(
    * Error Handling Strategy.
    *
    * The retry knobs are the converged `RetryPolicySchema` contract, shared with
-   * `job.retryPolicy`, a `try_catch` node's `retry` and an ETL pipeline's
-   * `retry` (#4661 + #4964 — see `shared/retry-policy.zod.ts`). Until 17 this
-   * block spelled the base delay `retryDelayMs` while the converged policy
-   * spelled it `backoffMs`, so an author who read the newer file and brought
-   * the word here had it silently stripped (pre-批 11) or rejected (post-批 11)
-   * — being punished for learning the canonical spelling. `strategy` stays
-   * here: it selects *whether* the policy runs, it is not part of the policy.
+   * `job.retryPolicy` and a `try_catch` node's `retry` (#4661 + #4964 — see
+   * `shared/retry-policy.zod.ts`; `ETLPipeline.retry` did the same until #6414
+   * retired the L2 ETL layer). Until 17 this block spelled the base delay
+   * `retryDelayMs` while the converged policy spelled it `backoffMs`, so an
+   * author who read the newer file and brought the word here had it silently
+   * stripped (pre-批 11) or rejected (post-批 11) — being punished for learning
+   * the canonical spelling. `strategy` stays here: it selects *whether* the
+   * policy runs, it is not part of the policy.
    *
    * **These defaults are the only defaults** (#4247). The engine reads the
    * parsed block field-by-field with no fallback of its own — `retryExecution`
@@ -717,14 +718,14 @@ export const FlowSchema = lazySchema(() => strictObject(
     // is what made the divergence so durable: it looked reviewed.
     //
     // The spread is what keeps that from happening again. A key added to the
-    // policy lands on all four surfaces at once, instead of on the ones
+    // policy lands on all three surfaces at once, instead of on the ones
     // whoever added it happened to grep for.
     ...retryPolicyShape(),
 
     // The ONE site-specific override, and it is prose only — same type, same
     // bounds, same default, all still single-sourced above. `.describe()`
     // lands in `content/docs/references/`, and the flow surface has a reading
-    // the other three do not: the count is read only under `strategy:
+    // the other two do not: the count is read only under `strategy:
     // 'retry'`, where the `superRefine` below then requires >= 1 (#4247).
     // Default 0 = "no retries" is the right reading for the two strategies
     // that never retry; under `'retry'` it would mean "retry, zero times",


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6630

**Part 2 of 2** — the closing half. Part 1 is PR #6701 (`shared/retry-policy.zod.ts` + `conversions/registry.ts`), which deliberately carried no `Fixes` line so the issue stayed open for this one; see the [claim-amendment comment](https://github.com/objectstack-ai/objectstack/issues/6630#issuecomment-5226105668) for the split and the [part-2 claim](https://github.com/objectstack-ai/objectstack/issues/6630#issuecomment-5226365752) for the re-anchored line numbers. `automation/flow.zod.ts` was inside #5593's in-flight surface when part 1 ran; #5593 has merged (PR #6595), so the file is released.

## What was wrong

#6414 retired the whole L2 ETL layer — `automation/etl.zod.ts`, 9 defs / 27 exported names, with the export absence pinned in `automation/sync-retirement.test.ts`. `ETLPipeline.retry` was one of the four surfaces that carried the converged `RetryPolicySchema` contract. Three sentences in `automation/flow.zod.ts` still said it was one of four.

## What changed

Three prose sites, one file, text only. Re-verified on `origin/main` @ `61282f906` before editing — the audit's anchors (`:665`/`:745`/`:752`) had drifted; the real ones are below.

| Site | Was | Now |
|:--|:--|:--|
| `:640` `errorHandling` TSDoc | "shared with `job.retryPolicy`, a `try_catch` node's `retry` **and an ETL pipeline's `retry`**" | shared with the two that survive; ETL "did the same until #6414 retired the L2 ETL layer" |
| `:720` | "a key added to the policy lands on **all four surfaces** at once" | all **three** surfaces |
| `:727` | "the flow surface has a reading **the other three** do not" | the other **two** |

The arithmetic is measured, not assumed: `retryPolicyShape()` / `RetryPolicySchema` have exactly three consumers on `main` — `system/job.zod.ts:141` (`job.retryPolicy`), `automation/control-flow.zod.ts:318` (a `try_catch` node's `retry`) and `automation/flow.zod.ts:722` (`flow.errorHandling`, the spread). `system/worker.zod.ts`'s `TaskRetryPolicySchema` is a separate declaration and was never part of this count.

**Wording matches part 1's landed choices**, which was the point of splitting rather than forking: enumerations name only surviving surfaces, the retired mention becomes explicitly historical in part 1's own words ("did the same until #6414 retired the L2 ETL layer" — the exact sentence part 1 put on `RetryPolicySchema`'s TSDoc), counts corrected in place. Two files in one package correcting the same defect two different ways would have been its own small drift.

**Zero acceptance-surface bytes.** No schema key, bound, default, `.describe()` or `retiredKey()` guidance string is touched. `check:authorable-surface` is green with no baseline edit.

**Out of scope, untouched:** everything else in `flow.zod.ts`; both files part 1 already fixed; `content/docs/releases/`.

## Mechanism assumptions — both verified, both held

The dispatch flagged two predictions and asked for them to be falsified if wrong. This time neither was.

**1. Zero regen (predicted; held — unlike part 1).** Part 1 falsified the same prediction because a `retiredKey()` `.describe()` reached two reference pages. Nothing here is a render input: `:640` is a TSDoc block and `:720`/`:727` are `//` comments. Measured rather than argued —

```
✓ All 10 generated artifacts are up to date.
  ✓ check:docs                 content/docs/references/**
  ✓ check:api-surface          api-surface/
  ✓ check:authorable-surface   authorable-surface/ + authorable-defaults/ + JSON schemas
```

`check:api-surface` reads the **built** dist, so `packages/spec` was built first — before that it fails as "stale" in any fresh worktree, which is a phantom, not a finding. The `.d.ts` carries none of the changed text (only the bundled `.js` does, as a preserved comment), which is why the API surface is byte-identical.

**2. A pin asserting the four-surface arithmetic or the ETL mention (predicted possible; none exists).** Swept, including the file the dispatch named specifically. `automation/flow.test.ts:1578` matches the *prescription* — `'was removed in @objectstack/spec 17.0.0'`, `'backoffMs'`, `'flow.errorHandling'` — never the enumeration or the count, exactly as part 1 measured for the rest of this family. `automation/sync-retirement.test.ts:152` asserts export **absence** of `ETL` and is unaffected. Nothing needed flipping.

## Why this PR adds no pin

Asked explicitly by the dispatch, so answering explicitly.

Nothing in this diff is runtime-observable. `flow.errorHandling` emits the tombstone by spreading `retryPolicyShape()`, so the only string a test can reach through `FlowSchema` is the very string **part 1 already pinned in both directions** in `shared/retry-policy.test.ts` (every live surface named / no retired surface named / prescription intact). A second assertion on that same string reached via `FlowSchema` would pin the spread, not the enumeration — and `flow.test.ts:1578` already pins the spread.

The remaining two sites are `//` comments. Pinning those means asserting source text. That idiom does exist in this package (`shared/expression-dialect-docs.pin.test.ts`, `ui/notification.test.ts`), so this is a choice and not an impossibility — but a general "a retirement updated some mentions and not others" detector is precisely the gate idea the PM split out as **#6635** and asked not to be re-bundled. A one-off `readFileSync` regex over `flow.zod.ts` would stake out that design in the wrong place.

Honest consequence, stated rather than dressed up: **reverse verification has no red direction here.** Restoring the old sentences turns nothing red, because no assertion reads comment text — which is not a gap this PR left, it is the measurement that motivates #6635.

## Changeset: none — the `skip-changeset` route

Deliberate, decided from what the diff contains. Part 1 carried `@objectstack/spec: patch` and justified it precisely: *"the tombstone guidance is author-visible, so it is a release-noted change rather than a docs-only one."* That justification does not transfer. Every byte here is a comment: it reaches no reference page (`check:docs` green), no `.d.ts` and no published type surface (`check:api-surface` green), no error message and no parse. There is nothing for a release note to tell a consumer.

Per the dispatch, the label is the PM's to apply at acceptance; this PR does not apply it.

## Verification

- `pnpm --filter @objectstack/spec test` — **345 files / 8844 tests passed** (8844 is main's count; part 1 adds the 8845th)
- `pnpm --filter @objectstack/spec typecheck` — green: `tsc --noEmit`, `check:scripts-typecheck`, `check:test-typecheck` (58 files / 267 errors held, ledger unchanged)
- `pnpm --filter @objectstack/spec check:generated` — **10/10 artifacts up to date**, nothing regenerated, nothing committed
- Every gate in the **ESLint** job, enumerated one by one from `.github/workflows/lint.yml` — **33/33 pass**, including `pnpm lint`, `check:nul-bytes`, `check:doc-authoring`, `check:docs-audit-scope`, `check:release-notes`, `check:engine-double-contract`, `check:route-envelope`, `check:error-code-casing`, `check:spec-parsed-alias`
- Byte discipline: `node scripts/check-nul-bytes.mjs` OK over 6258 tracked files, plus a direct `grep -naP` control-byte scan of the changed file — no hits

## Filed, not fixed

Filed as **#6750**: `content/docs/automation/flows.mdx:977` is a **hand-written** guide page (not generated — `content/docs/references/**` is the generated tree) that inherited the same sentence and still teaches an ETL pipeline's `retry` as a live surface, plus `content/docs/data-modeling/formulas.mdx:52`, which names both retired layers (`ETL`, `sync`) as `cron` consumers. #6630 explicitly scopes `content/docs/**` out as the docs seat's surface, so both are filed rather than slipped in here. A third hit, `content/docs/protocol/knowledge.mdx:49`, is the generic industry term and is not a defect.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk)_