### PR TITLE
fix(ci): run the changeset family's --self-test in lint.yml, out of reach of skip-changeset (#6509)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -345,6 +345,48 @@ jobs:
       - name: objectui pin-changeset digest guard
         run: pnpm check:objectui-changeset
 
+      # Changeset-family gate self-tests (#6509). The SELF-TEST halves only —
+      # the real scans stay in pr-automation.yml's `changeset-check`, and the
+      # split is the whole point of this step.
+      #
+      # Why they moved here. `check-empty-changeset.mjs` and
+      # `check-adr-0087-registration.mjs` were called from exactly one place in
+      # the repository: the `changeset-check` job, which a PR carrying
+      # `skip-changeset` is exempted from WHOLESALE (job-level `if:` plus the two
+      # per-step label reads). And "this PR edits a CI-internal script" is the
+      # textbook `skip-changeset` case — such a PR releases nothing, so by the
+      # workflow's own prescription it takes the label. The consequence is the
+      # exact inversion of #4690: a PR that edits these two checkers is the PR
+      # most likely to skip their own fixtures.
+      #
+      # Not hypothetical, and not this card's own reasoning either. PR #6876
+      # (#5620, merged) added FIVE consumer assertions to
+      # `check-empty-changeset.mjs` that never executed once on its own CI: it
+      # carried `skip-changeset`, so on run 31289894461 the step
+      # `Reject an empty-frontmatter changeset added by this PR` — the only thing
+      # that runs `--self-test` — reports `conclusion: skipped`. Every assertion
+      # in that PR was verified locally and by nothing else.
+      #
+      # This step is deliberately UNCONDITIONAL. No `if:`, no label read, no
+      # paths filter: an exemption is precisely what the two self-tests must not
+      # have, or the gap simply moves. That property is not left to prose —
+      # `check-empty-changeset.mjs`'s own consumer block asserts this step's
+      # shape (present, unguarded, self-test halves only), so removing or
+      # conditioning it reds the very check it was removing.
+      #
+      # Why the SELF-TEST halves only, and not `pnpm check:empty-changeset`:
+      # that script chains the real scan, whose verdict is a function of the
+      # PR's DIFF and therefore needs `$MERGE_BASE`. This job has no branch
+      # point, so a real scan here would fall back to reading stock — which is
+      # #6129, "judge the author for what main gained while their PR was open",
+      # in the direction of a false RED. The self-test halves have no such
+      # dependency: measured, both pass with REPO_ROOT pointing at a directory
+      # that is not a git repository at all. They build their own throwaway
+      # repos in $TMPDIR and read two files (this workflow and
+      # pr-automation.yml). ~0.8s + ~5.0s.
+      - name: Changeset-family gate self-tests
+        run: pnpm check:changeset-gate-self-tests
+
       # Release-notes drift guard: the platform is one version-locked train, so
       # every released @objectstack/spec major must have a curated, navigable
       # release page at content/docs/releases/v<major>.mdx. Catches the gap that

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -798,7 +798,7 @@ jobs:
             exit 0
           fi
           echo "Labels on PR #$PR_NUMBER right now: ${LABELS:-(none)}"
-          if grep -qxF 'allow-major' <<<"$LABELS"; then
+          if grep -qF 'allow-major' <<<"$LABELS"; then
             echo "::notice::'allow-major' is on PR #$PR_NUMBER (read live, not from the event payload), so a whole-stack major is intended here and the launch-window guard stands aside."
             echo 'allow=true' >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -798,7 +798,7 @@ jobs:
             exit 0
           fi
           echo "Labels on PR #$PR_NUMBER right now: ${LABELS:-(none)}"
-          if grep -qF 'allow-major' <<<"$LABELS"; then
+          if grep -qxF 'allow-major' <<<"$LABELS"; then
             echo "::notice::'allow-major' is on PR #$PR_NUMBER (read live, not from the event payload), so a whole-stack major is intended here and the launch-window guard stands aside."
             echo 'allow=true' >> "$GITHUB_OUTPUT"
           else

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "check:prerelease-pins": "node scripts/check-prerelease-pin-watch.mjs --self-test && node scripts/check-prerelease-pin-watch.mjs",
     "check:empty-changeset": "node scripts/check-empty-changeset.mjs --self-test && node scripts/check-empty-changeset.mjs",
     "check:adr-0087-registration": "node scripts/check-adr-0087-registration.mjs --self-test && node scripts/check-adr-0087-registration.mjs",
+    "check:changeset-gate-self-tests": "node scripts/check-empty-changeset.mjs --self-test && node scripts/check-adr-0087-registration.mjs --self-test",
     "check:override-consistency": "node scripts/check-override-consistency.mjs --self-test && node scripts/check-override-consistency.mjs",
     "check:release-notes": "node scripts/check-release-notes.mjs",
     "check:release-body": "node scripts/release-github-releases.mjs --self-test",

--- a/scripts/check-empty-changeset.mjs
+++ b/scripts/check-empty-changeset.mjs
@@ -905,6 +905,130 @@ function selfTest() {
       );
     }
 
+    // ── The second consumer: where THIS SELF-TEST runs (#6509) ───────────────
+    //
+    // Everything above pins the job that runs the REAL scan. This block pins the
+    // job that runs the self-test, and it exists because for a long time they
+    // were the same job -- which made the assertions above skippable by a label.
+    //
+    // The defect, stated once. `changeset-check` is exempt WHOLESALE when a PR
+    // carries `skip-changeset`, and a PR that edits a CI-internal script is the
+    // textbook case for that label (it releases nothing; the workflow itself
+    // prescribes the label for exactly that). So a PR editing this file was
+    // routinely the PR that skipped this file's own fixtures. Measured specimen,
+    // not a worry: PR #6876 (#5620, merged) added the five `allow-major`
+    // assertions above and NONE of them executed on its own CI -- it carried the
+    // label, and on run 31289894461 the step that runs `--self-test` reports
+    // `conclusion: skipped`. Both directions of that gap are real, and they are
+    // not symmetric: a BROKEN assertion is merely deferred onto the next
+    // unlabelled PR (an unrelated author eats the red), while a DELETED one is
+    // silent forever, because nothing afterwards remembers it existed.
+    //
+    // The fix is wiring, so the fixture for it has to read the wiring. Without
+    // this block `lint.yml`'s step could be deleted tomorrow with every
+    // assertion above still green -- the same "phantom check" shape (#4690) this
+    // whole family is written against.
+    //
+    // What is pinned is the property that closes the gap, not the step's prose:
+    // the self-test halves run in a job NO PR-level exemption reaches, and the
+    // merge-base-dependent halves stay out of it.
+    //
+    // RESIDUAL, recorded rather than implied. This assertion is run BY the step
+    // it pins, so a PR that deletes that step AND carries `skip-changeset` is
+    // still not caught -- both places that would have run it are gone in the
+    // same diff. That is a strictly smaller hole than the one it replaces (which
+    // swallowed EVERY labelled PR, including one that merely edits an
+    // assertion), it is a deletion visible in a `.github/**` diff rather than a
+    // silent no-op, and closing it entirely would need a gate outside this
+    // family asserting this family's wiring, which is a coupling with its own
+    // cost. Stated so the next reader inherits the fact and not a false sense of
+    // closure.
+    {
+      const lintPath = join(REPO_ROOT, '.github/workflows/lint.yml');
+      const lintPresent = existsSync(lintPath);
+      assert(lintPresent, 'consumer: .github/workflows/lint.yml must exist -- it is where this self-test runs unconditionally (#6509)');
+      const lintYaml = lintPresent ? readFileSync(lintPath, 'utf8') : '';
+      const uncommented = (text) => text.split('\n').filter((l) => !/^\s*#/.test(l)).join('\n');
+
+      // Scoped to the `lint` job: `typecheck` is a separate required job with a
+      // separate purpose, and a step landing there instead would be a different
+      // fact than the one asserted here.
+      const lintJobStart = lintYaml.indexOf('\n  lint:');
+      const lintJobEnd = lintYaml.indexOf('\n  typecheck:');
+      const lintJob = lintJobStart === -1 ? '' : lintYaml.slice(lintJobStart, lintJobEnd === -1 ? undefined : lintJobEnd);
+      const lintSteps = lintJob.split(/\n(?=      - name: )/).map(uncommented);
+      const wiredSteps = lintSteps.filter((s) => /run: pnpm check:changeset-gate-self-tests\b/.test(s));
+      assert(
+        wiredSteps.length === 1,
+        `consumer: the ESLint job of lint.yml must run \`pnpm check:changeset-gate-self-tests\` exactly once (found ${wiredSteps.length}) -- that step is the only place these two checkers' fixtures are executed on a PR carrying \`skip-changeset\` (#6509)`,
+      );
+      // The load-bearing half. A conditioned step is the defect again with one
+      // more hop: whatever the condition reads, it is a way for a PR to arrange
+      // that this self-test does not run on it.
+      assert(
+        wiredSteps.every((s) => !/^\s*if:/m.test(s)),
+        'consumer: the changeset-family self-test step in lint.yml must carry NO `if:` -- an exemptable self-test is #6509 itself, and the exemption it must not have is the one that hid PR #6876\'s five assertions',
+      );
+      // Same property, one level up: a label read anywhere in this workflow
+      // would mean some step of it can be waived by the author of the PR under
+      // test.
+      assert(
+        !/skip-changeset/.test(uncommented(lintYaml)),
+        'consumer: lint.yml must not read the `skip-changeset` label anywhere -- the whole point of running the self-tests here is that this workflow has no PR-level exemption',
+      );
+      // And one level up again: "runs on every PR" is what "unconditional"
+      // means in practice. A `paths:` filter is a condition written in the
+      // trigger instead of in an `if:`, and it would silently restore the gap
+      // for every PR whose file list misses the glob.
+      const onBlock = uncommented((lintYaml.match(/\non:\n([\s\S]*?)\n(?=[A-Za-z_])/) ?? ['', ''])[1]);
+      assert(
+        /^\s+pull_request:/m.test(onBlock),
+        'consumer: lint.yml must keep its `pull_request:` trigger -- a self-test that does not run on pull requests is not wired at all (#6509)',
+      );
+      assert(
+        !/\bpaths(-ignore)?\s*:/.test(onBlock),
+        'consumer: lint.yml must carry no `paths:`/`paths-ignore:` filter -- a path-filtered trigger is an exemption written one level up, and this self-test may not have one (#6509)',
+      );
+
+      // The other half of the split: the merge-base-dependent scans stay out of
+      // this job. `check:empty-changeset` / `check:adr-0087-registration` chain
+      // the REAL scan, whose verdict is a function of the PR's diff; this job
+      // has no branch point, so running one here reads stock and reports main's
+      // drift against the author -- #6129 in the false-RED direction.
+      const strayScans = uncommented(lintYaml)
+        .split('\n')
+        .filter((l) => /check-empty-changeset\.mjs|check-adr-0087-registration\.mjs|pnpm check:empty-changeset\b|pnpm check:adr-0087-registration\b/.test(l));
+      assert(
+        strayScans.length === 0,
+        `consumer: lint.yml must invoke these gates ONLY through \`pnpm check:changeset-gate-self-tests\` (found ${strayScans.length} direct invocation(s)) -- the real scans need $MERGE_BASE and this job has no branch point, which is #6129 in the false-RED direction`,
+      );
+
+      // What that pnpm script actually is. The step above is a name; this is the
+      // thing the name resolves to, and it is where "self-test halves only" and
+      // "BOTH of them" are actually true or false.
+      const pkgPath = join(REPO_ROOT, 'package.json');
+      const pkgPresent = existsSync(pkgPath);
+      assert(pkgPresent, 'consumer: the repository root package.json must exist -- it carries the script lint.yml runs');
+      let wiring = '';
+      try {
+        wiring = JSON.parse(pkgPresent ? readFileSync(pkgPath, 'utf8') : '{}').scripts?.['check:changeset-gate-self-tests'] ?? '';
+      } catch {
+        wiring = '';
+      }
+      assert(
+        /check-empty-changeset\.mjs --self-test/.test(wiring),
+        'consumer: `check:changeset-gate-self-tests` must run `check-empty-changeset.mjs --self-test` -- the step in lint.yml is only as real as the script it resolves to',
+      );
+      assert(
+        /check-adr-0087-registration\.mjs --self-test/.test(wiring),
+        'consumer: `check:changeset-gate-self-tests` must run `check-adr-0087-registration.mjs --self-test` too -- both checkers live in the same exempted job and both were unwired by it (#6509). `check-changeset-no-major.mjs` is deliberately absent: it has no `--self-test` to run.',
+      );
+      assert(
+        !/check-(?:empty-changeset|adr-0087-registration)\.mjs(?! --self-test)/.test(wiring),
+        'consumer: every invocation in `check:changeset-gate-self-tests` must carry `--self-test` -- chaining a real scan into the lint job is the #6129 direction this split exists to avoid',
+      );
+    }
+
     // ── Parser unit rows ─────────────────────────────────────────────────────
     assert(isEmptyDeclaration('---\n---\n\nbody\n'), 'parser: the canonical empty shape is empty');
     assert(isEmptyDeclaration('\n---\n\n---\n\nbody\n'), 'parser: blank lines around/inside the fence stay empty');


### PR DESCRIPTION
Fixes #6509

## The defect

`scripts/check-empty-changeset.mjs` and `scripts/check-adr-0087-registration.mjs` were called from **exactly one place in the repository**: the `changeset-check` job of `.github/workflows/pr-automation.yml` (`:681-682`). That job is exempted **wholesale** when a PR carries `skip-changeset` — job-level `if:` plus the two per-step label reads. And "this PR edits a CI-internal script" is the textbook `skip-changeset` case: such a PR releases nothing, so by the workflow's own prescription it takes the label.

The consequence is the exact inversion of #4690: **a PR that edits these two checkers is the PR most likely to skip their own fixtures.**

## Premise re-verified on `origin/main` @ `6968885ef`

| Probe | Result |
|:--|:--|
| `grep -rln` over `.github/workflows/` for all three script names | `pr-automation.yml` only, for all three |
| counter-probe: `grep -c "run: pnpm check:" .github/workflows/lint.yml` | **42** steps, and neither `check:empty-changeset` nor `check:adr-0087-registration` is among them |
| specimen: PR #6876 (#5620, merged) carried `skip-changeset` and added 5 consumer assertions | run `31289894461`, job `Check Changeset` (`93185167327`): step 12 `Reject an empty-frontmatter changeset added by this PR` — the only thing that runs `--self-test` — reports **`conclusion: skipped`**. Steps 13/14/15 likewise. Every one of those 5 assertions was verified locally and by nothing else. |

Both directions of the gap are real and they are **not symmetric**: a *broken* assertion is merely deferred onto the next unlabelled PR (an unrelated author eats the red), while a *deleted* one is silent forever, because nothing afterwards remembers it existed.

## Direction taken: candidate 1, and why it survives contact with the code

The card's candidate 1 and #6883's variant A converge: wire the **`--self-test` halves** into `lint.yml`, leave the **real scans** in `changeset-check` where `$MERGE_BASE` lives. Measured before implementing, not assumed:

- **The self-test halves have zero merge-base dependency.** Copying only `scripts/` and `.github/` into a directory that is **not a git repository at all** (`git rev-parse` there: `fatal: not a git repository`) and running both self-tests from there: both exit 0 (53 and 107 assertions). They build their own throwaway repos in `$TMPDIR` and read two files. ~0.8s + ~5.0s.
- **The real scans cannot move.** Their verdict is a function of the PR's diff, so a copy in a job with no branch point falls back to reading stock — which is #6129 ("judge the author for what main gained while their PR was open"), here in the false-**RED** direction. That is precisely why #6148 put them in `pr-automation.yml`.
- **`lint.yml` is the right host**: `on: pull_request:` with no `paths:` filter and an `on: merge_group:` trigger, so the step runs on every PR *and* every queue build, and the workflow reads no PR label anywhere.

⛔ **The `chunks.length === 5` job invariant is untouched.** The consumer block scopes that count to the `changeset-check` slice of `pr-automation.yml`; this PR adds no step to that job and adds no failable step anywhere near it. The alternative that redraws that boundary was not needed and was not taken. **`pr-automation.yml` is byte-identical to `origin/main` on this branch** (`git diff origin/main --name-only` lists only the three files below).

`check-changeset-no-major.mjs` is deliberately **not** wired: it has no `--self-test` to run. The new pin says so in its own assertion message, so the omission does not read as an oversight. Its lack of fixtures is filed separately as #6923.

## What changed (3 files, +167)

1. **`package.json`** — one new script, following the established self-test-only pattern already used by `check:release-body`, `check:stall-guard` and `check:objectui-changeset`:
   `"check:changeset-gate-self-tests": "node scripts/check-empty-changeset.mjs --self-test && node scripts/check-adr-0087-registration.mjs --self-test"`
2. **`.github/workflows/lint.yml`** — one step in the ESLint job, `- name: Changeset-family gate self-tests`, deliberately with **no `if:`**. An exemptable self-test is the card itself.
3. **`scripts/check-empty-changeset.mjs`** — 11 new consumer assertions (53 → 64) pinning the new wiring, in the block that already pins this family's workflow shape (#6129/#6378/#6434/#5620 all live there, so the next reader has one place to remember).

## CI evidence — the gap, and the gap closing, on this PR's own runs

This PR carries `skip-changeset`: it edits `.github/`, root `scripts/` and a `private: true` root manifest, so it releases nothing and route 2 of the workflow's own prescription applies. That makes it **the exact PR shape the card is about**, so the card's demand — *did your own new wiring actually execute on your own CI?* — is answered by measurement here, not by prose.

### 1. The defect, reproduced on this PR (commit `7a0e452b0`)

`Check Changeset` job `93196347946` (run `31294147110`):

| # | Step | Conclusion |
|--:|:--|:--|
| 12 | Reject an empty-frontmatter changeset added by this PR | **skipped** |
| 13 | Require an ADR-0087 disposition on a declared-breaking changeset | **skipped** |

Steps 12/13 were the only two places in the repository that ran `--self-test`. Identical to PR #6876's run `31289894461`. On the two later commits the whole job is **skipped at job level** (the label is in the payload by then).

### 2. The wiring executing — same commit, same label

`ESLint` job `93196348012` (run `31294147084`), conclusion **success**:

| # | Step | Conclusion | Duration |
|--:|:--|:--|:--|
| 29 | Changeset-family gate self-tests | **success** | 3s |

Same commit, same PR, same label: **skipped** in `changeset-check`, **executed** in `lint`. That is the whole fix, measured.

### 3. Reverse verification ON CI — a deliberate red, predicted in advance

A green step only proves it ran; it does not prove it can fail. So commit **`56f701810`** deliberately reintroduced a real #5620-class regression into `pr-automation.yml` — one character class, `grep -qxF 'allow-major'` to `grep -qF 'allow-major'` — and commit **`0290e7747`** reverted it. That ablation targets an assertion **PR #6876 added and never executed**, on a PR carrying the same label #6876 carried.

Predicted before pushing: `Check Changeset` skips its self-test steps again, and the new `lint.yml` step goes **RED**.

Observed — `ESLint` job `93196831253` (run `31294323300`), conclusion **failure**:

| # | Step | Conclusion |
|--:|:--|:--|
| 1-28 | everything before it | success |
| 29 | **Changeset-family gate self-tests** | **failure** |
| 30-42 | everything after it | skipped |

and in the same run, `Check Changeset` job `93196809939`: **skipped**. Nothing else in the repository could have caught it.

The failure text:

```
✗ check-empty-changeset --self-test -- 3 failure(s)
 - consumer: exactly one live `grep -qxF 'allow-major'` read is expected in the workflow; found 0. ...
 - consumer: the live allow-major read must honour both skip-changeset reads ...
 - consumer: the live allow-major read must write `allow=true` exactly once and only after the label
   was really observed (found 0 at [], grep at -1) ...
```

**Honest correction to the prediction: I predicted 1 failure and got 3.** Direction and primary message were right, count was not — because two further assertions *locate* the allow-major step by that same matcher, so removing it makes them fail too rather than pass vacuously. Recorded as observed rather than reshaped to fit the prediction.

**This red was not drift on `main`, and the check is cheap to redo:**

```
$ git show origin/main:.github/workflows/pr-automation.yml | grep -n "grep -qxF 'allow-major'"
801:          if grep -qxF 'allow-major' <<<"$LABELS"; then

$ git log --oneline -S "grep -qxF 'allow-major'" origin/main -- .github/workflows/pr-automation.yml
70949571c fix(ci): allow-major 改为求值时刻实时读标签,红 run 不再永久红 (#5620) (#6876)
```

The read is intact on `main`, and the commit that introduced it is **PR #6876 itself** — the specimen this card is built on. So the loop closes exactly: the assertion #6876 shipped without ever running is now demonstrated to be live, and to catch a regression to the very line #6876 added, on a PR carrying the label that hid it. **No assertion was deleted, loosened or skipped to reach green** — the ablation was reverted instead, and `pr-automation.yml` is byte-identical to `origin/main`.

Not a stale-artifact green either (AGENTS.md §9): these are `.mjs` files run directly by `node`, no `dist/` anywhere in the path, and the ablation moved the step from green to red and back.

## Reverse verification — the five local ablations, direction predicted before each run

Run against a sandbox copy of `scripts/` + `.github/` + `package.json`, all five predicted **RED**:

| Ablation | Predicted | Observed |
|:--|:--|:--|
| delete the `lint.yml` step | RED, "exactly once (found 0)" | exit 1, that exact message |
| condition the step on a `skip-changeset` label | RED, the no-`if:` pin | exit 1, **2** failures (the no-`if:` pin **and** the "lint.yml must not read `skip-changeset`" pin) |
| swap the step for `pnpm check:empty-changeset` (the full check) | RED, stray-scan + count | exit 1, both, naming #6129's false-RED direction |
| drop the adr-0087 half from the pnpm script | RED, the adr half | exit 1, that assertion |
| add `paths:` to `lint.yml`'s `pull_request:` trigger | RED, the paths pin | exit 1, that assertion |
| restore | GREEN | exit 0, 64 assertions |

## Residual, recorded rather than implied

The new assertion is run **by** the step it pins, so a PR that deletes that step **and** carries `skip-changeset` is still not caught — both places that would have run it are gone in the same diff. That is a strictly smaller hole than the one it replaces (which swallowed *every* labelled PR, including one that merely edits an assertion), it is a deletion plainly visible in a `.github/**` diff rather than a silent no-op, and closing it entirely would need a gate outside this family asserting this family's wiring — a coupling with its own cost. The comment in the source says the same thing, so the next reader inherits the fact and not a false sense of closure.

## Gates run locally

| Command | Result |
|:--|:--|
| `pnpm check:changeset-gate-self-tests` | PASS — 64 + 107 assertions |
| `pnpm check:workflow-status-functions` | PASS — real YAML parse, 23 workflows / 42 jobs / 24 job-level `if:` (proves the edited `lint.yml` still parses) |
| `pnpm check:node-version` | PASS — 26 setup-node steps, all Node 22 |
| `pnpm check:nul-bytes` | PASS — 6420 tracked files, no raw control bytes |
| `node scripts/check-type-check-coverage.mjs --self-test` | PASS — it reads `lint.yml` and the root manifest; unaffected |
| 13 further lint-job gates (`doc-authoring`, `docs-audit-scope`, `role-word`, `quick-reference-counts`, `adr-anchors`, `org-identifier`, `release-notes`, `release-body`, `shard-attestation`, `published-files`, `merge-driver`, `stall-guard`, `objectui-changeset`) | all PASS |
| `pnpm exec eslint scripts/check-empty-changeset.mjs --no-inline-config` | PASS |

## Boundaries

⛔ Untouched on the final tree: `docs/adr/**`, `content/docs/releases/**`, `pr-automation.yml` (byte-identical to `origin/main`), the `changeset-check` job and its `chunks.length === 5` invariant, the counting/merge-base logic, `check-changeset-no-major.mjs`, and every existing assertion in either checker.

Out-of-scope finding filed, not fixed here: **#6923** — `check-changeset-no-major.mjs` has no `--self-test`, and its enforcing half is unexecuted on every run today because Changesets is in pre-mode.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_