### PR TITLE
docs(runtime-services): document data.query() beside find on the services.data page

### DIFF
--- a/content/docs/kernel/runtime-services/data-service.mdx
+++ b/content/docs/kernel/runtime-services/data-service.mdx
@@ -1,6 +1,6 @@
 ---
 title: services.data
-description: CRUD runtime helper API for records (`get`, `find`, `create`, `update`, `delete`).
+description: CRUD runtime helper API for records (`query`, `get`, `find`, `create`, `update`, `delete`).
 ---
 
 # `services.data`
@@ -32,12 +32,37 @@ the code that **holds** the binding calls it, with plain arguments and no `ctx` 
 ## Methods
 
 ```ts
-services.data.get<T = any>(object: string, id: string): Promise<GetDataResult<T>>
+services.data.query<T = any>(object: string, query: Partial<QueryAST>): Promise<PaginatedResult<T>>
 services.data.find<T = any>(object: string, options?: QueryOptions | QueryOptionsV2): Promise<PaginatedResult<T>>
+services.data.get<T = any>(object: string, id: string): Promise<GetDataResult<T>>
 services.data.create<T = any>(object: string, data: Partial<T>): Promise<CreateDataResult<T>>
 services.data.update<T = any>(object: string, id: string, data: Partial<T>): Promise<UpdateDataResult<T>>
 services.data.delete(object: string, id: string): Promise<DeleteDataResult>
 ```
+
+### Two list entries, one preference
+
+`query` and `find` both answer a list read with the same
+`{ records, total?, hasMore? }` envelope, and the Canonical source declares which
+of the two to prefer — the block above lists them in its declaration order.
+`data.query` is *"Advanced Query using ObjectStack Query Protocol"*; `data.find`
+carries an `@deprecated` tag in the same file: *"Use `data.query()` with standard
+QueryAST parameters instead. This method uses legacy parameter names."* The tag
+ships in the package's published type declarations, so an editor strikes `find`
+through at every call site and points at `query`. As with the options vocabulary
+below, the posture is the SDK's own, not this page's — it is recorded product
+direction ([#986](https://github.com/objectstack-ai/objectstack/issues/986):
+deprecate the legacy-parameter query entries, promote `data.query(AST)`).
+
+Deprecated means "prefer `query`", not "scheduled for removal in this version":
+`find` remains fully functional, keeps both of its option vocabularies (see
+[below](#find-options-canonical-and-legacy)), and the Canonical source still
+names `QueryOptionsV2` *"the recommended interface for `data.find()` queries"*
+for callers that stay on it. The capability line between the two entries is
+real, though. `find` rides GET query parameters, so it has no spelling for a
+`search` term or for nested `expand` detail — it refuses a nested expand with an
+error whose own text says to use `data.query()`. `query` POSTs the full
+`QueryAST` as a JSON body (`POST /data/:object/query`) and carries all of it.
 
 ## Canonical source
 
@@ -60,6 +85,12 @@ key for key. A managed runtime binds `services.data` to this same shape.
 - `object`: short object name (for example `task`, `account`)
 - `id`: record ID for single-record operations
 - `data`: partial payload for create/update
+- `query` (`query`): a `Partial<QueryAST>` — the spec's query protocol shape
+  (`packages/spec/src/data/query.zod.ts`): `where` / `fields` / `orderBy` /
+  `limit` / `offset`, plus the AST-only clauses (`search`, `expand` with nested
+  detail, `aggregations`, `groupBy`, `having`). The AST's own `object` key is
+  not needed here: the server takes the target from the `object` argument (the
+  URL path) and overwrites anything the body says
 - `options` (`find`): filtering, sorting and pagination — two vocabularies, one
   behaviour; see the table below
 
@@ -97,7 +128,8 @@ silently rather than refused, so migrate an options object as a whole.
 ## Returns
 
 - `get`: single record payload
-- `find`: list payload + pagination metadata
+- `query`/`find`: list payload + pagination metadata — the same
+  `PaginatedResult` envelope for both
 - `create`/`update`: mutated record payload
 - `delete`: `{ object, id, success }` — the spec's `DeleteDataResponse`. The
   flag is `success`, not `deleted` (#5638)
@@ -133,7 +165,18 @@ export async function recentOrdersForContact(data: DataService, contactId: strin
     limit: 20,
   });
 
-  return { contact, orders };
+  // `query` — the Canonical source's preferred list entry — POSTs the same
+  // words as a Partial<QueryAST> body, and carries the clauses `find` has no
+  // GET spelling for. Here: per-relation `expand` detail, which `find`
+  // refuses with an error that itself points at `query`.
+  const { records: withContact } = await data.query<{ id: string; amount: number }>('sales_order', {
+    where: { contact_id: contact.id },
+    orderBy: [{ field: 'created_at', order: 'desc' }],
+    limit: 20,
+    expand: { contact_id: { object: 'contact', fields: ['name'] } },
+  });
+
+  return { contact, orders, withContact };
 }
 ```
 


### PR DESCRIPTION
Fixes #6323

## Premise re-measured on origin/main (64d764e76) — all three legs still held

- `content/docs/kernel/runtime-services/data-service.mdx` still presented `find` as the primary list entry (Stability: stable, five-method block, example entirely on `find`).
- The page's own declared Canonical source, `packages/client/src/index.ts`, still carries `@deprecated Use data.query() with standard QueryAST parameters instead` on `data.find` (line 4202), and the built `dist/index.d.ts` ships that tag (line 2687) — every editor strikes `find` through at the call site.
- `data.query()` appeared nowhere on the page.

## Direction: the docs were the stale side, not the tag

The dispatch deliberately left the direction open (docs stale vs. tag wrong). Measured:

- `data.query()` exists on both `ObjectStackClient.data` (index.ts:4190) and `ScopedProjectClient.data` (index.ts:4913), is exported, and ships untagged in the published type declarations — on the exact `ObjectStackClient['data']` binding the page documents, so it is reachable from the documented surface.
- It is served by a dedicated route (`POST /data/:object/query`, rest-server.ts:5694) with request-body validation.
- The tag is recorded product direction, not a typo: #986 rules "deprecate the legacy-parameter entries, promote data.query(AST)", and the tag dates to commit 17dca1326 ("unify Engine/Protocol/Client to QueryAST standard parameters") — commit c463c2334 then added QueryOptionsV2 while deliberately keeping the tag.
- Non-test production callers of `client.data.find` on this path are scarce; the CLI's `data query` command and objectui's data adapter (for spec-shaped queries) already call `data.query()`. The heavy in-repo `data.find` usage is `IDataEngine.find` — a different, lower surface the page itself already distinguishes. objectui's adapter comments record real `find` pain (no `search`, no nested expand — forced raw-HTTP workarounds), and `find`'s own nested-expand refusal error tells callers to use `data.query()`.

Withdrawing the tag would overrule recorded direction, which is not this task's call.

## Why the change is safe under either future ruling on `find`

The issue and the devx-seat comment worried the two roads were exclusive ("choose wrong and the work is wasted"). The shape landed here is correct under both: the page now records the Canonical source's posture with attribution — the same pattern the page already used for the QueryOptions / QueryOptionsV2 vocabulary layer ("the recommendation is the SDK's own, not this page's") — including the source's own second face (QueryOptionsV2 still calling itself the recommended interface for `find` calls). Documenting `query` (which exists, is routed, and is the only spelling for `search` / nested `expand` on this surface) is right whether `find` is later retired or the tag is later withdrawn; only the one attributed paragraph would need touching in the second case.

## Changes (docs-only, one file)

- Methods block: `query` added in the Canonical source's declaration order.
- New "Two list entries, one preference" section: quotes the source's `@deprecated` verbatim with attribution, cites #986, states plainly that deprecated means "prefer query", not "scheduled for removal" — `find` stays fully documented and functional — and draws the real capability line (GET params cannot carry a `search` term or nested `expand` detail; `query` POSTs the full AST).
- Parameters: the Partial QueryAST parameter documented, including that the AST's `object` key is overwritten server-side by the path argument (rest-server.ts:5723).
- Returns: `query`/`find` share the same PaginatedResult envelope.
- Example: extended with a `query` call carrying nested `expand` detail — the exact shape `find` refuses. The example block was typechecked against the built `dist/index.d.ts` (tsc --strict, clean); it remains unmarked for `check:skill-examples` for the reason the page's closing note already records.

## No changeset — reasoning

Docs-only (`content/docs/**`); no published package source changed, so nothing releases. `skip-changeset` label applied.

## Verification

- `check:doc-authoring` — 365 files clean
- `check:docs-audit-scope` — 178 hand-written docs in sync
- `check:quick-reference-counts` — 13 sections match
- `check:nul-bytes` — 6269 files, no raw control bytes
- `check:role-word` — no new occurrences
- fumadocs-mdx compile — clean
- Links: the added issue link is external (excluded by the offline lychee gate); the added anchor matches the existing heading slug; no new internal file links.

## Residual maintainer question (not blocking this page)

The source's two-faced posture stands: `data.find` is `@deprecated` while `QueryOptionsV2` still names itself the recommended interface for `find` calls. Whether `find` eventually exits (per #986) or the tag is withdrawn remains a maintainer ruling; this page now reports both faces accurately either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_