### PR TITLE
docs(permissions): isSystem 行为全集权威表 —— 按普查而非回忆构建 (#6782)

### DIFF
--- a/.claude/workflows/docs-accuracy-audit.js
+++ b/.claude/workflows/docs-accuracy-audit.js
@@ -158,6 +158,7 @@ const ALL_HANDWRITTEN = [
   "content/docs/permissions/rls.mdx",
   "content/docs/permissions/sharing-rules.mdx",
   "content/docs/permissions/sso.mdx",
+  "content/docs/permissions/system-context.mdx",
   "content/docs/plugins/adding-a-metadata-type.mdx",
   "content/docs/plugins/anatomy.mdx",
   "content/docs/plugins/development.mdx",

--- a/content/docs/permissions/authorization.mdx
+++ b/content/docs/permissions/authorization.mdx
@@ -233,7 +233,9 @@ one of two doors, each writing only what it owns:
   **overlay** — the record projects the effective body while the package keeps
   owning the row, and "delete" resets to the shipped declaration. System /
   boot writes carry `isSystem` and bypass it, so the seeder and materializer
-  are never self-blocked.
+  are never self-blocked. That bypass is not local to this gate — the full set
+  of behaviours the flag changes is catalogued in
+  [System Context (`isSystem`)](/docs/permissions/system-context).
 
 ## Lifecycle coverage (five stages)
 

--- a/content/docs/permissions/meta.json
+++ b/content/docs/permissions/meta.json
@@ -6,6 +6,7 @@
     "authentication",
     "sso",
     "authorization",
+    "system-context",
     "profiles",
     "permission-sets",
     "positions",

--- a/content/docs/permissions/system-context.mdx
+++ b/content/docs/permissions/system-context.mdx
@@ -1,0 +1,262 @@
+---
+title: System Context (isSystem)
+description: The authoritative table of every platform behaviour keyed off `ExecutionContext.isSystem` — what an elevated write gets, what it loses, and what the flag deliberately does NOT do. Built by census over the whole repo, not by recall.
+---
+
+# System Context (`isSystem`)
+
+`ExecutionContext.isSystem` is the platform's one elevation flag. Setting it on a
+write or read means "this operation is the engine acting on its own behalf" —
+the seed loader replaying package fixtures, a plugin's boot reconciler, a
+service self-write, a migration.
+
+This page is **the authority** for what that flag actually does. It exists
+because the flag is not one concept: it is a single boolean read at **80
+distinct sites across 18 packages**, and knowing three of those behaviours gives
+no hint that the other seventy-seven exist. Every documented app-side bug traced
+to `isSystem` had the same shape — the metadata was complete and correct, and
+the gap was observable only by querying the resulting rows.
+
+<Callout type="warn">
+**Elevation is total, and it is not granular.** `isSystem` is not "skip the
+permission check". It short-circuits authorization, ownership stamping,
+read-only protection, referential-integrity checks, sharing materialisation,
+approval locks and provenance stamping — in eighteen packages that do not know
+about each other. Read the table before you set it; prefer a scoped user
+context whenever one exists.
+</Callout>
+
+## Which `isSystem` this page is about
+
+Four unrelated declarations share the identifier. **This page documents only the
+first.** The others are ordinary metadata fields on a stored document and have
+nothing to do with elevation.
+
+| Declaration | What it is | This page? |
+|:---|:---|:---:|
+| `ExecutionContext.isSystem` — `packages/spec/src/kernel/execution-context.zod.ts:233` | The elevation flag on an operation's context | ✅ |
+| `Object.isSystem` — `packages/spec/src/data/object.zod.ts:1249` | Marks a **system object** (protected from deletion; defaults its org-wide sharing to `public` when no `sharingModel` is set) | ❌ |
+| `EmailTemplate.isSystem` — `packages/spec/src/system/email-template.zod.ts:125` | Built-in template; tenants may override but should not delete | ❌ |
+| `Environment.isSystem` — `packages/spec/src/cloud/environment.zod.ts:136` | Platform-infrastructure environment, not user data | ❌ |
+
+The collision is a genuine hazard rather than a naming nit: `Object.isSystem`
+changes an object's **default sharing**, and `ExecutionContext.isSystem` changes
+whether **sharing grants are materialised** — so a search for "isSystem sharing"
+returns both, and they are unrelated decisions.
+
+A fifth, closely-spelled family — `isSystemObjectName()` /
+`isSystemObject()` in `packages/runtime/src/action-execution.ts:53`,
+`packages/mcp/src/mcp-http-tools.ts:178` — keys on the `sys_` **name prefix**,
+not on any flag.
+
+## How the flag is set
+
+`isSystem` is **server-constructed and never client-supplied**. Inbound HTTP
+cannot set it (`packages/rest/src/rest-server.ts:2079`, `:2096`), and neither
+can an action body (`packages/runtime/src/domains/actions.ts:122`). It is
+written by internal callers only, as an option on the engine call:
+
+```ts
+await engine.insert('crm_account', row, { context: { isSystem: true } });
+```
+
+Its parse-time default is `false` (`execution-context.zod.ts:233`), so an absent
+context is never elevated.
+
+---
+
+## The table
+
+Grouped by lane. Every row cites the site that reads the flag. "What you lose"
+is the part that costs app-side bugs — it is the protection or the side effect
+that silently does not happen.
+
+### 1. Authorization and scoping
+
+| # | Behaviour when `isSystem` | Package | What you get / what you lose | Anchor |
+|:--|:---|:---|:---|:---|
+| 1 | **The whole security middleware short-circuits** before any gate runs | plugin-security | Get: every CRUD/FLS/tenant/owner gate below skipped in one branch. Lose: all of rows 2–6 at once — this is the single largest behaviour on the page | `security-plugin.ts:825` |
+| 2 | **`owner_id` is not auto-stamped on INSERT** (the step 3.5 anchor guard is inside the block row 1 skips) | plugin-security | Lose: the row lands `owner_id = NULL`, so the default `owner_only_writes` policy hides it **from its own creator**. Get: nothing — this is a gap, not a capability | guard at `security-plugin.ts:1466`–`1560`, skipped by `:825` |
+| 3 | Row-level read filter resolves to "no filter" | plugin-security | Get: unscoped reads. Lose: row-level scoping entirely | `security-plugin.ts:2747` |
+| 4 | Field-level security returns **all** fields | plugin-security | Get: every column readable. Lose: field masking | `security-plugin.ts:2898` |
+| 5 | Export permission granted unconditionally | plugin-security | Get: `canExport` is `true` | `security-plugin.ts:2964` |
+| 6 | Write bypass = `true`, effective write scope = `org` | plugin-security | Get: widest write scope without holding any capability | `security-plugin.ts:705`, `:727` |
+| 7 | Metadata-plane schema masking exempt (ADR-0106 D4) | metadata-core | Get: unmasked object schema. Note: the exemption is a **caller** property — it short-circuits before the security service is consulted | `object-schema-fls.ts:167` |
+| 8 | `explain()` may target a principal other than the caller | plugin-security | Get: no `manage_users` / delegated-admin check | `security-plugin.ts:2321` |
+| 9 | Anonymous-deny treats the caller as authenticated | core | Get: passes the 401 seam with no `userId` | `anonymous-deny.ts:114` |
+| 10 | Permission-set projection middleware skipped | plugin-security | Lose: projection of permission-set-derived columns | `permission-set-projection.ts:670` |
+| 11 | Session-resolution middleware skipped | plugin-auth | Get: no session lookup attempted | `auth-plugin.ts:1023` |
+| 12 | Per-request performance timings disclosed | observability | Get: timing headers a normal caller cannot pull | `perf-timing.ts:474` |
+
+### 2. Write pipeline and data integrity
+
+| # | Behaviour when `isSystem` | Package | What you get / what you lose | Anchor |
+|:--|:---|:---|:---|:---|
+| 13 | **`readonly` strip bypassed — UPDATE, single row** | objectql | Get: a `readonly` field CAN be written. Lose: the protection that stops a caller seeding e.g. `approval_status` | `engine.ts:6860` |
+| 14 | **`readonly` strip bypassed — UPDATE, bulk/predicate** | objectql | Same, on the multi-row path | `engine.ts:7004` |
+| 15 | **`readonly` strip bypassed — INSERT (engine pass)** | objectql | Same, on create | `engine.ts:6078` |
+| 16 | **`readonly` strip bypassed — INSERT (protocol ingress)** | metadata-protocol | `isSystem` is the **only** exemption here. `preserveAudit` is deliberately not read on this path (#6640) — a non-system historical import is still stripped on create | `protocol.ts:1114` |
+| 17 | Strict-drop refusal never fires | objectql | Lose: a caller that opted into loud refusal gets **silence** — strict refuses exactly what the strip would have taken, and the strip took nothing | `engine.ts:6098`, `readonly-strict-errors.ts:44` |
+| 18 | **Referential-integrity check skipped** | objectql | Get: writes proceed against unreachable/unresolvable targets. Lose: an `isSystem` caller can write a **dangling reference** | `engine.ts:3314` |
+| 19 | Tenant-audit warning silenced; `bypassTenantAudit` threaded to the driver | objectql | Get: unscoped system writes stop warning. Lose: the signal that would flag a genuine user-path scoping bug | `engine.ts:2073`, `:2075`, `:2102` |
+| 20 | Engine-owned / append-only write guard bypassed | plugin-security | Get: generic writes to `managedBy` engine-owned objects | `system-write-guard.ts:96`, `:120` |
+| 21 | Identity write guard bypassed (ADR-0092) | plugin-auth | Get: direct writes to identity tables through the generic data path | `identity-write-guard.ts:98` |
+
+### 3. Sharing (`plugin-sharing`)
+
+The largest single consumer — **19 of the 80 sites**.
+
+| # | Behaviour when `isSystem` | What you get / what you lose | Anchor |
+|:--|:---|:---|:---|
+| 22 | **Sharing-rule grant materialisation is skipped on all four record-write hooks** | Lose: **no `sys_record_share` rows are created**. A fully configured sharing rule grants **nothing** on seeded data until a rule is re-evaluated or the boot backfill runs. This is the behaviour that motivated #4707 | `rule-hooks.ts:157`, `:165`, `:180`, `:194` |
+| 23 | Sharing write verdict short-circuits to `allow` | Get: writes pass the sharing gate unconditionally | `sharing-service.ts:438` |
+| 24 | Record visibility / manage-shares checks return true | Get: no ownership or Modify-All requirement | `sharing-service.ts:635`, `:722`, `:1195` |
+| 25 | `grant()` skips the enforcement + manage-shares assertions | Get: the rule evaluator can materialise through the public API | `sharing-service.ts:808` |
+| 26 | `revoke()` deletes directly, **before** the non-manual-source guard | Get: the evaluator can revoke its own grants. Lose: the `CONFLICT` guard that warns a rule-materialised grant will be silently re-granted on the next reconcile | `sharing-service.ts:884` (guard at `:908`) |
+| 27 | `listShares()` skips the management gate | Get: full enumeration of who can see a record | `sharing-service.ts:936` |
+| 28 | `sys_record_share` reads are **not** self-scoped | Get: tenant-wide share listing without `manage_sharing` | `sharing-plugin.ts:839` |
+| 29 | Share-link policy `enabled` check bypassed; system callers re-enter under a system context | Get: link creation/resolution while the policy is off | `share-link-service.ts:264`, `:312`, `:316`, `:374`, `:404` |
+| 30 | Sharing-rule provenance stamp skipped | Lose: the row is not marked as an admin customization — seeder / `defineRule` / boot reconcilers are "the package door" | `sharing-rule-provenance.ts:50` |
+| 31 | Sharing-rule service write path returns early | Lose: the same provenance/gating step on the service surface | `sharing-rule-service.ts:99` |
+
+### 4. Approvals, reports, attachments, comments, knowledge
+
+| # | Behaviour when `isSystem` | Package | What you get / what you lose | Anchor |
+|:--|:---|:---|:---|:---|
+| 32 | **Approval record lock released** — a locked record is writable | plugin-approvals | Get: engine self-writes (the status mirror) pass. Lose: the lock that stops edits while an approval is live. Note there is deliberately **no admin exemption** here — only `isSystem` | `lifecycle-hooks.ts:325` |
+| 33 | Delegation write guard bypassed | plugin-approvals | Get: service / seed / import may write delegation rows naming another delegator | `lifecycle-hooks.ts:432` |
+| 34 | Approval actor / submitter / pending-approver checks bypassed (7 sites) | plugin-approvals | Get: approve, reject, recall, reassign without being a pending approver or the submitter | `approval-service.ts:658`, `:713`, `:2257`, `:2403`, `:2570`, `:2641`, `:2830`, `:2870` |
+| 35 | Saved-report ownership is **assignable**, and an update may reassign it | plugin-reports | Get: `ownerId` from input is honoured. A non-system caller always owns what it creates and can never reassign | `report-service.ts:334`, `:355` |
+| 36 | Saved-report access / mutation gates bypassed | plugin-reports | Get: read and overwrite any report | `report-service.ts:273`, `:302`, `:377`, `:567` |
+| 37 | Attachment access hooks return early (write + read AST) | service-storage | Lose: attachment visibility scoping | `attachment-access-hooks.ts:95`, `:144`, `:276` |
+| 38 | Comment access hooks return early (write + read AST) | plugin-audit | Lose: comment visibility scoping | `comment-access-hooks.ts:241`, `:346`, `:378`, `:423` |
+| 39 | Knowledge search returns hits unfiltered | service-knowledge | Lose: the permission filter over search results | `knowledge-service.ts:308` |
+
+### 5. Actions, metadata plane, provenance
+
+| # | Behaviour when `isSystem` | Package | What you get / what you lose | Anchor |
+|:--|:---|:---|:---|:---|
+| 40 | Object API-exposure gate bypassed (`apiEnabled` / `apiMethods`) | runtime | Get: internal self-writes ignore exposure declarations — these govern **external** exposure, not engine self-writes | `action-execution.ts:125` |
+| 41 | Action `requiredPermissions` bypassed | runtime | Get: engine self-invocation runs any action | `action-execution.ts:388` |
+| 42 | `manage_metadata` bypassed on metadata writes | runtime, rest | Get: schema writes without the capability | `domains/meta.ts:468`, `rest-server.ts:4047` |
+| 43 | Anonymous-deny seam satisfied on the domain dispatchers | runtime | Get: passes with no `userId` | `domains/actions.ts:129`, `domains/ai.ts:128`, `domains/automation.ts:151`, `domains/meta.ts:171`, `domains/security.ts:92` |
+| 44 | MCP principal check satisfied | runtime | Get: MCP surface reachable with no user | `domains/mcp.ts:60` |
+| 45 | Audience-binding suggestion recording skipped | plugin-security | Lose: install-time suggestions are not recorded for system callers | `suggested-audience-bindings.ts:262` |
+| 46 | Email-template / webhook provenance stamps skipped | plugin-email, plugin-webhooks | Lose: the row is not marked as an admin customization | `email-template-provenance.ts:59`, `webhook-provenance.ts:50` |
+| 47 | **Automation flow data nodes re-add the `owner_id` stamp** (the one place row 2's gap is compensated inline) | service-automation | Get: a flow-authored INSERT under system elevation still lands owned, when the run resolved a user. Fill-only — flow-authored values win | `runtime-identity.ts:279`, called from `builtin/crud-nodes.ts:309` |
+
+---
+
+## What `isSystem` does **not** do
+
+Just as costly as the list above. Each of these is a separate switch, and
+assuming `isSystem` covers it is a documented source of bugs.
+
+| Assumption | Reality | Anchor |
+|:---|:---|:---|
+| "It suppresses triggers / record-change automation" | **No.** Only `skipTriggers` does. A bare `{ isSystem: true }` on a seed write re-fired automation on freshly seeded rows and wedged first boot | `seed-loader.ts:1310`–`1313` (#3760), `flow.zod.ts:630` |
+| "It skips the state machine" | **No.** That is `skipStateMachine`, carried by seed replay and by `treatAsHistorical` imports | `engine.ts` FSM gate; see [State Machine](/docs/protocol/objectql/state-machine) |
+| "It skips validation rules" | **No.** Field shape, `format`, `script` and the rest still run. The `readonly` strip runs *before* validation precisely so a discarded value is not judged | `engine.ts:6060`–`6078` |
+| "It preserves a supplied `updated_at` / `updated_by`" | **No.** That is `preserveAudit`, a separate opt-in — and an UPDATE-path exemption only | `field.zod.ts:820` (#3493 / #6640) |
+| "It stamps `created_by`" | **No.** Audit stamping reads `userId` from the context. A user-less system write stamps nothing — that is today's behaviour, not an error | `runtime-identity.ts:268`–`272` |
+| "It bypasses every guard" | **No.** The last-admin guard applies to **every** context, `isSystem` included — the deprovision path that actually locks an org out is the system one | `last-admin-guard.ts:247` |
+| "A client can request it" | **No.** Never settable from inbound HTTP or from an action body | `rest-server.ts:2079`, `:2096`; `domains/actions.ts:122` |
+
+---
+
+## Known rough edges
+
+Recorded rather than smoothed over, because a reader who hits one of these
+should recognise it instead of re-deriving it.
+
+1. **The `owner_id` gap has two independent compensations and no shared
+   mechanism.** Row 2 is a real gap; the platform repairs it twice, in
+   unrelated places — inline for automation flow writes
+   (`runtime-identity.ts:279`, whose own comment states the reason: "the
+   security middleware that stamps it short-circuits on `isSystem` — so the
+   writer fills it here"), and as a boot-time sweep for seeded rows
+   (`plugin-security/src/claim-seed-ownership.ts`). Any *third* system write
+   path gets neither. If you add one, stamp ownership yourself.
+
+2. **Sharing materialisation is skipped silently.** Row 22 produces
+   "configured but inert": nine installed sharing rules, matching records,
+   correct positions — and `sys_record_share` empty, with nothing logged. The
+   boot backfill does eventually fix it, so the behaviour is not wrong; it is
+   undiscoverable. An INFO line for exactly this case is queued as #6783 and is
+   **not** shipped at the time of writing — do not read this row as already
+   observable.
+
+3. **Strict write observability is inert under elevation.** Row 17: a caller
+   that asked to be told loudly about dropped fields is told nothing, because
+   nothing was dropped. The two facts are indistinguishable from the outside.
+
+4. **`revoke()` skips its own conflict guard.** Row 26 is correct for the rule
+   evaluator and surprising for anything else: a system caller can delete a
+   rule-materialised grant that the next reconcile silently restores.
+
+5. **`applySystemFields` does not read this flag.** It is named as if it did.
+   `packages/objectql/src/registry.ts:307` is **schema-side column
+   provisioning** — which columns an object carries — and consumes
+   `ExecutionContext.isSystem` zero times. The write-time ownership behaviour
+   people attribute to it is row 2, in `plugin-security`.
+
+---
+
+## Decision on record: the flag is deliberately **not** being split
+
+Maintainer ruling, #4707, 2026-08-06. Recorded here at the ruling's own request,
+so the proposal stops being re-opened.
+
+Ownership injection, `readonly` bypass and sharing materialisation are
+independent decisions, and a seed loader plausibly wants the first two but not
+the third. The concept is nevertheless **staying as one boolean**:
+
+- **Shipped semantics.** `isSystem` is a published contract with 80 read sites
+  in 18 packages. Splitting it is a breaking contract change across all of them.
+- **No business pull.** No app has asked for the combinations a split would
+  enable; the observed need was to *understand* the flag, which is what this
+  page serves.
+- **Combinatorics are worse for AI authors, not better.** Three independent
+  switches are eight states, most of them untested and several of them
+  incoherent (grant materialisation without ownership). One flag plus this table
+  is judged more mistake-proof at authoring time than a surface where a wrong
+  combination is expressible and silently valid.
+
+The trade-off accepted with that ruling is that elevation stays coarse: you
+cannot ask for the ownership behaviour without also taking the sharing
+behaviour. Where a narrower need exists, the platform answers it with a
+**separate, explicit** option next to `isSystem` — `skipTriggers`,
+`preserveAudit`, `skipStateMachine`, `runAs` — rather than by subdividing the
+flag. That is the pattern to follow for any new narrow exemption.
+
+---
+
+## Maintaining this table
+
+The table's value is exhaustiveness, so it is built by census, not by recall.
+To re-verify after a change:
+
+```bash
+grep -rn "isSystem" --include="*.ts" --include="*.tsx" packages examples \
+  | grep -v node_modules | grep -v "/dist/"
+```
+
+Classify each hit into: a **consumer** of `ExecutionContext.isSystem` (a table
+row), a **producer** (`isSystem: true` on a call — not a behaviour), one of the
+three unrelated metadata fields, a `sys_`-prefix name helper, or a declaration.
+As of this page's census on `main`: **1179** total occurrences — 588 in tests,
+591 in sources; of the source occurrences, 16 declarations, 240 producers and
+121 consumers. Of the 121 consumers, **80 are behaviour-bearing reads of the
+elevation flag** (the rows above), 12 read one of the unrelated metadata
+`isSystem` fields, 11 are `sys_`-prefix name helpers, 5 only propagate the flag
+onward, and 13 are generated i18n, form declarations or schema prose.
+
+A new read of `ExecutionContext.isSystem` belongs in this table in the same PR
+that introduces it.
+
+## Related
+
+- [Authorization Architecture](/docs/permissions/authorization) — the six-gate enforcement chain this flag short-circuits
+- [Security & Access Control](/docs/protocol/objectql/security) — the `readonly` write strip and its exemptions
+- [State Machine](/docs/protocol/objectql/state-machine) — `skipStateMachine`, `preserveAudit`, `treatAsHistorical`
+- [Sharing Rules](/docs/permissions/sharing-rules) — what row 22 is skipping

--- a/content/docs/protocol/objectql/security.mdx
+++ b/content/docs/protocol/objectql/security.mdx
@@ -303,6 +303,12 @@ await data.update('attendance', { id, status: 'closed', work_duration: 480 },
 `isSystem` is the documented convention for this, and it is deliberately explicit: it
 bypasses permission checks too, so it declares "this write is platform code acting as the
 platform", not "this write came from a plugin".
+
+The read-only strip is **one of 80 behaviours** the platform keys off that flag, across 18
+packages — ownership stamping, referential-integrity checks and sharing-grant
+materialisation all change with it, and none of them is visible from the write payload.
+Before setting it, read the full census:
+[System Context (`isSystem`)](/docs/permissions/system-context).
 </Callout>
 
 **Detecting a drop programmatically.** Every strip pass reports itself to the caller


### PR DESCRIPTION
Fixes #6782
Part of #4707

（`Fixes` 只锁本执行子单；#4707 按裁决留作锚点，待 #6783 一并落地后关闭。）

## 做了什么

新增 `content/docs/permissions/system-context.mdx`，作为 `ExecutionContext.isSystem` 的**唯一权威页**。

⛔ 纯文档，无任何行为变更；未碰 `docs/adr/**`，未碰 `content/docs/releases/`。

## 普查，不是回忆

本单的价值在于「穷尽」，所以表是**普查出来的**：全仓 `isSystem` 逐处过一遍并分类，分类脚本显式列出每个 file:line，可复算。

| 口径 | 数量 |
|:---|---:|
| 全仓 `isSystem` 出现次数（ts/tsx/js，排除 node_modules 与 dist） | **1179** |
| ├─ 测试文件内 | 588 |
| └─ 源码文件内 | 591 |
| 源码中：类型/schema 声明 | 16 |
| 源码中：生产者（`isSystem: true` 传参，本身不是行为） | 240 |
| 源码中：**消费者**（读取点） | **121** |

121 个消费者再分类：

| 类别 | 数量 | 说明 |
|:---|---:|:---|
| **flag —— 真正改变行为的读取点** | **80** | 表中每一行的来源，横跨 **18 个包** |
| metadata | 12 | 读的是**同名但无关**的 `Object.isSystem` / `EmailTemplate.isSystem` / `Environment.isSystem` |
| namePrefix | 11 | `isSystemObjectName()` 一族，按 `sys_` 前缀判断，与该 flag 无关 |
| propagate | 5 | 只把 flag 往下传，自身无行为 |
| noise | 13 | 生成的 i18n bundle、form 声明、`.describe()` 文案、JSON schema 声明 |

80 个行为点按包分布（数量最多的几个）：plugin-sharing 19、plugin-security 11、plugin-approvals 10、runtime 9、objectql 7、plugin-reports 6、plugin-audit 4、service-storage 3，其余 10 个包各 1—2。

## 表怎么写的

按你要求的口径：**说清作者得到什么、失去什么，而不只是代码在哪**。每行都带 file:line 锚点，分五个车道：授权与作用域（12 行）、写入管线与完整性（9 行）、sharing（10 行）、审批·报表·附件·评论·知识（8 行）、action·元数据面·provenance（8 行）。

另加两节，与表同等重要：

- **`isSystem` 不做什么** —— 7 条反向条目，每条带锚点。最贵的一条：`isSystem` **不抑制触发器**，只有 `skipTriggers` 抑制（`seed-loader.ts:1310`—`1313`，#3760 曾因此在首次启动自触发死锁）。其余：不跳过状态机、不跳过校验规则、不保留 `updated_at`、不 stamp `created_by`、**不豁免 last-admin 闸门**（`last-admin-guard.ts:247` 明写「applies to EVERY context, isSystem included」）、不可由客户端设置。
- **已知粗糙处** —— 记录而不抹平，见下。

原单三行也在表内，但**锚点更正了一处**（见下）。

## ⛔ 发现的矛盾与可疑处（不抹平）

1. **原 issue 的第 1 行锚点归因错了。** 原文写 `packages/objectql/src/registry.ts`（`applySystemFields`）。实测 `applySystemFields`（`registry.ts:307`）是**schema 侧的列供给**（决定对象带哪些列），对执行上下文 `isSystem` 的读取次数为 **0** —— registry.ts 全文只有一处注释提到它。真正被跳过的写时 `owner_id` stamp 在 **plugin-security** 的安全中间件里（`security-plugin.ts:1466`—`1560` 的 3.5 步），而该中间件在 `security-plugin.ts:825` 因 `isSystem` 整体短路。行为描述成立，归因不成立，表里按实测锚点写。

2. **`owner_id` 缺口有两处彼此独立的补偿，且没有共享机制。** 自动化流程的数据节点内联补 stamp（`runtime-identity.ts:279`，由 `crud-nodes.ts:309` 调用，其注释自陈原因：「the security middleware that stamps it short-circuits on isSystem — so the writer fills it here」）；种子数据则靠启动期扫描补（`plugin-security/src/claim-seed-ownership.ts`）。**第三条系统写入路径两者都拿不到。** 这更像设计缺口而非设计，已在页面点名。

3. **strict 写入可观测性在提权下静默失效。** 调用方主动要求「丢字段就报错」，得到的却是沉默 —— 因为 strip 根本没跑，什么都没丢。「按对的方式豁免」与「可观测性坏了」从外部无法区分（`engine.ts:6098`、`readonly-strict-errors.ts:44`）。

4. **`revoke()` 在 system 分支绕过了自己的冲突闸门。** `sharing-service.ts:884` 直接删除并 return，走不到 `:908` 那条「该 grant 由规则物化、下次 reconcile 会被静默重新授予」的 `CONFLICT` 提示。对规则评估器是对的，对其他调用方是意外。

5. **四个同名 `isSystem` 声明的碰撞是真风险，不是命名洁癖。** `Object.isSystem` 改的是对象**默认 sharing 为 public**，`ExecutionContext.isSystem` 改的是**sharing grant 是否物化** —— 搜「isSystem sharing」两个都命中，而它们是无关的决定。页面开头专门用一张表消歧。

## ⚠️ 在飞工作

- **#6783（诉求 3 同族单）**：给「isSystem 写入覆盖活跃 sharing 规则却零物化」加 INFO 行。**尚未落地**，所以页面把第 22 行明确写成「目前静默」，并注明该 INFO 行是 queued 状态 —— 不把未来态写成现状。
- **PR #6880（#6827）**：改 `state-machine.mdx` 的 `preserveAudit` create/update 不对称叙述。与本页不冲突：它收敛的正是「`isSystem` 是 create 侧唯一豁免」这一点，本页第 16 行与之一致，且用链接而非复述指向 `security.mdx`。
- 全量翻了当前 open PR 与 open issue，**没有任何在飞工作改动 `isSystem` 语义本身**。

## 裁决入表

按 #4707 2026-08-06 维护者裁决，「⛔ 不拆分该 flag」作为**已知决定**写进页面（已发布语义 / 无业务拉动 / 三开关组合面对 AI 作者更易错），并写明所接受的取舍：提权只能是粗粒度的；需要更窄豁免时，平台的做法是在 `isSystem` **旁边**加显式选项（`skipTriggers`、`preserveAudit`、`skipStateMachine`、`runAs`），而不是细分这个 flag。

## 顺带改动

- `content/docs/permissions/meta.json`：注册新页。
- `content/docs/permissions/authorization.mdx`、`content/docs/protocol/objectql/security.mdx`：各加一处指向权威页的交叉链接（security.mdx 那处点明「readonly strip 只是 80 个行为之一」）。
- `.claude/workflows/docs-accuracy-audit.js`：由 `node scripts/docs-audit/check-audit-scope.mjs --write` 生成 —— 这是 `check:docs-audit-scope` 闸门要求的登记，不是手改。

## 验证

```
check-nul-bytes: OK (scanned 6408 tracked text file(s); no raw ASCII control bytes).
✓ doc authoring guard: 374 files clean — no bare metadata literals.
check-role-word: OK (44 baselined file(s), no new occurrences).
✓ check-quick-reference-counts: 13 section(s), every heading matches its table.
✓ docs-accuracy-audit scope is in sync with content/docs/: 179 hand-written doc(s).
```

`check:docs-audit-scope` 首跑是**红**的（新手写页未登记），`--write` 后转绿 —— 闸门确实抓到了东西，记录在此。

无 changeset：纯文档 + `.claude/`，不发布任何包，改挂 `skip-changeset`。

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_