### PR TITLE
test(driver-turso): drop the dead `as never` on date-bucket-parity's create options gate (#6394)

### DIFF
--- a/packages/drivers/driver-turso/src/date-bucket-parity.test.ts
+++ b/packages/drivers/driver-turso/src/date-bucket-parity.test.ts
@@ -65,7 +65,7 @@ describe('TursoDriver date-bucket parity (framework#3773)', () => {
         await driver.create(
           'bucket_storage_probe',
           { id: 'p1', at: new Date('2026-01-10T09:00:00Z') },
-          { bypassTenantAudit: true } as never,
+          { bypassTenantAudit: true },
         );
         const res: any = await driver.execute(
           `SELECT typeof("at") AS t FROM "bucket_storage_probe" WHERE id = 'p1'`,


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6394

## What changed

One cast, in `packages/drivers/driver-turso/src/date-bucket-parity.test.ts`:

```diff
         await driver.create(
           'bucket_storage_probe',
           { id: 'p1', at: new Date('2026-01-10T09:00:00Z') },
-          { bypassTenantAudit: true } as never,
+          { bypassTenantAudit: true },
         );
```

That is the entire diff — 1 file, +1/−1.

## Premise verified before implementing

- The cast **still exists** on current `origin/main`, located by pattern (`as never` in `date-bucket-parity.test.ts`), not by line number. It was the file's only remaining `as never`: #6354 already removed the ones on the `checkDateBucketParity(…)` stand-in call sites (lines 43–45 and 128–130 are cast-free on main).
- **No guard from #6399 conflicts with it.** #6399's resolution landed as the `check:verify-stand-in` gate in `lint.yml`; it passes green both before and after this change. It guards the stand-in call sites, not `driver.create`'s options parameter.
- `bypassTenantAudit` is a **declared** key, not a wild one — `packages/spec/src/data/driver.zod.ts:99`, on `DriverOptionsSchema`. Corroborating: the dogfood and turso parity tests both pass `createOptions: { bypassTenantAudit: true }` to `checkDateBucketParity` with no cast and always have.

## Evidence

Dependency closure built **before** typechecking (`pnpm --filter @objectstack/driver-turso... build`), so the verdict is not read off stale `dist/*.d.ts`. Re-run after merging `origin/main` @ `64d764e`.

```
> @objectstack/driver-turso@17.0.0-rc.5 typecheck
> tsc --noEmit
EXIT=0

> @objectstack/driver-turso@17.0.0-rc.5 test
> vitest run
Test Files  27 passed (27)
     Tests  836 passed (836)
EXIT=0
```

Zero output on typecheck, so the cast was dead: nothing depended on it.

I also confirmed the test file is genuinely in the compile graph rather than silently excluded — `driver-turso/tsconfig.json` has `"include": ["src/**/*"]`, and an unrelated `const x: number = "definitely-not-a-number"` appended to this same file does red:

```
src/date-bucket-parity.test.ts(137,7): error TS2322: Type 'string' is not assignable to type 'number'.
```

That control was reverted; it is not in the diff.

## Scope note — this restores no checking, and the issue's rationale on that point is wrong

The issue argues the cast's cost is that it "抹成 `never`，于是 options 里拼错的键、写错类型的值都不会红". I tried to measure that payoff and it does not exist at this gate. With the cast removed:

| Injected at the call site | `tsc` result |
|:--|:--|
| `{ bypassTenantAudditt: true }` (misspelled key) | **EXIT=0** — no error |
| `{ bypassTenantAudit: 'not-a-boolean' }` (wrong type) | **EXIT=0** — no error |

The reason: `TursoDriver` overrides `create` with `options?: any` (`packages/drivers/driver-turso/src/turso-driver.ts:523`), so the override — not `SqlDriver`'s `options?: DriverOptions` — is what resolves here. The parameter was already `any` before the cast ever applied.

The change is still correct and still worth landing: the cast reads as a needed escape hatch, and a future reader narrowing `TursoDriver`'s signatures would have to work out whether it was load-bearing. Removing dead noise is the honest description of the benefit — restoring type safety is not.

Filed rather than fixed here (out of scope, per the dispatch):
- **#6402** — I commented with a measurement correcting its inventory: the `options?: any` widening covers **16** overrides, not the 5 its table lists, and all 16 have a base declaring `DriverOptions`. `create` is among the 11 missing, which is precisely why this PR restores nothing.

## Same-shape scan of other drivers (read-only, per dispatch)

Filed as **#6754**, unassigned, not fixed here. 27 dead `{ bypassTenantAudit: true } as any` options-gate casts — 17 in `driver-sqlite-wasm`, 10 in `driver-sql`, across 12 files. Stripping all 27 leaves both packages at `EXIT=0`.

Those are the inverse trade to this PR: they sit on a **real typed gate** (`SqlDriver.create` declares `options?: DriverOptions` and `SqliteWasmDriver` does not override it), so removing them genuinely restores checking — measured by misspelling a key after the strip:

```
src/sql-driver-runtime-token-default.test.ts(111,73): error TS2561: Object literal may only
specify known properties, but 'bypassTenantAuditt' does not exist in type '{ transaction?:
unknown; … bypassTenantAudit?: boolean | undefined; }'. Did you mean to write 'bypassTenantAudit'?
```

All exploratory edits for that measurement were reverted; `git diff` against the commit is empty.

## Changeset

**None — this is a tests-only change.** No runtime or published surface is touched, so there is nothing for a changeset to describe. `skip-changeset` to be applied at acceptance.

## Gates

Enumerated from `.github/workflows/lint.yml`, every `check:*` step run one by one — **47 gates, all green** locally.

<details>
<summary>ESLint job — 33 gates</summary>

`pnpm lint`, then `check:` — `slot-lookup`, `query-options-erasure`, `verify-stand-in`, `nul-bytes`, `doc-authoring`, `docs-audit-scope`, `role-word`, `quick-reference-counts`, `adr-anchors`, `org-identifier`, `authz-resolver`, `service-providers`, `route-envelope`, `error-code-casing`, `wildcard-fallthrough`, `meta-type-normalized`, `init-service-contract`, `durability-log-level`, `startup-registry-verdict`, `objectui-changeset`, `release-notes`, `release-body`, `node-version`, `workflow-status-functions`, `shard-attestation`, `published-files`, `engine-double-contract`, `kernel-hook-pairs`, `resume-authority-declared`, `driver-memory-census`, `merge-driver`, `spec-parsed-alias`
</details>

<details>
<summary>TypeScript Type Check job — 14 gates</summary>

`check:type-check-coverage`, `check:driver-conformance`, `check:stall-guard`, `spec tsc --noEmit`, `spec check:generated --reconcile-only`, `spec check:skill-docs`, `spec check:spec-changes`, `spec check:upgrade-guide`, `spec check:authorable-surface`, `spec check:docs`, `spec check:skill-refs`, `check:skill-frame-sync`, `check:skill-compatibility`, `spec check:react-blocks`, `turbo build` (66 tasks), `turbo typecheck` (120 tasks), `turbo build packages/*/*`, `check:type-check-debt`, `examples typecheck`, `downstream-contract typecheck`, `spec check:api-surface`, `spec check:exported-any`, `spec check:dual-source-exports`, `spec check:skill-examples`, `lint check:doc-formula-expressions`, `check:i18n`, `check:i18n-coverage`, `check:app-nav-i18n`
</details>

`origin/main` @ `64d764e` merged in (PR #6706's `remote-transport.ts` / text-predicate work does not touch this file; the merge left `driver-turso`, `driver.zod.ts` and `verify` untouched). Suite re-run green after the merge.

## CI

Converged on `5e4e828` — **24 checks: 21 success, 2 skipped, 1 failure**.

The single red is **`Check Changeset`**, and it is the expected label gate, not a defect in this PR. Its log:

> `##[error]This PR adds no changeset. If it releases nothing …, apply the 'skip-changeset' label; otherwise run 'pnpm changeset' and name the packages.`

I confirmed from the job log that it failed on the changeset count, not on an unusable diff base. The gate offers exactly two routes, and an empty-frontmatter changeset is explicitly rejected as a third (#5471 / #4898). A tests-only change releases nothing, so the label is the correct route and fabricating a changeset would be the wrong one — **left for `skip-changeset` at acceptance.**

Everything else is green, including `ESLint`, `TypeScript Type Check`, `Test Core` (3 shards), `Build Core`, `Dogfood Regression Gate` (3 shards), `Dogfood Verify CLI`, and `Temporal Conformance (live PG + MySQL)`.