### PR TITLE
docs(skills): objectstack-ui 补 searchableFields 章节 —— 工具栏搜索的收窄语义与失败边界 (#6675)

### DIFF
--- a/packages/lint/src/validate-searchable-fields.test.ts
+++ b/packages/lint/src/validate-searchable-fields.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
+import { resolveSearchFields } from '@objectstack/spec/data';
 import {
   validateSearchableFields,
   SEARCHABLE_FIELD_UNKNOWN,
@@ -473,5 +474,169 @@ describe('validateSearchableFields — list views that narrow the set', () => {
     });
 
     expect(findings).toEqual([]);
+  });
+});
+
+/**
+ * [#6675] Skill-parity — `skills/objectstack-ui/SKILL.md` › "Toolbar Search
+ * (`searchableFields`, ADR-0061)" quotes this rule's two diagnostics verbatim
+ * and states three boundaries as fact. The skill ships to third parties via
+ * `npx skills add`, so a reader who follows it is following THIS code; if the
+ * wording or a verdict moves and nobody re-reads the skill, the published text
+ * teaches a rule the platform no longer has.
+ *
+ * The same reason `validate-rls-predicate-enforceability.test.ts` pins the RLS
+ * predicates the data skill prints. Change any assertion here and the skill
+ * section is what needs editing, not the assertion.
+ */
+describe('validateSearchableFields — objectstack-ui SKILL.md parity (#6675)', () => {
+  /** The object the skill's examples and quoted error texts are written against. */
+  const supportCase = {
+    name: 'support_case',
+    nameField: 'subject',
+    searchableFields: ['subject', 'case_number', 'description'],
+    fields: {
+      subject: { type: 'text' },
+      case_number: { type: 'autonumber' },
+      description: { type: 'textarea' },
+      status: { type: 'select' },
+      account_id: { type: 'lookup', reference: 'crm_account' },
+      account_name: { type: 'text' },
+    },
+  };
+
+  /** A `defineView` container whose `triage` list narrows the object's set. */
+  const viewStack = (searchableFields: unknown, objectOverrides: Record<string, unknown> = {}) => ({
+    objects: [{ ...supportCase, ...objectOverrides }],
+    views: [
+      {
+        name: 'support_case',
+        objectName: 'support_case',
+        list: {
+          label: 'All Cases',
+          type: 'grid',
+          data: { provider: 'object', object: 'support_case' },
+          columns: ['subject', 'status'],
+        },
+        listViews: {
+          triage: {
+            label: 'Triage',
+            type: 'grid',
+            data: { provider: 'object', object: 'support_case' },
+            columns: ['case_number', 'subject', 'status'],
+            ...(searchableFields === undefined ? {} : { searchableFields }),
+          },
+        },
+      },
+    ],
+  });
+
+  it('the skill\'s `os:check` example lints clean — a subset of the allowed set', () => {
+    // SKILL.md: `listViews.triage.searchableFields: ['case_number', 'subject']`.
+    expect(validateSearchableFields(viewStack(['case_number', 'subject']))).toEqual([]);
+  });
+
+  it('omitting the key lints clean (row 2 of the skill\'s boundary table)', () => {
+    expect(validateSearchableFields(viewStack(undefined))).toEqual([]);
+  });
+
+  /**
+   * The skill states an empty array is identical to omitting the key — the
+   * claim an author most needs, because the spelling suggests the opposite.
+   *
+   * The lint half of it is deliberately NOT the assertion that carries this
+   * test. `checkSearchableFieldList` returns early on a zero-length array, and
+   * even without that early return the entry loop has nothing to iterate — so
+   * "lints clean" is green because nothing was produced, not because the
+   * verdict is right, and it cannot go red on a regression. It is asserted
+   * below only to pin that no finding appears; the load-bearing assertion is
+   * the next one.
+   *
+   * `resolveSearchFields` is where `[]` acquires meaning: it is the ONE
+   * resolution the ingress gate (`assertSearchFieldsAreSearchable`) and the
+   * engine (`expandSearchToFilter`) share, so an empty request resolving to
+   * the full allowed set IS the runtime behaviour the skill describes. Narrow
+   * the fall-through and this goes red.
+   */
+  it('`searchableFields: []` is ABSENT, not "search off" — it resolves to the FULL allowed set', () => {
+    expect(validateSearchableFields(viewStack([]))).toEqual([]);
+
+    const resolutionArgs = {
+      fields: supportCase.fields,
+      searchableFields: supportCase.searchableFields,
+      displayField: supportCase.nameField,
+    };
+    // An empty narrowing scans every column the object allows …
+    expect(resolveSearchFields({ ...resolutionArgs, requestedFields: [] }))
+      .toEqual(['subject', 'case_number', 'description']);
+    // … which is exactly what omitting the key does …
+    expect(resolveSearchFields(resolutionArgs))
+      .toEqual(['subject', 'case_number', 'description']);
+    // … and strictly MORE than a one-entry narrowing, the inversion the skill
+    // calls out: `[]` searches wider than `['subject']`.
+    expect(resolveSearchFields({ ...resolutionArgs, requestedFields: ['subject'] }))
+      .toEqual(['subject']);
+  });
+
+  it('quotes the dotted-path diagnostic exactly as the skill prints it', () => {
+    const findings = validateSearchableFields(viewStack(['subject', 'account_id.name']));
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe(SEARCHABLE_FIELD_UNKNOWN);
+    expect(findings[0].severity).toBe('error');
+    expect(findings[0].message).toBe(
+      'list-view searchableFields entry "account_id.name" is not a field on object '
+      + '"support_case". The declaration is stale: searching it can never match, and the '
+      + 'engine silently drops it — leaving a narrower search than declared, or the '
+      + 'auto-default set once every entry is dropped.',
+    );
+  });
+
+  it('quotes the outside-the-declared-set diagnostic exactly as the skill prints it', () => {
+    const findings = validateSearchableFields(viewStack(['subject', 'status']));
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe(SEARCHABLE_FIELD_UNSEARCHABLE);
+    expect(findings[0].severity).toBe('error');
+    expect(findings[0].message).toBe(
+      'list-view searchableFields entry "status" is outside object "support_case"\'s '
+      + 'declared searchableFields (subject, case_number, description) — the set \'search\' '
+      + 'scans. Clients echo this declaration verbatim as the \'$searchFields\' override, '
+      + 'and the runtime refuses an entry outside the allowed set: every toolbar search on '
+      + 'this list returns 400 INVALID_FIELD (#4254).',
+    );
+  });
+
+  /**
+   * The correction the skill makes to a type-first reading: on an object that
+   * DECLARES its set, the declaration is the boundary and the field's type is
+   * not consulted — a lookup inside it is scanned, a text column outside it is
+   * refused. Both directions, because either alone reads as a coincidence.
+   */
+  it('a lookup INSIDE the object\'s declared set is accepted; a text column OUTSIDE it is not', () => {
+    const declaresLookup = { searchableFields: ['subject', 'account_id'] };
+
+    expect(validateSearchableFields(viewStack(['account_id'], declaresLookup))).toEqual([]);
+
+    const refused = validateSearchableFields(viewStack(['account_name'], declaresLookup));
+    expect(refused).toHaveLength(1);
+    expect(refused[0].rule).toBe(SEARCHABLE_FIELD_UNSEARCHABLE);
+    expect(refused[0].message).toContain('"account_name"');
+  });
+
+  /**
+   * …and the mirror image: with NO declaration on the object, the auto-default
+   * is the boundary, so type is exactly what decides. `select` is in the
+   * text-like set the skill lists; `lookup` is not.
+   */
+  it('with no object declaration, the auto-default type list decides', () => {
+    const noDeclaration = { searchableFields: undefined };
+
+    expect(validateSearchableFields(viewStack(['subject', 'status'], noDeclaration))).toEqual([]);
+
+    const refused = validateSearchableFields(viewStack(['account_id'], noDeclaration));
+    expect(refused).toHaveLength(1);
+    expect(refused[0].rule).toBe(SEARCHABLE_FIELD_UNSEARCHABLE);
+    expect(refused[0].message).toContain("of type 'lookup', which 'search' cannot scan");
   });
 });

--- a/skills/objectstack-ui/SKILL.md
+++ b/skills/objectstack-ui/SKILL.md
@@ -342,6 +342,122 @@ Rules:
   right cluster. Authors only control the `allowedVisualizations` whitelist;
   a single-entry whitelist locks the visualization (no switcher).
 
+### Toolbar Search (`searchableFields`, ADR-0061)
+
+The toolbar's search box scans a set the **object** owns. A list view's
+`searchableFields` **narrows** that set for this one list — it can never widen
+it, and the runtime enforces that by **refusing the request**, not by quietly
+dropping the extra name.
+
+<!-- os:check -->
+```typescript
+import { defineView } from '@objectstack/spec';
+
+const data = { provider: 'object' as const, object: 'support_case' };
+
+export const CaseViews = defineView({
+  // No `searchableFields` → the toolbar searches everything the object allows.
+  list: { label: 'All Cases', type: 'grid', data, columns: ['subject', 'status'] },
+  listViews: {
+    // This list only: search the reference number and the subject line.
+    triage: {
+      label: 'Triage', type: 'grid', data,
+      columns: ['case_number', 'subject', 'status'],
+      searchableFields: ['case_number', 'subject'],
+    },
+  },
+});
+```
+
+**What the object allows** is resolved server-side, and it is the whole rule:
+
+| The object … | The allowed set is |
+|:-------------|:-------------------|
+| declares `searchableFields` | **that list, verbatim** — whatever the field types are |
+| declares nothing | the auto-default: the name field + the text-like columns (`text` / `email` / `phone` / `url` / `autonumber` / `textarea` / `markdown` / `select` / `status`) |
+
+So field **type** decides only in the second row. On an object that declares
+`searchableFields: ['subject', 'account_id']`, a view narrowing to
+`['account_id']` — a lookup — is **accepted** and scanned; on the same object,
+narrowing to a `text` column the object left out is **refused**. Judge every
+entry against the object's allowed set, never against the type list.
+
+Modelling side — the object's own set, and the stored-mirror prescription for
+searching by a related record's title: **objectstack-data → Search Fields
+(`searchableFields`)**. Query side (`search.fields` over the API):
+**objectstack-query → Full-Text Search**.
+
+#### ⛔ One bad entry 400s EVERY search on that list
+
+The client echoes this declaration verbatim as the `$searchFields` override —
+the active view's list wins over the object's — and the ingress gate refuses any
+entry outside the allowed set before the engine ever runs. The blast radius is
+the list's whole search box, for every user and every term: not a narrower
+result, no result at all.
+
+| What you write on the view | `os validate` | Toolbar search at runtime |
+|:---------------------------|:--------------|:--------------------------|
+| a subset of the allowed set | clean | scans exactly those columns |
+| key omitted | clean | scans the object's full allowed set |
+| `searchableFields: []` | clean | **identical to omitting it** — see below |
+| a renamed / mistyped column | `searchable-field-unknown` | `400 INVALID_FIELD` |
+| a dotted path (`account_id.name`) | `searchable-field-unknown` | `400 INVALID_FIELD` |
+| a real column outside the allowed set | `searchable-field-unsearchable` | `400 INVALID_FIELD` |
+
+Both diagnostics are **errors**, not warnings — `os validate` fails the build.
+The two you will actually hit, verbatim:
+
+```text
+list-view searchableFields entry "account_id.name" is not a field on object
+"support_case". The declaration is stale: searching it can never match, and the
+engine silently drops it — leaving a narrower search than declared, or the
+auto-default set once every entry is dropped.
+
+list-view searchableFields entry "status" is outside object "support_case"'s
+declared searchableFields (subject, case_number, description) — the set 'search'
+scans. Clients echo this declaration verbatim as the '$searchFields' override,
+and the runtime refuses an entry outside the allowed set: every toolbar search
+on this list returns 400 INVALID_FIELD (#4254).
+```
+
+#### `searchableFields: []` does NOT turn search off
+
+An empty array is **absent**, at all three layers: the client omits the
+`$searchFields` key entirely, the ingress gate treats a zero-length override as
+no override, and the engine falls through to the object's allowed set. A view
+written `searchableFields: []` searches **more** columns than one written
+`searchableFields: ['subject']`, which is the opposite of what the spelling
+suggests.
+
+To actually remove the search box from the toolbar, toggle the affordance —
+a different key, on the same view:
+
+<!-- os:check -->
+```typescript
+import { defineView } from '@objectstack/spec';
+
+const data = { provider: 'object' as const, object: 'support_case' };
+
+export const AuditViews = defineView({
+  list: {
+    label: 'Audit Log', type: 'grid', data,
+    columns: ['case_number', 'status'],
+    userActions: { search: false },   // ← no search box; `searchableFields: []` would NOT do this
+  },
+});
+```
+
+#### Searching by a related record's title
+
+Never reach for a dotted path. `search` scans the queried object's **own**
+columns — unlike `columns` / `sort` / `filter`, the search axis resolves no
+traversal, so `account_id.name` is refused rather than silently dropped. Copy
+the parent's title into a **stored** field on this object and put that field in
+the object's `searchableFields`; the view then narrows to it like any other
+column. The full prescription — the mirror field, the two hooks that maintain
+it, and why a `formula` field cannot be the mirror — lives in
+**objectstack-data → Search Fields (`searchableFields`)**.
+
 ### Sorting
 
 ```typescript


### PR DESCRIPTION
Fixes #6675

## 背景

`skills/objectstack-ui/SKILL.md` 对 `searchableFields` 零覆盖。该键在这个 skill 里唯一出现的位置是**生成的** `references/react-blocks.md`(由 `packages/spec` 生成,手改会顶掉 `check:skill-refs`)。而列表视图工具栏的搜索框,正是 view 级收窄(ADR-0061)和 #4254 点号路径 400 真正打到 UI 作者身上的地方。

PR #6670 已经把 docs 侧补上了(`content/docs/ui/views.mdx` 的表格行),skill 侧仍然是空的 —— 而 skill 才是 AI 作者在授权时真正加载的东西。

前提复核:在 `origin/main` @ `e5bd76859` 上 `git grep searchableFields -- skills/objectstack-ui/SKILL.md` 仍为零,反向对照(`skills/objectstack-data/`、`skills/objectstack-query/`)有命中,扫描器是好的。卡片前提成立。

## 改了什么

新增 **"Toolbar Search (`searchableFields`, ADR-0061)"** 一节,落在 `## Configuring a List View` 既有结构里(End-User Quick Filters 之后、Sorting 之前),两个 `os:check` 例子 + 边界表 + 逐字错误文案。

按派单要求,**不只教 happy path**;每条边界都实测,不是推断。

### 1. 允许集由对象决定,判据是集合成员而不是字段类型

| 对象 | 允许集 |
|:--|:--|
| 声明了 `searchableFields` | **就是那份清单本身** —— 按存在性过滤,不看类型 |
| 没声明 | auto-default:name 字段 + 文本类列(text / email / phone / url / autonumber / textarea / markdown / select / status) |

实测:对象声明 `searchableFields: ['subject', 'account_id']`(`account_id` 是 lookup)时,view 收窄到 `['account_id']` **放行**,引擎拿到 `searchFields = ["account_id"]`;同一个对象上收窄到对象没列进去的 `account_name`(一个 `text` 列)反而 **400 INVALID_FIELD**。一个 lookup 通过、一个 text 被拒 —— 类型判据在这里是反的。

### 2. 一条坏 entry 会让该列表的每一次搜索 400

客户端把这份声明逐字回显为 `$searchFields`,入口门 `assertSearchFieldsAreSearchable` 在引擎之前就拒。炸的是整个搜索框,不是"变窄的结果"。

| 写法 | `os validate` | 运行时 |
|:--|:--|:--|
| 允许集的子集 | 干净 | 只扫这几列 |
| 不写这个 key | 干净 | 扫对象的完整允许集 |
| `searchableFields: []` | 干净 | 与不写完全相同 |
| 改过名 / 拼错的列 | `searchable-field-unknown` | `400 INVALID_FIELD` |
| 点号路径 | `searchable-field-unknown` | `400 INVALID_FIELD` |
| 允许集之外的真实列 | `searchable-field-unsearchable` | `400 INVALID_FIELD` |

两条诊断都是 **error**,`os validate` 直接失败 —— 章节里逐字给出了作者真正会撞到的两条文案。

### 3. `searchableFields: []` 不是"关掉搜索"

三层都把空数组当作**缺省**:客户端整个不发这个 key(长度守卫),入口门把零长度覆盖当没覆盖直接 return,引擎回落到对象的允许集。所以写 `[]` 比写 `['subject']` 搜得**更宽**,与字面直觉正好相反 —— 这是作者最需要、也最容易猜错的一条。真要去掉搜索框是 `userActions: { search: false }`,另一个键,附了可粘贴的例子。

### 4. 相关记录标题

点号路径永远被拒(搜索轴不解析 traversal)。只能用**存储的**镜像字段;完整处方(镜像字段、维护它的两条 hook、为什么 formula 不行)指向 objectstack-data,不在此重述。注意本节只引用诊断的 `message`,没有引用其 `hint` —— 后者的 "text/formula" 措辞正是 #6673 在处理的问题。

## 验证:例子是按真正解析它的 schema 校验的

这是发布给客户的 skill,不是内部笔记,所以每个例子都要能粘贴即用。

- **类型层**:`check:skill-examples` 把两个 `os:check` 块抽出来对着构建产物 `@objectstack/spec` 的 `.d.ts` 跑 `tsc --noEmit` —— `✅ 208 prose examples type-check`,其中 `skills/objectstack-ui/SKILL.md:354` 与 `:437` 就是这两块。
- **运行时 schema 层**(tsc 证明不了的那一半):把两块**逐字**抽出来喂给真正解析它们的 schema —— `defineView` → `ViewSchema` → `ObjectListViewSchema`(`packages/spec/src/ui/view.zod.ts`,即 `ListViewSchema` 去掉 `userFilters`)。确认 `searchableFields` 与 `userActions.search` 都穿过 parse 存活(`['case_number','subject']` / `false`),不是被 strip 掉。

## 测试

`packages/lint/src/validate-searchable-fields.test.ts` 新增一组 skill-parity 用例。skill 经 `npx skills add` 发给第三方,措辞漂了而没人回看 skill,发出去的就是平台已经没有的规则 —— 与 `validate-rls-predicate-enforceability.test.ts` 钉住 data skill 打印的 RLS 谓词同一个理由。

覆盖:逐字钉住两条诊断文案;三条边界;以及**两个方向都钉** —— 对象声明集内的 lookup 放行 / 集外的 text 被拒,和它的镜像(对象没声明时,auto-default 的类型清单才说了算)。

`[]` 那条的承重断言**刻意不放在 lint 上**:`checkSearchableFieldList` 对零长度数组提前返回,就算删掉那个提前返回,entry 循环也没东西可迭代 —— "lint 干净"是因为什么都没产出,不可能因回归转红。所以承重断言放在 `resolveSearchFields`(入口门与引擎共用的那一份 resolution)上。

**反向验证**(方向事先预判 —— 两条都预判为红,两条实测也都红):

1. 把规则里 `is outside object` 改成 `is not within object` → 逐字断言转红。
2. 把 `resolveSearchFields` 的空数组回落收窄(`requested.filter(...)` 直接返回)→ `[]` 那条承重断言转红,`expected [] to deeply equal [ 'subject', 'case_number', …(1) ]`。

第 2 条第一次跑是**绿的**,因为 `@objectstack/spec/data` 解析到 `dist/`,改 `src/` 根本没生效(AGENTS.md §9 陈旧产物陷阱)。重新 build spec 后才转红 —— 记在这里,因为"改了源码测试还绿"在这个 workspace 里默认要先怀疑没重建。

## 兄弟 skill 排查(派单要求,未扩大 diff)

| skill | `searchableFields` 覆盖 |
|:--|:--|
| `objectstack-data` | ✅ 有(对象级 canonical set + 镜像字段处方) |
| `objectstack-query` | ✅ 有(查询级 `search.fields` 收窄 + 400) |
| `objectstack-ui` | ❌ 本 PR 补上 |
| 其余 8 个 | 不拥有这个面 —— `objectstack-api` 只在 API 方法表里提到 derived 的 `search` 动词,两个 skill 都没有文档化 `$` 前缀参数族,属于另一个面而非同类缺口 |

结论:同类缺口只有 `objectstack-ui` 一处,已补;未改动任何兄弟 skill。

## 顺带发现(未在本 PR 修)

已另开 **#6897**(未认领):`content/docs/ui/views.mdx:106` 那行说 view 的 `searchableFields` 里 lookup "is refused",实测只在对象的允许集排除它时才拒 —— 对象声明了它就放行。文档把集合成员判据写成了类型判据,会让作者删掉一份能用的配置。本 PR 范围只在 skill,按 Prime Directive #10 不夹带。

## 门

- `check:skill-examples` ✅ / `check:skill-frame-sync` ✅ / `check:skill-compatibility` ✅ / `check:skill-frame-freshness` ✅
- `check:doc-authoring` ✅ / `check:nul-bytes` ✅ / `check:role-word` ✅ / `check:adr-anchors` ✅ / `check:quick-reference-counts` ✅ / `check:org-identifier` ✅ / `check:published-files` ✅
- `pnpm --filter @objectstack/lint test` → 67 files / 1753 tests 全绿;`typecheck` 绿
- test 层类型错误数 19 → 19(与 `origin/main` 同口径对比),TEST_DEBT 账本零增量

## 无 changeset

只改 `skills/**` 与一个测试文件,不发布任何包 —— 与同类前例一致(PR #6670 本身、#6233、#6030、#5989 均无 changeset)。已打 `skip-changeset`。

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_