### PR TITLE
fix(spec): `position.delegatable` names only the enforcer that exists (#6628)

### DIFF
--- a/.changeset/position-delegatable-phantom-lint-rule.md
+++ b/.changeset/position-delegatable-phantom-lint-rule.md
@@ -1,0 +1,46 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): `position.delegatable` no longer names a lint rule that was never written (#6628)
+
+The JSDoc on the authorable `delegatable` key closed with
+
+> so a delegatable position must never distribute an `adminScope`-carrying set
+> (enforced by the `security-delegatable-admin-position` lint rule and the D12
+> gate).
+
+Only the second of those two enforcers exists. `security-delegatable-admin-position`
+occurred **exactly once in the repository** — in that sentence. The security-domain
+publish linter's rule table (`packages/lint/src/validate-security-posture.ts`) and its
+twelve exported rule-id constants are the authority, and no delegatable/admin-position
+rule is among them. The control that makes this a reading rather than a guess:
+ADR-0091's *other* author-time rules did land — `security-grant-expired-at-authoring`
+(D2) and `security-delegation-missing-reason` (D3, the same decision as `delegatable`)
+are both present and both exported — so the absence is specific to this one rule, not
+an artefact of the linter skipping ADR-0091.
+
+The invariant itself is real and is enforced: `plugin-security`'s delegated-admin gate
+implements the D12 containment check as step 6 of the self-service delegation path.
+What was false is **when** it holds. The sentence promised an *author-time* gate, so an
+author pairing `delegatable: true` with an `adminScope`-carrying permission set believed
+`os lint` would stop them before shipping. It does not — the package publishes clean and
+the mistake surfaces later, in a different package, as a runtime deny phrased as a fact
+about the position rather than as a fix for the authoring error.
+
+The JSDoc now names only the enforcer that exists and says plainly where it runs: the
+D12 gate refuses the delegation at the moment a holder attempts it, denying with the
+offending permission set named, so the failure an author will see is a delegation deny
+at first use rather than a lint error. It also points at the one author-time rule
+ADR-0091 D3 *does* have (`security-delegation-missing-reason`) and says what that one
+actually checks, so "no lint rule for this" cannot be misread as "this invariant is
+unenforced".
+
+This is text only — a comment inside `position.zod.ts`, which `packages/spec` publishes
+to npm via its `src/**/*.zod.ts` files entry, so the corrected prose reaches consumers
+and AI authors reading the installed schema source. **`PositionSchema` accepts exactly
+what it accepted before**; no key, default, or acceptance behaviour changed, and no
+generated artifact moved.
+
+Whether ADR-0091 D3 *should* grow an author-time rule for this combination is a separate
+product decision and is deliberately not made here.

--- a/packages/spec/src/identity/position-delegatable-enforcer.pin.test.ts
+++ b/packages/spec/src/identity/position-delegatable-enforcer.pin.test.ts
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#6628] The `delegatable` JSDoc may name a lint rule only if that rule exists.
+ *
+ * That JSDoc is an authoring surface, not a comment: it is the TSDoc an author
+ * (often an AI author, ADR-0033) hovers at the exact moment they type
+ * `delegatable:`. For a whole major it closed with
+ *
+ *   "(enforced by the `security-delegatable-admin-position` lint rule and the
+ *    D12 gate)"
+ *
+ * and the first of those two enforcers had never been written — the string
+ * occurred exactly once in the repository, in that sentence. The runtime half
+ * was real (`plugin-security`'s delegated-admin gate, step 6), so the invariant
+ * held; what was false was WHEN it holds. The sentence promised an author-time
+ * gate, so an author pairing `delegatable: true` with an `adminScope`-carrying
+ * set believed `os lint` would stop them. It does not: the package publishes
+ * clean and the mistake surfaces later, in a different package, as a runtime
+ * deny phrased as a fact about the position rather than as a fix for the
+ * authoring error.
+ *
+ * This is the `validate-security-posture.ts` header's own hazard one layer out.
+ * That file records how alias tolerance "silently downgraded a NAMED rejection
+ * into an inert branch — and an inert branch in a security linter reads, to the
+ * next author, as a gate that is watching (#4984, #5009, #5017)". A rule that is
+ * named but absent reads the same way, and is cheaper to write by accident:
+ * prose costs nothing to add and no compiler checks it.
+ *
+ * So the authority here is machine-readable, never a hand-copied list — the
+ * rule-id constants `packages/lint` actually exports, read off its `src/`
+ * directory the way `rule-id-barrel-exports.test.ts` (#5648) reads it. A gate
+ * name the rule table does not back turns this red.
+ *
+ * ⛔ Scope: the relation, not the wording. Rewording this JSDoc freely is fine —
+ * what it may not do is name a `security-*` rule that no rule file declares, or
+ * stop locating the containment check at runtime. The second half matters
+ * because "no author-time rule" is only safe to say next to "the D12 gate does
+ * enforce this, at delegation time"; drop that and the text overcorrects into
+ * implying the invariant is unenforced, which is the opposite lie.
+ *
+ * Deliberately NOT asserted: that no author-time rule exists. Whether ADR-0091
+ * D3 should grow one is a product decision (the finding left it open); if that
+ * rule is ever written, this pin stays green the moment the JSDoc names it,
+ * because the name will resolve against the same rule table.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+/** …/packages/spec/src/identity → repo root */
+const REPO_ROOT = resolve(HERE, '../../../..');
+const LINT_SRC = join(REPO_ROOT, 'packages', 'lint', 'src');
+const POSITION_SOURCE = join(HERE, 'position.zod.ts');
+
+/** `export const NAME = 'security-…';` — how every security rule id is declared. */
+const EXPORTED_SECURITY_RULE_ID = /^export const [A-Z][A-Z0-9_]* = '(security-[a-z0-9-]+)';\s*$/;
+
+/**
+ * Every `security-*` rule id `packages/lint` declares, found by reading its
+ * `src/` directory rather than by naming files. A new security rule in a new
+ * file is therefore authoritative the moment it exists — the property a
+ * hand-maintained list here would quietly lose.
+ */
+function declaredSecurityRuleIds(): Set<string> {
+  const ids = new Set<string>();
+  for (const file of readdirSync(LINT_SRC)) {
+    if (!file.endsWith('.ts') || file.endsWith('.test.ts')) continue;
+    for (const line of readFileSync(join(LINT_SRC, file), 'utf8').split('\n')) {
+      const m = EXPORTED_SECURITY_RULE_ID.exec(line);
+      if (m) ids.add(m[1]);
+    }
+  }
+  return ids;
+}
+
+/** The JSDoc block attached to the authorable `delegatable` key. */
+function delegatableDoc(): string {
+  const source = readFileSync(POSITION_SOURCE, 'utf8');
+  const key = source.indexOf('delegatable: z.boolean()');
+  expect(key, 'the `delegatable` key declaration moved — re-anchor this pin').toBeGreaterThan(-1);
+  const open = source.lastIndexOf('/**', key);
+  const close = source.indexOf('*/', open);
+  expect(open, 'no JSDoc block precedes `delegatable`').toBeGreaterThan(-1);
+  expect(close, 'unterminated JSDoc block').toBeLessThan(key);
+  return source.slice(open, close + 2);
+}
+
+/**
+ * The `security-*` rule ids a piece of prose names, minus the ones the rule
+ * table backs. Rule ids are matched by their backticked, multi-segment slug
+ * shape: `security-owd-alias` is a rule id, while the cloud product name
+ * `security-enterprise` (one segment, and never called a rule) is prose.
+ */
+function unbackedRuleIds(prose: string, backed: Set<string>): string[] {
+  const named = [...prose.matchAll(/`(security-[a-z0-9]+(?:-[a-z0-9]+)+)`/g)].map((m) => m[1]);
+  return [...new Set(named.filter((id) => !backed.has(id)))];
+}
+
+describe('`delegatable` JSDoc names only enforcers that exist (#6628)', () => {
+  it('reads a real rule table off `packages/lint`', () => {
+    const ids = declaredSecurityRuleIds();
+    // A floor, not an exact count — new security rules are expected. Its only
+    // job is to fail loudly if the extraction above stops finding anything,
+    // which would turn the self-test below vacuously green.
+    expect(ids.size).toBeGreaterThanOrEqual(12);
+    // The control the finding itself used: an ADR-0091 D3 author-time rule that
+    // DID land, proving the absence of the phantom was specific to that one
+    // rule and not an artefact of the linter skipping ADR-0091.
+    expect([...ids]).toContain('security-delegation-missing-reason');
+  });
+
+  it('would reject a gate name the rule table does not back (self-test)', () => {
+    // The historical sentence's shape, proving the predicate has teeth
+    // regardless of what the JSDoc currently says — without this, "no unbacked
+    // ids" below could pass simply because the prose stopped naming rules.
+    //
+    // The rule name here is deliberately SYNTHETIC rather than #6628's literal
+    // `security-delegatable-admin-position`. Whether ADR-0091 D3 should grow
+    // that author-time rule is an open product decision the finding declined to
+    // make; asserting its name is unbacked would quietly make this test the
+    // thing that breaks when someone implements it. What needs pinning is the
+    // predicate, not what any one unwritten rule would be called.
+    const before =
+      'so a delegatable position must never distribute an `adminScope`-carrying ' +
+      'set (enforced by the `security-no-such-rule-exists` lint rule and the D12 gate).';
+    expect(unbackedRuleIds(before, declaredSecurityRuleIds())).toEqual([
+      'security-no-such-rule-exists',
+    ]);
+  });
+
+  it('names no rule that `packages/lint` does not declare', () => {
+    expect(unbackedRuleIds(delegatableDoc(), declaredSecurityRuleIds())).toEqual([]);
+  });
+
+  it('still locates the D12 containment check at runtime', () => {
+    const doc = delegatableDoc();
+    // Both halves, together: the gate that does enforce it, and WHEN. Naming
+    // D12 without placing it at runtime is the sentence this pin was written
+    // for; placing it at runtime without naming D12 reads as unenforced.
+    expect(doc).toContain('D12');
+    expect(doc).toMatch(/runtime/i);
+  });
+});

--- a/packages/spec/src/identity/position.zod.ts
+++ b/packages/spec/src/identity/position.zod.ts
@@ -83,9 +83,19 @@ export const PositionSchema = lazySchema(() => strictObject(
    * positions (an approver going on leave) opt in; admin-ish positions do
    * NOT — delegating administration would bypass the D12 containment gate,
    * so a delegatable position must never distribute an `adminScope`-carrying
-   * set (enforced by the `security-delegatable-admin-position` lint rule and
-   * the D12 gate). A grant that itself arrived via delegation is not
-   * re-delegatable (chains are cut).
+   * set. A grant that itself arrived via delegation is not re-delegatable
+   * (chains are cut).
+   *
+   * That invariant IS enforced — but at RUNTIME, not at authoring time. The
+   * D12 containment gate (`plugin-security`'s delegated-admin gate, step 6 of
+   * the self-service delegation path) refuses the delegation the moment a
+   * holder attempts it, denying with the offending permission set named. No
+   * lint rule checks the combination, so a package pairing `delegatable: true`
+   * with an `adminScope`-carrying set publishes clean and `os lint` stays
+   * green: what you will see is a delegation deny at first use, not an
+   * author-time error. (The one author-time rule ADR-0091 D3 does have,
+   * `security-delegation-missing-reason`, checks something else — that a
+   * seeded delegation row carries its dual-audit reason.)
    */
   delegatable: z.boolean().default(false).describe(
     'ADR-0091 D3: holders may self-service delegate this position, time-boxed (default false).',


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6628

## What was wrong

The JSDoc on the authorable `delegatable` key closed with:

> so a delegatable position must never distribute an `adminScope`-carrying set
> (enforced by the `security-delegatable-admin-position` lint rule and the D12 gate).

The parenthetical names **two** enforcers. Only the second one exists.

**Premise re-verified on `origin/main` @ `61282f906`** (the card was last re-anchored at `e0f300ba5`):

- `security-delegatable-admin-position` occurs **exactly once** in the repository — in that sentence (`git grep -c` over `origin/main` returns `packages/spec/src/identity/position.zod.ts:1`, and no other file).
- The authority is `packages/lint/src/validate-security-posture.ts` — its rule table (`:9-21`) and the twelve exported rule-id constants beside it (`:59-70`). No delegatable/admin-position rule is among them.
- The control that makes this a reading rather than a guess: ADR-0091's *other* author-time rules **did** land — `security-grant-expired-at-authoring` (D2) and `security-delegation-missing-reason` (D3, the same decision as `delegatable`) are both present and both exported. The absence is specific to this one rule, not an artefact of the linter skipping ADR-0091.
- The runtime half is real: `packages/plugins/plugin-security/src/delegated-admin-gate.ts:537-543` implements the D12 containment check as step 6 of the self-service delegation path, denying with the offending permission set named.

So the invariant **holds**. What was false is **when** it holds. The sentence promised an *author-time* gate, so an author marking a position `delegatable: true` while it distributes an `adminScope`-carrying set believed `os lint` would stop them before shipping. It does not: the package publishes clean, and the mistake surfaces later, in a different package, as a runtime deny phrased as a fact about the position rather than as a fix for the authoring error.

That is the `validate-security-posture.ts` header's own hazard one layer out. It records how alias tolerance "silently downgraded a NAMED rejection into an inert branch — and an inert branch in a security linter reads, to the next author, as a gate that is watching (#4984, #5009, #5017)". A rule that is *named but absent* reads the same way, and is cheaper to write by accident: prose costs nothing to add and no compiler checks it.

## The fix — text only

Per the direction ruling on the card, this corrects the text to name only the enforcer that exists; it deliberately does **not** write the missing lint rule. Whether ADR-0091 D3 should grow an author-time rule is a product decision the finding explicitly declined to make, and it stays open.

The corrected JSDoc keeps three properties the card asked for:

1. **the invariant is real and enforced** — "That invariant IS enforced";
2. **enforcement is at delegation time, not publish time** — the D12 gate "refuses the delegation the moment a holder attempts it";
3. **the failure the author will actually see is a deny, not a lint error** — stated in those words.

It also points at the one author-time rule ADR-0091 D3 *does* have (`security-delegation-missing-reason`) and says what that one actually checks (a seeded delegation row carries its dual-audit reason), so "no lint rule for this combination" cannot be misread as "this invariant is unenforced" — the opposite lie.

**Zero acceptance-surface bytes.** Every changed line in `position.zod.ts` is inside the JSDoc block — mechanically confirmed by filtering the diff to non-comment lines, which returns nothing. `PositionSchema` accepts exactly what it accepted before.

## The pin

`packages/spec/src/identity/position-delegatable-enforcer.pin.test.ts`, modelled on `expression-dialect-docs.pin.test.ts` (#6085) — the repo's existing "TSDoc prose versus a machine-readable authority" pin shape.

No pin asserted the phantom name or the parenthetical (swept: the name's single occurrence *was* the defect), so this adds one. The authority is never a hand-copied list: it reads the `security-*` rule-id constants off `packages/lint/src/` the way `rule-id-barrel-exports.test.ts` (#5648) reads that directory, so a security rule added in a new file counts the moment it exists. Four cases:

- the rule table is real (floor of 12 ids, and contains the `security-delegation-missing-reason` control the finding used);
- **self-test** — the historical sentence's *shape* with a deliberately synthetic rule name is reported as unbacked, proving the predicate has teeth regardless of what the prose currently says;
- the live JSDoc names no rule `packages/lint` does not declare;
- the JSDoc still locates the D12 check at runtime (both halves: naming D12 without placing it at runtime is the sentence this pin exists for; placing it at runtime without naming D12 reads as unenforced).

Two deliberate choices, both documented in the file:

- The self-test uses a **synthetic** name rather than the literal `security-delegatable-admin-position`. Asserting that specific name is unbacked would quietly make this test the thing that breaks the day someone implements the rule — the open product decision. What needs pinning is the predicate, not what an unwritten rule would be called.
- The rule-id slug pattern requires a **multi-segment** slug, which is what separates a rule id from prose: the cloud product name `security-enterprise` appears backticked in two spec files and is not a rule.

**Scope kept narrow, deliberately.** A repo-wide sweep was measured rather than assumed: the prose construct "backticked slug + `lint rule`" has **exactly one** instance repo-wide, and this PR removes it. A new repo-wide gate would therefore guard a class with zero remaining instances, at the cost of a CI step and a false-positive surface over other agents' in-flight prose. The narrow pin on the actual surface is the better trade; if the class ever recurs elsewhere, the generalisation is a separate card.

### Reverse verification — direction predicted before running

Predicted **red**, and specifically **2 of 4** cases: restoring the original sentence should fail the unbacked-rule-id assertion (the phantom is not in lint's exported set) and the runtime-location assertion (the old block says "D12" but never "runtime"), while the rule-table floor and the self-test are independent of the file and must stay green.

Measured, after `git checkout origin/main -- packages/spec/src/identity/position.zod.ts`:

```
Tests  2 failed | 2 passed (4)

FAIL  ... > names no rule that `packages/lint` does not declare
AssertionError: expected [ Array(1) ] to deeply equal []
- []
+ [ "security-delegatable-admin-position" ]

FAIL  ... > still locates the D12 containment check at runtime
AssertionError: expected '/**\n   * [ADR-0091 D3] Delegation of…' to match /runtime/i
```

Exactly as predicted, including which two.

## Mechanism assumptions — one confirmed, one falsified

**Falsified: no regeneration was needed.** The dispatch expected an authorable key's JSDoc to reach the generated reference page, making some regen plausible. Measured, it does not. `content/docs/references/identity/position.mdx:67` carries the `.describe()` string only — which this PR does not touch — and the JSDoc block reaches neither the `.d.ts` nor the runtime `.js`, only the sourcemaps. After a full `pnpm --filter @objectstack/spec build`, `check:generated` reports all ten artifacts up to date with nothing to regenerate. (Same "cuts both ways" shape as part 1 of #6630 / PR #6701.)

**Confirmed: the changeset is right, though for a different reason than hover.** `packages/spec`'s published `files` includes `"src/**/*.zod.ts"`, so `position.zod.ts` itself ships to npm — the corrected prose reaches consumers and AI authors reading the installed schema source. That is a published author surface, so `@objectstack/spec: patch`. No `skip-changeset` route is needed here.

## Verification

All run in this worktree off `origin/main` @ `61282f906`:

| Check | Result |
|---|---|
| `pnpm --filter @objectstack/spec test` | **346 files / 8848 tests passed** |
| `pnpm --filter @objectstack/spec typecheck` | pass (`tsc --noEmit` + `check:scripts-typecheck` + `check:test-typecheck`; the new pin compiles clean, no debt-ledger entry) |
| `pnpm --filter @objectstack/spec check:generated` | **all 10 artifacts up to date**, no regeneration |
| `pnpm lint` (the required ESLint job) | exit 0 |
| `pnpm check:nul-bytes` | OK — 6258 tracked files, no raw control bytes |
| `check:adr-anchors` / `check:role-word` / `check:doc-authoring` / `check:published-files` / `check:spec-parsed-alias` / `check:quick-reference-counts` | pass |

Byte discipline: the diff was self-scanned beyond the gate with `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` on both changed files — clean.

`content/docs/releases/` untouched.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk


---
_Generated by [Claude Code](https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk)_