### PR TITLE
docs(spec): 用 #5757 的实测事实刷新 gen:openapi 豁免的 `why`

### DIFF
--- a/packages/spec/scripts/check-generated.ts
+++ b/packages/spec/scripts/check-generated.ts
@@ -238,13 +238,29 @@ const UNGATED_GENERATORS: ReadonlyArray<{ gen: string; why: string }> = [
   // #5744 that names a reconciliation with no second party: the document
   // carries no route section at all — built-in routes are produced at serve
   // time by the package that mounts them (#5588 ruling C, #5078, ADR-0076), so
-  // there is nothing here to compare against a route table. What IS still
-  // ungated is staleness against `src/api`: nothing fails when a contract
-  // schema changes and the artifact is not regenerated. Coherence is covered
-  // (the generator self-checks before writing, #5168) — currency is not.
+  // there is nothing here to compare against a route table. Coherence is
+  // covered (the generator self-checks before writing, #5168); currency this
+  // aggregate still does not verify. #5757 measured what that omission costs
+  // and the answer was nothing — staleness here is unreachable, not merely
+  // unpunished — so "add a gate" was ruled not planned. The `why` carries the
+  // measurement so the next reader does not re-file it.
   {
     gen: 'gen:openapi',
-    why: 'the OpenAPI document is generated but nothing compares its components.schemas against src/api — a stale artifact fails nothing (it IS self-checked for coherence at write time, #5168, and since #5744 it describes no routes to reconcile)',
+    why:
+      'nothing here compares the document\'s components.schemas against src/api — but per the #5757 ' +
+      'measurement a stale artifact is not merely unpunished, it is unreachable on every canonical path. ' +
+      'Staleness cannot outlive one build of this package: `json-schema/**` is a turbo build OUTPUT and is ' +
+      'gitignored, so it is never a task input; `build` declares no `inputs`, so it hashes every git-tracked ' +
+      'file in the package; and everything this generator reads sits in there (the `src/**` closure reached ' +
+      'through `src/api`, these scripts, the manifest). That input surface is a SUBSET of the build task\'s, ' +
+      'so any edit able to make the artifact stale is exactly the edit that busts the cache — and `build` ' +
+      'runs the generator unconditionally (`gen:schema && gen:openapi && tsup`). Deleting the artifact does ' +
+      'not even bust the cache: the next build restores it byte-identically (measured, FULL TURBO). What a ' +
+      'stale copy could mislead is bounded too — the served document holds 0 $refs into components.schemas, ' +
+      'leaving the nine contract schemas an unreferenced island (#6797). It IS self-checked for coherence at ' +
+      'write time (#5168), and since #5744 it describes no routes to reconcile. Gating it would also be ' +
+      'dormant: CI runs this aggregate only as `--reconcile-only` (lint.yml), and a full run sits after ' +
+      '`pnpm build` — green by construction, the #4177/#4232 class.',
   },
   { gen: 'gen:sbom', why: 'the SBOM is a release artifact, regenerated at publish time rather than checked in' },
 ];


### PR DESCRIPTION
Part of #5757

维护者裁决取 A(关单 not planned,**不加门**),本 PR 落地其中「刷新豁免 `why`」这一半。**纯文档:一个 `why` 字符串 + 其上方注释,零逻辑改动、零行为改动、零 CI 接线改动。**

## 为什么改

原 `why` 说陈旧产物「fails nothing」——属实,但**低估**:#5757 的测量轮发现陈旧不只是「没人罚」,而是在所有正规路径上**结构性不可达**。把这两条实测事实写进 `why`,下一个读到 `Generated but ungated` 的 agent 才不会再立一次同样的卡。

## 两条事实我都独立复验过(未采信派单转述)

**1. 陈旧活不过自己包的一次 build。** 从 `turbo.json` + `packages/spec/package.json` 重新推导:

- `json-schema/**` 在 `build.outputs` 里,且 `.gitignore:61` 忽略该目录 ⇒ 它是**产出**,不是任务输入;
- `build` 任务**未声明 `inputs`** ⇒ turbo 默认哈希包内全部 git 跟踪文件;
- `gen:openapi` 读到的东西全在包内(经 `src/api` 到达的 `src/**` 闭包、`scripts/`、`package.json`);
- ⇒ 其输入面是 build 输入面的**子集**。任何能让产物过期的改动,恰好就是让缓存失效的改动,而 `build` 里 `gen:schema && gen:openapi && tsup` 无条件重跑它。

实测(本 worktree,`OS_SKIP_DTS=1`):冷跑一次 build 后删除 `openapi.json`,再跑 `turbo build --filter=@objectstack/spec` —— **298ms `FULL TURBO` 缓存命中**,sha256 与删除前逐字节一致(`f30f101b…88c6`)。删产物连缓存都没打穿,正是「产出不是输入」的直接印证。

**2. 服务出的文档里 0 个 `$ref` 指向 `components.schemas`。** 实测重建后的产物:顶层键为 `components` / `info` / `openapi` / `security` / `servers`(`paths` 整个缺席),`components.schemas` 9 个,全文 `$ref` 出现次数 **0**。运行期那一半也查了:`packages/rest` 中 `openapi-builtin-paths.ts` 与 `openapi-endpoints.ts` 对 `$ref` 的提及**全部在注释里**,无发射点(`rest-server.ts` 的 `$ref` 是 batch 的 op-index 引用,另一回事)。九个契约 schema 确为零入边孤岛(#6797)。

## 两处与派单口径的偏差(据实记录,未照抄)

1. 派单把 `gen:openapi` 的输入面写作「`packages/spec/src/api/**` + package manifest」。实测**更宽**:`src/api` 透传 import 了 `src/shared`、`src/data`、`src/ui`、`src/kernel`、`src/automation`、`src/system`(77 处 `from '../…'`)。承重的子集关系**因此更成立、而非更不成立**(这些仍全在包内、全被 build 哈希),但我没有照抄那个偏窄的措辞,`why` 写的是「经 `src/api` 到达的 `src/**` 闭包」。
2. 裁决评论引的 `lint.yml:624` 已漂到 **`lint.yml:773`**,事实不变(`.github/` 下唯一一处 `check:generated` 调用仍带 `--reconcile-only`),故 `why` 只写 `lint.yml`、不写行号,避免再漂。

## 保留的旧事实

`#5168`(写入时自检 coherence)与 `#5744`(不再描述任何路由)原样留在 `why` 里。

## 验证

| 命令 | 结果 |
|---|---|
| `pnpm --filter @objectstack/spec check:generated --reconcile-only` | 绿(19 个 `check:` + 13 个 `gen:` 全部分类) |
| `pnpm --filter @objectstack/spec test` | 绿,349 文件 / 9046 用例 |
| `pnpm --filter @objectstack/spec typecheck` | 绿(含 `tsconfig.scripts.json`,即编译本文件的那套) |
| `npx eslint packages/spec/scripts/check-generated.ts` | 绿 |
| `node scripts/check-nul-bytes.mjs` | OK,6442 个文件无裸控制字节 |

无测试新增:本改动不含可执行语义,`check-generated-ledger.test.ts` 只对账 `gen` 名而不锁 `why` 文本(已确认),故无可写的红/绿断言。

## Changeset

**无 changeset,挂 `skip-changeset`。** `packages/spec` 的 `files` 为 `dist` / `json-schema` / `liveness` / `prompts` / `llms.txt` / `README.md` / `src/**/*.zod.ts` / `CHANGELOG.md` / `api-surface` / `spec-changes.json` —— **`scripts/` 不在其中**,本改动不进任何发布产物,发布面为零。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZgRyPVwi1jLb1mNNuUQ9o


---
_Generated by [Claude Code](https://claude.ai/code/session_01AZgRyPVwi1jLb1mNNuUQ9o)_