### PR TITLE
docs(pm-dispatch): give the objectui local backlog its own target:v17 producer (#6903)

### DIFF
--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -1073,10 +1073,24 @@ Prime Directive #10 是一个强力生产者,而循环原本只有「修掉」�
   (发布后修不回);④ 发布说明里需要为它道歉的(含「照文档抄即失败」的首小时
   体验)。改进型、优化、重构、观察类 finding、内部工具、纯展示瑕疵默认**不
   阻塞** —— 坐下一班车。
-- **生产者唯一 = 分诊座位**(与 `domain:*` 同款单一生产者纪律):step 0 分诊
-  defect 类新单时顺手判;执行座位不打不摘 `target:<major>`,误判走上报。存量
-  已于 2026-08-06 全量清过一次(309 条 → 46 条),此后只有增量,⛔ 永不再全量
-  重扫。
+- **每个 backlog 恰好一个生产者**(与 `domain:*` 同款单一生产者纪律,只是把
+  作用域切对 —— 一个生产者管一个 backlog,不是一个生产者管全部):
+  - **objectstack 主 backlog → 分诊座位**:step 0 分诊 defect 类新单时顺手判;
+  - **objectui 本地 backlog → objectui 整仓座位**(`/pm-dispatch
+    repo:objectstack-ai/objectui`):在它自己的本地 backlog 扫描时,用**同一条
+    二元判据 + 同四类阻塞**在 objectui 仓里打 `target:<major>`。
+  其余执行座位一律不打不摘 `target:<major>`,误判走上报 —— 单一生产者纪律没有
+  放松,放松的只是「一个座位扫得完所有 backlog」这个错误前提。⛔ 两个生产者
+  各扫各的 backlog,谁都不去扫对方的(step 0 的 repo-scoped 限定正为此,见
+  「析取 2 必须 repo-scoped」)。
+  为什么补这条(实测 2026-08-09):objectui 的 `target:v17` 只在 2026-08-06/07
+  那次审计用过 7 次且全部已闭,此后本地 backlog 长到 117 open / 48 `pm:queue`
+  (立单读数;本 PR 复测 119 / 52)而板上 open **0** 条 —— 「随 console bundle 入板」有消费方却**没有常设生产
+  者**,而控制台正是从这个 backlog 发出去的。
+- **存量清板姿态(一次性,每侧各一次)**:objectstack 已于 2026-08-06 全量清过
+  一次(309 条 → 46 条);objectui 的存量补一次等价的清板(#6904,判据与四类
+  阻塞照抄本节)。两侧各清完那一次之后**只有增量**,⛔ 永不再全量重扫 ——
+  全量重扫正是此前历次一次性标注腐烂的那步。
 - **消费者三处**(a label exists iff something reads it):维护者的发版清单 =
   `label:target:<major> is:open` 一条查询(与 `pm:seat` 状态板同构,标签即
   看板);step 3 批次选择板上项优先;step 9 轮次报告第四健康指标。
@@ -1084,8 +1098,12 @@ Prime Directive #10 是一个强力生产者,而循环原本只有「修掉」�
   已修/不成立的摘牌 + 一句评论(main 一天 ~18 合并,阻塞判断有半衰期)。
 - **发版时刻 = 清板,不是重扫**:板上每条三选一 —— 修掉 / 摘牌(不再成立)/
   **明示接受带病发布**(摘标签 + 一句 accepted-for-GA 评论留痕,进 release
-  notes 的 known issues)。姊妹仓同标签:objectui 随 console bundle 入板;
-  cloud 独立部署不入板,advisory 单列。
+  notes 的 known issues)。姊妹仓同标签:objectui **在自己仓里上板**,生产者是
+  objectui 整仓座位(见上),修复经 console bundle 随 pin bump 进这次发布;
+  cloud 独立部署不入板,advisory 单列。⇒ 发版时刻的清单因此是**两条查询**
+  (objectstack 与 objectui 各一条 `label:target:<major> is:open`),两张板都要
+  清到空;上面「消费者三处」仍写作一条查询,口径更新与发版前 console bump 的
+  衔接归 #6906,不在本次改动范围。
 
 ### 1. Fetch candidates
 


### PR DESCRIPTION
Fixes #6903

## Maintainer authorization (quoted verbatim, per the card's guardrail note)

This is a `.claude/` internal-tooling PR. Under the standing exception it may be implemented by a PM seat **only** with the maintainer's authorization quoted here:

- 2026-08-09, on the three proposed actions: 「1 补上生产者」
- 2026-08-09, follow-up: 「三个动作都创建issue」
- 2026-08-09, dispatch instruction via the PM session: 「派发这两个任务」

**Review guardrail: this PR requires review by another seat or a maintainer walkthrough. No self-review-self-merge.** It is opened as a draft and stays that way until that review happens.

## Premise verification against origin/main (the issue body is a lead, not a spec)

Both halves of the card's premise still hold at `origin/main` (19d8948):

- The 发版板 section reads exactly as described. Before this PR it said 「生产者唯一 = 分诊座位」 and, on the release-day line, 「姊妹仓同标签:objectui 随 console bundle 入板」 — one producer, and a sibling-repo clause with consumers but no standing producer.
- The measured gap re-measured today: objectui's `target:v17` label has been used **7 times, all closed** (the 2026-08-06/07 audit). objectui's local backlog is **119 open / 52 pm:queue** (the card recorded 117 / 48 when filed a few hours earlier) with **0 open** board items. The numbers moved slightly; the gap is unchanged.

Both readings are pinned in the amended text (the filed reading and this PR's re-measure), rather than silently overwriting one with the other.

## What changed

Exactly the three numbered points of the deliverable, edited into the 发版板 section of `.claude/skills/pm-dispatch/SKILL.md`. The section's voice and bullet structure are kept; this is a surgical amendment, not a rewrite.

1. **Producer scope becomes "exactly one producer per backlog."** The bullet formerly titled 「生产者唯一 = 分诊座位」 becomes 「每个 backlog 恰好一个生产者」, with two named producers: the objectstack triage seat for the main backlog, and the **objectui whole-repo seat** (`/pm-dispatch repo:objectstack-ai/objectui`) for objectui's own local backlog, applying the **same binary criterion and the same four blocking classes** during its local backlog sweep. Other execution seats still never add or remove the label; mislabels go through escalation. The single-producer discipline is not relaxed — what is corrected is the wrong premise that one seat could sweep every backlog, which is why the step-0 sweep's repo-scoping (the 「析取 2 必须 repo-scoped」 note) is cross-referenced rather than contradicted. The measured gap is recorded inline as the reason the clause exists.
2. **Stock-clearing posture, now its own bullet** because it covers two backlogs: objectstack was cleared once on 2026-08-06 (309 to 46); objectui's stock gets one equivalent pass (#6904); after each side's single pass, both are incremental-only and never full-rescan.
3. **The sibling-repo line points at the new producer**: objectui now boards items in its own repo, produced by the objectui whole-repo seat, and fixes reach the release through the console bundle at pin-bump time. It also records that release-day inventory is therefore **two queries** (objectstack and objectui, each `label:target:v17 is:open`), both cleared to empty. The consumer bullet above still says one query — that wording update, and the pre-release console-bump linkage, belong to #6906 and are deliberately **not** touched here.

### Zero riders

`git diff --stat` is one file, 24 insertions / 6 deletions, all inside the 发版板 section. Three other queued cards target the same file (#6410 compiler-face checklist, #6490 fan-out ordering, #6741 ADR guardrail) — **none of them is implemented here**, and no other section of the SKILL is touched. They serialize behind this PR.

## Gates

Enumerated from `.github/workflows/lint.yml` (not from memory), then filtered to what a `.claude/**`-only change can reach. The applicable set was derived mechanically: `grep -rln '\.claude' scripts/` plus a read of each doc-scoped gate's scan roots. All run locally on the pushed commit, all green:

| Gate | Result |
|:---|:---|
| `pnpm check:nul-bytes` | OK — 6415 tracked text files, no raw ASCII control bytes (self-test 56 assertions) |
| `pnpm check:doc-authoring` | OK — 374 files clean; scan root is `.claude` (not `.claude/skills`), so this file is in scope |
| `pnpm check:skill-frame-sync` | OK — 4 copies of the decision frame structurally isomorphic across 3 files, incl. this SKILL.md; 42 markdown files scanned for undeclared copies |
| `pnpm check:skill-compatibility` | OK — 11 SKILL.md files reconciled against 77 workspace packages. Note its scan root is the published `skills/` dir, so it does **not** read `.claude/skills/`; run and reported because the dispatch named it |
| `pnpm check:agent-model-declared` | OK — 1 agent definition under `.claude/agents/`, declares `opus` |
| `pnpm check:docs-audit-scope` | OK — reads `.claude/workflows/docs-accuracy-audit.js`; 179 hand-written docs in sync |
| `pnpm check:role-word` | OK — 44 baselined files, no new occurrences |
| `pnpm check:quick-reference-counts` | OK — 13 sections, every heading matches its table |
| `pnpm check:adr-anchors` | OK — 40 anchored files, 20066 citations across 3290 files resolve |
| `pnpm lint` (ESLint) | OK, exit 0 — `eslint.config.mjs` carries only `ts/tsx/mts/cts/js/jsx/mjs/cjs` globs, so a markdown-only change cannot reach a rule; run anyway to confirm the job's own step |
| `pnpm check:skill-frame-freshness` | OK — not wired into any workflow; run because it parses this file's frame |

Not applicable, by scan surface rather than by guess: every remaining `check:*` step in `lint.yml` scans `packages/**`, `.github/workflows/**`, `content/docs/releases/**` or generated spec artifacts, none of which this diff touches. No test or typecheck run is meaningful for a markdown-only change to an agent instruction file, and none is claimed here.

## Changeset

None. `.claude/**`-only internal tooling releases no package, so the **skip-changeset** route applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGRN2cSRfggfX9B2L83bQc)_