### PR TITLE
feat(lint): 新增 gating 规则 flow-trigger-unroutable —— record_change flow 声明了引擎无法路由的 triggerType (#6637)

### DIFF
--- a/.changeset/lint-flow-trigger-unroutable.md
+++ b/.changeset/lint-flow-trigger-unroutable.md
@@ -1,0 +1,9 @@
+---
+'@objectstack/lint': minor
+---
+
+新增 gating 规则 `flow-trigger-unroutable`（#6637）：`type: 'record_change'` 的 flow 若在 start 节点声明了引擎无法路由的 `triggerType`（如 `onCreate`、`on_update`、`['onCreate']`），现在在 `os lint` / `os validate` / `os build` 与运行时发布闸门上报 `error`。
+
+这是 never-fire 家族里最安静的一种失败。引擎的 `resolveTriggerBinding` 只按字面量 `startsWith('record-')` 认领 record-change flow，落空后整条分支链走到底返回 `undefined`，`activateFlowTrigger` 直接 `return`，该 flow 就被当成手动 flow —— 而专门为「悄悄没绑上」而建的 `getTriggerBindingAudit` 调用的是同一个 resolver，会以「manual / screen flow — nothing to bind」跳过它。因此启动告警和 CLI 启动摘要都不会点名，唯一痕迹是 banner 里 flow 总数比 bound 数多一。
+
+规则范围刻意收窄到「声明了 `record_change`」的 flow：落空到无绑定本身也正是一个 flow 合法地成为手动 flow 的机制，而 `autolaunched` / `screen` 才是手动 flow 声明的类型，所以这条规则在结构上不可能误伤真正的手动 flow。`triggerType` 完全缺失的情形（同样必死）不在本次范围内，另行处理。

--- a/packages/cli/test/authoring-rule-command-parity.test.ts
+++ b/packages/cli/test/authoring-rule-command-parity.test.ts
@@ -57,7 +57,12 @@ const CASES: ReadonlyArray<{ rule: string; blindTo: readonly AuthoringCommand[];
       flows: [{
         name: 'parity_flow', label: 'Parity', type: 'record_change', runAs: 'system', status: 'active',
         nodes: [
-          { id: 'start', type: 'start', label: 'Start', config: { objectName: 'parity_task', triggerType: 'onCreate' } },
+          // #6637 — was `triggerType: 'onCreate'`, which on a `type: 'record_change'`
+          // flow the engine routes to no trigger at all. This case's planted defect
+          // is the approver expression; the trigger token was incidental, and leaving
+          // a second (now gating) defect in the fixture would let the case pass on a
+          // finding it is not about.
+          { id: 'start', type: 'start', label: 'Start', config: { objectName: 'parity_task', triggerType: 'record-after-create' } },
           { id: 'appr', type: 'approval', label: 'Approve', config: { approvers: [{ type: 'expression', value: 'record.owner ==' }] } },
           { id: 'end', type: 'end', label: 'End' },
         ],

--- a/packages/lint/src/authoring-rules.ts
+++ b/packages/lint/src/authoring-rules.ts
@@ -646,10 +646,12 @@ export const AUTHORING_RULES: readonly AuthoringRule[] = [
   //
   // `gating` since #5762, which reviewed the file's rules as one family and
   // split them on a single question: is THIS STACK enough to know the flow is
-  // dead? Three rules answer yes and now emit `error` — a `config.timeRelative`
+  // dead? Four rules answer yes and emit `error` — a `config.timeRelative`
   // the spec's own `TimeRelativeTriggerSchema` refuses, one the engine's routing
-  // predicate cannot route at all, and a `record-*` triggerType outside the
-  // closed token grammar `triggerTypeToHookEvents` maps. None of those verdicts
+  // predicate cannot route at all, a `record-*` triggerType outside the
+  // closed token grammar `triggerTypeToHookEvents` maps, and (#6637) a
+  // `type: 'record_change'` flow whose triggerType the engine's binding resolver
+  // routes nowhere, silently demoting it to a manual flow. None of those verdicts
   // can be changed by installing a package, so there is no reading under which
   // the flow fires. `flow-trigger-unknown-object` deliberately stayed `warning`
   // (the object may come from another installed package — a hedge this rule

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -83,6 +83,7 @@ export {
   FLOW_TRIGGER_UNKNOWN_EVENT,
   FLOW_TIME_RELATIVE_DESCRIPTOR_INVALID,
   FLOW_TIME_RELATIVE_DESCRIPTOR_UNROUTABLE,
+  FLOW_TRIGGER_UNROUTABLE,
 } from './validate-flow-trigger-readiness.js';
 export type {
   FlowTriggerReadinessFinding,

--- a/packages/lint/src/lint-flow-patterns.test.ts
+++ b/packages/lint/src/lint-flow-patterns.test.ts
@@ -452,7 +452,12 @@ describe('lintFlowPatterns — user-less runAs unscoped (#1888 / ADR-0049 / ADR-
   // existence. Pinned so nobody "fixes" the gap by guessing.
   it('does NOT flag record_change — undecidable at authoring time, caught at run time', () => {
     const fnds = lintFlowPatterns(
-      scheduledDataFlow({ flowType: 'record_change', startConfig: { triggerType: 'record_change', objectName: 'invoice' } }),
+      // #6637 — the token was `'record_change'` (the flow TYPE echoed into the
+      // trigger slot), which is not an authored trigger token at all: the engine
+      // routes only `record-*`, so that fixture described a flow that never fires.
+      // The pin is about a record-change flow, so it spells one — the same token
+      // the sibling guard below already uses.
+      scheduledDataFlow({ flowType: 'record_change', startConfig: { triggerType: 'record-after-update', objectName: 'invoice' } }),
     );
     expect(fnds.map((f) => f.rule)).not.toContain(FLOW_RUNAS_UNSCOPED);
   });

--- a/packages/lint/src/validate-flow-trigger-readiness.test.ts
+++ b/packages/lint/src/validate-flow-trigger-readiness.test.ts
@@ -9,6 +9,7 @@ import {
   FLOW_TRIGGER_UNKNOWN_EVENT,
   FLOW_TIME_RELATIVE_DESCRIPTOR_INVALID,
   FLOW_TIME_RELATIVE_DESCRIPTOR_UNROUTABLE,
+  FLOW_TRIGGER_UNROUTABLE,
 } from './validate-flow-trigger-readiness.js';
 
 function recordFlow(overrides: Record<string, unknown> = {}) {
@@ -720,6 +721,198 @@ describe('validateFlowTriggerReadiness', () => {
     expect(findings.some((f) => f.rule === FLOW_TRIGGER_UNKNOWN_EVENT)).toBe(false);
   });
 
+  // ── #6637 — a record_change flow the engine routes NOWHERE ───────────────
+  //
+  // The quietest member of the never-fire family. Every case below is built on
+  // `unroutable()`, which differs from `recordFlow()` in exactly the two ways
+  // the criterion cares about: `type: 'record_change'` (the declared intent) and
+  // a start-node `triggerType` outside the `record-` prefix (the contradiction).
+  //
+  // The "does NOT flag" block is the load-bearing half. A criterion phrased on
+  // "resolves to no binding" alone would flag every manual and screen flow in
+  // the world, so each guard below is a shape the rule must stay silent about,
+  // paired — per the same fixture — with the one-key mutation that makes it
+  // speak. A guard whose green could also be produced by a rule that never runs
+  // is not a guard.
+  describe('record_change flow with an unroutable triggerType (#6637)', () => {
+    /** A `type: 'record_change'` flow whose start node carries `config`. */
+    const unroutable = (config: Record<string, unknown>, flowOverrides: Record<string, unknown> = {}) => ({
+      objects: [candidateObject],
+      flows: [
+        {
+          name: 'candidate_hired',
+          type: 'record_change',
+          status: 'active',
+          nodes: [
+            { id: 'start', type: 'start', config: { objectName: 'app_candidate', ...config } },
+            { id: 'end', type: 'end' },
+          ],
+          edges: [{ id: 'e1', source: 'start', target: 'end' }],
+          ...flowOverrides,
+        },
+      ],
+    });
+
+    it("flags the issue's specimen — triggerType 'onCreate' on a record_change flow", () => {
+      const findings = validateFlowTriggerReadiness(unroutable({ triggerType: 'onCreate' }));
+      expect(findings.map((f) => f.rule)).toEqual([FLOW_TRIGGER_UNROUTABLE]);
+      expect(findings[0].severity).toBe('error');
+      expect(findings[0].message).toContain("'onCreate'");
+      expect(findings[0].path).toBe('flows[0].nodes[0].config.triggerType');
+    });
+
+    it('describes the MEASURED failure, not just "never fires"', () => {
+      // The three engine facts the message is built on — a message that only
+      // said "never fires" would be indistinguishable from `…-unknown-event`,
+      // whose flow DOES bind and DOES get a bind-time warn. The distinguishing
+      // claim is that nothing names this one, and the rule has to make it.
+      const [f] = validateFlowTriggerReadiness(unroutable({ triggerType: 'onCreate' }));
+      expect(f.message).toMatch(/record_change/);
+      expect(f.message).toMatch(/never fires/i);
+      expect(f.message).toMatch(/audit/i);
+      // …and it must NOT overclaim: the flow count line does move, so the
+      // message says "nothing NAMES it" rather than "no signal anywhere".
+      expect(f.message).toMatch(/count/i);
+      expect(f.hint).toMatch(/record-\{before,after\}/);
+      expect(f.hint).toMatch(/autolaunched/);
+    });
+
+    it('flags the other unroutable spellings an author reaches for', () => {
+      for (const tt of ['on_create', 'onUpdate', 'create', 'record_change', 'after_insert', '']) {
+        const findings = validateFlowTriggerReadiness(unroutable({ triggerType: tt }));
+        expect(findings.map((f) => f.rule), `triggerType ${JSON.stringify(tt)}`).toEqual([
+          FLOW_TRIGGER_UNROUTABLE,
+        ]);
+      }
+    });
+
+    it('flags a non-record ARRAY on a record_change flow — 1d deliberately does not claim it', () => {
+      // `['onCreate']` has no `record-` element, so `flow-trigger-unknown-event`
+      // (1d) stays silent by design and pins that silence in its own test. On an
+      // `autolaunched` flow that silence is correct; on a `record_change` flow it
+      // left the loudest possible contradiction unreported. The token is rendered
+      // as JSON so the author sees the shape they wrote.
+      const findings = validateFlowTriggerReadiness(unroutable({ triggerType: ['onCreate'] }));
+      expect(findings.map((f) => f.rule)).toEqual([FLOW_TRIGGER_UNROUTABLE]);
+      expect(findings[0].message).toContain('["onCreate"]');
+      expect(findings.some((f) => f.rule === FLOW_TRIGGER_UNKNOWN_EVENT)).toBe(false);
+    });
+
+    describe('does NOT flag (each paired with the mutation that makes it fire)', () => {
+      it('a canonical record-* token — the whole point of declaring record_change', () => {
+        expect(validateFlowTriggerReadiness(unroutable({ triggerType: 'record-after-update' }))).toEqual([]);
+        // Planted bad value on the SAME fixture: the green above is the rule
+        // judging a good token, not the rule failing to run.
+        expect(
+          validateFlowTriggerReadiness(unroutable({ triggerType: 'record_after_update' })).map((f) => f.rule),
+        ).toEqual([FLOW_TRIGGER_UNROUTABLE]);
+      });
+
+      it('an off-grammar record-* token — that is 1c\'s finding, and only 1c\'s', () => {
+        // The two ids partition the dead tokens on whether the engine routes the
+        // value, so exactly one of them can ever speak about a given token.
+        const findings = validateFlowTriggerReadiness(unroutable({ triggerType: 'record-after-updated' }));
+        expect(findings.map((f) => f.rule)).toEqual([FLOW_TRIGGER_UNKNOWN_EVENT]);
+        expect(findings.some((f) => f.rule === FLOW_TRIGGER_UNROUTABLE)).toBe(false);
+      });
+
+      it('a genuinely manual flow — autolaunched/screen, the types this rule cannot reach', () => {
+        // The recorded counter-argument to the whole rule (#6637): the
+        // fall-through to "no binding" is ALSO how a flow legitimately is
+        // manual. Declaring `record_change` is what separates the two, so these
+        // must stay silent no matter how unroutable the token is.
+        for (const type of ['autolaunched', 'screen']) {
+          expect(
+            validateFlowTriggerReadiness(unroutable({ triggerType: 'onCreate' }, { type })).map((f) => f.rule),
+            type,
+          ).not.toContain(FLOW_TRIGGER_UNROUTABLE);
+        }
+        // Same fixture, one key changed back: `record_change` and it fires.
+        expect(
+          validateFlowTriggerReadiness(unroutable({ triggerType: 'onCreate' }, { type: 'record_change' })).map(
+            (f) => f.rule,
+          ),
+        ).toContain(FLOW_TRIGGER_UNROUTABLE);
+      });
+
+      it('a record_change flow that ALSO declares a trigger the engine DOES route', () => {
+        // These bind and fire — on the wrong trigger's terms. A real defect, a
+        // different one, and not this rule's to name (see 1f). Pinned so the
+        // criterion is not quietly widened into a second verdict.
+        for (const extra of [
+          { schedule: { type: 'interval', intervalMs: 60000 } },
+          { timeRelative: { object: 'app_candidate', dateField: 'due_at', withinDays: 7 } },
+        ]) {
+          expect(
+            validateFlowTriggerReadiness(unroutable({ triggerType: 'onCreate', ...extra })).map((f) => f.rule),
+            JSON.stringify(extra),
+          ).not.toContain(FLOW_TRIGGER_UNROUTABLE);
+        }
+        // `triggerType: 'api'` routes on its own — the engine tests the token
+        // itself, so there is nothing to add to the fixture.
+        expect(
+          validateFlowTriggerReadiness(unroutable({ triggerType: 'api' })).map((f) => f.rule),
+        ).not.toContain(FLOW_TRIGGER_UNROUTABLE);
+        // Drop the routed sibling and the same flow is dead again.
+        expect(
+          validateFlowTriggerReadiness(unroutable({ triggerType: 'onCreate' })).map((f) => f.rule),
+        ).toEqual([FLOW_TRIGGER_UNROUTABLE]);
+      });
+
+      it('an ABSENT triggerType — dead too, deliberately deferred (#6637 corpus)', () => {
+        // Scope boundary, pinned rather than left to memory. A `record_change`
+        // flow with no triggerType at all resolves to no binding by the same
+        // fall-through and is just as dead — but it is an omission rather than a
+        // contradiction, and the corpus measurement found a LIVE instance of it
+        // in `examples/app-todo` (`TaskCompletionFlow`, #6882). Covering it here
+        // would gate a shipped example app on a guess about that app's
+        // semantics, so the criterion requires the key to be PRESENT and the
+        // omission case is filed separately. Widening this is then a deliberate
+        // edit that has to delete this test, not a side effect of touching the
+        // predicate.
+        expect(
+          validateFlowTriggerReadiness(unroutable({})).map((f) => f.rule),
+        ).not.toContain(FLOW_TRIGGER_UNROUTABLE);
+        // Non-vacuous: add the key back, and the same fixture fires.
+        expect(
+          validateFlowTriggerReadiness(unroutable({ triggerType: 'onCreate' })).map((f) => f.rule),
+        ).toEqual([FLOW_TRIGGER_UNROUTABLE]);
+      });
+
+      it('a flow with no start node at all', () => {
+        expect(
+          validateFlowTriggerReadiness({
+            objects: [candidateObject],
+            flows: [{ name: 'no_start', type: 'record_change', status: 'active', nodes: [{ id: 'end', type: 'end' }] }],
+          }),
+        ).toEqual([]);
+      });
+    });
+
+    it('co-fires with the timeRelative scalar rule — two keys, two facts', () => {
+      // `{ triggerType: 'onCreate', timeRelative: 'daily' }` is wrong twice over,
+      // at two different paths. The file's stated doctrine is two facts rather
+      // than one fact twice, so both are reported — and 1e's own consequence
+      // clause stays true, because nothing on this start node routes either.
+      const findings = validateFlowTriggerReadiness(
+        unroutable({ triggerType: 'onCreate', timeRelative: 'daily' }),
+      );
+      expect(findings.map((f) => f.rule).sort()).toEqual(
+        [FLOW_TIME_RELATIVE_DESCRIPTOR_UNROUTABLE, FLOW_TRIGGER_UNROUTABLE].sort(),
+      );
+      expect(new Set(findings.map((f) => f.path)).size).toBe(2);
+      expect(
+        findings.find((f) => f.rule === FLOW_TIME_RELATIVE_DESCRIPTOR_UNROUTABLE)!.message,
+      ).toMatch(/binds to NOTHING/);
+    });
+
+    it('the id is the published slug and is distinct from the routed-token id', () => {
+      expect(FLOW_TRIGGER_UNROUTABLE).toBe('flow-trigger-unroutable');
+      expect(FLOW_TRIGGER_UNROUTABLE).not.toBe(FLOW_TRIGGER_UNKNOWN_EVENT);
+      expect(FLOW_TRIGGER_UNROUTABLE).not.toBe(FLOW_TIME_RELATIVE_DESCRIPTOR_UNROUTABLE);
+    });
+  });
+
   // ── #5762 — the family's severity map ────────────────────────────────────
   //
   // The rules in this file were reviewed as ONE family and split on a single
@@ -787,6 +980,27 @@ describe('validateFlowTriggerReadiness', () => {
                   id: 'start',
                   type: 'start',
                   config: { objectName: 'app_candidate', triggerType: 'record-after-updated' },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      [
+        FLOW_TRIGGER_UNROUTABLE,
+        'error',
+        {
+          objects: [candidateObject],
+          flows: [
+            {
+              name: 'declared_dead',
+              type: 'record_change',
+              status: 'active',
+              nodes: [
+                {
+                  id: 'start',
+                  type: 'start',
+                  config: { objectName: 'app_candidate', triggerType: 'onCreate' },
                 },
               ],
             },

--- a/packages/lint/src/validate-flow-trigger-readiness.ts
+++ b/packages/lint/src/validate-flow-trigger-readiness.ts
@@ -42,6 +42,13 @@
 //      ADR-0018, so the scalar parses fine), not `os validate`, and not even
 //      the one bind-time warn rule 3's case gets.
 //
+//   5. A `type: 'record_change'` flow whose start-node `triggerType` the engine
+//      routes NOWHERE — `triggerType: 'onCreate'` (#6637). The quietest member
+//      of the family: rules 3 and 4 are about one key's shape, this one is
+//      about a flow that declares WHAT it is and then contradicts it. See 1f
+//      for the measured silence — every named runtime channel skips it because
+//      they all key off the same resolution that already gave up.
+//
 // The spec import is deliberate and is what makes rule 3 possible without a
 // second copy of the descriptor's shape living in this file. It stays inside the
 // package's stated dependency direction — lint → `@objectstack/spec`, never onto
@@ -54,15 +61,24 @@
 // It is whether THIS STACK is enough to know that:
 //
 //   - `error` — the never-fire family. `flow-time-relative-descriptor-invalid`,
-//     `flow-time-relative-descriptor-unroutable` and
-//     `flow-trigger-unknown-event` each read a value whose verdict is settled by
-//     a contract that ships in this repo: `TimeRelativeTriggerSchema` for the
+//     `flow-time-relative-descriptor-unroutable`, `flow-trigger-unknown-event`
+//     and `flow-trigger-unroutable` each read a value whose verdict is settled
+//     by a contract that ships in this repo: `TimeRelativeTriggerSchema` for the
 //     first, the engine's own `typeof … === 'object'` routing predicate for the
-//     second, `triggerTypeToHookEvents`' closed token grammar for the third.
+//     second, `triggerTypeToHookEvents`' closed token grammar for the third, and
+//     `resolveTriggerBinding`'s whole hardcoded branch chain for the fourth.
 //     Nothing an author or a tenant can INSTALL changes any of those verdicts,
 //     so there is no reading of the stack under which the flow fires. A rule
 //     that can prove a declared trigger is dead should not be asking the author
-//     to notice a warning about it.
+//     to notice a warning about it. `flow-trigger-unroutable` is the one that
+//     had to be MEASURED rather than assumed (#6637): a plugin CAN supply a
+//     trigger implementation, so "installing something fixes it" is a live
+//     hypothesis for this id in a way it is not for the other three. It is
+//     false — `registerTrigger` is keyed by the RESOLVED type
+//     (`record_change` / `schedule` / `time_relative` / `api`), and the
+//     authored-token → resolved-type map is a private chain of literal
+//     `startsWith` / `typeof` tests with no registry lookup anywhere in it. No
+//     package can teach the engine a new authored token.
 //   - `warning` — `flow-trigger-unknown-object`, both halves. An object name
 //     this stack does not define may be defined by another installed package,
 //     and this rule cannot see that package's objects. The hedge is real, so the
@@ -131,6 +147,25 @@ export const FLOW_TIME_RELATIVE_DESCRIPTOR_INVALID = 'flow-time-relative-descrip
  *     there is no runtime channel at all for it to be moved earlier from.
  */
 export const FLOW_TIME_RELATIVE_DESCRIPTOR_UNROUTABLE = 'flow-time-relative-descriptor-unroutable';
+/**
+ * #6637 — a `type: 'record_change'` flow whose start-node `triggerType` the
+ * engine routes to NO trigger at all, so the flow is silently demoted to a
+ * manual one.
+ *
+ * A separate id from `flow-trigger-unknown-event`, on the same distinction that
+ * separates the two `timeRelative` ids: whether the engine ROUTES the value.
+ * The two partition the declared-but-dead tokens and can never both fire on one
+ * value, because being `record-`-prefixed is exactly what routes a token:
+ *
+ *   - `record-`-prefixed but off-grammar (`record-after-updated`) — the engine
+ *     ROUTES it to the record-change trigger, which maps it to zero hook events
+ *     and says so in a bind-time warn. That is `…-UNKNOWN-EVENT`, and this rule
+ *     file moves that warn earlier.
+ *   - anything else (`onCreate`, `on_update`, `''`, `['onCreate']`) — the engine
+ *     routes it NOWHERE. That is this id, and there is no runtime channel to
+ *     move earlier from: see 1f for the three call sites that each skip it.
+ */
+export const FLOW_TRIGGER_UNROUTABLE = 'flow-trigger-unroutable';
 
 type AnyRec = Record<string, unknown>;
 
@@ -173,6 +208,22 @@ function renderNonObject(v: unknown): string {
   if (t === 'string' || t === 'number' || t === 'boolean') return `${JSON.stringify(v)} (a ${t})`;
   if (t === 'bigint') return `${String(v)}n (a bigint)`;
   return `a ${t}`;
+}
+
+/**
+ * Render a `config.triggerType` for the 1f message. Unlike `renderNonObject`
+ * this one has to survive an ARRAY (`['onCreate']` is a real authored shape that
+ * reaches 1f — see 1d, which claims only the arrays holding a `record-` element),
+ * so it quotes strings and JSON-renders everything else, falling back to the
+ * bare type for the values `JSON.stringify` returns `undefined` for (a function,
+ * a symbol). Same reasoning as `renderNonObject`: a diagnostic that interpolates
+ * the word "undefined" into a sentence about a value that is very much present
+ * misreports its own subject.
+ */
+function renderTriggerToken(v: unknown): string {
+  if (typeof v === 'string') return `'${v}'`;
+  const json = JSON.stringify(v);
+  return json === undefined ? `a ${typeof v}` : json;
 }
 
 /** The start node of a flow definition, if any. */
@@ -465,6 +516,102 @@ export function validateFlowTriggerReadiness(stack: AnyRec): FlowTriggerReadines
           `sibling key config.schedule on the same start node (it defaults to daily, so it is usually ` +
           `omitted). See TimeRelativeTriggerSchema and ` +
           `content/docs/references/automation/time-relative-trigger.mdx.`,
+      });
+    }
+
+    // 1f. #6637 — a flow that DECLARES `type: 'record_change'` and then names a
+    //     start-node `triggerType` the engine routes to no trigger at all.
+    //
+    //     `triggerType: 'onCreate'` is the specimen. What actually happens was
+    //     measured rather than assumed, because the card's word for it
+    //     ("silently degrades") is a summary and a diagnostic has to be true:
+    //
+    //       - `AutomationEngine.resolveTriggerBinding` tests the authored token
+    //         with a literal `startsWith('record-')`, then tries the array form,
+    //         `timeRelative`, `config.schedule`/`flow.type === 'schedule'`, and
+    //         `flow.type === 'api'`/`triggerType === 'api'`. A token matching
+    //         none of them falls off the end and the method returns `undefined`.
+    //       - `activateFlowTrigger` opens with `if (!resolved) return;`, so the
+    //         flow is never bound and never logs a word. It is now, in every
+    //         respect the engine can observe, a manual flow.
+    //       - `getTriggerBindingAudit` — the silent-miss audit built for exactly
+    //         this class of defect — calls the SAME resolver and skips it with
+    //         `if (!resolved) continue; // manual / screen flow — nothing to
+    //         bind`. So the one channel that exists to name unbound flows cannot
+    //         see this one, and neither can its two consumers: the automation
+    //         plugin's `kernel:bootstrapped` warn loop, and the CLI startup
+    //         summary's `unbound` list.
+    //
+    //     What is left is not a diagnostic. `getFlowRuntimeStates` does report
+    //     the flow with `bound: false` and `triggerType: undefined`, but the
+    //     only place that surfaces is the banner's count line ("N flow(s)
+    //     registered, N-1 bound") — a number with no flow name and no reason.
+    //     So the message below says "nothing names it", which is the measured
+    //     claim, rather than "no signal at all", which would be one count off.
+    //
+    //     The scope is the narrow one, and the narrowing is what makes the rule
+    //     safe: it speaks ONLY for flows that declare `type: 'record_change'`.
+    //     Falling through to no binding is also the legitimate mechanism by
+    //     which a flow IS manual, and `lint-flow-patterns.test.ts` already pins
+    //     a deliberate `does NOT flag record_change` case for a neighbouring
+    //     rule — so a criterion phrased on the fall-through ALONE would flag
+    //     every manual and screen flow in existence. A flow that declares
+    //     `record_change` has stated its own intent: `autolaunched` and `screen`
+    //     are the types a genuinely manual flow declares, and neither reaches
+    //     here. That is what makes this decidable at authoring time.
+    //
+    //     Two shapes are deliberately NOT this rule's, each pinned by a test:
+    //
+    //       - `triggerType` ABSENT on a `record_change` flow. Dead the same way
+    //         and arguably worse, but it is an omission rather than a
+    //         contradiction, and the corpus measurement (#6637) found a live
+    //         instance of it in `examples/app-todo` whose repair is a judgement
+    //         about that app's semantics, not a lint decision (#6882 — the flow
+    //         also writes its predicate to a `triggerCondition` key nothing
+    //         reads, so arming it is not a one-token edit). Widening this
+    //         criterion to cover it would gate a shipped example app on a guess.
+    //         The criterion here requires the key to be PRESENT so that widening
+    //         is a deliberate act, not a side effect.
+    //       - a `record_change` flow that ALSO declares something the engine
+    //         does route (`config.schedule`, `triggerType: 'api'`). That flow
+    //         binds and fires — on the wrong trigger's terms. A real defect, a
+    //         different one ("mis-bound", not "never bound"), with its own
+    //         severity argument to make. `routesToSomeTrigger` below is the
+    //         engine's chain character for character precisely so this rule
+    //         stays silent there instead of guessing at a second verdict.
+    const routesToSomeTrigger =
+      isRecordTriggered ||
+      isArrayRecordTriggered ||
+      isTimeRelative ||
+      config.schedule != null ||
+      flow.type === 'schedule' ||
+      flow.type === 'api' ||
+      triggerType === 'api';
+    if (start && flow.type === 'record_change' && config.triggerType != null && !routesToSomeTrigger) {
+      findings.push({
+        // `error` (#5762's criterion, applied to a fourth id). The verdict is
+        // the engine's own routing chain — literal `startsWith`/`typeof` tests
+        // with no registry lookup in them — so no installed package can make
+        // this token resolve. `registerTrigger` is keyed by the RESOLVED type,
+        // which is the near-miss worth stating: a plugin can supply the
+        // record-change trigger itself, and it still would not help, because
+        // the flow never reaches the point of asking for one.
+        severity: 'error',
+        rule: FLOW_TRIGGER_UNROUTABLE,
+        where: `flow "${flowName}" › start node`,
+        path: `flows[${flowIndex}].nodes[${start.index}].config.triggerType`,
+        message:
+          `declares type: 'record_change' but its start node's triggerType is ` +
+          `${renderTriggerToken(config.triggerType)}, which the engine routes to NO trigger — it binds a ` +
+          `record-change flow only for a token starting with 'record-', so this flow is demoted to a manual ` +
+          `one and never fires. Nothing NAMES it: the unbound-flow audit resolves the same binding and skips ` +
+          `the flow as "manual — nothing to bind", so neither the boot warning nor the startup summary lists ` +
+          `it; the only trace is the banner's flow count being one higher than its bound count.`,
+        hint:
+          `Use record-{before,after}-{create,update,delete,write} ('write' is create OR update in one flow, ` +
+          `#3427; create/insert are synonyms). If the flow really is launched by hand or from a screen, ` +
+          `declare type: 'autolaunched' or 'screen' instead of 'record_change' — those types have no trigger ` +
+          `to be missing.`,
       });
     }
 


### PR DESCRIPTION
Fixes #6637

`type: 'record_change'` 的 flow 若在 start 节点写下引擎无法路由的 `triggerType`（`onCreate`、`on_update`、`['onCreate']` 等），会被悄悄降级成手动 flow：声明得像装好了，`os validate` 通过、启动通过，然后永远不触发。本 PR 在 `validate-flow-trigger-readiness.ts` 里加一条 gating 规则 `flow-trigger-unroutable`（`error`，`surfaces: CLI_AND_RUNTIME`，随该文件既有注册项一起生效）。

## 一、先测量退化，再写诊断

issue 的措辞「silently degrades」是概括，而诊断信息必须为真，所以先按 file:line 把真实路径量出来：

| 位置 | 行为 |
| --- | --- |
| `service-automation/src/engine.ts:1625-1719` `resolveTriggerBinding` | 用字面量 `startsWith('record-')` 认领 record-change flow；落空后依次试数组形式、`timeRelative`、`config.schedule` / `flow.type === 'schedule'`、`flow.type === 'api'` / `triggerType === 'api'`，全不匹配则在 **:1718 返回 `undefined`** |
| `engine.ts:1729` `activateFlowTrigger` | 以 `if (!resolved) return;` 开头 —— flow 从未绑定，也不写一行日志 |
| `engine.ts:2387-2400` `getTriggerBindingAudit` | 专为「悄悄没绑上」而建的审计，调用**同一个** resolver，以 `if (!resolved) continue; // manual / screen flow — nothing to bind` 跳过它 |
| `service-automation/src/plugin.ts:907-910` | `kernel:bootstrapped` 的告警循环遍历上面这份审计 → 一条都不发 |
| `cli/src/commands/serve.ts:3428` | 启动摘要的 `unbound` 列表同样来自该审计 → 空 |
| `cli/src/commands/serve.ts:3435-3441` | 摘要里的「死对象」检查要求 `s.bound && s.triggerType === 'record_change'` → 也跳过 |

唯一痕迹：`getFlowRuntimeStates` 确实以 `bound: false` 报出该 flow，但它只汇入 banner 的计数行（flow 总数比 bound 数多一），**没有名字、没有原因**。

所以规则的 message 写的是「没有任何地方**点名**它」，而不是「完全没有信号」—— 后者会差一个计数。这条差别是刻意的：`flow-trigger-unknown-event` 的 flow 是**会**绑定、**会**有 bind-time warn 的，只说「never fires」两者就分不开了。

## 二、判据与范围

判据逐字镜像引擎的路由链，只在其**之外**说话：

```ts
const routesToSomeTrigger =
  isRecordTriggered || isArrayRecordTriggered || isTimeRelative ||
  config.schedule != null || flow.type === 'schedule' ||
  flow.type === 'api' || triggerType === 'api';
if (start && flow.type === 'record_change' && config.triggerType != null && !routesToSomeTrigger) { … }
```

**为什么必须收窄到 `type: 'record_change'`**：落空到无绑定本身也正是一个 flow 合法地成为手动 flow 的机制 —— `lint-flow-patterns.test.ts` 已经为邻近规则钉了一条 `does NOT flag record_change` 判例。只按落空判定会误伤世上每一个手动 flow。而 `autolaunched` / `screen` 才是手动 flow 声明的类型，二者都到不了这里，这正是它在编写期可判定的原因。

**新 id 而非复用 `flow-trigger-unknown-event`**：沿用 `timeRelative` 家族 `-invalid` / `-unroutable` 的同一条分界 —— 引擎是否**路由**该值。带 `record-` 前缀正是「被路由」的充要条件，所以两个 id 对死 token 构成划分，永不同时命中同一个值（有测试钉住）。

**两种形状刻意不归本规则**，各由测试钉住，避免日后被顺手放宽：

1. `triggerType` **完全缺失** —— 同样必死，但属于遗漏而非自相矛盾，且语料实测在 `examples/app-todo` 有活实例（见下）。判据要求该键**存在**。
2. 同时声明了引擎**能**路由的东西（`config.schedule`、`triggerType: 'api'`）—— 这类 flow 会绑定并触发，只是按错误的 trigger 语义。是另一种缺陷（错绑，而非未绑），有它自己的严重级论证要做。

## 三、严重级：`error`，以及唯一需要实测的那一步

按 #5762 的家族判据（本 stack 是否足以判定该 flow 已死）取 `error`。这一条是家族里**唯一需要实测而非假定**的：插件确实可以提供 trigger 实现，所以「装个包就好了」对它是个真假设。

实测为假 —— `registerTrigger` 以**解析后**的类型为键（`record_change` / `schedule` / `time_relative` / `api`），而「作者写的 token → 解析后类型」这张表是 `resolveTriggerBinding` 里一串写死的 `startsWith` / `typeof` 判断，全链路没有任何注册表查询。没有任何包能教会引擎一个新的作者 token；而且该 flow 根本走不到「向谁要 trigger」那一步。

## 四、语料实测（`origin/main`，三个 example app 共 34 个 authored flow）

机械跑了一遍（同时跑本 PR 判据与放宽判据）：

- `flow.type` 分布：`autolaunched` 24 · `schedule` 4 · `screen` 3 · `record_change` 2 · `api` 1
- **本 PR 判据命中：0** —— authored 语料上一条都不触发，因此没有加任何基线豁免
- 放宽判据（允许 `triggerType` 缺失）命中：**1** —— `examples/app-todo` 的 `task_completion`

`record_change` 类型共 2 个，`showcase_urgent_task_alert` 接线正确（`record-after-write`）。那唯一的死 flow 已单独立卡 #6882（它的谓词还写在没人读的 `triggerCondition` 键上，所以「补个 token」并不是它的修法，需要对该 example app 的语义做判断）—— 按 dispatch 的约束，**没有**用基线条目把它压掉。

## 五、Fixture 三分法：就地改写，不加豁免

仓库内两处 fixture 写了本规则所判之形状，均属「改写拼写」一类：

- `packages/cli/test/authoring-rule-command-parity.test.ts` 的 `triggerType: 'onCreate'`（issue 点名的那一处）—— 该用例的植入缺陷是审批表达式，trigger token 只是顺带；留着会让用例靠一个它并不针对的 finding 通过。改为 `record-after-create`。
- `packages/lint/src/lint-flow-patterns.test.ts` 把 flow 类型回写进 trigger 槽的 `triggerType: 'record_change'` —— 那不是一个作者 token，该 fixture 描述的是一个永不触发的 flow。改为 `record-after-update`（与同一文件里相邻的守卫用例一致）。

改写后，tracked tree 上本规则所判之形状为零。

## 六、消融验证（先写预测，再测）

新规则没有「改前」行为，所以方向就是常规的红向；三次消融各自预测并实测：

| 消融 | 预测 | 实测 |
| --- | --- | --- |
| A. 删掉整个 1f finding | 红：4 条 `flags…`、severity map 的非空性守卫、以及每条 `does NOT flag` **配对的**植入坏值那一半 | **红，10 failed / 51 passed**，与预测一致 |
| B. 去掉 `flow.type === 'record_change'` 收窄 | 红，且应落在手动 flow 判例上 | **红，恰好 1 failed** —— `a genuinely manual flow — autolaunched/screen` |
| C. 去掉 `config.triggerType != null` 存在性守卫 | 包内红在 `ABSENT triggerType` 那一条；语料上应命中 `examples/app-todo` | **红，恰好 1 failed**；语料探针独立确认命中且**仅**命中 `task_completion` |

B 有一点值得单独记下：既有的 `does not flag non-record triggerTypes (schedule/api/manual)` 用例在消融 B 下**仍然是绿的** —— 它只断言 `FLOW_TRIGGER_UNKNOWN_EVENT` 不出现，对新 id 是盲的。真正拦住这次越界的是本 PR 新加的手动 flow 判例。

每条「这是合法的」断言都配了同一 fixture 上的植入坏值（如 `record-after-update` → `record_after_update`、`autolaunched` → `record_change`、删键 → 补键），所以绿不是空跑 —— 消融 A 下这些配对半边全部转红即为证据。

## 七、门禁

- `pnpm --filter @objectstack/lint test` → **67 files / 1759 passed**
- `pnpm --filter @objectstack/lint typecheck`、`pnpm --filter @objectstack/cli typecheck` → clean
- `packages/cli` `authoring-rule-command-parity.test.ts`（真实 spawn CLI 的消费者）→ **11 passed**
- `packages/metadata-protocol` 五个 record_change flow 发布闸门用例 → **65 passed**
- `node scripts/check-nul-bytes.mjs` → OK；改动文件控制字符自扫 → clean
- `eslint` 改动文件 → clean

## 八、刻意没做

- **不动运行时 trigger 分发**（dispatch 明确划出范围）。#3481 的 runtime 半边仍悬着：值得考虑的最小动作是让 `getTriggerBindingAudit` 能看见「声明了 `record_change` 却没解析出绑定」的 flow —— 目前它按 `!resolved` 跳过，恰恰把这一类漏掉。留给维护者与 #3481 一起裁决。
- **不碰 `docs/adr/**`**。
- **不加任何基线豁免**；`examples/app-todo` 的死 flow 立卡 #6882，未在本 PR 修。


---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_