### PR TITLE
test(objectql): pin `getObject(n)` = `get('object', n)` across all three IMetadataService implementations

### DIFF
--- a/packages/objectql/src/metadata-service-getobject-equivalence.test.ts
+++ b/packages/objectql/src/metadata-service-getobject-equivalence.test.ts
@@ -1,0 +1,227 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Conformance pin — `getObject(name)` ≡ `get('object', name)` (#6745).
+ *
+ * `IMetadataService.getObject` (`packages/spec/src/contracts/metadata-service.ts`)
+ * DECLARES that the pair resolves through one lookup in every implementation this
+ * repo ships, and that both members hand back the identical object. PR #6723 (for
+ * #6505) wrote that down after measuring it with a throwaway probe, which left the
+ * statement declared-but-ungated: nothing failed if a later edit made the pair
+ * diverge, and the contract TSDoc would then simply be lying. This file is the gate.
+ *
+ * `packages/objectql` is the only package that can see all three implementations —
+ * it depends on both `@objectstack/metadata` (MetadataManager) and
+ * `@objectstack/core` (createMemoryMetadata), and owns MetadataFacade itself.
+ * `packages/spec` cannot host it: the contract has no runtime.
+ *
+ * Two things about the shape here are load-bearing, and both are the difference
+ * between this pin and a green-but-empty one:
+ *
+ * 1. **The facade is seeded through `registry.registerObject`, never through
+ *    `facade.register('object', …)`.** Those are not interchangeable: the facade
+ *    writes objects through `SchemaRegistry.registerItem`, which stores into the
+ *    generic `metadata` map, while BOTH of its object reads resolve from
+ *    `objectContributors` (`registry.getItem` special-cases the `object` type
+ *    straight back to `registry.getObject`). An object written the first way is
+ *    readable back through neither member — measured, both `undefined` — so a pin
+ *    that seeded that way would compare `undefined` to `undefined` and call it
+ *    equivalence. That write/read split is a separate, already-filed finding
+ *    (#6725); this file deliberately does not assert on it, and the
+ *    `expect(...).toBeDefined()` in the present-object case is what stops the
+ *    vacuous version from ever passing here again.
+ *
+ * 2. **MetadataManager appears twice, under both of its resolution paths.** Its
+ *    `get` answers from the in-memory registry when it can and falls back to the
+ *    loaders otherwise; `getObject` delegates to `get`, so a future edit that
+ *    re-implemented `getObject` against the registry alone would still agree on
+ *    every registry-seeded case and diverge only on a loader-backed one. Seeding
+ *    one subject through each path is what makes that break visible.
+ *
+ * Reference identity (`toBe`), not deep equality, is the assertion because
+ * identity is what each implementation's mechanism actually delivers today —
+ * measured on all four subjects, on both call orders — and it is what the contract
+ * claims. `MetadataManager.getObject` literally returns `this.get('object', name)`;
+ * `createMemoryMetadata` reads one `Map` from both members; the facade's two paths
+ * converge on `SchemaRegistry.getObject`, whose merge result is memoized in
+ * `mergedObjectCache`, so both members hand back the same instance.
+ *
+ * Refs #6745, #6505, PR #6723, #6725.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { IMetadataService } from '@objectstack/spec/contracts';
+import { SchemaRegistry } from './registry';
+import { MetadataFacade } from './metadata-facade';
+import { MetadataManager, type MetadataLoader } from '@objectstack/metadata';
+import { createMemoryMetadata } from '@objectstack/core';
+
+/**
+ * The two contract members under test, and nothing else. Typing the subjects
+ * against `IMetadataService` rather than against the concrete classes is
+ * deliberate: it is the contract's declaration this file is pinning, so a
+ * signature change on either member should reach this file through `tsc`.
+ */
+type ObjectResolvingService = Pick<IMetadataService, 'get' | 'getObject'>;
+
+interface ObjectFixture {
+    readonly name: string;
+    readonly definition: Record<string, unknown>;
+}
+
+const objectFixture = (name: string): ObjectFixture => ({
+    name,
+    definition: {
+        name,
+        label: name.replace(/_/g, ' '),
+        fields: { title: { type: 'text', label: 'Title' } },
+    },
+});
+
+/**
+ * A shipped implementation plus the seeding channel ITS OWN object reads observe.
+ * The channel is part of the subject, not an incidental detail — see note 1 in
+ * the file header.
+ */
+interface PinnedImplementation {
+    readonly label: string;
+    create(objects: readonly ObjectFixture[]): Promise<ObjectResolvingService>;
+}
+
+/** Minimal read-only loader, so MetadataManager's loader-fallback path is real. */
+class FixtureLoader implements MetadataLoader {
+    readonly contract: MetadataLoader['contract'] = {
+        name: 'getobject-equivalence-fixture',
+        protocol: 'memory:',
+        capabilities: { read: true, write: false, watch: false, list: true },
+    };
+
+    private readonly storage = new Map<string, unknown>();
+
+    constructor(objects: readonly ObjectFixture[]) {
+        for (const object of objects) {
+            this.storage.set(object.name, object.definition);
+        }
+    }
+
+    async load(type: string, name: string) {
+        const data = type === 'object' ? this.storage.get(name) : undefined;
+        return data
+            ? { data, source: this.contract.name, format: 'json' as const, loadTime: 0 }
+            : { data: null };
+    }
+
+    async loadMany<T = unknown>(type: string): Promise<T[]> {
+        return (type === 'object' ? Array.from(this.storage.values()) : []) as T[];
+    }
+
+    async exists(type: string, name: string): Promise<boolean> {
+        return type === 'object' && this.storage.has(name);
+    }
+
+    async stat() {
+        return null;
+    }
+
+    async list(type: string): Promise<string[]> {
+        return type === 'object' ? Array.from(this.storage.keys()) : [];
+    }
+}
+
+const IMPLEMENTATIONS: readonly PinnedImplementation[] = [
+    {
+        // `get` answers from the in-memory registry on this one.
+        label: 'MetadataManager (registry hit)',
+        async create(objects) {
+            const manager = new MetadataManager({ formats: ['json'], loaders: [] });
+            for (const object of objects) {
+                await manager.register('object', object.name, object.definition);
+            }
+            return manager;
+        },
+    },
+    {
+        // Nothing is registered, so `get` can only answer through the loaders —
+        // the second of MetadataManager's two resolution paths.
+        label: 'MetadataManager (loader fallback)',
+        async create(objects) {
+            return new MetadataManager({ formats: ['json'], loaders: [new FixtureLoader(objects)] });
+        },
+    },
+    {
+        label: 'createMemoryMetadata',
+        async create(objects) {
+            const memory = createMemoryMetadata();
+            for (const object of objects) {
+                await memory.register('object', object.name, object.definition);
+            }
+            return memory;
+        },
+    },
+    {
+        label: 'MetadataFacade',
+        async create(objects) {
+            const registry = new SchemaRegistry({ multiTenant: false });
+            for (const object of objects) {
+                // NOT `facade.register('object', …)` — that writes where neither of
+                // the facade's object reads look (#6725), which would make the
+                // present-object case below compare undefined to undefined.
+                registry.registerObject(object.definition as never, 'com.example.pin');
+            }
+            return new MetadataFacade(registry);
+        },
+    },
+];
+
+describe.each(IMPLEMENTATIONS)(
+    'IMetadataService conformance — getObject(n) ≡ get(\'object\', n) [$label]',
+    ({ create }) => {
+        it('answers a present object identically through both members', async () => {
+            const alpha = objectFixture('pin_alpha');
+            const service = await create([alpha]);
+
+            const viaGetObject = await service.getObject(alpha.name);
+            const viaGet = await service.get('object', alpha.name);
+
+            // Anti-vacuity: without this, a subject that resolved NOTHING would
+            // satisfy the equivalence below by answering undefined twice.
+            expect(viaGetObject).toBeDefined();
+            expect((viaGetObject as { name?: string }).name).toBe(alpha.name);
+
+            expect(viaGetObject).toBe(viaGet);
+        });
+
+        it('answers undefined through both members for an object nothing registered', async () => {
+            const service = await create([objectFixture('pin_alpha')]);
+
+            const viaGetObject = await service.getObject('pin_absent');
+            const viaGet = await service.get('object', 'pin_absent');
+
+            expect(viaGetObject).toBeUndefined();
+            expect(viaGet).toBeUndefined();
+        });
+
+        it('keeps the pair name-discriminating when several objects are registered', async () => {
+            const alpha = objectFixture('pin_alpha');
+            const beta = objectFixture('pin_beta');
+            const service = await create([alpha, beta]);
+
+            const alphaViaGetObject = await service.getObject(alpha.name);
+            const alphaViaGet = await service.get('object', alpha.name);
+            const betaViaGetObject = await service.getObject(beta.name);
+            const betaViaGet = await service.get('object', beta.name);
+
+            expect(alphaViaGetObject).toBeDefined();
+            expect(betaViaGetObject).toBeDefined();
+
+            expect(alphaViaGetObject).toBe(alphaViaGet);
+            expect(betaViaGetObject).toBe(betaViaGet);
+
+            // A member that ignored `name` and returned the first object would
+            // agree with itself on every case above; it cannot survive this one.
+            expect(alphaViaGetObject).not.toBe(betaViaGetObject);
+            expect((alphaViaGetObject as { name?: string }).name).toBe(alpha.name);
+            expect((betaViaGetObject as { name?: string }).name).toBe(beta.name);
+        });
+    },
+);


### PR DESCRIPTION
Fixes #6745

## 背景

PR #6723(为 #6505)在 `IMetadataService.getObject` 的 TSDoc 上写下:`getObject(name)` 与 `get('object', name)` 在本仓库发布的每一个实现里都走同一次查找,两个成员交回同一个对象。这句话当时只是**声明**,没有任何门禁——此后任一实现的改动让这对成员发生分歧,不会有任何测试变红,而契约 TSDoc 就开始说谎。正是本仓库反复付过学费的 declared-not-enforced 形状。

本 PR 把它变成门禁。

## 落点

新增 `packages/objectql/src/metadata-service-getobject-equivalence.test.ts`(纯测试)。

`packages/objectql` 是唯一能同时看见三个实现的包:它同时依赖 `@objectstack/metadata`(MetadataManager)与 `@objectstack/core`(createMemoryMetadata),而 MetadataFacade 本就是它自己的。`packages/spec` 无法承载——契约没有运行时。

## 先测量,再钉住

在写断言之前,先用一次性探针实测了三个实现在被钉住的路径上**实际返回什么**。结论:等价关系今天成立,而且成立在最强的形式上——**同一引用**(不只是深相等),命中与未命中两条路径都成立。

| 实现 | 命中 | 未命中 |
|:---|:---|:---|
| `MetadataManager`(注册表命中) | 同一引用,keys `name/label/fields` | 双方 `undefined` |
| `MetadataManager`(loader 回退) | 同一引用(loader 路径不克隆,两种调用顺序都成立) | 双方 `undefined` |
| `createMemoryMetadata` | 同一引用(两个成员读同一个 Map) | 双方 `undefined` |
| `MetadataFacade` | 同一引用,keys 含 `nameField` / `_packageId` / `_provenance` | 双方 `undefined` |

所以断言用 `toBe`(引用相等)而不是深相等:那才是三个实现的机制今天真正交付的东西,也正是契约声称的。facade 那一行额外印证了 TSDoc 的 "runtime-effective object" 说法——回来的对象带着物化接缝(`registerObject` → `resolveObject`)加上的列。

## 两处形状是承重的

**1. facade 必须用 `registry.registerObject` 播种,不能用 `facade.register('object', …)`。** 这两者不可互换:facade 走 `SchemaRegistry.registerItem` 写进通用 `metadata` map,而它自己的两个对象读法都从 `objectContributors` 解析(`getItem` 对 `object` 类型直接特判回 `registry.getObject`)。用后者写进去的对象,两个成员都读不回来——实测双方都是 `undefined`。若照那样播种,"命中"用例就变成拿 `undefined` 和 `undefined` 相比,绿得毫无内容。这条写读劈叉本身是已归档的独立 finding #6725,本 PR 刻意不对它下断言;present 用例里的 `expect(...).toBeDefined()` 就是防止这种空转版本再次通过的那道闩。

**2. MetadataManager 出现两次,覆盖它的两条解析路径。** 它的 `get` 能从内存注册表答就从注册表答,答不了才回退到 loaders;`getObject` 委托给 `get`。所以一次"把 getObject 改写成只读注册表"的改动,会在所有注册表播种的用例上继续一致,只在 loader 支撑的用例上分歧。两条路径各播种一个 subject,才让这种断裂可见。

## 反向验证(先预测方向,再测量)

预测写在跑之前。基线 12/12 绿(4 subject × 3 用例)。三次消融,每次只打断一个实现的 `getObject`:

| 消融 | 预测 | 实测 |
|:---|:---|:---|
| A1 facade 的 `getObject` 改读 #6725 那个存储位置 | facade 行 present + 辨名两例红,miss 例仍绿,其余 9 例绿 | 完全一致:2 failed / 10 passed,红在 `expected undefined to be defined` |
| A2 `createMemoryMetadata.getObject` 读错类型名(`objects`) | memory 行 present + 辨名两例红,miss 例绿,其余 9 例绿 | 完全一致:2 failed / 10 passed |
| A3 `MetadataManager.getObject` 不再委托 `get`,改为只读注册表 | **registry-hit 行 3/3 全绿**,loader-fallback 行 present + 辨名两例红 | 完全一致:2 failed / 10 passed |

A3 是最有价值的一次:它证明第二个 MetadataManager subject 是承重的——只放注册表播种那一个 subject 的钉子,面对一次真实分歧会全绿放行。

三次消融还一致地说明了一件值得写下来的事:**miss 用例抓不到这一类断裂**(双方都答 `undefined`,等价仍然成立)。真正抓到的是 present 用例里的反空转断言。miss 用例钉的是另一件事——两个成员在未命中时给出同一个答案。

三次消融已全部回滚,工作树只剩新增的测试文件。

## 门禁(真实输出)

- `pnpm --filter @objectstack/objectql test` → `Test Files 155 passed (155)` / `Tests 2680 passed (2680)`(新增文件前为 154 / 2668,新增 12 例)
- `pnpm --filter @objectstack/objectql typecheck` → `tsc --noEmit`,无输出
- `pnpm lint` → 无输出
- `check:nul-bytes` / `check:engine-double-contract` / `check:error-code-casing` / `check:route-envelope` / `check:slot-lookup` → 全部 PASS

## changeset

无。纯测试改动(单个新增 `*.test.ts`),不发布任何东西,已加 `skip-changeset` 标签。

## 刻意没做

- 没有碰 #6725 的写读劈叉(本卡明确划出范围),也没有对 `facade.register('object', …)` 的行为下任何断言。
- 没有加 `unregister` 用例:facade 的 `unregister('object', …)` 作用在通用 `metadata` map 上,对 `objectContributors` 是空操作,两个成员因此仍然一致——钉它等于把 #6725 家族的行为写进这张表。
- 没有动 `packages/spec` 的契约 TSDoc:#6505 的裁定把那半边限定在 PR #6723。

Refs #6505, PR #6723, #6724, #6725.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_