### PR TITLE
fix(objectql): retire `sys_fetch_previous_delete` so the delete-path per-object gate is honest (#5929)

### DIFF
--- a/.changeset/retire-delete-fetch-previous-builtin.md
+++ b/.changeset/retire-delete-fetch-previous-builtin.md
@@ -1,0 +1,49 @@
+---
+"@objectstack/objectql": patch
+---
+
+fix(objectql): retire `sys_fetch_previous_delete`, so `delete()`'s per-object prior-row gate is a real question (#5929)
+
+`delete()` reads the doomed row's pre-image only when something on **this
+object** consumes it — a delete-side hook in either phase, or a roll-up summary
+aggregating it. That gate has been per object since #5272, and on a
+kernel-hosted engine it was **constant true for every object that has ever
+existed**, so the skip it exists to perform never happened outside the unit
+tests' bare engines.
+
+The reason was `ObjectQLPlugin`'s own builtin. `sys_fetch_previous_delete`
+registered on `beforeDelete` with `object: '*'`, which made the gate's first
+term true everywhere — and it could not use what it held open: since #5272 (and
+#6697, which extended the same ordering to the predicate path, per matched row)
+the engine reads the pre-image and binds `previous` **before** `beforeDelete`
+dispatches, so the builtin's own `if (input.id && !ctx.previous)` guard was
+permanently false and it issued no read. Its only remaining effect was holding
+open the gate that made it redundant. Retired under ADR-0049
+enforce-or-remove.
+
+**What changes for you, in both directions:**
+
+- An object with **no** delete-side hook and no roll-up summary now performs
+  **no prior-row read** on a by-id `delete()`. Previously it always did, on any
+  kernel.
+- Where a delete-side hook **does** exist, `previous` still arrives bound,
+  identically — from the engine's own read, which was already the only producer.
+  Hook handlers, declarative `condition`s reading `previous`, the record-change
+  trigger, the audit diff and the summary recompute are all unaffected.
+- The residual shape the retired guard could still have been true for — the
+  engine's read found nothing because the row is already gone — is one where the
+  builtin's read found nothing either, so it binds nothing there too. `previous`
+  stays **unbound** rather than fabricated as `{}`, unchanged (#4649/#4775).
+
+Nothing about hook dispatch, the by-id repoint re-resolution, or the delete
+dispatch ladder changes. The gate's three terms are unchanged — what changed is
+that its first term now reflects **real** hooks.
+
+One caveat worth stating so nobody reads a skip into a trace that will not show
+one: a kernel that also loads plugin-auth, plugin-sharing or service-storage
+still has the gate held open on every object, because each registers a
+delete-phase hook with no `object` and decides applicability inside its handler.
+Those are real consumers, not circular ones. plugin-audit is the exception and
+the worked example — it narrows at the engine face with `excludeObjects`
+(#5860), so an excluded object really does skip the read. The full enumeration
+is in `engine.ts` beside `wantsPreImage`.

--- a/packages/objectql/src/engine-delete-prior-read-scope.test.ts
+++ b/packages/objectql/src/engine-delete-prior-read-scope.test.ts
@@ -235,7 +235,7 @@ describe('[#5929] the delete-side prior-row demand is asked per object', () => {
 
     expect((reads.findOneOn['del_scope_a'] ?? 0) - before).toBe(0);
     // The row really went — a skipped read must not have skipped the write.
-    expect(await engine.count('del_scope_a', {} as any)).toBe(0);
+    expect(await engine.count('del_scope_a', {})).toBe(0);
   });
 
   it('the object that DOES have the afterDelete hook pays it, and `previous` is the stored row', async () => {
@@ -315,7 +315,7 @@ describe('[#5929] the delete-side prior-row demand is asked per object', () => {
     await engine.delete('del_scope_locked', { where: { id: row.id } } as any);
 
     expect((reads.findOneOn['del_scope_locked'] ?? 0) - before).toBe(0);
-    expect(await engine.count('del_scope_locked', {} as any)).toBe(0);
+    expect(await engine.count('del_scope_locked', {})).toBe(0);
   });
 });
 
@@ -399,7 +399,7 @@ describe('[#5929] the predicate delete path asks the same per-object question', 
     await engine.delete('del_scope_a', { multi: true, where: { status: 'stale' } } as any);
 
     expect((reads.findOn['del_scope_a'] ?? 0) - before).toBe(0);
-    expect(await engine.count('del_scope_a', {} as any)).toBe(0);
+    expect(await engine.count('del_scope_a', {})).toBe(0);
   });
 
   it('…and reads it exactly once when the object IS hooked', async () => {
@@ -436,7 +436,11 @@ describe('[#5929] on a KERNEL-hosted engine the per-object skip finally happens'
     } as any);
     await kernel.use(new ObjectQLPlugin());
     await kernel.bootstrap();
-    const engine = kernel.getService('objectql') as any;
+    // `getService<ObjectQL>` — the slot's real contract, not `as any`. The
+    // erasure would switch off checking for every `engine.*` call below while
+    // looking identical to code that keeps it (#4168/#4176/#4251), and the
+    // calls below are the measurement.
+    const engine = kernel.getService<ObjectQL>('objectql');
     for (const o of objects) engine.registry.registerObject(o, 'test', 'test');
     return { kernel, engine, reads: stub.reads };
   }

--- a/packages/objectql/src/engine-delete-prior-read-scope.test.ts
+++ b/packages/objectql/src/engine-delete-prior-read-scope.test.ts
@@ -1,0 +1,564 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#5929] `delete()`'s prior-row read is demanded PER OBJECT — and on a
+ * kernel-hosted engine that demand is finally answerable.
+ *
+ * ## The defect
+ *
+ * The gate has asked per object since #5272:
+ *
+ *   `hasHooksFor('beforeDelete', object) || hasHooksFor('afterDelete', object)
+ *    || getSummaryDescriptors(object).length > 0`
+ *
+ * and on any kernel it was CONSTANT TRUE, because `ObjectQLPlugin` registered a
+ * builtin of its own — `sys_fetch_previous_delete`, `object: '*'`, priority 5,
+ * `beforeDelete` — which made the first term true for every object that has
+ * ever existed. The per-object skip the gate exists to perform therefore never
+ * happened on a real deployment, only on the bare `new ObjectQL()` engines the
+ * unit tests boot.
+ *
+ * The builtin could not even use what it held open. #5272 made the engine read
+ * the pre-image and bind `previous` BEFORE dispatching `beforeDelete` (#6697
+ * extended the same ordering to the predicate path, per matched row), so the
+ * builtin's own `if (input.id && !ctx.previous)` guard was permanently false and
+ * it issued no read. Circular: its only remaining effect was holding open the
+ * gate that made it redundant. Retired under ADR-0049 enforce-or-remove.
+ *
+ * ## What this file pins, and why it needed a KERNEL to pin it
+ *
+ * Sections 1–3 run on a bare engine and pin the gate's three terms, the
+ * `excludeObjects` subtraction, and the direction the gate is allowed to be
+ * wrong in (looser, never tighter). They would have passed before the
+ * retirement too — a bare engine never carried the builtin.
+ *
+ * Section 4 is the regression pin proper, and it boots a real `ObjectKernel`
+ * with `ObjectQLPlugin`, because that is the only configuration in which the
+ * defect was ever observable. `expect(reads).toBe(0)` there was `1` before this
+ * change.
+ *
+ * Section 5 replays the retired builtin's own shape as an authored hook and
+ * measures its guard short-circuiting, so "the guard can no longer be true"
+ * stays a measurement rather than a claim that rots. It is the delete-side twin
+ * of the case #5846 left in `engine-update-prior-read-scope.test.ts`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ObjectKernel } from '@objectstack/core';
+import { ObjectQL } from './engine.js';
+import { ObjectQLPlugin } from './plugin.js';
+import { bindHooksToEngine } from './hook-binder.js';
+import type { Hook, ObjectSchema } from '@objectstack/spec/data';
+
+const TASK_FIELDS = {
+  id: { name: 'id', label: 'ID', type: 'text' as const, primaryKey: true },
+  title: { name: 'title', label: 'Title', type: 'text' as const },
+  status: { name: 'status', label: 'Status', type: 'text' as const },
+  done: { name: 'done', label: 'Done', type: 'boolean' as const },
+};
+
+/** Two plain objects, neither declaring anything that needs a prior row. */
+const taskA = { name: 'del_scope_a', label: 'A', fields: TASK_FIELDS };
+const taskB = { name: 'del_scope_b', label: 'B', fields: TASK_FIELDS };
+
+/**
+ * Declares a `readonlyWhen` field, so `needsPriorRecord(schema)` is true for it
+ * — the term this gate deliberately does NOT carry (section 1's last case).
+ */
+const lockedTask = {
+  name: 'del_scope_locked',
+  label: 'Locked',
+  fields: {
+    ...TASK_FIELDS,
+    title: {
+      name: 'title', label: 'Title', type: 'text' as const,
+      readonlyWhen: 'record.done == true',
+    },
+  },
+};
+
+/** Parent/child pair for the roll-up demand. */
+const invoice = {
+  name: 'del_scope_invoice',
+  label: 'Invoice',
+  fields: {
+    id: { name: 'id', label: 'ID', type: 'text' as const, primaryKey: true },
+    name: { name: 'name', label: 'Name', type: 'text' as const },
+    line_total: {
+      name: 'line_total', label: 'Total', type: 'summary' as const,
+      summaryOperations: { object: 'del_scope_invoice_line', field: 'amount', function: 'sum' },
+    },
+  },
+};
+const invoiceLine = {
+  name: 'del_scope_invoice_line',
+  label: 'Line',
+  fields: {
+    id: { name: 'id', label: 'ID', type: 'text' as const, primaryKey: true },
+    amount: { name: 'amount', label: 'Amount', type: 'number' as const },
+    invoice: { name: 'invoice', label: 'Invoice', type: 'master_detail' as const, reference: 'del_scope_invoice' },
+  },
+};
+
+/**
+ * A driver that counts every read PER OBJECT, so "pays no prior read" is a
+ * measurement rather than an assertion about the code that was written.
+ *
+ * Per object because a delete legitimately reads OTHER objects — the roll-up
+ * recompute aggregates the child set, `cascadeDeleteRelations` looks for
+ * dependants. Counting only the total would conflate those with the pre-image
+ * read this file is about.
+ */
+function makeCountingDriver() {
+  const stores = new Map<string, Map<string, Record<string, unknown>>>();
+  const reads = { findOne: 0, find: 0, findOneOn: {} as Record<string, number>, findOn: {} as Record<string, number> };
+  const storeFor = (obj: string) => {
+    let s = stores.get(obj);
+    if (!s) { s = new Map(); stores.set(obj, s); }
+    return s;
+  };
+  let nextId = 0;
+  const matchesWhere = (row: Record<string, unknown>, where: any): boolean => {
+    if (!where || typeof where !== 'object') return true;
+    for (const [k, v] of Object.entries(where)) {
+      if (k === '$and' && Array.isArray(v)) {
+        if (!v.every((sub) => matchesWhere(row, sub))) return false;
+        continue;
+      }
+      if (k.startsWith('$')) continue;
+      const expected = (v && typeof v === 'object' && '$eq' in (v as any)) ? (v as any).$eq : v;
+      if ((row[k] ?? null) !== (expected ?? null)) return false;
+    }
+    return true;
+  };
+  const driver: any = {
+    name: 'del-counting', version: '0.0.0', supports: {} as any,
+    async connect() {}, async disconnect() {}, async checkHealth() { return true; },
+    async execute() { return null; }, async syncSchema() {},
+    async find(object: string, ast: any) {
+      reads.find += 1;
+      reads.findOn[object] = (reads.findOn[object] ?? 0) + 1;
+      return Array.from(storeFor(object).values()).filter((r) => matchesWhere(r, ast?.where));
+    },
+    async findOne(object: string, ast: any) {
+      reads.findOne += 1;
+      reads.findOneOn[object] = (reads.findOneOn[object] ?? 0) + 1;
+      for (const r of storeFor(object).values()) if (matchesWhere(r, ast?.where)) return r;
+      return null;
+    },
+    async create(object: string, data: Record<string, unknown>) {
+      nextId += 1;
+      const id = (data.id as string) ?? `r_${nextId}`;
+      const row: Record<string, unknown> = { ...data, id };
+      storeFor(object).set(id, row);
+      return row;
+    },
+    async update(object: string, id: string, data: Record<string, unknown>) {
+      const s = storeFor(object);
+      const cur = s.get(id);
+      if (!cur) return null;
+      const updated = { ...cur, ...data, id };
+      s.set(id, updated);
+      return updated;
+    },
+    async upsert(object: string, data: Record<string, unknown>) {
+      const id = data.id as string | undefined;
+      if (id && storeFor(object).has(id)) return this.update(object, id, data);
+      return this.create(object, data);
+    },
+    async delete(object: string, id: string) { return storeFor(object).delete(id); },
+    async count(object: string, ast: any) {
+      // Same reason as the bulk verbs below: a test's own `count()` assertion
+      // must not inflate the read counters it is asserting alongside.
+      return Array.from(storeFor(object).values()).filter((r) => matchesWhere(r, ast?.where)).length;
+    },
+    async bulkCreate(object: string, rows: Record<string, unknown>[]) {
+      return Promise.all(rows.map((r) => this.create(object, r)));
+    },
+    async bulkUpdate() { return []; },
+    async bulkDelete() {},
+    // ⚠️ The bulk verbs resolve their own row set WITHOUT going through
+    // `find()`. Routing them through it would charge the engine for a read the
+    // engine never issued — and this file's whole subject is read COUNTS, so a
+    // driver-internal read masquerading as an engine one would make every
+    // predicate-path number one too high.
+    async updateMany(object: string, ast: any, data: Record<string, unknown>) {
+      const rows = Array.from(storeFor(object).values()).filter((r) => matchesWhere(r, ast?.where));
+      for (const r of rows) storeFor(object).set(r.id as string, { ...r, ...data, id: r.id });
+      return rows.length;
+    },
+    async deleteMany(object: string, ast: any) {
+      const rows = Array.from(storeFor(object).values()).filter((r) => matchesWhere(r, ast?.where));
+      for (const r of rows) storeFor(object).delete(r.id as string);
+      return rows.length;
+    },
+    async beginTransaction() { return { commit: async () => {}, rollback: async () => {} }; },
+    async commit() {}, async rollback() {},
+  };
+  return { driver, reads, storeFor };
+}
+
+async function boot(hooks: Hook[] = [], objects: unknown[] = [taskA, taskB]) {
+  const engine = new ObjectQL();
+  const stub = makeCountingDriver();
+  engine.registerDriver(stub.driver, true);
+  await engine.init();
+  for (const o of objects) engine.registry.registerObject(o as any);
+  if (hooks.length > 0) {
+    bindHooksToEngine(engine, hooks, {
+      packageId: 'app:del-scope',
+      logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+    });
+  }
+  return { engine, reads: stub.reads, storeFor: stub.storeFor };
+}
+
+const observer = (
+  name: string, object: string, event: string, sink: Array<unknown>, extra: Record<string, unknown> = {},
+): Hook => ({
+  name, object, events: [event], priority: 90,
+  handler: (ctx: any) => { sink.push(ctx.previous); },
+  ...extra,
+} as unknown as Hook);
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * 1. The three terms, asked PER OBJECT
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+describe('[#5929] the delete-side prior-row demand is asked per object', () => {
+  it('object A pays NO prior read while only object B has an afterDelete hook', async () => {
+    const { engine, reads } = await boot([observer('audits_b', 'del_scope_b', 'afterDelete', [])]);
+
+    const row: any = await engine.insert('del_scope_a', { title: 'A', status: 'todo', done: false });
+    const before = reads.findOneOn['del_scope_a'] ?? 0;
+    await engine.delete('del_scope_a', { where: { id: row.id } } as any);
+
+    expect((reads.findOneOn['del_scope_a'] ?? 0) - before).toBe(0);
+    // The row really went — a skipped read must not have skipped the write.
+    expect(await engine.count('del_scope_a', {} as any)).toBe(0);
+  });
+
+  it('the object that DOES have the afterDelete hook pays it, and `previous` is the stored row', async () => {
+    const seen: Array<unknown> = [];
+    const { engine, reads } = await boot([observer('audits_b', 'del_scope_b', 'afterDelete', seen)]);
+
+    const row: any = await engine.insert('del_scope_b', { title: 'B', status: 'todo', done: false });
+    const before = reads.findOneOn['del_scope_b'] ?? 0;
+    await engine.delete('del_scope_b', { where: { id: row.id } } as any);
+
+    expect((reads.findOneOn['del_scope_b'] ?? 0) - before).toBe(1);
+    expect(seen).toEqual([{ id: row.id, title: 'B', status: 'todo', done: false }]);
+  });
+
+  it('a `beforeDelete` hook holds the gate open ALONE, and reads the row it opened it for', async () => {
+    // Term 1 on its own, with nothing hooking the after phase. This is the term
+    // the retired builtin used to satisfy for every object at once; it has to
+    // still work when a REAL hook satisfies it, or the retirement would have
+    // taken a live demand with it.
+    const seen: Array<unknown> = [];
+    const { engine, reads } = await boot([observer('pre_a', 'del_scope_a', 'beforeDelete', seen)]);
+
+    const row: any = await engine.insert('del_scope_a', { title: 'A', status: 'todo', done: false });
+    const before = reads.findOneOn['del_scope_a'] ?? 0;
+    await engine.delete('del_scope_a', { where: { id: row.id } } as any);
+
+    expect((reads.findOneOn['del_scope_a'] ?? 0) - before).toBe(1);
+    expect(seen).toEqual([{ id: row.id, title: 'A', status: 'todo', done: false }]);
+  });
+
+  it('a hook registered for `*` still demands the read on every object', async () => {
+    // The direction that matters: `hasHooksFor` mirrors `triggerHooks`' own
+    // filter, so an entry targeting `'*'` DOES reach this object. Getting the
+    // gate looser than dispatch costs a query; getting it TIGHTER would drop
+    // hooks that were going to fire. The retirement removed a `'*'` entry from
+    // the KERNEL — it did not narrow what `'*'` means.
+    const seen: Array<unknown> = [];
+    const { engine, reads } = await boot([{
+      name: 'audits_everything', object: '*', events: ['beforeDelete'], priority: 90,
+      handler: (ctx: any) => { seen.push(ctx.previous); },
+    } as unknown as Hook]);
+
+    const row: any = await engine.insert('del_scope_a', { title: 'A', status: 'todo', done: false });
+    const before = reads.findOneOn['del_scope_a'] ?? 0;
+    await engine.delete('del_scope_a', { where: { id: row.id } } as any);
+
+    expect((reads.findOneOn['del_scope_a'] ?? 0) - before).toBe(1);
+    expect(seen).toEqual([{ id: row.id, title: 'A', status: 'todo', done: false }]);
+  });
+
+  it('a roll-up summary alone forces the read, with no hooks registered anywhere', async () => {
+    // Term 3. `recomputeSummaries` reads the doomed row's FK to find the parent
+    // to recompute, so a deployment with no delete hook at all still owes this
+    // read — and the parent must actually come back down.
+    const { engine, reads, storeFor } = await boot([], [invoice, invoiceLine]);
+
+    const parent: any = await engine.insert('del_scope_invoice', { name: 'INV-1' });
+    const line: any = await engine.insert('del_scope_invoice_line', { invoice: parent.id, amount: 40 });
+    expect(storeFor('del_scope_invoice').get(parent.id)?.line_total).toBe(40);
+
+    const before = reads.findOneOn['del_scope_invoice_line'] ?? 0;
+    await engine.delete('del_scope_invoice_line', { where: { id: line.id } } as any);
+
+    expect((reads.findOneOn['del_scope_invoice_line'] ?? 0) - before).toBe(1);
+    expect(storeFor('del_scope_invoice').get(parent.id)?.line_total).toBe(0);
+  });
+
+  it('`needsPriorRecord` is NOT a term — a readonlyWhen object still skips the read', async () => {
+    // Stated as a case because it is the one asymmetry with `update()`'s twin
+    // gate, and an honest gate is exactly where someone would reflexively add
+    // it back. `delete()` evaluates no validation rules and no field
+    // predicates, so the term would buy a read with no reader.
+    const { engine, reads } = await boot([], [lockedTask]);
+
+    const row: any = await engine.insert('del_scope_locked', { title: 'Ship it', status: 'done', done: true });
+    const before = reads.findOneOn['del_scope_locked'] ?? 0;
+    await engine.delete('del_scope_locked', { where: { id: row.id } } as any);
+
+    expect((reads.findOneOn['del_scope_locked'] ?? 0) - before).toBe(0);
+    expect(await engine.count('del_scope_locked', {} as any)).toBe(0);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * 2. `excludeObjects` — the registration face that actually narrows the gate
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+describe('[#5929 / #5860] the gate honours `excludeObjects` on both delete phases', () => {
+  /**
+   * plugin-audit's delivered registration face (#5860), replayed here rather
+   * than imported: `@objectstack/objectql` cannot depend on a plugin that
+   * depends on it. What is pinned is the ENGINE's half — `hookMatchesObject`'s
+   * subtract step reaching `hasHooksFor`, hence reaching this read.
+   *
+   * ⚠️ `registerHook` directly, NOT `bindHooksToEngine`: the binder refuses a
+   * hook whose `object` is absent or empty rather than widening it to `'*'`
+   * (#4001), so the global-minus-exclusions face is only expressible on the
+   * engine's own registration API — which is exactly the API plugin-audit uses.
+   */
+  const registerGlobalDeleteHook = (
+    engine: ObjectQL, event: string, sink: unknown[], excludeObjects: string[],
+  ): void => {
+    (engine as any).registerHook(event, (ctx: any) => { sink.push(ctx.object); }, {
+      excludeObjects, packageId: 'app:del-audit-face', priority: 90,
+    });
+  };
+
+  it('an EXCLUDED object skips the prior read, and the hook does not fire on it', async () => {
+    const fired: unknown[] = [];
+    const { engine, reads } = await boot();
+    registerGlobalDeleteHook(engine, 'beforeDelete', fired, ['del_scope_a']);
+
+    const row: any = await engine.insert('del_scope_a', { title: 'A', status: 'todo', done: false });
+    const before = reads.findOneOn['del_scope_a'] ?? 0;
+    await engine.delete('del_scope_a', { where: { id: row.id } } as any);
+
+    expect((reads.findOneOn['del_scope_a'] ?? 0) - before).toBe(0);
+    // The read count and the dispatch agree — which is the property, not a
+    // coincidence: both ask `hookMatchesObject`.
+    expect(fired).toEqual([]);
+  });
+
+  it('a NON-excluded object still pays it and still dispatches', async () => {
+    const fired: unknown[] = [];
+    const { engine, reads } = await boot();
+    registerGlobalDeleteHook(engine, 'beforeDelete', fired, ['del_scope_a']);
+
+    const row: any = await engine.insert('del_scope_b', { title: 'B', status: 'todo', done: false });
+    const before = reads.findOneOn['del_scope_b'] ?? 0;
+    await engine.delete('del_scope_b', { where: { id: row.id } } as any);
+
+    expect((reads.findOneOn['del_scope_b'] ?? 0) - before).toBe(1);
+    expect(fired).toEqual(['del_scope_b']);
+  });
+
+  it('the after phase subtracts the same way', async () => {
+    const fired: unknown[] = [];
+    const { engine, reads } = await boot();
+    registerGlobalDeleteHook(engine, 'afterDelete', fired, ['del_scope_a']);
+
+    const row: any = await engine.insert('del_scope_a', { title: 'A', status: 'todo', done: false });
+    const before = reads.findOneOn['del_scope_a'] ?? 0;
+    await engine.delete('del_scope_a', { where: { id: row.id } } as any);
+
+    expect((reads.findOneOn['del_scope_a'] ?? 0) - before).toBe(0);
+    expect(fired).toEqual([]);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * 3. The bulk path is gated the same way (unchanged by this card, pinned so
+ *    the two halves cannot drift apart unnoticed)
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+describe('[#5929] the predicate delete path asks the same per-object question', () => {
+  it('a bulk delete on a hook-free object reads no matched row set', async () => {
+    const { engine, reads } = await boot([observer('elsewhere', 'del_scope_b', 'beforeDelete', [])]);
+    await engine.insert('del_scope_a', { title: 'A', status: 'stale', done: false });
+
+    const before = reads.findOn['del_scope_a'] ?? 0;
+    await engine.delete('del_scope_a', { multi: true, where: { status: 'stale' } } as any);
+
+    expect((reads.findOn['del_scope_a'] ?? 0) - before).toBe(0);
+    expect(await engine.count('del_scope_a', {} as any)).toBe(0);
+  });
+
+  it('…and reads it exactly once when the object IS hooked', async () => {
+    const seen: Array<unknown> = [];
+    const { engine, reads } = await boot([observer('pre_a', 'del_scope_a', 'beforeDelete', seen)]);
+    await engine.insert('del_scope_a', { title: 'A', status: 'stale', done: false });
+
+    const before = reads.findOn['del_scope_a'] ?? 0;
+    await engine.delete('del_scope_a', { multi: true, where: { status: 'stale' } } as any);
+
+    expect((reads.findOn['del_scope_a'] ?? 0) - before).toBe(1);
+    expect(seen).toHaveLength(1);
+    expect((seen[0] as any).title).toBe('A');
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * 4. THE REGRESSION PIN — a real kernel, where the defect actually lived
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+describe('[#5929] on a KERNEL-hosted engine the per-object skip finally happens', () => {
+  /**
+   * `logger.level: 'silent'` and `gracefulShutdown: false` for the reasons
+   * `plugin.integration.test.ts` records: a test kernel must not log its whole
+   * bootstrap, and must not install process-wide signal handlers that vitest's
+   * SIGTERM worker recycling then races with.
+   */
+  async function bootKernel(objects: ObjectSchema[]) {
+    const kernel = new ObjectKernel({ logger: { level: 'silent' }, gracefulShutdown: false } as any);
+    const stub = makeCountingDriver();
+    await kernel.use({
+      name: 'del-counting-plugin', type: 'driver', version: '1.0.0',
+      init: async (ctx: any) => { ctx.registerService('driver.del-counting', stub.driver); },
+    } as any);
+    await kernel.use(new ObjectQLPlugin());
+    await kernel.bootstrap();
+    const engine = kernel.getService('objectql') as any;
+    for (const o of objects) engine.registry.registerObject(o, 'test', 'test');
+    return { kernel, engine, reads: stub.reads };
+  }
+
+  const kernelTask: ObjectSchema = {
+    name: 'del_kernel_task', label: 'Kernel Task', datasource: 'del-counting',
+    fields: TASK_FIELDS,
+  } as unknown as ObjectSchema;
+
+  it('registers NO `beforeDelete` hook of its own — the builtin is gone', async () => {
+    // The retirement stated as a fact about the booted engine rather than about
+    // `plugin.ts`'s source, so re-adding the hook under any name fails here.
+    const { kernel, engine } = await bootKernel([kernelTask]);
+    try {
+      expect((engine as any).hasHooksFor('beforeDelete', 'del_kernel_task')).toBe(false);
+      expect((engine as any).hasHooksFor('afterDelete', 'del_kernel_task')).toBe(false);
+      // The stamp builtins that DO survive are still bound — this asserts the
+      // absence of one hook, not of the builtin set.
+      expect((engine as any).hasHooksFor('beforeInsert', 'del_kernel_task')).toBe(true);
+      expect((engine as any).hasHooksFor('beforeUpdate', 'del_kernel_task')).toBe(true);
+    } finally {
+      if (kernel.getState() === 'running') await kernel.shutdown();
+    }
+  });
+
+  it('a single-id delete on a hook-free object performs NO prior-row read', async () => {
+    // ⚠️ THE pin. This read count was 1 for every object on every kernel-hosted
+    // engine that has ever run, because `sys_fetch_previous_delete` held term 1
+    // of the gate open — and then never used the row it forced the engine to
+    // fetch.
+    const { kernel, engine, reads } = await bootKernel([kernelTask]);
+    try {
+      const row: any = await engine.insert('del_kernel_task', { title: 'A', status: 'todo', done: false });
+      const beforeFindOne = reads.findOneOn['del_kernel_task'] ?? 0;
+      const beforeFind = reads.findOn['del_kernel_task'] ?? 0;
+
+      await engine.delete('del_kernel_task', { where: { id: row.id } });
+
+      expect((reads.findOneOn['del_kernel_task'] ?? 0) - beforeFindOne).toBe(0);
+      expect((reads.findOn['del_kernel_task'] ?? 0) - beforeFind).toBe(0);
+      expect(await engine.count('del_kernel_task', {})).toBe(0);
+    } finally {
+      if (kernel.getState() === 'running') await kernel.shutdown();
+    }
+  });
+
+  it('an object WITH a real user `beforeDelete` still gets `previous` bound, from ONE read', async () => {
+    // The other half. The retirement must not cost a single binding: the row
+    // still arrives, and it arrives from the ENGINE's #5272/#6697 read — the
+    // count says there was only one, so nothing else supplied it.
+    const { kernel, engine, reads } = await bootKernel([kernelTask]);
+    try {
+      const seen: Array<unknown> = [];
+      bindHooksToEngine(engine, [observer('user_pre', 'del_kernel_task', 'beforeDelete', seen)], {
+        packageId: 'app:del-kernel',
+        logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+      });
+
+      const row: any = await engine.insert('del_kernel_task', { title: 'A', status: 'todo', done: false });
+      const before = reads.findOneOn['del_kernel_task'] ?? 0;
+      await engine.delete('del_kernel_task', { where: { id: row.id } });
+
+      expect((reads.findOneOn['del_kernel_task'] ?? 0) - before).toBe(1);
+      expect(seen).toHaveLength(1);
+      expect(seen[0]).toMatchObject({ id: row.id, title: 'A', status: 'todo' });
+    } finally {
+      if (kernel.getState() === 'running') await kernel.shutdown();
+    }
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * 5. The retired builtin's own shape, replayed — its guard cannot be true
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+describe('[#5929] a fetch-previous `beforeDelete` hook is now dead weight', () => {
+  it('its `!ctx.previous` guard short-circuits, so it issues no read of its own', async () => {
+    // Verbatim the retired builtin's shape — priority 5 (so it runs FIRST),
+    // `beforeDelete`, guard `if (input.id && !ctx.previous)`, fetching through
+    // `ctx.ql` exactly as `plugin.ts` reached for `this.ql`. Measured as a read
+    // count, because "the guard is false now" is the kind of claim that rots
+    // silently: if the engine ever stopped binding `previous` ahead of the
+    // before phase, this count would go to 2 and say so.
+    const supplied: Array<unknown> = [];
+    const { engine, reads } = await boot([
+      {
+        name: 'fetch_previous_delete_replay', object: '*', events: ['beforeDelete'], priority: 5,
+        handler: async (ctx: any) => {
+          if (ctx.input?.id && !ctx.previous) {
+            const existing = await ctx.ql.findOne(ctx.object, {
+              where: { id: ctx.input.id }, context: { isSystem: true },
+            });
+            if (existing) ctx.previous = existing;
+          }
+        },
+      } as unknown as Hook,
+      observer('reads_previous', 'del_scope_a', 'beforeDelete', supplied),
+    ]);
+
+    const row: any = await engine.insert('del_scope_a', { title: 'A', status: 'todo', done: false });
+    const before = reads.findOneOn['del_scope_a'] ?? 0;
+    await engine.delete('del_scope_a', { where: { id: row.id } } as any);
+
+    // The consumer saw the row…
+    expect(supplied).toEqual([{ id: row.id, title: 'A', status: 'todo', done: false }]);
+    // …and exactly ONE read produced it: the engine's. The replayed builtin
+    // added none — which is the whole argument for deleting it rather than
+    // leaving it behind a guard that can no longer be true.
+    expect((reads.findOneOn['del_scope_a'] ?? 0) - before).toBe(1);
+  });
+
+  it('the residual shape — engine read found nothing — leaves `previous` UNBOUND, not fabricated', async () => {
+    // The one shape in which the retired guard could still have been TRUE: the
+    // row is already gone, so the engine's read binds nothing. The builtin's
+    // read would have found nothing either (same row, same scope), so retiring
+    // it changes no binding here — and `bindPreImage` must still refuse to
+    // fabricate `{}`/`null` for a record nobody read (#4649/#4775).
+    const seen: Array<unknown> = [];
+    const { engine } = await boot([observer('pre_a', 'del_scope_a', 'beforeDelete', seen)]);
+
+    await engine.delete('del_scope_a', { where: { id: 'never_existed' } } as any);
+
+    expect(seen).toEqual([undefined]);
+  });
+});

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -7273,6 +7273,48 @@ export class ObjectQL implements IObjectQLEngine {
       // the predicate path — see the pre-phase below. `delete()` was already
       // the right shape here; what changed is that the predicate branch grew
       // the same discipline the by-id branch has had since #5272.
+      //
+      // [#5929] The gate's THREE terms, unchanged by that card and enumerated
+      // here because it had to enumerate them to answer it:
+      //   1. `hasHooksFor('beforeDelete', object)`
+      //   2. `hasHooksFor('afterDelete', object)`
+      //   3. `getSummaryDescriptors(object).length > 0`
+      // No validation term, deliberately — see `needsPriorRecord` above.
+      //
+      // What #5929 changed is not this expression but what term 1 MEANS. Until
+      // then, objectql's own `ObjectQLPlugin` registered a builtin
+      // `sys_fetch_previous_delete` on `beforeDelete` with `object: '*'`, so on
+      // every kernel-hosted engine term 1 was true for every object and the
+      // per-object skip this gate exists to perform could never happen. The
+      // builtin's only remaining effect WAS holding this gate open: the read
+      // below binds `previous` before `beforeDelete` dispatches, so its own
+      // `!ctx.previous` guard was already unreachable. Retiring it (plugin.ts,
+      // ADR-0049 enforce-or-remove) makes term 1 an honest question.
+      //
+      // ⚠️ Honest is not the same as usually-false, and the difference is worth
+      // knowing before anyone reads a skip into a production trace. Every
+      // delete-phase hook below registers with NO `object` — global — so each
+      // holds term 1 or term 2 open for every object on a kernel that loads it:
+      //
+      //   * `plugin-auth`   identity-write-guard  beforeDelete  (filters by
+      //                     `isManaged(ctx.object)` inside the handler)
+      //   * `plugin-sharing` record-share-cascade  before+afterDelete (filters
+      //                     by `targets(objectName)` inside the handler)
+      //   * `service-storage` file-reference-lifecycle before+afterDelete
+      //                     (filters by `activeFileFields(object)` inside)
+      //   * `plugin-audit`  captureBefore / writeAudit before+afterDelete,
+      //                     global MINUS `excludeObjects: AUDIT_EXCLUDED_OBJECTS`
+      //                     (#5860) — the one that narrows at the ENGINE face,
+      //                     so `hookMatchesObject` can subtract it and an
+      //                     excluded object really does skip this read.
+      //
+      // The first three are real handlers with real work, merely deciding their
+      // own applicability at dispatch time rather than at registration time;
+      // this gate answering "yes" for them is the gate WORKING, not a second
+      // instance of the #5929 defect. Narrowing any of them to the objects it
+      // actually serves — plugin-audit's `excludeObjects` face is the worked
+      // example — is what would convert them into skips, and that is each
+      // package's own card, not this one's.
       const deleteSchema = this._registry.getObject(object);
       const wantsPreImage =
         this.hasHooksFor('beforeDelete', object) ||

--- a/packages/objectql/src/plugin.ts
+++ b/packages/objectql/src/plugin.ts
@@ -917,51 +917,51 @@ export class ObjectQLPlugin implements Plugin {
       // This change removes one and makes the engine's the single producer;
       // `captureBefore`'s now-redundant read is the identity lane's follow-up.
       //
-      // ⚠️ `sys_fetch_previous_delete` below is in the SAME position now, and is
-      // deliberately left standing because retiring it is #5929's card, not a
-      // rider on this one. Recording the measurement so that card does not have
-      // to rediscover it:
+      // ⛔ RETIRED — `sys_fetch_previous_delete` (#5929, ADR-0049
+      // enforce-or-remove). Do not reintroduce it.
       //
-      // `delete()` reads its pre-image when `wantsPreImage` is true, and that
-      // gate is `hasHooksFor('beforeDelete', object) || hasHooksFor(
-      // 'afterDelete', object) || summaries`. The builtin is itself a
-      // `beforeDelete` hook on `'*'`, so it makes the FIRST term true for every
-      // object — and then the engine's read binds `previous` before the builtin
-      // runs, so the builtin's own `!ctx.previous` guard is false and it issues
-      // no `findOne`. It is circular: the builtin's only remaining effect is to
-      // hold open the gate that makes it redundant. That circularity IS #5929
-      // ("the delete-side per-object gate is always true"), and after this
-      // change its resolution is the same retirement performed above, with the
-      // same argument.
+      // #5846 left the measurement here rather than the hook, precisely so this
+      // retirement would not have to rediscover it. Quoted from the block above
+      // as it stood then, because it IS the argument:
       //
-      // The one shape where the guard can still be true — the engine read found
-      // nothing (the row is already gone) — is one where the builtin's read
-      // finds nothing either, so it changes no binding.
-      {
-        name: 'sys_fetch_previous_delete',
-        object: '*',
-        events: ['beforeDelete'],
-        priority: 5,
-        description: 'Auto-fetch the previous record for delete hooks',
-        handler: async (hookCtx: any) => {
-          if (hookCtx.input?.id && !hookCtx.previous) {
-            try {
-              const existing = await this.ql!.findOne(hookCtx.object, {
-                where: { id: hookCtx.input.id },
-                context: {
-                  positions: [],
-                  permissions: [],
-                  isSystem: true,
-                  ...(hookCtx.transaction ? { transaction: hookCtx.transaction } : {}),
-                } as any,
-              });
-              if (existing) hookCtx.previous = existing;
-            } catch (_e) {
-              // Non-fatal
-            }
-          }
-        },
-      },
+      //   `delete()` reads its pre-image when `wantsPreImage` is true, and that
+      //   gate is `hasHooksFor('beforeDelete', object) || hasHooksFor(
+      //   'afterDelete', object) || summaries`. The builtin is itself a
+      //   `beforeDelete` hook on `'*'`, so it makes the FIRST term true for
+      //   every object — and then the engine's read binds `previous` before the
+      //   builtin runs, so the builtin's own `!ctx.previous` guard is false and
+      //   it issues no `findOne`. It is circular: the builtin's only remaining
+      //   effect is to hold open the gate that makes it redundant.
+      //
+      // Verified on this branch before removing anything, because a measurement
+      // recorded on one PR is a hypothesis on the next: the engine binds
+      // `previous` ahead of `beforeDelete` on BOTH delete shapes — by-id since
+      // #5272, per matched row since #6697 — so the guard is unreachable in
+      // production, and removing the hook changes no `previous` binding
+      // anywhere. The residual shape, `!hookCtx.previous` because the engine's
+      // own read found nothing, is one where this handler's read finds nothing
+      // either (same row, same transaction, same tenant scope): it binds
+      // nothing, and `bindPreImage` deliberately leaves `previous` UNBOUND
+      // rather than fabricating `{}` (#4649/#4775).
+      //
+      // What retiring it buys, and what it does NOT buy — both worth stating so
+      // the next reader does not over-read the result:
+      //   * it makes `hasHooksFor('beforeDelete', object)` an honest question on
+      //     an objectql-only kernel, so an object with no delete-side hook and
+      //     no roll-up summary finally pays NO prior-row read on a by-id
+      //     `delete()`. That skip could never happen while this hook stood.
+      //   * it does not, on its own, make the gate false on a kernel that also
+      //     loads plugin-auth / plugin-sharing / plugin-audit: each of those
+      //     registers a delete-phase hook with no `object` (i.e. global), and
+      //     they hold the same gate open for their own reasons. Those are real
+      //     consumers with real handlers, not circular ones — the gate answering
+      //     "yes" for them is the gate working. The enumeration lives in
+      //     `engine.ts` beside `wantsPreImage`.
+      //
+      // The retired hook's own shape is replayed as an authored hook in
+      // `engine-delete-prior-read-scope.test.ts`, which measures that its guard
+      // short-circuits and it issues zero reads — so "the guard can no longer be
+      // true" stays a measurement instead of rotting into a claim.
     ];
 
     if (typeof (this.ql as any).bindHooks === 'function') {
@@ -979,7 +979,12 @@ export class ObjectQLPlugin implements Plugin {
       }
     }
 
-    ctx.logger.debug('Audit hooks registered via binder (created_by/updated_by, previousData)');
+    // `previousData` used to be listed here as a third thing these builtins
+    // did. It is not one any more: both fetch-previous hooks are retired
+    // (#5846 update-side, #5929 delete-side) and `previous` is bound by the
+    // ENGINE on both write paths. A log line naming a producer that no longer
+    // exists is the cheapest way to send the next reader looking for it.
+    ctx.logger.debug('Audit hooks registered via binder (created_by/updated_by/created_at/updated_at/tenant_id stamping)');
   }
 
   /**

--- a/packages/plugins/plugin-auth/src/last-admin-guard.ts
+++ b/packages/plugins/plugin-auth/src/last-admin-guard.ts
@@ -205,9 +205,11 @@
  *    the id alone — and reading it that way approved a sweep of every
  *    administrator one legitimate-looking row at a time. `options.multi` is the
  *    discriminator, and `resolveTargetIds` asks it FIRST. See that function.
- *  - `ctx.previous` (the engine's #5272 pre-image, and objectql's
- *    `sys_fetch_previous_delete` builtin — `object: '*'`, priority 5) is now
- *    bound on BOTH shapes: by-id since #5272, and per matched row since #5574.
+ *  - `ctx.previous` (the engine's #5272 pre-image — its SOLE producer since
+ *    #5929, which retired objectql's `sys_fetch_previous_delete` builtin
+ *    (`object: '*'`, priority 5) once the engine's own earlier read made that
+ *    hook's `!ctx.previous` guard unreachable) is now bound on BOTH shapes:
+ *    by-id since #5272, and per matched row since #5574.
  *    The guard still never consumes it, and the reason is sharper than before:
  *    it needs the target IDS as a SET, and a `previous`-based implementation
  *    would see exactly one row per dispatch — correct for a single write and


### PR DESCRIPTION
Fixes #5929

## The premise, verified before anything was removed

The card was filed 08-06 and both files it names were rewritten on 08-08 by #6697, so every claim was re-anchored on current `main` rather than taken from the issue text.

**Premise as filed:** `delete()`'s per-object prior-row gate is constant true on any kernel-managed engine, because `ObjectQLPlugin`'s `sys_fetch_previous_delete` registers on `beforeDelete` with `object: '*'`. **CONFIRMED.**

**Premise as upgraded by #6697's measurement:** the builtin is *circular* — the engine binds `previous` before `beforeDelete` dispatches, so the builtin's `!ctx.previous` guard is permanently false and its only remaining effect is holding open the gate that makes it redundant. **CONFIRMED, and re-measured rather than trusted** (see A1 below).

The measurement #6697 left behind, cited as asked — `packages/objectql/src/plugin.ts` (pre-change lines 920–939), inside the `sys_fetch_previous_update` retirement block:

> `delete()` reads its pre-image when `wantsPreImage` is true, and that gate is `hasHooksFor('beforeDelete', object) || hasHooksFor('afterDelete', object) || summaries`. The builtin is itself a `beforeDelete` hook on `'*'`, so it makes the FIRST term true for every object — and then the engine's read binds `previous` before the builtin runs, so the builtin's own `!ctx.previous` guard is false and it issues no `findOne`. It is circular: the builtin's only remaining effect is to hold open the gate that makes it redundant.

**Other consumers of the retired name — checked first, as instructed.** Grep for the quoted exact name across the repo (declarations, registrations, docs, JSON) returned exactly three hits: the declaration and the `plugin.ts` comment above it, plus one **doc comment** in `packages/plugins/plugin-auth/src/last-admin-guard.ts` which names the builtin as a co-producer of `ctx.previous` and states in the same sentence that the guard "still never consumes it". No live consumer. That comment is corrected here rather than left describing a hook that no longer exists.

## The work

**1. Retired `sys_fetch_previous_delete`** (`packages/objectql/src/plugin.ts`) under ADR-0049 enforce-or-remove, replaced by a `⛔ RETIRED` block in the shape #5846 used for its update-side twin: the argument, the residual shape, and — new — an explicit statement of what the retirement does *not* buy, so the next reader does not over-read the result.

Also corrected in the same file: the binder's debug line still advertised `previousData` as something these builtins produce. With both fetch-previous builtins retired, it named a producer that no longer exists.

**2. The delete-path per-object gate.** Enumerated fresh from current `main` (`engine.ts`, by-id branch). It has **three** terms:

| # | Term | Touched? |
|---|---|---|
| 1 | `hasHooksFor('beforeDelete', object)` | no |
| 2 | `hasHooksFor('afterDelete', object)` | no |
| 3 | `getSummaryDescriptors(object).length > 0` | no |

There is **no** summary/validation term beyond #3, and `needsPriorRecord(schema)` is deliberately absent (its own comment says why: `delete()` evaluates no validation rules, so the term would buy a read with no reader). The predicate branch carries its own twin gate, terms 1 and 2 only, likewise untouched.

**I changed no term.** The gate was already written honestly; what was dishonest was its *first term's answer*, and the `'*'` registration was the entire cause. Retiring the builtin is the whole fix. What `engine.ts` gains is the A2 enumeration recorded beside `wantsPreImage`, so the honest gate is not mistaken for a usually-false one.

**3. Acceptance pins** — new `packages/objectql/src/engine-delete-prior-read-scope.test.ts` (16 cases), the delete-side counterpart of `engine-update-prior-read-scope.test.ts`:

- kernel **without** delete hooks for an object: single-id `delete()` performs **zero** prior-row reads — asserted as driver call counts, per object, on a real `ObjectKernel` + `ObjectQLPlugin` (the only configuration where the defect was ever observable);
- object **with** a real user `beforeDelete` on that same kernel: `previous` still arrives bound, from **exactly one** read — the engine's #5272/#6697 read, and the count is what proves nothing else supplied it;
- the kernel engine registers **no** `beforeDelete`/`afterDelete` hook of its own, while the surviving stamp builtins stay bound (asserts the absence of one hook, not of the builtin set);
- `excludeObjects` (#6575 semantics / #5860's delivered registration face): an excluded object skips the read and does not dispatch; a non-excluded one pays it and does. Both phases. Registered through `engine.registerHook` — the binder refuses an absent `object` rather than widening it (#4001), so global-minus-exclusions is only expressible on the engine API, which is the API plugin-audit uses;
- the bare-engine per-object cases: term 1 alone, term 2 alone, term 3 alone, `'*'` still demanding the read everywhere, and `needsPriorRecord` explicitly *not* a term;
- the retired builtin's shape replayed as an authored hook, measuring its guard short-circuiting to zero reads;
- the residual shape (engine read found nothing) leaving `previous` **unbound**, not fabricated (#4649/#4775).

**4. The by-id delete REPOINT is untouched** (#6752 pending). `bulk-write-per-row-hooks.test.ts`'s `still HONOURS a by-id beforeDelete REPOINT — deliberately not retired here` is green. Nothing in this diff changes when the repoint's re-read happens: the re-read is guarded by the same `wantsPreImage` value computed once before the before phase, and that value's *computation* is unchanged — only what one of its inputs answers on a kernel.

## A1 — "retiring the builtin changes no observable binding anywhere"

**ANSWERED: true.** Reverse-verified in the direction the card asked for.

*Predicted:* with the builtin removed and **no** gate change, the full `@objectstack/objectql` suite stays green, with no failure at all — grep having already established that no test names the builtin as a live registration, only as prose.

*Actual:* `Test Files 149 passed (149) · Tests 2575 passed (2575)`. Zero failures. The premise has no hole.

## A2 — "does another `'*'` delete-phase builtin silently re-open the gate?"

**ANSWERED: no `'*'`-spelled one remains — but four packages register delete-phase hooks with `object` absent, which is the same thing by another spelling.** Enumerated exhaustively; every delete-phase registration in non-test source was read and classified:

| Package / file | Events | Engine-visible scope | Holds the gate open? |
|---|---|---|---|
| `objectql` `plugin.ts` | `beforeDelete` | `object: '*'` | **retired by this PR** |
| `plugin-auth` `identity-write-guard.ts` | `beforeDelete` | no `object` ⇒ global | yes — filters `isManaged(ctx.object)` inside the handler |
| `plugin-sharing` `record-share-cascade.ts` | `before`+`afterDelete` | no `object` ⇒ global | yes — filters `targets(objectName)` inside the handler |
| `service-storage` `file-reference-lifecycle.ts` | `before`+`afterDelete` | no `object` ⇒ global | yes — filters `activeFileFields(object)` inside the handler |
| `plugin-audit` `audit-writers.ts` | `before`+`afterDelete` | global **minus** `excludeObjects: AUDIT_EXCLUDED_OBJECTS` (#5860) | yes, except on excluded objects — which really do skip the read |
| `plugin-auth` `last-admin-guard.ts` | `beforeDelete` ×4 | object-scoped | no |
| `plugin-sharing` `rule-hooks.ts`, `primary-bu-projection.ts`, `sharing-plugin.ts` | delete phases | object-scoped | no |
| `service-storage` `attachment-lifecycle.ts`, `attachment-access-hooks.ts` | delete phases | `object: 'sys_attachment'` | no |
| `plugin-audit` `comment-access-hooks.ts` | `beforeDelete` | `object: 'sys_comment'` | no |

The four global ones are **real consumers with real handlers** — they merely decide applicability at dispatch time rather than at registration time. The gate answering "yes" for them is the gate working, not a second instance of #5929: what made the builtin a defect was that it consumed nothing. Narrowing any of them to the objects it actually serves is that package's own card; plugin-audit's `excludeObjects` face is the worked example of how, and this PR pins that the engine half of it works on both delete phases. This is stated in `engine.ts` and in the changeset so nobody expects a skip on a full kernel that will not appear.

## Reverse verification of the new pins

A pin that cannot fail is not a pin. Predicted-then-actual, with the builtin temporarily restored from `origin/main` and the new file re-run:

*Predicted:* exactly two cases red — `registers NO beforeDelete hook of its own` (`hasHooksFor` true) and `a single-id delete on a hook-free object performs NO prior-row read` (delta 1, not 0). The `previous` still bound from ONE read case stays **green**, because the builtin's guard short-circuits and it adds no read. Every bare-engine case stays green (a bare engine never carried the builtin).

*Actual:* `Tests 2 failed | 14 passed (16)` — `registers NO beforeDelete hook of its own`: `expected true to be false`; `a single-id delete on a hook-free object performs NO prior-row read`: `expected 1 to be +0`. Nothing else moved.

That second run is also the cleanest independent confirmation of the circularity claim: **with the builtin present**, the hooked-object case still measured exactly **one** read — so the builtin issued none, exactly as #6697 recorded.

Two harness bugs were found and fixed by this exercise rather than papered over: the counting driver's `deleteMany`/`updateMany`/`count` routed through their own `find()`, charging the engine for reads it never issued; and `bindHooksToEngine` refuses an absent `object` (#4001), so the `excludeObjects` face had to be registered through `engine.registerHook` — the first version's "excluded object skips the read" passed for the wrong reason, because the hook had never registered at all.

## Scope

`packages/objectql/src/plugin.ts` (the retirement) · `packages/objectql/src/engine.ts` (delete-gate region comment only — no term changed) · one stale doc comment in `plugin-auth/src/last-admin-guard.ts` · the new test file · `.changeset/`. No spec changes, no plugin-audit edits, nothing in the `registerObject`/registry region (#5543) or `resolveMasterDetailParent(s)` (#6457). `origin/main` merged immediately before opening this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNT8SWDEsDQp2TrmSBizKq)_