### PR TITLE
fix(metadata-protocol,objectql): activate the #4463 runtime authoring gate from a declared authoring channel instead of the environmentId proxy (#6710)

### DIFF
--- a/.changeset/authoring-channel-declaration.md
+++ b/.changeset/authoring-channel-declaration.md
@@ -1,0 +1,59 @@
+---
+"@objectstack/metadata-protocol": minor
+"@objectstack/objectql": minor
+---
+
+fix(metadata-protocol,objectql): the #4463 runtime authoring gate now runs on every kernel that has not declared itself the package author's channel (#6710)
+
+The 26 shared author-time rules (`AUTHORING_RULES` — the same table `os validate`
+/ `os build` / `os lint` run) were gated behind
+`if (this.environmentId === undefined) return;`. That short-circuit was meant to
+be ADR-0005's "the package author's own bootstrap channel" carve-out, and the
+carve-out itself is legitimate. The key was not: `environmentId` is a ROW-SCOPING
+key, and two very different topologies leave it undefined.
+
+**The defect.** The CLI's lightweight host-config assembler — `serve.ts`'s
+`config.objects && !hasObjectQL` auto-register branch, which constructs
+`new ObjectQLPlugin()` with no options — also boots with no `environmentId`.
+That is the shape any `objectstack.config.ts` with instantiated plugins gets
+(`isHostConfig` → `shouldBootWithLibrary === false`), including the flagship
+showcase app. Its `PUT /api/v1/meta/*` is an **end-user** surface, so a
+self-hosted app server ran **zero** of the 26 rules on every publish. For a
+Studio tenant or an MCP/AI author this gate is not the weakest of four doors —
+it is the only one, because a `sys_metadata` overlay row is never in the CLI's
+config file and there is no `os lint` for it. Measured at boot level: the kernel
+reports `environmentId === undefined` and #4463's own broken-CEL approval flow
+(`record.owner ==`) runs straight past the gate into persistence.
+
+**The fix — the channel is declared, not inferred.** A new plugin option states
+what a kernel *is*, and gate activation reads that instead of row scope:
+
+```ts
+new ObjectQLPlugin({ authoringChannel: 'package-author' })
+createMetadataProtocolPlugin({ authoringChannel: 'package-author' })
+```
+
+`'environment'` (the default, and what you get by omitting the option) runs the
+rules. `'package-author'` is the ADR-0005 carve-out and belongs only on the
+genuine control-plane assembly — the kernel installing packages on the
+platform's own behalf. The option is threaded through `assembleMetadataProtocol`,
+the one seam both mounts share, so the built-in and delegated (ADR-0076 Step 2)
+mounts cannot disagree.
+
+**Omitting it means more enforcement, never less.** That direction is the point:
+the failure mode being designed out is a future assembly variant nobody thought
+about silently reopening this hole, which is exactly how the host-config
+topology got here. It is also why the option is a channel NAME and not a
+boolean — `skipAuthoringRules: true` would be the same bytes with the opposite
+meaning, a switch for making a red publish go away. #5086 had already retired
+the same proxy key for the code-only refusal, for the same reason.
+
+**What changes for you.** A kernel that serves metadata writes to end users
+should change nothing — it now enforces the rules it always should have. A
+kernel that genuinely is a control plane must add `authoringChannel:
+'package-author'`; until it does it runs gated in the safe direction, and the
+existing per-write `OS_ALLOW_UNLINTED_METADATA_WRITES=1` hatch (#4463 D4)
+degrades a refusal to a loud log. `environmentId` keeps every one of its other
+jobs unchanged — the `environment_id` stamp and filter, the ADR-0005 overlay
+whitelist, the #3050 authoring gate's scope, and local metadata-storage
+provisioning. Only this one activation moved.

--- a/packages/metadata-protocol/src/index.ts
+++ b/packages/metadata-protocol/src/index.ts
@@ -6,7 +6,11 @@ export { ObjectStackProtocolImplementation, ConcurrentUpdateError, normalizeView
 // instead of minting a second not-found shape. See `recordNotFoundError`.
 export { recordNotFoundError } from './protocol.js';
 export { createMetadataProtocolPlugin, assembleMetadataProtocol } from './plugin.js';
-export type { MetadataProtocolPluginOptions } from './plugin.js';
+export type { MetadataProtocolPluginOptions, AssembleMetadataProtocolOptions } from './plugin.js';
+// [#6710] The declared authoring channel — the explicit expression of ADR-0005's
+// "package author's own bootstrap channel", replacing the `environmentId ===
+// undefined` proxy the #4463 gate used to key its activation off.
+export type { MetadataAuthoringChannel } from './protocol.js';
 
 // [#5839] `sys_view_definition`'s active-row uniqueness, delivered as a runtime
 // partial-UNIQUE migration (the `ensureOverlayIndex` paradigm, for the one other

--- a/packages/metadata-protocol/src/plugin.ts
+++ b/packages/metadata-protocol/src/plugin.ts
@@ -36,6 +36,7 @@ import {
     resolveIndexExec,
 } from './migrations/view-definition-active-index.js';
 import { ObjectStackProtocolImplementation } from './protocol.js';
+import type { MetadataAuthoringChannel } from './protocol.js';
 
 export interface MetadataProtocolPluginOptions {
     /**
@@ -46,10 +47,30 @@ export interface MetadataProtocolPluginOptions {
      * Mirrors `ObjectQLPluginOptions.environmentId` — pass the same value.
      */
     environmentId?: string;
+    /**
+     * [#6710] Which authoring channel this kernel's metadata writes arrive on.
+     *
+     * Leave unset on ANY kernel that serves `PUT /api/v1/meta/*` to end users
+     * (Studio tenants, MCP/AI authors, self-hosted app servers): the default
+     * `'environment'` runs the #4463 runtime authoring rules, which for those
+     * authors is the only author-time gate that exists.
+     *
+     * Set `'package-author'` ONLY on the genuine control-plane assembly — the
+     * kernel that installs packages on the platform's own behalf and is not an
+     * author publishing into a live tenant. Stating it is a claim about what
+     * this kernel IS; it is not a switch for making a red publish go away.
+     *
+     * Deliberately no env-var fallback (unlike `skipSchemaSync`): a deployment
+     * must not be able to turn an end-user guardrail off from the outside. The
+     * per-write escape hatch that DOES exist is
+     * `OS_ALLOW_UNLINTED_METADATA_WRITES` (#4463 D4), which degrades the
+     * refusal to a loud log instead of silencing it.
+     */
+    authoringChannel?: MetadataAuthoringChannel;
 }
 
 export function createMetadataProtocolPlugin(options: MetadataProtocolPluginOptions = {}): Plugin {
-    const { environmentId } = options;
+    const { environmentId, authoringChannel } = options;
     return {
         name: 'com.objectstack.metadata.protocol',
         version: '1.0.0',
@@ -71,9 +92,18 @@ export function createMetadataProtocolPlugin(options: MetadataProtocolPluginOpti
                 );
             }
 
-            assembleMetadataProtocol(ctx, ql, environmentId);
+            assembleMetadataProtocol(ctx, ql, environmentId, { authoringChannel });
         },
     };
+}
+
+/** Extra assembly inputs that are not row scope. Bag-shaped so the next one is additive. */
+export interface AssembleMetadataProtocolOptions {
+    /**
+     * [#6710] See {@link MetadataProtocolPluginOptions.authoringChannel}.
+     * Omitted ⇒ `'environment'` ⇒ the #4463 runtime authoring gate is active.
+     */
+    authoringChannel?: MetadataAuthoringChannel;
 }
 
 /**
@@ -98,6 +128,7 @@ export function assembleMetadataProtocol(
     ctx: PluginContext,
     ql: any,
     environmentId?: string,
+    options: AssembleMetadataProtocolOptions = {},
 ): ObjectStackProtocolImplementation {
             // Metadata-storage platform objects (sys_metadata + history/audit
             // siblings + sys_view_definition). Same `environmentId === undefined`
@@ -123,10 +154,20 @@ export function assembleMetadataProtocol(
                 });
             }
 
+            // [#6710] The authoring channel is threaded here and NOWHERE else:
+            // this function is the one seam BOTH mounts share (the delegated
+            // MetadataProtocolPlugin and ObjectQLPlugin's built-in
+            // `registerProtocol !== false` convenience mode), so a declaration
+            // that lands here cannot be half-applied depending on how the host
+            // chose to mount the protocol. `?? 'environment'` is the fail-safe
+            // default restated at the seam — a caller reaching
+            // `assembleMetadataProtocol` directly with no options bag gets the
+            // gated channel, exactly like one that omits the plugin option.
             const protocolShim = new ObjectStackProtocolImplementation(
                 ql,
                 () => (ctx.getServices ? ctx.getServices() : new Map()),
                 environmentId,
+                options.authoringChannel ?? 'environment',
             );
             ctx.registerService('protocol', protocolShim);
             ctx.logger.info('Protocol service registered (MetadataProtocolPlugin)');

--- a/packages/metadata-protocol/src/protocol.platform-schedule-org-gate.test.ts
+++ b/packages/metadata-protocol/src/protocol.platform-schedule-org-gate.test.ts
@@ -526,16 +526,20 @@ describe('#6285 refusal through saveMetaItem / publishMetaItem', () => {
         expect(shouted[0]).toContain(PLATFORM_SCHEDULE_CREATE_RECORD_ORG_MISSING);
     });
 
-    it('does not gate control-plane (package-author) writes — the pre-existing carve-out', async () => {
-        // The dispatch's STOP item. `environmentId === undefined` is the
-        // control-plane / package-author channel, and the short-circuit is
-        // EXISTING DESIGN (`protocol.runtime-authoring-gate.test.ts` pins it for
-        // the other 26 rules). It does not put this guardrail out of reach:
-        // every serving path binds an environment id (`env_local` /
-        // `proj_local` / a cloud project), which is the case the test above
-        // drives.
+    it('does not gate a DECLARED package-author (control-plane) channel — the pre-existing carve-out', async () => {
+        // The dispatch's STOP item, re-spelled by #6710. The carve-out is
+        // unchanged and still EXISTING DESIGN
+        // (`protocol.runtime-authoring-gate.test.ts` pins it for all 26 rules);
+        // what changed is how a kernel claims it. This case used to construct
+        // the protocol with no `environmentId` and rely on that meaning
+        // "control plane" — a row-scoping key standing in for a topology, which
+        // #6710 measured to be false for the CLI's host-config assembler. The
+        // channel is declared now, so the carve-out this case is about is
+        // stated rather than inferred.
         const { engine, rows } = makeStubEngine();
-        const protocol = new ObjectStackProtocolImplementation(engine, () => new Map()) as any;
+        const protocol = new ObjectStackProtocolImplementation(
+            engine, () => new Map(), undefined, 'package-author',
+        ) as any;
         const result = await protocol.saveMetaItem({
             type: 'flow',
             name: 'nightly_sweep',
@@ -543,6 +547,24 @@ describe('#6285 refusal through saveMetaItem / publishMetaItem', () => {
         });
         expect(result.success).toBe(true);
         expect(flowRows(rows).length).toBe(1);
+    });
+
+    it('[#6710] DOES gate an unscoped kernel that never declared the channel', async () => {
+        // The other half of the re-spelling, and the reason it is not merely
+        // cosmetic: this guardrail is one of the 26 shared rules, so #6710
+        // widened ITS reach too. An unscoped kernel that has not claimed the
+        // package-author channel is a host-config app server — an end-user
+        // surface — and #6285's refusal now applies there. Without this case
+        // the file would assert only the side that stayed the same.
+        const { engine, rows } = makeStubEngine();
+        const protocol = new ObjectStackProtocolImplementation(engine, () => new Map()) as any;
+        const err = await protocol
+            .saveMetaItem({ type: 'flow', name: 'nightly_sweep', item: scheduledSweep() })
+            .catch((e: any) => e);
+        expect(err?.code).toBe('INVALID_METADATA');
+        expect(err?.status).toBe(422);
+        expect(err.issues.map((i: any) => i.rule)).toContain(PLATFORM_SCHEDULE_CREATE_RECORD_ORG_MISSING);
+        expect(flowRows(rows)).toEqual([]);
     });
 
     it('does not gate `os migrate meta --stored`, which rewrites rows that already exist', async () => {

--- a/packages/metadata-protocol/src/protocol.runtime-authoring-gate.test.ts
+++ b/packages/metadata-protocol/src/protocol.runtime-authoring-gate.test.ts
@@ -32,6 +32,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // #5619 sank the two predicates into a package both sides already depend on.
 import { assertEngineDeleteDispatch, assertEngineUpdateDispatch } from '@objectstack/metadata-core';
 import { ObjectStackProtocolImplementation } from './protocol.js';
+import type { MetadataAuthoringChannel } from './protocol.js';
 
 /** The issue's body. Zod-valid: `approvers[].value` is just a string to the schema. */
 const brokenApprovalFlow = () => ({
@@ -140,10 +141,30 @@ function makeStubEngine() {
     return { engine, rows };
 }
 
-/** `environmentId` set: the gate, like every ADR-0005 authorization gate, is tenant-scoped. */
+/**
+ * A protocol on the ordinary tenant posture: an environment id AND the default
+ * (undeclared ⇒ `'environment'`) authoring channel.
+ */
 function makeProtocol() {
     const { engine, rows } = makeStubEngine();
     const protocol = new ObjectStackProtocolImplementation(engine, () => new Map(), 'env_test');
+    return { protocol: protocol as any, rows };
+}
+
+/**
+ * [#6710] The two activation inputs, driven independently. `environmentId` is
+ * row scope; `authoringChannel` is what decides whether the #4463 gate runs.
+ * Passing `undefined` for the channel exercises the constructor DEFAULT — the
+ * fail-safe direction — not an explicit `'environment'`.
+ */
+function makeProtocolOn(
+    environmentId: string | undefined,
+    authoringChannel?: MetadataAuthoringChannel,
+) {
+    const { engine, rows } = makeStubEngine();
+    const protocol = authoringChannel === undefined
+        ? new ObjectStackProtocolImplementation(engine, () => new Map(), environmentId)
+        : new ObjectStackProtocolImplementation(engine, () => new Map(), environmentId, authoringChannel);
     return { protocol: protocol as any, rows };
 }
 
@@ -259,11 +280,13 @@ describe('runtime authoring gate on saveMetaItem (#4463)', () => {
 
     // ── Scope: what the gate must NOT do ─────────────────────────────────
 
-    it('does not gate control-plane (package-author) writes', async () => {
-        // `environmentId === undefined` is the package author's own channel —
-        // the same carve-out every ADR-0005 authorization gate above it makes.
-        const { engine, rows } = makeStubEngine();
-        const protocol = new ObjectStackProtocolImplementation(engine, () => new Map()) as any;
+    it('does not gate a DECLARED package-author (control-plane) channel', async () => {
+        // The ADR-0005 carve-out itself is unchanged and still legitimate: a
+        // control-plane kernel installing a package is not an author
+        // publishing into a live tenant. What #6710 changed is that the kernel
+        // has to SAY SO — this is the one posture in the matrix below that
+        // may skip all 26 rules.
+        const { protocol, rows } = makeProtocolOn(undefined, 'package-author');
         const result = await protocol.saveMetaItem({
             type: 'flow',
             name: 'leave_approval',
@@ -333,5 +356,168 @@ describe('runtime authoring gate on saveMetaItem (#4463)', () => {
             .saveMetaItem({ type: 'flow', name: 'other_flow', item: { ...brokenApprovalFlow(), name: 'other_flow' } })
             .catch((e: any) => e);
         expect(err.status).toBe(422);
+    });
+});
+
+/**
+ * [#6710] What ACTIVATES the gate — the posture matrix.
+ *
+ * Until #6710 the answer was `environmentId !== undefined`, and the whole
+ * defect is that this key cannot tell two topologies apart: the genuine
+ * control plane and the CLI's host-config assembler
+ * (`serve.ts`'s `config.objects && !hasObjectQL` branch → `new ObjectQLPlugin()`
+ * with no options) BOTH leave it undefined, and only the first one is the
+ * package author's own channel. The second serves an end-user
+ * `PUT /api/v1/meta/*` — measured at boot level on `origin/main` @ `68feaadd6`:
+ * `protocol.environmentId === undefined` and the broken approval flow ran
+ * straight past this gate into persistence.
+ *
+ * So activation is now keyed on a DECLARED channel, and this matrix is the
+ * contract. The row that matters most is the first: **undeclared ⇒ gated**.
+ * An assembly that forgets gets more enforcement, never less.
+ */
+describe('#6710 — gate activation is keyed on the declared authoring channel', () => {
+    let warn: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => {
+        warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        delete process.env.OS_ALLOW_UNLINTED_METADATA_WRITES;
+    });
+    afterEach(() => {
+        warn.mockRestore();
+        delete process.env.OS_ALLOW_UNLINTED_METADATA_WRITES;
+    });
+
+    /**
+     * `undefined` = the option omitted entirely, which is the posture every
+     * assembly that has not been told about this option is in.
+     */
+    const matrix: Array<{
+        environmentId: string | undefined;
+        channel: MetadataAuthoringChannel | undefined;
+        gated: boolean;
+        why: string;
+    }> = [
+        {
+            environmentId: undefined, channel: undefined, gated: true,
+            why: 'THE #6710 FIX — the host-config topology (serve.ts, showcase). '
+                + 'Undeclared is the gated channel: this row going green in the other '
+                + 'direction is the defect this card exists to close.',
+        },
+        {
+            environmentId: undefined, channel: 'environment', gated: true,
+            why: 'the default, stated out loud — must agree with the omitted case',
+        },
+        {
+            environmentId: undefined, channel: 'package-author', gated: false,
+            why: 'the ADR-0005 carve-out, now declared — the genuine control plane',
+        },
+        {
+            environmentId: 'env_test', channel: undefined, gated: true,
+            why: 'the ordinary tenant kernel — gated before #6710 and gated after',
+        },
+        {
+            environmentId: 'env_test', channel: 'environment', gated: true,
+            why: 'same, stated out loud',
+        },
+        {
+            environmentId: 'env_test', channel: 'package-author', gated: false,
+            why: 'the DECLARATION decides on its own. Row scope is orthogonal and is '
+                + 'deliberately not AND-ed in here: re-admitting environmentId as a '
+                + 'co-condition would put the retired proxy key back into the '
+                + 'activation judgment, and a control plane that later gained a row '
+                + 'scope would silently change gate posture. No in-repo assembly is '
+                + 'in this posture; it is pinned so the rule reads one way only.',
+        },
+    ];
+
+    for (const { environmentId, channel, gated, why } of matrix) {
+        const label = `environmentId=${environmentId ?? 'undefined'}, `
+            + `authoringChannel=${channel ?? '<omitted>'} ⇒ ${gated ? 'GATED' : 'bypassed'}`;
+
+        it(label, async () => {
+            const { protocol, rows } = makeProtocolOn(environmentId, channel);
+            const outcome = await protocol
+                .saveMetaItem({ type: 'flow', name: 'leave_approval', item: brokenApprovalFlow() })
+                .then((r: any) => ({ ok: true as const, r }))
+                .catch((e: any) => ({ ok: false as const, e }));
+
+            if (!gated) {
+                expect(outcome.ok, `${why}\nunexpected refusal: ${String((outcome as any).e?.message)}`).toBe(true);
+                expect(flowRows(rows).length).toBe(1);
+                return;
+            }
+
+            expect(outcome.ok, why).toBe(false);
+            const err = (outcome as { ok: false; e: any }).e;
+            // ADR-0112 envelope, both halves. `rejects.toThrow()` alone would
+            // stay green on any throw at all — including the engine's own
+            // "no driver available", which is exactly how the ungated
+            // host-config topology fails today.
+            expect(err.code, why).toBe('INVALID_METADATA');
+            expect(err.status, why).toBe(422);
+            expect(err.issues.map((i: any) => i.rule)).toContain('approval-expression-invalid');
+            // A gate that rejects after persisting is a log line.
+            expect(flowRows(rows), 'nothing may land on a refusal').toEqual([]);
+        });
+    }
+
+    it('the gated postures are gated by the RULES, not by a blanket refusal', async () => {
+        // Guards against the lazy fix: "gate everything undeclared" is only
+        // correct if a clean body still publishes. Both undeclared postures
+        // must accept the valid flow.
+        for (const environmentId of [undefined, 'env_test']) {
+            const { protocol, rows } = makeProtocolOn(environmentId, undefined);
+            const result = await protocol.saveMetaItem({
+                type: 'flow', name: 'leave_approval', item: validApprovalFlow(),
+            });
+            expect(result.success, `environmentId=${String(environmentId)}`).toBe(true);
+            expect(flowRows(rows).length).toBe(1);
+        }
+    });
+
+    it('D4 hatch still covers the newly-gated topology (the cross-repo window depends on it)', async () => {
+        // Until `cloud`'s control-plane-preset declares the channel, the
+        // control plane runs on the undeclared (gated) posture. The maintainer
+        // accepted that window explicitly BECAUSE this hatch exists — so the
+        // hatch has to work on precisely the posture the window puts it in:
+        // environmentId undefined, channel undeclared.
+        process.env.OS_ALLOW_UNLINTED_METADATA_WRITES = '1';
+        const { protocol, rows } = makeProtocolOn(undefined, undefined);
+
+        const result = await protocol.saveMetaItem({
+            type: 'flow', name: 'leave_approval', item: brokenApprovalFlow(),
+        });
+        expect(result.success).toBe(true);
+        expect(flowRows(rows).length).toBe(1);
+
+        const shouted = (warn.mock.calls as unknown[][])
+            .map((c) => String(c[0]))
+            .filter((m) => m.includes('OS_ALLOW_UNLINTED_METADATA_WRITES'));
+        expect(shouted.length, 'tolerated, never invisible').toBe(1);
+        expect(shouted[0]).toContain('approval-expression-invalid');
+    });
+
+    it('does not disturb the OTHER gates that legitimately read environmentId', async () => {
+        // #6710 re-keys ONE activation. The #3050 authoring gate keeps its own
+        // `environmentId !== undefined` scope check, and it must stay keyed
+        // there — that gate really is about row scope. Declaring the
+        // package-author channel must not switch it on for a control-plane
+        // kernel, and must not switch it off for a tenant one.
+        const seen: string[] = [];
+        const gate = (ctx: { type: string; name: string }) => { seen.push(`${ctx.type}/${ctx.name}`); };
+
+        const cp = makeProtocolOn(undefined, 'package-author');
+        cp.protocol.registerAuthoringGate('flow', gate);
+        await cp.protocol.saveMetaItem({ type: 'flow', name: 'leave_approval', item: validApprovalFlow() });
+        expect(seen, 'the #3050 gate stays OFF where environmentId is undefined').toEqual([]);
+
+        const tenant = makeProtocolOn('env_test', 'package-author');
+        tenant.protocol.registerAuthoringGate('flow', gate);
+        await tenant.protocol.saveMetaItem({ type: 'flow', name: 'leave_approval', item: brokenApprovalFlow() });
+        expect(
+            seen,
+            'the #3050 gate stays ON where environmentId is set, even though the '
+            + '#4463 gate was waived by the channel declaration — two gates, two keys',
+        ).toEqual(['flow/leave_approval']);
     });
 });

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -2282,6 +2282,43 @@ export interface MetadataAuthoringGateContext {
 export type MetadataAuthoringGate = (ctx: MetadataAuthoringGateContext) => void | Promise<void>;
 
 /**
+ * Which authoring channel a kernel's metadata writes arrive on (#6710).
+ *
+ * ADR-0005 carves out "the package author's own bootstrap channel" from the
+ * runtime authoring rules: a control-plane kernel installing a package is not
+ * an author publishing into a live tenant, and gating it would refuse the very
+ * bodies the platform ships. The carve-out is legitimate and stays.
+ *
+ * What #6710 changed is **how a kernel says it is that channel**. Until this
+ * type existed the answer was inferred from `environmentId === undefined` — a
+ * ROW-SCOPING key pressed into service as a topology signal. That proxy lies:
+ * the CLI's lightweight host-config assembler (`serve.ts`'s auto-register
+ * branch, `new ObjectQLPlugin()` with no options) also leaves `environmentId`
+ * undefined, and it serves an END-USER `PUT /api/v1/meta/*`. Both topologies
+ * read identically, so the whole #4463 gate — all 26 shared `AUTHORING_RULES`
+ * — was disengaged on a self-hosted app server. #5086 had already moved the
+ * code-only refusal off the same proxy for the same reason ("keying
+ * authorization off a row-scoping key is what made a type-level declaration
+ * depend on deployment topology; the declaration decides it here instead").
+ *
+ * So the channel is now DECLARED, not inferred:
+ *
+ * - `'environment'` — metadata arrives from an author (Studio tenant, MCP/AI
+ *   agent, `PUT /api/v1/meta/*`). The gate runs. **This is the default**, and
+ *   the default is the whole point: an assembly that forgets to declare gets
+ *   MORE enforcement, never less, so the next assembly variant nobody thought
+ *   about cannot silently reopen this hole.
+ * - `'package-author'` — this kernel IS the package author's own bootstrap
+ *   channel. Only the genuine control-plane assembly may state this.
+ *
+ * Deliberately a channel NAME and not a boolean: `skipAuthoringRules: true`
+ * would be the same bytes with the opposite meaning — a kill switch any
+ * assembly could reach for to make a red publish go away. A caller has to
+ * claim to BE the package author to be treated as one.
+ */
+export type MetadataAuthoringChannel = 'environment' | 'package-author';
+
+/**
  * Implements the per-domain contracts this class ACTUALLY provides (ADR-0076
  * D10 — the facade never implemented the other domains; those live in their
  * owning services and are reached through the discovery `services` registry,
@@ -2300,8 +2337,26 @@ export class ObjectStackProtocolImplementation implements
      * saveMetaItem insert/update and loadMetaFromDb query is filtered by
      * `environment_id = environmentId`, so per-project kernels see only their own
      * metadata even if several projects share the same physical database.
+     *
+     * [#6710] Row scoping ONLY. This key keeps every one of its other jobs —
+     * the `environment_id` stamp/filter, the ADR-0005 overlay-whitelist gate,
+     * the #3050 authoring-gate scope, the local metadata-storage provisioning
+     * decision — but it no longer decides whether the #4463 runtime authoring
+     * rules run. See {@link authoringChannel}.
      */
     private environmentId?: string;
+
+    /**
+     * The declared authoring channel (#6710). Defaults to `'environment'`,
+     * which is what makes the #4463 gate active on every kernel that does not
+     * explicitly claim to be the package author's own bootstrap channel.
+     *
+     * Read by {@link assertRuntimeAuthoringRules} and nothing else — this is
+     * deliberately NOT a general-purpose authorization key. The ADR-0005
+     * overlay gate and the #3050 authoring gate keep reading `environmentId`,
+     * because those two really are about row scope.
+     */
+    private authoringChannel: MetadataAuthoringChannel;
 
     /**
      * Lazily-instantiated SysMetadataRepository per organization. Keyed by
@@ -2460,14 +2515,23 @@ export class ObjectStackProtocolImplementation implements
         return (name, body) => canonicalize.call(automation, name, body);
     }
 
+    /**
+     * @param authoringChannel [#6710] which channel this kernel's metadata
+     * writes arrive on. Omitted ⇒ `'environment'` ⇒ the #4463 runtime
+     * authoring gate is ACTIVE. Only the genuine control-plane assembly passes
+     * `'package-author'`. The default is the fail-safe direction on purpose:
+     * a caller that forgets this argument gets more enforcement, never less.
+     */
     constructor(
         engine: IDataEngine,
         getServicesRegistry?: () => Map<string, any>,
         environmentId?: string,
+        authoringChannel: MetadataAuthoringChannel = 'environment',
     ) {
         this.engine = engine as MetadataHostEngine;
         this.getServicesRegistry = getServicesRegistry;
         this.environmentId = environmentId;
+        this.authoringChannel = authoringChannel;
     }
 
     /**
@@ -2585,25 +2649,39 @@ export class ObjectStackProtocolImplementation implements
          */
         organizationId?: string | null;
     }): void {
-        // Environment writes only. `environmentId === undefined` is the
-        // package author's own control-plane channel — the same carve-out the
-        // ADR-0005 authorization gate and the #3050 authoring gate below both
-        // make, and pinned as deliberate by `protocol.runtime-authoring-gate.
-        // test.ts` ("does not gate control-plane (package-author) writes").
+        // [#6710] The ADR-0005 carve-out, now DECLARED instead of inferred.
         //
-        // [#6285] Measured before adding a guardrail behind it, because the
-        // dispatch asked whether the short-circuit makes the new refusal
-        // unreachable in the deployment shape it protects: it does not. Every
-        // serving path binds an environment id — `os dev` / `os start` default
-        // to `env_local` (`cli/src/commands/dev.ts:225`, `start.ts:197`), the
-        // standalone artifact stack to `proj_local`
-        // (`runtime/src/standalone-stack.ts:378`), and a cloud per-project
-        // kernel to its own — so a multi-organization deployment reaches this
-        // gate. What sits behind the short-circuit is the control-plane
-        // bootstrap kernel, which authors no tenant metadata. Widening it is
-        // therefore not this issue's business (and would change the blast
-        // radius of all 26 shared rules, not just this one).
-        if (this.environmentId === undefined) return;
+        // This line used to read `if (this.environmentId === undefined)
+        // return;` — the carve-out keyed off a ROW-SCOPING key. #6285 measured
+        // that short-circuit and found every *regular* serving path safely on
+        // the gated side (`os dev` / `os start` bind `env_local`, the
+        // standalone artifact stack `proj_local`, a cloud per-project kernel
+        // its own), and concluded the only thing behind it was the
+        // control-plane bootstrap kernel. That conclusion was incomplete, and
+        // #6710 measured the counter-example at boot level: the CLI's
+        // lightweight host-config assembler (`serve.ts`'s
+        // `config.objects && !hasObjectQL` branch → `new ObjectQLPlugin()`
+        // with no options) ALSO leaves `environmentId` undefined, and it
+        // serves an end-user `PUT /api/v1/meta/*`. `isHostConfig` →
+        // `shouldBootWithLibrary === false` is the flagship showcase's own
+        // boot shape, so a self-hosted app server ran all 26 shared
+        // `AUTHORING_RULES` on exactly nothing — and for a Studio tenant or an
+        // MCP/AI author this gate is not the weakest of four doors, it is the
+        // ONLY one (#4463's filing reason).
+        //
+        // Two topologies, one key, opposite intents: that is the definition of
+        // a proxy signal, and #5086 had already retired the same proxy for the
+        // code-only refusal a few hundred lines below. So the channel is now
+        // stated by the assembly (`assembleMetadataProtocol` ← the plugin
+        // option) rather than guessed from row scope, and the DEFAULT is the
+        // gated one. An assembly that forgets to declare gets more
+        // enforcement, never less — the direction matters more than the
+        // mechanism, because the failure mode being designed out is precisely
+        // "a new assembly variant nobody thought about".
+        //
+        // `environmentId` keeps every other job it has, including the #3050
+        // authoring gate's own scope check below.
+        if (this.authoringChannel === 'package-author') return;
         if (evt.state !== 'active') return;
         // `os migrate meta --stored --apply` rewrites rows that ALREADY EXIST
         // into the current dialect. It is not an author publishing anything —

--- a/packages/objectql/src/plugin.authoring-channel.test.ts
+++ b/packages/objectql/src/plugin.authoring-channel.test.ts
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #6710 — the assembly-wiring pin for the declared authoring channel.
+ *
+ * `metadata-protocol`'s `protocol.runtime-authoring-gate.test.ts` owns the
+ * POSTURE matrix (which channel gates which write). This file owns the other
+ * half, which that package structurally cannot test: **that a real kernel boot
+ * actually threads the declaration from the plugin option down to the protocol
+ * instance** — `metadata-protocol` must not depend on `objectql`, even as a
+ * devDependency, because turbo rejects the cycle (the same reason
+ * `plugin.step2.test.ts` lives here).
+ *
+ * The defect being pinned, measured at boot level on `origin/main` @ `68feaadd6`
+ * before the fix: `new ObjectQLPlugin()` — literally what
+ * `packages/cli/src/commands/serve.ts`'s `config.objects && !hasObjectQL`
+ * auto-register branch constructs — assembles a protocol with
+ * `environmentId === undefined`, which the #4463 gate read as "the package
+ * author's own bootstrap channel" and skipped. That topology is the flagship
+ * showcase's own boot shape (`isHostConfig` → `shouldBootWithLibrary === false`),
+ * and its `PUT /api/v1/meta/*` is an END-USER surface, so all 26 shared
+ * `AUTHORING_RULES` ran on nothing. The probe verdict was:
+ *
+ *   environmentId : undefined
+ *   PUT /meta     : THROWN "[ObjectQL] No driver available for object 'sys_metadata'"
+ *   GATE FIRED?   : false
+ *
+ * — the throw coming from the ENGINE's persistence layer, i.e. execution had
+ * already run past the gate. That is why the first test below asserts the
+ * `code`/`status` envelope and not merely that something threw: on this exact
+ * topology the unfixed build throws too, just from the wrong place and with
+ * neither field set.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ObjectKernel } from '@objectstack/core';
+import { createMetadataProtocolPlugin } from '@objectstack/metadata-protocol';
+import { ObjectQL } from './engine.js';
+import { ObjectQLPlugin } from './plugin';
+
+/** #4463's own measured body: Zod-valid, `os lint`-rejected since #4409. */
+const brokenApprovalFlow = () => ({
+  name: 'leave_approval',
+  label: 'Leave Approval',
+  type: 'autolaunched',
+  status: 'active',
+  nodes: [
+    { id: 'start', type: 'start', label: 'Start' },
+    {
+      id: 'approve',
+      type: 'approval',
+      label: 'Approve',
+      config: { approvers: [{ type: 'expression', value: 'record.owner ==' }] },
+    },
+  ],
+  edges: [{ id: 'e1', source: 'start', target: 'approve' }],
+});
+
+/**
+ * A driver just real enough that a write which PASSES the gate lands somewhere
+ * observable — so "allowed" is proved by a stored row rather than by the
+ * absence of one particular exception.
+ */
+function makeMemoryDriver() {
+  const stores = new Map<string, Map<string, Record<string, unknown>>>();
+  const storeFor = (obj: string) => {
+    let s = stores.get(obj);
+    if (!s) { s = new Map(); stores.set(obj, s); }
+    return s;
+  };
+  let nextId = 0;
+  const matchesWhere = (row: Record<string, unknown>, where: any): boolean => {
+    if (!where || typeof where !== 'object') return true;
+    if (Array.isArray(where.$and)) return where.$and.every((w: any) => matchesWhere(row, w));
+    if (Array.isArray(where.$or)) return where.$or.some((w: any) => matchesWhere(row, w));
+    for (const [k, v] of Object.entries(where)) {
+      if (k.startsWith('$')) continue;
+      const expected = (v && typeof v === 'object' && '$eq' in (v as any)) ? (v as any).$eq : v;
+      const a = row[k] === undefined ? null : row[k];
+      const b = expected === undefined ? null : expected;
+      if (a !== b) return false;
+    }
+    return true;
+  };
+  const driver: any = {
+    name: 'memory', version: '0.0.0', supports: {} as any,
+    async connect() {}, async disconnect() {}, async checkHealth() { return true; },
+    async execute() { return null; },
+    async find(object: string, ast: any) {
+      return Array.from(storeFor(object).values()).filter((r) => matchesWhere(r, ast?.where));
+    },
+    async findOne(object: string, ast: any) {
+      for (const r of storeFor(object).values()) if (matchesWhere(r, ast?.where)) return r;
+      return null;
+    },
+    async create(object: string, data: Record<string, unknown>) {
+      nextId += 1;
+      const id = (data.id as string) ?? `r_${nextId}`;
+      const row = { ...data, id };
+      storeFor(object).set(id, row);
+      return row;
+    },
+    async update(object: string, id: string, data: Record<string, unknown>) {
+      const s = storeFor(object);
+      const cur = s.get(id);
+      if (!cur) throw new Error(`not found: ${object}/${id}`);
+      const updated = { ...cur, ...data, id };
+      s.set(id, updated);
+      return updated;
+    },
+    async upsert(object: string, data: Record<string, unknown>) {
+      const id = data.id as string | undefined;
+      if (id && storeFor(object).has(id)) return this.update(object, id, data);
+      return this.create(object, data);
+    },
+    async delete(object: string, id: string) { return storeFor(object).delete(id); },
+    async count(object: string, ast: any) { return (await this.find(object, ast)).length; },
+    async bulkCreate(object: string, rows: Record<string, unknown>[]) {
+      return Promise.all(rows.map((r) => this.create(object, r)));
+    },
+    async bulkUpdate() { return []; }, async bulkDelete() {},
+    async beginTransaction() { return { commit: async () => {}, rollback: async () => {} }; },
+    async commit() {}, async rollback() {},
+  };
+  return { driver, stores };
+}
+
+/**
+ * A pre-built engine carrying the driver, handed to the plugin as `{ ql }`.
+ * `sys_metadata` itself is deliberately NOT registered here — the protocol
+ * assembly registers it (that is the `environmentId === undefined` branch of
+ * `assembleMetadataProtocol`), and pre-claiming it makes the kernel refuse the
+ * assembly's own ownership claim.
+ */
+function makeEngine() {
+  const engine = new ObjectQL();
+  const { driver, stores } = makeMemoryDriver();
+  engine.registerDriver(driver, true);
+  return { engine, stores };
+}
+
+const flowRows = (stores: Map<string, Map<string, Record<string, unknown>>>) =>
+  Array.from(stores.get('sys_metadata')?.values() ?? []).filter((r) => r.type === 'flow');
+
+/** Attempt the end-user publish and report the verdict without throwing. */
+async function publish(protocol: any) {
+  try {
+    const r = await protocol.saveMetaItem({
+      type: 'flow', name: 'leave_approval', item: brokenApprovalFlow(),
+    });
+    return { refused: false as const, result: r };
+  } catch (e: any) {
+    return { refused: true as const, code: e?.code, status: e?.status, message: String(e?.message) };
+  }
+}
+
+describe('#6710 — the authoring channel is threaded from plugin option to protocol', () => {
+  let kernel: ObjectKernel;
+
+  beforeEach(() => {
+    // Same two choices as plugin.step2.test.ts: `logger.level` is the real
+    // config key, and gracefulShutdown:false keeps process signal handlers out
+    // of vitest's fork workers (#4250).
+    kernel = new ObjectKernel({ logger: { level: 'silent' }, gracefulShutdown: false });
+  });
+  afterEach(async () => {
+    if (kernel.getState() === 'running') await kernel.shutdown();
+  });
+
+  it('the serve.ts host-config shape — `new ObjectQLPlugin()` — is GATED', async () => {
+    // Byte-for-byte what serve.ts's auto-register branch constructs. No
+    // options bag at all, so this also pins the fail-safe default reached
+    // through the legacy/empty construction path rather than through an
+    // explicit `authoringChannel: 'environment'`.
+    await kernel.use(new ObjectQLPlugin());
+    await kernel.bootstrap();
+    const protocol = kernel.getService('protocol') as any;
+
+    expect(
+      protocol.environmentId,
+      'the topology is unchanged — #6710 re-keys the gate, it does not bind an environment id',
+    ).toBeUndefined();
+
+    const verdict = await publish(protocol);
+    expect(verdict.refused, 'the end-user PUT /api/v1/meta/* surface must meet the gate').toBe(true);
+    // Both envelope halves (ADR-0112). Asserting only "it threw" would have
+    // been green on the UNFIXED build too: that build reached the engine and
+    // threw "No driver available", an Error whose code and status are both
+    // undefined. This pair is what separates "refused by the gate" from
+    // "failed somewhere downstream".
+    expect((verdict as any).code).toBe('INVALID_METADATA');
+    expect((verdict as any).status).toBe(422);
+  });
+
+  it('declaring `authoringChannel: package-author` restores the ADR-0005 carve-out', async () => {
+    const { engine, stores } = makeEngine();
+    await kernel.use(new ObjectQLPlugin({ ql: engine, authoringChannel: 'package-author' }));
+    await kernel.bootstrap();
+
+    const verdict = await publish(kernel.getService('protocol') as any);
+    expect(verdict.refused, `unexpected refusal: ${(verdict as any).message}`).toBe(false);
+    expect(flowRows(stores).length, 'the control plane still installs its own packages').toBe(1);
+  });
+
+  it('the SAME kernel without the declaration refuses and stores nothing', async () => {
+    // Identical harness to the case above — engine, driver, kernel, body. The
+    // only difference is the one option, which is what makes this pair the
+    // wiring evidence rather than two unrelated boots.
+    const { engine, stores } = makeEngine();
+    await kernel.use(new ObjectQLPlugin({ ql: engine }));
+    await kernel.bootstrap();
+
+    const verdict = await publish(kernel.getService('protocol') as any);
+    expect(verdict.refused).toBe(true);
+    expect((verdict as any).code).toBe('INVALID_METADATA');
+    expect((verdict as any).status).toBe(422);
+    expect(flowRows(stores), 'a gate that rejects after persisting is a log line').toEqual([]);
+  });
+
+  it('the DELEGATED mount (ADR-0076 Step 2) threads it identically', async () => {
+    // `assembleMetadataProtocol` is the one seam both mounts share, so the
+    // declaration must not depend on how the host chose to mount the protocol.
+    // A regression here would be the worst shape available: enforcement that
+    // silently differs by mount style.
+    const { engine, stores } = makeEngine();
+    await kernel.use(new ObjectQLPlugin({ ql: engine, registerProtocol: false }));
+    await kernel.use(createMetadataProtocolPlugin({ authoringChannel: 'package-author' }));
+    await kernel.bootstrap();
+
+    const verdict = await publish(kernel.getService('protocol') as any);
+    expect(verdict.refused, `unexpected refusal: ${(verdict as any).message}`).toBe(false);
+    expect(flowRows(stores).length).toBe(1);
+  });
+
+  it('the DELEGATED mount without the option is GATED too', async () => {
+    const { engine, stores } = makeEngine();
+    await kernel.use(new ObjectQLPlugin({ ql: engine, registerProtocol: false }));
+    await kernel.use(createMetadataProtocolPlugin());
+    await kernel.bootstrap();
+
+    const verdict = await publish(kernel.getService('protocol') as any);
+    expect(verdict.refused).toBe(true);
+    expect((verdict as any).code).toBe('INVALID_METADATA');
+    expect((verdict as any).status).toBe(422);
+    expect(flowRows(stores)).toEqual([]);
+  });
+
+  it('a declared kernel still publishes a body the rules accept (the carve-out is not a mute button)', async () => {
+    const { engine, stores } = makeEngine();
+    await kernel.use(new ObjectQLPlugin({ ql: engine, authoringChannel: 'package-author' }));
+    await kernel.bootstrap();
+
+    const flow = brokenApprovalFlow();
+    (flow.nodes[1] as any).config = {
+      approvers: [{ type: 'expression', value: 'current.owner' }],
+      emptyApproverPolicy: 'reject',
+    };
+    const result = await (kernel.getService('protocol') as any).saveMetaItem({
+      type: 'flow', name: 'leave_approval', item: flow,
+    });
+    expect(result.success).toBe(true);
+    expect(flowRows(stores).length).toBe(1);
+  });
+});

--- a/packages/objectql/src/plugin.ts
+++ b/packages/objectql/src/plugin.ts
@@ -2,6 +2,7 @@
 
 import { ObjectQL } from './engine.js';
 import { assembleMetadataProtocol } from '@objectstack/metadata-protocol';
+import type { MetadataAuthoringChannel } from '@objectstack/metadata-protocol';
 import { Plugin, PluginContext } from '@objectstack/core';
 import { applyConversionsToStoredItem } from '@objectstack/spec';
 import { StorageNameMapping } from '@objectstack/spec/system';
@@ -65,6 +66,25 @@ export interface ObjectQLPluginOptions {
   hostContext?: Record<string, any>;
   /** Scope sys_metadata reads/writes to this project. */
   environmentId?: string;
+  /**
+   * [#6710] Which authoring channel this kernel's metadata writes arrive on —
+   * the explicit expression of ADR-0005's "package author's own bootstrap
+   * channel".
+   *
+   * **Leave unset on every kernel that serves `PUT /api/v1/meta/*` to end
+   * users.** The default `'environment'` runs the #4463 runtime authoring
+   * rules (the 26 shared `AUTHORING_RULES` that `os validate` / `os lint`
+   * run), which for a Studio tenant or an MCP/AI author is the ONLY
+   * author-time gate — there is no `os lint` for a `sys_metadata` overlay row.
+   *
+   * Set `'package-author'` ONLY on the genuine control-plane assembly. Before
+   * #6710 this was inferred from `environmentId === undefined`, which is a row
+   * -scoping key and not a topology signal: the CLI's host-config assembler
+   * leaves it undefined too, so the flagship showcase's own boot shape ran the
+   * gate on nothing. Omitting this option now means MORE enforcement, never
+   * less — which is the whole point of declaring it rather than deducing it.
+   */
+  authoringChannel?: MetadataAuthoringChannel;
   /**
    * Override the kernel's default plugin-start timeout for this plugin.
    * Defaults to 120000 (120s). Schema sync to a remote SQL backend
@@ -165,6 +185,12 @@ export class ObjectQLPlugin implements Plugin {
   private ql: ObjectQL | undefined;
   private hostContext?: Record<string, any>;
   private environmentId?: string;
+  /**
+   * [#6710] Declared authoring channel, forwarded to the ONE protocol
+   * assembly. `undefined` here is not "unknown" — `assembleMetadataProtocol`
+   * resolves it to `'environment'`, the gated channel.
+   */
+  private authoringChannel?: MetadataAuthoringChannel;
   private skipSchemaSync = false;
   /** Serializes reload-time schema syncs so overlapping reloads can't race DDL. */
   private reloadSchemaSync: Promise<void> = Promise.resolve();
@@ -204,6 +230,7 @@ export class ObjectQLPlugin implements Plugin {
     }
     this.hostContext = opts.hostContext ?? hostContext;
     this.environmentId = opts.environmentId;
+    this.authoringChannel = opts.authoringChannel;
     if (typeof opts.startupTimeout === 'number' && opts.startupTimeout > 0) {
       this.startupTimeout = opts.startupTimeout;
     }
@@ -292,7 +319,13 @@ export class ObjectQLPlugin implements Plugin {
       // @objectstack/metadata-protocol — this built-in mode is the
       // single-kernel convenience mount of the same code path the
       // MetadataProtocolPlugin uses (identical objects/protocol/analytics).
-      const protocolShim = assembleMetadataProtocol(ctx, this.ql, this.environmentId);
+      // [#6710] `authoringChannel` rides the same seam as `environmentId`, and
+      // an undefined one resolves to `'environment'` (gated) inside the
+      // assembly — including on the legacy positional `(ObjectQL, hostContext)`
+      // constructor path, which returns before any option is read.
+      const protocolShim = assembleMetadataProtocol(ctx, this.ql, this.environmentId, {
+        authoringChannel: this.authoringChannel,
+      });
       this.subscribeMetadataRebind(ctx, protocolShim);
     } else {
       ctx.logger.info('registerProtocol=false — protocol assembly delegated to MetadataProtocolPlugin (ADR-0076 Step 2, #2462)');


### PR DESCRIPTION
Fixes #6710

Implements the maintainer's **A1** ruling of 2026-08-09 05:41Z (comment 5229995235): the gate is active by default on every kernel, and the ADR-0005 "package author's own bootstrap channel" carve-out becomes an explicit declaration plumbed through `assembleMetadataProtocol`.

## The defect

`ObjectStackProtocolImplementation.assertRuntimeAuthoringRules` — the #4463 runtime publish gate that runs the 26 shared `AUTHORING_RULES` (the same table `os validate` / `os build` / `os lint` run) — opened with:

```ts
if (this.environmentId === undefined) return;
```

That short-circuit was meant to express ADR-0005's carve-out, and **the carve-out itself is legitimate and stays**: a control-plane kernel installing a package is not an author publishing into a live tenant. The key was the problem. `environmentId` is a **row-scoping** key, and two topologies with opposite intents both leave it undefined:

| | genuine control plane | CLI host-config topology |
|---|---|---|
| `environmentId` | undefined | undefined |
| assembly | `assembleMetadataProtocol` | `assembleMetadataProtocol` |
| serves `PUT /api/v1/meta/*` | yes (package author's own channel) | yes (**end-user surface**) |

The second is `serve.ts`'s `config.objects && !hasObjectQL` auto-register branch (`new ObjectQLPlugin()` with no options), which is the shape any `objectstack.config.ts` with instantiated plugins gets (`isHostConfig` yields `shouldBootWithLibrary === false`) — including the flagship showcase. So a self-hosted app server ran **zero** of the 26 rules on every publish. For a Studio tenant or an MCP/AI author this gate is not the weakest of four doors, it is the only one: a `sys_metadata` overlay row is never in the CLI's config file, so there is no `os lint` for it.

#5086 had already retired this same proxy for the code-only refusal a few hundred lines below, for the same stated reason — it just moved that one site.

## Premise, re-measured on this base

Re-verified at boot level on `origin/main` @ `68feaadd6` (not a source read): a kernel built exactly as `serve.ts:1000` builds it, then #4463's own measured body (the broken-CEL approval flow `record.owner ==`) pushed through `saveMetaItem`:

```
PROBE environmentId     : undefined
PROBE PUT /meta verdict : {"outcome":"THROWN","message":"[ObjectQL] No driver available for object 'sys_metadata'"}
PROBE #4463 GATE FIRED? : false
```

The throw comes from the **engine's persistence layer**, not the gate — execution had already run past `assertRuntimeAuthoringRules` (which throws 422 `INVALID_METADATA` before any engine call). The producer is unchanged on this base: `packages/cli/src/commands/serve.ts:996-1001` still constructs `new ObjectQLPlugin()` with no options. **Premise holds.**

## The shape implemented, and why it is fail-safe

A new public plugin option states what a kernel **is**; gate activation reads that instead of row scope.

**New public contract shape (explicitly declared, as the ruling requires):**

```ts
export type MetadataAuthoringChannel = 'environment' | 'package-author';

new ObjectQLPlugin({ authoringChannel: 'package-author' })
createMetadataProtocolPlugin({ authoringChannel: 'package-author' })
assembleMetadataProtocol(ctx, ql, environmentId, { authoringChannel })
new ObjectStackProtocolImplementation(engine, getServices, environmentId, authoringChannel)
```

Exported from `@objectstack/metadata-protocol`: the type `MetadataAuthoringChannel`, the new `AssembleMetadataProtocolOptions`, and the widened `MetadataProtocolPluginOptions` / `ObjectQLPluginOptions`. All four surfaces are additive and optional — no existing call site changes shape.

Three properties are deliberate:

1. **Omission means MORE enforcement.** The default is `'environment'`, resolved at the assembly seam (`options.authoringChannel ?? 'environment'`) as well as at the constructor, so every path that predates this option — including `ObjectQLPlugin`'s legacy positional `(ObjectQL, hostContext)` constructor, which returns before any option is read — lands on the gated channel. The failure mode being designed out is precisely "a future assembly variant nobody thought about", which is how the host-config topology got here.
2. **A channel name, not a boolean.** `skipAuthoringRules: true` would be the same bytes with the opposite meaning — a switch any assembly could reach for to make a red publish go away. A caller has to claim to *be* the package author to be treated as one. There is deliberately **no env-var fallback** (unlike `skipSchemaSync`): a deployment must not be able to turn an end-user guardrail off from outside the code. The per-write hatch that does exist is `OS_ALLOW_UNLINTED_METADATA_WRITES` (#4463 D4), which degrades a refusal to a loud log rather than silencing it.
3. **Threaded through the one shared seam.** `assembleMetadataProtocol` is what both the built-in mount and the delegated ADR-0076 Step 2 mount call, so enforcement cannot silently differ by mount style. Pinned in both directions.

`environmentId` keeps every other job: the `environment_id` stamp and filter, the ADR-0005 overlay whitelist, the #3050 authoring gate's own scope check, and the local metadata-storage provisioning decision. **Only this one activation moved** — pinned by a dedicated case asserting the #3050 gate still turns on and off by `environmentId` while the #4463 gate follows the declaration.

## File surface (no deviation from the dispatch)

| file | change |
|---|---|
| `packages/metadata-protocol/src/protocol.ts` | `MetadataAuthoringChannel` type; `authoringChannel` field + 4th constructor param defaulting to `'environment'`; the activation line itself |
| `packages/metadata-protocol/src/plugin.ts` | `MetadataProtocolPluginOptions.authoringChannel`; new `AssembleMetadataProtocolOptions`; threads it into the protocol construction |
| `packages/metadata-protocol/src/index.ts` | exports the new type + options interface |
| `packages/objectql/src/plugin.ts` | `ObjectQLPluginOptions.authoringChannel`; field; forwards it to the assembly |
| `packages/metadata-protocol/src/protocol.runtime-authoring-gate.test.ts` | the 26 rules' posture matrix (6 rows) + 3 supporting cases |
| `packages/metadata-protocol/src/protocol.platform-schedule-org-gate.test.ts` | **one fixture re-spelled** — see below |
| `packages/objectql/src/plugin.authoring-channel.test.ts` | new: the assembly-wiring pin (6 cases) |
| `.changeset/authoring-channel-declaration.md` | minor for both packages |

The `saveMetaItem` two-tier write-gate region (#6190, in flight) was not touched. `packages/spec` was not needed. No `content/docs/releases/` edit.

**The one fixture the sweep found outside the edited test file:** `protocol.platform-schedule-org-gate.test.ts` (#6285) carried its own copy of the carve-out pin, spelled with the retired key. Disposition **re-spell**, not delete: the case's subject (the carve-out) is intact, only its expression changed, so it now constructs with `'package-author'`. It also gained a companion case, because #6285's guardrail is one of the 26 and its reach widened too — without it the file would assert only the side that stayed the same.

## Reverse verification

Predictions were written down **before** running (`/tmp/.../issue-6710/reverse-predictions.md`), then the activation line alone was reverted to `if (this.environmentId === undefined) return;` with the plumbing and tests left in place.

Predicted 7 red, measured 8. One miss, recorded rather than tidied away.

`protocol.runtime-authoring-gate.test.ts` — predicted 4 red, measured 5 (11 pre-existing #4463 cases stayed green throughout):

| case | predicted | measured |
|---|---|---|
| envId undefined, channel omitted ⇒ GATED | RED | **RED** |
| envId undefined, channel `environment` ⇒ GATED | RED | **RED** |
| envId undefined, channel `package-author` ⇒ bypassed | green (**cannot** go red) | green |
| envId `env_test`, channel omitted ⇒ GATED | green | green |
| envId `env_test`, channel `environment` ⇒ GATED | green | green |
| envId `env_test`, channel `package-author` ⇒ bypassed | RED (**inverted**) | **RED** |
| gated by the rules, not blanket | green | green |
| D4 hatch covers the newly-gated topology | RED | **RED** |
| does not disturb the #3050 gate | green | **RED — MISSED** |

Two of these are worth stating plainly rather than as a pass count:

- **One row cannot go red at all.** `envId undefined + channel package-author ⇒ bypassed` is green before and after, because the old code bypasses there too — for the wrong reason. It is honest coverage of the surviving carve-out, but it is *not* evidence for this change, and the matrix says so in its own comment.
- **One row is inverted by design.** `envId env_test + channel package-author` goes red on the revert because the OLD code *gates* where the new code bypasses. That is the row proving the declaration is genuinely read rather than ignored.
- **The missed prediction:** `does not disturb the OTHER gates` went red. Cause, on inspection: its tenant leg saves a *broken* flow, and under the old keying the #4463 gate refuses that write with a 422 **before** the #3050 gate is ever reached, so the observed gate list stayed empty. The red is real and informative (it pins the ordering of the two gates), but I predicted green because I only reasoned about the #3050 gate's own condition and not about what precedes it.

`plugin.authoring-channel.test.ts` — predicted 3 red, measured 3 (exactly cases 1, 3, 5).

The most load-bearing detail: the boot-level case failed on `expected undefined to be 'INVALID_METADATA'`, **not** on "did it throw". The unfixed build throws too — the engine's bare `No driver available`, an `Error` whose `code` and `status` are both undefined. A `rejects.toThrow()` assertion would therefore have stayed **green on the exact topology this issue is about**. Every rejection-class case here asserts the ADR-0112 `code` + `status` pair for that reason.

Side observation from the revert: `pnpm --filter @objectstack/metadata-protocol build` fails its DTS step under the reverted line, because `authoringChannel` becomes a field nothing reads. The ESM/CJS bundles are emitted before DTS fails, which is why the behavioural measurement above is still valid.

## Tests

All run through `flock /tmp/os-heavy-verify.lock` with `NODE_OPTIONS=--max-old-space-size=4096`.

```
@objectstack/metadata-protocol  Test Files  65 passed (65)    Tests  813 passed (813)
@objectstack/objectql           Test Files 160 passed (160)   Tests 2758 passed (2758)
@objectstack/rest               Test Files  72 passed (72)    Tests 1131 passed (1131)
@objectstack/runtime            Test Files 115 passed (115)   Tests 1743 passed (1743)
@objectstack/cli                Test Files 100 passed (100)   Tests 1044 passed (1044)
typecheck (metadata-protocol, objectql)   Done, 0 errors
pnpm lint (whole repo)                    exit 0
```

`rest` / `runtime` / `cli` are in the sweep because this change **widens** enforcement: they boot kernels that were previously on the bypassed side. All green with no fixture edits needed.

Family gates run locally (they live inside the ESLint CI job, not in `pnpm test`): `check:engine-double-contract`, `check:driver-memory-census`, `check:error-code-casing`, `check:route-envelope`, `check:meta-type-normalized`, `check:init-service-contract`, `check:published-files`, `check:doc-authoring`, `check:docs-audit-scope`, `check:nul-bytes` — all PASS.

## Follow-up in `cloud` (NOT in this PR)

One line, in `cloud`'s `packages/.../control-plane-preset.ts` around `:99` — the only genuine consumer of this carve-out in either repo:

```ts
new ObjectQLPlugin({ /* …existing… */ authoringChannel: 'package-author' })
```

The cross-repo window is accepted by the ruling and is safe by construction: until that lands, the control plane runs **gated** — the safe direction — softened by the existing `OS_ALLOW_UNLINTED_METADATA_WRITES` hatch. Same coordination shape as ADR-0076 Step 2 (#2462).


---
_Generated by [Claude Code](https://claude.ai/code/session_01W6bLax4KMrSfnE1ydFU8Dw)_