### PR TITLE
fix(objectql): hook `retryPolicy` 的默认值从 schema 派生,解析/未解析两条路径给同一个数 (#6832)

### DIFF
--- a/.changeset/hook-retry-policy-declared-defaults.md
+++ b/.changeset/hook-retry-policy-declared-defaults.md
@@ -1,0 +1,48 @@
+---
+"@objectstack/objectql": patch
+---
+
+fix(objectql): a hook's `retryPolicy` gets the same defaults whether or not its metadata was parsed (#6832)
+
+`HookSchema` declares `retryPolicy.maxRetries` with `.default(3)` and
+`retryPolicy.backoffMs` with `.default(1000)`. The executor that actually
+performs the retries read both with `?? 0`. So "how many times does an
+under-specified hook retry?" had **two answers**, and which one you got depended
+on whether the metadata had been through `HookSchema`:
+
+- parsed — `defineStack({ hooks })`, `PUT /meta`, the Studio form — got **3
+  retries with a 1000ms backoff**, matching the schema, the generated reference
+  page and the Studio form;
+- unparsed — the public `wrapDeclarativeHook` export, and `bindHooksToEngine`'s
+  own call, which hands it `Hook` metadata verbatim — got **0 and 0**.
+
+The failure was silent and pointed the wrong way: a retry surface that does not
+retry raises no error, logs nothing, and fails no test. It just loses the
+recovery the author believed they had configured. This is the divergence #4247
+removed from flow `errorHandling` ("one contract, one number"), one surface over
+and with the numbers swapped, and the `declared = enforced` case ADR-0049 exists
+to close.
+
+`wrapDeclarativeHook` now reads both defaults **out of `HookSchema`** instead of
+restating them, so the two paths agree by construction and a future key added to
+`hook.retryPolicy` needs no matching edit in the executor.
+
+**The boundary, which is deliberately unchanged — read this if you own hooks.**
+`retryPolicy` is `.optional()` with no `.default({})`, so an absent block and an
+empty one are different declarations, and they stay different:
+
+- **`retryPolicy` omitted entirely → still zero retries.** No policy was
+  declared, so none is applied. This is the behaviour every existing hook has
+  today and it does not change. (Making the omitted case default to 3 would have
+  "fixed" the divergence by silently giving every hook in every existing app
+  three retries it never asked for — a larger behaviour change than the defect.)
+- **`retryPolicy: {}` or a half-filled block → the declared defaults now apply.**
+  `retryPolicy: {}` means 3 retries / 1000ms; `retryPolicy: { backoffMs: 500 }`
+  means 3 retries / 500ms. Previously both of these retried zero times on the
+  unparsed path. If you wrote an empty or partial `retryPolicy` against a host
+  that does not parse its hook metadata, that hook now retries as its schema,
+  docs and Studio form have always said it would.
+
+Any value you wrote explicitly still wins outright, including an explicit
+`maxRetries: 0`. The backoff remains linear (`backoffMs * attempt`), which is
+what the declared shape describes.

--- a/packages/objectql/src/hook-retry-policy-default.test.ts
+++ b/packages/objectql/src/hook-retry-policy-default.test.ts
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#6832] `hook.retryPolicy` has ONE answer per key, whether or not the metadata
+ * has been through `HookSchema`.
+ *
+ * `packages/spec/src/data/hook.zod.ts` declares `maxRetries: .default(3)` and
+ * `backoffMs: .default(1000)`. `wrapDeclarativeHook` read both with `?? 0`. So
+ * "how many times does an under-specified hook retry?" had two answers, and the
+ * winner depended on the path: `defineStack` / `PUT /meta` / Studio parse through
+ * `HookSchema` and got 3, while the public `wrapDeclarativeHook` export — and
+ * `hook-binder.ts:221`, which calls it with unparsed `Hook` metadata — got 0.
+ * The generated reference page, the Studio form and the schema all promised a
+ * retry that the executor silently did not perform: no error, no log line, no
+ * red test, just the recovery the author thought they had configured, gone.
+ *
+ * That is the shape #4247 removed from flow `errorHandling` (`flow.zod.ts:651`,
+ * "one contract, one number") with the numbers swapped, and the ADR-0049
+ * declared-＝-enforced case for closing it.
+ *
+ * The boundary this file exists to pin — because the obvious fix breaks it:
+ * `retryPolicy` is `.optional()` with no `.default({})`, so an ABSENT block and
+ * an EMPTY one are different declarations. A bare `?? 3` would "fix" the
+ * divergence by giving every hook that never wrote a `retryPolicy` three retries
+ * it never asked for — a behaviour change for every existing author, worse than
+ * the defect. Absent stays 0.
+ *
+ *   1. block absent          → 1 attempt, no retry          (unchanged, and correct)
+ *   2. block present, empty  → schema's 3 retries / 1000ms  (was 1 attempt)
+ *   3. block half-filled     → written key wins, omitted key takes the default
+ *   4. parsed ≡ unparsed     → the two paths agree, per key
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { wrapDeclarativeHook } from './hook-wrappers.js';
+import { HookSchema } from '@objectstack/spec/data';
+import type { Hook, HookContext } from '@objectstack/spec/data';
+
+const taskObject = { name: 'retry_task', label: 'Task', fields: {} };
+const qlStub = { getObject: (n: string) => (n === 'retry_task' ? taskObject : undefined) };
+
+function makeCtx(): HookContext {
+  return {
+    object: 'retry_task',
+    event: 'beforeInsert',
+    input: { data: { title: 'x' } },
+    ql: qlStub,
+  } as unknown as HookContext;
+}
+
+/**
+ * Run an always-failing hook through the declarative wrapper and report how many
+ * times the handler was entered. `attempts === 1 + maxRetries`.
+ *
+ * `retryPolicy` is spread in only when supplied, so "absent" really is an absent
+ * key and not `retryPolicy: undefined`.
+ */
+async function attemptsFor(retryPolicy?: Hook['retryPolicy']): Promise<number> {
+  let attempts = 0;
+  const handler = async () => {
+    attempts += 1;
+    throw new Error('always fails');
+  };
+  const meta = {
+    name: 'h_retry',
+    object: 'retry_task',
+    events: ['beforeInsert'],
+    handler,
+    ...(retryPolicy === undefined ? {} : { retryPolicy }),
+  } as unknown as Hook;
+
+  const wrapped = wrapDeclarativeHook(meta, handler, { logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } });
+  await expect(wrapped(makeCtx())).rejects.toThrow('always fails');
+  return attempts;
+}
+
+/** The declared defaults, read from the schema so this file restates nothing either. */
+function declared(): { maxRetries: number; backoffMs: number } {
+  return HookSchema.shape.retryPolicy.unwrap().parse({});
+}
+
+/**
+ * Run `fn` with `setTimeout` firing synchronously, and return every delay it was
+ * asked for. The retry loop's only use of the clock is the backoff sleep, so the
+ * recorded delays ARE the backoff schedule — read without waiting for it.
+ */
+async function recordingBackoff(fn: () => Promise<void>): Promise<number[]> {
+  const slept: number[] = [];
+  const spy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((cb: () => void, ms?: number) => {
+    slept.push(ms ?? 0);
+    cb();
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout);
+  try {
+    await fn();
+  } finally {
+    spy.mockRestore();
+  }
+  return slept;
+}
+
+describe('#6832 — hook.retryPolicy defaults agree across the parsed and unparsed paths', () => {
+  it('the schema still declares the numbers this file is about', () => {
+    // If these ever change, the expectations below follow them rather than
+    // drifting: every assertion reads `declared()`. This one exists so a
+    // deliberate change to the published contract is visible in the diff.
+    expect(declared()).toEqual({ maxRetries: 3, backoffMs: 1000 });
+  });
+
+  describe('case 1 — the block is absent: no policy declared, so no retry', () => {
+    it('does not retry, and does NOT pick up the per-key defaults', async () => {
+      expect(await attemptsFor(undefined)).toBe(1);
+    });
+
+    it('agrees with the parsed path, which leaves retryPolicy undefined', () => {
+      const parsed = HookSchema.parse({
+        name: 'h_retry', object: 'retry_task', events: ['beforeInsert'], handler: async () => {},
+      });
+      expect(parsed.retryPolicy).toBeUndefined();
+    });
+  });
+
+  describe('case 2 — the block is present but empty: both keys take the declared default', () => {
+    it('retries `maxRetries` times', async () => {
+      let attempts = 0;
+      await recordingBackoff(async () => { attempts = await attemptsFor({}); });
+      expect(attempts).toBe(1 + declared().maxRetries);
+    });
+
+    it('waits the declared backoff between attempts (linear: backoffMs * attempt)', async () => {
+      const slept = await recordingBackoff(async () => { await attemptsFor({}); });
+      const base = declared().backoffMs;
+      // Three retries after a failed first attempt; the backoff is linear
+      // (`retryBackoffMs * attempt`), which matches the declared shape — there
+      // is no multiplier or jitter key on `hook.retryPolicy`.
+      expect(slept).toEqual([base * 1, base * 2, base * 3]);
+    });
+  });
+
+  describe('case 3 — the block is half-filled: written key wins, omitted key defaults', () => {
+    it('an omitted `maxRetries` takes the declared count even when `backoffMs` is written', async () => {
+      expect(await attemptsFor({ backoffMs: 0 })).toBe(1 + declared().maxRetries);
+    });
+
+    it('an omitted `backoffMs` takes the declared delay even when `maxRetries` is written', async () => {
+      let attempts = 0;
+      const slept = await recordingBackoff(async () => { attempts = await attemptsFor({ maxRetries: 1 }); });
+      expect(attempts).toBe(2);
+      expect(slept).toEqual([declared().backoffMs]);
+    });
+
+    it('a written value still wins outright, including an explicit 0', async () => {
+      expect(await attemptsFor({ maxRetries: 0, backoffMs: 0 })).toBe(1);
+      expect(await attemptsFor({ maxRetries: 2, backoffMs: 0 })).toBe(3);
+    });
+  });
+
+  describe('case 4 — the two paths answer identically, which is the whole point', () => {
+    for (const [label, policy] of [
+      ['absent', undefined],
+      ['empty', {}],
+      ['half-filled (backoffMs only)', { backoffMs: 0 }],
+      ['half-filled (maxRetries only)', { maxRetries: 1 }],
+      ['fully written', { maxRetries: 2, backoffMs: 0 }],
+    ] as const) {
+      it(`${label}: unparsed metadata retries as often as the same metadata parsed`, async () => {
+        const parsed = HookSchema.parse({
+          name: 'h_retry',
+          object: 'retry_task',
+          events: ['beforeInsert'],
+          handler: async () => {},
+          ...(policy === undefined ? {} : { retryPolicy: policy }),
+        });
+        const parsedMax = parsed.retryPolicy?.maxRetries ?? 0;
+
+        let attempts = 0;
+        await recordingBackoff(async () => { attempts = await attemptsFor(policy); });
+        expect(attempts).toBe(1 + parsedMax);
+      });
+    }
+  });
+});

--- a/packages/objectql/src/hook-wrappers.ts
+++ b/packages/objectql/src/hook-wrappers.ts
@@ -14,6 +14,7 @@
  * the metadata-driven behaviours.
  */
 import type { Hook, HookContext } from '@objectstack/spec/data';
+import { HookSchema } from '@objectstack/spec/data';
 import type { Expression } from '@objectstack/spec';
 import type { Logger } from '@objectstack/spec/contracts';
 import type { HookHandler } from './engine.js';
@@ -66,6 +67,34 @@ const noopLogger: HookDiagnosticsLogger = {
   warn: () => {},
   error: () => {},
 };
+
+/**
+ * The values `HookSchema` declares for an omitted `retryPolicy` key — READ from
+ * the declaration, never restated here (#6832).
+ *
+ * `wrapDeclarativeHook` used to answer "how many times does an under-specified
+ * hook retry?" with a hand-written `?? 0`, while `hook.zod.ts` answered `3` (and
+ * `1000` for the backoff). Which number you got depended on whether the metadata
+ * had been through `HookSchema` — `defineStack` / `PUT /meta` / Studio parse and
+ * got 3, this public export and `hook-binder.ts`'s own call did not and got 0.
+ * That is verbatim the divergence #4247 removed from flow `errorHandling`, whose
+ * ruling `flow.zod.ts` still carries: **one contract, one number**. Reading the
+ * numbers out of the schema is what makes there be only one — a third key added
+ * to `hook.retryPolicy` needs no edit on this side.
+ *
+ * The value is resolved on first use, not at module load: `HookSchema` is a
+ * `lazySchema` precisely so its closures are never allocated in a process that
+ * binds no hooks.
+ */
+let declaredRetryPolicy: { maxRetries: number; backoffMs: number } | undefined;
+function retryPolicyDefaults(): { maxRetries: number; backoffMs: number } {
+  // Parsing `{}` asks the schema what an empty-but-present block means, which is
+  // exactly the question the executor has to answer. `.unwrap()` steps past the
+  // `.optional()`; the ABSENCE of the block is a different question, answered at
+  // the call site.
+  declaredRetryPolicy ??= HookSchema.shape.retryPolicy.unwrap().parse({});
+  return declaredRetryPolicy;
+}
 
 /**
  * A hook declared a `condition` and the platform could not work out its value
@@ -308,8 +337,23 @@ export function wrapDeclarativeHook(
     }
   }
 
-  const retryMax = Math.max(0, Number(meta.retryPolicy?.maxRetries ?? 0));
-  const retryBackoffMs = Math.max(0, Number(meta.retryPolicy?.backoffMs ?? 0));
+  // `retryPolicy` is `.optional()` with NO `.default({})`, so the block's ABSENCE
+  // and its EMPTINESS are two different declarations and stay two different
+  // answers (#6832):
+  //
+  //   - no `retryPolicy` at all      → no retry policy was declared → 0 / 0, and
+  //     the parsed path agrees: `HookSchema` leaves the key `undefined`.
+  //   - `retryPolicy: {}`, or a block with only one key set → the author DID ask
+  //     for retries; each omitted key takes the value the schema declares for it.
+  //
+  // Only the second case was broken. #4247's answer — delete the executor's
+  // fallback and let the parsed default stand — does not transplant here, because
+  // the whole point is a path that never parses; and its mirror image, a bare
+  // `?? 3`, would be worse than the defect: every hook that never wrote a
+  // `retryPolicy` would start retrying three times.
+  const declaredRetry = meta.retryPolicy ? retryPolicyDefaults() : undefined;
+  const retryMax = Math.max(0, Number(meta.retryPolicy?.maxRetries ?? declaredRetry?.maxRetries ?? 0));
+  const retryBackoffMs = Math.max(0, Number(meta.retryPolicy?.backoffMs ?? declaredRetry?.backoffMs ?? 0));
   const timeoutMs = typeof meta.timeout === 'number' && meta.timeout > 0 ? meta.timeout : undefined;
   const onError = meta.onError ?? 'abort';
   // `async` is only meaningful for after* events; ignore on before* (we must


### PR DESCRIPTION
Closes #6832. Precedent: #4247 (`flow.errorHandling` 上的同一形状). 依据: ADR-0049 (declared = enforced).

## 缺陷

`hook.retryPolicy` 的两个键都有两个答案,取决于元数据有没有过 `HookSchema`:

| 键 | 声明 `packages/spec/src/data/hook.zod.ts:264-265` | 读取 `packages/objectql/src/hook-wrappers.ts:311-312` |
|---|---|---|
| `maxRetries` | `z.number().default(3)` | `?? 0` |
| `backoffMs`  | `z.number().default(1000)` | `?? 0` |

已解析路径(`defineStack` / `PUT /meta` / Studio)得 `3 / 1000`;未解析路径(公开导出 `wrapDeclarativeHook`,以及 `hook-binder.ts:221` 仓内既有调用点)得 `0 / 0`。危害静默且反向:schema、生成的参考文档、Studio 表单三处都告诉作者「重试 3 次」,执行器给 0 次 —— 不报错、不打日志、不红测试,只是把作者以为配好的恢复能力弄丢。

## 形状选择的测量依据

候选 (a) 让 `wrapDeclarativeHook` 自己解析 / 只收已解析 meta;(b) 让执行器侧的兜底**从 schema 派生**。**选 (b),并且 (a) 是被实测排除的,不是凭口味。**

对 `HookSchema.safeParse` 逐形状实测(`origin/main` @ `73bff86`),结果是**它拒绝四种 binder 今天照常绑定的形状**:

| 形状 | `HookSchema` |
|---|---|
| `{ ...base, nope: 1 }`(未知键) | ⛔ REFUSED — `Unrecognized key(s) on this hook: nope` |
| `{ events: ['beforeFrobnicate'] }` | ⛔ REFUSED — `Invalid option` |
| `{ retryPolicy: { maxRetries: 'x' } }` | ⛔ REFUSED — `expected number, received string` |
| `{ retryPolicy: { retries: 2 } }` | ⛔ REFUSED — `Unrecognized key(s) on this hook's retryPolicy` |
| 内联函数 handler / 字符串 handler / 无 handler / `_packageId` | ✅ PARSES |

若走 (a),这四种今天「绑上并运行」的 hook 会变成「绑不上」—— 非 strict 下被 binder 的 catch 记为 skip,strict 下直接 throw 掉启动。**爆炸半径大于缺陷本身。**

这与 `hook-binder.ts` 里 `normalizeObjects` 上方 #4001 注释写下的裁决一致 —— 本仓遇到完全同构的问题时的答案是「约束必须在执行器/binder 这边也成立」,而不是「逼调用方先解析」:

> `HookSchema` now refuses those shapes at parse time, but this binder accepts unparsed `Hook` input, so the guard has to hold here too.

(b) 的另一个好处:**一个机制同时覆盖两个键**,而且是「读」不是「重述」—— 日后给 `hook.retryPolicy` 加第三个键,执行器这边不需要跟着改。实现上取 `HookSchema.shape.retryPolicy.unwrap().parse({})`(实测:lazySchema 的 Proxy 对 `.shape` 访问是透明的),首次使用时求值并缓存,不在模块加载期分配 —— `lazySchema` 存在的理由正是这个。

## ⛔ 边界:只修一半,另一半必须原样保住

`retryPolicy` 整块是 `.optional()` 且**没有** `.default({})`,所以「整块缺失」与「块在、键省略」是两种不同的声明:

- **整块缺失** → 解析后仍 `undefined` → 0 次重试。**这是对的,不动。**
- **块在、键省略**(`retryPolicy: {}` / `{ backoffMs: 500 }`)→ 解析得 `3 / 1000`,未解析得 `0 / 0`。**只有这一半是缺陷。**

把 #4247 的答案照抄成 `?? 3` 会让**每一个从没写过 `retryPolicy` 的 hook** 从「不重试」变成「重试 3 次」—— 给每个现存作者改行为,比原缺陷严重。测试把这条边界钉死。

## 逆向验证(预测 vs 实际)

`packages/objectql/src/hook-retry-policy-default.test.ts` 共 13 例。把 `hook-wrappers.ts` 还原成 `origin/main` 后跑:

**预测 7 红 / 6 绿;实际 6 红 / 7 绿。** 唯一偏差解释在下:

| 用例 | 预测 | 实际 |
|---|---|---|
| schema 仍声明 3 / 1000 | 绿 | ✅ 绿 |
| ① 整块缺失 → 1 次尝试 | 绿 | ✅ 绿 |
| ① 已解析路径 `retryPolicy` 为 `undefined` | 绿 | ✅ 绿 |
| ② 空块 → 重试 `maxRetries` 次 | 红 | ✅ 红(1 vs 4) |
| ② 空块 → 线性 backoff `[1000, 2000, 3000]` | 红 | ✅ 红(`[]`) |
| ③ 省略 `maxRetries`(只写 `backoffMs`) | 红 | ✅ 红(1 vs 4) |
| ③ 省略 `backoffMs`(只写 `maxRetries`) | 红 | ✅ 红 |
| ③ 显式写的值仍然全胜(含显式 `0`) | 绿 | ✅ 绿 |
| ④ 整块缺失:两路径一致 | 绿 | ✅ 绿 |
| ④ 空块:两路径一致 | 红 | ✅ 红 |
| ④ 半填(只 `backoffMs`):两路径一致 | 红 | ✅ 红 |
| ④ 半填(只 `maxRetries`):两路径一致 | **红** | ❌ **绿** |
| ④ 全写:两路径一致 | 绿 | ✅ 绿 |

**偏差说明:** ④ 的断言只比较**重试次数**。`{ maxRetries: 1 }` 里 `maxRetries` 是写死的,未解析路径的 `?? 0` 根本不触发,次数两边都是 2 —— 这一格的发散只在 `backoffMs` 上,而 ④ 不看 backoff。该发散由 ③ 的 `省略 backoffMs` 一例覆盖(实测红)。是我的预测漏算了断言的观察面,不是代码行为出乎意料。

修复后:**13/13 绿**。`packages/objectql` 全量 **161 文件 / 2777 例全绿**,无回归。

## 跑过的门禁(本地,现场枚举 `.github/workflows/lint.yml` = **44** 个 `pnpm check:`)

| 门 | 结果 |
|---|---|
| `check:spec-parsed-alias`(ADR-0122) | ✅ PASS(18 self-test;1517 bare aliases / 823 pinned / 694 paired) |
| `check:engine-double-contract` | ✅ PASS(118 pinned / 133 debt / 2 exempt) |
| `check:kernel-hook-pairs` | ✅ PASS |
| `check:driver-memory-census` | ✅ PASS(本 PR 未新增 driver-memory import) |
| `check:type-check-coverage` / `check:type-check-debt` | ✅ PASS |
| `check:published-files` / `check:nul-bytes` / `check:meta-type-normalized` | ✅ PASS |
| `pnpm --filter @objectstack/objectql typecheck` | ✅ PASS |
| `eslint --no-inline-config`(改动文件) | ✅ PASS |

## 明确未做

- **未改 `packages/spec`** —— 结论不需要动 `hook.zod.ts`,所以不触发 #6532 / #5586 的跨座位声明流程。
- 线性 backoff(`backoffMs * attempt`)维持现状 —— 与声明形状一致,是更小的合同不是漂移的合同(已在卡上裁定)。
- `packages/spec/src/shared/retry-policy.test.ts:174` 那句夸大的注释未动 —— #6630 车道。
- 未重新论证 `hook.retryPolicy` 是否该并入 `RetryPolicySchema` —— 那是合同决策。
- 未碰 `packages/drivers/**`(#5499 冻结)、未碰 `content/docs/releases/`。

## 文件

- `packages/objectql/src/hook-wrappers.ts` — 从 schema 派生默认值,只在块存在时应用。
- `packages/objectql/src/hook-retry-policy-default.test.ts` — 新增,13 例。
- `.changeset/hook-retry-policy-declared-defaults.md` — patch,写清行为修正及其边界(尤其「整块缺失仍不重试」)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01S182oxejCaui6gg76z7Zq7)_