### PR TITLE
docs(spec): lifecycle.storage rotation 文案补上方言限定 — O(1) 分片 DROP 仅 SQLite (#6631)

### DIFF
--- a/.changeset/lifecycle-rotation-dialect-caveat.md
+++ b/.changeset/lifecycle-rotation-dialect-caveat.md
@@ -1,0 +1,24 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): `lifecycle.storage` 的 rotation 文案补上方言限定 —— O(1) 整分片 DROP 仅在 SQLite 成立 (#6631)
+
+`lifecycle.storage` 块的三处文案把 SQLite 独有的机制写成了 rotation 策略的无条件属性:
+`maxAge` guidance 的 "Rotation does not reap by age — it ... DROPs the oldest shard
+whole"、`strategy` describe 的 "(O(1) reclaim)"、以及模块 TSDoc 的 "Rotator
+(time-shard + DROP oldest)"。实测权威:物理分片是 SQLite-only 的驱动能力
+(`driver-sql` 的 `supportsRotation` 只在 `isSqlite` 下为 true,`rotateShards`
+在其他方言直接拒绝),Postgres/MySQL 走 LifecycleService 的 `'rotation-fallback'`
+分支 —— 按 `created_at` 的年龄批量 reap,恰是旧文案宣称 rotation 不使用的机制。
+
+三处文案改为驱动注释早已写对的表述:保留窗口(`shards` × `unit`)在所有方言上
+一致 —— 声明的边界处处成立;回收机制不一致 —— SQLite 整分片 DROP(O(1) 回收),
+其他方言按年龄 reap 同一窗口。`maxAge` guidance 的路由建议(用 `shards`/`unit`
+设窗口,或改用 `retention`)原样保留。
+
+**纯文案修改,接受面零变化**:`LifecycleSchema` 接受/拒绝的输入集合与改动前
+逐字节相同;`superRefine`(含 `retention.onlyWhen` × rotation 的拒绝及其理由)
+未触碰。批 20 测试新增两条 pin:guidance 与 describe 必须同时点名两条腿
+(SQLite 的分片 DROP 与其他方言的按龄 reap),并各带反空洞守卫,防止整段文案
+消失时 pin 静默变绿。

--- a/packages/spec/src/data/object-strictness-batch20.test.ts
+++ b/packages/spec/src/data/object-strictness-batch20.test.ts
@@ -252,6 +252,68 @@ describe('#4001 批 20 — curation is anchored to the sibling contract that mak
       expect(msg).toContain('retention');
     });
 
+    // #6631 — `lifecycle.storage.maxAge` is the third sideways pointer, and the
+    // mechanism it contrasted was true on exactly one dialect. Physical rotation
+    // is SQLite-only: `driver-sql` gates it behind
+    // `get supportsRotation() { return this.isSqlite }` and `rotateShards` throws
+    // on every other dialect (`packages/drivers/driver-sql/src/sql-driver.ts`).
+    // The LifecycleService then takes its `'rotation-fallback'` leg —
+    // `reap(…, 'rotation-fallback', 'created_at', windowMs, …)` in
+    // `packages/objectql/src/lifecycle/lifecycle-service.ts` — which is a reap BY
+    // AGE from `created_at`, precisely the mechanism the old guidance told the
+    // author rotation does not use. What the author most needs to keep believing
+    // still holds: the retained WINDOW is identical on every dialect. Only the
+    // reclamation is not — which is what the driver's own note directly above
+    // `supportsRotation` already says, and what these two surfaces now say too.
+    //
+    // ⛔ Scope: the qualifier, not the wording. Matched by idiom — does the text
+    // name the split at all? — so a rewrite is free and dropping the caveat is
+    // not. Nothing here asserts anything about what `LifecycleSchema` ACCEPTS,
+    // which is unchanged (the `onlyWhen`-vs-rotation `superRefine` carries the
+    // same dialect-specific reason and is deliberately left alone).
+    it('`lifecycle.storage.maxAge` points SIDEWAYS at `retention` — and qualifies the mechanism it contrasts, which is SQLite-only (#6631)', () => {
+      const rotating = { strategy: 'rotation', shards: 7, unit: 'day' } as const;
+      const msg = rejectOnObject({ lifecycle: { class: 'telemetry', storage: { ...rotating, maxAge: '7d' } } });
+
+      // Anti-vacuity. `strictObject` rejects an unknown key with or WITHOUT a
+      // `guidance` entry, so every assertion below would pass on a deleted entry.
+      // Anchor on the routing advice — the half of this message that was correct
+      // all along and must survive any rewording of the other half.
+      expect(msg, 'the `maxAge` guidance bullet is not being produced at all').toContain(
+        'Set the window with `shards`/`unit`, or use `retention` instead of rotation.',
+      );
+      // …and it really is THIS key's guidance rather than something the surface
+      // says to every unknown key: a sibling unknown key gets the bare rejection.
+      expect(rejectOnObject({ lifecycle: { class: 'telemetry', storage: { ...rotating, notAStorageKey: 1 } } }))
+        .not.toMatch(/SQLite/i);
+
+      // The pointed-at spelling really does parse (finding 18 — a prescription
+      // that does not work is worse than none).
+      accept(ObjectSchema, { ...OBJ, lifecycle: { class: 'telemetry', storage: rotating, retention: { maxAge: '7d' } } });
+
+      // The claim under test: both legs of the split are named.
+      expect(msg, 'the shard DROP must be attributed to SQLite').toMatch(/SQLite/);
+      expect(msg, 'and the other dialects must be told what they get instead').toMatch(/age-based reap|reaps? [^.]{0,32}by age/i);
+
+      // The retired unconditional claim, pinned by name so it cannot come back
+      // as a paraphrase of the same idea — it is false on Postgres/MySQL, where
+      // the fallback leg reaps from `created_at` exactly by age.
+      expect(msg).not.toContain('does not reap by age');
+    });
+
+    it("`lifecycle.storage.strategy`'s description carries the same qualifier — `(O(1) reclaim)` is a property of SQLite, not of the strategy (#6631)", () => {
+      const doc = LifecycleSchema.shape.storage.unwrap().shape.strategy.description ?? '';
+
+      // Anti-vacuity: an empty description satisfies every negative assertion
+      // below, and is exactly how a pin like this rots into decoration.
+      expect(doc.length, '`storage.strategy` lost its `.describe()`').toBeGreaterThan(0);
+      expect(doc, 'the description no longer describes the rotation mechanism at all').toMatch(/shard/i);
+
+      expect(doc, 'the O(1) shard DROP must be attributed to SQLite').toMatch(/SQLite/);
+      expect(doc, 'and the other dialects must be told what they get instead').toMatch(/age-based|by age/i);
+      expect(doc).not.toContain('rotate by DROPping the oldest shard (O(1) reclaim)');
+    });
+
     it('`access.sharingModel` points UP — it is a real TOP-LEVEL key, so distance would never find it', () => {
       const msg = rejectOnObject({ access: { default: 'private', sharingModel: 'private' } });
       expect(msg).toContain('TOP-LEVEL');

--- a/packages/spec/src/data/object.zod.ts
+++ b/packages/spec/src/data/object.zod.ts
@@ -600,7 +600,8 @@ export type ObjectRequiredPermissions = z.input<typeof ObjectRequiredPermissions
  * Declares how long an object's data lives and how its space is reclaimed —
  * the axis validation/permissions never covered. Enforced at runtime by the
  * platform-owned LifecycleService (`@objectstack/objectql`): Reaper (TTL/age
- * batch delete), Rotator (time-shard + DROP oldest), Archiver (cold-store
+ * batch delete), Rotator (time-shard + DROP oldest on SQLite, an age-based
+ * reap of the same window elsewhere), Archiver (cold-store
  * copy then delete). A declared policy with no runtime consumer is a spec
  * defect (ADR-0049 enforce-or-remove); the liveness gate requires every
  * non-`record` class to declare `retention`, `ttl`, or rotation `storage`.
@@ -732,12 +733,17 @@ export const LifecycleSchema = lazySchema(() => strictObject({
     aliases: { count: 'shards', interval: 'unit', period: 'unit', granularity: 'unit' },
     guidance: {
       maxAge:
-        '`maxAge` is a `retention` key. Rotation does not reap by age — it retains ' +
-        '`shards` × `unit` of history and DROPs the oldest shard whole. Set the window ' +
+        '`maxAge` is a `retention` key. Rotation takes its window from `shards` × `unit`, ' +
+        'not from an age you name — reclaimed by DROPping the oldest shard whole on SQLite, ' +
+        'by an equivalent age-based reap elsewhere. Set the window ' +
         'with `shards`/`unit`, or use `retention` instead of rotation.',
     },
   }, {
-    strategy: z.literal('rotation').describe('Time-shard the table; rotate by DROPping the oldest shard (O(1) reclaim).'),
+    strategy: z.literal('rotation').describe(
+      'Time-shard the table. The retained window (`shards` × `unit`) is the same on every ' +
+      'dialect; the reclamation is not — SQLite DROPs the oldest shard whole (O(1) reclaim), ' +
+      'other dialects reap that same window by age from `created_at`.',
+    ),
     shards: z.number().int().min(2).describe('Number of shards retained; total window = shards × unit.'),
     unit: z.enum(['day', 'week', 'month']).describe('Time width of one shard.'),
   }).optional().describe('Physical storage strategy for high-frequency telemetry (LifecycleService Rotator).'),

--- a/packages/spec/test-typecheck-debt.json
+++ b/packages/spec/test-typecheck-debt.json
@@ -33,7 +33,7 @@
     "src/data/driver.test.ts": 11,
     "src/data/driver/memory.test.ts": 1,
     "src/data/field.test.ts": 2,
-    "src/data/object-strictness-batch20.test.ts": 2,
+    "src/data/object-strictness-batch20.test.ts": 1,
     "src/data/query.test.ts": 25,
     "src/identity/scim.test.ts": 7,
     "src/integration/connector.test.ts": 7,


### PR DESCRIPTION
Fixes #6631

## 缺陷

`packages/spec/src/data/object.zod.ts` 的 `lifecycle.storage` 块有三处无条件表述,实际只在 SQLite 上为真(实测行号,基于 `origin/main` @ `a5d25734c`):

- `:735-737` — `maxAge` guidance:"Rotation does not reap by age — it retains `shards` × `unit` of history and DROPs the oldest shard whole."
- `:740` — `strategy: z.literal('rotation')` 的 `.describe()`:"Time-shard the table; rotate by DROPping the oldest shard (O(1) reclaim)."
- `:603` — 模块 TSDoc:"Rotator (time-shard + DROP oldest)"。

## 权威(逐条实测)

- `packages/drivers/driver-sql/src/sql-driver.ts:4128-4130`:`get supportsRotation() { return this.isSqlite; }`;`:4173-4175`:`rotateShards` 在其他方言直接 throw。`:4121-4123` 驱动注释本身已把分野写对——"SQLite-only; on other dialects the LifecycleService falls back to an age-based reap, so the declared bound holds everywhere — only the reclamation mechanics differ."
- `packages/objectql/src/lifecycle/lifecycle-service.ts:925-937`:`else if (lc.storage?.strategy === 'rotation' && !rotated && !lc.ttl)` 分支调用 `reap(engine, object, lc, 'rotation-fallback', 'created_at', windowMs, report)` —— 按 `created_at` 的**年龄** reap,恰是旧 guidance 宣称 rotation 不使用的机制;outcome 枚举自己就叫 `'rotation-fallback'`。
- 驱动普查:`packages/drivers/` 五个驱动中,`supportsRotation` 只在 `driver-sql` 声明、只在 `isSqlite` 下为 true;其余驱动无 `rotateShards`。

## 修改(纯文案,一个从句的代价)

三处均改为驱动注释已有的表述:**保留窗口(`shards` × `unit`)在所有方言一致**——声明的边界处处成立;**回收机制不一致**——SQLite 整分片 DROP(O(1) 回收),其他方言按年龄从 `created_at` reap 同一窗口。`maxAge` guidance 的路由建议("Set the window with `shards`/`unit`, or use `retention` instead of rotation.")**逐字保留**。

**接受面零变化**:未触碰任何 `superRefine`/`.refine`/类型/枚举/可选性;`retention.onlyWhen` × rotation 的拒绝(理由同样是方言特定的)按 issue 划定明确不动。`content/docs/references/data/object.mdx` 不含这三段文案(生成器只渲染顶层 property 表),`check:docs` 绿,无需再生成。

## Pin(批 20 新增两条,反空洞 + 按惯用语匹配)

- guidance 侧:`lifecycle.storage.maxAge` 的拒绝文案必须点名两条腿(`/SQLite/` + 按龄 reap 惯用语),路由建议句作反空洞锚(guidance 条目整体消失即红),兄弟未知键作对照(证明匹配的是本键的 guidance 而非 surface 通用文案),并钉死旧句 "does not reap by age" 不得以原文回归。
- describe 侧:`strategy.description` 非空、仍描述分片机制(反空洞),同样双腿匹配,旧无条件句钉死。

## 逆向验证(方向先行)

**预测**:回退三处文案(保留 pin)→ 恰好两条新 pin 红(红点落在 SQLite/按龄断言,反空洞守卫在回退文案上保持绿),其余 45 条测试不动;恢复 → 全绿。
**实测**:完全一致 —— 回退后 `2 failed | 45 passed`,失败断言分别在 `:295`(guidance 侧 `/SQLite/`)与 `:312`(describe 侧 `/SQLite/`),均位于反空洞守卫之后;恢复后该文件 47 条全绿,spec 全套 345 files / 8848 tests 全绿。

## 验证

- `pnpm --filter @objectstack/spec test` — 345 passed / 8848 passed
- `pnpm --filter @objectstack/spec typecheck` — 绿(`test-typecheck-debt.json` 批 20 条目 2 → 1:pin 引用了此前未使用的 `LifecycleSchema` import,消掉一条 TS6133;按 ratchet 要求重录)
- `node scripts/check-type-check-coverage.mjs --re-measure`(先按 lint.yml 构建 closure)— OK,34 entries re-measured,无一上漂
- `check:docs` / `check:generated` / `check:api-surface` / `check:authorable-surface` / `check:spec-changes` / `check:upgrade-guide` — 绿(`api-surface` 的 stale 为未建 dist 的本地伪象,干净 main 同样报;dist 构建后绿)
- `node scripts/check-nul-bytes.mjs` — OK;changed files ESLint — 0 problems

Changeset:`.changeset/lifecycle-rotation-dialect-caveat.md`(`@objectstack/spec` patch —— `.describe()` 为已发布文案)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk

---
_Generated by [Claude Code](https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk)_