### PR TITLE
fix(platform-objects): translate the Setup `nav_sso_providers` nav entry in all four locales

### DIFF
--- a/.changeset/sso-providers-nav-label.md
+++ b/.changeset/sso-providers-nav-label.md
@@ -1,0 +1,36 @@
+---
+'@objectstack/platform-objects': patch
+---
+
+Translate the Setup app's `nav_sso_providers` navigation entry in all four
+locales.
+
+`@objectstack/plugin-auth` contributes an **SSO Providers** entry into Setup's
+Access Control group (`sys_sso_provider`, priority 250), but no locale bundle
+carried a label for it: measured on `origin/main` `ea1d9165d`, a grep for
+`nav_sso_providers` over `en` / `zh-CN` / `ja-JP` / `es-ES` returned **0 each**,
+against a control probe (`nav_positions`) that returned 1 each. A deployment
+with an external IdP wired therefore rendered `SSO Providers` in English inside
+an otherwise fully translated Setup menu.
+
+| locale | label |
+| --- | --- |
+| `en` | SSO Providers |
+| `zh-CN` | SSO 提供方 |
+| `ja-JP` | SSO プロバイダー |
+| `es-ES` | Proveedores SSO |
+
+Each one matches that locale's existing `sys_sso_provider.pluralLabel`, since
+the nav entry opens exactly that object's list view.
+
+**Why no gate caught it.** `pnpm check:app-nav-i18n` (#5750) boots the real
+composition and asserts every *merged* Setup nav id carries a label in every
+locale — and `plugin-auth` spreads its `navigationContributions` in only when
+`authManager.isSsoWired()` is true. In the composition that gate boots, this
+entry is never contributed, never merged, and so never judged; the gate's header
+already declared that bound. This id is consequently the one Setup entry no
+boot-time check can reach, so it is pinned by hand instead, next to the dead-key
+tombstone (#6660) it is the converse of: one list holds ids whose label must be
+**gone**, the other ids whose label must **stay**. Making the gate itself
+union-aware was considered and deliberately left unbuilt — a separate
+maintainer-facing call, not a prerequisite for labelling the ids it cannot see.

--- a/packages/cli/scripts/check-app-nav-i18n.mjs
+++ b/packages/cli/scripts/check-app-nav-i18n.mjs
@@ -59,9 +59,12 @@
 //     carries no translation for a removed nav id; the same assertion here
 //     would delete the labels of conditionally-contributed entries, because a
 //     gated-off contribution is indistinguishable from a dead key when all you
-//     have is one runtime composition. The dead `apps.setup.navigation` keys
-//     that exist today are tracked separately rather than removed on a verdict
-//     this gate cannot honestly reach.
+//     have is one runtime composition. So Setup's reverse direction is decided
+//     per id by a human instead, in the two hand-kept lists of
+//     `setup-nav-dead-key-tombstone.test.ts`: the four keys that were dead were
+//     removed there under #6660, and `nav_sso_providers` — labelled in #6659
+//     although no composition this gate boots ever merges it — is pinned as the
+//     converse case. Neither verdict is one this gate could honestly reach.
 import { existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/packages/platform-objects/src/apps/translations/en.ts
+++ b/packages/platform-objects/src/apps/translations/en.ts
@@ -82,6 +82,19 @@ export const en: TranslationData = {
         nav_permission_sets: { label: 'Permission Sets' },
         nav_sharing_rules: { label: 'Sharing Rules' },
         nav_record_shares: { label: 'Record Shares' },
+        // `nav_sso_providers` is contributed by `@objectstack/plugin-auth` only
+        // when the external-IdP RP is wired (`OS_SSO_ENABLED`, or the cloud
+        // per-env `planAllowsSso`), so it is the one Setup entry
+        // `pnpm check:app-nav-i18n` structurally cannot judge: that gate boots
+        // ONE composition, and a contribution gated off in it is never merged
+        // and therefore never checked (see the gate header's bound #1). Its
+        // absence here was invisible for exactly that reason (#6659) — a
+        // deployment with SSO wired showed `SSO Providers` in English inside an
+        // otherwise translated menu. The pin that keeps this row honest lives
+        // in `setup-nav-dead-key-tombstone.test.ts`. Wording follows the
+        // object's own `pluralLabel` per locale (`sys_sso_provider`), since the
+        // entry opens that object's list view.
+        nav_sso_providers: { label: 'SSO Providers' },
         nav_api_keys: { label: 'API Keys' },
         nav_connect_agent: { label: 'Connect an Agent' },
 

--- a/packages/platform-objects/src/apps/translations/es-ES.ts
+++ b/packages/platform-objects/src/apps/translations/es-ES.ts
@@ -60,6 +60,11 @@ export const esES: TranslationData = {
         nav_permission_sets: { label: 'Conjuntos de Permisos' },
         nav_sharing_rules: { label: 'Reglas de Compartición' },
         nav_record_shares: { label: 'Registros Compartidos' },
+        // Conditionally contributed by `@objectstack/plugin-auth` (only when an
+        // external IdP is wired), so `check:app-nav-i18n` cannot see it — see
+        // the rationale in `en.ts` (#6659). Wording matches this locale's
+        // `sys_sso_provider.pluralLabel`.
+        nav_sso_providers: { label: 'Proveedores SSO' },
         nav_api_keys: { label: 'Claves API' },
         nav_connect_agent: { label: 'Conectar un agente' },
 

--- a/packages/platform-objects/src/apps/translations/ja-JP.ts
+++ b/packages/platform-objects/src/apps/translations/ja-JP.ts
@@ -60,6 +60,11 @@ export const jaJP: TranslationData = {
         nav_permission_sets: { label: '権限セット' },
         nav_sharing_rules: { label: '共有ルール' },
         nav_record_shares: { label: 'レコード共有' },
+        // Conditionally contributed by `@objectstack/plugin-auth` (only when an
+        // external IdP is wired), so `check:app-nav-i18n` cannot see it — see
+        // the rationale in `en.ts` (#6659). Wording matches this locale's
+        // `sys_sso_provider.pluralLabel`.
+        nav_sso_providers: { label: 'SSO プロバイダー' },
         nav_api_keys: { label: 'API キー' },
         nav_connect_agent: { label: 'エージェントを接続' },
 

--- a/packages/platform-objects/src/apps/translations/setup-nav-dead-key-tombstone.test.ts
+++ b/packages/platform-objects/src/apps/translations/setup-nav-dead-key-tombstone.test.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 //
-// Tombstone for four dead `apps.setup.navigation` translation keys (#6660).
+// Tombstone for four dead `apps.setup.navigation` translation keys (#6660), and
+// its converse: the labels of conditionally-contributed entries, which must
+// STAY (#6659).
 //
 // ---------------------------------------------------------------------------
 // Why a hard-coded id list instead of the general reverse direction
@@ -14,8 +16,10 @@
 // something", and why `pnpm check:app-nav-i18n` (which does boot) still refuses
 // the reverse direction: from one composition a dead key and a
 // conditionally-contributed key are indistinguishable (`nav_sso_providers` is
-// contributed only when an external IdP is wired). Making that gate
-// union-aware is tracked as #6659.
+// contributed only when an external IdP is wired). Teaching that gate to
+// enumerate conditional contributions — a union-aware gate — was considered and
+// deliberately NOT built (#6659's triage): it is a separate maintainer-facing
+// call, not a prerequisite for labelling the ids it cannot see.
 //
 // This file makes no general claim. It pins exactly four ids that were checked
 // ONE BY ONE against a repo-wide grep — `id: '<key>'` returned zero hits for
@@ -91,4 +95,54 @@ describe('removed Setup nav ids stay removed (#6660)', () => {
     expect(declared.has('nav_users'), 'nav_users is contributed here').toBe(true);
     expect(DEAD_SETUP_NAV_IDS.filter((id) => declared.has(id))).toEqual([]);
   });
+});
+
+// ---------------------------------------------------------------------------
+// The converse case (#6659): a label that must STAY although no boot sees it
+// ---------------------------------------------------------------------------
+// `pnpm check:app-nav-i18n` boots the real composition and asserts every MERGED
+// Setup nav id carries a label in every locale. That is the right shape for the
+// eleven contributors whose entries always merge — and it is structurally blind
+// to the ones that do not. `@objectstack/plugin-auth` spreads its
+// `navigationContributions` in only when `authManager.isSsoWired()` is true
+// (`OS_SSO_ENABLED` self-host, or the cloud per-env `planAllowsSso`), so in the
+// composition that gate boots, `nav_sso_providers` is never contributed, never
+// merged, and therefore never judged. It had no label in ANY of the four
+// locales while that gate reported OK, and a deployment with an external IdP
+// wired rendered `SSO Providers` in English inside an otherwise translated menu.
+//
+// So this case is a hand-kept list, exactly like `DEAD_SETUP_NAV_IDS` above and
+// for the same reason: one composition cannot decide the question, so a human
+// decided it per id. It is deliberately NOT a general union-aware gate — that
+// was ruled a separate maintainer-facing call (#6659's triage) and is not built.
+//
+// Bound worth stating: this file asserts only the LABEL half. The declaring
+// contribution lives in `@objectstack/plugin-auth`, which depends on this
+// package and so cannot be imported from here — the same import direction that
+// puts `check:app-nav-i18n` in `packages/cli`. A grep is what confirms the
+// declaring side; on `ea1d9165d` it sits at `auth-plugin.ts:552`.
+//
+// What to do when this test goes red: it goes red when a label is dropped, or
+// when a locale is added to the bundle without translating this id. Both are
+// bugs. If the CONTRIBUTION is ever retired, this list loses its entry in the
+// same commit that removes the nav item, and the id moves up to
+// `DEAD_SETUP_NAV_IDS` — the two lists are the two halves of one ledger.
+const CONDITIONAL_SETUP_NAV_IDS = ['nav_sso_providers'] as const;
+
+describe('conditionally-contributed Setup nav ids stay labelled (#6659)', () => {
+  for (const [locale, data] of Object.entries(LOCALES)) {
+    it(`${locale} carries a label for every conditionally-contributed Setup nav id`, () => {
+      const nav = (data.apps?.setup?.navigation ?? {}) as Record<string, { label?: string }>;
+
+      // Control: the subtree really resolved, so a missing/renamed
+      // `apps.setup.navigation` cannot make the assertion below pass by vacuity
+      // (it would instead report every id as unlabelled — which is the point).
+      expect(nav.nav_api_keys?.label, 'nav_api_keys anchors this subtree').toBeTruthy();
+
+      expect(
+        CONDITIONAL_SETUP_NAV_IDS.filter((id) => !nav[id]?.label),
+        'Setup nav ids with no label — no boot-time gate can see these; see this file header',
+      ).toEqual([]);
+    });
+  }
 });

--- a/packages/platform-objects/src/apps/translations/zh-CN.ts
+++ b/packages/platform-objects/src/apps/translations/zh-CN.ts
@@ -63,6 +63,11 @@ export const zhCN: TranslationData = {
         nav_permission_sets: { label: '权限集' },
         nav_sharing_rules: { label: '共享规则' },
         nav_record_shares: { label: '记录共享' },
+        // Conditionally contributed by `@objectstack/plugin-auth` (only when an
+        // external IdP is wired), so `check:app-nav-i18n` cannot see it — see
+        // the rationale in `en.ts` (#6659). Wording matches this locale's
+        // `sys_sso_provider.pluralLabel`.
+        nav_sso_providers: { label: 'SSO 提供方' },
         nav_api_keys: { label: 'API 密钥' },
         nav_connect_agent: { label: '连接智能体' },
 


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6659

## The gap

`@objectstack/plugin-auth` contributes an **SSO Providers** entry into the Setup app's `group_access_control` (`sys_sso_provider`, priority 250, `auth-plugin.ts:552`), and no locale bundle carried a label for it. A deployment with an external IdP wired therefore rendered `SSO Providers` in English inside an otherwise fully translated Setup menu.

**Premise re-measured on the fresh base** (`origin/main` `ea1d9165d`, i.e. after #6767 rewrote parts of these files):

| probe | en | zh-CN | ja-JP | es-ES |
| --- | --- | --- | --- | --- |
| `nav_sso_providers` | 0 | 0 | 0 | 0 |
| `nav_positions` (control) | 1 | 1 | 1 | 1 |

The declaring contribution had not drifted — still `auth-plugin.ts:552`.

## The change

Option 1 of the issue only. The union-aware gate (option 2) is deliberately **not** built.

| locale | label |
| --- | --- |
| `en` | SSO Providers |
| `zh-CN` | SSO 提供方 |
| `ja-JP` | SSO プロバイダー |
| `es-ES` | Proveedores SSO |

Each matches that locale's existing `sys_sso_provider.pluralLabel` (already in the generated object bundles), since the nav entry opens exactly that object's list view — so the menu and the page it opens read the same words. Placed inside the Access Control block, between `nav_record_shares` and `nav_api_keys`, matching the contribution's priority 250.

## Why no gate caught it, measured both ways

`pnpm check:app-nav-i18n` (#5750) boots the real composition and asserts every **merged** Setup nav id carries a label in every locale — and `plugin-auth` spreads its `navigationContributions` in only when `authManager.isSsoWired()` is true. In the composition that gate boots, this entry is never contributed, never merged, never judged. The gate's own header already declared that bound; this PR is the first concrete specimen of it.

Reverse verification, with the expected direction decided up front. The interesting half is that the gate is predicted **not** to move — that is the issue's central claim, not a gap in the verification. Measured with the four labels taken back out (`git checkout origin/main --` the four locale files, then rebuilt):

| check | predicted | measured |
| --- | --- | --- |
| new pin case | red x4 | red x4 — `expected [ 'nav_sso_providers' ] to deeply equal []`, one per locale |
| `check:app-nav-i18n` | **green, unchanged** | `OK (10 contributor(s), 53 merged setup nav id(s), 4 locale(s), every id labelled in every locale)` — byte-identical to the run with the labels present |

That second row is the point: the gate reports "every id labelled in every locale" while all four locales are missing this one. So the id is pinned **by hand** in `setup-nav-dead-key-tombstone.test.ts`, as the converse of the #6660 tombstone it now sits beside — one list holds ids whose label must be **gone**, the other ids whose label must **stay**. The two are the two halves of one ledger, and the file header says so, including the bound that this package can assert only the label half (`plugin-auth` depends on it, so it cannot be imported from here — the same import direction that put the boot gate in `packages/cli`).

## Also in scope (declared in the claim — cli-seat veto welcome)

`packages/cli/scripts/check-app-nav-i18n.mjs` header, **comment only, no logic edits**. Its closing sentence said "the dead `apps.setup.navigation` keys that exist today are tracked separately" — those four keys were removed by #6767, so that half-sentence is now false. Rewritten to point at where Setup's reverse direction is actually decided (the two hand-kept lists), keeping the still-true claim intact: the gate makes no reverse assertion, because from one composition a dead key and a gated-off contribution are indistinguishable.

One more citation was falsified by this PR and corrected in the same file it lives in: the tombstone header said "Making that gate union-aware is tracked as #6659". After triage, #6659 tracks the missing label and the union-aware gate is explicitly a separate, unbuilt card — leaving that line would point future readers at a closed issue for work never done.

## Verification

All foreground, heavy runs under `flock /tmp/os-heavy-verify.lock` with a 4 GB heap cap.

```
pnpm --filter @objectstack/platform-objects test    11 files, 289 passed
pnpm --filter @objectstack/platform-objects typecheck / @objectstack/cli typecheck   clean
pnpm check:app-nav-i18n     OK (10 contributors, 53 merged ids, 4 locales)
pnpm check:i18n             OK (9 packages, all bundles in sync)
pnpm check:i18n-coverage    OK (12 configs, 660 baselined, none new)
pnpm lint                   exit 0
pnpm check:nul-bytes        OK (6321 files)
pnpm check:doc-authoring    OK (373 files clean)
```

`check:i18n-coverage` first reported `COULD NOT MEASURE` — `@objectstack/connector-mcp` had no build output because the earlier build was scoped to `@objectstack/cli...`. That is the gate's documented `fix: pnpm build`, not a finding; it is green above after building the CI package set.

No `skip-changeset` label: this PR ships a changeset (`.changeset/sso-providers-nav-label.md`, patch on `@objectstack/platform-objects`).

---

### 中文摘要

`plugin-auth` 只有在外部 IdP 接通时才会向 Setup 的「访问控制」分组贡献 `nav_sso_providers`,而四个语言包都没有它的标签,所以接了 SSO 的部署会在一个已完全翻译的菜单里显示英文的 `SSO Providers`。本 PR 按裁决只做方案一:补齐四个语言的标签,措辞与各语言 `sys_sso_provider.pluralLabel` 保持一致。

`check:app-nav-i18n` 只启动**一个**组合,被条件关掉的贡献根本不会被合并,因此结构上看不到这个 id —— 已双向实测:删掉四个标签后该 gate 仍然输出完全相同的 `every id labelled in every locale`,而新增的 pin 用例四个语言全红。所以这个 id 改为手工 pin 在 `setup-nav-dead-key-tombstone.test.ts`,与 #6660 的墓碑互为反面:一份列「必须消失」的 id,一份列「必须保留」的 id。

**未**实现方案二(让 gate 具备 union 感知)—— 按裁决那是独立的、面向维护者的卡片。
