### PR TITLE
feat(spec): declare `metadata.maskObjectFields` and `getMetadataReadableFields` (ADR-0106 follow-through)

### DIFF
--- a/.changeset/adr-0106-declarations.md
+++ b/.changeset/adr-0106-declarations.md
@@ -1,0 +1,43 @@
+---
+"@objectstack/spec": minor
+---
+
+feat(spec): declare `metadata.maskObjectFields` and `getMetadataReadableFields` (#6622)
+
+ADR-0106's metadata-plane field-level security shipped in #6612 with two members
+**honoured but undeclared** — deliberately, because `packages/spec` is the spec
+seat's surface and the implementing PR did not touch it. Both now have a
+declared seat. This is the declaration half only: no runtime behaviour changes,
+in either direction, in any deployment.
+
+**`MetadataEndpointsConfigSchema.maskObjectFields`** — `z.boolean().default(true)`
+(ADR-0106 D8). The per-server switch for masking served object schemas to the
+calling user's readable fields. It was already read by `@objectstack/rest`'s
+`normalizeConfig` through a cast, following the `api.enableOpenApi` /
+`api.enableSearch` precedent, so a deployment that sets it has always been
+honoured. What the declaration adds is that the key is now **type-safe in
+`objectstack.config.ts`**, carries its documentation with it, appears in the
+generated config schema and reference docs, and — the part that was a real gap —
+**survives a parse**. `MetadataEndpointsConfigSchema` strips keys it does not
+declare, so an author who ran their config through the schema before handing it
+to the server lost the opt-out silently; that hole is closed. The default is
+`true`, matching the shipped behaviour, so no deployment moves.
+
+**`ISecurityService.getMetadataReadableFields?`** (ADR-0106 D7). The
+metadata-plane sibling of `getReadableFields`: identical except that a caller
+resolving to **zero** permission sets goes through the same fallback-set
+resolution `/auth/me/permissions` uses instead of falling open to the full field
+set — so a guest-facing deployment's schema exposure is a deliberate
+permission-set decision rather than an accidental everything-default.
+`@objectstack/plugin-security` has implemented it since #6612 and
+`@objectstack/metadata-core` already feature-detects it, falling back to
+`getReadableFields`.
+
+The member is **optional**, following the precedent #6841 set on this same
+contract: absence is a defined, handled state (a security service that predates
+ADR-0106 keeps its pre-ADR behaviour), so a required declaration would assert
+something the codebase deliberately declines to rely on — `packages/rest` types
+the whole service as `Partial<ISecurityService>`, and this contract's own header
+instructs consumers to feature-detect. Optional also prevents the mistake
+structurally: the unguarded call does not compile, so a consumer cannot skip the
+fallback by accident.

--- a/content/docs/references/api/rest-server.mdx
+++ b/content/docs/references/api/rest-server.mdx
@@ -133,6 +133,7 @@ const result = BatchEndpointsConfigSchema.parse(data);
 | **prefix** | `string` | ✅ | URL prefix for metadata endpoints |
 | **enableCache** | `boolean` | ✅ | Enable HTTP cache headers (ETag, Last-Modified) |
 | **cacheTtl** | `integer` | ✅ | Cache TTL in seconds |
+| **maskObjectFields** | `boolean` | ✅ | [ADR-0106 D8] Mask served object schemas to the caller's readable fields |
 | **endpoints** | `{ types: boolean; items: boolean; item: boolean; schema: boolean }` | optional | Enable/disable specific endpoints |
 
 
@@ -170,7 +171,7 @@ const result = BatchEndpointsConfigSchema.parse(data);
 | :--- | :--- | :--- | :--- |
 | **api** | `{ version: string; basePath: string; apiPath?: string; enableCrud: boolean; … }` | optional | REST API configuration |
 | **crud** | `{ operations?: object; patterns?: Record<string, object>; dataPrefix: string; objectParamStyle: Enum<'path' \| 'query'> }` | optional | CRUD endpoints configuration |
-| **metadata** | `{ prefix: string; enableCache: boolean; cacheTtl: integer; endpoints?: object }` | optional | Metadata endpoints configuration |
+| **metadata** | `{ prefix: string; enableCache: boolean; cacheTtl: integer; maskObjectFields: boolean; … }` | optional | Metadata endpoints configuration |
 | **batch** | `{ maxBatchSize: integer; enableBatchEndpoint: boolean; operations?: object; defaultAtomic: boolean }` | optional | Batch endpoints configuration |
 | **routes** | `{ includeObjects?: string[]; excludeObjects?: string[]; nameTransform: Enum<'none' \| 'plural' \| 'kebab-case' \| 'camelCase'>; overrides?: Record<string, object> }` | optional | Route generation configuration |
 | **openApi31** | `never` | optional | [REMOVED] `RestServerConfig.openApi31` was removed in @objectstack/spec 17 (#4579, ADR-0049) — no runtime ever read it: the REST server forwards only `api`/`crud`/`metadata`/`batch`/`routes`, and the served /openapi.json is the pre-generated contract enriched with the live server URL and the registered objects, so webhook/callback definitions declared here never appeared in it. Delete the key. Config-driven OpenAPI 3.1 webhooks/callbacks documentation is a new capability and must arrive via the enforce route of ADR-0049 (a new ADR), not by re-declaring the key; for a real outbound webhook use `Webhook` from `@objectstack/spec/automation`. |

--- a/packages/spec/authorable-defaults/api.json
+++ b/packages/spec/authorable-defaults/api.json
@@ -103,6 +103,7 @@
     "api/MetadataCacheResponse:notModified = false",
     "api/MetadataEndpointsConfig:cacheTtl = 3600",
     "api/MetadataEndpointsConfig:enableCache = true",
+    "api/MetadataEndpointsConfig:maskObjectFields = true",
     "api/MetadataEndpointsConfig:prefix = \"/meta\"",
     "api/MetadataExportRequest:format = \"json\"",
     "api/MetadataImportRequest:conflictResolution = \"skip\"",

--- a/packages/spec/authorable-surface/api.json
+++ b/packages/spec/authorable-surface/api.json
@@ -1025,6 +1025,7 @@
     "api/MetadataEndpointsConfig:cacheTtl",
     "api/MetadataEndpointsConfig:enableCache",
     "api/MetadataEndpointsConfig:endpoints",
+    "api/MetadataEndpointsConfig:maskObjectFields",
     "api/MetadataEndpointsConfig:prefix",
     "api/MetadataEvent:definition",
     "api/MetadataEvent:id",

--- a/packages/spec/src/api/rest-server.test.ts
+++ b/packages/spec/src/api/rest-server.test.ts
@@ -14,6 +14,7 @@ import {
   RestServerConfig,
   type RestApiConfig as RestApiConfigType,
   type RestServerConfig as RestServerConfigType,
+  type MetadataEndpointsConfig,
 } from './rest-server.zod';
 
 describe('RestApiConfigSchema', () => {
@@ -268,6 +269,55 @@ describe('MetadataEndpointsConfigSchema', () => {
     });
 
     expect(config.endpoints?.schema).toBe(false);
+  });
+
+  it('[ADR-0106 D8] maskObjectFields defaults to true — the mask is ON unless opted out', () => {
+    // The default is the whole security posture of the key: a deployment that
+    // never mentions `maskObjectFields` must still mask served object schemas.
+    // Pinning the MATERIALIZED default (not just the declaration) is what makes
+    // a later `.optional()` — which would hand `undefined` to the REST layer —
+    // fail here rather than silently unmask every metadata read.
+    const config = MetadataEndpointsConfigSchema.parse({});
+
+    expect(config.maskObjectFields).toBe(true);
+  });
+
+  it('[ADR-0106 D8] maskObjectFields: false is the declared per-server opt-out', () => {
+    // The opt-out has to SURVIVE the parse. Before this key had a declared seat,
+    // the schema stripped it (zod's default posture for an undeclared key) and
+    // the REST layer only saw it because it reads its config object raw, through
+    // a cast. An author who parses their config first now keeps the opt-out.
+    const optedOut = MetadataEndpointsConfigSchema.parse({ maskObjectFields: false });
+
+    expect(optedOut.maskObjectFields).toBe(false);
+
+    // Explicit `true` is a real answer too, not a no-op the parse discards.
+    expect(MetadataEndpointsConfigSchema.parse({ maskObjectFields: true }).maskObjectFields).toBe(true);
+  });
+
+  it('[ADR-0106 D8] maskObjectFields is authorable without a cast, and is a boolean (compile-time)', () => {
+    // The declaration's REASON for existing: `objectstack.config.ts` authors the
+    // key by name and `packages/rest`'s `normalizeConfig` reads it. Both of them
+    // go through this input type, so this is the pin that says the key no longer
+    // needs `(metadata as any)` to be reachable.
+    const authored: MetadataEndpointsConfig = { maskObjectFields: false };
+    const readAsBoolean: boolean | undefined = authored.maskObjectFields;
+    expect(readAsBoolean).toBe(false);
+
+    // Optional on the INPUT side — omitting it is how a deployment takes the
+    // default, and it must stay legal.
+    const omitted: MetadataEndpointsConfig = { prefix: '/meta' };
+    expect(omitted.maskObjectFields).toBeUndefined();
+
+    // …and it is a boolean switch, not a string one. Never invoked: its only job
+    // is to make the compiler prove the seat is typed rather than `any`, which
+    // is exactly what the cast it replaces could not do.
+    const mustNotCompile = () => {
+      // @ts-expect-error `maskObjectFields` is a boolean — a truthy string is not the opt-out
+      const wrongType: MetadataEndpointsConfig = { maskObjectFields: 'false' };
+      return wrongType;
+    };
+    expect(typeof mustNotCompile).toBe('function');
   });
 });
 

--- a/packages/spec/src/api/rest-server.zod.ts
+++ b/packages/spec/src/api/rest-server.zod.ts
@@ -290,7 +290,30 @@ export const MetadataEndpointsConfigSchema = lazySchema(() => z.object({
    * Cache TTL in seconds
    */
   cacheTtl: z.number().int().default(3600).describe('Cache TTL in seconds'),
-  
+
+  /**
+   * [ADR-0106 D8] Per-caller field-level masking of the OBJECT SCHEMAS this
+   * server serves from `/meta` and `/metadata`.
+   *
+   * Default **on**: an object schema is projected onto the fields the CALLING
+   * user may read, so a field they cannot read does not appear at all — not its
+   * name, label, type, picklist options, formula, `visibleWhen` predicate,
+   * `defaultValue`, nor the `requiredPermissions` capability guarding it.
+   *
+   * `false` opts this server out and serves the full schema to every
+   * authenticated caller, as releases before ADR-0106 did. The change is
+   * **disclosure only**: the data plane masks values and refuses forbidden
+   * writes either way, and the console reads field affordances from
+   * `/auth/me/permissions`, so toggling it never changes UI correctness.
+   *
+   * Deployment-wide counterpart: `OS_ALLOW_UNMASKED_OBJECT_METADATA=1`, which
+   * also covers the runtime `/metadata` dispatcher (that path has no per-server
+   * REST config to read). Either opt-out disables the mask; neither is needed
+   * to keep it on.
+   */
+  maskObjectFields: z.boolean().default(true)
+    .describe('[ADR-0106 D8] Mask served object schemas to the caller\'s readable fields'),
+
   /**
    * Enable specific metadata endpoints
    */

--- a/packages/spec/src/contracts/security-service.test.ts
+++ b/packages/spec/src/contracts/security-service.test.ts
@@ -98,6 +98,63 @@ describe('Security Service Contract', () => {
       .resolves.toEqual(['id', 'name']);
   });
 
+  it('[ADR-0106 D7] getMetadataReadableFields is OPTIONAL — absence degrades to getReadableFields', async () => {
+    // THE structural pin behind "a deployment whose security service predates
+    // ADR-0106 keeps its pre-ADR behaviour". Optional is what makes that a
+    // property of the TYPE: such a service still satisfies the contract, and a
+    // consumer cannot reach the metadata-plane answer without first handling
+    // the absent case.
+    const withoutIt: ISecurityService = makeService({ getReadableFields: async () => ['id', 'name'] });
+    expect(typeof withoutIt.getMetadataReadableFields).toBe('undefined');
+
+    // The unguarded call does not compile. Never invoked — its only job is to
+    // make the COMPILER prove the point (invoking it would merely prove that
+    // JavaScript throws on `undefined()`, which is the runtime symptom this
+    // declaration exists to prevent).
+    const mustNotCompileWithoutAGuard = () =>
+      // @ts-expect-error possibly undefined — a consumer must feature-detect first
+      withoutIt.getMetadataReadableFields('deal', { userId: 'u1' });
+    expect(typeof mustNotCompileWithoutAGuard).toBe('function');
+
+    // The shape consumers actually write (`metadata-core`'s object-schema mask
+    // resolver): prefer the metadata-plane answer, fall back to the data-plane
+    // one. The fallback is never NARROWER than the metadata-plane answer, which
+    // is why degrading here cannot hide columns a caller may see.
+    const ask = typeof withoutIt.getMetadataReadableFields === 'function'
+      ? withoutIt.getMetadataReadableFields.bind(withoutIt)
+      : withoutIt.getReadableFields.bind(withoutIt);
+    await expect(ask('deal', { userId: 'u1' })).resolves.toEqual(['id', 'name']);
+  });
+
+  it('[ADR-0106 D7] the metadata plane narrows where the data plane falls open', async () => {
+    // The one respect in which the two methods differ, and the reason a second
+    // method exists at all: a caller resolving to ZERO permission sets falls
+    // OPEN on the data plane (mirroring the middleware, which skips its field
+    // gate entirely) and resolves the fallback set on the metadata plane, so a
+    // guest deployment's schema exposure is a deliberate permission-set
+    // decision rather than an accidental everything-default.
+    const service = makeService({
+      getReadableFields: async () => ['id', 'name', 'secret'],
+      getMetadataReadableFields: async (_object, context) =>
+        context?.isSystem ? ['id', 'name', 'secret'] : ['id'],
+    });
+
+    await expect(service.getReadableFields('deal', {})).resolves.toEqual(['id', 'name', 'secret']);
+    await expect(service.getMetadataReadableFields?.('deal', {})).resolves.toEqual(['id']);
+
+    // A system context bypasses on BOTH planes.
+    await expect(service.getMetadataReadableFields?.('deal', { isSystem: true }))
+      .resolves.toEqual(['id', 'name', 'secret']);
+
+    // …and it inherits getReadableFields' two distinct empty answers, unchanged:
+    // `undefined` = no answer (fall back to your own projection), `[]` = the real
+    // answer that no field may be disclosed.
+    const noAnswer = makeService({ getMetadataReadableFields: async () => undefined });
+    await expect(noAnswer.getMetadataReadableFields?.('deal', { userId: 'u1' })).resolves.toBeUndefined();
+    const nothingDisclosable = makeService({ getMetadataReadableFields: async () => [] });
+    await expect(nothingDisclosable.getMetadataReadableFields?.('deal', { userId: 'u1' })).resolves.toEqual([]);
+  });
+
   it('a partial implementation is feature-detectable rather than wrong', () => {
     // Consumers probe (`typeof svc.getReadableFields === 'function'`) so an
     // implementation may omit a method it cannot honour and still be usable.

--- a/packages/spec/src/contracts/security-service.ts
+++ b/packages/spec/src/contracts/security-service.ts
@@ -33,7 +33,9 @@
  *   answers "which columns may this caller see" for presentation purposes; when
  *   the object schema cannot be resolved it returns `undefined`, meaning
  *   "no answer — use your own fallback", NOT "no fields are readable". An empty
- *   array is a real answer and means the opposite: nothing is readable.
+ *   array is a real answer and means the opposite: nothing is readable. Its
+ *   metadata-plane sibling {@link ISecurityService.getMetadataReadableFields}
+ *   (ADR-0106 D7) reads the same two empty answers the same way.
  * - **Verdicts fail to ABSTENTION.** {@link ISecurityService.checkAuthoredRowWrite}
  *   answers a question a composing caller may use to WIDEN, so its failure mode
  *   is the one that changes nothing: `abstain`. It never reports `admit` for a
@@ -230,6 +232,49 @@ export interface ISecurityService {
    * A system context bypasses field-level security and yields the full field set.
    */
   getReadableFields(object: string, context?: SecurityContext): Promise<string[] | undefined>;
+
+  /**
+   * [ADR-0106 D7] The METADATA-PLANE variant of {@link getReadableFields}:
+   * which field names may be DISCLOSED to `context` when an object SCHEMA is
+   * served, as opposed to which columns of a row it may read.
+   *
+   * Identical to {@link getReadableFields} in every respect but one — a caller
+   * that resolves to **zero** permission sets goes through the same fallback-set
+   * resolution `/auth/me/permissions` uses (`security.fallbackPermissionSet`,
+   * default `member_default`) instead of falling open to the full field set.
+   *
+   * **Why the two differ rather than converge.** `getReadableFields` mirrors the
+   * engine middleware, which skips its whole field gate for a caller with no
+   * permission sets; on the DATA plane, reporting a narrowing the enforcement
+   * path would not apply is its own kind of drift, so falling open is the
+   * correct, drift-free answer there. The metadata plane has no such symmetry to
+   * preserve — the question is disclosure, and D7 rules that a public/guest
+   * deployment's schema exposure must be a deliberate permission-set decision
+   * rather than an accidental everything-default. It still falls open when the
+   * fallback set itself resolves to nothing (no `member_default` in the
+   * deployment at all): that is the "no FLS posture here" tier, not a restricted
+   * caller.
+   *
+   * **Fails SOFT, with the same two distinct empty answers as
+   * {@link getReadableFields}:** `undefined` is "no answer — use your own
+   * fallback" (e.g. the object schema could not be resolved); `[]` is the real
+   * answer that this caller may see NO field. A system context bypasses and
+   * yields the full field set.
+   *
+   * **OPTIONAL, and absence is a defined state — not a bug.** A security service
+   * that predates ADR-0106, or one that cannot honour the fallback resolution,
+   * omits it; consumers feature-detect
+   * (`typeof svc.getMetadataReadableFields === 'function'`) and fall back to
+   * {@link getReadableFields}, which is the pre-ADR-0106 behaviour and never a
+   * *narrower* answer. Declaring it optional is what makes that degradation a
+   * property of the type rather than a promise in prose: the unguarded call does
+   * not compile, so a consumer cannot skip the fallback by accident.
+   *
+   * The masking itself is gated separately by the deployment's D8 opt-outs
+   * (`metadata.maskObjectFields: false`, `OS_ALLOW_UNMASKED_OBJECT_METADATA`);
+   * this method only answers the projection question when a mask applies.
+   */
+  getMetadataReadableFields?(object: string, context?: SecurityContext): Promise<string[] | undefined>;
 
   /**
    * The effective permission-set NAMES for `context` — positions expanded and


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6622

Part of #3682 (ADR-0106 metadata-plane FLS). PR #6612 shipped two members **honoured but undeclared**, deliberately: `packages/spec` is the spec seat's surface, so the implementing PR did not touch it. This is the declaration half, and it closes both in one PR as the card asks.

**No runtime behaviour changes, in either direction, in any deployment.** Both members are already implemented and already read; what moves is the type surface, the generated reference, and one authoring path that was silently lossy (below).

## 1. `MetadataEndpointsConfigSchema.maskObjectFields` (ADR-0106 D8)

```ts
maskObjectFields: z.boolean().default(true)
```

The per-server switch for masking served object schemas to the calling user's readable fields. `@objectstack/rest`'s `normalizeConfig` has read it since #6612 through `(metadata as any).maskObjectFields`, following the `api.enableOpenApi` / `api.enableSearch` precedent, so a deployment that sets it has always been honoured.

Three things the seat adds, one of which is a real gap rather than ergonomics:

- The key is type-safe in `objectstack.config.ts`, carries its documentation with it, and appears in the generated reference (`content/docs/references/api/rest-server.mdx`, regenerated in commit 2 — generated file, not hand-edited).
- **The opt-out now survives a parse.** `MetadataEndpointsConfigSchema` is a plain `z.object`, i.e. zod's `strip` posture: an undeclared key is discarded and the parse still succeeds. Nothing in the runtime parses `RestServerConfigSchema` today — `normalizeConfig` receives the config object raw, which is exactly why the cast worked — but an author who ran their own config through the schema before handing it to the server lost `maskObjectFields: false` silently, with a successful parse and an unmasked deployment. That hole is closed, and it is pinned (`maskObjectFields: false` survives `.parse()`).
- The default is `true`, matching the shipped behaviour and `isObjectSchemaMaskingEnabled`'s `configured === false` opt-out semantics, so no deployment moves. The deployment-wide `OS_ALLOW_UNMASKED_OBJECT_METADATA` escape hatch is unchanged and documented on the key.

## 2. `ISecurityService.getMetadataReadableFields?` (ADR-0106 D7)

```ts
getMetadataReadableFields?(object: string, context?: SecurityContext): Promise<string[] | undefined>;
```

The metadata-plane sibling of `getReadableFields`: identical in every respect but one — a caller resolving to **zero** permission sets goes through the same fallback-set resolution `/auth/me/permissions` uses (`security.fallbackPermissionSet`, default `member_default`) instead of falling open to the full field set, so a guest-facing deployment's schema exposure is a deliberate permission-set decision rather than an accidental everything-default. `@objectstack/plugin-security` has implemented it since #6612 and `@objectstack/metadata-core`'s `resolveObjectSchemaMaskPosture` already feature-detects it, falling back to `getReadableFields`.

Same shape as `loadDiagnosed` / `getDiagnosed` (#4127 batch 4 / #6051): call sites and implementation already agree, only the contract was missing.

### Optional, not required — following #6841

#6841 landed `checkAuthoredRowWrite?` as **optional** on this same contract three commits before this branch, and recorded the counter-precedent (#6428 declared `ISharingService.checkEdit` / `checkDelete` as required members with runtime feature detection). I follow #6841, and the reasons transfer without weakening:

1. **Absence is a defined, handled state, not a defect.** A security service predating ADR-0106 keeps its pre-ADR behaviour by design; `metadata-core` reads the missing method as "use `getReadableFields`". A required declaration would assert something the ruling explicitly names as legitimate.
2. **Required buys no guarantee here.** This contract's own header instructs consumers to feature-detect, and `packages/rest` types the whole service as `Partial<ISecurityService>`.
3. **Optional prevents the mistake structurally.** `svc.getMetadataReadableFields(...)` unguarded compiles under a required declaration and throws against any partial implementation; under an optional one it does not compile. There is a `@ts-expect-error` pin for exactly this.

One asymmetry worth naming, since it is the only place the two cards differ: degrading here is *never a narrowing*. The fallback (`getReadableFields`) is equal or **wider** than the metadata-plane answer, so absence cannot hide a column a caller may see — it can only decline the extra tightening D7 adds for zero-permission-set callers. That is the pre-ADR-0106 behaviour, which is the correct thing for a deployment that never opted into D7 to get.

## Strictness-ledger judgement: neither member needs it

The card left this to the spec seat. My call is **no ledger treatment**, for two independent reasons:

- `ISecurityService` is a TypeScript interface, not a zod object. The #4001 ledger classifies *object sites* by unknown-key posture; there is no site here to classify.
- `maskObjectFields` is added **inside an existing** `strip`-posture `z.object` site. The ledger counts sites, not keys, so this PR adds zero sites and shifts no count. Tightening `MetadataEndpointsConfigSchema` to `.strict()` would be a separate campaign step with its own compatibility question (it would start rejecting configs that pass extra keys today), and riding it in here would hide a behaviour change inside a declaration PR.

`pnpm --filter @objectstack/spec check:strictness-ledger` passes unchanged, which is the measurement behind both claims.

## The `(metadata as any)` cast in `packages/rest`: measured removable, deliberately not removed here

The dispatch asked me to measure this and state a call. Measured, on this branch, with the freshly built spec dist:

```
- maskObjectFields: isObjectSchemaMaskingEnabled((metadata as any).maskObjectFields),
+ maskObjectFields: isObjectSchemaMaskingEnabled(metadata.maskObjectFields),
```

`tsc --noEmit` in `packages/rest` reports **no new error** — only the two pre-existing, unrelated `src/package-routes.ts` `string | string[]` errors, byte-identical before and after. The cast is genuinely vestigial now. The probe was reverted; `git diff packages/rest/` is empty.

**Call: out of scope for this PR.** The card is claimed with a `packages/spec`-only file surface, and that surface exists because of same-file serialization in the spec lane (this card already waited on #6841 for one shared file). Reaching into `packages/rest/src/rest-server.ts` — one of the hottest files in the repo — to delete one cast trades a conflict risk against zero functional gain. The precedent agrees: `api.enableOpenApi` has had a declared seat in `rest-server.zod.ts` since long before this PR and `normalizeConfig` still reads it through a cast, so a leftover cast beside a declared key is an established, harmless state here rather than a defect this PR introduces.

Two follow-up cleanups, both recorded on #6622 rather than done here, and both now *purely* cosmetic:

1. `packages/rest/src/rest-server.ts` — drop the `(metadata as any)` cast (and, while there, the same for `api.enableOpenApi` / `api.enableSearch`), and shorten the comment that explains why the cast exists.
2. `packages/plugins/plugin-security/src/security-plugin.ts` — the `Object.assign` registration comment says the spec seat "is a separate change"; that is now stale prose, and the extension could be folded into the typed `securityService` literal. The `Object.assign` itself still type-checks correctly against the new contract either way (verified below).

## Reverse verification — the pin can go red

A pin that cannot fail is not a pin. Feeding a wrong-typed implementation to plugin-security's typed `securityService` literal turns its typecheck red **against the freshly built spec dist**, which is the check that the contract addition is being read from the new artefact and not a stale one:

```
src/security-plugin.ts(688,9): error TS2322: Type '(_object: string, _context?: any) => Promise<number[]>'
  is not assignable to type '(object: string, context?: …) => Promise<string[] | undefined>'.
    Type 'Promise<number[]>' is not assignable to type 'Promise<string[] | undefined>'.
      Type 'number[]' is not assignable to type 'string[]'.
```

The probe was restored byte-identically (confirmed by an empty `git diff` on the file), and `pnpm --filter @objectstack/plugin-security run typecheck` is clean again.

The config half carries the same instrument at source level: a `@ts-expect-error` pin that `maskObjectFields: 'false'` (a truthy string, the classic config typo) does not compile, so the seat is proven typed rather than `any`.

## Tests

`packages/spec/src/api/rest-server.test.ts` — 3 cases:
- the default `true` **materializes** through `.parse({})` (so a later `.optional()`, which would hand `undefined` to the REST layer, fails here instead of silently unmasking every metadata read);
- `maskObjectFields: false` **survives** the parse, and explicit `true` is a real answer rather than a discarded no-op;
- compile-time: the key is authorable without a cast, optional on the input side, and boolean-typed (`@ts-expect-error` on a string).

`packages/spec/src/contracts/security-service.test.ts` — 2 cases:
- optionality, the unguarded call not compiling (`@ts-expect-error`), and the exact prefer-then-fall-back shape `metadata-core` writes;
- the semantic difference the second method exists for — the metadata plane narrows for a zero-permission-set caller where the data plane falls open — plus `isSystem` bypassing on both planes, and the two distinct empty answers (`undefined` = no answer, `[]` = disclose nothing) inherited unchanged.

## Gates

Every `check:*` in `.github/workflows/lint.yml` was enumerated and run one by one, in the foreground, plus `check:strictness-ledger` from `spec-liveness-check.yml`. All pass. `check:docs` failed once, as expected — `content/docs/references/api/rest-server.mdx` is generated from the spec schemas and goes stale the moment `MetadataEndpointsConfigSchema` gains a key; regenerated with `gen:schema` + `gen:docs` on a clean tree (never in a merge state, never hand-edited) and committed separately.

The spec build regenerated `packages/spec/authorable-surface/api.json` and `authorable-defaults/api.json` (one line each: `api/MetadataEndpointsConfig:maskObjectFields` and `… = true`). Expected, committed, not reverted.

**Consumer sweep — prefix direction**, i.e. spec *and its dependents*, run after the closures were built (`turbo run build --filter='./packages/*' --filter='./examples/*^...'`, then the ledgered `--filter='./packages/*' --filter='./packages/*/*'`, so nothing typechecks against a stale `dist`): `pnpm --filter '...@objectstack/spec' run typecheck` over 74 packages — clean. Full test suites for spec and the three packages that actually consume these two surfaces: `@objectstack/spec` 8908 passed, `@objectstack/rest` 1109 passed, `@objectstack/plugin-security` 861 passed, `@objectstack/metadata-core` 124 passed.

## Boundaries honoured

- No `packages/rest` or `packages/plugins/plugin-security` edits — measured, deferred, recorded above.
- No `content/docs/releases/` edits; the changeset (`.changeset/adr-0106-declarations.md`, `@objectstack/spec` minor) is this PR's input to the release notes.
- No ADR edits — ADR-0106 D7/D8 already say what these declarations implement.

---
_Generated by [Claude Code](https://claude.ai/code/session_01115GjksiLKTEth6gZZMcvG)_