### PR TITLE
test(cli): 把 NDJSON e2e 的放行截止时间锚定到 device code 签发时刻 (#6855)

### DIFF
--- a/packages/cli/test/cloud-login-json-ndjson.e2e.test.ts
+++ b/packages/cli/test/cloud-login-json-ndjson.e2e.test.ts
@@ -84,6 +84,30 @@ const DEPLOY_DOCS = resolve(REPO_ROOT, 'content/docs/deployment/index.mdx');
  * anyway. Only reached when the record never arrives early — i.e. when the
  * contract is broken — and exists so that failure is an assertion rather than a
  * suite that hangs until the runner kills it.
+ *
+ * ## The clock starts at device-code issuance, not at spawn (#6855)
+ *
+ * This budget is armed when the endpoint hands the CLI its device code, because
+ * that is the first instant at which the contract is even measurable: from
+ * there the CLI holds the verification URL and owes it to stdout. Everything
+ * before it — `script(1)`, the `tsx` transform of the whole oclif command tree,
+ * module loading — is process startup, about which #6531/#6730 say nothing.
+ *
+ * Armed at spawn instead, this budget policed startup rather than the contract,
+ * and that is what made the assertion flaky. Measured on an idle machine, of
+ * the latency from spawn to the record being readable:
+ *
+ * | segment                              | measured  |
+ * |--------------------------------------|-----------|
+ * | spawn → device-code request (startup)| 3423–3713 ms |
+ * | device-code response → record readable (the contract) | 16–28 ms |
+ *
+ * So ~99.4% of the old budget was spent on work the contract does not govern,
+ * leaving startup needing only a ~5.7x slowdown to exhaust 20 s — routine on a
+ * merge-queue runner executing 84 tasks for 11½ minutes. It duly ejected two
+ * unrelated PRs (#6847 spec-only, #6835 docs-only). Anchored here, the budget
+ * covers a ~20 ms window with ~1000x headroom, and the number itself is
+ * unchanged: this is a re-anchoring, NOT a widened timeout.
  */
 const RELEASE_DEADLINE_MS = 20_000;
 
@@ -111,6 +135,14 @@ function startDeviceEndpoint(outcome: 'token' | 'access_denied') {
   let released = false;
   let authorizedAt: number | null = null;
 
+  // Resolved the moment the CLI has been handed its device code — the instant
+  // the emission contract starts running, and so the anchor for the release
+  // deadline. Definite-assignment: the Promise executor runs synchronously.
+  let markDeviceCodeIssued!: () => void;
+  const deviceCodeIssued = new Promise<void>((res) => {
+    markDeviceCodeIssued = res;
+  });
+
   const server: Server = createServer((req, res) => {
     req.resume();
     req.on('end', () => {
@@ -121,6 +153,7 @@ function startDeviceEndpoint(outcome: 'token' | 'access_denied') {
       const { pathname } = new URL(req.url ?? '/', 'http://placeholder');
 
       if (pathname === '/api/v1/auth/device/code') {
+        markDeviceCodeIssued();
         return send(200, {
           device_code: 'DEV-CODE-6730',
           user_code: 'WXYZ-6730',
@@ -153,6 +186,7 @@ function startDeviceEndpoint(outcome: 'token' | 'access_denied') {
     release: () => {
       released = true;
     },
+    deviceCodeIssued,
     authorizedAt: () => authorizedAt,
     listen: () =>
       new Promise<number>((res) => {
@@ -218,12 +252,20 @@ async function runCloudDeviceLogin(opts: {
     }
   }, WATCH_MS);
 
-  const deadline = setTimeout(() => {
-    if (urlSeenAt === null) {
-      releasedByDeadline = true;
-      endpoint.release();
-    }
-  }, RELEASE_DEADLINE_MS);
+  // Armed on device-code issuance rather than here, so the budget covers the
+  // window the contract governs and not the child's startup — see
+  // {@link RELEASE_DEADLINE_MS} for the measurements behind that (#6855).
+  // Stays unarmed if the CLI never reaches the device flow at all; that run
+  // ends when the child exits, and the assertions below name the absence.
+  let deadline: ReturnType<typeof setTimeout> | undefined;
+  void endpoint.deviceCodeIssued.then(() => {
+    deadline = setTimeout(() => {
+      if (urlSeenAt === null) {
+        releasedByDeadline = true;
+        endpoint.release();
+      }
+    }, RELEASE_DEADLINE_MS);
+  });
 
   const shell = [
     `'${TSX}' '${CLI}' cloud login${opts.json ? ' --json' : ''} --no-browser`,
@@ -330,7 +372,13 @@ describe('os cloud login --json — the declared NDJSON stream (#6730)', () => {
     it('hands over the verification URL BEFORE authorization — the reason this route was chosen', () => {
       // The endpoint only authorized because the watcher had already read the
       // record off stdout, so these two facts are the run's own history.
-      expect(ok.releasedByDeadline, 'the device record never reached stdout early').toBe(false);
+      expect(
+        ok.releasedByDeadline,
+        `the device record did not reach stdout within ${RELEASE_DEADLINE_MS}ms of the CLI ` +
+          'receiving its device code — the buffered-emit regression this route was chosen to ' +
+          'prevent. This window excludes process startup (#6855), so a slow runner is not a ' +
+          'cause: at the moment it opens the CLI already holds the verification URL.',
+      ).toBe(false);
       expect(ok.urlSeenAt).not.toBeNull();
       expect(ok.authorizedAt).not.toBeNull();
       expect(ok.urlSeenAt!).toBeLessThanOrEqual(ok.authorizedAt!);


### PR DESCRIPTION
Fixes #6855

## 结论先行:是 flaky,不是 main 坏了;是**测试**的锚点错了,产品行为正确

`packages/cli/test/cloud-login-json-ndjson.e2e.test.ts:333` 的 `releasedByDeadline` 断言在合并队列里间歇变红,已先后踢出两个与该断言毫无关系的 PR:#6847(仅改 spec)与 #6835(仅改 docs)。

先测量,后动手。干净 `origin/main` @ `659526212` 上:

| 场景 | 结果 |
|---|---|
| 串行 10 次(空载) | **10 passed / 0 failed** |
| 并发 8 份(4 核容器,模拟队列争抢) | **6 passed / 2 failed** |

两次失败的签名与 CI 完全一致 —— `Tests 1 failed | 11 passed (12)`,唯一红的就是 `:333`。所以:**不是 main 上的确定性失败,是负载下的竞态**。

## 根因:逃生阀计时器锚在 spawn 之前,于是它监督的是"启动快不快",而不是契约

`RELEASE_DEADLINE_MS`(20s)存在的目的,是让缓冲式实现以断言失败收场而不是把 suite 挂死。但它在 `execFile` 之前就已武装,于是 `script(1)` 启动 + `tsx` 对整棵 oclif 命令树的转译 + 模块加载全部被计入这 20s。空载实测(探针复刻 `runCloudDeviceLogin`,5 次):

| 区间 | 实测 |
|---|---|
| spawn → 请求 device code(**纯启动**) | 3423–3713 ms |
| device code 响应 → 记录可读(**真正的契约窗口**) | 16–28 ms |

约 **99.4%** 的旧预算花在契约管不着的启动上。启动只要慢 **5.7 倍**就耗尽 20s —— 对一个并发 84 个 task、跑满 11 分半的队列 runner 来说是常态。

把截止时间压到 1000ms(模拟"启动比预算还慢")即可稳定复现,而且复现结果本身就说明了失败消息是**误诊**:

```
releasedByDeadline: true      ← :333 变红
urlSeenAtMs:        3504      ← 记录仍然先到
authorizedAtMs:     4495      ← 授权仍然后到,契约完好
emitWindowMs:       19        ← 契约窗口毫发无损
```

记录**确实**早于授权到达 stdout。旧文案 “the device record never reached stdout early” 在这种情形下说的是错的。

## 改法:重新**锚定**,不是放宽超时

计时器改为在端点签发 device code 的那一刻才武装 —— 那是契约第一次可被观测的时刻,此后 CLI 手上已握有 verification URL,一个正确实现只需 ~20ms 就该把它写出去。

`RELEASE_DEADLINE_MS` 数值**保持 20s 原样**,这一点在 diff 里可直接核对:改的是预算**度量什么**,不是预算多大。重新锚定后余量从「20s 对 3.5s 启动」变成「20s 对 20ms 契约窗口」,约 1000 倍。

逃生阀语义完整保留:缓冲式实现依旧在 device code 签发后 20s 被判红,suite 不会挂死。CLI 若根本走不到设备流程,计时器不武装,该 run 随子进程退出结束,由既有断言指认缺失。

## #6730 的契约断言仍然咬得住(反向验证,方向事先声明)

事先声明的预期方向:**把 #6730 的缓冲式缺陷放回去,`:333` 必须依旧变红** —— 否则我只是把断言废掉了。

把 `src/commands/cloud/login.ts:218` 的早发限制退回 `onDeviceCode: undefined`(即 #6730 修好之前的缓冲形态)后:

```
Tests  5 failed | 7 passed (12)
AssertionError: the device record did not reach stdout within 20000ms of the CLI
receiving its device code — the buffered-emit regression this route was chosen to
prevent. ...: expected true to be false
```

红,且新文案准确指认了真实原因。产品文件随后已还原(`git checkout --`,diff 中不含任何 `src/` 改动)。

## 修复后的负载复测

同一套并发 8 份配置(此前 2/8 红),跑两轮:

```
=== CONCURRENT x8 TWO ROUNDS (fixed): pass=16 fail=0 / 16 ===
:333 signature count: 0
```

## 门禁

| 门禁 | 结果 |
|---|---|
| `pnpm --filter @objectstack/cli test` | `Test Files 98 passed (98)` · `Tests 1029 passed (1029)` |
| `pnpm --filter @objectstack/cli typecheck` | 通过(`tsc --noEmit` 无输出) |
| `node scripts/check-nul-bytes.mjs` | `OK (scanned 6398 tracked text file(s))` |

## 刻意没做的事

- **没有加 sleep、没有放宽超时、没有删断言**。20s 这个数字一个字节没动。
- **没有碰产品代码**。`#6838` 的实现与 #6531 的裁定都是对的,本 PR 不重开。
- **没有顺手改姊妹文件**。`test/login-json-ndjson.e2e.test.ts`(#6531,`os login`)有**同样**的 spawn 锚定写法(`setTimeout` 在 :205,`execFile` 在 :219),但它是另一条命令的另一个文件,而且我按同样的并发 8 份压测**没能复现失败**(0/8)。已按观察类另行归档为 **#6872**(`finding` + `domain:cli`,未指派、未打 `priority:`),连同实测余量:每子进程约 14.5s 对 20s 预算,约 1.4 倍,偏薄但尚未越线。

## 变更集

测试专属改动,不发布任何东西 → 无 changeset,加 `skip-changeset`。

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_