### PR TITLE
docs(lint,objectql): correct the null-guard seam ledger after #6454 — readonlyWhen is TOTAL, excluded by ruling, not by binding

### DIFF
--- a/packages/lint/src/validate-expressions.test.ts
+++ b/packages/lint/src/validate-expressions.test.ts
@@ -1559,7 +1559,8 @@ describe('null-guard gate (#4763)', () => {
     // flattened scope (this gate never resolves a bare identifier — only
     // `record.<f>`/`previous.<f>`, and the engine binds both roots
     // unconditionally). It is that `record-change-trigger.ts` seeds the flow's
-    // record as `{ ...inputDoc, ...after }` with no `materializeDeclaredFields`,
+    // record as `{ ...(inputData ?? {}), ...after }` (spelled `inputDoc` until
+    // #5671 dropped that alias read) with no `materializeDeclaredFields`,
     // so a declared column the write never mentioned is an ABSENT key — and on
     // an absent key the `!= null` this gate prescribes faults exactly like the
     // comparison it was meant to guard.

--- a/packages/lint/src/validate-expressions.ts
+++ b/packages/lint/src/validate-expressions.ts
@@ -340,14 +340,19 @@ export function validateStackExpressions(stack: AnyRec): ExprIssue[] {
    * (`rule-validator.ts`, fail-closed since #4761), lifecycle hook `condition`s,
    * and field `requiredWhen` (#4811).
    *
-   * Totality is the whole criterion, not a detail: on a total binding `has()` is
-   * uniformly true and `!= null` is the fix, while on a SPARSE one `has()` is a
-   * genuine guard and `!= null` faults with `No such key` — so pointing this gate
-   * at a sparse-bound surface would reject correct metadata and prescribe a fix
-   * that breaks it. `validate-null-guards.ts` carries the measured evidence table
-   * and the per-surface ledger (action predicates, flow conditions, field
-   * `readonlyWhen`, sharing rules and `Field.formula` are each excluded there with
-   * a traced reason). Read it before extending this call.
+   * Totality is the criterion that can DISQUALIFY a surface: on a total binding
+   * `has()` is uniformly true and `!= null` is the fix, while on a SPARSE one
+   * `has()` is a genuine guard and `!= null` faults with `No such key` — so
+   * pointing this gate at a sparse-bound surface would reject correct metadata
+   * and prescribe a fix that breaks it. It is not by itself a licence to cover:
+   * since #6454 field `readonlyWhen` is total and still excluded, by clause 3 of
+   * the #4953 ruling (the gate widens only once BOTH server-side seams are
+   * total, and the flow trigger-record half is not wired yet).
+   * `validate-null-guards.ts` carries the measured evidence table and the
+   * per-surface ledger (action predicates, flow conditions, field
+   * `readonlyWhen`, sharing rules and `Field.formula` are each excluded there
+   * with a traced reason, and the reasons are no longer all the same one). Read
+   * it before extending this call.
    */
   const checkNullGuards = (
     where: string,
@@ -609,7 +614,8 @@ export function validateStackExpressions(stack: AnyRec): ExprIssue[] {
       // unconditionally, so it is immune to that ambiguity.
       //
       // The real blocker is totality. `record-change-trigger.ts` seeds the flow's
-      // record as `{ ...inputDoc, ...after }` with no `materializeDeclaredFields`,
+      // record as `{ ...(inputData ?? {}), ...after }` (spelled `inputDoc` until
+      // #5671 dropped that alias read) with no `materializeDeclaredFields`,
       // so a declared column the write never mentioned is an ABSENT key, not a
       // null one — and there `record.x != null` faults (`No such key`) exactly
       // like the comparison it was meant to guard. The gate's prescription is
@@ -775,12 +781,16 @@ export function validateStackExpressions(stack: AnyRec): ExprIssue[] {
       // required and the write sails through. Validation rules at least
       // reject fail-closed since #4761.
       //
-      // `readonlyWhen` is deliberately NOT included even though it sits on
-      // the same field: it is evaluated by `stripReadonlyWhenFields`, which
-      // builds `{ ...previous, ...data }` and never materializes, so its
-      // binding is sparse and `!= null` would be the wrong prescription
-      // there. Same for `conditionalRequired` / `visibleWhen`, which have no
-      // record-scoped total binding of their own. See the surface ledger in
+      // `readonlyWhen` is still NOT included even though it sits on the same
+      // field — but no longer because its binding is sparse. Since #6454
+      // `readonlyWhenBindings` runs both roots through
+      // `materializeDeclaredFields`, so `!= null` IS the right prescription
+      // there now; what holds the wiring back is clause 3 of the #4953 ruling
+      // (both server-side seams first — the flow trigger-record half is
+      // outstanding). When it is wired it needs `'fail-open'`, like
+      // `requiredWhen` above and unlike the validation-rule surface. Same for
+      // `conditionalRequired` / `visibleWhen`, which have no record-scoped
+      // total binding of their own. See the surface ledger in
       // `validate-null-guards.ts`.
       checkNullGuards(
         `object '${objectName}' · field '${fname}' requiredWhen`,

--- a/packages/lint/src/validate-null-guards.ts
+++ b/packages/lint/src/validate-null-guards.ts
@@ -65,24 +65,64 @@
  * breaks it — strictly worse than not covering the surface at all. Hence:
  *
  * **This module may only be wired to a surface whose record binding is total.**
+ * Necessary, not sufficient — see the `readonlyWhen` row below, where a total
+ * binding is still excluded for a reason totality has nothing to say about.
  *
  * Surface ledger (each verdict traced to the code that decides it, so the next
- * author does not have to re-derive it — #4811):
+ * author does not have to re-derive it — #4811). `binding` is the measured
+ * shape TODAY; `verdict` is whether this gate runs there. Those are two
+ * questions, and since #6454 they have come apart on one row:
  *
  * | surface                        | binding | evidence                                                    | verdict |
  * |:-------------------------------|:--------|:------------------------------------------------------------|:--------|
  * | object validation rules        | TOTAL   | `rule-validator.ts` `materializeDeclaredFields(merged, …)`   | covered |
  * | lifecycle hook `condition`     | TOTAL   | `hook-wrappers.ts` `materializeDeclaredFields(…)`            | covered |
  * | field `requiredWhen`           | TOTAL   | same `merged` in `evaluateValidationRules` — fail-OPEN, so an unguarded predicate enforces NOTHING in silence | covered (#4811) |
- * | field `readonlyWhen`           | sparse  | `stripReadonlyWhenFields` merges `{...previous, ...data}` and never materializes | excluded |
- * | action `visible` / `disabled`  | sparse  | evaluated client-side; no materialization exists in `objectui` | excluded |
- * | flow / edge `condition`        | sparse  | `record-change-trigger.ts` seeds `{...inputDoc, ...after}`   | excluded |
+ * | field `readonlyWhen`           | TOTAL   | `rule-validator.ts` `readonlyWhenBindings` materialises BOTH roots (#4953 clause 1, landed in #6454) | excluded — NOT on totality; see below |
+ * | action `visible` / `disabled`  | sparse  | evaluated client-side; no materialization exists in `objectui` | excluded (decided — #4953 clause 2) |
+ * | flow / edge `condition`        | sparse  | `record-change-trigger.ts` seeds `{...(inputData ?? {}), ...after}` — #4953 clause 1's other half, not yet wired | excluded (not yet) |
  * | sharing-rule `condition`       | n/a     | compiled to a SQL filter; `NULL > x` is three-valued, never faults | excluded |
  * | field `expression` (`Field.formula`) | n/a | product judgement, not a wiring gap — see below              | excluded |
  *
- * The three exclusions that are *not* self-evident, spelled out because a
+ * The four exclusions that are *not* self-evident, spelled out because a
  * surface excluded without a reason is indistinguishable from one nobody
  * looked at — the failure mode this whole family of issues is about:
+ *
+ *  - **Field `readonlyWhen` — the row where `binding` and `verdict` came
+ *    apart.** Its binding is no longer sparse. Since #6454 (the engine-core
+ *    share of the maintainer's #4953 ruling, clause 1) `rule-validator.ts`
+ *    builds the two roots in `readonlyWhenBindings` and runs BOTH — `record`
+ *    (the prior row overlaid with the PATCH) and `previous` — through the same
+ *    `materializeDeclaredFields`. The totality criterion above is therefore
+ *    SATISFIED here, and the evidence this row used to carry
+ *    (`stripReadonlyWhenFields` merging `{...previous, ...data}` raw)
+ *    describes code that no longer exists. What keeps the row excluded is
+ *    clause 3 of the same ruling: the gate widens once BOTH server-side seams
+ *    are total, and the other one — flow trigger-record seeding, services
+ *    lane — is not wired yet. Widening this face alone would also mean the
+ *    `binding` column had stopped being the thing that decides coverage,
+ *    which is the property #4811 bought.
+ *
+ *    Two facts to carry into that widening; neither is bookkeeping:
+ *
+ *      1. **The fail policy is the OPPOSITE of the two surfaces #4763 wired.**
+ *         Validation rules and hook `condition`s are fail-CLOSED. A faulting
+ *         `readonlyWhen` is fail-OPEN: `isReadonlyWhenLocked` logs
+ *         `failed to evaluate — change allowed through`, and the field the
+ *         author declared frozen is WRITTEN. (One exception, #4889 — a fault
+ *         naming an UNBOUND ROOT resolves to LOCKED.) So this face wants
+ *         {@link nullGuardMessage}'s `'fail-open'` outcome for the same reason
+ *         the `requiredWhen` row already carries it: the damage is a declared
+ *         lock that silently enforces nothing, not a rejected write.
+ *      2. **Making the binding total moved one verdict the OTHER way.** On a
+ *         total record `has(record.<declared>)` is uniformly TRUE and
+ *         `!has(record.<declared>)` uniformly FALSE, so a lock spelled
+ *         `readonlyWhen: !has(record.b)` STOPPED locking when #6454 landed.
+ *         That is the `declared-fields.ts` contract since #4649 — `has()`
+ *         guards an UNDECLARED key, never an empty value; test emptiness with
+ *         `!= null` — and #6454 measured the cell and pinned both spellings in
+ *         `rule-validator.test.ts`. It is why "this face is materialized now"
+ *         is not, on its own, an accurate summary of what changed here.
  *
  *  - **Action `visible` / `disabled`.** #4811 asked whether the ActionEngine
  *    materializes declared fields before evaluating. It does not: the record
@@ -93,17 +133,29 @@
  *    `ExpressionInputSchema`, which the renderers preserve) and a fault IS
  *    fail-closed — the action silently vanishes — so the *trap* is real here.
  *    But with a sparse binding the prescription inverts (see the table), so the
- *    gate cannot be the thing that catches it. Covering this surface requires
- *    first deciding whether the action-predicate binding should be made total,
- *    which is a platform contract change, not a lint change.
+ *    gate cannot be the thing that catches it. That question is now DECIDED
+ *    rather than open: #4953 clause 2 defers making this binding total —
+ *    it would mean every REST read padding out all declared columns — so the
+ *    face stays sparse, is documented as sparse, and an author there guards
+ *    with `has()` (`declared-fields.ts` says the same from the engine's side).
+ *    The exclusion is permanent under the current decision, not pending one.
+ *    The ruling's replacement action for this face is the MIRROR of this gate
+ *    — flag `!= null` on a sparse binding — and it is an evaluation owed by
+ *    the devx / objectui lanes, never a widening of `checkNullGuards`.
  *  - **Flow / edge `condition`.** #4811 excluded these for flattened-scope
  *    ambiguity ("a bare identifier may be a flow variable"). That reason does
  *    not actually apply to this module — {@link findUnguardedNullableOperands}
  *    only ever resolves `record.<f>` / `previous.<f>` and never a bare
  *    identifier, and the engine binds `record` / `previous` unconditionally.
  *    The real blocker is totality: the trigger seeds the record as
- *    `{...inputDoc, ...after}`, so a declared column the write never mentioned
+ *    `{...(inputData ?? {}), ...after}` — spelled `inputDoc` here until #5671
+ *    dropped that alias read — so a declared column the write never mentioned
  *    is an ABSENT key, and the `!= null` this gate prescribes would fault.
+ *    Since #4953 that sparseness is a NOT-YET rather than a decision: clause 1
+ *    puts this seam under the same server-side totality guarantee as
+ *    `readonlyWhen`, and only the services-lane wiring is outstanding. When it
+ *    lands, this row and the `readonlyWhen` row flip together — which is
+ *    exactly what clause 3 asks for.
  *    (The flattened-scope ambiguity is real for a *bare-identifier* checker —
  *    flow inputs shadow record fields, and a node's `outputVariable` can
  *    overwrite either — but that is a different, unbuilt pass.)

--- a/packages/objectql/src/cel-fault.ts
+++ b/packages/objectql/src/cel-fault.ts
@@ -9,7 +9,12 @@
  * `condition`s (`hook-wrappers.ts`, #4775). Both were told to reuse ONE error
  * shape, and the only durable way to keep two messages worded alike is to stop
  * writing them twice — the same argument that put {@link
- * ./declared-fields.js#materializeDeclaredFields} in front of both evaluators.
+ * ./declared-fields.js#materializeDeclaredFields} in front of every server-side
+ * evaluator: two when this module was written, THREE since #4953 added the
+ * field `readonlyWhen` strips. That third seam is fail-open rather than
+ * rejecting, so it reads only {@link unknownVariableOf} (the #4889
+ * unbound-root branch) and never {@link describeCelFault}'s rejection
+ * sentences.
  *
  * This module has no opinion about what a caller does with a fault. It answers
  * three questions and hands back a sentence:


### PR DESCRIPTION
Fixes #6458

## Problem

The surface ledger in `packages/lint/src/validate-null-guards.ts` — the module-header table the next author reads to decide whether a seam joins the null-guard gate (#4811: "a surface excluded without a reason is indistinguishable from one nobody looked at") — still carried this row:

```
| field `readonlyWhen` | sparse | `stripReadonlyWhenFields` merges {...previous, ...data} and never materializes | excluded |
```

That row became false the moment PR #6454 merged (2026-08-07 22:14 UTC). #6454's own body says it deliberately did not touch `packages/lint` (quoted verbatim, per its Chinese original): 「#4811 的 null-guard 闸门扩面按裁决第 3 条要等两处服务端接缝都齐,故本 PR **不触 `packages/lint`**」— so the ledger was knowingly left behind, and this PR is the catch-up. Re-verified on `origin/main` (`64d764e76`) before editing: `readonlyWhenBindings` (rule-validator.ts:474) runs both the `record` and `previous` roots through `materializeDeclaredFields`; the code the evidence column pointed at no longer exists.

## What the corrected row says — deliberately not "now materialized"

A one-word swap from `sparse` to `TOTAL` would replace one false statement with another, because #6454's measured grid was not uniform — one cell flipped the opposite way:

| predicate | before (sparse prior) | after (sparse prior) |
|---|---|---|
| `record.b == null` | fault, change passes | true, change stripped |
| `has(record.b)` | false, change passes | true, change stripped |
| `!has(record.b)` | **true, change stripped** | **false, change passes** |

A lock spelled `!has(record.b)` **stopped locking** when #6454 landed. The rewritten row therefore records three facts, each traced to code:

1. **Binding: TOTAL** — `readonlyWhenBindings` materialises both roots (#4953 clause 1, landed in #6454). The totality criterion is now satisfied on this face.
2. **Verdict: still excluded — but the reason changed.** Not "the binding is sparse, the rule would prescribe the wrong fix" anymore; now it is clause 3 of the maintainer's 2026-08-06 ruling on #4953: the gate widens only once BOTH server-side seams are total, and the flow trigger-record half (services lane) is not wired yet. The header now states explicitly that totality is necessary but not sufficient — `binding` and `verdict` are two different questions and have come apart on this row.
3. **Two facts the future widening must carry into the evidence column** (the issue's half 2, recorded now so they are not re-derived): the face is fail-OPEN (`isReadonlyWhenLocked` logs `failed to evaluate — change allowed through`; exception: the #4889 unbound-root branch resolves LOCKED), so it wants `nullGuardMessage`'s `'fail-open'` outcome like `requiredWhen`; and the `!has(record.b)` reversal above, pinned by #6454 in `rule-validator.test.ts` in both spellings.

## Neighbouring rows — checked in the same pass, verdicts stated explicitly

- **flow / edge `condition` (stale, fixed):** the binding is still sparse (verified: `record-change-trigger.ts:309` seeds `{ ...(inputData ?? {}), ...after }`, no materialization), but the row's standing changed with the same ruling: this is #4953 clause 1's *other* half, so the exclusion is now a NOT-YET (services lane outstanding) rather than an open question. When it lands, this row and the `readonlyWhen` row flip together — exactly clause 3's condition. Also renamed the evidence's `inputDoc` spelling to `inputData` (#5671 dropped that alias read; the old name no longer appears in the trigger), here and in the two `validate-expressions.ts` / `.test.ts` comments that quoted it.
- **action `visible` / `disabled` (reason upgraded):** still sparse (no materialization exists in objectui on that path — unchanged), but the "requires first deciding whether the binding should be made total" sentence was stale: #4953 clause 2 DECIDED it. The face stays sparse by ruling (totalising would mean every REST read padding out all declared columns); authors there guard with `has()`. The row now cites the decision instead of asking for one.
- **object validation rules / lifecycle hook `condition` / field `requiredWhen`:** checked, still true — `rule-validator.ts:1370` (`materializeDeclaredFields(merged, fields)`), `hook-wrappers.ts:886/889/946`, and the `requiredWhen` row's fail-open note all still describe the code on main. Unchanged.
- **sharing-rule `condition` / field `expression`:** checked, still true — SQL compilation and the #5026 product-judgement exclusion are untouched by #6454. Unchanged.

## The rider the issue named

`packages/objectql/src/cel-fault.ts`'s header said `materializeDeclaredFields` sits "in front of **both** evaluators" — three server-side seams since #4953. Corrected in place, with the note that the third seam (fail-open) reads only `unknownVariableOf` and never this module's rejection sentences (which is why cel-fault itself needed no code change in #6454). Two lines of the same drift, same cause, folded in per the triage comment; it stayed a comment-only edit, so no lane boundary issue arose.

Also updated: the `checkNullGuards` doc block in `validate-expressions.ts`, which repeated the sparse-binding claim for `readonlyWhen` ("its binding is sparse and `!= null` would be the wrong prescription") — now states the real blocker (clause 3) and the `'fail-open'` outcome the future wiring needs.

## Scope guard

- ⛔ The gate itself is NOT widened: `checkNullGuards` call sites are unchanged; `validate-expressions.ts` / `.test.ts` edits are comment text only. Widening is #4811 / ruling clause 3 and waits for the services half.
- ⛔ `validate-translation-references.ts` untouched (claimed in parallel under #6422).
- No behaviour moves anywhere: the diff is doc comments in 3 source files + 1 test-file comment.

## Verification honesty

This ledger is a decision input, not a machine-read artifact: **no test or gate asserts its text**, so no assertion could go red on the stale row — that is exactly why the issue was filed rather than caught by CI. The gates below prove the change breaks nothing; they cannot prove the prose true. The truth claim rests on the file:line evidence cited above, all re-checked on `origin/main` at `64d764e76`.

Note on the **Docs Drift Check** advisory on this PR: it fired on package paths (any diff under `@objectstack/lint` / `@objectstack/objectql` triggers it), not on semantics. This diff carries no behaviour change, so none of the listed hand-written docs can have drifted from it — not actionable here, and it is advisory-only, not a required check.

```
$ pnpm --filter @objectstack/lint test -- --maxWorkers=2
 Test Files  65 passed (65)
      Tests  1652 passed (1652)

$ pnpm --filter @objectstack/objectql test -- --maxWorkers=2
 Test Files  149 passed (149)
      Tests  2549 passed (2549)

$ pnpm --filter @objectstack/lint typecheck && pnpm --filter @objectstack/objectql typecheck
(tsc --noEmit, both clean, exit 0)

$ node scripts/check-nul-bytes.mjs
check-nul-bytes: OK (scanned 6269 tracked text file(s); no raw ASCII control bytes).
$ grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]' (the 4 changed files)
clean — no raw control bytes

$ pnpm --filter @objectstack/lint run check:doc-formula-expressions
✓ 22 record-scoped formula example(s) across 378 files / 1397 TS blocks judged clean

$ pnpm exec eslint (the 4 changed files)
exit 0
```

Comment-only, releases nothing → no changeset; `skip-changeset` label applied (read back after the labeler settled: `size/m`, `tests`, `skip-changeset`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn