### PR TITLE
fix(metadata-protocol): revertCommit's soft-remove limb states its write intent per item, so a commit that CREATED an object can be reverted

### DIFF
--- a/.changeset/revert-commit-soft-remove-intent.md
+++ b/.changeset/revert-commit-soft-remove-intent.md
@@ -1,0 +1,48 @@
+---
+'@objectstack/metadata-protocol': patch
+---
+
+fix(metadata-protocol): `revertCommit`'s soft-remove limb states its write intent per item, so a commit that CREATED an object can be reverted (#6620)
+
+`ObjectStackProtocolImplementation.revertCommit` has two limbs. #6563 (PR #6642)
+fixed the one that RESTORES an edited artifact, where the intent was unstated and
+fell through to `restoreVersion`'s `?? 'override-artifact'` default. The other
+limb — an artifact the commit CREATED, which the revert soft-removes — stated the
+same intent as a literal constant:
+
+```
+intent: 'override-artifact',
+```
+
+`SysMetadataRepository.delete` opens with `this.assertAllowed(ref.type, opts.intent)`,
+the same gate `put` uses, and it refuses every type whose registry entry is not
+`allowOrgOverride`. `object` is exactly such a type, so every created object of a
+reverted commit came back in `failed[]`:
+
+```
+[NOT_OVERRIDABLE] 'object' is not allowOrgOverride in the registry.
+Overlay-allowed: view, page, dashboard, app, action, report, dataset, ...
+```
+
+This is the FIRST-BUILD undo — the Studio / AI flow that publishes a brand-new app
+and then undoes it. Every object the commit created stayed behind, the call
+answered `success: false` with a populated `failed[]`, and the package was left
+half-reverted: its overlay-allowed items removed, its objects not.
+`rollbackToPackageCommit` reverts through the same loop and inherited it, and
+there the symptom was quieter still — a per-item refusal never throws, so the
+rollback recorded the commit as reverted and answered `success: true` while the
+created object was untouched.
+
+The limb now derives the intent from the artifact the way the sibling DELETE
+caller `deleteMetaItem` already does — `isArtifactBacked` gives
+`'override-artifact'`, otherwise `'runtime-only'` — and does it **per item**,
+because one first-build commit routinely creates a runtime object beside a
+packaged-artifact name. All three delete/revert callers (`deleteMetaItem`,
+`rollbackMetaItem`, both `revertCommit` limbs) now derive the same fact the same
+way.
+
+The repository's gate is deliberately unchanged: it is right for callers that
+genuinely mean "override a packaged artifact", and the defect was this caller
+never saying which of the two cases each item is. An object a code package really
+ships still resolves to `'override-artifact'` and is still refused with
+`NOT_OVERRIDABLE`, which is pinned alongside the fix.

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -10205,12 +10205,46 @@ export class ObjectStackProtocolImplementation implements
                 const current = await repo.get(ref, { state: 'active' });
                 if (!it.existedBefore) {
                     // Created by this commit → soft-remove (metadata only; table stays).
+                    //
+                    // [#6620] The write INTENT is derived per item, exactly as
+                    // the sibling DELETE caller {@link deleteMetaItem} derives
+                    // it (and as the sibling revert caller
+                    // {@link rollbackMetaItem} derives its own) — all three now
+                    // agree. Stated as the CONSTANT `'override-artifact'` this
+                    // limb used to carry, `SysMetadataRepository.delete` opened
+                    // with `assertAllowed(ref.type, opts.intent)` — the same
+                    // gate `put` uses — which refuses every type that is not
+                    // `allowOrgOverride`, `object` among them. So a commit that
+                    // CREATED an object could not be reverted at all: the
+                    // first-build undo (publish a brand-new app, then undo it)
+                    // left every created object behind, answered `success:
+                    // false` with a populated `failed[]`, and left the package
+                    // half-reverted — its overlay-allowed items removed, its
+                    // objects not.
+                    //
+                    // Per ITEM, not per call: one first-build commit routinely
+                    // creates a runtime object beside a packaged-artifact name,
+                    // so a hoisted intent has to pick one and be wrong about
+                    // the other. A genuinely artifact-backed item still
+                    // resolves to `'override-artifact'` and is still refused
+                    // with `NOT_OVERRIDABLE` — the derivation states the
+                    // caller's case, it does not widen the repository's gate,
+                    // which is unchanged and right.
+                    //
+                    // Sibling limb: #6563 (PR #6642) did the same for the
+                    // restore branch below, where the intent was UNSTATED and
+                    // fell through to `restoreVersion`'s `?? 'override-artifact'`
+                    // default. Still not addressed here, filed with its own
+                    // measurement: neither limb refreshes the SchemaRegistry the
+                    // way `rollbackMetaItem` does (#6621).
+                    const intent: 'override-artifact' | 'runtime-only' =
+                        this.isArtifactBacked(it.type, it.name) ? 'override-artifact' : 'runtime-only';
                     if (current) {
                         await repo.delete(ref, {
                             parentVersion: current.hash,
                             actor,
                             source: 'protocol.revertCommit',
-                            intent: 'override-artifact',
+                            intent,
                             state: 'active',
                         });
                     }
@@ -10236,12 +10270,12 @@ export class ObjectStackProtocolImplementation implements
                     // resolves to `'override-artifact'` and is still refused — the
                     // derivation states the case, it does not widen the gate.
                     //
-                    // Two neighbours are deliberately NOT changed here, each filed
-                    // with its own measurement: the soft-remove limb above states the
-                    // same intent as a CONSTANT, so a commit that CREATED an object
-                    // still cannot be reverted (#6620); and neither limb refreshes the
-                    // SchemaRegistry the way `rollbackMetaItem` does, so a restored
-                    // body is persisted but not yet dispatched on (#6621).
+                    // The soft-remove limb above stated the same intent as a
+                    // CONSTANT and was fixed the same way (#6620), so both limbs now
+                    // derive it. One neighbour is still open, filed with its own
+                    // measurement: neither limb refreshes the SchemaRegistry the way
+                    // `rollbackMetaItem` does, so a restored body is persisted but not
+                    // yet dispatched on (#6621).
                     const intent: 'override-artifact' | 'runtime-only' =
                         this.isArtifactBacked(it.type, it.name) ? 'override-artifact' : 'runtime-only';
                     await repo.restoreVersion(ref, it.prevVersion, {

--- a/packages/objectql/src/protocol-commit-history.test.ts
+++ b/packages/objectql/src/protocol-commit-history.test.ts
@@ -632,3 +632,222 @@ describe('#6563 — rollbackToPackageCommit inherits the per-item intent', () =>
     expect(fields).not.toContain('due_date');
   });
 });
+
+/**
+ * #6620 — the OTHER limb of the same loop: SOFT-REMOVE states its intent too.
+ *
+ * `revertCommit` has two limbs, and #6563 (above) only fixed the restore one.
+ * The limb that undoes an artifact the commit CREATED stated its intent as a
+ * CONSTANT — `intent: 'override-artifact'`, written into the `repo.delete(...)`
+ * call — and `SysMetadataRepository.delete` opens with the same
+ * `assertAllowed(ref.type, opts.intent)` gate `put` uses. So `object`, which is
+ * not `allowOrgOverride`, was refused on the delete path exactly as it had been
+ * on the restore path, and a commit that CREATED an object could not be
+ * reverted either.
+ *
+ * That is the FIRST-BUILD undo — publish a brand-new app, then undo it — which
+ * is the flow Studio and AI authoring produce most. Every object the commit
+ * created stayed behind, `success` came back `false` with a populated
+ * `failed[]`, and the package was left half-reverted: its overlay-allowed items
+ * removed, its objects not.
+ *
+ * The two causes are different even though the symptom rhymes: #6563 was an
+ * UNSTATED intent falling through to the repository's `?? 'override-artifact'`
+ * default, this one is a literal the caller wrote down. The fix is the same
+ * family shape — derive it per item from `isArtifactBacked`, the way the
+ * sibling delete caller `deleteMetaItem` and the sibling revert caller
+ * `rollbackMetaItem` both already do — so all three delete/revert callers now
+ * agree, and the repository's gate is untouched.
+ */
+
+/** The commit item shape for an artifact this commit CREATED (ADR-0067). */
+const createdItem = (name: string) => ({
+  type: 'object', name, existedBefore: false, prevVersion: null,
+});
+
+/** The first-build shape: authored ONCE, never edited — nothing to restore to. */
+async function seedCreatedObject(protocol: any, name: string, packageId?: string) {
+  await protocol.saveMetaItem({
+    type: 'object', name, ...(packageId ? { packageId } : {}), item: invoiceBody(name),
+  });
+}
+
+const storedRows = (rows: Map<string, any>, name: string) =>
+  Array.from(rows.values()).filter((r) => r.name === name);
+
+describe('#6620 — revertCommit soft-removes a runtime-CREATED `object`', () => {
+  it('a package-bound created object reverts: revertedCount 1, failed [], row gone', async () => {
+    const { protocol, rows, historyRows } = makeRealRepoHarness([objectCommit({
+      id: 'cmt_new',
+      items: [createdItem('myapp_invoice')],
+    })]);
+    await seedCreatedObject(protocol, 'myapp_invoice', APP_PKG);
+    expect(storedRows(rows, 'myapp_invoice')).toHaveLength(1);
+
+    const res = await protocol.revertCommit({ commitId: 'cmt_new' });
+
+    // Pre-fix, verbatim (the issue's measurement): success false, revertedCount
+    // 0, failedCount 1 carrying "[NOT_OVERRIDABLE] 'object' is not
+    // allowOrgOverride in the registry.", and the row still standing.
+    expect(res.failed).toEqual([]);
+    expect(res.success).toBe(true);
+    expect(res.revertedCount).toBe(1);
+    expect(res.reverted[0]).toMatchObject({ type: 'object', name: 'myapp_invoice', action: 'removed' });
+    expect(storedRows(rows, 'myapp_invoice')).toHaveLength(0);
+    // Soft, not hard: ADR-0067 §5 keeps the removal recoverable, so the delete
+    // is an append-only tombstone in history rather than a vanished lineage.
+    const tombstone = historyRows.filter(
+      (h) => h.name === 'myapp_invoice' && h.operation_type === 'delete',
+    );
+    expect(tombstone).toHaveLength(1);
+    expect(tombstone[0].metadata).toBeNull();
+  });
+
+  it('a package-LESS created object reverts identically — the binding was never the cause', async () => {
+    const { protocol, rows } = makeRealRepoHarness([objectCommit({
+      id: 'cmt_new_global',
+      package_id: null,
+      items: [createdItem('global_invoice')],
+    })]);
+    await seedCreatedObject(protocol, 'global_invoice');
+
+    const res = await protocol.revertCommit({ commitId: 'cmt_new_global' });
+
+    expect(res.failed).toEqual([]);
+    expect(res.revertedCount).toBe(1);
+    expect(storedRows(rows, 'global_invoice')).toHaveLength(0);
+  });
+
+  /**
+   * The refusal that must SURVIVE the fix — and the one case the constant got
+   * right by accident, which is why its direction is INVERTED: it was green
+   * before the change and is green after. It cannot go red by removing the fix,
+   * because removing the fix refuses EVERYTHING. What it does go red on is the
+   * wrong fix — hard-coding `'runtime-only'` in place of the old
+   * `'override-artifact'` — which is the mistake a one-line "just make objects
+   * work" edit would make, and which would let a revert tombstone an artifact a
+   * code package genuinely ships.
+   *
+   * Staged the way a real deployment stages it (as in #6563's block): the
+   * overlay row is authored while the name is runtime-only, and the artifact
+   * arrives with the package that later claims it. `registerObject(body, pkg)`
+   * with no `_provenance` is the shape `applyProtection` stamps as `'package'`,
+   * which is what `getArtifactItem` reads and `isArtifactBacked` answers on.
+   *
+   * Envelope note (ADR-0112): `revertCommit` converts a per-item throw into a
+   * `failed[]` record whose DECLARED shape is `{ type, name, error, code? }` —
+   * no `status`. So `code` is asserted here together with the condition's own
+   * first sentence, and the full `{ code, status }` pair belongs to the
+   * throwing surface (`protocol-writepath-object-ownership.test.ts`), exactly
+   * as #6563 split it.
+   */
+  it('still REFUSES soft-removing an artifact-backed object: NOT_OVERRIDABLE, row kept', async () => {
+    const { protocol, registry, rows } = makeRealRepoHarness([objectCommit({
+      id: 'cmt_new_artifact',
+      items: [createdItem('myapp_invoice')],
+    })]);
+    await seedCreatedObject(protocol, 'myapp_invoice', APP_PKG);
+    registry.registerObject(invoiceBody('myapp_invoice') as never, APP_PKG);
+
+    const res = await protocol.revertCommit({ commitId: 'cmt_new_artifact' });
+
+    expect(res.revertedCount).toBe(0);
+    expect(res.failedCount).toBe(1);
+    expect(res.failed[0]).toMatchObject({
+      type: 'object',
+      name: 'myapp_invoice',
+      code: 'NOT_OVERRIDABLE',
+    });
+    expect(res.failed[0].error).toContain(
+      `[NOT_OVERRIDABLE] 'object' is not allowOrgOverride in the registry.`,
+    );
+    // Refused means refused: the artifact-backed row is still there.
+    expect(storedRows(rows, 'myapp_invoice')).toHaveLength(1);
+  });
+
+  /**
+   * PER ITEM, not per call — the half a single-item fixture cannot see, on the
+   * soft-remove limb this time. One commit, two created objects, opposite
+   * verdicts: a loop that hoisted one intent for the batch (which is precisely
+   * what the constant did) has to pick one and be wrong about the other.
+   */
+  it('derives the intent PER ITEM: one created object removed, its artifact-backed neighbour refused', async () => {
+    const { protocol, registry, rows } = makeRealRepoHarness([objectCommit({
+      id: 'cmt_new_mixed',
+      items: [createdItem('myapp_invoice'), createdItem('myapp_quote')],
+    })]);
+    await seedCreatedObject(protocol, 'myapp_invoice', APP_PKG);
+    await seedCreatedObject(protocol, 'myapp_quote', APP_PKG);
+    // Only the quote is claimed by a code artifact.
+    registry.registerObject(invoiceBody('myapp_quote') as never, APP_PKG);
+
+    const res = await protocol.revertCommit({ commitId: 'cmt_new_mixed' });
+
+    expect(res.reverted).toEqual([
+      { type: 'object', name: 'myapp_invoice', action: 'removed' },
+    ]);
+    expect(res.failed).toHaveLength(1);
+    expect(res.failed[0]).toMatchObject({ name: 'myapp_quote', code: 'NOT_OVERRIDABLE' });
+    expect(storedRows(rows, 'myapp_invoice')).toHaveLength(0);
+    expect(storedRows(rows, 'myapp_quote')).toHaveLength(1);
+  });
+
+  /**
+   * A commit that created BOTH an overlay-allowed item and an object is the
+   * half-reverted package the issue describes: pre-fix the view came out and
+   * the object stayed, so `success` was `false` and the package sat in a state
+   * neither before nor after the commit.
+   */
+  it('reverts a mixed-TYPE first build whole: the view and the object both come out', async () => {
+    const { protocol, rows } = makeRealRepoHarness([objectCommit({
+      id: 'cmt_new_build',
+      items: [
+        createdItem('myapp_invoice'),
+        { type: 'view', name: 'myapp_case_grid', existedBefore: false, prevVersion: null },
+      ],
+    })]);
+    await seedCreatedObject(protocol, 'myapp_invoice', APP_PKG);
+    await protocol.saveMetaItem({
+      type: 'view', name: 'myapp_case_grid', packageId: APP_PKG, item: gridBody('Cases'),
+    });
+
+    const res = await protocol.revertCommit({ commitId: 'cmt_new_build' });
+
+    expect(res.failed).toEqual([]);
+    expect(res.success).toBe(true);
+    expect(res.revertedCount).toBe(2);
+    expect(storedRows(rows, 'myapp_invoice')).toHaveLength(0);
+    expect(storedRows(rows, 'myapp_case_grid')).toHaveLength(0);
+  });
+});
+
+/**
+ * #6620 — the inheritance, on the soft-remove limb. `rollbackToPackageCommit`
+ * reverts through the SAME loop, so it carried the same constant.
+ *
+ * As in #6563's inheritance pin, the status cannot show the defect:
+ * `revertCommit` turns a per-item refusal into `failed[]` instead of throwing,
+ * so the rollback recorded the commit as reverted and answered `success: true`
+ * while the created object was never removed. The line that goes red pre-fix is
+ * the STORED ROW.
+ */
+describe('#6620 — rollbackToPackageCommit inherits the per-item soft-remove intent', () => {
+  it('rolls a first build back through the loop — and the created row really went away', async () => {
+    const { protocol, rows } = makeRealRepoHarness([
+      objectCommit({ id: 'cmt_base', items: [], created_at: '2026-08-08T00:00:01.000Z' }),
+      objectCommit({
+        id: 'cmt_build',
+        items: [createdItem('myapp_invoice')],
+        created_at: '2026-08-08T00:00:02.000Z',
+      }),
+    ]);
+    await seedCreatedObject(protocol, 'myapp_invoice', APP_PKG);
+
+    const res = await protocol.rollbackToPackageCommit({ commitId: 'cmt_base' });
+
+    expect(res.revertedCommits).toEqual(['cmt_build']);
+    expect(res.failed).toEqual([]);
+    // `success: true` was ALREADY true pre-fix — this is the line that was not.
+    expect(storedRows(rows, 'myapp_invoice')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6620

## What was wrong

`ObjectStackProtocolImplementation.revertCommit` has two limbs. PR #6642 (#6563) fixed the one that RESTORES an edited artifact, where the intent was **unstated** and fell through to `restoreVersion`'s `?? 'override-artifact'` default. The other limb — an artifact the commit **CREATED**, which the revert soft-removes — stated the same intent as a literal **constant**:

```ts
await repo.delete(ref, {
    parentVersion: current.hash,
    actor,
    source: 'protocol.revertCommit',
    intent: 'override-artifact',   // <- a constant, not a derivation
    state: 'active',
});
```

`SysMetadataRepository.delete` opens with `this.assertAllowed(ref.type, opts.intent)` — the same gate `put` uses — which refuses every type whose registry entry is not `allowOrgOverride`. `object` is exactly such a type, so a commit that created an object could not be reverted at all:

```
[NOT_OVERRIDABLE] 'object' is not allowOrgOverride in the registry.
Overlay-allowed: view, page, dashboard, app, action, report, dataset, translation,
email_template, book, permission, position, tool, skill.
```

This is the **first-build undo** — the Studio / AI flow that publishes a brand-new app and then undoes it. Every object the commit created stayed behind, the call answered `success: false` with a populated `failed[]`, and the package was left half-reverted: its overlay-allowed items removed, its objects not. `rollbackToPackageCommit` reverts through the same loop and inherited it, and there the symptom was quieter still — a per-item refusal never throws, so the rollback recorded the commit as reverted and answered `success: true` while the created object was untouched.

Two different causes, one rhyming symptom: #6563 was an unstated intent, #6620 is a literal the caller wrote down.

## The fix

The limb derives the intent **per item** from `isArtifactBacked`, the way the sibling callers already do. The repository's gate and default are untouched.

## Premise check 2 — which delete caller was mirrored, and why

The issue asked that `deleteMetaItem`'s derivation be read first so the two delete callers agree. Read on the merge base:

| caller | line | derivation |
|:--|:--|:--|
| `deleteMetaItem` | `protocol.ts:10716` | `artifactBacked ? 'override-artifact' : 'runtime-only'` (on `singularTypeForRepo`) |
| `rollbackMetaItem` | `protocol.ts:10395` | `artifactBacked ? 'override-artifact' : 'runtime-only'` (on `singularType`) |
| `revertCommit` restore limb (#6642) | `protocol.ts:10245` | `this.isArtifactBacked(it.type, it.name) ? … : 'runtime-only'` |

The two delete callers already agreed with each other and with the restore limb — there was nothing to reconcile, so mirroring is unambiguous. The one deliberate difference from `deleteMetaItem` is the type spelling: `deleteMetaItem` folds through `canonicalizeMetaRequestType` / `PLURAL_TO_SINGULAR` because it takes a caller-supplied `request.type` (#4432), while `revertCommit` reads `it.type` off a stored commit item and already uses that same raw `it.type` to build `ref`. Introducing a second spelling for one of the two facts inside one loop iteration would be the actual hazard, so this follows the region's existing convention (identical to #6642's restore limb). Canonicalizing the whole loop is a separate question and is **not** in this PR's ruled file surface.

Also updated: the note #6642 left in the restore limb saying the soft-remove limb "still cannot be reverted (#6620)". That sentence is now false, so it is rewritten rather than left to mislead the next reader; the still-open #6621 half of that note is kept verbatim.

## Tests

Extended `packages/objectql/src/protocol-commit-history.test.ts` in place (the #6215 / #6642 pin suite, same harness, same real `SysMetadataRepository` over the in-memory `sys_metadata` / `sys_metadata_history` / `sys_metadata_commit` double). Six new cases:

1. a package-bound **created** object reverts — `revertedCount 1`, `failed []`, row gone, and an append-only `operation_type: 'delete'` tombstone with `metadata: null` (ADR-0067 §5: soft, recoverable, not a vanished lineage)
2. a package-**less** created object reverts identically — the binding was never the cause
3. an **artifact-backed** created item is STILL refused: `code: 'NOT_OVERRIDABLE'` plus the condition's own first sentence, row kept
4. **per item**, not per call: one commit, two created objects, opposite verdicts
5. a mixed-**type** first build (created object + created view) reverts whole — the half-reverted package the issue describes
6. `rollbackToPackageCommit` inherits it through the same loop

Envelope split follows #6642: `revertCommit` converts a per-item throw into a `failed[]` record whose declared shape is `{ type, name, error, code? }` with **no** `status`, so `code` + the message's first sentence are asserted here, and the full `{ code, status }` pair belongs to the throwing surface.

### Reverse verification — and one honest inversion

Directions were predicted before running, and one of them is **not** before-green/after-red. Reporting it as measured rather than forcing the template:

| pin | old constant `'override-artifact'` | wrong fix: constant `'runtime-only'` | this PR |
|:--|:--|:--|:--|
| 1, 2, 4, 5, 6 | **RED** | green | green |
| 3 (artifact-backed refusal) | **green** | **RED** | green |

Pin 3 **cannot** go red by removing the fix, because removing the fix refuses *everything* — the constant was accidentally right for exactly this one case. Its real red direction is the *wrong* fix, i.e. the one-line "just make objects work" edit that swaps one constant for the other and would let a revert tombstone an artifact a code package genuinely ships. Both directions were run: 5 red / 18 pass on the old constant, 2 red / 21 pass on the inverted constant, 23/23 only on the per-item derivation. A pin that reads as coverage but cannot go red in any direction would not be coverage; this one goes red in the direction that actually threatens it.

### Commands

```
pnpm --filter @objectstack/metadata-protocol --filter @objectstack/objectql test
  metadata-protocol   Test Files  60 passed (60)    Tests   671 passed (671)
  objectql            Test Files 149 passed (149)   Tests  2557 passed (2557)

pnpm --filter @objectstack/objectql typecheck   -> tsc --noEmit, clean
  (@objectstack/metadata-protocol has no `typecheck` script; it is a measured
   ledger entry, and `pnpm check:type-check-coverage` passes unchanged)

pnpm lint  -> clean
```

Every `check:*` enumerated from `.github/workflows/lint.yml`'s ESLint job was run one by one, all pass: `slot-lookup`, `query-options-erasure`, `verify-stand-in`, `nul-bytes`, `doc-authoring`, `docs-audit-scope`, `role-word`, `quick-reference-counts`, `adr-anchors`, `org-identifier`, `authz-resolver`, `service-providers`, `route-envelope`, `error-code-casing`, `wildcard-fallthrough`, `meta-type-normalized`, `init-service-contract`, `durability-log-level`, `startup-registry-verdict`, `objectui-changeset`, `release-notes`, `release-body`, `node-version`, `workflow-status-functions`, `shard-attestation`, `published-files`, `engine-double-contract`, `kernel-hook-pairs`, `resume-authority-declared`, `driver-memory-census`, `merge-driver`, `spec-parsed-alias`. Plus from the type-check job: `type-check-coverage`, `driver-conformance`, `stall-guard`, `skill-frame-sync`, `skill-compatibility`, and spec `check:generated --reconcile-only`.

`origin/main` moved 12 commits during the work (including #6708 / #6709 on other regions of this same file); merged clean, reinstalled, rebuilt, and the numbers above are the post-merge run.

No new fake engine was added — the harness reuses the existing double, which already routes both write verbs through `assertEngineDeleteDispatch` / `assertEngineUpdateDispatch`.

## Scope

`packages/metadata-protocol/src/protocol.ts` (`revertCommit` soft-remove limb only) + `packages/objectql/src/protocol-commit-history.test.ts` + one changeset. #6621 (registry refresh after revert) targets the same region and was deliberately not absorbed.

---

## 中文摘要

`revertCommit` 的两条支路里，#6642 修好了「恢复被编辑的产物」那条；另一条——「软删除本次 commit 新建的产物」——把写入 intent 写成了常量 `'override-artifact'`。仓库层 `delete` 开头就是 `assertAllowed(ref.type, opts.intent)`，会拒绝一切非 `allowOrgOverride` 的类型，`object` 正是其一，于是**新建了对象的 commit 根本无法回滚**：这正是「发布一个全新应用再撤销」的首次构建撤销路径，对象全部留在原地，`success: false`，包处于半回滚状态；`rollbackToPackageCommit` 走同一循环，症状更隐蔽——它照样返回 `success: true`。

现在按**每一项**从 `isArtifactBacked` 推导 intent，与 `deleteMetaItem`、`rollbackMetaItem` 以及 #6642 的恢复支路完全一致（三处调用方口径统一）。仓库层的 gate 一行未改：真正由代码包提供的产物仍然解析为 `'override-artifact'`，仍然被 `NOT_OVERRIDABLE` 拒绝，这一条也一并钉住。

反向验证有一条方向是**反的**，如实记录而非套模板：artifact-backed 拒绝那条用例修前修后都绿——因为修改前是「全都拒绝」，它恰好被常量蒙对了；它真正会变红的方向是**错误的修法**（把常量换成 `'runtime-only'`）。两个方向都实测过：旧常量 5 红，反向常量 2 红，只有 per-item 推导 23/23 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6bLax4KMrSfnE1ydFU8Dw


---
_Generated by [Claude Code](https://claude.ai/code/session_01W6bLax4KMrSfnE1ydFU8Dw)_